### PR TITLE
gateway-api: prune stale Gateway API route parent statuses

### DIFF
--- a/operator/pkg/gateway-api/gamma_reconcile.go
+++ b/operator/pkg/gateway-api/gamma_reconcile.go
@@ -167,6 +167,7 @@ func (r *gammaReconciler) setHTTPRouteStatuses(gammaLogger *slog.Logger, ctx con
 	for httpRouteIndex, original := range httpRoutes.Items {
 
 		hr := original.DeepCopy()
+		hr.Status.Parents = pruneRouteParentStatuses(hr.Status.Parents, hr.Spec.ParentRefs)
 
 		hrName := types.NamespacedName{
 			Name:      hr.Name,
@@ -269,6 +270,7 @@ func (r *gammaReconciler) setGRPCRouteStatuses(gammaLogger *slog.Logger, ctx con
 	for grpcRouteIndex, original := range grpcRoutes.Items {
 
 		grpc := original.DeepCopy()
+		grpc.Status.Parents = pruneRouteParentStatuses(grpc.Status.Parents, grpc.Spec.ParentRefs)
 
 		grpcName := types.NamespacedName{
 			Name:      grpc.Name,

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -898,6 +898,7 @@ func (r *gatewayReconciler) setHTTPRouteStatuses(scopedLog *slog.Logger, ctx con
 	for httpRouteIndex, original := range httpRoutes.Items {
 
 		hr := original.DeepCopy()
+		hr.Status.Parents = pruneRouteParentStatuses(hr.Status.Parents, hr.Spec.ParentRefs)
 
 		// input for the validators
 		// The validators will mutate the HTTPRoute as required, setting its status correctly.
@@ -937,6 +938,7 @@ func (r *gatewayReconciler) setTLSRouteStatuses(scopedLog *slog.Logger, ctx cont
 	for tlsRouteIndex, original := range tlsRoutes.Items {
 
 		tlsr := original.DeepCopy()
+		tlsr.Status.Parents = pruneRouteParentStatuses(tlsr.Status.Parents, tlsr.Spec.ParentRefs)
 
 		// input for the validators
 		// The validators will mutate the TLSRoute as required, setting its status correctly.
@@ -971,6 +973,7 @@ func (r *gatewayReconciler) setGRPCRouteStatuses(scopedLog *slog.Logger, ctx con
 	for grpcRouteIndex, original := range grpcRoutes.Items {
 
 		grpcr := original.DeepCopy()
+		grpcr.Status.Parents = pruneRouteParentStatuses(grpcr.Status.Parents, grpcr.Spec.ParentRefs)
 
 		// input for the validators
 		// The validators will mutate the GRPCRoute as required, setting its status correctly.

--- a/operator/pkg/gateway-api/routechecks/grpcroute.go
+++ b/operator/pkg/gateway-api/routechecks/grpcroute.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"reflect"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -177,7 +176,7 @@ func (g *GRPCRouteInput) GetValidProtocols() []gatewayv1.ProtocolType {
 func (g *GRPCRouteInput) mergeStatusConditions(parentRef gatewayv1.ParentReference, updates []metav1.Condition) {
 	index := -1
 	for i, parent := range g.GRPCRoute.Status.RouteStatus.Parents {
-		if reflect.DeepEqual(parent.ParentRef, parentRef) {
+		if parent.ParentRef == parentRef {
 			index = i
 			break
 		}

--- a/operator/pkg/gateway-api/routechecks/httproute.go
+++ b/operator/pkg/gateway-api/routechecks/httproute.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"reflect"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -57,7 +56,7 @@ func (h *HTTPRouteInput) SetAllParentCondition(condition metav1.Condition) {
 func (h *HTTPRouteInput) mergeStatusConditions(parentRef gatewayv1.ParentReference, updates []metav1.Condition) {
 	index := -1
 	for i, parent := range h.HTTPRoute.Status.RouteStatus.Parents {
-		if reflect.DeepEqual(parent.ParentRef, parentRef) {
+		if parent.ParentRef == parentRef {
 			index = i
 			break
 		}

--- a/operator/pkg/gateway-api/routechecks/tlsroute.go
+++ b/operator/pkg/gateway-api/routechecks/tlsroute.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"reflect"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -56,7 +55,7 @@ func (t *TLSRouteInput) SetAllParentCondition(condition metav1.Condition) {
 func (t *TLSRouteInput) mergeStatusConditions(parentRef gatewayv1.ParentReference, updates []metav1.Condition) {
 	index := -1
 	for i, parent := range t.TLSRoute.Status.RouteStatus.Parents {
-		if reflect.DeepEqual(parent.ParentRef, parentRef) {
+		if parent.ParentRef == parentRef {
 			index = i
 			break
 		}

--- a/operator/pkg/gateway-api/status_route.go
+++ b/operator/pkg/gateway-api/status_route.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gateway_api
+
+import (
+	"slices"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+)
+
+func pruneRouteParentStatuses(parents []gatewayv1.RouteParentStatus, currentParentRefs []gatewayv1.ParentReference) []gatewayv1.RouteParentStatus {
+	filtered := parents[:0]
+
+	for _, parentStatus := range parents {
+		if parentStatus.ControllerName != helpers.CiliumDefaultControllerName || slices.Contains(currentParentRefs, parentStatus.ParentRef) {
+			filtered = append(filtered, parentStatus)
+		}
+	}
+
+	return filtered
+}

--- a/operator/pkg/gateway-api/status_route_test.go
+++ b/operator/pkg/gateway-api/status_route_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gateway_api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/operator/pkg/gateway-api/routechecks"
+)
+
+func TestPruneRouteParentStatusesPrunesDetachedParents(t *testing.T) {
+	currentParent := gatewayv1.ParentReference{
+		Name: "current-gateway",
+	}
+	detachedParent := gatewayv1.ParentReference{
+		Name: "detached-gateway",
+	}
+
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "route",
+			Namespace:  "default",
+			Generation: 7,
+		},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{currentParent},
+			},
+		},
+		Status: gatewayv1.HTTPRouteStatus{
+			RouteStatus: gatewayv1.RouteStatus{
+				Parents: []gatewayv1.RouteParentStatus{
+					{
+						ParentRef:      detachedParent,
+						ControllerName: helpers.CiliumDefaultControllerName,
+						Conditions: []metav1.Condition{{
+							Type:   string(gatewayv1.RouteConditionAccepted),
+							Status: metav1.ConditionFalse,
+							Reason: string(gatewayv1.RouteReasonNotAllowedByListeners),
+						}},
+					},
+					{
+						ParentRef:      currentParent,
+						ControllerName: helpers.CiliumDefaultControllerName,
+						Conditions: []metav1.Condition{{
+							Type:   string(gatewayv1.RouteConditionAccepted),
+							Status: metav1.ConditionTrue,
+							Reason: string(gatewayv1.RouteReasonAccepted),
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	input := &routechecks.HTTPRouteInput{HTTPRoute: route}
+
+	require.Len(t, route.Status.Parents, 2)
+	require.Equal(t, detachedParent, route.Status.Parents[0].ParentRef)
+	require.Equal(t, currentParent, route.Status.Parents[1].ParentRef)
+
+	input.SetAllParentCondition(metav1.Condition{
+		Type:   string(gatewayv1.RouteConditionAccepted),
+		Status: metav1.ConditionTrue,
+		Reason: string(gatewayv1.RouteReasonAccepted),
+	})
+
+	require.Len(t, route.Status.Parents, 2)
+	require.Equal(t, detachedParent, route.Status.Parents[0].ParentRef)
+	require.Equal(t, currentParent, route.Status.Parents[1].ParentRef)
+
+	route.Status.Parents = pruneRouteParentStatuses(route.Status.Parents, route.Spec.ParentRefs)
+
+	require.Len(t, route.Status.Parents, 1)
+	require.Equal(t, currentParent, route.Status.Parents[0].ParentRef)
+}

--- a/operator/pkg/gateway-api/status_route_test.go
+++ b/operator/pkg/gateway-api/status_route_test.go
@@ -14,12 +14,15 @@ import (
 	"github.com/cilium/cilium/operator/pkg/gateway-api/routechecks"
 )
 
-func TestPruneRouteParentStatusesPrunesDetachedParents(t *testing.T) {
+func TestPruneRouteParentStatuses(t *testing.T) {
 	currentParent := gatewayv1.ParentReference{
 		Name: "current-gateway",
 	}
-	detachedParent := gatewayv1.ParentReference{
+	ourDetachedParent := gatewayv1.ParentReference{
 		Name: "detached-gateway",
+	}
+	otherControllerDetachedParent := gatewayv1.ParentReference{
+		Name: "other-controller-gateway",
 	}
 
 	route := &gatewayv1.HTTPRoute{
@@ -37,13 +40,17 @@ func TestPruneRouteParentStatusesPrunesDetachedParents(t *testing.T) {
 			RouteStatus: gatewayv1.RouteStatus{
 				Parents: []gatewayv1.RouteParentStatus{
 					{
-						ParentRef:      detachedParent,
+						ParentRef:      ourDetachedParent,
 						ControllerName: helpers.CiliumDefaultControllerName,
 						Conditions: []metav1.Condition{{
 							Type:   string(gatewayv1.RouteConditionAccepted),
 							Status: metav1.ConditionFalse,
 							Reason: string(gatewayv1.RouteReasonNotAllowedByListeners),
 						}},
+					},
+					{
+						ParentRef:      otherControllerDetachedParent,
+						ControllerName: gatewayv1.GatewayController("example.com/other-gateway-controller"),
 					},
 					{
 						ParentRef:      currentParent,
@@ -61,9 +68,10 @@ func TestPruneRouteParentStatusesPrunesDetachedParents(t *testing.T) {
 
 	input := &routechecks.HTTPRouteInput{HTTPRoute: route}
 
-	require.Len(t, route.Status.Parents, 2)
-	require.Equal(t, detachedParent, route.Status.Parents[0].ParentRef)
-	require.Equal(t, currentParent, route.Status.Parents[1].ParentRef)
+	require.Len(t, route.Status.Parents, 3)
+	require.Equal(t, ourDetachedParent, route.Status.Parents[0].ParentRef)
+	require.Equal(t, otherControllerDetachedParent, route.Status.Parents[1].ParentRef)
+	require.Equal(t, currentParent, route.Status.Parents[2].ParentRef)
 
 	input.SetAllParentCondition(metav1.Condition{
 		Type:   string(gatewayv1.RouteConditionAccepted),
@@ -71,12 +79,16 @@ func TestPruneRouteParentStatusesPrunesDetachedParents(t *testing.T) {
 		Reason: string(gatewayv1.RouteReasonAccepted),
 	})
 
-	require.Len(t, route.Status.Parents, 2)
-	require.Equal(t, detachedParent, route.Status.Parents[0].ParentRef)
-	require.Equal(t, currentParent, route.Status.Parents[1].ParentRef)
+	require.Len(t, route.Status.Parents, 3, "merge alone keeps both detached statuses")
+	require.Equal(t, ourDetachedParent, route.Status.Parents[0].ParentRef, "merge alone keeps both detached statuses")
+	require.Equal(t, otherControllerDetachedParent, route.Status.Parents[1].ParentRef, "merge alone keeps both detached statuses")
+	require.Equal(t, currentParent, route.Status.Parents[2].ParentRef, "merge alone keeps both detached statuses")
 
 	route.Status.Parents = pruneRouteParentStatuses(route.Status.Parents, route.Spec.ParentRefs)
 
-	require.Len(t, route.Status.Parents, 1)
-	require.Equal(t, currentParent, route.Status.Parents[0].ParentRef)
+	require.Len(t, route.Status.Parents, 2, "prune removes only the detached Cilium-owned status")
+	require.Equal(t, otherControllerDetachedParent, route.Status.Parents[0].ParentRef, "prune removes only the detached Cilium-owned status")
+	require.Equal(t, gatewayv1.GatewayController("example.com/other-gateway-controller"), route.Status.Parents[0].ControllerName, "prune removes only the detached Cilium-owned status")
+	require.Equal(t, currentParent, route.Status.Parents[1].ParentRef, "prune removes only the detached Cilium-owned status")
+	require.Equal(t, gatewayv1.GatewayController(helpers.CiliumDefaultControllerName), route.Status.Parents[1].ControllerName, "prune removes only the detached Cilium-owned status")
 }


### PR DESCRIPTION
Route status reconciliation currently merges conditions into existing
status.parents entries but does not remove Cilium-owned parent statuses
for parentRefs that were removed from the route spec.

This leaves stale parent status on HTTPRoute, TLSRoute, and GRPCRoute
resources after detaching them from a Gateway. The same issue also
affects the GAMMA HTTPRoute/GRPCRoute status paths.

This commit fixes this by pruning Cilium-owned RouteParentStatus entries
that are no longer present in spec.parentRefs before recomputing route status.