### PR TITLE
v1.19 Backports 2026-05-11

### DIFF
--- a/Documentation/network/kubernetes/ciliumcidrgroup.rst
+++ b/Documentation/network/kubernetes/ciliumcidrgroup.rst
@@ -6,9 +6,9 @@
 
 .. _CiliumCIDRGroup:
 
-***************************
+***************
 CiliumCIDRGroup
-***************************
+***************
 
 CiliumCIDRGroup (CCG) is a feature that allows administrators to reference a group of
 CIDR blocks in a :ref:`CiliumNetworkPolicy`. Unlike :ref:`CiliumEndpoint` resources,
@@ -63,3 +63,12 @@ by names or labels.
 In this example, the ``fromCIDRSet`` directive in the CNP references the
 ``vpn-example-1`` group defined in the ``CiliumCIDRGroup``. This allows the CNP to
 apply ingress rules based on the CIDRs grouped under the ``vpn-example-1`` name.
+
+
+Scalability impacts
+-------------------
+
+CiliumCIDRGroups generally result in the creation of a single
+:ref:`security identity <arch_id_security>` per group. For large groups,
+this can be a significant savings. Use CiliumCIDRGroup
+when large numbers of CIDRs must be selected.

--- a/Documentation/observability/visibility.rst
+++ b/Documentation/observability/visibility.rst
@@ -45,7 +45,11 @@ permit all requests that match the L4 section of each rule:
           matchLabels:
             "k8s:io.kubernetes.pod.namespace": default
         egress:
-        - toPorts:
+        - toEndpoints:
+          - matchLabels:
+              "k8s:io.kubernetes.pod.namespace": kube-system
+              "k8s:k8s-app": kube-dns
+          toPorts:
           - ports:
             - port: "53"
               protocol: ANY
@@ -64,10 +68,11 @@ permit all requests that match the L4 section of each rule:
             rules:
               http: [{}]
 
-Based on the above policy, Cilium will pick up all TCP/UDP/53, TCP/80 and TCP/8080
-egress traffic from Pods in the ``default`` namespace and redirect it to the
-proxy (see :ref:`proxy_injection`) such that the output of ``cilium monitor`` or
-``hubble observe`` shows the L7 flow details.
+Based on the above policy, Cilium will pick up DNS traffic to ``kube-dns`` on
+port 53 and HTTP traffic on ports TCP/80 and TCP/8080 from Pods in the
+``default`` namespace and redirect it to the proxy (see :ref:`proxy_injection`)
+such that the output of ``cilium monitor`` or ``hubble observe`` shows the L7
+flow details.
 Below is the example of running ``hubble observe -f -t l7 -o compact`` command:
 
 ::

--- a/Documentation/security/policy/layer3.rst
+++ b/Documentation/security/policy/layer3.rst
@@ -445,6 +445,14 @@ but not CIDR prefix ``10.96.0.0/12``
 .. literalinclude:: ../../../examples/policies/l3/cidr/cidr.yaml
   :language: yaml
 
+
+Scalability
+~~~~~~~~~~~
+
+Policies that select large numbers of distinct CIDRs can cause agents to allocate
+large numbers of :ref:`security identities <arch_id_security>`. In this scenario,
+use a :ref:`CiliumCIDRGroup` to reduce identity usage.
+
 .. _cidr_select_nodes:
 
 Selecting nodes with CIDR / ipBlock

--- a/Documentation/security/policy/layer7.rst
+++ b/Documentation/security/policy/layer7.rst
@@ -213,6 +213,15 @@ query names or patterns of names (other DNS fields, such as query type, are not
 considered). This policy is effected via a `DNS Proxy`, which is also used to
 collect IPs used to populate L3 `DNS based` ``toFQDNs`` rules.
 
+.. danger::
+
+   When using Layer 7 DNS policy, strongly prefer intercepting DNS traffic
+   only to the cluster DNS service, such as ``kube-dns``. Intercepting DNS
+   traffic to other resolvers broadens the trust boundary for DNS-based policy
+   decisions and may allow less-trusted DNS servers to influence the IPs
+   learned for ``toFQDNs`` rules. This recommendation aligns with the trust
+   assumption documented in :ref:`the threat model <workload_attacker_table>`.
+
 .. note::  While Layer 7 DNS policy can be applied without any other Layer 3
            rules, the presence of a Layer 7 rule (with its Layer 3 and 4
            components) will block other traffic.
