### PR TITLE
cilium-cli: Remove partial JUnit file on error

### DIFF
--- a/cilium-cli/connectivity/check/junit.go
+++ b/cilium-cli/connectivity/check/junit.go
@@ -133,6 +133,7 @@ func (j *JUnitCollector) Write() error {
 	}
 
 	if err := suites.WriteReport(f); err != nil {
+		defer os.Remove(j.junitFile)
 		if e := f.Close(); e != nil {
 			return errors.Join(err, e)
 		}


### PR DESCRIPTION
If JUnit report write fails, we may leave the partial file on disk which might confuse JUnit consumers.

