### PR TITLE
docs: Fix DOCS_BUILDER_REPO env variable for BSD sed compatibility

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -32,7 +32,7 @@ base-image: Dockerfile ## Build the docs-base image for updating the requirement
 	$(call build_image,$<,docs-base,$(DOCS_BASE_IMG))
 
 DOCS_BUILDER_IMG ?= quay.io/cilium/docs-builder:299b1b0619ca41010e1a3d930848cfbba6166df5@sha256:30b84cea76127ba89cf3aec9dc6cc2a7d81825e49957a59b648f8b26c414800b
-DOCS_BUILDER_REPO := $(shell echo $(DOCS_BUILDER_IMG) | sed -E 's#:.*##')
+DOCS_BUILDER_REPO := $(shell echo $(DOCS_BUILDER_IMG) | sed -E 's/:.*//')
 
 ifndef SKIP_BUILDER_IMAGE
 builder-image: Dockerfile $(REQUIREMENTS) ## Build the docs-builder image for rendering and checking the documentation.


### PR DESCRIPTION
The `render-docs` target fails on macOS with the following error:

```
Makefile:35: *** unterminated call to function `shell': missing `)'.  Stop.
```

Here is the broken line:

```
DOCS_BUILDER_REPO := $(shell echo $(DOCS_BUILDER_IMG) | sed -E 's#:.*##')
```

Change the sed regex delimiter from `#` to `/` when setting the DOCS_BUILDER_REPO environment variable. This ensures compatibility with both BSD and GNU sed.

Fixes: #45774

CC: @joestringer since you introduced this change.
