### PR TITLE
azure: Skip listing NIC of empty VMSSs

### DIFF
--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -219,6 +219,13 @@ func (c *Client) listVirtualMachineScaleSetsNetworkInterfaces(ctx context.Contex
 	}
 
 	for _, virtualMachineScaleSet := range virtualMachineScaleSets {
+		// Skip scale sets known to be empty: AKS node pools scaled to zero
+		// surface as 0-capacity here and would otherwise cost an ARM call
+		// that returns 404.
+		if virtualMachineScaleSet.SKU != nil && virtualMachineScaleSet.SKU.Capacity != nil && *virtualMachineScaleSet.SKU.Capacity == 0 {
+			continue
+		}
+
 		virtualMachineScaleSetNetworkInterfaces, err := c.listVirtualMachineScaleSetNetworkInterfaces(ctx, *virtualMachineScaleSet.Name)
 		if err != nil {
 			// For scale set created by AKS node group (otherwise it will return an empty list) without any instances API will return not found. Then it can be skipped.


### PR DESCRIPTION
Since Azure does not expose a single API to list all network interfaces for VMSS instances, the way we currently list them is we first make an API call to list all VMSSs, then for each VMSS, we make a call to list its network interfaces.

The thing is that if a VMSS has zero instances (and so zero network interfaces), we still make that call to list VMSS network interfaces. 

Since the initial call that listed all VMSS also returned the number of instances in each VMSS, we can skip empty ones to save unnecessary API calls.

Not only is this good for API call rate limit buckets consumption, but since each VMSS listNetworkInterfaces calls are done serially, this can also significantly speed up the overall instance sync.

### Examples

Both measurements were done on the same cluster with the same number of VMSS. We can see that in this case, skipping empty ones speeds up the full resync from ~12s down to ~5s

Before:
<img width="1455" height="303" alt="image" src="https://github.com/user-attachments/assets/0b60fd05-1e5c-4187-8bf0-2fa6dfd05cac" />
<img width="1495" height="695" alt="image" src="https://github.com/user-attachments/assets/78bbad90-92ec-45f5-b2d9-344f11490e17" />


After:
<img width="1455" height="303" alt="image" src="https://github.com/user-attachments/assets/2086b39c-1743-464d-a895-7d3119162da5" />
<img width="1473" height="629" alt="image" src="https://github.com/user-attachments/assets/3640d953-5815-4ea4-84bf-5bdd3330c54c" />

