### PR TITLE
Fix ipv6 neighbor solicitation handling in host firewall

### DIFF
--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -493,7 +493,7 @@ icmp6_host_handle(struct __ctx_buff *ctx, int l4_off, __s8 *ext_err, bool handle
 	 * |      ICMPv6-mult-list-done      |   CTX_ACT_OK    |  132 |
 	 * |      ICMPv6-router-solici       |   CTX_ACT_OK    |  133 |
 	 * |      ICMPv6-router-advert       |   CTX_ACT_OK    |  134 |
-	 * |     ICMPv6-neighbor-solicit     | icmp6_handle_ns |  135 |
+	 * |     ICMPv6-neighbor-solicit     |   CTX_ACT_OK    |  135 |
 	 * |      ICMPv6-neighbor-advert     |   CTX_ACT_OK    |  136 |
 	 * |     ICMPv6-redirect-message     |  CTX_ACT_DROP   |  137 |
 	 * |      ICMPv6-router-renumber     |   CTX_ACT_OK    |  138 |
@@ -520,9 +520,6 @@ icmp6_host_handle(struct __ctx_buff *ctx, int l4_off, __s8 *ext_err, bool handle
 	 * |       ICMPv6-unallocated        |  CTX_ACT_DROP   |      |
 	 * |       ICMPv6-unassigned         |  CTX_ACT_DROP   |      |
 	 */
-
-	if (type == ICMP6_NS_MSG_TYPE)
-		return CTX_ACT_OK;
 
 	if (type == ICMPV6_ECHO_REQUEST || type == ICMPV6_ECHO_REPLY)
 		/* Decision is deferred to the host policies. */


### PR DESCRIPTION
This PR returns IPv6 neighbor solicitation ICMP packet handling to the original logic as it was introduced in commits 5244b68 and 8b62a2b after an incomplete revert of commit 6580714 in commit dc9dfd7. This keeps the in-bpf neighbor solicitation responder logic introduced in dc9dfd7, but also prevents host-originating neighbor solicitation packets from hitting host egress policy, as was originally intended in 8b62a2b. Without this change, using IPv6 in a cluster running Cilium with host firewall requires explicit egress rules on the host allowing host-originating neighbor soliciation packets, which (as originally noted in 5244b68) does not match how Cilium handles IPv4 ARP packets.

The new connectivity test `host-firewall-egress-to-fqdns` introduced by #45026 covers this change.

```release-note
bpf: fix ipv6 neighbor solicitation handling in host firewall
```