### PR TITLE
DO NOT MERGE conformance: avoid mirror log races

### DIFF
--- a/vendor/sigs.k8s.io/gateway-api/conformance/tests/httproute-request-mirror.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/tests/httproute-request-mirror.go
@@ -19,6 +19,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
@@ -104,8 +105,11 @@ var HTTPRouteRequestMirror = suite.ConformanceTest{
 			tc := testCases[i]
 			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
 				t.Parallel()
+				tc.AddRequestIDQueryParam(uuid.NewString())
+				// Start inspecting logs before sending the request
+				waitForMirroredRequests := http.ExpectMirroredRequest(t, suite.Client, suite.Clientset, tc.MirroredTo, tc.Request.Path, suite.TimeoutConfig)
+				defer waitForMirroredRequests() // defer in case we exit below
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
-				http.ExpectMirroredRequest(t, suite.Client, suite.Clientset, tc.MirroredTo, tc.Request.Path, suite.TimeoutConfig)
 			})
 		}
 	},

--- a/vendor/sigs.k8s.io/gateway-api/conformance/tests/httproute-request-mirror.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/tests/httproute-request-mirror.go
@@ -105,11 +105,14 @@ var HTTPRouteRequestMirror = suite.ConformanceTest{
 			tc := testCases[i]
 			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
 				t.Parallel()
-				tc.AddRequestIDQueryParam(uuid.NewString())
+				err := tc.AddRequestIDQueryParam(uuid.NewString())
+				if err != nil {
+					t.Fatalf("Invalid query in path: %v", err)
+				}
 				// Start inspecting logs before sending the request
 				waitForMirroredRequests := http.ExpectMirroredRequest(t, suite.Client, suite.Clientset, tc.MirroredTo, tc.Request.Path, suite.TimeoutConfig)
-				defer waitForMirroredRequests() // defer in case we exit below
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+				waitForMirroredRequests()
 			})
 		}
 	},

--- a/vendor/sigs.k8s.io/gateway-api/conformance/tests/httproute-request-multiple-mirrors.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/tests/httproute-request-multiple-mirrors.go
@@ -19,6 +19,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/http"
@@ -116,8 +117,11 @@ var HTTPRouteRequestMultipleMirrors = suite.ConformanceTest{
 			tc := testCases[i]
 			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
 				t.Parallel()
+				tc.AddRequestIDQueryParam(uuid.NewString())
+				// Start inspecting logs before sending the request
+				waitForMirroredRequests := http.ExpectMirroredRequest(t, suite.Client, suite.Clientset, tc.MirroredTo, tc.Request.Path, suite.TimeoutConfig)
+				defer waitForMirroredRequests() // defer in case we exit below
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
-				http.ExpectMirroredRequest(t, suite.Client, suite.Clientset, tc.MirroredTo, tc.Request.Path, suite.TimeoutConfig)
 			})
 		}
 	},

--- a/vendor/sigs.k8s.io/gateway-api/conformance/tests/httproute-request-multiple-mirrors.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/tests/httproute-request-multiple-mirrors.go
@@ -117,11 +117,14 @@ var HTTPRouteRequestMultipleMirrors = suite.ConformanceTest{
 			tc := testCases[i]
 			t.Run(tc.GetTestCaseName(i), func(t *testing.T) {
 				t.Parallel()
-				tc.AddRequestIDQueryParam(uuid.NewString())
+				err := tc.AddRequestIDQueryParam(uuid.NewString())
+				if err != nil {
+					t.Fatalf("Invalid query in path: %v", err)
+				}
 				// Start inspecting logs before sending the request
 				waitForMirroredRequests := http.ExpectMirroredRequest(t, suite.Client, suite.Clientset, tc.MirroredTo, tc.Request.Path, suite.TimeoutConfig)
-				defer waitForMirroredRequests() // defer in case we exit below
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, tc)
+				waitForMirroredRequests()
 			})
 		}
 	},

