### PR TITLE
install/kubernetes: expose minReadySeconds for cilium-agent DaemonSet

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -3176,6 +3176,10 @@
      - Configure maglev consistent hashing
      - object
      - ``{}``
+   * - :spelling:ignore:`minReadySeconds`
+     - Configure minReadySeconds for cilium-agent DaemonSet. This sets the minimum number of seconds a newly-ready pod must remain ready before the rolling update advances to the next pod. Increase this value to give subsystems such as the BGP control plane enough time to re-establish sessions during rolling upgrades. Defaults to 0 (Kubernetes default behavior).
+     - int
+     - ``0``
    * - :spelling:ignore:`monitor`
      - cilium-monitor sidecar.
      - object

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -578,6 +578,7 @@ memcached
 memcd
 microservice
 microservices
+minReadySeconds
 minikube
 misconfiguration
 misconfigured
@@ -671,9 +672,9 @@ powershell
 pprof
 pre
 preconfigured
+preferIpv
 prefilter
 preflight
-preferIpv
 preload
 preloaded
 preloading

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -844,6 +844,7 @@ contributors across the globe, there is almost always someone available to help.
 | localRedirectPolicy | bool | `false` | Enable Local Redirect Policy (deprecated, please use 'localRedirectPolicies.enabled' instead) |
 | logSystemLoad | bool | `false` | Enables periodic logging of system load |
 | maglev | object | `{}` | Configure maglev consistent hashing |
+| minReadySeconds | int | `0` | Configure minReadySeconds for cilium-agent DaemonSet. This sets the minimum number of seconds a newly-ready pod must remain ready before the rolling update advances to the next pod. Increase this value to give subsystems such as the BGP control plane enough time to re-establish sessions during rolling upgrades. Defaults to 0 (Kubernetes default behavior). |
 | monitor | object | `{"enabled":false}` | cilium-monitor sidecar. |
 | monitor.enabled | bool | `false` | Enable the cilium-monitor sidecar. |
 | name | string | `"cilium"` | Agent daemonset name. |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -37,6 +37,9 @@ metadata:
     {{- end }}
     {{- end }}
 spec:
+  {{- with .Values.minReadySeconds }}
+  minReadySeconds: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       k8s-app: cilium

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -4791,6 +4791,9 @@
     "maglev": {
       "type": "object"
     },
+    "minReadySeconds": {
+      "type": "integer"
+    },
     "monitor": {
       "properties": {
         "enabled": {

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -218,6 +218,12 @@ serviceAccounts:
     annotations: {}
 # -- Configure termination grace period for cilium-agent DaemonSet.
 terminationGracePeriodSeconds: 1
+# -- Configure minReadySeconds for cilium-agent DaemonSet. This sets the minimum
+# number of seconds a newly-ready pod must remain ready before the rolling
+# update advances to the next pod. Increase this value to give subsystems such
+# as the BGP control plane enough time to re-establish sessions during rolling
+# upgrades. Defaults to 0 (Kubernetes default behavior).
+minReadySeconds: 0
 # -- Install the cilium agent resources.
 agent: true
 # -- Agent daemonset name.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -221,6 +221,12 @@ serviceAccounts:
     annotations: {}
 # -- Configure termination grace period for cilium-agent DaemonSet.
 terminationGracePeriodSeconds: 1
+# -- Configure minReadySeconds for cilium-agent DaemonSet. This sets the minimum
+# number of seconds a newly-ready pod must remain ready before the rolling
+# update advances to the next pod. Increase this value to give subsystems such
+# as the BGP control plane enough time to re-establish sessions during rolling
+# upgrades. Defaults to 0 (Kubernetes default behavior).
+minReadySeconds: 0
 # -- Install the cilium agent resources.
 agent: true
 # -- Agent daemonset name.


### PR DESCRIPTION
The cilium-agent DaemonSet currently does not allow minReadySeconds to be configured, so the value is always left at its default of 0. This means a new agent pod is considered available as soon as it becomes Ready.

That can be too early for subsystems whose external state takes longer to converge. With BGP Control Plane, the agent pod may become Ready before BGP sessions with upstream peers are re-established. Even after the sessions are established, advertised routes may still need time to propagate before connectivity is fully restored.

Expose spec.minReadySeconds as a top-level Helm value for the cilium-agent DaemonSet. When set, each updated agent pod must remain Ready for the configured amount of time before Kubernetes considers it available and proceeds with the rolling update. In BGP environments, this gives sessions and advertised routes more time to converge before another node is restarted.

```release-note
Add a Helm value to configure minReadySeconds for the cilium-agent DaemonSet, allowing rolling updates to wait longer after each agent pod becomes Ready.
```
