### PR TITLE
gateway-api: fix unit test due to service name label

### DIFF
--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -413,8 +413,9 @@ func Test_desiredEndpointSlice(t *testing.T) {
 			Name:      "cilium-gateway-dummy-gateway",
 			Namespace: "dummy-namespace",
 			Labels: map[string]string{
-				owningGatewayLabel: "dummy-gateway",
-				gatewayNameLabel:   "dummy-gateway",
+				owningGatewayLabel:           "dummy-gateway",
+				gatewayNameLabel:             "dummy-gateway",
+				discoveryv1.LabelServiceName: "cilium-gateway-dummy-gateway",
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{


### PR DESCRIPTION
Fixes: https://github.com/cilium/cilium/pull/46242 (merge race with https://github.com/cilium/cilium/pull/46237)