### PR TITLE
gateway-api: treat TLSRoute as required type

### DIFF
--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -61,12 +61,10 @@ func newGatewayReconciler(mgr ctrl.Manager, translator translation.Translator, l
 // The reconciler will be triggered by Gateway, or any cilium-managed GatewayClass events
 func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Determine which optional CRDs are enabled
-	var tlsRouteEnabled, serviceImportEnabled bool
+	var serviceImportEnabled bool
 
 	for _, gvk := range r.installedCRDs {
 		switch gvk.Kind {
-		case helpers.TLSRouteKind:
-			tlsRouteEnabled = true
 		case helpers.ServiceImportKind:
 			serviceImportEnabled = true
 		}
@@ -95,14 +93,12 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	// Add indexes for TLSRoutes
-	if tlsRouteEnabled {
-		for indexName, indexerFunc := range map[string]client.IndexerFunc{
-			indexers.BackendServiceTLSRouteIndex: indexers.GenerateIndexerTLSRoutebyBackendService(r.Client, r.logger),
-			indexers.GatewayTLSRouteIndex:        indexers.IndexTLSRouteByGateway,
-		} {
-			if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.TLSRoute{}, indexName, indexerFunc); err != nil {
-				return fmt.Errorf("failed to setup field indexer %q: %w", indexName, err)
-			}
+	for indexName, indexerFunc := range map[string]client.IndexerFunc{
+		indexers.BackendServiceTLSRouteIndex: indexers.GenerateIndexerTLSRoutebyBackendService(r.Client, r.logger),
+		indexers.GatewayTLSRouteIndex:        indexers.IndexTLSRouteByGateway,
+	} {
+		if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.TLSRoute{}, indexName, indexerFunc); err != nil {
+			return fmt.Errorf("failed to setup field indexer %q: %w", indexName, err)
 		}
 	}
 
@@ -137,6 +133,8 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&gatewayv1.HTTPRoute{}, watchhandlers.EnqueueRequestForOwningHTTPRoute(r.Client, r.logger, helpers.CiliumDefaultControllerName)).
 		// Watch GRPCRoute linked to Gateway
 		Watches(&gatewayv1.GRPCRoute{}, watchhandlers.EnqueueRequestForOwningGRPCRoute(r.Client, r.logger, helpers.CiliumDefaultControllerName)).
+		// Watch TLSRoute linked to Gateway
+		Watches(&gatewayv1.TLSRoute{}, watchhandlers.EnqueueRequestForOwningTLSRoute(r.Client, r.logger, helpers.CiliumDefaultControllerName)).
 		// Watch related secrets used to configure TLS
 		Watches(&corev1.Secret{},
 			watchhandlers.EnqueueRequestForTLSSecret(r.Client, r.logger),
@@ -153,11 +151,6 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&ciliumv2.CiliumEnvoyConfig{}).
 		Owns(&corev1.Service{}).
 		Owns(&discoveryv1.EndpointSlice{})
-
-	if tlsRouteEnabled {
-		// Watch TLSRoute linked to Gateway
-		gatewayBuilder = gatewayBuilder.Watches(&gatewayv1.TLSRoute{}, watchhandlers.EnqueueRequestForOwningTLSRoute(r.Client, r.logger, helpers.CiliumDefaultControllerName))
-	}
 
 	if serviceImportEnabled {
 		// Watch for changes to Backend Service Imports

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -305,10 +305,9 @@ func Test_Conformance(t *testing.T) {
 				WithStatusSubresource(&gatewayv1.GatewayClass{}).
 				WithStatusSubresource(&gatewayv1.BackendTLSPolicy{})
 
-			switch tt.disableServiceImport {
-			case true:
-				clientBuilder.WithScheme(helpers.TestScheme(helpers.NoMCSOptionalKinds))
-			case false:
+			if tt.disableServiceImport {
+				clientBuilder.WithScheme(helpers.TestScheme(nil))
+			} else {
 				clientBuilder.WithScheme(helpers.TestScheme(helpers.AllOptionalKinds))
 			}
 
@@ -736,7 +735,8 @@ func fakeIndexHTTPRouteByBackendService(rawObj client.Object) []string {
 				continue
 			}
 			namespace := helpers.NamespaceDerefOr(backend.Namespace, route.Namespace)
-			backendServices = append(backendServices,
+			backendServices = append(
+				backendServices,
 				types.NamespacedName{
 					Namespace: namespace,
 					Name:      string(backend.Name),

--- a/operator/pkg/gateway-api/helpers/schemes.go
+++ b/operator/pkg/gateway-api/helpers/schemes.go
@@ -24,19 +24,15 @@ var RequiredGVKs = []schema.GroupVersionKind{
 	gatewayv1.SchemeGroupVersion.WithKind(GatewayKind),
 	gatewayv1.SchemeGroupVersion.WithKind(HTTPRouteKind),
 	gatewayv1.SchemeGroupVersion.WithKind(GRPCRouteKind),
+	gatewayv1.SchemeGroupVersion.WithKind(TLSRouteKind),
 	gatewayv1.SchemeGroupVersion.WithKind(ReferenceGrantKind),
 }
 
 var AllOptionalKinds = []schema.GroupVersionKind{
-	gatewayv1.SchemeGroupVersion.WithKind(TLSRouteKind),
 	mcsapiv1beta1.SchemeGroupVersion.WithKind(ServiceImportKind),
 }
 
-var NoMCSOptionalKinds = []schema.GroupVersionKind{
-	gatewayv1.SchemeGroupVersion.WithKind(TLSRouteKind),
-}
-
-func TestScheme(installedGVKs []schema.GroupVersionKind) *runtime.Scheme {
+func TestScheme(optionalKinds []schema.GroupVersionKind) *runtime.Scheme {
 	scheme := runtime.NewScheme()
 
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
@@ -44,7 +40,7 @@ func TestScheme(installedGVKs []schema.GroupVersionKind) *runtime.Scheme {
 	utilruntime.Must(ciliumv2alpha1.AddToScheme(scheme))
 	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 
-	RegisterGatewayAPITypesToScheme(scheme, installedGVKs)
+	RegisterGatewayAPITypesToScheme(scheme, optionalKinds)
 
 	return scheme
 }


### PR DESCRIPTION
Since Gateway API v1.5.0 `TLSRoute` is part of the standard channel.

Therefore, this commit removes the bits that treated it as optional CRD.

Fixes: https://github.com/cilium/cilium/pull/45251