### PR TITLE
gw-api: add external auth example

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -485,6 +485,8 @@ Makefile* @cilium/build
 /examples/kubernetes-egress-gateway/ @cilium/egress-gateway
 /examples/kubernetes/ @cilium/sig-k8s
 /examples/kubernetes/clustermesh/ @cilium/sig-clustermesh
+/examples/kubernetes/gateway/ @cilium/sig-servicemesh
+/examples/kubernetes/servicemesh/ @cilium/sig-servicemesh
 /examples/minikube/ @cilium/sig-k8s
 /examples/policies/kubernetes/clustermesh/ @cilium/sig-clustermesh
 /hack/ @cilium/contributing

--- a/examples/kubernetes/gateway/external-authz/Dockerfile
+++ b/examples/kubernetes/gateway/external-authz/Dockerfile
@@ -1,0 +1,9 @@
+FROM docker.io/library/golang:1.26 AS builder
+
+WORKDIR /src
+COPY . .
+RUN CGO_ENABLED=0 GOFLAGS=-mod=vendor go build -o /out/external-authz ./examples/kubernetes/gateway/external-authz
+
+FROM cgr.dev/chainguard/static:latest
+COPY --from=builder /out/external-authz /usr/local/bin/external-authz
+ENTRYPOINT ["/usr/local/bin/external-authz"]

--- a/examples/kubernetes/gateway/external-authz/README.md
+++ b/examples/kubernetes/gateway/external-authz/README.md
@@ -1,0 +1,81 @@
+# ExternalAuth Test Service
+
+This directory contains a minimal test auth service for Gateway API `ExternalAuth`
+experiments with Cilium.
+
+It exposes:
+
+- HTTP ext_authz endpoint on port `8080`
+- gRPC ext_authz endpoint on port `9000`
+
+Both variants:
+
+- always allow the request
+- log one line per request
+- add `X-Test-Authz` to the allow response
+
+## Build
+
+For a local `kind` cluster:
+
+```bash
+docker build -t external-authz-test:dev -f examples/kubernetes/gateway/external-authz/Dockerfile .
+kind load docker-image external-authz-test:dev
+```
+
+## Deploy
+
+This example assumes:
+
+- Cilium Gateway API support is enabled
+- Gateway API CRDs with `ExternalAuth` support are installed
+
+Apply the full setup:
+
+```bash
+kubectl apply -f examples/kubernetes/gateway/external-authz/manifests.yaml
+```
+
+This creates:
+
+- `auth-service` with HTTP and gRPC ext_authz endpoints
+- an `echo` backend service
+- one `Gateway`
+- five `HTTPRoute`s:
+  - `/http-auth` uses HTTP `ExternalAuth`
+  - `/http-auth-shared` reuses the same HTTP `ExternalAuth` config on another path
+  - `/http-auth-variant` reuses the same auth service with different HTTP auth settings
+  - `/grpc-auth` uses gRPC `ExternalAuth`
+  - `/no-auth` has no auth filter
+
+## Verify
+
+Get the gateway address:
+
+```bash
+kubectl -n gateway-external-authz-demo get gateway ext-authz-gateway
+```
+
+Then send requests:
+
+```bash
+curl -i http://GATEWAY_ADDRESS/http-auth
+curl -i http://GATEWAY_ADDRESS/http-auth-shared
+curl -i -H 'X-Debug-Token: demo' http://GATEWAY_ADDRESS/http-auth-variant
+curl -i http://GATEWAY_ADDRESS/grpc-auth
+curl -i http://GATEWAY_ADDRESS/no-auth
+```
+
+Watch auth logs:
+
+```bash
+kubectl -n gateway-external-authz-demo logs deploy/ext-authz-test -f
+```
+
+Expected behavior:
+
+- `/http-auth` logs an HTTP auth request
+- `/http-auth-shared` also logs an HTTP auth request through the same auth service
+- `/http-auth-variant` logs an HTTP auth request to a different auth path (`/variant-check`)
+- `/grpc-auth` logs a gRPC auth request
+- `/no-auth` reaches the backend without an auth-service log line

