### PR TITLE
gw-api: cleanup cecTranslator

### DIFF
--- a/operator/pkg/model/translation/cec_translator.go
+++ b/operator/pkg/model/translation/cec_translator.go
@@ -187,14 +187,12 @@ func (i *cecTranslator) desiredServicesWithPorts(namespace string, name string, 
 func (i *cecTranslator) desiredResources(m *model.Model) ([]ciliumv2.XDSResource, error) {
 	var res []ciliumv2.XDSResource
 
-	allAuthFilters := i.getUniqueAuthFilters(m)
-
-	listener, err := i.desiredEnvoyListener(m, allAuthFilters)
+	listener, err := i.desiredEnvoyListener(m)
 	if err != nil {
 		return nil, err
 	}
 
-	httpRoutes, err := i.desiredEnvoyHTTPRouteConfiguration(m, allAuthFilters)
+	httpRoutes, err := i.desiredEnvoyHTTPRouteConfiguration(m)
 	if err != nil {
 		return nil, err
 	}

--- a/operator/pkg/model/translation/cec_translator_test.go
+++ b/operator/pkg/model/translation/cec_translator_test.go
@@ -277,7 +277,7 @@ func TestSharedIngressTranslator_getListenerProxy(t *testing.T) {
 				},
 			},
 		},
-	}, nil)
+	})
 	require.NoError(t, err)
 	require.Len(t, res, 1)
 
@@ -311,7 +311,7 @@ func TestSharedIngressTranslator_getListener(t *testing.T) {
 				},
 			},
 		},
-	}, nil)
+	})
 	require.NoError(t, err)
 	require.Len(t, res, 1)
 
@@ -473,8 +473,8 @@ func TestGetEnvoyHTTPRouteConfiguration_VirtualHostSorted(t *testing.T) {
 		},
 	}
 
-	res1, err1 := defT.desiredEnvoyHTTPRouteConfiguration(&model.Model{HTTP: l1}, nil)
-	res2, err2 := defT.desiredEnvoyHTTPRouteConfiguration(&model.Model{HTTP: l2}, nil)
+	res1, err1 := defT.desiredEnvoyHTTPRouteConfiguration(&model.Model{HTTP: l1})
+	res2, err2 := defT.desiredEnvoyHTTPRouteConfiguration(&model.Model{HTTP: l2})
 	require.NoError(t, err1)
 	require.NoError(t, err2)
 
@@ -558,7 +558,7 @@ func TestSharedIngressTranslator_getEnvoyHTTPRouteConfiguration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			res, err := defT.desiredEnvoyHTTPRouteConfiguration(tt.args.m, nil)
+			res, err := defT.desiredEnvoyHTTPRouteConfiguration(tt.args.m)
 			require.NoError(t, err)
 			require.Len(t, res, len(tt.expectedRouteConfigs), "Number of Listeners did not match")
 

--- a/operator/pkg/model/translation/envoy_http_connection_manager.go
+++ b/operator/pkg/model/translation/envoy_http_connection_manager.go
@@ -84,7 +84,7 @@ func (i *cecTranslator) httpConnectionManagerMutators() []HttpConnectionManagerM
 	}
 }
 
