### PR TITLE
bgp: Handle errors from NewPathForPrefix

### DIFF
--- a/pkg/bgp/gobgp/state_test.go
+++ b/pkg/bgp/gobgp/state_test.go
@@ -411,12 +411,12 @@ func TestGetRoutes(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = testSC.AdvertisePath(context.TODO(), types.PathRequest{
-		Path: types.NewPathForPrefix(netip.MustParsePrefix("10.0.0.0/24")),
+		Path: types.MustNewPathForPrefix(netip.MustParsePrefix("10.0.0.0/24")),
 	})
 	require.NoError(t, err)
 
 	_, err = testSC.AdvertisePath(context.TODO(), types.PathRequest{
-		Path: types.NewPathForPrefix(netip.MustParsePrefix("fd00::/64")),
+		Path: types.MustNewPathForPrefix(netip.MustParsePrefix("fd00::/64")),
 	})
 	require.NoError(t, err)
 

--- a/pkg/bgp/manager/manager_test.go
+++ b/pkg/bgp/manager/manager_test.go
@@ -191,7 +191,7 @@ func TestGetRoutesLegacy(t *testing.T) {
 			// advertise test-provided prefixes
 			for _, cidr := range tt.advertisedPrefixes {
 				_, err := testInstance.Router.AdvertisePath(context.Background(), types.PathRequest{
-					Path: types.NewPathForPrefix(cidr),
+					Path: types.MustNewPathForPrefix(cidr),
 				})
 				require.NoError(t, err)
 			}

--- a/pkg/bgp/manager/reconciler/interface.go
+++ b/pkg/bgp/manager/reconciler/interface.go
@@ -113,7 +113,7 @@ func (r *InterfaceReconciler) Reconcile(ctx context.Context, p ReconcileParams) 
 	return r.reconcilePaths(ctx, p, desiredPeerAdverts, txn)
 }
 
-func (r *InterfaceReconciler) getDesiredPaths(desiredPeerAdverts PeerAdvertisements, txn statedb.ReadTxn) AFPathsMap {
+func (r *InterfaceReconciler) getDesiredPaths(desiredPeerAdverts PeerAdvertisements, txn statedb.ReadTxn) (AFPathsMap, error) {
 	desiredAdverts := make(AFPathsMap)
 	for _, peerFamilyAdverts := range desiredPeerAdverts {
 		for family, familyAdverts := range peerFamilyAdverts {
@@ -125,14 +125,17 @@ func (r *InterfaceReconciler) getDesiredPaths(desiredPeerAdverts PeerAdvertiseme
 			}
 			for _, advert := range familyAdverts {
 				for _, prefix := range r.getInterfacePrefixes(advert, agentFamily, txn) {
-					path := types.NewPathForPrefix(prefix)
+					path, err := types.NewPathForPrefix(prefix)
+					if err != nil {
+						return nil, fmt.Errorf("failed to create path for prefix %s: %w", prefix, err)
+					}
 					path.Family = agentFamily
 					pathsPerFamily[path.NLRI.String()] = path
 				}
 			}
 		}
 	}
-	return desiredAdverts
+	return desiredAdverts, nil
 }
 
 func (r *InterfaceReconciler) getDesiredRoutePolicies(desiredPeerAdverts PeerAdvertisements, txn statedb.ReadTxn) (RoutePolicyMap, error) {
@@ -212,7 +215,10 @@ func (r *InterfaceReconciler) reconcilePaths(ctx context.Context, p ReconcilePar
 	metadata := r.getMetadata(p.BGPInstance)
 
 	// get desired paths per address family
-	desiredFamilyAdverts := r.getDesiredPaths(desiredPeerAdverts, txn)
+	desiredFamilyAdverts, err := r.getDesiredPaths(desiredPeerAdverts, txn)
+	if err != nil {
+		return err
+	}
 
 	// reconcile family advertisements
 	updatedAFPaths, err := ReconcileAFPaths(&ReconcileAFPathsParams{

--- a/pkg/bgp/manager/reconciler/pod_cidr.go
+++ b/pkg/bgp/manager/reconciler/pod_cidr.go
@@ -116,7 +116,10 @@ func (r *PodCIDRReconciler) reconcilePaths(ctx context.Context, p ReconcileParam
 	metadata := r.getMetadata(p.BGPInstance)
 
 	// get desired paths per address family
-	desiredFamilyAdverts := r.getDesiredPathsPerFamily(desiredPeerAdverts, podPrefixes)
+	desiredFamilyAdverts, err := r.getDesiredPathsPerFamily(desiredPeerAdverts, podPrefixes)
+	if err != nil {
+		return err
+	}
 
 	// reconcile family advertisements
 	updatedAFPaths, err := ReconcileAFPaths(&ReconcileAFPathsParams{
@@ -158,7 +161,7 @@ func (r *PodCIDRReconciler) reconcileRoutePolicies(ctx context.Context, p Reconc
 // getDesiredPathsPerFamily returns a map of desired paths per address family.
 // Note: This returns prefixes per address family. Global routing table will contain prefix per family not per neighbor.
 // Per neighbor advertisement will be controlled by BGP Policy.
-func (r *PodCIDRReconciler) getDesiredPathsPerFamily(desiredPeerAdverts PeerAdvertisements, desiredPrefixes []netip.Prefix) AFPathsMap {
+func (r *PodCIDRReconciler) getDesiredPathsPerFamily(desiredPeerAdverts PeerAdvertisements, desiredPrefixes []netip.Prefix) (AFPathsMap, error) {
 	// Calculate desired paths per address family, collapsing per-peer advertisements into per-family advertisements.
 	desiredFamilyAdverts := make(AFPathsMap)
 	for _, peerFamilyAdverts := range desiredPeerAdverts {
@@ -174,7 +177,10 @@ func (r *PodCIDRReconciler) getDesiredPathsPerFamily(desiredPeerAdverts PeerAdve
 			// we need to add podCIDR prefixes to the desiredFamilyAdverts.
 			if len(familyAdverts) != 0 {
 				for _, prefix := range desiredPrefixes {
-					path := types.NewPathForPrefix(prefix)
+					path, err := types.NewPathForPrefix(prefix)
+					if err != nil {
+						return nil, fmt.Errorf("failed to create path for prefix %s: %w", prefix, err)
+					}
 					path.Family = agentFamily
 
 					// we only add path corresponding to the family of the prefix.
@@ -188,7 +194,7 @@ func (r *PodCIDRReconciler) getDesiredPathsPerFamily(desiredPeerAdverts PeerAdve
 			}
 		}
 	}
-	return desiredFamilyAdverts
+	return desiredFamilyAdverts, nil
 }
 
 func (r *PodCIDRReconciler) getDesiredRoutePolicies(desiredPeerAdverts PeerAdvertisements, desiredPrefixes []netip.Prefix) (RoutePolicyMap, error) {

--- a/pkg/bgp/manager/reconciler/pod_cidr_test.go
+++ b/pkg/bgp/manager/reconciler/pod_cidr_test.go
@@ -459,7 +459,7 @@ func Test_PodCIDRAdvertisement(t *testing.T) {
 			for preAdvertFam, preAdverts := range tt.preconfiguredPaths {
 				pathSet := make(map[string]*types.Path)
 				for preAdvert := range preAdverts {
-					path := types.NewPathForPrefix(netip.MustParsePrefix(preAdvert))
+					path := types.MustNewPathForPrefix(netip.MustParsePrefix(preAdvert))
 					path.Family = preAdvertFam
 					pathSet[preAdvert] = path
 				}

--- a/pkg/bgp/manager/reconciler/pod_ip_pool.go
+++ b/pkg/bgp/manager/reconciler/pod_ip_pool.go
@@ -339,7 +339,10 @@ func (r *PodIPPoolReconciler) getDesiredAFPaths(pool *v2alpha1.CiliumPodIPPool, 
 					// on the local node we have this pool configured.
 					// add the prefixes to the desiredPaths.
 					for _, prefix := range prefixes {
-						path := types.NewPathForPrefix(prefix)
+						path, err := types.NewPathForPrefix(prefix)
+						if err != nil {
+							return nil, fmt.Errorf("failed to create path for prefix %s: %w", prefix, err)
+						}
 						path.Family = agentFamily
 
 						// we only add path corresponding to the family of the prefix.

--- a/pkg/bgp/manager/reconciler/pod_ip_pool_test.go
+++ b/pkg/bgp/manager/reconciler/pod_ip_pool_test.go
@@ -623,7 +623,7 @@ func Test_PodIPPoolAdvertisements(t *testing.T) {
 				for fam, afPaths := range prePoolAFPaths {
 					pathSet := make(PathMap)
 					for prePath := range afPaths {
-						path := types.NewPathForPrefix(netip.MustParsePrefix(prePath))
+						path := types.MustNewPathForPrefix(netip.MustParsePrefix(prePath))
 						path.Family = fam
 						pathSet[prePath] = path
 					}

--- a/pkg/bgp/manager/reconciler/service.go
+++ b/pkg/bgp/manager/reconciler/service.go
@@ -526,7 +526,10 @@ func (r *ServiceReconciler) getServiceAFPaths(p ReconcileParams, desiredPeerAdve
 					for _, prefix := range prefixes.UnsortedList() {
 						// we only add path corresponding to the family of the prefix.
 						if agentFamily.Afi == types.AfiIPv4 && prefix.Addr().Is4() {
-							path := types.NewPathForPrefix(prefix)
+							path, err := types.NewPathForPrefix(prefix)
+							if err != nil {
+								return nil, fmt.Errorf("failed to create path for prefix %s: %w", prefix, err)
+							}
 							// For LoadBalancer IP prefixes, set origin to INCOMPLETE for legacy compatibility.
 							if r.legacyOriginAttributeEnabled && advertType == v2.BGPLoadBalancerIPAddr {
 								path = types.SetPathOriginAttrIncomplete(path)
@@ -535,7 +538,10 @@ func (r *ServiceReconciler) getServiceAFPaths(p ReconcileParams, desiredPeerAdve
 							addPathToAFPathsMap(desiredFamilyAdverts, agentFamily, path)
 						}
 						if agentFamily.Afi == types.AfiIPv6 && prefix.Addr().Is6() {
-							path := types.NewPathForPrefix(prefix)
+							path, err := types.NewPathForPrefix(prefix)
+							if err != nil {
+								return nil, fmt.Errorf("failed to create path for prefix %s: %w", prefix, err)
+							}
 							// For LoadBalancer IP prefixes, set origin to INCOMPLETE for legacy compatibility.
 							if r.legacyOriginAttributeEnabled && advertType == v2.BGPLoadBalancerIPAddr {
 								path = types.SetPathOriginAttrIncomplete(path)

--- a/pkg/bgp/manager/reconciler/service_test.go
+++ b/pkg/bgp/manager/reconciler/service_test.go
@@ -765,10 +765,10 @@ func Test_ServiceLBReconciler(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							ingressV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
+							ingressV4Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							ingressV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
+							ingressV6Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
 						},
 					},
 				},
@@ -800,10 +800,10 @@ func Test_ServiceLBReconciler(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							ingressV4PrefixAggr: types.NewPathForPrefix(netip.MustParsePrefix(ingressV4PrefixAggr)),
+							ingressV4PrefixAggr: types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV4PrefixAggr)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							ingressV6PrefixAggr: types.NewPathForPrefix(netip.MustParsePrefix(ingressV6PrefixAggr)),
+							ingressV6PrefixAggr: types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV6PrefixAggr)),
 						},
 					},
 				},
@@ -836,10 +836,10 @@ func Test_ServiceLBReconciler(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							ingressV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
+							ingressV4Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							ingressV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
+							ingressV6Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
 						},
 					},
 				},
@@ -872,10 +872,10 @@ func Test_ServiceLBReconciler(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							ingressV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
+							ingressV4Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							ingressV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
+							ingressV6Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
 						},
 					},
 				},
@@ -908,10 +908,10 @@ func Test_ServiceLBReconciler(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							ingressV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
+							ingressV4Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							ingressV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
+							ingressV6Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
 						},
 					},
 				},
@@ -992,10 +992,10 @@ func Test_ServiceLBReconciler(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							ingressV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
+							ingressV4Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							ingressV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
+							ingressV6Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
 						},
 					},
 				},
@@ -1033,10 +1033,10 @@ func Test_ServiceLBReconcilerWithLegacyOriginAttr(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							ingressV4Prefix: types.SetPathOriginAttrIncomplete(types.NewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix))),
+							ingressV4Prefix: types.SetPathOriginAttrIncomplete(types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix))),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							ingressV6Prefix: types.SetPathOriginAttrIncomplete(types.NewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix))),
+							ingressV6Prefix: types.SetPathOriginAttrIncomplete(types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix))),
 						},
 					},
 				},
@@ -1111,10 +1111,10 @@ func Test_ServiceExternalIPReconciler(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							externalV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV4Prefix)),
+							externalV4Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(externalV4Prefix)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							externalV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV6Prefix)),
+							externalV6Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(externalV6Prefix)),
 						},
 					},
 				},
