### PR TITLE
operator/auth: fix SPIRE Upsert sending empty entry.Id on update (silent infinite reconcile loop)

### DIFF
--- a/operator/auth/spire/client.go
+++ b/operator/auth/spire/client.go
@@ -333,10 +333,28 @@ func (c *Client) Upsert(ctx context.Context, id string) error {
 		return err
 	}
 
-	_, err = c.entry.BatchUpdateEntry(ctx, &entryv1.BatchUpdateEntryRequest{
+	// SPIRE keys updates on entry.Id. Carry over the Id of the existing entry,
+	// otherwise BatchUpdateEntry cannot resolve which row to update and fails
+	// with a per-entry error while the top-level RPC reports success.
+	desired[0].Id = entries.Entries[0].Id
+
+	resp, err := c.entry.BatchUpdateEntry(ctx, &entryv1.BatchUpdateEntryRequest{
 		Entries: desired,
 	})
-	return err
+	if err != nil {
+		return err
+	}
+
+	// Per-entry failures are reported in resp.Results[].Status, not in err.
+	// Surface them so the caller does not treat a failed update as success and
+	// re-emit the same Upsert on every resync, looping forever.
+	for _, r := range resp.GetResults() {
+		if r.GetStatus().GetCode() != int32(codes.OK) {
+			return fmt.Errorf("failed to update SPIRE entry for %q: %s (code %d)",
+				id, r.GetStatus().GetMessage(), r.GetStatus().GetCode())
+		}
+	}
+	return nil
 }
 
 // UpsertBatch creates or updates multiple SPIFFE entries at once.
@@ -381,6 +399,19 @@ func (c *Client) UpsertBatch(ctx context.Context, ids []string) error {
 	var toUpdate []*types.Entry
 	for j, r := range resp.Results {
 		if r.Status.Code == int32(codes.AlreadyExists) {
+			// SPIRE keys updates on entry.Id. On AlreadyExists, the result
+			// carries the existing entry (including its Id); copy that Id onto
+			// the desired entry so BatchUpdateEntry can resolve the row.
+			// Without it the update fails per-entry while the RPC reports
+			// success, causing the caller to loop forever on each resync.
+			existingID := r.GetEntry().GetId()
+			if existingID == "" {
+				errs = append(errs, fmt.Errorf(
+					"entry already exists but SPIRE returned no Id for %q, cannot update",
+					ids[j]))
+				continue
+			}
+			entries[j].Id = existingID
 			toUpdate = append(toUpdate, entries[j])
 		} else if r.Status.Code != int32(codes.OK) {
 			errs = append(errs, fmt.Errorf("entry create failed: %v: %s",
@@ -390,11 +421,19 @@ func (c *Client) UpsertBatch(ctx context.Context, ids []string) error {
 
 	// Update existing entries
 	if len(toUpdate) > 0 {
-		_, err := c.entry.BatchUpdateEntry(ctx,
+		updateResp, err := c.entry.BatchUpdateEntry(ctx,
 			&entryv1.BatchUpdateEntryRequest{Entries: toUpdate},
 		)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("batch update failed: %w", err))
+		} else {
+			// Per-entry update failures live in the response, not in err.
+			for _, r := range updateResp.GetResults() {
+				if r.GetStatus().GetCode() != int32(codes.OK) {
+					errs = append(errs, fmt.Errorf("entry update failed: %v: %s",
+						r.GetStatus().GetCode(), r.GetStatus().GetMessage()))
+				}
+			}
 		}
 	}
 

--- a/operator/auth/spire/client_test.go
+++ b/operator/auth/spire/client_test.go
@@ -203,12 +203,15 @@ func TestClient_Upsert(t *testing.T) {
 							},
 						}, in)
 						return &entryv1.ListEntriesResponse{
-							Entries: []*types.Entry{{}},
+							Entries: []*types.Entry{{Id: "existing-entry-id"}},
 						}, nil
 					},
 					BatchUpdateEntryFunc: func(ctx context.Context, in *entryv1.BatchUpdateEntryRequest, opts ...grpc.CallOption) (*entryv1.BatchUpdateEntryResponse, error) {
+						// The update entry must carry the Id of the existing
+						// entry; otherwise SPIRE cannot resolve the row.
 						require.ElementsMatch(t, in.Entries, []*types.Entry{
 							{
+								Id: "existing-entry-id",
 								SpiffeId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",
 									Path:        "/identity/dummy-id",
@@ -220,10 +223,43 @@ func TestClient_Upsert(t *testing.T) {
 								Selectors: defaultSelectors,
 							},
 						})
-						return &entryv1.BatchUpdateEntryResponse{}, nil
+						return &entryv1.BatchUpdateEntryResponse{
+							Results: []*entryv1.BatchUpdateEntryResponse_Result{
+								{Status: &types.Status{Code: int32(codes.OK)}},
+							},
+						}, nil
 					},
 				},
 			},
+		},
+		{
+			name: "entry exists but update returns per-entry failure",
+			args: args{
+				id: "dummy-id",
+			},
+			fields: fields{
+				entry: mockEntryClient{
+					ListEntriesFunc: func(ctx context.Context, in *entryv1.ListEntriesRequest, opts ...grpc.CallOption) (*entryv1.ListEntriesResponse, error) {
+						return &entryv1.ListEntriesResponse{
+							Entries: []*types.Entry{{Id: "existing-entry-id"}},
+						}, nil
+					},
+					BatchUpdateEntryFunc: func(ctx context.Context, in *entryv1.BatchUpdateEntryRequest, opts ...grpc.CallOption) (*entryv1.BatchUpdateEntryResponse, error) {
+						require.Equal(t, "existing-entry-id", in.Entries[0].Id)
+						// Top-level err is nil but the per-entry status fails;
+						// the caller must surface this as an error.
+						return &entryv1.BatchUpdateEntryResponse{
+							Results: []*entryv1.BatchUpdateEntryResponse_Result{
+								{Status: &types.Status{
+									Code:    int32(codes.NotFound),
+									Message: "Failed to update entry",
+								}},
+							},
+						}, nil
+					},
+				},
+			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -554,18 +590,74 @@ func TestClient_UpsertBatch(t *testing.T) {
 					return &entryv1.BatchCreateEntryResponse{
 						Results: []*entryv1.BatchCreateEntryResponse_Result{
 							{Status: &types.Status{Code: int32(codes.OK)}},
-							{Status: &types.Status{Code: int32(codes.AlreadyExists)}},
+							{
+								Status: &types.Status{Code: int32(codes.AlreadyExists)},
+								// SPIRE returns the existing entry (with its Id)
+								// on AlreadyExists.
+								Entry: &types.Entry{Id: "existing-id2"},
+							},
 						},
 					}, nil
 				},
 				BatchUpdateEntryFunc: func(ctx context.Context, in *entryv1.BatchUpdateEntryRequest, opts ...grpc.CallOption) (*entryv1.BatchUpdateEntryResponse, error) {
 					require.Len(t, in.Entries, 1)
 					require.Equal(t, "/identity/id2", in.Entries[0].SpiffeId.Path)
-					return &entryv1.BatchUpdateEntryResponse{}, nil
+					// The update entry must carry the existing Id.
+					require.Equal(t, "existing-id2", in.Entries[0].Id)
+					return &entryv1.BatchUpdateEntryResponse{
+						Results: []*entryv1.BatchUpdateEntryResponse_Result{
+							{Status: &types.Status{Code: int32(codes.OK)}},
+						},
+					}, nil
 				},
 			},
 			ids:     []string{"id1", "id2"},
 			wantErr: false,
+		},
+		{
+			name: "batch update per-entry failure surfaces error",
+			entry: mockEntryClient{
+				BatchCreateEntryFunc: func(ctx context.Context, in *entryv1.BatchCreateEntryRequest, opts ...grpc.CallOption) (*entryv1.BatchCreateEntryResponse, error) {
+					return &entryv1.BatchCreateEntryResponse{
+						Results: []*entryv1.BatchCreateEntryResponse_Result{
+							{
+								Status: &types.Status{Code: int32(codes.AlreadyExists)},
+								Entry:  &types.Entry{Id: "existing-id1"},
+							},
+						},
+					}, nil
+				},
+				BatchUpdateEntryFunc: func(ctx context.Context, in *entryv1.BatchUpdateEntryRequest, opts ...grpc.CallOption) (*entryv1.BatchUpdateEntryResponse, error) {
+					require.Equal(t, "existing-id1", in.Entries[0].Id)
+					// Top-level err is nil; failure is per-entry only.
+					return &entryv1.BatchUpdateEntryResponse{
+						Results: []*entryv1.BatchUpdateEntryResponse_Result{
+							{Status: &types.Status{
+								Code:    int32(codes.NotFound),
+								Message: "Failed to update entry",
+							}},
+						},
+					}, nil
+				},
+			},
+			ids:     []string{"id1"},
+			wantErr: true,
+		},
+		{
+			name: "batch upsert AlreadyExists without returned Id surfaces error",
+			entry: mockEntryClient{
+				BatchCreateEntryFunc: func(ctx context.Context, in *entryv1.BatchCreateEntryRequest, opts ...grpc.CallOption) (*entryv1.BatchCreateEntryResponse, error) {
+					return &entryv1.BatchCreateEntryResponse{
+						Results: []*entryv1.BatchCreateEntryResponse_Result{
+							// AlreadyExists but no Entry returned: we must not
+							// attempt an Id-less update (which would loop).
+							{Status: &types.Status{Code: int32(codes.AlreadyExists)}},
+						},
+					}, nil
+				},
+			},
+			ids:     []string{"id1"},
+			wantErr: true,
 		},
 		{
 			name: "batch create RPC error",
@@ -583,7 +675,10 @@ func TestClient_UpsertBatch(t *testing.T) {
 				BatchCreateEntryFunc: func(ctx context.Context, in *entryv1.BatchCreateEntryRequest, opts ...grpc.CallOption) (*entryv1.BatchCreateEntryResponse, error) {
 					return &entryv1.BatchCreateEntryResponse{
 						Results: []*entryv1.BatchCreateEntryResponse_Result{
-							{Status: &types.Status{Code: int32(codes.AlreadyExists)}},
+							{
+								Status: &types.Status{Code: int32(codes.AlreadyExists)},
+								Entry:  &types.Entry{Id: "existing-id1"},
+							},
 						},
 					}, nil
 				},


### PR DESCRIPTION
## Summary

The cilium-operator mutual-authentication SPIRE reconciler issues `BatchUpdateEntry` with an **empty `entry.Id`** whenever a matching registration entry already exists. SPIRE keys updates on `entry.Id`, so an empty Id cannot resolve the row: the server returns a per-entry failure (`Failed to update entry`, `entry_id=`) while the top-level RPC reports success.

Both `Upsert` and `UpsertBatch` discarded the `BatchUpdateEntry` response, so the per-entry status in `resp.Results[].Status` was never inspected. The returned `err` was `nil`, so:

- cilium-operator logs `Upsert identity ... error=<nil>` and `e.Done(nil)` acks the `CiliumIdentity` event as success;
- on the next resync the same `Upsert` is re-emitted, the entry still exists, the broken UPDATE path runs again and fails again — an **infinite, silent reconcile loop** plus one failed `BatchUpdateEntry` per identity per resync of SPIRE error spam.

This only triggers once a matching entry pre-exists (operator restart, upgrade, or trust-domain change with persisted entries); a clean install creates the entry first, which works — which is why it's rarely seen.

## Fix

- **`Upsert`**: carry the existing entry's `Id` (`entries.Entries[0].Id`, available from the preceding `listEntries`) onto the desired entry before `BatchUpdateEntry`, and inspect `resp.Results[].Status`, returning a real error on any non-OK status so per-entry failures surface instead of being swallowed.
- **`UpsertBatch`**: on `AlreadyExists`, copy the Id from the entry SPIRE returns in the create result (`result.GetEntry().GetId()`) onto the desired entry; guard against a missing Id (surface an error rather than send an Id-less update that would loop); and check the update response results for per-entry failures.

## Tests

Added/updated unit tests in `operator/auth/spire/client_test.go`:

- `Upsert` "entry exists": the existing entry now has a real `Id` and the test asserts the `BatchUpdateEntry` request carries that Id.
- `Upsert` "entry exists but update returns per-entry failure": top-level `err == nil` but a non-OK per-entry status — asserts `Upsert` returns an error.
- `UpsertBatch` "batch upsert with existing entries triggers update": the create `AlreadyExists` result returns the existing entry, and the test asserts the update entry carries its Id.
- `UpsertBatch` "batch update per-entry failure surfaces error" and "AlreadyExists without returned Id surfaces error".

Verified the tests are load-bearing: removing the `Id` assignment makes them fail. `go build ./operator/auth/...`, `go vet ./operator/auth/...`, `gofmt`, and `go test ./operator/auth/...` all pass locally.

```release-note
operator: Fix SPIRE mutual-auth reconciler sending an empty entry Id on update, which caused a silent infinite reconcile loop and SPIRE "Failed to update entry" errors when a registration entry already existed (e.g. after an operator restart, upgrade, or trust-domain change).
```

This PR was prepared with AIL:4. I reviewed the root cause against the current `main` source, the SPIRE `BatchUpdateEntry`/`BatchCreateEntry` API semantics (`AlreadyExists` returns the existing entry with its Id), and verified the unit tests fail without the fix.

Fixes: #46310
