### PR TITLE
policy: add some commands to introspect the mapstate

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -440,6 +440,8 @@ func ciliumDbgCommands(cmdDir string) []string {
 		"cilium-dbg shell -- bgp/routes -a out ipv4 unicast",
 		"cilium-dbg shell -- bgp/routes -a out ipv6 unicast",
 		"cilium-dbg shell -- bgp/route-policies",
+		"cilium-dbg shell -- policy/mapstate/entries",
+		"cilium-dbg shell -- policy/mapstate/topk",
 		"cilium-dbg troubleshoot kvstore",
 		"cilium-dbg troubleshoot clustermesh",
 		"cilium-dbg bpf frag list",

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -654,3 +654,11 @@ func (e *Endpoint) GetRealizedL4PolicyRuleOriginModel() (policy *models.L4Policy
 	}
 	return e.realizedPolicy.SelectorPolicy.L4Policy.GetRuleOriginModel(), e.policyRevision, nil
 }
+
+// GetDesiredPolicy returns the desired or current endpoint policy.
+// May return nil in certain circumstances.
+func (e *Endpoint) GetDesiredPolicy() *policy.EndpointPolicy {
+	e.mutex.RLock()
+	defer e.mutex.RUnlock()
+	return e.desiredPolicy
+}

--- a/pkg/policy/cell/cell.go
+++ b/pkg/policy/cell/cell.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	policyapi "github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/policy/commands"
 	"github.com/cilium/cilium/pkg/policy/types"
 )
 
