### PR TITLE
gateway-api: Add TCPRoute and UDPRoute support

### DIFF
--- a/Makefile.kind
+++ b/Makefile.kind
@@ -384,6 +384,8 @@ kind-servicemesh-install-cilium: check_deps kind-ready ## Install a local Cilium
 	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_grpcroutes.yaml
 	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_backendtlspolicies.yaml
 	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_tlsroutes.yaml
+	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_tcproutes.yaml
+	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_udproutes.yaml
 
 	$(CILIUM_CLI) install \
 		--chart-directory=$(ROOT_DIR)/install/kubernetes/cilium \

--- a/contrib/scripts/kind.sh
+++ b/contrib/scripts/kind.sh
@@ -67,8 +67,8 @@ readonly secondary_network_flag
 readonly optimize_sysctl
 readonly external_dns
 
-controlplanes="${1:-${CONTROLPLANES:=${default_controlplanes}}}"
-workers="${2:-${WORKERS:=${default_workers}}}"
+controlplanes="${1-${CONTROLPLANES-${default_controlplanes}}}"
+workers="${2-${WORKERS-${default_workers}}}"
 cluster_name="${3:-${CLUSTER_NAME:=${default_cluster_name}}}"
 # IMAGE controls the K8s version as well (e.g. kindest/node:v1.11.10)
 image="${4:-${IMAGE:=${default_image}}}"
@@ -176,10 +176,12 @@ control_planes() {
 }
 
 workers() {
-  for i in $(seq 1 "${workers}"); do
-    echo "- role: worker"
-    node_config "1" "$i" "${workers}"
-  done
+  if [ "${workers}" -gt 0 ]; then
+    for i in $(seq 1 "${workers}"); do
+      echo "- role: worker"
+      node_config "1" "$i" "${workers}"
+    done
+  fi
 }
 
 echo "${kind_cmd}"

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -347,6 +347,8 @@ rules:
   resources:
   - gatewayclasses
   - gateways
+  - tcproutes
+  - udproutes
   - tlsroutes
   - httproutes
   - grpcroutes
@@ -372,6 +374,8 @@ rules:
   - grpcroutes/status
   - tlsroutes/status
   - backendtlspolicies/status
+  - tcproutes/status
+  - udproutes/status
   verbs:
   - update
   - patch

--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -427,6 +427,7 @@ func registerReconcilers(mgr ctrlRuntime.Manager, translator translation.Transla
 		newGatewayReconciler(mgr, translator, logger, installedCRDs),
 		newGammaReconciler(mgr, translator, logger),
 		newGatewayClassConfigReconciler(mgr, logger),
+		newEndpointSliceReconciler(mgr, logger),
 	}
 
 	for _, r := range requiredReconcilers {
@@ -445,6 +446,14 @@ func registerReconcilers(mgr ctrlRuntime.Manager, translator translation.Transla
 			// TLSRoute is reconciled by the Gateway API reconciler, but log that the
 			// support has been successfully enabled.
 			logger.Info("TLSRoute CRD is installed, TLSRoute support is enabled")
+		case helpers.TCPRouteKind:
+			// TCPRoute is reconciled by the Gateway API reconciler, but log that the
+			// support has been successfully enabled.
+			logger.Info("TCPRoute CRD is installed, TCPRoute support is enabled")
+		case helpers.UDPRouteKind:
+			// UDPRoute is reconciled by the Gateway API reconciler, but log that the
+			// support has been successfully enabled.
+			logger.Info("UDPRoute CRD is installed, UDPRoute support is enabled")
 		case helpers.ServiceImportKind:
 			// we don't need a reconciler, but we do need to tell folks that the
 			// support is working.

--- a/operator/pkg/gateway-api/endpointslice_reconcile.go
+++ b/operator/pkg/gateway-api/endpointslice_reconcile.go
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gateway_api
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	controllerruntime "github.com/cilium/cilium/operator/pkg/controller-runtime"
+	"github.com/cilium/cilium/operator/pkg/gateway-api/predicates"
+	watchhandlers "github.com/cilium/cilium/operator/pkg/gateway-api/watch-handlers"
+	gwModel "github.com/cilium/cilium/operator/pkg/model/translation/gateway-api"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// endpointSliceReconciler keeps the Endpoints and resolved target port of
+// operator-managed frontend EndpointSlices in sync with the referenced backend
+// Service.
+//
+// Ownership split with the gatewayReconciler:
+//   - gatewayReconciler owns slice identity (Ports name/protocol, labels,
+//     annotations, OwnerReferences, stale-slice deletion) and seeds new slices
+//     with empty Endpoints.
+//   - endpointSliceReconciler owns the data-plane fields: Endpoints and the
+//     resolved numeric value applied uniformly across every Ports[].Port entry.
+//
+// Splitting writes between the two reconcilers prevents update loops.
+type endpointSliceReconciler struct {
+	client.Client
+	logger *slog.Logger
+}
+
+func newEndpointSliceReconciler(mgr ctrl.Manager, logger *slog.Logger) *endpointSliceReconciler {
+	return &endpointSliceReconciler{
+		Client: mgr.GetClient(),
+		logger: logger.With(logfields.Controller, endpointSlice),
+	}
+}
+
+// SetupWithManager wires the reconciler into the controller-runtime manager.
+func (r *endpointSliceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(endpointSlice).
+		For(&discoveryv1.EndpointSlice{},
+			builder.WithPredicates(predicates.ManagedFrontendEndpointSlice())).
+		Watches(&discoveryv1.EndpointSlice{},
+			watchhandlers.EnqueueFrontendsForBackendEndpointSlice(r.Client, r.logger),
+			builder.WithPredicates(predicates.NonManagedEndpointSlice())).
+		Watches(&corev1.Service{},
+			watchhandlers.EnqueueFrontendsForBackendService(r.Client, r.logger)).
+		Complete(r)
+}
+
+// Reconcile populates the endpoints and target port of a managed frontend
+// EndpointSlice from the backend Service and its own EndpointSlices.
+func (r *endpointSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	scopedLog := r.logger.With(logfields.Resource, req.NamespacedName)
+
+	frontend := &discoveryv1.EndpointSlice{}
+	if err := r.Client.Get(ctx, req.NamespacedName, frontend); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return controllerruntime.Success()
+		}
+		return controllerruntime.Fail(err)
+	}
+	if !predicates.IsManagedFrontendEndpointSlice(frontend) {
+		return controllerruntime.Success()
+	}
+
+	backendRef := frontend.Annotations[gwModel.BackendServiceAnnotation]
+	if backendRef == "" {
+		scopedLog.WarnContext(ctx, "Managed EndpointSlice missing backend-service annotation, skipping")
+		return controllerruntime.Success()
+	}
+	backendNs, backendName, ok := strings.Cut(backendRef, "/")
+	if !ok || backendNs == "" || backendName == "" {
+		scopedLog.WarnContext(ctx, "Invalid backend-service annotation",
+			"annotation", backendRef)
+		return controllerruntime.Success()
+	}
+
+	servicePort, err := strconv.ParseUint(frontend.Annotations[gwModel.BackendPortAnnotation], 10, 16)
+	if err != nil {
+		return controllerruntime.Fail(fmt.Errorf("invalid backend-port annotation %q: %w",
+			frontend.Annotations[gwModel.BackendPortAnnotation], err))
+	}
+
+	backendSvc := &corev1.Service{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: backendNs, Name: backendName}, backendSvc); err != nil {
+		if k8serrors.IsNotFound(err) {
+			scopedLog.DebugContext(ctx, "Backend Service not found, clearing endpoints",
+				"backend", backendRef)
+			return r.patchFrontend(ctx, frontend, nil, nil)
+		}
+		return controllerruntime.Fail(fmt.Errorf("failed to get backend Service %s: %w", backendRef, err))
+	}
+
+	matchedPort := matchServicePort(backendSvc.Spec.Ports, uint16(servicePort), portProtocol(frontend.Ports))
+	if matchedPort == nil {
+		scopedLog.WarnContext(ctx, "Backend Service does not expose requested port; clearing endpoints",
+			"backend", backendRef,
+			"port", servicePort,
+		)
+		return r.patchFrontend(ctx, frontend, nil, nil)
+	}
+
+	endpointPort, addresses, err := r.resolveBackendEndpoints(ctx, backendNs, backendName, frontend.AddressType, *matchedPort)
+	if err != nil {
+		return controllerruntime.Fail(err)
+	}
+	if endpointPort == nil {
+		// Backend Service exists but no matching EndpointSlice port resolved yet.
+		// Keep frontend port name/proto stable; clear endpoints until backend appears.
+		return r.patchFrontend(ctx, frontend, nil, nil)
+	}
+
+	return r.patchFrontend(ctx, frontend, endpointPort, addresses)
+}
+
+func (r *endpointSliceReconciler) patchFrontend(ctx context.Context, frontend *discoveryv1.EndpointSlice, port *int32, endpoints []discoveryv1.Endpoint) (ctrl.Result, error) {
+	updated := &discoveryv1.EndpointSlice{}
+	updated.Name = frontend.Name
+	updated.Namespace = frontend.Namespace
+
+	_, err := controllerutil.CreateOrPatch(ctx, r.Client, updated, func() error {
+		updated.Endpoints = endpoints
+		if port != nil {
+			// All EndpointPort entries in a managed frontend slice share the
+			// same backend Service port (see toL4EndpointSlices dedup), so they
+			// all resolve to the same target pod port. Apply the resolved port
+			// uniformly so per-listener name lookups in the LB reflector see
+			// matching numeric ports.
+			for i := range updated.Ports {
+				updated.Ports[i].Port = port
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return controllerruntime.Fail(fmt.Errorf("failed to patch frontend EndpointSlice: %w", err))
+	}
+	return controllerruntime.Success()
+}
+
+// matchServicePort returns the ServicePort matching the requested port number
+// and protocol, or nil when not found.
+func matchServicePort(ports []corev1.ServicePort, want uint16, proto corev1.Protocol) *corev1.ServicePort {
+	for i := range ports {
+		p := ports[i]
+		if uint16(p.Port) != want {
+			continue
+		}
+		if p.Protocol != "" && p.Protocol != proto {
+			continue
+		}
+		return &p
+	}
+	return nil
+}
+
+// resolveBackendEndpoints returns the resolved target port and endpoint addresses
+// for the given backend Service's ServicePort. The target port is determined by
+// matching backend EndpointSlice ports by name (preferred) or by port number.
+func (r *endpointSliceReconciler) resolveBackendEndpoints(ctx context.Context, ns, svcName string, family discoveryv1.AddressType, svcPort corev1.ServicePort) (*int32, []discoveryv1.Endpoint, error) {
+	list := &discoveryv1.EndpointSliceList{}
+	if err := r.Client.List(ctx, list,
+		client.InNamespace(ns),
+		client.MatchingLabels{gwModel.EndpointSliceServiceNameLabel: svcName},
+	); err != nil {
+		return nil, nil, fmt.Errorf("failed to list backend EndpointSlices for %s/%s: %w", ns, svcName, err)
+	}
+
+	var resolvedPort *int32
+	addrSeen := make(map[string]struct{})
+	var endpoints []discoveryv1.Endpoint
+	for i := range list.Items {
+		be := list.Items[i]
+		if be.AddressType != family {
+			continue
+		}
+		if predicates.IsManagedFrontendEndpointSlice(&be) {
+			continue
+		}
+		bePort := matchEndpointSlicePort(be.Ports, svcPort)
+		if bePort == nil {
+			continue
+		}
+		if resolvedPort == nil {
+			resolvedPort = ptr.To(*bePort)
+		}
+		for _, ep := range be.Endpoints {
+			if len(ep.Addresses) == 0 {
+				continue
+			}
+			key := strings.Join(ep.Addresses, ",")
+			if _, ok := addrSeen[key]; ok {
+				continue
+			}
+			addrSeen[key] = struct{}{}
+			endpoints = append(endpoints, discoveryv1.Endpoint{
+				Addresses:  append([]string(nil), ep.Addresses...),
+				Conditions: ep.Conditions,
+				Hostname:   ep.Hostname,
+				TargetRef:  ep.TargetRef,
+				NodeName:   ep.NodeName,
+				Zone:       ep.Zone,
+				Hints:      ep.Hints,
+			})
+		}
+	}
+
+	sort.SliceStable(endpoints, func(i, j int) bool {
+		return strings.Join(endpoints[i].Addresses, ",") < strings.Join(endpoints[j].Addresses, ",")
+	})
+	return resolvedPort, endpoints, nil
+}
+
+// matchEndpointSlicePort returns the EPS port number whose name matches the
+// ServicePort name, or whose numeric port matches the ServicePort targetPort.
+func matchEndpointSlicePort(ports []discoveryv1.EndpointPort, svcPort corev1.ServicePort) *int32 {
+	wantProto := svcPort.Protocol
+	wantName := svcPort.Name
+	wantNumeric := int32(0)
+	if svcPort.TargetPort.Type == 0 { // intstr.Int
+		wantNumeric = svcPort.TargetPort.IntVal
+	}
+
+	for _, p := range ports {
+		if p.Port == nil {
+			continue
+		}
+		if p.Protocol != nil && wantProto != "" && *p.Protocol != wantProto {
+			continue
+		}
+		// Prefer name match.
+		if p.Name != nil && wantName != "" && *p.Name == wantName {
+			return p.Port
+		}
+		// Fall back to numeric targetPort match.
+		if wantNumeric != 0 && *p.Port == wantNumeric {
+			return p.Port
+		}
+	}
+	// If the Service has only one port and no name match was found, use the first EPS port.
+	if len(ports) == 1 && ports[0].Port != nil {
+		return ports[0].Port
+	}
+	return nil
+}
+
+func portProtocol(ports []discoveryv1.EndpointPort) corev1.Protocol {
+	for _, p := range ports {
+		if p.Protocol != nil {
+			return *p.Protocol
+		}
+	}
+	return corev1.ProtocolTCP
+}

--- a/operator/pkg/gateway-api/gamma_reconcile.go
+++ b/operator/pkg/gateway-api/gamma_reconcile.go
@@ -137,7 +137,7 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	setGammaServiceAccepted(svc, true, "Gamma Service has routes attached", CiliumGammaReasonAccepted)
 
-	cec, _, cep, err := r.translator.Translate(&model.Model{HTTP: httpListeners})
+	cec, _, ceps, err := r.translator.Translate(&model.Model{HTTP: httpListeners})
 	if err != nil {
 		scopedLog.ErrorContext(ctx, "Unable to translate resources", logfields.Error, err)
 		return r.handleReconcileErrorWithStatus(ctx, err, originalSvc, svc)
@@ -148,9 +148,13 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return r.handleReconcileErrorWithStatus(ctx, err, originalSvc, svc)
 	}
 
-	if err = r.ensureEndpointSlice(ctx, cep); err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to ensure Endpoints", logfields.Error, err)
-		return r.handleReconcileErrorWithStatus(ctx, err, originalSvc, svc)
+	// GAMMA only ever produces a single dummy EndpointSlice; unwrap from the
+	// shared Translator interface that returns a list to support gateway-api L4.
+	if len(ceps) > 0 {
+		if err = r.ensureEndpointSlice(ctx, ceps[0]); err != nil {
+			scopedLog.ErrorContext(ctx, "Unable to ensure Endpoints", logfields.Error, err)
+			return r.handleReconcileErrorWithStatus(ctx, err, originalSvc, svc)
+		}
 	}
 
 	setGammaServiceProgrammed(svc, true, "Gamma Service has been programmed", CiliumGammaReasonProgrammed)

--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
@@ -31,6 +32,7 @@ import (
 const (
 	// Deprecated: owningGatewayLabel will be removed later in favour of gatewayNameLabel
 	owningGatewayLabel = "io.cilium.gateway/owning-gateway"
+	gatewayNameLabel   = "gateway.networking.k8s.io/gateway-name"
 
 	lastTransitionTime = "LastTransitionTime"
 )
@@ -61,10 +63,14 @@ func newGatewayReconciler(mgr ctrl.Manager, translator translation.Translator, l
 // The reconciler will be triggered by Gateway, or any cilium-managed GatewayClass events
 func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Determine which optional CRDs are enabled
-	var serviceImportEnabled bool
+	var tcpRouteEnabled, udpRouteEnabled, serviceImportEnabled bool
 
 	for _, gvk := range r.installedCRDs {
 		switch gvk.Kind {
+		case helpers.TCPRouteKind:
+			tcpRouteEnabled = true
+		case helpers.UDPRouteKind:
+			udpRouteEnabled = true
 		case helpers.ServiceImportKind:
 			serviceImportEnabled = true
 		}
@@ -99,6 +105,30 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	} {
 		if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.TLSRoute{}, indexName, indexerFunc); err != nil {
 			return fmt.Errorf("failed to setup field indexer %q: %w", indexName, err)
+		}
+	}
+
+	// Add indexes for TCPRoutes
+	if tcpRouteEnabled {
+		for indexName, indexerFunc := range map[string]client.IndexerFunc{
+			indexers.BackendServiceTCPRouteIndex: indexers.GenerateIndexerTCPRoutebyBackendService(r.Client, r.logger),
+			indexers.GatewayTCPRouteIndex:        indexers.IndexTCPRouteByGateway,
+		} {
+			if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1alpha2.TCPRoute{}, indexName, indexerFunc); err != nil {
+				return fmt.Errorf("failed to setup field indexer %q: %w", indexName, err)
+			}
+		}
+	}
+
+	// Add indexes for UDPRoutes
+	if udpRouteEnabled {
+		for indexName, indexerFunc := range map[string]client.IndexerFunc{
+			indexers.BackendServiceUDPRouteIndex: indexers.GenerateIndexerUDPRoutebyBackendService(r.Client, r.logger),
+			indexers.GatewayUDPRouteIndex:        indexers.IndexUDPRouteByGateway,
+		} {
+			if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1alpha2.UDPRoute{}, indexName, indexerFunc); err != nil {
+				return fmt.Errorf("failed to setup field indexer %q: %w", indexName, err)
+			}
 		}
 	}
 
@@ -151,6 +181,16 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&ciliumv2.CiliumEnvoyConfig{}).
 		Owns(&corev1.Service{}).
 		Owns(&discoveryv1.EndpointSlice{})
+
+	if tcpRouteEnabled {
+		// Watch TCPRoute linked to Gateway
+		gatewayBuilder = gatewayBuilder.Watches(&gatewayv1alpha2.TCPRoute{}, watchhandlers.EnqueueRequestForOwningTCPRoute(r.Client, r.logger, helpers.CiliumDefaultControllerName))
+	}
+
+	if udpRouteEnabled {
+		// Watch UDPRoute linked to Gateway
+		gatewayBuilder = gatewayBuilder.Watches(&gatewayv1alpha2.UDPRoute{}, watchhandlers.EnqueueRequestForOwningUDPRoute(r.Client, r.logger, helpers.CiliumDefaultControllerName))
+	}
 
 	if serviceImportEnabled {
 		// Watch for changes to Backend Service Imports

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 
 	controllerruntime "github.com/cilium/cilium/operator/pkg/controller-runtime"
@@ -133,6 +134,26 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 	btlspMap := helpers.BuildBackendTLSPolicyLookup(btlspList)
 
+	tcpRouteList := &gatewayv1alpha2.TCPRouteList{}
+	if helpers.HasTCPRouteSupport(r.Client.Scheme()) {
+		if err := r.Client.List(ctx, tcpRouteList, &client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector(indexers.GatewayTCPRouteIndex, client.ObjectKeyFromObject(original).String()),
+		}); err != nil {
+			scopedLog.ErrorContext(ctx, "Unable to list TCPRoutes", logfields.Error, err)
+			return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+		}
+	}
+
+	udpRouteList := &gatewayv1alpha2.UDPRouteList{}
+	if helpers.HasUDPRouteSupport(r.Client.Scheme()) {
+		if err := r.Client.List(ctx, udpRouteList, &client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector(indexers.GatewayUDPRouteIndex, client.ObjectKeyFromObject(original).String()),
+		}); err != nil {
+			scopedLog.ErrorContext(ctx, "Unable to list UDPRoutes", logfields.Error, err)
+			return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+		}
+	}
+
 	// TODO(tam): Only list the services / ServiceImports used by accepted Routes
 	servicesList := &corev1.ServiceList{}
 	if err := r.Client.List(ctx, servicesList); err != nil {
@@ -173,6 +194,22 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 	}
 