@@ -282,6 +291,12 @@ A DNS Proxy in the agent intercepts egress DNS traffic and records IPs seen
 in the responses. This interception is, itself, a separate policy rule governing
 DNS requests, and must be specified separately. For details on how to enforce
 policy on DNS requests and configuring the DNS proxy, see `Layer 7 Policies`_.
+
+.. danger::
+
+   When this proxy is used together with ``toFQDNs``, the security model
+   assumes that the intercepted DNS responses come from trusted cluster DNS
+   servers; see :ref:`the threat model <workload_attacker_table>`.
 
 Only IPs in intercepted DNS responses to an application will be allowed in
 the Cilium policy rules. For a given domain name, IPs from responses to all

--- a/Documentation/security/threat-model.rst
+++ b/Documentation/security/threat-model.rst
@@ -109,6 +109,8 @@ In this scenario, there is no potential for compromise of the Cilium
 stack; in fact, Cilium provides several features that would allow users
 to limit the scope of such an attack:
 
+.. _workload_attacker_table:
+
 .. rst-class:: wrapped-table
 
 +-----------------+---------------------+--------------------------------+
@@ -130,35 +132,41 @@ to limit the scope of such an attack:
 | Cilium eBPF     | None                |                                |
 | programs        |                     |                                |
 +-----------------+---------------------+--------------------------------+
-| Network data    | None                | - Cilium's network policy can  |
-|                 |                     |   be used to provide           |
-|                 |                     |   least-privilege isolation    |
-|                 |                     |   between Kubernetes           |
-|                 |                     |   workloads, and between       |
-|                 |                     |   Kubernetes workloads and     |
-|                 |                     |   "external" endpoints running |
-|                 |                     |   outside the Kubernetes       |
-|                 |                     |   cluster, or running on the   |
-|                 |                     |   Kubernetes worker nodes.     |
-|                 |                     |   Users should ideally define  |
-|                 |                     |   specific allow rules that    |
-|                 |                     |   only permit expected         |
-|                 |                     |   communication between        |
-|                 |                     |   services.                    |
-|                 |                     | - Cilium's network             |
-|                 |                     |   connectivity will prevent an |
-|                 |                     |   attacker from observing the  |
-|                 |                     |   traffic intended for other   |
-|                 |                     |   workloads, or sending        |
-|                 |                     |   traffic that "spoofs" the    |
-|                 |                     |   identity of another pod,     |
-|                 |                     |   even if transparent          |
-|                 |                     |   encryption is not in use.    |
-|                 |                     |   Pods cannot send traffic     |
-|                 |                     |   that "spoofs" other pods due |
-|                 |                     |   to limits on the use of      |
-|                 |                     |   source IPs and limits on     |
-|                 |                     |   sending tunneled traffic.    |
+| Network data    | When using          | - Cilium's network policy can  |
+|                 | ``toFQDNs`` to      |   be used to provide           |
+|                 | define permitted    |   least-privilege isolation    |
+|                 | traffic, Cilium     |   between Kubernetes           |
+|                 | assumes that the    |   workloads, and between       |
+|                 | DNS servers used    |   Kubernetes workloads and     |
+|                 | by the cluster can  |   "external" endpoints running |
+|                 | be trusted to       |   outside the Kubernetes       |
+|                 | return correct      |   cluster, or running on the   |
+|                 | answers for policy  |   Kubernetes worker nodes.     |
+|                 | decisions. If those |   Users should ideally define  |
+|                 | DNS servers are     |   specific allow rules that    |
+|                 | compromised or      |   only permit expected         |
+|                 | malicious, they may |   communication between        |
+|                 | influence which IPs |   services.                    |
+|                 | Cilium learns and   | - Cilium's network             |
+|                 | allows for          |   connectivity will prevent an |
+|                 | ``toFQDNs``-based   |   attacker from observing the  |
+|                 | policy. For         |   traffic intended for other   |
+|                 | guidance on         |   workloads, or sending        |
+|                 | constraining that   |   traffic that "spoofs" the    |
+|                 | DNS trust boundary, |   identity of another pod,     |
+|                 | see :ref:`DNS       |   even if transparent          |
+|                 | Policy and IP       |   encryption is not in use.    |
+|                 | Discovery           |   Pods cannot send traffic     |
+|                 | <dns_discovery>`.   |   that "spoofs" other pods due |
+|                 | In cases where the  |   to limits on the use of      |
+|                 | DNS boundary is not |   source IPs and limits on     |
+|                 | constrained, a      |   sending tunneled traffic.    |
+|                 | workload attacker   |                                |
+|                 | may be able to use  |                                |
+|                 | control of a        |                                |
+|                 | malicious DNS       |                                |
+|                 | server to influence |                                |
+|                 | policy decisions.   |                                |
 +-----------------+---------------------+--------------------------------+
 | Observability   | None                | Cilium's Hubble flow-event     |
 | data            |                     | observability can be used to   |
