### PR TITLE
datapath/orchestrator: fix goroutine leak in MergeChannels watch path

### DIFF
--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -4,6 +4,7 @@
 package common
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"reflect"
@@ -75,22 +76,33 @@ func RequireRootPrivilege(cmd string) {
 	}
 }
 
-func MergeChannels[T any](chans ...<-chan T) <-chan T {
+// MergeChannels forwards the first value received on any of the input channels.
+// The goroutine it starts is bound to ctx, so it is reclaimed on cancellation
+// even if no input ever fires and the caller abandons the returned channel.
+func MergeChannels[T any](ctx context.Context, chans ...<-chan T) <-chan T {
 	out := make(chan T)
-	cases := make([]reflect.SelectCase, len(chans))
-	for i, ch := range chans {
-		cases[i] = reflect.SelectCase{
+	cases := make([]reflect.SelectCase, 0, len(chans)+1)
+	for _, ch := range chans {
+		cases = append(cases, reflect.SelectCase{
 			Dir:  reflect.SelectRecv,
 			Chan: reflect.ValueOf(ch),
-		}
+		})
 	}
+	ctxCase := len(cases)
+	cases = append(cases, reflect.SelectCase{
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(ctx.Done()),
+	})
 	go func() {
 		defer close(out)
-		_, value, ok := reflect.Select(cases)
-		if !ok {
+		chosen, value, ok := reflect.Select(cases)
+		if chosen == ctxCase || !ok {
 			return
 		}
-		out <- value.Interface().(T)
+		select {
+		case out <- value.Interface().(T):
+		case <-ctx.Done():
+		}
 	}()
 	return out
 }

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -4,10 +4,8 @@
 package common
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"reflect"
 	"strconv"
 	"strings"
 )
@@ -74,35 +72,4 @@ func RequireRootPrivilege(cmd string) {
 		fmt.Fprintf(os.Stderr, "Please run %q command(s) with root privileges.\n", cmd)
 		os.Exit(1)
 	}
-}
-
-// MergeChannels forwards the first value received on any of the input channels.
-// The goroutine it starts is bound to ctx, so it is reclaimed on cancellation
-// even if no input ever fires and the caller abandons the returned channel.
-func MergeChannels[T any](ctx context.Context, chans ...<-chan T) <-chan T {
-	out := make(chan T)
-	cases := make([]reflect.SelectCase, 0, len(chans)+1)
-	for _, ch := range chans {
-		cases = append(cases, reflect.SelectCase{
-			Dir:  reflect.SelectRecv,
-			Chan: reflect.ValueOf(ch),
-		})
-	}
-	ctxCase := len(cases)
-	cases = append(cases, reflect.SelectCase{
-		Dir:  reflect.SelectRecv,
-		Chan: reflect.ValueOf(ctx.Done()),
-	})
-	go func() {
-		defer close(out)
-		chosen, value, ok := reflect.Select(cases)
-		if chosen == ctxCase || !ok {
-			return
-		}
-		select {
-		case out <- value.Interface().(T):
-		case <-ctx.Done():
-		}
-	}()
-	return out
 }

--- a/pkg/common/utils_test.go
+++ b/pkg/common/utils_test.go
@@ -4,9 +4,12 @@
 package common
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/testutils"
 )
 
 func TestC2GoArray(t *testing.T) {
@@ -47,4 +50,49 @@ func TestGoArray2C(t *testing.T) {
 	for _, test := range tests {
 		require.Equal(t, test.output, GoArray2C(test.input))
 	}
+}
+
+func TestMergeChannels(t *testing.T) {
+	t.Run("forwards the first received value", func(t *testing.T) {
+		a := make(chan int, 1)
+		b := make(chan int, 1)
+		out := MergeChannels(context.Background(), a, b)
+
+		b <- 42
+		require.Equal(t, 42, <-out)
+
+		// Only a single value is forwarded; the output channel is then closed.
+		_, ok := <-out
+		require.False(t, ok)
+	})
+
+	t.Run("closed input closes the output", func(t *testing.T) {
+		a := make(chan struct{})
+		b := make(chan struct{})
+		out := MergeChannels(context.Background(), a, b)
+
+		close(b)
+		_, ok := <-out
+		require.False(t, ok, "output channel should be closed once an input is closed")
+	})
+
+	t.Run("does not leak when context is cancelled", func(t *testing.T) {
+		// Regression test for https://github.com/cilium/cilium/issues/46254.
+		defer testutils.GoleakVerifyNone(t)
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		// Inputs that never fire, mimicking abandoned statedb watch channels.
+		a := make(chan struct{})
+		b := make(chan struct{})
+		c := make(chan struct{})
+		out := MergeChannels(ctx, a, b, c)
+
+		cancel()
+
+		// The output channel is closed once the goroutine observes the
+		// cancellation; this blocks until the goroutine has exited.
+		_, ok := <-out
+		require.False(t, ok)
+	})
 }

--- a/pkg/common/utils_test.go
+++ b/pkg/common/utils_test.go
@@ -4,12 +4,9 @@
 package common
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/cilium/cilium/pkg/testutils"
 )
 
 func TestC2GoArray(t *testing.T) {
@@ -50,49 +47,4 @@ func TestGoArray2C(t *testing.T) {
 	for _, test := range tests {
 		require.Equal(t, test.output, GoArray2C(test.input))
 	}
-}
-
-func TestMergeChannels(t *testing.T) {
-	t.Run("forwards the first received value", func(t *testing.T) {
-		a := make(chan int, 1)
-		b := make(chan int, 1)
-		out := MergeChannels(context.Background(), a, b)
-
-		b <- 42
-		require.Equal(t, 42, <-out)
-
-		// Only a single value is forwarded; the output channel is then closed.
-		_, ok := <-out
-		require.False(t, ok)
-	})
-
-	t.Run("closed input closes the output", func(t *testing.T) {
-		a := make(chan struct{})
-		b := make(chan struct{})
-		out := MergeChannels(context.Background(), a, b)
-
-		close(b)
-		_, ok := <-out
-		require.False(t, ok, "output channel should be closed once an input is closed")
-	})
-
-	t.Run("does not leak when context is cancelled", func(t *testing.T) {
-		// Regression test for https://github.com/cilium/cilium/issues/46254.
-		defer testutils.GoleakVerifyNone(t)
-
-		ctx, cancel := context.WithCancel(context.Background())
-
-		// Inputs that never fire, mimicking abandoned statedb watch channels.
-		a := make(chan struct{})
-		b := make(chan struct{})
-		c := make(chan struct{})
-		out := MergeChannels(ctx, a, b, c)
-
-		cancel()
-
-		// The output channel is closed once the goroutine observes the
-		// cancellation; this blocks until the goroutine has exited.
-		_, ok := <-out
-		require.False(t, ok)
-	})
 }

--- a/pkg/datapath/orchestrator/localnodeconfig.go
+++ b/pkg/datapath/orchestrator/localnodeconfig.go
@@ -205,7 +205,7 @@ func newLocalNodeConfig(
 		DatapathIsLayer2:             connectorConfig.GetOperationalMode().IsLayer2(),
 		DatapathIsNetkit:             connectorConfig.GetOperationalMode().IsNetkit(),
 		Plugins:                      plugins,
-	}, common.MergeChannels(watchChans...), nil
+	}, common.MergeChannels(ctx, watchChans...), nil
 }
 
 // getEphemeralPortRangeMin returns the minimum ephemeral port from