@@ -1146,10 +1146,10 @@ func Test_ServiceExternalIPReconciler(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							externalV4PrefixAggr: types.NewPathForPrefix(netip.MustParsePrefix(externalV4PrefixAggr)),
+							externalV4PrefixAggr: types.MustNewPathForPrefix(netip.MustParsePrefix(externalV4PrefixAggr)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							externalV6PrefixAggr: types.NewPathForPrefix(netip.MustParsePrefix(externalV6PrefixAggr)),
+							externalV6PrefixAggr: types.MustNewPathForPrefix(netip.MustParsePrefix(externalV6PrefixAggr)),
 						},
 					},
 				},
@@ -1182,10 +1182,10 @@ func Test_ServiceExternalIPReconciler(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							externalV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV4Prefix)),
+							externalV4Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(externalV4Prefix)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							externalV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV6Prefix)),
+							externalV6Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(externalV6Prefix)),
 						},
 					},
 				},
@@ -1218,10 +1218,10 @@ func Test_ServiceExternalIPReconciler(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							externalV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV4Prefix)),
+							externalV4Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(externalV4Prefix)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							externalV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV6Prefix)),
+							externalV6Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(externalV6Prefix)),
 						},
 					},
 				},
@@ -1254,10 +1254,10 @@ func Test_ServiceExternalIPReconciler(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							externalV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV4Prefix)),
+							externalV4Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(externalV4Prefix)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							externalV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV6Prefix)),
+							externalV6Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(externalV6Prefix)),
 						},
 					},
 				},
