### PR TITLE
multipool: Fix retries for CiliumNode Get errors

### DIFF
--- a/operator/pkg/ipam/allocator/multipool/node_handler.go
+++ b/operator/pkg/ipam/allocator/multipool/node_handler.go
@@ -129,10 +129,11 @@ func (n *NodeHandler) createUpsertController(resource *v2.CiliumNode) {
 			// If a previous run of the controller failed due to a conflict,
 			// we need to re-fetch the node to make sure we have the latest version.
 			if refetchNode {
-				resource, controllerErr = n.cnClient.Get(ctx, resource.Name, metav1.GetOptions{})
-				if controllerErr != nil {
-					return controllerErr
+				updResource, err := n.cnClient.Get(ctx, resource.Name, metav1.GetOptions{})
+				if err != nil {
+					return err
 				}
+				resource = updResource
 				refetchNode = false
 			}
 

--- a/operator/pkg/ipam/allocator/multipool/node_handler_test.go
+++ b/operator/pkg/ipam/allocator/multipool/node_handler_test.go
@@ -7,20 +7,25 @@ import (
 	"context"
 	"errors"
 	"net/netip"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
+	k8sTesting "k8s.io/client-go/testing"
 
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	ciliumFake "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/fake"
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
@@ -486,4 +491,159 @@ func TestOrphanCIDRsReleased(t *testing.T) {
 	}
 
 	nh.Stop()
+}
+
+func TestNodeHandlerRetries(t *testing.T) {
+	t.Cleanup(func() { testutils.GoleakVerifyNone(t) })
+
+	t.Run("get and update", func(t *testing.T) {
+		backend := NewPoolAllocator(hivetest.Logger(t), true, false)
+		assert.NoError(t, backend.UpsertPool("default", []string{"10.0.0.0/8"}, 24, nil, 0))
+
+		node := &v2.CiliumNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-status",
+			},
+			Spec: v2.NodeSpec{
+				IPAM: ipamTypes.IPAMSpec{
+					Pools: ipamTypes.IPAMPoolSpec{
+						Requested: []ipamTypes.IPAMPoolRequest{
+							{
+								Pool:   "default",
+								Needed: ipamTypes.IPAMPoolDemand{IPv4Addrs: 16},
+							},
+						},
+					},
+				},
+			},
+			Status: v2.NodeStatus{
+				IPAM: ipamTypes.IPAMStatus{
+					OperatorStatus: ipamTypes.OperatorStatus{Error: "stale allocation error"},
+				},
+			},
+		}
+
+		clientset := ciliumFake.NewSimpleClientset(node.DeepCopy())
+
+		var (
+			gets    atomic.Int32
+			updates atomic.Int32
+		)
+		clientset.PrependReactor("get", "ciliumnodes", func(action k8sTesting.Action) (bool, runtime.Object, error) {
+			gets.Add(1)
+			if gets.Load() == 1 {
+				return true, nil, errors.New("transient get failure")
+			}
+			return false, nil, nil
+		})
+		clientset.PrependReactor("update", "ciliumnodes", func(action k8sTesting.Action) (bool, runtime.Object, error) {
+			if action.GetSubresource() != "" {
+				return false, nil, nil
+			}
+
+			updates.Add(1)
+			if updates.Load() == 1 {
+				return true, nil, k8sErrors.NewConflict(
+					schema.GroupResource{
+						Group:    v2.CustomResourceDefinitionGroup,
+						Resource: v2.CNPluralName,
+					},
+					node.Name,
+					errors.New("update refused by unit test"),
+				)
+			}
+			return false, nil, nil
+		})
+
+		nh := NewNodeHandler("test", hivetest.Logger(t), backend, clientset.CiliumV2().CiliumNodes(), GetIPAMPools)
+		t.Cleanup(nh.Stop)
+		nh.controllerErrorRetryBaseDuration = time.Millisecond
+
+		nh.Upsert(node)
+		nh.Resync(t.Context(), time.Time{})
+
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			// wait for controller to retry after:
+			// - transient get failure
+			// - update conflict
+			assert.GreaterOrEqual(c, gets.Load(), int32(2))
+			assert.GreaterOrEqual(c, updates.Load(), int32(2))
+		}, 5*time.Second, 10*time.Millisecond)
+
+		updatedNode, err := clientset.CiliumV2().CiliumNodes().Get(t.Context(), node.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Len(t, updatedNode.Spec.IPAM.Pools.Allocated, 1)
+		require.Equal(t, "default", updatedNode.Spec.IPAM.Pools.Allocated[0].Pool)
+	})
+
+	t.Run("updatestatus", func(t *testing.T) {
+		backend := NewPoolAllocator(hivetest.Logger(t), true, false)
+		assert.NoError(t, backend.UpsertPool("default", []string{"10.0.0.0/8"}, 24, nil, 0))
+
+		node := &v2.CiliumNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-status",
+			},
+			Spec: v2.NodeSpec{
+				IPAM: ipamTypes.IPAMSpec{
+					Pools: ipamTypes.IPAMPoolSpec{
+						Allocated: []ipamTypes.IPAMPoolAllocation{
+							{
+								Pool:  "default",
+								CIDRs: []ipamTypes.IPAMCIDR{"10.0.0.0/24"},
+							},
+						},
+						Requested: []ipamTypes.IPAMPoolRequest{
+							{
+								Pool:   "default",
+								Needed: ipamTypes.IPAMPoolDemand{IPv4Addrs: 16},
+							},
+						},
+					},
+				},
+			},
+			Status: v2.NodeStatus{
+				IPAM: ipamTypes.IPAMStatus{
+					OperatorStatus: ipamTypes.OperatorStatus{Error: "stale allocation error"},
+				},
+			},
+		}
+
+		clientset := ciliumFake.NewSimpleClientset(node.DeepCopy())
+
+		var updateStatuses atomic.Int32
+		clientset.PrependReactor("update", "ciliumnodes", func(action k8sTesting.Action) (bool, runtime.Object, error) {
+			if action.GetSubresource() != "status" {
+				return false, nil, nil
+			}
+
+			if updateStatuses.Add(1) == 1 {
+				return true, nil, k8sErrors.NewConflict(
+					schema.GroupResource{
+						Group:    v2.CustomResourceDefinitionGroup,
+						Resource: v2.CNPluralName,
+					},
+					node.Name,
+					errors.New("update refused by unit test"),
+				)
+			}
+			return false, nil, nil
+		})
+
+		nh := NewNodeHandler("test", hivetest.Logger(t), backend, clientset.CiliumV2().CiliumNodes(), GetIPAMPools)
+		t.Cleanup(nh.Stop)
+		nh.controllerErrorRetryBaseDuration = time.Millisecond
+
+		nh.Upsert(node)
+		nh.Resync(t.Context(), time.Time{})
+
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			// wait for controller to retry after update conflict on status update
+			assert.GreaterOrEqual(c, updateStatuses.Load(), int32(2))
+		}, 5*time.Second, 10*time.Millisecond)
+
+		updatedNode, err := clientset.CiliumV2().CiliumNodes().Get(t.Context(), node.Name, metav1.GetOptions{})
+		assert.NoError(t, err)
+		assert.Empty(t, updatedNode.Status.IPAM.OperatorStatus.Error)
+	})
 }


### PR DESCRIPTION
In case of a transient error when calling Get on CiliumNode client, the resource is overwritten with a nil value. At the next execution of the controller, the Get is retried with a resource.Name that is equal to an empty string. Therefore, the Get cannot be successful until the next update of the controller.

Fix that by overwriting resource only when Get is successful and add a unit test to verify the controller behavior in case of client errors or conflicts.
