### PR TITLE
gateway-api: Add TCPRoute and UDPRoute support

### DIFF
--- a/Documentation/network/servicemesh/gateway-api/gateway-api.rst
+++ b/Documentation/network/servicemesh/gateway-api/gateway-api.rst
@@ -26,13 +26,15 @@ Cilium Gateway API Support
 Cilium supports Gateway API v1.5.1 for below resources, all the Core conformance
 tests are passed.
 
-- `GatewayClass <https://gateway-api.sigs.k8s.io/api-types/gatewayclass/>`_
-- `Gateway <https://gateway-api.sigs.k8s.io/api-types/gateway/>`_
-- `HTTPRoute <https://gateway-api.sigs.k8s.io/api-types/httproute/>`_
-- `GRPCRoute <https://gateway-api.sigs.k8s.io/api-types/grpcroute/>`__
-- `TLSRoute <https://gateway-api.sigs.k8s.io/api-types/tlsroute/>`__
-- `BackendTLSPolicy <https://gateway-api.sigs.k8s.io/api-types/backendtlspolicy/>`__
-- `ReferenceGrant <https://gateway-api.sigs.k8s.io/api-types/referencegrant/>`_
+- `GatewayClass <https://gateway-api.sigs.k8s.io/reference/api-types/gatewayclass/>`_
+- `Gateway <https://gateway-api.sigs.k8s.io/reference/api-types/gateway/>`_
+- `HTTPRoute <https://gateway-api.sigs.k8s.io/reference/api-types/httproute/>`_
+- `GRPCRoute <https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute/>`__
+- `TLSRoute <https://gateway-api.sigs.k8s.io/reference/api-types/tlsroute/>`__
+- `BackendTLSPolicy <https://gateway-api.sigs.k8s.io/reference/api-types/policy/backendtlspolicy/>`__
+- `ReferenceGrant <https://gateway-api.sigs.k8s.io/reference/api-types/referencegrant/>`_
+- `TCPRoute (experimental) <https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#tcproute>`__
+- `UDPRoute (experimental) <https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#udproute>`__
 
 Additionally, Cilium provides ``CiliumGatewayClassConfig`` CRD, which can be referenced in
 `GatewayClass.parametersRef <https://gateway-api.sigs.k8s.io/api-types/gatewayclass/#gatewayclass-parameters>`_.

--- a/Documentation/network/servicemesh/gateway-api/installation.rst
+++ b/Documentation/network/servicemesh/gateway-api/installation.rst
@@ -17,6 +17,12 @@ Prerequisites
     - `ReferenceGrant <https://gateway-api.sigs.k8s.io/api-types/referencegrant/>`_
     - `TLSRoute <https://gateway-api.sigs.k8s.io/api-types/tlsroute/>`_
 
+  If you wish to use the TCPRoute and UDPRoute functionality, you also need to install the TCPRoute and UDPRoute resource.
+  If this CRD is not installed, then Cilium will disable TCPRoute and UDPRoute support.
+
+    - `TCPRoute (experimental) <https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#tcproute>`__
+    - `UDPRoute (experimental) <https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#udproute>`__
+
   You can install the required CRDs like this:
 
     .. code-block:: shell-session
@@ -28,6 +34,13 @@ Prerequisites
         $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
         $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_backendtlspolicies.yaml
         $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_tlsroutes.yaml
+
+  For TCPRoute and UDPRoute, also add the related CRDs with the following snippet:
+
+    .. code-block:: shell-session
+
+        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
 
 * By default, the Gateway API controller creates a service of LoadBalancer type,
   so your environment will need to support this. Alternatively, since Cilium 1.16+,

--- a/Makefile.kind
+++ b/Makefile.kind
@@ -386,6 +386,10 @@ kind-servicemesh-install-cilium: check_deps kind-ready ## Install a local Cilium
 	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_grpcroutes.yaml
 	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_backendtlspolicies.yaml
 	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_tlsroutes.yaml
+ifeq ($(GW_CHANNEL),experimental)
+	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_tcproutes.yaml
+	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_udproutes.yaml
+endif
 
 	$(CILIUM_CLI) install \
 		--chart-directory=$(ROOT_DIR)/install/kubernetes/cilium \
@@ -414,6 +418,10 @@ kind-servicemesh-prereqs: check_deps kind-ready
 	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_grpcroutes.yaml
 	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_backendtlspolicies.yaml
 	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_tlsroutes.yaml
+ifeq ($(GW_CHANNEL),experimental)
+	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_tcproutes.yaml
+	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_udproutes.yaml
+endif
 
 	$(eval KIND_VALUES_FAST_FILES += --helm-values=$(ROOT_DIR)/contrib/testing/kind-servicemesh.yaml)
 

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -493,8 +493,16 @@ data:
 {{- if hasKey .Values.bpf "lbSourceRangeAllTypes" }}
   bpf-lb-source-range-all-types: {{ .Values.bpf.lbSourceRangeAllTypes | quote }}
 {{- end }}
-{{- if hasKey .Values.bpf "lbAlgorithmAnnotation" }}
+{{- if or (hasKey .Values.bpf "lbAlgorithmAnnotation") .Values.gatewayAPI.enabled }}
+# When Gateway API is enabled this is forced to "true" so per-backend weights
+# on TCPRoute/UDPRoute take effect (Maglev honors the LB algorithm annotation only
+# when enabled). Paired with `bpf-lb-sock-hostns-only`, which is forced "true"
+# for the same reason.
+{{- if .Values.gatewayAPI.enabled }}
+  bpf-lb-algorithm-annotation: "true"
+{{- else }}
   bpf-lb-algorithm-annotation: {{ .Values.bpf.lbAlgorithmAnnotation | quote }}
+{{- end }}
 {{- end }}
 {{- if hasKey .Values.bpf "lbModeAnnotation" }}
   bpf-lb-mode-annotation: {{ .Values.bpf.lbModeAnnotation | quote }}
@@ -856,8 +864,16 @@ data:
 {{- if hasKey $socketLB "enabled" }}
   bpf-lb-sock: {{ $socketLB.enabled | quote }}
 {{- end }}
-{{- if hasKey $socketLB "hostNamespaceOnly" }}
+{{- if or (hasKey $socketLB "hostNamespaceOnly") .Values.gatewayAPI.enabled }}
+# When Gateway API is enabled this is forced to "true" so per-backend weights
+# on TCPRoute/UDPRoute take effect (socket LB stays in the host namespace,
+# letting the Maglev LB mode apply). Paired with `bpf-lb-mode-annotation`,
+# which is forced "true" for the same reason.
+{{- if .Values.gatewayAPI.enabled }}
+  bpf-lb-sock-hostns-only: "true"
+{{- else }}
   bpf-lb-sock-hostns-only: {{ $socketLB.hostNamespaceOnly | quote }}
+{{- end }}
 {{- end }}
 {{- if hasKey $socketLB "terminatePodConnections" }}
   bpf-lb-sock-terminate-pod-connections: {{ $socketLB.terminatePodConnections | quote }}

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -347,6 +347,8 @@ rules:
   resources:
   - gatewayclasses
   - gateways
+  - tcproutes
+  - udproutes
   - tlsroutes
   - httproutes
   - grpcroutes
@@ -372,6 +374,8 @@ rules:
   - grpcroutes/status
   - tlsroutes/status
   - backendtlspolicies/status
+  - tcproutes/status
+  - udproutes/status
   verbs:
   - update
   - patch

