### PR TITLE
bgp: Do not use IPv6 NLRI with IPv4 extended nexthop in bgp tests

### DIFF
--- a/pkg/bgp/test/testdata/pod-ip-pool.txtar
+++ b/pkg/bgp/test/testdata/pod-ip-pool.txtar
@@ -1,4 +1,4 @@
-#! --ipam=multi-pool --test-peering-ips=10.99.2.1,10.99.2.2
+#! --ipam=multi-pool --test-peering-ips=fd00::99:2:1,fd00::99:2:2
 
 # Tests CiliumPodIPPool advertisements across multiple pools including partial allocation from the pool.
 
@@ -6,8 +6,8 @@
 hive start
 
 # Configure GoBGP server
-gobgp/add-server test 65010 10.99.2.1 1790
-gobgp/add-peer 10.99.2.2 65001
+gobgp/add-server test --router-id=10.99.2.1 65010 fd00::99:2:1 1790
+gobgp/add-peer fd00::99:2:2 65001
 
 # Configure BGP on Cilium
 k8s/add bgp-node-config.yaml bgp-peer-config.yaml
@@ -20,7 +20,7 @@ k8s/add cilium-node-partial.yaml
 k8s/add pod-pool-red.yaml pod-pool-green.yaml
 
 # Wait for peering to be established
-gobgp/wait-state 10.99.2.2 ESTABLISHED
+gobgp/wait-state fd00::99:2:2 ESTABLISHED
 
 # Validate red pool IPv4 routes
 gobgp/routes -o routes.actual ipv4 unicast
@@ -75,7 +75,7 @@ metadata:
   name: test-node
 spec:
   addresses:
-  - ip: 10.99.2.2
+  - ip: fd00::99:2:2
     type: InternalIP
   ipam:
     podCIDRs:
@@ -100,7 +100,7 @@ metadata:
   name: test-node
 spec:
   addresses:
-  - ip: 10.99.2.2
+  - ip: fd00::99:2:2
     type: InternalIP
   ipam:
     podCIDRs:
@@ -126,12 +126,13 @@ metadata:
 spec:
   bgpInstances:
   - localASN: 65001
+    routerID: 10.99.2.2
     name: tor
     peers:
     - name: gobgp-peer
       peerASN: 65010
-      peerAddress: 10.99.2.1
-      localAddress: 10.99.2.2
+      peerAddress: fd00::99:2:1
+      localAddress: fd00::99:2:2
       peerConfigRef:
         name: gobgp-peer-config
 
@@ -228,21 +229,21 @@ spec:
     maskSize: 120
 
 -- gobgp-routes-red-ipv4.expected --
-Prefix         NextHop     Attrs
-10.20.0.0/24   10.99.2.2   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.2.2} {Communities: 65001:100}]
-10.30.0.0/24   10.99.2.2   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.2.2} {Communities: 65001:100}]
+Prefix         NextHop        Attrs
+10.20.0.0/24   fd00::99:2:2   [{Origin: i} {AsPath: 65001} {Communities: 65001:100} {MpReach(ipv4-unicast): {Nexthop: fd00::99:2:2, NLRIs: [10.20.0.0/24:0]}}]
+10.30.0.0/24   fd00::99:2:2   [{Origin: i} {AsPath: 65001} {Communities: 65001:100} {MpReach(ipv4-unicast): {Nexthop: fd00::99:2:2, NLRIs: [10.30.0.0/24:0]}}]
 -- gobgp-routes-red-ipv6.expected --
-Prefix       NextHop            Attrs
-fd00::/120   ::ffff:10.99.2.2   [{Origin: i} {AsPath: 65001} {Communities: 65001:100} {MpReach(ipv6-unicast): {Nexthop: ::ffff:10.99.2.2, NLRIs: [fd00::/120:0]}}]
+Prefix       NextHop        Attrs
+fd00::/120   fd00::99:2:2   [{Origin: i} {AsPath: 65001} {Communities: 65001:100} {MpReach(ipv6-unicast): {Nexthop: fd00::99:2:2, NLRIs: [fd00::/120:0]}}]
 -- gobgp-routes-green-partial-ipv4.expected --
