### PR TITLE
helm: fix l2podAnnouncements.interface rendering dead configmap key

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -3135,15 +3135,15 @@
    * - :spelling:ignore:`l2podAnnouncements`
      - Configure L2 pod announcements
      - object
-     - ``{"enabled":false,"interface":"eth0"}``
+     - ``{"enabled":false,"interfacePattern":""}``
    * - :spelling:ignore:`l2podAnnouncements.enabled`
      - Enable L2 pod announcements
      - bool
      - ``false``
-   * - :spelling:ignore:`l2podAnnouncements.interface`
-     - Interface used for sending Gratuitous ARP pod announcements
+   * - :spelling:ignore:`l2podAnnouncements.interfacePattern`
+     - A regular expression matching interfaces used for sending Gratuitous ARP pod announcements
      - string
-     - ``"eth0"``
+     - ``""``
    * - :spelling:ignore:`l7Proxy`
      - Enable Layer 7 network policy.
      - bool

--- a/Documentation/network/l2-announcements.rst
+++ b/Documentation/network/l2-announcements.rst
@@ -570,19 +570,18 @@ To enable L2 Pod Announcements, set the following:
            :namespace: kube-system
            :extra-args: --reuse-values
            :set: l2podAnnouncements.enabled=true
-                 l2podAnnouncements.interface=eth0
+                 l2podAnnouncements.interfacePattern='^eth0$'
 
     .. group-tab:: ConfigMap
 
         .. code-block:: yaml
 
             enable-l2-pod-announcements: true
-            l2-pod-announcements-interface: eth0
+            l2-pod-announcements-interface-pattern: "^eth0$"
 
-The ``l2podAnnouncements.interface``/``l2-pod-announcements-interface`` options allows you to specify 
-one interface use to send announcements.  If you would like to send announcements on multiple interfaces, you should use the
-``l2podAnnouncements.interfacePattern``/``l2-pod-announcements-interface-pattern`` option instead. 
-This option takes a regex, matching on multiple interfaces.
+The ``l2podAnnouncements.interfacePattern``/``l2-pod-announcements-interface-pattern`` option takes
+a regex matching the interfaces used to send announcements. To match multiple interfaces, use a regex
+pattern like ``^(eth0|ens1)$``.
 
 .. tabs::
     .. group-tab:: Helm

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -833,9 +833,9 @@ contributors across the globe, there is almost always someone available to help.
 | l2NeighDiscovery.enabled | bool | `false` | Enable L2 neighbor discovery in the agent |
 | l2announcements | object | `{"enabled":false}` | Configure L2 announcements |
 | l2announcements.enabled | bool | `false` | Enable L2 announcements |
-| l2podAnnouncements | object | `{"enabled":false,"interface":"eth0"}` | Configure L2 pod announcements |
+| l2podAnnouncements | object | `{"enabled":false,"interfacePattern":""}` | Configure L2 pod announcements |
 | l2podAnnouncements.enabled | bool | `false` | Enable L2 pod announcements |
-| l2podAnnouncements.interface | string | `"eth0"` | Interface used for sending Gratuitous ARP pod announcements |
+| l2podAnnouncements.interfacePattern | string | `""` | A regular expression matching interfaces used for sending Gratuitous ARP pod announcements |
 | l7Proxy | bool | `true` | Enable Layer 7 network policy. |
 | livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1288,8 +1288,6 @@ data:
   enable-l2-pod-announcements: {{ .Values.l2podAnnouncements.enabled | quote }}
   {{- if .Values.l2podAnnouncements.interfacePattern }}
   l2-pod-announcements-interface-pattern: {{ .Values.l2podAnnouncements.interfacePattern | quote }}
-  {{- else }}
-  l2-pod-announcements-interface: {{ .Values.l2podAnnouncements.interface | quote }}
   {{- end }}
 {{- end }}
 

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -4748,7 +4748,7 @@
         "enabled": {
           "type": "boolean"
         },
