### PR TITLE
cni: extract configuration into separate package

### DIFF
--- a/daemon/cmd/cni/cell.go
+++ b/daemon/cmd/cni/cell.go
@@ -5,14 +5,13 @@ package cni
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"path"
 
 	"github.com/cilium/hive/cell"
-	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/daemon/cmd/cni/config"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/option"
 	cnitypes "github.com/cilium/cilium/plugins/cilium-cni/types"
@@ -22,19 +21,9 @@ var Cell = cell.Module(
 	"cni-config",
 	"CNI configuration manager",
 
-	cell.Config(defaultConfig),
+	config.Cell,
 	cell.Provide(enableConfigManager),
 )
-
-type Config struct {
-	WriteCNIConfWhenReady string
-	ReadCNIConf           string
-	CNIChainingMode       string
-	CNILogFile            string
-	CNIExclusive          bool
-	CNIChainingTarget     string
-	CNIExternalRouting    bool
-}
 
 type CNIConfigManager interface {
 	// GetMTU provides the MTU from the provided CNI configuration file.
@@ -55,46 +44,13 @@ type CNIConfigManager interface {
 	ExternalRoutingEnabled() bool
 }
 
-var defaultConfig = Config{
-	WriteCNIConfWhenReady: "",
-	ReadCNIConf:           "",
-	CNIChainingMode:       "none",
-	CNILogFile:            "/var/run/cilium/cilium-cni.log",
-	CNIExclusive:          false,
-	CNIChainingTarget:     "",
-	CNIExternalRouting:    false,
-}
-
-func (cfg Config) Flags(flags *pflag.FlagSet) {
-	flags.String(option.WriteCNIConfigurationWhenReady, defaultConfig.WriteCNIConfWhenReady, "Write the CNI configuration to the specified path when agent is ready")
-	flags.String(option.ReadCNIConfiguration, defaultConfig.ReadCNIConf, fmt.Sprintf("CNI configuration file to use as a source for --%s. If not supplied, a suitable one will be generated.", option.WriteCNIConfigurationWhenReady))
-	flags.String(option.CNIChainingMode, defaultConfig.CNIChainingMode, "Enable CNI chaining with the specified plugin")
-	flags.String(option.CNILogFile, defaultConfig.CNILogFile, "Path where the CNI plugin should write logs")
-	flags.String(option.CNIChainingTarget, defaultConfig.CNIChainingTarget, "CNI network name into which to insert the Cilium chained configuration. Use '*' to select any network.")
-	flags.Bool(option.CNIExclusive, defaultConfig.CNIExclusive, "Whether to remove other CNI configurations")
-	flags.Bool(option.CNIExternalRouting, defaultConfig.CNIExternalRouting, "Whether the chained CNI plugin handles routing on the node")
-}
-
-func enableConfigManager(lc cell.Lifecycle, logger *slog.Logger, cfg Config, dcfg *option.DaemonConfig /*only for .Debug*/) CNIConfigManager {
+func enableConfigManager(lc cell.Lifecycle, logger *slog.Logger, cfg config.Config, dcfg *option.DaemonConfig /*only for .Debug*/) CNIConfigManager {
 	c := newConfigManager(logger, cfg, dcfg.Debug)
 	lc.Append(c)
 	return c
 }
 
-func newConfigManager(logger *slog.Logger, cfg Config, debug bool) *cniConfigManager {
-	if cfg.CNIChainingMode == "aws-cni" && cfg.CNIChainingTarget == "" {
-		cfg.CNIChainingTarget = "aws-cni"
-		cfg.CNIExternalRouting = true
-	}
-
-	if cfg.CNIChainingTarget != "" && cfg.CNIChainingMode == "" {
-		cfg.CNIChainingMode = "generic-veth"
-	}
-
-	if cfg.CNIChainingMode == "" {
-		cfg.CNIChainingMode = "none"
-	}
-
+func newConfigManager(logger *slog.Logger, cfg config.Config, debug bool) *cniConfigManager {
 	s := models.Status{
 		Msg:   "CNI controller not started",
 		State: models.StatusStateFailure,

--- a/daemon/cmd/cni/cni_test.go
+++ b/daemon/cmd/cni/cni_test.go
@@ -12,11 +12,13 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
 	"github.com/tidwall/gjson"
+
+	"github.com/cilium/cilium/daemon/cmd/cni/config"
 )
 
 func TestInstallCNIConfFile(t *testing.T) {
 	workdir := t.TempDir()
-	cfg := Config{
+	cfg := config.Config{
 		CNILogFile:            `/opt"/cni.log`,
 		CNIChainingMode:       "none",
 		CNIExclusive:          true,
@@ -46,7 +48,7 @@ func TestInstallCNIConfFile(t *testing.T) {
 }
 
 func TestRenderCNIConfUnchained(t *testing.T) {
-	cfg := Config{
+	cfg := config.Config{
 		CNILogFile: `/opt"/cni.log`,
 	}
 	c := newConfigManager(hivetest.Logger(t), cfg, false)
@@ -62,7 +64,7 @@ func TestRenderCNIConfUnchained(t *testing.T) {
 }
 
 func TestRenderCNIConfChained(t *testing.T) {
-	cfg := Config{
+	cfg := config.Config{
 		CNILogFile:        `/opt"/cni.log`,
 		CNIChainingMode:   "testing",
 		CNIChainingTarget: "another-network",
@@ -231,7 +233,7 @@ func TestRenderCNIConfChained(t *testing.T) {
 
 func TestCleanupOtherCNI(t *testing.T) {
 	workdir := t.TempDir()
-	cfg := Config{
+	cfg := config.Config{
 		CNIExclusive:          true,
 		WriteCNIConfWhenReady: path.Join(workdir, "42-keep.json"),
 	}

--- a/daemon/cmd/cni/config.go
+++ b/daemon/cmd/cni/config.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tidwall/sjson"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/daemon/cmd/cni/config"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/time"
@@ -33,7 +34,7 @@ import (
 var legacyConfFile = "05-cilium.conf"
 
 type cniConfigManager struct {
-	config      Config
+	config      config.Config
 	debug       bool
 	cniConfDir  string // computed from WriteCNIConfigWhenReady
 	cniConfFile string // computed from WriteCNIConfigWhenReady

--- a/daemon/cmd/cni/config/config.go
+++ b/daemon/cmd/cni/config/config.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package config
+
+import (
+	"fmt"
+
+	"github.com/cilium/hive/cell"
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/option"
+)
+
+var (
+	Cell = cell.Group(
+		cell.Config(defaultConfig),
+		cell.Provide(config.Out),
+	)
+
+	defaultConfig = config{
+		WriteCNIConfWhenReady: "",
+		ReadCNIConf:           "",
+		CNIChainingMode:       "none",
+		CNILogFile:            "/var/run/cilium/cilium-cni.log",
+		CNIExclusive:          false,
+		CNIChainingTarget:     "",
+		CNIExternalRouting:    false,
+	}
+)
+
+type Config struct {
+	WriteCNIConfWhenReady string
+	ReadCNIConf           string
+	CNIChainingMode       string
+	CNILogFile            string
+	CNIExclusive          bool
+	CNIChainingTarget     string
+	CNIExternalRouting    bool
+}
+
+type config Config
+
+func (def config) Flags(flags *pflag.FlagSet) {
+	flags.String(option.WriteCNIConfigurationWhenReady, def.WriteCNIConfWhenReady, "Write the CNI configuration to the specified path when agent is ready")
+	flags.String(option.ReadCNIConfiguration, def.ReadCNIConf, fmt.Sprintf("CNI configuration file to use as a source for --%s. If not supplied, a suitable one will be generated.", option.WriteCNIConfigurationWhenReady))
+	flags.String(option.CNIChainingMode, def.CNIChainingMode, "Enable CNI chaining with the specified plugin")
+	flags.String(option.CNILogFile, def.CNILogFile, "Path where the CNI plugin should write logs")
+	flags.String(option.CNIChainingTarget, def.CNIChainingTarget, "CNI network name into which to insert the Cilium chained configuration. Use '*' to select any network.")
+	flags.Bool(option.CNIExclusive, def.CNIExclusive, "Whether to remove other CNI configurations")
+	flags.Bool(option.CNIExternalRouting, def.CNIExternalRouting, "Whether the chained CNI plugin handles routing on the node")
+}
+
+func (cfg config) Out() Config {
+	if cfg.CNIChainingMode == "aws-cni" && cfg.CNIChainingTarget == "" {
+		cfg.CNIChainingTarget = "aws-cni"
+		cfg.CNIExternalRouting = true
+	}
+
+	if cfg.CNIChainingTarget != "" && cfg.CNIChainingMode == "" {
+		cfg.CNIChainingMode = "generic-veth"
+	}
+
+	if cfg.CNIChainingMode == "" {
+		cfg.CNIChainingMode = "none"
+	}
+
+	return Config(cfg)
+}

--- a/daemon/cmd/cni/config/config_test.go
+++ b/daemon/cmd/cni/config/config_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package config
+
+import (
+	"testing"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/hive"
+)
+
+func TestConfig(t *testing.T) {
+	var tests = []struct {
+		name     string
+		override func(*config)
+		expected Config
+	}{
+		{
+			name: "default",
+			expected: Config{
+				CNIChainingMode: "none",
+				CNILogFile:      "/var/run/cilium/cilium-cni.log",
+			},
+		},
+		{
+			name:     "aws-cni chaining mode",
+			override: func(c *config) { c.CNIChainingMode = "aws-cni" },
+			expected: Config{
+				CNIChainingMode:    "aws-cni",
+				CNIChainingTarget:  "aws-cni",
+				CNIExternalRouting: true,
+				CNILogFile:         "/var/run/cilium/cilium-cni.log",
+			},
+		},
+		{
+			name: "generic-veth chaining mode",
+			override: func(c *config) {
+				c.CNIChainingMode, c.CNIChainingTarget = "", "foo"
+			},
+			expected: Config{
+				CNIChainingMode:   "generic-veth",
+				CNIChainingTarget: "foo",
+				CNILogFile:        "/var/run/cilium/cilium-cni.log",
+			},
+		},
+		{
+			name:     "empty chaining mode",
+			override: func(c *config) { c.CNIChainingMode = "" },
+			expected: Config{
+				CNIChainingMode: "none",
+				CNILogFile:      "/var/run/cilium/cilium-cni.log",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				got Config
+
+				h = hive.New(
+					Cell,
+
+					cell.Invoke(
+						func(cfg Config) {
+							got = cfg
+						},
+					),
+				)
+			)
+
+			if tt.override != nil {
+				hive.AddConfigOverride(h, tt.override)
+			}
+
+			require.NoError(t, h.Populate(hivetest.Logger(t)), "hive.Populate")
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
Currently, the CNI configuration flags are directly defined as part of the daemon/cmd/cni package. However, this is potentially problematic, as this package imports at least the renameio package that is incompatible with Windows. Hence, any (transitive) dependency of the Cilium CLI on the cni package (e.g., to validate the chaining mode) breaks the Windows build.

Let's get this fixed by extracting the configuration into a dedicated package. While being there, let's also change the defaulting logic so that the exposed configuration is always correct, to prevent surprises from possible consumers.
