### PR TITLE
loadbalancer: support multiple proxy redirects per service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/cilium/hive v1.0.1
 	github.com/cilium/lumberjack/v2 v2.4.2
 	github.com/cilium/proxy v0.0.0-20260508102643-7c2f6580d32e
-	github.com/cilium/statedb v0.8.0
+	github.com/cilium/statedb v0.8.1
 	github.com/cilium/stream v0.0.1
 	github.com/cilium/workerpool v1.4.0
 	github.com/cloudflare/cfssl v1.6.5

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,8 @@ github.com/cilium/lumberjack/v2 v2.4.2 h1:Wea2z1+ikRhjS5z36I6vgeMlgh7xzvIzqW+t9t
 github.com/cilium/lumberjack/v2 v2.4.2/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
 github.com/cilium/proxy v0.0.0-20260508102643-7c2f6580d32e h1:cYDQ14gFlagSSdv/bGvorajxP6LLQON2P8O55f8yZDM=
 github.com/cilium/proxy v0.0.0-20260508102643-7c2f6580d32e/go.mod h1:HAaqzi0id8SvQ1EL+Om/oW7mwL6lMoJdUFDQsXJL0M8=
-github.com/cilium/statedb v0.8.0 h1:Tm3ioI+pjHHmLvY4QTNv0kZHxXlzGQwvV4A/k+wHeLk=
-github.com/cilium/statedb v0.8.0/go.mod h1:Dtp96Hmwcw7DJj9kIa2MfkX5Irk4KVyITN40fXyolio=
+github.com/cilium/statedb v0.8.1 h1:7TdFU4/cQwWRnDhX2tsYg9YefUfJ56I0OYi4xR3CmNo=
+github.com/cilium/statedb v0.8.1/go.mod h1:Dtp96Hmwcw7DJj9kIa2MfkX5Irk4KVyITN40fXyolio=
 github.com/cilium/stream v0.0.1 h1:82zuM/WwkLiac2Jg5FrzPxZHvIBbxXTi4VY7M+EYLs0=
 github.com/cilium/stream v0.0.1/go.mod h1:/e83AwqvNKpyg4n3C41qmnmj1x2G9DwzI+jb7GkF4lI=
 github.com/cilium/workerpool v1.4.0 h1:Tn0e2Ie1THjepOnj5PobkhZ3CLknostEcKRvEGvbY/Y=

--- a/pkg/bgp/manager/reconciler/service.go
+++ b/pkg/bgp/manager/reconciler/service.go
@@ -184,7 +184,6 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, p ReconcileParams) er
 	}
 
 	err = r.reconcileServices(ctx, p, &metadata, desiredPeerAdverts, reqFullReconcile)
