### PR TITLE
Hubble observer server hardening

### DIFF
--- a/pkg/hubble/filters/cel_expression.go
+++ b/pkg/hubble/filters/cel_expression.go
@@ -27,6 +27,19 @@ var (
 	goBoolType = reflect.TypeFor[bool]()
 
 	celEnv *cel.Env
+
+	// Maximum size of the raw CEL filter expression(4096 characters).
+	celExpressionMaxSize int = 4096
+
+	// celProgramMaxRuntimeCost is the maximum runtime cost budget for a single
+	// expression evaluation. Evaluation is aborted with an error if the
+	// actual accumulated cost exceeds this value.
+	celProgramMaxRuntimeCost uint64 = 100000
+
+	// celProgramInterruptCheckFrequency controls how often (in comprehension
+	// iterations) CEL checks for context cancellation. Lower values make
+	// cancellation more responsive at the expense of a small throughput cost.
+	celProgramInterruptCheckFrequency uint = 100
 )
 
 func init() {
@@ -35,6 +48,7 @@ func init() {
 		cel.Container("flow"),
 		celTypes,
 		cel.Variable(flowVariableName, cel.ObjectType("flow.Flow")),
+		cel.ParserExpressionSizeLimit(celExpressionMaxSize),
 	)
 	if err != nil {
 		panic(fmt.Sprintf("error creating CEL env %s", err))
@@ -67,7 +81,7 @@ func compile(env *cel.Env, expr string, celType *cel.Type) (*cel.Ast, error) {
 	return ast, nil
 }
 
-func filterByCELExpression(ctx context.Context, log *slog.Logger, exprs []string) (FilterFunc, error) {
+func compileCELFilters(exprs []string) ([]cel.Program, error) {
 	var programs []cel.Program
 	for _, expr := range exprs {
 		// we want filters to be boolean expressions, so check the type of the
@@ -77,11 +91,25 @@ func filterByCELExpression(ctx context.Context, log *slog.Logger, exprs []string
 			return nil, fmt.Errorf("error compiling CEL expression: %w", err)
 		}
 
-		prg, err := celEnv.Program(ast)
+		prg, err := celEnv.Program(
+			ast,
+			cel.EvalOptions(cel.OptOptimize),
+			cel.CostLimit(celProgramMaxRuntimeCost),
+			cel.InterruptCheckFrequency(celProgramInterruptCheckFrequency),
+		)
 		if err != nil {
 			return nil, fmt.Errorf("error building CEL program: %w", err)
 		}
 		programs = append(programs, prg)
+	}
+
+	return programs, nil
+}
+
+func filterByCELExpression(ctx context.Context, log *slog.Logger, exprs []string) (FilterFunc, error) {
+	programs, err := compileCELFilters(exprs)
+	if err != nil {
+		return nil, err
 	}
 
 	return func(ev *v1.Event) bool {

--- a/pkg/hubble/filters/cel_expression.go
+++ b/pkg/hubble/filters/cel_expression.go
@@ -13,7 +13,9 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var (
@@ -27,6 +29,23 @@ var (
 	goBoolType = reflect.TypeFor[bool]()
 
 	celEnv *cel.Env
+
+	// Limiter to use for logging CEL filter program eval error.
+	// 1 log per second with a burst of 3.
+	celFilterLoggingLimiter = logging.NewLimiter(time.Second, 3)
+
+	// Maximum size of the raw CEL filter expression(4096 characters).
+	celExpressionMaxSize int = 4096
+
+	// celProgramMaxRuntimeCost is the maximum runtime cost budget for a single
+	// expression evaluation. Evaluation is aborted with an error if the
+	// actual accumulated cost exceeds this value.
+	celProgramMaxRuntimeCost uint64 = 100000
+
+	// celProgramInterruptCheckFrequency controls how often (in comprehension
+	// iterations) CEL checks for context cancellation. Lower values make
+	// cancellation more responsive at the expense of a small throughput cost.
+	celProgramInterruptCheckFrequency uint = 100
 )
 
 func init() {
@@ -35,6 +54,7 @@ func init() {
 		cel.Container("flow"),
 		celTypes,
 		cel.Variable(flowVariableName, cel.ObjectType("flow.Flow")),
+		cel.ParserExpressionSizeLimit(celExpressionMaxSize),
 	)
 	if err != nil {
 		panic(fmt.Sprintf("error creating CEL env %s", err))
@@ -67,7 +87,7 @@ func compile(env *cel.Env, expr string, celType *cel.Type) (*cel.Ast, error) {
 	return ast, nil
 }
 
-func filterByCELExpression(ctx context.Context, log *slog.Logger, exprs []string) (FilterFunc, error) {
+func compileCELFilters(exprs []string) ([]cel.Program, error) {
 	var programs []cel.Program
 	for _, expr := range exprs {
 		// we want filters to be boolean expressions, so check the type of the
@@ -77,11 +97,25 @@ func filterByCELExpression(ctx context.Context, log *slog.Logger, exprs []string
 			return nil, fmt.Errorf("error compiling CEL expression: %w", err)
 		}
 
-		prg, err := celEnv.Program(ast)
+		prg, err := celEnv.Program(
+			ast,
+			cel.EvalOptions(cel.OptOptimize),
+			cel.CostLimit(celProgramMaxRuntimeCost),
+			cel.InterruptCheckFrequency(celProgramInterruptCheckFrequency),
+		)
 		if err != nil {
 			return nil, fmt.Errorf("error building CEL program: %w", err)
 		}
 		programs = append(programs, prg)
+	}
+
+	return programs, nil
+}
+
+func filterByCELExpression(ctx context.Context, log *slog.Logger, exprs []string) (FilterFunc, error) {
+	programs, err := compileCELFilters(exprs)
+	if err != nil {
+		return nil, err
 	}
 
 	return func(ev *v1.Event) bool {
@@ -90,13 +124,18 @@ func filterByCELExpression(ctx context.Context, log *slog.Logger, exprs []string
 				flowVariableName: ev.GetFlow(),
 			})
 			if err != nil {
-				log.Error("error running CEL program", logfields.Error, err)
+				if celFilterLoggingLimiter.Allow() {
+					log.Error("Error running CEL program", logfields.Error, err)
+				} else {
+					log.Debug("Error running CEL program", logfields.Error, err)
+				}
 				return false
 			}
 
 			v, err := out.ConvertToNative(goBoolType)
 			if err != nil {
-				log.Error("invalid conversion in CEL program", logfields.Error, err)
+				// This branch is unreachable as we already verified boolean result during compilation.
+				log.Error("Invalid conversion in CEL program", logfields.Error, err)
 				return false
 			}
 			b, ok := v.(bool)

--- a/pkg/hubble/filters/cel_expression_test.go
+++ b/pkg/hubble/filters/cel_expression_test.go
@@ -6,6 +6,9 @@ package filters
 import (
 	"testing"
 
+	"github.com/google/cel-go/cel"
+	"github.com/stretchr/testify/require"
+
 	"github.com/cilium/hive/hivetest"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
@@ -136,6 +139,99 @@ func TestCELExpressionFilter(t *testing.T) {
 					t.Errorf("filterResult %d = %v, want %v", i, filterResult, tt.want[i])
 				}
 			}
+		})
+	}
+}
+
+func setCELProgramMaxRuntimeCost(cost uint64) func() {
+	orig := celProgramMaxRuntimeCost
+	celProgramMaxRuntimeCost = cost
+	return func() { celProgramMaxRuntimeCost = orig }
+}
+
+func TestCELExpressionCostLimits(t *testing.T) {
+	// evalProgram evaluates prg against flow and returns the boolean result.
+	evalProgram := func(t *testing.T, prg cel.Program, flow *flowpb.Flow) (bool, error) {
+		t.Helper()
+		out, _, err := prg.ContextEval(t.Context(), map[string]any{flowVariableName: flow})
+		if err != nil {
+			return false, err
+		}
+		v, err := out.ConvertToNative(goBoolType)
+		if err != nil {
+			return false, err
+		}
+		b, _ := v.(bool)
+		return b, nil
+	}
+
+	const (
+		simpleExpr  = "['10.0.0.1','10.0.0.2','10.0.0.3'].exists(ip, ip == _flow.IP.source)"
+		complexExpr = "_flow.source_names.exists(n, ['default','kube-system','production','staging','dev'].exists(ns, n.contains(ns))) && _flow.destination_names.filter(n, n.startsWith('backend')).map(n, n).size() > 0"
+
+		evalErrMsg = "operation cancelled: actual cost limit exceeded"
+	)
+
+	tests := []struct {
+		name           string
+		maxRuntimeCost uint64
+		expr           string
+		flow           *flowpb.Flow
+		wantEvalErrMsg string
+		wantResult     bool
+	}{
+		{
+			// Source IP absent from list forces full iteration, exhausting the budget.
+			name:           "simple - runtime cost limit exceeded",
+			maxRuntimeCost: 16,
+			expr:           simpleExpr,
+			flow:           &flowpb.Flow{IP: &flowpb.IP{Source: "9.9.9.9", Destination: "10.0.0.1"}},
+			wantEvalErrMsg: evalErrMsg,
+		},
+		{
+			// Runtime limit is sufficient: eval succeeds with a matching flow.
+			name:           "simple - runtime cost within limit",
+			maxRuntimeCost: 64,
+			expr:           simpleExpr,
+			flow:           &flowpb.Flow{IP: &flowpb.IP{Source: "10.0.0.2", Destination: "10.0.0.9"}},
+			wantResult:     true,
+		},
+		{
+			name:           "complex - runtime cost limit exceeded",
+			maxRuntimeCost: 32,
+			expr:           complexExpr,
+			flow: &flowpb.Flow{
+				SourceNames:      []string{"frontend.default.svc.cluster.local", "frontend.default"},
+				DestinationNames: []string{"backend.production.svc.cluster.local"},
+			},
+			wantEvalErrMsg: evalErrMsg,
+		},
+		{
+			name:           "complex - runtime cost within limit",
+			maxRuntimeCost: 128,
+			expr:           complexExpr,
+			flow: &flowpb.Flow{
+				SourceNames:      []string{"frontend.default.svc.cluster.local", "frontend.default"},
+				DestinationNames: []string{"backend.production.svc.cluster.local"},
+			},
+			wantResult: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(setCELProgramMaxRuntimeCost(tt.maxRuntimeCost))
+
+			programs, err := compileCELFilters([]string{tt.expr})
+			require.NoError(t, err)
+
+			result, evalErr := evalProgram(t, programs[0], tt.flow)
+			if tt.wantEvalErrMsg != "" {
+				require.EqualError(t, evalErr, tt.wantEvalErrMsg)
+				return
+			}
+			require.NoError(t, evalErr)
+			require.Equal(t, tt.wantResult, result)
 		})
 	}
 }

--- a/pkg/hubble/filters/cel_expression_test.go
+++ b/pkg/hubble/filters/cel_expression_test.go
@@ -6,6 +6,9 @@ package filters
 import (
 	"testing"
 
+	"cel.dev/cel-go/cel"
+	"github.com/stretchr/testify/require"
+
 	"github.com/cilium/hive/hivetest"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
@@ -136,6 +139,99 @@ func TestCELExpressionFilter(t *testing.T) {
 					t.Errorf("filterResult %d = %v, want %v", i, filterResult, tt.want[i])
 				}
 			}
+		})
+	}
+}
+
+func setCELProgramMaxRuntimeCost(cost uint64) func() {
+	orig := celProgramMaxRuntimeCost
+	celProgramMaxRuntimeCost = cost
+	return func() { celProgramMaxRuntimeCost = orig }
+}
+
+func TestCELExpressionCostLimits(t *testing.T) {
+	// evalProgram evaluates prg against flow and returns the boolean result.
+	evalProgram := func(t *testing.T, prg cel.Program, flow *flowpb.Flow) (bool, error) {
+		t.Helper()
+		out, _, err := prg.ContextEval(t.Context(), map[string]any{flowVariableName: flow})
+		if err != nil {
+			return false, err
+		}
+		v, err := out.ConvertToNative(goBoolType)
+		if err != nil {
+			return false, err
+		}
+		b, _ := v.(bool)
+		return b, nil
+	}
+
+	const (
+		simpleExpr  = "['10.0.0.1','10.0.0.2','10.0.0.3'].exists(ip, ip == _flow.IP.source)"
+		complexExpr = "_flow.source_names.exists(n, ['default','kube-system','production','staging','dev'].exists(ns, n.contains(ns))) && _flow.destination_names.filter(n, n.startsWith('backend')).map(n, n).size() > 0"
+
+		evalErrMsg = "operation cancelled: actual cost limit exceeded"
+	)
+
+	tests := []struct {
+		name           string
+		maxRuntimeCost uint64
+		expr           string
+		flow           *flowpb.Flow
+		wantEvalErrMsg string
+		wantResult     bool
+	}{
+		{
+			// Source IP absent from list forces full iteration, exhausting the budget.
+			name:           "simple - runtime cost limit exceeded",
+			maxRuntimeCost: 16,
+			expr:           simpleExpr,
+			flow:           &flowpb.Flow{IP: &flowpb.IP{Source: "9.9.9.9", Destination: "10.0.0.1"}},
+			wantEvalErrMsg: evalErrMsg,
+		},
+		{
+			// Runtime limit is sufficient: eval succeeds with a matching flow.
+			name:           "simple - runtime cost within limit",
+			maxRuntimeCost: 64,
+			expr:           simpleExpr,
+			flow:           &flowpb.Flow{IP: &flowpb.IP{Source: "10.0.0.2", Destination: "10.0.0.9"}},
+			wantResult:     true,
+		},
+		{
+			name:           "complex - runtime cost limit exceeded",
+			maxRuntimeCost: 32,
+			expr:           complexExpr,
+			flow: &flowpb.Flow{
+				SourceNames:      []string{"frontend.default.svc.cluster.local", "frontend.default"},
+				DestinationNames: []string{"backend.production.svc.cluster.local"},
+			},
+			wantEvalErrMsg: evalErrMsg,
+		},
+		{
+			name:           "complex - runtime cost within limit",
+			maxRuntimeCost: 128,
+			expr:           complexExpr,
+			flow: &flowpb.Flow{
+				SourceNames:      []string{"frontend.default.svc.cluster.local", "frontend.default"},
+				DestinationNames: []string{"backend.production.svc.cluster.local"},
+			},
+			wantResult: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(setCELProgramMaxRuntimeCost(tt.maxRuntimeCost))
+
+			programs, err := compileCELFilters([]string{tt.expr})
+			require.NoError(t, err)
+
+			result, evalErr := evalProgram(t, programs[0], tt.flow)
+			if tt.wantEvalErrMsg != "" {
+				require.EqualError(t, evalErr, tt.wantEvalErrMsg)
+				return
+			}
+			require.NoError(t, evalErr)
+			require.Equal(t, tt.wantResult, result)
 		})
 	}
 }

