### PR TITLE
ci: add ActionScope GitHub Actions security exposure scan

### DIFF
--- a/.github/workflows/actionscope.yml
+++ b/.github/workflows/actionscope.yml
@@ -1,0 +1,39 @@
+name: ActionScope
+on:
+  pull_request:
+    paths:
+      - ".github/actions/**"
+      - ".github/workflows/**"
+      - "**/*.tf"
+      - "**/*.tf.json"
+      - "**/*iam*.json"
+      - "**/*policy*.json"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/actions/**"
+      - ".github/workflows/**"
+      - "**/*.tf"
+      - "**/*.tf.json"
+      - "**/*iam*.json"
+      - "**/*policy*.json"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: GitHub Actions security exposure
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install ActionScope
+        run: python3 -m pip install "actionscope>=0.3.5,<1.0"
+
+      - name: Scan workflow exposure
+        run: actionscope scan . --fail-on critical --no-color


### PR DESCRIPTION
## What

Adds a lightweight ActionScope workflow to scan GitHub Actions, Terraform, and IAM/policy JSON changes for CI/CD security exposure.

The workflow is intentionally conservative:

- runs only when workflow/action/IaC/policy files change, plus manual dispatch
- uses only `contents: read`
- does not call AWS APIs or require cloud credentials
- pins `actions/checkout` to a full commit SHA
- installs `actionscope>=0.3.5,<1.0` from PyPI
- fails only on `critical` findings, so the current non-critical findings do not block CI

## Why

I ran ActionScope locally against this repository and it found workflow-level CI/CD security signal around AWS credentials, token permissions, environments, or action supply-chain posture.

```text
Overall Risk: 🟠 HIGH
Workflows scanned: 93
AWS credential sources: 22
Critical: 0 | High: 41 | Medium: 27 | Low: 455 | Info: 12
```

Because this uses `--fail-on critical`, this PR should add visibility without changing the current pass/fail posture.
