### PR TITLE
bpf: local_delivery: adopt new calling convention

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -2010,8 +2010,7 @@ int tail_ipv6_policy(struct __ctx_buff *ctx)
 	__u32 delivery_flags = ctx_load_meta(ctx, CB_DELIVERY_FLAGS);
 	bool do_redirect = delivery_flags & CB_DELIVERY_FLAGS_REDIRECT;
 	__u32 src_label = ctx_load_and_clear_meta(ctx, CB_SRC_LABEL);
-	bool from_host = ctx_load_and_clear_meta(ctx, CB_FROM_HOST);
-	bool from_tunnel = false, use_redirect_peer = false;
+	bool from_host = false, from_tunnel = false, use_redirect_peer = false;
 	void *data, *data_end;
 	__u16 proxy_port = 0;
 	struct ipv6hdr *ip6;
@@ -2031,7 +2030,6 @@ int tail_ipv6_policy(struct __ctx_buff *ctx)
 		use_redirect_peer = true;
 
 #ifdef HAVE_ENCAP
-	from_tunnel = ctx_load_and_clear_meta(ctx, CB_FROM_TUNNEL);
 	if (delivery_flags & CB_DELIVERY_FLAGS_FROM_TUNNEL)
 		from_tunnel = true;
 #endif
@@ -2336,8 +2334,7 @@ int tail_ipv4_policy(struct __ctx_buff *ctx)
 	__u32 delivery_flags = ctx_load_meta(ctx, CB_DELIVERY_FLAGS);
 	bool do_redirect = delivery_flags & CB_DELIVERY_FLAGS_REDIRECT;
 	__u32 src_label = ctx_load_and_clear_meta(ctx, CB_SRC_LABEL);
-	bool from_host = ctx_load_and_clear_meta(ctx, CB_FROM_HOST);
-	bool from_tunnel = false, use_redirect_peer = false;
+	bool from_host = false, from_tunnel = false, use_redirect_peer = false;
 	void *data, *data_end;
 	__u16 proxy_port = 0;
 	struct iphdr *ip4;
@@ -2359,7 +2356,6 @@ int tail_ipv4_policy(struct __ctx_buff *ctx)
 	ctx_store_meta(ctx, CB_CLUSTER_ID_INGRESS, 0);
 
 #ifdef HAVE_ENCAP
-	from_tunnel = ctx_load_and_clear_meta(ctx, CB_FROM_TUNNEL);
 	if (delivery_flags & CB_DELIVERY_FLAGS_FROM_TUNNEL)
 		from_tunnel = true;
 #endif

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -2011,7 +2011,7 @@ int tail_ipv6_policy(struct __ctx_buff *ctx)
 	bool do_redirect = delivery_flags & CB_DELIVERY_FLAGS_REDIRECT;
 	__u32 src_label = ctx_load_and_clear_meta(ctx, CB_SRC_LABEL);
 	bool from_host = ctx_load_and_clear_meta(ctx, CB_FROM_HOST);
-	bool from_tunnel = false;
+	bool from_tunnel = false, use_redirect_peer = false;
 	void *data, *data_end;
 	__u16 proxy_port = 0;
 	struct ipv6hdr *ip6;
@@ -2026,6 +2026,9 @@ int tail_ipv6_policy(struct __ctx_buff *ctx)
 
 	if (delivery_flags & CB_DELIVERY_FLAGS_FROM_EGRESS_PROXY)
 		ctx->tc_index |= TC_INDEX_F_FROM_EGRESS_PROXY;
+
+	if (delivery_flags & CB_DELIVERY_FLAGS_USE_REDIRECT_PEER)
+		use_redirect_peer = true;
 
 #ifdef HAVE_ENCAP
 	from_tunnel = ctx_load_and_clear_meta(ctx, CB_FROM_TUNNEL);
@@ -2060,8 +2063,7 @@ int tail_ipv6_policy(struct __ctx_buff *ctx)
 
 		if (do_redirect)
 			ret = redirect_ep(ctx, CONFIG(interface_ifindex),
-					  should_redirect_peer(ctx, from_host),
-					  from_tunnel);
+					  use_redirect_peer, from_tunnel);
 		break;
 	default:
 		break;
@@ -2335,7 +2337,7 @@ int tail_ipv4_policy(struct __ctx_buff *ctx)
 	bool do_redirect = delivery_flags & CB_DELIVERY_FLAGS_REDIRECT;
 	__u32 src_label = ctx_load_and_clear_meta(ctx, CB_SRC_LABEL);
 	bool from_host = ctx_load_and_clear_meta(ctx, CB_FROM_HOST);
