### PR TITLE
v1.17 Backport for endpoint: treat mirror pod UID mismatch as valid

### DIFF
--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -184,12 +185,22 @@ func (d *Daemon) fetchK8sMetadataForEndpoint(nsName, podName, uid string) (*slim
 		return nil, nil, err
 	}
 
-	if uid != "" && uid != string(p.GetUID()) {
+	if isPodStoreOutdatedForUID(uid, p) {
 		return nil, nil, podStoreOutdatedErr
 	}
 
 	metadata, err := d.fetchK8sMetadataForEndpointFromPod(p)
 	return p, metadata, err
+}
+
+// isPodStoreOutdatedForUID returns true when CNI uid disagrees with the store pod uid such
+// that podStoreOutdatedErr applies. Mirror pods (static pods; corev1.MirrorPodAnnotationKey) are exempt.
+func isPodStoreOutdatedForUID(uid string, pod *slim_corev1.Pod) bool {
+	if uid == "" || uid == string(pod.GetUID()) {
+		return false
+	}
+	_, mirrorPod := pod.GetAnnotations()[corev1.MirrorPodAnnotationKey]
+	return !mirrorPod
 }
 
 func (d *Daemon) fetchK8sMetadataForEndpointFromPod(p *slim_corev1.Pod) (*endpoint.K8sMetadata, error) {

--- a/daemon/cmd/endpoint_test.go
+++ b/daemon/cmd/endpoint_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -207,6 +208,61 @@ func (f *fetcher) FetchPod(nsName, podName string) (*slim_corev1.Pod, error) {
 	return f.fn(f.runs, nsName, podName)
 }
 
+func TestIsPodStoreOutdatedForUID(t *testing.T) {
+	storeUID := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	otherUID := "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+	tests := []struct {
+		name string
+		uid  string
+		pod  *slim_corev1.Pod
+		want bool
+	}{
+		{
+			name: "empty uid never outdated",
+			uid:  "",
+			pod:  &slim_corev1.Pod{ObjectMeta: slim_metav1.ObjectMeta{UID: types.UID(storeUID)}},
+			want: false,
+		},
+		{
+			name: "uid match not outdated",
+			uid:  storeUID,
+			pod:  &slim_corev1.Pod{ObjectMeta: slim_metav1.ObjectMeta{UID: types.UID(storeUID)}},
+			want: false,
+		},
+		{
+			name: "uid mismatch without mirror annotation is outdated",
+			uid:  otherUID,
+			pod: &slim_corev1.Pod{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					UID: types.UID(storeUID),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "uid mismatch mirror pod not outdated",
+			uid:  otherUID,
+			pod: &slim_corev1.Pod{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					UID: types.UID(storeUID),
+					Annotations: map[string]string{
+						corev1.MirrorPodAnnotationKey: otherUID,
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isPodStoreOutdatedForUID(tt.uid, tt.pod)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestHandleOutdatedPodInformer(t *testing.T) {
 	defer func(current time.Duration) { handleOutdatedPodInformerRetryPeriod = current }(handleOutdatedPodInformerRetryPeriod)
 	handleOutdatedPodInformerRetryPeriod = 1 * time.Millisecond
@@ -243,6 +299,18 @@ func TestHandleOutdatedPodInformer(t *testing.T) {
 				return podStoreOutdatedErr
 			},
 			retries: 20,
+		},
+		{
+			name: "uid mismatch mirror pod",
+			fetcher: func(_ uint, nsName, podName string) (*slim_corev1.Pod, error) {
+				return &slim_corev1.Pod{ObjectMeta: slim_metav1.ObjectMeta{
+					Name: podName, Namespace: nsName, UID: "other",
+					Annotations: map[string]string{
+						corev1.MirrorPodAnnotationKey: "uid",
+					},
+				}}, nil
+			},
+			err: func(string) error { return nil },
 		},
 		{
 			name: "uid mismatch, then resolved",


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Write a short paragraph that states whether you used machine learning models
      (including LLMs and other generative AI), and indicate the rating using
      [AI Influence Level](https://danielmiessler.com/blog/ai-influence-level-ail).
      Example: "This PR was prepared with AIL:3. I personally reviewed each line
      of the submission prior to opening this PR."
- [X] Thanks for contributing!

Backport of #45016 to v1.17.

The automated v1.17 backport skipped this PR because `pkg/endpoint/metadata/k8s_metadatafetcher.go` does not exist in v1.17. I asked whether a manual v1.17 PR using the v1.17 code path would be appropriate and @Artyop replied that a PR was OK if this could be fixed without bringing the metadata package into v1.17, and asked me to quote/link https://github.com/cilium/cilium/pull/45238#issuecomment-4212612466

This backport applies the same logic from #45016 in the pre-refactor location, `daemon/cmd/endpoint.go`, where v1.17 still performs the Kubernetes endpoint metadata lookup.

AI usage:
  This PR was prepared with AIL:3. I personally reviewed each line of the submission prior to opening this PR. I also had the AI run a full test including running a `kind` cluster and creating a static pod to confirm the fix.

Testing:
  - `BUILDER_GOCACHE_DIR=/private/tmp/cilium-builder-gocache contrib/scripts/builder.sh go test ./daemon/cmd -run
  'TestIsPodStoreOutdatedForUID|TestHandleOutdatedPodInformer' -count=1`
  - `make kind`
  - `make kind-image`
  - `CILIUM_CLI=/private/tmp/cilium-cli-v0.19.2/cilium make kind-install-cilium`
  - Created a static pod on `kind-worker`; verified the mirror pod had differing `.metadata.uid` and `kubernetes.io/config.mirror`, and Cilium
  created a ready endpoint with a real Kubernetes-label identity instead of `reserved:init`.

Fixes: #34197

```release-note
  Fix endpoint identity resolution for static pods whose CNI pod UID differs from the Kubernetes mirror pod UID.
```
