### PR TITLE
loader: Support max stack depth in verifier logs

### DIFF
--- a/pkg/datapath/loader/verifier_test.go
+++ b/pkg/datapath/loader/verifier_test.go
@@ -406,6 +406,10 @@ func parseStackDepth(s *ebpf.ProgramSpec, verifierLogs string, lastLineIndex, la
 		}
 	}
 	stackDepthLine = strings.TrimPrefix(strings.TrimSpace(stackDepthLine), "stack depth ")
+	// On newer kernels, the stack depth line may look as follows, so we need
+	// to remove the max info at the end.
+	//   stack depth 144+255 max 400
+	stackDepthLine = strings.Split(stackDepthLine, " max ")[0]
 
 	// Remove prefix so we are just left with plus separated stack depths, and parse them into ints.
 	//   144+280+120


### PR DESCRIPTION
Commit [1] upstream introduced some new information in the verifier logs, on the stack depth line:

    - stack depth 144+255
    + stack depth 144+255 max 400

Unfortunately, our verifier test fails to parse the per-subprog stack depths now that we have this additional information. In a subsequent pull request, we'll use that new information, but for now, let's just remove it from the input. This commit fixes the following error:

    Failed to parse stack depth for program cil_from_host: strconv.Atoi:
      parsing "192 max 192": invalid syntax

1: https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git/commit/?id=f41f34ec6474