### PR TITLE
pkg/k8s: fix ClusterNetworkPolicy matchExpressions values being dropped

### DIFF
--- a/pkg/k8s/cluster_network_policy.go
+++ b/pkg/k8s/cluster_network_policy.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"log/slog"
 	"maps"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -43,10 +44,11 @@ func toSlimLabelSelector(ls *metav1.LabelSelector) *slim_metav1.LabelSelector {
 			lsr := slim_metav1.LabelSelectorRequirement{
 				Key:      matchExp.Key,
 				Operator: slim_metav1.LabelSelectorOperator(string(matchExp.Operator)),
-			}
-			if matchExp.Values != nil {
-				lsr.Values = make([]string, 0, len(matchExp.Values))
-				copy(lsr.Values, matchExp.Values)
+				// slices.Clone copies all values (and returns nil for a nil
+				// input). This previously used make([]string, 0, len)+copy,
+				// which silently dropped every value because copy is bounded by
+				// the destination length (0).
+				Values: slices.Clone(matchExp.Values),
 			}
 			result.MatchExpressions = append(result.MatchExpressions, lsr)
 		}

--- a/pkg/k8s/cluster_network_policy_test.go
+++ b/pkg/k8s/cluster_network_policy_test.go
@@ -489,3 +489,118 @@ func TestParseClusterNetworkPolicy(t *testing.T) {
 		})
 	}
 }
+
+// TestToSlimLabelSelectorMatchExpressionsValues is a regression test ensuring that the
+// Values of a matchExpression survive the metav1 -> slim conversion. A previous
+// implementation allocated the destination slice with make([]string, 0, len(values))
+// and then copy()ed into it; because copy is bounded by the destination length (0), the
+// values were silently dropped. That turned every In/Equals requirement into one that
+// matches nothing and every NotIn/NotEquals requirement into one that matches
+// everything, silently corrupting ClusterNetworkPolicy enforcement (policy bypass).
+func TestToSlimLabelSelectorMatchExpressionsValues(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *metav1.LabelSelector
+		want *slim_metav1.LabelSelector
+	}{
+		{
+			name: "nil selector",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "In operator preserves all values",
+			in: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "tier",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"untrusted", "external"},
+					},
+				},
+			},
+			want: &slim_metav1.LabelSelector{
+				MatchLabels: map[string]slim_metav1.MatchLabelsValue{},
+				MatchExpressions: []slim_metav1.LabelSelectorRequirement{
+					{
+						Key:      "tier",
+						Operator: slim_metav1.LabelSelectorOpIn,
+						Values:   []string{"untrusted", "external"},
+					},
+				},
+			},
+		},
+		{
+			name: "NotIn operator preserves all values",
+			in: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "env",
+						Operator: metav1.LabelSelectorOpNotIn,
+						Values:   []string{"prod"},
+					},
+				},
+			},
+			want: &slim_metav1.LabelSelector{
+				MatchLabels: map[string]slim_metav1.MatchLabelsValue{},
+				MatchExpressions: []slim_metav1.LabelSelectorRequirement{
+					{
+						Key:      "env",
+						Operator: slim_metav1.LabelSelectorOpNotIn,
+						Values:   []string{"prod"},
+					},
+				},
+			},
+		},
+		{
+			name: "Exists operator has no values",
+			in: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "tier",
+						Operator: metav1.LabelSelectorOpExists,
+					},
+				},
+			},
+			want: &slim_metav1.LabelSelector{
+				MatchLabels: map[string]slim_metav1.MatchLabelsValue{},
+				MatchExpressions: []slim_metav1.LabelSelectorRequirement{
+					{
+						Key:      "tier",
+						Operator: slim_metav1.LabelSelectorOpExists,
+					},
+				},
+			},
+		},
+		{
+			name: "MatchLabels and MatchExpressions combined",
+			in: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "subject"},
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "tier",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"a", "b", "c"},
+					},
+				},
+			},
+			want: &slim_metav1.LabelSelector{
+				MatchLabels: map[string]slim_metav1.MatchLabelsValue{"app": "subject"},
+				MatchExpressions: []slim_metav1.LabelSelectorRequirement{
+					{
+						Key:      "tier",
+						Operator: slim_metav1.LabelSelectorOpIn,
+						Values:   []string{"a", "b", "c"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toSlimLabelSelector(tt.in)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
toSlimLabelSelector() converts a metav1.LabelSelector from a ClusterNetworkPolicy into Cilium's slim selector. For every matchExpression it allocated the destination slice with make([]string, 0, len(matchExp.Values)) and then copy()ed into it. copy is bounded by the destination length (0), so it copied zero elements and every In/NotIn/etc. requirement silently lost all of its values.

With an empty value set, MatchesRequirement() turns an In/Equals requirement into one that matches nothing and a NotIn/NotEquals requirement into one that matches everything. A ClusterNetworkPolicy that uses matchExpressions on its namespace, pod, node or subject selector therefore enforces something different from its admitted spec: an In-based Deny peer never matches (fail-open, the intended isolation is bypassed) while a NotIn-based selector collapses to match-everything. The sibling helper parsePodSelector() in network_policy.go got this right with make([]string, len(...)), confirming this was a copy-paste defect.

Use slices.Clone() instead of make+copy. It copies all the values and returns nil for a nil input (matching the previous behaviour for operators without values, e.g. Exists), and it removes the length foot-gun that caused the bug in the first place.

Add TestToSlimLabelSelectorMatchExpressionsValues asserting that the values of In/NotIn matchExpressions survive the conversion, that an Exists requirement carries no values, and that MatchLabels and MatchExpressions are both preserved. The test fails against the old make([]string, 0, len)+copy code.

```release-note
Fix Kubernetes ClusterNetworkPolicy (network-policy-api, alpha) match expressions (matchExpressions) being ignored when selecting endpoints. An "In" match selected no endpoints (e.g. a Deny rule would not block its intended traffic) and a "NotIn" match selected all endpoints, so policies using match expressions were not enforced as written. CiliumNetworkPolicy, CiliumClusterwideNetworkPolicy, and standard Kubernetes NetworkPolicy are not affected.
```