### PR TITLE
azure: Fix public IP reassignment failure loop on operator restart

### DIFF
--- a/operator/pkg/ipam/nodemanager/node.go
+++ b/operator/pkg/ipam/nodemanager/node.go
@@ -669,6 +669,8 @@ func (n *Node) recalculate(ctx context.Context) {
 	n.ipv4Alloc.available = a
 	if stats.AssignedStaticIP != "" {
 		n.stats.IPv4.AssignedStaticIP = stats.AssignedStaticIP
+	} else if n.stats.IPv4.AssignedStaticIP == "" && n.resource != nil {
+		n.stats.IPv4.AssignedStaticIP = n.resource.Status.IPAM.AssignedStaticIP
 	}
 
 	n.stats.IPv4.AvailableIPs = len(n.ipv4Alloc.available)

--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -898,15 +898,13 @@ func (c *Client) AssignPublicIPAddressesVMSS(ctx context.Context, instanceID, vm
 				return "", fmt.Errorf("failed to delete public IP address configuration for VM %s from VMSS %s: %w", instanceID, vmssName, err)
 			}
 		} else {
-			netIfName := "<unknown>"
-			if primaryNetIfConfig.Name != nil {
-				netIfName = *primaryNetIfConfig.Name
+			// Public IP already successfully provisioned, return the existing prefix ID
+			// so the caller can record the assignment without re-attempting allocation.
+			cfg := primaryIPConfig.Properties.PublicIPAddressConfiguration
+			if cfg.Properties != nil && cfg.Properties.PublicIPPrefix != nil && cfg.Properties.PublicIPPrefix.ID != nil {
+				return *cfg.Properties.PublicIPPrefix.ID, nil
 			}
-			return "", fmt.Errorf("public IP address already assigned to primary IP configuration for network configuration %s from VM %s from VMSS %s",
-				netIfName,
-				instanceID,
-				vmssName,
-			)
+			return "", fmt.Errorf("public IP already assigned to VM %s from VMSS %s but prefix ID is unavailable", instanceID, vmssName)
 		}
 	}
 
@@ -1041,7 +1039,12 @@ func (c *Client) AssignPublicIPAddressesVM(ctx context.Context, instanceID strin
 				return "", fmt.Errorf("failed to delete public IP address configuration for interface %s for VM %s: %w", interfaceName, vmName, err)
 			}
 		} else {
-			return "", fmt.Errorf("public IP address already assigned to primary IP configuration for interface %s", interfaceName)
+			// Public IP already successfully provisioned, return the existing IP resource
+			// ID so the caller can record the assignment without re-attempting allocation.
+			if primaryIPConfig.Properties.PublicIPAddress.ID != nil {
+				return *primaryIPConfig.Properties.PublicIPAddress.ID, nil
+			}
+			return "", fmt.Errorf("public IP already assigned to VM %s but resource ID is unavailable", vmName)
 		}
 	}
 


### PR DESCRIPTION
After an operator restart, `n.stats.IPv4.AssignedStaticIP` was always empty because `ResyncInterfacesAndIPs` never reads public IP state from the Azure API or the existing CiliumNode object. This caused `MaintainIPPool` to call `AllocateStaticIP` on every node that already had a public IP, leading to a tight retry loop of "public IP address already assigned" errors. This loop would continue until the node got rotated as the only way the operator had to set its in-memory `n.stats.IPv4.AssignedStaticIP` was following a sucessful public IP assignment.

This commit fixes this situation at two different levels:
* In `recalculate()`, seed `AssignedStaticIP` from the persisted CiliumNode `Status.IPAM.AssignedStaticIP` when the interface resync returns nothing. This prevents the redundant allocation attempt in the common case (normal restart).

* Make `AssignPublicIPAddressesVMSS/VM` idempotent: when a public IP is already successfully provisioned, return the existing prefix/resource ID instead of an error. This self-heals the crash-window edge case where the operator allocated a public IP but crashed before syncToAPIServer could persist the status back to the CiliumNode object.