### PR TITLE
node/manager: make cluster label bypass filtering

### DIFF
--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -641,10 +641,11 @@ func (m *manager) nodeIdentityLabels(n nodeTypes.Node) labels.Labels {
 
 	if option.Config.PerNodeLabelsEnabled() {
 		lbls := labels.Map2Labels(n.Labels, labels.LabelSourceNode)
-		clusterLabel := labels.NewLabel(k8sConst.PolicyLabelCluster, n.Cluster, labels.LabelSourceK8s)
-		lbls[clusterLabel.Key] = clusterLabel
 		filteredLbls, _ := labelsfilter.FilterNodeLabels(lbls)
 		nodeLabels.MergeLabels(filteredLbls)
+		nodeLabels.MergeLabels(labels.Map2Labels(map[string]string{
+			k8sConst.PolicyLabelCluster: n.Cluster,
+		}, labels.LabelSourceK8s))
 	}
 
 	return nodeLabels

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -353,14 +353,11 @@ func TestNodeLabels(t *testing.T) {
 	require.NoError(t, err)
 	mngr.NodeUpdated(nRemote)
 
-	if err := labelsfilter.ParseLabelPrefixCfg(logger, nil, nil, ""); err != nil {
-		t.Fatal("ParseLabelPrefixCfg() failed")
-	}
-
 	tests := []struct {
 		name               string
 		node               nodeTypes.Node
 		nodeSelectorLabels bool
+		nodeLabelPrefixes  []string
 		setupWanted        func() labels.Labels
 	}{{
 		name:               "Local node with node selector labels enabled",
@@ -400,10 +397,26 @@ func TestNodeLabels(t *testing.T) {
 		setupWanted: func() labels.Labels {
 			return labels.NewFrom(labels.LabelRemoteNode)
 		},
+	}, {
+		name:               "Remote node with node selector labels enabled and filtered labels",
+		node:               nRemote,
+		nodeSelectorLabels: true,
+		nodeLabelPrefixes:  []string{"node:test-label"},
+		setupWanted: func() labels.Labels {
+			want := labels.NewFrom(labels.LabelRemoteNode)
+			want.MergeLabels(labels.Map2Labels(map[string]string{
+				"test-label": "test-value",
+			}, labels.LabelSourceNode))
+			want.MergeLabels(labels.Map2Labels(map[string]string{
+				"io.cilium.k8s.policy.cluster": "default",
+			}, labels.LabelSourceK8s))
+			return want
+		},
 	}}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, labelsfilter.ParseLabelPrefixCfg(logger, nil, tt.nodeLabelPrefixes, ""))
 			option.Config.EnableNodeSelectorLabels = tt.nodeSelectorLabels
 			option.Config.ClusterName = "default"
 			got := mngr.nodeIdentityLabels(tt.node)


### PR DESCRIPTION
For users that have label filtering via the `nodeLabels` helm value this label could (and most likely was) filtered out. With the combination of `policy-default-local-cluster` which is turn on by default in 1.19 this is quite problematic as `toNodes` CNP would implicitly add a filter via this label which could thus be filtered out.

This commit fixes that by making the addition of the cluster label bypass the filtering logic.

Fixes: 6065e09028f39e ("node/manager: add cluster label for node identity")

Fixes: #45956

```release-note
Always add cluster label to node when `nodeSelectorLabels` is enabled to fix CiliumNetworkPolicy with `fromNodes`/`toNodes` with  `policy-default-local-cluster` enabled (enabled by default in 1.19+)
```
