### PR TITLE
cilium-cli: don't enable nodeinit on AKS

### DIFF
--- a/cilium-cli/install/node_init.go
+++ b/cilium-cli/install/node_init.go
@@ -8,5 +8,5 @@ import (
 )
 
 func needsNodeInit(k k8s.Kind) bool {
-	return k == k8s.KindAKS || k == k8s.KindGKE
+	return k == k8s.KindGKE
 }


### PR DESCRIPTION
The node-init DaemonSet has been enabled unconditionally on AKS since d828f9517d ("install: enable node-init script on AKS", March 2022), when AKS still defaulted to --network-plugin=azure or kubenet.
On AKS today, both supported datapath modes (DatapathAKSBYOCNI and DatapathAzure) leave every node-init action knob at its default, so the rendered script collapses to a few `ip` debug prints plus a `date > /tmp/cilium-bootstrap.d/cilium-bootstrap-time`. That timestamp file is never read by cilium-agent; the only consumer is the `wait-for-node-init` init container, which itself only exists when nodeinit.enabled=true.
Drop AKS from needsNodeInit so neither the DaemonSet nor the wait-for-node-init init container are installed on AKS.


Sample node init log(`logs-cilium-node-init-6nmfv-node-init-20260521-054804-prev.log`):
```
2026-05-21T05:27:47.158700487Z Link information:
2026-05-21T05:27:47.160329899Z 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
2026-05-21T05:27:47.160343099Z     link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2026-05-21T05:27:47.160346599Z 2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
2026-05-21T05:27:47.160349599Z     link/ether 00:0d:3a:5b:ad:0d brd ff:ff:ff:ff:ff:ff
2026-05-21T05:27:47.160585901Z Routing table:
2026-05-21T05:27:47.162296413Z default via 10.224.0.1 dev eth0 proto dhcp src 10.224.0.5 metric 100 
2026-05-21T05:27:47.162365514Z 10.224.0.0/16 dev eth0 proto kernel scope link src 10.224.0.5 metric 100 
2026-05-21T05:27:47.162451614Z 10.224.0.1 dev eth0 proto dhcp scope link src 10.224.0.5 metric 100 
2026-05-21T05:27:47.162527515Z 168.63.129.16 via 10.224.0.1 dev eth0 proto dhcp src 10.224.0.5 metric 100 
2026-05-21T05:27:47.162581015Z 169.254.169.254 via 10.224.0.1 dev eth0 proto dhcp src 10.224.0.5 metric 100 
2026-05-21T05:27:47.162879217Z Addressing:
2026-05-21T05:27:47.164102926Z 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
2026-05-21T05:27:47.164110526Z     inet 127.0.0.1/8 scope host lo
2026-05-21T05:27:47.164113426Z        valid_lft forever preferred_lft forever
2026-05-21T05:27:47.164116226Z 2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
2026-05-21T05:27:47.164118926Z     inet 10.224.0.5/16 metric 100 brd 10.224.255.255 scope global eth0
2026-05-21T05:27:47.164121826Z        valid_lft forever preferred_lft forever
2026-05-21T05:27:47.165644137Z 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 state UNKNOWN qlen 1000
2026-05-21T05:27:47.165654437Z     inet6 ::1/128 scope host 
2026-05-21T05:27:47.165657437Z        valid_lft forever preferred_lft forever
2026-05-21T05:27:47.165660037Z 2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 state UP qlen 1000
2026-05-21T05:27:47.165663437Z     inet6 fd37:a451:1906:2304::5/128 scope global dynamic noprefixroute 
2026-05-21T05:27:47.165665937Z        valid_lft 17279768sec preferred_lft 8639768sec
2026-05-21T05:27:47.165668637Z     inet6 fe80::20d:3aff:fe5b:ad0d/64 scope link 
2026-05-21T05:27:47.165671137Z        valid_lft forever preferred_lft forever
2026-05-21T05:27:47.168043055Z Node initialization complete
2026-05-21T05:27:47.169759567Z !!! startup-script succeeded!

```
Fixes: https://github.com/cilium/cilium/issues/45254

```release-note
cilium-cli: don't enable nodeinit on AKS
```
