### PR TITLE
[v1.19] Backport health command fixes from 46102

### DIFF
--- a/pkg/health/client/modules.go
+++ b/pkg/health/client/modules.go
@@ -36,14 +36,25 @@ func GetAndFormatModulesHealth(w io.Writer, ss []types.Status, verbose bool, pre
 			stack := strings.Split(s.ID.String(), ".")
 			upsertTree(r, &s, stack)
 		}
-		if len(r.nodes) != 0 {
-			r = r.nodes[0]
-			r.parent = nil
-		} else {
+		if len(r.nodes) == 0 {
 			return
 		}
 
-		body := strings.ReplaceAll(r.String(), "\n", "\n"+prefix)
+		var body string
+		if len(r.nodes) == 1 {
+			r = r.nodes[0]
+			r.parent = nil
+			body = r.String()
+		} else {
+			var b strings.Builder
+			for _, n := range r.nodes {
+				n.parent = nil
+				b.WriteString(n.String())
+			}
+			body = b.String()
+		}
+
+		body = strings.ReplaceAll(body, "\n", "\n"+prefix)
 		fmt.Fprintln(w, prefix+body)
 		return
 	}

--- a/pkg/health/client/modules_test.go
+++ b/pkg/health/client/modules_test.go
@@ -48,6 +48,28 @@ func TestGetAndFormatModulesHealth(t *testing.T) {
 	}
 }
 
