### PR TITLE
datapath: allow --local-router-ipv4/6 without enable-endpoint-routes

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1087,12 +1087,8 @@ func initEnv(logger *slog.Logger, vp *viper.Viper) {
 	}
 
 	if option.Config.LocalRouterIPv4 != "" || option.Config.LocalRouterIPv6 != "" {
-		// TODO(weil0ng): add a proper check for ipam in PR# 15429.
 		if option.Config.TunnelingEnabled() {
 			logging.Fatal(logger, fmt.Sprintf("Cannot specify %s or %s in tunnel mode.", option.LocalRouterIPv4, option.LocalRouterIPv6))
-		}
-		if !option.Config.EnableEndpointRoutes {
-			logging.Fatal(logger, fmt.Sprintf("Cannot specify %s or %s  without %s.", option.LocalRouterIPv4, option.LocalRouterIPv6, option.EnableEndpointRoutes))
 		}
 	}
 


### PR DESCRIPTION
The --local-router-ipv4/6 flags were originally added for CNI chaining mode where the chained CNI manages IPAM and Cilium may allocate a duplicate router IP from the pod CIDR (issue #13387). However, they were conservatively restricted to require enable-endpoint-routes=true.

In CNI chaining mode, Cilium does not own the CNI, meaning it does not control IPAM or the L3/L2 forwarding path for pod traffic. The chained CNI (e.g., kube-ovn) handles pod networking entirely. The cilium_host IP is only used locally for health checks and service loopback, so enable-endpoint-routes is not a prerequisite.

Remove the enable-endpoint-routes requirement. The tunnel mode restriction remains valid.



Fixes: #issue-number

```release-note
daemon: allow --local-router-ipv4/6 without --enable-endpoint-routes
```
