### PR TITLE
wireguard:mtu: fix mtu calculation with potential padding

### DIFF
--- a/pkg/mtu/mtu.go
+++ b/pkg/mtu/mtu.go
@@ -58,12 +58,14 @@ const (
 	// encapsulation.
 	//
 	// https://github.com/torvalds/linux/blob/v5.12/drivers/net/wireguard/device.c#L262:
+	// https://github.com/torvalds/linux/blob/v5.12/drivers/net/wireguard/send.c#L141
 	//      MESSAGE_MINIMUM_LENGTH:    32B
 	//      Outer IPv4 or IPv6 header: 40B
 	//      Outer UDP header:           8B
+	//      Maximum padding:           15B
 	//                                 ---
 	//      Total extra bytes:         80B
-	WireguardOverhead = 80
+	WireguardOverhead = 95
 
 	// IPv6MinMTU is the minimum MTU required for IPv6 to function on a
 	// network interface, as defined in RFC 8200 section 5. The Linux kernel

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -266,9 +266,19 @@ func (a *Agent) init() error {
 		return fmt.Errorf("failed to load or generate private key: %w", err)
 	}
 
+	// Best-effort MTU computation: account for WireGuard overhead including padding.
+	// Without this, the kernel defaults to 1500 - 80 = 1420, ignoring alignment padding.
+	// Worst case we set 1500 - 95 = 1405; the mtuReconciler will adjust once the MTU table is populated.
+	deviceMTU := mtu.EthernetMTU
+	if mtuRoute, _, _, found := a.mtuTable.GetWatch(a.db.ReadTxn(), mtu.MTURouteIndex.Query(mtu.DefaultPrefixV4)); found {
+		deviceMTU = mtuRoute.DeviceMTU
+	}
+	linkMTU := deviceMTU - mtu.WireguardOverhead
+
 	link := &netlink.Wireguard{
 		LinkAttrs: netlink.LinkAttrs{
 			Name: types.IfaceName,
+			MTU:  linkMTU,
 		},
 	}
 

--- a/pkg/wireguard/agent/cell_test.go
+++ b/pkg/wireguard/agent/cell_test.go
@@ -60,6 +60,9 @@ import (
 
 var TestTimeout = 5 * time.Second
 
+// Non-default device MTU for testing.
+const TestDeviceMTU = 1480
+
 // paramsOut holds the output parameters needed for running cells in the test.
 type paramsOut struct {
 	cell.Out
@@ -115,7 +118,6 @@ func TestPrivileged_TestWireGuardCell(t *testing.T) {
 	// getHive returns a new hive with Wireguard enabled/disabled.
 	getHive := func(wireguardEnabled bool) *hive.Hive {
 		return hive.New(
-			mtu.Cell,
 			nodeManager.Cell,
 			nodediscovery.Cell,
 			source.Cell,
@@ -137,6 +139,7 @@ func TestPrivileged_TestWireGuardCell(t *testing.T) {
 				newWireguardAgent,
 				newWireguardConfig,
 
+				mtu.NewMTUTable,
 				regeneration.NewFence,
 				tables.NewDeviceTable,
 				tables.NewNodeAddressTable,
@@ -144,6 +147,7 @@ func TestPrivileged_TestWireGuardCell(t *testing.T) {
 				ipcache.NewIPIdentitySynchronizer,
 				statedb.RWTable[*tables.Device].ToTable,
 				statedb.RWTable[tables.NodeAddress].ToTable,
+				statedb.RWTable[mtu.RouteMTU].ToTable,
 
 				func() paramsOut {
 					return paramsOut{
@@ -205,7 +209,17 @@ func TestPrivileged_TestWireGuardCell(t *testing.T) {
 					nodeStore = s
 					ipCache = i
 					cacheStatus = c
-				}),
+				},
+				func(db *statedb.DB, mtuTable statedb.RWTable[mtu.RouteMTU]) {
+					txn := db.WriteTxn(mtuTable)
+					mtuTable.Insert(txn, mtu.RouteMTU{
+						Prefix:    mtu.DefaultPrefixV4,
+						DeviceMTU: TestDeviceMTU,
+						RouteMTU:  TestDeviceMTU - mtu.WireguardOverhead,
+					})
+					txn.Commit()
+				},
+			),
 		)
 	}
 
@@ -224,10 +238,8 @@ func TestPrivileged_TestWireGuardCell(t *testing.T) {
 			link, err := safenetlink.LinkByName(types.IfaceName)
 			require.NoError(t, err)
 
-			// 4. Ensure the MTU is set accordingly (mtu-reconciler job).
-			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				assert.Equal(c, mtu.EthernetMTU-mtu.WireguardOverhead, link.Attrs().MTU)
-			}, TestTimeout, 50*time.Millisecond)
+			// 4. Ensure the MTU is set accordingly.
+			require.Equal(t, TestDeviceMTU-mtu.WireguardOverhead, link.Attrs().MTU)
 
 			// 5. Ensure local node has been updated (localnode-updater job).
 			require.EventuallyWithT(t, func(c *assert.CollectT) {


### PR DESCRIPTION
Prior to this patch, our WireguardOverhead constant was set to 80.
However, as perfectly analyzed in the issue below, WireGuard might add
up to 15 bytes of padding to the incoming packet to align it to a multiple
of 16 bytes, which is the block size of the cipher used. This means that
the actual overhead should be up to 95 bytes, and not 80 as we were
previously assuming.

With an overhead of 80 bytes:

1. 1500-80 = 1420, maximum packet size arriving at cilium_wg0, which is not a multiple of 16.
2. 1420+4 = 1424, therefore WireGuard adds 4 bytes of padding to make it multiple of 16.
3. 1424+80 = 1504, which is larger than the device MTU 1500, and therefore
                   the packet is fragmented at the native device.

The overhead of 95 bytes works in all the cases (mtu 1500, 1480, 9000, etc.).

Fixes: https://github.com/cilium/cilium/issues/23917.