--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -435,9 +435,10 @@ func registerReconcilers(mgr ctrlRuntime.Manager, translator translation.Transla
 		SetupWithManager(mgr ctrlRuntime.Manager) error
 	}{
 		newGatewayClassReconciler(mgr, logger, controllerName),
-		newGatewayReconciler(mgr, translator, logger, controllerName, installedCRDs),
+		newGatewayReconciler(mgr, translator, logger, controllerName),
 		newGammaReconciler(mgr, translator, logger, controllerName),
 		newGatewayClassConfigReconciler(mgr, logger),
+		newEndpointSliceReconciler(mgr, logger),
 	}
 
 	for _, r := range requiredReconcilers {
@@ -456,6 +457,14 @@ func registerReconcilers(mgr ctrlRuntime.Manager, translator translation.Transla
 			// TLSRoute is reconciled by the Gateway API reconciler, but log that the
 			// support has been successfully enabled.
 			logger.Info("TLSRoute CRD is installed, TLSRoute support is enabled")
+		case helpers.TCPRouteKind:
+			// TCPRoute is reconciled by the Gateway API reconciler, but log that the
+			// support has been successfully enabled.
+			logger.Info("TCPRoute CRD is installed, TCPRoute support is enabled")
+		case helpers.UDPRouteKind:
+			// UDPRoute is reconciled by the Gateway API reconciler, but log that the
+			// support has been successfully enabled.
+			logger.Info("UDPRoute CRD is installed, UDPRoute support is enabled")
 		case helpers.ServiceImportKind:
 			// we don't need a reconciler, but we do need to tell folks that the
 			// support is working.

--- a/operator/pkg/gateway-api/endpointslice_reconcile.go
+++ b/operator/pkg/gateway-api/endpointslice_reconcile.go
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gateway_api
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	controllerruntime "github.com/cilium/cilium/operator/pkg/controller-runtime"
+	"github.com/cilium/cilium/operator/pkg/gateway-api/predicates"
+	watchhandlers "github.com/cilium/cilium/operator/pkg/gateway-api/watch-handlers"
+	gwModel "github.com/cilium/cilium/operator/pkg/model/translation/gateway-api"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// endpointSliceReconciler keeps the Endpoints and resolved target port of
+// operator-managed frontend EndpointSlices in sync with the referenced backend
+// Service.
+//
+// Ownership split with the gatewayReconciler:
+//   - gatewayReconciler owns slice identity (Ports name/protocol, labels,
+//     annotations, OwnerReferences, stale-slice deletion) and seeds new slices
+//     with empty Endpoints.
+//   - endpointSliceReconciler owns the data-plane fields: Endpoints and the
+//     resolved numeric value applied uniformly across every Ports[].Port entry.
+//
+// Splitting writes between the two reconcilers prevents update loops.
+type endpointSliceReconciler struct {
+	client.Client
+	logger *slog.Logger
+}
+
+func newEndpointSliceReconciler(mgr ctrl.Manager, logger *slog.Logger) *endpointSliceReconciler {
+	return &endpointSliceReconciler{
+		Client: mgr.GetClient(),
+		logger: logger.With(logfields.Controller, endpointSlice),
+	}
+}
+
+// SetupWithManager wires the reconciler into the controller-runtime manager.
+func (r *endpointSliceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(endpointSlice).
+		For(&discoveryv1.EndpointSlice{},
+			builder.WithPredicates(predicates.ManagedFrontendEndpointSlice())).
+		Watches(&discoveryv1.EndpointSlice{},
+			watchhandlers.EnqueueFrontendsForBackendEndpointSlice(r.Client, r.logger),
+			builder.WithPredicates(predicates.NonManagedEndpointSlice())).
+		Watches(&corev1.Service{},
+			watchhandlers.EnqueueFrontendsForBackendService(r.Client, r.logger)).
+		Complete(r)
+}
+
+// Reconcile populates the endpoints and target port of a managed frontend
+// EndpointSlice from the backend Service and its own EndpointSlices.
+func (r *endpointSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	scopedLog := r.logger.With(logfields.Resource, req.NamespacedName)
+
+	frontend := &discoveryv1.EndpointSlice{}
+	if err := r.Client.Get(ctx, req.NamespacedName, frontend); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return controllerruntime.Success()
+		}
+		return controllerruntime.Fail(err)
+	}
+	if !predicates.IsManagedFrontendEndpointSlice(frontend) {
+		return controllerruntime.Success()
+	}
+
+	backendRef := frontend.Annotations[gwModel.BackendServiceAnnotation]
+	if backendRef == "" {
+		scopedLog.WarnContext(ctx, "Managed EndpointSlice missing backend-service annotation, skipping")
+		return controllerruntime.Success()
+	}
+	backendNs, backendName, ok := strings.Cut(backendRef, "/")
+	if !ok || backendNs == "" || backendName == "" {
+		scopedLog.WarnContext(ctx, "Invalid backend-service annotation",
+			logfields.Annotation, backendRef)
+		return controllerruntime.Success()
+	}
+
+	servicePort, err := strconv.ParseUint(frontend.Annotations[gwModel.BackendPortAnnotation], 10, 16)
+	if err != nil {
+		return controllerruntime.Fail(fmt.Errorf("invalid backend-port annotation %q: %w",
+			frontend.Annotations[gwModel.BackendPortAnnotation], err))
+	}
+
+	backendSvc := &corev1.Service{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: backendNs, Name: backendName}, backendSvc); err != nil {
+		if k8serrors.IsNotFound(err) {
+			scopedLog.DebugContext(ctx, "Backend Service not found, clearing endpoints",
+				logfields.Backend, backendRef)
+			return r.patchFrontend(ctx, frontend, nil, nil)
+		}
+		return controllerruntime.Fail(fmt.Errorf("failed to get backend Service %s: %w", backendRef, err))
+	}
+
+	matchedPort := matchServicePort(backendSvc.Spec.Ports, uint16(servicePort), portProtocol(frontend.Ports))
+	if matchedPort == nil {
+		scopedLog.WarnContext(ctx, "Backend Service does not expose requested port; clearing endpoints",
+			logfields.Backend, backendRef,
+			logfields.Port, servicePort,
+		)
+		return r.patchFrontend(ctx, frontend, nil, nil)
+	}
+
+	endpointPort, addresses, err := r.resolveBackendEndpoints(ctx, backendNs, backendName, frontend.AddressType, *matchedPort)
+	if err != nil {
+		return controllerruntime.Fail(err)
+	}
+	if endpointPort == nil {
+		// Backend Service exists but no matching EndpointSlice port resolved yet.
+		// Keep frontend port name/proto stable; clear endpoints until backend appears.
+		return r.patchFrontend(ctx, frontend, nil, nil)
+	}
+
+	return r.patchFrontend(ctx, frontend, endpointPort, addresses)
+}
+
+func (r *endpointSliceReconciler) patchFrontend(ctx context.Context, frontend *discoveryv1.EndpointSlice, port *int32, endpoints []discoveryv1.Endpoint) (ctrl.Result, error) {
+	updated := &discoveryv1.EndpointSlice{}
+	updated.Name = frontend.Name
+	updated.Namespace = frontend.Namespace
+
+	_, err := controllerutil.CreateOrPatch(ctx, r.Client, updated, func() error {
+		updated.Endpoints = endpoints
+		if port != nil {
+			// All EndpointPort entries in a managed frontend slice share the
+			// same backend Service port (see toL4EndpointSlices dedup), so they
+			// all resolve to the same target pod port. Apply the resolved port
+			// uniformly so per-listener name lookups in the LB reflector see
+			// matching numeric ports.
+			for i := range updated.Ports {
+				updated.Ports[i].Port = port
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return controllerruntime.Fail(fmt.Errorf("failed to patch frontend EndpointSlice: %w", err))
+	}
+	return controllerruntime.Success()
+}
+
+// matchServicePort returns the ServicePort matching the requested port number
+// and protocol, or nil when not found.
+func matchServicePort(ports []corev1.ServicePort, want uint16, proto corev1.Protocol) *corev1.ServicePort {
+	for i := range ports {
+		p := ports[i]
+		if uint16(p.Port) != want {
+			continue
+		}
+		if p.Protocol != "" && p.Protocol != proto {
+			continue
+		}
+		return &p
+	}
+	return nil
+}
+
+// resolveBackendEndpoints returns the resolved target port and endpoint addresses
+// for the given backend Service's ServicePort. The target port is determined by
+// matching backend EndpointSlice ports by name (preferred) or by port number.
+func (r *endpointSliceReconciler) resolveBackendEndpoints(ctx context.Context, ns, svcName string, family discoveryv1.AddressType, svcPort corev1.ServicePort) (*int32, []discoveryv1.Endpoint, error) {
+	list := &discoveryv1.EndpointSliceList{}
+	if err := r.Client.List(ctx, list,
+		client.InNamespace(ns),
+		client.MatchingLabels{gwModel.EndpointSliceServiceNameLabel: svcName},
+	); err != nil {
+		return nil, nil, fmt.Errorf("failed to list backend EndpointSlices for %s/%s: %w", ns, svcName, err)
+	}
+
+	var resolvedPort *int32
+	addrSeen := make(map[string]struct{})
+	var endpoints []discoveryv1.Endpoint
+	for i := range list.Items {
+		be := list.Items[i]
+		if be.AddressType != family {
+			continue
+		}
+		if predicates.IsManagedFrontendEndpointSlice(&be) {
+			continue
+		}
+		bePort := matchEndpointSlicePort(be.Ports, svcPort)
+		if bePort == nil {
+			continue
+		}
+		if resolvedPort == nil {
+			resolvedPort = ptr.To(*bePort)
+		}
+		for _, ep := range be.Endpoints {
+			if len(ep.Addresses) == 0 {
+				continue
+			}
+			key := strings.Join(ep.Addresses, ",")
+			if _, ok := addrSeen[key]; ok {
+				continue
+			}
+			addrSeen[key] = struct{}{}
+			endpoints = append(endpoints, discoveryv1.Endpoint{
+				Addresses:  append([]string(nil), ep.Addresses...),
+				Conditions: ep.Conditions,
+				Hostname:   ep.Hostname,
+				TargetRef:  ep.TargetRef,
+				NodeName:   ep.NodeName,
+				Zone:       ep.Zone,
+				Hints:      ep.Hints,
+			})
+		}
+	}
+
+	sort.SliceStable(endpoints, func(i, j int) bool {
+		return strings.Join(endpoints[i].Addresses, ",") < strings.Join(endpoints[j].Addresses, ",")
+	})
+	return resolvedPort, endpoints, nil
+}
+
+// matchEndpointSlicePort returns the EPS port number whose name matches the
+// ServicePort name, or whose numeric port matches the ServicePort targetPort.
+func matchEndpointSlicePort(ports []discoveryv1.EndpointPort, svcPort corev1.ServicePort) *int32 {
+	wantProto := svcPort.Protocol
+	wantName := svcPort.Name
+	wantNumeric := int32(0)
+	if svcPort.TargetPort.Type == 0 { // intstr.Int
+		wantNumeric = svcPort.TargetPort.IntVal
+	}
+
+	for _, p := range ports {
+		if p.Port == nil {
+			continue
+		}
+		if p.Protocol != nil && wantProto != "" && *p.Protocol != wantProto {
+			continue
+		}
+		// Prefer name match.
+		if p.Name != nil && wantName != "" && *p.Name == wantName {
+			return p.Port
+		}
+		// Fall back to numeric targetPort match.
+		if wantNumeric != 0 && *p.Port == wantNumeric {
+			return p.Port
+		}
+	}
+	// If the Service has only one port and no name match was found, use the first EPS port.
+	if len(ports) == 1 && ports[0].Port != nil {
+		return ports[0].Port
+	}
+	return nil
+}
+
+func portProtocol(ports []discoveryv1.EndpointPort) corev1.Protocol {
+	for _, p := range ports {
+		if p.Protocol != nil {
+			return *p.Protocol
+		}
+	}
+	return corev1.ProtocolTCP
+}

--- a/operator/pkg/gateway-api/endpointslice_reconcile_test.go
+++ b/operator/pkg/gateway-api/endpointslice_reconcile_test.go
@@ -1,0 +1,423 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gateway_api
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	gwModel "github.com/cilium/cilium/operator/pkg/model/translation/gateway-api"
+)
+
+const (
+	testNS          = "default"
+	testBackendName = "backend-svc"
+	testFrontendEPS = "frontend-eps"
+)
+
+// frontend builds a managed frontend EndpointSlice pointing at the given
+// backend Service / port, with a single Port entry to be filled by the
+// reconciler.
+func frontend(portName string, proto corev1.Protocol, backendPort string) *discoveryv1.EndpointSlice {
+	return &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testFrontendEPS,
+			Namespace: testNS,
+			Labels: map[string]string{
+				gwModel.EndpointSliceManagedByLabel: gwModel.EndpointSliceManagedByValue,
+			},
+			Annotations: map[string]string{
+				gwModel.BackendServiceAnnotation: testNS + "/" + testBackendName,
+				gwModel.BackendPortAnnotation:    backendPort,
+			},
+		},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Ports: []discoveryv1.EndpointPort{
+			{
+				Name:     ptr.To(portName),
+				Protocol: ptr.To(proto),
+				Port:     ptr.To(int32(0)),
+			},
+		},
+	}
+}
+
+func backendService(port int32, name string, proto corev1.Protocol, target intstr.IntOrString) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: testBackendName, Namespace: testNS},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:       name,
+					Protocol:   proto,
+					Port:       port,
+					TargetPort: target,
+				},
+			},
+		},
+	}
+}
+
+// backendEPS builds an upstream (non-managed) backend EndpointSlice.
+func backendEPS(name string, portName string, proto corev1.Protocol, port int32, addrs ...string) *discoveryv1.EndpointSlice {
+	return &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNS,
+			Labels: map[string]string{
+				gwModel.EndpointSliceServiceNameLabel: testBackendName,
+			},
+		},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Ports: []discoveryv1.EndpointPort{
+			{
+				Name:     ptr.To(portName),
+				Protocol: ptr.To(proto),
+				Port:     ptr.To(port),
+			},
+		},
+		Endpoints: []discoveryv1.Endpoint{
+			{Addresses: addrs},
+		},
+	}
+}
+
+func Test_endpointSliceReconciler_Reconcile(t *testing.T) {
+	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+
+	tests := []struct {
+		name          string
+		objects       []client.Object
+		wantErr       bool
+		wantPort      *int32
+		wantNumPorts  int // expected number of frontend ports; 0 defaults to 1
+		wantAddresses [][]string
+	}{
+		{
+			name: "resolves port by name and populates endpoints",
+			objects: []client.Object{
+				frontend("http", corev1.ProtocolTCP, "80"),
+				backendService(80, "http", corev1.ProtocolTCP, intstr.FromInt(8080)),
+				backendEPS("backend-eps", "http", corev1.ProtocolTCP, 8080, "10.0.0.1"),
+			},
+			wantPort:      ptr.To(int32(8080)),
+			wantAddresses: [][]string{{"10.0.0.1"}},
+		},
+		{
+			name: "resolves port by numeric targetPort when name absent",
+			objects: []client.Object{
+				frontend("", corev1.ProtocolTCP, "80"),
+				backendService(80, "", corev1.ProtocolTCP, intstr.FromInt(8080)),
+				backendEPS("backend-eps", "", corev1.ProtocolTCP, 8080, "10.0.0.2"),
+			},
+			wantPort:      ptr.To(int32(8080)),
+			wantAddresses: [][]string{{"10.0.0.2"}},
+		},
+		{
+			name: "dedups and sorts addresses across backend slices",
+			objects: []client.Object{
+				frontend("http", corev1.ProtocolTCP, "80"),
+				backendService(80, "http", corev1.ProtocolTCP, intstr.FromInt(8080)),
+				backendEPS("backend-eps-b", "http", corev1.ProtocolTCP, 8080, "10.0.0.9"),
+				backendEPS("backend-eps-a", "http", corev1.ProtocolTCP, 8080, "10.0.0.1"),
+				backendEPS("backend-eps-dup", "http", corev1.ProtocolTCP, 8080, "10.0.0.1"),
+			},
+			wantPort:      ptr.To(int32(8080)),
+			wantAddresses: [][]string{{"10.0.0.1"}, {"10.0.0.9"}},
+		},
+		{
+			name: "backend Service missing clears endpoints",
+			objects: []client.Object{
+				frontend("http", corev1.ProtocolTCP, "80"),
+			},
+			wantPort:      ptr.To(int32(0)), // untouched, stays at seeded value
+			wantAddresses: nil,
+		},
+		{
+			name: "Service does not expose requested port clears endpoints",
+			objects: []client.Object{
+				frontend("http", corev1.ProtocolTCP, "80"),
+				backendService(443, "https", corev1.ProtocolTCP, intstr.FromInt(8443)),
+				backendEPS("backend-eps", "https", corev1.ProtocolTCP, 8443, "10.0.0.1"),
+			},
+			wantPort:      ptr.To(int32(0)),
+			wantAddresses: nil,
+		},
+		{
+			name: "no backend EndpointSlice keeps endpoints empty",
+			objects: []client.Object{
+				frontend("http", corev1.ProtocolTCP, "80"),
+				backendService(80, "http", corev1.ProtocolTCP, intstr.FromInt(8080)),
+				// Service exists and exposes the port, but no backend slice yet.
+			},
+			wantPort:      ptr.To(int32(0)),
+			wantAddresses: nil,
+		},
+		{
+			name: "invalid backend-port annotation errors",
+			objects: []client.Object{
+				frontend("http", corev1.ProtocolTCP, "not-a-number"),
+				backendService(80, "http", corev1.ProtocolTCP, intstr.FromInt(8080)),
+			},
+			wantErr: true,
+		},
+		{
+			name: "ignores managed frontend slices when resolving backends",
+			objects: []client.Object{
+				frontend("http", corev1.ProtocolTCP, "80"),
+				backendService(80, "http", corev1.ProtocolTCP, intstr.FromInt(8080)),
+				backendEPS("backend-eps", "http", corev1.ProtocolTCP, 8080, "10.0.0.1"),
+				// a managed frontend slice that also carries the service-name
+				// label must be skipped as a backend source.
+				func() client.Object {
+					f := frontend("http", corev1.ProtocolTCP, "80")
+					f.Name = "other-frontend"
+					f.Labels[gwModel.EndpointSliceServiceNameLabel] = testBackendName
+					f.Endpoints = []discoveryv1.Endpoint{{Addresses: []string{"192.168.0.1"}}}
+					f.Ports[0].Port = ptr.To(int32(9999))
+					return f
+				}(),
+			},
+			wantPort:      ptr.To(int32(8080)),
+			wantAddresses: [][]string{{"10.0.0.1"}},
+		},
+		{
+			name: "resolves UDP port end-to-end",
+			objects: []client.Object{
+				frontend("dns", corev1.ProtocolUDP, "53"),
+				backendService(53, "dns", corev1.ProtocolUDP, intstr.FromInt(5353)),
+				backendEPS("backend-eps", "dns", corev1.ProtocolUDP, 5353, "10.0.0.5"),
+			},
+			wantPort:      ptr.To(int32(5353)),
+			wantAddresses: [][]string{{"10.0.0.5"}},
+		},
+		{
+			name: "ignores backend slices of a different address family",
+			objects: []client.Object{
+				frontend("http", corev1.ProtocolTCP, "80"),
+				backendService(80, "http", corev1.ProtocolTCP, intstr.FromInt(8080)),
+				// IPv6 backend slice must be skipped for an IPv4 frontend.
+				func() client.Object {
+					be := backendEPS("backend-eps-v6", "http", corev1.ProtocolTCP, 8080, "2001:db8::1")
+					be.AddressType = discoveryv1.AddressTypeIPv6
+					return be
+				}(),
+				backendEPS("backend-eps-v4", "http", corev1.ProtocolTCP, 8080, "10.0.0.1"),
+			},
+			wantPort:      ptr.To(int32(8080)),
+			wantAddresses: [][]string{{"10.0.0.1"}},
+		},
+		{
+			name: "resolves IPv6 frontend from IPv6 backend slice",
+			objects: []client.Object{
+				func() client.Object {
+					f := frontend("http", corev1.ProtocolTCP, "80")
+					f.AddressType = discoveryv1.AddressTypeIPv6
+					return f
+				}(),
+				backendService(80, "http", corev1.ProtocolTCP, intstr.FromInt(8080)),
+				func() client.Object {
+					be := backendEPS("backend-eps-v6", "http", corev1.ProtocolTCP, 8080, "2001:db8::1")
+					be.AddressType = discoveryv1.AddressTypeIPv6
+					return be
+				}(),
+				// an IPv4 backend slice that must be ignored for an IPv6 frontend.
+				backendEPS("backend-eps-v4", "http", corev1.ProtocolTCP, 8080, "10.0.0.1"),
+			},
+			wantPort:      ptr.To(int32(8080)),
+			wantAddresses: [][]string{{"2001:db8::1"}},
+		},
+		{
+			// A managed frontend carrying several EndpointPort entries (all
+			// sharing one backend Service port) must have the resolved target
+			// port applied uniformly across every entry.
+			name: "applies resolved port to every frontend port entry",
+			objects: []client.Object{
+				func() client.Object {
+					f := frontend("http", corev1.ProtocolTCP, "80")
+					f.Ports = append(f.Ports, discoveryv1.EndpointPort{
+						Name:     ptr.To("http-2"),
+						Protocol: ptr.To(corev1.ProtocolTCP),
+						Port:     ptr.To(int32(0)),
+					})
+					return f
+				}(),
+				backendService(80, "http", corev1.ProtocolTCP, intstr.FromInt(8080)),
+				backendEPS("backend-eps", "http", corev1.ProtocolTCP, 8080, "10.0.0.1"),
+			},
+			wantPort:      ptr.To(int32(8080)),
+			wantNumPorts:  2,
+			wantAddresses: [][]string{{"10.0.0.1"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().
+				WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+				WithObjects(tt.objects...).
+				Build()
+
+			r := &endpointSliceReconciler{
+				Client: c,
+				logger: logger,
+			}
+
+			result, err := r.Reconcile(t.Context(), ctrl.Request{
+				NamespacedName: types.NamespacedName{Namespace: testNS, Name: testFrontendEPS},
+			})
+			require.Equal(t, tt.wantErr, err != nil, "error mismatch, error was %v", err)
+			if tt.wantErr {
+				return
+			}
+			require.Equal(t, ctrl.Result{}, result)
+
+			got := &discoveryv1.EndpointSlice{}
+			require.NoError(t, c.Get(t.Context(), types.NamespacedName{Namespace: testNS, Name: testFrontendEPS}, got))
+
+			wantNumPorts := tt.wantNumPorts
+			if wantNumPorts == 0 {
+				wantNumPorts = 1
+			}
+			require.Len(t, got.Ports, wantNumPorts)
+			// The resolved target port is applied uniformly across every
+			// frontend port entry, so all entries must match wantPort.
+			for i := range got.Ports {
+				require.Equal(t, tt.wantPort, got.Ports[i].Port, "resolved port mismatch at index %d", i)
+			}
+
+			var gotAddrs [][]string
+			for _, ep := range got.Endpoints {
+				gotAddrs = append(gotAddrs, ep.Addresses)
+			}
+			require.Equal(t, tt.wantAddresses, gotAddrs, "endpoint addresses mismatch")
+		})
+	}
+}
+
+func Test_matchServicePort(t *testing.T) {
+	ports := []corev1.ServicePort{
+		{Name: "http", Protocol: corev1.ProtocolTCP, Port: 80},
+		{Name: "dns", Protocol: corev1.ProtocolUDP, Port: 53},
+		{Name: "noproto", Port: 8080},
+	}
+
+	tests := []struct {
+		name  string
+		want  uint16
+		proto corev1.Protocol
+		found bool
+	}{
+		{name: "matches port and proto", want: 80, proto: corev1.ProtocolTCP, found: true},
+		{name: "matches udp", want: 53, proto: corev1.ProtocolUDP, found: true},
+		{name: "proto mismatch", want: 80, proto: corev1.ProtocolUDP, found: false},
+		{name: "empty service proto matches any", want: 8080, proto: corev1.ProtocolTCP, found: true},
+		{name: "no such port", want: 9999, proto: corev1.ProtocolTCP, found: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchServicePort(ports, tt.want, tt.proto)
+			if tt.found {
+				require.NotNil(t, got)
+				require.Equal(t, int32(tt.want), got.Port)
+			} else {
+				require.Nil(t, got)
+			}
+		})
+	}
+}
+
+func Test_matchEndpointSlicePort(t *testing.T) {
+	tcp := corev1.ProtocolTCP
+	tests := []struct {
+		name    string
+		ports   []discoveryv1.EndpointPort
+		svcPort corev1.ServicePort
+		want    *int32
+	}{
+		{
+			name: "name match preferred",
+			ports: []discoveryv1.EndpointPort{
+				{Name: ptr.To("http"), Protocol: &tcp, Port: ptr.To(int32(8080))},
+				{Name: ptr.To("other"), Protocol: &tcp, Port: ptr.To(int32(9090))},
+			},
+			svcPort: corev1.ServicePort{Name: "http", Protocol: tcp, TargetPort: intstr.FromInt(1)},
+			want:    ptr.To(int32(8080)),
+		},
+		{
+			name: "numeric targetPort fallback",
+			ports: []discoveryv1.EndpointPort{
+				{Name: ptr.To(""), Protocol: &tcp, Port: ptr.To(int32(8080))},
+			},
+			svcPort: corev1.ServicePort{Protocol: tcp, TargetPort: intstr.FromInt(8080)},
+			want:    ptr.To(int32(8080)),
+		},
+		{
+			name: "single port no match uses first",
+			ports: []discoveryv1.EndpointPort{
+				{Name: ptr.To("mismatch"), Protocol: &tcp, Port: ptr.To(int32(7070))},
+			},
+			svcPort: corev1.ServicePort{Name: "http", Protocol: tcp, TargetPort: intstr.FromString("named")},
+			want:    ptr.To(int32(7070)),
+		},
+		{
+			name: "no match returns nil",
+			ports: []discoveryv1.EndpointPort{
+				{Name: ptr.To("a"), Protocol: &tcp, Port: ptr.To(int32(1))},
+				{Name: ptr.To("b"), Protocol: &tcp, Port: ptr.To(int32(2))},
+			},
+			svcPort: corev1.ServicePort{Name: "http", Protocol: tcp, TargetPort: intstr.FromString("named")},
+			want:    nil,
+		},
+		{
+			// proto mismatch skips the port; with >1 port the single-port
+			// fallback does not kick in, so the result is nil.
+			name: "proto mismatch skips port",
+			ports: []discoveryv1.EndpointPort{
+				{Name: ptr.To("http"), Protocol: ptr.To(corev1.ProtocolUDP), Port: ptr.To(int32(8080))},
+				{Name: ptr.To("extra"), Protocol: ptr.To(corev1.ProtocolUDP), Port: ptr.To(int32(9090))},
+			},
+			svcPort: corev1.ServicePort{Name: "http", Protocol: tcp, TargetPort: intstr.FromInt(8080)},
+			want:    nil,
+		},
+		{
+			// single-port fallback returns the only port even on proto mismatch.
+			name: "single port fallback ignores proto",
+			ports: []discoveryv1.EndpointPort{
+				{Name: ptr.To("http"), Protocol: ptr.To(corev1.ProtocolUDP), Port: ptr.To(int32(8080))},
+			},
+			svcPort: corev1.ServicePort{Name: "nomatch", Protocol: tcp, TargetPort: intstr.FromString("named")},
+			want:    ptr.To(int32(8080)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchEndpointSlicePort(tt.ports, tt.svcPort)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_portProtocol(t *testing.T) {
+	require.Equal(t, corev1.ProtocolTCP, portProtocol(nil))
+	require.Equal(t, corev1.ProtocolTCP, portProtocol([]discoveryv1.EndpointPort{{}}))
+	require.Equal(t, corev1.ProtocolUDP, portProtocol([]discoveryv1.EndpointPort{
+		{Protocol: ptr.To(corev1.ProtocolUDP)},
+	}))
+}

--- a/operator/pkg/gateway-api/gamma_reconcile.go
+++ b/operator/pkg/gateway-api/gamma_reconcile.go
@@ -137,7 +137,7 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	setGammaServiceAccepted(svc, true, "Gamma Service has routes attached", CiliumGammaReasonAccepted)
 
-	cec, _, cep, err := r.translator.Translate(&model.Model{HTTP: httpListeners})
+	cec, _, ceps, err := r.translator.Translate(&model.Model{HTTP: httpListeners})
 	if err != nil {
 		scopedLog.ErrorContext(ctx, "Unable to translate resources", logfields.Error, err)
 		return r.handleReconcileErrorWithStatus(ctx, err, originalSvc, svc)
@@ -148,9 +148,13 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return r.handleReconcileErrorWithStatus(ctx, err, originalSvc, svc)
 	}
 
-	if err = r.ensureEndpointSlice(ctx, cep); err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to ensure Endpoints", logfields.Error, err)
-		return r.handleReconcileErrorWithStatus(ctx, err, originalSvc, svc)
+	// GAMMA only ever produces a single dummy EndpointSlice; unwrap from the
+	// shared Translator interface that returns a list to support gateway-api L4.
+	if len(ceps) > 0 {
+		if err = r.ensureEndpointSlice(ctx, ceps[0]); err != nil {
+			scopedLog.ErrorContext(ctx, "Unable to ensure Endpoints", logfields.Error, err)
+			return r.handleReconcileErrorWithStatus(ctx, err, originalSvc, svc)
+		}
 	}
 
 	setGammaServiceProgrammed(svc, true, "Gamma Service has been programmed", CiliumGammaReasonProgrammed)

--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -11,12 +11,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
@@ -31,6 +31,7 @@ import (
 const (
 	// Deprecated: owningGatewayLabel will be removed later in favour of gatewayNameLabel
 	owningGatewayLabel = "io.cilium.gateway/owning-gateway"
+	gatewayNameLabel   = "gateway.networking.k8s.io/gateway-name"
 
 	lastTransitionTime = "LastTransitionTime"
 )
@@ -42,11 +43,10 @@ type gatewayReconciler struct {
 	translator translation.Translator
 
 	logger         *slog.Logger
-	installedCRDs  []schema.GroupVersionKind
 	controllerName string
 }
 
-func newGatewayReconciler(mgr ctrl.Manager, translator translation.Translator, logger *slog.Logger, controllerName string, installedCRDs []schema.GroupVersionKind) *gatewayReconciler {
+func newGatewayReconciler(mgr ctrl.Manager, translator translation.Translator, logger *slog.Logger, controllerName string) *gatewayReconciler {
 	scopedLog := logger.With(logfields.Controller, gateway)
 
 	return &gatewayReconciler{
@@ -54,7 +54,6 @@ func newGatewayReconciler(mgr ctrl.Manager, translator translation.Translator, l
 		Scheme:         mgr.GetScheme(),
 		translator:     translator,
 		logger:         scopedLog,
-		installedCRDs:  installedCRDs,
 		controllerName: controllerName,
 	}
 }
@@ -62,15 +61,12 @@ func newGatewayReconciler(mgr ctrl.Manager, translator translation.Translator, l
 // SetupWithManager sets up the controller with the Manager.
 // The reconciler will be triggered by Gateway, or any cilium-managed GatewayClass events
 func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// Determine which optional CRDs are enabled
-	var serviceImportEnabled bool
-
-	for _, gvk := range r.installedCRDs {
-		switch gvk.Kind {
-		case helpers.ServiceImportKind:
-			serviceImportEnabled = true
-		}
-	}
+	// Determine which optional CRDs are enabled. The scheme is registered from
+	// the autodetected CRDs, so Recognizes() reflects what is installed.
+	scheme := r.Client.Scheme()
+	tcpRouteEnabled := helpers.HasTCPRouteSupport(scheme)
+	udpRouteEnabled := helpers.HasUDPRouteSupport(scheme)
+	serviceImportEnabled := helpers.HasServiceImportSupport(scheme)
 
 	// Add field indexes for HTTPRoutes
 	for indexName, indexerFunc := range map[string]client.IndexerFunc{
@@ -101,6 +97,30 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	} {
 		if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.TLSRoute{}, indexName, indexerFunc); err != nil {
 			return fmt.Errorf("failed to setup field indexer %q: %w", indexName, err)
+		}
+	}
+
+	// Add indexes for TCPRoutes
+	if tcpRouteEnabled {
+		for indexName, indexerFunc := range map[string]client.IndexerFunc{
+			indexers.BackendServiceTCPRouteIndex: indexers.GenerateIndexerTCPRoutebyBackendService(r.Client, r.logger),
+			indexers.GatewayTCPRouteIndex:        indexers.IndexTCPRouteByGateway,
+		} {
+			if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1alpha2.TCPRoute{}, indexName, indexerFunc); err != nil {
+				return fmt.Errorf("failed to setup field indexer %q: %w", indexName, err)
+			}
+		}
+	}
+
+	// Add indexes for UDPRoutes
+	if udpRouteEnabled {
+		for indexName, indexerFunc := range map[string]client.IndexerFunc{
+			indexers.BackendServiceUDPRouteIndex: indexers.GenerateIndexerUDPRoutebyBackendService(r.Client, r.logger),
+			indexers.GatewayUDPRouteIndex:        indexers.IndexUDPRouteByGateway,
+		} {
+			if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1alpha2.UDPRoute{}, indexName, indexerFunc); err != nil {
+				return fmt.Errorf("failed to setup field indexer %q: %w", indexName, err)
+			}
 		}
 	}
 
@@ -153,6 +173,16 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&ciliumv2.CiliumEnvoyConfig{}).
 		Owns(&corev1.Service{}).
 		Owns(&discoveryv1.EndpointSlice{})
+
+	if tcpRouteEnabled {
+		// Watch TCPRoute linked to Gateway
+		gatewayBuilder = gatewayBuilder.Watches(&gatewayv1alpha2.TCPRoute{}, watchhandlers.EnqueueRequestForOwningTCPRoute(r.Client, r.logger, r.controllerName))
+	}
+
+	if udpRouteEnabled {
+		// Watch UDPRoute linked to Gateway
+		gatewayBuilder = gatewayBuilder.Watches(&gatewayv1alpha2.UDPRoute{}, watchhandlers.EnqueueRequestForOwningUDPRoute(r.Client, r.logger, r.controllerName))
+	}
 
 	if serviceImportEnabled {
 		// Watch for changes to Backend Service Imports

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 
 	controllerruntime "github.com/cilium/cilium/operator/pkg/controller-runtime"
@@ -147,6 +148,26 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 	btlspMap := helpers.BuildBackendTLSPolicyLookup(btlspList)
 
+	tcpRouteList := &gatewayv1alpha2.TCPRouteList{}
+	if helpers.HasTCPRouteSupport(r.Client.Scheme()) {
+		if err := r.Client.List(ctx, tcpRouteList, &client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector(indexers.GatewayTCPRouteIndex, client.ObjectKeyFromObject(original).String()),
+		}); err != nil {
+			scopedLog.ErrorContext(ctx, "Unable to list TCPRoutes", logfields.Error, err)
+			return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+		}
+	}
+
+	udpRouteList := &gatewayv1alpha2.UDPRouteList{}
+	if helpers.HasUDPRouteSupport(r.Client.Scheme()) {
+		if err := r.Client.List(ctx, udpRouteList, &client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector(indexers.GatewayUDPRouteIndex, client.ObjectKeyFromObject(original).String()),
+		}); err != nil {
+			scopedLog.ErrorContext(ctx, "Unable to list UDPRoutes", logfields.Error, err)
+			return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+		}
+	}
+
 	var namespaces []corev1.Namespace
 	if hasAllowedRoutesNamespaceSelector(gw) {
 		namespaceList := &corev1.NamespaceList{}
@@ -198,6 +219,22 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 	}
 
+	// Run the TCPRoute route checks here and update the status accordingly.
+	if helpers.HasTCPRouteSupport(r.Client.Scheme()) {
+		if err := r.setTCPRouteStatuses(scopedLog, ctx, tcpRouteList, grants); err != nil {
+			scopedLog.ErrorContext(ctx, "Unable to update TCPRoute Status", logfields.Error, err)
+			return controllerruntime.Fail(err)
+		}
+	}
+
+	// Run the UDPRoute route checks here and update the status accordingly.
+	if helpers.HasUDPRouteSupport(r.Client.Scheme()) {
+		if err := r.setUDPRouteStatuses(scopedLog, ctx, udpRouteList, grants); err != nil {
+			scopedLog.ErrorContext(ctx, "Unable to update UDPRoute Status", logfields.Error, err)
+			return controllerruntime.Fail(err)
+		}
+	}
+
 	// Run the GRPCRoute route checks here and update the status accordingly.
 	if err := r.setGRPCRouteStatuses(scopedLog, ctx, grpcRouteList, grants); err != nil {
 		scopedLog.ErrorContext(ctx, "Unable to update GRPCRoute Status", logfields.Error, err)
@@ -207,6 +244,8 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	httpRoutes := r.filterHTTPRoutesByGateway(ctx, gw, httpRouteList.Items, namespaceLabels)
 	tlsRoutes := r.filterTLSRoutesByGateway(ctx, gw, tlsRouteList.Items, namespaceLabels)
 	grpcRoutes := r.filterGRPCRoutesByGateway(ctx, gw, grpcRouteList.Items, namespaceLabels)
+	tcpRoutes := r.filterTCPRoutesByGateway(ctx, gw, tcpRouteList.Items, namespaceLabels)
+	udpRoutes := r.filterUDPRoutesByGateway(ctx, gw, udpRouteList.Items, namespaceLabels)
 
 	if err := r.setBackendTLSPolicyStatuses(scopedLog, ctx, httpRoutes, btlspMap, req.NamespacedName); err != nil {
 		scopedLog.ErrorContext(ctx, "Unable to update BackendTLSPolicy Status", logfields.Error, err)
@@ -220,6 +259,8 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		HTTPRoutes:          httpRoutes,
 		TLSRoutes:           tlsRoutes,
 		GRPCRoutes:          grpcRoutes,
+		TCPRoutes:           tcpRoutes,
+		UDPRoutes:           udpRoutes,
 		Namespaces:          namespaces,
 		Services:            servicesList.Items,
 		ServiceImports:      serviceImportsList.Items,
@@ -227,7 +268,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		BackendTLSPolicyMap: btlspMap,
 	})
 
-	validListener, err := r.setListenerStatus(ctx, gw, httpRouteList, tlsRouteList, grpcRouteList, namespaceLabels)
+	validListener, err := r.setListenerStatus(ctx, gw, httpRouteList, tlsRouteList, grpcRouteList, tcpRouteList, udpRouteList, namespaceLabels)
 	if err != nil {
 		scopedLog.ErrorContext(ctx, "Unable to set listener status", logfields.Error, err)
 		setGatewayAccepted(gw, false, "Unable to set listener status", gatewayv1.GatewayReasonNoResources)
@@ -244,7 +285,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	setGatewayAccepted(gw, true, "Gateway successfully scheduled", gatewayv1.GatewayReasonAccepted)
 
 	// Step 3: Translate the listeners into Cilium model
-	cec, svc, ep, err := r.translator.Translate(m)
+	cec, svc, eps, err := r.translator.Translate(m)
 	if err != nil {
 		scopedLog.ErrorContext(ctx, "Unable to translate resources", logfields.Error, err)
 		setGatewayAccepted(gw, false, "Unable to translate resources", gatewayv1.GatewayReasonNoResources)
@@ -264,14 +305,14 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
 
-	if err = r.ensureEndpointSlice(ctx, ep); err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to ensure Endpoints", logfields.Error, err)
-		setGatewayAccepted(gw, false, "Unable to ensure Endpoints resource", gatewayv1.GatewayReasonNoResources)
-		setGatewayProgrammed(gw, metav1.ConditionFalse, "Unable to create Endpoints resource", gatewayv1.GatewayReasonNoResources)
+	if err = r.reconcileEndpointSlices(ctx, gw, svc, eps); err != nil {
+		scopedLog.ErrorContext(ctx, "Unable to reconcile EndpointSlices", logfields.Error, err)
+		setGatewayAccepted(gw, false, "Unable to reconcile EndpointSlices", gatewayv1.GatewayReasonNoResources)
+		setGatewayProgrammed(gw, metav1.ConditionFalse, "Unable to reconcile EndpointSlices", gatewayv1.GatewayReasonNoResources)
 		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
 
-	if err = r.ensureEnvoyConfig(ctx, cec); err != nil {
+	if err = r.ensureEnvoyConfig(ctx, gw, cec); err != nil {
 		scopedLog.ErrorContext(ctx, "Unable to ensure CiliumEnvoyConfig", logfields.Error, err)
 		setGatewayAccepted(gw, false, "Unable to ensure CEC resource", gatewayv1.GatewayReasonNoResources)
 		setGatewayProgrammed(gw, metav1.ConditionFalse, "Unable to create CEC resource", gatewayv1.GatewayReasonNoResources)
@@ -333,11 +374,25 @@ func (r *gatewayReconciler) ensureService(ctx context.Context, desired *corev1.S
 	return err
 }
 
+// ensureEndpointSlice creates or updates a managed frontend EndpointSlice.
+// Endpoints and the numeric Ports[0].Port are owned by endpointSliceReconciler
+// once it has populated Endpoints; this avoids a write-fight between the two.
 func (r *gatewayReconciler) ensureEndpointSlice(ctx context.Context, desired *discoveryv1.EndpointSlice) error {
-	eps := desired.DeepCopy()
+	eps := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      desired.Name,
+			Namespace: desired.Namespace,
+		},
+	}
 	_, err := controllerutil.CreateOrPatch(ctx, r.Client, eps, func() error {
-		eps.Endpoints = desired.Endpoints
-		eps.Ports = desired.Ports
+		if eps.ResourceVersion == "" {
+			eps.AddressType = desired.AddressType
+			eps.Endpoints = desired.Endpoints
+			eps.Ports = desired.Ports
+		} else {
+			resolved := len(eps.Endpoints) > 0
+			eps.Ports = mergeEndpointPorts(eps.Ports, desired.Ports, resolved)
+		}
 		eps.OwnerReferences = desired.OwnerReferences
 		setMergedLabelsAndAnnotations(eps, desired)
 		return nil
@@ -345,7 +400,30 @@ func (r *gatewayReconciler) ensureEndpointSlice(ctx context.Context, desired *di
 	return err
 }
 
-func (r *gatewayReconciler) ensureEnvoyConfig(ctx context.Context, desired *ciliumv2.CiliumEnvoyConfig) error {
+// mergeEndpointPorts takes Name and Protocol from desired; the numeric Port
+// is kept from existing when preservePort is true (owned by
+// endpointSliceReconciler), otherwise taken from desired.
+func mergeEndpointPorts(existing, desired []discoveryv1.EndpointPort, preservePort bool) []discoveryv1.EndpointPort {
+	if len(existing) != len(desired) {
+		return desired
+	}
+	out := make([]discoveryv1.EndpointPort, len(desired))
+	for i := range desired {
+		out[i] = desired[i]
+		if preservePort && existing[i].Port != nil {
+			out[i].Port = existing[i].Port
+		}
+	}
+	return out
+}
+
+func (r *gatewayReconciler) ensureEnvoyConfig(ctx context.Context, gw *gatewayv1.Gateway, desired *ciliumv2.CiliumEnvoyConfig) error {
+	if desired == nil {
+		// No Envoy config is needed (e.g. the Gateway only has L4 TCP/UDP
+		// Routes attached). Delete any CiliumEnvoyConfig left over from a
+		// previous state where HTTP/TLS listeners were configured.
+		return r.ensureOwnedEnvoyConfigDeleted(ctx, gw)
+	}
 	cec := desired.DeepCopy()
 	_, err := controllerutil.CreateOrPatch(ctx, r.Client, cec, func() error {
 		cec.Spec = desired.Spec
@@ -355,8 +433,109 @@ func (r *gatewayReconciler) ensureEnvoyConfig(ctx context.Context, desired *cili
 	return err
 }
 
+// reconcileEndpointSlices applies the desired EndpointSlices and deletes
+// stale ones owned by the Gateway. Endpoints are populated later by
+// endpointSliceReconciler from the backend Service's own EndpointSlices.
+func (r *gatewayReconciler) reconcileEndpointSlices(ctx context.Context, gw *gatewayv1.Gateway, svc *corev1.Service, desired []*discoveryv1.EndpointSlice) error {
+	desired = r.filterEndpointSlicesByBackendFamilies(ctx, desired)
+
+	desiredByName := make(map[string]*discoveryv1.EndpointSlice, len(desired))
+	for _, d := range desired {
+		desiredByName[d.Name] = d
+		if err := r.ensureEndpointSlice(ctx, d); err != nil {
+			return err
+		}
+	}
+
+	if svc == nil {
+		return nil
+	}
+
+	existing := &discoveryv1.EndpointSliceList{}
+	if err := r.Client.List(ctx, existing,
+		client.InNamespace(gw.Namespace),
+		client.MatchingLabels{
+			gatewayApiTranslation.EndpointSliceServiceNameLabel: svc.Name,
+			gatewayApiTranslation.EndpointSliceManagedByLabel:   gatewayApiTranslation.EndpointSliceManagedByValue,
+		},
+	); err != nil {
+		return fmt.Errorf("failed to list managed EndpointSlices: %w", err)
+	}
+
+	for i := range existing.Items {
+		eps := existing.Items[i]
+		if !metav1.IsControlledBy(&eps, gw) {
+			continue
+		}
+		if _, ok := desiredByName[eps.Name]; ok {
+			continue
+		}
+		if err := client.IgnoreNotFound(r.Client.Delete(ctx, &eps)); err != nil {
+			return fmt.Errorf("failed to delete stale EndpointSlice %s/%s: %w", eps.Namespace, eps.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// filterEndpointSlicesByBackendFamilies drops slices whose AddressType is not
+// in the referenced backend Service's IPFamilies, mirroring how
+// kube-controller-manager only emits slices for supported families. Slices
+// are kept when the backend Service is missing or its IPFamilies is unset so
+// the next reconcile can correct them.
+func (r *gatewayReconciler) filterEndpointSlicesByBackendFamilies(ctx context.Context, desired []*discoveryv1.EndpointSlice) []*discoveryv1.EndpointSlice {
+	type backendKey struct{ ns, name string }
+	cache := map[backendKey]map[corev1.IPFamily]struct{}{}
+
+	out := make([]*discoveryv1.EndpointSlice, 0, len(desired))
+	for _, s := range desired {
+		ref := s.Annotations[gatewayApiTranslation.BackendServiceAnnotation]
+		ns, name, ok := strings.Cut(ref, "/")
+		if !ok || ns == "" || name == "" {
+			out = append(out, s)
+			continue
+		}
+		key := backendKey{ns, name}
+		fams, cached := cache[key]
+		if !cached {
+			be := &corev1.Service{}
+			if err := r.Client.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, be); err != nil {
+				cache[key] = nil
+				out = append(out, s)
+				continue
+			}
+			fams = make(map[corev1.IPFamily]struct{}, len(be.Spec.IPFamilies))
+			for _, f := range be.Spec.IPFamilies {
+				fams[f] = struct{}{}
+			}
+			cache[key] = fams
+		}
+		if len(fams) == 0 {
+			out = append(out, s)
+			continue
+		}
+		var want corev1.IPFamily
+		switch s.AddressType {
+		case discoveryv1.AddressTypeIPv4:
+			want = corev1.IPv4Protocol
+		case discoveryv1.AddressTypeIPv6:
+			want = corev1.IPv6Protocol
+		default:
+			out = append(out, s)
+			continue
+		}
+		if _, ok := fams[want]; ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
 func (r *gatewayReconciler) cleanupOwnedResources(ctx context.Context, gw *gatewayv1.Gateway) error {
 	if err := r.ensureOwnedServiceDeleted(ctx, gw); err != nil {
+		return err
+	}
+	if err := r.ensureOwnedEndpointSlicesDeleted(ctx, gw); err != nil {
 		return err
 	}
 	if err := r.ensureOwnedEnvoyConfigDeleted(ctx, gw); err != nil {
@@ -380,6 +559,30 @@ func (r *gatewayReconciler) ensureOwnedServiceDeleted(ctx context.Context, gw *g
 	}
 
 	return client.IgnoreNotFound(r.Client.Delete(ctx, svc))
+}
+
+func (r *gatewayReconciler) ensureOwnedEndpointSlicesDeleted(ctx context.Context, gw *gatewayv1.Gateway) error {
+	eps := &discoveryv1.EndpointSliceList{}
+	matchingLabels := client.MatchingLabels{
+		gatewayApiTranslation.EndpointSliceServiceNameLabel: shortener.ShortenK8sResourceName(
+			gatewayApiTranslation.CiliumGatewayPrefix + gw.Name,
+		),
+	}
+
+	if err := r.Client.List(ctx, eps, client.InNamespace(gw.Namespace), matchingLabels); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+
+	for _, ep := range eps.Items {
+		if !metav1.IsControlledBy(&ep, gw) {
+			continue
+		}
+		if err := client.IgnoreNotFound(r.Client.Delete(ctx, &ep)); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (r *gatewayReconciler) ensureOwnedEnvoyConfigDeleted(ctx context.Context, gw *gatewayv1.Gateway) error {
@@ -509,12 +712,56 @@ func (r *gatewayReconciler) filterTLSRoutesByGateway(ctx context.Context, gw *ga
 	return filtered
 }
 
+func (r *gatewayReconciler) filterTCPRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, routes []gatewayv1alpha2.TCPRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1alpha2.TCPRoute {
+	var filtered []gatewayv1alpha2.TCPRoute
+	for _, route := range routes {
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(gw, &route, namespaceLabels) {
+			filtered = append(filtered, route)
+		}
+	}
+	return filtered
+}
+
+func (r *gatewayReconciler) filterUDPRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, routes []gatewayv1alpha2.UDPRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1alpha2.UDPRoute {
+	var filtered []gatewayv1alpha2.UDPRoute
+	for _, route := range routes {
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(gw, &route, namespaceLabels) {
+			filtered = append(filtered, route)
+		}
+	}
+	return filtered
+}
+
 func (r *gatewayReconciler) filterTLSRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1.TLSRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1.TLSRoute {
 	var filtered []gatewayv1.TLSRoute
 	for _, route := range routes {
 		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) &&
 			listenerisAllowed(gw, listener, &route, namespaceLabels) &&
 			len(computeHostsForListener(listener, route.Spec.Hostnames, nil)) > 0 &&
+			parentRefMatched(gw, listener, route.GetNamespace(), route.Spec.ParentRefs) {
+			filtered = append(filtered, route)
+		}
+	}
+	return filtered
+}
+
+func (r *gatewayReconciler) filterTCPRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1alpha2.TCPRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1alpha2.TCPRoute {
+	var filtered []gatewayv1alpha2.TCPRoute
+	for _, route := range routes {
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) &&
+			listenerisAllowed(gw, listener, &route, namespaceLabels) &&
+			parentRefMatched(gw, listener, route.GetNamespace(), route.Spec.ParentRefs) {
+			filtered = append(filtered, route)
+		}
+	}
+	return filtered
+}
+
+func (r *gatewayReconciler) filterUDPRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1alpha2.UDPRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1alpha2.UDPRoute {
+	var filtered []gatewayv1alpha2.UDPRoute
+	for _, route := range routes {
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) &&
+			listenerisAllowed(gw, listener, &route, namespaceLabels) &&
 			parentRefMatched(gw, listener, route.GetNamespace(), route.Spec.ParentRefs) {
 			filtered = append(filtered, route)
 		}
@@ -623,7 +870,7 @@ func (r *gatewayReconciler) setStaticAddressStatus(ctx context.Context, gw *gate
 	return nil
 }
 
-func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1.Gateway, httpRoutes *gatewayv1.HTTPRouteList, tlsRoutes *gatewayv1.TLSRouteList, grpcRoutes *gatewayv1.GRPCRouteList, namespaceLabels helpers.NamespaceLabelIndex) (bool, error) {
+func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1.Gateway, httpRoutes *gatewayv1.HTTPRouteList, tlsRoutes *gatewayv1.TLSRouteList, grpcRoutes *gatewayv1.GRPCRouteList, tcpRoutes *gatewayv1alpha2.TCPRouteList, udpRoutes *gatewayv1alpha2.UDPRouteList, namespaceLabels helpers.NamespaceLabelIndex) (bool, error) {
 	grants := &gatewayv1.ReferenceGrantList{}
 	if err := r.Client.List(ctx, grants); err != nil {
 		return false, fmt.Errorf("failed to retrieve reference grants: %w", err)
@@ -759,6 +1006,8 @@ func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1
 		attachedRoutes += int32(len(r.filterHTTPRoutesByListener(ctx, gw, &l, httpRoutes.Items, namespaceLabels)))
 		attachedRoutes += int32(len(r.filterGRPCRoutesByListener(ctx, gw, &l, grpcRoutes.Items, namespaceLabels)))
 		attachedRoutes += int32(len(r.filterTLSRoutesByListener(ctx, gw, &l, tlsRoutes.Items, namespaceLabels)))
+		attachedRoutes += int32(len(r.filterTCPRoutesByListener(ctx, gw, &l, tcpRoutes.Items, namespaceLabels)))
+		attachedRoutes += int32(len(r.filterUDPRoutesByListener(ctx, gw, &l, udpRoutes.Items, namespaceLabels)))
 
 		found := false
 		for i := range gw.Status.Listeners {
@@ -1349,6 +1598,68 @@ func (r *gatewayReconciler) setBackendTLSPolicyStatuses(scopedLog *slog.Logger,
 	return nil
 }
 
+func (r *gatewayReconciler) setTCPRouteStatuses(scopedLog *slog.Logger, ctx context.Context, tcpRoutes *gatewayv1alpha2.TCPRouteList, grants *gatewayv1.ReferenceGrantList) error {
+	scopedLog.Debug("Updating TCPRoute statuses for Gateway", numRoutes, len(tcpRoutes.Items))
+	for tcpRouteIndex, original := range tcpRoutes.Items {
+
+		tcpr := original.DeepCopy()
+
+		i := &routechecks.TCPRouteInput{
+			Ctx:            ctx,
+			Logger:         scopedLog.With(logfields.TCPRoute, tcpr),
+			Client:         r.Client,
+			Grants:         grants,
+			TCPRoute:       tcpr,
+			ControllerName: r.controllerName,
+		}
+
+		if err := r.runCommonRouteChecks(i, tcpr.Spec.ParentRefs, tcpr.Namespace); err != nil {
+			return r.handleTCPRouteReconcileErrorWithStatus(ctx, scopedLog, err, &original, tcpr)
+		}
+
+		// TODO: warn in TCPRoute when conditions for weight are not met.
+
+		if err := r.updateTCPRouteStatus(ctx, scopedLog, &original, tcpr); err != nil {
+			return fmt.Errorf("failed to update TCPRoute status: %w", err)
+		}
+
+		tcpRoutes.Items[tcpRouteIndex].Status = tcpr.Status
+	}
+
+	return nil
+}
+
+func (r *gatewayReconciler) setUDPRouteStatuses(scopedLog *slog.Logger, ctx context.Context, udpRoutes *gatewayv1alpha2.UDPRouteList, grants *gatewayv1.ReferenceGrantList) error {
+	scopedLog.Debug("Updating UDPRoute statuses for Gateway", numRoutes, len(udpRoutes.Items))
+	for udpRouteIndex, original := range udpRoutes.Items {
+
+		udpr := original.DeepCopy()
+
+		i := &routechecks.UDPRouteInput{
+			Ctx:            ctx,
+			Logger:         scopedLog.With(logfields.UDPRoute, udpr),
+			Client:         r.Client,
+			Grants:         grants,
+			UDPRoute:       udpr,
+			ControllerName: r.controllerName,
+		}
+
+		if err := r.runCommonRouteChecks(i, udpr.Spec.ParentRefs, udpr.Namespace); err != nil {
+			return r.handleUDPRouteReconcileErrorWithStatus(ctx, scopedLog, err, &original, udpr)
+		}
+
+		// TODO: warn in UDPRoute when conditions for weight are not met.
+
+		if err := r.updateUDPRouteStatus(ctx, scopedLog, &original, udpr); err != nil {
+			return fmt.Errorf("failed to update UDPRoute status: %w", err)
+		}
+
+		udpRoutes.Items[udpRouteIndex].Status = udpr.Status
+	}
+
+	return nil
+}
+
 func (r *gatewayReconciler) handleHTTPRouteReconcileErrorWithStatus(ctx context.Context, scopedLog *slog.Logger, reconcileErr error, original *gatewayv1.HTTPRoute, modified *gatewayv1.HTTPRoute) error {
 	if err := r.updateHTTPRouteStatus(ctx, scopedLog, original, modified); err != nil {
 		return fmt.Errorf("failed to update Gateway status while handling the reconcile error: %w: %w", reconcileErr, err)
@@ -1374,6 +1685,20 @@ func (r *gatewayReconciler) handleTLSRouteReconcileErrorWithStatus(ctx context.C
 	return nil
 }
 
+func (r *gatewayReconciler) handleTCPRouteReconcileErrorWithStatus(ctx context.Context, scopedLog *slog.Logger, reconcileErr error, original *gatewayv1alpha2.TCPRoute, modified *gatewayv1alpha2.TCPRoute) error {
+	if err := r.updateTCPRouteStatus(ctx, scopedLog, original, modified); err != nil {
+		return fmt.Errorf("failed to update Gateway status while handling the reconcile error: %w: %w", reconcileErr, err)
+	}
+	return nil
+}
+
+func (r *gatewayReconciler) handleUDPRouteReconcileErrorWithStatus(ctx context.Context, scopedLog *slog.Logger, reconcileErr error, original *gatewayv1alpha2.UDPRoute, modified *gatewayv1alpha2.UDPRoute) error {
+	if err := r.updateUDPRouteStatus(ctx, scopedLog, original, modified); err != nil {
+		return fmt.Errorf("failed to update Gateway status while handling the reconcile error: %w: %w", reconcileErr, err)
+	}
+	return nil
+}
+
 func (r *gatewayReconciler) updateTLSRouteStatus(ctx context.Context, scopedLog *slog.Logger, original *gatewayv1.TLSRoute, new *gatewayv1.TLSRoute) error {
 	oldStatus := original.Status.DeepCopy()
 	newStatus := new.Status.DeepCopy()
@@ -1382,6 +1707,28 @@ func (r *gatewayReconciler) updateTLSRouteStatus(ctx context.Context, scopedLog 
 		return nil
 	}
 	scopedLog.Debug("Updating TLSRoute status", tlsRoute, types.NamespacedName{Name: original.Name, Namespace: original.Namespace})
+	return r.Client.Status().Update(ctx, new)
+}
+
+func (r *gatewayReconciler) updateTCPRouteStatus(ctx context.Context, scopedLog *slog.Logger, original *gatewayv1alpha2.TCPRoute, new *gatewayv1alpha2.TCPRoute) error {
+	oldStatus := original.Status.DeepCopy()
+	newStatus := new.Status.DeepCopy()
+
+	if cmp.Equal(oldStatus, newStatus, cmpopts.IgnoreFields(metav1.Condition{}, lastTransitionTime)) {
+		return nil
+	}
+	scopedLog.Debug("Updating TCPRoute status", tcpRoute, types.NamespacedName{Name: original.Name, Namespace: original.Namespace})
+	return r.Client.Status().Update(ctx, new)
+}
+
+func (r *gatewayReconciler) updateUDPRouteStatus(ctx context.Context, scopedLog *slog.Logger, original *gatewayv1alpha2.UDPRoute, new *gatewayv1alpha2.UDPRoute) error {
+	oldStatus := original.Status.DeepCopy()
+	newStatus := new.Status.DeepCopy()
+
+	if cmp.Equal(oldStatus, newStatus, cmpopts.IgnoreFields(metav1.Condition{}, lastTransitionTime)) {
+		return nil
+	}
+	scopedLog.Debug("Updating UDPRoute status", udpRoute, types.NamespacedName{Name: original.Name, Namespace: original.Namespace})
 	return r.Client.Status().Update(ctx, new)
 }
 

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -14,13 +14,16 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
@@ -32,8 +35,9 @@ import (
 )
 
 var (
-	gatewayv1APIVersion = gatewayv1.GroupVersion.Group + "/" + gatewayv1.GroupVersion.Version
-	gatewayTypeMeta     = metav1.TypeMeta{
+	gatewayv1APIVersion       = gatewayv1.GroupVersion.Group + "/" + gatewayv1.GroupVersion.Version
+	gatewayv1alpha2APIVersion = gatewayv1alpha2.GroupVersion.Group + "/" + gatewayv1alpha2.GroupVersion.Version
+	gatewayTypeMeta           = metav1.TypeMeta{
 		Kind:       "Gateway",
 		APIVersion: gatewayv1APIVersion,
 	}
@@ -52,6 +56,18 @@ var (
 	backendTLSPolicyTypeMeta = metav1.TypeMeta{
 		Kind:       "BackendTLSPolicy",
 		APIVersion: gatewayv1APIVersion,
+	}
+	tcpRouteTypeMeta = metav1.TypeMeta{
+		Kind:       "TCPRoute",
+		APIVersion: gatewayv1alpha2APIVersion,
+	}
+	udpRouteTypeMeta = metav1.TypeMeta{
+		Kind:       "UDPRoute",
+		APIVersion: gatewayv1alpha2APIVersion,
+	}
+	endpointSliceTypeMeta = metav1.TypeMeta{
+		Kind:       "EndpointSlice",
+		APIVersion: discoveryv1.SchemeGroupVersion.String(),
 	}
 )
 
@@ -84,6 +100,7 @@ func Test_Conformance(t *testing.T) {
 	type gwDetails struct {
 		FullName types.NamespacedName
 		wantErr  bool
+		skipCEC  bool
 	}
 
 	var (
@@ -96,6 +113,8 @@ func Test_Conformance(t *testing.T) {
 		name                 string
 		gateway              []gwDetails
 		disableServiceImport bool
+		disableTCPRoute      bool
+		disableUDPRoute      bool
 		wantErr              bool
 	}{
 		{
@@ -281,6 +300,17 @@ func Test_Conformance(t *testing.T) {
 		{name: "httproute-backendtlspolicy-invalid-ca-cert", gateway: []gwDetails{gatewaySameNamespace}},
 		{name: "httproute-backendtlspolicy-invalid-kind", gateway: []gwDetails{gatewaySameNamespace}},
 		{name: "gateway-multi-port-https", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "multi-port-https", Namespace: "gateway-conformance-infra"}}}},
+		{name: "tcproute-invalid-reference-grant", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "gateway-tcproute-referencegrant", Namespace: "gateway-conformance-infra"}, skipCEC: true}}},
+		{name: "tcproute-simple-same-namespace", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "gateway-tcproute", Namespace: "gateway-conformance-infra"}, skipCEC: true}}},
+		{name: "udproute-invalid-reference-grant", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "gateway-udproute-referencegrant", Namespace: "gateway-conformance-infra"}, skipCEC: true}}},
+		{name: "udproute-simple-same-namespace", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "gateway-udproute", Namespace: "gateway-conformance-infra"}, skipCEC: true}}},
+		// A single Gateway mixing an L7 (HTTP) and an L4 (TCP) listener: the
+		// L7 path produces a CiliumEnvoyConfig while the L4 path produces a
+		// managed EndpointSlice for the TCP backend (no dummy slice is added
+		// because a real L4 slice already exists).
+		{name: "gateway-mixed-http-tcp", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "gateway-mixed", Namespace: "gateway-conformance-infra"}}}},
+		{name: "tcproute-crd-not-installed", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "gateway-tcproute", Namespace: "gateway-conformance-infra"}, skipCEC: true}}, disableTCPRoute: true},
+		{name: "udproute-crd-not-installed", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "gateway-udproute", Namespace: "gateway-conformance-infra"}, skipCEC: true}}, disableUDPRoute: true},
 		{name: "tlsroute-invalid-reference-grant", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "gateway-tlsroute-referencegrant", Namespace: "gateway-conformance-infra"}}}},
 		{name: "tlsroute-simple-same-namespace", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "gateway-tlsroute", Namespace: "gateway-conformance-infra"}}}},
 		{name: "tlsroute-hostname-intersection", gateway: []gwDetails{
@@ -320,17 +350,35 @@ func Test_Conformance(t *testing.T) {
 				WithStatusSubresource(&gatewayv1.GatewayClass{}).
 				WithStatusSubresource(&gatewayv1.BackendTLSPolicy{})
 
-			if tt.disableServiceImport {
-				clientBuilder.WithScheme(helpers.TestScheme(nil))
-			} else {
-				clientBuilder.WithScheme(helpers.TestScheme(helpers.AllOptionalKinds))
+			disabledKinds := map[string]bool{
+				helpers.ServiceImportKind: tt.disableServiceImport,
+				helpers.TCPRouteKind:      tt.disableTCPRoute,
+				helpers.UDPRouteKind:      tt.disableUDPRoute,
 			}
+			optionalKinds := make([]schema.GroupVersionKind, 0, len(helpers.AllOptionalKinds))
+			for _, k := range helpers.AllOptionalKinds {
+				if disabledKinds[k.Kind] {
+					continue
+				}
+				optionalKinds = append(optionalKinds, k)
+			}
+			clientBuilder.WithScheme(helpers.TestScheme(optionalKinds))
 
 			// Add any required indexes here
 			clientBuilder.WithIndex(&gatewayv1.HTTPRoute{}, indexers.GatewayHTTPRouteIndex, indexers.IndexHTTPRouteByGateway)
 			clientBuilder.WithIndex(&gatewayv1.HTTPRoute{}, indexers.BackendServiceHTTPRouteIndex, fakeIndexHTTPRouteByBackendService)
 			clientBuilder.WithIndex(&gatewayv1.GRPCRoute{}, indexers.GatewayGRPCRouteIndex, indexers.IndexGRPCRouteByGateway)
 			clientBuilder.WithIndex(&gatewayv1.TLSRoute{}, indexers.GatewayTLSRouteIndex, indexers.IndexTLSRouteByGateway)
+			// TCPRoute/UDPRoute types are only registered in the scheme when their
+			// CRDs are installed, so only set their status subresource and index then.
+			if !tt.disableTCPRoute {
+				clientBuilder.WithStatusSubresource(&gatewayv1alpha2.TCPRoute{})
+				clientBuilder.WithIndex(&gatewayv1alpha2.TCPRoute{}, indexers.GatewayTCPRouteIndex, indexers.IndexTCPRouteByGateway)
+			}
+			if !tt.disableUDPRoute {
+				clientBuilder.WithStatusSubresource(&gatewayv1alpha2.UDPRoute{})
+				clientBuilder.WithIndex(&gatewayv1alpha2.UDPRoute{}, indexers.GatewayUDPRouteIndex, indexers.IndexUDPRouteByGateway)
+			}
 
 			c := clientBuilder.Build()
 
@@ -361,6 +409,20 @@ func Test_Conformance(t *testing.T) {
 			err = c.List(t.Context(), btlspList)
 			require.NoError(t, err)
 
+			// Reconcile all TCPRoute objects
+			tcprList := &gatewayv1alpha2.TCPRouteList{}
+			if !tt.disableTCPRoute {
+				err = c.List(t.Context(), tcprList)
+				require.NoError(t, err)
+			}
+
+			// Reconcile all UDPRoute objects
+			udprList := &gatewayv1alpha2.UDPRouteList{}
+			if !tt.disableUDPRoute {
+				err = c.List(t.Context(), udprList)
+				require.NoError(t, err)
+			}
+
 			for _, gwDetail := range tt.gateway {
 				// Reconcile the gateway under test
 				result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: gwDetail.FullName})
@@ -376,7 +438,7 @@ func Test_Conformance(t *testing.T) {
 				expectedGateway := &gatewayv1.Gateway{}
 				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/%s.yaml", tt.name, gwDetail.FullName.Name), expectedGateway)
 				require.Empty(t, cmp.Diff(expectedGateway, actualGateway, cmpIgnoreFields...))
-				if !gwDetail.wantErr {
+				if !gwDetail.wantErr && !gwDetail.skipCEC {
 					// Checking the output for CiliumEnvoyConfig
 					actualCEC := &ciliumv2.CiliumEnvoyConfig{}
 					err = c.Get(t.Context(), client.ObjectKey{
@@ -391,6 +453,23 @@ func Test_Conformance(t *testing.T) {
 				}
 
 			}
+
+			// Checking the output for EndpointSlices
+			epsList := &discoveryv1.EndpointSliceList{}
+			err = c.List(t.Context(), epsList, client.MatchingLabels{
+				gatewayApiTranslation.EndpointSliceManagedByLabel: gatewayApiTranslation.EndpointSliceManagedByValue,
+			})
+			require.NoError(t, err)
+			for _, eps := range epsList.Items {
+				actualEPS := &discoveryv1.EndpointSlice{}
+				err = c.Get(t.Context(), client.ObjectKeyFromObject(&eps), actualEPS)
+				actualEPS.TypeMeta = endpointSliceTypeMeta
+				require.NoError(t, err, "error getting EndpointSlice %s/%s: %v", eps.Namespace, eps.Name, err)
+				expectedEPS := &discoveryv1.EndpointSlice{}
+				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/endpointslice-%s.yaml", tt.name, eps.Name), expectedEPS)
+				require.Empty(t, cmp.Diff(expectedEPS, actualEPS, cmpIgnoreFields...))
+			}
+
 			// Checking the output for related HTTPRoute objects
 			for _, hr := range hrList.Items {
 				actualHR := &gatewayv1.HTTPRoute{}
@@ -432,6 +511,26 @@ func Test_Conformance(t *testing.T) {
 				expectedBTLSP := &gatewayv1.BackendTLSPolicy{}
 				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/backendtlspolicy-%s.yaml", tt.name, btlsp.Name), expectedBTLSP)
 				require.Empty(t, cmp.Diff(expectedBTLSP, actualBTLSP, cmpIgnoreFields...))
+			}
+
+			for _, tcpr := range tcprList.Items {
+				actualTCPR := &gatewayv1alpha2.TCPRoute{}
+				err = c.Get(t.Context(), client.ObjectKeyFromObject(&tcpr), actualTCPR)
+				actualTCPR.TypeMeta = tcpRouteTypeMeta
+				require.NoError(t, err, "error getting TCPRoute %s/%s: %v", tcpr.Namespace, tcpr.Name, err)
+				expectedTCPR := &gatewayv1alpha2.TCPRoute{}
+				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/tcproute-%s.yaml", tt.name, tcpr.Name), expectedTCPR)
+				require.Empty(t, cmp.Diff(expectedTCPR, actualTCPR, cmpIgnoreFields...))
+			}
+
+			for _, udpr := range udprList.Items {
+				actualUDPR := &gatewayv1alpha2.UDPRoute{}
+				err = c.Get(t.Context(), client.ObjectKeyFromObject(&udpr), actualUDPR)
+				actualUDPR.TypeMeta = udpRouteTypeMeta
+				require.NoError(t, err, "error getting UDPRoute %s/%s: %v", udpr.Namespace, udpr.Name, err)
+				expectedUDPR := &gatewayv1alpha2.UDPRoute{}
+				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/udproute-%s.yaml", tt.name, udpr.Name), expectedUDPR)
+				require.Empty(t, cmp.Diff(expectedUDPR, actualUDPR, cmpIgnoreFields...))
 			}
 		})
 	}
@@ -601,6 +700,92 @@ func Test_gatewayReconciler_Reconcile_cleansUpResourcesOnHandoff(t *testing.T) {
 			require.NoError(t, c.Get(t.Context(), client.ObjectKeyFromObject(gw), actualGateway))
 		})
 	}
+}
+
+// Test_gatewayReconciler_ensureEnvoyConfig_deletesStaleCEC verifies that a
+// CiliumEnvoyConfig left over from a previous HTTP/TLS state is cleaned up when
+// the Gateway no longer needs Envoy (e.g. it switches to pure L4 TCP/UDP
+// Routes, so the translator returns a nil desired CEC).
+func Test_gatewayReconciler_ensureEnvoyConfig_deletesStaleCEC(t *testing.T) {
+	t.Parallel()
+
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "l4-gateway",
+			Namespace: "default",
+			UID:       types.UID("gateway-uid"),
+		},
+	}
+
+	cecKey := types.NamespacedName{
+		Namespace: gw.Namespace,
+		Name:      shortener.ShortenK8sResourceName(gatewayApiTranslation.CiliumGatewayPrefix + gw.Name),
+	}
+
+	ownedCEC := func() *ciliumv2.CiliumEnvoyConfig {
+		return &ciliumv2.CiliumEnvoyConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cecKey.Name,
+				Namespace: cecKey.Namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: gatewayv1.GroupVersion.String(),
+						Kind:       "Gateway",
+						Name:       gw.Name,
+						UID:        gw.UID,
+						Controller: ptr.To(true),
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("deletes owned stale CEC when desired is nil", func(t *testing.T) {
+		c := fake.NewClientBuilder().
+			WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+			WithObjects(gw, ownedCEC()).
+			Build()
+		r := &gatewayReconciler{
+			Client: c,
+			logger: hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug)),
+		}
+
+		require.NoError(t, r.ensureEnvoyConfig(t.Context(), gw, nil))
+
+		err := c.Get(t.Context(), cecKey, &ciliumv2.CiliumEnvoyConfig{})
+		require.ErrorContains(t, err, "not found")
+	})
+
+	t.Run("keeps CEC not owned by the Gateway", func(t *testing.T) {
+		foreign := ownedCEC()
+		foreign.OwnerReferences[0].UID = types.UID("other-uid")
+		foreign.OwnerReferences[0].Name = "other-gateway"
+		c := fake.NewClientBuilder().
+			WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+			WithObjects(gw, foreign).
+			Build()
+		r := &gatewayReconciler{
+			Client: c,
+			logger: hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug)),
+		}
+
+		require.NoError(t, r.ensureEnvoyConfig(t.Context(), gw, nil))
+
+		require.NoError(t, c.Get(t.Context(), cecKey, &ciliumv2.CiliumEnvoyConfig{}))
+	})
+
+	t.Run("no error when no CEC exists", func(t *testing.T) {
+		c := fake.NewClientBuilder().
+			WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+			WithObjects(gw).
+			Build()
+		r := &gatewayReconciler{
+			Client: c,
+			logger: hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug)),
+		}
+
+		require.NoError(t, r.ensureEnvoyConfig(t.Context(), gw, nil))
+	})
 }
 
 func filterHTTPRoute(hrList *gatewayv1.HTTPRouteList, gatewayName string, namespace string) []gatewayv1.HTTPRoute {

--- a/operator/pkg/gateway-api/gatewayclass_status.go
+++ b/operator/pkg/gateway-api/gatewayclass_status.go
@@ -22,6 +22,19 @@ var supportedFeatures = features.AllFeatures
 
 var gatewayClassSupportedFeatures = getSupportedFeatures()
 
+// extraFeatures lists features that Cilium supports but are missing from
+// features.AllFeatures in the pinned gateway-api version: UDPRoute is defined
+// but not yet added to AllFeatures, and TCPRoute does not exist as a Feature
+// constant.
+// TODO: Remove entries here once the gateway-api bump exposes them.
+var extraFeatures = []features.Feature{
+	features.UDPRouteFeature,
+	{
+		Name:    features.FeatureName("TCPRoute"),
+		Channel: features.FeatureChannelExperimental,
+	},
+}
+
 // This lists the features we do _not_ support, so that we can skip
 // them in the supportedFeatures list in the GatewayClass.
 var exemptFeatures = []features.Feature{
@@ -41,6 +54,9 @@ var exemptFeatures = []features.Feature{
 // List of Gateway API features supported by Cilium.
 // The same should stay in sync with GHA CI in .github/workflows/conformance-gateway-api.yaml
 func getSupportedFeatures() []gatewayv1.SupportedFeature {
+	for _, feature := range extraFeatures {
+		supportedFeatures.Insert(feature)
+	}
 	for _, feature := range exemptFeatures {
 		supportedFeatures.Delete(feature)
 	}

--- a/operator/pkg/gateway-api/helper_test.go
+++ b/operator/pkg/gateway-api/helper_test.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 	k8syaml "sigs.k8s.io/yaml"
 )
@@ -96,6 +97,14 @@ func readInput(t *testing.T, file string) []client.Object {
 			res = append(res, obj)
 		case "TLSRoute":
 			obj := &gatewayv1.TLSRoute{}
+			fromYaml(t, o, obj)
+			res = append(res, obj)
+		case "TCPRoute":
+			obj := &gatewayv1alpha2.TCPRoute{}
+			fromYaml(t, o, obj)
+			res = append(res, obj)
+		case "UDPRoute":
+			obj := &gatewayv1alpha2.UDPRoute{}
 			fromYaml(t, o, obj)
 			res = append(res, obj)
 		case "GRPCRoute":

--- a/operator/pkg/gateway-api/helpers.go
+++ b/operator/pkg/gateway-api/helpers.go
@@ -96,6 +96,12 @@ func isKindAllowed(listener gatewayv1.Listener, route metav1.Object) bool {
 		} else if (kind.Group == nil || string(*kind.Group) == gatewayv1.GroupName) &&
 			kind.Kind == kindGRPCRoute && routeKind == kindGRPCRoute {
 			return true
+		} else if (kind.Group == nil || string(*kind.Group) == gatewayv1alpha2.GroupName) &&
+			kind.Kind == kindTCPRoute && routeKind == kindTCPRoute {
+			return true
+		} else if (kind.Group == nil || string(*kind.Group) == gatewayv1alpha2.GroupName) &&
+			kind.Kind == kindUDPRoute && routeKind == kindUDPRoute {
+			return true
 		}
 	}
 	return false

--- a/operator/pkg/gateway-api/helpers/schemes.go
+++ b/operator/pkg/gateway-api/helpers/schemes.go
@@ -13,6 +13,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -31,6 +32,8 @@ var RequiredGVKs = []schema.GroupVersionKind{
 
 var AllOptionalKinds = []schema.GroupVersionKind{
 	mcsapiv1beta1.SchemeGroupVersion.WithKind(ServiceImportKind),
+	gatewayv1alpha2.SchemeGroupVersion.WithKind(TCPRouteKind),
+	gatewayv1alpha2.SchemeGroupVersion.WithKind(UDPRouteKind),
 }
 
 func TestScheme(optionalKinds []schema.GroupVersionKind) *runtime.Scheme {

--- a/operator/pkg/gateway-api/helpers/tcproute.go
+++ b/operator/pkg/gateway-api/helpers/tcproute.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package helpers
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+// HasTCPRouteSupport returns if the TCPRoute CRD is supported.
+// This checks if the Gateway API v1alpha2 TCPRoute CRD is registered in the client scheme.
+func HasTCPRouteSupport(scheme *runtime.Scheme) bool {
+	return scheme.Recognizes(gatewayv1alpha2.SchemeGroupVersion.WithKind("TCPRoute"))
+}

--- a/operator/pkg/gateway-api/helpers/tcproute_test.go
+++ b/operator/pkg/gateway-api/helpers/tcproute_test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func TestHasTCPRouteSupport(t *testing.T) {
+	scheme1 := runtime.NewScheme()
+	assert.False(t, HasTCPRouteSupport(scheme1), "Should be false when group is not registered")
+
+	scheme2 := runtime.NewScheme()
+	scheme2.AddKnownTypes(gatewayv1alpha2.SchemeGroupVersion, &gatewayv1alpha2.TLSRoute{})
+	assert.False(t, HasTCPRouteSupport(scheme2), "Should be false when group is registered but TCPRoute kind is not")
+
+	scheme3 := runtime.NewScheme()
+	err := gatewayv1alpha2.AddToScheme(scheme3)
+	assert.NoError(t, err)
+	assert.True(t, HasTCPRouteSupport(scheme3), "Should be true when TCPRoute kind is registered")
+}

--- a/operator/pkg/gateway-api/helpers/types.go
+++ b/operator/pkg/gateway-api/helpers/types.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 )
 
@@ -28,6 +29,10 @@ const (
 	BackendTLSPolicyKind  string = "backendtlspolicies"
 	TLSRouteKind          string = "tlsroutes"
 	TLSRouteListKind      string = "tlsroutelists"
+	TCPRouteKind          string = "tcproutes"
+	TCPRouteListKind      string = "tcproutelists"
+	UDPRouteKind          string = "udproutes"
+	UDPRouteListKind      string = "udproutelists"
 	ServiceImportKind     string = "serviceimports"
 	ServiceImportListKind string = "serviceimportlists"
 )
@@ -105,6 +110,14 @@ func GetConcreteObject(schemaType schema.GroupVersionKind) runtime.Object {
 		return &gatewayv1.TLSRoute{}
 	case TLSRouteListKind:
 		return &gatewayv1.TLSRouteList{}
+	case TCPRouteKind:
+		return &gatewayv1alpha2.TCPRoute{}
+	case TCPRouteListKind:
+		return &gatewayv1alpha2.TCPRouteList{}
+	case UDPRouteKind:
+		return &gatewayv1alpha2.UDPRoute{}
+	case UDPRouteListKind:
+		return &gatewayv1alpha2.UDPRouteList{}
 	case ServiceImportKind:
 		return &mcsapiv1beta1.ServiceImport{}
 	case ServiceImportListKind:

--- a/operator/pkg/gateway-api/helpers/types_test.go
+++ b/operator/pkg/gateway-api/helpers/types_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 func TestIsGammaService(t *testing.T) {
@@ -286,6 +287,42 @@ func TestGetConcreteObject(t *testing.T) {
 				Kind:    TLSRouteListKind,
 			},
 			want: &gatewayv1.TLSRouteList{},
+		},
+		{
+			name: "TCPRoute",
+			gvk: schema.GroupVersionKind{
+				Group:   gatewayv1alpha2.GroupVersion.Group,
+				Version: gatewayv1alpha2.GroupVersion.Version,
+				Kind:    TCPRouteKind,
+			},
+			want: &gatewayv1alpha2.TCPRoute{},
+		},
+		{
+			name: "TCPRouteList",
+			gvk: schema.GroupVersionKind{
+				Group:   gatewayv1alpha2.GroupVersion.Group,
+				Version: gatewayv1alpha2.GroupVersion.Version,
+				Kind:    TCPRouteListKind,
+			},
+			want: &gatewayv1alpha2.TCPRouteList{},
+		},
+		{
+			name: "UDPRoute",
+			gvk: schema.GroupVersionKind{
+				Group:   gatewayv1alpha2.GroupVersion.Group,
+				Version: gatewayv1alpha2.GroupVersion.Version,
+				Kind:    UDPRouteKind,
+			},
+			want: &gatewayv1alpha2.UDPRoute{},
+		},
+		{
+			name: "UDPRouteList",
+			gvk: schema.GroupVersionKind{
+				Group:   gatewayv1alpha2.GroupVersion.Group,
+				Version: gatewayv1alpha2.GroupVersion.Version,
+				Kind:    UDPRouteListKind,
+			},
+			want: &gatewayv1alpha2.UDPRouteList{},
 		},
 	}
 	for _, tt := range tests {

--- a/operator/pkg/gateway-api/helpers/udproute.go
+++ b/operator/pkg/gateway-api/helpers/udproute.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package helpers
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+// HasUDPRouteSupport returns if the UDPRoute CRD is supported.
+// This checks if the Gateway API v1alpha2 UDPRoute CRD is registered in the client scheme.
+func HasUDPRouteSupport(scheme *runtime.Scheme) bool {
+	return scheme.Recognizes(gatewayv1alpha2.SchemeGroupVersion.WithKind("UDPRoute"))
+}

--- a/operator/pkg/gateway-api/helpers/udproute_test.go
+++ b/operator/pkg/gateway-api/helpers/udproute_test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func TestHasUDPRouteSupport(t *testing.T) {
+	scheme1 := runtime.NewScheme()
+	assert.False(t, HasUDPRouteSupport(scheme1), "Should be false when group is not registered")
+
+	scheme2 := runtime.NewScheme()
+	scheme2.AddKnownTypes(gatewayv1alpha2.SchemeGroupVersion, &gatewayv1alpha2.TLSRoute{})
+	assert.False(t, HasUDPRouteSupport(scheme2), "Should be false when group is registered but UDPRoute kind is not")
+
+	scheme3 := runtime.NewScheme()
+	err := gatewayv1alpha2.AddToScheme(scheme3)
+	assert.NoError(t, err)
+	assert.True(t, HasUDPRouteSupport(scheme3), "Should be true when UDPRoute kind is registered")
+}

--- a/operator/pkg/gateway-api/indexers/indexnames.go
+++ b/operator/pkg/gateway-api/indexers/indexnames.go
@@ -43,4 +43,16 @@ const (
 
 	// Indexes GatewayClass objects by the CiliumGatewayClassConfig they reference.
 	GatewayClassCiliumGatewayClassConfigsIndex = "gatewayClassCiliumGatewayClassConfigsIndex"
+
+	// Indexes TCPRoutes by all the backend Services referenced in the object.
+	BackendServiceTCPRouteIndex = "backendServiceTCPRouteIndex"
+
+	// Indexes TCPRoutes by all the Gateway parents referenced in the object.
+	GatewayTCPRouteIndex = "gatewayTCPRouteIndex"
+
+	// Indexes UDPRoutes by all the backend Services referenced in the object.
+	BackendServiceUDPRouteIndex = "backendServiceUDPRouteIndex"
+
+	// Indexes UDPRoutes by all the Gateway parents referenced in the object.
+	GatewayUDPRouteIndex = "gatewayUDPRouteIndex"
 )

--- a/operator/pkg/gateway-api/indexers/tcproute.go
+++ b/operator/pkg/gateway-api/indexers/tcproute.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package indexers
+
+import (
+	"log/slog"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// GenerateIndexerTCPRoutebyBackendService takes a single TCPRoute and returns all referenced
+// backend service full names (`namespace/name`) to add to the relevant index.
+func GenerateIndexerTCPRoutebyBackendService(c client.Client, logger *slog.Logger) client.IndexerFunc {
+	return func(rawObj client.Object) []string {
+		route := rawObj.(*gatewayv1alpha2.TCPRoute)
+		var backendServices []string
+
+		for _, rule := range route.Spec.Rules {
+			for _, backend := range rule.BackendRefs {
+				namespace := helpers.NamespaceDerefOr(backend.Namespace, route.Namespace)
+				backendServiceName, err := helpers.GetBackendServiceName(c, namespace, backend.BackendObjectReference)
+				if err != nil {
+					logger.Error("Failed to get backend service name",
+						logfields.LogSubsys, logfields.TCPRoute,
+						logfields.TCPRoute, client.ObjectKeyFromObject(rawObj),
+						logfields.Error, err)
+					continue
+				}
+				backendServices = append(backendServices,
+					types.NamespacedName{
+						Namespace: helpers.NamespaceDerefOr(backend.Namespace, route.Namespace),
+						Name:      backendServiceName,
+					}.String(),
+				)
+			}
+		}
+
+		return backendServices
+	}
+}
+
+// IndexTCPRouteByGateway takes a single TCPRoute and returns all referenced Gateway object
+// full names (`namespace/name`) to add to the relevant index.
+//
+// Note that this does _not_ filter to only Cilium-relevant Gateways.
+func IndexTCPRouteByGateway(rawObj client.Object) []string {
+	route := rawObj.(*gatewayv1alpha2.TCPRoute)
+	var gateways []string
+	for _, parent := range route.Spec.ParentRefs {
+		if !helpers.IsGateway(parent) {
+			continue
+		}
+		gateways = append(gateways,
+			types.NamespacedName{
+				Namespace: helpers.NamespaceDerefOr(parent.Namespace, route.Namespace),
+				Name:      string(parent.Name),
+			}.String(),
+		)
+	}
+	return gateways
+}

--- a/operator/pkg/gateway-api/indexers/tcproute_test.go
+++ b/operator/pkg/gateway-api/indexers/tcproute_test.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package indexers
+
+import (
+	"slices"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func TestIndexTCPRouteByGateway(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  client.Object
+		want []string
+	}{
+		{
+			name: "parentRef is Gateway",
+			obj: &gatewayv1alpha2.TCPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "valid-gateway",
+					Namespace: "default",
+				},
+				Spec: gatewayv1alpha2.TCPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:      "valid",
+								Namespace: ptr.To[gatewayv1.Namespace]("default"),
+							},
+						},
+					},
+				},
+			},
+			want: []string{
+				"default/valid",
+			},
+		},
+		{
+			name: "parentRef is a Gateway, nil namespace",
+			obj: &gatewayv1alpha2.TCPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "valid-gateway",
+					Namespace: "default",
+				},
+				Spec: gatewayv1alpha2.TCPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name: "valid-nil-namespace",
+							},
+						},
+					},
+				},
+			},
+			want: []string{
+				"default/valid-nil-namespace",
+			},
+		},
+		{
+			name: "parentRef is not a Gateway",
+			obj: &gatewayv1alpha2.TCPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-parent",
+					Namespace: "default",
+				},
+				Spec: gatewayv1alpha2.TCPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:      "invalid",
+								Namespace: ptr.To[gatewayv1.Namespace]("default"),
+								Kind:      ptr.To[gatewayv1.Kind]("OtherKind"),
+								Group:     ptr.To[gatewayv1.Group]("somegroup.io"),
+							},
+						},
+					},
+				},
+			},
+			want: []string(nil),
+		},
+		{
+			name: "parentRef has explicit Gateway kind/group",
+			obj: &gatewayv1alpha2.TCPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "explicit-gateway",
+					Namespace: "default",
+				},
+				Spec: gatewayv1alpha2.TCPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:      "gw-explicit",
+								Namespace: ptr.To[gatewayv1.Namespace]("default"),
+								Kind:      ptr.To[gatewayv1.Kind]("Gateway"),
+								Group:     ptr.To[gatewayv1.Group](gatewayv1.GroupName),
+							},
+						},
+					},
+				},
+			},
+			want: []string{"default/gw-explicit"},
+		},
+		{
+			name: "parentRef has Gateway kind but wrong group",
+			obj: &gatewayv1alpha2.TCPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gateway-wrong-group",
+					Namespace: "default",
+				},
+				Spec: gatewayv1alpha2.TCPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:      "gw-wrong-group",
+								Namespace: ptr.To[gatewayv1.Namespace]("default"),
+								Kind:      ptr.To[gatewayv1.Kind]("Gateway"),
+								Group:     ptr.To[gatewayv1.Group]("example.io"),
+							},
+						},
+					},
+				},
+			},
+			want: []string(nil),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IndexTCPRouteByGateway(tt.obj); !slices.Equal(got, tt.want) {
+				t.Errorf("IndexTCPRouteByGateway() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}

--- a/operator/pkg/gateway-api/indexers/udproute.go
+++ b/operator/pkg/gateway-api/indexers/udproute.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package indexers
+
+import (
+	"log/slog"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// GenerateIndexerUDPRoutebyBackendService takes a single UDPRoute and returns all referenced
+// backend service full names (`namespace/name`) to add to the relevant index.
+func GenerateIndexerUDPRoutebyBackendService(c client.Client, logger *slog.Logger) client.IndexerFunc {
+	return func(rawObj client.Object) []string {
+		route := rawObj.(*gatewayv1alpha2.UDPRoute)
+		var backendServices []string
+
+		for _, rule := range route.Spec.Rules {
+			for _, backend := range rule.BackendRefs {
+				namespace := helpers.NamespaceDerefOr(backend.Namespace, route.Namespace)
+				backendServiceName, err := helpers.GetBackendServiceName(c, namespace, backend.BackendObjectReference)
+				if err != nil {
+					logger.Error("Failed to get backend service name",
+						logfields.LogSubsys, logfields.UDPRoute,
+						logfields.UDPRoute, client.ObjectKeyFromObject(rawObj),
+						logfields.Error, err)
+					continue
+				}
+				backendServices = append(backendServices,
+					types.NamespacedName{
+						Namespace: helpers.NamespaceDerefOr(backend.Namespace, route.Namespace),
+						Name:      backendServiceName,
+					}.String(),
+				)
+			}
+		}
+
+		return backendServices
+	}
+}
+
+// IndexUDPRouteByGateway takes a single UDPRoute and returns all referenced Gateway object
+// full names (`namespace/name`) to add to the relevant index.
+//
+// Note that this does _not_ filter to only Cilium-relevant Gateways.
+func IndexUDPRouteByGateway(rawObj client.Object) []string {
+	route := rawObj.(*gatewayv1alpha2.UDPRoute)
+	var gateways []string
+	for _, parent := range route.Spec.ParentRefs {
+		if !helpers.IsGateway(parent) {
+			continue
+		}
+		gateways = append(gateways,
+			types.NamespacedName{
+				Namespace: helpers.NamespaceDerefOr(parent.Namespace, route.Namespace),
+				Name:      string(parent.Name),
+			}.String(),
+		)
+	}
+	return gateways
+}

--- a/operator/pkg/gateway-api/indexers/udproute_test.go
+++ b/operator/pkg/gateway-api/indexers/udproute_test.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package indexers
+
+import (
+	"slices"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func TestIndexUDPRouteByGateway(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  client.Object
+		want []string
+	}{
+		{
+			name: "parentRef is Gateway",
+			obj: &gatewayv1alpha2.UDPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "valid-gateway",
+					Namespace: "default",
+				},
+				Spec: gatewayv1alpha2.UDPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:      "valid",
+								Namespace: ptr.To[gatewayv1.Namespace]("default"),
+							},
+						},
+					},
+				},
+			},
+			want: []string{
+				"default/valid",
+			},
+		},
+		{
+			name: "parentRef is a Gateway, nil namespace",
+			obj: &gatewayv1alpha2.UDPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "valid-gateway",
+					Namespace: "default",
+				},
+				Spec: gatewayv1alpha2.UDPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name: "valid-nil-namespace",
+							},
+						},
+					},
+				},
+			},
+			want: []string{
+				"default/valid-nil-namespace",
+			},
+		},
+		{
+			name: "parentRef is not a Gateway",
+			obj: &gatewayv1alpha2.UDPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-parent",
+					Namespace: "default",
+				},
+				Spec: gatewayv1alpha2.UDPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:      "invalid",
+								Namespace: ptr.To[gatewayv1.Namespace]("default"),
+								Kind:      ptr.To[gatewayv1.Kind]("OtherKind"),
+								Group:     ptr.To[gatewayv1.Group]("somegroup.io"),
+							},
+						},
+					},
+				},
+			},
+			want: []string(nil),
+		},
+		{
+			name: "parentRef has explicit Gateway kind/group",
+			obj: &gatewayv1alpha2.UDPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "explicit-gateway",
+					Namespace: "default",
+				},
+				Spec: gatewayv1alpha2.UDPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:      "gw-explicit",
+								Namespace: ptr.To[gatewayv1.Namespace]("default"),
+								Kind:      ptr.To[gatewayv1.Kind]("Gateway"),
+								Group:     ptr.To[gatewayv1.Group](gatewayv1.GroupName),
+							},
+						},
+					},
+				},
+			},
+			want: []string{"default/gw-explicit"},
+		},
+		{
+			name: "parentRef has Gateway kind but wrong group",
+			obj: &gatewayv1alpha2.UDPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gateway-wrong-group",
+					Namespace: "default",
+				},
+				Spec: gatewayv1alpha2.UDPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:      "gw-wrong-group",
+								Namespace: ptr.To[gatewayv1.Namespace]("default"),
+								Kind:      ptr.To[gatewayv1.Kind]("Gateway"),
+								Group:     ptr.To[gatewayv1.Group]("example.io"),
+							},
+						},
+					},
+				},
+			},
+			want: []string(nil),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IndexUDPRouteByGateway(tt.obj); !slices.Equal(got, tt.want) {
+				t.Errorf("IndexUDPRouteByGateway() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}

--- a/operator/pkg/gateway-api/logger.go
+++ b/operator/pkg/gateway-api/logger.go
@@ -10,8 +10,11 @@ const (
 	httpRoute          = "httpRoute"
 	grpcRoute          = "grpcRoute"
 	tlsRoute           = "tlsRoute"
+	tcpRoute           = "tcpRoute"
+	udpRoute           = "udpRoute"
 	relevantHTTPRoutes = "relevantHTTPRoutes"
 	numRoutes          = "numRoutes"
 	policies           = "policies"
 	backendTLSPolicy   = "BackendTLSPolicy"
+	endpointSlice      = "endpointSlice"
 )

--- a/operator/pkg/gateway-api/predicates/endpointslice.go
+++ b/operator/pkg/gateway-api/predicates/endpointslice.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package predicates
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	gwModel "github.com/cilium/cilium/operator/pkg/model/translation/gateway-api"
+)
+
+// IsManagedFrontendEndpointSlice returns true when the EndpointSlice is a
+// frontend slice managed by the cilium-operator (created by the Gateway
+// translator for an L4 listener). The check is based on the standard
+// EndpointSlice managed-by label.
+func IsManagedFrontendEndpointSlice(obj client.Object) bool {
+	if obj == nil {
+		return false
+	}
+	return obj.GetLabels()[gwModel.EndpointSliceManagedByLabel] == gwModel.EndpointSliceManagedByValue
+}
+
+// ManagedFrontendEndpointSlice is a predicate that only admits managed frontend
+// EndpointSlices.
+func ManagedFrontendEndpointSlice() predicate.Predicate {
+	return predicate.NewPredicateFuncs(IsManagedFrontendEndpointSlice)
+}
+
+// NonManagedEndpointSlice is a predicate that admits any EndpointSlice that is
+// not a managed frontend slice (i.e. a backend slice produced by upstream
+// kube-controller-manager or another controller).
+func NonManagedEndpointSlice() predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		return !IsManagedFrontendEndpointSlice(obj)
+	})
+}

