### PR TITLE
bpf: constify and minor NAT cleanups

### DIFF
--- a/bpf/include/bpf/helpers_skb.h
+++ b/bpf/include/bpf/helpers_skb.h
@@ -22,7 +22,7 @@ static int BPF_FUNC(redirect_peer, int ifindex, __u32 flags);
 static int BPF_FUNC(clone_redirect, struct __sk_buff *skb, __u32 ifindex, __u64 flags);
 
 /* Packet manipulation */
-static int BPF_FUNC(skb_load_bytes, struct __sk_buff *skb, __u32 off,
+static int BPF_FUNC(skb_load_bytes, const struct __sk_buff *skb, __u32 off,
 		    void *to, __u32 len);
 static int BPF_FUNC(skb_store_bytes, struct __sk_buff *skb, __u32 off,
 		    const void *from, __u32 len, __u32 flags);
@@ -43,7 +43,7 @@ static int BPF_FUNC(skb_change_tail, struct __sk_buff *skb, __u32 nlen,
 static int BPF_FUNC(skb_change_head, struct __sk_buff *skb, __u32 head_room,
 		    __u64 flags);
 
-static int BPF_FUNC(skb_pull_data, struct __sk_buff *skb, __u32 len);
+static int BPF_FUNC(skb_pull_data, const struct __sk_buff *skb, __u32 len);
 
 /* Packet tunnel encap/decap */
 static int BPF_FUNC(skb_get_tunnel_key, struct __sk_buff *skb,
@@ -57,7 +57,7 @@ static int BPF_FUNC(skb_set_tunnel_opt, struct __sk_buff *skb,
 		    void *opt, __u32 size);
 
 /* Events for user space */
-static int BPF_FUNC_REMAP(skb_event_output, struct __sk_buff *skb, void *map,
+static int BPF_FUNC_REMAP(skb_event_output, const struct __sk_buff *skb, void *map,
 			  __u64 index, const void *data, __u32 size) =
 			 (void *)BPF_FUNC_perf_event_output;
 

--- a/bpf/include/bpf/helpers_xdp.h
+++ b/bpf/include/bpf/helpers_xdp.h
@@ -22,10 +22,10 @@ static int BPF_FUNC(redirect, int ifindex, __u32 flags);
 /* Packet manipulation */
 
 #ifdef HAVE_XDP_LOAD_BYTES
-static int BPF_FUNC(xdp_load_bytes, struct xdp_md *xdp, __u32 off,
+static int BPF_FUNC(xdp_load_bytes, const struct xdp_md *xdp, __u32 off,
 		    void *to, __u32 len);
 #else
-static int BPF_STUB(xdp_load_bytes, struct xdp_md *xdp, __u32 off,
+static int BPF_STUB(xdp_load_bytes, const struct xdp_md *xdp, __u32 off,
 		    void *to, __u32 len);
 #endif
 
@@ -63,6 +63,6 @@ static int BPF_STUB(xdp_get_tunnel_opt, struct xdp_md *xdp, void *opt,
 		    __u32 size);
 
 /* Events for user space */
-static int BPF_FUNC_REMAP(xdp_event_output, struct xdp_md *xdp, void *map,
+static int BPF_FUNC_REMAP(xdp_event_output, const struct xdp_md *xdp, void *map,
 			  __u64 index, const void *data, __u32 size) =
 			 (void *)BPF_FUNC_perf_event_output;

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -94,7 +94,7 @@ static __always_inline bool validate_ethertype(struct __ctx_buff *ctx,
 }
 
 static __always_inline __maybe_unused bool
-__revalidate_data_pull(struct __ctx_buff *ctx, void **data_, void **data_end_,
+__revalidate_data_pull(const struct __ctx_buff *ctx, void **data_, void **data_end_,
 		       void **l3, const __u32 l3_off, const __u32 l3_len,
 		       const bool pull)
 {

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -351,7 +351,7 @@ ct_entry_matches_types(const struct ct_entry *entry __maybe_unused,
  * 'ct_state', if not nullptr, will be filled in only if CT_ESTABLISHED is returned.
  */
 static __always_inline enum ct_status
-__ct_lookup(const void *map, struct __ctx_buff *ctx, const void *tuple,
+__ct_lookup(const void *map, const struct __ctx_buff *ctx, const void *tuple,
 	    enum ct_action action, enum ct_dir dir, __u32 ct_entry_types,
 	    struct ct_state *ct_state, bool is_tcp, union tcp_flags seen_flags,
 	    __u32 *monitor)
@@ -495,7 +495,7 @@ ct_is_reply ## FAMILY(const void *map,						\
 }
 
 static __always_inline int
-ipv6_extract_tuple(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple)
+ipv6_extract_tuple(const struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple)
 {
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
@@ -584,7 +584,7 @@ ipv6_ct_reverse_tuple_daddr(const struct ipv6_ct_tuple *rtuple)
 }
 
 static __always_inline int
-ct_extract_ports6(struct __ctx_buff *ctx, struct ipv6hdr *ip6, fraginfo_t fraginfo,
+ct_extract_ports6(const struct __ctx_buff *ctx, struct ipv6hdr *ip6, fraginfo_t fraginfo,
 		  int off, enum ct_dir dir, struct ipv6_ct_tuple *tuple)
 {
 	switch (tuple->nexthdr) {
@@ -662,7 +662,7 @@ ct_extract_ports6(struct __ctx_buff *ctx, struct ipv6hdr *ip6, fraginfo_t fragin
 DEFINE_FUNC_CT_IS_REPLY(6)
 
 static __always_inline int
-__ct_lookup6(const void *map, struct ipv6_ct_tuple *tuple, struct __ctx_buff *ctx,
+__ct_lookup6(const void *map, struct ipv6_ct_tuple *tuple, const struct __ctx_buff *ctx,
 	     fraginfo_t fraginfo, int l4_off, enum ct_dir dir, enum ct_scope scope,
 	     __u32 ct_entry_types, struct ct_state *ct_state, __u32 *monitor)
 {
@@ -721,7 +721,7 @@ out:
 
 /* An IPv6 version of ct_lazy_lookup4. */
 static __always_inline int
-ct_lazy_lookup6(const void *map, struct ipv6_ct_tuple *tuple, struct __ctx_buff *ctx,
+ct_lazy_lookup6(const void *map, struct ipv6_ct_tuple *tuple, const struct __ctx_buff *ctx,
 		fraginfo_t fraginfo, int l4_off, enum ct_dir dir, enum ct_scope scope,
 		__u32 ct_entry_types, struct ct_state *ct_state, __u32 *monitor)
 {
@@ -734,7 +734,7 @@ ct_lazy_lookup6(const void *map, struct ipv6_ct_tuple *tuple, struct __ctx_buff 
 /* Offset must point to IPv6 */
 static __always_inline int ct_lookup6(const void *map,
 				      struct ipv6_ct_tuple *tuple,
-				      struct __ctx_buff *ctx, struct ipv6hdr *ip6,
+				      const struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 				      fraginfo_t fraginfo, int l4_off,
 				      enum ct_dir dir, enum ct_scope scope,
 				      struct ct_state *ct_state,
@@ -756,7 +756,7 @@ static __always_inline int ct_lookup6(const void *map,
 }
 
 static __always_inline int
-ipv4_extract_tuple(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple)
+ipv4_extract_tuple(const struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple)
 {
 	void *data, *data_end;
 	struct iphdr *ip4;
@@ -842,7 +842,7 @@ ipv4_ct_reverse_tuple_daddr(const struct ipv4_ct_tuple *rtuple)
 }
 
 static __always_inline int
-ct_extract_ports4(struct __ctx_buff *ctx, struct iphdr *ip4, fraginfo_t fraginfo,
+ct_extract_ports4(const struct __ctx_buff *ctx, struct iphdr *ip4, fraginfo_t fraginfo,
 		  int off, enum ct_dir dir, struct ipv4_ct_tuple *tuple)
 {
 	switch (tuple->nexthdr) {
@@ -920,7 +920,7 @@ ct_extract_ports4(struct __ctx_buff *ctx, struct iphdr *ip4, fraginfo_t fraginfo
 DEFINE_FUNC_CT_IS_REPLY(4)
 
 static __always_inline int
-__ct_lookup4(const void *map, struct ipv4_ct_tuple *tuple, struct __ctx_buff *ctx,
+__ct_lookup4(const void *map, struct ipv4_ct_tuple *tuple, const struct __ctx_buff *ctx,
 	     fraginfo_t fraginfo, int l4_off, enum ct_dir dir, enum ct_scope scope,
 	     __u32 ct_entry_types, struct ct_state *ct_state, __u32 *monitor)
 {
@@ -1002,7 +1002,7 @@ out:
  * ICMP types to ct_lazy_lookup4.
  */
 static __always_inline int
-ct_lazy_lookup4(const void *map, struct ipv4_ct_tuple *tuple, struct __ctx_buff *ctx,
+ct_lazy_lookup4(const void *map, struct ipv4_ct_tuple *tuple, const struct __ctx_buff *ctx,
 		fraginfo_t fraginfo, int l4_off, enum ct_dir dir, enum ct_scope scope,
 		__u32 ct_entry_types, struct ct_state *ct_state, __u32 *monitor)
 {
@@ -1015,7 +1015,7 @@ ct_lazy_lookup4(const void *map, struct ipv4_ct_tuple *tuple, struct __ctx_buff 
 /* Offset must point to IPv4 header */
 static __always_inline int ct_lookup4(const void *map,
 				      struct ipv4_ct_tuple *tuple,
-				      struct __ctx_buff *ctx, struct iphdr *ip4,
+				      const struct __ctx_buff *ctx, struct iphdr *ip4,
 				      int off, enum ct_dir dir, enum ct_scope scope,
 				      struct ct_state *ct_state, __u32 *monitor)
 {
@@ -1066,7 +1066,7 @@ ct_create_fill_entry(struct ct_entry *entry, const struct ct_state *state,
 /* Offset must point to IPv6 */
 static __always_inline int ct_create6(const void *map_main, const void *map_related,
 				      struct ipv6_ct_tuple *tuple,
-				      struct __ctx_buff *ctx, const enum ct_dir dir,
+				      const struct __ctx_buff *ctx, const enum ct_dir dir,
 				      const struct ct_state *ct_state, __s8 *ext_err)
 {
 	/* Create entry in original direction */
@@ -1121,7 +1121,7 @@ drop_err:
 static __always_inline int ct_create4(const void *map_main,
 				      const void *map_related,
 				      struct ipv4_ct_tuple *tuple,
-				      struct __ctx_buff *ctx, const enum ct_dir dir,
+				      const struct __ctx_buff *ctx, const enum ct_dir dir,
 				      const struct ct_state *ct_state,
 				      __s8 *ext_err)
 {

--- a/bpf/lib/csum.h
+++ b/bpf/lib/csum.h
@@ -7,8 +7,9 @@
 #include <linux/udp.h>
 #include <linux/icmpv6.h>
 
-#define TCP_CSUM_OFF (offsetof(struct tcphdr, check))
-#define UDP_CSUM_OFF (offsetof(struct udphdr, check))
+#define TCP_CSUM_OFF	(offsetof(struct tcphdr, check))
+#define TCP_CSUM_SIZE	(field_sizeof(struct tcphdr, check))
+#define UDP_CSUM_OFF	(offsetof(struct udphdr, check))
 
 struct csum_offset {
 	__u16 offset;

--- a/bpf/lib/dbg.h
+++ b/bpf/lib/dbg.h
@@ -204,7 +204,7 @@ struct debug_capture_msg {
 		})
 
 
-static __always_inline void cilium_dbg(struct __ctx_buff *ctx, __u8 type,
+static __always_inline void cilium_dbg(const struct __ctx_buff *ctx, __u8 type,
 				       __u32 arg1, __u32 arg2)
 {
 	struct debug_msg msg = {
@@ -221,7 +221,7 @@ static __always_inline void cilium_dbg(struct __ctx_buff *ctx, __u8 type,
 			 &msg, sizeof(msg));
 }
 
-static __always_inline void cilium_dbg3(struct __ctx_buff *ctx, __u8 type,
+static __always_inline void cilium_dbg3(const struct __ctx_buff *ctx, __u8 type,
 					__u32 arg1, __u32 arg2, __u32 arg3)
 {
 	struct debug_msg msg = {
@@ -240,7 +240,7 @@ static __always_inline void cilium_dbg3(struct __ctx_buff *ctx, __u8 type,
 }
 
 
-static __always_inline void cilium_dbg_capture2(struct __ctx_buff *ctx, __u8 type,
+static __always_inline void cilium_dbg_capture2(const struct __ctx_buff *ctx, __u8 type,
 						__u32 arg1, __u32 arg2)
 {
 	__u64 ctx_len = ctx_full_len(ctx);
@@ -261,7 +261,7 @@ static __always_inline void cilium_dbg_capture2(struct __ctx_buff *ctx, __u8 typ
 			 &msg, sizeof(msg));
 }
 
-static __always_inline void cilium_dbg_capture(struct __ctx_buff *ctx, __u8 type,
+static __always_inline void cilium_dbg_capture(const struct __ctx_buff *ctx, __u8 type,
 					       __u32 arg1)
 {
 	cilium_dbg_capture2(ctx, type, arg1, 0);
@@ -271,26 +271,26 @@ static __always_inline void cilium_dbg_capture(struct __ctx_buff *ctx, __u8 type
 		do { } while (0)
 
 static __always_inline
-void cilium_dbg(struct __ctx_buff *ctx __maybe_unused, __u8 type __maybe_unused,
+void cilium_dbg(const struct __ctx_buff *ctx __maybe_unused, __u8 type __maybe_unused,
 		__u32 arg1 __maybe_unused, __u32 arg2 __maybe_unused)
 {
 }
 
 static __always_inline
-void cilium_dbg3(struct __ctx_buff *ctx __maybe_unused,
+void cilium_dbg3(const struct __ctx_buff *ctx __maybe_unused,
 		 __u8 type __maybe_unused, __u32 arg1 __maybe_unused,
 		 __u32 arg2 __maybe_unused, __u32 arg3 __maybe_unused)
 {
 }
 
 static __always_inline
-void cilium_dbg_capture(struct __ctx_buff *ctx __maybe_unused,
+void cilium_dbg_capture(const struct __ctx_buff *ctx __maybe_unused,
 			__u8 type __maybe_unused, __u32 arg1 __maybe_unused)
 {
 }
 
 static __always_inline
-void cilium_dbg_capture2(struct __ctx_buff *ctx __maybe_unused,
+void cilium_dbg_capture2(const struct __ctx_buff *ctx __maybe_unused,
 			 __u8 type __maybe_unused, __u32 arg1 __maybe_unused,
 			 __u32 arg2 __maybe_unused)
 {

--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -52,7 +52,7 @@ ipv4_csum_update_by_diff(struct __ctx_buff *ctx, int l3_off, __u64 diff)
 			       0, (__u32)diff, 0);
 }
 
-static __always_inline int ipv4_load_daddr(struct __ctx_buff *ctx, int off,
+static __always_inline int ipv4_load_daddr(const struct __ctx_buff *ctx, int off,
 					   __u32 *dst)
 {
 	return ctx_load_bytes(ctx, off + offsetof(struct iphdr, daddr), dst, 4);
@@ -103,7 +103,7 @@ ipv4_frag_get_l4ports(const struct ipv4_frag_id *frag_id,
 }
 
 static __always_inline int
-ipv4_handle_fragmentation(struct __ctx_buff *ctx,
+ipv4_handle_fragmentation(const struct __ctx_buff *ctx,
 			  const struct iphdr *ip4,
 			  fraginfo_t fraginfo,
 			  int l4_off,
@@ -141,7 +141,7 @@ ipv4_handle_fragmentation(struct __ctx_buff *ctx,
 }
 
 static __always_inline int
-ipv4_load_l4_ports(struct __ctx_buff *ctx, struct iphdr *ip4 __maybe_unused,
+ipv4_load_l4_ports(const struct __ctx_buff *ctx, struct iphdr *ip4 __maybe_unused,
 		   fraginfo_t fraginfo, int l4_off, enum ct_dir dir __maybe_unused,
 		   __be16 *ports)
 {

--- a/bpf/lib/ipv6.h
+++ b/bpf/lib/ipv6.h
@@ -74,7 +74,7 @@ static __always_inline int ipv6_authlen(const struct ipv6_opt_hdr *opthdr)
 	return (opthdr->hdrlen + 2) << 2;
 }
 
-static __always_inline int ipv6_skip_exthdr(struct __ctx_buff *ctx, __u8 *nexthdr, int off)
+static __always_inline int ipv6_skip_exthdr(const struct __ctx_buff *ctx, __u8 *nexthdr, int off)
 {
 	struct ipv6_opt_hdr opthdr __align_stack_8;
 	__u8 nh = *nexthdr;
@@ -116,7 +116,7 @@ static __always_inline int ipv6_skip_exthdr(struct __ctx_buff *ctx, __u8 *nexthd
 	}
 }
 
-static __always_inline int ipv6_hdrlen_offset(struct __ctx_buff *ctx, int l3_off,
+static __always_inline int ipv6_hdrlen_offset(const struct __ctx_buff *ctx, int l3_off,
 					      __u8 *nexthdr, fraginfo_t *fraginfo)
 {
 	int i, len = sizeof(struct ipv6hdr);
@@ -161,14 +161,14 @@ static __always_inline int ipv6_hdrlen_offset(struct __ctx_buff *ctx, int l3_off
 	return DROP_INVALID_EXTHDR;
 }
 
-static __always_inline int ipv6_hdrlen_with_fraginfo(struct __ctx_buff *ctx,
+static __always_inline int ipv6_hdrlen_with_fraginfo(const struct __ctx_buff *ctx,
 						     __u8 *nexthdr,
 						     fraginfo_t *fraginfo)
 {
 	return ipv6_hdrlen_offset(ctx, ETH_HLEN, nexthdr, fraginfo);
 }
 
-static __always_inline int ipv6_hdrlen(struct __ctx_buff *ctx, __u8 *nexthdr)
+static __always_inline int ipv6_hdrlen(const struct __ctx_buff *ctx, __u8 *nexthdr)
 {
 	return ipv6_hdrlen_offset(ctx, ETH_HLEN, nexthdr, NULL);
 }
@@ -248,7 +248,7 @@ static __always_inline int ipv6_dec_hoplimit(struct __ctx_buff *ctx, int off)
 	return 0;
 }
 
-static __always_inline int ipv6_load_saddr(struct __ctx_buff *ctx, int off,
+static __always_inline int ipv6_load_saddr(const struct __ctx_buff *ctx, int off,
 					   union v6addr *dst)
 {
 	return ctx_load_bytes(ctx, off + offsetof(struct ipv6hdr, saddr), dst->addr,
@@ -262,7 +262,7 @@ static __always_inline int ipv6_store_saddr(struct __ctx_buff *ctx, const __u8 *
 	return ctx_store_bytes(ctx, off + offsetof(struct ipv6hdr, saddr), addr, 16, 0);
 }
 
-static __always_inline int ipv6_load_daddr(struct __ctx_buff *ctx, int off,
+static __always_inline int ipv6_load_daddr(const struct __ctx_buff *ctx, int off,
 					   union v6addr *dst)
 {
 	return ctx_load_bytes(ctx, off + offsetof(struct ipv6hdr, daddr), dst->addr,
@@ -276,7 +276,7 @@ ipv6_store_daddr(struct __ctx_buff *ctx, const __u8 *addr, int off)
 	return ctx_store_bytes(ctx, off + offsetof(struct ipv6hdr, daddr), addr, 16, 0);
 }
 
-static __always_inline int ipv6_load_nexthdr(struct __ctx_buff *ctx, int off,
+static __always_inline int ipv6_load_nexthdr(const struct __ctx_buff *ctx, int off,
 					     __u8 *nexthdr)
 {
 	return ctx_load_bytes(ctx, off + offsetof(struct ipv6hdr, nexthdr), nexthdr,
@@ -291,7 +291,7 @@ static __always_inline int ipv6_store_nexthdr(struct __ctx_buff *ctx, __u8 *next
 			      sizeof(__u8), 0);
 }
 
-static __always_inline int ipv6_load_paylen(struct __ctx_buff *ctx, int off,
+static __always_inline int ipv6_load_paylen(const struct __ctx_buff *ctx, int off,
 					    __be16 *len)
 {
 	return ctx_load_bytes(ctx, off + offsetof(struct ipv6hdr, payload_len),
@@ -331,7 +331,7 @@ static __always_inline int ipv6_addr_is_mapped(const union v6addr *addr)
 
 /* As opposed to ipfrag_encode_ipv6, this function can return errors. */
 static __always_inline fraginfo_t
-ipv6_get_fraginfo(struct __ctx_buff *ctx, const struct ipv6hdr *ip6)
+ipv6_get_fraginfo(const struct __ctx_buff *ctx, const struct ipv6hdr *ip6)
 {
 	int l3_off = (int)((void *)ip6 - ctx_data(ctx));
 	int i, len = sizeof(struct ipv6hdr);
@@ -386,7 +386,7 @@ ipv6_frag_get_l4ports(const struct ipv6_frag_id *frag_id,
 }
 
 static __always_inline int
-ipv6_handle_fragmentation(struct __ctx_buff *ctx,
+ipv6_handle_fragmentation(const struct __ctx_buff *ctx,
 			  const struct ipv6hdr *ip6,
 			  fraginfo_t fraginfo,
 			  int l4_off,
@@ -431,7 +431,7 @@ out:
 }
 
 static __always_inline int
-ipv6_load_l4_ports(struct __ctx_buff *ctx, struct ipv6hdr *ip6 __maybe_unused,
+ipv6_load_l4_ports(const struct __ctx_buff *ctx, struct ipv6hdr *ip6 __maybe_unused,
 		   fraginfo_t fraginfo, int l4_off, enum ct_dir dir __maybe_unused,
 		   __be16 *ports)
 {

--- a/bpf/lib/l4.h
+++ b/bpf/lib/l4.h
@@ -64,19 +64,19 @@ static __always_inline int l4_modify_port(struct __ctx_buff *ctx, int l4_off,
 	return 0;
 }
 
-static __always_inline int l4_load_port(struct __ctx_buff *ctx, int off,
+static __always_inline int l4_load_port(const struct __ctx_buff *ctx, int off,
 					__be16 *port)
 {
 	return ctx_load_bytes(ctx, off, port, sizeof(__be16));
 }
 
-static __always_inline int l4_load_ports(struct __ctx_buff *ctx, int off,
+static __always_inline int l4_load_ports(const struct __ctx_buff *ctx, int off,
 					 __be16 *ports)
 {
 	return ctx_load_bytes(ctx, off, ports, 2 * sizeof(__be16));
 }
 
-static __always_inline int l4_load_tcp_flags(struct __ctx_buff *ctx, int l4_off,
+static __always_inline int l4_load_tcp_flags(const struct __ctx_buff *ctx, int l4_off,
 					     union tcp_flags *flags)
 {
 	return ctx_load_bytes(ctx, l4_off + 12, flags, 2);

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -497,7 +497,6 @@ snat_v4_rewrite_headers(struct __ctx_buff *ctx, __u8 nexthdr, int l3_off,
 		return DROP_CSUM_L3;
 
 	if (has_l4_header) {
-		int flags = BPF_F_PSEUDO_HDR;
 		struct csum_offset csum = {};
 
 		csum_l4_offset_and_flags(nexthdr, &csum);
@@ -535,7 +534,7 @@ snat_v4_rewrite_headers(struct __ctx_buff *ctx, __u8 nexthdr, int l3_off,
 
 		/* Amend the L4 checksum due to changing the addresses. */
 		if (csum.offset &&
-		    csum_l4_replace(ctx, l4_off, &csum, 0, sum, flags) < 0)
+		    csum_l4_replace(ctx, l4_off, &csum, 0, sum, BPF_F_PSEUDO_HDR) < 0)
 			return DROP_CSUM_L4;
 
 		/* Apply additional L4 checksum diff if provided (for ICMP error messages). */

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -863,7 +863,7 @@ snat_v4_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 
 	/* Check if the inner L4 header has checksum */
 	if (tuple.nexthdr == IPPROTO_TCP &&
-	    total_inner_len < ipv4_hdrlen(&iphdr) + TCP_CSUM_OFF + sizeof(__u16))
+	    total_inner_len < ipv4_hdrlen(&iphdr) + TCP_CSUM_OFF + TCP_CSUM_SIZE)
 		icmp_has_inner_l4_csum = false;
 
 	/* We found SNAT entry to NAT embedded packet. The destination addr
@@ -1090,7 +1090,7 @@ snat_v4_rev_nat_handle_icmp_error(struct __ctx_buff *ctx,
 
 	/* Check if the inner L4 header has checksum */
 	if (tuple.nexthdr == IPPROTO_TCP &&
-	    total_inner_len < ipv4_hdrlen(&iphdr) + TCP_CSUM_OFF + sizeof(__u16))
+	    total_inner_len < ipv4_hdrlen(&iphdr) + TCP_CSUM_OFF + TCP_CSUM_SIZE)
 		icmp_has_inner_l4_csum = false;
 
 	/* For UDP, a checksum value of zero means that no checksum */

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -220,8 +220,9 @@ set_v4_rtuple(const struct ipv4_ct_tuple *otuple,
 	rtuple->dport = ostate->to_sport;
 }
 
-static __always_inline int snat_v4_new_mapping(struct __ctx_buff *ctx, void *map,
-					       struct ipv4_ct_tuple *otuple,
+static __always_inline int snat_v4_new_mapping(const struct __ctx_buff *ctx,
+					       const void *map,
+					       const struct ipv4_ct_tuple *otuple,
 					       struct ipv4_nat_entry *ostate,
 					       const struct ipv4_nat_target *target,
 					       bool needs_ct, __s8 *ext_err)
@@ -304,8 +305,8 @@ out:
 }
 
 static __always_inline int
-snat_v4_nat_handle_mapping(struct __ctx_buff *ctx,
-			   struct ipv4_ct_tuple *tuple,
+snat_v4_nat_handle_mapping(const struct __ctx_buff *ctx,
+			   const struct ipv4_ct_tuple *tuple,
 			   fraginfo_t fraginfo,
 			   struct ipv4_nat_entry **state,
 			   struct ipv4_nat_entry *tmp,
@@ -399,8 +400,8 @@ snat_v4_nat_handle_mapping(struct __ctx_buff *ctx,
 }
 
 static __always_inline int
-snat_v4_rev_nat_handle_mapping(struct __ctx_buff *ctx,
-			       struct ipv4_ct_tuple *tuple,
+snat_v4_rev_nat_handle_mapping(const struct __ctx_buff *ctx,
+			       const struct ipv4_ct_tuple *tuple,
 			       fraginfo_t fraginfo,
 			       struct ipv4_nat_entry **state,
 			       __u32 off,
@@ -1345,8 +1346,8 @@ set_v6_rtuple(const struct ipv6_ct_tuple *otuple,
 	rtuple->dport = ostate->to_sport;
 }
 
-static __always_inline int snat_v6_new_mapping(struct __ctx_buff *ctx,
-					       struct ipv6_ct_tuple *otuple,
+static __always_inline int snat_v6_new_mapping(const struct __ctx_buff *ctx,
+					       const struct ipv6_ct_tuple *otuple,
 					       struct ipv6_nat_entry *ostate,
 					       const struct ipv6_nat_target *target,
 					       bool needs_ct, __s8 *ext_err)
@@ -1425,8 +1426,8 @@ DEFINE_AUX(struct ipv6_nat_entry, snat_v6_nhm_nat_entry)
 DEFINE_AUX(struct ipv6_ct_tuple, snat_v6_nhm_tuple)
 
 static __always_inline int
-snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
-			   struct ipv6_ct_tuple *tuple,
+snat_v6_nat_handle_mapping(const struct __ctx_buff *ctx,
+			   const struct ipv6_ct_tuple *tuple,
 			   fraginfo_t fraginfo,
 			   struct ipv6_nat_entry **state,
 			   __u32 off,
@@ -1510,8 +1511,8 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 }
 
 static __always_inline int
-snat_v6_rev_nat_handle_mapping(struct __ctx_buff *ctx,
-			       struct ipv6_ct_tuple *tuple,
+snat_v6_rev_nat_handle_mapping(const struct __ctx_buff *ctx,
+			       const struct ipv6_ct_tuple *tuple,
 			       fraginfo_t fraginfo,
 			       struct ipv6_nat_entry **state,
 			       __u32 off,

--- a/bpf/lib/signal.h
+++ b/bpf/lib/signal.h
@@ -49,7 +49,7 @@ struct signal_msg {
 			 sizeof(msg.signal_nr) + sizeof(msg.MEMBER));	\
   }
 
-static __always_inline void send_signal_nat_fill_up(struct __ctx_buff *ctx,
+static __always_inline void send_signal_nat_fill_up(const struct __ctx_buff *ctx,
 						    __u32 proto)
 {
 	SEND_SIGNAL(ctx, SIGNAL_NAT_FILL_UP, proto, proto);


### PR DESCRIPTION
I was poking around `lib/nat.h` a bit - here's some resulting cleanups (no actual diff in the codegen) that made my life easier + the code more robust.