### PR TITLE
operator/ipam: Avoid short-lived ctx for allocators start

### DIFF
--- a/operator/pkg/ipam/alibabacloud.go
+++ b/operator/pkg/ipam/alibabacloud.go
@@ -6,6 +6,7 @@
 package ipam
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/spf13/pflag"
 
 	operatorOption "github.com/cilium/cilium/operator/option"
+	allocatorTypes "github.com/cilium/cilium/operator/pkg/ipam/allocator"
 	"github.com/cilium/cilium/operator/pkg/ipam/allocator/alibabacloud"
 	ipamMetrics "github.com/cilium/cilium/operator/pkg/ipam/metrics"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
@@ -84,12 +86,15 @@ func startAlibabaAllocator(p alibabaParams) {
 					return fmt.Errorf("unable to init AlibabaCloud allocator: %w", err)
 				}
 
-				nm, err := allocator.Start(ctx, &ciliumNodeUpdateImplementation{p.Clientset}, p.IPAMMetrics)
-				if err != nil {
-					return fmt.Errorf("unable to start AlibabaCloud allocator: %w", err)
-				}
-
-				p.JobGroup.Add(p.NodeWatcherFactory(nm))
+				p.JobGroup.Add(p.NodeWatcherFactory(
+					func(ctx context.Context) (allocatorTypes.NodeEventHandler, error) {
+						nm, err := allocator.Start(ctx, &ciliumNodeUpdateImplementation{p.Clientset}, p.IPAMMetrics)
+						if err != nil {
+							return nil, fmt.Errorf("unable to start AlibabaCloud allocator: %w", err)
+						}
+						return nm, nil
+					},
+				))
 
 				return nil
 			},

--- a/operator/pkg/ipam/aws.go
+++ b/operator/pkg/ipam/aws.go
@@ -6,6 +6,7 @@
 package ipam
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/cilium/hive/job"
 	"github.com/spf13/pflag"
 
+	allocatorTypes "github.com/cilium/cilium/operator/pkg/ipam/allocator"
 	"github.com/cilium/cilium/operator/pkg/ipam/allocator/aws"
 	ipamMetrics "github.com/cilium/cilium/operator/pkg/ipam/metrics"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
@@ -124,12 +126,15 @@ func startAWSAllocator(p awsParams) {
 					return fmt.Errorf("unable to init AWS allocator: %w", err)
 				}
 
-				nm, err := allocator.Start(ctx, &ciliumNodeUpdateImplementation{p.Clientset}, p.IPAMMetrics)
-				if err != nil {
-					return fmt.Errorf("unable to start AWS allocator: %w", err)
-				}
-
-				p.JobGroup.Add(p.NodeWatcherFactory(nm))
+				p.JobGroup.Add(p.NodeWatcherFactory(
+					func(ctx context.Context) (allocatorTypes.NodeEventHandler, error) {
+						nm, err := allocator.Start(ctx, &ciliumNodeUpdateImplementation{p.Clientset}, p.IPAMMetrics)
+						if err != nil {
+							return nil, fmt.Errorf("unable to start AWS allocator: %w", err)
+						}
+						return nm, nil
+					},
+				))
 
 				return nil
 			},

--- a/operator/pkg/ipam/azure.go
+++ b/operator/pkg/ipam/azure.go
@@ -6,6 +6,7 @@
 package ipam
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/spf13/pflag"
 
 	operatorOption "github.com/cilium/cilium/operator/option"
+	allocatorTypes "github.com/cilium/cilium/operator/pkg/ipam/allocator"
 	"github.com/cilium/cilium/operator/pkg/ipam/allocator/azure"
 	ipamMetrics "github.com/cilium/cilium/operator/pkg/ipam/metrics"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
@@ -92,12 +94,15 @@ func startAzureAllocator(p azureParams) {
 					return fmt.Errorf("unable to init Azure allocator: %w", err)
 				}
 
-				nm, err := allocator.Start(ctx, &ciliumNodeUpdateImplementation{p.Clientset}, p.AzureMetrics, p.IPAMMetrics)
-				if err != nil {
-					return fmt.Errorf("unable to start Azure allocator: %w", err)
-				}
-
-				p.JobGroup.Add(p.NodeWatcherFactory(nm))
+				p.JobGroup.Add(p.NodeWatcherFactory(
+					func(ctx context.Context) (allocatorTypes.NodeEventHandler, error) {
+						nm, err := allocator.Start(ctx, &ciliumNodeUpdateImplementation{p.Clientset}, p.AzureMetrics, p.IPAMMetrics)
+						if err != nil {
+							return nil, fmt.Errorf("unable to start Azure allocator: %w", err)
+						}
+						return nm, nil
+					},
+				))
 
 				return nil
 			},

