### PR TITLE
policy: Fix data race in resolve tests under -race

### DIFF
--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -126,6 +126,19 @@ func (td *testData) getCachedSelectorForTest(es api.EndpointSelector) CachedSele
 	return cs
 }
 
+func (td *testData) stopNotificationHandlers() {
+	td.sc.StopNotificationHandler()
+	td.subjectSc.StopNotificationHandler()
+}
+
+// assertEqualPolicies stops the SelectorCache notification handlers before
+// comparing, to avoid racing with handleUserNotifications.
+func (td *testData) assertEqualPolicies(t *testing.T, expected, actual any) {
+	t.Helper()
+	td.stopNotificationHandlers()
+	require.EqualExportedValues(t, expected, actual)
+}
+
 // withIDs loads the set of IDs in to the SelectorCache. Returns
 // the same testData for easy chaining.
 func (td *testData) withIDs(initIDs ...identity.IdentityMap) *testData {

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -276,7 +276,7 @@ func TestL3WithIngressDenyWildcard(t *testing.T) {
 		PolicyOwner: DummyOwner{logger: hivetest.Logger(t)},
 	}
 
-	require.EqualExportedValues(t, &expectedEndpointPolicy, policy)
+	td.assertEqualPolicies(t, &expectedEndpointPolicy, policy)
 }
 
 func TestL3WithLocalHostWildcardd(t *testing.T) {
@@ -362,7 +362,7 @@ func TestL3WithLocalHostWildcardd(t *testing.T) {
 		PolicyOwner: DummyOwner{logger: logger},
 	}
 
-	require.EqualExportedValues(t, &expectedEndpointPolicy, policy)
+	td.assertEqualPolicies(t, &expectedEndpointPolicy, policy)
 }
 
 func TestMapStateWithIngressDenyWildcard(t *testing.T) {
@@ -459,7 +459,7 @@ func TestMapStateWithIngressDenyWildcard(t *testing.T) {
 	// compare policyMapState separately
 	require.Truef(t, policy.policyMapState.Equal(&expectedEndpointPolicy.policyMapState), policy.policyMapState.diff(&expectedEndpointPolicy.policyMapState))
 
-	require.EqualExportedValues(t, &expectedEndpointPolicy, policy)
+	td.assertEqualPolicies(t, &expectedEndpointPolicy, policy)
 }
 
 func TestMapStateWithIngressDeny(t *testing.T) {
@@ -620,5 +620,5 @@ func TestMapStateWithIngressDeny(t *testing.T) {
 	// compare policyMapState separately
 	require.Truef(t, policy.policyMapState.Equal(&expectedEndpointPolicy.policyMapState), policy.policyMapState.diff(&expectedEndpointPolicy.policyMapState))
 
-	require.EqualExportedValues(t, &expectedEndpointPolicy, policy)
+	td.assertEqualPolicies(t, &expectedEndpointPolicy, policy)
 }

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -374,7 +374,7 @@ func TestEgressCIDRTCPPort(t *testing.T) {
 	mdl := repo.GetRulesList()
 	require.Contains(t, mdl.Policy, "10.1.1.1")
 
-	require.EqualExportedValues(t, &expectedEndpointPolicy, policy)
+	td.assertEqualPolicies(t, &expectedEndpointPolicy, policy)
 }
 
 func TestEgressWildcardCIDRMatchesWorld(t *testing.T) {
@@ -446,7 +446,7 @@ func TestEgressWildcardCIDRMatchesWorld(t *testing.T) {
 		EgressPolicyEnabled:  true,
 	}
 
-	require.EqualExportedValues(t, expectedPolicy, selPolicy)
+	td.assertEqualPolicies(t, expectedPolicy, selPolicy)
 
 	policy := selPolicy.DistillPolicy(logger, DummyOwner{logger: logger}, testRedirects)
 	policy.Ready()
@@ -540,7 +540,7 @@ func TestL7WithIngressWildcard(t *testing.T) {
 		PolicyOwner: DummyOwner{logger: logger},
 	}
 
-	require.EqualExportedValues(t, &expectedEndpointPolicy, policy)
+	td.assertEqualPolicies(t, &expectedEndpointPolicy, policy)
 }
 
 func TestL7WithLocalHostWildcard(t *testing.T) {
@@ -638,7 +638,7 @@ func TestL7WithLocalHostWildcard(t *testing.T) {
 		PolicyOwner: DummyOwner{logger: logger},
 	}
 
-	require.EqualExportedValues(t, &expectedEndpointPolicy, policy)
+	td.assertEqualPolicies(t, &expectedEndpointPolicy, policy)
 }
 
 func TestMapStateWithIngressWildcard(t *testing.T) {
@@ -731,7 +731,7 @@ func TestMapStateWithIngressWildcard(t *testing.T) {
 	// policyMapState cannot be compared via DeepEqual
 	require.Truef(t, policy.policyMapState.Equal(&expectedEndpointPolicy.policyMapState), policy.policyMapState.diff(&expectedEndpointPolicy.policyMapState))
 
-	require.EqualExportedValues(t, &expectedEndpointPolicy, policy)
+	td.assertEqualPolicies(t, &expectedEndpointPolicy, policy)
 }
 
 func TestMapStateWithIngress(t *testing.T) {
@@ -902,7 +902,7 @@ func TestMapStateWithIngress(t *testing.T) {
 	// policyMapState cannot be compared via DeepEqual
 	require.Truef(t, policy.policyMapState.Equal(&expectedEndpointPolicy.policyMapState), policy.policyMapState.diff(&expectedEndpointPolicy.policyMapState))
 
-	require.EqualExportedValues(t, &expectedEndpointPolicy, policy)
+	td.assertEqualPolicies(t, &expectedEndpointPolicy, policy)
 }
 
 // allowsIdentity returns whether the specified policy allows

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -23,59 +23,38 @@ import (
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 )
 
-// testNewSelectorCache returns a newly initialized SelectorCache and a function used to
-// stop the incremental update notifier goroutine of the new selector cache.
-// Typically the caller would do something like this:
-//
-// sc, closer := testNewSelectorCache(...)
-// defer closer()
-//
-// This way the 'closer' is called right before 'sc' goes out of scope. If 'sc' is returned up the
-// call stack, then the 'closer' should be returned as well so that the defer on it can be done at
-// the right scope.
 func testNewSelectorCache(tb testing.TB, logger *slog.Logger, ids identity.IdentityMap) *SelectorCache {
 	sc := NewSelectorCache(logger, ids)
 	sc.userHandlerDone = make(chan struct{})
-
 	sc.SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
+	tb.Cleanup(sc.StopNotificationHandler)
+	return sc
+}
 
-	tb.Cleanup(func() {
-		sc.userMutex.Lock()
-		defer sc.userMutex.Unlock()
+// StopNotificationHandler drains pending notifications and terminates the
+// handler goroutine. Idempotent.
+func (sc *SelectorCache) StopNotificationHandler() {
+	sc.userMutex.Lock()
+	defer sc.userMutex.Unlock()
 
-		// Only ever execute the termination signaling and wait once
-		if sc.userHandlerDone != nil {
-			handlerWasStarted := true // assume the handler was started
+	if sc.userHandlerDone == nil {
+		return
+	}
 
-			// Execute Once to see if the handler was really started
-			sc.startNotificationsHandlerOnce.Do(func() {
-				// if this executes then the handler was NOT started
-				handlerWasStarted = false
-			})
-
-			if handlerWasStarted {
-				// Append an empty user notification to tell the handler to close
-				sc.userNotes = append(sc.userNotes, userNotification{})
-
-				// Unlock so thet handler is not blocked when it wakes up
-				sc.userMutex.Unlock()
-
-				// tell the handler to wake up
-				sc.userCond.Signal()
-
-				// wait for the handler to process the zero notification and close
-				<-sc.userHandlerDone
-
-				// lock again
-				sc.userMutex.Lock()
-
-				// nil the channel to not wait again for an already done handler
-				sc.userHandlerDone = nil
-			}
-		}
+	handlerWasStarted := true
+	sc.startNotificationsHandlerOnce.Do(func() {
+		handlerWasStarted = false
 	})
 
-	return sc
+	if handlerWasStarted {
+		sc.userNotes = append(sc.userNotes, userNotification{})
+		sc.userMutex.Unlock()
+		sc.userCond.Signal()
+		<-sc.userHandlerDone
+		sc.userMutex.Lock()
+	}
+
+	sc.userHandlerDone = nil
 }
 
 type selectorUpdate struct {


### PR DESCRIPTION
The SelectorCache notification handler races with the
require.EqualExportedValues assertion in the policy tests. :

    WARNING: DATA RACE
    Read at 0x00c00027ebc0 by goroutine 27:
      github.com/stretchr/testify/assert.EqualExportedValues()
      github.com/cilium/cilium/pkg/policy.TestL3WithIngressDenyWildcard()
          pkg/policy/resolve_deny_test.go:279

    Previous write at 0x00c00027ebc0 by goroutine 28:
      sync.(*Cond).Wait()
      github.com/cilium/cilium/pkg/policy.(*SelectorCache).handleUserNotifications()
          pkg/policy/selectorcache.go:380

Reproduced with `go test -count=100 -race ./pkg/policy/` which I
discovered when working on a separate PR in the policy package. I was
able to bisect to 93cca971236, which dropped a call to `detach(true, 0)`
that used to tear the handler down before the assertion.

Fix by wrapping the shutdown and assertion in a td.assertEqualPolicies
helper so future tests cannot forget the shutdown step.

Fixes: 93cca971236 ("policy: Only test exported fields")