### PR TITLE
bpf: Make `ipv6_hdrlen_with_fraginfo` function global

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -331,8 +331,8 @@ static __always_inline int __per_packet_lb_svc_xlate_6(void *ctx, struct ipv6hdr
 {
 	struct ipv6_ct_tuple tuple __align_stack_8 = {};
 	struct ct_state ct_state_new = {};
-	fraginfo_t fraginfo;
 	const struct lb6_service *svc;
+	fraginfo_t fraginfo = 0;
 	struct lb6_key key = {};
 	__u16 proxy_port = 0;
 	int l4_off;

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -497,9 +497,9 @@ ct_is_reply ## FAMILY(const void *map,						\
 static __always_inline int
 ipv6_extract_tuple(const struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple)
 {
+	fraginfo_t fraginfo = 0;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
-	fraginfo_t fraginfo;
 	int ret;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -551,8 +551,8 @@ int egress_gw_handle_request(struct __ctx_buff *ctx, __be16 proto,
 	int l4_off;
 	const struct remote_endpoint_info *info;
 	const struct endpoint_info *src_ep;
+	fraginfo_t fraginfo = 0;
 	bool is_reply;
-	fraginfo_t fraginfo;
 	int ret;
 
 	if (src_sec_identity == HOST_ID)

--- a/bpf/lib/ipv6.h
+++ b/bpf/lib/ipv6.h
@@ -161,10 +161,12 @@ static __always_inline int ipv6_hdrlen_offset(const struct __ctx_buff *ctx, int 
 	return DROP_INVALID_EXTHDR;
 }
 
-static __always_inline int ipv6_hdrlen_with_fraginfo(const struct __ctx_buff *ctx,
-						     __u8 *nexthdr,
-						     fraginfo_t *fraginfo)
+__noinline __weak
+int ipv6_hdrlen_with_fraginfo(const struct __ctx_buff *ctx, __u8 *nexthdr, fraginfo_t *fraginfo)
 {
+	if (!nexthdr)
+		return DROP_INVALID;
+
 	return ipv6_hdrlen_offset(ctx, ETH_HLEN, nexthdr, fraginfo);
 }
 

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -2117,9 +2117,9 @@ snat_v6_rev_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target,
 	struct ipv6_nat_entry *state = NULL;
 	struct ipv6_ct_tuple tuple = {};
 	__u32 off, inner_l3_off;
+	fraginfo_t fraginfo = 0;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
-	fraginfo_t fraginfo;
 	__be16 to_dport = 0;
 	__u16 port_off = 0;
 	int ret, hdrlen;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -416,7 +416,7 @@ static __always_inline int encap_geneve_dsr_opt6(struct __ctx_buff *ctx,
 	__u16 encap_len = sizeof(struct ipv6hdr) + sizeof(struct udphdr) +
 		sizeof(struct genevehdr) + ETH_HLEN;
 	__u16 payload_len = bpf_ntohs(ip6->payload_len) + sizeof(*ip6);
-	fraginfo_t fraginfo;
+	fraginfo_t fraginfo = 0;
 	__u16 total_len = 0;
 	__be16 src_port;
 	int l4_off, ret;
@@ -957,7 +957,7 @@ nodeport_rev_dnat_ipv6(struct __ctx_buff *ctx, enum ct_dir dir,
 	__u32 src_sec_identity __maybe_unused = SECLABEL;
 	__be16 src_port __maybe_unused = 0;
 	bool allow_neigh_map = true;
-	fraginfo_t fraginfo;
+	fraginfo_t fraginfo = 0;
 	int ifindex = 0;
 	__u32 monitor = 0;
 
@@ -1231,9 +1231,9 @@ int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 	};
 	struct ipv6_nat_entry *state = NULL;
 	int ret, l4_off, oif = 0;
+	fraginfo_t fraginfo = 0;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
-	fraginfo_t fraginfo;
 	__s8 ext_err = 0;
 #ifdef TUNNEL_MODE
 	const struct remote_endpoint_info *info;
@@ -1553,11 +1553,11 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 					__s8 *ext_err,
 					bool __maybe_unused *dsr)
 {
-	fraginfo_t fraginfo;
 	bool is_svc_proto __maybe_unused = true;
 	int ret, l3_off = ETH_HLEN, l4_off;
 	struct ipv6_ct_tuple tuple __align_stack_8 = {};
 	const struct lb6_service *svc;
+	fraginfo_t fraginfo = 0;
 	struct lb6_key key = {};
 
 	tuple.nexthdr = ip6->nexthdr;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1208,17 +1208,14 @@ drop_err:
 	return send_drop_notify_error_ext(ctx, src_id, ret, ext_err, METRIC_INGRESS);
 }
 
+DEFINE_AUX(struct bpf_fib_lookup_padded, nodeport_fib_params);
+
 __declare_tail(CILIUM_CALL_IPV6_NODEPORT_NAT_EGRESS)
 static __always_inline
 int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 {
 	const bool nat_46x64 = nat46x64_cb_xlate(ctx);
-	struct bpf_fib_lookup_padded fib_params = {
-		.l = {
-			.family		= AF_INET6,
-			.ifindex	= ctx_get_ifindex(ctx),
-		},
-	};
+	struct bpf_fib_lookup_padded *fib_params = AUX(nodeport_fib_params);
 	struct ipv6_nat_target target = {
 		.min_port = NODEPORT_PORT_MIN_NAT,
 		.max_port = NODEPORT_PORT_MAX_NAT,
@@ -1344,16 +1341,19 @@ fib_ipv4:
 			ret = DROP_INVALID;
 			goto drop_err;
 		}
-		fib_params.l.ipv4_src = ip4->saddr;
-		fib_params.l.ipv4_dst = ip4->daddr;
-		fib_params.l.family = AF_INET;
+		fib_params->l.ipv4_src = ip4->saddr;
+		fib_params->l.ipv4_dst = ip4->daddr;
+		fib_params->l.family = AF_INET;
 	} else {
-		ipv6_addr_copy((union v6addr *)&fib_params.l.ipv6_src,
+		ipv6_addr_copy((union v6addr *)&fib_params->l.ipv6_src,
 			       (union v6addr *)&ip6->saddr);
-		ipv6_addr_copy((union v6addr *)&fib_params.l.ipv6_dst,
+		ipv6_addr_copy((union v6addr *)&fib_params->l.ipv6_dst,
 			       (union v6addr *)&ip6->daddr);
+		fib_params->l.family = AF_INET6;
 	}
-	ret = fib_redirect(ctx, true, &fib_params, false, &ext_err, &oif);
+
+	fib_params->l.ifindex = ctx_get_ifindex(ctx);
+	ret = fib_redirect(ctx, true, fib_params, false, &ext_err, &oif);
 	if (fib_ok(ret)) {
 		return ret;
 	}

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -60,9 +60,9 @@ static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 						  __s8 *ext_err, struct snat_v6_args *args)
 {
 	int hdrlen, l4_off, ret = NAT_PUNT_TO_STACK;
+	fraginfo_t fraginfo = 0;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
-	fraginfo_t fraginfo;
 
 	args->target.min_port = NODEPORT_PORT_MIN_NAT;
 	args->target.max_port = NODEPORT_PORT_MAX_NAT;
@@ -163,8 +163,8 @@ nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, bool *snat_done,
 	struct bpf_fib_lookup_padded fib_params __maybe_unused = {};
 	struct lb6_reverse_nat nat_info __align_stack_8;
 	struct ipv6_ct_tuple tuple __align_stack_8 = {};
+	fraginfo_t fraginfo = 0;
 	void *data, *data_end;
-	fraginfo_t fraginfo;
 	struct ipv6hdr *ip6;
 	__u32 monitor = 0;
 	int ret, l4_off;


### PR DESCRIPTION
This pull request makes the `ipv6_hdrlen_with_fraginfo`, used early on many IPv6 code paths, into a global function to be verified independently from the main programs. The two other commits are required to prepare for that change.

### Impact on Complexity

The impact on complexity is huge, mostly because this function is not trivial and it happens at the top of all control flow graphs, so removing it from the BPF programs' control flow graphs significantly reduces the number of paths, and thus complexity. It reduces complexity by 83–93% for some of our most complex programs.

#### Top 5 Most-Complex Programs Before

| Collection/Program | Max |
|--------------------|-----|
| host/tail_handle_ipv6_from_netdev | $${\color{orange}515151}$$ (51.52%) for v5.15/1/0 |
| xdp/tail_lb_ipv6 | 422287 (42.23%) for v5.15/1/0 |
| xdp/tail_nodeport_nat_egress_ipv6 | 390658 (39.07%) for v5.15/6/0 |
| host/tail_handle_snat_fwd_ipv4 | 325727 (32.57%) for v6.1/3/2 |
| xdp/tail_nodeport_nat_ingress_ipv6 | 210354 (21.04%) for v5.15/1/0 |

#### Top 5 Most-Complex Programs After

| Collection/Program | Max |
|--------------------|-----|
| host/tail_handle_snat_fwd_ipv4 | 325727 (32.57%) for v6.1/3/2 |
| host/cil_to_netdev | 200805 (20.08%) for v5.15/1/0 |
| host/tail_handle_snat_fwd_ipv6 | 150867 (15.09%) for v5.15/8/0 |
| xdp/tail_nodeport_nat_ingress_ipv4 | 110228 (11.02%) for v6.1/7/0 |
| host/tail_nodeport_nat_ingress_ipv6 | 107468 (10.75%) for v5.15/1/3 |

### Impact on Stack Sizes

Unfortunately, this change also has negative impact on stack sizes, increasing them by 48B or more for all affected BPF programs. This is inherent to the use of global functions. Thankfully, this is mostly affecting BPF programs that were not already close to the stack size limit.

All our BPF programs have at least 50B of leeway before reaching the limit. I've therefore chosen on purpose to not address this here. Stack size issues are a lot easier to resolve than complexity issues and can probably even be resolved reactively.