### PR TITLE
gha: fix hour handling in Ariane scheduled workflow

### DIFF
--- a/.github/workflows/ariane-scheduled.yaml
+++ b/.github/workflows/ariane-scheduled.yaml
@@ -41,7 +41,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          HOUR=$(date -u +"%H")
+          echo "Current date time: $(date --utc --rfc-3339=seconds)"
+
+          HOUR=$(date --utc +"%-H")
           if (( HOUR % 6 == ${{ matrix.hourModulo }} )); then
             echo "Running scheduled workflows for branch ${{ matrix.branch }}"
           else


### PR DESCRIPTION
Currently, the Ariane scheduled workflow retrieves the current hour leveraging the `%H` format specifier, which is zero padded by default. However, this is problematic during the subsequent if check, as bash interprets literals starting with a 0 as octal numbers, hence failing in case of `08` and `09`, which are invalid in octal. Let's get this fixed by removing the padding through the `-` modifier.

While being there, let's also explicitly print the current date and time, which can help in case we want to figure out why a given set of tests was (or was not) run, and use the long option variant for `--utc`, to make it more explicit.

```
$ date --utc +"%H" -d 2006-08-14T02:34:56
02

$ date --utc +"%-H" -d 2006-08-14T02:34:56
2
```
