### PR TITLE
Improve quiet mode and debuggability in build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -376,13 +376,15 @@ generate-k8s-api-local:
 
 .PHONY: generate-k8s-api
 generate-k8s-api: ## Generate Cilium k8s API client, deepcopy and deepequal Go sources.
+	@$(ECHO_DOCKER)
 	contrib/scripts/builder.sh \
-		$(MAKE_CONTAINER) -C /go/src/github.com/cilium/cilium/ generate-k8s-api-local
+		$(MAKE_CONTAINER) -C /go/src/github.com/cilium/cilium/ generate-k8s-api-local V=$(V)
 
 .PHONY: generate-bpf
 generate-bpf: ## Generate config structs from BPF objects using dpgen and Go skeletons with bpf2go
+	@$(ECHO_DOCKER)
 	contrib/scripts/builder.sh \
-		$(MAKE_CONTAINER) -C /go/src/github.com/cilium/cilium/bpf generate
+		$(MAKE_CONTAINER) -C /go/src/github.com/cilium/cilium/bpf generate V=$(V)
 
 check-k8s-clusterrole: ## Ensures there is no diff between preflight's clusterrole and runtime's clusterrole.
 	./contrib/scripts/check-preflight-clusterrole.sh

--- a/Makefile
+++ b/Makefile
@@ -385,6 +385,8 @@ generate-bpf: ## Generate config structs from BPF objects using dpgen and Go ske
 	@$(ECHO_DOCKER)
 	contrib/scripts/builder.sh \
 		$(MAKE_CONTAINER) -C /go/src/github.com/cilium/cilium/bpf generate V=$(V)
+	@$(ECHO_CHECK) bpf-skel
+	$(QUIET)git status bpf/ pkg/ --porcelain
 
 check-k8s-clusterrole: ## Ensures there is no diff between preflight's clusterrole and runtime's clusterrole.
 	./contrib/scripts/check-preflight-clusterrole.sh

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -152,22 +152,25 @@ endif
 
 include ./Makefile.bpf
 
-.PHONY: all bpf_all build_all install clean generate gen_compile_commands
-
+.PHONY: all
 all: bpf_all
 
+.PHONY: bpf_all
 bpf_all: $(BPF) generate
 