@@ -1315,10 +1315,10 @@ func Test_ServiceExternalIPReconciler(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							externalV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV4Prefix)),
+							externalV4Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(externalV4Prefix)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							externalV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV6Prefix)),
+							externalV6Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(externalV6Prefix)),
 						},
 					},
 				},
@@ -1425,10 +1425,10 @@ func Test_ServiceClusterIPReconciler(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							clusterV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
+							clusterV4Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							clusterV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(clusterV6Prefix)),
+							clusterV6Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(clusterV6Prefix)),
 						},
 					},
 				},
@@ -1460,10 +1460,10 @@ func Test_ServiceClusterIPReconciler(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							clusterV4PrefixAggr: types.NewPathForPrefix(netip.MustParsePrefix(clusterV4PrefixAggr)),
+							clusterV4PrefixAggr: types.MustNewPathForPrefix(netip.MustParsePrefix(clusterV4PrefixAggr)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							clusterV6PrefixAggr: types.NewPathForPrefix(netip.MustParsePrefix(clusterV6PrefixAggr)),
+							clusterV6PrefixAggr: types.MustNewPathForPrefix(netip.MustParsePrefix(clusterV6PrefixAggr)),
 						},
 					},
 				},
@@ -1496,10 +1496,10 @@ func Test_ServiceClusterIPReconciler(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							clusterV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
+							clusterV4Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							clusterV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(clusterV6Prefix)),
+							clusterV6Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(clusterV6Prefix)),
 						},
 					},
 				},
