### PR TITLE
Extend default APIInteractions metric buckets from 10s to 2min

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -725,6 +725,8 @@ func NewLegacyMetrics() *LegacyMetrics {
 			Subsystem: SubsystemAgent,
 			Name:      "api_process_time_seconds",
 			Help:      "Duration of processed API calls labeled by path, method and return code.",
+			// default buckets extended to 2min
+			Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 20, 30, 60, 90, 120},
 		}, []string{LabelPath, LabelMethod, LabelAPIReturnCode}),
 
 		EndpointComponentStatus: metric.NewGaugeVec(metric.GaugeOpts{


### PR DESCRIPTION
This PR moves limit for historgram buckets for `APIInteractions` metric from default 10s to 2min. In huge clusters or during high pod churn `api processing time` might increase significantly, but values will be limited to 10s - this creates significant observability gap.

My understanding on why this change is safe:
 * There might be temporary issues with dashboard or queries for this metric - during the transition window in which old and new metric value will be reported
 * No permanent breaks - queries/dashboards relying on existing bucketing (e.g. `{le="0.5"}` usage) will continue to work just fine, existing buckets are just extended, not modified.

