### PR TITLE
Fix incorrect 'skipping test' reason messages

### DIFF
--- a/cilium-cli/utils/features/features.go
+++ b/cilium-cli/utils/features/features.go
@@ -157,6 +157,13 @@ func (s Status) String() string {
 	return fmt.Sprintf("%s:%s", str, s.Mode)
 }
 
+func (s Status) shortString() string {
+	if s.Enabled {
+		return "enabled"
+	}
+	return "disabled"
+}
+
 // Set contains the Status of a collection of Features.
 type Set map[Feature]Status
 
@@ -166,7 +173,7 @@ func (fs Set) MatchRequirements(reqs ...Requirement) (bool, string) {
 	for _, req := range reqs {
 		status := fs[req.Feature]
 		if req.requiresEnabled && (req.enabled != status.Enabled) {
-			return false, fmt.Sprintf("Feature %s is disabled", req.Feature)
+			return false, fmt.Sprintf("Feature %s is %s", req.Feature, status.shortString())
 		}
 		if req.requiresMode && (req.mode != status.Mode) {
 			return false, fmt.Sprintf("requires Feature %s mode %s, got %s", req.Feature, req.mode, status.Mode)


### PR DESCRIPTION
When a connectivity test is skipped because a feature enabled status does not match test requirements, the reason message was always 'disabled', which is confusing. E.g. in the case below `host-firewall-egress-to-fqdns` requires `endpoint-routes` to be disabled in order to run, and was correctly skipped because Cilium was installed with endpoint routes enabled, but the skip reason is wrong.

```
[=] [cilium-test-1] Skipping test [host-firewall-ingress] [1/11] (Feature host-firewall is disabled)
[=] [cilium-test-1] Skipping test [host-firewall-egress] [2/11] (Feature host-firewall is disabled)
[=] [cilium-test-1] Skipping test [host-firewall-egress-to-fqdns] [3/11] (Feature endpoint-routes is disabled)
```