-
 	if err != nil {
 		// Preserve partial router state without committing desired advertisements or other metadata.
 		currentMetadata := r.getMetadata(p.BGPInstance)
@@ -647,10 +646,10 @@ func (r *ServiceReconciler) getLoadBalancerIPPaths(p ReconcileParams, svc *loadb
 	}
 
 	// Check if this service has a local proxy (Envoy) handling its traffic.
-	// ProxyRedirect is non-nil when the local Envoy proxy is running and configured
+	// ProxyRedirects is non-empty when the local Envoy proxy is running and configured
 	// to handle this service (e.g., Gateway API or Ingress services).
 	// This handles deployments where cilium-envoy has a nodeSelector that excludes some nodes.
-	hasLocalProxy := svc.ProxyRedirect != nil
+	hasLocalProxy := !svc.ProxyRedirects.Empty()
 
 	for _, fe := range frontends {
 		if fe.Type != loadbalancer.SVCTypeLoadBalancer {

--- a/pkg/bgp/manager/reconciler/service_test.go
+++ b/pkg/bgp/manager/reconciler/service_test.go
@@ -117,17 +117,17 @@ var (
 		ExtTrafficPolicy: loadbalancer.SVCTrafficPolicyCluster,
 		IntTrafficPolicy: loadbalancer.SVCTrafficPolicyLocal,
 	}
-	// redSvcExtTPLocalWithProxy is a service with eTP=Local and ProxyRedirect set,
+	// redSvcExtTPLocalWithProxy is a service with eTP=Local and ProxyRedirects set,
 	// simulating a Gateway API / Ingress service where local Envoy handles traffic.
 	redSvcExtTPLocalWithProxy = &loadbalancer.Service{
 		Name:             redSvcName,
 		Labels:           redSvcLabels,
 		ExtTrafficPolicy: loadbalancer.SVCTrafficPolicyLocal,
 		IntTrafficPolicy: loadbalancer.SVCTrafficPolicyCluster,
-		ProxyRedirect: &loadbalancer.ProxyRedirect{
+		ProxyRedirects: loadbalancer.ProxyRedirects{{
 			ProxyPort: 10000,
 			Ports:     []uint16{80, 443},
-		},
+		}},
 	}
 	redSvc2TPCluster = &loadbalancer.Service{
 		Name:             redSvc2Name,

--- a/pkg/bgp/test/commands/svc.go
+++ b/pkg/bgp/test/commands/svc.go
@@ -72,12 +72,12 @@ func SvcSetProxyRedirectCmd(w *writer.Writer) script.Cmd {
 					return "", "", fmt.Errorf("service %s not found", svcName)
 				}
 
-				// Clone and set ProxyRedirect
+				// Clone and set ProxyRedirects
 				svc = svc.Clone()
-				svc.ProxyRedirect = &loadbalancer.ProxyRedirect{
+				svc.ProxyRedirects = loadbalancer.ProxyRedirects{{
 					ProxyPort: proxyPort,
 					Ports:     []uint16{80, 443},
-				}
+				}}
 
 				// UpsertService also calls updateServiceReferences internally,
 				// which updates all frontends to point to the new service.

--- a/pkg/ciliumenvoyconfig/controller.go
+++ b/pkg/ciliumenvoyconfig/controller.go
@@ -232,12 +232,16 @@ func (c *cecProcessor) processCEC(wtxn statedb.WriteTxn, cecName CECName) *state
 	ws := statedb.NewWatchSet()
 	ws.Add(watch)
 
-	var redirects part.Map[loadbalancer.ServiceName, *loadbalancer.ProxyRedirect]
+	var redirects part.Map[loadbalancer.ServiceName, loadbalancer.ProxyRedirects]
 	for _, l := range cec.Spec.Services {
-		redirects = redirects.Set(l.ServiceName(), getProxyRedirect(cec, l))
+		pr := getProxyRedirect(cec, l)
+		if pr != nil {
+			existing, _ := redirects.Get(l.ServiceName())
+			redirects = redirects.Set(l.ServiceName(), append(existing, *pr))
+		}
 
 		// Watch changes for each of the referenced services to make sure we reprocess the CEC
-		// and set the ProxyRedirect in cases where CEC was created before the Service.
+		// and set the ProxyRedirects in cases where CEC was created before the Service.
 		_, _, watchSvc, _ := c.writer.Services().GetWatch(wtxn, loadbalancer.ServiceByName(l.ServiceName()))
 		ws.Add(watchSvc)
 	}

--- a/pkg/ciliumenvoyconfig/reconciler.go
+++ b/pkg/ciliumenvoyconfig/reconciler.go
@@ -45,7 +45,7 @@ func (ops *envoyOps) Delete(ctx context.Context, _ statedb.ReadTxn, _ statedb.Re
 			svc, _, found := ops.writer.Services().Get(wtxn, loadbalancer.ServiceByName(name))
 			if found {
 				svc = svc.Clone()
-				svc.ProxyRedirect = nil
+				svc.ProxyRedirects = nil
 				ops.writer.UpsertService(wtxn, svc)
 			}
 		}
@@ -224,11 +224,11 @@ func (ops *envoyOps) Update(ctx context.Context, txn statedb.ReadTxn, _ statedb.
 		if res.Redirects.Len() > 0 || res.ReconciledRedirects.Len() > 0 {
 			wtxn := ops.writer.WriteTxn()
 			orphanRedirects := res.ReconciledRedirects
-			for name, redirect := range res.Redirects.All() {
+			for name, redirects := range res.Redirects.All() {
 				svc, _, found := ops.writer.Services().Get(wtxn, loadbalancer.ServiceByName(name))
-				if found && !svc.ProxyRedirect.Equal(redirect) {
+				if found && !svc.ProxyRedirects.Equal(redirects) {
 					svc = svc.Clone()
-					svc.ProxyRedirect = redirect
+					svc.ProxyRedirects = redirects
 					ops.writer.UpsertService(wtxn, svc)
 				}
 				orphanRedirects = orphanRedirects.Delete(name)
@@ -238,7 +238,7 @@ func (ops *envoyOps) Update(ctx context.Context, txn statedb.ReadTxn, _ statedb.
 					svc, _, found := ops.writer.Services().Get(wtxn, loadbalancer.ServiceByName(name))
 					if found {
 						svc = svc.Clone()
-						svc.ProxyRedirect = nil
+						svc.ProxyRedirects = nil
 						ops.writer.UpsertService(wtxn, svc)
 					}
 				}

--- a/pkg/ciliumenvoyconfig/tables.go
+++ b/pkg/ciliumenvoyconfig/tables.go
@@ -181,10 +181,10 @@ type EnvoyResource struct {
 
 	// Redirects are the proxy redirects to set. Redirection of services is performed after
 	// the resources have been reconciled to Envoy.
-	Redirects part.Map[loadbalancer.ServiceName, *loadbalancer.ProxyRedirect]
+	Redirects part.Map[loadbalancer.ServiceName, loadbalancer.ProxyRedirects]
 
 	// ReconciledRedirects are the redirects that were successfully set.
-	ReconciledRedirects part.Map[loadbalancer.ServiceName, *loadbalancer.ProxyRedirect]
+	ReconciledRedirects part.Map[loadbalancer.ServiceName, loadbalancer.ProxyRedirects]
 
 	ReferencedServices part.Set[loadbalancer.ServiceName]
 

--- a/pkg/ciliumenvoyconfig/testdata/anyport.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/anyport.txtar
@@ -60,7 +60,7 @@ test/echo
 
 -- services_redirected.table --
 Name        Flags
-test/echo   ProxyRedirect=1000
+test/echo   ProxyRedirects=1000
 
 -- backends.table --
 Address

--- a/pkg/ciliumenvoyconfig/testdata/backendservices.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/backendservices.txtar
@@ -57,7 +57,7 @@ test/frontend
 Name                      Flags
 test/backend
 test/backend_unnamed_port
-test/frontend             ProxyRedirect=1000 (ports: [80])
+test/frontend             ProxyRedirects=1000 (ports: [80])
 
 -- frontends1.table --
 Address            Type        ServiceName     PortName   Backends           Status   Error

--- a/pkg/ciliumenvoyconfig/testdata/clusterwide.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/clusterwide.txtar
@@ -55,7 +55,7 @@ test/echo2
 
 -- services_redirected.table --
 Name        Flags
-test/echo2  ProxyRedirect=1000
+test/echo2  ProxyRedirects=1000
 
 -- cec.table --
 Name                  Selected  Services    Listeners

--- a/pkg/ciliumenvoyconfig/testdata/ingress.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/ingress.txtar
@@ -37,7 +37,7 @@ lb/maps-dump maps.actual
 
 -- services.table --
 Name                                  Source  PortNames           TrafficPolicy  Flags
-default/cilium-ingress-basic-ingress  k8s     http=80, https=443  Cluster        ProxyRedirect=1000 (ports: [80])
+default/cilium-ingress-basic-ingress  k8s     http=80, https=443  Cluster        ProxyRedirects=1000 (ports: [80])
 default/details                       k8s     http=9080           Cluster
 default/productpage                   k8s     http=9080           Cluster
 

--- a/pkg/ciliumenvoyconfig/testdata/marshalling.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/marshalling.txtar
@@ -367,23 +367,27 @@ spec:
   "Redirects": [
     {
       "k": "test/echo",
-      "v": {
-        "ProxyPort": 1000,
-        "Ports": [
-          80
-        ]
-      }
+      "v": [
+        {
+          "ProxyPort": 1000,
+          "Ports": [
+            80
+          ]
+        }
+      ]
     }
   ],
   "ReconciledRedirects": [
     {
       "k": "test/echo",
-      "v": {
-        "ProxyPort": 1000,
-        "Ports": [
-          80
-        ]
-      }
+      "v": [
+        {
+          "ProxyPort": 1000,
+          "Ports": [
+            80
+          ]
+        }
+      ]
     }
   ],
   "ReferencedServices": [

--- a/pkg/ciliumenvoyconfig/testdata/multi-port-redirect.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/multi-port-redirect.txtar
@@ -1,0 +1,136 @@
+# Test handling of CiliumEnvoyConfig with multiple proxy redirects to different
+# ports on the same service. This validates the fix for the bug where the second
+# ServiceListener entry for the same service would overwrite the first, leaving
+# one port without an L7 redirect in the BPF LB map.
+#
+# Scenario: A Gateway with two listeners (HTTP on port 80, HTTPS on port 443)
+# targeting the same backend service. Each listener should produce a separate
+# ProxyRedirect entry, and both frontends should get L7 proxy redirection.
+
+hive start
+
+# Set up the service and endpoints
+k8s/add service.yaml endpointslice.yaml
+
+# Validate initial state (no proxy redirect yet)
+db/cmp services services.table
+db/cmp frontends frontends.table
+
+# Add the CiliumEnvoyConfig with two service entries for the same service,
+# each targeting a different port.
+k8s/add cec.yaml
+db/cmp ciliumenvoyconfigs cec.table
+
+# Both ports should now have proxy redirects.
+db/cmp services services_redirected.table
+
+# Check BPF maps. Port 80 gets proxy port 1000, port 443 gets proxy port 2000.
+lb/maps-dump lbmaps.out
+* grep '10.96.50.104:80/TCP.*L7Proxy=1000' lbmaps.out
+* grep '10.96.50.104:443/TCP.*L7Proxy=2000' lbmaps.out
+
+# Remove the CEC and verify redirects are cleared.
+k8s/delete cec.yaml
+db/cmp services services.table
+
+# ---------------------------------------------
+
+-- services.table --
+Name          Flags
+test/gateway
+
+-- services_redirected.table --
+Name          Flags
+test/gateway  ProxyRedirects=[1000 (ports: [80]), 2000 (ports: [443])]
+
+-- frontends.table --
+Address                Type       ServiceName   PortName  Status  Backends
+10.96.50.104:80/TCP    ClusterIP  test/gateway  http      Done    10.244.1.1:8080/TCP
+10.96.50.104:443/TCP   ClusterIP  test/gateway  https     Done    10.244.1.1:8443/TCP
+
+-- cec.table --
+Name                   Services
+test/gateway-cec       test/gateway, test/gateway
+
+-- cec.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumEnvoyConfig
+metadata:
+  name: gateway-cec
+  namespace: test
+spec:
+  services:
+    - name: gateway
+      namespace: test
+      listener: http-listener
+      ports:
+      - 80
+    - name: gateway
+      namespace: test
+      listener: https-listener
+      ports:
+      - 443
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      name: http-listener
+      address:
+        socket_address:
+          address: 127.0.0.1
+          port_value: 1000
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      name: https-listener
+      address:
+        socket_address:
+          address: 127.0.0.1
+          port_value: 2000
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway
+  namespace: test
+  uid: b59fe99c-3564-4754-acc4-780f2331a49b
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app: gateway
+  type: ClusterIP
+status: {}
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: gateway
+  name: gateway-eps1
+  namespace: test
+  uid: e1f517f6-ab88-4c76-9bd0-4906a17cdd75
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: testnode
+ports:
+- name: http
+  port: 8080
+  protocol: TCP
+- name: https
+  port: 8443
+  protocol: TCP

--- a/pkg/ciliumenvoyconfig/testdata/namespaced.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/namespaced.txtar
@@ -82,7 +82,7 @@ test/echo
 
 -- services_redirected.table --
 Name        Flags
-test/echo   ProxyRedirect=1000 (ports: [80])
+test/echo   ProxyRedirects=1000 (ports: [80])
 
 -- backends.table --
 Address

--- a/pkg/ciliumenvoyconfig/testdata/shared_cluster.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/shared_cluster.txtar
@@ -66,7 +66,7 @@ test/echo
 
 -- services_redirected.table --
 Name        Flags
-test/echo   ProxyRedirect=1000 (ports: [80])
+test/echo   ProxyRedirects=1000 (ports: [80])
 
 -- backends.table --
 Address

--- a/pkg/ciliumenvoyconfig/testdata/terminating.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/terminating.txtar
@@ -41,7 +41,7 @@ test/echo
 
 -- services_redirected.table --
 Name        Flags
-test/echo   ProxyRedirect=1000 (ports: [80])
+test/echo   ProxyRedirects=1000 (ports: [80])
 
 -- backends.table --
 Address              State        PortNames

--- a/pkg/loadbalancer/frontend.go
+++ b/pkg/loadbalancer/frontend.go
@@ -43,7 +43,7 @@ type FrontendParams struct {
 	// ServicePort is the associated "ClusterIP" port of this frontend.
 	// Same as [Address.L4Addr.Port] except when [Type] NodePort or
 	// LoadBalancer. This is used to match frontends with the [Ports] of
-	// [Service.ProxyRedirect].
+	// [Service.ProxyRedirects].
 	ServicePort uint16
 }
 
@@ -201,7 +201,7 @@ func (fe *Frontend) ToModel() *models.Service {
 		spec.BackendAddresses = append(spec.BackendAddresses, backendModel(be))
 	}
 
-	if svc.ProxyRedirect != nil {
+	if pr := svc.ProxyRedirects.ForPort(fe.ServicePort); pr != nil {
 		state, _ := BackendStateActive.String()
 		localhost := "127.0.0.1"
 		if fe.Address.AddrCluster().Is6() {
@@ -211,7 +211,7 @@ func (fe *Frontend) ToModel() *models.Service {
 		spec.BackendAddresses = append(spec.BackendAddresses, &models.BackendAddress{
 			IP:        &localhost,
 			Protocol:  fe.Address.Protocol(),
-			Port:      svc.ProxyRedirect.ProxyPort,
+			Port:      pr.ProxyPort,
 			State:     state,
 			Preferred: true,
 		})

--- a/pkg/loadbalancer/healthserver/healthserver.go
+++ b/pkg/loadbalancer/healthserver/healthserver.go
@@ -321,7 +321,7 @@ type httpHealthServer struct {
 func (h *httpHealthServer) getLocalEndpointCount() int {
 	txn := h.db.ReadTxn()
 	svc, _, found := h.services.Get(txn, lb.ServiceByName(h.name))
-	if found && svc.ProxyRedirect != nil {
+	if found && !svc.ProxyRedirects.Empty() {
 		// Traffic is redirected to a proxy and thus we have no information on
 		// the actual backends. Return a synthetic single backend in this case.
 		return 1

--- a/pkg/loadbalancer/healthserver/script_test.go
+++ b/pkg/loadbalancer/healthserver/script_test.go
@@ -228,10 +228,10 @@ func svcSetProxyRedirectCmd(writer *writer.Writer) script.Cmd {
 				}
 
 				svc = svc.Clone()
-				svc.ProxyRedirect = &loadbalancer.ProxyRedirect{
+				svc.ProxyRedirects = loadbalancer.ProxyRedirects{{
 					ProxyPort: proxyPort,
 					Ports:     []uint16{80, 443},
-				}
+				}}
 
 				if _, err := writer.UpsertService(wtxn, svc); err != nil {
 					return "", "", fmt.Errorf("failed to upsert service: %w", err)

--- a/pkg/loadbalancer/proxy_redirects_test.go
+++ b/pkg/loadbalancer/proxy_redirects_test.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package loadbalancer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProxyRedirects_ForPort(t *testing.T) {
+	tests := []struct {
+		name      string
+		redirects ProxyRedirects
+		port      uint16
+		want      *ProxyRedirect
+	}{
+		{
+			name:      "nil redirects",
+			redirects: nil,
+			port:      80,
+			want:      nil,
+		},
+		{
+			name:      "empty redirects",
+			redirects: ProxyRedirects{},
+			port:      80,
+			want:      nil,
+		},
+		{
+			name: "exact port match",
+			redirects: ProxyRedirects{
+				{ProxyPort: 1000, Ports: []uint16{80}},
+				{ProxyPort: 2000, Ports: []uint16{443}},
+			},
+			port: 443,
+			want: &ProxyRedirect{ProxyPort: 2000, Ports: []uint16{443}},
+		},
+		{
+			name: "wildcard match when no exact match",
+			redirects: ProxyRedirects{
+				{ProxyPort: 1000},
+			},
+			port: 8080,
+			want: &ProxyRedirect{ProxyPort: 1000},
+		},
+		{
+			name: "exact match preferred over wildcard (wildcard first)",
+			redirects: ProxyRedirects{
+				{ProxyPort: 1000}, // wildcard
+				{ProxyPort: 2000, Ports: []uint16{80}},
+			},
+			port: 80,
+			want: &ProxyRedirect{ProxyPort: 2000, Ports: []uint16{80}},
+		},
+		{
+			name: "exact match preferred over wildcard (exact first)",
+			redirects: ProxyRedirects{
+				{ProxyPort: 2000, Ports: []uint16{80}},
+				{ProxyPort: 1000}, // wildcard
+			},
+			port: 80,
+			want: &ProxyRedirect{ProxyPort: 2000, Ports: []uint16{80}},
+		},
+		{
+			name: "wildcard fallback when port not in any exact set",
+			redirects: ProxyRedirects{
+				{ProxyPort: 1000}, // wildcard
+				{ProxyPort: 2000, Ports: []uint16{443}},
+			},
+			port: 8080,
+			want: &ProxyRedirect{ProxyPort: 1000},
+		},
+		{
+			name: "no match when port not in any set and no wildcard",
+			redirects: ProxyRedirects{
+				{ProxyPort: 1000, Ports: []uint16{80}},
+				{ProxyPort: 2000, Ports: []uint16{443}},
+			},
+			port: 8080,
+			want: nil,
+		},
+		{
+			name: "multi-port redirect matches any listed port",
+			redirects: ProxyRedirects{
+				{ProxyPort: 1000, Ports: []uint16{80, 443}},
+			},
+			port: 443,
+			want: &ProxyRedirect{ProxyPort: 1000, Ports: []uint16{80, 443}},
+		},
+		{
+			name: "first wildcard wins when multiple wildcards exist",
+			redirects: ProxyRedirects{
+				{ProxyPort: 1000},
+				{ProxyPort: 2000},
+			},
+			port: 80,
+			want: &ProxyRedirect{ProxyPort: 1000},
+		},
+		{
+			name: "multiple redirects different ports",
+			redirects: ProxyRedirects{
+				{ProxyPort: 1000, Ports: []uint16{80}},
+				{ProxyPort: 2000, Ports: []uint16{443}},
+				{ProxyPort: 3000, Ports: []uint16{8080}},
+			},
+			port: 8080,
+			want: &ProxyRedirect{ProxyPort: 3000, Ports: []uint16{8080}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.redirects.ForPort(tt.port)
+			if tt.want == nil {
+				assert.Nil(t, got)
+			} else {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestProxyRedirects_Redirects(t *testing.T) {
+	redirects := ProxyRedirects{
+		{ProxyPort: 1000, Ports: []uint16{80}},
+		{ProxyPort: 2000, Ports: []uint16{443}},
+	}
+
+	assert.True(t, redirects.Redirects(80))
+	assert.True(t, redirects.Redirects(443))
+	assert.False(t, redirects.Redirects(8080))
+}
+
+func TestProxyRedirects_Empty(t *testing.T) {
+	assert.True(t, ProxyRedirects(nil).Empty())
+	assert.True(t, ProxyRedirects{}.Empty())
+	assert.False(t, ProxyRedirects{{ProxyPort: 1000}}.Empty())
+}
+
+func TestProxyRedirects_Equal(t *testing.T) {
+	a := ProxyRedirects{
+		{ProxyPort: 1000, Ports: []uint16{80}},
+		{ProxyPort: 2000, Ports: []uint16{443}},
+	}
+	b := ProxyRedirects{
+		{ProxyPort: 1000, Ports: []uint16{80}},
+		{ProxyPort: 2000, Ports: []uint16{443}},
+	}
+	c := ProxyRedirects{
+		{ProxyPort: 1000, Ports: []uint16{80}},
+	}
+
+	assert.True(t, a.Equal(b))
+	assert.False(t, a.Equal(c))
+	assert.True(t, ProxyRedirects(nil).Equal(nil))
+}
+
+func TestProxyRedirects_String(t *testing.T) {
+	assert.Empty(t, ProxyRedirects(nil).String())
+	assert.Equal(t, "1000 (ports: [80])", ProxyRedirects{{ProxyPort: 1000, Ports: []uint16{80}}}.String())
+	assert.Equal(t, "[1000 (ports: [80]), 2000 (ports: [443])]",
+		ProxyRedirects{
+			{ProxyPort: 1000, Ports: []uint16{80}},
+			{ProxyPort: 2000, Ports: []uint16{443}},
+		}.String())
+}

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -828,7 +828,7 @@ func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend, isLocalAddr func(ne
 
 	// Check for invalid feature combinations to catch bugs at the upper layers.
 	switch {
-	case svc.SessionAffinity && svc.ProxyRedirect != nil:
+	case svc.SessionAffinity && !svc.ProxyRedirects.Empty():
 		return fmt.Errorf("invalid feature combination: SessionAffinity with proxy redirection is not supported")
 	case svc.LoopbackHostPort && proxyDelegation != loadbalancer.SVCProxyDelegationNone:
 		return fmt.Errorf("invalid feature combination: HostPort loopback with proxy delegation is not supported ")
@@ -893,7 +893,7 @@ func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend, isLocalAddr func(ne
 		IsRoutable:       isRoutable,
 		CheckSourceRange: checkSourceRange,
 		SourceRangeDeny:  checkSourceRange && svc.GetSourceRangesPolicy() == loadbalancer.SVCSourceRangesPolicyDeny,
-		L7LoadBalancer:   svc.ProxyRedirect.Redirects(fe.ServicePort),
+		L7LoadBalancer:   svc.ProxyRedirects.Redirects(fe.ServicePort),
 		LoopbackHostport: svc.LoopbackHostPort || proxyDelegation != loadbalancer.SVCProxyDelegationNone,
 		Quarantined:      false,
 	})
@@ -1090,7 +1090,7 @@ func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend, isLocalAddr func(ne
 	ops.log.Debug("Update master service",
 		logfields.ID, feID,
 		logfields.Type, fe.Type,
-		logfields.ProxyRedirect, fe.Service.ProxyRedirect,
+		logfields.ProxyRedirect, fe.Service.ProxyRedirects,
 		logfields.Address, fe.Address,
 		logfields.Count, backendCount,
 		logfieldActiveCount, activeCount,
@@ -1230,8 +1230,8 @@ func (ops *BPFOps) upsertMaster(svcKey maps.ServiceKey, svcVal maps.ServiceValue
 			return err
 		}
 	}
-	if svc.ProxyRedirect.Redirects(fe.ServicePort) {
-		svcVal.SetL7LBProxyPort(svc.ProxyRedirect.ProxyPort)
+	if pr := svc.ProxyRedirects.ForPort(fe.ServicePort); pr != nil {
+		svcVal.SetL7LBProxyPort(pr.ProxyPort)
 	}
 	return ops.upsertService(svcKey, svcVal)
 }
@@ -1318,7 +1318,6 @@ func (ops *BPFOps) upsertRevNat(id loadbalancer.ServiceID, svcKey maps.ServiceKe
 		return fmt.Errorf("Unable to update reverse NAT %+v => %+v: %w", revNATKey, revNATValue, err)
 	}
 	return nil
-
 }
 
 type backendWithRevision struct {

--- a/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
@@ -114,7 +114,6 @@ func parseAddrPort(s string) loadbalancer.L3n4Addr {
 		loadbalancer.TCP,
 		addr, uint16(port), loadbalancer.ScopeExternal,
 	)
-
 }
 
 func dumpLBMapsWithReplace(lbmaps maps.LBMaps, feAddr loadbalancer.L3n4Addr, sanitizeIDs bool) (out []maps.MapDump) {
@@ -183,7 +182,7 @@ var baseService = loadbalancer.Service{
 	IntTrafficPolicy:       loadbalancer.SVCTrafficPolicyLocal,
 	SessionAffinity:        false,
 	SessionAffinityTimeout: 0,
-	ProxyRedirect:          nil,
+	ProxyRedirects:         nil,
 	LoopbackHostPort:       false,
 }
 
@@ -196,8 +195,10 @@ var baseFrontend = loadbalancer.Frontend{
 	Status:   reconciler.StatusPending(),
 }
 
-var baseBackend = newTestBackend(backend1, loadbalancer.BackendStateActive)
-var nextBackendRevision = statedb.Revision(1)
+var (
+	baseBackend         = newTestBackend(backend1, loadbalancer.BackendStateActive)
+	nextBackendRevision = statedb.Revision(1)
+)
 
 func concatBe(bes loadbalancer.BackendsSeq2, be loadbalancer.Backend, rev statedb.Revision) loadbalancer.BackendsSeq2 {
 	return func(yield func(*loadbalancer.Backend, statedb.Revision) bool) {
@@ -294,8 +295,7 @@ var clusterIPTestCases = []testCase{
 		func(svc *loadbalancer.Service, fe *loadbalancer.Frontend) (delete bool, bes []loadbalancer.Backend) {
 			fe.Type = ClusterIP
 			fe.Address = autoAddr
-			be1, be2 :=
-				newTestBackend(backend1, loadbalancer.BackendStateActive),
+			be1, be2 := newTestBackend(backend1, loadbalancer.BackendStateActive),
 				newTestBackend(backend2, loadbalancer.BackendStateActive)
 			return false, []loadbalancer.Backend{be1, be2}
 		},
@@ -317,8 +317,7 @@ var clusterIPTestCases = []testCase{
 		func(svc *loadbalancer.Service, fe *loadbalancer.Frontend) (delete bool, bes []loadbalancer.Backend) {
 			fe.Type = ClusterIP
 			fe.Address = autoAddr
-			be1, be2, be3, be4 :=
-				newTestBackend(backend1, loadbalancer.BackendStateActive),
+			be1, be2, be3, be4 := newTestBackend(backend1, loadbalancer.BackendStateActive),
 				newTestBackend(backend2, loadbalancer.BackendStateActive),
 				newTestBackend(withClusterID(backend2, 10), loadbalancer.BackendStateActive),
 				newTestBackend(withClusterID(backend2, 20), loadbalancer.BackendStateActive)
@@ -436,8 +435,7 @@ var quarantineTestCases = []testCase{
 		func(svc *loadbalancer.Service, fe *loadbalancer.Frontend) (delete bool, bes []loadbalancer.Backend) {
 			fe.Type = ClusterIP
 			fe.Address = autoAddr
-			be1, be2 :=
-				newTestBackend(backend1, loadbalancer.BackendStateActive),
+			be1, be2 := newTestBackend(backend1, loadbalancer.BackendStateActive),
 				newTestBackend(backend2, loadbalancer.BackendStateActive)
 			return false, []loadbalancer.Backend{be1, be2}
 		},
@@ -459,8 +457,7 @@ var quarantineTestCases = []testCase{
 		func(svc *loadbalancer.Service, fe *loadbalancer.Frontend) (delete bool, bes []loadbalancer.Backend) {
 			fe.Type = ClusterIP
 			fe.Address = autoAddr
-			be1, be2 :=
-				newTestBackend(backend1, loadbalancer.BackendStateQuarantined),
+			be1, be2 := newTestBackend(backend1, loadbalancer.BackendStateQuarantined),
 				newTestBackend(backend2, loadbalancer.BackendStateActive)
 			return false, []loadbalancer.Backend{be1, be2}
 		},
@@ -497,8 +494,7 @@ var nodePortTestCases = []testCase{
 		func(svc *loadbalancer.Service, fe *loadbalancer.Frontend) (delete bool, bes []loadbalancer.Backend) {
 			fe.Type = NodePort
 			fe.Address = zeroAddr
-			be1, be2 :=
-				newTestBackend(backend1, loadbalancer.BackendStateActive),
+			be1, be2 := newTestBackend(backend1, loadbalancer.BackendStateActive),
 				newTestBackend(backend2, loadbalancer.BackendStateActive)
 			return false, []loadbalancer.Backend{be1, be2}
 		},
@@ -606,9 +602,9 @@ var proxyTestCases = []testCase{
 			// from how the backend ID is normally stored (host byte-order). Hence to make this
 			// work on both little and big-endian machine's the port is set to a value that's the
 			// same in both byte orders.
-			svc.ProxyRedirect = &loadbalancer.ProxyRedirect{
+			svc.ProxyRedirects = loadbalancer.ProxyRedirects{{
 				ProxyPort: 0x0a0a, // 2570
-			}
+			}}
 			return false, []loadbalancer.Backend{baseBackend}
 		},
 		[]maps.MapDump{
@@ -852,8 +848,7 @@ var sessionAffinityTestCases = []testCase{
 			fe.Address = zeroAddr
 			svc.SessionAffinity = true
 			svc.SessionAffinityTimeout = time.Second
-			be1, be2 :=
-				newTestBackend(backend1, loadbalancer.BackendStateActive),
+			be1, be2 := newTestBackend(backend1, loadbalancer.BackendStateActive),
 				newTestBackend(backend2, loadbalancer.BackendStateActive)
 			return false, []loadbalancer.Backend{be1, be2}
 		},
@@ -887,8 +882,7 @@ var sessionAffinityTestCases = []testCase{
 			fe.Address = zeroAddr
 			svc.SessionAffinity = true
 			svc.SessionAffinityTimeout = time.Second
-			be1, be2 :=
-				newTestBackend(backend1, loadbalancer.BackendStateQuarantined),
+			be1, be2 := newTestBackend(backend1, loadbalancer.BackendStateQuarantined),
 				newTestBackend(backend2, loadbalancer.BackendStateActive)
 			return false, []loadbalancer.Backend{be1, be2}
 		},

--- a/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
@@ -624,6 +624,81 @@ var proxyTestCases = []testCase{
 		nil,
 		false,
 	),
+	newTestCase(
+		"L7Proxy_distinct_port80",
+
+		func(svc *loadbalancer.Service, fe *loadbalancer.Frontend) (delete bool, bes []loadbalancer.Backend) {
+			fe.Type = ClusterIP
+			fe.Address = autoAddr
+			fe.ServicePort = 80
+
+			svc.ProxyRedirects = loadbalancer.ProxyRedirects{
+				{ProxyPort: 0x0a0a, Ports: []uint16{80}},
+				{ProxyPort: 0x0b0b, Ports: []uint16{443}},
+			}
+			return false, []loadbalancer.Backend{baseBackend}
+		},
+		[]maps.MapDump{
+			"BE: ID=2 ADDR=10.1.0.1:80/TCP STATE=active",
+			"REV: ID=2 ADDR=<auto>",
+			"SVC: ID=0 ADDR=<auto>/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable",
+			"SVC: ID=2 ADDR=<auto>/TCP SLOT=0 L7Proxy=2570 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable+l7-load-balancer",
+			"SVC: ID=2 ADDR=<auto>/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable+l7-load-balancer",
+		},
+		nil,
+		false,
+	),
+	newTestCase(
+		"L7Proxy_distinct_port443",
+
+		func(svc *loadbalancer.Service, fe *loadbalancer.Frontend) (delete bool, bes []loadbalancer.Backend) {
+			fe.Type = ClusterIP
+			fe.Address = loadbalancer.NewL3n4Addr(loadbalancer.TCP, types.MustParseAddrCluster("10.0.0.2"), 443, loadbalancer.ScopeExternal)
+			fe.ServicePort = 443
+
+			svc.ProxyRedirects = loadbalancer.ProxyRedirects{
+				{ProxyPort: 0x0a0a, Ports: []uint16{80}},
+				{ProxyPort: 0x0b0b, Ports: []uint16{443}},
+			}
+			return false, []loadbalancer.Backend{baseBackend}
+		},
+		[]maps.MapDump{
+			"BE: ID=2 ADDR=10.1.0.1:80/TCP STATE=active",
+			"REV: ID=2 ADDR=<auto>",
+			"REV: ID=3 ADDR=10.0.0.2:443",
+			"SVC: ID=0 ADDR=10.0.0.2:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable",
+			"SVC: ID=0 ADDR=<auto>/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable",
+			"SVC: ID=2 ADDR=<auto>/TCP SLOT=0 L7Proxy=2570 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable+l7-load-balancer",
+			"SVC: ID=2 ADDR=<auto>/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable+l7-load-balancer",
+			"SVC: ID=3 ADDR=10.0.0.2:443/TCP SLOT=0 L7Proxy=2827 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable+l7-load-balancer",
+			"SVC: ID=3 ADDR=10.0.0.2:443/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable+l7-load-balancer",
+		},
+		nil,
+		false,
+	),
+	newTestCase(
+		"L7Proxy_distinct_cleanup",
+		deleteFrontend(autoAddr, ClusterIP),
+		[]maps.MapDump{
+			"BE: ID=2 ADDR=10.1.0.1:80/TCP STATE=active",
+			"REV: ID=3 ADDR=10.0.0.2:443",
+			"SVC: ID=0 ADDR=10.0.0.2:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable",
+			"SVC: ID=3 ADDR=10.0.0.2:443/TCP SLOT=0 L7Proxy=2827 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable+l7-load-balancer",
+			"SVC: ID=3 ADDR=10.0.0.2:443/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+Local+InternalLocal+non-routable+l7-load-balancer",
+		},
+		nil,
+		false,
+	),
+	newTestCase(
+		"L7Proxy_distinct_cleanup_2",
+		deleteFrontend(
+			loadbalancer.NewL3n4Addr(loadbalancer.TCP, types.MustParseAddrCluster("10.0.0.2"), 443, loadbalancer.ScopeExternal),
+			ClusterIP,
+		),
+		[]maps.MapDump{},
+		nil,
+		false,
+	),
 }
 
 var extraFrontendInternal = loadbalancer.NewL3n4Addr(

--- a/pkg/loadbalancer/service.go
+++ b/pkg/loadbalancer/service.go
@@ -215,7 +215,8 @@ func (p ProxyRedirects) Equal(other ProxyRedirects) bool {
 }
 
 // ForPort finds the ProxyRedirect that matches the given frontend port.
-// Returns nil if no match is found.
+// It prefers an exact port match over a wildcard (Ports is empty) match.
+// Returns nil if no match is found. Nil entries are not expected.
 func (p ProxyRedirects) ForPort(port uint16) *ProxyRedirect {
 	var wildcard *ProxyRedirect
 	for i := range p {

--- a/pkg/loadbalancer/service.go
+++ b/pkg/loadbalancer/service.go
@@ -71,10 +71,13 @@ type Service struct {
 	// for a LoadBalancer service. If unset the default implementation is used.
 	LoadBalancerClass *string
 
-	// ProxyRedirect if non-nil redirects the traffic going to the frontends
-	// towards a locally running proxy.
+	// ProxyRedirects if non-empty redirects the traffic going to the frontends
+	// towards a locally running proxy. Each entry can target different frontend
+	// ports to different proxy ports.
+	// NOTE: This is a slice and is shared by Clone() (shallow copy). Do not
+	// mutate in place after cloning; always replace the whole field.
 	// +deepequal-gen=false
-	ProxyRedirect *ProxyRedirect
+	ProxyRedirects ProxyRedirects
 
 	// HealthCheckNodePort defines on which port the node runs a HTTP health
 	// check server which may be used by external loadbalancers to determine
@@ -126,7 +129,7 @@ func (td TrafficDistribution) RequiresZoneUpdate() bool {
 
 func (svc *Service) DeepEqual(other *Service) bool {
 	return svc.deepEqual(other) &&
-		svc.ProxyRedirect.Equal(other.ProxyRedirect) &&
+		svc.ProxyRedirects.Equal(other.ProxyRedirects) &&
 		slices.EqualFunc(svc.SourceRanges, other.SourceRanges,
 			func(a, b netip.Prefix) bool {
 				return a == b
@@ -183,17 +186,6 @@ func (pr *ProxyRedirect) Redirects(port uint16) bool {
 	return len(pr.Ports) == 0 || slices.Contains(pr.Ports, port)
 }
 
-func (pr *ProxyRedirect) Equal(other *ProxyRedirect) bool {
-	switch {
-	case pr == nil && other == nil:
-		return true
-	case pr != nil && other != nil:
-		return pr.ProxyPort == other.ProxyPort && slices.Equal(pr.Ports, other.Ports)
-	default:
-		return false
-	}
-}
-
 func (pr *ProxyRedirect) String() string {
 	if pr == nil {
 		return ""
@@ -202,6 +194,65 @@ func (pr *ProxyRedirect) String() string {
 		return fmt.Sprintf("%d (ports: %v)", pr.ProxyPort, pr.Ports)
 	}
 	return strconv.FormatUint(uint64(pr.ProxyPort), 10)
+}
+
+// ProxyRedirects is a set of proxy redirects associated with a service.
+type ProxyRedirects []ProxyRedirect
+
+// Equal returns true if two ProxyRedirects are equal.
+// Comparison is order-sensitive; this is safe because the slice order is
+// determined by the stable ordering of CEC spec.services entries.
+func (p ProxyRedirects) Equal(other ProxyRedirects) bool {
+	if len(p) != len(other) {
+		return false
+	}
+	for i := range p {
+		if p[i].ProxyPort != other[i].ProxyPort || !slices.Equal(p[i].Ports, other[i].Ports) {
+			return false
+		}
+	}
+	return true
+}
+
+// ForPort finds the ProxyRedirect that matches the given frontend port.
+// Returns nil if no match is found.
+func (p ProxyRedirects) ForPort(port uint16) *ProxyRedirect {
+	var wildcard *ProxyRedirect
+	for i := range p {
+		if slices.Contains(p[i].Ports, port) {
+			return &p[i]
+		}
+		if wildcard == nil && len(p[i].Ports) == 0 {
+			wildcard = &p[i]
+		}
+	}
+	return wildcard
+}
+
+// Redirects returns true if any ProxyRedirect in the set matches the given
+// frontend port.
+func (p ProxyRedirects) Redirects(port uint16) bool {
+	return p.ForPort(port) != nil
+}
+
+// Empty reports whether the set contains no proxy redirects.
+func (p ProxyRedirects) Empty() bool {
+	return len(p) == 0
+}
+
+// String returns a human-readable representation of the redirects.
+func (p ProxyRedirects) String() string {
+	if len(p) == 0 {
+		return ""
+	}
+	if len(p) == 1 {
+		return p[0].String()
+	}
+	ss := make([]string, len(p))
+	for i := range p {
+		ss[i] = p[i].String()
+	}
+	return "[" + strings.Join(ss, ", ") + "]"
 }
 
 // Clone returns a shallow clone of the service, e.g. for updating a service with UpsertService. Fields that are references
@@ -251,8 +302,8 @@ func (svc *Service) TableRow() []string {
 		flags = append(flags, "SourceRangesPolicy=deny")
 	}
 
-	if svc.ProxyRedirect != nil {
-		flags = append(flags, "ProxyRedirect="+svc.ProxyRedirect.String())
+	if !svc.ProxyRedirects.Empty() {
+		flags = append(flags, "ProxyRedirects="+svc.ProxyRedirects.String())
 	}
 
 	if svc.HealthCheckNodePort != 0 {

--- a/pkg/loadbalancer/tests/testdata/marshalling.txtar
+++ b/pkg/loadbalancer/tests/testdata/marshalling.txtar
@@ -65,7 +65,7 @@ test/echo  [2002::2]:8080/TCP
   "SessionAffinity": false,
   "SessionAffinityTimeout": 0,
   "LoadBalancerClass": null,
-  "ProxyRedirect": null,
+  "ProxyRedirects": null,
   "HealthCheckNodePort": 0,
   "LoopbackHostPort": false,
   "SourceRanges": null,
@@ -216,7 +216,7 @@ forwardingmode: ""
 sessionaffinity: false
 sessionaffinitytimeout: 0s
 loadbalancerclass: null
-proxyredirect: null
+proxyredirects: []
 healthchecknodeport: 0
 loopbackhostport: false
 sourceranges: []

--- a/vendor/github.com/cilium/statedb/part_index.go
+++ b/vendor/github.com/cilium/statedb/part_index.go
@@ -367,10 +367,7 @@ func (r *partIndexTxn) reindex(idKey index.Key, old object, new object) {
 					if !unique {
 						oldKey = encodeNonUniqueKey(idKey, oldKey)
 					}
-					_, hadOld := r.tx.Delete(oldKey)
-					if !unique && !hadOld {
-						panic("BUG: delete did not find old object")
-					}
+					r.tx.Delete(oldKey)
 				}
 			},
 		)

--- a/vendor/github.com/cilium/statedb/reconciler/builder.go
+++ b/vendor/github.com/cilium/statedb/reconciler/builder.go
@@ -4,6 +4,7 @@
 package reconciler
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/cilium/hive/job"
@@ -81,9 +82,17 @@ func Register[Obj comparable](
 		progress:             newProgressTracker(),
 	}
 
-	params.JobGroup.Add(job.OneShot("reconcile", r.reconcileLoop))
+	var scoped = func(jn string) string {
+		if cfg.Name == "" {
+			return jn
+		}
+
+		return fmt.Sprintf("%s-%s", jn, cfg.Name)
+	}
+
+	params.JobGroup.Add(job.OneShot(scoped("reconcile"), r.reconcileLoop))
 	if r.config.RefreshInterval > 0 {
-		params.JobGroup.Add(job.OneShot("refresh", r.refreshLoop))
+		params.JobGroup.Add(job.OneShot(scoped("refresh"), r.refreshLoop))
 	}
 	return r, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -356,7 +356,7 @@ github.com/cilium/lumberjack/v2
 # github.com/cilium/proxy v0.0.0-20260508102643-7c2f6580d32e
 ## explicit; go 1.25.0
 github.com/cilium/proxy/go/cilium/api
-# github.com/cilium/statedb v0.8.0
+# github.com/cilium/statedb v0.8.1
 ## explicit; go 1.25
 github.com/cilium/statedb
 github.com/cilium/statedb/index


### PR DESCRIPTION
processCEC stored one ProxyRedirect per service name. When multi-port Gateways produced two ServiceListener entries for the same service the second overwrote the first, leaving one port without an L7 redirect in the BPF LB map.

Change Service.ProxyRedirect to ProxyRedirects ([]*ProxyRedirect) and resolve per frontend via ProxyRedirectForPort(). The BPF map already supports per-frontend proxy ports so no datapath changes are needed.

Please ensure your pull request adheres to the following guidelines:

This PR was prepared with AIL:3. I personally reviewed each line of the submission prior to opening this PR. I ran all tests in a kind cluster with cloud-provider-kind for testing the entire data path. The tests run are defined in the column 44889 in https://github.com/eufriction/k8s-cilium-gapi#test-results-by-version.

Related to https://github.com/cilium/cilium/pull/44889

```release-note
loadbalancer: proxy ports are now resolved per frontend instead of per service, preventing one port from losing its L7 redirect when multiple listeners share a service.
```