### PR TITLE
k8s/portforward: avoid panic in case of service without ports

### DIFF
--- a/pkg/k8s/portforward/portforward.go
+++ b/pkg/k8s/portforward/portforward.go
@@ -146,6 +146,9 @@ func (pf *PortForwarder) PortForwardService(ctx context.Context, namespace, name
 	}
 
 	if svcPort == 0 {
+		if len(svc.Spec.Ports) == 0 {
+			return nil, fmt.Errorf("service %q doesn't have any ports", name)
+		}
 		svcPort = svc.Spec.Ports[0].Port
 	}
 


### PR DESCRIPTION
`svc` is fetched from the Kubernetes API, so a service with no ports would cause a runtime panic. The godoc says "If `svcPort` is 0, uses the first port configured on the service " but there's currently no guard for an empty Ports slice. Return a proper error in this case instead of `panic`ing.