+func TestGetAndFormatModulesHealthMultipleRoots(t *testing.T) {
+	w := bytes.NewBufferString("")
+	client.GetAndFormatModulesHealth(w, []types.Status{
+		{
+			ID:      ident([]string{"operator", "operator-controlplane"}, "leader-election"),
+			Level:   types.LevelOK,
+			Message: "Leader",
+		},
+		{
+			ID:      ident([]string{"health"}, "job-module-status-metrics"),
+			Level:   types.LevelOK,
+			Message: "Running",
+		},
+	}, true, "")
+
+	out := strings.TrimSpace(w.String())
+	assert.Contains(t, out, "health\n└── job-module-status-metrics")
+	assert.Contains(t, out, "operator\n└── operator-controlplane")
+	assert.Contains(t, out, "[OK] Running")
+	assert.Contains(t, out, "[OK] Leader")
+}
+
 // Helpers
 
 func ident(mid []string, cid ...string) types.Identifier {

--- a/pkg/hive/health/command.go
+++ b/pkg/hive/health/command.go
@@ -34,7 +34,7 @@ func healthTreeCommand(db *statedb.DB, table statedb.Table[types.Status]) script
 			Args:    "[reporter-id-prefix]",
 			Flags: func(fs *pflag.FlagSet) {
 				fs.StringP("match", "m", "", "Output only health reports where the reporter ID path contains the substring")
-				fs.StringArrayP("levels", "s", []string{types.LevelOK, types.LevelDegraded, types.LevelDegraded},
+				fs.StringSliceP("levels", "s", []string{types.LevelOK, types.LevelDegraded, types.LevelStopped},
 					"Output only health reports with the specified state (i.e. ok,degraded,stopped)")
 				fs.StringP("output", "o", "", "File to write output to")
 			},
@@ -55,7 +55,7 @@ func healthTreeCommand(db *statedb.DB, table statedb.Table[types.Status]) script
 				return nil, err
 			}
 
-			levels, err := s.Flags.GetStringArray("levels")
+			levels, err := s.Flags.GetStringSlice("levels")
 			if err != nil {
 				return nil, err
 			}
@@ -92,25 +92,17 @@ func healthTreeCommand(db *statedb.DB, table statedb.Table[types.Status]) script
 }
 
 func getHealth(db *statedb.DB, table statedb.Table[types.Status], prefix, match string, levels []string) []types.Status {
+	tx := db.ReadTxn()
+	results := table.Prefix(tx, PrimaryIndex.Query(types.HealthID(prefix)))
 	ss := []types.Status{}
-	if prefix != "" {
-		tx := db.ReadTxn()
-		for status := range table.Prefix(tx, PrimaryIndex.Query(types.HealthID(prefix))) {
-			ss = append(ss, status)
+	for status := range results {
+		if match != "" && !strings.Contains(status.ID.String(), match) {
+			continue
 		}
-	} else {
-		tx := db.ReadTxn()
-		for status := range table.All(tx) {
-			if match != "" && !strings.Contains(status.ID.String(), match) {
-				continue
-			}
-
-			if !slices.Contains(levels, strings.ToLower(status.Level.String())) {
-				continue
-			}
-
-			ss = append(ss, status)
+		if !slices.Contains(levels, strings.ToLower(status.Level.String())) {
+			continue
 		}
+		ss = append(ss, status)
 	}
 	return ss
 }

--- a/pkg/hive/health/testdata/health.txtar
+++ b/pkg/hive/health/testdata/health.txtar
@@ -31,6 +31,12 @@ health --output=out --levels=degraded,stopped
 sed ' \(.*\)' '' out
 cmp degraded-stopped.expected.txt out
 
+# Inserting a new root will show two trees
+db/insert health foo.yaml
+health --output=out
+sed ' \(.*\)' '' out
+cmp foo.expected.txt out
+
 -- allok.yaml --
 id:
     module:
@@ -78,6 +84,21 @@ id:
         - m1
     component:
         - c1
+level: OK
+message: yay
+error: ""
+lastok: 2025-04-01T21:28:00.000000000-07:00
+updated: 2025-04-01T21:28:00.000000000-07:00
+stopped: 0001-01-01T00:00:00Z
+final: ""
+count: 1
+
+-- foo.yaml --
+id:
+    module:
+        - foo
+    component:
+        - c1
 level: OK 
 message: yay 
 error: ""
@@ -86,6 +107,7 @@ updated: 2025-04-01T21:28:00.000000000-07:00
 stopped: 0001-01-01T00:00:00Z
 final: ""
 count: 1
+
 -- all.expected.txt --
 agent
 ├── m0
@@ -114,4 +136,14 @@ agent
 agent
 └── m0
     └── c1                                          [DEGRADED] no!
+
+-- foo.expected.txt --
+agent
+├── m0
+│   ├── c0                                          [OK] ok
+│   └── c1                                          [DEGRADED] no!
+└── m1
+    └── c1                                          [OK] yay
+foo
+└── c1                                          [OK] yay
 

--- a/pkg/hive/health/testdata/health.txtar
+++ b/pkg/hive/health/testdata/health.txtar
@@ -19,9 +19,17 @@ health --output=out agent.m0
 sed ' \(.*\)' '' out
 cmp m0.expected.txt out
 
+health --output=out --match=c1 agent.m0
+sed ' \(.*\)' '' out
+cmp m0.c1.expected.txt out
+
 health --output=out --levels=degraded 
 sed ' \(.*\)' '' out
 cmp degraded.expected.txt out
+
+health --output=out --levels=degraded,stopped
+sed ' \(.*\)' '' out
+cmp degraded-stopped.expected.txt out
 
 -- allok.yaml --
 id:
@@ -92,7 +100,17 @@ agent
     ├── c0                                          [OK] ok
     └── c1                                          [DEGRADED] no!
 
+-- m0.c1.expected.txt --
+agent
+└── m0
+    └── c1                                          [DEGRADED] no!
+
 -- degraded.expected.txt --
+agent
+└── m0
+    └── c1                                          [DEGRADED] no!
+
+-- degraded-stopped.expected.txt --
 agent
 └── m0
     └── c1                                          [DEGRADED] no!


### PR DESCRIPTION
This backports the two small fixes to the `health` command from https://github.com/cilium/cilium/pull/46102#issuecomment-4554514201. The main fix is that now `health` command actually shows proper output with `cilium-operator generic -- shell -- health` while before it only showed the `health.job-module-status-metrics` due to the incorrect assumption that there's only one root module. 