### PR TITLE
v1.18 backports of PR 45799

### DIFF
--- a/pkg/datapath/connector/add.go
+++ b/pkg/datapath/connector/add.go
@@ -6,9 +6,12 @@ package connector
 import (
 	"crypto/sha256"
 	"fmt"
+	"slices"
 
+	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
+	"github.com/cilium/cilium/pkg/datapath/link"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 )
 
@@ -17,7 +20,29 @@ const (
 	HostInterfacePrefix = "lxc"
 	// temporaryInterfacePrefix is the temporary interface prefix while setting up libNetwork interface.
 	temporaryInterfacePrefix = "tmp"
+	// ciliumCNIAltName is the alternative interface name set on the peer (pod-side)
+	// end of every veth/netkit pair created by Cilium. Used to identify
+	// Cilium-owned interfaces.
+	ciliumCNIAltName = "cilium_cni"
 )
+
+// IsCiliumManagedLink returns true if the link was created by Cilium, identified
+// by the presence of the CniAltName(ifname) altname attribute.
+func IsCiliumManagedLink(link netlink.Link) bool {
+	return slices.Contains(link.Attrs().AltNames, CniAltName(link.Attrs().Name))
+}
+
+// CniAltName returns the altname for this `ifName`
+func CniAltName(ifName string) string {
+	return fmt.Sprintf("%s:%s", ciliumCNIAltName, ifName)
+}
+
+// MarkOwned sets the altname on the interface to mark it as Cilium-owned.
+// Errors are non-fatal — if the kernel doesn't support altnames, the caller
+// should log and continue.
+func MarkOwned(ifName string) error {
+	return link.AddAltName(ifName, CniAltName(ifName))
+}
 
 // Endpoint2IfName returns the host interface name for the given endpointID.
 func Endpoint2IfName(endpointID string) string {

--- a/pkg/datapath/link/link.go
+++ b/pkg/datapath/link/link.go
@@ -50,6 +50,15 @@ func Rename(curName, newName string) error {
 	return netlink.LinkSetName(link, newName)
 }
 
+// AddAltName adds an alternative name to the link identified by linkName.
+func AddAltName(linkName, altName string) error {
+	link, err := safenetlink.LinkByName(linkName)
+	if err != nil {
+		return err
+	}
+	return netlink.LinkAddAltName(link, altName)
+}
+
 func GetHardwareAddr(ifName string) (mac.MAC, error) {
 	iface, err := safenetlink.LinkByName(ifName)
 	if err != nil {

--- a/pkg/mtu/endpoint_updater.go
+++ b/pkg/mtu/endpoint_updater.go
@@ -301,6 +301,10 @@ func defaultRouteHook(routeMTUs []RouteMTU) error {
 			continue
 		}
 
+		if !connector.IsCiliumManagedLink(link) {
+			continue
+		}
+
 		netlink.LinkSetMTU(link, defaultRouteMTU.DeviceMTU)
 
 		routes, err := safenetlink.RouteList(link, netlink.FAMILY_ALL)

--- a/pkg/mtu/endpoint_updater_test.go
+++ b/pkg/mtu/endpoint_updater_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package mtu
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+
+	"github.com/cilium/cilium/pkg/datapath/connector"
+	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+// TestPrivilegedDefaultRouteHookOnlyUpdatesCiliumLinks verifies that
+// defaultRouteHook only sets the MTU on veth interfaces that were created
+// by Cilium (identified via the cilium_cni altname), and leaves interfaces
+// created by other CNI plugins untouched.
+func TestPrivilegedDefaultRouteHookOnlyUpdatesCiliumLinks(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	const (
+		initMTU = 1500
+		newMTU  = 1400
+	)
+
+	// Create a Cilium-managed veth pair (host side: cilium-h, peer side: cilium-p).
+	ciliumVeth := &netlink.Veth{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:   "test-cilium-h",
+			TxQLen: 1000,
+		},
+		PeerName: "test-cilium-p",
+	}
+	require.NoError(t, netlink.LinkAdd(ciliumVeth))
+	defer netlink.LinkDel(ciliumVeth)
+
+	// Set initial MTU on the cilium peer.
+	ciliumPeer, err := safenetlink.LinkByName("test-cilium-p")
+	require.NoError(t, err)
+	require.NoError(t, netlink.LinkSetMTU(ciliumPeer, initMTU))
+
+	// Mark the peer as Cilium-owned by adding the altname.
+	require.NoError(t, netlink.LinkAddAltName(ciliumPeer, connector.CniAltName("test-cilium-p")))
+
+	// Create a plain veth pair NOT owned by Cilium (simulates another CNI plugin).
+	otherVeth := &netlink.Veth{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:   "test-other-h",
+			TxQLen: 1000,
+		},
+		PeerName:         "test-other-p",
+		PeerHardwareAddr: net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x01},
+	}
+	require.NoError(t, netlink.LinkAdd(otherVeth))
+	defer netlink.LinkDel(otherVeth)
+
+	otherPeer, err := safenetlink.LinkByName("test-other-p")
+	require.NoError(t, err)
+	require.NoError(t, netlink.LinkSetMTU(otherPeer, initMTU))
+	// No altname set — this is not a Cilium interface.
+
+	// Build a minimal RouteMTU list that defaultRouteHook will use.
+	routeMTUs := []RouteMTU{
+		{
+			Prefix:    DefaultPrefixV4,
+			DeviceMTU: newMTU,
+			RouteMTU:  newMTU,
+		},
+	}
+
+	// Run the hook.
+	err = defaultRouteHook(routeMTUs)
+	require.NoError(t, err)
+
+	// The Cilium peer's MTU should have been updated.
+	updatedCiliumPeer, err := safenetlink.LinkByName("test-cilium-p")
+	require.NoError(t, err)
+	require.Equal(t, newMTU, updatedCiliumPeer.Attrs().MTU,
+		"expected Cilium-managed peer MTU to be updated to %d", newMTU)
+
+	// The other CNI plugin's peer MTU should be unchanged.
+	updatedOtherPeer, err := safenetlink.LinkByName("test-other-p")
+	require.NoError(t, err)
+	require.Equal(t, initMTU, updatedOtherPeer.Attrs().MTU,
+		"expected non-Cilium peer MTU to remain at %d", initMTU)
+}