+	// Run the TCPRoute route checks here and update the status accordingly.
+	if helpers.HasTCPRouteSupport(r.Client.Scheme()) {
+		if err := r.setTCPRouteStatuses(scopedLog, ctx, tcpRouteList, grants); err != nil {
+			scopedLog.ErrorContext(ctx, "Unable to update TCPRoute Status", logfields.Error, err)
+			return controllerruntime.Fail(err)
+		}
+	}
+
+	// Run the UDPRoute route checks here and update the status accordingly.
+	if helpers.HasUDPRouteSupport(r.Client.Scheme()) {
+		if err := r.setUDPRouteStatuses(scopedLog, ctx, udpRouteList, grants); err != nil {
+			scopedLog.ErrorContext(ctx, "Unable to update UDPRoute Status", logfields.Error, err)
+			return controllerruntime.Fail(err)
+		}
+	}
+
 	// Run the GRPCRoute route checks here and update the status accordingly.
 	if err := r.setGRPCRouteStatuses(scopedLog, ctx, grpcRouteList, grants); err != nil {
 		scopedLog.ErrorContext(ctx, "Unable to update GRPCRoute Status", logfields.Error, err)
@@ -182,26 +219,30 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	httpRoutes := r.filterHTTPRoutesByGateway(ctx, gw, httpRouteList.Items)
 	tlsRoutes := r.filterTLSRoutesByGateway(ctx, gw, tlsRouteList.Items)
 	grpcRoutes := r.filterGRPCRoutesByGateway(ctx, gw, grpcRouteList.Items)
+	tcpRoutes := r.filterTCPRoutesByGateway(ctx, gw, tcpRouteList.Items)
+	udpRoutes := r.filterUDPRoutesByGateway(ctx, gw, udpRouteList.Items)
 
 	if err := r.setBackendTLSPolicyStatuses(scopedLog, ctx, httpRoutes, btlspMap, req.NamespacedName); err != nil {
 		scopedLog.ErrorContext(ctx, "Unable to update BackendTLSPolicy Status", logfields.Error, err)
 		return controllerruntime.Fail(err)
 	}
 
-	httpListeners, tlsPassthroughListeners := ingestion.GatewayAPI(scopedLog, ingestion.Input{
+	httpListeners, tlsPassthroughListeners, l4Listeners := ingestion.GatewayAPI(scopedLog, ingestion.Input{
 		GatewayClass:        *gwc,
 		GatewayClassConfig:  r.getGatewayClassConfig(ctx, gwc),
 		Gateway:             *gw,
 		HTTPRoutes:          httpRoutes,
 		TLSRoutes:           tlsRoutes,
 		GRPCRoutes:          grpcRoutes,
+		TCPRoutes:           tcpRoutes,
+		UDPRoutes:           udpRoutes,
 		Services:            servicesList.Items,
 		ServiceImports:      serviceImportsList.Items,
 		ReferenceGrants:     grants.Items,
 		BackendTLSPolicyMap: btlspMap,
 	})
 
-	validListener, err := r.setListenerStatus(ctx, gw, httpRouteList, tlsRouteList, grpcRouteList)
+	validListener, err := r.setListenerStatus(ctx, gw, httpRouteList, tlsRouteList, grpcRouteList, tcpRouteList, udpRouteList)
 	if err != nil {
 		scopedLog.ErrorContext(ctx, "Unable to set listener status", logfields.Error, err)
 		setGatewayAccepted(gw, false, "Unable to set listener status", gatewayv1.GatewayReasonNoResources)
@@ -218,7 +259,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	setGatewayAccepted(gw, true, "Gateway successfully scheduled", gatewayv1.GatewayReasonAccepted)
 
 	// Step 3: Translate the listeners into Cilium model
-	cec, svc, ep, err := r.translator.Translate(&model.Model{HTTP: httpListeners, TLSPassthrough: tlsPassthroughListeners})
+	cec, svc, eps, err := r.translator.Translate(&model.Model{HTTP: httpListeners, TLSPassthrough: tlsPassthroughListeners, L4: l4Listeners})
 	if err != nil {
 		scopedLog.ErrorContext(ctx, "Unable to translate resources", logfields.Error, err)
 		setGatewayAccepted(gw, false, "Unable to translate resources", gatewayv1.GatewayReasonNoResources)
@@ -238,10 +279,10 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
 
-	if err = r.ensureEndpointSlice(ctx, ep); err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to ensure Endpoints", logfields.Error, err)
-		setGatewayAccepted(gw, false, "Unable to ensure Endpoints resource", gatewayv1.GatewayReasonNoResources)
-		setGatewayProgrammed(gw, metav1.ConditionFalse, "Unable to create Endpoints resource", gatewayv1.GatewayReasonNoResources)
+	if err = r.reconcileEndpointSlices(ctx, gw, svc, eps); err != nil {
+		scopedLog.ErrorContext(ctx, "Unable to reconcile EndpointSlices", logfields.Error, err)
+		setGatewayAccepted(gw, false, "Unable to reconcile EndpointSlices", gatewayv1.GatewayReasonNoResources)
+		setGatewayProgrammed(gw, metav1.ConditionFalse, "Unable to reconcile EndpointSlices", gatewayv1.GatewayReasonNoResources)
 		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
 
@@ -292,11 +333,25 @@ func (r *gatewayReconciler) ensureService(ctx context.Context, desired *corev1.S
 	return err
 }
 
+// ensureEndpointSlice creates or updates a managed frontend EndpointSlice.
+// Endpoints and the numeric Ports[0].Port are owned by endpointSliceReconciler
+// once it has populated Endpoints; this avoids a write-fight between the two.
 func (r *gatewayReconciler) ensureEndpointSlice(ctx context.Context, desired *discoveryv1.EndpointSlice) error {
-	eps := desired.DeepCopy()
+	eps := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      desired.Name,
+			Namespace: desired.Namespace,
+		},
+	}
 	_, err := controllerutil.CreateOrPatch(ctx, r.Client, eps, func() error {
-		eps.Endpoints = desired.Endpoints
-		eps.Ports = desired.Ports
+		if eps.ResourceVersion == "" {
+			eps.AddressType = desired.AddressType
+			eps.Endpoints = desired.Endpoints
+			eps.Ports = desired.Ports
+		} else {
+			resolved := len(eps.Endpoints) > 0
+			eps.Ports = mergeEndpointPorts(eps.Ports, desired.Ports, resolved)
+		}
 		eps.OwnerReferences = desired.OwnerReferences
 		setMergedLabelsAndAnnotations(eps, desired)
 		return nil
@@ -304,7 +359,27 @@ func (r *gatewayReconciler) ensureEndpointSlice(ctx context.Context, desired *di
 	return err
 }
 
+// mergeEndpointPorts takes Name and Protocol from desired; the numeric Port
+// is kept from existing when preservePort is true (owned by
+// endpointSliceReconciler), otherwise taken from desired.
+func mergeEndpointPorts(existing, desired []discoveryv1.EndpointPort, preservePort bool) []discoveryv1.EndpointPort {
+	if len(existing) != len(desired) {
+		return desired
+	}
+	out := make([]discoveryv1.EndpointPort, len(desired))
+	for i := range desired {
+		out[i] = desired[i]
+		if preservePort && existing[i].Port != nil {
+			out[i].Port = existing[i].Port
+		}
+	}
+	return out
+}
+
 func (r *gatewayReconciler) ensureEnvoyConfig(ctx context.Context, desired *ciliumv2.CiliumEnvoyConfig) error {
+	if desired == nil {
+		return nil
+	}
 	cec := desired.DeepCopy()
 	_, err := controllerutil.CreateOrPatch(ctx, r.Client, cec, func() error {
 		cec.Spec = desired.Spec
@@ -312,6 +387,104 @@ func (r *gatewayReconciler) ensureEnvoyConfig(ctx context.Context, desired *cili
 		return nil
 	})
 	return err
+}
+
+// reconcileEndpointSlices applies the desired EndpointSlices and deletes
+// stale ones owned by the Gateway. Endpoints are populated later by
+// endpointSliceReconciler from the backend Service's own EndpointSlices.
+func (r *gatewayReconciler) reconcileEndpointSlices(ctx context.Context, gw *gatewayv1.Gateway, svc *corev1.Service, desired []*discoveryv1.EndpointSlice) error {
+	desired = r.filterEndpointSlicesByBackendFamilies(ctx, desired)
+
+	desiredByName := make(map[string]*discoveryv1.EndpointSlice, len(desired))
+	for _, d := range desired {
+		desiredByName[d.Name] = d
+		if err := r.ensureEndpointSlice(ctx, d); err != nil {
+			return err
+		}
+	}
+
+	if svc == nil {
+		return nil
+	}
+
+	existing := &discoveryv1.EndpointSliceList{}
+	if err := r.Client.List(ctx, existing,
+		client.InNamespace(gw.Namespace),
+		client.MatchingLabels{
+			gatewayApiTranslation.EndpointSliceServiceNameLabel: svc.Name,
+			gatewayApiTranslation.EndpointSliceManagedByLabel:   gatewayApiTranslation.EndpointSliceManagedByValue,
+		},
+	); err != nil {
+		return fmt.Errorf("failed to list managed EndpointSlices: %w", err)
+	}
+
+	for i := range existing.Items {
+		eps := existing.Items[i]
+		if !metav1.IsControlledBy(&eps, gw) {
+			continue
+		}
+		if _, ok := desiredByName[eps.Name]; ok {
+			continue
+		}
+		if err := client.IgnoreNotFound(r.Client.Delete(ctx, &eps)); err != nil {
+			return fmt.Errorf("failed to delete stale EndpointSlice %s/%s: %w", eps.Namespace, eps.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// filterEndpointSlicesByBackendFamilies drops slices whose AddressType is not
+// in the referenced backend Service's IPFamilies, mirroring how
+// kube-controller-manager only emits slices for supported families. Slices
+// are kept when the backend Service is missing or its IPFamilies is unset so
+// the next reconcile can correct them.
+func (r *gatewayReconciler) filterEndpointSlicesByBackendFamilies(ctx context.Context, desired []*discoveryv1.EndpointSlice) []*discoveryv1.EndpointSlice {
+	type backendKey struct{ ns, name string }
+	cache := map[backendKey]map[corev1.IPFamily]struct{}{}
+
+	out := make([]*discoveryv1.EndpointSlice, 0, len(desired))
+	for _, s := range desired {
+		ref := s.Annotations[gatewayApiTranslation.BackendServiceAnnotation]
+		ns, name, ok := strings.Cut(ref, "/")
+		if !ok || ns == "" || name == "" {
+			out = append(out, s)
+			continue
+		}
+		key := backendKey{ns, name}
+		fams, cached := cache[key]
+		if !cached {
+			be := &corev1.Service{}
+			if err := r.Client.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, be); err != nil {
+				cache[key] = nil
+				out = append(out, s)
+				continue
+			}
+			fams = make(map[corev1.IPFamily]struct{}, len(be.Spec.IPFamilies))
+			for _, f := range be.Spec.IPFamilies {
+				fams[f] = struct{}{}
+			}
+			cache[key] = fams
+		}
+		if len(fams) == 0 {
+			out = append(out, s)
+			continue
+		}
+		var want corev1.IPFamily
+		switch s.AddressType {
+		case discoveryv1.AddressTypeIPv4:
+			want = corev1.IPv4Protocol
+		case discoveryv1.AddressTypeIPv6:
+			want = corev1.IPv6Protocol
+		default:
+			out = append(out, s)
+			continue
+		}
+		if _, ok := fams[want]; ok {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 func (r *gatewayReconciler) cleanupOwnedResources(ctx context.Context, gw *gatewayv1.Gateway) error {
@@ -468,12 +641,56 @@ func (r *gatewayReconciler) filterTLSRoutesByGateway(ctx context.Context, gw *ga
 	return filtered
 }
 
+func (r *gatewayReconciler) filterTCPRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, routes []gatewayv1alpha2.TCPRoute) []gatewayv1alpha2.TCPRoute {
+	var filtered []gatewayv1alpha2.TCPRoute
+	for _, route := range routes {
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(ctx, r.Client, gw, &route, r.logger) {
+			filtered = append(filtered, route)
+		}
+	}
+	return filtered
+}
+
+func (r *gatewayReconciler) filterUDPRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, routes []gatewayv1alpha2.UDPRoute) []gatewayv1alpha2.UDPRoute {
+	var filtered []gatewayv1alpha2.UDPRoute
+	for _, route := range routes {
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(ctx, r.Client, gw, &route, r.logger) {
+			filtered = append(filtered, route)
+		}
+	}
+	return filtered
+}
+
 func (r *gatewayReconciler) filterTLSRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1.TLSRoute) []gatewayv1.TLSRoute {
 	var filtered []gatewayv1.TLSRoute
 	for _, route := range routes {
 		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) &&
 			listenerisAllowed(ctx, r.Client, gw, listener, &route, r.logger) &&
 			len(computeHostsForListener(listener, route.Spec.Hostnames, nil)) > 0 &&
+			parentRefMatched(gw, listener, route.GetNamespace(), route.Spec.ParentRefs) {
+			filtered = append(filtered, route)
+		}
+	}
+	return filtered
+}
+
+func (r *gatewayReconciler) filterTCPRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1alpha2.TCPRoute) []gatewayv1alpha2.TCPRoute {
+	var filtered []gatewayv1alpha2.TCPRoute
+	for _, route := range routes {
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) &&
+			listenerisAllowed(ctx, r.Client, gw, listener, &route, r.logger) &&
+			parentRefMatched(gw, listener, route.GetNamespace(), route.Spec.ParentRefs) {
+			filtered = append(filtered, route)
+		}
+	}
+	return filtered
+}
+
+func (r *gatewayReconciler) filterUDPRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1alpha2.UDPRoute) []gatewayv1alpha2.UDPRoute {
+	var filtered []gatewayv1alpha2.UDPRoute
+	for _, route := range routes {
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) &&
+			listenerisAllowed(ctx, r.Client, gw, listener, &route, r.logger) &&
 			parentRefMatched(gw, listener, route.GetNamespace(), route.Spec.ParentRefs) {
 			filtered = append(filtered, route)
 		}
@@ -582,7 +799,7 @@ func (r *gatewayReconciler) setStaticAddressStatus(ctx context.Context, gw *gate
 	return nil
 }
 
-func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1.Gateway, httpRoutes *gatewayv1.HTTPRouteList, tlsRoutes *gatewayv1.TLSRouteList, grpcRoutes *gatewayv1.GRPCRouteList) (bool, error) {
+func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1.Gateway, httpRoutes *gatewayv1.HTTPRouteList, tlsRoutes *gatewayv1.TLSRouteList, grpcRoutes *gatewayv1.GRPCRouteList, tcpRoutes *gatewayv1alpha2.TCPRouteList, udpRoutes *gatewayv1alpha2.UDPRouteList) (bool, error) {
 	grants := &gatewayv1.ReferenceGrantList{}
 	if err := r.Client.List(ctx, grants); err != nil {
 		return false, fmt.Errorf("failed to retrieve reference grants: %w", err)
@@ -715,6 +932,8 @@ func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1
 		attachedRoutes += int32(len(r.filterHTTPRoutesByListener(ctx, gw, &l, httpRoutes.Items)))
 		attachedRoutes += int32(len(r.filterGRPCRoutesByListener(ctx, gw, &l, grpcRoutes.Items)))
 		attachedRoutes += int32(len(r.filterTLSRoutesByListener(ctx, gw, &l, tlsRoutes.Items)))
+		attachedRoutes += int32(len(r.filterTCPRoutesByListener(ctx, gw, &l, tcpRoutes.Items)))
+		attachedRoutes += int32(len(r.filterUDPRoutesByListener(ctx, gw, &l, udpRoutes.Items)))
 
 		found := false
 		for i := range gw.Status.Listeners {
@@ -1258,6 +1477,66 @@ func (r *gatewayReconciler) setBackendTLSPolicyStatuses(scopedLog *slog.Logger,
 	return nil
 }
 
+func (r *gatewayReconciler) setTCPRouteStatuses(scopedLog *slog.Logger, ctx context.Context, tcpRoutes *gatewayv1alpha2.TCPRouteList, grants *gatewayv1.ReferenceGrantList) error {
+	scopedLog.Debug("Updating TCPRoute statuses for Gateway", numRoutes, len(tcpRoutes.Items))
+	for tcpRouteIndex, original := range tcpRoutes.Items {
+
+		tcpr := original.DeepCopy()
+
+		i := &routechecks.TCPRouteInput{
+			Ctx:      ctx,
+			Logger:   scopedLog.With(logfields.TCPRoute, tcpr),
+			Client:   r.Client,
+			Grants:   grants,
+			TCPRoute: tcpr,
+		}
+
+		if err := r.runCommonRouteChecks(i, tcpr.Spec.ParentRefs, tcpr.Namespace); err != nil {
+			return r.handleTCPRouteReconcileErrorWithStatus(ctx, scopedLog, err, &original, tcpr)
+		}
+
+		// TODO: warn in TCPRoute when conditions for weight are not met.
+
+		if err := r.updateTCPRouteStatus(ctx, scopedLog, &original, tcpr); err != nil {
+			return fmt.Errorf("failed to update TCPRoute status: %w", err)
+		}
+
+		tcpRoutes.Items[tcpRouteIndex].Status = tcpr.Status
+	}
+
+	return nil
+}
+
+func (r *gatewayReconciler) setUDPRouteStatuses(scopedLog *slog.Logger, ctx context.Context, udpRoutes *gatewayv1alpha2.UDPRouteList, grants *gatewayv1.ReferenceGrantList) error {
+	scopedLog.Debug("Updating UDPRoute statuses for Gateway", numRoutes, len(udpRoutes.Items))
+	for udpRouteIndex, original := range udpRoutes.Items {
+
+		udpr := original.DeepCopy()
+
+		i := &routechecks.UDPRouteInput{
+			Ctx:      ctx,
+			Logger:   scopedLog.With(logfields.UDPRoute, udpr),
+			Client:   r.Client,
+			Grants:   grants,
+			UDPRoute: udpr,
+		}
+
+		if err := r.runCommonRouteChecks(i, udpr.Spec.ParentRefs, udpr.Namespace); err != nil {
+			return r.handleUDPRouteReconcileErrorWithStatus(ctx, scopedLog, err, &original, udpr)
+		}
+
+		// TODO: warn in UDPRoute when conditions for weight are not met.
+
+		if err := r.updateUDPRouteStatus(ctx, scopedLog, &original, udpr); err != nil {
+			return fmt.Errorf("failed to update UDPRoute status: %w", err)
+		}
+
+		udpRoutes.Items[udpRouteIndex].Status = udpr.Status
+	}
+
+	return nil
+}
+
 func (r *gatewayReconciler) handleHTTPRouteReconcileErrorWithStatus(ctx context.Context, scopedLog *slog.Logger, reconcileErr error, original *gatewayv1.HTTPRoute, modified *gatewayv1.HTTPRoute) error {
 	if err := r.updateHTTPRouteStatus(ctx, scopedLog, original, modified); err != nil {
 		return fmt.Errorf("failed to update Gateway status while handling the reconcile error: %w: %w", reconcileErr, err)
@@ -1283,6 +1562,20 @@ func (r *gatewayReconciler) handleTLSRouteReconcileErrorWithStatus(ctx context.C
 	return nil
 }
 
+func (r *gatewayReconciler) handleTCPRouteReconcileErrorWithStatus(ctx context.Context, scopedLog *slog.Logger, reconcileErr error, original *gatewayv1alpha2.TCPRoute, modified *gatewayv1alpha2.TCPRoute) error {
+	if err := r.updateTCPRouteStatus(ctx, scopedLog, original, modified); err != nil {
+		return fmt.Errorf("failed to update Gateway status while handling the reconcile error: %w: %w", reconcileErr, err)
+	}
+	return nil
+}
+
+func (r *gatewayReconciler) handleUDPRouteReconcileErrorWithStatus(ctx context.Context, scopedLog *slog.Logger, reconcileErr error, original *gatewayv1alpha2.UDPRoute, modified *gatewayv1alpha2.UDPRoute) error {
+	if err := r.updateUDPRouteStatus(ctx, scopedLog, original, modified); err != nil {
+		return fmt.Errorf("failed to update Gateway status while handling the reconcile error: %w: %w", reconcileErr, err)
+	}
+	return nil
+}
+
 func (r *gatewayReconciler) updateTLSRouteStatus(ctx context.Context, scopedLog *slog.Logger, original *gatewayv1.TLSRoute, new *gatewayv1.TLSRoute) error {
 	oldStatus := original.Status.DeepCopy()
 	newStatus := new.Status.DeepCopy()
@@ -1291,6 +1584,28 @@ func (r *gatewayReconciler) updateTLSRouteStatus(ctx context.Context, scopedLog 
 		return nil
 	}
 	scopedLog.Debug("Updating TLSRoute status", tlsRoute, types.NamespacedName{Name: original.Name, Namespace: original.Namespace})
+	return r.Client.Status().Update(ctx, new)
+}
+
+func (r *gatewayReconciler) updateTCPRouteStatus(ctx context.Context, scopedLog *slog.Logger, original *gatewayv1alpha2.TCPRoute, new *gatewayv1alpha2.TCPRoute) error {
+	oldStatus := original.Status.DeepCopy()
+	newStatus := new.Status.DeepCopy()
+
+	if cmp.Equal(oldStatus, newStatus, cmpopts.IgnoreFields(metav1.Condition{}, lastTransitionTime)) {
+		return nil
+	}
+	scopedLog.Debug("Updating TCPRoute status", tcpRoute, types.NamespacedName{Name: original.Name, Namespace: original.Namespace})
+	return r.Client.Status().Update(ctx, new)
+}
+
+func (r *gatewayReconciler) updateUDPRouteStatus(ctx context.Context, scopedLog *slog.Logger, original *gatewayv1alpha2.UDPRoute, new *gatewayv1alpha2.UDPRoute) error {
+	oldStatus := original.Status.DeepCopy()
+	newStatus := new.Status.DeepCopy()
+
+	if cmp.Equal(oldStatus, newStatus, cmpopts.IgnoreFields(metav1.Condition{}, lastTransitionTime)) {
+		return nil
+	}
+	scopedLog.Debug("Updating UDPRoute status", udpRoute, types.NamespacedName{Name: original.Name, Namespace: original.Namespace})
 	return r.Client.Status().Update(ctx, new)
 }
 

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
@@ -31,8 +32,9 @@ import (
 )
 
 var (
-	gatewayv1APIVersion = gatewayv1.GroupVersion.Group + "/" + gatewayv1.GroupVersion.Version
-	gatewayTypeMeta     = metav1.TypeMeta{
+	gatewayv1APIVersion       = gatewayv1.GroupVersion.Group + "/" + gatewayv1.GroupVersion.Version
+	gatewayv1alpha2APIVersion = gatewayv1alpha2.GroupVersion.Group + "/" + gatewayv1alpha2.GroupVersion.Version
+	gatewayTypeMeta           = metav1.TypeMeta{
 		Kind:       "Gateway",
 		APIVersion: gatewayv1APIVersion,
 	}
@@ -51,6 +53,14 @@ var (
 	backendTLSPolicyTypeMeta = metav1.TypeMeta{
 		Kind:       "BackendTLSPolicy",
 		APIVersion: gatewayv1APIVersion,
+	}
+	tcpRouteTypeMeta = metav1.TypeMeta{
+		Kind:       "TCPRoute",
+		APIVersion: gatewayv1alpha2APIVersion,
+	}
+	udpRouteTypeMeta = metav1.TypeMeta{
+		Kind:       "UDPRoute",
+		APIVersion: gatewayv1alpha2APIVersion,
 	}
 )
 
@@ -76,6 +86,7 @@ func Test_Conformance(t *testing.T) {
 	type gwDetails struct {
 		FullName types.NamespacedName
 		wantErr  bool
+		skipCEC  bool
 	}
 
 	var (
@@ -272,6 +283,10 @@ func Test_Conformance(t *testing.T) {
 		{name: "httproute-backendtlspolicy-conflict-resolution", gateway: []gwDetails{gatewaySameNamespace}},
 		{name: "httproute-backendtlspolicy-invalid-ca-cert", gateway: []gwDetails{gatewaySameNamespace}},
 		{name: "httproute-backendtlspolicy-invalid-kind", gateway: []gwDetails{gatewaySameNamespace}},
+		{name: "tcproute-invalid-reference-grant", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "gateway-tcproute-referencegrant", Namespace: "gateway-conformance-infra"}, skipCEC: true}}},
+		{name: "tcproute-simple-same-namespace", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "gateway-tcproute", Namespace: "gateway-conformance-infra"}, skipCEC: true}}},
+		{name: "udproute-invalid-reference-grant", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "gateway-udproute-referencegrant", Namespace: "gateway-conformance-infra"}, skipCEC: true}}},
+		{name: "udproute-simple-same-namespace", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "gateway-udproute", Namespace: "gateway-conformance-infra"}, skipCEC: true}}},
 		{name: "tlsroute-invalid-reference-grant", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "gateway-tlsroute-referencegrant", Namespace: "gateway-conformance-infra"}}}},
 		{name: "tlsroute-simple-same-namespace", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "gateway-tlsroute", Namespace: "gateway-conformance-infra"}}}},
 		{name: "tlsroute-hostname-intersection", gateway: []gwDetails{
@@ -302,6 +317,8 @@ func Test_Conformance(t *testing.T) {
 				WithStatusSubresource(&gatewayv1.GRPCRoute{}).
 				WithStatusSubresource(&gatewayv1.HTTPRoute{}).
 				WithStatusSubresource(&gatewayv1.TLSRoute{}).
+				WithStatusSubresource(&gatewayv1alpha2.TCPRoute{}).
+				WithStatusSubresource(&gatewayv1alpha2.UDPRoute{}).
 				WithStatusSubresource(&gatewayv1.Gateway{}).
 				WithStatusSubresource(&gatewayv1.GatewayClass{}).
 				WithStatusSubresource(&gatewayv1.BackendTLSPolicy{})
@@ -317,6 +334,8 @@ func Test_Conformance(t *testing.T) {
 			clientBuilder.WithIndex(&gatewayv1.HTTPRoute{}, indexers.BackendServiceHTTPRouteIndex, fakeIndexHTTPRouteByBackendService)
 			clientBuilder.WithIndex(&gatewayv1.GRPCRoute{}, indexers.GatewayGRPCRouteIndex, indexers.IndexGRPCRouteByGateway)
 			clientBuilder.WithIndex(&gatewayv1.TLSRoute{}, indexers.GatewayTLSRouteIndex, indexers.IndexTLSRouteByGateway)
+			clientBuilder.WithIndex(&gatewayv1alpha2.TCPRoute{}, indexers.GatewayTCPRouteIndex, indexers.IndexTCPRouteByGateway)
+			clientBuilder.WithIndex(&gatewayv1alpha2.UDPRoute{}, indexers.GatewayUDPRouteIndex, indexers.IndexUDPRouteByGateway)
 
 			c := clientBuilder.Build()
 
@@ -346,6 +365,16 @@ func Test_Conformance(t *testing.T) {
 			err = c.List(t.Context(), btlspList)
 			require.NoError(t, err)
 
+			// Reconcile all TCPRoute objects
+			tcprList := &gatewayv1alpha2.TCPRouteList{}
+			err = c.List(t.Context(), tcprList)
+			require.NoError(t, err)
+
+			// Reconcile all UDPRoute objects
+			udprList := &gatewayv1alpha2.UDPRouteList{}
+			err = c.List(t.Context(), udprList)
+			require.NoError(t, err)
+
 			for _, gwDetail := range tt.gateway {
 				// Reconcile the gateway under test
 				result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: gwDetail.FullName})
@@ -361,7 +390,7 @@ func Test_Conformance(t *testing.T) {
 				expectedGateway := &gatewayv1.Gateway{}
 				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/%s.yaml", tt.name, gwDetail.FullName.Name), expectedGateway)
 				require.Empty(t, cmp.Diff(expectedGateway, actualGateway, cmpIgnoreFields...))
-				if !gwDetail.wantErr {
+				if !gwDetail.wantErr && !gwDetail.skipCEC {
 					// Checking the output for CiliumEnvoyConfig
 					actualCEC := &ciliumv2.CiliumEnvoyConfig{}
 					err = c.Get(t.Context(), client.ObjectKey{
@@ -417,6 +446,26 @@ func Test_Conformance(t *testing.T) {
 				expectedBTLSP := &gatewayv1.BackendTLSPolicy{}
 				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/backendtlspolicy-%s.yaml", tt.name, btlsp.Name), expectedBTLSP)
 				require.Empty(t, cmp.Diff(expectedBTLSP, actualBTLSP, cmpIgnoreFields...))
+			}
+
+			for _, tcpr := range tcprList.Items {
+				actualTCPR := &gatewayv1alpha2.TCPRoute{}
+				err = c.Get(t.Context(), client.ObjectKeyFromObject(&tcpr), actualTCPR)
+				actualTCPR.TypeMeta = tcpRouteTypeMeta
+				require.NoError(t, err, "error getting TCPRoute %s/%s: %v", tcpr.Namespace, tcpr.Name, err)
+				expectedTCPR := &gatewayv1alpha2.TCPRoute{}
+				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/tcproute-%s.yaml", tt.name, tcpr.Name), expectedTCPR)
+				require.Empty(t, cmp.Diff(expectedTCPR, actualTCPR, cmpIgnoreFields...))
+			}
+
+			for _, udpr := range udprList.Items {
+				actualUDPR := &gatewayv1alpha2.UDPRoute{}
+				err = c.Get(t.Context(), client.ObjectKeyFromObject(&udpr), actualUDPR)
+				actualUDPR.TypeMeta = udpRouteTypeMeta
+				require.NoError(t, err, "error getting UDPRoute %s/%s: %v", udpr.Namespace, udpr.Name, err)
+				expectedUDPR := &gatewayv1alpha2.UDPRoute{}
+				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/udproute-%s.yaml", tt.name, udpr.Name), expectedUDPR)
+				require.Empty(t, cmp.Diff(expectedUDPR, actualUDPR, cmpIgnoreFields...))
 			}
 		})
 	}

--- a/operator/pkg/gateway-api/gatewayclass_status.go
+++ b/operator/pkg/gateway-api/gatewayclass_status.go
@@ -22,6 +22,19 @@ var supportedFeatures = features.AllFeatures
 
 var gatewayClassSupportedFeatures = getSupportedFeatures()
 
+// extraFeatures lists features that Cilium supports but are missing from
+// features.AllFeatures in the pinned gateway-api version: UDPRoute is defined
+// but not yet added to AllFeatures, and TCPRoute does not exist as a Feature
+// constant.
+// TODO: Remove entries here once the gateway-api bump exposes them.
+var extraFeatures = []features.Feature{
+	features.UDPRouteFeature,
+	{
+		Name:    features.FeatureName("TCPRoute"),
+		Channel: features.FeatureChannelExperimental,
+	},
+}
+
 // This lists the features we do _not_ support, so that we can skip
 // them in the supportedFeatures list in the GatewayClass.
 var exemptFeatures = []features.Feature{
@@ -41,6 +54,9 @@ var exemptFeatures = []features.Feature{
 // List of Gateway API features supported by Cilium.
 // The same should stay in sync with GHA CI in .github/workflows/conformance-gateway-api.yaml
 func getSupportedFeatures() []gatewayv1.SupportedFeature {
+	for _, feature := range extraFeatures {
+		supportedFeatures.Insert(feature)
+	}
 	for _, feature := range exemptFeatures {
 		supportedFeatures.Delete(feature)
 	}

--- a/operator/pkg/gateway-api/helper_test.go
+++ b/operator/pkg/gateway-api/helper_test.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 	k8syaml "sigs.k8s.io/yaml"
 )
@@ -96,6 +97,14 @@ func readInput(t *testing.T, file string) []client.Object {
 			res = append(res, obj)
 		case "TLSRoute":
 			obj := &gatewayv1.TLSRoute{}
+			fromYaml(t, o, obj)
+			res = append(res, obj)
+		case "TCPRoute":
+			obj := &gatewayv1alpha2.TCPRoute{}
+			fromYaml(t, o, obj)
+			res = append(res, obj)
+		case "UDPRoute":
+			obj := &gatewayv1alpha2.UDPRoute{}
 			fromYaml(t, o, obj)
 			res = append(res, obj)
 		case "GRPCRoute":

--- a/operator/pkg/gateway-api/helpers.go
+++ b/operator/pkg/gateway-api/helpers.go
@@ -156,6 +156,12 @@ func isKindAllowed(listener gatewayv1.Listener, route metav1.Object) bool {
 		} else if (kind.Group == nil || string(*kind.Group) == gatewayv1.GroupName) &&
 			kind.Kind == kindGRPCRoute && routeKind == kindGRPCRoute {
 			return true
+		} else if (kind.Group == nil || string(*kind.Group) == gatewayv1alpha2.GroupName) &&
+			kind.Kind == kindTCPRoute && routeKind == kindTCPRoute {
+			return true
+		} else if (kind.Group == nil || string(*kind.Group) == gatewayv1alpha2.GroupName) &&
+			kind.Kind == kindUDPRoute && routeKind == kindUDPRoute {
+			return true
 		}
 	}
 	return false

--- a/operator/pkg/gateway-api/helpers/schemes.go
+++ b/operator/pkg/gateway-api/helpers/schemes.go
@@ -13,6 +13,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -31,6 +32,8 @@ var RequiredGVKs = []schema.GroupVersionKind{
 
 var AllOptionalKinds = []schema.GroupVersionKind{
 	mcsapiv1beta1.SchemeGroupVersion.WithKind(ServiceImportKind),
+	gatewayv1alpha2.SchemeGroupVersion.WithKind(TCPRouteKind),
+	gatewayv1alpha2.SchemeGroupVersion.WithKind(UDPRouteKind),
 }
 
 func TestScheme(optionalKinds []schema.GroupVersionKind) *runtime.Scheme {

--- a/operator/pkg/gateway-api/helpers/tcproute.go
+++ b/operator/pkg/gateway-api/helpers/tcproute.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package helpers
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+// HasTCPRouteSupport returns if the TCPRoute CRD is supported.
+// This checks if the Gateway API v1alpha2 TCPRoute CRD is registered in the client scheme.
+func HasTCPRouteSupport(scheme *runtime.Scheme) bool {
+	return scheme.Recognizes(gatewayv1alpha2.SchemeGroupVersion.WithKind("TCPRoute"))
+}

--- a/operator/pkg/gateway-api/helpers/tcproute_test.go
+++ b/operator/pkg/gateway-api/helpers/tcproute_test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func TestHasTCPRouteSupport(t *testing.T) {
+	scheme1 := runtime.NewScheme()
+	assert.False(t, HasTCPRouteSupport(scheme1), "Should be false when group is not registered")
+
+	scheme2 := runtime.NewScheme()
+	scheme2.AddKnownTypes(gatewayv1alpha2.SchemeGroupVersion, &gatewayv1alpha2.TLSRoute{})
+	assert.False(t, HasTCPRouteSupport(scheme2), "Should be false when group is registered but TCPRoute kind is not")
+
+	scheme3 := runtime.NewScheme()
+	err := gatewayv1alpha2.AddToScheme(scheme3)
+	assert.NoError(t, err)
+	assert.True(t, HasTCPRouteSupport(scheme3), "Should be true when TCPRoute kind is registered")
+}

--- a/operator/pkg/gateway-api/helpers/types.go
+++ b/operator/pkg/gateway-api/helpers/types.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 )
 
@@ -28,6 +29,10 @@ const (
 	BackendTLSPolicyKind  string = "backendtlspolicies"
 	TLSRouteKind          string = "tlsroutes"
 	TLSRouteListKind      string = "tlsroutelists"
+	TCPRouteKind          string = "tcproutes"
+	TCPRouteListKind      string = "tcproutelists"
+	UDPRouteKind          string = "udproutes"
+	UDPRouteListKind      string = "udproutelists"
 	ServiceImportKind     string = "serviceimports"
 	ServiceImportListKind string = "serviceimportlists"
 )
@@ -105,6 +110,14 @@ func GetConcreteObject(schemaType schema.GroupVersionKind) runtime.Object {
 		return &gatewayv1.TLSRoute{}
 	case TLSRouteListKind:
 		return &gatewayv1.TLSRouteList{}
+	case TCPRouteKind:
+		return &gatewayv1alpha2.TCPRoute{}
+	case TCPRouteListKind:
+		return &gatewayv1alpha2.TCPRouteList{}
+	case UDPRouteKind:
+		return &gatewayv1alpha2.UDPRoute{}
+	case UDPRouteListKind:
+		return &gatewayv1alpha2.UDPRouteList{}
 	case ServiceImportKind:
 		return &mcsapiv1beta1.ServiceImport{}
 	case ServiceImportListKind:

--- a/operator/pkg/gateway-api/helpers/types_test.go
+++ b/operator/pkg/gateway-api/helpers/types_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 func TestIsGammaService(t *testing.T) {
@@ -286,6 +287,42 @@ func TestGetConcreteObject(t *testing.T) {
 				Kind:    TLSRouteListKind,
 			},
 			want: &gatewayv1.TLSRouteList{},
+		},
+		{
+			name: "TCPRoute",
+			gvk: schema.GroupVersionKind{
+				Group:   gatewayv1alpha2.GroupVersion.Group,
+				Version: gatewayv1alpha2.GroupVersion.Version,
+				Kind:    TCPRouteKind,
+			},
+			want: &gatewayv1alpha2.TCPRoute{},
+		},
+		{
+			name: "TCPRouteList",
+			gvk: schema.GroupVersionKind{
+				Group:   gatewayv1alpha2.GroupVersion.Group,
+				Version: gatewayv1alpha2.GroupVersion.Version,
+				Kind:    TCPRouteListKind,
+			},
+			want: &gatewayv1alpha2.TCPRouteList{},
+		},
+		{
+			name: "UDPRoute",
+			gvk: schema.GroupVersionKind{
+				Group:   gatewayv1alpha2.GroupVersion.Group,
+				Version: gatewayv1alpha2.GroupVersion.Version,
+				Kind:    UDPRouteKind,
+			},
+			want: &gatewayv1alpha2.UDPRoute{},
+		},
+		{
+			name: "UDPRouteList",
+			gvk: schema.GroupVersionKind{
+				Group:   gatewayv1alpha2.GroupVersion.Group,
+				Version: gatewayv1alpha2.GroupVersion.Version,
+				Kind:    UDPRouteListKind,
+			},
+			want: &gatewayv1alpha2.UDPRouteList{},
 		},
 	}
 	for _, tt := range tests {

--- a/operator/pkg/gateway-api/helpers/udproute.go
+++ b/operator/pkg/gateway-api/helpers/udproute.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package helpers
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+// HasUDPRouteSupport returns if the UDPRoute CRD is supported.
+// This checks if the Gateway API v1alpha2 UDPRoute CRD is registered in the client scheme.
+func HasUDPRouteSupport(scheme *runtime.Scheme) bool {
+	return scheme.Recognizes(gatewayv1alpha2.SchemeGroupVersion.WithKind("UDPRoute"))
+}

--- a/operator/pkg/gateway-api/helpers/udproute_test.go
+++ b/operator/pkg/gateway-api/helpers/udproute_test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func TestHasUDPRouteSupport(t *testing.T) {
+	scheme1 := runtime.NewScheme()
+	assert.False(t, HasUDPRouteSupport(scheme1), "Should be false when group is not registered")
+
+	scheme2 := runtime.NewScheme()
+	scheme2.AddKnownTypes(gatewayv1alpha2.SchemeGroupVersion, &gatewayv1alpha2.TLSRoute{})
+	assert.False(t, HasUDPRouteSupport(scheme2), "Should be false when group is registered but UDPRoute kind is not")
+
+	scheme3 := runtime.NewScheme()
+	err := gatewayv1alpha2.AddToScheme(scheme3)
+	assert.NoError(t, err)
+	assert.True(t, HasUDPRouteSupport(scheme3), "Should be true when UDPRoute kind is registered")
+}

--- a/operator/pkg/gateway-api/indexers/indexnames.go
+++ b/operator/pkg/gateway-api/indexers/indexnames.go
@@ -44,4 +44,16 @@ const (
 	// Indexes GatewayClassCiliumGatewayClassConfigsIndex indexes GatewayClass by the CiliumGatewayClassConfig
 	// that it refers to.
 	GatewayClassCiliumGatewayClassConfigsIndex = "gatewayClassCiliumGatewayClassConfigsIndex"
+
+	// Indexes TCPRoutes by all the backend Services referenced in the object.
+	BackendServiceTCPRouteIndex = "backendServiceTCPRouteIndex"
+
+	// Indexes TCPRoutes by all the Gateway parents referenced in the object.
+	GatewayTCPRouteIndex = "gatewayTCPRouteIndex"
+
+	// Indexes UDPRoutes by all the backend Services referenced in the object.
+	BackendServiceUDPRouteIndex = "backendServiceUDPRouteIndex"
+
+	// Indexes UDPRoutes by all the Gateway parents referenced in the object.
+	GatewayUDPRouteIndex = "gatewayUDPRouteIndex"
 )

--- a/operator/pkg/gateway-api/indexers/tcproute.go
+++ b/operator/pkg/gateway-api/indexers/tcproute.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package indexers
+
+import (
+	"log/slog"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// GenerateIndexerTCPRoutebyBackendService takes a single TCPRoute and returns all referenced
+// backend service full names (`namespace/name`) to add to the relevant index.
+func GenerateIndexerTCPRoutebyBackendService(c client.Client, logger *slog.Logger) client.IndexerFunc {
+	return func(rawObj client.Object) []string {
+		route := rawObj.(*gatewayv1alpha2.TCPRoute)
+		var backendServices []string
+
+		for _, rule := range route.Spec.Rules {
+			for _, backend := range rule.BackendRefs {
+				namespace := helpers.NamespaceDerefOr(backend.Namespace, route.Namespace)
+				backendServiceName, err := helpers.GetBackendServiceName(c, namespace, backend.BackendObjectReference)
+				if err != nil {
+					logger.Error("Failed to get backend service name",
+						logfields.LogSubsys, logfields.TCPRoute,
+						logfields.TCPRoute, client.ObjectKeyFromObject(rawObj),
+						logfields.Error, err)
+					continue
+				}
+				backendServices = append(backendServices,
+					types.NamespacedName{
+						Namespace: helpers.NamespaceDerefOr(backend.Namespace, route.Namespace),
+						Name:      backendServiceName,
+					}.String(),
+				)
+			}
+		}
+
+		return backendServices
+	}
+}
+
+// IndexTCPRouteByGateway takes a single TCPRoute and returns all referenced Gateway object
+// full names (`namespace/name`) to add to the relevant index.
+//
+// Note that this does _not_ filter to only Cilium-relevant Gateways.
+func IndexTCPRouteByGateway(rawObj client.Object) []string {
+	route := rawObj.(*gatewayv1alpha2.TCPRoute)
+	var gateways []string
+	for _, parent := range route.Spec.ParentRefs {
+		if !helpers.IsGateway(parent) {
+			continue
+		}
+		gateways = append(gateways,
+			types.NamespacedName{
+				Namespace: helpers.NamespaceDerefOr(parent.Namespace, route.Namespace),
+				Name:      string(parent.Name),
+			}.String(),
+		)
+	}
+	return gateways
+}

--- a/operator/pkg/gateway-api/indexers/tcproute_test.go
+++ b/operator/pkg/gateway-api/indexers/tcproute_test.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package indexers
+
+import (
+	"slices"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func TestIndexTCPRouteByGateway(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  client.Object
+		want []string
+	}{
+		{
+			name: "parentRef is Gateway",
+			obj: &gatewayv1alpha2.TCPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "valid-gateway",
+					Namespace: "default",
+				},
+				Spec: gatewayv1alpha2.TCPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:      "valid",
+								Namespace: ptr.To[gatewayv1.Namespace]("default"),
+							},
+						},
+					},
+				},
+			},
+			want: []string{
+				"default/valid",
+			},
+		},
+		{
+			name: "parentRef is a Gateway, nil namespace",
+			obj: &gatewayv1alpha2.TCPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "valid-gateway",
+					Namespace: "default",
+				},
+				Spec: gatewayv1alpha2.TCPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name: "valid-nil-namespace",
+							},
+						},
+					},
+				},
+			},
+			want: []string{
+				"default/valid-nil-namespace",
+			},
+		},
+		{
+			name: "parentRef is not a Gateway",
+			obj: &gatewayv1alpha2.TCPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-parent",
+					Namespace: "default",
+				},
+				Spec: gatewayv1alpha2.TCPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:      "invalid",
+								Namespace: ptr.To[gatewayv1.Namespace]("default"),
+								Kind:      ptr.To[gatewayv1.Kind]("OtherKind"),
+								Group:     ptr.To[gatewayv1.Group]("somegroup.io"),
+							},
+						},
+					},
+				},
+			},
+			want: []string(nil),
+		},
+		{
+			name: "parentRef has explicit Gateway kind/group",
+			obj: &gatewayv1alpha2.TCPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "explicit-gateway",
+					Namespace: "default",
+				},
+				Spec: gatewayv1alpha2.TCPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:      "gw-explicit",
+								Namespace: ptr.To[gatewayv1.Namespace]("default"),
+								Kind:      ptr.To[gatewayv1.Kind]("Gateway"),
+								Group:     ptr.To[gatewayv1.Group](gatewayv1.GroupName),
+							},
+						},
+					},
+				},
+			},
+			want: []string{"default/gw-explicit"},
+		},
+		{
+			name: "parentRef has Gateway kind but wrong group",
+			obj: &gatewayv1alpha2.TCPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gateway-wrong-group",
+					Namespace: "default",
+				},
+				Spec: gatewayv1alpha2.TCPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:      "gw-wrong-group",
+								Namespace: ptr.To[gatewayv1.Namespace]("default"),
+								Kind:      ptr.To[gatewayv1.Kind]("Gateway"),
+								Group:     ptr.To[gatewayv1.Group]("example.io"),
+							},
+						},
+					},
+				},
+			},
+			want: []string(nil),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IndexTCPRouteByGateway(tt.obj); !slices.Equal(got, tt.want) {
+				t.Errorf("IndexTCPRouteByGateway() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}

--- a/operator/pkg/gateway-api/indexers/udproute.go
+++ b/operator/pkg/gateway-api/indexers/udproute.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package indexers
+
+import (
+	"log/slog"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// GenerateIndexerUDPRoutebyBackendService takes a single UDPRoute and returns all referenced
+// backend service full names (`namespace/name`) to add to the relevant index.
+func GenerateIndexerUDPRoutebyBackendService(c client.Client, logger *slog.Logger) client.IndexerFunc {
+	return func(rawObj client.Object) []string {
+		route := rawObj.(*gatewayv1alpha2.UDPRoute)
+		var backendServices []string
+
+		for _, rule := range route.Spec.Rules {
+			for _, backend := range rule.BackendRefs {
+				namespace := helpers.NamespaceDerefOr(backend.Namespace, route.Namespace)
+				backendServiceName, err := helpers.GetBackendServiceName(c, namespace, backend.BackendObjectReference)
+				if err != nil {
+					logger.Error("Failed to get backend service name",
+						logfields.LogSubsys, logfields.UDPRoute,
+						logfields.UDPRoute, client.ObjectKeyFromObject(rawObj),
+						logfields.Error, err)
+					continue
+				}
+				backendServices = append(backendServices,
+					types.NamespacedName{
+						Namespace: helpers.NamespaceDerefOr(backend.Namespace, route.Namespace),
+						Name:      backendServiceName,
+					}.String(),
+				)
+			}
+		}
+
+		return backendServices
+	}
+}
+
+// IndexUDPRouteByGateway takes a single UDPRoute and returns all referenced Gateway object
+// full names (`namespace/name`) to add to the relevant index.
+//
+// Note that this does _not_ filter to only Cilium-relevant Gateways.
+func IndexUDPRouteByGateway(rawObj client.Object) []string {
+	route := rawObj.(*gatewayv1alpha2.UDPRoute)
+	var gateways []string
+	for _, parent := range route.Spec.ParentRefs {
+		if !helpers.IsGateway(parent) {
+			continue
+		}
+		gateways = append(gateways,
+			types.NamespacedName{
+				Namespace: helpers.NamespaceDerefOr(parent.Namespace, route.Namespace),
+				Name:      string(parent.Name),
+			}.String(),
+		)
+	}
+	return gateways
+}

--- a/operator/pkg/gateway-api/indexers/udproute_test.go
+++ b/operator/pkg/gateway-api/indexers/udproute_test.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package indexers
+
+import (
+	"slices"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func TestIndexUDPRouteByGateway(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  client.Object
+		want []string
+	}{
+		{
+			name: "parentRef is Gateway",
+			obj: &gatewayv1alpha2.UDPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "valid-gateway",
+					Namespace: "default",
+				},
+				Spec: gatewayv1alpha2.UDPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:      "valid",
+								Namespace: ptr.To[gatewayv1.Namespace]("default"),
+							},
+						},
+					},
+				},
+			},
+			want: []string{
+				"default/valid",
+			},
+		},
+		{
+			name: "parentRef is a Gateway, nil namespace",
+			obj: &gatewayv1alpha2.UDPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "valid-gateway",
+					Namespace: "default",
+				},
+				Spec: gatewayv1alpha2.UDPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name: "valid-nil-namespace",
+							},
+						},
+					},
+				},
+			},
+			want: []string{
+				"default/valid-nil-namespace",
+			},
+		},
+		{
+			name: "parentRef is not a Gateway",
+			obj: &gatewayv1alpha2.UDPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-parent",
+					Namespace: "default",
+				},
+				Spec: gatewayv1alpha2.UDPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:      "invalid",
+								Namespace: ptr.To[gatewayv1.Namespace]("default"),
+								Kind:      ptr.To[gatewayv1.Kind]("OtherKind"),
+								Group:     ptr.To[gatewayv1.Group]("somegroup.io"),
+							},
+						},
+					},
+				},
+			},
+			want: []string(nil),
+		},
+		{
+			name: "parentRef has explicit Gateway kind/group",
+			obj: &gatewayv1alpha2.UDPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "explicit-gateway",
+					Namespace: "default",
+				},
+				Spec: gatewayv1alpha2.UDPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:      "gw-explicit",
+								Namespace: ptr.To[gatewayv1.Namespace]("default"),
+								Kind:      ptr.To[gatewayv1.Kind]("Gateway"),
+								Group:     ptr.To[gatewayv1.Group](gatewayv1.GroupName),
+							},
+						},
+					},
+				},
+			},
+			want: []string{"default/gw-explicit"},
+		},
+		{
+			name: "parentRef has Gateway kind but wrong group",
+			obj: &gatewayv1alpha2.UDPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gateway-wrong-group",
+					Namespace: "default",
+				},
+				Spec: gatewayv1alpha2.UDPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:      "gw-wrong-group",
+								Namespace: ptr.To[gatewayv1.Namespace]("default"),
+								Kind:      ptr.To[gatewayv1.Kind]("Gateway"),
+								Group:     ptr.To[gatewayv1.Group]("example.io"),
+							},
+						},
+					},
+				},
+			},
+			want: []string(nil),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IndexUDPRouteByGateway(tt.obj); !slices.Equal(got, tt.want) {
+				t.Errorf("IndexUDPRouteByGateway() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}

--- a/operator/pkg/gateway-api/logger.go
+++ b/operator/pkg/gateway-api/logger.go
@@ -10,8 +10,11 @@ const (
 	httpRoute          = "httpRoute"
 	grpcRoute          = "grpcRoute"
 	tlsRoute           = "tlsRoute"
+	tcpRoute           = "tcpRoute"
+	udpRoute           = "udpRoute"
 	relevantHTTPRoutes = "relevantHTTPRoutes"
 	numRoutes          = "numRoutes"
 	policies           = "policies"
 	backendTLSPolicy   = "BackendTLSPolicy"
+	endpointSlice      = "endpointSlice"
 )

--- a/operator/pkg/gateway-api/predicates/endpointslice.go
+++ b/operator/pkg/gateway-api/predicates/endpointslice.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package predicates
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	gwModel "github.com/cilium/cilium/operator/pkg/model/translation/gateway-api"
+)
+
+// IsManagedFrontendEndpointSlice returns true when the EndpointSlice is a
+// frontend slice managed by the cilium-operator (created by the Gateway
+// translator for an L4 listener). The check is based on the standard
+// EndpointSlice managed-by label.
+func IsManagedFrontendEndpointSlice(obj client.Object) bool {
+	if obj == nil {
+		return false
+	}
+	return obj.GetLabels()[gwModel.EndpointSliceManagedByLabel] == gwModel.EndpointSliceManagedByValue
+}
+
+// ManagedFrontendEndpointSlice is a predicate that only admits managed frontend
+// EndpointSlices.
+func ManagedFrontendEndpointSlice() predicate.Predicate {
+	return predicate.NewPredicateFuncs(IsManagedFrontendEndpointSlice)
+}
+
+// NonManagedEndpointSlice is a predicate that admits any EndpointSlice that is
+// not a managed frontend slice (i.e. a backend slice produced by upstream
+// kube-controller-manager or another controller).
+func NonManagedEndpointSlice() predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		return !IsManagedFrontendEndpointSlice(obj)
+	})
+}