--- a/operator/pkg/gateway-api/routechecks/gateway_checks.go
+++ b/operator/pkg/gateway-api/routechecks/gateway_checks.go
@@ -81,7 +81,7 @@ func CheckGatewayRouteKindAllowed(input Input, parentRef gatewayv1.ParentReferen
 	gw, err := input.GetGateway(parentRef)
 	if err != nil {
 		input.SetParentCondition(parentRef, metav1.Condition{
-			Type:    "Accepted",
+			Type:    string(gatewayv1.RouteConditionAccepted),
 			Status:  metav1.ConditionFalse,
 			Reason:  "Invalid" + input.GetGVK().Kind,
 			Message: err.Error(),
@@ -177,7 +177,7 @@ func CheckGatewayMatchingPorts(input Input, parentRef gatewayv1.ParentReference)
 		input.SetParentCondition(parentRef, metav1.Condition{
 			Type:    string(gatewayv1.RouteConditionAccepted),
 			Status:  metav1.ConditionFalse,
-			Reason:  "NoMatchingParent",
+			Reason:  string(gatewayv1.RouteReasonNoMatchingParent),
 			Message: fmt.Sprintf("No matching listener with port %d", *parentRef.Port),
 		})
 
@@ -212,7 +212,7 @@ func CheckGatewayMatchingSection(input Input, parentRef gatewayv1.ParentReferenc
 			input.SetParentCondition(parentRef, metav1.Condition{
 				Type:    string(gatewayv1.RouteConditionAccepted),
 				Status:  metav1.ConditionFalse,
-				Reason:  "NoMatchingParent",
+				Reason:  string(gatewayv1.RouteReasonNoMatchingParent),
 				Message: fmt.Sprintf("No matching listener with sectionName %s", *parentRef.SectionName),
 			})
 

--- a/operator/pkg/gateway-api/routechecks/tcproute.go
+++ b/operator/pkg/gateway-api/routechecks/tcproute.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package routechecks
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"reflect"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+)
+
+// TCPRouteInput is used to implement the Input interface for TCPRoute.
+type TCPRouteInput struct {
+	Ctx            context.Context
+	Logger         *slog.Logger
+	Client         client.Client
+	Grants         *gatewayv1.ReferenceGrantList
+	TCPRoute       *gatewayv1alpha2.TCPRoute
+	ControllerName string
+
+	gateways map[gatewayv1.ParentReference]*gatewayv1.Gateway
+}
+
+func (t *TCPRouteInput) SetParentCondition(ref gatewayv1.ParentReference, condition metav1.Condition) {
+	condition.LastTransitionTime = metav1.NewTime(time.Now())
+	condition.ObservedGeneration = t.TCPRoute.GetGeneration()
+
+	t.mergeStatusConditions(ref, []metav1.Condition{
+		condition,
+	})
+}
+
+func (t *TCPRouteInput) SetAllParentCondition(condition metav1.Condition) {
+	// fill in the condition
+	condition.LastTransitionTime = metav1.NewTime(time.Now())
+	condition.ObservedGeneration = t.TCPRoute.GetGeneration()
+
+	for _, parent := range t.TCPRoute.Spec.ParentRefs {
+		t.mergeStatusConditions(parent, []metav1.Condition{
+			condition,
+		})
+	}
+}
+
+func (t *TCPRouteInput) mergeStatusConditions(parentRef gatewayv1alpha2.ParentReference, updates []metav1.Condition) {
+	index := -1
+	for i, parent := range t.TCPRoute.Status.RouteStatus.Parents {
+		if reflect.DeepEqual(parent.ParentRef, parentRef) {
+			index = i
+			break
+		}
+	}
+	if index != -1 {
+		t.TCPRoute.Status.RouteStatus.Parents[index].Conditions = helpers.MergeConditions(t.TCPRoute.Status.RouteStatus.Parents[index].Conditions, updates...)
+		return
+	}
+	t.TCPRoute.Status.RouteStatus.Parents = append(t.TCPRoute.Status.RouteStatus.Parents, gatewayv1alpha2.RouteParentStatus{
+		ParentRef:      parentRef,
+		ControllerName: gatewayv1.GatewayController(t.ControllerName),
+		Conditions:     updates,
+	})
+}
+
+func (t *TCPRouteInput) GetGrants() []gatewayv1.ReferenceGrant {
+	return t.Grants.Items
+}
+
+func (t *TCPRouteInput) GetNamespace() string {
+	return t.TCPRoute.GetNamespace()
+}
+
+func (t *TCPRouteInput) GetGVK() schema.GroupVersionKind {
+	return gatewayv1alpha2.SchemeGroupVersion.WithKind("TCPRoute")
+}
+
+func (t *TCPRouteInput) GetRules() []GenericRule {
+	var rules []GenericRule
+	for _, rule := range t.TCPRoute.Spec.Rules {
+		rules = append(rules, &TCPRouteRule{rule})
+	}
+	return rules
+}
+
+func (t *TCPRouteInput) GetClient() client.Client {
+	return t.Client
+}
+
+func (t *TCPRouteInput) GetContext() context.Context {
+	return t.Ctx
+}
+
+// TCPRouteRule is used to implement the GenericRule interface for TCPRoute.
+type TCPRouteRule struct {
+	Rule gatewayv1alpha2.TCPRouteRule
+}
+
+func (t *TCPRouteRule) GetBackendRefs() []gatewayv1.BackendRef {
+	return t.Rule.BackendRefs
+}
+
+func (t *TCPRouteInput) GetHostnames() []gatewayv1.Hostname {
+	return nil
+}
+
+func (t *TCPRouteInput) GetGateway(parent gatewayv1.ParentReference) (*gatewayv1.Gateway, error) {
+	if t.gateways == nil {
+		t.gateways = make(map[gatewayv1.ParentReference]*gatewayv1.Gateway)
+	}
+
+	if gw, exists := t.gateways[parent]; exists {
+		return gw, nil
+	}
+
+	ns := helpers.NamespaceDerefOr(parent.Namespace, t.GetNamespace())
+	gw := &gatewayv1.Gateway{}
+
+	if err := t.Client.Get(t.Ctx, client.ObjectKey{Namespace: ns, Name: string(parent.Name)}, gw); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return nil, fmt.Errorf("error while getting gateway: %w", err)
+		}
+
+		return nil, fmt.Errorf("gateway %q does not exist: %w", parent.Name, err)
+	}
+
+	t.gateways[parent] = gw
+
+	return gw, nil
+}
+
+func (t *TCPRouteInput) GetParentGammaService(parent gatewayv1.ParentReference) (*corev1.Service, error) {
+	return nil, fmt.Errorf("GAMMA support is not implemented in this reconciler")
+}
+
+func (t *TCPRouteInput) Log() *slog.Logger {
+	return t.Logger
+}
+
+func (t *TCPRouteInput) GetValidProtocols() []gatewayv1.ProtocolType {
+	return []gatewayv1.ProtocolType{gatewayv1.TCPProtocolType}
+}

--- a/operator/pkg/gateway-api/routechecks/udproute.go
+++ b/operator/pkg/gateway-api/routechecks/udproute.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package routechecks
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"reflect"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+)
+
+// UDPRouteInput is used to implement the Input interface for UDPRoute.
+type UDPRouteInput struct {
+	Ctx            context.Context
+	Logger         *slog.Logger
+	Client         client.Client
+	Grants         *gatewayv1.ReferenceGrantList
+	UDPRoute       *gatewayv1alpha2.UDPRoute
+	ControllerName string
+
+	gateways map[gatewayv1.ParentReference]*gatewayv1.Gateway
+}
+
+func (u *UDPRouteInput) SetParentCondition(ref gatewayv1.ParentReference, condition metav1.Condition) {
+	condition.LastTransitionTime = metav1.NewTime(time.Now())
+	condition.ObservedGeneration = u.UDPRoute.GetGeneration()
+
+	u.mergeStatusConditions(ref, []metav1.Condition{
+		condition,
+	})
+}
+
+func (u *UDPRouteInput) SetAllParentCondition(condition metav1.Condition) {
+	// fill in the condition
+	condition.LastTransitionTime = metav1.NewTime(time.Now())
+	condition.ObservedGeneration = u.UDPRoute.GetGeneration()
+
+	for _, parent := range u.UDPRoute.Spec.ParentRefs {
+		u.mergeStatusConditions(parent, []metav1.Condition{
+			condition,
+		})
+	}
+}
+
+func (u *UDPRouteInput) mergeStatusConditions(parentRef gatewayv1alpha2.ParentReference, updates []metav1.Condition) {
+	index := -1
+	for i, parent := range u.UDPRoute.Status.RouteStatus.Parents {
+		if reflect.DeepEqual(parent.ParentRef, parentRef) {
+			index = i
+			break
+		}
+	}
+	if index != -1 {
+		u.UDPRoute.Status.RouteStatus.Parents[index].Conditions = helpers.MergeConditions(u.UDPRoute.Status.RouteStatus.Parents[index].Conditions, updates...)
+		return
+	}
+	u.UDPRoute.Status.RouteStatus.Parents = append(u.UDPRoute.Status.RouteStatus.Parents, gatewayv1alpha2.RouteParentStatus{
+		ParentRef:      parentRef,
+		ControllerName: gatewayv1.GatewayController(u.ControllerName),
+		Conditions:     updates,
+	})
+}
+
+func (u *UDPRouteInput) GetGrants() []gatewayv1.ReferenceGrant {
+	return u.Grants.Items
+}
+
+func (u *UDPRouteInput) GetNamespace() string {
+	return u.UDPRoute.GetNamespace()
+}
+
+func (u *UDPRouteInput) GetGVK() schema.GroupVersionKind {
+	return gatewayv1alpha2.SchemeGroupVersion.WithKind("UDPRoute")
+}
+
+func (u *UDPRouteInput) GetRules() []GenericRule {
+	var rules []GenericRule
+	for _, rule := range u.UDPRoute.Spec.Rules {
+		rules = append(rules, &UDPRouteRule{rule})
+	}
+	return rules
+}
+
+func (u *UDPRouteInput) GetClient() client.Client {
+	return u.Client
+}
+
+func (u *UDPRouteInput) GetContext() context.Context {
+	return u.Ctx
+}
+
+// UDPRouteRule is used to implement the GenericRule interface for UDPRoute.
+type UDPRouteRule struct {
+	Rule gatewayv1alpha2.UDPRouteRule
+}
+
+func (u *UDPRouteRule) GetBackendRefs() []gatewayv1.BackendRef {
+	return u.Rule.BackendRefs
+}
+
+func (u *UDPRouteInput) GetHostnames() []gatewayv1.Hostname {
+	return nil
+}
+
+func (u *UDPRouteInput) GetGateway(parent gatewayv1.ParentReference) (*gatewayv1.Gateway, error) {
+	if u.gateways == nil {
+		u.gateways = make(map[gatewayv1.ParentReference]*gatewayv1.Gateway)
+	}
+
+	if gw, exists := u.gateways[parent]; exists {
+		return gw, nil
+	}
+
+	ns := helpers.NamespaceDerefOr(parent.Namespace, u.GetNamespace())
+	gw := &gatewayv1.Gateway{}
+
+	if err := u.Client.Get(u.Ctx, client.ObjectKey{Namespace: ns, Name: string(parent.Name)}, gw); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return nil, fmt.Errorf("error while getting gateway: %w", err)
+		}
+
+		return nil, fmt.Errorf("gateway %q does not exist: %w", parent.Name, err)
+	}
+
+	u.gateways[parent] = gw
+
+	return gw, nil
+}
+
+func (u *UDPRouteInput) GetParentGammaService(parent gatewayv1.ParentReference) (*corev1.Service, error) {
+	return nil, fmt.Errorf("GAMMA support is not implemented in this reconciler")
+}
+
+func (u *UDPRouteInput) Log() *slog.Logger {
+	return u.Logger
+}
+
+func (u *UDPRouteInput) GetValidProtocols() []gatewayv1.ProtocolType {
+	return []gatewayv1.ProtocolType{gatewayv1.UDPProtocolType}
+}

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-mixed-http-tcp/input/gateway-mixed-http-tcp.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-mixed-http-tcp/input/gateway-mixed-http-tcp.yaml
@@ -1,0 +1,58 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-mixed
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: HTTPRoute
+    - name: tcp
+      port: 3000
+      protocol: TCP
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TCPRoute
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mixed-http
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gateway-mixed
+      namespace: gateway-conformance-infra
+      sectionName: http
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: mixed-tcp
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gateway-mixed
+      namespace: gateway-conformance-infra
+      sectionName: tcp
+  rules:
+    - backendRefs:
+        - name: tcp-backend
+          port: 3000

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-mixed-http-tcp/output/cec-gateway-mixed.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-mixed-http-tcp/output/cec-gateway-mixed.yaml
@@ -1,0 +1,105 @@
+metadata:
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: gateway-mixed
+  name: cilium-gateway-gateway-mixed
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: gateway-mixed
+    uid: ""
+  resourceVersion: "1"
+spec:
+  backendServices:
+  - name: infra-backend-v1
+    namespace: gateway-conformance-infra
+    number:
+    - "8080"
+  resources:
+  - '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    filterChains:
+    - filterChainMatch:
+        transportProtocol: raw_buffer
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            maxStreamDuration: 0s
+          httpFilters:
+          - name: envoy.filters.http.grpc_web
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+          - name: envoy.filters.http.grpc_stats
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+              emitFilterState: true
+              enableUpstreamStats: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig: {}
+          rds:
+            routeConfigName: listener-insecure
+          statPrefix: listener-insecure
+          streamIdleTimeout: 300s
+          upgradeConfigs:
+          - upgradeType: websocket
+          useRemoteAddress: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: listener
+    socketOptions:
+    - description: Enable TCP keep-alive (default to enabled)
+      intValue: "1"
+      level: "1"
+      name: "9"
+    - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+      intValue: "10"
+      level: "6"
+      name: "4"
+    - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+      intValue: "5"
+      level: "6"
+      name: "5"
+    - description: TCP keep-alive probe max failures.
+      intValue: "10"
+      level: "6"
+      name: "6"
+  - '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    name: listener-insecure
+    virtualHosts:
+    - domains:
+      - '*'
+      name: '*'
+      routes:
+      - match:
+          prefix: /
+        route:
+          cluster: gateway-conformance-infra:infra-backend-v1:8080
+          maxStreamDuration:
+            maxStreamDuration: 0s
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    edsClusterConfig:
+      serviceName: gateway-conformance-infra/infra-backend-v1:8080
+    name: gateway-conformance-infra:infra-backend-v1:8080
+    outlierDetection:
+      splitExternalLocalOriginErrors: true
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 60s
+        useDownstreamProtocolConfig:
+          http2ProtocolOptions: {}
+  services:
+  - name: cilium-gateway-gateway-mixed
+    namespace: gateway-conformance-infra
+    ports:
+    - 80

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-mixed-http-tcp/output/endpointslice-cilium-gateway-gateway-mixed-ecb92c68-ipv4.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-mixed-http-tcp/output/endpointslice-cilium-gateway-gateway-mixed-ecb92c68-ipv4.yaml
@@ -1,0 +1,24 @@
+addressType: IPv4
+apiVersion: discovery.k8s.io/v1
+endpoints: []
+kind: EndpointSlice
+metadata:
+  annotations:
+    gateway.cilium.io/backend-port: "3000"
+    gateway.cilium.io/backend-service: gateway-conformance-infra/tcp-backend
+  labels:
+    endpointslice.kubernetes.io/managed-by: cilium-operator
+    gateway.networking.k8s.io/gateway-name: gateway-mixed
+    kubernetes.io/service-name: cilium-gateway-gateway-mixed
+  name: cilium-gateway-gateway-mixed-ecb92c68-ipv4
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: gateway-mixed
+    uid: ""
+ports:
+- name: port-3000
+  port: 3000
+  protocol: TCP

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-mixed-http-tcp/output/gateway-mixed.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-mixed-http-tcp/output/gateway-mixed.yaml
@@ -1,0 +1,80 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-mixed
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  gatewayClassName: cilium
+  listeners:
+  - allowedRoutes:
+      kinds:
+      - kind: HTTPRoute
+      namespaces:
+        from: Same
+    name: http
+    port: 80
+    protocol: HTTP
+  - allowedRoutes:
+      kinds:
+      - kind: TCPRoute
+      namespaces:
+        from: Same
+    name: tcp
+    port: 3000
+    protocol: TCP
+status:
+  conditions:
+  - lastTransitionTime: "2026-06-05T07:01:22Z"
+    message: Gateway successfully scheduled
+    reason: Accepted
+    status: "True"
+    type: Accepted
+  - lastTransitionTime: "2026-06-05T07:01:22Z"
+    message: Gateway waiting for address
+    reason: AddressNotAssigned
+    status: "False"
+    type: Programmed
+  listeners:
+  - attachedRoutes: 1
+    conditions:
+    - lastTransitionTime: "2026-06-05T07:01:22Z"
+      message: Resolved Refs
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    - lastTransitionTime: "2026-06-05T07:01:22Z"
+      message: Listener Accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-06-05T07:01:22Z"
+      message: Address not ready yet
+      reason: Pending
+      status: "False"
+      type: Programmed
+    name: http
+    supportedKinds:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+  - attachedRoutes: 1
+    conditions:
+    - lastTransitionTime: "2026-06-05T07:01:22Z"
+      message: Resolved Refs
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    - lastTransitionTime: "2026-06-05T07:01:22Z"
+      message: Listener Accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-06-05T07:01:22Z"
+      message: Address not ready yet
+      reason: Pending
+      status: "False"
+      type: Programmed
+    name: tcp
+    supportedKinds:
+    - group: gateway.networking.k8s.io
+      kind: TCPRoute

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-mixed-http-tcp/output/httproute-mixed-http.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-mixed-http-tcp/output/httproute-mixed-http.yaml
@@ -1,0 +1,37 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mixed-http
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  parentRefs:
+  - name: gateway-mixed
+    namespace: gateway-conformance-infra
+    sectionName: http
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: "2026-06-05T07:01:22Z"
+      message: Accepted HTTPRoute
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-06-05T07:01:22Z"
+      message: Service reference is valid
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: io.cilium/gateway-controller
+    parentRef:
+      name: gateway-mixed
+      namespace: gateway-conformance-infra
+      sectionName: http

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-mixed-http-tcp/output/tcproute-mixed-tcp.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-mixed-http-tcp/output/tcproute-mixed-tcp.yaml
@@ -1,0 +1,33 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: mixed-tcp
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  parentRefs:
+  - name: gateway-mixed
+    namespace: gateway-conformance-infra
+    sectionName: tcp
+  rules:
+  - backendRefs:
+    - name: tcp-backend
+      port: 3000
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: "2026-06-05T07:01:22Z"
+      message: Accepted TCPRoute
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-06-05T07:01:22Z"
+      message: Service reference is valid
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: io.cilium/gateway-controller
+    parentRef:
+      name: gateway-mixed
+      namespace: gateway-conformance-infra
+      sectionName: tcp