-        "interface": {
+        "interfacePattern": {
           "type": "string"
         }
       },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -509,10 +509,8 @@ l2announcements:
 l2podAnnouncements:
   # -- Enable L2 pod announcements
   enabled: false
-  # -- Interface used for sending Gratuitous ARP pod announcements
-  interface: "eth0"
   # -- A regular expression matching interfaces used for sending Gratuitous ARP pod announcements
-  # interfacePattern: ""
+  interfacePattern: ""
 # -- This feature set enables virtual BGP routers to be created via BGP CRDs.
 bgpControlPlane:
   # -- Enables the BGP control plane.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -512,10 +512,8 @@ l2announcements:
 l2podAnnouncements:
   # -- Enable L2 pod announcements
   enabled: false
-  # -- Interface used for sending Gratuitous ARP pod announcements
-  interface: "eth0"
   # -- A regular expression matching interfaces used for sending Gratuitous ARP pod announcements
-  # interfacePattern: ""
+  interfacePattern: ""
 # -- This feature set enables virtual BGP routers to be created via BGP CRDs.
 bgpControlPlane:
   # -- Enables the BGP control plane.


### PR DESCRIPTION
## Summary

The Helm chart's configmap template renders the defunct key `l2-pod-announcements-interface` when
`l2podAnnouncements.interface` is set but `l2podAnnouncements.interfacePattern` is empty.
Since v1.19, the cilium-agent only recognises the `--l2-pod-announcements-interface-pattern` flag
(see `pkg/datapath/gneigh/cells.go`). The legacy `--l2-pod-announcements-interface` flag was
announced as removed in v1.18 and no longer exists in the agent.

This caused the agent to crash-loop with:

```
unable to run agent: failed to start: failed to populate object graph:
'--l2-pod-announcements-interface-pattern' must be set, when --enable-l2-pod-announcements=true
```

This PR fully removes the defunct `interface` value from the Helm chart and only keeps
`interfacePattern`, which is the only option the agent supports.

### Changes:
- **`install/kubernetes/cilium/templates/cilium-configmap.yaml`**: Remove the `else` branch
  that rendered the dead `l2-pod-announcements-interface` key. Only render
  `l2-pod-announcements-interface-pattern` when `interfacePattern` is set.
- **`install/kubernetes/cilium/values.yaml.tmpl`** and **`install/kubernetes/cilium/values.yaml`**:
  Remove the defunct `interface` field entirely. Make `interfacePattern` the only option.
- **`install/kubernetes/cilium/values.schema.json`**: Replace `interface` with `interfacePattern`
  in the schema definition.
- **`Documentation/network/l2-announcements.rst`**: Remove all references to the defunct
  `interface` option and document `interfacePattern` as the sole configuration method.

## AI Influence

This PR was prepared with AIL:3. I personally reviewed each line of the submission prior to
opening this PR.

Fixes: [#46075](https://github.com/cilium/cilium/issues/46075)

```release-note
Remove defunct `l2podAnnouncements.interface` Helm value that rendered a configmap key the agent no longer recognises, causing crash-loops when L2 pod announcements were enabled. Users must use `l2podAnnouncements.interfacePattern` instead.
```

---

## How to test

```bash
# Test 1: interfacePattern works correctly
helm template cilium ./cilium \
  --set l2podAnnouncements.enabled=true \
  --set 'l2podAnnouncements.interfacePattern=^eno1$' \
  | grep "l2-pod-announcements"
# Expected: l2-pod-announcements-interface-pattern: "^eno1$"

# Test 2: no dead key rendered when interfacePattern is empty
helm template cilium ./cilium \
  --set l2podAnnouncements.enabled=true \
  | grep "l2-pod-announcements"
# Expected: only enable-l2-pod-announcements: "true" (no interface-pattern line)

# Test 3: multi-interface regex
helm template cilium ./cilium \
  --set l2podAnnouncements.enabled=true \
  --set 'l2podAnnouncements.interfacePattern=^(eth0|ens1)$' \
  | grep "l2-pod-announcements"
# Expected: l2-pod-announcements-interface-pattern: "^(eth0|ens1)$"
```