-func getHTTPConnectionManagerHttpFilters(authFilters []*model.HTTPExternalAuthFilter, m *model.Model) ([]*httpConnectionManagerv3.HttpFilter, error) {
+func (i *cecTranslator) getHTTPConnectionManagerHttpFilters(m *model.Model) []*httpConnectionManagerv3.HttpFilter {
 	hf := []*httpConnectionManagerv3.HttpFilter{
 		{
 			Name: "envoy.filters.http.grpc_web",
@@ -103,17 +103,13 @@ func getHTTPConnectionManagerHttpFilters(authFilters []*model.HTTPExternalAuthFi
 		},
 	}
 
-	for _, af := range authFilters {
-		f, err := buildExtAuthzHTTPFilter(af)
-		if err != nil {
-			return nil, err
-		}
-		hf = append(hf, f)
+	for _, af := range i.getUniqueAuthFilters(m) {
+		hf = append(hf, buildExtAuthzHTTPFilter(af))
 	}
 
 	// HTTP filter order matters. When CORS is enabled,
 	// the CORS filter must run before envoy.filters.http.router.
-	if m != nil && m.IsCORSFilterConfigured() {
+	if m.IsCORSFilterConfigured() {
 		hf = append(hf, &httpConnectionManagerv3.HttpFilter{
 			Name: "envoy.filters.http.cors",
 			ConfigType: &httpConnectionManagerv3.HttpFilter_TypedConfig{
@@ -129,17 +125,11 @@ func getHTTPConnectionManagerHttpFilters(authFilters []*model.HTTPExternalAuthFi
 		},
 	})
 
-	return hf, nil
+	return hf
 }
 
 // desiredHTTPConnectionManager returns a new HTTP connection manager filter with the given name and route.
-// authFilters is a deduplicated list of external auth backends; one named ext_authz filter is added per entry,
-// positioned before the terminal router filter so that per-route TypedPerFilterConfig can enable/disable each.
-func (i *cecTranslator) desiredHTTPConnectionManager(name, routeName string, authFilters []*model.HTTPExternalAuthFilter, m *model.Model) (ciliumv2.XDSResource, error) {
-	hf, err := getHTTPConnectionManagerHttpFilters(authFilters, m)
-	if err != nil {
-		return ciliumv2.XDSResource{}, err
-	}
+func (i *cecTranslator) desiredHTTPConnectionManager(name, routeName string, m *model.Model) (ciliumv2.XDSResource, error) {
 	connectionManager := &httpConnectionManagerv3.HttpConnectionManager{
 		StatPrefix: name,
 		RouteSpecifier: &httpConnectionManagerv3.HttpConnectionManager_Rds{
@@ -147,7 +137,7 @@ func (i *cecTranslator) desiredHTTPConnectionManager(name, routeName string, aut
 		},
 		UseRemoteAddress: &wrapperspb.BoolValue{Value: true},
 		SkipXffAppend:    false,
-		HttpFilters:      hf,
+		HttpFilters:      i.getHTTPConnectionManagerHttpFilters(m),
 		UpgradeConfigs: []*httpConnectionManagerv3.HttpConnectionManager_UpgradeConfig{
 			{UpgradeType: "websocket"},
 		},
@@ -166,8 +156,10 @@ func (i *cecTranslator) desiredHTTPConnectionManager(name, routeName string, aut
 	return toXdsResource(connectionManager, envoy.HttpConnectionManagerTypeURL)
 }
 
-// buildExtAuthzHTTPFilter creates a named HCM HttpFilter for the given external auth config.
-func buildExtAuthzHTTPFilter(af *model.HTTPExternalAuthFilter) (*httpConnectionManagerv3.HttpFilter, error) {
+// buildExtAuthzHTTPFilter creates one named ext_authz HCM HttpFilter for a deduplicated
+// external auth config. These filters are positioned before the terminal router filter so
+// that per-route TypedPerFilterConfig can enable or disable each instance.
+func buildExtAuthzHTTPFilter(af *model.HTTPExternalAuthFilter) *httpConnectionManagerv3.HttpFilter {
 	var clusterName string
 	if af.Protocol == model.ExternalAuthProtocolGRPC {
 		clusterName = getGRPCExtAuthClusterName(af.Backend.Namespace, af.Backend.Name, af.Backend.Port.GetPort())
@@ -261,7 +253,7 @@ func buildExtAuthzHTTPFilter(af *model.HTTPExternalAuthFilter) (*httpConnectionM
 		ConfigType: &httpConnectionManagerv3.HttpFilter_TypedConfig{
 			TypedConfig: toAny(config),
 		},
-	}, nil
+	}
 }
 
 // allHeadersMatcher returns a ListStringMatcher that matches every header name.

--- a/operator/pkg/model/translation/envoy_http_connection_manager_test.go
+++ b/operator/pkg/model/translation/envoy_http_connection_manager_test.go
@@ -19,7 +19,7 @@ func Test_desiredHTTPConnectionManager(t *testing.T) {
 	t.Run("no CORS filter enabled", func(t *testing.T) {
 		i := &cecTranslator{}
 		m := &model.Model{}
-		res, err := i.desiredHTTPConnectionManager("dummy-name", "dummy-route-name", nil, m)
+		res, err := i.desiredHTTPConnectionManager("dummy-name", "dummy-route-name", m)
 		require.NoError(t, err)
 
 		httpConnectionManager := &httpConnectionManagerv3.HttpConnectionManager{}
@@ -51,7 +51,7 @@ func Test_desiredHTTPConnectionManager(t *testing.T) {
 				},
 			},
 		}}
-		res, err := i.desiredHTTPConnectionManager("dummy-name", "dummy-route-name", nil, m)
+		res, err := i.desiredHTTPConnectionManager("dummy-name", "dummy-route-name", m)
 		require.NoError(t, err)
 
 		httpConnectionManager := &httpConnectionManagerv3.HttpConnectionManager{}
@@ -78,8 +78,8 @@ func Test_desiredHTTPConnectionManager(t *testing.T) {
 func Test_getHTTPConnectionManagerHttpFilters(t *testing.T) {
 	t.Run("no CORS filter enabled", func(t *testing.T) {
 		m := &model.Model{}
-		res, err := getHTTPConnectionManagerHttpFilters([]*model.HTTPExternalAuthFilter{}, m)
-		require.NoError(t, err)
+		i := &cecTranslator{}
+		res := i.getHTTPConnectionManagerHttpFilters(m)
 
 		require.Len(t, res, 3)
 		require.Equal(t, "envoy.filters.http.grpc_web", res[0].Name)
@@ -96,8 +96,8 @@ func Test_getHTTPConnectionManagerHttpFilters(t *testing.T) {
 				},
 			},
 		}}
-		res, err := getHTTPConnectionManagerHttpFilters([]*model.HTTPExternalAuthFilter{}, m)
-		require.NoError(t, err)
+		i := &cecTranslator{}
+		res := i.getHTTPConnectionManagerHttpFilters(m)
 
 		require.Len(t, res, 4)
 		require.Equal(t, "envoy.filters.http.grpc_web", res[0].Name)
@@ -109,20 +109,28 @@ func Test_getHTTPConnectionManagerHttpFilters(t *testing.T) {
 }
 
 func Test_desiredHTTPConnectionManager_withExtAuthz(t *testing.T) {
-	authFilters := []*model.HTTPExternalAuthFilter{
-		{
-			Backend:  model.Backend{Name: "grpc-authz", Namespace: "default", Port: &model.BackendPort{Port: 9000}},
-			Protocol: model.ExternalAuthProtocolGRPC,
-		},
-		{
-			Backend:    model.Backend{Name: "http-authz", Namespace: "default", Port: &model.BackendPort{Port: 8080}},
-			Protocol:   model.ExternalAuthProtocolHTTP,
-			PathPrefix: "/auth",
-		},
-	}
-
 	i := &cecTranslator{}
-	res, err := i.desiredHTTPConnectionManager("dummy-name", "dummy-route-name", authFilters, nil)
+	m := &model.Model{
+		HTTP: []model.HTTPListener{{
+			Routes: []model.HTTPRoute{
+				{
+					ExternalAuth: &model.HTTPExternalAuthFilter{
+						Backend:  model.Backend{Name: "grpc-authz", Namespace: "default", Port: &model.BackendPort{Port: 9000}},
+						Protocol: model.ExternalAuthProtocolGRPC,
+					},
+				},
+				{
+					ExternalAuth: &model.HTTPExternalAuthFilter{
+						Backend:    model.Backend{Name: "http-authz", Namespace: "default", Port: &model.BackendPort{Port: 8080}},
+						Protocol:   model.ExternalAuthProtocolHTTP,
+						PathPrefix: "/auth",
+					},
+				},
+			},
+		}},
+	}
+	authFilters := i.getUniqueAuthFilters(m)
+	res, err := i.desiredHTTPConnectionManager("dummy-name", "dummy-route-name", m)
 	require.NoError(t, err)
 
 	hcm := &httpConnectionManagerv3.HttpConnectionManager{}
@@ -157,8 +165,7 @@ func Test_buildExtAuthzHTTPFilter_forwardBody(t *testing.T) {
 			Protocol:    model.ExternalAuthProtocolGRPC,
 			ForwardBody: &model.ForwardBodyConfig{MaxSize: 4096},
 		}
-		filter, err := buildExtAuthzHTTPFilter(af)
-		require.NoError(t, err)
+		filter := buildExtAuthzHTTPFilter(af)
 		config := &extauthzv3.ExtAuthz{}
 		require.NoError(t, proto.Unmarshal(filter.GetTypedConfig().Value, config))
 		require.NotNil(t, config.GetWithRequestBody())
@@ -172,8 +179,7 @@ func Test_buildExtAuthzHTTPFilter_forwardBody(t *testing.T) {
 			Protocol:    model.ExternalAuthProtocolHTTP,
 			ForwardBody: &model.ForwardBodyConfig{MaxSize: 8192},
 		}
-		filter, err := buildExtAuthzHTTPFilter(af)
-		require.NoError(t, err)
+		filter := buildExtAuthzHTTPFilter(af)
 		config := &extauthzv3.ExtAuthz{}
 		require.NoError(t, proto.Unmarshal(filter.GetTypedConfig().Value, config))
 		require.NotNil(t, config.GetWithRequestBody())
@@ -186,8 +192,7 @@ func Test_buildExtAuthzHTTPFilter_forwardBody(t *testing.T) {
 			Backend:  model.Backend{Name: "http-authz", Namespace: "default", Port: &model.BackendPort{Port: 8080}},
 			Protocol: model.ExternalAuthProtocolHTTP,
 		}
-		filter, err := buildExtAuthzHTTPFilter(af)
-		require.NoError(t, err)
+		filter := buildExtAuthzHTTPFilter(af)
 		config := &extauthzv3.ExtAuthz{}
 		require.NoError(t, proto.Unmarshal(filter.GetTypedConfig().Value, config))
 		require.Nil(t, config.GetWithRequestBody())
@@ -199,8 +204,7 @@ func Test_buildExtAuthzHTTPFilter_forwardBody(t *testing.T) {
 			Protocol:    model.ExternalAuthProtocolHTTP,
 			ForwardBody: &model.ForwardBodyConfig{MaxSize: 0},
 		}
-		filter, err := buildExtAuthzHTTPFilter(af)
-		require.NoError(t, err)
+		filter := buildExtAuthzHTTPFilter(af)
 		config := &extauthzv3.ExtAuthz{}
 		require.NoError(t, proto.Unmarshal(filter.GetTypedConfig().Value, config))
 		require.Nil(t, config.GetWithRequestBody())
@@ -216,8 +220,7 @@ func Test_buildExtAuthzHTTPFilter_allowedRequestHeaders(t *testing.T) {
 			Protocol:              model.ExternalAuthProtocolGRPC,
 			AllowedRequestHeaders: []string{},
 		}
-		filter, err := buildExtAuthzHTTPFilter(af)
-		require.NoError(t, err)
+		filter := buildExtAuthzHTTPFilter(af)
 		config := &extauthzv3.ExtAuthz{}
 		require.NoError(t, proto.Unmarshal(filter.GetTypedConfig().Value, config))
 		require.Nil(t, config.GetAllowedHeaders())
@@ -228,8 +231,7 @@ func Test_buildExtAuthzHTTPFilter_allowedRequestHeaders(t *testing.T) {
 			Backend:  model.Backend{Name: "grpc-authz", Namespace: "default", Port: &model.BackendPort{Port: 9000}},
 			Protocol: model.ExternalAuthProtocolGRPC,
 		}
-		filter, err := buildExtAuthzHTTPFilter(af)
-		require.NoError(t, err)
+		filter := buildExtAuthzHTTPFilter(af)
 		config := &extauthzv3.ExtAuthz{}
 		require.NoError(t, proto.Unmarshal(filter.GetTypedConfig().Value, config))
 		require.Nil(t, config.GetAllowedHeaders())
@@ -241,8 +243,7 @@ func Test_buildExtAuthzHTTPFilter_allowedRequestHeaders(t *testing.T) {
 			Protocol:              model.ExternalAuthProtocolGRPC,
 			AllowedRequestHeaders: []string{"X-Custom-Header", "X-Tenant-ID"},
 		}
-		filter, err := buildExtAuthzHTTPFilter(af)
-		require.NoError(t, err)
+		filter := buildExtAuthzHTTPFilter(af)
 		config := &extauthzv3.ExtAuthz{}
 		require.NoError(t, proto.Unmarshal(filter.GetTypedConfig().Value, config))
 		require.NotNil(t, config.GetAllowedHeaders())
@@ -257,8 +258,7 @@ func Test_buildExtAuthzHTTPFilter_allowedRequestHeaders(t *testing.T) {
 			Protocol:              model.ExternalAuthProtocolHTTP,
 			AllowedRequestHeaders: []string{},
 		}
-		filter, err := buildExtAuthzHTTPFilter(af)
-		require.NoError(t, err)
+		filter := buildExtAuthzHTTPFilter(af)
 		config := &extauthzv3.ExtAuthz{}
 		require.NoError(t, proto.Unmarshal(filter.GetTypedConfig().Value, config))
 		require.Nil(t, config.GetAllowedHeaders())
@@ -270,8 +270,7 @@ func Test_buildExtAuthzHTTPFilter_allowedRequestHeaders(t *testing.T) {
 			Protocol:              model.ExternalAuthProtocolHTTP,
 			AllowedRequestHeaders: []string{"X-Custom-Header"},
 		}
-		filter, err := buildExtAuthzHTTPFilter(af)
-		require.NoError(t, err)
+		filter := buildExtAuthzHTTPFilter(af)
 		config := &extauthzv3.ExtAuthz{}
 		require.NoError(t, proto.Unmarshal(filter.GetTypedConfig().Value, config))
 		require.NotNil(t, config.GetAllowedHeaders())

--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -204,12 +204,12 @@ func withSocketOption(tcpKeepAlive, tcpKeepIdleInSeconds, tcpKeepAliveProbeInter
 }
 
 // desiredEnvoyListener returns the desired Envoy listener for the given model.
-func (i *cecTranslator) desiredEnvoyListener(m *model.Model, authFilters []*model.HTTPExternalAuthFilter) ([]ciliumv2.XDSResource, error) {
+func (i *cecTranslator) desiredEnvoyListener(m *model.Model) ([]ciliumv2.XDSResource, error) {
 	if m.IsEmpty() {
 		return nil, nil
 	}
 
-	filterChains, err := i.filterChains(listenerName, m, authFilters)
+	filterChains, err := i.filterChains(listenerName, m)
 	if err != nil {
 		return nil, err
 	}
@@ -238,11 +238,11 @@ func (i *cecTranslator) desiredEnvoyListener(m *model.Model, authFilters []*mode
 	return []ciliumv2.XDSResource{res}, nil
 }
 
-func (i *cecTranslator) filterChains(name string, m *model.Model, authFilters []*model.HTTPExternalAuthFilter) ([]*envoy_config_listener.FilterChain, error) {
+func (i *cecTranslator) filterChains(name string, m *model.Model) ([]*envoy_config_listener.FilterChain, error) {
 	var filterChains []*envoy_config_listener.FilterChain
 
 	if m.IsHTTPListenerConfigured() {
-		httpFilterChain, err := i.httpFilterChain(name, authFilters, m)
+		httpFilterChain, err := i.httpFilterChain(name, m)
 		if err != nil {
 			return nil, err
 		}
@@ -250,7 +250,7 @@ func (i *cecTranslator) filterChains(name string, m *model.Model, authFilters []
 	}
 
 	if m.IsHTTPSListenerConfigured() {
-		httpsFilterChains, err := i.httpsFilterChains(name, m, authFilters)
+		httpsFilterChains, err := i.httpsFilterChains(name, m)
 		if err != nil {
 			return nil, err
 		}
@@ -296,12 +296,11 @@ func (i *cecTranslator) listenerMutators(m *model.Model) []ListenerMutator {
 	return res
 }
 
-func (i *cecTranslator) httpFilterChain(name string, authFilters []*model.HTTPExternalAuthFilter, m *model.Model) (*envoy_config_listener.FilterChain, error) {
+func (i *cecTranslator) httpFilterChain(name string, m *model.Model) (*envoy_config_listener.FilterChain, error) {
 	insecureHttpConnectionManagerName := fmt.Sprintf("%s-insecure", name)
 	insecureHttpConnectionManager, err := i.desiredHTTPConnectionManager(
 		insecureHttpConnectionManagerName,
 		insecureHttpConnectionManagerName,
-		authFilters,
 		m,
 	)
 	if err != nil {
@@ -321,7 +320,7 @@ func (i *cecTranslator) httpFilterChain(name string, authFilters []*model.HTTPEx
 	}, nil
 }
 
-func (i *cecTranslator) httpsFilterChains(name string, m *model.Model, authFilters []*model.HTTPExternalAuthFilter) ([]*envoy_config_listener.FilterChain, error) {
+func (i *cecTranslator) httpsFilterChains(name string, m *model.Model) ([]*envoy_config_listener.FilterChain, error) {
 	tlsToHostnames := m.TLSSecretsToHostnames()
 	if len(tlsToHostnames) == 0 {
 		return nil, nil
@@ -337,7 +336,7 @@ func (i *cecTranslator) httpsFilterChains(name string, m *model.Model, authFilte
 		hostNames := tlsToHostnames[secret]
 
 		secureHttpConnectionManagerName := fmt.Sprintf("%s-secure", name)
-		secureHttpConnectionManager, err := i.desiredHTTPConnectionManager(secureHttpConnectionManagerName, secureHttpConnectionManagerName, authFilters, m)
+		secureHttpConnectionManager, err := i.desiredHTTPConnectionManager(secureHttpConnectionManagerName, secureHttpConnectionManagerName, m)
 		if err != nil {
 			return nil, err
 		}

--- a/operator/pkg/model/translation/envoy_route_configuration.go
+++ b/operator/pkg/model/translation/envoy_route_configuration.go
@@ -19,8 +19,9 @@ import (
 type RouteConfigurationMutator func(*envoy_config_route_v3.RouteConfiguration) *envoy_config_route_v3.RouteConfiguration
 
 // desiredEnvoyHTTPRouteConfiguration returns the route configuration for the given model.
-func (i *cecTranslator) desiredEnvoyHTTPRouteConfiguration(m *model.Model, allAuthFilters []*model.HTTPExternalAuthFilter) ([]ciliumv2.XDSResource, error) {
+func (i *cecTranslator) desiredEnvoyHTTPRouteConfiguration(m *model.Model) ([]ciliumv2.XDSResource, error) {
 	var res []ciliumv2.XDSResource
+	allAuthFilters := i.getUniqueAuthFilters(m)
 
 	type hostnameRedirect struct {
 		hostname string


### PR DESCRIPTION
This commit streamlines and cleans up the `cecTranslator`:

* use model to retrieve authfilters (don't pass as an additional argument)
* remove unnecessary errors in signature (`buildExtAuthzHTTPFilter`)
* remove unnecessary model nil-check (cors)