### PR TITLE
Deprecate Identity.StringID & Refactor callers to use String() instead

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2321,7 +2321,7 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context) (regenTriggered bo
 	// identity is new, then this will start updating the policy for other
 	// co-located endpoints without having to wait for that RTT.
 	//
-	// This must happen before triggering regeration, as this ID must be
+	// This must happen before triggering regeneration, as this ID must be
 	// plumbed in to the SelectorCache in order for policy to correctly apply
 	// to this endpoint. Fortunately AllocateIdentity() will synchronously
 	// update the SelectorCache, so there are no problems here.
@@ -2398,7 +2398,7 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context) (regenTriggered bo
 
 	scopedLog.Debug(
 		"Assigned new identity to endpoint",
-		logfields.IdentityNew, allocatedIdentity.StringID(),
+		logfields.IdentityNew, allocatedIdentity,
 	)
 
 	identityToRelease := e.SetIdentity(allocatedIdentity)

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -1166,7 +1166,7 @@ func (e *Endpoint) runIPIdentitySync(endpointIP netip.Addr) {
 func (e *Endpoint) SetIdentity(identity *identityPkg.Identity) (identityToRelease *identityPkg.Identity) {
 	oldIdentity := "no identity"
 	if e.SecurityIdentity != nil {
-		oldIdentity = e.SecurityIdentity.StringID()
+		oldIdentity = e.SecurityIdentity.String()
 	}
 
 	// Current security identity for endpoint is its old identity - delete its
@@ -1199,16 +1199,16 @@ func (e *Endpoint) SetIdentity(identity *identityPkg.Identity) (identityToReleas
 		e.runIPIdentitySync(e.IPv6)
 	}
 
-	if oldIdentity != identity.StringID() {
+	if oldIdentity != identity.String() {
 		e.getLogger().Info(
 			"Identity of endpoint changed",
-			logfields.IdentityNew, identity.StringID(),
+			logfields.IdentityNew, identity,
 			logfields.IdentityOld, oldIdentity,
 			logfields.IdentityLabels, map[string]labels.Label(identity.Labels),
 		)
 	}
 	e.UpdateLogger(map[string]any{
-		logfields.Identity: identity.StringID(),
+		logfields.Identity: identity.String(),
 	})
 	return identityToRelease
 }

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -101,11 +101,6 @@ func (id *Identity) Sanitize() {
 	}
 }
 
-// StringID returns the identity identifier as string
-func (id *Identity) StringID() string {
-	return id.ID.StringID()
-}
-
 // String returns the identity identifier as string
 func (id *Identity) String() string {
 	return id.ID.StringID()


### PR DESCRIPTION
### Context & Problem
The StringID function had the same implementation as the String function in `identity.go`. This only causes potential unnecessary confusion and bugs. This came up during the discussion of this [PR](https://github.com/cilium/cilium/pull/46012). @joestringer suggested that I could create a follow-up PR which removes the StringID function entirely and refactors the callers.

### Proposed Solution
Instead of immediately removing the StringID function I propose to deprecate it first and refactor the callers to use the String function instead. Reason being is that there could be repos which import cilium and use the StringID function since it is part of the public API of that package.

@joestringer if you think that this is too cautious I can also just remove the StringID function as well.
I did not use LLMs in order to create this PR.