### PR TITLE
kvstore: add transcode support to commands

### DIFF
--- a/pkg/clustermesh/types/endpointslice/endpointslice.go
+++ b/pkg/clustermesh/types/endpointslice/endpointslice.go
@@ -26,6 +26,14 @@ import (
 // break backwards compatibility
 var EndpointSliceStorePrefix = path.Join(kvstore.BaseKeyPrefix, "state", "endpointslices", "v1")
 
+func init() {
+	kvstore.RegisterCommandTranscoder(
+		func() kvstore.TranscodableJSON { return &ClusterEndpointSlice{} },
+		EndpointSliceStorePrefix,
+		kvstore.StateToCachePrefix(EndpointSliceStorePrefix),
+	)
+}
+
 // ClusterEndpointSlice is the definition of an EndpointSlice in a cluster.
 //
 // WARNING - STABLE API: Any change to this structure must be done in a

--- a/pkg/kvstore/commands.go
+++ b/pkg/kvstore/commands.go
@@ -132,8 +132,6 @@ func (c cmds) list() script.Cmd {
 							return "", "", fmt.Errorf("unexpected output format %q", outfmt)
 						}
 					}
-
-					fmt.Fprint(&b)
 				}
 				if len(args) == 2 {
 					err = os.WriteFile(s.Path(args[1]), b.Bytes(), 0644)

--- a/pkg/kvstore/commands.go
+++ b/pkg/kvstore/commands.go
@@ -42,12 +42,22 @@ func (c cmds) update() script.Cmd {
 			if len(args) != 2 {
 				return nil, fmt.Errorf("%w: expected key and value file", script.ErrUsage)
 			}
-			b, err := os.ReadFile(s.Path(args[1]))
+			key := args[0]
+			value, err := os.ReadFile(s.Path(args[1]))
 			if err != nil {
 				return nil, fmt.Errorf("could not read %q: %w", s.Path(args[1]), err)
 			}
 
-			return nil, c.client.Update(s.Context(), args[0], b, false)
+			// As this is a dev/test only command, we can be a bit more
+			// aggressive with trimming whitespace to simplify our test scripts.
+			value = bytes.TrimSpace(value)
+
+			value, err = tryTranscodeFromJSON(key, value)
+			if err != nil {
+				return nil, fmt.Errorf("could not transcode %q value: %w", key, err)
+			}
+
+			return nil, c.client.Update(s.Context(), key, value, false)
 		},
 	)
 }