--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -682,9 +682,20 @@ func (cmd *Cmd) Add(args *skel.CmdArgs) (err error) {
 		if err := netlink.LinkSetNsFd(epLink, ns.FD()); err != nil {
 			return fmt.Errorf("unable to move netkit pair %q to netns %s: %w", epLink, args.Netns, err)
 		}
+
 		err = connector.RenameLinkInRemoteNs(ns, tmpIfName, epConf.IfName())
 		if err != nil {
 			return fmt.Errorf("unable to set up netkit on container side: %w", err)
+		}
+
+		if err := ns.Do(func() error {
+			// Mark the peer interface as Cilium-owned via altname so that other
+			// components (e.g. MTU updater) can distinguish it from interfaces
+			// created by other CNI plugins.
+
+			return connector.MarkOwned(epConf.IfName())
+		}); err != nil {
+			return fmt.Errorf("failed to rename link from %q to %q: %w", tmpIfName, epConf.IfName(), err)
 		}
 
 		if l2Mode {


### PR DESCRIPTION
* [x] #45799 (modified files are not existing in the target branch)

the changes were manually introduced as the original PR was built on top of main after some refactoring was done (https://github.com/cilium/cilium/pull/43062). the refactor changes were not backported, and caused quite a few conflicts.
implementing the equivalent functionality seemed to be the least intrusive course of action, so here we are. 

cherry-picked commits from https://github.com/cilium/cilium/pull/46028

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 45799
```