--- a/operator/pkg/gateway-api/routechecks/gateway_checks.go
+++ b/operator/pkg/gateway-api/routechecks/gateway_checks.go
@@ -81,7 +81,7 @@ func CheckGatewayRouteKindAllowed(input Input, parentRef gatewayv1.ParentReferen
 	gw, err := input.GetGateway(parentRef)
 	if err != nil {
 		input.SetParentCondition(parentRef, metav1.Condition{
-			Type:    "Accepted",
+			Type:    string(gatewayv1.RouteConditionAccepted),
 			Status:  metav1.ConditionFalse,
 			Reason:  "Invalid" + input.GetGVK().Kind,
 			Message: err.Error(),
@@ -177,7 +177,7 @@ func CheckGatewayMatchingPorts(input Input, parentRef gatewayv1.ParentReference)
 		input.SetParentCondition(parentRef, metav1.Condition{
 			Type:    string(gatewayv1.RouteConditionAccepted),
 			Status:  metav1.ConditionFalse,
-			Reason:  "NoMatchingParent",
+			Reason:  string(gatewayv1.RouteReasonNoMatchingParent),
 			Message: fmt.Sprintf("No matching listener with port %d", *parentRef.Port),
 		})
 
@@ -212,7 +212,7 @@ func CheckGatewayMatchingSection(input Input, parentRef gatewayv1.ParentReferenc
 			input.SetParentCondition(parentRef, metav1.Condition{
 				Type:    string(gatewayv1.RouteConditionAccepted),
 				Status:  metav1.ConditionFalse,
-				Reason:  "NoMatchingParent",
+				Reason:  string(gatewayv1.RouteReasonNoMatchingParent),
 				Message: fmt.Sprintf("No matching listener with sectionName %s", *parentRef.SectionName),
 			})
 

--- a/operator/pkg/gateway-api/routechecks/tcproute.go
+++ b/operator/pkg/gateway-api/routechecks/tcproute.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package routechecks
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"reflect"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+)
+
+// TCPRouteInput is used to implement the Input interface for TCPRoute.
+type TCPRouteInput struct {
+	Ctx      context.Context
+	Logger   *slog.Logger
+	Client   client.Client
+	Grants   *gatewayv1.ReferenceGrantList
+	TCPRoute *gatewayv1alpha2.TCPRoute
+
+	gateways map[gatewayv1.ParentReference]*gatewayv1.Gateway
+}
+
+func (t *TCPRouteInput) SetParentCondition(ref gatewayv1.ParentReference, condition metav1.Condition) {
+	condition.LastTransitionTime = metav1.NewTime(time.Now())
+	condition.ObservedGeneration = t.TCPRoute.GetGeneration()
+
+	t.mergeStatusConditions(ref, []metav1.Condition{
+		condition,
+	})
+}
+
+func (t *TCPRouteInput) SetAllParentCondition(condition metav1.Condition) {
+	// fill in the condition
+	condition.LastTransitionTime = metav1.NewTime(time.Now())
+	condition.ObservedGeneration = t.TCPRoute.GetGeneration()
+
+	for _, parent := range t.TCPRoute.Spec.ParentRefs {
+		t.mergeStatusConditions(parent, []metav1.Condition{
+			condition,
+		})
+	}
+}
+
+func (t *TCPRouteInput) mergeStatusConditions(parentRef gatewayv1alpha2.ParentReference, updates []metav1.Condition) {
+	index := -1
+	for i, parent := range t.TCPRoute.Status.RouteStatus.Parents {
+		if reflect.DeepEqual(parent.ParentRef, parentRef) {
+			index = i
+			break
+		}
+	}
+	if index != -1 {
+		t.TCPRoute.Status.RouteStatus.Parents[index].Conditions = helpers.MergeConditions(t.TCPRoute.Status.RouteStatus.Parents[index].Conditions, updates...)
+		return
+	}
+	t.TCPRoute.Status.RouteStatus.Parents = append(t.TCPRoute.Status.RouteStatus.Parents, gatewayv1alpha2.RouteParentStatus{
+		ParentRef:      parentRef,
+		ControllerName: controllerName,
+		Conditions:     updates,
+	})
+}
+
+func (t *TCPRouteInput) GetGrants() []gatewayv1.ReferenceGrant {
+	return t.Grants.Items
+}
+
+func (t *TCPRouteInput) GetNamespace() string {
+	return t.TCPRoute.GetNamespace()
+}
+
+func (t *TCPRouteInput) GetGVK() schema.GroupVersionKind {
+	return gatewayv1alpha2.SchemeGroupVersion.WithKind("TCPRoute")
+}
+
+func (t *TCPRouteInput) GetRules() []GenericRule {
+	var rules []GenericRule
+	for _, rule := range t.TCPRoute.Spec.Rules {
+		rules = append(rules, &TCPRouteRule{rule})
+	}
+	return rules
+}
+
+func (t *TCPRouteInput) GetClient() client.Client {
+	return t.Client
+}
+
+func (t *TCPRouteInput) GetContext() context.Context {
+	return t.Ctx
+}
+
+// TCPRouteRule is used to implement the GenericRule interface for TCPRoute.
+type TCPRouteRule struct {
+	Rule gatewayv1alpha2.TCPRouteRule
+}
+
+func (t *TCPRouteRule) GetBackendRefs() []gatewayv1.BackendRef {
+	return t.Rule.BackendRefs
+}
+
+func (t *TCPRouteInput) GetHostnames() []gatewayv1.Hostname {
+	return nil
+}
+
+func (t *TCPRouteInput) GetGateway(parent gatewayv1.ParentReference) (*gatewayv1.Gateway, error) {
+	if t.gateways == nil {
+		t.gateways = make(map[gatewayv1.ParentReference]*gatewayv1.Gateway)
+	}
+
+	if gw, exists := t.gateways[parent]; exists {
+		return gw, nil
+	}
+
+	ns := helpers.NamespaceDerefOr(parent.Namespace, t.GetNamespace())
+	gw := &gatewayv1.Gateway{}
+
+	if err := t.Client.Get(t.Ctx, client.ObjectKey{Namespace: ns, Name: string(parent.Name)}, gw); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return nil, fmt.Errorf("error while getting gateway: %w", err)
+		}
+
+		return nil, fmt.Errorf("gateway %q does not exist: %w", parent.Name, err)
+	}
+
+	t.gateways[parent] = gw
+
+	return gw, nil
+}
+
+func (t *TCPRouteInput) GetParentGammaService(parent gatewayv1.ParentReference) (*corev1.Service, error) {
+	return nil, fmt.Errorf("GAMMA support is not implemented in this reconciler")
+}
+
+func (t *TCPRouteInput) Log() *slog.Logger {
+	return t.Logger
+}
+
+func (t *TCPRouteInput) GetValidProtocols() []gatewayv1.ProtocolType {
+	return []gatewayv1.ProtocolType{gatewayv1.TCPProtocolType}
+}

--- a/operator/pkg/gateway-api/routechecks/udproute.go
+++ b/operator/pkg/gateway-api/routechecks/udproute.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package routechecks
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"reflect"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+)
+
+// UDPRouteInput is used to implement the Input interface for UDPRoute.
+type UDPRouteInput struct {
+	Ctx      context.Context
+	Logger   *slog.Logger
+	Client   client.Client
+	Grants   *gatewayv1.ReferenceGrantList
+	UDPRoute *gatewayv1alpha2.UDPRoute
+
+	gateways map[gatewayv1.ParentReference]*gatewayv1.Gateway
+}
+
+func (u *UDPRouteInput) SetParentCondition(ref gatewayv1.ParentReference, condition metav1.Condition) {
+	condition.LastTransitionTime = metav1.NewTime(time.Now())
+	condition.ObservedGeneration = u.UDPRoute.GetGeneration()
+
+	u.mergeStatusConditions(ref, []metav1.Condition{
+		condition,
+	})
+}
+
+func (u *UDPRouteInput) SetAllParentCondition(condition metav1.Condition) {
+	// fill in the condition
+	condition.LastTransitionTime = metav1.NewTime(time.Now())
+	condition.ObservedGeneration = u.UDPRoute.GetGeneration()
+
+	for _, parent := range u.UDPRoute.Spec.ParentRefs {
+		u.mergeStatusConditions(parent, []metav1.Condition{
+			condition,
+		})
+	}
+}
+
+func (u *UDPRouteInput) mergeStatusConditions(parentRef gatewayv1alpha2.ParentReference, updates []metav1.Condition) {
+	index := -1
+	for i, parent := range u.UDPRoute.Status.RouteStatus.Parents {
+		if reflect.DeepEqual(parent.ParentRef, parentRef) {
+			index = i
+			break
+		}
+	}
+	if index != -1 {
+		u.UDPRoute.Status.RouteStatus.Parents[index].Conditions = helpers.MergeConditions(u.UDPRoute.Status.RouteStatus.Parents[index].Conditions, updates...)
+		return
+	}
+	u.UDPRoute.Status.RouteStatus.Parents = append(u.UDPRoute.Status.RouteStatus.Parents, gatewayv1alpha2.RouteParentStatus{
+		ParentRef:      parentRef,
+		ControllerName: controllerName,
+		Conditions:     updates,
+	})
+}
+
+func (u *UDPRouteInput) GetGrants() []gatewayv1.ReferenceGrant {
+	return u.Grants.Items
+}
+
+func (u *UDPRouteInput) GetNamespace() string {
+	return u.UDPRoute.GetNamespace()
+}
+
+func (u *UDPRouteInput) GetGVK() schema.GroupVersionKind {
+	return gatewayv1alpha2.SchemeGroupVersion.WithKind("UDPRoute")
+}
+
+func (u *UDPRouteInput) GetRules() []GenericRule {
+	var rules []GenericRule
+	for _, rule := range u.UDPRoute.Spec.Rules {
+		rules = append(rules, &UDPRouteRule{rule})
+	}
+	return rules
+}
+
+func (u *UDPRouteInput) GetClient() client.Client {
+	return u.Client
+}
+
+func (u *UDPRouteInput) GetContext() context.Context {
+	return u.Ctx
+}
+
+// UDPRouteRule is used to implement the GenericRule interface for UDPRoute.
+type UDPRouteRule struct {
+	Rule gatewayv1alpha2.UDPRouteRule
+}
+
+func (u *UDPRouteRule) GetBackendRefs() []gatewayv1.BackendRef {
+	return u.Rule.BackendRefs
+}
+
+func (u *UDPRouteInput) GetHostnames() []gatewayv1.Hostname {
+	return nil
+}
+
+func (u *UDPRouteInput) GetGateway(parent gatewayv1.ParentReference) (*gatewayv1.Gateway, error) {
+	if u.gateways == nil {
+		u.gateways = make(map[gatewayv1.ParentReference]*gatewayv1.Gateway)
+	}
+
+	if gw, exists := u.gateways[parent]; exists {
+		return gw, nil
+	}
+
+	ns := helpers.NamespaceDerefOr(parent.Namespace, u.GetNamespace())
+	gw := &gatewayv1.Gateway{}
+
+	if err := u.Client.Get(u.Ctx, client.ObjectKey{Namespace: ns, Name: string(parent.Name)}, gw); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return nil, fmt.Errorf("error while getting gateway: %w", err)
+		}
+
+		return nil, fmt.Errorf("gateway %q does not exist: %w", parent.Name, err)
+	}
+
+	u.gateways[parent] = gw
+
+	return gw, nil
+}
+
+func (u *UDPRouteInput) GetParentGammaService(parent gatewayv1.ParentReference) (*corev1.Service, error) {
+	return nil, fmt.Errorf("GAMMA support is not implemented in this reconciler")
+}
+
+func (u *UDPRouteInput) Log() *slog.Logger {
+	return u.Logger
+}
+
+func (u *UDPRouteInput) GetValidProtocols() []gatewayv1.ProtocolType {
+	return []gatewayv1.ProtocolType{gatewayv1.UDPProtocolType}
+}