--- a/examples/kubernetes/gateway/external-authz/main.go
+++ b/examples/kubernetes/gateway/external-authz/main.go
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"slices"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	authv3 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	grpc_health_v1 "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+const (
+	defaultHTTPPort = 8080
+	defaultGRPCPort = 9000
+	shutdownTimeout = 5 * time.Second
+
+	logKeyError   = "error"
+	logKeyHeaders = "headers"
+	logKeyHost    = "host"
+	logKeyMethod  = "method"
+	logKeyPath    = "path"
+	logKeyPort    = "port"
+)
+
+type server struct {
+	authv3.UnimplementedAuthorizationServer
+	logger *slog.Logger
+}
+
+func main() {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+
+	httpPort := getenvInt("HTTP_PORT", defaultHTTPPort)
+	grpcPort := getenvInt("GRPC_PORT", defaultGRPCPort)
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	httpSrv := &http.Server{
+		Addr:              fmt.Sprintf(":%d", httpPort),
+		Handler:           newHTTPMux(logger),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	grpcLis, err := net.Listen("tcp", fmt.Sprintf(":%d", grpcPort))
+	if err != nil {
+		logger.Error("failed to listen for gRPC", logKeyError, err)
+		os.Exit(1)
+	}
+
+	grpcSrv := grpc.NewServer()
+	authv3.RegisterAuthorizationServer(grpcSrv, &server{logger: logger})
+	grpc_health_v1.RegisterHealthServer(grpcSrv, healthServer{})
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		logger.Info("starting HTTP auth service", logKeyPort, httpPort)
+		err := httpSrv.ListenAndServe()
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return err
+		}
+		return nil
+	})
+	g.Go(func() error {
+		logger.Info("starting gRPC auth service", logKeyPort, grpcPort)
+		if err := grpcSrv.Serve(grpcLis); err != nil && gctx.Err() == nil {
+			return err
+		}
+		return nil
+	})
+
+	<-ctx.Done()
+	logger.Info("shutdown requested")
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+
+	grpcSrv.GracefulStop()
+	if err := httpSrv.Shutdown(shutdownCtx); err != nil {
+		logger.Error("HTTP shutdown failed", logKeyError, err)
+	}
+
+	if err := g.Wait(); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+		logger.Error("server exited with error", logKeyError, err)
+		os.Exit(1)
+	}
+}
+
+func newHTTPMux(logger *slog.Logger) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok\n"))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		logger.Info("http ext_authz request",
+			logKeyMethod, r.Method,
+			logKeyPath, r.URL.Path,
+			logKeyHost, r.Host,
+			logKeyHeaders, flattenHTTPHeaders(r.Header),
+		)
+		w.Header().Set("X-Test-Authz", "allowed-http")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("allowed\n"))
+	})
+	return mux
+}
+
+func (s *server) Check(ctx context.Context, req *authv3.CheckRequest) (*authv3.CheckResponse, error) {
+	httpAttrs := req.GetAttributes().GetRequest().GetHttp()
+	s.logger.InfoContext(ctx, "grpc ext_authz request",
+		logKeyMethod, httpAttrs.GetMethod(),
+		logKeyPath, httpAttrs.GetPath(),
+		logKeyHost, httpAttrs.GetHost(),
+		logKeyHeaders, flattenHeaderMap(httpAttrs.GetHeaders()),
+	)
+
+	return &authv3.CheckResponse{
+		Status: status.New(codes.OK, "").Proto(),
+		HttpResponse: &authv3.CheckResponse_OkResponse{
+			OkResponse: &authv3.OkHttpResponse{
+				Headers: []*corev3.HeaderValueOption{
+					{
+						Header: &corev3.HeaderValue{
+							Key:   "x-test-authz",
+							Value: "allowed-grpc",
+						},
+					},
+				},
+				DynamicMetadata: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"result": structpb.NewStringValue("allowed"),
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+type healthServer struct {
+	grpc_health_v1.UnimplementedHealthServer
+}
+
+func (healthServer) Check(_ context.Context, _ *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
+}
+
+func (healthServer) Watch(_ *grpc_health_v1.HealthCheckRequest, srv grpc_health_v1.Health_WatchServer) error {
+	return srv.Send(&grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING})
+}
+
+func getenvInt(key string, fallback int) int {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return fallback
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		return fallback
+	}
+	return v
+}
+
+func flattenHTTPHeaders(headers http.Header) string {
+	keys := make([]string, 0, len(headers))
+	for key := range headers {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	parts := make([]string, 0, len(headers))
+	for _, key := range keys {
+		values := headers[key]
+		parts = append(parts, key+"="+strings.Join(values, ","))
+	}
+	return strings.Join(parts, " ")
+}
+
+func flattenHeaderMap(headers map[string]string) string {
+	keys := make([]string, 0, len(headers))
+	for key := range headers {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	parts := make([]string, 0, len(headers))
+	for _, key := range keys {
+		value := headers[key]
+		parts = append(parts, key+"="+value)
+	}
+	return strings.Join(parts, " ")
+}

--- a/examples/kubernetes/gateway/external-authz/manifests.yaml
+++ b/examples/kubernetes/gateway/external-authz/manifests.yaml
@@ -1,0 +1,232 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gateway-external-authz-demo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ext-authz-test
+  namespace: gateway-external-authz-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ext-authz-test
+  template:
+    metadata:
+      labels:
+        app: ext-authz-test
+    spec:
+      containers:
+      - name: auth-service
+        image: external-authz-test:dev
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: http
+          containerPort: 8080
+        - name: grpc
+          containerPort: 9000
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: auth-service
+  namespace: gateway-external-authz-demo
+spec:
+  selector:
+    app: ext-authz-test
+  ports:
+  - name: http
+    port: 8080
+    targetPort: http
+  - name: grpc
+    port: 9000
+    targetPort: grpc
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo
+  namespace: gateway-external-authz-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: echo
+  template:
+    metadata:
+      labels:
+        app: echo
+    spec:
+      containers:
+      - name: echo
+        image: gcr.io/k8s-staging-gateway-api/echo-basic:v20240412-v1.0.0-394-g40c666fd
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: http
+          containerPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: gateway-external-authz-demo
+spec:
+  selector:
+    app: echo
+  ports:
+  - name: http
+    port: 8080
+    targetPort: http
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ext-authz-gateway
+  namespace: gateway-external-authz-demo
+spec:
+  gatewayClassName: cilium
+  listeners:
+  - name: web
+    protocol: HTTP
+    port: 80
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ext-authz-http
+  namespace: gateway-external-authz-demo
+spec:
+  parentRefs:
+  - name: ext-authz-gateway
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /http-auth
+    filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: HTTP
+        backendRef:
+          name: auth-service
+          port: 8080
+        http:
+          path: /check
+          allowedResponseHeaders:
+          - X-Test-Authz
+    backendRefs:
+    - name: echo
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ext-authz-http-shared
+  namespace: gateway-external-authz-demo
+spec:
+  parentRefs:
+  - name: ext-authz-gateway
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /http-auth-shared
+    filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: HTTP
+        backendRef:
+          name: auth-service
+          port: 8080
+        http:
+          path: /check
+          allowedResponseHeaders:
+          - X-Test-Authz
+    backendRefs:
+    - name: echo
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ext-authz-http-variant
+  namespace: gateway-external-authz-demo
+spec:
+  parentRefs:
+  - name: ext-authz-gateway
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /http-auth-variant
+    filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: HTTP
+        backendRef:
+          name: auth-service
+          port: 8080
+        http:
+          path: /variant-check
+          allowedHeaders:
+          - X-Debug-Token
+          allowedResponseHeaders:
+          - X-Test-Authz
+    backendRefs:
+    - name: echo
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ext-authz-grpc
+  namespace: gateway-external-authz-demo
+spec:
+  parentRefs:
+  - name: ext-authz-gateway
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /grpc-auth
+    filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: GRPC
+        backendRef:
+          name: auth-service
+          port: 9000
+        grpc: {}
+    backendRefs:
+    - name: echo
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: no-auth
+  namespace: gateway-external-authz-demo
+spec:
+  parentRefs:
+  - name: ext-authz-gateway
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /no-auth
+    backendRefs:
+    - name: echo
+      port: 8080


### PR DESCRIPTION
This commit adds an example for the newly added Gateway API External Auth functionality. It's meant for development purposes.

Note: also changing code-ownership for sig-servicemesh related examples

Related to: https://github.com/cilium/cilium/pull/45739