--- a/operator/pkg/gateway-api/testdata/gateway/tcproute-crd-not-installed/input/tcproute-crd-not-installed.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tcproute-crd-not-installed/input/tcproute-crd-not-installed.yaml
@@ -1,0 +1,29 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-tcproute
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: tcp
+      port: 8080
+      protocol: TCP
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TCPRoute
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tcp-backend-simple
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: tcp-backend-simple
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080

--- a/operator/pkg/gateway-api/testdata/gateway/tcproute-crd-not-installed/output/gateway-tcproute.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tcproute-crd-not-installed/output/gateway-tcproute.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-tcproute
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: tcp
+      port: 8080
+      protocol: TCP
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TCPRoute
+status:
+  conditions:
+    - message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+      lastTransitionTime: "2026-02-25T00:00:00Z"
+    - message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+      lastTransitionTime: "2026-02-25T00:00:00Z"
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+      name: tcp
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TCPRoute

--- a/operator/pkg/gateway-api/testdata/gateway/tcproute-invalid-reference-grant/input/tcproute-invalid-reference-grant.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tcproute-invalid-reference-grant/input/tcproute-invalid-reference-grant.yaml
@@ -1,0 +1,46 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: reference-grant-wrong-kind
+  namespace: gateway-conformance-web-backend
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: UDPRoute
+      namespace: gateway-conformance-infra
+  to:
+    - group: ""
+      kind: Service
+      name: web-backend
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: reference-grant
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gateway-tcproute-referencegrant
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: web-backend
+          namespace: gateway-conformance-web-backend
+          port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-tcproute-referencegrant
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: tcp
+      port: 8080
+      protocol: TCP
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TCPRoute

