### PR TITLE
health: Add health/history command

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -386,6 +386,7 @@ func ciliumDbgCommands(cmdDir string) []string {
 		fmt.Sprintf("cilium-dbg debuginfo --output=markdown,json -f --output-directory=%s", cmdDir),
 		"cilium-dbg metrics list",
 		"cilium-dbg shell -- metrics/html",
+		"cilium-dbg shell -- health/history",
 		"cilium-dbg bpf metrics list",
 		"cilium-dbg fqdn cache list",
 		"cilium-dbg config -a",

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -80,6 +80,7 @@ import (
 	// with pkg/nodediscovery so ENI IPAM works at runtime in the agent.
 	// Kept out of cilium-operator-generic (which does not import the daemon
 	// package) to avoid pulling the AWS SDK into non-AWS operator builds.
+	hiveHealth "github.com/cilium/cilium/pkg/hive/health"
 	_ "github.com/cilium/cilium/pkg/nodediscovery/eni"
 	"github.com/cilium/cilium/pkg/nodeipamconfig"
 	"github.com/cilium/cilium/pkg/option"
@@ -118,6 +119,13 @@ var (
 
 		// Runs the gops agent, a tool to diagnose Go processes.
 		gops.Cell(defaults.EnableGops, defaults.GopsPortAgent),
+
+		// Provides the 'health/history' command. The health history logs are stored
+		// in the state directory.
+		hiveHealth.HistoryCell,
+		cell.ProvidePrivate(func(cfg *option.DaemonConfig) hiveHealth.HistoryDir {
+			return hiveHealth.HistoryDir(cfg.StateDir)
+		}),
 
 		// Provides Clientset, API for accessing Kubernetes objects.
 		k8sClient.Cell,

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -68,6 +68,7 @@ import (
 	"github.com/cilium/cilium/pkg/dial"
 	"github.com/cilium/cilium/pkg/gops"
 	"github.com/cilium/cilium/pkg/hive"
+	hiveHealth "github.com/cilium/cilium/pkg/hive/health"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/apis"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
@@ -95,6 +96,13 @@ var (
 
 		// Runs the gops agent, a tool to diagnose Go processes.
 		gops.Cell(defaults.EnableGops, defaults.GopsPortOperator),
+
+		// Provides the 'health/history' command. The health history logs are stored
+		// in the state directory.
+		hiveHealth.HistoryCell,
+		cell.ProvidePrivate(func(cfg *option.DaemonConfig) hiveHealth.HistoryDir {
+			return hiveHealth.HistoryDir(filepath.Join(defaults.RuntimePath, defaults.StateDir))
+		}),
 
 		// Provides a Kubernetes client and ClientBuilderFunc that can be used by other cells to create a client.
 		client.Cell,

--- a/pkg/health/client/modules.go
+++ b/pkg/health/client/modules.go
@@ -36,14 +36,25 @@ func GetAndFormatModulesHealth(w io.Writer, ss []types.Status, verbose bool, pre
 			stack := strings.Split(s.ID.String(), ".")
 			upsertTree(r, &s, stack)
 		}
-		if len(r.nodes) != 0 {
-			r = r.nodes[0]
-			r.parent = nil
-		} else {
+		if len(r.nodes) == 0 {
 			return
 		}
 
-		body := strings.ReplaceAll(r.String(), "\n", "\n"+prefix)
+		var body string
+		if len(r.nodes) == 1 {
+			r = r.nodes[0]
+			r.parent = nil
+			body = r.String()
+		} else {
+			var b strings.Builder
+			for _, n := range r.nodes {
+				n.parent = nil
+				b.WriteString(n.String())
+			}
+			body = b.String()
+		}
+
+		body = strings.ReplaceAll(body, "\n", "\n"+prefix)
 		fmt.Fprintln(w, prefix+body)
 		return
 	}

--- a/pkg/health/client/modules_test.go
+++ b/pkg/health/client/modules_test.go
@@ -48,6 +48,28 @@ func TestGetAndFormatModulesHealth(t *testing.T) {
 	}
 }
 
+func TestGetAndFormatModulesHealthMultipleRoots(t *testing.T) {
+	w := bytes.NewBufferString("")
+	client.GetAndFormatModulesHealth(w, []types.Status{
+		{
+			ID:      ident([]string{"operator", "operator-controlplane"}, "leader-election"),
+			Level:   types.LevelOK,
+			Message: "Leader",
+		},
+		{
+			ID:      ident([]string{"health"}, "job-module-status-metrics"),
+			Level:   types.LevelOK,
+			Message: "Running",
+		},
+	}, true, "")
+
+	out := strings.TrimSpace(w.String())
+	assert.Contains(t, out, "health\n└── job-module-status-metrics")
+	assert.Contains(t, out, "operator\n└── operator-controlplane")
+	assert.Contains(t, out, "[OK] Running")
+	assert.Contains(t, out, "[OK] Leader")
+}
+
 // Helpers
 
 func ident(mid []string, cid ...string) types.Identifier {

--- a/pkg/hive/health/cell.go
+++ b/pkg/hive/health/cell.go
@@ -27,6 +27,10 @@ var Cell = cell.Module(
 	cell.Provide(healthCommands),
 )
 
+// HistoryCell provides the health/history commands. The [HistoryDir]
+// must be provided for storing status logs.
+var HistoryCell = cell.Provide(newHealthHistory)
+
 var (
 	PrimaryIndex = statedb.Index[types.Status, types.HealthID]{
 		Name: "identifier",

--- a/pkg/hive/health/cmds_test.go
+++ b/pkg/hive/health/cmds_test.go
@@ -5,10 +5,12 @@ package health
 
 import (
 	"context"
+	"errors"
 	"maps"
 	"testing"
 
 	"github.com/cilium/cilium/pkg/hive/health/types"
+	"github.com/cilium/cilium/pkg/time"
 
 	"github.com/cilium/hive"
 	"github.com/cilium/hive/cell"
@@ -24,13 +26,24 @@ import (
 
 func TestHealthCommands(t *testing.T) {
 	log := hivetest.Logger(t)
+	origNow := time.Now
+	time.Now = func() time.Time {
+		return time.Unix(1, 0)
+	}
+	t.Cleanup(func() {
+		time.Now = origNow
+	})
 	scripttest.Test(t,
 		context.Background(),
 		func(t testing.TB, args []string) *script.Engine {
 			h := hive.New(
 				statedb.Cell,
 				Cell,
+				HistoryCell,
 				job.Cell,
+				cell.Provide(func() HistoryDir {
+					return HistoryDir(t.TempDir())
+				}),
 				cell.Provide(func(p types.Provider, jr job.Registry) job.Group {
 					h := p.ForModule(cell.FullModuleID{"test"})
 					return jr.NewGroup(h)
@@ -38,6 +51,24 @@ func TestHealthCommands(t *testing.T) {
 				cell.Invoke(func(p types.Provider) {
 					hr := p.ForModule(cell.FullModuleID{"agent", "m0"})
 					hr.NewScope("c0").OK("ok")
+
+					degraded := p.ForModule(cell.FullModuleID{"agent", "m2"}).
+						NewScope("degraded-closed")
+					degraded.Degraded("broken", errors.New("err2"))
+					degraded.Close()
+
+					p.ForModule(cell.FullModuleID{"agent", "m2"}).
+						NewScope("degraded").
+						Degraded("broken", errors.New("err2"))
+
+					closedOK := p.ForModule(cell.FullModuleID{"agent", "m3"}).NewScope("done")
+					closedOK.OK("finished")
+					closedOK.Close()
+
+					stopped := p.ForModule(cell.FullModuleID{"agent", "m4"}).
+						NewScope("stopped")
+					stopped.OK("ok")
+					stopped.Stopped("now stopped")
 				}),
 			)
 			t.Cleanup(func() {

--- a/pkg/hive/health/command.go
+++ b/pkg/hive/health/command.go
@@ -10,21 +10,33 @@ import (
 	"slices"
 	"strings"
 
-	healthPkg "github.com/cilium/cilium/pkg/health/client"
-	"github.com/cilium/cilium/pkg/hive/health/types"
-
 	"github.com/cilium/hive"
+	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/script"
 	"github.com/cilium/statedb"
-
 	"github.com/spf13/pflag"
+
+	healthPkg "github.com/cilium/cilium/pkg/health/client"
+	"github.com/cilium/cilium/pkg/hive/health/types"
 )
 
-func healthCommands(db *statedb.DB, table statedb.Table[types.Status]) hive.ScriptCmdsOut {
-	return hive.NewScriptCmds(map[string]script.Cmd{
-		"health":    healthTreeCommand(db, table),
-		"health/ok": allOK(db, table),
-	})
+type healthCommandsParams struct {
+	cell.In
+
+	DB       *statedb.DB
+	Statuses statedb.Table[types.Status]
+	History  *healthHistory `optional:"true"`
+}
+
+func healthCommands(p healthCommandsParams) hive.ScriptCmdsOut {
+	cmds := map[string]script.Cmd{
+		"health":    healthTreeCommand(p.DB, p.Statuses),
+		"health/ok": allOK(p.DB, p.Statuses),
+	}
+	if p.History != nil {
+		cmds["health/history"] = healthHistoryCommand(p.History)
+	}
+	return hive.NewScriptCmds(cmds)
 }
 
 func healthTreeCommand(db *statedb.DB, table statedb.Table[types.Status]) script.Cmd {
@@ -149,6 +161,38 @@ func allOK(db *statedb.DB, table statedb.Table[types.Status]) script.Cmd {
 				return nil, fmt.Errorf("found %d degraded health reports", len(ss))
 			}
 			return nil, nil
+		},
+	)
+}
+
+func healthHistoryCommand(history *healthHistory) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Show health history",
+			Flags: func(fs *pflag.FlagSet) {
+				fs.StringP("output", "o", "", "File to write output to")
+			},
+			Detail: []string{
+				"Shows past degraded, stopped and closed health reports",
+			},
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			file, err := s.Flags.GetString("output")
+			if err != nil {
+				return nil, err
+			}
+			w := s.LogWriter()
+			if file != "" {
+				p := s.Path(file)
+				fd, err := os.Create(p)
+				if err != nil {
+					return nil, err
+				}
+				defer fd.Close()
+				w = fd
+			}
+			err = history.replay(w)
+			return nil, err
 		},
 	)
 }

--- a/pkg/hive/health/command.go
+++ b/pkg/hive/health/command.go
@@ -46,7 +46,7 @@ func healthTreeCommand(db *statedb.DB, table statedb.Table[types.Status]) script
 			Args:    "[reporter-id-prefix]",
 			Flags: func(fs *pflag.FlagSet) {
 				fs.StringP("match", "m", "", "Output only health reports where the reporter ID path contains the substring")
-				fs.StringArrayP("levels", "s", []string{types.LevelOK, types.LevelDegraded, types.LevelDegraded},
+				fs.StringSliceP("levels", "s", []string{types.LevelOK, types.LevelDegraded, types.LevelStopped},
 					"Output only health reports with the specified state (i.e. ok,degraded,stopped)")
 				fs.StringP("output", "o", "", "File to write output to")
 			},
@@ -67,7 +67,7 @@ func healthTreeCommand(db *statedb.DB, table statedb.Table[types.Status]) script
 				return nil, err
 			}
 
-			levels, err := s.Flags.GetStringArray("levels")
+			levels, err := s.Flags.GetStringSlice("levels")
 			if err != nil {
 				return nil, err
 			}
@@ -104,25 +104,17 @@ func healthTreeCommand(db *statedb.DB, table statedb.Table[types.Status]) script
 }
 
 func getHealth(db *statedb.DB, table statedb.Table[types.Status], prefix, match string, levels []string) []types.Status {
+	tx := db.ReadTxn()
+	results := table.Prefix(tx, PrimaryIndex.Query(types.HealthID(prefix)))
 	ss := []types.Status{}
-	if prefix != "" {
-		tx := db.ReadTxn()
-		for status := range table.Prefix(tx, PrimaryIndex.Query(types.HealthID(prefix))) {
-			ss = append(ss, status)
+	for status := range results {
+		if match != "" && !strings.Contains(status.ID.String(), match) {
+			continue
 		}
-	} else {
-		tx := db.ReadTxn()
-		for status := range table.All(tx) {
-			if match != "" && !strings.Contains(status.ID.String(), match) {
-				continue
-			}
-
-			if !slices.Contains(levels, strings.ToLower(status.Level.String())) {
-				continue
-			}
-
-			ss = append(ss, status)
+		if !slices.Contains(levels, strings.ToLower(status.Level.String())) {
+			continue
 		}
+		ss = append(ss, status)
 	}
 	return ss
 }

--- a/pkg/hive/health/history.go
+++ b/pkg/hive/health/history.go
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package health
+
+import (
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/lumberjack/v2"
+
+	"github.com/cilium/cilium/pkg/hive/health/types"
+	"github.com/cilium/cilium/pkg/time"
+	"github.com/cilium/cilium/pkg/version"
+)
+
+const (
+	defaultHealthHistoryMaxSize    = 5 // MB
+	defaultHealthHistoryMaxBackups = 1 // max 2*5=10MB
+	healthHistoryFileMode          = 0600
+)
+
+type HistoryDir string
+
+type healthHistoryParams struct {
+	cell.In
+
+	Lifecycle  cell.Lifecycle
+	Logger     *slog.Logger
+	HistoryDir HistoryDir
+}
+
+type healthHistory struct {
+	logger *slog.Logger
+	writer *lumberjack.Logger
+}
+
+func newHealthHistory(params healthHistoryParams) (*healthHistory, error) {
+	if params.HistoryDir == "" {
+		return nil, nil
+	}
+	// Construct a filename tied to the process name to avoid two
+	// different kinds of processes from appending to the same history.
+	filename := filepath.Join(
+		string(params.HistoryDir),
+		filepath.Base(os.Args[0])+"-health-history.log")
+	h := &healthHistory{
+		logger: params.Logger,
+		writer: &lumberjack.Logger{
+			Filename:   filename,
+			MaxSize:    defaultHealthHistoryMaxSize,
+			MaxBackups: defaultHealthHistoryMaxBackups,
+			Compress:   true,
+			FileMode:   healthHistoryFileMode,
+		},
+	}
+	params.Lifecycle.Append(h)
+	return h, nil
+}
+
+func (h *healthHistory) Start(cell.HookContext) error {
+	fmt.Fprintf(h.writer, "%s | Started | %s\n", time.Now().UTC().Format(time.RFC3339), version.Version)
+	return nil
+}
+
+func (h *healthHistory) Stop(cell.HookContext) (err error) {
+	if h.writer != nil {
+		fmt.Fprintf(h.writer, "%s | Stopped | %s\n", time.Now().UTC().Format(time.RFC3339), version.Version)
+		err = h.writer.Close()
+		h.writer = nil
+	}
+	return
+}
+
+func (h *healthHistory) observeUpsert(s types.Status) {
+	if h == nil {
+		return
+	}
+	if s.Level == types.LevelDegraded {
+		h.append(s, false)
+	}
+}
+
+func (h *healthHistory) observeStopped(s types.Status) {
+	if h == nil {
+		return
+	}
+	h.append(s, false)
+}
+
+func (h *healthHistory) observeClosed(s types.Status) {
+	if h == nil {
+		return
+	}
+	h.append(s, true)
+}
+
+func (h *healthHistory) append(status types.Status, closed bool) {
+	message := status.Message
+	if status.Level == types.LevelStopped && status.Final != "" {
+		message = status.Final
+	}
+	level := status.Level
+	if closed {
+		level = "Closed(" + level + ")"
+	}
+	err := ""
+	if status.Error != "" {
+		err = " | " + status.Error
+	}
+	fmt.Fprintf(
+		h.writer,
+		"%s | %-16s | %s: %s%s\n",
+		time.Now().UTC().Format(time.RFC3339),
+		level,
+		status.ID.String(),
+		message,
+		err,
+	)
+}
+
+func (h *healthHistory) replay(w io.Writer) error {
+	files, err := h.historyFiles()
+	if err != nil {
+		return err
+	}
+	for _, file := range files {
+		f, err := os.Open(file)
+		if err != nil {
+			return err
+		}
+		if filepath.Ext(file) == ".gz" {
+			var r io.ReadCloser
+			if r, err = gzip.NewReader(f); err == nil {
+				_, err = io.Copy(w, r)
+				r.Close()
+			}
+		} else {
+			_, err = io.Copy(w, f)
+		}
+		f.Close()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h *healthHistory) historyFiles() ([]string, error) {
+	filename := h.writer.Filename
+	dir := filepath.Dir(filename)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading health history directory: %w", err)
+	}
+
+	name := filepath.Base(filename)
+	ext := filepath.Ext(name)
+	base := strings.TrimSuffix(name, ext)
+	prefix := base + "-"
+
+	var files []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		entryName := entry.Name()
+		if strings.HasPrefix(entryName, prefix) {
+			files = append(files, filepath.Join(dir, entryName))
+		}
+	}
+	sort.Strings(files)
+
+	if _, err := os.Stat(filename); err == nil {
+		files = append(files, filename)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("checking health history file: %w", err)
+	}
+
+	return files, nil
+}

--- a/pkg/hive/health/metrics_test.go
+++ b/pkg/hive/health/metrics_test.go
@@ -38,6 +38,12 @@ func Test_Metrics(t *testing.T) {
 
 		cell.ProvidePrivate(newTablesPrivate),
 		cell.Provide(
+			newHealthHistory,
+			func() HistoryDir {
+				return HistoryDir(t.TempDir())
+			},
+		),
+		cell.Provide(
 			newHealthV2Provider,
 			statedb.RWTable[types.Status].ToTable,
 		),

--- a/pkg/hive/health/provider.go
+++ b/pkg/hive/health/provider.go
@@ -23,6 +23,7 @@ type providerParams struct {
 	DB          *statedb.DB
 	Lifecycle   cell.Lifecycle
 	StatusTable statedb.RWTable[types.Status]
+	History     *healthHistory `optional:"true"`
 	Logger      *slog.Logger
 }
 
@@ -31,6 +32,7 @@ type provider struct {
 
 	stopped     atomic.Bool
 	statusTable statedb.RWTable[types.Status]
+	history     *healthHistory
 	logger      *slog.Logger
 }
 
@@ -39,6 +41,7 @@ const TableName = "health"
 func newHealthV2Provider(params providerParams) types.Provider {
 	p := &provider{
 		statusTable: params.StatusTable,
+		history:     params.History,
 		db:          params.DB,
 		logger:      params.Logger,
 	}
@@ -93,6 +96,7 @@ func (p *provider) ForModule(mid cell.FullModuleID) cell.Health {
 				)
 			}
 
+			p.history.observeUpsert(s)
 			tx.Commit()
 			return nil
 		},
@@ -100,28 +104,33 @@ func (p *provider) ForModule(mid cell.FullModuleID) cell.Health {
 			if p.stopped.Load() {
 				return fmt.Errorf("provider is stopped, no more updates will take place")
 			}
+
 			tx := p.db.WriteTxn(p.statusTable)
 			defer tx.Abort()
 			q := PrimaryIndex.Query(types.HealthID(i.String()))
 			iter := p.statusTable.Prefix(tx, q)
-			var deleted int
+			numDeleted := 0
 			for o := range iter {
-				if _, _, err := p.statusTable.Delete(tx, types.Status{
+				_, found, err := p.statusTable.Delete(tx, types.Status{
 					ID: o.ID,
-				}); err != nil {
+				})
+				if err != nil {
 					return fmt.Errorf("deleting prunable child %s: %w", i, err)
 				}
-				deleted++
+				if found {
+					p.history.observeClosed(o)
+					numDeleted++
+				}
 			}
 
 			p.logger.Debug("delete health sub-tree",
 				logfields.Prefix, i,
-				logfields.Deleted, deleted,
+				logfields.Deleted, numDeleted,
 			)
 			tx.Commit()
 			return nil
 		},
-		stop: func(i types.Identifier) error {
+		stop: func(i types.Identifier, msg string) error {
 			if p.stopped.Load() {
 				return fmt.Errorf("provider is stopped, no more updates will take place")
 			}
@@ -137,9 +146,11 @@ func (p *provider) ForModule(mid cell.FullModuleID) cell.Health {
 			}
 			old.Level = types.LevelStopped
 			old.Stopped = time.Now()
+			old.Final = msg
 			if _, _, err := p.statusTable.Insert(tx, old); err != nil {
 				return fmt.Errorf("stopping reporter - upsert status %s: %w", old, err)
 			}
+			p.history.observeStopped(old)
 			tx.Commit()
 			p.logger.Debug("stopping health reporter",
 				logfields.ReporterID, i,
@@ -154,9 +165,10 @@ type moduleReporter struct {
 	logger          *slog.Logger
 	id              types.Identifier
 	stopped         atomic.Bool
+	closed          atomic.Bool
 	providerStopped func() bool
 	upsert          func(types.Status) error
-	stop            func(types.Identifier) error
+	stop            func(types.Identifier, string) error
 	deletePrefix    func(types.Identifier) error
 }
 
@@ -196,7 +208,9 @@ func (r *moduleReporter) OK(msg string) {
 		LastOK:  ts,
 		Updated: ts,
 	}); err != nil {
-		r.logger.Error("failed to upsert ok health status", logfields.Error, err)
+		r.logger.Error("failed to upsert ok health status",
+			logfields.ReporterID, r.id,
+			logfields.Error, err)
 	}
 }
 
@@ -211,7 +225,10 @@ func (r *moduleReporter) Degraded(msg string, err error) {
 		Error:   err.Error(),
 		Updated: time.Now(),
 	}); err != nil {
-		r.logger.Error("failed to upsert degraded health status", logfields.Error, err)
+		r.logger.Error("failed to upsert degraded health status",
+			logfields.ReporterID, r.id,
+			logfields.Error, err,
+		)
 	}
 }
 
@@ -219,15 +236,23 @@ func (r *moduleReporter) Degraded(msg string, err error) {
 // maintaining the last known status of the reporter.
 func (r *moduleReporter) Stopped(msg string) {
 	r.stopped.Store(true)
-	if err := r.stop(r.id); err != nil {
-		r.logger.Error("failed to delete reporter status tree", logfields.Error, err)
+	if err := r.stop(r.id, msg); err != nil {
+		r.logger.Error("failed to upsert stop health status",
+			logfields.ReporterID, r.id,
+			logfields.Error, err)
 	}
 }
 
 // Close completely closes out a tree, it will remove all health statuses below
 // this reporter scope.
 func (r *moduleReporter) Close() {
+	if !r.closed.CompareAndSwap(false, true) {
+		// Already closed.
+		return
+	}
 	if err := r.deletePrefix(r.id); err != nil {
-		r.logger.Error("failed to delete reporter status tree", logfields.Error, err)
+		r.logger.Error("failed to delete reporter status tree",
+			logfields.ReporterID, r.id,
+			logfields.Error, err)
 	}
 }

--- a/pkg/hive/health/provider_test.go
+++ b/pkg/hive/health/provider_test.go
@@ -10,9 +10,8 @@ import (
 	"github.com/cilium/hive"
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/cilium/statedb"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/cilium/cilium/pkg/hive/health/types"
 )
@@ -30,8 +29,12 @@ func TestProvider(t *testing.T) {
 	h := hive.New(
 		statedb.Cell,
 		cell.Provide(newHealthV2Provider),
+		cell.Provide(newHealthHistory),
 		cell.ProvidePrivate(newTablesPrivate),
-		cell.Invoke(func(statusTable statedb.RWTable[types.Status], db *statedb.DB, p types.Provider, sd hive.Shutdowner) error {
+		cell.Provide(func() HistoryDir {
+			return HistoryDir(t.TempDir())
+		}),
+		cell.Invoke(func(statusTable statedb.RWTable[types.Status], db *statedb.DB, p types.Provider, history *healthHistory, sd hive.Shutdowner) error {
 			h := p.ForModule(cell.FullModuleID{"foo", "bar"})
 			hm2 := p.ForModule(cell.FullModuleID{"foo", "bar2"})
 			hm2.NewScope("zzz").OK("yay2")

--- a/pkg/hive/health/testdata/health.txtar
+++ b/pkg/hive/health/testdata/health.txtar
@@ -1,3 +1,12 @@
+
+# Test history against the state inserted in [cmd_test.go].
+health/history --output=history
+cmp history.expected.txt history
+
+# From here on test the 'health' command with direct modifications
+# to health table.
+# Health not OK as there's a non-closed degraded entry
+! health/ok 
 db/insert health allok.yaml
 
 # Should be all ok
@@ -27,9 +36,9 @@ cmp degraded.expected.txt out
 id:
     module:
         - agent
-        - m0
+        - m2
     component:
-        - c0
+        - degraded
 level: OK
 message: ok
 error: ""
@@ -83,8 +92,10 @@ agent
 ├── m0
 │   ├── c0                                          [OK] ok
 │   └── c1                                          [DEGRADED] no!
-└── m1
-    └── c1                                          [OK] yay
+├── m1
+│   └── c1                                          [OK] yay
+└── m2
+    └── degraded                                    [OK] ok
 
 -- m0.expected.txt --
 agent
@@ -97,3 +108,9 @@ agent
 └── m0
     └── c1                                          [DEGRADED] no!
 
+-- history.expected.txt --
+1970-01-01T00:00:01Z | Degraded         | agent.m2.degraded-closed: broken | err2
+1970-01-01T00:00:01Z | Closed(Degraded) | agent.m2.degraded-closed: broken | err2
+1970-01-01T00:00:01Z | Degraded         | agent.m2.degraded: broken | err2
+1970-01-01T00:00:01Z | Closed(OK)       | agent.m3.done: finished
+1970-01-01T00:00:01Z | Stopped          | agent.m4.stopped: now stopped

--- a/pkg/hive/health/testdata/health.txtar
+++ b/pkg/hive/health/testdata/health.txtar
@@ -40,6 +40,12 @@ health --output=out --levels=degraded,stopped
 sed ' \(.*\)' '' out
 cmp degraded-stopped.expected.txt out
 
+# Inserting a new root will show two trees
+db/insert health foo.yaml
+health --output=out
+sed ' \(.*\)' '' out
+cmp foo.expected.txt out
+
 -- allok.yaml --
 id:
     module:
@@ -87,6 +93,21 @@ id:
         - m1
     component:
         - c1
+level: OK
+message: yay
+error: ""
+lastok: 2025-04-01T21:28:00.000000000-07:00
+updated: 2025-04-01T21:28:00.000000000-07:00
+stopped: 0001-01-01T00:00:00Z
+final: ""
+count: 1
+
+-- foo.yaml --
+id:
+    module:
+        - foo
+    component:
+        - c1
 level: OK 
 message: yay 
 error: ""
@@ -95,6 +116,7 @@ updated: 2025-04-01T21:28:00.000000000-07:00
 stopped: 0001-01-01T00:00:00Z
 final: ""
 count: 1
+
 -- all.expected.txt --
 agent
 ├── m0
@@ -129,6 +151,20 @@ agent
 │   └── c1                                          [DEGRADED] no!
 └── m4
     └── stopped                                     [STOPPED] ok
+
+-- foo.expected.txt --
+agent
+├── m0
+│   ├── c0                                          [OK] ok
+│   └── c1                                          [DEGRADED] no!
+├── m1
+│   └── c1                                          [OK] yay
+├── m2
+│   └── degraded                                    [OK] ok
+└── m4
+    └── stopped                                     [STOPPED] ok
+foo
+└── c1                                          [OK] yay
 
 -- history.expected.txt --
 1970-01-01T00:00:01Z | Degraded         | agent.m2.degraded-closed: broken | err2

--- a/pkg/hive/health/testdata/health.txtar
+++ b/pkg/hive/health/testdata/health.txtar
@@ -28,9 +28,17 @@ health --output=out agent.m0
 sed ' \(.*\)' '' out
 cmp m0.expected.txt out
 
+health --output=out --match=c1 agent.m0
+sed ' \(.*\)' '' out
+cmp m0.c1.expected.txt out
+
 health --output=out --levels=degraded 
 sed ' \(.*\)' '' out
 cmp degraded.expected.txt out
+
+health --output=out --levels=degraded,stopped
+sed ' \(.*\)' '' out
+cmp degraded-stopped.expected.txt out
 
 -- allok.yaml --
 id:
@@ -94,8 +102,10 @@ agent
 │   └── c1                                          [DEGRADED] no!
 ├── m1
 │   └── c1                                          [OK] yay
-└── m2
-    └── degraded                                    [OK] ok
+├── m2
+│   └── degraded                                    [OK] ok
+└── m4
+    └── stopped                                     [STOPPED] ok
 
 -- m0.expected.txt --
 agent
@@ -103,10 +113,22 @@ agent
     ├── c0                                          [OK] ok
     └── c1                                          [DEGRADED] no!
 
+-- m0.c1.expected.txt --
+agent
+└── m0
+    └── c1                                          [DEGRADED] no!
+
 -- degraded.expected.txt --
 agent
 └── m0
     └── c1                                          [DEGRADED] no!
+
+-- degraded-stopped.expected.txt --
+agent
+├── m0
+│   └── c1                                          [DEGRADED] no!
+└── m4
+    └── stopped                                     [STOPPED] ok
 
 -- history.expected.txt --
 1970-01-01T00:00:01Z | Degraded         | agent.m2.degraded-closed: broken | err2

--- a/pkg/hive/health/types/types.go
+++ b/pkg/hive/health/types/types.go
@@ -5,6 +5,7 @@ package types
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -57,6 +58,11 @@ func (i Identifier) String() string {
 
 func (i Identifier) HealthID() HealthID {
 	return HealthID(i.String())
+}
+
+func (i Identifier) Equal(other Identifier) bool {
+	return slices.Equal(i.Module, other.Module) &&
+		slices.Equal(i.Component, other.Component)
 }
 
 // Status represents a current health status update.


### PR DESCRIPTION
As part of https://github.com/cilium/hive/pull/72 we wanted to make it feasible to have unlimited number of hive jobs starting and stopping without accumulating endless amounts of state. To do that we need to close the health scopes for jobs which leads to the status being removed from the health table. 

In order to be able to still see the result of closed jobs for debugging this PR adds support for writing degraded/stopped/closed health updates to a log on disk and adds the "health/history" command to output it:

```
$ kubectl exec ... ds/cilium -- cilium shell
kind-control-plane> health/history
2026-05-26T13:19:38Z | Started | 1.20.0-dev 120109a83c 2026-05-26T14:03:32+02:00 go version go1.26.0 linux/arm64
2026-05-26T13:19:38Z | Closed(OK)       | agent.infra.k8s-synced-crdsync.job-sync-crds: Finished (51.649007ms)
2026-05-26T13:19:38Z | Closed(OK)       | agent.datapath.iptables.ipset.job-ipset-init-finalizer: Finished (9.333634ms)
...

$ kubectl exec ... pod/cilium-operator ... -- cilium-operator-generic shell
2026-05-26T14:08:13Z | Started | 1.20.0-dev 5fa5cc56bb 2026-05-26T14:03:32+02:00 go version go1.26.0 linux/arm64
2026-05-26T14:08:38Z | Closed(OK)       | operator.operator-controlplane.leader-lifecycle.k8s-endpointslice-gc.job-to-k8s-ciliumendpointslice-gc: Finished (1.915813ms)
2026-05-26T14:08:38Z | Closed(OK)       | operator.operator-controlplane.leader-lifecycle.enabled-features.job-update-config-metric: Finished (95.415µs)
...
```

The output of `health/history` is included in sysdumps in file `cilium-bugtool/*/cmd/cilium-dbg-shell----health-history.md`. There is some overlap with the normal logs, but quite often the logs we get from sysdumps are very truncated. Having this separate log much increases the likelyhood that we don't miss degraded health events.
I do wonder though whether we should have a more generic event log system for these sort of things, but perhaps better not to generalize just yet.

As part of this I stumbled into multiple bugs in the `health` command which I fixed.