### PR TITLE
Azure IPAM: Primary IP  tracking

### DIFF
--- a/operator/pkg/ipam/allocator/azure/azure.go
+++ b/operator/pkg/ipam/allocator/azure/azure.go
@@ -72,7 +72,7 @@ func (a *AllocatorAzure) Start(ctx context.Context, getterUpdater allocator.Cili
 	if err != nil {
 		return nil, fmt.Errorf("unable to create Azure client: %w", err)
 	}
-	instances := azureIPAM.NewInstancesManager(a.rootLogger, azureClient)
+	instances := azureIPAM.NewInstancesManager(a.rootLogger, azureClient, a.AzureUsePrimaryAddress)
 	nodeManager, err := nodemanager.NewNodeManager(a.logger, instances, getterUpdater, iMetrics, a.ParallelAllocWorkers, false, 0, false)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize Azure node manager: %w", err)

--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -330,28 +330,34 @@ func parseInterface(iface *armnetwork.Interface, subnets ipamTypes.SubnetMap, us
 	}
 
 	if iface.Properties.IPConfigurations != nil {
-		for _, ip := range (*iface).Properties.IPConfigurations {
-			if !usePrimary && ip.Properties.Primary != nil && *ip.Properties.Primary {
+		for _, ip := range iface.Properties.IPConfigurations {
+			if ip.Properties.PrivateIPAddress == nil {
 				continue
 			}
-			if ip.Properties.PrivateIPAddress != nil {
-				addr := types.AzureAddress{
-					IP:    *ip.Properties.PrivateIPAddress,
-					State: strings.ToLower(string(*ip.Properties.ProvisioningState)),
+			isPrimary := ip.Properties.Primary != nil && *ip.Properties.Primary
+			if isPrimary {
+				i.IP = *ip.Properties.PrivateIPAddress
+				if !usePrimary {
+					continue
 				}
-
-				if ip.Properties.Subnet != nil {
-					addr.Subnet = *ip.Properties.Subnet.ID
-					if subnet, ok := subnets[addr.Subnet]; ok {
-						if subnet.CIDR.IsValid() {
-							i.CIDR = subnet.CIDR.String()
-						}
-						i.Gateway = deriveGatewayIP(subnet.CIDR.Addr())
-					}
-				}
-
-				i.Addresses = append(i.Addresses, addr)
 			}
+
+			addr := types.AzureAddress{
+				IP:    *ip.Properties.PrivateIPAddress,
+				State: strings.ToLower(string(*ip.Properties.ProvisioningState)),
+			}
+
+			if ip.Properties.Subnet != nil {
+				addr.Subnet = *ip.Properties.Subnet.ID
+				if subnet, ok := subnets[addr.Subnet]; ok {
+					if subnet.CIDR.IsValid() {
+						i.CIDR = subnet.CIDR.String()
+					}
+					i.Gateway = deriveGatewayIP(subnet.CIDR.Addr())
+				}
+			}
+
+			i.Addresses = append(i.Addresses, addr)
 		}
 	}
 

--- a/pkg/azure/api/api_test.go
+++ b/pkg/azure/api/api_test.go
@@ -11,8 +11,146 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
 	"github.com/stretchr/testify/require"
 
+	// Required so SetID() resolves the Azure resource-ID parser.
+	_ "github.com/cilium/cilium/pkg/azure/types/azureid"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 )
+
+func TestParseInterface(t *testing.T) {
+	ifaceID := "/subscriptions/xxx/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic1"
+	subnetID := "/subscriptions/xxx/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet1"
+
+	newIPConfig := func(ip string, primary bool) *armnetwork.InterfaceIPConfiguration {
+		return &armnetwork.InterfaceIPConfiguration{
+			Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+				PrivateIPAddress:  new(ip),
+				Primary:           new(primary),
+				ProvisioningState: new(armnetwork.ProvisioningStateSucceeded),
+				Subnet:            &armnetwork.Subnet{ID: new(subnetID)},
+			},
+		}
+	}
+
+	newIface := func(configs ...*armnetwork.InterfaceIPConfiguration) *armnetwork.Interface {
+		return &armnetwork.Interface{
+			ID: new(ifaceID),
+			Properties: &armnetwork.InterfacePropertiesFormat{
+				IPConfigurations: configs,
+			},
+		}
+	}
+
+	subnetMap := ipamTypes.SubnetMap{
+		subnetID: &ipamTypes.Subnet{
+			ID:   subnetID,
+			CIDR: netip.MustParsePrefix("10.0.0.0/24"),
+		},
+	}
+
+	tests := []struct {
+		name            string
+		iface           *armnetwork.Interface
+		subnets         ipamTypes.SubnetMap
+		usePrimary      bool
+		expectedIP      string
+		expectedAddrs   []string
+		expectedCIDR    string
+		expectedGateway string
+	}{
+		{
+			name: "primary and secondaries, usePrimary=false",
+			iface: newIface(
+				newIPConfig("10.0.0.4", true),
+				newIPConfig("10.0.0.5", false),
+				newIPConfig("10.0.0.6", false),
+			),
+			subnets:         subnetMap,
+			usePrimary:      false,
+			expectedIP:      "10.0.0.4",
+			expectedAddrs:   []string{"10.0.0.5", "10.0.0.6"},
+			expectedCIDR:    "10.0.0.0/24",
+			expectedGateway: "10.0.0.1",
+		},
+		{
+			name: "primary and secondaries, usePrimary=true",
+			iface: newIface(
+				newIPConfig("10.0.0.4", true),
+				newIPConfig("10.0.0.5", false),
+				newIPConfig("10.0.0.6", false),
+			),
+			subnets:         subnetMap,
+			usePrimary:      true,
+			expectedIP:      "10.0.0.4",
+			expectedAddrs:   []string{"10.0.0.4", "10.0.0.5", "10.0.0.6"},
+			expectedCIDR:    "10.0.0.0/24",
+			expectedGateway: "10.0.0.1",
+		},
+		{
+			// Pre-existing behaviour: when the only IPConfiguration is the primary
+			// and usePrimary=false, CIDR/Gateway are not derived from the subnet.
+			// Pinning this so a future fix has to update both code and test.
+			name:            "only primary, usePrimary=false, subnet info not derived",
+			iface:           newIface(newIPConfig("10.0.0.4", true)),
+			subnets:         subnetMap,
+			usePrimary:      false,
+			expectedIP:      "10.0.0.4",
+			expectedAddrs:   nil,
+			expectedCIDR:    "",
+			expectedGateway: "",
+		},
+		{
+			name:          "no IPConfigurations",
+			iface:         newIface(),
+			usePrimary:    false,
+			expectedIP:    "",
+			expectedAddrs: nil,
+		},
+		{
+			name: "no primary flag set on any config",
+			iface: newIface(
+				newIPConfig("10.0.0.5", false),
+				newIPConfig("10.0.0.6", false),
+			),
+			usePrimary:    false,
+			expectedIP:    "",
+			expectedAddrs: []string{"10.0.0.5", "10.0.0.6"},
+		},
+		{
+			name: "nil Primary pointer treated as non-primary",
+			iface: newIface(&armnetwork.InterfaceIPConfiguration{
+				Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+					PrivateIPAddress:  new("10.0.0.5"),
+					Primary:           nil,
+					ProvisioningState: new(armnetwork.ProvisioningStateSucceeded),
+					Subnet:            &armnetwork.Subnet{ID: new(subnetID)},
+				},
+			}),
+			usePrimary:    false,
+			expectedIP:    "",
+			expectedAddrs: []string{"10.0.0.5"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, got := parseInterface(tt.iface, tt.subnets, tt.usePrimary)
+			require.NotNil(t, got)
+			require.Equal(t, tt.expectedIP, got.IP)
+			require.Equal(t, tt.expectedCIDR, got.CIDR)
+			require.Equal(t, tt.expectedGateway, got.Gateway)
+
+			gotAddrs := make([]string, 0, len(got.Addresses))
+			for _, a := range got.Addresses {
+				gotAddrs = append(gotAddrs, a.IP)
+			}
+			if tt.expectedAddrs == nil {
+				require.Empty(t, gotAddrs)
+			} else {
+				require.Equal(t, tt.expectedAddrs, gotAddrs)
+			}
+		})
+	}
+}
 
 func TestAvailableIPs(t *testing.T) {
 	cidr := netip.MustParsePrefix("10.0.0.0/8")

--- a/pkg/azure/ipam/instances.go
+++ b/pkg/azure/ipam/instances.go
@@ -48,6 +48,10 @@ type InstancesManager struct {
 	// resyncLock ensures instance incremental resync do not run at the same time as a full API resync
 	resyncLock lock.RWMutex
 
+	// usePrimary mirrors the --azure-use-primary-address operator flag; when
+	// true, each NIC's primary IP is exposed to the allocatable pool.
+	usePrimary bool
+
 	// mutex protects the fields below
 	mutex     lock.RWMutex
 	instances *ipamTypes.InstanceMap
@@ -56,11 +60,12 @@ type InstancesManager struct {
 }
 
 // NewInstancesManager returns a new instances manager
-func NewInstancesManager(logger *slog.Logger, api AzureAPI) *InstancesManager {
+func NewInstancesManager(logger *slog.Logger, api AzureAPI, usePrimary bool) *InstancesManager {
 	return &InstancesManager{
-		logger:    logger.With(subsysLogAttr...),
-		instances: ipamTypes.NewInstanceMap(),
-		api:       api,
+		logger:     logger.With(subsysLogAttr...),
+		instances:  ipamTypes.NewInstanceMap(),
+		api:        api,
+		usePrimary: usePrimary,
 	}
 }
 

--- a/pkg/azure/ipam/instances_test.go
+++ b/pkg/azure/ipam/instances_test.go
@@ -161,7 +161,7 @@ func TestSubnetDiscovery(t *testing.T) {
 	api := apimock.NewAPI(subnets, vnets)
 	require.NotNil(t, api)
 
-	mngr := NewInstancesManager(hivetest.Logger(t), api)
+	mngr := NewInstancesManager(hivetest.Logger(t), api, false)
 	require.NotNil(t, mngr)
 
 	require.Nil(t, mngr.subnets["subnet-1"])
@@ -196,7 +196,7 @@ func TestResyncInstancePreservesOtherNodesSubnets(t *testing.T) {
 	api := apimock.NewAPI(subnets2, vnets)
 	require.NotNil(t, api)
 
-	mngr := NewInstancesManager(hivetest.Logger(t), api)
+	mngr := NewInstancesManager(hivetest.Logger(t), api, false)
 	require.NotNil(t, mngr)
 
 	// Two instances using DIFFERENT subnets:
@@ -253,7 +253,7 @@ func TestExtractSubnetIDs(t *testing.T) {
 	api := apimock.NewAPI(subnets, vnets)
 	require.NotNil(t, api)
 
-	mngr := NewInstancesManager(hivetest.Logger(t), api)
+	mngr := NewInstancesManager(hivetest.Logger(t), api, false)
 	require.NotNil(t, mngr)
 
 	// Create 100 instances across only 2 different subnets to test deduplication

--- a/pkg/azure/ipam/ipam_test.go
+++ b/pkg/azure/ipam/ipam_test.go
@@ -147,7 +147,7 @@ func TestIpamPreAllocate8(t *testing.T) {
 	toUse := 7
 
 	api := apimock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVnet})
-	instances := NewInstancesManager(hivetest.Logger(t), api)
+	instances := NewInstancesManager(hivetest.Logger(t), api, false)
 	require.NotNil(t, instances)
 
 	m := ipamTypes.NewInstanceMap()
@@ -209,7 +209,7 @@ func TestIpamMinAllocate10(t *testing.T) {
 	toUse := 7
 
 	api := apimock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVnet})
-	instances := NewInstancesManager(hivetest.Logger(t), api)
+	instances := NewInstancesManager(hivetest.Logger(t), api, false)
 	require.NotNil(t, instances)
 
 	m := ipamTypes.NewInstanceMap()
@@ -293,7 +293,7 @@ func TestIpamManyNodes(t *testing.T) {
 				minAllocate = 1
 			)
 			api := apimock.NewAPI(testSubnets, []*ipamTypes.VirtualNetwork{testVnet})
-			instances := NewInstancesManager(hivetest.Logger(t), api)
+			instances := NewInstancesManager(hivetest.Logger(t), api, false)
 			require.NotNil(t, instances)
 
 			k8sapi := newK8sMock()
@@ -368,7 +368,7 @@ func benchmarkAllocWorker(b *testing.B, workers int64, delay time.Duration, rate
 	api.SetDelay(apimock.AllOperations, delay)
 	api.SetLimiter(rateLimit, burst)
 
-	instances := NewInstancesManager(hivetest.Logger(b), api)
+	instances := NewInstancesManager(hivetest.Logger(b), api, false)
 	require.NotNil(b, instances)
 
 	k8sapi := newK8sMock()

--- a/pkg/azure/ipam/node.go
+++ b/pkg/azure/ipam/node.go
@@ -80,13 +80,14 @@ func (n *Node) PrepareIPAllocation(scopedLog *slog.Logger) (a *nodemanager.Alloc
 	requiredIfaceName := n.k8sObj.Spec.Azure.InterfaceName
 	n.manager.mutex.RLock()
 	defer n.manager.mutex.RUnlock()
+	usePrimary := n.manager.usePrimary
 	err = n.manager.instances.ForeachInterface(n.node.InstanceID(), func(instanceID, interfaceID string, interfaceObj ipamTypes.Interface) error {
 		iface, ok := interfaceObj.(*types.AzureInterface)
 		if !ok {
 			return fmt.Errorf("invalid interface object")
 		}
 
-		availableOnInterface, available := isAvailableInterface(requiredIfaceName, iface, scopedLog)
+		availableOnInterface, available := isAvailableInterface(requiredIfaceName, iface, usePrimary, scopedLog)
 		if !available {
 			return nil
 		}
@@ -161,12 +162,6 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *slog.Logge
 	stats stats.InterfaceStats,
 	err error) {
 
-	// Azure virtual machines always have an upper limit of 256 addresses.
-	// Both VMs and NICs can have a maximum of 256 addresses, so as long as
-	// there is at least one available NIC, we can allocate up to 256 addresses
-	// on the VM (minus the primary IP address).
-	stats.NodeCapacity = max(n.GetMaximumAllocatableIPv4()-1, 0)
-
 	if n.node.InstanceID() == "" {
 		return nil, stats, nil
 	}
@@ -174,6 +169,7 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *slog.Logge
 	available = ipamTypes.AllocationMap{}
 	n.manager.mutex.RLock()
 	defer n.manager.mutex.RUnlock()
+	usePrimary := n.manager.usePrimary
 	err = n.manager.instances.ForeachAddress(n.node.InstanceID(), func(instanceID, interfaceID, ip, poolID string, addressObj ipamTypes.Address) error {
 		address, ok := addressObj.(types.AzureAddress)
 		if !ok {
@@ -199,6 +195,9 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *slog.Logge
 		return nil, stats, err
 	}
 
+	// Azure caps both NICs and VMs at 256 addresses; start from that ceiling
+	// and decrement per NIC below for any primary slot we can't allocate.
+	nodeCapacity := types.InterfaceAddressLimit
 	requiredIfaceName := n.k8sObj.Spec.Azure.InterfaceName
 	err = n.manager.instances.ForeachInterface(n.node.InstanceID(), func(instanceID, interfaceID string, interfaceObj ipamTypes.Interface) error {
 		iface, ok := interfaceObj.(*types.AzureInterface)
@@ -211,7 +210,13 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *slog.Logge
 			n.vmss = iface.GetVMScaleSetName()
 		}
 
-		_, available := isAvailableInterface(requiredIfaceName, iface, scopedLog)
+		// The primary IP still consumes a NIC slot even when it is not
+		// allocatable; reserve it from the VM-wide budget.
+		if !usePrimary && iface.IP != "" {
+			nodeCapacity--
+		}
+
+		_, available := isAvailableInterface(requiredIfaceName, iface, usePrimary, scopedLog)
 		if available {
 			stats.RemainingAvailableInterfaceCount++
 		}
@@ -220,6 +225,7 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *slog.Logge
 	if err != nil {
 		return nil, stats, err
 	}
+	stats.NodeCapacity = max(nodeCapacity, 0)
 
 	return available, stats, nil
 }
@@ -243,7 +249,7 @@ func (n *Node) IsPrefixDelegated() bool {
 }
 
 // isAvailableInterface returns whether interface is available and the number of available IPs to allocate in interface
-func isAvailableInterface(requiredIfaceName string, iface *types.AzureInterface, scopedLog *slog.Logger) (availableOnInterface int, available bool) {
+func isAvailableInterface(requiredIfaceName string, iface *types.AzureInterface, usePrimary bool, scopedLog *slog.Logger) (availableOnInterface int, available bool) {
 	if requiredIfaceName != "" {
 		if iface.Name != requiredIfaceName {
 			scopedLog.Debug(
@@ -261,7 +267,14 @@ func isAvailableInterface(requiredIfaceName string, iface *types.AzureInterface,
 		logfields.NumAddresses, len(iface.Addresses),
 	)
 
-	availableOnInterface = max(types.InterfaceAddressLimit-len(iface.Addresses), 0)
+	// The 256-address NIC limit covers both the primary and any secondaries.
+	// When the primary is not exposed to the pool, its slot is consumed but
+	// not reflected in iface.Addresses, so reserve it here.
+	limit := types.InterfaceAddressLimit
+	if !usePrimary && iface.IP != "" {
+		limit--
+	}
+	availableOnInterface = max(limit-len(iface.Addresses), 0)
 	if availableOnInterface <= 0 {
 		return 0, false
 	}

--- a/pkg/azure/ipam/node_stats_test.go
+++ b/pkg/azure/ipam/node_stats_test.go
@@ -9,45 +9,115 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
 
+	apimock "github.com/cilium/cilium/pkg/azure/api/mock"
 	"github.com/cilium/cilium/pkg/azure/types"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 )
 
-func TestENIIPAMCapacityAccounting(t *testing.T) {
-	assert := assert.New(t)
+func newCapacityTestNode(t *testing.T, ifaces []*types.AzureInterface, usePrimary bool) *Node {
+	t.Helper()
 	m := ipamTypes.NewInstanceMap()
-	resource := &types.AzureInterface{
-		Name:          "eth0",
-		SecurityGroup: "sg1",
-		Addresses: []types.AzureAddress{
-			{
-				IP:     "1.1.1.1",
-				Subnet: "subnet-1",
-				State:  types.StateSucceeded,
-			},
-		},
-		State: types.StateSucceeded,
+	for _, iface := range ifaces {
+		m.Update("vm1", iface.DeepCopy())
 	}
-	resource.SetID("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm1/networkInterfaces/vmss11")
-	m.Update("vm1", resource.DeepCopy())
-
-	n := &Node{
+	return &Node{
 		node: mockIPAMNode("vm1"),
 		manager: &InstancesManager{
-			instances: m,
+			instances:  m,
+			api:        apimock.NewAPI(nil, nil),
+			usePrimary: usePrimary,
 		},
 		k8sObj: &v2.CiliumNode{
 			Spec: v2.NodeSpec{
-				Azure: types.AzureSpec{
-					InterfaceName: "eth0",
-				},
+				Azure: types.AzureSpec{InterfaceName: "eth0"},
 			},
 		},
 	}
+}
+
+func newCapacityTestInterface(name, id, primaryIP string, secondaryIPs ...string) *types.AzureInterface {
+	addrs := make([]types.AzureAddress, 0, len(secondaryIPs))
+	for _, ip := range secondaryIPs {
+		addrs = append(addrs, types.AzureAddress{
+			IP:     ip,
+			Subnet: "subnet-1",
+			State:  types.StateSucceeded,
+		})
+	}
+	iface := &types.AzureInterface{
+		Name:          name,
+		IP:            primaryIP,
+		SecurityGroup: "sg1",
+		Addresses:     addrs,
+		State:         types.StateSucceeded,
+	}
+	iface.SetID(id)
+	return iface
+}
+
+func TestENIIPAMCapacityAccounting(t *testing.T) {
+	assert := assert.New(t)
+	iface := newCapacityTestInterface(
+		"eth0",
+		"/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm1/networkInterfaces/vmss11",
+		"1.1.1.1",
+		"1.1.1.2",
+	)
+	n := newCapacityTestNode(t, []*types.AzureInterface{iface}, false)
 	_, stats, err := n.ResyncInterfacesAndIPs(t.Context(), hivetest.Logger(t))
 	assert.NoError(err)
 	assert.Equal(255, stats.NodeCapacity)
+}
+
+func TestENIIPAMCapacityAccountingUsePrimary(t *testing.T) {
+	assert := assert.New(t)
+	iface := newCapacityTestInterface(
+		"eth0",
+		"/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm1/networkInterfaces/vmss11",
+		"1.1.1.1",
+		"1.1.1.2",
+	)
+	n := newCapacityTestNode(t, []*types.AzureInterface{iface}, true)
+	_, stats, err := n.ResyncInterfacesAndIPs(t.Context(), hivetest.Logger(t))
+	assert.NoError(err)
+	assert.Equal(256, stats.NodeCapacity)
+}
+
+func TestENIIPAMCapacityAccountingMultiNIC(t *testing.T) {
+	assert := assert.New(t)
+	iface1 := newCapacityTestInterface(
+		"eth0",
+		"/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm1/networkInterfaces/nic1",
+		"1.1.1.1",
+	)
+	iface2 := newCapacityTestInterface(
+		"eth1",
+		"/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm1/networkInterfaces/nic2",
+		"1.1.2.1",
+	)
+	n := newCapacityTestNode(t, []*types.AzureInterface{iface1, iface2}, false)
+	_, stats, err := n.ResyncInterfacesAndIPs(t.Context(), hivetest.Logger(t))
+	assert.NoError(err)
+	assert.Equal(254, stats.NodeCapacity)
+}
+
+func TestENIIPAMCapacityAccountingMultiNICUsePrimary(t *testing.T) {
+	assert := assert.New(t)
+	iface1 := newCapacityTestInterface(
+		"eth0",
+		"/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm1/networkInterfaces/nic1",
+		"1.1.1.1",
+	)
+	iface2 := newCapacityTestInterface(
+		"eth1",
+		"/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm1/networkInterfaces/nic2",
+		"1.1.2.1",
+	)
+	n := newCapacityTestNode(t, []*types.AzureInterface{iface1, iface2}, true)
+	_, stats, err := n.ResyncInterfacesAndIPs(t.Context(), hivetest.Logger(t))
+	assert.NoError(err)
+	assert.Equal(256, stats.NodeCapacity)
 }
 
 type mockIPAMNode string

--- a/pkg/azure/types/types.go
+++ b/pkg/azure/types/types.go
@@ -72,6 +72,11 @@ type AzureInterface struct {
 	// +optional
 	ID string `json:"id,omitempty"`
 
+	// IP is the primary IP of the interface
+	//
+	// +optional
+	IP string `json:"ip,omitempty"`
+
 	// Name is the name of the interface
 	//
 	// +optional
@@ -87,8 +92,10 @@ type AzureInterface struct {
 	// +optional
 	State string `json:"state,omitempty"`
 
-	// Addresses is the list of all IPs associated with the interface,
-	// including all secondary addresses
+	// Addresses is the list of secondary IPs associated with the interface.
+	// The primary IP is tracked separately in the IP field, but is also
+	// included here when the operator is configured to expose it for
+	// allocation.
 	//
 	// +optional
 	Addresses []AzureAddress `json:"addresses,omitempty"`

--- a/pkg/azure/types/zz_generated.deepequal.go
+++ b/pkg/azure/types/zz_generated.deepequal.go
@@ -38,6 +38,9 @@ func (in *AzureInterface) DeepEqual(other *AzureInterface) bool {
 	if in.ID != other.ID {
 		return false
 	}
+	if in.IP != other.IP {
+		return false
+	}
 	if in.Name != other.Name {
 		return false
 	}

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -527,8 +527,10 @@ spec:
                       properties:
                         addresses:
                           description: |-
-                            Addresses is the list of all IPs associated with the interface,
-                            including all secondary addresses
+                            Addresses is the list of secondary IPs associated with the interface.
+                            The primary IP is tracked separately in the IP field, but is also
+                            included here when the operator is configured to expose it for
+                            allocation.
                           items:
                             description: AzureAddress is an IP address assigned to
                               an AzureInterface
@@ -556,6 +558,9 @@ spec:
                           type: string
                         id:
                           description: ID is the identifier
+                          type: string
+                        ip:
+                          description: IP is the primary IP of the interface
                           type: string
                         mac:
                           description: MAC is the mac address

--- a/pkg/k8s/apis/cilium.io/register.go
+++ b/pkg/k8s/apis/cilium.io/register.go
@@ -15,5 +15,5 @@ const (
 	//
 	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.33.4"
+	CustomResourceDefinitionSchemaVersion = "1.33.5"
 )


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Write a short paragraph that states whether you used machine learning models
      (including LLMs and other generative AI), and indicate the rating using
      [AI Influence Level](https://danielmiessler.com/blog/ai-influence-level-ail).
      Example: "This PR was prepared with AIL:3. I personally reviewed each line
      of the submission prior to opening this PR."
- [x] Thanks for contributing!

<!-- Description of change -->

I'm working on two larger features, IP Release & Prefix on NIC support for the Azure IPAM mode. In doing so, I've realized that both need to have Azure's IPAM mode track which IP is the `primary` similar to AWS and Alibaba. This PR implements the primary IP tracking following a similar setup to AWS. In Azure, only 1 IP on the NIC can be primary, so this updates the CRD to track that under the CiliumNode object at `status.azure.interfaces[].ip` like AWS's `status.eni.enis[].ip`. 

Now that it's tracking the Primary, I can also remove a hardcoded `-1` in the availability calculation logic too. Now if `--azure-use-primary-address` is set to true, it'll keep that IP in the availability bool, and if not, remove it. I think in the grand scheme of things this is minor though, because Azure lets us have up to 256 IP's and I suspect no one has hit that and noticed the misaccounting anyway. 

For testing, I have [backported this change to our fork of 1.19](https://github.com/DataDog/cilium/compare/v1.19-dd...DataDog:cilium:jared.ledvina/azure-primary-ip-v1.19?expand=1) and validated that when the operator & agent are deployed w/ this patch, the `CiliumNode` object properly begins to track the new `.ip` field w/ the Primary IP's as expected. 

Fixes: _I didn't file an issue for this, happy to do so if folks prefer._

```release-note
Azure IPAM: Add tracking of the Primary IP per interface 
```

As discussed during the weekly community syncs (and per https://github.com/cilium/community/blob/main/AI-POLICY.md): I used Claude Code, at AIL:3, as a tool for exploration, drafting, and code review against the AWS pattern. I've gone through the entire diff in detail prior to submitting. 