### PR TITLE
feat: add hostfirewall + ipsec functionality

### DIFF
--- a/Documentation/security/policy/host.rst
+++ b/Documentation/security/policy/host.rst
@@ -173,6 +173,3 @@ Host Policies known issues
   services for the native device (such as NodePort), hosts will enforce Host
   Policies on service addresses rather than the service endpoints. For details,
   refer to :gh-issue:`12545`.
-
-- Host Firewall and thus Host Policies do not work together with IPsec.
-  For details, refer to :gh-issue:`41854`.

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1379,6 +1379,15 @@ int cil_to_netdev(struct __ctx_buff *ctx)
 	if (ctx_snat_done(ctx))
 		goto skip_host_firewall;
 
+# ifdef ENABLE_IPSEC
+	/* The post-XFRM ESP packet recirculates through the native device with
+	 * MARK_MAGIC_ENCRYPT set. Skip host firewall egress on this pass; the
+	 * ESP outer tuple would otherwise be treated as host-originated traffic.
+	 */
+	if (ctx_is_encrypt(ctx))
+		goto skip_host_firewall;
+# endif
+
 	if (!eth_is_supported_ethertype(proto)) {
 		ret = DROP_UNSUPPORTED_L2;
 		goto drop_err;
@@ -1749,8 +1758,9 @@ int cil_to_host(struct __ctx_buff *ctx)
 		goto skip_ipsec_nodeport_revdnat;
 
 	/* handle_nat_fwd() tail calls in the majority of cases, so control
-	 * might never return to this program. Since IPsec is not compatible
-	 * iwth Host Firewall, this won't be an issue.
+	 * might never return to this program. On IPsec recirculation, packets
+	 * delivered to local endpoints do not need host firewall ingress; the
+	 * destination identity lookup below would skip them.
 	 */
 	ret = handle_nat_fwd(ctx, 0, src_id, proto, true, &trace, &ext_err);
 	if (IS_ERR(ret))

--- a/bpf/tests/host_hostfw_ipsec_egress.c
+++ b/bpf/tests/host_hostfw_ipsec_egress.c
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+/* Native-routing variant for IPsec recirculation hostFW egress tests. */
+
+#define ENABLE_IPSEC			1
+
+#include "host_hostfw_ipsec_egress.h"

--- a/bpf/tests/host_hostfw_ipsec_egress.h
+++ b/bpf/tests/host_hostfw_ipsec_egress.h
@@ -1,0 +1,299 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+/* Tests that MARK_MAGIC_ENCRYPT skips hostFW egress for the post-XFRM ESP
+ * pass, while ordinary host-originated traffic is still evaluated.
+ */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+#define ENABLE_IPV4			1
+#define ENABLE_IPV6			1
+#define ENABLE_HOST_FIREWALL		1
+
+#define LOCAL_NODE_IP			v4_node_one
+#define REMOTE_NODE_IP			v4_node_two
+#define LOCAL_NODE_IP6			((const union v6addr *)v6_node_one)
+#define REMOTE_NODE_IP6			((const union v6addr *)v6_node_two)
+
+#define POD_SRC_IP			v4_pod_one
+#define POD_DST_IP			v4_pod_one_on_node_two
+#define POD_SRC_IDENTITY		(CIDR_IDENTITY_RANGE_START - 1)
+#define POD_DST_IDENTITY		(CIDR_IDENTITY_RANGE_START - 2)
+
+static volatile const __u8 *node_mac = mac_one;
+static volatile const __u8 *peer_mac = mac_two;
+
+#include "lib/bpf_host.h"
+
+#include "lib/endpoint.h"
+#include "lib/ipcache.h"
+#include "lib/policy.h"
+
+ASSIGN_CONFIG(bool, enable_conntrack_accounting, true)
+
+/*
+ * Test 1: hostfw_ipsec_egress_no_bogus_verdict (IPv4)
+ *
+ * ESP packet shaped like the post-XFRM pass. A host egress deny policy is
+ * installed; MARK_MAGIC_ENCRYPT must bypass hostFW egress and leave no CT
+ * entry for the outer ESP tuple.
+ */
+PKTGEN("tc", "hostfw_ipsec_egress_v4_no_bogus_verdict")
+int hostfw_ipsec_egress_v4_no_bogus_verdict_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct iphdr *l3;
+
+	pktgen__init(&builder, ctx);
+
+	l3 = pktgen__push_ipv4_packet(&builder, (__u8 *)node_mac, (__u8 *)peer_mac,
+				      LOCAL_NODE_IP, REMOTE_NODE_IP);
+	if (!l3)
+		return TEST_ERROR;
+	l3->protocol = IPPROTO_ESP;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "hostfw_ipsec_egress_v4_no_bogus_verdict")
+int hostfw_ipsec_egress_v4_no_bogus_verdict_setup(struct __ctx_buff *ctx)
+{
+	endpoint_v4_add_entry(LOCAL_NODE_IP, 0, 0, ENDPOINT_F_HOST, HOST_ID,
+			      0, (__u8 *)node_mac, (__u8 *)node_mac);
+	ipcache_v4_add_entry(LOCAL_NODE_IP, 0, HOST_ID, 0, 0);
+	ipcache_v4_add_entry(REMOTE_NODE_IP, 0, REMOTE_NODE_ID, 0, 0);
+	ipcache_v4_add_world_entry();
+
+	/* This would drop the ESP tuple if hostFW egress ran. */
+	policy_add_egress_deny_all_entry();
+
+	/* Mark the skb as the post-XFRM pass. */
+	ctx->mark = MARK_MAGIC_ENCRYPT;
+
+	return netdev_send_packet(ctx);
+}
+
+CHECK("tc", "hostfw_ipsec_egress_v4_no_bogus_verdict")
+int hostfw_ipsec_egress_v4_no_bogus_verdict_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	endpoint_v4_del_entry(LOCAL_NODE_IP);
+	policy_delete_egress_all_entry();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_OK);
+
+	/* The outer ESP tuple must not be tracked by hostFW egress. */
+	struct ipv4_ct_tuple tuple = {
+		.daddr   = REMOTE_NODE_IP,
+		.saddr   = LOCAL_NODE_IP,
+		.dport   = 0,
+		.sport   = 0,
+		.nexthdr = IPPROTO_ESP,
+		.flags   = TUPLE_F_OUT,
+	};
+	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+
+	if (ct_entry)
+		test_fatal("hostFW egress unexpectedly created CT on encrypted recirculation");
+
+	test_finish();
+}
+
+/*
+ * Test 2: hostfw_ipsec_egress_v4_host_originated_still_evaluated
+ *
+ * Scope guard: MARK_MAGIC_HOST must not match the encrypted-recirculation
+ * skip, so host-originated ICMP still hits egress policy.
+ */
+PKTGEN("tc", "hostfw_ipsec_egress_v4_host_originated_drop")
+int hostfw_ipsec_egress_v4_host_originated_drop_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct iphdr *l3;
+
+	pktgen__init(&builder, ctx);
+
+	l3 = pktgen__push_ipv4_packet(&builder, (__u8 *)node_mac, (__u8 *)peer_mac,
+				      LOCAL_NODE_IP, REMOTE_NODE_IP);
+	if (!l3)
+		return TEST_ERROR;
+	l3->protocol = IPPROTO_ICMP;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "hostfw_ipsec_egress_v4_host_originated_drop")
+int hostfw_ipsec_egress_v4_host_originated_drop_setup(struct __ctx_buff *ctx)
+{
+	endpoint_v4_add_entry(LOCAL_NODE_IP, 0, 0, ENDPOINT_F_HOST, HOST_ID,
+			      0, (__u8 *)node_mac, (__u8 *)node_mac);
+	ipcache_v4_add_entry(LOCAL_NODE_IP, 0, HOST_ID, 0, 0);
+	ipcache_v4_add_entry(REMOTE_NODE_IP, 0, REMOTE_NODE_ID, 0, 0);
+	ipcache_v4_add_world_entry();
+
+	policy_add_egress_deny_all_entry();
+
+	/* Host-originated traffic must still hit hostFW egress. */
+	set_identity_mark(ctx, 0, MARK_MAGIC_HOST);
+
+	return netdev_send_packet(ctx);
+}
+
+CHECK("tc", "hostfw_ipsec_egress_v4_host_originated_drop")
+int hostfw_ipsec_egress_v4_host_originated_drop_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	endpoint_v4_del_entry(LOCAL_NODE_IP);
+	policy_delete_egress_all_entry();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_DROP);
+
+	test_finish();
+}
+
+/*
+ * Test 3: hostfw_ipsec_egress_v4_clear_pass_short_circuits
+ *
+ * Clear pod-to-pod traffic should not trigger hostFW egress because neither
+ * the source identity nor the ipcache source identity is HOST_ID.
+ */
+PKTGEN("tc", "hostfw_ipsec_egress_v4_clear_pass")
+int hostfw_ipsec_egress_v4_clear_pass_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct iphdr *l3;
+
+	pktgen__init(&builder, ctx);
+
+	l3 = pktgen__push_ipv4_packet(&builder, (__u8 *)node_mac, (__u8 *)peer_mac,
+				      POD_SRC_IP, POD_DST_IP);
+	if (!l3)
+		return TEST_ERROR;
+	l3->protocol = IPPROTO_TCP;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "hostfw_ipsec_egress_v4_clear_pass")
+int hostfw_ipsec_egress_v4_clear_pass_setup(struct __ctx_buff *ctx)
+{
+	ipcache_v4_add_entry(POD_SRC_IP, 0, POD_SRC_IDENTITY, 0, 0);
+	ipcache_v4_add_entry(POD_DST_IP, 0, POD_DST_IDENTITY, REMOTE_NODE_IP, 0);
+
+	/* The clear pod-to-pod pass should bypass this host policy. */
+	policy_add_egress_deny_all_entry();
+
+	set_identity_mark(ctx, POD_SRC_IDENTITY, MARK_MAGIC_IDENTITY);
+
+	return netdev_send_packet(ctx);
+}
+
+CHECK("tc", "hostfw_ipsec_egress_v4_clear_pass")
+int hostfw_ipsec_egress_v4_clear_pass_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	policy_delete_egress_all_entry();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	/* HostFW egress skipped the pod-sourced packet. */
+	assert(*status_code == CTX_ACT_OK);
+
+	test_finish();
+}
+
+/*
+ * Test 4: hostfw_ipsec_egress_v6_no_bogus_verdict
+ *
+ * IPv6 sibling of Test 1.
+ */
+PKTGEN("tc", "hostfw_ipsec_egress_v6_no_bogus_verdict")
+int hostfw_ipsec_egress_v6_no_bogus_verdict_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct ipv6hdr *l3;
+
+	pktgen__init(&builder, ctx);
+
+	l3 = pktgen__push_ipv6_packet(&builder, (__u8 *)node_mac, (__u8 *)peer_mac,
+				      (__u8 *)LOCAL_NODE_IP6, (__u8 *)REMOTE_NODE_IP6);
+	if (!l3)
+		return TEST_ERROR;
+	l3->nexthdr = IPPROTO_ESP;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "hostfw_ipsec_egress_v6_no_bogus_verdict")
+int hostfw_ipsec_egress_v6_no_bogus_verdict_setup(struct __ctx_buff *ctx)
+{
+	ipcache_v6_add_entry(LOCAL_NODE_IP6, 0, HOST_ID, 0, 0);
+	ipcache_v6_add_entry(REMOTE_NODE_IP6, 0, REMOTE_NODE_ID, 0, 0);
+
+	policy_add_egress_deny_all_entry();
+
+	ctx->mark = MARK_MAGIC_ENCRYPT;
+
+	return netdev_send_packet(ctx);
+}
+
+CHECK("tc", "hostfw_ipsec_egress_v6_no_bogus_verdict")
+int hostfw_ipsec_egress_v6_no_bogus_verdict_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	policy_delete_egress_all_entry();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_OK);
+
+	test_finish();
+}

