### PR TITLE
lb: skip terminating backends in topology preference

### DIFF
--- a/pkg/loadbalancer/tests/testdata/topology-aware-terminating.txtar
+++ b/pkg/loadbalancer/tests/testdata/topology-aware-terminating.txtar
@@ -1,0 +1,165 @@
+#! --enable-service-topology --lb-test-fault-probability=0.0
+#
+# Regression test for the topology safeguard interaction with terminating
+# endpoints. The EndpointSlice controller computes zone hints only for Ready
+# endpoints, so a Pod in the terminating phase appears in the slice without
+# hints.forZones. Before the fix this hint-less terminating backend would
+# trip the missing-hints safeguard (safeguard #4 at
+# https://kubernetes.io/docs/concepts/services-networking/topology-aware-routing/#safeguards)
+# and disable topology-aware routing for the entire Service.
+#
+
+# Set the node zone label before starting so it's read by the zone watcher.
+test/set-node-labels topology.kubernetes.io/zone=foo
+
+# Start and wait for watchers
+hive start
+
+# Add the service (with topology-mode=auto) and both endpointslices.
+# Both Pods initially Ready with hints for zone 'foo' so that, with the
+# local node in zone 'foo', both are selected.
+k8s/add service.yaml endpointslice1.yaml endpointslice2.yaml
+db/cmp services services.table
+db/cmp backends backends-both-active.table
+db/cmp frontends frontends-both.table
+
+# === Regression: one Pod becomes terminating without hints ===
+# Transform endpointslice2 to a terminating endpoint that has no hints, as
+# the real EndpointSlice controller would produce for a non-Ready Pod.
+# Pre-fix this would have fallen back to all backends (missingHints=true);
+# post-fix the safeguard ignores the terminating backend and only the
+# Ready zone-local endpoint is selected.
+cp endpointslice2.yaml endpointslice2-terminating.yaml
+sed 'ready: true' 'ready: false' endpointslice2-terminating.yaml
+sed 'terminating: false' 'terminating: true' endpointslice2-terminating.yaml
+sed 'forZones:' 'notForZones:' endpointslice2-terminating.yaml
+k8s/update endpointslice2-terminating.yaml
+db/cmp backends backends-one-terminating.table
+db/cmp frontends frontends-only-eps1.table
+
+# === Drain fallback: all Pods terminating ===
+# Once every backend is terminating the safeguard finds no candidates and
+# falls back to the default behaviour, which yields all backends so the
+# graceful-termination drain semantics are preserved.
+cp endpointslice1.yaml endpointslice1-terminating.yaml
+sed 'ready: true' 'ready: false' endpointslice1-terminating.yaml
+sed 'terminating: false' 'terminating: true' endpointslice1-terminating.yaml
+sed 'forZones:' 'notForZones:' endpointslice1-terminating.yaml
+k8s/update endpointslice1-terminating.yaml
+db/cmp backends backends-both-terminating.table
+db/cmp frontends frontends-both-terminating.table
+
+# === Cleanup ===
+k8s/delete endpointslice1-terminating.yaml endpointslice2-terminating.yaml
+db/cmp frontends frontends-none.table
+* db/empty backends
+
+#####
+
+-- services.table --
+Name        Source   PortNames  TrafficPolicy  Flags
+test/echo   k8s      http=80    Cluster        TrafficDistribution=PreferSameZone
+
+-- backends-both-active.table --
+Service    Address              State
+test/echo  10.244.1.1:80/TCP    active
+test/echo  10.244.2.1:80/TCP    active
+
+-- backends-one-terminating.table --
+Service    Address              State
+test/echo  10.244.1.1:80/TCP    active
+test/echo  10.244.2.1:80/TCP    terminating
+
+-- backends-both-terminating.table --
+Service    Address              State
+test/echo  10.244.1.1:80/TCP    terminating
+test/echo  10.244.2.1:80/TCP    terminating
+
+-- frontends-both.table --
+Address               Type        ServiceName   PortName   Status  Backends
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP, 10.244.2.1:80/TCP
+
+-- frontends-only-eps1.table --
+Address               Type        ServiceName   PortName   Status  Backends
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP
+
+-- frontends-both-terminating.table --
+Address               Type        ServiceName   PortName   Status  Backends
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP, 10.244.2.1:80/TCP
+
+-- frontends-none.table --
+Address               Type        ServiceName   PortName   Status   Backends
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+  annotations:
+    service.kubernetes.io/topology-mode: auto
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  type: ClusterIP
+
+-- endpointslice1.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-eps1
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+  zone: "foo"
+  hints:
+    forZones:
+    - name: foo
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+
+-- endpointslice2.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-eps2
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.2.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+  zone: "bar"
+  hints:
+    forZones:
+    - name: foo
+ports:
+- name: http
+  port: 80
+  protocol: TCP