@@ -713,6 +721,9 @@ production Kubernetes cluster with Cilium:
    and Hubble UI.
 #. Use `Tetragon`_ as a runtime security solution to rapidly detect unexpected
    behavior within your Kubernetes cluster.
+#. If using ``toFQDNs``-based network policies, strongly prefer intercepting DNS traffic
+   only to the cluster DNS service. See :ref:`the workload attacker table <workload_attacker_table>`
+   for details.
 
 If you have questions, suggestions, or would like to help improve Cilium's security
 posture, reach out to security@cilium.io.

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -720,6 +720,7 @@ reproducibility
 reqid
 requireIPv
 resizable
+resolvers
 resync
 retpoline
 retransmission

--- a/cilium-dbg/cmd/map_list.go
+++ b/cilium-dbg/cmd/map_list.go
@@ -5,8 +5,10 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path"
+	"strconv"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -39,7 +41,7 @@ var mapListCmd = &cobra.Command{
 			if verbose {
 				printMapListVerbose(mapList)
 			} else {
-				printMapList(mapList)
+				printMapList(os.Stdout, mapList)
 			}
 		}
 	},
@@ -53,23 +55,30 @@ func printMapListVerbose(mapList *models.BPFMapList) {
 	}
 }
 
-func printMapList(mapList *models.BPFMapList) {
-	w := tabwriter.NewWriter(os.Stdout, 5, 0, 3, ' ', 0)
+func printMapList(out io.Writer, mapList *models.BPFMapList) {
+	w := tabwriter.NewWriter(out, 5, 0, 3, ' ', 0)
 	fmt.Fprintf(w, "Name\tNum entries\tNum errors\tCache enabled\n")
 	for _, m := range mapList.Maps {
-		entries, errors := 0, 0
+		entries := "unknown"
+		var errorCount int
 		cacheEnabled := m.Cache != nil
 
-		for _, e := range m.Cache {
-			if e != nil {
-				if e.LastError != "" {
-					errors++
+		if cacheEnabled {
+			var entryCount int
+			for _, e := range m.Cache {
+				if e == nil {
+					continue
 				}
-				entries++
+				entryCount++
+				if e.LastError != "" {
+					errorCount++
+				}
 			}
+			entries = strconv.Itoa(entryCount)
 		}
-		fmt.Fprintf(w, "%s\t%d\t%d\t%t\n",
-			path.Base(m.Path), entries, errors, cacheEnabled)
+
+		fmt.Fprintf(w, "%s\t%s\t%d\t%t\n",
+			path.Base(m.Path), entries, errorCount, cacheEnabled)
 	}
 	w.Flush()
 }

--- a/cilium-dbg/cmd/map_list_test.go
+++ b/cilium-dbg/cmd/map_list_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/api/v1/models"
+)
+
+func TestPrintMapList(t *testing.T) {
+	tests := []struct {
+		name     string
+		maps     []*models.BPFMap
+		expected []string
+	}{
+		{
+			name: "map with cache entries shows count",
+			maps: []*models.BPFMap{
+				{
+					Path: "/sys/fs/bpf/tc/globals/cilium_ipcache",
+					Cache: []*models.BPFMapEntry{
+						{Key: "key1", Value: "val1"},
+						{Key: "key2", Value: "val2"},
+					},
+				},
+			},
+			expected: []string{"cilium_ipcache", "2", "0", "true"},
+		},
+		{
+			name: "map with nil cache shows unknown",
+			maps: []*models.BPFMap{
+				{
+					Path: "/sys/fs/bpf/tc/globals/cilium_node_map_v2",
+				},
+			},
+			expected: []string{"cilium_node_map_v2", "unknown", "0", "false"},
+		},
+		{
+			name: "map with empty cache shows zero",
+			maps: []*models.BPFMap{
+				{
+					Path:  "/sys/fs/bpf/tc/globals/cilium_empty_map",
+					Cache: []*models.BPFMapEntry{},
+				},
+			},
+			expected: []string{"cilium_empty_map", "0", "0", "true"},
+		},
+		{
+			name: "map with cache errors counts them",
+			maps: []*models.BPFMap{
+				{
+					Path: "/sys/fs/bpf/tc/globals/cilium_test",
+					Cache: []*models.BPFMapEntry{
+						{Key: "key1", Value: "val1"},
+						{Key: "key2", Value: "val2", LastError: "sync failed"},
+					},
+				},
+			},
+			expected: []string{"cilium_test", "2", "1", "true"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			printMapList(&buf, &models.BPFMapList{Maps: tt.maps})
+			output := buf.String()
+
+			for _, exp := range tt.expected {
+				require.Contains(t, output, exp,
+					"expected output to contain %q, got:\n%s", exp, output)
+			}
+		})
+	}
+}

--- a/operator/pkg/ingress/ingress_reconcile.go
+++ b/operator/pkg/ingress/ingress_reconcile.go
@@ -252,9 +252,9 @@ func (r *ingressReconciler) buildDedicatedResources(ctx context.Context, ingress
 	m := &model.Model{}
 
 	if annotations.GetAnnotationTLSPassthroughEnabled(ingress) {
-		m.TLSPassthrough = append(m.TLSPassthrough, ingestion.IngressPassthrough(nil, *ingress, passthroughPort)...)
+		m.TLSPassthrough = append(m.TLSPassthrough, ingestion.IngressPassthrough(scopedLog, *ingress, passthroughPort)...)
 	} else {
-		m.HTTP = append(m.HTTP, ingestion.Ingress(nil, *ingress, r.defaultSecretNamespace, r.defaultSecretName, r.enforcedHTTPS, insecureHTTPPort, secureHTTPPort, r.defaultRequestTimeout)...)
+		m.HTTP = append(m.HTTP, ingestion.Ingress(scopedLog, *ingress, r.defaultSecretNamespace, r.defaultSecretName, r.enforcedHTTPS, insecureHTTPPort, secureHTTPPort, r.defaultRequestTimeout)...)
 	}
 
 	cec, svc, ep, err := r.dedicatedTranslator.Translate(m)

--- a/operator/pkg/ingress/ingress_reconcile_test.go
+++ b/operator/pkg/ingress/ingress_reconcile_test.go
@@ -1148,6 +1148,69 @@ func TestReconcile(t *testing.T) {
 		assert.Len(t, dedicatedIngressTranslator.model.HTTP, 1)
 		assert.Equal(t, uint32(55555), dedicatedIngressTranslator.model.HTTP[0].Port)
 	})
+
+	t.Run("Reconcile of dedicated TLS passthrough Ingress with a non-root path skips invalid rules without panicking", func(t *testing.T) {
+		pathType := networkingv1.PathTypePrefix
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(testScheme()).
+			WithObjects(
+				&networkingv1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test",
+						Name:      "test",
+						Annotations: map[string]string{
+							"ingress.cilium.io/loadbalancer-mode": "dedicated",
+							"ingress.cilium.io/tls-passthrough":   "true",
+						},
+					},
+					Spec: networkingv1.IngressSpec{
+						IngressClassName: ptr.To("cilium"),
+						Rules: []networkingv1.IngressRule{
+							{
+								Host: "example.com",
+								IngressRuleValue: networkingv1.IngressRuleValue{
+									HTTP: &networkingv1.HTTPIngressRuleValue{
+										Paths: []networkingv1.HTTPIngressPath{
+											{
+												Path:     "/api/webhook",
+												PathType: &pathType,
+												Backend: networkingv1.IngressBackend{
+													Service: &networkingv1.IngressServiceBackend{
+														Name: "test",
+														Port: networkingv1.ServiceBackendPort{
+															Number: 8080,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			).
+			Build()
+
+		cecTranslator := &fakeCECTranslator{}
+		dedicatedIngressTranslator := &fakeDedicatedIngressTranslator{}
+
+		reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0)
+
+		result, err := reconciler.Reconcile(t.Context(), reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: "test",
+				Name:      "test",
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		assert.Empty(t, dedicatedIngressTranslator.model.TLSPassthrough)
+		assert.Empty(t, dedicatedIngressTranslator.model.HTTP)
+	})
 }
 
 var _ translation.CECTranslator = &fakeCECTranslator{}

--- a/operator/pkg/secretsync/secretsync_reconcile.go
+++ b/operator/pkg/secretsync/secretsync_reconcile.go
@@ -167,6 +167,13 @@ func (r *secretSyncer) ensureSyncedSecret(ctx context.Context, desired *corev1.S
 		return err
 	}
 
+	if existing.Type != desired.Type {
+		if err := r.client.Delete(ctx, existing); err != nil && !k8serrors.IsNotFound(err) {
+			return err
+		}
+		return r.client.Create(ctx, desired)
+	}
+
 	temp := existing.DeepCopy()
 	temp.SetAnnotations(desired.GetAnnotations())
 	temp.SetLabels(desired.GetLabels())

--- a/operator/pkg/secretsync/secretsync_reconcile_test.go
+++ b/operator/pkg/secretsync/secretsync_reconcile_test.go
@@ -352,6 +352,107 @@ func Test_SecretSync_Reconcile(t *testing.T) {
 	})
 }
 
+var secretFixtureTypeChange = []client.Object{
+	&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test",
+			Name:      "cert-tls",
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			"tls.crt": []byte("cert"),
+			"tls.key": []byte("key"),
+		},
+	},
+	&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: secretsNamespace,
+			Name:      "test-cert-tls",
+			UID:       "stale-opaque-uid",
+			Labels: map[string]string{
+				secretsync.OwningSecretNamespace: "test",
+				secretsync.OwningSecretName:      "cert-tls",
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+	},
+	&gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cilium",
+		},
+		Spec: gatewayv1.GatewayClassSpec{
+			ControllerName: "io.cilium/gateway-controller",
+		},
+	},
+	&gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test",
+			Name:      "tls-gateway",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cilium",
+			Listeners: []gatewayv1.Listener{
+				{
+					Name:     "https",
+					Port:     443,
+					Hostname: ptr.To[gatewayv1.Hostname]("*.cilium.io"),
+					Protocol: "HTTPS",
+					TLS: &gatewayv1.ListenerTLSConfig{
+						CertificateRefs: []gatewayv1.SecretObjectReference{
+							{Name: "cert-tls"},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+func Test_SecretSync_Reconcile_TypeChange(t *testing.T) {
+	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+
+	c := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(secretFixtureTypeChange...).
+		Build()
+
+	r := secretsync.NewSecretSyncReconciler(c, logger, []*secretsync.SecretSyncRegistration{
+		{
+			RefObject:            &gatewayv1.Gateway{},
+			RefObjectEnqueueFunc: gateway_api.EnqueueTLSSecrets(c, logger),
+			RefObjectCheckFunc:   gateway_api.IsReferencedByCiliumGateway,
+			SecretsNamespace:     secretsNamespace,
+		},
+	},
+		time.Minute,
+		0.1,
+	)
+
+	t.Run("synced secret type is updated when source secret type changes", func(t *testing.T) {
+		synced := &corev1.Secret{}
+		err := c.Get(t.Context(), types.NamespacedName{Namespace: secretsNamespace, Name: "test-cert-tls"}, synced)
+		require.NoError(t, err)
+		require.Equal(t, corev1.SecretTypeOpaque, synced.Type)
+
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: "test",
+				Name:      "cert-tls",
+			},
+		})
+		require.NoError(t, err)
+		require.True(t, resultHasResync(result))
+		synced = &corev1.Secret{}
+		err = c.Get(t.Context(), types.NamespacedName{Namespace: secretsNamespace, Name: "test-cert-tls"}, synced)
+		require.NoError(t, err)
+		require.Equal(t, corev1.SecretTypeTLS, synced.Type, "synced secret should adopt the source secret's type")
+		require.Equal(t, []byte("cert"), synced.Data["tls.crt"])
+		require.Equal(t, []byte("key"), synced.Data["tls.key"])
+		require.NotEqual(t, types.UID("stale-opaque-uid"), synced.UID,
+			"synced secret must be recreated (new UID) since Secret.Type is immutable")
+	})
+}
+
 var secretFixtureDefaultSecret = []client.Object{
 	&corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/hive/health/command.go
+++ b/pkg/hive/health/command.go
@@ -4,6 +4,7 @@
 package health
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"slices"
@@ -80,6 +81,11 @@ func healthTreeCommand(db *statedb.DB, table statedb.Table[types.Status]) script
 
 			ss := getHealth(db, table, prefix, match, levels)
 			healthPkg.GetAndFormatModulesHealth(w, ss, true, "")
+
+			if (prefix != "" || match != "") && len(ss) == 0 {
+				return nil, errors.New("no health status found for the filter")
+			}
+
 			return nil, nil
 		},
 	)


### PR DESCRIPTION
 * [ ] #45721 (@ssam18)
 * [ ] #45554 (@fristonio)
 * [x] #45763 (@squeed)
 * [ ] #44951 (@skymensch)
 * [ ] #45737 (@weizhoublue)
 * [x] #45525 (@ferozsalam)

PRs skipped due to conflicts:

 * #45679 (@mhofstetter)
    :x: Skipped, as it looks like none of the reverted commits had been backported to v1.19.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 45721 45554 45763 44951 45737 45525
```
