### PR TITLE
gateway-api: treat BackendTLSPolicy as required type

### DIFF
--- a/operator/pkg/gateway-api/helpers/schemes.go
+++ b/operator/pkg/gateway-api/helpers/schemes.go
@@ -25,6 +25,7 @@ var RequiredGVKs = []schema.GroupVersionKind{
 	gatewayv1.SchemeGroupVersion.WithKind(HTTPRouteKind),
 	gatewayv1.SchemeGroupVersion.WithKind(GRPCRouteKind),
 	gatewayv1.SchemeGroupVersion.WithKind(ReferenceGrantKind),
+	gatewayv1.SchemeGroupVersion.WithKind(BackendTLSPolicyKind),
 }
 
 var AllOptionalKinds = []schema.GroupVersionKind{

--- a/operator/pkg/gateway-api/helpers/types.go
+++ b/operator/pkg/gateway-api/helpers/types.go
@@ -25,6 +25,7 @@ const (
 	HTTPRouteKind         string = "httproutes"
 	GRPCRouteKind         string = "grpcroutes"
 	ReferenceGrantKind    string = "referencegrants"
+	BackendTLSPolicyKind  string = "backendtlspolicies"
 	TLSRouteKind          string = "tlsroutes"
 	TLSRouteListKind      string = "tlsroutelists"
 	ServiceImportKind     string = "serviceimports"


### PR DESCRIPTION
This commit adds the Gateway API CRD `BackendTLSPolicy` to the list of required types.

Cilium Operator bootstrap without CRD `BackendTLSPolicy` installed

```
time=2026-05-18T13:08:15.169430045Z level=error source=/go/src/github.com/cilium/cilium/operator/pkg/gateway-api/cell.go:158 msg="Required GatewayAPI resources are not found, please refer to docs for installation instructions" module=operator.operator-controlplane.leader-lifecycle.gateway-api error="customresourcedefinitions.apiextensions.k8s.io \"backendtlspolicies.gateway.networking.k8s.io\" not found"
```

Fixes: https://github.com/cilium/cilium/pull/43045