@@ -1532,10 +1532,10 @@ func Test_ServiceClusterIPReconciler(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							clusterV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
+							clusterV4Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							clusterV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(clusterV6Prefix)),
+							clusterV6Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(clusterV6Prefix)),
 						},
 					},
 				},
@@ -1568,10 +1568,10 @@ func Test_ServiceClusterIPReconciler(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							clusterV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
+							clusterV4Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							clusterV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(clusterV6Prefix)),
+							clusterV6Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(clusterV6Prefix)),
 						},
 					},
 				},
@@ -1629,10 +1629,10 @@ func Test_ServiceClusterIPReconciler(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							clusterV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
+							clusterV4Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							clusterV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(clusterV6Prefix)),
+							clusterV6Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(clusterV6Prefix)),
 						},
 					},
 				},
@@ -1735,10 +1735,10 @@ func Test_ServiceAndAdvertisementModifications(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							clusterV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
+							clusterV4Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							clusterV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(clusterV6Prefix)),
+							clusterV6Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(clusterV6Prefix)),
 						},
 					},
 				},
@@ -1809,12 +1809,12 @@ func Test_ServiceAndAdvertisementModifications(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							clusterV4Prefix:  types.NewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
-							externalV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV4Prefix)),
+							clusterV4Prefix:  types.MustNewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
+							externalV4Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(externalV4Prefix)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							clusterV6Prefix:  types.NewPathForPrefix(netip.MustParsePrefix(clusterV6Prefix)),
-							externalV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV6Prefix)),
+							clusterV6Prefix:  types.MustNewPathForPrefix(netip.MustParsePrefix(clusterV6Prefix)),
+							externalV6Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(externalV6Prefix)),
 						},
 					},
 				},