--- a/operator/pkg/gateway-api/testdata/gateway/tcproute-invalid-reference-grant/output/gateway-tcproute-referencegrant.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tcproute-invalid-reference-grant/output/gateway-tcproute-referencegrant.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-tcproute-referencegrant
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: tcp
+      port: 8080
+      protocol: TCP
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TCPRoute
+status:
+  conditions:
+    - message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+      lastTransitionTime: "2026-02-25T00:00:00Z"
+    - message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+      lastTransitionTime: "2026-02-25T00:00:00Z"
+  listeners:
+    - attachedRoutes: 1
+      conditions:
+        - message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+      name: tcp
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TCPRoute

--- a/operator/pkg/gateway-api/testdata/gateway/tcproute-invalid-reference-grant/output/tcproute-reference-grant.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tcproute-invalid-reference-grant/output/tcproute-reference-grant.yaml
@@ -1,0 +1,31 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: reference-grant
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gateway-tcproute-referencegrant
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: web-backend
+          namespace: gateway-conformance-web-backend
+          port: 8080
+status:
+  parents:
+    - conditions:
+        - message: Accepted TCPRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Cross namespace references are not allowed
+          reason: RefNotPermitted
+          status: "False"
+          type: ResolvedRefs
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: gateway-tcproute-referencegrant
+        namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/tcproute-simple-same-namespace/input/tcproute-simple-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tcproute-simple-same-namespace/input/tcproute-simple-same-namespace.yaml
@@ -1,0 +1,43 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: gateway-conformance-infra-tcp-test
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gateway-tcproute
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: tcp-backend-simple
+          port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-tcproute
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: tcp
+      port: 8080
+      protocol: TCP
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TCPRoute
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tcp-backend-simple
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: tcp-backend-simple
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080

--- a/operator/pkg/gateway-api/testdata/gateway/tcproute-simple-same-namespace/output/endpointslice-cilium-gateway-gateway-tcproute-babd3fe1-ipv4.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tcproute-simple-same-namespace/output/endpointslice-cilium-gateway-gateway-tcproute-babd3fe1-ipv4.yaml
@@ -1,0 +1,24 @@
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: cilium-gateway-gateway-tcproute-babd3fe1-ipv4
+  namespace: gateway-conformance-infra
+  labels:
+    endpointslice.kubernetes.io/managed-by: cilium-operator
+    gateway.networking.k8s.io/gateway-name: gateway-tcproute
+    kubernetes.io/service-name: cilium-gateway-gateway-tcproute
+  annotations:
+    gateway.cilium.io/backend-port: "8080"
+    gateway.cilium.io/backend-service: gateway-conformance-infra/tcp-backend-simple
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      kind: Gateway
+      name: gateway-tcproute
+      controller: true
+      uid: ""
+addressType: IPv4
+endpoints: []
+ports:
+  - name: port-8080
+    port: 8080
+    protocol: TCP

--- a/operator/pkg/gateway-api/testdata/gateway/tcproute-simple-same-namespace/output/gateway-tcproute.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tcproute-simple-same-namespace/output/gateway-tcproute.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-tcproute
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: tcp
+      port: 8080
+      protocol: TCP
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TCPRoute
+status:
+  conditions:
+    - message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+      lastTransitionTime: "2026-02-25T00:00:00Z"
+    - message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+      lastTransitionTime: "2026-02-25T00:00:00Z"
+  listeners:
+    - attachedRoutes: 1
+      conditions:
+        - message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+      name: tcp
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: TCPRoute

--- a/operator/pkg/gateway-api/testdata/gateway/tcproute-simple-same-namespace/output/tcproute-gateway-conformance-infra-tcp-test.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tcproute-simple-same-namespace/output/tcproute-gateway-conformance-infra-tcp-test.yaml
@@ -1,0 +1,30 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: gateway-conformance-infra-tcp-test
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gateway-tcproute
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: tcp-backend-simple
+          port: 8080
+status:
+  parents:
+    - conditions:
+        - message: Accepted TCPRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: gateway-tcproute
+        namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/udproute-crd-not-installed/input/udproute-crd-not-installed.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/udproute-crd-not-installed/input/udproute-crd-not-installed.yaml
@@ -1,0 +1,29 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-udproute
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: udp
+      port: 5353
+      protocol: UDP
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: UDPRoute
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: udp-backend
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: udp-backend
+  ports:
+    - protocol: UDP
+      port: 5353
+      targetPort: 5353

--- a/operator/pkg/gateway-api/testdata/gateway/udproute-crd-not-installed/output/gateway-udproute.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/udproute-crd-not-installed/output/gateway-udproute.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-udproute
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: udp
+      port: 5353
+      protocol: UDP
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: UDPRoute
+status:
+  conditions:
+    - message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+      lastTransitionTime: "2026-02-25T00:00:00Z"
+    - message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+      lastTransitionTime: "2026-02-25T00:00:00Z"
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+      name: udp
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: UDPRoute

--- a/operator/pkg/gateway-api/testdata/gateway/udproute-invalid-reference-grant/input/udproute-invalid-reference-grant.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/udproute-invalid-reference-grant/input/udproute-invalid-reference-grant.yaml
@@ -1,0 +1,46 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: reference-grant-wrong-kind
+  namespace: gateway-conformance-web-backend
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: TCPRoute
+      namespace: gateway-conformance-infra
+  to:
+    - group: ""
+      kind: Service
+      name: web-backend
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: UDPRoute
+metadata:
+  name: reference-grant
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gateway-udproute-referencegrant
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: web-backend
+          namespace: gateway-conformance-web-backend
+          port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-udproute-referencegrant
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: udp
+      port: 5353
+      protocol: UDP
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: UDPRoute

--- a/operator/pkg/gateway-api/testdata/gateway/udproute-invalid-reference-grant/output/gateway-udproute-referencegrant.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/udproute-invalid-reference-grant/output/gateway-udproute-referencegrant.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-udproute-referencegrant
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: udp
+      port: 5353
+      protocol: UDP
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: UDPRoute
+status:
+  conditions:
+    - message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+      lastTransitionTime: "2026-02-25T00:00:00Z"
+    - message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+      lastTransitionTime: "2026-02-25T00:00:00Z"
+  listeners:
+    - attachedRoutes: 1
+      conditions:
+        - message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+      name: udp
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: UDPRoute

--- a/operator/pkg/gateway-api/testdata/gateway/udproute-invalid-reference-grant/output/udproute-reference-grant.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/udproute-invalid-reference-grant/output/udproute-reference-grant.yaml
@@ -1,0 +1,31 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: UDPRoute
+metadata:
+  name: reference-grant
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gateway-udproute-referencegrant
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: web-backend
+          namespace: gateway-conformance-web-backend
+          port: 8080
+status:
+  parents:
+    - conditions:
+        - message: Accepted UDPRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Cross namespace references are not allowed
+          reason: RefNotPermitted
+          status: "False"
+          type: ResolvedRefs
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: gateway-udproute-referencegrant
+        namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/udproute-simple-same-namespace/input/udproute-simple-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/udproute-simple-same-namespace/input/udproute-simple-same-namespace.yaml
@@ -1,0 +1,43 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: UDPRoute
+metadata:
+  name: gateway-conformance-infra-udp-test
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gateway-udproute
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: udp-backend
+          port: 5353
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-udproute
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: udp
+      port: 5353
+      protocol: UDP
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: UDPRoute
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: udp-backend
+  namespace: gateway-conformance-infra
+spec:
+  selector:
+    app: udp-backend
+  ports:
+    - protocol: UDP
+      port: 5353
+      targetPort: 5353

--- a/operator/pkg/gateway-api/testdata/gateway/udproute-simple-same-namespace/output/endpointslice-cilium-gateway-gateway-udproute-fe390332-ipv4.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/udproute-simple-same-namespace/output/endpointslice-cilium-gateway-gateway-udproute-fe390332-ipv4.yaml
@@ -1,0 +1,24 @@
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: cilium-gateway-gateway-udproute-fe390332-ipv4
+  namespace: gateway-conformance-infra
+  labels:
+    endpointslice.kubernetes.io/managed-by: cilium-operator
+    gateway.networking.k8s.io/gateway-name: gateway-udproute
+    kubernetes.io/service-name: cilium-gateway-gateway-udproute
+  annotations:
+    gateway.cilium.io/backend-port: "5353"
+    gateway.cilium.io/backend-service: gateway-conformance-infra/udp-backend
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      kind: Gateway
+      name: gateway-udproute
+      controller: true
+      uid: ""
+addressType: IPv4
+endpoints: []
+ports:
+  - name: port-5353-udp
+    port: 5353
+    protocol: UDP

--- a/operator/pkg/gateway-api/testdata/gateway/udproute-simple-same-namespace/output/gateway-udproute.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/udproute-simple-same-namespace/output/gateway-udproute.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-udproute
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: udp
+      port: 5353
+      protocol: UDP
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: UDPRoute
+status:
+  conditions:
+    - message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+      lastTransitionTime: "2026-02-25T00:00:00Z"
+    - message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+      lastTransitionTime: "2026-02-25T00:00:00Z"
+  listeners:
+    - attachedRoutes: 1
+      conditions:
+        - message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+      name: udp
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: UDPRoute

--- a/operator/pkg/gateway-api/testdata/gateway/udproute-simple-same-namespace/output/udproute-gateway-conformance-infra-udp-test.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/udproute-simple-same-namespace/output/udproute-gateway-conformance-infra-udp-test.yaml
@@ -1,0 +1,30 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: UDPRoute
+metadata:
+  name: gateway-conformance-infra-udp-test
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: gateway-udproute
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: udp-backend
+          port: 5353
+status:
+  parents:
+    - conditions:
+        - message: Accepted UDPRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: gateway-udproute
+        namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/watch-handlers/endpointslice.go
+++ b/operator/pkg/gateway-api/watch-handlers/endpointslice.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchhandlers
+
+import (
+	"context"
+	"log/slog"
+
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	gwModel "github.com/cilium/cilium/operator/pkg/model/translation/gateway-api"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// EnqueueFrontendsForBackendEndpointSlice returns an event handler that, when
+// passed a backend EndpointSlice, returns reconcile.Requests for all managed
+// frontend EndpointSlices whose BackendServiceAnnotation matches the backend
+// Service the slice belongs to (via the kubernetes.io/service-name label).
+func EnqueueFrontendsForBackendEndpointSlice(c client.Client, logger *slog.Logger) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
+		eps, ok := o.(*discoveryv1.EndpointSlice)
+		if !ok {
+			return nil
+		}
+		svcName := eps.Labels[gwModel.EndpointSliceServiceNameLabel]
+		if svcName == "" {
+			return nil
+		}
+		return frontendsMatchingBackend(ctx, c, logger, eps.Namespace, svcName)
+	})
+}
+
+// EnqueueFrontendsForBackendService returns an event handler that, when passed
+// a Service, returns reconcile.Requests for all managed frontend EndpointSlices
+// whose BackendServiceAnnotation references that Service.
+func EnqueueFrontendsForBackendService(c client.Client, logger *slog.Logger) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
+		svc, ok := o.(*corev1.Service)
+		if !ok {
+			return nil
+		}
+		return frontendsMatchingBackend(ctx, c, logger, svc.Namespace, svc.Name)
+	})
+}
+
+func frontendsMatchingBackend(ctx context.Context, c client.Client, logger *slog.Logger, ns, name string) []reconcile.Request {
+	wantBackend := ns + "/" + name
+
+	list := &discoveryv1.EndpointSliceList{}
+	if err := c.List(ctx, list, client.MatchingLabels{
+		gwModel.EndpointSliceManagedByLabel: gwModel.EndpointSliceManagedByValue,
+	}); err != nil {
+		logger.WarnContext(ctx, "Failed to list managed EndpointSlices",
+			logfields.Error, err)
+		return nil
+	}
+
+	var reqs []reconcile.Request
+	for i := range list.Items {
+		fe := list.Items[i]
+		if fe.Annotations[gwModel.BackendServiceAnnotation] == wantBackend {
+			reqs = append(reqs, reconcile.Request{
+				NamespacedName: types.NamespacedName{Namespace: fe.Namespace, Name: fe.Name},
+			})
+		}
+	}
+	return reqs
+}

--- a/operator/pkg/gateway-api/watch-handlers/routes.go
+++ b/operator/pkg/gateway-api/watch-handlers/routes.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 // EnqueueRequestForOwningHTTPRoute returns an event handler that, when passed a HTTPRoute, returns reconcile.Requests
@@ -49,5 +50,31 @@ func EnqueueRequestForOwningGRPCRoute(c client.Client, logger *slog.Logger, cont
 		}
 
 		return getGatewayReconcileRequestsForRoute(ctx, c, a, gr.Spec.CommonRouteSpec, logger, controllerName)
