### PR TITLE
bpf: local_delivery: condense usage of skb cb slots

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -2018,7 +2018,8 @@ static __always_inline
 int tail_ipv6_policy(struct __ctx_buff *ctx)
 {
 	struct ipv6_ct_tuple tuple = {};
-	bool do_redirect = ctx_load_meta(ctx, CB_DELIVERY_REDIRECT);
+	__u32 delivery_flags = ctx_load_meta(ctx, CB_DELIVERY_FLAGS);
+	bool do_redirect = delivery_flags & CB_DELIVERY_FLAGS_REDIRECT;
 	__u32 src_label = ctx_load_and_clear_meta(ctx, CB_SRC_LABEL);
 	bool from_host = ctx_load_and_clear_meta(ctx, CB_FROM_HOST);
 	bool from_tunnel = false;
@@ -2330,7 +2331,8 @@ static __always_inline
 int tail_ipv4_policy(struct __ctx_buff *ctx)
 {
 	struct ipv4_ct_tuple tuple = {};
-	bool do_redirect = ctx_load_meta(ctx, CB_DELIVERY_REDIRECT);
+	__u32 delivery_flags = ctx_load_meta(ctx, CB_DELIVERY_FLAGS);
+	bool do_redirect = delivery_flags & CB_DELIVERY_FLAGS_REDIRECT;
 	__u32 src_label = ctx_load_and_clear_meta(ctx, CB_SRC_LABEL);
 	bool from_host = ctx_load_and_clear_meta(ctx, CB_FROM_HOST);
 	bool from_tunnel = false;

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -2029,8 +2029,13 @@ int tail_ipv6_policy(struct __ctx_buff *ctx)
 	__s8 ext_err = 0;
 	int ret;
 
+	if (delivery_flags & CB_DELIVERY_FLAGS_FROM_HOST)
+		from_host = true;
+
 #ifdef HAVE_ENCAP
 	from_tunnel = ctx_load_and_clear_meta(ctx, CB_FROM_TUNNEL);
+	if (delivery_flags & CB_DELIVERY_FLAGS_FROM_TUNNEL)
+		from_tunnel = true;
 #endif
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6)) {
@@ -2342,10 +2347,15 @@ int tail_ipv4_policy(struct __ctx_buff *ctx)
 	__s8 ext_err = 0;
 	int ret;
 
+	if (delivery_flags & CB_DELIVERY_FLAGS_FROM_HOST)
+		from_host = true;
+
 	ctx_store_meta(ctx, CB_CLUSTER_ID_INGRESS, 0);
 
 #ifdef HAVE_ENCAP
 	from_tunnel = ctx_load_and_clear_meta(ctx, CB_FROM_TUNNEL);
+	if (delivery_flags & CB_DELIVERY_FLAGS_FROM_TUNNEL)
+		from_tunnel = true;
 #endif
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4)) {

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -306,6 +306,8 @@ enum metric_dir {
 #define TC_INDEX_F_SKIP_HOST_FIREWALL	16
 
 #define CB_DELIVERY_FLAGS_REDIRECT	(1 << 0)
+#define CB_DELIVERY_FLAGS_FROM_HOST	(1 << 1)
+#define CB_DELIVERY_FLAGS_FROM_TUNNEL	(1 << 2)
 
 #define CB_NAT_FLAGS_REVDNAT_ONLY	(1 << 0)
 

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -305,6 +305,8 @@ enum metric_dir {
 #define TC_INDEX_F_SKIP_HEALTH_CHECK	8
 #define TC_INDEX_F_SKIP_HOST_FIREWALL	16
 
+#define CB_DELIVERY_FLAGS_REDIRECT	(1 << 0)
+
 #define CB_NAT_FLAGS_REVDNAT_ONLY	(1 << 0)
 
 /*
@@ -327,7 +329,7 @@ enum {
 #define CB_SRV6_SID_1		CB_SRC_LABEL	/* Alias, non-overlapping */
 #define CB_VERDICT		CB_SRC_LABEL	/* Alias, non-overlapping */
 	CB_1,
-#define	CB_DELIVERY_REDIRECT	CB_1		/* Alias, non-overlapping */
+#define	CB_DELIVERY_FLAGS	CB_1		/* Alias, non-overlapping */
 #define	CB_NAT_46X64		CB_1		/* Alias, non-overlapping */
 #define	CB_ADDR_V4		CB_1		/* Alias, non-overlapping */
 #define	CB_ADDR_V6_1		CB_1		/* Alias, non-overlapping */

--- a/bpf/lib/local_delivery.h
+++ b/bpf/lib/local_delivery.h
@@ -109,8 +109,13 @@ local_delivery_fill_meta(struct __ctx_buff *ctx, __u32 seclabel,
 			 bool delivery_redirect, bool from_host,
 			 bool from_tunnel, __u32 cluster_id)
 {
+	__u32 delivery_flags = 0;
+
+	if (delivery_redirect)
+		delivery_flags |= CB_DELIVERY_FLAGS_REDIRECT;
+
 	ctx_store_meta(ctx, CB_SRC_LABEL, seclabel);
-	ctx_store_meta(ctx, CB_DELIVERY_REDIRECT, delivery_redirect ? 1 : 0);
+	ctx_store_meta(ctx, CB_DELIVERY_FLAGS, delivery_flags);
 	ctx_store_meta(ctx, CB_FROM_HOST, from_host ? 1 : 0);
 	ctx_store_meta(ctx, CB_FROM_TUNNEL, from_tunnel ? 1 : 0);
 	ctx_store_meta(ctx, CB_CLUSTER_ID_INGRESS, cluster_id);

--- a/bpf/lib/local_delivery.h
+++ b/bpf/lib/local_delivery.h
@@ -113,6 +113,10 @@ local_delivery_fill_meta(struct __ctx_buff *ctx, __u32 seclabel,
 
 	if (delivery_redirect)
 		delivery_flags |= CB_DELIVERY_FLAGS_REDIRECT;
+	if (from_host)
+		delivery_flags |= CB_DELIVERY_FLAGS_FROM_HOST;
+	if (from_tunnel)
+		delivery_flags |= CB_DELIVERY_FLAGS_FROM_TUNNEL;
 
 	ctx_store_meta(ctx, CB_SRC_LABEL, seclabel);
 	ctx_store_meta(ctx, CB_DELIVERY_FLAGS, delivery_flags);

--- a/bpf/tests/inter_cluster_snat_clusterip_backend_overlay.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_backend_overlay.c
@@ -239,8 +239,12 @@ int from_overlay_syn_check(struct __ctx_buff *ctx)
 		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0xd71f));
 
 	meta = ctx_load_meta(ctx, CB_DELIVERY_FLAGS);
-	if (meta != CB_DELIVERY_FLAGS_REDIRECT)
-		test_fatal("skb->cb[CB_DELIVERY_FLAGS] should be 1, got %d", meta);
+	if (!(meta & CB_DELIVERY_FLAGS_REDIRECT))
+		test_fatal("skb->cb[CB_DELIVERY_FLAGS] should have CB_DELIVERY_FLAGS_REDIRECT");
+	if (meta & CB_DELIVERY_FLAGS_FROM_HOST)
+		test_fatal("skb->cb[CB_DELIVERY_FLAGS] has CB_DELIVERY_FLAGS_FROM_HOST");
+	if (!(meta & CB_DELIVERY_FLAGS_FROM_TUNNEL))
+		test_fatal("skb->cb[CB_DELIVERY_FLAGS] should have CB_DELIVERY_FLAGS_FROM_TUNNEL");
 
 	meta = ctx_load_meta(ctx, CB_SRC_LABEL);
 	if (meta != CLIENT_IDENTITY)
@@ -411,8 +415,12 @@ int from_overlay_ack_check(struct __ctx_buff *ctx)
 		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0xd711));
 
 	meta = ctx_load_meta(ctx, CB_DELIVERY_FLAGS);
-	if (meta != CB_DELIVERY_FLAGS_REDIRECT)
-		test_fatal("skb->cb[CB_DELIVERY_FLAGS] should be 1, got %d", meta);
+	if (!(meta & CB_DELIVERY_FLAGS_REDIRECT))
+		test_fatal("skb->cb[CB_DELIVERY_FLAGS] should have CB_DELIVERY_FLAGS_REDIRECT");
+	if (meta & CB_DELIVERY_FLAGS_FROM_HOST)
+		test_fatal("skb->cb[CB_DELIVERY_FLAGS] has CB_DELIVERY_FLAGS_FROM_HOST");
+	if (!(meta & CB_DELIVERY_FLAGS_FROM_TUNNEL))
+		test_fatal("skb->cb[CB_DELIVERY_FLAGS] should have CB_DELIVERY_FLAGS_FROM_TUNNEL");
 
 	meta = ctx_load_meta(ctx, CB_SRC_LABEL);
 	if (meta != CLIENT_IDENTITY)

--- a/bpf/tests/inter_cluster_snat_clusterip_backend_overlay.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_backend_overlay.c
@@ -238,9 +238,9 @@ int from_overlay_syn_check(struct __ctx_buff *ctx)
 	if (l4->check != bpf_htons(0xd71f))
 		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0xd71f));
 
