### PR TITLE
fix(deps): backport gopacket geneve options reset

### DIFF
--- a/vendor/github.com/gopacket/gopacket/layers/geneve.go
+++ b/vendor/github.com/gopacket/gopacket/layers/geneve.go
@@ -86,6 +86,7 @@ func (gn *Geneve) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error
 
 	gn.Version = data[0] >> 7
 	gn.OptionsLength = (data[0] & 0x3f) * 4
+	gn.Options = gn.Options[:0]
 
 	gn.OAMPacket = data[1]&0x80 > 0
 	gn.CriticalOption = data[1]&0x40 > 0


### PR DESCRIPTION
This PR fixes a cilium-agent memory leak bug seen in the following pprof:

```
File: cilium-agent
Build ID: 6d9373753ac64d0d93fe9b4fe4b1d7feb02372ca
Type: inuse_space
Time: 2026-05-16 16:16:50 CEST
Showing nodes accounting for 2984.65MB, 94.29% of 3165.53MB total
Dropped 742 nodes (cum <= 15.83MB)
      flat  flat%   sum%        cum   cum%
 2056.06MB 64.95% 64.95%  2056.06MB 64.95%  github.com/gopacket/gopacket/layers.decodeGeneveOption
  481.98MB 15.23% 80.18%  2538.03MB 80.18%  github.com/gopacket/gopacket/layers.(*Geneve).DecodeFromBytes
  ```

After implementing the fix, I noticed that the upstream gopacket already has the fix in:

https://github.com/gopacket/gopacket/pull/146

However, there is no gopacket release published yet that includes this fix, so this PR backports it into cilium.