-Prefix         NextHop     Attrs
-11.20.0.0/24   10.99.2.2   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.2.2} {Communities: no-export}]
+Prefix         NextHop        Attrs
+11.20.0.0/24   fd00::99:2:2   [{Origin: i} {AsPath: 65001} {Communities: no-export} {MpReach(ipv4-unicast): {Nexthop: fd00::99:2:2, NLRIs: [11.20.0.0/24:0]}}]
 -- gobgp-routes-green-full-ipv4.expected --
-Prefix         NextHop     Attrs
-11.20.0.0/24   10.99.2.2   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.2.2} {Communities: no-export}]
-11.30.0.0/24   10.99.2.2   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.2.2} {Communities: no-export}]
+Prefix         NextHop        Attrs
+11.20.0.0/24   fd00::99:2:2   [{Origin: i} {AsPath: 65001} {Communities: no-export} {MpReach(ipv4-unicast): {Nexthop: fd00::99:2:2, NLRIs: [11.20.0.0/24:0]}}]
+11.30.0.0/24   fd00::99:2:2   [{Origin: i} {AsPath: 65001} {Communities: no-export} {MpReach(ipv4-unicast): {Nexthop: fd00::99:2:2, NLRIs: [11.30.0.0/24:0]}}]
 -- gobgp-routes-green-ipv6.expected --
-Prefix       NextHop            Attrs
-fd11::/120   ::ffff:10.99.2.2   [{Origin: i} {AsPath: 65001} {Communities: no-export} {MpReach(ipv6-unicast): {Nexthop: ::ffff:10.99.2.2, NLRIs: [fd11::/120:0]}}]
+Prefix       NextHop        Attrs
+fd11::/120   fd00::99:2:2   [{Origin: i} {AsPath: 65001} {Communities: no-export} {MpReach(ipv6-unicast): {Nexthop: fd00::99:2:2, NLRIs: [fd11::/120:0]}}]
 -- gobgp-routes-empty.expected --
 Prefix   NextHop   Attrs

--- a/pkg/bgp/test/testdata/svc-aggregation.txtar
+++ b/pkg/bgp/test/testdata/svc-aggregation.txtar
@@ -1,4 +1,4 @@
-#! --test-peering-ips=10.99.4.211,10.99.4.212
+#! --test-peering-ips=fd00::99:4:211,fd00::99:4:212
 
 # Tests service advertisements with aggregated/non-aggregated prefixes.
 # When aggregation is enabled, non-aggregated prefixes are still advertised for services with local traffic policy.
@@ -7,10 +7,10 @@
 hive start
 
 # Configure gobgp server
-gobgp/add-server test 65010 10.99.4.211 1790
+gobgp/add-server test --router-id=10.99.4.211 65010 fd00::99:4:211 1790
 
 # Configure peers on GoBGP
-gobgp/add-peer 10.99.4.212 65001
+gobgp/add-peer fd00::99:4:212 65001
 
 # Add k8s services and endpoints
 k8s/add service-1.yaml service-2.yaml service-3.yaml endpoints-ipv4.yaml endpoints-ipv6.yaml
@@ -19,7 +19,7 @@ k8s/add service-1.yaml service-2.yaml service-3.yaml endpoints-ipv4.yaml endpoin
 k8s/add cilium-node.yaml bgp-node-config.yaml bgp-peer-config.yaml bgp-advertisement-1.yaml
 
 # Wait for peering to be established
-gobgp/wait-state 10.99.4.212 ESTABLISHED
+gobgp/wait-state fd00::99:4:212 ESTABLISHED
 
 # Validate that IPv4 aggregated routes are advertised
 gobgp/routes -o routes.actual ipv4 unicast
@@ -60,7 +60,7 @@ metadata:
   name: test-node
 spec:
   addresses:
-  - ip: 10.99.4.212
+  - ip: fd00::99:4:212
     type: InternalIP
   ipam:
     podCIDRs:
@@ -74,12 +74,13 @@ metadata:
 spec:
   bgpInstances:
   - localASN: 65001
+    routerID: 10.99.4.212
     name: tor-65001
     peers:
     - name: gobgp-peer-1
       peerASN: 65010
