### PR TITLE
Fix typo: StringID -> String in doc comment of Identity.String function

### DIFF
--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -106,7 +106,7 @@ func (id *Identity) StringID() string {
 	return id.ID.StringID()
 }
 
-// StringID returns the identity identifier as string
+// String returns the identity identifier as string
 func (id *Identity) String() string {
 	return id.ID.StringID()
 }


### PR DESCRIPTION
Fixed a copy paste typo in the String functions doc comment. While reading through the source code I stumbled upon a small typo. Since I wanted to start to contribute anyway why not begin with a very simple change. 
I did not use any LLM in the process of creating this PR.