@@ -36,6 +37,7 @@ var Cell = cell.Module(
 	cell.Provide(newIPCacher),
 	cell.Config(defaultConfig),
 	metrics.Metric(newIdentityUpdaterMetrics),
+	cell.Provide(commands.NewPolicyCommands),
 )
 
 type Config struct {

--- a/pkg/policy/commands/cell.go
+++ b/pkg/policy/commands/cell.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package commands
+
+import (
+	"fmt"
+	"math"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/cilium/hive"
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/script"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/labels"
+)
+
+type CmdParams struct {
+	cell.In
+
+	EPL endpointmanager.EndpointsLookup
+}
+
+type PolicyCommands map[string]script.Cmd
+
+func NewPolicyCommands(params CmdParams) hive.ScriptCmdsOut {
+	return hive.NewScriptCmds(map[string]script.Cmd{
+		"policy/mapstate/entries": msEntriesCmd(params),
+		"policy/mapstate/topk":    topKCmd(params),
+	})
+}
+
+// autocompleteEndpoints returns a list of Endpoints that match the prefix of the argument.
+//
+// Accepted values are numeric endpoint IDs or <namespace/name>
+func autocompleteEndpoints(params CmdParams) func(_ *script.State, _ []string, cur string) []string {
+	return func(_ *script.State, _ []string, cur string) []string {
+		eps := params.EPL.GetEndpoints()
+		epNames := make([]string, 0, len(eps)*2)
+		for _, ep := range eps {
+			epNames = append(epNames, fmt.Sprintf("%d", ep.ID))
+			if ep.K8sNamespace != "" && ep.K8sPodName != "" {
+				epNames = append(epNames, fmt.Sprintf("%s/%s", ep.K8sNamespace, ep.K8sPodName))
+			}
+		}
+
+		return filterPrefix(epNames, cur)
+	}
+}
+
+// lookupEPs returns the set of endpoints that match the given specs,
+// or all endpoints if empty
+func lookupEPs(epl endpointmanager.EndpointsLookup, specs []string) ([]*endpoint.Endpoint, error) {
+	if len(specs) == 0 {
+		return epl.GetEndpoints(), nil
+	}
+
+	out := make([]*endpoint.Endpoint, 0, len(specs))
+	for _, spec := range specs {
+		if epid, err := strconv.Atoi(spec); err == nil {
+			if epid > math.MaxUint16 || epid <= 0 {
+				return nil, fmt.Errorf("invalid endpoint id %s", spec)
+			}
+			ep := epl.LookupCiliumID(uint16(epid))
+			if ep == nil {
+				return nil, fmt.Errorf("No endpoint with ID %d", epid)
+			}
+			out = append(out, ep)
+		} else if strings.Contains(spec, "/") {
+			eps := epl.GetEndpointsByPodName(spec)
+			if len(eps) == 0 {
+				return nil, fmt.Errorf("No endpoints with pod namespace/name %s", spec)
+			}
+			out = append(out, eps...)
+		} else {
+			return nil, fmt.Errorf("endpoint must either be numeric ID or <namespace/podname>s")
+		}
+	}
+	return out, nil
+}
+
+func filterPrefix(vals []string, cur string) []string {
+	return slices.DeleteFunc(vals, func(s string) bool {
+		return !strings.HasPrefix(s, cur)
+	})
+}
+
+type origin struct {
+	Kind      string `json:"kind"`
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+}
+
+func summarizeOrigin(lbls labels.LabelArray) origin {
+	kind := lbls.Get("io.cilium.k8s.policy.derived-from")
+	ns := lbls.Get("k8s:io.cilium.k8s.policy.namespace")
+	name := lbls.Get("k8s:io.cilium.k8s.policy.name")
+
+	if kind != "" {
+		return origin{
+			Kind:      kind,
+			Namespace: ns,
+			Name:      name,
+		}
+	}
+
+	from := lbls.Get("any:io.cilium.policy.derived-from")
+	if from != "" {
+		return origin{
+			Kind: from,
+		}
+	}
+	return origin{
+		Kind: lbls.String(),
+	}
+}
+
+func (o *origin) String() string {
+	switch {
+	case o.Namespace != "":
+		return fmt.Sprintf("%s:%s/%s", o.Kind, o.Namespace, o.Name)
+	case o.Name != "":
+		return fmt.Sprintf("%s:%s", o.Kind, o.Name)
+	default:
+		return o.Kind
+	}
+}
+
+func joinOrigins(os []origin) string {
+	strs := make([]string, 0, len(os))
+	for _, o := range os {
+		strs = append(strs, o.String())
+	}
+	return strings.Join(strs, ",")
+}

--- a/pkg/policy/commands/mapstate.go
+++ b/pkg/policy/commands/mapstate.go
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package commands
+
+import (
+	"cmp"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/cilium/hive/script"
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/policy"
+	policytypes "github.com/cilium/cilium/pkg/policy/types"
+)
+
+// msEntriesCmd dumps the mapstate entries, rather than the existing
+// BPF policymap.
+func msEntriesCmd(params CmdParams) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Display policy map state for a given endpoint",
+			Args:    "<pod-or-endpoint>+",
+			Flags: func(fs *pflag.FlagSet) {
+				fs.StringP("format", "f", "table", "Format to write in (table, json)")
+			},
+			AutocompleteFlag: func(_ *script.State, _ []string, flag, cur string) []string {
+				switch flag {
+				case "format":
+					return filterPrefix([]string{"table", "json"}, cur)
+				}
+				return nil
+			},
+			AutocompleteArgs: autocompleteEndpoints(params),
+			Detail: []string{
+				"List all MapState entries for some or all endpoints.",
+				"The MapState is the *desired* contents of the BPF policy map.",
+				"This command dumps the desired state as understood by the agent.",
+				"",
+				`pod-or-endpoint: either numerical endpoint ID or "namespace/podname", optionall repeateds`,
+			},
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			return func(*script.State) (stdout, stderr string, err error) {
+				format, err := s.Flags.GetString("format")
+				if err != nil {
+					return "", "", err
+				}
+				if format != "json" && format != "table" {
+					return "", "", fmt.Errorf("unsupported format %s", format)
+				}
+
+				// Collect policy from all endpoints
+				eps, err := lookupEPs(params.EPL, args)
+				if err != nil {
+					return "", "", err
+				}
+				outs := make([]entriesEPOut, 0, len(eps))
+
+				for _, ep := range eps {
+					epo := entriesEPOut{
+						ID:        ep.ID,
+						Namespace: ep.K8sNamespace,
+						Name:      ep.K8sPodName,
+					}
+					policy := ep.GetDesiredPolicy()
+					if policy != nil {
+						for key, entry := range policy.Entries() {
+							meta, _ := policy.GetRuleMeta(key)
+							epo.Entries = append(epo.Entries, makeEntry(key, entry, meta))
+						}
+					}
+					outs = append(outs, epo)
+				}
+
+				// sort by ID
+				slices.SortFunc(outs, func(a, b entriesEPOut) int {
+					return cmp.Compare(a.ID, b.ID)
+				})
+
+				// Output, in table or json format
+				switch format {
+				case "json":
+					b, err := json.MarshalIndent(outs, "", "\t")
+					if err != nil {
+						return "", "", fmt.Errorf("json marshal failed: %w", err)
+					}
+					return string(b), "", nil
+				case "table":
+					buf := &strings.Builder{}
+
+					for _, ep := range outs {
+						fmt.Fprintf(buf, "ID: %d\tNamespace: %s\tName: %s\tEntries:%d\n", ep.ID, ep.Namespace, ep.Name, len(ep.Entries))
+						tw := tabwriter.NewWriter(buf, 5, 0, 3, ' ', 0)
+						fmt.Fprintf(tw, "Direction\tIdentity\tProto+Port\tPriority\tListenerPrio\tVerdict\tProxyPort\tCookie\tOrigins\n")
+
+						for _, row := range ep.Entries {
+							fmt.Fprintf(tw, "%s\t%d\t%s\t%d\t%d\t%s\t%d\t%d\t%s\n",
+								row.Direction,
+								row.Identity,
+								row.PortProto,
+								row.Priority,
+								row.ListenerPriority,
+								row.Verdict,
+								row.ProxyPort,
+								row.Cookie,
+								joinOrigins(row.Origins),
+							)
+						}
+						tw.Flush()
+						fmt.Fprintln(buf)
+					}
+					return buf.String(), "", nil
+				}
+
+				return "", "", fmt.Errorf("unsupported format %s", format)
+
+			}, nil
+		},
+	)
+}
+
+type entriesEPOut struct {
+	ID        uint16 `json:"id"`
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+
+	Entries []entryOut `json:"entries"`
+}
+
+type entryOut struct {
+	Direction string                   `json:"direction"`
+	Identity  identity.NumericIdentity `json:"identity"`
+	PortProto string                   `json:"portproto"`
+
+	Priority         policytypes.Priority         `json:"priority"`
+	ListenerPriority policytypes.ListenerPriority `json:"listenerpriority"`
+
+	Verdict   string `json:"verdict"`
+	ProxyPort uint16 `json:"proxyPort"`
+	Cookie    uint32 `json:"cookie"`
+
+	Origins []origin `json:"origins"`
+}
+
+func makeEntry(key policy.Key, entry policy.MapStateEntry, meta policy.RuleMeta) entryOut {
+	out := entryOut{
+		Direction: key.TrafficDirection().String(),
+		Identity:  key.Identity,
+
+		Priority:         entry.Precedence.Priority(),
+		ListenerPriority: entry.Precedence.ListenerPriority(),
+
+		Verdict:   "unknown",
+		ProxyPort: entry.ProxyPort,
+		Cookie:    entry.Cookie,
+	}
+
+	if key.Nexthdr == 0 {
+		out.PortProto = "*"
+	} else if key.HasPortWildcard() {
+		out.PortProto = fmt.Sprintf("%s/%d-%d",
+			key.Nexthdr.String(),
+			key.DestPort,
+			key.EndPort(),
+		)
+	} else {
+		out.PortProto = fmt.Sprintf("%s/%d",
+			key.Nexthdr.String(),
+			key.DestPort,
+		)
+	}
+
+	switch {
+	case !entry.IsValid():
+		out.Verdict = "invalid"
+	case entry.IsDeny():
+		out.Verdict = "deny"
+	case entry.Precedence.IsPass():
+		out.Verdict = "pass"
+	case entry.IsAllow():
+		out.Verdict = "allow"
+	}
+
+	for _, lbls := range meta.LabelArray() {
+		out.Origins = append(out.Origins, summarizeOrigin(lbls))
+	}
+
+	return out
+}

