### PR TITLE
gh: conn-disrupt: remove skip-include-conn-disrupt-test-ns-traffic flag

### DIFF
--- a/.github/actions/conn-disrupt-test-check/action.yaml
+++ b/.github/actions/conn-disrupt-test-check/action.yaml
@@ -24,10 +24,6 @@ inputs:
     required: false
     default: '1'
     description: 'Concurrency level to run tests'
-  skip-include-conn-disrupt-test-ns-traffic:
-    required: false
-    default: 'false'
-    description: 'Skip NS traffic disruption test (--include-conn-disrupt-test-ns-traffic). Can be removed after Cilium v1.20 release'
   include-conn-disrupt-test-l7-traffic:
     required: false
     default: 'false'
@@ -45,20 +41,14 @@ runs:
           if [[ -n "${{ env.CONN_DISRUPT_EXTRA_TEST }}" ]]; then
             TEST_ARG="${TEST_ARG},${{ env.CONN_DISRUPT_EXTRA_TEST }}"
           fi
-          EXTRA_ARG="--include-conn-disrupt-test --include-conn-disrupt-test-egw"
-          if [[ "${{ inputs.skip-include-conn-disrupt-test-ns-traffic }}" != "true" ]]; then
-            EXTRA_ARG="${EXTRA_ARG} --include-conn-disrupt-test-ns-traffic"
-          fi
+          EXTRA_ARG="--include-conn-disrupt-test --include-conn-disrupt-test-egw --include-conn-disrupt-test-ns-traffic"
           if [[ -n "${{ env.CONN_DISRUPT_EXTRA_ARG }}" ]]; then
             EXTRA_ARG="${EXTRA_ARG} ${{ env.CONN_DISRUPT_EXTRA_ARG }}"
           fi
         fi
         if [[ "${{ inputs.full-test }}" == "true" ]]; then
           TEST_ARG=""
-          EXTRA_ARG="--include-conn-disrupt-test --include-conn-disrupt-test-egw"
-          if [[ "${{ inputs.skip-include-conn-disrupt-test-ns-traffic }}" != "true" ]]; then
-            EXTRA_ARG="${EXTRA_ARG} --include-conn-disrupt-test-ns-traffic"
-          fi
+          EXTRA_ARG="--include-conn-disrupt-test --include-conn-disrupt-test-egw --include-conn-disrupt-test-ns-traffic"
         fi
 
         if [[ "${{ inputs.include-conn-disrupt-test-l7-traffic }}" == "true" ]]; then

--- a/.github/actions/e2e/kube-proxy.yaml
+++ b/.github/actions/e2e/kube-proxy.yaml
@@ -34,7 +34,6 @@
   misc: 'socketLB.enabled=false,bpf.masquerade=true'
   local-redirect-policy: 'true'
   node-local-dns: 'true'
-  skip-include-conn-disrupt-test-ns-traffic: 'true'
   # L7 testing: Node local DNS requires DNS proxy testing
   test-l7: 'true'
 - name: 'kube-proxy-5'

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -589,7 +589,6 @@ jobs:
         with:
           job-name: cilium-upgrade-${{ matrix.name }}-precheck
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
-          skip-include-conn-disrupt-test-ns-traffic: ${{ matrix.skip-include-conn-disrupt-test-ns-traffic }}
 
       - name: Start unencrypted packets check for connectivity tests after upgrade
         if: ${{ steps.vars.outputs.downgrade_version != '' && matrix.encryption != '' }}
@@ -654,7 +653,6 @@ jobs:
         with:
           job-name: cilium-restart-${{ matrix.name }}-precheck
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
-          skip-include-conn-disrupt-test-ns-traffic: ${{ matrix.skip-include-conn-disrupt-test-ns-traffic }}
           include-conn-disrupt-test-l7-traffic: ${{ steps.vars-conn.outputs.include_conn_disrupt_test_l7_traffic }}
 
       - name: Features tested before downgrade
@@ -700,7 +698,6 @@ jobs:
         with:
           job-name: cilium-downgrade-${{ matrix.name }}-precheck
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
-          skip-include-conn-disrupt-test-ns-traffic: ${{ matrix.skip-include-conn-disrupt-test-ns-traffic }}
 
       - name: Start unencrypted packets check for connectivity tests after downgrade
         if: ${{ steps.vars.outputs.downgrade_version != '' && steps.vars.outputs.skip_upgrade != 'true' && matrix.encryption != '' }}


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/41380 introduced this flag to work-around a Nodeport-related issue when mixing v1.18 and v1.19 releases.

It's no longer required for testing upgrade/downgrade between v1.19 and main.