### PR TITLE
.github: Enable ciliumbot to pass patch checks

### DIFF
--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -71,14 +71,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           make -C bpf checkpatch || (echo "Run 'make -C bpf checkpatch' locally to investigate reports"; exit 1)
-      - name: Double-check Signed-off-by
+      - name: Validate authors
         run: |
           commits=$(git log ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})
-          if echo "$commits" | grep -v renovate | grep 'Signed-off-by:.*noreply.*'; then
+          if echo "$commits" \
+             | grep -v -e 'renovate\[bot\]' -e 'noreply@cilium.io' \
+             | grep 'Signed-off-by:.*noreply.*'; \
+          then
             echo "Please use a real email address for your Signed-off-by."
             exit 1
           fi
-          if echo "$commits" | grep -v renovate | grep -i 'author.*noreply.*'; then
+          if echo "$commits" \
+             | grep -v -e 'renovate\[bot\]' -e 'noreply@cilium.io' \
+             | grep -i 'author.*noreply.*'; \
+          then
             echo "Please use a real email address for all authors. Generative AI tools can not author or sign off contributions."
             exit 1
           fi


### PR DESCRIPTION
Commit 3a291920b159 ("workflows: Reject GitHub's default email for SOB")
introduced new checks for author and signed-off-by lines that cause the
check to fail when a contributor submits a change with a noreply email
address. But it was catching the automated bot updates prepared as part
this CI. Let's exclude those.

This also does some minor formatting for consistency and line lengths.

Fixes: #45912 