--- a/bpf/tests/host_hostfw_ipsec_egress_tunnel.c
+++ b/bpf/tests/host_hostfw_ipsec_egress_tunnel.c
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+/* Tunnel-routing variant for IPsec recirculation hostFW egress tests. */
+
+#define TUNNEL_MODE			1
+#define ENCAP_IFINDEX			42
+
+#define ENABLE_IPSEC			1
+
+#include "host_hostfw_ipsec_egress.h"

--- a/bpf/tests/host_hostfw_ipsec_to_host.c
+++ b/bpf/tests/host_hostfw_ipsec_to_host.c
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+/* Native-routing variant for IPsec recirculation to-host tests. */
+
+#define ENABLE_IPSEC			1
+
+#include "host_hostfw_ipsec_to_host.h"

--- a/bpf/tests/host_hostfw_ipsec_to_host.h
+++ b/bpf/tests/host_hostfw_ipsec_to_host.h
@@ -1,0 +1,154 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+/* Tests the cil_to_host IPsec recirculation path with hostFW and NodePort
+ * enabled. These cases verify the marked path returns without an error; they
+ * do not seed LB/NAT state or assert revDNAT rewrites.
+ */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+#define ENABLE_IPV4			1
+#define ENABLE_IPV6			1
+#define ENABLE_HOST_FIREWALL		1
+#define ENABLE_NODEPORT			1
+#define ENABLE_MASQUERADE_IPV4		1
+
+#define LOCAL_NODE_IP			v4_node_one
+#define REMOTE_NODE_IP			v4_node_two
+
+#define POD_LOCAL_IP			v4_pod_one
+#define POD_REMOTE_IP			v4_pod_one_on_node_two
+#define POD_LOCAL_IDENTITY		(CIDR_IDENTITY_RANGE_START - 1)
+#define POD_REMOTE_IDENTITY		(CIDR_IDENTITY_RANGE_START - 2)
+
+#define CLIENT_PORT			bpf_htons(54321)
+#define BACKEND_PORT			bpf_htons(8080)
+
+static volatile const __u8 *node_mac = mac_one;
+static volatile const __u8 *peer_mac = mac_two;
+
+#include "lib/bpf_host.h"
+
+#include "lib/ipcache.h"
+#include "lib/policy.h"
+
+ASSIGN_CONFIG(bool, enable_conntrack_accounting, true)
+
+/* Build a TCP packet shaped like an IPsec-decrypted backend reply. The
+ * NodePort path only needs parseable IPv4/TCP headers here.
+ */
+static __always_inline int build_inner_tcp_v4(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)peer_mac, (__u8 *)node_mac,
+					  POD_LOCAL_IP, POD_REMOTE_IP,
+					  BACKEND_PORT, CLIENT_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+/*
+ * Test 1: ipsec_recirc_to_host_nodeport_path_runs
+ *
+ * MARK_MAGIC_ENCRYPT enters the IPsec NodePort revDNAT path. No LB/NAT
+ * state is seeded, so handle_nat_fwd returns without rewrite and hostFW
+ * ingress skips the pod-bound packet.
+ */
+PKTGEN("tc", "ipsec_recirc_to_host_nodeport_path_runs")
+int ipsec_recirc_to_host_nodeport_path_runs_pktgen(struct __ctx_buff *ctx)
+{
+	return build_inner_tcp_v4(ctx);
+}
+
+SETUP("tc", "ipsec_recirc_to_host_nodeport_path_runs")
+int ipsec_recirc_to_host_nodeport_path_runs_setup(struct __ctx_buff *ctx)
+{
+	ipcache_v4_add_entry(POD_LOCAL_IP, 0, POD_LOCAL_IDENTITY, 0, 0);
+	ipcache_v4_add_entry(POD_REMOTE_IP, 0, POD_REMOTE_IDENTITY,
+			     REMOTE_NODE_IP, 0);
+	ipcache_v4_add_world_entry();
+
+	/* Mark the skb as IPsec-decrypted recirculation. */
+	ctx->mark = MARK_MAGIC_ENCRYPT;
+
+	return host_receive_packet(ctx);
+}
+
+CHECK("tc", "ipsec_recirc_to_host_nodeport_path_runs")
+int ipsec_recirc_to_host_nodeport_path_runs_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	/* No LB/NAT state is seeded, so the packet is returned unmodified (CTX_ACT_OK). */
+	assert(*status_code == CTX_ACT_OK);
+
+	test_finish();
+}
+
+/*
+ * Test 2: ipsec_recirc_to_host_no_encrypt_skips_nodeport_block
+ *
+ * Scope guard: without MARK_MAGIC_ENCRYPT, the IPsec NodePort revDNAT block
+ * is skipped and regular pod-bound ingress still returns OK.
+ */
+PKTGEN("tc", "ipsec_recirc_to_host_no_encrypt_skips_nodeport_block")
+int ipsec_recirc_to_host_no_encrypt_skips_nodeport_block_pktgen(struct __ctx_buff *ctx)
+{
+	return build_inner_tcp_v4(ctx);
+}
+
+SETUP("tc", "ipsec_recirc_to_host_no_encrypt_skips_nodeport_block")
+int ipsec_recirc_to_host_no_encrypt_skips_nodeport_block_setup(struct __ctx_buff *ctx)
+{
+	ipcache_v4_add_entry(POD_LOCAL_IP, 0, POD_LOCAL_IDENTITY, 0, 0);
+	ipcache_v4_add_entry(POD_REMOTE_IP, 0, POD_REMOTE_IDENTITY,
+			     REMOTE_NODE_IP, 0);
+	ipcache_v4_add_world_entry();
+
+	/* Regular ingress, not IPsec recirculation. */
+	ctx->mark = 0;
+
+	return host_receive_packet(ctx);
+}
+
+CHECK("tc", "ipsec_recirc_to_host_no_encrypt_skips_nodeport_block")
+int ipsec_recirc_to_host_no_encrypt_skips_nodeport_block_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_OK);
+
+	test_finish();
+}

