### PR TITLE
ci: gate conn-disrupt-test-check via explicit input 

### DIFF
--- a/.github/actions/conn-disrupt-test-check/action.yaml
+++ b/.github/actions/conn-disrupt-test-check/action.yaml
@@ -20,6 +20,10 @@ inputs:
     required: false
     default: ''
     description: 'Select which connectivity tests to run'
+  conn-disrupt:
+    required: false
+    default: 'true'
+    description: 'Whether to run the conn-disrupt sub-tests (--include-conn-disrupt-test*). Set to false for plain connectivity test runs. full-test=true enables them regardless of this input.'
   test-concurrency:
     required: false
     default: '1'
@@ -38,7 +42,7 @@ runs:
     - name: Perform Conn Disrupt Test
       shell: bash
       run: |
-        if [[ -n "${{ inputs.tests }}" ]]; then
+        if [[ "${{ inputs.conn-disrupt }}" != "true" ]]; then
           TEST_ARG="${{ inputs.tests }}"
         else
           TEST_ARG="no-interrupted-connections,no-ipsec-xfrm-error"
@@ -61,7 +65,7 @@ runs:
           fi
         fi
 
-        if [[ "${{ inputs.include-conn-disrupt-test-l7-traffic }}" == "true" ]]; then
+        if [[ "${{ inputs.conn-disrupt }}" == "true" && "${{ inputs.include-conn-disrupt-test-l7-traffic }}" == "true" ]]; then
           EXTRA_ARG="${EXTRA_ARG} --include-conn-disrupt-test-l7-traffic"
         fi
 

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -607,6 +607,7 @@ jobs:
         with:
           job-name: cilium-upgrade-${{ matrix.name }}-concurrent
           tests: ${{ steps.vars.outputs.concurrent_connectivity_tests }}
+          conn-disrupt: 'false'
           test-concurrency: ${{ env.test_concurrency }}
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
 
@@ -616,6 +617,7 @@ jobs:
         with:
           job-name: cilium-upgrade-${{ matrix.name }}-postcheck
           tests: 'no-unexpected-packet-drops'
+          conn-disrupt: 'false'
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
 
       - name: Assert that no unencrypted packets are leaked during connectivity tests after upgrade
@@ -716,6 +718,7 @@ jobs:
         with:
           job-name: cilium-downgrade-${{ matrix.name }}-concurrent
           tests: ${{ steps.vars.outputs.concurrent_connectivity_tests }}
+          conn-disrupt: 'false'
           test-concurrency: ${{ env.test_concurrency }}
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
 
@@ -725,6 +728,7 @@ jobs:
         with:
           job-name: cilium-upgrade-${{ matrix.name }}-postcheck
           tests: 'no-unexpected-packet-drops'
+          conn-disrupt: 'false'
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
 
       - name: Assert that no unencrypted packets are leaked during connectivity tests after downgrade


### PR DESCRIPTION
The conn-disrupt-test-check action used an empty 'tests' input as an implicit signal to run the conn-disrupt check path. In that case, it enabled the conn-disrupt flags (--include-conn-disrupt-test*) and ran the no-interrupted-connections/no-ipsec-xfrm-error checks.

However, an empty 'tests' value can also legitimately mean "run the whole connectivity test suite".

This broke scheduled tests-e2e-upgrade runs. "Run concurrent Cilium tests" step passes concurrent_connectivity_tests,
which is empty. The action mistook that for a conn-disrupt check and waited for the test-conn-disrupt-server deployment, which had already been removed by the preceding conn-disrupt check step:

```
timeout reached waiting for deployment cilium-test-1/test-conn-disrupt-server to become ready (last error: deployments.apps "test-conn-disrupt-server" not found)
```

Add an explicit 'conn-disrupt' input, defaulting to true, to gate the conn-disrupt check path independently of 'tests'.

Note: As a follow-up, we should refactor `conn-disrupt-test-check` into a generic connectivity-test action. The action is currently used even for cases that do not run conn-disrupt tests, so the name and behavior are misleading. 

Fixes: #45453