### PR TITLE
ipam: Add cluster-pool to multi-pool migration

### DIFF
--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -41,6 +41,7 @@ cilium-operator-generic [flags]
       --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
       --enable-cilium-endpoint-slice                               If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-cluster-pool-to-multi-pool-migration                Enable the migration of all nodes from cluster-pool IPAM to multi-pool IPAM
       --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
       --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
       --enable-gateway-api-proxy-protocol                          Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
@@ -95,6 +96,7 @@ cilium-operator-generic [flags]
       --ingress-use-remote-address                                 Use the immediate client's IP address as the origin client's IP address (default true)
       --instance-tags-filter map                                   EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                                Backend to use for IPAM (default "cluster-pool")
+      --ipam-default-ip-pool string                                Name of the default IP Pool when using multi-pool (default "default")
       --k8s-api-server-urls strings                                Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
@@ -125,6 +127,7 @@ cilium-operator-generic [flags]
       --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
       --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --multi-pool-migration-workers int                           Number of workers to use for migrating nodes from cluster-pool IPAM to multi-pool IPAM (default 16)
       --nodes-gc-interval duration                                 GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -37,6 +37,7 @@ cilium-operator-generic hive [flags]
       --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
       --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-cluster-pool-to-multi-pool-migration                Enable the migration of all nodes from cluster-pool IPAM to multi-pool IPAM
       --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
       --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
       --enable-gateway-api-proxy-protocol                          Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
@@ -83,6 +84,7 @@ cilium-operator-generic hive [flags]
       --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
       --ingress-use-remote-address                                 Use the immediate client's IP address as the origin client's IP address (default true)
+      --ipam-default-ip-pool string                                Name of the default IP Pool when using multi-pool (default "default")
       --k8s-api-server-urls strings                                Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
@@ -110,6 +112,7 @@ cilium-operator-generic hive [flags]
       --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
       --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --multi-pool-migration-workers int                           Number of workers to use for migrating nodes from cluster-pool IPAM to multi-pool IPAM (default 16)
       --nodes-gc-interval duration                                 GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -43,6 +43,7 @@ cilium-operator-generic hive dot-graph [flags]
       --default-lb-service-ipam string                             Indicates the default LoadBalancer Service IPAM when no LoadBalancer class is set.Applicable values: lbipam, nodeipam, none (default "lbipam")
       --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
       --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-cluster-pool-to-multi-pool-migration                Enable the migration of all nodes from cluster-pool IPAM to multi-pool IPAM
       --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
       --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
       --enable-gateway-api-proxy-protocol                          Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
@@ -88,6 +89,7 @@ cilium-operator-generic hive dot-graph [flags]
       --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
       --ingress-use-remote-address                                 Use the immediate client's IP address as the origin client's IP address (default true)
+      --ipam-default-ip-pool string                                Name of the default IP Pool when using multi-pool (default "default")
       --k8s-api-server-urls strings                                Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
@@ -115,6 +117,7 @@ cilium-operator-generic hive dot-graph [flags]
       --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
       --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --multi-pool-migration-workers int                           Number of workers to use for migrating nodes from cluster-pool IPAM to multi-pool IPAM (default 16)
       --nodes-gc-interval duration                                 GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -52,6 +52,7 @@ cilium-operator [flags]
       --ec2-api-endpoint string                                    AWS API endpoint for the EC2 service
       --enable-cilium-endpoint-slice                               If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-cluster-pool-to-multi-pool-migration                Enable the migration of all nodes from cluster-pool IPAM to multi-pool IPAM
       --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
       --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
       --enable-gateway-api-proxy-protocol                          Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
@@ -110,6 +111,7 @@ cilium-operator [flags]
       --ingress-use-remote-address                                 Use the immediate client's IP address as the origin client's IP address (default true)
       --instance-tags-filter map                                   EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                                Backend to use for IPAM (default "cluster-pool")
+      --ipam-default-ip-pool string                                Name of the default IP Pool when using multi-pool (default "default")
       --k8s-api-server-urls strings                                Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
@@ -140,6 +142,7 @@ cilium-operator [flags]
       --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
       --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --multi-pool-migration-workers int                           Number of workers to use for migrating nodes from cluster-pool IPAM to multi-pool IPAM (default 16)
       --nodes-gc-interval duration                                 GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -48,6 +48,7 @@ cilium-operator hive [flags]
       --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
       --ec2-api-endpoint string                                    AWS API endpoint for the EC2 service
       --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-cluster-pool-to-multi-pool-migration                Enable the migration of all nodes from cluster-pool IPAM to multi-pool IPAM
       --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
       --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
       --enable-gateway-api-proxy-protocol                          Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
@@ -98,6 +99,7 @@ cilium-operator hive [flags]
       --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
       --ingress-use-remote-address                                 Use the immediate client's IP address as the origin client's IP address (default true)
+      --ipam-default-ip-pool string                                Name of the default IP Pool when using multi-pool (default "default")
       --k8s-api-server-urls strings                                Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
@@ -125,6 +127,7 @@ cilium-operator hive [flags]
       --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
       --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --multi-pool-migration-workers int                           Number of workers to use for migrating nodes from cluster-pool IPAM to multi-pool IPAM (default 16)
       --nodes-gc-interval duration                                 GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -54,6 +54,7 @@ cilium-operator hive dot-graph [flags]
       --double-write-metric-reporter-interval duration             Refresh interval for the Double Write Metric Reporter (default 1m0s)
       --ec2-api-endpoint string                                    AWS API endpoint for the EC2 service
       --enable-cilium-operator-server-access strings               List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-cluster-pool-to-multi-pool-migration                Enable the migration of all nodes from cluster-pool IPAM to multi-pool IPAM
       --enable-gateway-api-alpn                                    Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API
       --enable-gateway-api-app-protocol                            Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol
       --enable-gateway-api-proxy-protocol                          Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
@@ -103,6 +104,7 @@ cilium-operator hive dot-graph [flags]
       --ingress-secrets-namespace string                           Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
       --ingress-shared-lb-service-name string                      Name of shared LB service name for Ingress. (default "cilium-ingress")
       --ingress-use-remote-address                                 Use the immediate client's IP address as the origin client's IP address (default true)
+      --ipam-default-ip-pool string                                Name of the default IP Pool when using multi-pool (default "default")
       --k8s-api-server-urls strings                                Kubernetes API server URLs
       --k8s-client-connection-keep-alive duration                  Configures the keep alive duration of K8s client connections. K8 client is disabled if the value is set to 0 (default 30s)
       --k8s-client-connection-timeout duration                     Configures the timeout of K8s client connections. K8s client is disabled if the value is set to 0 (default 30s)
@@ -130,6 +132,7 @@ cilium-operator hive dot-graph [flags]
       --mesh-auth-spire-server-address string                      SPIRE server endpoint. (default "spire-server.spire.svc:8081")
       --mesh-auth-spire-server-connection-timeout duration         SPIRE server connection timeout. (default 10s)
       --metrics-sampling-interval duration                         Set the internal metrics sampling interval (default 5m0s)
+      --multi-pool-migration-workers int                           Number of workers to use for migrating nodes from cluster-pool IPAM to multi-pool IPAM (default 16)
       --nodes-gc-interval duration                                 GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string                             Address to serve API requests (default "localhost:9234")
       --operator-k8s-client-burst int                              Burst value allowed for the K8s client (default 200)

--- a/Documentation/network/concepts/ipam/cluster-pool-to-multi-pool.rst
+++ b/Documentation/network/concepts/ipam/cluster-pool-to-multi-pool.rst
@@ -1,0 +1,349 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    http://docs.cilium.io
+
+.. _ipam_cluster_pool_to_multi_pool_migration:
+
+Migrating from Cluster Scope to Multi-Pool
+##########################################
+
+This section describes how to migrate a running cluster from
+:ref:`ipam_crd_cluster_pool` IPAM mode to :ref:`ipam_crd_multi_pool` IPAM mode.
+The migration keeps the existing per-node PodCIDR allocations stable, so pods
+keep their IP addresses and connectivity is not disrupted while the cluster is
+being migrated.
+
+During the migration, the Cilium operator converts each ``CiliumNode`` from the
+cluster-pool representation in ``spec.ipam.podCIDRs`` to the multi-pool
+representation in ``spec.ipam.pools.allocated``. Cilium agents can then be
+restarted incrementally. Nodes that still run in cluster-pool mode and nodes
+that already run in multi-pool mode can continue to serve pod connectivity
+during this rolling restart.
+
+Limitations
+***********
+
+The following limitations apply to the migration:
+
+* The migration only supports moving from cluster-pool IPAM mode to multi-pool
+  IPAM mode. In case of failure, no rollback is available.
+* All pods with IPs allocated from cluster-pool IPAM are migrated to the
+  default multi-pool IP pool. Existing pods are not distributed into different
+  pools based on pod annotations, namespace annotations, or pool selectors.
+* The default pool must be available to the operator when it performs the
+  migration. You can either create a ``CiliumPodIPPool`` manually before
+  restarting the operator, or let the operator create it on startup by setting
+  the ``auto-create-cilium-pod-ip-pools`` option. With Helm, this option is
+  configured through the ``ipam.operator.autoCreateCiliumPodIPPools`` value.
+* The default pool must cover the cluster-pool CIDRs that are already allocated
+  to nodes, and must use the same mask size as the existing cluster-pool
+  allocation.
+* The default pool name is ``default`` unless changed with the
+  ``ipam-default-ip-pool`` option.
+* The default pool name used for the migration must not be overwritten on a
+  per-node basis through a ``CiliumNodeConfig``. If you need to use a
+  non-default pool name, change it globally with the ``ipam-default-ip-pool``
+  option when restarting the operator.
+
+Migration Steps
+***************
+
+Use this high-level workflow for the migration:
+
+1. Create the default ``CiliumPodIPPool``, or configure
+   ``auto-create-cilium-pod-ip-pools`` so that the Cilium operator creates it
+   when it starts.
+2. Upgrade the Cilium Helm release to change the Cilium configuration from
+   ``ipam: cluster-pool`` to ``ipam: multi-pool``, set the operator option
+   ``enable-cluster-pool-to-multi-pool-migration`` to ``true``, and restart
+   only the Cilium operator.
+3. Wait until each ``CiliumNode`` has its existing PodCIDR listed under
+   ``spec.ipam.pools.allocated``.
+4. Restart the Cilium agents, all at once or incrementally.
+
+Practical Example
+*****************
+
+The following example migrates a kind cluster with one control-plane node and
+three worker nodes. The cluster starts in cluster-pool IPAM mode with
+``10.0.0.0/8`` as the cluster-wide pool and ``/24`` per-node PodCIDRs.
+
+Before the migration, each ``CiliumNode`` stores its per-node allocation in
+``spec.ipam.podCIDRs``:
+
+.. code-block:: shell-session
+
+  $ kubectl get ciliumnode kind-worker -o yaml | yq .spec.ipam
+  podCIDRs:
+    - 10.0.3.0/24
+  pools: {}
+
+  $ kubectl get ciliumnode kind-worker2 -o yaml | yq .spec.ipam
+  podCIDRs:
+    - 10.0.0.0/24
+  pools: {}
+
+  $ kubectl get ciliumnode kind-worker3 -o yaml | yq .spec.ipam
+  podCIDRs:
+    - 10.0.1.0/24
+  pools: {}
+
+  $ kubectl get ciliumnode kind-control-plane -o yaml | yq .spec.ipam
+  podCIDRs:
+    - 10.0.2.0/24
+  pools: {}
+
+Upgrade the Cilium Helm release to switch to multi-pool IPAM mode and enable
+the operator migration. This example uses
+``ipam.operator.autoCreateCiliumPodIPPools`` to let the operator create the
+``default`` ``CiliumPodIPPool`` with the same CIDR and per-node mask size used
+by cluster-pool IPAM. The command updates the Cilium ConfigMap and restarts
+only the Cilium operator:
+
+.. code-block:: shell-session
+
+  $ helm upgrade cilium cilium/cilium \
+      --namespace kube-system \
+      --reuse-values \
+      --set ipam.mode=multi-pool \
+      --set ipam.operator.autoCreateCiliumPodIPPools.default.ipv4.cidrs='{10.0.0.0/8}' \
+      --set ipam.operator.autoCreateCiliumPodIPPools.default.ipv4.maskSize=24 \
+      --set-string extraConfig.enable-cluster-pool-to-multi-pool-migration=true \
+      --set operator.rollOutPods=true \
+      --set rollOutCiliumPods=false
+
+If you want to use a different default pool name for the migration, configure
+it globally in the same Helm upgrade that restarts the operator, with
+``--set-string extraConfig.ipam-default-ip-pool=<pool-name>``.
+
+Wait for the operator to create the default pool:
+
+.. code-block:: shell-session
+
+  $ kubectl get ciliumpodippool default -o yaml
+  apiVersion: cilium.io/v2alpha1
+  kind: CiliumPodIPPool
+  metadata:
+    name: default
+  spec:
+    ipv4:
+      cidrs:
+      - 10.0.0.0/8
+      maskSize: 24
+
+After the operator performs the migration, each node has the same per-node CIDR
+allocated from the default multi-pool IP pool:
+
+.. code-block:: shell-session
+
+  $ kubectl get ciliumnode kind-worker -o yaml | yq .spec.ipam
+  pools:
+    allocated:
+      - cidrs:
+          - 10.0.3.0/24
+        pool: default
+
+  $ kubectl get ciliumnode kind-worker2 -o yaml | yq .spec.ipam
+  pools:
+    allocated:
+      - cidrs:
+          - 10.0.0.0/24
+        pool: default
+
+  $ kubectl get ciliumnode kind-worker3 -o yaml | yq .spec.ipam
+  pools:
+    allocated:
+      - cidrs:
+          - 10.0.1.0/24
+        pool: default
+
+  $ kubectl get ciliumnode kind-control-plane -o yaml | yq .spec.ipam
+  pools:
+    allocated:
+      - cidrs:
+          - 10.0.2.0/24
+        pool: default
+
+Restart one Cilium agent. You can delete the agent pod directly, or select it by
+node name:
+
+.. code-block:: shell-session
+
+  $ kubectl -n kube-system delete pod \
+      --field-selector spec.nodeName=kind-worker \
+      --selector="app.kubernetes.io/name=cilium-agent"
+
+After the agent restarts, it runs in multi-pool IPAM mode and requests IPs from
+the default pool while preserving the IPs of restored endpoints:
+
+.. code-block:: shell-session
+
+  $ kubectl get ciliumnode kind-worker -o yaml | yq .spec.ipam
+  pools:
+    allocated:
+      - cidrs:
+          - 10.0.3.0/24
+        pool: default
+    requested:
+      - needed:
+          ipv4-addrs: 16
+        pool: default
+
+  $ kubectl -n kube-system exec -ti cilium-qvz4n -- cilium-dbg status --all-addresses
+  IPAM:                   IPv4: 1 IPAM pool(s) available,
+  Allocated addresses:
+    10.0.3.190 (router)
+    10.0.3.203 (default/nginx-66686b6766-9v2sb [restored])
+    10.0.3.240 (health)
+
+Connectivity between nodes is maintained while some agents have already moved
+to multi-pool mode and other agents are still running in cluster-pool mode:
+
+.. code-block:: shell-session
+
+  $ kubectl exec -ti nginx-66686b6766-9v2sb -- curl 10.0.0.30:80
+  <!DOCTYPE html>
+  <html>
+  <head>
+  <title>Welcome to nginx!</title>
+  ...
+
+  $ kubectl exec -ti nginx-66686b6766-ktpgn -- curl 10.0.3.203:80
+  <!DOCTYPE html>
+  <html>
+  <head>
+  <title>Welcome to nginx!</title>
+  ...
+
+New pods can also be scheduled during the rolling migration. Multi-pool agents
+allocate new IPs from the migrated default pool, while cluster-pool agents
+continue to use their existing cluster-pool allocations until they are
+restarted:
+
+.. code-block:: shell-session
+
+  $ kubectl scale deployment nginx --replicas=8
+  deployment.apps/nginx scaled
+
+  $ kubectl get pods -o wide
+  NAME                     READY   STATUS    RESTARTS   AGE   IP           NODE
+  nginx-66686b6766-26jkc   1/1     Running   0          12s   10.0.3.209   kind-worker
+  nginx-66686b6766-hcnlz   1/1     Running   0          12s   10.0.0.101   kind-worker2
+  nginx-66686b6766-9v2sb   1/1     Running   0          21m   10.0.3.203   kind-worker
+  nginx-66686b6766-ktpgn   1/1     Running   0          21m   10.0.0.30    kind-worker2
+  ...
+
+Continue restarting the remaining Cilium agents until all nodes run in multi-pool
+IPAM mode:
+
+.. code-block:: shell-session
+
+  $ kubectl -n kube-system delete pod \
+      --field-selector spec.nodeName=kind-worker2 \
+      --selector="app.kubernetes.io/name=cilium-agent"
+
+  $ kubectl -n kube-system delete pod \
+      --field-selector spec.nodeName=kind-worker3 \
+      --selector="app.kubernetes.io/name=cilium-agent"
+
+  $ kubectl -n kube-system delete pod \
+      --field-selector spec.nodeName=kind-control-plane \
+      --selector="app.kubernetes.io/name=cilium-agent"
+
+When the last agent has restarted, the cluster is running multi-pool IPAM. The
+existing pod IPs remain stable in the default multi-pool IP pool.
+
+After the migration is complete, you can extend the allocatable PodCIDRs by
+adding CIDRs to the default pool (for guidance on changing an existing pool,
+see :ref:`update_existing_ciliumpodippools`) or by creating additional pools.
+This overcomes the limitation of cluster-pool IPAM mode, where adding additional
+CIDRs to a node is not supported.
+
+.. warning::
+
+  Only schedule pods that reference a non-default pool after all Cilium agents
+  have restarted in multi-pool IPAM mode. During the rolling migration,
+  Kubernetes may schedule the pod onto a node whose Cilium agent still runs in
+  cluster-pool IPAM mode, where the referenced pool is not available.
+
+Create a new pool:
+
+.. code-block:: yaml
+
+  apiVersion: cilium.io/v2alpha1
+  kind: CiliumPodIPPool
+  metadata:
+    name: test-pool
+  spec:
+    ipv4:
+      cidrs:
+      - 11.0.0.0/8
+      maskSize: 24
+
+Then create a pod that explicitly requests IPs from the new pool:
+
+.. code-block:: yaml
+
+  apiVersion: v1
+  kind: Pod
+  metadata:
+    name: nginx-other-pool
+    annotations:
+      ipam.cilium.io/ip-pool: test-pool
+  spec:
+    containers:
+      - name: nginx
+        image: nginx
+        ports:
+          - containerPort: 80
+
+Apply the resources:
+
+.. code-block:: shell-session
+
+  $ kubectl apply -f test-pool.yaml
+  ciliumpodippool.cilium.io/test-pool created
+  $ kubectl apply -f nginx-other-pool.yaml
+  pod/nginx-other-pool created
+
+The new pod receives an IP from the new pool:
+
+.. code-block:: shell-session
+
+  $ kubectl get pods -o wide
+  NAME                     READY   STATUS    RESTARTS   AGE   IP           NODE
+  nginx-other-pool         1/1     Running   0          28s   11.0.0.15    kind-worker
+  ...
+
+The node hosting the pod now has an allocation from both the migrated default
+pool and the new pool:
+
+.. code-block:: shell-session
+
+  $ kubectl get ciliumnode kind-worker -o yaml | yq .spec.ipam
+  pools:
+    allocated:
+      - cidrs:
+          - 10.0.3.0/24
+        pool: default
+      - cidrs:
+          - 11.0.0.0/24
+        pool: test-pool
+    requested:
+      - needed:
+          ipv4-addrs: 16
+        pool: default
+      - needed:
+          ipv4-addrs: 1
+        pool: test-pool
+
+  $ kubectl -n kube-system exec -ti cilium-qvz4n -- cilium-dbg status --all-addresses
+  IPAM:                   IPv4: 2 IPAM pool(s) available,
+  Allocated addresses:
+    10.0.3.190 (router)
+    10.0.3.203 (default/nginx-66686b6766-9v2sb [restored])
+    10.0.3.209 (default/nginx-66686b6766-26jkc)
+    10.0.3.240 (health)
+    test-pool/11.0.0.15 (default/nginx-other-pool)

