### PR TITLE
GatewayAPI: Implement ListenerSets

### DIFF
--- a/Makefile.kind
+++ b/Makefile.kind
@@ -386,6 +386,7 @@ kind-servicemesh-install-cilium: check_deps kind-ready ## Install a local Cilium
 	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_grpcroutes.yaml
 	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_backendtlspolicies.yaml
 	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_tlsroutes.yaml
+	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_listenersets.yaml
 ifeq ($(GW_CHANNEL),experimental)
 	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_tcproutes.yaml
 	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_udproutes.yaml
@@ -418,6 +419,7 @@ kind-servicemesh-prereqs: check_deps kind-ready
 	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_grpcroutes.yaml
 	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_backendtlspolicies.yaml
 	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_tlsroutes.yaml
+	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_listenersets.yaml
 ifeq ($(GW_CHANNEL),experimental)
 	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_tcproutes.yaml
 	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_udproutes.yaml

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -355,6 +355,7 @@ rules:
   - referencegrants
   - referencepolicies
   - backendtlspolicies
+  - listenersets
   verbs:
   - get
   - list
@@ -376,6 +377,7 @@ rules:
   - backendtlspolicies/status
   - tcproutes/status
   - udproutes/status
+  - listenersets/status
   verbs:
   - update
   - patch

--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -461,6 +461,10 @@ func registerReconcilers(mgr ctrlRuntime.Manager, translator translation.Transla
 			// UDPRoute is reconciled by the Gateway API reconciler, but log that the
 			// support has been successfully enabled.
 			logger.Info("UDPRoute CRD is installed, UDPRoute support is enabled")
+		case helpers.ListenerSetKind:
+			// ListenerSet is reconciled by the Gateway API reconciler, but log that the
+			// support has been successfully enabled.
+			logger.Info("ListenerSet CRD is installed, ListenerSet support is enabled")
 		case helpers.ServiceImportKind:
 			// we don't need a reconciler, but we do need to tell folks that the
 			// support is working.

--- a/operator/pkg/gateway-api/gamma_reconcile.go
+++ b/operator/pkg/gateway-api/gamma_reconcile.go
@@ -253,7 +253,7 @@ func (r *gammaReconciler) setHTTPRouteStatuses(gammaLogger *slog.Logger, ctx con
 func (r *gammaReconciler) filterHTTPRoutesByService(ctx context.Context, gammaService *corev1.Service, routes []gatewayv1.HTTPRoute) []gatewayv1.HTTPRoute {
 	var filtered []gatewayv1.HTTPRoute
 	for _, route := range routes {
-		if helpers.IsParentAttachable(ctx, gammaService, &route, route.Status.Parents) {
+		if helpers.IsParentAttachable(ctx, gammaService, &route, route.Status.Parents, nil) {
 			filtered = append(filtered, route)
 		}
 	}
@@ -263,7 +263,7 @@ func (r *gammaReconciler) filterHTTPRoutesByService(ctx context.Context, gammaSe
 func (r *gammaReconciler) filterGRPCRoutesByService(ctx context.Context, gammaService *corev1.Service, routes []gatewayv1.GRPCRoute) []gatewayv1.GRPCRoute {
 	var filtered []gatewayv1.GRPCRoute
 	for _, route := range routes {
-		if helpers.IsParentAttachable(ctx, gammaService, &route, route.Status.Parents) {
+		if helpers.IsParentAttachable(ctx, gammaService, &route, route.Status.Parents, nil) {
 			filtered = append(filtered, route)
 		}
 	}

--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -155,6 +155,16 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.TLSRoute{}, indexers.TLSRouteListenerSetIndex, indexers.IndexTLSRouteByListenerSet); err != nil {
 			return fmt.Errorf("failed to setup field indexer %q: %w", indexers.TLSRouteListenerSetIndex, err)
 		}
+		if tcpRouteEnabled {
+			if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1alpha2.TCPRoute{}, indexers.TCPRouteListenerSetIndex, indexers.IndexTCPRouteByListenerSet); err != nil {
+				return fmt.Errorf("failed to setup field indexer %q: %w", indexers.TCPRouteListenerSetIndex, err)
+			}
+		}
+		if udpRouteEnabled {
+			if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1alpha2.UDPRoute{}, indexers.UDPRouteListenerSetIndex, indexers.IndexUDPRouteByListenerSet); err != nil {
+				return fmt.Errorf("failed to setup field indexer %q: %w", indexers.UDPRouteListenerSetIndex, err)
+			}
+		}
 	}
 
 	hasMatchingControllerFn := helpers.GatewayHasMatchingControllerFn(context.Background(), r.Client, r.controllerName, r.logger)

--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -67,6 +67,7 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	tcpRouteEnabled := helpers.HasTCPRouteSupport(scheme)
 	udpRouteEnabled := helpers.HasUDPRouteSupport(scheme)
 	serviceImportEnabled := helpers.HasServiceImportSupport(scheme)
+	listenerSetEnabled := helpers.HasListenerSetSupport(scheme)
 
 	// Add field indexes for HTTPRoutes
 	for indexName, indexerFunc := range map[string]client.IndexerFunc{
@@ -139,6 +140,23 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return fmt.Errorf("failed to setup field indexer %q: %w", indexers.BackendTLSPolicyConfigMapIndex, err)
 	}
 
+	// Index ListenerSets by parent Gateway, and routes by ListenerSet parentRefs
+	if listenerSetEnabled {
+		if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.ListenerSet{}, indexers.ListenerSetGatewayIndex, indexers.IndexListenerSetByGateway); err != nil {
+			return fmt.Errorf("failed to setup field indexer %q: %w", indexers.ListenerSetGatewayIndex, err)
+		}
+
+		if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.HTTPRoute{}, indexers.HTTPRouteListenerSetIndex, indexers.IndexHTTPRouteByListenerSet); err != nil {
+			return fmt.Errorf("failed to setup field indexer %q: %w", indexers.HTTPRouteListenerSetIndex, err)
+		}
+		if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.GRPCRoute{}, indexers.GRPCRouteListenerSetIndex, indexers.IndexGRPCRouteByListenerSet); err != nil {
+			return fmt.Errorf("failed to setup field indexer %q: %w", indexers.GRPCRouteListenerSetIndex, err)
+		}
+		if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.TLSRoute{}, indexers.TLSRouteListenerSetIndex, indexers.IndexTLSRouteByListenerSet); err != nil {
+			return fmt.Errorf("failed to setup field indexer %q: %w", indexers.TLSRouteListenerSetIndex, err)
+		}
+	}
+
 	hasMatchingControllerFn := helpers.GatewayHasMatchingControllerFn(context.Background(), r.Client, r.controllerName, r.logger)
 	gatewayBuilder := ctrl.NewControllerManagedBy(mgr).
 		// Watch its own resource
@@ -184,6 +202,11 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if udpRouteEnabled {
 		// Watch UDPRoute linked to Gateway
 		gatewayBuilder = gatewayBuilder.Watches(&gatewayv1alpha2.UDPRoute{}, watchhandlers.EnqueueRequestForOwningUDPRoute(r.Client, r.logger, r.controllerName))
+	}
+
+	if listenerSetEnabled {
+		// Watch ListenerSet linked to Gateway
+		gatewayBuilder = gatewayBuilder.Watches(&gatewayv1.ListenerSet{}, watchhandlers.EnqueueRequestForListenerSetOwner(r.Client, r.logger, defaultControllerName))
 	}
 
 	if serviceImportEnabled {

--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -91,6 +91,11 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return fmt.Errorf("failed to setup field indexer %q: %w", indexers.ImplementationGatewayIndex, err)
 	}
 
+	// Index Gateways by referenced TLS Secrets
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.Gateway{}, helpers.GatewaySecretIndex, indexers.IndexGatewayBySecret); err != nil {
+		return fmt.Errorf("failed to setup field indexer %q: %w", helpers.GatewaySecretIndex, err)
+	}
+
 	// Add indexes for TLSRoutes
 	for indexName, indexerFunc := range map[string]client.IndexerFunc{
 		indexers.BackendServiceTLSRouteIndex: indexers.GenerateIndexerTLSRoutebyBackendService(r.Client, r.logger),
@@ -146,6 +151,10 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			return fmt.Errorf("failed to setup field indexer %q: %w", indexers.ListenerSetGatewayIndex, err)
 		}
 
+		if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.ListenerSet{}, helpers.ListenerSetSecretIndex, indexers.IndexListenerSetBySecret); err != nil {
+			return fmt.Errorf("failed to setup field indexer %q: %w", helpers.ListenerSetSecretIndex, err)
+		}
+
 		if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.HTTPRoute{}, indexers.HTTPRouteListenerSetIndex, indexers.IndexHTTPRouteByListenerSet); err != nil {
 			return fmt.Errorf("failed to setup field indexer %q: %w", indexers.HTTPRouteListenerSetIndex, err)
 		}
@@ -187,8 +196,8 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&gatewayv1.TLSRoute{}, watchhandlers.EnqueueRequestForOwningTLSRoute(r.Client, r.logger, r.controllerName)).
 		// Watch related secrets used to configure TLS
 		Watches(&corev1.Secret{},
-			watchhandlers.EnqueueRequestForTLSSecret(r.Client, r.logger),
-			builder.WithPredicates(predicate.NewPredicateFuncs(predicates.SecretUsedInGatewayFn(r.Client, r.logger)))).
+			watchhandlers.EnqueueRequestForTLSSecret(r.Client, r.controllerName, r.logger),
+			builder.WithPredicates(predicate.NewPredicateFuncs(predicates.SecretUsedInGatewayFn(r.Client, r.controllerName, r.logger)))).
 		// Watch related namespace in allowed namespaces
 		Watches(&corev1.Namespace{},
 			watchhandlers.EnqueueRequestForAllowedNamespace(r.Client, r.logger)).

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/policychecks"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/routechecks"
+	"github.com/cilium/cilium/operator/pkg/model"
 	"github.com/cilium/cilium/operator/pkg/model/ingestion"
 	gatewayApiTranslation "github.com/cilium/cilium/operator/pkg/model/translation/gateway-api"
 	"github.com/cilium/cilium/pkg/annotation"
@@ -294,9 +295,9 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return controllerruntime.Fail(err)
 	}
 
-	httpRoutes := r.filterHTTPRoutesByGateway(ctx, gw, httpRouteList.Items, namespaceLabels)
-	tlsRoutes := r.filterTLSRoutesByGateway(ctx, gw, tlsRouteList.Items, namespaceLabels)
-	grpcRoutes := r.filterGRPCRoutesByGateway(ctx, gw, grpcRouteList.Items, namespaceLabels)
+	httpRoutes := r.filterHTTPRoutesByGateway(ctx, gw, attachedListenerSets, httpRouteList.Items, namespaceLabels)
+	tlsRoutes := r.filterTLSRoutesByGateway(ctx, gw, attachedListenerSets, tlsRouteList.Items, namespaceLabels)
+	grpcRoutes := r.filterGRPCRoutesByGateway(ctx, gw, attachedListenerSets, grpcRouteList.Items, namespaceLabels)
 	tcpRoutes := r.filterTCPRoutesByGateway(ctx, gw, tcpRouteList.Items, namespaceLabels)
 	udpRoutes := r.filterUDPRoutesByGateway(ctx, gw, udpRouteList.Items, namespaceLabels)
 
@@ -761,49 +762,51 @@ func resolveAllowedNamespaces(ctx context.Context, c client.Client, listenerName
 	return map[string]struct{}{listenerNamespace: {}}
 }
 
-func (r *gatewayReconciler) filterHTTPRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, routes []gatewayv1.HTTPRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1.HTTPRoute {
+func (r *gatewayReconciler) filterHTTPRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, attachedListenerSets []gatewayv1.ListenerSet, routes []gatewayv1.HTTPRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1.HTTPRoute {
 	var filtered []gatewayv1.HTTPRoute
 	allListenerHostNames := routechecks.GetAllListenerHostNames(gw.Spec.Listeners)
 	for _, route := range routes {
-		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, nil) && isAllowed(gw, &route, namespaceLabels) && len(computeHosts(gw, route.Spec.Hostnames, allListenerHostNames)) > 0 {
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, attachedListenerSets) && isAllowed(gw, &route, namespaceLabels) && len(computeHosts(gw, route.Spec.Hostnames, allListenerHostNames)) > 0 {
 			filtered = append(filtered, route)
 		}
 	}
 	return filtered
 }
 
-func (r *gatewayReconciler) filterGRPCRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, routes []gatewayv1.GRPCRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1.GRPCRoute {
+func (r *gatewayReconciler) filterGRPCRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, attachedListenerSets []gatewayv1.ListenerSet, routes []gatewayv1.GRPCRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1.GRPCRoute {
 	var filtered []gatewayv1.GRPCRoute
 	allListenerHostNames := routechecks.GetAllListenerHostNames(gw.Spec.Listeners)
 
 	for _, route := range routes {
-		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, nil) && isAllowed(gw, &route, namespaceLabels) && len(computeHosts(gw, route.Spec.Hostnames, allListenerHostNames)) > 0 {
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, attachedListenerSets) && isAllowed(gw, &route, namespaceLabels) && len(computeHosts(gw, route.Spec.Hostnames, allListenerHostNames)) > 0 {
 			filtered = append(filtered, route)
 		}
 	}
 	return filtered
 }
 
-func (r *gatewayReconciler) filterHTTPRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1.HTTPRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1.HTTPRoute {
+func (r *gatewayReconciler) filterHTTPRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, listenerSource *model.FullyQualifiedResource, routes []gatewayv1.HTTPRoute, namespaceLabels helpers.NamespaceLabelIndex, attachedListenerSets ...gatewayv1.ListenerSet) []gatewayv1.HTTPRoute {
+	lsNS := listenerOwnerNamespace(gw, listenerSource)
 	var filtered []gatewayv1.HTTPRoute
 	for _, route := range routes {
-		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, nil) &&
-			listenerisAllowed(gw, listener, &route, namespaceLabels) &&
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, attachedListenerSets) &&
+			listenerisAllowed(lsNS, listener, &route, namespaceLabels) &&
 			len(computeHostsForListener(listener, route.Spec.Hostnames, nil)) > 0 &&
-			parentRefMatched(gw, listener, route.GetNamespace(), route.Spec.ParentRefs) {
+			parentRefMatched(gw, listener, listenerSource, route.GetNamespace(), route.Spec.ParentRefs) {
 			filtered = append(filtered, route)
 		}
 	}
 	return filtered
 }
 
-func (r *gatewayReconciler) filterGRPCRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1.GRPCRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1.GRPCRoute {
+func (r *gatewayReconciler) filterGRPCRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, listenerSource *model.FullyQualifiedResource, routes []gatewayv1.GRPCRoute, namespaceLabels helpers.NamespaceLabelIndex, attachedListenerSets ...gatewayv1.ListenerSet) []gatewayv1.GRPCRoute {
+	lsNS := listenerOwnerNamespace(gw, listenerSource)
 	var filtered []gatewayv1.GRPCRoute
 	for _, route := range routes {
-		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, nil) &&
-			listenerisAllowed(gw, listener, &route, namespaceLabels) &&
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, attachedListenerSets) &&
+			listenerisAllowed(lsNS, listener, &route, namespaceLabels) &&
 			len(computeHostsForListener(listener, route.Spec.Hostnames, nil)) > 0 &&
-			parentRefMatched(gw, listener, route.GetNamespace(), route.Spec.ParentRefs) {
+			parentRefMatched(gw, listener, listenerSource, route.GetNamespace(), route.Spec.ParentRefs) {
 			filtered = append(filtered, route)
 		}
 	}
@@ -829,31 +832,49 @@ func (r *gatewayReconciler) getGatewayClassConfig(ctx context.Context, gwc *gate
 	return res
 }
 
