### PR TITLE
fix(gateway-api): set ready condition in endpointSlice to true

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
@@ -70,6 +70,8 @@ addressType: IPv4
 endpoints:
 - addresses:
   - "192.192.192.192"
+  conditions:
+    ready: true
 ports:
 - port: 9999
 {{- end }}

--- a/operator/pkg/model/translation/gateway-api/translator.go
+++ b/operator/pkg/model/translation/gateway-api/translator.go
@@ -333,6 +333,11 @@ func (t *gatewayAPITranslator) desiredEndpointSlice(owner *model.FullyQualifiedR
 				// to the lb map when the service has no backends.
 				// Related github issue https://github.com/cilium/cilium/issues/19262
 				Addresses: []string{"192.192.192.192"}, // dummy
+				// Ready must be explicit: K8s treats nil as ready, but some
+				// consumers (e.g. GKE NEG controller) require it set. See #44611.
+				Conditions: discoveryv1.EndpointConditions{
+					Ready: ptr.To(true),
+				},
 			},
 		},
 		Ports: []discoveryv1.EndpointPort{

--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -390,6 +391,51 @@ func Test_getService(t *testing.T) {
 			assert.LessOrEqual(t, len(got.Name), 63, "Service name is too long")
 		})
 	}
+}
+
+func Test_desiredEndpointSlice(t *testing.T) {
+	trans := &gatewayAPITranslator{}
+	owner := &model.FullyQualifiedResource{
+		Name:      "dummy-gateway",
+		Namespace: "dummy-namespace",
+		Version:   "v1",
+		Kind:      "Gateway",
+		UID:       "57889650-380b-4c05-9a2e-3baee7fd5271",
+	}
+
+	got := trans.desiredEndpointSlice(owner, nil, nil)
+
+	require.Equal(t, &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cilium-gateway-dummy-gateway",
+			Namespace: "dummy-namespace",
+			Labels: map[string]string{
+				owningGatewayLabel: "dummy-gateway",
+				gatewayNameLabel:   "dummy-gateway",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: gatewayv1.GroupVersion.String(),
+					Kind:       "Gateway",
+					Name:       "dummy-gateway",
+					UID:        types.UID("57889650-380b-4c05-9a2e-3baee7fd5271"),
+					Controller: ptr.To(true),
+				},
+			},
+		},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Endpoints: []discoveryv1.Endpoint{
+			{
+				Addresses: []string{"192.192.192.192"},
+				Conditions: discoveryv1.EndpointConditions{
+					Ready: ptr.To(true),
+				},
+			},
+		},
+		Ports: []discoveryv1.EndpointPort{
+			{Port: ptr.To[int32](9999)},
+		},
+	}, got)
 }
 
 func Test_translator_Translate_ShortensCECName(t *testing.T) {

--- a/operator/pkg/model/translation/ingress/dedicated_ingress.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress.go
@@ -181,6 +181,11 @@ func getEndpointSlice(resource model.FullyQualifiedResource) *discoveryv1.Endpoi
 				// to the lb map when the service has no backends.
 				// Related github issue https://github.com/cilium/cilium/issues/19262
 				Addresses: []string{"192.192.192.192"}, // dummy
+				// Ready must be explicit: K8s treats nil as ready, but some
+				// consumers (e.g. GKE NEG controller) require it set. See #44611.
+				Conditions: discoveryv1.EndpointConditions{
+					Ready: ptr.To(true),
+				},
 			},
 		},
 		Ports: []discoveryv1.EndpointPort{

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
@@ -220,6 +220,9 @@ func Test_getEndpointForIngress(t *testing.T) {
 				// to the lb map when the service has no backends.
 				// Related github issue https://github.com/cilium/cilium/issues/19262
 				Addresses: []string{"192.192.192.192"}, // dummy
+				Conditions: discoveryv1.EndpointConditions{
+					Ready: ptr.To(true),
+				},
 			},
 		},
 		Ports: []discoveryv1.EndpointPort{{Port: ptr.To[int32](9999)}}, // dummy port


### PR DESCRIPTION
<!-- Description of change -->

Cilium creates a dummy EndpointSlice (192.192.192.192:9999) for Gateway API and dedicated Ingress services so that the agent pushes the service entry to the LB map (see #19262).
Since #3f999e3e48 ("gateway-api: Replace Endpoint with EndpointSlice"), this slice is created directly instead of being mirrored from a legacy `Endpoints` object, but `Conditions.Ready` was not carried over.

While the Kubernetes spec treats a nil `Ready` as "true", some downstream consumers - notably GKE's NEG controller for `GCE_VM_IP` NEGs with `ExternalTrafficPolicy: Cluster` - require the field to be set explicitly.
Without it, NEGs created for Cilium Gateway services stay empty and the GCP load balancer has no backends.

Fix: explicitly set `Conditions.Ready: true` on the dummy endpoint in both the Gateway API and dedicated Ingress translators.
Restores the v1.18.x behavior where the legacy `Endpoints` object was mirrored as ready.

Related: https://github.com/cilium/cilium/pull/41083 (that migrated K8s Endpoints to EndpointSlices for Ingress & Gateway API. Note: this is only part of v1.19 & main)
Fixes: #44611


[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
