### PR TITLE
gha: make conformance kubespray runner configurable

### DIFF
--- a/.github/workflows/conformance-kubespray.yaml
+++ b/.github/workflows/conformance-kubespray.yaml
@@ -103,7 +103,7 @@ jobs:
 
   installation-and-connectivity:
     name: Installation and Connectivity Test
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
     needs: wait-for-images
     timeout-minutes: 60
     env:


### PR DESCRIPTION
Let's match the configuration already used by most of the other conformance workflows, and allow configuring the runner via the dedicated environment variable. The default value matches the current setting, so that nothing changes if not specified.
