### PR TITLE
bgp: Reconcile svc route policies only once per reconciliation

### DIFF
--- a/pkg/bgp/manager/reconciler/service.go
+++ b/pkg/bgp/manager/reconciler/service.go
@@ -5,7 +5,6 @@ package reconciler
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -66,9 +65,13 @@ type ServiceReconciler struct {
 
 // ServiceReconcilerMetadata holds per-instance reconciler state.
 type ServiceReconcilerMetadata struct {
-	ServicePaths               ResourceAFPathsMap
+	// ServicePaths and ServiceRoutePolicies hold actual router state,
+	// must be updated upon unsuccessful partial reconciliation as well.
+	ServicePaths         ResourceAFPathsMap
+	ServiceRoutePolicies ResourceRoutePolicyMap
+
+	// The below reconciler metadata needs to be updated only upon successful reconciliation.
 	ServiceAdvertisements      PeerAdvertisements
-	ServiceRoutePolicies       ResourceRoutePolicyMap
 	FrontendChanges            statedb.ChangeIterator[*loadbalancer.Frontend]
 	FrontendChangesInitialized bool
 }
@@ -175,19 +178,30 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, p ReconcileParams) er
 	metadata := r.getMetadata(p.BGPInstance)
 	reqFullReconcile := r.modifiedServiceAdvertisements(&metadata, desiredPeerAdverts)
 
-	// if frontend changes iterator has not been initialized yet (first reconcile), perform full reconciliation
+	// if frontend changes iterator has not been initialized (first reconcile or a retry), perform full reconciliation
 	if !metadata.FrontendChangesInitialized {
 		reqFullReconcile = true
 	}
 
 	err = r.reconcileServices(ctx, p, &metadata, desiredPeerAdverts, reqFullReconcile)
 
