### PR TITLE
iptables: use proto + port instead of packet mark for matching wireguard packets

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1067,7 +1067,6 @@ do_netdev(struct __ctx_buff *ctx, __be16 proto, __u32 identity,
 			if (likely(hdrlen > 0) &&
 			    ctx_is_wireguard(ctx, ETH_HLEN + hdrlen, next_proto, identity)) {
 				trace.reason = TRACE_REASON_ENCRYPTED;
-				set_decrypt_mark(ctx, 0);
 			}
 		}
 # endif /* ENABLE_WIREGUARD */
@@ -1107,7 +1106,6 @@ do_netdev(struct __ctx_buff *ctx, __be16 proto, __u32 identity,
 			hdrlen = ipv4_hdrlen(ip4);
 			if (ctx_is_wireguard(ctx, ETH_HLEN + hdrlen, next_proto, identity)) {
 				trace.reason = TRACE_REASON_ENCRYPTED;
-				set_decrypt_mark(ctx, 0);
 			}
 		}
 #endif /* ENABLE_WIREGUARD */

--- a/bpf/tests/decrypt_host.h
+++ b/bpf/tests/decrypt_host.h
@@ -110,9 +110,8 @@ int check(const struct __ctx_buff *ctx, bool ipv4)
 
 	assert(*status_code == CTX_ACT_OK);
 
-	assert(ctx_is_decrypt(ctx));
-
 #ifdef ENABLE_WIREGUARD
+	assert(!ctx_is_decrypt(ctx));
 	if (ipv4) {
 		ASSERT_CTX_BUF_OFF("v4_wg_pkt_ok", "Ether", ctx, sizeof(__u32),
 				   v4_wireguard, sizeof(v4_wireguard));
@@ -122,6 +121,7 @@ int check(const struct __ctx_buff *ctx, bool ipv4)
 	}
 #endif
 #ifdef ENABLE_IPSEC
