### PR TITLE
bpf: sock: touch revnat entry after insert to set LRU ref-bit

### DIFF
--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -164,9 +164,17 @@ static __always_inline int sock4_update_revnat(struct bpf_sock_addr *ctx,
 	val.rev_nat_index = rev_nat_id;
 
 	tmp = map_lookup_elem(&cilium_lb4_reverse_sk, &key);
-	if (!tmp || memcmp(tmp, &val, sizeof(val)))
-		ret = map_update_elem(&cilium_lb4_reverse_sk, &key,
-				      &val, 0);
+	if (!tmp || memcmp(tmp, &val, sizeof(val))) {
+		ret = map_update_elem(&cilium_lb4_reverse_sk, &key, &val, 0);
+
+		/* Touch the reverse NAT entry after insertion to
+		 * prevent premature LRU eviction before the
+		 * reverse-path lookup arrives.
+		 */
+		if (ret == 0 && !tmp)
+			map_lookup_elem(&cilium_lb4_reverse_sk, &key);
+	}
+
 	return ret;
 }
 
@@ -677,9 +685,17 @@ static __always_inline int sock6_update_revnat(struct bpf_sock_addr *ctx,
 	val.rev_nat_index = rev_nat_index;
 
 	tmp = map_lookup_elem(&cilium_lb6_reverse_sk, &key);
-	if (!tmp || memcmp(tmp, &val, sizeof(val)))
-		ret = map_update_elem(&cilium_lb6_reverse_sk, &key,
-				      &val, 0);
+	if (!tmp || memcmp(tmp, &val, sizeof(val))) {
+		ret = map_update_elem(&cilium_lb6_reverse_sk, &key, &val, 0);
+
+		/* Touch the reverse NAT entry after insertion to
+		 * prevent premature LRU eviction before the
+		 * reverse-path lookup arrives.
+		 */
+		if (ret == 0 && !tmp)
+			map_lookup_elem(&cilium_lb6_reverse_sk, &key);
+	}
+
 	return ret;
 }
 


### PR DESCRIPTION
Linux upstream commit 3a08c2fd763450a927d1130de078d6f9e74944fb ("bpf: LRU List") describes the BPF LRU hash map ref-bit semantics as follows:

"The access frequency is approximated by a ref-bit. The ref-bit is set during the bpf_lookup_elem()."

A newly inserted socket reverse NAT entry can enter the BPF LRU hash map with ref=0. Unless the entry is looked up afterwards, the kernel has not observed any access that would set the ref bit. When the map is close to full and more new entries are inserted afterwards, this can make the fresh entry look inactive and allow it to be reclaimed before the reverse-path lookup gets a chance to use it.

The failure can happen as follows:

  t0: the map is close to full, and Cilium inserts a new socket reverse
      NAT entry. The new LRU node remains ref=0.

  t1: more new entries are inserted, consuming LOCAL_FREE and triggering
      a local flush. Since the target entry still has ref=0, it is moved
      from LOCAL_PENDING to the INACTIVE list.

  t2: GLOBAL_FREE cannot refill enough entries, so LRU shrink scans the
      INACTIVE list from the tail. The still-untouched target entry can
      be deleted from the hash.

  t3: the reverse-path lookup for the same socket reverse NAT entry
      misses, even though the entry was inserted on the forward path.

The interval from t0 to t3 can be only a few hundred milliseconds. In our production environment, this was observed with DNS traffic: a container sent a DNS query, but the DNS response was not reverse-NATed because the socket reverse NAT entry had already been evicted.

Look up newly inserted socket reverse NAT entries once after a successful update. This lets the kernel set the LRU ref bit via bpf_lookup_elem() and prevents premature eviction before the reverse-path lookup arrives.

Fixes: f62d27bc32d9 ("bpf: implement unconnected udp based host lb")

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

<!-- Description of change -->

```release-note
Prevent premature LRU eviction of newly inserted socket reverse NAT entries by touching the entry after insertion to set the LRU reference bit.
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
