### PR TITLE
build: Allow local-only images in kind-load-base-images

### DIFF
--- a/Makefile.kind
+++ b/Makefile.kind
@@ -181,8 +181,10 @@ PREPULL_IMAGES ?= quay.io/cilium/cilium-ci:latest  quay.io/cilium/operator-gener
 .PHONY: kind-load-base-images
 kind-load-base-images:
 	@echo "  PULL cluster images"
-	for image in $(PREPULL_IMAGES); do docker pull $$image; done
-	for cluster_name in $${KIND_CLUSTERS:-$(shell kind get clusters)}; do \
+	for image in $(PREPULL_IMAGES); do \
+		docker pull $$image || docker image inspect $$image >/dev/null 2>&1; \
+	done
+	for cluster_name in $${KIND_CLUSTERS:-$$(kind get clusters)}; do \
 		kind load docker-image $(PREPULL_IMAGES) -n $$cluster_name; \
 	done
 


### PR DESCRIPTION
Check if image exists locally with 'docker image inspect' if 'docker image pull' fails. This way remote images still get updated, but local-only images are also allowed.

Use '$$(...)' instead of '$(shell ...)' to only evaluate 'kind get clusters' when needed.
