### PR TITLE
pkg/node/sync: Add support for injecting init functions

### DIFF
--- a/pkg/node/sync/local_node_sync.go
+++ b/pkg/node/sync/local_node_sync.go
@@ -38,6 +38,11 @@ var LocalNodeSyncCell = cell.Module(
 	cell.Provide(newLocalNodeSynchronizer),
 )
 
+// InitFunc is called before during startup to fill in the local node before other
+// sub-systems can access it. This is called after the [node.LocalNode] is filled in
+// from configuration and k8s node.
+type InitFunc func(context.Context, *node.LocalNode) error
+
 type localNodeSynchronizerParams struct {
 	cell.In
 
@@ -47,6 +52,7 @@ type localNodeSynchronizerParams struct {
 	K8sLocalNode       agentK8s.LocalNodeResource
 	K8sCiliumLocalNode agentK8s.LocalCiliumNodeResource
 	IPsecConfig        ipsec.Config
+	ExtraInitFuncs     []InitFunc `group:"init-funcs"`
 }
 
 // localNodeSynchronizer performs the bootstrapping of the LocalNodeStore,
@@ -74,6 +80,12 @@ func (ini *localNodeSynchronizer) InitLocalNode(ctx context.Context, n *node.Loc
 	n.BootID = node.GetBootID(ini.Logger)
 	if ini.IPsecConfig.Enabled() && n.BootID == "" {
 		return fmt.Errorf("IPSec requires a valid BootID")
+	}
+
+	for _, fn := range ini.ExtraInitFuncs {
+		if err := fn(ctx, n); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/node/sync/local_node_sync_test.go
+++ b/pkg/node/sync/local_node_sync_test.go
@@ -129,6 +129,12 @@ func TestLocalNodeSync(t *testing.T) {
 				},
 			},
 			IPsecConfig: fakeipsec.Config{},
+			ExtraInitFuncs: []InitFunc{
+				func(_ context.Context, n *node.LocalNode) error {
+					n.Annotations["extra-init-func"] = "called"
+					return nil
+				},
+			},
 		})
 	)
 
@@ -138,7 +144,7 @@ func TestLocalNodeSync(t *testing.T) {
 	require.Equal(t, "10.0.0.1", local.GetNodeInternalIPv4().String())
 	require.Equal(t, "fc00::11", local.GetNodeInternalIPv6().String())
 	require.Equal(t, map[string]string{"ex": "label", "foo": "bar"}, local.Labels)
-	require.Equal(t, map[string]string{"ex": "annot", "cilium.io/baz": "qux"}, local.Annotations)
+	require.Equal(t, map[string]string{"ex": "annot", "cilium.io/baz": "qux", "extra-init-func": "called"}, local.Annotations)
 	require.Equal(t, k8stypes.UID("uid1"), local.Local.UID)
 	require.Equal(t, "provider://foobar", local.Local.ProviderID)
 
@@ -153,7 +159,7 @@ func TestLocalNodeSync(t *testing.T) {
 	updates := stream.ToChannel(t.Context(), store)
 	update := <-updates
 	require.Equal(t, map[string]string{"ex": "label", "qux": "baz"}, update.Labels)
-	require.Equal(t, map[string]string{"ex": "annot", "cilium.io/bar": "foo"}, update.Annotations)
+	require.Equal(t, map[string]string{"ex": "annot", "cilium.io/bar": "foo", "extra-init-func": "called"}, update.Annotations)
 	require.Equal(t, k8stypes.UID("uid2"), update.Local.UID)
 	require.Equal(t, "provider://foobaz", update.Local.ProviderID)
 


### PR DESCRIPTION
Add support for initializing the local node with Hive-provided functions. This will allow features to set fields in [LocalNode] before any other sub-system sees it and before it's reflected into CiliumNode without having to bake feature specific code into pkg/node/sync.