### PR TITLE
bpf/analyze: Always visit global functions

### DIFF
--- a/pkg/bpf/analyze/reachability.go
+++ b/pkg/bpf/analyze/reachability.go
@@ -152,6 +152,15 @@ func Reachability(blocks Blocks, insns asm.Instructions, variables map[string]*e
 		return nil, fmt.Errorf("predicting blocks: %w", err)
 	}
 
+	// Always visit bpf2bpf callees since they are always reachable, on pre-6.8 kernels
+	for _, block := range blocks {
+		for _, called := range block.calls {
+			if err := r.visitBlock(called, vars); err != nil {
+				return nil, fmt.Errorf("predicting blocks: %w", err)
+			}
+		}
+	}
+
 	return r, nil
 }
 

--- a/pkg/bpf/analyze/reachability_test.go
+++ b/pkg/bpf/analyze/reachability_test.go
@@ -53,13 +53,16 @@ func eachLiveRef(r *Reachable, fn func(ref string)) {
 }
 
 // allUnreachable asserts that all symbols appearing in insns are marked
-// unreachable in r.
+// unreachable in r, except for sym_i, which should never be marked
+// unreachable.
 func allUnreachable(t *testing.T, insns asm.Instructions, r *Reachable) {
 	t.Helper()
 
 	syms := symbols(insns)
 	eachLiveRef(r, func(ref string) {
-		assert.Nil(t, syms[ref], "symbol %q should be unreachable", ref)
+		if ref != "sym_i" {
+			assert.Nil(t, syms[ref], "symbol %q should be unreachable", ref)
+		}
 	})
 }
 

--- a/pkg/bpf/unused_maps_test.go
+++ b/pkg/bpf/unused_maps_test.go
@@ -80,8 +80,9 @@ func TestPrivilegedUnusedMaps(t *testing.T) {
 
 	assert.Nil(t, spec.Maps["map_a"])
 	assert.Nil(t, spec.Maps["map_b"])
-	assert.Nil(t, spec.Maps["map_static"])
-	assert.Nil(t, spec.Maps["map_global"])
+	// BPF functions are always visited to match the kernel's behavior pre-v6.8.
+	assert.NotNil(t, spec.Maps["map_static"])
+	assert.NotNil(t, spec.Maps["map_global"])
 	assert.True(t, slices.ContainsFunc(obj.Program.Instructions, func(ins asm.Instruction) bool {
 		return ins.Constant == poisonedMapLoad
 	}), "At least one instruction should have been poisoned")
@@ -89,7 +90,8 @@ func TestPrivilegedUnusedMaps(t *testing.T) {
 	coll = mustNewCollection(t, spec)
 	freed, err = freedMaps(coll, nil)
 	assert.NoError(t, err)
-	assert.Empty(t, freed)
+	// Depending on the kernel versions, map_static and map_global may be freed by the verifier.
+	assert.GreaterOrEqual(t, 2, len(freed))
 }
 
 func TestPrivilegedUnusedMapsFalseNegative(t *testing.T) {


### PR DESCRIPTION
Before commit [1] upstream (v6.8), global functions were always verified even if never called. The reachability analysis in Cilium therefore needs to implement the same. If not, Cilium will prune maps in global functions that are not called and the verifier will then fail while trying to verify those same functions.

The long term fix would be to prune unused global functions: https://github.com/cilium/cilium/issues/45918.

1: https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf.git/commit/?id=2afae08c9dcb