### PR TITLE
v1.19 Backports 2026-05-25

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -3059,15 +3059,15 @@
    * - :spelling:ignore:`l2podAnnouncements`
      - Configure L2 pod announcements
      - object
-     - ``{"enabled":false,"interface":"eth0"}``
+     - ``{"enabled":false,"interfacePattern":""}``
    * - :spelling:ignore:`l2podAnnouncements.enabled`
      - Enable L2 pod announcements
      - bool
      - ``false``
-   * - :spelling:ignore:`l2podAnnouncements.interface`
-     - Interface used for sending Gratuitous ARP pod announcements
+   * - :spelling:ignore:`l2podAnnouncements.interfacePattern`
+     - A regular expression matching interfaces used for sending Gratuitous ARP pod announcements
      - string
-     - ``"eth0"``
+     - ``""``
    * - :spelling:ignore:`l7Proxy`
      - Enable Layer 7 network policy.
      - bool

--- a/Documentation/network/l2-announcements.rst
+++ b/Documentation/network/l2-announcements.rst
@@ -570,19 +570,18 @@ To enable L2 Pod Announcements, set the following:
            :namespace: kube-system
            :extra-args: --reuse-values
            :set: l2podAnnouncements.enabled=true
-                 l2podAnnouncements.interface=eth0
+                 l2podAnnouncements.interfacePattern='^eth0$'
 
     .. group-tab:: ConfigMap
 
         .. code-block:: yaml
 
             enable-l2-pod-announcements: true
-            l2-pod-announcements-interface: eth0
+            l2-pod-announcements-interface-pattern: "^eth0$"
 
-The ``l2podAnnouncements.interface``/``l2-pod-announcements-interface`` options allows you to specify 
-one interface use to send announcements.  If you would like to send announcements on multiple interfaces, you should use the
-``l2podAnnouncements.interfacePattern``/``l2-pod-announcements-interface-pattern`` option instead. 
-This option takes a regex, matching on multiple interfaces.
+The ``l2podAnnouncements.interfacePattern``/``l2-pod-announcements-interface-pattern`` option takes
+a regex matching the interfaces used to send announcements. To match multiple interfaces, use a regex
+pattern like ``^(eth0|ens1)$``.
 
 .. tabs::
     .. group-tab:: Helm