-func parentRefMatched(gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routeNamespace string, refs []gatewayv1.ParentReference) bool {
+func parentRefMatched(gw *gatewayv1.Gateway, listener *gatewayv1.Listener, listenerSource *model.FullyQualifiedResource, routeNamespace string, refs []gatewayv1.ParentReference) bool {
 	for _, ref := range refs {
-		// Check if the parentRef is a Gateway before checking name and namespace
-		if !helpers.IsGateway(ref) {
+		if helpers.IsGateway(ref) {
+			if listenerSource != nil && listenerSource.Kind != "Gateway" {
+				continue
+			}
+			if string(ref.Name) == gw.GetName() && gw.GetNamespace() == helpers.NamespaceDerefOr(ref.Namespace, routeNamespace) {
+				if ref.SectionName == nil && ref.Port == nil {
+					return true
+				}
+				sectionNameCheck := ref.SectionName == nil || *ref.SectionName == listener.Name
+				portCheck := ref.Port == nil || *ref.Port == listener.Port
+				if sectionNameCheck && portCheck {
+					return true
+				}
+			}
 			continue
 		}
 
-		if string(ref.Name) == gw.GetName() && gw.GetNamespace() == helpers.NamespaceDerefOr(ref.Namespace, routeNamespace) {
-			if ref.SectionName == nil && ref.Port == nil {
-				return true
+		if helpers.IsListenerSet(ref) {
+			if listenerSource == nil || listenerSource.Kind != "ListenerSet" {
+				continue
 			}
-			sectionNameCheck := ref.SectionName == nil || *ref.SectionName == listener.Name
-			portCheck := ref.Port == nil || *ref.Port == listener.Port
-			if sectionNameCheck && portCheck {
-				return true
+			if string(ref.Name) == listenerSource.Name &&
+				helpers.NamespaceDerefOr(ref.Namespace, routeNamespace) == listenerSource.Namespace {
+				if ref.SectionName == nil && ref.Port == nil {
+					return true
+				}
+				sectionNameCheck := ref.SectionName == nil || *ref.SectionName == listener.Name
+				portCheck := ref.Port == nil || *ref.Port == listener.Port
+				if sectionNameCheck && portCheck {
+					return true
+				}
 			}
 		}
 	}
 	return false
 }
 
-func (r *gatewayReconciler) filterTLSRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, routes []gatewayv1.TLSRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1.TLSRoute {
+func (r *gatewayReconciler) filterTLSRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, attachedListenerSets []gatewayv1.ListenerSet, routes []gatewayv1.TLSRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1.TLSRoute {
 	var filtered []gatewayv1.TLSRoute
 	for _, route := range routes {
-		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, nil) && isAllowed(gw, &route, namespaceLabels) &&
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, attachedListenerSets) && isAllowed(gw, &route, namespaceLabels) &&
 			len(computeHosts(gw, route.Spec.Hostnames, nil)) > 0 {
 			filtered = append(filtered, route)
 		}
@@ -881,13 +902,14 @@ func (r *gatewayReconciler) filterUDPRoutesByGateway(ctx context.Context, gw *ga
 	return filtered
 }
 
-func (r *gatewayReconciler) filterTLSRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1.TLSRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1.TLSRoute {
+func (r *gatewayReconciler) filterTLSRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, listenerSource *model.FullyQualifiedResource, routes []gatewayv1.TLSRoute, namespaceLabels helpers.NamespaceLabelIndex, attachedListenerSets ...gatewayv1.ListenerSet) []gatewayv1.TLSRoute {
+	lsNS := listenerOwnerNamespace(gw, listenerSource)
 	var filtered []gatewayv1.TLSRoute
 	for _, route := range routes {
-		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, nil) &&
-			listenerisAllowed(gw, listener, &route, namespaceLabels) &&
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, attachedListenerSets) &&
+			listenerisAllowed(lsNS, listener, &route, namespaceLabels) &&
 			len(computeHostsForListener(listener, route.Spec.Hostnames, nil)) > 0 &&
-			parentRefMatched(gw, listener, route.GetNamespace(), route.Spec.ParentRefs) {
+			parentRefMatched(gw, listener, listenerSource, route.GetNamespace(), route.Spec.ParentRefs) {
 			filtered = append(filtered, route)
 		}
 	}
@@ -898,8 +920,8 @@ func (r *gatewayReconciler) filterTCPRoutesByListener(ctx context.Context, gw *g
 	var filtered []gatewayv1alpha2.TCPRoute
 	for _, route := range routes {
 		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, nil) &&
-			listenerisAllowed(gw, listener, &route, namespaceLabels) &&
-			parentRefMatched(gw, listener, route.GetNamespace(), route.Spec.ParentRefs) {
+			listenerisAllowed(gw.GetNamespace(), listener, &route, namespaceLabels) &&
+			parentRefMatched(gw, listener, nil, route.GetNamespace(), route.Spec.ParentRefs) {
 			filtered = append(filtered, route)
 		}
 	}
@@ -910,8 +932,8 @@ func (r *gatewayReconciler) filterUDPRoutesByListener(ctx context.Context, gw *g
 	var filtered []gatewayv1alpha2.UDPRoute
 	for _, route := range routes {
 		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, nil) &&
-			listenerisAllowed(gw, listener, &route, namespaceLabels) &&
-			parentRefMatched(gw, listener, route.GetNamespace(), route.Spec.ParentRefs) {
+			listenerisAllowed(gw.GetNamespace(), listener, &route, namespaceLabels) &&
+			parentRefMatched(gw, listener, nil, route.GetNamespace(), route.Spec.ParentRefs) {
 			filtered = append(filtered, route)
 		}
 	}
@@ -1188,10 +1210,11 @@ func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1
 				gatewayListenerAcceptedCondition(gw, true, gatewayv1.ListenerReasonAccepted, "Listener Accepted"),
 				gatewayListenerProgrammedCondition(gw, false, "Address not ready yet"))
 		}
+		gwSource := gatewayFQR(gw)
 		var attachedRoutes int32
-		attachedRoutes += int32(len(r.filterHTTPRoutesByListener(ctx, gw, &l, httpRoutes.Items, namespaceLabels)))
-		attachedRoutes += int32(len(r.filterGRPCRoutesByListener(ctx, gw, &l, grpcRoutes.Items, namespaceLabels)))
-		attachedRoutes += int32(len(r.filterTLSRoutesByListener(ctx, gw, &l, tlsRoutes.Items, namespaceLabels)))
+		attachedRoutes += int32(len(r.filterHTTPRoutesByListener(ctx, gw, &l, &gwSource, httpRoutes.Items, namespaceLabels)))
+		attachedRoutes += int32(len(r.filterGRPCRoutesByListener(ctx, gw, &l, &gwSource, grpcRoutes.Items, namespaceLabels)))
+		attachedRoutes += int32(len(r.filterTLSRoutesByListener(ctx, gw, &l, &gwSource, tlsRoutes.Items, namespaceLabels)))
 		attachedRoutes += int32(len(r.filterTCPRoutesByListener(ctx, gw, &l, tcpRoutes.Items, namespaceLabels)))
 		attachedRoutes += int32(len(r.filterUDPRoutesByListener(ctx, gw, &l, udpRoutes.Items, namespaceLabels)))
 
@@ -1945,4 +1968,11 @@ func (r *gatewayReconciler) updateBackendTLSPolicyStatus(ctx context.Context, sc
 	}
 	scopedLog.Debug("BackendTLSPolicy status", backendTLSPolicy, types.NamespacedName{Name: original.Name, Namespace: original.Namespace})
 	return r.Client.Status().Update(ctx, new)
+}
+
+func listenerOwnerNamespace(gw *gatewayv1.Gateway, listenerSource *model.FullyQualifiedResource) string {
+	if listenerSource != nil && listenerSource.Kind == "ListenerSet" {
+		return listenerSource.Namespace
+	}
+	return gw.GetNamespace()
 }

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -223,7 +223,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	var namespaces []corev1.Namespace
-	if hasAllowedRoutesNamespaceSelector(gw) {
+	if hasAllowedRoutesNamespaceSelector(gw, attachedListenerSets) {
 		namespaceList := &corev1.NamespaceList{}
 		if err := r.Client.List(ctx, namespaceList); err != nil {
 			scopedLog.ErrorContext(ctx, "Unable to list Namespaces", logfields.Error, err)
@@ -399,7 +399,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	return controllerruntime.Success()
 }
 
-func hasAllowedRoutesNamespaceSelector(gw *gatewayv1.Gateway) bool {
+func hasAllowedRoutesNamespaceSelector(gw *gatewayv1.Gateway, attachedListenerSets []gatewayv1.ListenerSet) bool {
 	for _, listener := range gw.Spec.Listeners {
 		if listener.AllowedRoutes == nil || listener.AllowedRoutes.Namespaces == nil {
 			continue
@@ -409,6 +409,20 @@ func hasAllowedRoutesNamespaceSelector(gw *gatewayv1.Gateway) bool {
 		}
 		if listener.AllowedRoutes.Namespaces.From == nil && listener.AllowedRoutes.Namespaces.Selector != nil {
 			return true
+		}
+	}
+	for _, ls := range attachedListenerSets {
+		for _, entry := range ls.Spec.Listeners {
+			l := helpers.ListenerEntryToListener(entry)
+			if l.AllowedRoutes == nil || l.AllowedRoutes.Namespaces == nil {
+				continue
+			}
+			if l.AllowedRoutes.Namespaces.From != nil && *l.AllowedRoutes.Namespaces.From == gatewayv1.NamespacesFromSelector {
+				return true
+			}
+			if l.AllowedRoutes.Namespaces.From == nil && l.AllowedRoutes.Namespaces.Selector != nil {
+				return true
+			}
 		}
 	}
 	return false

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -618,7 +618,7 @@ func (r *gatewayReconciler) filterHTTPRoutesByGateway(ctx context.Context, gw *g
 	var filtered []gatewayv1.HTTPRoute
 	allListenerHostNames := routechecks.GetAllListenerHostNames(gw.Spec.Listeners)
 	for _, route := range routes {
-		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(gw, &route, namespaceLabels) && len(computeHosts(gw, route.Spec.Hostnames, allListenerHostNames)) > 0 {
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, nil) && isAllowed(gw, &route, namespaceLabels) && len(computeHosts(gw, route.Spec.Hostnames, allListenerHostNames)) > 0 {
 			filtered = append(filtered, route)
 		}
 	}
@@ -630,7 +630,7 @@ func (r *gatewayReconciler) filterGRPCRoutesByGateway(ctx context.Context, gw *g
 	allListenerHostNames := routechecks.GetAllListenerHostNames(gw.Spec.Listeners)
 
 	for _, route := range routes {
-		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(gw, &route, namespaceLabels) && len(computeHosts(gw, route.Spec.Hostnames, allListenerHostNames)) > 0 {
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, nil) && isAllowed(gw, &route, namespaceLabels) && len(computeHosts(gw, route.Spec.Hostnames, allListenerHostNames)) > 0 {
 			filtered = append(filtered, route)
 		}
 	}
@@ -640,7 +640,7 @@ func (r *gatewayReconciler) filterGRPCRoutesByGateway(ctx context.Context, gw *g
 func (r *gatewayReconciler) filterHTTPRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1.HTTPRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1.HTTPRoute {
 	var filtered []gatewayv1.HTTPRoute
 	for _, route := range routes {
-		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) &&
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, nil) &&
 			listenerisAllowed(gw, listener, &route, namespaceLabels) &&
 			len(computeHostsForListener(listener, route.Spec.Hostnames, nil)) > 0 &&
 			parentRefMatched(gw, listener, route.GetNamespace(), route.Spec.ParentRefs) {
@@ -653,7 +653,7 @@ func (r *gatewayReconciler) filterHTTPRoutesByListener(ctx context.Context, gw *
 func (r *gatewayReconciler) filterGRPCRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1.GRPCRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1.GRPCRoute {
 	var filtered []gatewayv1.GRPCRoute
 	for _, route := range routes {
-		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) &&
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, nil) &&
 			listenerisAllowed(gw, listener, &route, namespaceLabels) &&
 			len(computeHostsForListener(listener, route.Spec.Hostnames, nil)) > 0 &&
 			parentRefMatched(gw, listener, route.GetNamespace(), route.Spec.ParentRefs) {
@@ -706,7 +706,7 @@ func parentRefMatched(gw *gatewayv1.Gateway, listener *gatewayv1.Listener, route
 func (r *gatewayReconciler) filterTLSRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, routes []gatewayv1.TLSRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1.TLSRoute {
 	var filtered []gatewayv1.TLSRoute
 	for _, route := range routes {
-		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(gw, &route, namespaceLabels) &&
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, nil) && isAllowed(gw, &route, namespaceLabels) &&
 			len(computeHosts(gw, route.Spec.Hostnames, nil)) > 0 {
 			filtered = append(filtered, route)
 		}
@@ -717,7 +717,7 @@ func (r *gatewayReconciler) filterTLSRoutesByGateway(ctx context.Context, gw *ga
 func (r *gatewayReconciler) filterTCPRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, routes []gatewayv1alpha2.TCPRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1alpha2.TCPRoute {
 	var filtered []gatewayv1alpha2.TCPRoute
 	for _, route := range routes {
-		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(gw, &route, namespaceLabels) {
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, nil) && isAllowed(gw, &route, namespaceLabels) {
 			filtered = append(filtered, route)
 		}
 	}
@@ -727,7 +727,7 @@ func (r *gatewayReconciler) filterTCPRoutesByGateway(ctx context.Context, gw *ga
 func (r *gatewayReconciler) filterUDPRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, routes []gatewayv1alpha2.UDPRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1alpha2.UDPRoute {
 	var filtered []gatewayv1alpha2.UDPRoute
 	for _, route := range routes {
-		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(gw, &route, namespaceLabels) {
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, nil) && isAllowed(gw, &route, namespaceLabels) {
 			filtered = append(filtered, route)
 		}
 	}
@@ -737,7 +737,7 @@ func (r *gatewayReconciler) filterUDPRoutesByGateway(ctx context.Context, gw *ga
 func (r *gatewayReconciler) filterTLSRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1.TLSRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1.TLSRoute {
 	var filtered []gatewayv1.TLSRoute
 	for _, route := range routes {
-		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) &&
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, nil) &&
 			listenerisAllowed(gw, listener, &route, namespaceLabels) &&
 			len(computeHostsForListener(listener, route.Spec.Hostnames, nil)) > 0 &&
 			parentRefMatched(gw, listener, route.GetNamespace(), route.Spec.ParentRefs) {
@@ -750,7 +750,7 @@ func (r *gatewayReconciler) filterTLSRoutesByListener(ctx context.Context, gw *g
 func (r *gatewayReconciler) filterTCPRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1alpha2.TCPRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1alpha2.TCPRoute {
 	var filtered []gatewayv1alpha2.TCPRoute
 	for _, route := range routes {
-		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) &&
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, nil) &&
 			listenerisAllowed(gw, listener, &route, namespaceLabels) &&
 			parentRefMatched(gw, listener, route.GetNamespace(), route.Spec.ParentRefs) {
 			filtered = append(filtered, route)
@@ -762,7 +762,7 @@ func (r *gatewayReconciler) filterTCPRoutesByListener(ctx context.Context, gw *g
 func (r *gatewayReconciler) filterUDPRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1alpha2.UDPRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1alpha2.UDPRoute {
 	var filtered []gatewayv1alpha2.UDPRoute
 	for _, route := range routes {
-		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) &&
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, nil) &&
 			listenerisAllowed(gw, listener, &route, namespaceLabels) &&
 			parentRefMatched(gw, listener, route.GetNamespace(), route.Spec.ParentRefs) {
 			filtered = append(filtered, route)

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -117,6 +117,12 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 	}
 
+	mergedListeners, attachedListenerSets, err := r.resolveAllowedListeners(ctx, scopedLog, gw)
+	if err != nil {
+		scopedLog.ErrorContext(ctx, "Unable to resolve allowed ListenerSet listeners", logfields.Error, err)
+		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+	}
+
 	httpRouteList := &gatewayv1.HTTPRouteList{}
 	if err := r.Client.List(ctx, httpRouteList, &client.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector(indexers.GatewayHTTPRouteIndex, client.ObjectKeyFromObject(original).String()),
@@ -141,6 +147,51 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			scopedLog.ErrorContext(ctx, "Unable to list TLSRoutes", logfields.Error, err)
 			return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 		}
+	}
+
+	if helpers.HasListenerSetSupport(r.Client.Scheme()) {
+		for _, ls := range attachedListenerSets {
+			lsKey := client.ObjectKeyFromObject(&ls).String()
+
+			lsHTTPRoutes := &gatewayv1.HTTPRouteList{}
+			if err := r.Client.List(ctx, lsHTTPRoutes, &client.ListOptions{
+				FieldSelector: fields.OneTermEqualSelector(indexers.HTTPRouteListenerSetIndex, lsKey),
+			}); err != nil {
+				scopedLog.ErrorContext(ctx, "Unable to list HTTPRoutes for ListenerSet",
+					logfields.Error, err,
+					logfields.Resource, lsKey)
+			} else {
+				httpRouteList.Items = append(httpRouteList.Items, lsHTTPRoutes.Items...)
+			}
+
+			lsGRPCRoutes := &gatewayv1.GRPCRouteList{}
+			if err := r.Client.List(ctx, lsGRPCRoutes, &client.ListOptions{
+				FieldSelector: fields.OneTermEqualSelector(indexers.GRPCRouteListenerSetIndex, lsKey),
+			}); err != nil {
+				scopedLog.ErrorContext(ctx, "Unable to list GRPCRoutes for ListenerSet",
+					logfields.Error, err,
+					logfields.Resource, lsKey)
+			} else {
+				grpcRouteList.Items = append(grpcRouteList.Items, lsGRPCRoutes.Items...)
+			}
+
+			if helpers.HasTLSRouteSupport(r.Client.Scheme()) {
+				lsTLSRoutes := &gatewayv1.TLSRouteList{}
+				if err := r.Client.List(ctx, lsTLSRoutes, &client.ListOptions{
+					FieldSelector: fields.OneTermEqualSelector(indexers.TLSRouteListenerSetIndex, lsKey),
+				}); err != nil {
+					scopedLog.ErrorContext(ctx, "Unable to list TLSRoutes for ListenerSet",
+						logfields.Error, err,
+						logfields.Resource, lsKey)
+				} else {
+					tlsRouteList.Items = append(tlsRouteList.Items, lsTLSRoutes.Items...)
+				}
+			}
+		}
+
+		httpRouteList.Items = deduplicateHTTPRoutes(httpRouteList.Items)
+		grpcRouteList.Items = deduplicateGRPCRoutes(grpcRouteList.Items)
+		tlsRouteList.Items = deduplicateTLSRoutes(tlsRouteList.Items)
 	}
 
 	btlspList := &gatewayv1.BackendTLSPolicyList{}
@@ -268,6 +319,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		ServiceImports:      serviceImportsList.Items,
 		ReferenceGrants:     grants.Items,
 		BackendTLSPolicyMap: btlspMap,
+		MergedListeners:     mergedListeners,
 	})
 
 	validListener, err := r.setListenerStatus(ctx, gw, httpRouteList, tlsRouteList, grpcRouteList, tcpRouteList, udpRouteList, namespaceLabels)
@@ -612,6 +664,101 @@ func (r *gatewayReconciler) updateStatus(ctx context.Context, original *gatewayv
 		return nil
 	}
 	return r.Client.Status().Update(ctx, new)
+}
+
+func (r *gatewayReconciler) updateListenerSetStatus(ctx context.Context, original *gatewayv1.ListenerSet, new *gatewayv1.ListenerSet) error {
+	oldStatus := original.Status.DeepCopy()
+	newStatus := new.Status.DeepCopy()
+
+	if cmp.Equal(oldStatus, newStatus, cmpopts.IgnoreFields(metav1.Condition{}, lastTransitionTime)) {
+		return nil
+	}
+	return r.Client.Status().Update(ctx, new)
+}
+
+func (r *gatewayReconciler) resolveAllowedListeners(
+	ctx context.Context,
+	scopedLog *slog.Logger,
+	gw *gatewayv1.Gateway,
+) ([]ingestion.ListenerWithContext, []gatewayv1.ListenerSet, error) {
+	gwSource := gatewayFQR(gw)
+
+	var merged []ingestion.ListenerWithContext
+	for _, l := range gw.Spec.Listeners {
+		merged = append(merged, ingestion.ListenerWithContext{
+			Listener: l,
+			Source:   gwSource,
+		})
+	}
+
+	if !helpers.HasListenerSetSupport(r.Client.Scheme()) {
+		return merged, nil, nil
+	}
+
+	lsList := &gatewayv1.ListenerSetList{}
+	if err := r.Client.List(ctx, lsList, &client.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector(indexers.ListenerSetGatewayIndex, client.ObjectKeyFromObject(gw).String()),
+	}); err != nil {
+		return nil, nil, fmt.Errorf("failed to list ListenerSets: %w", err)
+	}
+
+	sortListenerSets(lsList.Items)
+
+	var attachedSets []gatewayv1.ListenerSet
+	for i := range lsList.Items {
+		ls := &lsList.Items[i]
+		if !isListenerSetAllowed(ctx, r.Client, gw, ls, scopedLog) {
+			original := ls.DeepCopy()
+			setListenerSetAccepted(ls, false, "ListenerSet is not allowed by the Gateway's allowedListeners policy", gatewayv1.ListenerSetReasonNotAllowed)
+			setListenerSetProgrammed(ls, false, "ListenerSet is not allowed by the Gateway's allowedListeners policy", gatewayv1.ListenerSetReasonNotAllowed)
+			if err := r.updateListenerSetStatus(ctx, original, ls); err != nil {
+				scopedLog.ErrorContext(ctx, "Unable to update ListenerSet status", logfields.Error, err)
+			}
+			continue
+		}
+		attachedSets = append(attachedSets, *ls)
+
+		lsSource := listenerSetFQR(ls)
+		for _, entry := range ls.Spec.Listeners {
+			listener := helpers.ListenerEntryToListener(entry)
+			merged = append(merged, ingestion.ListenerWithContext{
+				Listener:          listener,
+				Source:            lsSource,
+				AllowedNamespaces: resolveAllowedNamespaces(ctx, r.Client, ls.GetNamespace(), listener, scopedLog),
+			})
+		}
+	}
+
+	attachedCount := int32(len(attachedSets))
+	gw.Status.AttachedListenerSets = &attachedCount
+	return merged, attachedSets, nil
+}
+
+// resolveAllowedNamespaces resolves a listener's allowedRoutes.namespaces policy
+// into a set of namespace names. Returns nil to indicate all namespaces are allowed.
+func resolveAllowedNamespaces(ctx context.Context, c client.Client, listenerNamespace string, listener gatewayv1.Listener, logger *slog.Logger) map[string]struct{} {
+	if listener.AllowedRoutes == nil || listener.AllowedRoutes.Namespaces == nil || listener.AllowedRoutes.Namespaces.From == nil {
+		return map[string]struct{}{listenerNamespace: {}}
+	}
+	switch *listener.AllowedRoutes.Namespaces.From {
+	case gatewayv1.NamespacesFromAll:
+		return nil
+	case gatewayv1.NamespacesFromSame:
+		return map[string]struct{}{listenerNamespace: {}}
+	case gatewayv1.NamespacesFromSelector:
+		nsList := &corev1.NamespaceList{}
+		selector, _ := metav1.LabelSelectorAsSelector(listener.AllowedRoutes.Namespaces.Selector)
+		if err := c.List(ctx, nsList, client.MatchingLabelsSelector{Selector: selector}); err != nil {
+			logger.ErrorContext(ctx, "Unable to list namespaces for listener", logfields.Error, err)
+			return map[string]struct{}{listenerNamespace: {}}
+		}
+		allowed := make(map[string]struct{})
+		for _, ns := range nsList.Items {
+			allowed[ns.Name] = struct{}{}
+		}
+		return allowed
+	}
+	return map[string]struct{}{listenerNamespace: {}}
 }
 
 func (r *gatewayReconciler) filterHTTPRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, routes []gatewayv1.HTTPRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1.HTTPRoute {

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -150,6 +150,26 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 	}
 
+	tcpRouteList := &gatewayv1alpha2.TCPRouteList{}
+	if helpers.HasTCPRouteSupport(r.Client.Scheme()) {
+		if err := r.Client.List(ctx, tcpRouteList, &client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector(indexers.GatewayTCPRouteIndex, client.ObjectKeyFromObject(original).String()),
+		}); err != nil {
+			scopedLog.ErrorContext(ctx, "Unable to list TCPRoutes", logfields.Error, err)
+			return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+		}
+	}
+
+	udpRouteList := &gatewayv1alpha2.UDPRouteList{}
+	if helpers.HasUDPRouteSupport(r.Client.Scheme()) {
+		if err := r.Client.List(ctx, udpRouteList, &client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector(indexers.GatewayUDPRouteIndex, client.ObjectKeyFromObject(original).String()),
+		}); err != nil {
+			scopedLog.ErrorContext(ctx, "Unable to list UDPRoutes", logfields.Error, err)
+			return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+		}
+	}
+
 	if helpers.HasListenerSetSupport(r.Client.Scheme()) {
 		for _, ls := range attachedListenerSets {
 			lsKey := client.ObjectKeyFromObject(&ls).String()
@@ -188,11 +208,39 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 					tlsRouteList.Items = append(tlsRouteList.Items, lsTLSRoutes.Items...)
 				}
 			}
+
+			if helpers.HasTCPRouteSupport(r.Client.Scheme()) {
+				lsTCPRoutes := &gatewayv1alpha2.TCPRouteList{}
+				if err := r.Client.List(ctx, lsTCPRoutes, &client.ListOptions{
+					FieldSelector: fields.OneTermEqualSelector(indexers.TCPRouteListenerSetIndex, lsKey),
+				}); err != nil {
+					scopedLog.ErrorContext(ctx, "Unable to list TCPRoutes for ListenerSet",
+						logfields.Error, err,
+						logfields.Resource, lsKey)
+				} else {
+					tcpRouteList.Items = append(tcpRouteList.Items, lsTCPRoutes.Items...)
+				}
+			}
+
+			if helpers.HasUDPRouteSupport(r.Client.Scheme()) {
+				lsUDPRoutes := &gatewayv1alpha2.UDPRouteList{}
+				if err := r.Client.List(ctx, lsUDPRoutes, &client.ListOptions{
+					FieldSelector: fields.OneTermEqualSelector(indexers.UDPRouteListenerSetIndex, lsKey),
+				}); err != nil {
+					scopedLog.ErrorContext(ctx, "Unable to list UDPRoutes for ListenerSet",
+						logfields.Error, err,
+						logfields.Resource, lsKey)
+				} else {
+					udpRouteList.Items = append(udpRouteList.Items, lsUDPRoutes.Items...)
+				}
+			}
 		}
 
 		httpRouteList.Items = deduplicateHTTPRoutes(httpRouteList.Items)
 		grpcRouteList.Items = deduplicateGRPCRoutes(grpcRouteList.Items)
 		tlsRouteList.Items = deduplicateTLSRoutes(tlsRouteList.Items)
+		tcpRouteList.Items = deduplicateTCPRoutes(tcpRouteList.Items)
+		udpRouteList.Items = deduplicateUDPRoutes(udpRouteList.Items)
 	}
 
 	btlspList := &gatewayv1.BackendTLSPolicyList{}
@@ -201,26 +249,6 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
 	btlspMap := helpers.BuildBackendTLSPolicyLookup(btlspList)
-
-	tcpRouteList := &gatewayv1alpha2.TCPRouteList{}
-	if helpers.HasTCPRouteSupport(r.Client.Scheme()) {
-		if err := r.Client.List(ctx, tcpRouteList, &client.ListOptions{
-			FieldSelector: fields.OneTermEqualSelector(indexers.GatewayTCPRouteIndex, client.ObjectKeyFromObject(original).String()),
-		}); err != nil {
-			scopedLog.ErrorContext(ctx, "Unable to list TCPRoutes", logfields.Error, err)
-			return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
-		}
-	}
-
-	udpRouteList := &gatewayv1alpha2.UDPRouteList{}
-	if helpers.HasUDPRouteSupport(r.Client.Scheme()) {
-		if err := r.Client.List(ctx, udpRouteList, &client.ListOptions{
-			FieldSelector: fields.OneTermEqualSelector(indexers.GatewayUDPRouteIndex, client.ObjectKeyFromObject(original).String()),
-		}); err != nil {
-			scopedLog.ErrorContext(ctx, "Unable to list UDPRoutes", logfields.Error, err)
-			return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
-		}
-	}
 
 	var namespaces []corev1.Namespace
 	if hasAllowedRoutesNamespaceSelector(gw, attachedListenerSets) {
@@ -298,8 +326,8 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	httpRoutes := r.filterHTTPRoutesByGateway(ctx, gw, attachedListenerSets, httpRouteList.Items, namespaceLabels)
 	tlsRoutes := r.filterTLSRoutesByGateway(ctx, gw, attachedListenerSets, tlsRouteList.Items, namespaceLabels)
 	grpcRoutes := r.filterGRPCRoutesByGateway(ctx, gw, attachedListenerSets, grpcRouteList.Items, namespaceLabels)
-	tcpRoutes := r.filterTCPRoutesByGateway(ctx, gw, tcpRouteList.Items, namespaceLabels)
-	udpRoutes := r.filterUDPRoutesByGateway(ctx, gw, udpRouteList.Items, namespaceLabels)
+	tcpRoutes := r.filterTCPRoutesByGateway(ctx, gw, attachedListenerSets, tcpRouteList.Items, namespaceLabels)
+	udpRoutes := r.filterUDPRoutesByGateway(ctx, gw, attachedListenerSets, udpRouteList.Items, namespaceLabels)
 
 	if err := r.setBackendTLSPolicyStatuses(scopedLog, ctx, httpRoutes, btlspMap, req.NamespacedName); err != nil {
 		scopedLog.ErrorContext(ctx, "Unable to update BackendTLSPolicy Status", logfields.Error, err)
@@ -331,7 +359,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
 
-	r.setListenerSetStatuses(ctx, gw, attachedListenerSets, httpRouteList, tlsRouteList, grpcRouteList, namespaceLabels)
+	r.setListenerSetStatuses(ctx, gw, attachedListenerSets, httpRouteList, tlsRouteList, grpcRouteList, tcpRouteList, udpRouteList, namespaceLabels)
 	if !validListener {
 		err := fmt.Errorf("No Accepted Listeners for Gateway")
 		scopedLog.ErrorContext(ctx, "No Accepted Listeners for Gateway", logfields.Error, err)
@@ -896,20 +924,20 @@ func (r *gatewayReconciler) filterTLSRoutesByGateway(ctx context.Context, gw *ga
 	return filtered
 }
 
-func (r *gatewayReconciler) filterTCPRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, routes []gatewayv1alpha2.TCPRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1alpha2.TCPRoute {
+func (r *gatewayReconciler) filterTCPRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, attachedListenerSets []gatewayv1.ListenerSet, routes []gatewayv1alpha2.TCPRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1alpha2.TCPRoute {
 	var filtered []gatewayv1alpha2.TCPRoute
 	for _, route := range routes {
-		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, nil) && isAllowed(gw, &route, namespaceLabels) {
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, attachedListenerSets) && isAllowed(gw, &route, namespaceLabels) {
 			filtered = append(filtered, route)
 		}
 	}
 	return filtered
 }
 
-func (r *gatewayReconciler) filterUDPRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, routes []gatewayv1alpha2.UDPRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1alpha2.UDPRoute {
+func (r *gatewayReconciler) filterUDPRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, attachedListenerSets []gatewayv1.ListenerSet, routes []gatewayv1alpha2.UDPRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1alpha2.UDPRoute {
 	var filtered []gatewayv1alpha2.UDPRoute
 	for _, route := range routes {
-		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, nil) && isAllowed(gw, &route, namespaceLabels) {
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, attachedListenerSets) && isAllowed(gw, &route, namespaceLabels) {
 			filtered = append(filtered, route)
 		}
 	}
@@ -930,24 +958,26 @@ func (r *gatewayReconciler) filterTLSRoutesByListener(ctx context.Context, gw *g
 	return filtered
 }
 
-func (r *gatewayReconciler) filterTCPRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1alpha2.TCPRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1alpha2.TCPRoute {
+func (r *gatewayReconciler) filterTCPRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, listenerSource *model.FullyQualifiedResource, routes []gatewayv1alpha2.TCPRoute, namespaceLabels helpers.NamespaceLabelIndex, attachedListenerSets ...gatewayv1.ListenerSet) []gatewayv1alpha2.TCPRoute {
+	lsNS := listenerOwnerNamespace(gw, listenerSource)
 	var filtered []gatewayv1alpha2.TCPRoute
 	for _, route := range routes {
-		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, nil) &&
-			listenerisAllowed(gw.GetNamespace(), listener, &route, namespaceLabels) &&
-			parentRefMatched(gw, listener, nil, route.GetNamespace(), route.Spec.ParentRefs) {
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, attachedListenerSets) &&
+			listenerisAllowed(lsNS, listener, &route, namespaceLabels) &&
+			parentRefMatched(gw, listener, listenerSource, route.GetNamespace(), route.Spec.ParentRefs) {
 			filtered = append(filtered, route)
 		}
 	}
 	return filtered
 }
 
-func (r *gatewayReconciler) filterUDPRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1alpha2.UDPRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1alpha2.UDPRoute {
+func (r *gatewayReconciler) filterUDPRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, listenerSource *model.FullyQualifiedResource, routes []gatewayv1alpha2.UDPRoute, namespaceLabels helpers.NamespaceLabelIndex, attachedListenerSets ...gatewayv1.ListenerSet) []gatewayv1alpha2.UDPRoute {
+	lsNS := listenerOwnerNamespace(gw, listenerSource)
 	var filtered []gatewayv1alpha2.UDPRoute
 	for _, route := range routes {
-		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, nil) &&
-			listenerisAllowed(gw.GetNamespace(), listener, &route, namespaceLabels) &&
-			parentRefMatched(gw, listener, nil, route.GetNamespace(), route.Spec.ParentRefs) {
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents, attachedListenerSets) &&
+			listenerisAllowed(lsNS, listener, &route, namespaceLabels) &&
+			parentRefMatched(gw, listener, listenerSource, route.GetNamespace(), route.Spec.ParentRefs) {
 			filtered = append(filtered, route)
 		}
 	}
@@ -1155,8 +1185,8 @@ func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1
 		attachedRoutes += int32(len(r.filterHTTPRoutesByListener(ctx, gw, &l, &gwSource, httpRoutes.Items, namespaceLabels)))
 		attachedRoutes += int32(len(r.filterGRPCRoutesByListener(ctx, gw, &l, &gwSource, grpcRoutes.Items, namespaceLabels)))
 		attachedRoutes += int32(len(r.filterTLSRoutesByListener(ctx, gw, &l, &gwSource, tlsRoutes.Items, namespaceLabels)))
-		attachedRoutes += int32(len(r.filterTCPRoutesByListener(ctx, gw, &l, tcpRoutes.Items, namespaceLabels)))
-		attachedRoutes += int32(len(r.filterUDPRoutesByListener(ctx, gw, &l, udpRoutes.Items, namespaceLabels)))
+		attachedRoutes += int32(len(r.filterTCPRoutesByListener(ctx, gw, &l, &gwSource, tcpRoutes.Items, namespaceLabels)))
+		attachedRoutes += int32(len(r.filterUDPRoutesByListener(ctx, gw, &l, &gwSource, udpRoutes.Items, namespaceLabels)))
 
 		found := false
 		for i := range gw.Status.Listeners {
@@ -1487,6 +1517,8 @@ func (r *gatewayReconciler) setListenerSetStatuses(
 	httpRoutes *gatewayv1.HTTPRouteList,
 	tlsRoutes *gatewayv1.TLSRouteList,
 	grpcRoutes *gatewayv1.GRPCRouteList,
+	tcpRoutes *gatewayv1alpha2.TCPRouteList,
+	udpRoutes *gatewayv1alpha2.UDPRouteList,
 	namespaceLabels helpers.NamespaceLabelIndex,
 ) {
 	gw.Status.AttachedListenerSets = nil
@@ -1581,6 +1613,8 @@ func (r *gatewayReconciler) setListenerSetStatuses(
 			attachedRoutes += int32(len(r.filterHTTPRoutesByListener(ctx, gw, &l, &lsSource, httpRoutes.Items, namespaceLabels, *ls)))
 			attachedRoutes += int32(len(r.filterGRPCRoutesByListener(ctx, gw, &l, &lsSource, grpcRoutes.Items, namespaceLabels, *ls)))
 			attachedRoutes += int32(len(r.filterTLSRoutesByListener(ctx, gw, &l, &lsSource, tlsRoutes.Items, namespaceLabels, *ls)))
+			attachedRoutes += int32(len(r.filterTCPRoutesByListener(ctx, gw, &l, &lsSource, tcpRoutes.Items, namespaceLabels, *ls)))
+			attachedRoutes += int32(len(r.filterUDPRoutesByListener(ctx, gw, &l, &lsSource, udpRoutes.Items, namespaceLabels, *ls)))
 
 			listenerStatuses = append(listenerStatuses, gatewayv1.ListenerEntryStatus{
 				Name:           entry.Name,

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -330,6 +330,8 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		setGatewayProgrammed(gw, metav1.ConditionFalse, "Unable to set listener status", gatewayv1.GatewayReasonListenersNotValid)
 		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
+
+	r.setListenerSetStatuses(ctx, gw, attachedListenerSets, httpRouteList, tlsRouteList, grpcRouteList, namespaceLabels)
 	if !validListener {
 		err := fmt.Errorf("No Accepted Listeners for Gateway")
 		scopedLog.ErrorContext(ctx, "No Accepted Listeners for Gateway", logfields.Error, err)
@@ -730,8 +732,6 @@ func (r *gatewayReconciler) resolveAllowedListeners(
 		}
 	}
 
-	attachedCount := int32(len(attachedSets))
-	gw.Status.AttachedListenerSets = &attachedCount
 	return merged, attachedSets, nil
 }
 
@@ -1084,112 +1084,38 @@ func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1
 		return false, fmt.Errorf("failed to retrieve reference grants: %w", err)
 	}
 
-	conflictedListeners := samePortCrossProtocolConflictedListeners(gw)
+	conflictedListeners := conflictedGatewayListeners(gw)
 
 	// Keep track of if there is at least one Valid Listener; if not, the Gateway cannot be Accepted.
 	oneValidListener := false
 	for _, l := range gw.Spec.Listeners {
 		isValid := true
 		var invalidMessages []string
-		invalidReason := gatewayv1.ListenerReasonInvalid
 
 		var conds []metav1.Condition
 
-		if conflictMessage, ok := conflictedListeners[l.Name]; ok {
-			conds = merge(conds, gatewayListenerConflictedCondition(gw, gatewayv1.ListenerReasonProtocolConflict, conflictMessage))
-			invalidMessages = append(invalidMessages, conflictMessage)
+		if conflict, ok := conflictedListeners[l.Name]; ok {
+			conds = merge(conds, listenerConflictedCondition(gw.GetGeneration(), conflict.reason, conflict.message))
+			invalidMessages = append(invalidMessages, conflict.message)
 			isValid = false
 		}
 
-		allSupported := getSupportedRouteKinds(l.Protocol)
-		if allSupported == nil {
-			invalidMessages = append(invalidMessages, "Unsupported Listener Protocol.")
-			isValid = false
-		}
-		supportedKinds := []gatewayv1.RouteGroupKind{}
-
-		if l.AllowedRoutes != nil && len(l.AllowedRoutes.Kinds) > 0 {
-			for _, supported := range allSupported {
-				for _, allowed := range l.AllowedRoutes.Kinds {
-					if supported.Kind == allowed.Kind &&
-						groupDerefOr(allowed.Group, gatewayv1.GroupName) == string(*supported.Group) {
-						supportedKinds = append(supportedKinds, supported)
-						break
-					}
-				}
-			}
-
-			// Add ResolvedRefs if not all explicitly allowed kinds are actually supported
-			if len(supportedKinds) != len(l.AllowedRoutes.Kinds) {
-				conds = merge(conds, gatewayListenerInvalidRouteKinds(gw, "Unsupported Route Kinds in allowedRoutes.kinds"))
-			}
-		} else {
-			// If there are no Kinds specified in AllowedRoutes, then supportedKinds should contain
-			// all the supported Kinds for that Protocol.
-			supportedKinds = allSupported
-		}
-
-		if l.TLS != nil {
-			for _, cert := range l.TLS.CertificateRefs {
-				if !helpers.IsSecret(cert) {
-					conds = merge(conds, metav1.Condition{
-						Type:               string(gatewayv1.ListenerConditionResolvedRefs),
-						Status:             metav1.ConditionFalse,
-						Reason:             string(gatewayv1.ListenerReasonInvalidCertificateRef),
-						Message:            "Invalid CertificateRef",
-						LastTransitionTime: metav1.Now(),
-					})
-					invalidMessages = append(invalidMessages, "Invalid CertificateRef, must be a Secret.")
-					isValid = false
-					break
-				}
-
-				if !helpers.IsSecretReferenceAllowed(gw.Namespace, cert, gatewayv1.SchemeGroupVersion.WithKind("Gateway"), grants.Items) {
-					conds = merge(conds, metav1.Condition{
-						Type:               string(gatewayv1.ListenerConditionResolvedRefs),
-						Status:             metav1.ConditionFalse,
-						Reason:             string(gatewayv1.ListenerReasonRefNotPermitted),
-						Message:            "CertificateRef is not permitted",
-						LastTransitionTime: metav1.Now(),
-					})
-					invalidMessages = append(invalidMessages, "Invalid CertificateRef, not permitted.")
-					isValid = false
-					break
-				}
-
-				if err := validateTLSSecret(ctx, r.Client, helpers.NamespaceDerefOr(cert.Namespace, gw.GetNamespace()), string(cert.Name)); err != nil {
-					r.logger.InfoContext(ctx, "Found an invalid TLS Secret",
-						logfields.Error, err.Error(),
-						logfields.Resource, client.ObjectKeyFromObject(gw).String())
-					conds = merge(conds, metav1.Condition{
-						Type:               string(gatewayv1.ListenerConditionResolvedRefs),
-						Status:             metav1.ConditionFalse,
-						Reason:             string(gatewayv1.ListenerReasonInvalidCertificateRef),
-						Message:            "Invalid CertificateRef",
-						LastTransitionTime: metav1.Now(),
-					})
-					invalidMessages = append(invalidMessages, "Invalid CertificateRef, "+err.Error())
-					isValid = false
-					break
-				}
-			}
-			// Handle terminated TLSRoute until we support it
-			if l.Protocol == gatewayv1.TLSProtocolType && *l.TLS.Mode == gatewayv1.TLSModeTerminate {
-				// Until we support this, we need to mark this as invalid.
-				isValid = false
-				invalidMessages = append(invalidMessages, "Using TLSRoute with TLS.mode Terminate is unsupported.")
-				invalidReason = gatewayv1.ListenerReasonUnsupportedValue
-				// The specific conformance test for this expects supportedKinds to be empty.
-				// This is probably an upstream bug, but work around it for now.
-				supportedKinds = []gatewayv1.RouteGroupKind{}
-			}
-
-		}
+		res := r.validateListener(ctx, l, listenerValidationParams{
+			ownerNamespace: gw.Namespace,
+			ownerKind:      "Gateway",
+			generation:     gw.GetGeneration(),
+			grants:         grants.Items,
+			ownerRef:       client.ObjectKeyFromObject(gw).String(),
+		})
+		isValid = isValid && res.isValid
+		invalidMessages = append(invalidMessages, res.invalidMessages...)
+		conds = merge(conds, res.conds...)
+		supportedKinds := res.supportedKinds
 
 		if !isValid {
 			conds = merge(conds,
-				gatewayListenerAcceptedCondition(gw, false, invalidReason, "Listener not valid. "+strings.Join(invalidMessages, " ")),
-				gatewayListenerProgrammedCondition(gw, false, "Address not ready yet"))
+				listenerAcceptedCondition(gw.GetGeneration(), false, res.invalidReason, "Listener not valid. "+strings.Join(invalidMessages, " ")),
+				listenerProgrammedCondition(gw.GetGeneration(), false, gatewayv1.ListenerReasonPending, "Address not ready yet"))
 			// If the Listener is not valid, then no kinds are supported
 			// supportedKinds = []gatewayv1.RouteGroupKind{}
 		} else {
@@ -1207,8 +1133,8 @@ func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1
 				})
 			}
 			conds = merge(conds,
-				gatewayListenerAcceptedCondition(gw, true, gatewayv1.ListenerReasonAccepted, "Listener Accepted"),
-				gatewayListenerProgrammedCondition(gw, false, "Address not ready yet"))
+				listenerAcceptedCondition(gw.GetGeneration(), true, gatewayv1.ListenerReasonAccepted, "Listener Accepted"),
+				listenerProgrammedCondition(gw.GetGeneration(), false, gatewayv1.ListenerReasonPending, "Address not ready yet"))
 		}
 		gwSource := gatewayFQR(gw)
 		var attachedRoutes int32
@@ -1252,41 +1178,111 @@ func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1
 	return oneValidListener, nil
 }
 
-func samePortCrossProtocolConflictedListeners(gw *gatewayv1.Gateway) map[gatewayv1.SectionName]string {
-	conflicted := map[gatewayv1.SectionName]string{}
+type listenerConflict struct {
+	reason  gatewayv1.ListenerConditionReason
+	message string
+}
+
+func conflictedGatewayListeners(gw *gatewayv1.Gateway) map[gatewayv1.SectionName]listenerConflict {
+	conflicts := map[gatewayv1.SectionName]listenerConflict{}
 
 	for i := range gw.Spec.Listeners {
 		for j := i + 1; j < len(gw.Spec.Listeners); j++ {
 			first := &gw.Spec.Listeners[i]
 			second := &gw.Spec.Listeners[j]
-			if !listenersHaveSamePortCrossProtocolHostnameConflict(first, second) {
+			reason, ok := listenerPairConflict(first, second)
+			if !ok {
 				continue
 			}
 
-			conflicted[first.Name] = samePortCrossProtocolConflictMessage(second.Name, first.Port)
-			conflicted[second.Name] = samePortCrossProtocolConflictMessage(first.Name, second.Port)
+			conflicts[first.Name] = listenerConflict{
+				reason:  reason,
+				message: listenerConflictMessage(reason, first, second),
+			}
+			conflicts[second.Name] = listenerConflict{
+				reason:  reason,
+				message: listenerConflictMessage(reason, second, first),
+			}
 		}
 	}
 
-	return conflicted
+	return conflicts
 }
 
-func listenersHaveSamePortCrossProtocolHostnameConflict(first, second *gatewayv1.Listener) bool {
+// listenerPairConflict reports whether two listeners that share a Gateway, or a
+// Gateway and its ListenerSets, conflict, along with the reason. Listeners on
+// different ports never conflict.
+func listenerPairConflict(first, second *gatewayv1.Listener) (gatewayv1.ListenerConditionReason, bool) {
 	if first.Port != second.Port {
-		return false
+		return "", false
 	}
 
-	if helpers.IsHTTPSTerminatedListener(first) && helpers.IsTLSPassthroughListener(second) {
-		return helpers.SNIHostnamesIntersect(helpers.ListenerHostname(first), helpers.ListenerHostname(second))
+	firstL4 := isL4Protocol(first.Protocol)
+	secondL4 := isL4Protocol(second.Protocol)
+
+	// L4 listeners own a port outright with no demultiplexing. TCP and UDP on
+	// the same port are the only compatible case involving an L4 listener.
+	if firstL4 || secondL4 {
+		if firstL4 && secondL4 && first.Protocol != second.Protocol {
+			return "", false
+		}
+		return gatewayv1.ListenerReasonProtocolConflict, true
 	}
-	if helpers.IsHTTPSTerminatedListener(second) && helpers.IsTLSPassthroughListener(first) {
-		return helpers.SNIHostnamesIntersect(helpers.ListenerHostname(first), helpers.ListenerHostname(second))
+
+	// HTTPS termination and TLS passthrough both consume the SNI of the same
+	// port, so they conflict whenever their hostnames can match the same value.
+	if isHTTPSAndTLSPassthroughPair(first, second) {
+		if helpers.SNIHostnamesIntersect(
+			helpers.ListenerHostname(first), helpers.ListenerHostname(second)) {
+			return gatewayv1.ListenerReasonProtocolConflict, true
+		}
+		return "", false
 	}
-	return false
+
+	// Listeners of the same muxed protocol demultiplex by hostname, so they only
+	// conflict when they claim the exact same hostname.
+	if first.Protocol == second.Protocol &&
+		normalizedListenerHostname(first) == normalizedListenerHostname(second) {
+		return gatewayv1.ListenerReasonHostnameConflict, true
+	}
+
+	return "", false
 }
 
-func samePortCrossProtocolConflictMessage(listenerName gatewayv1.SectionName, port gatewayv1.PortNumber) string {
-	return fmt.Sprintf("Listener conflicts with listener %q: same port %d has overlapping HTTPS and TLS passthrough hostnames.", listenerName, port)
+func isL4Protocol(p gatewayv1.ProtocolType) bool {
+	return p == gatewayv1.TCPProtocolType || p == gatewayv1.UDPProtocolType
+}
+
+func isHTTPSAndTLSPassthroughPair(first, second *gatewayv1.Listener) bool {
+	return (helpers.IsHTTPSTerminatedListener(first) && helpers.IsTLSPassthroughListener(second)) ||
+		(helpers.IsHTTPSTerminatedListener(second) && helpers.IsTLSPassthroughListener(first))
+}
+
+func normalizedListenerHostname(l *gatewayv1.Listener) string {
+	if h := helpers.ListenerHostname(l); h != "" {
+		return h
+	}
+	return "*"
+}
+
+func listenerConflictMessage(
+	reason gatewayv1.ListenerConditionReason,
+	self, other *gatewayv1.Listener,
+) string {
+	switch {
+	case reason == gatewayv1.ListenerReasonHostnameConflict:
+		return fmt.Sprintf(
+			"Listener conflicts with listener %q: same port %d has overlapping hostnames.",
+			other.Name, self.Port)
+	case isHTTPSAndTLSPassthroughPair(self, other):
+		return fmt.Sprintf(
+			"Listener conflicts with listener %q: same port %d has overlapping HTTPS and TLS passthrough hostnames.",
+			other.Name, self.Port)
+	default:
+		return fmt.Sprintf(
+			"Listener conflicts with listener %q: same port %d has incompatible protocols.",
+			other.Name, self.Port)
+	}
 }
 
 func validateTLSSecret(ctx context.Context, c client.Client, namespace, name string) error {
@@ -1335,86 +1331,385 @@ func (r *gatewayReconciler) verifyGatewayStaticAddresses(gw *gatewayv1.Gateway) 
 	return nil
 }
 
+type listenerValidationParams struct {
+	ownerNamespace string
+	ownerKind      string
+	generation     int64
+	grants         []gatewayv1.ReferenceGrant
+	ownerRef       string
+}
+
+type listenerValidationResult struct {
+	isValid         bool
+	supportedKinds  []gatewayv1.RouteGroupKind
+	invalidReason   gatewayv1.ListenerConditionReason
+	invalidMessages []string
+	conds           []metav1.Condition
+}
+
+func (r *gatewayReconciler) validateListener(ctx context.Context, l gatewayv1.Listener, params listenerValidationParams) listenerValidationResult {
+	res := listenerValidationResult{
+		isValid:       true,
+		invalidReason: gatewayv1.ListenerReasonInvalid,
+	}
+
+	allSupported := getSupportedRouteKinds(l.Protocol)
+	if allSupported == nil {
+		res.invalidMessages = append(res.invalidMessages, "Unsupported Listener Protocol.")
+		res.isValid = false
+	}
+
+	if l.AllowedRoutes != nil && len(l.AllowedRoutes.Kinds) > 0 {
+		res.supportedKinds = []gatewayv1.RouteGroupKind{}
+		for _, supported := range allSupported {
+			for _, allowed := range l.AllowedRoutes.Kinds {
+				if supported.Kind == allowed.Kind &&
+					groupDerefOr(allowed.Group, gatewayv1.GroupName) == string(*supported.Group) {
+					res.supportedKinds = append(res.supportedKinds, supported)
+					break
+				}
+			}
+		}
+
+		if len(res.supportedKinds) != len(l.AllowedRoutes.Kinds) {
+			res.conds = merge(res.conds, listenerInvalidRouteKinds(params.generation, "Unsupported Route Kinds in allowedRoutes.kinds"))
+
+			if len(res.supportedKinds) == 0 {
+				res.invalidMessages = append(res.invalidMessages, "None of the Allowed Route Kinds are supported.")
+				res.isValid = false
+			}
+		}
+	} else {
+		res.supportedKinds = allSupported
+	}
+
+	if l.TLS != nil {
+		ownerGVK := gatewayv1.SchemeGroupVersion.WithKind(params.ownerKind)
+		for _, cert := range l.TLS.CertificateRefs {
+			if !helpers.IsSecret(cert) {
+				res.conds = merge(res.conds, metav1.Condition{
+					Type:               string(gatewayv1.ListenerConditionResolvedRefs),
+					Status:             metav1.ConditionFalse,
+					Reason:             string(gatewayv1.ListenerReasonInvalidCertificateRef),
+					Message:            "Invalid CertificateRef",
+					ObservedGeneration: params.generation,
+					LastTransitionTime: metav1.Now(),
+				})
+				res.invalidMessages = append(res.invalidMessages, "Invalid CertificateRef, must be a Secret.")
+				res.isValid = false
+				break
+			}
+
+			if !helpers.IsSecretReferenceAllowed(params.ownerNamespace, cert, ownerGVK, params.grants) {
+				res.conds = merge(res.conds, metav1.Condition{
+					Type:               string(gatewayv1.ListenerConditionResolvedRefs),
+					Status:             metav1.ConditionFalse,
+					Reason:             string(gatewayv1.ListenerReasonRefNotPermitted),
+					Message:            "CertificateRef is not permitted",
+					ObservedGeneration: params.generation,
+					LastTransitionTime: metav1.Now(),
+				})
+				res.invalidMessages = append(res.invalidMessages, "Invalid CertificateRef, not permitted.")
+				res.isValid = false
+				break
+			}
+
+			if err := validateTLSSecret(ctx, r.Client, helpers.NamespaceDerefOr(cert.Namespace, params.ownerNamespace), string(cert.Name)); err != nil {
+				r.logger.InfoContext(ctx, "Found an invalid TLS Secret",
+					logfields.Error, err.Error(),
+					logfields.Resource, params.ownerRef)
+				res.conds = merge(res.conds, metav1.Condition{
+					Type:               string(gatewayv1.ListenerConditionResolvedRefs),
+					Status:             metav1.ConditionFalse,
+					Reason:             string(gatewayv1.ListenerReasonInvalidCertificateRef),
+					Message:            "Invalid CertificateRef",
+					ObservedGeneration: params.generation,
+					LastTransitionTime: metav1.Now(),
+				})
+				res.invalidMessages = append(res.invalidMessages, "Invalid CertificateRef, "+err.Error())
+				res.isValid = false
+				break
+			}
+		}
+		// Handle terminated TLSRoute until we support it
+		if l.Protocol == gatewayv1.TLSProtocolType && l.TLS.Mode != nil && *l.TLS.Mode == gatewayv1.TLSModeTerminate {
+			// Until we support this, we need to mark this as invalid.
+			res.isValid = false
+			res.invalidMessages = append(res.invalidMessages, "Using TLSRoute with TLS.mode Terminate is unsupported.")
+			res.invalidReason = gatewayv1.ListenerReasonUnsupportedValue
+			// The specific conformance test for this expects supportedKinds to be empty.
+			// This is probably an upstream bug, but work around it for now.
+			res.supportedKinds = []gatewayv1.RouteGroupKind{}
+		}
+	}
+
+	return res
+}
+
+// acceptedListeners is an ordered accumulator of listeners that have already
+// won their port. Listeners are checked against it in precedence order, so an
+// earlier listener keeps the port and a later conflicting one is rejected.
+type acceptedListeners struct {
+	listeners []gatewayv1.Listener
+}
+
+func (a *acceptedListeners) checkConflict(l gatewayv1.Listener) gatewayv1.ListenerConditionReason {
+	for i := range a.listeners {
+		if reason, ok := listenerPairConflict(&a.listeners[i], &l); ok {
+			return reason
+		}
+	}
+	return ""
+}
+
+func (a *acceptedListeners) accept(l gatewayv1.Listener) {
+	a.listeners = append(a.listeners, l)
+}
+
+func (r *gatewayReconciler) setListenerSetStatuses(
+	ctx context.Context,
+	gw *gatewayv1.Gateway,
+	attachedListenerSets []gatewayv1.ListenerSet,
+	httpRoutes *gatewayv1.HTTPRouteList,
+	tlsRoutes *gatewayv1.TLSRouteList,
+	grpcRoutes *gatewayv1.GRPCRouteList,
+	namespaceLabels helpers.NamespaceLabelIndex,
+) {
+	gw.Status.AttachedListenerSets = nil
+
+	grants := &gatewayv1.ReferenceGrantList{}
+	if err := r.Client.List(ctx, grants); err != nil {
+		r.logger.ErrorContext(ctx, "Failed to list ReferenceGrants for ListenerSet status", logfields.Error, err)
+		return
+	}
+
+	// Seed the accumulator with the direct Gateway listeners, which take
+	// precedence over any ListenerSet listener.
+	accepted := &acceptedListeners{}
+	for _, l := range gw.Spec.Listeners {
+		accepted.accept(l)
+	}
+
+	var validAttachedCount int32
+	for i := range attachedListenerSets {
+		ls := &attachedListenerSets[i]
+		original := ls.DeepCopy()
+
+		oneValidListener := false
+		var listenerStatuses []gatewayv1.ListenerEntryStatus
+
+		for _, entry := range ls.Spec.Listeners {
+			l := helpers.ListenerEntryToListener(entry)
+			var conds []metav1.Condition
+
+			conflictReason := accepted.checkConflict(l)
+			isConflicted := conflictReason != ""
+
+			if isConflicted {
+				conds = merge(conds,
+					listenerAcceptedCondition(ls.GetGeneration(), false, conflictReason, "Listener has a conflict"),
+					listenerProgrammedCondition(ls.GetGeneration(), false, conflictReason, "Listener has a conflict"),
+					listenerConflictedCondition(ls.GetGeneration(), conflictReason, "Listener has a conflict"),
+					metav1.Condition{
+						Type:               string(gatewayv1.ListenerConditionResolvedRefs),
+						Status:             metav1.ConditionTrue,
+						Reason:             string(gatewayv1.ListenerReasonResolvedRefs),
+						Message:            "Resolved Refs",
+						ObservedGeneration: ls.GetGeneration(),
+						LastTransitionTime: metav1.Now(),
+					},
+				)
+			}
+
+			var supportedKinds []gatewayv1.RouteGroupKind
+			if !isConflicted {
+				res := r.validateListener(ctx, l, listenerValidationParams{
+					ownerNamespace: ls.Namespace,
+					ownerKind:      "ListenerSet",
+					generation:     ls.GetGeneration(),
+					grants:         grants.Items,
+					ownerRef:       client.ObjectKeyFromObject(ls).String(),
+				})
+				isValid := res.isValid
+				supportedKinds = res.supportedKinds
+				conds = merge(conds, res.conds...)
+
+				if !isValid {
+					conds = merge(conds,
+						listenerAcceptedCondition(ls.GetGeneration(), false, res.invalidReason, "Listener not valid. "+strings.Join(res.invalidMessages, " ")),
+						listenerProgrammedCondition(ls.GetGeneration(), false, res.invalidReason, "Listener not valid"),
+					)
+				} else {
+					oneValidListener = true
+					// Claim this slot for subsequent listeners
+					accepted.accept(l)
+
+					// If ResolvedRefs is not already present, add a successful one.
+					if !helpers.IsConditionPresent(conds, string(gatewayv1.ListenerConditionResolvedRefs)) {
+						conds = merge(conds, metav1.Condition{
+							Type:               string(gatewayv1.ListenerConditionResolvedRefs),
+							Status:             metav1.ConditionTrue,
+							Reason:             string(gatewayv1.ListenerReasonResolvedRefs),
+							Message:            "Resolved Refs",
+							ObservedGeneration: ls.GetGeneration(),
+							LastTransitionTime: metav1.Now(),
+						})
+					}
+					conds = merge(conds,
+						listenerAcceptedCondition(ls.GetGeneration(), true, gatewayv1.ListenerReasonAccepted, "Listener Accepted"),
+						listenerProgrammedCondition(ls.GetGeneration(), true, gatewayv1.ListenerConditionReason(gatewayv1.ListenerConditionProgrammed), "Listener Programmed"),
+					)
+				}
+			}
+
+			lsSource := listenerSetFQR(ls)
+			var attachedRoutes int32
+			attachedRoutes += int32(len(r.filterHTTPRoutesByListener(ctx, gw, &l, &lsSource, httpRoutes.Items, namespaceLabels, *ls)))
+			attachedRoutes += int32(len(r.filterGRPCRoutesByListener(ctx, gw, &l, &lsSource, grpcRoutes.Items, namespaceLabels, *ls)))
+			attachedRoutes += int32(len(r.filterTLSRoutesByListener(ctx, gw, &l, &lsSource, tlsRoutes.Items, namespaceLabels, *ls)))
+
+			listenerStatuses = append(listenerStatuses, gatewayv1.ListenerEntryStatus{
+				Name:           entry.Name,
+				SupportedKinds: supportedKinds,
+				Conditions:     conds,
+				AttachedRoutes: attachedRoutes,
+			})
+		}
+
+		ls.Status.Listeners = listenerStatuses
+
+		if oneValidListener {
+			validAttachedCount++
+			setListenerSetAccepted(ls, true, "ListenerSet is accepted", gatewayv1.ListenerSetReasonAccepted)
+			setListenerSetProgrammed(ls, true, "ListenerSet is programmed", gatewayv1.ListenerSetReasonProgrammed)
+		} else {
+			setListenerSetAccepted(ls, false, "No valid listeners", gatewayv1.ListenerSetReasonListenersNotValid)
+			setListenerSetProgrammed(ls, false, "No valid listeners", gatewayv1.ListenerSetReasonListenersNotValid)
+		}
+
+		if err := r.updateListenerSetStatus(ctx, original, ls); err != nil {
+			r.logger.ErrorContext(ctx, "Unable to update ListenerSet status", logfields.Error, err,
+				logfields.Resource, client.ObjectKeyFromObject(ls).String())
+		}
+	}
+
+	if validAttachedCount > 0 {
+		gw.Status.AttachedListenerSets = &validAttachedCount
+	}
+}
+
 // runCommonRouteChecks runs all the checks that are common across all supported Route types.
 //
 // Uses the helpers.Input interface to ensure that this still applies as new types are added.
-func (r *gatewayReconciler) runCommonRouteChecks(input routechecks.Input, parentRefs []gatewayv1.ParentReference, objNamespace string) error {
+func (r *gatewayReconciler) runCommonRouteChecks(ctx context.Context, input routechecks.Input, parentRefs []gatewayv1.ParentReference, objNamespace string) error {
 	for _, parent := range parentRefs {
-		// If this parentRef is not a Gateway parentRef, skip it.
-		if !helpers.IsGateway(parent) {
-			continue
-		}
-
-		// Similarly, if this Gateway is not a matching one, skip it.
-		if !r.parentIsMatchingGateway(parent, objNamespace) {
-			continue
-		}
-
-		// set Accepted to okay, this wil be overwritten in checks if needed
-		input.SetParentCondition(parent, metav1.Condition{
-			Type:    string(gatewayv1.RouteConditionAccepted),
-			Status:  metav1.ConditionTrue,
-			Reason:  string(gatewayv1.RouteReasonAccepted),
-			Message: fmt.Sprintf("Accepted %s", input.GetGVK().Kind),
-		})
-
-		// set ResolvedRefs to okay, this wil be overwritten in checks if needed
-		input.SetParentCondition(parent, metav1.Condition{
-			Type:    string(gatewayv1.RouteConditionResolvedRefs),
-			Status:  metav1.ConditionTrue,
-			Reason:  string(gatewayv1.RouteReasonResolvedRefs),
-			Message: "Service reference is valid",
-		})
-
-		// run the Gateway validators
-		for _, fn := range []routechecks.CheckWithParentFunc{
-			routechecks.CheckGatewayMatchingProtocol,
-			routechecks.CheckGatewayRouteKindAllowed,
-			routechecks.CheckGatewayMatchingPorts,
-			routechecks.CheckGatewayMatchingHostnames,
-			routechecks.CheckGatewayMatchingSection,
-			routechecks.CheckGatewayAllowedForNamespace,
-		} {
-			continueCheck, err := fn(input, parent)
-			if err != nil {
-				return fmt.Errorf("failed to apply Gateway check: %w", err)
+		if helpers.IsGateway(parent) {
+			if err := r.runGatewayRouteChecks(ctx, input, parent, objNamespace); err != nil {
+				return err
 			}
-
-			if !continueCheck {
-				break
+		} else if helpers.IsListenerSet(parent) {
+			if err := r.runListenerSetRouteChecks(ctx, input, parent, objNamespace); err != nil {
+				return err
 			}
 		}
-
-		// Run the Rule validators, these need to be run per-parent so that we
-		// don't update status for parents we don't own.
-		for _, fn := range []routechecks.CheckWithParentFunc{
-			routechecks.CheckAgainstCrossNamespaceBackendReferences,
-			routechecks.CheckBackend,
-			routechecks.CheckHasServiceImportSupport,
-			routechecks.CheckBackendIsExistingService,
-		} {
-			continueCheck, err := fn(input, parent)
-			if err != nil {
-				return fmt.Errorf("failed to apply Backend check: %w", err)
-			}
-
-			if !continueCheck {
-				break
-			}
-		}
-
 	}
 
 	return nil
 }
 
-func (r *gatewayReconciler) parentIsMatchingGateway(parent gatewayv1.ParentReference, namespace string) bool {
-	hasMatchingControllerFn := helpers.GatewayHasMatchingControllerFn(context.Background(), r.Client, r.controllerName, r.logger)
+var gatewayCheckFuncs = []routechecks.CheckWithParentFunc{
+	routechecks.CheckGatewayMatchingProtocol,
+	routechecks.CheckGatewayRouteKindAllowed,
+	routechecks.CheckGatewayMatchingPorts,
+	routechecks.CheckGatewayMatchingHostnames,
+	routechecks.CheckGatewayMatchingSection,
+	routechecks.CheckGatewayAllowedForNamespace,
+}
+
+var backendCheckFuncs = []routechecks.CheckWithParentFunc{
+	routechecks.CheckAgainstCrossNamespaceBackendReferences,
+	routechecks.CheckBackend,
+	routechecks.CheckHasServiceImportSupport,
+	routechecks.CheckBackendIsExistingService,
+}
+
+func runCheckFuncs(input routechecks.Input, parent gatewayv1.ParentReference, fns []routechecks.CheckWithParentFunc, errPrefix string) error {
+	for _, fn := range fns {
+		continueCheck, err := fn(input, parent)
+		if err != nil {
+			return fmt.Errorf("failed to apply %s check: %w", errPrefix, err)
+		}
+		if !continueCheck {
+			break
+		}
+	}
+	return nil
+}
+
+func setInitialRouteConditions(input routechecks.Input, parent gatewayv1.ParentReference) {
+	input.SetParentCondition(parent, metav1.Condition{
+		Type:    string(gatewayv1.RouteConditionAccepted),
+		Status:  metav1.ConditionTrue,
+		Reason:  string(gatewayv1.RouteReasonAccepted),
+		Message: fmt.Sprintf("Accepted %s", input.GetGVK().Kind),
+	})
+	input.SetParentCondition(parent, metav1.Condition{
+		Type:    string(gatewayv1.RouteConditionResolvedRefs),
+		Status:  metav1.ConditionTrue,
+		Reason:  string(gatewayv1.RouteReasonResolvedRefs),
+		Message: "Service reference is valid",
+	})
+}
+
+func (r *gatewayReconciler) runGatewayRouteChecks(ctx context.Context, input routechecks.Input, parent gatewayv1.ParentReference, objNamespace string) error {
+	if !r.parentIsMatchingGateway(ctx, parent, objNamespace) {
+		return nil
+	}
+
+	setInitialRouteConditions(input, parent)
+
+	if err := runCheckFuncs(input, parent, gatewayCheckFuncs, "Gateway"); err != nil {
+		return err
+	}
+	return runCheckFuncs(input, parent, backendCheckFuncs, "Backend")
+}
+
+func (r *gatewayReconciler) runListenerSetRouteChecks(ctx context.Context, input routechecks.Input, parent gatewayv1.ParentReference, objNamespace string) error {
+	ns := helpers.NamespaceDerefOr(parent.Namespace, objNamespace)
+	ls := &gatewayv1.ListenerSet{}
+	if err := r.Client.Get(ctx, types.NamespacedName{
+		Namespace: ns,
+		Name:      string(parent.Name),
+	}, ls); err != nil {
+		return nil
+	}
+
+	gwNN := helpers.ListenerSetParentGateway(ls)
+	gw := &gatewayv1.Gateway{}
+	if err := r.Client.Get(ctx, *gwNN, gw); err != nil {
+		return nil
+	}
+
+	hasMatchingControllerFn := helpers.GatewayHasMatchingControllerFn(ctx, r.Client, r.controllerName, r.logger)
+	if !hasMatchingControllerFn(gw) {
+		return nil
+	}
+
+	setInitialRouteConditions(input, parent)
+
+	if err := runCheckFuncs(input, parent, gatewayCheckFuncs, "Gateway for ListenerSet"); err != nil {
+		return err
+	}
+	return runCheckFuncs(input, parent, backendCheckFuncs, "Backend for ListenerSet")
+}
+
+func (r *gatewayReconciler) parentIsMatchingGateway(ctx context.Context, parent gatewayv1.ParentReference, namespace string) bool {
+	hasMatchingControllerFn := helpers.GatewayHasMatchingControllerFn(ctx, r.Client, r.controllerName, r.logger)
 	if !helpers.IsGateway(parent) {
 		return false
 	}
 	gw := &gatewayv1.Gateway{}
-	if err := r.Client.Get(context.Background(), types.NamespacedName{
+	if err := r.Client.Get(ctx, types.NamespacedName{
 		Namespace: helpers.NamespaceDerefOr(parent.Namespace, namespace),
 		Name:      string(parent.Name),
 	}, gw); err != nil {
@@ -1441,7 +1736,7 @@ func (r *gatewayReconciler) setHTTPRouteStatuses(scopedLog *slog.Logger, ctx con
 			ControllerName: r.controllerName,
 		}
 
-		if err := r.runCommonRouteChecks(i, hr.Spec.ParentRefs, hr.Namespace); err != nil {
+		if err := r.runCommonRouteChecks(ctx, i, hr.Spec.ParentRefs, hr.Namespace); err != nil {
 			return r.handleHTTPRouteReconcileErrorWithStatus(ctx, scopedLog, err, &original, hr)
 		}
 
@@ -1482,7 +1777,7 @@ func (r *gatewayReconciler) setTLSRouteStatuses(scopedLog *slog.Logger, ctx cont
 			ControllerName: r.controllerName,
 		}
 
-		if err := r.runCommonRouteChecks(i, tlsr.Spec.ParentRefs, tlsr.Namespace); err != nil {
+		if err := r.runCommonRouteChecks(ctx, i, tlsr.Spec.ParentRefs, tlsr.Namespace); err != nil {
 			return r.handleTLSRouteReconcileErrorWithStatus(ctx, scopedLog, err, tlsr, &original)
 		}
 
@@ -1518,7 +1813,7 @@ func (r *gatewayReconciler) setGRPCRouteStatuses(scopedLog *slog.Logger, ctx con
 			ControllerName: r.controllerName,
 		}
 
-		if err := r.runCommonRouteChecks(i, grpcr.Spec.ParentRefs, grpcr.Namespace); err != nil {
+		if err := r.runCommonRouteChecks(ctx, i, grpcr.Spec.ParentRefs, grpcr.Namespace); err != nil {
 			return r.handleGRPCRouteReconcileErrorWithStatus(ctx, scopedLog, err, grpcr, &original)
 		}
 
@@ -1822,7 +2117,7 @@ func (r *gatewayReconciler) setTCPRouteStatuses(scopedLog *slog.Logger, ctx cont
 			ControllerName: r.controllerName,
 		}
 
-		if err := r.runCommonRouteChecks(i, tcpr.Spec.ParentRefs, tcpr.Namespace); err != nil {
+		if err := r.runCommonRouteChecks(ctx, i, tcpr.Spec.ParentRefs, tcpr.Namespace); err != nil {
 			return r.handleTCPRouteReconcileErrorWithStatus(ctx, scopedLog, err, &original, tcpr)
 		}
 
@@ -1853,7 +2148,7 @@ func (r *gatewayReconciler) setUDPRouteStatuses(scopedLog *slog.Logger, ctx cont
 			ControllerName: r.controllerName,
 		}
 
-		if err := r.runCommonRouteChecks(i, udpr.Spec.ParentRefs, udpr.Namespace); err != nil {
+		if err := r.runCommonRouteChecks(ctx, i, udpr.Spec.ParentRefs, udpr.Namespace); err != nil {
 			return r.handleUDPRouteReconcileErrorWithStatus(ctx, scopedLog, err, &original, udpr)
 		}
 

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -359,7 +359,6 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
 
-	r.setListenerSetStatuses(ctx, gw, attachedListenerSets, httpRouteList, tlsRouteList, grpcRouteList, tcpRouteList, udpRouteList, namespaceLabels)
 	if !validListener {
 		err := fmt.Errorf("No Accepted Listeners for Gateway")
 		scopedLog.ErrorContext(ctx, "No Accepted Listeners for Gateway", logfields.Error, err)
@@ -367,6 +366,12 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		setGatewayProgrammed(gw, metav1.ConditionFalse, "No Accepted Listeners", gatewayv1.GatewayReasonListenersNotValid)
 		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
+
+	// ListenerSet status is reported independently from the parent Gateway's
+	// Accepted and Programmed conditions. Those Gateway conditions reflect the
+	// Gateway's local configuration, so valid ListenerSets do not make an
+	// otherwise invalid Gateway accepted or programmed.
+	r.setListenerSetStatuses(ctx, gw, attachedListenerSets, httpRouteList, tlsRouteList, grpcRouteList, tcpRouteList, udpRouteList, namespaceLabels)
 	setGatewayAccepted(gw, true, "Gateway successfully scheduled", gatewayv1.GatewayReasonAccepted)
 
 	// Step 3: Translate the listeners into Cilium model

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -65,6 +65,10 @@ var (
 		Kind:       "UDPRoute",
 		APIVersion: gatewayv1alpha2APIVersion,
 	}
+	listenerSetTypeMeta = metav1.TypeMeta{
+		Kind:       "ListenerSet",
+		APIVersion: gatewayv1APIVersion,
+	}
 	endpointSliceTypeMeta = metav1.TypeMeta{
 		Kind:       "EndpointSlice",
 		APIVersion: discoveryv1.SchemeGroupVersion.String(),
@@ -115,6 +119,7 @@ func Test_Conformance(t *testing.T) {
 		disableServiceImport bool
 		disableTCPRoute      bool
 		disableUDPRoute      bool
+		skipCEC              bool
 		wantErr              bool
 		hostNetwork          bool
 	}{
@@ -336,6 +341,34 @@ func Test_Conformance(t *testing.T) {
 		{name: "hostNetwork-enabled-valid", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "hostnetwork-enabled", Namespace: "gateway-conformance-infra"}}}, hostNetwork: true},
 		{name: "hostNetwork-enabled-exceed-max-address", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "hostnetwork-enabled", Namespace: "gateway-conformance-infra"}}}, hostNetwork: true},
 		{name: "gatewayclassconfig-nodeport", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "nodeport-gateway", Namespace: "gateway-conformance-infra"}}}},
+		// ListenerSet tests
+		{name: "listenerset-default-not-allowed", gateway: []gwDetails{
+			{FullName: types.NamespacedName{Name: "default-not-allowed", Namespace: "gateway-conformance-infra"}},
+		}},
+		{name: "listenerset-allowed-namespace-none", gateway: []gwDetails{
+			{FullName: types.NamespacedName{Name: "allowed-namespace-none", Namespace: "gateway-conformance-infra"}},
+		}},
+		{name: "listenerset-allowed-namespace-same", skipCEC: true, gateway: []gwDetails{
+			{FullName: types.NamespacedName{Name: "allowed-namespace-same", Namespace: "gateway-conformance-infra"}},
+		}},
+		{name: "listenerset-allowed-namespace-selector", skipCEC: true, gateway: []gwDetails{
+			{FullName: types.NamespacedName{Name: "allowed-namespace-selector", Namespace: "gateway-conformance-infra"}},
+		}},
+		{name: "listenerset-protocol-conflict", skipCEC: true, gateway: []gwDetails{
+			{FullName: types.NamespacedName{Name: "protocol-conflict", Namespace: "gateway-conformance-infra"}},
+		}},
+		{name: "listenerset-hostname-conflict", skipCEC: true, gateway: []gwDetails{
+			{FullName: types.NamespacedName{Name: "hostname-conflict", Namespace: "gateway-conformance-infra"}},
+		}},
+		{name: "listenerset-cross-listenerset-hostname-conflict", skipCEC: true, gateway: []gwDetails{
+			{FullName: types.NamespacedName{Name: "cross-listenerset-hostname-conflict", Namespace: "gateway-conformance-infra"}},
+		}},
+		{name: "listenerset-cross-listenerset-protocol-conflict", skipCEC: true, gateway: []gwDetails{
+			{FullName: types.NamespacedName{Name: "cross-listenerset-protocol-conflict", Namespace: "gateway-conformance-infra"}},
+		}},
+		{name: "listenerset-allowed-routes-kinds", skipCEC: true, gateway: []gwDetails{
+			{FullName: types.NamespacedName{Name: "allowed-route-kinds", Namespace: "gateway-conformance-infra"}},
+		}},
 	}
 
 	for _, tt := range tests {
@@ -351,7 +384,8 @@ func Test_Conformance(t *testing.T) {
 				WithStatusSubresource(&gatewayv1.TLSRoute{}).
 				WithStatusSubresource(&gatewayv1.Gateway{}).
 				WithStatusSubresource(&gatewayv1.GatewayClass{}).
-				WithStatusSubresource(&gatewayv1.BackendTLSPolicy{})
+				WithStatusSubresource(&gatewayv1.BackendTLSPolicy{}).
+				WithStatusSubresource(&gatewayv1.ListenerSet{})
 
 			disabledKinds := map[string]bool{
 				helpers.ServiceImportKind: tt.disableServiceImport,
@@ -382,6 +416,10 @@ func Test_Conformance(t *testing.T) {
 				clientBuilder.WithStatusSubresource(&gatewayv1alpha2.UDPRoute{})
 				clientBuilder.WithIndex(&gatewayv1alpha2.UDPRoute{}, indexers.GatewayUDPRouteIndex, indexers.IndexUDPRouteByGateway)
 			}
+			clientBuilder.WithIndex(&gatewayv1.ListenerSet{}, indexers.ListenerSetGatewayIndex, indexers.IndexListenerSetByGateway)
+			clientBuilder.WithIndex(&gatewayv1.HTTPRoute{}, indexers.HTTPRouteListenerSetIndex, indexers.IndexHTTPRouteByListenerSet)
+			clientBuilder.WithIndex(&gatewayv1.GRPCRoute{}, indexers.GRPCRouteListenerSetIndex, indexers.IndexGRPCRouteByListenerSet)
+			clientBuilder.WithIndex(&gatewayv1.TLSRoute{}, indexers.TLSRouteListenerSetIndex, indexers.IndexTLSRouteByListenerSet)
 
 			c := clientBuilder.Build()
 			if tt.hostNetwork {
@@ -453,7 +491,7 @@ func Test_Conformance(t *testing.T) {
 				expectedGateway := &gatewayv1.Gateway{}
 				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/%s.yaml", tt.name, gwDetail.FullName.Name), expectedGateway)
 				require.Empty(t, cmp.Diff(expectedGateway, actualGateway, cmpIgnoreFields...))
-				if !gwDetail.wantErr && !gwDetail.skipCEC {
+				if !gwDetail.wantErr && !gwDetail.skipCEC && !tt.skipCEC {
 					// Checking the output for CiliumEnvoyConfig
 					actualCEC := &ciliumv2.CiliumEnvoyConfig{}
 					err = c.Get(t.Context(), client.ObjectKey{
@@ -546,6 +584,19 @@ func Test_Conformance(t *testing.T) {
 				expectedUDPR := &gatewayv1alpha2.UDPRoute{}
 				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/udproute-%s.yaml", tt.name, udpr.Name), expectedUDPR)
 				require.Empty(t, cmp.Diff(expectedUDPR, actualUDPR, cmpIgnoreFields...))
+			}
+
+			lsList := &gatewayv1.ListenerSetList{}
+			err = c.List(t.Context(), lsList)
+			require.NoError(t, err)
+			for _, ls := range lsList.Items {
+				actualLS := &gatewayv1.ListenerSet{}
+				err = c.Get(t.Context(), client.ObjectKeyFromObject(&ls), actualLS)
+				actualLS.TypeMeta = listenerSetTypeMeta
+				require.NoError(t, err, "error getting ListenerSet %s/%s: %v", ls.Namespace, ls.Name, err)
+				expectedLS := &gatewayv1.ListenerSet{}
+				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/listenerset-%s.yaml", tt.name, ls.Name), expectedLS)
+				require.Empty(t, cmp.Diff(expectedLS, actualLS, cmpIgnoreFields...))
 			}
 		})
 	}

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -369,6 +369,12 @@ func Test_Conformance(t *testing.T) {
 		{name: "listenerset-allowed-routes-kinds", skipCEC: true, gateway: []gwDetails{
 			{FullName: types.NamespacedName{Name: "allowed-route-kinds", Namespace: "gateway-conformance-infra"}},
 		}},
+		// A Route that targets the Gateway must not leak into a ListenerSet's
+		// L4 listeners, even when the Route lives in a namespace the ListenerSet
+		// listener would otherwise allow.
+		{name: "listenerset-l4-namespace-isolation", skipCEC: true, gateway: []gwDetails{
+			{FullName: types.NamespacedName{Name: "l4-namespace-isolation", Namespace: "gateway-conformance-infra"}},
+		}},
 	}
 
 	for _, tt := range tests {
@@ -411,10 +417,12 @@ func Test_Conformance(t *testing.T) {
 			if !tt.disableTCPRoute {
 				clientBuilder.WithStatusSubresource(&gatewayv1alpha2.TCPRoute{})
 				clientBuilder.WithIndex(&gatewayv1alpha2.TCPRoute{}, indexers.GatewayTCPRouteIndex, indexers.IndexTCPRouteByGateway)
+				clientBuilder.WithIndex(&gatewayv1alpha2.TCPRoute{}, indexers.TCPRouteListenerSetIndex, indexers.IndexTCPRouteByListenerSet)
 			}
 			if !tt.disableUDPRoute {
 				clientBuilder.WithStatusSubresource(&gatewayv1alpha2.UDPRoute{})
 				clientBuilder.WithIndex(&gatewayv1alpha2.UDPRoute{}, indexers.GatewayUDPRouteIndex, indexers.IndexUDPRouteByGateway)
+				clientBuilder.WithIndex(&gatewayv1alpha2.UDPRoute{}, indexers.UDPRouteListenerSetIndex, indexers.IndexUDPRouteByListenerSet)
 			}
 			clientBuilder.WithIndex(&gatewayv1.ListenerSet{}, indexers.ListenerSetGatewayIndex, indexers.IndexListenerSetByGateway)
 			clientBuilder.WithIndex(&gatewayv1.HTTPRoute{}, indexers.HTTPRouteListenerSetIndex, indexers.IndexHTTPRouteByListenerSet)

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -989,7 +989,7 @@ func Test_sectionNameMatched(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, parentRefMatched(gw, tt.args.listener, "default", tt.args.refs), "parentRefMatched(%v, %v, %v, %v)", gw, tt.args.listener, tt.args.routeNamespace, tt.args.refs)
+			assert.Equalf(t, tt.want, parentRefMatched(gw, tt.args.listener, nil, "default", tt.args.refs), "parentRefMatched(%v, %v, %v, %v)", gw, tt.args.listener, tt.args.routeNamespace, tt.args.refs)
 		})
 	}
 }

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -369,6 +369,9 @@ func Test_Conformance(t *testing.T) {
 		{name: "listenerset-allowed-routes-kinds", skipCEC: true, gateway: []gwDetails{
 			{FullName: types.NamespacedName{Name: "allowed-route-kinds", Namespace: "gateway-conformance-infra"}},
 		}},
+		{name: "listenerset-valid-with-invalid-gateway-listener", skipCEC: true, gateway: []gwDetails{
+			{FullName: types.NamespacedName{Name: "valid-listenerset-only", Namespace: "gateway-conformance-infra"}, wantErr: true},
+		}},
 		// A Route that targets the Gateway must not leak into a ListenerSet's
 		// L4 listeners, even when the Route lives in a namespace the ListenerSet
 		// listener would otherwise allow.

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -132,7 +132,7 @@ func Test_Conformance(t *testing.T) {
 		{
 			name: "gateway-invalid-route-kind",
 			gateway: []gwDetails{
-				{FullName: types.NamespacedName{Name: "gateway-only-invalid-route-kind", Namespace: "gateway-conformance-infra"}},
+				{FullName: types.NamespacedName{Name: "gateway-only-invalid-route-kind", Namespace: "gateway-conformance-infra"}, wantErr: true},
 				{FullName: types.NamespacedName{Name: "gateway-supported-and-invalid-route-kind", Namespace: "gateway-conformance-infra"}},
 			},
 		},

--- a/operator/pkg/gateway-api/gateway_status.go
+++ b/operator/pkg/gateway-api/gateway_status.go
@@ -167,3 +167,33 @@ func gatewayListenerInvalidRouteKinds(gw *gatewayv1.Gateway, msg string) metav1.
 		LastTransitionTime: metav1.NewTime(time.Now()),
 	}
 }
+
+func setListenerSetAccepted(ls *gatewayv1.ListenerSet, accepted bool, msg string, reason gatewayv1.ListenerSetConditionReason) {
+	status := metav1.ConditionTrue
+	if !accepted {
+		status = metav1.ConditionFalse
+	}
+	ls.Status.Conditions = merge(ls.Status.Conditions, metav1.Condition{
+		Type:               string(gatewayv1.ListenerSetConditionAccepted),
+		Status:             status,
+		Reason:             string(reason),
+		Message:            msg,
+		ObservedGeneration: ls.GetGeneration(),
+		LastTransitionTime: metav1.NewTime(time.Now()),
+	})
+}
+
+func setListenerSetProgrammed(ls *gatewayv1.ListenerSet, programmed bool, msg string, reason gatewayv1.ListenerSetConditionReason) {
+	status := metav1.ConditionTrue
+	if !programmed {
+		status = metav1.ConditionFalse
+	}
+	ls.Status.Conditions = merge(ls.Status.Conditions, metav1.Condition{
+		Type:               string(gatewayv1.ListenerSetConditionProgrammed),
+		Status:             status,
+		Reason:             string(reason),
+		Message:            msg,
+		ObservedGeneration: ls.GetGeneration(),
+		LastTransitionTime: metav1.NewTime(time.Now()),
+	})
+}

--- a/operator/pkg/gateway-api/gateway_status.go
+++ b/operator/pkg/gateway-api/gateway_status.go
@@ -100,36 +100,36 @@ func gatewayStatusReadyCondition(gw *gatewayv1.Gateway, scheduled bool, msg stri
 	}
 }
 
-func gatewayListenerProgrammedCondition(gw *gatewayv1.Gateway, ready bool, msg string) metav1.Condition {
+func listenerProgrammedCondition(generation int64, ready bool, reason gatewayv1.ListenerConditionReason, msg string) metav1.Condition {
 	switch ready {
 	case true:
 		return metav1.Condition{
 			Type:               string(gatewayv1.ListenerConditionProgrammed),
 			Status:             metav1.ConditionTrue,
-			ObservedGeneration: gw.GetGeneration(),
+			ObservedGeneration: generation,
 			LastTransitionTime: metav1.NewTime(time.Now()),
-			Reason:             string(gatewayv1.ListenerConditionProgrammed),
+			Reason:             string(reason),
 			Message:            msg,
 		}
 	default:
 		return metav1.Condition{
 			Type:               string(gatewayv1.ListenerConditionProgrammed),
 			Status:             metav1.ConditionFalse,
-			Reason:             string(gatewayv1.ListenerReasonPending),
+			Reason:             string(reason),
 			Message:            msg,
-			ObservedGeneration: gw.GetGeneration(),
+			ObservedGeneration: generation,
 			LastTransitionTime: metav1.NewTime(time.Now()),
 		}
 	}
 }
 
-func gatewayListenerAcceptedCondition(gw *gatewayv1.Gateway, ready bool, reason gatewayv1.ListenerConditionReason, msg string) metav1.Condition {
+func listenerAcceptedCondition(generation int64, ready bool, reason gatewayv1.ListenerConditionReason, msg string) metav1.Condition {
 	switch ready {
 	case true:
 		return metav1.Condition{
 			Type:               string(gatewayv1.ListenerConditionAccepted),
 			Status:             metav1.ConditionTrue,
-			ObservedGeneration: gw.GetGeneration(),
+			ObservedGeneration: generation,
 			LastTransitionTime: metav1.NewTime(time.Now()),
 			Reason:             string(reason),
 			Message:            msg,
@@ -140,30 +140,30 @@ func gatewayListenerAcceptedCondition(gw *gatewayv1.Gateway, ready bool, reason 
 			Status:             metav1.ConditionFalse,
 			Reason:             string(reason),
 			Message:            msg,
-			ObservedGeneration: gw.GetGeneration(),
+			ObservedGeneration: generation,
 			LastTransitionTime: metav1.NewTime(time.Now()),
 		}
 	}
 }
 
-func gatewayListenerConflictedCondition(gw *gatewayv1.Gateway, reason gatewayv1.ListenerConditionReason, msg string) metav1.Condition {
+func listenerConflictedCondition(generation int64, reason gatewayv1.ListenerConditionReason, msg string) metav1.Condition {
 	return metav1.Condition{
 		Type:               string(gatewayv1.ListenerConditionConflicted),
 		Status:             metav1.ConditionTrue,
 		Reason:             string(reason),
 		Message:            msg,
-		ObservedGeneration: gw.GetGeneration(),
+		ObservedGeneration: generation,
 		LastTransitionTime: metav1.NewTime(time.Now()),
 	}
 }
 
-func gatewayListenerInvalidRouteKinds(gw *gatewayv1.Gateway, msg string) metav1.Condition {
+func listenerInvalidRouteKinds(generation int64, msg string) metav1.Condition {
 	return metav1.Condition{
 		Type:               string(gatewayv1.ListenerConditionResolvedRefs),
 		Status:             metav1.ConditionFalse,
 		Reason:             string(gatewayv1.ListenerReasonInvalidRouteKinds),
 		Message:            msg,
-		ObservedGeneration: gw.GetGeneration(),
+		ObservedGeneration: generation,
 		LastTransitionTime: metav1.NewTime(time.Now()),
 	}
 }

--- a/operator/pkg/gateway-api/gateway_status_test.go
+++ b/operator/pkg/gateway-api/gateway_status_test.go
@@ -132,11 +132,12 @@ func Test_gatewayStatusReadyCondition(t *testing.T) {
 	}
 }
 
-func Test_gatewayListenerProgrammedCondition(t *testing.T) {
+func Test_listenerProgrammedCondition(t *testing.T) {
 	type args struct {
-		gw    *gatewayv1.Gateway
-		ready bool
-		msg   string
+		generation int64
+		ready      bool
+		reason     gatewayv1.ListenerConditionReason
+		msg        string
 	}
 	tests := []struct {
 		name string
@@ -146,13 +147,10 @@ func Test_gatewayListenerProgrammedCondition(t *testing.T) {
 		{
 			name: "ready",
 			args: args{
-				gw: &gatewayv1.Gateway{
-					ObjectMeta: metav1.ObjectMeta{
-						Generation: 100,
-					},
-				},
-				ready: true,
-				msg:   "Listener Ready",
+				generation: 100,
+				ready:      true,
+				reason:     gatewayv1.ListenerConditionReason(gatewayv1.ListenerConditionProgrammed),
+				msg:        "Listener Ready",
 			},
 			want: metav1.Condition{
 				Type:               "Programmed",
@@ -165,13 +163,10 @@ func Test_gatewayListenerProgrammedCondition(t *testing.T) {
 		{
 			name: "unready",
 			args: args{
-				gw: &gatewayv1.Gateway{
-					ObjectMeta: metav1.ObjectMeta{
-						Generation: 100,
-					},
-				},
-				ready: false,
-				msg:   "Listener Pending",
+				generation: 100,
+				ready:      false,
+				reason:     gatewayv1.ListenerReasonPending,
+				msg:        "Listener Pending",
 			},
 			want: metav1.Condition{
 				Type:               "Programmed",
@@ -184,8 +179,8 @@ func Test_gatewayListenerProgrammedCondition(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := gatewayListenerProgrammedCondition(tt.args.gw, tt.args.ready, tt.args.msg)
-			assert.True(t, cmp.Equal(got, tt.want, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")), "gatewayStatusAcceptedCondition() = %v, want %v", got, tt.want)
+			got := listenerProgrammedCondition(tt.args.generation, tt.args.ready, tt.args.reason, tt.args.msg)
+			assert.True(t, cmp.Equal(got, tt.want, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")), "listenerProgrammedCondition() = %v, want %v", got, tt.want)
 		})
 	}
 }

--- a/operator/pkg/gateway-api/gatewayclass_status.go
+++ b/operator/pkg/gateway-api/gatewayclass_status.go
@@ -42,7 +42,6 @@ var exemptFeatures = []features.Feature{
 	features.MeshConsumerRouteFeature,
 	features.BackendTLSPolicySanValidationFeature,
 	features.TLSRouteModeTerminateFeature,
-	features.ListenerSetFeature,
 	features.GatewayBackendClientCertificateFeature,
 	features.GatewayFrontendClientCertificateValidationFeature,
 	features.HTTPRoute303RedirectStatusCodeFeature,

--- a/operator/pkg/gateway-api/helper_test.go
+++ b/operator/pkg/gateway-api/helper_test.go
@@ -135,6 +135,10 @@ func readInput(t *testing.T, file string) []client.Object {
 			obj := &corev1.Node{}
 			fromYaml(t, o, obj)
 			res = append(res, obj)
+		case "ListenerSet":
+			obj := &gatewayv1.ListenerSet{}
+			fromYaml(t, o, obj)
+			res = append(res, obj)
 		}
 	}
 

--- a/operator/pkg/gateway-api/helpers.go
+++ b/operator/pkg/gateway-api/helpers.go
@@ -11,6 +11,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -279,4 +280,43 @@ func sortListenerSets(sets []gatewayv1.ListenerSet) {
 		nj := sets[j].GetNamespace() + "/" + sets[j].GetName()
 		return ni < nj
 	})
+}
+
+func deduplicateHTTPRoutes(routes []gatewayv1.HTTPRoute) []gatewayv1.HTTPRoute {
+	seen := make(map[types.NamespacedName]struct{}, len(routes))
+	result := make([]gatewayv1.HTTPRoute, 0, len(routes))
+	for _, r := range routes {
+		key := types.NamespacedName{Namespace: r.Namespace, Name: r.Name}
+		if _, ok := seen[key]; !ok {
+			seen[key] = struct{}{}
+			result = append(result, r)
+		}
+	}
+	return result
+}
+
+func deduplicateGRPCRoutes(routes []gatewayv1.GRPCRoute) []gatewayv1.GRPCRoute {
+	seen := make(map[types.NamespacedName]struct{}, len(routes))
+	result := make([]gatewayv1.GRPCRoute, 0, len(routes))
+	for _, r := range routes {
+		key := types.NamespacedName{Namespace: r.Namespace, Name: r.Name}
+		if _, ok := seen[key]; !ok {
+			seen[key] = struct{}{}
+			result = append(result, r)
+		}
+	}
+	return result
+}
+
+func deduplicateTLSRoutes(routes []gatewayv1.TLSRoute) []gatewayv1.TLSRoute {
+	seen := make(map[types.NamespacedName]struct{}, len(routes))
+	result := make([]gatewayv1.TLSRoute, 0, len(routes))
+	for _, r := range routes {
+		key := types.NamespacedName{Namespace: r.Namespace, Name: r.Name}
+		if _, ok := seen[key]; !ok {
+			seen[key] = struct{}{}
+			result = append(result, r)
+		}
+	}
+	return result
 }

--- a/operator/pkg/gateway-api/helpers.go
+++ b/operator/pkg/gateway-api/helpers.go
@@ -4,8 +4,12 @@
 package gateway_api
 
 import (
+	"context"
+	"log/slog"
 	"maps"
+	"sort"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -13,6 +17,7 @@ import (
 
 	gatewayapihelpers "github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/model"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 const (
@@ -196,4 +201,82 @@ func mergeMap(left, right map[string]string) map[string]string {
 func setMergedLabelsAndAnnotations(temp, desired client.Object) {
 	temp.SetAnnotations(mergeMap(temp.GetAnnotations(), desired.GetAnnotations()))
 	temp.SetLabels(mergeMap(temp.GetLabels(), desired.GetLabels()))
+}
+
+// isListenerSetAllowed determines if a Gateway allows a given ListenerSet
+func isListenerSetAllowed(
+	ctx context.Context,
+	c client.Client,
+	gw *gatewayv1.Gateway,
+	ls *gatewayv1.ListenerSet,
+	logger *slog.Logger,
+) bool {
+	if gw.Spec.AllowedListeners == nil {
+		return false
+	}
+	ns := gw.Spec.AllowedListeners.Namespaces
+	if ns == nil || ns.From == nil {
+		return false
+	}
+	switch *ns.From {
+	case gatewayv1.NamespacesFromNone:
+		return false
+	case gatewayv1.NamespacesFromAll:
+		return true
+	case gatewayv1.NamespacesFromSame:
+		return ls.GetNamespace() == gw.GetNamespace()
+	case gatewayv1.NamespacesFromSelector:
+		nsList := &corev1.NamespaceList{}
+		selector, err := metav1.LabelSelectorAsSelector(ns.Selector)
+		if err != nil {
+			logger.ErrorContext(ctx, "Unable to parse namespace selector", logfields.Error, err)
+			return false
+		}
+		if err := c.List(ctx, nsList, client.MatchingLabelsSelector{Selector: selector}); err != nil {
+			logger.ErrorContext(ctx, "Unable to list namespaces", logfields.Error, err)
+			return false
+		}
+		for _, n := range nsList.Items {
+			if n.Name == ls.GetNamespace() {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func gatewayFQR(gw *gatewayv1.Gateway) model.FullyQualifiedResource {
+	return model.FullyQualifiedResource{
+		Name:      gw.GetName(),
+		Namespace: gw.GetNamespace(),
+		Group:     gatewayv1.SchemeGroupVersion.Group,
+		Version:   gatewayv1.SchemeGroupVersion.Version,
+		Kind:      "Gateway",
+		UID:       string(gw.GetUID()),
+	}
+}
+
+func listenerSetFQR(ls *gatewayv1.ListenerSet) model.FullyQualifiedResource {
+	return model.FullyQualifiedResource{
+		Name:      ls.GetName(),
+		Namespace: ls.GetNamespace(),
+		Group:     gatewayv1.SchemeGroupVersion.Group,
+		Version:   gatewayv1.SchemeGroupVersion.Version,
+		Kind:      "ListenerSet",
+		UID:       string(ls.GetUID()),
+	}
+}
+
+// sortListenerSets sorts ListenerSets by precedence rules
+func sortListenerSets(sets []gatewayv1.ListenerSet) {
+	sort.Slice(sets, func(i, j int) bool {
+		ti := sets[i].CreationTimestamp.Time
+		tj := sets[j].CreationTimestamp.Time
+		if !ti.Equal(tj) {
+			return ti.Before(tj)
+		}
+		ni := sets[i].GetNamespace() + "/" + sets[i].GetName()
+		nj := sets[j].GetNamespace() + "/" + sets[j].GetName()
+		return ni < nj
+	})
 }

--- a/operator/pkg/gateway-api/helpers.go
+++ b/operator/pkg/gateway-api/helpers.go
@@ -320,3 +320,29 @@ func deduplicateTLSRoutes(routes []gatewayv1.TLSRoute) []gatewayv1.TLSRoute {
 	}
 	return result
 }
+
+func deduplicateTCPRoutes(routes []gatewayv1alpha2.TCPRoute) []gatewayv1alpha2.TCPRoute {
+	seen := make(map[types.NamespacedName]struct{}, len(routes))
+	result := make([]gatewayv1alpha2.TCPRoute, 0, len(routes))
+	for _, r := range routes {
+		key := types.NamespacedName{Namespace: r.Namespace, Name: r.Name}
+		if _, ok := seen[key]; !ok {
+			seen[key] = struct{}{}
+			result = append(result, r)
+		}
+	}
+	return result
+}
+
+func deduplicateUDPRoutes(routes []gatewayv1alpha2.UDPRoute) []gatewayv1alpha2.UDPRoute {
+	seen := make(map[types.NamespacedName]struct{}, len(routes))
+	result := make([]gatewayv1alpha2.UDPRoute, 0, len(routes))
+	for _, r := range routes {
+		key := types.NamespacedName{Namespace: r.Namespace, Name: r.Name}
+		if _, ok := seen[key]; !ok {
+			seen[key] = struct{}{}
+			result = append(result, r)
+		}
+	}
+	return result
+}

--- a/operator/pkg/gateway-api/helpers.go
+++ b/operator/pkg/gateway-api/helpers.go
@@ -58,7 +58,7 @@ func groupDerefOr(group *gatewayv1.Group, defaultGroup string) string {
 // isAllowed returns true if the provided Route is allowed to attach to given gateway
 func isAllowed(gw *gatewayv1.Gateway, route metav1.Object, namespaceLabels gatewayapihelpers.NamespaceLabelIndex) bool {
 	for _, listener := range gw.Spec.Listeners {
-		if listenerisAllowed(gw, &listener, route, namespaceLabels) {
+		if listenerisAllowed(gw.GetNamespace(), &listener, route, namespaceLabels) {
 			return true
 		}
 	}
@@ -66,16 +66,16 @@ func isAllowed(gw *gatewayv1.Gateway, route metav1.Object, namespaceLabels gatew
 }
 
 // listenerisAllowed reports whether route may attach to listener.
-func listenerisAllowed(gw *gatewayv1.Gateway, listener *gatewayv1.Listener, route metav1.Object, namespaceLabels gatewayapihelpers.NamespaceLabelIndex) bool {
+func listenerisAllowed(listenerNamespace string, listener *gatewayv1.Listener, route metav1.Object, namespaceLabels gatewayapihelpers.NamespaceLabelIndex) bool {
 	if listener.AllowedRoutes == nil || listener.AllowedRoutes.Namespaces == nil {
-		return gatewayapihelpers.IsListenerNamespaceAllowed(*listener, route.GetNamespace(), gw.GetNamespace(), namespaceLabels)
+		return gatewayapihelpers.IsListenerNamespaceAllowed(*listener, route.GetNamespace(), listenerNamespace, namespaceLabels)
 	}
 
 	// check if route is kind-allowed
 	if !isKindAllowed(*listener, route) {
 		return false
 	}
-	return gatewayapihelpers.IsListenerNamespaceAllowed(*listener, route.GetNamespace(), gw.GetNamespace(), namespaceLabels)
+	return gatewayapihelpers.IsListenerNamespaceAllowed(*listener, route.GetNamespace(), listenerNamespace, namespaceLabels)
 }
 
 func isKindAllowed(listener gatewayv1.Listener, route metav1.Object) bool {

--- a/operator/pkg/gateway-api/helpers/listenerset.go
+++ b/operator/pkg/gateway-api/helpers/listenerset.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package helpers
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func HasListenerSetSupport(scheme *runtime.Scheme) bool {
+	return scheme.Recognizes(gatewayv1.SchemeGroupVersion.WithKind("ListenerSet"))
+}
+
+func ListenerEntryToListener(entry gatewayv1.ListenerEntry) gatewayv1.Listener {
+	// These currently have identical fields
+	return gatewayv1.Listener(entry)
+}
+
+func ResolveListenerSetToGateway(
+	ctx context.Context, c client.Client,
+	lsName string, lsNamespace string,
+) *types.NamespacedName {
+	ls := &gatewayv1.ListenerSet{}
+	nn := types.NamespacedName{Namespace: lsNamespace, Name: lsName}
+	if err := c.Get(ctx, nn, ls); err != nil {
+		return nil
+	}
+
+	return ListenerSetParentGateway(ls)
+}
+
+func ListenerSetParentGateway(ls *gatewayv1.ListenerSet) *types.NamespacedName {
+	gwNamespace := ls.GetNamespace()
+	if ls.Spec.ParentRef.Namespace != nil {
+		gwNamespace = string(*ls.Spec.ParentRef.Namespace)
+	}
+
+	return &types.NamespacedName{
+		Namespace: gwNamespace,
+		Name:      string(ls.Spec.ParentRef.Name),
+	}
+}

--- a/operator/pkg/gateway-api/helpers/listenerset_test.go
+++ b/operator/pkg/gateway-api/helpers/listenerset_test.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestIsListenerSet(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  gatewayv1.ParentReference
+		want bool
+	}{
+		{
+			name: "default kind (nil) is Gateway, not ListenerSet",
+			ref:  gatewayv1.ParentReference{},
+			want: false,
+		},
+		{
+			name: "explicit Gateway kind",
+			ref: gatewayv1.ParentReference{
+				Kind: ptr.To[gatewayv1.Kind]("Gateway"),
+			},
+			want: false,
+		},
+		{
+			name: "ListenerSet kind with default group",
+			ref: gatewayv1.ParentReference{
+				Kind: ptr.To[gatewayv1.Kind]("ListenerSet"),
+			},
+			want: true,
+		},
+		{
+			name: "ListenerSet kind with explicit gateway-api group",
+			ref: gatewayv1.ParentReference{
+				Kind:  ptr.To[gatewayv1.Kind]("ListenerSet"),
+				Group: ptr.To[gatewayv1.Group](gatewayv1.GroupName),
+			},
+			want: true,
+		},
+		{
+			name: "ListenerSet kind with wrong group",
+			ref: gatewayv1.ParentReference{
+				Kind:  ptr.To[gatewayv1.Kind]("ListenerSet"),
+				Group: ptr.To[gatewayv1.Group]("example.com"),
+			},
+			want: false,
+		},
+		{
+			name: "Service kind",
+			ref: gatewayv1.ParentReference{
+				Kind:  ptr.To[gatewayv1.Kind]("Service"),
+				Group: ptr.To[gatewayv1.Group](""),
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsListenerSet(tt.ref))
+		})
+	}
+}
+
+func TestListenerEntryToListener(t *testing.T) {
+	entry := gatewayv1.ListenerEntry{
+		Name:     "https",
+		Hostname: ptr.To[gatewayv1.Hostname]("example.com"),
+		Port:     443,
+		Protocol: gatewayv1.HTTPSProtocolType,
+		TLS: &gatewayv1.ListenerTLSConfig{
+			Mode: ptr.To(gatewayv1.TLSModeTerminate),
+			CertificateRefs: []gatewayv1.SecretObjectReference{
+				{Name: "my-cert"},
+			},
+		},
+		AllowedRoutes: &gatewayv1.AllowedRoutes{
+			Namespaces: &gatewayv1.RouteNamespaces{
+				From: ptr.To(gatewayv1.NamespacesFromAll),
+			},
+		},
+	}
+
+	l := ListenerEntryToListener(entry)
+
+	assert.Equal(t, entry.Name, l.Name)
+	assert.Equal(t, entry.Hostname, l.Hostname)
+	assert.Equal(t, entry.Port, l.Port)
+	assert.Equal(t, entry.Protocol, l.Protocol)
+	assert.Equal(t, entry.TLS, l.TLS)
+	assert.Equal(t, entry.AllowedRoutes, l.AllowedRoutes)
+}
+
+func TestListenerSetParentGateway(t *testing.T) {
+	tests := []struct {
+		name          string
+		ls            *gatewayv1.ListenerSet
+		wantName      string
+		wantNamespace string
+	}{
+		{
+			name: "namespace defaults to ListenerSet namespace",
+			ls: &gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ls-namespace",
+				},
+				Spec: gatewayv1.ListenerSetSpec{
+					ParentRef: gatewayv1.ParentGatewayReference{
+						Name: "my-gateway",
+					},
+				},
+			},
+			wantName:      "my-gateway",
+			wantNamespace: "ls-namespace",
+		},
+		{
+			name: "explicit namespace in parentRef",
+			ls: &gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ls-namespace",
+				},
+				Spec: gatewayv1.ListenerSetSpec{
+					ParentRef: gatewayv1.ParentGatewayReference{
+						Name:      "my-gateway",
+						Namespace: ptr.To[gatewayv1.Namespace]("gw-namespace"),
+					},
+				},
+			},
+			wantName:      "my-gateway",
+			wantNamespace: "gw-namespace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ListenerSetParentGateway(tt.ls)
+			require.NotNil(t, result)
+			assert.Equal(t, tt.wantName, result.Name)
+			assert.Equal(t, tt.wantNamespace, result.Namespace)
+		})
+	}
+}

--- a/operator/pkg/gateway-api/helpers/routes.go
+++ b/operator/pkg/gateway-api/helpers/routes.go
@@ -10,21 +10,46 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-func IsParentAttachable(_ context.Context, reconcileParent metav1.Object, route metav1.Object, parents []gatewayv1.RouteParentStatus) bool {
+func IsParentAttachable(
+	_ context.Context,
+	reconcileParent metav1.Object,
+	route metav1.Object,
+	parents []gatewayv1.RouteParentStatus,
+	attachedListenerSets []gatewayv1.ListenerSet,
+) bool {
 	for _, rps := range parents {
-		if NamespaceDerefOr(rps.ParentRef.Namespace, route.GetNamespace()) != reconcileParent.GetNamespace() ||
-			string(rps.ParentRef.Name) != reconcileParent.GetName() {
+		parentNS := NamespaceDerefOr(rps.ParentRef.Namespace, route.GetNamespace())
+		parentName := string(rps.ParentRef.Name)
+
+		matched := false
+		if parentNS == reconcileParent.GetNamespace() && parentName == reconcileParent.GetName() {
+			matched = true
+		} else if IsListenerSet(rps.ParentRef) {
+			for _, ls := range attachedListenerSets {
+				if parentNS == ls.GetNamespace() && parentName == ls.GetName() {
+					matched = true
+					break
+				}
+			}
+		}
+
+		if !matched {
 			continue
 		}
 
-		acceptedValid := false
+		// (ajs) Note well that this predicate depends upon looping over a list
+		// of conditions that are expected to already be populated. In the
+		// future, let's have this type of condition be an explicit mark on an
+		// augmented Route type.
+		//
+		// Also note well, we are first checking the parentRef relationship
+		// here, and then checking if the route was accepted. These states
+		// should be more than implicitly related, such that this type of
+		// function is not needed.
 		for _, cond := range rps.Conditions {
 			if cond.Type == string(gatewayv1.RouteConditionAccepted) && cond.Status == metav1.ConditionTrue {
-				acceptedValid = true
+				return true
 			}
-		}
-		if acceptedValid {
-			return true
 		}
 	}
 	return false

--- a/operator/pkg/gateway-api/helpers/routes_test.go
+++ b/operator/pkg/gateway-api/helpers/routes_test.go
@@ -112,7 +112,7 @@ func TestIsParentAttachable(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := IsParentAttachable(context.Background(), tt.reconcileParent, tt.route, tt.parents)
+			got := IsParentAttachable(context.Background(), tt.reconcileParent, tt.route, tt.parents, nil)
 			// TODO: update the condition below to compare got with tt.want.
 			if tt.want != got {
 				t.Errorf("IsParentAttachable() = %v, want %v", got, tt.want)

--- a/operator/pkg/gateway-api/helpers/schemes.go
+++ b/operator/pkg/gateway-api/helpers/schemes.go
@@ -31,6 +31,7 @@ var RequiredGVKs = []schema.GroupVersionKind{
 }
 
 var AllOptionalKinds = []schema.GroupVersionKind{
+	gatewayv1.SchemeGroupVersion.WithKind(ListenerSetKind),
 	mcsapiv1beta1.SchemeGroupVersion.WithKind(ServiceImportKind),
 	gatewayv1alpha2.SchemeGroupVersion.WithKind(TCPRouteKind),
 	gatewayv1alpha2.SchemeGroupVersion.WithKind(UDPRouteKind),

--- a/operator/pkg/gateway-api/helpers/secrets.go
+++ b/operator/pkg/gateway-api/helpers/secrets.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"log/slog"
 
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -24,23 +25,68 @@ func GetGatewaysForSecret(ctx context.Context, c client.Client, obj client.Objec
 		return nil
 	}
 
+	// Track which Gateways we've already added to avoid duplicates
+	seen := make(map[types.NamespacedName]struct{})
 	var gateways []*gatewayv1.Gateway
+
 	for _, gw := range gwList.Items {
 		for _, l := range gw.Spec.Listeners {
-			if l.TLS == nil {
-				continue
-			}
-
-			for _, cert := range l.TLS.CertificateRefs {
-				if !IsSecret(cert) {
-					continue
-				}
-				ns := NamespaceDerefOr(cert.Namespace, gw.GetNamespace())
-				if string(cert.Name) == obj.GetName() && ns == obj.GetNamespace() {
+			if listenerReferencesSecret(l.TLS, gw.GetNamespace(), obj) {
+				gwNN := types.NamespacedName{Name: gw.GetName(), Namespace: gw.GetNamespace()}
+				if _, ok := seen[gwNN]; !ok {
+					seen[gwNN] = struct{}{}
 					gateways = append(gateways, &gw)
+				}
+				break
+			}
+		}
+	}
+
+	// Also scan ListenerSets for secret references
+	if HasListenerSetSupport(c.Scheme()) {
+		lsList := &gatewayv1.ListenerSetList{}
+		if err := c.List(ctx, lsList); err != nil {
+			scopedLog.WarnContext(ctx, "Unable to list ListenerSets", logfields.Error, err)
+			return gateways
+		}
+
+		for _, ls := range lsList.Items {
+			for _, entry := range ls.Spec.Listeners {
+				if listenerReferencesSecret(entry.TLS, ls.GetNamespace(), obj) {
+					gwNN := *ListenerSetParentGateway(&ls)
+					if _, ok := seen[gwNN]; ok {
+						break
+					}
+					seen[gwNN] = struct{}{}
+					// Look up the actual Gateway object
+					gw := &gatewayv1.Gateway{}
+					if err := c.Get(ctx, gwNN, gw); err != nil {
+						scopedLog.WarnContext(ctx, "Unable to get Gateway for ListenerSet", logfields.Error, err)
+						break
+					}
+					gateways = append(gateways, gw)
+					break
 				}
 			}
 		}
 	}
+
 	return gateways
+}
+
+// listenerReferencesSecret checks if a listener's TLS config references the given secret.
+func listenerReferencesSecret(tls *gatewayv1.ListenerTLSConfig, ownerNamespace string, secret client.Object) bool {
+	if tls == nil {
+		return false
+	}
+	for _, cert := range tls.CertificateRefs {
+		if !IsSecret(cert) {
+			continue
+		}
+		ns := NamespaceDerefOr(cert.Namespace, ownerNamespace)
+		if string(cert.Name) == secret.GetName() && ns == secret.GetNamespace() {
+			return true
+		}
+	}
+	return false
 }

--- a/operator/pkg/gateway-api/helpers/secrets.go
+++ b/operator/pkg/gateway-api/helpers/secrets.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"log/slog"
 
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -14,79 +15,73 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
-func GetGatewaysForSecret(ctx context.Context, c client.Client, obj client.Object, logger *slog.Logger) []*gatewayv1.Gateway {
+const (
+	// GatewaySecretIndex indexes Gateways by referenced TLS Secrets.
+	GatewaySecretIndex = "gatewaySecretIndex"
+
+	// ListenerSetSecretIndex indexes ListenerSets by referenced TLS Secrets.
+	ListenerSetSecretIndex = "listenerSetSecretIndex"
+)
+
+func GetGatewaysForSecret(ctx context.Context, c client.Client, obj client.Object, controllerName string, logger *slog.Logger) []*gatewayv1.Gateway {
 	scopedLog := logger.With(
 		logfields.Resource, obj.GetName(),
 	)
+	hasMatchingControllerFn := GatewayHasMatchingControllerFn(ctx, c, controllerName, logger)
+
+	secretKey := types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}.String()
 
 	gwList := &gatewayv1.GatewayList{}
-	if err := c.List(ctx, gwList); err != nil {
+	if err := c.List(ctx, gwList, &client.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector(GatewaySecretIndex, secretKey),
+	}); err != nil {
 		scopedLog.WarnContext(ctx, "Unable to list Gateways", logfields.Error, err)
 		return nil
 	}
 
-	// Track which Gateways we've already added to avoid duplicates
 	seen := make(map[types.NamespacedName]struct{})
 	var gateways []*gatewayv1.Gateway
 
-	for _, gw := range gwList.Items {
-		for _, l := range gw.Spec.Listeners {
-			if listenerReferencesSecret(l.TLS, gw.GetNamespace(), obj) {
-				gwNN := types.NamespacedName{Name: gw.GetName(), Namespace: gw.GetNamespace()}
-				if _, ok := seen[gwNN]; !ok {
-					seen[gwNN] = struct{}{}
-					gateways = append(gateways, &gw)
-				}
-				break
-			}
+	for i := range gwList.Items {
+		gw := &gwList.Items[i]
+		if !hasMatchingControllerFn(gw) {
+			continue
 		}
+		gwNN := types.NamespacedName{Name: gw.GetName(), Namespace: gw.GetNamespace()}
+		if _, ok := seen[gwNN]; ok {
+			continue
+		}
+		seen[gwNN] = struct{}{}
+		gateways = append(gateways, gw)
 	}
 
-	// Also scan ListenerSets for secret references
 	if HasListenerSetSupport(c.Scheme()) {
 		lsList := &gatewayv1.ListenerSetList{}
-		if err := c.List(ctx, lsList); err != nil {
+		if err := c.List(ctx, lsList, &client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector(ListenerSetSecretIndex, secretKey),
+		}); err != nil {
 			scopedLog.WarnContext(ctx, "Unable to list ListenerSets", logfields.Error, err)
 			return gateways
 		}
 
-		for _, ls := range lsList.Items {
-			for _, entry := range ls.Spec.Listeners {
-				if listenerReferencesSecret(entry.TLS, ls.GetNamespace(), obj) {
-					gwNN := *ListenerSetParentGateway(&ls)
-					if _, ok := seen[gwNN]; ok {
-						break
-					}
-					seen[gwNN] = struct{}{}
-					// Look up the actual Gateway object
-					gw := &gatewayv1.Gateway{}
-					if err := c.Get(ctx, gwNN, gw); err != nil {
-						scopedLog.WarnContext(ctx, "Unable to get Gateway for ListenerSet", logfields.Error, err)
-						break
-					}
-					gateways = append(gateways, gw)
-					break
-				}
+		for i := range lsList.Items {
+			gwNN := *ListenerSetParentGateway(&lsList.Items[i])
+			if _, ok := seen[gwNN]; ok {
+				continue
 			}
+			seen[gwNN] = struct{}{}
+
+			gw := &gatewayv1.Gateway{}
+			if err := c.Get(ctx, gwNN, gw); err != nil {
+				scopedLog.WarnContext(ctx, "Unable to get Gateway for ListenerSet", logfields.Error, err)
+				continue
+			}
+			if !hasMatchingControllerFn(gw) {
+				continue
+			}
+			gateways = append(gateways, gw)
 		}
 	}
 
 	return gateways
-}
-
-// listenerReferencesSecret checks if a listener's TLS config references the given secret.
-func listenerReferencesSecret(tls *gatewayv1.ListenerTLSConfig, ownerNamespace string, secret client.Object) bool {
-	if tls == nil {
-		return false
-	}
-	for _, cert := range tls.CertificateRefs {
-		if !IsSecret(cert) {
-			continue
-		}
-		ns := NamespaceDerefOr(cert.Namespace, ownerNamespace)
-		if string(cert.Name) == secret.GetName() && ns == secret.GetNamespace() {
-			return true
-		}
-	}
-	return false
 }

--- a/operator/pkg/gateway-api/helpers/secrets_test.go
+++ b/operator/pkg/gateway-api/helpers/secrets_test.go
@@ -9,10 +9,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers/testhelpers"
 )
@@ -42,5 +44,254 @@ func Test_getGatewaysForSecret(t *testing.T) {
 		}, logger)
 
 		require.Empty(t, gwList)
+	})
+}
+
+func Test_getGatewaysForSecretInListenerSet(t *testing.T) {
+	// Build a client with a Gateway + ListenerSet referencing a secret
+	lsSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ls-tls-secret",
+			Namespace: "default",
+		},
+		StringData: map[string]string{
+			"tls.crt": "cert",
+			"tls.key": "key",
+		},
+		Type: corev1.SecretTypeTLS,
+	}
+
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "parent-gateway",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cilium",
+			Listeners:        []gatewayv1.Listener{},
+		},
+	}
+
+	ls := &gatewayv1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-listenerset",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.ListenerSetSpec{
+			ParentRef: gatewayv1.ParentGatewayReference{
+				Name: "parent-gateway",
+			},
+			Listeners: []gatewayv1.ListenerEntry{
+				{
+					Name:     "https",
+					Port:     443,
+					Protocol: gatewayv1.HTTPSProtocolType,
+					Hostname: ptr.To[gatewayv1.Hostname]("ls.example.com"),
+					TLS: &gatewayv1.ListenerTLSConfig{
+						CertificateRefs: []gatewayv1.SecretObjectReference{
+							{Name: "ls-tls-secret"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(TestScheme(AllOptionalKinds)).
+		WithObjects(testhelpers.ControllerTestFixture...).
+		WithObjects(lsSecret, gw, ls).
+		Build()
+	logger := hivetest.Logger(t)
+
+	t.Run("secret referenced from ListenerSet resolves to parent Gateway", func(t *testing.T) {
+		gwList := GetGatewaysForSecret(t.Context(), c, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ls-tls-secret",
+				Namespace: "default",
+			},
+		}, logger)
+
+		require.Len(t, gwList, 1)
+		require.Equal(t, "parent-gateway", gwList[0].Name)
+	})
+
+	t.Run("secret not referenced from any ListenerSet", func(t *testing.T) {
+		gwList := GetGatewaysForSecret(t.Context(), c, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "unknown-secret",
+				Namespace: "default",
+			},
+		}, logger)
+
+		require.Empty(t, gwList)
+	})
+}
+
+func Test_getGatewaysForSecretFromBothGatewayAndListenerSet(t *testing.T) {
+	sharedSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "shared-secret",
+			Namespace: "default",
+		},
+		Type: corev1.SecretTypeTLS,
+	}
+
+	// Gateway A references the secret directly via its own listener
+	gwA := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gateway-a",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cilium",
+			Listeners: []gatewayv1.Listener{
+				{
+					Name:     "https",
+					Port:     443,
+					Protocol: gatewayv1.HTTPSProtocolType,
+					TLS: &gatewayv1.ListenerTLSConfig{
+						CertificateRefs: []gatewayv1.SecretObjectReference{
+							{Name: "shared-secret"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Gateway B has no listeners referencing the secret
+	gwB := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gateway-b",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cilium",
+			Listeners:        []gatewayv1.Listener{},
+		},
+	}
+
+	// ListenerSet references the secret and is parented to Gateway B
+	ls := &gatewayv1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ls-for-gateway-b",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.ListenerSetSpec{
+			ParentRef: gatewayv1.ParentGatewayReference{
+				Name: "gateway-b",
+			},
+			Listeners: []gatewayv1.ListenerEntry{
+				{
+					Name:     "https",
+					Port:     443,
+					Protocol: gatewayv1.HTTPSProtocolType,
+					TLS: &gatewayv1.ListenerTLSConfig{
+						CertificateRefs: []gatewayv1.SecretObjectReference{
+							{Name: "shared-secret"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(TestScheme(AllOptionalKinds)).
+		WithObjects(testhelpers.ControllerTestFixture...).
+		WithObjects(sharedSecret, gwA, gwB, ls).
+		Build()
+	logger := hivetest.Logger(t)
+
+	t.Run("returns both gateways when secret is referenced from Gateway and ListenerSet", func(t *testing.T) {
+		gwList := GetGatewaysForSecret(t.Context(), c, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "shared-secret",
+				Namespace: "default",
+			},
+		}, logger)
+
+		require.Len(t, gwList, 2)
+		names := []string{gwList[0].Name, gwList[1].Name}
+		require.Contains(t, names, "gateway-a")
+		require.Contains(t, names, "gateway-b")
+	})
+}
+
+func Test_getGatewaysForSecretDeduplication(t *testing.T) {
+	sharedSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dedup-secret",
+			Namespace: "default",
+		},
+		Type: corev1.SecretTypeTLS,
+	}
+
+	// Gateway references the secret directly via its own listener
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dedup-gateway",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cilium",
+			Listeners: []gatewayv1.Listener{
+				{
+					Name:     "https",
+					Port:     443,
+					Protocol: gatewayv1.HTTPSProtocolType,
+					TLS: &gatewayv1.ListenerTLSConfig{
+						CertificateRefs: []gatewayv1.SecretObjectReference{
+							{Name: "dedup-secret"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// ListenerSet also references the same secret, parented to the same Gateway
+	ls := &gatewayv1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ls-same-gateway",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.ListenerSetSpec{
+			ParentRef: gatewayv1.ParentGatewayReference{
+				Name: "dedup-gateway",
+			},
+			Listeners: []gatewayv1.ListenerEntry{
+				{
+					Name:     "https-alt",
+					Port:     8443,
+					Protocol: gatewayv1.HTTPSProtocolType,
+					TLS: &gatewayv1.ListenerTLSConfig{
+						CertificateRefs: []gatewayv1.SecretObjectReference{
+							{Name: "dedup-secret"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(TestScheme(AllOptionalKinds)).
+		WithObjects(testhelpers.ControllerTestFixture...).
+		WithObjects(sharedSecret, gw, ls).
+		Build()
+	logger := hivetest.Logger(t)
+
+	t.Run("same gateway is not duplicated when secret is referenced from both Gateway and ListenerSet", func(t *testing.T) {
+		gwList := GetGatewaysForSecret(t.Context(), c, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dedup-secret",
+				Namespace: "default",
+			},
+		}, logger)
+
+		require.Len(t, gwList, 1)
+		require.Equal(t, "dedup-gateway", gwList[0].Name)
 	})
 }

--- a/operator/pkg/gateway-api/helpers/secrets_test.go
+++ b/operator/pkg/gateway-api/helpers/secrets_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package helpers
+package helpers_test
 
 import (
 	"testing"
@@ -16,32 +16,95 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers/testhelpers"
+	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
 )
 
+const testGatewayControllerName = "io.cilium/gateway-controller"
+
+func withSecretIndexes(b *fake.ClientBuilder) *fake.ClientBuilder {
+	return b.
+		WithIndex(&gatewayv1.Gateway{}, helpers.GatewaySecretIndex, indexers.IndexGatewayBySecret).
+		WithIndex(&gatewayv1.ListenerSet{}, helpers.ListenerSetSecretIndex, indexers.IndexListenerSetBySecret)
+}
+
 func Test_getGatewaysForSecret(t *testing.T) {
-	c := fake.NewClientBuilder().WithScheme(TestScheme(AllOptionalKinds)).WithObjects(testhelpers.ControllerTestFixture...).Build()
+	c := withSecretIndexes(fake.NewClientBuilder().WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).WithObjects(testhelpers.ControllerTestFixture...)).Build()
 	logger := hivetest.Logger(t)
 
 	t.Run("secret is used in gateway", func(t *testing.T) {
-		gwList := GetGatewaysForSecret(t.Context(), c, &corev1.Secret{
+		gwList := helpers.GetGatewaysForSecret(t.Context(), c, &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "tls-secret",
 				Namespace: "default",
 			},
-		}, logger)
+		}, testGatewayControllerName, logger)
 
 		require.Len(t, gwList, 1)
 		require.Equal(t, "valid-gateway", gwList[0].Name)
 	})
 
 	t.Run("secret is not used in gateway", func(t *testing.T) {
-		gwList := GetGatewaysForSecret(t.Context(), c, &corev1.Secret{
+		gwList := helpers.GetGatewaysForSecret(t.Context(), c, &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "tls-secret-not-used",
 				Namespace: "default",
 			},
-		}, logger)
+		}, testGatewayControllerName, logger)
+
+		require.Empty(t, gwList)
+	})
+
+	t.Run("secret is used only in gateway for different controller", func(t *testing.T) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "third-party-secret",
+				Namespace: "default",
+			},
+			Type: corev1.SecretTypeTLS,
+		}
+		gwc := &gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "third-party",
+			},
+			Spec: gatewayv1.GatewayClassSpec{
+				ControllerName: "example.com/third-party-controller",
+			},
+		}
+		gw := &gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "third-party-gateway",
+				Namespace: "default",
+			},
+			Spec: gatewayv1.GatewaySpec{
+				GatewayClassName: "third-party",
+				Listeners: []gatewayv1.Listener{
+					{
+						Name:     "https",
+						Port:     443,
+						Protocol: gatewayv1.HTTPSProtocolType,
+						TLS: &gatewayv1.ListenerTLSConfig{
+							CertificateRefs: []gatewayv1.SecretObjectReference{
+								{Name: "third-party-secret"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		c := withSecretIndexes(fake.NewClientBuilder().
+			WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+			WithObjects(secret, gwc, gw)).
+			Build()
+
+		gwList := helpers.GetGatewaysForSecret(t.Context(), c, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "third-party-secret",
+				Namespace: "default",
+			},
+		}, testGatewayControllerName, logger)
 
 		require.Empty(t, gwList)
 	})
@@ -97,32 +160,32 @@ func Test_getGatewaysForSecretInListenerSet(t *testing.T) {
 		},
 	}
 
-	c := fake.NewClientBuilder().
-		WithScheme(TestScheme(AllOptionalKinds)).
+	c := withSecretIndexes(fake.NewClientBuilder().
+		WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
 		WithObjects(testhelpers.ControllerTestFixture...).
-		WithObjects(lsSecret, gw, ls).
+		WithObjects(lsSecret, gw, ls)).
 		Build()
 	logger := hivetest.Logger(t)
 
 	t.Run("secret referenced from ListenerSet resolves to parent Gateway", func(t *testing.T) {
-		gwList := GetGatewaysForSecret(t.Context(), c, &corev1.Secret{
+		gwList := helpers.GetGatewaysForSecret(t.Context(), c, &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "ls-tls-secret",
 				Namespace: "default",
 			},
-		}, logger)
+		}, testGatewayControllerName, logger)
 
 		require.Len(t, gwList, 1)
 		require.Equal(t, "parent-gateway", gwList[0].Name)
 	})
 
 	t.Run("secret not referenced from any ListenerSet", func(t *testing.T) {
-		gwList := GetGatewaysForSecret(t.Context(), c, &corev1.Secret{
+		gwList := helpers.GetGatewaysForSecret(t.Context(), c, &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "unknown-secret",
 				Namespace: "default",
 			},
-		}, logger)
+		}, testGatewayControllerName, logger)
 
 		require.Empty(t, gwList)
 	})
@@ -197,20 +260,20 @@ func Test_getGatewaysForSecretFromBothGatewayAndListenerSet(t *testing.T) {
 		},
 	}
 
-	c := fake.NewClientBuilder().
-		WithScheme(TestScheme(AllOptionalKinds)).
+	c := withSecretIndexes(fake.NewClientBuilder().
+		WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
 		WithObjects(testhelpers.ControllerTestFixture...).
-		WithObjects(sharedSecret, gwA, gwB, ls).
+		WithObjects(sharedSecret, gwA, gwB, ls)).
 		Build()
 	logger := hivetest.Logger(t)
 
 	t.Run("returns both gateways when secret is referenced from Gateway and ListenerSet", func(t *testing.T) {
-		gwList := GetGatewaysForSecret(t.Context(), c, &corev1.Secret{
+		gwList := helpers.GetGatewaysForSecret(t.Context(), c, &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "shared-secret",
 				Namespace: "default",
 			},
-		}, logger)
+		}, testGatewayControllerName, logger)
 
 		require.Len(t, gwList, 2)
 		names := []string{gwList[0].Name, gwList[1].Name}
@@ -276,20 +339,20 @@ func Test_getGatewaysForSecretDeduplication(t *testing.T) {
 		},
 	}
 
-	c := fake.NewClientBuilder().
-		WithScheme(TestScheme(AllOptionalKinds)).
+	c := withSecretIndexes(fake.NewClientBuilder().
+		WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
 		WithObjects(testhelpers.ControllerTestFixture...).
-		WithObjects(sharedSecret, gw, ls).
+		WithObjects(sharedSecret, gw, ls)).
 		Build()
 	logger := hivetest.Logger(t)
 
 	t.Run("same gateway is not duplicated when secret is referenced from both Gateway and ListenerSet", func(t *testing.T) {
-		gwList := GetGatewaysForSecret(t.Context(), c, &corev1.Secret{
+		gwList := helpers.GetGatewaysForSecret(t.Context(), c, &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "dedup-secret",
 				Namespace: "default",
 			},
-		}, logger)
+		}, testGatewayControllerName, logger)
 
 		require.Len(t, gwList, 1)
 		require.Equal(t, "dedup-gateway", gwList[0].Name)

--- a/operator/pkg/gateway-api/helpers/types.go
+++ b/operator/pkg/gateway-api/helpers/types.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	kindGateway       = "Gateway"
+	kindListenerSet   = "ListenerSet"
 	kindService       = "Service"
 	kindServiceImport = "ServiceImport"
 	kindSecret        = "Secret"
@@ -33,12 +34,18 @@ const (
 	TCPRouteListKind      string = "tcproutelists"
 	UDPRouteKind          string = "udproutes"
 	UDPRouteListKind      string = "udproutelists"
+	ListenerSetKind       string = "listenersets"
+	ListenerSetListKind   string = "listenersetlists"
 	ServiceImportKind     string = "serviceimports"
 	ServiceImportListKind string = "serviceimportlists"
 )
 
 func IsGateway(parent gatewayv1.ParentReference) bool {
 	return (parent.Kind == nil || *parent.Kind == kindGateway) && (parent.Group == nil || *parent.Group == gatewayv1.GroupName)
+}
+
+func IsListenerSet(parent gatewayv1.ParentReference) bool {
+	return parent.Kind != nil && *parent.Kind == kindListenerSet && (parent.Group == nil || *parent.Group == gatewayv1.GroupName)
 }
 
 func IsGammaService(parent gatewayv1.ParentReference) bool {
@@ -118,6 +125,10 @@ func GetConcreteObject(schemaType schema.GroupVersionKind) runtime.Object {
 		return &gatewayv1alpha2.UDPRoute{}
 	case UDPRouteListKind:
 		return &gatewayv1alpha2.UDPRouteList{}
+	case ListenerSetKind:
+		return &gatewayv1.ListenerSet{}
+	case ListenerSetListKind:
+		return &gatewayv1.ListenerSetList{}
 	case ServiceImportKind:
 		return &mcsapiv1beta1.ServiceImport{}
 	case ServiceImportListKind:

--- a/operator/pkg/gateway-api/helpers_listenerset_test.go
+++ b/operator/pkg/gateway-api/helpers_listenerset_test.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gateway_api
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+)
+
+func fromPtr(f gatewayv1.FromNamespaces) *gatewayv1.FromNamespaces {
+	return &f
+}
+
+func Test_sortListenerSets(t *testing.T) {
+	t1 := metav1.NewTime(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	t2 := metav1.NewTime(time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC))
+
+	tests := []struct {
+		name     string
+		input    []gatewayv1.ListenerSet
+		expected []string // namespace/name in expected order
+	}{
+		{
+			name: "sort by creation timestamp",
+			input: []gatewayv1.ListenerSet{
+				{ObjectMeta: metav1.ObjectMeta{Name: "newer", Namespace: "ns", CreationTimestamp: t2}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "older", Namespace: "ns", CreationTimestamp: t1}},
+			},
+			expected: []string{"ns/older", "ns/newer"},
+		},
+		{
+			name: "same timestamp sorts alphabetically",
+			input: []gatewayv1.ListenerSet{
+				{ObjectMeta: metav1.ObjectMeta{Name: "zebra", Namespace: "ns", CreationTimestamp: t1}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "alpha", Namespace: "ns", CreationTimestamp: t1}},
+			},
+			expected: []string{"ns/alpha", "ns/zebra"},
+		},
+		{
+			name: "same timestamp sorts by namespace then name",
+			input: []gatewayv1.ListenerSet{
+				{ObjectMeta: metav1.ObjectMeta{Name: "ls", Namespace: "z-ns", CreationTimestamp: t1}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "ls", Namespace: "a-ns", CreationTimestamp: t1}},
+			},
+			expected: []string{"a-ns/ls", "z-ns/ls"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sortListenerSets(tt.input)
+			var got []string
+			for _, ls := range tt.input {
+				got = append(got, ls.GetNamespace()+"/"+ls.GetName())
+			}
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func Test_isListenerSetAllowed_noAllowedListeners(t *testing.T) {
+	gw := &gatewayv1.Gateway{
+		Spec: gatewayv1.GatewaySpec{},
+	}
+	ls := &gatewayv1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+	}
+	assert.False(t, isListenerSetAllowed(t.Context(), nil, gw, ls, nil))
+}
+
+func Test_isListenerSetAllowed_fromNone(t *testing.T) {
+	gw := &gatewayv1.Gateway{
+		Spec: gatewayv1.GatewaySpec{
+			AllowedListeners: &gatewayv1.AllowedListeners{
+				Namespaces: &gatewayv1.ListenerNamespaces{
+					From: fromPtr(gatewayv1.NamespacesFromNone),
+				},
+			},
+		},
+	}
+	ls := &gatewayv1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+	}
+	assert.False(t, isListenerSetAllowed(t.Context(), nil, gw, ls, nil))
+}
+
+func Test_isListenerSetAllowed_fromAll(t *testing.T) {
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "gw-ns"},
+		Spec: gatewayv1.GatewaySpec{
+			AllowedListeners: &gatewayv1.AllowedListeners{
+				Namespaces: &gatewayv1.ListenerNamespaces{
+					From: fromPtr(gatewayv1.NamespacesFromAll),
+				},
+			},
+		},
+	}
+	ls := &gatewayv1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "other-ns"},
+	}
+	assert.True(t, isListenerSetAllowed(t.Context(), nil, gw, ls, nil))
+}
+
+func Test_isListenerSetAllowed_fromSame(t *testing.T) {
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "gw-ns"},
+		Spec: gatewayv1.GatewaySpec{
+			AllowedListeners: &gatewayv1.AllowedListeners{
+				Namespaces: &gatewayv1.ListenerNamespaces{
+					From: fromPtr(gatewayv1.NamespacesFromSame),
+				},
+			},
+		},
+	}
+
+	t.Run("same namespace allowed", func(t *testing.T) {
+		ls := &gatewayv1.ListenerSet{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "gw-ns"},
+		}
+		assert.True(t, isListenerSetAllowed(t.Context(), nil, gw, ls, nil))
+	})
+
+	t.Run("different namespace rejected", func(t *testing.T) {
+		ls := &gatewayv1.ListenerSet{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "other-ns"},
+		}
+		assert.False(t, isListenerSetAllowed(t.Context(), nil, gw, ls, nil))
+	})
+}
+
+func Test_isListenerSetAllowed_fromSelector(t *testing.T) {
+	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "gw-ns"},
+		Spec: gatewayv1.GatewaySpec{
+			AllowedListeners: &gatewayv1.AllowedListeners{
+				Namespaces: &gatewayv1.ListenerNamespaces{
+					From:     fromPtr(gatewayv1.NamespacesFromSelector),
+					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"team": "infra"}},
+				},
+			},
+		},
+	}
+
+	t.Run("matching label allowed", func(t *testing.T) {
+		c := fake.NewClientBuilder().
+			WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+			WithObjects(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "infra-ns", Labels: map[string]string{"team": "infra"}}}).
+			Build()
+		ls := &gatewayv1.ListenerSet{ObjectMeta: metav1.ObjectMeta{Namespace: "infra-ns"}}
+		assert.True(t, isListenerSetAllowed(t.Context(), c, gw, ls, logger))
+	})
+
+	t.Run("non-matching label rejected", func(t *testing.T) {
+		c := fake.NewClientBuilder().
+			WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+			WithObjects(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "other-ns", Labels: map[string]string{"team": "platform"}}}).
+			Build()
+		ls := &gatewayv1.ListenerSet{ObjectMeta: metav1.ObjectMeta{Namespace: "other-ns"}}
+		assert.False(t, isListenerSetAllowed(t.Context(), c, gw, ls, logger))
+	})
+}

--- a/operator/pkg/gateway-api/indexers/grpcroute.go
+++ b/operator/pkg/gateway-api/indexers/grpcroute.go
@@ -35,6 +35,25 @@ func IndexGRPCRouteByGateway(rawObj client.Object) []string {
 	return gateways
 }
 
+// IndexGRPCRouteByListenerSet indexes GRPCRoutes by all ListenerSet parents
+// referenced in the object, returning ListenerSet full names (`namespace/name`).
+func IndexGRPCRouteByListenerSet(rawObj client.Object) []string {
+	route := rawObj.(*gatewayv1.GRPCRoute)
+	var listenerSets []string
+	for _, parent := range route.Spec.ParentRefs {
+		if !helpers.IsListenerSet(parent) {
+			continue
+		}
+		listenerSets = append(listenerSets,
+			types.NamespacedName{
+				Namespace: helpers.NamespaceDerefOr(parent.Namespace, route.Namespace),
+				Name:      string(parent.Name),
+			}.String(),
+		)
+	}
+	return listenerSets
+}
+
 // IndexGRPCRouteByGammaService is a client.IndexerFunc that takes a single GRPCRoute and returns all
 // referenced Service object full names (`namespace/name`) to add to the relevant index.
 func IndexGRPCRouteByGammaService(rawObj client.Object) []string {

--- a/operator/pkg/gateway-api/indexers/httproute.go
+++ b/operator/pkg/gateway-api/indexers/httproute.go
@@ -35,6 +35,25 @@ func IndexHTTPRouteByGateway(rawObj client.Object) []string {
 	return gateways
 }
 
+// IndexHTTPRouteByListenerSet indexes HTTPRoutes by all ListenerSet parents
+// referenced in the object, returning ListenerSet full names (`namespace/name`).
+func IndexHTTPRouteByListenerSet(rawObj client.Object) []string {
+	hr := rawObj.(*gatewayv1.HTTPRoute)
+	var listenerSets []string
+	for _, parent := range hr.Spec.ParentRefs {
+		if !helpers.IsListenerSet(parent) {
+			continue
+		}
+		listenerSets = append(listenerSets,
+			types.NamespacedName{
+				Namespace: helpers.NamespaceDerefOr(parent.Namespace, hr.Namespace),
+				Name:      string(parent.Name),
+			}.String(),
+		)
+	}
+	return listenerSets
+}
+
 // IndexHTTPRouteByGammaService is a client.IndexerFunc that takes a single HTTPRoute and returns all
 // referenced Service object full names (`namespace/name`) to add to the relevant index.
 func IndexHTTPRouteByGammaService(rawObj client.Object) []string {

--- a/operator/pkg/gateway-api/indexers/indexnames.go
+++ b/operator/pkg/gateway-api/indexers/indexnames.go
@@ -55,4 +55,16 @@ const (
 
 	// Indexes UDPRoutes by all the Gateway parents referenced in the object.
 	GatewayUDPRouteIndex = "gatewayUDPRouteIndex"
+
+	// Indexes ListenerSets by the parent Gateway referenced in the object.
+	ListenerSetGatewayIndex = "listenerSetGatewayIndex"
+
+	// Indexes HTTPRoutes by all the ListenerSet parents referenced in the object.
+	HTTPRouteListenerSetIndex = "listenerSetHTTPRouteIndex"
+
+	// Indexes GRPCRoutes by all the ListenerSet parents referenced in the object.
+	GRPCRouteListenerSetIndex = "listenerSetGRPCRouteIndex"
+
+	// Indexes TLSRoutes by all the ListenerSet parents referenced in the object.
+	TLSRouteListenerSetIndex = "listenerSetTLSRouteIndex"
 )

--- a/operator/pkg/gateway-api/indexers/indexnames.go
+++ b/operator/pkg/gateway-api/indexers/indexnames.go
@@ -67,4 +67,10 @@ const (
 
 	// Indexes TLSRoutes by all the ListenerSet parents referenced in the object.
 	TLSRouteListenerSetIndex = "listenerSetTLSRouteIndex"
+
+	// Indexes TCPRoutes by all the ListenerSet parents referenced in the object.
+	TCPRouteListenerSetIndex = "listenerSetTCPRouteIndex"
+
+	// Indexes UDPRoutes by all the ListenerSet parents referenced in the object.
+	UDPRouteListenerSetIndex = "listenerSetUDPRouteIndex"
 )

--- a/operator/pkg/gateway-api/indexers/listenerset.go
+++ b/operator/pkg/gateway-api/indexers/listenerset.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package indexers
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// IndexListenerSetByGateway is a client.IndexerFunc that takes a single ListenerSet and returns
+// the parent Gateway object full name (`namespace/name`) to add to the relevant index.
+func IndexListenerSetByGateway(rawObj client.Object) []string {
+	ls := rawObj.(*gatewayv1.ListenerSet)
+
+	gwNamespace := ls.GetNamespace()
+	if ls.Spec.ParentRef.Namespace != nil {
+		gwNamespace = string(*ls.Spec.ParentRef.Namespace)
+	}
+
+	return []string{
+		types.NamespacedName{
+			Namespace: gwNamespace,
+			Name:      string(ls.Spec.ParentRef.Name),
+		}.String(),
+	}
+}

--- a/operator/pkg/gateway-api/indexers/listenerset_test.go
+++ b/operator/pkg/gateway-api/indexers/listenerset_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package indexers
+
+import (
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestIndexListenerSetByGateway(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  client.Object
+		want []string
+	}{
+		{
+			name: "parentRef with no namespace defaults to ListenerSet namespace",
+			obj: &gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-listenerset",
+					Namespace: "default",
+				},
+				Spec: gatewayv1.ListenerSetSpec{
+					ParentRef: gatewayv1.ParentGatewayReference{
+						Name: "my-gateway",
+					},
+				},
+			},
+			want: []string{"default/my-gateway"},
+		},
+		{
+			name: "parentRef with explicit namespace",
+			obj: &gatewayv1.ListenerSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-listenerset",
+					Namespace: "default",
+				},
+				Spec: gatewayv1.ListenerSetSpec{
+					ParentRef: gatewayv1.ParentGatewayReference{
+						Name:      "my-gateway",
+						Namespace: ptr.To[gatewayv1.Namespace]("infra"),
+					},
+				},
+			},
+			want: []string{"infra/my-gateway"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IndexListenerSetByGateway(tt.obj)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("IndexListenerSetByGateway() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/operator/pkg/gateway-api/indexers/secrets.go
+++ b/operator/pkg/gateway-api/indexers/secrets.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package indexers
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+)
+
+func IndexGatewayBySecret(rawObj client.Object) []string {
+	gw := rawObj.(*gatewayv1.Gateway)
+
+	var keys []string
+	for _, l := range gw.Spec.Listeners {
+		keys = append(keys, listenerSecretKeys(l.TLS, gw.GetNamespace())...)
+	}
+	return keys
+}
+
+func IndexListenerSetBySecret(rawObj client.Object) []string {
+	ls := rawObj.(*gatewayv1.ListenerSet)
+
+	var keys []string
+	for _, l := range ls.Spec.Listeners {
+		keys = append(keys, listenerSecretKeys(l.TLS, ls.GetNamespace())...)
+	}
+	return keys
+}
+
+func listenerSecretKeys(tls *gatewayv1.ListenerTLSConfig, ownerNamespace string) []string {
+	if tls == nil {
+		return nil
+	}
+
+	var keys []string
+	for _, cert := range tls.CertificateRefs {
+		if !helpers.IsSecret(cert) {
+			continue
+		}
+		keys = append(keys, types.NamespacedName{
+			Name:      string(cert.Name),
+			Namespace: helpers.NamespaceDerefOr(cert.Namespace, ownerNamespace),
+		}.String())
+	}
+	return keys
+}

--- a/operator/pkg/gateway-api/indexers/tcproute.go
+++ b/operator/pkg/gateway-api/indexers/tcproute.go
@@ -65,3 +65,20 @@ func IndexTCPRouteByGateway(rawObj client.Object) []string {
 	}
 	return gateways
 }
+
+func IndexTCPRouteByListenerSet(rawObj client.Object) []string {
+	route := rawObj.(*gatewayv1alpha2.TCPRoute)
+	var listenerSets []string
+	for _, parent := range route.Spec.ParentRefs {
+		if !helpers.IsListenerSet(parent) {
+			continue
+		}
+		listenerSets = append(listenerSets,
+			types.NamespacedName{
+				Namespace: helpers.NamespaceDerefOr(parent.Namespace, route.Namespace),
+				Name:      string(parent.Name),
+			}.String(),
+		)
+	}
+	return listenerSets
+}

--- a/operator/pkg/gateway-api/indexers/tlsroute.go
+++ b/operator/pkg/gateway-api/indexers/tlsroute.go
@@ -65,3 +65,22 @@ func IndexTLSRouteByGateway(rawObj client.Object) []string {
 	}
 	return gateways
 }
+
+// IndexTLSRouteByListenerSet indexes TLSRoutes by all ListenerSet parents
+// referenced in the object, returning ListenerSet full names (`namespace/name`).
+func IndexTLSRouteByListenerSet(rawObj client.Object) []string {
+	route := rawObj.(*gatewayv1.TLSRoute)
+	var listenerSets []string
+	for _, parent := range route.Spec.ParentRefs {
+		if !helpers.IsListenerSet(parent) {
+			continue
+		}
+		listenerSets = append(listenerSets,
+			types.NamespacedName{
+				Namespace: helpers.NamespaceDerefOr(parent.Namespace, route.Namespace),
+				Name:      string(parent.Name),
+			}.String(),
+		)
+	}
+	return listenerSets
+}

--- a/operator/pkg/gateway-api/indexers/udproute.go
+++ b/operator/pkg/gateway-api/indexers/udproute.go
@@ -65,3 +65,20 @@ func IndexUDPRouteByGateway(rawObj client.Object) []string {
 	}
 	return gateways
 }
+
+func IndexUDPRouteByListenerSet(rawObj client.Object) []string {
+	route := rawObj.(*gatewayv1alpha2.UDPRoute)
+	var listenerSets []string
+	for _, parent := range route.Spec.ParentRefs {
+		if !helpers.IsListenerSet(parent) {
+			continue
+		}
+		listenerSets = append(listenerSets,
+			types.NamespacedName{
+				Namespace: helpers.NamespaceDerefOr(parent.Namespace, route.Namespace),
+				Name:      string(parent.Name),
+			}.String(),
+		)
+	}
+	return listenerSets
+}

--- a/operator/pkg/gateway-api/listener_conflict_test.go
+++ b/operator/pkg/gateway-api/listener_conflict_test.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gateway_api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func muxedListener(
+	name string,
+	protocol gatewayv1.ProtocolType,
+	port gatewayv1.PortNumber,
+	hostname string,
+) *gatewayv1.Listener {
+	l := &gatewayv1.Listener{
+		Name:     gatewayv1.SectionName(name),
+		Protocol: protocol,
+		Port:     port,
+	}
+	if hostname != "" {
+		l.Hostname = ptr.To(gatewayv1.Hostname(hostname))
+	}
+	if protocol == gatewayv1.HTTPSProtocolType {
+		l.TLS = &gatewayv1.ListenerTLSConfig{Mode: ptr.To(gatewayv1.TLSModeTerminate)}
+	}
+	return l
+}
+
+func tlsPassthroughListener(
+	name string,
+	port gatewayv1.PortNumber,
+	hostname string,
+) *gatewayv1.Listener {
+	l := muxedListener(name, gatewayv1.TLSProtocolType, port, hostname)
+	l.TLS = &gatewayv1.ListenerTLSConfig{Mode: ptr.To(gatewayv1.TLSModePassthrough)}
+	return l
+}
+
+func l4Listener(
+	name string,
+	protocol gatewayv1.ProtocolType,
+	port gatewayv1.PortNumber,
+) *gatewayv1.Listener {
+	return &gatewayv1.Listener{
+		Name:     gatewayv1.SectionName(name),
+		Protocol: protocol,
+		Port:     port,
+	}
+}
+
+func Test_listenerPairConflict(t *testing.T) {
+	tests := []struct {
+		name       string
+		first      *gatewayv1.Listener
+		second     *gatewayv1.Listener
+		wantReason gatewayv1.ListenerConditionReason
+		wantOK     bool
+	}{
+		{
+			name:   "different ports never conflict",
+			first:  muxedListener("a", gatewayv1.HTTPProtocolType, 80, "foo.example.com"),
+			second: muxedListener("b", gatewayv1.HTTPProtocolType, 81, "foo.example.com"),
+		},
+		{
+			name:   "same protocol distinct hostnames coexist",
+			first:  muxedListener("a", gatewayv1.HTTPProtocolType, 80, "foo.example.com"),
+			second: muxedListener("b", gatewayv1.HTTPProtocolType, 80, "bar.example.com"),
+		},
+		{
+			name:   "same protocol wildcard and specific hostname coexist",
+			first:  muxedListener("a", gatewayv1.HTTPProtocolType, 80, "*.example.com"),
+			second: muxedListener("b", gatewayv1.HTTPProtocolType, 80, "foo.example.com"),
+		},
+		{
+			name:       "same protocol identical hostname conflicts",
+			first:      muxedListener("a", gatewayv1.HTTPProtocolType, 80, "foo.example.com"),
+			second:     muxedListener("b", gatewayv1.HTTPProtocolType, 80, "foo.example.com"),
+			wantReason: gatewayv1.ListenerReasonHostnameConflict,
+			wantOK:     true,
+		},
+		{
+			name:       "same protocol identical wildcard hostname conflicts",
+			first:      muxedListener("a", gatewayv1.HTTPProtocolType, 80, "*.example.com"),
+			second:     muxedListener("b", gatewayv1.HTTPProtocolType, 80, "*.example.com"),
+			wantReason: gatewayv1.ListenerReasonHostnameConflict,
+			wantOK:     true,
+		},
+		{
+			name:       "same protocol both catch-all hostnames conflict",
+			first:      muxedListener("a", gatewayv1.HTTPProtocolType, 80, ""),
+			second:     muxedListener("b", gatewayv1.HTTPProtocolType, 80, ""),
+			wantReason: gatewayv1.ListenerReasonHostnameConflict,
+			wantOK:     true,
+		},
+		{
+			name:   "http and https same hostname coexist",
+			first:  muxedListener("a", gatewayv1.HTTPProtocolType, 443, "foo.example.com"),
+			second: muxedListener("b", gatewayv1.HTTPSProtocolType, 443, "foo.example.com"),
+		},
+		{
+			name:       "https and tls passthrough identical hostname conflict",
+			first:      muxedListener("a", gatewayv1.HTTPSProtocolType, 443, "foo.example.com"),
+			second:     tlsPassthroughListener("b", 443, "foo.example.com"),
+			wantReason: gatewayv1.ListenerReasonProtocolConflict,
+			wantOK:     true,
+		},
+		{
+			name:       "https and tls passthrough wildcard overlap conflict",
+			first:      muxedListener("a", gatewayv1.HTTPSProtocolType, 443, "*.example.com"),
+			second:     tlsPassthroughListener("b", 443, "foo.example.com"),
+			wantReason: gatewayv1.ListenerReasonProtocolConflict,
+			wantOK:     true,
+		},
+		{
+			name:   "https and tls passthrough disjoint hostnames coexist",
+			first:  muxedListener("a", gatewayv1.HTTPSProtocolType, 443, "foo.example.com"),
+			second: tlsPassthroughListener("b", 443, "bar.example.com"),
+		},
+		{
+			name:       "tcp and muxed same port conflict",
+			first:      l4Listener("a", gatewayv1.TCPProtocolType, 80),
+			second:     muxedListener("b", gatewayv1.HTTPProtocolType, 80, "foo.example.com"),
+			wantReason: gatewayv1.ListenerReasonProtocolConflict,
+			wantOK:     true,
+		},
+		{
+			name:       "duplicate tcp same port conflict",
+			first:      l4Listener("a", gatewayv1.TCPProtocolType, 80),
+			second:     l4Listener("b", gatewayv1.TCPProtocolType, 80),
+			wantReason: gatewayv1.ListenerReasonProtocolConflict,
+			wantOK:     true,
+		},
+		{
+			name:   "tcp and udp same port coexist",
+			first:  l4Listener("a", gatewayv1.TCPProtocolType, 80),
+			second: l4Listener("b", gatewayv1.UDPProtocolType, 80),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, ok := listenerPairConflict(tt.first, tt.second)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantReason, reason)
+
+			reasonSwapped, okSwapped := listenerPairConflict(tt.second, tt.first)
+			assert.Equal(t, ok, okSwapped, "conflict detection must be symmetric")
+			assert.Equal(t, reason, reasonSwapped, "conflict reason must be symmetric")
+		})
+	}
+}
+
+func gatewayWithConflictListeners(listeners ...*gatewayv1.Listener) *gatewayv1.Gateway {
+	gw := &gatewayv1.Gateway{}
+	for _, l := range listeners {
+		gw.Spec.Listeners = append(gw.Spec.Listeners, *l)
+	}
+	return gw
+}
+
+func Test_conflictedGatewayListeners(t *testing.T) {
+	t.Run("non-conflicting listeners produce no entries", func(t *testing.T) {
+		gw := gatewayWithConflictListeners(
+			muxedListener("a", gatewayv1.HTTPProtocolType, 80, "foo.example.com"),
+			muxedListener("b", gatewayv1.HTTPProtocolType, 80, "bar.example.com"),
+		)
+		assert.Empty(t, conflictedGatewayListeners(gw))
+	})
+
+	t.Run("identical hostname duplicate marks both listeners", func(t *testing.T) {
+		gw := gatewayWithConflictListeners(
+			muxedListener("a", gatewayv1.HTTPSProtocolType, 443, "foo.example.com"),
+			muxedListener("b", gatewayv1.HTTPSProtocolType, 443, "foo.example.com"),
+		)
+		conflicts := conflictedGatewayListeners(gw)
+		assert.Equal(t, gatewayv1.ListenerReasonHostnameConflict, conflicts["a"].reason)
+		assert.Equal(t, gatewayv1.ListenerReasonHostnameConflict, conflicts["b"].reason)
+		assert.Contains(t, conflicts["a"].message, `listener "b"`)
+		assert.Contains(t, conflicts["b"].message, `listener "a"`)
+	})
+
+	t.Run("l4 and muxed on same port mark both listeners", func(t *testing.T) {
+		gw := gatewayWithConflictListeners(
+			l4Listener("a", gatewayv1.TCPProtocolType, 80),
+			muxedListener("b", gatewayv1.HTTPProtocolType, 80, "foo.example.com"),
+		)
+		conflicts := conflictedGatewayListeners(gw)
+		assert.Equal(t, gatewayv1.ListenerReasonProtocolConflict, conflicts["a"].reason)
+		assert.Equal(t, gatewayv1.ListenerReasonProtocolConflict, conflicts["b"].reason)
+	})
+
+	t.Run("https and tls passthrough overlap keeps existing message", func(t *testing.T) {
+		gw := gatewayWithConflictListeners(
+			muxedListener("https", gatewayv1.HTTPSProtocolType, 443, "api.example.test"),
+			tlsPassthroughListener("tls-passthrough", 443, "api.example.test"),
+		)
+		conflicts := conflictedGatewayListeners(gw)
+		assert.Equal(t, gatewayv1.ListenerReasonProtocolConflict, conflicts["https"].reason)
+		assert.Equal(t,
+			`Listener conflicts with listener "tls-passthrough": same port 443 has overlapping HTTPS and TLS passthrough hostnames.`,
+			conflicts["https"].message)
+	})
+}
+
+func Test_acceptedListeners(t *testing.T) {
+	t.Run("later listener loses against an accepted listener", func(t *testing.T) {
+		accepted := &acceptedListeners{}
+		accepted.accept(*muxedListener("gw-https", gatewayv1.HTTPSProtocolType, 443, "*.example.com"))
+
+		reason := accepted.checkConflict(*tlsPassthroughListener("ls-tls", 443, "foo.example.com"))
+		assert.Equal(t, gatewayv1.ListenerReasonProtocolConflict, reason)
+	})
+
+	t.Run("distinct hostname on the same protocol is accepted", func(t *testing.T) {
+		accepted := &acceptedListeners{}
+		accepted.accept(*muxedListener("first", gatewayv1.HTTPProtocolType, 80, "foo.example.com"))
+
+		reason := accepted.checkConflict(*muxedListener("second", gatewayv1.HTTPProtocolType, 80, "bar.example.com"))
+		assert.Empty(t, string(reason))
+	})
+}

--- a/operator/pkg/gateway-api/predicates/secrets.go
+++ b/operator/pkg/gateway-api/predicates/secrets.go
@@ -12,8 +12,8 @@ import (
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 )
 
-func SecretUsedInGatewayFn(c client.Client, logger *slog.Logger) func(obj client.Object) bool {
+func SecretUsedInGatewayFn(c client.Client, controllerName string, logger *slog.Logger) func(obj client.Object) bool {
 	return func(obj client.Object) bool {
-		return len(helpers.GetGatewaysForSecret(context.Background(), c, obj, logger)) > 0
+		return len(helpers.GetGatewaysForSecret(context.Background(), c, obj, controllerName, logger)) > 0
 	}
 }

--- a/operator/pkg/gateway-api/routechecks/gateway_checks.go
+++ b/operator/pkg/gateway-api/routechecks/gateway_checks.go
@@ -14,7 +14,7 @@ import (
 )
 
 func CheckGatewayAllowedForNamespace(input Input, parentRef gatewayv1.ParentReference) (bool, error) {
-	gw, err := input.GetGateway(parentRef)
+	owner, err := input.GetListenerOwner(parentRef)
 	if err != nil {
 		input.SetParentCondition(parentRef, metav1.Condition{
 			Type:    "Accepted",
@@ -26,9 +26,10 @@ func CheckGatewayAllowedForNamespace(input Input, parentRef gatewayv1.ParentRefe
 		return false, nil
 	}
 
-	allListenerHostNames := GetAllListenerHostNames(gw.Spec.Listeners)
+	listeners := owner.GetListeners()
+	allListenerHostNames := GetAllListenerHostNames(listeners)
 	hasNamespaceRestriction := false
-	for _, listener := range gw.Spec.Listeners {
+	for _, listener := range listeners {
 		if parentRef.SectionName != nil && listener.Name != *parentRef.SectionName {
 			continue
 		}
@@ -49,7 +50,7 @@ func CheckGatewayAllowedForNamespace(input Input, parentRef gatewayv1.ParentRefe
 		case gatewayv1.NamespacesFromAll:
 			return true, nil
 		case gatewayv1.NamespacesFromSame:
-			if input.GetNamespace() == gw.GetNamespace() {
+			if input.GetNamespace() == owner.GetNamespace() {
 				return true, nil
 			}
 		case gatewayv1.NamespacesFromSelector:
@@ -78,7 +79,7 @@ func CheckGatewayAllowedForNamespace(input Input, parentRef gatewayv1.ParentRefe
 }
 
 func CheckGatewayRouteKindAllowed(input Input, parentRef gatewayv1.ParentReference) (bool, error) {
-	gw, err := input.GetGateway(parentRef)
+	owner, err := input.GetListenerOwner(parentRef)
 	if err != nil {
 		input.SetParentCondition(parentRef, metav1.Condition{
 			Type:    string(gatewayv1.RouteConditionAccepted),
@@ -92,7 +93,7 @@ func CheckGatewayRouteKindAllowed(input Input, parentRef gatewayv1.ParentReferen
 
 	routeGVK := input.GetGVK()
 	hasKindRestriction := false
-	for _, listener := range gw.Spec.Listeners {
+	for _, listener := range owner.GetListeners() {
 		if parentRef.SectionName != nil && listener.Name != *parentRef.SectionName {
 			continue
 		}
@@ -128,7 +129,7 @@ func CheckGatewayRouteKindAllowed(input Input, parentRef gatewayv1.ParentReferen
 }
 
 func CheckGatewayMatchingHostnames(input Input, parentRef gatewayv1.ParentReference) (bool, error) {
-	gw, err := input.GetGateway(parentRef)
+	owner, err := input.GetListenerOwner(parentRef)
 	if err != nil {
 		input.SetParentCondition(parentRef, metav1.Condition{
 			Type:    "Accepted",
@@ -140,7 +141,7 @@ func CheckGatewayMatchingHostnames(input Input, parentRef gatewayv1.ParentRefere
 		return false, nil
 	}
 
-	if len(computeHosts(gw, input.GetHostnames(), nil)) == 0 {
+	if len(computeHosts(owner.GetListeners(), input.GetHostnames(), nil)) == 0 {
 
 		input.SetParentCondition(parentRef, metav1.Condition{
 			Type:    string(gatewayv1.RouteConditionAccepted),
@@ -156,7 +157,7 @@ func CheckGatewayMatchingHostnames(input Input, parentRef gatewayv1.ParentRefere
 }
 
 func CheckGatewayMatchingPorts(input Input, parentRef gatewayv1.ParentReference) (bool, error) {
-	gw, err := input.GetGateway(parentRef)
+	owner, err := input.GetListenerOwner(parentRef)
 	if err != nil {
 		input.SetParentCondition(parentRef, metav1.Condition{
 			Type:    "Accepted",
@@ -169,7 +170,7 @@ func CheckGatewayMatchingPorts(input Input, parentRef gatewayv1.ParentReference)
 	}
 
 	if parentRef.Port != nil {
-		for _, listener := range gw.Spec.Listeners {
+		for _, listener := range owner.GetListeners() {
 			if listener.Port == *parentRef.Port {
 				return true, nil
 			}
@@ -188,7 +189,7 @@ func CheckGatewayMatchingPorts(input Input, parentRef gatewayv1.ParentReference)
 }
 
 func CheckGatewayMatchingSection(input Input, parentRef gatewayv1.ParentReference) (bool, error) {
-	gw, err := input.GetGateway(parentRef)
+	owner, err := input.GetListenerOwner(parentRef)
 	if err != nil {
 		input.SetParentCondition(parentRef, metav1.Condition{
 			Type:    "Accepted",
@@ -202,7 +203,7 @@ func CheckGatewayMatchingSection(input Input, parentRef gatewayv1.ParentReferenc
 
 	if parentRef.SectionName != nil {
 		found := false
-		for _, listener := range gw.Spec.Listeners {
+		for _, listener := range owner.GetListeners() {
 			if listener.Name == *parentRef.SectionName {
 				found = true
 				break
@@ -234,7 +235,7 @@ func GetAllListenerHostNames(listeners []gatewayv1.Listener) []gatewayv1.Hostnam
 }
 
 func CheckGatewayMatchingProtocol(input Input, parentRef gatewayv1.ParentReference) (bool, error) {
-	gw, err := input.GetGateway(parentRef)
+	owner, err := input.GetListenerOwner(parentRef)
 	if err != nil {
 		input.SetParentCondition(parentRef, metav1.Condition{
 			Type:    "Accepted",
@@ -249,7 +250,7 @@ func CheckGatewayMatchingProtocol(input Input, parentRef gatewayv1.ParentReferen
 	supportedProtocols := input.GetValidProtocols()
 
 	found := false
-	for _, listener := range gw.Spec.Listeners {
+	for _, listener := range owner.GetListeners() {
 		if slices.Contains(supportedProtocols, listener.Protocol) {
 			found = true
 		}

--- a/operator/pkg/gateway-api/routechecks/grpcroute.go
+++ b/operator/pkg/gateway-api/routechecks/grpcroute.go
@@ -32,7 +32,7 @@ type GRPCRouteInput struct {
 	GRPCRoute      *gatewayv1.GRPCRoute
 	ControllerName string
 
-	gateways      map[gatewayv1.ParentReference]*gatewayv1.Gateway
+	gateways      map[gatewayv1.ParentReference]ListenerOwner
 	gammaServices map[gatewayv1.ParentReference]*corev1.Service
 }
 
@@ -89,30 +89,22 @@ func (g *GRPCRouteInput) GetGrants() []gatewayv1.ReferenceGrant {
 	return g.Grants.Items
 }
 
-func (g *GRPCRouteInput) GetGateway(parent gatewayv1.ParentReference) (*gatewayv1.Gateway, error) {
+func (g *GRPCRouteInput) GetListenerOwner(parent gatewayv1.ParentReference) (ListenerOwner, error) {
 	if g.gateways == nil {
-		g.gateways = make(map[gatewayv1.ParentReference]*gatewayv1.Gateway)
+		g.gateways = make(map[gatewayv1.ParentReference]ListenerOwner)
 	}
 
-	if gw, exists := g.gateways[parent]; exists {
-		return gw, nil
+	if owner, exists := g.gateways[parent]; exists {
+		return owner, nil
 	}
 
-	ns := helpers.NamespaceDerefOr(parent.Namespace, g.GetNamespace())
-	gw := &gatewayv1.Gateway{}
-
-	if err := g.Client.Get(g.Ctx, client.ObjectKey{Namespace: ns, Name: string(parent.Name)}, gw); err != nil {
-		if !k8serrors.IsNotFound(err) {
-			// if it is not just a not found error, we should return the error as something is bad
-			return nil, fmt.Errorf("error while getting gateway: %w", err)
-		}
-
-		// Gateway does not exist skip further checks
-		return nil, fmt.Errorf("gateway %q does not exist: %w", parent.Name, err)
+	owner, err := ResolveListenerOwner(g.Ctx, g.Client, parent, g.GetNamespace())
+	if err != nil {
+		return nil, err
 	}
 
-	g.gateways[parent] = gw
-	return gw, nil
+	g.gateways[parent] = owner
+	return owner, nil
 }
 
 func (g *GRPCRouteInput) GetParentGammaService(parent gatewayv1.ParentReference) (*corev1.Service, error) {

--- a/operator/pkg/gateway-api/routechecks/hostnames.go
+++ b/operator/pkg/gateway-api/routechecks/hostnames.go
@@ -9,9 +9,9 @@ import (
 	"github.com/cilium/cilium/operator/pkg/model"
 )
 
-func computeHosts[T ~string](gw *gatewayv1.Gateway, hostnames []T, excludeHostNames []T) []string {
+func computeHosts[T ~string](listeners []gatewayv1.Listener, hostnames []T, excludeHostNames []T) []string {
 	hosts := make([]string, 0, len(hostnames))
-	for _, listener := range gw.Spec.Listeners {
+	for _, listener := range listeners {
 		hosts = append(hosts, computeHostsForListener(&listener, hostnames, excludeHostNames)...)
 	}
 

--- a/operator/pkg/gateway-api/routechecks/httproute.go
+++ b/operator/pkg/gateway-api/routechecks/httproute.go
@@ -29,7 +29,7 @@ type HTTPRouteInput struct {
 	HTTPRoute      *gatewayv1.HTTPRoute
 	ControllerName string
 
-	gateways      map[gatewayv1.ParentReference]*gatewayv1.Gateway
+	gateways      map[gatewayv1.ParentReference]ListenerOwner
 	gammaServices map[gatewayv1.ParentReference]*corev1.Service
 }
 
@@ -106,31 +106,23 @@ func (h *HTTPRouteInput) GetHostnames() []gatewayv1.Hostname {
 	return h.HTTPRoute.Spec.Hostnames
 }
 
-func (h *HTTPRouteInput) GetGateway(parent gatewayv1.ParentReference) (*gatewayv1.Gateway, error) {
+func (h *HTTPRouteInput) GetListenerOwner(parent gatewayv1.ParentReference) (ListenerOwner, error) {
 	if h.gateways == nil {
-		h.gateways = make(map[gatewayv1.ParentReference]*gatewayv1.Gateway)
+		h.gateways = make(map[gatewayv1.ParentReference]ListenerOwner)
 	}
 
-	if gw, exists := h.gateways[parent]; exists {
-		return gw, nil
+	if owner, exists := h.gateways[parent]; exists {
+		return owner, nil
 	}
 
-	ns := helpers.NamespaceDerefOr(parent.Namespace, h.GetNamespace())
-	gw := &gatewayv1.Gateway{}
-
-	if err := h.Client.Get(h.Ctx, client.ObjectKey{Namespace: ns, Name: string(parent.Name)}, gw); err != nil {
-		if !k8serrors.IsNotFound(err) {
-			// if it is not just a not found error, we should return the error as something is bad
-			return nil, fmt.Errorf("error while getting gateway: %w", err)
-		}
-
-		// Gateway does not exist skip further checks
-		return nil, fmt.Errorf("gateway %q does not exist: %w", parent.Name, err)
+	owner, err := ResolveListenerOwner(h.Ctx, h.Client, parent, h.GetNamespace())
+	if err != nil {
+		return nil, err
 	}
 
-	h.gateways[parent] = gw
+	h.gateways[parent] = owner
 
-	return gw, nil
+	return owner, nil
 }
 
 func (h *HTTPRouteInput) GetParentGammaService(parent gatewayv1.ParentReference) (*corev1.Service, error) {

--- a/operator/pkg/gateway-api/routechecks/input.go
+++ b/operator/pkg/gateway-api/routechecks/input.go
@@ -5,14 +5,81 @@ package routechecks
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 )
+
+type ListenerOwner interface {
+	GetListeners() []gatewayv1.Listener
+	GetNamespace() string
+}
+
+type GatewayListenerOwner struct {
+	*gatewayv1.Gateway
+}
+
+func (g *GatewayListenerOwner) GetListeners() []gatewayv1.Listener {
+	return g.Spec.Listeners
+}
+
+type ListenerSetListenerOwner struct {
+	Listeners []gatewayv1.Listener
+	Namespace string
+}
+
+func (l *ListenerSetListenerOwner) GetListeners() []gatewayv1.Listener {
+	return l.Listeners
+}
+
+func (l *ListenerSetListenerOwner) GetNamespace() string {
+	return l.Namespace
+}
+
+func ResolveListenerOwner(
+	ctx context.Context,
+	c client.Client,
+	parent gatewayv1.ParentReference,
+	defaultNamespace string,
+) (ListenerOwner, error) {
+	ns := helpers.NamespaceDerefOr(parent.Namespace, defaultNamespace)
+
+	if helpers.IsListenerSet(parent) {
+		ls := &gatewayv1.ListenerSet{}
+		if err := c.Get(ctx, client.ObjectKey{Namespace: ns, Name: string(parent.Name)}, ls); err != nil {
+			if !k8serrors.IsNotFound(err) {
+				return nil, fmt.Errorf("error while getting listenerset: %w", err)
+			}
+			return nil, fmt.Errorf("listenerset %q does not exist: %w", parent.Name, err)
+		}
+
+		listeners := make([]gatewayv1.Listener, 0, len(ls.Spec.Listeners))
+		for _, entry := range ls.Spec.Listeners {
+			listeners = append(listeners, helpers.ListenerEntryToListener(entry))
+		}
+		return &ListenerSetListenerOwner{
+			Listeners: listeners,
+			Namespace: ls.GetNamespace(),
+		}, nil
+	}
+
+	gw := &gatewayv1.Gateway{}
+	if err := c.Get(ctx, client.ObjectKey{Namespace: ns, Name: string(parent.Name)}, gw); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return nil, fmt.Errorf("error while getting gateway: %w", err)
+		}
+		return nil, fmt.Errorf("gateway %q does not exist: %w", parent.Name, err)
+	}
+	return &GatewayListenerOwner{Gateway: gw}, nil
+}
 
 type GenericRule interface {
 	GetBackendRefs() []gatewayv1.BackendRef
@@ -25,7 +92,7 @@ type Input interface {
 	GetContext() context.Context
 	GetGVK() schema.GroupVersionKind
 	GetGrants() []gatewayv1.ReferenceGrant
-	GetGateway(parent gatewayv1.ParentReference) (*gatewayv1.Gateway, error)
+	GetListenerOwner(parent gatewayv1.ParentReference) (ListenerOwner, error)
 	GetParentGammaService(parent gatewayv1.ParentReference) (*corev1.Service, error)
 	GetHostnames() []gatewayv1.Hostname
 	GetValidProtocols() []gatewayv1.ProtocolType

--- a/operator/pkg/gateway-api/routechecks/tcproute.go
+++ b/operator/pkg/gateway-api/routechecks/tcproute.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,7 +29,7 @@ type TCPRouteInput struct {
 	TCPRoute       *gatewayv1alpha2.TCPRoute
 	ControllerName string
 
-	gateways map[gatewayv1.ParentReference]*gatewayv1.Gateway
+	gateways map[gatewayv1.ParentReference]ListenerOwner
 }
 
 func (t *TCPRouteInput) SetParentCondition(ref gatewayv1.ParentReference, condition metav1.Condition) {
@@ -114,33 +113,27 @@ func (t *TCPRouteInput) GetHostnames() []gatewayv1.Hostname {
 	return nil
 }
 
-func (t *TCPRouteInput) GetGateway(parent gatewayv1.ParentReference) (*gatewayv1.Gateway, error) {
-	if t.gateways == nil {
-		t.gateways = make(map[gatewayv1.ParentReference]*gatewayv1.Gateway)
-	}
-
-	if gw, exists := t.gateways[parent]; exists {
-		return gw, nil
-	}
-
-	ns := helpers.NamespaceDerefOr(parent.Namespace, t.GetNamespace())
-	gw := &gatewayv1.Gateway{}
-
-	if err := t.Client.Get(t.Ctx, client.ObjectKey{Namespace: ns, Name: string(parent.Name)}, gw); err != nil {
-		if !k8serrors.IsNotFound(err) {
-			return nil, fmt.Errorf("error while getting gateway: %w", err)
-		}
-
-		return nil, fmt.Errorf("gateway %q does not exist: %w", parent.Name, err)
-	}
-
-	t.gateways[parent] = gw
-
-	return gw, nil
-}
-
 func (t *TCPRouteInput) GetParentGammaService(parent gatewayv1.ParentReference) (*corev1.Service, error) {
 	return nil, fmt.Errorf("GAMMA support is not implemented in this reconciler")
+}
+
+func (t *TCPRouteInput) GetListenerOwner(parent gatewayv1.ParentReference) (ListenerOwner, error) {
+	if t.gateways == nil {
+		t.gateways = make(map[gatewayv1.ParentReference]ListenerOwner)
+	}
+
+	if owner, exists := t.gateways[parent]; exists {
+		return owner, nil
+	}
+
+	owner, err := ResolveListenerOwner(t.Ctx, t.Client, parent, t.GetNamespace())
+	if err != nil {
+		return nil, err
+	}
+
+	t.gateways[parent] = owner
+
+	return owner, nil
 }
 
 func (t *TCPRouteInput) Log() *slog.Logger {

--- a/operator/pkg/gateway-api/routechecks/tlsroute.go
+++ b/operator/pkg/gateway-api/routechecks/tlsroute.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,7 +28,7 @@ type TLSRouteInput struct {
 	TLSRoute       *gatewayv1.TLSRoute
 	ControllerName string
 
-	gateways map[gatewayv1.ParentReference]*gatewayv1.Gateway
+	gateways map[gatewayv1.ParentReference]ListenerOwner
 }
 
 func (t *TLSRouteInput) SetParentCondition(ref gatewayv1.ParentReference, condition metav1.Condition) {
@@ -114,31 +113,23 @@ func (t *TLSRouteInput) GetHostnames() []gatewayv1.Hostname {
 	return t.TLSRoute.Spec.Hostnames
 }
 
-func (t *TLSRouteInput) GetGateway(parent gatewayv1.ParentReference) (*gatewayv1.Gateway, error) {
+func (t *TLSRouteInput) GetListenerOwner(parent gatewayv1.ParentReference) (ListenerOwner, error) {
 	if t.gateways == nil {
-		t.gateways = make(map[gatewayv1.ParentReference]*gatewayv1.Gateway)
+		t.gateways = make(map[gatewayv1.ParentReference]ListenerOwner)
 	}
 
-	if gw, exists := t.gateways[parent]; exists {
-		return gw, nil
+	if owner, exists := t.gateways[parent]; exists {
+		return owner, nil
 	}
 
-	ns := helpers.NamespaceDerefOr(parent.Namespace, t.GetNamespace())
-	gw := &gatewayv1.Gateway{}
-
-	if err := t.Client.Get(t.Ctx, client.ObjectKey{Namespace: ns, Name: string(parent.Name)}, gw); err != nil {
-		if !k8serrors.IsNotFound(err) {
-			// if it is not just a not found error, we should return the error as something is bad
-			return nil, fmt.Errorf("error while getting gateway: %w", err)
-		}
-
-		// Gateway does not exist skip further checks
-		return nil, fmt.Errorf("gateway %q does not exist: %w", parent.Name, err)
+	owner, err := ResolveListenerOwner(t.Ctx, t.Client, parent, t.GetNamespace())
+	if err != nil {
+		return nil, err
 	}
 
-	t.gateways[parent] = gw
+	t.gateways[parent] = owner
 
-	return gw, nil
+	return owner, nil
 }
 
 func (t *TLSRouteInput) GetParentGammaService(parent gatewayv1.ParentReference) (*corev1.Service, error) {

--- a/operator/pkg/gateway-api/routechecks/udproute.go
+++ b/operator/pkg/gateway-api/routechecks/udproute.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,7 +29,7 @@ type UDPRouteInput struct {
 	UDPRoute       *gatewayv1alpha2.UDPRoute
 	ControllerName string
 
-	gateways map[gatewayv1.ParentReference]*gatewayv1.Gateway
+	gateways map[gatewayv1.ParentReference]ListenerOwner
 }
 
 func (u *UDPRouteInput) SetParentCondition(ref gatewayv1.ParentReference, condition metav1.Condition) {
@@ -114,33 +113,27 @@ func (u *UDPRouteInput) GetHostnames() []gatewayv1.Hostname {
 	return nil
 }
 
-func (u *UDPRouteInput) GetGateway(parent gatewayv1.ParentReference) (*gatewayv1.Gateway, error) {
-	if u.gateways == nil {
-		u.gateways = make(map[gatewayv1.ParentReference]*gatewayv1.Gateway)
-	}
-
-	if gw, exists := u.gateways[parent]; exists {
-		return gw, nil
-	}
-
-	ns := helpers.NamespaceDerefOr(parent.Namespace, u.GetNamespace())
-	gw := &gatewayv1.Gateway{}
-
-	if err := u.Client.Get(u.Ctx, client.ObjectKey{Namespace: ns, Name: string(parent.Name)}, gw); err != nil {
-		if !k8serrors.IsNotFound(err) {
-			return nil, fmt.Errorf("error while getting gateway: %w", err)
-		}
-
-		return nil, fmt.Errorf("gateway %q does not exist: %w", parent.Name, err)
-	}
-
-	u.gateways[parent] = gw
-
-	return gw, nil
-}
-
 func (u *UDPRouteInput) GetParentGammaService(parent gatewayv1.ParentReference) (*corev1.Service, error) {
 	return nil, fmt.Errorf("GAMMA support is not implemented in this reconciler")
+}
+
+func (u *UDPRouteInput) GetListenerOwner(parent gatewayv1.ParentReference) (ListenerOwner, error) {
+	if u.gateways == nil {
+		u.gateways = make(map[gatewayv1.ParentReference]ListenerOwner)
+	}
+
+	if owner, exists := u.gateways[parent]; exists {
+		return owner, nil
+	}
+
+	owner, err := ResolveListenerOwner(u.Ctx, u.Client, parent, u.GetNamespace())
+	if err != nil {
+		return nil, err
+	}
+
+	u.gateways[parent] = owner
+
+	return owner, nil
 }
 
 func (u *UDPRouteInput) Log() *slog.Logger {

--- a/operator/pkg/gateway-api/secretsync.go
+++ b/operator/pkg/gateway-api/secretsync.go
@@ -72,14 +72,7 @@ func (h *SecretSyncHandler) EnqueueTLSSecrets() handler.EventHandler {
 }
 
 func (h *SecretSyncHandler) IsReferencedByGateway(ctx context.Context, _ client.Client, _ *slog.Logger, obj *corev1.Secret) bool {
-	gateways := helpers.GetGatewaysForSecret(ctx, h.client, obj, h.logger)
-	for _, gw := range gateways {
-		if helpers.GatewayHasMatchingControllerFn(ctx, h.client, h.controllerName, h.logger)(gw) {
-			return true
-		}
-	}
-
-	return false
+	return len(helpers.GetGatewaysForSecret(ctx, h.client, obj, h.controllerName, h.logger)) > 0
 }
 
 // Enqueue BackendTLSPolicyConfigmaps produces a handler.EventHandler that, when it is passed a

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-route-kind/output/gateway-only-invalid-route-kind.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-route-kind/output/gateway-only-invalid-route-kind.yaml
@@ -19,13 +19,13 @@ spec:
 status:
   conditions:
     - lastTransitionTime: "2025-07-01T05:23:50Z"
-      message: Gateway successfully scheduled
-      reason: Accepted
-      status: "True"
+      message: No Accepted Listeners
+      reason: ListenersNotValid
+      status: "False"
       type: Accepted
     - lastTransitionTime: "2025-07-01T05:06:15Z"
-      message: Gateway waiting for address
-      reason: AddressNotAssigned
+      message: No Accepted Listeners
+      reason: ListenersNotValid
       status: "False"
       type: Programmed
   listeners:
@@ -37,9 +37,9 @@ status:
           status: "False"
           type: ResolvedRefs
         - lastTransitionTime: "2025-07-01T05:23:50Z"
-          message: Listener Accepted
-          reason: Accepted
-          status: "True"
+          message: "Listener not valid. None of the Allowed Route Kinds are supported."
+          reason: Invalid
+          status: "False"
           type: Accepted
         - lastTransitionTime: "2025-07-01T05:06:15Z"
           message: Address not ready yet

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-namespace-none/input/listenerset-allowed-namespace-none.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-namespace-none/input/listenerset-allowed-namespace-none.yaml
@@ -1,0 +1,31 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: allowed-namespace-none
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  allowedListeners:
+    namespaces:
+      from: None
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: rejected-none
+  namespace: gateway-conformance-infra
+spec:
+  parentRef:
+    name: allowed-namespace-none
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: extra-http
+      port: 8080
+      protocol: HTTP

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-namespace-none/output/allowed-namespace-none.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-namespace-none/output/allowed-namespace-none.yaml
@@ -1,0 +1,55 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: allowed-namespace-none
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  gatewayClassName: cilium
+  allowedListeners:
+    namespaces:
+      from: None
+  listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: http
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-namespace-none/output/cec-allowed-namespace-none.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-namespace-none/output/cec-allowed-namespace-none.yaml
@@ -1,0 +1,77 @@
+metadata:
+  creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: allowed-namespace-none
+  name: cilium-gateway-allowed-namespace-none
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: allowed-namespace-none
+    uid: ""
+  resourceVersion: "1"
+spec:
+  resources:
+  - '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    filterChains:
+    - filterChainMatch:
+        transportProtocol: raw_buffer
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            maxStreamDuration: 0s
+          httpFilters:
+          - name: envoy.filters.http.grpc_web
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+          - name: envoy.filters.http.grpc_stats
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+              emitFilterState: true
+              enableUpstreamStats: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig: {}
+          rds:
+            routeConfigName: listener-insecure
+          statPrefix: listener-insecure
+          streamIdleTimeout: 300s
+          upgradeConfigs:
+          - upgradeType: websocket
+          useRemoteAddress: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: listener
+    socketOptions:
+    - description: Enable TCP keep-alive (default to enabled)
+      intValue: "1"
+      level: "1"
+      name: "9"
+    - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+      intValue: "10"
+      level: "6"
+      name: "4"
+    - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+      intValue: "5"
+      level: "6"
+      name: "5"
+    - description: TCP keep-alive probe max failures.
+      intValue: "10"
+      level: "6"
+      name: "6"
+  - '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    name: listener-insecure
+  services:
+  - listener: ""
+    name: cilium-gateway-allowed-namespace-none
+    namespace: gateway-conformance-infra
+    ports:
+    - 80

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-namespace-none/output/listenerset-rejected-none.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-namespace-none/output/listenerset-rejected-none.yaml
@@ -1,0 +1,27 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  creationTimestamp: null
+  name: rejected-none
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  parentRef:
+    name: allowed-namespace-none
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: extra-http
+      port: 8080
+      protocol: HTTP
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: ListenerSet is not allowed by the Gateway's allowedListeners policy
+      reason: NotAllowed
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: ListenerSet is not allowed by the Gateway's allowedListeners policy
+      reason: NotAllowed
+      status: "False"
+      type: Programmed

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-namespace-same/input/listenerset-allowed-namespace-same.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-namespace-same/input/listenerset-allowed-namespace-same.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: other-ns
+  labels:
+    kubernetes.io/metadata.name: other-ns
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: allowed-namespace-same
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  allowedListeners:
+    namespaces:
+      from: Same
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: same-namespace
+  namespace: gateway-conformance-infra
+spec:
+  parentRef:
+    name: allowed-namespace-same
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: extra-http
+      port: 8080
+      protocol: HTTP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: cross-namespace
+  namespace: other-ns
+spec:
+  parentRef:
+    name: allowed-namespace-same
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: extra-http
+      port: 9090
+      protocol: HTTP

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-namespace-same/output/allowed-namespace-same.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-namespace-same/output/allowed-namespace-same.yaml
@@ -1,0 +1,56 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: allowed-namespace-same
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  gatewayClassName: cilium
+  allowedListeners:
+    namespaces:
+      from: Same
+  listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+status:
+  attachedListenerSets: 1
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: http
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-namespace-same/output/listenerset-cross-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-namespace-same/output/listenerset-cross-namespace.yaml
@@ -1,0 +1,27 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  creationTimestamp: null
+  name: cross-namespace
+  namespace: other-ns
+  resourceVersion: "999"
+spec:
+  parentRef:
+    name: allowed-namespace-same
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: extra-http
+      port: 9090
+      protocol: HTTP
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: ListenerSet is not allowed by the Gateway's allowedListeners policy
+      reason: NotAllowed
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: ListenerSet is not allowed by the Gateway's allowedListeners policy
+      reason: NotAllowed
+      status: "False"
+      type: Programmed

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-namespace-same/output/listenerset-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-namespace-same/output/listenerset-same-namespace.yaml
@@ -1,0 +1,51 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  creationTimestamp: null
+  name: same-namespace
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  parentRef:
+    name: allowed-namespace-same
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: extra-http
+      port: 8080
+      protocol: HTTP
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: ListenerSet is accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: ListenerSet is programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      name: extra-http
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-namespace-selector/input/listenerset-allowed-namespace-selector.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-namespace-selector/input/listenerset-allowed-namespace-selector.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: team-a-ns
+  labels:
+    kubernetes.io/metadata.name: team-a-ns
+    team: frontend
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: team-b-ns
+  labels:
+    kubernetes.io/metadata.name: team-b-ns
+    team: backend
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: allowed-namespace-selector
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  allowedListeners:
+    namespaces:
+      from: Selector
+      selector:
+        matchLabels:
+          team: frontend
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: matching-namespace
+  namespace: team-a-ns
+spec:
+  parentRef:
+    name: allowed-namespace-selector
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: extra-http
+      port: 8080
+      protocol: HTTP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: non-matching-namespace
+  namespace: team-b-ns
+spec:
+  parentRef:
+    name: allowed-namespace-selector
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: extra-http
+      port: 9090
+      protocol: HTTP

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-namespace-selector/output/allowed-namespace-selector.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-namespace-selector/output/allowed-namespace-selector.yaml
@@ -1,0 +1,59 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: allowed-namespace-selector
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  gatewayClassName: cilium
+  allowedListeners:
+    namespaces:
+      from: Selector
+      selector:
+        matchLabels:
+          team: frontend
+  listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+status:
+  attachedListenerSets: 1
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: http
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-namespace-selector/output/listenerset-matching-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-namespace-selector/output/listenerset-matching-namespace.yaml
@@ -1,0 +1,51 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  creationTimestamp: null
+  name: matching-namespace
+  namespace: team-a-ns
+  resourceVersion: "999"
+spec:
+  parentRef:
+    name: allowed-namespace-selector
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: extra-http
+      port: 8080
+      protocol: HTTP
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: ListenerSet is accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: ListenerSet is programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      name: extra-http
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-namespace-selector/output/listenerset-non-matching-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-namespace-selector/output/listenerset-non-matching-namespace.yaml
@@ -1,0 +1,27 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  creationTimestamp: null
+  name: non-matching-namespace
+  namespace: team-b-ns
+  resourceVersion: "999"
+spec:
+  parentRef:
+    name: allowed-namespace-selector
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: extra-http
+      port: 9090
+      protocol: HTTP
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: ListenerSet is not allowed by the Gateway's allowedListeners policy
+      reason: NotAllowed
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: ListenerSet is not allowed by the Gateway's allowedListeners policy
+      reason: NotAllowed
+      status: "False"
+      type: Programmed

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-routes-kinds/input/listenerset-allowed-routes-kinds.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-routes-kinds/input/listenerset-allowed-routes-kinds.yaml
@@ -1,0 +1,51 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: allowed-route-kinds
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  allowedListeners:
+    namespaces:
+      from: Same
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: valid-kinds
+  namespace: gateway-conformance-infra
+spec:
+  parentRef:
+    name: allowed-route-kinds
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: http-valid
+      port: 8080
+      protocol: HTTP
+      allowedRoutes:
+        kinds:
+          - kind: HTTPRoute
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: invalid-kinds
+  namespace: gateway-conformance-infra
+spec:
+  parentRef:
+    name: allowed-route-kinds
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: http-invalid
+      port: 9090
+      protocol: HTTP
+      allowedRoutes:
+        kinds:
+          - kind: FooRoute

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-routes-kinds/output/allowed-route-kinds.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-routes-kinds/output/allowed-route-kinds.yaml
@@ -1,0 +1,56 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: allowed-route-kinds
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  gatewayClassName: cilium
+  allowedListeners:
+    namespaces:
+      from: Same
+  listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+status:
+  attachedListenerSets: 1
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: http
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-routes-kinds/output/listenerset-invalid-kinds.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-routes-kinds/output/listenerset-invalid-kinds.yaml
@@ -1,0 +1,49 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  creationTimestamp: null
+  name: invalid-kinds
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  parentRef:
+    name: allowed-route-kinds
+    namespace: gateway-conformance-infra
+  listeners:
+    - allowedRoutes:
+        kinds:
+          - kind: FooRoute
+      name: http-invalid
+      port: 9090
+      protocol: HTTP
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: No valid listeners
+      reason: ListenersNotValid
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: No valid listeners
+      reason: ListenersNotValid
+      status: "False"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Unsupported Route Kinds in allowedRoutes.kinds
+          reason: InvalidRouteKinds
+          status: "False"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: "Listener not valid. None of the Allowed Route Kinds are supported."
+          reason: Invalid
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener not valid
+          reason: Invalid
+          status: "False"
+          type: Programmed
+      name: http-invalid

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-routes-kinds/output/listenerset-valid-kinds.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-allowed-routes-kinds/output/listenerset-valid-kinds.yaml
@@ -1,0 +1,52 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  creationTimestamp: null
+  name: valid-kinds
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  parentRef:
+    name: allowed-route-kinds
+    namespace: gateway-conformance-infra
+  listeners:
+    - allowedRoutes:
+        kinds:
+          - kind: HTTPRoute
+      name: http-valid
+      port: 8080
+      protocol: HTTP
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: ListenerSet is accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: ListenerSet is programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      name: http-valid
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-cross-listenerset-hostname-conflict/input/listenerset-cross-listenerset-hostname-conflict.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-cross-listenerset-hostname-conflict/input/listenerset-cross-listenerset-hostname-conflict.yaml
@@ -1,0 +1,54 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: cross-listenerset-hostname-conflict
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  allowedListeners:
+    namespaces:
+      from: Same
+  listeners:
+    - name: http
+      hostname: gateway.example.com
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+# Alphabetically first ListenerSet — wins the hostname slot
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: hostname-alpha
+  namespace: gateway-conformance-infra
+spec:
+  parentRef:
+    name: cross-listenerset-hostname-conflict
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: shared-hostname
+      hostname: shared.example.com
+      port: 80
+      protocol: HTTP
+---
+# Alphabetically second ListenerSet — loses, conflicting listener marked Conflicted
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: hostname-beta
+  namespace: gateway-conformance-infra
+spec:
+  parentRef:
+    name: cross-listenerset-hostname-conflict
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: dup-hostname
+      hostname: shared.example.com
+      port: 80
+      protocol: HTTP
+    - name: unique-hostname
+      hostname: unique.example.com
+      port: 80
+      protocol: HTTP

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-cross-listenerset-hostname-conflict/output/cross-listenerset-hostname-conflict.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-cross-listenerset-hostname-conflict/output/cross-listenerset-hostname-conflict.yaml
@@ -1,0 +1,57 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: cross-listenerset-hostname-conflict
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  gatewayClassName: cilium
+  allowedListeners:
+    namespaces:
+      from: Same
+  listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      hostname: gateway.example.com
+      name: http
+      port: 80
+      protocol: HTTP
+status:
+  attachedListenerSets: 2
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: http
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-cross-listenerset-hostname-conflict/output/listenerset-hostname-alpha.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-cross-listenerset-hostname-conflict/output/listenerset-hostname-alpha.yaml
@@ -1,0 +1,52 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  creationTimestamp: null
+  name: hostname-alpha
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  parentRef:
+    name: cross-listenerset-hostname-conflict
+    namespace: gateway-conformance-infra
+  listeners:
+    - hostname: shared.example.com
+      name: shared-hostname
+      port: 80
+      protocol: HTTP
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: ListenerSet is accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: ListenerSet is programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      name: shared-hostname
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-cross-listenerset-hostname-conflict/output/listenerset-hostname-beta.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-cross-listenerset-hostname-conflict/output/listenerset-hostname-beta.yaml
@@ -1,0 +1,79 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  creationTimestamp: null
+  name: hostname-beta
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  parentRef:
+    name: cross-listenerset-hostname-conflict
+    namespace: gateway-conformance-infra
+  listeners:
+    - hostname: shared.example.com
+      name: dup-hostname
+      port: 80
+      protocol: HTTP
+    - hostname: unique.example.com
+      name: unique-hostname
+      port: 80
+      protocol: HTTP
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: ListenerSet is accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: ListenerSet is programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener has a conflict
+          reason: HostnameConflict
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener has a conflict
+          reason: HostnameConflict
+          status: "False"
+          type: Programmed
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener has a conflict
+          reason: HostnameConflict
+          status: "True"
+          type: Conflicted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      name: dup-hostname
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      name: unique-hostname
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-cross-listenerset-protocol-conflict/input/listenerset-cross-listenerset-protocol-conflict.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-cross-listenerset-protocol-conflict/input/listenerset-cross-listenerset-protocol-conflict.yaml
@@ -1,0 +1,50 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: cross-listenerset-protocol-conflict
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  allowedListeners:
+    namespaces:
+      from: Same
+  listeners:
+    - name: http
+      port: 8888
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+# Alphabetically first ListenerSet — wins port 80
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: protocol-alpha
+  namespace: gateway-conformance-infra
+spec:
+  parentRef:
+    name: cross-listenerset-protocol-conflict
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: http-on-80
+      port: 80
+      protocol: HTTP
+---
+# Alphabetically second ListenerSet, port 80 TCP conflicts with protocol-alpha's HTTP
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: protocol-beta
+  namespace: gateway-conformance-infra
+spec:
+  parentRef:
+    name: cross-listenerset-protocol-conflict
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: tcp-on-80
+      port: 80
+      protocol: TCP
+    - name: http-on-8080
+      port: 8080
+      protocol: HTTP

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-cross-listenerset-protocol-conflict/output/cross-listenerset-protocol-conflict.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-cross-listenerset-protocol-conflict/output/cross-listenerset-protocol-conflict.yaml
@@ -1,0 +1,56 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: cross-listenerset-protocol-conflict
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  gatewayClassName: cilium
+  allowedListeners:
+    namespaces:
+      from: Same
+  listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 8888
+      protocol: HTTP
+status:
+  attachedListenerSets: 2
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: http
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-cross-listenerset-protocol-conflict/output/listenerset-protocol-alpha.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-cross-listenerset-protocol-conflict/output/listenerset-protocol-alpha.yaml
@@ -1,0 +1,51 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  creationTimestamp: null
+  name: protocol-alpha
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  parentRef:
+    name: cross-listenerset-protocol-conflict
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: http-on-80
+      port: 80
+      protocol: HTTP
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: ListenerSet is accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: ListenerSet is programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      name: http-on-80
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-cross-listenerset-protocol-conflict/output/listenerset-protocol-beta.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-cross-listenerset-protocol-conflict/output/listenerset-protocol-beta.yaml
@@ -1,0 +1,77 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  creationTimestamp: null
+  name: protocol-beta
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  parentRef:
+    name: cross-listenerset-protocol-conflict
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: tcp-on-80
+      port: 80
+      protocol: TCP
+    - name: http-on-8080
+      port: 8080
+      protocol: HTTP
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: ListenerSet is accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: ListenerSet is programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener has a conflict
+          reason: ProtocolConflict
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener has a conflict
+          reason: ProtocolConflict
+          status: "False"
+          type: Programmed
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener has a conflict
+          reason: ProtocolConflict
+          status: "True"
+          type: Conflicted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      name: tcp-on-80
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      name: http-on-8080
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-default-not-allowed/input/listenerset-default-not-allowed.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-default-not-allowed/input/listenerset-default-not-allowed.yaml
@@ -1,0 +1,28 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: default-not-allowed
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: rejected
+  namespace: gateway-conformance-infra
+spec:
+  parentRef:
+    name: default-not-allowed
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: extra-http
+      port: 8080
+      protocol: HTTP

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-default-not-allowed/output/cec-default-not-allowed.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-default-not-allowed/output/cec-default-not-allowed.yaml
@@ -1,0 +1,77 @@
+metadata:
+  creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: default-not-allowed
+  name: cilium-gateway-default-not-allowed
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: default-not-allowed
+    uid: ""
+  resourceVersion: "1"
+spec:
+  resources:
+  - '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    filterChains:
+    - filterChainMatch:
+        transportProtocol: raw_buffer
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            maxStreamDuration: 0s
+          httpFilters:
+          - name: envoy.filters.http.grpc_web
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+          - name: envoy.filters.http.grpc_stats
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+              emitFilterState: true
+              enableUpstreamStats: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig: {}
+          rds:
+            routeConfigName: listener-insecure
+          statPrefix: listener-insecure
+          streamIdleTimeout: 300s
+          upgradeConfigs:
+          - upgradeType: websocket
+          useRemoteAddress: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: listener
+    socketOptions:
+    - description: Enable TCP keep-alive (default to enabled)
+      intValue: "1"
+      level: "1"
+      name: "9"
+    - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+      intValue: "10"
+      level: "6"
+      name: "4"
+    - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+      intValue: "5"
+      level: "6"
+      name: "5"
+    - description: TCP keep-alive probe max failures.
+      intValue: "10"
+      level: "6"
+      name: "6"
+  - '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    name: listener-insecure
+  services:
+  - listener: ""
+    name: cilium-gateway-default-not-allowed
+    namespace: gateway-conformance-infra
+    ports:
+    - 80

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-default-not-allowed/output/default-not-allowed.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-default-not-allowed/output/default-not-allowed.yaml
@@ -1,0 +1,52 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: default-not-allowed
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: http
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-default-not-allowed/output/listenerset-rejected.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-default-not-allowed/output/listenerset-rejected.yaml
@@ -1,0 +1,27 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  creationTimestamp: null
+  name: rejected
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  parentRef:
+    name: default-not-allowed
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: extra-http
+      port: 8080
+      protocol: HTTP
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: ListenerSet is not allowed by the Gateway's allowedListeners policy
+      reason: NotAllowed
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: ListenerSet is not allowed by the Gateway's allowedListeners policy
+      reason: NotAllowed
+      status: "False"
+      type: Programmed

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-hostname-conflict/input/listenerset-hostname-conflict.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-hostname-conflict/input/listenerset-hostname-conflict.yaml
@@ -1,0 +1,52 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: hostname-conflict
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  allowedListeners:
+    namespaces:
+      from: Same
+  listeners:
+    - name: http
+      hostname: example.com
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: hostname-conflict-only
+  namespace: gateway-conformance-infra
+spec:
+  parentRef:
+    name: hostname-conflict
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: dup-hostname
+      hostname: example.com
+      port: 80
+      protocol: HTTP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: hostname-conflict-mixed
+  namespace: gateway-conformance-infra
+spec:
+  parentRef:
+    name: hostname-conflict
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: dup-hostname
+      hostname: example.com
+      port: 80
+      protocol: HTTP
+    - name: unique-hostname
+      hostname: other.com
+      port: 80
+      protocol: HTTP

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-hostname-conflict/output/hostname-conflict.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-hostname-conflict/output/hostname-conflict.yaml
@@ -1,0 +1,57 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: hostname-conflict
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  gatewayClassName: cilium
+  allowedListeners:
+    namespaces:
+      from: Same
+  listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      hostname: example.com
+      name: http
+      port: 80
+      protocol: HTTP
+status:
+  attachedListenerSets: 1
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: http
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-hostname-conflict/output/listenerset-hostname-conflict-mixed.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-hostname-conflict/output/listenerset-hostname-conflict-mixed.yaml
@@ -1,0 +1,79 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  creationTimestamp: null
+  name: hostname-conflict-mixed
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  parentRef:
+    name: hostname-conflict
+    namespace: gateway-conformance-infra
+  listeners:
+    - hostname: example.com
+      name: dup-hostname
+      port: 80
+      protocol: HTTP
+    - hostname: other.com
+      name: unique-hostname
+      port: 80
+      protocol: HTTP
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: ListenerSet is accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: ListenerSet is programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener has a conflict
+          reason: HostnameConflict
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener has a conflict
+          reason: HostnameConflict
+          status: "False"
+          type: Programmed
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener has a conflict
+          reason: HostnameConflict
+          status: "True"
+          type: Conflicted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      name: dup-hostname
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      name: unique-hostname
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-hostname-conflict/output/listenerset-hostname-conflict-only.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-hostname-conflict/output/listenerset-hostname-conflict-only.yaml
@@ -1,0 +1,52 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  creationTimestamp: null
+  name: hostname-conflict-only
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  parentRef:
+    name: hostname-conflict
+    namespace: gateway-conformance-infra
+  listeners:
+    - hostname: example.com
+      name: dup-hostname
+      port: 80
+      protocol: HTTP
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: No valid listeners
+      reason: ListenersNotValid
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: No valid listeners
+      reason: ListenersNotValid
+      status: "False"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener has a conflict
+          reason: HostnameConflict
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener has a conflict
+          reason: HostnameConflict
+          status: "False"
+          type: Programmed
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener has a conflict
+          reason: HostnameConflict
+          status: "True"
+          type: Conflicted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      name: dup-hostname

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-l4-namespace-isolation/input/listenerset-l4-namespace-isolation.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-l4-namespace-isolation/input/listenerset-l4-namespace-isolation.yaml
@@ -1,0 +1,115 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: l4-listenerset-ns
+  labels:
+    kubernetes.io/metadata.name: l4-listenerset-ns
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: l4-namespace-isolation
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  allowedListeners:
+    namespaces:
+      from: All
+  listeners:
+    - name: tcp
+      port: 3000
+      protocol: TCP
+      allowedRoutes:
+        namespaces:
+          from: All
+        kinds:
+          - kind: TCPRoute
+    - name: udp
+      port: 3001
+      protocol: UDP
+      allowedRoutes:
+        namespaces:
+          from: All
+        kinds:
+          - kind: UDPRoute
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: l4-extra
+  namespace: l4-listenerset-ns
+spec:
+  parentRef:
+    name: l4-namespace-isolation
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: tcp-extra
+      port: 4000
+      protocol: TCP
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TCPRoute
+    - name: udp-extra
+      port: 4001
+      protocol: UDP
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: UDPRoute
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: gateway-tcp
+  namespace: l4-listenerset-ns
+spec:
+  parentRefs:
+    - name: l4-namespace-isolation
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: tcp-backend
+          port: 3000
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: UDPRoute
+metadata:
+  name: gateway-udp
+  namespace: l4-listenerset-ns
+spec:
+  parentRefs:
+    - name: l4-namespace-isolation
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: udp-backend
+          port: 3001
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tcp-backend
+  namespace: l4-listenerset-ns
+spec:
+  selector:
+    app: tcp-backend
+  ports:
+    - protocol: TCP
+      port: 3000
+      targetPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: udp-backend
+  namespace: l4-listenerset-ns
+spec:
+  selector:
+    app: udp-backend
+  ports:
+    - protocol: UDP
+      port: 3001
+      targetPort: 3001

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-l4-namespace-isolation/output/endpointslice-cilium-gateway-l4-namespace-isolation-13de6d01-ipv4.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-l4-namespace-isolation/output/endpointslice-cilium-gateway-l4-namespace-isolation-13de6d01-ipv4.yaml
@@ -1,0 +1,25 @@
+addressType: IPv4
+apiVersion: discovery.k8s.io/v1
+endpoints: []
+kind: EndpointSlice
+metadata:
+  annotations:
+    gateway.cilium.io/backend-port: "3001"
+    gateway.cilium.io/backend-service: l4-listenerset-ns/udp-backend
+  labels:
+    endpointslice.kubernetes.io/managed-by: cilium-operator
+    gateway.networking.k8s.io/gateway-name: l4-namespace-isolation
+    kubernetes.io/service-name: cilium-gateway-l4-namespace-isolation
+  name: cilium-gateway-l4-namespace-isolation-13de6d01-ipv4
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: l4-namespace-isolation
+    uid: ""
+  resourceVersion: "1"
+ports:
+- name: port-3001-udp
+  port: 3001
+  protocol: UDP

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-l4-namespace-isolation/output/endpointslice-cilium-gateway-l4-namespace-isolation-7e670fc1-ipv4.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-l4-namespace-isolation/output/endpointslice-cilium-gateway-l4-namespace-isolation-7e670fc1-ipv4.yaml
@@ -1,0 +1,25 @@
+addressType: IPv4
+apiVersion: discovery.k8s.io/v1
+endpoints: []
+kind: EndpointSlice
+metadata:
+  annotations:
+    gateway.cilium.io/backend-port: "3000"
+    gateway.cilium.io/backend-service: l4-listenerset-ns/tcp-backend
+  labels:
+    endpointslice.kubernetes.io/managed-by: cilium-operator
+    gateway.networking.k8s.io/gateway-name: l4-namespace-isolation
+    kubernetes.io/service-name: cilium-gateway-l4-namespace-isolation
+  name: cilium-gateway-l4-namespace-isolation-7e670fc1-ipv4
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: l4-namespace-isolation
+    uid: ""
+  resourceVersion: "1"
+ports:
+- name: port-3000
+  port: 3000
+  protocol: TCP

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-l4-namespace-isolation/output/l4-namespace-isolation.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-l4-namespace-isolation/output/l4-namespace-isolation.yaml
@@ -1,0 +1,84 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: l4-namespace-isolation
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  allowedListeners:
+    namespaces:
+      from: All
+  gatewayClassName: cilium
+  listeners:
+  - allowedRoutes:
+      kinds:
+      - kind: TCPRoute
+      namespaces:
+        from: All
+    name: tcp
+    port: 3000
+    protocol: TCP
+  - allowedRoutes:
+      kinds:
+      - kind: UDPRoute
+      namespaces:
+        from: All
+    name: udp
+    port: 3001
+    protocol: UDP
+status:
+  attachedListenerSets: 1
+  conditions:
+  - lastTransitionTime: "2026-06-12T01:24:17Z"
+    message: Gateway successfully scheduled
+    reason: Accepted
+    status: "True"
+    type: Accepted
+  - lastTransitionTime: "2026-06-12T01:24:17Z"
+    message: Gateway waiting for address
+    reason: AddressNotAssigned
+    status: "False"
+    type: Programmed
+  listeners:
+  - attachedRoutes: 1
+    conditions:
+    - lastTransitionTime: "2026-06-12T01:24:17Z"
+      message: Resolved Refs
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    - lastTransitionTime: "2026-06-12T01:24:17Z"
+      message: Listener Accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-06-12T01:24:17Z"
+      message: Address not ready yet
+      reason: Pending
+      status: "False"
+      type: Programmed
+    name: tcp
+    supportedKinds:
+    - group: gateway.networking.k8s.io
+      kind: TCPRoute
+  - attachedRoutes: 1
+    conditions:
+    - lastTransitionTime: "2026-06-12T01:24:17Z"
+      message: Resolved Refs
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    - lastTransitionTime: "2026-06-12T01:24:17Z"
+      message: Listener Accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-06-12T01:24:17Z"
+      message: Address not ready yet
+      reason: Pending
+      status: "False"
+      type: Programmed
+    name: udp
+    supportedKinds:
+    - group: gateway.networking.k8s.io
+      kind: UDPRoute

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-l4-namespace-isolation/output/listenerset-l4-extra.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-l4-namespace-isolation/output/listenerset-l4-extra.yaml
@@ -1,0 +1,82 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: l4-extra
+  namespace: l4-listenerset-ns
+  resourceVersion: "1000"
+spec:
+  listeners:
+  - allowedRoutes:
+      kinds:
+      - kind: TCPRoute
+      namespaces:
+        from: Same
+    name: tcp-extra
+    port: 4000
+    protocol: TCP
+  - allowedRoutes:
+      kinds:
+      - kind: UDPRoute
+      namespaces:
+        from: Same
+    name: udp-extra
+    port: 4001
+    protocol: UDP
+  parentRef:
+    name: l4-namespace-isolation
+    namespace: gateway-conformance-infra
+status:
+  conditions:
+  - lastTransitionTime: "2026-06-12T01:24:17Z"
+    message: ListenerSet is accepted
+    reason: Accepted
+    status: "True"
+    type: Accepted
+  - lastTransitionTime: "2026-06-12T01:24:17Z"
+    message: ListenerSet is programmed
+    reason: Programmed
+    status: "True"
+    type: Programmed
+  listeners:
+  - attachedRoutes: 0
+    conditions:
+    - lastTransitionTime: "2026-06-12T01:24:17Z"
+      message: Resolved Refs
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    - lastTransitionTime: "2026-06-12T01:24:17Z"
+      message: Listener Accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-06-12T01:24:17Z"
+      message: Listener Programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+    name: tcp-extra
+    supportedKinds:
+    - group: gateway.networking.k8s.io
+      kind: TCPRoute
+  - attachedRoutes: 0
+    conditions:
+    - lastTransitionTime: "2026-06-12T01:24:17Z"
+      message: Resolved Refs
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    - lastTransitionTime: "2026-06-12T01:24:17Z"
+      message: Listener Accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-06-12T01:24:17Z"
+      message: Listener Programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+    name: udp-extra
+    supportedKinds:
+    - group: gateway.networking.k8s.io
+      kind: UDPRoute

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-l4-namespace-isolation/output/tcproute-gateway-tcp.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-l4-namespace-isolation/output/tcproute-gateway-tcp.yaml
@@ -1,0 +1,31 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: gateway-tcp
+  namespace: l4-listenerset-ns
+  resourceVersion: "1000"
+spec:
+  parentRefs:
+  - name: l4-namespace-isolation
+    namespace: gateway-conformance-infra
+  rules:
+  - backendRefs:
+    - name: tcp-backend
+      port: 3000
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: "2026-06-12T01:24:17Z"
+      message: Accepted TCPRoute
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-06-12T01:24:17Z"
+      message: Service reference is valid
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: io.cilium/gateway-controller
+    parentRef:
+      name: l4-namespace-isolation
+      namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-l4-namespace-isolation/output/udproute-gateway-udp.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-l4-namespace-isolation/output/udproute-gateway-udp.yaml
@@ -1,0 +1,31 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: UDPRoute
+metadata:
+  name: gateway-udp
+  namespace: l4-listenerset-ns
+  resourceVersion: "1000"
+spec:
+  parentRefs:
+  - name: l4-namespace-isolation
+    namespace: gateway-conformance-infra
+  rules:
+  - backendRefs:
+    - name: udp-backend
+      port: 3001
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: "2026-06-12T01:24:17Z"
+      message: Accepted UDPRoute
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-06-12T01:24:17Z"
+      message: Service reference is valid
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: io.cilium/gateway-controller
+    parentRef:
+      name: l4-namespace-isolation
+      namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-protocol-conflict/input/listenerset-protocol-conflict.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-protocol-conflict/input/listenerset-protocol-conflict.yaml
@@ -1,0 +1,48 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: protocol-conflict
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  allowedListeners:
+    namespaces:
+      from: Same
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: protocol-conflict-only
+  namespace: gateway-conformance-infra
+spec:
+  parentRef:
+    name: protocol-conflict
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: tcp-on-port-80
+      port: 80
+      protocol: TCP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: protocol-conflict-mixed
+  namespace: gateway-conformance-infra
+spec:
+  parentRef:
+    name: protocol-conflict
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: tcp-on-port-80
+      port: 80
+      protocol: TCP
+    - name: http-on-port-8080
+      port: 8080
+      protocol: HTTP

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-protocol-conflict/output/listenerset-protocol-conflict-mixed.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-protocol-conflict/output/listenerset-protocol-conflict-mixed.yaml
@@ -1,0 +1,77 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  creationTimestamp: null
+  name: protocol-conflict-mixed
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  parentRef:
+    name: protocol-conflict
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: tcp-on-port-80
+      port: 80
+      protocol: TCP
+    - name: http-on-port-8080
+      port: 8080
+      protocol: HTTP
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: ListenerSet is accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: ListenerSet is programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener has a conflict
+          reason: ProtocolConflict
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener has a conflict
+          reason: ProtocolConflict
+          status: "False"
+          type: Programmed
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener has a conflict
+          reason: ProtocolConflict
+          status: "True"
+          type: Conflicted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      name: tcp-on-port-80
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      name: http-on-port-8080
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-protocol-conflict/output/listenerset-protocol-conflict-only.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-protocol-conflict/output/listenerset-protocol-conflict-only.yaml
@@ -1,0 +1,51 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  creationTimestamp: null
+  name: protocol-conflict-only
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  parentRef:
+    name: protocol-conflict
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: tcp-on-port-80
+      port: 80
+      protocol: TCP
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: No valid listeners
+      reason: ListenersNotValid
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: No valid listeners
+      reason: ListenersNotValid
+      status: "False"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener has a conflict
+          reason: ProtocolConflict
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener has a conflict
+          reason: ProtocolConflict
+          status: "False"
+          type: Programmed
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener has a conflict
+          reason: ProtocolConflict
+          status: "True"
+          type: Conflicted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      name: tcp-on-port-80

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-protocol-conflict/output/protocol-conflict.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-protocol-conflict/output/protocol-conflict.yaml
@@ -1,0 +1,56 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: protocol-conflict
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  gatewayClassName: cilium
+  allowedListeners:
+    namespaces:
+      from: Same
+  listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+status:
+  attachedListenerSets: 1
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: http
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-valid-with-invalid-gateway-listener/input/listenerset-valid-with-invalid-gateway-listener.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-valid-with-invalid-gateway-listener/input/listenerset-valid-with-invalid-gateway-listener.yaml
@@ -1,0 +1,33 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: valid-listenerset-only
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  allowedListeners:
+    namespaces:
+      from: Same
+  listeners:
+    - name: invalid-http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: InvalidRoute
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: valid-listenerset
+  namespace: gateway-conformance-infra
+spec:
+  parentRef:
+    name: valid-listenerset-only
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: extra-http
+      port: 8080
+      protocol: HTTP

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-valid-with-invalid-gateway-listener/output/listenerset-valid-listenerset.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-valid-with-invalid-gateway-listener/output/listenerset-valid-listenerset.yaml
@@ -1,0 +1,14 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  creationTimestamp: null
+  name: valid-listenerset
+  namespace: gateway-conformance-infra
+spec:
+  parentRef:
+    name: valid-listenerset-only
+    namespace: gateway-conformance-infra
+  listeners:
+    - name: extra-http
+      port: 8080
+      protocol: HTTP

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-valid-with-invalid-gateway-listener/output/valid-listenerset-only.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-valid-with-invalid-gateway-listener/output/valid-listenerset-only.yaml
@@ -1,0 +1,53 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: valid-listenerset-only
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  gatewayClassName: cilium
+  allowedListeners:
+    namespaces:
+      from: Same
+  listeners:
+    - allowedRoutes:
+        kinds:
+          - kind: InvalidRoute
+        namespaces:
+          from: Same
+      name: invalid-http
+      port: 80
+      protocol: HTTP
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: No Accepted Listeners
+      reason: ListenersNotValid
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: No Accepted Listeners
+      reason: ListenersNotValid
+      status: "False"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Unsupported Route Kinds in allowedRoutes.kinds
+          reason: InvalidRouteKinds
+          status: "False"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: "Listener not valid. None of the Allowed Route Kinds are supported."
+          reason: Invalid
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: invalid-http
+      supportedKinds: []

--- a/operator/pkg/gateway-api/watch-handlers/backendtlspolicy.go
+++ b/operator/pkg/gateway-api/watch-handlers/backendtlspolicy.go
@@ -162,6 +162,6 @@ func updateReconcileRequestsForBackendTLSPolicy(ctx context.Context,
 		httpRoutes = append(httpRoutes, hrList.Items...)
 	}
 	for _, hr := range httpRoutes {
-		updateReconcileRequestsForParentRefs(hr.Spec.ParentRefs, hr.Namespace, allGatewaysSet, rrSet)
+		updateReconcileRequestsForParentRefs(ctx, c, hr.Spec.ParentRefs, hr.Namespace, allGatewaysSet, rrSet)
 	}
 }

--- a/operator/pkg/gateway-api/watch-handlers/helpers.go
+++ b/operator/pkg/gateway-api/watch-handlers/helpers.go
@@ -20,18 +20,28 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
-// updateReconcileRequestsForParentRefs mutates the passed reconcile.Request set to add all
-func updateReconcileRequestsForParentRefs(parentRefs []gatewayv1.ParentReference, ns string, allGatewaysSet map[string]struct{}, rrSet map[reconcile.Request]struct{}) {
+// updateReconcileRequestsForParentRefs mutates the passed reconcile.Request set
+// to add all referenced Gateways, both via Gateway and via ListenerSet
+func updateReconcileRequestsForParentRefs(ctx context.Context, c client.Client, parentRefs []gatewayv1.ParentReference, ns string, allGatewaysSet map[string]struct{}, rrSet map[reconcile.Request]struct{}) {
 	for _, parent := range parentRefs {
-		if !helpers.IsGateway(parent) {
+		if helpers.IsGateway(parent) {
+			parentFullName := types.NamespacedName{
+				Name:      string(parent.Name),
+				Namespace: helpers.NamespaceDerefOr(parent.Namespace, ns),
+			}
+			if _, found := allGatewaysSet[parentFullName.String()]; found {
+				rrSet[reconcile.Request{NamespacedName: parentFullName}] = struct{}{}
+			}
 			continue
 		}
-		parentFullName := types.NamespacedName{
-			Name:      string(parent.Name),
-			Namespace: helpers.NamespaceDerefOr(parent.Namespace, ns),
-		}
-		if _, found := allGatewaysSet[parentFullName.String()]; found {
-			rrSet[reconcile.Request{NamespacedName: parentFullName}] = struct{}{}
+
+		if helpers.IsListenerSet(parent) {
+			gwNN := helpers.ResolveListenerSetToGateway(ctx, c, string(parent.Name), helpers.NamespaceDerefOr(parent.Namespace, ns))
+			if gwNN != nil {
+				if _, found := allGatewaysSet[gwNN.String()]; found {
+					rrSet[reconcile.Request{NamespacedName: *gwNN}] = struct{}{}
+				}
+			}
 		}
 	}
 }
@@ -68,17 +78,26 @@ func getGatewayReconcileRequestsForRoute(ctx context.Context, c client.Client, o
 	)
 
 	for _, parent := range route.ParentRefs {
-		if !helpers.IsGateway(parent) {
+		var gwNN types.NamespacedName
+
+		switch {
+		case helpers.IsGateway(parent):
+			gwNN = types.NamespacedName{
+				Namespace: helpers.NamespaceDerefOr(parent.Namespace, object.GetNamespace()),
+				Name:      string(parent.Name),
+			}
+		case helpers.IsListenerSet(parent):
+			resolved := helpers.ResolveListenerSetToGateway(ctx, c, string(parent.Name), helpers.NamespaceDerefOr(parent.Namespace, object.GetNamespace()))
+			if resolved == nil {
+				continue
+			}
+			gwNN = *resolved
+		default:
 			continue
 		}
 
-		ns := helpers.NamespaceDerefOr(parent.Namespace, object.GetNamespace())
-
 		gw := &gatewayv1.Gateway{}
-		if err := c.Get(ctx, types.NamespacedName{
-			Namespace: ns,
-			Name:      string(parent.Name),
-		}, gw); err != nil {
+		if err := c.Get(ctx, gwNN, gw); err != nil {
 			if !k8serrors.IsNotFound(err) {
 				scopedLog.ErrorContext(ctx, "Failed to get Gateway", logfields.Error, err)
 			}
@@ -92,15 +111,12 @@ func getGatewayReconcileRequestsForRoute(ctx context.Context, c client.Client, o
 
 		scopedLog.InfoContext(ctx,
 			"Enqueued gateway for Route",
-			logfields.K8sNamespace, ns,
-			logfields.ParentResource, parent.Name,
+			logfields.K8sNamespace, gwNN.Namespace,
+			logfields.ParentResource, gwNN.Name,
 			logfields.Route, object.GetName())
 
 		reqs = append(reqs, reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Namespace: ns,
-				Name:      string(parent.Name),
-			},
+			NamespacedName: gwNN,
 		})
 	}
 

--- a/operator/pkg/gateway-api/watch-handlers/listenerset.go
+++ b/operator/pkg/gateway-api/watch-handlers/listenerset.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchhandlers
+
+import (
+	"context"
+	"log/slog"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+func EnqueueRequestForListenerSetOwner(c client.Client, logger *slog.Logger, controllerName string) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
+		ls, ok := a.(*gatewayv1.ListenerSet)
+		if !ok {
+			return nil
+		}
+
+		scopedLog := logger.With(
+			logfields.Resource, types.NamespacedName{
+				Namespace: ls.GetNamespace(),
+				Name:      ls.GetName(),
+			},
+		)
+
+		gwNN := helpers.ListenerSetParentGateway(ls)
+
+		gw := &gatewayv1.Gateway{}
+		if err := c.Get(ctx, *gwNN, gw); err != nil {
+			if !k8serrors.IsNotFound(err) {
+				scopedLog.ErrorContext(ctx, "Failed to get Gateway for ListenerSet", logfields.Error, err)
+			}
+			return nil
+		}
+
+		if !hasMatchingController(ctx, c, controllerName, logger)(gw) {
+			scopedLog.DebugContext(ctx, "Gateway does not have matching controller, skipping")
+			return nil
+		}
+
+		scopedLog.InfoContext(ctx,
+			"Enqueued gateway for ListenerSet",
+			logfields.K8sNamespace, gwNN.Namespace,
+			logfields.Gateway, gwNN.Name,
+		)
+
+		return []reconcile.Request{
+			{
+				NamespacedName: *gwNN,
+			},
+		}
+	})
+}

--- a/operator/pkg/gateway-api/watch-handlers/namespaces.go
+++ b/operator/pkg/gateway-api/watch-handlers/namespaces.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -45,45 +46,74 @@ func getGatewaysForNamespace(ctx context.Context, c client.Client, ns client.Obj
 
 	var gateways []types.NamespacedName
 	for _, gw := range gwList.Items {
+		gwNN := client.ObjectKey{Namespace: gw.GetNamespace(), Name: gw.GetName()}
 		for _, l := range gw.Spec.Listeners {
-			if l.AllowedRoutes == nil || l.AllowedRoutes.Namespaces == nil {
+			ok := addGatewayIfNamespaceMatches(ctx, c, ns, l, gw.GetNamespace(), gwNN, scopedLog, &gateways)
+			if !ok {
+				return nil
+			}
+		}
+	}
+
+	if helpers.HasListenerSetSupport(c.Scheme()) {
+		lsList := &gatewayv1.ListenerSetList{}
+		if err := c.List(ctx, lsList); err != nil {
+			scopedLog.WarnContext(ctx, "Unable to list ListenerSets", logfields.Error, err)
+			return nil
+		}
+		for _, ls := range lsList.Items {
+			gwNN := helpers.ListenerSetParentGateway(&ls)
+			if gwNN == nil {
 				continue
 			}
-
-			switch *l.AllowedRoutes.Namespaces.From {
-			case gatewayv1.NamespacesFromAll:
-				gateways = append(gateways, client.ObjectKey{
-					Namespace: gw.GetNamespace(),
-					Name:      gw.GetName(),
-				})
-			case gatewayv1.NamespacesFromSame:
-				if ns.GetName() == gw.GetNamespace() {
-					gateways = append(gateways, client.ObjectKey{
-						Namespace: gw.GetNamespace(),
-						Name:      gw.GetName(),
-					})
-				}
-			case gatewayv1.NamespacesFromSelector:
-				if l.AllowedRoutes.Namespaces.Selector == nil {
-					scopedLog.WarnContext(ctx, "AllowedRoutes namespace set to Selector but no selector specified", logfields.Gateway, gw.GetName())
-					continue
-				}
-				nsList := &corev1.NamespaceList{}
-				err := c.List(ctx, nsList, client.MatchingLabels(l.AllowedRoutes.Namespaces.Selector.MatchLabels))
-				if err != nil {
-					scopedLog.WarnContext(ctx, "Unable to list Namespaces", logfields.Error, err)
+			for _, entry := range ls.Spec.Listeners {
+				l := helpers.ListenerEntryToListener(entry)
+				ok := addGatewayIfNamespaceMatches(ctx, c, ns, l, ls.GetNamespace(), *gwNN, scopedLog, &gateways)
+				if !ok {
 					return nil
-				}
-				for _, item := range nsList.Items {
-					if item.GetName() == ns.GetName() {
-						gateways = append(gateways, client.ObjectKey{
-							Namespace: gw.GetNamespace(),
-							Name:      gw.GetName(),
-						})
-					}
 				}
 			}
 		}
 	}
+
 	return gateways
+}
+
+func addGatewayIfNamespaceMatches(
+	ctx context.Context,
+	c client.Client,
+	ns client.Object,
+	l gatewayv1.Listener,
+	ownerNamespace string,
+	gwNN types.NamespacedName,
+	scopedLog *slog.Logger,
+	gateways *[]types.NamespacedName,
+) bool {
+	if l.AllowedRoutes == nil || l.AllowedRoutes.Namespaces == nil {
+		return true
+	}
+	switch *l.AllowedRoutes.Namespaces.From {
+	case gatewayv1.NamespacesFromAll:
+		*gateways = append(*gateways, gwNN)
+	case gatewayv1.NamespacesFromSame:
+		if ns.GetName() == ownerNamespace {
+			*gateways = append(*gateways, gwNN)
+		}
+	case gatewayv1.NamespacesFromSelector:
+		if l.AllowedRoutes.Namespaces.Selector == nil {
+			scopedLog.WarnContext(ctx, "AllowedRoutes namespace set to Selector but no selector specified", logfields.Gateway, gwNN.Name)
+			return true
+		}
+		nsList := &corev1.NamespaceList{}
+		if err := c.List(ctx, nsList, client.MatchingLabels(l.AllowedRoutes.Namespaces.Selector.MatchLabels)); err != nil {
+			scopedLog.WarnContext(ctx, "Unable to list Namespaces", logfields.Error, err)
+			return false
+		}
+		for _, item := range nsList.Items {
+			if item.GetName() == ns.GetName() {
+				*gateways = append(*gateways, gwNN)
+			}
+		}
+	}
+	return true
 }

--- a/operator/pkg/gateway-api/watch-handlers/secrets.go
+++ b/operator/pkg/gateway-api/watch-handlers/secrets.go
@@ -16,9 +16,9 @@ import (
 )
 
 // EnqueueRequestForTLSSecret returns an event handler for any changes with TLS secrets
-func EnqueueRequestForTLSSecret(c client.Client, logger *slog.Logger) handler.EventHandler {
+func EnqueueRequestForTLSSecret(c client.Client, controllerName string, logger *slog.Logger) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
-		gateways := helpers.GetGatewaysForSecret(ctx, c, a, logger)
+		gateways := helpers.GetGatewaysForSecret(ctx, c, a, controllerName, logger)
 		reqs := make([]reconcile.Request, 0, len(gateways))
 		for _, gw := range gateways {
 			reqs = append(reqs, reconcile.Request{

--- a/operator/pkg/gateway-api/watch-handlers/service.go
+++ b/operator/pkg/gateway-api/watch-handlers/service.go
@@ -18,7 +18,6 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 
-	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
@@ -88,17 +87,17 @@ func EnqueueRequestForBackendService(c client.Client, logger slog.Logger) handle
 
 		// iterate through the HTTPRoutes, update reconcileRequests for each Gateway that is relevant.
 		for _, hr := range hrList.Items {
-			updateReconcileRequestsForParentRefs(hr.Spec.ParentRefs, hr.Namespace, allCiliumGatewaysSet, reconcileRequests)
+			updateReconcileRequestsForParentRefs(ctx, c, hr.Spec.ParentRefs, hr.Namespace, allCiliumGatewaysSet, reconcileRequests)
 		}
 
 		// iterate through the TLSRoutes, update reconcileRequests for each Gateway that is relevant.
 		for _, tlsr := range tlsrList.Items {
-			updateReconcileRequestsForParentRefs(tlsr.Spec.ParentRefs, tlsr.Namespace, allCiliumGatewaysSet, reconcileRequests)
+			updateReconcileRequestsForParentRefs(ctx, c, tlsr.Spec.ParentRefs, tlsr.Namespace, allCiliumGatewaysSet, reconcileRequests)
 		}
 
 		// iterate through the TLSRoutes, update reconcileRequests for each Gateway that is relevant.
 		for _, grpcr := range grpcRouteList.Items {
-			updateReconcileRequestsForParentRefs(grpcr.Spec.ParentRefs, grpcr.Namespace, allCiliumGatewaysSet, reconcileRequests)
+			updateReconcileRequestsForParentRefs(ctx, c, grpcr.Spec.ParentRefs, grpcr.Namespace, allCiliumGatewaysSet, reconcileRequests)
 		}
 
 		// return the keys of the set, since that's the actual reconcile.Requests.
@@ -150,20 +149,9 @@ func EnqueueRequestForBackendServiceImport(c client.Client, logger slog.Logger) 
 			allCiliumGatewaysSet[gwFullName.String()] = struct{}{}
 		}
 
-		// iterate through the HTTPRoutes, return a reconcile.Request for each Gateways that is relevant.
+		// iterate through the HTTPRoutes, return a reconcile.Request for each Gateway that is relevant.
 		for _, hr := range hrList.Items {
-			for _, parent := range hr.Spec.ParentRefs {
-				if !helpers.IsGateway(parent) {
-					continue
-				}
-				parentFullName := types.NamespacedName{
-					Name:      string(parent.Name),
-					Namespace: helpers.NamespaceDerefOr(parent.Namespace, hr.Namespace),
-				}
-				if _, found := allCiliumGatewaysSet[parentFullName.String()]; found {
-					reconcileRequests[reconcile.Request{NamespacedName: parentFullName}] = struct{}{}
-				}
-			}
+			updateReconcileRequestsForParentRefs(ctx, c, hr.Spec.ParentRefs, hr.Namespace, allCiliumGatewaysSet, reconcileRequests)
 		}
 
 		// return the keys of the set.

--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -109,6 +109,26 @@ func (l *ListenerWithContext) FilterTLSRoutes(routes []gatewayv1.TLSRoute) []gat
 	return filtered
 }
 
+func (l *ListenerWithContext) FilterTCPRoutes(routes []gatewayv1alpha2.TCPRoute) []gatewayv1alpha2.TCPRoute {
+	var filtered []gatewayv1alpha2.TCPRoute
+	for _, r := range routes {
+		if l.routeAllowedByParent(r.Spec.ParentRefs, r.GetNamespace()) {
+			filtered = append(filtered, r)
+		}
+	}
+	return filtered
+}
+
+func (l *ListenerWithContext) FilterUDPRoutes(routes []gatewayv1alpha2.UDPRoute) []gatewayv1alpha2.UDPRoute {
+	var filtered []gatewayv1alpha2.UDPRoute
+	for _, r := range routes {
+		if l.routeAllowedByParent(r.Spec.ParentRefs, r.GetNamespace()) {
+			filtered = append(filtered, r)
+		}
+	}
+	return filtered
+}
+
 // Input is the input for GatewayAPI.
 type Input struct {
 	GatewayClass       gatewayv1.GatewayClass
@@ -236,23 +256,25 @@ func GatewayAPI(log *slog.Logger, input Input) *model.Model {
 			}
 
 		case gatewayv1.TCPProtocolType:
+			namespacesPreFiltered := l.AllowedNamespaces != nil
 			resL4 = append(resL4, model.L4Listener{
 				Name:           string(l.Name),
 				Sources:        []model.FullyQualifiedResource{l.Source},
 				Port:           uint32(l.Port),
 				Protocol:       model.L4ProtocolTCP,
-				Routes:         toTCPRoutes(l.Listener, l.Source.Namespace, namespaceLabels, input.TCPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants),
+				Routes:         toTCPRoutes(l.Listener, l.Source.Namespace, namespaceLabels, namespacesPreFiltered, l.FilterTCPRoutes(input.TCPRoutes), input.Services, input.ServiceImports, input.ReferenceGrants),
 				Infrastructure: infra,
 				Service:        toServiceModel(input.GatewayClassConfig),
 			})
 
 		case gatewayv1.UDPProtocolType:
+			namespacesPreFiltered := l.AllowedNamespaces != nil
 			resL4 = append(resL4, model.L4Listener{
 				Name:           string(l.Name),
 				Sources:        []model.FullyQualifiedResource{l.Source},
 				Port:           uint32(l.Port),
 				Protocol:       model.L4ProtocolUDP,
-				Routes:         toUDPRoutes(l.Listener, l.Source.Namespace, namespaceLabels, input.UDPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants),
+				Routes:         toUDPRoutes(l.Listener, l.Source.Namespace, namespaceLabels, namespacesPreFiltered, l.FilterUDPRoutes(input.UDPRoutes), input.Services, input.ServiceImports, input.ReferenceGrants),
 				Infrastructure: infra,
 				Service:        toServiceModel(input.GatewayClassConfig),
 			})
@@ -963,7 +985,15 @@ func sortL4RoutesByAge[T any](routes []T, meta func(T) metav1.ObjectMeta) {
 	})
 }
 
-func toTCPRoutes(listener gatewayv1beta1.Listener, gatewayNamespace string, namespaceLabels helpers.NamespaceLabelIndex, input []gatewayv1alpha2.TCPRoute, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1.ReferenceGrant) []model.L4Route {
+func toTCPRoutes(listener gatewayv1beta1.Listener,
+	gatewayNamespace string,
+	namespaceLabels helpers.NamespaceLabelIndex,
+	namespacesPreFiltered bool,
+	input []gatewayv1alpha2.TCPRoute,
+	services []corev1.Service,
+	serviceImports []mcsapiv1beta1.ServiceImport,
+	grants []gatewayv1.ReferenceGrant,
+) []model.L4Route {
 	// Collect every TCPRoute that attaches to this listener, then keep only the
 	// oldest. Per Gateway API conflict resolution
 	// (https://gateway-api.sigs.k8s.io/guides/api-design/#conflicts), an L4
@@ -972,7 +1002,7 @@ func toTCPRoutes(listener gatewayv1beta1.Listener, gatewayNamespace string, name
 	// Accepted=True (handled by the status reconciler) but route no traffic.
 	attached := make([]gatewayv1alpha2.TCPRoute, 0, len(input))
 	for _, r := range input {
-		if !helpers.IsListenerNamespaceAllowed(listener, r.GetNamespace(), gatewayNamespace, namespaceLabels) {
+		if !namespacesPreFiltered && !helpers.IsListenerNamespaceAllowed(listener, r.GetNamespace(), gatewayNamespace, namespaceLabels) {
 			continue
 		}
 		if l4RouteAttachesToListener(r.Spec.ParentRefs, listener) {
@@ -1019,11 +1049,19 @@ func toTCPRoutes(listener gatewayv1beta1.Listener, gatewayNamespace string, name
 	return l4Routes
 }
 
-func toUDPRoutes(listener gatewayv1beta1.Listener, gatewayNamespace string, namespaceLabels helpers.NamespaceLabelIndex, input []gatewayv1alpha2.UDPRoute, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1.ReferenceGrant) []model.L4Route {
+func toUDPRoutes(listener gatewayv1beta1.Listener,
+	gatewayNamespace string,
+	namespaceLabels helpers.NamespaceLabelIndex,
+	namespacesPreFiltered bool,
+	input []gatewayv1alpha2.UDPRoute,
+	services []corev1.Service,
+	serviceImports []mcsapiv1beta1.ServiceImport,
+	grants []gatewayv1.ReferenceGrant,
+) []model.L4Route {
 	// Keep only the oldest attaching UDPRoute. See toTCPRoutes for the rationale.
 	attached := make([]gatewayv1alpha2.UDPRoute, 0, len(input))
 	for _, r := range input {
-		if !helpers.IsListenerNamespaceAllowed(listener, r.GetNamespace(), gatewayNamespace, namespaceLabels) {
+		if !namespacesPreFiltered && !helpers.IsListenerNamespaceAllowed(listener, r.GetNamespace(), gatewayNamespace, namespaceLabels) {
 			continue
 		}
 		if l4RouteAttachesToListener(r.Spec.ParentRefs, listener) {

--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -13,6 +13,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -31,6 +32,83 @@ const (
 	allHosts = "*"
 )
 
+type ListenerWithContext struct {
+	gatewayv1.Listener
+	// Source is where this listener appears: Gateway or ListenerSet
+	Source model.FullyQualifiedResource
+
+	// AllowedNamespaces is the set of namespaces allowed for Route attachment
+	AllowedNamespaces map[string]struct{}
+}
+
+func parentRefMatchesSource(parent gatewayv1.ParentReference, source model.FullyQualifiedResource, routeNamespace string) bool {
+	parentKind := "Gateway"
+	if parent.Kind != nil {
+		parentKind = string(*parent.Kind)
+	}
+	if parentKind != source.Kind {
+		return false
+	}
+	if string(parent.Name) != source.Name {
+		return false
+	}
+	parentNS := routeNamespace
+	if parent.Namespace != nil {
+		parentNS = string(*parent.Namespace)
+	}
+	return parentNS == source.Namespace
+}
+
+func (l *ListenerWithContext) routeAllowedByParent(parentRefs []gatewayv1.ParentReference, routeNamespace string) bool {
+	if l.AllowedNamespaces != nil {
+		if _, ok := l.AllowedNamespaces[routeNamespace]; !ok {
+			return false
+		}
+	}
+
+	for _, parent := range parentRefs {
+		if parentRefMatchesSource(parent, l.Source, routeNamespace) {
+			if parent.SectionName != nil && string(*parent.SectionName) != string(l.Listener.Name) {
+				// We didn't find a listener yet that matches the section name
+				continue
+			}
+			return true
+		}
+	}
+
+	return false
+}
+
+func (l *ListenerWithContext) FilterHTTPRoutes(routes []gatewayv1.HTTPRoute) []gatewayv1.HTTPRoute {
+	var filtered []gatewayv1.HTTPRoute
+	for _, r := range routes {
+		if l.routeAllowedByParent(r.Spec.ParentRefs, r.GetNamespace()) {
+			filtered = append(filtered, r)
+		}
+	}
+	return filtered
+}
+
+func (l *ListenerWithContext) FilterGRPCRoutes(routes []gatewayv1.GRPCRoute) []gatewayv1.GRPCRoute {
+	var filtered []gatewayv1.GRPCRoute
+	for _, r := range routes {
+		if l.routeAllowedByParent(r.Spec.ParentRefs, r.GetNamespace()) {
+			filtered = append(filtered, r)
+		}
+	}
+	return filtered
+}
+
+func (l *ListenerWithContext) FilterTLSRoutes(routes []gatewayv1.TLSRoute) []gatewayv1.TLSRoute {
+	var filtered []gatewayv1.TLSRoute
+	for _, r := range routes {
+		if l.routeAllowedByParent(r.Spec.ParentRefs, r.GetNamespace()) {
+			filtered = append(filtered, r)
+		}
+	}
+	return filtered
+}
+
 // Input is the input for GatewayAPI.
 type Input struct {
 	GatewayClass       gatewayv1.GatewayClass
@@ -47,6 +125,7 @@ type Input struct {
 	Services            []corev1.Service
 	ServiceImports      []mcsapiv1beta1.ServiceImport
 	BackendTLSPolicyMap helpers.BackendTLSPolicyServiceMap
+	MergedListeners     []ListenerWithContext
 }
 
 // GatewayAPI translates Gateway API resources into a model.
@@ -81,11 +160,30 @@ func GatewayAPI(log *slog.Logger, input Input) *model.Model {
 	}
 
 	namespaceLabels := helpers.NewNamespaceLabelIndex(input.Namespaces)
+	listeners := input.MergedListeners
+	// When MergedListeners is not provided, build it from the direct
+	// Gateway-listeners
+	if listeners == nil {
+		gwSource := model.FullyQualifiedResource{
+			Name:      input.Gateway.GetName(),
+			Namespace: input.Gateway.GetNamespace(),
+			Group:     gatewayv1.SchemeGroupVersion.Group,
+			Version:   gatewayv1.SchemeGroupVersion.Version,
+			Kind:      "Gateway",
+			UID:       string(input.Gateway.GetUID()),
+		}
+		for _, l := range input.Gateway.Spec.Listeners {
+			listeners = append(listeners, ListenerWithContext{
+				Listener: l,
+				Source:   gwSource,
+			})
+		}
+	}
 
 	// Find all the listener host names, so that we can match them with the routes
 	// Gateway API spec guarantees that the hostnames are unique across all listeners
 	listenerHostnamesByProtocol := make(map[gatewayv1.ProtocolType][]string)
-	for _, l := range input.Gateway.Spec.Listeners {
+	for _, l := range listeners {
 		if l.Hostname != nil {
 			_, ok := listenerHostnamesByProtocol[l.Protocol]
 			if !ok {
@@ -95,27 +193,31 @@ func GatewayAPI(log *slog.Logger, input Input) *model.Model {
 		}
 	}
 
-	for _, l := range input.Gateway.Spec.Listeners {
+	for _, l := range listeners {
 		switch l.Protocol {
 		case gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType, gatewayv1.TLSProtocolType:
+			filteredHTTPRoutes := l.FilterHTTPRoutes(input.HTTPRoutes)
+			filteredGRPCRoutes := l.FilterGRPCRoutes(input.GRPCRoutes)
+
 			var httpRoutes []model.HTTPRoute
-			httpRoutes = append(httpRoutes, toHTTPRoutes(log, l, input.Gateway.GetNamespace(), namespaceLabels, listenerHostnamesByProtocol, input.HTTPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants, input.BackendTLSPolicyMap)...)
-			httpRoutes = append(httpRoutes, toGRPCRoutes(l, input.Gateway.GetNamespace(), namespaceLabels, listenerHostnamesByProtocol, input.GRPCRoutes, input.Services, input.ServiceImports, input.ReferenceGrants)...)
+
+			// (ajs) Note well, we are using the existence of AllowedNamespace
+			// as a hint that this listener has already performed filtering for
+			// routes based on AllowedNamespaces. We need to refactor this type
+			// of assumption to not apply only to ListenerSets, and be a true
+			// invariant expected by this code path. That is, move all such
+			// validation out of the ingestion codepath and into a combined
+			// validate-and-record status phase of the reconcile pipeline.
+			namespacesPreFiltered := l.AllowedNamespaces != nil
+
+			httpRoutes = append(httpRoutes, toHTTPRoutes(log, l.Listener, l.Source.Namespace, namespaceLabels, namespacesPreFiltered, listenerHostnamesByProtocol, filteredHTTPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants, input.BackendTLSPolicyMap)...)
+			httpRoutes = append(httpRoutes, toGRPCRoutes(l.Listener, l.Source.Namespace, namespaceLabels, namespacesPreFiltered, listenerHostnamesByProtocol, filteredGRPCRoutes, input.Services, input.ServiceImports, input.ReferenceGrants)...)
 			resHTTP = append(resHTTP, model.HTTPListener{
-				Name: string(l.Name),
-				Sources: []model.FullyQualifiedResource{
-					{
-						Name:      input.Gateway.GetName(),
-						Namespace: input.Gateway.GetNamespace(),
-						Group:     gatewayv1.SchemeGroupVersion.Group,
-						Version:   gatewayv1.SchemeGroupVersion.Version,
-						Kind:      "Gateway",
-						UID:       string(input.Gateway.GetUID()),
-					},
-				},
+				Name:           string(l.Name),
+				Sources:        []model.FullyQualifiedResource{l.Source},
 				Port:           uint32(l.Port),
 				Hostname:       toHostname(l.Hostname),
-				TLS:            toTLS(l.TLS, input.ReferenceGrants, input.Gateway.GetNamespace()),
+				TLS:            toTLS(l.TLS, input.ReferenceGrants, l.Source.Namespace, schema.GroupVersionKind{Group: l.Source.Group, Version: l.Source.Version, Kind: l.Source.Kind}),
 				Routes:         httpRoutes,
 				Infrastructure: infra,
 				Service:        toServiceModel(input.GatewayClassConfig),
@@ -123,20 +225,11 @@ func GatewayAPI(log *slog.Logger, input Input) *model.Model {
 
 			if l.Protocol == gatewayv1.TLSProtocolType {
 				resTLSPassthrough = append(resTLSPassthrough, model.TLSPassthroughListener{
-					Name: string(l.Name),
-					Sources: []model.FullyQualifiedResource{
-						{
-							Name:      input.Gateway.GetName(),
-							Namespace: input.Gateway.GetNamespace(),
-							Group:     gatewayv1.SchemeGroupVersion.Group,
-							Version:   gatewayv1.SchemeGroupVersion.Version,
-							Kind:      "Gateway",
-							UID:       string(input.Gateway.GetUID()),
-						},
-					},
+					Name:           string(l.Name),
+					Sources:        []model.FullyQualifiedResource{l.Source},
 					Port:           uint32(l.Port),
 					Hostname:       toHostname(l.Hostname),
-					Routes:         toTLSRoutes(l, input.Gateway.GetNamespace(), namespaceLabels, listenerHostnamesByProtocol, input.TLSRoutes, input.Services, input.ServiceImports, input.ReferenceGrants),
+					Routes:         toTLSRoutes(l.Listener, l.Source.Namespace, namespaceLabels, namespacesPreFiltered, listenerHostnamesByProtocol, l.FilterTLSRoutes(input.TLSRoutes), input.Services, input.ServiceImports, input.ReferenceGrants),
 					Infrastructure: infra,
 					Service:        toServiceModel(input.GatewayClassConfig),
 				})
@@ -144,40 +237,22 @@ func GatewayAPI(log *slog.Logger, input Input) *model.Model {
 
 		case gatewayv1.TCPProtocolType:
 			resL4 = append(resL4, model.L4Listener{
-				Name: string(l.Name),
-				Sources: []model.FullyQualifiedResource{
-					{
-						Name:      input.Gateway.GetName(),
-						Namespace: input.Gateway.GetNamespace(),
-						Group:     gatewayv1.SchemeGroupVersion.Group,
-						Version:   gatewayv1.SchemeGroupVersion.Version,
-						Kind:      "Gateway",
-						UID:       string(input.Gateway.GetUID()),
-					},
-				},
+				Name:           string(l.Name),
+				Sources:        []model.FullyQualifiedResource{l.Source},
 				Port:           uint32(l.Port),
 				Protocol:       model.L4ProtocolTCP,
-				Routes:         toTCPRoutes(l, input.Gateway.GetNamespace(), namespaceLabels, input.TCPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants),
+				Routes:         toTCPRoutes(l.Listener, l.Source.Namespace, namespaceLabels, input.TCPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants),
 				Infrastructure: infra,
 				Service:        toServiceModel(input.GatewayClassConfig),
 			})
 
 		case gatewayv1.UDPProtocolType:
 			resL4 = append(resL4, model.L4Listener{
-				Name: string(l.Name),
-				Sources: []model.FullyQualifiedResource{
-					{
-						Name:      input.Gateway.GetName(),
-						Namespace: input.Gateway.GetNamespace(),
-						Group:     gatewayv1.SchemeGroupVersion.Group,
-						Version:   gatewayv1.SchemeGroupVersion.Version,
-						Kind:      "Gateway",
-						UID:       string(input.Gateway.GetUID()),
-					},
-				},
+				Name:           string(l.Name),
+				Sources:        []model.FullyQualifiedResource{l.Source},
 				Port:           uint32(l.Port),
 				Protocol:       model.L4ProtocolUDP,
-				Routes:         toUDPRoutes(l, input.Gateway.GetNamespace(), namespaceLabels, input.UDPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants),
+				Routes:         toUDPRoutes(l.Listener, l.Source.Namespace, namespaceLabels, input.UDPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants),
 				Infrastructure: infra,
 				Service:        toServiceModel(input.GatewayClassConfig),
 			})
@@ -234,6 +309,7 @@ func toHTTPRoutes(log *slog.Logger,
 	listener gatewayv1.Listener,
 	gatewayNamespace string,
 	namespaceLabels helpers.NamespaceLabelIndex,
+	namespacesPreFiltered bool,
 	listenerHostnamesByProtocol map[gatewayv1.ProtocolType][]string,
 	input []gatewayv1.HTTPRoute,
 	services []corev1.Service,
@@ -287,7 +363,7 @@ func toHTTPRoutes(log *slog.Logger,
 			continue
 		}
 
-		if !helpers.IsListenerNamespaceAllowed(listener, r.GetNamespace(), gatewayNamespace, namespaceLabels) {
+		if !namespacesPreFiltered && !helpers.IsListenerNamespaceAllowed(listener, r.GetNamespace(), gatewayNamespace, namespaceLabels) {
 			continue
 		}
 
@@ -637,6 +713,7 @@ func toHTTPRetry(retry *gatewayv1.HTTPRouteRetry) *model.HTTPRetry {
 func toGRPCRoutes(listener gatewayv1beta1.Listener,
 	gatewayNamespace string,
 	namespaceLabels helpers.NamespaceLabelIndex,
+	namespacesPreFiltered bool,
 	listenerHostnamesByProtocol map[gatewayv1.ProtocolType][]string,
 	input []gatewayv1.GRPCRoute,
 	services []corev1.Service,
@@ -656,7 +733,7 @@ func toGRPCRoutes(listener gatewayv1beta1.Listener,
 			continue
 		}
 
-		if !helpers.IsListenerNamespaceAllowed(listener, r.GetNamespace(), gatewayNamespace, namespaceLabels) {
+		if !namespacesPreFiltered && !helpers.IsListenerNamespaceAllowed(listener, r.GetNamespace(), gatewayNamespace, namespaceLabels) {
 			continue
 		}
 
@@ -778,7 +855,7 @@ func extractGRPCRoutes(hostnames []string, grpcr gatewayv1.GRPCRoute, services [
 	return grpcRoutes
 }
 
-func toTLSRoutes(listener gatewayv1beta1.Listener, gatewayNamespace string, namespaceLabels helpers.NamespaceLabelIndex, listenerHostnamesByProtocol map[gatewayv1.ProtocolType][]string, input []gatewayv1.TLSRoute, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1.ReferenceGrant) []model.TLSPassthroughRoute {
+func toTLSRoutes(listener gatewayv1beta1.Listener, gatewayNamespace string, namespaceLabels helpers.NamespaceLabelIndex, namespacesPreFiltered bool, listenerHostnamesByProtocol map[gatewayv1.ProtocolType][]string, input []gatewayv1.TLSRoute, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1.ReferenceGrant) []model.TLSPassthroughRoute {
 	var tlsRoutes []model.TLSPassthroughRoute
 	for _, r := range input {
 		isListener := false
@@ -792,7 +869,7 @@ func toTLSRoutes(listener gatewayv1beta1.Listener, gatewayNamespace string, name
 			continue
 		}
 
-		if !helpers.IsListenerNamespaceAllowed(listener, r.GetNamespace(), gatewayNamespace, namespaceLabels) {
+		if !namespacesPreFiltered && !helpers.IsListenerNamespaceAllowed(listener, r.GetNamespace(), gatewayNamespace, namespaceLabels) {
 			continue
 		}
 
@@ -1349,14 +1426,14 @@ func toQueryMatch(match gatewayv1.HTTPRouteMatch) []model.KeyValueMatch {
 	return res
 }
 
-func toTLS(tls *gatewayv1.ListenerTLSConfig, grants []gatewayv1.ReferenceGrant, defaultNamespace string) []model.TLSSecret {
+func toTLS(tls *gatewayv1.ListenerTLSConfig, grants []gatewayv1.ReferenceGrant, defaultNamespace string, sourceGVK schema.GroupVersionKind) []model.TLSSecret {
 	if tls == nil {
 		return nil
 	}
 
 	res := make([]model.TLSSecret, 0, len(tls.CertificateRefs))
 	for _, cert := range tls.CertificateRefs {
-		if !helpers.IsSecretReferenceAllowed(defaultNamespace, cert, gatewayv1.SchemeGroupVersion.WithKind("Gateway"), grants) {
+		if !helpers.IsSecretReferenceAllowed(defaultNamespace, cert, sourceGVK, grants) {
 			// not allowed to be referred to, skipping
 			continue
 		}

--- a/operator/pkg/model/translation/gateway-api/translator.go
+++ b/operator/pkg/model/translation/gateway-api/translator.go
@@ -61,8 +61,15 @@ func (t *gatewayAPITranslator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyC
 
 	for _, l := range listeners {
 		sources := l.GetSources()
-		source = &sources[0]
-		owner = source
+		// Source must come from a direct Gateway listener or a GAMMA Service.
+		// The existence of one such listener is validated in the calling
+		// context. ListenerSet listeners may appear first, so this loop scans
+		// for the first direct Gateway listener source.
+		if source == nil && sources[0].Kind != "ListenerSet" {
+			source = &sources[0]
+			owner = source
+		}
+
 		// If there's more than one source in the listener, then this model is a GAMMA one,
 		// and includes a HTTPRoute source as the second one.
 		if len(sources) > 1 {

--- a/operator/pkg/secretsync/secretsync_reconcile_test.go
+++ b/operator/pkg/secretsync/secretsync_reconcile_test.go
@@ -25,6 +25,8 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	gateway_api "github.com/cilium/cilium/operator/pkg/gateway-api"
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
 	"github.com/cilium/cilium/operator/pkg/ingress"
 	"github.com/cilium/cilium/operator/pkg/secretsync"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -33,6 +35,12 @@ import (
 var secretsNamespace = "cilium-secrets-test"
 
 const testSecretSyncControllerName = "example.com/test-gateway-controller"
+
+func withGatewaySecretIndexes(b *fake.ClientBuilder) *fake.ClientBuilder {
+	return b.
+		WithIndex(&gatewayv1.Gateway{}, helpers.GatewaySecretIndex, indexers.IndexGatewayBySecret).
+		WithIndex(&gatewayv1.ListenerSet{}, helpers.ListenerSetSecretIndex, indexers.IndexListenerSetBySecret)
+}
 
 var secretFixture = []client.Object{
 	&corev1.Secret{
@@ -200,9 +208,9 @@ var secretFixture = []client.Object{
 func Test_SecretSync_Reconcile(t *testing.T) {
 	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
 
-	c := fake.NewClientBuilder().
+	c := withGatewaySecretIndexes(fake.NewClientBuilder().
 		WithScheme(testScheme()).
-		WithObjects(secretFixture...).
+		WithObjects(secretFixture...)).
 		Build()
 
 	gatewayHandler := gateway_api.NewSecretSyncHandler(c, logger, testSecretSyncControllerName)
@@ -415,9 +423,9 @@ var secretFixtureTypeChange = []client.Object{
 func Test_SecretSync_Reconcile_TypeChange(t *testing.T) {
 	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
 
-	c := fake.NewClientBuilder().
+	c := withGatewaySecretIndexes(fake.NewClientBuilder().
 		WithScheme(testScheme()).
-		WithObjects(secretFixtureTypeChange...).
+		WithObjects(secretFixtureTypeChange...)).
 		Build()
 
 	gatewayHandler := gateway_api.NewSecretSyncHandler(c, logger, testSecretSyncControllerName)
@@ -471,9 +479,9 @@ var secretFixtureDefaultSecret = []client.Object{
 func Test_SecretSync_Reconcile_WithDefaultSecret(t *testing.T) {
 	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
 
-	c := fake.NewClientBuilder().
+	c := withGatewaySecretIndexes(fake.NewClientBuilder().
 		WithScheme(testScheme()).
-		WithObjects(secretFixtureDefaultSecret...).
+		WithObjects(secretFixtureDefaultSecret...)).
 		Build()
 	gatewayHandler := gateway_api.NewSecretSyncHandler(c, logger, testSecretSyncControllerName)
 	r := secretsync.NewSecretSyncReconciler(c, logger, []*secretsync.SecretSyncRegistration{


### PR DESCRIPTION
Implements ListenerSets for Cilium.

This branch currently passes all of the upstream conformance tests. This includes [two](https://github.com/kubernetes-sigs/gateway-api/pull/4841) recent [sets](https://github.com/kubernetes-sigs/gateway-api/pull/4899) of conformance tests which I contributed upstream while working on this PR.

Please review one commit at a time, which should make the PR much easier to digest. I've spent a decent amount of time ensuring that each commit by itself can be reviewed in around one sitting.

This PR was prepared with AIL:2. I made an attempt to use frontier models to implement this feature in a way that would satisfy all of the current conformance cases and additional edge cases, but kept running into strange design shortcuts on the part of the model that I would not be comfortable introducing. Therefore, a significant portion of this was written by me and a significant portion of this was written by a model (over the course of weeks with maybe ~20 iterations of rewrites and refactoring). Also with some bug fixing and test fixture generation carried out by AI. In those cases the model was Claude Opus 4.6 on high thinking mode. I have personally read and reviewed all of this code.

Please ensure your pull request adheres to the following guidelines:

- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #42756

```release-note
GatewayAPI: Implement ListenerSets. Allows per-namespace control of many Listeners for a single Gateway
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request


```
[INFO] === ListenerSet test results ===
    --- PASS: TestConformance/ListenerSetAllowedNamespaceNone (1.04s)
    --- PASS: TestConformance/ListenerSetAllowedNamespaceSame (0.12s)
    --- PASS: TestConformance/ListenerSetAllowedNamespaceSelector (1.13s)
    --- PASS: TestConformance/ListenerSetAllowedRoutesNamespaces (1.23s)
        --- PASS: TestConformance/ListenerSetAllowedRoutesNamespaces/Same-namespace_ListenerSet (0.01s)
            --- PASS: TestConformance/ListenerSetAllowedRoutesNamespaces/Same-namespace_ListenerSet/5_request_to_'listener-set-listener-allowed-routes-same.com/route-not-in-selected-namespace'_should_receive_one_of_[] (0.01s)
            --- PASS: TestConformance/ListenerSetAllowedRoutesNamespaces/Same-namespace_ListenerSet/6_request_to_'listener-set-listener-allowed-routes-selector.com/route-in-same-namespace'_should_receive_one_of_[] (0.01s)
            --- PASS: TestConformance/ListenerSetAllowedRoutesNamespaces/Same-namespace_ListenerSet/4_request_to_'listener-set-listener-allowed-routes-same.com/route-in-selected-namespace'_should_receive_one_of_[] (0.01s)
            --- PASS: TestConformance/ListenerSetAllowedRoutesNamespaces/Same-namespace_ListenerSet/8_request_to_'listener-set-listener-allowed-routes-selector.com/route-not-in-selected-namespace'_should_receive_one_of_[] (0.01s)
            --- PASS: TestConformance/ListenerSetAllowedRoutesNamespaces/Same-namespace_ListenerSet/2_request_to_'listener-set-listener-allowed-routes-all.com/route-not-in-selected-namespace'_should_go_to_infra-backend-v3 (0.01s)
            --- PASS: TestConformance/ListenerSetAllowedRoutesNamespaces/Same-namespace_ListenerSet/7_request_to_'listener-set-listener-allowed-routes-selector.com/route-in-selected-namespace'_should_go_to_infra-backend-v2 (0.02s)
            --- PASS: TestConformance/ListenerSetAllowedRoutesNamespaces/Same-namespace_ListenerSet/0_request_to_'listener-set-listener-allowed-routes-all.com/route-in-same-namespace'_should_go_to_infra-backend-v1 (0.02s)
            --- PASS: TestConformance/ListenerSetAllowedRoutesNamespaces/Same-namespace_ListenerSet/3_request_to_'listener-set-listener-allowed-routes-same.com/route-in-same-namespace'_should_go_to_infra-backend-v1 (0.02s)
            --- PASS: TestConformance/ListenerSetAllowedRoutesNamespaces/Same-namespace_ListenerSet/1_request_to_'listener-set-listener-allowed-routes-all.com/route-in-selected-namespace'_should_go_to_infra-backend-v2 (0.01s)
        --- PASS: TestConformance/ListenerSetAllowedRoutesNamespaces/Cross-namespace_ListenerSet (0.01s)
            --- PASS: TestConformance/ListenerSetAllowedRoutesNamespaces/Cross-namespace_ListenerSet/1_request_to_'listener-set-listener-allowed-routes-cross-ns-same.com/route-in-gateway-namespace'_should_receive_one_of_[] (0.00s)
            --- PASS: TestConformance/ListenerSetAllowedRoutesNamespaces/Cross-namespace_ListenerSet/0_request_to_'listener-set-listener-allowed-routes-cross-ns-same.com/route-in-listenerset-namespace'_should_go_to_infra-backend-v1 (0.01s)
    --- PASS: TestConformance/ListenerSetAllowedRoutesSupportedKinds (1.05s)
    --- PASS: TestConformance/ListenerSetDefaultNotAllowed (0.10s)
    --- PASS: TestConformance/ListenerSetDualParentRefIndependence (1.12s)
        --- PASS: TestConformance/ListenerSetDualParentRefIndependence/Both_parentRefs_are_Accepted (0.00s)
            --- PASS: TestConformance/ListenerSetDualParentRefIndependence/Both_parentRefs_are_Accepted/1_request_to_'ls-dual.com/dualboth'_should_go_to_infra-backend-v1 (0.01s)
            --- PASS: TestConformance/ListenerSetDualParentRefIndependence/Both_parentRefs_are_Accepted/0_request_to_'gw-dual.com/dualboth'_should_go_to_infra-backend-v1 (0.01s)
        --- PASS: TestConformance/ListenerSetDualParentRefIndependence/One_of_two_parentRefs_is_Accepted (0.01s)
            --- PASS: TestConformance/ListenerSetDualParentRefIndependence/One_of_two_parentRefs_is_Accepted/1_request_to_'gw-dual.com/dualone'_should_receive_one_of_[] (0.00s)
            --- PASS: TestConformance/ListenerSetDualParentRefIndependence/One_of_two_parentRefs_is_Accepted/0_request_to_'ls-dual.com/dualone'_should_go_to_infra-backend-v2 (0.01s)
    --- PASS: TestConformance/ListenerSetGatewayParentSectionNameNotFound (1.09s)
    --- PASS: TestConformance/ListenerSetHostnameConflict (1.12s)
    --- PASS: TestConformance/ListenerSetHTTPRouting (1.16s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/25_request_to_'gateway-listener-2.com/listener-set-http-routing-1-section-route'_should_receive_one_of_[] (0.01s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/27_request_to_'listener-set-http-routing-1-listener-2.com/listener-set-http-routing-1-section-route'_should_receive_one_of_[] (0.01s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/24_request_to_'gateway-listener-1.com/listener-set-http-routing-1-section-route'_should_receive_one_of_[] (0.00s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/9_request_to_'listener-set-http-routing-1-listener-2.com/gateway-route'_should_receive_one_of_[] (0.01s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/22_request_to_'listener-set-http-routing-2-listener-1.com/listener-set-http-routing-1-route'_should_receive_one_of_[] (0.01s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/18_request_to_'gateway-listener-1.com/listener-set-http-routing-1-route'_should_receive_one_of_[] (0.02s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/26_request_to_'listener-set-http-routing-1-listener-1.com/listener-set-http-routing-1-section-route'_should_go_to_infra-backend-v3 (0.02s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/35_request_to_'listener-set-http-routing-2-listener-2.com/listener-set-http-routing-2-route'_should_go_to_infra-backend-v2 (0.02s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/0_request_to_'gateway-listener-1.com/route'_should_go_to_infra-backend-v1 (0.02s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/23_request_to_'listener-set-http-routing-2-listener-2.com/listener-set-http-routing-1-route'_should_receive_one_of_[] (0.01s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/31_request_to_'gateway-listener-2.com/listener-set-http-routing-2-route'_should_receive_one_of_[] (0.01s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/21_request_to_'listener-set-http-routing-1-listener-2.com/listener-set-http-routing-1-route'_should_go_to_infra-backend-v2 (0.02s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/33_request_to_'listener-set-http-routing-1-listener-2.com/listener-set-http-routing-2-route'_should_receive_one_of_[] (0.01s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/5_request_to_'listener-set-http-routing-2-listener-2.com/route'_should_go_to_infra-backend-v1 (0.03s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/19_request_to_'gateway-listener-2.com/listener-set-http-routing-1-route'_should_receive_one_of_[] (0.01s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/14_request_to_'listener-set-http-routing-1-listener-1.com/gateway-section-route'_should_receive_one_of_[] (0.01s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/32_request_to_'listener-set-http-routing-1-listener-1.com/listener-set-http-routing-2-route'_should_receive_one_of_[] (0.01s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/16_request_to_'listener-set-http-routing-2-listener-1.com/gateway-section-route'_should_receive_one_of_[] (0.01s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/17_request_to_'listener-set-http-routing-2-listener-2.com/gateway-section-route'_should_receive_one_of_[] (0.01s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/34_request_to_'listener-set-http-routing-2-listener-1.com/listener-set-http-routing-2-route'_should_go_to_infra-backend-v2 (0.02s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/15_request_to_'listener-set-http-routing-1-listener-2.com/gateway-section-route'_should_receive_one_of_[] (0.01s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/29_request_to_'listener-set-http-routing-2-listener-2.com/listener-set-http-routing-1-section-route'_should_receive_one_of_[] (0.01s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/20_request_to_'listener-set-http-routing-1-listener-1.com/listener-set-http-routing-1-route'_should_go_to_infra-backend-v2 (0.02s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/30_request_to_'gateway-listener-1.com/listener-set-http-routing-2-route'_should_receive_one_of_[] (0.01s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/13_request_to_'gateway-listener-2.com/gateway-section-route'_should_receive_one_of_[] (0.01s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/11_request_to_'listener-set-http-routing-2-listener-2.com/gateway-route'_should_receive_one_of_[] (0.02s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/8_request_to_'listener-set-http-routing-1-listener-1.com/gateway-route'_should_receive_one_of_[] (0.01s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/7_request_to_'gateway-listener-2.com/gateway-route'_should_go_to_infra-backend-v2 (0.02s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/28_request_to_'listener-set-http-routing-2-listener-1.com/listener-set-http-routing-1-section-route'_should_receive_one_of_[] (0.02s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/3_request_to_'listener-set-http-routing-1-listener-2.com/route'_should_go_to_infra-backend-v1 (0.03s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/10_request_to_'listener-set-http-routing-2-listener-1.com/gateway-route'_should_receive_one_of_[] (0.01s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/12_request_to_'gateway-listener-1.com/gateway-section-route'_should_go_to_infra-backend-v3 (0.04s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/4_request_to_'listener-set-http-routing-2-listener-1.com/route'_should_go_to_infra-backend-v1 (0.03s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/6_request_to_'gateway-listener-1.com/gateway-route'_should_go_to_infra-backend-v2 (0.02s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/1_request_to_'gateway-listener-2.com/route'_should_go_to_infra-backend-v1 (0.02s)
        --- PASS: TestConformance/ListenerSetHTTPRouting/2_request_to_'listener-set-http-routing-1-listener-1.com/route'_should_go_to_infra-backend-v1 (0.04s)
    --- PASS: TestConformance/ListenerSetProtocolConflict (1.13s)
    --- PASS: TestConformance/ListenerSetReferenceGrant (1.10s)
    --- PASS: TestConformance/ListenerSetRouteStatusScopedToParentRef (1.09s)
        --- PASS: TestConformance/ListenerSetRouteStatusScopedToParentRef/Gateway-only_parentRef (0.00s)
        --- PASS: TestConformance/ListenerSetRouteStatusScopedToParentRef/ListenerSet-only_parentRef (0.01s)
