### PR TITLE
ciliumenvoyconfig: log transitions in NodeSelector and service-lookup paths

### DIFF
--- a/pkg/ciliumenvoyconfig/controller.go
+++ b/pkg/ciliumenvoyconfig/controller.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"iter"
+	"log/slog"
 	"maps"
 	"slices"
 	"strconv"
@@ -27,6 +28,7 @@ import (
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/loadbalancer/writer"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/time"
@@ -35,6 +37,7 @@ import (
 type cecControllerParams struct {
 	cell.In
 
+	Log            *slog.Logger
 	DB             *statedb.DB
 	JobGroup       job.Group
 	ExpConfig      loadbalancer.Config
@@ -101,9 +104,11 @@ func getProxyRedirect(cec *CEC, svcl *ciliumv2.ServiceListener) *loadbalancer.Pr
 func (c *cecController) processLoop(ctx context.Context, health cell.Health) error {
 	var closedWatches []<-chan struct{}
 	backendProcessor := backendProcessor{
-		watchSets:      map[loadbalancer.ServiceName]*statedb.WatchSet{},
-		envoyResources: c.EnvoyResources,
-		writer:         c.Writer,
+		log:              c.Log,
+		watchSets:        map[loadbalancer.ServiceName]*statedb.WatchSet{},
+		prevServiceFound: map[loadbalancer.ServiceName]bool{},
+		envoyResources:   c.EnvoyResources,
+		writer:           c.Writer,
 	}
 	cecProcessor := cecProcessor{
 		watchSets:      map[types.NamespacedName]*statedb.WatchSet{},
@@ -318,15 +323,22 @@ func (c *cecProcessor) removeClusterReference(wtxn statedb.WriteTxn, cecName CEC
 // backedProcessor fills in the backends into the EnvoyResources with Origin=backendsync that were created by [cecProcessor].
 // These will be recomputed if any of the inputs change.
 type backendProcessor struct {
+	log *slog.Logger
 	// watchSets per service name. We hold onto the watches returned by queries made when computing the backends to sync
 	// per service name so we know when it needs to be recomputed.
-	watchSets      map[loadbalancer.ServiceName]*statedb.WatchSet
-	envoyResources statedb.RWTable[*EnvoyResource]
-	writer         *writer.Writer
+	watchSets        map[loadbalancer.ServiceName]*statedb.WatchSet
+	prevServiceFound map[loadbalancer.ServiceName]bool
+	envoyResources   statedb.RWTable[*EnvoyResource]
+	writer           *writer.Writer
 }
 
 func (bs *backendProcessor) process(wtxn statedb.WriteTxn, closedWatches []<-chan struct{}, allWatches *statedb.WatchSet) {
+	// Track service names observed this iteration so prevServiceFound entries can be reclaimed
+	// when the underlying envoyResource is deleted from outside this function (e.g. by
+	// cecProcessor.removeClusterReference when the last referencing CEC goes away).
+	seen := sets.New[loadbalancer.ServiceName]()
 	for res := range bs.envoyResources.List(wtxn, EnvoyResourceByOrigin(EnvoyResourceOriginBackendSync)) {
+		seen.Insert(res.ClusterServiceName())
 		// Check if any of the inputs have changed. If not we can skip processing it.
 		ws, found := bs.watchSets[res.ClusterServiceName()]
 		if found {
@@ -358,7 +370,14 @@ func (bs *backendProcessor) process(wtxn statedb.WriteTxn, closedWatches []<-cha
 		// Look up the referenced service for the port name to port number mappings.
 		svc, _, watchSvc, found := bs.writer.Services().GetWatch(wtxn, loadbalancer.ServiceByName(res.ClusterServiceName()))
 		ws.Add(watchSvc)
+		prevFound, hadPrev := bs.prevServiceFound[res.ClusterServiceName()]
 		if found {
+			if !hadPrev || !prevFound {
+				bs.log.Info("Service referenced by CiliumEnvoyConfig is present; syncing backends to Envoy",
+					logfields.ServiceName, res.ClusterServiceName(),
+				)
+			}
+			bs.prevServiceFound[res.ClusterServiceName()] = true
 			// Look up associated backends and update the load assignments.
 			bes, watchBes := bs.writer.BackendsForService(wtxn, svc.Name)
 			ws.Add(watchBes)
@@ -368,6 +387,12 @@ func (bs *backendProcessor) process(wtxn statedb.WriteTxn, closedWatches []<-cha
 				svc.PortNames,
 				bs.writer.SelectBackends(wtxn, bes, svc, nil))
 		} else {
+			if !hadPrev || prevFound {
+				bs.log.Info("Service referenced by CiliumEnvoyConfig is not present in the local service table; Envoy will have no backends for it until it appears",
+					logfields.ServiceName, res.ClusterServiceName(),
+				)
+			}
+			bs.prevServiceFound[res.ClusterServiceName()] = false
 			// No service found (yet) and thus there are no endpoints.
 			newEndpoints = nil
 		}
@@ -390,6 +415,13 @@ func (bs *backendProcessor) process(wtxn statedb.WriteTxn, closedWatches []<-cha
 		}
 
 		allWatches.Merge(ws)
+	}
+
+	// Reclaim prevServiceFound entries whose envoyResource has been deleted from outside this function.
+	for name := range bs.prevServiceFound {
+		if !seen.Has(name) {
+			delete(bs.prevServiceFound, name)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

The CEC controller in `pkg/ciliumenvoyconfig/controller.go` has two silent skip paths that make it impossible to diagnose the symptom "Envoy listener is loaded but cilium-agent never programmed the eBPF redirect" from `cilium-agent` logs alone. This PR adds Info-level logs on state transitions only steady-state operation is unchanged, and reprocessing-driven loops don't produce spam.

### What was silent

1. **NodeSelector filtering**  at [controller.go](https://github.com/cilium/cilium/blob/main/pkg/ciliumenvoyconfig/controller.go#L183), CECs with `!SelectsLocalNode` were dropped with no log. A user whose NodeSelector didn't match the agent's node labels would see zero evidence in agent logs that the CEC had even been observed locally.
2. **Referenced service missing** in `backendProcessor.process()`, when the service named in a CEC's `services[]`/`backendServices[]` wasn't in the local Service table, `newEndpoints` was silently set to `nil`. Envoy would have the listener configured but no backends, again with no log.

### What changed

Both paths now log at Info on transitions (first observation, or a flip between selected and not-selected, resp. present missing). Two small tracker maps (`prevSelectsLocalNode` on `cecProcessor`, `prevServiceFound` on `backendProcessor`) gate the logs.

The tracker maps are reclaimed when the CEC / backendsync resource is deleted. For CECs that are deleted without ever selecting the local node, they don't go through the orphan-cleanup path because they never registered any envoy resources. A separate `seen` set after the main loop reclaims their `prevSelectsLocalNode` entry.

### What is not changed

A third candidate silent path is `getProxyRedirect` returning `nil` when an explicitly-named listener (`svcl.Listener != \"\"`) can't be resolved in `cec.Listeners`. That presents as "Envoy listener missing" rather than the "listener loaded, no eBPF redirect" pattern this PR targets, and adding a transition-tracked log there needs a slightly different key shape (per-CEC, per-svc). Left for a follow-up.

### Motivation

A user [reported (#45871)](https://github.com/cilium/cilium/issues/45871) the exact "Envoy listeners loaded, 0 redirects active, cilium-agent logs empty" symptom in a complex stack (kpr=true + external-envoy + Gateway API + WireGuard nodeEncryption on EKS). Without these logs there is no way to tell from the agent side whether the CEC was even seen, filtered by NodeSelector, or processed but waiting on a service. This PR doesn't claim to fix that bug, root cause is undetermined but it makes the next report of this shape diagnosable from default-level logs.

## Test plan

- [x] `go build ./pkg/ciliumenvoyconfig/...`
- [x] `go test ./pkg/ciliumenvoyconfig/... -count=1`
- [x] `go vet ./pkg/ciliumenvoyconfig/...`
- [x] Wider build sanity: `go build ./daemon/... ./operator/... ./pkg/envoy/... ./pkg/proxy/...`
- [ ] CI

Related: #45871