### PR TITLE
envoy: Apply default config in standalone_envoy_test

### DIFF
--- a/pkg/envoy/standalone_envoy_test.go
+++ b/pkg/envoy/standalone_envoy_test.go
@@ -112,6 +112,10 @@ func TestEnvoy(t *testing.T) {
 		baseID:                         15,
 		connectTimeout:                 1,
 		maxActiveDownstreamConnections: 100,
+		idleTimeout:                    60,
+		maxConcurrentRetries:           128,
+		maxConnections:                 1024,
+		maxRequests:                    1024,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, envoyProxy)
@@ -235,6 +239,10 @@ func TestEnvoyNACK(t *testing.T) {
 		baseID:                         42,
 		connectTimeout:                 1,
 		maxActiveDownstreamConnections: 100,
+		idleTimeout:                    60,
+		maxConcurrentRetries:           128,
+		maxConnections:                 1024,
+		maxRequests:                    1024,
 	})
 	require.NotNil(t, envoyProxy)
 	require.NoError(t, err)


### PR DESCRIPTION
Configured max requests/connections values are now applied also to xDS cluster as well, so they must be supplied in the standaloneEnvoyConfig to allow any connections/requests on the xDS cluster.

Fixes: #45445
