### PR TITLE
envoy: finalize policy update

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1065,6 +1065,12 @@ func (e *Endpoint) ApplyPolicyMapChanges(proxyWaitGroup *completion.WaitGroup) e
 		metrics.EndpointDetachedSelectorPolicyTimeStats.WithLabelValues("incremental-update").Observe(time.Since(t).Seconds())
 	}
 
+	if !e.desiredPolicy.IsValid() {
+		// The endpoint has no computed policy yet, so it is pointless to try apply
+		// incremental changes on it.
+		return nil
+	}
+
 	// NOTE: Since we create an ephemeral regenerationContext for the endpoint here,
 	// the revert functions of updated proxy network policies are not retained.
 	// This means that even if Envoy would end up NACKing a NetworkPolicy, it will remain in the
@@ -1112,8 +1118,6 @@ func (e *Endpoint) applyPolicyMapChangesLocked(regenContext *regenerationContext
 
 	stats := &regenContext.Stats
 	datapathRegenCtxt := regenContext.datapathRegenerationContext
-	var err error
-
 	proxyWaitGroup := datapathRegenCtxt.proxyWaitGroup
 
 	// Ingress endpoint does not need to wait.
@@ -1144,11 +1148,14 @@ func (e *Endpoint) applyPolicyMapChangesLocked(regenContext *regenerationContext
 		if hasNewPolicy || hasEnvoyRedirect || e.isIngress {
 			e.getLogger().Debug("applyPolicyMapChanges: Updating Envoy NetworkPolicy")
 			stats.proxyPolicyCalculation.Start()
-			var rf revert.RevertFunc
-			err, rf = e.proxy.UpdateNetworkPolicy(e, e.desiredPolicy, proxyWaitGroup)
-			stats.proxyPolicyCalculation.End(err == nil)
-			if err == nil {
+			proxyErr, rf, ff := e.proxy.UpdateNetworkPolicy(e, e.desiredPolicy, proxyWaitGroup)
+			stats.proxyPolicyCalculation.End(proxyErr == nil)
+
+			// UpdateNetworkPolicy only returns revert/finalize func if there is no
+			// synchronous error
+			if proxyErr == nil {
 				datapathRegenCtxt.revertStack.Push(rf)
+				datapathRegenCtxt.finalizeList.Append(ff)
 			}
 		}
 	}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1052,10 +1052,11 @@ func (e *Endpoint) addPolicyKey(keyToAdd policy.Key, entry policy.MapStateEntry)
 // ApplyPolicyMapChanges updates the Endpoint's PolicyMap with the changes
 // that have accumulated for the PolicyMap via various outside events (e.g.,
 // identities added / deleted).
-// 'proxyWaitGroup' may not be nil.
-func (e *Endpoint) ApplyPolicyMapChanges(proxyWaitGroup *completion.WaitGroup) error {
-	if err := e.lockAlive(); err != nil {
-		return err
+// 'proxyWaitGroup' may not be nil. Caller must ultimately call either the returned revert or
+// finalize func, if non-nil and proxyWaitGroup.Wait fails or succeeds, respectively.
+func (e *Endpoint) ApplyPolicyMapChanges(proxyWaitGroup *completion.WaitGroup) (err error, rf revert.RevertFunc, ff revert.FinalizeFunc) {
+	if err = e.lockAlive(); err != nil {
+		return err, nil, nil
 	}
 	defer e.unlock()
 
@@ -1068,26 +1069,38 @@ func (e *Endpoint) ApplyPolicyMapChanges(proxyWaitGroup *completion.WaitGroup) e
 	if !e.desiredPolicy.IsValid() {
 		// The endpoint has no computed policy yet, so it is pointless to try apply
 		// incremental changes on it.
-		return nil
+		return nil, nil, nil
 	}
 
-	// NOTE: Since we create an ephemeral regenerationContext for the endpoint here,
-	// the revert functions of updated proxy network policies are not retained.
-	// This means that even if Envoy would end up NACKing a NetworkPolicy, it will remain in the
-	// xDS cache until the next update.
-	err := e.applyPolicyMapChangesLocked(&regenerationContext{
+	regenCtx := regenerationContext{
 		datapathRegenerationContext: &datapathRegenerationContext{
 			proxyWaitGroup: proxyWaitGroup,
 		},
-	}, false)
+	}
+	err = e.applyPolicyMapChangesLocked(&regenCtx, false)
 
 	if err != nil {
 		e.logStatusLocked(Policy, Failure, err.Error())
-	} else {
-		e.LogStatusOKLocked(Policy, "Policy Map changes applied")
+
+		// revert any changes on synchronous error for an endpoint
+		regenCtx.datapathRegenerationContext.revertStack.Revert()
+
+		return err, nil, nil
 	}
 
-	return err
+	e.LogStatusOKLocked(Policy, "Policy Map changes applied")
+
+	// otherwise the revert/finalize decision is postponed after
+	// eventual proxyWaitGroup.Wait by the caller
+
+	if !regenCtx.datapathRegenerationContext.revertStack.Empty() {
+		rf = regenCtx.datapathRegenerationContext.revertStack.Revert
+	}
+	if !regenCtx.datapathRegenerationContext.finalizeList.Empty() {
+		ff = regenCtx.datapathRegenerationContext.finalizeList.Finalize
+	}
+
+	return nil, rf, ff
 }
 
 // applyPolicyMapChangesLocked applies any incremental policy map changes
@@ -1156,6 +1169,10 @@ func (e *Endpoint) applyPolicyMapChangesLocked(regenContext *regenerationContext
 			if proxyErr == nil {
 				datapathRegenCtxt.revertStack.Push(rf)
 				datapathRegenCtxt.finalizeList.Append(ff)
+			} else {
+				e.getLogger().Debug("applyPolicyMapChanges: UpdateNetworkPolicy failed",
+					logfields.Error, proxyErr)
+				return proxyErr
 			}
 		}
 	}
@@ -1199,6 +1216,7 @@ func (e *Endpoint) applyPolicyMapChangesLocked(regenContext *regenerationContext
 	if errors > 0 {
 		return fmt.Errorf("updating bpf policy maps failed")
 	}
+
 	if len(changes.Adds) > 0 || len(changes.Deletes) > 0 {
 		e.getLogger().Debug(
 			"Applied policy map updates due to identity changes",
@@ -1206,6 +1224,7 @@ func (e *Endpoint) applyPolicyMapChangesLocked(regenContext *regenerationContext
 			logfields.DeletedPolicyID, changes.Deletes,
 		)
 	}
+
 	return nil
 }
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -980,7 +980,7 @@ func (e *Endpoint) ComputeInitialPolicy(regenContext *regenerationContext) (erro
 
 		stats.proxyPolicyCalculation.Start()
 		// Initial NetworkPolicy is not reverted
-		err, _ = e.proxy.UpdateNetworkPolicy(e, e.desiredPolicy, nil)
+		err, _, finalize := e.proxy.UpdateNetworkPolicy(e, e.desiredPolicy, nil)
 		stats.proxyPolicyCalculation.End(err == nil)
 		if err != nil {
 			e.getLogger().Warn(
@@ -990,6 +990,7 @@ func (e *Endpoint) ComputeInitialPolicy(regenContext *regenerationContext) (erro
 			// Do not error out so that the policy regeneration is tried again.
 			return nil, release
 		}
+		finalize()
 	}
 
 	// Signal computation of the initial Envoy policy if not done yet

--- a/pkg/endpoint/proxy.go
+++ b/pkg/endpoint/proxy.go
@@ -19,7 +19,7 @@ type EndpointProxy interface {
 	CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, epID uint16, wg *completion.WaitGroup) (proxyPort uint16, err error, revertFunc revert.RevertFunc)
 	RemoveRedirect(id string)
 	UpdateSDP(rules map[identity.NumericIdentity]policy.SelectorPolicy)
-	UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) (error, func() error)
+	UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) (error, revert.RevertFunc, revert.FinalizeFunc)
 	RemoveNetworkPolicy(ep endpoint.EndpointInfoSource)
 	GetListenerProxyPort(listener string) uint16
 	IsSDPEnabled() bool
@@ -49,8 +49,8 @@ func (f *FakeEndpointProxy) RemoveRedirect(id string) {
 }
 
 // UpdateNetworkPolicy does nothing.
-func (f *FakeEndpointProxy) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) (error, func() error) {
-	return nil, nil
+func (f *FakeEndpointProxy) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) (error, revert.RevertFunc, revert.FinalizeFunc) {
+	return nil, nil, nil
 }
 
 // RemoveNetworkPolicy does nothing.

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -114,8 +114,8 @@ func (r *RedirectSuiteProxy) RemoveRedirect(id string) {
 }
 
 // UpdateNetworkPolicy does nothing.
-func (r *RedirectSuiteProxy) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) (error, func() error) {
-	return nil, nil
+func (r *RedirectSuiteProxy) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) (error, revert.RevertFunc, revert.FinalizeFunc) {
+	return nil, nil, nil
 }
 
 // RemoveNetworkPolicy does nothing.

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -34,6 +34,7 @@ import (
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/revert"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -206,6 +207,9 @@ func (mgr *endpointManager) UpdatePolicyMaps(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, mgr.config.EndpointPolicyUpdateTimeout)
 	defer cancel()
 
+	var guard lock.Mutex
+	var finalizeList revert.FinalizeList
+	var revertStack revert.RevertStack
 	proxyWaitGroup := completion.NewWaitGroup(ctx)
 
 	eps := mgr.GetEndpoints()
@@ -213,7 +217,13 @@ func (mgr *endpointManager) UpdatePolicyMaps(ctx context.Context) error {
 
 	for _, ep := range eps {
 		go func(ep *endpoint.Endpoint) {
-			if err := ep.ApplyPolicyMapChanges(proxyWaitGroup); err != nil && !errors.Is(err, endpoint.ErrNotAlive) {
+			err, rf, ff := ep.ApplyPolicyMapChanges(proxyWaitGroup)
+			guard.Lock()
+			revertStack.Push(rf)
+			finalizeList.Append(ff)
+			guard.Unlock()
+
+			if err != nil && !errors.Is(err, endpoint.ErrNotAlive) {
 				ep.Logger("endpointmanager").Warn("Failed to apply policy map changes. These will be re-applied in future updates.", logfields.Error, err)
 			}
 			wg.Done()
@@ -224,9 +234,18 @@ func (mgr *endpointManager) UpdatePolicyMaps(ctx context.Context) error {
 	// changes before waiting for the changes to be ACKed
 	wg.Wait()
 
+	// wait for proxy completions can return with no error immediately without waiting for
+	// anything if all Endpoint updates failed synchronously, but even in that case calling the
+	// finalize functions is the right thing to do.
 	err := mgr.waitForProxyCompletions(proxyWaitGroup)
+
+	// no endpoint locks needed here, as ApplyPolicyMapChanges currently collects
+	// revert/finalize functions only from UpdateNetworkPolicy
 	if err != nil {
+		revertStack.Revert()
 		mgr.logger.Warn("Failed to apply L7 proxy policy changes. These will be re-applied in future updates.", logfields.Error, err)
+	} else {
+		finalizeList.Finalize()
 	}
 
 	// Perform policy update call if required.

--- a/pkg/endpointmanager/manager_proxy_test.go
+++ b/pkg/endpointmanager/manager_proxy_test.go
@@ -1,0 +1,369 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package endpointmanager
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
+	fakeipsec "github.com/cilium/cilium/pkg/datapath/linux/ipsec/fake"
+	"github.com/cilium/cilium/pkg/endpoint"
+	fakeendpoint "github.com/cilium/cilium/pkg/endpoint/fake"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	envoypolicy "github.com/cilium/cilium/pkg/envoy/policy"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/identitymanager"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/maps/ctmap"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
+	proxyendpoint "github.com/cilium/cilium/pkg/proxy/endpoint"
+	"github.com/cilium/cilium/pkg/revert"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
+	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
+	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
+	fakewireguard "github.com/cilium/cilium/pkg/wireguard/fake"
+)
+
+type policyCompletionOwner string
+
+func (o policyCompletionOwner) ID() string {
+	return string(o)
+}
+
+func (policyCompletionOwner) CleanupAfterWait(*completion.Completion) {}
+
+type recordingEndpointProxy struct {
+	mu lock.Mutex
+
+	syncErrByEndpoint map[uint64]error
+	completions       map[uint64]*completion.Completion
+	revertCalls       map[uint64]int
+	finalizeCalls     map[uint64]int
+
+	updatesSeen     int
+	expectedUpdates int
+	updatesObserved chan struct{}
+}
+
+func newRecordingEndpointProxy() *recordingEndpointProxy {
+	return &recordingEndpointProxy{
+		syncErrByEndpoint: make(map[uint64]error),
+		completions:       make(map[uint64]*completion.Completion),
+		revertCalls:       make(map[uint64]int),
+		finalizeCalls:     make(map[uint64]int),
+	}
+}
+
+func (p *recordingEndpointProxy) expectUpdates(expected int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.completions = make(map[uint64]*completion.Completion)
+	p.revertCalls = make(map[uint64]int)
+	p.finalizeCalls = make(map[uint64]int)
+	p.updatesSeen = 0
+	p.expectedUpdates = expected
+	p.updatesObserved = make(chan struct{})
+}
+
+func (p *recordingEndpointProxy) setSynchronousError(endpointID uint64, err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if err == nil {
+		delete(p.syncErrByEndpoint, endpointID)
+		return
+	}
+	p.syncErrByEndpoint[endpointID] = err
+}
+
+func (p *recordingEndpointProxy) waitForUpdates(t *testing.T) {
+	t.Helper()
+
+	p.mu.Lock()
+	ch := p.updatesObserved
+	p.mu.Unlock()
+
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for proxy update calls")
+	}
+}
+
+func (p *recordingEndpointProxy) completeUpdate(t *testing.T, endpointID uint64, err error) {
+	t.Helper()
+
+	p.mu.Lock()
+	comp := p.completions[endpointID]
+	p.mu.Unlock()
+
+	require.NotNilf(t, comp, "missing completion for endpoint %d", endpointID)
+	comp.Complete(err)
+}
+
+func (p *recordingEndpointProxy) revertCount(endpointID uint64) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.revertCalls[endpointID]
+}
+
+func (p *recordingEndpointProxy) finalizeCount(endpointID uint64) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.finalizeCalls[endpointID]
+}
+
+func (p *recordingEndpointProxy) totalCallbackCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	total := 0
+	for _, count := range p.revertCalls {
+		total += count
+	}
+	for _, count := range p.finalizeCalls {
+		total += count
+	}
+	return total
+}
+
+func (p *recordingEndpointProxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, epID uint16, wg *completion.WaitGroup) (proxyPort uint16, err error, revertFunc revert.RevertFunc) {
+	return 0, nil, nil
+}
+
+func (p *recordingEndpointProxy) RemoveRedirect(id string) {}
+
+func (p *recordingEndpointProxy) UpdateNetworkPolicy(ep proxyendpoint.EndpointUpdater, epp *policy.EndpointPolicy, wg *completion.WaitGroup) (error, revert.RevertFunc, revert.FinalizeFunc) {
+	endpointID := ep.GetID()
+
+	p.mu.Lock()
+	err := p.syncErrByEndpoint[endpointID]
+	trackUpdates := p.expectedUpdates > 0
+	if err == nil && wg != nil && trackUpdates {
+		p.completions[endpointID] = wg.AddCompletionWithCallback(policyCompletionOwner("network-policy-update"), nil)
+	}
+	if trackUpdates {
+		p.updatesSeen++
+	}
+	if trackUpdates && p.updatesSeen == p.expectedUpdates && p.updatesObserved != nil {
+		close(p.updatesObserved)
+	}
+	p.mu.Unlock()
+
+	if err != nil {
+		return err, nil, nil
+	}
+
+	return nil, func() error {
+			p.mu.Lock()
+			defer p.mu.Unlock()
+			p.revertCalls[endpointID]++
+			return nil
+		}, func() {
+			p.mu.Lock()
+			defer p.mu.Unlock()
+			p.finalizeCalls[endpointID]++
+		}
+}
+
+func (p *recordingEndpointProxy) RemoveNetworkPolicy(ep proxyendpoint.EndpointInfoSource) {}
+
+func (p *recordingEndpointProxy) UpdateSDP(rules map[identity.NumericIdentity]policy.SelectorPolicy) {
+}
+
+func (p *recordingEndpointProxy) GetListenerProxyPort(listener string) uint16 {
+	return 0
+}
+
+func (p *recordingEndpointProxy) IsSDPEnabled() bool {
+	return false
+}
+
+func newUpdatePolicyMapsTestRepo(t *testing.T) (*policy.Repository, identitymanager.IDManager) {
+	t.Helper()
+
+	logger := hivetest.Logger(t)
+	idmgr := identitymanager.NewIDManager(logger)
+	repo := policy.NewPolicyRepository(
+		logger,
+		nil,
+		nil,
+		envoypolicy.NewEnvoyL7RulesTranslator(logger, certificatemanager.NewMockSecretManagerInline()),
+		idmgr,
+		testpolicy.NewPolicyMetricsNoop(),
+	)
+
+	oldPolicyMode := policy.GetPolicyEnabled()
+	policy.SetPolicyEnabled(option.DefaultEnforcement)
+	t.Cleanup(func() {
+		policy.SetPolicyEnabled(oldPolicyMode)
+	})
+
+	repo.MustAddList(api.Rules{{
+		EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("bar")),
+		Ingress: []api.IngressRule{{
+			ToPorts: []api.PortRule{{
+				Ports: []api.PortProtocol{{
+					Port:     "80",
+					Protocol: api.ProtoTCP,
+				}},
+				Rules: &api.L7Rules{
+					HTTP: []api.PortRuleHTTP{{
+						Path:   "/",
+						Method: "GET",
+					}},
+				},
+			}},
+		}},
+	}})
+
+	return repo, idmgr
+}
+
+func newUpdatePolicyMapsTestEndpoint(t *testing.T, mgr *endpointManager, repo policy.PolicyRepository, idmgr identitymanager.IDManager, proxy endpoint.EndpointProxy, modelID int, addr netip.Addr) *endpoint.Endpoint {
+	t.Helper()
+
+	model := newTestEndpointModel(modelID, endpoint.StateWaitingForIdentity)
+	ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
+		Logger:           hivetest.Logger(t),
+		EPBuildQueue:     &endpoint.MockEndpointBuildQueue{},
+		Orchestrator:     &fakeendpoint.FakeOrchestrator{},
+		PolicyRepo:       repo,
+		IdentityManager:  idmgr,
+		NamedPortsGetter: testipcache.NewMockIPCache(),
+		IPSecConfig:      fakeipsec.Config{},
+		WgConfig:         &fakewireguard.Config{},
+		CTMapGC:          ctmap.NewFakeGCRunner(),
+		Allocator:        testidentity.NewMockIdentityAllocator(nil),
+		KVStoreSynchronizer: ipcache.NewIPIdentitySynchronizer(
+			hivetest.Logger(t),
+			kvstore.SetupDummy(t, kvstore.DisabledBackendName),
+		),
+	}, nil, proxy, model, nil)
+	require.NoError(t, err)
+
+	ep.Start(uint16(model.ID))
+	t.Cleanup(ep.Stop)
+
+	ep.IPv4 = addr
+	ep.SetIdentity(identity.NewIdentityFromLabelArray(identity.NumericIdentity(1000+modelID), labels.ParseLabelArray("k8s:bar")))
+
+	err = mgr.expose(ep)
+	require.NoError(t, err)
+
+	success := <-ep.RegenerateIfAlive(&regeneration.ExternalRegenerationMetadata{
+		Reason:            regeneration.ReasonPolicyUpdate,
+		RegenerationLevel: regeneration.RegenerateWithoutDatapath,
+	})
+	require.True(t, success)
+
+	return ep
+}
+
+func TestUpdatePolicyMapsFinalizesDeferredNetworkPolicyCallbacksAfterSuccessfulWait(t *testing.T) {
+	logger := hivetest.Logger(t)
+	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
+	repo, idmgr := newUpdatePolicyMapsTestRepo(t)
+	proxy := newRecordingEndpointProxy()
+
+	ep1 := newUpdatePolicyMapsTestEndpoint(t, mgr, repo, idmgr, proxy, 101, netip.MustParseAddr("10.0.0.1"))
+	ep2 := newUpdatePolicyMapsTestEndpoint(t, mgr, repo, idmgr, proxy, 102, netip.MustParseAddr("10.0.0.2"))
+
+	proxy.expectUpdates(2)
+
+	errCh := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		errCh <- mgr.UpdatePolicyMaps(ctx)
+	}()
+
+	proxy.waitForUpdates(t)
+	require.Zero(t, proxy.totalCallbackCount())
+
+	proxy.completeUpdate(t, ep1.GetID(), nil)
+	proxy.completeUpdate(t, ep2.GetID(), nil)
+
+	require.NoError(t, <-errCh)
+	require.Equal(t, 0, proxy.revertCount(ep1.GetID()))
+	require.Equal(t, 0, proxy.revertCount(ep2.GetID()))
+	require.Equal(t, 1, proxy.finalizeCount(ep1.GetID()))
+	require.Equal(t, 1, proxy.finalizeCount(ep2.GetID()))
+}
+
+func TestUpdatePolicyMapsRevertsDeferredNetworkPolicyCallbacksAfterProxyWaitFailure(t *testing.T) {
+	logger := hivetest.Logger(t)
+	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
+	repo, idmgr := newUpdatePolicyMapsTestRepo(t)
+	proxy := newRecordingEndpointProxy()
+
+	ep1 := newUpdatePolicyMapsTestEndpoint(t, mgr, repo, idmgr, proxy, 201, netip.MustParseAddr("10.0.1.1"))
+	ep2 := newUpdatePolicyMapsTestEndpoint(t, mgr, repo, idmgr, proxy, 202, netip.MustParseAddr("10.0.1.2"))
+
+	proxy.expectUpdates(2)
+
+	errCh := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		errCh <- mgr.UpdatePolicyMaps(ctx)
+	}()
+
+	proxy.waitForUpdates(t)
+	require.Zero(t, proxy.totalCallbackCount())
+
+	proxy.completeUpdate(t, ep1.GetID(), errors.New("proxy wait failed"))
+
+	err := <-errCh
+	require.Error(t, err)
+	require.ErrorContains(t, err, "proxy updates failed")
+	require.Equal(t, 1, proxy.revertCount(ep1.GetID()))
+	require.Equal(t, 1, proxy.revertCount(ep2.GetID()))
+	require.Equal(t, 0, proxy.finalizeCount(ep1.GetID()))
+	require.Equal(t, 0, proxy.finalizeCount(ep2.GetID()))
+}
+
+func TestUpdatePolicyMapsDoesNotDeferCallbacksForSynchronousApplyFailure(t *testing.T) {
+	logger := hivetest.Logger(t)
+	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
+	repo, idmgr := newUpdatePolicyMapsTestRepo(t)
+	proxy := newRecordingEndpointProxy()
+
+	ep1 := newUpdatePolicyMapsTestEndpoint(t, mgr, repo, idmgr, proxy, 301, netip.MustParseAddr("10.0.2.1"))
+	ep2 := newUpdatePolicyMapsTestEndpoint(t, mgr, repo, idmgr, proxy, 302, netip.MustParseAddr("10.0.2.2"))
+
+	proxy.expectUpdates(2)
+	proxy.setSynchronousError(ep1.GetID(), errors.New("sync proxy error"))
+
+	errCh := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		errCh <- mgr.UpdatePolicyMaps(ctx)
+	}()
+
+	proxy.waitForUpdates(t)
+	require.Zero(t, proxy.totalCallbackCount())
+
+	proxy.completeUpdate(t, ep2.GetID(), nil)
+
+	require.NoError(t, <-errCh)
+	require.Equal(t, 0, proxy.revertCount(ep1.GetID()))
+	require.Equal(t, 0, proxy.finalizeCount(ep1.GetID()))
+	require.Equal(t, 0, proxy.revertCount(ep2.GetID()))
+	require.Equal(t, 1, proxy.finalizeCount(ep2.GetID()))
+}

