### PR TITLE
docs: add CNI chaining guide for Oracle Kubernetes Engine (OKE)

### DIFF
--- a/Documentation/installation/cni-chaining-oracle-oke.rst
+++ b/Documentation/installation/cni-chaining-oracle-oke.rst
@@ -114,6 +114,34 @@ Use the following to identify pods that need restarting:
         done
    done
 
+Uninstall
+=========
+
+.. code-block:: shell-session
+
+   $ helm uninstall cilium -n kube-system
+
+.. warning::
+
+   ``helm uninstall`` removes Kubernetes resources but does not clean up files
+   written to node host paths. The ``/etc/cni/net.d/05-cilium.conflist`` file
+   remains on every node after uninstall. Because it sorts before
+   ``10-oci.conflist``, the kubelet continues to use it for new pod creations.
+   With the Cilium agent gone, ``cilium-cni`` cannot reach its socket and
+   **new pods will be stuck in ContainerCreating** with the error
+   ``dial unix /var/run/cilium/cilium.sock: connect: no such file or directory``.
+   Existing running pods are not affected since CNI is only called at pod
+   creation time.
+
+   After uninstalling, SSH into each node and remove the file:
+
+   .. code-block:: shell-session
+
+      $ sudo rm -f /etc/cni/net.d/05-cilium.conflist
+
+   OKE's ``vcn-native-ip-cni`` DaemonSet will then handle all new pod
+   networking via ``10-oci.conflist``.
+
 .. include:: k8s-install-validate.rst
 
 .. include:: next-steps.rst

--- a/Documentation/installation/cni-chaining-oracle-oke.rst
+++ b/Documentation/installation/cni-chaining-oracle-oke.rst
@@ -38,29 +38,18 @@ veth peer, and routing uses a proxy-ARP gateway at ``169.254.1.1``. This model
 is functionally identical to AWS VPC CNI.
 
 Cilium runs as the third plugin in the chain via the ``generic-veth`` chaining
-mode. When ``cni.chainingTarget=oci`` is set, the Cilium agent automatically
-discovers the existing OCI conflist named ``"oci"`` on each node and injects
-itself at the end of the plugin array. No manual CNI ConfigMap is required.
-
-The final conflist on each node looks like:
-
-.. code-block:: json
-
-   {
-     "name": "oci",
-     "cniVersion": "0.3.1",
-     "plugins": [
-       {"type": "oci-ipvlan", "mode": "l2", "ipam": {"type": "oci-ipam"}},
-       {"type": "oci-ptp", "containerInterface": "ptp-veth0", "mtu": 9000},
-       {"type": "cilium-cni", "chaining-mode": "generic-veth"}
-     ]
-   }
+mode. When ``cni.chainingTarget=oci`` is set, the Cilium agent discovers the
+existing OCI conflist named ``"oci"`` on each node, merges itself into the
+plugin array, and writes the result to ``/etc/cni/net.d/05-cilium.conflist``.
+The original ``10-oci.conflist`` is not modified — checking that file will not
+show the ``cilium-cni`` entry. Because ``05-cilium.conflist`` sorts before
+``10-oci.conflist``, the kubelet picks it up automatically for all new pods.
+No manual CNI ConfigMap is required.
 
 Prerequisites
 =============
 
 - OKE cluster with VCN-Native Pod Networking enabled (not Flannel)
-- Oracle Linux 8+ with kernel 5.15 UEK (standard OKE managed node images)
 - ``kubectl`` configured and pointing at the cluster
 - Helm v3+
 

