### PR TITLE
cilium-cli: Test wildcard port proxy redirect

### DIFF
--- a/cilium-cli/connectivity/builder/manifests/client-egress-to-fqdns-and-ccec-listener.yaml
+++ b/cilium-cli/connectivity/builder/manifests/client-egress-to-fqdns-and-ccec-listener.yaml
@@ -1,5 +1,9 @@
-# CiliumEnvoyConfig to proxy any incoming HTTP request on the listener to the
-# configured destination.
+# CiliumEnvoyConfig to proxy any incoming TCP connection on the listener to the
+# configured destination, but only if destination port is 80. Connenctions with
+# other destination ports are accepted (downstream connection established), but
+# not connected anywhere in upstream, so the downstream connection is closed.
+# If the connection was a TLS connection, it will get a TLS error as the handshake
+# cannot be finished.
 apiVersion: cilium.io/v2
 kind: CiliumClusterwideEnvoyConfig
 metadata:
@@ -9,26 +13,14 @@ spec:
   - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
     name: proxy-{{trimSuffix .ExternalTarget "."}}-listener
     filter_chains:
-    - filters:
-      - name: envoy.filters.network.http_connection_manager
+    - filter_chain_match:
+        destination_port: 80
+      filters:
+      - name: envoy.filters.network.tcp_proxy
         typed_config:
-          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
           stat_prefix: test-listener
-          route_config:
-            name: default-route
-            virtual_hosts:
-            - name: default-vhost
-              domains: ["*"]
-              routes:
-              - match:
-                  prefix: "/"
-                route:
-                  cluster: proxy-{{trimSuffix .ExternalTarget "."}}-cluster
-          http_filters:
-          - name: envoy.filters.http.router
-            typed_config:
-              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-
+          cluster: proxy-{{trimSuffix .ExternalTarget "."}}-cluster
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     connectTimeout: 55s
     name: proxy-{{trimSuffix .ExternalTarget "."}}-cluster
@@ -56,5 +48,5 @@ spec:
         name: proxy-{{trimSuffix .ExternalTarget "."}}-listener
         priority: 1
       ports:
-      - port: "80"
+      - port: "0"
         protocol: TCP

--- a/cilium-cli/connectivity/builder/to_fqdns.go
+++ b/cilium-cli/connectivity/builder/to_fqdns.go
@@ -123,13 +123,25 @@ func (t toFqdnsWithProxy) build(ct *check.ConnectivityTest, templates map[string
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			extTarget := ct.Params().ExternalTarget
-			if a.Destination().Port() == 80 && a.Destination().Address(features.GetIPFamily(extTarget)) == extTarget {
-				egress = check.ResultDNSOK
-				egress.HTTP = check.HTTP{
-					Method: "GET",
-					URL:    fmt.Sprintf("http://%s/", strings.TrimSuffix(extTarget, ".")),
+			// All ports on the extTarget get redirected to Envoy listener,
+			// but the listener has filter chain match on the TcpProxy filter chain,
+			// only matching connections with destination port 80.
+			if a.Destination().Address(features.GetIPFamily(extTarget)) == extTarget {
+				if a.Destination().Port() == 80 {
+					egress = check.ResultDNSOK
+					egress.HTTP = check.HTTP{
+						Method: "GET",
+						URL:    fmt.Sprintf("http://%s/", strings.TrimSuffix(extTarget, ".")),
+					}
+					return egress, check.ResultNone
 				}
-				return egress, check.ResultNone
+				// other ports miss the destination port match on the Envoy
+				// filter chain, so they get connected, but not forwarded.
+				if a.Destination().Port() == 443 {
+					// port 443 gets the Curl SSL connect error
+					return check.ResultCurlSSLError, check.ResultNone
+				}
+				// other ports get the curl timeout
 			}
 			// No HTTP proxy on other ports/target
 			return check.ResultDNSOKDropCurlTimeout, check.ResultNone


### PR DESCRIPTION
Cilium has recently added support for proxy redirects on the wildcard port, allowing all ports to be forwarded to an Envoy listener defined via a CiliumEnvoyConfig or CiliumClusterwideEnvoyConfig CRD. Change the existing `to-fqdns-with-ccec-listener` test case to use a wildcard port redirect, and adjust test expectations for the https port, as now also port 443 is redirected to Envoy, gets connected but not forwarded, so it gets an SSL error instead of a connection timeout.

```release-note
`cilium-cli` connectivity tests now test for policy-based Envoy listener redirects on the wildcard port.
```