--- a/Documentation/network/concepts/ipam/index.rst
+++ b/Documentation/network/concepts/ipam/index.rst
@@ -26,10 +26,15 @@ Multiple CIDRs per node      ❌                     ❌                       �
 Dynamic CIDR/IP allocation   ❌                     ❌                       ✅          ✅          ✅              ✅                ❌
 ============================ ====================== ======================== =========== =========== =============== ================= ===============
 
-Don't change the IPAM mode of an existing cluster. Changing the IPAM mode in
-a live environment may cause persistent disruption of connectivity for existing workloads.
-The safest path to change IPAM mode is to install a fresh Kubernetes cluster with the new IPAM configuration.
-If you are interested in extending Cilium to support migration between IPAM modes, see :gh-issue:`27164`.
+Don't change the IPAM mode of an existing cluster except when following a
+documented migration procedure. Changing the IPAM mode in a live environment may
+cause persistent disruption of connectivity for existing workloads. The safest
+path to change IPAM mode is to install a fresh Kubernetes cluster with the new
+IPAM configuration.
+
+The only currently available online migration path is from cluster-pool IPAM to
+multi-pool IPAM. To migrate, see
+:ref:`ipam_cluster_pool_to_multi_pool_migration`.
 
 .. toctree::
    :maxdepth: 1
@@ -38,6 +43,7 @@ If you are interested in extending Cilium to support migration between IPAM mode
    cluster-pool
    kubernetes
    multi-pool
+   cluster-pool-to-multi-pool
    azure
    azure-delegated-ipam
    eni