--- a/pkg/loadbalancer/writer/writer.go
+++ b/pkg/loadbalancer/writer/writer.go
@@ -442,8 +442,18 @@ func matchesFrontend(be *loadbalancer.Backend, fe *loadbalancer.Frontend) bool {
 }
 
 // topologyPreferenceCandidate reports whether a backend should participate in
-// same-node and same-zone preference decisions.
+// same-node and same-zone preference decisions. This mirrors kube-proxy's
+// behaviour where topology hint validation considers Ready endpoints only.
 func (w *Writer) topologyPreferenceCandidate(svc *loadbalancer.Service, be *loadbalancer.Backend) bool {
+	// Terminating backends are excluded from hint computation by the
+	// EndpointSlice controller, so they would always lack hints. Including
+	// them here would either spuriously trip the missing-hints safeguard or
+	// pin traffic to a draining Pod.
+	if be.State == loadbalancer.BackendStateTerminating ||
+		be.State == loadbalancer.BackendStateTerminatingNotServing {
+		return false
+	}
+
 	if w.isServiceHealthCheckedFunc == nil || !w.isServiceHealthCheckedFunc(svc) {
 		return true
 	}
@@ -570,8 +580,11 @@ func (w *Writer) DefaultSelectBackends(txn statedb.ReadTxn, bes iter.Seq2[*loadb
 					continue
 				}
 			}
-			if checkZoneHints && !slices.Contains(be.Zone.ForZones, *thisZone) {
-				continue
+			if checkZoneHints {
+				if be.Zone == nil ||
+					!slices.Contains(be.Zone.ForZones, *thisZone) {
+					continue
+				}
 			}
 			if !yield(be, rev) {
 				return

--- a/pkg/loadbalancer/writer/writer_test.go
+++ b/pkg/loadbalancer/writer/writer_test.go
@@ -912,3 +912,139 @@ func TestWriter_SelectBackends_PreferCloseFallsBackFromUnhealthySameZone(t *test
 	assert.Contains(t, addresses, localAddr)
 	assert.Contains(t, addresses, remoteAddr)
 }
+
+// TestWriter_SelectBackends_PreferCloseIgnoresTerminatingForMissingHints verifies
+// that backends in BackendStateTerminating / BackendStateTerminatingNotServing are
+// excluded from the missing-hints safeguard. The EndpointSlice controller does not
+// compute zone hints for non-Ready endpoints, so without this exclusion a single
+// terminating Pod would disable topology-aware routing for the entire Service.
+func TestWriter_SelectBackends_PreferCloseIgnoresTerminatingForMissingHints(t *testing.T) {
+	p := fixture(t)
+	p.Writer.config.EnableServiceTopology = true
+	p.LocalNodeStore.Update(func(n *node.LocalNode) {
+		if n.Labels == nil {
+			n.Labels = map[string]string{}
+		}
+		n.Labels[corev1.LabelTopologyZone] = "zone-a"
+	})
+
+	svcName := loadbalancer.NewServiceName("test", "svc")
+	feAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(1), 80, loadbalancer.ScopeExternal)
+	activeLocalAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(2), 8080, loadbalancer.ScopeExternal)
+	activeRemoteAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(3), 8080, loadbalancer.ScopeExternal)
+	terminatingAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(4), 8080, loadbalancer.ScopeExternal)
+	terminatingNoZoneAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(5), 8080, loadbalancer.ScopeExternal)
+
+	svc := &loadbalancer.Service{
+		Name:                svcName,
+		Source:              source.Kubernetes,
+		TrafficDistribution: loadbalancer.TrafficDistributionPreferClose,
+	}
+	fe := &loadbalancer.Frontend{
+		FrontendParams: loadbalancer.FrontendParams{
+			ServiceName: svcName,
+			Address:     feAddr,
+			Type:        loadbalancer.SVCTypeClusterIP,
+			ServicePort: feAddr.Port(),
+		},
+		Service: svc,
+	}
+	backends := iter.Seq2[*loadbalancer.Backend, statedb.Revision](func(yield func(*loadbalancer.Backend, statedb.Revision) bool) {
+		for i, be := range []*loadbalancer.Backend{
+			{
+				Address: activeLocalAddr,
+				State:   loadbalancer.BackendStateActive,
+				Zone:    &loadbalancer.BackendZone{Zone: "zone-a", ForZones: []string{"zone-a"}},
+			},
+			{
+				Address: activeRemoteAddr,
+				State:   loadbalancer.BackendStateActive,
+				Zone:    &loadbalancer.BackendZone{Zone: "zone-b", ForZones: []string{"zone-b"}},
+			},
+			{
+				// Terminating Pod whose endpoint kept its zone label but has no
+				// ForZones hint. Pre-fix this would have set missingHints=true and
+				// disabled topology routing for the whole Service.
+				Address: terminatingAddr,
+				State:   loadbalancer.BackendStateTerminating,
+				Zone:    &loadbalancer.BackendZone{Zone: "zone-c"},
+			},
+			{
+				// Terminating Pod on a node without a zone label. Pre-fix the
+				// emit loop would have nil-dereferenced be.Zone.ForZones.
+				Address: terminatingNoZoneAddr,
+				State:   loadbalancer.BackendStateTerminatingNotServing,
+			},
+		} {
+			if !yield(be, statedb.Revision(i+1)) {
+				return
+			}
+		}
+	})
+
+	selected := slices.Collect(statedb.ToSeq(p.Writer.SelectBackends(p.DB.ReadTxn(), backends, svc, fe)))
+
+	// Topology safeguard must remain engaged: only the zone-a Active backend
+	// should be selected. Terminating backends are filtered from primary traffic
+	// because their (possibly empty / nil) ForZones cannot match the local zone.
+	require.Len(t, selected, 1)
+	assert.Equal(t, activeLocalAddr.String(), selected[0].Address.String())
+}
+
+// TestWriter_SelectBackends_PreferCloseFallsBackWhenOnlyTerminating verifies that
+// when every backend is terminating, the safeguard reports no candidates and we
+// fall back to the default behaviour (yield all backends), preserving graceful
+// drain semantics. The nil-Zone backend must not panic.
+func TestWriter_SelectBackends_PreferCloseFallsBackWhenOnlyTerminating(t *testing.T) {
+	p := fixture(t)
+	p.Writer.config.EnableServiceTopology = true
+	p.LocalNodeStore.Update(func(n *node.LocalNode) {
+		if n.Labels == nil {
+			n.Labels = map[string]string{}
+		}
+		n.Labels[corev1.LabelTopologyZone] = "zone-a"
+	})
+
+	svcName := loadbalancer.NewServiceName("test", "svc")
+	feAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(1), 80, loadbalancer.ScopeExternal)
+	terminatingAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(2), 8080, loadbalancer.ScopeExternal)
+	terminatingNoZoneAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(3), 8080, loadbalancer.ScopeExternal)
+
+	svc := &loadbalancer.Service{
+		Name:                svcName,
+		Source:              source.Kubernetes,
+		TrafficDistribution: loadbalancer.TrafficDistributionPreferClose,
+	}
+	fe := &loadbalancer.Frontend{
+		FrontendParams: loadbalancer.FrontendParams{
+			ServiceName: svcName,
+			Address:     feAddr,
+			Type:        loadbalancer.SVCTypeClusterIP,
+			ServicePort: feAddr.Port(),
+		},
+		Service: svc,
+	}
+	backends := iter.Seq2[*loadbalancer.Backend, statedb.Revision](func(yield func(*loadbalancer.Backend, statedb.Revision) bool) {
+		for i, be := range []*loadbalancer.Backend{
+			{
+				Address: terminatingAddr,
+				State:   loadbalancer.BackendStateTerminating,
+				Zone:    &loadbalancer.BackendZone{Zone: "zone-a"},
+			},
+			{
+				Address: terminatingNoZoneAddr,
+				State:   loadbalancer.BackendStateTerminating,
+			},
+		} {
+			if !yield(be, statedb.Revision(i+1)) {
+				return
+			}
+		}
+	})
+
+	selected := slices.Collect(statedb.ToSeq(p.Writer.SelectBackends(p.DB.ReadTxn(), backends, svc, fe)))
+	require.Len(t, selected, 2)
+	addresses := []loadbalancer.L3n4Addr{selected[0].Address, selected[1].Address}
+	assert.Contains(t, addresses, terminatingAddr)
+	assert.Contains(t, addresses, terminatingNoZoneAddr)
+}


