### PR TITLE
iptables: remove feeder rules by line number, not body replay

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/statedb"
 	"github.com/mattn/go-shellwords"
 	"github.com/vishvananda/netlink"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock"
 
 	"github.com/cilium/cilium/daemon/cmd/cni"
@@ -190,32 +191,6 @@ func (ipt *ipt) runProg(args []string) error {
 	return err
 }
 
-func reverseRule(rule string) ([]string, error) {
-	if strings.HasPrefix(rule, "-A") {
-		// From: -A POSTROUTING -m comment [...]
-		// To:   -D POSTROUTING -m comment [...]
-		return shellwords.Parse(strings.Replace(rule, "-A", "-D", 1))
-	}
-
-	if strings.HasPrefix(rule, "-I") {
-		// From: -I POSTROUTING -m comment [...]
-		// To:   -D POSTROUTING -m comment [...]
-		return shellwords.Parse(strings.Replace(rule, "-I", "-D", 1))
-	}
-
-	return []string{}, nil
-}
-
-func ruleReferencesDisabledChain(disableIptablesFeederRules []string, rule string) (bool, string) {
-	for _, disabledChain := range disableIptablesFeederRules {
-		if strings.Contains(rule, " "+strings.ToUpper(disabledChain)+" ") {
-			return true, disabledChain
-		}
-	}
-
-	return false, ""
-}
-
 func isDisabledChain(disableIptablesFeederRules []string, chain string) bool {
 	for _, disabledChain := range disableIptablesFeederRules {
 		if strings.EqualFold(chain, disabledChain) {
@@ -226,62 +201,83 @@ func isDisabledChain(disableIptablesFeederRules []string, chain string) bool {
 	return false
 }
 
-func (m *manager) removeCiliumRules(table string, prog runnable, match string) error {
-	rules, err := prog.runProgOutput([]string{"-t", table, "-S"})
-	if err != nil {
-		return err
+// removeCiliumFeederRules removes feeder rules in built-in chains that jump
+// to any Cilium-owned chain whose name starts with chainPrefix + "CILIUM_".
+// Rules are matched by line number and jump target only; the body is never
+// inspected, so cleanup tolerates iptables version skew that can corrupt body
+// fields (issue #33465). Rules inside Cilium chains are flushed by
+// customChain.doRemove and not visited here.
+func (m *manager) removeCiliumFeederRules(table string, prog runnable, chainPrefix string) error {
+	hookSet := sets.New[string]()
+	for _, c := range ciliumChains {
+		if c.table != table {
+			continue
+		}
+		hookSet.Insert(c.hook)
 	}
+	if hookSet.Len() == 0 {
+		return nil
+	}
+	hooks := sets.List(hookSet)
 
-	scanner := bufio.NewScanner(strings.NewReader(rules))
-	for scanner.Scan() {
-		rule := scanner.Text()
+	// Prefix (not exact chain) match also catches feeders left behind by
+	// chains removed in older Cilium versions.
+	targetPrefix := chainPrefix + "CILIUM_"
+	lineRe := regexp.MustCompile(`^\s*(\d+)\s+(\S+)`)
 
-		// All rules installed by cilium either belong to a chain with
-		// the name CILIUM_ or call a chain with the name CILIUM_:
-		// -A CILIUM_FORWARD -o cilium_host -m comment --comment "cilium: any->cluster on cilium_host forward accept" -j ACCEPT
-		// -A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST" -j CILIUM_POST
-		if !strings.Contains(rule, match) {
-			continue
-		}
-
-		// Skip rules that live inside a CILIUM_ chain — they will be cleared when
-		// the chain is flushed in doRemove. Only feeder rules (those in built-in
-		// chains that jump to a CILIUM_ chain) need explicit removal here, because
-		// iptables -X fails if the chain is still referenced by another chain.
-		if parts := strings.Fields(rule); len(parts) >= 2 && strings.HasPrefix(parts[1], match) {
-			continue
-		}
-
-		// do not remove feeder for chains that are set to be disabled
-		// ie catch the beginning of the rule like -A POSTROUTING to match it against
-		// disabled chains
-		if skip, disabledChain := ruleReferencesDisabledChain(m.cfg.DisableIptablesFeederRules, rule); skip {
+	for _, hook := range hooks {
+		if isDisabledChain(m.cfg.DisableIptablesFeederRules, hook) {
 			m.logger.Info(
-				"Skipping the removal of feeder chain",
-				logfields.Chain, disabledChain,
+				"Skipping the removal of feeder rules in disabled chain",
+				logfields.Chain, hook,
 			)
 			continue
 		}
 
-		reversedRule, err := reverseRule(rule)
+		out, err := prog.runProgOutput([]string{"-t", table, "-nL", hook, "--line-numbers"})
 		if err != nil {
-			m.logger.Warn(
-				"Unable to parse rule into slice. Leaving rule behind.",
-				logfields.Error, err,
-				logfields.Prog, prog,
-			)
-			continue
+			if isMissingChainOrTableErr(err) {
+				continue
+			}
+			return err
 		}
 
-		if len(reversedRule) > 0 {
-			deleteRule := append([]string{"-t", table}, reversedRule...)
-			if err := prog.runProg(deleteRule); err != nil {
+		var toDelete []int
+		scanner := bufio.NewScanner(strings.NewReader(out))
+		for scanner.Scan() {
+			match := lineRe.FindStringSubmatch(scanner.Text())
+			if match == nil {
+				continue
+			}
+			if !strings.HasPrefix(match[2], targetPrefix) {
+				continue
+			}
+			num, err := strconv.Atoi(match[1])
+			if err != nil {
+				continue
+			}
+			toDelete = append(toDelete, num)
+		}
+
+		// Delete descending so earlier indices remain valid.
+		slices.Sort(toDelete)
+		slices.Reverse(toDelete)
+		for _, num := range toDelete {
+			if err := prog.runProg([]string{"-t", table, "-D", hook, strconv.Itoa(num)}); err != nil {
 				return err
 			}
 		}
 	}
 
 	return nil
+}
+
+// isMissingChainOrTableErr mirrors the error patterns customChain.exists tolerates.
+func isMissingChainOrTableErr(err error) bool {
+	s := err.Error()
+	return strings.Contains(s, "No chain/target/match by that name.") ||
+		strings.Contains(s, "is incompatible, use 'nft' tool.") ||
+		strings.Contains(s, "tables: Incompatible with this kernel.")
 }
 
 type podAndNameSpace struct {
@@ -630,12 +626,12 @@ func (m *manager) removeRules(prefix string) error {
 	// Set of tables that have had iptables rules in any Cilium version
 	tables := []string{"nat", "mangle", "raw", "filter"}
 	for _, t := range tables {
-		if err := m.removeCiliumRules(t, m.ip4tables, prefix+"CILIUM_"); err != nil {
+		if err := m.removeCiliumFeederRules(t, m.ip4tables, prefix); err != nil {
 			return err
 		}
 
 		if m.haveIp6tables {
-			if err := m.removeCiliumRules(t, m.ip6tables, prefix+"CILIUM_"); err != nil {
+			if err := m.removeCiliumFeederRules(t, m.ip6tables, prefix); err != nil {
 				return err
 			}
 		}

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -602,90 +602,92 @@ func TestAddProxyRulesv6(t *testing.T) {
 	}
 }
 
-func TestRemoveCiliumRulesv4(t *testing.T) {
+func TestRemoveCiliumFeederRulesV4(t *testing.T) {
 	mockIp4tables := &mockIptables{t: t, prog: "iptables"}
 	mockIp4tables.expectations = []expectation{
 		{
-			args: "-t mangle -S",
-			out: []byte(
-				`-P PREROUTING ACCEPT
--P INPUT ACCEPT
--P FORWARD ACCEPT
--P OUTPUT ACCEPT
--P POSTROUTING ACCEPT
--N OLD_CILIUM_POST_mangle
--N OLD_CILIUM_PRE_mangle
--N CILIUM_POST_mangle
--N CILIUM_PRE_mangle
--N KUBE-KUBELET-CANARY
--N KUBE-PROXY-CANARY
--A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
--A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
--A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
--A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
--A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
--A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 127.0.0.1 --tproxy-mark 0x200/0xffffffff
--A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 127.0.0.1 --tproxy-mark 0x200/0xffffffff
--A CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
--A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 127.0.0.1 --tproxy-mark 0x200/0xffffffff
--A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip 127.0.0.1 --tproxy-mark 0x200/0xffffffff
+			args: "-t mangle -nL POSTROUTING --line-numbers",
+			out: []byte(`Chain POSTROUTING (policy ACCEPT)
+num  target                  prot opt source               destination
+1    KUBE-POSTROUTING        0    --  0.0.0.0/0            0.0.0.0/0
+2    OLD_CILIUM_POST_mangle  0    --  0.0.0.0/0            0.0.0.0/0            /* cilium-feeder: CILIUM_POST_mangle */
+3    CILIUM_POST_mangle      0    --  0.0.0.0/0            0.0.0.0/0            /* cilium-feeder: CILIUM_POST_mangle */
 `),
-		}, {
-			args: "-t mangle -D PREROUTING -m comment --comment cilium-feeder: CILIUM_PRE_mangle -j OLD_CILIUM_PRE_mangle",
-		}, {
-			args: "-t mangle -D POSTROUTING -m comment --comment cilium-feeder: CILIUM_POST_mangle -j OLD_CILIUM_POST_mangle",
 		},
+		{args: "-t mangle -D POSTROUTING 2"},
+		{
+			args: "-t mangle -nL PREROUTING --line-numbers",
+			out: []byte(`Chain PREROUTING (policy ACCEPT)
+num  target                 prot opt source               destination
+1    OLD_CILIUM_PRE_mangle  0    --  0.0.0.0/0            0.0.0.0/0            /* cilium-feeder: CILIUM_PRE_mangle */
+2    CILIUM_PRE_mangle      0    --  0.0.0.0/0            0.0.0.0/0            /* cilium-feeder: CILIUM_PRE_mangle */
+`),
+		},
+		{args: "-t mangle -D PREROUTING 1"},
 	}
 
-	// Only removes Cilium chains with the OLD_ prefix
-	mockManager.removeCiliumRules("mangle", mockIp4tables, oldCiliumPrefix+"CILIUM_")
-	err := mockIp4tables.checkExpectations()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, mockManager.removeCiliumFeederRules("mangle", mockIp4tables, oldCiliumPrefix))
+	require.NoError(t, mockIp4tables.checkExpectations())
 }
 
-func TestRemoveCiliumRulesv6(t *testing.T) {
+func TestRemoveCiliumFeederRulesV6(t *testing.T) {
 	mockIp6tables := &mockIptables{t: t, prog: "ip6tables"}
 	mockIp6tables.expectations = []expectation{
 		{
-			args: "-t mangle -S",
-			out: []byte(
-				`-P PREROUTING ACCEPT
--P INPUT ACCEPT
--P FORWARD ACCEPT
--P OUTPUT ACCEPT
--P POSTROUTING ACCEPT
--N OLD_CILIUM_POST_mangle
--N OLD_CILIUM_PRE_mangle
--N CILIUM_POST_mangle
--N CILIUM_PRE_mangle
--N KUBE-KUBELET-CANARY
--N KUBE-PROXY-CANARY
--A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j OLD_CILIUM_PRE_mangle
--A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j OLD_CILIUM_POST_mangle
--A PREROUTING -m comment --comment "cilium-feeder: CILIUM_PRE_mangle" -j CILIUM_PRE_mangle
--A POSTROUTING -m comment --comment "cilium-feeder: CILIUM_POST_mangle" -j CILIUM_POST_mangle
--A OLD_CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
--A OLD_CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip ::1 --tproxy-mark 0x200/0xffffffff
--A OLD_CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip ::1 --tproxy-mark 0x200/0xffffffff
--A CILIUM_PRE_mangle -m socket --transparent -m comment --comment "cilium: any->pod redirect proxied traffic to host proxy" -j MARK --set-xmark 0x200/0xffffffff
--A CILIUM_PRE_mangle -p tcp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip ::1 --tproxy-mark 0x200/0xffffffff
--A CILIUM_PRE_mangle -p udp -m mark --mark 0xd5a90200 -m comment --comment "cilium: TPROXY to host cilium-dns-egress proxy" -j TPROXY --on-port 43477 --on-ip ::1 --tproxy-mark 0x200/0xffffffff
+			args: "-t mangle -nL POSTROUTING --line-numbers",
+			out: []byte(`Chain POSTROUTING (policy ACCEPT)
+num  target                  prot opt source               destination
+1    OLD_CILIUM_POST_mangle  0        ::/0                 ::/0                 /* cilium-feeder: CILIUM_POST_mangle */
+2    CILIUM_POST_mangle      0        ::/0                 ::/0                 /* cilium-feeder: CILIUM_POST_mangle */
 `),
-		}, {
-			args: "-t mangle -D PREROUTING -m comment --comment cilium-feeder: CILIUM_PRE_mangle -j OLD_CILIUM_PRE_mangle",
-		}, {
-			args: "-t mangle -D POSTROUTING -m comment --comment cilium-feeder: CILIUM_POST_mangle -j OLD_CILIUM_POST_mangle",
+		},
+		{args: "-t mangle -D POSTROUTING 1"},
+		{
+			args: "-t mangle -nL PREROUTING --line-numbers",
+			out: []byte(`Chain PREROUTING (policy ACCEPT)
+num  target                 prot opt source               destination
+1    OLD_CILIUM_PRE_mangle  0        ::/0                 ::/0                 /* cilium-feeder: CILIUM_PRE_mangle */
+2    CILIUM_PRE_mangle      0        ::/0                 ::/0                 /* cilium-feeder: CILIUM_PRE_mangle */
+`),
+		},
+		{args: "-t mangle -D PREROUTING 1"},
+	}
+
+	require.NoError(t, mockManager.removeCiliumFeederRules("mangle", mockIp6tables, oldCiliumPrefix))
+	require.NoError(t, mockIp6tables.checkExpectations())
+}
+
+// Regression test for #33465: body corruption (line 2 has 99.105.108.105/24 in
+// the IP slot from version-skew misalignment), legacy chain prefix matching
+// (line 5 targets a chain not in current ciliumChains), and descending-order
+// deletion across multiple matches in one hook.
+func TestRemoveCiliumFeederRulesIgnoresCorruptedBodyAndHandlesLegacyTargets(t *testing.T) {
+	mockIp4tables := &mockIptables{t: t, prog: "iptables"}
+	mockIp4tables.expectations = []expectation{
+		{
+			args: "-t mangle -nL POSTROUTING --line-numbers",
+			out: []byte(`Chain POSTROUTING (policy ACCEPT)
+num  target                  prot opt source               destination
+1    KUBE-POSTROUTING        0    --  0.0.0.0/0            0.0.0.0/0
+2    OLD_CILIUM_POST_mangle  0    --  10.42.0.0/24         99.105.108.105/24    /* corrupted body */
+3    CILIUM_POST_mangle      0    --  0.0.0.0/0            0.0.0.0/0
+4    OLD_CILIUM_POST_mangle  0    --  0.0.0.0/0            0.0.0.0/0
+5    OLD_CILIUM_LEGACY_FOO   0    --  0.0.0.0/0            0.0.0.0/0
+`),
+		},
+		{args: "-t mangle -D POSTROUTING 5"},
+		{args: "-t mangle -D POSTROUTING 4"},
+		{args: "-t mangle -D POSTROUTING 2"},
+		{
+			args: "-t mangle -nL PREROUTING --line-numbers",
+			out: []byte(`Chain PREROUTING (policy ACCEPT)
+num  target     prot opt source               destination
+`),
 		},
 	}
 
-	// Only removes Cilium chains with the OLD_ prefix
-	mockManager.removeCiliumRules("mangle", mockIp6tables, oldCiliumPrefix+"CILIUM_")
-	err := mockIp6tables.checkExpectations()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, mockManager.removeCiliumFeederRules("mangle", mockIp4tables, oldCiliumPrefix))
+	require.NoError(t, mockIp4tables.checkExpectations())
 }
 
 func TestNodeIpsetNATCmds(t *testing.T) {


### PR DESCRIPTION
## Description

When the iptables binary inside the Cilium container and the host's iptables binary disagree on nftables expression serialization (1.8.8 vs 1.8.10 is a common pairing on newer distros), `iptables -S` output can have comment-buffer bytes misaligned into the IP slot, producing the known `99.105.108.105/24` artifact ("cili" in ASCII). The current cleanup path replays that text as `-D`, the kernel rejects it, and the agent loops forever.

This PR makes feeder cleanup body-agnostic: read only line number and jump target from `iptables -nL --line-numbers`, match targets by the `OLD_CILIUM_` prefix, and delete by line number in descending order. Rule bodies are never inspected.

Supersedes #45866, which proposed a narrower config-validation guard before the actual root cause was identified.

## Test plan

- [x] `go test ./pkg/datapath/...` — green
- [x] New unit test: feeder body holds `99.105.108.105/24`, cleanup still issues correct `-D <hook> <N>` calls in descending order

```release-note
Fix iptables reconciliation deadlock when the container-bundled iptables and the host iptables disagree on nftables expression serialization.
```

Fixes: https://github.com/cilium/cilium/issues/33465