-      peerAddress: 10.99.4.211
-      localAddress: 10.99.4.212
+      peerAddress: fd00::99:4:211
+      localAddress: fd00::99:4:212
       peerConfigRef:
         name: gobgp-peer-config
 
@@ -319,56 +320,56 @@ ports:
   protocol: TCP
 
 -- gobgp-routes-aggregated-ipv4-1.expected --
-Prefix            NextHop       Attrs
-10.10.10.0/24     10.99.4.212   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.4.212}]
-10.10.10.3/32     10.99.4.212   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.4.212}]
-10.96.50.0/24     10.99.4.212   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.4.212}]
-10.96.50.103/32   10.99.4.212   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.4.212}]
-172.16.1.0/24     10.99.4.212   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.4.212}]
-172.16.1.3/32     10.99.4.212   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.4.212}]
+Prefix            NextHop          Attrs
+10.10.10.0/24     fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv4-unicast): {Nexthop: fd00::99:4:212, NLRIs: [10.10.10.0/24:0]}}]
+10.10.10.3/32     fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv4-unicast): {Nexthop: fd00::99:4:212, NLRIs: [10.10.10.3/32:0]}}]
+10.96.50.0/24     fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv4-unicast): {Nexthop: fd00::99:4:212, NLRIs: [10.96.50.0/24:0]}}]
+10.96.50.103/32   fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv4-unicast): {Nexthop: fd00::99:4:212, NLRIs: [10.96.50.103/32:0]}}]
+172.16.1.0/24     fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv4-unicast): {Nexthop: fd00::99:4:212, NLRIs: [172.16.1.0/24:0]}}]
+172.16.1.3/32     fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv4-unicast): {Nexthop: fd00::99:4:212, NLRIs: [172.16.1.3/32:0]}}]
 -- gobgp-routes-aggregated-ipv4-2.expected --
-Prefix            NextHop       Attrs
-10.10.0.0/16      10.99.4.212   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.4.212}]
-10.10.10.3/32     10.99.4.212   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.4.212}]
-10.96.0.0/16      10.99.4.212   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.4.212}]
-10.96.50.103/32   10.99.4.212   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.4.212}]
-172.16.0.0/16     10.99.4.212   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.4.212}]
-172.16.1.3/32     10.99.4.212   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.4.212}]
+Prefix            NextHop          Attrs
+10.10.0.0/16      fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv4-unicast): {Nexthop: fd00::99:4:212, NLRIs: [10.10.0.0/16:0]}}]
+10.10.10.3/32     fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv4-unicast): {Nexthop: fd00::99:4:212, NLRIs: [10.10.10.3/32:0]}}]
+10.96.0.0/16      fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv4-unicast): {Nexthop: fd00::99:4:212, NLRIs: [10.96.0.0/16:0]}}]
+10.96.50.103/32   fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv4-unicast): {Nexthop: fd00::99:4:212, NLRIs: [10.96.50.103/32:0]}}]
+172.16.0.0/16     fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv4-unicast): {Nexthop: fd00::99:4:212, NLRIs: [172.16.0.0/16:0]}}]
+172.16.1.3/32     fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv4-unicast): {Nexthop: fd00::99:4:212, NLRIs: [172.16.1.3/32:0]}}]
 -- gobgp-routes-non-aggregated-ipv4.expected --
