### PR TITLE
ctmap: skip GC delete of CT entries reopened by the datapath

### DIFF
--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -1229,6 +1229,28 @@ func (m *Map) Lookup(key MapKey) (MapValue, error) {
 	return value, nil
 }
 
+func (m *Map) LookupTo(key MapKey, value MapValue) error {
+	if err := m.Open(); err != nil {
+		return err
+	}
+
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	var duration *spanstat.SpanStat
+	if metrics.BPFSyscallDuration.IsEnabled() {
+		duration = spanstat.Start()
+	}
+
+	err := m.m.Lookup(key, value)
+
+	if metrics.BPFSyscallDuration.IsEnabled() {
+		metrics.BPFSyscallDuration.WithLabelValues(metricOpLookup, metrics.Error2Outcome(err)).Observe(duration.End(err == nil).Total().Seconds())
+	}
+
+	return err
+}
+
 func (m *Map) Update(key MapKey, value MapValue) error {
 	var err error
 

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -42,6 +42,11 @@ var (
 	mapInfo map[mapType]mapAttributes
 )
 
+// errDeferredReopened indicates that purgeCtEntry skipped a delete because the
+// entry was reopened by the datapath between the GC batch read and the delete
+// attempt. Expected under churn; logged at debug level rather than as an error.
+var errDeferredReopened = errors.New("deferring delete: entry reopened by datapath")
+
 const (
 	// mapCount counts the maximum number of CT maps that one endpoint may
 	// access at once.
@@ -453,7 +458,24 @@ func (m *Map) doGCForFamily(filter GCFilter, next4, next6 func(GCEvent), ipv6 bo
 	return stats
 }
 
-func (m *Map) purgeCtEntry(key CtKey, entry *CtEntry, natMap *nat.Map, next func(event GCEvent), actCountFailed func(uint16, uint32)) error {
+func (m *Map) purgeCtEntry(key CtKey, entry *CtEntry, scratch *CtEntry, natMap *nat.Map, next func(event GCEvent), actCountFailed func(uint16, uint32)) error {
+	// Re-lookup the entry at delete time and compare its Lifetime with the
+	// snapshot value the GC iterator handed us. A changed Lifetime means the
+	// datapath refreshed (typically reopened) the entry between the batch read
+	// and now. This narrows but does not fully close the race: the datapath can
+	// still reopen between this lookup and DeleteLocked. A later GC pass retries.
+	if lookupErr := m.LookupTo(key, scratch); lookupErr == nil {
+		if scratch.Lifetime != entry.Lifetime {
+			return fmt.Errorf("%w: snapshot Lifetime=%d current Lifetime=%d drift=%+d snapshot Flags=0x%04x current Flags=0x%04x",
+				errDeferredReopened,
+				entry.Lifetime,
+				scratch.Lifetime,
+				int64(scratch.Lifetime)-int64(entry.Lifetime),
+				entry.Flags,
+				scratch.Flags)
+		}
+	}
+
 	err := m.DeleteLocked(key)
 	if err != nil {
 		return err
@@ -506,6 +528,9 @@ func (m *Map) cleanup(filter GCFilter, natMap *nat.Map, stats *gcStats, next fun
 			countFailedFn = ACT.CountFailed6
 		}
 	}
+	// scratch is reused by purgeCtEntry's re-lookup for every GC'd entry. The
+	// callback runs sequentially within a single GC pass, so sharing is safe.
+	scratch := &CtEntry{}
 	return func(key bpf.MapKey, value bpf.MapValue) {
 		// TODO: These type assertions are a bit dangerous, make more of this well typed
 		// to avoid having to make these assertions.
@@ -524,15 +549,22 @@ func (m *Map) cleanup(filter GCFilter, natMap *nat.Map, stats *gcStats, next fun
 
 		switch action {
 		case deleteEntry:
-			err := m.purgeCtEntry(ctKey, entry, natMap, next, countFailedFn)
+			err := m.purgeCtEntry(ctKey, entry, scratch, natMap, next, countFailedFn)
 			if err != nil {
-				if errors.Is(err, ebpf.ErrKeyNotExist) {
+				switch {
+				case errors.Is(err, ebpf.ErrKeyNotExist):
 					m.Logger.Debug("key is missing, likely due to lru eviction - skipping",
 						logfields.Error, err,
 						logfields.Key, ctKey.ToHost(),
 					)
 					stats.skipped++
-				} else {
+				case errors.Is(err, errDeferredReopened):
+					m.Logger.Debug("deferred delete: entry reopened between batch read and delete",
+						logfields.Error, err,
+						logfields.Key, ctKey.ToHost(),
+					)
+					stats.skipped++
+				default:
 					m.Logger.Error("key is missing, likely due to lru eviction - skipping",
 						logfields.Error, err,
 						logfields.Key, ctKey.ToHost(),

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -352,6 +352,76 @@ func TestPrivilegedCtGcTcp(t *testing.T) {
 	require.Empty(t, buf)
 }
 
+// TestPrivilegedCtGcReopenedEntry verifies purgeCtEntry's contract: before
+// deleting, it re-looks-up the entry and compares the live Lifetime against the
+// snapshot value the GC iterator captured during the batch read. If the datapath
+// reopened the entry in between (Lifetime changed), the delete is deferred; if
+// the entry is unchanged, it is deleted.
+//
+// The snapshot is passed to purgeCtEntry as a separate argument from the live
+// map value, which is exactly the divergence the re-lookup guards against, so
+// the two branches can be exercised directly and deterministically.
+func TestPrivilegedCtGcReopenedEntry(t *testing.T) {
+	setupCTMap(t)
+
+	ctMapName := MapNameTCP4Global + "_test"
+	ctMap := newMap(ctMapName, mapTypeIPv4TCPGlobal)
+	err := ctMap.OpenOrCreate()
+	require.NoError(t, err)
+	defer ctMap.Map.Unpin()
+
+	key := &CtKey4Global{
+		tuple.TupleKey4Global{
+			TupleKey4: tuple.TupleKey4{
+				SourceAddr: types.IPv4{192, 168, 61, 12},
+				DestAddr:   types.IPv4{192, 168, 61, 11},
+				SourcePort: 0x3195,
+				DestPort:   0x50,
+				NextHeader: u8proto.TCP,
+				Flags:      tuple.TUPLE_F_OUT,
+			},
+		},
+	}
+
+	t.Run("reopened entry is not deleted", func(t *testing.T) {
+		// Live value as it currently exists in the map: the datapath reopened the
+		// connection and refreshed its Lifetime past expiry.
+		err := ctMap.Map.Update(key, &CtEntry{Packets: 5, Bytes: 600, Lifetime: 50000})
+		require.NoError(t, err)
+
+		// Snapshot is the older, expired value the GC iterator handed us; that is
+		// why GC selected the entry for deletion in the first place.
+		snapshot := &CtEntry{Packets: 1, Bytes: 216, Lifetime: 38000}
+		scratch := &CtEntry{}
+
+		err = ctMap.purgeCtEntry(key, snapshot, scratch, nil, func(GCEvent) {}, nil)
+		require.ErrorIs(t, err, errDeferredReopened)
+
+		// The reopened entry must still be present.
+		_, err = ctMap.Map.Lookup(key)
+		require.NoError(t, err, "reopened entry must not be deleted")
+
+		require.NoError(t, ctMap.Map.Delete(key))
+	})
+
+	t.Run("unchanged entry is deleted", func(t *testing.T) {
+		live := &CtEntry{Packets: 1, Bytes: 216, Lifetime: 38000}
+		err := ctMap.Map.Update(key, live)
+		require.NoError(t, err)
+
+		// Snapshot matches the live value: the datapath did not touch the entry,
+		// so purgeCtEntry proceeds with the delete.
+		snapshot := &CtEntry{Packets: 1, Bytes: 216, Lifetime: 38000}
+		scratch := &CtEntry{}
+
+		err = ctMap.purgeCtEntry(key, snapshot, scratch, nil, func(GCEvent) {}, nil)
+		require.NoError(t, err)
+
+		_, err = ctMap.Map.Lookup(key)
+		require.Error(t, err, "unchanged entry must be deleted")
+	})
+}
+
 // TestPrivilegedCtGcDsr tests whether DSR NAT entries are removed upon a removal of
 // their CT entry (== CT_EGRESS).
 func TestPrivilegedCtGcDsr(t *testing.T) {
@@ -964,18 +1034,30 @@ func populateFakeDataCTMap4(tb testing.TB, m CtMap, size int) map[*CtKey4Global]
 }
 
 func BenchmarkPrivilegedCtGcTcpXL(t *testing.B) {
-	benchmarkCtGc(t, 1<<24) // max size
+	benchmarkCtGc(t, 1<<24, false) // max size
 }
 
 func BenchmarkPrivilegedCtGcTcpL(t *testing.B) {
-	benchmarkCtGc(t, 1<<22)
+	benchmarkCtGc(t, 1<<22, false)
 }
 
 func BenchmarkPrivilegedCtGcTcpM(t *testing.B) {
-	benchmarkCtGc(t, 1<<17)
+	benchmarkCtGc(t, 1<<17, false)
 }
 
-func benchmarkCtGc(t *testing.B, size int) {
+func BenchmarkPrivilegedCtGcTcpXLExpired(t *testing.B) {
+	benchmarkCtGc(t, 1<<24, true) // max size
+}
+
+func BenchmarkPrivilegedCtGcTcpLExpired(t *testing.B) {
+	benchmarkCtGc(t, 1<<22, true)
+}
+
+func BenchmarkPrivilegedCtGcTcpMExpired(t *testing.B) {
+	benchmarkCtGc(t, 1<<17, true)
+}
+
+func benchmarkCtGc(t *testing.B, size int, expireAll bool) {
 	for t.Loop() {
 		t.StopTimer()
 		setupCTMap(t)
@@ -1023,6 +1105,9 @@ func benchmarkCtGc(t *testing.B, size int) {
 				Packets:  1,
 				Bytes:    216,
 				Lifetime: 2,
+			}
+			if expireAll {
+				ctVal.Lifetime = 0
 			}
 			err = ctMap.Map.Update(ctKey, ctVal)
 			assert.NoError(t, err)


### PR DESCRIPTION
## Description
- Fixes: #46298
- This PR was prepared with AIL:3.
 
This fixes a TOCTOU race in batched conntrack GC. GC reads CT entries in batches and deletes the expired ones afterwards. Between the batch read and the delete, the datapath can refresh (reopen) an entry — for TCP, `__ct_lookup` calls `ct_reset_closing` / `ct_update_timeout` on the same 5-tuple. GC would delete it anyway based on the stale snapshot, removing a connection-tracking entry that is still in use; this cascades into NAT mapping deletion and SNAT source-port reallocation for an otherwise healthy connection.

This PR re-looks up each entry in `purgeCtEntry` just before deleting it and compares its `Lifetime` against the snapshot value the GC iterator handed us. A changed `Lifetime` means the datapath touched the entry after the batch read, so the delete is skipped and a later GC pass reconsiders it. The skip is reported via a dedicated `errDeferredReopened` sentinel and logged at debug level (it is expected under churn).

This narrows but does not fully close the race — the datapath can still reopen between the re-lookup and `DeleteLocked` — but it eliminates the large window spanning the whole batch, which is where the problem was observed.

To keep the re-lookup off the allocation hot path, `bpf.Map.LookupTo` is added: it unmarshals into a caller-provided value instead of allocating a fresh one via `m.value.New()` on every GC'd entry (~64B each, up to ~1GiB at `LimitTableMax`). A single scratch `CtEntry` is reused across the whole GC pass; the cleanup callback runs sequentially within a pass, so sharing is safe.

## Testing

`TestPrivilegedCtGcReopenedEntry` is added. It drives `purgeCtEntry` directly with a snapshot whose `Lifetime` differs from the live map value (the datapath reopened the entry) and asserts the delete is deferred via `errDeferredReopened` and the entry survives; with a matching snapshot it asserts the entry is deleted. Removing the re-lookup comparison makes the reopened case fail, so it is a true regression test for the fix.

`BenchmarkPrivilegedCtGcTcp{M,L,XL}Expired` are also added. Unlike the existing read-only benchmarks, they populate entries that GC actually deletes, so they exercise the delete path (and the new re-lookup).

The original issue reproduces reliably with BPF masquerade (SNAT) enabled and rapid TCP connection churn that reuses ephemeral ports (e.g. no HTTP/1.1 keep-alive) — roughly 7,500 connections/s on a single node triggers it within ~10 minutes. With this change the GC no longer deletes entries the datapath reopened during that churn.

```release-note
Fix conntrack garbage collection deleting CT entries that the datapath reopened between the GC batch read and the delete, which could cascade into NAT mapping deletion and SNAT source-port reallocation for live connections.
```