--- a/operator/pkg/gateway-api/testdata/gateway/tcproute-invalid-reference-grant/input/tcproute-invalid-reference-grant.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tcproute-invalid-reference-grant/input/tcproute-invalid-reference-grant.yaml
@@ -1,0 +1,46 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: reference-grant-wrong-kind
+  namespace: gateway-conformance-web-backend
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: UDPRoute
+      namespace: gateway-conformance-infra
+  to:
+    - group: ""
+      kind: Service
+      name: web-backend
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: reference-grant
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gateway-tcproute-referencegrant
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: web-backend
+          namespace: gateway-conformance-web-backend
+          port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-tcproute-referencegrant
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: tcp
+      port: 8080
+      protocol: TCP
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TCPRoute

--- a/operator/pkg/gateway-api/testdata/gateway/tcproute-invalid-reference-grant/output/gateway-tcproute-referencegrant.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tcproute-invalid-reference-grant/output/gateway-tcproute-referencegrant.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-tcproute-referencegrant
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: tcp
+      port: 8080
+      protocol: TCP
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TCPRoute
+status:
+  conditions:
+    - message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+      lastTransitionTime: "2026-02-25T00:00:00Z"
+    - message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+      lastTransitionTime: "2026-02-25T00:00:00Z"
+  listeners:
+    - attachedRoutes: 1
+      conditions:
+        - message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+      name: tcp
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TCPRoute

