### PR TITLE
workflows/verifier: Fix again always-passing workflow status

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -285,4 +285,4 @@ jobs:
         uses: cilium/cilium/.github/actions/set-commit-status@98995b41cfa4549131dadab2498f598c2a0c8d16 # main
         with:
           sha: ${{ inputs.SHA || github.sha }}
-          status: ${{ needs.merge-and-diff.result && needs.setup-and-test.result }}
+          status: ${{ needs.setup-and-test.result == 'success' && needs.merge-and-diff.result }}


### PR DESCRIPTION
Commit 92a29f212c5a ("workflows/verifier: Fix always-passing workflow status") stated:

    Commit 8418a20754e4 ("workflows/verifier: Wait for complexity-diff to
    set workflow status") was meant to have our verifier workflow report a
    failure if the merge-and-diff job failed. It however broke the status
    reporting, causing failures in the setup-and-test job, the job that
    actually runs the verifier, to be ignored.

  This commit fixes it.

It didn't. I was a bit too confident and didn't properly test this. I had missed that the result field of jobs is a string and not a boolean. As a result, commit 92a29f212c5a didn't change anything.

This pull request should fix it, by explicitly checking that the first job was a success and in that case using the status of the second job as the status for the whole workflow. I tested it in another PR.

Fixes: https://github.com/cilium/cilium/pull/45835.