### PR TITLE
ciliumenvoyconfig: skip internal listeners when disabling SO_REUSEPORT

### DIFF
--- a/pkg/ciliumenvoyconfig/cec_resource_parser.go
+++ b/pkg/ciliumenvoyconfig/cec_resource_parser.go
@@ -69,6 +69,11 @@ type CECResourceParser struct {
 	defaultMaxRequests          uint32
 	httpLingerConfig            int
 	accessLogPath               string
+
+	// enableBPFTProxy indicates whether BPF TProxy is enabled. When set,
+	// SO_REUSEPORT is disabled on (non-internal) listeners as it is not
+	// compatible with BPF TPROXY.
+	enableBPFTProxy bool
 }
 
 type parserParams struct {
@@ -81,8 +86,9 @@ type parserParams struct {
 	DB            *statedb.DB
 	Nodes         statedb.Table[*node.LocalNode]
 
-	CecConfig   CECConfig
-	EnvoyConfig envoyCfg.ProxyConfig
+	DaemonConfig *option.DaemonConfig
+	CecConfig    CECConfig
+	EnvoyConfig  envoyCfg.ProxyConfig
 }
 
 func newCECResourceParser(params parserParams) *CECResourceParser {
@@ -93,6 +99,7 @@ func newCECResourceParser(params parserParams) *CECResourceParser {
 		defaultMaxConnections:       params.EnvoyConfig.ProxyClusterMaxConnections,
 		defaultMaxRequests:          params.EnvoyConfig.ProxyClusterMaxRequests,
 		httpLingerConfig:            params.EnvoyConfig.EnvoyHTTPUpstreamLingerTimeout,
+		enableBPFTProxy:             params.DaemonConfig.EnableBPFTProxy,
 	}
 	if params.EnvoyConfig.EnvoyAccessLogEnabled {
 		parser.accessLogPath = envoy.GetAccessLogSocketPath()
@@ -175,7 +182,7 @@ func (r *CECResourceParser) ParseResources(cecNamespace string, cecName string, 
 				return envoy.Resources{}, fmt.Errorf("unspecified Listener name")
 			}
 
-			if option.Config.EnableBPFTProxy && listener.GetInternalListener() == nil {
+			if r.enableBPFTProxy && listener.GetInternalListener() == nil {
 				// Envoy since 1.20.0 uses SO_REUSEPORT on listeners by default.
 				// BPF TPROXY is currently not compatible with SO_REUSEPORT, so
 				// disable it.  Note that this may degrade Envoy performance.

--- a/pkg/ciliumenvoyconfig/cec_resource_parser.go
+++ b/pkg/ciliumenvoyconfig/cec_resource_parser.go
@@ -175,10 +175,12 @@ func (r *CECResourceParser) ParseResources(cecNamespace string, cecName string, 
 				return envoy.Resources{}, fmt.Errorf("unspecified Listener name")
 			}
 
-			if option.Config.EnableBPFTProxy {
+			if option.Config.EnableBPFTProxy && listener.GetInternalListener() == nil {
 				// Envoy since 1.20.0 uses SO_REUSEPORT on listeners by default.
 				// BPF TPROXY is currently not compatible with SO_REUSEPORT, so
 				// disable it.  Note that this may degrade Envoy performance.
+				// Skip internal listeners as they don't bind to sockets and
+				// don't support the EnableReusePort field (validation would fail).
 				listener.EnableReusePort = &wrapperspb.BoolValue{Value: false}
 			}
 

--- a/pkg/ciliumenvoyconfig/cec_resource_parser_test.go
+++ b/pkg/ciliumenvoyconfig/cec_resource_parser_test.go
@@ -877,6 +877,102 @@ func TestCiliumEnvoyConfigMissingInternalListener(t *testing.T) {
 	assert.ErrorContains(t, err, "missing internal listener: internal-listener")
 }
 
+var ciliumEnvoyConfigReusePortInternalListener = `apiVersion: cilium.io/v2
+kind: CiliumEnvoyConfig
+metadata:
+  name: reuseport-internal-listener
+spec:
+  version_info: "0"
+  resources:
+  - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+    name: regular-listener
+    address:
+      socket_address:
+        address: 127.0.0.1
+        port_value: 10000
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.tcp_proxy
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          stat_prefix: tcp_stats
+          cluster: "cluster_0"
+  - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+    name: internal-listener
+    internal_listener: {}
+`
+
+// TestCiliumEnvoyConfigReusePortWithInternalListener verifies that, when BPF
+// TProxy is enabled, SO_REUSEPORT (enable_reuse_port) is disabled on regular
+// (socket-bound) listeners but left untouched on internal listeners. Internal
+// listeners do not bind to a socket and Envoy rejects them outright if the
+// enable_reuse_port field is set ("has unsupported tcp listener feature").
+//
+// The parser's enableBPFTProxy field is set directly on the struct so the test
+// does not have to mutate the global option.Config.EnableBPFTProxy.
+func TestCiliumEnvoyConfigReusePortWithInternalListener(t *testing.T) {
+	parseListeners := func(t *testing.T, enableBPFTProxy bool) []*envoy_config_listener.Listener {
+		t.Helper()
+
+		parser := CECResourceParser{
+			logger:          hivetest.Logger(t),
+			portAllocator:   NewMockPortAllocator(),
+			enableBPFTProxy: enableBPFTProxy,
+		}
+
+		jsonBytes, err := yaml.YAMLToJSON([]byte(ciliumEnvoyConfigReusePortInternalListener))
+		require.NoError(t, err)
+		cec := &cilium_v2.CiliumEnvoyConfig{}
+		err = json.Unmarshal(jsonBytes, cec)
+		require.NoError(t, err)
+		require.Len(t, cec.Spec.Resources, 2)
+
+		resources, err := parser.ParseResources("namespace", "name", cec.Spec.Resources, false, false, false, true)
+		require.NoError(t, err)
+		require.Len(t, resources.Listeners, 2)
+
+		return resources.Listeners
+	}
+
+	findListener := func(t *testing.T, listeners []*envoy_config_listener.Listener, name string) *envoy_config_listener.Listener {
+		t.Helper()
+		for _, l := range listeners {
+			if l.Name == name {
+				return l
+			}
+		}
+		t.Fatalf("listener %q not found", name)
+		return nil
+	}
+
+	t.Run("BPF TProxy enabled", func(t *testing.T) {
+		listeners := parseListeners(t, true)
+
+		// Regular (socket-bound) listener must have SO_REUSEPORT disabled.
+		regular := findListener(t, listeners, "namespace/name/regular-listener")
+		assert.Nil(t, regular.GetInternalListener())
+		require.NotNil(t, regular.GetEnableReusePort())
+		assert.False(t, regular.GetEnableReusePort().GetValue())
+
+		// Internal listener must NOT have the EnableReusePort field set, otherwise
+		// Envoy rejects it with "has unsupported tcp listener feature".
+		internal := findListener(t, listeners, "namespace/name/internal-listener")
+		assert.NotNil(t, internal.GetInternalListener())
+		assert.Nil(t, internal.GetEnableReusePort())
+	})
+
+	t.Run("BPF TProxy disabled", func(t *testing.T) {
+		listeners := parseListeners(t, false)
+
+		// Without BPF TProxy, EnableReusePort is left untouched on all listeners.
+		regular := findListener(t, listeners, "namespace/name/regular-listener")
+		assert.Nil(t, regular.GetEnableReusePort())
+
+		internal := findListener(t, listeners, "namespace/name/internal-listener")
+		assert.Nil(t, internal.GetEnableReusePort())
+	})
+}
+
 func TestCiliumEnvoyConfigTCPProxy(t *testing.T) {
 	parser := CECResourceParser{
 		logger:        hivetest.Logger(t),


### PR DESCRIPTION
Fixes: #46275 

This PR was prepared with AI:3. I personally reviewed the fix and test.

## TL;DR

When `EnableBPFTProxy=true`, [`CECResourceParser.ParseResources`](pkg/ciliumenvoyconfig/cec_resource_parser.go:148-573) **unconditionally** sets `enable_reuse_port = false` on every listener. However, Envoy **internal listeners** do not bind to a real socket and **must not have any socket-related fields set** (including `enable_reuse_port`). When such a field is present, Envoy rejects the listener at validation time, which causes the entire `CiliumEnvoyConfig` (CEC) / `CiliumClusterwideEnvoyConfig` (CCEC) push to fail.

This PR adds a `listener.GetInternalListener() == nil` check so that internal listeners are skipped.

---

## Background

### 1. Current logic on the Cilium side

`pkg/ciliumenvoyconfig/cec_resource_parser.go` iterates over every listener in a CEC/CCEC resource and does the following first:

```go
// pkg/ciliumenvoyconfig/cec_resource_parser.go (before this fix)
if option.Config.EnableBPFTProxy {
    // Envoy since 1.20.0 uses SO_REUSEPORT on listeners by default.
    // BPF TPROXY is currently not compatible with SO_REUSEPORT, so
    // disable it.  Note that this may degrade Envoy performance.
    listener.EnableReusePort = &wrapperspb.BoolValue{Value: false}
}
```

The intent: under BPF TPROXY, a given 5-tuple packet must land on a single, well-known socket queue, whereas `SO_REUSEPORT` distributes connections across multiple worker sockets via a kernel hash, which breaks BPF TPROXY's packet path. Therefore `enable_reuse_port` must be forcibly disabled on every listener.

### 2. What is an Envoy internal listener?

Envoy 1.20+ introduced [internal listeners](https://www.envoyproxy.io/docs/envoy/latest/configuration/other_features/internal_listener), which forward connections between listeners inside the Envoy process and never bind to a NIC/port. In the proto definition, it is part of the `oneof listener_specifier`:

```go
// vendor/github.com/envoyproxy/go-control-plane/envoy/config/listener/v3/listener.pb.go
type Listener struct {
    ...
    // The exclusive listener type and the corresponding config.
    //
    // Types that are valid to be assigned to ListenerSpecifier:
    //
    //  *Listener_InternalListener
    ListenerSpecifier isListener_ListenerSpecifier `protobuf_oneof:"listener_specifier"`
    ...
}

func (x *Listener) GetInternalListener() *Listener_InternalListenerConfig {
    if x != nil {
        if x, ok := x.ListenerSpecifier.(*Listener_InternalListener); ok {
            return x.InternalListener
        }
    }
    return nil
}
```

Cilium already uses `GetInternalListener() != nil` in several places to recognize internal listeners. For example, [`ParseResources`](pkg/ciliumenvoyconfig/cec_resource_parser.go:452-505) skips internal listeners when allocating TPROXY ports and when injecting the `cilium.bpf_metadata` listener filter:

```go
for _, listener := range resources.Listeners {
    // Figure out if this is an internal listener
    isInternalListener := listener.GetInternalListener() != nil

    if !isInternalListener {
        // allocate TPROXY port, inject cilium.bpf_metadata, ...
        ...
    }
    ...
}
```

### 3. The hard constraint enforced by upstream Envoy

When Envoy creates a listener, it runs `ListenerImpl::buildInternalListener`. If `internal_listener` is set together with **any** socket-related field (including `enable_reuse_port`, `freebind`, `transparent`, `tcp_backlog_size`, `tcp_fast_open_queue_length`, `enable_mptcp`, `socket_options`, ...), the listener is rejected outright.

Source: [envoyproxy/envoy `source/common/listener_manager/listener_impl.cc`](https://github.com/envoyproxy/envoy/blob/main/source/common/listener_manager/listener_impl.cc) -> `ListenerImpl::buildInternalListener`:

```cpp
absl::Status ListenerImpl::buildInternalListener(
    const envoy::config::listener::v3::Listener& config) {
  if (config.has_internal_listener()) {
    if (config.has_address() || !config.additional_addresses().empty()) {
      return absl::InvalidArgumentError(
          fmt::format("error adding listener '{}': address should not be used "
                      "when an internal listener config is provided",
                      name_));
    }
    if ((config.has_connection_balance_config() &&
         config.connection_balance_config().has_exact_balance()) ||
        config.enable_mptcp() ||
        config.has_enable_reuse_port()   // <-- internal listener doesn't use physical l4 port.
        || (config.has_freebind() && config.freebind().value())
        || config.has_tcp_backlog_size()
        || config.has_tcp_fast_open_queue_length()
        || (config.has_transparent() && config.transparent().value())) {
      return absl::InvalidArgumentError(fmt::format(
          "error adding listener named '{}': has unsupported tcp listener feature", name_));
    }
    if (!config.socket_options().empty()) {
      return absl::InvalidArgumentError(
          fmt::format("error adding listener named '{}': does not support socket option", name_));
    }
    ...
  }
  ...
}
```

Note the inline comment in the upstream source: `// internal listener doesn't use physical l4 port.` This is exactly why Envoy explicitly rejects the field — an internal listener has no L4 port, so socket options such as `SO_REUSEPORT` are meaningless.

### 4. Trigger condition

`bpf.tproxy` is **disabled by default** in Cilium (it is a beta feature; see [`pkg/defaults/defaults.go`](pkg/defaults/defaults.go:247-248) `EnableBPFTProxy = false`, [`install/kubernetes/cilium/templates/cilium-configmap.yaml`](install/kubernetes/cilium/templates/cilium-configmap.yaml:6) `$defaultBpfTProxy := "false"`, and the Helm chart [README](install/kubernetes/cilium/README.md:175) entry `bpf.tproxy | bool | false`). The bug therefore only affects clusters where the user has **explicitly opted in** to BPF TPROXY.

The bug reproduces 100% of the time whenever both of the following are true:

1. The user has explicitly enabled BPF TPROXY (`--enable-bpf-tproxy=true`, equivalently Helm `--set bpf.tproxy=true`).
2. The user-supplied CEC/CCEC contains an internal listener (common in Gateway API / Ingress, where Envoy chains listeners internally; or in multi-stage L7 LB matching).

The resulting error looks like:

```
error adding listener named '<ns>/<cec-name>/<listener-name>': has unsupported tcp listener feature
```

which causes the whole CEC/CCEC push to fail and the associated proxy path to become unusable.

