### PR TITLE
Gateway API: Support weighted TLSRoute passthrough backends

### DIFF
--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-empty-hostname-x-4.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-empty-hostname-x-4.yaml
@@ -56,16 +56,6 @@ spec:
                 useRemoteAddress: true
         - filterChainMatch:
             serverNames:
-              - abc.example.com
-            transportProtocol: tls
-          filters:
-            - name: envoy.filters.network.tcp_proxy
-              typedConfig:
-                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-                cluster: gateway-conformance-infra:tls-backend:443
-                statPrefix: gateway-conformance-infra:tls-backend:443
-        - filterChainMatch:
-            serverNames:
               - "*.com"
             transportProtocol: tls
           filters:
@@ -73,7 +63,17 @@ spec:
               typedConfig:
                 "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
                 cluster: gateway-conformance-infra:tls-backend-2:443
-                statPrefix: gateway-conformance-infra:tls-backend-2:443
+                statPrefix: tls-passthrough:*.com
+        - filterChainMatch:
+            serverNames:
+              - abc.example.com
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: gateway-conformance-infra:tls-backend:443
+                statPrefix: tls-passthrough:abc.example.com
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-exact-hostname-x-1.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-exact-hostname-x-1.yaml
@@ -59,7 +59,7 @@ spec:
               typedConfig:
                 "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
                 cluster: gateway-conformance-infra:tls-backend:443
-                statPrefix: gateway-conformance-infra:tls-backend:443
+                statPrefix: tls-passthrough:abc.example.com
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-less-specific-wc-hostname-x-3.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-less-specific-wc-hostname-x-3.yaml
@@ -56,16 +56,6 @@ spec:
                 useRemoteAddress: true
         - filterChainMatch:
             serverNames:
-              - abc.example.com
-            transportProtocol: tls
-          filters:
-            - name: envoy.filters.network.tcp_proxy
-              typedConfig:
-                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-                cluster: gateway-conformance-infra:tls-backend:443
-                statPrefix: gateway-conformance-infra:tls-backend:443
-        - filterChainMatch:
-            serverNames:
               - "*.example.com"
             transportProtocol: tls
           filters:
@@ -73,7 +63,17 @@ spec:
               typedConfig:
                 "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
                 cluster: gateway-conformance-infra:tls-backend-2:443
-                statPrefix: gateway-conformance-infra:tls-backend-2:443
+                statPrefix: tls-passthrough:*.example.com
+        - filterChainMatch:
+            serverNames:
+              - abc.example.com
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: gateway-conformance-infra:tls-backend:443
+                statPrefix: tls-passthrough:abc.example.com
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-more-specific-wc-hostname-x-2.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-more-specific-wc-hostname-x-2.yaml
@@ -56,16 +56,6 @@ spec:
                 useRemoteAddress: true
         - filterChainMatch:
             serverNames:
-              - abc.example.com
-            transportProtocol: tls
-          filters:
-            - name: envoy.filters.network.tcp_proxy
-              typedConfig:
-                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-                cluster: gateway-conformance-infra:tls-backend:443
-                statPrefix: gateway-conformance-infra:tls-backend:443
-        - filterChainMatch:
-            serverNames:
               - "*.example.com"
             transportProtocol: tls
           filters:
@@ -73,7 +63,17 @@ spec:
               typedConfig:
                 "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
                 cluster: gateway-conformance-infra:tls-backend-2:443
-                statPrefix: gateway-conformance-infra:tls-backend-2:443
+                statPrefix: tls-passthrough:*.example.com
+        - filterChainMatch:
+            serverNames:
+              - abc.example.com
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: gateway-conformance-infra:tls-backend:443
+                statPrefix: tls-passthrough:abc.example.com
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/output/cec-gateway-tlsroute-mixed.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/output/cec-gateway-tlsroute-mixed.yaml
@@ -94,7 +94,7 @@ spec:
               typedConfig:
                 "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
                 cluster: gateway-conformance-infra:tls-backend:443
