### PR TITLE
node: skip tentative and dadfailed addresses in firstGlobalAddr

### DIFF
--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -455,6 +455,14 @@ func (dc *devicesController) processBatch(txn statedb.WriteTxn, batch map[int][]
 				if dc.deadLinkIndexes.Has(u.LinkIndex) {
 					continue
 				}
+				// Skip addresses that are not usable yet. Tentative addresses
+				// are still going through DAD and dadfailed ones never will,
+				// so populating Device.Addrs with them would surface unusable
+				// addresses to downstream features. A later AddrUpdate emitted
+				// by the kernel when DAD completes will add the address.
+				if u.NewAddr && u.Flags&(unix.IFA_F_TENTATIVE|unix.IFA_F_DADFAILED) != 0 {
+					continue
+				}
 				addr := deviceAddressFromAddrUpdate(u)
 				i := slices.Index(d.Addrs, addr)
 				if u.NewAddr {

--- a/pkg/node/address_linux.go
+++ b/pkg/node/address_linux.go
@@ -51,18 +51,8 @@ retryScope:
 	hasPreferred := false
 
 	for _, a := range addr {
-		if a.Scope > linkScopeMax {
-			continue
-		}
-		if ip.ListContainsIP(ipsToExclude, a.IP) {
-			continue
-		}
-		if len(a.IP) < ipLen {
-			continue
-		}
 		isPreferredIP := a.IP.Equal(preferredIP)
-		if a.Flags&unix.IFA_F_SECONDARY > 0 && !isPreferredIP {
-			// Skip secondary addresses if they're not the preferredIP
+		if !addrUsableAsNodeIP(a, isPreferredIP, ipsToExclude, linkScopeMax, ipLen) {
 			continue
 		}
 
@@ -124,6 +114,25 @@ retryScope:
 	}
 
 	return nil, fmt.Errorf("No address found")
+}
+
+func addrUsableAsNodeIP(a netlink.Addr, isPreferredIP bool, ipsToExclude []net.IP, linkScopeMax, ipLen int) bool {
+	if a.Scope > linkScopeMax {
+		return false
+	}
+	if ip.ListContainsIP(ipsToExclude, a.IP) {
+		return false
+	}
+	if len(a.IP) < ipLen {
+		return false
+	}
+	if a.Flags&unix.IFA_F_SECONDARY > 0 && !isPreferredIP {
+		return false
+	}
+	if a.Flags&(unix.IFA_F_TENTATIVE|unix.IFA_F_DADFAILED) != 0 {
+		return false
+	}
+	return true
 }
 
 // firstGlobalV4Addr returns the first IPv4 global IP of an interface,

--- a/pkg/node/address_linux_test.go
+++ b/pkg/node/address_linux_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/testutils"
@@ -62,6 +63,91 @@ func TestPrivilegedFirstGlobalV4Addr(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, tc.want, got.String())
 		removeDevice(ifName)
+	}
+}
+
+func TestAddrUsableAsNodeIP(t *testing.T) {
+	testCases := []struct {
+		name          string
+		addr          netlink.Addr
+		isPreferredIP bool
+		ipsToExclude  []net.IP
+		linkScopeMax  int
+		ipLen         int
+		want          bool
+	}{
+		{
+			name:         "plain IPv4 is usable",
+			addr:         netlink.Addr{IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.1"), Mask: net.CIDRMask(24, 32)}, Scope: int(unix.RT_SCOPE_UNIVERSE)},
+			linkScopeMax: int(unix.RT_SCOPE_UNIVERSE),
+			ipLen:        4,
+			want:         true,
+		},
+		{
+			name:         "tentative IPv6 is rejected",
+			addr:         netlink.Addr{IPNet: &net.IPNet{IP: net.ParseIP("2001:db8::1"), Mask: net.CIDRMask(64, 128)}, Scope: int(unix.RT_SCOPE_UNIVERSE), Flags: unix.IFA_F_TENTATIVE},
+			linkScopeMax: int(unix.RT_SCOPE_UNIVERSE),
+			ipLen:        16,
+			want:         false,
+		},
+		{
+			name:         "dadfailed IPv6 is rejected",
+			addr:         netlink.Addr{IPNet: &net.IPNet{IP: net.ParseIP("2001:db8::2"), Mask: net.CIDRMask(64, 128)}, Scope: int(unix.RT_SCOPE_UNIVERSE), Flags: unix.IFA_F_DADFAILED},
+			linkScopeMax: int(unix.RT_SCOPE_UNIVERSE),
+			ipLen:        16,
+			want:         false,
+		},
+		{
+			name:         "tentative and dadfailed combined is rejected",
+			addr:         netlink.Addr{IPNet: &net.IPNet{IP: net.ParseIP("2001:db8::3"), Mask: net.CIDRMask(64, 128)}, Scope: int(unix.RT_SCOPE_UNIVERSE), Flags: unix.IFA_F_TENTATIVE | unix.IFA_F_DADFAILED},
+			linkScopeMax: int(unix.RT_SCOPE_UNIVERSE),
+			ipLen:        16,
+			want:         false,
+		},
+		{
+			name:          "secondary IPv4 is rejected unless preferred",
+			addr:          netlink.Addr{IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.2"), Mask: net.CIDRMask(24, 32)}, Scope: int(unix.RT_SCOPE_UNIVERSE), Flags: unix.IFA_F_SECONDARY},
+			isPreferredIP: false,
+			linkScopeMax:  int(unix.RT_SCOPE_UNIVERSE),
+			ipLen:         4,
+			want:          false,
+		},
+		{
+			name:          "secondary IPv4 is accepted when it is the preferred IP",
+			addr:          netlink.Addr{IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.2"), Mask: net.CIDRMask(24, 32)}, Scope: int(unix.RT_SCOPE_UNIVERSE), Flags: unix.IFA_F_SECONDARY},
+			isPreferredIP: true,
+			linkScopeMax:  int(unix.RT_SCOPE_UNIVERSE),
+			ipLen:         4,
+			want:          true,
+		},
+		{
+			name:         "address narrower than allowed scope is rejected",
+			addr:         netlink.Addr{IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.1"), Mask: net.CIDRMask(24, 32)}, Scope: int(unix.RT_SCOPE_HOST)},
+			linkScopeMax: int(unix.RT_SCOPE_SITE),
+			ipLen:        4,
+			want:         false,
+		},
+		{
+			name:         "excluded address is rejected",
+			addr:         netlink.Addr{IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.1"), Mask: net.CIDRMask(24, 32)}, Scope: int(unix.RT_SCOPE_UNIVERSE)},
+			ipsToExclude: []net.IP{net.ParseIP("10.0.0.1")},
+			linkScopeMax: int(unix.RT_SCOPE_UNIVERSE),
+			ipLen:        4,
+			want:         false,
+		},
+		{
+			name:         "address shorter than required ipLen is rejected",
+			addr:         netlink.Addr{IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.1").To4(), Mask: net.CIDRMask(24, 32)}, Scope: int(unix.RT_SCOPE_UNIVERSE)},
+			linkScopeMax: int(unix.RT_SCOPE_UNIVERSE),
+			ipLen:        16,
+			want:         false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := addrUsableAsNodeIP(tc.addr, tc.isPreferredIP, tc.ipsToExclude, tc.linkScopeMax, tc.ipLen)
+			require.Equal(t, tc.want, got)
+		})
 	}
 }
 


### PR DESCRIPTION
On a node where every global IPv6 on the named interface ended up tentative or dadfailed (for example after a duplicate-address conflict on the LAN), firstGlobalAddr would still return one of the failed addresses or fall back to an unrelated address from a different interface, and the CiliumNode CRD could end up holding another node's IP. The legacy path adds a check for IFA_F_TENTATIVE and IFA_F_DADFAILED next to the existing IFA_F_SECONDARY filter so non-usable addresses are skipped, and pulls the per-address acceptability logic into a small helper so it can be unit tested. The same filter is now also applied in devices_controller.go when ingesting AddrUpdate events so the modern Table[*Device] does not pick up tentative or dadfailed addresses either, since that table is the source of addresses for many features beyond firstGlobalAddr. New table-driven tests cover the tentative and dadfailed cases as well as the existing scope, secondary, exclude, and length checks.

Fixes #45840

```release-note
Fix Cilium node IPv6 selection silently picking an address that failed duplicate-address detection, which could result in the node advertising an address belonging to another node
```