@@ -103,12 +113,18 @@ func (c cmds) list() script.Cmd {
 					}
 
 					if !keysOnly {
+						v := kvs[k].Data
+						v, err = tryTranscodeToJSON(k, v)
+						if err != nil {
+							return "", "", fmt.Errorf("could not transcode %q value: %w", k, err)
+						}
+
 						outfmt, _ := s.Flags.GetString("output")
 						switch outfmt {
 						case "plain":
-							fmt.Fprintln(&b, string(kvs[k].Data))
+							fmt.Fprintln(&b, string(v))
 						case "json":
-							if err := json.Indent(&b, kvs[k].Data, "", "  "); err != nil {
+							if err := json.Indent(&b, v, "", "  "); err != nil {
 								fmt.Fprintf(&b, "ERROR: %s", err)
 							}
 							fmt.Fprintln(&b)

--- a/pkg/kvstore/commands_transcode.go
+++ b/pkg/kvstore/commands_transcode.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package kvstore
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+type TranscodableJSON interface {
+	Marshal() ([]byte, error)
+	Unmarshal(key string, data []byte) error
+
+	json.Marshaler
+	json.Unmarshaler
+}
+
+type TranscodableCreator func() TranscodableJSON
+
+type transcoder struct {
+	prefix  string
+	creator TranscodableCreator
+}
+
+func (t transcoder) transcodeToJSON(key string, value []byte) ([]byte, error) {
+	val := t.creator()
+	if err := val.Unmarshal(strings.TrimPrefix(key, t.prefix), value); err != nil {
+		return nil, err
+	}
+	return val.MarshalJSON()
+}
+
+func (t transcoder) transcodeFromJSON(value []byte) ([]byte, error) {
+	val := t.creator()
+	if err := val.UnmarshalJSON(value); err != nil {
+		return nil, err
+	}
+	return val.Marshal()
+}
+
+var transcoders []transcoder
+
+func RegisterCommandTranscoder(creator TranscodableCreator, prefixes ...string) {
+	for _, prefix := range prefixes {
+		transcoders = append(
+			transcoders,
+			transcoder{
+				creator: creator,
+				prefix:  strings.TrimRight(prefix, "/") + "/",
+			},
+		)
+	}
+}
+
+func tryTranscodeToJSON(key string, value []byte) ([]byte, error) {
+	for _, transcoder := range transcoders {
+		if !strings.HasPrefix(key, transcoder.prefix) {
+			continue
+		}
+		return transcoder.transcodeToJSON(key, value)
+	}
+
+	return value, nil
+}
+
+func tryTranscodeFromJSON(key string, value []byte) ([]byte, error) {
+	for _, transcoder := range transcoders {
+		if !strings.HasPrefix(key, transcoder.prefix) {
+			continue
+		}
+		return transcoder.transcodeFromJSON(value)
+	}
+
+	return value, nil
+}

--- a/pkg/kvstore/script_test.go
+++ b/pkg/kvstore/script_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// We use a different package to avoid import cycle over the endpointslice
+// package imported here to test transcoding
+package kvstore_test
+
+import (
+	"context"
+	"maps"
+	"testing"
+
+	"github.com/cilium/hive/script"
+	"github.com/cilium/hive/script/scripttest"
+	"github.com/cilium/statedb"
+
+	_ "github.com/cilium/cilium/pkg/clustermesh/types/endpointslice"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+func TestScript(t *testing.T) {
+	setup := func(t testing.TB, args []string) *script.Engine {
+		client := kvstore.NewInMemoryClient(statedb.New(), "__local__")
+		cmds := kvstore.Commands(client)
+		maps.Insert(cmds, maps.All(script.DefaultCmds()))
+
+		return &script.Engine{Cmds: cmds}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	scripttest.Test(t,
+		ctx,
+		setup,
+		[]string{},
+		"testdata/*.txtar")
+}

--- a/pkg/kvstore/testdata/endpointslice-transcode.txtar
+++ b/pkg/kvstore/testdata/endpointslice-transcode.txtar
@@ -1,0 +1,40 @@
+kvstore/update cilium/state/endpointslices/v1/cluster-a/default/backend endpointslice.json
+
+# Test JSON transcoding with explicit json output and auto
+kvstore/list -o json --values-only cilium/state/endpointslices/v1 endpointslice-json.actual
+cmp endpointslice-json.actual endpointslice.json
+
+# If transcoding wasn't applied the output should be pretty-printed, let's test
+# that it's not the case
+kvstore/list --values-only cilium/state/endpointslices/v1 endpointslice-plain.actual
+cmp endpointslice-plain.actual endpointslice-plain.expected
+
+-- endpointslice.json --
+{
+  "cluster": "cluster-a",
+  "clusterID": 1,
+  "namespace": "default",
+  "name": "backend",
+  "addressType": "IPv4",
+  "endpoints": [
+    {
+      "addresses": [
+        "10.0.0.1"
+      ],
+      "conditions": {
+        "ready": true,
+        "serving": true,
+        "terminating": false
+      }
+    }
+  ],
+  "ports": [
+    {
+      "name": "http",
+      "protocol": "TCP",
+      "port": 80
+    }
+  ]
+}
+-- endpointslice-plain.expected --
+{"cluster":"cluster-a","clusterID":1,"namespace":"default","name":"backend","addressType":"IPv4","endpoints":[{"addresses":["10.0.0.1"],"conditions":{"ready":true,"serving":true,"terminating":false}}],"ports":[{"name":"http","protocol":"TCP","port":80}]}


### PR DESCRIPTION
Add transcode support for the new ClusterEndpointSlice type. Related to https://github.com/cilium/cilium/issues/41953 / https://github.com/cilium/design-cfps/blob/main/cilium/CFP-41953-clustermesh-service-v2.md.

Used AIL-3 at the begining but ended up rewriting most of the command/core logic myself