### PR TITLE
fix: Fix wildcard namespace bypass for selectorless ipBlock rules

### DIFF
--- a/pkg/k8s/network_policy.go
+++ b/pkg/k8s/network_policy.go
@@ -17,7 +17,6 @@ import (
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	k8sUtils "github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/types"
@@ -108,20 +107,24 @@ func processNamespaceSelector(ns *slim_metav1.LabelSelector) *slim_metav1.LabelS
 	return namespaceSelector
 }
 
-func parseNetworkPolicyPeer(clusterName, namespace string, peer *slim_networkingv1.NetworkPolicyPeer) types.Selector {
-	if peer == nil || (peer.PodSelector == nil && peer.NamespaceSelector == nil) {
+func parseNetworkPolicyPeer(clusterName, namespace string, peer *slim_networkingv1.NetworkPolicyPeer) types.Selectors {
+	if peer == nil {
 		return nil
+	}
+
+	if peer.IPBlock != nil {
+		return types.ToSelectors(ipBlockToCIDRRule(peer.IPBlock))
 	}
 
 	// peer should not be mutated in this function
 	podSelector := peer.PodSelector.DeepCopy()
+	if podSelector == nil {
+		podSelector = &slim_metav1.LabelSelector{}
+	}
 
 	// The PodSelector should only reflect to the configured cluster unless the selector
 	// explicitly targets another cluster already.
 	if clusterName != cmtypes.PolicyAnyCluster && !isPodSelectorSelectingCluster(podSelector) {
-		if podSelector == nil {
-			podSelector = &slim_metav1.LabelSelector{}
-		}
 		if podSelector.MatchLabels == nil {
 			podSelector.MatchLabels = map[string]slim_metav1.MatchLabelsValue{}
 		}
@@ -131,14 +134,12 @@ func parseNetworkPolicyPeer(clusterName, namespace string, peer *slim_networking
 	if peer.NamespaceSelector != nil {
 		namespaceSelector := processNamespaceSelector(peer.NamespaceSelector)
 		es := api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, namespaceSelector, podSelector)
-		return types.NewLabelSelector(es)
-	} else if podSelector != nil {
-		podSelector = parsePodSelector(podSelector, namespace)
-		es := api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, podSelector)
-		return types.NewLabelSelector(es)
+		return types.Selectors{types.NewLabelSelector(es)}
 	}
 
-	return nil
+	podSelector = parsePodSelector(podSelector, namespace)
+	es := api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, podSelector)
+	return types.Selectors{types.NewLabelSelector(es)}
 }
 
 func hasV1PolicyType(pTypes []slim_networkingv1.PolicyType, typ slim_networkingv1.PolicyType) bool {
@@ -164,22 +165,11 @@ func ParseNetworkPolicy(logger *slog.Logger, clusterName string, np *slim_networ
 		fromRules := types.PolicyEntries{}
 		if len(iRule.From) > 0 {
 			for _, rule := range iRule.From {
-				ingress := &types.PolicyEntry{Ingress: true, Tier: types.Normal}
-				endpointSelector := parseNetworkPolicyPeer(clusterName, namespace, &rule)
-
-				if endpointSelector != nil {
-					ingress.L3 = append(ingress.L3, endpointSelector)
-				} else {
-					// No label-based selectors were in NetworkPolicyPeer.
-					logger.Debug("NetworkPolicyPeer does not have PodSelector or NamespaceSelector", logfields.K8sNetworkPolicyName, np.Name)
+				ingress := &types.PolicyEntry{
+					Ingress: true,
+					Tier:    types.Normal,
+					L3:      parseNetworkPolicyPeer(clusterName, namespace, &rule),
 				}
-
-				// Parse CIDR-based parts of rule.
-				if rule.IPBlock != nil {
-					cidrRule := ipBlockToCIDRRule(rule.IPBlock)
-					ingress.L3 = append(ingress.L3, types.ToSelectors(cidrRule)...)
-				}
-
 				fromRules = append(fromRules, ingress)
 			}
 		} else {
@@ -187,9 +177,11 @@ func ParseNetworkPolicy(logger *slog.Logger, clusterName string, np *slim_networ
 			//   From []NetworkPolicyPeer
 			//   If this field is empty or missing, this rule matches all
 			//   sources (traffic not restricted by source).
-			ingress := &types.PolicyEntry{Ingress: true, Tier: types.Normal}
-			ingress.L3 = append(ingress.L3, types.WildcardSelector)
-
+			ingress := &types.PolicyEntry{
+				Ingress: true,
+				Tier:    types.Normal,
+				L3:      types.WildcardSelectors,
+			}
 			fromRules = append(fromRules, ingress)
 		}
 
@@ -212,23 +204,11 @@ func ParseNetworkPolicy(logger *slog.Logger, clusterName string, np *slim_networ
 
 		if len(eRule.To) > 0 {
 			for _, rule := range eRule.To {
-				egress := &types.PolicyEntry{Ingress: false, Tier: types.Normal}
-				if rule.NamespaceSelector != nil || rule.PodSelector != nil {
-					endpointSelector := parseNetworkPolicyPeer(clusterName, namespace, &rule)
-
-					if endpointSelector != nil {
-						egress.L3 = append(egress.L3, endpointSelector)
-					} else {
-						logger.Debug("NetworkPolicyPeer does not have PodSelector or NamespaceSelector", logfields.K8sNetworkPolicyName, np.Name)
-					}
+				egress := &types.PolicyEntry{
+					Ingress: false,
+					Tier:    types.Normal,
+					L3:      parseNetworkPolicyPeer(clusterName, namespace, &rule),
 				}
-
-				// Parse CIDR-based parts of rule.
-				if rule.IPBlock != nil {
-					cidrRule := ipBlockToCIDRRule(rule.IPBlock)
-					egress.L3 = append(egress.L3, types.ToSelector(cidrRule))
-				}
-
 				toRules = append(toRules, egress)
 			}
 		} else {
@@ -236,9 +216,11 @@ func ParseNetworkPolicy(logger *slog.Logger, clusterName string, np *slim_networ
 			//   To []NetworkPolicyPeer
 			//   If this field is empty or missing, this rule matches all
 			//   destinations (traffic not restricted by destination)
-			egress := &types.PolicyEntry{Ingress: false, Tier: types.Normal}
-			egress.L3 = append(egress.L3, types.WildcardSelector)
-
+			egress := &types.PolicyEntry{
+				Ingress: false,
+				Tier:    types.Normal,
+				L3:      types.WildcardSelectors,
+			}
 			toRules = append(toRules, egress)
 		}
 

--- a/pkg/k8s/network_policy.go
+++ b/pkg/k8s/network_policy.go
@@ -109,7 +109,7 @@ func processNamespaceSelector(ns *slim_metav1.LabelSelector) *slim_metav1.LabelS
 }
 
 func parseNetworkPolicyPeer(clusterName, namespace string, peer *slim_networkingv1.NetworkPolicyPeer) types.Selector {
-	if peer == nil {
+	if peer == nil || (peer.PodSelector == nil && peer.NamespaceSelector == nil) {
 		return nil
 	}
 

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -323,6 +323,27 @@ func TestParseNetworkPolicy(t *testing.T) {
 				L3:          policytypes.ToSelectors(api.NewESFromLabels()),
 			},
 		},
+		{
+			name: "ingress empty peer",
+			in: slim_networkingv1.NetworkPolicySpec{
+				Ingress: []slim_networkingv1.NetworkPolicyIngressRule{
+					{
+						From: []slim_networkingv1.NetworkPolicyPeer{
+							{},
+						},
+					},
+				},
+			},
+			out: policytypes.PolicyEntry{
+				Ingress:     true,
+				DefaultDeny: true,
+				Verdict:     policytypes.Allow,
+				Tier:        policytypes.Normal,
+				L3: policytypes.ToSelectors(api.NewESFromLabels(
+					labels.NewLabel(k8sConst.PodNamespaceLabel, slim_metav1.NamespaceDefault, labels.LabelSourceK8s),
+				)),
+			},
+		},
 	} {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
 			np := &slim_networkingv1.NetworkPolicy{
@@ -1573,7 +1594,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want policytypes.Selector
+		want policytypes.Selectors
 	}{
 		{
 			name: "peer-with-pod-selector",
@@ -1595,7 +1616,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 					},
 				},
 			},
-			want: getSelectorPointer(
+			want: policytypes.Selectors{getSelectorPointer(
 				api.NewESFromMatchRequirements(
 					map[string]string{
 						"k8s:foo":                          "bar",
@@ -1610,7 +1631,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 						},
 					},
 				),
-			),
+			)},
 		},
 		{
 			name: "peer-nil",
@@ -1649,7 +1670,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 					},
 				},
 			},
-			want: getSelectorPointer(
+			want: policytypes.Selectors{getSelectorPointer(
 				api.NewESFromMatchRequirements(
 					map[string]string{
 						"k8s:foo": "bar",
@@ -1667,7 +1688,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 						},
 					},
 				),
-			),
+			)},
 		},
 		{
 			name: "peer-with-ns-selector",
@@ -1687,7 +1708,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 					},
 				},
 			},