--- a/pkg/policy/commands/topk.go
+++ b/pkg/policy/commands/topk.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package commands
+
+import (
+	"cmp"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/cilium/hive/script"
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+)
+
+// topKCmd returns a command that indicates the resources
+// responsible for the most mapstate entries.
+func topKCmd(params CmdParams) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Determine causes of mapstate entries",
+			Args:    "<pod-or-endpoint>",
+			Flags: func(fs *pflag.FlagSet) {
+				fs.IntP("num", "n", 10, "Maxiumum number of rows per endpoint to display")
+				fs.IntP("count", "c", 0, "Maxiumum number of endpoints to display")
+				fs.StringP("format", "f", "table", "Format to write in (table, json)")
+			},
+			AutocompleteFlag: func(_ *script.State, _ []string, flag, cur string) []string {
+				switch flag {
+				case "format":
+					return filterPrefix([]string{"table", "json"}, cur)
+				}
+				return nil
+			},
+			AutocompleteArgs: autocompleteEndpoints(params),
+			Detail: []string{
+				"List policies and the number of mapstate entries they cause.",
+				"",
+				"NOTE: multiple policies may insert the same mapstate entries.",
+				"The total may not be the exact sum.",
+				"",
+				`pod-or-endpoint: either numerical endpoint ID or "namespace/podname"`,
+			},
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			return func(*script.State) (stdout, stderr string, err error) {
+				num, err := s.Flags.GetInt("num")
+				if err != nil {
+					return "", "", err
+				}
+				count, err := s.Flags.GetInt("count")
+				if err != nil {
+					return "", "", err
+				}
+				format, err := s.Flags.GetString("format")
+				if err != nil {
+					return "", "", err
+				}
+				if format != "json" && format != "table" {
+					return "", "", fmt.Errorf("unsupported format %s", format)
+				}
+
+				eps, err := lookupEPs(params.EPL, args)
+				if err != nil {
+					return "", "", err
+				}
+				outs := make([]topKEPOut, 0, len(eps))
+				for _, ep := range eps {
+					outs = append(outs, gatherEPTopK(ep, num))
+				}
+
+				// Sort by largest mapstate
+				slices.SortFunc(outs, func(a, b topKEPOut) int {
+					return cmp.Compare(b.Total, a.Total) // reverse sort
+				})
+
+				if count > 0 {
+					outs = outs[:min(len(outs), count)]
+				}
+
+				switch format {
+				case "json":
+					b, err := json.MarshalIndent(outs, "", "\t")
+					if err != nil {
+						return "", "", fmt.Errorf("json marshal failed: %w", err)
+					}
+					return string(b), "", nil
+				case "table":
+					buf := &strings.Builder{}
+
+					for _, ep := range outs {
+						fmt.Fprintf(buf, "ID: %d\tNamespace: %s\tName: %s\tEntries: %d (may not sum)\tPolicies: %d\n", ep.ID, ep.Namespace, ep.Name, ep.Total, ep.NumOrigins)
+
+						tw := tabwriter.NewWriter(buf, 5, 0, 3, ' ', 0)
+						fmt.Fprintf(tw, "Policy\tEntries\n")
+
+						for _, origin := range ep.Origins {
+							fmt.Fprintf(tw, "%s\t%d\n", origin.String(), origin.Count)
+						}
+						tw.Flush()
+						fmt.Fprintln(buf)
+					}
+					return buf.String(), "", nil
+				}
+				return "", "", nil
+			}, nil
+		},
+	)
+}
+
+func gatherEPTopK(ep *endpoint.Endpoint, num int) topKEPOut {
+	out := topKEPOut{
+		ID:        ep.ID,
+		Namespace: ep.K8sNamespace,
+		Name:      ep.K8sPodName,
+	}
+
+	policy := ep.GetDesiredPolicy()
+	if policy == nil {
+		return out
+	}
+	out.Total = policy.Len()
+
+	totals := map[origin]int{}
+
+	for key := range policy.Entries() {
+		meta, _ := policy.GetRuleMeta(key)
+		for _, lbls := range meta.LabelArray() {
+			origin := summarizeOrigin(lbls)
+			totals[origin] = totals[origin] + 1
+		}
+	}
+
+	out.Origins = make([]topKOrigin, 0, len(totals))
+
+	for origin, count := range totals {
+		out.Origins = append(out.Origins, topKOrigin{origin: origin, Count: count})
+	}
+
+	slices.SortFunc(out.Origins, func(a, b topKOrigin) int {
+		// want topk, so reverse order
+		return cmp.Compare(b.Count, a.Count)
+	})
+
+	out.NumOrigins = len(out.Origins)
+	out.Origins = out.Origins[:min(len(out.Origins), num)]
+	return out
+}
+
+type topKEPOut struct {
+	ID        uint16 `json:"id"`
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+
+	Origins []topKOrigin `json:"origins"`
+
+	// Total number of entries
+	Total int `json:"total"`
+
+	// Total number of unique origins
+	NumOrigins int `json:"numOrigins"`
+}
+
+type topKOrigin struct {
+	origin
+
+	Count int `json:"count"`
+}

--- a/pkg/policy/types/entry.go
+++ b/pkg/policy/types/entry.go
@@ -129,6 +129,10 @@ func (p Precedence) Priority() Priority {
 	return LowestPriority - Priority(p>>precedencePriorityShift)
 }
 
+func (p Precedence) ListenerPriority() ListenerPriority {
+	return ListenerPriority(precedenceByteMask - (p & precedenceByteMask))
+}
+
 // MapStateEntry is the configuration associated with a Key in a
 // MapState. This is a minimized version of policymap.PolicyEntry.
 type MapStateEntry struct {


### PR DESCRIPTION
This adds two commands to look in to the policy mapstate:

- policy/mapstate/entries: show the mapstate of a given endpoint
- policy/mapstate/topk: show the policies that cause the greatest number of mapstate entries.

The latter is intended for diagnosing policy map pressure.

```release-note
Added some commands to cilium-dbg to help diagnose policy map pressure.
```