@@ -1932,12 +1932,12 @@ func Test_ServiceAndAdvertisementModifications(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							clusterV4Prefix:  types.NewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
-							externalV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV4Prefix)),
+							clusterV4Prefix:  types.MustNewPathForPrefix(netip.MustParsePrefix(clusterV4Prefix)),
+							externalV4Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(externalV4Prefix)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							clusterV6Prefix:  types.NewPathForPrefix(netip.MustParsePrefix(clusterV6Prefix)),
-							externalV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(externalV6Prefix)),
+							clusterV6Prefix:  types.MustNewPathForPrefix(netip.MustParsePrefix(clusterV6Prefix)),
+							externalV6Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(externalV6Prefix)),
 						},
 					},
 				},
@@ -2075,10 +2075,10 @@ func Test_ServiceVIPSharing(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							ingressV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
+							ingressV4Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							ingressV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
+							ingressV6Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
 						},
 					},
 				},
@@ -2134,18 +2134,18 @@ func Test_ServiceVIPSharing(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							ingressV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
+							ingressV4Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							ingressV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
+							ingressV6Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
 						},
 					},
 					redSvc2Key: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							ingressV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
+							ingressV4Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							ingressV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
+							ingressV6Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
 						},
 					},
 				},
@@ -2205,10 +2205,10 @@ func Test_ServiceVIPSharing(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvc2Key: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							ingressV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
+							ingressV4Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							ingressV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
+							ingressV6Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
 						},
 					},
 				},
@@ -2315,10 +2315,10 @@ func Test_ServiceVIPSharing(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							ingressV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
+							ingressV4Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							ingressV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
+							ingressV6Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
 						},
 					},
 				},
@@ -2407,10 +2407,10 @@ func Test_ServiceAdvertisementWithPeerIPChange(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							ingressV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
+							ingressV4Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							ingressV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
+							ingressV6Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
 						},
 					},
 				},
@@ -2523,10 +2523,10 @@ func Test_ServiceAdvertisementWithPeerIPChange(t *testing.T) {
 				ServicePaths: ResourceAFPathsMap{
 					redSvcKey: AFPathsMap{
 						{Afi: types.AfiIPv4, Safi: types.SafiUnicast}: {
-							ingressV4Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
+							ingressV4Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)),
 						},
 						{Afi: types.AfiIPv6, Safi: types.SafiUnicast}: {
-							ingressV6Prefix: types.NewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
+							ingressV6Prefix: types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV6Prefix)),
 						},
 					},
 				},
@@ -2978,7 +2978,7 @@ func TestServiceReconcilerMetadataPartialFailure(t *testing.T) {
 			FakeRouter: fake.NewFakeRouter(),
 			failPrefix: ingressV4PrefixAggr, // aggregation prefix will fail during reconcile
 		}