--- a/pkg/hubble/server/server.go
+++ b/pkg/hubble/server/server.go
@@ -12,11 +12,13 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/reflection"
 
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 	peerpb "github.com/cilium/cilium/api/v1/peer"
 	"github.com/cilium/cilium/pkg/hubble/server/serveroption"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var (
@@ -52,7 +54,14 @@ func NewServer(log *slog.Logger, options ...serveroption.Option) (*Server, error
 }
 
 func (s *Server) newGRPCServer() *grpc.Server {
-	var opts []grpc.ServerOption
+	opts := []grpc.ServerOption{
+		grpc.MaxConcurrentStreams(1024),
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			Time:    60 * time.Second,
+			Timeout: 15 * time.Second,
+		}),
+	}
+
 	if len(s.opts.GRPCUnaryInterceptors) > 0 {
 		opts = append(opts, grpc.ChainUnaryInterceptor(s.opts.GRPCUnaryInterceptors...))
 	}

--- a/pkg/hubble/server/server.go
+++ b/pkg/hubble/server/server.go
@@ -12,11 +12,13 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/reflection"
 
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 	peerpb "github.com/cilium/cilium/api/v1/peer"
 	"github.com/cilium/cilium/pkg/hubble/server/serveroption"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var (
@@ -52,7 +54,14 @@ func NewServer(log *slog.Logger, options ...serveroption.Option) (*Server, error
 }
 
 func (s *Server) newGRPCServer() *grpc.Server {
-	var opts []grpc.ServerOption
+	opts := []grpc.ServerOption{
+		grpc.MaxConcurrentStreams(250),
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			Time:    60 * time.Second,
+			Timeout: 15 * time.Second,
+		}),
+	}
+
 	if len(s.opts.GRPCUnaryInterceptors) > 0 {
 		opts = append(opts, grpc.ChainUnaryInterceptor(s.opts.GRPCUnaryInterceptors...))
 	}


### PR DESCRIPTION
This change does not implement compile time cost limit for flow filter CEL Expressions. Currently the [flow proto types](https://github.com/fristonio/cilium/blob/0906ee16c4f4c01d98297cc520d0d5a821b6b085/api/v1/flow/flow.proto#L14) are not annotated with validation descriptors, so the size of strings/map/list are not known at compile time causing cost estimate to explode. In the context of this PR the cost limit is only enforced at runtime. For compile time protection against user provided CEL expression, a hard limit on the size of raw expression is enforced.

Compile time cost limit enforcement will be implemented as a followup. For this we need to standardize the approach for annotating proto contracts with validation descriptors(either using [protoc-gen-validate](https://github.com/bufbuild/protoc-gen-validate) or [protovalidator](https://protovalidate.com/)) and close on the exact constraints for all flow proto types fields. This can then be consumed from a custom cost estimator.