### PR TITLE
azure: Return actual public IP from AssignPublicIPAddresses{VMSS,VM}

### DIFF
--- a/operator/pkg/ipam/nodemanager/node.go
+++ b/operator/pkg/ipam/nodemanager/node.go
@@ -323,6 +323,28 @@ func (n *Node) getStaticIPTags() ipamTypes.Tags {
 	return ipamTypes.Tags{}
 }
 
+// staticIPNeedsResolution reports whether the recorded static IP needs to be
+// (re)resolved through the cloud provider. This is the case when no IP has been
+// assigned yet, or when the stored value is not a valid IP address.
+//
+// The latter handles a migration: earlier operator versions persisted the Azure
+// public IP prefix/address resource ID as a placeholder instead of the actual
+// address. Such legacy values fail to parse as an IP, so they are re-resolved
+// and overwritten with the real address on the next maintenance run. Providers
+// that already record an IP (e.g. AWS) parse cleanly and are left untouched.
+//
+// TODO: the non-IP (resource ID) branch only exists to migrate values persisted
+// by 1.19 azure operators and can be removed in 1.21, once all AssignedStaticIP
+// values are guaranteed to have been updated to actual IP addresses by 1.20
+// operators.
+func staticIPNeedsResolution(assignedStaticIP string) bool {
+	if assignedStaticIP == "" {
+		return true
+	}
+	_, err := netip.ParseAddr(assignedStaticIP)
+	return err != nil
+}
+
 // GetNeededAddresses returns the number of needed addresses that need to be
 // allocated or released. A positive number is returned to indicate allocation.
 // A negative number is returned to indicate release of addresses.
@@ -734,7 +756,7 @@ func (n *Node) allocationNeeded() bool {
 		return false
 	}
 