+	})
+}
+
+// EnqueueRequestForOwningTCPRoute returns an event handler that, when passed a TCPRoute, returns reconcile.Requests
+// for any Cilium-relevant Gateways associated with that TCPRoute.
+func EnqueueRequestForOwningTCPRoute(c client.Client, logger *slog.Logger, controllerName string) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
+		tr, ok := a.(*gatewayv1alpha2.TCPRoute)
+		if !ok {
+			return nil
+		}
+
+		return getGatewayReconcileRequestsForRoute(context.Background(), c, a, tr.Spec.CommonRouteSpec, logger, controllerName)
+	})
+}
+
+// EnqueueRequestForOwningUDPRoute returns an event handler that, when passed a UDPRoute, returns reconcile.Requests
+// for any Cilium-relevant Gateways associated with that UDPRoute.
+func EnqueueRequestForOwningUDPRoute(c client.Client, logger *slog.Logger, controllerName string) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
+		ur, ok := a.(*gatewayv1alpha2.UDPRoute)
+		if !ok {
+			return nil
+		}
+
+		return getGatewayReconcileRequestsForRoute(context.Background(), c, a, ur.Spec.CommonRouteSpec, logger, controllerName)
 	})
 }

--- a/operator/pkg/ingress/ingress_reconcile.go
+++ b/operator/pkg/ingress/ingress_reconcile.go
@@ -264,9 +264,15 @@ func (r *ingressReconciler) buildDedicatedResources(ctx context.Context, ingress
 		m.HTTP = append(m.HTTP, ingestion.Ingress(scopedLog, *ingress, r.defaultSecretNamespace, r.defaultSecretName, r.enforcedHTTPS, insecureHTTPPort, secureHTTPPort, r.defaultRequestTimeout)...)
 	}
 
-	cec, svc, ep, err := r.dedicatedTranslator.Translate(m)
+	cec, svc, eps, err := r.dedicatedTranslator.Translate(m)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to translate model into resources: %w", err)
+	}
+	// Ingress only ever produces a single dummy EndpointSlice; unwrap from the
+	// shared Translator interface that returns a list to support gateway-api L4.
+	var ep *discoveryv1.EndpointSlice
+	if len(eps) > 0 {
+		ep = eps[0]
 	}
 
 	r.propagateIngressAnnotationsAndLabels(ingress, &svc.ObjectMeta)

--- a/operator/pkg/ingress/ingress_reconcile_test.go
+++ b/operator/pkg/ingress/ingress_reconcile_test.go
@@ -1318,12 +1318,12 @@ type fakeDedicatedIngressTranslator struct {
 	model *model.Model
 }
 