-Prefix            NextHop       Attrs
-10.10.10.1/32     10.99.4.212   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.4.212}]
-10.10.10.2/32     10.99.4.212   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.4.212}]
-10.10.10.3/32     10.99.4.212   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.4.212}]
-10.96.50.101/32   10.99.4.212   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.4.212}]
-10.96.50.102/32   10.99.4.212   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.4.212}]
-10.96.50.103/32   10.99.4.212   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.4.212}]
-172.16.1.1/32     10.99.4.212   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.4.212}]
-172.16.1.2/32     10.99.4.212   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.4.212}]
-172.16.1.3/32     10.99.4.212   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.4.212}]
+Prefix            NextHop          Attrs
+10.10.10.1/32     fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv4-unicast): {Nexthop: fd00::99:4:212, NLRIs: [10.10.10.1/32:0]}}]
+10.10.10.2/32     fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv4-unicast): {Nexthop: fd00::99:4:212, NLRIs: [10.10.10.2/32:0]}}]
+10.10.10.3/32     fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv4-unicast): {Nexthop: fd00::99:4:212, NLRIs: [10.10.10.3/32:0]}}]
+10.96.50.101/32   fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv4-unicast): {Nexthop: fd00::99:4:212, NLRIs: [10.96.50.101/32:0]}}]
+10.96.50.102/32   fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv4-unicast): {Nexthop: fd00::99:4:212, NLRIs: [10.96.50.102/32:0]}}]
+10.96.50.103/32   fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv4-unicast): {Nexthop: fd00::99:4:212, NLRIs: [10.96.50.103/32:0]}}]
+172.16.1.1/32     fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv4-unicast): {Nexthop: fd00::99:4:212, NLRIs: [172.16.1.1/32:0]}}]
+172.16.1.2/32     fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv4-unicast): {Nexthop: fd00::99:4:212, NLRIs: [172.16.1.2/32:0]}}]
+172.16.1.3/32     fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv4-unicast): {Nexthop: fd00::99:4:212, NLRIs: [172.16.1.3/32:0]}}]
 -- gobgp-routes-aggregated-ipv6-1.expected --
-Prefix                   NextHop              Attrs
-2001:db8:fd00::100/120   ::ffff:10.99.4.212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: ::ffff:10.99.4.212, NLRIs: [2001:db8:fd00::100/120:0]}}]
-2001:db8:fd00::103/128   ::ffff:10.99.4.212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: ::ffff:10.99.4.212, NLRIs: [2001:db8:fd00::103/128:0]}}]
-fd00:aa:bb::/120         ::ffff:10.99.4.212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: ::ffff:10.99.4.212, NLRIs: [fd00:aa:bb::/120:0]}}]
-fd00:aa:bb::3/128        ::ffff:10.99.4.212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: ::ffff:10.99.4.212, NLRIs: [fd00:aa:bb::3/128:0]}}]
-fd00:cc:dd::/120         ::ffff:10.99.4.212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: ::ffff:10.99.4.212, NLRIs: [fd00:cc:dd::/120:0]}}]
-fd00:cc:dd::3/128        ::ffff:10.99.4.212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: ::ffff:10.99.4.212, NLRIs: [fd00:cc:dd::3/128:0]}}]
+Prefix                   NextHop          Attrs
+2001:db8:fd00::100/120   fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: fd00::99:4:212, NLRIs: [2001:db8:fd00::100/120:0]}}]
+2001:db8:fd00::103/128   fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: fd00::99:4:212, NLRIs: [2001:db8:fd00::103/128:0]}}]
+fd00:aa:bb::/120         fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: fd00::99:4:212, NLRIs: [fd00:aa:bb::/120:0]}}]
+fd00:aa:bb::3/128        fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: fd00::99:4:212, NLRIs: [fd00:aa:bb::3/128:0]}}]
+fd00:cc:dd::/120         fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: fd00::99:4:212, NLRIs: [fd00:cc:dd::/120:0]}}]
+fd00:cc:dd::3/128        fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: fd00::99:4:212, NLRIs: [fd00:cc:dd::3/128:0]}}]
 -- gobgp-routes-aggregated-ipv6-2.expected --
-Prefix                   NextHop              Attrs
-2001:db8:fd00::/64       ::ffff:10.99.4.212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: ::ffff:10.99.4.212, NLRIs: [2001:db8:fd00::/64:0]}}]
-2001:db8:fd00::103/128   ::ffff:10.99.4.212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: ::ffff:10.99.4.212, NLRIs: [2001:db8:fd00::103/128:0]}}]
-fd00:aa:bb::/64          ::ffff:10.99.4.212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: ::ffff:10.99.4.212, NLRIs: [fd00:aa:bb::/64:0]}}]
-fd00:aa:bb::3/128        ::ffff:10.99.4.212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: ::ffff:10.99.4.212, NLRIs: [fd00:aa:bb::3/128:0]}}]
-fd00:cc:dd::/64          ::ffff:10.99.4.212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: ::ffff:10.99.4.212, NLRIs: [fd00:cc:dd::/64:0]}}]
-fd00:cc:dd::3/128        ::ffff:10.99.4.212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: ::ffff:10.99.4.212, NLRIs: [fd00:cc:dd::3/128:0]}}]
+Prefix                   NextHop          Attrs
+2001:db8:fd00::/64       fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: fd00::99:4:212, NLRIs: [2001:db8:fd00::/64:0]}}]
+2001:db8:fd00::103/128   fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: fd00::99:4:212, NLRIs: [2001:db8:fd00::103/128:0]}}]
+fd00:aa:bb::/64          fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: fd00::99:4:212, NLRIs: [fd00:aa:bb::/64:0]}}]
+fd00:aa:bb::3/128        fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: fd00::99:4:212, NLRIs: [fd00:aa:bb::3/128:0]}}]
+fd00:cc:dd::/64          fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: fd00::99:4:212, NLRIs: [fd00:cc:dd::/64:0]}}]
+fd00:cc:dd::3/128        fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: fd00::99:4:212, NLRIs: [fd00:cc:dd::3/128:0]}}]
 -- gobgp-routes-non-aggregated-ipv6.expected --
