### PR TITLE
lb: support EndpointSlice weights for Maglev backends

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -851,6 +851,95 @@ service creation and cannot be changed during the lifetime of the given
 Kubernetes service. Switching between load balancing algorithms requires
 recreation of a service.
 
+Annotation-based Load Balancing Weight
+**************************************
+
+Backend weights can be assigned on a per-``EndpointSlice`` basis through the
+``service.cilium.io/weight`` annotation.
+
+Weights are only honored for the Service referenced by that ``EndpointSlice``
+when it uses the Maglev load-balancing algorithm, whether Maglev is configured
+globally or selected per service through ``service.cilium.io/lb-algorithm``.
+Per-service algorithm selection requires ``bpf.lbAlgorithmAnnotation=true``.
+This is primarily intended for selectorless Services backed by multiple
+manually managed ``EndpointSlice`` objects, where each ``EndpointSlice`` can
+assign a different weight to the backends it contributes to the Service.
+
+For example, the following selectorless Service is explicitly marked to use
+the Maglev load-balancing algorithm and is backed by two ``EndpointSlice``
+objects with weights ``70`` and ``30``:
+
+.. code-block:: yaml
+
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: example-service
+    annotations:
+      service.cilium.io/lb-algorithm: maglev
+  spec:
+    ports:
+      - name: http
+        port: 8080
+        protocol: TCP
+        targetPort: 8080
+    type: ClusterIP
+  ---
+  apiVersion: discovery.k8s.io/v1
+  kind: EndpointSlice
+  metadata:
+    name: example-service-1
+    labels:
+      kubernetes.io/service-name: example-service
+    annotations:
+      service.cilium.io/weight: "70"
+  addressType: IPv4
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+  endpoints:
+    - addresses:
+        - 10.0.0.11
+    - addresses:
+        - 10.0.0.12
+  ---
+  apiVersion: discovery.k8s.io/v1
+  kind: EndpointSlice
+  metadata:
+    name: example-service-2
+    labels:
+      kubernetes.io/service-name: example-service
+    annotations:
+      service.cilium.io/weight: "30"
+  addressType: IPv4
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+  endpoints:
+    - addresses:
+        - 10.0.0.21
+    - addresses:
+        - 10.0.0.22
+
+The configured weight applies to all backends in a given ``EndpointSlice``.
+Valid values range from ``0`` to ``65535``. A weight of ``0`` marks those
+backends as being in maintenance so that existing connections can continue
+while new traffic is steered to other backends. Invalid values are ignored.
+Weights are relative and do not need to add up to ``100``.
+
+In the example above, new traffic is distributed according to the relative
+weights of the two ``EndpointSlice`` objects, that is, roughly ``70%%`` to the
+backends from ``example-service-1`` and ``30%%`` to the backends from
+``example-service-2``.
+
+If the second ``EndpointSlice`` is later changed from weight ``30`` to
+weight ``0``, all of its backends enter maintenance. Existing connections can
+continue to use them, but new traffic is steered entirely to the remaining
+non-maintenance backends from ``example-service-1``. In other words, the first
+slice now receives ``100%%`` of the new traffic share.
+
 .. _socketlb-host-netns-only:
 
 Socket LoadBalancer Bypass in Pod Namespace

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -671,9 +671,9 @@ powershell
 pprof
 pre
 preconfigured
+preferIpv
 prefilter
 preflight
-preferIpv
 preload
 preloaded
 preloading
@@ -751,6 +751,7 @@ seccomp
 secretName
 secretsBackend
 secretsNamespace
+selectorless
 selftest
 selftests
 serverinfo

