### PR TITLE
Envoy: Network policy cleanup

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1267,6 +1267,11 @@ func (e *Endpoint) leaveLocked(conf DeleteConfig) []error {
 		}
 	}
 
+	// Endpoint's network policy must be released even if the identity is not released.
+	// Remove network policy before (possibly) releasing identity so proxy cleanup
+	// can still observe the endpoint exactly as it was published.
+	e.removeNetworkPolicy()
+
 	if !conf.NoIdentityRelease && e.SecurityIdentity != nil {
 		if e.identitySet {
 			// Restored endpoint may be created with a reserved identity of 5
@@ -1283,7 +1288,6 @@ func (e *Endpoint) leaveLocked(conf DeleteConfig) []error {
 				errs = append(errs, fmt.Errorf("unable to release identity: %w", err))
 			}
 		}
-		e.removeNetworkPolicy()
 		e.SecurityIdentity = nil
 	}
 

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -24,6 +24,7 @@ import (
 	fakeendpoint "github.com/cilium/cilium/pkg/endpoint/fake"
 	endpoint "github.com/cilium/cilium/pkg/endpoint/types"
 	"github.com/cilium/cilium/pkg/eventqueue"
+	fqdnrestore "github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -40,6 +41,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
+	proxyendpoint "github.com/cilium/cilium/pkg/proxy/endpoint"
 	"github.com/cilium/cilium/pkg/testutils"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
@@ -775,6 +777,24 @@ func TestWaitForPolicyRevision(t *testing.T) {
 	require.Empty(t, e.policyRevisionSignals)
 }
 
+func TestDeleteRemovesNetworkPolicyWhenIdentityReleaseIsSkipped(t *testing.T) {
+	p := createTestEndpointParams(t)
+	proxy := &recordingRemoveNetworkPolicyProxy{}
+
+	ep, err := NewEndpointFromChangeModel(p, noopDNSRulesAPI{}, proxy, newTestEndpointModel(1234, StateReady), nil)
+	require.NoError(t, err)
+
+	ep.Start(uint16(ep.ID))
+
+	errs := ep.Delete(DeleteConfig{
+		NoIdentityRelease: true,
+		NoIPRelease:       true,
+	})
+	require.Empty(t, errs)
+	require.Equal(t, 1, proxy.calls)
+	require.Equal(t, uint64(ep.ID), proxy.lastEndpointID)
+}
+
 func TestProxyID(t *testing.T) {
 	setupEndpointSuite(t)
 
@@ -1088,6 +1108,23 @@ func newTestEndpointModel(id int, state State) *models.EndpointChangeRequest {
 			endpoint.PropertyFakeEndpoint: true,
 		},
 	}
+}
+
+type noopDNSRulesAPI struct{}
+
+func (noopDNSRulesAPI) GetDNSRules(uint16) fqdnrestore.DNSRules { return nil }
+
+func (noopDNSRulesAPI) RemoveRestoredDNSRules(uint16) {}
+
+type recordingRemoveNetworkPolicyProxy struct {
+	FakeEndpointProxy
+	calls          int
+	lastEndpointID uint64
+}
+
+func (p *recordingRemoveNetworkPolicyProxy) RemoveNetworkPolicy(ep proxyendpoint.EndpointInfoSource) {
+	p.calls++
+	p.lastEndpointID = ep.GetID()
 }
 
 //TODODODODO

--- a/pkg/envoy/localendpointstore.go
+++ b/pkg/envoy/localendpointstore.go
@@ -4,41 +4,97 @@
 package envoy
 
 import (
+	"fmt"
+
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/proxy/endpoint"
 )
 
-// LocalEndpointStore tracks the mapping between a given endpoint IP and the actual local endpoint.
+// LocalEndpointStore tracks the mapping between a given endpoint IP and the local endpoint.
 type LocalEndpointStore struct {
 	// mutex protects accesses to the configuration resources below.
 	mutex lock.RWMutex
 
 	// networkPolicyEndpoints maps endpoint IP to the info on the local endpoint.
 	// mutex must be held when accessing this.
+	// endpoint.EndpointUpdater interface must be stable for the lifetime of the endpoint.
 	networkPolicyEndpoints map[string]endpoint.EndpointUpdater
+}
+
+// endpointInfo is the map key/value pair used to report conflicts
+// Empty 'ip' strings or nil 'ep' values are not used.
+type endpointInfo struct {
+	policyName string
+	ep         endpoint.EndpointInfoSource
+}
+
+func (d endpointInfo) String() string {
+	return fmt.Sprintf("PolicyName: %s, EndpointID: %d", d.policyName, d.ep.GetID())
 }
 
 // getLocalEndpoint returns the endpoint info for the local endpoint on which
 // the network policy of the given name if enforced, or nil if not found.
