### PR TITLE
network driver: add networkdriverconfig cell to operator

### DIFF
--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -49,6 +49,7 @@ import (
 	"github.com/cilium/cilium/operator/pkg/kvstore/locksweeper"
 	"github.com/cilium/cilium/operator/pkg/kvstore/nodesgc"
 	"github.com/cilium/cilium/operator/pkg/lbipam"
+	networkdriverconfig "github.com/cilium/cilium/operator/pkg/networkdriver/config"
 	networkdriveripam "github.com/cilium/cilium/operator/pkg/networkdriver/ipam"
 	"github.com/cilium/cilium/operator/pkg/networkpolicy"
 	"github.com/cilium/cilium/operator/pkg/nodeipam"
@@ -368,6 +369,9 @@ var (
 
 		// Provide Multi Pool IPAM for DRA resources managed by the Cilium Network Driver
 		networkdriveripam.Cell,
+
+		// CiliumNetworkDriverClusterConfig handling
+		networkdriverconfig.Cell,
 	}
 
 	binaryName = filepath.Base(os.Args[0])


### PR DESCRIPTION
cell was missing. because of that, the operator
does not create the node configs based
on cluster configs.

fix it by adding the networkdriverconfig cell

```release-note
network driver: add networkdriverconfig to the operator
```
