### PR TITLE
v1.17 Backports 2026-05-11

### DIFF
--- a/Documentation/observability/visibility.rst
+++ b/Documentation/observability/visibility.rst
@@ -45,7 +45,11 @@ permit all requests that match the L4 section of each rule:
           matchLabels:
             "k8s:io.kubernetes.pod.namespace": default
         egress:
-        - toPorts:
+        - toEndpoints:
+          - matchLabels:
+              "k8s:io.kubernetes.pod.namespace": kube-system
+              "k8s:k8s-app": kube-dns
+          toPorts:
           - ports:
             - port: "53"
               protocol: ANY
@@ -64,10 +68,11 @@ permit all requests that match the L4 section of each rule:
             rules:
               http: [{}]
 
-Based on the above policy, Cilium will pick up all TCP/UDP/53, TCP/80 and TCP/8080
-egress traffic from Pods in the ``default`` namespace and redirect it to the
-proxy (see :ref:`proxy_injection`) such that the output of ``cilium monitor`` or
-``hubble observe`` shows the L7 flow details.
+Based on the above policy, Cilium will pick up DNS traffic to ``kube-dns`` on
+port 53 and HTTP traffic on ports TCP/80 and TCP/8080 from Pods in the
+``default`` namespace and redirect it to the proxy (see :ref:`proxy_injection`)
+such that the output of ``cilium monitor`` or ``hubble observe`` shows the L7
+flow details.
 Below is the example of running ``hubble observe -f -t l7 -o compact`` command:
 
 ::

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -1231,6 +1231,15 @@ query names or patterns of names (other DNS fields, such as query type, are not
 considered). This policy is effected via a DNS proxy, which is also used to
 collect IPs used to populate L3 `DNS based`_ ``toFQDNs`` rules.
 
+.. danger::
+
+   When using Layer 7 DNS policy, strongly prefer intercepting DNS traffic
+   only to the cluster DNS service, such as ``kube-dns``. Intercepting DNS
+   traffic to other resolvers broadens the trust boundary for DNS-based policy
+   decisions and may allow less-trusted DNS servers to influence the IPs
+   learned for ``toFQDNs`` rules. This recommendation aligns with the trust
+   assumption documented in :ref:`the threat model <workload_attacker_table>`.
+
 .. note::  While Layer 7 DNS policy can be applied without any other Layer 3
            rules, the presence of a Layer 7 rule (with its Layer 3 and 4
            components) will block other traffic.
@@ -1313,6 +1322,12 @@ DNS Proxy
   DNS requests, and must be specified separately. For details on how to enforce
   policy on DNS requests and configuring the DNS proxy, see `Layer 7
   Examples`_.
+
+  .. danger::
+
+   When this proxy is used together with ``toFQDNs``, the security model
+   assumes that the intercepted DNS responses come from trusted cluster DNS
+   servers; see :ref:`the threat model <workload_attacker_table>`.
 
   Only IPs in intercepted DNS responses to an application will be allowed in
   the Cilium policy rules. For a given domain name, IPs from responses to all

--- a/Documentation/security/threat-model.rst
+++ b/Documentation/security/threat-model.rst
@@ -109,6 +109,8 @@ In this scenario, there is no potential for compromise of the Cilium
 stack; in fact, Cilium provides several features that would allow users
 to limit the scope of such an attack:
 
+.. _workload_attacker_table:
+
 .. rst-class:: wrapped-table
 
 +-----------------+---------------------+--------------------------------+
@@ -130,35 +132,41 @@ to limit the scope of such an attack:
 | Cilium eBPF     | None                |                                |
 | programs        |                     |                                |
 +-----------------+---------------------+--------------------------------+
