### PR TITLE
Routing: rollback partial ip rules on Configure() failure

### DIFF
--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -390,7 +390,7 @@ func (r Rule) String() string {
 	return str
 }
 
-func lookupRule(spec Rule, family int) (bool, error) {
+func LookupRule(spec Rule, family int) (bool, error) {
 	rules, err := safenetlink.RuleList(family)
 	if err != nil {
 		return false, err
@@ -483,7 +483,7 @@ func ReplaceRuleIPv6(spec Rule) error {
 }
 
 func replaceRule(spec Rule, family int) error {
-	exists, err := lookupRule(spec, family)
+	exists, err := LookupRule(spec, family)
 	if err != nil {
 		return err
 	}

--- a/pkg/datapath/linux/route/route_linux_test.go
+++ b/pkg/datapath/linux/route/route_linux_test.go
@@ -129,12 +129,12 @@ func testReplaceRule(t *testing.T, mark uint32, from, to *net.IPNet, table int) 
 	err := ReplaceRule(rule)
 	require.NoError(t, err)
 
-	exists, err := lookupRule(rule, netlink.FAMILY_V4)
+	exists, err := LookupRule(rule, netlink.FAMILY_V4)
 	require.NoError(t, err)
 	require.True(t, exists)
 
 	rule.Mask++
-	exists, err = lookupRule(rule, netlink.FAMILY_V4)
+	exists, err = LookupRule(rule, netlink.FAMILY_V4)
 	require.NoError(t, err)
 	require.False(t, exists)
 	rule.Mask--
@@ -142,7 +142,7 @@ func testReplaceRule(t *testing.T, mark uint32, from, to *net.IPNet, table int) 
 	err = DeleteRule(netlink.FAMILY_V4, rule)
 	require.NoError(t, err)
 
-	exists, err = lookupRule(rule, netlink.FAMILY_V4)
+	exists, err = LookupRule(rule, netlink.FAMILY_V4)
 	require.NoError(t, err)
 	require.False(t, exists)
 }
@@ -157,14 +157,14 @@ func testReplaceRuleIPv6(t *testing.T, mark uint32, from, to *net.IPNet, table i
 	err := ReplaceRuleIPv6(rule)
 	require.NoError(t, err)
 
-	exists, err := lookupRule(rule, netlink.FAMILY_V6)
+	exists, err := LookupRule(rule, netlink.FAMILY_V6)
 	require.NoError(t, err)
 	require.True(t, exists)
 
 	err = DeleteRule(netlink.FAMILY_V6, rule)
 	require.NoError(t, err)
 
-	exists, err = lookupRule(rule, netlink.FAMILY_V6)
+	exists, err = LookupRule(rule, netlink.FAMILY_V6)
 	require.NoError(t, err)
 	require.False(t, exists)
 }

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -74,13 +74,41 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, host bool) error {
 		}
 	}
 
+	var family int
+	if ip.To4() != nil {
+		family = netlink.FAMILY_V4
+	} else {
+		family = netlink.FAMILY_V6
+	}
+
+	var installedRules []route.Rule
+	defer func() {
+		for _, r := range installedRules {
+			_ = route.DeleteRule(family, r)
+		}
+	}()
+
+	installRule := func(r route.Rule) error {
+		existed, err := route.LookupRule(r, family)
+		if err != nil {
+			return err
+		}
+		if err := replaceRule(r); err != nil {
+			return err
+		}
+		if !existed {
+			installedRules = append(installedRules, r)
+		}
+		return nil
+	}
+
 	// Ingress rule. This rule is not installed for the cilium_host IP, because
 	// the cilium_host IP is a local IP and therefore must be routed via the
 	// 'local' table instead of 'main'.
 	if !host {
 		// On ingress, route all traffic to the endpoint IP via the main routing
 		// table. Egress rules are created in a per-ENI routing table.
-		if err := replaceRule(route.Rule{
+		if err := installRule(route.Rule{
 			Priority: linux_defaults.RulePriorityIngress,
 			To:       &ipWithMask,
 			Table:    route.MainTable,
@@ -107,7 +135,7 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, host bool) error {
 		// ReplaceRule function doesn't handle all zeros cidr and return `file exists` error,
 		// so we need to normalize the rule to cidr here and in Delete
 		for _, cidr := range info.CIDRs {
-			if err := replaceRule(route.Rule{
+			if err := installRule(route.Rule{
 				Priority: egressPriority,
 				From:     &ipWithMask,
 				To:       normalizeRuleToCIDR(&cidr),
@@ -119,7 +147,7 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, host bool) error {
 		}
 	} else {
 		// Lookup a VPC specific table for all traffic from an endpoint.
-		if err := replaceRule(route.Rule{
+		if err := installRule(route.Rule{
 			Priority: egressPriority,
 			From:     &ipWithMask,
 			Table:    tableID,
@@ -129,7 +157,12 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, host bool) error {
 		}
 	}
 
-	return info.installRoutes(ifindex, tableID)
+	if err := info.installRoutes(ifindex, tableID); err != nil {
+		return err
+	}
+
+	installedRules = nil
+	return nil
 }
 
 func (info *RoutingInfo) ReconcileGatewayRoutes(mtu int, rx statedb.ReadTxn, routes statedb.Table[*tables.Route]) (*statedb.WatchSet, error) {

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -83,6 +83,112 @@ func TestPrivilegedConfigureZeros(t *testing.T) {
 	})
 }
 
+// TestPrivilegedConfigureRevertsOnError verifies that Configure() cleans up
+// any rules it installed if it fails partway through. Without rollback,
+// a second attempt to attach the same IP would fail because stale rules
+// from the first attempt are still present (issue #39751).
+func TestPrivilegedConfigureRevertsOnError(t *testing.T) {
+	setupLinuxRoutingSuite(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		ip, ri := getFakes(t, ipamOption.IPAMENI, true, false)
+		masterMAC := ri.MasterIfMAC
+		ifaceCleanup := createDummyDevice(t, masterMAC)
+		defer ifaceCleanup()
+
+		beforeRules, _ := listRulesAndRoutes(t, netlink.FAMILY_V4)
+
+		// Force installRoutes to fail by zeroing the gateway so that
+		// netlink.RouteReplace returns an error.
+		badRI := ri
+		badRI.Gateway = net.IPv4zero
+
+		err := badRI.Configure(ip.AsSlice(), 1500, false)
+		require.Error(t, err)
+
+		// After the failed Configure, the rule count must be exactly the same
+		// as before — no leaked ingress or egress rules.
+		afterRules, _ := listRulesAndRoutes(t, netlink.FAMILY_V4)
+		require.Len(t, afterRules, len(beforeRules),
+			"Configure() leaked ip rules after partial failure")
+
+		return nil
+	})
+}
+
+// TestPrivilegedConfigureRevertsOnErrorWithPreexistingRules verifies that if
+// Configure() was already called successfully once, a subsequent failing call
+// does not delete the rules installed by the first successful call.
+func TestPrivilegedConfigureRevertsOnErrorWithPreexistingRules(t *testing.T) {
+	setupLinuxRoutingSuite(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		ip, ri := getFakes(t, ipamOption.IPAMENI, true, false)
+		masterMAC := ri.MasterIfMAC
+		ifaceCleanup := createDummyDevice(t, masterMAC)
+		defer ifaceCleanup()
+
+		// First call — succeeds, rules and routes are installed.
+		err := ri.Configure(ip.AsSlice(), 1500, false)
+		require.NoError(t, err)
+
+		afterFirstRules, _ := listRulesAndRoutes(t, netlink.FAMILY_V4)
+		require.NotEmpty(t, afterFirstRules)
+
+		// Second call with a bad gateway — fails at installRoutes.
+		// The rules installed by the first call must survive.
+		badRI := ri
+		badRI.Gateway = net.IPv4zero
+
+		err = badRI.Configure(ip.AsSlice(), 1500, false)
+		require.Error(t, err)
+
+		afterSecondRules, _ := listRulesAndRoutes(t, netlink.FAMILY_V4)
+		require.Len(t, afterSecondRules, len(afterFirstRules),
+			"Configure() deleted pre-existing rules during rollback")
+
+		return nil
+	})
+}
+
+// TestPrivilegedConfigureRevertsOnErrorWithPreexistingRulesAzure is the same
+// as TestPrivilegedConfigureRevertsOnErrorWithPreexistingRules but for Azure
+// IPAM mode, which uses RulePriorityEgress instead of RulePriorityEgressv2.
+func TestPrivilegedConfigureRevertsOnErrorWithPreexistingRulesAzure(t *testing.T) {
+	setupLinuxRoutingSuite(t)
+
+	ns := netns.NewNetNS(t)
+	ns.Do(func() error {
+		ip, ri := getFakes(t, ipamOption.IPAMAzure, true, false)
+		masterMAC := ri.MasterIfMAC
+		ifaceCleanup := createDummyDevice(t, masterMAC)
+		defer ifaceCleanup()
+
+		// First call — succeeds, rules and routes are installed.
+		err := ri.Configure(ip.AsSlice(), 1500, false)
+		require.NoError(t, err)
+
+		afterFirstRules, _ := listRulesAndRoutes(t, netlink.FAMILY_V4)
+		require.NotEmpty(t, afterFirstRules)
+
+		// Second call with a bad gateway — fails at installRoutes.
+		// The rules installed by the first call must survive.
+		badRI := ri
+		badRI.Gateway = net.IPv4zero
+
+		err = badRI.Configure(ip.AsSlice(), 1500, false)
+		require.Error(t, err)
+
+		afterSecondRules, _ := listRulesAndRoutes(t, netlink.FAMILY_V4)
+		require.Len(t, afterSecondRules, len(afterFirstRules),
+			"Configure() deleted pre-existing rules during rollback")
+
+		return nil
+	})
+}
+
 func TestPrivilegedConfigureRouteWithIncompatibleIP(t *testing.T) {
 	setupLinuxRoutingSuite(t)
 


### PR DESCRIPTION
## Description

`Configure()` in `pkg/datapath/linux/routing` installs ip rules in
three steps (ingress rule, egress rule(s), routes) with no rollback
if a later step fails. Leftover rules from a partial failure block
subsequent pod creation attempts on the same IP.

This change adds a deferred rollback inside `Configure()` using the
same `deleteRulesFiltered` logic as `Delete()`. If the function returns
an error, any rules installed before the failure are cleaned up.

---

- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title, description and a `Fixes: #XXX` line if the commit addresses a particular GitHub issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Write a short paragraph that states whether you used machine learning models (including LLMs and other generative AI), and indicate the rating using [AI Influence Level](https://danielmiessler.com/blog/ai-influence-level-ail).

**AI disclosure:** This PR was prepared with AIL:3. I personally reviewed each line of the submission prior to opening this PR.

Fixes: #39751

```
release-note
routing: clean up partial ip rules when Configure() fails midway
```
