### PR TITLE
sysdump: add Gateway API BackendTLSPolicy to sysdump

### DIFF
--- a/cilium-cli/sysdump/constants.go
+++ b/cilium-cli/sysdump/constants.go
@@ -121,6 +121,7 @@ const (
 	grpcRoutesFileName                       = "gatewayapi-grpcroutes-<ts>.yaml"
 	tcpRoutesFileName                        = "gatewayapi-tcroutes-<ts>.yaml"
 	udpRoutesFileName                        = "gatewayapi-udproutes-<ts>.yaml"
+	backendTLSPoliciesFileName               = "gatewayapi-backendtlspolicies-<ts>.yaml"
 	referenceGrantsFileName                  = "gatewayapi-referencegrants-<ts>.yaml"
 	ingressClassesFileName                   = "ingressclasses-<ts>.yaml"
 	k8sResourceFileName                      = "%s-<ts>.yaml"
@@ -190,6 +191,12 @@ var (
 		Group:    "gateway.networking.k8s.io",
 		Resource: "referencegrants",
 		Version:  "v1beta1",
+	}
+
+	backendTLSPolicy = schema.GroupVersionResource{
+		Group:    "gateway.networking.k8s.io",
+		Resource: "backendtlspolicies",
+		Version:  "v1",
 	}
 
 	httpRoute = schema.GroupVersionResource{

--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -2166,6 +2166,21 @@ func (c *Collector) getGatewayAPITasks() []Task {
 			},
 		},
 		{
+			Description: "Collecting BackendTLSPolicy entries",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				n := corev1.NamespaceAll
+				v, err := c.Client.ListUnstructured(ctx, backendTLSPolicy, &n, metav1.ListOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to collect BackendTLSPolicy entries: %w", err)
+				}
+				if err := c.WriteYAML(backendTLSPoliciesFileName, v); err != nil {
+					return fmt.Errorf("failed to collect BackendTLSPolicy entries: %w", err)
+				}
+				return nil
+			},
+		},
+		{
 			Description: "Collecting GRPCRoute entries",
 			Quick:       true,
 			Task: func(ctx context.Context) error {


### PR DESCRIPTION
Currently, the Gateway API resources `BackendTLSPolicy` isn't collected during Cilium sysdump execution.

For better analysis, this commit adds the missing CRD.

Fixes: https://github.com/cilium/cilium/pull/43045