--- a/Documentation/installation/cni-chaining-oracle-oke.rst
+++ b/Documentation/installation/cni-chaining-oracle-oke.rst
@@ -1,0 +1,130 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+.. _chaining_oracle_oke:
+
+*******************************************************
+Oracle Kubernetes Engine (OKE) VCN-Native Pod Networking
+*******************************************************
+
+This guide explains how to set up Cilium on top of Oracle Kubernetes Engine
+(OKE) with VCN-Native Pod Networking. In this hybrid mode, Oracle's CNI stack
+is responsible for setting up the virtual network devices and for IP address
+management (IPAM) from the VCN subnet. After the initial networking is set up
+for a given pod, the Cilium CNI plugin attaches eBPF programs to enforce
+network policies, perform load-balancing, and provide visibility.
+
+VCN-Native Pod Networking is Oracle's recommended production CNI mode for OKE.
+It assigns pod IPs directly from the VCN subnet, making pods natively routable
+without an overlay. This is the Oracle equivalent of AWS VPC CNI or Azure CNI.
+
+.. include:: cni-chaining-limitations.rst
+
+How it works
+============
+
+The OKE CNI stack runs two plugins in sequence:
+
+- **oci-ipvlan**: allocates a pod IP from the VCN subnet via OCI IPAM and
+  manages VNIC attachment on the underlying compute instance
+- **oci-ptp**: creates a veth pair between the pod network namespace and the host
+
+Despite the ``oci-ipvlan`` plugin name, the actual pod-facing interface is a
+standard veth pair. Pods receive a VCN-native IP, the host holds a per-pod
+veth peer, and routing uses a proxy-ARP gateway at ``169.254.1.1``. This model
+is functionally identical to AWS VPC CNI.
+
+Cilium runs as the third plugin in the chain via the ``generic-veth`` chaining
+mode. When ``cni.chainingTarget=oci`` is set, the Cilium agent automatically
+discovers the existing OCI conflist named ``"oci"`` on each node and injects
+itself at the end of the plugin array. No manual CNI ConfigMap is required.
+
+The final conflist on each node looks like:
+
+.. code-block:: json
+
+   {
+     "name": "oci",
+     "cniVersion": "0.3.1",
+     "plugins": [
+       {"type": "oci-ipvlan", "mode": "l2", "ipam": {"type": "oci-ipam"}},
+       {"type": "oci-ptp", "containerInterface": "ptp-veth0", "mtu": 9000},
+       {"type": "cilium-cni", "chaining-mode": "generic-veth"}
+     ]
+   }
+
+Prerequisites
+=============
+
+- OKE cluster with VCN-Native Pod Networking enabled (not Flannel)
+- Oracle Linux 8+ with kernel 5.15 UEK (standard OKE managed node images)
+- ``kubectl`` configured and pointing at the cluster
+- Helm v3+
+
+Setting up Cilium
+=================
+
+.. include:: k8s-install-download-release.rst
+
+Deploy Cilium via Helm:
+
+.. cilium-helm-install::
+   :namespace: kube-system
+   :set: cni.chainingTarget=oci
+         cni.exclusive=false
+         routingMode=native
+         enableIPv4Masquerade=false
+         kubeProxyReplacement=false
+         ipam.mode=cluster-pool
+         ipam.operator.clusterPoolIPv4PodCIDRList=100.64.0.0/16
+
+Setting ``cni.chainingTarget=oci`` tells the Cilium agent to find the existing
+OCI CNI conflist and inject itself automatically. Tunneling is disabled because
+pod IPs are directly routable within the VCN. Masquerading is disabled because
+OCI handles routing at the VCN level. ``cni.exclusive=false`` ensures Cilium
+does not take ownership of the CNI config directory, leaving OKE's
+``vcn-native-ip-cni`` DaemonSet in control.
+
+.. note::
+
+   The ``ipam.operator.clusterPoolIPv4PodCIDRList`` is set to the RFC 6598
+   CGNAT range ``100.64.0.0/16``. This does not conflict with VCN subnets and
+   is used by Cilium for internal purposes only. Actual pod IPs are always
+   assigned by OCI IPAM from the VCN subnet.
+
+.. note::
+
+   OKE runs ``kube-proxy`` by default. The ``kubeProxyReplacement=false`` flag
+   leaves it in place. If you want Cilium to replace kube-proxy, follow the
+   standard :ref:`kubeproxy-free` guide after the chaining setup is stable.
+
+Restart existing pods
+=====================
+
+The new CNI chaining configuration will not apply to pods that were already
+running before Cilium was installed. Those pods remain reachable and Cilium
+will load-balance to them, but policy enforcement will not apply until they are
+restarted.
+
+Use the following to identify pods that need restarting:
+
+.. code-block:: bash
+
+   for ns in $(kubectl get ns -o jsonpath='{.items[*].metadata.name}'); do
+        ceps=$(kubectl -n "${ns}" get cep \
+            -o jsonpath='{.items[*].metadata.name}')
+        pods=$(kubectl -n "${ns}" get pod \
+            -o custom-columns=NAME:.metadata.name,NETWORK:.spec.hostNetwork \
+            | grep -E '\s(<none>|false)' | awk '{print $1}' | tr '\n' ' ')
+        ncep=$(echo "${pods} ${ceps}" | tr ' ' '\n' | sort | uniq -u | paste -s -d ' ' -)
+        for pod in $(echo $ncep); do
+          echo "${ns}/${pod}";
+        done
+   done
+
+.. include:: k8s-install-validate.rst
+
+.. include:: next-steps.rst

--- a/Documentation/installation/cni-chaining-oracle-oke.rst
+++ b/Documentation/installation/cni-chaining-oracle-oke.rst
@@ -6,9 +6,9 @@
 
 .. _chaining_oracle_oke:
 
-*******************************************************
+********************************************************
 Oracle Kubernetes Engine (OKE) VCN-Native Pod Networking
-*******************************************************
+********************************************************
 
 This guide explains how to set up Cilium on top of Oracle Kubernetes Engine
 (OKE) with VCN-Native Pod Networking. In this hybrid mode, Oracle's CNI stack

--- a/Documentation/installation/cni-chaining.rst
+++ b/Documentation/installation/cni-chaining.rst
@@ -25,5 +25,6 @@ visibility, policy enforcement and other advanced features.
    cni-chaining-azure-cni
    cni-chaining-calico
    cni-chaining-generic-veth
+   cni-chaining-oracle-oke
    cni-chaining-portmap
    cni-chaining-weave

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -1,5 +1,6 @@
 AArch
 AKS
+ARP
 Alemayhu
 Alibaba
 Aquantia
@@ -139,6 +140,7 @@ Triaging
 Twilio
 Uncompress
 Uncordon
+VCN
 VM
 VMSS
 VMs
@@ -270,6 +272,7 @@ configMapKey
 configSources
 configmap
 configs
+conflist
 conntrack
 conntrackGCInterval
 containerd


### PR DESCRIPTION
Add installation guide covering how to run Cilium in chaining mode on OKE with VCN-Native Pod Networking using `cni.chainingTarget=oci`. Cilium auto-discovers the existing oci conflist and injects itself via generic-veth without requiring a custom CNI ConfigMap.

Tested on OKE with Oracle Linux 8.10, kernel 5.15.0 UEK, Kubernetes 1.36.0, Cilium 1.19.4.

## Checklist

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title, description and a `Fixes: #XXX` line if the commit addresses a particular GitHub issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] AI Influence Level statement below.

Fixes: #46107

```release-note
Added documentation for running Cilium in CNI chaining mode on Oracle Kubernetes Engine (OKE) with VCN-Native Pod Networking.
```

This document was formalized with AI assistance (AIL:3). The content, helm commands, architecture explanation, and all steps were written and tested personally on a live OKE cluster. I verified each step end to end before opening this PR.