-	if len(n.getStaticIPTags()) > 0 && n.stats.IPv4.AssignedStaticIP == "" {
+	if len(n.getStaticIPTags()) > 0 && staticIPNeedsResolution(n.stats.IPv4.AssignedStaticIP) {
 		return true
 	}
 
@@ -1268,7 +1290,7 @@ func (n *Node) maintainIPPool(ctx context.Context) (instanceMutated bool, err er
 	if len(n.getStaticIPTags()) > 0 {
 		nodeStats := n.Stats()
 
-		if nodeStats.IPv4.AssignedStaticIP == "" {
+		if staticIPNeedsResolution(nodeStats.IPv4.AssignedStaticIP) {
 			ip, err := n.ops.AllocateStaticIP(ctx, n.getStaticIPTags())
 			if err != nil {
 				return false, err

--- a/operator/pkg/ipam/nodemanager/node_test.go
+++ b/operator/pkg/ipam/nodemanager/node_test.go
@@ -80,6 +80,44 @@ func TestCalculateExcessIPs(t *testing.T) {
 	}
 }
 
+func TestStaticIPNeedsResolution(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		assignedStaticIP string
+		want             bool
+	}{
+		{
+			name:             "empty value not yet assigned",
+			assignedStaticIP: "",
+			want:             true,
+		},
+		{
+			name:             "legacy azure public IP prefix resource ID",
+			assignedStaticIP: "/subscriptions/0000/resourceGroups/rg/providers/Microsoft.Network/publicIPPrefixes/prefix",
+			want:             true,
+		},
+		{
+			name:             "legacy azure public IP resource ID",
+			assignedStaticIP: "/subscriptions/0000/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/cilium-managed-public-ip",
+			want:             true,
+		},
+		{
+			name:             "valid IPv4 address",
+			assignedStaticIP: "203.0.113.7",
+			want:             false,
+		},
+		{
+			name:             "valid IPv6 address",
+			assignedStaticIP: "2001:db8::1",
+			want:             false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, staticIPNeedsResolution(tc.assignedStaticIP))
+		})
+	}
+}
+
 type k8sMockNode struct{}
 
 func (k *k8sMockNode) Update(origNode, newNode *v2.CiliumNode) (*v2.CiliumNode, error) {

--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -34,6 +34,8 @@ const (
 	interfacesGet                   = "Interfaces.Get"
 	interfacesList                  = "Interfaces.List"
 	publicIPPrefixesList            = "PublicIPPrefixes.List"
+	publicIPAddressesGet            = "PublicIPAddresses.Get"
+	publicIPAddressesListVMSS       = "PublicIPAddresses.ListVirtualMachineScaleSetVMPublicIPAddresses"
 	virtualMachinesGet              = "VirtualMachines.Get"
 	virtualMachineScaleSetsList     = "VirtualMachineScaleSets.List"
 	virtualMachineScaleSetVMsGet    = "VirtualMachineScaleSetVMs.Get"
@@ -51,6 +53,7 @@ type Client struct {
 	resourceGroup             string
 	interfaces                *armnetwork.InterfacesClient
 	publicIPPrefixes          *armnetwork.PublicIPPrefixesClient
+	publicIPAddresses         *armnetwork.PublicIPAddressesClient
 	virtualMachines           *armcompute.VirtualMachinesClient
 	subnets                   *armnetwork.SubnetsClient
 	virtualMachineScaleSetVMs *armcompute.VirtualMachineScaleSetVMsClient
@@ -155,12 +158,18 @@ func NewClient(logger *slog.Logger, cloudName, subscriptionID, resourceGroup, us
 		return nil, err
 	}
 
+	publicIPAddressesClient, err := armnetwork.NewPublicIPAddressesClient(subscriptionID, credential, armClientOptions)
+	if err != nil {
+		return nil, err
+	}
+
 	c := &Client{
 		logger:                    logger,
 		subscriptionID:            subscriptionID,
 		resourceGroup:             resourceGroup,
 		interfaces:                interfacesClient,
 		publicIPPrefixes:          publicIPPrefixesClient,
+		publicIPAddresses:         publicIPAddressesClient,
 		virtualMachines:           virtualMachinesClient,
 		subnets:                   subnetsClient,
 		virtualMachineScaleSetVMs: virtualMachineScaleSetVMsClient,
@@ -743,15 +752,102 @@ func (c *Client) AssignPrivateIpAddressesVM(ctx context.Context, subnetID, inter
 	return nil
 }
 
+// getVMSSPublicIP returns the public IP address assigned to the primary NIC of a VMSS VM instance.
+// It lists the instance's NICs to locate the primary IP configuration, then queries the Azure
+// public IP addresses API scoped to that VMSS VM.
+func (c *Client) getVMSSPublicIP(ctx context.Context, vmssName, instanceNum string) (ip netip.Addr, err error) {
+	nics, err := c.listVirtualMachineScaleSetVMNetworkInterfaces(ctx, vmssName, instanceNum)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("failed to list NICs for instance %s in VMSS %s: %w", instanceNum, vmssName, err)
+	}
+
+	var primaryNICName, primaryIPConfigName string
+	for _, nic := range nics {
+		if nic.Properties == nil || nic.Properties.Primary == nil || !*nic.Properties.Primary || nic.Name == nil {
+			continue
+		}
+		primaryNICName = *nic.Name
+		for _, ipConfig := range nic.Properties.IPConfigurations {
+			if ipConfig.Properties == nil || ipConfig.Properties.Primary == nil || !*ipConfig.Properties.Primary || ipConfig.Name == nil {
+				continue
+			}
+			primaryIPConfigName = *ipConfig.Name
+			break
+		}
+		break
+	}
+
+	if primaryNICName == "" {
+		return netip.Addr{}, fmt.Errorf("no primary NIC found for instance %s in VMSS %s", instanceNum, vmssName)
+	}
+	if primaryIPConfigName == "" {
+		return netip.Addr{}, fmt.Errorf("no primary IP configuration found on NIC %s for instance %s in VMSS %s", primaryNICName, instanceNum, vmssName)
+	}
+
+	c.limiter.Limit(ctx, publicIPAddressesListVMSS)
+	sinceStart := spanstat.Start()
+	pager := c.publicIPAddresses.NewListVirtualMachineScaleSetVMPublicIPAddressesPager(c.resourceGroup, vmssName, instanceNum, primaryNICName, primaryIPConfigName, nil)
+
+	defer func() {
+		c.metricsAPI.ObserveAPICall(publicIPAddressesListVMSS, deriveStatus(err), sinceStart.Seconds())
+	}()
+
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return netip.Addr{}, fmt.Errorf("failed to list public IPs for instance %s in VMSS %s: %w", instanceNum, vmssName, err)
+		}
+		for _, pip := range page.Value {
+			if pip.Properties != nil && pip.Properties.IPAddress != nil {
+				addr, err := netip.ParseAddr(*pip.Properties.IPAddress)
+				if err != nil {
+					return netip.Addr{}, fmt.Errorf("failed to parse public IP %q for instance %s in VMSS %s: %w", *pip.Properties.IPAddress, instanceNum, vmssName, err)
+				}
+				return addr, nil
+			}
+		}
+	}
+	return netip.Addr{}, fmt.Errorf("no public IP address found for instance %s in VMSS %s", instanceNum, vmssName)
+}
+
+// getVMPublicIP resolves a public IP address reference to its actual IP address.
+// publicIPRef must be a valid resource ID
+func (c *Client) getVMPublicIP(ctx context.Context, publicIPRef *armnetwork.PublicIPAddress) (netip.Addr, error) {
+	if publicIPRef.ID == nil {
+		return netip.Addr{}, fmt.Errorf("public IP reference has no resource ID")
+	}
+	resourceID, err := arm.ParseResourceID(*publicIPRef.ID)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("failed to parse public IP resource ID %q: %w", *publicIPRef.ID, err)
+	}
+
+	c.limiter.Limit(ctx, publicIPAddressesGet)
+	sinceStart := spanstat.Start()
+
+	pip, err := c.publicIPAddresses.Get(ctx, resourceID.ResourceGroupName, resourceID.Name, nil)
+	c.metricsAPI.ObserveAPICall(publicIPAddressesGet, deriveStatus(err), sinceStart.Seconds())
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("failed to get public IP %s: %w", resourceID.Name, err)
+	}
+	if pip.Properties == nil || pip.Properties.IPAddress == nil {
+		return netip.Addr{}, fmt.Errorf("public IP %s has no IP address assigned", resourceID.Name)
+	}
+	addr, err := netip.ParseAddr(*pip.Properties.IPAddress)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("failed to parse public IP %q for %s: %w", *pip.Properties.IPAddress, resourceID.Name, err)
+	}
+	return addr, nil
+}
+
 // AssignPublicIPAddressesVMSS assigns a public IP to a VMSS instance.
 // The public IP is allocated from a Public IP Prefix matching publicIpTags