-			want: getSelectorPointer(
+			want: policytypes.Selectors{getSelectorPointer(
 				api.NewESFromMatchRequirements(
 					map[string]string{
 						"k8s:io.cilium.k8s.namespace.labels.ns-foo": "ns-bar",
@@ -1699,7 +1720,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 						},
 					},
 				),
-			),
+			)},
 		},
 		{
 			name: "peer-with-allow-all-ns-selector",
@@ -1709,7 +1730,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 					NamespaceSelector: &slim_metav1.LabelSelector{},
 				},
 			},
-			want: getSelectorPointer(
+			want: policytypes.Selectors{getSelectorPointer(
 				api.NewESFromMatchRequirements(
 					map[string]string{},
 					[]slim_metav1.LabelSelectorRequirement{
@@ -1719,7 +1740,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 						},
 					},
 				),
-			),
+			)},
 		},
 		{
 			name: "peer-with-defaut-cluster",
@@ -1741,7 +1762,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 					},
 				},
 			},
-			want: getSelectorPointer(
+			want: policytypes.Selectors{getSelectorPointer(
 				api.NewESFromMatchRequirements(
 					map[string]string{
 						"k8s:foo":                          "bar",
@@ -1756,7 +1777,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 						},
 					},
 				),
-			),
+			)},
 		},
 		{
 			name: "peer-with-cluster-selector",
@@ -1772,7 +1793,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 					},
 				},
 			},