-                statPrefix: gateway-conformance-infra:tls-backend:443
+                statPrefix: tls-passthrough:tls.example.com
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-simple-same-namespace/output/cec-gateway-tlsroute.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-simple-same-namespace/output/cec-gateway-tlsroute.yaml
@@ -59,7 +59,7 @@ spec:
               typedConfig:
                 "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
                 cluster: gateway-conformance-infra:tls-backend:443
-                statPrefix: gateway-conformance-infra:tls-backend:443
+                statPrefix: tls-passthrough:abc.example.com
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:

--- a/operator/pkg/model/ingestion/gateway_test.go
+++ b/operator/pkg/model/ingestion/gateway_test.go
@@ -74,6 +74,7 @@ func TestTLSGatewayAPI(t *testing.T) {
 		"Conformance/TLSRouteSimpleSameNamespace":  {},
 		"Conformance/TLSRouteHostnameIntersection": {},
 		"mixed protocol listeners TLSRoute":        {},
+		"tls weighted backends":                    {},
 	}
 
 	for name := range tests {

--- a/operator/pkg/model/ingestion/testdata/gateway/tls_weighted_backends/input-gateway.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/tls_weighted_backends/input-gateway.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: my-gateway
+  namespace: default
+spec:
+  gatewayClassName: ""
+  listeners:
+  - name: tls
+    port: 443
+    protocol: TLS
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/tls_weighted_backends/input-gatewayclass.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/tls_weighted_backends/input-gatewayclass.yaml
@@ -1,0 +1,5 @@
+metadata:
+  creationTimestamp: null
+spec:
+  controllerName: ""
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/tls_weighted_backends/input-service.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/tls_weighted_backends/input-service.yaml
@@ -1,0 +1,14 @@
+- metadata:
+    creationTimestamp: null
+    name: backend-v1
+    namespace: default
+  spec: {}
+  status:
+    loadBalancer: {}
+- metadata:
+    creationTimestamp: null
+    name: backend-v2
+    namespace: default
+  spec: {}
+  status:
+    loadBalancer: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/tls_weighted_backends/input-tlsroute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/tls_weighted_backends/input-tlsroute.yaml
@@ -1,0 +1,19 @@
+- metadata:
+    creationTimestamp: null
+    name: tls-weighted
+    namespace: default
+  spec:
+    hostnames:
+    - test.example.com
+    parentRefs:
+    - name: my-gateway
+    rules:
+    - backendRefs:
+      - name: backend-v1
+        port: 443
+        weight: 70
+      - name: backend-v2
+        port: 443
+        weight: 30
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gateway/tls_weighted_backends/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/tls_weighted_backends/output-listeners.yaml
@@ -1,0 +1,23 @@
+- hostname: '*'
+  name: tls
+  port: 443
+  routes:
+  - backends:
+    - name: backend-v1
+      namespace: default
+      port:
+        port: 443
+      weight: 70
+    - name: backend-v2
+      namespace: default
+      port:
+        port: 443
+      weight: 30
+    hostnames:
+    - test.example.com
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: my-gateway
+    namespace: default
+    version: v1

--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"maps"
 	goslices "slices"
+	"strings"
 	"syscall"
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -24,6 +25,7 @@ import (
 	"github.com/cilium/cilium/operator/pkg/model"
 	"github.com/cilium/cilium/pkg/envoy"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/slices"
 )
 
 const (
@@ -399,33 +401,158 @@ func getHostNetworkListenerAddresses(ports []uint32, ipv4Enabled, ipv6Enabled bo
 }
 
 func tlsPassthroughFilterChains(m *model.Model) []*envoy_config_listener.FilterChain {
-	ptBackendsToHostnames := m.TLSBackends()
-	if len(ptBackendsToHostnames) == 0 {
-		return nil
-	}
-
 	var filterChains []*envoy_config_listener.FilterChain
 
-	for _, backend := range ptBackendsToHostnames {
-		filterChains = append(filterChains, &envoy_config_listener.FilterChain{
-			FilterChainMatch: toFilterChainMatch(backend.Hostnames),
-			Filters: []*envoy_config_listener.Filter{
-				{
-					Name: tcpProxyType,
-					ConfigType: &envoy_config_listener.Filter_TypedConfig{
-						TypedConfig: toAny(&envoy_extensions_filters_network_tcp_v3.TcpProxy{
-							StatPrefix: backend.BackendKey,
-							ClusterSpecifier: &envoy_extensions_filters_network_tcp_v3.TcpProxy_Cluster{
-								Cluster: backend.BackendKey,
-							},
-						}),
+	for _, listener := range stableTLSPassthroughListeners(m.TLSPassthrough) {
+		for _, route := range stableTLSPassthroughRoutes(listener.Routes) {
+			backends := stableTLSPassthroughBackends(route.Backends)
+			if len(backends) == 0 {
+				continue
+			}
+
+			filterChains = append(filterChains, &envoy_config_listener.FilterChain{
+				FilterChainMatch: toFilterChainMatch(route.Hostnames),
+				Filters: []*envoy_config_listener.Filter{
+					{
+						Name: tcpProxyType,
+						ConfigType: &envoy_config_listener.Filter_TypedConfig{
+							TypedConfig: toAny(tcpProxyForTLSPassthroughRoute(route, backends)),
+						},
 					},
 				},
-			},
-		})
+			})
+		}
 	}
 
 	return filterChains
+}
+
+func stableTLSPassthroughListeners(listeners []model.TLSPassthroughListener) []model.TLSPassthroughListener {
+	if len(listeners) < 2 {
+		return listeners
+	}
+
+	stable := append([]model.TLSPassthroughListener(nil), listeners...)
+	goslices.SortFunc(stable, func(a, b model.TLSPassthroughListener) int {
+		return cmp.Or(
+			cmp.Compare(a.Port, b.Port),
+			cmp.Compare(a.Address, b.Address),
+			cmp.Compare(a.Hostname, b.Hostname),
+			cmp.Compare(a.Name, b.Name),
+		)
+	})
+
+	return stable
+}
+
+func stableTLSPassthroughRoutes(routes []model.TLSPassthroughRoute) []model.TLSPassthroughRoute {
+	if len(routes) < 2 {
+		return routes
+	}
+
+	stable := append([]model.TLSPassthroughRoute(nil), routes...)
+	goslices.SortFunc(stable, func(a, b model.TLSPassthroughRoute) int {
+		return cmp.Or(
+			cmp.Compare(tlsPassthroughHostnamesKey(a.Hostnames), tlsPassthroughHostnamesKey(b.Hostnames)),
+			cmp.Compare(tlsPassthroughBackendsKey(a.Backends), tlsPassthroughBackendsKey(b.Backends)),
+			cmp.Compare(a.Name, b.Name),
+		)
+	})
+
+	return stable
+}
+
+func stableTLSPassthroughBackends(backends []model.Backend) []model.Backend {
+	if len(backends) < 2 {
+		return backends
+	}
+
+	stable := append([]model.Backend(nil), backends...)
+	goslices.SortFunc(stable, func(a, b model.Backend) int {
+		return cmp.Or(
+			cmp.Compare(a.Namespace, b.Namespace),
+			cmp.Compare(a.Name, b.Name),
+			cmp.Compare(tlsPassthroughBackendPort(a), tlsPassthroughBackendPort(b)),
+			cmp.Compare(tlsPassthroughBackendWeight(a), tlsPassthroughBackendWeight(b)),
+		)
+	})
+
+	return stable
+}
+
+func tcpProxyForTLSPassthroughRoute(route model.TLSPassthroughRoute, backends []model.Backend) *envoy_extensions_filters_network_tcp_v3.TcpProxy {
+	tcpProxy := &envoy_extensions_filters_network_tcp_v3.TcpProxy{
+		StatPrefix: tlsPassthroughFilterChainStatPrefix(route),
+	}
+
+	if len(backends) == 1 {
+		tcpProxy.ClusterSpecifier = &envoy_extensions_filters_network_tcp_v3.TcpProxy_Cluster{
+			Cluster: tlsPassthroughClusterName(backends[0]),
+		}
+		return tcpProxy
+	}
+
+	weightedClusters := make([]*envoy_extensions_filters_network_tcp_v3.TcpProxy_WeightedCluster_ClusterWeight, 0, len(backends))
+	for _, backend := range backends {
+		weightedClusters = append(weightedClusters, &envoy_extensions_filters_network_tcp_v3.TcpProxy_WeightedCluster_ClusterWeight{
+			Name:   tlsPassthroughClusterName(backend),
+			Weight: tlsPassthroughBackendWeight(backend),
+		})
+	}
+
+	tcpProxy.ClusterSpecifier = &envoy_extensions_filters_network_tcp_v3.TcpProxy_WeightedClusters{
+		WeightedClusters: &envoy_extensions_filters_network_tcp_v3.TcpProxy_WeightedCluster{
+			Clusters: weightedClusters,
+		},
+	}
+
+	return tcpProxy
+}
+
+func tlsPassthroughClusterName(backend model.Backend) string {
+	return getClusterName(backend.Namespace, backend.Name, backend.Port.GetPort())
+}
+
+func tlsPassthroughFilterChainStatPrefix(route model.TLSPassthroughRoute) string {
+	return "tls-passthrough:" + tlsPassthroughHostnamesKey(route.Hostnames)
+}
+
+func tlsPassthroughHostnamesKey(hostnames []string) string {
+	if len(hostnames) == 0 {
+		return "*"
+	}
+
+	stable := append([]string(nil), hostnames...)
+	goslices.Sort(stable)
+	return strings.Join(stable, ",")
+}
+
+func tlsPassthroughBackendsKey(backends []model.Backend) string {
+	stable := stableTLSPassthroughBackends(backends)
+	keys := make([]string, 0, len(stable))
+	for _, backend := range stable {
+		keys = append(keys, fmt.Sprintf("%s/%s:%s:%d", backend.Namespace, backend.Name, tlsPassthroughBackendPort(backend), tlsPassthroughBackendWeight(backend)))
+	}
+	return strings.Join(keys, ",")
+}
+
+func tlsPassthroughBackendPort(backend model.Backend) string {
+	if backend.Port == nil {
+		return ""
+	}
+	return backend.Port.GetPort()
+}
+
+func tlsPassthroughBackendWeight(backend model.Backend) uint32 {
+	if backend.Weight == nil {
+		return 1
+	}
+	// Gateway API validates non-negative weights, but clamp defensively for
+	// internal model callers.
+	if *backend.Weight < 0 {
+		return 0
+	}
+	return uint32(*backend.Weight)
 }
 
 func toTransportSocket(ciliumSecretNamespace string, tls []model.TLSSecret) *envoy_config_core_v3.TransportSocket {
@@ -463,10 +590,11 @@ func toFilterChainMatch(hostNames []string) *envoy_config_listener.FilterChainMa
 	res := &envoy_config_listener.FilterChainMatch{
 		TransportProtocol: tlsTransportProtocol,
 	}
-	// The hostNames slice cannot have duplicates, so we do not need to check for uniqueness.
-	if goslices.Contains(hostNames, "*") {
+	// ServerNames must be sorted and unique, and Envoy does not support "*" as a server name.
+	serverNames := slices.SortedUnique(hostNames)
+	if goslices.Contains(serverNames, "*") {
 		return res
 	}
-	res.ServerNames = hostNames
+	res.ServerNames = serverNames
 	return res
 }

--- a/operator/pkg/model/translation/envoy_listener_test.go
+++ b/operator/pkg/model/translation/envoy_listener_test.go
@@ -8,8 +8,10 @@ import (
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	envoy_extensions_filters_network_tcp_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/cilium/cilium/operator/pkg/model"
@@ -236,6 +238,275 @@ func Test_getHostNetworkListenerAddresses(t *testing.T) {
 			assert.Equal(t, tC.expectedAdditionalAdresses, additionalAddresses)
 		})
 	}
+}
+
+func Test_tlsPassthroughFilterChains_Backends(t *testing.T) {
+	weight70 := int32(70)
+	weight30 := int32(30)
+	weight0 := int32(0)
+	weight99 := int32(99)
+	weightNegative := int32(-10)
+
+	tests := []struct {
+		name             string
+		backends         []model.Backend
+		wantFilterChains int
+		wantStatPrefix   string
+		wantCluster      string
+		wantWeighted     []*envoy_extensions_filters_network_tcp_v3.TcpProxy_WeightedCluster_ClusterWeight
+	}{
+		{
+			name:             "no valid backends emits no filter chain",
+			wantFilterChains: 0,
+		},
+		{
+			name: "single backend",
+			backends: []model.Backend{
+				tlsBackend("one", "backend-v1", 443, nil),
+			},
+			wantFilterChains: 1,
+			wantStatPrefix:   "tls-passthrough:test.example.com",
+			wantCluster:      "one:backend-v1:443",
+		},
+		{
+			name: "weighted backends",
+			backends: []model.Backend{
+				tlsBackend("one", "backend-v1", 443, &weight70),
+				tlsBackend("one", "backend-v2", 443, &weight30),
+			},
+			wantFilterChains: 1,
+			wantStatPrefix:   "tls-passthrough:test.example.com",
+			wantWeighted: []*envoy_extensions_filters_network_tcp_v3.TcpProxy_WeightedCluster_ClusterWeight{
+				{Name: "one:backend-v1:443", Weight: 70},
+				{Name: "one:backend-v2:443", Weight: 30},
+			},
+		},
+		{
+			name: "omitted weights default to one",
+			backends: []model.Backend{
+				tlsBackend("one", "backend-v1", 443, nil),
+				tlsBackend("one", "backend-v2", 443, nil),
+			},
+			wantFilterChains: 1,
+			wantStatPrefix:   "tls-passthrough:test.example.com",
+			wantWeighted: []*envoy_extensions_filters_network_tcp_v3.TcpProxy_WeightedCluster_ClusterWeight{
+				{Name: "one:backend-v1:443", Weight: 1},
+				{Name: "one:backend-v2:443", Weight: 1},
+			},
+		},
+		{
+			name: "mixed omitted explicit zero and negative weights are deterministic",
+			backends: []model.Backend{
+				tlsBackend("one", "backend-v1", 443, nil),
+				tlsBackend("one", "backend-v2", 443, &weight99),
+				tlsBackend("one", "backend-v3", 443, &weight0),
+				tlsBackend("one", "backend-v4", 443, &weightNegative),
+			},
+			wantFilterChains: 1,
+			wantStatPrefix:   "tls-passthrough:test.example.com",
+			wantWeighted: []*envoy_extensions_filters_network_tcp_v3.TcpProxy_WeightedCluster_ClusterWeight{
+				{Name: "one:backend-v1:443", Weight: 1},
+				{Name: "one:backend-v2:443", Weight: 99},
+				{Name: "one:backend-v3:443", Weight: 0},
+				{Name: "one:backend-v4:443", Weight: 0},
+			},
+		},
+		{
+			name: "all zero weights preserve configured zero values",
+			backends: []model.Backend{
+				tlsBackend("one", "backend-v1", 443, &weight0),
+				tlsBackend("one", "backend-v2", 443, &weight0),
+			},
+			wantFilterChains: 1,
+			wantStatPrefix:   "tls-passthrough:test.example.com",
+			wantWeighted: []*envoy_extensions_filters_network_tcp_v3.TcpProxy_WeightedCluster_ClusterWeight{
+				{Name: "one:backend-v1:443", Weight: 0},
+				{Name: "one:backend-v2:443", Weight: 0},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filterChains := tlsPassthroughFilterChains(&model.Model{
+				TLSPassthrough: []model.TLSPassthroughListener{
+					{
+						Routes: []model.TLSPassthroughRoute{
+							{
+								Hostnames: []string{"test.example.com"},
+								Backends:  tt.backends,
+							},
+						},
+					},
+				},
+			})
+
+			require.Len(t, filterChains, tt.wantFilterChains)
+			if tt.wantFilterChains == 0 {
+				return
+			}
+
+			tcpProxy := getTCPProxy(t, filterChains[0])
+			assert.Equal(t, tt.wantStatPrefix, tcpProxy.GetStatPrefix())
+			if tt.wantCluster != "" {
+				assert.Equal(t, tt.wantCluster, tcpProxy.GetCluster())
+				assert.Nil(t, tcpProxy.GetWeightedClusters())
+				return
+			}
+
+			assert.Empty(t, tcpProxy.GetCluster())
+			require.NotNil(t, tcpProxy.GetWeightedClusters())
+			assert.Equal(t, tt.wantWeighted, tcpProxy.GetWeightedClusters().GetClusters())
+		})
+	}
+}
+
+func Test_tlsPassthroughFilterChains_DuplicateSNIRoutesPreserveCurrentBehavior(t *testing.T) {
+	filterChains := tlsPassthroughFilterChains(&model.Model{
+		TLSPassthrough: []model.TLSPassthroughListener{
+			{
+				Routes: []model.TLSPassthroughRoute{
+					{
+						Hostnames: []string{"test.example.com"},
+						Backends: []model.Backend{
+							tlsBackend("one", "backend-v1", 443, nil),
+						},
+					},
+					{
+						Hostnames: []string{"test.example.com"},
+						Backends: []model.Backend{
+							tlsBackend("one", "backend-v2", 443, nil),
+						},
+					},
+				},
+			},
+		},
+	})
+
+	require.Len(t, filterChains, 2)
+	assert.Equal(t, []string{"test.example.com"}, filterChains[0].GetFilterChainMatch().GetServerNames())
+	assert.Equal(t, []string{"test.example.com"}, filterChains[1].GetFilterChainMatch().GetServerNames())
+	assert.Equal(t, "tls-passthrough:test.example.com", getTCPProxy(t, filterChains[0]).GetStatPrefix())
+	assert.Equal(t, "tls-passthrough:test.example.com", getTCPProxy(t, filterChains[1]).GetStatPrefix())
+	assert.Equal(t, "one:backend-v1:443", getTCPProxy(t, filterChains[0]).GetCluster())
+	assert.Equal(t, "one:backend-v2:443", getTCPProxy(t, filterChains[1]).GetCluster())
+}
+
+func Test_tlsPassthroughFilterChains_DeterministicOrder(t *testing.T) {
+	weight70 := int32(70)
+	weight30 := int32(30)
+
+	modelA := &model.Model{
+		TLSPassthrough: []model.TLSPassthroughListener{
+			{
+				Name: "listener-z",
+				Port: 443,
+				Routes: []model.TLSPassthroughRoute{
+					{
+						Hostnames: []string{"c.example.com"},
+						Backends: []model.Backend{
+							tlsBackend("two", "backend-z", 8443, nil),
+						},
+					},
+				},
+			},
+			{
+				Name: "listener-a",
+				Port: 443,
+				Routes: []model.TLSPassthroughRoute{
+					{
+						Hostnames: []string{"b.example.com"},
+						Backends: []model.Backend{
+							tlsBackend("one", "backend-b", 443, nil),
+						},
+					},
+					{
+						Hostnames: []string{"a.example.com"},
+						Backends: []model.Backend{
+							tlsBackend("one", "backend-a", 443, &weight70),
+							tlsBackend("one", "backend-c", 443, &weight30),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	modelB := &model.Model{
+		TLSPassthrough: []model.TLSPassthroughListener{
+			{
+				Name: "listener-a",
+				Port: 443,
+				Routes: []model.TLSPassthroughRoute{
+					{
+						Hostnames: []string{"a.example.com"},
+						Backends: []model.Backend{
+							tlsBackend("one", "backend-c", 443, &weight30),
+							tlsBackend("one", "backend-a", 443, &weight70),
+						},
+					},
+					{
+						Hostnames: []string{"b.example.com"},
+						Backends: []model.Backend{
+							tlsBackend("one", "backend-b", 443, nil),
+						},
+					},
+				},
+			},
+			{
+				Name: "listener-z",
+				Port: 443,
+				Routes: []model.TLSPassthroughRoute{
+					{
+						Hostnames: []string{"c.example.com"},
+						Backends: []model.Backend{
+							tlsBackend("two", "backend-z", 8443, nil),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	filterChainsA := tlsPassthroughFilterChains(modelA)
+	filterChainsB := tlsPassthroughFilterChains(modelB)
+
+	diffOutput := cmp.Diff(filterChainsA, filterChainsB, protocmp.Transform())
+	if len(diffOutput) != 0 {
+		t.Fatalf("TLS passthrough filter chains were not deterministic across equivalent inputs:\n%s\n", diffOutput)
+	}
+
+	require.Len(t, filterChainsA, 3)
+	assert.Equal(t, []string{"a.example.com"}, filterChainsA[0].GetFilterChainMatch().GetServerNames())
+	assert.Equal(t, []string{"b.example.com"}, filterChainsA[1].GetFilterChainMatch().GetServerNames())
+	assert.Equal(t, []string{"c.example.com"}, filterChainsA[2].GetFilterChainMatch().GetServerNames())
+
+	tcpProxy := getTCPProxy(t, filterChainsA[0])
+	assert.Equal(t, "tls-passthrough:a.example.com", tcpProxy.GetStatPrefix())
+	require.NotNil(t, tcpProxy.GetWeightedClusters())
+	assert.Equal(t, []*envoy_extensions_filters_network_tcp_v3.TcpProxy_WeightedCluster_ClusterWeight{
+		{Name: "one:backend-a:443", Weight: 70},
+		{Name: "one:backend-c:443", Weight: 30},
+	}, tcpProxy.GetWeightedClusters().GetClusters())
+}
+
+func tlsBackend(namespace, name string, port uint32, weight *int32) model.Backend {
+	return model.Backend{
+		Namespace: namespace,
+		Name:      name,
+		Port: &model.BackendPort{
+			Port: port,
+		},
+		Weight: weight,
+	}
+}
+
+func getTCPProxy(t *testing.T, filterChain *envoy_config_listener.FilterChain) *envoy_extensions_filters_network_tcp_v3.TcpProxy {
+	require.Len(t, filterChain.GetFilters(), 1)
+
+	tcpProxy := &envoy_extensions_filters_network_tcp_v3.TcpProxy{}
+	require.NoError(t, filterChain.GetFilters()[0].GetTypedConfig().UnmarshalTo(tcpProxy))
+	return tcpProxy
 }
 
 func Test_withHostNetworkPortSorted(t *testing.T) {

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/tlsroute_hostname_intersection/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/tlsroute_hostname_intersection/cec-output.yaml
@@ -27,16 +27,6 @@ spec:
       filterChains:
         - filterChainMatch:
             serverNames:
-              - abc.example.com
-            transportProtocol: tls
-          filters:
-            - name: envoy.filters.network.tcp_proxy
-              typedConfig:
-                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-                cluster: gateway-conformance-infra:tls-backend:443
-                statPrefix: gateway-conformance-infra:tls-backend:443
-        - filterChainMatch:
-            serverNames:
               - "*.com"
             transportProtocol: tls
           filters:
@@ -44,7 +34,17 @@ spec:
               typedConfig:
                 "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
                 cluster: gateway-conformance-infra:tls-backend-2:443
-                statPrefix: gateway-conformance-infra:tls-backend-2:443
+                statPrefix: tls-passthrough:*.com
+        - filterChainMatch:
+            serverNames:
+              - abc.example.com
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: gateway-conformance-infra:tls-backend:443
+                statPrefix: tls-passthrough:abc.example.com
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:

--- a/operator/pkg/model/translation/gateway-api/testdata/tls_sni_weighted_backends/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/tls_sni_weighted_backends/cec-output.yaml
@@ -14,23 +14,32 @@ metadata:
     uid: ""
 spec:
   backendServices:
-  - name: my-service
+  - name: backend-v1
     namespace: default
     number:
-    - "8080"
+    - "443"
+  - name: backend-v2
+    namespace: default
+    number:
+    - "443"
   resources:
   - '@type': type.googleapis.com/envoy.config.listener.v3.Listener
     filterChains:
     - filterChainMatch:
         serverNames:
-        - foo.com
+        - test.example.com
         transportProtocol: tls
       filters:
       - name: envoy.filters.network.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: default:my-service:8080
-          statPrefix: tls-passthrough:foo.com
+          statPrefix: tls-passthrough:test.example.com
+          weightedClusters:
+            clusters:
+            - name: default:backend-v1:443
+              weight: 70
+            - name: default:backend-v2:443
+              weight: 30
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:
@@ -55,8 +64,15 @@ spec:
       name: "6"
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
-      serviceName: default/my-service:8080
-    name: default:my-service:8080
+      serviceName: default/backend-v1:443
+    name: default:backend-v1:443
+    outlierDetection:
+      splitExternalLocalOriginErrors: true
+    type: EDS
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    edsClusterConfig:
+      serviceName: default/backend-v2:443
+    name: default:backend-v2:443
     outlierDetection:
       splitExternalLocalOriginErrors: true
     type: EDS

--- a/operator/pkg/model/translation/gateway-api/testdata/tls_sni_weighted_backends/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/tls_sni_weighted_backends/config-input.yaml
@@ -1,0 +1,10 @@
+cluster_config:
+  idle_timeout_seconds: 60
+host_network_config: {}
+ip_config: {}
+listener_config:
+  stream_idle_timeout_seconds: 300
+original_ip_detection_config: {}
+route_config:
+  host_name_suffix_match: true
+secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/tls_sni_weighted_backends/input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/tls_sni_weighted_backends/input.yaml
@@ -1,0 +1,24 @@
+tls_passthrough:
+- hostname: '*'
+  name: prod-web-gw
+  port: 443
+  routes:
+  - backends:
+    - name: backend-v1
+      namespace: default
+      port:
+        port: 443
+      weight: 70
+    - name: backend-v2
+      namespace: default
+      port:
+        port: 443
+      weight: 30
+    hostnames:
+    - test.example.com
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: my-gateway
+    namespace: default
+    version: v1

--- a/operator/pkg/model/translation/gateway-api/testdata/tls_sni_weighted_backends/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/tls_sni_weighted_backends/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: my-gateway
+    io.cilium.gateway/owning-gateway: my-gateway
+  name: cilium-gateway-my-gateway
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: my-gateway
+    uid: ""
+spec:
+  ports:
+  - name: port-443
+    port: 443
+    protocol: TCP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -38,6 +38,7 @@ func Test_translator_Translate(t *testing.T) {
 		{name: "basic_http_listener_external_traffic_policy"},
 		{name: "basic_http_listener_load_balancer"},
 		{name: "basic_tls_sni_listener"},
+		{name: "tls_sni_weighted_backends"},
 		{name: "conformance/httproute_simple_same_namespace"},
 		{name: "conformance/httproute_backend_protocol_h_2_c"},
 		{name: "conformance/httproute_cross_namespace"},


### PR DESCRIPTION
Route TLS passthrough proxy generation by TLSRoute rule so multiple valid Service backends for the same SNI can share one TCP proxy weighted cluster instead of emitting competing single-cluster filter chains. Add translation, ingestion, zero-weight, and duplicate-SNI regression coverage.

This PR was prepared with AIL:3. I personally reviewed each line of the submission prior to opening this PR

Fixes: https://github.com/cilium/cilium/issues/45932

```release-note
bug: fixed weighted backend traffic splitting for TLSRoute passthrough listeners in Gateway API 
```
