### PR TITLE
bpf: don't drop non-first fragments on map miss

### DIFF
--- a/api/v1/flow/README.md
+++ b/api/v1/flow/README.md
@@ -1181,6 +1181,7 @@ here.
 | DROP_EP_NOT_READY | 203 | A BPF program wants to tail call some endpoint&#39;s policy program in cilium_call_policy, but the program is not available. |
 | DROP_NO_EGRESS_IP | 204 | An Egress Gateway node matched a packet against an Egress Gateway policy that didn&#39;t select a valid Egress IP. |
 | DROP_PUNT_PROXY | 205 | Punt packet to a user space proxy. |
+| DROP_FRAG_NEEDS_STACK | 206 | Out-of-order IP fragment: tracking map miss; packet was passed to the kernel for reassembly instead of being dropped. |
 
 
 

--- a/api/v1/flow/flow.pb.go
+++ b/api/v1/flow/flow.pb.go
@@ -652,6 +652,9 @@ const (
 	DropReason_DROP_NO_EGRESS_IP DropReason = 204
 	// Punt packet to a user space proxy.
 	DropReason_DROP_PUNT_PROXY DropReason = 205
+	// Out-of-order IP fragment: tracking map miss; packet was passed to the
+	// kernel for reassembly instead of being dropped.
+	DropReason_DROP_FRAG_NEEDS_STACK DropReason = 206
 )
 
 // Enum value maps for DropReason.
@@ -733,6 +736,7 @@ var (
 		203: "DROP_EP_NOT_READY",
 		204: "DROP_NO_EGRESS_IP",
 		205: "DROP_PUNT_PROXY",
+		206: "DROP_FRAG_NEEDS_STACK",
 	}
 	DropReason_value = map[string]int32{
 		"DROP_REASON_UNKNOWN":                                   0,
@@ -811,6 +815,7 @@ var (
 		"DROP_EP_NOT_READY":                                     203,
 		"DROP_NO_EGRESS_IP":                                     204,
 		"DROP_PUNT_PROXY":                                       205,
+		"DROP_FRAG_NEEDS_STACK":                                 206,
 	}
 )
 
@@ -5916,7 +5921,7 @@ const file_flow_flow_proto_rawDesc = "" +
 	"\n" +
 	"\x06TRACED\x10\x06\x12\x0e\n" +
 	"\n" +
-	"TRANSLATED\x10\a*\xc5\x11\n" +
+	"TRANSLATED\x10\a*\xe1\x11\n" +
 	"\n" +
 	"DropReason\x12\x17\n" +
 	"\x13DROP_REASON_UNKNOWN\x10\x00\x12\x1b\n" +
@@ -5997,7 +6002,8 @@ const file_flow_flow_proto_rawDesc = "" +
 	"\x13DROP_HOST_NOT_READY\x10\xca\x01\x12\x16\n" +
 	"\x11DROP_EP_NOT_READY\x10\xcb\x01\x12\x16\n" +
 	"\x11DROP_NO_EGRESS_IP\x10\xcc\x01\x12\x14\n" +
-	"\x0fDROP_PUNT_PROXY\x10\xcd\x01*J\n" +
+	"\x0fDROP_PUNT_PROXY\x10\xcd\x01\x12\x1a\n" +
+	"\x15DROP_FRAG_NEEDS_STACK\x10\xce\x01*J\n" +
 	"\x10TrafficDirection\x12\x1d\n" +
 	"\x19TRAFFIC_DIRECTION_UNKNOWN\x10\x00\x12\v\n" +
 	"\aINGRESS\x10\x01\x12\n" +

