### PR TITLE
operator/ipam: Consolidate cloud allocator bootstrap

### DIFF
--- a/operator/pkg/ipam/alibabacloud.go
+++ b/operator/pkg/ipam/alibabacloud.go
@@ -6,8 +6,6 @@
 package ipam
 
 import (
-	"context"
-	"fmt"
 	"log/slog"
 
 	"github.com/cilium/hive/cell"
@@ -15,7 +13,6 @@ import (
 	"github.com/spf13/pflag"
 
 	operatorOption "github.com/cilium/cilium/operator/option"
-	allocatorTypes "github.com/cilium/cilium/operator/pkg/ipam/allocator"
 	"github.com/cilium/cilium/operator/pkg/ipam/allocator/alibabacloud"
 	ipamMetrics "github.com/cilium/cilium/operator/pkg/ipam/metrics"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
@@ -67,37 +64,22 @@ type alibabaParams struct {
 }
 
 func startAlibabaAllocator(p alibabaParams) {
-	if p.DaemonCfg.IPAM != ipamOption.IPAMAlibabaCloud {
-		return
-	}
-
-	allocator := &alibabacloud.AllocatorAlibabaCloud{
+	alloc := &alibabacloud.AllocatorAlibabaCloud{
 		AlibabaCloudVPCID:            p.AlibabaCfg.AlibabaCloudVPCID,
 		AlibabaCloudReleaseExcessIPs: p.AlibabaCfg.AlibabaCloudReleaseExcessIPs,
 		ParallelAllocWorkers:         p.Cfg.ParallelAllocWorkers,
 		LimitIPAMAPIBurst:            p.Cfg.LimitIPAMAPIBurst,
 		LimitIPAMAPIQPS:              p.Cfg.LimitIPAMAPIQPS,
+		AlibabaMetrics:               p.AlibabaMetrics,
 	}
 
-	p.Lifecycle.Append(
-		cell.Hook{
-			OnStart: func(ctx cell.HookContext) error {
-				if err := allocator.Init(ctx, p.Logger, p.AlibabaMetrics); err != nil {
-					return fmt.Errorf("unable to init AlibabaCloud allocator: %w", err)
-				}
-
-				p.JobGroup.Add(p.NodeWatcherFactory(
-					func(ctx context.Context) (allocatorTypes.NodeEventHandler, error) {
-						nm, err := allocator.Start(ctx, &ciliumNodeUpdateImplementation{p.Clientset}, p.IPAMMetrics)
-						if err != nil {
-							return nil, fmt.Errorf("unable to start AlibabaCloud allocator: %w", err)
-						}
-						return nm, nil
-					},
-				))
-
-				return nil
-			},
-		},
-	)
+	startCloudAllocator(cloudAllocatorBootstrap{
+		Logger:             p.Logger,
+		Lifecycle:          p.Lifecycle,
+		JobGroup:           p.JobGroup,
+		Clientset:          p.Clientset,
+		IPAMMetrics:        p.IPAMMetrics,
+		DaemonCfg:          p.DaemonCfg,
+		NodeWatcherFactory: p.NodeWatcherFactory,
+	}, "AlibabaCloud", ipamOption.IPAMAlibabaCloud, alloc)
 }

--- a/operator/pkg/ipam/allocator/alibabacloud/alibabacloud.go
+++ b/operator/pkg/ipam/allocator/alibabacloud/alibabacloud.go
@@ -34,6 +34,7 @@ type AllocatorAlibabaCloud struct {
 	ParallelAllocWorkers         int64
 	LimitIPAMAPIBurst            int
 	LimitIPAMAPIQPS              float64
+	AlibabaMetrics               alibabacloudAPI.MetricsAPI
 
 	rootLogger *slog.Logger
 	logger     *slog.Logger
@@ -42,7 +43,7 @@ type AllocatorAlibabaCloud struct {
 
 // Init sets up ENI limits based on given options
 // Credential ref https://github.com/aliyun/alibaba-cloud-sdk-go/blob/master/docs/2-Client-EN.md
-func (a *AllocatorAlibabaCloud) Init(ctx context.Context, logger *slog.Logger, aMetrics alibabacloudAPI.MetricsAPI) error {
+func (a *AllocatorAlibabaCloud) Init(ctx context.Context, logger *slog.Logger) error {
 	a.rootLogger = logger
 	a.logger = logger.With(subsysLogAttr...)
 
@@ -76,7 +77,7 @@ func (a *AllocatorAlibabaCloud) Init(ctx context.Context, logger *slog.Logger, a
 	vpcClient.GetConfig().WithScheme("HTTPS")
 	ecsClient.GetConfig().WithScheme("HTTPS")
 
-	a.client = alibabacloudAPI.NewClient(vpcClient, ecsClient, aMetrics, a.LimitIPAMAPIQPS,
+	a.client = alibabacloudAPI.NewClient(vpcClient, ecsClient, a.AlibabaMetrics, a.LimitIPAMAPIQPS,
 		a.LimitIPAMAPIBurst, operatorOption.Config.IPAMInstanceTags)
 
 	if err := limits.UpdateFromAPI(ctx, a.client); err != nil {

--- a/operator/pkg/ipam/allocator/aws/aws.go
+++ b/operator/pkg/ipam/allocator/aws/aws.go
@@ -41,6 +41,7 @@ type AllocatorAWS struct {
 	ParallelAllocWorkers         int64
 	LimitIPAMAPIBurst            int
 	LimitIPAMAPIQPS              float64
+	AWSMetrics                   ec2shim.MetricsAPI
 
 	rootLogger *slog.Logger
 	logger     *slog.Logger
@@ -85,7 +86,7 @@ func (a *AllocatorAWS) initENIGarbageCollectionTags(ctx context.Context, cfg aws
 }
 
 // Init sets up ENI limits based on given options
-func (a *AllocatorAWS) Init(ctx context.Context, logger *slog.Logger, aMetrics ec2shim.MetricsAPI) error {
+func (a *AllocatorAWS) Init(ctx context.Context, logger *slog.Logger) error {
 	a.rootLogger = logger
 	a.logger = logger.With(subsysLogAttr...)
 
@@ -115,7 +116,7 @@ func (a *AllocatorAWS) Init(ctx context.Context, logger *slog.Logger, aMetrics e
 		}
 	}
 
-	a.client = ec2shim.NewClient(a.rootLogger, ec2.NewFromConfig(cfg, optionsFunc), aMetrics, a.LimitIPAMAPIQPS,
+	a.client = ec2shim.NewClient(a.rootLogger, ec2.NewFromConfig(cfg, optionsFunc), a.AWSMetrics, a.LimitIPAMAPIQPS,
 		a.LimitIPAMAPIBurst, subnetsFilters, instancesFilters, eniCreationTags,
 		a.AWSUsePrimaryAddress, a.AWSMaxResultsPerCall)
 

--- a/operator/pkg/ipam/allocator/azure/azure.go
+++ b/operator/pkg/ipam/allocator/azure/azure.go
@@ -24,6 +24,7 @@ type AllocatorAzure struct {
 	ParallelAllocWorkers        int64
 	LimitIPAMAPIBurst           int
 	LimitIPAMAPIQPS             float64
+	AzureMetrics                azureAPI.MetricsAPI
 
 	rootLogger *slog.Logger
 	logger     *slog.Logger
@@ -37,7 +38,7 @@ func (a *AllocatorAzure) Init(ctx context.Context, logger *slog.Logger) error {
 }
 
 // Start kicks of the Azure IP allocation
-func (a *AllocatorAzure) Start(ctx context.Context, getterUpdater allocator.CiliumNodeGetterUpdater, azMetrics azureAPI.MetricsAPI, iMetrics nodemanager.MetricsAPI) (allocator.NodeEventHandler, error) {
+func (a *AllocatorAzure) Start(ctx context.Context, getterUpdater allocator.CiliumNodeGetterUpdater, iMetrics nodemanager.MetricsAPI) (allocator.NodeEventHandler, error) {
 	a.logger.Info("Starting Azure IP allocator...")
 
 	a.logger.Debug("Retrieving Azure cloud name via Azure IMS")
@@ -68,7 +69,7 @@ func (a *AllocatorAzure) Start(ctx context.Context, getterUpdater allocator.Cili
 		a.logger.Debug("Detected resource group name via Azure IMS", logfields.Resource, resourceGroupName)
 	}
 
-	azureClient, err := azureAPI.NewClient(a.rootLogger, azureCloudName, subscriptionID, resourceGroupName, a.AzureUserAssignedIdentityID, azMetrics, a.LimitIPAMAPIQPS, a.LimitIPAMAPIBurst, a.AzureUsePrimaryAddress)
+	azureClient, err := azureAPI.NewClient(a.rootLogger, azureCloudName, subscriptionID, resourceGroupName, a.AzureUserAssignedIdentityID, a.AzureMetrics, a.LimitIPAMAPIQPS, a.LimitIPAMAPIBurst, a.AzureUsePrimaryAddress)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create Azure client: %w", err)
 	}

--- a/operator/pkg/ipam/aws.go
+++ b/operator/pkg/ipam/aws.go
@@ -6,15 +6,12 @@
 package ipam
 
 import (
-	"context"
-	"fmt"
 	"log/slog"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
 	"github.com/spf13/pflag"
 
-	allocatorTypes "github.com/cilium/cilium/operator/pkg/ipam/allocator"
 	"github.com/cilium/cilium/operator/pkg/ipam/allocator/aws"
 	ipamMetrics "github.com/cilium/cilium/operator/pkg/ipam/metrics"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
@@ -88,7 +85,7 @@ type awsParams struct {
 	Lifecycle          cell.Lifecycle
 	JobGroup           job.Group
 	Clientset          k8sClient.Clientset
-	EC2Metrics         *aws.Metrics
+	AWSMetrics         *aws.Metrics
 	IPAMMetrics        *ipamMetrics.Metrics
 	DaemonCfg          *option.DaemonConfig
 	NodeWatcherFactory nodeWatcherJobFactory
@@ -98,11 +95,7 @@ type awsParams struct {
 }
 
 func startAWSAllocator(p awsParams) {
-	if p.DaemonCfg.IPAM != ipamOption.IPAMENI {
-		return
-	}
-
-	allocator := &aws.AllocatorAWS{
+	alloc := &aws.AllocatorAWS{
 		AWSReleaseExcessIPs:          p.AwsCfg.AWSReleaseExcessIPs,
 		ExcessIPReleaseDelay:         p.AwsCfg.ExcessIPReleaseDelay,
 		AWSEnablePrefixDelegation:    p.AwsCfg.AWSEnablePrefixDelegation,
@@ -117,27 +110,16 @@ func startAWSAllocator(p awsParams) {
 		ParallelAllocWorkers:         p.Cfg.ParallelAllocWorkers,
 		LimitIPAMAPIBurst:            p.Cfg.LimitIPAMAPIBurst,
 		LimitIPAMAPIQPS:              p.Cfg.LimitIPAMAPIQPS,
+		AWSMetrics:                   p.AWSMetrics,
 	}
 
-	p.Lifecycle.Append(
-		cell.Hook{
-			OnStart: func(ctx cell.HookContext) error {
-				if err := allocator.Init(ctx, p.Logger, p.EC2Metrics); err != nil {
-					return fmt.Errorf("unable to init AWS allocator: %w", err)
-				}
-
-				p.JobGroup.Add(p.NodeWatcherFactory(
-					func(ctx context.Context) (allocatorTypes.NodeEventHandler, error) {
-						nm, err := allocator.Start(ctx, &ciliumNodeUpdateImplementation{p.Clientset}, p.IPAMMetrics)
-						if err != nil {
-							return nil, fmt.Errorf("unable to start AWS allocator: %w", err)
-						}
-						return nm, nil
-					},
-				))
-
-				return nil
-			},
-		},
-	)
+	startCloudAllocator(cloudAllocatorBootstrap{
+		Logger:             p.Logger,
+		Lifecycle:          p.Lifecycle,
+		JobGroup:           p.JobGroup,
+		Clientset:          p.Clientset,
+		IPAMMetrics:        p.IPAMMetrics,
+		DaemonCfg:          p.DaemonCfg,
+		NodeWatcherFactory: p.NodeWatcherFactory,
+	}, "AWS", ipamOption.IPAMENI, alloc)
 }

--- a/operator/pkg/ipam/azure.go
+++ b/operator/pkg/ipam/azure.go
@@ -6,8 +6,6 @@
 package ipam
 
 import (
-	"context"
-	"fmt"
 	"log/slog"
 
 	"github.com/cilium/hive/cell"
@@ -15,7 +13,6 @@ import (
 	"github.com/spf13/pflag"
 
 	operatorOption "github.com/cilium/cilium/operator/option"
-	allocatorTypes "github.com/cilium/cilium/operator/pkg/ipam/allocator"
 	"github.com/cilium/cilium/operator/pkg/ipam/allocator/azure"
 	ipamMetrics "github.com/cilium/cilium/operator/pkg/ipam/metrics"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
@@ -73,11 +70,7 @@ type azureParams struct {
 }
 
 func startAzureAllocator(p azureParams) {
-	if p.DaemonCfg.IPAM != ipamOption.IPAMAzure {
-		return
-	}
-
-	allocator := &azure.AllocatorAzure{
+	alloc := &azure.AllocatorAzure{
 		AzureSubscriptionID:         p.AzureCfg.AzureSubscriptionID,
 		AzureResourceGroup:          p.AzureCfg.AzureResourceGroup,
 		AzureUserAssignedIdentityID: p.AzureCfg.AzureUserAssignedIdentityID,
@@ -85,27 +78,16 @@ func startAzureAllocator(p azureParams) {
 		ParallelAllocWorkers:        p.Cfg.ParallelAllocWorkers,
 		LimitIPAMAPIBurst:           p.Cfg.LimitIPAMAPIBurst,
 		LimitIPAMAPIQPS:             p.Cfg.LimitIPAMAPIQPS,
+		AzureMetrics:                p.AzureMetrics,
 	}
 
-	p.Lifecycle.Append(
-		cell.Hook{
-			OnStart: func(ctx cell.HookContext) error {
-				if err := allocator.Init(ctx, p.Logger); err != nil {
-					return fmt.Errorf("unable to init Azure allocator: %w", err)
-				}
-
-				p.JobGroup.Add(p.NodeWatcherFactory(
-					func(ctx context.Context) (allocatorTypes.NodeEventHandler, error) {
-						nm, err := allocator.Start(ctx, &ciliumNodeUpdateImplementation{p.Clientset}, p.AzureMetrics, p.IPAMMetrics)
-						if err != nil {
-							return nil, fmt.Errorf("unable to start Azure allocator: %w", err)
-						}
-						return nm, nil
-					},
-				))
-
-				return nil
-			},
-		},
-	)
+	startCloudAllocator(cloudAllocatorBootstrap{
+		Logger:             p.Logger,
+		Lifecycle:          p.Lifecycle,
+		JobGroup:           p.JobGroup,
+		Clientset:          p.Clientset,
+		IPAMMetrics:        p.IPAMMetrics,
+		DaemonCfg:          p.DaemonCfg,
+		NodeWatcherFactory: p.NodeWatcherFactory,
+	}, "Azure", ipamOption.IPAMAzure, alloc)
 }

--- a/operator/pkg/ipam/cloud_allocator.go
+++ b/operator/pkg/ipam/cloud_allocator.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build ipam_provider_aws || ipam_provider_azure || ipam_provider_alibabacloud
+
+package ipam
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+
+	"github.com/cilium/cilium/operator/pkg/ipam/allocator"
+	ipamMetrics "github.com/cilium/cilium/operator/pkg/ipam/metrics"
+	"github.com/cilium/cilium/operator/pkg/ipam/nodemanager"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// CloudAllocator is the lifecycle contract implemented by every cloud-provider
+// IPAM allocator (AWS, Azure, AlibabaCloud). It exists so the per-cloud cell
+// files can share a single bootstrap path (startCloudAllocator) instead of
+// duplicating identical lifecycle plumbing.
+type CloudAllocator interface {
+	Init(ctx context.Context, logger *slog.Logger) error
+	Start(ctx context.Context, getterUpdater allocator.CiliumNodeGetterUpdater, iMetrics nodemanager.MetricsAPI) (allocator.NodeEventHandler, error)
+}
+
+// cloudAllocatorBootstrap groups the dependencies that every cloud allocator
+// cell hands to startCloudAllocator.
+type cloudAllocatorBootstrap struct {
+	Logger             *slog.Logger
+	Lifecycle          cell.Lifecycle
+	JobGroup           job.Group
+	Clientset          k8sClient.Clientset
+	IPAMMetrics        *ipamMetrics.Metrics
+	DaemonCfg          *option.DaemonConfig
+	NodeWatcherFactory nodeWatcherJobFactory
+}
+
+// startCloudAllocator registers the OnStart lifecycle hook that drives the
+// Init -> Start -> NodeWatcher wiring shared by every cloud-provider allocator.
+// It is a no-op unless the configured IPAM mode matches.
+func startCloudAllocator(b cloudAllocatorBootstrap, name, mode string, alloc CloudAllocator) {
+	if b.DaemonCfg.IPAM != mode {
+		return
+	}
+	b.Lifecycle.Append(cell.Hook{
+		OnStart: func(ctx cell.HookContext) error {
+			if err := alloc.Init(ctx, b.Logger); err != nil {
+				return fmt.Errorf("unable to init %s allocator: %w", name, err)
+			}
+			b.JobGroup.Add(b.NodeWatcherFactory(
+				func(ctx context.Context) (allocator.NodeEventHandler, error) {
+					nm, err := alloc.Start(ctx, &ciliumNodeUpdateImplementation{b.Clientset}, b.IPAMMetrics)
+					if err != nil {
+						return nil, fmt.Errorf("unable to start %s allocator: %w", name, err)
+					}
+					return nm, nil
+				},
+			))
+			return nil
+		},
+	})
+}


### PR DESCRIPTION
The AWS, Azure, and AlibabaCloud cell files all carried a near-identical "build allocator -> Init -> Start -> wire NodeWatcher" lifecycle, with historical drift in the Init/Start signatures (provider metrics passed as Init args in AWS/AlibabaCloud, as a Start arg in Azure).

This commit moves each provider's metrics into the allocator struct (already hive-injected at the cell layer), normalizes Init/Start to a shared `CloudAllocator` interface, and extract the `OnStart` wiring into a single `startCloudAllocator` helper in the always-built cell package. Each per-cloud cell shrinks to its config + allocator construction.

Followup to #43628