### PR TITLE
gha/clustermesh: run on schedule, rather than on every push to main

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -21,12 +21,8 @@ on:
         required: false
         default: '{}'
 
-  push:
-    branches:
-      - main
-      - ft/main/**
-    paths-ignore:
-      - 'Documentation/**'
+  schedule:
+    - cron: '30 5/8 * * *'
 
 # By specifying the access of one of the scopes, all of those that are not
 # specified are set to 'none'.
@@ -46,6 +42,7 @@ concurrency:
   # - Event type
   # - A unique identifier depending on event type:
   #   - push: SHA
+  #   - schedule: SHA
   #   - workflow_dispatch: PR number
   #
   # This structure ensures a unique concurrency group name is generated for each
@@ -55,6 +52,7 @@ concurrency:
     ${{ github.event_name }}
     ${{
       (github.event_name == 'push' && github.sha) ||
+      (github.event_name == 'schedule' && github.sha) ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.PR-number)
     }}
   cancel-in-progress: true

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -21,12 +21,8 @@ on:
         required: false
         default: '{}'
 
-  push:
-    branches:
-      - main
-      - ft/main/**
-    paths-ignore:
-      - 'Documentation/**'
+  schedule:
+    - cron: '30 5/8 * * *'
 
 # By specifying the access of one of the scopes, all of those that are not
 # specified are set to 'none'.
@@ -46,6 +42,7 @@ concurrency:
   # - Event type
   # - A unique identifier depending on event type:
   #   - push: SHA
+  #   - schedule: SHA
   #   - workflow_dispatch: PR number
   #
   # This structure ensures a unique concurrency group name is generated for each
@@ -55,6 +52,7 @@ concurrency:
     ${{ github.event_name }}
     ${{
       (github.event_name == 'push' && github.sha) ||
+      (github.event_name == 'schedule' && github.sha) ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.PR-number)
     }}
   cancel-in-progress: true


### PR DESCRIPTION
Let's switch the Cluster Mesh workflows to run on a scheduled basis, rather than every time a commit is merged into the main branch. This aligns them with the vast majority of the other workflows that also run on schedule, and ensure a consistent interval regardless of the number of commits that get merged in a given interval of time, making it also easier to analyze results in the CI dashboard. The likelihood of a newly merged commit introducing regressions is anyways fairly low, considering that the same tests also gate PR merging. In addition, this change should also help with reducing our GitHub Actions usage.

This PR essentially reverts d21617f4e47c ("ci: migrate clustermesh workflows from schedule to push")