### PR TITLE
completion: Prune pending completions after Wait

### DIFF
--- a/pkg/completion/completion.go
+++ b/pkg/completion/completion.go
@@ -19,12 +19,12 @@ type WaitGroup struct {
 	// cancel is the function to call if any pending operation fails, if Wait returns or when cleaning up all resources
 	cancel context.CancelFunc
 
-	// counterLocker locks all calls to AddCompletion and Wait, which must not
-	// be called concurrently.
+	// counterLocker locks all calls to AddCompletionWithCallback and Wait,
+	// which must not be called concurrently.
 	counterLocker lock.Mutex
 
-	// pendingCompletions is the list of Completions returned by
-	// AddCompletion() which have not yet been completed.
+	// pendingCompletions is the list of Completions added to the wait group
+	// which have not yet been completed.
 	pendingCompletions []*Completion
 }
 
@@ -46,23 +46,22 @@ func (wg *WaitGroup) Context() context.Context {
 	return wg.ctx
 }
 
-type idFunc = func() string
+// Owner provides optional debug correlation and wait-time cleanup for a
+// completion created with AddCompletionWithCallback.
+type Owner interface {
+	ID() string
+	CleanupAfterWait(*Completion)
+}
 
 // AddCompletionWithCallback creates a new completion, adds it to the wait
 // group, and returns it. The callback will be called upon completion.
 // Completion can complete in a failure (err != nil)
