### PR TITLE
Bump to Hive v1.0.4-rc2 and fix job stop ordering issues

### DIFF
--- a/daemon/healthz/kube_proxy_healthz.go
+++ b/daemon/healthz/kube_proxy_healthz.go
@@ -84,7 +84,7 @@ func registerKubeProxyHealthzHTTPService(params kubeProxyHealthParams) error {
 	params.JobGroup.Add(job.OneShot("kube-proxy-healthz-server", func(ctx context.Context, health cell.Health) error {
 		addr := params.Config.KubeProxyReplacementHealthzBindAddress
 		lc := net.ListenConfig{Control: setsockoptReuseAddrAndPort}
-		ln, err := lc.Listen(context.Background(), "tcp", addr)
+		ln, err := lc.Listen(ctx, "tcp", addr)
 		if errors.Is(err, unix.EADDRNOTAVAIL) {
 			params.Logger.Info("KubeProxy healthz server not available", logfields.Address, addr)
 		} else if err != nil {
@@ -108,6 +108,13 @@ func registerKubeProxyHealthzHTTPService(params kubeProxyHealthParams) error {
 		}
 
 		params.Logger.Info("Starting kube-proxy healthz server", logfields.Address, addr)
+
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		go func() {
+			<-ctx.Done()
+			srv.Close()
+		}()
 
 		if err := srv.Serve(ln); errors.Is(err, http.ErrServerClosed) {
 			params.Logger.Info("kube-proxy healthz status API server shutdown", logfields.Address, addr)

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/cilium/ebpf v0.21.0
 	github.com/cilium/endpointslice-controller v0.0.0-20250410163339-ffb33e27879c
 	github.com/cilium/fake v0.7.0
-	github.com/cilium/hive v1.0.1
+	github.com/cilium/hive v1.0.4-rc2
 	github.com/cilium/lumberjack/v2 v2.4.2
 	github.com/cilium/proxy v0.0.0-20260508102643-7c2f6580d32e
 	github.com/cilium/statedb v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/cilium/endpointslice-controller v0.0.0-20250410163339-ffb33e27879c h1
 github.com/cilium/endpointslice-controller v0.0.0-20250410163339-ffb33e27879c/go.mod h1:izWO5C3waDVkh/nt++nNyozXyJAPL6tfFpJSMtzVnwQ=
 github.com/cilium/fake v0.7.0 h1:4EKBtTweQrJoD4q45qDGu8udulmYMo48Y0BhEbrB1jc=
 github.com/cilium/fake v0.7.0/go.mod h1:hA1YsEjgIs5Gdeq/DVrDWGuhLCoVok7THTvQaGDO5bc=
-github.com/cilium/hive v1.0.1 h1:5PZpis3yw1ywfTnDVQ8AB7k/esVVeoE0cnWVyZDCxE0=
-github.com/cilium/hive v1.0.1/go.mod h1:NY1wD3TQ4sya7zkhkB4QX6eIZ4FjwZPG+lnUB2IH5Xs=
+github.com/cilium/hive v1.0.4-rc2 h1:IW98tggZDkut0i52pwWa5XTDe4/HvgshqYN3bCzDWN0=
+github.com/cilium/hive v1.0.4-rc2/go.mod h1:NY1wD3TQ4sya7zkhkB4QX6eIZ4FjwZPG+lnUB2IH5Xs=
 github.com/cilium/linters v0.4.0 h1:ViNciIgyKRMTAabKRN8GOFJB2LQvUE1GOYASApKEpRg=
 github.com/cilium/linters v0.4.0/go.mod h1:w5c2w86r0D5sib0Fei5q73izPuuAfQJc3t1K9VSQEcc=
 github.com/cilium/lumberjack/v2 v2.4.2 h1:Wea2z1+ikRhjS5z36I6vgeMlgh7xzvIzqW+t9tTvpkQ=

--- a/operator/pkg/bgp/peer_test.go
+++ b/operator/pkg/bgp/peer_test.go
@@ -321,13 +321,8 @@ func TestDisablePeerConfigStatusReport(t *testing.T) {
 
 				rtxn := f.db.ReadTxn()
 
-				o, _, found := f.healthTable.Get(rtxn, health.PrimaryIndex.Query(healthTypes.HealthID("test.job-cleanup-peer-config-status")))
-				if !assert.True(ct, found, "Health status for the job is not found") {
-					return
-				}
-
-				assert.Equal(ct, healthTypes.Level(healthTypes.LevelStopped), o.Level)
-				assert.Equal(ct, "Cleanup job is done successfully", o.Message)
+				_, _, found := f.healthTable.Get(rtxn, health.PrimaryIndex.Query(healthTypes.HealthID("test.job-cleanup-peer-config-status")))
+				assert.False(ct, found, "expected job to be done")
 			}, time.Second*3, time.Millisecond*100)
 		})
 	}

--- a/operator/pkg/ciliumendpointslice/endpointslice.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
@@ -183,6 +183,15 @@ func (c *DefaultController) Start(ctx cell.HookContext) error {
 			c.worker()
 			return nil
 		}),
+		// Add the shutdown job last so it stops first.
+		job.OneShot("shutdown", func(ctx context.Context, health cell.Health) error {
+			<-ctx.Done()
+			c.wp.Close()
+			c.fastQueue.ShutDown()
+			c.standardQueue.ShutDown()
+			c.contextCancel()
+			return nil
+		}),
 	)
 
 	return nil
@@ -231,6 +240,14 @@ func (c *SlimController) Start(ctx cell.HookContext) error {
 			c.worker()
 			return nil
 		}),
+		// Add the shutdown job last so it stops first.
+		job.OneShot("shutdown", func(ctx context.Context, health cell.Health) error {
+			<-ctx.Done()
+			c.fastQueue.ShutDown()
+			c.standardQueue.ShutDown()
+			c.contextCancel()
+			return nil
+		}),
 	)
 	// Start the work pools processing CEP events only after syncing CES in local cache.
 	// c.wp = workerpool.New(4)
@@ -251,17 +268,10 @@ func (c *SlimController) Start(ctx cell.HookContext) error {
 }
 
 func (c *DefaultController) Stop(ctx cell.HookContext) error {
-	c.wp.Close()
-	c.fastQueue.ShutDown()
-	c.standardQueue.ShutDown()
-	c.contextCancel()
 	return nil
 }
 
 func (c *SlimController) Stop(ctx cell.HookContext) error {
-	c.fastQueue.ShutDown()
-	c.standardQueue.ShutDown()
-	c.contextCancel()
 	return nil
 }
 

