### PR TITLE
loadbalancing: Expose ReflectorWaitTime via flag

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -906,6 +906,9 @@ data:
 {{- if hasKey .Values.loadBalancer "serviceTopology" }}
   enable-service-topology: {{ .Values.loadBalancer.serviceTopology | quote }}
 {{- end }}
+{{- if hasKey .Values.loadBalancer "reflectorWaitTime" }}
+  lb-reflector-wait-time: {{ .Values.loadBalancer.reflectorWaitTime | quote }}
+{{- end }}
 {{- end }}
 
 {{- if hasKey .Values.maglev "tableSize" }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2539,6 +2539,14 @@ loadBalancer:
   # -- serviceTopology enables K8s Topology Aware Hints -based service
   # endpoints filtering
   serviceTopology: false
+  # -- reflectorWaitTime is the maximum amount of time the K8s reflector waits
+  # to fill its events buffer. A higher wait time will reduce processing of
+  # transient states and increases throughput as it gives bigger batches
+  # downstream for processing. Batching also helps to combine related objects,
+  # e.g. a Service may have multiple associated EndpointSlices and preferably
+  # these would be processed together.
+  # reflectorWaitTime: "500ms"
+
   # -- L7 LoadBalancer
   l7:
     # -- Enable L7 service load balancing via envoy proxy.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2567,6 +2567,14 @@ loadBalancer:
   # endpoints filtering
   serviceTopology: false
 
+  # -- reflectorWaitTime is the maximum amount of time the K8s reflector waits
+  # to fill its events buffer. A higher wait time will reduce processing of
+  # transient states and increases throughput as it gives bigger batches
+  # downstream for processing. Batching also helps to combine related objects,
+  # e.g. a Service may have multiple associated EndpointSlices and preferably
+  # these would be processed together.
+  # reflectorWaitTime: "500ms"
+
   # -- L7 LoadBalancer
   l7:
     # -- Enable L7 service load balancing via envoy proxy.

--- a/pkg/datapath/linux/ipsec/cell_test.go
+++ b/pkg/datapath/linux/ipsec/cell_test.go
@@ -179,7 +179,7 @@ func TestPrivileged_TestIPSecCell(t *testing.T) {
 						WireguardConfig:  fakewireguard.Config{},
 						TunnelConfig:     tunnel.Config{},
 						DaemonConfig:     option.Config,
-						LBConfig:         loadbalancer.Config{},
+						LBConfig:         loadbalancer.DefaultConfig,
 						LBExternalConfig: loadbalancer.ExternalConfig{},
 						LocalNode: node.LocalNode{
 							Node: nodeTypes.Node{

--- a/pkg/loadbalancer/config.go
+++ b/pkg/loadbalancer/config.go
@@ -228,6 +228,14 @@ type UserConfig struct {
 	// Enable dynamic source IP resolution for SNAT via linux's routing table.
 	// The kernel must support this feature.
 	NodePortEnableDynamicSourceLookup bool `mapstructure:"enable-dynamic-source-lookup-nodeport"`
+
+	// ReflectorWaitTime is the maximum amount of time the K8s reflector waits
+	// to fill its events buffer. A higher wait time will reduce processing of
+	// transient states and increases throughput as it gives bigger batches
+	// downstream for processing. Batching also helps to combine related
+	// objects, e.g. a Service may have multiple associated EndpointSlices and
+	// preferably these would be processed together.
+	ReflectorWaitTime time.Duration `mapstructure:"lb-reflector-wait-time"`
 }
 
 // ConfigCell provides the [Config] and [ExternalConfig] configurations.
@@ -333,7 +341,11 @@ func (def UserConfig) Flags(flags *pflag.FlagSet) {
 	flags.Duration("lb-init-wait-timeout", def.InitWaitTimeout, "Amount of time to wait for initialization before reconciling BPF maps")
 	flags.MarkHidden("lb-init-wait-timeout")
 
+	flags.Duration("lb-reflector-wait-time", def.ReflectorWaitTime, "Maximum time the K8s reflector waits to fill its event buffer")
+	flags.MarkHidden("lb-reflector-wait-time")
+
 	flags.Bool(NodePortEnableDynamicSourceLookup, def.NodePortEnableDynamicSourceLookup, "Enable dynamic source IP resolution for SNAT via linux's routing table. The kernel must support this feature.")
+
 }
 
 // NewConfig takes the user-provided configuration, validates and processes it to produce the final
@@ -440,6 +452,10 @@ func NewConfig(log *slog.Logger, userConfig UserConfig, dcfg *option.DaemonConfi
 		return Config{}, fmt.Errorf("The value --%s=%s is not supported as default under annotation mode", LoadBalancerModeName, cfg.LBMode)
 	}
 
+	if cfg.ReflectorWaitTime <= 0 {
+		return Config{}, fmt.Errorf("--lb-reflector-wait-time must be greater than 0, got %s", cfg.ReflectorWaitTime)
+	}
+
 	/* FIXME:
 
 	if cfg.NodePortMode == option.NodePortModeDSR &&
@@ -499,7 +515,8 @@ var DefaultUserConfig = UserConfig{
 
 	EnableServiceTopology: false,
 
-	InitWaitTimeout: 1 * time.Minute,
+	InitWaitTimeout:   1 * time.Minute,
+	ReflectorWaitTime: 500 * time.Millisecond,
 }
 
 var DefaultConfig = Config{

--- a/pkg/loadbalancer/reflectors/k8s.go
+++ b/pkg/loadbalancer/reflectors/k8s.go
@@ -46,13 +46,6 @@ const (
 	// reflectorBufferSize is the maximum size of the event buffer.
 	reflectorBufferSize = 500
 
-	// reflectorWaitTime is the maximum amount of time to try and fill the buffer.
-	// A higher wait time will reduce processing of transient states and increases
-	// throughput as it gives bigger batches downstream for processing. Batching
-	// also helps to combine related objects, e.g. a Service may have multiple
-	// associated EndpointSlices and preferably these would be processed together.
-	reflectorWaitTime = 500 * time.Millisecond
-
 	// K8sInitializerPrefix is the StateDB initializer prefix used here. This can
 	// be used to wait for the tables to be populated just from k8s even when
 	// other initializers are present.
@@ -101,7 +94,7 @@ func (p reflectorParams) waitTime() time.Duration {
 		// Use a much lower wait time in tests to trigger more edge cases and make them faster.
 		return 10 * time.Millisecond
 	}
-	return reflectorWaitTime
+	return p.Config.ReflectorWaitTime
 }
 
 func RegisterK8sReflector(p reflectorParams) {

--- a/pkg/loadbalancer/zz_generated.deepequal.go
+++ b/pkg/loadbalancer/zz_generated.deepequal.go
@@ -388,6 +388,9 @@ func (in *UserConfig) DeepEqual(other *UserConfig) bool {
 	if in.NodePortEnableDynamicSourceLookup != other.NodePortEnableDynamicSourceLookup {
 		return false
 	}
+	if in.ReflectorWaitTime != other.ReflectorWaitTime {
+		return false
+	}
 
 	return true
 }

--- a/pkg/wireguard/agent/cell_test.go
+++ b/pkg/wireguard/agent/cell_test.go
@@ -168,7 +168,7 @@ func TestPrivileged_TestWireGuardCell(t *testing.T) {
 						},
 						TunnelConfig:     tunnel.Config{},
 						DaemonConfig:     option.Config,
-						LBConfig:         loadbalancer.Config{},
+						LBConfig:         loadbalancer.DefaultConfig,
 						LBExternalConfig: loadbalancer.ExternalConfig{},
 						LocalNode: node.LocalNode{
 							Node: nodeTypes.Node{


### PR DESCRIPTION
Some users reported that 500ms might be to long to reflect K8s EndpointSlice updates. For example, this can result in clients trying to connect to terminated pods via ClusterIP.
