### PR TITLE
gateway-api: reconcile ListenerSet listeners for HTTPRoutes

### DIFF
--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -48,6 +48,7 @@ var Cell = cell.Module(
 		EnableGatewayAPIProxyProtocol:          false,
 		EnableGatewayAPIAppProtocol:            false,
 		EnableGatewayAPIAlpn:                   false,
+		EnableGatewayAPIListenerSet:            false,
 		GatewayAPIServiceExternalTrafficPolicy: "Cluster",
 		GatewayAPISecretsNamespace:             "cilium-secrets",
 		GatewayAPIXffNumTrustedHops:            0,
@@ -186,6 +187,7 @@ type gatewayApiConfig struct {
 	EnableGatewayAPIProxyProtocol          bool
 	EnableGatewayAPIAppProtocol            bool
 	EnableGatewayAPIAlpn                   bool
+	EnableGatewayAPIListenerSet            bool
 	GatewayAPIServiceExternalTrafficPolicy string
 	GatewayAPISecretsNamespace             string
 	GatewayAPIXffNumTrustedHops            uint32
@@ -199,6 +201,7 @@ func (r gatewayApiConfig) Flags(flags *pflag.FlagSet) {
 	flags.Bool("enable-gateway-api-proxy-protocol", r.EnableGatewayAPIProxyProtocol, "Enable proxy protocol for all GatewayAPI listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.")
 	flags.Bool("enable-gateway-api-app-protocol", r.EnableGatewayAPIAppProtocol, "Enables Backend Protocol selection (GEP-1911) for Gateway API via appProtocol")
 	flags.Bool("enable-gateway-api-alpn", r.EnableGatewayAPIAlpn, "Enables exposing ALPN with HTTP2 and HTTP/1.1 support for Gateway API")
+	flags.Bool("enable-gateway-api-listener-set", r.EnableGatewayAPIListenerSet, "Enables ListenerSet support (Gateway API experimental) for Gateway API")
 	flags.Uint32("gateway-api-xff-num-trusted-hops", r.GatewayAPIXffNumTrustedHops, "The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.")
 	flags.String("gateway-api-service-externaltrafficpolicy", r.GatewayAPIServiceExternalTrafficPolicy, "Kubernetes LoadBalancer Service externalTrafficPolicy for all Gateway instances.")
 	flags.String("gateway-api-secrets-namespace", r.GatewayAPISecretsNamespace, "Namespace having tls secrets used by CEC for Gateway API")
@@ -282,6 +285,7 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 		gatewayAPITranslator,
 		params.Logger,
 		installedKinds,
+		params.GatewayApiConfig.EnableGatewayAPIListenerSet,
 	); err != nil {
 		return fmt.Errorf("failed to create gateway controller: %w", err)
 	}
@@ -419,12 +423,12 @@ func checkCRDs(ctx context.Context, clientset k8sClient.Clientset, logger *slog.
 
 // registerReconcilers registers Gateway API reconcilers to the controller-runtime library manager.
 // optionalKinds are previously autodetected based on what CRDs are present in the cluster.
-func registerReconcilers(mgr ctrlRuntime.Manager, translator translation.Translator, logger *slog.Logger, installedCRDs []schema.GroupVersionKind) error {
+func registerReconcilers(mgr ctrlRuntime.Manager, translator translation.Translator, logger *slog.Logger, installedCRDs []schema.GroupVersionKind, enableListenerSet bool) error {
 	requiredReconcilers := []interface {
 		SetupWithManager(mgr ctrlRuntime.Manager) error
 	}{
 		newGatewayClassReconciler(mgr, logger),
-		newGatewayReconciler(mgr, translator, logger, installedCRDs),
+		newGatewayReconciler(mgr, translator, logger, installedCRDs, enableListenerSet),
 		newGammaReconciler(mgr, translator, logger),
 		newGatewayClassConfigReconciler(mgr, logger),
 	}

--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -41,19 +41,21 @@ type gatewayReconciler struct {
 	Scheme     *runtime.Scheme
 	translator translation.Translator
 
-	logger        *slog.Logger
-	installedCRDs []schema.GroupVersionKind
+	logger            *slog.Logger
+	installedCRDs     []schema.GroupVersionKind
+	enableListenerSet bool
 }
 
-func newGatewayReconciler(mgr ctrl.Manager, translator translation.Translator, logger *slog.Logger, installedCRDs []schema.GroupVersionKind) *gatewayReconciler {
+func newGatewayReconciler(mgr ctrl.Manager, translator translation.Translator, logger *slog.Logger, installedCRDs []schema.GroupVersionKind, enableListenerSet bool) *gatewayReconciler {
 	scopedLog := logger.With(logfields.Controller, gateway)
 
 	return &gatewayReconciler{
-		Client:        mgr.GetClient(),
-		Scheme:        mgr.GetScheme(),
-		translator:    translator,
-		logger:        scopedLog,
-		installedCRDs: installedCRDs,
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		translator:        translator,
+		logger:            scopedLog,
+		installedCRDs:     installedCRDs,
+		enableListenerSet: enableListenerSet,
 	}
 }
 
@@ -77,6 +79,12 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	} {
 		if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.HTTPRoute{}, indexName, indexerFunc); err != nil {
 			return fmt.Errorf("failed to setup field indexer %q: %w", indexName, err)
+		}
+	}
+
+	if r.enableListenerSet {
+		if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.HTTPRoute{}, indexers.ListenerSetHTTPRouteIndex, indexers.IndexHTTPRouteByListenerSet); err != nil {
+			return fmt.Errorf("failed to setup field indexer %q: %w", indexers.ListenerSetHTTPRouteIndex, err)
 		}
 	}
 
@@ -155,6 +163,11 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if serviceImportEnabled {
 		// Watch for changes to Backend Service Imports
 		gatewayBuilder = gatewayBuilder.Watches(&mcsapiv1beta1.ServiceImport{}, watchhandlers.EnqueueRequestForBackendServiceImport(r.Client, *r.logger))
+	}
+
+	if r.enableListenerSet {
+		// Watch ListenerSet linked to Gateway
+		gatewayBuilder = gatewayBuilder.Watches(&gatewayv1.ListenerSet{}, watchhandlers.EnqueueRequestForOwningListenerSet(r.Client, r.logger, helpers.CiliumDefaultControllerName))
 	}
 
 	return gatewayBuilder.Complete(r)

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -40,6 +40,39 @@ import (
 	"github.com/cilium/cilium/pkg/shortener"
 )
 
+type listenerSetResult struct {
+	ls       *gatewayv1.ListenerSet
+	accepted bool
+	reason   gatewayv1.ListenerSetConditionReason
+	message  string
+	routes   []gatewayv1.HTTPRoute
+}
+
+var gatewayParentChecks = []routechecks.CheckWithParentFunc{
+	routechecks.CheckGatewayMatchingProtocol,
+	routechecks.CheckGatewayRouteKindAllowed,
+	routechecks.CheckGatewayMatchingPorts,
+	routechecks.CheckGatewayMatchingHostnames,
+	routechecks.CheckGatewayMatchingSection,
+	routechecks.CheckGatewayAllowedForNamespace,
+}
+
+var listenerSetParentChecks = []routechecks.CheckWithParentFunc{
+	routechecks.CheckListenerSetMatchingProtocol,
+	routechecks.CheckListenerSetRouteKindAllowed,
+	routechecks.CheckListenerSetMatchingPorts,
+	routechecks.CheckListenerSetMatchingHostnames,
+	routechecks.CheckListenerSetMatchingSection,
+	routechecks.CheckListenerSetAllowedForNamespace,
+}
+
+var backendChecks = []routechecks.CheckWithParentFunc{
+	routechecks.CheckAgainstCrossNamespaceBackendReferences,
+	routechecks.CheckBackend,
+	routechecks.CheckHasServiceImportSupport,
+	routechecks.CheckBackendIsExistingService,
+}
+
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 //
@@ -188,6 +221,16 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return controllerruntime.Fail(err)
 	}
 
+	var listenerSets []listenerSetResult
+
+	if r.enableListenerSet {
+		var err error
+		if listenerSets, err = r.gatherListenerSets(ctx, gw); err != nil {
+			scopedLog.ErrorContext(ctx, "Unable to gather ListenerSets", logfields.Error, err)
+			return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+		}
+	}
+
 	gatewayClassConfig := r.getGatewayClassConfig(ctx, gwc)
 	httpListeners, tlsPassthroughListeners := ingestion.GatewayAPI(scopedLog, ingestion.Input{
 		GatewayClass:        *gwc,
@@ -200,6 +243,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		ServiceImports:      serviceImportsList.Items,
 		ReferenceGrants:     grants.Items,
 		BackendTLSPolicyMap: btlspMap,
+		ListenerSets:        listenerSetInputs(listenerSets),
 	})
 
 	validListener, err := r.setListenerStatus(ctx, gw, httpRouteList, tlsRouteList, grpcRouteList)
@@ -214,9 +258,13 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		scopedLog.ErrorContext(ctx, "No Accepted Listeners for Gateway", logfields.Error, err)
 		setGatewayAccepted(gw, false, "No Accepted Listeners", gatewayv1.GatewayReasonListenersNotValid)
 		setGatewayProgrammed(gw, metav1.ConditionFalse, "No Accepted Listeners", gatewayv1.GatewayReasonListenersNotValid)
+		if lsErr := r.updateListenerSetStatuses(ctx, listenerSets, false); lsErr != nil {
+			scopedLog.ErrorContext(ctx, "Unable to update ListenerSet statuses", logfields.Error, lsErr)
+		}
 		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
 	setGatewayAccepted(gw, true, "Gateway successfully scheduled", gatewayv1.GatewayReasonAccepted)
+	setGatewayAttachedListenerSets(gw, listenerSets)
 
 	// Step 3: Translate the listeners into Cilium model
 	cec, svc, ep, err := r.translator.Translate(&model.Model{
@@ -258,6 +306,11 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		scopedLog.ErrorContext(ctx, "Unable to ensure CiliumEnvoyConfig", logfields.Error, err)
 		setGatewayAccepted(gw, false, "Unable to ensure CEC resource", gatewayv1.GatewayReasonNoResources)
 		setGatewayProgrammed(gw, metav1.ConditionFalse, "Unable to create CEC resource", gatewayv1.GatewayReasonNoResources)
+		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+	}
+
+	if err := r.updateListenerSetStatuses(ctx, listenerSets, true); err != nil {
+		scopedLog.ErrorContext(ctx, "Unable to update ListenerSet statuses", logfields.Error, err)
 		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
 
@@ -810,15 +863,28 @@ func (r *gatewayReconciler) verifyGatewayStaticAddresses(gw *gatewayv1.Gateway) 
 // Uses the helpers.Input interface to ensure that this still applies as new types are added.
 func (r *gatewayReconciler) runCommonRouteChecks(input routechecks.Input, parentRefs []gatewayv1.ParentReference, objNamespace string) error {
 	for _, parent := range parentRefs {
-		// If this parentRef is not a Gateway parentRef, skip it.
-		if !helpers.IsGateway(parent) {
+		var checks []routechecks.CheckWithParentFunc
+
+		switch {
+		case helpers.IsGateway(parent):
+			if !r.parentIsMatchingGateway(parent, objNamespace) {
+				continue
+			}
+
+			checks = append(checks, gatewayParentChecks...)
+		case r.enableListenerSet && helpers.IsListenerSet(parent) && input.GetGVK().Kind == "HTTPRoute": // TODO: gate behind the ListenerSet feature flag
+			if !r.parentIsMatchingListenerSet(parent, objNamespace) {
+				continue
+			}
+
+			checks = append(checks, listenerSetParentChecks...)
+		default:
+			// Skip all other parent types.
 			continue
 		}
 
-		// Similarly, if this Gateway is not a matching one, skip it.
-		if !r.parentIsMatchingGateway(parent, objNamespace) {
-			continue
-		}
+		// Ensure backend checks run after parent checks
+		checks = append(checks, backendChecks...)
 
 		// set Accepted to okay, this wil be overwritten in checks if needed
 		input.SetParentCondition(parent, metav1.Condition{
@@ -836,43 +902,19 @@ func (r *gatewayReconciler) runCommonRouteChecks(input routechecks.Input, parent
 			Message: "Service reference is valid",
 		})
 
-		// run the Gateway validators
-		for _, fn := range []routechecks.CheckWithParentFunc{
-			routechecks.CheckGatewayMatchingProtocol,
-			routechecks.CheckGatewayRouteKindAllowed,
-			routechecks.CheckGatewayMatchingPorts,
-			routechecks.CheckGatewayMatchingHostnames,
-			routechecks.CheckGatewayMatchingSection,
-			routechecks.CheckGatewayAllowedForNamespace,
-		} {
-			continueCheck, err := fn(input, parent)
-			if err != nil {
-				return fmt.Errorf("failed to apply Gateway check: %w", err)
-			}
-
-			if !continueCheck {
-				break
-			}
-		}
-
 		// Run the Rule validators, these need to be run per-parent so that we
 		// don't update status for parents we don't own.
-		for _, fn := range []routechecks.CheckWithParentFunc{
-			routechecks.CheckAgainstCrossNamespaceBackendReferences,
-			routechecks.CheckBackend,
-			routechecks.CheckHasServiceImportSupport,
-			routechecks.CheckBackendIsExistingService,
-		} {
+		for _, fn := range checks {
 			continueCheck, err := fn(input, parent)
+
 			if err != nil {
-				return fmt.Errorf("failed to apply Backend check: %w", err)
+				return fmt.Errorf("failed to apply route check: %w", err)
 			}
 
 			if !continueCheck {
 				break
 			}
 		}
-
 	}
 
 	return nil
@@ -890,6 +932,31 @@ func (r *gatewayReconciler) parentIsMatchingGateway(parent gatewayv1.ParentRefer
 	}, gw); err != nil {
 		return false
 	}
+	return hasMatchingControllerFn(gw)
+}
+
+func (r *gatewayReconciler) parentIsMatchingListenerSet(parent gatewayv1.ParentReference, namespace string) bool {
+	if !helpers.IsListenerSet(parent) {
+		return false
+	}
+
+	ls := &gatewayv1.ListenerSet{}
+	if err := r.Client.Get(context.Background(), types.NamespacedName{
+		Namespace: helpers.NamespaceDerefOr(parent.Namespace, namespace),
+		Name:      string(parent.Name),
+	}, ls); err != nil {
+		return false
+	}
+
+	gw := &gatewayv1.Gateway{}
+	if err := r.Client.Get(context.Background(), types.NamespacedName{
+		Namespace: helpers.NamespaceDerefOr(ls.Spec.ParentRef.Namespace, ls.GetNamespace()),
+		Name:      string(ls.Spec.ParentRef.Name),
+	}, gw); err != nil {
+		return false
+	}
+
+	hasMatchingControllerFn := helpers.GatewayHasMatchingControllerFn(context.Background(), r.Client, helpers.CiliumDefaultControllerName, r.logger)
 	return hasMatchingControllerFn(gw)
 }
 
@@ -1330,4 +1397,141 @@ func (r *gatewayReconciler) updateBackendTLSPolicyStatus(ctx context.Context, sc
 	}
 	scopedLog.Debug("BackendTLSPolicy status", backendTLSPolicy, types.NamespacedName{Name: original.Name, Namespace: original.Namespace})
 	return r.Client.Status().Update(ctx, new)
+}
+func (r *gatewayReconciler) gatherListenerSets(ctx context.Context, gw *gatewayv1.Gateway) ([]listenerSetResult, error) {
+	lsList := &gatewayv1.ListenerSetList{}
+	if err := r.Client.List(ctx, lsList); err != nil {
+		return nil, err
+	}
+
+	var results []listenerSetResult
+	for i := range lsList.Items {
+		ls := &lsList.Items[i]
+		if !listenerSetTargetsGateway(ls, gw) {
+			continue // ListenerSet is not pointing at our Gateway. Skip it.
+		}
+
+		res := listenerSetResult{ls: ls}
+
+		allowed, err := r.listenerSetAllowedByGateway(ctx, gw, ls.GetNamespace())
+		if err != nil {
+			return nil, err
+		}
+		if !allowed {
+			res.accepted = false
+			res.reason = gatewayv1.ListenerSetReasonNotAllowed
+			res.message = "ListenerSet is not allowed to attach to this Gateway"
+			results = append(results, res)
+			continue
+		}
+
+		hrList := &gatewayv1.HTTPRouteList{}
+		if err := r.Client.List(ctx, hrList, &client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector(indexers.ListenerSetHTTPRouteIndex, client.ObjectKeyFromObject(ls).String()),
+		}); err != nil {
+			return nil, err
+		}
+
+		for j := range hrList.Items {
+			route := hrList.Items[j]
+
+			if !helpers.IsParentAttachable(ctx, ls, &route, route.Status.Parents) {
+				continue
+			}
+
+			res.routes = append(res.routes, route)
+		}
+
+		res.accepted = true
+		res.reason = gatewayv1.ListenerSetReasonAccepted
+		res.message = "ListenerSet Accepted"
+		results = append(results, res)
+	}
+
+	return results, nil
+}
+
+func listenerSetInputs(results []listenerSetResult) []ingestion.ListenerSetInput {
+	var inputs []ingestion.ListenerSetInput
+	for _, res := range results {
+		if !res.accepted {
+			continue
+		}
+		inputs = append(inputs, ingestion.ListenerSetInput{ListenerSet: *res.ls, HTTPRoutes: res.routes})
+	}
+	return inputs
+}
+
+func listenerSetTargetsGateway(ls *gatewayv1.ListenerSet, gw *gatewayv1.Gateway) bool {
+	pr := ls.Spec.ParentRef
+
+	if pr.Kind != nil && *pr.Kind != "Gateway" {
+		return false
+	}
+
+	if pr.Group != nil && *pr.Group != gatewayv1.GroupName {
+		return false
+	}
+
+	ns := ls.GetNamespace()
+
+	if pr.Namespace != nil {
+		ns = string(*pr.Namespace)
+	}
+
+	return string(pr.Name) == gw.GetName() && ns == gw.GetNamespace()
+}
+
+func filterHTTPRoutesByListenerSetEntry(ls *gatewayv1.ListenerSet, entry gatewayv1.ListenerEntry, routes []gatewayv1.HTTPRoute) []gatewayv1.HTTPRoute {
+	var filtered []gatewayv1.HTTPRoute
+	for _, route := range routes {
+		for _, parent := range route.Spec.ParentRefs {
+			ns := helpers.NamespaceDerefOr(parent.Namespace, route.GetNamespace())
+			if !helpers.IsListenerSet(parent) || string(parent.Name) != ls.GetName() || ns != ls.GetNamespace() {
+				continue
+			}
+			if parent.SectionName == nil || *parent.SectionName == entry.Name {
+				filtered = append(filtered, route)
+				break
+			}
+		}
+	}
+	return filtered
+}
+
+// listenerSetAllowedByGateway reports whether the Gateway's spec.allowedListeners
+// permits this ListenerSet (which lives in lsNamespace) to attach.
+// Default (nil / From: None) => not allowed.
+func (r *gatewayReconciler) listenerSetAllowedByGateway(ctx context.Context, gw *gatewayv1.Gateway, lsNamespace string) (bool, error) {
+	al := gw.Spec.AllowedListeners
+	if al == nil || al.Namespaces == nil || al.Namespaces.From == nil {
+		return false, nil // default: None
+	}
+	switch *al.Namespaces.From {
+	case gatewayv1.NamespacesFromNone:
+		return false, nil
+	case gatewayv1.NamespacesFromAll:
+		return true, nil
+	case gatewayv1.NamespacesFromSame:
+		return lsNamespace == gw.GetNamespace(), nil
+	case gatewayv1.NamespacesFromSelector:
+		if al.Namespaces.Selector == nil {
+			return false, nil
+		}
+		selector, err := metav1.LabelSelectorAsSelector(al.Namespaces.Selector)
+		if err != nil {
+			return false, fmt.Errorf("invalid allowedListeners selector: %w", err)
+		}
+		nsList := &corev1.NamespaceList{}
+		if err := r.Client.List(ctx, nsList, client.MatchingLabelsSelector{Selector: selector}); err != nil {
+			return false, fmt.Errorf("unable to list namespaces: %w", err)
+		}
+		for _, ns := range nsList.Items {
+			if ns.Name == lsNamespace {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+	return false, nil
 }

--- a/operator/pkg/gateway-api/helpers/listenerset.go
+++ b/operator/pkg/gateway-api/helpers/listenerset.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package helpers
+
+import gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+// ListenerSetListeners projects a ListenerSet's entries onto the Gateway Listener
+// shape so the existing listener helpers/checks can be reused unchanged.
+func ListenerSetListeners(ls *gatewayv1.ListenerSet) []gatewayv1.Listener {
+	listeners := make([]gatewayv1.Listener, 0, len(ls.Spec.Listeners))
+
+	for _, entry := range ls.Spec.Listeners {
+		listeners = append(listeners, gatewayv1.Listener{
+			Name:          entry.Name,
+			Hostname:      entry.Hostname,
+			Port:          entry.Port,
+			Protocol:      entry.Protocol,
+			TLS:           entry.TLS,
+			AllowedRoutes: entry.AllowedRoutes,
+		})
+	}
+
+	return listeners
+}

--- a/operator/pkg/gateway-api/helpers/types.go
+++ b/operator/pkg/gateway-api/helpers/types.go
@@ -19,6 +19,7 @@ const (
 	kindServiceImport = "ServiceImport"
 	kindSecret        = "Secret"
 	kindConfigMap     = "ConfigMap"
+	kindListenerSet   = "ListenerSet"
 
 	GatewayClassKind      string = "gatewayclasses"
 	GatewayKind           string = "gateways"
@@ -39,6 +40,10 @@ func IsGateway(parent gatewayv1.ParentReference) bool {
 func IsGammaService(parent gatewayv1.ParentReference) bool {
 	return parent.Kind != nil && *parent.Kind == kindService &&
 		parent.Group != nil && (*parent.Group == corev1.GroupName || *parent.Group == "core")
+}
+
+func IsListenerSet(parent gatewayv1.ParentReference) bool {
+	return parent.Kind != nil && *parent.Kind == kindListenerSet && parent.Group != nil && *parent.Group == gatewayv1.GroupName
 }
 
 func IsGammaServiceEqual(parent gatewayv1.ParentReference, gammaService *corev1.Service, objNamespace string) bool {

--- a/operator/pkg/gateway-api/indexers/httproute.go
+++ b/operator/pkg/gateway-api/indexers/httproute.go
@@ -35,6 +35,24 @@ func IndexHTTPRouteByGateway(rawObj client.Object) []string {
 	return gateways
 }
 
+// IndexHTTPRouteByListenerSet indexes an HTTPRoute by the ListenerSet parents it references.
+func IndexHTTPRouteByListenerSet(rawObj client.Object) []string {
+	hr := rawObj.(*gatewayv1.HTTPRoute)
+	var listenerSets []string
+	for _, parent := range hr.Spec.ParentRefs {
+		if !helpers.IsListenerSet(parent) {
+			continue
+		}
+		listenerSets = append(listenerSets,
+			types.NamespacedName{
+				Namespace: helpers.NamespaceDerefOr(parent.Namespace, hr.Namespace),
+				Name:      string(parent.Name),
+			}.String(),
+		)
+	}
+	return listenerSets
+}
+
 // IndexHTTPRouteByGammaService is a client.IndexerFunc that takes a single HTTPRoute and returns all
 // referenced Service object full names (`namespace/name`) to add to the relevant index.
 func IndexHTTPRouteByGammaService(rawObj client.Object) []string {

--- a/operator/pkg/gateway-api/indexers/indexnames.go
+++ b/operator/pkg/gateway-api/indexers/indexnames.go
@@ -13,6 +13,9 @@ const (
 	// Indexes HTTPRoutes by all the Gateway parents referenced in the object.
 	GatewayHTTPRouteIndex = "gatewayHTTPRouteIndex"
 
+	// Indexes HTTPRoutes by all the ListenerSet parents referenced in the object.
+	ListenerSetHTTPRouteIndex = "listenerSetHTTPRouteIndex"
+
 	// Indexes Gateways and records if the Gateway is relevant for Cilium.
 	ImplementationGatewayIndex = "implementationGatewayIndex"
 

--- a/operator/pkg/gateway-api/listenerset_status.go
+++ b/operator/pkg/gateway-api/listenerset_status.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gateway_api
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// ListenerSetReasonParentNotProgrammed: spec-documented Programmed=False reason
+// ([listenerset_types.go] mentions it) for which upstream defines no constant.
+const listenerSetReasonParentNotProgrammed gatewayv1.ListenerSetConditionReason = "ParentNotProgrammed"
+
+func setListenerSetAccepted(ls *gatewayv1.ListenerSet, accepted bool, msg string, reason gatewayv1.ListenerSetConditionReason) {
+	status := metav1.ConditionFalse
+
+	if accepted {
+		status = metav1.ConditionTrue
+	}
+
+	ls.Status.Conditions = merge(ls.Status.Conditions, metav1.Condition{
+		Type:               string(gatewayv1.ListenerSetConditionAccepted),
+		Status:             status,
+		Reason:             string(reason),
+		Message:            msg,
+		ObservedGeneration: ls.GetGeneration(),
+		LastTransitionTime: metav1.NewTime(time.Now()),
+	})
+}
+
+func setListenerSetProgrammed(ls *gatewayv1.ListenerSet, status metav1.ConditionStatus, msg string, reason gatewayv1.ListenerSetConditionReason) {
+	ls.Status.Conditions = merge(ls.Status.Conditions, metav1.Condition{
+		Type:               string(gatewayv1.ListenerSetConditionProgrammed),
+		Status:             status,
+		Reason:             string(reason),
+		Message:            msg,
+		ObservedGeneration: ls.GetGeneration(),
+		LastTransitionTime: metav1.NewTime(time.Now()),
+	})
+}
+
+func setListenerSetEntryStatuses(ls *gatewayv1.ListenerSet, programmed metav1.ConditionStatus, routes []gatewayv1.HTTPRoute) {
+	for _, entry := range ls.Spec.Listeners {
+		acceptedCondition := metav1.Condition{
+			Type:               string(gatewayv1.ListenerEntryConditionAccepted),
+			Status:             metav1.ConditionTrue,
+			Reason:             string(gatewayv1.ListenerEntryReasonAccepted),
+			Message:            "Listener Accepted",
+			ObservedGeneration: ls.GetGeneration(),
+			LastTransitionTime: metav1.NewTime(time.Now()),
+		}
+		resolvedRefsCondition := metav1.Condition{
+			Type:               string(gatewayv1.ListenerEntryConditionResolvedRefs),
+			Status:             metav1.ConditionTrue,
+			Reason:             string(gatewayv1.ListenerEntryReasonResolvedRefs),
+			Message:            "Resolved Refs",
+			ObservedGeneration: ls.GetGeneration(),
+			LastTransitionTime: metav1.NewTime(time.Now()),
+		}
+
+		programmedReason := gatewayv1.ListenerEntryReasonProgrammed
+		programmedMessage := "Listener Programmed"
+		if programmed != metav1.ConditionTrue {
+			programmedReason = gatewayv1.ListenerEntryReasonPending
+			programmedMessage = "Listener not yet programmed"
+		}
+		programmedCondition := metav1.Condition{
+			Type:               string(gatewayv1.ListenerEntryConditionProgrammed),
+			Status:             programmed,
+			Reason:             string(programmedReason),
+			Message:            programmedMessage,
+			ObservedGeneration: ls.GetGeneration(),
+			LastTransitionTime: metav1.NewTime(time.Now()),
+		}
+
+		supportedKinds := getSupportedRouteKinds(entry.Protocol)
+		attachedRoutes := int32(len(filterHTTPRoutesByListenerSetEntry(ls, entry, routes)))
+
+		found := false
+		for i := range ls.Status.Listeners {
+			if ls.Status.Listeners[i].Name == entry.Name {
+				ls.Status.Listeners[i].SupportedKinds = supportedKinds
+				ls.Status.Listeners[i].AttachedRoutes = attachedRoutes
+				ls.Status.Listeners[i].Conditions = merge(ls.Status.Listeners[i].Conditions,
+					acceptedCondition, resolvedRefsCondition, programmedCondition)
+				found = true
+				break
+			}
+		}
+		if !found {
+			ls.Status.Listeners = append(ls.Status.Listeners, gatewayv1.ListenerEntryStatus{
+				Name:           entry.Name,
+				SupportedKinds: supportedKinds,
+				AttachedRoutes: attachedRoutes,
+				Conditions:     merge(nil, acceptedCondition, resolvedRefsCondition, programmedCondition),
+			})
+		}
+	}
+
+	// Prune status entries whose listener no longer exists in the spec.
+	var pruned []gatewayv1.ListenerEntryStatus
+	for _, es := range ls.Status.Listeners {
+		for _, entry := range ls.Spec.Listeners {
+			if es.Name == entry.Name {
+				pruned = append(pruned, es)
+				break
+			}
+		}
+	}
+	ls.Status.Listeners = pruned
+}
+
+func setGatewayAttachedListenerSets(gw *gatewayv1.Gateway, results []listenerSetResult) {
+	var n int32
+	for _, res := range results {
+		if res.accepted {
+			n++
+		}
+	}
+	gw.Status.AttachedListenerSets = &n
+}
+
+func (r *gatewayReconciler) updateListenerSetStatus(ctx context.Context, original, updated *gatewayv1.ListenerSet) error {
+	if cmp.Equal(original.Status, updated.Status, cmpopts.IgnoreFields(metav1.Condition{}, lastTransitionTime)) {
+		return nil
+	}
+
+	return r.Client.Status().Update(ctx, updated)
+}
+
+func (r *gatewayReconciler) updateListenerSetStatuses(ctx context.Context, results []listenerSetResult, gatewayAccepted bool) error {
+	for i := range results {
+		res := results[i]
+		original := res.ls.DeepCopy()
+		updated := res.ls
+
+		switch {
+		case !res.accepted:
+			// Rejected by the Gateway's allowedListeners gate.
+			setListenerSetAccepted(updated, false, res.message, res.reason)
+			setListenerSetProgrammed(updated, metav1.ConditionFalse, res.message, res.reason)
+			updated.Status.Listeners = nil // Rejected ListenerSet claims no per-entry status.
+
+		case !gatewayAccepted:
+			// Allowed to attach, but the parent Gateway itself is not Accepted.
+			setListenerSetAccepted(updated, false, "Parent Gateway is not Accepted", gatewayv1.ListenerSetReasonParentNotAccepted)
+			setListenerSetProgrammed(updated, metav1.ConditionFalse, "Parent Gateway is not Programmed", listenerSetReasonParentNotProgrammed)
+			updated.Status.Listeners = nil
+
+		default:
+			// Accepted and programmed (only reached after the CEC is ensured).
+			setListenerSetAccepted(updated, true, "ListenerSet Accepted", gatewayv1.ListenerSetReasonAccepted)
+			setListenerSetProgrammed(updated, metav1.ConditionTrue, "ListenerSet Programmed", gatewayv1.ListenerSetReasonProgrammed)
+			setListenerSetEntryStatuses(updated, metav1.ConditionTrue, res.routes)
+		}
+
+		if err := r.updateListenerSetStatus(ctx, original, updated); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/operator/pkg/gateway-api/routechecks/grpcroute.go
+++ b/operator/pkg/gateway-api/routechecks/grpcroute.go
@@ -114,6 +114,10 @@ func (g *GRPCRouteInput) GetGateway(parent gatewayv1.ParentReference) (*gatewayv
 	return gw, nil
 }
 
+func (g *GRPCRouteInput) GetListenerSet(parent gatewayv1.ParentReference) (*gatewayv1.ListenerSet, error) {
+	return nil, fmt.Errorf("ListenerSet parent is not supported for GRPCRoute")
+}
+
 func (g *GRPCRouteInput) GetParentGammaService(parent gatewayv1.ParentReference) (*corev1.Service, error) {
 	if g.gammaServices == nil {
 		g.gammaServices = make(map[gatewayv1.ParentReference]*corev1.Service)

--- a/operator/pkg/gateway-api/routechecks/hostnames.go
+++ b/operator/pkg/gateway-api/routechecks/hostnames.go
@@ -9,9 +9,9 @@ import (
 	"github.com/cilium/cilium/operator/pkg/model"
 )
 
-func computeHosts[T ~string](gw *gatewayv1.Gateway, hostnames []T, excludeHostNames []T) []string {
+func computeHosts[T ~string](listeners []gatewayv1.Listener, hostnames []T, excludeHostNames []T) []string {
 	hosts := make([]string, 0, len(hostnames))
-	for _, listener := range gw.Spec.Listeners {
+	for _, listener := range listeners {
 		hosts = append(hosts, computeHostsForListener(&listener, hostnames, excludeHostNames)...)
 	}
 

--- a/operator/pkg/gateway-api/routechecks/httproute.go
+++ b/operator/pkg/gateway-api/routechecks/httproute.go
@@ -29,6 +29,7 @@ type HTTPRouteInput struct {
 	HTTPRoute *gatewayv1.HTTPRoute
 
 	gateways      map[gatewayv1.ParentReference]*gatewayv1.Gateway
+	listenerSets  map[gatewayv1.ParentReference]*gatewayv1.ListenerSet
 	gammaServices map[gatewayv1.ParentReference]*corev1.Service
 }
 
@@ -130,6 +131,31 @@ func (h *HTTPRouteInput) GetGateway(parent gatewayv1.ParentReference) (*gatewayv
 	h.gateways[parent] = gw
 
 	return gw, nil
+}
+
+func (h *HTTPRouteInput) GetListenerSet(parent gatewayv1.ParentReference) (*gatewayv1.ListenerSet, error) {
+	if h.listenerSets == nil {
+		h.listenerSets = make(map[gatewayv1.ParentReference]*gatewayv1.ListenerSet)
+	}
+
+	if ls, exists := h.listenerSets[parent]; exists {
+		return ls, nil
+	}
+
+	ns := helpers.NamespaceDerefOr(parent.Namespace, h.GetNamespace())
+	ls := &gatewayv1.ListenerSet{}
+
+	if err := h.Client.Get(h.Ctx, client.ObjectKey{Namespace: ns, Name: string(parent.Name)}, ls); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return nil, fmt.Errorf("error while getting listenerset: %w", err)
+		}
+
+		return nil, fmt.Errorf("listenerset %q does not exist: %w", parent.Name, err)
+	}
+
+	h.listenerSets[parent] = ls
+
+	return ls, nil
 }
 
 func (h *HTTPRouteInput) GetParentGammaService(parent gatewayv1.ParentReference) (*corev1.Service, error) {

--- a/operator/pkg/gateway-api/routechecks/input.go
+++ b/operator/pkg/gateway-api/routechecks/input.go
@@ -31,6 +31,7 @@ type Input interface {
 	GetGVK() schema.GroupVersionKind
 	GetGrants() []gatewayv1.ReferenceGrant
 	GetGateway(parent gatewayv1.ParentReference) (*gatewayv1.Gateway, error)
+	GetListenerSet(parent gatewayv1.ParentReference) (*gatewayv1.ListenerSet, error)
 	GetParentGammaService(parent gatewayv1.ParentReference) (*corev1.Service, error)
 	GetHostnames() []gatewayv1.Hostname
 	GetValidProtocols() []gatewayv1.ProtocolType

--- a/operator/pkg/gateway-api/routechecks/listenerset_checks.go
+++ b/operator/pkg/gateway-api/routechecks/listenerset_checks.go
@@ -11,13 +11,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 )
 
-func CheckGatewayAllowedForNamespace(input Input, parentRef gatewayv1.ParentReference) (bool, error) {
-	gw, err := input.GetGateway(parentRef)
+func CheckListenerSetAllowedForNamespace(input Input, parentRef gatewayv1.ParentReference) (bool, error) {
+	ls, err := input.GetListenerSet(parentRef)
 	if err != nil {
 		input.SetParentCondition(parentRef, metav1.Condition{
-			Type:    "Accepted",
+			Type:    string(gatewayv1.RouteConditionAccepted),
 			Status:  metav1.ConditionFalse,
 			Reason:  "Invalid" + input.GetGVK().Kind,
 			Message: err.Error(),
@@ -26,20 +28,19 @@ func CheckGatewayAllowedForNamespace(input Input, parentRef gatewayv1.ParentRefe
 		return false, nil
 	}
 
-	allListenerHostNames := GetAllListenerHostNames(gw.Spec.Listeners)
+	listeners := helpers.ListenerSetListeners(ls)
+	allListenerHostNames := GetAllListenerHostNames(listeners)
 	hasNamespaceRestriction := false
-	for _, listener := range gw.Spec.Listeners {
+	for _, listener := range listeners {
 		if parentRef.SectionName != nil && listener.Name != *parentRef.SectionName {
 			continue
 		}
 		if parentRef.Port != nil && listener.Port != *parentRef.Port {
 			continue
 		}
-
 		if listener.Hostname != nil && len(computeHostsForListener(&listener, input.GetHostnames(), allListenerHostNames)) == 0 {
 			continue
 		}
-
 		if listener.AllowedRoutes == nil || listener.AllowedRoutes.Namespaces == nil {
 			continue
 		}
@@ -49,7 +50,7 @@ func CheckGatewayAllowedForNamespace(input Input, parentRef gatewayv1.ParentRefe
 		case gatewayv1.NamespacesFromAll:
 			return true, nil
 		case gatewayv1.NamespacesFromSame:
-			if input.GetNamespace() == gw.GetNamespace() {
+			if input.GetNamespace() == ls.GetNamespace() {
 				return true, nil
 			}
 		case gatewayv1.NamespacesFromSelector:
@@ -66,22 +67,23 @@ func CheckGatewayAllowedForNamespace(input Input, parentRef gatewayv1.ParentRefe
 			}
 		}
 	}
+
 	if hasNamespaceRestriction {
 		input.SetParentCondition(parentRef, metav1.Condition{
-			Type:    "Accepted",
+			Type:    string(gatewayv1.RouteConditionAccepted),
 			Status:  metav1.ConditionFalse,
 			Reason:  string(gatewayv1.RouteReasonNotAllowedByListeners),
-			Message: input.GetGVK().Kind + " is not allowed to attach to this Gateway due to namespace restrictions",
+			Message: input.GetGVK().Kind + " is not allowed to attach to this ListenerSet due to namespace restrictions",
 		})
 	}
 	return false, nil
 }
 
-func CheckGatewayRouteKindAllowed(input Input, parentRef gatewayv1.ParentReference) (bool, error) {
-	gw, err := input.GetGateway(parentRef)
+func CheckListenerSetRouteKindAllowed(input Input, parentRef gatewayv1.ParentReference) (bool, error) {
+	ls, err := input.GetListenerSet(parentRef)
 	if err != nil {
 		input.SetParentCondition(parentRef, metav1.Condition{
-			Type:    "Accepted",
+			Type:    string(gatewayv1.RouteConditionAccepted),
 			Status:  metav1.ConditionFalse,
 			Reason:  "Invalid" + input.GetGVK().Kind,
 			Message: err.Error(),
@@ -92,23 +94,21 @@ func CheckGatewayRouteKindAllowed(input Input, parentRef gatewayv1.ParentReferen
 
 	routeGVK := input.GetGVK()
 	hasKindRestriction := false
-	for _, listener := range gw.Spec.Listeners {
+	for _, listener := range helpers.ListenerSetListeners(ls) {
 		if parentRef.SectionName != nil && listener.Name != *parentRef.SectionName {
 			continue
 		}
 		if parentRef.Port != nil && listener.Port != *parentRef.Port {
 			continue
 		}
-
 		if listener.AllowedRoutes == nil || len(listener.AllowedRoutes.Kinds) == 0 {
 			continue
 		}
 
 		hasKindRestriction = true
 		for _, kind := range listener.AllowedRoutes.Kinds {
-			if (kind.Group == nil || (kind.Group != nil && *kind.Group == gatewayv1.Group(routeGVK.Group))) &&
+			if (kind.Group == nil || *kind.Group == gatewayv1.Group(routeGVK.Group)) &&
 				kind.Kind == gatewayv1.Kind(routeGVK.Kind) {
-				// At least one matching listener allows this route kind.
 				return true, nil
 			}
 		}
@@ -119,16 +119,17 @@ func CheckGatewayRouteKindAllowed(input Input, parentRef gatewayv1.ParentReferen
 			Type:    string(gatewayv1.RouteConditionAccepted),
 			Status:  metav1.ConditionFalse,
 			Reason:  string(gatewayv1.RouteReasonNotAllowedByListeners),
-			Message: routeGVK.Kind + " is not allowed to attach to this Gateway due to route kind restrictions",
+			Message: routeGVK.Kind + " is not allowed to attach to this ListenerSet due to route kind restrictions",
 		})
+
 		return false, nil
 	}
 
 	return true, nil
 }
 
-func CheckGatewayMatchingHostnames(input Input, parentRef gatewayv1.ParentReference) (bool, error) {
-	gw, err := input.GetGateway(parentRef)
+func CheckListenerSetMatchingHostnames(input Input, parentRef gatewayv1.ParentReference) (bool, error) {
+	ls, err := input.GetListenerSet(parentRef)
 	if err != nil {
 		input.SetParentCondition(parentRef, metav1.Condition{
 			Type:    "Accepted",
@@ -140,7 +141,7 @@ func CheckGatewayMatchingHostnames(input Input, parentRef gatewayv1.ParentRefere
 		return false, nil
 	}
 
-	if len(computeHosts(gw.Spec.Listeners, input.GetHostnames(), nil)) == 0 {
+	if len(computeHosts(helpers.ListenerSetListeners(ls), input.GetHostnames(), nil)) == 0 {
 		input.SetParentCondition(parentRef, metav1.Condition{
 			Type:    string(gatewayv1.RouteConditionAccepted),
 			Status:  metav1.ConditionFalse,
@@ -154,8 +155,8 @@ func CheckGatewayMatchingHostnames(input Input, parentRef gatewayv1.ParentRefere
 	return true, nil
 }
 
-func CheckGatewayMatchingPorts(input Input, parentRef gatewayv1.ParentReference) (bool, error) {
-	gw, err := input.GetGateway(parentRef)
+func CheckListenerSetMatchingPorts(input Input, parentRef gatewayv1.ParentReference) (bool, error) {
+	ls, err := input.GetListenerSet(parentRef)
 	if err != nil {
 		input.SetParentCondition(parentRef, metav1.Condition{
 			Type:    "Accepted",
@@ -168,7 +169,7 @@ func CheckGatewayMatchingPorts(input Input, parentRef gatewayv1.ParentReference)
 	}
 
 	if parentRef.Port != nil {
-		for _, listener := range gw.Spec.Listeners {
+		for _, listener := range helpers.ListenerSetListeners(ls) {
 			if listener.Port == *parentRef.Port {
 				return true, nil
 			}
@@ -186,8 +187,8 @@ func CheckGatewayMatchingPorts(input Input, parentRef gatewayv1.ParentReference)
 	return true, nil
 }
 
-func CheckGatewayMatchingSection(input Input, parentRef gatewayv1.ParentReference) (bool, error) {
-	gw, err := input.GetGateway(parentRef)
+func CheckListenerSetMatchingSection(input Input, parentRef gatewayv1.ParentReference) (bool, error) {
+	ls, err := input.GetListenerSet(parentRef)
 	if err != nil {
 		input.SetParentCondition(parentRef, metav1.Condition{
 			Type:    "Accepted",
@@ -201,7 +202,7 @@ func CheckGatewayMatchingSection(input Input, parentRef gatewayv1.ParentReferenc
 
 	if parentRef.SectionName != nil {
 		found := false
-		for _, listener := range gw.Spec.Listeners {
+		for _, listener := range helpers.ListenerSetListeners(ls) {
 			if listener.Name == *parentRef.SectionName {
 				found = true
 				break
@@ -222,18 +223,8 @@ func CheckGatewayMatchingSection(input Input, parentRef gatewayv1.ParentReferenc
 	return true, nil
 }
 
-func GetAllListenerHostNames(listeners []gatewayv1.Listener) []gatewayv1.Hostname {
-	var hosts []gatewayv1.Hostname
-	for _, listener := range listeners {
-		if listener.Hostname != nil {
-			hosts = append(hosts, *listener.Hostname)
-		}
-	}
-	return hosts
-}
-
-func CheckGatewayMatchingProtocol(input Input, parentRef gatewayv1.ParentReference) (bool, error) {
-	gw, err := input.GetGateway(parentRef)
+func CheckListenerSetMatchingProtocol(input Input, parentRef gatewayv1.ParentReference) (bool, error) {
+	ls, err := input.GetListenerSet(parentRef)
 	if err != nil {
 		input.SetParentCondition(parentRef, metav1.Condition{
 			Type:    "Accepted",
@@ -248,11 +239,12 @@ func CheckGatewayMatchingProtocol(input Input, parentRef gatewayv1.ParentReferen
 	supportedProtocols := input.GetValidProtocols()
 
 	found := false
-	for _, listener := range gw.Spec.Listeners {
+	for _, listener := range helpers.ListenerSetListeners(ls) {
 		if slices.Contains(supportedProtocols, listener.Protocol) {
 			found = true
 		}
 	}
+
 	if !found {
 		input.SetParentCondition(parentRef, metav1.Condition{
 			Type:    string(gatewayv1.RouteConditionAccepted),

--- a/operator/pkg/gateway-api/routechecks/tlsroute.go
+++ b/operator/pkg/gateway-api/routechecks/tlsroute.go
@@ -140,6 +140,10 @@ func (t *TLSRouteInput) GetGateway(parent gatewayv1.ParentReference) (*gatewayv1
 	return gw, nil
 }
 
+func (t *TLSRouteInput) GetListenerSet(parent gatewayv1.ParentReference) (*gatewayv1.ListenerSet, error) {
+	return nil, fmt.Errorf("ListenerSet parent is not supported for TLSRoute")
+}
+
 func (t *TLSRouteInput) GetParentGammaService(parent gatewayv1.ParentReference) (*corev1.Service, error) {
 	return nil, fmt.Errorf("GAMMA support is not implemented in this reconciler")
 }

--- a/operator/pkg/gateway-api/watch-handlers/backendtlspolicy.go
+++ b/operator/pkg/gateway-api/watch-handlers/backendtlspolicy.go
@@ -162,6 +162,6 @@ func updateReconcileRequestsForBackendTLSPolicy(ctx context.Context,
 		httpRoutes = append(httpRoutes, hrList.Items...)
 	}
 	for _, hr := range httpRoutes {
-		updateReconcileRequestsForParentRefs(hr.Spec.ParentRefs, hr.Namespace, allGatewaysSet, rrSet)
+		updateReconcileRequestsForParentRefs(ctx, c, scopedLog, hr.Spec.ParentRefs, hr.Namespace, allGatewaysSet, rrSet)
 	}
 }

--- a/operator/pkg/gateway-api/watch-handlers/helpers.go
+++ b/operator/pkg/gateway-api/watch-handlers/helpers.go
@@ -21,15 +21,44 @@ import (
 )
 
 // updateReconcileRequestsForParentRefs mutates the passed reconcile.Request set to add all
-func updateReconcileRequestsForParentRefs(parentRefs []gatewayv1.ParentReference, ns string, allGatewaysSet map[string]struct{}, rrSet map[reconcile.Request]struct{}) {
+func updateReconcileRequestsForParentRefs(ctx context.Context, c client.Client, logger *slog.Logger, parentRefs []gatewayv1.ParentReference, ns string, allGatewaysSet map[string]struct{}, rrSet map[reconcile.Request]struct{}) {
 	for _, parent := range parentRefs {
-		if !helpers.IsGateway(parent) {
+		var parentFullName types.NamespacedName
+
+		switch {
+		case helpers.IsGateway(parent):
+			parentFullName = types.NamespacedName{
+				Name:      string(parent.Name),
+				Namespace: helpers.NamespaceDerefOr(parent.Namespace, ns),
+			}
+
+		case helpers.IsListenerSet(parent):
+			// A ListenerSet parent attaches to the Gateway named in its own
+			// spec.parentRef, so follow that to find the Gateway to reconcile.
+			ls := &gatewayv1.ListenerSet{}
+			if err := c.Get(ctx, types.NamespacedName{
+				Namespace: helpers.NamespaceDerefOr(parent.Namespace, ns),
+				Name:      string(parent.Name),
+			}, ls); err != nil {
+				if !k8serrors.IsNotFound(err) {
+					logger.ErrorContext(ctx, "Failed to get ListenerSet parent", logfields.Error, err)
+				}
+				continue
+			}
+			pr := ls.Spec.ParentRef
+			lsGwNS := ls.GetNamespace()
+			if pr.Namespace != nil {
+				lsGwNS = string(*pr.Namespace)
+			}
+			parentFullName = types.NamespacedName{
+				Name:      string(pr.Name),
+				Namespace: lsGwNS,
+			}
+
+		default:
 			continue
 		}
-		parentFullName := types.NamespacedName{
-			Name:      string(parent.Name),
-			Namespace: helpers.NamespaceDerefOr(parent.Namespace, ns),
-		}
+
 		if _, found := allGatewaysSet[parentFullName.String()]; found {
 			rrSet[reconcile.Request{NamespacedName: parentFullName}] = struct{}{}
 		}
@@ -68,17 +97,35 @@ func getGatewayReconcileRequestsForRoute(ctx context.Context, c client.Client, o
 	)
 
 	for _, parent := range route.ParentRefs {
-		if !helpers.IsGateway(parent) {
+		var gwNS, gwName string
+
+		switch {
+		case helpers.IsGateway(parent):
+			gwNS = helpers.NamespaceDerefOr(parent.Namespace, object.GetNamespace())
+			gwName = string(parent.Name)
+
+		case helpers.IsListenerSet(parent):
+			lsNS := helpers.NamespaceDerefOr(parent.Namespace, object.GetNamespace())
+			ls := &gatewayv1.ListenerSet{}
+			if err := c.Get(ctx, types.NamespacedName{Namespace: lsNS, Name: string(parent.Name)}, ls); err != nil {
+				if !k8serrors.IsNotFound(err) {
+					scopedLog.ErrorContext(ctx, "Failed to get ListenerSet parent", logfields.Error, err)
+				}
+				continue
+			}
+			pr := ls.Spec.ParentRef
+			gwNS = lsNS
+			if pr.Namespace != nil {
+				gwNS = string(*pr.Namespace)
+			}
+			gwName = string(pr.Name)
+
+		default:
 			continue
 		}
 
-		ns := helpers.NamespaceDerefOr(parent.Namespace, object.GetNamespace())
-
 		gw := &gatewayv1.Gateway{}
-		if err := c.Get(ctx, types.NamespacedName{
-			Namespace: ns,
-			Name:      string(parent.Name),
-		}, gw); err != nil {
+		if err := c.Get(ctx, types.NamespacedName{Namespace: gwNS, Name: gwName}, gw); err != nil {
 			if !k8serrors.IsNotFound(err) {
 				scopedLog.ErrorContext(ctx, "Failed to get Gateway", logfields.Error, err)
 			}
@@ -90,18 +137,10 @@ func getGatewayReconcileRequestsForRoute(ctx context.Context, c client.Client, o
 			continue
 		}
 
-		scopedLog.InfoContext(ctx,
-			"Enqueued gateway for Route",
-			logfields.K8sNamespace, ns,
-			logfields.ParentResource, parent.Name,
-			logfields.Route, object.GetName())
+		scopedLog.InfoContext(ctx, "Enqueued gateway for Route",
+			logfields.K8sNamespace, gwNS, logfields.ParentResource, parent.Name, logfields.Route, object.GetName())
 
-		reqs = append(reqs, reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Namespace: ns,
-				Name:      string(parent.Name),
-			},
-		})
+		reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: gwNS, Name: gwName}})
 	}
 
 	return reqs

--- a/operator/pkg/gateway-api/watch-handlers/listenerset.go
+++ b/operator/pkg/gateway-api/watch-handlers/listenerset.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchhandlers
+
+import (
+	"context"
+	"log/slog"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+func EnqueueRequestForOwningListenerSet(c client.Client, logger *slog.Logger, controllerName string) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
+		ls, ok := a.(*gatewayv1.ListenerSet)
+		if !ok {
+			return nil
+		}
+
+		scopedLog := logger.With(
+			logfields.Resource, types.NamespacedName{Namespace: ls.GetNamespace(), Name: ls.GetName()},
+		)
+
+		pr := ls.Spec.ParentRef
+		// ParentGatewayReference defaults Group/Kind to Gateway when nil.
+		if (pr.Kind != nil && *pr.Kind != "Gateway") || (pr.Group != nil && *pr.Group != gatewayv1.GroupName) {
+			return nil
+		}
+
+		ns := ls.GetNamespace()
+		if pr.Namespace != nil {
+			ns = string(*pr.Namespace)
+		}
+
+		gw := &gatewayv1.Gateway{}
+		if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: string(pr.Name)}, gw); err != nil {
+			if !k8serrors.IsNotFound(err) {
+				scopedLog.ErrorContext(ctx, "Failed to get parent Gateway", logfields.Error, err)
+			}
+
+			return nil
+		}
+
+		if !hasMatchingController(ctx, c, controllerName, logger)(gw) {
+			scopedLog.DebugContext(ctx, "Parent Gateway does not have matching controller, skipping")
+
+			return nil
+		}
+
+		scopedLog.InfoContext(ctx, "Enqueued Gateway for ListenerSet", logfields.Gateway, pr.Name)
+
+		return []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: ns, Name: string(pr.Name)}}}
+	})
+}

--- a/operator/pkg/gateway-api/watch-handlers/service.go
+++ b/operator/pkg/gateway-api/watch-handlers/service.go
@@ -88,17 +88,17 @@ func EnqueueRequestForBackendService(c client.Client, logger slog.Logger) handle
 
 		// iterate through the HTTPRoutes, update reconcileRequests for each Gateway that is relevant.
 		for _, hr := range hrList.Items {
-			updateReconcileRequestsForParentRefs(hr.Spec.ParentRefs, hr.Namespace, allCiliumGatewaysSet, reconcileRequests)
+			updateReconcileRequestsForParentRefs(ctx, c, scopedLog, hr.Spec.ParentRefs, hr.Namespace, allCiliumGatewaysSet, reconcileRequests)
 		}
 
 		// iterate through the TLSRoutes, update reconcileRequests for each Gateway that is relevant.
 		for _, tlsr := range tlsrList.Items {
-			updateReconcileRequestsForParentRefs(tlsr.Spec.ParentRefs, tlsr.Namespace, allCiliumGatewaysSet, reconcileRequests)
+			updateReconcileRequestsForParentRefs(ctx, c, scopedLog, tlsr.Spec.ParentRefs, tlsr.Namespace, allCiliumGatewaysSet, reconcileRequests)
 		}
 
 		// iterate through the TLSRoutes, update reconcileRequests for each Gateway that is relevant.
 		for _, grpcr := range grpcRouteList.Items {
-			updateReconcileRequestsForParentRefs(grpcr.Spec.ParentRefs, grpcr.Namespace, allCiliumGatewaysSet, reconcileRequests)
+			updateReconcileRequestsForParentRefs(ctx, c, scopedLog, grpcr.Spec.ParentRefs, grpcr.Namespace, allCiliumGatewaysSet, reconcileRequests)
 		}
 
 		// return the keys of the set, since that's the actual reconcile.Requests.

--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -41,6 +41,12 @@ type Input struct {
 	Services            []corev1.Service
 	ServiceImports      []mcsapiv1beta1.ServiceImport
 	BackendTLSPolicyMap helpers.BackendTLSPolicyServiceMap
+	ListenerSets        []ListenerSetInput
+}
+
+type ListenerSetInput struct {
+	ListenerSet gatewayv1.ListenerSet
+	HTTPRoutes  []gatewayv1.HTTPRoute // routes whose parentRef = this ListenerSet
 }
 
 // GatewayAPI translates Gateway API resources into a model.
@@ -75,16 +81,11 @@ func GatewayAPI(log *slog.Logger, input Input) ([]model.HTTPListener, []model.TL
 
 	// Find all the listener host names, so that we can match them with the routes
 	// Gateway API spec guarantees that the hostnames are unique across all listeners
-	listenerHostnamesByProtocol := make(map[gatewayv1.ProtocolType][]string)
-	for _, l := range input.Gateway.Spec.Listeners {
-		if l.Hostname != nil {
-			_, ok := listenerHostnamesByProtocol[l.Protocol]
-			if !ok {
-				listenerHostnamesByProtocol[l.Protocol] = []string{}
-			}
-			listenerHostnamesByProtocol[l.Protocol] = append(listenerHostnamesByProtocol[l.Protocol], toHostname(l.Hostname))
-		}
+	mergedListeners := append([]gatewayv1.Listener{}, input.Gateway.Spec.Listeners...)
+	for _, lsIn := range input.ListenerSets {
+		mergedListeners = append(mergedListeners, toListeners(lsIn.ListenerSet.Spec.Listeners)...)
 	}
+	listenerHostnamesByProtocol := hostnamesByProtocol(mergedListeners)
 
 	for _, l := range input.Gateway.Spec.Listeners {
 		if l.Protocol != gatewayv1.HTTPProtocolType &&
@@ -132,6 +133,34 @@ func GatewayAPI(log *slog.Logger, input Input) ([]model.HTTPListener, []model.TL
 				Port:           uint32(l.Port),
 				Hostname:       toHostname(l.Hostname),
 				Routes:         toTLSRoutes(l, listenerHostnamesByProtocol, input.TLSRoutes, input.Services, input.ServiceImports, input.ReferenceGrants),
+				Infrastructure: infra,
+				Service:        toServiceModel(input.GatewayClassConfig),
+			})
+		}
+	}
+
+	for _, lsIn := range input.ListenerSets {
+		for _, listener := range toListeners(lsIn.ListenerSet.Spec.Listeners) {
+			if listener.Protocol != gatewayv1.HTTPProtocolType && listener.Protocol != gatewayv1.HTTPSProtocolType {
+				continue // GRPC/TLS deferred
+			}
+
+			resHTTP = append(resHTTP, model.HTTPListener{
+				Name: fmt.Sprintf("%s-%s-%s", lsIn.ListenerSet.Namespace, lsIn.ListenerSet.Name, listener.Name),
+				Sources: []model.FullyQualifiedResource{
+					{
+						Name:      input.Gateway.GetName(),
+						Namespace: input.Gateway.GetNamespace(),
+						Group:     gatewayv1.SchemeGroupVersion.Group,
+						Version:   gatewayv1.SchemeGroupVersion.Version,
+						Kind:      "Gateway",
+						UID:       string(input.Gateway.GetUID()),
+					},
+				},
+				Port:           uint32(listener.Port),
+				Hostname:       toHostname(listener.Hostname),
+				TLS:            toTLS(listener.TLS, input.ReferenceGrants, lsIn.ListenerSet.GetNamespace()), // certs from LS's own ns
+				Routes:         toHTTPRoutes(log, listener, listenerHostnamesByProtocol, lsIn.HTTPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants, input.BackendTLSPolicyMap),
 				Infrastructure: infra,
 				Service:        toServiceModel(input.GatewayClassConfig),
 			})
@@ -941,6 +970,24 @@ func backendRefToAppProtocol(svc corev1.Service, backendPort int32) *string {
 	return nil
 }
 
+func hostnamesByProtocol(listeners []gatewayv1.Listener) map[gatewayv1.ProtocolType][]string {
+	hostnames := make(map[gatewayv1.ProtocolType][]string)
+
+	for _, l := range listeners {
+		if l.Hostname == nil {
+			continue
+		}
+
+		if _, ok := hostnames[l.Protocol]; !ok {
+			hostnames[l.Protocol] = []string{}
+		}
+
+		hostnames[l.Protocol] = append(hostnames[l.Protocol], toHostname(l.Hostname))
+	}
+
+	return hostnames
+}
+
 func toPathMatch(match gatewayv1.HTTPRouteMatch) model.StringMatch {
 	if match.Path == nil {
 		return model.StringMatch{}
@@ -1148,4 +1195,25 @@ func toStringSlice[S ~string](s []S) []string {
 		res = append(res, string(h))
 	}
 	return res
+}
+
+func toListener(entry gatewayv1.ListenerEntry) gatewayv1.Listener {
+	return gatewayv1.Listener{
+		Name:          entry.Name,
+		Hostname:      entry.Hostname,
+		Port:          entry.Port,
+		Protocol:      entry.Protocol,
+		TLS:           entry.TLS,
+		AllowedRoutes: entry.AllowedRoutes,
+	}
+}
+
+func toListeners(entries []gatewayv1.ListenerEntry) []gatewayv1.Listener {
+	listeners := make([]gatewayv1.Listener, 0, len(entries))
+
+	for _, entry := range entries {
+		listeners = append(listeners, toListener(entry))
+	}
+
+	return listeners
 }


### PR DESCRIPTION
Add support for adding listeners via ListenerSet for HTTPRoutes (Gateway API v1.5).

Functionality is gated behind `--enable-gateway-api-listener-set` and disabled by default. GRPC and TLSRoutes will be added in a later commit. Unit and reconciliation tests not yet added.

Refs: #42756

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request]
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here or remove this release-note section from your PR description. Do NOT put an "empty" release note here -->
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
