### PR TITLE
Revert "chore(deps): update all lvh-images main"

### DIFF
--- a/.github/actions/e2e/kernel-versions.yml
+++ b/.github/actions/e2e/kernel-versions.yml
@@ -1,13 +1,13 @@
 kernels:
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
-  rhel8.10: 'rhel8.10-20260525.014435'
+  rhel8.10: 'rhel8.10-20260310.122539'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
-  5.15: '5.15-20260525.014435'
+  5.15: '5.15-20260310.122539'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
-  6.1: '6.1-20260525.014435'
+  6.1: '6.1-20260310.122539'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
   6.6: '6.6-20260525.014435'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
-  6.12: '6.12-20260525.014435'
+  6.12: '6.12-20260310.122539'
   # renovate: datasource=docker depName=quay.io/lvh-images/kind
-  6.18: '6.18-20260525.014435'
+  6.18: '6.18-20260310.122539'

--- a/.github/actions/ginkgo/main-k8s-versions.yaml
+++ b/.github/actions/ginkgo/main-k8s-versions.yaml
@@ -6,7 +6,7 @@ include:
     # renovate: datasource=docker
     kube-image: "quay.io/cilium/kindest-node:v1.36.0@sha256:0244ee685fe1947d4826c766291f7b03ba29a6794b655ad9a579c29cb627d8a8"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "6.18-20260525.014435"
+    kernel: "6.18-20260310.122539"
     kernel-type: "latest"
 
   - k8s-version: "1.35"
@@ -14,7 +14,7 @@ include:
     # renovate: datasource=docker
     kube-image: "quay.io/cilium/kindest-node:v1.35.0@sha256:a36285a50bb7ee33d44b6d7938dca10e34f8a9294873ae4b0b04f9d21619d44c"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "6.12-20260525.014435"
+    kernel: "6.12-20260310.122539"
     kernel-type: "oldstable"
 
   - k8s-version: "1.34"
@@ -30,5 +30,5 @@ include:
     # renovate: datasource=docker
     kube-image: "quay.io/cilium/kindest-node:v1.33.4@sha256:25a6018e48dfcaee478f4a59af81157a437f15e6e140bf103f85a2e7cd0cbbf2"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "6.1-20260525.014435"
+    kernel: "6.1-20260310.122539"
     kernel-type: "stable"

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -201,7 +201,7 @@ jobs:
 
           - focus: "privileged"
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            lvhImage: "6.18-20260525.014435"
+            lvhImage: "6.18-20260504.013701"
 
     timeout-minutes: 50
     steps:

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -142,17 +142,17 @@ jobs:
           KERNEL="${{ matrix.kernel }}"
           case "$KERNEL" in
             # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-            "5.15") FULL_KERNEL="5.15-20260525.014435" ;;
+            "5.15") FULL_KERNEL="5.15-20260310.122539" ;;
             # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-            "6.1") FULL_KERNEL="6.1-20260525.014435" ;;
+            "6.1") FULL_KERNEL="6.1-20260310.122539" ;;
             # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
             "6.6") FULL_KERNEL="6.6-20260525.014435" ;;
             # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-            "6.12") FULL_KERNEL="6.12-20260525.014435" ;;
+            "6.12") FULL_KERNEL="6.12-20260310.122539" ;;
             # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-            "6.18") FULL_KERNEL="6.18-20260525.014435" ;;
+            "6.18") FULL_KERNEL="6.18-20260310.122539" ;;
             # renovate: datasource=docker depName=quay.io/lvh-images/complexity-test
-            "bpf-next") FULL_KERNEL="bpf-next-20260525.014435" ;;
+            "bpf-next") FULL_KERNEL="bpf-next-20260310.122539" ;;
             *) FULL_KERNEL="$KERNEL" ;;
           esac
           echo "full=${FULL_KERNEL}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This reverts commit e6f96bc078f77676a1b2d4d072bd1a3c68150811. That update of LVH images broke the Conformance Runtime workflow.