### PR TITLE
azure: Remove duplicate `GetInstance` call in per-instance resync

### DIFF
--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -385,17 +385,6 @@ func deriveGatewayIP(subnetIP netip.Addr) string {
 	return subnetIP.Next().String()
 }
 
-// GetInstances returns the list of all instances including all attached
-// interfaces as instanceMap
-func (c *Client) GetInstances(ctx context.Context, subnets ipamTypes.SubnetMap) (*ipamTypes.InstanceMap, error) {
-	networkInterfaces, err := c.ListAllNetworkInterfaces(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.ParseInterfacesIntoInstanceMap(networkInterfaces, subnets), nil
-}
-
 // ListAllNetworkInterfaces returns all network interfaces in the resource group
 // This is exposed to allow callers to fetch network interfaces once and parse them multiple times
 func (c *Client) ListAllNetworkInterfaces(ctx context.Context) ([]*armnetwork.Interface, error) {
@@ -425,24 +414,6 @@ func (c *Client) ParseInterfacesIntoInstanceMap(networkInterfaces []*armnetwork.
 	}
 
 	return instances
-}
-
-// GetInstance returns the interfaces of a given instance
-func (c *Client) GetInstance(ctx context.Context, subnets ipamTypes.SubnetMap, instanceID string) (*ipamTypes.Instance, error) {
-	resourceID, err := arm.ParseResourceID(instanceID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse instance ID %q", instanceID)
-	}
-	if strings.ToLower(resourceID.ResourceType.Type) != "virtualmachinescalesets/virtualmachines" {
-		return nil, fmt.Errorf("instance %q is not a virtual machine scale set instance", instanceID)
-	}
-
-	networkInterfaces, err := c.listVirtualMachineScaleSetVMNetworkInterfaces(ctx, resourceID.Parent.Name, resourceID.Name)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.ParseInterfacesIntoInstance(networkInterfaces, subnets), nil
 }
 
 // ListVMNetworkInterfaces returns all network interfaces for a specific VMSS instance

--- a/pkg/azure/api/mock/mock.go
+++ b/pkg/azure/api/mock/mock.go
@@ -25,8 +25,8 @@ type Operation int
 
 const (
 	AllOperations Operation = iota
-	GetInstance
-	GetInstances
+	ListVMNetworkInterfaces
+	ListAllNetworkInterfaces
 	GetVpcsAndSubnets
 	GetSubnetsByIDs
 	AssignPrivateIpAddressesVMSS
@@ -127,42 +127,6 @@ func (a *API) rateLimit() {
 	if delay := r.Delay(); delay != time.Duration(0) && delay != rate.InfDuration {
 		time.Sleep(delay)
 	}
-}
-
-func (a *API) GetInstance(ctx context.Context, subnets ipamTypes.SubnetMap, instanceID string) (*ipamTypes.Instance, error) {
-	a.rateLimit()
-	a.delaySim.Delay(GetInstance)
-
-	a.mutex.RLock()
-	defer a.mutex.RUnlock()
-
-	if err, ok := a.errors[GetInstance]; ok {
-		return nil, err
-	}
-
-	instance := ipamTypes.Instance{}
-	instance.Interfaces = map[string]ipamTypes.Interface{}
-	if err := a.instances.ForeachInterface(instanceID, func(instanceID, interfaceID string, iface ipamTypes.Interface) error {
-		instance.Interfaces[interfaceID] = iface
-		return nil
-	}); err != nil {
-		return nil, err
-	}
-	return instance.DeepCopy(), nil
-}
-
-func (a *API) GetInstances(ctx context.Context, subnets ipamTypes.SubnetMap) (*ipamTypes.InstanceMap, error) {
-	a.rateLimit()
-	a.delaySim.Delay(GetInstances)
-
-	a.mutex.RLock()
-	defer a.mutex.RUnlock()
-
-	if err, ok := a.errors[GetInstances]; ok {
-		return nil, err
-	}
-
-	return a.instances.DeepCopy(), nil
 }
 
 func (a *API) GetVpcsAndSubnets(ctx context.Context) (ipamTypes.VirtualNetworkMap, ipamTypes.SubnetMap, error) {
@@ -297,12 +261,12 @@ func (a *API) AssignPublicIPAddressesVM(ctx context.Context, instanceID string, 
 // The mock API uses instances directly rather than armnetwork.Interface objects
 func (a *API) ListAllNetworkInterfaces(ctx context.Context) ([]*armnetwork.Interface, error) {
 	a.rateLimit()
-	a.delaySim.Delay(GetInstances)
+	a.delaySim.Delay(ListAllNetworkInterfaces)
 
 	a.mutex.RLock()
 	defer a.mutex.RUnlock()
 
-	if err, ok := a.errors[GetInstances]; ok {
+	if err, ok := a.errors[ListAllNetworkInterfaces]; ok {
 		return nil, err
 	}
 
@@ -320,35 +284,43 @@ func (a *API) ParseInterfacesIntoInstanceMap(networkInterfaces []*armnetwork.Int
 	return a.instances.DeepCopy()
 }
 
-// ListVMNetworkInterfaces returns a dummy slice since mock doesn't use real network interfaces
-// The mock API uses instances directly rather than armnetwork.Interface objects
+// ListVMNetworkInterfaces returns a single sentinel armnetwork.Interface whose
+// ID carries the requested instanceID, so ParseInterfacesIntoInstance can
+// recover which instance to return without making another API call.
 func (a *API) ListVMNetworkInterfaces(ctx context.Context, instanceID string) ([]*armnetwork.Interface, error) {
 	a.rateLimit()
-	a.delaySim.Delay(GetInstance)
+	a.delaySim.Delay(ListVMNetworkInterfaces)
 
 	a.mutex.RLock()
 	defer a.mutex.RUnlock()
 
-	if err, ok := a.errors[GetInstance]; ok {
+	if err, ok := a.errors[ListVMNetworkInterfaces]; ok {
 		return nil, err
 	}
 
-	// Check if instance exists
 	if !a.instances.Exists(instanceID) {
 		return nil, fmt.Errorf("instance %s not found", instanceID)
 	}
 
-	// Return an empty slice - the mock doesn't use actual armnetwork.Interface objects
-	// ParseInterfacesIntoInstance will handle returning the mock instance
-	return []*armnetwork.Interface{}, nil
+	id := instanceID
+	return []*armnetwork.Interface{{ID: &id}}, nil
 }
 
-// ParseInterfacesIntoInstance ignores the input and returns the mock's instance
-// The mock API doesn't use real armnetwork.Interface objects
+// ParseInterfacesIntoInstance recovers the instanceID from the sentinel
+// produced by ListVMNetworkInterfaces and returns the mock's instance.
 func (a *API) ParseInterfacesIntoInstance(networkInterfaces []*armnetwork.Interface, subnets ipamTypes.SubnetMap) *ipamTypes.Instance {
 	a.mutex.RLock()
 	defer a.mutex.RUnlock()
-	// The instance will be populated by the caller based on the mock's data
-	// Return a basic structure that will be filled in
-	return &ipamTypes.Instance{Interfaces: map[string]ipamTypes.Interface{}}
+
+	instance := ipamTypes.Instance{Interfaces: map[string]ipamTypes.Interface{}}
+	if len(networkInterfaces) == 0 || networkInterfaces[0].ID == nil {
+		return &instance
+	}
+	instanceID := *networkInterfaces[0].ID
+
+	_ = a.instances.ForeachInterface(instanceID, func(_, interfaceID string, iface ipamTypes.Interface) error {
+		instance.Interfaces[interfaceID] = iface
+		return nil
+	})
+	return instance.DeepCopy()
 }

--- a/pkg/azure/api/mock/mock_test.go
+++ b/pkg/azure/api/mock/mock_test.go
@@ -23,8 +23,9 @@ func TestMock(t *testing.T) {
 	api := NewAPI([]*ipamTypes.Subnet{subnet}, []*ipamTypes.VirtualNetwork{{ID: "v-1"}})
 	require.NotNil(t, api)
 
-	instances, err := api.GetInstances(t.Context(), ipamTypes.SubnetMap{})
+	nics, err := api.ListAllNetworkInterfaces(t.Context())
 	require.NoError(t, err)
+	instances := api.ParseInterfacesIntoInstanceMap(nics, ipamTypes.SubnetMap{})
 	require.Equal(t, 0, instances.NumInstances())
 
 	vnets, subnets, err := api.GetVpcsAndSubnets(t.Context())
@@ -40,8 +41,9 @@ func TestMock(t *testing.T) {
 	resource.SetID(ifaceID)
 	instances.Update("vm1", resource.DeepCopy())
 	api.UpdateInstances(instances)
-	instances, err = api.GetInstances(t.Context(), ipamTypes.SubnetMap{})
+	nics, err = api.ListAllNetworkInterfaces(t.Context())
 	require.NoError(t, err)
+	instances = api.ParseInterfacesIntoInstanceMap(nics, ipamTypes.SubnetMap{})
 	require.Equal(t, 1, instances.NumInstances())
 	instances.ForeachInterface("", func(instanceID, interfaceID string, iface ipamTypes.Interface) error {
 		require.Equal(t, "vm1", instanceID)
@@ -51,8 +53,9 @@ func TestMock(t *testing.T) {
 
 	err = api.AssignPrivateIpAddressesVMSS(t.Context(), "vm1", "vmss1", "s-1", "eth0", 2)
 	require.NoError(t, err)
-	instances, err = api.GetInstances(t.Context(), ipamTypes.SubnetMap{})
+	nics, err = api.ListAllNetworkInterfaces(t.Context())
 	require.NoError(t, err)
+	instances = api.ParseInterfacesIntoInstanceMap(nics, ipamTypes.SubnetMap{})
 	require.Equal(t, 1, instances.NumInstances())
 	instances.ForeachInterface("", func(instanceID, interfaceID string, iface ipamTypes.Interface) error {
 		require.Equal(t, "vm1", instanceID)
@@ -85,8 +88,8 @@ func TestSetMockError(t *testing.T) {
 
 	mockError := errors.New("error")
 
-	api.SetMockError(GetInstances, mockError)
-	_, err := api.GetInstances(t.Context(), ipamTypes.SubnetMap{})
+	api.SetMockError(ListAllNetworkInterfaces, mockError)
+	_, err := api.ListAllNetworkInterfaces(t.Context())
 	require.ErrorIs(t, err, mockError)
 
 	api.SetMockError(GetVpcsAndSubnets, mockError)
@@ -105,6 +108,6 @@ func TestSetLimiter(t *testing.T) {
 	require.NotNil(t, api)
 
 	api.SetLimiter(10.0, 2)
-	_, err := api.GetInstances(t.Context(), ipamTypes.SubnetMap{})
+	_, err := api.ListAllNetworkInterfaces(t.Context())
 	require.NoError(t, err)
 }

--- a/pkg/azure/ipam/instances.go
+++ b/pkg/azure/ipam/instances.go
@@ -26,17 +26,14 @@ import (
 	"github.com/cilium/cilium/pkg/time"
 )
 
-// AzureAPI is the API surface used of the Azure API
+// AzureAPI is the API surface used of the Azure API.
 type AzureAPI interface {
-	GetInstance(ctx context.Context, subnets ipamTypes.SubnetMap, instanceID string) (*ipamTypes.Instance, error)
-	GetInstances(ctx context.Context, subnets ipamTypes.SubnetMap) (*ipamTypes.InstanceMap, error)
 	GetVpcsAndSubnets(ctx context.Context) (ipamTypes.VirtualNetworkMap, ipamTypes.SubnetMap, error)
 	GetSubnetsByIDs(ctx context.Context, nodeSubnetIDs []string) (ipamTypes.SubnetMap, error)
 	AssignPrivateIpAddressesVM(ctx context.Context, subnetID, interfaceName string, addresses int) error
 	AssignPrivateIpAddressesVMSS(ctx context.Context, instanceID, vmssName, subnetID, interfaceName string, addresses int) error
 	AssignPublicIPAddressesVM(ctx context.Context, instanceID string, publicIpTags ipamTypes.Tags) (string, error)
 	AssignPublicIPAddressesVMSS(ctx context.Context, instanceID, vmssName string, publicIpTags ipamTypes.Tags) (string, error)
-	// New methods for optimization: fetch network interfaces once and parse multiple times
 	ListAllNetworkInterfaces(ctx context.Context) ([]*armnetwork.Interface, error)
 	ParseInterfacesIntoInstanceMap(networkInterfaces []*armnetwork.Interface, subnets ipamTypes.SubnetMap) *ipamTypes.InstanceMap
 	ListVMNetworkInterfaces(ctx context.Context, instanceID string) ([]*armnetwork.Interface, error)
@@ -107,18 +104,17 @@ func (m *InstancesManager) Resync(ctx context.Context) (time.Time, error) {
 }
 
 // resyncInstance only resyncs a given instance
-// Note: This function uses GetInstance directly (not optimized with separate fetch/parse)
-// because it already queries per-instance APIs which are relatively lightweight
 func (m *InstancesManager) resyncInstance(ctx context.Context, instanceID string) (time.Time, error) {
 	resyncStart := time.Now()
 
-	// First get the instance with empty subnet map to extract subnet IDs
-	instance, err := m.api.GetInstance(ctx, ipamTypes.SubnetMap{}, instanceID)
+	// Fetch network interfaces once from Azure API
+	networkInterfaces, err := m.api.ListVMNetworkInterfaces(ctx, instanceID)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("synchronize Azure instance %s interface list: %w", instanceID, err)
 	}
 
-	// Extract subnet IDs from this instance
+	// Parse with empty subnets to discover which subnets are actually in use
+	instance := m.api.ParseInterfacesIntoInstance(networkInterfaces, ipamTypes.SubnetMap{})
 	instanceMap := ipamTypes.NewInstanceMap()
 	instanceMap.UpdateInstance(instanceID, instance)
 	nodeSubnetIDs := m.extractSubnetIDs(instanceMap)
@@ -134,12 +130,10 @@ func (m *InstancesManager) resyncInstance(ctx context.Context, instanceID string
 		subnets = ipamTypes.SubnetMap{}
 	}
 
-	// Re-query instance with discovered subnets for complete information
+	// Re-parse the same network interface data with subnet details to populate
+	// CIDR and gateway info without making another Azure API call
 	if len(subnets) > 0 {
-		instance, err = m.api.GetInstance(ctx, subnets, instanceID)
-		if err != nil {
-			return time.Time{}, fmt.Errorf("re-synchronize Azure instance %s with subnet details: %w", instanceID, err)
-		}
+		instance = m.api.ParseInterfacesIntoInstance(networkInterfaces, subnets)
 	}
 
 	m.logger.Info(


### PR DESCRIPTION
`resyncInstance` previously called `GetInstance` twice:
* once with an empty subnet map to discover referenced subnet IDs
* then again with the resolved subnets to repopulate CIDR/gateway info.

Each end up causing Azure API calls through `listVirtualMachineScaleSetVMNetworkInterfaces` even though the NIC data returned is identical in both cases.

This PR mirrors the fetch-once/parse-twice pattern already used by the full-cluster `resyncInstances` path: call `ListVMNetworkInterfaces` once, then run `ParseInterfacesIntoInstance` twice (first with an empty subnet map, then with the resolved subnets). The second parse is a pure in-memory operation, eliminating the redundant `GetInstance` call per InstanceSync.

Note: Since `GetInstance` was a wrapper over `ListVMNetworkInterfaces` + `ParseInterfacesIntoInstance` but we now run those separately as we only get once and parse twice, the `GetInstance` function is no longer used and is removed. Similarly, the already unused `GetInstances` function is removed as well.

### Examples

Before:
<img width="1016" height="144" alt="image" src="https://github.com/user-attachments/assets/fcbb24bf-3e2c-470d-8358-92d037f6c0c5" />

After:
<img width="1016" height="144" alt="image" src="https://github.com/user-attachments/assets/fc814979-8971-4f9d-90b6-fb4590c0723c" />