+	assert(ctx_is_decrypt(ctx));
 	if (ipv4) {
 		ASSERT_CTX_BUF_OFF("v4_ipsec_pkt_ok", "Ether", ctx, sizeof(__u32),
 				   v4_ipsec, sizeof(v4_ipsec));

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/versioncheck"
+	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 const (
@@ -1978,6 +1979,10 @@ func (m *manager) addCiliumAcceptEncryptionRules() error {
 		return nil
 	}
 
+	if m.sharedCfg.EnableWireguard {
+		return m.addCiliumAcceptWireguardRules()
+	}
+
 	insertAcceptEncrypt := func(ipt iptablesInterface, table, chain string) error {
 		matchDecrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkDecrypt, linux_defaults.RouteMarkMask)
 		matchEncrypt := fmt.Sprintf("%#08x/%#08x", linux_defaults.RouteMarkEncrypt, linux_defaults.RouteMarkMask)
@@ -2021,6 +2026,10 @@ func (m *manager) addCiliumAcceptEncryptionRules() error {
 }
 
 func (m *manager) addCiliumNoTrackEncryptionRules() (err error) {
+	if m.sharedCfg.EnableWireguard {
+		return m.addCiliumNoTrackWireguardRules()
+	}
+
 	if m.sharedCfg.EnableIPv4 {
 		if err = m.ciliumNoTrackEncryptionRules(m.ip4tables, "-I"); err != nil {
 			return
@@ -2370,4 +2379,83 @@ func (m *manager) setNoTrackHostPorts(currentState noTrackHostPortsByPod, podNam
 
 	return m.replaceNoTrackHostPortRules(oldPorts, newPorts)
 
+}
+
+func (m *manager) addCiliumAcceptWireguardRules() error {
+	cmds := [][]string{{
+		"-t", "filter",
+		"-A", ciliumOutputChain,
+		"-p", "udp",
+		"--dport", strconv.Itoa(int(wgTypes.ListenPort)),
+		"-m", "comment", "--comment", "cilium: ACCEPT for wireguard traffic",
+		"-j", "ACCEPT",
+	}, {
+		"-t", "filter",
+		"-A", ciliumInputChain,
+		"-p", "udp",
+		"--dport", strconv.Itoa(int(wgTypes.ListenPort)),
+		"-m", "comment", "--comment", "cilium: ACCEPT for wireguard traffic",
+		"-j", "ACCEPT",
+	}}
+
+	for _, cmd := range cmds {
+		if m.sharedCfg.EnableIPv4 {
+			if err := m.ip4tables.runProg(cmd); err != nil {
+				return err
+			}
+		}
+
+		if m.sharedCfg.EnableIPv6 {
+			if err := m.ip6tables.runProg(cmd); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// ciliumNoTrackWireguardRules adds notrack rules for wireguard tunnel.
+// this way, the kernel doesn't keep CT state for wg tunnels, reducing the
+// performance impact in the packet forwarding.
+func (m *manager) addCiliumNoTrackWireguardRules() error {
+	input := []string{
+		"-t", "raw",
+		"-A", ciliumPreRawChain,
+		"-p", "udp",
+		"--dport", strconv.Itoa(int(wgTypes.ListenPort)),
+		"-m", "comment", "--comment", "cilium: NOTRACK for wireguard traffic",
+		"-j", "CT", "--notrack",
+	}
+
+	output := []string{
+		"-t", "raw",
+		"-A", ciliumOutputRawChain,
+		"-p", "udp",
+		"--dport", strconv.Itoa(int(wgTypes.ListenPort)),
+		"-m", "comment", "--comment", "cilium: NOTRACK for wireguard traffic",
+		"-j", "CT", "--notrack",
+	}
+
+	if m.sharedCfg.EnableIPv4 {
+		if err := m.ip4tables.runProg(input); err != nil {
+			return err
+		}
+
+		if err := m.ip4tables.runProg(output); err != nil {
+			return err
+		}
+	}
+
+	if m.sharedCfg.EnableIPv6 {
+		if err := m.ip6tables.runProg(input); err != nil {
+			return err
+		}
+
+		if err := m.ip6tables.runProg(output); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
+
+	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
 
 type expectation struct {
@@ -1108,14 +1110,14 @@ func TestEncryptionRules(t *testing.T) {
 		haveBPFSocketAssign:  false,
 		ipEarlyDemuxDisabled: false,
 		sharedCfg: SharedConfig{
-			EnableIPv4:      true,
-			EnableIPv6:      true,
-			EnableWireguard: true,
+			EnableIPv4:  true,
+			EnableIPv6:  true,
+			EnableIPSec: true,
 		},
 		ip4tables: mockIp4tables,
 		ip6tables: mockIp6tables,
 	}
-	t.Run("test adding iptables rules for wireguard encryption", func(t *testing.T) {
+	t.Run("test adding iptables rules for ipsec encryption", func(t *testing.T) {
 
 		mockIp4tables.expectations = []expectation{
 			{args: "-t filter -A CILIUM_INPUT -m mark --mark 0x00000e00/0x00000f00 -m comment --comment exclude encrypt/decrypt marks from filter CILIUM_INPUT chain -j ACCEPT"},
@@ -1162,6 +1164,39 @@ func TestEncryptionRules(t *testing.T) {
 		}
 
 		assert.NoError(t, testMgr.addCiliumNoTrackEncryptionRules())
+		assert.NoError(t, mockIp4tables.checkExpectations())
+		assert.NoError(t, mockIp6tables.checkExpectations())
+	})
+
+	t.Run("test adding iptables rules for wireguard encryption", func(t *testing.T) {
+		testMgr.sharedCfg = SharedConfig{
+			EnableIPv4:      true,
+			EnableIPv6:      true,
+			EnableWireguard: true,
+		}
+
+		port := wgTypes.ListenPort
+		expected := "%s -A %s -p udp --dport %d -m comment --comment %s"
+
+		mockIp4tables.expectations = []expectation{
+			{args: fmt.Sprintf(expected, "-t raw", "CILIUM_PRE_raw", port, "cilium: NOTRACK for wireguard traffic -j CT --notrack")},
+			{args: fmt.Sprintf(expected, "-t raw", "CILIUM_OUTPUT_raw", port, "cilium: NOTRACK for wireguard traffic -j CT --notrack")},
+		}
+
+		mockIp6tables.expectations = mockIp4tables.expectations
+
+		assert.NoError(t, testMgr.addCiliumNoTrackEncryptionRules())
+		assert.NoError(t, mockIp4tables.checkExpectations())
+		assert.NoError(t, mockIp6tables.checkExpectations())
+
+		mockIp4tables.expectations = []expectation{
+			{args: fmt.Sprintf(expected, "-t filter", "CILIUM_OUTPUT", port, "cilium: ACCEPT for wireguard traffic -j ACCEPT")},
+			{args: fmt.Sprintf(expected, "-t filter", "CILIUM_INPUT", port, "cilium: ACCEPT for wireguard traffic -j ACCEPT")},
+		}
+
+		mockIp6tables.expectations = mockIp4tables.expectations
+
+		assert.NoError(t, testMgr.addCiliumAcceptEncryptionRules())
 		assert.NoError(t, mockIp4tables.checkExpectations())
 		assert.NoError(t, mockIp6tables.checkExpectations())
 	})


### PR DESCRIPTION
reverts the work from https://github.com/cilium/cilium/pull/41990

what was happening here is that packets received on a wireguard interface (that is, after decryption) were not being conntrack'd, which led to two issues:
- iptables with policy DROP could not match on ctstate, and common rules in such deployments like `--ctstate NEW,RELATED,ESTABLISHED` would not work.
- no conntrack would also mean that SNAT to node addresses when traffic flows over the tunnel wasn't working properly.

the original change above assumed that the mark was used to identify pre-decryption packets (the ones we want to notrack), and the iptables rule matches any packets with that mark. but in [bpf_wireguard this mark also means "this packet was decrypted"](https://github.com/cilium/cilium/blob/e41231047c9a8fe317b4e079a7def7573663d0d5/bpf/bpf_wireguard.c#L268-L270), and post-decryption packets matched that rule too.

this PR solves this problem by removing set_mark from the pre-decryption path and changes the iptables rules for wireguard to match based on proto + port

Fixes: #45837
Fixes: #45497

```release-note
iptables: match wireguard packets by proto+port instead of packet mark
```
