### PR TITLE
tools/cloud-dep-check: gitignore the built binary

### DIFF
--- a/tools/cloud-dep-check/.gitignore
+++ b/tools/cloud-dep-check/.gitignore
@@ -1,0 +1,1 @@
+cilium-cloud-dep-check


### PR DESCRIPTION
PR #45680 introduced the `cloud-dep-check` tool, but contrary to other tools under `tools/` it's missing a `.gitignore` ignoring the built binary.

This is causing issues when renovate runs as it runs the checks causing the binary to be build and then fails because the binary has a different UID than that of the running renovate process:

```
  WARN: Error updating branch (repository=cilium/cilium,
        baseBranch=main, branch=renovate/main-all-go-deps-main)
  "dep": "github.com/go-openapi/runtime",
  "err": {
    "errno": -13,
    "code": "EACCES",
    "syscall": "open",
    "path": "/tmp/renovate/repos/github/cilium/cilium/tools/cloud-dep-check/cilium-cloud-dep-check",
    "message": "EACCES: permission denied, open
      '/tmp/renovate/repos/github/cilium/cilium/tools/cloud-dep-check/cilium-cloud-dep-check'"
  }
```

See renovate [logs](https://github.com/cilium/cilium/actions/runs/25636303746/job/75248669945).

Adding the missing `.gitignore` for this tool should allow renovate to ignore it and sucessrully create its dependency update branches.