-			want: getSelectorPointer(
+			want: policytypes.Selectors{getSelectorPointer(
 				api.NewESFromMatchRequirements(
 					map[string]string{
 						"k8s:foo":                          "bar",
@@ -1781,7 +1802,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 					},
 					nil,
 				),
-			),
+			)},
 		},
 		{
 			name: "peer-with-cluster-selector-expr",
@@ -1800,7 +1821,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 					},
 				},
 			},
-			want: getSelectorPointer(
+			want: policytypes.Selectors{getSelectorPointer(
 				api.NewESFromMatchRequirements(
 					map[string]string{
 						"k8s:io.kubernetes.pod.namespace": "foo-namespace",
@@ -1813,7 +1834,26 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 						},
 					},
 				),
-			),
+			)},
+		},
+		{
+			name: "peer-with-ipblock",
+			args: args{
+				namespace:   "foo-namespace",
+				clusterName: "cluster1",
+				peer: &slim_networkingv1.NetworkPolicyPeer{
+					IPBlock: &slim_networkingv1.IPBlock{
+						CIDR:   "10.0.0.0/8",
+						Except: []string{"10.96.0.0/12"},
+					},
+				},
+			},
+			want: policytypes.Selectors{
+				policytypes.ToSelector(api.CIDRRule{
+					Cidr:        "10.0.0.0/8",
+					ExceptCIDRs: []api.CIDR{"10.96.0.0/12"},
+				}),
+			},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -522,10 +522,12 @@ func TestParseNetworkPolicyNoSelectors(t *testing.T) {
 	}
 	expectedRules := policytypes.PolicyEntries{expectedRule}
 
-	rules, err := ParseNetworkPolicy(hivetest.Logger(t), cmtypes.PolicyAnyCluster, &np)
-	require.NoError(t, err)
-	require.NotNil(t, rules)
-	require.Equal(t, expectedRules, rules)
+	for _, clusterName := range []string{cmtypes.PolicyAnyCluster, "my-cluster"} {
+		rules, err := ParseNetworkPolicy(hivetest.Logger(t), clusterName, &np)
+		require.NoError(t, err)
+		require.NotNil(t, rules)
+		require.Equal(t, expectedRules, rules)
+	}
 }
 
 func TestParseNetworkPolicyEgress(t *testing.T) {


### PR DESCRIPTION
Return nil early in parseNetworkPolicyPeer when both PodSelector and NamespaceSelector are nil.

This prevents a regression where a non-wildcard clusterName configuration erroneously instantiated a podSelector on selectorless (ipBlock-only) peers, resulting in an unintended wildcard namespace allow rule.

Fixes: cilium/security#39

```release-note
Fix wildcard namespace bypass for selectorless ipBlock rules
```