### PR TITLE
Fix/unmanaged pods stale cache restart

### DIFF
--- a/operator/unmanagedpods/controller.go
+++ b/operator/unmanagedpods/controller.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cilium/hive/cell"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/operator/watchers"
@@ -173,6 +174,41 @@ func (c *unmanagedPodsController) enableUnmanagedController() {
 										)
 										continue
 									}
+								}
+
+								// Verify the pod is still Running via a live API call
+								// before deleting it. The UnmanagedPodStore is eventually
+								// consistent — it can still contain a pod that has already
+								// transitioned to Succeeded or Failed, or is being terminated.
+								currentPod, err := c.clientset.CoreV1().Pods(pod.Namespace).Get(
+									ctx, pod.Name, metav1.GetOptions{},
+								)
+								if err != nil {
+									if ctx.Err() != nil {
+										// Context cancelled — operator is shutting down, stop the loop.
+										return ctx.Err()
+									}
+									c.logger.WarnContext(ctx,
+										"Unable to verify pod phase before restart, skipping",
+										logfields.Error, err,
+										logfields.K8sPodName, podID,
+									)
+									continue
+								}
+								if currentPod.Status.Phase != corev1.PodRunning {
+									c.logger.DebugContext(ctx,
+										"Skipping pod restart, pod is no longer Running",
+										logfields.K8sPodName, podID,
+										"phase", currentPod.Status.Phase,
+									)
+									continue
+								}
+								if currentPod.DeletionTimestamp != nil {
+									c.logger.DebugContext(ctx,
+										"Skipping pod restart, pod is already being terminated",
+										logfields.K8sPodName, podID,
+									)
+									continue
 								}
 
 								c.logger.InfoContext(ctx,


### PR DESCRIPTION
## Description

The `restart-unmanaged-pods` controller uses `UnmanagedPodStore` to find Running pods without a `CiliumEndpoint` and restarts them. However, `UnmanagedPodStore` is an eventually-consistent k8s informer cache a pod that has already transitioned to `Succeeded` or `Failed` may still appear in the store while its `CiliumEndpoint` has already been removed. This causes the controller to incorrectly delete a completed pod.

Additionally, a pod in the `Terminating` state has `phase=Running` but a non-nil `DeletionTimestamp` — the existing code would attempt to delete an already-terminating pod unnecessarily.

This change adds a live API call to verify the pod is still `Running` and not already being terminated before issuing a delete. The context error is checked separately to distinguish between a shutting-down operator (stop the loop) and a transient API error (skip this pod, retry next interval).

---

- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title, description and a `Fixes: #XXX` line if the commit addresses a particular GitHub issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Write a short paragraph that states whether you used machine learning models (including LLMs and other generative AI), and indicate the rating using [AI Influence Level](https://danielmiessler.com/blog/ai-influence-level-ail).

**AI disclosure:** This PR was prepared with AIL:3. I personally reviewed each line of the submission prior to opening this PR.

Fixes: #43353

```release-note
operator: fix restart-unmanaged-pods controller incorrectly deleting Succeeded/Failed pods
```
