### PR TITLE
gateway-api/ingress: set service label on EndpointSlices

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
@@ -56,6 +56,7 @@ metadata:
   name: {{ .Values.ingressController.service.name }}
   namespace: {{ include "cilium.namespace" . }}
   labels:
+    kubernetes.io/service-name: {{ .Values.ingressController.service.name }}
     {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/operator/pkg/ingress/ingress_reconcile_test.go
+++ b/operator/pkg/ingress/ingress_reconcile_test.go
@@ -95,6 +95,7 @@ func TestReconcile(t *testing.T) {
 		eps := discoveryv1.EndpointSlice{}
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &eps)
 		require.NoError(t, err, "Dedicated loadbalancer service endpoints should exist")
+		require.Equal(t, "cilium-ingress-test", eps.Labels[discoveryv1.LabelServiceName])
 
 		cec := ciliumv2.CiliumEnvoyConfig{}
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test-test"}, &cec)
@@ -910,6 +911,7 @@ func TestReconcile(t *testing.T) {
 		eps := discoveryv1.EndpointSlice{}
 		err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: "cilium-ingress-test"}, &eps)
 		require.NoError(t, err)
+		require.Equal(t, "cilium-ingress-test", eps.Labels[discoveryv1.LabelServiceName])
 
 		require.Contains(t, eps.Labels, "additional.label/test-label", "Existing labels should not be deleted")
 		require.Contains(t, eps.Annotations, "additional.annotation/test-annotation", "Existing annotations should not be deleted")

--- a/operator/pkg/model/translation/gateway-api/translator.go
+++ b/operator/pkg/model/translation/gateway-api/translator.go
@@ -312,8 +312,9 @@ func (t *gatewayAPITranslator) desiredEndpointSlice(owner *model.FullyQualifiedR
 			Name:      shortener.ShortenK8sResourceName(CiliumGatewayPrefix + owner.Name),
 			Namespace: owner.Namespace,
 			Labels: mergeMap(map[string]string{
-				owningGatewayLabel: shortedName,
-				gatewayNameLabel:   shortedName,
+				owningGatewayLabel:           shortedName,
+				gatewayNameLabel:             shortedName,
+				discoveryv1.LabelServiceName: shortener.ShortenK8sResourceName(CiliumGatewayPrefix + owner.Name),
 			}, labels),
 			Annotations: annotations,
 			OwnerReferences: []metav1.OwnerReference{

--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -92,10 +93,12 @@ func Test_translator_Translate(t *testing.T) {
 			expectedService := &corev1.Service{}
 			readOutput(t, fmt.Sprintf("testdata/%s/service-output.yaml", tt.name), expectedService)
 
-			cec, svc, _, err := trans.Translate(input)
+			cec, svc, ep, err := trans.Translate(input)
 
 			require.Equal(t, tt.wantErr, err != nil, "Error mismatch")
 			require.Equal(t, expectedService, svc, "Service mismatch")
+			require.NotNil(t, ep)
+			require.Equal(t, svc.Name, ep.Labels[discoveryv1.LabelServiceName], "EndpointSlice must carry the Service association label")
 
 			diffOutput := cmp.Diff(expectedCEC, cec, protocmp.Transform())
 			if len(diffOutput) != 0 {
@@ -209,12 +212,13 @@ func Test_translator_Translate_HostNetwork(t *testing.T) {
 					cec, svc, ep, err := trans.Translate(input)
 					require.Equal(t, tt.wantErr, err != nil, "Error mismatch")
 					require.Equal(t, expectedService, svc, "Service mismatch")
+					require.NotNil(t, ep)
+					require.Equal(t, svc.Name, ep.Labels[discoveryv1.LabelServiceName], "EndpointSlice must carry the Service association label")
 
 					diffOutput := cmp.Diff(output, cec, protocmp.Transform())
 					if len(diffOutput) != 0 {
 						t.Errorf("CiliumEnvoyConfigs did not match:\n%s\n", diffOutput)
 					}
-					require.NotNil(t, ep)
 				})
 			}
 		})

--- a/operator/pkg/model/translation/ingress/dedicated_ingress.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress.go
@@ -163,7 +163,10 @@ func getEndpointSlice(resource model.FullyQualifiedResource) *discoveryv1.Endpoi
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-%s", ciliumIngressPrefix, resource.Name),
 			Namespace: resource.Namespace,
-			Labels:    map[string]string{ciliumIngressLabelKey: "true"},
+			Labels: map[string]string{
+				ciliumIngressLabelKey:        "true",
+				discoveryv1.LabelServiceName: fmt.Sprintf("%s-%s", ciliumIngressPrefix, resource.Name),
+			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: slim_networkingv1.SchemeGroupVersion.String(),

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
@@ -202,7 +202,10 @@ func Test_getEndpointForIngress(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cilium-ingress-dummy-ingress",
 			Namespace: "dummy-namespace",
-			Labels:    map[string]string{"cilium.io/ingress": "true"},
+			Labels: map[string]string{
+				"cilium.io/ingress":          "true",
+				discoveryv1.LabelServiceName: "cilium-ingress-dummy-ingress",
+			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: "networking.k8s.io/v1",


### PR DESCRIPTION
Currently, the K8s `EndpointSlice` that contains the pseudo ingress ip for Gateway API & Ingress does not have the label `kubernetes.io/service-name` set.

This label is necessary to associate the slices with their backing Services and is required by EndpointSlice consumers such as MetalLB. Without the label, the LB IP may be allocated but never announced.

Fixes: https://github.com/cilium/cilium/pull/41083 (that migrated K8s `Endpoints` to `EndpointSlices` for Ingress & Gateway API. Note: this is only part of `v1.19` & `main`)

Reported by @renesepp - thanks! :pray: in https://github.com/cilium/cilium/issues/45209#issuecomment-4568625484