### PR TITLE
ci:bpftrace: fail curl with corrupted binary download

### DIFF
--- a/.github/actions/bpftrace/start/action.yaml
+++ b/.github/actions/bpftrace/start/action.yaml
@@ -25,7 +25,7 @@ runs:
             # https://github.com/bpftrace/bpftrace/issues/3011
             # Let's buy us some time, and keep installing v0.19.1 for the moment.
 
-            curl -L https://github.com/bpftrace/bpftrace/releases/download/v0.19.1/bpftrace -o bpftrace
+            curl -fL https://github.com/bpftrace/bpftrace/releases/download/v0.19.1/bpftrace -o bpftrace
             install -m 755 bpftrace /usr/local/bin/bpftrace
 
           fi


### PR DESCRIPTION
When downloading the bpftrace binary from GitHub releases, the download can sometimes fail due to many problems (e.g., GitHub downtime). In these cases, we should fail the workflow, given the `bpftrace` binary is actually an HTML page with an error message (e.g., 404 not found). The error message observed in CI runs is:

```
Unexpected error reported by bpftrace
/usr/local/bin/bpftrace: line 1: syntax error near unexpected token `newline'
/usr/local/bin/bpftrace: line 1: `<!DOCTYPE html>'
```