### PR TITLE
Testing: ICMP FN/PTB errors improved checksum coverage and cleanup

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -799,7 +799,7 @@ snat_v4_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 	struct ipv4_ct_tuple tuple = {};
 	struct iphdr iphdr;
 	__u16 port_off;
-	__u32 icmpoff;
+	__u32 inner_l4_off;
 	__u8 type;
 	int ret;
 	bool icmp_has_inner_l4_csum = true;
@@ -820,7 +820,7 @@ snat_v4_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 	tuple.daddr = iphdr.saddr;
 	tuple.flags = NAT_DIR_EGRESS;
 
-	icmpoff = inner_l3_off + ipv4_hdrlen(&iphdr);
+	inner_l4_off = inner_l3_off + ipv4_hdrlen(&iphdr);
 	switch (tuple.nexthdr) {
 	case IPPROTO_TCP:
 	case IPPROTO_UDP:
@@ -830,13 +830,13 @@ snat_v4_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 		/* No reasons to handle IP fragmentation for this case as it is
 		 * expected that DF isn't set for this particular context.
 		 */
-		if (l4_load_ports(ctx, icmpoff, &tuple.dport) < 0)
+		if (l4_load_ports(ctx, inner_l4_off, &tuple.dport) < 0)
 			return DROP_INVALID;
 
 		port_off = TCP_DPORT_OFF;
 		break;
 	case IPPROTO_ICMP:
-		if (ctx_load_bytes(ctx, icmpoff, &type, sizeof(type)) < 0)
+		if (ctx_load_bytes(ctx, inner_l4_off, &type, sizeof(type)) < 0)
 			return DROP_INVALID;
 
 		switch (type) {
@@ -849,7 +849,7 @@ snat_v4_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 			return DROP_UNKNOWN_ICMP4_CODE;
 		}
 
-		if (ctx_load_bytes(ctx, icmpoff + port_off,
+		if (ctx_load_bytes(ctx, inner_l4_off + port_off,
 				   &tuple.sport, sizeof(tuple.sport)) < 0)
 			return DROP_INVALID;
 		break;
@@ -869,7 +869,7 @@ snat_v4_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 	/* We found SNAT entry to NAT embedded packet. The destination addr
 	 * should be NATed according to the entry.
 	 */
-	ret = snat_v4_rewrite_headers(ctx, tuple.nexthdr, inner_l3_off, true, icmpoff,
+	ret = snat_v4_rewrite_headers(ctx, tuple.nexthdr, inner_l3_off, true, inner_l4_off,
 				      tuple.saddr, (*state)->to_saddr, IPV4_DADDR_OFF,
 				      tuple.sport, (*state)->to_sport, port_off, 0);
 	/* Failing to update the inner L4 checksum is not fatal if the header
@@ -1022,7 +1022,7 @@ snat_v4_rev_nat_handle_icmp_error(struct __ctx_buff *ctx,
 	struct ipv4_ct_tuple tuple = {};
 	struct iphdr iphdr;
 	__u16 port_off;
-	__u32 icmpoff;
+	__u32 inner_l4_off;
 	__u8 type;
 	bool icmp_has_inner_l4_csum = true;
 	bool is_inner_l4_csum_enabled = true;
@@ -1047,7 +1047,7 @@ snat_v4_rev_nat_handle_icmp_error(struct __ctx_buff *ctx,
 	tuple.daddr = iphdr.saddr;
 	tuple.flags = NAT_DIR_INGRESS;
 
-	icmpoff = (__u32)(inner_l3_off + ipv4_hdrlen(&iphdr));
+	inner_l4_off = (__u32)(inner_l3_off + ipv4_hdrlen(&iphdr));
 	switch (tuple.nexthdr) {
 	case IPPROTO_TCP:
 	case IPPROTO_UDP:
@@ -1057,13 +1057,13 @@ snat_v4_rev_nat_handle_icmp_error(struct __ctx_buff *ctx,
 		/* No reasons to handle IP fragmentation for this case as it is
 		 * expected that DF isn't set for this particular context.
 		 */
-		if (l4_load_ports(ctx, icmpoff, &tuple.dport) < 0)
+		if (l4_load_ports(ctx, inner_l4_off, &tuple.dport) < 0)
 			return DROP_INVALID;
 
 		port_off = TCP_SPORT_OFF;
 		break;
 	case IPPROTO_ICMP:
-		if (ctx_load_bytes(ctx, icmpoff, &type, sizeof(type)) < 0)
+		if (ctx_load_bytes(ctx, inner_l4_off, &type, sizeof(type)) < 0)
 			return DROP_INVALID;
 
 		switch (type) {
@@ -1076,7 +1076,7 @@ snat_v4_rev_nat_handle_icmp_error(struct __ctx_buff *ctx,
 			return DROP_UNKNOWN_ICMP4_CODE;
 		}
 
-		if (ctx_load_bytes(ctx, icmpoff + port_off,
+		if (ctx_load_bytes(ctx, inner_l4_off + port_off,
 				   &tuple.dport, sizeof(tuple.dport)) < 0)
 			return DROP_INVALID;
 		break;
@@ -1097,7 +1097,7 @@ snat_v4_rev_nat_handle_icmp_error(struct __ctx_buff *ctx,
 	if (tuple.nexthdr == IPPROTO_UDP) {
 		__be16 l4_csum_be = 0;
 
-		if (ctx_load_bytes(ctx, icmpoff + offsetof(struct udphdr, check),
+		if (ctx_load_bytes(ctx, inner_l4_off + offsetof(struct udphdr, check),
 				   &l4_csum_be, sizeof(l4_csum_be)) < 0)
 			return DROP_INVALID;
 		if (l4_csum_be == 0)
@@ -1113,7 +1113,7 @@ snat_v4_rev_nat_handle_icmp_error(struct __ctx_buff *ctx,
 
 	/* The embedded packet was SNATed on egress. Reverse it again: */
 	ret = snat_v4_rewrite_headers(ctx, tuple.nexthdr, (int)inner_l3_off,
-				      true, icmpoff,
+				      true, inner_l4_off,
 				      tuple.daddr, (*state)->to_daddr, IPV4_SADDR_OFF,
 				      tuple.dport, (*state)->to_dport, port_off, 0);
 	/* Failing to update the inner L4 checksum is not fatal if the header
@@ -1811,7 +1811,7 @@ snat_v6_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 	struct ipv6_ct_tuple tuple = {};
 	struct ipv6hdr ip6;
 	__u16 port_off;
-	__u32 icmpoff;
+	__u32 inner_l4_off;
 	int hdrlen;
 	__u8 type;
 
@@ -1835,7 +1835,7 @@ snat_v6_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 	if (hdrlen < 0)
 		return hdrlen;
 
-	icmpoff = inner_l3_off + hdrlen;
+	inner_l4_off = inner_l3_off + hdrlen;
 
 	switch (tuple.nexthdr) {
 	case IPPROTO_TCP:
@@ -1846,13 +1846,13 @@ snat_v6_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 		/* No reasons to handle IP fragmentation for this case as it is
 		 * expected that DF isn't set for this particular context.
 		 */
-		if (l4_load_ports(ctx, icmpoff, &tuple.dport) < 0)
+		if (l4_load_ports(ctx, inner_l4_off, &tuple.dport) < 0)
 			return DROP_INVALID;
 
 		port_off = TCP_DPORT_OFF;
 		break;
 	case IPPROTO_ICMPV6:
-		if (icmp6_load_type(ctx, icmpoff, &type) < 0)
+		if (icmp6_load_type(ctx, inner_l4_off, &type) < 0)
 			return DROP_INVALID;
 
 		switch (type) {
@@ -1865,7 +1865,7 @@ snat_v6_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 			return DROP_UNKNOWN_ICMP6_CODE;
 		}
 
-		if (ctx_load_bytes(ctx, icmpoff + port_off,
+		if (ctx_load_bytes(ctx, inner_l4_off + port_off,
 				   &tuple.sport, sizeof(tuple.sport)) < 0)
 			return DROP_INVALID;
 		break;
@@ -1878,7 +1878,7 @@ snat_v6_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 		return NAT_PUNT_TO_STACK;
 
 	/* The embedded packet was RevSNATed on ingress. Reverse it again: */
-	return snat_v6_rewrite_headers(ctx, tuple.nexthdr, inner_l3_off, true, icmpoff,
+	return snat_v6_rewrite_headers(ctx, tuple.nexthdr, inner_l3_off, true, inner_l4_off,
 				       &tuple.saddr, &(*state)->to_saddr, IPV6_DADDR_OFF,
 				       tuple.sport, (*state)->to_sport, port_off);
 }
@@ -2029,7 +2029,7 @@ snat_v6_rev_nat_handle_icmp_pkt_toobig(struct __ctx_buff *ctx,
 	struct ipv6_ct_tuple tuple = {};
 	struct ipv6hdr iphdr;
 	__u16 port_off;
-	__u32 icmpoff;
+	__u32 inner_l4_off;
 	__u8 type;
 	int hdrlen;
 
@@ -2062,7 +2062,7 @@ snat_v6_rev_nat_handle_icmp_pkt_toobig(struct __ctx_buff *ctx,
 	if (hdrlen < 0)
 		return hdrlen;
 
-	icmpoff = inner_l3_off + hdrlen;
+	inner_l4_off = inner_l3_off + hdrlen;
 
 	switch (tuple.nexthdr) {
 	case IPPROTO_TCP:
@@ -2074,7 +2074,7 @@ snat_v6_rev_nat_handle_icmp_pkt_toobig(struct __ctx_buff *ctx,
 		 * as it is expected that DF isn't set for this particular
 		 * context.
 		 */
-		if (l4_load_ports(ctx, icmpoff, &tuple.dport) < 0)
+		if (l4_load_ports(ctx, inner_l4_off, &tuple.dport) < 0)
 			return DROP_INVALID;
 
 		port_off = TCP_SPORT_OFF;
@@ -2083,14 +2083,14 @@ snat_v6_rev_nat_handle_icmp_pkt_toobig(struct __ctx_buff *ctx,
 		/* No reasons to see a packet different than
 		 * ICMPV6_ECHO_REQUEST.
 		 */
-		if (icmp6_load_type(ctx, icmpoff, &type) < 0 ||
+		if (icmp6_load_type(ctx, inner_l4_off, &type) < 0 ||
 		    type != ICMPV6_ECHO_REQUEST)
 			return DROP_INVALID;
 
 		port_off = offsetof(struct icmp6hdr,
 				    icmp6_dataun.u_echo.identifier);
 
-		if (ctx_load_bytes(ctx, icmpoff + port_off,
+		if (ctx_load_bytes(ctx, inner_l4_off + port_off,
 				   &tuple.dport, sizeof(tuple.dport)) < 0)
 			return DROP_INVALID;
 		break;
@@ -2103,7 +2103,7 @@ snat_v6_rev_nat_handle_icmp_pkt_toobig(struct __ctx_buff *ctx,
 		return NAT_PUNT_TO_STACK;
 
 	/* The embedded packet was SNATed on egress. Reverse it again: */
-	return snat_v6_rewrite_headers(ctx, tuple.nexthdr, inner_l3_off, true, icmpoff,
+	return snat_v6_rewrite_headers(ctx, tuple.nexthdr, inner_l3_off, true, inner_l4_off,
 				       &tuple.daddr, &(*state)->to_daddr, IPV6_SADDR_OFF,
 				       tuple.dport, (*state)->to_dport, port_off);
 }

--- a/bpf/tests/bpf_nat_icmp.h
+++ b/bpf/tests/bpf_nat_icmp.h
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
 /* Copyright Authors of Cilium */
 
+#pragma once
+
 #include <bpf/ctx/skb.h>
 #include <bpf/api.h>
 #include "common.h"

--- a/bpf/tests/bpf_nat_icmp.h
+++ b/bpf/tests/bpf_nat_icmp.h
@@ -1,0 +1,148 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include <bpf/api.h>
+#include "common.h"
+#include "pktgen.h"
+
+#define ENABLE_IPV4
+#define ENABLE_NODEPORT
+#define ENABLE_MASQUERADE_IPV4		1
+
+#include "lib/bpf_host.h"
+
+#include <bpf/config/node.h>
+
+#define DEBUG
+
+#include <lib/dbg.h>
+#include <lib/eps.h>
+#include <lib/nat.h>
+#include <lib/time.h>
+
+#include "nodeport_defaults.h"
+#include "bpf_nat_tuples.h"
+#include "scapy.h"
+
+const __u8 icmp4_err_nodeport_revnat_full_tcp[] = {
+	SCAPY_BUF_BYTES(icmp4_err_nodeport_revnat_full_tcp)
+};
+const __u8 icmp4_err_nodeport_revnat_full_tcp_after[] = {
+	SCAPY_BUF_BYTES(icmp4_err_nodeport_revnat_full_tcp_after)
+};
+const __u8 icmp4_err_nodeport_revnat_min_tcp[] = {
+	SCAPY_BUF_BYTES(icmp4_err_nodeport_revnat_min_tcp)
+};
+const __u8 icmp4_err_nodeport_revnat_min_tcp_after[] = {
+	SCAPY_BUF_BYTES(icmp4_err_nodeport_revnat_min_tcp_after)
+};
+
+#define EXT_IP  v4_ext_one
+#define NODE_IP v4_node_one
+#define POD_IP  v4_pod_one
+
+static int snat_v4_insert_nodeport_nat(void)
+{
+	/* The revSNAT lookup key for the ICMP error path is built from the
+	 * inner IP+TCP headers: saddr/daddr are swapped relative to the inner
+	 * packet, and the inner sport/dport are loaded directly into
+	 * tuple.dport/sport via l4_load_ports.
+	 *
+	 * Inner packet: saddr=node_ip, daddr=ext_ip, sport=32768, dport=22330
+	 * Tuple key:    saddr=ext_ip,  daddr=node_ip, dport=32768, sport=22330
+	 *               flags=NAT_DIR_INGRESS
+	 */
+	struct ipv4_ct_tuple tuple = {
+		.daddr   = NODE_IP,
+		.saddr   = EXT_IP,
+		.dport   = bpf_htons(32768), /* NODEPORT_PORT_MIN_NAT */
+		.sport   = bpf_htons(22330), /* tcp_src_one */
+		.nexthdr = IPPROTO_TCP,
+		.flags   = NAT_DIR_INGRESS,
+	};
+	/* to_daddr: rewrite inner saddr (and outer daddr) to pod IP.
+	 * to_dport: restore inner sport to original pre-SNAT value.
+	 */
+	struct ipv4_nat_entry entry = {
+		.to_daddr = POD_IP,
+		.to_dport = bpf_htons(22330), /* tcp_src_one */
+	};
+
+	return map_update_elem(&cilium_snat_v4_external, &tuple, &entry, BPF_ANY);
+}
+
+/*
+ * Full inner TCP header + data payload variant.
+ */
+PKTGEN("tc", "snat_v4_tcp_pmtu")
+int snat_v4_pmtu_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+	scapy_push_data(&builder,
+			icmp4_err_nodeport_revnat_full_tcp,
+			sizeof(icmp4_err_nodeport_revnat_full_tcp));
+	pktgen__finish(&builder);
+	return TEST_PASS;
+}
+
+SETUP("tc", "snat_v4_tcp_pmtu")
+int snat_v4_pmtu_setup(struct __ctx_buff *ctx)
+{
+	if (snat_v4_insert_nodeport_nat() < 0)
+		return TEST_FAIL;
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "snat_v4_tcp_pmtu")
+int snat_v4_pmtu_check(const struct __ctx_buff *ctx)
+{
+	test_init();
+	ASSERT_CTX_BUF_OFF("snat_v4_tcp_pmtu", "Ether", ctx, sizeof(__u32),
+			   icmp4_err_nodeport_revnat_full_tcp_after,
+			   sizeof(icmp4_err_nodeport_revnat_full_tcp_after));
+	test_finish();
+
+	return 0;
+}
+
+/*
+ * Minimal inner TCP (8 bytes: sport + dport + seq) variant.
+ * Tests that revSNAT handles the RFC 792 minimum embedded header correctly.
+ */
+PKTGEN("tc", "snat_v4_tcp_pmtu_min_hdr")
+int snat_v4_pmtu_min_hdr_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+	scapy_push_data(&builder,
+			icmp4_err_nodeport_revnat_min_tcp,
+			sizeof(icmp4_err_nodeport_revnat_min_tcp));
+	pktgen__finish(&builder);
+	return TEST_PASS;
+}
+
+SETUP("tc", "snat_v4_tcp_pmtu_min_hdr")
+int snat_v4_pmtu_min_hdr_setup(struct __ctx_buff *ctx)
+{
+	if (snat_v4_insert_nodeport_nat() < 0)
+		return TEST_FAIL;
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "snat_v4_tcp_pmtu_min_hdr")
+int snat_v4_pmtu_min_hdr_check(const struct __ctx_buff *ctx)
+{
+	test_init();
+	ASSERT_CTX_BUF_OFF("snat_v4_tcp_pmtu_min_hdr", "Ether", ctx, sizeof(__u32),
+			   icmp4_err_nodeport_revnat_min_tcp_after,
+			   sizeof(icmp4_err_nodeport_revnat_min_tcp_after));
+	test_finish();
+
+	return 0;
+}

--- a/bpf/tests/bpf_nat_icmp6.h
+++ b/bpf/tests/bpf_nat_icmp6.h
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
 /* Copyright Authors of Cilium */
 
+#pragma once
+
 #include <bpf/ctx/skb.h>
 #include "common.h"
 #include "pktgen.h"
@@ -40,9 +42,9 @@
 
 #include "bpf_nat_tuples.h"
 
-#define NODE_ONE { .addr = v6_node_one_addr }
-#define EXT_IP { .addr = v6_ext_node_one_addr }
-#define POD_IP { .addr = v6_pod_one_addr }
+#define NODE_ONE6 { .addr = v6_node_one_addr }
+#define EXT_IP6 { .addr = v6_ext_node_one_addr }
+#define POD_IP6 { .addr = v6_pod_one_addr }
 
 /*
  * Input packet represents a device sending a PKT_TOO_BIG response ICMPv6
@@ -105,13 +107,13 @@ const __u8 icmp6_err_nodeport_revnat_full_udp_after[] = {
 int snat_v6_insert_ct_nat(__u8 proto)
 {
 	struct ipv6_nat_entry entry = {
-		.to_daddr = POD_IP,
+		.to_daddr = POD_IP6,
 	};
 	entry.to_sport = 0;
 	entry.to_dport = bpf_htons(20);
 	struct ipv6_ct_tuple tuple = {
-		.daddr   = NODE_ONE,
-		.saddr   = EXT_IP,
+		.daddr   = NODE_ONE6,
+		.saddr   = EXT_IP6,
 		.dport   = bpf_htons(30001), /* SNAT remapped port */
 		.sport   = bpf_htons(1234),
 		.nexthdr = proto,

--- a/bpf/tests/bpf_nat_icmp6.h
+++ b/bpf/tests/bpf_nat_icmp6.h
@@ -36,6 +36,8 @@
 #include <lib/nat.h>
 #include <lib/time.h>
 
+#include "scapy.h"
+
 #include "bpf_nat_tuples.h"
 
 #define NODE_ONE { .addr = v6_node_one_addr }
@@ -87,64 +89,18 @@
  *
  * Ref: https://datatracker.ietf.org/doc/html/rfc4443#section-3.2
  */
-__always_inline int gen_pmtu_pkt(struct pktgen *builder, int l4_type)
-{
-	struct ipv6hdr *inner_l3 = NULL;
-	struct icmp6hdr *l4 = NULL;
-	struct tcphdr *inner_l4 = NULL;
-	struct udphdr *inner_l4_udp = NULL; /* compiler complains if this isn't init to null? */
-	struct sctphdr *inner_l4_sctp = NULL;
-	void *data = NULL;
-
-	l4 = pktgen__push_ipv6_icmp6_packet(builder,
-					    (__u8 *)mac_one,
-					    (__u8 *)mac_two,
-					    (__u8 *)v6_ext_node_one,
-					    (__u8 *)v6_node_one,
-					    ICMPV6_PKT_TOOBIG);
-	if (!l4)
-		return TEST_FAIL;
-
-	inner_l3 = pktgen__push_default_ipv6hdr(builder);
-	if (!inner_l3)
-		return TEST_FAIL;
-
-	inner_l3->nexthdr = (__u8)l4_type;
-	ipv6hdr__set_addrs(inner_l3, (__u8 *)v6_node_one, (__u8 *)v6_ext_node_one);
-
-	switch (l4_type) {
-	case IPPROTO_TCP:
-		inner_l4 = pktgen__push_default_tcphdr(builder);
-		if (!inner_l4)
-			return TEST_FAIL;
-		/* original source */
-		inner_l4->dest = 1234;
-		inner_l4->source = 30001;
-		break;
-	case IPPROTO_UDP:
-		inner_l4_udp = pktgen__push_default_udphdr(builder);
-		if (!inner_l4_udp)
-			return TEST_FAIL;
-		inner_l4_udp->dest = 1234;
-		inner_l4_udp->source = 30001;
-		break;
-	case IPPROTO_SCTP:
-		inner_l4_sctp = pktgen__push_default_sctphdr(builder);
-		if (!inner_l4_udp)
-			return TEST_FAIL;
-		inner_l4_sctp->dest = 1234;
-		inner_l4_sctp->source = 30001;
-		break;
-	default:
-		return TEST_FAIL;
-	}
-
-	data = pktgen__push_data(builder, default_data, sizeof(default_data));
-	if (!data)
-		return TEST_FAIL;
-
-	return TEST_PASS;
-}
+const __u8 icmp6_err_nodeport_revnat_full_tcp[] = {
+	SCAPY_BUF_BYTES(icmp6_err_nodeport_revnat_full_tcp)
+};
+const __u8 icmp6_err_nodeport_revnat_full_tcp_after[] = {
+	SCAPY_BUF_BYTES(icmp6_err_nodeport_revnat_full_tcp_after)
+};
+const __u8 icmp6_err_nodeport_revnat_full_udp[] = {
+	SCAPY_BUF_BYTES(icmp6_err_nodeport_revnat_full_udp)
+};
+const __u8 icmp6_err_nodeport_revnat_full_udp_after[] = {
+	SCAPY_BUF_BYTES(icmp6_err_nodeport_revnat_full_udp_after)
+};
 
 int snat_v6_insert_ct_nat(__u8 proto)
 {
@@ -152,14 +108,14 @@ int snat_v6_insert_ct_nat(__u8 proto)
 		.to_daddr = POD_IP,
 	};
 	entry.to_sport = 0;
-	entry.to_dport = 20;
+	entry.to_dport = bpf_htons(20);
 	struct ipv6_ct_tuple tuple = {
 		.daddr   = NODE_ONE,
 		.saddr   = EXT_IP,
-		.dport   = 30001, /* SNAT remapped port */
-		.sport   = 1234,
+		.dport   = bpf_htons(30001), /* SNAT remapped port */
+		.sport   = bpf_htons(1234),
 		.nexthdr = proto,
-		.flags = TUPLE_F_IN,
+		.flags   = TUPLE_F_IN,
 	};
 	return map_update_elem(&cilium_snat_v6_external, &tuple, &entry, BPF_ANY);
 }
@@ -200,9 +156,9 @@ int do_icmp6_pkt_too_big_check(const struct __ctx_buff *ctx)
 	l4 = (void *)(data + sizeof(__u32) +
 		sizeof(struct ethhdr) + sizeof(struct ipv6hdr) +
 		sizeof(struct icmp6hdr) + sizeof(struct ipv6hdr));
-	if (*((__u16 *)l4) != 20)
+	if (*((__u16 *)l4) != bpf_htons(20))
 		return TEST_FAIL;
-	if (*((__u16 *)(l4 + sizeof(__u16))) != 1234)
+	if (*((__u16 *)(l4 + sizeof(__u16))) != bpf_htons(1234))
 		return TEST_FAIL;
 	return 0;
 }
@@ -213,7 +169,9 @@ int snat_v6_pmtu_pktgen(struct __ctx_buff *ctx)
 	struct pktgen builder;
 
 	pktgen__init(&builder, ctx);
-	gen_pmtu_pkt(&builder, IPPROTO_TCP);
+	scapy_push_data(&builder,
+			icmp6_err_nodeport_revnat_full_tcp,
+			sizeof(icmp6_err_nodeport_revnat_full_tcp));
 	pktgen__finish(&builder);
 	return TEST_PASS;
 }
@@ -234,7 +192,9 @@ CHECK("tc", "snat_v6_tcp_pmtu")
 int snat_v6_pmtu_check(const struct __ctx_buff *ctx)
 {
 	test_init();
-	assert(do_icmp6_pkt_too_big_check(ctx) == 0);
+	ASSERT_CTX_BUF_OFF("snat_v6_tcp_pmtu", "Ether", ctx, sizeof(__u32),
+			   icmp6_err_nodeport_revnat_full_tcp_after,
+			   sizeof(icmp6_err_nodeport_revnat_full_tcp_after));
 	test_finish();
 
 	return 0;
@@ -246,7 +206,9 @@ int snat_v6_pmtu_udp_pktgen(struct __ctx_buff *ctx)
 	struct pktgen builder;
 
 	pktgen__init(&builder, ctx);
-	gen_pmtu_pkt(&builder, IPPROTO_UDP);
+	scapy_push_data(&builder,
+			icmp6_err_nodeport_revnat_full_udp,
+			sizeof(icmp6_err_nodeport_revnat_full_udp));
 	pktgen__finish(&builder);
 	return TEST_PASS;
 }
@@ -267,7 +229,9 @@ CHECK("tc", "snat_v6_udp_pmtu")
 int snat_v6_pmtu_udp_check(const struct __ctx_buff *ctx)
 {
 	test_init();
-	assert(do_icmp6_pkt_too_big_check(ctx) == 0);
+	ASSERT_CTX_BUF_OFF("snat_v6_udp_pmtu", "Ether", ctx, sizeof(__u32),
+			   icmp6_err_nodeport_revnat_full_udp_after,
+			   sizeof(icmp6_err_nodeport_revnat_full_udp_after));
 	test_finish();
 
 	return 0;

--- a/bpf/tests/lib/bpf_host.h
+++ b/bpf/tests/lib/bpf_host.h
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
 /* Copyright Authors of Cilium */
 
+#pragma once
+
 #include <bpf_host.c>
 
 #define FROM_NETDEV		0

--- a/bpf/tests/scapy/icmp_err_revnat_pkt_defs.py
+++ b/bpf/tests/scapy/icmp_err_revnat_pkt_defs.py
@@ -15,7 +15,6 @@ icmp4_err_frag_needed_for_revnat = (
     TCP(sport=32768, dport=80)  # NODEPORT_PORT_MIN_NAT (SNAT'd port)
 )
 
-
 # After rev-NAT: pod_two -> node_one, with original port restored
 icmp4_err_frag_needed_after_revnat = (
     Ether(src=mac_one, dst=mac_two) /
@@ -23,4 +22,44 @@ icmp4_err_frag_needed_after_revnat = (
     ICMP(type=3, code=4, nexthopmtu=1500) /
     IP(src=v4_node_one, dst=v4_pod_two, flags="DF") /
     TCP(sport=3030, dport=80)  # original port restored
+)
+
+# Full inner TCP header + complete data payload
+icmp4_err_nodeport_revnat_full_tcp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_node_one) /
+    ICMP(type=3, code=4, nexthopmtu=1500) /
+    IP(src=v4_node_one, dst=v4_ext_one, flags="DF") /
+    TCP(sport=32768, dport=tcp_src_one, seq=tcp_default_seq) /
+    Raw(default_data)
+)
+
+# After revSNAT: outer daddr -> pod_ip, inner saddr -> pod_ip, sport restored
+icmp4_err_nodeport_revnat_full_tcp_after = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_pod_one) /
+    ICMP(type=3, code=4, nexthopmtu=1500) /
+    IP(src=v4_pod_one, dst=v4_ext_one, flags="DF") /
+    TCP(sport=tcp_src_one, dport=tcp_src_one, seq=tcp_default_seq) /
+    Raw(default_data)
+)
+
+# Inner TCP truncated to first 8 bytes: sport + dport + seq (RFC 792 minimum)
+_nodeport_tcp_hdr_min = bytes(TCP(sport=32768, dport=tcp_src_one, seq=tcp_default_seq))[:8]
+icmp4_err_nodeport_revnat_min_tcp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_node_one) /
+    ICMP(type=3, code=4, nexthopmtu=1500) /
+    IP(src=v4_node_one, dst=v4_ext_one, flags="DF", proto=6) /
+    Raw(_nodeport_tcp_hdr_min)
+)
+
+# After revSNAT (min TCP): outer daddr -> pod_ip, inner saddr -> pod_ip, sport restored
+_nodeport_tcp_hdr_min_after = bytes(TCP(sport=tcp_src_one, dport=tcp_src_one, seq=tcp_default_seq))[:8]
+icmp4_err_nodeport_revnat_min_tcp_after = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_pod_one) /
+    ICMP(type=3, code=4, nexthopmtu=1500) /
+    IP(src=v4_pod_one, dst=v4_ext_one, flags="DF", proto=6) /
+    Raw(_nodeport_tcp_hdr_min_after)
 )

--- a/bpf/tests/scapy/icmp_err_revnat_pkt_defs.py
+++ b/bpf/tests/scapy/icmp_err_revnat_pkt_defs.py
@@ -63,3 +63,40 @@ icmp4_err_nodeport_revnat_min_tcp_after = (
     IP(src=v4_pod_one, dst=v4_ext_one, flags="DF", proto=6) /
     Raw(_nodeport_tcp_hdr_min_after)
 )
+
+def _icmp6_nodeport_revnat_pkt(inner_l4):
+    """Outer ICMPv6 PKT_TOO_BIG wrapper (pre-revSNAT): ext -> node, inner node -> ext."""
+    return (
+        Ether(src=mac_one, dst=mac_two) /
+        IPv6(src=v6_ext_node_one, dst=v6_node_one) /
+        ICMPv6PacketTooBig(mtu=1500) /
+        IPv6(src=v6_node_one, dst=v6_ext_node_one) /
+        inner_l4
+    )
+
+def _icmp6_nodeport_revnat_after_pkt(inner_l4):
+    """Outer ICMPv6 PKT_TOO_BIG wrapper (post-revSNAT): ext -> pod, inner pod -> ext."""
+    return (
+        Ether(src=mac_one, dst=mac_two) /
+        IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
+        ICMPv6PacketTooBig(mtu=1500) /
+        IPv6(src=v6_pod_one, dst=v6_ext_node_one) /
+        inner_l4
+    )
+
+icmp6_err_nodeport_revnat_full_tcp = _icmp6_nodeport_revnat_pkt(
+    TCP(sport=30001, dport=1234, seq=tcp_default_seq) / Raw(default_data)
+)
+
+icmp6_err_nodeport_revnat_full_tcp_after = _icmp6_nodeport_revnat_after_pkt(
+    TCP(sport=20, dport=1234, seq=tcp_default_seq) / Raw(default_data)
+)
+
+icmp6_err_nodeport_revnat_full_udp = _icmp6_nodeport_revnat_pkt(
+    TCP(sport=30001, dport=1234) / Raw(default_data)
+)
+
+icmp6_err_nodeport_revnat_full_udp_after = _icmp6_nodeport_revnat_after_pkt(
+    TCP(sport=20, dport=1234) / Raw(default_data)
+)
+

--- a/bpf/tests/tc_nodeport_icmp4_snat.c
+++ b/bpf/tests/tc_nodeport_icmp4_snat.c
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
-/* Copyright Authors of Cilium */
-
-#undef TUNNEL_MODE
-
-#include "tc_nodeport_icmp4_snat.h"
-

--- a/bpf/tests/tc_nodeport_icmp4_snat_hostfw.c
+++ b/bpf/tests/tc_nodeport_icmp4_snat_hostfw.c
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
-/* Copyright Authors of Cilium */
-
-#define ENABLE_HOST_FIREWALL
-
-#include "tc_nodeport_icmp4_snat.h"

--- a/bpf/tests/tc_nodeport_icmp4_snat_tunnel.c
+++ b/bpf/tests/tc_nodeport_icmp4_snat_tunnel.c
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
-/* Copyright Authors of Cilium */
-
-#define ENABLE_TUNNEL
-
-#include "tc_nodeport_icmp4_snat.h"

--- a/bpf/tests/tc_nodeport_icmp6_snat.c
+++ b/bpf/tests/tc_nodeport_icmp6_snat.c
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
-/* Copyright Authors of Cilium */
-
-#undef TUNNEL_MODE
-
-#include "bpf_nat_icmp6.h"

--- a/bpf/tests/tc_nodeport_icmp6_snat_hostfw.c
+++ b/bpf/tests/tc_nodeport_icmp6_snat_hostfw.c
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
-/* Copyright Authors of Cilium */
-
-#define ENABLE_HOST_FIREWALL
-
-#include "bpf_nat_icmp6.h"

--- a/bpf/tests/tc_nodeport_icmp6_snat_tunnel.c
+++ b/bpf/tests/tc_nodeport_icmp6_snat_tunnel.c
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
-/* Copyright Authors of Cilium */
-
-#define ENABLE_DSR
-#define ENCAP_IFINDEX 1
-
-#include "bpf_nat_icmp6.h"

--- a/bpf/tests/tc_nodeport_icmp_snat.c
+++ b/bpf/tests/tc_nodeport_icmp_snat.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
 /* Copyright Authors of Cilium */
 
-#define ENABLE_HOST_FIREWALL
+#undef TUNNEL_MODE
 
 #define ENABLE_IPV4
 #define ENABLE_IPV6

--- a/bpf/tests/tc_nodeport_icmp_snat_hostfw.c
+++ b/bpf/tests/tc_nodeport_icmp_snat_hostfw.c
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define ENABLE_HOST_FIREWALL
+
+#include "bpf_nat_icmp6.h"

--- a/bpf/tests/tc_nodeport_icmp_snat_tunnel.c
+++ b/bpf/tests/tc_nodeport_icmp_snat_tunnel.c
@@ -2,6 +2,14 @@
 /* Copyright Authors of Cilium */
 
 #define ENABLE_DSR
-#define ENCAP_IFINDEX 1
+#define ENCAP_IFINDEX		1
+
+#define ENABLE_IPV4
+#define ENABLE_IPV6
+#define ENABLE_SCTP
+#define ENABLE_NODEPORT
+#define ENABLE_MASQUERADE_IPV4		1
+#define ENABLE_MASQUERADE_IPV6		1
 
 #include "bpf_nat_icmp.h"
+#include "bpf_nat_icmp6.h"

--- a/bpf/tests/tc_nodeport_icmp_snat_tunnel.c
+++ b/bpf/tests/tc_nodeport_icmp_snat_tunnel.c
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define ENABLE_DSR
+#define ENCAP_IFINDEX 1
+
+#include "bpf_nat_icmp.h"


### PR DESCRIPTION
This PR seeks to tackle several improvements related ICMP{4,6} PTB/FN message handling:

* Introduce more comprehensive testing of icmp testing of the revSNAT scenario, similar to the icmp6 approach.
* Cleanup: in nat icmp handling code we often use the var name icmpoff to denote a header offset pointing the data _after_ the first icmp{4,6} header. This is confused as in most cases this likely will not be an icmp offset but rather an offset to some inner l4 header like TCP. This cleans up the code a bit by renaming it to inner_l4_off to be more in line with the convention of using inner_l3_off to denote the inner IP header offset (with encapsulated ICMP being more of the edge case).
* bpf_nat_icmp6: refactor away from manual packet crafting and instead use scapy generated data. Notably, this automatically adds coverage for checksum adjustments being correct following the netdev code path.

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here or remove this release-note section from your PR description. Do NOT put an "empty" release note here -->
```

**AI Disclosure:** I used Claude code to help generate test data, automate researching bpf code, perform some refactors (i.e. helping to solve import issues) and solve test issues.  Any AI generated code was carefully introduced step-by-step and was personally read/adjusted by me. 