### PR TITLE
Clarify AI policy guidance in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,11 +9,10 @@ Please ensure your pull request adheres to the following guidelines:
       please add the commit author[s] as reviewer[s] to this issue.
 - [ ] All commits are signed off. See the section [Developer’s Certificate of Origin]
 - [ ] Provide a title or release-note blurb suitable for the release notes.
-- [ ] Write a short paragraph that states whether you used machine learning models
-      (including LLMs and other generative AI), and indicate the rating using
+- [ ] Disclose use of machine learning models (including LLMs and other generative AI)
+      in accordance with the [Cilium AI Policy], and indicate the rating using
       [AI Influence Level].
-      Example: "This PR was prepared with AIL:3. I personally reviewed each line
-      of the submission prior to opening this PR."
+      Example: "This PR was prepared with AIL:3. I personally checked X."
 - [ ] Thanks for contributing!
 
 <!-- Description of change -->
@@ -25,5 +24,6 @@ Fixes: #issue-number
 ```
 
 [AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
+[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
 [Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
 [Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,17 @@
 Please ensure your pull request adheres to the following guidelines:
 
-- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
+- [ ] For first time contributors, read [Submitting a pull request]
 - [ ] All code is covered by unit and/or runtime tests where feasible.
 - [ ] All commits contain a well written commit description including a title,
       description and a `Fixes: #XXX` line if the commit addresses a particular
       GitHub issue.
 - [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
       please add the commit author[s] as reviewer[s] to this issue.
-- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
+- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin]
 - [ ] Provide a title or release-note blurb suitable for the release notes.
 - [ ] Write a short paragraph that states whether you used machine learning models
       (including LLMs and other generative AI), and indicate the rating using
-      [AI Influence Level](https://danielmiessler.com/blog/ai-influence-level-ail).
+      [AI Influence Level].
       Example: "This PR was prepared with AIL:3. I personally reviewed each line
       of the submission prior to opening this PR."
 - [ ] Thanks for contributing!
@@ -23,3 +23,7 @@ Fixes: #issue-number
 ```release-note
 <!-- Enter the release note text here or remove this release-note section from your PR description. Do NOT put an "empty" release note here -->
 ```
+
+[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
+[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
+[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request


### PR DESCRIPTION
Since we added AIL to the template, we ratified an organization-wide policy.
Add a link to it in the PR template. Furthermore, while in general
contributors have adopted this new step very well, occasionally
contributors will exactly copy the example. This reveals when
contributors did not edit the template, but it doesn't inform reviewers
whether the contributor actually understands the policy or has
personally reviewed the code. Therefore, simplify to ask the contributor
to state what they have checked.

