### PR TITLE
kvstore: Don't set fake pod CIDRs for remote nodes

### DIFF
--- a/pkg/node/store/store.go
+++ b/pkg/node/store/store.go
@@ -10,9 +10,11 @@ import (
 	"path"
 
 	"github.com/cilium/cilium/pkg/defaults"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -167,7 +169,7 @@ func (nr *NodeRegistrar) RegisterNode(ctx context.Context, logger *slog.Logger, 
 		return err
 	}
 
-	err = nodeStore.UpdateLocalKeySync(ctx, n.DeepCopy())
+	err = nodeStore.UpdateLocalKeySync(ctx, copyForRemoteNodes(n))
 	if err != nil {
 		nodeStore.Release()
 		return err
@@ -183,5 +185,23 @@ func (nr *NodeRegistrar) RegisterNode(ctx context.Context, logger *slog.Logger, 
 // UpdateLocalKeySync synchronizes the local key for the node using the
 // SharedStore.
 func (nr *NodeRegistrar) UpdateLocalKeySync(ctx context.Context, n *nodeTypes.Node) error {
-	return nr.SharedStore.UpdateLocalKeySync(ctx, n.DeepCopy())
+	return nr.SharedStore.UpdateLocalKeySync(ctx, copyForRemoteNodes(n))
+}
+
+func copyForRemoteNodes(n *nodeTypes.Node) *nodeTypes.Node {
+	node := n.DeepCopy()
+	switch option.Config.IPAM {
+	case ipamOption.IPAMKubernetes, ipamOption.IPAMClusterPool, ipamOption.IPAMMultiPool:
+		// Keep the PodCIDRs as they are valid.
+	default:
+		// Strip the PodCIDRs on non-podCIDR based IPAM modes (e.g. ENI, Azure, AlibabaCloud). In
+		// those cases, the IPv4/IPv6AllocRange is auto-generated and otherwise unused, so it does
+		// not make sense to copy it to the kvstore.
+		// See NodeDiscovery.mutateNodeResource() for the equivalent CRD mode logic.
+		node.IPv4AllocCIDR = nil
+		node.IPv4SecondaryAllocCIDRs = nil
+		node.IPv6AllocCIDR = nil
+		node.IPv6SecondaryAllocCIDRs = nil
+	}
+	return node
 }

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -343,6 +343,7 @@ func (n *NodeDiscovery) mutateNodeResource(ctx context.Context, nodeResource *ci
 		// is no such thing as a podCIDR to begin with. In those cases, the
 		// IPv4/IPv6AllocRange is auto-generated and otherwise unused, so it does not
 		// make sense to copy it into the CiliumNode it either.
+		// See NodeRegistrar.RegisterNode() for the equivalent kvstore mode logic.
 		nodeResource.Spec.IPAM.PodCIDRs = []string{}
 		if cidr := ln.IPv4AllocCIDR; cidr != nil {
 			nodeResource.Spec.IPAM.PodCIDRs = append(nodeResource.Spec.IPAM.PodCIDRs, cidr.String())


### PR DESCRIPTION
This commit is the kvstore mode counterpart of 15685580c9a4 ("ipam: Fix invalid PodCIDR in CiliumNode in ENI/Azure/MultiPool mode") which fixed this bug in the CRD mode case.

In kvstore mode, we are currently announcing the internal, auto-generated pod CIDRs of the local node to all remote nodes via the kvstore. In IPAM modes without a pod CIDR (ex., ENI, Azure, AlibabaCloud), this results in a fake pod CIDR (10.x.0.0/16) being announced to other nodes.

Since 731e182e166d ("node/manager: Store node allocation CIDRs into ipcache"), this pod CIDR is written in the ipcache, as a fallback entry. That fallback ipcache entry can cause issues when the fake CIDR clashes with existing entities outside the cluster.

For example, it will cause packet drops and prevent connectivity to such entities if IPsec or WireGuard is enabled. In those cases, the fallback ipcache entry carries the encryption key reference. Outgoing packets will thus be marked for encryption but the corresponding IPsec or WireGuard configuration will be missing, leading to packet drops.

Fixes: https://github.com/cilium/cilium/pull/38483.
Fixes: https://github.com/cilium/cilium/pull/26663.