-	meta = ctx_load_meta(ctx, CB_DELIVERY_REDIRECT);
-	if (meta != 1)
-		test_fatal("skb->cb[CB_DELIVERY_REDIRECT] should be 1, got %d", meta);
+	meta = ctx_load_meta(ctx, CB_DELIVERY_FLAGS);
+	if (meta != CB_DELIVERY_FLAGS_REDIRECT)
+		test_fatal("skb->cb[CB_DELIVERY_FLAGS] should be 1, got %d", meta);
 
 	meta = ctx_load_meta(ctx, CB_SRC_LABEL);
 	if (meta != CLIENT_IDENTITY)
@@ -410,9 +410,9 @@ int from_overlay_ack_check(struct __ctx_buff *ctx)
 	if (l4->check != bpf_htons(0xd711))
 		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0xd711));
 
-	meta = ctx_load_meta(ctx, CB_DELIVERY_REDIRECT);
-	if (meta != 1)
-		test_fatal("skb->cb[CB_DELIVERY_REDIRECT] should be 1, got %d", meta);
+	meta = ctx_load_meta(ctx, CB_DELIVERY_FLAGS);
+	if (meta != CB_DELIVERY_FLAGS_REDIRECT)
+		test_fatal("skb->cb[CB_DELIVERY_FLAGS] should be 1, got %d", meta);
 
 	meta = ctx_load_meta(ctx, CB_SRC_LABEL);
 	if (meta != CLIENT_IDENTITY)

