### PR TITLE
bgp: Use CreatedAt time instead of AgeNanoseconds in Path type

### DIFF
--- a/cilium-cli/bgp/routes.go
+++ b/cilium-cli/bgp/routes.go
@@ -284,7 +284,7 @@ func printRouteSummary(out io.Writer, routesPerNode map[string][]*models.BgpRout
 				}
 				fmt.Fprintf(w, "%s\t", path.NLRI)
 				fmt.Fprintf(w, "%s\t", nextHopFromPathAttributes(path.PathAttributes))
-				fmt.Fprintf(w, "%s\t", time.Duration(path.AgeNanoseconds).Round(time.Second))
+				fmt.Fprintf(w, "%s\t", path.Age().Round(time.Second))
 				fmt.Fprintf(w, "%s\t", path.PathAttributes)
 				fmt.Fprintf(w, "\n")
 			}

--- a/pkg/bgp/api/conversions.go
+++ b/pkg/bgp/api/conversions.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
+	"time"
 
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
 
@@ -78,7 +79,7 @@ func ToAPIFamilies(families []types.Family) []*models.BgpFamily {
 func ToAPIPath(p *types.Path) (*models.BgpPath, error) {
 	ret := &models.BgpPath{}
 
-	ret.AgeNanoseconds = p.AgeNanoseconds
+	ret.AgeNanoseconds = int64(p.Age())
 	ret.Best = p.Best
 
 	// We need this Base64 encoding because OpenAPI 2.0 spec doesn't support Union
@@ -118,7 +119,9 @@ func ToAPIPath(p *types.Path) (*models.BgpPath, error) {
 func ToAgentPath(m *models.BgpPath) (*types.Path, error) {
 	p := &types.Path{}
 
-	p.AgeNanoseconds = m.AgeNanoseconds
+	if m.AgeNanoseconds > 0 {
+		p.CreatedAt = time.Now().Add(-time.Duration(m.AgeNanoseconds))
+	}
 	p.Best = m.Best
 
 	// Decode serialized NLRI to bytes

--- a/pkg/bgp/api/printers.go
+++ b/pkg/bgp/api/printers.go
@@ -126,7 +126,7 @@ func PrintBGPRoutesTable(w *tabwriter.Writer, routes []*models.BgpRoute, printPe
 			fmt.Fprintf(w, "%s\t", path.NLRI)
 			fmt.Fprintf(w, "%s\t", NextHopFromPathAttributes(path.PathAttributes))
 			if printAge {
-				fmt.Fprintf(w, "%s\t", time.Duration(path.AgeNanoseconds).Round(time.Second))
+				fmt.Fprintf(w, "%s\t", path.Age().Round(time.Second))
 			}
 			fmt.Fprintf(w, "%s\n", path.PathAttributes)
 		}

--- a/pkg/bgp/commands/routes.go
+++ b/pkg/bgp/commands/routes.go
@@ -130,7 +130,7 @@ func PrintRoutes(tw *tabwriter.Writer, instances []agent.InstanceRoutes, printPe
 					Prefix:   route.Prefix,
 					NextHop:  api.NextHopFromPathAttributes(path.PathAttributes),
 					Best:     strconv.FormatBool(path.Best),
-					Age:      time.Duration(path.AgeNanoseconds).Truncate(time.Second).String(),
+					Age:      path.Age().Round(time.Second).String(),
 					Attrs:    FormatPathAttributes(path.PathAttributes),
 				}
 				if noAge {

--- a/pkg/bgp/gobgp/conversions.go
+++ b/pkg/bgp/gobgp/conversions.go
@@ -16,15 +16,22 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/bgp/types"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // ToGoBGPPath converts the Agent Path type to the GoBGP Path type
 func ToGoBGPPath(p *types.Path) (*apiutil.Path, error) {
+	createdAt := p.CreatedAt
+	if createdAt.IsZero() {
+		// GoBGP's Age field is a Unix creation timestamp in seconds;
+		// zero would mean 1970-01-01, not an unset timestamp.
+		createdAt = time.Now()
+	}
 	return &apiutil.Path{
 		Family:  bgp.NewFamily(uint16(p.Family.Afi), uint8(p.Family.Safi)),
 		Nlri:    p.NLRI,
 		Attrs:   p.PathAttributes,
-		Age:     p.AgeNanoseconds,
+		Age:     createdAt.Unix(),
 		Best:    p.Best,
 		PeerASN: p.SourceASN,
 	}, nil
@@ -39,7 +46,7 @@ func ToAgentPath(p *apiutil.Path) (*types.Path, error) {
 		},
 		NLRI:           p.Nlri,
 		PathAttributes: p.Attrs,
-		AgeNanoseconds: p.Age,
+		CreatedAt:      time.Unix(p.Age, 0), // GoBGP's Age field is a Unix creation timestamp in seconds.
 		Best:           p.Best,
 		SourceASN:      p.PeerASN,
 	}, nil

--- a/pkg/bgp/types/bgp.go
+++ b/pkg/bgp/types/bgp.go
@@ -58,10 +58,22 @@ type Path struct {
 	Family         Family
 
 	// readonly
-	AgeNanoseconds int64 // time duration in nanoseconds since the Path was created
-	Best           bool
-	UUID           []byte // path identifier in underlying implementation
-	SourceASN      uint32
+	CreatedAt time.Time // time when the Path was created
+	Best      bool
+	UUID      []byte // path identifier in underlying implementation
+	SourceASN uint32
+}
+
+// Age returns the elapsed duration since the Path was created.
+func (p *Path) Age() time.Duration {
+	if p.CreatedAt.IsZero() {
+		return 0
+	}
+	age := time.Since(p.CreatedAt)
+	if age < 0 {
+		return 0
+	}
+	return age
 }
 
 // Neighbor is an object representing a single BGP neighbor. It is an analogue


### PR DESCRIPTION
This is post-GoBGPv4 migration fixup for path creation time. In GoBGPv4, `path.Age` is now actually a creation time in seconds, not a duration since its creation anymore.

To reflect this change, adapt out internal type to store path creation time and update the conversion methods.

A helper `Path.Age()` is added to return Path's age as `time.Duration`.

The type in the legacy REST API is left unchanged to not break compatibility.

```release-note
bgp: Use CreatedAt timestamp instead of AgeNanoseconds in the internal Path type
```