--- a/bpf/tests/host_hostfw_ipsec_to_host_tunnel.c
+++ b/bpf/tests/host_hostfw_ipsec_to_host_tunnel.c
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+/* Tunnel-routing variant for IPsec recirculation to-host tests. */
+
+#define TUNNEL_MODE			1
+#define ENCAP_IFINDEX			42
+
+#define ENABLE_IPSEC			1
+
+#include "host_hostfw_ipsec_to_host.h"

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -51,12 +51,6 @@ func initAndValidateDaemonConfig(params daemonConfigParams) error {
 		return fmt.Errorf("Strict ingress encryption requires tunneling to be enabled.")
 	}
 
-	if params.DaemonConfig.EnableHostFirewall {
-		if params.IPSecConfig.Enabled() {
-			return fmt.Errorf("IPSec cannot be used with the host firewall.")
-		}
-	}
-
 	if params.DaemonConfig.LocalRouterIPv4 != "" || params.DaemonConfig.LocalRouterIPv6 != "" {
 		if params.IPSecConfig.Enabled() {
 			return fmt.Errorf("Cannot specify %s or %s with %s.", option.LocalRouterIPv4, option.LocalRouterIPv6, option.EnableIPSec)


### PR DESCRIPTION
This PR aims to add support for Ipsec feature to be compatible with host firewall. Today, when IPSec is enabled, host firewall drops all egress ESP packets and this results in them not being compatible. On the ingress encrypted packets do not go via the host firewall evaluation. 

The fix here is to match the implicit ingress behavior for egress as well and let the encrypted ESP packets to skip host firewall.

Fixes: #41854 

```release-note
Host Firewall and thus Host Policies are now compatible with IPsec
```

This PR was prepared with AIL:2, most of the tests are written and expanded by LLM.