--- a/operator/pkg/gateway-api/testdata/gateway/tcproute-invalid-reference-grant/output/tcproute-reference-grant.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tcproute-invalid-reference-grant/output/tcproute-reference-grant.yaml
@@ -1,0 +1,31 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: reference-grant
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gateway-tcproute-referencegrant
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: web-backend
+          namespace: gateway-conformance-web-backend
+          port: 8080
+status:
+  parents:
+    - conditions:
+        - message: Accepted TCPRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Cross namespace references are not allowed
+          reason: RefNotPermitted
+          status: "False"
+          type: ResolvedRefs
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: gateway-tcproute-referencegrant
+        namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/tcproute-simple-same-namespace/input/tcproute-simple-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tcproute-simple-same-namespace/input/tcproute-simple-same-namespace.yaml
@@ -1,0 +1,43 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: gateway-conformance-infra-tcp-test
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gateway-tcproute
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: tcp-backend-simple
+          port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-tcproute
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: tcp
+      port: 8080
+      protocol: TCP
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TCPRoute
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tcp-backend-simple
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: tcp-backend-simple
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080

--- a/operator/pkg/gateway-api/testdata/gateway/tcproute-simple-same-namespace/output/gateway-tcproute.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tcproute-simple-same-namespace/output/gateway-tcproute.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-tcproute
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: tcp
+      port: 8080
+      protocol: TCP
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TCPRoute
+status:
+  conditions:
+    - message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+      lastTransitionTime: "2026-02-25T00:00:00Z"
+    - message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+      lastTransitionTime: "2026-02-25T00:00:00Z"
+  listeners:
+    - attachedRoutes: 1
+      conditions:
+        - message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+      name: tcp
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TCPRoute

--- a/operator/pkg/gateway-api/testdata/gateway/tcproute-simple-same-namespace/output/tcproute-gateway-conformance-infra-tcp-test.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tcproute-simple-same-namespace/output/tcproute-gateway-conformance-infra-tcp-test.yaml
@@ -1,0 +1,30 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: gateway-conformance-infra-tcp-test
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gateway-tcproute
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: tcp-backend-simple
+          port: 8080
+status:
+  parents:
+    - conditions:
+        - message: Accepted TCPRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: gateway-tcproute
+        namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/udproute-invalid-reference-grant/input/udproute-invalid-reference-grant.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/udproute-invalid-reference-grant/input/udproute-invalid-reference-grant.yaml
@@ -1,0 +1,46 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: reference-grant-wrong-kind
+  namespace: gateway-conformance-web-backend
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: TCPRoute
+      namespace: gateway-conformance-infra
+  to:
+    - group: ""
+      kind: Service
+      name: web-backend
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: UDPRoute
+metadata:
+  name: reference-grant
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gateway-udproute-referencegrant
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: web-backend
+          namespace: gateway-conformance-web-backend
+          port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-udproute-referencegrant
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: udp
+      port: 5353
+      protocol: UDP
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: UDPRoute

--- a/operator/pkg/gateway-api/testdata/gateway/udproute-invalid-reference-grant/output/gateway-udproute-referencegrant.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/udproute-invalid-reference-grant/output/gateway-udproute-referencegrant.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-udproute-referencegrant
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: udp
+      port: 5353
+      protocol: UDP
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: UDPRoute
+status:
+  conditions:
+    - message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+      lastTransitionTime: "2026-02-25T00:00:00Z"
+    - message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+      lastTransitionTime: "2026-02-25T00:00:00Z"
+  listeners:
+    - attachedRoutes: 1
+      conditions:
+        - message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+      name: udp
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: UDPRoute

--- a/operator/pkg/gateway-api/testdata/gateway/udproute-invalid-reference-grant/output/udproute-reference-grant.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/udproute-invalid-reference-grant/output/udproute-reference-grant.yaml
@@ -1,0 +1,31 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: UDPRoute
+metadata:
+  name: reference-grant
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gateway-udproute-referencegrant
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: web-backend
+          namespace: gateway-conformance-web-backend
+          port: 8080
+status:
+  parents:
+    - conditions:
+        - message: Accepted UDPRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Cross namespace references are not allowed
+          reason: RefNotPermitted
+          status: "False"
+          type: ResolvedRefs
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: gateway-udproute-referencegrant
+        namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/udproute-simple-same-namespace/input/udproute-simple-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/udproute-simple-same-namespace/input/udproute-simple-same-namespace.yaml
@@ -1,0 +1,43 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: UDPRoute
+metadata:
+  name: gateway-conformance-infra-udp-test
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gateway-udproute
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: udp-backend
+          port: 5353
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-udproute
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: udp
+      port: 5353
+      protocol: UDP
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: UDPRoute
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: udp-backend
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: udp-backend
+  ports:
+    - protocol: UDP
+      port: 5353
+      targetPort: 5353

--- a/operator/pkg/gateway-api/testdata/gateway/udproute-simple-same-namespace/output/gateway-udproute.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/udproute-simple-same-namespace/output/gateway-udproute.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-udproute
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: udp
+      port: 5353
+      protocol: UDP
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: UDPRoute
+status:
+  conditions:
+    - message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+      lastTransitionTime: "2026-02-25T00:00:00Z"
+    - message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+      lastTransitionTime: "2026-02-25T00:00:00Z"
+  listeners:
+    - attachedRoutes: 1
+      conditions:
+        - message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+      name: udp
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: UDPRoute

--- a/operator/pkg/gateway-api/testdata/gateway/udproute-simple-same-namespace/output/udproute-gateway-conformance-infra-udp-test.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/udproute-simple-same-namespace/output/udproute-gateway-conformance-infra-udp-test.yaml
@@ -1,0 +1,30 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: UDPRoute
+metadata:
+  name: gateway-conformance-infra-udp-test
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gateway-udproute
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: udp-backend
+          port: 5353
+status:
+  parents:
+    - conditions:
+        - message: Accepted UDPRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: gateway-udproute
+        namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/watch-handlers/endpointslice.go
+++ b/operator/pkg/gateway-api/watch-handlers/endpointslice.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchhandlers
+
+import (
+	"context"
+	"log/slog"
+
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	gwModel "github.com/cilium/cilium/operator/pkg/model/translation/gateway-api"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// EnqueueFrontendsForBackendEndpointSlice returns an event handler that, when
+// passed a backend EndpointSlice, returns reconcile.Requests for all managed
+// frontend EndpointSlices whose BackendServiceAnnotation matches the backend
+// Service the slice belongs to (via the kubernetes.io/service-name label).
+func EnqueueFrontendsForBackendEndpointSlice(c client.Client, logger *slog.Logger) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
+		eps, ok := o.(*discoveryv1.EndpointSlice)
+		if !ok {
+			return nil
+		}
+		svcName := eps.Labels[gwModel.EndpointSliceServiceNameLabel]
+		if svcName == "" {
+			return nil
+		}
+		return frontendsMatchingBackend(ctx, c, logger, eps.Namespace, svcName)
+	})
+}
+
+// EnqueueFrontendsForBackendService returns an event handler that, when passed
+// a Service, returns reconcile.Requests for all managed frontend EndpointSlices
+// whose BackendServiceAnnotation references that Service.
+func EnqueueFrontendsForBackendService(c client.Client, logger *slog.Logger) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
+		svc, ok := o.(*corev1.Service)
+		if !ok {
+			return nil
+		}
+		return frontendsMatchingBackend(ctx, c, logger, svc.Namespace, svc.Name)
+	})
+}
+
+func frontendsMatchingBackend(ctx context.Context, c client.Client, logger *slog.Logger, ns, name string) []reconcile.Request {
+	wantBackend := ns + "/" + name
+
+	list := &discoveryv1.EndpointSliceList{}
+	if err := c.List(ctx, list, client.MatchingLabels{
+		gwModel.EndpointSliceManagedByLabel: gwModel.EndpointSliceManagedByValue,
+	}); err != nil {
+		logger.WarnContext(ctx, "Failed to list managed EndpointSlices",
+			logfields.Error, err)
+		return nil
+	}
+
+	var reqs []reconcile.Request
+	for i := range list.Items {
+		fe := list.Items[i]
+		if fe.Annotations[gwModel.BackendServiceAnnotation] == wantBackend {
+			reqs = append(reqs, reconcile.Request{
+				NamespacedName: types.NamespacedName{Namespace: fe.Namespace, Name: fe.Name},
+			})
+		}
+	}
+	return reqs
+}

--- a/operator/pkg/gateway-api/watch-handlers/routes.go
+++ b/operator/pkg/gateway-api/watch-handlers/routes.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 // EnqueueRequestForOwningHTTPRoute returns an event handler that, when passed a HTTPRoute, returns reconcile.Requests
@@ -49,5 +50,31 @@ func EnqueueRequestForOwningGRPCRoute(c client.Client, logger *slog.Logger, cont
 		}
 
 		return getGatewayReconcileRequestsForRoute(ctx, c, a, gr.Spec.CommonRouteSpec, logger, controllerName)
