### PR TITLE
bpf: egressgw: skip redirect checks in to-netdev for non-local traffic

### DIFF
--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -90,6 +90,9 @@ static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 
 #if defined(ENABLE_EGRESS_GATEWAY_COMMON) && defined(IS_BPF_HOST)
 	if (args->target.egress_gateway) {
+		if (ctx_egw_done(ctx))
+			goto apply_snat;
+
 		/* Stay on the desired egress interface: */
 		if (args->target.ifindex && args->target.ifindex == CONFIG(interface_ifindex))
 			goto apply_snat;
@@ -378,6 +381,10 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 
 #if defined(ENABLE_EGRESS_GATEWAY_COMMON) && defined(IS_BPF_HOST)
 	if (target.egress_gateway) {
+		/* from-overlay has already picked the correct egress interface: */
+		if (ctx_egw_done(ctx))
+			goto apply_snat;
+
 		/* Stay on the desired egress interface: */
 		if (target.ifindex && target.ifindex == CONFIG(interface_ifindex))
 			goto apply_snat;

--- a/bpf/tests/lib/egressgw.h
+++ b/bpf/tests/lib/egressgw.h
@@ -40,8 +40,7 @@ enum egressgw_test {
 	TEST_REDIRECT_EXCL_CIDR       = 5,
 	TEST_REDIRECT_SKIP_NO_GATEWAY = 6,
 	TEST_XDP_REPLY                = 7,
-	TEST_FIB                      = 8,
-	TEST_DROP_NO_EGRESS_IP        = 9,
+	TEST_DROP_NO_EGRESS_IP        = 8,
 };
 
 struct egressgw_test_ctx {

--- a/bpf/tests/tc_egressgw_redirect_from_host.c
+++ b/bpf/tests/tc_egressgw_redirect_from_host.c
@@ -15,12 +15,15 @@
 #define ENABLE_HOST_FIREWALL		1
 #define ENCAP_IFINDEX 0
 
+#define PRIMARY_IFACE			21
+#define EGRESS_IFACE			22
+
 #define RT_TBID				3
 
 #define fib_lookup mock_fib_lookup
 static __always_inline __maybe_unused long
 mock_fib_lookup(void *ctx __maybe_unused,
-		const struct bpf_fib_lookup *params __maybe_unused,
+		struct bpf_fib_lookup *params __maybe_unused,
 		int plen __maybe_unused, __u32 flags __maybe_unused);
 
 #include "lib/bpf_host.h"
@@ -29,6 +32,8 @@ mock_fib_lookup(void *ctx __maybe_unused,
 #include "lib/endpoint.h"
 #include "lib/ipcache.h"
 #include "lib/metrics.h"
+
+ASSIGN_CONFIG(__u32, interface_ifindex, PRIMARY_IFACE)
 
 struct fib_lookup_settings {
 	__u32 tbid;
@@ -44,7 +49,7 @@ struct {
 
 static __always_inline __maybe_unused long
 mock_fib_lookup(void *ctx __maybe_unused,
-		const struct bpf_fib_lookup *params __maybe_unused,
+		struct bpf_fib_lookup *params __maybe_unused,
 		int plen __maybe_unused, __u32 flags __maybe_unused)
 {
 	__u32 key = 0;
@@ -62,22 +67,23 @@ mock_fib_lookup(void *ctx __maybe_unused,
 		}
 	}
 
+	params->ifindex = EGRESS_IFACE;
 	return 0;
 }
 
 /* Test that a packet matching an egress gateway policy on the to-netdev
- * program egresses locally, using the endpoint's rt_info.
+ * program egresses locally.
  */
-PKTGEN("tc", "tc_egressgw_egress1_rt_info")
-int egressgw_egress1_rt_info_pktgen(struct __ctx_buff *ctx)
+PKTGEN("tc", "tc_egressgw_egress1")
+int egressgw_egress1_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
 			.test = TEST_SNAT1,
 		});
 }
 
-SETUP("tc", "tc_egressgw_egress1_rt_info")
-int egressgw_egress1_rt_info_setup(struct __ctx_buff *ctx)
+SETUP("tc", "tc_egressgw_egress1")
+int egressgw_egress1_setup(struct __ctx_buff *ctx)
 {
 	__u32 key = 0;
 	struct fib_lookup_settings *settings = map_lookup_elem(&fib_lookup_settings_map, &key);
@@ -86,10 +92,7 @@ int egressgw_egress1_rt_info_setup(struct __ctx_buff *ctx)
 		return TEST_ERROR;
 
 	settings->fib_lookup_called = false;
-	settings->tbid = RT_TBID;
 
-	endpoint_v4_add_entry_with_rt_info(CLIENT_IP, 0, 0, 0, 0, 0, RT_TBID,
-					   NULL, NULL);
 	endpoint_v4_add_entry(GATEWAY_NODE_IP, 0, 0, ENDPOINT_F_HOST,
 			      0, 0, NULL, NULL);
 	endpoint_v4_add_entry(EGRESS_IP, 0, 0, ENDPOINT_F_HOST,
@@ -106,11 +109,56 @@ int egressgw_egress1_rt_info_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_egress1_rt_info")
-int egressgw_egress1_rt_info_check(const struct __ctx_buff *ctx)
+CHECK("tc", "tc_egressgw_egress1")
+int egressgw_egress1_check(const struct __ctx_buff *ctx)
+{
+	__u32 key = 0;
+	struct fib_lookup_settings *settings = map_lookup_elem(&fib_lookup_settings_map, &key);
+
+	if (!settings || !settings->fib_lookup_called)
+		return TEST_ERROR;
+
+	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
+			.status_code = CTX_ACT_REDIRECT,
+	});
+
+	return ret;
+}
+
+/* Test that a packet matching an egress gateway policy on the to-netdev
+ * program egresses locally, using the endpoint's rt_info.
+ */
+PKTGEN("tc", "tc_egressgw_egress2_rt_info")
+int egressgw_egress2_rt_info_pktgen(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT1,
+		});
+}
+
+SETUP("tc", "tc_egressgw_egress2_rt_info")
+int egressgw_egress2_rt_info_setup(struct __ctx_buff *ctx)
+{
+	__u32 key = 0;
+	struct fib_lookup_settings *settings = map_lookup_elem(&fib_lookup_settings_map, &key);
+
+	if (!settings)
+		return TEST_ERROR;
+
+	settings->fib_lookup_called = false;
+	settings->tbid = RT_TBID;
+
+	endpoint_v4_add_entry_with_rt_info(CLIENT_IP, 0, 0, 0, 0, 0, RT_TBID,
+					   NULL, NULL);
+
+	return netdev_send_packet(ctx);
+}
+
+CHECK("tc", "tc_egressgw_egress2_rt_info")
+int egressgw_egress2_rt_info_check(const struct __ctx_buff *ctx)
 {
 	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
-			.status_code = CTX_ACT_OK,
+			.status_code = CTX_ACT_REDIRECT,
 	});
 	__u32 key = 0;
 
