### PR TITLE
workflows: Update 6.6 LVH image

### DIFF
--- a/.github/actions/e2e/kernel-versions.yml
+++ b/.github/actions/e2e/kernel-versions.yml
@@ -6,7 +6,7 @@ kernels:
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
   6.1: '6.1-20260310.122539'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
-  6.6: '6.6-20260310.122539'
+  6.6: '6.6-20260525.014435'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
   6.12: '6.12-20260310.122539'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind

--- a/.github/actions/ginkgo/main-k8s-versions.yaml
+++ b/.github/actions/ginkgo/main-k8s-versions.yaml
@@ -22,7 +22,7 @@ include:
     # renovate: datasource=docker
     kube-image: "quay.io/cilium/kindest-node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "6.6-20260310.122539"
+    kernel: "6.6-20260525.014435"
     kernel-type: "oldstable"
 
   - k8s-version: "1.33"

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -146,7 +146,7 @@ jobs:
             # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
             "6.1") FULL_KERNEL="6.1-20260310.122539" ;;
             # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-            "6.6") FULL_KERNEL="6.6-20260310.122539" ;;
+            "6.6") FULL_KERNEL="6.6-20260525.014435" ;;
             # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
             "6.12") FULL_KERNEL="6.12-20260310.122539" ;;
             # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test


### PR DESCRIPTION
This commit updates only the 6.6 LVH image. The other image updates are blocked by a CI issue and need investigation. The new 6.6 kernel includes a big reduction of the complexity so it helps (me) if we can update it without waiting for the rest.

### Results

The Complexity workflow doesn't compare directly the main and PR LVH images, but we can compare numbers from a main run with numbers from this PR's workflow run. We're only showing programs above 200k instructions here for brevity.

#### Old LVH Image

| Collection/Program | Max |
| -- | -- |
| host/tail_handle_ipv6_from_netdev | $${\color{orange}633288}$$ (63.33%) for v6.6/1/0 |
| xdp/tail_lb_ipv6 | $${\color{orange}505426}$$ (50.54%) for v6.6/7/0 |
| xdp/tail_nodeport_nat_egress_ipv6 | 365801 (36.58%) for v6.6/6/0 |
| xdp/tail_nodeport_nat_ingress_ipv6 | 280151 (28.02%) for v6.6/1/0 |
| host/tail_handle_snat_fwd_ipv4 | 325727 (32.57%) for v6.1/3/2 |
| host/cil_to_netdev | 222059 (22.21%) for v6.6/2/3 |
| host/tail_handle_snat_fwd_ipv6 | 204973 (20.50%) for v5.15/8/3 |
| lxc/tail_handle_ipv6 | 202250 (20.23%) for v6.6/6/0 |

#### New LVH Image

| Collection/Program | Max |
| -- | -- |
| host/tail_handle_ipv6_from_netdev | $${\color{orange}515151}$$ (51.52%) for v5.15/1/0 |
| xdp/tail_lb_ipv6 | 422287 (42.23%) for v5.15/1/0 |
| xdp/tail_nodeport_nat_egress_ipv6 | 330819 (33.08%) for v6.6/6/0 |
| host/tail_handle_snat_fwd_ipv4 | 325727 (32.57%) for v6.1/3/2 |
| xdp/tail_nodeport_nat_ingress_ipv6 | 210354 (21.04%) for v5.15/1/0 |
| host/cil_to_netdev | 221965 (22.20%) for v5.15/2/3 |
| host/tail_handle_snat_fwd_ipv6 | 204973 (20.50%) for v5.15/8/3 |

As we can see, the overall complexity reduced. In addition, where we used to have v6.6 dominate the list of programs with the highest complexity, it now mostly disappeared from the list. The highest complexity numbers are now found on v5.15 and v6.1, where the kernel patch didn't land (yet :crossed_fingers:).