### PR TITLE
workflows: Reject GitHub's default email for SOB

### DIFF
--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -71,6 +71,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           make -C bpf checkpatch || (echo "Run 'make -C bpf checkpatch' locally to investigate reports"; exit 1)
+      - name: Double-check Signed-off-by
+        run: |
+          commits=$(git log ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})
+          if echo "$commits" | grep -v renovate | grep 'Signed-off-by:.*noreply.*'; then
+            echo "Please use a real email address for your Signed-off-by."
+            exit 1
+          fi
+          if echo "$commits" | grep -v renovate | grep -i 'author.*noreply.*'; then
+            echo "Please use a real email address for all authors. Generative AI tools can not author or sign off contributions."
+            exit 1
+          fi
 
   # Runs only if code under bpf/ or contrib/coccinnelle/ is changed.
   coccicheck:


### PR DESCRIPTION
We need a real email address in the Signed-off-by as that's how we'll contact authors if we ever need to make a license change. That's not just a theoretical matter. It happened at least twice in the past already [1, 2].

Unfortunately, we have a fair number of contributors who submit patches using GitHub's WebUI and end up with the no-reply by-default email address from GitHub as their author email address and SOB email address. Such "fake" email addresses are not always caught by reviewers and sometimes end up in the git history. This commit should help catch these.

In addition, AI bots also cannot claim authorship on commits (nor obviously use Signed-off-by). We already have one commit in our history with a Co-authored-by tag for a bot. Let's detect and block that as well.

I tested this using an additional commit that had a GitHub noreply address: https://github.com/cilium/cilium/actions/runs/25701588553/job/75462733686 and one that had an incorrect authorship tag for a bot: https://github.com/cilium/cilium/actions/runs/25701878788/job/75463627521.

1: 043ff5b8cbc5 ("cocci: Re-license Coccinelle scripts as Apache 2.0")
2: da2ae90819f0 ("bpf: Dual-license the code as GPL-2.0 OR BSD-2-Clause (update text)")