--- a/operator/pkg/ipam/cell.go
+++ b/operator/pkg/ipam/cell.go
@@ -4,6 +4,8 @@
 package ipam
 
 import (
+	"context"
+
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
 	"github.com/spf13/pflag"
@@ -47,4 +49,5 @@ func (cfg Config) Flags(flags *pflag.FlagSet) {
 	flags.Float64("limit-ipam-api-qps", defaultConfig.LimitIPAMAPIQPS, "Queries per second limit when accessing external IPAM APIs")
 }
 
-type nodeWatcherJobFactory func(nm allocator.NodeEventHandler) job.Job
+type nodeEventHandlerFactory func(ctx context.Context) (allocator.NodeEventHandler, error)
+type nodeWatcherJobFactory func(nmFactory nodeEventHandlerFactory) job.Job

--- a/operator/pkg/ipam/clusterpool.go
+++ b/operator/pkg/ipam/clusterpool.go
@@ -6,6 +6,7 @@
 package ipam
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/cilium/hive/job"
 	"github.com/spf13/pflag"
 
+	allocatorTypes "github.com/cilium/cilium/operator/pkg/ipam/allocator"
 	"github.com/cilium/cilium/operator/pkg/ipam/allocator/clusterpool"
 	ipamMetrics "github.com/cilium/cilium/operator/pkg/ipam/metrics"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
@@ -97,12 +99,15 @@ func startClusterPoolAllocator(p clusterPoolParams) {
 					return fmt.Errorf("unable to init ClusterPool allocator: %w", err)
 				}
 
-				nm, err := allocator.Start(ctx, &ciliumNodeUpdateImplementation{p.Clientset}, p.IPAMMetrics.K8sSyncTrigger())
-				if err != nil {
-					return fmt.Errorf("unable to start ClusterPool allocator: %w", err)
-				}
-
-				p.JobGroup.Add(p.NodeWatcherFactory(nm))
+				p.JobGroup.Add(p.NodeWatcherFactory(
+					func(ctx context.Context) (allocatorTypes.NodeEventHandler, error) {
+						nm, err := allocator.Start(ctx, &ciliumNodeUpdateImplementation{p.Clientset}, p.IPAMMetrics.K8sSyncTrigger())
+						if err != nil {
+							return nil, fmt.Errorf("unable to start ClusterPool allocator: %w", err)
+						}
+						return nm, nil
+					},
+				))
 
 				return nil
 			},

--- a/operator/pkg/ipam/multipool.go
+++ b/operator/pkg/ipam/multipool.go
@@ -16,6 +16,7 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	allocatorTypes "github.com/cilium/cilium/operator/pkg/ipam/allocator"
 	"github.com/cilium/cilium/operator/pkg/multipool"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/ipam/types"
@@ -87,22 +88,26 @@ func startMultiPoolAllocator(p multiPoolParams) {
 					return err
 				}
 
-				// The following operation will block until all pools are restored, thus it
-				// is safe to continue starting node allocation right after return.
-				startIPPoolAllocator(
-					ctx, allocator, p.CiliumPodIPPools,
-					p.Logger.With(logfields.LogSubsys, "ip-pool-watcher"),
-				)
+				p.JobGroup.Add(p.NodeWatcherFactory(
+					func(ctx context.Context) (allocatorTypes.NodeEventHandler, error) {
+						// The following operation will block until all pools are restored, thus it
+						// is safe to continue starting node allocation right after return.
+						startIPPoolAllocator(
+							ctx, allocator, p.CiliumPodIPPools,
+							p.Logger.With(logfields.LogSubsys, "ip-pool-watcher"),
+						)
 
-				nm := multipool.NewNodeHandler(
-					"ipam-multi-pool-sync",
-					logger, allocator, p.Clientset.CiliumV2().CiliumNodes(),
-					func(cn *v2.CiliumNode) *types.IPAMPoolSpec {
-						return &cn.Spec.IPAM.Pools
+						nm := multipool.NewNodeHandler(
+							"ipam-multi-pool-sync",
+							logger, allocator, p.Clientset.CiliumV2().CiliumNodes(),
+							func(cn *v2.CiliumNode) *types.IPAMPoolSpec {
+								return &cn.Spec.IPAM.Pools
+							},
+						)
+
+						return nm, nil
 					},
-				)
-
-				p.JobGroup.Add(p.NodeWatcherFactory(nm))
+				))
 
 				return nil
 			},

--- a/operator/pkg/ipam/nodewatcher.go
+++ b/operator/pkg/ipam/nodewatcher.go
@@ -29,10 +29,15 @@ func newNodeWatcherJobFactory(
 	ciliumNodes resource.Resource[*cilium_api_v2.CiliumNode],
 	daemonCfg *option.DaemonConfig,
 ) nodeWatcherJobFactory {
-	return func(nm allocator.NodeEventHandler) job.Job {
+	return func(nmFactory nodeEventHandlerFactory) job.Job {
 		return job.OneShot(
 			"cilium-nodes-watcher",
 			func(ctx context.Context, _ cell.Health) error {
+				nm, err := nmFactory(ctx)
+				if err != nil {
+					return fmt.Errorf("unable to create node event handler: %w", err)
+				}
+
 				// The NodeEventHandler uses operatorWatchers.PodStore for IPAM surge allocation.
 				podStore, err := pods.Store(ctx)
 				if err != nil {


### PR DESCRIPTION
Each IPAM mode start hook is essentially composed of three steps:

1) initialize the specific allocator
2) start the allocator and build the node manager
3) watch the CiliumNodes and call into the node manager handlers

Step 2 requires a context to control the lifetime of the allocator. The context passed to the allocator start function must not be the one from the start hook, since that will be cancelled once all start hooks executed.

To fix this issue, the call to the allocator Start is moved into the job where we watches for CiliumNode updates. The job relies on its own context, not the one from the start hook.

Fixes: https://github.com/cilium/cilium/issues/45980
Related: https://github.com/cilium/cilium/pull/43628

Thanks to @alimehrabikoshki for reporting the [issue](https://github.com/cilium/cilium/issues/45980) and proposing a [fix](https://github.com/cilium/cilium/pull/45986) that inspired these changes.

Note: ~I'll open a follow up PR with a script based test and some other minor fixes target to to multi-pool IPAM.~ Opened https://github.com/cilium/cilium/pull/46035 as a follow up to test this scenario
