### PR TITLE
logging: Downgrade leader election lease conflict to info

### DIFF
--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -119,9 +119,7 @@ runs:
             --set-string=hubble.relay.extraEnv[1].name=CILIUM_INVALID_METRIC_VALUE_DETECTOR \
             --set-string=hubble.relay.extraEnv[1].value=true \
             --set-string=hubble.relay.extraEnv[2].name=CILIUM_SLOG_DUP_ATTR_DETECTOR \
-            --set-string=hubble.relay.extraEnv[2].value=true \
-            --helm-set-string=operator.extraArgs[0]=--leader-election-lease-duration=30s \
-            --helm-set-string=operator.extraArgs[1]=--leader-election-renew-deadline=20s"
+            --set-string=hubble.relay.extraEnv[2].value=true"
 
           IMAGE=""
           if [ "${{ inputs.image-tag }}" != "" ]; then

--- a/pkg/logging/klog_bridge.go
+++ b/pkg/logging/klog_bridge.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"regexp"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -15,16 +16,22 @@ import (
 
 var klogOverrides = []logLevelOverride{
 	{
-		// TODO: We can drop this once bumped to new client-go version which has this at info level:
-		// https://github.com/kubernetes/client-go/commit/ea7a7e7cf9697850f17631f79ef4ef45b95c449e.
-		matcher:     regexp.MustCompile("Failed to update.*falling back to slow path"),
-		targetLevel: slog.LevelInfo,
+		// A lease conflict during leader election is benign and self-recovers on
+		// the next renew. It happens when operators briefly co-lead during a
+		// rolling upgrade. Downgrade only the conflict so genuine lease update
+		// failures still surface at error. See GH-45426.
+		matcher:      regexp.MustCompile("Failed to update lease"),
+		errPredicate: apierrors.IsConflict,
+		targetLevel:  slog.LevelInfo,
 	},
 }
 
 type logLevelOverride struct {
-	matcher     *regexp.Regexp
-	targetLevel slog.Level
+	matcher *regexp.Regexp
+	// errPredicate, when set, must also match the record's "err" attribute for
+	// the override to apply.
+	errPredicate func(error) bool
+	targetLevel  slog.Level
 }
 
 // klogOverrideHandler is an slog.Handler that adds a "subsys" attribute and
@@ -45,12 +52,30 @@ func (h *klogOverrideHandler) Enabled(ctx context.Context, level slog.Level) boo
 
 func (h *klogOverrideHandler) Handle(ctx context.Context, record slog.Record) error {
 	for _, override := range h.overrides {
-		if override.matcher.MatchString(record.Message) {
-			record.Level = override.targetLevel
-			break
+		if !override.matcher.MatchString(record.Message) {
+			continue
 		}
+		if override.errPredicate != nil && !override.errPredicate(recordErr(record)) {
+			continue
+		}
+		record.Level = override.targetLevel
+		break
 	}
 	return h.inner.Handle(ctx, record)
+}
+
+// recordErr returns the error stored under the "err" attribute by logr's slog
+// bridge for klog Error() calls, or nil if absent.
+func recordErr(record slog.Record) error {
+	var err error
+	record.Attrs(func(a slog.Attr) bool {
+		if a.Key != "err" {
+			return true
+		}
+		err, _ = a.Value.Any().(error)
+		return false
+	})
+	return err
 }
 
 func (h *klogOverrideHandler) WithAttrs(attrs []slog.Attr) slog.Handler {

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -112,6 +114,58 @@ func TestKlogBridgeLevelOverrides(t *testing.T) {
 			assert.Equal(t, "error", level, "non-overridden error should stay error, got line: %s", line)
 			assert.Equal(t, "value", entry["key"], "structured key-value pairs should be preserved")
 			assert.Equal(t, "something failed", entry[logfields.Error], "error should be preserved as a structured field")
+		}
+	}
+}
+
+func TestKlogBridgeErrPredicate(t *testing.T) {
+	var out bytes.Buffer
+	logger := slog.New(
+		slog.NewJSONHandler(&out,
+			&slog.HandlerOptions{
+				ReplaceAttr: ReplaceAttrFnWithoutTimestamp,
+			},
+		),
+	)
+	log := logger.With(logfields.LogSubsys, "klog")
+
+	overrides := []logLevelOverride{
+		{
+			matcher:      regexp.MustCompile("Failed to update lease"),
+			errPredicate: apierrors.IsConflict,
+			targetLevel:  slog.LevelInfo,
+		},
+	}
+	handler := &klogOverrideHandler{
+		inner:     log.Handler(),
+		overrides: overrides,
+	}
+	klog.SetSlogLogger(slog.New(handler))
+
+	lease := schema.GroupResource{Group: "coordination.k8s.io", Resource: "leases"}
+	conflict := apierrors.NewConflict(lease, "cilium-operator-resource-lock",
+		fmt.Errorf("the object has been modified"))
+	timeout := apierrors.NewServerTimeout(lease, "update", 1)
+
+	klog.ErrorS(conflict, "Failed to update lease")
+	klog.ErrorS(timeout, "Failed to update lease")
+	klog.ErrorS(nil, "Failed to update lease")
+	klog.Flush()
+
+	logout := strings.Trim(out.String(), "\n")
+	lines := strings.Split(logout, "\n")
+	require.Len(t, lines, 3)
+
+	for i, line := range lines {
+		var entry map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &entry))
+
+		level, _ := entry["level"].(string)
+		switch i {
+		case 0:
+			assert.Equal(t, "info", level, "conflict should be downgraded, got line: %s", line)
+		default:
+			assert.Equal(t, "error", level, "non-conflict should stay error, got line: %s", line)
 		}
 	}
 }


### PR DESCRIPTION
The operator runs with two replicas. During a rolling upgrade the old
and new leaders briefly contend for the same leader election lease, and
one renew loses to the other with a 409 conflict ("the object has been
modified"). This is benign and recovers on the next renew, but client-go
logs it at error, which trips CI's check-log-errors.

Match the "Failed to update lease" message and downgrade it to info only
when the error is a conflict, so genuine lease update failures (e.g.
control plane overload) still surface at error.

This replaces the previous override for the fast-path "...falling back to
slow path" message, which client-go logs at info anyway as of the v1.36
bump, so that matcher was a no-op.

The second commit drops the operator leader-election timing bump added in
#45667, which was based on the theory that a 5s client HTTP timeout was
racing a delayed commit. The failing run logs show the error is a 409
returned by a successful request, not a timeout, so the bump did not help.

Fixes: #45426