### PR TITLE
gh: ztunnel-e2e: set commit status to pending on main job

### DIFF
--- a/.github/workflows/conformance-ztunnel-e2e.yaml
+++ b/.github/workflows/conformance-ztunnel-e2e.yaml
@@ -107,6 +107,11 @@ jobs:
 
     timeout-minutes: 75
     steps:
+      - name: Set commit status to pending
+        uses: cilium/cilium/.github/actions/set-commit-status@main # main
+        with:
+          sha: ${{ inputs.SHA || github.sha }}
+
       - name: Collect Workflow Telemetry
         uses: cilium/workflow-telemetry-action@b1a318f80a08acede58027afe1455d037379966f # v2.2.0
         with:


### PR DESCRIPTION
Match 9145cd874906 (".github/workflows: set commit status to pending on main job").