### PR TITLE
Fix golangci-lint v2.12+ findings

### DIFF
--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -545,8 +545,7 @@ func (ipam *LBIPAM) serviceViewFromService(key resource.Key, svc *slim_core_v1.S
 func (ipam *LBIPAM) stripInvalidAllocations(sv *ServiceView) error {
 	var errs error
 	// Remove bad allocations which are no longer valid
-	for allocIdx := len(sv.AllocatedIPs) - 1; allocIdx >= 0; allocIdx-- {
-		alloc := sv.AllocatedIPs[allocIdx]
+	for allocIdx, alloc := range slices.Backward(sv.AllocatedIPs) {
 		cluster, _ := alloc.Origin.alloc.Get(alloc.IP)
 
 		releaseAllocIP := func() {
@@ -1357,8 +1356,7 @@ func (ipam *LBIPAM) handlePoolModified(ctx context.Context, existingPool *LBPool
 	}
 
 	// Remove existing ranges that no longer exist
-	for i := len(existingPool.ranges) - 1; i >= 0; i-- {
-		extRange := existingPool.ranges[i]
+	for i, extRange := range slices.Backward(existingPool.ranges) {
 		found := false
 		fromCidr := false
 		for _, newRange := range newRanges {
@@ -1607,9 +1605,7 @@ func (ipam *LBIPAM) setPoolCondition(
 func (ipam *LBIPAM) deleteRangeAllocations(delRange *LBRange) []*ServiceView {
 	delAllocs := func(sv *ServiceView) bool {
 		svModified := false
-		for i := len(sv.AllocatedIPs) - 1; i >= 0; i-- {
-			alloc := sv.AllocatedIPs[i]
-
+		for i, alloc := range slices.Backward(sv.AllocatedIPs) {
 			if alloc.Origin == delRange {
 				sv.AllocatedIPs = slices.Delete(sv.AllocatedIPs, i, i+1)
 				svModified = true

--- a/pkg/container/bitlpm/trie.go
+++ b/pkg/container/bitlpm/trie.go
@@ -5,6 +5,7 @@ package bitlpm
 
 import (
 	"container/heap"
+	"slices"
 )
 
 // Trie is a [non-preemptive] [binary] [trie] that indexes arbitrarily long
@@ -504,8 +505,8 @@ func (t *trie[K, T]) treverse(prefixLen uint, k K, fn func(currentNode *node[K, 
 	}
 
 	// Call the function for stacked nodes in reverse order, i.e., longest-prefix-match first
-	for i := len(stack) - 1; i >= 0; i-- {
-		if !fn(stack[i]) {
+	for _, node := range slices.Backward(stack) {
+		if !fn(node) {
 			return
 		}
 	}

--- a/pkg/container/bitlpm/unsigned_test.go
+++ b/pkg/container/bitlpm/unsigned_test.go
@@ -6,6 +6,7 @@ package bitlpm
 import (
 	"fmt"
 	"math/bits"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -624,8 +625,7 @@ func TestUnsignedDelete(t *testing.T) {
 			for _, pr := range tt.ranges {
 				ut.Upsert(pr.prefix(), pr.start, fmt.Sprintf("%d-%d", pr.start, pr.end))
 			}
-			for i := len(tt.ranges) - 1; i >= 0; i-- {
-				pr := tt.ranges[i]
+			for i, pr := range slices.Backward(tt.ranges) {
 				// The "got" slice cannot be nil for the DeepEqual
 				// comparison, even if it is empty.
 				got := make([]uint16Range, 0, i+1)

--- a/pkg/datapath/config/unmarshal.go
+++ b/pkg/datapath/config/unmarshal.go
@@ -130,7 +130,7 @@ func structFields(structVal reflect.Value, tag string, visited map[reflect.Type]
 		// to a struct, attempt to gather its fields as well.
 		var v reflect.Value
 		switch field.Type.Kind() {
-		case reflect.Ptr:
+		case reflect.Pointer:
 			if field.Type.Elem().Kind() != reflect.Struct {
 				continue
 			}

--- a/pkg/envoy/xds/ack.go
+++ b/pkg/envoy/xds/ack.go
@@ -60,8 +60,8 @@ type AckingResourceMutatorRevertFuncList []AckingResourceMutatorRevertFunc
 
 func (rl AckingResourceMutatorRevertFuncList) Revert() {
 	// Revert the listed funcions in reverse order
-	for i := len(rl) - 1; i >= 0; i-- {
-		rl[i]()
+	for _, revertFunc := range slices.Backward(rl) {
+		revertFunc()
 	}
 }
 

--- a/pkg/hubble/observer/local_observer_test.go
+++ b/pkg/hubble/observer/local_observer_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"slices"
 	"testing"
 	"time"
 
@@ -172,14 +173,14 @@ func TestGetFlowRate(t *testing.T) {
 				c = tc.ringCap
 			}
 			ring := container.NewRing(c)
-			for i := len(tc.events) - 1; i >= 0; i-- {
-				ev := tc.events[i].event
+			for _, e := range slices.Backward(tc.events) {
+				ev := e.event
 				if ev == nil {
 					// Default is flow
 					ev = &flowpb.Flow{}
 				}
 				ring.Write(&hubv1.Event{
-					Timestamp: timestamppb.New(now.Add(-1 * time.Duration(tc.events[i].offset) * time.Millisecond)),
+					Timestamp: timestamppb.New(now.Add(-1 * time.Duration(e.offset) * time.Millisecond)),
 					Event:     ev,
 				})
 			}

--- a/pkg/ipam/pool.go
+++ b/pkg/ipam/pool.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/netip"
+	"slices"
 
 	"github.com/vishvananda/netlink"
 	"go4.org/netipx"
@@ -186,8 +187,7 @@ func (p *cidrPool) releaseExcessCIDRsMultiPool(neededIPs int) {
 	// Iterate over CIDRs in reverse order, so we prioritize releasing
 	// later CIDRs.
 	retainedAllocators := []*ipallocator.Range{}
-	for i := len(p.ipAllocators) - 1; i >= 0; i-- {
-		ipAllocator := p.ipAllocators[i]
+	for _, ipAllocator := range slices.Backward(p.ipAllocators) {
 		cidr := ipAllocator.CIDR()
 
 		// If the CIDR is not used and releasing it would

--- a/pkg/metrics/cell.go
+++ b/pkg/metrics/cell.go
@@ -77,7 +77,7 @@ var AgentCell = cell.Group(
 func Metric[S any](ctor func() S) cell.Cell {
 	var nilOut S
 	outTyp := reflect.TypeOf(nilOut)
-	if outTyp.Kind() == reflect.Ptr {
+	if outTyp.Kind() == reflect.Pointer {
 		outTyp = outTyp.Elem()
 	}
 

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"maps"
 	"net/netip"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -1128,9 +1129,9 @@ func generateRule(testCase int) api.Rules {
 		ruleL3L4___Deny,
 	}
 	rules := make(api.Rules, 0, len(rulesIdx))
-	for i := len(rulesIdx) - 1; i >= 0; i-- {
+	for i, rule := range slices.Backward(rulesIdx) {
 		if ((testCase >> i) & 0x1) != 0 {
-			rules = append(rules, rulesIdx[i])
+			rules = append(rules, rule)
 		} else {
 			if i >= 5 { // denyIdx
 				rules = append(rules, rule_____NoDeny)

--- a/pkg/revert/revert.go
+++ b/pkg/revert/revert.go
@@ -3,7 +3,10 @@
 
 package revert
 
-import "fmt"
+import (
+	"fmt"
+	"slices"
+)
 
 // RevertFunc is a function returned by a successful function call, which
 // reverts the side-effects of the initial function call. A call that returns
@@ -29,8 +32,8 @@ func (s *RevertStack) Push(revertFunc RevertFunc) {
 // Revert executes all the RevertFuncs in the given stack in the reverse order
 // they were pushed.
 func (s *RevertStack) Revert() error {
-	for i := len(s.revertFuncs) - 1; i >= 0; i-- {
-		if err := s.revertFuncs[i](); err != nil {
+	for i, revertFunc := range slices.Backward(s.revertFuncs) {
+		if err := revertFunc(); err != nil {
 			return fmt.Errorf("failed to execute revert function; skipping %d revert functions: %w", i, err)
 		}
 	}


### PR DESCRIPTION
This PR is the same as #45894. For some reason I didn't catch all new failures in that earlier PR so now #45725 (the PR attempting to update golangci-lint to v2.12.2) is failing with those remaing failures. I did double check this time and there shouldn't be any remaining v2.12+ findings after this PR.

For the details of the findings being fixed here, check the job logs for the golangci-lint job on #45725: [logs](https://github.com/cilium/cilium/actions/runs/25801072919/job/75790980893?pr=45725).