### PR TITLE
ipam: Deflake TestMarkForReleaseNoAllocate

### DIFF
--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -104,12 +104,14 @@ func TestIPNotAvailableInPoolError(t *testing.T) {
 	assert.NotErrorIs(t, err, err2)
 }
 
-var testConfigurationCRD = &option.DaemonConfig{
-	EnableIPv4:              true,
-	EnableIPv6:              false,
-	EnableHealthChecking:    true,
-	EnableUnreachableRoutes: false,
-	IPAM:                    ipamOption.IPAMCRD,
+func testDaemonConfig() *option.DaemonConfig {
+	return &option.DaemonConfig{
+		EnableIPv4:              true,
+		EnableIPv6:              false,
+		EnableHealthChecking:    true,
+		EnableUnreachableRoutes: false,
+		IPAM:                    ipamOption.IPAMCRD,
+	}
 }
 
 func newFakeNodeStore(conf *option.DaemonConfig, t *testing.T) *nodeStore {
@@ -138,7 +140,7 @@ func TestMarkForReleaseNoAllocate(t *testing.T) {
 	}
 
 	fakeAddressing := fakenode.NewAddressing()
-	conf := testConfigurationCRD
+	conf := testDaemonConfig()
 	initNodeStore.Do(func() {}) // Ensure the real initNodeStore is not called
 	sharedNodeStore = newFakeNodeStore(conf, t)
 	sharedNodeStore.ownNode = cn
@@ -206,7 +208,7 @@ func TestAzureIPMasq(t *testing.T) {
 	}
 
 	fakeAddressing := fakenode.NewAddressing()
-	conf := testConfigurationCRD
+	conf := testDaemonConfig()
 	conf.IPAM = ipamOption.IPAMAzure
 	conf.EnableIPMasqAgent = true
 	ipMasqAgent := ipmasq.NewIPMasqAgent(hivetest.Logger(t), "", ipMasqMapDummy{})


### PR DESCRIPTION
TestMarkForReleaseNoAllocate and TestAzureIPMasq relies on a package level var as daemon configuration. But TestAzureIPMasq changes this config to set the Azure IPAM mode, while the
TestMarkForReleaseNoAllocate is expecting the CRD IPAM mode. This leads to flaky results when running TestMarkForReleaseNoAllocate after TestAzureIPMasq, because in *crdAllocator.buildAllocationResult the IPAM subsystem searches for a nonexistent Azure interface named "foo":

```
$ go test -trimpath -v ./pkg/ipam -run 'Test(MarkForReleaseNoAllocate|AzureIPMasq)$' -count=2 -failfast
    ...
--- PASS: TestAzureIPMasq (0.00s)
=== RUN   TestMarkForReleaseNoAllocate
    logger.go:256: time=2026-05-26T15:18:59.136+02:00 level=INFO source=github.com/cilium/cilium/pkg/ipam/ipam.go:194 msg="Initializing CRD-based IPAM"
    crd_test.go:164:
        	Error Trace:	github.com/cilium/cilium/pkg/ipam/crd_test.go:164
        	Error:      	Received unexpected error:
        	            	failed to associate IP 1.1.1.1 inside CiliumNode: unable to find ENI foo
        	Test:       	TestMarkForReleaseNoAllocate
--- FAIL: TestMarkForReleaseNoAllocate (0.00s)

```

Fix this by creating a new DaemonConfig struct for each test run.