--- a/operator/pkg/ipam/allocator/multipool/migration_test.go
+++ b/operator/pkg/ipam/allocator/multipool/migration_test.go
@@ -1,0 +1,355 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package multipool
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/netip"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sTesting "k8s.io/client-go/testing"
+
+	operatorK8s "github.com/cilium/cilium/operator/k8s"
+	"github.com/cilium/cilium/pkg/hive"
+	iputil "github.com/cilium/cilium/pkg/ip"
+	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+)
+
+func TestMigrateNode(t *testing.T) {
+	const (
+		nodeName    = "test-node"
+		defaultPool = "default"
+	)
+
+	t.Run("node updated after migration", func(t *testing.T) {
+		node := &v2.CiliumNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+			},
+			Spec: v2.NodeSpec{
+				IPAM: ipamTypes.IPAMSpec{
+					PodCIDRs: []string{"10.0.0.0/24", "fd00::/124"},
+				},
+			},
+		}
+
+		clientset, store := fixture(t, node, nil)
+
+		err := migrateNode(t.Context(), store, clientset.CiliumV2().CiliumNodes(), resource.Key{Name: node.Name}, defaultPool)
+		require.NoError(t, err)
+
+		updatedNode, err := clientset.CiliumV2().CiliumNodes().Get(t.Context(), node.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		assert.Empty(t, updatedNode.Spec.IPAM.PodCIDRs)
+		assert.Equal(t, []ipamTypes.IPAMPoolAllocation{
+			{
+				Pool: defaultPool,
+				CIDRs: []iputil.Prefix{
+					iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.0/24")),
+					iputil.PrefixFrom(netip.MustParsePrefix("fd00::/124"))},
+			},
+		}, updatedNode.Spec.IPAM.Pools.Allocated)
+		assert.Empty(t, updatedNode.Status.IPAM.OperatorStatus.Error)
+	})
+
+	t.Run("retry after transient error", func(t *testing.T) {
+		node := &v2.CiliumNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+			},
+			Spec: v2.NodeSpec{
+				IPAM: ipamTypes.IPAMSpec{
+					PodCIDRs: []string{"10.0.0.0/24", "fd00::/124"},
+				},
+			},
+		}
+
+		var updates atomic.Int32
+
+		synctest.Test(t, func(t *testing.T) {
+			clientset, store := fixture(t, node, func(cs *k8sClient.FakeClientset) {
+				cs.CiliumFakeClientset.PrependReactor("update", "ciliumnodes", func(action k8sTesting.Action) (bool, runtime.Object, error) {
+					if updates.Add(1) == 1 {
+						// return a transient error for the first update attempt
+						return true, nil, k8sErrors.NewServerTimeout(
+							schema.GroupResource{
+								Group:    v2.CustomResourceDefinitionGroup,
+								Resource: v2.CNPluralName,
+							},
+							"update",
+							1,
+						)
+					}
+					return false, nil, nil
+				})
+			})
+
+			err := migrateNode(t.Context(), store, clientset.CiliumV2().CiliumNodes(), resource.Key{Name: node.Name}, defaultPool)
+			require.NoError(t, err)
+			require.Equal(t, int32(2), updates.Load())
+
+			updatedNode, err := clientset.CiliumV2().CiliumNodes().Get(t.Context(), node.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+
+			assert.Empty(t, updatedNode.Spec.IPAM.PodCIDRs)
+			assert.Equal(t, []ipamTypes.IPAMPoolAllocation{
+				{
+					Pool: defaultPool,
+					CIDRs: []iputil.Prefix{
+						iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.0/24")),
+						iputil.PrefixFrom(netip.MustParsePrefix("fd00::/124"))},
+				},
+			}, updatedNode.Spec.IPAM.Pools.Allocated)
+			assert.Empty(t, updatedNode.Status.IPAM.OperatorStatus.Error)
+		})
+	})
+
+	t.Run("refetch and retry after update conflict", func(t *testing.T) {
+		node := &v2.CiliumNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+			},
+			Spec: v2.NodeSpec{
+				IPAM: ipamTypes.IPAMSpec{
+					PodCIDRs: []string{"10.0.0.0/24", "fd00::/124"},
+				},
+			},
+		}
+
+		var updates atomic.Int32
+
+		synctest.Test(t, func(t *testing.T) {
+			clientset, store := fixture(t, node, func(cs *k8sClient.FakeClientset) {
+				cs.CiliumFakeClientset.PrependReactor("update", "ciliumnodes", func(action k8sTesting.Action) (bool, runtime.Object, error) {
+					if updates.Add(1) == 1 {
+						// change the node in the store to simulate a conflict
+						gvr := v2.SchemeGroupVersion.WithResource(v2.CNPluralName)
+						current, err := cs.CiliumFakeClientset.Tracker().Get(gvr, "", nodeName, metav1.GetOptions{})
+						require.NoError(t, err)
+						currentNode := current.(*v2.CiliumNode).DeepCopy()
+						currentNode.Labels = map[string]string{"conflict-test": "true"}
+						if err := cs.CiliumFakeClientset.Tracker().Update(gvr, currentNode, ""); err != nil {
+							return true, nil, err
+						}
+
+						// return a conflict error for the first update attempt
+						return true, nil, k8sErrors.NewConflict(
+							schema.GroupResource{
+								Group:    v2.CustomResourceDefinitionGroup,
+								Resource: v2.CNPluralName,
+							},
+							nodeName,
+							errors.New("update refused by unit test"),
+						)
+					}
+					return false, nil, nil
+				})
+			})
+
+			err := migrateNode(t.Context(), store, clientset.CiliumV2().CiliumNodes(), resource.Key{Name: node.Name}, defaultPool)
+			require.NoError(t, err)
+			require.Equal(t, int32(2), updates.Load())
+
+			updatedNode, err := clientset.CiliumV2().CiliumNodes().Get(t.Context(), node.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+
+			assert.Empty(t, updatedNode.Spec.IPAM.PodCIDRs)
+			assert.Equal(t, []ipamTypes.IPAMPoolAllocation{
+				{
+					Pool: defaultPool,
+					CIDRs: []iputil.Prefix{
+						iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.0/24")),
+						iputil.PrefixFrom(netip.MustParsePrefix("fd00::/124"))},
+				},
+			}, updatedNode.Spec.IPAM.Pools.Allocated)
+			assert.Empty(t, updatedNode.Status.IPAM.OperatorStatus.Error)
+		})
+	})
+
+	t.Run("no retry if node was deleted", func(t *testing.T) {
+		node := &v2.CiliumNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+			},
+			Spec: v2.NodeSpec{
+				IPAM: ipamTypes.IPAMSpec{
+					PodCIDRs: []string{"10.0.0.0/24", "fd00::/124"},
+				},
+			},
+		}
+
+		var updates atomic.Int32
+
+		synctest.Test(t, func(t *testing.T) {
+			clientset, store := fixture(t, node, func(cs *k8sClient.FakeClientset) {
+				cs.CiliumFakeClientset.PrependReactor("update", "ciliumnodes", func(action k8sTesting.Action) (bool, runtime.Object, error) {
+					if updates.Add(1) == 1 {
+						// delete the node in the store
+						gvr := v2.SchemeGroupVersion.WithResource(v2.CNPluralName)
+						err := cs.CiliumFakeClientset.Tracker().Delete(gvr, "", nodeName, metav1.DeleteOptions{})
+						require.NoError(t, err)
+
+						// return a not found error
+						return true, nil, k8sErrors.NewNotFound(
+							schema.GroupResource{
+								Group:    v2.CustomResourceDefinitionGroup,
+								Resource: v2.CNPluralName,
+							},
+							nodeName,
+						)
+					}
+					return false, nil, nil
+				})
+			})
+
+			err := migrateNode(t.Context(), store, clientset.CiliumV2().CiliumNodes(), resource.Key{Name: node.Name}, defaultPool)
+			require.NoError(t, err)
+			require.Equal(t, int32(1), updates.Load())
+
+			_, err = clientset.CiliumV2().CiliumNodes().Get(t.Context(), node.Name, metav1.GetOptions{})
+			require.Error(t, err)
+			require.True(t, k8sErrors.IsNotFound(err))
+		})
+	})
+}
+
+func TestUpdateStatusForFailure(t *testing.T) {
+	const nodeName = "test-node"
+
+	t.Run("update status for failed migration", func(t *testing.T) {
+		node := &v2.CiliumNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+			},
+		}
+
+		migrationErr := errors.New("migration failed")
+
+		synctest.Test(t, func(t *testing.T) {
+			clientset, store := fixture(t, node, nil)
+
+			err := updateStatusForFailure(t.Context(), store, clientset.CiliumV2().CiliumNodes(), resource.Key{Name: node.Name}, migrationErr)
+			require.NoError(t, err)
+
+			updatedNode, err := clientset.CiliumV2().CiliumNodes().Get(t.Context(), node.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+
+			assert.Equal(t, fmt.Sprintf("migration to multi-pool IPAM failed: %s", migrationErr), updatedNode.Status.IPAM.OperatorStatus.Error)
+		})
+	})
+
+	t.Run("refetch and retry after update status conflict", func(t *testing.T) {
+		node := &v2.CiliumNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+			},
+		}
+
+		migrationErr := errors.New("migration failed")
+
+		var statusUpdates atomic.Int32
+
+		synctest.Test(t, func(t *testing.T) {
+			clientset, store := fixture(t, node, func(cs *k8sClient.FakeClientset) {
+				cs.CiliumFakeClientset.PrependReactor("update", "ciliumnodes", func(action k8sTesting.Action) (bool, runtime.Object, error) {
+					if action.GetSubresource() != "status" {
+						return false, nil, nil
+					}
+
+					if statusUpdates.Add(1) == 1 {
+						// change the node in the store to simulate a conflict
+						gvr := v2.SchemeGroupVersion.WithResource(v2.CNPluralName)
+						current, err := cs.CiliumFakeClientset.Tracker().Get(gvr, "", nodeName, metav1.GetOptions{})
+						require.NoError(t, err)
+						currentNode := current.(*v2.CiliumNode).DeepCopy()
+						currentNode.Status.IPAM.OperatorStatus.Error = "conflict-test"
+						if err := cs.CiliumFakeClientset.Tracker().Update(gvr, currentNode, ""); err != nil {
+							return true, nil, err
+						}
+
+						// return a conflict error for the first update status attempt
+						return true, nil, k8sErrors.NewConflict(
+							schema.GroupResource{
+								Group:    v2.CustomResourceDefinitionGroup,
+								Resource: v2.CNPluralName,
+							},
+							nodeName,
+							errors.New("update status refused by unit test"),
+						)
+					}
+					return false, nil, nil
+				})
+			})
+
+			err := updateStatusForFailure(t.Context(), store, clientset.CiliumV2().CiliumNodes(), resource.Key{Name: node.Name}, migrationErr)
+			require.NoError(t, err)
+			require.Equal(t, int32(2), statusUpdates.Load())
+
+			updatedNode, err := clientset.CiliumV2().CiliumNodes().Get(t.Context(), node.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+
+			assert.Equal(t, fmt.Sprintf("migration to multi-pool IPAM failed: %s", migrationErr), updatedNode.Status.IPAM.OperatorStatus.Error)
+		})
+	})
+}
+
+func fixture(
+	t *testing.T,
+	node *v2.CiliumNode,
+	setReactor func(cs *k8sClient.FakeClientset),
+) (*k8sClient.FakeClientset, resource.Store[*v2.CiliumNode]) {
+	t.Helper()
+
+	var (
+		clientset   *k8sClient.FakeClientset
+		ciliumNodes resource.Resource[*v2.CiliumNode]
+	)
+
+	testHive := hive.New(
+		k8sClient.FakeClientCell(),
+		operatorK8s.ResourcesCell,
+		cell.Invoke(
+			func(cs *k8sClient.FakeClientset, cn resource.Resource[*v2.CiliumNode]) {
+				clientset = cs
+				ciliumNodes = cn
+			},
+			func(cs *k8sClient.FakeClientset) {
+				if setReactor != nil {
+					setReactor(cs)
+				}
+			},
+		),
+	)
+
+	tlog := hivetest.Logger(t, hivetest.LogLevel(slog.LevelError))
+	require.NoError(t, testHive.Start(tlog, t.Context()))
+	t.Cleanup(func() {
+		assert.NoError(t, testHive.Stop(tlog, context.Background()))
+	})
+
+	_, err := clientset.CiliumV2().CiliumNodes().Create(t.Context(), node.DeepCopy(), metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	store, err := ciliumNodes.Store(t.Context())
+	require.NoError(t, err)
+
+	return clientset, store
+}

--- a/operator/pkg/ipam/allocator/multipool/multipool.go
+++ b/operator/pkg/ipam/allocator/multipool/multipool.go
@@ -5,16 +5,23 @@ package multipool
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"net/netip"
+	"time"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
+	"github.com/cilium/workerpool"
 	"github.com/spf13/pflag"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	allocatorTypes "github.com/cilium/cilium/operator/pkg/ipam/allocator"
+	"github.com/cilium/cilium/pkg/defaults"
+	iputil "github.com/cilium/cilium/pkg/ip"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -22,27 +29,48 @@ import (
 	cilium_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 )
 
-// autoCreateCiliumPodIPPoolsFlag is the flag name used to pre-declare
-// CiliumPodIPPool resources to be auto-created on startup.
-const autoCreateCiliumPodIPPoolsFlag = "auto-create-cilium-pod-ip-pools"
+const (
+	// autoCreateCiliumPodIPPoolsFlag is the flag name used to pre-declare
+	// CiliumPodIPPool resources to be auto-created on startup.
+	autoCreateCiliumPodIPPoolsFlag = "auto-create-cilium-pod-ip-pools"
+
+	// enableClusterPoolToMultiPoolMigration is the flag name to enable the migration
+	// of all nodes from cluster-pool IPAM to multi-pool IPAM
+	enableClusterPoolToMultiPoolMigration = "enable-cluster-pool-to-multi-pool-migration"
+
+	// migrationWorker is the flag name to set the number of workers to use for migrating
+	// nodes from cluster-pool IPAM to multi-pool IPAM.
+	migrationWorker = "multi-pool-migration-workers"
+)
 
 type Config struct {
-	AutoCreatePools map[string]string `mapstructure:"auto-create-cilium-pod-ip-pools"`
+	AutoCreatePools          map[string]string `mapstructure:"auto-create-cilium-pod-ip-pools"`
+	IPAMDefaultPool          string            `mapstructure:"ipam-default-ip-pool"` // keep this in sync with agent config "IPAMDefaultIPPool"
+	FromClusterPoolMigration bool              `mapstructure:"enable-cluster-pool-to-multi-pool-migration"`
+	MigrationWorkers         int               `mapstructure:"multi-pool-migration-workers"`
 }
 
 var DefaultConfig = Config{
-	AutoCreatePools: nil,
+	AutoCreatePools:          nil,
+	FromClusterPoolMigration: false,
+	IPAMDefaultPool:          defaults.IPAMDefaultIPPool,
+	MigrationWorkers:         16,
 }
 
 func (cfg Config) Flags(flags *pflag.FlagSet) {
 	flags.StringToString(autoCreateCiliumPodIPPoolsFlag, DefaultConfig.AutoCreatePools,
 		"Automatically create CiliumPodIPPool resources on startup. "+
 			"Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag)")
+	flags.Bool(enableClusterPoolToMultiPoolMigration, DefaultConfig.FromClusterPoolMigration,
+		"Enable the migration of all nodes from cluster-pool IPAM to multi-pool IPAM")
+	flags.String(option.IPAMDefaultIPPool, DefaultConfig.IPAMDefaultPool, "Name of the default IP Pool when using multi-pool")
+	flags.Int(migrationWorker, DefaultConfig.MigrationWorkers, "Number of workers to use for migrating nodes from cluster-pool IPAM to multi-pool IPAM")
 }
 
 type multiPoolParams struct {
@@ -55,6 +83,7 @@ type multiPoolParams struct {
 	DaemonCfg          *option.DaemonConfig
 	CiliumPodIPPools   resource.Resource[*cilium_api_v2alpha1.CiliumPodIPPool]
 	NodeWatcherFactory allocatorTypes.NodeWatcherJobFactory
+	CiliumNodes        resource.Resource[*v2.CiliumNode]
 
 	MultiPoolCfg Config
 }
@@ -75,6 +104,73 @@ func StartAllocator(p multiPoolParams) {
 					return err
 				}
 
+				migrationDone := make(chan struct{})
+
+				p.JobGroup.Add(
+					job.OneShot(
+						"from-cluster-pool-migration",
+						func(ctx context.Context, _ cell.Health) error {
+							defer close(migrationDone)
+
+							if !p.MultiPoolCfg.FromClusterPoolMigration {
+								return nil
+							}
+
+							store, err := p.CiliumNodes.Store(ctx)
+							if err != nil {
+								return fmt.Errorf("failed to get CiliumNode store, migration to multi-pool IPAM failed: %w", err)
+							}
+
+							wp := workerpool.NewWithContext(ctx, max(p.MultiPoolCfg.MigrationWorkers, 1))
+							defer wp.Close()
+
+							iter := store.IterKeys()
+							for iter.Next() {
+								key := iter.Key()
+								wp.Submit(
+									key.Name,
+									func(ctx context.Context) error {
+										var errs []error
+										if err := migrateNode(
+											ctx, store, p.Clientset.CiliumV2().CiliumNodes(),
+											key, p.MultiPoolCfg.IPAMDefaultPool,
+										); err != nil {
+											errs = append(errs, fmt.Errorf("failed to migrate node %q: %w", key.Name, err))
+
+											if err := updateStatusForFailure(
+												ctx, store, p.Clientset.CiliumV2().CiliumNodes(),
+												key, err,
+											); err != nil {
+												errs = append(errs, fmt.Errorf("failed to update CiliumNode status for node %q after migration failure: %w", key.Name, err))
+											}
+										}
+										return errors.Join(errs...)
+									},
+								)
+							}
+
+							tasks, err := wp.Drain()
+							if err != nil {
+								p.Logger.ErrorContext(
+									ctx, "Failed to drain worker pool for multi-pool migration",
+									logfields.Error, err,
+								)
+							}
+							for _, task := range tasks {
+								if err := task.Err(); err != nil {
+									p.Logger.ErrorContext(
+										ctx, "Migration to multi-pool IPAM failed for node",
+										logfields.Error, err,
+										logfields.Node, task,
+									)
+								}
+							}
+
+							return nil
+						},
+					),
+				)
+
 				p.JobGroup.Add(p.NodeWatcherFactory(
 					func(ctx context.Context) (allocatorTypes.NodeEventHandler, error) {
 						// The following operation will block until all pools are restored, thus it
@@ -83,6 +179,9 @@ func StartAllocator(p multiPoolParams) {
 							ctx, allocator, p.CiliumPodIPPools,
 							p.Logger.With(logfields.LogSubsys, "ip-pool-watcher"),
 						)
+
+						// Wait for all nodes to be migrated to multi-pool
+						<-migrationDone
 
 						nm := NewNodeHandler(
 							"ipam-multi-pool-sync",
@@ -142,6 +241,149 @@ func multiPoolAutoCreatePools(ctx context.Context, clientset client.Clientset, p
 		}
 
 		logger.InfoContext(ctx, "Created CiliumPodIPPool resource", logfields.PoolName, poolName)
+	}
+
+	return nil
+}
+
+func migrateNode(
+	ctx context.Context,
+	store resource.Store[*v2.CiliumNode],
+	client cilium_v2.CiliumNodeInterface,
+	key resource.Key,
+	pool string,
+) error {
+	return updateNodeWithRetries(
+		ctx, store, key,
+		func(node *v2.CiliumNode) (done bool, conflict bool, err error) {
+			if len(node.Spec.IPAM.PodCIDRs) == 0 {
+				return true, false, nil
+			}
+
+			newNode := node.DeepCopy()
+			cidrs := make([]iputil.Prefix, 0, len(node.Spec.IPAM.PodCIDRs))
+			for _, cidr := range node.Spec.IPAM.PodCIDRs {
+				prefix, err := netip.ParsePrefix(cidr)
+				if err != nil {
+					return true, false, fmt.Errorf("unable to parse CIDR %q: %w", cidr, err)
+				}
+				cidrs = append(cidrs, iputil.PrefixFrom(prefix))
+			}
+			newNode.Spec.IPAM.Pools = types.IPAMPoolSpec{
+				Allocated: []types.IPAMPoolAllocation{
+					{
+						Pool:  pool,
+						CIDRs: cidrs,
+					},
+				},
+			}
+			newNode.Spec.IPAM.PodCIDRs = nil
+
+			if _, err := client.Update(ctx, newNode, metav1.UpdateOptions{}); err != nil {
+				switch {
+				case k8sErrors.IsConflict(err):
+					return false, true, err
+				case k8sErrors.IsNotFound(err):
+					// node was deleted after we read it, nothing to do
+					return true, false, nil
+				default:
+					return false, false, fmt.Errorf("unable to update node: %w", err)
+				}
+			}
+
+			return true, false, nil
+		},
+	)
+}
+
+func updateStatusForFailure(
+	ctx context.Context,
+	store resource.Store[*v2.CiliumNode],
+	client cilium_v2.CiliumNodeInterface,
+	key resource.Key,
+	migrationErr error,
+) error {
+	errorMessage := fmt.Sprintf("migration to multi-pool IPAM failed: %s", migrationErr)
+
+	return updateNodeWithRetries(
+		ctx, store, key,
+		func(node *v2.CiliumNode) (done bool, conflict bool, err error) {
+			if node.Status.IPAM.OperatorStatus.Error == errorMessage {
+				return true, false, nil
+			}
+
+			newNode := node.DeepCopy()
+			newNode.Status.IPAM.OperatorStatus.Error = errorMessage
+			if _, err := client.UpdateStatus(ctx, newNode, metav1.UpdateOptions{}); err != nil {
+				switch {
+				case k8sErrors.IsConflict(err):
+					return false, true, err
+				case k8sErrors.IsNotFound(err):
+					// node was deleted after we read it, nothing to do
+					return true, false, nil
+				default:
+					return false, false, fmt.Errorf("unable to update node status: %w", err)
+				}
+			}
+
+			return true, false, nil
+		},
+	)
+}
+
+func updateNodeWithRetries(
+	ctx context.Context,
+	store resource.Store[*v2.CiliumNode],
+	key resource.Key,
+	updateFunc func(node *v2.CiliumNode) (bool, bool, error),
+) error {
+	var (
+		node      *v2.CiliumNode
+		updateErr error
+	)
+
+	backoff := wait.Backoff{
+		Steps:    10,
+		Duration: 10 * time.Millisecond,
+		Factor:   2.5,
+		Jitter:   0.1,
+	}
+
+	var conflict bool
+	if err := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
+		updNode, exists, err := store.GetByKey(key)
+		if err != nil {
+			return false, fmt.Errorf("unable to get node from store: %w", err)
+		}
+		if !exists {
+			// node was deleted, nothing to do
+			return true, nil
+		}
+		if conflict && node.ResourceVersion == updNode.ResourceVersion {
+			// wait for the store to be updated after a conflict
+			return false, nil
+		}
+		node = updNode
+		conflict = false
+
+		var done bool
+
+		done, conflict, err = updateFunc(node)
+
+		// propagate last error
+		updateErr = err
+
+		if !done {
+			// keep retrying
+			return false, nil
+		}
+
+		return true, err
+	}); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil
+		}
+		return updateErr
 	}
 
 	return nil

--- a/operator/pkg/ipam/allocator/multipool/multipool.go
+++ b/operator/pkg/ipam/allocator/multipool/multipool.go
@@ -85,6 +85,8 @@ type multiPoolParams struct {
 	NodeWatcherFactory allocatorTypes.NodeWatcherJobFactory
 	CiliumNodes        resource.Resource[*v2.CiliumNode]
 
+	Allocator *PoolAllocator
+
 	MultiPoolCfg Config
 }
 
@@ -93,14 +95,10 @@ func StartAllocator(p multiPoolParams) {
 		return
 	}
 
-	logger := p.Logger.With([]any{logfields.LogSubsys, "ipam-allocator-multi-pool"}...)
-
-	allocator := NewPoolAllocator(logger, p.DaemonCfg.EnableIPv4, p.DaemonCfg.EnableIPv6)
-
 	p.Lifecycle.Append(
 		cell.Hook{
 			OnStart: func(ctx cell.HookContext) error {
-				if err := multiPoolAutoCreatePools(ctx, p.Clientset, p.MultiPoolCfg.AutoCreatePools, logger); err != nil {
+				if err := multiPoolAutoCreatePools(ctx, p.Clientset, p.MultiPoolCfg.AutoCreatePools, p.Logger); err != nil {
 					return err
 				}
 
@@ -175,17 +173,14 @@ func StartAllocator(p multiPoolParams) {
 					func(ctx context.Context) (allocatorTypes.NodeEventHandler, error) {
 						// The following operation will block until all pools are restored, thus it
 						// is safe to continue starting node allocation right after return.
-						startIPPoolAllocator(
-							ctx, allocator, p.CiliumPodIPPools,
-							p.Logger.With(logfields.LogSubsys, "ip-pool-watcher"),
-						)
+						startIPPoolAllocator(ctx, p.Allocator, p.CiliumPodIPPools, p.Logger)
 
 						// Wait for all nodes to be migrated to multi-pool
 						<-migrationDone
 
 						nm := NewNodeHandler(
 							"ipam-multi-pool-sync",
-							logger, allocator, p.Clientset.CiliumV2().CiliumNodes(),
+							p.Logger, p.Allocator, p.Clientset.CiliumV2().CiliumNodes(),
 							func(cn *v2.CiliumNode) *types.IPAMPoolSpec {
 								return &cn.Spec.IPAM.Pools
 							},

--- a/operator/pkg/ipam/multipool.go
+++ b/operator/pkg/ipam/multipool.go
@@ -6,9 +6,14 @@
 package ipam
 
 import (
+	"log/slog"
+
 	"github.com/cilium/hive/cell"
 
 	"github.com/cilium/cilium/operator/pkg/ipam/allocator/multipool"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 func init() {
@@ -17,6 +22,20 @@ func init() {
 		"Multi Pool IP Allocator",
 
 		cell.Config(multipool.DefaultConfig),
-		cell.Invoke(multipool.StartAllocator),
+		cell.Decorate(
+			func(logger *slog.Logger) *slog.Logger {
+				return logger.With(logfields.LogSubsys, "ipam-allocator-multi-pool")
+			},
+			cell.ProvidePrivate(
+				func(logger *slog.Logger, daemonCfg *option.DaemonConfig) *multipool.PoolAllocator {
+					if daemonCfg.IPAM != ipamOption.IPAMMultiPool {
+						return nil
+					}
+
+					return multipool.NewPoolAllocator(logger, daemonCfg.EnableIPv4, daemonCfg.EnableIPv6)
+				},
+			),
+			cell.Invoke(multipool.StartAllocator),
+		),
 	))
 }

--- a/operator/pkg/ipam/multipool_script_test.go
+++ b/operator/pkg/ipam/multipool_script_test.go
@@ -35,6 +35,9 @@ func init() {
 		"Multi Pool IP Allocator",
 
 		cell.Config(multipool.DefaultConfig),
+		cell.Provide(func(logger *slog.Logger, daemonCfg *option.DaemonConfig) *multipool.PoolAllocator {
+			return multipool.NewPoolAllocator(logger, daemonCfg.EnableIPv4, daemonCfg.EnableIPv6)
+		}),
 		cell.Invoke(multipool.StartAllocator),
 	))
 }

--- a/operator/pkg/ipam/multipool_script_test.go
+++ b/operator/pkg/ipam/multipool_script_test.go
@@ -5,6 +5,7 @@ package ipam
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"log/slog"
 	"maps"
@@ -20,6 +21,7 @@ import (
 
 	"github.com/cilium/cilium/operator/k8s"
 	"github.com/cilium/cilium/operator/pkg/ipam/allocator/multipool"
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/hive"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
@@ -48,22 +50,32 @@ func TestScriptMultiPool(t *testing.T) {
 	t.Cleanup(func() { testutils.GoleakVerifyNone(t) })
 
 	setup := func(t testing.TB, args []string) *script.Engine {
+		var allocator *multipool.PoolAllocator
+
 		h := hive.New(
 			k8sClient.FakeClientCell(),
 			k8s.ResourcesCell,
 			cell.Provide(func() *option.DaemonConfig {
 				return &option.DaemonConfig{
-					EnableIPv4: true,
-					EnableIPv6: true,
-					IPAM:       ipamOption.IPAMMultiPool,
+					EnableIPv4:        true,
+					EnableIPv6:        true,
+					IPAM:              ipamOption.IPAMMultiPool,
+					IPAMDefaultIPPool: defaults.IPAMDefaultIPPool,
 				}
 			}),
 
 			Cell(),
+
+			cell.Invoke(func(allocator_ *multipool.PoolAllocator) {
+				allocator = allocator_
+			}),
 		)
 
 		flags := pflag.NewFlagSet("", pflag.ContinueOnError)
 		h.RegisterFlags(flags)
+
+		// Parse the shebang arguments in the script.
+		require.NoError(t, flags.Parse(args), "flags.Parse")
 
 		var opts []hivetest.LogOption
 		if *debug {
@@ -79,6 +91,7 @@ func TestScriptMultiPool(t *testing.T) {
 		cmds, err := h.ScriptCommands(log)
 		require.NoError(t, err, "ScriptCommands")
 		maps.Insert(cmds, maps.All(script.DefaultCmds()))
+		maps.Insert(cmds, maps.All(commands(allocator)))
 
 		return &script.Engine{Cmds: cmds}
 	}
@@ -89,4 +102,28 @@ func TestScriptMultiPool(t *testing.T) {
 		[]string{},
 		"testdata/multipool/*.txtar",
 	)
+}
+
+func commands(allocator *multipool.PoolAllocator) map[string]script.Cmd {
+	return map[string]script.Cmd{
+		"allocator/allocated-pools": script.Command(
+			script.CmdUsage{
+				Summary: "Dump PoolAllocator.AllocatedPools for a node",
+				Args:    "node-name",
+			},
+			func(_ *script.State, args ...string) (script.WaitFunc, error) {
+				if len(args) != 1 {
+					return nil, script.ErrUsage
+				}
+
+				return func(_ *script.State) (stdout string, stderr string, err error) {
+					data, err := json.MarshalIndent(allocator.AllocatedPools(args[0]), "", "  ")
+					if err != nil {
+						return "", "", err
+					}
+					return string(data) + "\n", "", nil
+				}, nil
+			},
+		),
+	}
 }

--- a/operator/pkg/ipam/testdata/multipool/from-cluster-pool-migration.txtar
+++ b/operator/pkg/ipam/testdata/multipool/from-cluster-pool-migration.txtar
@@ -1,0 +1,146 @@
+#! --enable-cluster-pool-to-multi-pool-migration=true --ipam-default-ip-pool=custom-pool
+
+# Validate operator-side migration from cluster-pool to multi-pool IPAM.
+#
+# The CiliumNodes have cluster-pool PodCIDRs in spec.ipam.podCIDRs when the operator starts.
+
+k8s/add node-a.yaml
+k8s/add node-b.yaml
+k8s/add custom-pool.yaml
+
+hive start
+
+# The operator should convert each cluster-pool PodCIDR into an allocation from
+# the globally configured default pool, with the same CIDR.
+
+k8s/get cilium.io.v2.ciliumnodes node-a -o actual-node-a.yaml
+* cmp expected-node-a.yaml actual-node-a.yaml
+
+k8s/get cilium.io.v2.ciliumnodes node-b -o actual-node-b.yaml
+* cmp expected-node-b.yaml actual-node-b.yaml
+
+# The allocator internal state should match the migrated allocations in
+# spec.ipam.pools.allocated.
+
+allocator/allocated-pools node-a
+* cmp stdout expected-allocator-node-a.json
+
+allocator/allocated-pools node-b
+* cmp stdout expected-allocator-node-b.json
+
+hive stop
+
+# ----
+
+-- node-a.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: node-a
+  labels:
+    kubernetes.io/hostname: node-a
+spec:
+  ipam:
+    podCIDRs:
+    - 10.244.1.0/24
+    - fd00::/124
+-- node-b.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: node-b
+  labels:
+    kubernetes.io/hostname: node-b
+spec:
+  ipam:
+    podCIDRs:
+    - 10.244.2.0/24
+    - fd00::10/124
+-- custom-pool.yaml --
+apiVersion: cilium.io/v2alpha1
+kind: CiliumPodIPPool
+metadata:
+  name: custom-pool
+spec:
+  ipv4:
+    cidrs:
+    - 10.244.0.0/16
+    maskSize: 24
+  ipv6:
+    cidrs:
+    - fd00::/112
+    maskSize: 124
+-- expected-node-a.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  labels:
+    kubernetes.io/hostname: node-a
+  name: node-a
+spec:
+  alibaba-cloud: {}
+  azure: {}
+  encryption: {}
+  eni: {}
+  health: {}
+  ingress: {}
+  ipam:
+    pools:
+      allocated:
+      - cidrs:
+        - 10.244.1.0/24
+        - fd00::/124
+        pool: custom-pool
+status:
+  alibaba-cloud: {}
+  azure: {}
+  eni: {}
+  ipam:
+    operator-status: {}
+-- expected-node-b.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  labels:
+    kubernetes.io/hostname: node-b
+  name: node-b
+spec:
+  alibaba-cloud: {}
+  azure: {}
+  encryption: {}
+  eni: {}
+  health: {}
+  ingress: {}
+  ipam:
+    pools:
+      allocated:
+      - cidrs:
+        - 10.244.2.0/24
+        - fd00::10/124
+        pool: custom-pool
+status:
+  alibaba-cloud: {}
+  azure: {}
+  eni: {}
+  ipam:
+    operator-status: {}
+-- expected-allocator-node-a.json --
+[
+  {
+    "pool": "custom-pool",
+    "cidrs": [
+      "10.244.1.0/24",
+      "fd00::/124"
+    ]
+  }
+]
+-- expected-allocator-node-b.json --
+[
+  {
+    "pool": "custom-pool",
+    "cidrs": [
+      "10.244.2.0/24",
+      "fd00::10/124"
+    ]
+  }
+]

--- a/pkg/ipam/migration/script_test.go
+++ b/pkg/ipam/migration/script_test.go
@@ -1,0 +1,325 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package migration
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"maps"
+	"net/netip"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/script"
+	"github.com/cilium/hive/script/scripttest"
+	"github.com/cilium/statedb"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/api/v1/models"
+	endpointapi "github.com/cilium/cilium/api/v1/server/restapi/endpoint"
+	agentK8s "github.com/cilium/cilium/daemon/k8s"
+	"github.com/cilium/cilium/pkg/cidr"
+	"github.com/cilium/cilium/pkg/container/set"
+	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
+	sysctlFake "github.com/cilium/cilium/pkg/datapath/linux/sysctl/fake"
+	datapathTables "github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipam"
+	ipamcell "github.com/cilium/cilium/pkg/ipam/cell"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/ipmasq"
+	k8sClientTest "github.com/cilium/cilium/pkg/k8s/client/testutils"
+	k8sTables "github.com/cilium/cilium/pkg/k8s/tables"
+	"github.com/cilium/cilium/pkg/k8s/watchers"
+	"github.com/cilium/cilium/pkg/mtu"
+	mtuFake "github.com/cilium/cilium/pkg/mtu/fake"
+	"github.com/cilium/cilium/pkg/node"
+	nodeFake "github.com/cilium/cilium/pkg/node/fake"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/nodediscovery"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+func TestScriptClusterPoolToMultiPool(t *testing.T) {
+	var (
+		initializer *ipamcell.IPAMInitializer
+		manager     *ipam.IPAM
+	)
+
+	defer testutils.GoleakVerifyNone(t)
+
+	scripttest.Test(t,
+		t.Context(),
+		func(t testing.TB, args []string) *script.Engine {
+			h := hive.New(
+				k8sClientTest.FakeClientCell(),
+				agentK8s.ResourcesCell,
+				k8sTables.TablesCell,
+				datapathTables.DirectRoutingDeviceCell,
+				cell.Provide(
+					func() *option.DaemonConfig {
+						return &option.DaemonConfig{
+							EnableIPv4:                 true,
+							EnableIPv6:                 true,
+							EnableCiliumNodeCRD:        true,
+							IPAM:                       ipamOption.IPAMMultiPool,
+							IPAMDefaultIPPool:          defaults.IPAMDefaultIPPool,
+							IPAMMultiPoolPreAllocation: map[string]string{defaults.IPAMDefaultIPPool: "8"},
+							IPAMCiliumNodeUpdateRate:   time.Nanosecond, // speed up CiliumNode sync to k8s
+							IPv4Range:                  "auto",
+							IPv6Range:                  "auto",
+						}
+					},
+					func() *node.LocalNodeStore {
+						nodeTypes.SetName("test-node")
+						localNode := node.LocalNode{
+							Node: nodeTypes.Node{
+								Name:          nodeTypes.GetName(),
+								IPv4AllocCIDR: cidr.MustParseCIDR("10.244.0.0/24"),
+								IPv6AllocCIDR: cidr.MustParseCIDR("fd00:10:244::/96"),
+							},
+							Local: &node.LocalNodeInfo{},
+						}
+						return node.NewTestLocalNodeStore(localNode)
+					},
+					func() node.Addressing { return nodeFake.NewAddressing() },
+					func() *watchers.K8sEventReporter { return &watchers.K8sEventReporter{} },
+					func() endpointmanager.EndpointManager { return noopEndpointManager{} },
+					func() *nodediscovery.NodeDiscovery { return &nodediscovery.NodeDiscovery{} },
+					func() *ipmasq.IPMasqAgent { return nil },
+					func() mtu.MTU { return &mtuFake.MTU{} },
+					func() sysctl.Sysctl { return &sysctlFake.Sysctl{} },
+					datapathTables.NewDeviceTable,
+					statedb.RWTable[*datapathTables.Device].ToTable,
+				),
+
+				ipamcell.Cell,
+
+				cell.Invoke(func(initializer_ *ipamcell.IPAMInitializer, manager_ *ipam.IPAM) {
+					initializer = initializer_
+					manager = manager_
+				}),
+			)
+
+			flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+			h.RegisterFlags(flags)
+
+			log := hivetest.Logger(t, hivetest.LogLevel(slog.LevelError))
+			t.Cleanup(func() {
+				assert.NoError(t, h.Stop(log, context.TODO()))
+			})
+
+			cmds, err := h.ScriptCommands(log)
+			require.NoError(t, err, "ScriptCommands")
+			maps.Insert(cmds, maps.All(script.DefaultCmds()))
+			maps.Insert(cmds, maps.All(commands(initializer, manager)))
+
+			return &script.Engine{Cmds: cmds}
+		}, []string{}, "testdata/*.txtar")
+}
+
+func commands(initializer *ipamcell.IPAMInitializer, manager *ipam.IPAM) map[string]script.Cmd {
+	return map[string]script.Cmd{
+		"ipam/start": script.Command(
+			script.CmdUsage{
+				Summary: "Call IPAMInitializer.ConfigureAndStartIPAM",
+			},
+			func(state *script.State, args ...string) (script.WaitFunc, error) {
+				if len(args) != 0 {
+					return nil, script.ErrUsage
+				}
+				initializer.ConfigureAndStartIPAM(state.Context())
+				return nil, nil
+			},
+		),
+		"ipam/restore-endpoint": script.Command(
+			script.CmdUsage{
+				Summary: "Restore an endpoint IP allocation through IPAM",
+				Args:    "ip-address owner",
+			},
+			func(_ *script.State, args ...string) (script.WaitFunc, error) {
+				if len(args) != 2 {
+					return nil, script.ErrUsage
+				}
+
+				addr, err := netip.ParseAddr(args[0])
+				if err != nil {
+					return nil, err
+				}
+
+				_, err = manager.AllocateIPWithoutSyncUpstream(
+					addr.AsSlice(),
+					args[1],
+					ipam.PoolOrDefault(""), // restored endpoints from cluster-pool should have an empty pool
+				)
+				return nil, err
+			},
+		),
+		"ipam/restore-finished": script.Command(
+			script.CmdUsage{
+				Summary: "Call IPAMInitializer.RestoreFinished",
+			},
+			func(_ *script.State, args ...string) (script.WaitFunc, error) {
+				if len(args) != 0 {
+					return nil, script.ErrUsage
+				}
+				initializer.RestoreFinished()
+				return nil, nil
+			},
+		),
+		"ipam/allocate": script.Command(
+			script.CmdUsage{
+				Summary: "Allocate the next pod IPs from the default pool",
+				Args:    "owner",
+			},
+			func(_ *script.State, args ...string) (script.WaitFunc, error) {
+				if len(args) != 1 {
+					return nil, script.ErrUsage
+				}
+
+				_, _, err := manager.AllocateNext("", args[0], ipam.PoolDefault())
+				return nil, err
+			},
+		),
+		"ipam/dump": script.Command(
+			script.CmdUsage{
+				Summary: "Write formatted IPAM.Dump output to a file",
+				Args:    "output-file",
+			},
+			func(state *script.State, args ...string) (script.WaitFunc, error) {
+				if len(args) != 1 {
+					return nil, script.ErrUsage
+				}
+
+				allocv4, allocv6, _ := manager.Dump()
+				data, err := formatDump(allocv4, allocv6)
+				if err != nil {
+					return nil, err
+				}
+
+				return nil, os.WriteFile(state.Path(args[0]), []byte(data), 0644)
+			},
+		),
+	}
+}
+
+type ipamStatus struct {
+	IPv4 ipamAllocs `json:"ipv4"`
+	IPv6 ipamAllocs `json:"ipv6"`
+}
+
+type ipamAllocs struct {
+	Pools  map[string]int `json:"pools"`
+	Owners []string       `json:"owners"`
+}
+
+func formatDump(allocv4, allocv6 map[string]string) (string, error) {
+	dump := ipamStatus{
+		IPv4: formatAllocs(allocv4),
+		IPv6: formatAllocs(allocv6),
+	}
+
+	out, err := json.MarshalIndent(dump, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(out) + "\n", nil
+}
+
+func formatAllocs(allocs map[string]string) ipamAllocs {
+	family := ipamAllocs{
+		Pools:  map[string]int{},
+		Owners: make([]string, 0, len(allocs)),
+	}
+
+	for ip, owner := range allocs {
+		pool, _, ok := strings.Cut(ip, "/")
+		if !ok {
+			pool = string(ipam.PoolDefault())
+		}
+		family.Pools[pool]++
+
+		family.Owners = append(family.Owners, owner)
+	}
+	sort.Strings(family.Owners)
+
+	return family
+}
+
+type noopEndpointManager struct{}
+
+func (noopEndpointManager) Lookup(string) (*endpoint.Endpoint, error) { return nil, nil }
+func (noopEndpointManager) LookupCiliumID(uint16) *endpoint.Endpoint  { return nil }
+func (noopEndpointManager) LookupCNIAttachmentID(string) *endpoint.Endpoint {
+	return nil
+}
+func (noopEndpointManager) LookupIPv4(string) *endpoint.Endpoint { return nil }
+func (noopEndpointManager) LookupIPv6(string) *endpoint.Endpoint { return nil }
+func (noopEndpointManager) LookupIP(netip.Addr) *endpoint.Endpoint {
+	return nil
+}
+func (noopEndpointManager) LookupCEPName(string) *endpoint.Endpoint { return nil }
+func (noopEndpointManager) GetEndpointsByPodName(string) []*endpoint.Endpoint {
+	return nil
+}
+func (noopEndpointManager) GetEndpointsByContainerID(string) []*endpoint.Endpoint {
+	return nil
+}
+func (noopEndpointManager) GetEndpointsByServiceAccount(string, string) []*endpoint.Endpoint {
+	return nil
+}
+func (noopEndpointManager) GetEndpointsByNamespace(string) []*endpoint.Endpoint {
+	return nil
+}
+func (noopEndpointManager) GetEndpoints() []*endpoint.Endpoint { return nil }
+func (noopEndpointManager) GetEndpointList(endpointapi.GetEndpointParams) []*models.Endpoint {
+	return nil
+}
+func (noopEndpointManager) EndpointExists(uint16) bool             { return false }
+func (noopEndpointManager) GetHostEndpoint() *endpoint.Endpoint    { return nil }
+func (noopEndpointManager) HostEndpointExists() bool               { return false }
+func (noopEndpointManager) GetIngressEndpoint() *endpoint.Endpoint { return nil }
+func (noopEndpointManager) IngressEndpointExists() bool            { return false }
+func (noopEndpointManager) AddEndpoint(*endpoint.Endpoint) error   { return nil }
+func (noopEndpointManager) RestoreEndpoint(*endpoint.Endpoint) error {
+	return nil
+}
+func (noopEndpointManager) UpdateReferences(*endpoint.Endpoint) error {
+	return nil
+}
+func (noopEndpointManager) RemoveEndpoint(*endpoint.Endpoint, endpoint.DeleteConfig) []error {
+	return nil
+}
+func (noopEndpointManager) RunK8sCiliumEndpointSync(*endpoint.Endpoint, cell.Health) {}
+func (noopEndpointManager) DeleteK8sCiliumEndpointSync(*endpoint.Endpoint)           {}
+func (noopEndpointManager) Subscribe(endpointmanager.Subscriber)                     {}
+func (noopEndpointManager) Unsubscribe(endpointmanager.Subscriber)                   {}
+func (noopEndpointManager) UpdatePolicyMaps(context.Context) error                   { return nil }
+func (noopEndpointManager) RegenerateAllEndpoints(*regeneration.ExternalRegenerationMetadata) *sync.WaitGroup {
+	return &sync.WaitGroup{}
+}
+func (noopEndpointManager) TriggerRegenerateAllEndpoints()                            {}
+func (noopEndpointManager) RegenerateAllForPolicy(uint64)                             {}
+func (noopEndpointManager) WaitForEndpointsAtPolicyRev(context.Context, uint64) error { return nil }
+func (noopEndpointManager) OverrideEndpointOpts(option.OptionMap)                     {}
+func (noopEndpointManager) InitHostEndpointLabels(context.Context)                    {}
+func (noopEndpointManager) UpdatePolicy(*set.Set[identity.NumericIdentity], uint64, uint64) {
+}
+
+var _ endpointmanager.EndpointManager = noopEndpointManager{}

--- a/pkg/ipam/migration/testdata/from-cluster-pool-migration.txtar
+++ b/pkg/ipam/migration/testdata/from-cluster-pool-migration.txtar
@@ -1,0 +1,307 @@
+# Validate agent-side migration from cluster-pool to multi-pool IPAM.
+#
+# The CiliumNode is already migrated by the operator before the agent starts:
+# it has an allocated CIDR in spec.ipam.pools.allocated and no requests yet.
+
+k8s/add default-pool.yaml
+k8s/add migrated-cilium-node.yaml
+
+hive start
+
+# Simulate the startup IPAM sequence of the daemon, including endpoints restoration
+# with endpoints coming from the previous cluster-pool IPAM mode
+ipam/start
+ipam/restore-endpoint 10.0.0.2 restored-endpoint-1
+ipam/restore-endpoint fd00::2 restored-endpoint-1
+ipam/restore-endpoint 10.0.0.3 restored-endpoint-2
+ipam/restore-endpoint fd00::3 restored-endpoint-2
+ipam/restore-endpoint 10.0.0.4 restored-endpoint-3
+ipam/restore-endpoint fd00::4 restored-endpoint-3
+ipam/restore-finished
+
+# Wait for the agent to sync the restored endpoints demand to the CiliumNode.
+k8s/get cilium.io.v2.ciliumnodes test-node -o actual.yaml
+* cmp expected-cilium-node.yaml actual.yaml
+
+# Simulate CNI ADD calls for new pods. The restored endpoints plus six new pod
+# allocations increase the default pool demand from 16 to 24.
+ipam/allocate pod-1
+ipam/allocate pod-2
+ipam/allocate pod-3
+ipam/allocate pod-4
+ipam/allocate pod-5
+ipam/allocate pod-6
+
+# Wait for the agent to sync the increased demand to the CiliumNode.
+k8s/get cilium.io.v2.ciliumnodes test-node -o actual-after-pods.yaml
+* cmp expected-after-pods-cilium-node.yaml actual-after-pods.yaml
+
+# Simulate the operator fulfilling the increased demand with another CIDR.
+k8s/update operator-expanded-cilium-node.yaml
+
+# Validate that the newly allocated CIDR is present in the CiliumNode.
+k8s/get cilium.io.v2.ciliumnodes test-node -o actual-after-operator.yaml
+* cmp expected-after-operator-cilium-node.yaml actual-after-operator.yaml
+
+# Continue allocating pod IPs after the operator handed out the second /28 and /124.
+# The sixth allocation in this block requires the newly allocated CIDR (the
+# /28 and /124 CIDRs give the agent 14 available addresses since the first and the
+# last one are not allowed).
+ipam/allocate post-operator-pod-1
+ipam/allocate post-operator-pod-2
+ipam/allocate post-operator-pod-3
+ipam/allocate post-operator-pod-4
+ipam/allocate post-operator-pod-5
+
+# Wait until the IPAM manager has observed the additional CIDR.
+* ipam/allocate post-operator-pod-6
+
+# Keep allocating to prove demand still increases after the new CIDR is used.
+ipam/allocate post-operator-pod-7
+ipam/allocate post-operator-pod-8
+
+# Wait for the agent to sync the post-operator pod allocations.
+k8s/get cilium.io.v2.ciliumnodes test-node -o actual-after-more-pods.yaml
+* cmp expected-after-more-pods-cilium-node.yaml actual-after-more-pods.yaml
+
+# Validate multi-pool internal status.
+ipam/dump actual-ipam-dump.json
+cmp expected-ipam-dump.json actual-ipam-dump.json
+
+hive stop
+
+-- migrated-cilium-node.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: test-node
+  labels:
+    kubernetes.io/hostname: test-node
+spec:
+  ipam:
+    pools:
+      allocated:
+      - pool: default
+        cidrs:
+        - 10.0.0.0/28
+        - fd00::/124
+      requested: []
+-- default-pool.yaml --
+apiVersion: cilium.io/v2alpha1
+kind: CiliumPodIPPool
+metadata:
+  name: default
+spec:
+  ipv4:
+    cidrs:
+    - 10.0.0.0/16
+    maskSize: 28
+  ipv6:
+    cidrs:
+    - fd00::/112
+    maskSize: 124
+-- expected-cilium-node.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  labels:
+    kubernetes.io/hostname: test-node
+  name: test-node
+spec:
+  alibaba-cloud: {}
+  azure: {}
+  encryption: {}
+  eni: {}
+  health: {}
+  ingress: {}
+  ipam:
+    pools:
+      allocated:
+      - cidrs:
+        - 10.0.0.0/28
+        - fd00::/124
+        pool: default
+      requested:
+      - needed:
+          ipv4-addrs: 16
+          ipv6-addrs: 16
+        pool: default
+status:
+  alibaba-cloud: {}
+  azure: {}
+  eni: {}
+  ipam:
+    operator-status: {}
+-- expected-after-pods-cilium-node.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  labels:
+    kubernetes.io/hostname: test-node
+  name: test-node
+spec:
+  alibaba-cloud: {}
+  azure: {}
+  encryption: {}
+  eni: {}
+  health: {}
+  ingress: {}
+  ipam:
+    pools:
+      allocated:
+      - cidrs:
+        - 10.0.0.0/28
+        - fd00::/124
+        pool: default
+      requested:
+      - needed:
+          ipv4-addrs: 24
+          ipv6-addrs: 24
+        pool: default
+status:
+  alibaba-cloud: {}
+  azure: {}
+  eni: {}
+  ipam:
+    operator-status: {}
+-- operator-expanded-cilium-node.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: test-node
+  labels:
+    kubernetes.io/hostname: test-node
+spec:
+  ipam:
+    pools:
+      allocated:
+      - pool: default
+        cidrs:
+        - 10.0.0.0/28
+        - 10.0.0.16/28
+        - fd00::/124
+        - fd00::10/124
+      requested:
+      - pool: default
+        needed:
+          ipv4-addrs: 24
+          ipv6-addrs: 24
+-- expected-after-operator-cilium-node.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  labels:
+    kubernetes.io/hostname: test-node
+  name: test-node
+spec:
+  alibaba-cloud: {}
+  azure: {}
+  encryption: {}
+  eni: {}
+  health: {}
+  ingress: {}
+  ipam:
+    pools:
+      allocated:
+      - cidrs:
+        - 10.0.0.0/28
+        - 10.0.0.16/28
+        - fd00::/124
+        - fd00::10/124
+        pool: default
+      requested:
+      - needed:
+          ipv4-addrs: 24
+          ipv6-addrs: 24
+        pool: default
+status:
+  alibaba-cloud: {}
+  azure: {}
+  eni: {}
+  ipam:
+    operator-status: {}
+-- expected-after-more-pods-cilium-node.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  labels:
+    kubernetes.io/hostname: test-node
+  name: test-node
+spec:
+  alibaba-cloud: {}
+  azure: {}
+  encryption: {}
+  eni: {}
+  health: {}
+  ingress: {}
+  ipam:
+    pools:
+      allocated:
+      - cidrs:
+        - 10.0.0.0/28
+        - 10.0.0.16/28
+        - fd00::/124
+        - fd00::10/124
+        pool: default
+      requested:
+      - needed:
+          ipv4-addrs: 32
+          ipv6-addrs: 32
+        pool: default
+status:
+  alibaba-cloud: {}
+  azure: {}
+  eni: {}
+  ipam:
+    operator-status: {}
+-- expected-ipam-dump.json --
+{
+  "ipv4": {
+    "pools": {
+      "default": 17
+    },
+    "owners": [
+      "pod-1",
+      "pod-2",
+      "pod-3",
+      "pod-4",
+      "pod-5",
+      "pod-6",
+      "post-operator-pod-1",
+      "post-operator-pod-2",
+      "post-operator-pod-3",
+      "post-operator-pod-4",
+      "post-operator-pod-5",
+      "post-operator-pod-6",
+      "post-operator-pod-7",
+      "post-operator-pod-8",
+      "restored-endpoint-1",
+      "restored-endpoint-2",
+      "restored-endpoint-3"
+    ]
+  },
+  "ipv6": {
+    "pools": {
+      "default": 17
+    },
+    "owners": [
+      "pod-1",
+      "pod-2",
+      "pod-3",
+      "pod-4",
+      "pod-5",
+      "pod-6",
+      "post-operator-pod-1",
+      "post-operator-pod-2",
+      "post-operator-pod-3",
+      "post-operator-pod-4",
+      "post-operator-pod-5",
+      "post-operator-pod-6",
+      "post-operator-pod-7",
+      "post-operator-pod-8",
+      "restored-endpoint-1",
+      "restored-endpoint-2",
+      "restored-endpoint-3"
+    ]
+  }
+}

--- a/pkg/ipam/multipool_manager.go
+++ b/pkg/ipam/multipool_manager.go
@@ -532,8 +532,19 @@ func (m *multiPoolManager) computeNeededIPsPerPoolLocked() map[Pool]types.IPAMPo
 
 func (m *multiPoolManager) restoreFinished(family Family) {
 	m.poolsMutex.Lock()
+	defer m.poolsMutex.Unlock()
+
 	m.finishedRestore[family] = true
-	m.poolsMutex.Unlock()
+
+	// Trigger update to k8s to recalculate and synchronize requested addresses in CiliumNode
+	// .Spec.IPAM.Pools.Requested with the actual need after restore is finished.
+	if m.ipv4Enabled && !m.finishedRestore[IPv4] {
+		return
+	}
+	if m.ipv6Enabled && !m.finishedRestore[IPv6] {
+		return
+	}
+	m.k8sUpdater.Trigger()
 }
 
 func (m *multiPoolManager) isRestoreFinishedLocked(family Family) bool {

--- a/pkg/ipam/multipool_test.go
+++ b/pkg/ipam/multipool_test.go
@@ -48,32 +48,12 @@ import (
 )
 
 func Test_MultiPoolManager(t *testing.T) {
-	fakeConfig := testConfiguration
-	// disable debounce interval to trigger CiliumNode update at each test step
-	fakeConfig.IPAMCiliumNodeUpdateRate = 1 * time.Nanosecond
-	// set custom preAllocMap for unit tests
-	fakeConfig.IPAMMultiPoolPreAllocation = map[string]string{
-		"default": "16",
-		"mars":    "8",
-	}
-	events := make(chan string, 1)
-	cnEvents := make(chan resource.Event[*ciliumv2.CiliumNode])
-	fakeK8sCiliumNodeAPI := &fakeK8sCiliumNodeAPIResource{
-		c:    cnEvents,
-		node: &ciliumv2.CiliumNode{},
-		onDeleteEvent: func(err error) {
-			if err != nil {
-				t.Errorf("deleting failed: %v", err)
-			}
-			events <- "delete"
-		},
-		onUpsertEvent: func(err error) {
-			if err != nil {
-				t.Errorf("upserting failed: %v", err)
-			}
-			events <- "upsert"
-		},
-	}
+	var (
+		tick    = 10 * time.Millisecond
+		timeout = 2 * refreshPoolInterval
+	)
+
+	nodeTypes.SetName("test-node")
 
 	defaultIPv4CIDR1 := netip.MustParsePrefix("10.0.22.0/24")
 	defaultIPv6CIDR1 := netip.MustParsePrefix("fd00:22::/96")
@@ -106,371 +86,428 @@ func Test_MultiPoolManager(t *testing.T) {
 		},
 	}
 
-	// provide initial CiliumNode CRD - we expect newMultiPoolManager to stop
-	// waiting for initial local node sync and return
-	go fakeK8sCiliumNodeAPI.updateNode(currentNode)
+	synctest.Test(t, func(t *testing.T) {
+		var (
+			jg        job.Group
+			localNode k8s.LocalCiliumNodeResource
+			clientset *k8sClient.FakeClientset
+		)
+		h := hive.New(
+			k8s.ResourcesCell,
+			k8sClient.FakeClientCell(),
+			cell.Provide(func() *node.LocalNodeStore { return node.NewTestLocalNodeStore(node.LocalNode{}) }),
+			cell.Invoke(
+				func(
+					jg_ job.Group,
+					localNode_ k8s.LocalCiliumNodeResource,
+					localNodeStore_ *node.LocalNodeStore,
+					clientset_ *k8sClient.FakeClientset,
+				) {
+					jg = jg_
+					localNode = localNode_
+					clientset = clientset_
+				},
+			),
+		)
 
-	var jg job.Group
-	h := hive.New(
-		cell.Invoke(func(jg_ job.Group) { jg = jg_ }),
-	)
+		tlog := hivetest.Logger(t, hivetest.LogLevel(slog.LevelError))
+		assert.NoError(t, h.Start(tlog, t.Context()))
+		t.Cleanup(func() { h.Stop(tlog, context.Background()) })
 
-	tlog := hivetest.Logger(t, hivetest.LogLevel(slog.LevelError))
-	assert.NoError(t, h.Start(tlog, t.Context()))
-	t.Cleanup(func() { h.Stop(tlog, context.Background()) })
+		// create local node
+		_, err := clientset.CiliumV2().CiliumNodes().Create(t.Context(), currentNode, metav1.CreateOptions{})
+		assert.NoError(t, err)
 
-	preallocMap, err := ParseMultiPoolPreAllocMap(fakeConfig.IPAMMultiPoolPreAllocation)
-	assert.NoError(t, err)
+		preallocMap, err := ParseMultiPoolPreAllocMap(map[string]string{
+			"default": "16",
+			"mars":    "8",
+		})
+		assert.NoError(t, err)
 
-	c := newMultiPoolManager(MultiPoolManagerParams{
-		Logger:               hivetest.Logger(t),
-		IPv4Enabled:          fakeConfig.EnableIPv4,
-		IPv6Enabled:          fakeConfig.EnableIPv6,
-		CiliumNodeUpdateRate: fakeConfig.IPAMCiliumNodeUpdateRate,
-		PreallocMap:          preallocMap,
-		Node:                 fakeK8sCiliumNodeAPI,
-		CNClient:             fakeK8sCiliumNodeAPI,
-		JobGroup:             jg,
-		PoolsFromResource: func(cn *ciliumv2.CiliumNode) *types.IPAMPoolSpec {
-			return &cn.Spec.IPAM.Pools
-		},
+		mgr := newMultiPoolManager(MultiPoolManagerParams{
+			Logger:               hivetest.Logger(t),
+			IPv4Enabled:          true,
+			IPv6Enabled:          true,
+			CiliumNodeUpdateRate: time.Nanosecond,
+			PreallocMap:          preallocMap,
+			Node:                 localNode,
+			CNClient:             clientset.CiliumV2().CiliumNodes(),
+			JobGroup:             jg,
+			PoolsFromResource: func(cn *ciliumv2.CiliumNode) *types.IPAMPoolSpec {
+				return &cn.Spec.IPAM.Pools
+			},
+		})
+
+		// Wait for agent pre-allocation request, then validate it
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			currentNode, err := clientset.CiliumV2().CiliumNodes().Get(t.Context(), nodeTypes.GetName(), metav1.GetOptions{})
+			assert.NoError(c, err)
+
+			assert.ElementsMatch(c,
+				[]types.IPAMPoolRequest{
+					{Pool: "default", Needed: types.IPAMPoolDemand{IPv4Addrs: 16, IPv6Addrs: 16}},
+					{Pool: "mars", Needed: types.IPAMPoolDemand{IPv4Addrs: 8, IPv6Addrs: 8}},
+				},
+				currentNode.Spec.IPAM.Pools.Requested,
+			)
+			assert.ElementsMatch(c,
+				[]types.IPAMPoolAllocation{
+					{
+						Pool: "default",
+						CIDRs: []iputil.Prefix{
+							iputil.PrefixFrom(defaultIPv4CIDR1),
+							iputil.PrefixFrom(defaultIPv6CIDR1),
+						},
+					},
+					{
+						Pool: "mars",
+						CIDRs: []iputil.Prefix{
+							iputil.PrefixFrom(marsIPv4CIDR1),
+							iputil.PrefixFrom(marsIPv6CIDR1),
+						},
+					},
+				},
+				currentNode.Spec.IPAM.Pools.Allocated,
+			)
+		}, timeout, tick)
+
+		unusedIPv4CIDR1 := netip.MustParsePrefix("10.0.33.0/24")
+		unusedIPv6CIDR1 := netip.MustParsePrefix("fd00:33::/96")
+
+		// Assign further CIDRs to pools (i.e. this simulates the operator logic)
+		currentNode, err = clientset.CiliumV2().CiliumNodes().Get(t.Context(), nodeTypes.GetName(), metav1.GetOptions{})
+		assert.NoError(t, err)
+
+		updNode := currentNode.DeepCopy()
+		allocatedPools := []types.IPAMPoolAllocation{
+			{
+				Pool: "default",
+				CIDRs: []iputil.Prefix{
+					iputil.PrefixFrom(defaultIPv4CIDR1),
+					iputil.PrefixFrom(defaultIPv6CIDR1),
+				},
+			},
+			{
+				Pool: "mars",
+				CIDRs: []iputil.Prefix{
+					iputil.PrefixFrom(marsIPv4CIDR1),
+					iputil.PrefixFrom(marsIPv6CIDR1),
+				},
+			},
+			{
+				Pool: "unused",
+				CIDRs: []iputil.Prefix{
+					iputil.PrefixFrom(unusedIPv4CIDR1),
+					iputil.PrefixFrom(unusedIPv6CIDR1),
+				},
+			},
+		}
+		updNode.Spec.IPAM.Pools.Allocated = allocatedPools
+
+		_, err = clientset.CiliumV2().CiliumNodes().Update(t.Context(), updNode, metav1.UpdateOptions{})
+		assert.NoError(t, err)
+
+		mgr.waitForAllPools()
+
+		// test allocation in default pool
+		defaultAllocation, err := mgr.allocateIP(netip.MustParseAddr("10.0.22.1"), "default-pod-1", "default", IPv4, false)
+		assert.NoError(t, err)
+		assert.Equal(t, netip.MustParseAddr("10.0.22.1"), defaultAllocation.IP)
+
+		// cannot allocate the same IP twice
+		faultyAllocation, err := mgr.allocateIP(netip.MustParseAddr("10.0.22.1"), "default-pod-1", "default", IPv4, false)
+		assert.ErrorIs(t, err, ipallocator.ErrAllocated)
+		assert.Nil(t, faultyAllocation)
+
+		// Allocation from an unknown pool should create a new pending allocation
+		jupiterIPv4CIDR := netip.MustParsePrefix("192.168.1.0/16")
+		juptierIPv6CIDR := netip.MustParsePrefix("fc00:33::/96")
+
+		faultyAllocation, err = mgr.allocateIP(netip.MustParseAddr("192.168.1.1"), "jupiter-pod-0", "jupiter", IPv4, false)
+		assert.ErrorIs(t, err, &ErrPoolNotReadyYet{})
+		assert.Nil(t, faultyAllocation)
+		faultyAllocation, err = mgr.allocateNext("jupiter-pod-1", "jupiter", IPv6, false)
+		assert.ErrorIs(t, err, &ErrPoolNotReadyYet{})
+		assert.Nil(t, faultyAllocation)
+
+		// Try again. This should still fail, but not request an additional third IP
+		// (since the owner has already attempted to allocate). This however sets
+		// upstreamSync to 'true', which should populate .Spec.IPAM.Pools.Requested
+		// with pending requests for the "jupiter" pool
+		faultyAllocation, err = mgr.allocateNext("jupiter-pod-1", "jupiter", IPv6, true)
+		assert.ErrorIs(t, err, &ErrPoolNotReadyYet{})
+		assert.Nil(t, faultyAllocation)
+
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			currentNode, err = clientset.CiliumV2().CiliumNodes().Get(t.Context(), nodeTypes.GetName(), metav1.GetOptions{})
+			assert.NoError(c, err)
+
+			// Check that the agent has not (yet) removed the unused pool.
+			assert.Equal(c, allocatedPools, currentNode.Spec.IPAM.Pools.Allocated)
+			// Check if the agent now requests one IPv4 and one IPv6 IP for the jupiter pool
+			assert.Equal(c, []types.IPAMPoolRequest{
+				{
+					Pool: "default",
+					Needed: types.IPAMPoolDemand{
+						IPv4Addrs: 32, // 1 allocated + 16 pre-allocate, rounded up to multiple of 16
+						IPv6Addrs: 16, // 0 allocated + 16 pre-allocate
+					},
+				},
+				{
+					Pool: "jupiter",
+					Needed: types.IPAMPoolDemand{
+						IPv4Addrs: 1, // 1 pending, no pre-allocate
+						IPv6Addrs: 1, // 1 pending, no pre-allocate
+					},
+				},
+				{
+					Pool: "mars",
+					Needed: types.IPAMPoolDemand{
+						IPv4Addrs: 8, // 0 allocated + 8 pre-allocate
+						IPv6Addrs: 8, // 0 allocated + 8 pre-allocate
+					},
+				},
+			}, currentNode.Spec.IPAM.Pools.Requested)
+		}, timeout, tick)
+
+		mgr.restoreFinished(IPv4)
+		mgr.restoreFinished(IPv6)
+
+		// Assign the jupiter pool
+		currentNode, err = clientset.CiliumV2().CiliumNodes().Get(t.Context(), nodeTypes.GetName(), metav1.GetOptions{})
+		assert.NoError(t, err)
+
+		updNode = currentNode.DeepCopy()
+		updNode.Spec.IPAM.Pools.Allocated = []types.IPAMPoolAllocation{
+			{
+				Pool: "default",
+				CIDRs: []iputil.Prefix{
+					iputil.PrefixFrom(defaultIPv6CIDR1),
+					iputil.PrefixFrom(defaultIPv4CIDR1),
+				},
+			},
+			{
+				Pool: "jupiter",
+				CIDRs: []iputil.Prefix{
+					iputil.PrefixFrom(jupiterIPv4CIDR),
+					iputil.PrefixFrom(juptierIPv6CIDR),
+				},
+			},
+			{
+				Pool: "mars",
+				CIDRs: []iputil.Prefix{
+					iputil.PrefixFrom(marsIPv6CIDR1),
+					iputil.PrefixFrom(marsIPv4CIDR1),
+				},
+			},
+			{
+				Pool: "unused",
+				CIDRs: []iputil.Prefix{
+					iputil.PrefixFrom(unusedIPv4CIDR1),
+					iputil.PrefixFrom(unusedIPv6CIDR1),
+				},
+			},
+		}
+		_, err = clientset.CiliumV2().CiliumNodes().Update(t.Context(), updNode, metav1.UpdateOptions{})
+		assert.NoError(t, err)
+
+		assert.True(t, mgr.waitForPool(t.Context(), IPv4, "jupiter"))
+		assert.True(t, mgr.waitForPool(t.Context(), IPv6, "jupiter"))
+
+		// Allocations should now succeed
+		jupiterIP0 := netip.MustParseAddr("192.168.1.1")
+		allocatedJupiterIP0, err := mgr.allocateIP(jupiterIP0, "jupiter-pod-0", "jupiter", IPv4, false)
+		require.NoError(t, err)
+		require.NotNil(t, allocatedJupiterIP0)
+		assert.Equal(t, jupiterIP0, allocatedJupiterIP0.IP)
+
+		allocatedJupiterIP1, err := mgr.allocateNext("jupiter-pod-1", "jupiter", IPv6, false)
+		require.NoError(t, err)
+		require.NotNil(t, allocatedJupiterIP1)
+		assert.True(t, juptierIPv6CIDR.Contains(allocatedJupiterIP1.IP))
+
+		// Release IPs from jupiter pool. This should fully remove it from both
+		// "requested" and "allocated"
+		err = mgr.releaseIP(allocatedJupiterIP0.IP, "jupiter", IPv4, false)
+		assert.NoError(t, err)
+		err = mgr.releaseIP(allocatedJupiterIP1.IP, "jupiter", IPv6, true) // triggers sync
+		assert.NoError(t, err)
+
+		// Wait for agent to release jupiter and unused CIDRs
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			currentNode, err = clientset.CiliumV2().CiliumNodes().Get(t.Context(), nodeTypes.GetName(), metav1.GetOptions{})
+			assert.NoError(c, err)
+			assert.Equal(c, types.IPAMPoolSpec{
+				Requested: []types.IPAMPoolRequest{
+					{
+						Pool: "default",
+						Needed: types.IPAMPoolDemand{
+							IPv4Addrs: 32, // 1 allocated + 16 pre-allocate, rounded up to multiple of 16
+							IPv6Addrs: 16, // 0 allocated + 16 pre-allocate
+						},
+					},
+					{
+						Pool: "mars",
+						Needed: types.IPAMPoolDemand{
+							IPv4Addrs: 8, // 0 allocated + 8 pre-allocate
+							IPv6Addrs: 8, // 0 allocated + 8 pre-allocate
+						},
+					},
+				},
+				Allocated: []types.IPAMPoolAllocation{
+					{
+						Pool: "default",
+						CIDRs: []iputil.Prefix{
+							iputil.PrefixFrom(defaultIPv4CIDR1),
+							iputil.PrefixFrom(defaultIPv6CIDR1),
+						},
+					},
+					{
+						Pool: "mars",
+						CIDRs: []iputil.Prefix{
+							iputil.PrefixFrom(marsIPv4CIDR1),
+							iputil.PrefixFrom(marsIPv6CIDR1),
+						},
+					},
+				},
+			}, currentNode.Spec.IPAM.Pools)
+		}, timeout, tick)
+
+		// exhaust mars ipv4 pool (/27 contains 30 IPs)
+		allocatedMarsIPs := []netip.Addr{}
+		numMarsIPs := 30
+		for i := range numMarsIPs {
+			// set upstreamSync to true for last allocation, to ensure we only get one upsert event
+			ar, err := mgr.allocateNext(fmt.Sprintf("mars-pod-%d", i), "mars", IPv4, i == numMarsIPs-1)
+			assert.NoError(t, err)
+			require.NotNil(t, ar)
+			assert.True(t, marsIPv4CIDR1.Contains(ar.IP))
+			allocatedMarsIPs = append(allocatedMarsIPs, ar.IP)
+		}
+		_, err = mgr.allocateNext("mars-pod-overflow", "mars", IPv4, false)
+		assert.ErrorContains(t, err, "all CIDR ranges are exhausted")
+
+		ipv4Dump, _ := mgr.dump(IPv4)
+		assert.Len(t, ipv4Dump, 2) // 2 pools: default + mars
+		assert.Len(t, ipv4Dump[PoolDefault()], 1)
+		assert.Len(t, ipv4Dump[Pool("mars")], numMarsIPs)
+
+		// Ensure Requested numbers are bumped
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			currentNode, err = clientset.CiliumV2().CiliumNodes().Get(t.Context(), nodeTypes.GetName(), metav1.GetOptions{})
+			assert.NoError(c, err)
+			assert.Equal(c, []types.IPAMPoolRequest{
+				{
+					Pool: "default",
+					Needed: types.IPAMPoolDemand{
+						IPv4Addrs: 32, // 1 allocated + 16 pre-allocate, rounded up to multiple of 16
+						IPv6Addrs: 16,
+					},
+				},
+				{
+					Pool: "mars",
+					Needed: types.IPAMPoolDemand{
+						IPv4Addrs: 40, // 30 allocated + 8 pre-allocate, rounded up to multiple of 8
+						IPv6Addrs: 8,
+					},
+				},
+			}, currentNode.Spec.IPAM.Pools.Requested)
+		}, timeout, tick)
+
+		marsIPv4CIDR2 := netip.MustParsePrefix("10.0.12.0/27")
+
+		// Assign additional mars IPv4 CIDR
+		currentNode, err = clientset.CiliumV2().CiliumNodes().Get(t.Context(), nodeTypes.GetName(), metav1.GetOptions{})
+		assert.NoError(t, err)
+
+		updNode = currentNode.DeepCopy()
+		updNode.Spec.IPAM.Pools.Allocated = []types.IPAMPoolAllocation{
+			{
+				Pool: "default",
+				CIDRs: []iputil.Prefix{
+					iputil.PrefixFrom(defaultIPv4CIDR1),
+					iputil.PrefixFrom(defaultIPv6CIDR1),
+				},
+			},
+			{
+				Pool: "mars",
+				CIDRs: []iputil.Prefix{
+					iputil.PrefixFrom(marsIPv4CIDR1),
+					iputil.PrefixFrom(marsIPv4CIDR2),
+					iputil.PrefixFrom(marsIPv6CIDR1),
+				},
+			},
+		}
+		_, err = clientset.CiliumV2().CiliumNodes().Update(t.Context(), updNode, metav1.UpdateOptions{})
+		assert.NoError(t, err)
+
+		var marsAllocation *AllocationResult
+
+		// Should eventually be able to allocate from mars pool again
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			marsAllocation, err = mgr.allocateNext("mars-pod-overflow", "mars", IPv4, false)
+			require.NoError(c, err)
+			require.NotNil(c, marsAllocation)
+			assert.True(c, marsIPv4CIDR2.Contains(marsAllocation.IP))
+		}, timeout, tick)
+
+		// Deallocate all other IPs from mars pool. This should release the old CIDR
+		for i, addr := range allocatedMarsIPs {
+			err = mgr.releaseIP(addr, "mars", IPv4, i == numMarsIPs-1)
+			assert.NoError(t, err)
+		}
+
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			currentNode, err = clientset.CiliumV2().CiliumNodes().Get(t.Context(), nodeTypes.GetName(), metav1.GetOptions{})
+			assert.NoError(c, err)
+
+			assert.Equal(c, []types.IPAMPoolRequest{
+				{
+					Pool: "default",
+					Needed: types.IPAMPoolDemand{
+						IPv4Addrs: 32, // 1 allocated + 16 pre-allocate, rounded up to multiple of 16
+						IPv6Addrs: 16,
+					},
+				},
+				{
+					Pool: "mars",
+					Needed: types.IPAMPoolDemand{
+						IPv4Addrs: 16, // 1 allocated + 8 pre-allocate, rounded up to multiple of 8
+						IPv6Addrs: 8,
+					},
+				},
+			}, currentNode.Spec.IPAM.Pools.Requested)
+
+			// Initial mars CIDR should have been marked as released now
+			assert.Equal(c, []types.IPAMPoolAllocation{
+				{
+					Pool: "default",
+					CIDRs: []iputil.Prefix{
+						iputil.PrefixFrom(defaultIPv4CIDR1),
+						iputil.PrefixFrom(defaultIPv6CIDR1),
+					},
+				},
+				{
+					Pool: "mars",
+					CIDRs: []iputil.Prefix{
+						iputil.PrefixFrom(marsIPv4CIDR2),
+						iputil.PrefixFrom(marsIPv6CIDR1),
+					},
+				},
+			}, currentNode.Spec.IPAM.Pools.Allocated)
+		}, timeout, tick)
+
+		ipv4Dump, ipv4Summary := mgr.dump(IPv4)
+		assert.Equal(t, map[Pool]map[string]string{
+			PoolDefault(): {
+				defaultAllocation.IP.String(): "",
+			},
+			Pool("mars"): {
+				marsAllocation.IP.String(): "",
+			},
+		}, ipv4Dump)
+		assert.Equal(t, "2 IPAM pool(s) available", ipv4Summary)
 	})
