### PR TITLE
[v1.19] chore(deps): update lvh-images for conformance-runtime

### DIFF
--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -201,7 +201,7 @@ jobs:
 
           - focus: "privileged"
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            lvhImage: "6.18-20260310.122539"
+            lvhImage: "6.18-20260504.013701"
 
     timeout-minutes: 50
     steps:

--- a/pkg/datapath/linux/route/route_linux_test.go
+++ b/pkg/datapath/linux/route/route_linux_test.go
@@ -61,7 +61,7 @@ func TestPrivilegedReplaceNexthopRoute(t *testing.T) {
 	testReplaceNexthopRoute(t, link, routerNet)
 }
 
-func testReplaceRoute(t *testing.T, prefixStr, nexthopStr string, lookupTest bool) {
+func testReplaceRoute(t *testing.T, device, prefixStr, nexthopStr string, lookupTest bool) {
 	_, prefix, err := net.ParseCIDR(prefixStr)
 	require.NoError(t, err)
 	require.NotNil(t, prefix)
@@ -70,7 +70,7 @@ func testReplaceRoute(t *testing.T, prefixStr, nexthopStr string, lookupTest boo
 	require.NotNil(t, nexthop)
 
 	rt := Route{
-		Device:  "lo",
+		Device:  device,
 		Prefix:  *prefix,
 		Nexthop: &nexthop,
 	}
@@ -81,7 +81,7 @@ func testReplaceRoute(t *testing.T, prefixStr, nexthopStr string, lookupTest boo
 	// Defer deletion of route and nexthop route to cleanup in case of failure
 	defer Delete(rt)
 	defer Delete(Route{
-		Device: "lo",
+		Device: device,
 		Prefix: *rt.getNexthopAsIPNet(),
 		Scope:  netlink.SCOPE_LINK,
 	})
@@ -106,9 +106,17 @@ func testReplaceRoute(t *testing.T, prefixStr, nexthopStr string, lookupTest boo
 func TestPrivilegedReplaceRoute(t *testing.T) {
 	setup(t)
 
-	testReplaceRoute(t, "2.2.0.0/16", "1.2.3.4", true)
-	// lookup test broken for IPv6 as long as use lo as device
-	testReplaceRoute(t, "f00d::a02:200:0:0/96", "f00d::a02:100:0:815b", false)
+	testReplaceRoute(t, "lo", "2.2.0.0/16", "1.2.3.4", true)
+
+	// Linux rejects IPv6 routes via nexthop on loopback, so use a
+	// temporary dummy interface for the IPv6 case.
+	// patch: https://github.com/torvalds/linux/commit/b3b5a03
+	dummy := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "test-dummy0"}}
+	require.NoError(t, netlink.LinkAdd(dummy))
+	defer netlink.LinkDel(dummy)
+	require.NoError(t, netlink.LinkSetUp(dummy))
+
+	testReplaceRoute(t, dummy.Name, "f00d::a02:200:0:0/96", "f00d::a02:100:0:815b", true)
 }
 
 func testReplaceRule(t *testing.T, mark uint32, from, to *net.IPNet, table int) {


### PR DESCRIPTION
Backport of
* [ ] https://github.com/cilium/cilium/pull/45922

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 45922
```