### PR TITLE
gateway-api: add HTTPRoute filter CORS support

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -198,6 +198,7 @@ func Test_Conformance(t *testing.T) {
 		{name: "grpcroute-listener-hostname-matching", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "grpcroute-listener-hostname-matching", Namespace: "gateway-conformance-infra"}}}},
 		{name: "httproute-backend-protocol-h2c", gateway: []gwDetails{gatewaySameNamespace}},
 		{name: "httproute-backend-protocol-websocket", gateway: []gwDetails{gatewaySameNamespace}},
+		{name: "httproute-cors", gateway: []gwDetails{gatewaySameNamespace}},
 		{name: "httproute-cross-namespace", gateway: []gwDetails{gatewayBackendNamespace}},
 		{
 			name:    "httproute-allowed-kind-by-section-name",

--- a/operator/pkg/gateway-api/gatewayclass_status.go
+++ b/operator/pkg/gateway-api/gatewayclass_status.go
@@ -28,7 +28,6 @@ var exemptFeatures = []features.Feature{
 	features.HTTPRouteParentRefPortFeature,
 	features.MeshConsumerRouteFeature,
 	features.BackendTLSPolicySanValidationFeature,
-	features.HTTPRouteCORS,
 	features.TLSRouteModeTerminateFeature,
 	features.ListenerSetFeature,
 	features.GatewayBackendClientCertificateFeature,
@@ -45,7 +44,7 @@ func getSupportedFeatures() []gatewayv1.SupportedFeature {
 	for _, feature := range exemptFeatures {
 		supportedFeatures.Delete(feature)
 	}
-	ret := []gatewayv1.SupportedFeature{}
+	ret := make([]gatewayv1.SupportedFeature, 0, len(supportedFeatures))
 	for _, feat := range supportedFeatures.UnsortedList() {
 		ret = append(ret, gatewayv1.SupportedFeature{Name: gatewayv1.FeatureName(feat.Name)})
 	}

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-cors/input/httproute-cors.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-cors/input/httproute-cors.yaml
@@ -1,0 +1,122 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: cors-multiple-origins-methods-headers
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - filters:
+    - type: CORS
+      cors:
+        allowOrigins:
+        - "https://www.foo.com"
+        - "https://*.bar.com"
+        allowMethods:
+        - GET
+        - OPTIONS
+        allowHeaders:
+        - "x-header-1"
+        - "x-header-2"
+        exposeHeaders:
+        - "x-header-3"
+        - "x-header-4"
+        allowCredentials: true
+        maxAge: 3600
+    matches:
+    - path:
+        type: PathPrefix
+        value: /cors-1
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: cors-wildcard-methods
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - filters:
+    - type: CORS
+      cors:
+        allowOrigins:
+        - "https://www.foo.com"
+        allowMethods: ["*"]
+    matches:
+    - path:
+        type: PathPrefix
+        value: /cors-2
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: cors-wildcard-origin   # test CORS with origin *.foo.com and expect the exact answer to come on the header
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - filters:
+    - type: CORS
+      cors:
+        allowOrigins:
+        - "*"
+        allowMethods: ["PUT"]
+        allowCredentials: false
+    matches:
+    - path:
+        type: PathPrefix
+        value: /cors-wildcard-origin
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---
+# Test the usage of wildcards on authenticated and unauthenticated requests and the proper response
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: cors-wildcard-methods-headers
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - filters:
+    - type: CORS
+      cors:
+        allowOrigins:
+        - "*"
+        allowMethods: ["*"]
+        allowHeaders: ["*"]
+        allowCredentials: true
+    matches:
+    - path:
+        type: PathPrefix
+        value: /cors-wildcard-methods-headers
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+  - filters:
+    - type: CORS
+      cors:
+        allowOrigins:
+        - "*"
+        allowMethods: ["*"]
+        allowHeaders: ["*"]
+        allowCredentials: false
+    matches:
+    - path:
+        type: PathPrefix
+        value: /cors-wildcard-methods-headers-unauth
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+---

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-cors/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-cors/output/cec-same-namespace.yaml
@@ -1,0 +1,188 @@
+metadata:
+  creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      controller: true
+      kind: Gateway
+      name: same-namespace
+      uid: ""
+  resourceVersion: "1"
+spec:
+  backendServices:
+    - name: infra-backend-v1
+      namespace: gateway-conformance-infra
+      number:
+        - "8080"
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            transportProtocol: raw_buffer
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.cors
+                    typedConfig:
+                      '@type': type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-insecure
+                statPrefix: listener-insecure
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-insecure
+      virtualHosts:
+        - domains:
+            - "*"
+          name: "*"
+          routes:
+            - match:
+                pathSeparatedPrefix: /cors-wildcard-methods-headers-unauth
+              route:
+                cluster: gateway-conformance-infra:infra-backend-v1:8080
+                maxStreamDuration:
+                  maxStreamDuration: 0s
+              typedPerFilterConfig:
+                envoy.filters.http.cors:
+                  '@type': type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy
+                  allowCredentials: false
+                  allowHeaders: "*"
+                  allowMethods: "*"
+                  allowOriginStringMatch:
+                    - safeRegex:
+                        regex: ^.*$
+                  maxAge: "5"
+                  forwardNotMatchingPreflights: false
+            - match:
+                pathSeparatedPrefix: /cors-wildcard-methods-headers
+              route:
+                cluster: gateway-conformance-infra:infra-backend-v1:8080
+                maxStreamDuration:
+                  maxStreamDuration: 0s
+              typedPerFilterConfig:
+                envoy.filters.http.cors:
+                  '@type': type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy
+                  allowCredentials: true
+                  allowHeaders: "*"
+                  allowMethods: "*"
+                  allowOriginStringMatch:
+                    - safeRegex:
+                        regex: ^.*$
+                  maxAge: "5"
+                  forwardNotMatchingPreflights: false
+            - match:
+                pathSeparatedPrefix: /cors-wildcard-origin
+              route:
+                cluster: gateway-conformance-infra:infra-backend-v1:8080
+                maxStreamDuration:
+                  maxStreamDuration: 0s
+              typedPerFilterConfig:
+                envoy.filters.http.cors:
+                  '@type': type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy
+                  allowCredentials: false
+                  allowMethods: "PUT"
+                  allowOriginStringMatch:
+                    - safeRegex:
+                        regex: ^.*$
+                  maxAge: "5"
+                  forwardNotMatchingPreflights: false
+            - match:
+                pathSeparatedPrefix: /cors-1
+              route:
+                cluster: gateway-conformance-infra:infra-backend-v1:8080
+                maxStreamDuration:
+                  maxStreamDuration: 0s
+              typedPerFilterConfig:
+                envoy.filters.http.cors:
+                  '@type': type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy
+                  allowCredentials: true
+                  allowHeaders: x-header-1, x-header-2
+                  allowMethods: GET, OPTIONS
+                  allowOriginStringMatch:
+                    - exact: https://www.foo.com
+                    - safeRegex:
+                        regex: ^https://[A-Za-z0-9.-]+\.bar\.com$
+                  exposeHeaders: x-header-3, x-header-4
+                  maxAge: "3600"
+                  forwardNotMatchingPreflights: false
+            - match:
+                pathSeparatedPrefix: /cors-2
+              route:
+                cluster: gateway-conformance-infra:infra-backend-v1:8080
+                maxStreamDuration:
+                  maxStreamDuration: 0s
+              typedPerFilterConfig:
+                envoy.filters.http.cors:
+                  '@type': type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy
+                  allowCredentials: false
+                  allowMethods: "*"
+                  allowOriginStringMatch:
+                    - exact: https://www.foo.com
+                  maxAge: "5"
+                  forwardNotMatchingPreflights: false
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/infra-backend-v1:8080
+      name: gateway-conformance-infra:infra-backend-v1:8080
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 60s
+          useDownstreamProtocolConfig:
+            http2ProtocolOptions: {}
+  services:
+    - listener: ""
+      name: cilium-gateway-same-namespace
+      namespace: gateway-conformance-infra
+      ports:
+        - 80

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-cors/output/httproute-cors-multiple-origins-methods-headers.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-cors/output/httproute-cors-multiple-origins-methods-headers.yaml
@@ -1,0 +1,58 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  creationTimestamp: null
+  name: cors-multiple-origins-methods-headers
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+    filters:
+    - type: CORS
+      cors:
+        allowOrigins:
+        - "https://www.foo.com"
+        - "https://*.bar.com"
+        allowMethods:
+        - GET
+        - OPTIONS
+        allowHeaders:
+        - "x-header-1"
+        - "x-header-2"
+        exposeHeaders:
+        - "x-header-3"
+        - "x-header-4"
+        allowCredentials: true
+        maxAge: 3600
+    matches:
+    - path:
+        type: PathPrefix
+        value: /cors-1
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: "2026-05-12T09:41:00Z"
+      message: Accepted HTTPRoute
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-05-12T09:41:00Z"
+      message: Service reference is valid
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: io.cilium/gateway-controller
+    parentRef:
+      name: same-namespace

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-cors/output/httproute-cors-wildcard-methods-headers.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-cors/output/httproute-cors-wildcard-methods-headers.yaml
@@ -1,0 +1,57 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  creationTimestamp: null
+  name: cors-wildcard-methods-headers
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - filters:
+    - type: CORS
+      cors:
+        allowOrigins:
+        - "*"
+        allowMethods: ["*"]
+        allowHeaders: ["*"]
+        allowCredentials: true
+    matches:
+    - path:
+        type: PathPrefix
+        value: /cors-wildcard-methods-headers
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+  - filters:
+    - type: CORS
+      cors:
+        allowOrigins:
+        - "*"
+        allowMethods: ["*"]
+        allowHeaders: ["*"]
+        allowCredentials: false
+    matches:
+    - path:
+        type: PathPrefix
+        value: /cors-wildcard-methods-headers-unauth
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: "2026-05-12T09:41:00Z"
+      message: Accepted HTTPRoute
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-05-12T09:41:00Z"
+      message: Service reference is valid
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: io.cilium/gateway-controller
+    parentRef:
+      name: same-namespace

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-cors/output/httproute-cors-wildcard-methods.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-cors/output/httproute-cors-wildcard-methods.yaml
@@ -1,0 +1,40 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  creationTimestamp: null
+  name: cors-wildcard-methods
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - filters:
+    - type: CORS
+      cors:
+        allowOrigins:
+        - "https://www.foo.com"
+        allowMethods: ["*"]
+    matches:
+    - path:
+        type: PathPrefix
+        value: /cors-2
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: "2026-05-12T09:41:00Z"
+      message: Accepted HTTPRoute
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-05-12T09:41:00Z"
+      message: Service reference is valid
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: io.cilium/gateway-controller
+    parentRef:
+      name: same-namespace

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-cors/output/httproute-cors-wildcard-origin.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-cors/output/httproute-cors-wildcard-origin.yaml
@@ -1,0 +1,41 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  creationTimestamp: null
+  name: cors-wildcard-origin
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - filters:
+    - type: CORS
+      cors:
+        allowOrigins:
+        - "*"
+        allowMethods: ["PUT"]
+        allowCredentials: false
+    matches:
+    - path:
+        type: PathPrefix
+        value: /cors-wildcard-origin
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: "2026-05-12T09:41:00Z"
+      message: Accepted HTTPRoute
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-05-12T09:41:00Z"
+      message: Service reference is valid
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: io.cilium/gateway-controller
+    parentRef:
+      name: same-namespace

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-cors/output/same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-cors/output/same-namespace.yaml
@@ -1,0 +1,52 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: same-namespace
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T14:29:32Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T05:06:15Z"
+      message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 4
+      conditions:
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: http
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -4,6 +4,7 @@
 package ingestion
 
 import (
+	"cmp"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -322,6 +323,7 @@ func extractRoutes(logger *slog.Logger,
 		var rewriteFilter *model.HTTPURLRewriteFilter
 		var requestMirrors []*model.HTTPRequestMirror
 		var externalAuth *model.HTTPExternalAuthFilter
+		var requestCORS *model.HTTPCORSFilter
 
 		for _, f := range rule.Filters {
 			switch f.Type {
@@ -354,6 +356,21 @@ func extractRoutes(logger *slog.Logger,
 					}
 				}
 				externalAuth = toHTTPExternalAuthFilter(logger, f.ExternalAuth, hr.Namespace, services, serviceImports, btlspMap)
+			case gatewayv1.HTTPRouteFilterCORS:
+				ac := false
+				if f.CORS.AllowCredentials != nil {
+					ac = *f.CORS.AllowCredentials
+				}
+				requestCORS = &model.HTTPCORSFilter{
+					AllowOrigins:     toStringSlice(f.CORS.AllowOrigins),
+					AllowCredentials: ac,
+					AllowMethods:     toStringSlice(f.CORS.AllowMethods),
+					AllowHeaders:     toStringSlice(f.CORS.AllowHeaders),
+					ExposeHeaders:    toStringSlice(f.CORS.ExposeHeaders),
+					// CRD defaults the value to 5 and allows values of 1 or higher.
+					// Local tests can bypass this, ensuring we always get a default.
+					MaxAge: cmp.Or(f.CORS.MaxAge, int32(5)),
+				}
 			}
 		}
 
@@ -371,6 +388,7 @@ func extractRoutes(logger *slog.Logger,
 				ExternalAuth:           externalAuth,
 				Timeout:                toTimeout(rule.Timeouts),
 				Retry:                  toHTTPRetry(rule.Retry),
+				CORS:                   requestCORS,
 			})
 		}
 
@@ -392,6 +410,7 @@ func extractRoutes(logger *slog.Logger,
 				ExternalAuth:           externalAuth,
 				Timeout:                toTimeout(rule.Timeouts),
 				Retry:                  toHTTPRetry(rule.Retry),
+				CORS:                   requestCORS,
 			})
 		}
 	}