-func (s *LocalEndpointStore) getLocalEndpoint(endpointIP string) endpoint.EndpointUpdater {
+func (s *LocalEndpointStore) getLocalEndpoint(name string) endpoint.EndpointUpdater {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
-	return s.networkPolicyEndpoints[endpointIP]
+	return s.networkPolicyEndpoints[name]
 }
 
-// setLocalEndpoint maps the given IP to the local endpoint.
-func (s *LocalEndpointStore) setLocalEndpoint(endpointIP string, ep endpoint.EndpointUpdater) {
+// setLocalEndpoint maps endpoint's policy names to the local endpoint.
+// 'ep' must not be nil. Returns any conflicts found, nil for none.
+func (s *LocalEndpointStore) setLocalEndpoint(ep endpoint.EndpointUpdater) []endpointInfo {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	s.networkPolicyEndpoints[endpointIP] = ep
+	var conflicts []endpointInfo
+	for _, name := range ep.GetPolicyNames() {
+		foundEP := s.networkPolicyEndpoints[name]
+		// 'ep' is assumed to be stable for the lifetime of the endpoint, so
+		// interface inequality indicates a conflict.
+		if foundEP != nil && foundEP != ep {
+			conflicts = append(conflicts, endpointInfo{policyName: name, ep: foundEP})
+		}
+		s.networkPolicyEndpoints[name] = ep
+	}
+	if len(conflicts) > 0 {
+		// remove all entries for the conflicting endpoints
+		for name, existingEP := range s.networkPolicyEndpoints {
+			for _, conflict := range conflicts {
+				if existingEP == conflict.ep {
+					delete(s.networkPolicyEndpoints, name)
+				}
+			}
+		}
+	}
+	return conflicts
 }
 
-// removeLocalEndpoint delete the mapping for the given endpoint IP
-func (s *LocalEndpointStore) removeLocalEndpoint(endpointIP string) {
+// removeLocalEndpoint deletes the IP mappings for the given endpoint.
+// Returns any conflicts found, nil for none.
+func (s *LocalEndpointStore) removeLocalEndpoint(ep endpoint.EndpointInfoSource) {
+	names := ep.GetPolicyNames()
+
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	delete(s.networkPolicyEndpoints, endpointIP)
+	deleteCount := 0
+	for _, name := range names {
+		foundEP, found := s.networkPolicyEndpoints[name]
+		// 'ep' is assumed to be stable for the lifetime of the endpoint.
+		if found && foundEP == ep {
+			deleteCount++
+			delete(s.networkPolicyEndpoints, name)
+		}
+	}
+
+	if deleteCount < len(names) {
+		// One or more IPs was not deleted, make sure this endpoint is removed by scanning
+		// the map.
+		for name, existingEP := range s.networkPolicyEndpoints {
+			if existingEP == ep {
+				delete(s.networkPolicyEndpoints, name)
+			}
+		}
+	}
 }

--- a/pkg/envoy/xds/ack.go
+++ b/pkg/envoy/xds/ack.go
@@ -77,9 +77,6 @@ type AckingResourceMutator interface {
 	// method call.
 	Upsert(typeURL string, resourceName string, resource proto.Message, nodeIDs []string, wg *completion.WaitGroup, callback func(error)) AckingResourceMutatorRevertFunc
 
-	// DeleteNode frees resources held for the named node
-	DeleteNode(nodeID string)
-
 	// Delete deletes a resource from this set by name and increases the cache's
 	// version number atomically if the resource is actually deleted.
 	// The completion is called back when the new deleted resources' version is
@@ -295,18 +292,6 @@ func (m *AckingResourceMutatorWrapper) maybeAddCurrentVersionCompletion(wait boo
 	if !wait && callback != nil {
 		callback(nil)
 	}
-}
-
-// DeleteNode frees resources held for the named nodes
-func (m *AckingResourceMutatorWrapper) DeleteNode(nodeID string) {
-	m.locker.Lock()
-	defer m.locker.Unlock()
-
-	delete(m.ackedVersions, nodeID)
-	if ch, exists := m.ackedNodes[nodeID]; exists && ch != nil {
-		close(ch)
-	}
-	delete(m.ackedNodes, nodeID)
 }
 
 // CancelCompletions is called after it is known the xDS client has been terminated, so that waiting

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1807,11 +1807,19 @@ var ErrNilPolicy = errors.New("nil EndpointPolicy")
 
 func (s *xdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, epp *policy.EndpointPolicy, wg *completion.WaitGroup,
 ) (error, func() error) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
 	if epp == nil {
 		return ErrNilPolicy, nil
+	}
+
+	names := ep.GetPolicyNames()
+	if len(names) == 0 {
+		// It looks like the "host EP" (identity == 1) has no IPs, so it is possible to find
+		// there are no policy names here. In this case just skip without updating a policy.
+		s.logger.Debug("Endpoint has no policy names",
+			logfields.Name, names,
+			logfields.EndpointID, ep.GetID(),
+		)
+		return nil, func() error { return nil }
 	}
 
 	l4policy := &epp.SelectorPolicy.L4Policy
@@ -1824,22 +1832,28 @@ func (s *xdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, epp *policy
 		return policy.ErrStaleSelectors, nil
 	}
 
-	ips := ep.GetPolicyNames()
-	if len(ips) == 0 {
-		// It looks like the "host EP" (identity == 1) has no IPs, so it is possible to find
-		// there are no IPs here. In this case just skip without updating a policy, as
-		// policies are always keyed by an IP.
-		//
-		// TODO: When L7 policy support for the host is needed, all host IPs should be
-		// considered here?
-		s.logger.Debug("Endpoint has no IP addresses or name",
-			logfields.Name, ips,
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	// Update local endpoint IP/policy mapping for access log correlation and log any conflicts.
+	// This is done even if policy update fails, as this information only depends on the
+	// existence of the endpoint and does not need to be reverted even if policy update fails.
+	conflicts := s.localEndpointStore.setLocalEndpoint(ep)
+	if len(conflicts) > 0 {
+		s.logger.Error("Conflicting policy names detected while updating local endpoint store",
 			logfields.EndpointID, ep.GetID(),
+			logfields.Info, conflicts,
 		)
-		return nil, func() error { return nil }
+
+		// remove conflicting policies
+		for _, dup := range conflicts {
+			// We use the string form of the Endpoint's ID as the xDS resource name.
+			dupName := strconv.FormatUint(dup.ep.GetID(), 10)
+			s.networkPolicyMutator.Delete(NetworkPolicyTypeURL, dupName, nil, nil, nil)
+		}
 	}
 
-	networkPolicy := s.getNetworkPolicy(ep, selectors, ips, l4policy, ingressPolicyEnforced, egressPolicyEnforced, s.config.useFullTLSContext, s.config.useSDS, s.secretManager.GetSecretSyncNamespace())
+	networkPolicy := s.getNetworkPolicy(ep, selectors, names, l4policy, ingressPolicyEnforced, egressPolicyEnforced, s.config.useFullTLSContext, s.config.useSDS, s.secretManager.GetSecretSyncNamespace())
 
 	// First, validate the policy
 	err := networkPolicy.Validate()
@@ -1855,37 +1869,22 @@ func (s *xdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, epp *policy
 	}
 
 	// When successful, push policy into the cache.
-	var callback func(error)
 	policyRevision := l4policy.Revision
-	callback = func(err error) {
+	callback := func(err error) {
 		if err == nil {
 			go ep.OnProxyPolicyUpdate(policyRevision)
 		}
 	}
-
 	epID := ep.GetID()
 	nodeIDs := getNodeIDs(ep, l4policy)
 	resourceName := strconv.FormatUint(epID, 10)
 	revertFunc := s.networkPolicyMutator.Upsert(NetworkPolicyTypeURL, resourceName, networkPolicy, nodeIDs, wg, callback)
-	revertUpdatedNetworkPolicyEndpoints := make(map[string]endpoint.EndpointUpdater, len(ips))
-	for _, ip := range ips {
-		revertUpdatedNetworkPolicyEndpoints[ip] = s.localEndpointStore.getLocalEndpoint(ip)
-		s.localEndpointStore.setLocalEndpoint(ip, ep)
-	}
 
 	return nil, func() error {
 		s.logger.Debug("Reverting xDS network policy update")
 
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
-
-		for ip, ep := range revertUpdatedNetworkPolicyEndpoints {
-			if ep == nil {
-				s.localEndpointStore.removeLocalEndpoint(ip)
-			} else {
-				s.localEndpointStore.setLocalEndpoint(ip, ep)
-			}
-		}
 
 		revertFunc()
 
@@ -1906,14 +1905,7 @@ func (s *xdsServer) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource) {
 	// ignored.
 	s.networkPolicyMutator.Delete(NetworkPolicyTypeURL, resourceName, nil, nil, nil)
 
-	ip := ep.GetIPv6Address()
-	if ip != "" {
-		s.localEndpointStore.removeLocalEndpoint(ip)
-	}
-	ip = ep.GetIPv4Address()
-	if ip != "" {
-		s.localEndpointStore.removeLocalEndpoint(ip)
-	}
+	s.localEndpointStore.removeLocalEndpoint(ep)
 }
 
 func (s *xdsServer) RemoveAllNetworkPolicies() {

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1913,8 +1913,6 @@ func (s *xdsServer) RemoveNetworkPolicy(ep endpoint.EndpointInfoSource) {
 	ip = ep.GetIPv4Address()
 	if ip != "" {
 		s.localEndpointStore.removeLocalEndpoint(ip)
-		// Delete node resources held in the cache for the endpoint
-		s.networkPolicyMutator.DeleteNode(ip)
 	}
 }
 

--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -4,6 +4,7 @@
 package envoy
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
@@ -2235,4 +2236,120 @@ func (s *xdsServer) GetNetworkPolicies(resourceNames []string) (map[string]*cili
 		}
 	}
 	return networkPolicies, nil
+}
+
+func TestUpdateNetworkPolicyRevertKeepsLocalEndpointStoreAfterStaleDuplicateRemoval(t *testing.T) {
+	currentEP := &listenerProxyUpdaterMock{ProxyUpdaterMock: &test.ProxyUpdaterMock{
+		Id:   2766,
+		Ipv4: "10.0.0.159",
+		Ipv6: "fd00:10:244::ab0e",
+	}}
+	repo, localIdentity, currentEPP := newTestEndpointPolicy(t, currentEP)
+	xds := newTestXDSServer(t)
+
+	err, revert := xds.UpdateNetworkPolicy(currentEP, currentEPP, nil)
+	require.NoError(t, err)
+	require.NotNil(t, revert)
+
+	staleEP := &listenerProxyUpdaterMock{ProxyUpdaterMock: &test.ProxyUpdaterMock{
+		Id:   500,
+		Ipv4: currentEP.Ipv4,
+		Ipv6: "fd00:10:244::500",
+	}}
+	staleResourceName := strconv.FormatUint(staleEP.GetID(), 10)
+	_, updated, _ := xds.networkPolicyCache.Upsert(NetworkPolicyTypeURL, staleResourceName, &cilium.NetworkPolicy{})
+	require.True(t, updated)
+	xds.localEndpointStore.setLocalEndpoint(staleEP)
+	xds.localEndpointStore.setLocalEndpoint(staleEP)
+	localEP := xds.localEndpointStore.getLocalEndpoint(staleEP.Ipv6)
+	require.NotNil(t, localEP)
+	require.Equal(t, staleEP.GetID(), localEP.GetID())
+
+	refreshedCurrentEPP := distillEndpointPolicy(t, repo, localIdentity, currentEP)
+	err, revert = xds.UpdateNetworkPolicy(currentEP, refreshedCurrentEPP, nil)
+	require.NoError(t, err)
+	require.NotNil(t, revert)
+
+	localEP = xds.localEndpointStore.getLocalEndpoint(currentEP.Ipv4)
+	require.NotNil(t, localEP)
+	require.Equal(t, currentEP.GetID(), localEP.GetID())
+	localEP = xds.localEndpointStore.getLocalEndpoint(currentEP.Ipv6)
+	require.NotNil(t, localEP)
+	require.Equal(t, currentEP.GetID(), localEP.GetID())
+	require.Nil(t, xds.localEndpointStore.getLocalEndpoint(staleEP.Ipv6))
+
+	require.NoError(t, revert())
+
+	localEP = xds.localEndpointStore.getLocalEndpoint(currentEP.Ipv4)
+	require.NotNil(t, localEP)
+	require.Equal(t, currentEP.GetID(), localEP.GetID())
+	localEP = xds.localEndpointStore.getLocalEndpoint(currentEP.Ipv6)
+	require.NotNil(t, localEP)
+	require.Equal(t, currentEP.GetID(), localEP.GetID())
+	require.Nil(t, xds.localEndpointStore.getLocalEndpoint(staleEP.Ipv6))
+
+	stalePolicy, err := xds.networkPolicyCache.Lookup(NetworkPolicyTypeURL, staleResourceName)
+	require.NoError(t, err)
+	require.Nil(t, stalePolicy)
+}
+
+func newTestEndpointPolicy(t *testing.T, ep *listenerProxyUpdaterMock) (*policy.Repository, *identity.Identity, *policy.EndpointPolicy) {
+	logger := hivetest.Logger(t)
+	localIdentity := identity.NewIdentity(9001, labels.LabelArray{
+		labels.NewLabel("id", "a", labels.LabelSourceK8s),
+		labels.NewLabel(k8sConst.PodNamespaceLabel, "default", labels.LabelSourceK8s),
+	}.Labels())
+
+	idMgr := identitymanager.NewIDManager(logger)
+	repo := policy.NewPolicyRepository(
+		logger,
+		identity.IdentityMap{localIdentity.ID: localIdentity.LabelArray},
+		nil,
+		envoypolicy.NewEnvoyL7RulesTranslator(logger, certificatemanager.NewMockSecretManagerInline()),
+		idMgr,
+		testpolicy.NewPolicyMetricsNoop(),
+	)
+	idMgr.Add(localIdentity)
+	t.Cleanup(func() {
+		idMgr.Remove(localIdentity)
+	})
+
+	rule := &api.Rule{
+		EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("id=a")),
+		Egress: []api.EgressRule{{
+			EgressCommonRule: api.EgressCommonRule{
+				ToEndpoints: []api.EndpointSelector{api.WildcardEndpointSelector},
+			},
+		}},
+	}
+	require.NoError(t, rule.Sanitize())
+	repo.MustAddList(api.Rules{rule})
+
+	return repo, localIdentity, distillEndpointPolicy(t, repo, localIdentity, ep)
+}
+
+func distillEndpointPolicy(t *testing.T, repo *policy.Repository, localIdentity *identity.Identity, ep *listenerProxyUpdaterMock) *policy.EndpointPolicy {
+	logger := hivetest.Logger(t)
+	selPolicy, _, err := repo.GetSelectorPolicy(localIdentity, 0, &dummyPolicyStats{}, ep.GetID())
+	require.NoError(t, err)
+
+	epp := selPolicy.DistillPolicy(logger, ep, nil)
+	t.Cleanup(func() {
+		epp.Detach(logger)
+	})
+	return epp
+}
+
+func newTestXDSServer(t *testing.T) *xdsServer {
+	logger := hivetest.Logger(t)
+	xds := newXDSServer(
+		logger,
+		nil,
+		nil,
+		newLocalEndpointStore(),
+		xdsServerConfig{},
+		certificatemanager.NewMockSecretManagerInline(),
+	)
+	xds.l7RulesTranslator = envoypolicy.NewEnvoyL7RulesTranslator(logger, nil)
+	return xds
 }


### PR DESCRIPTION
Clean-up stale network policy state if there is any evidence for it:
- endpoint: remove network policy unconditionally when deleting an endpoint
- envoy: Remove stale policies/IPs on UpdateNetworkPolicy
- envoy: Remove DeleteNode

DeleteNode was only ever called on the Endpoint's IPv4 address, so it did not do anything.
