### PR TITLE
gateway-api: fix GatewayClass field index

### DIFF
--- a/operator/pkg/gateway-api/gatewayclass.go
+++ b/operator/pkg/gateway-api/gatewayclass.go
@@ -72,6 +72,10 @@ func referencedConfig(rawObj client.Object) []string {
 		return nil
 	}
 
+	if string(gwc.Spec.ControllerName) != helpers.CiliumDefaultControllerName {
+		return nil
+	}
+
 	if !isParameterRefSupported(gwc.Spec.ParametersRef) {
 		return nil
 	}

--- a/operator/pkg/gateway-api/gatewayclass.go
+++ b/operator/pkg/gateway-api/gatewayclass.go
@@ -16,13 +16,10 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/predicates"
 	watchhandlers "github.com/cilium/cilium/operator/pkg/gateway-api/watch-handlers"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
-)
-
-const (
-	gatewayClassConfigMapIndexName = ".spec.parametersRef"
 )
 
 // gatewayClassReconciler reconciles a GatewayClass object
@@ -44,7 +41,7 @@ func newGatewayClassReconciler(mgr ctrl.Manager, logger *slog.Logger) *gatewayCl
 // SetupWithManager sets up the controller with the Manager.
 func (r *gatewayClassReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	for indexName, indexerFunc := range map[string]client.IndexerFunc{
-		gatewayClassConfigMapIndexName: referencedConfig,
+		indexers.GatewayClassCiliumGatewayClassConfigsIndex: referencedConfig,
 	} {
 		if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.GatewayClass{}, indexName, indexerFunc); err != nil {
 			return fmt.Errorf("failed to setup field indexer %q: %w", indexName, err)

--- a/operator/pkg/gateway-api/gatewayclass_test.go
+++ b/operator/pkg/gateway-api/gatewayclass_test.go
@@ -7,9 +7,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 )
 
@@ -47,6 +51,74 @@ func Test_matchesControllerName(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.expected, matchesControllerName("foo")(tc.object))
+		})
+	}
+}
+
+func Test_referencedConfig(t *testing.T) {
+	testCases := []struct {
+		name     string
+		object   client.Object
+		expected []string
+	}{
+		{
+			name: "cilium GatewayClass with supported parametersRef",
+			object: &gatewayv1.GatewayClass{
+				Spec: gatewayv1.GatewayClassSpec{
+					ControllerName: helpers.CiliumDefaultControllerName,
+					ParametersRef: &gatewayv1.ParametersReference{
+						Group:     v2alpha1.CustomResourceDefinitionGroup,
+						Kind:      v2alpha1.CGCCKindDefinition,
+						Name:      "dummy-gateway-class-config",
+						Namespace: ptr.To(gatewayv1.Namespace("default")),
+					},
+				},
+			},
+			expected: []string{types.NamespacedName{
+				Namespace: "default",
+				Name:      "dummy-gateway-class-config",
+			}.String()},
+		},
+		{
+			name: "non-Cilium GatewayClass with supported parametersRef",
+			object: &gatewayv1.GatewayClass{
+				Spec: gatewayv1.GatewayClassSpec{
+					ControllerName: "not-cilium-controller-name",
+					ParametersRef: &gatewayv1.ParametersReference{
+						Group:     v2alpha1.CustomResourceDefinitionGroup,
+						Kind:      v2alpha1.CGCCKindDefinition,
+						Name:      "dummy-gateway-class-config",
+						Namespace: ptr.To(gatewayv1.Namespace("default")),
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "cilium GatewayClass with unsupported parametersRef",
+			object: &gatewayv1.GatewayClass{
+				Spec: gatewayv1.GatewayClassSpec{
+					ControllerName: helpers.CiliumDefaultControllerName,
+					ParametersRef: &gatewayv1.ParametersReference{
+						Group:     "v1",
+						Kind:      "ConfigMap",
+						Name:      "dummy-cm",
+						Namespace: ptr.To(gatewayv1.Namespace("default")),
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name:     "not a GatewayClass",
+			object:   &corev1.Service{},
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, referencedConfig(tc.object))
 		})
 	}
 }

--- a/operator/pkg/gateway-api/indexers/indexnames.go
+++ b/operator/pkg/gateway-api/indexers/indexnames.go
@@ -41,7 +41,6 @@ const (
 	// Service as a parent.
 	GammaGRPCRouteParentRefsIndex = "gammaGRPCRouteParentRefs"
 
-	// Indexes GatewayClassCiliumGatewayClassConfigsIndex indexes GatewayClass by the CiliumGatewayClassConfig
-	// that it refers to.
+	// Indexes GatewayClass objects by the CiliumGatewayClassConfig they reference.
 	GatewayClassCiliumGatewayClassConfigsIndex = "gatewayClassCiliumGatewayClassConfigsIndex"
 )


### PR DESCRIPTION
This fixes GatewayClass reconciliation when a referenced CiliumGatewayClassConfig changes.

The controller was registering one index name but looking up another, so config updates were not finding the GatewayClasses that referenced them. This PR makes those names match, and also limits that lookup to GatewayClasses owned by Cilium.