### PR TITLE
gh: kpr-aks: disable IPsec testing

### DIFF
--- a/.github/workflows/conformance-kpr-aks.yaml
+++ b/.github/workflows/conformance-kpr-aks.yaml
@@ -108,17 +108,18 @@ jobs:
       SHA: ${{ inputs.SHA || github.sha }}
       extra-args: '{"kpr": true, "bpf-masq-v4": true, "advanced-features": true}'
 
-  conformance-aks-kpr-ipsec:
-    name: Conformance AKS with KPR + IPsec
-    needs: wait-for-images
-    uses: ./.github/workflows/conformance-aks.yaml
-    secrets: inherit
-    with:
-      PR-number: ${{ inputs.PR-number || github.ref_name }}
-      UID: 2
-      context-ref: ${{ inputs.context-ref || github.sha }}
-      SHA: ${{ inputs.SHA || github.sha }}
-      extra-args: '{"kpr": true, "bpf-masq-v4": true, "advanced-features": true, "ipsec": true}'
+# AKS currently doesn't support IPsec (https://github.com/cilium/cilium/issues/46023)
+#  conformance-aks-kpr-ipsec:
+#    name: Conformance AKS with KPR + IPsec
+#    needs: wait-for-images
+#    uses: ./.github/workflows/conformance-aks.yaml
+#    secrets: inherit
+#    with:
+#      PR-number: ${{ inputs.PR-number || github.ref_name }}
+#      UID: 2
+#      context-ref: ${{ inputs.context-ref || github.sha }}
+#      SHA: ${{ inputs.SHA || github.sha }}
+#      extra-args: '{"kpr": true, "bpf-masq-v4": true, "advanced-features": true, "ipsec": true}'
 
   conformance-aks-kpr-wireguard:
     name: Conformance AKS with KPR + WireGuard
@@ -135,10 +136,12 @@ jobs:
   merge-upload-and-status:
     name: Merge Upload and Status
     if: ${{ always() }}
-    needs: [conformance-aks-kpr, conformance-aks-kpr-ipsec, conformance-aks-kpr-wireguard]
+#    needs: [conformance-aks-kpr, conformance-aks-kpr-ipsec, conformance-aks-kpr-wireguard]
+    needs: [conformance-aks-kpr, conformance-aks-kpr-wireguard]
     uses: ./.github/workflows/common-post-jobs.yaml
     secrets: inherit
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ (needs.conformance-aks-kpr.result == 'success' && needs.conformance-aks-kpr-ipsec.result == 'success' && needs.conformance-aks-kpr-wireguard.result == 'success') }}
+#      success: ${{ (needs.conformance-aks-kpr.result == 'success' && needs.conformance-aks-kpr-ipsec.result == 'success' && needs.conformance-aks-kpr-wireguard.result == 'success') }}
+      success: ${{ (needs.conformance-aks-kpr.result == 'success' && needs.conformance-aks-kpr-wireguard.result == 'success') }}


### PR DESCRIPTION
AKS has applied a big hammer to disable IPsec in their clusters (see https://github.com/cilium/cilium/issues/46023), causing a cluster with such a config to fail on startup.

Until AKS has addressed this issue, let's not bother running IPsec tests.