### PR TITLE
.github: Support other versions in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -23,12 +23,14 @@ body:
         What version of Cilium was running when you discovered this issue? (run `cilium version`)
         **NOTE: If your version is NOT listed then please upgrade before opening the GH issue. Thank you**
       options:
+        - 'Latest pre-release'
         # renovate: datasource=github-tags depName=cilium/cilium
         - 'equal or higher than v1.19.4 and lower than v1.20.0'
         # renovate: datasource=github-tags depName=cilium/cilium
         - 'equal or higher than v1.18.10 and lower than v1.19.0'
         # renovate: datasource=github-tags depName=cilium/cilium
         - 'equal or higher than v1.17.16 and lower than v1.18.0'
+        - 'Other version'
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
Sometimes users report issues against the latest pre-release. Sometimes
they are also reporting a bug on a different version but the template is
too restrictive so they file the bug with the wrong version then add the
version later on in the bug report.

We already make it clear to the reporter that they should upgrade if the
version is not listed, but I would rather that the top section of the
template reports more accurately (such as 'Other' which suggests the
version might be unmaintained) rather than have the reporter add a
version number in this section which is wrong.
