### PR TITLE
test: Print journalctl from failed service

### DIFF
--- a/test/provision/compile.sh
+++ b/test/provision/compile.sh
@@ -43,7 +43,7 @@ services=$(cd /etc/systemd/system; ls -1 ${services_pattern})
 for service in ${services}; do
     echo "installing service $service"
     sudo systemctl enable $service || echo "service $service failed"
-    sudo systemctl restart $service || echo "service $service failed to restart"
+    sudo systemctl restart $service || journalctl -xeu $service
 done
 
 echo "running \"sudo adduser ${VMUSER} cilium\" "


### PR DESCRIPTION
Originally I added this to debug https://github.com/cilium/cilium/issues/46223, but it seems generally useful
in case docker-run-cilium.sh fails in the future.

Example output:

```
May 28 01:23:55 kind-6.18 systemd[1]: Starting cilium.service - cilium...
░░ Subject: A start job for unit cilium.service has begun execution
░░ Defined-By: systemd
░░ Support: https://www.debian.org/support
░░ 
░░ A start job for unit cilium.service has begun execution.
░░ 
░░ The job identifier is 602.
May 28 01:23:55 kind-6.18 docker-run-cilium[1260]: Launching Cilium agent quay.io/cilium/cilium-ci:d8debc9c43da52a56ec4ce53e923156b3e27265a with params --kvstore etcd --kvstore-opt etcd.address=127.0.0.1:4001
May 28 01:23:55 kind-6.18 docker-run-cilium[1270]: Unable to find image 'quay.io/cilium/cilium-ci:d8debc9c43da52a56ec4ce53e923156b3e27265a' locally
May 28 01:23:56 kind-6.18 docker-run-cilium[1270]: d8debc9c43da52a56ec4ce53e923156b3e27265a: Pulling from cilium/cilium-ci
May 28 01:23:56 kind-6.18 docker-run-cilium[1270]: ad02e31fc9e5: Pulling fs layer
May 28 01:23:56 kind-6.18 docker-run-cilium[1270]: b3958d325295: Pulling fs layer
May 28 01:23:56 kind-6.18 docker-run-cilium[1270]: ae1fc6635f44: Pulling fs layer
May 28 01:23:56 kind-6.18 docker-run-cilium[1270]: 9c458481021e: Pulling fs layer
May 28 01:23:56 kind-6.18 docker-run-cilium[1270]: 88d751de0957: Pulling fs layer
May 28 01:23:57 kind-6.18 docker-run-cilium[1270]: 9c458481021e: Download complete
May 28 01:23:57 kind-6.18 docker-run-cilium[1270]: ae1fc6635f44: Download complete
May 28 01:23:58 kind-6.18 docker-run-cilium[1270]: b3958d325295: Download complete
May 28 01:24:01 kind-6.18 docker-run-cilium[1270]: 9c458481021e: Pull complete
May 28 01:24:01 kind-6.18 docker-run-cilium[1270]: b3958d325295: Pull complete
May 28 01:24:01 kind-6.18 docker-run-cilium[1270]: ad02e31fc9e5: Download complete
May 28 01:24:02 kind-6.18 docker-run-cilium[1270]: ad02e31fc9e5: Pull complete
May 28 01:24:08 kind-6.18 docker-run-cilium[1270]: 88d751de0957: Download complete
May 28 01:24:11 kind-6.18 docker-run-cilium[1270]: ae1fc6635f44: Pull complete
May 28 01:24:11 kind-6.18 docker-run-cilium[1270]: 88d751de0957: Pull complete
May 28 01:24:11 kind-6.18 docker-run-cilium[1270]: Digest: sha256:aa1ddf847e26b50fed64797b19d85336b11be9de00b3143b77c3e43a7ce1a974
May 28 01:24:11 kind-6.18 docker-run-cilium[1270]: Status: Downloaded newer image for quay.io/cilium/cilium-ci:d8debc9c43da52a56ec4ce53e923156b3e27265a
May 28 01:24:12 kind-6.18 docker-run-cilium[1270]: d65acef3f52eecbc6cb6c3f9562af9f67d6e76093c021afff8ecb4bee2809e9b
May 28 01:24:12 kind-6.18 docker-run-cilium[1328]: Error response from daemon: mkdirat var/run/cilium: path escapes from parent
May 28 01:24:12 kind-6.18 systemd[1]: cilium.service: Main process exited, code=exited, status=1/FAILURE
```