+	})
+}
+
+// EnqueueRequestForOwningTCPRoute returns an event handler that, when passed a TCPRoute, returns reconcile.Requests
+// for any Cilium-relevant Gateways associated with that TCPRoute.
+func EnqueueRequestForOwningTCPRoute(c client.Client, logger *slog.Logger, controllerName string) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
+		tr, ok := a.(*gatewayv1alpha2.TCPRoute)
+		if !ok {
+			return nil
+		}
+
+		return getGatewayReconcileRequestsForRoute(context.Background(), c, a, tr.Spec.CommonRouteSpec, logger, controllerName)
+	})
+}
+
+// EnqueueRequestForOwningUDPRoute returns an event handler that, when passed a UDPRoute, returns reconcile.Requests
+// for any Cilium-relevant Gateways associated with that UDPRoute.
+func EnqueueRequestForOwningUDPRoute(c client.Client, logger *slog.Logger, controllerName string) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
+		ur, ok := a.(*gatewayv1alpha2.UDPRoute)
+		if !ok {
+			return nil
+		}
+
+		return getGatewayReconcileRequestsForRoute(context.Background(), c, a, ur.Spec.CommonRouteSpec, logger, controllerName)
 	})
 }

--- a/operator/pkg/ingress/ingress_reconcile.go
+++ b/operator/pkg/ingress/ingress_reconcile.go
@@ -263,9 +263,15 @@ func (r *ingressReconciler) buildDedicatedResources(ctx context.Context, ingress
 		m.HTTP = append(m.HTTP, ingestion.Ingress(scopedLog, *ingress, r.defaultSecretNamespace, r.defaultSecretName, r.enforcedHTTPS, insecureHTTPPort, secureHTTPPort, r.defaultRequestTimeout)...)
 	}
 
-	cec, svc, ep, err := r.dedicatedTranslator.Translate(m)
+	cec, svc, eps, err := r.dedicatedTranslator.Translate(m)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to translate model into resources: %w", err)
+	}
+	// Ingress only ever produces a single dummy EndpointSlice; unwrap from the
+	// shared Translator interface that returns a list to support gateway-api L4.
+	var ep *discoveryv1.EndpointSlice
+	if len(eps) > 0 {
+		ep = eps[0]
 	}
 
 	r.propagateIngressAnnotationsAndLabels(ingress, &svc.ObjectMeta)

--- a/operator/pkg/ingress/ingress_reconcile_test.go
+++ b/operator/pkg/ingress/ingress_reconcile_test.go
@@ -1234,12 +1234,12 @@ type fakeDedicatedIngressTranslator struct {
 	model *model.Model
 }
 
