### PR TITLE
kpr/initializer: fix reserved port range validation

### DIFF
--- a/pkg/kpr/initializer/kube_proxy_replacement.go
+++ b/pkg/kpr/initializer/kube_proxy_replacement.go
@@ -407,8 +407,8 @@ func checkNodePortAndEphemeralPortRanges(lbConfig loadbalancer.Config, sysctl sy
 			break
 		}
 		ports := strings.Split(portRange, "-")
-		if len(ports) == 0 {
-			return fmt.Errorf("Invalid reserved ports range")
+		if len(ports) != 1 && len(ports) != 2 {
+			return fmt.Errorf("Invalid reserved ports range %q", portRange)
 		}
 		from, err := strconv.Atoi(ports[0])
 		if err != nil {
@@ -418,6 +418,9 @@ func checkNodePortAndEphemeralPortRanges(lbConfig loadbalancer.Config, sysctl sy
 		if len(ports) == 2 {
 			if to, err = strconv.Atoi(ports[1]); err != nil {
 				return fmt.Errorf("Unable to parse reserved port %q", ports[1])
+			}
+			if from > to {
+				return fmt.Errorf("Invalid reserved ports range %q: start must be less than or equal to end", portRange)
 			}
 		}
 


### PR DESCRIPTION
`strings.Split` always returns a slice with at least one item (the original string) even if the delimiter wasn't found. Thus the check is currently dead code. The intent is to reject invalid reserved port ranges such as 1000-2000-3000. Fix the condition to only either match single ports or port ranges of the form N-M. Also add an additional check that from ≤ to as suggested by Anton.