-	bool from_tunnel = false;
+	bool from_tunnel = false, use_redirect_peer = false;
 	void *data, *data_end;
 	__u16 proxy_port = 0;
 	struct iphdr *ip4;
@@ -2350,6 +2352,9 @@ int tail_ipv4_policy(struct __ctx_buff *ctx)
 
 	if (delivery_flags & CB_DELIVERY_FLAGS_FROM_EGRESS_PROXY)
 		ctx->tc_index |= TC_INDEX_F_FROM_EGRESS_PROXY;
+
+	if (delivery_flags & CB_DELIVERY_FLAGS_USE_REDIRECT_PEER)
+		use_redirect_peer = true;
 
 	ctx_store_meta(ctx, CB_CLUSTER_ID_INGRESS, 0);
 
@@ -2393,8 +2398,7 @@ int tail_ipv4_policy(struct __ctx_buff *ctx)
 
 		if (do_redirect)
 			ret = redirect_ep(ctx, CONFIG(interface_ifindex),
-					  should_redirect_peer(ctx, from_host),
-					  from_tunnel);
+					  use_redirect_peer, from_tunnel);
 		break;
 	default:
 		break;

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -335,7 +335,6 @@ enum {
 						 * Not used by xfrm.
 						 */
 #define	CB_SRV6_VRF_ID		CB_CT_STATE	/* Alias, non-overlapping */
-#define	CB_FROM_TUNNEL		CB_CT_STATE	/* Alias, non-overlapping */
 };
 
 /* Magic values for CB_FROM_HOST.

--- a/bpf/lib/local_delivery.h
+++ b/bpf/lib/local_delivery.h
@@ -133,8 +133,6 @@ local_delivery_fill_meta(struct __ctx_buff *ctx, __u32 seclabel,
 
 	ctx_store_meta(ctx, CB_SRC_LABEL, seclabel);
 	ctx_store_meta(ctx, CB_DELIVERY_FLAGS, delivery_flags);
-	ctx_store_meta(ctx, CB_FROM_HOST, from_host ? 1 : 0);
-	ctx_store_meta(ctx, CB_FROM_TUNNEL, from_tunnel ? 1 : 0);
 	ctx_store_meta(ctx, CB_CLUSTER_ID_INGRESS, cluster_id);
 }
 

--- a/bpf/tests/inter_cluster_snat_clusterip_backend_overlay.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_backend_overlay.c
@@ -250,14 +250,6 @@ int from_overlay_syn_check(struct __ctx_buff *ctx)
 	if (meta != CLIENT_IDENTITY)
 		test_fatal("skb->cb[CB_SRC_LABEL] should be %d, got %d", CLIENT_IDENTITY, meta);
 
-	meta = ctx_load_meta(ctx, CB_FROM_TUNNEL);
-	if (meta != 1)
-		test_fatal("skb->cb[CB_FROM_TUNNEL] should be 1, got %d", meta);
-
-	meta = ctx_load_meta(ctx, CB_FROM_HOST);
-	if (meta != 0)
-		test_fatal("skb->cb[CB_FROM_HOST] should be 0, got %d", meta);
-
 	meta = ctx_load_meta(ctx, CB_CLUSTER_ID_INGRESS);
 	if (meta != 0)
 		test_fatal("skb->cb[CB_CLUSTER_ID_INGRESS] should be 0, got %d", meta);
@@ -425,14 +417,6 @@ int from_overlay_ack_check(struct __ctx_buff *ctx)
 	meta = ctx_load_meta(ctx, CB_SRC_LABEL);
 	if (meta != CLIENT_IDENTITY)
 		test_fatal("skb->cb[CB_SRC_LABEL] should be %d, got %d", CLIENT_IDENTITY, meta);
-
-	meta = ctx_load_meta(ctx, CB_FROM_TUNNEL);
-	if (meta != 1)
-		test_fatal("skb->cb[CB_FROM_TUNNEL] should be 1, got %d", meta);
-
-	meta = ctx_load_meta(ctx, CB_FROM_HOST);
-	if (meta != 0)
-		test_fatal("skb->cb[CB_FROM_HOST] should be 0, got %d", meta);
 
 	meta = ctx_load_meta(ctx, CB_CLUSTER_ID_INGRESS);
 	if (meta != 0)

--- a/bpf/tests/inter_cluster_snat_clusterip_client_overlay.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_client_overlay.c
@@ -348,14 +348,6 @@ int from_overlay_synack_check(struct __ctx_buff *ctx)
 	if (meta != BACKEND_IDENTITY)
 		test_fatal("skb->cb[CB_SRC_LABEL] should be %d, got %d", BACKEND_IDENTITY, meta);
 
-	meta = ctx_load_meta(ctx, CB_FROM_TUNNEL);
-	if (meta != 1)
-		test_fatal("skb->cb[CB_FROM_TUNNEL] should be 1, got %d", meta);
-
-	meta = ctx_load_meta(ctx, CB_FROM_HOST);
-	if (meta != 0)
-		test_fatal("skb->cb[CB_FROM_HOST] should be 0, got %d", meta);
-
 	meta = ctx_load_meta(ctx, CB_CLUSTER_ID_INGRESS);
 	if (meta != BACKEND_CLUSTER_ID)
 		test_fatal("skb->cb[CB_CLUSTER_ID_INGRESS] should be %u, got %d",

--- a/bpf/tests/tc_redirect_host.h
+++ b/bpf/tests/tc_redirect_host.h
@@ -120,15 +120,15 @@ mock_ctx_get_ingress_ifindex(const struct __sk_buff *ctx __maybe_unused)
  */
 int mock_tail_policy(struct __ctx_buff *ctx)
 {
-	bool do_redirect = ctx_load_meta(ctx, CB_DELIVERY_FLAGS) & CB_DELIVERY_FLAGS_REDIRECT;
 	bool from_host = ctx_load_and_clear_meta(ctx, CB_FROM_HOST);
-	bool from_tunnel = false;
+	__u32 delivery_flags = ctx_load_meta(ctx, CB_DELIVERY_FLAGS);
+	bool do_redirect = delivery_flags & CB_DELIVERY_FLAGS_REDIRECT;
+	bool use_redirect_peer = delivery_flags & CB_DELIVERY_FLAGS_USE_REDIRECT_PEER;
 
 	/* We should always be from_host here. */
 	if (do_redirect && from_host)
 		return redirect_ep(ctx, CONFIG(interface_ifindex),
-				   should_redirect_peer(ctx, from_host),
-				   from_tunnel);
+				   use_redirect_peer, false);
 
 	/* Failure path */
 	return CTX_ACT_DROP;