--- a/api/v1/flow/flow.proto
+++ b/api/v1/flow/flow.proto
@@ -524,6 +524,9 @@ enum DropReason {
     DROP_NO_EGRESS_IP = 204;
     // Punt packet to a user space proxy.
     DROP_PUNT_PROXY = 205;
+    // Out-of-order IP fragment: tracking map miss; packet was passed to the
+    // kernel for reassembly instead of being dropped.
+    DROP_FRAG_NEEDS_STACK = 206;
 }
 
 enum TrafficDirection {

--- a/api/v1/observer/observer.pb.go
+++ b/api/v1/observer/observer.pb.go
@@ -211,6 +211,7 @@ const DropReason_DROP_HOST_NOT_READY = flow.DropReason_DROP_HOST_NOT_READY
 const DropReason_DROP_EP_NOT_READY = flow.DropReason_DROP_EP_NOT_READY
 const DropReason_DROP_NO_EGRESS_IP = flow.DropReason_DROP_NO_EGRESS_IP
 const DropReason_DROP_PUNT_PROXY = flow.DropReason_DROP_PUNT_PROXY
+const DropReason_DROP_FRAG_NEEDS_STACK = flow.DropReason_DROP_FRAG_NEEDS_STACK
 
 var DropReason_name = flow.DropReason_name
 var DropReason_value = flow.DropReason_value

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -211,10 +211,9 @@ struct srv6_policy_key6 {
 
 /* Return value to indicate that proxy redirection is required */
 #define POLICY_ACT_PROXY_REDIRECT (1 << 16)
-
 #define NAT_PUNT_TO_STACK	DROP_NAT_NOT_NEEDED
-
 #define NAT_NEEDED		CTX_ACT_OK
+#define FRAG_PUNT_TO_STACK	DROP_FRAG_NEEDS_STACK
 
 /* Cilium metrics reasons for forwarding packets and other stats.
  * If reason is larger than below then this is a drop reason and

--- a/bpf/lib/drop.h
+++ b/bpf/lib/drop.h
@@ -202,21 +202,49 @@ int _send_drop_notify(__u8 file __maybe_unused, __u16 line __maybe_unused,
 })
 
 #define send_drop_notify(ctx, src, dst, dst_id, reason, direction) \
-	_send_drop_notify(__MAGIC_FILE__, __MAGIC_LINE__, ctx, src, dst, dst_id, \
-			  __DROP_REASON(reason), CTX_ACT_DROP, direction)
+	({ \
+		int __r = (int)(reason); \
+		__r == DROP_FRAG_NEEDS_STACK ? CTX_ACT_OK : \
+			_send_drop_notify(__MAGIC_FILE__, __MAGIC_LINE__, \
+					  ctx, src, dst, dst_id, \
+					  __DROP_REASON(__r), CTX_ACT_DROP, direction); \
+	})
 
 #define send_drop_notify_error(ctx, src, reason, direction) \
-	_send_drop_notify(__MAGIC_FILE__, __MAGIC_LINE__, ctx, src, 0, 0, \
-			  __DROP_REASON(reason), CTX_ACT_DROP, direction)
+	({ \
+		int __r = (int)(reason); \
+		__r == DROP_FRAG_NEEDS_STACK ? CTX_ACT_OK : \
+			_send_drop_notify(__MAGIC_FILE__, __MAGIC_LINE__, \
+					  ctx, src, 0, 0, \
+					  __DROP_REASON(__r), CTX_ACT_DROP, direction); \
+	})
 
 #define send_drop_notify_ext(ctx, src, dst, dst_id, reason, ext_err, direction) \
-	_send_drop_notify(__MAGIC_FILE__, __MAGIC_LINE__, ctx, src, dst, dst_id, \
-			  __DROP_REASON_EXT(reason, ext_err), CTX_ACT_DROP, direction)
+	({ \
+		int __r = (int)(reason); \
+		__r == DROP_FRAG_NEEDS_STACK ? CTX_ACT_OK : \
+			_send_drop_notify(__MAGIC_FILE__, __MAGIC_LINE__, \
+					  ctx, src, dst, dst_id, \
+					  __DROP_REASON_EXT(__r, ext_err), \
+					  CTX_ACT_DROP, direction); \
+	})
 
 #define send_drop_notify_error_ext(ctx, src, reason, ext_err, direction) \
-	_send_drop_notify(__MAGIC_FILE__, __MAGIC_LINE__, ctx, src, 0, 0, \
-			  __DROP_REASON_EXT(reason, ext_err), CTX_ACT_DROP, direction)
+	({ \
+		int __r = (int)(reason); \
+		__r == DROP_FRAG_NEEDS_STACK ? CTX_ACT_OK : \
+			_send_drop_notify(__MAGIC_FILE__, __MAGIC_LINE__, \
+					  ctx, src, 0, 0, \
+					  __DROP_REASON_EXT(__r, ext_err), \
+					  CTX_ACT_DROP, direction); \
+	})
 
 #define send_drop_notify_error_with_exitcode_ext(ctx, src, reason, ext_err, exitcode, direction) \
-	_send_drop_notify(__MAGIC_FILE__, __MAGIC_LINE__, ctx, src, 0, 0, \
-			  __DROP_REASON_EXT(reason, ext_err), exitcode, direction)
+	({ \
+		int __r = (int)(reason); \
+		__r == DROP_FRAG_NEEDS_STACK ? CTX_ACT_OK : \
+			_send_drop_notify(__MAGIC_FILE__, __MAGIC_LINE__, \
+					  ctx, src, 0, 0, \
+					  __DROP_REASON_EXT(__r, ext_err), \
+					  exitcode, direction); \
+	})

--- a/bpf/lib/drop_reasons.h
+++ b/bpf/lib/drop_reasons.h
@@ -86,3 +86,4 @@
 #define DROP_EP_NOT_READY	-203
 #define DROP_NO_EGRESS_IP	-204
 #define DROP_PUNT_PROXY		-205 /* Mapped as drop code, though drop not necessary. */
+#define DROP_FRAG_NEEDS_STACK	-206

--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -95,7 +95,7 @@ ipv4_frag_get_l4ports(const struct ipv4_frag_id *frag_id,
 
 	tmp = map_lookup_elem(&cilium_ipv4_frag_datagrams, frag_id);
 	if (!tmp)
-		return DROP_FRAG_NOT_FOUND;
+		return FRAG_PUNT_TO_STACK;
 
 	/* Do not make ports a pointer to map data, copy from map */
 	memcpy(ports, tmp, sizeof(*ports));

--- a/bpf/lib/ipv6.h
+++ b/bpf/lib/ipv6.h
@@ -379,7 +379,7 @@ ipv6_frag_get_l4ports(const struct ipv6_frag_id *frag_id,
 
 	tmp = map_lookup_elem(&cilium_ipv6_frag_datagrams, frag_id);
 	if (!tmp)
-		return DROP_FRAG_NOT_FOUND;
+		return FRAG_PUNT_TO_STACK;
 
 	memcpy(ports, tmp, sizeof(*ports));
 	return 0;


### PR DESCRIPTION
Draft for discussion. Addresses #46100.

## What this changes

In `ipv4_frag_get_l4ports` and `ipv6_frag_get_l4ports`, replace the eager `DROP_FRAG_NOT_FOUND` on map miss with zeroed ports plus a success return. The packet then passes to the kernel, where `ip_defrag` / IPv6 reassembly queue fragments correctly and the reassembled datagram re-enters Cilium policy at the next BPF hook with full L4 ports.

```
bpf/lib/ipv4.h | 7 +++++--
bpf/lib/ipv6.h | 7 +++++--
2 files changed, 10 insertions(+), 4 deletions(-)
```

## Why this is the right shape (or at least worth discussing)

The first-fragment write side is already best-effort, see the existing comment around `map_update_elem` in `ipv4_handle_fragmentation` ("Do not return an error if map update failed, as nothing prevents us to process the current packet normally"). Making the non-first-fragment read side also best-effort restores symmetry.

The reporter's pwru trace in #46100 shows that today's behaviour is non-deterministic: when the timing happens to work, the second fragment finds the entry and passes through, and the kernel ip_defrag does the reassembly correctly (their "Path B"). When timing doesn't work, the BPF program drops eagerly (their "Path A"). After this change, every non-first fragment takes Path B.

## Honest semantic shift

This moves the policy decision for the single misclassified non-first fragment from fail-closed (Cilium drops) to defer-to-kernel-then-Cilium (kernel reassembles, reassembled packet hits Cilium policy at the next interface with correct ports). CT and policy enforcement still happens on the reassembled datagram, just at the next hop rather than on the lone fragment.

`@smagnani96` you're already tagged on the issue, would value your read on whether this semantic is acceptable, or whether you'd prefer a gated config knob, or a different shape entirely (e.g. propagating a `CTX_FRAG_NEEDS_STACK`-style status through the caller chain so the top-level program returns `CTX_ACT_OK` explicitly).

## What I could NOT validate locally

I do not have an OCI-like multi-queue VM with WireGuard node encryption available, so I cannot reproduce the race from the reporter's environment. The patch is small enough that I am confident the BPF verifier accepts it by inspection (just two stack stores and a literal return), but I did not run the existing fragment tests under Little VM Helper since the local toolchain is not set up. CI on this PR will be the first end-to-end test of the change.

Marking draft accordingly.