-Prefix                   NextHop              Attrs
-2001:db8:fd00::101/128   ::ffff:10.99.4.212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: ::ffff:10.99.4.212, NLRIs: [2001:db8:fd00::101/128:0]}}]
-2001:db8:fd00::102/128   ::ffff:10.99.4.212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: ::ffff:10.99.4.212, NLRIs: [2001:db8:fd00::102/128:0]}}]
-2001:db8:fd00::103/128   ::ffff:10.99.4.212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: ::ffff:10.99.4.212, NLRIs: [2001:db8:fd00::103/128:0]}}]
-fd00:aa:bb::1/128        ::ffff:10.99.4.212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: ::ffff:10.99.4.212, NLRIs: [fd00:aa:bb::1/128:0]}}]
-fd00:aa:bb::2/128        ::ffff:10.99.4.212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: ::ffff:10.99.4.212, NLRIs: [fd00:aa:bb::2/128:0]}}]
-fd00:aa:bb::3/128        ::ffff:10.99.4.212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: ::ffff:10.99.4.212, NLRIs: [fd00:aa:bb::3/128:0]}}]
-fd00:cc:dd::1/128        ::ffff:10.99.4.212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: ::ffff:10.99.4.212, NLRIs: [fd00:cc:dd::1/128:0]}}]
-fd00:cc:dd::2/128        ::ffff:10.99.4.212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: ::ffff:10.99.4.212, NLRIs: [fd00:cc:dd::2/128:0]}}]
-fd00:cc:dd::3/128        ::ffff:10.99.4.212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: ::ffff:10.99.4.212, NLRIs: [fd00:cc:dd::3/128:0]}}]
+Prefix                   NextHop          Attrs
+2001:db8:fd00::101/128   fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: fd00::99:4:212, NLRIs: [2001:db8:fd00::101/128:0]}}]
+2001:db8:fd00::102/128   fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: fd00::99:4:212, NLRIs: [2001:db8:fd00::102/128:0]}}]
+2001:db8:fd00::103/128   fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: fd00::99:4:212, NLRIs: [2001:db8:fd00::103/128:0]}}]
+fd00:aa:bb::1/128        fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: fd00::99:4:212, NLRIs: [fd00:aa:bb::1/128:0]}}]
+fd00:aa:bb::2/128        fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: fd00::99:4:212, NLRIs: [fd00:aa:bb::2/128:0]}}]
+fd00:aa:bb::3/128        fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: fd00::99:4:212, NLRIs: [fd00:aa:bb::3/128:0]}}]
+fd00:cc:dd::1/128        fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: fd00::99:4:212, NLRIs: [fd00:cc:dd::1/128:0]}}]
+fd00:cc:dd::2/128        fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: fd00::99:4:212, NLRIs: [fd00:cc:dd::2/128:0]}}]
+fd00:cc:dd::3/128        fd00::99:4:212   [{Origin: i} {AsPath: 65001} {MpReach(ipv6-unicast): {Nexthop: fd00::99:4:212, NLRIs: [fd00:cc:dd::3/128:0]}}]


### PR DESCRIPTION
It is not specified in any RFC and GoBGP even doesn't advertise this combination as a capability, so let's not use it in our tests.