@@ -1123,7 +1142,7 @@ func toMapString[K, V ~string](in map[K]V) map[string]string {
 	return out
 }
 
-func toStringSlice(s []gatewayv1.Hostname) []string {
+func toStringSlice[S ~string](s []S) []string {
 	res := make([]string, 0, len(s))
 	for _, h := range s {
 		res = append(res, string(h))

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -313,6 +313,28 @@ type ForwardBodyConfig struct {
 	MaxSize uint32 `json:"max_size"`
 }
 
+// HTTPCORSFilter defines configuration for the CORS filter.
+type HTTPCORSFilter struct {
+	// AllowOrigins indicates whether the response can be shared with
+	// requested resource from the given `Origin`.
+	AllowOrigins []string `json:"allowOrigins,omitempty"`
+	// AllowCredentials indicates whether the actual cross-origin request
+	// allows to include credentials.
+	AllowCredentials bool `json:"allowCredentials,omitempty"`
+	// AllowMethods indicates which HTTP methods are supported
+	// for accessing the requested resource.
+	AllowMethods []string `json:"allowMethods,omitempty"`
+	// AllowHeaders indicates which HTTP request headers are supported
+	// for accessing the requested resource.
+	AllowHeaders []string `json:"allowHeaders,omitempty"`
+	// ExposeHeaders indicates which HTTP response headers can be exposed
+	// to client-side scripts in response to a cross-origin request.
+	ExposeHeaders []string `json:"exposeHeaders,omitempty"`
+	// MaxAge indicates the duration (in seconds) for the client to cache
+	// the results of a "preflight" request.
+	MaxAge int32 `json:"maxAge,omitempty"`
+}
+
 // HTTPRoute holds all the details needed to route HTTP traffic to a backend.
 type HTTPRoute struct {
 	Name string `json:"name,omitempty"`
@@ -362,6 +384,9 @@ type HTTPRoute struct {
 
 	// Retry holds the retry configuration for a route.
 	Retry *HTTPRetry `json:"retry,omitempty"`
+
+	// CORS holds cross-origin resource sharing filters for a route.
+	CORS *HTTPCORSFilter `json:"cors,omitempty"`
 }
 
 type BackendHTTPFilter struct {
@@ -600,6 +625,19 @@ func (m *Model) HTTPPorts() []uint32 {
 		ports = append(ports, l.Port)
 	}
 	return slices.SortedUnique(ports)
+}
+
+// IsCORSFilterConfigured returns true if any HTTP route has a configured CORS filter.
+func (m *Model) IsCORSFilterConfigured() bool {
+	for _, h := range m.HTTP {
+		for _, r := range h.Routes {
+			if r.CORS != nil {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // TLSPassthroughPorts returns a list of unique ports for all TLS Passthrough listeners.

--- a/operator/pkg/model/model_test.go
+++ b/operator/pkg/model/model_test.go
@@ -78,3 +78,61 @@ func TestModel_GetListeners(t *testing.T) {
 		})
 	}
 }
+
+func TestModel_IsCORSFilterConfigured(t *testing.T) {
+	tests := []struct {
+		name          string
+		httpListeners []HTTPListener
+		want          bool
+	}{
+		{
+			name:          "no HTTP listeners",
+			httpListeners: []HTTPListener{},
+			want:          false,
+		},
+		{
+			name: "HTTP listener without CORS",
+			httpListeners: []HTTPListener{
+				{Routes: []HTTPRoute{{CORS: nil}}},
+			},
+			want: false,
+		},
+		{
+			name: "one HTTP listener with CORS",
+			httpListeners: []HTTPListener{
+				{Routes: []HTTPRoute{
+					{
+						CORS: &HTTPCORSFilter{
+							AllowOrigins: []string{"*"},
+						},
+					},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "multiple HTTP listeners with one CORS filter",
+			httpListeners: []HTTPListener{
+				{Routes: []HTTPRoute{{CORS: nil}}},
+				{Routes: []HTTPRoute{
+					{
+						CORS: &HTTPCORSFilter{
+							AllowOrigins: []string{"*"},
+						},
+					},
+				}},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Model{
+				HTTP: tt.httpListeners,
+			}
+			if got := m.IsCORSFilterConfigured(); got != tt.want {
+				t.Errorf("Model.IsCORSFilterConfigured() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/operator/pkg/model/translation/envoy_http_connection_manager.go
+++ b/operator/pkg/model/translation/envoy_http_connection_manager.go
@@ -11,6 +11,7 @@ import (
 
 	mutation_rules_v3 "github.com/envoyproxy/go-control-plane/envoy/config/common/mutation_rules/v3"
 	envoy_config_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	httpCorsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/cors/v3"
 	extauthzv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
 	grpcStatsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/grpc_stats/v3"
 	grpcWebv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/grpc_web/v3"
@@ -83,11 +84,8 @@ func (i *cecTranslator) httpConnectionManagerMutators() []HttpConnectionManagerM
 	}
 }
 
-// desiredHTTPConnectionManager returns a new HTTP connection manager filter with the given name and route.
-// authFilters is a deduplicated list of external auth backends; one named ext_authz filter is added per entry,
-// positioned before the terminal router filter so that per-route TypedPerFilterConfig can enable/disable each.
-func (i *cecTranslator) desiredHTTPConnectionManager(name, routeName string, authFilters []*model.HTTPExternalAuthFilter) (ciliumv2.XDSResource, error) {
-	httpFilters := []*httpConnectionManagerv3.HttpFilter{
+func getHTTPConnectionManagerHttpFilters(authFilters []*model.HTTPExternalAuthFilter, m *model.Model) ([]*httpConnectionManagerv3.HttpFilter, error) {
+	hf := []*httpConnectionManagerv3.HttpFilter{
 		{
 			Name: "envoy.filters.http.grpc_web",
 			ConfigType: &httpConnectionManagerv3.HttpFilter_TypedConfig{
@@ -108,18 +106,40 @@ func (i *cecTranslator) desiredHTTPConnectionManager(name, routeName string, aut
 	for _, af := range authFilters {
 		f, err := buildExtAuthzHTTPFilter(af)
 		if err != nil {
-			return ciliumv2.XDSResource{}, err
+			return nil, err
 		}
-		httpFilters = append(httpFilters, f)
+		hf = append(hf, f)
 	}
 
-	httpFilters = append(httpFilters, &httpConnectionManagerv3.HttpFilter{
+	// HTTP filter order matters. When CORS is enabled,
+	// the CORS filter must run before envoy.filters.http.router.
+	if m != nil && m.IsCORSFilterConfigured() {
+		hf = append(hf, &httpConnectionManagerv3.HttpFilter{
+			Name: "envoy.filters.http.cors",
+			ConfigType: &httpConnectionManagerv3.HttpFilter_TypedConfig{
+				TypedConfig: toAny(&httpCorsv3.Cors{}),
+			},
+		})
+	}
+
+	hf = append(hf, &httpConnectionManagerv3.HttpFilter{
 		Name: "envoy.filters.http.router",
 		ConfigType: &httpConnectionManagerv3.HttpFilter_TypedConfig{
 			TypedConfig: toAny(&httpRouterv3.Router{}),
 		},
 	})
 
+	return hf, nil
+}
+
+// desiredHTTPConnectionManager returns a new HTTP connection manager filter with the given name and route.
+// authFilters is a deduplicated list of external auth backends; one named ext_authz filter is added per entry,
+// positioned before the terminal router filter so that per-route TypedPerFilterConfig can enable/disable each.
+func (i *cecTranslator) desiredHTTPConnectionManager(name, routeName string, authFilters []*model.HTTPExternalAuthFilter, m *model.Model) (ciliumv2.XDSResource, error) {
+	hf, err := getHTTPConnectionManagerHttpFilters(authFilters, m)
+	if err != nil {
+		return ciliumv2.XDSResource{}, err
+	}
 	connectionManager := &httpConnectionManagerv3.HttpConnectionManager{
 		StatPrefix: name,
 		RouteSpecifier: &httpConnectionManagerv3.HttpConnectionManager_Rds{
@@ -127,7 +147,7 @@ func (i *cecTranslator) desiredHTTPConnectionManager(name, routeName string, aut
 		},
 		UseRemoteAddress: &wrapperspb.BoolValue{Value: true},
 		SkipXffAppend:    false,
-		HttpFilters:      httpFilters,
+		HttpFilters:      hf,
 		UpgradeConfigs: []*httpConnectionManagerv3.HttpConnectionManager_UpgradeConfig{
 			{UpgradeType: "websocket"},
 		},

--- a/operator/pkg/model/translation/envoy_http_connection_manager_test.go
+++ b/operator/pkg/model/translation/envoy_http_connection_manager_test.go
@@ -6,6 +6,7 @@ package translation
 import (
 	"testing"
 
+	httpCORSv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/cors/v3"
 	extauthzv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
 	httpConnectionManagerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/stretchr/testify/require"
@@ -15,27 +16,96 @@ import (
 )
 
 func Test_desiredHTTPConnectionManager(t *testing.T) {
-	i := &cecTranslator{}
-	res, err := i.desiredHTTPConnectionManager("dummy-name", "dummy-route-name", nil)
-	require.NoError(t, err)
+	t.Run("no CORS filter enabled", func(t *testing.T) {
+		i := &cecTranslator{}
+		m := &model.Model{}
+		res, err := i.desiredHTTPConnectionManager("dummy-name", "dummy-route-name", nil, m)
+		require.NoError(t, err)
 
-	httpConnectionManager := &httpConnectionManagerv3.HttpConnectionManager{}
-	err = proto.Unmarshal(res.Value, httpConnectionManager)
+		httpConnectionManager := &httpConnectionManagerv3.HttpConnectionManager{}
+		err = proto.Unmarshal(res.Value, httpConnectionManager)
 
-	require.NoError(t, err)
+		require.NoError(t, err)
 
-	require.Equal(t, "dummy-name", httpConnectionManager.StatPrefix)
-	require.Equal(t, &httpConnectionManagerv3.HttpConnectionManager_Rds{
-		Rds: &httpConnectionManagerv3.Rds{RouteConfigName: "dummy-route-name"},
-	}, httpConnectionManager.GetRouteSpecifier())
+		require.Equal(t, "dummy-name", httpConnectionManager.StatPrefix)
+		require.Equal(t, &httpConnectionManagerv3.HttpConnectionManager_Rds{
+			Rds: &httpConnectionManagerv3.Rds{RouteConfigName: "dummy-route-name"},
+		}, httpConnectionManager.GetRouteSpecifier())
 
-	require.Len(t, httpConnectionManager.GetHttpFilters(), 3)
-	require.Equal(t, "envoy.filters.http.grpc_web", httpConnectionManager.GetHttpFilters()[0].Name)
-	require.Equal(t, "envoy.filters.http.grpc_stats", httpConnectionManager.GetHttpFilters()[1].Name)
-	require.Equal(t, "envoy.filters.http.router", httpConnectionManager.GetHttpFilters()[2].Name)
+		require.Len(t, httpConnectionManager.GetHttpFilters(), 3)
+		require.Equal(t, "envoy.filters.http.grpc_web", httpConnectionManager.GetHttpFilters()[0].Name)
+		require.Equal(t, "envoy.filters.http.grpc_stats", httpConnectionManager.GetHttpFilters()[1].Name)
+		require.Equal(t, "envoy.filters.http.router", httpConnectionManager.GetHttpFilters()[2].Name)
 
-	require.Len(t, httpConnectionManager.GetUpgradeConfigs(), 1)
-	require.Equal(t, "websocket", httpConnectionManager.GetUpgradeConfigs()[0].UpgradeType)
+		require.Len(t, httpConnectionManager.GetUpgradeConfigs(), 1)
+		require.Equal(t, "websocket", httpConnectionManager.GetUpgradeConfigs()[0].UpgradeType)
+	})
+	t.Run("CORS filter enabled", func(t *testing.T) {
+		i := &cecTranslator{}
+		m := &model.Model{HTTP: []model.HTTPListener{
+			{
+				Routes: []model.HTTPRoute{
+					{
+						CORS: &model.HTTPCORSFilter{AllowOrigins: []string{"*"}},
+					},
+				},
+			},
+		}}
+		res, err := i.desiredHTTPConnectionManager("dummy-name", "dummy-route-name", nil, m)
+		require.NoError(t, err)
+
+		httpConnectionManager := &httpConnectionManagerv3.HttpConnectionManager{}
+		err = proto.Unmarshal(res.Value, httpConnectionManager)
+
+		require.NoError(t, err)
+
+		require.Equal(t, "dummy-name", httpConnectionManager.StatPrefix)
+		require.Equal(t, &httpConnectionManagerv3.HttpConnectionManager_Rds{
+			Rds: &httpConnectionManagerv3.Rds{RouteConfigName: "dummy-route-name"},
+		}, httpConnectionManager.GetRouteSpecifier())
+
+		require.Len(t, httpConnectionManager.GetHttpFilters(), 4)
+		require.Equal(t, "envoy.filters.http.grpc_web", httpConnectionManager.GetHttpFilters()[0].Name)
+		require.Equal(t, "envoy.filters.http.grpc_stats", httpConnectionManager.GetHttpFilters()[1].Name)
+		require.Equal(t, "envoy.filters.http.cors", httpConnectionManager.GetHttpFilters()[2].Name)
+		require.Equal(t, "envoy.filters.http.router", httpConnectionManager.GetHttpFilters()[3].Name)
+
+		require.Len(t, httpConnectionManager.GetUpgradeConfigs(), 1)
+		require.Equal(t, "websocket", httpConnectionManager.GetUpgradeConfigs()[0].UpgradeType)
+	})
+}
+
+func Test_getHTTPConnectionManagerHttpFilters(t *testing.T) {
+	t.Run("no CORS filter enabled", func(t *testing.T) {
+		m := &model.Model{}
+		res, err := getHTTPConnectionManagerHttpFilters([]*model.HTTPExternalAuthFilter{}, m)
+		require.NoError(t, err)
+
+		require.Len(t, res, 3)
+		require.Equal(t, "envoy.filters.http.grpc_web", res[0].Name)
+		require.Equal(t, "envoy.filters.http.grpc_stats", res[1].Name)
+		require.Equal(t, "envoy.filters.http.router", res[2].Name)
+	})
+	t.Run("CORS filter enabled", func(t *testing.T) {
+		m := &model.Model{HTTP: []model.HTTPListener{
+			{
+				Routes: []model.HTTPRoute{
+					{
+						CORS: &model.HTTPCORSFilter{AllowOrigins: []string{"*"}},
+					},
+				},
+			},
+		}}
+		res, err := getHTTPConnectionManagerHttpFilters([]*model.HTTPExternalAuthFilter{}, m)
+		require.NoError(t, err)
+
+		require.Len(t, res, 4)
+		require.Equal(t, "envoy.filters.http.grpc_web", res[0].Name)
+		require.Equal(t, "envoy.filters.http.grpc_stats", res[1].Name)
+		require.Equal(t, "envoy.filters.http.cors", res[2].Name)
+		require.Equal(t, "envoy.filters.http.router", res[3].Name)
+
+	})
 }
 
 func Test_desiredHTTPConnectionManager_withExtAuthz(t *testing.T) {
@@ -52,7 +122,7 @@ func Test_desiredHTTPConnectionManager_withExtAuthz(t *testing.T) {
 	}
 
 	i := &cecTranslator{}
-	res, err := i.desiredHTTPConnectionManager("dummy-name", "dummy-route-name", authFilters)
+	res, err := i.desiredHTTPConnectionManager("dummy-name", "dummy-route-name", authFilters, nil)
 	require.NoError(t, err)
 
 	hcm := &httpConnectionManagerv3.HttpConnectionManager{}
@@ -210,14 +280,14 @@ func Test_buildExtAuthzHTTPFilter_allowedRequestHeaders(t *testing.T) {
 	})
 }
 
-func Test_buildExtAuthzPerRouteConfig(t *testing.T) {
+func Test_getTypedPerFilterConfig(t *testing.T) {
 	authFilters := []*model.HTTPExternalAuthFilter{
 		{Backend: model.Backend{Name: "svc-a", Namespace: "ns", Port: &model.BackendPort{Port: 9000}}, Protocol: model.ExternalAuthProtocolGRPC},
 		{Backend: model.Backend{Name: "svc-b", Namespace: "ns", Port: &model.BackendPort{Port: 8080}}, Protocol: model.ExternalAuthProtocolHTTP},
 	}
 
 	t.Run("route without auth disables all filters", func(t *testing.T) {
-		cfg := buildExtAuthzPerRouteConfig(nil, authFilters)
+		cfg := getTypedPerFilterConfig(nil, authFilters, model.HTTPRoute{})
 		require.Len(t, cfg, 2)
 		for _, v := range cfg {
 			perRoute := &extauthzv3.ExtAuthzPerRoute{}
@@ -231,7 +301,7 @@ func Test_buildExtAuthzPerRouteConfig(t *testing.T) {
 			Backend:  model.Backend{Name: "svc-a", Namespace: "ns", Port: &model.BackendPort{Port: 9000}},
 			Protocol: model.ExternalAuthProtocolGRPC,
 		}
-		cfg := buildExtAuthzPerRouteConfig(routeAuth, authFilters)
+		cfg := getTypedPerFilterConfig(routeAuth, authFilters, model.HTTPRoute{})
 		// Only svc-b should be disabled; svc-a has no entry (enabled by default)
 		require.Len(t, cfg, 1)
 		_, hasSvcA := cfg["envoy.filters.http.ext_authz/GRPC:ns:svc-a:9000"]
@@ -243,8 +313,17 @@ func Test_buildExtAuthzPerRouteConfig(t *testing.T) {
 		require.True(t, perRoute.GetDisabled())
 	})
 
+	t.Run("route with CORS filter", func(t *testing.T) {
+		cfg := getTypedPerFilterConfig(nil, nil, model.HTTPRoute{
+			CORS: &model.HTTPCORSFilter{MaxAge: 42},
+		})
+		require.Len(t, cfg, 1)
+		cors := &httpCORSv3.CorsPolicy{}
+		require.NoError(t, proto.Unmarshal(cfg["envoy.filters.http.cors"].Value, cors))
+	})
+
 	t.Run("no auth filters returns nil", func(t *testing.T) {
-		require.Nil(t, buildExtAuthzPerRouteConfig(nil, nil))
+		require.Nil(t, getTypedPerFilterConfig(nil, nil, model.HTTPRoute{}))
 	})
 }
 

--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -242,7 +242,7 @@ func (i *cecTranslator) filterChains(name string, m *model.Model, authFilters []
 	var filterChains []*envoy_config_listener.FilterChain
 
 	if m.IsHTTPListenerConfigured() {
-		httpFilterChain, err := i.httpFilterChain(name, authFilters)
+		httpFilterChain, err := i.httpFilterChain(name, authFilters, m)
 		if err != nil {
 			return nil, err
 		}
@@ -296,12 +296,13 @@ func (i *cecTranslator) listenerMutators(m *model.Model) []ListenerMutator {
 	return res
 }
 
-func (i *cecTranslator) httpFilterChain(name string, authFilters []*model.HTTPExternalAuthFilter) (*envoy_config_listener.FilterChain, error) {
+func (i *cecTranslator) httpFilterChain(name string, authFilters []*model.HTTPExternalAuthFilter, m *model.Model) (*envoy_config_listener.FilterChain, error) {
 	insecureHttpConnectionManagerName := fmt.Sprintf("%s-insecure", name)
 	insecureHttpConnectionManager, err := i.desiredHTTPConnectionManager(
 		insecureHttpConnectionManagerName,
 		insecureHttpConnectionManagerName,
 		authFilters,
+		m,
 	)
 	if err != nil {
 		return nil, err
@@ -336,7 +337,7 @@ func (i *cecTranslator) httpsFilterChains(name string, m *model.Model, authFilte
 		hostNames := tlsToHostnames[secret]
 
 		secureHttpConnectionManagerName := fmt.Sprintf("%s-secure", name)
-		secureHttpConnectionManager, err := i.desiredHTTPConnectionManager(secureHttpConnectionManagerName, secureHttpConnectionManagerName, authFilters)
+		secureHttpConnectionManager, err := i.desiredHTTPConnectionManager(secureHttpConnectionManagerName, secureHttpConnectionManagerName, authFilters, m)
 		if err != nil {
 			return nil, err
 		}

--- a/operator/pkg/model/translation/envoy_virtual_host.go
+++ b/operator/pkg/model/translation/envoy_virtual_host.go
@@ -8,11 +8,13 @@ import (
 	"net"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	envoy_extensions_filters_http_cors_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/cors/v3"
 	extauthzv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
 	envoy_type_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	envoy_type_v3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
@@ -31,6 +33,7 @@ const (
 	starDot        = "*."
 	dotRegex       = "[.]"
 	notDotRegex    = "[^.]"
+	dotStar        = ".*"
 )
 
 type VirtualHostMutator func(*envoy_config_route_v3.VirtualHost) *envoy_config_route_v3.VirtualHost
@@ -171,6 +174,85 @@ func (i *cecTranslator) desiredVirtualHost(httpRoutes []model.HTTPRoute, param V
 	return res
 }
 
+func getCORSStringMatcher(origin string) *envoy_type_matcher_v3.StringMatcher {
+	if !strings.Contains(origin, wildCard) {
+		return &envoy_type_matcher_v3.StringMatcher{
+			MatchPattern: &envoy_type_matcher_v3.StringMatcher_Exact{
+				Exact: origin,
+			},
+		}
+	}
+
+	regex := dotStar
+	if origin != wildCard {
+		regex = regexp.QuoteMeta(origin)
+		regex = strings.ReplaceAll(regex, regexp.QuoteMeta(wildCard), "[A-Za-z0-9.-]+")
+	}
+
+	return &envoy_type_matcher_v3.StringMatcher{
+		MatchPattern: &envoy_type_matcher_v3.StringMatcher_SafeRegex{
+			SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
+				Regex: "^" + regex + "$",
+			},
+		},
+	}
+}
+
+func getCORS(cors *model.HTTPCORSFilter) *anypb.Any {
+	ao := make([]*envoy_type_matcher_v3.StringMatcher, 0, len(cors.AllowOrigins))
+	for _, o := range cors.AllowOrigins {
+		ao = append(ao, getCORSStringMatcher(o))
+	}
+
+	return toAny(&envoy_extensions_filters_http_cors_v3.CorsPolicy{
+		AllowOriginStringMatch: ao,
+		AllowCredentials:       wrapperspb.Bool(cors.AllowCredentials),
+		AllowMethods:           strings.Join(cors.AllowMethods, ", "),
+		AllowHeaders:           strings.Join(cors.AllowHeaders, ", "),
+		ExposeHeaders:          strings.Join(cors.ExposeHeaders, ", "),
+		MaxAge:                 strconv.Itoa(int(cors.MaxAge)),
+		// Gateway API implementation is expected to be the final authority on a CORS preflight request,
+		// so any path containing a CORS filter MUST NOT pass the request to the upstream.
+		ForwardNotMatchingPreflights: wrapperspb.Bool(false),
+	})
+}
+
+// getTypedPerFilterConfig returns the TypedPerFilterConfig map for a route.
+func getTypedPerFilterConfig(routeAuth *model.HTTPExternalAuthFilter, allAuthFilters []*model.HTTPExternalAuthFilter, route model.HTTPRoute) map[string]*anypb.Any {
+	var activeKey string
+	if routeAuth != nil {
+		activeKey = extAuthzFilterKey(routeAuth)
+	}
+
+	config := make(map[string]*anypb.Any, len(allAuthFilters))
+	// For each ext_authz filter active on the listener:
+	//   - If this route's ExternalAuth uses that filter's cluster: no entry (enabled by default).
+	//   - Otherwise: disabled via ExtAuthzPerRoute{Disabled: true}.
+	for _, af := range allAuthFilters {
+		filterKey := extAuthzFilterKey(af)
+		filterName := ExtAuthzFilterName(filterKey)
+		if filterKey == activeKey {
+			// This filter is enabled for this route; no per-route override needed.
+			continue
+		}
+		// Disable this filter for this route.
+		disabled := toAny(&extauthzv3.ExtAuthzPerRoute{
+			Override: &extauthzv3.ExtAuthzPerRoute_Disabled{Disabled: true},
+		})
+		config[filterName] = disabled
+	}
+
+	if route.CORS != nil {
+		config["envoy.filters.http.cors"] = getCORS(route.CORS)
+	}
+
+	if len(config) == 0 {
+		return nil
+	}
+
+	return config
+}
+
 func envoyHTTPSRoutes(httpRoutes []model.HTTPRoute, hostnames []string, hostNameSuffixMatch bool, allAuthFilters []*model.HTTPExternalAuthFilter) []*envoy_config_route_v3.Route {
 	matchBackendMap := make(map[string][]model.HTTPRoute)
 	for _, r := range httpRoutes {
@@ -199,7 +281,7 @@ func envoyHTTPSRoutes(httpRoutes []model.HTTPRoute, hostnames []string, hostName
 				hRoutes[0].HeadersMatch,
 				hRoutes[0].Method),
 			Action:               rRedirect,
-			TypedPerFilterConfig: buildExtAuthzPerRouteConfig(nil, allAuthFilters),
+			TypedPerFilterConfig: getTypedPerFilterConfig(nil, allAuthFilters, r),
 		}
 		routes = append(routes, &route)
 		delete(matchBackendMap, r.GetMatchKey())
@@ -225,10 +307,7 @@ func envoyHTTPRoutes(httpRoutes []model.HTTPRoute, hostnames []string, hostNameS
 		}
 
 		if len(backends) == 0 && hRoutes[0].RequestRedirect == nil {
-			noBackendRoute := envoyHTTPRouteNoBackend(hRoutes[0], hostnames, hostNameSuffixMatch)
-			if noBackendRoute != nil {
-				noBackendRoute.TypedPerFilterConfig = buildExtAuthzPerRouteConfig(hRoutes[0].ExternalAuth, allAuthFilters)
-			}
+			noBackendRoute := envoyHTTPRouteNoBackend(hRoutes[0], hostnames, hostNameSuffixMatch, allAuthFilters)
 			routes = append(routes, noBackendRoute)
 			continue
 		}
@@ -244,7 +323,7 @@ func envoyHTTPRoutes(httpRoutes []model.HTTPRoute, hostnames []string, hostNameS
 			RequestHeadersToRemove:  getHeadersToRemove(hRoutes[0].RequestHeaderFilter),
 			ResponseHeadersToAdd:    getHeadersToAdd(hRoutes[0].ResponseHeaderModifier),
 			ResponseHeadersToRemove: getHeadersToRemove(hRoutes[0].ResponseHeaderModifier),
-			TypedPerFilterConfig:    buildExtAuthzPerRouteConfig(hRoutes[0].ExternalAuth, allAuthFilters),
+			TypedPerFilterConfig:    getTypedPerFilterConfig(hRoutes[0].ExternalAuth, allAuthFilters, r),
 		}
 
 		if hRoutes[0].RequestRedirect != nil {
@@ -268,42 +347,6 @@ func envoyHTTPRoutes(httpRoutes []model.HTTPRoute, hostnames []string, hostNameS
 		delete(matchBackendMap, r.GetMatchKey())
 	}
 	return routes
-}
-
-// buildExtAuthzPerRouteConfig returns the TypedPerFilterConfig map for a route.
-// For each ext_authz filter active on the listener:
-//   - If this route's ExternalAuth uses that filter's cluster: no entry (enabled by default).
-//   - Otherwise: disabled via ExtAuthzPerRoute{Disabled: true}.
-//
-// Returns nil when there are no auth filters on the listener (avoids allocations on the common path).
-func buildExtAuthzPerRouteConfig(routeAuth *model.HTTPExternalAuthFilter, allAuthFilters []*model.HTTPExternalAuthFilter) map[string]*anypb.Any {
-	if len(allAuthFilters) == 0 {
-		return nil
-	}
-
-	var activeKey string
-	if routeAuth != nil {
-		activeKey = extAuthzFilterKey(routeAuth)
-	}
-
-	config := make(map[string]*anypb.Any, len(allAuthFilters))
-	for _, af := range allAuthFilters {
-		filterKey := extAuthzFilterKey(af)
-		filterName := ExtAuthzFilterName(filterKey)
-		if filterKey == activeKey {
-			// This filter is enabled for this route; no per-route override needed.
-			continue
-		}
-		// Disable this filter for this route.
-		disabled := toAny(&extauthzv3.ExtAuthzPerRoute{
-			Override: &extauthzv3.ExtAuthzPerRoute_Disabled{Disabled: true},
-		})
-		config[filterName] = disabled
-	}
-	if len(config) == 0 {
-		return nil
-	}
-	return config
 }
 
 type routeActionMutation func(*envoy_config_route_v3.Route_Route) *envoy_config_route_v3.Route_Route
@@ -567,7 +610,7 @@ func getRouteRedirectMatch(match string) *envoy_config_route_v3.HeaderMatcher {
 	}
 }
 
-func envoyHTTPRouteNoBackend(route model.HTTPRoute, hostnames []string, hostNameSuffixMatch bool) *envoy_config_route_v3.Route {
+func envoyHTTPRouteNoBackend(route model.HTTPRoute, hostnames []string, hostNameSuffixMatch bool, allAuthFilters []*model.HTTPExternalAuthFilter) *envoy_config_route_v3.Route {
 	if route.DirectResponse == nil {
 		return nil
 	}
@@ -589,6 +632,7 @@ func envoyHTTPRouteNoBackend(route model.HTTPRoute, hostnames []string, hostName
 				},
 			},
 		},
+		TypedPerFilterConfig: getTypedPerFilterConfig(route.ExternalAuth, allAuthFilters, route),
 	}
 }
 

--- a/operator/pkg/model/translation/envoy_virtual_host_test.go
+++ b/operator/pkg/model/translation/envoy_virtual_host_test.go
@@ -12,11 +12,13 @@ import (
 	"time"
 
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	envoy_extensions_filters_http_cors_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/cors/v3"
 	extauthzv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
 	envoy_type_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	"k8s.io/utils/ptr"
 
 	"github.com/cilium/cilium/operator/pkg/model"
@@ -707,6 +709,45 @@ func Test_envoyHTTPRoutes(t *testing.T) {
 		require.NotNil(t, res[1].GetRoute())
 		require.Equal(t, "default:backend:31337", res[1].GetRoute().GetCluster())
 	})
+	t.Run("http route with CORS filter and no backend", func(t *testing.T) {
+		corsPolicy := toAny(&envoy_extensions_filters_http_cors_v3.CorsPolicy{
+			AllowOriginStringMatch: []*envoy_type_matcher_v3.StringMatcher{
+				{
+					MatchPattern: &envoy_type_matcher_v3.StringMatcher_Exact{
+						Exact: "https://example.com",
+					},
+				},
+			},
+			AllowCredentials:             wrapperspb.Bool(false),
+			AllowMethods:                 "*",
+			AllowHeaders:                 "*",
+			ExposeHeaders:                "*",
+			MaxAge:                       "42",
+			ForwardNotMatchingPreflights: wrapperspb.Bool(false),
+		})
+		httpRoutes := []model.HTTPRoute{
+			{
+				Name:      "Index",
+				PathMatch: model.StringMatch{Prefix: "/"},
+				DirectResponse: &model.DirectResponse{
+					StatusCode: 500,
+				},
+				CORS: &model.HTTPCORSFilter{
+					AllowOrigins:  []string{"https://example.com"},
+					AllowMethods:  []string{"*"},
+					AllowHeaders:  []string{"*"},
+					ExposeHeaders: []string{"*"},
+					MaxAge:        42,
+				},
+			},
+		}
+		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, true, 80, nil)
+		require.Len(t, res, 1)
+		require.NotNil(t, res[0])
+		require.NotNil(t, res[0].GetDirectResponse())
+		require.Equal(t, uint32(500), res[0].GetDirectResponse().GetStatus())
+		require.Equal(t, corsPolicy, res[0].GetTypedPerFilterConfig()["envoy.filters.http.cors"])
+	})
 }
 
 // Test_envoyHTTPSRoutes_disablesExtAuthzFilters verifies that HTTPS redirect routes
@@ -797,4 +838,109 @@ func Test_envoyHTTPSRoutes_noAuthFilters(t *testing.T) {
 	result := envoyHTTPSRoutes(routes, []string{"example.com"}, false, nil)
 	require.Len(t, result, 1)
 	require.Nil(t, result[0].TypedPerFilterConfig, "redirect route must not set TypedPerFilterConfig when there are no auth filters")
+}
+
+func Test_getCORSStringMatcher(t *testing.T) {
+	t.Run("exact match no wildcard", func(t *testing.T) {
+		ao := "http://example.com"
+		match := &envoy_type_matcher_v3.StringMatcher{
+			MatchPattern: &envoy_type_matcher_v3.StringMatcher_Exact{
+				Exact: ao,
+			},
+		}
+		res := getCORSStringMatcher(ao)
+		require.Equal(t, match, res)
+	})
+	t.Run("wildcard only match", func(t *testing.T) {
+		ao := "*"
+		match := &envoy_type_matcher_v3.StringMatcher{
+			MatchPattern: &envoy_type_matcher_v3.StringMatcher_SafeRegex{
+				SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
+					Regex: "^.*$",
+				},
+			},
+		}
+		res := getCORSStringMatcher(ao)
+		require.Equal(t, match, res)
+	})
+	t.Run("wildcard match", func(t *testing.T) {
+		ao := "http://*.example.com"
+		match := &envoy_type_matcher_v3.StringMatcher{
+			MatchPattern: &envoy_type_matcher_v3.StringMatcher_SafeRegex{
+				SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
+					Regex: "^http://[A-Za-z0-9.-]+\\.example\\.com$",
+				},
+			},
+		}
+		res := getCORSStringMatcher(ao)
+		require.Equal(t, match, res)
+	})
+}
+
+func Test_getCORS(t *testing.T) {
+	t.Run("allow and expose all", func(t *testing.T) {
+		cf := &model.HTTPCORSFilter{
+			AllowOrigins:     []string{"*"},
+			AllowCredentials: false,
+			AllowMethods:     []string{"*"},
+			AllowHeaders:     []string{"*"},
+			ExposeHeaders:    []string{"*"},
+			MaxAge:           42,
+		}
+		res := getCORS(cf)
+		match := toAny(&envoy_extensions_filters_http_cors_v3.CorsPolicy{
+			AllowOriginStringMatch: []*envoy_type_matcher_v3.StringMatcher{
+				{
+					MatchPattern: &envoy_type_matcher_v3.StringMatcher_SafeRegex{
+						SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
+							Regex: "^.*$",
+						},
+					},
+				},
+			},
+			AllowCredentials:             wrapperspb.Bool(false),
+			AllowMethods:                 "*",
+			AllowHeaders:                 "*",
+			ExposeHeaders:                "*",
+			MaxAge:                       "42",
+			ForwardNotMatchingPreflights: wrapperspb.Bool(false),
+		})
+		require.NotNil(t, res)
+		require.Equal(t, match, res)
+	})
+	t.Run("allow specific methods and headers", func(t *testing.T) {
+		cf := &model.HTTPCORSFilter{
+			AllowOrigins:     []string{"http://example.com", "http://*.example.com"},
+			AllowCredentials: false,
+			AllowMethods:     []string{"PUT", "GET"},
+			AllowHeaders:     []string{"Keep-Alive", "User-Agent"},
+			ExposeHeaders:    []string{"Content-Security-Policy"},
+			MaxAge:           42,
+		}
+		res := getCORS(cf)
+		match := toAny(&envoy_extensions_filters_http_cors_v3.CorsPolicy{
+			AllowOriginStringMatch: []*envoy_type_matcher_v3.StringMatcher{
+				{
+					MatchPattern: &envoy_type_matcher_v3.StringMatcher_Exact{
+						Exact: "http://example.com",
+					},
+				},
+				{
+					MatchPattern: &envoy_type_matcher_v3.StringMatcher_SafeRegex{
+						SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
+							Regex: "^http://[A-Za-z0-9.-]+\\.example\\.com$",
+						},
+					},
+				},
+			},
+			AllowCredentials:             wrapperspb.Bool(false),
+			AllowMethods:                 "PUT, GET",
+			AllowHeaders:                 "Keep-Alive, User-Agent",
+			ExposeHeaders:                "Content-Security-Policy",
+			MaxAge:                       "42",
+			ForwardNotMatchingPreflights: wrapperspb.Bool(false),
+		})
+		require.NotNil(t, res)
+		require.Equal(t, match, res)
+	})
 }


### PR DESCRIPTION
Introduce the CORS filter type to HTTPRoute rules, allowing users to configure Cross-Origin Resource Sharing (CORS) policies directly in Gateway API resources.

This implementation conforms to Gateway API GEP-1767: CORS Filter.

It supports the following fields:
- allowOrigins
- allowMethods
- allowHeaders
- allowCredentials
- exposeHeaders
- maxAge

The implementation allows enabling CORS filters at the route filter level: spec.rules[].filters[].cors.

Fixes: #45272

```release-note
gateway-api: Add HTTPRoute CORS filter support.
```