-func (wg *WaitGroup) AddCompletionWithCallback(id idFunc, callback func(err error)) *Completion {
+func (wg *WaitGroup) AddCompletionWithCallback(owner Owner, callback func(err error)) *Completion {
 	wg.counterLocker.Lock()
 	defer wg.counterLocker.Unlock()
-	c := NewCompletion(id, wg.cancel, callback)
+	c := NewCompletion(owner, wg.cancel, callback)
 	wg.pendingCompletions = append(wg.pendingCompletions, c)
 	return c
-}
-
-// AddCompletion creates a new completion, adds it into the wait group, and
-// returns it.
-func (wg *WaitGroup) AddCompletion(id idFunc) *Completion {
-	return wg.AddCompletionWithCallback(id, nil)
 }
 
 // updateError updates the error value to be returned from Wait()
@@ -87,8 +86,8 @@ func updateError(old, new error) error {
 	return old
 }
 
-// Wait blocks until all completions added by calling AddCompletion are
-// completed, or the context is canceled, whichever happens first.
+// Wait blocks until all completions added to the wait group are completed, or
+// the context is canceled, whichever happens first.
 // Returns the context's error if it is cancelled, nil otherwise.
 // No callbacks of the completions in this wait group will be called after
 // this returns.
@@ -112,6 +111,9 @@ Loop:
 			for _, c := range wg.pendingCompletions[i:] {
 				// 'comp' may have already completed on a different error
 				compErr := c.Complete(ctxErr)
+				if c.owner != nil {
+					c.owner.CleanupAfterWait(c)
+				}
 				err = updateError(err, compErr) // Keep the most severe error value we encounter
 			}
 			// override error with the hanging completion if deadline exceeded
@@ -129,9 +131,6 @@ Loop:
 // Completion provides the Complete callback to be called when an asynchronous
 // computation is completed.
 type Completion struct {
-	// id is used for correlation for debugging only
-	id idFunc
-
 	// cancel is used to cancel the WaitGroup the completion belongs in case of an error
 	cancel context.CancelFunc
 
@@ -145,6 +144,9 @@ type Completion struct {
 	// callback is called when Complete is called the first time.
 	callback func(err error)
 
+	// owner provides an optional debug ID and wait-time cleanup hook.
+	owner Owner
+
 	// err is the error the completion completed with
 	err error
 }
@@ -157,10 +159,10 @@ func (c *Completion) Err() error {
 }
 
 func (c *Completion) Id() string {
-	if c.id == nil {
+	if c.owner == nil {
 		return ""
 	}
-	return c.id()
+	return c.owner.ID()
 }
 
 // Complete notifies of the completion of the asynchronous computation.
@@ -199,9 +201,9 @@ func (c *Completion) Completed() <-chan struct{} {
 
 // NewCompletion creates a Completion which calls a function upon Complete().
 // 'cancel' is called if the associated operation fails for any reason.
-func NewCompletion(id idFunc, cancel context.CancelFunc, callback func(err error)) *Completion {
+func NewCompletion(owner Owner, cancel context.CancelFunc, callback func(err error)) *Completion {
 	return &Completion{
-		id:        id,
+		owner:     owner,
 		cancel:    cancel,
 		completed: make(chan struct{}),
 		callback:  callback,

--- a/pkg/completion/completion_test.go
+++ b/pkg/completion/completion_test.go
@@ -18,6 +18,21 @@ const (
 	CompletionDelay  = 250 * time.Millisecond
 )
 
+type testOwner struct {
+	id      string
+	cleanup func(*Completion)
+}
+
+func (o *testOwner) ID() string {
+	return o.id
+}
+
+func (o *testOwner) CleanupAfterWait(c *Completion) {
+	if o.cleanup != nil {
+		o.cleanup(c)
+	}
+}
+
 func TestNoCompletion(t *testing.T) {
 	var err error
 
@@ -45,7 +60,7 @@ func TestCompletionBeforeWait(t *testing.T) {
 
 	wg := NewWaitGroup(ctx)
 
-	comp := wg.AddCompletion(nil)
+	comp := wg.AddCompletionWithCallback(nil, nil)
 
 	comp.Complete(nil)
 
@@ -62,7 +77,7 @@ func TestCompletionAfterWait(t *testing.T) {
 
 	wg := NewWaitGroup(ctx)
 
-	comp := wg.AddCompletion(nil)
+	comp := wg.AddCompletionWithCallback(nil, nil)
 
 	go func() {
 		time.Sleep(CompletionDelay)
@@ -82,7 +97,7 @@ func TestCompletionAfterWaitWithCancelledContext(t *testing.T) {
 
 	wg := NewWaitGroup(ctx)
 
-	comp := wg.AddCompletion(nil)
+	comp := wg.AddCompletionWithCallback(nil, nil)
 
 	wg.Cancel()
 
@@ -104,9 +119,9 @@ func TestCompletionBeforeAndAfterWait(t *testing.T) {
 
 	wg := NewWaitGroup(ctx)
 
-	comp1 := wg.AddCompletion(nil)
+	comp1 := wg.AddCompletionWithCallback(nil, nil)
 
-	comp2 := wg.AddCompletion(nil)
+	comp2 := wg.AddCompletionWithCallback(nil, nil)
 
 	comp1.Complete(nil)
 
@@ -152,6 +167,53 @@ func TestCompletionTimeout(t *testing.T) {
 	comp.Complete(nil)
 }
 
+func TestCompletionWaitCleanupOnTimeout(t *testing.T) {
+	var cleaned int
+
+	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
+	defer cancel()
+
+	wgCtx, cancel := context.WithTimeout(ctx, WaitGroupTimeout)
+	defer cancel()
+	wg := NewWaitGroup(wgCtx)
+
+	var comp *Completion
+	owner := &testOwner{
+		id: "cleanup-owner",
+		cleanup: func(got *Completion) {
+			require.Same(t, comp, got)
+			cleaned++
+		},
+	}
+	comp = wg.AddCompletionWithCallback(owner, nil)
+
+	err := wg.Wait()
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Equal(t, 1, cleaned)
+}
+
+func TestCompletionWaitCleanupNotCalledOnNormalCompletion(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
+	defer cancel()
+
+	wg := NewWaitGroup(ctx)
+
+	cleaned := false
+	comp := wg.AddCompletionWithCallback(&testOwner{
+		id: "normal-completion-owner",
+		cleanup: func(*Completion) {
+			cleaned = true
+		},
+	}, nil)
+
+	comp.Complete(nil)
+
+	err := wg.Wait()
+	require.NoError(t, err)
+	require.False(t, cleaned)
+}
+
 func TestCompletionMultipleCompleteCalls(t *testing.T) {
 	var err error
 
@@ -161,7 +223,7 @@ func TestCompletionMultipleCompleteCalls(t *testing.T) {
 	// Set a shorter timeout to shorten the test duration.
 	wg := NewWaitGroup(ctx)
 
-	comp := wg.AddCompletion(nil)
+	comp := wg.AddCompletionWithCallback(nil, nil)
 
 	// Complete is idempotent.
 	comp.Complete(nil)

--- a/pkg/completion/doc.go
+++ b/pkg/completion/doc.go
@@ -9,11 +9,11 @@
 //	wg := completion.NewWaitGroup(ctx)
 //
 // For each concurrent computation to wait for, a Completion is created by
-// calling AddCompletion and then passing it to the concurrent computation:
+// calling AddCompletionWithCallback and then passing it to the concurrent computation:
 //
-//	comp1 := wg.AddCompletion()
+//	comp1 := wg.AddCompletionWithCallback(nil, nil)
 //	DoSomethingConcurrently(..., comp1)
-//	comp2 := wg.AddCompletion()
+//	comp2 := wg.AddCompletionWithCallback(nil, nil)
 //	DoSomethingElse(..., comp2)
 //
 // The Completion type provides the Complete and Completed() methods:
@@ -48,7 +48,7 @@
 // A Completion can also be created with a callback, which is called at most
 // once when the Completion is completed before the context is canceled:
 //
-//	comp := wg.AddCompletionWithCallback(func(err error) {
+//	comp := wg.AddCompletionWithCallback(nil, func(err error) {
 //	    if err == nil {
 //	        fmt.Println("completed')
 //	    }

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -81,6 +81,14 @@ func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, hr 
 func (epSync *dummyEpSyncher) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) {
 }
 
+type blockingCompletionOwner string
+
+func (o blockingCompletionOwner) ID() string {
+	return string(o)
+}
+
+func (blockingCompletionOwner) CleanupAfterWait(*completion.Completion) {}
+
 func TestWaitForProxyCompletionsReturnsBlockingCompletionDetailsOnTimeout(t *testing.T) {
 	logger := hivetest.Logger(t)
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
@@ -92,7 +100,7 @@ func TestWaitForProxyCompletionsReturnsBlockingCompletionDetailsOnTimeout(t *tes
 	const blockingCompletionID = "blocking-proxy-policy-update"
 
 	// Leave the completion pending so the wait group times out while waiting on it.
-	proxyWaitGroup.AddCompletion(func() string { return blockingCompletionID })
+	proxyWaitGroup.AddCompletionWithCallback(blockingCompletionOwner(blockingCompletionID), nil)
 
 	err := mgr.waitForProxyCompletions(proxyWaitGroup)
 	require.Error(t, err)

--- a/pkg/envoy/xds/ack.go
+++ b/pkg/envoy/xds/ack.go
@@ -133,6 +133,9 @@ type AckingResourceMutatorWrapper struct {
 
 // pendingCompletion is an update that is pending completion.
 type pendingCompletion struct {
+	// owner is the mutator wrapper that owns the pending completion.
+	owner *AckingResourceMutatorWrapper
+
 	// version is the version to be ACKed.
 	version uint64
 
@@ -168,6 +171,19 @@ func (pc *pendingCompletion) remainingString() string {
 	}
 	sb.WriteString("]")
 	return sb.String()
+}
+
+func (pc *pendingCompletion) ID() string {
+	return pc.remainingString()
+}
+
+func (pc *pendingCompletion) CleanupAfterWait(comp *completion.Completion) {
+	if pc.owner == nil {
+		return
+	}
+	pc.owner.locker.Lock()
+	defer pc.owner.locker.Unlock()
+	delete(pc.owner.pendingCompletions, comp)
 }
 
 // NewAckingResourceMutatorWrapper creates a new AckingResourceMutatorWrapper
@@ -260,11 +276,12 @@ func (m *AckingResourceMutatorWrapper) addCurrentVersionCompletion(typeURL strin
 	}
 
 	comp := &pendingCompletion{
+		owner:                   m,
 		version:                 m.version,
 		typeURL:                 typeURL,
 		remainingNodesResources: remainingNodesResources,
 	}
-	c := wg.AddCompletionWithCallback(comp.remainingString, callback)
+	c := wg.AddCompletionWithCallback(comp, callback)
 	m.pendingCompletions[c] = comp
 	return true
 }
@@ -358,6 +375,7 @@ func (m *AckingResourceMutatorWrapper) Upsert(typeURL string, resourceName strin
 
 	if wait {
 		comp := &pendingCompletion{
+			owner:                   m,
 			version:                 m.version,
 			typeURL:                 typeURL,
 			remainingNodesResources: make(map[string]map[string]struct{}, len(nodeIDs)),
@@ -367,7 +385,7 @@ func (m *AckingResourceMutatorWrapper) Upsert(typeURL string, resourceName strin
 			comp.remainingNodesResources[nodeID][resourceName] = struct{}{}
 		}
 
-		c := wg.AddCompletionWithCallback(comp.remainingString, callback)
+		c := wg.AddCompletionWithCallback(comp, callback)
 		m.pendingCompletions[c] = comp
 	} else if callback != nil {
 		callback(nil)

--- a/pkg/envoy/xds/ack_test.go
+++ b/pkg/envoy/xds/ack_test.go
@@ -381,6 +381,30 @@ func TestCancelCompletions(t *testing.T) {
 	require.Equal(t, 0, metrics.cancel[typeURL2])
 }
 
+func TestTimedOutWaitPrunesPendingCompletion(t *testing.T) {
+	logger := hivetest.Logger(t)
+	ctx, cancel := context.WithTimeout(context.Background(), MaxCompletionDuration)
+	defer cancel()
+
+	typeURL := "type.googleapis.com/envoy.config.v3.DummyConfiguration"
+	wg := completion.NewWaitGroup(ctx)
+	metrics := newMockMetrics()
+
+	cache := NewCache(logger)
+	acker := NewAckingResourceMutatorWrapper(logger, cache, metrics)
+
+	acker.Upsert(typeURL, resources[0].Name, resources[0], []string{node0}, wg, nil)
+	require.Len(t, acker.pendingCompletions, 1)
+
+	err := wg.Wait()
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Empty(t, acker.pendingCompletions)
+	require.Equal(t, 0, metrics.ack[typeURL])
+	require.Equal(t, 0, metrics.nack[typeURL])
+	require.Equal(t, 0, metrics.cancel[typeURL])
+}
+
 func TestUpsertMultipleNodes(t *testing.T) {
 	logger := hivetest.Logger(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -611,7 +635,7 @@ func TestPendingCompletionTimeoutErrorIncludesRemainingDetails(t *testing.T) {
 		},
 	}
 
-	wg.AddCompletion(pending.remainingString)
+	wg.AddCompletionWithCallback(pending, nil)
 
 	err := wg.Wait()
 	require.Error(t, err)

--- a/pkg/envoy/xds/doc.go
+++ b/pkg/envoy/xds/doc.go
@@ -64,8 +64,8 @@
 //	ctx, cancel := context.WithTimeout(..., 5*time.Second)
 //	wg := completion.NewWaitGroup(ctx)
 //	nodes := []string{"10.0.0.1"} // Nodes to wait an ACK from.
-//	lds.Upsert(typeURL, "listener123", listenerA, nodes, wg.AddCompletion())
-//	lds.Delete(typeURL, "listener456", nodes, wg.AddCompletion())
+//	lds.Upsert(typeURL, "listener123", listenerA, nodes, wg, nil)
+//	lds.Delete(typeURL, "listener456", nodes, wg, nil)
 //	wg.Wait()
 //	cancel()
 package xds


### PR DESCRIPTION
When a WaitGroup returns due to cancellation or timeout, let completion owners clean up any state that still points at the abandoned completion.

Use this in the xDS ACK tracker to remove pending ACK waits as soon as the caller stops waiting, instead of retaining them until a later ACK, cancel, or resource mutation happens. This avoids stale xDS pending state holding callback closures after failed proxy updates and keeps subsequent ACK processing limited to live waits.

Completions that end in normal ACK/NACK are already cleaned up by the owner in HandleResourceVersionAck().
