### PR TITLE
docs: drop stale nodeinit from Azure CNI chaining guide

### DIFF
--- a/Documentation/installation/cni-chaining-azure-cni.rst
+++ b/Documentation/installation/cni-chaining-azure-cni.rst
@@ -93,14 +93,10 @@ Deploy Cilium release via Helm:
    :set: cni.chainingMode=generic-veth
          cni.customConf=true
          cni.exclusive=false
-         nodeinit.enabled=true
          cni.configMap=cni-configuration
          routingMode=native
          enableIPv4Masquerade=false
          endpointRoutes.enabled=true
-
-This will create both the main cilium daemonset, as well as the cilium-node-init daemonset, which handles tasks like mounting the eBPF filesystem and updating the
-existing Azure CNI plugin to run in 'transparent' mode.
 
 .. include:: k8s-install-restart-pods.rst
 


### PR DESCRIPTION
The legacy Azure CNI chaining install instructions set `nodeinit.enabled=true` and include a paragraph claiming that cilium-node-init "handles tasks like mounting the eBPF filesystem and updating the existing Azure CNI plugin to run in 'transparent' mode".

Neither claim is accurate against the current chart:

  - bpffs is mounted by cilium-agent's `mount-bpf-fs` init container in templates/cilium-agent/daemonset.yaml; nodeinit is not involved.
  - Azure CNI "transparent" mode is configured by the user-supplied `cni-configuration` ConfigMap (Step 1 of this same page); nodeinit does not touch the Azure CNI config. The nodeinit script (install/kubernetes/cilium/files/nodeinit/startup.bash) has no Azure-specific or chaining-specific branches at all.

With every node-init action knob (removeCbrBridge, reconfigureKubelet, gke.enabled, waitForCloudInit, startup.{pre,post}Script) at its default on AKS, the rendered script collapses to a few `ip link/route/addr` debug prints plus `date > /tmp/cilium-bootstrap.d/cilium-bootstrap-time`. That timestamp file is only consumed by the `wait-for-node-init` init container on cilium-agent, which itself only exists when `nodeinit.enabled=true` resulting in a self-handshake that synchronizes nothing.

Remove `nodeinit.enabled=true` from the Helm flags and drop the misleading paragraph. cilium-agent's own init containers handle bpffs and CNI conf installation, and the user's ConfigMap handles Azure CNI mode.

This mirrors the same reasoning behind dropping AKS from `needsNodeInit` in cilium-cli: https://github.com/cilium/cilium/pull/46105


```release-note
docs: drop stale nodeinit from Azure CNI chaining guide
```
