### PR TITLE
ipam: move ipPoolWatcherJob from OnStart hook to long-lived job

### DIFF
--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -335,6 +335,77 @@ jobs:
           cilium status --wait --interactive=false
           kubectl -n kube-system get pods
 
+      - name: Verify late-created pool is reconciled
+        id: late-pool
+        timeout-minutes: 10
+        run: |
+          echo "Deploying late-created-pool-check deployment..."
+          cat <<'EOF' | kubectl apply -f -
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: late-created-pool-check
+            namespace: default
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: late-created-pool-check
+            template:
+              metadata:
+                labels:
+                  app: late-created-pool-check
+                annotations:
+                  ipam.cilium.io/ip-pool: late-created-pool
+              spec:
+                containers:
+                - name: pause
+                  image: registry.k8s.io/pause:3.10
+          EOF
+
+          if kubectl rollout status deployment/late-created-pool-check --namespace default --timeout=60s; then
+            echo "::error::deployment unexpectedly became ready before pool creation"
+            exit 1
+          fi
+
+          echo "Creating late-created-pool CiliumPodIPPool..."
+          cat <<'EOF' | kubectl apply -f -
+          apiVersion: cilium.io/v2alpha1
+          kind: CiliumPodIPPool
+          metadata:
+            name: late-created-pool
+          spec:
+            ipv4:
+              cidrs:
+              - 192.168.32.0/20
+              maskSize: 27
+            ipv6:
+              cidrs:
+              - fd00::400/120
+              maskSize: 122
+          EOF
+
+          kubectl rollout status deployment/late-created-pool-check --namespace default --timeout=5m
+          kubectl get pod --namespace default -l app=late-created-pool-check -o "jsonpath=pod_ips={.items[0].status.podIPs[*].ip}{'\n'}" >> "$GITHUB_OUTPUT"
+          echo "ipv4_cidr=192.168.32.0/20" >> "$GITHUB_OUTPUT"
+          echo "ipv6_cidr=fd00::400/120" >> "$GITHUB_OUTPUT"
+
+      - name: Validate late-created pool pod IPs
+        shell: python
+        run: |
+          from ipaddress import ip_address, ip_network
+
+          ips = "${{ steps.late-pool.outputs.pod_ips }}".split()
+          assert ips, "late-created-pool pod has no IPs"
+          assert any(ip_address(ip) in ip_network("${{ steps.late-pool.outputs.ipv4_cidr }}") for ip in ips), "missing IPv4 address from late-created-pool"
+          assert any(ip_address(ip) in ip_network("${{ steps.late-pool.outputs.ipv6_cidr }}") for ip in ips), "missing IPv6 address from late-created-pool"
+
+      - name: Cleanup late-created pool resources
+        if: always()
+        run: |
+          kubectl delete deployment/late-created-pool-check --namespace default --ignore-not-found=true --wait=true
+          kubectl delete ciliumpodippool/late-created-pool --ignore-not-found=true --wait=true
+
       - name: Make JUnit report directory
         run: |
           mkdir -p cilium-junits

--- a/operator/pkg/ipam/multipool.go
+++ b/operator/pkg/ipam/multipool.go
@@ -77,6 +77,7 @@ func startMultiPoolAllocator(p multiPoolParams) {
 	}
 
 	logger := p.Logger.With([]any{logfields.LogSubsys, "ipam-allocator-multi-pool"}...)
+	poolLogger := p.Logger.With([]any{logfields.LogSubsys, "ip-pool-watcher"}...)
 
 	allocator := multipool.NewPoolAllocator(logger, p.DaemonCfg.EnableIPv4, p.DaemonCfg.EnableIPv6)
 
@@ -87,12 +88,23 @@ func startMultiPoolAllocator(p multiPoolParams) {
 					return err
 				}
 
-				// The following operation will block until all pools are restored, thus it
-				// is safe to continue starting node allocation right after return.
-				startIPPoolAllocator(
-					ctx, allocator, p.CiliumPodIPPools,
-					p.Logger.With(logfields.LogSubsys, "ip-pool-watcher"),
-				)
+				synced := make(chan struct{})
+
+				// Watch PodIPPool events via a job, so the watcher persists beyond
+				// the start hook and new pools created at runtime are picked up.
+				p.JobGroup.Add(job.OneShot(
+					"ip-pool-allocator",
+					ipPoolWatcherJob(allocator, p.CiliumPodIPPools, poolLogger, synced),
+				))
+
+				// Block until all pools are restored, so callers can
+				// safely start node allocation right after return.
+				select {
+				case <-synced:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+				poolLogger.InfoContext(ctx, "All CiliumPodIPPool resources synchronized")
 
 				nm := multipool.NewNodeHandler(
 					"ipam-multi-pool-sync",
@@ -155,17 +167,16 @@ func multiPoolAutoCreatePools(ctx context.Context, clientset client.Clientset, p
 	return nil
 }
 
-func startIPPoolAllocator(
-	ctx context.Context,
+func ipPoolWatcherJob(
 	allocator *multipool.PoolAllocator,
 	ipPools resource.Resource[*cilium_v2alpha1.CiliumPodIPPool],
 	logger *slog.Logger,
-) {
-	logger.InfoContext(ctx, "Starting CiliumPodIPPool allocator watcher")
+	synced chan struct{},
+) func(ctx context.Context, health cell.Health) error {
+	return func(ctx context.Context, health cell.Health) error {
+		logger.InfoContext(ctx, "Starting CiliumPodIPPool allocator watcher")
+		health.OK("Primed")
 
-	synced := make(chan struct{})
-
-	go func() {
 		for ev := range ipPools.Events(ctx) {
 			var err error
 			var action string
@@ -173,6 +184,7 @@ func startIPPoolAllocator(
 			switch ev.Kind {
 			case resource.Sync:
 				close(synced)
+				health.OK("Synced")
 			case resource.Upsert:
 				err = multipool.UpsertPool(allocator, ev.Object.Name, ev.Object.Spec.IPv4, ev.Object.Spec.IPv6)
 				action = "upsert"
@@ -185,10 +197,7 @@ func startIPPoolAllocator(
 				logger.ErrorContext(ctx, fmt.Sprintf("failed to %s pool %q", action, ev.Key), logfields.Error, err)
 			}
 		}
-	}()
 
-	// Block until all pools are restored, so callers can safely start node allocation
-	// right after return.
-	<-synced
-	logger.InfoContext(ctx, "All CiliumPodIPPool resources synchronized")
+		return nil
+	}
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Write a short paragraph that states whether you used machine learning models
      (including LLMs and other generative AI), and indicate the rating using
      [AI Influence Level](https://danielmiessler.com/blog/ai-influence-level-ail).
      Example: "This PR was prepared with AIL:3. I personally reviewed each line
      of the submission prior to opening this PR."
- [x] Thanks for contributing!

This PR was prepared with AIL:2. I wrote the Go code and had it reviewed and improved by AI. The CI test was written by AI. I've reviewed each line of code before submitting the PR.

<!-- Description of change -->
This PR moves the multipool allocator's ipPoolWatcherJob from the OnStart hook to a OneShot job as the current HookContext is cancelled once all hooks are completed.

This ensures the watcher persists beyond the start hook, so pools created at runtime are properly picked up and reconciled. This fixes a bug introduced in the multipool refactor that put the watcher in the short-lived HookContext.

Also added a test to conformance-multi-pool that verifies pools created after startup are reconciled.

Fixes: #45980

```release-note
ipam: move ipPoolWatcherJob from OnStart hook to long-lived job
```
