### PR TITLE
operator/bgp: fix cleanup hang when PeerConfig has no status conditions

### DIFF
--- a/operator/pkg/bgp/peer.go
+++ b/operator/pkg/bgp/peer.go
@@ -156,24 +156,29 @@ func (u *peerConfigStatusReconciler) cleanupStatus(ctx context.Context, health c
 
 			// The resource doesn't exist anymore which is fine.
 			if !exists {
+				removed.Insert(k)
 				continue
 			}
 
 			updateStatus := false
 			for _, cond := range v2.AllBGPPeerConfigConditions {
-				if removed := meta.RemoveStatusCondition(&pc.Status.Conditions, cond); removed {
+				if meta.RemoveStatusCondition(&pc.Status.Conditions, cond) {
 					updateStatus = true
 				}
 			}
 
-			if updateStatus {
-				if _, err := u.cs.CiliumV2().CiliumBGPPeerConfigs().UpdateStatus(ctx, pc, meta_v1.UpdateOptions{}); err != nil {
-					// Failed to update status. Skip and retry.
-					continue
-				} else {
-					removed.Insert(k)
-				}
+			if !updateStatus {
+				// No managed conditions are present on this resource,
+				// so there is nothing to clean up.
+				removed.Insert(k)
+				continue
 			}
+
+			if _, err := u.cs.CiliumV2().CiliumBGPPeerConfigs().UpdateStatus(ctx, pc, meta_v1.UpdateOptions{}); err != nil {
+				// Failed to update status. Skip and retry.
+				continue
+			}
+			removed.Insert(k)
 		}
 
 		remaining = remaining.Difference(removed)

--- a/operator/pkg/bgp/peer_test.go
+++ b/operator/pkg/bgp/peer_test.go
@@ -244,69 +244,91 @@ func TestMissingAuthSecretCondition(t *testing.T) {
 }
 
 func TestDisablePeerConfigStatusReport(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), TestTimeout)
-	t.Cleanup(func() {
-		cancel()
-	})
-
-	f, ready := newPeerConfigTestFixture(t, ctx, false)
-
-	logger := hivetest.Logger(t)
-
-	f.hive.Start(logger, ctx)
-	t.Cleanup(func() {
-		f.hive.Stop(logger, ctx)
-	})
-
-	ready()
-
-	peerConfig := &v2.CiliumBGPPeerConfig{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name: "config0",
+	tests := []struct {
+		name       string
+		peerConfig *v2.CiliumBGPPeerConfig
+	}{
+		{
+			name: "Conditions are populated",
+			peerConfig: &v2.CiliumBGPPeerConfig{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name: "config0",
+				},
+				Spec: v2.CiliumBGPPeerConfigSpec{
+					AuthSecretRef: ptr.To("secret0"),
+				},
+				Status: v2.CiliumBGPPeerConfigStatus{
+					Conditions: func() []meta_v1.Condition {
+						conds := []meta_v1.Condition{}
+						for _, cond := range v2.AllBGPPeerConfigConditions {
+							conds = append(conds, meta_v1.Condition{Type: cond})
+						}
+						return conds
+					}(),
+				},
+			},
 		},
-		Spec: v2.CiliumBGPPeerConfigSpec{
-			AuthSecretRef: ptr.To("secret0"),
-		},
-		Status: v2.CiliumBGPPeerConfigStatus{
-			Conditions: []meta_v1.Condition{},
+		{
+			name: "Status is empty",
+			peerConfig: &v2.CiliumBGPPeerConfig{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name: "config0",
+				},
+				Spec: v2.CiliumBGPPeerConfigSpec{
+					AuthSecretRef: ptr.To("secret0"),
+				},
+			},
 		},
 	}
 
-	// Fill with all known conditions
-	for _, cond := range v2.AllBGPPeerConfigConditions {
-		peerConfig.Status.Conditions = append(peerConfig.Status.Conditions, meta_v1.Condition{
-			Type: cond,
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), TestTimeout)
+			t.Cleanup(func() {
+				cancel()
+			})
+
+			f, ready := newPeerConfigTestFixture(t, ctx, false)
+
+			logger := hivetest.Logger(t)
+
+			f.hive.Start(logger, ctx)
+			t.Cleanup(func() {
+				f.hive.Stop(logger, ctx)
+			})
+
+			ready()
+
+			_, err := f.fakeClientSet.CiliumFakeClientset.CiliumV2().CiliumBGPPeerConfigs().Create(
+				ctx, tt.peerConfig, meta_v1.CreateOptions{},
+			)
+			require.NoError(t, err)
+
+			peerConfigStore, err := f.peerConfigResource.Store(ctx)
+			require.NoError(t, err)
+
+			require.EventuallyWithT(t, func(ct *assert.CollectT) {
+				pc, exists, err := peerConfigStore.GetByKey(resource.Key{
+					Name: tt.peerConfig.Name,
+				})
+				if !assert.NoError(ct, err, "Failed to get peer config") {
+					return
+				}
+				if !assert.True(ct, exists, "Peer config not found") {
+					return
+				}
+				assert.Empty(ct, pc.Status.Conditions, "Conditions are not cleared")
+
+				rtxn := f.db.ReadTxn()
+
+				o, _, found := f.healthTable.Get(rtxn, health.PrimaryIndex.Query(healthTypes.HealthID("test.job-cleanup-peer-config-status")))
+				if !assert.True(ct, found, "Health status for the job is not found") {
+					return
+				}
+
+				assert.Equal(ct, healthTypes.Level(healthTypes.LevelStopped), o.Level)
+				assert.Equal(ct, "Cleanup job is done successfully", o.Message)
+			}, time.Second*3, time.Millisecond*100)
 		})
 	}
-
-	_, err := f.fakeClientSet.CiliumFakeClientset.CiliumV2().CiliumBGPPeerConfigs().Create(
-		ctx, peerConfig, meta_v1.CreateOptions{},
-	)
-	require.NoError(t, err)
-
-	peerConfigStore, err := f.peerConfigResource.Store(ctx)
-	require.NoError(t, err)
-
-	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		pc, exists, err := peerConfigStore.GetByKey(resource.Key{
-			Name: peerConfig.Name,
-		})
-		if !assert.NoError(ct, err, "Failed to get peer config") {
-			return
-		}
-		if !assert.True(ct, exists, "Peer config not found") {
-			return
-		}
-		assert.Empty(ct, pc.Status.Conditions, "Conditions are not cleared")
-
-		rtxn := f.db.ReadTxn()
-
-		o, _, found := f.healthTable.Get(rtxn, health.PrimaryIndex.Query(healthTypes.HealthID("test.job-cleanup-peer-config-status")))
-		if !assert.True(ct, found, "Health status for the job is not found") {
-			return
-		}
-
-		assert.Equal(ct, healthTypes.Level(healthTypes.LevelStopped), o.Level)
-		assert.Equal(ct, "Cleanup job is done successfully", o.Message)
-	}, time.Second*3, time.Millisecond*100)
 }


### PR DESCRIPTION
peerConfigStatusReconciler.cleanupStatus retries until every key leaves the remaining set, but only moves a key to removed after a successful UpdateStatus call. When a CiliumBGPPeerConfig has no managed conditions to remove, for example because its status block is empty, no update is performed. The key then stays in remaining, and the retry times out after about 60s with "timed out waiting for the condition".

The same can happen if the resource is deleted between the initial scan and a retry attempt.

Treat resources that are already deleted, and resources with no managed conditions left, as already cleaned up so the retry can converge.

```release-note
Fix BGP PeerConfig status cleanup so it no longer times out when there are no managed conditions to remove.
```