+.PHONY: build_all
 build_all: force
 	@$(ECHO_CHECK)/*.c BUILD_PERMUTATIONS=1
 	$(QUIET) $(MAKE) $(SUBMAKEOPTS) bpf_all BUILD_PERMUTATIONS=1
 
+.PHONY: testdata
 testdata:
 	@$(ECHO_CC)
 	$(QUIET)${CLANG} ${FLAGS} --target=bpf -Wall -Werror \
 	-c ../pkg/alignchecker/testdata/bpf_foo.c \
 	-o ../pkg/alignchecker/testdata/bpf_foo.o
 
+.PHONY: generate
 generate: $(BPF)
 	@$(ECHO_GEN)../pkg/datapath/types
 	$(QUIET)$(GO) generate ../pkg/datapath/types
@@ -235,10 +238,13 @@ bpf_lxc.o:: bpf_lxc.c $(LIB)
 
 $(foreach OPTS,$(LXC_OPTIONS),$(eval $(call PERMUTATION_template,bpf_lxc.o,$(OPTS))))
 
+.PHONY: install-binary
 install-binary:
 
+.PHONY: install-bash-completion
 install-bash-completion:
 
+.PHONY: clean
 clean:
 	@$(ECHO_CLEAN)
 	$(QUIET)rm -fr *.o *.ll *.i *.s
@@ -246,6 +252,7 @@ clean:
 
 
 BEAR_CLI   = $(shell which bear 2> /dev/null)
+.PHONY: gen_compile_commands
 gen_compile_commands:
 ifeq (, $(BEAR_CLI))
 	@echo 'Bear cli must be in $$PATH to generate json compilation database'

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -163,15 +163,21 @@ build_all: force
 	$(QUIET) $(MAKE) $(SUBMAKEOPTS) bpf_all BUILD_PERMUTATIONS=1
 
 testdata:
-	${CLANG} ${FLAGS} --target=bpf -Wall -Werror \
+	@$(ECHO_CC)
+	$(QUIET)${CLANG} ${FLAGS} --target=bpf -Wall -Werror \
 	-c ../pkg/alignchecker/testdata/bpf_foo.c \
 	-o ../pkg/alignchecker/testdata/bpf_foo.o
 
 generate: $(BPF)
-	$(GO) generate ../pkg/datapath/types
-	$(GO) generate ../pkg/datapath/config
-	$(GO) generate ../pkg/datapath/maps
-	BPF2GO_CC="$(CLANG)" BPF2GO_CFLAGS="$(MAX_OVERLAY_OPTIONS) $(CLANG_FLAGS)" $(GO) generate ../pkg/datapath/bpf
+	@$(ECHO_GEN)../pkg/datapath/types
+	$(QUIET)$(GO) generate ../pkg/datapath/types
+	@$(ECHO_GEN)../pkg/datapath/config
+	$(QUIET)$(GO) generate ../pkg/datapath/config
+	@$(ECHO_GEN)../pkg/datapath/maps
+	$(QUIET)$(GO) generate ../pkg/datapath/maps
+	@$(ECHO_GEN)../pkg/datapath/bpf
+	$(QUIET)BPF2GO_CC="$(CLANG)" BPF2GO_CFLAGS="$(MAX_OVERLAY_OPTIONS) $(CLANG_FLAGS)" \
+		$(GO) generate ../pkg/datapath/bpf
 
 $(BPF_SIMPLE): %.o: %.c $(LIB)
 	@$(ECHO_CC)

--- a/contrib/scripts/builder.sh
+++ b/contrib/scripts/builder.sh
@@ -2,6 +2,11 @@
 
 set -eu
 
+V=${V:-""}
+if [ "$V" != '0' ]; then
+    set -x
+fi
+
 cd "$(dirname "$0")/../.."
 
 CILIUM_BUILDER_IMAGE=$(cat images/cilium/Dockerfile | grep '^ARG CILIUM_BUILDER_IMAGE=' | cut -d '=' -f 2)
@@ -12,6 +17,10 @@ USERID=$(id -u)
 GROUPID=$(id -g)
 USER_OPTION=(--user "$USERID:$GROUPID")
 USER_PATH="/home/ubuntu"
+CHOWN_FLAGS=("--no-dereference")
+if [ "$V" != '0' ]; then
+    CHOWN_FLAGS+=("--changes")
+fi
 
 # Ensure that the GOCACHE and GOMODCACHE directories exist, create as the
 # current user if not: Docker would create it as root if they don't exist, and
@@ -47,7 +56,6 @@ elif [ -d "$LOCAL_CCACHE_DIR" ]; then
 fi
 
 set +u # Workaround for macOS and BASH 3.2 that treats an empty array as "unbound variable".
-echo "Docker params: ${MOUNT_GOCACHE_DIR[@]} ${MOUNT_GOMODCACHE_DIR[@]} ${MOUNT_CCACHE_DIR[@]}"
 CONTAINER=$(docker create \
 	"${MOUNT_GOCACHE_DIR[@]}" \
 	"${MOUNT_GOMODCACHE_DIR[@]}" \
@@ -115,7 +123,11 @@ fi
 
 docker exec "$CONTAINER" groupmod -g "$GROUPID" ubuntu
 # usermod fixes UIDs, but GIDs need to be fixed manually.
-docker exec "$CONTAINER" chown -Rhc --from=:1000 :ubuntu /home/ubuntu
-docker exec "$CONTAINER" usermod -u "$USERID" ubuntu
-docker exec "$CONTAINER" chown -hc ubuntu:ubuntu /home/ubuntu/.cache
+docker exec "$CONTAINER" chown --recursive "${CHOWN_FLAGS[@]}" --from=:1000 :ubuntu /home/ubuntu
+if [ "$V" = '0' ]; then
+	docker exec "$CONTAINER" usermod -u "$USERID" ubuntu >/dev/null
+else
+	docker exec "$CONTAINER" usermod -u "$USERID" ubuntu
+fi
+docker exec "$CONTAINER" chown "${CHOWN_FLAGS[@]}" ubuntu:ubuntu /home/ubuntu/.cache
 docker exec "${USER_OPTION[@]}" ${DOCKER_ARGS:+$DOCKER_ARGS} "$CONTAINER" "$@"

--- a/pkg/bpf/testdata/Makefile
+++ b/pkg/bpf/testdata/Makefile
@@ -18,14 +18,17 @@ TARGETS := \
 
 .DEFAULT_GOAL: docker
 docker: ## Build the testdata binaries using the cilium-builder Docker image.
-	docker run --rm -u "$(UIDGID)" -v "$(ROOT_DIR):/cilium" $(CILIUM_BUILDER_IMAGE) make -C /cilium/pkg/bpf/testdata clean build
+	docker run --rm -u "$(UIDGID)" -v "$(ROOT_DIR):/cilium" -e V=$(V) \
+		$(CILIUM_BUILDER_IMAGE) make -C /cilium/pkg/bpf/testdata clean build
 
 clean: ## Remove testdata artifacts.
-	find "$(TESTDATA_DIR)" -name "*.o" -delete
+	@$(ECHO_CLEAN)
+	$(QUIET)find "$(TESTDATA_DIR)" -name "*.o" -delete
 
 ## Build the testdata binaries using the host's toolchain.
 build: $(addsuffix .o,$(TARGETS))
 
 %.o: %.c
-	$(CLANG) $(CFLAGS) -target bpfel -c $< -o $@
-	$(STRIP) -g $@
+	@$(ECHO_CC) $@
+	$(QUIET)$(CLANG) $(CFLAGS) -target bpfel -c $< -o $@
+	$(QUIET)$(STRIP) -g $@


### PR DESCRIPTION
When passing `V=0` for quiet verbosity on these targets, the build process
was echoing a bunch of find commands and compiler invocations. Fix them
to respect the environment flag and print the quieter form:

```
$ make --quiet -C pkg/bpf/testdata docker V=0
make: Entering directory '/cilium/pkg/bpf/testdata'
  CLEAN  pkg/bpf/testdata /cilium/pkg/bpf/testdata
  CC     pkg/bpf/testdata/reachability.o reachability.o
  CC     pkg/bpf/testdata/unreachable-tailcall.o unreachable-tailcall.o
  CC     pkg/bpf/testdata/upgrade-map.o upgrade-map.o
  CC     pkg/bpf/testdata/unused-map-pruning.o unused-map-pruning.o
  CC     pkg/bpf/testdata/unused-map-false-negative.o unused-map-false-negative.o
make: Leaving directory '/cilium/pkg/bpf/testdata'
$ make --quiet generate-bpf V=0
  DOCKER  generate-bpf
7d9a426f066e8a7effd17434d31c3818583797488e75b33ef30b42f8ea4c08a7
make: Entering directory '/go/src/github.com/cilium/cilium/bpf'
  GEN    bpf/../pkg/datapath/types
  GEN    bpf/../pkg/datapath/config
  GEN    bpf/../pkg/datapath/maps
  GEN    bpf/../pkg/datapath/bpf
make: Leaving directory '/go/src/github.com/cilium/cilium/bpf'
7d9a426f066e8a7effd17434d31c3818583797488e75b33ef30b42f8ea4c08a7
```

And while we're at it, make the `.PHONY` declarations more consistent.

AIL:0
