### PR TITLE
golangci-lint: Update `gomodguard` linter to v2

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,7 +13,7 @@ linters:
     - errorlint
     - forbidigo
     - goheader
-    - gomodguard
+    - gomodguard_v2
     - gosec
     - govet
     - ineffassign
@@ -44,64 +44,63 @@ linters:
       template: |-
         SPDX-License-Identifier: Apache-2.0
         Copyright Authors of {{ PROJECT }}
-    gomodguard:
+    gomodguard_v2:
       blocked:
-        modules:
-          - github.com/miekg/dns:
-              recommendations:
-                - github.com/cilium/dns
-              reason: use the cilium fork directly to avoid replace directives in go.mod, see https://github.com/cilium/cilium/pull/27582
-          - go.uber.org/goleak:
-              recommendations:
-                - github.com/cilium/cilium/pkg/testutils
-              reason: Use testutils.Goleak* instead for the shared default options.
-          - gopkg.in/check.v1:
-              recommendations:
-                - testing
-                - github.com/stretchr/testify/assert
-              reason: gocheck has been deprecated, see https://github.com/cilium/cilium/issues/28596
-          - gopkg.in/yaml.v2:
-              recommendations:
-                - go.yaml.in/yaml/v2
-              reason: gopkg.in/yaml.v2 is deprecated, see https://github.com/yaml/go-yaml/discussions/11
-          - gopkg.in/yaml.v3:
-              recommendations:
-                - go.yaml.in/yaml/v3
-              reason: gopkg.in/yaml.v3 is deprecated, see https://github.com/yaml/go-yaml/discussions/11
-          - github.com/cilium/checkmate:
-              recommendations:
-                - github.com/stretchr/testify/assert
-                - github.com/stretchr/testify/require
-              reason: cilium/checkmate has been deprecated, see https://github.com/cilium/cilium/issues/28596
-          - github.com/sirupsen/logrus:
-              recommendations:
-                - log/slog
-              reason: Use the Go 1.21+ log/slog package for structured logging.
-          - go.uber.org/multierr:
-              recommendations:
-                - errors
-              reason: Go 1.20+ has support for combining multiple errors, see https://go.dev/doc/go1.20#errors
-          - golang.org/x/exp/maps:
-              recommendations:
-                - maps
-                - slices
-              reason: Go 1.23+ has support for maps and slices, see https://go.dev/doc/go1.23#iterators
-          - golang.org/x/exp/constraints:
-              recommendations:
-                - cmp
-              reason: Go 1.21+ has support for Ordered constraint, see https://go.dev/doc/go1.21#cmp
-          - golang.org/x/exp/slices:
-              recommendations:
-                - slices
-              reason: Go 1.21+ provides many common operations for slices using generic functions, see https://go.dev/doc/go1.21#slices
-          - k8s.io/utils/pointer:
-              recommendations:
-                - k8s.io/utils/ptr
-              reason: k8s.io/utils/pointer is deprecated, see https://pkg.go.dev/k8s.io/utils/pointer
-          - github.com/google/gopacket:
-              recommendations:
-                - github.com/gopacket/gopacket
-              reason: This package is better supported and gets regular updates, see https://github.com/cilium/cilium/issues/34536
+        - module: github.com/miekg/dns
+          recommendations:
+            - github.com/cilium/dns
+          reason: use the cilium fork directly to avoid replace directives in go.mod, see https://github.com/cilium/cilium/pull/27582
+        - module: go.uber.org/goleak
+          recommendations:
+            - github.com/cilium/cilium/pkg/testutils
+          reason: Use testutils.Goleak* instead for the shared default options.
+        - module: gopkg.in/check.v1
+          recommendations:
+            - testing
+            - github.com/stretchr/testify/assert
+          reason: gocheck has been deprecated, see https://github.com/cilium/cilium/issues/28596
+        - module: gopkg.in/yaml.v2
+          recommendations:
+            - go.yaml.in/yaml/v2
+          reason: gopkg.in/yaml.v2 is deprecated, see https://github.com/yaml/go-yaml/discussions/11
+        - module: gopkg.in/yaml.v3
+          recommendations:
+            - go.yaml.in/yaml/v3
+          reason: gopkg.in/yaml.v3 is deprecated, see https://github.com/yaml/go-yaml/discussions/11
+        - module: github.com/cilium/checkmate
+          recommendations:
+            - github.com/stretchr/testify/assert
+            - github.com/stretchr/testify/require
+          reason: cilium/checkmate has been deprecated, see https://github.com/cilium/cilium/issues/28596
+        - module: github.com/sirupsen/logrus
+          recommendations:
+            - log/slog
+          reason: Use the Go 1.21+ log/slog package for structured logging.
+        - module: go.uber.org/multierr
+          recommendations:
+            - errors
+          reason: Go 1.20+ has support for combining multiple errors, see https://go.dev/doc/go1.20#errors
+        - module: golang.org/x/exp/maps
+          recommendations:
+            - maps
+            - slices
+          reason: Go 1.23+ has support for maps and slices, see https://go.dev/doc/go1.23#iterators
+        - module: golang.org/x/exp/constraints
+          recommendations:
+            - cmp
+          reason: Go 1.21+ has support for Ordered constraint, see https://go.dev/doc/go1.21#cmp
+        - module: golang.org/x/exp/slices
+          recommendations:
+            - slices
+          reason: Go 1.21+ provides many common operations for slices using generic functions, see https://go.dev/doc/go1.21#slices
+        - module: k8s.io/utils/pointer
+          recommendations:
+            - k8s.io/utils/ptr
+          reason: k8s.io/utils/pointer is deprecated, see https://pkg.go.dev/k8s.io/utils/pointer
+        - module: github.com/google/gopacket
+          recommendations:
+            - github.com/gopacket/gopacket
+          reason: This package is better supported and gets regular updates, see https://github.com/cilium/cilium/issues/34536
     gosec:
       includes:
         - G402
@@ -199,7 +198,7 @@ linters:
           - sloglint
         path: tools/.*.go
       - linters:
-          - gomodguard
+          - gomodguard_v2
         path: test/
         text: "logrus"
     paths:

--- a/pkg/testutils/goleak.go
+++ b/pkg/testutils/goleak.go
@@ -7,7 +7,7 @@ import (
 	"slices"
 	"testing"
 
-	//nolint:gomodguard
+	//nolint:gomodguard_v2
 	"go.uber.org/goleak"
 )
 


### PR DESCRIPTION
Solves this warning we currently get when running `golangci-lint`:

```
WARN The linter 'gomodguard' is deprecated (since v2.12.0) due to: new major version. Replaced by gomodguard_v2.
```

This PR replaces `gomodguard` with `gomodguard_v2` in the `golangci-lint` config and updates the corresponding linter config to match its new struture.