### PR TITLE
endpoint: gracefully degrade policy map overflow

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -5,12 +5,15 @@ package endpoint
 
 import (
 	"bufio"
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 
@@ -27,6 +30,10 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	endpointtypes "github.com/cilium/cilium/pkg/endpoint/types"
+	"github.com/cilium/cilium/pkg/identity"
+	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	k8sCiliumUtils "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/loadinfo"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
@@ -35,6 +42,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	policyapi "github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	policytypes "github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/revert"
 	"github.com/cilium/cilium/pkg/time"
@@ -959,6 +967,122 @@ func (e *Endpoint) updatePolicyMapPressureMetric(len int) {
 	})
 }
 
+// prioritizedPolicyMapEntry keeps a desired policy entry with its precomputed
+// overflow ranking fields.
+type prioritizedPolicyMapEntry struct {
+	key     policy.Key
+	entry   policy.MapStateEntry
+	traffic bool
+	tcpUDP  bool
+	current bool
+	ccnp    bool
+}
+
+func policyKeyFromPolicyMapKey(key policymap.PolicyKey) policy.Key {
+	return policy.KeyForDirection(trafficdirection.TrafficDirection(key.TrafficDirection)).
+		WithIdentity(identity.NumericIdentity(key.Identity)).
+		WithPortProtoPrefix(u8proto.U8proto(key.Nexthdr), key.GetDestPort(), key.GetPortPrefixLen())
+}
+
+func policyEntryFromPolicyMapEntry(key policymap.PolicyKey, entry policymap.PolicyEntry) policy.MapStateEntry {
+	policyEntry := policy.MapStateEntry{
+		Precedence:      entry.Precedence,
+		ProxyPort:       entry.GetProxyPort(),
+		AuthRequirement: entry.AuthRequirement,
+		Cookie:          entry.Cookie,
+	}.WithDeny(entry.IsDeny())
+	if !entry.IsValid(&key) {
+		policyEntry.Invalidate()
+	}
+	return policyEntry
+}
+
+func policyMapEntryHasTraffic(entry policymap.PolicyEntryDump) bool {
+	return (entry.Packets != policymap.StatNotAvailable && entry.Packets > 0) ||
+		(entry.Bytes != policymap.StatNotAvailable && entry.Bytes > 0)
+}
+
+func currentPolicyMapState(entries policymap.PolicyEntriesDump) (policy.MapStateMap, map[policy.Key]bool) {
+	current := make(policy.MapStateMap, len(entries))
+	traffic := make(map[policy.Key]bool, len(entries))
+	for _, entry := range entries {
+		key := policyKeyFromPolicyMapKey(entry.Key)
+		current[key] = policyEntryFromPolicyMapEntry(entry.Key, entry.PolicyEntry)
+		traffic[key] = policyMapEntryHasTraffic(entry)
+	}
+	return current, traffic
+}
+
+func endpointPolicyMapEntries(p *policy.EndpointPolicy) policy.MapStateMap {
+	entries := make(policy.MapStateMap, p.Len())
+	maps.Insert(entries, p.Entries())
+	return entries
+}
+
+func isCCNPDerived(lblsList labels.LabelArrayList) bool {
+	for _, lbls := range lblsList {
+		for _, lbl := range lbls {
+			if lbl.Key == k8sconst.PolicyLabelDerivedFrom &&
+				lbl.Value == k8sCiliumUtils.ResourceTypeCiliumClusterwideNetworkPolicy {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func policyKeyCompare(a, b policy.Key) int {
+	return cmp.Or(
+		cmp.Compare(a.TrafficDirection(), b.TrafficDirection()),
+		cmp.Compare(a.Identity, b.Identity),
+		cmp.Compare(a.Nexthdr, b.Nexthdr),
+		cmp.Compare(a.DestPort, b.DestPort),
+		cmp.Compare(a.PortPrefixLen(), b.PortPrefixLen()),
+	)
+}
+
+// prioritizedPolicyMapEntries returns desired entries sorted by overflow
+// priority: traffic, TCP/UDP, current BPF map presence, CCNP origin, then key.
+func prioritizedPolicyMapEntries(
+	desired policy.MapStateMap,
+	current policy.MapStateMap,
+	traffic map[policy.Key]bool,
+	ruleLabels func(policy.Key) (labels.LabelArrayList, bool),
+) []prioritizedPolicyMapEntry {
+	entries := make([]prioritizedPolicyMapEntry, 0, len(desired))
+	for key, entry := range desired {
+		lbls, hasLabels := ruleLabels(key)
+		_, isCurrent := current[key]
+		entries = append(entries, prioritizedPolicyMapEntry{
+			key:     key,
+			entry:   entry,
+			traffic: traffic[key],
+			tcpUDP:  key.Nexthdr == u8proto.TCP || key.Nexthdr == u8proto.UDP,
+			current: isCurrent,
+			ccnp:    hasLabels && isCCNPDerived(lbls),
+		})
+	}
+	slices.SortFunc(entries, func(a, b prioritizedPolicyMapEntry) int {
+		cmpBool := func(a, b bool) int {
+			if a == b {
+				return 0
+			}
+			if a {
+				return -1
+			}
+			return 1
+		}
+		return cmp.Or(
+			cmpBool(a.traffic, b.traffic),
+			cmpBool(a.tcpUDP, b.tcpUDP),
+			cmpBool(a.current, b.current),
+			cmpBool(a.ccnp, b.ccnp),
+			policyKeyCompare(a.key, b.key),
+		)
+	})
+	return entries
+}
+
 func (e *Endpoint) deletePolicyKeys(deletes, adds policy.Keys) int {
 	var errors int
 	for k := range deletes {
@@ -1042,6 +1166,125 @@ func (e *Endpoint) addPolicyKey(keyToAdd policy.Key, entry policy.MapStateEntry)
 		logfields.BPFMapValue, entry,
 	)
 	return true
+}
+
+func (e *Endpoint) addPolicyMapEntries(entries []prioritizedPolicyMapEntry, current policy.MapStateMap, diffs *[]policy.MapChange) int {
+	errors := 0
+	for _, entry := range entries {
+		if currentEntry, ok := current[entry.key]; ok && currentEntry == entry.entry {
+			continue
+		}
+		if !e.addPolicyKey(entry.key, entry.entry) {
+			errors++
+			continue
+		}
+		if diffs != nil {
+			*diffs = append(*diffs, policy.MapChange{
+				Add:   true,
+				Key:   entry.key,
+				Value: entry.entry,
+			})
+		}
+	}
+	return errors
+}
+
+func (e *Endpoint) deletePolicyMapEntries(desired, current policy.MapStateMap, diffs *[]policy.MapChange) int {
+	errors := 0
+	for key, entry := range current {
+		if _, ok := desired[key]; ok {
+			continue
+		}
+		if !e.deletePolicyKey(key) {
+			errors++
+			continue
+		}
+		if diffs != nil {
+			*diffs = append(*diffs, policy.MapChange{
+				Key:   key,
+				Value: entry,
+			})
+		}
+	}
+	return errors
+}
+
+// syncPolicyMapEntries writes an already-prioritized desired set to the BPF map.
+func (e *Endpoint) syncPolicyMapEntries(
+	prioritized []prioritizedPolicyMapEntry,
+	current policy.MapStateMap,
+	withDiffs bool,
+) (diffCount int, diffs []policy.MapChange, err error) {
+	var collectedDiffs *[]policy.MapChange
+	if withDiffs {
+		collectedDiffs = &diffs
+	}
+
+	desired := make(policy.MapStateMap, len(prioritized))
+	adds := 0
+	for _, entry := range prioritized {
+		desired[entry.key] = entry.entry
+		if _, ok := current[entry.key]; !ok {
+			adds++
+		}
+	}
+	addErrors, deleteErrors := 0, 0
+	deleteFirst := len(current)+adds > int(e.policyMap.MaxEntries())
+	if deleteFirst {
+		deleteErrors = e.deletePolicyMapEntries(desired, current, collectedDiffs)
+		addErrors = e.addPolicyMapEntries(prioritized, current, collectedDiffs)
+	} else {
+		addErrors = e.addPolicyMapEntries(prioritized, current, collectedDiffs)
+		deleteErrors = e.deletePolicyMapEntries(desired, current, collectedDiffs)
+	}
+	if addErrors > 0 || deleteErrors > 0 {
+		return 0, diffs, fmt.Errorf("syncPolicyMapEntries failed")
+	}
+	if withDiffs {
+		diffCount = len(diffs)
+	}
+	return diffCount, diffs, nil
+}
+
+func (e *Endpoint) syncPolicyMapWithOverflow(withDiffs bool) (diffCount int, diffs []policy.MapChange, err error) {
+	dump, err := e.policyMap.DumpToSlice()
+	if err != nil {
+		return 0, nil, fmt.Errorf("dump PolicyMap for overflow prioritization: %w", err)
+	}
+	current, traffic := currentPolicyMapState(dump)
+	return e.syncPolicyMapWithOverflowState(current, traffic, withDiffs)
+}
+
+func (e *Endpoint) syncPolicyMapWithOverflowState(
+	current policy.MapStateMap,
+	traffic map[policy.Key]bool,
+	withDiffs bool,
+) (diffCount int, diffs []policy.MapChange, err error) {
+	maxEntries := int(e.policyMap.MaxEntries())
+	desired := endpointPolicyMapEntries(e.desiredPolicy)
+	prioritized := prioritizedPolicyMapEntries(desired, current, traffic, func(key policy.Key) (labels.LabelArrayList, bool) {
+		meta, err := e.desiredPolicy.GetRuleMeta(key)
+		return meta.LabelArray(), err == nil
+	})
+	omitted := 0
+	if len(prioritized) > maxEntries {
+		omitted = len(prioritized) - maxEntries
+		prioritized = prioritized[:maxEntries]
+	}
+	if omitted > 0 && omitted != e.lastPolicyMapOmittedEntries {
+		e.getLogger().Warn(
+			"Policy map exceeds max entries, applying prioritized subset",
+			logfields.Entries, len(desired),
+			logfields.Maximum, maxEntries,
+			logfields.OmittedEntries, omitted,
+		)
+	}
+
+	diffCount, diffs, err = e.syncPolicyMapEntries(prioritized, current, withDiffs)
+	if err == nil {
+		e.lastPolicyMapOmittedEntries = omitted
+	}
+	return diffCount, diffs, err
 }
 
 // ApplyPolicyMapChanges updates the Endpoint's PolicyMap with the changes
@@ -1189,6 +1432,11 @@ func (e *Endpoint) applyPolicyMapChangesLocked(regenContext *regenerationContext
 	if e.policyMap == nil {
 		e.getLogger().Debug("Skipping bpf updates due to endpoint not having policy map yet")
 		return nil
+	}
+
+	if e.desiredPolicy.Len() > int(e.policyMap.MaxEntries()) {
+		_, _, err := e.syncPolicyMapWithOverflow(false)
+		return err
 	}
 
 	// Add policy map entries before deleting to avoid transient drops. If there
@@ -1350,6 +1598,11 @@ func (e *Endpoint) syncPolicyMap() error {
 		return ErrComingOutOfLockdown
 	}
 
+	if e.desiredPolicy.Len() > int(e.policyMap.MaxEntries()) {
+		_, _, err := e.syncPolicyMapWithOverflow(false)
+		return err
+	}
+
 	// Add policy map entries before deleting to avoid transient drops
 	for k, v := range e.desiredPolicy.Updated(e.realizedPolicy) {
 		if !e.addPolicyKey(k, v) {
@@ -1396,6 +1649,11 @@ func (e *Endpoint) syncPolicyMapWith(realized policy.MapStateMap, withDiffs bool
 	}
 	if e.stopLockdownLocked() {
 		err = ErrComingOutOfLockdown
+		return
+	}
+
+	if e.desiredPolicy.Len() > int(e.policyMap.MaxEntries()) {
+		diffCount, diffs, err = e.syncPolicyMapWithOverflow(withDiffs)
 		return
 	}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -258,6 +258,10 @@ type Endpoint struct {
 	// reference to all policy related BPF
 	policyMap policymap.PolicyMap
 
+	// lastPolicyMapOmittedEntries tracks the number of entries omitted
+	// in the last policy map sync due to overflow.
+	lastPolicyMapOmittedEntries int
+
 	// PolicyMapPressureUpdater updates the policymap pressure metric.
 	PolicyMapPressureUpdater policyMapPressureUpdater
 

--- a/pkg/endpoint/policy_map_overflow_test.go
+++ b/pkg/endpoint/policy_map_overflow_test.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package endpoint
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+	"k8s.io/apimachinery/pkg/types"
+
+	k8sCiliumUtils "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/maps/policymap"
+	"github.com/cilium/cilium/pkg/policy"
+	policytypes "github.com/cilium/cilium/pkg/policy/types"
+	testpolicy "github.com/cilium/cilium/pkg/testutils/policy"
+)
+
+type overflowTestPolicyMap struct {
+	entries    map[policymap.PolicyKey]policymap.PolicyEntry
+	stats      map[policymap.PolicyKey]policymap.StatsValue
+	maxEntries uint32
+}
+
+type overflowPolicyMapPressureUpdater struct{}
+
+func (overflowPolicyMapPressureUpdater) Update(PolicyMapPressureEvent) {}
+func (overflowPolicyMapPressureUpdater) Remove(uint16)                 {}
+
+func newOverflowTestPolicyMap(maxEntries uint32) *overflowTestPolicyMap {
+	return &overflowTestPolicyMap{
+		entries:    map[policymap.PolicyKey]policymap.PolicyEntry{},
+		stats:      map[policymap.PolicyKey]policymap.StatsValue{},
+		maxEntries: maxEntries,
+	}
+}
+
+func (pm *overflowTestPolicyMap) Update(key *policymap.PolicyKey, entry *policymap.PolicyEntry) error {
+	if _, exists := pm.entries[*key]; !exists && len(pm.entries) >= int(pm.maxEntries) {
+		return unix.ENOSPC
+	}
+	pm.entries[*key] = *entry
+	return nil
+}
+
+func (pm *overflowTestPolicyMap) DeleteKey(key policymap.PolicyKey) error {
+	delete(pm.entries, key)
+	delete(pm.stats, key)
+	return nil
+}
+
+func (pm *overflowTestPolicyMap) DeleteEntry(entry *policymap.PolicyEntryDump) error {
+	return pm.DeleteKey(entry.Key)
+}
+
+func (pm *overflowTestPolicyMap) String() string {
+	return "overflow-test-policy-map"
+}
+
+func (pm *overflowTestPolicyMap) Dump() (string, error) {
+	return "", nil
+}
+
+func (pm *overflowTestPolicyMap) DumpToSlice() (policymap.PolicyEntriesDump, error) {
+	entries := make(policymap.PolicyEntriesDump, 0, len(pm.entries))
+	for key, value := range pm.entries {
+		entries = append(entries, policymap.PolicyEntryDump{
+			Key:         key,
+			PolicyEntry: value,
+			StatsValue:  pm.stats[key],
+		})
+	}
+	return entries, nil
+}
+
+func (pm *overflowTestPolicyMap) DumpToMapStateMap() (policytypes.MapStateMap, error) {
+	dump, err := pm.DumpToSlice()
+	if err != nil {
+		return nil, err
+	}
+	current, _ := currentPolicyMapState(dump)
+	return current, nil
+}
+
+func (pm *overflowTestPolicyMap) MaxEntries() uint32 { return pm.maxEntries }
+func (pm *overflowTestPolicyMap) Close() error       { return nil }
+
+var _ policymap.PolicyMap = (*overflowTestPolicyMap)(nil)
+
+func testEndpointPolicy(t *testing.T, logger *slog.Logger, entries policy.MapStateMap) *policy.EndpointPolicy {
+	t.Helper()
+	repo := policy.NewPolicyRepository(logger, nil, nil, nil, nil, testpolicy.NewPolicyMetricsNoop())
+	epPolicy := policy.NewEndpointPolicy(logger, repo)
+	epPolicy.CopyMapStateFrom(entries)
+	return epPolicy
+}
+
+func TestPolicyMapOverflowSyncUsesHeuristics(t *testing.T) {
+	logger := hivetest.Logger(t)
+	testMap := newOverflowTestPolicyMap(3)
+
+	trafficKey := policy.IngressKey().WithIdentity(1001).WithTCPPort(80)
+	sctpCurrentKey := policy.IngressKey().WithIdentity(1002).WithSCTPPort(80)
+	udpCurrentKey := policy.IngressKey().WithIdentity(1003).WithUDPPort(80)
+	tcpNewKey := policy.IngressKey().WithIdentity(1004).WithTCPPort(80)
+	sctpNewKey := policy.IngressKey().WithIdentity(1005).WithSCTPPort(80)
+
+	allowEntry := policytypes.AllowEntry()
+	for _, key := range []policy.Key{trafficKey, sctpCurrentKey, udpCurrentKey} {
+		pmKey := policymap.NewKeyFromPolicyKey(key)
+		pmEntry := policymap.NewEntryFromPolicyEntry(pmKey, allowEntry)
+		require.NoError(t, testMap.Update(&pmKey, &pmEntry))
+	}
+	testMap.stats[policymap.NewKeyFromPolicyKey(trafficKey)] = policymap.StatsValue{Packets: 1}
+
+	desired := policy.MapStateMap{
+		trafficKey:     allowEntry,
+		sctpCurrentKey: allowEntry,
+		udpCurrentKey:  allowEntry,
+		tcpNewKey:      allowEntry,
+		sctpNewKey:     allowEntry,
+	}
+
+	ep := &Endpoint{
+		ID:                       123,
+		policyMap:                testMap,
+		desiredPolicy:            testEndpointPolicy(t, logger, desired),
+		realizedPolicy:           testEndpointPolicy(t, logger, nil),
+		PolicyMapPressureUpdater: overflowPolicyMapPressureUpdater{},
+	}
+	ep.UpdateLogger(nil)
+
+	err := ep.syncPolicyMap()
+	require.NoError(t, err)
+
+	got, err := testMap.DumpToMapStateMap()
+	require.NoError(t, err)
+	require.Contains(t, got, trafficKey, "entry with traffic should be retained first")
+	require.Contains(t, got, udpCurrentKey, "TCP/UDP and existing entry should be retained")
+	require.Contains(t, got, tcpNewKey, "TCP should be preferred over SCTP when space remains")
+	require.NotContains(t, got, sctpCurrentKey, "SCTP should lose to TCP/UDP entries")
+	require.NotContains(t, got, sctpNewKey, "SCTP without traffic or existing state should be omitted")
+	require.Len(t, got, int(testMap.MaxEntries()))
+}
+
+func TestPolicyMapOverflowIgnoresUnavailableTrafficStats(t *testing.T) {
+	key := policy.IngressKey().WithIdentity(1001).WithTCPPort(80)
+	allowEntry := policytypes.AllowEntry()
+	pmKey := policymap.NewKeyFromPolicyKey(key)
+	pmEntry := policymap.NewEntryFromPolicyEntry(pmKey, allowEntry)
+
+	_, traffic := currentPolicyMapState(policymap.PolicyEntriesDump{
+		{
+			Key:         pmKey,
+			PolicyEntry: pmEntry,
+			StatsValue: policymap.StatsValue{
+				Packets: policymap.StatNotAvailable,
+				Bytes:   policymap.StatNotAvailable,
+			},
+		},
+	})
+	require.False(t, traffic[key])
+}
+
+func TestPolicyMapOverflowPrioritizesCCNPOverCNP(t *testing.T) {
+	cnpKey := policy.IngressKey().WithIdentity(2001).WithTCPPort(80)
+	ccnpKey := policy.IngressKey().WithIdentity(2002).WithTCPPort(80)
+	allowEntry := policytypes.AllowEntry()
+	desired := policy.MapStateMap{
+		cnpKey:  allowEntry,
+		ccnpKey: allowEntry,
+	}
+
+	cnpLabels := labels.LabelArrayList{
+		k8sCiliumUtils.GetPolicyLabels("default", "cnp", types.UID("cnp"), k8sCiliumUtils.ResourceTypeCiliumNetworkPolicy),
+	}
+	ccnpLabels := labels.LabelArrayList{
+		k8sCiliumUtils.GetPolicyLabels("", "ccnp", types.UID("ccnp"), k8sCiliumUtils.ResourceTypeCiliumClusterwideNetworkPolicy),
+	}
+
+	prioritized := prioritizedPolicyMapEntries(desired, nil, nil, func(key policy.Key) (labels.LabelArrayList, bool) {
+		switch key {
+		case cnpKey:
+			return cnpLabels, true
+		case ccnpKey:
+			return ccnpLabels, true
+		default:
+			return nil, false
+		}
+	})
+	require.Len(t, prioritized, 2)
+	require.Equal(t, ccnpKey, prioritized[0].key)
+	require.Equal(t, cnpKey, prioritized[1].key)
+}

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -1644,6 +1644,8 @@ const (
 
 	AliveEntries = "aliveEntries"
 
+	OmittedEntries = "omittedEntries"
+
 	Scope = "scope"
 
 	NewLocally = "newLocally"


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

Implemented the four heuristics proposed in #46189 to choose which entries to retain when the policy map is over capacity:

1. Entries with observed traffic (packet/byte counters > 0)
2. TCP/UDP entries over SCTP
3. Entries already present in the BPF map
4. Entries derived from CiliumClusterwideNetworkPolicy over CiliumNetworkPolicy

Related: #46189 (Further heuristics can be added in future)
This PR was prepared with AIL:2.

```release-note
Policy map overflow applies a priority-based heuristic to retain
the most important entries when the map is full, instead of dropping
entries randomly.
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