-
-	// assert initial CiliumNode upsert has been sent to the events chan
-	assert.Equal(t, "upsert", <-events)
-
-	// Wait for agent pre-allocation request, then validate it
-	assert.Equal(t, "upsert", <-events)
-	currentNode = fakeK8sCiliumNodeAPI.currentNode()
-	assert.ElementsMatch(t,
-		[]types.IPAMPoolRequest{
-			{Pool: "default", Needed: types.IPAMPoolDemand{IPv4Addrs: 16, IPv6Addrs: 16}},
-			{Pool: "mars", Needed: types.IPAMPoolDemand{IPv4Addrs: 8, IPv6Addrs: 8}},
-		},
-		currentNode.Spec.IPAM.Pools.Requested,
-	)
-	assert.ElementsMatch(t,
-		[]types.IPAMPoolAllocation{
-			{
-				Pool: "default",
-				CIDRs: []iputil.Prefix{
-					iputil.PrefixFrom(defaultIPv4CIDR1),
-					iputil.PrefixFrom(defaultIPv6CIDR1),
-				},
-			},
-			{
-				Pool: "mars",
-				CIDRs: []iputil.Prefix{
-					iputil.PrefixFrom(marsIPv4CIDR1),
-					iputil.PrefixFrom(marsIPv6CIDR1),
-				},
-			},
-		},
-		currentNode.Spec.IPAM.Pools.Allocated,
-	)
-
-	unusedIPv4CIDR1 := netip.MustParsePrefix("10.0.33.0/24")
-	unusedIPv6CIDR1 := netip.MustParsePrefix("fd00:33::/96")
-
-	// Assign further CIDRs to pools (i.e. this simulates the operator logic)
-	allocatedPools := []types.IPAMPoolAllocation{
-		{
-			Pool: "default",
-			CIDRs: []iputil.Prefix{
-				iputil.PrefixFrom(defaultIPv4CIDR1),
-				iputil.PrefixFrom(defaultIPv6CIDR1),
-			},
-		},
-		{
-			Pool: "mars",
-			CIDRs: []iputil.Prefix{
-				iputil.PrefixFrom(marsIPv4CIDR1),
-				iputil.PrefixFrom(marsIPv6CIDR1),
-			},
-		},
-		{
-			Pool: "unused",
-			CIDRs: []iputil.Prefix{
-				iputil.PrefixFrom(unusedIPv4CIDR1),
-				iputil.PrefixFrom(unusedIPv6CIDR1),
-			},
-		},
-	}
-	currentNode.Spec.IPAM.Pools.Allocated = allocatedPools
-
-	fakeK8sCiliumNodeAPI.updateNode(currentNode)
-	assert.Equal(t, "upsert", <-events)
-	c.waitForAllPools()
-
-	// test allocation in default pool
-	defaultAllocation, err := c.allocateIP(netip.MustParseAddr("10.0.22.1"), "default-pod-1", "default", IPv4, false)
-	assert.NoError(t, err)
-	assert.Equal(t, netip.MustParseAddr("10.0.22.1"), defaultAllocation.IP)
-
-	// cannot allocate the same IP twice
-	faultyAllocation, err := c.allocateIP(netip.MustParseAddr("10.0.22.1"), "default-pod-1", "default", IPv4, false)
-	assert.ErrorIs(t, err, ipallocator.ErrAllocated)
-	assert.Nil(t, faultyAllocation)
-
-	// Allocation from an unknown pool should create a new pending allocation
-	jupiterIPv4CIDR := netip.MustParsePrefix("192.168.1.0/16")
-	juptierIPv6CIDR := netip.MustParsePrefix("fc00:33::/96")
-
-	faultyAllocation, err = c.allocateIP(netip.MustParseAddr("192.168.1.1"), "jupiter-pod-0", "jupiter", IPv4, false)
-	assert.ErrorIs(t, err, &ErrPoolNotReadyYet{})
-	assert.Nil(t, faultyAllocation)
-	faultyAllocation, err = c.allocateNext("jupiter-pod-1", "jupiter", IPv6, false)
-	assert.ErrorIs(t, err, &ErrPoolNotReadyYet{})
-	assert.Nil(t, faultyAllocation)
-	// Try again. This should still fail, but not request an additional third IP
-	// (since the owner has already attempted to allocate). This however sets
-	// upstreamSync to 'true', which should populate .Spec.IPAM.Pools.Requested
-	// with pending requests for the "jupiter" pool
-	faultyAllocation, err = c.allocateNext("jupiter-pod-1", "jupiter", IPv6, true)
-	assert.ErrorIs(t, err, &ErrPoolNotReadyYet{})
-	assert.Nil(t, faultyAllocation)
-
-	assert.Equal(t, "upsert", <-events)
-	currentNode = fakeK8sCiliumNodeAPI.currentNode()
-	// Check that the agent has not (yet) removed the unused pool.
-	assert.Equal(t, allocatedPools, currentNode.Spec.IPAM.Pools.Allocated)
-	// Check if the agent now requests one IPv4 and one IPv6 IP for the jupiter pool
-	assert.Equal(t, []types.IPAMPoolRequest{
-		{
-			Pool: "default",
-			Needed: types.IPAMPoolDemand{
-				IPv4Addrs: 32, // 1 allocated + 16 pre-allocate, rounded up to multiple of 16
-				IPv6Addrs: 16, // 0 allocated + 16 pre-allocate
-			},
-		},
-		{
-			Pool: "jupiter",
-			Needed: types.IPAMPoolDemand{
-				IPv4Addrs: 1, // 1 pending, no pre-allocate
-				IPv6Addrs: 1, // 1 pending, no pre-allocate
-			},
-		},
-		{
-			Pool: "mars",
-			Needed: types.IPAMPoolDemand{
-				IPv4Addrs: 8, // 0 allocated + 8 pre-allocate
-				IPv6Addrs: 8, // 0 allocated + 8 pre-allocate
-			},
-		},
-	}, currentNode.Spec.IPAM.Pools.Requested)
-
-	c.restoreFinished(IPv4)
-	c.restoreFinished(IPv6)
-
-	// Assign the jupiter pool
-	currentNode.Spec.IPAM.Pools.Allocated = []types.IPAMPoolAllocation{
-		{
-			Pool: "default",
-			CIDRs: []iputil.Prefix{
-				iputil.PrefixFrom(defaultIPv6CIDR1),
-				iputil.PrefixFrom(defaultIPv4CIDR1),
-			},
-		},
-		{
-			Pool: "jupiter",
-			CIDRs: []iputil.Prefix{
-				iputil.PrefixFrom(jupiterIPv4CIDR),
-				iputil.PrefixFrom(juptierIPv6CIDR),
-			},
-		},
-		{
-			Pool: "mars",
-			CIDRs: []iputil.Prefix{
-				iputil.PrefixFrom(marsIPv6CIDR1),
-				iputil.PrefixFrom(marsIPv4CIDR1),
-			},
-		},
-		{
-			Pool: "unused",
-			CIDRs: []iputil.Prefix{
-				iputil.PrefixFrom(unusedIPv4CIDR1),
-				iputil.PrefixFrom(unusedIPv6CIDR1),
-			},
-		},
-	}
-	fakeK8sCiliumNodeAPI.updateNode(currentNode)
-	assert.Equal(t, "upsert", <-events)
-
-	c.waitForPool(t.Context(), IPv4, "jupiter")
-	c.waitForPool(t.Context(), IPv6, "jupiter")
-
-	// Allocations should now succeed
-	jupiterIP0 := netip.MustParseAddr("192.168.1.1")
-	allocatedJupiterIP0, err := c.allocateIP(jupiterIP0, "jupiter-pod-0", "jupiter", IPv4, false)
-	assert.NoError(t, err)
-	assert.Equal(t, jupiterIP0, allocatedJupiterIP0.IP)
-	allocatedJupiterIP1, err := c.allocateNext("jupiter-pod-1", "jupiter", IPv6, false)
-	assert.NoError(t, err)
-	assert.True(t, juptierIPv6CIDR.Contains(allocatedJupiterIP1.IP))
-
-	// Release IPs from jupiter pool. This should fully remove it from both
-	// "requested" and "allocated"
-	err = c.releaseIP(allocatedJupiterIP0.IP, "jupiter", IPv4, false)
-	assert.NoError(t, err)
-	err = c.releaseIP(allocatedJupiterIP1.IP, "jupiter", IPv6, true) // triggers sync
-	assert.NoError(t, err)
-
-	// Wait for agent to release jupiter and unused CIDRs
-	assert.Equal(t, "upsert", <-events)
-	currentNode = fakeK8sCiliumNodeAPI.currentNode()
-	assert.Equal(t, types.IPAMPoolSpec{
-		Requested: []types.IPAMPoolRequest{
-			{
-				Pool: "default",
-				Needed: types.IPAMPoolDemand{
-					IPv4Addrs: 32, // 1 allocated + 16 pre-allocate, rounded up to multiple of 16
-					IPv6Addrs: 16, // 0 allocated + 16 pre-allocate
-				},
-			},
-			{
-				Pool: "mars",
-				Needed: types.IPAMPoolDemand{
-					IPv4Addrs: 8, // 0 allocated + 8 pre-allocate
-					IPv6Addrs: 8, // 0 allocated + 8 pre-allocate
-				},
-			},
-		},
-		Allocated: []types.IPAMPoolAllocation{
-			{
-				Pool: "default",
-				CIDRs: []iputil.Prefix{
-					iputil.PrefixFrom(defaultIPv4CIDR1),
-					iputil.PrefixFrom(defaultIPv6CIDR1),
-				},
-			},
-			{
-				Pool: "mars",
-				CIDRs: []iputil.Prefix{
-					iputil.PrefixFrom(marsIPv4CIDR1),
-					iputil.PrefixFrom(marsIPv6CIDR1),
-				},
-			},
-		},
-	}, currentNode.Spec.IPAM.Pools)
-
-	// exhaust mars ipv4 pool (/27 contains 30 IPs)
-	allocatedMarsIPs := []netip.Addr{}
-	numMarsIPs := 30
-	for i := range numMarsIPs {
-		// set upstreamSync to true for last allocation, to ensure we only get one upsert event
-		ar, err := c.allocateNext(fmt.Sprintf("mars-pod-%d", i), "mars", IPv4, i == numMarsIPs-1)
-		assert.NoError(t, err)
-		assert.True(t, marsIPv4CIDR1.Contains(ar.IP))
-		allocatedMarsIPs = append(allocatedMarsIPs, ar.IP)
-	}
-	_, err = c.allocateNext("mars-pod-overflow", "mars", IPv4, false)
-	assert.ErrorContains(t, err, "all CIDR ranges are exhausted")
-
-	ipv4Dump, _ := c.dump(IPv4)
-	assert.Len(t, ipv4Dump, 2) // 2 pools: default + mars
-	assert.Len(t, ipv4Dump[PoolDefault()], 1)
-	assert.Len(t, ipv4Dump[Pool("mars")], numMarsIPs)
-
-	// Ensure Requested numbers are bumped
-	assert.Equal(t, "upsert", <-events)
-	currentNode = fakeK8sCiliumNodeAPI.currentNode()
-	assert.Equal(t, []types.IPAMPoolRequest{
-		{
-			Pool: "default",
-			Needed: types.IPAMPoolDemand{
-				IPv4Addrs: 32, // 1 allocated + 16 pre-allocate, rounded up to multiple of 16
-				IPv6Addrs: 16,
-			},
-		},
-		{
-			Pool: "mars",
-			Needed: types.IPAMPoolDemand{
-				IPv4Addrs: 40, // 30 allocated + 8 pre-allocate, rounded up to multiple of 8
-				IPv6Addrs: 8,
-			},
-		},
-	}, currentNode.Spec.IPAM.Pools.Requested)
-
-	marsIPv4CIDR2 := netip.MustParsePrefix("10.0.12.0/27")
-
-	// Assign additional mars IPv4 CIDR
-	currentNode.Spec.IPAM.Pools.Allocated = []types.IPAMPoolAllocation{
-		{
-			Pool: "default",
-			CIDRs: []iputil.Prefix{
-				iputil.PrefixFrom(defaultIPv4CIDR1),
-				iputil.PrefixFrom(defaultIPv6CIDR1),
-			},
-		},
-		{
-			Pool: "mars",
-			CIDRs: []iputil.Prefix{
-				iputil.PrefixFrom(marsIPv4CIDR1),
-				iputil.PrefixFrom(marsIPv4CIDR2),
-				iputil.PrefixFrom(marsIPv6CIDR1),
-			},
-		},
-	}
-	fakeK8sCiliumNodeAPI.updateNode(currentNode)
-	assert.Equal(t, "upsert", <-events)
-
-	// Should now be able to allocate from mars pool again
-	marsAllocation, err := c.allocateNext("mars-pod-overflow", "mars", IPv4, false)
-	assert.NoError(t, err)
-	assert.True(t, marsIPv4CIDR2.Contains(marsAllocation.IP))
-
-	// Deallocate all other IPs from mars pool. This should release the old CIDR
-	for i, addr := range allocatedMarsIPs {
-		err = c.releaseIP(addr, "mars", IPv4, i == numMarsIPs-1)
-		assert.NoError(t, err)
-	}
-	assert.Equal(t, "upsert", <-events)
-	currentNode = fakeK8sCiliumNodeAPI.currentNode()
-	assert.Equal(t, []types.IPAMPoolRequest{
-		{
-			Pool: "default",
-			Needed: types.IPAMPoolDemand{
-				IPv4Addrs: 32, // 1 allocated + 16 pre-allocate, rounded up to multiple of 16
-				IPv6Addrs: 16,
-			},
-		},
-		{
-			Pool: "mars",
-			Needed: types.IPAMPoolDemand{
-				IPv4Addrs: 16, // 1 allocated + 8 pre-allocate, rounded up to multiple of 8
-				IPv6Addrs: 8,
-			},
-		},
-	}, currentNode.Spec.IPAM.Pools.Requested)
-
-	// Initial mars CIDR should have been marked as released now
-	assert.Equal(t, []types.IPAMPoolAllocation{
-		{
-			Pool: "default",
-			CIDRs: []iputil.Prefix{
-				iputil.PrefixFrom(defaultIPv4CIDR1),
-				iputil.PrefixFrom(defaultIPv6CIDR1),
-			},
-		},
-		{
-			Pool: "mars",
-			CIDRs: []iputil.Prefix{
-				iputil.PrefixFrom(marsIPv4CIDR2),
-				iputil.PrefixFrom(marsIPv6CIDR1),
-			},
-		},
-	}, currentNode.Spec.IPAM.Pools.Allocated)
-
-	ipv4Dump, ipv4Summary := c.dump(IPv4)
-	assert.Equal(t, map[Pool]map[string]string{
-		PoolDefault(): {
-			defaultAllocation.IP.String(): "",
-		},
-		Pool("mars"): {
-			marsAllocation.IP.String(): "",
-		},
-	}, ipv4Dump)
-	assert.Equal(t, "2 IPAM pool(s) available", ipv4Summary)
 }
 
 // Test_MultiPoolManager_ReleaseUnusedCIDR verifies that we release all unused CIDRs.


### PR DESCRIPTION
Add support for a migration procedure from cluster-pool IPAM mode to multi-pool IPAM mode. The migrations aims at preserving all the allocated IP addresses without any connectivity disruption and allows to be completed incrementally, one node at a time.

The main limitation is that all the IP allocated in the previous cluster-pool run should be part of the default CiliumPodIPPool after the migration to multi-pool.

This PR was created with the aid of Codex for tests and documentation at AIL 3. I've reviewed the entire diff.

```release-note
Add support to migrate a cluster from cluster-pool IPAM mode to multi-pool IPAM mode.
```

~Depends on https://github.com/cilium/cilium/pull/46035~