### PR TITLE
egressgw: fix NamespaceSelector corruption in ParseCEGP()

### DIFF
--- a/pkg/egressgateway/helpers_test.go
+++ b/pkg/egressgateway/helpers_test.go
@@ -89,6 +89,7 @@ type policyGatewayParams struct {
 type policyParams struct {
 	name             string
 	endpointLabels   map[string]string
+	namespaceLabels  map[string]string
 	nodeSelectors    map[string]string
 	destinationCIDRs []string
 	excludedCIDRs    []string
@@ -173,13 +174,6 @@ func newCEGP(params *policyParams) (*v2.CiliumEgressGatewayPolicy, *PolicyConfig
 			Name: params.name,
 		},
 		Spec: v2.CiliumEgressGatewayPolicySpec{
-			Selectors: []v2.EgressRule{
-				{
-					PodSelector: &slimv1.LabelSelector{
-						MatchLabels: params.endpointLabels,
-					},
-				},
-			},
 			DestinationCIDRs: destinationCIDRs,
 			ExcludedCIDRs:    excludedCIDRs,
 			EgressGateway: &v2.EgressGateway{
@@ -190,6 +184,24 @@ func newCEGP(params *policyParams) (*v2.CiliumEgressGatewayPolicy, *PolicyConfig
 				EgressIP:  params.policyGwParams[0].egressIP,
 			},
 		},
+	}
+
+	if len(params.namespaceLabels) != 0 {
+		cegp.Spec.Selectors = []v2.EgressRule{
+			{
+				NamespaceSelector: &slimv1.LabelSelector{
+					MatchLabels: params.namespaceLabels,
+				},
+			},
+		}
+	} else {
+		cegp.Spec.Selectors = []v2.EgressRule{
+			{
+				PodSelector: &slimv1.LabelSelector{
+					MatchLabels: params.endpointLabels,
+				},
+			},
+		}
 	}
 
 	// Only populate the list if there is more than one gateway.

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -104,6 +104,8 @@ var (
 	ep1Labels = map[string]string{"test-key": "test-value-1"}
 	ep2Labels = map[string]string{"test-key": "test-value-2"}
 
+	ns1Labels = map[string]string{"test-key": "ns-test-value-1"}
+
 	identityAllocator = testidentity.NewMockIdentityAllocator(nil)
 
 	nodeGroupNotFoundLabels = map[string]string{"label1": "notfound"}
@@ -310,6 +312,40 @@ func TestPrivilegedEgressGatewayCEGPParser(t *testing.T) {
 	cegp.Spec.Selectors[0].PodSelector = nil
 	_, err = ParseCEGP(cegp)
 	require.Error(t, err)
+
+	// PodSelector is not mutated by the CEGP parser
+	policy = policyParams{
+		name:             "policy-1",
+		endpointLabels:   ep1Labels,
+		destinationCIDRs: []string{destCIDR},
+		policyGwParams: []policyGatewayParams{
+			{
+				iface: testInterface1,
+			},
+		},
+	}
+
+	cegp, _ = newCEGP(&policy)
+	_, err = ParseCEGP(cegp)
+	require.NoError(t, err)
+	require.Equal(t, ep1Labels, cegp.Spec.Selectors[0].PodSelector.MatchLabels)
+
+	// NamespaceSelector is not mutated by the CEGP parser
+	policy = policyParams{
+		name:             "policy-1",
+		namespaceLabels:  ns1Labels,
+		destinationCIDRs: []string{destCIDR},
+		policyGwParams: []policyGatewayParams{
+			{
+				iface: testInterface1,
+			},
+		},
+	}
+
+	cegp, _ = newCEGP(&policy)
+	_, err = ParseCEGP(cegp)
+	require.NoError(t, err)
+	require.Equal(t, ns1Labels, cegp.Spec.Selectors[0].NamespaceSelector.MatchLabels)
 
 	// can't specify both egress iface and IP
 	policy = policyParams{

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -436,7 +436,7 @@ func ParseCEGP(cegp *v2.CiliumEgressGatewayPolicy) (*PolicyConfig, error) {
 				policyTypes.NewLabelSelector(api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, egressRule.NodeSelector)))
 		}
 		if egressRule.NamespaceSelector != nil {
-			prefixedNsSelector := egressRule.NamespaceSelector
+			prefixedNsSelector := egressRule.NamespaceSelector.DeepCopy()
 			matchLabels := map[string]string{}
 			// We use our own special label prefix for namespace metadata,
 			// thus we need to prefix that prefix to all NamespaceSelector.MatchLabels


### PR DESCRIPTION
When ParseCEGP() translates a policy's NamespaceSelector, do so without mutating the original CEGP object. Otherwise the NamespaceSelector contains garbage, and won't work as intended when we parse the CEGP a second time later on.

```release-note
Fix a bug that causes the NamespaceSelector field in a CiliumEgressGatewayPolicy to be corrupted, and no longer effective. 
```