--- a/bpf/tests/tc_redirect_host.h
+++ b/bpf/tests/tc_redirect_host.h
@@ -120,9 +120,9 @@ mock_ctx_get_ingress_ifindex(const struct __sk_buff *ctx __maybe_unused)
  */
 int mock_tail_policy(struct __ctx_buff *ctx)
 {
-	bool from_host = ctx_load_and_clear_meta(ctx, CB_FROM_HOST);
 	__u32 delivery_flags = ctx_load_meta(ctx, CB_DELIVERY_FLAGS);
 	bool do_redirect = delivery_flags & CB_DELIVERY_FLAGS_REDIRECT;
+	bool from_host = delivery_flags & CB_DELIVERY_FLAGS_FROM_HOST;
 	bool use_redirect_peer = delivery_flags & CB_DELIVERY_FLAGS_USE_REDIRECT_PEER;
 
 	/* We should always be from_host here. */

--- a/bpf/tests/tc_redirect_netdev.h
+++ b/bpf/tests/tc_redirect_netdev.h
@@ -128,14 +128,13 @@ mock_ctx_get_ingress_ifindex(const struct __sk_buff *ctx __maybe_unused)
  */
 int mock_tail_policy(struct __ctx_buff *ctx)
 {
-	bool do_redirect = ctx_load_meta(ctx, CB_DELIVERY_FLAGS) & CB_DELIVERY_FLAGS_REDIRECT;
-	bool from_host = ctx_load_and_clear_meta(ctx, CB_FROM_HOST);
-	bool from_tunnel = false;
+	__u32 delivery_flags = ctx_load_meta(ctx, CB_DELIVERY_FLAGS);
+	bool do_redirect = delivery_flags & CB_DELIVERY_FLAGS_REDIRECT;
+	bool use_redirect_peer = delivery_flags & CB_DELIVERY_FLAGS_USE_REDIRECT_PEER;
 
 	if (do_redirect)
 		return redirect_ep(ctx, CONFIG(interface_ifindex),
-				   should_redirect_peer(ctx, from_host),
-				   from_tunnel);
+				   use_redirect_peer, false);
 
 	/* Failure path */
 	return CTX_ACT_DROP;


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/46204 introduces the new calling convention bits into `v1.19`. We can thus trust on upgrade that all skbs carry metadata in the new format, and for `v1.20` we can (1) remove the old calling convention bits, and (2) make use of `CB_DELIVERY_FLAGS_USE_REDIRECT_PEER`.