@@ -311,18 +359,18 @@ int egressgw_drop_no_egress_ip_check(const struct __ctx_buff *ctx)
 }
 
 /* Test that a packet matching an egress gateway policy on the to-netdev
- * program egresses locally, using the endpoint's rt_info.
+ * program egresses locally.
  */
-PKTGEN("tc", "tc_egressgw_egress1_rt_info_v6")
-int egressgw_egress1_rt_info_v6_pktgen(struct __ctx_buff *ctx)
+PKTGEN("tc", "tc_egressgw_v6_egress1")
+int egressgw_v6_egress1_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
 			.test = TEST_SNAT1,
 		});
 }
 
-SETUP("tc", "tc_egressgw_egress1_rt_info_v6")
-int egressgw_egress1_rt_info_v6_setup(struct __ctx_buff *ctx)
+SETUP("tc", "tc_egressgw_v6_egress1")
+int egressgw_v6_egress1_setup(struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
 	union v6addr client_ip = CLIENT_IP_V6;
@@ -334,10 +382,8 @@ int egressgw_egress1_rt_info_v6_setup(struct __ctx_buff *ctx)
 		return TEST_ERROR;
 
 	settings->fib_lookup_called = false;
-	settings->tbid = RT_TBID;
 
-	endpoint_v6_add_entry_with_rt_info(&client_ip, 0, 0, 0, 0, RT_TBID,
-					   NULL, NULL);
+	endpoint_v6_add_entry(&client_ip, 0, 0, 0, 0, NULL, NULL);
 	endpoint_v4_add_entry(GATEWAY_NODE_IP, 0, 0, ENDPOINT_F_HOST,
 			      0, 0, NULL, NULL);
 	endpoint_v6_add_entry(&egress_ip, 0, 0, ENDPOINT_F_HOST,
@@ -354,14 +400,112 @@ int egressgw_egress1_rt_info_v6_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_egress1_rt_info_v6")
-int egressgw_egress1_rt_info_v6_check(const struct __ctx_buff *ctx)
+CHECK("tc", "tc_egressgw_v6_egress1")
+int egressgw_v6_egress1_check(const struct __ctx_buff *ctx)
+{
+	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
+			.status_code = CTX_ACT_REDIRECT,
+	});
+	__u32 key = 0;
+
+	struct fib_lookup_settings *settings = map_lookup_elem(&fib_lookup_settings_map, &key);
+
+	if (!settings || !settings->fib_lookup_called)
+		return TEST_ERROR;
+
+	return ret;
+}
+
+/* Test that a packet matching an egress gateway policy on the to-netdev
+ * program egresses locally. Using the ifindex in the policy.
+ */
+PKTGEN("tc", "tc_egressgw_v6_egress2_ifindex")
+int egressgw_v6_egress2_ifindex_pktgen(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT1,
+		});
+}
+
+SETUP("tc", "tc_egressgw_v6_egress2_ifindex")
+int egressgw_v6_egress2_ifindex_setup(struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+	union v6addr egress_ip = EGRESS_IP_V6;
+	__u32 key = 0;
+	struct fib_lookup_settings *settings = map_lookup_elem(&fib_lookup_settings_map, &key);
+
+	if (!settings)
+		return TEST_ERROR;
+
+	settings->fib_lookup_called = false;
+
+	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
+				     &egress_ip, PRIMARY_IFACE);
+
+	return netdev_send_packet(ctx);
+}
+
+CHECK("tc", "tc_egressgw_v6_egress2_ifindex")
+int egressgw_v6_egress2_ifindex_check(const struct __ctx_buff *ctx)
+{
+	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
+			.status_code = CTX_ACT_OK,
+	});
+	__u32 key = 0;
+
+	struct fib_lookup_settings *settings = map_lookup_elem(&fib_lookup_settings_map, &key);
+
+	if (!settings || settings->fib_lookup_called)
+		return TEST_ERROR;
+
+	return ret;
+}
+
+/* Test that a packet matching an egress gateway policy on the to-netdev
+ * program egresses locally, using the endpoint's rt_info.
+ */
+PKTGEN("tc", "tc_egressgw_v6_egress3_rt_info")
+int egressgw_v6_egress3_rt_info_pktgen(struct __ctx_buff *ctx)
+{
+	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT1,
+		});
+}
+
+SETUP("tc", "tc_egressgw_v6_egress3_rt_info")
+int egressgw_v6_egress3_rt_info_setup(struct __ctx_buff *ctx)
+{
+	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
+	union v6addr egress_ip = EGRESS_IP_V6;
+	union v6addr client_ip = CLIENT_IP_V6;
+	__u32 key = 0;
+	struct fib_lookup_settings *settings = map_lookup_elem(&fib_lookup_settings_map, &key);
+
+	if (!settings)
+		return TEST_ERROR;
+
+	settings->fib_lookup_called = false;
+	settings->tbid = RT_TBID;
+
+	endpoint_v6_add_entry_with_rt_info(&client_ip, 0, 0, 0, 0, RT_TBID,
+					   NULL, NULL);
+
+	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
+				     &egress_ip, 0);
+
+	return netdev_send_packet(ctx);
+}
+
+CHECK("tc", "tc_egressgw_v6_egress3_rt_info")
+int egressgw_v6_egress3_rt_info_check(const struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
 	union v6addr client_ip = CLIENT_IP_V6;
 	union v6addr egress_ip = EGRESS_IP_V6;
 	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
-			.status_code = CTX_ACT_OK,
+			.status_code = CTX_ACT_REDIRECT,
 	});
 	__u32 key = 0;
 

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -28,7 +28,7 @@ mock_redirect_neigh(int ifindex, struct bpf_redir_neigh *params, int plen,
 
 #define fib_lookup mock_fib_lookup
 static __always_inline __maybe_unused long
-mock_fib_lookup(void *ctx __maybe_unused, struct bpf_fib_lookup *params __maybe_unused,
+mock_fib_lookup(void *ctx __maybe_unused, const struct bpf_fib_lookup *params __maybe_unused,
 		int plen __maybe_unused, __u32 flags __maybe_unused);
 
 #include "lib/bpf_host.h"
@@ -66,20 +66,11 @@ mock_redirect_neigh(int ifindex, struct bpf_redir_neigh *params __maybe_unused,
 }
 
 static __always_inline __maybe_unused long
-mock_fib_lookup(void *ctx __maybe_unused, struct bpf_fib_lookup *params __maybe_unused,
+mock_fib_lookup(void *ctx __maybe_unused, const struct bpf_fib_lookup *params __maybe_unused,
 		int plen __maybe_unused, __u32 flags __maybe_unused)
 {
-	union v6addr egress_ip = EGRESS_IP2_V6;
-
-	if (params) {
-		if (params->ipv4_src == EGRESS_IP2)
-			params->ifindex = SECONDARY_IFACE_IFINDEX;
-
-		if (memcmp(&params->ipv6_src, &egress_ip, sizeof(union v6addr)) == 0)
-			params->ifindex = SECONDARY_IFACE_IFINDEX;
-	}
-
-	return 0;
+	/* expect no FIB lookup for packets that arrived via overlay */
+	return -1;
 }
 
 /* Test that a packet matching an egress gateway policy on the to-netdev program
@@ -363,42 +354,6 @@ int egressgw_skip_excluded_cidr_snat_check(const struct __ctx_buff *ctx)
 		test_fatal("dst port has changed");
 
 	test_finish();
-}
-
-PKTGEN("tc", "tc_egressgw_fib_redirect")
-int egressgw_fib_redirect_pktgen(struct __ctx_buff *ctx)
-{
-	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
-			.test = TEST_FIB,
-			.redirect = true,
-		});
-}
-
-SETUP("tc", "tc_egressgw_fib_redirect")
-int egressgw_fib_redirect_setup(struct __ctx_buff *ctx)
-{
-	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24,
-				  GATEWAY_NODE_IP, EGRESS_IP2);
-	ipcache_v4_add_entry(EGRESS_IP2, 0, HOST_ID, 0, 0);
-
-	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
-
-	return netdev_send_packet(ctx);
-}
-
-CHECK("tc", "tc_egressgw_fib_redirect")
-int egressgw_fib_redirect_check(const struct __ctx_buff *ctx __maybe_unused)
-{
-	int ret = egressgw_snat_check(ctx, (struct egressgw_test_ctx) {
-			.test = TEST_FIB,
-			.redirect = true,
-			.packets = 1,
-			.status_code = CTX_ACT_REDIRECT,
-		});
-
-	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24);
-
-	return ret;
 }
 
 /* Test that a packet matching an egress gateway policy on the to-netdev program
@@ -710,48 +665,4 @@ int egressgw_skip_excluded_cidr_snat_check_v6(const struct __ctx_buff *ctx)
 		test_fatal("dst port has changed");
 
 	test_finish();
-}
-
-/* Test FIB lookup based redirect functionality (IPv6) */
-PKTGEN("tc", "tc_v6_egressgw_fib_redirect")
-int egressgw_fib_redirect_pktgen_v6(struct __ctx_buff *ctx)
-{
-	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
-			.test = TEST_FIB,
-			.redirect = true,
-		});
-}
-
-SETUP("tc", "tc_v6_egressgw_fib_redirect")
-int egressgw_fib_redirect_setup_v6(struct __ctx_buff *ctx)
-{
-	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
-	union v6addr client_ip = CLIENT_IP_V6;
-	union v6addr egress_ip = EGRESS_IP2_V6;
-
-	add_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX, GATEWAY_NODE_IP,
-				     &egress_ip, 0);
-	ipcache_v6_add_entry(&egress_ip, 0, HOST_ID, 0, 0);
-
-	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
-
-	return netdev_send_packet(ctx);
-}
-
-CHECK("tc", "tc_v6_egressgw_fib_redirect")
-int egressgw_fib_redirect_check_v6(const struct __ctx_buff *ctx __maybe_unused)
-{
-	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
-	union v6addr client_ip = CLIENT_IP_V6;
-
-	int ret = egressgw_snat_check_v6(ctx, (struct egressgw_test_ctx) {
-			.test = TEST_FIB,
-			.redirect = true,
-			.packets = 1,
-			.status_code = CTX_ACT_REDIRECT,
-		});
-
-	del_egressgw_policy_entry_v6(&client_ip, &ext_svc_ip, IPV6_SUBNET_PREFIX);
-
-	return ret;
 }


### PR DESCRIPTION
When `from-overlay` has matched a packet against an EGW policy, it already picks the correct egress interface (based on either the policy entry, or a FIB lookup) and also handles the L2 rewrite.

For such a packet it is therefore safe to skip additional redirect checks in `to-netdev`'s EGW code. All it still needs to do is SNATing the packet.

Remove the relevant tests in tc_egressgw_snat.c (we're no longer doing FIB lookups for packets that arrived from the overlay). And while at it extend the tests in tc_egressgw_redirect_from_host.c to cover a wider range of packets by a local endpoint that egress on the local node.