### PR TITLE
[network-driver]: Follow agents config to enable IP address families

### DIFF
--- a/pkg/networkdriver/dra.go
+++ b/pkg/networkdriver/dra.go
@@ -296,8 +296,12 @@ type netDevConfig struct {
 func (driver *Driver) netConfigForDevice(ctx context.Context, device string, cfg types.DeviceConfig) (netDevConfig, error) {
 	var devCfg netDevConfig
 
-	devCfg.ipv4 = cfg.IPv4Addr
-	devCfg.ipv6 = cfg.IPv6Addr
+	if driver.ipv4Enabled {
+		devCfg.ipv4 = cfg.IPv4Addr
+	}
+	if driver.ipv6Enabled {
+		devCfg.ipv6 = cfg.IPv6Addr
+	}
 	devCfg.vlan = cfg.Vlan
 
 	if cfg.NetworkConfig == "" {
@@ -322,8 +326,12 @@ func (driver *Driver) netConfigForDevice(ctx context.Context, device string, cfg
 	}
 	targetCfg := &netCfg.Specs[targetIdx]
 
-	devCfg.routes = make([]route, 0, len(targetCfg.IPv4Routes)+len(targetCfg.IPv6Routes))
-	devCfg.routes = append(targetCfg.IPv4Routes, targetCfg.IPv6Routes...)
+	if driver.ipv4Enabled {
+		devCfg.routes = append(devCfg.routes, targetCfg.IPv4Routes...)
+	}
+	if driver.ipv6Enabled {
+		devCfg.routes = append(devCfg.routes, targetCfg.IPv6Routes...)
+	}
 
 	// Overwrite VLAN only when it is not configured directly in the DeviceConfiga
 	if devCfg.vlan == 0 {
@@ -337,17 +345,10 @@ func (driver *Driver) netConfigForDevice(ctx context.Context, device string, cfg
 		pool = targetCfg.IPPool
 	}
 
-	v4FromPool := !cfg.IPv4Addr.IsValid() && pool != ""
-	v6FromPool := !cfg.IPv6Addr.IsValid() && pool != ""
+	v4FromPool := !cfg.IPv4Addr.IsValid() && pool != "" && driver.ipv4Enabled
+	v6FromPool := !cfg.IPv6Addr.IsValid() && pool != "" && driver.ipv6Enabled
 
 	if v4FromPool || v6FromPool {
-		if v4FromPool && !driver.ipv4Enabled {
-			return devCfg, fmt.Errorf("unable to allocate an IPv4 address from resource pool %s for device %s: IPv4 support is not enabled", pool, device)
-		}
-		if v6FromPool && !driver.ipv6Enabled {
-			return devCfg, fmt.Errorf("unable to allocate an IPv6 address from resource pool %s for device %s: IPv6 support is not enabled", pool, device)
-		}
-
 		devCfg.ipPool = pool
 
 		v4PoolAddr, v6PoolAddr, err := driver.addrsForDevice(ctx, device, ipam.Pool(pool), v4FromPool, v6FromPool)

--- a/pkg/networkdriver/dra.go
+++ b/pkg/networkdriver/dra.go
@@ -333,7 +333,7 @@ func (driver *Driver) netConfigForDevice(ctx context.Context, device string, cfg
 		devCfg.routes = append(devCfg.routes, targetCfg.IPv6Routes...)
 	}
 
-	// Overwrite VLAN only when it is not configured directly in the DeviceConfiga
+	// Overwrite VLAN only when it is not configured directly in the DeviceConfig
 	if devCfg.vlan == 0 {
 		devCfg.vlan = targetCfg.Vlan
 	}

--- a/pkg/networkdriver/network_config.go
+++ b/pkg/networkdriver/network_config.go
@@ -213,7 +213,7 @@ func resourceNetworkConfigReflectorConfig(cs client.Clientset, crdSync promise.P
 						if err != nil {
 							return resourceNetworkConfig{}, false
 						}
-						s.IPv4Routes = append(s.IPv4Routes, r)
+						s.IPv6Routes = append(s.IPv6Routes, r)
 					}
 				}
 

--- a/pkg/networkdriver/prepare_test.go
+++ b/pkg/networkdriver/prepare_test.go
@@ -318,12 +318,13 @@ func TestPrepare_PodStaticIPsAnnotation(t *testing.T) {
 	testCases := []struct {
 		name        string
 		annotation  map[string]types.StaticAddrsMap
+		ipv4Enabled bool
+		ipv6Enabled bool
 		expectedIPs []string
 	}{
 		{
-			name: "IPv4 and IPv6",
+			name: "IPv4 and IPv6 on dual stack",
 			annotation: map[string]types.StaticAddrsMap{
-
 				prepTestClaimName: {
 					prepTestRequest: {
 						IPv4: netip.MustParsePrefix("10.44.0.9/24"),
@@ -331,10 +332,40 @@ func TestPrepare_PodStaticIPsAnnotation(t *testing.T) {
 					},
 				},
 			},
+			ipv4Enabled: true,
+			ipv6Enabled: true,
 			expectedIPs: []string{"10.44.0.9/24", "fdaa::1/128"}, // IPs from annotation must be used instead of defaults in claim config
 		},
 		{
-			name: "IPv4 only",
+			name: "IPv4 and IPv6 on v4 single stack",
+			annotation: map[string]types.StaticAddrsMap{
+				prepTestClaimName: {
+					prepTestRequest: {
+						IPv4: netip.MustParsePrefix("10.44.0.9/24"),
+						IPv6: netip.MustParsePrefix("fdaa::1/128"),
+					},
+				},
+			},
+			ipv4Enabled: true,
+			ipv6Enabled: false,
+			expectedIPs: []string{"10.44.0.9/24"}, // IPv4 from annotation must be used instead of defaults in claim config
+		},
+		{
+			name: "IPv4 and IPv6 on v6 single stack",
+			annotation: map[string]types.StaticAddrsMap{
+				prepTestClaimName: {
+					prepTestRequest: {
+						IPv4: netip.MustParsePrefix("10.44.0.9/24"),
+						IPv6: netip.MustParsePrefix("fdaa::1/128"),
+					},
+				},
+			},
+			ipv4Enabled: false,
+			ipv6Enabled: true,
+			expectedIPs: []string{"fdaa::1/128"}, // IPv6 from annotation must be used instead of defaults in claim config
+		},
+		{
+			name: "IPv4 only on dual stack",
 			annotation: map[string]types.StaticAddrsMap{
 				prepTestClaimName: {
 					prepTestRequest: {
@@ -342,10 +373,12 @@ func TestPrepare_PodStaticIPsAnnotation(t *testing.T) {
 					},
 				},
 			},
+			ipv4Enabled: true,
+			ipv6Enabled: true,
 			expectedIPs: []string{"10.44.0.9/24", "fd00::1/128"}, // IPv4 from annotation, IPv6 from claim config (annotation must not override missing IP family)
 		},
 		{
-			name: "IPv6 only",
+			name: "IPv6 only on dual stack",
 			annotation: map[string]types.StaticAddrsMap{
 				prepTestClaimName: {
 					prepTestRequest: {
@@ -353,6 +386,8 @@ func TestPrepare_PodStaticIPsAnnotation(t *testing.T) {
 					},
 				},
 			},
+			ipv4Enabled: true,
+			ipv6Enabled: true,
 			expectedIPs: []string{"10.1.0.1/32", "fdaa::1/128"}, // IPv4 from claim config (annotation must not override missing IP family), IPv6 from annotation
 		},
 	}
@@ -390,13 +425,22 @@ func TestPrepare_PodStaticIPsAnnotation(t *testing.T) {
 					})
 
 					driver := buildPrepDriver(t, cs, dev)
+					driver.ipv4Enabled = tc.ipv4Enabled
+					driver.ipv6Enabled = tc.ipv6Enabled
 
 					result := driver.prepareResourceClaim(t.Context(), claim)
 					require.NoError(t, result.Err)
 
 					require.Len(t, dev.setupCfgs, 1)
-					assert.Equal(t, netip.MustParsePrefix(tc.expectedIPs[0]), dev.setupCfgs[0].IPv4Addr)
-					assert.Equal(t, netip.MustParsePrefix(tc.expectedIPs[1]), dev.setupCfgs[0].IPv6Addr)
+					var addrs []string
+					if dev.setupCfgs[0].IPv4Addr.IsValid() {
+						addrs = append(addrs, dev.setupCfgs[0].IPv4Addr.String())
+					}
+					if dev.setupCfgs[0].IPv6Addr.IsValid() {
+						addrs = append(addrs, dev.setupCfgs[0].IPv6Addr.String())
+					}
+					require.ElementsMatch(t, tc.expectedIPs, addrs)
+
 					updated, err := cs.KubernetesFakeClientset.ResourceV1().
 						ResourceClaims(prepTestClaimNS).Get(t.Context(), claim.Name, metav1.GetOptions{})
 					require.NoError(t, err)


### PR DESCRIPTION
Since the network driver manages interfaces independently from the Cilium dataplane, ideally it should have dedicated options to enable address families support. This would allow to support cases where an address family is enabled for all Cilium managed interfaces but not for the network driver managed ones or vice versa.

For now, let's just suppose that the daemon settings are valid for all the network driver interfaces too. This allows to avoid errors while running the driver in ipv4-only or ipv6-only clusters.

Also, fix a bug in the Resource Network Config reflector that was appending v6 routes to v4 routes slice.