--- a/pkg/envoy/secretsync_test.go
+++ b/pkg/envoy/secretsync_test.go
@@ -19,6 +19,7 @@ import (
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/endpoint"
+	"github.com/cilium/cilium/pkg/revert"
 )
 
 func Test_k8sSecretToEnvoySecretTlsCertificate(t *testing.T) {
@@ -458,7 +459,7 @@ func (*fakeXdsServer) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource) {
 	panic("unimplemented")
 }
 
-func (*fakeXdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) (error, func() error) {
+func (*fakeXdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) (error, revert.RevertFunc, revert.FinalizeFunc) {
 	panic("unimplemented")
 }
 

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -48,6 +48,7 @@ import (
 	policyTypes "github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/proxy/endpoint"
+	"github.com/cilium/cilium/pkg/revert"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -120,7 +121,7 @@ type XDSServer interface {
 	// UpdateNetworkPolicy adds or updates a network policy in the set published to L7 proxies.
 	// When the proxy acknowledges the network policy update, it will result in
 	// a subsequent call to the endpoint's OnProxyPolicyUpdate() function.
-	UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) (error, func() error)
+	UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) (error, revert.RevertFunc, revert.FinalizeFunc)
 	// RemoveNetworkPolicy removes network policies relevant to the specified
 	// endpoint from the set published to L7 proxies, and stops listening for
 	// acks for policies on this endpoint.
@@ -1805,10 +1806,11 @@ func getNodeIDs(ep endpoint.EndpointUpdater, policy *policy.L4Policy) []string {
 // implemented by Cilium.
 var ErrNilPolicy = errors.New("nil EndpointPolicy")
 
+// UpdateNetworkPolicy returns nil revert/finalize funcs with synchronous errors.
 func (s *xdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, epp *policy.EndpointPolicy, wg *completion.WaitGroup,
-) (error, func() error) {
+) (error, revert.RevertFunc, revert.FinalizeFunc) {
 	if epp == nil {
-		return ErrNilPolicy, nil
+		return ErrNilPolicy, nil, nil
 	}
 
 	names := ep.GetPolicyNames()
@@ -1819,7 +1821,7 @@ func (s *xdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, epp *policy
 			logfields.Name, names,
 			logfields.EndpointID, ep.GetID(),
 		)
-		return nil, func() error { return nil }
+		return nil, func() error { return nil }, func() {}
 	}
 
 	l4policy := &epp.SelectorPolicy.L4Policy
@@ -1829,7 +1831,7 @@ func (s *xdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, epp *policy
 
 	// Error out if the selectors are no longer valid
 	if !selectors.IsValid() {
-		return policy.ErrStaleSelectors, nil
+		return policy.ErrStaleSelectors, nil, nil
 	}
 
 	s.mutex.Lock()
@@ -1858,7 +1860,7 @@ func (s *xdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, epp *policy
 	// First, validate the policy
 	err := networkPolicy.Validate()
 	if err != nil {
-		return fmt.Errorf("error validating generated NetworkPolicy for %d/%s: %w", ep.GetID(), ep.GetPolicyNames(), err), nil
+		return fmt.Errorf("error validating generated NetworkPolicy for %d/%s: %w", ep.GetID(), ep.GetPolicyNames(), err), nil, nil
 	}
 
 	// If there are no listeners configured, the local node's Envoy proxy won't
@@ -1881,17 +1883,23 @@ func (s *xdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, epp *policy
 	revertFunc := s.networkPolicyMutator.Upsert(NetworkPolicyTypeURL, resourceName, networkPolicy, nodeIDs, wg, callback)
 
 	return nil, func() error {
-		s.logger.Debug("Reverting xDS network policy update")
+			s.logger.Debug("Reverting xDS network policy update",
+				logfields.EndpointID, epID,
+			)
 
-		s.mutex.Lock()
-		defer s.mutex.Unlock()
+			s.mutex.Lock()
+			defer s.mutex.Unlock()
 
-		revertFunc()
+			revertFunc()
 
-		s.logger.Debug("Finished reverting xDS network policy update")
+			s.logger.Debug("Finished reverting xDS network policy update")
 
-		return nil
-	}
+			return nil
+		}, func() {
+			s.logger.Debug("Finalizing xDS network policy update",
+				logfields.EndpointID, epID,
+			)
+		}
 }
 
 func (s *xdsServer) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource) {

--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -2247,9 +2247,11 @@ func TestUpdateNetworkPolicyRevertKeepsLocalEndpointStoreAfterStaleDuplicateRemo
 	repo, localIdentity, currentEPP := newTestEndpointPolicy(t, currentEP)
 	xds := newTestXDSServer(t)
 
-	err, revert := xds.UpdateNetworkPolicy(currentEP, currentEPP, nil)
+	err, revert, finalize := xds.UpdateNetworkPolicy(currentEP, currentEPP, nil)
 	require.NoError(t, err)
 	require.NotNil(t, revert)
+	require.NotNil(t, finalize)
+	finalize()
 
 	staleEP := &listenerProxyUpdaterMock{ProxyUpdaterMock: &test.ProxyUpdaterMock{
 		Id:   500,
@@ -2266,9 +2268,11 @@ func TestUpdateNetworkPolicyRevertKeepsLocalEndpointStoreAfterStaleDuplicateRemo
 	require.Equal(t, staleEP.GetID(), localEP.GetID())
 
 	refreshedCurrentEPP := distillEndpointPolicy(t, repo, localIdentity, currentEP)
-	err, revert = xds.UpdateNetworkPolicy(currentEP, refreshedCurrentEPP, nil)
+	err, revert, finalize = xds.UpdateNetworkPolicy(currentEP, refreshedCurrentEPP, nil)
 	require.NoError(t, err)
 	require.NotNil(t, revert)
+	require.NotNil(t, finalize)
+	finalize()
 
 	localEP = xds.localEndpointStore.getLocalEndpoint(currentEP.Ipv4)
 	require.NotNil(t, localEP)

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -585,6 +585,16 @@ func (p *EndpointPolicy) ConsumeMapChanges() (closer func(), changes ChangeState
 	features := p.SelectorPolicy.L4Policy.Ingress.features | p.SelectorPolicy.L4Policy.Egress.features
 	selectors, changes := p.policyMapChanges.consumeMapChanges(p, features)
 
+	// Even if there were no incremental map changes, follow-on processing may
+	// still need a usable selector snapshot. Reopen one on demand if the
+	// current snapshot is already stale.
+	// This block can be removed when UpdateNetworkPolicy no longer requires a selector
+	// snapshot.
+	if !selectors.IsValid() && !p.selectors.IsValid() {
+		// this will get stored to p.selectors below
+		selectors = p.SelectorPolicy.GetSelectorSnapshot()
+	}
+
 	// Update current selector snapshot and provide a closer function to close the new snapshot
 	// if (and only if) the old one was already closed.
 	closer = func() {}
@@ -615,9 +625,15 @@ func (p *EndpointPolicy) ConsumeMapChanges() (closer func(), changes ChangeState
 
 // NewEndpointPolicy returns an empty EndpointPolicy stub.
 // The returned stub is not modified.
+// PolicyOwner is left as nil
 func NewEndpointPolicy(logger *slog.Logger, repo PolicyRepository) *EndpointPolicy {
 	return &EndpointPolicy{
 		SelectorPolicy: newSelectorPolicy(repo.GetSelectorCache()),
 		policyMapState: emptyMapState(logger),
 	}
+}
+
+// IsValid returns true if the policy is a result of a policy computation, false for the empty stub.
+func (p *EndpointPolicy) IsValid() bool {
+	return p.PolicyOwner != nil
 }

--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -67,7 +67,7 @@ func (p *envoyProxyIntegration) changeLogLevel(level slog.Level) error {
 	return p.adminClient.ChangeLogLevel(level)
 }
 
-func (p *envoyProxyIntegration) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) (error, func() error) {
+func (p *envoyProxyIntegration) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) (error, revert.RevertFunc, revert.FinalizeFunc) {
 	return p.xdsServer.UpdateNetworkPolicy(ep, policy, wg)
 }
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -330,7 +330,7 @@ func (p *Proxy) removeRedirect(id string) {
 	}
 }
 
-func (p *Proxy) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) (error, func() error) {
+func (p *Proxy) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) (error, revert.RevertFunc, revert.FinalizeFunc) {
 	return p.envoyIntegration.UpdateNetworkPolicy(ep, policy, wg)
 }
 

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/endpoint"
 	"github.com/cilium/cilium/pkg/proxy/proxyports"
+	"github.com/cilium/cilium/pkg/revert"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -193,7 +194,7 @@ func (*fakeXdsServer) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource) {
 	panic("unimplemented")
 }
 
-func (*fakeXdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) (error, func() error) {
+func (*fakeXdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, policy *policy.EndpointPolicy, wg *completion.WaitGroup) (error, revert.RevertFunc, revert.FinalizeFunc) {
 	panic("unimplemented")
 }
 

--- a/pkg/revert/finalize.go
+++ b/pkg/revert/finalize.go
@@ -19,6 +19,11 @@ type FinalizeList struct {
 	finalizeFuncs []FinalizeFunc
 }
 
+// Empty returns true if the finalize list has no functions in it.
+func (f *FinalizeList) Empty() bool {
+	return len(f.finalizeFuncs) == 0
+}
+
 // Append appends the given FinalizeFunc at the end of this list. If the
 // function is nil, it is ignored.
 func (f *FinalizeList) Append(finalizeFunc FinalizeFunc) {

--- a/pkg/revert/revert.go
+++ b/pkg/revert/revert.go
@@ -21,6 +21,11 @@ type RevertStack struct {
 	revertFuncs []RevertFunc
 }
 
+// Empty returns true if the revert stack has no functions in it.
+func (s *RevertStack) Empty() bool {
+	return len(s.revertFuncs) == 0
+}
+
 // Push pushes the given RevertFunc on top of this stack. If the function is
 // nil, it is ignored.
 func (s *RevertStack) Push(revertFunc RevertFunc) {


### PR DESCRIPTION
Finalize envoy policy updates:
- envoy: Add finalize return on UpdateNetworkPolicy
- endpoint: Revert/finalize incremental proxy updates

The first commit is updating the interfaces for future changes where finalization is needed, but the 2nd changes incremental update behavior by failing on any synchronous errors.