--- a/pkg/datapath/orchestrator/localnodeconfig.go
+++ b/pkg/datapath/orchestrator/localnodeconfig.go
@@ -15,7 +15,6 @@ import (
 	"go4.org/netipx"
 
 	"github.com/cilium/cilium/pkg/cidr"
-	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/datapath/config"
 	"github.com/cilium/cilium/pkg/datapath/connector"
 	ipsec "github.com/cilium/cilium/pkg/datapath/linux/ipsec/types"
@@ -57,8 +56,10 @@ func prefixToCIDR(p netip.Prefix) *cidr.CIDR {
 // LocalNodeConfiguration instance is generated. Previous LocalNodeConfiguration
 // is never mutated in-place.
 //
-// The returned channel will be closed for recoverable errors once the state of
-// failing condition changes.
+// Each returned watch channel is closed when the piece of state it tracks
+// changes; the caller should wait on all of them. For recoverable errors, a
+// single watch channel is returned that is closed once the failing condition
+// changes.
 func newLocalNodeConfig(
 	ctx context.Context,
 	daemon *option.DaemonConfig,
@@ -80,7 +81,7 @@ func newLocalNodeConfig(
 	ipsecCfg ipsec.Config,
 	connectorConfig connector.Config,
 	plugins plugin.Plugins,
-) (config.Config, <-chan struct{}, error) {
+) (config.Config, []<-chan struct{}, error) {
 	auxPrefixes := []ip.Prefix{}
 
 	if daemon.IPv4ServiceRange.IsValid() {
@@ -102,14 +103,14 @@ func newLocalNodeConfig(
 		if drd == nil {
 			// If the direct routing device is not present return the watch channel along with an error.
 			// Watch channel will be closed when there is an update to the DirectRouting device configuration.
-			return config.Config{}, directRoutingDevWatch, errors.New("direct routing device required but not configured")
+			return config.Config{}, []<-chan struct{}{directRoutingDevWatch}, errors.New("direct routing device required but not configured")
 		}
 
 		// Ensure the device has at least one usable address for the enabled
 		// address families. If not, return the watch channel so we retry as
 		// soon as the device's addresses change.
 		if !directRoutingDeviceHasAddr(drd) {
-			return config.Config{}, directRoutingDevWatch,
+			return config.Config{}, []<-chan struct{}{directRoutingDevWatch},
 				fmt.Errorf("direct routing device %s has no usable addresses", drd.Name)
 		}
 
@@ -135,7 +136,7 @@ func newLocalNodeConfig(
 
 	ciliumHostDevice, _, hostWatch, ok := devices.GetWatch(txn, tables.DeviceByName(defaults.HostDevice))
 	if !ok {
-		return config.Config{}, hostWatch, fmt.Errorf("failed to look up link '%s'", defaults.HostDevice)
+		return config.Config{}, []<-chan struct{}{hostWatch}, fmt.Errorf("failed to look up link '%s'", defaults.HostDevice)
 	}
 	watchChans = append(watchChans, hostWatch)
 	ciliumHostMAC, err := mac.ParseMAC(ciliumHostDevice.HardwareAddr.String())
@@ -145,7 +146,7 @@ func newLocalNodeConfig(
 
 	ciliumNetDevice, _, netWatch, ok := devices.GetWatch(txn, tables.DeviceByName(defaults.SecondHostDevice))
 	if !ok {
-		return config.Config{}, netWatch, fmt.Errorf("failed to look up link '%s'", defaults.SecondHostDevice)
+		return config.Config{}, []<-chan struct{}{netWatch}, fmt.Errorf("failed to look up link '%s'", defaults.SecondHostDevice)
 	}
 	watchChans = append(watchChans, netWatch)
 	ciliumNetMAC, err := mac.ParseMAC(ciliumNetDevice.HardwareAddr.String())
@@ -204,7 +205,7 @@ func newLocalNodeConfig(
 		DatapathIsLayer2:             connectorConfig.GetOperationalMode().IsLayer2(),
 		DatapathIsNetkit:             connectorConfig.GetOperationalMode().IsNetkit(),
 		Plugins:                      plugins,
-	}, common.MergeChannels(ctx, watchChans...), nil
+	}, watchChans, nil
 }
 
 // getEphemeralPortRangeMin returns the minimum ephemeral port from

--- a/pkg/datapath/orchestrator/localnodeconfig.go
+++ b/pkg/datapath/orchestrator/localnodeconfig.go
@@ -204,7 +204,7 @@ func newLocalNodeConfig(
 		DatapathIsLayer2:             connectorConfig.GetOperationalMode().IsLayer2(),
 		DatapathIsNetkit:             connectorConfig.GetOperationalMode().IsNetkit(),
 		Plugins:                      plugins,
-	}, common.MergeChannels(watchChans...), nil
+	}, common.MergeChannels(ctx, watchChans...), nil
 }
 
 // getEphemeralPortRangeMin returns the minimum ephemeral port from

--- a/pkg/datapath/orchestrator/localnodeconfig_test.go
+++ b/pkg/datapath/orchestrator/localnodeconfig_test.go
@@ -4,13 +4,32 @@
 package orchestrator
 
 import (
+	"context"
 	"net/netip"
 	"testing"
 
+	"github.com/cilium/statedb"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 
+	fakeconnector "github.com/cilium/cilium/pkg/datapath/connector/fake"
+	fakeipsec "github.com/cilium/cilium/pkg/datapath/linux/ipsec/fake"
+	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	"github.com/cilium/cilium/pkg/datapath/xdp"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/kpr"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/maglev"
+	"github.com/cilium/cilium/pkg/mtu"
+	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/svcrouteconfig"
+	"github.com/cilium/cilium/pkg/testutils"
+	wgfake "github.com/cilium/cilium/pkg/wireguard/fake"
 )
 
 func TestDirectRoutingDeviceHasAddr(t *testing.T) {
@@ -101,5 +120,94 @@ func TestDirectRoutingDeviceHasAddr(t *testing.T) {
 			dev := &tables.Device{Name: "eth0", Index: 2, Addrs: tt.addrs}
 			assert.Equal(t, tt.want, directRoutingDeviceHasAddr(dev))
 		})
+	}
+}
+
+// TestNewLocalNodeConfigNoGoroutineLeak is a regression test for
+// https://github.com/cilium/cilium/issues/46254: the watch channel returned by
+// newLocalNodeConfig is backed by a common.MergeChannels goroutine that must be
+// reclaimed when the caller cancels the context, even if no input ever fires.
+func TestNewLocalNodeConfigNoGoroutineLeak(t *testing.T) {
+	// Save and restore the global config touched below.
+	savedHostLegacy := option.Config.UnsafeDaemonConfigOption.EnableHostLegacyRouting
+	savedV4Range := option.Config.IPv4ServiceRange
+	savedV6Range := option.Config.IPv6ServiceRange
+	t.Cleanup(func() {
+		option.Config.UnsafeDaemonConfigOption.EnableHostLegacyRouting = savedHostLegacy
+		option.Config.IPv4ServiceRange = savedV4Range
+		option.Config.IPv6ServiceRange = savedV6Range
+	})
+	// KPR + BPF host routing + Wireguard disabled => DirectRoutingDeviceRequired
+	// is false, so newLocalNodeConfig skips the direct routing device branch.
+	option.Config.UnsafeDaemonConfigOption.EnableHostLegacyRouting = true
+	option.Config.IPv4ServiceRange = AutoCIDR
+	option.Config.IPv6ServiceRange = AutoCIDR
+
+	db := statedb.New()
+	devices, err := tables.NewDeviceTable(db)
+	require.NoError(t, err)
+	nodeAddrs, err := tables.NewNodeAddressTable(db)
+	require.NoError(t, err)
+	mtuTable, err := mtu.NewMTUTable(db)
+	require.NoError(t, err)
+
+	// Seed cilium_host and cilium_net so newLocalNodeConfig reaches the success
+	// path that builds the merged watch channel.
+	wtxn := db.WriteTxn(devices)
+	for i, name := range []string{defaults.HostDevice, defaults.SecondHostDevice} {
+		_, _, err = devices.Insert(wtxn, &tables.Device{
+			Index:        i + 1,
+			Name:         name,
+			HardwareAddr: tables.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, byte(i + 1)},
+		})
+		require.NoError(t, err)
+	}
+	wtxn.Commit()
+
+	// In-memory sysctl with the ephemeral port range getEphemeralPortRangeMin reads.
+	memFS := afero.NewMemMapFs()
+	require.NoError(t, memFS.MkdirAll("/proc/sys/net/ipv4", 0755))
+	require.NoError(t, afero.WriteFile(memFS,
+		"/proc/sys/net/ipv4/ip_local_port_range", []byte("32768\t60999"), 0644))
+	sysctlReader := sysctl.NewDirectSysctl(memFS, "/proc")
+
+	wgAgent := wgfake.NewTestAgent(wgfake.Config{EnableWireguard: false})
+
+	call := func(ctx context.Context) error {
+		_, _, err := newLocalNodeConfig(
+			ctx,
+			option.Config,
+			node.LocalNode{Local: &node.LocalNodeInfo{}},
+			sysctlReader,
+			tunnel.Config{},
+			db.ReadTxn(),
+			tables.DirectRoutingDevice{},
+			devices,
+			nodeAddrs,
+			"",
+			xdp.Config{},
+			loadbalancer.Config{},
+			kpr.KPRConfig{},
+			svcrouteconfig.RoutesConfig{},
+			maglev.Config{},
+			mtuTable,
+			wgAgent,
+			fakeipsec.Config{},
+			fakeconnector.NewVeth(),
+			nil,
+		)
+		return err
+	}
+
+	// Baseline goroutines after setup so statedb's etc. are not counted.
+	defer testutils.GoleakVerifyNone(t, goleak.IgnoreCurrent())
+
+	// Emulate the reconciler loop: create a watch, abandon it (as when the loop
+	// wakes via another event source), then cancel the per-iteration context.
+	// Without the fix the merge goroutines block forever in reflect.Select.
+	for range 1000 {
+		watchCtx, cancelWatch := context.WithCancel(context.Background())
+		require.NoError(t, call(watchCtx))
+		cancelWatch()
 	}
 }

--- a/pkg/datapath/orchestrator/localnodeconfig_test.go
+++ b/pkg/datapath/orchestrator/localnodeconfig_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 
 	fakeconnector "github.com/cilium/cilium/pkg/datapath/connector/fake"
 	fakeipsec "github.com/cilium/cilium/pkg/datapath/linux/ipsec/fake"
@@ -124,9 +123,11 @@ func TestDirectRoutingDeviceHasAddr(t *testing.T) {
 }
 
 // TestNewLocalNodeConfigNoGoroutineLeak is a regression test for
-// https://github.com/cilium/cilium/issues/46254: the watch channel returned by
-// newLocalNodeConfig is backed by a common.MergeChannels goroutine that must be
-// reclaimed when the caller cancels the context, even if no input ever fires.
+// https://github.com/cilium/cilium/issues/46254. newLocalNodeConfig must return
+// its watch channels directly rather than merging them with a helper goroutine:
+// the reconciler abandons the watch set whenever it wakes up via another event
+// source, so any goroutine tied to it would leak. This test guards against a
+// merge helper being reintroduced.
 func TestNewLocalNodeConfigNoGoroutineLeak(t *testing.T) {
 	// Save and restore the global config touched below.
 	savedHostLegacy := option.Config.UnsafeDaemonConfigOption.EnableHostLegacyRouting
@@ -140,8 +141,8 @@ func TestNewLocalNodeConfigNoGoroutineLeak(t *testing.T) {
 	// KPR + BPF host routing + Wireguard disabled => DirectRoutingDeviceRequired
 	// is false, so newLocalNodeConfig skips the direct routing device branch.
 	option.Config.UnsafeDaemonConfigOption.EnableHostLegacyRouting = true
-	option.Config.IPv4ServiceRange = AutoCIDR
-	option.Config.IPv6ServiceRange = AutoCIDR
+	option.Config.IPv4ServiceRange = netip.Prefix{}
+	option.Config.IPv6ServiceRange = netip.Prefix{}
 
 	db := statedb.New()
 	devices, err := tables.NewDeviceTable(db)
@@ -152,7 +153,7 @@ func TestNewLocalNodeConfigNoGoroutineLeak(t *testing.T) {
 	require.NoError(t, err)
 
 	// Seed cilium_host and cilium_net so newLocalNodeConfig reaches the success
-	// path that builds the merged watch channel.
+	// path that returns the full watch channel set.
 	wtxn := db.WriteTxn(devices)
 	for i, name := range []string{defaults.HostDevice, defaults.SecondHostDevice} {
 		_, _, err = devices.Insert(wtxn, &tables.Device{
@@ -173,8 +174,8 @@ func TestNewLocalNodeConfigNoGoroutineLeak(t *testing.T) {
 
 	wgAgent := wgfake.NewTestAgent(wgfake.Config{EnableWireguard: false})
 
-	call := func(ctx context.Context) error {
-		_, _, err := newLocalNodeConfig(
+	call := func(ctx context.Context) ([]<-chan struct{}, error) {
+		_, watches, err := newLocalNodeConfig(
 			ctx,
 			option.Config,
 			node.LocalNode{Local: &node.LocalNodeInfo{}},
@@ -196,18 +197,18 @@ func TestNewLocalNodeConfigNoGoroutineLeak(t *testing.T) {
 			fakeconnector.NewVeth(),
 			nil,
 		)
-		return err
+		return watches, err
 	}
 
 	// Baseline goroutines after setup so statedb's etc. are not counted.
-	defer testutils.GoleakVerifyNone(t, goleak.IgnoreCurrent())
+	defer testutils.GoleakVerifyNone(t, testutils.GoleakIgnoreCurrent())
 
-	// Emulate the reconciler loop: create a watch, abandon it (as when the loop
-	// wakes via another event source), then cancel the per-iteration context.
-	// Without the fix the merge goroutines block forever in reflect.Select.
+	// Emulate the reconciler loop rebuilding and abandoning its watch set when
+	// another event source wakes it. No goroutine should be created for the
+	// watch channels.
 	for range 1000 {
-		watchCtx, cancelWatch := context.WithCancel(context.Background())
-		require.NoError(t, call(watchCtx))
-		cancelWatch()
+		watches, err := call(context.Background())
+		require.NoError(t, err)
+		require.NotEmpty(t, watches)
 	}
 }

--- a/pkg/datapath/orchestrator/orchestrator.go
+++ b/pkg/datapath/orchestrator/orchestrator.go
@@ -218,8 +218,13 @@ func (o *orchestrator) reconciler(ctx context.Context, health cell.Health) error
 		retryChan <-chan time.Time
 	)
 	for {
+		// Per-iteration context for the watch goroutine started by
+		// newLocalNodeConfig, cancelled below so it does not leak if we proceed
+		// via a different event source than localNodeConfigWatch.
+		watchCtx, cancelWatch := context.WithCancel(ctx)
+
 		localNodeConfig, localNodeConfigWatch, err := newLocalNodeConfig(
-			ctx,
+			watchCtx,
 			option.Config,
 			localNode,
 			o.params.Sysctl,
@@ -270,12 +275,16 @@ func (o *orchestrator) reconciler(ctx context.Context, health cell.Health) error
 
 		select {
 		case <-ctx.Done():
+			cancelWatch()
 			return ctx.Err()
 		case <-localNodeConfigWatch:
 		case <-retryChan:
 		case localNode = <-localNodes:
 		case request = <-o.trigger:
 		}
+
+		// Stop this iteration's watch goroutine now that we no longer need it.
+		cancelWatch()
 
 		// Limit the rate at which we reinitialize and to give the devs&addrs
 		// a chance to settle down.

--- a/pkg/datapath/orchestrator/orchestrator.go
+++ b/pkg/datapath/orchestrator/orchestrator.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"reflect"
 	"sync/atomic"
 
 	"github.com/cilium/hive/cell"
@@ -218,13 +219,8 @@ func (o *orchestrator) reconciler(ctx context.Context, health cell.Health) error
 		retryChan <-chan time.Time
 	)
 	for {
-		// Per-iteration context for the watch goroutine started by
-		// newLocalNodeConfig, cancelled below so it does not leak if we proceed
-		// via a different event source than localNodeConfigWatch.
-		watchCtx, cancelWatch := context.WithCancel(ctx)
-
-		localNodeConfig, localNodeConfigWatch, err := newLocalNodeConfig(
-			watchCtx,
+		localNodeConfig, localNodeConfigWatches, err := newLocalNodeConfig(
+			ctx,
 			option.Config,
 			localNode,
 			o.params.Sysctl,
@@ -273,18 +269,37 @@ func (o *orchestrator) reconciler(ctx context.Context, health cell.Health) error
 		}
 		request = reinitializeRequest{ctx: ctx}
 
-		select {
-		case <-ctx.Done():
-			cancelWatch()
-			return ctx.Err()
-		case <-localNodeConfigWatch:
-		case <-retryChan:
-		case localNode = <-localNodes:
-		case request = <-o.trigger:
+		// Wait on all event sources with a single select. The statedb watch
+		// channels are variable in number, so the select is built with reflect;
+		// the index of each case is derived from the statement that adds it.
+		cases := make([]reflect.SelectCase, 0, 4+len(localNodeConfigWatches))
+		add := func(ch any) int {
+			cases = append(cases, reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(ch)})
+			return len(cases) - 1
+		}
+		ctxCase := add(ctx.Done())
+		retryCase := add(retryChan)
+		localNodesCase := add(localNodes)
+		triggerCase := add(o.trigger)
+		for _, watch := range localNodeConfigWatches {
+			add(watch)
 		}
 
-		// Stop this iteration's watch goroutine now that we no longer need it.
-		cancelWatch()
+		chosen, value, ok := reflect.Select(cases)
+		switch chosen {
+		case ctxCase:
+			return ctx.Err()
+		case retryCase:
+			// Retry immediately after the rate limiter below.
+		case localNodesCase:
+			if !ok {
+				// localNodes is closed when ctx is cancelled.
+				return ctx.Err()
+			}
+			localNode = value.Interface().(node.LocalNode)
+		case triggerCase:
+			request = value.Interface().(reinitializeRequest)
+		}
 
 		// Limit the rate at which we reinitialize and to give the devs&addrs
 		// a chance to settle down.


### PR DESCRIPTION
## Description of the bug

Fixes: #46254

common.MergeChannels starts a goroutine that blocks in reflect.Select until one
of its input channels fires, with no way to cancel it. Its only caller,
newLocalNodeConfig, merges statedb watch channels and returns the result as the
orchestrator reconciler's localNodeConfigWatch.

The reconciler builds a fresh watch on every loop iteration. When it wakes via
another event source (a LocalNodeStore update or an explicit trigger) rather
than localNodeConfigWatch, the previous iteration's MergeChannels goroutine is
abandoned. If none of its input watch channels ever close - which happens when
only the local node changes while the device and address tables stay stable -
that goroutine blocks forever. Under multi-pool IPAM with sustained CiliumNode
churn this leaks one goroutine per update, accumulating thousands over time and
driving up CPU, latency and packet drops.

## Changes
- Remove MergeChannels and return the statedb watch channels directly from
newLocalNodeConfig. The reconciler waits on them alongside its other event
sources with a single reflect.Select and no helper goroutine.

- Add a regression test that repeatedly builds and abandons the watch set and
asserts that no goroutines leak.

This bug is present on `main` and in released `v1.18.x` (reported on v1.18.10),
so it should be backported to the affected stable branches.


```
This PR was prepared with AIL:3.
```

## Release note
```release-note
Fixed a goroutine leak that could cause Cilium agents to accumulate thousands of goroutines under sustained CiliumNode churn, increasing CPU usage and contributing to latency or packet drops.
```
