### PR TITLE
vendor: Update `controller-runtime` to `v0.24.0`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -135,7 +135,7 @@ require (
 	k8s.io/kubectl v0.36.0
 	k8s.io/metrics v0.36.0
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5
-	sigs.k8s.io/controller-runtime v0.23.3
+	sigs.k8s.io/controller-runtime v0.24.0
 	sigs.k8s.io/gateway-api v1.5.1
 	sigs.k8s.io/gateway-api/conformance v1.5.1
 	sigs.k8s.io/mcs-api v0.4.2-0.20260429160526-4546fabf7251
@@ -339,10 +339,6 @@ require (
 // Using private fork of controller-tools. See commit msg for more context
 // as to why we are using a private fork.
 replace sigs.k8s.io/controller-tools => github.com/cilium/controller-tools v0.16.5-1
-
-// controller-runtime v0.24 (matching k8s.io/* v0.36) is not yet released.
-// Use a commit from main that includes the k8s v0.36 bump.
-replace sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.23.1-0.20260331131016-598e330bda55
 
 // Using private fork of gobgp. See commit msg for more context as to why we
 // are using a private fork.

--- a/go.sum
+++ b/go.sum
@@ -1067,8 +1067,8 @@ oras.land/oras-go/v2 v2.6.0/go.mod h1:magiQDfG6H1O9APp+rOsvCPcW1GD2MM7vgnKY0Y+u1
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 h1:hSfpvjjTQXQY2Fol2CS0QHMNs/WI1MOSGzCm1KhM5ec=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
-sigs.k8s.io/controller-runtime v0.23.1-0.20260331131016-598e330bda55 h1:HYrtAkFK1ObCgDcuT4n8zQJOZZXxnERv1H81huW+wF0=
-sigs.k8s.io/controller-runtime v0.23.1-0.20260331131016-598e330bda55/go.mod h1:bTZXYvH6eWv12M5PgRYYTSMw/LDN1xBf0oNTycNo1YY=
+sigs.k8s.io/controller-runtime v0.24.0 h1:Ck6N2LdS8Lovy1o25BB4r1xjvLEKUl1s2o9kU+KWDE4=
+sigs.k8s.io/controller-runtime v0.24.0/go.mod h1:vFkfY5fGt5xAC/sKb8IBFKgWPNKG9OUG29dR8Y2wImw=
 sigs.k8s.io/gateway-api v1.5.1 h1:RqVRIlkhLhUO8wOHKTLnTJA6o/1un4po4/6M1nRzdd0=
 sigs.k8s.io/gateway-api v1.5.1/go.mod h1:GvCETiaMAlLym5CovLxGjS0NysqFk3+Yuq3/rh6QL2o=
 sigs.k8s.io/gateway-api/conformance v1.5.1 h1:5eruSMKcwKnkX42PFek8oO6BgPNBD5FbWbTcRV76KIw=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2816,7 +2816,7 @@ oras.land/oras-go/v2/registry/remote/credentials/trace
 oras.land/oras-go/v2/registry/remote/errcode
 oras.land/oras-go/v2/registry/remote/internal/errutil
 oras.land/oras-go/v2/registry/remote/retry
-# sigs.k8s.io/controller-runtime v0.23.3 => sigs.k8s.io/controller-runtime v0.23.1-0.20260331131016-598e330bda55
+# sigs.k8s.io/controller-runtime v0.24.0
 ## explicit; go 1.26.0
 sigs.k8s.io/controller-runtime
 sigs.k8s.io/controller-runtime/pkg/builder
@@ -3043,5 +3043,4 @@ sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v3
 sigs.k8s.io/yaml/kyaml
 # sigs.k8s.io/controller-tools => github.com/cilium/controller-tools v0.16.5-1
-# sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.23.1-0.20260331131016-598e330bda55
 # github.com/osrg/gobgp/v3 => github.com/cilium/gobgp/v3 v3.0.0-20260130142103-27e5da2a39e6

--- a/vendor/sigs.k8s.io/controller-runtime/.gitignore
+++ b/vendor/sigs.k8s.io/controller-runtime/.gitignore
@@ -13,6 +13,7 @@
 
 # editor and IDE paraphernalia
 .idea
+*.iml
 *.swp
 *.swo
 *~

--- a/vendor/sigs.k8s.io/controller-runtime/.golangci.yml
+++ b/vendor/sigs.k8s.io/controller-runtime/.golangci.yml
@@ -81,7 +81,6 @@ linters:
       disable:
         - omitzero
         - fmtappendf
-        - newexpr
     revive:
       rules:
         # The following rules are recommended https://github.com/mgechev/revive#recommended-configuration

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/apiutil/restmapper.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/apiutil/restmapper.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
-	"k8s.io/utils/ptr"
 )
 
 // NewDynamicRESTMapper returns a dynamic RESTMapper for cfg. The dynamic
@@ -197,7 +196,7 @@ func (m *mapper) addKnownGroupAndReload(groupName string, versions ...string) er
 				}
 			}
 			if len(failedGroups) > 0 {
-				return ptr.To(ErrResourceDiscoveryFailed(failedGroups))
+				return new(ErrResourceDiscoveryFailed(failedGroups))
 			}
 			return nil
 		}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/applyconfigurations.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/applyconfigurations.go