-func (c *Client) AssignPublicIPAddressesVMSS(ctx context.Context, instanceID, vmssName string, publicIpTags ipamTypes.Tags) (string, error) {
+func (c *Client) AssignPublicIPAddressesVMSS(ctx context.Context, instanceID, vmssName string, publicIpTags ipamTypes.Tags) (netip.Addr, error) {
 	// The instance ID format is:
 	// /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmssName}/virtualMachines/{instanceNum}
 	// Parse the instance ID to get just the instance number
 	resourceID, err := arm.ParseResourceID(instanceID)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse instance ID %q: %w", instanceID, err)
+		return netip.Addr{}, fmt.Errorf("failed to parse instance ID %q: %w", instanceID, err)
 	}
 	instanceNum := resourceID.Name
 
@@ -768,7 +864,7 @@ func (c *Client) AssignPublicIPAddressesVMSS(ctx context.Context, instanceID, vm
 
 	c.metricsAPI.ObserveAPICall(virtualMachineScaleSetVMsGet, deriveStatus(err), sinceStart.Seconds())
 	if err != nil {
-		return "", fmt.Errorf("failed to get VM %s from VMSS %s: %w", instanceID, vmssName, err)
+		return netip.Addr{}, fmt.Errorf("failed to get VM %s from VMSS %s: %w", instanceID, vmssName, err)
 	}
 
 	// Search for the primary network interface configuration
@@ -782,7 +878,7 @@ func (c *Client) AssignPublicIPAddressesVMSS(ctx context.Context, instanceID, vm
 	}
 
 	if primaryNetIfConfig == nil {
-		return "", fmt.Errorf("can't find primary interface for VM %s from VMSS %s", instanceID, vmssName)
+		return netip.Addr{}, fmt.Errorf("can't find primary interface for VM %s from VMSS %s", instanceID, vmssName)
 	}
 
 	// Find the primary IP configuration
@@ -801,7 +897,7 @@ func (c *Client) AssignPublicIPAddressesVMSS(ctx context.Context, instanceID, vm
 		if primaryNetIfConfig.Name != nil {
 			netIfName = *primaryNetIfConfig.Name
 		}
-		return "", fmt.Errorf("can't find primary IP configuration for network configuration %s from VM %s from VMSS %s",
+		return netip.Addr{}, fmt.Errorf("can't find primary IP configuration for network configuration %s from VM %s from VMSS %s",
 			netIfName,
 			instanceID,
 			vmssName,
@@ -814,23 +910,19 @@ func (c *Client) AssignPublicIPAddressesVMSS(ctx context.Context, instanceID, vm
 			// This leads to the VM failing to provision properly. In this case, we need to delete the erroneous public IP address configuration
 			// and configure it again.
 			if err := c.deletePublicIPAddressConfigurationVMSS(ctx, instanceNum, vmssName, &vm, primaryIPConfig); err != nil {
-				return "", fmt.Errorf("failed to delete public IP address configuration for VM %s from VMSS %s: %w", instanceID, vmssName, err)
+				return netip.Addr{}, fmt.Errorf("failed to delete public IP address configuration for VM %s from VMSS %s: %w", instanceID, vmssName, err)
 			}
 		} else {
-			// Public IP already successfully provisioned, return the existing prefix ID
+			// Public IP already successfully provisioned, look up and return the actual IP address
 			// so the caller can record the assignment without re-attempting allocation.
-			cfg := primaryIPConfig.Properties.PublicIPAddressConfiguration
-			if cfg.Properties != nil && cfg.Properties.PublicIPPrefix != nil && cfg.Properties.PublicIPPrefix.ID != nil {
-				return *cfg.Properties.PublicIPPrefix.ID, nil
-			}
-			return "", fmt.Errorf("public IP already assigned to VM %s from VMSS %s but prefix ID is unavailable", instanceID, vmssName)
+			return c.getVMSSPublicIP(ctx, vmssName, instanceNum)
 		}
 	}
 
 	// Find a public IP prefix with the given tags
 	publicIPPrefixID, err := c.getPublicIPPrefixIDByTags(ctx, publicIpTags)
 	if err != nil {
-		return "", err
+		return netip.Addr{}, err
 	}
 
 	// Create a new public IP configuration
@@ -859,30 +951,27 @@ func (c *Client) AssignPublicIPAddressesVMSS(ctx context.Context, instanceID, vm
 	poller, err := c.virtualMachineScaleSetVMs.BeginUpdate(ctx, c.resourceGroup, vmssName, instanceNum, vm.VirtualMachineScaleSetVM, nil)
 	if err != nil {
 		c.metricsAPI.ObserveAPICall(virtualMachineScaleSetVMsUpdate, deriveStatus(err), sinceStart.Seconds())
-		return "", fmt.Errorf("unable to update virtualMachineScaleSetVMs: %w", err)
+		return netip.Addr{}, fmt.Errorf("unable to update virtualMachineScaleSetVMs: %w", err)
 	}
 
 	_, err = poller.PollUntilDone(ctx, nil)
 	c.metricsAPI.ObserveAPICall(virtualMachineScaleSetVMsUpdate, deriveStatus(err), sinceStart.Seconds())
 	if err != nil {
-		return "", fmt.Errorf("error while waiting for virtualMachineScaleSetVMs Update to complete: %w", err)
+		return netip.Addr{}, fmt.Errorf("error while waiting for virtualMachineScaleSetVMs Update to complete: %w", err)
 	}
 
-	// TODO return the actual public IP address
-	// This would require additional API call(s) and polling, so the
-	// Public IP Prefix ID is good enough to start with
-	return publicIPPrefixID, nil
+	return c.getVMSSPublicIP(ctx, vmssName, instanceNum)
 }
 
 // AssignPublicIPAddressesVM assigns a public IP to a VM instance.
 // The public IP is allocated from a Public IP Prefix matching publicIpTags
-func (c *Client) AssignPublicIPAddressesVM(ctx context.Context, instanceID string, publicIpTags ipamTypes.Tags) (string, error) {
+func (c *Client) AssignPublicIPAddressesVM(ctx context.Context, instanceID string, publicIpTags ipamTypes.Tags) (netip.Addr, error) {
 	// The instance ID format is:
 	// /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Compute/virtualMachines/{vmName}
 	// Parse the instance ID to get the VM name
 	resourceID, err := arm.ParseResourceID(instanceID)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse instance ID %q: %w", instanceID, err)
+		return netip.Addr{}, fmt.Errorf("failed to parse instance ID %q: %w", instanceID, err)
 	}
 	vmName := resourceID.Name
 
@@ -898,7 +987,7 @@ func (c *Client) AssignPublicIPAddressesVM(ctx context.Context, instanceID strin
 
 	c.metricsAPI.ObserveAPICall(virtualMachinesGet, deriveStatus(err), sinceStart.Seconds())
 	if err != nil {
-		return "", fmt.Errorf("failed to get VM %s: %w", vmName, err)
+		return netip.Addr{}, fmt.Errorf("failed to get VM %s: %w", vmName, err)
 	}
 
 	// Search for the primary network interface
@@ -913,13 +1002,13 @@ func (c *Client) AssignPublicIPAddressesVM(ctx context.Context, instanceID strin
 	}
 
 	if primaryNetIfID == "" {
-		return "", fmt.Errorf("can't find primary interface for VM %s", vmName)
+		return netip.Addr{}, fmt.Errorf("can't find primary interface for VM %s", vmName)
 	}
 
 	// Parse interface ID to get the interface name
 	netIfResourceID, err := arm.ParseResourceID(primaryNetIfID)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse network interface ID %q: %w", primaryNetIfID, err)
+		return netip.Addr{}, fmt.Errorf("failed to parse network interface ID %q: %w", primaryNetIfID, err)
 	}
 	interfaceName := netIfResourceID.Name
 
@@ -931,7 +1020,7 @@ func (c *Client) AssignPublicIPAddressesVM(ctx context.Context, instanceID strin
 
 	c.metricsAPI.ObserveAPICall(interfacesGet, deriveStatus(err), sinceStart.Seconds())
 	if err != nil {
-		return "", fmt.Errorf("failed to get network interface %s: %w", interfaceName, err)
+		return netip.Addr{}, fmt.Errorf("failed to get network interface %s: %w", interfaceName, err)
 	}
 
 	// Find the primary IP configuration
@@ -946,7 +1035,7 @@ func (c *Client) AssignPublicIPAddressesVM(ctx context.Context, instanceID strin
 	}
 
 	if primaryIPConfig == nil {
-		return "", fmt.Errorf("can't find primary IP configuration for interface %s", interfaceName)
+		return netip.Addr{}, fmt.Errorf("can't find primary IP configuration for interface %s", interfaceName)
 	}
 
 	if primaryIPConfig.Properties.PublicIPAddress != nil {
@@ -955,22 +1044,19 @@ func (c *Client) AssignPublicIPAddressesVM(ctx context.Context, instanceID strin
 			// This leads to the VM failing to provision properly. In this case, we need to delete the erroneous public IP address configuration
 			// and configure it again.
 			if err := c.deletePublicIPAddressConfigurationVM(ctx, interfaceName, vmName, &iface, primaryIPConfig); err != nil {
-				return "", fmt.Errorf("failed to delete public IP address configuration for interface %s for VM %s: %w", interfaceName, vmName, err)
+				return netip.Addr{}, fmt.Errorf("failed to delete public IP address configuration for interface %s for VM %s: %w", interfaceName, vmName, err)
 			}
 		} else {
-			// Public IP already successfully provisioned, return the existing IP resource
-			// ID so the caller can record the assignment without re-attempting allocation.
-			if primaryIPConfig.Properties.PublicIPAddress.ID != nil {
-				return *primaryIPConfig.Properties.PublicIPAddress.ID, nil
-			}
-			return "", fmt.Errorf("public IP already assigned to VM %s but resource ID is unavailable", vmName)
+			// Public IP already successfully provisioned, look up and return the actual IP address
+			// so the caller can record the assignment without re-attempting allocation.
+			return c.getVMPublicIP(ctx, primaryIPConfig.Properties.PublicIPAddress)
 		}
 	}
 
 	// Find a public IP prefix with the given tags
 	publicIPPrefixID, err := c.getPublicIPPrefixIDByTags(ctx, publicIpTags)
 	if err != nil {
-		return "", err
+		return netip.Addr{}, err
 	}
 
 	// Assign the public IP prefix to the primary IP configuration
@@ -990,19 +1076,27 @@ func (c *Client) AssignPublicIPAddressesVM(ctx context.Context, instanceID strin
 	poller, err := c.interfaces.BeginCreateOrUpdate(ctx, c.resourceGroup, interfaceName, iface.Interface, nil)
 	if err != nil {
 		c.metricsAPI.ObserveAPICall(interfacesCreateOrUpdate, deriveStatus(err), sinceStart.Seconds())
-		return "", fmt.Errorf("unable to update interface %s for VM %s: %w", interfaceName, vmName, err)
+		return netip.Addr{}, fmt.Errorf("unable to update interface %s for VM %s: %w", interfaceName, vmName, err)
 	}
 
-	_, err = poller.PollUntilDone(ctx, nil)
+	updatedIface, err := poller.PollUntilDone(ctx, nil)
 	c.metricsAPI.ObserveAPICall(interfacesCreateOrUpdate, deriveStatus(err), sinceStart.Seconds())
 	if err != nil {
-		return "", fmt.Errorf("error while waiting for interface CreateOrUpdate to complete for VM %s: %w", vmName, err)
+		return netip.Addr{}, fmt.Errorf("error while waiting for interface CreateOrUpdate to complete for VM %s: %w", vmName, err)
 	}
 
-	// TODO return the actual public IP address
-	// This would require additional API call(s) and polling, so the
-	// Public IP Prefix ID is good enough to start with
-	return publicIPPrefixID, nil
+	if updatedIface.Properties != nil {
+		for _, ipConfig := range updatedIface.Properties.IPConfigurations {
+			if ipConfig.Properties == nil || ipConfig.Properties.Primary == nil || !*ipConfig.Properties.Primary {
+				continue
+			}
+			if ipConfig.Properties.PublicIPAddress == nil {
+				return netip.Addr{}, fmt.Errorf("no public IP reference on updated NIC for VM %s", vmName)
+			}
+			return c.getVMPublicIP(ctx, ipConfig.Properties.PublicIPAddress)
+		}
+	}
+	return netip.Addr{}, fmt.Errorf("no primary IP configuration found on updated NIC for VM %s", vmName)
 }
 
 // deletePublicIPAddressConfigurationVMSS deletes the public IP address configuration from a VMSS instance

--- a/pkg/azure/api/mock/mock.go
+++ b/pkg/azure/api/mock/mock.go
@@ -214,14 +214,14 @@ func (a *API) AssignPrivateIpAddressesVMSS(ctx context.Context, vmName, vmssName
 	return nil
 }
 
-func (a *API) AssignPublicIPAddressesVMSS(ctx context.Context, instanceID, vmssName string, publicIpTags ipamTypes.Tags) (string, error) {
+func (a *API) AssignPublicIPAddressesVMSS(ctx context.Context, instanceID, vmssName string, publicIpTags ipamTypes.Tags) (netip.Addr, error) {
 	a.rateLimit()
-	return "mock-public-ip-prefix-id", nil
+	return netip.MustParseAddr("192.0.2.1"), nil
 }
 
-func (a *API) AssignPublicIPAddressesVM(ctx context.Context, instanceID string, publicIpTags ipamTypes.Tags) (string, error) {
+func (a *API) AssignPublicIPAddressesVM(ctx context.Context, instanceID string, publicIpTags ipamTypes.Tags) (netip.Addr, error) {
 	a.rateLimit()
-	return "mock-public-ip-prefix-id", nil
+	return netip.MustParseAddr("192.0.2.1"), nil
 }
 
 // ListAllNetworkInterfaces returns a dummy slice since mock doesn't use real network interfaces

--- a/pkg/azure/ipam/instances.go
+++ b/pkg/azure/ipam/instances.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"net/netip"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -31,8 +32,8 @@ type AzureAPI interface {
 	GetSubnetsByIDs(ctx context.Context, nodeSubnetIDs []string) (ipamTypes.SubnetMap, error)
 	AssignPrivateIpAddressesVM(ctx context.Context, subnetID, interfaceName string, addresses int) error
 	AssignPrivateIpAddressesVMSS(ctx context.Context, instanceID, vmssName, subnetID, interfaceName string, addresses int) error
-	AssignPublicIPAddressesVM(ctx context.Context, instanceID string, publicIpTags ipamTypes.Tags) (string, error)
-	AssignPublicIPAddressesVMSS(ctx context.Context, instanceID, vmssName string, publicIpTags ipamTypes.Tags) (string, error)
+	AssignPublicIPAddressesVM(ctx context.Context, instanceID string, publicIpTags ipamTypes.Tags) (netip.Addr, error)
+	AssignPublicIPAddressesVMSS(ctx context.Context, instanceID, vmssName string, publicIpTags ipamTypes.Tags) (netip.Addr, error)
 	ListAllNetworkInterfaces(ctx context.Context) ([]*armnetwork.Interface, error)
 	ParseInterfacesIntoInstanceMap(networkInterfaces []*armnetwork.Interface, subnets ipamTypes.SubnetMap) *ipamTypes.InstanceMap
 	ListVMNetworkInterfaces(ctx context.Context, instanceID string) ([]*armnetwork.Interface, error)

--- a/pkg/azure/ipam/node.go
+++ b/pkg/azure/ipam/node.go
@@ -142,10 +142,17 @@ func (n *Node) AllocateIPs(ctx context.Context, a *nodemanager.AllocationAction)
 }
 
 func (n *Node) AllocateStaticIP(ctx context.Context, staticIPTags ipamTypes.Tags) (string, error) {
+	var addr netip.Addr
+	var err error
 	if n.vmss == "" {
-		return n.manager.api.AssignPublicIPAddressesVM(ctx, n.node.InstanceID(), staticIPTags)
+		addr, err = n.manager.api.AssignPublicIPAddressesVM(ctx, n.node.InstanceID(), staticIPTags)
+	} else {
+		addr, err = n.manager.api.AssignPublicIPAddressesVMSS(ctx, n.node.InstanceID(), n.vmss, staticIPTags)
 	}
-	return n.manager.api.AssignPublicIPAddressesVMSS(ctx, n.node.InstanceID(), n.vmss, staticIPTags)
+	if err != nil {
+		return "", err
+	}
+	return addr.String(), nil
 }
 
 // CreateInterface is called to create a new interface. This operation is


### PR DESCRIPTION
Previously these functions returned the public IP prefix resource ID as a placeholder. Returning the actual IP makes `AssignedStaticIP` meaningful for monitoring and unblocks migrating it from being a `string` to being a more strongly typed `netip.Addr` (see #24246).

For VMSS, a `PublicIPAddressesClient` is added to query the VMSS-scoped public IP listing API (`ListVirtualMachineScaleSetVMPublicIPAddresses`), which requires first listing the instance's NICs to obtain the primary NIC and IP config names.

For standalone VMs, the `BeginCreateOrUpdate` response already carries the updated NIC. The public IP reference is resolved via `PublicIPAddresses.Get`. Both the post-assignment path and the idempotent "already assigned" early-return path use the same helpers.

Followup to #42219:
https://github.com/cilium/cilium/blob/1ecc3722eb0f29932fe4683450224f1c4d22e248/pkg/azure/api/api.go#L992-L994