-	if err == nil {
-		// update svc advertisements in metadata only if the reconciliation was successful
-		metadata.ServiceAdvertisements = desiredPeerAdverts
-		r.setMetadata(p.BGPInstance, metadata)
+	if err != nil {
+		// Preserve partial router state without committing desired advertisements or other metadata.
+		currentMetadata := r.getMetadata(p.BGPInstance)
+		currentMetadata.ServicePaths = metadata.ServicePaths
+		currentMetadata.ServiceRoutePolicies = metadata.ServiceRoutePolicies
+
+		// As the frontend change iterator may have advanced before the failure, force full reconciliation
+		// for the next retry, as otherwise we may miss some events.
+		currentMetadata.FrontendChangesInitialized = false
+		r.setMetadata(p.BGPInstance, currentMetadata)
+		return err
 	}
-	return err
+
+	// update svc advertisements in metadata only if the reconciliation was successful
+	metadata.ServiceAdvertisements = desiredPeerAdverts
+	r.setMetadata(p.BGPInstance, metadata)
+	return nil
 }
 
 func (r *ServiceReconciler) reconcileServices(
@@ -255,29 +269,64 @@ func (r *ServiceReconciler) reconcileServices(
 }
 
 func (r *ServiceReconciler) reconcileSvcRoutePolicies(ctx context.Context, p ReconcileParams, metadata *ServiceReconcilerMetadata, desiredSvcRoutePolicies ResourceRoutePolicyMap) error {
-	var err error
-	for svcKey, desiredSvcRoutePolicies := range desiredSvcRoutePolicies {
-		currentSvcRoutePolicies, exists := metadata.ServiceRoutePolicies[svcKey]
-		if !exists && len(desiredSvcRoutePolicies) == 0 {
+	if len(desiredSvcRoutePolicies) == 0 {
+		return nil
+	}
+
+	currentPolicies := make(RoutePolicyMap)
+	desiredPolicies := make(RoutePolicyMap)
+
+	for svcKey, desiredSvcPolicies := range desiredSvcRoutePolicies {
+		currentSvcPolicies, exists := metadata.ServiceRoutePolicies[svcKey]
+		if !exists && len(desiredSvcPolicies) == 0 {
 			continue
 		}
+		maps.Copy(currentPolicies, currentSvcPolicies)
+		maps.Copy(desiredPolicies, desiredSvcPolicies)
+	}
 
-		updatedSvcRoutePolicies, rErr := ReconcileRoutePolicies(&ReconcileRoutePoliciesParams{
-			Logger:          r.logger.With(types.InstanceLogField, p.DesiredConfig.Name),
-			Ctx:             ctx,
-			Router:          p.BGPInstance.Router,
-			DesiredPolicies: desiredSvcRoutePolicies,
-			CurrentPolicies: currentSvcRoutePolicies,
-		})
+	updatedPolicies, err := ReconcileRoutePolicies(&ReconcileRoutePoliciesParams{
+		Logger:          r.logger.With(types.InstanceLogField, p.DesiredConfig.Name),
+		Ctx:             ctx,
+		Router:          p.BGPInstance.Router,
+		DesiredPolicies: desiredPolicies,
+		CurrentPolicies: currentPolicies,
+	})
 
-		if rErr == nil && len(desiredSvcRoutePolicies) == 0 {
-			delete(metadata.ServiceRoutePolicies, svcKey)
-		} else {
-			metadata.ServiceRoutePolicies[svcKey] = updatedSvcRoutePolicies
+	// Update per-service policy metadata even if reconciliation failed.
+	// The returned updatedPolicies map reflects router state changes that completed before the error.
+	for svcKey, desiredSvcPolicies := range desiredSvcRoutePolicies {
+		currentSvcPolicies, exists := metadata.ServiceRoutePolicies[svcKey]
+		if !exists && len(desiredSvcPolicies) == 0 {
+			continue
 		}
-		err = errors.Join(err, rErr)
+		updatedSvcPolicies := updatedSvcRoutePolicies(updatedPolicies, currentSvcPolicies, desiredSvcPolicies)
+		if len(updatedSvcPolicies) == 0 && len(desiredSvcPolicies) == 0 {
+			delete(metadata.ServiceRoutePolicies, svcKey)
+			continue
+		}
+		metadata.ServiceRoutePolicies[svcKey] = updatedSvcPolicies
 	}
 	return err
+}
+
+// updatedSvcRoutePolicies reconstructs the policies that were installed for a service during policy reconciliation.
+// Both currentSvcPolicies and desiredSvcPolicies needs to be considered:
+//   - currentSvcPolicies cover policies that may still be installed after failed removals or failed updates,
+//   - desiredSvcPolicies cover successfully added or updated policies.
+func updatedSvcRoutePolicies(updatedPolicies, currentSvcPolicies, desiredSvcPolicies RoutePolicyMap) RoutePolicyMap {
+	updatedSvcPolicies := make(RoutePolicyMap, len(currentSvcPolicies)+len(desiredSvcPolicies))
+	for policyName := range currentSvcPolicies {
+		if policy, exists := updatedPolicies[policyName]; exists {
+			updatedSvcPolicies[policyName] = policy
+		}
+	}
+	for policyName := range desiredSvcPolicies {
+		if policy, exists := updatedPolicies[policyName]; exists {
+			updatedSvcPolicies[policyName] = policy
+		}
+	}
+	return updatedSvcPolicies
 }
 
 func (r *ServiceReconciler) getDesiredRoutePolicies(p ReconcileParams, desiredPeerAdverts PeerAdvertisements, toUpdate []*loadbalancer.Service, toRemove []loadbalancer.ServiceName, rx statedb.ReadTxn) (ResourceRoutePolicyMap, error) {

--- a/pkg/bgp/manager/reconciler/service_test.go
+++ b/pkg/bgp/manager/reconciler/service_test.go
@@ -5,6 +5,7 @@ package reconciler
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"maps"
 	"net/netip"
@@ -19,6 +20,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/cilium/cilium/pkg/bgp/agent/signaler"
+	"github.com/cilium/cilium/pkg/bgp/fake"
 	"github.com/cilium/cilium/pkg/bgp/manager/instance"
 	"github.com/cilium/cilium/pkg/bgp/manager/store"
 	"github.com/cilium/cilium/pkg/bgp/option"
@@ -2858,4 +2860,162 @@ func advertisedPoliciesAttributesMatch(
 	for _, policy := range response.Policies {
 		req.Equal(policy, expectedPolicies[policy.Name])
 	}
+}
+
+type failingFakeRouter struct {
+	*fake.FakeRouter
+	failPolicyName string
+	failPrefix     string
+}
+
+func (r *failingFakeRouter) AddRoutePolicy(ctx context.Context, p types.RoutePolicyRequest) error {
+	if p.Policy != nil && p.Policy.Name == r.failPolicyName {
+		return errors.New("injected add route policy failure")
+	}
+	return r.FakeRouter.AddRoutePolicy(ctx, p)
+}
+
+func (r *failingFakeRouter) AdvertisePath(ctx context.Context, p types.PathRequest) (types.PathResponse, error) {
+	if p.Path != nil && p.Path.NLRI.String() == r.failPrefix {
+		return types.PathResponse{}, errors.New("injected advertise path failure")
+	}
+	return r.FakeRouter.AdvertisePath(ctx, p)
+}
+
+func TestServiceReconcilerMetadataPartialFailure(t *testing.T) {
+	// runFailedReconcile runs a reconciliation attempt that should fail thanks to passed failingFakeRouter.
+	// One aggregated service advertisement is being reconciled here.
+	runFailedReconcile := func(t *testing.T, router *failingFakeRouter, initialMetadata ServiceReconcilerMetadata) ServiceReconcilerMetadata {
+		t.Helper()
+		req := require.New(t)
+
+		f := newServiceTestFixture(t, bgpConfig())
+		log := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+		err := f.hive.Start(log, context.Background())
+		req.NoError(err)
+		t.Cleanup(func() {
+			f.hive.Stop(log, context.Background())
+		})
+
+		testBGPInstance := instance.NewFakeBGPInstance()
+		testBGPInstance.Router = router
+		f.svcReconciler.Init(testBGPInstance)
+		t.Cleanup(func() {
+			f.svcReconciler.Cleanup(testBGPInstance)
+		})
+
+		// Upsert peer config and aggregation advertisement
+		f.PeerConfigStore.Upsert(redPeerConfig)
+		f.AdvertStore.Upsert(redSvcAdvertWithAdvertisements(lbSvcAdvertWithSelector(redSvcSelector, aggregation)))
+		f.svcReconciler.setMetadata(testBGPInstance, initialMetadata)
+
+		// Upser service frontend + backend
+		frontend := svcLBFrontend(redSvcTPCluster, ingressV4)
+		frontend.Backends = concatBackend(frontend.Backends, *newTestBackend(redSvcName, backendAddr("10.1.0.1", 80), "node1", loadbalancer.BackendStateActive), 1)
+		tx := f.db.WriteTxn(f.frontends)
+		_, _, err = f.frontends.Insert(tx, frontend)
+		req.NoError(err)
+		tx.Commit()
+
+		// Run reconcile
+		err = f.svcReconciler.Reconcile(t.Context(), ReconcileParams{
+			BGPInstance:   testBGPInstance,
+			DesiredConfig: testBGPInstanceConfig,
+			CiliumNode:    testCiliumNodeConfig,
+		})
+		req.Error(err)
+
+		return f.svcReconciler.getMetadata(testBGPInstance)
+	}
+
+	// This covers failed route policy replacement:
+	// The old policy is removed, new policy addition fails during reconcile,
+	// so metadata must not keep the old policy that was removed during partial reconcile.
+	t.Run("route policy reconcile failure", func(t *testing.T) {
+		req := require.New(t)
+
+		router := &failingFakeRouter{
+			FakeRouter:     fake.NewFakeRouter(),
+			failPolicyName: redPeer65001v4LBRPName,
+		}
+
+		// add pre-existing route policy that will be updated in the reconcile
+		err := router.FakeRouter.AddRoutePolicy(t.Context(), types.RoutePolicyRequest{
+			Policy: redPeer65001v4LBRP, // non-aggregation policy, should be replaced with aggregation
+
+		})
+		req.NoError(err)
+
+		initialMetadata := ServiceReconcilerMetadata{
+			ServicePaths:          make(ResourceAFPathsMap),
+			ServiceAdvertisements: make(PeerAdvertisements),
+			ServiceRoutePolicies: ResourceRoutePolicyMap{
+				redSvcKey: {
+					redPeer65001v4LBRPName: redPeer65001v4LBRP,
+				},
+			},
+		}
+		newMetadata := runFailedReconcile(t, router, initialMetadata)
+
+		// route policy should be removed from metadata as well as router now
+		req.Empty(newMetadata.ServiceRoutePolicies[redSvcKey])
+		policies, err := router.GetRoutePolicies(t.Context())
+		req.NoError(err)
+		req.Empty(policies.Policies)
+
+		// ServiceAdvertisements should not update after failure, FrontendChangesInitialized should be false
+		req.Empty(newMetadata.ServiceAdvertisements)
+		req.False(newMetadata.FrontendChangesInitialized)
+	})
+
+	// This covers failed path replacement:
+	// The old path is withdrawn, the replacement advertise fails during reconcile,
+	// so metadata must not keep the withdrawn old path after reconcile.
+	t.Run("advertise path failure", func(t *testing.T) {
+		req := require.New(t)
+
+		router := &failingFakeRouter{
+			FakeRouter: fake.NewFakeRouter(),
+			failPrefix: ingressV4PrefixAggr, // aggregation prefix will fail during reconcile
+		}
+		oldPath := types.NewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)) // non-aggregated prefix
+
+		req.NoError(router.FakeRouter.AddRoutePolicy(t.Context(), types.RoutePolicyRequest{
+			Policy: redPeer65001v4LBRP,
+		}))
+		_, err := router.FakeRouter.AdvertisePath(t.Context(), types.PathRequest{
+			Path: oldPath,
+		})
+		req.NoError(err)
+
+		initialMetadata := ServiceReconcilerMetadata{
+			ServicePaths: ResourceAFPathsMap{
+				redSvcKey: {
+					{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
+						ingressV4Prefix: oldPath,
+					},
+				},
+			},
+			ServiceAdvertisements: make(PeerAdvertisements),
+			ServiceRoutePolicies: ResourceRoutePolicyMap{
+				redSvcKey: {
+					redPeer65001v4LBRPName: redPeer65001v4LBRP,
+				},
+			},
+		}
+		newMetadata := runFailedReconcile(t, router, initialMetadata)
+
+		// service prefix should be withdrawn from metadata as well as router now
+		paths := newMetadata.ServicePaths[redSvcKey][types.Family{Afi: types.AfiIPv4, Safi: types.SafiUnicast}]
+		req.NotContains(paths, ingressV4Prefix)
+		req.NotContains(paths, ingressV4PrefixAggr)
+
+		routes, err := router.GetRoutes(t.Context(), &types.GetRoutesRequest{TableType: types.TableTypeLocRIB})
+		req.NoError(err)
+		req.Empty(routes.Routes)
+
+		// ServiceAdvertisements should not update after failure, FrontendChangesInitialized should be false
+		req.Empty(newMetadata.ServiceAdvertisements)
+		req.False(newMetadata.FrontendChangesInitialized)
+	})
 }


### PR DESCRIPTION
Each policy reconciliation causes a soft reset of affected BGP peers, so instead of doing it per service, call ReconcileRoutePolicies only once per whole reconciliation, with desired route policies of all affected services.

This reduces the amount of soft resets and thus separate BGP UPDATE messages especially in clusters with many services.

```release-note
bgp: Reduce amount of soft peer resets by service reconciliation and fix potentially missed incorrect metadata update upon failed reconciliation.
```
