### PR TITLE
ipam/multi-pool: Use accessors to get and set CiliumNode pools

### DIFF
--- a/operator/pkg/ipam/allocator/multipool/multipool.go
+++ b/operator/pkg/ipam/allocator/multipool/multipool.go
@@ -22,6 +22,7 @@ import (
 	allocatorTypes "github.com/cilium/cilium/operator/pkg/ipam/allocator"
 	"github.com/cilium/cilium/pkg/defaults"
 	iputil "github.com/cilium/cilium/pkg/ip"
+	"github.com/cilium/cilium/pkg/ipam"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -181,9 +182,7 @@ func StartAllocator(p multiPoolParams) {
 						nm := NewNodeHandler(
 							"ipam-multi-pool-sync",
 							p.Logger, p.Allocator, p.Clientset.CiliumV2().CiliumNodes(),
-							func(cn *v2.CiliumNode) *types.IPAMPoolSpec {
-								return &cn.Spec.IPAM.Pools
-							},
+							ipam.MultiPoolAccessor,
 						)
 
 						return nm, nil

--- a/operator/pkg/ipam/allocator/multipool/node_handler.go
+++ b/operator/pkg/ipam/allocator/multipool/node_handler.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cilium/cilium/operator/pkg/ipam/allocator"
 	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/ipam"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
@@ -25,9 +26,9 @@ type NodeHandler struct {
 	logger *slog.Logger
 	mutex  lock.Mutex
 
-	poolManager       *PoolAllocator
-	cnClient          cilium_v2.CiliumNodeInterface
-	poolsFromResource v2.PoolsFromResourceFunc
+	poolManager   *PoolAllocator
+	cnClient      cilium_v2.CiliumNodeInterface
+	poolsAccessor ipam.PoolSpecAccessors
 
 	name string
 
@@ -46,13 +47,13 @@ func NewNodeHandler(
 	logger *slog.Logger,
 	manager *PoolAllocator,
 	cnClient cilium_v2.CiliumNodeInterface,
-	poolsFromResource v2.PoolsFromResourceFunc,
+	poolsAccessor ipam.PoolSpecAccessors,
 ) *NodeHandler {
 	return &NodeHandler{
 		logger:                 logger,
 		poolManager:            manager,
 		cnClient:               cnClient,
-		poolsFromResource:      poolsFromResource,
+		poolsAccessor:          poolsAccessor,
 		name:                   name,
 		nodesPendingAllocation: map[string]*v2.CiliumNode{},
 		controllerManager:      controller.NewManager(),
@@ -105,7 +106,7 @@ func (n *NodeHandler) Stop() {
 func (n *NodeHandler) upsertLocked(resource *v2.CiliumNode) {
 	if !n.restoreFinished {
 		n.nodesPendingAllocation[resource.Name] = resource
-		pools := n.poolsFromResource(resource)
+		pools := n.poolsAccessor.FromResource(resource)
 		_ = n.poolManager.AllocateToNode(resource.Name, pools)
 		return
 	}
@@ -137,7 +138,7 @@ func (n *NodeHandler) createUpsertController(resource *v2.CiliumNode) {
 				refetchNode = false
 			}
 
-			pools := n.poolsFromResource(resource)
+			pools := n.poolsAccessor.FromResource(resource)
 			err := n.poolManager.AllocateToNode(resource.Name, pools)
 			if err != nil {
 				n.logger.Warn(
@@ -152,10 +153,11 @@ func (n *NodeHandler) createUpsertController(resource *v2.CiliumNode) {
 			newResource := resource.DeepCopy()
 			newResource.Status.IPAM.OperatorStatus.Error = errorMessage
 
-			newPools := n.poolsFromResource(newResource)
+			newPools := n.poolsAccessor.FromResource(newResource)
 			newPools.Allocated = n.poolManager.AllocatedPools(newResource.Name)
+			changed := n.poolsAccessor.ToResource(newResource, newPools)
 
-			if !newPools.DeepEqual(pools) {
+			if changed {
 				_, err = n.cnClient.Update(ctx, newResource, metav1.UpdateOptions{})
 				if err != nil {
 					controllerErr = errors.Join(controllerErr, fmt.Errorf("failed to update spec: %w", err))

--- a/operator/pkg/ipam/allocator/multipool/node_handler_test.go
+++ b/operator/pkg/ipam/allocator/multipool/node_handler_test.go
@@ -24,6 +24,7 @@ import (
 	k8sTesting "k8s.io/client-go/testing"
 
 	iputil "github.com/cilium/cilium/pkg/ip"
+	"github.com/cilium/cilium/pkg/ipam"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	ciliumFake "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/fake"
@@ -94,10 +95,6 @@ type mockResult struct {
 	err  error
 }
 
-func GetIPAMPools(cn *v2.CiliumNode) *ipamTypes.IPAMPoolSpec {
-	return &cn.Spec.IPAM.Pools
-}
-
 func TestNodeHandler(t *testing.T) {
 	t.Cleanup(func() { testutils.GoleakVerifyNone(t) })
 
@@ -130,7 +127,10 @@ func TestNodeHandler(t *testing.T) {
 			return r.node, r.err
 		},
 	}
-	nh := NewNodeHandler("test", hivetest.Logger(t), backend, nodeUpdater, GetIPAMPools)
+	nh := NewNodeHandler(
+		"test", hivetest.Logger(t), backend, nodeUpdater,
+		ipam.MultiPoolAccessor,
+	)
 
 	// wait 1ms instead of default 1s base duration in unit tests
 	nh.controllerErrorRetryBaseDuration = 1 * time.Millisecond
@@ -276,7 +276,10 @@ func TestOrphanCIDRsAfterRestart(t *testing.T) {
 			return r.node, r.err
 		},
 	}
-	nh := NewNodeHandler("test", hivetest.Logger(t), backend, nodeUpdater, GetIPAMPools)
+	nh := NewNodeHandler(
+		"test", hivetest.Logger(t), backend, nodeUpdater,
+		ipam.MultiPoolAccessor,
+	)
 
 	// wait 1ms instead of default 1s base duration in unit tests
 	nh.controllerErrorRetryBaseDuration = 1 * time.Millisecond
@@ -406,7 +409,10 @@ func TestOrphanCIDRsReleased(t *testing.T) {
 			return r.node, r.err
 		},
 	}
-	nh := NewNodeHandler("test", hivetest.Logger(t), backend, nodeUpdater, GetIPAMPools)
+	nh := NewNodeHandler(
+		"test", hivetest.Logger(t), backend, nodeUpdater,
+		ipam.MultiPoolAccessor,
+	)
 
 	// wait 1ms instead of default 1s base duration in unit tests
 	nh.controllerErrorRetryBaseDuration = 1 * time.Millisecond
@@ -564,7 +570,10 @@ func TestNodeHandlerRetries(t *testing.T) {
 			return false, nil, nil
 		})
 
-		nh := NewNodeHandler("test", hivetest.Logger(t), backend, clientset.CiliumV2().CiliumNodes(), GetIPAMPools)
+		nh := NewNodeHandler(
+			"test", hivetest.Logger(t), backend, clientset.CiliumV2().CiliumNodes(),
+			ipam.MultiPoolAccessor,
+		)
 		t.Cleanup(nh.Stop)
 		nh.controllerErrorRetryBaseDuration = time.Millisecond
 
@@ -639,7 +648,10 @@ func TestNodeHandlerRetries(t *testing.T) {
 			return false, nil, nil
 		})
 
-		nh := NewNodeHandler("test", hivetest.Logger(t), backend, clientset.CiliumV2().CiliumNodes(), GetIPAMPools)
+		nh := NewNodeHandler(
+			"test", hivetest.Logger(t), backend, clientset.CiliumV2().CiliumNodes(),
+			ipam.MultiPoolAccessor,
+		)
 		t.Cleanup(nh.Stop)
 		nh.controllerErrorRetryBaseDuration = time.Millisecond
 

--- a/operator/pkg/ipam/allocator/multipool/pool_allocator.go
+++ b/operator/pkg/ipam/allocator/multipool/pool_allocator.go
@@ -387,7 +387,7 @@ func (p *PoolAllocator) DeletePool(poolName string) error {
 	return nil
 }
 
-func (p *PoolAllocator) AllocateToNode(nodeName string, pools *types.IPAMPoolSpec) error {
+func (p *PoolAllocator) AllocateToNode(nodeName string, pools types.IPAMPoolSpec) error {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 

--- a/operator/pkg/ipam/allocator/multipool/pool_allocator_test.go
+++ b/operator/pkg/ipam/allocator/multipool/pool_allocator_test.go
@@ -102,7 +102,7 @@ func TestPoolAllocator(t *testing.T) {
 		},
 	}
 	// node1 has some pre-allocated pools that need to be restored
-	err = p.AllocateToNode(node1.Name, &node1.Spec.IPAM.Pools)
+	err = p.AllocateToNode(node1.Name, node1.Spec.IPAM.Pools)
 	assert.ErrorIs(t, ErrAllocatorNotReady, err)
 	assert.Equal(t, []ipamTypes.IPAMPoolAllocation{
 		{
@@ -116,12 +116,12 @@ func TestPoolAllocator(t *testing.T) {
 	}, p.AllocatedPools(node1.Name))
 
 	// node2 must not allocate before restoration has finished
-	err = p.AllocateToNode(node2.Name, &node2.Spec.IPAM.Pools)
+	err = p.AllocateToNode(node2.Name, node2.Spec.IPAM.Pools)
 	assert.ErrorIs(t, ErrAllocatorNotReady, err)
 	assert.Empty(t, p.AllocatedPools(node2.Name))
 
 	// node3 must not steal the restored CIDR from node1
-	err = p.AllocateToNode(node3.Name, &node3.Spec.IPAM.Pools)
+	err = p.AllocateToNode(node3.Name, node3.Spec.IPAM.Pools)
 	assert.ErrorIs(t, ErrAllocatorNotReady, err)
 	assert.Empty(t, p.AllocatedPools(node3.Name))
 
@@ -129,7 +129,7 @@ func TestPoolAllocator(t *testing.T) {
 	p.RestoreFinished()
 
 	// The following is a no-op, but should not return any errors
-	err = p.AllocateToNode(node1.Name, &node1.Spec.IPAM.Pools)
+	err = p.AllocateToNode(node1.Name, node1.Spec.IPAM.Pools)
 	assert.NoError(t, err)
 	node1.Spec.IPAM.Pools.Allocated = p.AllocatedPools(node1.Name)
 	assert.Equal(t, []ipamTypes.IPAMPoolAllocation{
@@ -144,7 +144,7 @@ func TestPoolAllocator(t *testing.T) {
 	}, node1.Spec.IPAM.Pools.Allocated)
 
 	// The following should allocate one IPv4 and IPv6 CIDR each to node2
-	err = p.AllocateToNode(node2.Name, &node2.Spec.IPAM.Pools)
+	err = p.AllocateToNode(node2.Name, node2.Spec.IPAM.Pools)
 	assert.NoError(t, err)
 	node2.Spec.IPAM.Pools.Allocated = p.AllocatedPools(node2.Name)
 	assert.Equal(t, []ipamTypes.IPAMPoolAllocation{
@@ -158,7 +158,7 @@ func TestPoolAllocator(t *testing.T) {
 	}, node2.Spec.IPAM.Pools.Allocated)
 
 	// The following should be rejected, because the CIDR is owned by node1
-	err = p.AllocateToNode(node3.Name, &node3.Spec.IPAM.Pools)
+	err = p.AllocateToNode(node3.Name, node3.Spec.IPAM.Pools)
 	assert.EqualError(t, err, "unable to reuse from pool default: cidr 10.100.10.0/24 has already been allocated")
 	assert.Empty(t, p.AllocatedPools(node3.Name))
 
@@ -172,12 +172,12 @@ func TestPoolAllocator(t *testing.T) {
 			},
 		},
 	}
-	err = p.AllocateToNode(node1.Name, &node1.Spec.IPAM.Pools)
+	err = p.AllocateToNode(node1.Name, node1.Spec.IPAM.Pools)
 	assert.NoError(t, err)
 	assert.Equal(t, node1.Spec.IPAM.Pools.Allocated, p.AllocatedPools(node1.Name))
 
 	// node3 can now allocate 10.100.10.0/24
-	err = p.AllocateToNode(node3.Name, &node3.Spec.IPAM.Pools)
+	err = p.AllocateToNode(node3.Name, node3.Spec.IPAM.Pools)
 	assert.NoError(t, err)
 	node3.Spec.IPAM.Pools.Allocated = p.AllocatedPools(node3.Name)
 	assert.Equal(t, []ipamTypes.IPAMPoolAllocation{
@@ -204,7 +204,7 @@ func TestPoolAllocator(t *testing.T) {
 			},
 		},
 	}
-	err = p.AllocateToNode(node3.Name, &node3.Spec.IPAM.Pools)
+	err = p.AllocateToNode(node3.Name, node3.Spec.IPAM.Pools)
 	assert.NoError(t, err)
 	assert.Equal(t, node3.Spec.IPAM.Pools.Allocated, p.AllocatedPools(node3.Name))
 
@@ -218,7 +218,7 @@ func TestPoolAllocator(t *testing.T) {
 			},
 		},
 	}
-	err = p.AllocateToNode(node1.Name, &node1.Spec.IPAM.Pools)
+	err = p.AllocateToNode(node1.Name, node1.Spec.IPAM.Pools)
 	assert.NoError(t, err)
 	node1.Spec.IPAM.Pools.Allocated = p.AllocatedPools(node1.Name)
 	assert.Equal(t, []ipamTypes.IPAMPoolAllocation{
@@ -257,7 +257,7 @@ func TestPoolAllocator_PoolErrors(t *testing.T) {
 		},
 	}
 
-	err := p.AllocateToNode(node.Name, &node.Spec.IPAM.Pools)
+	err := p.AllocateToNode(node.Name, node.Spec.IPAM.Pools)
 	assert.ErrorContains(t, err, `failed to allocate ipv4 address for node "node1" from pool "no-exist"`)
 	assert.ErrorContains(t, err, `cannot allocate from non-existing pool: no-exist`)
 
@@ -274,7 +274,7 @@ func TestPoolAllocator_PoolErrors(t *testing.T) {
 			},
 		},
 	}
-	err = p.AllocateToNode(node.Name, &node.Spec.IPAM.Pools)
+	err = p.AllocateToNode(node.Name, node.Spec.IPAM.Pools)
 	assert.ErrorContains(t, err, `failed to allocate ipv6 address for node "node1" from pool "ipv4-only"`)
 	assert.ErrorContains(t, err, `pool empty`)
 
@@ -311,7 +311,7 @@ func TestPoolAllocator_PoolErrors(t *testing.T) {
 			},
 		},
 	}
-	err = p.AllocateToNode(node.Name, &node.Spec.IPAM.Pools)
+	err = p.AllocateToNode(node.Name, node.Spec.IPAM.Pools)
 	assert.ErrorContains(t, err, `failed to allocate ipv6 address for node "node1" from pool "ipv4-only"`)
 	assert.ErrorContains(t, err, `failed to allocate ipv6 address for node "node1" from pool "ipv4-only-same-cidr"`)
 	assert.ErrorContains(t, err, `failed to allocate ipv4 address for node "node1" from pool "ipv6-only"`)
@@ -347,7 +347,7 @@ func TestPoolAllocator_PoolErrors(t *testing.T) {
 			{}, // zero-value Prefix: invalid
 		},
 	}
-	err = p.AllocateToNode(node.Name, &node.Spec.IPAM.Pools)
+	err = p.AllocateToNode(node.Name, node.Spec.IPAM.Pools)
 	assert.ErrorContains(t, err, `invalid CIDR`)
 }
 
@@ -625,7 +625,7 @@ func TestPoolAllocatorAllowFirstAndLastIPs(t *testing.T) {
 				},
 			}
 
-			err = p.AllocateToNode(node.Name, &node.Spec.IPAM.Pools)
+			err = p.AllocateToNode(node.Name, node.Spec.IPAM.Pools)
 			assert.NoError(t, err)
 			assert.Equal(t, []ipamTypes.IPAMPoolAllocation{
 				{
@@ -707,7 +707,7 @@ func TestPoolUpdateWithCIDRInUse(t *testing.T) {
 	assert.Equal(t, 96, testPool.v6MaskSize)
 
 	// allocate to node from test-pool
-	err = p.AllocateToNode(node.Name, &node.Spec.IPAM.Pools)
+	err = p.AllocateToNode(node.Name, node.Spec.IPAM.Pools)
 	assert.NoError(t, err)
 	assert.Equal(t, []ipamTypes.IPAMPoolAllocation{
 		{
@@ -827,7 +827,7 @@ func TestOrphanCIDRs(t *testing.T) {
 	assert.Equal(t, 96, testPool.v6MaskSize)
 
 	// allocate to node1 from test-pool
-	err = p.AllocateToNode(node1.Name, &node1.Spec.IPAM.Pools)
+	err = p.AllocateToNode(node1.Name, node1.Spec.IPAM.Pools)
 	assert.NoError(t, err)
 	assert.Equal(t, []ipamTypes.IPAMPoolAllocation{
 		{
@@ -846,7 +846,7 @@ func TestOrphanCIDRs(t *testing.T) {
 	}, p.nodes[node1.Name])
 
 	// allocate to node2 from test-pool
-	err = p.AllocateToNode(node2.Name, &node2.Spec.IPAM.Pools)
+	err = p.AllocateToNode(node2.Name, node2.Spec.IPAM.Pools)
 	assert.NoError(t, err)
 	assert.Equal(t, []ipamTypes.IPAMPoolAllocation{
 		{
@@ -996,7 +996,7 @@ func TestOrphanCIDRs(t *testing.T) {
 	}, p.AllocatedPools(node2.Name))
 
 	// allocate to node3 from test-pool, but v4 CIDR allocation should fail
-	err = p.AllocateToNode(node3.Name, &node3.Spec.IPAM.Pools)
+	err = p.AllocateToNode(node3.Name, node3.Spec.IPAM.Pools)
 	assert.ErrorIs(t, err, errPoolEmpty)
 	assert.Equal(t, []ipamTypes.IPAMPoolAllocation{
 		{
@@ -1048,7 +1048,7 @@ func TestOrphanCIDRs(t *testing.T) {
 	}, p.AllocatedPools(node2.Name))
 
 	// allocate again to node3 from test-pool, now it should succeed for v4 too
-	err = p.AllocateToNode(node3.Name, &node3.Spec.IPAM.Pools)
+	err = p.AllocateToNode(node3.Name, node3.Spec.IPAM.Pools)
 	assert.NoError(t, err)
 
 	assert.Equal(t, poolToCIDRs{
@@ -1110,7 +1110,7 @@ func TestOrphanCIDRsNotStolenFromAnotherPool(t *testing.T) {
 	p.RestoreFinished()
 
 	// try to allocate to the node: it should fail, but previous CIDRs should be marked orphans
-	err := p.AllocateToNode(node1.Name, &node1.Spec.IPAM.Pools)
+	err := p.AllocateToNode(node1.Name, node1.Spec.IPAM.Pools)
 	assert.ErrorContains(t, err, `failed to allocate ipv4 address for node "node1" from pool "test-pool"`)
 	assert.ErrorContains(t, err, `cannot allocate from non-existing pool: test-pool`)
 
@@ -1197,7 +1197,7 @@ func TestUpdatePoolKeepOldCIDRs(t *testing.T) {
 
 	p.RestoreFinished()
 
-	err = p.AllocateToNode(node.Name, &node.Spec.IPAM.Pools)
+	err = p.AllocateToNode(node.Name, node.Spec.IPAM.Pools)
 	assert.NoError(t, err)
 	assert.Equal(t, []ipamTypes.IPAMPoolAllocation{
 		{

--- a/pkg/ipam/eni.go
+++ b/pkg/ipam/eni.go
@@ -546,67 +546,76 @@ func eniContainsIP(eni awsTypes.ENI, addr netip.Addr) bool {
 	return false
 }
 
-// eniPoolsFromResource returns the pool specification for ENI IPAM mode.
-// Unlike the standard multi-pool mode which reads Allocated CIDRs from
-// Spec.IPAM.Pools.Allocated, ENI mode derives them from Status.ENI.ENIs
-// which is maintained by the operator. This allows the agent to be the
-// sole writer of Spec.IPAM.Pools.Allocated while reading CIDRs from a
-// different source.
-//
-// Secondary IPs are represented as host-prefix CIDRs (/32 for IPv4, /128 for
-// IPv6) and delegated prefixes as /28 CIDRs for IPv4 and /80 CIDRs for IPv6.
-func eniPoolsFromResource(node *ciliumv2.CiliumNode) *ipamTypes.IPAMPoolSpec {
-	pools := &ipamTypes.IPAMPoolSpec{
-		Requested: node.Spec.IPAM.Pools.Requested,
-		Allocated: node.Spec.IPAM.Pools.Allocated,
-	}
+var eniPoolAccessor = PoolSpecAccessors{
+	// FromResource returns the pool specification for ENI IPAM mode.
+	// Unlike the standard multi-pool mode which reads Allocated CIDRs from
+	// Spec.IPAM.Pools.Allocated, ENI mode derives them from Status.ENI.ENIs
+	// which is maintained by the operator. This allows the agent to be the
+	// sole writer of Spec.IPAM.Pools.Allocated while reading CIDRs from a
+	// different source.
+	//
+	// Secondary IPs are represented as host-prefix CIDRs (/32 for IPv4, /128 for
+	// IPv6) and delegated prefixes as /28 CIDRs for IPv4 and /80 CIDRs for IPv6.
+	FromResource: func(node *ciliumv2.CiliumNode) ipamTypes.IPAMPoolSpec {
+		pools := ipamTypes.IPAMPoolSpec{
+			Requested: node.Spec.IPAM.Pools.Requested,
+			Allocated: node.Spec.IPAM.Pools.Allocated,
+		}
 
-	if len(node.Status.ENI.ENIs) == 0 {
+		if len(node.Status.ENI.ENIs) == 0 {
+			return pools
+		}
+
+		var cidrs []iputil.Prefix
+		for _, eni := range node.Status.ENI.ENIs {
+			if eni.IsExcludedBySpec(node.Spec.ENI) {
+				continue
+			}
+
+			var prefixes []netip.Prefix
+			for _, p := range eni.Prefixes {
+				cidrs = append(cidrs, p)
+				if p.IsValid() {
+					prefixes = append(prefixes, p.Prefix)
+				}
+			}
+
+			// In parseENI (pkg/aws/api), we currently use PrefixToIps to flatten each prefixes
+			// into 16 individual IPs and append those IPs to the ENI Addresses field.
+			// Here we need to apply a reverse logic to only advertise as /32 CIDRs in the pool
+			// regular secondary addresses (or the ENI primary IP when using UsePrimaryAddress)
+			// and not addresses that are already being advertised through a /28 CIDR.
+			for _, addr := range eni.Addresses {
+				if !addr.IsValid() {
+					continue
+				}
+				if addressCoveredByPrefix(addr.Addr, prefixes) {
+					continue
+				}
+				cidrs = append(cidrs, iputil.PrefixFrom(netip.PrefixFrom(addr.Addr, addr.BitLen())))
+			}
+		}
+
+		if len(cidrs) > 0 {
+			pools.Allocated = []ipamTypes.IPAMPoolAllocation{
+				{
+					Pool:         defaults.IPAMDefaultIPPool,
+					AllowFirstIP: true,
+					AllowLastIP:  true,
+					CIDRs:        cidrs,
+				},
+			}
+		}
+
 		return pools
-	}
-
-	var cidrs []iputil.Prefix
-	for _, eni := range node.Status.ENI.ENIs {
-		if eni.IsExcludedBySpec(node.Spec.ENI) {
-			continue
+	},
+	ToResource: func(node *ciliumv2.CiliumNode, spec ipamTypes.IPAMPoolSpec) bool {
+		if !node.Spec.IPAM.Pools.DeepEqual(&spec) {
+			node.Spec.IPAM.Pools = spec
+			return true
 		}
-
-		var prefixes []netip.Prefix
-		for _, p := range eni.Prefixes {
-			cidrs = append(cidrs, p)
-			if p.IsValid() {
-				prefixes = append(prefixes, p.Prefix)
-			}
-		}
-
-		// In parseENI (pkg/aws/api), we currently use PrefixToIps to flatten each prefixes
-		// into 16 individual IPs and append those IPs to the ENI Addresses field.
-		// Here we need to apply a reverse logic to only advertise as /32 CIDRs in the pool
-		// regular secondary addresses (or the ENI primary IP when using UsePrimaryAddress)
-		// and not addresses that are already being advertised through a /28 CIDR.
-		for _, addr := range eni.Addresses {
-			if !addr.IsValid() {
-				continue
-			}
-			if addressCoveredByPrefix(addr.Addr, prefixes) {
-				continue
-			}
-			cidrs = append(cidrs, iputil.PrefixFrom(netip.PrefixFrom(addr.Addr, addr.BitLen())))
-		}
-	}
-
-	if len(cidrs) > 0 {
-		pools.Allocated = []ipamTypes.IPAMPoolAllocation{
-			{
-				Pool:         defaults.IPAMDefaultIPPool,
-				AllowFirstIP: true,
-				AllowLastIP:  true,
-				CIDRs:        cidrs,
-			},
-		}
-	}
-
-	return pools
+		return false
+	},
 }
 
 // addressCoveredByPrefix returns true if the given IP address falls
@@ -705,7 +714,7 @@ func newENIMultiPoolAllocators(p ENIMultiPoolAllocatorParams) (Allocator, Alloca
 		Node:                 p.Node,
 		CNClient:             p.CNClient,
 		JobGroup:             p.JobGroup,
-		PoolsFromResource:    eniPoolsFromResource,
+		PoolSpecAccessors:    eniPoolAccessor,
 		LinearPreAlloc:       true,
 	})
 

--- a/pkg/ipam/eni_test.go
+++ b/pkg/ipam/eni_test.go
@@ -5,20 +5,30 @@ package ipam
 
 import (
 	"context"
+	"log/slog"
 	"net/netip"
 	"testing"
+	"time"
 
+	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/job"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/cilium/cilium/daemon/k8s"
 	awsTypes "github.com/cilium/cilium/pkg/aws/types"
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/hive"
 	iputil "github.com/cilium/cilium/pkg/ip"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	"github.com/cilium/cilium/pkg/ipmasq"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
 	"github.com/cilium/cilium/pkg/node"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/slices"
 )
@@ -487,10 +497,10 @@ func TestAddressCoveredByPrefix(t *testing.T) {
 	}
 }
 
-func TestEniPoolsFromResource(t *testing.T) {
+func TestENIPoolsAccessorFromResource(t *testing.T) {
 	t.Run("no ENIs returns spec pools", func(t *testing.T) {
 		node := &ciliumv2.CiliumNode{}
-		result := eniPoolsFromResource(node)
+		result := eniPoolAccessor.FromResource(node)
 		require.Empty(t, result.Allocated)
 	})
 
@@ -502,7 +512,7 @@ func TestEniPoolsFromResource(t *testing.T) {
 			},
 		}
 
-		result := eniPoolsFromResource(node)
+		result := eniPoolAccessor.FromResource(node)
 		require.Len(t, result.Allocated, 1)
 		require.Equal(t, defaults.IPAMDefaultIPPool, result.Allocated[0].Pool)
 		require.True(t, result.Allocated[0].AllowFirstIP)
@@ -529,7 +539,7 @@ func TestEniPoolsFromResource(t *testing.T) {
 			},
 		}
 
-		result := eniPoolsFromResource(node)
+		result := eniPoolAccessor.FromResource(node)
 		require.Len(t, result.Allocated, 1)
 		require.Equal(t, defaults.IPAMDefaultIPPool, result.Allocated[0].Pool)
 		require.True(t, result.Allocated[0].AllowFirstIP)
@@ -554,13 +564,91 @@ func TestEniPoolsFromResource(t *testing.T) {
 			},
 		}
 
-		result := eniPoolsFromResource(node)
+		result := eniPoolAccessor.FromResource(node)
 		require.Len(t, result.Allocated, 1)
 		require.True(t, result.Allocated[0].AllowFirstIP)
 		require.True(t, result.Allocated[0].AllowLastIP)
 		require.Len(t, result.Allocated[0].CIDRs, 1)
 		require.Contains(t, result.Allocated[0].CIDRs, iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.2/32")))
 	})
+}
+
+func TestENIMultiPoolAllocator(t *testing.T) {
+	eniCIDR1 := netip.MustParsePrefix("10.0.10.1/32")
+	eniCIDR2 := netip.MustParsePrefix("10.0.10.2/32")
+	initialNode := &ciliumv2.CiliumNode{
+		ObjectMeta: metav1.ObjectMeta{Name: nodeTypes.GetName()},
+		Status: ciliumv2.NodeStatus{
+			ENI: awsTypes.ENIStatus{
+				ENIs: map[string]awsTypes.ENI{
+					"eni-1": {
+						Addresses: addrs(eniCIDR1.Addr().String(), eniCIDR2.Addr().String()),
+						VPC: awsTypes.AwsVPC{
+							PrimaryCIDR: iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.0/16")),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var (
+		jg             job.Group
+		localNode      k8s.LocalCiliumNodeResource
+		localNodeStore *node.LocalNodeStore
+		clientset      *k8sClient.FakeClientset
+	)
+	h := hive.New(
+		k8s.ResourcesCell,
+		k8sClient.FakeClientCell(),
+		cell.Provide(func() *node.LocalNodeStore { return node.NewTestLocalNodeStore(node.LocalNode{}) }),
+		cell.Invoke(
+			func(
+				jg_ job.Group,
+				localNode_ k8s.LocalCiliumNodeResource,
+				localNodeStore_ *node.LocalNodeStore,
+				clientset_ *k8sClient.FakeClientset,
+			) {
+				jg = jg_
+				localNode = localNode_
+				localNodeStore = localNodeStore_
+				clientset = clientset_
+			},
+		),
+	)
+
+	tlog := hivetest.Logger(t, hivetest.LogLevel(slog.LevelError))
+	require.NoError(t, h.Start(tlog, t.Context()))
+	t.Cleanup(func() { h.Stop(tlog, context.Background()) })
+
+	_, err := clientset.CiliumV2().CiliumNodes().Create(t.Context(), initialNode, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	ipv4Allocator, ipv6Allocator := newENIMultiPoolAllocators(ENIMultiPoolAllocatorParams{
+		Logger:               hivetest.Logger(t),
+		IPv4Enabled:          true,
+		IPv6Enabled:          false,
+		CiliumNodeUpdateRate: time.Nanosecond,
+		Node:                 localNode,
+		LocalNodeStore:       localNodeStore,
+		CNClient:             clientset.CiliumV2().CiliumNodes(),
+		JobGroup:             jg,
+		Conf:                 &option.DaemonConfig{},
+	})
+	require.NotNil(t, ipv4Allocator)
+	require.NotNil(t, ipv6Allocator)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		updated, err := clientset.CiliumV2().CiliumNodes().Get(t.Context(), initialNode.Name, metav1.GetOptions{})
+		assert.NoError(c, err)
+		alloc := updated.Spec.IPAM.Pools.Allocated
+		require.Len(c, alloc, 1)
+		assert.Equal(c, defaults.IPAMDefaultIPPool, alloc[0].Pool)
+		assert.ElementsMatch(c, []iputil.Prefix{
+			iputil.PrefixFrom(eniCIDR1),
+			iputil.PrefixFrom(eniCIDR2),
+		}, alloc[0].CIDRs)
+	}, 5*time.Second, 10*time.Millisecond)
 }
 
 func TestDeriveENIVpcCIDR(t *testing.T) {

--- a/pkg/ipam/multipool.go
+++ b/pkg/ipam/multipool.go
@@ -30,6 +30,19 @@ import (
 
 const waitForPoolInStateDBTimeout = time.Minute
 
+var MultiPoolAccessor = PoolSpecAccessors{
+	FromResource: func(cn *ciliumv2.CiliumNode) types.IPAMPoolSpec {
+		return cn.Spec.IPAM.Pools
+	},
+	ToResource: func(cn *ciliumv2.CiliumNode, spec types.IPAMPoolSpec) bool {
+		if !cn.Spec.IPAM.Pools.DeepEqual(&spec) {
+			cn.Spec.IPAM.Pools = spec
+			return true
+		}
+		return false
+	},
+}
+
 var _ Allocator = (*multiPoolAllocator)(nil)
 
 type MultiPoolAllocatorParams struct {
@@ -71,9 +84,7 @@ func newMultiPoolAllocators(p MultiPoolAllocatorParams) (Allocator, Allocator) {
 		CNClient:              p.CNClient,
 		JobGroup:              p.JobGroup,
 		SkipMasqueradeForPool: shouldSkipMasqForPool(p.DB, p.PodIPPools, p.OnlyMasqueradeDefaultPool),
-		PoolsFromResource: func(cn *ciliumv2.CiliumNode) *types.IPAMPoolSpec {
-			return &cn.Spec.IPAM.Pools
-		},
+		PoolSpecAccessors:     MultiPoolAccessor,
 	})
 
 	waitForAllPools(p.Logger, p.DB, p.PodIPPools, preallocMap)

--- a/pkg/ipam/multipool_manager.go
+++ b/pkg/ipam/multipool_manager.go
@@ -219,6 +219,20 @@ func (p pendingAllocationsPerOwner) pendingForFamily(family Family) int {
 	return len(p[family])
 }
 
+// PoolSpecAccessors reads and writes the pool specification in the CiliumNode.
+//
+// This is needed to reuse the same multi-pool manager for different implementations,
+// since each frontend targets a different field when reading and writing the pool
+// specs.
+type PoolSpecAccessors struct {
+	// FromResource returns the IPAM Pool specs from the CiliumNode
+	FromResource func(*ciliumv2.CiliumNode) types.IPAMPoolSpec
+
+	// ToResource writes the IPAM Pool specs to the CiliumNode.
+	// It returns true if the pools have been updated, false otherwise.
+	ToResource func(*ciliumv2.CiliumNode, types.IPAMPoolSpec) bool
+}
+
 // SkipMasqueradeForPoolFn is the type of a function that, given a pool
 // returns true if the addresses of that pool should be excluded from
 // masquerading, false otherwise.
@@ -237,7 +251,7 @@ type MultiPoolManagerParams struct {
 	CNClient cilium_v2.CiliumNodeInterface
 	JobGroup job.Group
 
-	PoolsFromResource ciliumv2.PoolsFromResourceFunc
+	PoolSpecAccessors PoolSpecAccessors
 
 	SkipMasqueradeForPool SkipMasqueradeForPoolFn
 
@@ -272,7 +286,8 @@ type multiPoolManager struct {
 
 	logger *slog.Logger
 
-	poolsFromResource     ciliumv2.PoolsFromResourceFunc
+	poolsAccessor PoolSpecAccessors
+
 	skipMasqueradeForPool SkipMasqueradeForPoolFn
 
 	linearPreAlloc bool
@@ -296,8 +311,8 @@ func newMultiPoolManager(p MultiPoolManagerParams) *multiPoolManager {
 		localNodeUpdateFn: sync.OnceFunc(func() {
 			close(localNodeUpdated)
 		}),
-		poolsFromResource: p.PoolsFromResource,
-		linearPreAlloc:    p.LinearPreAlloc,
+		poolsAccessor:  p.PoolSpecAccessors,
+		linearPreAlloc: p.LinearPreAlloc,
 		skipMasqueradeForPool: func(Pool) (bool, error) {
 			return false, nil
 		},
@@ -403,7 +418,7 @@ func (m *multiPoolManager) ciliumNodeUpdated(newNode *ciliumv2.CiliumNode) {
 	m.poolsMutex.Lock()
 	defer m.poolsMutex.Unlock()
 
-	for _, pool := range m.poolsFromResource(newNode).Allocated {
+	for _, pool := range m.poolsAccessor.FromResource(newNode).Allocated {
 		m.upsertPoolLocked(Pool(pool.Pool), pool.CIDRs, pool.AllowFirstIP, pool.AllowLastIP)
 	}
 
@@ -622,21 +637,28 @@ func (m *multiPoolManager) updateLocalNode(ctx context.Context) error {
 	sort.Slice(allocated, func(i, j int) bool {
 		return allocated[i].Pool < allocated[j].Pool
 	})
-	newNode.Spec.IPAM.Pools.Requested = requested
-	// Only write Allocated once local pools have been populated. Before
-	// that, the agent has no CIDRs of its own and writing an empty
+
+	var newPoolsSpec types.IPAMPoolSpec
+	newPoolsSpec.Requested = requested
+
+	// Only update Allocated once local pools have been populated. Before
+	// that, the agent has no CIDRs of its own and updating with an empty
 	// Allocated would clear CIDRs that may still be in use from a
 	// previous agent run. Once the agent has observed at least one CIDR
 	// (from Status.ENI.ENIs in ENI mode, or from Pools.Allocated in
-	// standard multi-pool mode), it writes Allocated to communicate
+	// standard multi-pool mode), it updates Allocated to communicate
 	// in-use CIDRs back to the operator.
 	if len(m.pools) > 0 {
-		newNode.Spec.IPAM.Pools.Allocated = allocated
+		newPoolsSpec.Allocated = allocated
+	} else {
+		pools := m.poolsAccessor.FromResource(curNode)
+		newPoolsSpec.Allocated = pools.Allocated
 	}
 
 	m.poolsMutex.Unlock()
 
-	if !newNode.Spec.IPAM.Pools.DeepEqual(&curNode.Spec.IPAM.Pools) {
+	changed := m.poolsAccessor.ToResource(newNode, newPoolsSpec)
+	if changed {
 		updatedNode, err := m.cnClient.Update(ctx, newNode, metav1.UpdateOptions{})
 		switch {
 		case k8sErrors.IsConflict(err):

--- a/pkg/ipam/multipool_test.go
+++ b/pkg/ipam/multipool_test.go
@@ -134,9 +134,7 @@ func Test_MultiPoolManager(t *testing.T) {
 			Node:                 localNode,
 			CNClient:             clientset.CiliumV2().CiliumNodes(),
 			JobGroup:             jg,
-			PoolsFromResource: func(cn *ciliumv2.CiliumNode) *types.IPAMPoolSpec {
-				return &cn.Spec.IPAM.Pools
-			},
+			PoolSpecAccessors:    MultiPoolAccessor,
 		})
 
 		// Wait for agent pre-allocation request, then validate it
@@ -586,9 +584,7 @@ func Test_MultiPoolManager_ReleaseUnusedCIDR(t *testing.T) {
 		Node:                 fakeK8sAPI,
 		CNClient:             fakeK8sAPI,
 		JobGroup:             jg,
-		PoolsFromResource: func(cn *ciliumv2.CiliumNode) *types.IPAMPoolSpec {
-			return &cn.Spec.IPAM.Pools
-		},
+		PoolSpecAccessors:    MultiPoolAccessor,
 	})
 
 	<-events // first upsert (initial node)
@@ -707,9 +703,7 @@ func Test_MultiPoolManager_ReleaseUnusedCIDR_PreAlloc(t *testing.T) {
 		Node:                 fakeK8sAPI,
 		CNClient:             fakeK8sAPI,
 		JobGroup:             jg,
-		PoolsFromResource: func(cn *ciliumv2.CiliumNode) *types.IPAMPoolSpec {
-			return &cn.Spec.IPAM.Pools
-		},
+		PoolSpecAccessors:    MultiPoolAccessor,
 	})
 
 	<-events // first upsert (initial node)
@@ -974,9 +968,7 @@ func Test_MultiPoolManager_UpdateNodeRetries(t *testing.T) {
 			Node:                 localNode,
 			CNClient:             clientset.CiliumV2().CiliumNodes(),
 			JobGroup:             jg,
-			PoolsFromResource: func(cn *ciliumv2.CiliumNode) *types.IPAMPoolSpec {
-				return &cn.Spec.IPAM.Pools
-			},
+			PoolSpecAccessors:    MultiPoolAccessor,
 		})
 		require.NotNil(t, mgr)
 

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -526,13 +526,6 @@ func (n *CiliumNode) InstanceID() (instanceID string) {
 	return
 }
 
-// PoolsFromResourceFunc is the type of a function that returns the pool
-// specification in the CiliumNode that should be used by the multi pool
-// manager instance.
-// For multi pool pod IPAM this means referencing the .Spec.IPAM.Pools field
-// in the CiliumNode.
-type PoolsFromResourceFunc func(*CiliumNode) *ipamTypes.IPAMPoolSpec
-
 func (n NodeAddress) ToString() string {
 	return n.IP
 }


### PR DESCRIPTION
The multi-pool manager is at the core of different IPAM modes: multi-pool IPAM, ENI IPAM and the upcoming multi-pool Resource IPAM for the Cilium Network Driver. Though all these modes rely on the same logic to allocate CIDRs to nodes, each one reference specific CiliumNode fields to store the requested CIDRs and the allocated ones. Therefore, to make the multipool manager generic enough for all implementation, a PoolSpecAccessors struct with all the accessors needed to customize the manager is added.

Besides the functions to read and write the pool specs from and into the CiliumNode, a further equal function to compare the specs in two CiliumNode objects is added. This is because in ENI mode the "read" accessor may generate the pool specs on the fly, from the CiliumNode.Status. But when the CiliumNode is about to be updated by the agent, in order to compare the real content of the version stored in the k8s API server with the desired one, the accessor should consider only the actual content of Spec.IPAM.Pools, not something derived from the Status.

Fixes: 3345ce1 ("ipam: Switch ENI IPAM from CRD to multi-pool allocator")