--- a/operator/pkg/ciliumidentity/controller.go
+++ b/operator/pkg/ciliumidentity/controller.go
@@ -160,8 +160,6 @@ func (c *Controller) Start(ctx cell.HookContext) error {
 }
 
 func (c *Controller) Stop(_ cell.HookContext) error {
-	c.resourceQueue.ShutDown()
-
 	return nil
 }
 
@@ -229,6 +227,11 @@ func (c *Controller) initReconciler(ctx context.Context) error {
 func (c *Controller) runResourceWorker(ctx context.Context) error {
 	c.logger.InfoContext(ctx, "Starting resource worker")
 	defer c.logger.InfoContext(ctx, "Stopping resource worker")
+
+	go func() {
+		<-ctx.Done()
+		c.resourceQueue.ShutDown()
+	}()
 
 	for c.processNextItem() {
 		select {

--- a/pkg/envoy/accesslog_server.go
+++ b/pkg/envoy/accesslog_server.go
@@ -45,8 +45,8 @@ func newAccessLogServer(logger *slog.Logger, accessLogger accesslog.ProxyAccessL
 	}
 }
 
-// start starts the access log server.
-func (s *AccessLogServer) start(ctx context.Context) error {
+// run runs the access log server.
+func (s *AccessLogServer) run(ctx context.Context) error {
 	socketListener, err := s.newSocketListener()
 	if err != nil {
 		return fmt.Errorf("failed to create socket listener: %w", err)
@@ -56,6 +56,14 @@ func (s *AccessLogServer) start(ctx context.Context) error {
 	s.logger.Info("Envoy: Starting access log server listening",
 		logfields.Address, socketListener.Addr(),
 	)
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go func() {
+		<-ctx.Done()
+		socketListener.Close()
+	}()
+
 	for {
 		// Each Envoy listener opens a new connection over the Unix domain socket.
 		// Multiple worker threads serving the listener share that same connection
@@ -103,12 +111,6 @@ func (s *AccessLogServer) newSocketListener() (*net.UnixListener, error) {
 		)
 	}
 	return accessLogListener, nil
-}
-
-func (s *AccessLogServer) stop() {
-	if s.socketListener != nil {
-		_ = s.socketListener.Close()
-	}
 }
 
 func (s *AccessLogServer) handleConn(ctx context.Context, conn *net.UnixConn) {

--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -116,18 +116,9 @@ func newEnvoyXDSServer(params xdsServerParams) (XDSServer, error) {
 		return xdsServer, nil
 	}
 
-	params.Lifecycle.Append(cell.Hook{
-		OnStart: func(_ cell.HookContext) error {
-			params.JobGroup.Add(job.OneShot("xds-server", func(ctx context.Context, _ cell.Health) error {
-				return xdsServer.start(ctx)
-			}, job.WithShutdown()))
-			return nil
-		},
-		OnStop: func(_ cell.HookContext) error {
-			xdsServer.stop()
-			return nil
-		},
-	})
+	params.JobGroup.Add(job.OneShot("xds-server", func(ctx context.Context, _ cell.Health) error {
+		return xdsServer.run(ctx)
+	}, job.WithShutdown()))
 
 	if !option.Config.ExternalEnvoyProxy {
 		return &onDemandXdsStarter{
@@ -187,19 +178,9 @@ func newEnvoyAccessLogServer(params accessLogServerParams) *AccessLogServer {
 		params.EnvoyProxyConfig.EnvoyAccessLogBufferSize,
 	)
 
-	params.Lifecycle.Append(cell.Hook{
-		OnStart: func(_ cell.HookContext) error {
-			params.JobGroup.Add(job.OneShot("accesslog-server", func(ctx context.Context, _ cell.Health) error {
-				return accessLogServer.start(ctx)
-			}, job.WithShutdown()))
-			return nil
-		},
-		OnStop: func(_ cell.HookContext) error {
-			accessLogServer.stop()
-			return nil
-		},
-	})
-
+	params.JobGroup.Add(job.OneShot("accesslog-server", func(ctx context.Context, _ cell.Health) error {
+		return accessLogServer.run(ctx)
+	}, job.WithShutdown()))
 	return accessLogServer
 }
 

--- a/pkg/envoy/grpc.go
+++ b/pkg/envoy/grpc.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 
 	cilium "github.com/cilium/proxy/go/cilium/api"
 	envoy_service_cluster "github.com/envoyproxy/go-control-plane/envoy/service/cluster/v3"
@@ -27,9 +28,10 @@ import (
 // implemented by Cilium.
 var ErrNotImplemented = errors.New("not implemented")
 
-// startXDSGRPCServer starts a gRPC server to serve xDS APIs using the given
-// resource watcher and network listener.
-func (s *xdsServer) startXDSGRPCServer(ctx context.Context, config map[string]*xds.ResourceTypeConfiguration) error {
+// runXDSGRPCServer runs a gRPC server to serve xDS APIs using the given
+// resource watcher and network listener. Returns on error or when [ctx]
+// is cancelled.
+func (s *xdsServer) runXDSGRPCServer(ctx context.Context, config map[string]*xds.ResourceTypeConfiguration) error {
 	listener, err := s.newSocketListener()
 	if err != nil {
 		return fmt.Errorf("failed to create socket listener: %w", err)
@@ -54,16 +56,16 @@ func (s *xdsServer) startXDSGRPCServer(ctx context.Context, config map[string]*x
 
 	reflection.Register(grpcServer)
 
-	ctx, cancel := context.WithTimeout(ctx, s.config.policyRestoreTimeout)
+	restoreCtx, cancel := context.WithTimeout(ctx, s.config.policyRestoreTimeout)
 	defer cancel()
 	s.stopFunc = grpcServer.Stop
 
 	if s.restorerPromise != nil {
 		s.logger.Info("Envoy: Waiting for endpoint restorer before serving xDS resources...")
-		restorer, err := s.restorerPromise.Await(ctx)
+		restorer, err := s.restorerPromise.Await(restoreCtx)
 		if err == nil && restorer != nil {
 			s.logger.Info("Envoy: Waiting for endpoint restoration before serving xDS resources...")
-			err = restorer.WaitForInitialPolicy(ctx)
+			err = restorer.WaitForInitialPolicy(restoreCtx)
 		}
 		if errors.Is(err, context.Canceled) {
 			s.logger.Debug("Envoy: xDS server stopped before started serving")
@@ -81,6 +83,17 @@ func (s *xdsServer) startXDSGRPCServer(ctx context.Context, config map[string]*x
 	s.logger.Info("Envoy: Starting xDS gRPC server listening",
 		logfields.Address, listener.Addr(),
 	)
+
+	ctx, cancel = context.WithCancel(ctx)
+	defer cancel()
+	go func() {
+		<-ctx.Done()
+		grpcServer.Stop()
+		if s.socketPath != "" {
+			_ = os.Remove(s.socketPath)
+		}
+	}()
+
 	if err := grpcServer.Serve(listener); err != nil && !errors.Is(err, net.ErrClosed) {
 		s.logger.Error("Envoy: Failed to serve xDS gRPC API",
 			logfields.Error, err,

--- a/pkg/envoy/standalone_envoy_test.go
+++ b/pkg/envoy/standalone_envoy_test.go
@@ -59,7 +59,7 @@ func (s *EnvoySuite) waitForProxyCompletion() error {
 
 func TestEnvoy(t *testing.T) {
 	s := setupEnvoySuite(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	s.waitGroup = completion.NewWaitGroup(ctx)
@@ -91,18 +91,16 @@ func TestEnvoy(t *testing.T) {
 	require.NotNil(t, xdsServer)
 
 	go func() {
-		err = xdsServer.start(t.Context())
+		err = xdsServer.run(ctx)
 		require.NoError(t, err)
 	}()
-	defer xdsServer.stop()
 
 	accessLogServer := newAccessLogServer(logger, &proxyAccessLoggerMock{}, testRunDir, 1337, localEndpointStore, 4096)
 	require.NotNil(t, accessLogServer)
 	go func() {
-		err = accessLogServer.start(t.Context())
+		err = accessLogServer.run(t.Context())
 		require.NoError(t, err)
 	}()
-	defer accessLogServer.stop()
 
 	// launch debug variant of the Envoy proxy
 	starter := &onDemandXdsStarter{logger: logger}
@@ -188,7 +186,7 @@ func TestEnvoy(t *testing.T) {
 func TestEnvoyNACK(t *testing.T) {
 	s := setupEnvoySuite(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Second)
 	defer cancel()
 
 	s.waitGroup = completion.NewWaitGroup(ctx)
@@ -218,18 +216,16 @@ func TestEnvoyNACK(t *testing.T) {
 	require.NotNil(t, xdsServer)
 
 	go func() {
-		err = xdsServer.start(t.Context())
+		err = xdsServer.run(ctx)
 		require.NoError(t, err)
 	}()
-	defer xdsServer.stop()
 
 	accessLogServer := newAccessLogServer(logger, &proxyAccessLoggerMock{}, testRunDir, 1337, localEndpointStore, 4096)
 	require.NotNil(t, accessLogServer)
 	go func() {
-		err = accessLogServer.start(t.Context())
+		err = accessLogServer.run(t.Context())
 		require.NoError(t, err)
 	}()
-	defer accessLogServer.stop()
 
 	// launch debug variant of the Envoy proxy
 	starter := &onDemandXdsStarter{logger: logger}

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -288,8 +288,8 @@ func newXDSServer(logger *slog.Logger, restorerPromise promise.Promise[endpoints
 	return xdsServer
 }
 
-func (s *xdsServer) start(ctx context.Context) error {
-	return s.startXDSGRPCServer(ctx, s.resourceConfig)
+func (s *xdsServer) run(ctx context.Context) error {
+	return s.runXDSGRPCServer(ctx, s.resourceConfig)
 }
 
 func (s *xdsServer) initializeXdsConfigs() {
@@ -385,15 +385,6 @@ func (s *xdsServer) newSocketListener() (*net.UnixListener, error) {
 		)
 	}
 	return socketListener, nil
-}
-
-func (s *xdsServer) stop() {
-	if s.stopFunc != nil {
-		s.stopFunc()
-	}
-	if s.socketPath != "" {
-		_ = os.Remove(s.socketPath)
-	}
 }
 
 func GetAccessLogSocketPath() string {

--- a/pkg/loadbalancer/healthserver/healthserver.go
+++ b/pkg/loadbalancer/healthserver/healthserver.go
@@ -120,8 +120,6 @@ func (s *healthServer) controlLoop(ctx context.Context, health cell.Health) erro
 	limiter := rate.NewLimiter(100*time.Millisecond, 1)
 	defer limiter.Stop()
 
-	defer s.cleanupListeners(ctx)
-
 	for {
 		if err := limiter.Wait(ctx); err != nil {
 			return err
@@ -241,12 +239,6 @@ func (s *healthServer) controlLoop(ctx context.Context, health cell.Health) erro
 	}
 }
 
-func (s *healthServer) cleanupListeners(ctx context.Context) {
-	for _, srv := range s.serverByPort {
-		srv.shutdown(ctx)
-	}
-}
-
 func (s *healthServer) addListener(svc *lb.Service, port uint16) {
 	if srv, exists := s.serverByPort[port]; exists {
 		s.params.Log.Warn("HealthServer: Listener already exists",
@@ -276,8 +268,19 @@ func (s *healthServer) addListener(svc *lb.Service, port uint16) {
 		job.OneShot(
 			fmt.Sprintf("listener-%d", port),
 			func(ctx context.Context, health cell.Health) error {
-				if err := srv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
-					return err
+				errs := make(chan error, 1)
+				go func() {
+					defer close(errs)
+					errs <- srv.ListenAndServe()
+				}()
+				defer srv.Shutdown(ctx)
+				select {
+				case <-ctx.Done():
+					return nil
+				case err := <-errs:
+					if !errors.Is(err, http.ErrServerClosed) {
+						return err
+					}
 				}
 				return nil
 			},

--- a/pkg/loadbalancer/healthserver/testdata/healthserver-ipv6.txtar
+++ b/pkg/loadbalancer/healthserver/testdata/healthserver-ipv6.txtar
@@ -5,8 +5,8 @@ db/insert node-addresses addrv6.yaml
 
 hive start
 
-env HEALTHPORT1=40000
-env HEALTHPORT2=40001
+env HEALTHPORT1=40010
+env HEALTHPORT2=40011
 cp service.yaml service2.yaml
 cp service.yaml service_no_health.yaml
 replace '$HEALTHPORT' $HEALTHPORT1 service.yaml
@@ -109,7 +109,7 @@ loadbalancer-healthserver   job-control-loop                  OK      0 health s
 -- health_with_service.table --
 Module                      Component                         Level   Message                    Error
 loadbalancer-healthserver   job-control-loop                  OK      1 health servers running
-loadbalancer-healthserver   job-listener-40000                OK      Running
+loadbalancer-healthserver   job-listener-40010                OK      Running
 
 -- services.table --
 Name                   Source   PortNames  TrafficPolicy   Flags
@@ -279,12 +279,12 @@ X-Load-Balancing-Endpoint-Weight=0
 -- lbmaps.expected --
 BE: ID=1 ADDR=[fd02::1]:80/TCP STATE=active
 BE: ID=2 ADDR=[fd02::2]:80/TCP STATE=active
-BE: ID=3 ADDR=[fd03::1111]:40000/TCP STATE=active
+BE: ID=3 ADDR=[fd03::1111]:40010/TCP STATE=active
 REV: ID=1 ADDR=[::]:30781
 REV: ID=2 ADDR=[fd03::1111]:30781
 REV: ID=3 ADDR=[fd00::aaaa]:80
 REV: ID=4 ADDR=[fd01::bbbb]:80
-REV: ID=5 ADDR=[fd01::bbbb]:40000
+REV: ID=5 ADDR=[fd01::bbbb]:40010
 SVC: ID=0 ADDR=[fd00::aaaa]:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
 SVC: ID=0 ADDR=[fd01::bbbb]:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+non-routable
 SVC: ID=1 ADDR=[::]:30781/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+Local+InternalLocal+non-routable
@@ -299,5 +299,5 @@ SVC: ID=3 ADDR=[fd00::aaaa]:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterI
 SVC: ID=4 ADDR=[fd01::bbbb]:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal
 SVC: ID=4 ADDR=[fd01::bbbb]:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal
 SVC: ID=4 ADDR=[fd01::bbbb]:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal
-SVC: ID=5 ADDR=[fd01::bbbb]:40000/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal
-SVC: ID=5 ADDR=[fd01::bbbb]:40000/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal
+SVC: ID=5 ADDR=[fd01::bbbb]:40010/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal
+SVC: ID=5 ADDR=[fd01::bbbb]:40010/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+Local+InternalLocal

--- a/pkg/loadbalancer/healthserver/testdata/healthserver-proxy-redirect.txtar
+++ b/pkg/loadbalancer/healthserver/testdata/healthserver-proxy-redirect.txtar
@@ -5,7 +5,7 @@ db/insert node-addresses addrv4.yaml
 
 hive start
 
-env HEALTHPORT=40002
+env HEALTHPORT=40022
 replace '$HEALTHPORT' $HEALTHPORT service.yaml
 
 # Add endpoints first to avoid races with health server setup.

--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -14,7 +14,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/cilium/hive"
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
 	"github.com/prometheus/client_golang/prometheus"
@@ -50,10 +49,9 @@ func (rc RegistryConfig) Flags(flags *pflag.FlagSet) {
 type RegistryParams struct {
 	cell.In
 
-	Logger     *slog.Logger
-	Shutdowner hive.Shutdowner
-	Lifecycle  cell.Lifecycle
-	JobGroup   job.Group
+	Logger    *slog.Logger
+	Lifecycle cell.Lifecycle
+	JobGroup  job.Group
 
 	AutoMetrics []metricpkg.WithMetadata `group:"hive-metrics"`
 	Config      RegistryConfig
@@ -85,17 +83,21 @@ func (reg *Registry) Gather() ([]*dto.MetricFamily, error) {
 }
 
 func (reg *Registry) AddServerRuntimeHooks(serverId string, tlsConfigPromise TLSConfigPromise, listenConfig net.ListenConfig) {
-	if reg.params.Config.PrometheusServeAddr != "" {
-		// The Handler function provides a default handler to expose metrics
-		// via an HTTP server. "/metrics" is the usual endpoint for that.
-		mux := http.NewServeMux()
-		mux.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
-		srv := http.Server{
-			Addr:    reg.params.Config.PrometheusServeAddr,
-			Handler: mux,
-		}
+	if reg.params.Config.PrometheusServeAddr == "" {
+		return
+	}
 
-		reg.params.JobGroup.Add(job.OneShot(serverId, func(ctx context.Context, _ cell.Health) error {
+	// The Handler function provides a default handler to expose metrics
+	// via an HTTP server. "/metrics" is the usual endpoint for that.
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
+	srv := http.Server{
+		Addr:    reg.params.Config.PrometheusServeAddr,
+		Handler: mux,
+	}
+
+	reg.params.JobGroup.Add(
+		job.OneShot(serverId, func(ctx context.Context, _ cell.Health) error {
 			tlsEnabled := tlsConfigPromise != nil
 			reg.params.Logger.Info("Serving prometheus metrics",
 				logfields.Server, serverId,
@@ -105,8 +107,7 @@ func (reg *Registry) AddServerRuntimeHooks(serverId string, tlsConfigPromise TLS
 
 			ln, err := listenConfig.Listen(ctx, "tcp", reg.params.Config.PrometheusServeAddr)
 			if err != nil {
-				reg.params.Shutdowner.Shutdown(hive.ShutdownWithError(err))
-				return nil
+				return err
 			}
 
 			var serveFn func() error
@@ -123,17 +124,19 @@ func (reg *Registry) AddServerRuntimeHooks(serverId string, tlsConfigPromise TLS
 				serveFn = func() error { return srv.Serve(ln) }
 			}
 
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			go func() {
+				<-ctx.Done()
+				srv.Close()
+			}()
+
 			if err := serveFn(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-				reg.params.Shutdowner.Shutdown(hive.ShutdownWithError(err))
+				return err
 			}
 			return nil
-		}))
-		reg.params.Lifecycle.Append(cell.Hook{
-			OnStop: func(hc cell.HookContext) error {
-				return srv.Shutdown(hc)
-			},
-		})
-	}
+		}, job.WithShutdown()),
+	)
 }
 
 // NewRegistry constructs a new registry that is not initialized with

--- a/vendor/github.com/cilium/hive/cell/lifecycle.go
+++ b/vendor/github.com/cilium/hive/cell/lifecycle.go
@@ -36,6 +36,14 @@ type HookDescriptiveInterface interface {
 	HookInfo() string
 }
 
+// PreStopHook marks the hook as a pre-stop hook. This is used by the
+// [job.registry] to ensure that the jobs started at runtime are
+// stopped before anything else to ensure their dependencies are not
+// stopped before the jobs.
+type PreStopHook interface {
+	PreStopHookMarker()
+}
+
 // Hook is a pair of start and stop callbacks. Both are optional.
 // They're paired up to make sure that on failed start all corresponding
 // stop hooks are executed.
@@ -82,12 +90,13 @@ type DefaultLifecycle struct {
 type augmentedHook struct {
 	HookInterface
 	moduleID FullModuleID
+	stopped  bool
 }
 
 func NewDefaultLifecycle(hooks []HookInterface, numStarted int, logThreshold time.Duration) *DefaultLifecycle {
 	h := make([]augmentedHook, 0, len(hooks))
 	for _, hook := range hooks {
-		h = append(h, augmentedHook{hook, nil})
+		h = append(h, augmentedHook{hook, nil, false})
 	}
 	return &DefaultLifecycle{
 		mu:           sync.Mutex{},
@@ -101,7 +110,7 @@ func (lc *DefaultLifecycle) Append(hook HookInterface) {
 	lc.mu.Lock()
 	defer lc.mu.Unlock()
 
-	lc.hooks = append(lc.hooks, augmentedHook{hook, nil})
+	lc.hooks = append(lc.hooks, augmentedHook{hook, nil, false})
 }
 
 func (lc *DefaultLifecycle) Start(log *slog.Logger, ctx context.Context) error {
@@ -116,6 +125,8 @@ func (lc *DefaultLifecycle) Start(log *slog.Logger, ctx context.Context) error {
 
 	from := lc.numStarted
 	for i, hook := range lc.hooks[from:] {
+		lc.hooks[from+i].stopped = false
+
 		fnName, exists := getHookFuncName(hook, true)
 
 		if !exists {
@@ -164,15 +175,10 @@ func (lc *DefaultLifecycle) Stop(log *slog.Logger, ctx context.Context) error {
 	defer cancel()
 
 	var errs error
-	for ; lc.numStarted > 0; lc.numStarted-- {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-		hook := lc.hooks[lc.numStarted-1]
-
+	runStopHook := func(hook augmentedHook) {
 		fnName, exists := getHookFuncName(hook, false)
 		if !exists {
-			continue
+			return
 		}
 
 		l := log.With("function", fnName)
@@ -195,6 +201,35 @@ func (lc *DefaultLifecycle) Stop(log *slog.Logger, ctx context.Context) error {
 			}
 		}
 	}
+
+	// Stop pre-stop hooks first. We can't update [lc.numStarted]
+	// since we're skipping hooks, so instead we mark the hook
+	// as already stopped to retain idempotency.
+	for i := lc.numStarted - 1; i >= 0; i-- {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		hook := lc.hooks[i]
+		if hook.stopped {
+			continue
+		}
+		if _, ok := hook.HookInterface.(PreStopHook); ok {
+			runStopHook(hook)
+			lc.hooks[i].stopped = true
+		}
+	}
+
+	// Finally stop the normal hooks.
+	for i := lc.numStarted - 1; i >= 0; i-- {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		hook := lc.hooks[i]
+		if !hook.stopped {
+			runStopHook(hook)
+		}
+		lc.numStarted--
+	}
 	return errs
 }
 
@@ -212,13 +247,24 @@ func (lc *DefaultLifecycle) PrintHooks(w io.Writer) {
 	}
 
 	fmt.Fprintf(w, "\nStop hooks:\n\n")
-	for i := len(lc.hooks) - 1; i >= 0; i-- {
-		hook := lc.hooks[i]
+	printHook := func(hook augmentedHook) {
 		fnName, exists := getHookFuncName(hook.HookInterface, false)
 		if !exists {
-			continue
+			return
 		}
 		fmt.Fprintf(w, "  • %s (%s)\n", fnName, hook.moduleID)
+	}
+	for i := len(lc.hooks) - 1; i >= 0; i-- {
+		hook := lc.hooks[i]
+		if _, ok := hook.HookInterface.(PreStopHook); ok {
+			printHook(hook)
+		}
+	}
+	for i := len(lc.hooks) - 1; i >= 0; i-- {
+		hook := lc.hooks[i]
+		if _, ok := hook.HookInterface.(PreStopHook); !ok {
+			printHook(hook)
+		}
 	}
 }
 
@@ -231,7 +277,7 @@ func (lc augmentedLifecycle) Append(hook HookInterface) {
 	lc.mu.Lock()
 	defer lc.mu.Unlock()
 
-	lc.hooks = append(lc.hooks, augmentedHook{hook, lc.moduleID})
+	lc.hooks = append(lc.hooks, augmentedHook{hook, lc.moduleID, false})
 }
 
 func getHookFuncName(hook HookInterface, start bool) (name string, hasHook bool) {

--- a/vendor/github.com/cilium/hive/cell/simple_health.go
+++ b/vendor/github.com/cilium/hive/cell/simple_health.go
@@ -31,11 +31,16 @@ func (h *SimpleHealth) NewScope(name string) Health {
 	h.Lock()
 	defer h.Unlock()
 
+	scope := name
+	if len(h.Scope) > 0 {
+		scope = h.Scope + "." + name
+	}
+
 	h2 := &SimpleHealth{
 		simpleHealthRoot: h.simpleHealthRoot,
-		Scope:            h.Scope + "." + name,
+		Scope:            scope,
 	}
-	h.all[name] = h2
+	h.all[scope] = h2
 	return h2
 }
 

--- a/vendor/github.com/cilium/hive/hive.go
+++ b/vendor/github.com/cilium/hive/hive.go
@@ -224,7 +224,7 @@ func AddConfigOverride[Cfg cell.Flagger](h *Hive, override func(*Cfg)) {
 }
 
 // RunOptionFunc is a functional option type for configuring hive on Run stage.
-type RunOptionFunc func (*Hive)
+type RunOptionFunc func(*Hive)
 
 // WithStartTimeout overrides hive StartTimeout option.
 func WithStartTimeout(timeout time.Duration) RunOptionFunc {

--- a/vendor/github.com/cilium/hive/job/job.go
+++ b/vendor/github.com/cilium/hive/job/job.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"runtime/pprof"
 	"sync"
+	"time"
 
 	"github.com/cilium/hive"
 	"github.com/cilium/hive/cell"
@@ -44,12 +45,20 @@ type registry struct {
 	logger     *slog.Logger
 	shutdowner hive.Shutdowner
 
-	mu      sync.Mutex
+	// appLifecycle is the main application appLifecycle. Jobs that are
+	// added before the registry is started are appended here. This ensures
+	// that the job starting order is interleaved with the start hooks and
+	// that we don't start the jobs before a dependency's start hook has ran.
+	appLifecycle cell.Lifecycle
+
+	// runtimeLifecycle is the lifecycle used after registry has started.
+	runtimeLifecycle jobLifecycle
+
+	// mu protects the fields below
+	mu sync.Mutex
+
 	groups  []*group
 	started bool
-
-	lifecycle cell.Lifecycle
-	dynamicLC *cell.DefaultLifecycle
 }
 
 var _ cell.HookInterface = (*registry)(nil)
@@ -60,9 +69,9 @@ func newRegistry(
 	lc cell.Lifecycle,
 ) Registry {
 	r := &registry{
-		logger:     logger,
-		shutdowner: shutdowner,
-		lifecycle:  lc,
+		logger:       logger,
+		shutdowner:   shutdowner,
+		appLifecycle: lc,
 	}
 	lc.Append(r)
 	return r
@@ -76,7 +85,6 @@ func (c *registry) Start(cell.HookContext) error {
 		return nil
 	}
 	c.started = true
-	c.dynamicLC = cell.NewDefaultLifecycle(nil, 0, 0)
 	return nil
 }
 
@@ -86,16 +94,18 @@ func (c *registry) Stop(ctx cell.HookContext) error {
 	if !c.started {
 		return nil
 	}
-	c.started = false
-	c.dynamicLC.Stop(c.logger, ctx)
-	return nil
+	return c.runtimeLifecycle.stop(ctx, c.logger)
 }
+
+// PreStopHookMarker tells [cell.DefaultLifecycle] that this
+// hook should be stopped before any other hook.
+func (c *registry) PreStopHookMarker() {}
 
 func (c *registry) WithLifecycle(lifecycle cell.Lifecycle) Registry {
 	r := &registry{
-		logger:     c.logger,
-		shutdowner: c.shutdowner,
-		lifecycle:  lifecycle,
+		logger:       c.logger,
+		shutdowner:   c.shutdowner,
+		appLifecycle: lifecycle,
 	}
 	lifecycle.Append(r)
 	return r
@@ -136,7 +146,7 @@ func (c *registry) addJobs(health cell.Health, opts options, jobs ...Job) {
 
 	if !c.started {
 		for _, job := range jobs {
-			c.lifecycle.Append(&queuedJob{
+			c.appLifecycle.Append(&queuedJob{
 				registry: c,
 				job:      job,
 				health:   health,
@@ -147,15 +157,15 @@ func (c *registry) addJobs(health cell.Health, opts options, jobs ...Job) {
 	}
 
 	for _, job := range jobs {
-		qj := &queuedJob{
-			registry: c,
-			job:      job,
-			health:   health,
-			options:  opts,
-		}
-		c.dynamicLC.Append(qj)
-		// Start the newly appended job immediately.
-		c.dynamicLC.Start(c.logger, context.Background())
+		c.runtimeLifecycle.insertAndStart(
+			&queuedJob{
+				registry:   c,
+				job:        job,
+				health:     health,
+				options:    opts,
+				runtimeJob: true,
+			},
+		)
 	}
 }
 
@@ -180,22 +190,40 @@ type Job interface {
 }
 
 type queuedJob struct {
-	registry *registry
-	job      Job
-	health   cell.Health
-	options  options
-	cancel   context.CancelFunc
-	done     chan struct{}
+	registry   *registry
+	job        Job
+	health     cell.Health
+	options    options
+	cancel     context.CancelFunc
+	done       chan struct{}
+	startedAt  time.Time
+	prev       *queuedJob
+	next       *queuedJob
+	runtimeJob bool
 }
 
 // Start implements cell.HookInterface.
 func (qj *queuedJob) Start(cell.HookContext) error {
+	qj.startedAt = time.Now()
 	qj.done = make(chan struct{})
 	ctx, cancel := context.WithCancel(context.Background())
 	qj.cancel = cancel
 	pprof.Do(ctx, qj.options.pprofLabels, func(ctx context.Context) {
 		go func() {
-			defer close(qj.done)
+			defer func() {
+				qj.registry.runtimeLifecycle.remove(qj)
+				if qj.runtimeJob {
+					qj.registry.logger.Info("Job stopped",
+						"job", qj.HookInfo(),
+						"duration", time.Since(qj.startedAt))
+				}
+				close(qj.done)
+			}()
+			if qj.runtimeJob {
+				// We only log this for runtime jobs since we already have the
+				// lifecycle logging for the jobs added before starting.
+				qj.registry.logger.Info("Job started", "job", qj.HookInfo())
+			}
 			qj.job.start(ctx, qj.health, qj.options)
 		}()
 	})
@@ -217,7 +245,7 @@ func (qj *queuedJob) Stop(ctx cell.HookContext) error {
 	}
 }
 
-var _ cell.HookInterface = &queuedJob{}
+var _ cell.HookDescriptiveInterface = &queuedJob{}
 
 type group struct {
 	registry *registry

--- a/vendor/github.com/cilium/hive/job/lifecycle.go
+++ b/vendor/github.com/cilium/hive/job/lifecycle.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package job
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	"github.com/cilium/hive/cell"
+)
+
+// jobLifecycle tracks jobs started after the [registry] has been started
+// (and thus not appended to application lifecycle) and to stop them when
+// [registry] stops. Jobs that are stopped earlier are removed from the
+// lifecycle.
+type jobLifecycle struct {
+	mu sync.Mutex
+
+	// jobs is a doubly linked-list of started jobs. The head is the latest
+	// started jobs, e.g. they're in the order they should be stopped.
+	jobs *queuedJob
+
+	// stopped is true if the lifecycle has been stopped and no new jobs
+	// can be added.
+	stopped bool
+}
+
+func (r *jobLifecycle) insertAndStart(job *queuedJob) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.stopped {
+		return
+	}
+
+	if r.jobs != nil {
+		r.jobs.prev = job
+	}
+	job.next = r.jobs
+	r.jobs = job
+	job.Start(context.Background())
+}
+
+func (r *jobLifecycle) remove(qj *queuedJob) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.jobs == nil {
+		qj.prev = nil
+		qj.next = nil
+		return
+	}
+
+	if qj.next != nil {
+		qj.next.prev = qj.prev
+	}
+	if qj == r.jobs {
+		r.jobs = qj.next
+	} else if qj.prev != nil {
+		qj.prev.next = qj.next
+	}
+	qj.prev = nil
+	qj.next = nil
+}
+
+func (r *jobLifecycle) stop(ctx cell.HookContext, log *slog.Logger) error {
+	// Collect jobs to stop and unlink them. We must stop them without holding the
+	// lock as [queuedJob.Stop] will try to call [jobLifecycle.remove].
+	var jobsToStop []*queuedJob
+	r.mu.Lock()
+	var next *queuedJob
+	for job := r.jobs; job != nil; job = next {
+		next = job.next
+		job.next = nil
+		job.prev = nil
+		jobsToStop = append(jobsToStop, job)
+	}
+	r.jobs = nil
+	r.stopped = true
+	r.mu.Unlock()
+	for _, job := range jobsToStop {
+		job.Stop(ctx)
+		if ctx.Err() != nil {
+			log.Error("Stop cancelled while waiting for job to stop",
+				"job",
+				job.job.info())
+			break
+		}
+	}
+	return ctx.Err()
+}

--- a/vendor/github.com/cilium/hive/job/observer.go
+++ b/vendor/github.com/cilium/hive/job/observer.go
@@ -42,6 +42,14 @@ type ObserverFunc[T any] func(ctx context.Context, event T) error
 
 type observerOpt[T any] func(*jobObserver[T])
 
+// WithObserverShutdown option configures an observer job to shutdown the whole
+// hive if the observer function returns a non-nil, non-context.Canceled error.
+func WithObserverShutdown[T any]() observerOpt[T] {
+	return func(jo *jobObserver[T]) {
+		jo.shutdownOnError = true
+	}
+}
+
 type jobObserver[T any] struct {
 	name string
 	fn   ObserverFunc[T]
@@ -52,7 +60,8 @@ type jobObserver[T any] struct {
 	observable stream.Observable[T]
 
 	// If not nil, call the shutdowner on error
-	shutdown hive.Shutdowner
+	shutdown        hive.Shutdowner
+	shutdownOnError bool
 }
 
 func (jo *jobObserver[T]) info() string {
@@ -64,7 +73,12 @@ func (jo *jobObserver[T]) start(ctx context.Context, health cell.Health, options
 		opt(jo)
 	}
 
+	if jo.shutdownOnError && options.shutdowner != nil {
+		jo.shutdown = options.shutdowner
+	}
+
 	jo.health = health.NewScope("observer-job-" + jo.name)
+	defer jo.health.Close()
 	reportTicker := time.NewTicker(10 * time.Second)
 	defer reportTicker.Stop()
 
@@ -72,7 +86,6 @@ func (jo *jobObserver[T]) start(ctx context.Context, health cell.Health, options
 		"name", jo.name,
 		"func", internal.FuncNameAndLocation(jo.fn))
 
-	l.Debug("Observer job started")
 	jo.health.OK("Primed")
 	var msgCount uint64
 
@@ -93,8 +106,12 @@ func (jo *jobObserver[T]) start(ctx context.Context, health cell.Health, options
 				return
 			}
 
-			jo.health.Degraded("observer job errored", err)
-			l.Error("Observer job errored", "error", err)
+			msg := fmt.Sprintf("Observer job failed (duration %s)", duration)
+			jo.health.Degraded(msg, err)
+			l.Error("Observer job errored",
+				"error", err,
+				"duration", duration,
+			)
 
 			if options.metrics != nil {
 				options.metrics.JobError(jo.name, err)
@@ -122,10 +139,7 @@ func (jo *jobObserver[T]) start(ctx context.Context, health cell.Health, options
 
 	<-done
 
-	jo.health.Stopped("observer job done")
 	if err != nil && !errors.Is(err, context.Canceled) {
 		l.Error("Observer job stopped with an error", "error", err)
-	} else {
-		l.Debug("Observer job stopped")
 	}
 }

--- a/vendor/github.com/cilium/hive/job/oneshot.go
+++ b/vendor/github.com/cilium/hive/job/oneshot.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/cilium/hive"
@@ -112,16 +113,16 @@ func (jos *jobOneShot) start(ctx context.Context, health cell.Health, options op
 	}
 
 	jos.health = health.NewScope("job-" + jos.name)
-	defer jos.health.Stopped("one-shot job done")
+	defer jos.health.Close()
 
 	l := options.logger.With(
 		"name", jos.name,
 		"func", internal.FuncNameAndLocation(jos.fn))
 
 	var err error
+	var timeout time.Duration
 	for i := 0; jos.retry < 0 || i <= jos.retry; i++ {
 		if i != 0 {
-			timeout := jos.backoff.Wait()
 			options.logger.Debug("Delaying retry attempt",
 				"backoff", timeout,
 				"retry-count", i,
@@ -133,22 +134,40 @@ func (jos *jobOneShot) start(ctx context.Context, health cell.Health, options op
 			}
 		}
 
-		l.Debug("Starting one-shot job")
-
 		jos.health.OK("Running")
 		start := time.Now()
 		err = jos.fn(ctx, jos.health)
 
+		duration := time.Since(start)
 		if options.metrics != nil {
-			duration := time.Since(start)
 			options.metrics.OneShotRunDuration(jos.name, duration)
 		}
 
-		if err == nil {
+		switch {
+		case err == nil:
+			jos.health.OK("Finished (" + duration.String() + ")")
 			return
-		} else if !errors.Is(err, context.Canceled) {
-			jos.health.Degraded("one-shot job errored", err)
-			l.Error("one-shot job errored", "error", err)
+		case errors.Is(err, context.Canceled) || ctx.Err() != nil:
+			return
+		default:
+			if jos.backoff != nil && (jos.retry < 0 || i < jos.retry) {
+				timeout = jos.backoff.Wait()
+			}
+			retriesRemain := strconv.FormatInt(int64(jos.retry-i), 10)
+			if jos.retry < 0 {
+				retriesRemain = "<inf>"
+			} else if jos.retry == 0 {
+				retriesRemain = "<none>"
+			}
+			msg := fmt.Sprintf("Failed (duration %s, retry %d/%s in %s)", duration, i+1, retriesRemain, timeout)
+			jos.health.Degraded(msg, err)
+			l.Error("Failed",
+				"error", err,
+				"retry", i+1,
+				"remaining", retriesRemain,
+				"timeout", timeout,
+				"duration", duration,
+			)
 			if options.metrics != nil {
 				options.metrics.JobError(jos.name, err)
 			}

--- a/vendor/github.com/cilium/hive/job/timer.go
+++ b/vendor/github.com/cilium/hive/job/timer.go
@@ -155,6 +155,7 @@ func (jt *jobTimer) start(ctx context.Context, health cell.Health, options optio
 	}
 
 	jt.health = health.NewScope("timer-job-" + jt.name)
+	defer jt.health.Close()
 
 	l := options.logger.With(
 		"name", jt.name,
@@ -172,13 +173,11 @@ func (jt *jobTimer) start(ctx context.Context, health cell.Health, options optio
 		triggerChan = jt.trigger.c
 	}
 
-	l.Debug("Starting timer job")
 	jt.health.OK("Primed")
 
 	for {
 		select {
 		case <-ctx.Done():
-			jt.health.Stopped("timer job context done")
 			return
 		case <-tickerChan:
 		case <-triggerChan:
@@ -202,8 +201,11 @@ func (jt *jobTimer) start(ctx context.Context, health cell.Health, options optio
 			jt.health.OK("OK (" + duration.String() + ")")
 			l.Debug("Timer job finished")
 		} else if !errors.Is(err, context.Canceled) {
-			jt.health.Degraded("timer job errored", err)
-			l.Error("Timer job errored", "error", err)
+			msg := fmt.Sprintf("Timer job failed (duration %s)", duration)
+			jt.health.Degraded(msg, err)
+			l.Error("Timer job failed",
+				"error", err,
+				"duration", duration)
 
 			if options.metrics != nil {
 				options.metrics.JobError(jt.name, err)

--- a/vendor/github.com/cilium/hive/shell/client.go
+++ b/vendor/github.com/cilium/hive/shell/client.go
@@ -235,12 +235,13 @@ repl:
 			}
 
 			line, ended := strings.CutSuffix(line, endMarker)
+			line, errored := strings.CutSuffix(line, errorMarker)
 			if isPrefix {
 				fmt.Fprint(console, line)
 			} else {
 				fmt.Fprintln(console, line)
 			}
-			if ended {
+			if ended || errored {
 				break
 			}
 		}

--- a/vendor/github.com/cilium/hive/shell/server.go
+++ b/vendor/github.com/cilium/hive/shell/server.go
@@ -102,7 +102,6 @@ func (sh shell) listener(ctx context.Context, health cell.Health) error {
 			fmt.Sprintf("shell-%d", connID),
 			func(ctx context.Context, h cell.Health) error {
 				sh.handleConn(ctx, connID, conn)
-				h.Close() // remove from health list
 				return nil
 			}))
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -333,7 +333,7 @@ github.com/cilium/endpointslice-controller/util/endpointslice
 # github.com/cilium/fake v0.7.0
 ## explicit; go 1.22
 github.com/cilium/fake
-# github.com/cilium/hive v1.0.1
+# github.com/cilium/hive v1.0.4-rc2
 ## explicit; go 1.23.0
 github.com/cilium/hive
 github.com/cilium/hive/cell


### PR DESCRIPTION
Bump to latest Hive version (https://github.com/cilium/hive/releases/tag/v1.0.4-rc2). The main change is to fix the stop ordering of jobs added at runtime (https://github.com/cilium/hive/pull/72). Earlier they were stopped as part of the job registry which usually was one of the last stop hooks, but this was way too late since dependencies of jobs were likely stopped before the jobs themselves. As we're starting to have many more jobs with more complexity it's best to fix this now. 

The cilium/hive release was marked as pre-release to stop automation from bumping to it and allowing manually bump along with fixes without having to race with automation. Once this is merged I'll release the v1.0.4 proper.

Multiple fixes were needed to code to fix the now incorrect assumptions on job stop ordering. If a fix was missed due to lacking CI coverage for a feature the worst case is stopping Cilium might get stuck and Hive would abort the stop, skip rest of the stop hooks and exit with non-zero status. I find this unlikely as coverage is generally good and I also did an audit of all job usages in the codebase and thus am of the opinion that fixing this now close to v1.20 branching is the right thing to do.

Cilium v1.19 and earlier depend on Hive v0.0.x and thus will not automatically bump to Hive v1.0.x. Currently no plan to backport v1.0.x versions of Hive to releases older than Cilium v1.20. The jobs in v1.19 earlier are still relatively simple and there's been no known issues from the stopping occurring late so no pressure to backport this (and potentially create issues).

The branch name references v2.0.0 which was the original versioning plan, but reverted to sticking with v1.0.x since v1.0 wasn't used yet in released versions of Cilium and since bumping to v2.0.0 requires switching to `/v2` Go module naming convention which is overkill for this change, especially as Hive v1.0.x is not yet used by released versions.

As an aside we had hints that something was wrong with job stop ordering for awhile with:
```
logger.go:256: time=2026-06-09T12:27:19.467+02:00 level=ERROR source=/home/jussi/go/src/github.com/cilium/cilium/pkg/hive/health/provider.go:240 
  msg="failed to upsert stop health status" module=health 
  reporter-id=loadbalancer-reconciler.job-refresh 
  error="provider is stopped, no more updates will take place"
```
Now these errors are gone as the jobs are correctly stopped earlier and do not try to use a stopped health reporter.