-func (r *fakeDedicatedIngressTranslator) Translate(model *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, *discoveryv1.EndpointSlice, error) {
+func (r *fakeDedicatedIngressTranslator) Translate(model *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, []*discoveryv1.EndpointSlice, error) {
 	r.model = model
 
 	return &ciliumv2.CiliumEnvoyConfig{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test"}},
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test"}},
-		&discoveryv1.EndpointSlice{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test"}},
+		[]*discoveryv1.EndpointSlice{{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test"}}},
 		nil
 }
 

--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 
@@ -37,6 +38,8 @@ type Input struct {
 	HTTPRoutes          []gatewayv1.HTTPRoute
 	TLSRoutes           []gatewayv1.TLSRoute
 	GRPCRoutes          []gatewayv1.GRPCRoute
+	TCPRoutes           []gatewayv1alpha2.TCPRoute
+	UDPRoutes           []gatewayv1alpha2.UDPRoute
 	ReferenceGrants     []gatewayv1.ReferenceGrant
 	Services            []corev1.Service
 	ServiceImports      []mcsapiv1beta1.ServiceImport
@@ -44,9 +47,10 @@ type Input struct {
 }
 
 // GatewayAPI translates Gateway API resources into a model.
-func GatewayAPI(log *slog.Logger, input Input) ([]model.HTTPListener, []model.TLSPassthroughListener) {
+func GatewayAPI(log *slog.Logger, input Input) ([]model.HTTPListener, []model.TLSPassthroughListener, []model.L4Listener) {
 	var resHTTP []model.HTTPListener
 	var resTLSPassthrough []model.TLSPassthroughListener
+	var resL4 []model.L4Listener
 
 	labels := make(map[string]string)
 	annotations := make(map[string]string)
@@ -87,37 +91,12 @@ func GatewayAPI(log *slog.Logger, input Input) ([]model.HTTPListener, []model.TL
 	}
 
 	for _, l := range input.Gateway.Spec.Listeners {
-		if l.Protocol != gatewayv1.HTTPProtocolType &&
-			l.Protocol != gatewayv1.HTTPSProtocolType &&
-			l.Protocol != gatewayv1.TLSProtocolType {
-			continue
-		}
-
-		var httpRoutes []model.HTTPRoute
-		httpRoutes = append(httpRoutes, toHTTPRoutes(log, l, listenerHostnamesByProtocol, input.HTTPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants, input.BackendTLSPolicyMap)...)
-		httpRoutes = append(httpRoutes, toGRPCRoutes(l, listenerHostnamesByProtocol, input.GRPCRoutes, input.Services, input.ServiceImports, input.ReferenceGrants)...)
-		resHTTP = append(resHTTP, model.HTTPListener{
-			Name: string(l.Name),
-			Sources: []model.FullyQualifiedResource{
-				{
-					Name:      input.Gateway.GetName(),
-					Namespace: input.Gateway.GetNamespace(),
-					Group:     gatewayv1.SchemeGroupVersion.Group,
-					Version:   gatewayv1.SchemeGroupVersion.Version,
-					Kind:      "Gateway",
-					UID:       string(input.Gateway.GetUID()),
-				},
-			},
-			Port:           uint32(l.Port),
-			Hostname:       toHostname(l.Hostname),
-			TLS:            toTLS(l.TLS, input.ReferenceGrants, input.Gateway.GetNamespace()),
-			Routes:         httpRoutes,
-			Infrastructure: infra,
-			Service:        toServiceModel(input.GatewayClassConfig),
-		})
-
-		if l.Protocol == gatewayv1.TLSProtocolType {
-			resTLSPassthrough = append(resTLSPassthrough, model.TLSPassthroughListener{
+		switch l.Protocol {
+		case gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType, gatewayv1.TLSProtocolType:
+			var httpRoutes []model.HTTPRoute
+			httpRoutes = append(httpRoutes, toHTTPRoutes(log, l, listenerHostnamesByProtocol, input.HTTPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants, input.BackendTLSPolicyMap)...)
+			httpRoutes = append(httpRoutes, toGRPCRoutes(l, listenerHostnamesByProtocol, input.GRPCRoutes, input.Services, input.ServiceImports, input.ReferenceGrants)...)
+			resHTTP = append(resHTTP, model.HTTPListener{
 				Name: string(l.Name),
 				Sources: []model.FullyQualifiedResource{
 					{
@@ -131,14 +110,76 @@ func GatewayAPI(log *slog.Logger, input Input) ([]model.HTTPListener, []model.TL
 				},
 				Port:           uint32(l.Port),
 				Hostname:       toHostname(l.Hostname),
-				Routes:         toTLSRoutes(l, listenerHostnamesByProtocol, input.TLSRoutes, input.Services, input.ServiceImports, input.ReferenceGrants),
+				TLS:            toTLS(l.TLS, input.ReferenceGrants, input.Gateway.GetNamespace()),
+				Routes:         httpRoutes,
+				Infrastructure: infra,
+				Service:        toServiceModel(input.GatewayClassConfig),
+			})
+
+			if l.Protocol == gatewayv1.TLSProtocolType {
+				resTLSPassthrough = append(resTLSPassthrough, model.TLSPassthroughListener{
+					Name: string(l.Name),
+					Sources: []model.FullyQualifiedResource{
+						{
+							Name:      input.Gateway.GetName(),
+							Namespace: input.Gateway.GetNamespace(),
+							Group:     gatewayv1.SchemeGroupVersion.Group,
+							Version:   gatewayv1.SchemeGroupVersion.Version,
+							Kind:      "Gateway",
+							UID:       string(input.Gateway.GetUID()),
+						},
+					},
+					Port:           uint32(l.Port),
+					Hostname:       toHostname(l.Hostname),
+					Routes:         toTLSRoutes(l, listenerHostnamesByProtocol, input.TLSRoutes, input.Services, input.ServiceImports, input.ReferenceGrants),
+					Infrastructure: infra,
+					Service:        toServiceModel(input.GatewayClassConfig),
+				})
+			}
+
+		case gatewayv1.TCPProtocolType:
+			resL4 = append(resL4, model.L4Listener{
+				Name: string(l.Name),
+				Sources: []model.FullyQualifiedResource{
+					{
+						Name:      input.Gateway.GetName(),
+						Namespace: input.Gateway.GetNamespace(),
+						Group:     gatewayv1.SchemeGroupVersion.Group,
+						Version:   gatewayv1.SchemeGroupVersion.Version,
+						Kind:      "Gateway",
+						UID:       string(input.Gateway.GetUID()),
+					},
+				},
+				Port:           uint32(l.Port),
+				Protocol:       model.L4ProtocolTCP,
+				Routes:         toTCPRoutes(l, input.TCPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants),
+				Infrastructure: infra,
+				Service:        toServiceModel(input.GatewayClassConfig),
+			})
+
+		case gatewayv1.UDPProtocolType:
+			resL4 = append(resL4, model.L4Listener{
+				Name: string(l.Name),
+				Sources: []model.FullyQualifiedResource{
+					{
+						Name:      input.Gateway.GetName(),
+						Namespace: input.Gateway.GetNamespace(),
+						Group:     gatewayv1.SchemeGroupVersion.Group,
+						Version:   gatewayv1.SchemeGroupVersion.Version,
+						Kind:      "Gateway",
+						UID:       string(input.Gateway.GetUID()),
+					},
+				},
+				Port:           uint32(l.Port),
+				Protocol:       model.L4ProtocolUDP,
+				Routes:         toUDPRoutes(l, input.UDPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants),
 				Infrastructure: infra,
 				Service:        toServiceModel(input.GatewayClassConfig),
 			})
 		}
 	}
 
-	return resHTTP, resTLSPassthrough
+	return resHTTP, resTLSPassthrough, resL4
 }
 
 func getBackendServiceName(namespace string, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, backendObjectReference gatewayv1.BackendObjectReference) (string, error) {
@@ -743,6 +784,138 @@ func toTLSRoutes(listener gatewayv1beta1.Listener, listenerHostnamesByProtocol m
 		}
 	}
 	return tlsRoutes
+}
+
+func toTCPRoutes(listener gatewayv1beta1.Listener, input []gatewayv1alpha2.TCPRoute, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1.ReferenceGrant) []model.L4Route {
+	var l4Routes []model.L4Route
+	for _, r := range input {
+		listenerIsParent := false
+		for _, parent := range r.Spec.ParentRefs {
+			if parent.SectionName == nil && parent.Port == nil {
+				listenerIsParent = true
+				break
+			}
+
+			if parent.SectionName != nil {
+				if *parent.SectionName != listener.Name {
+					continue
+				}
+				if parent.Port != nil && *parent.Port != listener.Port {
+					continue
+				}
+				listenerIsParent = true
+				break
+			}
+
+			if parent.Port != nil {
+				if *parent.Port != listener.Port {
+					continue
+				}
+				listenerIsParent = true
+				break
+			}
+		}
+
+		if !listenerIsParent {
+			continue
+		}
+
+		for _, rule := range r.Spec.Rules {
+			bes := make([]model.Backend, 0, len(rule.BackendRefs))
+			for _, be := range rule.BackendRefs {
+				if !helpers.IsBackendReferenceAllowed(r.GetNamespace(), be, gatewayv1alpha2.SchemeGroupVersion.WithKind("TCPRoute"), grants) {
+					continue
+				}
+				svcName, err := getBackendServiceName(helpers.NamespaceDerefOr(be.Namespace, r.Namespace), services, serviceImports, be.BackendObjectReference)
+				if err != nil {
+					continue
+				}
+				if svcName != string(be.Name) {
+					be = *be.DeepCopy()
+					be.BackendObjectReference = gatewayv1beta1.BackendObjectReference{
+						Name:      gatewayv1beta1.ObjectName(svcName),
+						Port:      be.Port,
+						Namespace: be.Namespace,
+					}
+				}
+				svc := getServiceSpec(string(be.Name), helpers.NamespaceDerefOr(be.Namespace, r.Namespace), services)
+				if svc != nil {
+					bes = append(bes, backendToModelBackend(*svc, be, r.Namespace))
+				}
+			}
+
+			l4Routes = append(l4Routes, model.L4Route{
+				Backends: bes,
+			})
+		}
+	}
+	return l4Routes
+}
+
+func toUDPRoutes(listener gatewayv1beta1.Listener, input []gatewayv1alpha2.UDPRoute, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1.ReferenceGrant) []model.L4Route {
+	var l4Routes []model.L4Route
+	for _, r := range input {
+		listenerIsParent := false
+		for _, parent := range r.Spec.ParentRefs {
+			if parent.SectionName == nil && parent.Port == nil {
+				listenerIsParent = true
+				break
+			}
+
+			if parent.SectionName != nil {
+				if *parent.SectionName != listener.Name {
+					continue
+				}
+				if parent.Port != nil && *parent.Port != listener.Port {
+					continue
+				}
+				listenerIsParent = true
+				break
+			}
+
+			if parent.Port != nil {
+				if *parent.Port != listener.Port {
+					continue
+				}
+				listenerIsParent = true
+				break
+			}
+		}
+
+		if !listenerIsParent {
+			continue
+		}
+
+		for _, rule := range r.Spec.Rules {
+			bes := make([]model.Backend, 0, len(rule.BackendRefs))
+			for _, be := range rule.BackendRefs {
+				if !helpers.IsBackendReferenceAllowed(r.GetNamespace(), be, gatewayv1alpha2.SchemeGroupVersion.WithKind("UDPRoute"), grants) {
+					continue
+				}
+				svcName, err := getBackendServiceName(helpers.NamespaceDerefOr(be.Namespace, r.Namespace), services, serviceImports, be.BackendObjectReference)
+				if err != nil {
+					continue
+				}
+				if svcName != string(be.Name) {
+					be = *be.DeepCopy()
+					be.BackendObjectReference = gatewayv1beta1.BackendObjectReference{
+						Name:      gatewayv1beta1.ObjectName(svcName),
+						Port:      be.Port,
+						Namespace: be.Namespace,
+					}
+				}
+				svc := getServiceSpec(string(be.Name), helpers.NamespaceDerefOr(be.Namespace, r.Namespace), services)
+				if svc != nil {
+					bes = append(bes, backendToModelBackend(*svc, be, r.Namespace))
+				}
+			}
+
+			l4Routes = append(l4Routes, model.L4Route{
+				Backends: bes,
+			})
+		}
+	}
+	return l4Routes
 }
 
 func toHTTPRequestRedirectFilter(listenerPort int32, redirect *gatewayv1.HTTPRequestRedirectFilter) *model.HTTPRequestRedirectFilter {

--- a/operator/pkg/model/ingestion/gateway_test.go
+++ b/operator/pkg/model/ingestion/gateway_test.go
@@ -63,7 +63,7 @@ func TestHTTPGatewayAPI(t *testing.T) {
 			logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
 
 			input := readGatewayInput(t, name)
-			listeners, _ := GatewayAPI(logger, input)
+			listeners, _, _ := GatewayAPI(logger, input)
 
 			expected := []model.HTTPListener{}
 			readOutput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(name), "output-listeners.yaml"), &expected)
@@ -87,7 +87,7 @@ func TestTLSGatewayAPI(t *testing.T) {
 			logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
 
 			input := readGatewayInput(t, name)
-			_, listeners := GatewayAPI(logger, input)
+			_, listeners, _ := GatewayAPI(logger, input)
 
 			expected := []model.TLSPassthroughListener{}
 			readOutput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(name), "output-listeners.yaml"), &expected)
@@ -107,10 +107,30 @@ func TestGRPCGatewayAPI(t *testing.T) {
 
 			input := readGatewayInput(t, name)
 
-			listeners, _ := GatewayAPI(logger, input)
+			listeners, _, _ := GatewayAPI(logger, input)
 
 			expected := []model.HTTPListener{}
 			readOutput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(name), "output-listeners.yaml"), &expected)
+			assert.Equal(t, toYaml(t, expected), toYaml(t, listeners), "Listeners did not match")
+		})
+	}
+}
+
+func TestL4GatewayAPI(t *testing.T) {
+	tests := map[string]struct{}{
+		"basic l4": {},
+	}
+
+	for name := range tests {
+		t.Run(name, func(t *testing.T) {
+			logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+
+			input := readGatewayInput(t, name)
+			_, _, listeners := GatewayAPI(logger, input)
+
+			expected := []model.L4Listener{}
+			readOutput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(name), "output-listeners.yaml"), &expected)
+
 			assert.Equal(t, toYaml(t, expected), toYaml(t, listeners), "Listeners did not match")
 		})
 	}
@@ -218,6 +238,8 @@ func readGatewayInput(t *testing.T, testName string) Input {
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-httproute.yaml"), &input.HTTPRoutes)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-tlsroute.yaml"), &input.TLSRoutes)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-grpcroute.yaml"), &input.GRPCRoutes)
+	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-tcproute.yaml"), &input.TCPRoutes)
+	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-udproute.yaml"), &input.UDPRoutes)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-service.yaml"), &input.Services)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-serviceimport.yaml"), &input.ServiceImports)
 

--- a/operator/pkg/model/ingestion/testdata/gateway/basic_l4/input-gateway.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/basic_l4/input-gateway.yaml
@@ -1,0 +1,17 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: gw
+  namespace: default
+  uid: uid
+spec:
+  gatewayClassName: ""
+  listeners:
+  - name: tcp-listener
+    port: 8080
+    protocol: TCP
+  - name: udp-listener
+    port: 5353
+    protocol: UDP
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/basic_l4/input-service.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/basic_l4/input-service.yaml
@@ -1,0 +1,24 @@
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    name: tcp-backend
+    namespace: default
+  spec:
+    ports:
+    - port: 8080
+      protocol: TCP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    name: udp-backend
+    namespace: default
+  spec:
+    ports:
+    - port: 5353
+      protocol: UDP
+  status:
+    loadBalancer: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/basic_l4/input-tcproute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/basic_l4/input-tcproute.yaml
@@ -1,0 +1,15 @@
+- metadata:
+    creationTimestamp: null
+    name: tcp-route
+    namespace: default
+  spec:
+    parentRefs:
+    - name: gw
+      port: 8080
+      sectionName: tcp-listener
+    rules:
+    - backendRefs:
+      - name: tcp-backend
+        port: 8080
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gateway/basic_l4/input-udproute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/basic_l4/input-udproute.yaml
@@ -1,0 +1,15 @@
+- metadata:
+    creationTimestamp: null
+    name: udp-route
+    namespace: default
+  spec:
+    parentRefs:
+    - name: gw
+      port: 5353
+      sectionName: udp-listener
+    rules:
+    - backendRefs:
+      - name: udp-backend
+        port: 5353
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gateway/basic_l4/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/basic_l4/output-listeners.yaml
@@ -1,0 +1,32 @@
+- name: tcp-listener
+  sources:
+  - name: gw
+    namespace: default
+    group: gateway.networking.k8s.io
+    version: v1
+    kind: Gateway
+    uid: uid
+  port: 8080
+  protocol: TCP
+  routes:
+  - backends:
+    - name: tcp-backend
+      namespace: default
+      port:
+        port: 8080
+- name: udp-listener
+  sources:
+  - name: gw
+    namespace: default
+    group: gateway.networking.k8s.io
+    version: v1
+    kind: Gateway
+    uid: uid
+  port: 5353
+  protocol: UDP
+  routes:
+  - backends:
+    - name: udp-backend
+      namespace: default
+      port:
+        port: 5353

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -18,6 +18,7 @@ import (
 type Model struct {
 	HTTP           []HTTPListener           `json:"http,omitempty"`
 	TLSPassthrough []TLSPassthroughListener `json:"tls_passthrough,omitempty"`
+	L4             []L4Listener             `json:"l4,omitempty"`
 }
 
 func (m *Model) GetListeners() []Listener {
@@ -31,6 +32,10 @@ func (m *Model) GetListeners() []Listener {
 		listeners = append(listeners, &m.TLSPassthrough[i])
 	}
 
+	for i := range m.L4 {
+		listeners = append(listeners, &m.L4[i])
+	}
+
 	return listeners
 }
 
@@ -40,6 +45,7 @@ type Listener interface {
 	GetAnnotations() map[string]string
 	GetLabels() map[string]string
 	GetService() *Service
+	GetProtocol() L4Protocol
 }
 
 // HTTPListener holds configuration for any listener that terminates and proxies HTTP
@@ -111,6 +117,10 @@ func (l HTTPListener) GetService() *Service {
 	return l.Service
 }
 
+func (l HTTPListener) GetProtocol() L4Protocol {
+	return L4ProtocolTCP
+}
+
 // TLSPassthroughListener holds configuration for any listener that proxies TLS
 // based on the SNI value.
 // Each holds the configuration info for one distinct TLS listener, by
@@ -165,6 +175,74 @@ func (l TLSPassthroughListener) GetPort() uint32 {
 
 func (l TLSPassthroughListener) GetService() *Service {
 	return l.Service
+}
+
+func (l TLSPassthroughListener) GetProtocol() L4Protocol {
+	return L4ProtocolTCP
+}
+
+type L4Protocol string
+
+const (
+	L4ProtocolTCP L4Protocol = "TCP"
+	L4ProtocolUDP L4Protocol = "UDP"
+)
+
+// L4Listener holds configuration for TCP or UDP listeners.
+type L4Listener struct {
+	// Name of the listener
+	Name string `json:"name,omitempty"`
+	// Sources is a slice of fully qualified resources this listener is sourced from.
+	Sources []FullyQualifiedResource `json:"sources,omitempty"`
+	// IPAddress that the listener should listen on.
+	Address string `json:"address,omitempty"`
+	// Port on which the service can be expected to be accessed by clients.
+	Port uint32 `json:"port,omitempty"`
+	// Protocol of the listener (TCP or UDP).
+	Protocol L4Protocol `json:"protocol,omitempty"`
+	// Routes associated with traffic to the service.
+	Routes []L4Route `json:"routes,omitempty"`
+	// Service configuration
+	Service *Service `json:"service,omitempty"`
+	// Infrastructure configuration
+	Infrastructure *Infrastructure `json:"infrastructure,omitempty"`
+}
+
+func (l L4Listener) GetAnnotations() map[string]string {
+	if l.Infrastructure != nil {
+		return l.Infrastructure.Annotations
+	}
+	return nil
+}
+
+func (l L4Listener) GetLabels() map[string]string {
+	if l.Infrastructure != nil {
+		return l.Infrastructure.Labels
+	}
+	return nil
+}
+
+func (l L4Listener) GetSources() []FullyQualifiedResource {
+	return l.Sources
+}
+
+func (l L4Listener) GetPort() uint32 {
+	return l.Port
+}
+
+func (l L4Listener) GetService() *Service {
+	return l.Service
+}
+
+func (l L4Listener) GetProtocol() L4Protocol {
+	return l.Protocol
+}
+
+// L4Route holds the details needed to route TCP/UDP traffic to backends.
+type L4Route struct {
+	Name string `json:"name,omitempty"`
+	// Backends handling the requests.
+	Backends []Backend `json:"backends,omitempty"`
 }
 
 // Service holds the configuration for desired Service details
@@ -593,9 +671,9 @@ type HTTPRetry struct {
 	Backoff *time.Duration `json:"backoff,omitempty"`
 }
 
-// IsEmpty returns true if the model has no HTTP or TLS Passthrough listeners.
+// IsEmpty returns true if the model has no HTTP, TLS Passthrough or L4 listeners.
 func (m *Model) IsEmpty() bool {
-	return len(m.HTTP) == 0 && len(m.TLSPassthrough) == 0
+	return len(m.HTTP) == 0 && len(m.TLSPassthrough) == 0 && len(m.L4) == 0
 }
 
 // IsHTTPListenerConfigured returns true if the model has any HTTP listeners.
@@ -611,6 +689,11 @@ func (m *Model) IsHTTPSListenerConfigured() bool {
 		}
 	}
 	return false
+}
+
+// IsL4ListenerConfigured returns true if the model has any L4 listeners.
+func (m *Model) IsL4ListenerConfigured() bool {
+	return len(m.L4) > 0
 }
 
 // IsTLSPassthroughListenerConfigured returns true if the model has any TLS Passthrough listeners.

--- a/operator/pkg/model/model_test.go
+++ b/operator/pkg/model/model_test.go
@@ -28,10 +28,23 @@ var testHTTPListener2 = HTTPListener{
 	Port: 80,
 }
 
+var testL4Listener = L4Listener{
+	Name:     "test-l4-listener",
+	Port:     8080,
+	Protocol: L4ProtocolTCP,
+}
+
+var testL4Listener2 = L4Listener{
+	Name:     "test-l4-listener2",
+	Port:     8081,
+	Protocol: L4ProtocolUDP,
+}
+
 func TestModel_GetListeners(t *testing.T) {
 	type fields struct {
 		HTTP []HTTPListener
 		TLS  []TLSPassthroughListener
+		L4   []L4Listener
 	}
 	tests := []struct {
 		name   string
@@ -43,8 +56,9 @@ func TestModel_GetListeners(t *testing.T) {
 			fields: fields{
 				HTTP: []HTTPListener{testHTTPListener, testHTTPListener2},
 				TLS:  []TLSPassthroughListener{testTLSListener, testTLSListener2},
+				L4:   []L4Listener{testL4Listener, testL4Listener2},
 			},
-			want: []Listener{&testHTTPListener, &testHTTPListener2, &testTLSListener, &testTLSListener2},
+			want: []Listener{&testHTTPListener, &testHTTPListener2, &testTLSListener, &testTLSListener2, &testL4Listener, &testL4Listener2},
 		},
 		{
 			name: "Only HTTP listeners",
@@ -61,6 +75,13 @@ func TestModel_GetListeners(t *testing.T) {
 			want: []Listener{&testTLSListener, &testTLSListener2},
 		},
 		{
+			name: "Only L4 listeners",
+			fields: fields{
+				L4: []L4Listener{testL4Listener, testL4Listener2},
+			},
+			want: []Listener{&testL4Listener, &testL4Listener2},
+		},
+		{
 			name:   "No listeners",
 			fields: fields{},
 			want:   nil,
@@ -71,6 +92,7 @@ func TestModel_GetListeners(t *testing.T) {
 			m := &Model{
 				HTTP:           tt.fields.HTTP,
 				TLSPassthrough: tt.fields.TLS,
+				L4:             tt.fields.L4,
 			}
 			if got := m.GetListeners(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Model.GetListeners() = %v, want %v", got, tt.want)

--- a/operator/pkg/model/translation/gateway-api/endpointslices.go
+++ b/operator/pkg/model/translation/gateway-api/endpointslices.go
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gateway_api
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/operator/pkg/model"
+	"github.com/cilium/cilium/pkg/shortener"
+)
+
+const (
+	EndpointSliceManagedByLabel   = "endpointslice.kubernetes.io/managed-by"
+	EndpointSliceManagedByValue   = "cilium-operator"
+	EndpointSliceServiceNameLabel = "kubernetes.io/service-name"
+	BackendServiceAnnotation      = "gateway.cilium.io/backend-service"
+	BackendPortAnnotation         = "gateway.cilium.io/backend-port"
+	EndpointSliceWeightAnnotation = "service.cilium.io/weight"
+	endpointSliceFamilySuffixIPv4 = "ipv4"
+	endpointSliceFamilySuffixIPv6 = "ipv6"
+)
+
+// toL4EndpointSlices builds skeleton EndpointSlices per (backend Service,
+// backendRef.port, IP family). Listeners/routes sharing that tuple are merged
+// into one slice with one Ports entry per listener; endpointSliceReconciler
+// later resolves the numeric Port and populates .endpoints.
+func (t *gatewayAPITranslator) toL4EndpointSlices(listeners []model.L4Listener, source *model.FullyQualifiedResource, lbSvc *corev1.Service) []*discoveryv1.EndpointSlice {
+	if len(listeners) == 0 || source == nil || lbSvc == nil {
+		return nil
+	}
+
+	families := enabledAddressTypes(lbSvc)
+	if len(families) == 0 {
+		return nil
+	}
+
+	ownerRef := metav1.OwnerReference{
+		APIVersion: gatewayv1.GroupVersion.String(),
+		Kind:       source.Kind,
+		Name:       source.Name,
+		UID:        types.UID(source.UID),
+		Controller: ptr.To(true),
+	}
+	shortGw := shortener.ShortenK8sResourceName(source.Name)
+	svcName := lbSvc.Name
+
+	type groupKey struct {
+		backendNs   string
+		backendName string
+		backendPort uint32
+		family      discoveryv1.AddressType
+	}
+	type group struct {
+		key        groupKey
+		backend    model.Backend
+		listener   model.L4Listener
+		ports      []discoveryv1.EndpointPort
+		seenPort   map[string]struct{}
+	}
+
+	groups := map[groupKey]*group{}
+	var order []groupKey
+
+	for _, l := range listeners {
+		listener := l
+		portName := listenerPortName(listener)
+		protocol := corev1.ProtocolTCP
+		if listener.GetProtocol() == model.L4ProtocolUDP {
+			protocol = corev1.ProtocolUDP
+		}
+		listenerPort := int32(listener.GetPort())
+
+		for _, route := range listener.Routes {
+			for _, backend := range route.Backends {
+				b := backend
+				backendPort := backendTargetPort(listener, b)
+
+				for _, family := range families {
+					k := groupKey{
+						backendNs:   b.Namespace,
+						backendName: b.Name,
+						backendPort: backendPort,
+						family:      family,
+					}
+					g, ok := groups[k]
+					if !ok {
+						g = &group{
+							key:      k,
+							backend:  b,
+							listener: listener,
+							seenPort: map[string]struct{}{},
+						}
+						groups[k] = g
+						order = append(order, k)
+					}
+					if _, dup := g.seenPort[portName]; dup {
+						continue
+					}
+					g.seenPort[portName] = struct{}{}
+					g.ports = append(g.ports, discoveryv1.EndpointPort{
+						Name:     ptr.To(portName),
+						Port:     ptr.To(listenerPort),
+						Protocol: ptr.To(protocol),
+					})
+				}
+			}
+		}
+	}
+
+	slicesOut := make([]*discoveryv1.EndpointSlice, 0, len(order))
+	for _, k := range order {
+		g := groups[k]
+		// Stable order so mergeEndpointPorts pairs existing/desired by index.
+		sort.SliceStable(g.ports, func(i, j int) bool {
+			return ptr.Deref(g.ports[i].Name, "") < ptr.Deref(g.ports[j].Name, "")
+		})
+		slicesOut = append(slicesOut, buildEndpointSlice(buildEPSArgs{
+			svcName:     svcName,
+			gwShort:     shortGw,
+			namespace:   source.Namespace,
+			backend:     g.backend,
+			family:      g.key.family,
+			backendPort: g.key.backendPort,
+			ports:       g.ports,
+			ownerRef:    ownerRef,
+		}))
+	}
+
+	sort.SliceStable(slicesOut, func(i, j int) bool { return slicesOut[i].Name < slicesOut[j].Name })
+	return slicesOut
+}
+
+type buildEPSArgs struct {
+	svcName     string
+	gwShort     string
+	namespace   string
+	backend     model.Backend
+	family      discoveryv1.AddressType
+	backendPort uint32
+	ports       []discoveryv1.EndpointPort
+	ownerRef    metav1.OwnerReference
+}
+
+func buildEndpointSlice(args buildEPSArgs) *discoveryv1.EndpointSlice {
+	familySuffix := endpointSliceFamilySuffixIPv4
+	if args.family == discoveryv1.AddressTypeIPv6 {
+		familySuffix = endpointSliceFamilySuffixIPv6
+	}
+
+	hash := backendHash(args.backend, args.backendPort)
+	rawName := fmt.Sprintf("%s-%s-%s", args.svcName, hash, familySuffix)
+	name := shortener.ShortenK8sResourceName(rawName)
+
+	annotations := map[string]string{
+		BackendServiceAnnotation: args.backend.Namespace + "/" + args.backend.Name,
+		BackendPortAnnotation:    strconv.FormatUint(uint64(args.backendPort), 10),
+	}
+	if w := normalizedWeight(args.backend.Weight); w != nil {
+		annotations[EndpointSliceWeightAnnotation] = strconv.FormatInt(int64(*w), 10)
+	}
+
+	return &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: args.namespace,
+			Labels: map[string]string{
+				EndpointSliceServiceNameLabel: args.svcName,
+				EndpointSliceManagedByLabel:   EndpointSliceManagedByValue,
+				gatewayNameLabel:              args.gwShort,
+			},
+			Annotations:     annotations,
+			OwnerReferences: []metav1.OwnerReference{args.ownerRef},
+		},
+		AddressType: args.family,
+		Ports:       args.ports,
+		Endpoints:   []discoveryv1.Endpoint{},
+	}
+}
+
+// listenerPortName mirrors the ServicePort.Name produced by toServicePorts.
+func listenerPortName(l model.L4Listener) string {
+	if l.GetProtocol() == model.L4ProtocolUDP {
+		return fmt.Sprintf("port-%d-udp", l.GetPort())
+	}
+	return fmt.Sprintf("port-%d", l.GetPort())
+}
+
+// backendTargetPort returns the port on the backend Pods. If unset on the
+// backendRef, the listener port is used.
+func backendTargetPort(listener model.L4Listener, b model.Backend) uint32 {
+	if b.Port != nil && b.Port.Port != 0 {
+		return b.Port.Port
+	}
+	return listener.Port
+}
+
+func enabledAddressTypes(svc *corev1.Service) []discoveryv1.AddressType {
+	if svc == nil {
+		return nil
+	}
+	if len(svc.Spec.IPFamilies) == 0 {
+		return []discoveryv1.AddressType{discoveryv1.AddressTypeIPv4}
+	}
+	res := make([]discoveryv1.AddressType, 0, len(svc.Spec.IPFamilies))
+	for _, f := range svc.Spec.IPFamilies {
+		switch f {
+		case corev1.IPv4Protocol:
+			res = append(res, discoveryv1.AddressTypeIPv4)
+		case corev1.IPv6Protocol:
+			res = append(res, discoveryv1.AddressTypeIPv6)
+		}
+	}
+	return res
+}
+
+// backendHash keys the slice name on (backend Service, backendRef.port) so
+// listeners/routes sharing that tuple share a slice.
+func backendHash(b model.Backend, port uint32) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "%s/%s|%d", b.Namespace, b.Name, port)
+	return hex.EncodeToString(h.Sum(nil))[:8]
+}
+
+// normalizedWeight caps Gateway API weight (0..1_000_000) to uint16, the range
+// honored by service.cilium.io/weight (cilium/cilium#46061).
+func normalizedWeight(w *int32) *uint16 {
+	if w == nil {
+		return nil
+	}
+	return ptr.To(uint16(min(*w, 65535)))
+}

--- a/operator/pkg/model/translation/gateway-api/translator.go
+++ b/operator/pkg/model/translation/gateway-api/translator.go
@@ -27,8 +27,10 @@ var _ translation.Translator = (*gatewayAPITranslator)(nil)
 const (
 	CiliumGatewayPrefix = "cilium-gateway-"
 	// Deprecated: owningGatewayLabel will be removed later in favour of gatewayNameLabel
-	owningGatewayLabel = "io.cilium.gateway/owning-gateway"
-	gatewayNameLabel   = "gateway.networking.k8s.io/gateway-name"
+	owningGatewayLabel    = "io.cilium.gateway/owning-gateway"
+	gatewayNameLabel      = "gateway.networking.k8s.io/gateway-name"
+	lbAlgorithmAnnotation = "service.cilium.io/lb-algorithm"
+	lbAlgorithmMaglev     = "maglev"
 )
 
 type gatewayAPITranslator struct {
@@ -43,7 +45,7 @@ func NewTranslator(cecTranslator translation.CECTranslator, cfg translation.Conf
 	}
 }
 
-func (t *gatewayAPITranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, *discoveryv1.EndpointSlice, error) {
+func (t *gatewayAPITranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, []*discoveryv1.EndpointSlice, error) {
 	listeners := m.GetListeners()
 	if len(listeners) == 0 || len(listeners[0].GetSources()) == 0 {
 		return nil, nil, nil, fmt.Errorf("model source can't be empty, %d listeners", len(listeners))
@@ -57,7 +59,6 @@ func (t *gatewayAPITranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyC
 	// is the HTTPRoute.
 	var owner *model.FullyQualifiedResource
 
-	var ports []uint32
 	for _, l := range listeners {
 		sources := l.GetSources()
 		source = &sources[0]
@@ -68,7 +69,6 @@ func (t *gatewayAPITranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyC
 			owner = &sources[1]
 		}
 
-		ports = append(ports, l.GetPort())
 	}
 
 	if source == nil || source.Name == "" {
@@ -84,9 +84,13 @@ func (t *gatewayAPITranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyC
 	if source.Kind == "Service" {
 		generatedName = source.Name
 	}
-	cec, err := t.cecTranslator.Translate(source.Namespace, shortener.ShortenK8sResourceName(generatedName), m)
-	if err != nil {
-		return nil, nil, nil, err
+	var cec *ciliumv2.CiliumEnvoyConfig
+	var err error
+	if m.IsHTTPListenerConfigured() || m.IsTLSPassthroughListenerConfigured() {
+		cec, err = t.cecTranslator.Translate(source.Namespace, shortener.ShortenK8sResourceName(generatedName), m)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 	}
 
 	var allLabels, allAnnotations map[string]string
@@ -97,39 +101,51 @@ func (t *gatewayAPITranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyC
 		allLabels = mergeMap(allLabels, l.GetLabels())
 	}
 
-	if err = decorateCEC(cec, owner, allLabels, allAnnotations); err != nil {
-		return nil, nil, nil, err
+	if cec != nil {
+		if err = decorateCEC(cec, owner, allLabels, allAnnotations); err != nil {
+			return nil, nil, nil, err
+		}
 	}
 
-	eps := t.desiredEndpointSlice(source, allLabels, allAnnotations)
-	lbSvc := t.desiredService(listeners[0].GetService(), source, ports, allLabels, allAnnotations)
+	// Maglev is required for Cilium's datapath to honor backend weights.
+	// See cilium/cilium#46061.
+	if l4HasWeights(m.L4) {
+		allAnnotations = mergeMap(allAnnotations, map[string]string{
+			lbAlgorithmAnnotation: lbAlgorithmMaglev,
+		})
+	}
 
-	return cec, lbSvc, eps, err
+	servicePorts := t.toServicePorts(listeners)
+	lbSvc := t.desiredService(listeners[0].GetService(), source, servicePorts, allLabels, allAnnotations)
+
+	endpointSlices := t.toL4EndpointSlices(m.L4, source, lbSvc)
+	// L7 paths need a dummy EndpointSlice (see cilium/cilium#19262); L4 paths supply their own.
+	if len(endpointSlices) == 0 && (m.IsHTTPListenerConfigured() || m.IsTLSPassthroughListenerConfigured()) {
+		endpointSlices = t.desiredEndpointSlice(source, allLabels, allAnnotations)
+	}
+
+	return cec, lbSvc, endpointSlices, nil
+}
+
+func l4HasWeights(listeners []model.L4Listener) bool {
+	for _, l := range listeners {
+		for _, route := range l.Routes {
+			for _, b := range route.Backends {
+				if b.Weight != nil {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 func (t *gatewayAPITranslator) desiredService(params *model.Service, owner *model.FullyQualifiedResource,
-	ports []uint32, labels, annotations map[string]string,
+	servicePorts []corev1.ServicePort, labels, annotations map[string]string,
 ) *corev1.Service {
 	if owner == nil {
 		return nil
 	}
-
-	uniquePorts := map[uint32]struct{}{}
-	for _, p := range ports {
-		uniquePorts[p] = struct{}{}
-	}
-
-	servicePorts := make([]corev1.ServicePort, 0, len(uniquePorts))
-	for p := range uniquePorts {
-		servicePorts = append(servicePorts, corev1.ServicePort{
-			Name:     fmt.Sprintf("port-%d", p),
-			Port:     int32(p),
-			Protocol: corev1.ProtocolTCP,
-		})
-	}
-	slices.SortFunc(servicePorts, func(a, b corev1.ServicePort) int {
-		return int(a.Port) - int(b.Port)
-	})
 
 	shortenName := shortener.ShortenK8sResourceName(owner.Name)
 
@@ -153,7 +169,7 @@ func (t *gatewayAPITranslator) desiredService(params *model.Service, owner *mode
 			},
 		},
 		Spec: corev1.ServiceSpec{
-			Ports:                         t.toServicePorts(ports),
+			Ports:                         servicePorts,
 			Type:                          t.toServiceType(params),
 			ExternalTrafficPolicy:         t.toExternalTrafficPolicy(params),
 			LoadBalancerClass:             t.toLoadBalancerClass(params),
@@ -168,24 +184,78 @@ func (t *gatewayAPITranslator) desiredService(params *model.Service, owner *mode
 	return res
 }
 
-// toServicePorts returns a list of ServicePort objects from the given list of ports.
-func (t *gatewayAPITranslator) toServicePorts(ports []uint32) []corev1.ServicePort {
-	uniquePorts := map[uint32]struct{}{}
-	for _, p := range ports {
-		uniquePorts[p] = struct{}{}
+// toServicePorts returns a list of ServicePort objects from the given listeners.
+func (t *gatewayAPITranslator) toServicePorts(listeners []model.Listener) []corev1.ServicePort {
+	type portProtocols struct {
+		tcp bool
+		udp bool
 	}
 
-	servicePorts := make([]corev1.ServicePort, 0, len(uniquePorts))
-	for p := range uniquePorts {
+	byPort := map[uint32]portProtocols{}
+	for _, l := range listeners {
+		if l == nil {
+			continue
+		}
+		port := l.GetPort()
+		protos := byPort[port]
+		switch l.GetProtocol() {
+		case model.L4ProtocolUDP:
+			protos.udp = true
+		default:
+			protos.tcp = true
+		}
+		byPort[port] = protos
+	}
+
+	type portProtocol struct {
+		port  uint32
+		proto corev1.Protocol
+	}
+
+	entries := make([]portProtocol, 0, len(byPort))
+	for port, protos := range byPort {
+		if protos.tcp {
+			entries = append(entries, portProtocol{
+				port:  port,
+				proto: corev1.ProtocolTCP,
+			})
+		}
+		if protos.udp {
+			entries = append(entries, portProtocol{
+				port:  port,
+				proto: corev1.ProtocolUDP,
+			})
+		}
+	}
+
+	slices.SortFunc(entries, func(a, b portProtocol) int {
+		if a.port != b.port {
+			if a.port < b.port {
+				return -1
+			}
+			return 1
+		}
+		if a.proto == b.proto {
+			return 0
+		}
+		if a.proto == corev1.ProtocolTCP {
+			return -1
+		}
+		return 1
+	})
+
+	servicePorts := make([]corev1.ServicePort, 0, len(entries))
+	for _, entry := range entries {
+		name := fmt.Sprintf("port-%d", entry.port)
+		if entry.proto == corev1.ProtocolUDP {
+			name = fmt.Sprintf("port-%d-udp", entry.port)
+		}
 		servicePorts = append(servicePorts, corev1.ServicePort{
-			Name:     fmt.Sprintf("port-%d", p),
-			Port:     int32(p),
-			Protocol: corev1.ProtocolTCP,
+			Name:     name,
+			Port:     int32(entry.port),
+			Protocol: entry.proto,
 		})
 	}
-	slices.SortFunc(servicePorts, func(a, b corev1.ServicePort) int {
-		return int(a.Port) - int(b.Port)
-	})
 
 	return servicePorts
 }
@@ -301,43 +371,45 @@ func (t *gatewayAPITranslator) toTrafficDistribution(params *model.Service) *str
 	return params.TrafficDistribution
 }
 
-func (t *gatewayAPITranslator) desiredEndpointSlice(owner *model.FullyQualifiedResource, labels, annotations map[string]string) *discoveryv1.EndpointSlice {
+func (t *gatewayAPITranslator) desiredEndpointSlice(owner *model.FullyQualifiedResource, labels, annotations map[string]string) []*discoveryv1.EndpointSlice {
 	if owner == nil {
 		return nil
 	}
 	shortedName := shortener.ShortenK8sResourceName(owner.Name)
 
-	return &discoveryv1.EndpointSlice{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      shortener.ShortenK8sResourceName(CiliumGatewayPrefix + owner.Name),
-			Namespace: owner.Namespace,
-			Labels: mergeMap(map[string]string{
-				owningGatewayLabel: shortedName,
-				gatewayNameLabel:   shortedName,
-			}, labels),
-			Annotations: annotations,
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: gatewayv1beta1.GroupVersion.String(),
-					Kind:       owner.Kind,
-					Name:       owner.Name,
-					UID:        types.UID(owner.UID),
-					Controller: ptr.To(true),
+	return []*discoveryv1.EndpointSlice{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      shortener.ShortenK8sResourceName(CiliumGatewayPrefix + owner.Name),
+				Namespace: owner.Namespace,
+				Labels: mergeMap(map[string]string{
+					owningGatewayLabel: shortedName,
+					gatewayNameLabel:   shortedName,
+				}, labels),
+				Annotations: annotations,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: gatewayv1beta1.GroupVersion.String(),
+						Kind:       owner.Kind,
+						Name:       owner.Name,
+						UID:        types.UID(owner.UID),
+						Controller: ptr.To(true),
+					},
 				},
 			},
-		},
-		AddressType: discoveryv1.AddressTypeIPv4,
-		Endpoints: []discoveryv1.Endpoint{
-			{
-				// This dummy endpoint is required as agent refuses to push service entry
-				// to the lb map when the service has no backends.
-				// Related github issue https://github.com/cilium/cilium/issues/19262
-				Addresses: []string{"192.192.192.192"}, // dummy
+			AddressType: discoveryv1.AddressTypeIPv4,
+			Endpoints: []discoveryv1.Endpoint{
+				{
+					// This dummy endpoint is required as agent refuses to push service entry
+					// to the lb map when the service has no backends.
+					// Related github issue https://github.com/cilium/cilium/issues/19262
+					Addresses: []string{"192.192.192.192"}, // dummy
+				},
 			},
-		},
-		Ports: []discoveryv1.EndpointPort{
-			{
-				Port: ptr.To[int32](9999), // dummy
+			Ports: []discoveryv1.EndpointPort{
+				{
+					Port: ptr.To[int32](9999), // dummy
+				},
 			},
 		},
 	}

--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -275,10 +275,99 @@ func Test_translator_Translate_WithXffNumTrustedHops(t *testing.T) {
 	}
 }
 
+func Test_translator_Translate_L4Only(t *testing.T) {
+	trans := &gatewayAPITranslator{
+		cecTranslator: translation.NewCECTranslator(translation.Config{}),
+	}
+	source := model.FullyQualifiedResource{
+		Name:      "test",
+		Namespace: "default",
+		Kind:      "Gateway",
+		UID:       "uid",
+	}
+	input := &model.Model{
+		L4: []model.L4Listener{
+			{
+				Name:     "tcp",
+				Sources:  []model.FullyQualifiedResource{source},
+				Port:     80,
+				Protocol: model.L4ProtocolTCP,
+			},
+			{
+				Name:     "udp",
+				Sources:  []model.FullyQualifiedResource{source},
+				Port:     53,
+				Protocol: model.L4ProtocolUDP,
+			},
+		},
+	}
+
+	cec, svc, _, err := trans.Translate(input)
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+	require.Nil(t, cec)
+	assert.ElementsMatch(t, []corev1.ServicePort{
+		{
+			Name:     "port-80",
+			Port:     80,
+			Protocol: corev1.ProtocolTCP,
+		},
+		{
+			Name:     "port-53-udp",
+			Port:     53,
+			Protocol: corev1.ProtocolUDP,
+		},
+	}, svc.Spec.Ports)
+}
+
+func Test_translator_toServicePorts_MixedProtocolsSamePort(t *testing.T) {
+	trans := &gatewayAPITranslator{}
+	listeners := []model.Listener{
+		&model.L4Listener{
+			Port:     80,
+			Protocol: model.L4ProtocolUDP,
+		},
+		&model.HTTPListener{
+			Port: 80,
+		},
+		&model.TLSPassthroughListener{
+			Port: 53,
+		},
+		&model.L4Listener{
+			Port:     53,
+			Protocol: model.L4ProtocolUDP,
+		},
+	}
+
+	servicePorts := trans.toServicePorts(listeners)
+	assert.Equal(t, []corev1.ServicePort{
+		{
+			Name:     "port-53",
+			Port:     53,
+			Protocol: corev1.ProtocolTCP,
+		},
+		{
+			Name:     "port-53-udp",
+			Port:     53,
+			Protocol: corev1.ProtocolUDP,
+		},
+		{
+			Name:     "port-80",
+			Port:     80,
+			Protocol: corev1.ProtocolTCP,
+		},
+		{
+			Name:     "port-80-udp",
+			Port:     80,
+			Protocol: corev1.ProtocolUDP,
+		},
+	}, servicePorts)
+}
+
 func Test_getService(t *testing.T) {
 	type args struct {
 		resource              *model.FullyQualifiedResource
-		allPorts              []uint32
+		allPorts              []corev1.ServicePort
 		labels                map[string]string
 		annotations           map[string]string
 		externalTrafficPolicy string
@@ -298,7 +387,13 @@ func Test_getService(t *testing.T) {
 					Kind:      "Gateway",
 					UID:       "57889650-380b-4c05-9a2e-3baee7fd5271",
 				},
-				allPorts:              []uint32{80},
+				allPorts: []corev1.ServicePort{
+					{
+						Name:     fmt.Sprintf("port-%d", 80),
+						Port:     80,
+						Protocol: corev1.ProtocolTCP,
+					},
+				},
 				externalTrafficPolicy: "Cluster",
 			},
 			want: &corev1.Service{
@@ -342,7 +437,7 @@ func Test_getService(t *testing.T) {
 					Kind:      "Gateway",
 					UID:       "41b82697-2d8d-4776-81b6-44d0bbac7faa",
 				},
-				allPorts:              []uint32{80},
+				allPorts:              []corev1.ServicePort{{Name: "port-80", Port: 80, Protocol: corev1.ProtocolTCP}},
 				externalTrafficPolicy: "Local",
 			},
 			want: &corev1.Service{

--- a/operator/pkg/model/translation/ingress/dedicated_ingress.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress.go
@@ -41,7 +41,7 @@ func NewDedicatedIngressTranslator(log *slog.Logger, cecTranslator translation.C
 	}
 }
 
-func (d *dedicatedIngressTranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, *discoveryv1.EndpointSlice, error) {
+func (d *dedicatedIngressTranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, []*discoveryv1.EndpointSlice, error) {
 	if m == nil || (len(m.HTTP) == 0 && len(m.TLSPassthrough) == 0) {
 		return nil, nil, nil, fmt.Errorf("model source can't be empty")
 	}
@@ -158,34 +158,36 @@ func (d *dedicatedIngressTranslator) getService(resource model.FullyQualifiedRes
 	}
 }
 
-func getEndpointSlice(resource model.FullyQualifiedResource) *discoveryv1.EndpointSlice {
-	return &discoveryv1.EndpointSlice{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", ciliumIngressPrefix, resource.Name),
-			Namespace: resource.Namespace,
-			Labels:    map[string]string{ciliumIngressLabelKey: "true"},
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: slim_networkingv1.SchemeGroupVersion.String(),
-					Kind:       "Ingress",
-					Name:       resource.Name,
-					UID:        types.UID(resource.UID),
-					Controller: ptr.To(true),
+func getEndpointSlice(resource model.FullyQualifiedResource) []*discoveryv1.EndpointSlice {
+	return []*discoveryv1.EndpointSlice{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%s", ciliumIngressPrefix, resource.Name),
+				Namespace: resource.Namespace,
+				Labels:    map[string]string{ciliumIngressLabelKey: "true"},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: slim_networkingv1.SchemeGroupVersion.String(),
+						Kind:       "Ingress",
+						Name:       resource.Name,
+						UID:        types.UID(resource.UID),
+						Controller: ptr.To(true),
+					},
 				},
 			},
-		},
-		AddressType: discoveryv1.AddressTypeIPv4,
-		Endpoints: []discoveryv1.Endpoint{
-			{
-				// This dummy endpoint is required as agent refuses to push service entry
-				// to the lb map when the service has no backends.
-				// Related github issue https://github.com/cilium/cilium/issues/19262
-				Addresses: []string{"192.192.192.192"}, // dummy
+			AddressType: discoveryv1.AddressTypeIPv4,
+			Endpoints: []discoveryv1.Endpoint{
+				{
+					// This dummy endpoint is required as agent refuses to push service entry
+					// to the lb map when the service has no backends.
+					// Related github issue https://github.com/cilium/cilium/issues/19262
+					Addresses: []string{"192.192.192.192"}, // dummy
+				},
 			},
-		},
-		Ports: []discoveryv1.EndpointPort{
-			{
-				Port: ptr.To[int32](9999), // dummy
+			Ports: []discoveryv1.EndpointPort{
+				{
+					Port: ptr.To[int32](9999), // dummy
+				},
 			},
 		},
 	}

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
@@ -198,31 +198,33 @@ func Test_getEndpointForIngress(t *testing.T) {
 		UID:       "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
 	})
 
-	require.Equal(t, &discoveryv1.EndpointSlice{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "cilium-ingress-dummy-ingress",
-			Namespace: "dummy-namespace",
-			Labels:    map[string]string{"cilium.io/ingress": "true"},
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: "networking.k8s.io/v1",
-					Kind:       "Ingress",
-					Name:       "dummy-ingress",
-					UID:        "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
-					Controller: ptr.To(true),
+	require.Equal(t, []*discoveryv1.EndpointSlice{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cilium-ingress-dummy-ingress",
+				Namespace: "dummy-namespace",
+				Labels:    map[string]string{"cilium.io/ingress": "true"},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "networking.k8s.io/v1",
+						Kind:       "Ingress",
+						Name:       "dummy-ingress",
+						UID:        "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+						Controller: ptr.To(true),
+					},
 				},
 			},
-		},
-		AddressType: discoveryv1.AddressTypeIPv4,
-		Endpoints: []discoveryv1.Endpoint{
-			{
-				// This dummy endpoint is required as agent refuses to push service entry
-				// to the lb map when the service has no backends.
-				// Related github issue https://github.com/cilium/cilium/issues/19262
-				Addresses: []string{"192.192.192.192"}, // dummy
+			AddressType: discoveryv1.AddressTypeIPv4,
+			Endpoints: []discoveryv1.Endpoint{
+				{
+					// This dummy endpoint is required as agent refuses to push service entry
+					// to the lb map when the service has no backends.
+					// Related github issue https://github.com/cilium/cilium/issues/19262
+					Addresses: []string{"192.192.192.192"}, // dummy
+				},
 			},
+			Ports: []discoveryv1.EndpointPort{{Port: ptr.To[int32](9999)}}, // dummy port
 		},
-		Ports: []discoveryv1.EndpointPort{{Port: ptr.To[int32](9999)}}, // dummy port
 	}, res)
 }
 

--- a/operator/pkg/model/translation/types.go
+++ b/operator/pkg/model/translation/types.go
@@ -16,7 +16,7 @@ import (
 //
 // Different use cases (e.g. Ingress, Gateway API) can provide its own generation logic.
 type Translator interface {
-	Translate(model *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, *discoveryv1.EndpointSlice, error)
+	Translate(model *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, []*discoveryv1.EndpointSlice, error)
 }
 
 // CECTranslator is the interface to take the model and generate required CiliumEnvoyConfig.

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -1214,6 +1214,10 @@ const (
 
 	GRPCRoute = "grpcRoute"
 
+	TCPRoute = "tcpRoute"
+
+	UDPRoute = "udpRoute"
+
 	Secret = "secret"
 
 	Nodes = "nodes"


### PR DESCRIPTION
This adds Gateway API operator support for TCPRoute and UDPRoute without relying on Envoy. The operator now reconciles L4 routes into LoadBalancer Services and operator-managed EndpointSlices consumed by Cilium’s service load-balancer, including backend weight propagation support.

The implementation also adds dedicated TCP/UDP route reconciliation, backend endpoint synchronization, route checks, translation support for L4 listeners, and automatic service annotations for Maglev-based load-balancing.

Fixes: #21929

```release-note
gateway-api: Add TCPRoute and UDPRoute support
```

This PR was prepared with AIL:1. AI assistance was used for implementation review, validation, and iterative feedback by the author and Cilium developers; the feature design and implementation were done by the author.

cc @mhofstetter, @youngnick 