--- a/bpf/tests/inter_cluster_snat_clusterip_client_overlay.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_client_overlay.c
@@ -337,8 +337,12 @@ int from_overlay_synack_check(struct __ctx_buff *ctx)
 		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x8f65));
 
 	meta = ctx_load_meta(ctx, CB_DELIVERY_FLAGS);
-	if (meta != CB_DELIVERY_FLAGS_REDIRECT)
-		test_fatal("skb->cb[CB_DELIVERY_FLAGS] should be 1, got %d", meta);
+	if (!(meta & CB_DELIVERY_FLAGS_REDIRECT))
+		test_fatal("skb->cb[CB_DELIVERY_FLAGS] should have CB_DELIVERY_FLAGS_REDIRECT");
+	if (meta & CB_DELIVERY_FLAGS_FROM_HOST)
+		test_fatal("skb->cb[CB_DELIVERY_FLAGS] has CB_DELIVERY_FLAGS_FROM_HOST");
+	if (!(meta & CB_DELIVERY_FLAGS_FROM_TUNNEL))
+		test_fatal("skb->cb[CB_DELIVERY_FLAGS] should have CB_DELIVERY_FLAGS_FROM_TUNNEL");
 
 	meta = ctx_load_meta(ctx, CB_SRC_LABEL);
 	if (meta != BACKEND_IDENTITY)

--- a/bpf/tests/inter_cluster_snat_clusterip_client_overlay.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_client_overlay.c
@@ -336,9 +336,9 @@ int from_overlay_synack_check(struct __ctx_buff *ctx)
 	if (l4->check != bpf_htons(0x8f65))
 		test_fatal("L4 checksum is invalid: %x != %x", l4->check, bpf_htons(0x8f65));
 
-	meta = ctx_load_meta(ctx, CB_DELIVERY_REDIRECT);
-	if (meta != 1)
-		test_fatal("skb->cb[CB_DELIVERY_REDIRECT] should be 1, got %d", meta);
+	meta = ctx_load_meta(ctx, CB_DELIVERY_FLAGS);
+	if (meta != CB_DELIVERY_FLAGS_REDIRECT)
+		test_fatal("skb->cb[CB_DELIVERY_FLAGS] should be 1, got %d", meta);
 
 	meta = ctx_load_meta(ctx, CB_SRC_LABEL);
 	if (meta != BACKEND_IDENTITY)

--- a/bpf/tests/tc_redirect_host.h
+++ b/bpf/tests/tc_redirect_host.h
@@ -97,7 +97,7 @@ mock_tail_call_dynamic(struct __ctx_buff *ctx __maybe_unused,
  */
 int mock_tail_policy(struct __ctx_buff *ctx)
 {
-	bool do_redirect = ctx_load_meta(ctx, CB_DELIVERY_REDIRECT);
+	bool do_redirect = ctx_load_meta(ctx, CB_DELIVERY_FLAGS) & CB_DELIVERY_FLAGS_REDIRECT;
 	bool from_host = ctx_load_and_clear_meta(ctx, CB_FROM_HOST);
 	bool from_tunnel = false;
 


### PR DESCRIPTION
Shrink a bunch of boolean flags into a single CB slot, so that we have more room for expansion.

As per the comment above `local_delivery_fill_meta()`, we introduce this gently for `v1.20` to not break in-flight packets. And can then remove the old usage with `v1.21`.