### PR TITLE
bpf: Clean up more comprehensively

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -237,6 +237,9 @@ clean:
 	@$(ECHO_CLEAN)
 	$(QUIET)rm -fr *.o *.ll *.i *.s
 	$(QUIET)rm -f $(TARGET)
+	$(QUIET)rm -f $(wildcard .cache/clangd/index/*.idx)
+	$(QUIET)rm -f compile_commands.json
+	$(QUIET)$(MAKE) $(SUBMAKEOPTS) -C tests clean
 
 
 BEAR_CLI   = $(shell which bear 2> /dev/null)

--- a/bpf/tests/Makefile
+++ b/bpf/tests/Makefile
@@ -67,5 +67,6 @@ clean:
 	rm -f $(wildcard *.o)
 	rm -f $(wildcard *.i)
 	rm -f $(wildcard *.d)
+	rm -f $(wildcard scapy/__pycache__/*.pyc)
 
 -include $(TEST_OBJECTS:.o=.d)


### PR DESCRIPTION
There were a bunch of generated files here that were not being caught
by 'make clean' or 'make -C bpf clean'. Fix them up.
