### PR TITLE
docs: Document BTF as a requirement

### DIFF
--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -161,6 +161,7 @@ linked, either choice is valid.
         CONFIG_BPF_JIT=y
         CONFIG_NET_CLS_ACT=y
         CONFIG_NET_SCH_INGRESS=y
+        CONFIG_DEBUG_INFO_BTF=y
         CONFIG_CRYPTO_SHA1=y
         CONFIG_CRYPTO_USER_API_HASH=y
         CONFIG_CGROUPS=y


### PR DESCRIPTION
Cilium requires the kernel config `CONFIG_DEBUG_INFO_BTF` to be enabled since commit 6a262777bebc ("bpf: Make snat_v6_needs_masquerade global"). Even without this recent change needed to address complexity issues, BTF would soon be required for other features. It's becoming a core requirement of many BPF features, such as kfuncs, and as such is going to be difficult to avoid.

Fixes: https://github.com/cilium/cilium/pull/44544.
Fixes: https://github.com/cilium/cilium/issues/45224.