@@ -39,28 +39,6 @@ func ApplyConfigurationFromUnstructured(u *unstructured.Unstructured) runtime.Ap
 	return &unstructuredApplyConfiguration{Unstructured: u}
 }
 
-type applyconfigurationRuntimeObject struct {
-	runtime.ApplyConfiguration
-}
-
-func (a *applyconfigurationRuntimeObject) GetObjectKind() schema.ObjectKind {
-	return a
-}
-
-func (a *applyconfigurationRuntimeObject) GroupVersionKind() schema.GroupVersionKind {
-	return schema.GroupVersionKind{}
-}
-
-func (a *applyconfigurationRuntimeObject) SetGroupVersionKind(gvk schema.GroupVersionKind) {}
-
-func (a *applyconfigurationRuntimeObject) DeepCopyObject() runtime.Object {
-	panic("applyconfigurationRuntimeObject does not support DeepCopyObject")
-}
-
-func runtimeObjectFromApplyConfiguration(ac runtime.ApplyConfiguration) runtime.Object {
-	return &applyconfigurationRuntimeObject{ApplyConfiguration: ac}
-}
-
 func gvkFromApplyConfiguration(ac applyConfiguration) (schema.GroupVersionKind, error) {
 	var gvk schema.GroupVersionKind
 	gv, err := schema.ParseGroupVersion(ptr.Deref(ac.GetAPIVersion(), ""))

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/client.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/client.go
@@ -67,7 +67,6 @@ import (
 	clientgoapplyconfigurations "k8s.io/client-go/applyconfigurations"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/testing"
-	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -634,12 +633,12 @@ func (c *fakeClient) Create(ctx context.Context, obj client.Object, opts ...clie
 		return err
 	}
 
+	var generateNameBase string
 	if accessor.GetName() == "" && accessor.GetGenerateName() != "" {
-		base := accessor.GetGenerateName()
-		if len(base) > maxGeneratedNameLength {
-			base = base[:maxGeneratedNameLength]
+		generateNameBase = accessor.GetGenerateName()
+		if len(generateNameBase) > maxGeneratedNameLength {
+			generateNameBase = generateNameBase[:maxGeneratedNameLength]
 		}
-		accessor.SetName(fmt.Sprintf("%s%s", base, utilrand.String(randomLength)))
 	}
 	// Ignore attempts to set deletion timestamp
 	if !accessor.GetDeletionTimestamp().IsZero() {
@@ -654,10 +653,21 @@ func (c *fakeClient) Create(ctx context.Context, obj client.Object, opts ...clie
 	c.trackerWriteLock.Lock()
 	defer c.trackerWriteLock.Unlock()
 
-	if err := c.tracker.Create(gvr, obj, accessor.GetNamespace(), *createOptions.AsCreateOptions()); err != nil {
+	const maxRetries = 7
+	var createErr error
+	for range maxRetries {
+		if generateNameBase != "" {
+			accessor.SetName(fmt.Sprintf("%s%s", generateNameBase, utilrand.String(randomLength)))
+		}
+		createErr = c.tracker.Create(gvr, obj, accessor.GetNamespace(), *createOptions.AsCreateOptions())
+		if createErr == nil || generateNameBase == "" || !apierrors.IsAlreadyExists(createErr) {
+			break
+		}
+	}
+	if createErr != nil {
 		// The managed fields tracker sets gvk even on errors
 		_ = ensureTypeMeta(obj, gvk)
-		return err
+		return createErr
 	}
 
 	if !c.returnManagedFields {
@@ -1621,13 +1631,13 @@ func extractScale(obj client.Object) (*autoscalingv1.Scale, error) {
 func applyScale(obj client.Object, scale *autoscalingv1.Scale) error {
 	switch obj := obj.(type) {
 	case *appsv1.Deployment:
-		obj.Spec.Replicas = ptr.To(scale.Spec.Replicas)
+		obj.Spec.Replicas = new(scale.Spec.Replicas)
 	case *appsv1.ReplicaSet:
-		obj.Spec.Replicas = ptr.To(scale.Spec.Replicas)
+		obj.Spec.Replicas = new(scale.Spec.Replicas)
 	case *corev1.ReplicationController:
-		obj.Spec.Replicas = ptr.To(scale.Spec.Replicas)
+		obj.Spec.Replicas = new(scale.Spec.Replicas)
 	case *appsv1.StatefulSet:
-		obj.Spec.Replicas = ptr.To(scale.Spec.Replicas)
+		obj.Spec.Replicas = new(scale.Spec.Replicas)
 	default:
 		// TODO: CRDs https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#scale-subresource
 		return fmt.Errorf("unimplemented scale subresource for resource %T", obj)

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/options.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/options.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
-	"k8s.io/utils/ptr"
 )
 
 // {{{ "Functional" Option Interfaces
@@ -741,12 +740,12 @@ type UnsafeDisableDeepCopyOption bool
 
 // ApplyToGet applies this configuration to the given an Get options.
 func (d UnsafeDisableDeepCopyOption) ApplyToGet(opts *GetOptions) {
-	opts.UnsafeDisableDeepCopy = ptr.To(bool(d))
+	opts.UnsafeDisableDeepCopy = new(bool(d))
 }
 
 // ApplyToList applies this configuration to the given an List options.
 func (d UnsafeDisableDeepCopyOption) ApplyToList(opts *ListOptions) {
-	opts.UnsafeDisableDeepCopy = ptr.To(bool(d))
+	opts.UnsafeDisableDeepCopy = new(bool(d))
 }
 
 // UnsafeDisableDeepCopy indicates not to deep copy objects during list objects.
@@ -953,19 +952,19 @@ var ForceOwnership = forceOwnership{}
 type forceOwnership struct{}
 
 func (forceOwnership) ApplyToPatch(opts *PatchOptions) {
-	opts.Force = ptr.To(true)
+	opts.Force = new(true)
 }
 
 func (forceOwnership) ApplyToSubResourcePatch(opts *SubResourcePatchOptions) {
-	opts.Force = ptr.To(true)
+	opts.Force = new(true)
 }
 
 func (forceOwnership) ApplyToApply(opts *ApplyOptions) {
-	opts.Force = ptr.To(true)
+	opts.Force = new(true)
 }
 
 func (forceOwnership) ApplyToSubResourceApply(opts *SubResourceApplyOptions) {
-	opts.Force = ptr.To(true)
+	opts.Force = new(true)
 }
 
 // }}}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/typed_client.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/typed_client.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/client-go/util/apply"
 )
 
@@ -146,17 +147,24 @@ func (c *typedClient) Apply(ctx context.Context, obj runtime.ApplyConfiguration,
 	applyOpts := &ApplyOptions{}
 	applyOpts.ApplyOptions(opts)
 
-	return req.
+	var contentType string
+	body, err := req.
 		NamespaceIfScoped(o.namespace, o.isNamespaced()).
 		Resource(o.resource()).
 		Name(o.name).
 		VersionedParams(applyOpts.AsPatchOptions(), c.paramCodec).
 		Do(ctx).
-		// This is hacky, it is required because `Into` takes a `runtime.Object` and
-		// that is not implemented by the ApplyConfigurations. The generated clients
-		// don't have this problem because they deserialize into the api type, not the
-		// apply configuration: https://github.com/kubernetes/kubernetes/blob/22f5e01a37c0bc6a5f494dec14dd4e3688ee1d55/staging/src/k8s.io/client-go/gentype/type.go#L296-L317
-		Into(runtimeObjectFromApplyConfiguration(obj))
+		ContentType(&contentType).
+		Raw()
+	if err != nil {
+		return err
+	}
+
+	if contentType != "application/json" {
+		return fmt.Errorf("unexpected content type %q in apply response, expected application/json", contentType)
+	}
+
+	return json.Unmarshal(body, obj)
 }
 
 // Get implements client.Client.
@@ -324,16 +332,23 @@ func (c *typedClient) ApplySubResource(ctx context.Context, obj runtime.ApplyCon
 		return fmt.Errorf("failed to create apply request: %w", err)
 	}
 
-	return req.
+	var contentType string
+	respBody, err := req.
 		NamespaceIfScoped(o.namespace, o.isNamespaced()).
 		Resource(o.resource()).
 		Name(o.name).
 		SubResource(subResource).
 		VersionedParams(applyOpts.AsPatchOptions(), c.paramCodec).
 		Do(ctx).
-		// This is hacky, it is required because `Into` takes a `runtime.Object` and
-		// that is not implemented by the ApplyConfigurations. The generated clients
-		// don't have this problem because they deserialize into the api type, not the
-		// apply configuration: https://github.com/kubernetes/kubernetes/blob/22f5e01a37c0bc6a5f494dec14dd4e3688ee1d55/staging/src/k8s.io/client-go/gentype/type.go#L296-L317
-		Into(runtimeObjectFromApplyConfiguration(obj))
+		ContentType(&contentType).
+		Raw()
+	if err != nil {
+		return err
+	}
+
+	if contentType != "application/json" {
+		return fmt.Errorf("unexpected content type %q in apply response, expected application/json", contentType)
+	}
+
+	return json.Unmarshal(respBody, obj)
 }

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllerutil/controllerutil.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controllerutil/controllerutil.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -88,8 +87,8 @@ func SetControllerReference(owner, controlled metav1.Object, scheme *runtime.Sch
 		Kind:               gvk.Kind,
 		Name:               owner.GetName(),
 		UID:                owner.GetUID(),
-		BlockOwnerDeletion: ptr.To(true),
-		Controller:         ptr.To(true),
+		BlockOwnerDeletion: new(true),
+		Controller:         new(true),
 	}
 	for _, opt := range opts {
 		opt(&ref)

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue/priorityqueue.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue/priorityqueue.go
@@ -213,7 +213,7 @@ func (w *priorityqueue[T]) lockedAddWithOpts(o AddOpts, items ...T) {
 
 		var readyAt *time.Time
 		if after > 0 {
-			readyAt = ptr.To(w.now().Add(after))
+			readyAt = new(w.now().Add(after))
 			w.metrics.retry()
 		}
 		if _, ok := w.items[key]; !ok {

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/handler/enqueue_mapped.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/handler/enqueue_mapped.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -142,7 +141,7 @@ func (e *enqueueRequestsFromMapFunc[object, request]) mapAndEnqueue(
 		if !ok {
 			if lowPriority {
 				q.(priorityqueue.PriorityQueue[request]).AddWithOpts(priorityqueue.AddOpts{
-					Priority: ptr.To(LowPriority),
+					Priority: new(LowPriority),
 				}, req)
 			} else {
 				q.Add(req)

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/handler/eventhandler.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/handler/eventhandler.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -135,7 +134,7 @@ func (h TypedFuncs[object, request]) Create(ctx context.Context, e event.TypedCr
 			PriorityQueue: q.(priorityqueue.PriorityQueue[request]),
 		}
 		if e.IsInInitialList {
-			wq.priority = ptr.To(LowPriority)
+			wq.priority = new(LowPriority)
 		}
 		h.CreateFunc(ctx, e, wq)
 	}
@@ -162,7 +161,7 @@ func (h TypedFuncs[object, request]) Update(ctx context.Context, e event.TypedUp
 			PriorityQueue: q.(priorityqueue.PriorityQueue[request]),
 		}
 		if any(e.ObjectOld).(client.Object).GetResourceVersion() == any(e.ObjectNew).(client.Object).GetResourceVersion() {
-			wq.priority = ptr.To(LowPriority)
+			wq.priority = new(LowPriority)
 		}
 		h.UpdateFunc(ctx, e, wq)
 	}
@@ -225,7 +224,7 @@ func addToQueueCreate[T client.Object, request comparable](q workqueue.TypedRate
 
 	var priority *int
 	if evt.IsInInitialList {
-		priority = ptr.To(LowPriority)
+		priority = new(LowPriority)
 	}
 	priorityQueue.AddWithOpts(priorityqueue.AddOpts{Priority: priority}, item)
 }
@@ -241,7 +240,7 @@ func addToQueueUpdate[T client.Object, request comparable](q workqueue.TypedRate
 
 	var priority *int
 	if evt.ObjectOld.GetResourceVersion() == evt.ObjectNew.GetResourceVersion() {
-		priority = ptr.To(LowPriority)
+		priority = new(LowPriority)
 	}
 	priorityQueue.AddWithOpts(priorityqueue.AddOpts{Priority: priority}, item)
 }

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go
@@ -30,7 +30,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/internal/controller/metrics"
@@ -485,7 +484,7 @@ func (c *Controller[request]) reconcileHandler(ctx context.Context, req request,
 		if errors.Is(err, reconcile.TerminalError(nil)) {
 			ctrlmetrics.TerminalReconcileErrors.WithLabelValues(c.Name).Inc()
 		} else {
-			c.Queue.AddWithOpts(priorityqueue.AddOpts{RateLimited: true, Priority: ptr.To(priority)}, req)
+			c.Queue.AddWithOpts(priorityqueue.AddOpts{RateLimited: true, Priority: new(priority)}, req)
 		}
 		ctrlmetrics.ReconcileErrors.WithLabelValues(c.Name).Inc()
 		ctrlmetrics.ReconcileTotal.WithLabelValues(c.Name, labelError).Inc()
@@ -500,11 +499,11 @@ func (c *Controller[request]) reconcileHandler(ctx context.Context, req request,
 		// We need to drive to stable reconcile loops before queuing due
 		// to result.RequestAfter
 		c.Queue.Forget(req)
-		c.Queue.AddWithOpts(priorityqueue.AddOpts{After: result.RequeueAfter, Priority: ptr.To(priority)}, req)
+		c.Queue.AddWithOpts(priorityqueue.AddOpts{After: result.RequeueAfter, Priority: new(priority)}, req)
 		ctrlmetrics.ReconcileTotal.WithLabelValues(c.Name, labelRequeueAfter).Inc()
 	case result.Requeue: //nolint: staticcheck // We have to handle it until it is removed
 		log.V(5).Info("Reconcile done, requeueing")
-		c.Queue.AddWithOpts(priorityqueue.AddOpts{RateLimited: true, Priority: ptr.To(priority)}, req)
+		c.Queue.AddWithOpts(priorityqueue.AddOpts{RateLimited: true, Priority: new(priority)}, req)
 		ctrlmetrics.ReconcileTotal.WithLabelValues(c.Name, labelRequeue).Inc()
 	default:
 		log.V(5).Info("Reconcile successful")

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/internal/source/kind.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/internal/source/kind.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	toolscache "k8s.io/client-go/tools/cache"
@@ -116,10 +118,18 @@ func (ks *Kind[object, request]) Start(ctx context.Context, queue workqueue.Type
 }
 
 func (ks *Kind[object, request]) String() string {
-	if !isNil(ks.Type) {
+	if isNil(ks.Type) {
+		return "kind source: unknown type"
+	}
+
+	switch v := any(ks.Type).(type) {
+	case *unstructured.Unstructured, *metav1.PartialObjectMetadata:
+		gvk := v.(client.Object).GetObjectKind().GroupVersionKind()
+		gv, kind := gvk.ToAPIVersionAndKind()
+		return fmt.Sprintf("kind source: %T[%s %s]", v, gv, kind)
+	default:
 		return fmt.Sprintf("kind source: %T", ks.Type)
 	}
-	return "kind source: unknown type"
 }
 
 // WaitForSync implements SyncingSource to allow controllers to wait with starting
@@ -133,7 +143,7 @@ func (ks *Kind[object, request]) WaitForSync(ctx context.Context) error {
 		if errors.Is(ctx.Err(), context.Canceled) {
 			return nil
 		}
-		return fmt.Errorf("timed out waiting for cache to be synced for Kind %T", ks.Type)
+		return fmt.Errorf("timed out waiting for cache to be synced for %s", ks.String())
 	}
 }
 

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/log/zap/zap.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/log/zap/zap.go
@@ -272,7 +272,7 @@ func (o *Options) BindFlags(fs *flag.FlagSet) {
 	}
 	fs.Var(&levelVal, "zap-log-level",
 		"Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', 'panic'"+
-			"or any integer value > 0 which corresponds to custom debug levels of increasing verbosity")
+			" or any integer value > 0 which corresponds to custom debug levels of increasing verbosity")
 
 	// Set the StrackTrace Level
 	var stackVal stackTraceFlag

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/manager/manager.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/manager/manager.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/ptr"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/conversion"
 
@@ -444,7 +443,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 	errChan := make(chan error, 1)
 	runnables := newRunnables(options.BaseContext, errChan).withLogger(options.Logger)
 	return &controllerManager{
-		stopProcedureEngaged:          ptr.To(int64(0)),
+		stopProcedureEngaged:          new(int64(0)),
 		cluster:                       cluster,
 		runnables:                     runnables,
 		errChan:                       errChan,

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/source/source.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/source/source.go
@@ -24,7 +24,6 @@ import (
 
 	toolscache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -186,7 +185,7 @@ func (cs *channel[object, request]) Start(
 	}
 
 	if cs.bufferSize == nil {
-		cs.bufferSize = ptr.To(1024)
+		cs.bufferSize = new(1024)
 	}
 
 	dst := make(chan event.TypedGenericEvent[object], *cs.bufferSize)


### PR DESCRIPTION
Followup to #45499: now that there's a `controller-runtime` release compatible with k8s 1.36, we can stop using a pseudo version.

See [release notes](https://github.com/kubernetes-sigs/controller-runtime/releases/tag/v0.24.0).