### PR TITLE
gateway-api: do not reject listeners when no route kinds are supported

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -628,11 +628,6 @@ func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1
 			if len(supportedKinds) != len(l.AllowedRoutes.Kinds) {
 				conds = merge(conds, gatewayListenerInvalidRouteKinds(gw, "Unsupported Route Kinds in allowedRoutes.kinds"))
 			}
-
-			if len(supportedKinds) == 0 {
-				invalidMessages = append(invalidMessages, "None of the Allowed Route Kinds are supported.")
-				isValid = false
-			}
 		} else {
 			// If there are no Kinds specified in AllowedRoutes, then supportedKinds should contain
 			// all the supported Kinds for that Protocol.

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -105,7 +105,7 @@ func Test_Conformance(t *testing.T) {
 		{
 			name: "gateway-invalid-route-kind",
 			gateway: []gwDetails{
-				{FullName: types.NamespacedName{Name: "gateway-only-invalid-route-kind", Namespace: "gateway-conformance-infra"}, wantErr: true},
+				{FullName: types.NamespacedName{Name: "gateway-only-invalid-route-kind", Namespace: "gateway-conformance-infra"}},
 				{FullName: types.NamespacedName{Name: "gateway-supported-and-invalid-route-kind", Namespace: "gateway-conformance-infra"}},
 			},
 		},

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-route-kind/output/cec-gateway-only-invalid-route-kind.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-route-kind/output/cec-gateway-only-invalid-route-kind.yaml
@@ -1,0 +1,77 @@
+metadata:
+  creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: gateway-only-invalid-route-kind
+  name: cilium-gateway-gateway-only-invalid-route-kind
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: gateway-only-invalid-route-kind
+    uid: ""
+  resourceVersion: "1"
+spec:
+  resources:
+  - '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    filterChains:
+    - filterChainMatch:
+        transportProtocol: raw_buffer
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            maxStreamDuration: 0s
+          httpFilters:
+          - name: envoy.filters.http.grpc_web
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+          - name: envoy.filters.http.grpc_stats
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+              emitFilterState: true
+              enableUpstreamStats: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig: {}
+          rds:
+            routeConfigName: listener-insecure
+          statPrefix: listener-insecure
+          streamIdleTimeout: 300s
+          upgradeConfigs:
+          - upgradeType: websocket
+          useRemoteAddress: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: listener
+    socketOptions:
+    - description: Enable TCP keep-alive (default to enabled)
+      intValue: "1"
+      level: "1"
+      name: "9"
+    - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+      intValue: "10"
+      level: "6"
+      name: "4"
+    - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+      intValue: "5"
+      level: "6"
+      name: "5"
+    - description: TCP keep-alive probe max failures.
+      intValue: "10"
+      level: "6"
+      name: "6"
+  - '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    name: listener-insecure
+  services:
+  - listener: ""
+    name: cilium-gateway-gateway-only-invalid-route-kind
+    namespace: gateway-conformance-infra
+    ports:
+    - 80

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-route-kind/output/gateway-only-invalid-route-kind.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-route-kind/output/gateway-only-invalid-route-kind.yaml
@@ -19,13 +19,13 @@ spec:
 status:
   conditions:
     - lastTransitionTime: "2025-07-01T05:23:50Z"
-      message: No Accepted Listeners
-      reason: ListenersNotValid
-      status: "False"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
       type: Accepted
     - lastTransitionTime: "2025-07-01T05:06:15Z"
-      message: No Accepted Listeners
-      reason: ListenersNotValid
+      message: Gateway waiting for address
+      reason: AddressNotAssigned
       status: "False"
       type: Programmed
   listeners:
@@ -37,9 +37,9 @@ status:
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: "2025-07-01T05:23:50Z"
-          message: Listener not valid. None of the Allowed Route Kinds are supported.
-          reason: Invalid
-          status: "False"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
           type: Accepted
         - lastTransitionTime: "2025-07-01T05:06:15Z"
           message: Address not ready yet


### PR DESCRIPTION
Keep Gateway listeners accepted when allowedRoutes.kinds contains no route kind compatible with the listener protocol.

Cilium currently reports listener ResolvedRefs=False with InvalidRouteKinds, but also marks the listener invalid when the filtered supportedKinds set is empty. That can cascade into Gateway Accepted=False / ListenersNotValid.

This is too strict. A listener with a valid protocol but route-kind restrictions that exclude all compatible routes should remain accepted, while route attachment is rejected separately with NotAllowedByListeners.

Keep the InvalidRouteKinds validation and empty supportedKinds status, but stop treating that case as listener invalidity. Update the invalid-route-kind reconciliation goldens accordingly.

Note: Upcoming TCP/UDPRoute conformance checks would fail for Cilium with this strict logic in place: https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/tests/tcproute-invalid-non-tcp-listener.go#L59