### PR TITLE
workflows/verifier: Fix scheduled runs

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -201,7 +201,10 @@ jobs:
         with:
           provision: 'false'
           cmd: |
-            cd /host/pull
+            cd /host/base
+            if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+              cd /host/pull
+            fi
             export TMPDIR=/var/tmp
             export GOCACHE=/host/gocache
             mkdir -p /host/datapath-verifier /host/gocache


### PR DESCRIPTION
Commit 9cea129a6b81 ("workflows/verifier: Run consistent version of tests") changed the verifier workflow to always run the version of the tests from the pull request. Obviously that broke scheduled runs where we don't have a pull request... This commit fixes it.

Fixes: https://github.com/cilium/cilium/pull/45880.