### PR TITLE
docs: clarify IPv6 cluster-pool CIDR mask limits

### DIFF
--- a/Documentation/network/kubernetes/ipam-cluster-pool.rst
+++ b/Documentation/network/kubernetes/ipam-cluster-pool.rst
@@ -34,6 +34,18 @@ Enable Cluster-pool IPAM mode
    * ``--set ipam.operator.clusterPoolIPv4MaskSize=<IPv4MaskSize>``
    * ``--set ipam.operator.clusterPoolIPv6MaskSize=<IPv6MaskSize>``
 
+   .. note::
+
+      For IPv6 cluster-pool IPAM, the difference between the cluster CIDR
+      prefix length and the per-node mask size must not be greater than 16.
+      For example, the default ``fd00::/104`` pool with
+      ``ipam.operator.clusterPoolIPv6MaskSize=120`` is valid because the
+      difference is 16. If you use a larger IPv6 pool such as ``/64``, set
+      ``ipam.operator.clusterPoolIPv6MaskSize`` to ``80`` or another value that
+      keeps the difference at 16 or less. Otherwise, the operator fails to
+      initialize the IPv6 allocator with
+      ``New CIDR set failed; the node CIDR size is too big``.
+
 #. Deploy Cilium and Cilium-Operator. Cilium will automatically wait until the
    ``podCIDR`` is allocated for its node by Cilium Operator.
 


### PR DESCRIPTION
## Summary
- Add a Cluster-pool IPAM documentation note for the IPv6 allocator limit behind `New CIDR set failed; the node CIDR size is too big`.
- Document that the IPv6 cluster CIDR prefix length and per-node mask size difference must be <=16.
- Include examples for `fd00::/104` with `clusterPoolIPv6MaskSize=120`, and `/64` with `clusterPoolIPv6MaskSize=80`.

## Validation
- Netlify docs preview succeeded.
- GitHub image/build checks succeeded.

Fixes #20756

```release-note
Document the IPv6 cluster-pool CIDR and per-node mask size relationship for Cluster-pool IPAM.
```

## AI disclosure
AI assistance was used to prepare this PR (AIL:3). I reviewed the issue context and documentation diff.
