### PR TITLE
sysdump: add CRD CiliumGatewayClassConfig to sysdump

### DIFF
--- a/cilium-cli/sysdump/constants.go
+++ b/cilium-cli/sysdump/constants.go
@@ -122,6 +122,7 @@ const (
 	tcpRoutesFileName                        = "gatewayapi-tcroutes-<ts>.yaml"
 	udpRoutesFileName                        = "gatewayapi-udproutes-<ts>.yaml"
 	referenceGrantsFileName                  = "gatewayapi-referencegrants-<ts>.yaml"
+	ciliumGatewayClassConfigsFileName        = "ciliumgatewayclassconfigs-<ts>.yaml"
 	ingressClassesFileName                   = "ingressclasses-<ts>.yaml"
 	k8sResourceFileName                      = "%s-<ts>.yaml"
 )
@@ -220,5 +221,11 @@ var (
 		Group:    "gateway.networking.k8s.io",
 		Resource: "grpcroutes",
 		Version:  "v1alpha2",
+	}
+
+	ciliumGatewayClassConfig = schema.GroupVersionResource{
+		Group:    "cilium.io",
+		Resource: "ciliumgatewayclassconfigs",
+		Version:  "v2alpha1",
 	}
 )

--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -2210,6 +2210,21 @@ func (c *Collector) getGatewayAPITasks() []Task {
 				return nil
 			},
 		},
+		{
+			Description: "Collecting CiliumGatewayClassConfig entries",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				n := corev1.NamespaceAll
+				v, err := c.Client.ListUnstructured(ctx, ciliumGatewayClassConfig, &n, metav1.ListOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to collect CiliumGatewayClassConfig entries: %w", err)
+				}
+				if err := c.WriteYAML(ciliumGatewayClassConfigsFileName, v); err != nil {
+					return fmt.Errorf("failed to collect CiliumGatewayClassConfig entries: %w", err)
+				}
+				return nil
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
Currently, the Gateway API related resources `CiliumGatewayClassConfig` isn't collected during Cilium sysdump execution.

For better analysis, this commit adds the missing CRD.

Fixes: https://github.com/cilium/cilium/pull/37402