-| Network data    | None                | - Cilium's network policy can  |
-|                 |                     |   be used to provide           |
-|                 |                     |   least-privilege isolation    |
-|                 |                     |   between Kubernetes           |
-|                 |                     |   workloads, and between       |
-|                 |                     |   Kubernetes workloads and     |
-|                 |                     |   "external" endpoints running |
-|                 |                     |   outside the Kubernetes       |
-|                 |                     |   cluster, or running on the   |
-|                 |                     |   Kubernetes worker nodes.     |
-|                 |                     |   Users should ideally define  |
-|                 |                     |   specific allow rules that    |
-|                 |                     |   only permit expected         |
-|                 |                     |   communication between        |
-|                 |                     |   services.                    |
-|                 |                     | - Cilium's network             |
-|                 |                     |   connectivity will prevent an |
-|                 |                     |   attacker from observing the  |
-|                 |                     |   traffic intended for other   |
-|                 |                     |   workloads, or sending        |
-|                 |                     |   traffic that "spoofs" the    |
-|                 |                     |   identity of another pod,     |
-|                 |                     |   even if transparent          |
-|                 |                     |   encryption is not in use.    |
-|                 |                     |   Pods cannot send traffic     |
-|                 |                     |   that "spoofs" other pods due |
-|                 |                     |   to limits on the use of      |
-|                 |                     |   source IPs and limits on     |
-|                 |                     |   sending tunneled traffic.    |
+| Network data    | When using          | - Cilium's network policy can  |
+|                 | ``toFQDNs`` to      |   be used to provide           |
+|                 | define permitted    |   least-privilege isolation    |
+|                 | traffic, Cilium     |   between Kubernetes           |
+|                 | assumes that the    |   workloads, and between       |
+|                 | DNS servers used    |   Kubernetes workloads and     |
+|                 | by the cluster can  |   "external" endpoints running |
+|                 | be trusted to       |   outside the Kubernetes       |
+|                 | return correct      |   cluster, or running on the   |
+|                 | answers for policy  |   Kubernetes worker nodes.     |
+|                 | decisions. If those |   Users should ideally define  |
+|                 | DNS servers are     |   specific allow rules that    |
+|                 | compromised or      |   only permit expected         |
+|                 | malicious, they may |   communication between        |
+|                 | influence which IPs |   services.                    |
+|                 | Cilium learns and   | - Cilium's network             |
+|                 | allows for          |   connectivity will prevent an |
+|                 | ``toFQDNs``-based   |   attacker from observing the  |
+|                 | policy. For         |   traffic intended for other   |
+|                 | guidance on         |   workloads, or sending        |
+|                 | constraining that   |   traffic that "spoofs" the    |
+|                 | DNS trust boundary, |   identity of another pod,     |
+|                 | see :ref:`DNS       |   even if transparent          |
+|                 | Policy and IP       |   encryption is not in use.    |
+|                 | Discovery           |   Pods cannot send traffic     |
+|                 | <dns_discovery>`.   |   that "spoofs" other pods due |
+|                 | In cases where the  |   to limits on the use of      |
+|                 | DNS boundary is not |   source IPs and limits on     |
+|                 | constrained, a      |   sending tunneled traffic.    |
+|                 | workload attacker   |                                |
+|                 | may be able to use  |                                |
+|                 | control of a        |                                |
+|                 | malicious DNS       |                                |
+|                 | server to influence |                                |
+|                 | policy decisions.   |                                |
 +-----------------+---------------------+--------------------------------+
 | Observability   | None                | Cilium's Hubble flow-event     |
 | data            |                     | observability can be used to   |
@@ -713,6 +721,9 @@ production Kubernetes cluster with Cilium:
    and Hubble UI.
 #. Use `Tetragon`_ as a runtime security solution to rapidly detect unexpected
    behavior within your Kubernetes cluster.
+#. If using ``toFQDNs``-based network policies, strongly prefer intercepting DNS traffic
+   only to the cluster DNS service. See :ref:`the workload attacker table <workload_attacker_table>`
+   for details.
 
 If you have questions, suggestions, or would like to help improve Cilium's security
 posture, reach out to security@cilium.io.

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -683,6 +683,7 @@ reproducibility
 reqid
 requireIPv
 resizable
+resolvers
 resync
 retpoline
 retransmission


### PR DESCRIPTION
 * [x] #45525 (@ferozsalam) :warning: resolved conflicts
      :information_source: moved the `layer7.rst` hunks to `language.rst`, alongside the sibling content.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 45525
```
