### PR TITLE
fix: duplicated words in allocator/node-store/endpoint doc-comments

### DIFF
--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -258,7 +258,7 @@ type Backend interface {
 	// have been created by other agents.
 	Get(ctx context.Context, key AllocatorKey) (idpool.ID, error)
 
-	// GetIfLocked behaves like Get, but but when lock is non-nil the
+	// GetIfLocked behaves like Get, but when lock is non-nil the
 	// operation proceeds only if it is still valid.
 	GetIfLocked(ctx context.Context, key AllocatorKey, lock kvstore.KVLocker) (idpool.ID, error)
 

--- a/pkg/endpoint/regenerationcontext.go
+++ b/pkg/endpoint/regenerationcontext.go
@@ -57,7 +57,7 @@ func (r regenerationFailureReason) String() string {
 	}
 }
 
-// IsPolicyFailure indicates if the the regeneration failed due any policy related reason.
+// IsPolicyFailure indicates if the regeneration failed due any policy related reason.
 func (r regenerationFailureReason) IsPolicyFailure() bool {
 	return r == regenerationFailureReasonPolicyRegenerationError ||
 		r == regenerationFailureReasonEndpointPolicyUpdateError ||

--- a/pkg/node/store/store.go
+++ b/pkg/node/store/store.go
@@ -65,7 +65,7 @@ func ClusterNameValidator(clusterName string) nodeValidator {
 	}
 }
 
-// NameValidator returns a validator enforcing that the name of the the unmarshaled
+// NameValidator returns a validator enforcing that the name of the unmarshaled
 // node matches the kvstore key.
 func NameValidator() nodeValidator {
 	return func(key string, n *nodeTypes.Node) error {


### PR DESCRIPTION
Three one-line typo fixes for duplicated words in doc-comments:
- `pkg/allocator/allocator.go` — "// GetIfLocked behaves like Get, but but when lock is non-nil the" → "...but when lock is non-nil the"
- `pkg/node/store/store.go` — "// NameValidator returns a validator enforcing that the name of the the unmarshaled" → "...the name of the unmarshaled"
- `pkg/endpoint/regenerationcontext.go` — "// IsPolicyFailure indicates if the the regeneration failed due any policy related reason." → "...if the regeneration failed due any policy related reason."

No code/behavior change.

Signed-off-by: Noa Levi <275430404+lphuc2250gma@users.noreply.github.com>