### PR TITLE
gateway-api: Fix BackendTLSPolicy connections to TLS 1.3-only services

### DIFF
--- a/operator/pkg/gateway-api/testdata/gateway/httproute-backendtlspolicy-conflict-resolution/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-backendtlspolicy-conflict-resolution/output/cec-same-namespace.yaml
@@ -123,6 +123,8 @@ spec:
         typedConfig:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
           commonTlsContext:
+            tlsParams:
+              tlsMaximumProtocolVersion: TLSv1_3
             combinedValidationContext:
               defaultValidationContext: {}
               validationContextSdsSecretConfig:
@@ -147,6 +149,8 @@ spec:
         typedConfig:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
           commonTlsContext:
+            tlsParams:
+              tlsMaximumProtocolVersion: TLSv1_3
             combinedValidationContext:
               defaultValidationContext: {}
               validationContextSdsSecretConfig:
@@ -171,6 +175,8 @@ spec:
         typedConfig:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
           commonTlsContext:
+            tlsParams:
+              tlsMaximumProtocolVersion: TLSv1_3
             combinedValidationContext:
               defaultValidationContext: {}
               validationContextSdsSecretConfig:
@@ -195,6 +201,8 @@ spec:
         typedConfig:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
           commonTlsContext:
+            tlsParams:
+              tlsMaximumProtocolVersion: TLSv1_3
             combinedValidationContext:
               defaultValidationContext: {}
               validationContextSdsSecretConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-backendtlspolicy-multiparent/output/cec-same-namespace-with-https-listener.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-backendtlspolicy-multiparent/output/cec-same-namespace-with-https-listener.yaml
@@ -134,6 +134,8 @@ spec:
         typedConfig:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
           commonTlsContext:
+            tlsParams:
+              tlsMaximumProtocolVersion: TLSv1_3
             combinedValidationContext:
               defaultValidationContext: {}
               validationContextSdsSecretConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-backendtlspolicy-multiparent/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-backendtlspolicy-multiparent/output/cec-same-namespace.yaml
@@ -97,6 +97,8 @@ spec:
         typedConfig:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
           commonTlsContext:
+            tlsParams:
+              tlsMaximumProtocolVersion: TLSv1_3
             combinedValidationContext:
               defaultValidationContext: {}
               validationContextSdsSecretConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-backendtlspolicy-reencrypt/output/cec-same-namespace-with-https-listener.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-backendtlspolicy-reencrypt/output/cec-same-namespace-with-https-listener.yaml
@@ -134,6 +134,8 @@ spec:
         typedConfig:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
           commonTlsContext:
+            tlsParams:
+              tlsMaximumProtocolVersion: TLSv1_3
             combinedValidationContext:
               defaultValidationContext: {}
               validationContextSdsSecretConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-backendtlspolicy-valid/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-backendtlspolicy-valid/output/cec-same-namespace.yaml
@@ -116,6 +116,8 @@ spec:
         typedConfig:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
           commonTlsContext:
+            tlsParams:
+              tlsMaximumProtocolVersion: TLSv1_3
             combinedValidationContext:
               defaultValidationContext: {}
               validationContextSdsSecretConfig:
@@ -140,6 +142,8 @@ spec:
         typedConfig:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
           commonTlsContext:
+            tlsParams:
+              tlsMaximumProtocolVersion: TLSv1_3
             combinedValidationContext:
               defaultValidationContext: {}
               validationContextSdsSecretConfig:
@@ -164,6 +168,8 @@ spec:
         typedConfig:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
           commonTlsContext:
+            tlsParams:
+              tlsMaximumProtocolVersion: TLSv1_3
             combinedValidationContext:
               defaultValidationContext: {}
               validationContextSdsSecretConfig:

--- a/operator/pkg/model/translation/envoy_cluster_mutator.go
+++ b/operator/pkg/model/translation/envoy_cluster_mutator.go
@@ -127,6 +127,9 @@ func withTLSOrigination(tls *model.BackendTLSOrigination) ClusterMutator {
 		tlsContext := &envoy_config_tls.UpstreamTlsContext{
 			Sni: tls.SNI,
 			CommonTlsContext: &envoy_config_tls.CommonTlsContext{
+				TlsParams: &envoy_config_tls.TlsParameters{
+					TlsMaximumProtocolVersion: envoy_config_tls.TlsParameters_TLSv1_3,
+				},
 				ValidationContextType: &envoy_config_tls.CommonTlsContext_CombinedValidationContext{
 					CombinedValidationContext: &envoy_config_tls.CommonTlsContext_CombinedCertificateValidationContext{
 						DefaultValidationContext: &envoy_config_tls.CertificateValidationContext{},

--- a/operator/pkg/model/translation/envoy_cluster_test.go
+++ b/operator/pkg/model/translation/envoy_cluster_test.go
@@ -7,8 +7,12 @@ import (
 	"testing"
 
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_config_tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/cilium/cilium/operator/pkg/model"
 )
 
 func Test_withClusterLbPolicy(t *testing.T) {
@@ -80,6 +84,30 @@ func Test_httpCluster(t *testing.T) {
 	require.Equal(t, &envoy_config_cluster_v3.Cluster_Type{
 		Type: envoy_config_cluster_v3.Cluster_EDS,
 	}, cluster.ClusterDiscoveryType)
+}
+
+func Test_httpClusterWithTLSOriginationAllowsTLS13(t *testing.T) {
+	c := &cecTranslator{}
+	res, err := c.httpCluster("dummy-name", "dummy-name", false, "", &model.BackendTLSOrigination{
+		SNI: "backend.example.com",
+		CACertRef: &model.FullyQualifiedResource{
+			Name:      "ca-cert",
+			Namespace: "default",
+		},
+	})
+	require.NoError(t, err)
+
+	cluster := &envoy_config_cluster_v3.Cluster{}
+	err = proto.Unmarshal(res.Value, cluster)
+	require.NoError(t, err)
+	require.Equal(t, "envoy.transport_sockets.tls", cluster.TransportSocket.Name)
+
+	typedConfig := cluster.TransportSocket.ConfigType.(*envoy_config_core_v3.TransportSocket_TypedConfig)
+	tlsContext := &envoy_config_tls.UpstreamTlsContext{}
+	err = proto.Unmarshal(typedConfig.TypedConfig.Value, tlsContext)
+	require.NoError(t, err)
+	require.NotNil(t, tlsContext.CommonTlsContext.TlsParams)
+	require.Equal(t, envoy_config_tls.TlsParameters_TLSv1_3, tlsContext.CommonTlsContext.TlsParams.TlsMaximumProtocolVersion)
 }
 
 func Test_tcpCluster(t *testing.T) {


### PR DESCRIPTION

## Trigger
  User creates an HTTPRoute or GRPCRoute with a BackendTLSPolicy in Cilium 1.20.0-pre.0, and the backend service only accepts TLS 1.3.
  Envoy fails the TLS handshake with `TLSV1_ALERT_PROTOCOL_VERSION`. The backend rejects the connection, all traffic to that backend is blocked.
Envoy, acting as an upstream TLS client, should negotiate TLS 1.3 with the backend successfully.

## Root Cause

  The operator builds a `CommonTlsContext` with only `Sni` and  `CombinedValidationContext`. It does not set `TlsParams.TlsMaximumProtocolVersion`. 
  Per Envoy upstream documentation: *"By default, it's TLSv1_2 for clients and TLSv1_3  for servers."* Since upstream connections use the client role, the maximum defaults to TLS 1.2, and TLS 1.3-only backends reject the handshake.

Fixes:  https://github.com/cilium/cilium/issues/45864

 
