### PR TITLE
cilium-dbg: rank policy selectors by identity count

### DIFF
--- a/Documentation/cmdref/cilium-dbg_policy_selectors.md
+++ b/Documentation/cmdref/cilium-dbg_policy_selectors.md
@@ -11,9 +11,12 @@ cilium-dbg policy selectors [flags]
 ### Options
 
 ```
-  -h, --help            help for selectors
-  -o, --output string   json| yaml| jsonpath='{}'
-  -v, --verbose         Show the full labels
+  -h, --help                     help for selectors
+      --identity-threshold int   Minimum selector identity count shown with --top-identities
+      --limit int                Limit number of policies shown with --top-identities (0 for all) (default 20)
+  -o, --output string            json| yaml| jsonpath='{}'
+      --top-identities           Show policies with the highest selector identity count
+  -v, --verbose                  Show the full labels
 ```
 
 ### Options inherited from parent commands

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -424,6 +424,7 @@ func ciliumDbgCommands(cmdDir string) []string {
 		"cilium-dbg identity list",
 		"cilium-dbg policy get",
 		"cilium-dbg policy selectors -o json",
+		"cilium-dbg policy selectors --top-identities --limit 0 -o json",
 		"cilium-dbg node list",
 		"cilium-dbg node list -o json",
 		"cilium-dbg bpf nodeid list",

--- a/cilium-dbg/cmd/policy_selectors.go
+++ b/cilium-dbg/cmd/policy_selectors.go
@@ -19,6 +19,17 @@ import (
 )
 
 var verbosePolicySelectors bool
+var topPolicySelectorsByIdentities bool
+var topPolicySelectorsLimit int
+var topPolicySelectorsIdentityThreshold int
+
+type policySelectorIdentityCount struct {
+	IdentityCount int    `json:"identity_count"`
+	Policy        string `json:"policy"`
+	Namespace     string `json:"namespace"`
+	DerivedFrom   string `json:"derived_from"`
+	UID           string `json:"uid"`
+}
 
 // policyCacheGetCmd represents the policy selectors commands
 var policyCacheGetCmd = func(name, description string, f func() (models.SelectorCache, error)) *cobra.Command {
@@ -28,6 +39,26 @@ var policyCacheGetCmd = func(name, description string, f func() (models.Selector
 		Run: func(cmd *cobra.Command, args []string) {
 			if resp, err := f(); err != nil {
 				Fatalf("Cannot get policy: %s\n", err)
+			} else if topPolicySelectorsByIdentities {
+				if topPolicySelectorsLimit < 0 {
+					Fatalf("--limit must be greater than or equal to 0\n")
+				}
+				if topPolicySelectorsIdentityThreshold < 0 {
+					Fatalf("--identity-threshold must be greater than or equal to 0\n")
+				}
+
+				policies := getTopPolicySelectorIdentityCounts(
+					resp,
+					topPolicySelectorsIdentityThreshold,
+					topPolicySelectorsLimit,
+				)
+				if command.OutputOption() {
+					if err := command.PrintOutput(policies); err != nil {
+						os.Exit(1)
+					}
+				} else {
+					printPolicySelectorIdentityCounts(policies)
+				}
 			} else if command.OutputOption() {
 				if err := command.PrintOutput(resp); err != nil {
 					os.Exit(1)
@@ -74,6 +105,98 @@ var policyCacheGetCmd = func(name, description string, f func() (models.Selector
 	}
 }
 
+func getTopPolicySelectorIdentityCounts(resp models.SelectorCache, identityThreshold, limit int) []policySelectorIdentityCount {
+	countsByPolicy := map[policySelectorIdentityCount]policySelectorIdentityCount{}
+
+	for _, mapping := range resp {
+		if mapping == nil {
+			continue
+		}
+
+		identityCount := len(mapping.Identities)
+		if identityCount < identityThreshold {
+			continue
+		}
+
+		lblsList := constructLabelArrayListFromAPIType(mapping.Labels)
+		if len(lblsList) == 0 {
+			upsertPolicySelectorIdentityCount(countsByPolicy, policySelectorIdentityCount{IdentityCount: identityCount})
+			continue
+		}
+
+		for _, lbls := range lblsList {
+			policy := policySelectorIdentityCountFromLabels(lbls, identityCount)
+			upsertPolicySelectorIdentityCount(countsByPolicy, policy)
+		}
+	}
+
+	policies := make([]policySelectorIdentityCount, 0, len(countsByPolicy))
+	for _, policy := range countsByPolicy {
+		policies = append(policies, policy)
+	}
+
+	sort.Slice(policies, func(i, j int) bool {
+		if policies[i].IdentityCount != policies[j].IdentityCount {
+			return policies[i].IdentityCount > policies[j].IdentityCount
+		}
+		if policies[i].Namespace != policies[j].Namespace {
+			return policies[i].Namespace < policies[j].Namespace
+		}
+		if policies[i].Policy != policies[j].Policy {
+			return policies[i].Policy < policies[j].Policy
+		}
+		if policies[i].DerivedFrom != policies[j].DerivedFrom {
+			return policies[i].DerivedFrom < policies[j].DerivedFrom
+		}
+		return policies[i].UID < policies[j].UID
+	})
+
+	if limit > 0 && len(policies) > limit {
+		return policies[:limit]
+	}
+
+	return policies
+}
+
+func policySelectorIdentityCountFromLabels(lbls labels.LabelArray, identityCount int) policySelectorIdentityCount {
+	policy := policySelectorIdentityCount{
+		IdentityCount: identityCount,
+		Policy:        lbls.Get(labels.LabelSourceK8sKeyPrefix + k8sconst.PolicyLabelName),
+		Namespace:     lbls.Get(labels.LabelSourceK8sKeyPrefix + k8sconst.PolicyLabelNamespace),
+		DerivedFrom:   lbls.Get(labels.LabelSourceK8sKeyPrefix + k8sconst.PolicyLabelDerivedFrom),
+		UID:           lbls.Get(labels.LabelSourceK8sKeyPrefix + k8sconst.PolicyLabelUID),
+	}
+
+	if policy.Policy == "" && policy.Namespace == "" && policy.DerivedFrom == "" && policy.UID == "" {
+		return policySelectorIdentityCount{IdentityCount: identityCount}
+	}
+
+	return policy
+}
+
+func upsertPolicySelectorIdentityCount(countsByPolicy map[policySelectorIdentityCount]policySelectorIdentityCount, policy policySelectorIdentityCount) {
+	key := policy
+	key.IdentityCount = 0
+
+	existing, ok := countsByPolicy[key]
+	if !ok || policy.IdentityCount > existing.IdentityCount {
+		countsByPolicy[key] = policy
+	}
+}
+
+func printPolicySelectorIdentityCounts(policies []policySelectorIdentityCount) {
+	w := tabwriter.NewWriter(os.Stdout, 5, 0, 3, ' ', 0)
+	fmt.Fprintf(w, "IDENTITY COUNT\tPOLICY\tNAMESPACE\tDERIVED FROM\tUID\n")
+	for _, policy := range policies {
+		policyName := policy.Policy
+		if policyName == "" {
+			policyName = "<unknown>"
+		}
+		fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\n", policy.IdentityCount, policyName, policy.Namespace, policy.DerivedFrom, policy.UID)
+	}
+	w.Flush()
+}
+
 func getNameAndNamespaceFromLabels(list labels.LabelArrayList) string {
 	var sb strings.Builder
 	for _, lbls := range list {
@@ -108,14 +231,16 @@ func constructLabelArrayListFromAPIType(in models.LabelArrayList) labels.LabelAr
 
 func init() {
 	for _, c := range []struct {
-		name        string
-		description string
-		f           func() (models.SelectorCache, error)
+		name          string
+		description   string
+		topIdentities bool
+		f             func() (models.SelectorCache, error)
 	}{
 		{
-			name:        "selectors",
-			description: "Display cached information about selectors",
-			f:           func() (models.SelectorCache, error) { return client.PolicyCacheGet() },
+			name:          "selectors",
+			description:   "Display cached information about selectors",
+			topIdentities: true,
+			f:             func() (models.SelectorCache, error) { return client.PolicyCacheGet() },
 		},
 		{
 			name:        "subject-selectors",
@@ -125,6 +250,11 @@ func init() {
 	} {
 		cmd := policyCacheGetCmd(c.name, c.description, c.f)
 		cmd.Flags().BoolVarP(&verbosePolicySelectors, "verbose", "v", false, "Show the full labels")
+		if c.topIdentities {
+			cmd.Flags().BoolVar(&topPolicySelectorsByIdentities, "top-identities", false, "Show policies with the highest selector identity count")
+			cmd.Flags().IntVar(&topPolicySelectorsLimit, "limit", 20, "Limit number of policies shown with --top-identities (0 for all)")
+			cmd.Flags().IntVar(&topPolicySelectorsIdentityThreshold, "identity-threshold", 0, "Minimum selector identity count shown with --top-identities")
+		}
 		PolicyCmd.AddCommand(cmd)
 		command.AddOutputOption(cmd)
 	}

--- a/cilium-dbg/cmd/policy_selectors_test.go
+++ b/cilium-dbg/cmd/policy_selectors_test.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/api/v1/models"
+	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	labelpkg "github.com/cilium/cilium/pkg/labels"
+)
+
+func TestGetTopPolicySelectorIdentityCounts(t *testing.T) {
+	resp := models.SelectorCache{
+		{
+			Selector:   "selector-a",
+			Identities: testPolicySelectorIdentities(10),
+			Labels: models.LabelArrayList{
+				testPolicySelectorLabels("default", "policy-a", "uid-a", "CiliumNetworkPolicy"),
+			},
+		},
+		{
+			Selector:   "selector-b",
+			Identities: testPolicySelectorIdentities(5),
+			Labels: models.LabelArrayList{
+				testPolicySelectorLabels("default", "policy-a", "uid-a", "CiliumNetworkPolicy"),
+			},
+		},
+		{
+			Selector:   "selector-c",
+			Identities: testPolicySelectorIdentities(12),
+			Labels: models.LabelArrayList{
+				testPolicySelectorLabels("default", "policy-b", "uid-b", "CiliumNetworkPolicy"),
+				testPolicySelectorLabels("", "policy-c", "uid-c", "CiliumClusterwideNetworkPolicy"),
+			},
+		},
+		{
+			Selector:   "selector-d",
+			Identities: testPolicySelectorIdentities(11),
+		},
+		{
+			Selector:   "selector-e",
+			Identities: testPolicySelectorIdentities(1),
+			Labels: models.LabelArrayList{
+				testPolicySelectorLabels("default", "policy-e", "uid-e", "CiliumNetworkPolicy"),
+			},
+		},
+	}
+
+	got := getTopPolicySelectorIdentityCounts(resp, 2, 0)
+
+	require.Equal(t, []policySelectorIdentityCount{
+		{
+			IdentityCount: 12,
+			Policy:        "policy-c",
+			DerivedFrom:   "CiliumClusterwideNetworkPolicy",
+			UID:           "uid-c",
+		},
+		{
+			IdentityCount: 12,
+			Policy:        "policy-b",
+			Namespace:     "default",
+			DerivedFrom:   "CiliumNetworkPolicy",
+			UID:           "uid-b",
+		},
+		{
+			IdentityCount: 11,
+		},
+		{
+			IdentityCount: 10,
+			Policy:        "policy-a",
+			Namespace:     "default",
+			DerivedFrom:   "CiliumNetworkPolicy",
+			UID:           "uid-a",
+		},
+	}, got)
+}
+
+func TestGetTopPolicySelectorIdentityCountsAppliesLimit(t *testing.T) {
+	resp := models.SelectorCache{
+		{
+			Identities: testPolicySelectorIdentities(3),
+			Labels: models.LabelArrayList{
+				testPolicySelectorLabels("default", "policy-a", "uid-a", "CiliumNetworkPolicy"),
+			},
+		},
+		{
+			Identities: testPolicySelectorIdentities(2),
+			Labels: models.LabelArrayList{
+				testPolicySelectorLabels("default", "policy-b", "uid-b", "CiliumNetworkPolicy"),
+			},
+		},
+	}
+
+	got := getTopPolicySelectorIdentityCounts(resp, 0, 1)
+
+	require.Equal(t, []policySelectorIdentityCount{
+		{
+			IdentityCount: 3,
+			Policy:        "policy-a",
+			Namespace:     "default",
+			DerivedFrom:   "CiliumNetworkPolicy",
+			UID:           "uid-a",
+		},
+	}, got)
+}
+
+func testPolicySelectorLabels(namespace, name, uid, derivedFrom string) models.LabelArray {
+	lbls := models.LabelArray{
+		{
+			Key:    k8sconst.PolicyLabelDerivedFrom,
+			Source: labelpkg.LabelSourceK8s,
+			Value:  derivedFrom,
+		},
+		{
+			Key:    k8sconst.PolicyLabelName,
+			Source: labelpkg.LabelSourceK8s,
+			Value:  name,
+		},
+		{
+			Key:    k8sconst.PolicyLabelUID,
+			Source: labelpkg.LabelSourceK8s,
+			Value:  uid,
+		},
+	}
+
+	if namespace != "" {
+		lbls = append(lbls, &models.Label{
+			Key:    k8sconst.PolicyLabelNamespace,
+			Source: labelpkg.LabelSourceK8s,
+			Value:  namespace,
+		})
+	}
+
+	return lbls
+}
+
+func testPolicySelectorIdentities(count int) []int64 {
+	identities := make([]int64, count)
+	for i := range identities {
+		identities[i] = int64(i + 1)
+	}
+	return identities
+}


### PR DESCRIPTION
## Summary

Add `cilium-dbg policy selectors --top-identities` to surface the policies whose selectors match the most identities. The new view:

- aggregates selector entries per policy using the maximum selector identity count
- shows `identity_count`, policy name, namespace, derived-from, and UID
- keeps unattributed selectors visible as unknown
- supports `--limit` with `0` meaning unlimited and `--identity-threshold`
- returns the same policy-level records for `-o json`

Also collect the unlimited JSON report in `cilium-bugtool`, and regenerate cmdref for the new flags.