--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -137,6 +137,11 @@ const (
 	// - maglev
 	ServiceLoadBalancingAlgorithm = ServicePrefix + "/lb-algorithm"
 
+	// EndpointSliceWeight indicates the load-balancing weight to assign to all
+	// backends in an EndpointSlice. A weight of 0 marks the backends as being in
+	// maintenance.
+	EndpointSliceWeight = ServicePrefix + "/weight"
+
 	// ServiceNodeExposure is the label name used to mark a service to only a
 	// subset of the nodes which match the same value. For all other nodes, this
 	// service is ignored and not installed into their datapath.

--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -14,6 +14,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/cilium/cilium/pkg/annotation"
 	serviceStore "github.com/cilium/cilium/pkg/clustermesh/store"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -159,6 +160,8 @@ type Backend struct {
 	HintsForZones []string
 	Preferred     bool
 	Zone          string
+	Weight        uint16
+	Maintenance   bool
 }
 
 func (b *Backend) DeepEqual(other *Backend) bool {
@@ -168,7 +171,9 @@ func (b *Backend) DeepEqual(other *Backend) bool {
 		b.Conditions == other.Conditions &&
 		slices.Equal(b.HintsForZones, other.HintsForZones) &&
 		b.Preferred == other.Preferred &&
-		b.Zone == other.Zone
+		b.Zone == other.Zone &&
+		b.Weight == other.Weight &&
+		b.Maintenance == other.Maintenance
 }
 
 func (b *Backend) ToPortConfiguration() serviceStore.PortConfiguration {
@@ -268,6 +273,23 @@ func ParseEndpointSliceV1(logger *slog.Logger, ep *slim_discovery_v1.EndpointSli
 		logfields.Name, ep.Name,
 	)
 
+	var weight uint16
+	maintenance := false
+	if value, ok := annotation.Get(ep, annotation.EndpointSliceWeight); ok {
+		parsedWeight, err := strconv.ParseUint(value, 10, 16)
+		if err != nil {
+			logger.Warn("Ignoring invalid EndpointSlice annotation",
+				logfields.Error, err,
+				logfields.Name, ep.Name,
+				logfields.Annotations, annotation.EndpointSliceWeight,
+			)
+		} else if parsedWeight == 0 {
+			maintenance = true
+		} else {
+			weight = uint16(parsedWeight)
+		}
+	}
+
 	// Parse the ports shared by all the backends.
 	ports := make(map[loadbalancer.L4Addr][]string, len(ep.Ports))
 	for _, port := range ep.Ports {
@@ -279,8 +301,10 @@ func ParseEndpointSliceV1(logger *slog.Logger, ep *slim_discovery_v1.EndpointSli
 	for i, sub := range ep.Endpoints {
 		// Construct the backend configuration shared by all the addresses in this slice.
 		backend := &Backend{
-			Conditions: ParseEndpointConditionsV1(sub.Conditions),
-			Ports:      ports,
+			Conditions:  ParseEndpointConditionsV1(sub.Conditions),
+			Ports:       ports,
+			Weight:      weight,
+			Maintenance: maintenance,
 		}
 
 		if sub.NodeName != nil {

--- a/pkg/k8s/endpoints_test.go
+++ b/pkg/k8s/endpoints_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
+	"github.com/cilium/cilium/pkg/annotation"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_discovery_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1"
@@ -876,6 +877,137 @@ func Test_parseK8sEPSlicev1(t *testing.T) {
 					},
 					Conditions:    BackendConditionReady | BackendConditionServing,
 					HintsForZones: []string{"testing"},
+				}
+				return svcEP
+			},
+		},
+		{
+			name: "endpoint slice weight annotation",
+			setupArgs: func() args {
+				return args{
+					eps: &slim_discovery_v1.EndpointSlice{
+						AddressType: slim_discovery_v1.AddressTypeIPv4,
+						ObjectMeta: slim_metav1.ObjectMeta{
+							Name:      meta.Name,
+							Namespace: meta.Namespace,
+							Labels:    meta.Labels,
+							Annotations: map[string]string{
+								annotation.EndpointSliceWeight: "42",
+							},
+						},
+						Endpoints: []slim_discovery_v1.Endpoint{
+							{
+								Addresses: []string{"172.0.0.1"},
+							},
+						},
+						Ports: []slim_discovery_v1.EndpointPort{
+							{
+								Name:     func() *string { a := "http-test-svc"; return &a }(),
+								Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+								Port:     func() *int32 { a := int32(8080); return &a }(),
+							},
+						},
+					},
+				}
+			},
+			setupWanted: func() *Endpoints {
+				svcEP := newEmptyEndpoints()
+				svcEP.ObjectMeta.Annotations = map[string]string{
+					annotation.EndpointSliceWeight: "42",
+				}
+				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.1")] = &Backend{
+					Ports: map[loadbalancer.L4Addr][]string{
+						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
+					},
+					Conditions: BackendConditionReady | BackendConditionServing,
+					Weight:     42,
+				}
+				return svcEP
+			},
+		},
+		{
+			name: "endpoint slice zero weight annotation enables maintenance",
+			setupArgs: func() args {
+				return args{
+					eps: &slim_discovery_v1.EndpointSlice{
+						AddressType: slim_discovery_v1.AddressTypeIPv4,
+						ObjectMeta: slim_metav1.ObjectMeta{
+							Name:      meta.Name,
+							Namespace: meta.Namespace,
+							Labels:    meta.Labels,
+							Annotations: map[string]string{
+								annotation.EndpointSliceWeight: "0",
+							},
+						},
+						Endpoints: []slim_discovery_v1.Endpoint{
+							{
+								Addresses: []string{"172.0.0.1"},
+							},
+						},
+						Ports: []slim_discovery_v1.EndpointPort{
+							{
+								Name:     func() *string { a := "http-test-svc"; return &a }(),
+								Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+								Port:     func() *int32 { a := int32(8080); return &a }(),
+							},
+						},
+					},
+				}
+			},
+			setupWanted: func() *Endpoints {
+				svcEP := newEmptyEndpoints()
+				svcEP.ObjectMeta.Annotations = map[string]string{
+					annotation.EndpointSliceWeight: "0",
+				}
+				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.1")] = &Backend{
+					Ports: map[loadbalancer.L4Addr][]string{
+						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
+					},
+					Conditions:  BackendConditionReady | BackendConditionServing,
+					Maintenance: true,
+				}
+				return svcEP
+			},
+		},
+		{
+			name: "invalid endpoint slice weight annotation falls back to default behavior",
+			setupArgs: func() args {
+				return args{
+					eps: &slim_discovery_v1.EndpointSlice{
+						AddressType: slim_discovery_v1.AddressTypeIPv4,
+						ObjectMeta: slim_metav1.ObjectMeta{
+							Name:      meta.Name,
+							Namespace: meta.Namespace,
+							Labels:    meta.Labels,
+							Annotations: map[string]string{
+								annotation.EndpointSliceWeight: "abc",
+							},
+						},
+						Endpoints: []slim_discovery_v1.Endpoint{
+							{
+								Addresses: []string{"172.0.0.1"},
+							},
+						},
+						Ports: []slim_discovery_v1.EndpointPort{
+							{
+								Name:     func() *string { a := "http-test-svc"; return &a }(),
+								Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+								Port:     func() *int32 { a := int32(8080); return &a }(),
+							},
+						},
+					},
+				}
+			},
+			setupWanted: func() *Endpoints {
+				svcEP := newEmptyEndpoints()
+				svcEP.ObjectMeta.Annotations = map[string]string{
+					annotation.EndpointSliceWeight: "abc",
+				}
+				svcEP.Backends[cmtypes.MustParseAddrCluster("172.0.0.1")] = &Backend{
+					Ports: map[loadbalancer.L4Addr][]string{
+						loadbalancer.NewL4Addr(loadbalancer.TCP, 8080): {"http-test-svc"},
+					},
+					Conditions: BackendConditionReady | BackendConditionServing,
 				}
 				return svcEP
 			},

--- a/pkg/loadbalancer/reflectors/conversions.go
+++ b/pkg/loadbalancer/reflectors/conversions.go
@@ -430,6 +430,8 @@ func convertEndpoints(rawlog *slog.Logger, cfg loadbalancer.ExternalConfig, svcN
 
 				var state loadbalancer.BackendState
 				switch {
+				case be.Maintenance:
+					state = loadbalancer.BackendStateMaintenance
 				case be.Conditions.IsReady():
 					// A backend that is ready (regardless of serving and terminating) is considered
 					// active. We may see backends that are ready+terminating if 'PublishNotReadyAddresses'
@@ -455,11 +457,15 @@ func convertEndpoints(rawlog *slog.Logger, cfg loadbalancer.ExternalConfig, svcN
 					// to existing connections when a backend readiness is flapping.
 					state = loadbalancer.BackendStateMaintenance
 				}
+				weight := be.Weight
+				if weight == 0 && !be.Maintenance {
+					weight = loadbalancer.DefaultBackendWeight
+				}
 				bep := loadbalancer.Backend{
 					Address:   l3n4Addr,
 					NodeName:  be.NodeName,
 					PortNames: portNames,
-					Weight:    loadbalancer.DefaultBackendWeight,
+					Weight:    weight,
 					State:     state,
 				}
 				if be.Zone != "" {

--- a/pkg/loadbalancer/reflectors/k8s_test.go
+++ b/pkg/loadbalancer/reflectors/k8s_test.go
@@ -6,13 +6,18 @@ package reflectors
 import (
 	"log/slog"
 	"maps"
+	"slices"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
 
+	"github.com/cilium/cilium/pkg/annotation"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/k8s"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_discovery_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/k8s/testutils"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/source"
@@ -67,4 +72,74 @@ func BenchmarkConvertEndpoints(b *testing.B) {
 		convertEndpoints(logger, benchmarkExternalConfig, eps.ServiceName, backends)
 	}
 	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "endpoints/sec")
+}
+
+func TestConvertEndpointsRespectsEndpointSliceWeight(t *testing.T) {
+	logger := hivetest.Logger(t)
+	eps := k8s.ParseEndpointSliceV1(logger, &slim_discovery_v1.EndpointSlice{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "slice",
+			Namespace: "default",
+			Labels: map[string]string{
+				slim_discovery_v1.LabelServiceName: "svc",
+			},
+			Annotations: map[string]string{
+				annotation.EndpointSliceWeight: "42",
+			},
+		},
+		AddressType: slim_discovery_v1.AddressTypeIPv4,
+		Endpoints: []slim_discovery_v1.Endpoint{
+			{Addresses: []string{"10.0.0.1"}},
+		},
+		Ports: []slim_discovery_v1.EndpointPort{
+			{
+				Name:     func() *string { a := "http"; return &a }(),
+				Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+				Port:     func() *int32 { a := int32(80); return &a }(),
+			},
+		},
+	})
+
+	backends := slices.Collect(convertEndpoints(logger, benchmarkExternalConfig, eps.ServiceName, maps.All(eps.Backends)))
+	require.Len(t, backends, 1)
+	require.Equal(t, uint16(42), backends[0].Weight)
+	require.Equal(t, loadbalancer.BackendStateActive, backends[0].State)
+	require.Equal(t, cmtypes.MustParseAddrCluster("10.0.0.1"), backends[0].Address.AddrCluster())
+}
+
+func TestConvertEndpointsWeightZeroForcesMaintenance(t *testing.T) {
+	logger := hivetest.Logger(t)
+	eps := k8s.ParseEndpointSliceV1(logger, &slim_discovery_v1.EndpointSlice{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "slice",
+			Namespace: "default",
+			Labels: map[string]string{
+				slim_discovery_v1.LabelServiceName: "svc",
+			},
+			Annotations: map[string]string{
+				annotation.EndpointSliceWeight: "0",
+			},
+		},
+		AddressType: slim_discovery_v1.AddressTypeIPv4,
+		Endpoints: []slim_discovery_v1.Endpoint{
+			{
+				Addresses: []string{"10.0.0.1"},
+				Conditions: slim_discovery_v1.EndpointConditions{
+					Ready: func() *bool { b := true; return &b }(),
+				},
+			},
+		},
+		Ports: []slim_discovery_v1.EndpointPort{
+			{
+				Name:     func() *string { a := "http"; return &a }(),
+				Protocol: func() *slim_corev1.Protocol { a := slim_corev1.ProtocolTCP; return &a }(),
+				Port:     func() *int32 { a := int32(80); return &a }(),
+			},
+		},
+	})
+
+	backends := slices.Collect(convertEndpoints(logger, benchmarkExternalConfig, eps.ServiceName, maps.All(eps.Backends)))
+	require.Len(t, backends, 1)
+	require.Zero(t, backends[0].Weight)
+	require.Equal(t, loadbalancer.BackendStateMaintenance, backends[0].State)
 }

--- a/pkg/loadbalancer/tests/testdata/endpointslice-weight.txtar
+++ b/pkg/loadbalancer/tests/testdata/endpointslice-weight.txtar
@@ -1,0 +1,312 @@
+#! --bpf-lb-algorithm=maglev --bpf-lb-external-clusterip=true --lb-test-fault-probability=0.0
+#
+# Test EndpointSlice slice-level weights and maintenance handling.
+
+hive start
+
+# Start with two EndpointSlices for the same service. Each slice contributes
+# two backends, and each backend inherits the slice weight (70/30).
+cp endpointslice1.yaml.tmpl endpointslice1.yaml
+replace '$WEIGHT1' '70' endpointslice1.yaml
+cp endpointslice2.yaml.tmpl endpointslice2.yaml
+replace '$WEIGHT2' '30' endpointslice2.yaml
+
+k8s/add service.yaml endpointslice1.yaml endpointslice2.yaml
+db/cmp backends backends-weighted.expected.table
+db/show backends -f json -o backends-weighted.json
+cmp backends-weighted.json backends-weighted.expected.json
+
+lb/maps-dump lbmaps.actual
+* cmp lbmaps-weighted.expected lbmaps.actual
+
+# Mark the first EndpointSlice as weight 0. Both backends from that slice
+# should enter maintenance and disappear from the Maglev table, while the
+# backends from the other slice remain active.
+cp endpointslice1.yaml.tmpl endpointslice1.yaml
+replace '$WEIGHT1' '0' endpointslice1.yaml
+k8s/update endpointslice1.yaml
+
+db/cmp backends backends-maintenance.expected.table
+db/show backends -f json -o backends-maintenance.json
+cmp backends-maintenance.json backends-maintenance.expected.json
+
+lb/maps-dump lbmaps.actual
+* cmp lbmaps-maintenance.expected lbmaps.actual
+
+k8s/delete service.yaml endpointslice1.yaml endpointslice2.yaml
+
+-- lbmaps-maintenance.expected --
+BE: ID=1 ADDR=10.244.0.112:8081/TCP STATE=maintenance
+BE: ID=2 ADDR=10.244.0.113:8081/TCP STATE=maintenance
+BE: ID=3 ADDR=10.244.0.122:8081/TCP STATE=active
+BE: ID=4 ADDR=10.244.0.123:8081/TCP STATE=active
+MAGLEV: ID=1 INNER=[3(511), 4(510)]
+REV: ID=1 ADDR=10.96.116.33:8081
+SVC: ID=0 ADDR=10.96.116.33:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP
+SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
+SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
+-- lbmaps-weighted.expected --
+BE: ID=1 ADDR=10.244.0.112:8081/TCP STATE=active
+BE: ID=2 ADDR=10.244.0.113:8081/TCP STATE=active
+BE: ID=3 ADDR=10.244.0.122:8081/TCP STATE=active
+BE: ID=4 ADDR=10.244.0.123:8081/TCP STATE=active
+MAGLEV: ID=1 INNER=[1(358), 2(357), 3(153), 4(153)]
+REV: ID=1 ADDR=10.96.116.33:8081
+SVC: ID=0 ADDR=10.96.116.33:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=4 QCOUNT=0 FLAGS=ClusterIP
+SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
+SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
+SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=3 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
+SVC: ID=1 ADDR=10.96.116.33:8081/TCP SLOT=4 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP
+-- backends-weighted.expected.table --
+Service              Address                NodeName
+test/eps-weight-svc  10.244.0.112:8081/TCP  eps-weight-control-plane
+test/eps-weight-svc  10.244.0.113:8081/TCP  eps-weight-control-plane
+test/eps-weight-svc  10.244.0.122:8081/TCP  eps-weight-control-plane
+test/eps-weight-svc  10.244.0.123:8081/TCP  eps-weight-control-plane
+
+-- backends-maintenance.expected.table --
+Service              Address                State        NodeName
+test/eps-weight-svc  10.244.0.112:8081/TCP  maintenance  eps-weight-control-plane
+test/eps-weight-svc  10.244.0.113:8081/TCP  maintenance  eps-weight-control-plane
+test/eps-weight-svc  10.244.0.122:8081/TCP  active       eps-weight-control-plane
+test/eps-weight-svc  10.244.0.123:8081/TCP  active       eps-weight-control-plane
+
+-- backends-weighted.expected.json --
+{
+  "ServiceName": "test/eps-weight-svc",
+  "Address": "10.244.0.112:8081/TCP",
+  "PortNames": [
+    "http"
+  ],
+  "Weight": 70,
+  "NodeName": "eps-weight-control-plane",
+  "Zone": null,
+  "ClusterID": 0,
+  "Source": "k8s",
+  "State": 0,
+  "Unhealthy": false,
+  "UnhealthyUpdatedAt": null
+}
+{
+  "ServiceName": "test/eps-weight-svc",
+  "Address": "10.244.0.113:8081/TCP",
+  "PortNames": [
+    "http"
+  ],
+  "Weight": 70,
+  "NodeName": "eps-weight-control-plane",
+  "Zone": null,
+  "ClusterID": 0,
+  "Source": "k8s",
+  "State": 0,
+  "Unhealthy": false,
+  "UnhealthyUpdatedAt": null
+}
+{
+  "ServiceName": "test/eps-weight-svc",
+  "Address": "10.244.0.122:8081/TCP",
+  "PortNames": [
+    "http"
+  ],
+  "Weight": 30,
+  "NodeName": "eps-weight-control-plane",
+  "Zone": null,
+  "ClusterID": 0,
+  "Source": "k8s",
+  "State": 0,
+  "Unhealthy": false,
+  "UnhealthyUpdatedAt": null
+}
+{
+  "ServiceName": "test/eps-weight-svc",
+  "Address": "10.244.0.123:8081/TCP",
+  "PortNames": [
+    "http"
+  ],
+  "Weight": 30,
+  "NodeName": "eps-weight-control-plane",
+  "Zone": null,
+  "ClusterID": 0,
+  "Source": "k8s",
+  "State": 0,
+  "Unhealthy": false,
+  "UnhealthyUpdatedAt": null
+}
+-- backends-maintenance.expected.json --
+{
+  "ServiceName": "test/eps-weight-svc",
+  "Address": "10.244.0.112:8081/TCP",
+  "PortNames": [
+    "http"
+  ],
+  "Weight": 0,
+  "NodeName": "eps-weight-control-plane",
+  "Zone": null,
+  "ClusterID": 0,
+  "Source": "k8s",
+  "State": 4,
+  "Unhealthy": false,
+  "UnhealthyUpdatedAt": null
+}
+{
+  "ServiceName": "test/eps-weight-svc",
+  "Address": "10.244.0.113:8081/TCP",
+  "PortNames": [
+    "http"
+  ],
+  "Weight": 0,
+  "NodeName": "eps-weight-control-plane",
+  "Zone": null,
+  "ClusterID": 0,
+  "Source": "k8s",
+  "State": 4,
+  "Unhealthy": false,
+  "UnhealthyUpdatedAt": null
+}
+{
+  "ServiceName": "test/eps-weight-svc",
+  "Address": "10.244.0.122:8081/TCP",
+  "PortNames": [
+    "http"
+  ],
+  "Weight": 30,
+  "NodeName": "eps-weight-control-plane",
+  "Zone": null,
+  "ClusterID": 0,
+  "Source": "k8s",
+  "State": 0,
+  "Unhealthy": false,
+  "UnhealthyUpdatedAt": null
+}
+{
+  "ServiceName": "test/eps-weight-svc",
+  "Address": "10.244.0.123:8081/TCP",
+  "PortNames": [
+    "http"
+  ],
+  "Weight": 30,
+  "NodeName": "eps-weight-control-plane",
+  "Zone": null,
+  "ClusterID": 0,
+  "Source": "k8s",
+  "State": 0,
+  "Unhealthy": false,
+  "UnhealthyUpdatedAt": null
+}
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2023-02-02T01:21:10Z"
+  name: eps-weight-svc
+  namespace: test
+  resourceVersion: "663"
+  uid: be7e85d4-6d27-400b-aff2-bd7284837fc9
+spec:
+  clusterIP: 10.96.116.33
+  clusterIPs:
+  - 10.96.116.33
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - port: 8081
+    protocol: TCP
+    targetPort: 8081
+  selector:
+    app: eps-weight-server
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}
+
+-- endpointslice1.yaml.tmpl --
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  annotations:
+    service.cilium.io/weight: "$WEIGHT1"
+  creationTimestamp: "2023-02-02T01:21:10Z"
+  generateName: eps-weight-svc-
+  generation: 1
+  labels:
+    endpointslice.kubernetes.io/managed-by: endpointslice-controller.k8s.io
+    kubernetes.io/service-name: eps-weight-svc
+  name: eps-weight-svc-a
+  namespace: test
+  ownerReferences:
+  - apiVersion: v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Service
+    name: eps-weight-svc
+    uid: be7e85d4-6d27-400b-aff2-bd7284837fc9
+  resourceVersion: "729"
+  uid: ed13283f-c92e-4531-ae1b-f6d6aa4463b7
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.0.112
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: eps-weight-control-plane
+- addresses:
+  - 10.244.0.113
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: eps-weight-control-plane
+ports:
+- name: http
+  port: 8081
+  protocol: TCP
+
+-- endpointslice2.yaml.tmpl --
+kind: EndpointSlice
+apiVersion: discovery.k8s.io/v1
+metadata:
+  annotations:
+    service.cilium.io/weight: "$WEIGHT2"
+  creationTimestamp: "2023-02-02T01:21:10Z"
+  generateName: eps-weight-svc-
+  generation: 1
+  labels:
+    endpointslice.kubernetes.io/managed-by: endpointslice-controller.k8s.io
+    kubernetes.io/service-name: eps-weight-svc
+  name: eps-weight-svc-b
+  namespace: test
+  ownerReferences:
+  - apiVersion: v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Service
+    name: eps-weight-svc
+    uid: be7e85d4-6d27-400b-aff2-bd7284837fc9
+  resourceVersion: "730"
+  uid: fd13283f-c92e-4531-ae1b-f6d6aa4463b8
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.0.122
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: eps-weight-control-plane
+- addresses:
+  - 10.244.0.123
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: eps-weight-control-plane
+ports:
+- name: http
+  port: 8081
+  protocol: TCP


### PR DESCRIPTION
This change adds support for configuring backend weights on Kubernetes EndpointSlice objects via the `service.cilium.io/weight` annotation.

Weights are only honored for Services using the Maglev load-balancing algorithm.

A weight of 0 marks all backends in the EndpointSlice as being in maintenance, allowing existing connections to continue while steering new traffic to other backends.

Invalid weight values are ignored.

Fixes: #40190
Relates to: #45654 (~ GW API TCPRoute/UDPRoute)

cc @eminaktas  - FYI. As discussed this might be eventually used by the GW API TCP/UDP-Route implementation.