### PR DESCRIPTION
## Description

The Kubernetes EndpointSlice controller only computes topology hints
for `Ready` endpoints, so endpoints backed by a terminating Pod always
have an empty `hints.forZones` list.

`DefaultSelectBackends`'s missing-hints safeguard previously inspected
every backend, including terminating ones. As a result a single
terminating Pod would set `missingHints=true` and disable
topology-aware routing for the entire Service until the Pod was fully
removed. The `PreferSameNode` path had the same shape of bug: a
terminating Pod on the local node was still picked as a same-node
candidate and pinned traffic to a draining Pod.

This change folds the exclusion into `topologyPreferenceCandidate` so
both same-node and same-zone preference decisions ignore terminating
backends. This mirrors kube-proxy's behaviour in
[`pkg/proxy/topology.go`](https://github.com/kubernetes/kubernetes/blob/master/pkg/proxy/topology.go)
where the topology hint check considers `Ready` endpoints only and
terminating endpoints are used only as a fallback when no `Ready`
candidates exist.

Also adds a nil-guard for `be.Zone` in the emit loop: a terminating
backend on a node without a `topology.kubernetes.io/zone` label may
have `be.Zone == nil`, and the previous code would have dereferenced
it directly once terminating backends started leaking past the
safeguard in some edge configurations.

### Tests

Two new unit tests in `pkg/loadbalancer/writer/writer_test.go`:

- `TestWriter_SelectBackends_PreferCloseIgnoresTerminatingForMissingHints`
  — verifies that `Active` backends with hints + a `Terminating`
  backend without hints no longer trip the missing-hints safeguard;
  only the zone-local `Active` backend is selected. Confirmed to fail
  without the fix.
- `TestWriter_SelectBackends_PreferCloseFallsBackWhenOnlyTerminating`
  — verifies the all-terminating fallback path (drain semantics) and
  guards against an `nil`-`Zone` panic regression.

The existing
`TestWriter_SelectBackends_PreferCloseFallsBackFromUnhealthySameZone`
continues to pass without modification.

## AI assistance

This PR was prepared with **AIL:3**. I personally reviewed each line
of the submission prior to opening this PR. AI assistance was used
during root-cause analysis, code drafting, and test authoring; the
choice to fold the terminating-skip into `topologyPreferenceCandidate`
(rather than keep it inline at the safeguard call site) was made by me
after reviewing the alternative.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Write a short paragraph that states whether you used machine learning models
      (including LLMs and other generative AI), and indicate the rating using
      [AI Influence Level](https://danielmiessler.com/blog/ai-influence-level-ail).
      Example: "This PR was prepared with AIL:3. I personally reviewed each line
      of the submission prior to opening this PR."
- [x] Thanks for contributing!

```release-note
lb: don't disable topology-aware routing because of a terminating Pod
```