### PR TITLE
cilium-cli: Ignore additional known GoBGPv4 warnings in no-errors-in-logs

### DIFF
--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -64,6 +64,7 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, extraExc
 		routerIPReallocated, cantFindIdentityInCache, keyAllocFailedFoundMaster,
 		cantRecreateMasterKey, cantUpdateCRDIdentity, cantDeleteFromPolicyMap, failedToListCRDs,
 		hubbleQueueFull, reflectPanic, svcNotFound, gobgpv3Warnings, gobgpNotification, gobgpNoMatchingWithdrawPath,
+		gobgpReceivedNotification, gobgpFailedToSend,
 		endpointMapDeleteFailed, etcdReconnection, failedToRetrieveRemoteClusterCfg, epRestoreMissingState, mutationDetectorKlog,
 		hubbleFailedCreatePeer, fqdnDpUpdatesTimeout, longNetpolUpdate, failedToGetEpLabels,
 		failedCreategRPCClient, unableReallocateIngressIP, fqdnMaxIPPerHostname, failedGetMetricsAPI,
@@ -460,6 +461,7 @@ const (
 	gobgpv3Warnings                  stringMatcher = "component=gobgp.BgpServerInstance"                                     // cf. https://github.com/cilium/cilium/issues/35799
 	gobgpNotification                stringMatcher = "sent notification"                                                     // cf. https://github.com/cilium/cilium/issues/35799
 	gobgpNoMatchingWithdrawPath      stringMatcher = "No matching path for withdraw found"                                   // cf. https://github.com/cilium/cilium/issues/35799
+	gobgpReceivedNotification        stringMatcher = "received notification"                                                 // cf. https://github.com/cilium/cilium/issues/35799
 	etcdReconnection                 stringMatcher = "Error observed on etcd connection, reconnecting etcd"                  // cf. https://github.com/cilium/cilium/issues/35865
 	failedToRetrieveRemoteClusterCfg stringMatcher = "failed to retrieve cluster configuration: not found"                   // Possible race condition in KVStoreMesh mode
 	epRestoreMissingState            stringMatcher = "Couldn't find state, ignoring endpoint"                                // cf. https://github.com/cilium/cilium/issues/35869
@@ -501,6 +503,9 @@ var (
 	bgpAlphaResourceDeprecation = regexMatcher{regexp.MustCompile(`cilium.io/v2alpha1 CiliumBGP\w+ is deprecated`)}
 	// ccgAlphaResourceDeprecation is the same as bgpAlphaResourceDeprecation but for the CiliumCIDRGroup.
 	ccgAlphaResourceDeprecation = regexMatcher{regexp.MustCompile(`cilium.io/v2alpha1 CiliumCIDRGroup is deprecated`)}
+	// gobgpFailedToSend ignores GoBGPv4's "failed to send" warning, but only when the write
+	// failed because the peer connection was torn down (closed connection or broken pipe);
+	gobgpFailedToSend = regexMatcher{regexp.MustCompile(`osrg/gobgp/v4/pkg/server.*msg="failed to send".*(use of closed network connection|broken pipe)`)}
 	// For https://github.com/cilium/cilium/issues/39370: Fixed only in cilium version >= 1.18
 	linkNotFound = regexMatcher{regexp.MustCompile(`retrieving device .+\: Link not found`)}
 )

--- a/cilium-cli/connectivity/tests/errors_test.go
+++ b/cilium-cli/connectivity/tests/errors_test.go
@@ -124,6 +124,46 @@ time=2025-04-08T14:27:09Z level=error msg="bar" serviceID=2 source=/go/src/githu
 	}
 }
 
+func TestGoBGPv4FailedToSendMatcher(t *testing.T) {
+	const src = "/go/src/github.com/cilium/cilium/vendor/github.com/osrg/gobgp/v4/pkg/server/fsm.go"
+
+	for _, tt := range []struct {
+		name      string
+		log       string
+		wantMatch bool
+	}{
+		{
+			name:      "ignored: failed to send due to closed network connection",
+			log:       `time=2026-05-25T23:16:20Z level=warn source=` + src + `:1739 msg="failed to send" component=gobgp-server State=BGP_FSM_ESTABLISHED Data="write tcp 192.168.10.7:47615->192.168.10.8:11179: use of closed network connection"`,
+			wantMatch: true,
+		},
+		{
+			name:      "ignored: failed to send due to broken pipe",
+			log:       `time=2026-05-26T07:33:03Z level=warn source=` + src + `:1739 msg="failed to send" component=gobgp-server State=BGP_FSM_ESTABLISHED Data="write tcp4 192.168.10.8:11179->192.168.10.6:45369: write: broken pipe"`,
+			wantMatch: true,
+		},
+		{
+			name:      "reported: failed to send due to another error",
+			log:       `time=2026-05-26T07:33:03Z level=warn source=` + src + `:1739 msg="failed to send" component=gobgp-server State=BGP_FSM_ESTABLISHED Data="write tcp 192.168.10.7:47615->192.168.10.8:11179: i/o timeout"`,
+			wantMatch: false,
+		},
+		{
+			name:      "reported: failed to send keepalive (distinct msg) even on broken pipe",
+			log:       `time=2026-05-26T07:33:03Z level=warn source=` + src + `:997 msg="failed to send keepalive on outgoing connection" component=gobgp-server Error="write tcp 192.168.10.7:47615->192.168.10.8:11179: write: broken pipe"`,
+			wantMatch: false,
+		},
+		{
+			name:      "reported: failed to send on broken pipe from another subsystem",
+			log:       `time=2026-05-26T07:33:03Z level=warn source=/go/src/github.com/cilium/cilium/pkg/hubble/relay/relay.go:42 msg="failed to send" subsys=hubble error="broken pipe"`,
+			wantMatch: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantMatch, gobgpFailedToSend.IsMatch(tt.log))
+		})
+	}
+}
+
 func TestExtractPathFromLog(t *testing.T) {
 	_, thisPath, _, _ := runtime.Caller(0)
 	repoDir, _ := filepath.Abs(filepath.Join(thisPath, "..", "..", "..", ".."))


### PR DESCRIPTION
The no-errors-in-logs test flagged three additional GoBGPv4 warnings that are benign during BGP peer teardown:

- "received notification": a peer sends a NOTIFICATION during peer teardown.
- "failed to send": a write to a peer fails because the connection has already been torn down.

related: #35799