### PR TITLE
Fix new golangci-lint findings

### DIFF
--- a/cilium-cli/install/install.go
+++ b/cilium-cli/install/install.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"slices"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -191,8 +192,8 @@ func (k *K8sInstaller) listVersions() error {
 	}
 	defaultVersion := helm.GetDefaultVersionString()
 	// Iterate backwards to print the newest version first.
-	for i := len(versions) - 1; i >= 0; i-- {
-		version := "v" + versions[i].String()
+	for _, v := range slices.Backward(versions) {
+		version := "v" + v.String()
 		if version == defaultVersion {
 			fmt.Println(version, "(default)")
 		} else {

--- a/cilium-cli/internal/helm/helm.go
+++ b/cilium-cli/internal/helm/helm.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -217,12 +218,12 @@ func GetDefaultVersionString() string {
 		panic(err)
 	}
 	// Start from the latest version
-	for i := len(versions) - 1; i >= 0; i-- {
+	for _, v := range slices.Backward(versions) {
 		// Skip pre-releases
-		if versions[i].Pre != nil {
+		if v.Pre != nil {
 			continue
 		}
-		return fmt.Sprintf("v%s", versions[i].String())
+		return fmt.Sprintf("v%s", v.String())
 	}
 	panic("there is no Cilium version to install")
 }

--- a/daemon/cmd/endpoint_restore.go
+++ b/daemon/cmd/endpoint_restore.go
@@ -540,9 +540,7 @@ func (r *endpointRestorer) regenerateRestoredEndpoints(state *endpointRestoreSta
 	// purpose, all endpoints being restored must already be in the
 	// endpoint list.
 	startTimeRestore := time.Now()
-	for i := len(state.restored) - 1; i >= 0; i-- {
-		ep := state.restored[i]
-
+	for i, ep := range slices.Backward(state.restored) {
 		// Insert into endpoint manager so it can be regenerated when calls to
 		// RegenerateAllEndpoints() are made. This must be done synchronously (i.e.,
 		// not in a goroutine) because regenerateRestoredEndpoints must guarantee

--- a/pkg/bpf/analyze/fields.go
+++ b/pkg/bpf/analyze/fields.go
@@ -16,7 +16,7 @@ import (
 // Fields extracts object names tagged 'ebpf' from a struct type.
 func Fields(to any) (*set.Set[string], error) {
 	toValue := reflect.ValueOf(to)
-	if toValue.Type().Kind() != reflect.Ptr {
+	if toValue.Type().Kind() != reflect.Pointer {
 		return nil, fmt.Errorf("%T is not a pointer to struct", to)
 	}
 
@@ -62,7 +62,7 @@ func ebpfFields(structVal reflect.Value, visited map[reflect.Type]bool) (*set.Se
 		// to a struct, attempt to gather its fields as well.
 		var v reflect.Value
 		switch field.Type.Kind() {
-		case reflect.Ptr:
+		case reflect.Pointer:
 			if field.Type.Elem().Kind() != reflect.Struct {
 				continue
 			}

--- a/pkg/bpf/constants.go
+++ b/pkg/bpf/constants.go
@@ -83,7 +83,7 @@ func typeName(i any) string {
 		return ""
 	}
 	typ := reflect.TypeOf(i)
-	if typ.Kind() == reflect.Ptr {
+	if typ.Kind() == reflect.Pointer {
 		typ = typ.Elem()
 	}
 	return typ.String()

--- a/pkg/datapath/linux/route/route.go
+++ b/pkg/datapath/linux/route/route.go
@@ -35,9 +35,9 @@ func (r *Route) LogAttrs() []any {
 	}
 
 	return []any{
-		slog.String("prefix", r.Prefix.String()),
-		slog.String("nexthop", nexthop),
-		slog.String("local", r.Local.String()),
+		slog.String(logfields.Prefix, r.Prefix.String()),
+		slog.String(logfields.NextHop, nexthop),
+		slog.String(logfields.LocalIP, r.Local.String()),
 		slog.String(logfields.Interface, r.Device),
 	}
 }

--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -18,6 +18,8 @@ import (
 	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
 )
 
+const testField = "testField"
+
 func TestPolicyLog(t *testing.T) {
 	tmpDir := t.TempDir()
 	logPath := filepath.Join(tmpDir, "endpoint-policy.log")
@@ -52,7 +54,7 @@ func TestPolicyLog(t *testing.T) {
 
 	// Test logging with integrated nil check, no fields
 	ep.PolicyDebug("testing PolicyDebug")
-	ep.PolicyDebug("PolicyDebug with fields", slog.String("testField", "Test Value"))
+	ep.PolicyDebug("PolicyDebug with fields", slog.String(testField, "Test Value"))
 
 	// Disable option
 	ep.Options.SetValidated(option.DebugPolicy, option.OptionDisabled)

--- a/pkg/logging/slog.go
+++ b/pkg/logging/slog.go
@@ -93,18 +93,18 @@ func replaceAttrFn(groups []string, a slog.Attr) slog.Attr {
 		switch level := a.Value; {
 		case level.Equal(levelFatalValue):
 			return slog.Attr{
-				Key:   a.Key,
+				Key:   slog.LevelKey,
 				Value: slog.StringValue("fatal"),
 			}
 		case level.Equal(levelPanicValue):
 			return slog.Attr{
-				Key:   a.Key,
+				Key:   slog.LevelKey,
 				Value: slog.StringValue("panic"),
 			}
 		}
 		// Lower-case the log level
 		return slog.Attr{
-			Key:   a.Key,
+			Key:   slog.LevelKey,
 			Value: slog.StringValue(strings.ToLower(a.Value.String())),
 		}
 	case logrErrorKey:


### PR DESCRIPTION
PR #45725 is updating `golangci-lint` from `v2.11.4` to `v2.12.1`. This update brings new and updated linter rules, causing new failures, see the golangci-lint [job](https://github.com/cilium/cilium/actions/runs/25504628804/job/74846790273?pr=45725) on that PR:
```
  Error: pkg/bpf/analyze/fields.go:19:30: inline: Constant reflect.Ptr should be inlined (govet)
  	if toValue.Type().Kind() != reflect.Ptr {
  	                            ^
  Error: pkg/bpf/analyze/fields.go:65:8: inline: Constant reflect.Ptr should be inlined (govet)
  		case reflect.Ptr:
  		     ^
  Error: pkg/bpf/constants.go:86:19: inline: Constant reflect.Ptr should be inlined (govet)
  	if typ.Kind() == reflect.Ptr {
  	                 ^
  Error: cilium-cli/install/install.go:194:6: slicesbackward: backward loop over slice can be modernized using slices.Backward (modernize)
  	for i := len(versions) - 1; i >= 0; i-- {
  	    ^
  Error: cilium-cli/internal/helm/helm.go:220:6: slicesbackward: backward loop over slice can be modernized using slices.Backward (modernize)
  	for i := len(versions) - 1; i >= 0; i-- {
  	    ^
  Error: daemon/cmd/endpoint_restore.go:542:6: slicesbackward: backward loop over slice can be modernized using slices.Backward (modernize)
  	for i := len(state.restored) - 1; i >= 0; i-- {
  	    ^
  Error: pkg/datapath/linux/route/route.go:38:15: the "prefix" key should be a constant (sloglint)
  		slog.String("prefix", r.Prefix.String()),
  		            ^
  Error: pkg/datapath/linux/route/route.go:39:15: the "nexthop" key should be a constant (sloglint)
  		slog.String("nexthop", nexthop),
  		            ^
  Error: pkg/datapath/linux/route/route.go:40:15: the "local" key should be a constant (sloglint)
  		slog.String("local", r.Local.String()),
  		            ^
  Error: pkg/endpoint/log_test.go:59:56: the "testField" key should be a constant (sloglint)
  	ep.PolicyDebug("PolicyDebug with fields", slog.String("testField", "Test Value"))
  	                                                      ^
  Error: pkg/logging/slog.go:96:14: the "" key should be a constant (sloglint)
  				Key:   a.Key,
  				         ^
  Error: pkg/logging/slog.go:101:14: the "" key should be a constant (sloglint)
  				Key:   a.Key,
  				         ^
  Error: pkg/logging/slog.go:107:13: the "" key should be a constant (sloglint)
  			Key:   a.Key,
  			         ^
  13 issues:
  * govet: 3
  * modernize: 3
  * sloglint: 7
```

This PR fixes those so we can unblock #45725.

Note: similar PRs updating golangci-lint in stable beanches also have the same issue, we'll have to decide how we want to deal with those (fix the findings or pin golangci-lint in stable branches):
* 1.17: #45876 ([job](https://github.com/cilium/cilium/actions/runs/25616356556/job/75195050146?pr=45876))
* 1.18: #45831 ([job](https://github.com/cilium/cilium/actions/runs/25504496824/job/74846237289?pr=45831))
* 1.19: #45468 ([job](https://github.com/cilium/cilium/actions/runs/25641666457/job/75263043810?pr=45468))