--- a/clustermesh-apiserver/clustermesh/converters.go
+++ b/clustermesh-apiserver/clustermesh/converters.go
@@ -7,10 +7,8 @@ import (
 	"errors"
 	"iter"
 	"log/slog"
-	"maps"
 	"net"
 	"path"
-	"slices"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -50,37 +48,35 @@ type CachedConverter[T runtime.Object] struct {
 	mapper func(T) iter.Seq[store.Key]
 	// cache remembers the kvstore keys associated with any Kubernetes resource.
 	cache map[resource.Key]sets.Set[string]
-	// refCount tracks the number of resources referencing each kvstore key.
-	refCount map[string]int
+	// ownership tracks the entries proposed by each resource for each kvstore key.
+	ownership map[string]map[resource.Key]store.Key
 }
 
 func NewCachedCoverter[T runtime.Object](mapper func(T) iter.Seq[store.Key]) *CachedConverter[T] {
 	return &CachedConverter[T]{
-		mapper:   mapper,
-		cache:    make(map[resource.Key]sets.Set[string]),
-		refCount: make(map[string]int),
+		mapper:    mapper,
+		cache:     make(map[resource.Key]sets.Set[string]),
+		ownership: make(map[string]map[resource.Key]store.Key),
 	}
 }
 
 func (ec *CachedConverter[T]) Convert(event resource.Event[T]) (upserts iter.Seq[store.Key], deletes iter.Seq[store.NamedKey]) {
 	toDelete := ec.cache[event.Key]
-	if toDelete == nil {
-		toDelete = sets.New[string]()
-	}
 	var toAdd []store.Key
 
 	if event.Kind != resource.Delete {
-		var current = sets.New[string]()
+		current := sets.New[string]()
 		for entry := range ec.mapper(event.Object) {
 			key := entry.GetKeyName()
 			toAdd = append(toAdd, entry)
+			current.Insert(key)
 
-			if !current.Has(key) {
-				if !toDelete.Has(key) {
-					ec.refCount[key]++
-				}
-				current.Insert(key)
+			ownerMap, ok := ec.ownership[key]
+			if !ok {
+				ownerMap = make(map[resource.Key]store.Key)
+				ec.ownership[key] = ownerMap
 			}
+			ownerMap[event.Key] = entry
 			toDelete.Delete(key)
 		}
 		ec.cache[event.Key] = current
@@ -88,19 +84,47 @@ func (ec *CachedConverter[T]) Convert(event resource.Event[T]) (upserts iter.Seq
 		delete(ec.cache, event.Key)
 	}
 
+	// For each key scheduled for deletion, make sure the resource from the event
+	// is removed as an owner of that key.
+	for keyName := range toDelete {
+		delete(ec.ownership[keyName], event.Key)
+	}
+
+	upsertIter := func(yield func(store.Key) bool) {
+		// Fresh updates from this event
+		for _, entry := range toAdd {
+			if !yield(entry) {
+				return
+			}
+		}
+		// if a key is marked for deletion but other resources still own the key,
+		// we must re-upsert one of the other owner's values to ensure kvstore is
+		// correct.
+		for keyName := range toDelete {
+			if ownerMap := ec.ownership[keyName]; len(ownerMap) > 0 {
+				for _, entry := range ownerMap {
+					if !yield(entry) {
+						return
+					}
+					break
+				}
+			}
+		}
+	}
+
+	// only delete the key from the kvstore if no resource owns the key.
 	deleteIter := func(yield func(store.NamedKey) bool) {
-		for entry := range maps.Keys(toDelete) {
-			ec.refCount[entry]--
-			if ec.refCount[entry] == 0 {
-				delete(ec.refCount, entry)
-				if !yield(store.NewKVPair(entry, "")) {
+		for keyName := range toDelete {
+			if len(ec.ownership[keyName]) == 0 {
+				delete(ec.ownership, keyName)
+				if !yield(store.NewKVPair(keyName, "")) {
 					return
 				}
 			}
 		}
 	}
 
-	return slices.Values(toAdd), deleteIter
+	return upsertIter, deleteIter
 }
 
 // ----- CiliumNodes ----- //

--- a/clustermesh-apiserver/clustermesh/converters.go
+++ b/clustermesh-apiserver/clustermesh/converters.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net"
 	"path"
+	"slices"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -39,6 +40,55 @@ func singleIter[T any](value T) iter.Seq[T] {
 	}
 }
 
+type resourceOwner struct {
+	owner resource.Key
+	entry store.Key
+}
+
+// entryGroup tracks all Kubernetes resources claiming a given kvstore key.
+// It is optimized for the common case where a key is owned by a single resource.
+type entryGroup struct {
+	primary resource.Key
+	pending []resourceOwner
+}
+
+func (e *entryGroup) upsert(owner resource.Key, entry store.Key) (primary bool) {
+	if e.primary == (resource.Key{}) || e.primary == owner {
+		e.primary = owner
+		return true
+	}
+
+	if i := slices.IndexFunc(e.pending, func(ro resourceOwner) bool { return ro.owner == owner }); i >= 0 {
+		e.pending[i].entry = entry
+		return false
+	}
+
+	e.pending = append(e.pending, resourceOwner{owner: owner, entry: entry})
+	return false
+}
+
+func (e *entryGroup) release(owner resource.Key) store.Key {
+	if e.primary == owner {
+		if len(e.pending) > 0 {
+			next := e.pending[0]
+			e.primary = next.owner
+			e.pending = e.pending[1:]
+			return next.entry
+		}
+		e.primary = resource.Key{}
+		return nil
+	}
+
+	e.pending = slices.DeleteFunc(e.pending, func(ro resourceOwner) bool {
+		return ro.owner == owner
+	})
+	return nil
+}
+
+func (e *entryGroup) empty() bool {
+	return e.primary == (resource.Key{})
+}
+
 // ----- Generic ----- //
 
 // CachedConverter implements the common logic of a converter that, given a single
@@ -48,83 +98,61 @@ type CachedConverter[T runtime.Object] struct {
 	mapper func(T) iter.Seq[store.Key]
 	// cache remembers the kvstore keys associated with any Kubernetes resource.
 	cache map[resource.Key]sets.Set[string]
-	// ownership tracks the entries proposed by each resource for each kvstore key.
-	ownership map[string]map[resource.Key]store.Key
+	// ownership tracks all Kubernetes resources claiming a given kvstore key.
+	ownership map[string]*entryGroup
 }
 
-func NewCachedCoverter[T runtime.Object](mapper func(T) iter.Seq[store.Key]) *CachedConverter[T] {
+func NewCachedConverter[T runtime.Object](mapper func(T) iter.Seq[store.Key]) *CachedConverter[T] {
 	return &CachedConverter[T]{
 		mapper:    mapper,
 		cache:     make(map[resource.Key]sets.Set[string]),
-		ownership: make(map[string]map[resource.Key]store.Key),
+		ownership: make(map[string]*entryGroup),
 	}
 }
 
 func (ec *CachedConverter[T]) Convert(event resource.Event[T]) (upserts iter.Seq[store.Key], deletes iter.Seq[store.NamedKey]) {
-	toDelete := ec.cache[event.Key]
+	stale := ec.cache[event.Key]
 	var toAdd []store.Key
 
-	if event.Kind != resource.Delete {
+	if event.Kind == resource.Upsert {
 		current := sets.New[string]()
 		for entry := range ec.mapper(event.Object) {
 			key := entry.GetKeyName()
-			toAdd = append(toAdd, entry)
 			current.Insert(key)
 
-			ownerMap, ok := ec.ownership[key]
+			group, ok := ec.ownership[key]
 			if !ok {
-				ownerMap = make(map[resource.Key]store.Key)
-				ec.ownership[key] = ownerMap
+				group = &entryGroup{}
+				ec.ownership[key] = group
 			}
-			ownerMap[event.Key] = entry
-			toDelete.Delete(key)
+			if group.upsert(event.Key, entry) {
+				toAdd = append(toAdd, entry)
+			}
+			stale.Delete(key)
 		}
 		ec.cache[event.Key] = current
 	} else {
 		delete(ec.cache, event.Key)
 	}
 
+	var toDelete []store.NamedKey
 	// For each key scheduled for deletion, make sure the resource from the event
 	// is removed as an owner of that key.
-	for keyName := range toDelete {
-		delete(ec.ownership[keyName], event.Key)
-	}
-
-	upsertIter := func(yield func(store.Key) bool) {
-		// Fresh updates from this event
-		for _, entry := range toAdd {
-			if !yield(entry) {
-				return
-			}
+	for keyName := range stale {
+		group := ec.ownership[keyName]
+		if entry := group.release(event.Key); entry != nil {
+			// if the primary owner is removed, but other resources still own the key,
+			// we must re-upsert the entry of the new primary owner.
+			toAdd = append(toAdd, entry)
 		}
-		// if a key is marked for deletion but other resources still own the key,
-		// we must re-upsert one of the other owner's values to ensure kvstore is
-		// correct.
-		for keyName := range toDelete {
-			if ownerMap := ec.ownership[keyName]; len(ownerMap) > 0 {
-				for _, entry := range ownerMap {
-					if !yield(entry) {
-						return
-					}
-					break
-				}
-			}
+
+		if group.empty() {
+			delete(ec.ownership, keyName)
+			toDelete = append(toDelete, store.NewKVPair(keyName, ""))
 		}
 	}
 
-	// only delete the key from the kvstore if no resource owns the key.
-	deleteIter := func(yield func(store.NamedKey) bool) {
-		for keyName := range toDelete {
-			if len(ec.ownership[keyName]) == 0 {
-				delete(ec.ownership, keyName)
-				if !yield(store.NewKVPair(keyName, "")) {
-					return
-				}
-			}
-		}
-	}
-
-	return upsertIter, deleteIter
+	return slices.Values(toAdd), slices.Values(toDelete)
 }
 
 // ----- CiliumNodes ----- //
@@ -210,7 +238,7 @@ func newCiliumEndpointOptions(cfg cmk8s.CiliumEndpointSliceConfig) Options[*type
 }
 
 func newCiliumEndpointConverter(logger *slog.Logger, cinfo cmtypes.ClusterInfo) Converter[*types.CiliumEndpoint] {
-	return NewCachedCoverter(ciliumEndpointMapper)
+	return NewCachedConverter(ciliumEndpointMapper)
 }
 
 func ciliumEndpointMapper(endpoint *types.CiliumEndpoint) iter.Seq[store.Key] {
@@ -257,7 +285,7 @@ func newCiliumEndpointSliceOptions(cfg cmk8s.CiliumEndpointSliceConfig) Options[
 }
 
 func newCiliumEndpointSliceConverter(logger *slog.Logger, cinfo cmtypes.ClusterInfo) Converter[*cilium_api_v2a1.CiliumEndpointSlice] {
-	return NewCachedCoverter(ciliumEndpointSliceMapper)
+	return NewCachedConverter(ciliumEndpointSliceMapper)
 }
 
 func ciliumEndpointSliceMapper(endpointslice *cilium_api_v2a1.CiliumEndpointSlice) iter.Seq[store.Key] {

--- a/clustermesh-apiserver/clustermesh/converters.go
+++ b/clustermesh-apiserver/clustermesh/converters.go
@@ -50,47 +50,57 @@ type CachedConverter[T runtime.Object] struct {
 	mapper func(T) iter.Seq[store.Key]
 	// cache remembers the kvstore keys associated with any Kubernetes resource.
 	cache map[resource.Key]sets.Set[string]
+	// refCount tracks the number of resources referencing each kvstore key.
+	refCount map[string]int
 }
 
 func NewCachedCoverter[T runtime.Object](mapper func(T) iter.Seq[store.Key]) *CachedConverter[T] {
 	return &CachedConverter[T]{
-		mapper: mapper,
-		cache:  make(map[resource.Key]sets.Set[string]),
+		mapper:   mapper,
+		cache:    make(map[resource.Key]sets.Set[string]),
+		refCount: make(map[string]int),
 	}
 }
 
 func (ec *CachedConverter[T]) Convert(event resource.Event[T]) (upserts iter.Seq[store.Key], deletes iter.Seq[store.NamedKey]) {
-	if event.Kind == resource.Delete {
-		toDelete := maps.Keys(ec.cache[event.Key])
+	toDelete := ec.cache[event.Key]
+	if toDelete == nil {
+		toDelete = sets.New[string]()
+	}
+	var toAdd []store.Key
+
+	if event.Kind != resource.Delete {
+		var current = sets.New[string]()
+		for entry := range ec.mapper(event.Object) {
+			key := entry.GetKeyName()
+			toAdd = append(toAdd, entry)
+
+			if !current.Has(key) {
+				if !toDelete.Has(key) {
+					ec.refCount[key]++
+				}
+				current.Insert(key)
+			}
+			toDelete.Delete(key)
+		}
+		ec.cache[event.Key] = current
+	} else {
 		delete(ec.cache, event.Key)
-		return noneIter[store.Key], ec.deletesIter(toDelete)
 	}
 
-	var (
-		toAdd    []store.Key
-		toDelete = ec.cache[event.Key]
-		current  = sets.New[string]()
-	)
-
-	for entry := range ec.mapper(event.Object) {
-		key := entry.GetKeyName()
-		toAdd = append(toAdd, entry)
-		current.Insert(key)
-		toDelete.Delete(key)
-	}
-
-	ec.cache[event.Key] = current
-	return slices.Values(toAdd), ec.deletesIter(maps.Keys(toDelete))
-}
-
-func (ec *CachedConverter[T]) deletesIter(keys iter.Seq[string]) iter.Seq[store.NamedKey] {
-	return func(yield func(store.NamedKey) bool) {
-		for key := range keys {
-			if !yield(store.NewKVPair(key, "")) {
-				return
+	deleteIter := func(yield func(store.NamedKey) bool) {
+		for entry := range maps.Keys(toDelete) {
+			ec.refCount[entry]--
+			if ec.refCount[entry] == 0 {
+				delete(ec.refCount, entry)
+				if !yield(store.NewKVPair(entry, "")) {
+					return
+				}
 			}
 		}
 	}
+
+	return slices.Values(toAdd), deleteIter
 }
 
 // ----- CiliumNodes ----- //

--- a/clustermesh-apiserver/clustermesh/testdata/ciliumendpoints.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/ciliumendpoints.txtar
@@ -44,53 +44,54 @@ kvstore/list -o json cilium/state/ip ips-1+3.actual
 # Add one more CiliumEndpoint; the IPv4 address overlaps with that of endpoint-3
 k8s/add endpoint-4.yaml
 
-# Wait for synchronization. The entry for the IP of endpoint-3 should be updated
-# to that of endpoint-4
-kvstore/list -o json cilium/state/ip ips-1+3+4.actual
-* cmp ips-1+3+4.actual ips-1+3+4.expected
+# Wait for synchronization. The entry for the IP of endpoint-3 should be preserved
+# as the primary entry.
+kvstore/list -o json cilium/state/ip ips-1+4+3.actual
+* cmp ips-1+4+3.actual ips-1+4+3.expected
 
 # Delete endpoint-4.
 k8s/delete endpoint-4.yaml
 
-# Wait for synchronization. The entry for endpoint-3 should be preserved after endpoint-4 is deleted.
+# Wait for synchronization. The entry for endpoint-3 remains the primary entry.
 kvstore/list -o json cilium/state/ip ips-1+3.actual
 * cmp ips-1+3.actual ips-1+3.expected
 
 # Add endpoint-4 again
 k8s/add endpoint-4.yaml
 
-# Wait for synchronization. The entry for the IP of endpoint-3 should be updated
-# to that of endpoint-4
-kvstore/list -o json cilium/state/ip ips-1+3+4.actual
-* cmp ips-1+3+4.actual ips-1+3+4.expected
+# Wait for synchronization. The entry for the IP of endpoint-3 should be preserved
+# as the primary entry.
+kvstore/list -o json cilium/state/ip ips-1+4+3.actual
+* cmp ips-1+4+3.actual ips-1+4+3.expected
 
 # Delete endpoint-3.
 k8s/delete endpoint-3.yaml
 
-# Wait for synchronization. The entry for endpoint-4 should be preserved after endpoint-3 is deleted.
+# Wait for synchronization. The entry for endpoint-4 should become the primary entry
+# after endpoint-3 is deleted.
 kvstore/list -o json cilium/state/ip ips-1+4.actual
 * cmp ips-1+4.actual ips-1+4.expected
 
 # Add endpoint-3 again
 k8s/add endpoint-3.yaml
 
-# Wait for synchronization. The entry for the IP of endpoint-4 should be updated
-# to that of endpoint-3.
+# Wait for synchronization. The entry for the IP of endpoint-4 should be preserved
+# as the primary entry
 kvstore/list -o json cilium/state/ip ips-1+3+4.actual
-* cmp ips-1+3+4.actual ips-1+4+3.expected
+* cmp ips-1+3+4.actual ips-1+3+4.expected
 
 # Trigger an update for endpoint-4
 k8s/update endpoint-4.yaml
 
-# Wait for synchronization. The entry for the IP of endpoint-3 should be updated
-# to that of endpoint-4.
+# Wait for synchronization. The entry for the IP of endpoint-4 should be updated.
 kvstore/list -o json cilium/state/ip ips-1+3+4.actual
 * cmp ips-1+3+4.actual ips-1+3+4.expected
 
 # Delete endpoint-4.
 k8s/delete endpoint-4.yaml
 
-# Wait for synchronization. The entry for endpoint-3 should be preserved after endpoint-4 is deleted.
+# Wait for synchronization. The entry for endpoint-3 should become the primary entry
+# after endpoint-4 is deleted.
 kvstore/list -o json cilium/state/ip ips-1+3.actual
 * cmp ips-1+3.actual ips-1+3.expected
 

--- a/clustermesh-apiserver/clustermesh/testdata/ciliumendpoints.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/ciliumendpoints.txtar
@@ -41,6 +41,27 @@ k8s/delete endpoint-2.yaml
 kvstore/list -o json cilium/state/ip ips-1+3.actual
 * cmp ips-1+3.actual ips-1+3.expected
 
+# Add one more CiliumEndpoint; the IPv4 address overlaps with that of endpoint-3
+k8s/add endpoint-4.yaml
+
+# Wait for synchronization
+kvstore/list -o json cilium/state/ip ips-1+3+4.actual
+* cmp ips-1+3+4.actual ips-1+3+4.expected
+
+# Delete endpoint-3. The entry for endpoint-4 should be preserved
+k8s/delete endpoint-3.yaml
+
+# Wait for synchronization
+kvstore/list -o json cilium/state/ip ips-1+4.actual
+* cmp ips-1+4.actual ips-1+4.expected
+
+# Delete endpoint-4. No entry for the ip should exist anymore
+k8s/delete endpoint-4.yaml
+
+# Wait for synchronization
+kvstore/list -o json cilium/state/ip ips-1.actual
+* cmp ips-1.actual ips-1.expected
+
 # Annotate namespace-1 as non-global
 k8s/update namespace-1-annotated.yaml
 
@@ -129,6 +150,26 @@ status:
     - ipv4: 10.244.2.91
       ipv6: fd00:10:244:2::e4b4
     node: 172.18.0.2
+  service-account: default
+  state: ready
+
+-- endpoint-4.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumEndpoint
+metadata:
+  name: cep-004
+  namespace: foo
+status:
+  id: 1484
+  identity:
+    id: 199479
+    labels:
+    - k8s:app=foo
+  networking:
+    addressing:
+    - ipv4: 10.244.2.91
+      ipv6: fd00:10:244:2::e4b5
+    node: 172.18.0.3
   service-account: default
   state: ready
 
@@ -314,5 +355,153 @@ status:
   "Metadata": "",
   "K8sNamespace": "foo",
   "K8sPodName": "cep-002",
+  "K8sServiceAccount": "default"
+}
+-- ips-1+3+4.expected --
+# cilium/state/ip/v1/default/10.244.1.80
+{
+  "IP": "10.244.1.80",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-001",
+  "K8sServiceAccount": "default"
+}
+# cilium/state/ip/v1/default/10.244.2.91
+{
+  "IP": "10.244.2.91",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199479,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-004",
+  "K8sServiceAccount": "default"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::e4b4
+{
+  "IP": "fd00:10:244:2::e4b4",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-002",
+  "K8sServiceAccount": "default"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::e4b5
+{
+  "IP": "fd00:10:244:2::e4b5",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199479,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-004",
+  "K8sServiceAccount": "default"
+}
+-- ips-1+3+4-bis.expected --
+# cilium/state/ip/v1/default/10.244.1.80
+{
+  "IP": "10.244.1.80",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-001",
+  "K8sServiceAccount": "default"
+}
+# cilium/state/ip/v1/default/10.244.2.91
+{
+  "IP": "10.244.2.91",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-002",
+  "K8sServiceAccount": "default"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::e4b4
+{
+  "IP": "fd00:10:244:2::e4b4",
+  "Mask": null,
+  "HostIP": "172.18.0.2",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-002",
+  "K8sServiceAccount": "default"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::e4b5
+{
+  "IP": "fd00:10:244:2::e4b5",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199479,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-004",
+  "K8sServiceAccount": "default"
+}
+-- ips-1+4.expected --
+# cilium/state/ip/v1/default/10.244.1.80
+{
+  "IP": "10.244.1.80",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-001",
+  "K8sServiceAccount": "default"
+}
+# cilium/state/ip/v1/default/10.244.2.91
+{
+  "IP": "10.244.2.91",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199479,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-004",
+  "K8sServiceAccount": "default"
+}
+# cilium/state/ip/v1/default/fd00:10:244:2::e4b5
+{
+  "IP": "fd00:10:244:2::e4b5",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199479,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-004",
+  "K8sServiceAccount": "default"
+}
+-- ips-1.expected --
+# cilium/state/ip/v1/default/10.244.1.80
+{
+  "IP": "10.244.1.80",
+  "Mask": null,
+  "HostIP": "172.18.0.3",
+  "ID": 199472,
+  "Key": 0,
+  "Metadata": "",
+  "K8sNamespace": "foo",
+  "K8sPodName": "cep-001",
   "K8sServiceAccount": "default"
 }

--- a/clustermesh-apiserver/clustermesh/testdata/ciliumendpoints.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/ciliumendpoints.txtar
@@ -44,21 +44,60 @@ kvstore/list -o json cilium/state/ip ips-1+3.actual
 # Add one more CiliumEndpoint; the IPv4 address overlaps with that of endpoint-3
 k8s/add endpoint-4.yaml
 
-# Wait for synchronization
+# Wait for synchronization. The entry for the IP of endpoint-3 should be updated
+# to that of endpoint-4
 kvstore/list -o json cilium/state/ip ips-1+3+4.actual
 * cmp ips-1+3+4.actual ips-1+3+4.expected
 
-# Delete endpoint-3. The entry for endpoint-4 should be preserved
+# Delete endpoint-4.
+k8s/delete endpoint-4.yaml
+
+# Wait for synchronization. The entry for endpoint-3 should be preserved after endpoint-4 is deleted.
+kvstore/list -o json cilium/state/ip ips-1+3.actual
+* cmp ips-1+3.actual ips-1+3.expected
+
+# Add endpoint-4 again
+k8s/add endpoint-4.yaml
+
+# Wait for synchronization. The entry for the IP of endpoint-3 should be updated
+# to that of endpoint-4
+kvstore/list -o json cilium/state/ip ips-1+3+4.actual
+* cmp ips-1+3+4.actual ips-1+3+4.expected
+
+# Delete endpoint-3.
 k8s/delete endpoint-3.yaml
 
-# Wait for synchronization
+# Wait for synchronization. The entry for endpoint-4 should be preserved after endpoint-3 is deleted.
 kvstore/list -o json cilium/state/ip ips-1+4.actual
 * cmp ips-1+4.actual ips-1+4.expected
 
-# Delete endpoint-4. No entry for the ip should exist anymore
+# Add endpoint-3 again
+k8s/add endpoint-3.yaml
+
+# Wait for synchronization. The entry for the IP of endpoint-4 should be updated
+# to that of endpoint-3.
+kvstore/list -o json cilium/state/ip ips-1+3+4.actual
+* cmp ips-1+3+4.actual ips-1+4+3.expected
+
+# Trigger an update for endpoint-4
+k8s/update endpoint-4.yaml
+
+# Wait for synchronization. The entry for the IP of endpoint-3 should be updated
+# to that of endpoint-4.
+kvstore/list -o json cilium/state/ip ips-1+3+4.actual
+* cmp ips-1+3+4.actual ips-1+3+4.expected
+
+# Delete endpoint-4.
 k8s/delete endpoint-4.yaml
 
-# Wait for synchronization
+# Wait for synchronization. The entry for endpoint-3 should be preserved after endpoint-4 is deleted.
+kvstore/list -o json cilium/state/ip ips-1+3.actual
+* cmp ips-1+3.actual ips-1+3.expected
+
+# Delete endpoint-3.
+k8s/delete endpoint-3.yaml
+
+# Wait for synchronization. No entry for the IP of endpoint-3 should exist anymore.
 kvstore/list -o json cilium/state/ip ips-1.actual
 * cmp ips-1.actual ips-1.expected
 
@@ -406,7 +445,7 @@ status:
   "K8sPodName": "cep-004",
   "K8sServiceAccount": "default"
 }
--- ips-1+3+4-bis.expected --
+-- ips-1+4+3.expected --
 # cilium/state/ip/v1/default/10.244.1.80
 {
   "IP": "10.244.1.80",

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -814,9 +814,9 @@ contributors across the globe, there is almost always someone available to help.
 | l2NeighDiscovery.enabled | bool | `false` | Enable L2 neighbor discovery in the agent |
 | l2announcements | object | `{"enabled":false}` | Configure L2 announcements |
 | l2announcements.enabled | bool | `false` | Enable L2 announcements |
-| l2podAnnouncements | object | `{"enabled":false,"interface":"eth0"}` | Configure L2 pod announcements |
+| l2podAnnouncements | object | `{"enabled":false,"interfacePattern":""}` | Configure L2 pod announcements |
 | l2podAnnouncements.enabled | bool | `false` | Enable L2 pod announcements |
-| l2podAnnouncements.interface | string | `"eth0"` | Interface used for sending Gratuitous ARP pod announcements |
+| l2podAnnouncements.interfacePattern | string | `""` | A regular expression matching interfaces used for sending Gratuitous ARP pod announcements |
 | l7Proxy | bool | `true` | Enable Layer 7 network policy. |
 | livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1284,8 +1284,6 @@ data:
   enable-l2-pod-announcements: {{ .Values.l2podAnnouncements.enabled | quote }}
   {{- if .Values.l2podAnnouncements.interfacePattern }}
   l2-pod-announcements-interface-pattern: {{ .Values.l2podAnnouncements.interfacePattern | quote }}
-  {{- else }}
-  l2-pod-announcements-interface: {{ .Values.l2podAnnouncements.interface | quote }}
   {{- end }}
 {{- end }}
 

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -891,9 +891,6 @@ data:
   enable-auto-protect-node-port-range: {{ .Values.nodePort.autoProtectPortRange | quote }}
 {{- end }}
 {{- if hasKey .Values "loadBalancer" }}
-{{- if .Values.loadBalancer.standalone }}
-  bpf-lb-only: {{ .Values.loadBalancer.standalone | quote }}
-{{- end }}
 {{- if hasKey .Values.loadBalancer "mode" }}
   bpf-lb-mode: {{ .Values.loadBalancer.mode | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -4635,7 +4635,7 @@
         "enabled": {
           "type": "boolean"
         },
-        "interface": {
+        "interfacePattern": {
           "type": "string"
         }
       },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -505,10 +505,8 @@ l2announcements:
 l2podAnnouncements:
   # -- Enable L2 pod announcements
   enabled: false
-  # -- Interface used for sending Gratuitous ARP pod announcements
-  interface: "eth0"
   # -- A regular expression matching interfaces used for sending Gratuitous ARP pod announcements
-  # interfacePattern: ""
+  interfacePattern: ""
 # -- This feature set enables virtual BGP routers to be created via BGP CRDs.
 bgpControlPlane:
   # -- Enables the BGP control plane.

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2472,10 +2472,6 @@ monitor:
   enabled: false
 # -- Configure service load balancing
 loadBalancer:
-  # -- standalone enables the standalone L4LB which does not connect to
-  # kube-apiserver.
-  # standalone: false
-
   # -- algorithm is the name of the load balancing algorithm for backend
   # selection e.g. random or maglev
   # algorithm: random

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -508,10 +508,8 @@ l2announcements:
 l2podAnnouncements:
   # -- Enable L2 pod announcements
   enabled: false
-  # -- Interface used for sending Gratuitous ARP pod announcements
-  interface: "eth0"
   # -- A regular expression matching interfaces used for sending Gratuitous ARP pod announcements
-  # interfacePattern: ""
+  interfacePattern: ""
 # -- This feature set enables virtual BGP routers to be created via BGP CRDs.
 bgpControlPlane:
   # -- Enables the BGP control plane.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2496,10 +2496,6 @@ monitor:
   enabled: false
 # -- Configure service load balancing
 loadBalancer:
-  # -- standalone enables the standalone L4LB which does not connect to
-  # kube-apiserver.
-  # standalone: false
-
   # -- algorithm is the name of the load balancing algorithm for backend
   # selection e.g. random or maglev
   # algorithm: random

--- a/operator/pkg/bgp/peer.go
+++ b/operator/pkg/bgp/peer.go
@@ -156,24 +156,29 @@ func (u *peerConfigStatusReconciler) cleanupStatus(ctx context.Context, health c
 
 			// The resource doesn't exist anymore which is fine.
 			if !exists {
+				removed.Insert(k)
 				continue
 			}
 
 			updateStatus := false
 			for _, cond := range v2.AllBGPPeerConfigConditions {
-				if removed := meta.RemoveStatusCondition(&pc.Status.Conditions, cond); removed {
+				if meta.RemoveStatusCondition(&pc.Status.Conditions, cond) {
 					updateStatus = true
 				}
 			}
 
-			if updateStatus {
-				if _, err := u.cs.CiliumV2().CiliumBGPPeerConfigs().UpdateStatus(ctx, pc, meta_v1.UpdateOptions{}); err != nil {
-					// Failed to update status. Skip and retry.
-					continue
-				} else {
-					removed.Insert(k)
-				}
+			if !updateStatus {
+				// No managed conditions are present on this resource,
+				// so there is nothing to clean up.
+				removed.Insert(k)
+				continue
 			}
+
+			if _, err := u.cs.CiliumV2().CiliumBGPPeerConfigs().UpdateStatus(ctx, pc, meta_v1.UpdateOptions{}); err != nil {
+				// Failed to update status. Skip and retry.
+				continue
+			}
+			removed.Insert(k)
 		}
 
 		remaining = remaining.Difference(removed)

--- a/operator/pkg/bgp/peer_test.go
+++ b/operator/pkg/bgp/peer_test.go
@@ -244,69 +244,91 @@ func TestMissingAuthSecretCondition(t *testing.T) {
 }
 
 func TestDisablePeerConfigStatusReport(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), TestTimeout)
-	t.Cleanup(func() {
-		cancel()
-	})
-
-	f, ready := newPeerConfigTestFixture(t, ctx, false)
-
-	logger := hivetest.Logger(t)
-
-	f.hive.Start(logger, ctx)
-	t.Cleanup(func() {
-		f.hive.Stop(logger, ctx)
-	})
-
-	ready()
-
-	peerConfig := &v2.CiliumBGPPeerConfig{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name: "config0",
+	tests := []struct {
+		name       string
+		peerConfig *v2.CiliumBGPPeerConfig
+	}{
+		{
+			name: "Conditions are populated",
+			peerConfig: &v2.CiliumBGPPeerConfig{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name: "config0",
+				},
+				Spec: v2.CiliumBGPPeerConfigSpec{
+					AuthSecretRef: ptr.To("secret0"),
+				},
+				Status: v2.CiliumBGPPeerConfigStatus{
+					Conditions: func() []meta_v1.Condition {
+						conds := []meta_v1.Condition{}
+						for _, cond := range v2.AllBGPPeerConfigConditions {
+							conds = append(conds, meta_v1.Condition{Type: cond})
+						}
+						return conds
+					}(),
+				},
+			},
 		},
-		Spec: v2.CiliumBGPPeerConfigSpec{
-			AuthSecretRef: ptr.To("secret0"),
-		},
-		Status: v2.CiliumBGPPeerConfigStatus{
-			Conditions: []meta_v1.Condition{},
+		{
+			name: "Status is empty",
+			peerConfig: &v2.CiliumBGPPeerConfig{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name: "config0",
+				},
+				Spec: v2.CiliumBGPPeerConfigSpec{
+					AuthSecretRef: ptr.To("secret0"),
+				},
+			},
 		},
 	}
 
-	// Fill with all known conditions
-	for _, cond := range v2.AllBGPPeerConfigConditions {
-		peerConfig.Status.Conditions = append(peerConfig.Status.Conditions, meta_v1.Condition{
-			Type: cond,
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), TestTimeout)
+			t.Cleanup(func() {
+				cancel()
+			})
+
+			f, ready := newPeerConfigTestFixture(t, ctx, false)
+
+			logger := hivetest.Logger(t)
+
+			f.hive.Start(logger, ctx)
+			t.Cleanup(func() {
+				f.hive.Stop(logger, ctx)
+			})
+
+			ready()
+
+			_, err := f.fakeClientSet.CiliumFakeClientset.CiliumV2().CiliumBGPPeerConfigs().Create(
+				ctx, tt.peerConfig, meta_v1.CreateOptions{},
+			)
+			require.NoError(t, err)
+
+			peerConfigStore, err := f.peerConfigResource.Store(ctx)
+			require.NoError(t, err)
+
+			require.EventuallyWithT(t, func(ct *assert.CollectT) {
+				pc, exists, err := peerConfigStore.GetByKey(resource.Key{
+					Name: tt.peerConfig.Name,
+				})
+				if !assert.NoError(ct, err, "Failed to get peer config") {
+					return
+				}
+				if !assert.True(ct, exists, "Peer config not found") {
+					return
+				}
+				assert.Empty(ct, pc.Status.Conditions, "Conditions are not cleared")
+
+				rtxn := f.db.ReadTxn()
+
+				o, _, found := f.healthTable.Get(rtxn, health.PrimaryIndex.Query(healthTypes.HealthID("test.job-cleanup-peer-config-status")))
+				if !assert.True(ct, found, "Health status for the job is not found") {
+					return
+				}
+
+				assert.Equal(ct, healthTypes.Level(healthTypes.LevelStopped), o.Level)
+				assert.Equal(ct, "Cleanup job is done successfully", o.Message)
+			}, time.Second*3, time.Millisecond*100)
 		})
 	}
-
-	_, err := f.fakeClientSet.CiliumFakeClientset.CiliumV2().CiliumBGPPeerConfigs().Create(
-		ctx, peerConfig, meta_v1.CreateOptions{},
-	)
-	require.NoError(t, err)
-
-	peerConfigStore, err := f.peerConfigResource.Store(ctx)
-	require.NoError(t, err)
-
-	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		pc, exists, err := peerConfigStore.GetByKey(resource.Key{
-			Name: peerConfig.Name,
-		})
-		if !assert.NoError(ct, err, "Failed to get peer config") {
-			return
-		}
-		if !assert.True(ct, exists, "Peer config not found") {
-			return
-		}
-		assert.Empty(ct, pc.Status.Conditions, "Conditions are not cleared")
-
-		rtxn := f.db.ReadTxn()
-
-		o, _, found := f.healthTable.Get(rtxn, health.PrimaryIndex.Query(healthTypes.HealthID("test.job-cleanup-peer-config-status")))
-		if !assert.True(ct, found, "Health status for the job is not found") {
-			return
-		}
-
-		assert.Equal(ct, healthTypes.Level(healthTypes.LevelStopped), o.Level)
-		assert.Equal(ct, "Cleanup job is done successfully", o.Message)
-	}, time.Second*3, time.Millisecond*100)
 }

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-empty-hostname-x-4.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-empty-hostname-x-4.yaml
@@ -56,16 +56,6 @@ spec:
                 useRemoteAddress: true
         - filterChainMatch:
             serverNames:
-              - abc.example.com
-            transportProtocol: tls
-          filters:
-            - name: envoy.filters.network.tcp_proxy
-              typedConfig:
-                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-                cluster: gateway-conformance-infra:tls-backend:443
-                statPrefix: gateway-conformance-infra:tls-backend:443
-        - filterChainMatch:
-            serverNames:
               - "*.com"
             transportProtocol: tls
           filters:
@@ -73,7 +63,17 @@ spec:
               typedConfig:
                 "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
                 cluster: gateway-conformance-infra:tls-backend-2:443
-                statPrefix: gateway-conformance-infra:tls-backend-2:443
+                statPrefix: tls-passthrough:*.com
+        - filterChainMatch:
+            serverNames:
+              - abc.example.com
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: gateway-conformance-infra:tls-backend:443
+                statPrefix: tls-passthrough:abc.example.com
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-exact-hostname-x-1.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-exact-hostname-x-1.yaml
@@ -59,7 +59,7 @@ spec:
               typedConfig:
                 "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
                 cluster: gateway-conformance-infra:tls-backend:443
-                statPrefix: gateway-conformance-infra:tls-backend:443
+                statPrefix: tls-passthrough:abc.example.com
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-less-specific-wc-hostname-x-3.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-less-specific-wc-hostname-x-3.yaml
@@ -56,16 +56,6 @@ spec:
                 useRemoteAddress: true
         - filterChainMatch:
             serverNames:
-              - abc.example.com
-            transportProtocol: tls
-          filters:
-            - name: envoy.filters.network.tcp_proxy
-              typedConfig:
-                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-                cluster: gateway-conformance-infra:tls-backend:443
-                statPrefix: gateway-conformance-infra:tls-backend:443
-        - filterChainMatch:
-            serverNames:
               - "*.example.com"
             transportProtocol: tls
           filters:
@@ -73,7 +63,17 @@ spec:
               typedConfig:
                 "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
                 cluster: gateway-conformance-infra:tls-backend-2:443
-                statPrefix: gateway-conformance-infra:tls-backend-2:443
+                statPrefix: tls-passthrough:*.example.com
+        - filterChainMatch:
+            serverNames:
+              - abc.example.com
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: gateway-conformance-infra:tls-backend:443
+                statPrefix: tls-passthrough:abc.example.com
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-more-specific-wc-hostname-x-2.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-more-specific-wc-hostname-x-2.yaml
@@ -56,16 +56,6 @@ spec:
                 useRemoteAddress: true
         - filterChainMatch:
             serverNames:
-              - abc.example.com
-            transportProtocol: tls
-          filters:
-            - name: envoy.filters.network.tcp_proxy
-              typedConfig:
-                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-                cluster: gateway-conformance-infra:tls-backend:443
-                statPrefix: gateway-conformance-infra:tls-backend:443
-        - filterChainMatch:
-            serverNames:
               - "*.example.com"
             transportProtocol: tls
           filters:
@@ -73,7 +63,17 @@ spec:
               typedConfig:
                 "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
                 cluster: gateway-conformance-infra:tls-backend-2:443
-                statPrefix: gateway-conformance-infra:tls-backend-2:443
+                statPrefix: tls-passthrough:*.example.com
+        - filterChainMatch:
+            serverNames:
+              - abc.example.com
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: gateway-conformance-infra:tls-backend:443
+                statPrefix: tls-passthrough:abc.example.com
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/output/cec-gateway-tlsroute-mixed.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/output/cec-gateway-tlsroute-mixed.yaml
@@ -94,7 +94,7 @@ spec:
               typedConfig:
                 "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
                 cluster: gateway-conformance-infra:tls-backend:443
-                statPrefix: gateway-conformance-infra:tls-backend:443
+                statPrefix: tls-passthrough:tls.example.com
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-simple-same-namespace/output/cec-gateway-tlsroute.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-simple-same-namespace/output/cec-gateway-tlsroute.yaml
@@ -59,7 +59,7 @@ spec:
               typedConfig:
                 "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
                 cluster: gateway-conformance-infra:tls-backend:443
-                statPrefix: gateway-conformance-infra:tls-backend:443
+                statPrefix: tls-passthrough:abc.example.com
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:

--- a/operator/pkg/model/ingestion/gateway_test.go
+++ b/operator/pkg/model/ingestion/gateway_test.go
@@ -65,6 +65,7 @@ func TestTLSGatewayAPI(t *testing.T) {
 		"Conformance/TLSRouteSimpleSameNamespace":  {},
 		"Conformance/TLSRouteHostnameIntersection": {},
 		"mixed protocol listeners TLSRoute":        {},
+		"tls weighted backends":                    {},
 	}
 
 	for name := range tests {

--- a/operator/pkg/model/ingestion/testdata/gateway/tls_weighted_backends/input-gateway.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/tls_weighted_backends/input-gateway.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: my-gateway
+  namespace: default
+spec:
+  gatewayClassName: ""
+  listeners:
+  - name: tls
+    port: 443
+    protocol: TLS
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/tls_weighted_backends/input-gatewayclass.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/tls_weighted_backends/input-gatewayclass.yaml
@@ -1,0 +1,5 @@
+metadata:
+  creationTimestamp: null
+spec:
+  controllerName: ""
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/tls_weighted_backends/input-service.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/tls_weighted_backends/input-service.yaml
@@ -1,0 +1,14 @@
+- metadata:
+    creationTimestamp: null
+    name: backend-v1
+    namespace: default
+  spec: {}
+  status:
+    loadBalancer: {}
+- metadata:
+    creationTimestamp: null
+    name: backend-v2
+    namespace: default
+  spec: {}
+  status:
+    loadBalancer: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/tls_weighted_backends/input-tlsroute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/tls_weighted_backends/input-tlsroute.yaml
@@ -1,0 +1,19 @@
+- metadata:
+    creationTimestamp: null
+    name: tls-weighted
+    namespace: default
+  spec:
+    hostnames:
+    - test.example.com
+    parentRefs:
+    - name: my-gateway
+    rules:
+    - backendRefs:
+      - name: backend-v1
+        port: 443
+        weight: 70
+      - name: backend-v2
+        port: 443
+        weight: 30
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gateway/tls_weighted_backends/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/tls_weighted_backends/output-listeners.yaml
@@ -1,0 +1,23 @@
+- hostname: '*'
+  name: tls
+  port: 443
+  routes:
+  - backends:
+    - name: backend-v1
+      namespace: default
+      port:
+        port: 443
+      weight: 70
+    - name: backend-v2
+      namespace: default
+      port:
+        port: 443
+      weight: 30
+    hostnames:
+    - test.example.com
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: my-gateway
+    namespace: default
+    version: v1

--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"maps"
 	goslices "slices"
+	"strings"
 	"syscall"
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -24,6 +25,7 @@ import (
 	"github.com/cilium/cilium/operator/pkg/model"
 	"github.com/cilium/cilium/pkg/envoy"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/slices"
 )
 
 const (
@@ -399,33 +401,158 @@ func getHostNetworkListenerAddresses(ports []uint32, ipv4Enabled, ipv6Enabled bo
 }
 
 func tlsPassthroughFilterChains(m *model.Model) []*envoy_config_listener.FilterChain {
-	ptBackendsToHostnames := m.TLSBackends()
-	if len(ptBackendsToHostnames) == 0 {
-		return nil
-	}
-
 	var filterChains []*envoy_config_listener.FilterChain
 
-	for _, backend := range ptBackendsToHostnames {
-		filterChains = append(filterChains, &envoy_config_listener.FilterChain{
-			FilterChainMatch: toFilterChainMatch(backend.Hostnames),
-			Filters: []*envoy_config_listener.Filter{
-				{
-					Name: tcpProxyType,
-					ConfigType: &envoy_config_listener.Filter_TypedConfig{
-						TypedConfig: toAny(&envoy_extensions_filters_network_tcp_v3.TcpProxy{
-							StatPrefix: backend.BackendKey,
-							ClusterSpecifier: &envoy_extensions_filters_network_tcp_v3.TcpProxy_Cluster{
-								Cluster: backend.BackendKey,
-							},
-						}),
+	for _, listener := range stableTLSPassthroughListeners(m.TLSPassthrough) {
+		for _, route := range stableTLSPassthroughRoutes(listener.Routes) {
+			backends := stableTLSPassthroughBackends(route.Backends)
+			if len(backends) == 0 {
+				continue
+			}
+
+			filterChains = append(filterChains, &envoy_config_listener.FilterChain{
+				FilterChainMatch: toFilterChainMatch(route.Hostnames),
+				Filters: []*envoy_config_listener.Filter{
+					{
+						Name: tcpProxyType,
+						ConfigType: &envoy_config_listener.Filter_TypedConfig{
+							TypedConfig: toAny(tcpProxyForTLSPassthroughRoute(route, backends)),
+						},
 					},
 				},
-			},
-		})
+			})
+		}
 	}
 
 	return filterChains
+}
+
+func stableTLSPassthroughListeners(listeners []model.TLSPassthroughListener) []model.TLSPassthroughListener {
+	if len(listeners) < 2 {
+		return listeners
+	}
+
+	stable := append([]model.TLSPassthroughListener(nil), listeners...)
+	goslices.SortFunc(stable, func(a, b model.TLSPassthroughListener) int {
+		return cmp.Or(
+			cmp.Compare(a.Port, b.Port),
+			cmp.Compare(a.Address, b.Address),
+			cmp.Compare(a.Hostname, b.Hostname),
+			cmp.Compare(a.Name, b.Name),
+		)
+	})
+
+	return stable
+}
+
+func stableTLSPassthroughRoutes(routes []model.TLSPassthroughRoute) []model.TLSPassthroughRoute {
+	if len(routes) < 2 {
+		return routes
+	}
+
+	stable := append([]model.TLSPassthroughRoute(nil), routes...)
+	goslices.SortFunc(stable, func(a, b model.TLSPassthroughRoute) int {
+		return cmp.Or(
+			cmp.Compare(tlsPassthroughHostnamesKey(a.Hostnames), tlsPassthroughHostnamesKey(b.Hostnames)),
+			cmp.Compare(tlsPassthroughBackendsKey(a.Backends), tlsPassthroughBackendsKey(b.Backends)),
+			cmp.Compare(a.Name, b.Name),
+		)
+	})
+
+	return stable
+}
+
+func stableTLSPassthroughBackends(backends []model.Backend) []model.Backend {
+	if len(backends) < 2 {
+		return backends
+	}
+
+	stable := append([]model.Backend(nil), backends...)
+	goslices.SortFunc(stable, func(a, b model.Backend) int {
+		return cmp.Or(
+			cmp.Compare(a.Namespace, b.Namespace),
+			cmp.Compare(a.Name, b.Name),
+			cmp.Compare(tlsPassthroughBackendPort(a), tlsPassthroughBackendPort(b)),
+			cmp.Compare(tlsPassthroughBackendWeight(a), tlsPassthroughBackendWeight(b)),
+		)
+	})
+
+	return stable
+}
+
+func tcpProxyForTLSPassthroughRoute(route model.TLSPassthroughRoute, backends []model.Backend) *envoy_extensions_filters_network_tcp_v3.TcpProxy {
+	tcpProxy := &envoy_extensions_filters_network_tcp_v3.TcpProxy{
+		StatPrefix: tlsPassthroughFilterChainStatPrefix(route),
+	}
+
+	if len(backends) == 1 {
+		tcpProxy.ClusterSpecifier = &envoy_extensions_filters_network_tcp_v3.TcpProxy_Cluster{
+			Cluster: tlsPassthroughClusterName(backends[0]),
+		}
+		return tcpProxy
+	}
+
+	weightedClusters := make([]*envoy_extensions_filters_network_tcp_v3.TcpProxy_WeightedCluster_ClusterWeight, 0, len(backends))
+	for _, backend := range backends {
+		weightedClusters = append(weightedClusters, &envoy_extensions_filters_network_tcp_v3.TcpProxy_WeightedCluster_ClusterWeight{
+			Name:   tlsPassthroughClusterName(backend),
+			Weight: tlsPassthroughBackendWeight(backend),
+		})
+	}
+
+	tcpProxy.ClusterSpecifier = &envoy_extensions_filters_network_tcp_v3.TcpProxy_WeightedClusters{
+		WeightedClusters: &envoy_extensions_filters_network_tcp_v3.TcpProxy_WeightedCluster{
+			Clusters: weightedClusters,
+		},
+	}
+
+	return tcpProxy
+}
+
+func tlsPassthroughClusterName(backend model.Backend) string {
+	return getClusterName(backend.Namespace, backend.Name, backend.Port.GetPort())
+}
+
+func tlsPassthroughFilterChainStatPrefix(route model.TLSPassthroughRoute) string {
+	return "tls-passthrough:" + tlsPassthroughHostnamesKey(route.Hostnames)
+}
+
+func tlsPassthroughHostnamesKey(hostnames []string) string {
+	if len(hostnames) == 0 {
+		return "*"
+	}
+
+	stable := append([]string(nil), hostnames...)
+	goslices.Sort(stable)
+	return strings.Join(stable, ",")
+}
+
+func tlsPassthroughBackendsKey(backends []model.Backend) string {
+	stable := stableTLSPassthroughBackends(backends)
+	keys := make([]string, 0, len(stable))
+	for _, backend := range stable {
+		keys = append(keys, fmt.Sprintf("%s/%s:%s:%d", backend.Namespace, backend.Name, tlsPassthroughBackendPort(backend), tlsPassthroughBackendWeight(backend)))
+	}
+	return strings.Join(keys, ",")
+}
+
+func tlsPassthroughBackendPort(backend model.Backend) string {
+	if backend.Port == nil {
+		return ""
+	}
+	return backend.Port.GetPort()
+}
+
+func tlsPassthroughBackendWeight(backend model.Backend) uint32 {
+	if backend.Weight == nil {
+		return 1
+	}
+	// Gateway API validates non-negative weights, but clamp defensively for
+	// internal model callers.
+	if *backend.Weight < 0 {
+		return 0
+	}
+	return uint32(*backend.Weight)
 }
 
 func toTransportSocket(ciliumSecretNamespace string, tls []model.TLSSecret) *envoy_config_core_v3.TransportSocket {
@@ -463,10 +590,11 @@ func toFilterChainMatch(hostNames []string) *envoy_config_listener.FilterChainMa
 	res := &envoy_config_listener.FilterChainMatch{
 		TransportProtocol: tlsTransportProtocol,
 	}
-	// The hostNames slice cannot have duplicates, so we do not need to check for uniqueness.
-	if goslices.Contains(hostNames, "*") {
+	// ServerNames must be sorted and unique, and Envoy does not support "*" as a server name.
+	serverNames := slices.SortedUnique(hostNames)
+	if goslices.Contains(serverNames, "*") {
 		return res
 	}
-	res.ServerNames = hostNames
+	res.ServerNames = serverNames
 	return res
 }

--- a/operator/pkg/model/translation/envoy_listener_test.go
+++ b/operator/pkg/model/translation/envoy_listener_test.go
@@ -8,8 +8,10 @@ import (
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	envoy_extensions_filters_network_tcp_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/cilium/cilium/operator/pkg/model"
@@ -236,6 +238,275 @@ func Test_getHostNetworkListenerAddresses(t *testing.T) {
 			assert.Equal(t, tC.expectedAdditionalAdresses, additionalAddresses)
 		})
 	}
+}
+
+func Test_tlsPassthroughFilterChains_Backends(t *testing.T) {
+	weight70 := int32(70)
+	weight30 := int32(30)
+	weight0 := int32(0)
+	weight99 := int32(99)
+	weightNegative := int32(-10)
+
+	tests := []struct {
+		name             string
+		backends         []model.Backend
+		wantFilterChains int
+		wantStatPrefix   string
+		wantCluster      string
+		wantWeighted     []*envoy_extensions_filters_network_tcp_v3.TcpProxy_WeightedCluster_ClusterWeight
+	}{
+		{
+			name:             "no valid backends emits no filter chain",
+			wantFilterChains: 0,
+		},
+		{
+			name: "single backend",
+			backends: []model.Backend{
+				tlsBackend("one", "backend-v1", 443, nil),
+			},
+			wantFilterChains: 1,
+			wantStatPrefix:   "tls-passthrough:test.example.com",
+			wantCluster:      "one:backend-v1:443",
+		},
+		{
+			name: "weighted backends",
+			backends: []model.Backend{
+				tlsBackend("one", "backend-v1", 443, &weight70),
+				tlsBackend("one", "backend-v2", 443, &weight30),
+			},
+			wantFilterChains: 1,
+			wantStatPrefix:   "tls-passthrough:test.example.com",
+			wantWeighted: []*envoy_extensions_filters_network_tcp_v3.TcpProxy_WeightedCluster_ClusterWeight{
+				{Name: "one:backend-v1:443", Weight: 70},
+				{Name: "one:backend-v2:443", Weight: 30},
+			},
+		},
+		{
+			name: "omitted weights default to one",
+			backends: []model.Backend{
+				tlsBackend("one", "backend-v1", 443, nil),
+				tlsBackend("one", "backend-v2", 443, nil),
+			},
+			wantFilterChains: 1,
+			wantStatPrefix:   "tls-passthrough:test.example.com",
+			wantWeighted: []*envoy_extensions_filters_network_tcp_v3.TcpProxy_WeightedCluster_ClusterWeight{
+				{Name: "one:backend-v1:443", Weight: 1},
+				{Name: "one:backend-v2:443", Weight: 1},
+			},
+		},
+		{
+			name: "mixed omitted explicit zero and negative weights are deterministic",
+			backends: []model.Backend{
+				tlsBackend("one", "backend-v1", 443, nil),
+				tlsBackend("one", "backend-v2", 443, &weight99),
+				tlsBackend("one", "backend-v3", 443, &weight0),
+				tlsBackend("one", "backend-v4", 443, &weightNegative),
+			},
+			wantFilterChains: 1,
+			wantStatPrefix:   "tls-passthrough:test.example.com",
+			wantWeighted: []*envoy_extensions_filters_network_tcp_v3.TcpProxy_WeightedCluster_ClusterWeight{
+				{Name: "one:backend-v1:443", Weight: 1},
+				{Name: "one:backend-v2:443", Weight: 99},
+				{Name: "one:backend-v3:443", Weight: 0},
+				{Name: "one:backend-v4:443", Weight: 0},
+			},
+		},
+		{
+			name: "all zero weights preserve configured zero values",
+			backends: []model.Backend{
+				tlsBackend("one", "backend-v1", 443, &weight0),
+				tlsBackend("one", "backend-v2", 443, &weight0),
+			},
+			wantFilterChains: 1,
+			wantStatPrefix:   "tls-passthrough:test.example.com",
+			wantWeighted: []*envoy_extensions_filters_network_tcp_v3.TcpProxy_WeightedCluster_ClusterWeight{
+				{Name: "one:backend-v1:443", Weight: 0},
+				{Name: "one:backend-v2:443", Weight: 0},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filterChains := tlsPassthroughFilterChains(&model.Model{
+				TLSPassthrough: []model.TLSPassthroughListener{
+					{
+						Routes: []model.TLSPassthroughRoute{
+							{
+								Hostnames: []string{"test.example.com"},
+								Backends:  tt.backends,
+							},
+						},
+					},
+				},
+			})
+
+			require.Len(t, filterChains, tt.wantFilterChains)
+			if tt.wantFilterChains == 0 {
+				return
+			}
+
+			tcpProxy := getTCPProxy(t, filterChains[0])
+			assert.Equal(t, tt.wantStatPrefix, tcpProxy.GetStatPrefix())
+			if tt.wantCluster != "" {
+				assert.Equal(t, tt.wantCluster, tcpProxy.GetCluster())
+				assert.Nil(t, tcpProxy.GetWeightedClusters())
+				return
+			}
+
+			assert.Empty(t, tcpProxy.GetCluster())
+			require.NotNil(t, tcpProxy.GetWeightedClusters())
+			assert.Equal(t, tt.wantWeighted, tcpProxy.GetWeightedClusters().GetClusters())
+		})
+	}
+}
+
+func Test_tlsPassthroughFilterChains_DuplicateSNIRoutesPreserveCurrentBehavior(t *testing.T) {
+	filterChains := tlsPassthroughFilterChains(&model.Model{
+		TLSPassthrough: []model.TLSPassthroughListener{
+			{
+				Routes: []model.TLSPassthroughRoute{
+					{
+						Hostnames: []string{"test.example.com"},
+						Backends: []model.Backend{
+							tlsBackend("one", "backend-v1", 443, nil),
+						},
+					},
+					{
+						Hostnames: []string{"test.example.com"},
+						Backends: []model.Backend{
+							tlsBackend("one", "backend-v2", 443, nil),
+						},
+					},
+				},
+			},
+		},
+	})
+
+	require.Len(t, filterChains, 2)
+	assert.Equal(t, []string{"test.example.com"}, filterChains[0].GetFilterChainMatch().GetServerNames())
+	assert.Equal(t, []string{"test.example.com"}, filterChains[1].GetFilterChainMatch().GetServerNames())
+	assert.Equal(t, "tls-passthrough:test.example.com", getTCPProxy(t, filterChains[0]).GetStatPrefix())
+	assert.Equal(t, "tls-passthrough:test.example.com", getTCPProxy(t, filterChains[1]).GetStatPrefix())
+	assert.Equal(t, "one:backend-v1:443", getTCPProxy(t, filterChains[0]).GetCluster())
+	assert.Equal(t, "one:backend-v2:443", getTCPProxy(t, filterChains[1]).GetCluster())
+}
+
+func Test_tlsPassthroughFilterChains_DeterministicOrder(t *testing.T) {
+	weight70 := int32(70)
+	weight30 := int32(30)
+
+	modelA := &model.Model{
+		TLSPassthrough: []model.TLSPassthroughListener{
+			{
+				Name: "listener-z",
+				Port: 443,
+				Routes: []model.TLSPassthroughRoute{
+					{
+						Hostnames: []string{"c.example.com"},
+						Backends: []model.Backend{
+							tlsBackend("two", "backend-z", 8443, nil),
+						},
+					},
+				},
+			},
+			{
+				Name: "listener-a",
+				Port: 443,
+				Routes: []model.TLSPassthroughRoute{
+					{
+						Hostnames: []string{"b.example.com"},
+						Backends: []model.Backend{
+							tlsBackend("one", "backend-b", 443, nil),
+						},
+					},
+					{
+						Hostnames: []string{"a.example.com"},
+						Backends: []model.Backend{
+							tlsBackend("one", "backend-a", 443, &weight70),
+							tlsBackend("one", "backend-c", 443, &weight30),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	modelB := &model.Model{
+		TLSPassthrough: []model.TLSPassthroughListener{
+			{
+				Name: "listener-a",
+				Port: 443,
+				Routes: []model.TLSPassthroughRoute{
+					{
+						Hostnames: []string{"a.example.com"},
+						Backends: []model.Backend{
+							tlsBackend("one", "backend-c", 443, &weight30),
+							tlsBackend("one", "backend-a", 443, &weight70),
+						},
+					},
+					{
+						Hostnames: []string{"b.example.com"},
+						Backends: []model.Backend{
+							tlsBackend("one", "backend-b", 443, nil),
+						},
+					},
+				},
+			},
+			{
+				Name: "listener-z",
+				Port: 443,
+				Routes: []model.TLSPassthroughRoute{
+					{
+						Hostnames: []string{"c.example.com"},
+						Backends: []model.Backend{
+							tlsBackend("two", "backend-z", 8443, nil),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	filterChainsA := tlsPassthroughFilterChains(modelA)
+	filterChainsB := tlsPassthroughFilterChains(modelB)
+
+	diffOutput := cmp.Diff(filterChainsA, filterChainsB, protocmp.Transform())
+	if len(diffOutput) != 0 {
+		t.Fatalf("TLS passthrough filter chains were not deterministic across equivalent inputs:\n%s\n", diffOutput)
+	}
+
+	require.Len(t, filterChainsA, 3)
+	assert.Equal(t, []string{"a.example.com"}, filterChainsA[0].GetFilterChainMatch().GetServerNames())
+	assert.Equal(t, []string{"b.example.com"}, filterChainsA[1].GetFilterChainMatch().GetServerNames())
+	assert.Equal(t, []string{"c.example.com"}, filterChainsA[2].GetFilterChainMatch().GetServerNames())
+
+	tcpProxy := getTCPProxy(t, filterChainsA[0])
+	assert.Equal(t, "tls-passthrough:a.example.com", tcpProxy.GetStatPrefix())
+	require.NotNil(t, tcpProxy.GetWeightedClusters())
+	assert.Equal(t, []*envoy_extensions_filters_network_tcp_v3.TcpProxy_WeightedCluster_ClusterWeight{
+		{Name: "one:backend-a:443", Weight: 70},
+		{Name: "one:backend-c:443", Weight: 30},
+	}, tcpProxy.GetWeightedClusters().GetClusters())
+}
+
+func tlsBackend(namespace, name string, port uint32, weight *int32) model.Backend {
+	return model.Backend{
+		Namespace: namespace,
+		Name:      name,
+		Port: &model.BackendPort{
+			Port: port,
+		},
+		Weight: weight,
+	}
+}
+
+func getTCPProxy(t *testing.T, filterChain *envoy_config_listener.FilterChain) *envoy_extensions_filters_network_tcp_v3.TcpProxy {
+	require.Len(t, filterChain.GetFilters(), 1)
+
+	tcpProxy := &envoy_extensions_filters_network_tcp_v3.TcpProxy{}
+	require.NoError(t, filterChain.GetFilters()[0].GetTypedConfig().UnmarshalTo(tcpProxy))
+	return tcpProxy
 }
 
 func Test_withHostNetworkPortSorted(t *testing.T) {

--- a/operator/pkg/model/translation/gateway-api/testdata/conformance/tlsroute_hostname_intersection/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/conformance/tlsroute_hostname_intersection/cec-output.yaml
@@ -27,16 +27,6 @@ spec:
       filterChains:
         - filterChainMatch:
             serverNames:
-              - abc.example.com
-            transportProtocol: tls
-          filters:
-            - name: envoy.filters.network.tcp_proxy
-              typedConfig:
-                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-                cluster: gateway-conformance-infra:tls-backend:443
-                statPrefix: gateway-conformance-infra:tls-backend:443
-        - filterChainMatch:
-            serverNames:
               - "*.com"
             transportProtocol: tls
           filters:
@@ -44,7 +34,17 @@ spec:
               typedConfig:
                 "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
                 cluster: gateway-conformance-infra:tls-backend-2:443
-                statPrefix: gateway-conformance-infra:tls-backend-2:443
+                statPrefix: tls-passthrough:*.com
+        - filterChainMatch:
+            serverNames:
+              - abc.example.com
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: gateway-conformance-infra:tls-backend:443
+                statPrefix: tls-passthrough:abc.example.com
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:

--- a/operator/pkg/model/translation/gateway-api/testdata/tls_sni_weighted_backends/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/tls_sni_weighted_backends/cec-output.yaml
@@ -14,23 +14,32 @@ metadata:
     uid: ""
 spec:
   backendServices:
-  - name: my-service
+  - name: backend-v1
     namespace: default
     number:
-    - "8080"
+    - "443"
+  - name: backend-v2
+    namespace: default
+    number:
+    - "443"
   resources:
   - '@type': type.googleapis.com/envoy.config.listener.v3.Listener
     filterChains:
     - filterChainMatch:
         serverNames:
-        - foo.com
+        - test.example.com
         transportProtocol: tls
       filters:
       - name: envoy.filters.network.tcp_proxy
         typedConfig:
           '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-          cluster: default:my-service:8080
-          statPrefix: tls-passthrough:foo.com
+          statPrefix: tls-passthrough:test.example.com
+          weightedClusters:
+            clusters:
+            - name: default:backend-v1:443
+              weight: 70
+            - name: default:backend-v2:443
+              weight: 30
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:
@@ -55,8 +64,15 @@ spec:
       name: "6"
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
-      serviceName: default/my-service:8080
-    name: default:my-service:8080
+      serviceName: default/backend-v1:443
+    name: default:backend-v1:443
+    outlierDetection:
+      splitExternalLocalOriginErrors: true
+    type: EDS
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    edsClusterConfig:
+      serviceName: default/backend-v2:443
+    name: default:backend-v2:443
     outlierDetection:
       splitExternalLocalOriginErrors: true
     type: EDS

--- a/operator/pkg/model/translation/gateway-api/testdata/tls_sni_weighted_backends/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/tls_sni_weighted_backends/config-input.yaml
@@ -1,0 +1,10 @@
+cluster_config:
+  idle_timeout_seconds: 60
+host_network_config: {}
+ip_config: {}
+listener_config:
+  stream_idle_timeout_seconds: 300
+original_ip_detection_config: {}
+route_config:
+  host_name_suffix_match: true
+secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/tls_sni_weighted_backends/input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/tls_sni_weighted_backends/input.yaml
@@ -1,0 +1,24 @@
+tls_passthrough:
+- hostname: '*'
+  name: prod-web-gw
+  port: 443
+  routes:
+  - backends:
+    - name: backend-v1
+      namespace: default
+      port:
+        port: 443
+      weight: 70
+    - name: backend-v2
+      namespace: default
+      port:
+        port: 443
+      weight: 30
+    hostnames:
+    - test.example.com
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: my-gateway
+    namespace: default
+    version: v1

--- a/operator/pkg/model/translation/gateway-api/testdata/tls_sni_weighted_backends/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/tls_sni_weighted_backends/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: my-gateway
+    io.cilium.gateway/owning-gateway: my-gateway
+  name: cilium-gateway-my-gateway
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: my-gateway
+    uid: ""
+spec:
+  ports:
+  - name: port-443
+    port: 443
+    protocol: TCP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -37,6 +37,7 @@ func Test_translator_Translate(t *testing.T) {
 		{name: "basic_http_listener_external_traffic_policy"},
 		{name: "basic_http_listener_load_balancer"},
 		{name: "basic_tls_sni_listener"},
+		{name: "tls_sni_weighted_backends"},
 		{name: "conformance/httproute_simple_same_namespace"},
 		{name: "conformance/httproute_backend_protocol_h_2_c"},
 		{name: "conformance/httproute_cross_namespace"},

--- a/pkg/datapath/gneigh/gneigh.go
+++ b/pkg/datapath/gneigh/gneigh.go
@@ -207,6 +207,7 @@ func (s *ndSender) Send(ip netip.Addr, srcHW net.HardwareAddr) error {
 
 	msg := &ndp.NeighborAdvertisement{
 		TargetAddress: ip,
+		Override:      true,
 		Options: []ndp.Option{
 			&ndp.LinkLayerAddress{
 				Direction: ndp.Target,

--- a/pkg/datapath/gneigh/gneigh.go
+++ b/pkg/datapath/gneigh/gneigh.go
@@ -209,7 +209,7 @@ func (s *ndSender) Send(ip netip.Addr, srcHW net.HardwareAddr) error {
 		TargetAddress: ip,
 		Options: []ndp.Option{
 			&ndp.LinkLayerAddress{
-				Direction: ndp.Source,
+				Direction: ndp.Target,
 				Addr:      srcHW,
 			},
 		},

--- a/pkg/k8s/statedb.go
+++ b/pkg/k8s/statedb.go
@@ -55,6 +55,7 @@ func RegisterReflector[Obj any](jobGroup job.Group, db *statedb.DB, cfg Reflecto
 		db:              db,
 		table:           targetTable,
 		source:          source,
+		log:             slog.Default(),
 	}
 	wtxn := db.WriteTxn(targetTable)
 	r.initDone = targetTable.RegisterInitializer(wtxn, r.ReflectorConfig.Name)

--- a/pkg/mtu/mtu.go
+++ b/pkg/mtu/mtu.go
@@ -58,12 +58,14 @@ const (
 	// encapsulation.
 	//
 	// https://github.com/torvalds/linux/blob/v5.12/drivers/net/wireguard/device.c#L262:
+	// https://github.com/torvalds/linux/blob/v5.12/drivers/net/wireguard/send.c#L141
 	//      MESSAGE_MINIMUM_LENGTH:    32B
 	//      Outer IPv4 or IPv6 header: 40B
 	//      Outer UDP header:           8B
+	//      Maximum padding:           15B
 	//                                 ---
 	//      Total extra bytes:         80B
-	WireguardOverhead = 80
+	WireguardOverhead = 95
 
 	// IPv6MinMTU is the minimum MTU required for IPv6 to function on a
 	// network interface, as defined in RFC 8200 section 5. The Linux kernel

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -647,10 +647,11 @@ func (m *manager) nodeIdentityLabels(n nodeTypes.Node) (nodeLabels labels.Labels
 		hasOverride = true
 	} else if !n.IsLocal() && option.Config.PerNodeLabelsEnabled() {
 		lbls := labels.Map2Labels(n.Labels, labels.LabelSourceNode)
-		clusterLabel := labels.NewLabel(k8sConst.PolicyLabelCluster, n.Cluster, labels.LabelSourceK8s)
-		lbls[clusterLabel.Key] = clusterLabel
 		filteredLbls, _ := labelsfilter.FilterNodeLabels(lbls)
 		nodeLabels.MergeLabels(filteredLbls)
+		nodeLabels.MergeLabels(labels.Map2Labels(map[string]string{
+			k8sConst.PolicyLabelCluster: n.Cluster,
+		}, labels.LabelSourceK8s))
 	}
 
 	return nodeLabels, hasOverride

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -203,12 +203,12 @@ func (a *Agent) Stop(cell.HookContext) error {
 	return a.wgClient.Close()
 }
 
-// Name implements datapath.NodeHandler.
+// Name implements node.Handler.
 func (a *Agent) Name() string {
 	return "wireguard-agent"
 }
 
-// Returns true when enabled. Implements [types.WireguardAgent].
+// Returns true when enabled. Implements [types.Agent].
 func (a *Agent) Enabled() bool {
 	return a.config.Enabled()
 }
@@ -272,9 +272,19 @@ func (a *Agent) init() error {
 		_ = netlink.LinkDel(link)
 	}
 
+	// Best-effort MTU computation: account for WireGuard overhead including padding.
+	// Without this, the kernel defaults to 1500 - 80 = 1420, ignoring alignment padding.
+	// Worst case we set 1500 - 95 = 1405; the mtuReconciler will adjust once the MTU table is populated.
+	deviceMTU := mtu.EthernetMTU
+	if mtuRoute, _, _, found := a.mtuTable.GetWatch(a.db.ReadTxn(), mtu.MTURouteIndex.Query(mtu.DefaultPrefixV4)); found {
+		deviceMTU = mtuRoute.DeviceMTU
+	}
+	linkMTU := deviceMTU - mtu.WireguardOverhead
+
 	link = &netlink.Wireguard{
 		LinkAttrs: netlink.LinkAttrs{
 			Name: types.IfaceName,
+			MTU:  linkMTU,
 		},
 	}
 

--- a/pkg/wireguard/agent/cell_test.go
+++ b/pkg/wireguard/agent/cell_test.go
@@ -59,6 +59,9 @@ import (
 
 var TestTimeout = 5 * time.Second
 
+// Non-default device MTU for testing.
+const TestDeviceMTU = 1480
+
 // paramsOut holds the output parameters needed for running cells in the test.
 type paramsOut struct {
 	cell.Out
@@ -114,7 +117,6 @@ func TestPrivileged_TestWireGuardCell(t *testing.T) {
 	// getHive returns a new hive with Wireguard enabled/disabled.
 	getHive := func(wireguardEnabled bool) *hive.Hive {
 		return hive.New(
-			mtu.Cell,
 			nodeManager.Cell,
 			nodediscovery.Cell,
 			source.Cell,
@@ -136,6 +138,7 @@ func TestPrivileged_TestWireGuardCell(t *testing.T) {
 				newWireguardAgent,
 				newWireguardConfig,
 
+				mtu.NewMTUTable,
 				regeneration.NewFence,
 				tables.NewDeviceTable,
 				tables.NewNodeAddressTable,
@@ -143,6 +146,7 @@ func TestPrivileged_TestWireGuardCell(t *testing.T) {
 				ipcache.NewIPIdentitySynchronizer,
 				statedb.RWTable[*tables.Device].ToTable,
 				statedb.RWTable[tables.NodeAddress].ToTable,
+				statedb.RWTable[mtu.RouteMTU].ToTable,
 
 				func() paramsOut {
 					return paramsOut{
@@ -202,7 +206,17 @@ func TestPrivileged_TestWireGuardCell(t *testing.T) {
 					nodeStore = s
 					ipCache = i
 					cacheStatus = c
-				}),
+				},
+				func(db *statedb.DB, mtuTable statedb.RWTable[mtu.RouteMTU]) {
+					txn := db.WriteTxn(mtuTable)
+					mtuTable.Insert(txn, mtu.RouteMTU{
+						Prefix:    mtu.DefaultPrefixV4,
+						DeviceMTU: TestDeviceMTU,
+						RouteMTU:  TestDeviceMTU - mtu.WireguardOverhead,
+					})
+					txn.Commit()
+				},
+			),
 		)
 	}
 
@@ -221,10 +235,8 @@ func TestPrivileged_TestWireGuardCell(t *testing.T) {
 			link, err := safenetlink.LinkByName(types.IfaceName)
 			require.NoError(t, err)
 
-			// 4. Ensure the MTU is set accordingly (mtu-reconciler job).
-			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				assert.Equal(c, mtu.EthernetMTU-mtu.WireguardOverhead, link.Attrs().MTU)
-			}, TestTimeout, 50*time.Millisecond)
+			// 4. Ensure the MTU is set accordingly.
+			require.Equal(t, TestDeviceMTU-mtu.WireguardOverhead, link.Attrs().MTU)
 
 			// 5. Ensure local node has been updated (localnode-updater job).
 			require.EventuallyWithT(t, func(c *assert.CollectT) {


### PR DESCRIPTION
 * [x] #45937 (@nickolaev)
 * [x] #45967 (@ysksuzuki)
 * [x] #45940 (@smagnani96) :warning: resolved conflicts
 * #45927 (@rastislavs) skipped due to usage of non-existing in 1.19 `bgp/fake` package in tests
 * [x] #46070 (@joestringer)
 * [x] #46079 (@giorio94)
 * [ ] #46093 (@salamidrus)
 * [x] #46068 (@MrFreezeex) :warning: resolved conflicts. didn't backport test changes because of too many conflicts
 * [x] #45780 (@adamwathieu)
 * [ ] #45782 (@weizhoublue)

Removed:
 * [x] #46031 (@mhofstetter) :warning: resolved conflicts

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 45937 45967 45940 46070 46079 46093 46068 45780 45782
```