--- a/vendor/sigs.k8s.io/gateway-api/conformance/tests/httproute-request-percentage-mirror.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/tests/httproute-request-percentage-mirror.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -141,8 +142,11 @@ var HTTPRouteRequestPercentageMirror = suite.ConformanceTest{
 		for i := range testCases {
 			expected := testCases[i]
 			t.Run(expected.GetTestCaseName(i), func(t *testing.T) {
+				initialExpected := expected
+				initialExpected.AddRequestIDQueryParam(uuid.NewString())
+
 				// Assert request succeeds before doing our distribution check
-				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expected)
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, initialExpected)
 
 				// Override to not have more requests than expected
 				dedicatedTimeoutConfig := suite.TimeoutConfig
@@ -152,6 +156,8 @@ var HTTPRouteRequestPercentageMirror = suite.ConformanceTest{
 				var wg sync.WaitGroup
 
 				for k := 0; k < numDistributionChecks; k++ {
+					distributionExpected := expected
+					distributionExpected.AddRequestIDQueryParam(uuid.NewString())
 					timeNow := time.Now()
 					for j := 0; j < totalRequests; j++ {
 						wg.Add(1)
@@ -160,10 +166,10 @@ var HTTPRouteRequestPercentageMirror = suite.ConformanceTest{
 							defer wg.Done()
 							defer func() { <-semaphore }()
 							http.MakeRequestAndExpectEventuallyConsistentResponse(t, r, timeoutConfig, gwAddr, expected)
-						}(t, suite.RoundTripper, dedicatedTimeoutConfig, gwAddr, expected)
+						}(t, suite.RoundTripper, dedicatedTimeoutConfig, gwAddr, distributionExpected)
 					}
 					wg.Wait()
-					if err := testMirroredRequestsDistribution(t, suite, expected, timeNow); err != nil {
+					if err := testMirroredRequestsDistribution(t, suite, distributionExpected, timeNow); err != nil {
 						t.Logf("Traffic distribution test failed (%d/%d): %s", k+1, numDistributionChecks, err)
 						time.Sleep(2 * time.Second)
 					} else {
@@ -189,7 +195,7 @@ func testMirroredRequestsDistribution(t *testing.T, suite *suite.ConformanceTest
 
 	for _, mirrorPod := range mirrorPods {
 		require.Eventually(t, func() bool {
-			mirrorLogRegexp := regexp.MustCompile(fmt.Sprintf("Echoing back request made to \\%s to client", expected.Request.Path))
+			mirrorLogRegexp := regexp.MustCompile(fmt.Sprintf("Echoing back request made to %s to client", regexp.QuoteMeta(expected.Request.Path)))
 
 			tlog.Log(t, "Searching for the mirrored request log")
 			tlog.Logf(t, `Reading "%s/%s" logs`, mirrorPod.Namespace, mirrorPod.Name)

--- a/vendor/sigs.k8s.io/gateway-api/conformance/tests/httproute-request-percentage-mirror.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/tests/httproute-request-percentage-mirror.go
@@ -142,11 +142,8 @@ var HTTPRouteRequestPercentageMirror = suite.ConformanceTest{
 		for i := range testCases {
 			expected := testCases[i]
 			t.Run(expected.GetTestCaseName(i), func(t *testing.T) {
-				initialExpected := expected
-				initialExpected.AddRequestIDQueryParam(uuid.NewString())
-
 				// Assert request succeeds before doing our distribution check
-				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, initialExpected)
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, gwAddr, expected)
 
 				// Override to not have more requests than expected
 				dedicatedTimeoutConfig := suite.TimeoutConfig
@@ -156,8 +153,10 @@ var HTTPRouteRequestPercentageMirror = suite.ConformanceTest{
 				var wg sync.WaitGroup
 
 				for k := 0; k < numDistributionChecks; k++ {
-					distributionExpected := expected
-					distributionExpected.AddRequestIDQueryParam(uuid.NewString())
+					err := expected.AddRequestIDQueryParam(uuid.NewString())
+					if err != nil {
+						t.Fatalf("Invalid query in path: %v", err)
+					}
 					timeNow := time.Now()
 					for j := 0; j < totalRequests; j++ {
 						wg.Add(1)
@@ -166,10 +165,10 @@ var HTTPRouteRequestPercentageMirror = suite.ConformanceTest{
 							defer wg.Done()
 							defer func() { <-semaphore }()
 							http.MakeRequestAndExpectEventuallyConsistentResponse(t, r, timeoutConfig, gwAddr, expected)
-						}(t, suite.RoundTripper, dedicatedTimeoutConfig, gwAddr, distributionExpected)
+						}(t, suite.RoundTripper, dedicatedTimeoutConfig, gwAddr, expected)
 					}
 					wg.Wait()
-					if err := testMirroredRequestsDistribution(t, suite, distributionExpected, timeNow); err != nil {
+					if err := testMirroredRequestsDistribution(t, suite, expected, timeNow); err != nil {
 						t.Logf("Traffic distribution test failed (%d/%d): %s", k+1, numDistributionChecks, err)
 						time.Sleep(2 * time.Second)
 					} else {

--- a/vendor/sigs.k8s.io/gateway-api/conformance/utils/http/http.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/utils/http/http.go
@@ -85,25 +85,40 @@ const requestIDQueryParam = "gateway-api-conformance-request-id"
 
 // AddRequestIDQueryParam adds a request ID to the request URI so that echo
 // server logs for this request can be matched unambiguously.
-func (e *ExpectedResponse) AddRequestIDQueryParam(requestID string) {
-	e.Request.Path = addQueryParam(e.Request.Path, requestIDQueryParam, requestID)
-	if e.ExpectedRequest != nil {
-		if e.ExpectedRequest.Path == "" {
-			e.ExpectedRequest.Path = e.Request.Path
+// Returns a non-nil error if either Request.Path or ExpectedRequest.Path has an unparseable query.
+func (er *ExpectedResponse) AddRequestIDQueryParam(requestID string) error {
+	path, err := addQueryParam(er.Request.Path, requestIDQueryParam, requestID)
+	if err != nil {
+		return err
+	}
+	if er.ExpectedRequest != nil {
+		if er.ExpectedRequest.Path == "" {
+			er.ExpectedRequest.Path = path
 		} else {
-			e.ExpectedRequest.Path = addQueryParam(e.ExpectedRequest.Path, requestIDQueryParam, requestID)
+			er.ExpectedRequest.Path, err = addQueryParam(er.ExpectedRequest.Path, requestIDQueryParam, requestID)
+			if err != nil {
+				return err
+			}
 		}
 	}
+	er.Request.Path = path
+	return nil
 }
 
-func addQueryParam(path, name, value string) string {
-	pathOnly, rawQuery, _ := strings.Cut(path, "?")
-	query, err := url.ParseQuery(rawQuery)
-	if err != nil {
-		query = url.Values{}
+// addQueryParam adds 'name'='value' query parameter to the given 'path'.
+// returns an error if existing query cannot be parsed.
+func addQueryParam(path, name, value string) (string, error) {
+	var query url.Values
+	pathOnly, rawQuery, found := strings.Cut(path, "?")
+	if found {
+		var err error
+		query, err = url.ParseQuery(rawQuery)
+		if err != nil {
+			return "", err
+		}
 	}
 	query.Set(name, value)
-	return pathOnly + "?" + query.Encode()
+	return pathOnly + "?" + query.Encode(), nil
 }
 
 // ExpectedRequest defines expected properties of a request that reaches a backend.

--- a/vendor/sigs.k8s.io/gateway-api/conformance/utils/http/http.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/utils/http/http.go
@@ -81,6 +81,31 @@ type Request struct {
 	ClientCert       string
 }
 
+const requestIDQueryParam = "gateway-api-conformance-request-id"
+
+// AddRequestIDQueryParam adds a request ID to the request URI so that echo
+// server logs for this request can be matched unambiguously.
+func (e *ExpectedResponse) AddRequestIDQueryParam(requestID string) {
+	e.Request.Path = addQueryParam(e.Request.Path, requestIDQueryParam, requestID)
+	if e.ExpectedRequest != nil {
+		if e.ExpectedRequest.Path == "" {
+			e.ExpectedRequest.Path = e.Request.Path
+		} else {
+			e.ExpectedRequest.Path = addQueryParam(e.ExpectedRequest.Path, requestIDQueryParam, requestID)
+		}
+	}
+}
+
+func addQueryParam(path, name, value string) string {
+	pathOnly, rawQuery, _ := strings.Cut(path, "?")
+	query, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		query = url.Values{}
+	}
+	query.Set(name, value)
+	return pathOnly + "?" + query.Encode()
+}
+
 // ExpectedRequest defines expected properties of a request that reaches a backend.
 type ExpectedRequest struct {
 	Request

--- a/vendor/sigs.k8s.io/gateway-api/conformance/utils/http/mirror.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/utils/http/mirror.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 	clientset "k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -32,25 +32,31 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
 )
 
-func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clientset.Interface, mirrorPods []MirroredBackend, path string, timeoutConfig config.TimeoutConfig) {
+func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clientset.Interface, mirrorPods []MirroredBackend, path string, timeoutConfig config.TimeoutConfig) func() {
 	for i, mirrorPod := range mirrorPods {
 		if mirrorPod.Name == "" {
 			tlog.Fatalf(t, "Mirrored BackendRef[%d].Name wasn't provided in the testcase, this test should only check http request mirror.", i)
 		}
 	}
 
-	var wg sync.WaitGroup
-	wg.Add(len(mirrorPods))
+	mirrorLogRegexp := regexp.MustCompile(fmt.Sprintf("Echoing back request made to %s to client", regexp.QuoteMeta(path)))
 
-	assertionStart := time.Now()
+	var done sync.WaitGroup
+	done.Add(len(mirrorPods))
+	var started sync.WaitGroup
+	started.Add(len(mirrorPods))
+	results := make(chan bool, len(mirrorPods))
+
+	// Apply one second safety margin for small clock skew between the nodes.
+	assertionStart := time.Now().Add(-time.Second)
 
 	for _, mirrorPod := range mirrorPods {
 		go func(mirrorPod MirroredBackend) {
-			defer wg.Done()
+			var startedOnce sync.Once
 
-			require.Eventually(t, func() bool {
-				mirrorLogRegexp := regexp.MustCompile(fmt.Sprintf("Echoing back request made to \\%s to client", path))
+			defer done.Done()
 
+			success := assert.Eventually(t, func() bool {
 				tlog.Log(t, "Searching for the mirrored request log")
 				tlog.Logf(t, `Reading "%s/%s" logs`, mirrorPod.Namespace, mirrorPod.Name)
 				logs, err := kubernetes.DumpEchoLogs(t.Context(), mirrorPod.Namespace, mirrorPod.Name, client, clientset, assertionStart)
@@ -59,6 +65,10 @@ func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clients
 					return false
 				}
 
+				// Report as started after we have successfully dumped the logs for
+				// the first time.
+				startedOnce.Do(started.Done)
+
 				for _, log := range logs {
 					if mirrorLogRegexp.MatchString(log) {
 						return true
@@ -66,10 +76,30 @@ func ExpectMirroredRequest(t *testing.T, client client.Client, clientset clients
 				}
 				return false
 			}, timeoutConfig.RequestTimeout, time.Second, `Couldn't find mirrored request in "%s/%s" logs`, mirrorPod.Namespace, mirrorPod.Name)
+
+			// signal done even if all log dumps failed above.
+			startedOnce.Do(started.Done)
+			results <- success
 		}(mirrorPod)
 	}
 
-	wg.Wait()
+	// Wait until each watcher has either dumped logs at least once or timed out.
+	started.Wait()
 
-	tlog.Log(t, "Found mirrored request log in all desired backends")
+	// caller should eventually call the returned function to wait for the goroutines to be done
+	// and to log if successful
+	return func() {
+		done.Wait()
+		close(results)
+
+		successes := 0
+		for result := range results {
+			if result {
+				successes++
+			}
+		}
+		if successes == len(mirrorPods) {
+			tlog.Log(t, "Found mirrored request log in all desired backends")
+		}
+	}
 }


### PR DESCRIPTION
Start watching mirrored backend logs before sending mirror test requests, and add a unique request ID query parameter to the echoed URI matched in logs. This avoids flakes where the mirrored request is logged before the test starts reading logs, as seen in Cilium CI, and prevents logs from nearby test runs or retry attempts from satisfying the matcher.

Also add a small log timestamp lookback for node clock skew and quote the matched URI before building the regex.

> NOTE: This is a change against verdored files for testing purposes only!

Fixes: #46078
