### PR TITLE
ipam: Add CIDR-based release mechanism for ENI multipool mode

### DIFF
--- a/operator/pkg/ipam/nodemanager/node.go
+++ b/operator/pkg/ipam/nodemanager/node.go
@@ -16,6 +16,7 @@ import (
 	"sync/atomic"
 
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 
 	operatorK8s "github.com/cilium/cilium/operator/k8s"
@@ -87,7 +88,7 @@ type Node struct {
 	// printed that this node is out of adapters
 	lastMaxAdapterWarning time.Time
 
-	// instanceRunning is true when the EC2 instance backing the node is
+	// instanceRunning is true when the instance backing the node is
 	// not running. This state is detected based on error messages returned
 	// when modifying instance state
 	instanceRunning bool
@@ -100,8 +101,8 @@ type Node struct {
 
 	// TODO: Add support for IPv6 allocation: https://github.com/cilium/cilium/issues/19251
 
-	// resyncNeeded is set to the current time when a resync with the EC2
-	// API is required. The timestamp is required to ensure that this is
+	// resyncNeeded is set to the current time when a resync with the
+	// instances API is required. The timestamp is required to ensure that this is
 	// only reset if the resync started after the time stored in
 	// resyncNeeded. This is needed because resyncs and allocations happen
 	// in parallel.
@@ -138,6 +139,18 @@ type Node struct {
 
 	// ExcessIPReleaseDelay controls how long operator would wait before an IP previously marked as excess is released.
 	excessIPReleaseDelay time.Duration
+
+	// previousAllocatedCIDRs is the set of CIDRs last observed in
+	// Spec.IPAM.Pools.Allocated. Used by multi-pool mode to detect
+	// CIDRs the agent has released (present before, absent now). Nil
+	// until the first CiliumNode observation seeds it.
+	previousAllocatedCIDRs sets.Set[netip.Prefix]
+
+	// multiPoolCIDRsMarkedForRelease tracks CIDRs the agent removed
+	// from Allocated, with the timestamp they were first observed as
+	// removed. The excessIPReleaseDelay must elapse before the operator
+	// calls the cloud API to detach them.
+	multiPoolCIDRsMarkedForRelease map[netip.Prefix]time.Time
 }
 
 // ipAllocAttrs represents IP-specific allocation attributes.
@@ -253,14 +266,14 @@ func (n *Node) updateLogger() {
 	}
 }
 
-// getMaxAboveWatermark returns the max-above-watermark setting for an AWS node
+// getMaxAboveWatermark returns the max-above-watermark setting for a node
 //
 // n.mutex must be held when calling this function
 func (n *Node) getMaxAboveWatermark() int {
 	return n.resource.Spec.IPAM.MaxAboveWatermark
 }
 
-// getPreAllocate returns the pre-allocation setting for an AWS node
+// getPreAllocate returns the pre-allocation setting for a node
 //
 // n.mutex must be held when calling this function
 func (n *Node) getPreAllocate() int {
@@ -270,14 +283,14 @@ func (n *Node) getPreAllocate() int {
 	return defaults.IPAMPreAllocation
 }
 
-// getMinAllocate returns the minimum-allocation setting of an AWS node
+// getMinAllocate returns the minimum-allocation setting of a node
 //
 // n.mutex must be held when calling this function
 func (n *Node) getMinAllocate() int {
 	return n.resource.Spec.IPAM.MinAllocate
 }
 
-// getMaxAllocate returns the maximum-allocation setting of an AWS node
+// getMaxAllocate returns the maximum-allocation setting of a node
 func (n *Node) getMaxAllocate() int {
 	instanceMax := n.ops.GetMaximumAllocatableIPv4()
 	if n.resource.Spec.IPAM.MaxAllocate > 0 {
@@ -404,6 +417,165 @@ func poolRequestedIPv4(resource *v2.CiliumNode) (int, bool) {
 	return 0, false
 }
 
+// isMultiPoolNodeLocked returns true if this node's agent uses the multi-pool
+// allocator (1.20+) rather than the CRD allocator (1.19). The detection
+// heuristic checks that the agent has written Spec.IPAM.Pools.Requested
+// (multi-pool demand) and has cleared Status.IPAM.Used (CRD allocator field).
+// Caller must hold n.mutex (at least RLock).
+func (n *Node) isMultiPoolNodeLocked() bool {
+	if n.resource == nil {
+		return false
+	}
+	_, hasPoolRequest := poolRequestedIPv4(n.resource)
+	return hasPoolRequest && len(n.resource.Status.IPAM.Used) == 0
+}
+
+// trackMultiPoolAllocatedLocked updates previousAllocatedCIDRs and detects
+// CIDRs the agent has removed from Spec.IPAM.Pools.Allocated. Removed CIDRs
+// are added to multiPoolCIDRsMarkedForRelease with the current timestamp.
+// Caller must hold n.mutex.
+func (n *Node) trackMultiPoolAllocatedLocked() {
+	if !n.isMultiPoolNodeLocked() {
+		return
+	}
+
+	currentCIDRs := sets.New[netip.Prefix]()
+	for _, alloc := range n.resource.Spec.IPAM.Pools.Allocated {
+		for _, cidr := range alloc.CIDRs {
+			prefix, err := cidr.ToPrefix()
+			if err != nil {
+				continue
+			}
+			currentCIDRs.Insert(*prefix)
+		}
+	}
+
+	attachedCIDRs := n.ops.GetAttachedCIDRs()
+
+	now := time.Now()
+
+	if n.previousAllocatedCIDRs == nil {
+		// Seed: mark any CIDR attached on the ENI but missing from
+		// Allocated. Recovers releases that would otherwise be lost
+		// across operator restart (the agent removed the CIDR while
+		// the operator was down, so there is no transition to observe
+		// in steady state). Mid-allocation CIDRs (attached just before
+		// restart, not yet acked by the agent) are also marked, but
+		// the agent will write them into Allocated well within
+		// excessIPReleaseDelay, and the reconciliation loop below will
+		// clear them from the marked map before any EC2 call happens.
+		for _, cidr := range attachedCIDRs {
+			if !currentCIDRs.Has(cidr) {
+				n.multiPoolCIDRsMarkedForRelease[cidr] = now
+				n.logger.Load().Debug("Marking CIDR for release at seed", logfields.CIDR, cidr)
+			}
+		}
+		n.previousAllocatedCIDRs = currentCIDRs
+		return
+	}
+
+	for cidr := range n.previousAllocatedCIDRs {
+		if !currentCIDRs.Has(cidr) {
+			if _, already := n.multiPoolCIDRsMarkedForRelease[cidr]; !already {
+				n.multiPoolCIDRsMarkedForRelease[cidr] = now
+				n.logger.Load().Debug("Marking CIDR for release", logfields.CIDR, cidr)
+			}
+		}
+	}
+
+	for cidr := range n.multiPoolCIDRsMarkedForRelease {
+		if currentCIDRs.Has(cidr) {
+			// Agent re-added the CIDR before the operator released it.
+			delete(n.multiPoolCIDRsMarkedForRelease, cidr)
+		} else if !slices.Contains(attachedCIDRs, cidr) {
+			// CIDR is no longer attached at the ENI level, it was
+			// already detached (possibly by a previous release attempt
+			// that returned an error despite succeeding).
+			delete(n.multiPoolCIDRsMarkedForRelease, cidr)
+		}
+	}
+
+	n.previousAllocatedCIDRs = currentCIDRs
+}
+
+// handleMultiPoolCIDRRelease releases CIDRs that the multi-pool agent has
+// removed from Spec.IPAM.Pools.Allocated, after the excessIPReleaseDelay
+// has elapsed.
+func (n *Node) handleMultiPoolCIDRRelease(ctx context.Context) (bool, error) {
+	n.mutex.Lock()
+	if !n.isMultiPoolNodeLocked() || len(n.multiPoolCIDRsMarkedForRelease) == 0 {
+		n.mutex.Unlock()
+		return false, nil
+	}
+
+	now := time.Now()
+	var readyCIDRs []netip.Prefix
+	for cidr, ts := range n.multiPoolCIDRsMarkedForRelease {
+		if now.Sub(ts) >= n.excessIPReleaseDelay {
+			readyCIDRs = append(readyCIDRs, cidr)
+		}
+	}
+	n.mutex.Unlock()
+
+	if len(readyCIDRs) == 0 {
+		return false, nil
+	}
+
+	scopedLog := n.logger.Load()
+	actions := n.ops.PrepareCIDRRelease(readyCIDRs)
+	if len(actions) == 0 {
+		return false, nil
+	}
+
+	mutated := false
+	for _, action := range actions {
+		// Re-check membership in multiPoolCIDRsMarkedForRelease immediately
+		// before each EC2 release. The agent may have re-added a CIDR to
+		// Spec.IPAM.Pools.Allocated since readyCIDRs was selected, in which
+		// case trackMultiPoolAllocatedLocked will have removed it from the
+		// map. Detaching it would leave the agent's view inconsistent with
+		// the ENI state.
+		n.mutex.Lock()
+		filtered := action.CIDRsToRelease[:0]
+		for _, cidr := range action.CIDRsToRelease {
+			if _, ok := n.multiPoolCIDRsMarkedForRelease[cidr]; ok {
+				filtered = append(filtered, cidr)
+			}
+		}
+		action.CIDRsToRelease = filtered
+		n.mutex.Unlock()
+
+		if len(action.CIDRsToRelease) == 0 {
+			continue
+		}
+
+		releaseLog := scopedLog.With(
+			logfields.SelectedInterface, action.InterfaceID,
+			logfields.SelectedPoolID, action.PoolID,
+		)
+
+		released, err := n.ops.ReleaseCIDRs(ctx, action)
+		n.mutex.Lock()
+		for _, cidr := range released {
+			delete(n.multiPoolCIDRsMarkedForRelease, cidr)
+		}
+		n.mutex.Unlock()
+		if len(released) > 0 {
+			mutated = true
+		}
+		if err != nil {
+			releaseLog.Warn(
+				"Unable to release CIDRs from interface",
+				logfields.Error, err,
+				logfields.ReleasingAddresses, action.CIDRsToRelease,
+			)
+			return mutated, err
+		}
+	}
+
+	return mutated, nil
+}
+
 func (n *Node) requirePoolMaintenance() {
 	n.mutex.Lock()
 	n.ipv4Alloc.waitingForPoolMaintenance = true
@@ -446,6 +618,7 @@ func (n *Node) UpdatedResource(resource *v2.CiliumNode) bool {
 	// instance is alive
 	n.instanceRunning = true
 	n.resource = resource
+	n.trackMultiPoolAllocatedLocked()
 	n.mutex.Unlock()
 	n.updateLogger()
 
@@ -453,7 +626,8 @@ func (n *Node) UpdatedResource(resource *v2.CiliumNode) bool {
 
 	n.recalculate(context.Background())
 	allocationNeeded := n.allocationNeeded()
-	if allocationNeeded {
+	releaseNeeded := n.releaseNeeded()
+	if allocationNeeded || releaseNeeded {
 		n.requirePoolMaintenance()
 		n.poolMaintainer.Trigger()
 	}
@@ -565,6 +739,15 @@ func (n *Node) releaseNeeded() (needed bool) {
 	if n.resource != nil {
 		releaseInProgress := len(n.resource.Status.IPAM.ReleaseIPs) > 0
 		needed = needed || releaseInProgress
+	}
+	if !needed && len(n.multiPoolCIDRsMarkedForRelease) > 0 {
+		now := time.Now()
+		for _, ts := range n.multiPoolCIDRsMarkedForRelease {
+			if now.Sub(ts) >= n.excessIPReleaseDelay {
+				needed = true
+				break
+			}
+		}
 	}
 	n.mutex.RUnlock()
 	return
@@ -688,11 +871,25 @@ type ReleaseAction struct {
 	// value such as "global" to indicate a single address pool.
 	PoolID ipamTypes.PoolID
 
-	// IPsToRelease is the list of IPs to release
+	// IPsToRelease is the list of IPs to release.
+	//
+	// Used by the CRD-mode release path. The multi-pool release path uses
+	// CIDRsToRelease instead.
 	IPsToRelease []string
 
-	// IPPrefixes is the list of prefixes to release
+	// IPPrefixesToRelease is the list of prefixes to release.
+	//
+	// Used by the CRD-mode release path. The multi-pool release path uses
+	// CIDRsToRelease instead.
 	IPPrefixesToRelease []string
+
+	// CIDRsToRelease is the list of CIDRs to release. Single-IP entries
+	// (e.g. 10.0.0.5/32 for IPv4, 2001:db8::1/128 for IPv6) are detected via
+	// netip.Prefix.IsSingleIP() by the cloud-specific implementation, which
+	// dispatches to the appropriate underlying API (e.g.
+	// UnassignPrivateIpAddresses vs UnassignENIPrefixes on AWS). Used by the
+	// multi-pool release path.
+	CIDRsToRelease []netip.Prefix
 }
 
 // ErrLimitsNotFound signals lack of limits for given instance type.
@@ -866,6 +1063,15 @@ func (n *Node) handleIPReleaseResponse(markedIP netip.Addr, ipsToRelease *[]neti
 //
 // Handshake would be aborted if there are new allocations and the node doesn't have IPs in excess anymore.
 func (n *Node) handleIPRelease(ctx context.Context, a *maintenanceAction) (instanceMutated bool, err error) {
+	// Multi-pool nodes don't use the 4-state handshake. Release is
+	// handled by handleMultiPoolCIDRRelease.
+	n.mutex.RLock()
+	isMultiPool := n.isMultiPoolNodeLocked()
+	n.mutex.RUnlock()
+	if isMultiPool {
+		return false, nil
+	}
+
 	var ipsToMark []netip.Addr
 	var ipsToRelease []netip.Addr
 
@@ -1030,6 +1236,14 @@ func (n *Node) maintainIPPool(ctx context.Context) (instanceMutated bool, err er
 		n.removeStaleReleaseIPs()
 	}
 
+	// Multi-pool CIDR release path: release CIDRs that the agent has
+	// removed from Allocated after the excessIPReleaseDelay has elapsed.
+	if n.manager.releaseExcessIPs {
+		if mutated, err := n.handleMultiPoolCIDRRelease(ctx); mutated || err != nil {
+			return mutated, err
+		}
+	}
+
 	if len(n.getStaticIPTags()) > 0 {
 		nodeStats := n.Stats()
 
@@ -1120,6 +1334,15 @@ func (n *Node) MaintainIPPool(ctx context.Context) error {
 
 // PopulateIPReleaseStatus Updates cilium node IPAM status with excess IP release data
 func (n *Node) PopulateIPReleaseStatus(node *v2.CiliumNode) {
+	// Multi-pool nodes don't participate in the ReleaseIPs handshake.
+	n.mutex.RLock()
+	isMultiPool := n.isMultiPoolNodeLocked()
+	n.mutex.RUnlock()
+	if isMultiPool {
+		node.Status.IPAM.ReleaseIPs = nil
+		return
+	}
+
 	// maintainIPPool() might not have run yet since the last update from agent.
 	// Attempt to remove any stale entries
 	n.removeStaleReleaseIPs()
@@ -1152,7 +1375,7 @@ func (n *Node) PopulateStaticIPStatus(node *v2.CiliumNode) {
 // [(*Node).resource)] with the K8s apiserver. This operation occurs on an
 // interval to refresh the CiliumNode resource.
 //
-// For Azure and ENI IPAM modes, this function serves two purposes: (1)
+// For cloud provider IPAM modes, this function serves two purposes: (1)
 // finalizes the initialization of the CiliumNode resource (setting
 // PreAllocate) and (2) to keep the resource up-to-date with K8s.
 //

--- a/operator/pkg/ipam/nodemanager/node_manager.go
+++ b/operator/pkg/ipam/nodemanager/node_manager.go
@@ -96,6 +96,28 @@ type NodeOperations interface {
 
 	// IsPrefixDelegated helps identify if a node supports prefix delegation
 	IsPrefixDelegated() bool
+
+	// GetAttachedCIDRs returns the CIDRs currently attached to the node's
+	// network interfaces, as observed by the cloud-specific implementation.
+	// Used by multi-pool mode to reconcile the tracking map against ground
+	// truth (drop CIDRs no longer attached, seed releases that survived an
+	// operator restart). Implementations that do not support multi-pool may
+	// return nil.
+	GetAttachedCIDRs() []netip.Prefix
+
+	// PrepareCIDRRelease maps released CIDRs back to their source
+	// network interfaces and returns release actions grouped by interface.
+	// Used by multi-pool mode where the agent removes CIDRs from
+	// Allocated instead of participating in the IP release handshake.
+	PrepareCIDRRelease(releasedCIDRs []netip.Prefix) []*ReleaseAction
+
+	// ReleaseCIDRs performs the release of the CIDRs listed in
+	// release.CIDRsToRelease. The cloud-specific implementation is responsible
+	// for appropriately handling single-IP CIDRs and larger ones by dispatching to
+	// the appropriate underlying APIs. Returns the subset of CIDRs that were
+	// successfully released so the caller can prune its tracking state even on
+	// partial failure.
+	ReleaseCIDRs(ctx context.Context, release *ReleaseAction) (released []netip.Prefix, err error)
 }
 
 // AllocationImplementation is the interface an implementation must provide.
@@ -155,10 +177,10 @@ type MetricsNodeAPI interface {
 	DeleteNode(node string)
 }
 
-// nodeMap is a mapping of node names to ENI nodes
+// nodeMap is a mapping of node names to nodes
 type nodeMap map[string]*Node
 
-// NodeManager manages all nodes with ENIs
+// NodeManager manages all nodes
 type NodeManager struct {
 	logger               *slog.Logger
 	mutex                lock.RWMutex
@@ -292,7 +314,8 @@ func (n *NodeManager) Upsert(resource *v2.CiliumNode) {
 				ipsMarkedForRelease: make(map[netip.Addr]time.Time),
 				ipReleaseStatus:     make(map[netip.Addr]string),
 			},
-			excessIPReleaseDelay: time.Duration(n.excessIPReleaseDelay) * time.Second,
+			excessIPReleaseDelay:           time.Duration(n.excessIPReleaseDelay) * time.Second,
+			multiPoolCIDRsMarkedForRelease: make(map[netip.Prefix]time.Time),
 		}
 		node.logger.Store(node.rootLogger.With(fieldName, resource.Name))
 
@@ -416,7 +439,7 @@ func (n *NodeManager) Delete(resource *v2.CiliumNode) {
 	// Delete the instance from instanceManager. This will cause Update() to
 	// invoke instancesAPIResync if this instance rejoins the cluster.
 	// This ensures that Node.recalculate() does not use stale data for
-	// instances which rejoin the cluster after their EC2 configuration has changed.
+	// instances which rejoin the cluster after their configuration has changed.
 	if resource.Spec.InstanceID != "" {
 		n.instancesAPI.DeleteInstance(resource.Spec.InstanceID)
 	}

--- a/operator/pkg/ipam/nodemanager/node_manager_test.go
+++ b/operator/pkg/ipam/nodemanager/node_manager_test.go
@@ -83,6 +83,8 @@ type nodeOperationsMock struct {
 	// mutex protects allocatedIPs
 	mutex        lock.RWMutex
 	allocatedIPs []string
+
+	attachedCIDRs []netip.Prefix
 }
 
 func (n *nodeOperationsMock) GetUsedIPWithPrefixes() int {
@@ -191,6 +193,18 @@ func (n *nodeOperationsMock) GetMinimumAllocatableIPv4() int {
 
 func (n *nodeOperationsMock) IsPrefixDelegated() bool {
 	return false
+}
+
+func (n *nodeOperationsMock) GetAttachedCIDRs() []netip.Prefix {
+	return n.attachedCIDRs
+}
+
+func (n *nodeOperationsMock) PrepareCIDRRelease(_ []netip.Prefix) []*ReleaseAction {
+	return nil
+}
+
+func (n *nodeOperationsMock) ReleaseCIDRs(_ context.Context, _ *ReleaseAction) ([]netip.Prefix, error) {
+	return nil, nil
 }
 
 func TestGetNodeNames(t *testing.T) {

--- a/operator/pkg/ipam/nodemanager/node_test.go
+++ b/operator/pkg/ipam/nodemanager/node_test.go
@@ -4,6 +4,8 @@
 package nodemanager
 
 import (
+	"context"
+	"errors"
 	"net/netip"
 	"testing"
 
@@ -11,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 
+	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	"github.com/cilium/cilium/pkg/defaults"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -157,5 +160,468 @@ func TestPoolRequestedIPv4(t *testing.T) {
 		requested, ok := poolRequestedIPv4(cn)
 		require.True(t, ok)
 		require.Equal(t, 0, requested)
+	})
+}
+
+// newMultiPoolNode creates a Node with a CiliumNode that passes the multi-pool
+// heuristic (Pools.Requested present, Status.IPAM.Used empty). The enis map
+// is converted to the attached CIDRs returned by ops.GetAttachedCIDRs.
+func newMultiPoolNode(t *testing.T, allocated []ipamTypes.IPAMPoolAllocation, enis map[string]eniTypes.ENI) *Node {
+	cn := &v2.CiliumNode{}
+	cn.Spec.IPAM.Pools.Requested = []ipamTypes.IPAMPoolRequest{
+		{Pool: defaults.IPAMDefaultIPPool, Needed: ipamTypes.IPAMPoolDemand{IPv4Addrs: 16}},
+	}
+	cn.Spec.IPAM.Pools.Allocated = allocated
+	n := &Node{
+		rootLogger:                     hivetest.Logger(t),
+		resource:                       cn,
+		ops:                            &nodeOperationsMock{attachedCIDRs: enisToCIDRs(enis)},
+		multiPoolCIDRsMarkedForRelease: make(map[netip.Prefix]time.Time),
+	}
+	n.logger.Store(n.rootLogger)
+	return n
+}
+
+// enisToCIDRs flattens a map of ENIs into the CIDRs (addresses as /32,
+// plus prefixes) attached to them.
+func enisToCIDRs(enis map[string]eniTypes.ENI) []netip.Prefix {
+	if enis == nil {
+		return nil
+	}
+	var out []netip.Prefix
+	for _, eni := range enis {
+		for _, prefix := range eni.Prefixes {
+			if p, err := netip.ParsePrefix(prefix); err == nil {
+				out = append(out, p)
+			}
+		}
+		for _, addr := range eni.Addresses {
+			if a, err := netip.ParseAddr(addr); err == nil {
+				out = append(out, netip.PrefixFrom(a, a.BitLen()))
+			}
+		}
+	}
+	return out
+}
+
+func TestTrackMultiPoolAllocatedLocked(t *testing.T) {
+	t.Run("no-op for non-multi-pool node", func(t *testing.T) {
+		n := &Node{
+			resource:                       &v2.CiliumNode{},
+			multiPoolCIDRsMarkedForRelease: make(map[netip.Prefix]time.Time),
+		}
+		// No Pools.Requested -> not multi-pool.
+		n.trackMultiPoolAllocatedLocked()
+		require.Nil(t, n.previousAllocatedCIDRs)
+	})
+
+	t.Run("seed with no ENI orphans does not mark release", func(t *testing.T) {
+		n := newMultiPoolNode(t, []ipamTypes.IPAMPoolAllocation{
+			{Pool: defaults.IPAMDefaultIPPool, CIDRs: []ipamTypes.IPAMCIDR{"10.0.0.1/32", "10.0.0.2/32"}},
+		}, nil)
+
+		n.trackMultiPoolAllocatedLocked()
+
+		require.NotNil(t, n.previousAllocatedCIDRs)
+		require.True(t, n.previousAllocatedCIDRs.Has(netip.MustParsePrefix("10.0.0.1/32")))
+		require.True(t, n.previousAllocatedCIDRs.Has(netip.MustParsePrefix("10.0.0.2/32")))
+		require.Empty(t, n.multiPoolCIDRsMarkedForRelease)
+	})
+
+	t.Run("removed CIDR is marked for release", func(t *testing.T) {
+		enis := map[string]eniTypes.ENI{
+			"eni-1": {Addresses: []string{"10.0.0.1", "10.0.0.2"}},
+		}
+		n := newMultiPoolNode(t, []ipamTypes.IPAMPoolAllocation{
+			{Pool: defaults.IPAMDefaultIPPool, CIDRs: []ipamTypes.IPAMCIDR{"10.0.0.1/32", "10.0.0.2/32"}},
+		}, enis)
+
+		// First call: seed.
+		n.trackMultiPoolAllocatedLocked()
+
+		// Agent removes 10.0.0.2/32 from Allocated.
+		n.resource.Spec.IPAM.Pools.Allocated = []ipamTypes.IPAMPoolAllocation{
+			{Pool: defaults.IPAMDefaultIPPool, CIDRs: []ipamTypes.IPAMCIDR{"10.0.0.1/32"}},
+		}
+		n.trackMultiPoolAllocatedLocked()
+
+		require.Len(t, n.multiPoolCIDRsMarkedForRelease, 1)
+		require.Contains(t, n.multiPoolCIDRsMarkedForRelease, netip.MustParsePrefix("10.0.0.2/32"))
+	})
+
+	t.Run("reappearing CIDR is removed from marked-for-release", func(t *testing.T) {
+		enis := map[string]eniTypes.ENI{
+			"eni-1": {Addresses: []string{"10.0.0.1", "10.0.0.2"}},
+		}
+		n := newMultiPoolNode(t, []ipamTypes.IPAMPoolAllocation{
+			{Pool: defaults.IPAMDefaultIPPool, CIDRs: []ipamTypes.IPAMCIDR{"10.0.0.1/32", "10.0.0.2/32"}},
+		}, enis)
+
+		// First call: seed.
+		n.trackMultiPoolAllocatedLocked()
+
+		// Remove 10.0.0.2/32.
+		n.resource.Spec.IPAM.Pools.Allocated = []ipamTypes.IPAMPoolAllocation{
+			{Pool: defaults.IPAMDefaultIPPool, CIDRs: []ipamTypes.IPAMCIDR{"10.0.0.1/32"}},
+		}
+		n.trackMultiPoolAllocatedLocked()
+		require.Contains(t, n.multiPoolCIDRsMarkedForRelease, netip.MustParsePrefix("10.0.0.2/32"))
+
+		// Agent re-adds 10.0.0.2/32.
+		n.resource.Spec.IPAM.Pools.Allocated = []ipamTypes.IPAMPoolAllocation{
+			{Pool: defaults.IPAMDefaultIPPool, CIDRs: []ipamTypes.IPAMCIDR{"10.0.0.1/32", "10.0.0.2/32"}},
+		}
+		n.trackMultiPoolAllocatedLocked()
+		require.Empty(t, n.multiPoolCIDRsMarkedForRelease)
+	})
+
+	t.Run("CIDR detached from ENI is cleaned up from marked-for-release", func(t *testing.T) {
+		enis := map[string]eniTypes.ENI{
+			"eni-1": {Addresses: []string{"10.0.0.1", "10.0.0.2"}},
+		}
+		n := newMultiPoolNode(t, []ipamTypes.IPAMPoolAllocation{
+			{Pool: defaults.IPAMDefaultIPPool, CIDRs: []ipamTypes.IPAMCIDR{"10.0.0.1/32", "10.0.0.2/32"}},
+		}, enis)
+
+		// First call: seed.
+		n.trackMultiPoolAllocatedLocked()
+
+		// Agent removes 10.0.0.2/32.
+		n.resource.Spec.IPAM.Pools.Allocated = []ipamTypes.IPAMPoolAllocation{
+			{Pool: defaults.IPAMDefaultIPPool, CIDRs: []ipamTypes.IPAMCIDR{"10.0.0.1/32"}},
+		}
+		n.trackMultiPoolAllocatedLocked()
+		require.Contains(t, n.multiPoolCIDRsMarkedForRelease, netip.MustParsePrefix("10.0.0.2/32"))
+
+		// ENI status updated: 10.0.0.2 no longer attached (operator detached it).
+		n.ops.(*nodeOperationsMock).attachedCIDRs = enisToCIDRs(map[string]eniTypes.ENI{
+			"eni-1": {Addresses: []string{"10.0.0.1"}},
+		})
+		n.trackMultiPoolAllocatedLocked()
+		require.Empty(t, n.multiPoolCIDRsMarkedForRelease)
+	})
+
+	t.Run("already-marked CIDR keeps original timestamp", func(t *testing.T) {
+		enis := map[string]eniTypes.ENI{
+			"eni-1": {Addresses: []string{"10.0.0.1", "10.0.0.2"}},
+		}
+		n := newMultiPoolNode(t, []ipamTypes.IPAMPoolAllocation{
+			{Pool: defaults.IPAMDefaultIPPool, CIDRs: []ipamTypes.IPAMCIDR{"10.0.0.1/32", "10.0.0.2/32"}},
+		}, enis)
+
+		// First call: seed.
+		n.trackMultiPoolAllocatedLocked()
+
+		// Remove 10.0.0.2/32.
+		n.resource.Spec.IPAM.Pools.Allocated = []ipamTypes.IPAMPoolAllocation{
+			{Pool: defaults.IPAMDefaultIPPool, CIDRs: []ipamTypes.IPAMCIDR{"10.0.0.1/32"}},
+		}
+		n.trackMultiPoolAllocatedLocked()
+		firstTS := n.multiPoolCIDRsMarkedForRelease[netip.MustParsePrefix("10.0.0.2/32")]
+
+		// Call again, timestamp should not change.
+		n.trackMultiPoolAllocatedLocked()
+		require.Equal(t, firstTS, n.multiPoolCIDRsMarkedForRelease[netip.MustParsePrefix("10.0.0.2/32")])
+	})
+
+	t.Run("prefix delegation CIDR tracked correctly", func(t *testing.T) {
+		enis := map[string]eniTypes.ENI{
+			"eni-1": {
+				Addresses: []string{"10.0.0.1"},
+				Prefixes:  []string{"10.0.0.16/28"},
+			},
+		}
+		n := newMultiPoolNode(t, []ipamTypes.IPAMPoolAllocation{
+			{Pool: defaults.IPAMDefaultIPPool, CIDRs: []ipamTypes.IPAMCIDR{"10.0.0.1/32", "10.0.0.16/28"}},
+		}, enis)
+
+		// First call: seed.
+		n.trackMultiPoolAllocatedLocked()
+
+		// Agent releases the /28 prefix.
+		n.resource.Spec.IPAM.Pools.Allocated = []ipamTypes.IPAMPoolAllocation{
+			{Pool: defaults.IPAMDefaultIPPool, CIDRs: []ipamTypes.IPAMCIDR{"10.0.0.1/32"}},
+		}
+		n.trackMultiPoolAllocatedLocked()
+
+		require.Len(t, n.multiPoolCIDRsMarkedForRelease, 1)
+		require.Contains(t, n.multiPoolCIDRsMarkedForRelease, netip.MustParsePrefix("10.0.0.16/28"))
+	})
+}
+
+// multiPoolOpsMock is a focused NodeOperations mock for the
+// handleMultiPoolCIDRRelease tests. It records calls and allows error
+// injection. Unused methods are inherited from nodeOperationsMock as no-ops.
+type multiPoolOpsMock struct {
+	nodeOperationsMock
+
+	prepare   func(released []netip.Prefix) []*ReleaseAction
+	releaseFn func(*ReleaseAction) ([]netip.Prefix, error)
+
+	prepareCalls [][]netip.Prefix
+	releaseCalls []*ReleaseAction
+}
+
+func (m *multiPoolOpsMock) PrepareCIDRRelease(released []netip.Prefix) []*ReleaseAction {
+	m.prepareCalls = append(m.prepareCalls, append([]netip.Prefix(nil), released...))
+	if m.prepare != nil {
+		return m.prepare(released)
+	}
+	return nil
+}
+
+func (m *multiPoolOpsMock) ReleaseCIDRs(_ context.Context, action *ReleaseAction) ([]netip.Prefix, error) {
+	m.releaseCalls = append(m.releaseCalls, snapshotAction(action))
+	if m.releaseFn != nil {
+		return m.releaseFn(action)
+	}
+	return append([]netip.Prefix(nil), action.CIDRsToRelease...), nil
+}
+
+func snapshotAction(a *ReleaseAction) *ReleaseAction {
+	c := *a
+	c.CIDRsToRelease = append([]netip.Prefix(nil), a.CIDRsToRelease...)
+	return &c
+}
+
+func TestHandleMultiPoolCIDRRelease(t *testing.T) {
+	setupNode := func(t *testing.T, mock *multiPoolOpsMock, marked map[netip.Prefix]time.Time, multiPool bool) *Node {
+		n := &Node{
+			rootLogger:                     hivetest.Logger(t),
+			ops:                            mock,
+			excessIPReleaseDelay:           5 * time.Second,
+			multiPoolCIDRsMarkedForRelease: marked,
+		}
+		n.logger.Store(n.rootLogger)
+		cn := &v2.CiliumNode{}
+		if multiPool {
+			cn.Spec.IPAM.Pools.Requested = []ipamTypes.IPAMPoolRequest{
+				{Pool: defaults.IPAMDefaultIPPool, Needed: ipamTypes.IPAMPoolDemand{IPv4Addrs: 16}},
+			}
+		}
+		n.resource = cn
+		return n
+	}
+
+	past := func() time.Time { return time.Now().Add(-time.Hour) }
+
+	t.Run("no-op for non-multi-pool node", func(t *testing.T) {
+		mock := &multiPoolOpsMock{}
+		n := setupNode(t, mock, map[netip.Prefix]time.Time{
+			netip.MustParsePrefix("10.0.0.1/32"): past(),
+		}, false)
+
+		mutated, err := n.handleMultiPoolCIDRRelease(context.Background())
+		require.NoError(t, err)
+		require.False(t, mutated)
+		require.Empty(t, mock.prepareCalls)
+	})
+
+	t.Run("no-op when marked map is empty", func(t *testing.T) {
+		mock := &multiPoolOpsMock{}
+		n := setupNode(t, mock, map[netip.Prefix]time.Time{}, true)
+
+		mutated, err := n.handleMultiPoolCIDRRelease(context.Background())
+		require.NoError(t, err)
+		require.False(t, mutated)
+		require.Empty(t, mock.prepareCalls)
+	})
+
+	t.Run("no-op when delay has not elapsed", func(t *testing.T) {
+		mock := &multiPoolOpsMock{}
+		n := setupNode(t, mock, map[netip.Prefix]time.Time{
+			netip.MustParsePrefix("10.0.0.1/32"): time.Now(),
+		}, true)
+
+		mutated, err := n.handleMultiPoolCIDRRelease(context.Background())
+		require.NoError(t, err)
+		require.False(t, mutated)
+		require.Empty(t, mock.prepareCalls)
+	})
+
+	t.Run("no-op when PrepareCIDRRelease returns no actions", func(t *testing.T) {
+		cidr := netip.MustParsePrefix("10.0.0.5/32")
+		mock := &multiPoolOpsMock{
+			prepare: func([]netip.Prefix) []*ReleaseAction { return nil },
+		}
+		n := setupNode(t, mock, map[netip.Prefix]time.Time{cidr: past()}, true)
+
+		mutated, err := n.handleMultiPoolCIDRRelease(context.Background())
+		require.NoError(t, err)
+		require.False(t, mutated)
+		// CIDR still tracked so the operator will retry on the next pass.
+		require.Contains(t, n.multiPoolCIDRsMarkedForRelease, cidr)
+	})
+
+	t.Run("releases single IPs and clears them from the marked map", func(t *testing.T) {
+		cidr := netip.MustParsePrefix("10.0.0.5/32")
+		mock := &multiPoolOpsMock{
+			prepare: func([]netip.Prefix) []*ReleaseAction {
+				return []*ReleaseAction{{
+					InterfaceID:    "eni-1",
+					CIDRsToRelease: []netip.Prefix{cidr},
+				}}
+			},
+		}
+		n := setupNode(t, mock, map[netip.Prefix]time.Time{cidr: past()}, true)
+
+		mutated, err := n.handleMultiPoolCIDRRelease(context.Background())
+		require.NoError(t, err)
+		require.True(t, mutated)
+		require.Len(t, mock.releaseCalls, 1)
+		require.Equal(t, []netip.Prefix{cidr}, mock.releaseCalls[0].CIDRsToRelease)
+		require.Empty(t, n.multiPoolCIDRsMarkedForRelease)
+	})
+
+	t.Run("releases prefixes and clears them from the marked map", func(t *testing.T) {
+		cidr := netip.MustParsePrefix("10.0.0.16/28")
+		mock := &multiPoolOpsMock{
+			prepare: func([]netip.Prefix) []*ReleaseAction {
+				return []*ReleaseAction{{
+					InterfaceID:    "eni-1",
+					CIDRsToRelease: []netip.Prefix{cidr},
+				}}
+			},
+		}
+		n := setupNode(t, mock, map[netip.Prefix]time.Time{cidr: past()}, true)
+
+		mutated, err := n.handleMultiPoolCIDRRelease(context.Background())
+		require.NoError(t, err)
+		require.True(t, mutated)
+		require.Len(t, mock.releaseCalls, 1)
+		require.Equal(t, []netip.Prefix{cidr}, mock.releaseCalls[0].CIDRsToRelease)
+		require.Empty(t, n.multiPoolCIDRsMarkedForRelease)
+	})
+
+	t.Run("only CIDRs past the delay are selected", func(t *testing.T) {
+		ready := netip.MustParsePrefix("10.0.0.5/32")
+		notReady := netip.MustParsePrefix("10.0.0.6/32")
+		mock := &multiPoolOpsMock{
+			prepare: func(released []netip.Prefix) []*ReleaseAction {
+				require.Equal(t, []netip.Prefix{ready}, released)
+				return []*ReleaseAction{{
+					InterfaceID:    "eni-1",
+					CIDRsToRelease: []netip.Prefix{ready},
+				}}
+			},
+		}
+		n := setupNode(t, mock, map[netip.Prefix]time.Time{
+			ready:    past(),
+			notReady: time.Now(),
+		}, true)
+
+		mutated, err := n.handleMultiPoolCIDRRelease(context.Background())
+		require.NoError(t, err)
+		require.True(t, mutated)
+		require.NotContains(t, n.multiPoolCIDRsMarkedForRelease, ready)
+		require.Contains(t, n.multiPoolCIDRsMarkedForRelease, notReady)
+	})
+
+	t.Run("re-check filters out CIDRs re-added between selection and release", func(t *testing.T) {
+		// Both CIDRs are past the delay. Mid-PrepareCIDRRelease, simulate
+		// trackMultiPoolAllocatedLocked observing the agent re-adding `readd`
+		// by deleting it from the marked map. The re-check inside
+		// handleMultiPoolCIDRRelease must drop it from the EC2 call.
+		keep := netip.MustParsePrefix("10.0.0.16/28")
+		readd := netip.MustParsePrefix("10.0.0.32/28")
+		var n *Node
+		mock := &multiPoolOpsMock{
+			prepare: func([]netip.Prefix) []*ReleaseAction {
+				n.mutex.Lock()
+				delete(n.multiPoolCIDRsMarkedForRelease, readd)
+				n.mutex.Unlock()
+				return []*ReleaseAction{{
+					InterfaceID:    "eni-1",
+					CIDRsToRelease: []netip.Prefix{keep, readd},
+				}}
+			},
+		}
+		n = setupNode(t, mock, map[netip.Prefix]time.Time{
+			keep:  past(),
+			readd: past(),
+		}, true)
+
+		mutated, err := n.handleMultiPoolCIDRRelease(context.Background())
+		require.NoError(t, err)
+		require.True(t, mutated)
+		require.Len(t, mock.releaseCalls, 1)
+		require.Equal(t, []netip.Prefix{keep}, mock.releaseCalls[0].CIDRsToRelease)
+		require.NotContains(t, n.multiPoolCIDRsMarkedForRelease, keep)
+		require.NotContains(t, n.multiPoolCIDRsMarkedForRelease, readd)
+	})
+
+	t.Run("ReleaseCIDRs error preserves unreleased CIDRs in marked map", func(t *testing.T) {
+		prefix := netip.MustParsePrefix("10.0.0.16/28")
+		ip := netip.MustParsePrefix("10.0.0.5/32")
+		mock := &multiPoolOpsMock{
+			prepare: func([]netip.Prefix) []*ReleaseAction {
+				return []*ReleaseAction{{
+					InterfaceID:    "eni-1",
+					CIDRsToRelease: []netip.Prefix{prefix, ip},
+				}}
+			},
+			releaseFn: func(*ReleaseAction) ([]netip.Prefix, error) {
+				return nil, errors.New("ec2 boom")
+			},
+		}
+		n := setupNode(t, mock, map[netip.Prefix]time.Time{
+			prefix: past(),
+			ip:     past(),
+		}, true)
+
+		mutated, err := n.handleMultiPoolCIDRRelease(context.Background())
+		require.Error(t, err)
+		require.False(t, mutated)
+		require.Contains(t, n.multiPoolCIDRsMarkedForRelease, prefix)
+		require.Contains(t, n.multiPoolCIDRsMarkedForRelease, ip)
+	})
+
+	t.Run("partial release on error clears only the released subset", func(t *testing.T) {
+		prefix := netip.MustParsePrefix("10.0.0.16/28")
+		ip := netip.MustParsePrefix("10.0.0.5/32")
+		mock := &multiPoolOpsMock{
+			prepare: func([]netip.Prefix) []*ReleaseAction {
+				return []*ReleaseAction{{
+					InterfaceID:    "eni-1",
+					CIDRsToRelease: []netip.Prefix{prefix, ip},
+				}}
+			},
+			releaseFn: func(*ReleaseAction) ([]netip.Prefix, error) {
+				return []netip.Prefix{prefix}, errors.New("ec2 boom")
+			},
+		}
+		n := setupNode(t, mock, map[netip.Prefix]time.Time{
+			prefix: past(),
+			ip:     past(),
+		}, true)
+
+		mutated, err := n.handleMultiPoolCIDRRelease(context.Background())
+		require.Error(t, err)
+		require.True(t, mutated)
+		require.NotContains(t, n.multiPoolCIDRsMarkedForRelease, prefix)
+		require.Contains(t, n.multiPoolCIDRsMarkedForRelease, ip)
+	})
+
+	t.Run("multiple actions across ENIs each clear their own entries", func(t *testing.T) {
+		cidr1 := netip.MustParsePrefix("10.0.0.5/32")
+		cidr2 := netip.MustParsePrefix("10.0.1.5/32")
+		mock := &multiPoolOpsMock{
+			prepare: func([]netip.Prefix) []*ReleaseAction {
+				return []*ReleaseAction{
+					{InterfaceID: "eni-1", CIDRsToRelease: []netip.Prefix{cidr1}},
+					{InterfaceID: "eni-2", CIDRsToRelease: []netip.Prefix{cidr2}},
+				}
+			},
+		}
+		n := setupNode(t, mock, map[netip.Prefix]time.Time{
+			cidr1: past(),
+			cidr2: past(),
+		}, true)
+
+		mutated, err := n.handleMultiPoolCIDRRelease(context.Background())
+		require.NoError(t, err)
+		require.True(t, mutated)
+		require.Len(t, mock.releaseCalls, 2)
+		require.Empty(t, n.multiPoolCIDRsMarkedForRelease)
 	})
 }

--- a/pkg/alibabacloud/eni/node.go
+++ b/pkg/alibabacloud/eni/node.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/netip"
 
 	"github.com/cilium/cilium/operator/pkg/ipam/nodemanager"
 	"github.com/cilium/cilium/operator/pkg/ipam/stats"
@@ -421,6 +422,24 @@ func (n *Node) loggerLocked() *slog.Logger {
 
 func (n *Node) IsPrefixDelegated() bool {
 	return false
+}
+
+// GetAttachedCIDRs is a no-op since AlibabaCloud does not use multi-pool
+// but uses the CRD allocator.
+func (n *Node) GetAttachedCIDRs() []netip.Prefix {
+	return nil
+}
+
+// PrepareCIDRRelease is a no-op since AlibabaCloud does not use multi-pool
+// but uses the CRD allocator, that's backed by PrepareIPRelease
+func (n *Node) PrepareCIDRRelease(_ []netip.Prefix) []*nodemanager.ReleaseAction {
+	return nil
+}
+
+// ReleaseCIDRs is a no-op since AlibabaCloud does not use multi-pool but
+// uses the CRD allocator, that's backed by ReleaseIPs/ReleaseIPPrefixes
+func (n *Node) ReleaseCIDRs(_ context.Context, _ *nodemanager.ReleaseAction) ([]netip.Prefix, error) {
+	return nil, nil
 }
 
 // getLimits returns the interface and IP limits of this node

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -31,6 +31,7 @@ import (
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	cslices "github.com/cilium/cilium/pkg/slices"
 )
 
 const (
@@ -141,6 +142,10 @@ func (n *Node) getLimitsLocked() (ipamTypes.Limits, bool) {
 }
 
 // PrepareIPRelease prepares the release of ENI IPs.
+//
+// This function only covers 1.19 and below agents that use the CRD allocator.
+// 1.20+ agents use the multipool allocator and their IP release mechanism uses
+// PrepareCIDRRelease instead.
 func (n *Node) PrepareIPRelease(excessIPs int, scopedLog *slog.Logger) *nodemanager.ReleaseAction {
 	r := &nodemanager.ReleaseAction{}
 
@@ -268,7 +273,131 @@ func (n *Node) PrepareIPRelease(excessIPs int, scopedLog *slog.Logger) *nodemana
 	return r
 }
 
+// GetAttachedCIDRs returns the CIDRs (addresses as /32 or /128, and
+// prefixes) currently attached across all ENIs of this node.
+func (n *Node) GetAttachedCIDRs() []netip.Prefix {
+	n.mutex.RLock()
+	defer n.mutex.RUnlock()
+
+	var attached []netip.Prefix
+	for _, eni := range n.enis {
+		for _, prefix := range eni.Prefixes {
+			if p, err := netip.ParsePrefix(prefix); err == nil {
+				attached = append(attached, p)
+			}
+		}
+		for _, addr := range eni.Addresses {
+			if a, err := netip.ParseAddr(addr); err == nil {
+				attached = append(attached, netip.PrefixFrom(a, a.BitLen()))
+			}
+		}
+	}
+	return attached
+}
+
+// PrepareCIDRRelease maps released CIDRs back to their source ENIs
+// and returns release actions grouped by ENI interface ID.
+func (n *Node) PrepareCIDRRelease(releasedCIDRs []netip.Prefix) []*nodemanager.ReleaseAction {
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
+
+	type eniRelease struct {
+		cidrs    []netip.Prefix
+		subnetID string
+	}
+	byENI := map[string]*eniRelease{}
+
+	for _, prefix := range releasedCIDRs {
+		for eniID, eni := range n.enis {
+			if eni.IsExcludedBySpec(n.k8sObj.Spec.ENI) {
+				continue
+			}
+
+			// Never release an ENI's primary IP. AWS rejects the
+			// UnassignPrivateIpAddresses call for primary IPs, which
+			// would leave the CIDR stuck in the release-marked map.
+			// Only reachable when UsePrimaryAddress is true, since
+			// otherwise the primary is filtered out of eni.Addresses
+			// at the EC2 layer.
+			if prefix.IsSingleIP() && prefix.Addr().String() == eni.IP {
+				break
+			}
+
+			var found bool
+			if prefix.IsSingleIP() {
+				found = slices.Contains(eni.Addresses, prefix.Addr().String())
+			} else {
+				found = slices.Contains(eni.Prefixes, prefix.String())
+			}
+			if !found {
+				continue
+			}
+
+			rel, ok := byENI[eniID]
+			if !ok {
+				rel = &eniRelease{subnetID: eni.Subnet.ID}
+				byENI[eniID] = rel
+			}
+			rel.cidrs = append(rel.cidrs, prefix)
+			break // Found the ENI, move to next CIDR.
+		}
+	}
+
+	actions := make([]*nodemanager.ReleaseAction, 0, len(byENI))
+	for eniID, rel := range byENI {
+		actions = append(actions, &nodemanager.ReleaseAction{
+			InterfaceID:    eniID,
+			PoolID:         ipamTypes.PoolID(rel.subnetID),
+			CIDRsToRelease: rel.cidrs,
+		})
+	}
+	return actions
+}
+
+// ReleaseCIDRs releases the CIDRs in release.CIDRsToRelease from the ENI
+// identified by release.InterfaceID. Single-IP entries are unassigned via
+// UnassignPrivateIpAddresses; larger prefixes via UnassignENIPrefixes.
+//
+// Prefixes are released first, then single IPs. The returned slice contains
+// the CIDRs that were successfully released so the caller can prune its
+// tracking state even on partial failure.
+func (n *Node) ReleaseCIDRs(ctx context.Context, r *nodemanager.ReleaseAction) ([]netip.Prefix, error) {
+	var prefixes, ips []netip.Prefix
+	for _, c := range r.CIDRsToRelease {
+		if c.IsSingleIP() {
+			ips = append(ips, c)
+		} else {
+			prefixes = append(prefixes, c)
+		}
+	}
+
+	released := make([]netip.Prefix, 0, len(r.CIDRsToRelease))
+
+	if len(prefixes) > 0 {
+		strs := cslices.Map(prefixes, netip.Prefix.String)
+		if err := n.manager.ec2api.UnassignENIPrefixes(ctx, r.InterfaceID, strs); err != nil {
+			return released, err
+		}
+		released = append(released, prefixes...)
+	}
+
+	if len(ips) > 0 {
+		strs := cslices.Map(ips, func(p netip.Prefix) string { return p.Addr().String() })
+		if err := n.manager.ec2api.UnassignPrivateIpAddresses(ctx, r.InterfaceID, strs); err != nil {
+			return released, err
+		}
+		n.manager.RemoveIPsFromENI(n.node.InstanceID(), r.InterfaceID, strs)
+		released = append(released, ips...)
+	}
+
+	return released, nil
+}
+
 // ReleaseIPPrefixes performs the ENI IPPrefixes release operation
+//
+// This function only covers 1.19 and below agents that use the CRD allocator.
+// 1.20+ agents use the multipool allocator and their IP release mechanism uses
+// ReleaseCIDRs instead.
 func (n *Node) ReleaseIPPrefixes(ctx context.Context, r *nodemanager.ReleaseAction) error {
 	if err := n.manager.ec2api.UnassignENIPrefixes(ctx, r.InterfaceID, r.IPPrefixesToRelease); err != nil {
 		return err
@@ -312,6 +441,10 @@ func getIndividualIPs(ipPrefixes, ipAddresses []string) (individualIPs []string)
 }
 
 // ReleaseIPs performs the ENI IP release operation
+//
+// This function only covers 1.19 and below agents that use the CRD allocator.
+// 1.20+ agents use the multipool allocator and their IP release mechanism uses
+// ReleaseCIDRs instead.
 func (n *Node) ReleaseIPs(ctx context.Context, r *nodemanager.ReleaseAction) error {
 	// Filter IPs that do not belong to any IPPrefix
 	if len(r.IPPrefixesToRelease) > 0 {

--- a/pkg/aws/eni/node_test.go
+++ b/pkg/aws/eni/node_test.go
@@ -4,6 +4,7 @@
 package eni
 
 import (
+	"net/netip"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
@@ -285,4 +286,184 @@ func TestIsPrefixDelegated(t *testing.T) {
 			require.Equal(t, tt.expectDelegated, n.IsPrefixDelegated())
 		})
 	}
+}
+
+func TestGetAttachedCIDRs(t *testing.T) {
+	newNode := func(enis map[string]types.ENI) *Node {
+		n := &Node{
+			rootLogger: hivetest.Logger(t),
+			enis:       enis,
+			k8sObj:     &v2.CiliumNode{},
+		}
+		n.logger.Store(n.rootLogger)
+		return n
+	}
+
+	t.Run("no ENIs returns empty set", func(t *testing.T) {
+		n := newNode(nil)
+		require.Empty(t, n.GetAttachedCIDRs())
+	})
+
+	t.Run("addresses and prefixes from multiple ENIs are merged", func(t *testing.T) {
+		n := newNode(map[string]types.ENI{
+			"eni-1": {
+				Addresses: []string{"10.0.0.1"},
+				Prefixes:  []string{"10.0.0.16/28"},
+			},
+			"eni-2": {
+				Addresses: []string{"2001:db8::1"},
+				Prefixes:  []string{"2001:db8:1::/80"},
+			},
+		})
+
+		require.ElementsMatch(t, []netip.Prefix{
+			netip.MustParsePrefix("10.0.0.1/32"),
+			netip.MustParsePrefix("10.0.0.16/28"),
+			netip.MustParsePrefix("2001:db8::1/128"),
+			netip.MustParsePrefix("2001:db8:1::/80"),
+		}, n.GetAttachedCIDRs())
+	})
+}
+
+func TestPrepareCIDRRelease(t *testing.T) {
+	newNode := func(enis map[string]types.ENI) *Node {
+		n := &Node{
+			rootLogger: hivetest.Logger(t),
+			enis:       enis,
+			k8sObj:     &v2.CiliumNode{},
+		}
+		n.logger.Store(n.rootLogger)
+		return n
+	}
+
+	t.Run("secondary IP mapped to correct ENI", func(t *testing.T) {
+		n := newNode(map[string]types.ENI{
+			"eni-1": {
+				Addresses: []string{"10.0.0.1", "10.0.0.2"},
+				Subnet:    types.AwsSubnet{ID: "subnet-1"},
+			},
+			"eni-2": {
+				Addresses: []string{"10.0.1.1"},
+				Subnet:    types.AwsSubnet{ID: "subnet-2"},
+			},
+		})
+
+		actions := n.PrepareCIDRRelease([]netip.Prefix{netip.MustParsePrefix("10.0.1.1/32")})
+
+		require.Len(t, actions, 1)
+		require.Equal(t, "eni-2", actions[0].InterfaceID)
+		require.Equal(t, ipamTypes.PoolID("subnet-2"), actions[0].PoolID)
+		require.Equal(t, []netip.Prefix{netip.MustParsePrefix("10.0.1.1/32")}, actions[0].CIDRsToRelease)
+	})
+
+	t.Run("prefix mapped to correct ENI", func(t *testing.T) {
+		n := newNode(map[string]types.ENI{
+			"eni-1": {
+				Addresses: []string{"10.0.0.1"},
+				Prefixes:  []string{"10.0.0.16/28"},
+				Subnet:    types.AwsSubnet{ID: "subnet-1"},
+			},
+		})
+
+		actions := n.PrepareCIDRRelease([]netip.Prefix{netip.MustParsePrefix("10.0.0.16/28")})
+
+		require.Len(t, actions, 1)
+		require.Equal(t, "eni-1", actions[0].InterfaceID)
+		require.Equal(t, []netip.Prefix{netip.MustParsePrefix("10.0.0.16/28")}, actions[0].CIDRsToRelease)
+	})
+
+	t.Run("multiple CIDRs on same ENI grouped into one action", func(t *testing.T) {
+		n := newNode(map[string]types.ENI{
+			"eni-1": {
+				Addresses: []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"},
+				Subnet:    types.AwsSubnet{ID: "subnet-1"},
+			},
+		})
+
+		actions := n.PrepareCIDRRelease([]netip.Prefix{netip.MustParsePrefix("10.0.0.1/32"), netip.MustParsePrefix("10.0.0.3/32")})
+
+		require.Len(t, actions, 1)
+		require.Equal(t, "eni-1", actions[0].InterfaceID)
+		require.ElementsMatch(t, []netip.Prefix{netip.MustParsePrefix("10.0.0.1/32"), netip.MustParsePrefix("10.0.0.3/32")}, actions[0].CIDRsToRelease)
+	})
+
+	t.Run("CIDRs on different ENIs produce separate actions", func(t *testing.T) {
+		n := newNode(map[string]types.ENI{
+			"eni-1": {
+				Addresses: []string{"10.0.0.1"},
+				Subnet:    types.AwsSubnet{ID: "subnet-1"},
+			},
+			"eni-2": {
+				Addresses: []string{"10.0.1.1"},
+				Subnet:    types.AwsSubnet{ID: "subnet-2"},
+			},
+		})
+
+		actions := n.PrepareCIDRRelease([]netip.Prefix{netip.MustParsePrefix("10.0.0.1/32"), netip.MustParsePrefix("10.0.1.1/32")})
+
+		require.Len(t, actions, 2)
+		eniIDs := map[string]bool{}
+		for _, a := range actions {
+			eniIDs[a.InterfaceID] = true
+		}
+		require.True(t, eniIDs["eni-1"])
+		require.True(t, eniIDs["eni-2"])
+	})
+
+	t.Run("excluded ENIs are skipped", func(t *testing.T) {
+		n := newNode(map[string]types.ENI{
+			"eni-1": {
+				Addresses: []string{"10.0.0.1"},
+				Subnet:    types.AwsSubnet{ID: "subnet-1"},
+				Tags:      map[string]string{"skip": "true"},
+			},
+		})
+		n.k8sObj.Spec.ENI.ExcludeInterfaceTags = map[string]string{"skip": "true"}
+
+		actions := n.PrepareCIDRRelease([]netip.Prefix{netip.MustParsePrefix("10.0.0.1/32")})
+
+		require.Empty(t, actions)
+	})
+
+	t.Run("CIDR not found on any ENI produces no action", func(t *testing.T) {
+		n := newNode(map[string]types.ENI{
+			"eni-1": {
+				Addresses: []string{"10.0.0.1"},
+				Subnet:    types.AwsSubnet{ID: "subnet-1"},
+			},
+		})
+
+		actions := n.PrepareCIDRRelease([]netip.Prefix{netip.MustParsePrefix("10.99.99.99/32")})
+
+		require.Empty(t, actions)
+	})
+
+	t.Run("empty input returns empty result", func(t *testing.T) {
+		n := newNode(map[string]types.ENI{
+			"eni-1": {Addresses: []string{"10.0.0.1"}},
+		})
+
+		actions := n.PrepareCIDRRelease(nil)
+		require.Empty(t, actions)
+	})
+
+	t.Run("primary IP is never released", func(t *testing.T) {
+		// With UsePrimaryAddress=true, the primary IP is included in
+		// eni.Addresses. The release path must still refuse to release
+		// it because AWS rejects UnassignPrivateIpAddresses on a primary.
+		n := newNode(map[string]types.ENI{
+			"eni-1": {
+				IP:        "10.0.0.1",
+				Addresses: []string{"10.0.0.1", "10.0.0.2"},
+				Subnet:    types.AwsSubnet{ID: "subnet-1"},
+			},
+		})
+
+		actions := n.PrepareCIDRRelease(
+			[]netip.Prefix{netip.MustParsePrefix("10.0.0.1/32"), netip.MustParsePrefix("10.0.0.2/32")},
+		)
+
+		require.Len(t, actions, 1)
+		require.Equal(t, []netip.Prefix{netip.MustParsePrefix("10.0.0.2/32")}, actions[0].CIDRsToRelease)
+	})
 }

--- a/pkg/azure/ipam/node.go
+++ b/pkg/azure/ipam/node.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/netip"
 
 	"github.com/cilium/cilium/operator/pkg/ipam/nodemanager"
 	"github.com/cilium/cilium/operator/pkg/ipam/stats"
@@ -240,6 +241,24 @@ func (n *Node) GetMinimumAllocatableIPv4() int {
 
 func (n *Node) IsPrefixDelegated() bool {
 	return false
+}
+
+// GetAttachedCIDRs is a no-op since Azure does not use multi-pool but uses
+// the CRD allocator.
+func (n *Node) GetAttachedCIDRs() []netip.Prefix {
+	return nil
+}
+
+// PrepareCIDRRelease is a no-op since Azure does not use multi-pool but uses
+// the CRD allocator, that's backed by PrepareIPRelease
+func (n *Node) PrepareCIDRRelease(_ []netip.Prefix) []*nodemanager.ReleaseAction {
+	return nil
+}
+
+// ReleaseCIDRs is a no-op since Azure does not use multi-pool but uses the
+// CRD allocator, that's backed by ReleaseIPs/ReleaseIPPrefixes
+func (n *Node) ReleaseCIDRs(_ context.Context, _ *nodemanager.ReleaseAction) ([]netip.Prefix, error) {
+	return nil, nil
 }
 
 // isAvailableInterface returns whether interface is available and the number of available IPs to allocate in interface


### PR DESCRIPTION
In #45154, the agent switched from using the CRD allocator to using the multipool allocator when in ENI IPAM mode. This PR is a followup that implements an IP/prefix release mechanism in the operator that's compatible with a multipool agent.

In CRD mode, we currently rely on the following 4-way handshake between the agent and operator to release IPs:
* The operator detects excess IPs by comparing available IPs and `Status.IPAM.Used`. It marks those in `Status.IPAM.ReleaseIPs` as `marked-for-release`.
* The agent confirms that these IPs are safe to be released by updating them to `ready-for-release` in `Status.IPAM.ReleaseIPs`.
* The operator detaches the IPs from the ENI and marks them as `released` in `Status.IPAM.ReleaseIPs`.
* The agent sees that and removes the IPs from `Status.IPAM.ReleaseIPs`.

Here for multipool ENI, we implement a slightly simpler handshake between the agent and operator that does not rely on the `Status.IPAM.ReleaseIPs` field.

The new release mechanism is as follows:
* The agent removes unused and in excess CIDRs from `Spec.IPAM.Pools.Allocated`
* The operator sees that and starts tracking those CIDRs in an internal `previousAllocatedCIDRs` state.
* If more than `excessIPReleaseDelay` has passed since a given CIDR was first detected as removed from `Spec.IPAM.Pools.Allocated` and it is still missing from it, then the operator proceeds to detaching the IP/prefix from the ENI.

So the main difference is that the release is now driven by the agent instead of the operator. Otherwise, the resulting behavior is equivalent.

Existing logic in the operator supporting the IP release mechanism for CRD ENI agents is preserved to keep compatibility with 1.19 agents during the upgrade to 1.20. This will be removed in 1.21.

Relates to cilium/design-cfps#87

Note: this is the last major functional change related to cilium/design-cfps#87, only remaining followups will be documentation update and post 1.20 release cleanup.