### PR TITLE
ipam: allow first and last pod pool IPs

### DIFF
--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -11,7 +11,7 @@ cilium-operator-generic [flags]
 ### Options
 
 ```
-      --auto-create-cilium-pod-ip-pools stringToString             Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag) (default [])
+      --auto-create-cilium-pod-ip-pools stringToString             Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size>[;allow-first-ip:<bool>][;allow-last-ip:<bool>] (multiple pools can also be passed by repeating the CLI flag) (default [])
       --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -11,7 +11,7 @@ cilium-operator-generic hive [flags]
 ### Options
 
 ```
-      --auto-create-cilium-pod-ip-pools stringToString             Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag) (default [])
+      --auto-create-cilium-pod-ip-pools stringToString             Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size>[;allow-first-ip:<bool>][;allow-last-ip:<bool>] (multiple pools can also be passed by repeating the CLI flag) (default [])
       --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -17,7 +17,7 @@ cilium-operator-generic hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
-      --auto-create-cilium-pod-ip-pools stringToString             Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag) (default [])
+      --auto-create-cilium-pod-ip-pools stringToString             Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size>[;allow-first-ip:<bool>][;allow-last-ip:<bool>] (multiple pools can also be passed by repeating the CLI flag) (default [])
       --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -13,7 +13,7 @@ cilium-operator [flags]
 ```
       --alibaba-cloud-release-excess-ips                           Enable releasing excess free IP addresses from Alibaba Cloud ENI.
       --alibaba-cloud-vpc-id string                                Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator
-      --auto-create-cilium-pod-ip-pools stringToString             Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag) (default [])
+      --auto-create-cilium-pod-ip-pools stringToString             Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size>[;allow-first-ip:<bool>][;allow-last-ip:<bool>] (multiple pools can also be passed by repeating the CLI flag) (default [])
       --aws-enable-prefix-delegation                               Allows operator to allocate prefixes to ENIs instead of individual IP addresses
       --aws-max-results-per-call int32                             Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
       --aws-release-excess-ips                                     Enable releasing excess free IP addresses from AWS ENI.

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -13,7 +13,7 @@ cilium-operator hive [flags]
 ```
       --alibaba-cloud-release-excess-ips                           Enable releasing excess free IP addresses from Alibaba Cloud ENI.
       --alibaba-cloud-vpc-id string                                Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator
-      --auto-create-cilium-pod-ip-pools stringToString             Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag) (default [])
+      --auto-create-cilium-pod-ip-pools stringToString             Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size>[;allow-first-ip:<bool>][;allow-last-ip:<bool>] (multiple pools can also be passed by repeating the CLI flag) (default [])
       --aws-enable-prefix-delegation                               Allows operator to allocate prefixes to ENIs instead of individual IP addresses
       --aws-max-results-per-call int32                             Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
       --aws-release-excess-ips                                     Enable releasing excess free IP addresses from AWS ENI.

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -19,7 +19,7 @@ cilium-operator hive dot-graph [flags]
 ```
       --alibaba-cloud-release-excess-ips                           Enable releasing excess free IP addresses from Alibaba Cloud ENI.
       --alibaba-cloud-vpc-id string                                Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator
-      --auto-create-cilium-pod-ip-pools stringToString             Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag) (default [])
+      --auto-create-cilium-pod-ip-pools stringToString             Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size>[;allow-first-ip:<bool>][;allow-last-ip:<bool>] (multiple pools can also be passed by repeating the CLI flag) (default [])
       --aws-enable-prefix-delegation                               Allows operator to allocate prefixes to ENIs instead of individual IP addresses
       --aws-max-results-per-call int32                             Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
       --aws-release-excess-ips                                     Enable releasing excess free IP addresses from AWS ENI.

--- a/Documentation/network/concepts/ipam/multi-pool.rst
+++ b/Documentation/network/concepts/ipam/multi-pool.rst
@@ -86,9 +86,12 @@ extended at run-time. In-use CIDRs must not be removed, and existing pools must 
 be deleted if they are still in use by a Cilium node. In case updating an in-use pool
 is needed, please follow this :ref:`procedure <update_existing_ciliumpodippools>` in order to
 minimize disruption during the update.
-The mask size of a pool is immutable and the same for all nodes. Neither restriction
-is enforced until :gh-issue:`26966` is resolved. The first and last address of a
-``CiliumPodIPPool`` are reserved and cannot be allocated. Pools with less than 3
+The mask size of a pool is immutable and the same for all nodes. The
+``spec.allowFirstIP`` and ``spec.allowLastIP`` fields are immutable as well.
+By default, the first and last address of each allocated CIDR from a
+``CiliumPodIPPool`` are reserved and cannot be allocated. Set
+``spec.allowFirstIP`` or ``spec.allowLastIP`` to ``true`` when creating the pool
+to make either address allocatable independently. Pools with less than 3
 addresses (/31, /32, /127, /128) do not have this limitation.
 
 

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1232,6 +1232,12 @@ data:
     {{- $attrs = append $attrs (printf "ipv6-cidrs:%s" (join "," $spec.ipv6.cidrs)) }}
     {{- $attrs = append $attrs (printf "ipv6-mask-size:%s" (toString $spec.ipv6.maskSize)) }}
     {{- end }}
+    {{- if hasKey $spec "allowFirstIP" }}
+    {{- $attrs = append $attrs (printf "allow-first-ip:%s" (toString $spec.allowFirstIP)) }}
+    {{- end }}
+    {{- if hasKey $spec "allowLastIP" }}
+    {{- $attrs = append $attrs (printf "allow-last-ip:%s" (toString $spec.allowLastIP)) }}
+    {{- end }}
     {{- $pools = append $pools (printf "%s=%s" $pool (join ";" $attrs)) }}
   {{- end }}
   auto-create-cilium-pod-ip-pools: {{ join "," $pools | quote }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2315,6 +2315,8 @@ ipam:
     #       cidrs:
     #         - 10.10.0.0/8
     #       maskSize: 24
+    #     allowFirstIP: true
+    #     allowLastIP: true
     #   other:
     #     ipv6:
     #       cidrs:

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2334,6 +2334,8 @@ ipam:
     #       cidrs:
     #         - 10.10.0.0/8
     #       maskSize: 24
+    #     allowFirstIP: true
+    #     allowLastIP: true
     #   other:
     #     ipv6:
     #       cidrs:

--- a/operator/pkg/ipam/allocator/multipool/multipool.go
+++ b/operator/pkg/ipam/allocator/multipool/multipool.go
@@ -66,7 +66,7 @@ var DefaultConfig = Config{
 func (cfg Config) Flags(flags *pflag.FlagSet) {
 	flags.StringToString(autoCreateCiliumPodIPPoolsFlag, DefaultConfig.AutoCreatePools,
 		"Automatically create CiliumPodIPPool resources on startup. "+
-			"Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag)")
+			"Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size>[;allow-first-ip:<bool>][;allow-last-ip:<bool>] (multiple pools can also be passed by repeating the CLI flag)")
 	flags.Bool(enableClusterPoolToMultiPoolMigration, DefaultConfig.FromClusterPoolMigration,
 		"Enable the migration of all nodes from cluster-pool IPAM to multi-pool IPAM")
 	flags.String(option.IPAMDefaultIPPool, DefaultConfig.IPAMDefaultPool, "Name of the default IP Pool when using multi-pool")
@@ -198,7 +198,7 @@ func StartAllocator(p multiPoolParams) {
 
 func multiPoolAutoCreatePools(ctx context.Context, clientset client.Clientset, poolMap map[string]string, logger *slog.Logger) error {
 	for poolName, poolSpecStr := range poolMap {
-		v4PoolSpec, v6PoolSpec, err := ParsePoolSpec(poolSpecStr)
+		poolSpec, err := ParsePoolSpec(poolSpecStr)
 		if err != nil {
 			logger.ErrorContext(ctx,
 				fmt.Sprintf("Failed to parse IP pool spec in %q flag", autoCreateCiliumPodIPPoolsFlag),
@@ -213,8 +213,10 @@ func multiPoolAutoCreatePools(ctx context.Context, clientset client.Clientset, p
 				Name: poolName,
 			},
 			Spec: cilium_v2alpha1.IPPoolSpec{
-				IPv4: v4PoolSpec,
-				IPv6: v6PoolSpec,
+				IPv4:         poolSpec.IPv4,
+				IPv6:         poolSpec.IPv6,
+				AllowFirstIP: poolSpec.AllowFirstIP,
+				AllowLastIP:  poolSpec.AllowLastIP,
 			},
 		}
 
@@ -403,7 +405,7 @@ func startIPPoolAllocator(
 			case resource.Sync:
 				close(synced)
 			case resource.Upsert:
-				err = UpsertPool(allocator, ev.Object.Name, ev.Object.Spec.IPv4, ev.Object.Spec.IPv6)
+				err = UpsertPool(allocator, ev.Object.Name, ev.Object.Spec.IPv4, ev.Object.Spec.IPv6, ev.Object.Spec.AllowFirstIP, ev.Object.Spec.AllowLastIP)
 				action = "upsert"
 			case resource.Delete:
 				err = DeletePool(allocator, ev.Object.Name)

--- a/operator/pkg/ipam/allocator/multipool/pool_allocator.go
+++ b/operator/pkg/ipam/allocator/multipool/pool_allocator.go
@@ -22,10 +22,31 @@ import (
 )
 
 type cidrPool struct {
-	v4         []cidralloc.CIDRAllocator
-	v6         []cidralloc.CIDRAllocator
-	v4MaskSize int
-	v6MaskSize int
+	v4           []cidralloc.CIDRAllocator
+	v6           []cidralloc.CIDRAllocator
+	v4MaskSize   int
+	v6MaskSize   int
+	allowFirstIP bool
+	allowLastIP  bool
+}
+
+type poolOptions struct {
+	allowFirstIP bool
+	allowLastIP  bool
+}
+
+type PoolOption func(*poolOptions)
+
+func WithAllowFirstIP() PoolOption {
+	return func(o *poolOptions) {
+		o.allowFirstIP = true
+	}
+}
+
+func WithAllowLastIP() PoolOption {
+	return func(o *poolOptions) {
+		o.allowLastIP = true
+	}
 }
 
 type cidrSet map[netip.Prefix]struct{}
@@ -39,18 +60,20 @@ func (c cidrSet) CIDRSlice() []iputil.Prefix {
 	return cidrs
 }
 
-// availableAddrs returns the number of available addresses in this set
-func (c cidrSet) availableAddrs() *big.Int {
+// availableAddrs returns the number of available addresses in this set.
+func (c cidrSet) availableAddrs(allowFirstIP, allowLastIP bool) *big.Int {
 	total := big.NewInt(0)
 	for p := range c {
-		total.Add(total, addrsInPrefix(p))
+		total.Add(total, addrsInPrefix(p, allowFirstIP, allowLastIP))
 	}
 	return total
 }
 
 type cidrSets struct {
-	v4 cidrSet
-	v6 cidrSet
+	v4           cidrSet
+	v6           cidrSet
+	allowFirstIP bool
+	allowLastIP  bool
 }
 
 type poolToCIDRs map[string]cidrSets // poolName -> list of allocated CIDRs
@@ -68,7 +91,7 @@ func (m errAllocatorNotReady) Is(target error) bool {
 }
 
 // addrsInPrefix calculates the number of usable addresses in a prefix p, or 0 if p is not valid.
-func addrsInPrefix(p netip.Prefix) *big.Int {
+func addrsInPrefix(p netip.Prefix, allowFirstIP, allowLastIP bool) *big.Int {
 	if !p.IsValid() {
 		return big.NewInt(0)
 	}
@@ -77,15 +100,16 @@ func addrsInPrefix(p netip.Prefix) *big.Int {
 	addrs := new(big.Int)
 	addrs.Lsh(big.NewInt(1), uint(p.Addr().BitLen()-p.Bits()))
 
-	// prefix has less than 3 addresses
-	two := big.NewInt(2)
-	if addrs.Cmp(two) <= 0 {
+	if addrs.Cmp(big.NewInt(2)) <= 0 {
 		return addrs
 	}
 
-	// subtract network and broadcast address, which are not available for
-	// allocation in the cilium/ipam library for now
-	addrs.Sub(addrs, two)
+	if !allowFirstIP {
+		addrs.Sub(addrs, big.NewInt(1))
+	}
+	if !allowLastIP {
+		addrs.Sub(addrs, big.NewInt(1))
+	}
 	if addrs.Sign() < 0 {
 		return big.NewInt(0)
 	}
@@ -130,9 +154,19 @@ func (p *PoolAllocator) cleanupOrphans(node, pool string) {
 			delete(p.orphans, node)
 		}
 	case len(p.orphans[node][pool].v4) == 0:
-		p.orphans[node][pool] = cidrSets{v6: p.orphans[node][pool].v6}
+		cidrs := p.orphans[node][pool]
+		p.orphans[node][pool] = cidrSets{
+			v6:           cidrs.v6,
+			allowFirstIP: cidrs.allowFirstIP,
+			allowLastIP:  cidrs.allowLastIP,
+		}
 	case len(p.orphans[node][pool].v6) == 0:
-		p.orphans[node][pool] = cidrSets{v4: p.orphans[node][pool].v4}
+		cidrs := p.orphans[node][pool]
+		p.orphans[node][pool] = cidrSets{
+			v4:           cidrs.v4,
+			allowFirstIP: cidrs.allowFirstIP,
+			allowLastIP:  cidrs.allowLastIP,
+		}
 	}
 }
 
@@ -233,7 +267,7 @@ func (p *PoolAllocator) updateCIDRSets(isV6 bool, cidrSets []cidralloc.CIDRAlloc
 						logfields.PoolName, pool,
 						logfields.Node, node,
 					)
-					p.markOrphan(node, pool, cidr)
+					p.markOrphan(node, pool, cidr, allocatedCIDRSets.allowFirstIP, allocatedCIDRSets.allowLastIP)
 					delete(cidrs, cidr)
 				}
 			}
@@ -256,9 +290,14 @@ func parseCIDRStrings(cidrStrs []string) ([]netip.Prefix, error) {
 	return prefixes, nil
 }
 
-func (p *PoolAllocator) UpsertPool(poolName string, ipv4CIDRs []string, ipv4MaskSize int, ipv6CIDRs []string, ipv6MaskSize int) error {
+func (p *PoolAllocator) UpsertPool(poolName string, ipv4CIDRs []string, ipv4MaskSize int, ipv6CIDRs []string, ipv6MaskSize int, opts ...PoolOption) error {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
+
+	var options poolOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
 
 	pool, exists := p.pools[poolName]
 	if exists && ipv4MaskSize != pool.v4MaskSize {
@@ -266,6 +305,12 @@ func (p *PoolAllocator) UpsertPool(poolName string, ipv4CIDRs []string, ipv4Mask
 	}
 	if exists && ipv6MaskSize != pool.v6MaskSize {
 		return fmt.Errorf("cannot change IPv6 mask size in existing pool %q", poolName)
+	}
+	if exists && options.allowFirstIP != pool.allowFirstIP {
+		return fmt.Errorf("cannot change allowFirstIP in existing pool %q", poolName)
+	}
+	if exists && options.allowLastIP != pool.allowLastIP {
+		return fmt.Errorf("cannot change allowLastIP in existing pool %q", poolName)
 	}
 
 	ipv4Prefixes, err := parseCIDRStrings(ipv4CIDRs)
@@ -296,10 +341,12 @@ func (p *PoolAllocator) UpsertPool(poolName string, ipv4CIDRs []string, ipv4Mask
 	}
 
 	p.pools[poolName] = cidrPool{
-		v4:         v4,
-		v6:         v6,
-		v4MaskSize: ipv4MaskSize,
-		v6MaskSize: ipv6MaskSize,
+		v4:           v4,
+		v6:           v6,
+		v4MaskSize:   ipv4MaskSize,
+		v6MaskSize:   ipv6MaskSize,
+		allowFirstIP: options.allowFirstIP,
+		allowLastIP:  options.allowLastIP,
 	}
 
 	return p.reconcileOrphanCIDRs(poolName, v4, v6)
@@ -329,10 +376,10 @@ func (p *PoolAllocator) DeletePool(poolName string) error {
 		)
 		delete(p.nodes[node], poolName)
 		for cidr := range cidrSets.v4 {
-			p.markOrphan(node, poolName, cidr)
+			p.markOrphan(node, poolName, cidr, cidrSets.allowFirstIP, cidrSets.allowLastIP)
 		}
 		for cidr := range cidrSets.v6 {
-			p.markOrphan(node, poolName, cidr)
+			p.markOrphan(node, poolName, cidr, cidrSets.allowFirstIP, cidrSets.allowLastIP)
 		}
 	}
 
@@ -368,7 +415,7 @@ func (p *PoolAllocator) AllocateToNode(nodeName string, pools *types.IPAMPoolSpe
 			} else {
 				// pool cannot be found: it must be a pool deleted before the operator restarted.
 				// Mark the CIDR as orphan to preserve node allocations.
-				p.markOrphan(nodeName, allocatedPool.Pool, prefix)
+				p.markOrphan(nodeName, allocatedPool.Pool, prefix, allocatedPool.AllowFirstIP, allocatedPool.AllowLastIP)
 				err = errors.Join(err,
 					fmt.Errorf("unable to find pool %s, prefix %s is still allocated to the node but is marked as orphan",
 						allocatedPool.Pool, prefix))
@@ -402,10 +449,13 @@ func (p *PoolAllocator) AllocateToNode(nodeName string, pools *types.IPAMPoolSpe
 
 	for _, reqPool := range pools.Requested {
 		allocatedCIDRs := p.nodes[nodeName][reqPool.Pool]
+		pool, ok := p.pools[reqPool.Pool]
+		allowFirstIP := ok && pool.allowFirstIP
+		allowLastIP := ok && pool.allowLastIP
 
 		if p.ipv4Enabled {
 			neededIPv4Addrs := big.NewInt(int64(reqPool.Needed.IPv4Addrs))
-			toAllocate := neededIPv4Addrs.Sub(neededIPv4Addrs, allocatedCIDRs.v4.availableAddrs())
+			toAllocate := neededIPv4Addrs.Sub(neededIPv4Addrs, allocatedCIDRs.v4.availableAddrs(allowFirstIP, allowLastIP))
 
 			if allocErr := p.allocateCIDRs(nodeName, reqPool.Pool, ipam.IPv4, toAllocate); allocErr != nil {
 				err = errors.Join(err,
@@ -415,7 +465,7 @@ func (p *PoolAllocator) AllocateToNode(nodeName string, pools *types.IPAMPoolSpe
 		}
 		if p.ipv6Enabled {
 			neededIPv6Addrs := big.NewInt(int64(reqPool.Needed.IPv6Addrs))
-			toAllocate := neededIPv6Addrs.Sub(neededIPv6Addrs, allocatedCIDRs.v6.availableAddrs())
+			toAllocate := neededIPv6Addrs.Sub(neededIPv6Addrs, allocatedCIDRs.v6.availableAddrs(allowFirstIP, allowLastIP))
 
 			if allocErr := p.allocateCIDRs(nodeName, reqPool.Pool, ipam.IPv6, toAllocate); allocErr != nil {
 				err = errors.Join(err,
@@ -469,12 +519,20 @@ func (p *PoolAllocator) AllocatedPools(targetNode string) (pools []types.IPAMPoo
 			continue
 		}
 		sets := cidrSets{v4: cidrSet{}, v6: cidrSet{}}
-
-		maps.Copy(sets.v4, p.nodes[targetNode][poolName].v4)
-		maps.Copy(sets.v4, p.orphans[targetNode][poolName].v4)
-
-		maps.Copy(sets.v6, p.nodes[targetNode][poolName].v6)
-		maps.Copy(sets.v6, p.orphans[targetNode][poolName].v6)
+		if nodeSets, ok := p.nodes[targetNode][poolName]; ok {
+			sets.allowFirstIP = nodeSets.allowFirstIP
+			sets.allowLastIP = nodeSets.allowLastIP
+			maps.Copy(sets.v4, nodeSets.v4)
+			maps.Copy(sets.v6, nodeSets.v6)
+		}
+		if orphanSets, ok := p.orphans[targetNode][poolName]; ok {
+			if len(sets.v4) == 0 && len(sets.v6) == 0 {
+				sets.allowFirstIP = orphanSets.allowFirstIP
+				sets.allowLastIP = orphanSets.allowLastIP
+			}
+			maps.Copy(sets.v4, orphanSets.v4)
+			maps.Copy(sets.v6, orphanSets.v6)
+		}
 
 		poolToCIDRs[poolName] = sets
 	}
@@ -484,8 +542,10 @@ func (p *PoolAllocator) AllocatedPools(targetNode string) (pools []types.IPAMPoo
 		v6CIDRs := cidrs.v6.CIDRSlice()
 
 		pools = append(pools, types.IPAMPoolAllocation{
-			Pool:  poolName,
-			CIDRs: append(v4CIDRs, v6CIDRs...),
+			Pool:         poolName,
+			AllowFirstIP: cidrs.allowFirstIP,
+			AllowLastIP:  cidrs.allowLastIP,
+			CIDRs:        append(v4CIDRs, v6CIDRs...),
 		})
 	}
 
@@ -516,9 +576,12 @@ func (p *PoolAllocator) markAllocated(targetNode, sourcePool string, cidr netip.
 
 	cidrs, ok := pools[sourcePool]
 	if !ok {
+		pool := p.pools[sourcePool]
 		cidrs = cidrSets{
-			v4: cidrSet{},
-			v6: cidrSet{},
+			v4:           cidrSet{},
+			v6:           cidrSet{},
+			allowFirstIP: pool.allowFirstIP,
+			allowLastIP:  pool.allowLastIP,
 		}
 		pools[sourcePool] = cidrs
 	}
@@ -566,7 +629,7 @@ func (p *PoolAllocator) isOrphan(targetNode, sourcePool string, cidr netip.Prefi
 	return found
 }
 
-func (p *PoolAllocator) markOrphan(targetNode string, sourcePool string, cidr netip.Prefix) {
+func (p *PoolAllocator) markOrphan(targetNode string, sourcePool string, cidr netip.Prefix, allowFirstIP, allowLastIP bool) {
 	pools, ok := p.orphans[targetNode]
 	if !ok {
 		pools = poolToCIDRs{}
@@ -576,8 +639,10 @@ func (p *PoolAllocator) markOrphan(targetNode string, sourcePool string, cidr ne
 	cidrs, ok := pools[sourcePool]
 	if !ok {
 		cidrs = cidrSets{
-			v4: cidrSet{},
-			v6: cidrSet{},
+			v4:           cidrSet{},
+			v6:           cidrSet{},
+			allowFirstIP: allowFirstIP,
+			allowLastIP:  allowLastIP,
 		}
 		pools[sourcePool] = cidrs
 	}
@@ -640,7 +705,7 @@ func (p *PoolAllocator) allocateCIDRs(targetNode, sourcePool string, family ipam
 		}
 
 		p.markAllocated(targetNode, sourcePool, cidr)
-		toAllocate.Sub(toAllocate, addrsInPrefix(cidr))
+		toAllocate.Sub(toAllocate, addrsInPrefix(cidr, pool.allowFirstIP, pool.allowLastIP))
 	}
 
 	return nil

--- a/operator/pkg/ipam/allocator/multipool/pool_allocator_test.go
+++ b/operator/pkg/ipam/allocator/multipool/pool_allocator_test.go
@@ -420,6 +420,30 @@ func TestPoolAllocator_AddUpsertDelete(t *testing.T) {
 	assert.True(t, mars.hasCIDR(netip.MustParsePrefix("fe00:100::/80")))
 	assert.True(t, mars.hasCIDR(netip.MustParsePrefix("fb00:200::/80")))
 
+	// allowFirstIP cannot be changed on existing pool
+	err = p.UpsertPool("mars",
+		[]string{"10.10.0.0/16", "10.20.0.0/16"}, 24,
+		[]string{"fe00:100::/80", "fb00:200::/80"}, 96,
+		WithAllowFirstIP(),
+	)
+	assert.ErrorContains(t, err, `cannot change allowFirstIP in existing pool "mars"`)
+	mars, exists = p.pools["mars"]
+	assert.True(t, exists)
+	assert.False(t, mars.allowFirstIP)
+	assert.False(t, mars.allowLastIP)
+
+	// allowLastIP cannot be changed on existing pool
+	err = p.UpsertPool("mars",
+		[]string{"10.10.0.0/16", "10.20.0.0/16"}, 24,
+		[]string{"fe00:100::/80", "fb00:200::/80"}, 96,
+		WithAllowLastIP(),
+	)
+	assert.ErrorContains(t, err, `cannot change allowLastIP in existing pool "mars"`)
+	mars, exists = p.pools["mars"]
+	assert.True(t, exists)
+	assert.False(t, mars.allowFirstIP)
+	assert.False(t, mars.allowLastIP)
+
 	// Changes in pool CIDRs are reflected in internal bookkeeping after upsert
 	err = p.UpsertPool("mars",
 		[]string{"10.1.0.0/16", "10.3.0.0/16", "10.10.0.0/16"}, 24,
@@ -458,9 +482,11 @@ func Test_addrsInPrefix(t *testing.T) {
 	}
 
 	tests := []struct {
-		name string
-		args netip.Prefix
-		want *big.Int
+		name         string
+		args         netip.Prefix
+		allowFirstIP bool
+		allowLastIP  bool
+		want         *big.Int
 	}{
 		{
 			name: "ipv4",
@@ -492,12 +518,123 @@ func Test_addrsInPrefix(t *testing.T) {
 			args: netip.MustParsePrefix("10.0.0.0/30"),
 			want: big.NewInt(2),
 		},
+		{
+			name:         "/30 with first IP allowed",
+			args:         netip.MustParsePrefix("10.0.0.0/30"),
+			allowFirstIP: true,
+			want:         big.NewInt(3),
+		},
+		{
+			name:        "/30 with last IP allowed",
+			args:        netip.MustParsePrefix("10.0.0.0/30"),
+			allowLastIP: true,
+			want:        big.NewInt(3),
+		},
+		{
+			name:         "/30 with first and last IPs allowed",
+			args:         netip.MustParsePrefix("10.0.0.0/30"),
+			allowFirstIP: true,
+			allowLastIP:  true,
+			want:         big.NewInt(4),
+		},
+		{
+			name:         "ipv6 with first and last IPs allowed",
+			args:         netip.MustParsePrefix("f00d::/126"),
+			allowFirstIP: true,
+			allowLastIP:  true,
+			want:         big.NewInt(4),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := addrsInPrefix(tt.args); got.Cmp(tt.want) != 0 {
+			if got := addrsInPrefix(tt.args, tt.allowFirstIP, tt.allowLastIP); got.Cmp(tt.want) != 0 {
 				t.Errorf("addrsInPrefix() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestPoolAllocatorAllowFirstAndLastIPs(t *testing.T) {
+	tests := []struct {
+		name              string
+		options           []PoolOption
+		allowFirstIP      bool
+		allowLastIP       bool
+		expectedAllocated []iputil.Prefix
+	}{
+		{
+			name: "disabled",
+			expectedAllocated: []iputil.Prefix{
+				iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.0/30")),
+				iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.4/30")),
+			},
+		},
+		{
+			name:         "first IP allowed",
+			options:      []PoolOption{WithAllowFirstIP()},
+			allowFirstIP: true,
+			expectedAllocated: []iputil.Prefix{
+				iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.0/30")),
+				iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.4/30")),
+			},
+		},
+		{
+			name:        "last IP allowed",
+			options:     []PoolOption{WithAllowLastIP()},
+			allowLastIP: true,
+			expectedAllocated: []iputil.Prefix{
+				iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.0/30")),
+				iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.4/30")),
+			},
+		},
+		{
+			name:         "first and last IPs allowed",
+			options:      []PoolOption{WithAllowFirstIP(), WithAllowLastIP()},
+			allowFirstIP: true,
+			allowLastIP:  true,
+			expectedAllocated: []iputil.Prefix{
+				iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.0/30")),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewPoolAllocator(hivetest.Logger(t), true, false)
+			err := p.UpsertPool("test-pool", []string{"10.0.0.0/29"}, 30, nil, 0, tt.options...)
+			assert.NoError(t, err)
+			p.RestoreFinished()
+
+			node := &v2.CiliumNode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node",
+				},
+				Spec: v2.NodeSpec{
+					IPAM: ipamTypes.IPAMSpec{
+						Pools: ipamTypes.IPAMPoolSpec{
+							Requested: []ipamTypes.IPAMPoolRequest{
+								{
+									Pool: "test-pool",
+									Needed: ipamTypes.IPAMPoolDemand{
+										IPv4Addrs: 4,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			err = p.AllocateToNode(node.Name, &node.Spec.IPAM.Pools)
+			assert.NoError(t, err)
+			assert.Equal(t, []ipamTypes.IPAMPoolAllocation{
+				{
+					Pool:         "test-pool",
+					AllowFirstIP: tt.allowFirstIP,
+					AllowLastIP:  tt.allowLastIP,
+					CIDRs:        tt.expectedAllocated,
+				},
+			}, p.AllocatedPools(node.Name))
 		})
 	}
 }

--- a/operator/pkg/ipam/allocator/multipool/pool_handler.go
+++ b/operator/pkg/ipam/allocator/multipool/pool_handler.go
@@ -17,52 +17,74 @@ const (
 	poolKeyIPv4MaskSize = "ipv4-mask-size"
 	poolKeyIPv6CIDRs    = "ipv6-cidrs"
 	poolKeyIPv6MaskSize = "ipv6-mask-size"
+	poolKeyAllowFirstIP = "allow-first-ip"
+	poolKeyAllowLastIP  = "allow-last-ip"
 )
+
+type ParsedPoolSpec struct {
+	IPv4         *cilium_v2alpha1.IPv4PoolSpec
+	IPv6         *cilium_v2alpha1.IPv6PoolSpec
+	AllowFirstIP bool
+	AllowLastIP  bool
+}
 
 // ParsePoolSpec parses a pool spec string in the form
 // "ipv4-cidrs:172.16.0.0/16,172.17.0.0/16;ipv4-mask-size:24".
-func ParsePoolSpec(poolString string) (*cilium_v2alpha1.IPv4PoolSpec, *cilium_v2alpha1.IPv6PoolSpec, error) {
+func ParsePoolSpec(poolString string) (*ParsedPoolSpec, error) {
 	fields := strings.FieldsFunc(strings.ReplaceAll(poolString, " ", ""), func(c rune) bool {
 		return c == ';'
 	})
 
 	var ipv4CIDRs, ipv6CIDRs []cilium_v2alpha1.PoolCIDR
 	var ipv4MaskSize, ipv6MaskSize uint8
+	var allowFirstIP, allowLastIP bool
 
 	for _, field := range fields {
 		key, value, ok := strings.Cut(field, ":")
 		if !ok {
-			return nil, nil, fmt.Errorf("invalid number of key delimiters in pool spec %s", poolString)
+			return nil, fmt.Errorf("invalid number of key delimiters in pool spec %s", poolString)
 		}
 		switch key {
 		case poolKeyIPv4CIDRs:
 			for cidr := range strings.SplitSeq(value, ",") {
 				_, err := netip.ParsePrefix(cidr)
 				if err != nil {
-					return nil, nil, fmt.Errorf("invalid value for key %q: %w", poolKeyIPv4CIDRs, err)
+					return nil, fmt.Errorf("invalid value for key %q: %w", poolKeyIPv4CIDRs, err)
 				}
 				ipv4CIDRs = append(ipv4CIDRs, cilium_v2alpha1.PoolCIDR(cidr))
 			}
 		case poolKeyIPv4MaskSize:
 			mask, err := strconv.ParseUint(value, 10, 8)
 			if err != nil {
-				return nil, nil, fmt.Errorf("invalid value for key %q: %w", poolKeyIPv4MaskSize, err)
+				return nil, fmt.Errorf("invalid value for key %q: %w", poolKeyIPv4MaskSize, err)
 			}
 			ipv4MaskSize = uint8(mask)
 		case poolKeyIPv6CIDRs:
 			for cidr := range strings.SplitSeq(value, ",") {
 				_, err := netip.ParsePrefix(cidr)
 				if err != nil {
-					return nil, nil, fmt.Errorf("invalid value for key %q: %w", poolKeyIPv6CIDRs, err)
+					return nil, fmt.Errorf("invalid value for key %q: %w", poolKeyIPv6CIDRs, err)
 				}
 				ipv6CIDRs = append(ipv6CIDRs, cilium_v2alpha1.PoolCIDR(cidr))
 			}
 		case poolKeyIPv6MaskSize:
 			mask, err := strconv.ParseUint(value, 10, 8)
 			if err != nil {
-				return nil, nil, fmt.Errorf("invalid value for key %q: %w", poolKeyIPv6MaskSize, err)
+				return nil, fmt.Errorf("invalid value for key %q: %w", poolKeyIPv6MaskSize, err)
 			}
 			ipv6MaskSize = uint8(mask)
+		case poolKeyAllowFirstIP:
+			parsed, err := strconv.ParseBool(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for key %q: %w", poolKeyAllowFirstIP, err)
+			}
+			allowFirstIP = parsed
+		case poolKeyAllowLastIP:
+			parsed, err := strconv.ParseBool(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for key %q: %w", poolKeyAllowLastIP, err)
+			}
+			allowLastIP = parsed
 		}
 	}
 
@@ -83,10 +105,15 @@ func ParsePoolSpec(poolString string) (*cilium_v2alpha1.IPv4PoolSpec, *cilium_v2
 		}
 	}
 
-	return v4PoolSpec, v6PoolSpec, nil
+	return &ParsedPoolSpec{
+		IPv4:         v4PoolSpec,
+		IPv6:         v6PoolSpec,
+		AllowFirstIP: allowFirstIP,
+		AllowLastIP:  allowLastIP,
+	}, nil
 }
 
-func UpsertPool(allocator *PoolAllocator, name string, v4Spec *cilium_v2alpha1.IPv4PoolSpec, v6Spec *cilium_v2alpha1.IPv6PoolSpec) error {
+func UpsertPool(allocator *PoolAllocator, name string, v4Spec *cilium_v2alpha1.IPv4PoolSpec, v6Spec *cilium_v2alpha1.IPv6PoolSpec, allowFirstIP, allowLastIP bool) error {
 	var ipv4CIDRs, ipv6CIDRs []string
 	var ipv4MaskSize, ipv6MaskSize int
 
@@ -106,12 +133,21 @@ func UpsertPool(allocator *PoolAllocator, name string, v4Spec *cilium_v2alpha1.I
 		}
 	}
 
+	var opts []PoolOption
+	if allowFirstIP {
+		opts = append(opts, WithAllowFirstIP())
+	}
+	if allowLastIP {
+		opts = append(opts, WithAllowLastIP())
+	}
+
 	return allocator.UpsertPool(
 		name,
 		ipv4CIDRs,
 		ipv4MaskSize,
 		ipv6CIDRs,
 		ipv6MaskSize,
+		opts...,
 	)
 }
 

--- a/pkg/ipam/eni.go
+++ b/pkg/ipam/eni.go
@@ -598,8 +598,10 @@ func eniPoolsFromResource(node *ciliumv2.CiliumNode) *ipamTypes.IPAMPoolSpec {
 	if len(cidrs) > 0 {
 		pools.Allocated = []ipamTypes.IPAMPoolAllocation{
 			{
-				Pool:  defaults.IPAMDefaultIPPool,
-				CIDRs: cidrs,
+				Pool:         defaults.IPAMDefaultIPPool,
+				AllowFirstIP: true,
+				AllowLastIP:  true,
+				CIDRs:        cidrs,
 			},
 		}
 	}
@@ -704,7 +706,6 @@ func newENIMultiPoolAllocators(p ENIMultiPoolAllocatorParams) (Allocator, Alloca
 		CNClient:             p.CNClient,
 		JobGroup:             p.JobGroup,
 		PoolsFromResource:    eniPoolsFromResource,
-		AllowFirstLastIPs:    true,
 		LinearPreAlloc:       true,
 	})
 

--- a/pkg/ipam/eni_test.go
+++ b/pkg/ipam/eni_test.go
@@ -505,6 +505,8 @@ func TestEniPoolsFromResource(t *testing.T) {
 		result := eniPoolsFromResource(node)
 		require.Len(t, result.Allocated, 1)
 		require.Equal(t, defaults.IPAMDefaultIPPool, result.Allocated[0].Pool)
+		require.True(t, result.Allocated[0].AllowFirstIP)
+		require.True(t, result.Allocated[0].AllowLastIP)
 		require.Contains(t, result.Allocated[0].CIDRs, iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.1/32")))
 		require.Contains(t, result.Allocated[0].CIDRs, iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.2/32")))
 	})
@@ -530,6 +532,8 @@ func TestEniPoolsFromResource(t *testing.T) {
 		result := eniPoolsFromResource(node)
 		require.Len(t, result.Allocated, 1)
 		require.Equal(t, defaults.IPAMDefaultIPPool, result.Allocated[0].Pool)
+		require.True(t, result.Allocated[0].AllowFirstIP)
+		require.True(t, result.Allocated[0].AllowLastIP)
 		// Should contain the /28 prefix and the primary IP as /32,
 		// but not the 16 expanded prefix IPs.
 		require.Contains(t, result.Allocated[0].CIDRs, iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.16/28")))
@@ -552,6 +556,8 @@ func TestEniPoolsFromResource(t *testing.T) {
 
 		result := eniPoolsFromResource(node)
 		require.Len(t, result.Allocated, 1)
+		require.True(t, result.Allocated[0].AllowFirstIP)
+		require.True(t, result.Allocated[0].AllowLastIP)
 		require.Len(t, result.Allocated[0].CIDRs, 1)
 		require.Contains(t, result.Allocated[0].CIDRs, iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.2/32")))
 	})

--- a/pkg/ipam/multipool_manager.go
+++ b/pkg/ipam/multipool_manager.go
@@ -685,10 +685,10 @@ func (m *multiPoolManager) upsertPoolLocked(poolName Pool, cidrs []iputil.Prefix
 	if !ok {
 		pool = &poolPair{}
 		if m.ipv4Enabled {
-			pool.v4 = newCIDRPool(m.logger, m.allowFirstLastIPs)
+			pool.v4 = newCIDRPool(m.logger, false, false)
 		}
 		if m.ipv6Enabled {
-			pool.v6 = newCIDRPool(m.logger, m.allowFirstLastIPs)
+			pool.v6 = newCIDRPool(m.logger, false, false)
 		}
 	}
 

--- a/pkg/ipam/multipool_manager.go
+++ b/pkg/ipam/multipool_manager.go
@@ -61,8 +61,10 @@ func (e *ErrPoolNotReadyYet) Is(err error) bool {
 }
 
 type poolPair struct {
-	v4 *cidrPool
-	v6 *cidrPool
+	v4           *cidrPool
+	v6           *cidrPool
+	allowFirstIP bool
+	allowLastIP  bool
 }
 
 type preAllocatePerPool map[Pool]int
@@ -239,10 +241,6 @@ type MultiPoolManagerParams struct {
 
 	SkipMasqueradeForPool SkipMasqueradeForPoolFn
 
-	// AllowFirstLastIPs makes CIDR pools include the first and last IPs.
-	// Used for ENI prefix delegation where the entire /28 is allocatable.
-	AllowFirstLastIPs bool
-
 	// LinearPreAlloc uses a simple inUse + preAlloc formula for demand
 	// computation instead of the multi-pool's neededIPCeil rounding. This
 	// matches the CRD allocator's calculateNeededIPs behavior and allows
@@ -277,8 +275,7 @@ type multiPoolManager struct {
 	poolsFromResource     ciliumv2.PoolsFromResourceFunc
 	skipMasqueradeForPool SkipMasqueradeForPoolFn
 
-	allowFirstLastIPs bool
-	linearPreAlloc    bool
+	linearPreAlloc bool
 }
 
 func newMultiPoolManager(p MultiPoolManagerParams) *multiPoolManager {
@@ -300,7 +297,6 @@ func newMultiPoolManager(p MultiPoolManagerParams) *multiPoolManager {
 			close(localNodeUpdated)
 		}),
 		poolsFromResource: p.PoolsFromResource,
-		allowFirstLastIPs: p.AllowFirstLastIPs,
 		linearPreAlloc:    p.LinearPreAlloc,
 		skipMasqueradeForPool: func(Pool) (bool, error) {
 			return false, nil
@@ -408,7 +404,7 @@ func (m *multiPoolManager) ciliumNodeUpdated(newNode *ciliumv2.CiliumNode) {
 	defer m.poolsMutex.Unlock()
 
 	for _, pool := range m.poolsFromResource(newNode).Allocated {
-		m.upsertPoolLocked(Pool(pool.Pool), pool.CIDRs)
+		m.upsertPoolLocked(Pool(pool.Pool), pool.CIDRs, pool.AllowFirstIP, pool.AllowLastIP)
 	}
 
 	// Sync pre-allocate value from the CiliumNode spec. For cloud IPAM modes,
@@ -613,8 +609,10 @@ func (m *multiPoolManager) updateLocalNode(ctx context.Context) error {
 		}
 
 		allocated = append(allocated, types.IPAMPoolAllocation{
-			Pool:  poolName.String(),
-			CIDRs: cidrs,
+			Pool:         poolName.String(),
+			AllowFirstIP: pool.allowFirstIP,
+			AllowLastIP:  pool.allowLastIP,
+			CIDRs:        cidrs,
 		})
 	}
 
@@ -680,16 +678,44 @@ func (m *multiPoolManager) updateLocalNode(ctx context.Context) error {
 	return nil
 }
 
-func (m *multiPoolManager) upsertPoolLocked(poolName Pool, cidrs []iputil.Prefix) {
+func (m *multiPoolManager) upsertPoolLocked(poolName Pool, cidrs []iputil.Prefix, allowFirstIP, allowLastIP bool) {
 	pool, ok := m.pools[poolName]
 	if !ok {
-		pool = &poolPair{}
+		pool = &poolPair{
+			allowFirstIP: allowFirstIP,
+			allowLastIP:  allowLastIP,
+		}
 		if m.ipv4Enabled {
-			pool.v4 = newCIDRPool(m.logger, false, false)
+			pool.v4 = newCIDRPool(m.logger, allowFirstIP, allowLastIP)
 		}
 		if m.ipv6Enabled {
-			pool.v6 = newCIDRPool(m.logger, false, false)
+			pool.v6 = newCIDRPool(m.logger, allowFirstIP, allowLastIP)
 		}
+	} else if pool.allowFirstIP != allowFirstIP || pool.allowLastIP != allowLastIP {
+		if pool.v4 != nil {
+			if pool.v4.inUseIPCount() == 0 {
+				pool.v4 = newCIDRPool(m.logger, allowFirstIP, allowLastIP)
+			} else {
+				m.logger.Warn(
+					"ignoring changed first/last IP settings for pool with in-use IPs",
+					logfields.PoolName, poolName,
+					logfields.Family, IPv4,
+				)
+			}
+		}
+		if pool.v6 != nil {
+			if pool.v6.inUseIPCount() == 0 {
+				pool.v6 = newCIDRPool(m.logger, allowFirstIP, allowLastIP)
+			} else {
+				m.logger.Warn(
+					"ignoring changed first/last IP settings for pool with in-use IPs",
+					logfields.PoolName, poolName,
+					logfields.Family, IPv6,
+				)
+			}
+		}
+		pool.allowFirstIP = allowFirstIP
+		pool.allowLastIP = allowLastIP
 	}
 
 	var ipv4Prefixes, ipv6Prefixes []netip.Prefix

--- a/pkg/ipam/multipool_test.go
+++ b/pkg/ipam/multipool_test.go
@@ -74,7 +74,8 @@ func Test_MultiPoolManager(t *testing.T) {
 							},
 						},
 						{
-							Pool: "mars",
+							Pool:        "mars",
+							AllowLastIP: true,
 							CIDRs: []iputil.Prefix{
 								iputil.PrefixFrom(marsIPv4CIDR1),
 								iputil.PrefixFrom(marsIPv6CIDR1),
@@ -160,7 +161,8 @@ func Test_MultiPoolManager(t *testing.T) {
 						},
 					},
 					{
-						Pool: "mars",
+						Pool:        "mars",
+						AllowLastIP: true,
 						CIDRs: []iputil.Prefix{
 							iputil.PrefixFrom(marsIPv4CIDR1),
 							iputil.PrefixFrom(marsIPv6CIDR1),
@@ -188,7 +190,8 @@ func Test_MultiPoolManager(t *testing.T) {
 				},
 			},
 			{
-				Pool: "mars",
+				Pool:        "mars",
+				AllowLastIP: true,
 				CIDRs: []iputil.Prefix{
 					iputil.PrefixFrom(marsIPv4CIDR1),
 					iputil.PrefixFrom(marsIPv6CIDR1),
@@ -294,7 +297,8 @@ func Test_MultiPoolManager(t *testing.T) {
 				},
 			},
 			{
-				Pool: "mars",
+				Pool:        "mars",
+				AllowLastIP: true,
 				CIDRs: []iputil.Prefix{
 					iputil.PrefixFrom(marsIPv6CIDR1),
 					iputil.PrefixFrom(marsIPv4CIDR1),
@@ -363,7 +367,8 @@ func Test_MultiPoolManager(t *testing.T) {
 						},
 					},
 					{
-						Pool: "mars",
+						Pool:        "mars",
+						AllowLastIP: true,
 						CIDRs: []iputil.Prefix{
 							iputil.PrefixFrom(marsIPv4CIDR1),
 							iputil.PrefixFrom(marsIPv6CIDR1),
@@ -373,9 +378,9 @@ func Test_MultiPoolManager(t *testing.T) {
 			}, currentNode.Spec.IPAM.Pools)
 		}, timeout, tick)
 
-		// exhaust mars ipv4 pool (/27 contains 30 IPs)
+		// exhaust mars ipv4 pool (/27 contains 31 IPs with allowLastIP enabled)
 		allocatedMarsIPs := []netip.Addr{}
-		numMarsIPs := 30
+		numMarsIPs := 31
 		for i := range numMarsIPs {
 			// set upstreamSync to true for last allocation, to ensure we only get one upsert event
 			ar, err := mgr.allocateNext(fmt.Sprintf("mars-pod-%d", i), "mars", IPv4, i == numMarsIPs-1)
@@ -407,7 +412,7 @@ func Test_MultiPoolManager(t *testing.T) {
 				{
 					Pool: "mars",
 					Needed: types.IPAMPoolDemand{
-						IPv4Addrs: 40, // 30 allocated + 8 pre-allocate, rounded up to multiple of 8
+						IPv4Addrs: 40, // 31 allocated + 8 pre-allocate, rounded up to multiple of 8
 						IPv6Addrs: 8,
 					},
 				},
@@ -430,7 +435,8 @@ func Test_MultiPoolManager(t *testing.T) {
 				},
 			},
 			{
-				Pool: "mars",
+				Pool:        "mars",
+				AllowLastIP: true,
 				CIDRs: []iputil.Prefix{
 					iputil.PrefixFrom(marsIPv4CIDR1),
 					iputil.PrefixFrom(marsIPv4CIDR2),
@@ -488,7 +494,8 @@ func Test_MultiPoolManager(t *testing.T) {
 					},
 				},
 				{
-					Pool: "mars",
+					Pool:        "mars",
+					AllowLastIP: true,
 					CIDRs: []iputil.Prefix{
 						iputil.PrefixFrom(marsIPv4CIDR2),
 						iputil.PrefixFrom(marsIPv6CIDR1),
@@ -1307,11 +1314,46 @@ func TestAllocateNext_SkipMasquerade(t *testing.T) {
 	require.False(t, res.SkipMasquerade, "SkipMasquerade should default to false")
 }
 
-func insertPool(t *testing.T, db *statedb.DB, tbl statedb.RWTable[podippool.LocalPodIPPool], name string, skipMasq bool) {
+func TestMultiPoolManagerUpdatesFirstLastIPSettingsBeforeAllocation(t *testing.T) {
+	logger := hivetest.Logger(t)
+	mgr := &multiPoolManager{
+		logger:       logger,
+		ipv4Enabled:  true,
+		pools:        map[Pool]*poolPair{},
+		poolsUpdated: make(chan struct{}, 1),
+		pendingIPsPerPool: newPendingAllocationsPerPool(
+			logger,
+		),
+		skipMasqueradeForPool: func(Pool) (bool, error) {
+			return false, nil
+		},
+	}
+
+	prefix := iputil.PrefixFrom(netip.MustParsePrefix("10.20.0.0/30"))
+	lastIP := netip.MustParseAddr("10.20.0.3")
+
+	mgr.upsertPoolLocked("default", []iputil.Prefix{prefix}, false, false)
+	_, err := mgr.allocateIP(lastIP, "pod-a", "default", IPv4, false)
+	require.Error(t, err)
+
+	mgr.upsertPoolLocked("default", []iputil.Prefix{prefix}, false, true)
+	result, err := mgr.allocateIP(lastIP, "pod-a", "default", IPv4, false)
+	require.NoError(t, err)
+	require.Equal(t, lastIP, result.IP)
+}
+
+func insertPool(t *testing.T, db *statedb.DB, tbl statedb.RWTable[podippool.LocalPodIPPool], name string, skipMasq bool, allowFirstAndLastIPs ...bool) {
 	t.Helper()
 	ann := map[string]string{}
 	if skipMasq {
 		ann[annotation.IPAMSkipMasquerade] = "true"
+	}
+	var allowFirstIP, allowLastIP bool
+	if len(allowFirstAndLastIPs) > 0 {
+		allowFirstIP = allowFirstAndLastIPs[0]
+	}
+	if len(allowFirstAndLastIPs) > 1 {
+		allowLastIP = allowFirstAndLastIPs[1]
 	}
 
 	poolObj := podippool.LocalPodIPPool{
@@ -1319,6 +1361,10 @@ func insertPool(t *testing.T, db *statedb.DB, tbl statedb.RWTable[podippool.Loca
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        name,
 				Annotations: ann,
+			},
+			Spec: k8sv2alpha1.IPPoolSpec{
+				AllowFirstIP: allowFirstIP,
+				AllowLastIP:  allowLastIP,
 			},
 		},
 		UpdatedAt: time.Now(),

--- a/pkg/ipam/podippool/podippool.go
+++ b/pkg/ipam/podippool/podippool.go
@@ -71,6 +71,12 @@ func (p LocalPodIPPool) TableRow() []string {
 	if v, ok := p.ObjectMeta.Annotations[annotation.IPAMSkipMasquerade]; ok && v == "true" {
 		flags = append(flags, "SkipMasquerade=true")
 	}
+	if p.Spec.AllowFirstIP {
+		flags = append(flags, "AllowFirstIP=true")
+	}
+	if p.Spec.AllowLastIP {
+		flags = append(flags, "AllowLastIP=true")
+	}
 
 	return []string{
 		p.Name,

--- a/pkg/ipam/podippool/testdata/podippool.txtar
+++ b/pkg/ipam/podippool/testdata/podippool.txtar
@@ -95,6 +95,8 @@ ciliumpodippool:
             cidrs:
                 - fd00::/112
             masksize: 120
+        allowfirstip: false
+        allowlastip: false
         podselector: null
         namespaceselector: null
 updatedAt: 2000-01-01T10:30:00Z

--- a/pkg/ipam/pool.go
+++ b/pkg/ipam/pool.go
@@ -40,19 +40,21 @@ type cidrPool struct {
 	ipAllocators []*ipallocator.Range
 	released     map[netip.Prefix]struct{}
 	removed      map[netip.Prefix]struct{}
-	// allowFirstLastIPs, when true, makes the pool include the first and last
-	// IPs of each CIDR (normally reserved as network/broadcast). This is used
-	// for delegated prefixes where the entire range is exclusively assigned.
-	allowFirstLastIPs bool
+	// allowFirstIP and allowLastIP make the pool include the first and last IPs
+	// of each CIDR (normally reserved as network/broadcast). This is used for
+	// delegated prefixes where the range is exclusively assigned.
+	allowFirstIP bool
+	allowLastIP  bool
 }
 
 // newCIDRPool creates a new CIDR pool.
-func newCIDRPool(logger *slog.Logger, allowFirstLastIPs bool) *cidrPool {
+func newCIDRPool(logger *slog.Logger, allowFirstIP, allowLastIP bool) *cidrPool {
 	return &cidrPool{
-		logger:            logger,
-		released:          map[netip.Prefix]struct{}{},
-		removed:           map[netip.Prefix]struct{}{},
-		allowFirstLastIPs: allowFirstLastIPs,
+		logger:       logger,
+		released:     map[netip.Prefix]struct{}{},
+		removed:      map[netip.Prefix]struct{}{},
+		allowFirstIP: allowFirstIP,
+		allowLastIP:  allowLastIP,
 	}
 }
 
@@ -276,8 +278,11 @@ func (p *cidrPool) updatePool(prefixes []netip.Prefix) {
 
 	// Create and add new IP allocators to newIPAllocators.
 	var rangeOpts []ipallocator.CIDRRangeOption
-	if p.allowFirstLastIPs {
-		rangeOpts = append(rangeOpts, ipallocator.WithAllowFirstLastIPs())
+	if p.allowFirstIP {
+		rangeOpts = append(rangeOpts, ipallocator.WithAllowFirstIP())
+	}
+	if p.allowLastIP {
+		rangeOpts = append(rangeOpts, ipallocator.WithAllowLastIP())
 	}
 	for _, prefix := range prefixes {
 		if _, ok := existingAllocators[prefix]; ok {

--- a/pkg/ipam/pool_test.go
+++ b/pkg/ipam/pool_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCIDRPoolAllowFirstLastIPs(t *testing.T) {
+func TestCIDRPoolAllowFirstAndLastIPs(t *testing.T) {
 	logger := hivetest.Logger(t)
 
 	t.Run("default excludes first and last", func(t *testing.T) {
-		pool := newCIDRPool(logger, false)
+		pool := newCIDRPool(logger, false, false)
 		pool.updatePool([]netip.Prefix{netip.MustParsePrefix("10.0.0.0/28")})
 
 		// /28 = 16 IPs, minus first and last = 14 usable
@@ -30,8 +30,26 @@ func TestCIDRPoolAllowFirstLastIPs(t *testing.T) {
 		require.NoError(t, pool.allocate(netip.MustParseAddr("10.0.0.14")))
 	})
 
-	t.Run("allowFirstLastIPs includes all IPs", func(t *testing.T) {
-		pool := newCIDRPool(logger, true)
+	t.Run("allowFirstIP includes first IP", func(t *testing.T) {
+		pool := newCIDRPool(logger, true, false)
+		pool.updatePool([]netip.Prefix{netip.MustParsePrefix("10.0.0.0/28")})
+
+		require.Equal(t, 15, pool.capacity())
+		require.NoError(t, pool.allocate(netip.MustParseAddr("10.0.0.0")))
+		require.Error(t, pool.allocate(netip.MustParseAddr("10.0.0.15")))
+	})
+
+	t.Run("allowLastIP includes last IP", func(t *testing.T) {
+		pool := newCIDRPool(logger, false, true)
+		pool.updatePool([]netip.Prefix{netip.MustParsePrefix("10.0.0.0/28")})
+
+		require.Equal(t, 15, pool.capacity())
+		require.Error(t, pool.allocate(netip.MustParseAddr("10.0.0.0")))
+		require.NoError(t, pool.allocate(netip.MustParseAddr("10.0.0.15")))
+	})
+
+	t.Run("allowFirstIP and allowLastIP includes all IPs", func(t *testing.T) {
+		pool := newCIDRPool(logger, true, true)
 		pool.updatePool([]netip.Prefix{netip.MustParsePrefix("10.0.0.0/28")})
 
 		// /28 = 16 IPs, all usable
@@ -42,8 +60,8 @@ func TestCIDRPoolAllowFirstLastIPs(t *testing.T) {
 		require.NoError(t, pool.allocate(netip.MustParseAddr("10.0.0.15")))
 	})
 
-	t.Run("allowFirstLastIPs with multiple CIDRs", func(t *testing.T) {
-		pool := newCIDRPool(logger, true)
+	t.Run("allowFirstIP and allowLastIP with multiple CIDRs", func(t *testing.T) {
+		pool := newCIDRPool(logger, true, true)
 		pool.updatePool([]netip.Prefix{netip.MustParsePrefix("10.0.0.0/28"), netip.MustParsePrefix("10.0.0.16/28")})
 
 		require.Equal(t, 32, pool.capacity())

--- a/pkg/ipam/service/ipallocator/allocator.go
+++ b/pkg/ipam/service/ipallocator/allocator.go
@@ -42,16 +42,35 @@ func (e *ErrNotInRange) Error() string {
 type CIDRRangeOption func(*cidrRangeOptions)
 
 type cidrRangeOptions struct {
-	allowFirstLastIPs bool
+	allowFirstIP bool
+	allowLastIP  bool
+}
+
+// WithAllowFirstIP configures the Range to include the first IP of the CIDR
+// (normally reserved as the network address). This is useful for delegated
+// prefixes where the entire range is exclusively assigned.
+func WithAllowFirstIP() CIDRRangeOption {
+	return func(o *cidrRangeOptions) {
+		o.allowFirstIP = true
+	}
+}
+
+// WithAllowLastIP configures the Range to include the last IP of the CIDR
+// (normally reserved as the broadcast address). This is useful for delegated
+// prefixes where the entire range is exclusively assigned.
+func WithAllowLastIP() CIDRRangeOption {
+	return func(o *cidrRangeOptions) {
+		o.allowLastIP = true
+	}
 }
 
 // WithAllowFirstLastIPs configures the Range to include the first and last IPs
-// of the CIDR (normally reserved as network and broadcast addresses). This is
-// useful for delegated prefixes (e.g. AWS /28 prefix delegation) where the
-// entire range is exclusively assigned and there is no shared network segment.
+// of the CIDR. This is kept as a convenience wrapper for callers that need both
+// addresses.
 func WithAllowFirstLastIPs() CIDRRangeOption {
 	return func(o *cidrRangeOptions) {
-		o.allowFirstLastIPs = true
+		o.allowFirstIP = true
+		o.allowLastIP = true
 	}
 }
 
@@ -84,7 +103,8 @@ type Range struct {
 // NewCIDRRange creates a Range over a netip.Prefix, calling allocator.NewAllocationMap
 // to construct the backing store. By default, the first (network) and last
 // (broadcast) addresses are excluded for CIDRs with more than 2 addresses.
-// Pass functional options (e.g. WithAllowFirstLastIPs) to alter this behavior.
+// Pass functional options (e.g. WithAllowFirstIP, WithAllowLastIP) to alter
+// this behavior.
 func NewCIDRRange(prefix netip.Prefix, opts ...CIDRRangeOption) *Range {
 	var o cidrRangeOptions
 	for _, opt := range opts {
@@ -95,12 +115,15 @@ func NewCIDRRange(prefix netip.Prefix, opts ...CIDRRangeOption) *Range {
 	base := prefix.Addr()
 	size := RangeSize(prefix)
 
-	// for any CIDR other than /32 or /128:
-	if size > 2 && !o.allowFirstLastIPs {
-		// don't use the network broadcast
-		size = max(0, size-2)
-		// don't use the network base
-		base = base.Next()
+	// for any CIDR other than /31, /32, /127 or /128:
+	if size > 2 {
+		if !o.allowFirstIP {
+			size--
+			base = base.Next()
+		}
+		if !o.allowLastIP {
+			size--
+		}
 	}
 
 	return &Range{

--- a/pkg/ipam/service/ipallocator/allocator_test.go
+++ b/pkg/ipam/service/ipallocator/allocator_test.go
@@ -107,6 +107,22 @@ func TestNewCIDRRangeWithAllowFirstLastIPs(t *testing.T) {
 	}
 }
 
+func TestNewCIDRRangeWithAllowFirstOrLastIP(t *testing.T) {
+	prefix := netip.MustParsePrefix("10.0.0.0/28")
+
+	first := NewCIDRRange(prefix, WithAllowFirstIP())
+	require.Equal(t, netip.MustParseAddr("10.0.0.0"), first.base)
+	require.Equal(t, 15, first.max)
+	require.NoError(t, first.Allocate(netip.MustParseAddr("10.0.0.0")))
+	require.ErrorContains(t, first.Allocate(netip.MustParseAddr("10.0.0.15")), "not in the valid range")
+
+	last := NewCIDRRange(prefix, WithAllowLastIP())
+	require.Equal(t, netip.MustParseAddr("10.0.0.1"), last.base)
+	require.Equal(t, 15, last.max)
+	require.ErrorContains(t, last.Allocate(netip.MustParseAddr("10.0.0.0")), "not in the valid range")
+	require.NoError(t, last.Allocate(netip.MustParseAddr("10.0.0.15")))
+}
+
 func TestAllowFirstLastIPsAllocateAll(t *testing.T) {
 	// Verify all 16 IPs in a /28 are allocatable with WithAllowFirstLastIPs.
 	prefix := netip.MustParsePrefix("10.0.0.0/28")

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -64,6 +64,16 @@ type IPAMPoolAllocation struct {
 	// +kubebuilder:validation:MinLength=1
 	Pool string `json:"pool"`
 
+	// AllowFirstIP allows the first IP of each allocated CIDR to be used.
+	//
+	// +optional
+	AllowFirstIP bool `json:"allowFirstIP,omitempty"`
+
+	// AllowLastIP allows the last IP of each allocated CIDR to be used.
+	//
+	// +optional
+	AllowLastIP bool `json:"allowLastIP,omitempty"`
+
 	// CIDRs contains a list of pod CIDRs currently allocated from this pool
 	//
 	// +optional

--- a/pkg/ipam/types/zz_generated.deepequal.go
+++ b/pkg/ipam/types/zz_generated.deepequal.go
@@ -59,6 +59,12 @@ func (in *IPAMPoolAllocation) DeepEqual(other *IPAMPoolAllocation) bool {
 	if in.Pool != other.Pool {
 		return false
 	}
+	if in.AllowFirstIP != other.AllowFirstIP {
+		return false
+	}
+	if in.AllowLastIP != other.AllowLastIP {
+		return false
+	}
 	if ((in.CIDRs != nil) && (other.CIDRs != nil)) || ((in.CIDRs == nil) != (other.CIDRs == nil)) {
 		in, other := &in.CIDRs, &other.CIDRs
 		if other == nil {

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -356,6 +356,14 @@ spec:
                             IPAMPoolAllocation describes an allocation of an IPAM pool from the operator to the
                             node. It contains the assigned PodCIDRs allocated from this pool
                           properties:
+                            allowFirstIP:
+                              description: AllowFirstIP allows the first IP of each
+                                allocated CIDR to be used.
+                              type: boolean
+                            allowLastIP:
+                              description: AllowLastIP allows the last IP of each
+                                allocated CIDR to be used.
+                              type: boolean
                             cidrs:
                               description: CIDRs contains a list of pod CIDRs currently
                                 allocated from this pool

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumpodippools.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumpodippools.yaml
@@ -44,6 +44,28 @@ spec:
             type: object
           spec:
             properties:
+              allowFirstIP:
+                default: false
+                description: |-
+                  AllowFirstIP allows the first IP of each allocated CIDR to be used. If
+                  unset or false, this IP is reserved. This field is ignored for /{31,32}
+                  and /{127,128} CIDRs since reserving the first and last IPs would make
+                  the CIDRs unusable. This field is immutable.
+                type: boolean
+                x-kubernetes-validations:
+                - message: allowFirstIP is immutable
+                  rule: self == oldSelf
+              allowLastIP:
+                default: false
+                description: |-
+                  AllowLastIP allows the last IP of each allocated CIDR to be used. If
+                  unset or false, this IP is reserved. This field is ignored for /{31,32}
+                  and /{127,128} CIDRs since reserving the first and last IPs would make
+                  the CIDRs unusable. This field is immutable.
+                type: boolean
+                x-kubernetes-validations:
+                - message: allowLastIP is immutable
+                  rule: self == oldSelf
               ipv4:
                 description: IPv4 specifies the IPv4 CIDRs and mask sizes of the pool
                 properties:
@@ -62,6 +84,9 @@ spec:
                     maximum: 32
                     minimum: 1
                     type: integer
+                    x-kubernetes-validations:
+                    - message: maskSize is immutable
+                      rule: self == oldSelf
                   pool:
                     description: |-
                       Pool contains per-CIDR configuration for a subset of CIDRs listed in CIDRs.
@@ -123,6 +148,9 @@ spec:
                     maximum: 128
                     minimum: 1
                     type: integer
+                    x-kubernetes-validations:
+                    - message: maskSize is immutable
+                      rule: self == oldSelf
                   pool:
                     description: |-
                       Pool contains per-CIDR configuration for a subset of CIDRs listed in CIDRs.
@@ -327,6 +355,28 @@ spec:
             type: object
           spec:
             properties:
+              allowFirstIP:
+                default: false
+                description: |-
+                  AllowFirstIP allows the first IP of each allocated CIDR to be used. If
+                  unset or false, this IP is reserved. This field is ignored for /{31,32}
+                  and /{127,128} CIDRs since reserving the first and last IPs would make
+                  the CIDRs unusable. This field is immutable.
+                type: boolean
+                x-kubernetes-validations:
+                - message: allowFirstIP is immutable
+                  rule: self == oldSelf
+              allowLastIP:
+                default: false
+                description: |-
+                  AllowLastIP allows the last IP of each allocated CIDR to be used. If
+                  unset or false, this IP is reserved. This field is ignored for /{31,32}
+                  and /{127,128} CIDRs since reserving the first and last IPs would make
+                  the CIDRs unusable. This field is immutable.
+                type: boolean
+                x-kubernetes-validations:
+                - message: allowLastIP is immutable
+                  rule: self == oldSelf
               ipv4:
                 description: IPv4 specifies the IPv4 CIDRs and mask sizes of the pool
                 properties:
@@ -344,6 +394,9 @@ spec:
                     maximum: 32
                     minimum: 1
                     type: integer
+                    x-kubernetes-validations:
+                    - message: maskSize is immutable
+                      rule: self == oldSelf
                 required:
                 - cidrs
                 - maskSize
@@ -365,6 +418,9 @@ spec:
                     maximum: 128
                     minimum: 1
                     type: integer
+                    x-kubernetes-validations:
+                    - message: maskSize is immutable
+                      rule: self == oldSelf
                 required:
                 - cidrs
                 - maskSize

--- a/pkg/k8s/apis/cilium.io/v2/ippool_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/ippool_types.go
@@ -40,6 +40,26 @@ type IPPoolSpec struct {
 	// +kubebuilder:validation:Optional
 	IPv6 *IPv6PoolSpec `json:"ipv6,omitempty"`
 
+	// AllowFirstIP allows the first IP of each allocated CIDR to be used. If
+	// unset or false, this IP is reserved. This field is ignored for /{31,32}
+	// and /{127,128} CIDRs since reserving the first and last IPs would make
+	// the CIDRs unusable. This field is immutable.
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="allowFirstIP is immutable"
+	AllowFirstIP bool `json:"allowFirstIP,omitempty"`
+
+	// AllowLastIP allows the last IP of each allocated CIDR to be used. If
+	// unset or false, this IP is reserved. This field is ignored for /{31,32}
+	// and /{127,128} CIDRs since reserving the first and last IPs would make
+	// the CIDRs unusable. This field is immutable.
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="allowLastIP is immutable"
+	AllowLastIP bool `json:"allowLastIP,omitempty"`
+
 	// PodSelector selects the set of Pods that are eligible to receive IPs from
 	// this pool when neither the Pod nor its Namespace specify an explicit
 	// `ipam.cilium.io/*` annotation.
@@ -82,6 +102,7 @@ type IPv4PoolSpec struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=32
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="maskSize is immutable"
 	MaskSize uint8 `json:"maskSize"`
 
 	// Pool contains per-CIDR configuration for a subset of CIDRs listed in CIDRs.
@@ -108,6 +129,7 @@ type IPv6PoolSpec struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=128
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="maskSize is immutable"
 	MaskSize uint8 `json:"maskSize"`
 
 	// Pool contains per-CIDR configuration for a subset of CIDRs listed in CIDRs.

--- a/pkg/k8s/apis/cilium.io/v2/zz_generated.deepequal.go
+++ b/pkg/k8s/apis/cilium.io/v2/zz_generated.deepequal.go
@@ -2200,6 +2200,12 @@ func (in *IPPoolSpec) DeepEqual(other *IPPoolSpec) bool {
 		}
 	}
 
+	if in.AllowFirstIP != other.AllowFirstIP {
+		return false
+	}
+	if in.AllowLastIP != other.AllowLastIP {
+		return false
+	}
 	if (in.PodSelector == nil) != (other.PodSelector == nil) {
 		return false
 	} else if in.PodSelector != nil {

--- a/pkg/k8s/apis/cilium.io/v2alpha1/ippool_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/ippool_types.go
@@ -40,6 +40,26 @@ type IPPoolSpec struct {
 	// +kubebuilder:validation:Optional
 	IPv6 *IPv6PoolSpec `json:"ipv6,omitempty"`
 
+	// AllowFirstIP allows the first IP of each allocated CIDR to be used. If
+	// unset or false, this IP is reserved. This field is ignored for /{31,32}
+	// and /{127,128} CIDRs since reserving the first and last IPs would make
+	// the CIDRs unusable. This field is immutable.
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="allowFirstIP is immutable"
+	AllowFirstIP bool `json:"allowFirstIP,omitempty"`
+
+	// AllowLastIP allows the last IP of each allocated CIDR to be used. If
+	// unset or false, this IP is reserved. This field is ignored for /{31,32}
+	// and /{127,128} CIDRs since reserving the first and last IPs would make
+	// the CIDRs unusable. This field is immutable.
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="allowLastIP is immutable"
+	AllowLastIP bool `json:"allowLastIP,omitempty"`
+
 	// PodSelector selects the set of Pods that are eligible to receive IPs from
 	// this pool when neither the Pod nor its Namespace specify an explicit
 	// `ipam.cilium.io/*` annotation.
@@ -80,6 +100,7 @@ type IPv4PoolSpec struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=32
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="maskSize is immutable"
 	MaskSize uint8 `json:"maskSize"`
 }
 
@@ -95,6 +116,7 @@ type IPv6PoolSpec struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=128
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="maskSize is immutable"
 	MaskSize uint8 `json:"maskSize"`
 }
 

--- a/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
@@ -1449,6 +1449,12 @@ func (in *IPPoolSpec) DeepEqual(other *IPPoolSpec) bool {
 		}
 	}
 
+	if in.AllowFirstIP != other.AllowFirstIP {
+		return false
+	}
+	if in.AllowLastIP != other.AllowLastIP {
+		return false
+	}
 	if (in.PodSelector == nil) != (other.PodSelector == nil) {
 		return false
 	} else if in.PodSelector != nil {

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -1154,6 +1154,10 @@ const (
 
 	PoolName = "poolName"
 
+	AllowFirstIP = "allowFirstIP"
+
+	AllowLastIP = "allowLastIP"
+
 	MaxRetries = "maxRetries"
 
 	Retries = "retries"


### PR DESCRIPTION
Fixes #46201

## Summary

Add `spec.allowFirstLastIPs` to `CiliumPodIPPool` so Multi-Pool IPAM users can opt into allocating the first and last IPs from each per-node CIDR.

This wires the setting through:

- the `CiliumPodIPPool` API types and generated CRD schema
- Helm `autoCreateCiliumPodIPPools`
- the operator Multi-Pool allocator capacity calculation
- the agent-side Multi-Pool CIDR allocator via the local Pod IP pool table

The default remains `false`, preserving the existing reservation behavior.

## Testing

- `GOOS=linux go test -c ./operator/pkg/ipam/allocator/multipool -o /tmp/cilium-multipool.test`
- `GOOS=linux go test -c ./pkg/ipam -o /tmp/cilium-ipam.test`

Full test execution was not possible in this macOS workspace because the Cilium packages pull in Linux-only APIs, and Linux test binaries cannot be executed locally on macOS.

```release-note
Add `spec.allowFirstIP` and `spec.allowLastIP` to `CiliumPodIPPool` to allow Multi-Pool IPAM users to make the first and last IPs of each allocated pod CIDR allocatable.
```

This PR was prepared with AIL:3. I checked the issue scope, implementation, generated schema updates, and local compile checks.
