### PR TITLE
bpf: test: egressgw: fine-tune the FIB lookup for local packets

### DIFF
--- a/bpf/tests/tc_egressgw_redirect_from_host.c
+++ b/bpf/tests/tc_egressgw_redirect_from_host.c
@@ -67,7 +67,11 @@ mock_fib_lookup(void *ctx __maybe_unused,
 		}
 	}
 
-	params->ifindex = EGRESS_IFACE;
+	/* Any regular FIB lookup for this packet will use the pod IP.
+	 * Confirm that the EGW FIB lookup is egressIP-aware.
+	 */
+	params->ifindex = (params->ipv4_src == EGRESS_IP) ? EGRESS_IFACE :
+							    PRIMARY_IFACE;
 	return 0;
 }
 


### PR DESCRIPTION
Demonstrate that the EGW code in to-netdev does a custom FIB lookup, respecting the egressIP from the EGW policy.