-		oldPath := types.NewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)) // non-aggregated prefix
+		oldPath := types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)) // non-aggregated prefix
 
 		req.NoError(router.FakeRouter.AddRoutePolicy(t.Context(), types.RoutePolicyRequest{
 			Policy: redPeer65001v4LBRP,

--- a/pkg/bgp/test/commands/gobgp.go
+++ b/pkg/bgp/test/commands/gobgp.go
@@ -502,9 +502,9 @@ func GoBGPAdvertiseRouteCmd(cmdCtx *GoBGPCmdContext) script.Cmd {
 			}
 
 			return func(s *script.State) (stdout, stderr string, err error) {
-				agentPath := types.NewPathForPrefix(prefix)
-				if agentPath == nil {
-					return "", "", fmt.Errorf("could not create path for prefix %s", prefix)
+				agentPath, err := types.NewPathForPrefix(prefix)
+				if err != nil {
+					return "", "", fmt.Errorf("could not create path for prefix %s: %w", prefix, err)
 				}
 				path, err := gobgp.ToGoBGPPath(agentPath)
 				if err != nil {

--- a/pkg/bgp/types/utils.go
+++ b/pkg/bgp/types/utils.go
@@ -4,6 +4,7 @@
 package types
 
 import (
+	"fmt"
 	"net/netip"
 	"slices"
 
@@ -30,7 +31,7 @@ func CanAdvertisePodCIDR(ipam string) bool {
 //
 // The next hop of the path will always be set to "0.0.0.0" for IPv4 and "::" for IPv6,
 // so the underlying BGP implementation selects appropriate actual nexthop address when advertising it.
-func NewPathForPrefix(prefix netip.Prefix) (path *Path) {
+func NewPathForPrefix(prefix netip.Prefix) (*Path, error) {
 	originAttr := bgp.NewPathAttributeOrigin(bgp.BGP_ORIGIN_ATTR_TYPE_IGP)
 
 	// Currently, we only support advertising locally originated paths (the paths generated in Cilium
@@ -53,24 +54,24 @@ func NewPathForPrefix(prefix netip.Prefix) (path *Path) {
 	case prefix.Addr().Is4():
 		nlri, err := bgp.NewIPAddrPrefix(prefix)
 		if err != nil {
-			return nil
+			return nil, err
 		}
 		nextHopAttr, err := bgp.NewPathAttributeNextHop(netip.IPv4Unspecified())
 		if err != nil {
-			return nil
+			return nil, err
 		}
-		path = &Path{
+		return &Path{
 			Family: Family{Afi: AfiIPv4, Safi: SafiUnicast},
 			NLRI:   nlri,
 			PathAttributes: []bgp.PathAttributeInterface{
 				originAttr,
 				nextHopAttr,
 			},
-		}
+		}, nil
 	case prefix.Addr().Is6():
 		nlri, err := bgp.NewIPAddrPrefix(prefix)
 		if err != nil {
-			return nil
+			return nil, err
 		}
 		mpReachNLRIAttr, err := bgp.NewPathAttributeMpReachNLRI(
 			bgp.NewFamily(bgp.AFI_IP6, bgp.SAFI_UNICAST),
@@ -78,19 +79,29 @@ func NewPathForPrefix(prefix netip.Prefix) (path *Path) {
 			netip.IPv6Unspecified(),
 		)
 		if err != nil {
-			return nil
+			return nil, err
 		}
-		path = &Path{
+		return &Path{
 			Family: Family{Afi: AfiIPv6, Safi: SafiUnicast},
 			NLRI:   nlri,
 			PathAttributes: []bgp.PathAttributeInterface{
 				originAttr,
 				mpReachNLRIAttr,
 			},
-		}
+		}, nil
+	default:
+		return nil, fmt.Errorf("invalid prefix: %v", prefix)
 	}
+}
 
-	return
+// MustNewPathForPrefix returns a Path for prefix or panics if the path cannot
+// be created.
+func MustNewPathForPrefix(prefix netip.Prefix) *Path {
+	path, err := NewPathForPrefix(prefix)
+	if err != nil {
+		panic(err)
+	}
+	return path
 }
 
 // SetPathOriginAttrIncomplete ensures the given path has an ORIGIN path


### PR DESCRIPTION
As `NewIPAddrPrefix` in GoBGPv4 may return an error, our `NewPathForPrefix` helper now returns it as well. This has been adapted in the BGP CP codebase.

