### PR TITLE
daemon: Fix privileged integration policy test

### DIFF
--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -254,6 +254,9 @@ func (ds *DaemonSuite) setupConfigOptions() {
 	mockCmd := &cobra.Command{}
 	ds.hive.RegisterFlags(mockCmd.Flags())
 	InitGlobalFlags(ds.log, mockCmd, ds.hive.Viper())
+	if err := mockCmd.Flags().Set("envoy-policy-restore-timeout", "100ms"); err != nil {
+		panic("setting envoy-policy-restore-timeout failed")
+	}
 	option.Config.Populate(ds.log, ds.hive.Viper())
 	option.Config.PopulateEnableCiliumNodeCRD(ds.log, ds.hive.Viper())
 	if option.Config.Debug {

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/maps/subnet"
@@ -114,8 +115,13 @@ func setupDaemonEtcdSuite(tb testing.TB) *DaemonSuite {
 
 	client := kvstore.SetupDummy(tb, kvstore.EtcdBackendName)
 
+	logOpts := []hivetest.LogOption{}
+	if os.Getenv("CILIUM_DEBUG") != "" {
+		logOpts = append(logOpts, hivetest.LogLevel(slog.LevelDebug))
+	}
+
 	ds := &DaemonSuite{
-		log: hivetest.Logger(tb),
+		log: hivetest.Logger(tb, logOpts...),
 	}
 	ctx := context.Background()
 
@@ -193,8 +199,34 @@ func setupDaemonEtcdSuite(tb testing.TB) *DaemonSuite {
 	option.Config.RunDir = testRunDir
 	option.Config.StateDir = testRunDir
 
-	err := ds.hive.Start(ds.log, ctx)
+	oldWd, err := os.Getwd()
 	require.NoError(tb, err)
+	require.NoError(tb, os.Chdir(option.Config.StateDir))
+
+	hiveStarted := false
+	tb.Cleanup(func() {
+		controller.NewManager().RemoveAllAndWait()
+
+		// Restore the policy enforcement mode.
+		policy.SetPolicyEnabled(ds.oldPolicyEnabled)
+
+		if hiveStarted {
+			err := ds.hive.Stop(ds.log, ctx)
+			require.NoError(tb, err)
+		}
+
+		require.NoError(tb, os.Chdir(oldWd))
+
+		// It's helpful to keep the directories around if a test failed; only delete
+		// them if tests succeed.
+		if !tb.Failed() {
+			os.RemoveAll(option.Config.RunDir)
+		}
+	})
+
+	err = ds.hive.Start(ds.log, ctx)
+	require.NoError(tb, err)
+	hiveStarted = true
 
 	ds.policyRepository.GetSelectorCache().SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
 
@@ -213,22 +245,6 @@ func setupDaemonEtcdSuite(tb testing.TB) *DaemonSuite {
 		metrics.EndpointStateCount.WithLabelValues(s).Set(0.0)
 	}
 
-	tb.Cleanup(func() {
-		controller.NewManager().RemoveAllAndWait()
-
-		// It's helpful to keep the directories around if a test failed; only delete
-		// them if tests succeed.
-		if !tb.Failed() {
-			os.RemoveAll(option.Config.RunDir)
-		}
-
-		// Restore the policy enforcement mode.
-		policy.SetPolicyEnabled(ds.oldPolicyEnabled)
-
-		err := ds.hive.Stop(ds.log, ctx)
-		require.NoError(tb, err)
-	})
-
 	return ds
 }
 
@@ -240,9 +256,22 @@ func (ds *DaemonSuite) setupConfigOptions() {
 	InitGlobalFlags(ds.log, mockCmd, ds.hive.Viper())
 	option.Config.Populate(ds.log, ds.hive.Viper())
 	option.Config.PopulateEnableCiliumNodeCRD(ds.log, ds.hive.Viper())
+	if option.Config.Debug {
+		logging.SetLogLevel(slog.LevelDebug)
+	}
 	option.Config.IdentityAllocationMode = option.IdentityAllocationModeKVstore
 	option.Config.DryMode = true
 	option.Config.Opts = option.NewIntOptions(&option.DaemonMutableOptionLibrary)
+	for _, grp := range option.Config.DebugVerbose {
+		switch grp {
+		case argDebugVerboseEnvoy:
+			envoy.EnableTracing()
+		case argDebugVerbosePolicy:
+			option.Config.Opts.SetBool(option.DebugPolicy, true)
+		case argDebugVerboseTagged:
+			option.Config.Opts.SetBool(option.DebugTagged, true)
+		}
+	}
 	// GetConfig the default labels prefix filter
 	err := labelsfilter.ParseLabelPrefixCfg(ds.log, nil, nil, "")
 	if err != nil {

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -312,13 +312,14 @@ func (ds *DaemonSuite) testUpdateConsumerMap(t *testing.T) {
 	require.False(t, eQABar.Allows(qaBarSecLblsCtx.ID))
 	require.False(t, eQABar.Allows(prodBarSecLblsCtx.ID))
 	require.True(t, eQABar.Allows(qaFooSecLblsCtx.ID))
-	require.False(t, eQABar.Allows(prodFooSecLblsCtx.ID))
+	require.True(t, eQABar.Allows(prodFooSecLblsCtx.ID))
+	require.True(t, eQABar.Allows(prodFooJoeSecLblsCtx.ID))
 
 	eProdBar := ds.prepareEndpoint(t, prodBarSecLblsCtx, false)
 	require.False(t, eProdBar.Allows(0))
 	require.False(t, eProdBar.Allows(qaBarSecLblsCtx.ID))
 	require.False(t, eProdBar.Allows(prodBarSecLblsCtx.ID))
-	require.False(t, eProdBar.Allows(qaFooSecLblsCtx.ID))
+	require.True(t, eProdBar.Allows(qaFooSecLblsCtx.ID))
 	require.True(t, eProdBar.Allows(prodFooSecLblsCtx.ID))
 	require.True(t, eProdBar.Allows(prodFooJoeSecLblsCtx.ID))
 
@@ -331,10 +332,8 @@ func (ds *DaemonSuite) testUpdateConsumerMap(t *testing.T) {
 	require.NotNil(t, qaBarNetworkPolicy)
 	expectedRemotePolicies := []uint32{
 		uint32(qaFooSecLblsCtx.ID),
-		// The prodFoo* identities are allowed by FromEndpoints but rejected by
-		// FromRequires, so they are not included in the remote policies:
-		// uint32(prodFooSecLblsCtx.ID),
-		// uint32(prodFooJoeSecLblsCtx.ID),
+		uint32(prodFooSecLblsCtx.ID),
+		uint32(prodFooJoeSecLblsCtx.ID),
 	}
 	slices.Sort(expectedRemotePolicies)
 	expectedNetworkPolicy := &cilium.NetworkPolicy{
@@ -347,6 +346,7 @@ func (ds *DaemonSuite) testUpdateConsumerMap(t *testing.T) {
 				Rules: []*cilium.PortNetworkPolicyRule{
 					{
 						RemotePolicies: expectedRemotePolicies,
+						Precedence:     4294967041,
 					},
 				},
 			},
@@ -357,6 +357,7 @@ func (ds *DaemonSuite) testUpdateConsumerMap(t *testing.T) {
 					{
 						RemotePolicies: expectedRemotePolicies,
 						L7:             &PNPAllowGETbar,
+						Precedence:     4294967194,
 					},
 				},
 			},
@@ -371,9 +372,7 @@ func (ds *DaemonSuite) testUpdateConsumerMap(t *testing.T) {
 	prodBarNetworkPolicy := networkPolicies[ProdIPv4Addr.String()]
 	require.NotNil(t, prodBarNetworkPolicy)
 	expectedRemotePolicies = []uint32{
-		// The qaFoo identity is allowed by FromEndpoints but rejected by
-		// FromRequires, so it is not included in the remote policies:
-		// uint64(qaFooSecLblsCtx.ID),
+		uint32(qaFooSecLblsCtx.ID),
 		uint32(prodFooSecLblsCtx.ID),
 		uint32(prodFooJoeSecLblsCtx.ID),
 	}
@@ -389,6 +388,7 @@ func (ds *DaemonSuite) testUpdateConsumerMap(t *testing.T) {
 				Rules: []*cilium.PortNetworkPolicyRule{
 					{
 						RemotePolicies: expectedRemotePolicies,
+						Precedence:     4294967041,
 					},
 				},
 			},
@@ -399,6 +399,7 @@ func (ds *DaemonSuite) testUpdateConsumerMap(t *testing.T) {
 					{
 						RemotePolicies: expectedRemotePolicies,
 						L7:             &PNPAllowGETbar,
+						Precedence:     4294967194,
 					},
 				},
 			},
@@ -482,10 +483,13 @@ func (ds *DaemonSuite) testL4L7Shadowing(t *testing.T) {
 				Port:     80,
 				Protocol: envoy_config_core.SocketAddress_TCP,
 				Rules: []*cilium.PortNetworkPolicyRule{
-					{},
 					{
 						RemotePolicies: []uint32{uint32(qaFooSecLblsCtx.ID)},
 						L7:             &PNPAllowGETbarLog,
+						Precedence:     4294967194,
+					},
+					{
+						Precedence: 4294967041,
 					},
 				},
 			},
@@ -571,7 +575,16 @@ func (ds *DaemonSuite) testL4L7ShadowingShortCircuit(t *testing.T) {
 			{
 				Port:     80,
 				Protocol: envoy_config_core.SocketAddress_TCP,
-				Rules:    nil,
+				Rules: []*cilium.PortNetworkPolicyRule{
+					{
+						RemotePolicies: []uint32{uint32(qaFooSecLblsCtx.ID)},
+						L7:             &PNPAllowGETbar,
+						Precedence:     4294967194,
+					},
+					{
+						Precedence: 4294967041,
+					},
+				},
 			},
 		},
 		EgressPerPortPolicies: []*cilium.PortNetworkPolicy{ // Allow-all policy.
@@ -666,6 +679,7 @@ func (ds *DaemonSuite) testL3DependentL7(t *testing.T) {
 				Rules: []*cilium.PortNetworkPolicyRule{
 					{
 						RemotePolicies: []uint32{uint32(qaJoeSecLblsCtx.ID)},
+						Precedence:     4294967041,
 					},
 				},
 			},
@@ -676,6 +690,7 @@ func (ds *DaemonSuite) testL3DependentL7(t *testing.T) {
 					{
 						RemotePolicies: []uint32{uint32(qaFooSecLblsCtx.ID)},
 						L7:             &PNPAllowGETbar,
+						Precedence:     4294967194,
 					},
 				},
 			},
@@ -749,6 +764,7 @@ func (ds *DaemonSuite) testRemovePolicy(t *testing.T) {
 	require.NotNil(t, qaBarNetworkPolicy)
 
 	// Delete the endpoint.
+	e.SetPropertyValue(endpointtypes.PropertyFakeEndpoint, true) // prevent panic during e.Delete
 	e.Delete(endpoint.DeleteConfig{})
 
 	// Check that the policy has been removed from the xDS cache.
@@ -852,6 +868,7 @@ func (ds *DaemonSuite) testIncrementalPolicy(t *testing.T) {
 				Rules: []*cilium.PortNetworkPolicyRule{
 					{
 						RemotePolicies: []uint32{uint32(qaFooID.ID)},
+						Precedence:     4294967041,
 					},
 				},
 			},
@@ -862,6 +879,7 @@ func (ds *DaemonSuite) testIncrementalPolicy(t *testing.T) {
 					{
 						RemotePolicies: []uint32{uint32(qaFooID.ID)},
 						L7:             &PNPAllowGETbar,
+						Precedence:     4294967194,
 					},
 				},
 			},
@@ -872,6 +890,7 @@ func (ds *DaemonSuite) testIncrementalPolicy(t *testing.T) {
 	}, qaBarNetworkPolicy)
 
 	// Delete the endpoint.
+	eQABar.SetPropertyValue(endpointtypes.PropertyFakeEndpoint, true) // prevent panic during e.Delete
 	eQABar.Delete(endpoint.DeleteConfig{})
 
 	// Check that the policy has been removed from the xDS cache.

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/netip"
 	"os"
 	"path/filepath"
@@ -16,8 +17,14 @@ import (
 	cilium "github.com/cilium/proxy/go/cilium/api"
 	envoy_config_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	envoy_service_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	envoy_type_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 	"k8s.io/utils/ptr"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -25,8 +32,10 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	endpointtypes "github.com/cilium/cilium/pkg/endpoint/types"
+	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/testutils"
 )
@@ -170,9 +179,88 @@ var (
 // getXDSNetworkPolicies returns the representation of the xDS network policies
 // as a map of IP addresses to NetworkPolicy objects
 func (ds *DaemonSuite) getXDSNetworkPolicies(t *testing.T, resourceNames []string) map[string]*cilium.NetworkPolicy {
-	networkPolicies, err := ds.envoyXdsServer.GetNetworkPolicies(resourceNames)
-	require.NoError(t, err)
-	return networkPolicies
+	socketPath := filepath.Join(envoy.GetSocketDir(option.Config.RunDir), "xds.sock")
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	var lastErr error
+	for ctx.Err() == nil {
+		attemptCtx, attemptCancel := context.WithTimeout(ctx, time.Second)
+		networkPolicies, err := func() (map[string]*cilium.NetworkPolicy, error) {
+			conn, err := grpc.DialContext(attemptCtx, "passthrough:///xds",
+				grpc.WithBlock(),
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+				grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+					var d net.Dialer
+					return d.DialContext(ctx, "unix", socketPath)
+				}))
+			if err != nil {
+				return nil, err
+			}
+			defer conn.Close()
+
+			stream, err := cilium.NewNetworkPolicyDiscoveryServiceClient(conn).StreamNetworkPolicies(attemptCtx)
+			if err != nil {
+				return nil, err
+			}
+			defer stream.CloseSend()
+
+			err = stream.Send(&envoy_service_discovery.DiscoveryRequest{
+				TypeUrl:       envoy.NetworkPolicyTypeURL,
+				ResourceNames: resourceNames,
+				Node: &envoy_config_core.Node{
+					Id: "host~127.0.0.1~no-id~localdomain",
+				},
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			resp, err := stream.Recv()
+			if err != nil {
+				return nil, err
+			}
+
+			networkPolicies := make(map[string]*cilium.NetworkPolicy, len(resp.Resources))
+			for _, anyResource := range resp.Resources {
+				networkPolicy := &cilium.NetworkPolicy{}
+				err = anypb.UnmarshalTo(anyResource, networkPolicy, proto.UnmarshalOptions{})
+				if err != nil {
+					return nil, err
+				}
+				for _, ip := range networkPolicy.EndpointIps {
+					networkPolicies[ip] = networkPolicy
+				}
+			}
+			return networkPolicies, nil
+		}()
+		attemptCancel()
+		if err == nil {
+			return networkPolicies
+		}
+		lastErr = err
+
+		timer := time.NewTimer(100 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+		case <-timer.C:
+		}
+	}
+
+	require.NoError(t, lastErr)
+	return nil
+}
+
+func logNetworkPolicy(t *testing.T, title string, policy *cilium.NetworkPolicy) {
+	t.Helper()
+
+	if policy == nil {
+		t.Logf("%s: <nil>", title)
+		return
+	}
+
+	t.Logf("%s:\n%s", title, prototext.Format(policy))
 }
 
 func prepareEndpointDirs() (cleanup func(), err error) {
@@ -857,6 +945,10 @@ func (ds *DaemonSuite) testIncrementalPolicy(t *testing.T) {
 		qaBarNetworkPolicy = networkPolicies[QAIPv4Addr.String()]
 		return qaBarNetworkPolicy != nil && len(qaBarNetworkPolicy.IngressPerPortPolicies) == 2
 	}, time.Second*1)
+	if err != nil {
+		networkPolicies = ds.getXDSNetworkPolicies(t, nil)
+		logNetworkPolicy(t, "Timed out waiting for incremental projected NPDS policy", networkPolicies[QAIPv4Addr.String()])
+	}
 	require.NoError(t, err)
 	require.EqualExportedValues(t, &cilium.NetworkPolicy{
 		EndpointIps: []string{QAIPv6Addr.String(), QAIPv4Addr.String()},

--- a/pkg/envoy/secretsync_test.go
+++ b/pkg/envoy/secretsync_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
-	cilium "github.com/cilium/proxy/go/cilium/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -444,10 +443,6 @@ func (*fakeXdsServer) AddAdminListener(port uint16, wg *completion.WaitGroup) {
 }
 
 func (*fakeXdsServer) AddMetricsListener(port uint16, wg *completion.WaitGroup) {
-	panic("unimplemented")
-}
-
-func (*fakeXdsServer) GetNetworkPolicies(resourceNames []string) (map[string]*cilium.NetworkPolicy, error) {
 	panic("unimplemented")
 }
 

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -117,11 +117,6 @@ type XDSServer interface {
 	// responds.
 	DeleteEnvoyResources(ctx context.Context, resources Resources) error
 
-	// GetNetworkPolicies returns the current version of the network policies with the given names.
-	// If resourceNames is empty, all resources are returned.
-	//
-	// Only used for testing
-	GetNetworkPolicies(resourceNames []string) (map[string]*cilium.NetworkPolicy, error)
 	// UpdateNetworkPolicy adds or updates a network policy in the set published to L7 proxies.
 	// When the proxy acknowledges the network policy update, it will result in
 	// a subsequent call to the endpoint's OnProxyPolicyUpdate() function.
@@ -1925,21 +1920,6 @@ func (s *xdsServer) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource) {
 
 func (s *xdsServer) RemoveAllNetworkPolicies() {
 	s.networkPolicyCache.Clear(NetworkPolicyTypeURL)
-}
-
-func (s *xdsServer) GetNetworkPolicies(resourceNames []string) (map[string]*cilium.NetworkPolicy, error) {
-	resources, err := s.networkPolicyCache.GetResources(NetworkPolicyTypeURL, 0, "", resourceNames)
-	if err != nil {
-		return nil, err
-	}
-	networkPolicies := make(map[string]*cilium.NetworkPolicy, len(resources.Resources))
-	for _, res := range resources.Resources {
-		networkPolicy := res.(*cilium.NetworkPolicy)
-		for _, ip := range networkPolicy.EndpointIps {
-			networkPolicies[ip] = networkPolicy
-		}
-	}
-	return networkPolicies, nil
 }
 
 // Resources contains all Envoy resources parsed from a CiliumEnvoyConfig CRD

--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -2221,3 +2221,18 @@ func testXdsServer(t *testing.T) *xdsServer {
 		l7RulesTranslator: envoypolicy.NewEnvoyL7RulesTranslator(logger, nil),
 	}
 }
+
+func (s *xdsServer) GetNetworkPolicies(resourceNames []string) (map[string]*cilium.NetworkPolicy, error) {
+	resources, err := s.networkPolicyCache.GetResources(NetworkPolicyTypeURL, 0, "", resourceNames)
+	if err != nil {
+		return nil, err
+	}
+	networkPolicies := make(map[string]*cilium.NetworkPolicy, len(resources.Resources))
+	for _, res := range resources.Resources {
+		networkPolicy := res.(*cilium.NetworkPolicy)
+		for _, ip := range networkPolicy.EndpointIps {
+			networkPolicies[ip] = networkPolicy
+		}
+	}
+	return networkPolicies, nil
+}

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
 	"github.com/cilium/hive/job"
-	cilium "github.com/cilium/proxy/go/cilium/api"
 	statedbReconciler "github.com/cilium/statedb/reconciler"
 	"github.com/stretchr/testify/require"
 
@@ -179,10 +178,6 @@ func (*fakeXdsServer) AddAdminListener(port uint16, wg *completion.WaitGroup) {
 }
 
 func (*fakeXdsServer) AddMetricsListener(port uint16, wg *completion.WaitGroup) {
-	panic("unimplemented")
-}
-
-func (*fakeXdsServer) GetNetworkPolicies(resourceNames []string) (map[string]*cilium.NetworkPolicy, error) {
 	panic("unimplemented")
 }
 


### PR DESCRIPTION
Fix the bit-rot in daemon/cmd/policy_test.go that is resulting from two recent changes:
- removal of ToRequires/FromRequires from the policy API (commit c98e572b9f policy: Remove support for FromRequires and ToRequires)
- addition of policy precedence support for Envoy policies (commit 928e1cc69b envoy: Support policy precedence)

Remove testing-only GetNetworkPolicies from XDSServer interface.
- Add real out-of-package coverage to daemon package in xds_server_test.go and make daemon test connect to the xDS server on the unix domain socket to get the NetworkPolicy so that we can remove GetNetworkPolicy from the public interface.
- Set the envoy-policy-restore-timeout to 100ms for the daemon tests so
that xDS server starts serving the config quickly enough for the tests.

Policy expectation changes are due to the removal of ToRequires/FromRequires, while the addition or Precedence field is from the latter. Additional allow rules are harmless.

Make daemon tests honor the debug logging setting from environment variables, so that the tests can run with debug logs on.

Change the working directory to a temporary so that endpoint directories can be moved without issues with cross filesystem moves.

Run the tests like this:

PRIVILEGED_TESTS=true INTEGRATION_TESTS=true CILIUM_DEBUG=true go test -exec "sudo -E" ./daemon/cmd

Fixes: #42615
Fixes: #44509
