### PR TITLE
loadbalancer honor initializer barrier before pruning BPF entries

### DIFF
--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -112,6 +112,7 @@ type BPFOps struct {
 	log       rateLimitingLogger
 	db        *statedb.DB
 	nodeAddrs statedb.Table[tables.NodeAddress]
+	frontends statedb.Table[*loadbalancer.Frontend]
 
 	cfg           loadbalancer.Config
 	extCfg        loadbalancer.ExternalConfig
@@ -186,6 +187,7 @@ type bpfOpsParams struct {
 	Maglev         *maglev.Maglev
 	DB             *statedb.DB
 	NodeAddresses  statedb.Table[tables.NodeAddress]
+	Frontends      statedb.Table[*loadbalancer.Frontend]
 }
 
 const (
@@ -203,6 +205,7 @@ func newBPFOps(p bpfOpsParams) *BPFOps {
 		LBMaps:    p.LBMaps,
 		db:        p.DB,
 		nodeAddrs: p.NodeAddresses,
+		frontends: p.Frontends,
 	}
 	ops.setLastUpdatedAt()
 
@@ -681,10 +684,26 @@ func (ops *BPFOps) pruneMaglev() error {
 	return errors.Join(errs...)
 }
 
+var errInitializersPending = errors.New("load-balancing tables not fully initialized")
+
+func (ops *BPFOps) initializersPending(txn statedb.ReadTxn) bool {
+	if ops.frontends == nil {
+		return false
+	}
+	initialized, _ := ops.frontends.Initialized(txn)
+	return !initialized
+}
+
 // Prune implements reconciler.Operations.
-func (ops *BPFOps) Prune(_ context.Context, _ statedb.ReadTxn, _ iter.Seq2[*loadbalancer.Frontend, statedb.Revision]) error {
+func (ops *BPFOps) Prune(_ context.Context, txn statedb.ReadTxn, _ iter.Seq2[*loadbalancer.Frontend, statedb.Revision]) error {
 	ops.mu.Lock()
 	defer ops.mu.Unlock()
+	if ops.initializersPending(txn) {
+		ops.log.Warn("Skipping prune: load-balancing initializers are still pending",
+			"pending-initializers", ops.frontends.PendingInitializers(txn),
+		)
+		return nil
+	}
 	defer func() { ops.pruneCount.Add(1) }()
 	ops.log.Debug("Pruning")
 	return errors.Join(
@@ -705,6 +724,19 @@ func (ops *BPFOps) Update(_ context.Context, txn statedb.ReadTxn, _ statedb.Revi
 
 	if (!ops.extCfg.EnableIPv6 && fe.Address.IsIPv6()) || (!ops.extCfg.EnableIPv4 && !fe.Address.IsIPv6()) {
 		return nil
+	}
+
+	hasBackends := false
+	for range fe.Backends {
+		hasBackends = true
+		break
+	}
+	if !hasBackends && ops.initializersPending(txn) {
+		ops.log.Warn("Deferring update: frontend has no backends and initializers are still pending",
+			logfields.Address, fe.Address,
+			"pending-initializers", ops.frontends.PendingInitializers(txn),
+		)
+		return errInitializersPending
 	}
 
 	isLocalAddr := func(addr netip.Addr) bool {

--- a/pkg/loadbalancer/reconciler/bpf_reconciler_initializers_test.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler_initializers_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/statedb"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/loadbalancer/maps"
+	"github.com/cilium/cilium/pkg/maglev"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+func Test_PendingInitializers_DefersUpdateAndPrune(t *testing.T) {
+	lc := hivetest.Lifecycle(t)
+	log := hivetest.Logger(t)
+
+	db := statedb.New()
+
+	nodeAddrs, err := tables.NewNodeAddressTable(db)
+	require.NoError(t, err)
+
+	fes, err := loadbalancer.NewFrontendsTable(loadbalancer.DefaultConfig, db)
+	require.NoError(t, err)
+
+	wtxn := db.WriteTxn(fes)
+	completeInit := fes.RegisterInitializer(wtxn, "clustermesh")
+	wtxn.Commit()
+
+	maglevCfg, err := maglev.UserConfig{
+		TableSize: 1021,
+		HashSeed:  maglev.DefaultHashSeed,
+	}.ToConfig()
+	require.NoError(t, err)
+	mglv := maglev.New(maglevCfg, lc)
+
+	cfg, _ := loadbalancer.NewConfig(log, loadbalancer.DefaultUserConfig, &option.DaemonConfig{})
+
+	ops := newBPFOps(bpfOpsParams{
+		Lifecycle: lc,
+		Log:       log,
+		Config:    cfg,
+		ExternalConfig: loadbalancer.ExternalConfig{
+			ZoneMapper: &option.DaemonConfig{},
+			EnableIPv4: true,
+			EnableIPv6: true,
+		},
+		LBMaps:        maps.NewFakeLBMaps(),
+		Maglev:        mglv,
+		DB:            db,
+		NodeAddresses: nodeAddrs,
+		Frontends:     fes,
+	})
+
+	fe := &loadbalancer.Frontend{
+		FrontendParams: loadbalancer.FrontendParams{
+			Address: loadbalancer.NewL3n4Addr(
+				loadbalancer.TCP,
+				types.MustParseAddrCluster("10.0.0.1"),
+				80,
+				loadbalancer.ScopeExternal,
+			),
+			Type: loadbalancer.SVCTypeClusterIP,
+		},
+		Backends: func(yield func(*loadbalancer.Backend, statedb.Revision) bool) {},
+	}
+
+	rtxn := db.ReadTxn()
+
+	err = ops.Update(context.Background(), rtxn, 0, fe)
+	require.ErrorIs(t, err, errInitializersPending)
+
+	prevPruneCount := ops.pruneCount.Load()
+
+	err = ops.Prune(context.Background(), rtxn, nil)
+	require.NoError(t, err)
+	require.Equal(t, prevPruneCount, ops.pruneCount.Load(),
+		"pruneCount must not advance while initializers are pending")
+
+	wtxn = db.WriteTxn(fes)
+	completeInit(wtxn)
+	wtxn.Commit()
+
+	rtxn = db.ReadTxn()
+	err = ops.Prune(context.Background(), rtxn, nil)
+	require.NoError(t, err)
+	require.Equal(t, prevPruneCount+1, ops.pruneCount.Load(),
+		"pruneCount must advance once initializers are complete")
+}
+
+func Test_InitializersPending_NilFrontendsTable(t *testing.T) {
+	ops := &BPFOps{}
+	require.False(t, ops.initializersPending(nil))
+}

--- a/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
@@ -1417,6 +1417,7 @@ func TestBPFOps(t *testing.T) {
 					Maglev:         maglev,
 					DB:             db,
 					NodeAddresses:  nodeAddrs,
+					Frontends:      nil,
 				}
 
 				ops := newBPFOps(p)


### PR DESCRIPTION
This is a fix for an unrecoverable failure mode in kvstore mode that was reported in #45981. When the ClusterMesh initializer is blocked on an unreachable etcd and the one minute startup grace period expires, the reconciler can scale services like CoreDNS down to zero backends based on a partial view of desired state, after which the agent cannot recover because pinned BPF maps preserve the bad state across restarts. The change honors the contract documented on Writer.RegisterInitializer by deferring prune passes and zero backend updates until initializers have actually completed. A unit test covers the deferral and the resumption once the initializer is marked done.