-func (r *fakeDedicatedIngressTranslator) Translate(model *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, *discoveryv1.EndpointSlice, error) {
+func (r *fakeDedicatedIngressTranslator) Translate(model *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, []*discoveryv1.EndpointSlice, error) {
 	r.model = model
 
 	return &ciliumv2.CiliumEnvoyConfig{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test"}},
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test"}},
-		&discoveryv1.EndpointSlice{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test"}},
+		[]*discoveryv1.EndpointSlice{{ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test"}}},
 		nil
 }
 

--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -7,13 +7,16 @@ import (
 	"cmp"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 
@@ -37,6 +40,8 @@ type Input struct {
 	HTTPRoutes          []gatewayv1.HTTPRoute
 	TLSRoutes           []gatewayv1.TLSRoute
 	GRPCRoutes          []gatewayv1.GRPCRoute
+	TCPRoutes           []gatewayv1alpha2.TCPRoute
+	UDPRoutes           []gatewayv1alpha2.UDPRoute
 	ReferenceGrants     []gatewayv1.ReferenceGrant
 	Namespaces          []corev1.Namespace
 	Services            []corev1.Service
@@ -48,6 +53,7 @@ type Input struct {
 func GatewayAPI(log *slog.Logger, input Input) *model.Model {
 	var resHTTP []model.HTTPListener
 	var resTLSPassthrough []model.TLSPassthroughListener
+	var resL4 []model.L4Listener
 
 	labels := make(map[string]string)
 	annotations := make(map[string]string)
@@ -90,37 +96,12 @@ func GatewayAPI(log *slog.Logger, input Input) *model.Model {
 	}
 
 	for _, l := range input.Gateway.Spec.Listeners {
-		if l.Protocol != gatewayv1.HTTPProtocolType &&
-			l.Protocol != gatewayv1.HTTPSProtocolType &&
-			l.Protocol != gatewayv1.TLSProtocolType {
-			continue
-		}
-
-		var httpRoutes []model.HTTPRoute
-		httpRoutes = append(httpRoutes, toHTTPRoutes(log, l, input.Gateway.GetNamespace(), namespaceLabels, listenerHostnamesByProtocol, input.HTTPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants, input.BackendTLSPolicyMap)...)
-		httpRoutes = append(httpRoutes, toGRPCRoutes(l, input.Gateway.GetNamespace(), namespaceLabels, listenerHostnamesByProtocol, input.GRPCRoutes, input.Services, input.ServiceImports, input.ReferenceGrants)...)
-		resHTTP = append(resHTTP, model.HTTPListener{
-			Name: string(l.Name),
-			Sources: []model.FullyQualifiedResource{
-				{
-					Name:      input.Gateway.GetName(),
-					Namespace: input.Gateway.GetNamespace(),
-					Group:     gatewayv1.SchemeGroupVersion.Group,
-					Version:   gatewayv1.SchemeGroupVersion.Version,
-					Kind:      "Gateway",
-					UID:       string(input.Gateway.GetUID()),
-				},
-			},
-			Port:           uint32(l.Port),
-			Hostname:       toHostname(l.Hostname),
-			TLS:            toTLS(l.TLS, input.ReferenceGrants, input.Gateway.GetNamespace()),
-			Routes:         httpRoutes,
-			Infrastructure: infra,
-			Service:        toServiceModel(input.GatewayClassConfig),
-		})
-
-		if l.Protocol == gatewayv1.TLSProtocolType {
-			resTLSPassthrough = append(resTLSPassthrough, model.TLSPassthroughListener{
+		switch l.Protocol {
+		case gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType, gatewayv1.TLSProtocolType:
+			var httpRoutes []model.HTTPRoute
+			httpRoutes = append(httpRoutes, toHTTPRoutes(log, l, input.Gateway.GetNamespace(), namespaceLabels, listenerHostnamesByProtocol, input.HTTPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants, input.BackendTLSPolicyMap)...)
+			httpRoutes = append(httpRoutes, toGRPCRoutes(l, input.Gateway.GetNamespace(), namespaceLabels, listenerHostnamesByProtocol, input.GRPCRoutes, input.Services, input.ServiceImports, input.ReferenceGrants)...)
+			resHTTP = append(resHTTP, model.HTTPListener{
 				Name: string(l.Name),
 				Sources: []model.FullyQualifiedResource{
 					{
@@ -134,7 +115,69 @@ func GatewayAPI(log *slog.Logger, input Input) *model.Model {
 				},
 				Port:           uint32(l.Port),
 				Hostname:       toHostname(l.Hostname),
-				Routes:         toTLSRoutes(l, input.Gateway.GetNamespace(), namespaceLabels, listenerHostnamesByProtocol, input.TLSRoutes, input.Services, input.ServiceImports, input.ReferenceGrants),
+				TLS:            toTLS(l.TLS, input.ReferenceGrants, input.Gateway.GetNamespace()),
+				Routes:         httpRoutes,
+				Infrastructure: infra,
+				Service:        toServiceModel(input.GatewayClassConfig),
+			})
+
+			if l.Protocol == gatewayv1.TLSProtocolType {
+				resTLSPassthrough = append(resTLSPassthrough, model.TLSPassthroughListener{
+					Name: string(l.Name),
+					Sources: []model.FullyQualifiedResource{
+						{
+							Name:      input.Gateway.GetName(),
+							Namespace: input.Gateway.GetNamespace(),
+							Group:     gatewayv1.SchemeGroupVersion.Group,
+							Version:   gatewayv1.SchemeGroupVersion.Version,
+							Kind:      "Gateway",
+							UID:       string(input.Gateway.GetUID()),
+						},
+					},
+					Port:           uint32(l.Port),
+					Hostname:       toHostname(l.Hostname),
+					Routes:         toTLSRoutes(l, input.Gateway.GetNamespace(), namespaceLabels, listenerHostnamesByProtocol, input.TLSRoutes, input.Services, input.ServiceImports, input.ReferenceGrants),
+					Infrastructure: infra,
+					Service:        toServiceModel(input.GatewayClassConfig),
+				})
+			}
+
+		case gatewayv1.TCPProtocolType:
+			resL4 = append(resL4, model.L4Listener{
+				Name: string(l.Name),
+				Sources: []model.FullyQualifiedResource{
+					{
+						Name:      input.Gateway.GetName(),
+						Namespace: input.Gateway.GetNamespace(),
+						Group:     gatewayv1.SchemeGroupVersion.Group,
+						Version:   gatewayv1.SchemeGroupVersion.Version,
+						Kind:      "Gateway",
+						UID:       string(input.Gateway.GetUID()),
+					},
+				},
+				Port:           uint32(l.Port),
+				Protocol:       model.L4ProtocolTCP,
+				Routes:         toTCPRoutes(l, input.TCPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants),
+				Infrastructure: infra,
+				Service:        toServiceModel(input.GatewayClassConfig),
+			})
+
+		case gatewayv1.UDPProtocolType:
+			resL4 = append(resL4, model.L4Listener{
+				Name: string(l.Name),
+				Sources: []model.FullyQualifiedResource{
+					{
+						Name:      input.Gateway.GetName(),
+						Namespace: input.Gateway.GetNamespace(),
+						Group:     gatewayv1.SchemeGroupVersion.Group,
+						Version:   gatewayv1.SchemeGroupVersion.Version,
+						Kind:      "Gateway",
+						UID:       string(input.Gateway.GetUID()),
+					},
+				},
+				Port:           uint32(l.Port),
+				Protocol:       model.L4ProtocolUDP,
+				Routes:         toUDPRoutes(l, input.UDPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants),
 				Infrastructure: infra,
 				Service:        toServiceModel(input.GatewayClassConfig),
 			})
@@ -144,6 +187,7 @@ func GatewayAPI(log *slog.Logger, input Input) *model.Model {
 	m := &model.Model{
 		HTTP:           resHTTP,
 		TLSPassthrough: resTLSPassthrough,
+		L4:             resL4,
 	}
 
 	if input.GatewayClassConfig != nil {
@@ -775,6 +819,152 @@ func toTLSRoutes(listener gatewayv1beta1.Listener, gatewayNamespace string, name
 		}
 	}
 	return tlsRoutes
+}
+
+// l4RouteAttachesToListener reports whether a TCP/UDP route with the given
+// parentRefs attaches to the listener, mirroring the sectionName/port matching
+// rules used by HTTP/TLS routes.
+func l4RouteAttachesToListener(parentRefs []gatewayv1.ParentReference, listener gatewayv1beta1.Listener) bool {
+	for _, parent := range parentRefs {
+		if parent.SectionName == nil && parent.Port == nil {
+			return true
+		}
+
+		if parent.SectionName != nil {
+			if *parent.SectionName != listener.Name {
+				continue
+			}
+			if parent.Port != nil && *parent.Port != listener.Port {
+				continue
+			}
+			return true
+		}
+
+		if parent.Port != nil {
+			if *parent.Port != listener.Port {
+				continue
+			}
+			return true
+		}
+	}
+	return false
+}
+
+// sortL4RoutesByAge orders routes oldest-first by creation timestamp, tie-broken
+// by namespace then name, so L4 conflict resolution deterministically binds the
+// oldest route to the listener.
+func sortL4RoutesByAge[T any](routes []T, meta func(T) metav1.ObjectMeta) {
+	slices.SortStableFunc(routes, func(a, b T) int {
+		ma, mb := meta(a), meta(b)
+		if c := ma.CreationTimestamp.Time.Compare(mb.CreationTimestamp.Time); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(ma.Namespace, mb.Namespace); c != 0 {
+			return c
+		}
+		return cmp.Compare(ma.Name, mb.Name)
+	})
+}
+
+func toTCPRoutes(listener gatewayv1beta1.Listener, input []gatewayv1alpha2.TCPRoute, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1.ReferenceGrant) []model.L4Route {
+	// Collect every TCPRoute that attaches to this listener, then keep only the
+	// oldest. Per Gateway API conflict resolution
+	// (https://gateway-api.sigs.k8s.io/guides/api-design/#conflicts), an L4
+	// listener binds traffic to a single route: the oldest by creation
+	// timestamp, tie-broken by namespace/name. Newer routes still report
+	// Accepted=True (handled by the status reconciler) but route no traffic.
+	attached := make([]gatewayv1alpha2.TCPRoute, 0, len(input))
+	for _, r := range input {
+		if l4RouteAttachesToListener(r.Spec.ParentRefs, listener) {
+			attached = append(attached, r)
+		}
+	}
+	if len(attached) == 0 {
+		return nil
+	}
+	sortL4RoutesByAge(attached, func(r gatewayv1alpha2.TCPRoute) metav1.ObjectMeta { return r.ObjectMeta })
+
+	var l4Routes []model.L4Route
+	{
+		r := attached[0]
+		for _, rule := range r.Spec.Rules {
+			bes := make([]model.Backend, 0, len(rule.BackendRefs))
+			for _, be := range rule.BackendRefs {
+				if !helpers.IsBackendReferenceAllowed(r.GetNamespace(), be, gatewayv1alpha2.SchemeGroupVersion.WithKind("TCPRoute"), grants) {
+					continue
+				}
+				svcName, err := getBackendServiceName(helpers.NamespaceDerefOr(be.Namespace, r.Namespace), services, serviceImports, be.BackendObjectReference)
+				if err != nil {
+					continue
+				}
+				if svcName != string(be.Name) {
+					be = *be.DeepCopy()
+					be.BackendObjectReference = gatewayv1beta1.BackendObjectReference{
+						Name:      gatewayv1beta1.ObjectName(svcName),
+						Port:      be.Port,
+						Namespace: be.Namespace,
+					}
+				}
+				svc := getServiceSpec(string(be.Name), helpers.NamespaceDerefOr(be.Namespace, r.Namespace), services)
+				if svc != nil {
+					bes = append(bes, backendToModelBackend(*svc, be, r.Namespace))
+				}
+			}
+
+			l4Routes = append(l4Routes, model.L4Route{
+				Backends: bes,
+			})
+		}
+	}
+	return l4Routes
+}
+
+func toUDPRoutes(listener gatewayv1beta1.Listener, input []gatewayv1alpha2.UDPRoute, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1.ReferenceGrant) []model.L4Route {
+	// Keep only the oldest attaching UDPRoute. See toTCPRoutes for the rationale.
+	attached := make([]gatewayv1alpha2.UDPRoute, 0, len(input))
+	for _, r := range input {
+		if l4RouteAttachesToListener(r.Spec.ParentRefs, listener) {
+			attached = append(attached, r)
+		}
+	}
+	if len(attached) == 0 {
+		return nil
+	}
+	sortL4RoutesByAge(attached, func(r gatewayv1alpha2.UDPRoute) metav1.ObjectMeta { return r.ObjectMeta })
+
+	var l4Routes []model.L4Route
+	{
+		r := attached[0]
+		for _, rule := range r.Spec.Rules {
+			bes := make([]model.Backend, 0, len(rule.BackendRefs))
+			for _, be := range rule.BackendRefs {
+				if !helpers.IsBackendReferenceAllowed(r.GetNamespace(), be, gatewayv1alpha2.SchemeGroupVersion.WithKind("UDPRoute"), grants) {
+					continue
+				}
+				svcName, err := getBackendServiceName(helpers.NamespaceDerefOr(be.Namespace, r.Namespace), services, serviceImports, be.BackendObjectReference)
+				if err != nil {
+					continue
+				}
+				if svcName != string(be.Name) {
+					be = *be.DeepCopy()
+					be.BackendObjectReference = gatewayv1beta1.BackendObjectReference{
+						Name:      gatewayv1beta1.ObjectName(svcName),
+						Port:      be.Port,
+						Namespace: be.Namespace,
+					}
+				}
+				svc := getServiceSpec(string(be.Name), helpers.NamespaceDerefOr(be.Namespace, r.Namespace), services)
+				if svc != nil {
+					bes = append(bes, backendToModelBackend(*svc, be, r.Namespace))
+				}
+			}
+
+			l4Routes = append(l4Routes, model.L4Route{
+				Backends: bes,
+			})
+		}
+	}
+	return l4Routes
 }
 
 func toHTTPRequestRedirectFilter(listenerPort int32, redirect *gatewayv1.HTTPRequestRedirectFilter) *model.HTTPRequestRedirectFilter {

--- a/operator/pkg/model/ingestion/gateway_test.go
+++ b/operator/pkg/model/ingestion/gateway_test.go
@@ -226,6 +226,26 @@ func TestGRPCGatewayAPI(t *testing.T) {
 	}
 }
 
+func TestL4GatewayAPI(t *testing.T) {
+	tests := map[string]struct{}{
+		"basic l4": {},
+	}
+
+	for name := range tests {
+		t.Run(name, func(t *testing.T) {
+			logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+
+			input := readGatewayInput(t, name)
+			m := GatewayAPI(logger, input)
+
+			expected := []model.L4Listener{}
+			readOutput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(name), "output-listeners.yaml"), &expected)
+
+			assert.Equal(t, toYaml(t, expected), toYaml(t, m.L4), "Listeners did not match")
+		})
+	}
+}
+
 func TestGPRCPathMatch(t *testing.T) {
 	tests := map[string]struct {
 		input gatewayv1.GRPCRouteMatch
@@ -329,6 +349,8 @@ func readGatewayInput(t *testing.T, testName string) Input {
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-tlsroute.yaml"), &input.TLSRoutes)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-grpcroute.yaml"), &input.GRPCRoutes)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-namespace.yaml"), &input.Namespaces)
+	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-tcproute.yaml"), &input.TCPRoutes)
+	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-udproute.yaml"), &input.UDPRoutes)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-service.yaml"), &input.Services)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-serviceimport.yaml"), &input.ServiceImports)
 

--- a/operator/pkg/model/ingestion/testdata/gateway/basic_l4/input-gateway.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/basic_l4/input-gateway.yaml
@@ -1,0 +1,17 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: gw
+  namespace: default
+  uid: uid
+spec:
+  gatewayClassName: ""
+  listeners:
+  - name: tcp-listener
+    port: 8080
+    protocol: TCP
+  - name: udp-listener
+    port: 5353
+    protocol: UDP
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/basic_l4/input-service.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/basic_l4/input-service.yaml
@@ -1,0 +1,24 @@
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    name: tcp-backend
+    namespace: default
+  spec:
+    ports:
+    - port: 8080
+      protocol: TCP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    name: udp-backend
+    namespace: default
+  spec:
+    ports:
+    - port: 5353
+      protocol: UDP
+  status:
+    loadBalancer: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/basic_l4/input-tcproute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/basic_l4/input-tcproute.yaml
@@ -1,0 +1,15 @@
+- metadata:
+    creationTimestamp: null
+    name: tcp-route
+    namespace: default
+  spec:
+    parentRefs:
+    - name: gw
+      port: 8080
+      sectionName: tcp-listener
+    rules:
+    - backendRefs:
+      - name: tcp-backend
+        port: 8080
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gateway/basic_l4/input-udproute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/basic_l4/input-udproute.yaml
@@ -1,0 +1,15 @@
+- metadata:
+    creationTimestamp: null
+    name: udp-route
+    namespace: default
+  spec:
+    parentRefs:
+    - name: gw
+      port: 5353
+      sectionName: udp-listener
+    rules:
+    - backendRefs:
+      - name: udp-backend
+        port: 5353
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gateway/basic_l4/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/basic_l4/output-listeners.yaml
@@ -1,0 +1,32 @@
+- name: tcp-listener
+  sources:
+  - name: gw
+    namespace: default
+    group: gateway.networking.k8s.io
+    version: v1
+    kind: Gateway
+    uid: uid
+  port: 8080
+  protocol: TCP
+  routes:
+  - backends:
+    - name: tcp-backend
+      namespace: default
+      port:
+        port: 8080
+- name: udp-listener
+  sources:
+  - name: gw
+    namespace: default
+    group: gateway.networking.k8s.io
+    version: v1
+    kind: Gateway
+    uid: uid
+  port: 5353
+  protocol: UDP
+  routes:
+  - backends:
+    - name: udp-backend
+      namespace: default
+      port:
+        port: 5353

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -17,6 +17,7 @@ import (
 type Model struct {
 	HTTP           []HTTPListener           `json:"http,omitempty"`
 	TLSPassthrough []TLSPassthroughListener `json:"tls_passthrough,omitempty"`
+	L4             []L4Listener             `json:"l4,omitempty"`
 	HTTPOptions    *HTTPOptions             `json:"http_options,omitempty"`
 }
 
@@ -25,7 +26,8 @@ type HTTPOptions struct {
 }
 
 type GRPCWebTranslationConfig struct {
-	Enabled bool `json:"enabled"`
+	Enabled bool         `json:"enabled"`
+	L4      []L4Listener `json:"l4,omitempty"`
 }
 
 func (m *Model) GetListeners() []Listener {
@@ -37,6 +39,10 @@ func (m *Model) GetListeners() []Listener {
 
 	for i := range m.TLSPassthrough {
 		listeners = append(listeners, &m.TLSPassthrough[i])
+	}
+
+	for i := range m.L4 {
+		listeners = append(listeners, &m.L4[i])
 	}
 
 	return listeners
@@ -55,6 +61,7 @@ type Listener interface {
 	GetAnnotations() map[string]string
 	GetLabels() map[string]string
 	GetService() *Service
+	GetProtocol() L4Protocol
 }
 
 // HTTPListener holds configuration for any listener that terminates and proxies HTTP
@@ -126,6 +133,10 @@ func (l HTTPListener) GetService() *Service {
 	return l.Service
 }
 
+func (l HTTPListener) GetProtocol() L4Protocol {
+	return L4ProtocolTCP
+}
+
 // TLSPassthroughListener holds configuration for any listener that proxies TLS
 // based on the SNI value.
 // Each holds the configuration info for one distinct TLS listener, by
@@ -180,6 +191,74 @@ func (l TLSPassthroughListener) GetPort() uint32 {
 
 func (l TLSPassthroughListener) GetService() *Service {
 	return l.Service
+}
+
+func (l TLSPassthroughListener) GetProtocol() L4Protocol {
+	return L4ProtocolTCP
+}
+
+type L4Protocol string
+
+const (
+	L4ProtocolTCP L4Protocol = "TCP"
+	L4ProtocolUDP L4Protocol = "UDP"
+)
+
+// L4Listener holds configuration for TCP or UDP listeners.
+type L4Listener struct {
+	// Name of the listener
+	Name string `json:"name,omitempty"`
+	// Sources is a slice of fully qualified resources this listener is sourced from.
+	Sources []FullyQualifiedResource `json:"sources,omitempty"`
+	// IPAddress that the listener should listen on.
+	Address string `json:"address,omitempty"`
+	// Port on which the service can be expected to be accessed by clients.
+	Port uint32 `json:"port,omitempty"`
+	// Protocol of the listener (TCP or UDP).
+	Protocol L4Protocol `json:"protocol,omitempty"`
+	// Routes associated with traffic to the service.
+	Routes []L4Route `json:"routes,omitempty"`
+	// Service configuration
+	Service *Service `json:"service,omitempty"`
+	// Infrastructure configuration
+	Infrastructure *Infrastructure `json:"infrastructure,omitempty"`
+}
+
+func (l L4Listener) GetAnnotations() map[string]string {
+	if l.Infrastructure != nil {
+		return l.Infrastructure.Annotations
+	}
+	return nil
+}
+
+func (l L4Listener) GetLabels() map[string]string {
+	if l.Infrastructure != nil {
+		return l.Infrastructure.Labels
+	}
+	return nil
+}
+
+func (l L4Listener) GetSources() []FullyQualifiedResource {
+	return l.Sources
+}
+
+func (l L4Listener) GetPort() uint32 {
+	return l.Port
+}
+
+func (l L4Listener) GetService() *Service {
+	return l.Service
+}
+
+func (l L4Listener) GetProtocol() L4Protocol {
+	return l.Protocol
+}
+
+// L4Route holds the details needed to route TCP/UDP traffic to backends.
+type L4Route struct {
+	Name string `json:"name,omitempty"`
+	// Backends handling the requests.
+	Backends []Backend `json:"backends,omitempty"`
 }
 
 // Service holds the configuration for desired Service details
@@ -608,9 +687,9 @@ type HTTPRetry struct {
 	Backoff *time.Duration `json:"backoff,omitempty"`
 }
 
-// IsEmpty returns true if the model has no HTTP or TLS Passthrough listeners.
+// IsEmpty returns true if the model has no HTTP, TLS Passthrough or L4 listeners.
 func (m *Model) IsEmpty() bool {
-	return len(m.HTTP) == 0 && len(m.TLSPassthrough) == 0
+	return len(m.HTTP) == 0 && len(m.TLSPassthrough) == 0 && len(m.L4) == 0
 }
 
 // IsHTTPListenerConfigured returns true if the model has any HTTP listeners.
@@ -626,6 +705,11 @@ func (m *Model) IsHTTPSListenerConfigured() bool {
 		}
 	}
 	return false
+}
+
+// IsL4ListenerConfigured returns true if the model has any L4 listeners.
+func (m *Model) IsL4ListenerConfigured() bool {
+	return len(m.L4) > 0
 }
 
 // IsHTTPSPortConfigured returns true if the model contains an HTTPS listener

--- a/operator/pkg/model/model_test.go
+++ b/operator/pkg/model/model_test.go
@@ -30,10 +30,23 @@ var testHTTPListener2 = HTTPListener{
 	Port: 80,
 }
 
+var testL4Listener = L4Listener{
+	Name:     "test-l4-listener",
+	Port:     8080,
+	Protocol: L4ProtocolTCP,
+}
+
+var testL4Listener2 = L4Listener{
+	Name:     "test-l4-listener2",
+	Port:     8081,
+	Protocol: L4ProtocolUDP,
+}
+
 func TestModel_GetListeners(t *testing.T) {
 	type fields struct {
 		HTTP []HTTPListener
 		TLS  []TLSPassthroughListener
+		L4   []L4Listener
 	}
 	tests := []struct {
 		name   string
@@ -45,8 +58,9 @@ func TestModel_GetListeners(t *testing.T) {
 			fields: fields{
 				HTTP: []HTTPListener{testHTTPListener, testHTTPListener2},
 				TLS:  []TLSPassthroughListener{testTLSListener, testTLSListener2},
+				L4:   []L4Listener{testL4Listener, testL4Listener2},
 			},
-			want: []Listener{&testHTTPListener, &testHTTPListener2, &testTLSListener, &testTLSListener2},
+			want: []Listener{&testHTTPListener, &testHTTPListener2, &testTLSListener, &testTLSListener2, &testL4Listener, &testL4Listener2},
 		},
 		{
 			name: "Only HTTP listeners",
@@ -63,6 +77,13 @@ func TestModel_GetListeners(t *testing.T) {
 			want: []Listener{&testTLSListener, &testTLSListener2},
 		},
 		{
+			name: "Only L4 listeners",
+			fields: fields{
+				L4: []L4Listener{testL4Listener, testL4Listener2},
+			},
+			want: []Listener{&testL4Listener, &testL4Listener2},
+		},
+		{
 			name:   "No listeners",
 			fields: fields{},
 			want:   nil,
@@ -73,6 +94,7 @@ func TestModel_GetListeners(t *testing.T) {
 			m := &Model{
 				HTTP:           tt.fields.HTTP,
 				TLSPassthrough: tt.fields.TLS,
+				L4:             tt.fields.L4,
 			}
 			if got := m.GetListeners(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Model.GetListeners() = %v, want %v", got, tt.want)

--- a/operator/pkg/model/translation/gateway-api/endpointslices.go
+++ b/operator/pkg/model/translation/gateway-api/endpointslices.go
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gateway_api
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/operator/pkg/model"
+	"github.com/cilium/cilium/pkg/shortener"
+)
+
+const (
+	EndpointSliceManagedByLabel   = "endpointslice.kubernetes.io/managed-by"
+	EndpointSliceManagedByValue   = "cilium-operator"
+	EndpointSliceServiceNameLabel = "kubernetes.io/service-name"
+	BackendServiceAnnotation      = "gateway.cilium.io/backend-service"
+	BackendPortAnnotation         = "gateway.cilium.io/backend-port"
+	EndpointSliceWeightAnnotation = "service.cilium.io/weight"
+	endpointSliceFamilySuffixIPv4 = "ipv4"
+	endpointSliceFamilySuffixIPv6 = "ipv6"
+)
+
+// desiredL4EndpointSlices builds skeleton EndpointSlices per (backend Service,
+// backendRef.port, IP family). Listeners/routes sharing that tuple are merged
+// into one slice with one Ports entry per listener; endpointSliceReconciler
+// later resolves the numeric Port and populates .endpoints.
+func (t *gatewayAPITranslator) desiredL4EndpointSlices(listeners []model.L4Listener, source *model.FullyQualifiedResource, lbSvc *corev1.Service) []*discoveryv1.EndpointSlice {
+	if len(listeners) == 0 || source == nil || lbSvc == nil {
+		return nil
+	}
+
+	families := enabledAddressTypes(lbSvc)
+	if len(families) == 0 {
+		return nil
+	}
+
+	ownerRef := metav1.OwnerReference{
+		APIVersion: gatewayv1.GroupVersion.String(),
+		Kind:       source.Kind,
+		Name:       source.Name,
+		UID:        types.UID(source.UID),
+		Controller: ptr.To(true),
+	}
+	shortGw := shortener.ShortenK8sResourceName(source.Name)
+	svcName := lbSvc.Name
+
+	type groupKey struct {
+		backendNs   string
+		backendName string
+		backendPort uint32
+		protocol    corev1.Protocol
+		family      discoveryv1.AddressType
+	}
+	type group struct {
+		key      groupKey
+		backend  model.Backend
+		listener model.L4Listener
+		ports    []discoveryv1.EndpointPort
+		seenPort map[string]struct{}
+	}
+
+	groups := map[groupKey]*group{}
+	var order []groupKey
+
+	for _, l := range listeners {
+		listener := l
+		portName := listenerPortName(listener)
+		protocol := corev1.ProtocolTCP
+		if listener.GetProtocol() == model.L4ProtocolUDP {
+			protocol = corev1.ProtocolUDP
+		}
+		listenerPort := int32(listener.GetPort())
+
+		for _, route := range listener.Routes {
+			for _, backend := range route.Backends {
+				b := backend
+				backendPort := backendTargetPort(listener, b)
+
+				for _, family := range families {
+					k := groupKey{
+						backendNs:   b.Namespace,
+						backendName: b.Name,
+						backendPort: backendPort,
+						protocol:    protocol,
+						family:      family,
+					}
+					g, ok := groups[k]
+					if !ok {
+						g = &group{
+							key:      k,
+							backend:  b,
+							listener: listener,
+							seenPort: map[string]struct{}{},
+						}
+						groups[k] = g
+						order = append(order, k)
+					}
+					if _, dup := g.seenPort[portName]; dup {
+						continue
+					}
+					g.seenPort[portName] = struct{}{}
+					g.ports = append(g.ports, discoveryv1.EndpointPort{
+						Name:     ptr.To(portName),
+						Port:     ptr.To(listenerPort),
+						Protocol: ptr.To(protocol),
+					})
+				}
+			}
+		}
+	}
+
+	slicesOut := make([]*discoveryv1.EndpointSlice, 0, len(order))
+	for _, k := range order {
+		g := groups[k]
+		// Stable order so mergeEndpointPorts pairs existing/desired by index.
+		sort.SliceStable(g.ports, func(i, j int) bool {
+			return ptr.Deref(g.ports[i].Name, "") < ptr.Deref(g.ports[j].Name, "")
+		})
+		slicesOut = append(slicesOut, buildEndpointSlice(buildEPSArgs{
+			svcName:     svcName,
+			gwShort:     shortGw,
+			namespace:   source.Namespace,
+			backend:     g.backend,
+			family:      g.key.family,
+			backendPort: g.key.backendPort,
+			protocol:    g.key.protocol,
+			ports:       g.ports,
+			ownerRef:    ownerRef,
+		}))
+	}
+
+	sort.SliceStable(slicesOut, func(i, j int) bool { return slicesOut[i].Name < slicesOut[j].Name })
+	return slicesOut
+}
+
+type buildEPSArgs struct {
+	svcName     string
+	gwShort     string
+	namespace   string
+	backend     model.Backend
+	family      discoveryv1.AddressType
+	backendPort uint32
+	protocol    corev1.Protocol
+	ports       []discoveryv1.EndpointPort
+	ownerRef    metav1.OwnerReference
+}
+
+func buildEndpointSlice(args buildEPSArgs) *discoveryv1.EndpointSlice {
+	familySuffix := endpointSliceFamilySuffixIPv4
+	if args.family == discoveryv1.AddressTypeIPv6 {
+		familySuffix = endpointSliceFamilySuffixIPv6
+	}
+
+	hash := backendHash(args.backend, args.backendPort, args.protocol)
+	rawName := fmt.Sprintf("%s-%s-%s", args.svcName, hash, familySuffix)
+	name := shortener.ShortenK8sResourceName(rawName)
+
+	annotations := map[string]string{
+		BackendServiceAnnotation: args.backend.Namespace + "/" + args.backend.Name,
+		BackendPortAnnotation:    strconv.FormatUint(uint64(args.backendPort), 10),
+	}
+	if w := normalizedWeight(args.backend.Weight); w != nil {
+		annotations[EndpointSliceWeightAnnotation] = strconv.FormatInt(int64(*w), 10)
+	}
+
+	return &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: args.namespace,
+			Labels: map[string]string{
+				EndpointSliceServiceNameLabel: args.svcName,
+				EndpointSliceManagedByLabel:   EndpointSliceManagedByValue,
+				gatewayNameLabel:              args.gwShort,
+			},
+			Annotations:     annotations,
+			OwnerReferences: []metav1.OwnerReference{args.ownerRef},
+		},
+		AddressType: args.family,
+		Ports:       args.ports,
+		Endpoints:   []discoveryv1.Endpoint{},
+	}
+}
+
+// listenerPortName mirrors the ServicePort.Name produced by toServicePorts.
+func listenerPortName(l model.L4Listener) string {
+	if l.GetProtocol() == model.L4ProtocolUDP {
+		return fmt.Sprintf("port-%d-udp", l.GetPort())
+	}
+	return fmt.Sprintf("port-%d", l.GetPort())
+}
+
+// backendTargetPort returns the port on the backend Pods. If unset on the
+// backendRef, the listener port is used.
+func backendTargetPort(listener model.L4Listener, b model.Backend) uint32 {
+	if b.Port != nil && b.Port.Port != 0 {
+		return b.Port.Port
+	}
+	return listener.Port
+}
+
+func enabledAddressTypes(svc *corev1.Service) []discoveryv1.AddressType {
+	if svc == nil {
+		return nil
+	}
+	if len(svc.Spec.IPFamilies) == 0 {
+		return []discoveryv1.AddressType{discoveryv1.AddressTypeIPv4}
+	}
+	res := make([]discoveryv1.AddressType, 0, len(svc.Spec.IPFamilies))
+	for _, f := range svc.Spec.IPFamilies {
+		switch f {
+		case corev1.IPv4Protocol:
+			res = append(res, discoveryv1.AddressTypeIPv4)
+		case corev1.IPv6Protocol:
+			res = append(res, discoveryv1.AddressTypeIPv6)
+		}
+	}
+	return res
+}
+
+// backendHash keys the slice name on (backend Service, backendRef.port,
+// protocol) so listeners/routes sharing that tuple share a slice, while TCP and
+// UDP for the same backend/port resolve to distinct slices.
+func backendHash(b model.Backend, port uint32, protocol corev1.Protocol) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "%s/%s|%d|%s", b.Namespace, b.Name, port, protocol)
+	return hex.EncodeToString(h.Sum(nil))[:8]
+}
+
+// normalizedWeight caps Gateway API weight (0..1_000_000) to uint16, the range
+// honored by service.cilium.io/weight (cilium/cilium#46061).
+func normalizedWeight(w *int32) *uint16 {
+	if w == nil {
+		return nil
+	}
+	return ptr.To(uint16(min(*w, 65535)))
+}

--- a/operator/pkg/model/translation/gateway-api/endpointslices_test.go
+++ b/operator/pkg/model/translation/gateway-api/endpointslices_test.go
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gateway_api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/cilium/cilium/operator/pkg/model"
+)
+
+func testL4Source() *model.FullyQualifiedResource {
+	return &model.FullyQualifiedResource{
+		Name:      "my-gateway",
+		Namespace: "default",
+		Kind:      "Gateway",
+		UID:       "uid-123",
+	}
+}
+
+func testLBService(families ...corev1.IPFamily) *corev1.Service {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cilium-gateway-my-gateway",
+			Namespace: "default",
+		},
+	}
+	svc.Spec.IPFamilies = families
+	return svc
+}
+
+func tcpListener(port uint32, routes ...model.L4Route) model.L4Listener {
+	return model.L4Listener{
+		Name:     "tcp",
+		Port:     port,
+		Protocol: model.L4ProtocolTCP,
+		Routes:   routes,
+	}
+}
+
+func udpListener(port uint32, routes ...model.L4Route) model.L4Listener {
+	return model.L4Listener{
+		Name:     "udp",
+		Port:     port,
+		Protocol: model.L4ProtocolUDP,
+		Routes:   routes,
+	}
+}
+
+func Test_desiredL4EndpointSlices_emptyInputs(t *testing.T) {
+	trans := &gatewayAPITranslator{}
+
+	tests := []struct {
+		name      string
+		listeners []model.L4Listener
+		source    *model.FullyQualifiedResource
+		lbSvc     *corev1.Service
+	}{
+		{name: "no listeners", listeners: nil, source: testL4Source(), lbSvc: testLBService()},
+		{name: "nil source", listeners: []model.L4Listener{tcpListener(8080)}, source: nil, lbSvc: testLBService()},
+		{name: "nil lbSvc", listeners: []model.L4Listener{tcpListener(8080)}, source: testL4Source(), lbSvc: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := trans.desiredL4EndpointSlices(tt.listeners, tt.source, tt.lbSvc)
+			assert.Nil(t, got)
+		})
+	}
+}
+
+func Test_desiredL4EndpointSlices_singleTCP(t *testing.T) {
+	trans := &gatewayAPITranslator{}
+
+	listeners := []model.L4Listener{
+		tcpListener(8080, model.L4Route{
+			Name: "tcp-route",
+			Backends: []model.Backend{
+				{Name: "echo", Namespace: "default", Port: &model.BackendPort{Port: 9090}},
+			},
+		}),
+	}
+
+	got := trans.desiredL4EndpointSlices(listeners, testL4Source(), testLBService(corev1.IPv4Protocol))
+	require.Len(t, got, 1)
+
+	eps := got[0]
+	assert.Equal(t, "default", eps.Namespace)
+	assert.Equal(t, discoveryv1.AddressTypeIPv4, eps.AddressType)
+	assert.Empty(t, eps.Endpoints)
+
+	// Labels
+	assert.Equal(t, "cilium-gateway-my-gateway", eps.Labels[EndpointSliceServiceNameLabel])
+	assert.Equal(t, EndpointSliceManagedByValue, eps.Labels[EndpointSliceManagedByLabel])
+	assert.NotEmpty(t, eps.Labels[gatewayNameLabel])
+
+	// Annotations encode the backend service/port targeting.
+	assert.Equal(t, "default/echo", eps.Annotations[BackendServiceAnnotation])
+	assert.Equal(t, "9090", eps.Annotations[BackendPortAnnotation])
+
+	// OwnerReference points back at the Gateway.
+	require.Len(t, eps.OwnerReferences, 1)
+	owner := eps.OwnerReferences[0]
+	assert.Equal(t, "Gateway", owner.Kind)
+	assert.Equal(t, "my-gateway", owner.Name)
+	assert.True(t, ptr.Deref(owner.Controller, false))
+
+	// One port entry; listener port exposed, protocol TCP, name matches ServicePort.
+	require.Len(t, eps.Ports, 1)
+	assert.Equal(t, "port-8080", ptr.Deref(eps.Ports[0].Name, ""))
+	assert.Equal(t, int32(8080), ptr.Deref(eps.Ports[0].Port, 0))
+	assert.Equal(t, corev1.ProtocolTCP, ptr.Deref(eps.Ports[0].Protocol, ""))
+}
+
+func Test_desiredL4EndpointSlices_dualStack(t *testing.T) {
+	trans := &gatewayAPITranslator{}
+
+	listeners := []model.L4Listener{
+		tcpListener(8080, model.L4Route{
+			Backends: []model.Backend{{Name: "echo", Namespace: "default", Port: &model.BackendPort{Port: 9090}}},
+		}),
+	}
+
+	got := trans.desiredL4EndpointSlices(listeners, testL4Source(), testLBService(corev1.IPv4Protocol, corev1.IPv6Protocol))
+	require.Len(t, got, 2)
+
+	families := map[discoveryv1.AddressType]bool{}
+	for _, eps := range got {
+		families[eps.AddressType] = true
+	}
+	assert.True(t, families[discoveryv1.AddressTypeIPv4])
+	assert.True(t, families[discoveryv1.AddressTypeIPv6])
+	// Distinct names per family.
+	assert.NotEqual(t, got[0].Name, got[1].Name)
+}
+
+func Test_desiredL4EndpointSlices_tcpAndUDPSamePortDistinctSlices(t *testing.T) {
+	trans := &gatewayAPITranslator{}
+
+	backend := model.Backend{Name: "echo", Namespace: "default", Port: &model.BackendPort{Port: 9090}}
+	listeners := []model.L4Listener{
+		tcpListener(8080, model.L4Route{Backends: []model.Backend{backend}}),
+		udpListener(8080, model.L4Route{Backends: []model.Backend{backend}}),
+	}
+
+	got := trans.desiredL4EndpointSlices(listeners, testL4Source(), testLBService(corev1.IPv4Protocol))
+	require.Len(t, got, 2)
+
+	protocols := map[corev1.Protocol]bool{}
+	for _, eps := range got {
+		require.Len(t, eps.Ports, 1)
+		protocols[ptr.Deref(eps.Ports[0].Protocol, "")] = true
+	}
+	assert.True(t, protocols[corev1.ProtocolTCP])
+	assert.True(t, protocols[corev1.ProtocolUDP])
+	assert.NotEqual(t, got[0].Name, got[1].Name, "TCP and UDP for same backend/port must not share a slice")
+}
+
+func Test_desiredL4EndpointSlices_mergeListenersSharingBackendTuple(t *testing.T) {
+	trans := &gatewayAPITranslator{}
+
+	backend := model.Backend{Name: "echo", Namespace: "default", Port: &model.BackendPort{Port: 9090}}
+	// Two listeners on different ports route to the same backend Service+port.
+	listeners := []model.L4Listener{
+		tcpListener(8080, model.L4Route{Backends: []model.Backend{backend}}),
+		tcpListener(8081, model.L4Route{Backends: []model.Backend{backend}}),
+	}
+
+	got := trans.desiredL4EndpointSlices(listeners, testL4Source(), testLBService(corev1.IPv4Protocol))
+	require.Len(t, got, 1, "listeners sharing backend tuple merge into one slice")
+
+	// One Ports entry per listener, sorted by name.
+	require.Len(t, got[0].Ports, 2)
+	assert.Equal(t, "port-8080", ptr.Deref(got[0].Ports[0].Name, ""))
+	assert.Equal(t, "port-8081", ptr.Deref(got[0].Ports[1].Name, ""))
+}
+
+func Test_desiredL4EndpointSlices_dedupSamePortName(t *testing.T) {
+	trans := &gatewayAPITranslator{}
+
+	backend := model.Backend{Name: "echo", Namespace: "default", Port: &model.BackendPort{Port: 9090}}
+	// Same listener port referenced via two routes -> single Ports entry.
+	listeners := []model.L4Listener{
+		tcpListener(8080,
+			model.L4Route{Backends: []model.Backend{backend}},
+			model.L4Route{Backends: []model.Backend{backend}},
+		),
+	}
+
+	got := trans.desiredL4EndpointSlices(listeners, testL4Source(), testLBService(corev1.IPv4Protocol))
+	require.Len(t, got, 1)
+	require.Len(t, got[0].Ports, 1, "duplicate port name is deduped")
+}
+
+func Test_desiredL4EndpointSlices_weightAnnotation(t *testing.T) {
+	trans := &gatewayAPITranslator{}
+
+	tests := []struct {
+		name      string
+		weight    *int32
+		wantSet   bool
+		wantValue string
+	}{
+		{name: "weight set", weight: ptr.To(int32(50)), wantSet: true, wantValue: "50"},
+		{name: "weight unset", weight: nil, wantSet: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			listeners := []model.L4Listener{
+				tcpListener(8080, model.L4Route{
+					Backends: []model.Backend{{Name: "echo", Namespace: "default", Port: &model.BackendPort{Port: 9090}, Weight: tt.weight}},
+				}),
+			}
+
+			got := trans.desiredL4EndpointSlices(listeners, testL4Source(), testLBService(corev1.IPv4Protocol))
+			require.Len(t, got, 1)
+			value, ok := got[0].Annotations[EndpointSliceWeightAnnotation]
+			assert.Equal(t, tt.wantSet, ok)
+			assert.Equal(t, tt.wantValue, value)
+		})
+	}
+}
+
+func Test_desiredL4EndpointSlices_noEnabledFamilies(t *testing.T) {
+	trans := &gatewayAPITranslator{}
+
+	svc := testLBService()
+	// An unrecognized family yields no address types.
+	svc.Spec.IPFamilies = []corev1.IPFamily{corev1.IPFamily("bogus")}
+
+	listeners := []model.L4Listener{
+		tcpListener(8080, model.L4Route{Backends: []model.Backend{{Name: "echo", Namespace: "default"}}}),
+	}
+
+	got := trans.desiredL4EndpointSlices(listeners, testL4Source(), svc)
+	assert.Nil(t, got)
+}
+
+func Test_listenerPortName(t *testing.T) {
+	assert.Equal(t, "port-8080", listenerPortName(tcpListener(8080)))
+	assert.Equal(t, "port-53-udp", listenerPortName(udpListener(53)))
+}
+
+func Test_backendTargetPort(t *testing.T) {
+	l := tcpListener(8080)
+
+	// Explicit backend port wins.
+	assert.Equal(t, uint32(9090), backendTargetPort(l, model.Backend{Port: &model.BackendPort{Port: 9090}}))
+	// Unset backend port falls back to listener port.
+	assert.Equal(t, uint32(8080), backendTargetPort(l, model.Backend{}))
+	// Zero backend port falls back to listener port.
+	assert.Equal(t, uint32(8080), backendTargetPort(l, model.Backend{Port: &model.BackendPort{Port: 0}}))
+}
+
+func Test_enabledAddressTypes(t *testing.T) {
+	tests := []struct {
+		name string
+		svc  *corev1.Service
+		want []discoveryv1.AddressType
+	}{
+		{name: "nil svc", svc: nil, want: nil},
+		{name: "default to IPv4", svc: testLBService(), want: []discoveryv1.AddressType{discoveryv1.AddressTypeIPv4}},
+		{name: "IPv4 only", svc: testLBService(corev1.IPv4Protocol), want: []discoveryv1.AddressType{discoveryv1.AddressTypeIPv4}},
+		{name: "IPv6 only", svc: testLBService(corev1.IPv6Protocol), want: []discoveryv1.AddressType{discoveryv1.AddressTypeIPv6}},
+		{name: "dual stack", svc: testLBService(corev1.IPv4Protocol, corev1.IPv6Protocol), want: []discoveryv1.AddressType{discoveryv1.AddressTypeIPv4, discoveryv1.AddressTypeIPv6}},
+		{name: "unknown family dropped", svc: testLBService(corev1.IPFamily("bogus")), want: []discoveryv1.AddressType{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, enabledAddressTypes(tt.svc))
+		})
+	}
+}
+
+func Test_backendHash(t *testing.T) {
+	b := model.Backend{Name: "echo", Namespace: "default"}
+
+	h := backendHash(b, 9090, corev1.ProtocolTCP)
+	assert.Len(t, h, 8)
+	// Deterministic.
+	assert.Equal(t, h, backendHash(b, 9090, corev1.ProtocolTCP))
+	// Protocol differentiates.
+	assert.NotEqual(t, h, backendHash(b, 9090, corev1.ProtocolUDP))
+	// Port differentiates.
+	assert.NotEqual(t, h, backendHash(b, 9091, corev1.ProtocolTCP))
+	// Backend identity differentiates.
+	assert.NotEqual(t, h, backendHash(model.Backend{Name: "other", Namespace: "default"}, 9090, corev1.ProtocolTCP))
+}
+
+func Test_normalizedWeight(t *testing.T) {
+	assert.Nil(t, normalizedWeight(nil))
+	assert.Equal(t, uint16(0), ptr.Deref(normalizedWeight(ptr.To(int32(0))), 1))
+	assert.Equal(t, uint16(50), ptr.Deref(normalizedWeight(ptr.To(int32(50))), 0))
+	// Capped to uint16 max.
+	assert.Equal(t, uint16(65535), ptr.Deref(normalizedWeight(ptr.To(int32(1_000_000))), 0))
+}
+
+func Test_buildEndpointSlice_familySuffix(t *testing.T) {
+	args := buildEPSArgs{
+		svcName:     "cilium-gateway-my-gateway",
+		gwShort:     "my-gateway",
+		namespace:   "default",
+		backend:     model.Backend{Name: "echo", Namespace: "default"},
+		backendPort: 9090,
+		protocol:    corev1.ProtocolTCP,
+		ownerRef:    metav1.OwnerReference{Kind: "Gateway"},
+	}
+
+	v4 := buildEndpointSlice(func() buildEPSArgs { a := args; a.family = discoveryv1.AddressTypeIPv4; return a }())
+	v6 := buildEndpointSlice(func() buildEPSArgs { a := args; a.family = discoveryv1.AddressTypeIPv6; return a }())
+
+	assert.Contains(t, v4.Name, "ipv4")
+	assert.Contains(t, v6.Name, "ipv6")
+	assert.NotEqual(t, v4.Name, v6.Name)
+	assert.Equal(t, discoveryv1.AddressTypeIPv4, v4.AddressType)
+	assert.Equal(t, discoveryv1.AddressTypeIPv6, v6.AddressType)
+}

--- a/operator/pkg/model/translation/gateway-api/testdata/tcproute_basic/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/tcproute_basic/config-input.yaml
@@ -1,0 +1,12 @@
+cluster_config:
+  idle_timeout_seconds: 60
+host_network_config: {}
+ip_config:
+  ipv4_enabled: true
+  ipv6_enabled: true
+listener_config:
+  stream_idle_timeout_seconds: 300
+original_ip_detection_config: {}
+route_config:
+  host_name_suffix_match: true
+secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/tcproute_basic/input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/tcproute_basic/input.yaml
@@ -1,0 +1,16 @@
+l4:
+- name: prod-tcp-gw
+  port: 80
+  protocol: TCP
+  routes:
+  - backends:
+    - name: my-service
+      namespace: default
+      port:
+        port: 8080
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: my-gateway
+    namespace: default
+    version: v1

--- a/operator/pkg/model/translation/gateway-api/testdata/tcproute_basic/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/tcproute_basic/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: my-gateway
+    io.cilium.gateway/owning-gateway: my-gateway
+  name: cilium-gateway-my-gateway
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: my-gateway
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/testdata/udproute_basic/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/udproute_basic/config-input.yaml
@@ -1,0 +1,12 @@
+cluster_config:
+  idle_timeout_seconds: 60
+host_network_config: {}
+ip_config:
+  ipv4_enabled: true
+  ipv6_enabled: true
+listener_config:
+  stream_idle_timeout_seconds: 300
+original_ip_detection_config: {}
+route_config:
+  host_name_suffix_match: true
+secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/udproute_basic/input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/udproute_basic/input.yaml
@@ -1,0 +1,16 @@
+l4:
+- name: prod-udp-gw
+  port: 53
+  protocol: UDP
+  routes:
+  - backends:
+    - name: my-dns
+      namespace: default
+      port:
+        port: 5353
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: my-gateway
+    namespace: default
+    version: v1

--- a/operator/pkg/model/translation/gateway-api/testdata/udproute_basic/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/udproute_basic/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: my-gateway
+    io.cilium.gateway/owning-gateway: my-gateway
+  name: cilium-gateway-my-gateway
+  namespace: default
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: my-gateway
+    uid: ""
+spec:
+  ports:
+  - name: port-53-udp
+    port: 53
+    protocol: UDP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/translator.go
+++ b/operator/pkg/model/translation/gateway-api/translator.go
@@ -27,8 +27,10 @@ var _ translation.Translator = (*gatewayAPITranslator)(nil)
 const (
 	CiliumGatewayPrefix = "cilium-gateway-"
 	// Deprecated: owningGatewayLabel will be removed later in favour of gatewayNameLabel
-	owningGatewayLabel = "io.cilium.gateway/owning-gateway"
-	gatewayNameLabel   = "gateway.networking.k8s.io/gateway-name"
+	owningGatewayLabel    = "io.cilium.gateway/owning-gateway"
+	gatewayNameLabel      = "gateway.networking.k8s.io/gateway-name"
+	lbAlgorithmAnnotation = "service.cilium.io/lb-algorithm"
+	lbAlgorithmMaglev     = "maglev"
 )
 
 type gatewayAPITranslator struct {
@@ -43,7 +45,7 @@ func NewTranslator(cecTranslator translation.CECTranslator, cfg translation.Conf
 	}
 }
 
-func (t *gatewayAPITranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, *discoveryv1.EndpointSlice, error) {
+func (t *gatewayAPITranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, []*discoveryv1.EndpointSlice, error) {
 	listeners := m.GetListeners()
 	if len(listeners) == 0 || len(listeners[0].GetSources()) == 0 {
 		return nil, nil, nil, fmt.Errorf("model source can't be empty, %d listeners", len(listeners))
@@ -57,7 +59,6 @@ func (t *gatewayAPITranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyC
 	// is the HTTPRoute.
 	var owner *model.FullyQualifiedResource
 
-	var ports []uint32
 	for _, l := range listeners {
 		sources := l.GetSources()
 		source = &sources[0]
@@ -68,7 +69,6 @@ func (t *gatewayAPITranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyC
 			owner = &sources[1]
 		}
 
-		ports = append(ports, l.GetPort())
 	}
 
 	if source == nil || source.Name == "" {
@@ -84,9 +84,13 @@ func (t *gatewayAPITranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyC
 	if source.Kind == "Service" {
 		generatedName = source.Name
 	}
-	cec, err := t.cecTranslator.Translate(source.Namespace, shortener.ShortenK8sResourceName(generatedName), m)
-	if err != nil {
-		return nil, nil, nil, err
+	var cec *ciliumv2.CiliumEnvoyConfig
+	var err error
+	if m.IsHTTPListenerConfigured() || m.IsTLSPassthroughListenerConfigured() {
+		cec, err = t.cecTranslator.Translate(source.Namespace, shortener.ShortenK8sResourceName(generatedName), m)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 	}
 
 	var allLabels, allAnnotations map[string]string
@@ -97,39 +101,51 @@ func (t *gatewayAPITranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyC
 		allLabels = mergeMap(allLabels, l.GetLabels())
 	}
 
-	if err = decorateCEC(cec, owner, allLabels, allAnnotations); err != nil {
-		return nil, nil, nil, err
+	if cec != nil {
+		if err = decorateCEC(cec, owner, allLabels, allAnnotations); err != nil {
+			return nil, nil, nil, err
+		}
 	}
 
-	eps := t.desiredEndpointSlice(source, allLabels, allAnnotations)
-	lbSvc := t.desiredService(listeners[0].GetService(), source, ports, allLabels, allAnnotations)
+	// Maglev is required for Cilium's datapath to honor backend weights.
+	// See cilium/cilium#46061.
+	if l4HasWeights(m.L4) {
+		allAnnotations = mergeMap(allAnnotations, map[string]string{
+			lbAlgorithmAnnotation: lbAlgorithmMaglev,
+		})
+	}
 
-	return cec, lbSvc, eps, err
+	servicePorts := t.toServicePorts(listeners)
+	lbSvc := t.desiredService(listeners[0].GetService(), source, servicePorts, allLabels, allAnnotations)
+
+	endpointSlices := t.desiredL4EndpointSlices(m.L4, source, lbSvc)
+	// L7 paths need a dummy EndpointSlice (see cilium/cilium#19262); L4 paths supply their own.
+	if len(endpointSlices) == 0 && (m.IsHTTPListenerConfigured() || m.IsTLSPassthroughListenerConfigured()) {
+		endpointSlices = t.desiredL7DummyEndpointSlice(source, allLabels, allAnnotations)
+	}
+
+	return cec, lbSvc, endpointSlices, nil
+}
+
+func l4HasWeights(listeners []model.L4Listener) bool {
+	for _, l := range listeners {
+		for _, route := range l.Routes {
+			for _, b := range route.Backends {
+				if b.Weight != nil {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 func (t *gatewayAPITranslator) desiredService(params *model.Service, owner *model.FullyQualifiedResource,
-	ports []uint32, labels, annotations map[string]string,
+	servicePorts []corev1.ServicePort, labels, annotations map[string]string,
 ) *corev1.Service {
 	if owner == nil {
 		return nil
 	}
-
-	uniquePorts := map[uint32]struct{}{}
-	for _, p := range ports {
-		uniquePorts[p] = struct{}{}
-	}
-
-	servicePorts := make([]corev1.ServicePort, 0, len(uniquePorts))
-	for p := range uniquePorts {
-		servicePorts = append(servicePorts, corev1.ServicePort{
-			Name:     fmt.Sprintf("port-%d", p),
-			Port:     int32(p),
-			Protocol: corev1.ProtocolTCP,
-		})
-	}
-	slices.SortFunc(servicePorts, func(a, b corev1.ServicePort) int {
-		return int(a.Port) - int(b.Port)
-	})
 
 	shortenName := shortener.ShortenK8sResourceName(owner.Name)
 
@@ -153,7 +169,7 @@ func (t *gatewayAPITranslator) desiredService(params *model.Service, owner *mode
 			},
 		},
 		Spec: corev1.ServiceSpec{
-			Ports:                         t.toServicePorts(ports),
+			Ports:                         servicePorts,
 			Type:                          t.toServiceType(params),
 			ExternalTrafficPolicy:         t.toExternalTrafficPolicy(params),
 			LoadBalancerClass:             t.toLoadBalancerClass(params),
@@ -168,24 +184,78 @@ func (t *gatewayAPITranslator) desiredService(params *model.Service, owner *mode
 	return res
 }
 
-// toServicePorts returns a list of ServicePort objects from the given list of ports.
-func (t *gatewayAPITranslator) toServicePorts(ports []uint32) []corev1.ServicePort {
-	uniquePorts := map[uint32]struct{}{}
-	for _, p := range ports {
-		uniquePorts[p] = struct{}{}
+// toServicePorts returns a list of ServicePort objects from the given listeners.
+func (t *gatewayAPITranslator) toServicePorts(listeners []model.Listener) []corev1.ServicePort {
+	type portProtocols struct {
+		tcp bool
+		udp bool
 	}
 
-	servicePorts := make([]corev1.ServicePort, 0, len(uniquePorts))
-	for p := range uniquePorts {
+	byPort := map[uint32]portProtocols{}
+	for _, l := range listeners {
+		if l == nil {
+			continue
+		}
+		port := l.GetPort()
+		protos := byPort[port]
+		switch l.GetProtocol() {
+		case model.L4ProtocolUDP:
+			protos.udp = true
+		default:
+			protos.tcp = true
+		}
+		byPort[port] = protos
+	}
+
+	type portProtocol struct {
+		port  uint32
+		proto corev1.Protocol
+	}
+
+	entries := make([]portProtocol, 0, len(byPort))
+	for port, protos := range byPort {
+		if protos.tcp {
+			entries = append(entries, portProtocol{
+				port:  port,
+				proto: corev1.ProtocolTCP,
+			})
+		}
+		if protos.udp {
+			entries = append(entries, portProtocol{
+				port:  port,
+				proto: corev1.ProtocolUDP,
+			})
+		}
+	}
+
+	slices.SortFunc(entries, func(a, b portProtocol) int {
+		if a.port != b.port {
+			if a.port < b.port {
+				return -1
+			}
+			return 1
+		}
+		if a.proto == b.proto {
+			return 0
+		}
+		if a.proto == corev1.ProtocolTCP {
+			return -1
+		}
+		return 1
+	})
+
+	servicePorts := make([]corev1.ServicePort, 0, len(entries))
+	for _, entry := range entries {
+		name := fmt.Sprintf("port-%d", entry.port)
+		if entry.proto == corev1.ProtocolUDP {
+			name = fmt.Sprintf("port-%d-udp", entry.port)
+		}
 		servicePorts = append(servicePorts, corev1.ServicePort{
-			Name:     fmt.Sprintf("port-%d", p),
-			Port:     int32(p),
-			Protocol: corev1.ProtocolTCP,
+			Name:     name,
+			Port:     int32(entry.port),
+			Protocol: entry.proto,
 		})
 	}
-	slices.SortFunc(servicePorts, func(a, b corev1.ServicePort) int {
-		return int(a.Port) - int(b.Port)
-	})
 
 	return servicePorts
 }
@@ -301,49 +371,51 @@ func (t *gatewayAPITranslator) toTrafficDistribution(params *model.Service) *str
 	return params.TrafficDistribution
 }
 
-func (t *gatewayAPITranslator) desiredEndpointSlice(owner *model.FullyQualifiedResource, labels, annotations map[string]string) *discoveryv1.EndpointSlice {
+func (t *gatewayAPITranslator) desiredL7DummyEndpointSlice(owner *model.FullyQualifiedResource, labels, annotations map[string]string) []*discoveryv1.EndpointSlice {
 	if owner == nil {
 		return nil
 	}
 	shortedName := shortener.ShortenK8sResourceName(owner.Name)
 
-	return &discoveryv1.EndpointSlice{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      shortener.ShortenK8sResourceName(CiliumGatewayPrefix + owner.Name),
-			Namespace: owner.Namespace,
-			Labels: mergeMap(map[string]string{
-				owningGatewayLabel:           shortedName,
-				gatewayNameLabel:             shortedName,
-				discoveryv1.LabelServiceName: shortener.ShortenK8sResourceName(CiliumGatewayPrefix + owner.Name),
-			}, labels),
-			Annotations: annotations,
-			OwnerReferences: []metav1.OwnerReference{
+	return []*discoveryv1.EndpointSlice{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      shortener.ShortenK8sResourceName(CiliumGatewayPrefix + owner.Name),
+				Namespace: owner.Namespace,
+				Labels: mergeMap(map[string]string{
+					owningGatewayLabel:           shortedName,
+					gatewayNameLabel:             shortedName,
+					discoveryv1.LabelServiceName: shortener.ShortenK8sResourceName(CiliumGatewayPrefix + owner.Name),
+				}, labels),
+				Annotations: annotations,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: gatewayv1beta1.GroupVersion.String(),
+						Kind:       owner.Kind,
+						Name:       owner.Name,
+						UID:        types.UID(owner.UID),
+						Controller: ptr.To(true),
+					},
+				},
+			},
+			AddressType: discoveryv1.AddressTypeIPv4,
+			Endpoints: []discoveryv1.Endpoint{
 				{
-					APIVersion: gatewayv1beta1.GroupVersion.String(),
-					Kind:       owner.Kind,
-					Name:       owner.Name,
-					UID:        types.UID(owner.UID),
-					Controller: ptr.To(true),
+					// This dummy endpoint is required as agent refuses to push service entry
+					// to the lb map when the service has no backends.
+					// Related github issue https://github.com/cilium/cilium/issues/19262
+					Addresses: []string{"192.192.192.192"}, // dummy
+					// Ready must be explicit: K8s treats nil as ready, but some
+					// consumers (e.g. GKE NEG controller) require it set. See #44611.
+					Conditions: discoveryv1.EndpointConditions{
+						Ready: ptr.To(true),
+					},
 				},
 			},
-		},
-		AddressType: discoveryv1.AddressTypeIPv4,
-		Endpoints: []discoveryv1.Endpoint{
-			{
-				// This dummy endpoint is required as agent refuses to push service entry
-				// to the lb map when the service has no backends.
-				// Related github issue https://github.com/cilium/cilium/issues/19262
-				Addresses: []string{"192.192.192.192"}, // dummy
-				// Ready must be explicit: K8s treats nil as ready, but some
-				// consumers (e.g. GKE NEG controller) require it set. See #44611.
-				Conditions: discoveryv1.EndpointConditions{
-					Ready: ptr.To(true),
+			Ports: []discoveryv1.EndpointPort{
+				{
+					Port: ptr.To[int32](9999), // dummy
 				},
-			},
-		},
-		Ports: []discoveryv1.EndpointPort{
-			{
-				Port: ptr.To[int32](9999), // dummy
 			},
 		},
 	}

--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -78,6 +78,8 @@ func Test_translator_Translate(t *testing.T) {
 		{name: "httproute_external_auth_http_with_tls"},
 		{name: "httproute_external_auth_mixed"},
 		{name: "httproute_external_auth_shared_and_no_auth"},
+		{name: "tcproute_basic"},
+		{name: "udproute_basic"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -90,18 +92,26 @@ func Test_translator_Translate(t *testing.T) {
 			input := &model.Model{}
 			readInput(t, fmt.Sprintf("testdata/%s/input.yaml", tt.name), input)
 			expectedCEC := &ciliumv2.CiliumEnvoyConfig{}
-			readOutput(t, fmt.Sprintf("testdata/%s/cec-output.yaml", tt.name), expectedCEC)
+			// An empty cec-output.yaml means no CEC is expected (L4-only paths,
+			// e.g. TCPRoute/UDPRoute, don't produce a CiliumEnvoyConfig).
+			cecYaml := readOutput(t, fmt.Sprintf("testdata/%s/cec-output.yaml", tt.name), expectedCEC)
+			var wantCEC *ciliumv2.CiliumEnvoyConfig
+			if cecYaml != "" {
+				wantCEC = expectedCEC
+			}
 			expectedService := &corev1.Service{}
 			readOutput(t, fmt.Sprintf("testdata/%s/service-output.yaml", tt.name), expectedService)
 
-			cec, svc, ep, err := trans.Translate(input)
+			cec, svc, eps, err := trans.Translate(input)
 
 			require.Equal(t, tt.wantErr, err != nil, "Error mismatch")
 			require.Equal(t, expectedService, svc, "Service mismatch")
-			require.NotNil(t, ep)
-			require.Equal(t, svc.Name, ep.Labels[discoveryv1.LabelServiceName], "EndpointSlice must carry the Service association label")
+			require.NotNil(t, eps)
+			for i, ep := range eps {
+				require.Equal(t, svc.Name, ep.Labels[discoveryv1.LabelServiceName], "EndpointSlice[%d] must carry the Service association label", i)
+			}
 
-			diffOutput := cmp.Diff(expectedCEC, cec, protocmp.Transform())
+			diffOutput := cmp.Diff(wantCEC, cec, protocmp.Transform())
 			if len(diffOutput) != 0 {
 				t.Errorf("CiliumEnvoyConfigs did not match:\n%s\n", diffOutput)
 			}
@@ -218,11 +228,13 @@ func Test_translator_Translate_HostNetwork(t *testing.T) {
 					expectedService := &corev1.Service{}
 					readOutput(t, fmt.Sprintf("testdata/%s/%s/service-output.yaml", tt.name, translatorCase.name), expectedService)
 
-					cec, svc, ep, err := trans.Translate(input)
+					cec, svc, eps, err := trans.Translate(input)
 					require.Equal(t, tt.wantErr, err != nil, "Error mismatch")
 					require.Equal(t, expectedService, svc, "Service mismatch")
-					require.NotNil(t, ep)
-					require.Equal(t, svc.Name, ep.Labels[discoveryv1.LabelServiceName], "EndpointSlice must carry the Service association label")
+					require.NotNil(t, eps)
+					for i, ep := range eps {
+						require.Equal(t, svc.Name, ep.Labels[discoveryv1.LabelServiceName], "EndpointSlice[%d] must carry the Service association label", i)
+					}
 
 					diffOutput := cmp.Diff(output, cec, protocmp.Transform())
 					if len(diffOutput) != 0 {
@@ -290,10 +302,145 @@ func Test_translator_Translate_WithXffNumTrustedHops(t *testing.T) {
 	}
 }
 
+func Test_translator_Translate_L4Only(t *testing.T) {
+	trans := &gatewayAPITranslator{
+		cecTranslator: translation.NewCECTranslator(translation.Config{}),
+	}
+	source := model.FullyQualifiedResource{
+		Name:      "test",
+		Namespace: "default",
+		Kind:      "Gateway",
+		UID:       "uid",
+	}
+	input := &model.Model{
+		L4: []model.L4Listener{
+			{
+				Name:     "tcp",
+				Sources:  []model.FullyQualifiedResource{source},
+				Port:     80,
+				Protocol: model.L4ProtocolTCP,
+			},
+			{
+				Name:     "udp",
+				Sources:  []model.FullyQualifiedResource{source},
+				Port:     53,
+				Protocol: model.L4ProtocolUDP,
+			},
+		},
+	}
+
+	cec, svc, _, err := trans.Translate(input)
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+	require.Nil(t, cec)
+	assert.ElementsMatch(t, []corev1.ServicePort{
+		{
+			Name:     "port-80",
+			Port:     80,
+			Protocol: corev1.ProtocolTCP,
+		},
+		{
+			Name:     "port-53-udp",
+			Port:     53,
+			Protocol: corev1.ProtocolUDP,
+		},
+	}, svc.Spec.Ports)
+}
+
+func Test_translator_Translate_L4MaglevWeightAnnotation(t *testing.T) {
+	trans := &gatewayAPITranslator{
+		cecTranslator: translation.NewCECTranslator(translation.Config{}),
+	}
+	source := model.FullyQualifiedResource{
+		Name:      "test",
+		Namespace: "default",
+		Kind:      "Gateway",
+		UID:       "uid",
+	}
+	l4 := func(backend model.Backend) []model.L4Listener {
+		return []model.L4Listener{
+			{
+				Name:     "tcp",
+				Sources:  []model.FullyQualifiedResource{source},
+				Port:     80,
+				Protocol: model.L4ProtocolTCP,
+				Routes: []model.L4Route{
+					{Backends: []model.Backend{backend}},
+				},
+			},
+		}
+	}
+
+	// Weighted L4 backend -> maglev annotation set (datapath honors weights).
+	input := &model.Model{L4: l4(model.Backend{
+		Name: "echo", Namespace: "default",
+		Port: &model.BackendPort{Port: 9090}, Weight: ptr.To(int32(50)),
+	})}
+	_, svc, eps, err := trans.Translate(input)
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+	assert.Equal(t, lbAlgorithmMaglev, svc.Annotations[lbAlgorithmAnnotation])
+	require.NotEmpty(t, eps, "weighted L4 backend must yield EndpointSlices")
+
+	// No weights -> no maglev annotation.
+	input = &model.Model{L4: l4(model.Backend{
+		Name: "echo", Namespace: "default", Port: &model.BackendPort{Port: 9090},
+	})}
+	_, svc, _, err = trans.Translate(input)
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+	_, ok := svc.Annotations[lbAlgorithmAnnotation]
+	assert.False(t, ok, "unweighted L4 backend must not set maglev annotation")
+}
+
+func Test_translator_toServicePorts_MixedProtocolsSamePort(t *testing.T) {
+	trans := &gatewayAPITranslator{}
+	listeners := []model.Listener{
+		&model.L4Listener{
+			Port:     80,
+			Protocol: model.L4ProtocolUDP,
+		},
+		&model.HTTPListener{
+			Port: 80,
+		},
+		&model.TLSPassthroughListener{
+			Port: 53,
+		},
+		&model.L4Listener{
+			Port:     53,
+			Protocol: model.L4ProtocolUDP,
+		},
+	}
+
+	servicePorts := trans.toServicePorts(listeners)
+	assert.Equal(t, []corev1.ServicePort{
+		{
+			Name:     "port-53",
+			Port:     53,
+			Protocol: corev1.ProtocolTCP,
+		},
+		{
+			Name:     "port-53-udp",
+			Port:     53,
+			Protocol: corev1.ProtocolUDP,
+		},
+		{
+			Name:     "port-80",
+			Port:     80,
+			Protocol: corev1.ProtocolTCP,
+		},
+		{
+			Name:     "port-80-udp",
+			Port:     80,
+			Protocol: corev1.ProtocolUDP,
+		},
+	}, servicePorts)
+}
+
 func Test_getService(t *testing.T) {
 	type args struct {
 		resource              *model.FullyQualifiedResource
-		allPorts              []uint32
+		allPorts              []corev1.ServicePort
 		labels                map[string]string
 		annotations           map[string]string
 		externalTrafficPolicy string
@@ -313,7 +460,13 @@ func Test_getService(t *testing.T) {
 					Kind:      "Gateway",
 					UID:       "57889650-380b-4c05-9a2e-3baee7fd5271",
 				},
-				allPorts:              []uint32{80},
+				allPorts: []corev1.ServicePort{
+					{
+						Name:     fmt.Sprintf("port-%d", 80),
+						Port:     80,
+						Protocol: corev1.ProtocolTCP,
+					},
+				},
 				externalTrafficPolicy: "Cluster",
 			},
 			want: &corev1.Service{
@@ -357,7 +510,7 @@ func Test_getService(t *testing.T) {
 					Kind:      "Gateway",
 					UID:       "41b82697-2d8d-4776-81b6-44d0bbac7faa",
 				},
-				allPorts:              []uint32{80},
+				allPorts:              []corev1.ServicePort{{Name: "port-80", Port: 80, Protocol: corev1.ProtocolTCP}},
 				externalTrafficPolicy: "Local",
 			},
 			want: &corev1.Service{
@@ -406,7 +559,7 @@ func Test_getService(t *testing.T) {
 	}
 }
 
-func Test_desiredEndpointSlice(t *testing.T) {
+func Test_desiredL7DummyEndpointSlice(t *testing.T) {
 	trans := &gatewayAPITranslator{}
 	owner := &model.FullyQualifiedResource{
 		Name:      "dummy-gateway",
@@ -416,9 +569,9 @@ func Test_desiredEndpointSlice(t *testing.T) {
 		UID:       "57889650-380b-4c05-9a2e-3baee7fd5271",
 	}
 
-	got := trans.desiredEndpointSlice(owner, nil, nil)
+	got := trans.desiredL7DummyEndpointSlice(owner, nil, nil)
 
-	require.Equal(t, &discoveryv1.EndpointSlice{
+	require.Equal(t, []*discoveryv1.EndpointSlice{{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cilium-gateway-dummy-gateway",
 			Namespace: "dummy-namespace",
@@ -449,7 +602,7 @@ func Test_desiredEndpointSlice(t *testing.T) {
 		Ports: []discoveryv1.EndpointPort{
 			{Port: ptr.To[int32](9999)},
 		},
-	}, got)
+	}}, got)
 }
 
 func Test_translator_Translate_ShortensCECName(t *testing.T) {

--- a/operator/pkg/model/translation/ingress/dedicated_ingress.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress.go
@@ -42,7 +42,7 @@ func NewDedicatedIngressTranslator(log *slog.Logger, cecTranslator translation.C
 	}
 }
 
-func (d *dedicatedIngressTranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, *discoveryv1.EndpointSlice, error) {
+func (d *dedicatedIngressTranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, []*discoveryv1.EndpointSlice, error) {
 	if m == nil || (len(m.HTTP) == 0 && len(m.TLSPassthrough) == 0) {
 		return nil, nil, nil, fmt.Errorf("model source can't be empty")
 	}
@@ -156,42 +156,44 @@ func (d *dedicatedIngressTranslator) getService(resource model.FullyQualifiedRes
 	}
 }
 
-func getEndpointSlice(resource model.FullyQualifiedResource) *discoveryv1.EndpointSlice {
-	return &discoveryv1.EndpointSlice{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      shortener.ShortenK8sResourceName(fmt.Sprintf("%s-%s", ciliumIngressPrefix, resource.Name)),
-			Namespace: resource.Namespace,
-			Labels: map[string]string{
-				ciliumIngressLabelKey:        "true",
-				discoveryv1.LabelServiceName: shortener.ShortenK8sResourceName(fmt.Sprintf("%s-%s", ciliumIngressPrefix, resource.Name)),
+func getEndpointSlice(resource model.FullyQualifiedResource) []*discoveryv1.EndpointSlice {
+	return []*discoveryv1.EndpointSlice{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      shortener.ShortenK8sResourceName(fmt.Sprintf("%s-%s", ciliumIngressPrefix, resource.Name)),
+				Namespace: resource.Namespace,
+				Labels: map[string]string{
+					ciliumIngressLabelKey:        "true",
+					discoveryv1.LabelServiceName: shortener.ShortenK8sResourceName(fmt.Sprintf("%s-%s", ciliumIngressPrefix, resource.Name)),
+				},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: slim_networkingv1.SchemeGroupVersion.String(),
+						Kind:       "Ingress",
+						Name:       resource.Name,
+						UID:        types.UID(resource.UID),
+						Controller: ptr.To(true),
+					},
+				},
 			},
-			OwnerReferences: []metav1.OwnerReference{
+			AddressType: discoveryv1.AddressTypeIPv4,
+			Endpoints: []discoveryv1.Endpoint{
 				{
-					APIVersion: slim_networkingv1.SchemeGroupVersion.String(),
-					Kind:       "Ingress",
-					Name:       resource.Name,
-					UID:        types.UID(resource.UID),
-					Controller: ptr.To(true),
+					// This dummy endpoint is required as agent refuses to push service entry
+					// to the lb map when the service has no backends.
+					// Related github issue https://github.com/cilium/cilium/issues/19262
+					Addresses: []string{"192.192.192.192"}, // dummy
+					// Ready must be explicit: K8s treats nil as ready, but some
+					// consumers (e.g. GKE NEG controller) require it set. See #44611.
+					Conditions: discoveryv1.EndpointConditions{
+						Ready: ptr.To(true),
+					},
 				},
 			},
-		},
-		AddressType: discoveryv1.AddressTypeIPv4,
-		Endpoints: []discoveryv1.Endpoint{
-			{
-				// This dummy endpoint is required as agent refuses to push service entry
-				// to the lb map when the service has no backends.
-				// Related github issue https://github.com/cilium/cilium/issues/19262
-				Addresses: []string{"192.192.192.192"}, // dummy
-				// Ready must be explicit: K8s treats nil as ready, but some
-				// consumers (e.g. GKE NEG controller) require it set. See #44611.
-				Conditions: discoveryv1.EndpointConditions{
-					Ready: ptr.To(true),
+			Ports: []discoveryv1.EndpointPort{
+				{
+					Port: ptr.To[int32](9999), // dummy
 				},
-			},
-		},
-		Ports: []discoveryv1.EndpointPort{
-			{
-				Port: ptr.To[int32](9999), // dummy
 			},
 		},
 	}

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
@@ -198,37 +198,39 @@ func Test_getEndpointForIngress(t *testing.T) {
 		UID:       "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
 	})
 
-	require.Equal(t, &discoveryv1.EndpointSlice{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "cilium-ingress-dummy-ingress",
-			Namespace: "dummy-namespace",
-			Labels: map[string]string{
-				"cilium.io/ingress":          "true",
-				discoveryv1.LabelServiceName: "cilium-ingress-dummy-ingress",
+	require.Equal(t, []*discoveryv1.EndpointSlice{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cilium-ingress-dummy-ingress",
+				Namespace: "dummy-namespace",
+				Labels: map[string]string{
+					"cilium.io/ingress":          "true",
+					discoveryv1.LabelServiceName: "cilium-ingress-dummy-ingress",
+				},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "networking.k8s.io/v1",
+						Kind:       "Ingress",
+						Name:       "dummy-ingress",
+						UID:        "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
+						Controller: ptr.To(true),
+					},
+				},
 			},
-			OwnerReferences: []metav1.OwnerReference{
+			AddressType: discoveryv1.AddressTypeIPv4,
+			Endpoints: []discoveryv1.Endpoint{
 				{
-					APIVersion: "networking.k8s.io/v1",
-					Kind:       "Ingress",
-					Name:       "dummy-ingress",
-					UID:        "d4bd3dc3-2ac5-4ab4-9dca-89c62c60177e",
-					Controller: ptr.To(true),
+					// This dummy endpoint is required as agent refuses to push service entry
+					// to the lb map when the service has no backends.
+					// Related github issue https://github.com/cilium/cilium/issues/19262
+					Addresses: []string{"192.192.192.192"}, // dummy
+					Conditions: discoveryv1.EndpointConditions{
+						Ready: ptr.To(true),
+					},
 				},
 			},
+			Ports: []discoveryv1.EndpointPort{{Port: ptr.To[int32](9999)}}, // dummy port
 		},
-		AddressType: discoveryv1.AddressTypeIPv4,
-		Endpoints: []discoveryv1.Endpoint{
-			{
-				// This dummy endpoint is required as agent refuses to push service entry
-				// to the lb map when the service has no backends.
-				// Related github issue https://github.com/cilium/cilium/issues/19262
-				Addresses: []string{"192.192.192.192"}, // dummy
-				Conditions: discoveryv1.EndpointConditions{
-					Ready: ptr.To(true),
-				},
-			},
-		},
-		Ports: []discoveryv1.EndpointPort{{Port: ptr.To[int32](9999)}}, // dummy port
 	}, res)
 }
 

--- a/operator/pkg/model/translation/types.go
+++ b/operator/pkg/model/translation/types.go
@@ -16,7 +16,7 @@ import (
 //
 // Different use cases (e.g. Ingress, Gateway API) can provide its own generation logic.
 type Translator interface {
-	Translate(model *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, *discoveryv1.EndpointSlice, error)
+	Translate(model *model.Model) (*ciliumv2.CiliumEnvoyConfig, *corev1.Service, []*discoveryv1.EndpointSlice, error)
 }
 
 // CECTranslator is the interface to take the model and generate required CiliumEnvoyConfig.

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -1214,6 +1214,10 @@ const (
 
 	GRPCRoute = "grpcRoute"
 
+	TCPRoute = "tcpRoute"
+
+	UDPRoute = "udpRoute"
+
 	Secret = "secret"
 
 	Nodes = "nodes"


### PR DESCRIPTION
This adds Gateway API operator support for TCPRoute and UDPRoute without relying on Envoy. The operator now reconciles L4 routes into LoadBalancer Services and operator-managed EndpointSlices consumed by Cilium’s service load-balancer, including backend weight propagation support.

The implementation also adds dedicated TCP/UDP route reconciliation, backend endpoint synchronization, route checks, translation support for L4 listeners, and automatic service annotations for Maglev-based load-balancing.

Fixes: #21929

```release-note
gateway-api: Add TCPRoute and UDPRoute support
```

This PR was prepared with AIL:1. AI assistance was used for implementation review, validation, and iterative feedback by the author and Cilium developers; the feature design and implementation were done by the author.

cc @mhofstetter, @youngnick 