### PR TITLE
wireguard: skip iptables NOTRACK with node encryption and legacy routing

### DIFF
--- a/pkg/datapath/iptables/cell.go
+++ b/pkg/datapath/iptables/cell.go
@@ -50,6 +50,8 @@ var Cell = cell.Module(
 			EnableL7Proxy:               cfg.EnableL7Proxy,
 			InstallIptRules:             cfg.InstallIptRules,
 			EnableWireguard:             wgConfig.Enabled(),
+			EnableNodeEncrypt:           cfg.EncryptNode,
+			EnableHostLegacyRouting:     cfg.UnsafeDaemonConfigOption.EnableHostLegacyRouting,
 		}
 	}),
 	cell.Provide(newManager),
@@ -112,4 +114,6 @@ type SharedConfig struct {
 	EnableL7Proxy               bool
 	InstallIptRules             bool
 	EnableWireguard             bool
+	EnableNodeEncrypt           bool
+	EnableHostLegacyRouting     bool
 }

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1887,7 +1887,10 @@ func (m *manager) installRules(state desiredState) error {
 		}
 	}
 
-	if m.sharedCfg.EnableIPSec || m.sharedCfg.EnableWireguard {
+	// For IPSec we can always skip kernel conntrack for encrypted traffic.
+	// For WireGuard, we need kernel conntrack only when node encryption and
+	// host legacy routing are enabled to rev-SNAT back pod-to-host traffic.
+	if m.sharedCfg.EnableIPSec || (m.sharedCfg.EnableWireguard && !(m.sharedCfg.EnableNodeEncrypt && m.sharedCfg.EnableHostLegacyRouting)) {
 		if err := m.addCiliumNoTrackEncryptionRules(); err != nil {
 			return fmt.Errorf("cannot install encryption rules: %w", err)
 		}


### PR DESCRIPTION
When both NodeEncryption and HostLegacyRouting are enabled, we need to keep kernel conntrack to rev-SNAT back pod-to-host traffic. Otherwise, replies packets from host to pod will be dropped post WireGuard decryption as they won't match any kernel conntrack entry to rev-SNAT back to the pod IP. Pod-to-pod traffic are not affected as they are not SNATed (same CIDR).

Fixes: https://github.com/cilium/cilium/issues/45837.
Fixes: https://github.com/cilium/cilium/issues/45497.

Suggested-by: Robin Gögge <r.goegge@isovalent.com>