### PR TITLE
Make unsolicited neighbor advertisements conformant to RFC 4861

### DIFF
--- a/pkg/datapath/gneigh/gneigh.go
+++ b/pkg/datapath/gneigh/gneigh.go
@@ -207,6 +207,7 @@ func (s *ndSender) Send(ip netip.Addr, srcHW net.HardwareAddr) error {
 
 	msg := &ndp.NeighborAdvertisement{
 		TargetAddress: ip,
+		Override:      true,
 		Options: []ndp.Option{
 			&ndp.LinkLayerAddress{
 				Direction: ndp.Target,

--- a/pkg/datapath/gneigh/gneigh.go
+++ b/pkg/datapath/gneigh/gneigh.go
@@ -209,7 +209,7 @@ func (s *ndSender) Send(ip netip.Addr, srcHW net.HardwareAddr) error {
 		TargetAddress: ip,
 		Options: []ndp.Option{
 			&ndp.LinkLayerAddress{
-				Direction: ndp.Source,
+				Direction: ndp.Target,
 				Addr:      srcHW,
 			},
 		},


### PR DESCRIPTION
According to RFC 4861 [1], the only valid neighbor advertisement option is "Target link-layer address", which corresponds to the link-layer address of the sender of the advertisement. Hence, let's fix our implementation that used to incorrectly set the "Source link-layer address" option, which is instead used in neighbor solicitation, router solicitation and router advertisement packets. 

Additionally, quoting RFC 4861, "the O-bit indicates that the advertisement should override an existing cache entry and update the cached link-layer address". This is the desired behavior for gratuitous NAs, because we want to let receivers know that the link-layer address associated with the given IP changed. Hence, let's set it.

\[1]: https://datatracker.ietf.org/doc/html/rfc4861#section-4.4

<!-- Description of change -->

```release-note
Fixed unsolicited IPv6 L2 announcements ignored by receiving hosts, as not conformant to RFC 4861
```
