### PR TITLE
egressgw: add script test support

### DIFF
--- a/pkg/egressgateway/cell.go
+++ b/pkg/egressgateway/cell.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package egressgateway
+
+import (
+	"github.com/cilium/hive/cell"
+
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// Cell provides a [Manager] for consumption with hive.
+var Cell = cell.Module(
+	"egressgateway",
+	"Egress Gateway allows originating traffic from specific addresses",
+	cell.Config(defaultConfig),
+	cell.Provide(NewEgressGatewayManager),
+	cell.Provide(newPolicyResource),
+	cell.Provide(func(dcfg *option.DaemonConfig) tunnel.EnablerOut {
+		if !dcfg.EnableEgressGateway {
+			return tunnel.EnablerOut{}
+		}
+		return tunnel.NewEnabler(true)
+	}),
+)

--- a/pkg/egressgateway/commands.go
+++ b/pkg/egressgateway/commands.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package egressgateway
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/cilium/hive"
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/script"
+
+	"github.com/cilium/cilium/pkg/maps/egressmap"
+)
+
+// Contains test commands used for hive-script-testing egressgw.
+// These should *not* be included in the general egressgw hive cells.
+//
+// In general, it should be preferred to have output come from statedb
+// tables as that provides a consistent interface for table writing
+// and queries etc.
+//
+// This also attempts to maintain a separation between script testing
+// code and egressgw internals.
+var testCommandsCell = cell.Module("test-commands", "Test Commands",
+	cell.Provide(scriptCommands),
+)
+
+type params struct {
+	cell.In
+
+	PolicyMap4 egressmap.PolicyMap4V2
+	PolicyMap6 egressmap.PolicyMap6
+}
+
+func scriptCommands(p params) hive.ScriptCmdsOut {
+	return hive.NewScriptCmds(map[string]script.Cmd{
+		"egress/policy-maps-dump": mapsDump(p),
+	})
+}
+
+func mapsDump(p params) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Dump the egressgw BPF maps",
+			Args:    "(output file)",
+			Detail: []string{
+				"This dumps the egressgw BPF maps either to stdout or to a file.",
+				"Output is written in the format: key=value with spaces used to separate",
+				"For example: source_ip=10.0.0.1 dest_cidr=99.0.0.0/24 egress_ip=100.0.0.1 gateway_ip=...",
+				"Format is not guaranteed to be stable as this command is only",
+				"for testing and debugging purposes.",
+			},
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			return func(s *script.State) (stdout string, stderr string, err error) {
+				out := s.LogWriter()
+				if len(args) > 0 {
+					var err error
+					out, err = os.Create(s.Path(args[0]))
+					if err != nil {
+						return "", "", err
+					}
+				}
+				w := tabwriter.NewWriter(out, 5, 0, 3, ' ', 0)
+				lines := []string{}
+				p.PolicyMap4.IterateWithCallback(func(k *egressmap.EgressPolicyKey4, v *egressmap.EgressPolicyVal4V2) {
+					lines = append(lines,
+						fmt.Sprintf("source_ip=%s dest_cidr=%s egress_ip=%s egress_ifindex=%d gateway_ip=%s", k.SourceIP, k.DestCIDR, v.EgressIP, v.EgressIfindex, v.GetGatewayAddr()))
+				})
+				p.PolicyMap6.IterateWithCallback(func(k *egressmap.EgressPolicyKey6, v *egressmap.EgressPolicyVal6) {
+					lines = append(lines,
+						fmt.Sprintf("source_ip=%s dest_cidr=%s egress_ip=%s egress_ifindex=%d gateway_ip=%s", k.SourceIP, k.DestCIDR, v.EgressIP, v.EgressIfindex, v.GetGatewayAddr()))
+				})
+
+				sort.Strings(lines)
+				for _, l := range lines {
+					fmt.Fprintln(w, l)
+				}
+				w.Flush()
+
+				return
+			}, nil
+		},
+	)
+}

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -57,21 +57,6 @@ var (
 	EgressIPNotFoundIPv6 = netip.IPv6Unspecified()
 )
 
-// Cell provides a [Manager] for consumption with hive.
-var Cell = cell.Module(
-	"egressgateway",
-	"Egress Gateway allows originating traffic from specific IPv4 addresses",
-	cell.Config(defaultConfig),
-	cell.Provide(NewEgressGatewayManager),
-	cell.Provide(newPolicyResource),
-	cell.Provide(func(dcfg *option.DaemonConfig) tunnel.EnablerOut {
-		if !dcfg.EnableEgressGateway {
-			return tunnel.EnablerOut{}
-		}
-		return tunnel.NewEnabler(true)
-	}),
-)
-
 type eventType int
 
 const (

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -121,11 +121,11 @@ type Manager struct {
 	identityAllocator identityCache.IdentityAllocator
 
 	// policyMap4 communicates the active IPv4 policies to the datapath.
-	policyMap4   *egressmap.PolicyMap4
-	policyMap4V2 *egressmap.PolicyMap4V2
+	policyMap4   egressmap.PolicyMap4
+	policyMap4V2 egressmap.PolicyMap4V2
 
 	// policyMap6 communicates the active IPv6 policies to the datapath.
-	policyMap6 *egressmap.PolicyMap6
+	policyMap6 egressmap.PolicyMap6
 
 	// reconciliationTriggerInterval is the amount of time between triggers
 	// of reconciliations are invoked
@@ -160,9 +160,9 @@ type Params struct {
 	DaemonConfig      *option.DaemonConfig
 	TunnelConfig      tunnel.Config
 	IdentityAllocator identityCache.IdentityAllocator
-	PolicyMap4        *egressmap.PolicyMap4
-	PolicyMap4V2      *egressmap.PolicyMap4V2
-	PolicyMap6        *egressmap.PolicyMap6
+	PolicyMap4        egressmap.PolicyMap4
+	PolicyMap4V2      egressmap.PolicyMap4V2
+	PolicyMap6        egressmap.PolicyMap6
 	Policies          resource.Resource[*Policy]
 	Nodes             resource.Resource[*cilium_api_v2.CiliumNode]
 	Endpoints         resource.Resource[*k8sTypes.CiliumEndpoint]

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -1249,14 +1249,14 @@ func parseEgressRule(sourceIP, destCIDR, egressIP, gatewayIP string, egressIfind
 	}
 }
 
-func assertEgressRules4(t *testing.T, policyMap *egressmap.PolicyMap4V2, rules []egressRule) {
+func assertEgressRules4(t *testing.T, policyMap egressmap.PolicyMap4V2, rules []egressRule) {
 	t.Helper()
 
 	err := tryAssertEgressRules4(policyMap, rules)
 	require.NoError(t, err)
 }
 
-func tryAssertEgressRules4(policyMap *egressmap.PolicyMap4V2, rules []egressRule) error {
+func tryAssertEgressRules4(policyMap egressmap.PolicyMap4V2, rules []egressRule) error {
 	parsedRules := []parsedEgressRule{}
 	for _, r := range rules {
 		parsedRules = append(parsedRules, parseEgressRule(r.sourceIP, r.destCIDR, r.egressIP, r.gatewayIP, r.egressIfindex))
@@ -1299,14 +1299,14 @@ func tryAssertEgressRules4(policyMap *egressmap.PolicyMap4V2, rules []egressRule
 
 	return nil
 }
-func assertEgressRules6(t *testing.T, policyMap *egressmap.PolicyMap6, rules []egressRule) {
+func assertEgressRules6(t *testing.T, policyMap egressmap.PolicyMap6, rules []egressRule) {
 	t.Helper()
 
 	err := tryAssertEgressRules6(policyMap, rules)
 	require.NoError(t, err)
 }
 
-func tryAssertEgressRules6(policyMap *egressmap.PolicyMap6, rules []egressRule) error {
+func tryAssertEgressRules6(policyMap egressmap.PolicyMap6, rules []egressRule) error {
 	parsedRules := []parsedEgressRule{}
 	for _, r := range rules {
 		parsedRules = append(parsedRules, parseEgressRule(r.sourceIP, r.destCIDR, r.egressIP, r.gatewayIP, r.egressIfindex))

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -173,6 +173,25 @@ func (config *PolicyConfig) regenerateGatewayConfig(manager *Manager) {
 	}
 }
 
+func deviceGetFirstAdresses(dev *tables.Device) (netip.Addr, netip.Addr) {
+	var firstIPv4, firstIPv6 netip.Addr
+
+	for _, addr := range dev.Addrs {
+		if addr.Addr.Is4() && !firstIPv4.IsValid() {
+			firstIPv4 = addr.Addr
+		}
+		if addr.Addr.Is6() && !firstIPv6.IsValid() {
+			firstIPv6 = addr.Addr
+		}
+
+		if firstIPv4.IsValid() && firstIPv6.IsValid() {
+			break
+		}
+	}
+
+	return firstIPv4, firstIPv6
+}
+
 // deriveFromPolicyGatewayConfig retrieves all the missing gateway configuration
 // data (such as egress IP or interface) given a policy egress gateway config
 func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(manager *Manager, gc *policyGatewayConfig, v4Needed bool, v6Needed bool) error {
@@ -192,6 +211,15 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(manager *Manager, gc *po
 		dev, _, found := manager.deviceTable.Get(manager.db.ReadTxn(), tables.DeviceNameIndex.Query(gc.iface))
 		if found {
 			gwc.egressIfindex = uint32(dev.Index)
+
+			egressIP4, egressIP6 = deviceGetFirstAdresses(dev)
+			if v4Needed && !egressIP4.IsValid() {
+				return fmt.Errorf("failed to retrieve IPv4 address for egress interface")
+			}
+
+			if v6Needed && !egressIP6.IsValid() {
+				return fmt.Errorf("failed to retrieve IPv6 address for egress interface")
+			}
 		} else {
 			iface, err := safenetlink.LinkByName(gwc.ifaceName)
 			if err != nil {
@@ -199,19 +227,19 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(manager *Manager, gc *po
 			}
 
 			gwc.egressIfindex = uint32(iface.Attrs().Index)
-		}
 
-		if v4Needed {
-			egressIP4, err = netdevice.GetIfaceFirstIPv4Address(gc.iface)
-			if err != nil {
-				return fmt.Errorf("failed to retrieve IPv4 address for egress interface: %w", err)
+			if v4Needed {
+				egressIP4, err = netdevice.GetIfaceFirstIPv4Address(gc.iface)
+				if err != nil {
+					return fmt.Errorf("failed to retrieve IPv4 address for egress interface: %w", err)
+				}
 			}
-		}
 
-		if v6Needed {
-			egressIP6, err = netdevice.GetIfaceFirstIPv6Address(gc.iface)
-			if err != nil {
-				return fmt.Errorf("failed to retrieve IPv6 address for egress interface: %w", err)
+			if v6Needed {
+				egressIP6, err = netdevice.GetIfaceFirstIPv6Address(gc.iface)
+				if err != nil {
+					return fmt.Errorf("failed to retrieve IPv6 address for egress interface: %w", err)
+				}
 			}
 		}
 	case gc.egressIP.IsValid():

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -192,6 +192,16 @@ func deviceGetFirstAdresses(dev *tables.Device) (netip.Addr, netip.Addr) {
 	return firstIPv4, firstIPv6
 }
 
+func getDeviceWithAddress(manager *Manager, addr netip.Addr) *tables.Device {
+	for dev := range manager.deviceTable.All(manager.db.ReadTxn()) {
+		if dev.HasIP(addr) {
+			return dev
+		}
+	}
+
+	return nil
+}
+
 // deriveFromPolicyGatewayConfig retrieves all the missing gateway configuration
 // data (such as egress IP or interface) given a policy egress gateway config
 func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(manager *Manager, gc *policyGatewayConfig, v4Needed bool, v6Needed bool) error {
@@ -245,36 +255,60 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(manager *Manager, gc *po
 	case gc.egressIP.IsValid():
 		// If the gateway config specifies an egress IP, use the interface with that IP as egress
 		// interface.
-		if gc.egressIP.Is4() {
-			egressIP4 = gc.egressIP
+		dev := getDeviceWithAddress(manager, gc.egressIP)
+		if dev != nil {
+			gwc.ifaceName = dev.Name
 
-			gwc.ifaceName, err = netdevice.GetIfaceWithIPv4Address(gc.egressIP)
-			if err != nil {
-				return fmt.Errorf("failed to retrieve interface with egress IP: %w", err)
-			}
+			if gc.egressIP.Is4() {
+				egressIP4 = gc.egressIP
 
-			if v6Needed {
-				egressIP6, err = netdevice.GetIfaceFirstIPv6Address(gwc.ifaceName)
-				if err != nil {
-					return fmt.Errorf("failed to retrieve IPv6 address for egress interface: %w", err)
+				if v6Needed {
+					_, egressIP6 = deviceGetFirstAdresses(dev)
+					if !egressIP6.IsValid() {
+						return fmt.Errorf("failed to retrieve IPv6 address for egress interface")
+					}
+				}
+			} else if gc.egressIP.Is6() {
+				egressIP6 = gc.egressIP
+
+				if v4Needed {
+					egressIP4, _ = deviceGetFirstAdresses(dev)
+					if !egressIP4.IsValid() {
+						return fmt.Errorf("failed to retrieve IPv4 address for egress interface")
+					}
 				}
 			}
-		} else if gc.egressIP.Is6() {
-			egressIP6 = gc.egressIP
+		} else {
+			if gc.egressIP.Is4() {
+				egressIP4 = gc.egressIP
 
-			gwc.ifaceName, err = netdevice.GetIfaceWithIPv6Address(gc.egressIP)
-			if err != nil {
-				return fmt.Errorf("failed to retrieve interface with IPv6 egress IP: %w", err)
-			}
-
-			if v4Needed {
-				egressIP4, err = netdevice.GetIfaceFirstIPv4Address(gwc.ifaceName)
+				gwc.ifaceName, err = netdevice.GetIfaceWithIPv4Address(gc.egressIP)
 				if err != nil {
-					return fmt.Errorf("failed to retrieve IPv4 address for egress interface: %w", err)
+					return fmt.Errorf("failed to retrieve interface with egress IP: %w", err)
+				}
+
+				if v6Needed {
+					egressIP6, err = netdevice.GetIfaceFirstIPv6Address(gwc.ifaceName)
+					if err != nil {
+						return fmt.Errorf("failed to retrieve IPv6 address for egress interface: %w", err)
+					}
+				}
+			} else if gc.egressIP.Is6() {
+				egressIP6 = gc.egressIP
+
+				gwc.ifaceName, err = netdevice.GetIfaceWithIPv6Address(gc.egressIP)
+				if err != nil {
+					return fmt.Errorf("failed to retrieve interface with IPv6 egress IP: %w", err)
+				}
+
+				if v4Needed {
+					egressIP4, err = netdevice.GetIfaceFirstIPv4Address(gwc.ifaceName)
+					if err != nil {
+						return fmt.Errorf("failed to retrieve IPv4 address for egress interface: %w", err)
+					}
 				}
 			}
 		}
-
 	default:
 		// If the gateway config doesn't specify any egress IP or interface, use the
 		// interface with the IPv4 default route

--- a/pkg/egressgateway/script_test.go
+++ b/pkg/egressgateway/script_test.go
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package egressgateway
+
+import (
+	"context"
+	"maps"
+	"net"
+	"testing"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/script"
+	"github.com/cilium/hive/script/scripttest"
+	"github.com/cilium/statedb"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	daemonk8s "github.com/cilium/cilium/daemon/k8s"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/endpointstate"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/identity/cache"
+	k8sFake "github.com/cilium/cilium/pkg/k8s/client/testutils"
+	k8sTables "github.com/cilium/cilium/pkg/k8s/tables"
+	"github.com/cilium/cilium/pkg/kpr"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/maps/egressmap"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/monitor/agent"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/node/addressing"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/promise"
+	"github.com/cilium/cilium/pkg/testutils"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+func TestPrivilegedScripts(t *testing.T) {
+	testutils.PrivilegedTest(t)
+	log := hivetest.Logger(t)
+	ctx := t.Context()
+
+	// Set the node name to be "localnode1" for all the tests.
+	nodeTypes.SetName("localnode1")
+
+	scripttest.Test(t,
+		ctx,
+		func(t testing.TB, args []string) *script.Engine {
+			h := hive.New(
+				k8sFake.FakeClientCell(),
+				daemonk8s.ResourcesCell,
+				k8sTables.NamespaceTableCell,
+				agent.Cell,
+
+				Cell,
+				sysctl.Cell,
+
+				// Note: We use the default local node store, and setup the node obj
+				// using the mock node sync type.
+				node.LocalNodeStoreCell,
+				endpointmanager.Cell,
+				cell.Provide(func() promise.Promise[endpointstate.Restorer] {
+					resolver, promise := promise.New[endpointstate.Restorer]()
+					resolver.Resolve(&fakeRestorer{})
+					return promise
+				}),
+				tunnel.Cell,
+
+				testCell,
+
+				cell.Config(metrics.RegistryConfig{}),
+				cell.Config(cmtypes.DefaultClusterInfo),
+				cell.Provide(
+					metrics.NewRegistry,
+					// LocalNodeSynchronizer syncs via apiserver, after the node is initialized, generally
+					// using local stored config (if available) in daemon package.
+					func() node.LocalNodeSynchronizer {
+						return &mockNodeSync{}
+					},
+					func() *option.DaemonConfig {
+						return &option.DaemonConfig{
+							EnableIPv4:             true,
+							EnableIPv6:             true,
+							EnableBPFMasquerade:    true,
+							EnableIPv4Masquerade:   true,
+							EnableIPv6Masquerade:   true,
+							EnableEgressGateway:    true,
+							IdentityAllocationMode: option.IdentityAllocationModeCRD,
+							Debug:                  false,
+						}
+					},
+
+					func() cache.IdentityAllocator {
+						m := testidentity.NewMockIdentityAllocator(nil)
+
+						_, _, err := m.AllocateIdentity(context.TODO(),
+							labels.NewLabelsFromSortedList("k8s:foo=bar"),
+							false,
+							30000,
+						)
+						assert.NoError(t, err)
+
+						return m
+					},
+
+					tables.NewDeviceTable,
+					statedb.RWTable[*tables.Device].ToTable,
+					statedb.RWTable[tables.NodeAddress].ToTable,
+
+					func() loadbalancer.Config {
+						return loadbalancer.DefaultConfig
+					},
+					func() kpr.KPRConfig { return kpr.KPRConfig{} },
+				),
+
+				cell.Invoke(func(*Manager) {}),
+			)
+
+			flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+			h.RegisterFlags(flags)
+
+			t.Cleanup(func() {
+				assert.NoError(t, h.Stop(log, context.TODO()))
+			})
+			cmds, err := h.ScriptCommands(log)
+			require.NoError(t, err, "ScriptCommands")
+			maps.Insert(cmds, maps.All(script.DefaultCmds()))
+			return &script.Engine{
+				Cmds:          cmds,
+				RetryInterval: 1500 * time.Millisecond,
+			}
+		}, []string{}, "testdata/*.txtar")
+}
+
+var testCell = cell.Group(
+	testCommandsCell,
+	cell.Provide(
+		func() egressmap.PolicyConfig {
+			return egressmap.DefaultPolicyConfig
+		},
+		egressmap.CreatePrivatePolicyMap4,
+		egressmap.CreatePrivatePolicyMap4V2,
+		egressmap.CreatePrivatePolicyMap6,
+	),
+)
+
+type mockNodeSync struct{}
+
+func (m *mockNodeSync) WaitForNodeInformation(ctx context.Context, store *node.LocalNodeStore) error {
+	return nil
+}
+
+func (m *mockNodeSync) InitLocalNode(ctx context.Context, n *node.LocalNode) error {
+	n.Node = nodeTypes.Node{
+		Name: "localnode1",
+		IPAddresses: []nodeTypes.Address{
+			{Type: addressing.NodeInternalIP, IP: net.ParseIP("172.18.0.3")},
+		},
+	}
+	return nil
+}
+
+func (m *mockNodeSync) SyncLocalNode(context.Context, *node.LocalNodeStore) {
+}
+
+type fakeRestorer struct{}
+
+func (r *fakeRestorer) Await(context.Context) (endpointstate.Restorer, error) {
+	return r, nil
+}
+
+func (r *fakeRestorer) WaitForEndpointRestoreWithoutRegeneration(ctx context.Context) error {
+	return nil
+}
+
+func (r *fakeRestorer) WaitForEndpointRestore(_ context.Context) error {
+	return nil
+}
+
+func (r *fakeRestorer) WaitForInitialPolicy(_ context.Context) error {
+	return nil
+}

--- a/pkg/egressgateway/testdata/test.txtar
+++ b/pkg/egressgateway/testdata/test.txtar
@@ -1,0 +1,120 @@
+hive start
+
+db/initialized
+
+# Add initial k8s resources.
+k8s/add node1.yaml ciliumnode1.yaml
+k8s/add policy1.yaml
+k8s/add ciliumendpoint1.yaml
+
+db/insert devices device-eth0.yaml device-eth1.yaml
+
+# Check that manager realizes expected bpf map state.
+ egress/policy-maps-dump policymap.actual
+ * cmp policymap.actual policymap.expected.1
+
+# Update the `interface` field in the CEGP, and validate that this is reflected in the agent state.
+# This also covers the support for interface altnames.
+ cp policy1.yaml policy1_2.yaml
+ sed '    interface: eth0' '    interface: eth1-alt' policy1_2.yaml
+ k8s/update policy1_2.yaml
+
+# Check that manager realizes expected bpf map state.
+ egress/policy-maps-dump policymap.actual
+ * cmp policymap.actual policymap.expected.2
+
+-- policymap.expected.1 --
+source_ip=10.244.3.91 dest_cidr=0.0.0.0 egress_ip=10.10.0.1 egress_ifindex=1 gateway_ip=172.18.0.3
+source_ip=fd00:10:244:3::9c94 dest_cidr=:: egress_ip=fd00::10:10:0:1 egress_ifindex=1 gateway_ip=172.18.0.3
+-- policymap.expected.2 --
+source_ip=10.244.3.91 dest_cidr=0.0.0.0 egress_ip=10.10.0.2 egress_ifindex=2 gateway_ip=172.18.0.3
+source_ip=fd00:10:244:3::9c94 dest_cidr=:: egress_ip=fd00::10:10:0:2 egress_ifindex=2 gateway_ip=172.18.0.3
+-- node1.yaml --
+apiVersion: v1
+kind: Node
+metadata:
+  name: localnode1
+  uid: c57b0909-b567-48a3-865a-c1d1a17b545d
+status:
+  addresses:
+  - address: 172.18.0.3
+    type: InternalIP
+-- ciliumnode1.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  generation: 1
+  labels:
+    kubernetes.io/hostname: kind-worker
+    foo: bar
+  name: localnode1
+  uid: 00000000-0000-0000-0000-000000000000
+spec:
+  addresses:
+  - ip: 172.18.0.3
+    type: InternalIP
+-- policy1.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumEgressGatewayPolicy
+metadata:
+  generation: 1
+  name: policy1
+  uid: 00000000-0000-0000-0000-000000000000
+spec:
+  destinationCIDRs:
+  - 0.0.0.0/0
+  - ::/0
+  egressGateway:
+    interface: eth0
+    nodeSelector:
+      matchLabels:
+        kubernetes.io/hostname: kind-worker
+  excludedCIDRs: []
+  selectors:
+  - podSelector:
+      matchLabels:
+        foo: bar
+-- ciliumendpoint1.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumEndpoint
+metadata:
+  generation: 1
+  labels:
+    name: client1
+    foo: bar
+  name: client1-795488bf5-2tplm
+  namespace: test1
+  uid: 7c22952d-25a0-409d-952c-60895b5c2a90
+status:
+  id: 2000
+  identity:
+    id: 1000
+    labels:
+    - k8s:foo=bar
+  networking:
+    addressing:
+    - ipv4: 10.244.3.91
+      ipv6: fd00:10:244:3::9c94
+    node: 172.18.0.5
+  state: ready
+-- device-eth0.yaml --
+index: 1
+name: eth0
+addrs:
+  - addr: 10.10.0.1
+  - addr: fd00::10:10:0:1
+  - addr: fe80::42:bdff:ec52:ab12
+type: veth
+flags: 1 # admin-up
+operstatus: up
+-- device-eth1.yaml --
+index: 2
+name: eth1
+altnames:
+  - eth1-alt
+addrs:
+  - addr: 10.10.0.2
+  - addr: fd00::10:10:0:2
+type: veth
+flags: 1 # admin-up
+operstatus: up

--- a/pkg/egressgateway/testdata/test_egressip.txtar
+++ b/pkg/egressgateway/testdata/test_egressip.txtar
@@ -1,0 +1,118 @@
+hive start
+
+db/initialized
+
+# Add initial k8s resources.
+k8s/add node1.yaml ciliumnode1.yaml
+k8s/add policy1.yaml
+k8s/add ciliumendpoint1.yaml
+
+db/insert devices device-eth0.yaml device-eth1.yaml
+
+# Check that manager realizes expected bpf map state.
+ egress/policy-maps-dump policymap.actual
+ * cmp policymap.actual policymap.expected.1
+
+# Update the `egressIP` field in the CEGP, and validate that this is reflected in the agent state.
+ cp policy1.yaml policy1_2.yaml
+ sed '    egressIP: 10.10.0.1' '    egressIP: fd00::10:10:0:2' policy1_2.yaml
+ k8s/update policy1_2.yaml
+
+# Check that manager realizes expected bpf map state.
+ egress/policy-maps-dump policymap.actual
+ * cmp policymap.actual policymap.expected.2
+
+-- policymap.expected.1 --
+source_ip=10.244.3.91 dest_cidr=0.0.0.0 egress_ip=10.10.0.1 egress_ifindex=0 gateway_ip=172.18.0.3
+source_ip=fd00:10:244:3::9c94 dest_cidr=:: egress_ip=fd00::10:10:0:1 egress_ifindex=0 gateway_ip=172.18.0.3
+-- policymap.expected.2 --
+source_ip=10.244.3.91 dest_cidr=0.0.0.0 egress_ip=10.10.0.2 egress_ifindex=0 gateway_ip=172.18.0.3
+source_ip=fd00:10:244:3::9c94 dest_cidr=:: egress_ip=fd00::10:10:0:2 egress_ifindex=0 gateway_ip=172.18.0.3
+-- node1.yaml --
+apiVersion: v1
+kind: Node
+metadata:
+  name: localnode1
+  uid: c57b0909-b567-48a3-865a-c1d1a17b545d
+status:
+  addresses:
+  - address: 172.18.0.3
+    type: InternalIP
+-- ciliumnode1.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  generation: 1
+  labels:
+    kubernetes.io/hostname: kind-worker
+    foo: bar
+  name: localnode1
+  uid: 00000000-0000-0000-0000-000000000000
+spec:
+  addresses:
+  - ip: 172.18.0.3
+    type: InternalIP
+-- policy1.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumEgressGatewayPolicy
+metadata:
+  generation: 1
+  name: policy1
+  uid: 00000000-0000-0000-0000-000000000000
+spec:
+  destinationCIDRs:
+  - 0.0.0.0/0
+  - ::/0
+  egressGateway:
+    egressIP: 10.10.0.1
+    nodeSelector:
+      matchLabels:
+        kubernetes.io/hostname: kind-worker
+  excludedCIDRs: []
+  selectors:
+  - podSelector:
+      matchLabels:
+        foo: bar
+-- ciliumendpoint1.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumEndpoint
+metadata:
+  generation: 1
+  labels:
+    name: client1
+    foo: bar
+  name: client1-795488bf5-2tplm
+  namespace: test1
+  uid: 7c22952d-25a0-409d-952c-60895b5c2a90
+status:
+  id: 2000
+  identity:
+    id: 1000
+    labels:
+    - k8s:foo=bar
+  networking:
+    addressing:
+    - ipv4: 10.244.3.91
+      ipv6: fd00:10:244:3::9c94
+    node: 172.18.0.5
+  state: ready
+-- device-eth0.yaml --
+index: 1
+name: eth0
+addrs:
+  - addr: 10.10.0.1
+  - addr: fd00::10:10:0:1
+  - addr: fe80::42:bdff:ec52:ab11
+type: veth
+flags: 1 # admin-up
+operstatus: up
+-- device-eth1.yaml --
+index: 2
+name: eth1
+addrs:
+  - addr: 10.10.0.2
+  - addr: fd00::10:10:0:2
+  - addr: fe80::42:bdff:ec52:ab12
+type: veth
+flags: 1 # admin-up
+operstatus: up

--- a/pkg/maps/egressmap/policy.go
+++ b/pkg/maps/egressmap/policy.go
@@ -87,14 +87,37 @@ func (def PolicyConfig) Flags(flags *pflag.FlagSet) {
 }
 
 // PolicyMap4 is used to communicate ipv4 EGW policies to the datapath.
-type PolicyMap4 policyMap
-type PolicyMap4V2 policyMap
+type PolicyMap4 interface {
+	Lookup(sourceIP netip.Addr, destCIDR netip.Prefix) (*EgressPolicyVal4, error)
+	Update(sourceIP netip.Addr, destCIDR netip.Prefix, egressIP netip.Addr, gatewayIP netip.Addr) error
+	Delete(sourceIP netip.Addr, destCIDR netip.Prefix) error
+	IterateWithCallback(EgressPolicyIterateCallback) error
+}
+type PolicyMap4V2 interface {
+	Lookup(sourceIP netip.Addr, destCIDR netip.Prefix) (*EgressPolicyVal4V2, error)
+	Update(sourceIP netip.Addr, destCIDR netip.Prefix, egressIP netip.Addr, gatewayIP netip.Addr, egressIfindex uint32) error
+	Delete(sourceIP netip.Addr, destCIDR netip.Prefix) error
+	IterateWithCallback(EgressPolicyIterateCallbackV2) error
+}
 
 // PolicyMap6 is used to communicate ipv6 EGW policies to the datapath.
-type PolicyMap6 policyMap
+type PolicyMap6 interface {
+	Lookup(sourceIP netip.Addr, destCIDR netip.Prefix) (*EgressPolicyVal6, error)
+	Update(sourceIP netip.Addr, destCIDR netip.Prefix, egressIP netip.Addr, gatewayIP netip.Addr, egressIfindex uint32) error
+	Delete(sourceIP netip.Addr, destCIDR netip.Prefix) error
+	IterateWithCallback(EgressPolicyIterateCallback6) error
+}
 
 // policyMap is the internal representation of an egress policy map.
-type policyMap struct {
+type policyMap4 struct {
+	m *bpf.Map
+}
+
+type policyMap4V2 struct {
+	m *bpf.Map
+}
+
+type policyMap6 struct {
 	m *bpf.Map
 }
 
@@ -108,9 +131,9 @@ func createPolicyMapFromDaemonConfig(in struct {
 }) (out struct {
 	cell.Out
 
-	IPv4Map   bpf.MapOut[*PolicyMap4]
-	IPv4MapV2 bpf.MapOut[*PolicyMap4V2]
-	IPv6Map   bpf.MapOut[*PolicyMap6]
+	IPv4Map   bpf.MapOut[PolicyMap4]
+	IPv4MapV2 bpf.MapOut[PolicyMap4V2]
+	IPv6Map   bpf.MapOut[PolicyMap6]
 	defines.NodeOut
 }) {
 	out.NodeDefines = map[string]string{
@@ -122,12 +145,12 @@ func createPolicyMapFromDaemonConfig(in struct {
 	}
 
 	if in.EnableIPv4 {
-		out.IPv4Map = bpf.NewMapOut(createPolicyMap4(in.Lifecycle, in.MetricsRegistry, in.PolicyConfig, ebpf.PinByName))
-		out.IPv4MapV2 = bpf.NewMapOut(createPolicyMap4V2(in.Lifecycle, in.MetricsRegistry, in.PolicyConfig, ebpf.PinByName))
+		out.IPv4Map = bpf.NewMapOut(PolicyMap4(createPolicyMap4(in.Lifecycle, in.MetricsRegistry, in.PolicyConfig, ebpf.PinByName)))
+		out.IPv4MapV2 = bpf.NewMapOut(PolicyMap4V2(createPolicyMap4V2(in.Lifecycle, in.MetricsRegistry, in.PolicyConfig, ebpf.PinByName)))
 	}
 
 	if in.EnableIPv6 {
-		out.IPv6Map = bpf.NewMapOut(createPolicyMap6(in.Lifecycle, in.MetricsRegistry, in.PolicyConfig, ebpf.PinByName))
+		out.IPv6Map = bpf.NewMapOut(PolicyMap6(createPolicyMap6(in.Lifecycle, in.MetricsRegistry, in.PolicyConfig, ebpf.PinByName)))
 	}
 
 	return
@@ -136,22 +159,22 @@ func createPolicyMapFromDaemonConfig(in struct {
 // CreatePrivatePolicyMap4 creates an unpinned IPv4 policy map.
 //
 // Useful for testing.
-func CreatePrivatePolicyMap4(lc cell.Lifecycle, registry *metrics.Registry, cfg PolicyConfig) *PolicyMap4 {
+func CreatePrivatePolicyMap4(lc cell.Lifecycle, registry *metrics.Registry, cfg PolicyConfig) PolicyMap4 {
 	return createPolicyMap4(lc, registry, cfg, ebpf.PinNone)
 }
 
-func CreatePrivatePolicyMap4V2(lc cell.Lifecycle, registry *metrics.Registry, cfg PolicyConfig) *PolicyMap4V2 {
+func CreatePrivatePolicyMap4V2(lc cell.Lifecycle, registry *metrics.Registry, cfg PolicyConfig) PolicyMap4V2 {
 	return createPolicyMap4V2(lc, registry, cfg, ebpf.PinNone)
 }
 
 // CreatePrivatePolicyMap6 creates an unpinned IPv6 policy map.
 //
 // Useful for testing.
-func CreatePrivatePolicyMap6(lc cell.Lifecycle, registry *metrics.Registry, cfg PolicyConfig) *PolicyMap6 {
+func CreatePrivatePolicyMap6(lc cell.Lifecycle, registry *metrics.Registry, cfg PolicyConfig) PolicyMap6 {
 	return createPolicyMap6(lc, registry, cfg, ebpf.PinNone)
 }
 
-func createPolicyMap4(lc cell.Lifecycle, registry *metrics.Registry, cfg PolicyConfig, pinning ebpf.PinType) *PolicyMap4 {
+func createPolicyMap4(lc cell.Lifecycle, registry *metrics.Registry, cfg PolicyConfig, pinning ebpf.PinType) *policyMap4 {
 	m := bpf.NewMap(
 		PolicyMapName4,
 		ebpf.LPMTrie,
@@ -176,10 +199,10 @@ func createPolicyMap4(lc cell.Lifecycle, registry *metrics.Registry, cfg PolicyC
 		},
 	})
 
-	return &PolicyMap4{m}
+	return &policyMap4{m}
 }
 
-func createPolicyMap4V2(lc cell.Lifecycle, registry *metrics.Registry, cfg PolicyConfig, pinning ebpf.PinType) *PolicyMap4V2 {
+func createPolicyMap4V2(lc cell.Lifecycle, registry *metrics.Registry, cfg PolicyConfig, pinning ebpf.PinType) *policyMap4V2 {
 	m := bpf.NewMap(
 		PolicyMapName4V2,
 		ebpf.LPMTrie,
@@ -204,10 +227,10 @@ func createPolicyMap4V2(lc cell.Lifecycle, registry *metrics.Registry, cfg Polic
 		},
 	})
 
-	return &PolicyMap4V2{m}
+	return &policyMap4V2{m}
 }
 
-func createPolicyMap6(lc cell.Lifecycle, registry *metrics.Registry, cfg PolicyConfig, pinning ebpf.PinType) *PolicyMap6 {
+func createPolicyMap6(lc cell.Lifecycle, registry *metrics.Registry, cfg PolicyConfig, pinning ebpf.PinType) *policyMap6 {
 	m := bpf.NewMap(
 		PolicyMapName6,
 		ebpf.LPMTrie,
@@ -232,36 +255,36 @@ func createPolicyMap6(lc cell.Lifecycle, registry *metrics.Registry, cfg PolicyC
 		},
 	})
 
-	return &PolicyMap6{m}
+	return &policyMap6{m}
 }
 
 // OpenPinnedPolicyMap4 opens an existing pinned IPv4 policy map.
-func OpenPinnedPolicyMap4(logger *slog.Logger) (*PolicyMap4, error) {
+func OpenPinnedPolicyMap4(logger *slog.Logger) (PolicyMap4, error) {
 	m, err := bpf.OpenMap(bpf.MapPath(logger, PolicyMapName4), &EgressPolicyKey4{}, &EgressPolicyVal4{})
 	if err != nil {
 		return nil, err
 	}
 
-	return &PolicyMap4{m}, nil
+	return &policyMap4{m}, nil
 }
 
-func OpenPinnedPolicyMap4V2(logger *slog.Logger) (*PolicyMap4V2, error) {
+func OpenPinnedPolicyMap4V2(logger *slog.Logger) (PolicyMap4V2, error) {
 	m, err := bpf.OpenMap(bpf.MapPath(logger, PolicyMapName4V2), &EgressPolicyKey4{}, &EgressPolicyVal4V2{})
 	if err != nil {
 		return nil, err
 	}
 
-	return &PolicyMap4V2{m}, nil
+	return &policyMap4V2{m}, nil
 }
 
 // OpenPinnedPolicyMap6 opens an existing pinned IPv6 policy map.
-func OpenPinnedPolicyMap6(logger *slog.Logger) (*PolicyMap6, error) {
+func OpenPinnedPolicyMap6(logger *slog.Logger) (PolicyMap6, error) {
 	m, err := bpf.OpenMap(bpf.MapPath(logger, PolicyMapName6), &EgressPolicyKey6{}, &EgressPolicyVal6{})
 	if err != nil {
 		return nil, err
 	}
 
-	return &PolicyMap6{m}, nil
+	return &policyMap6{m}, nil
 }
 
 // NewEgressPolicyKey4 returns a new EgressPolicyKey4 object representing the
@@ -370,7 +393,7 @@ func (v *EgressPolicyVal4V2) String() string {
 
 // Lookup returns the egress policy object associated with the provided (source
 // IP, destination CIDR) tuple.
-func (m *PolicyMap4) Lookup(sourceIP netip.Addr, destCIDR netip.Prefix) (*EgressPolicyVal4, error) {
+func (m *policyMap4) Lookup(sourceIP netip.Addr, destCIDR netip.Prefix) (*EgressPolicyVal4, error) {
 	key := NewEgressPolicyKey4(sourceIP, destCIDR)
 	val, err := m.m.Lookup(&key)
 	if err != nil {
@@ -380,7 +403,7 @@ func (m *PolicyMap4) Lookup(sourceIP netip.Addr, destCIDR netip.Prefix) (*Egress
 	return val.(*EgressPolicyVal4), err
 }
 
-func (m *PolicyMap4V2) Lookup(sourceIP netip.Addr, destCIDR netip.Prefix) (*EgressPolicyVal4V2, error) {
+func (m *policyMap4V2) Lookup(sourceIP netip.Addr, destCIDR netip.Prefix) (*EgressPolicyVal4V2, error) {
 	key := NewEgressPolicyKey4(sourceIP, destCIDR)
 	val, err := m.m.Lookup(&key)
 	if err != nil {
@@ -392,14 +415,14 @@ func (m *PolicyMap4V2) Lookup(sourceIP netip.Addr, destCIDR netip.Prefix) (*Egre
 
 // Update updates the (sourceIP, destCIDR) egress policy entry with the provided
 // egress and gateway IPs.
-func (m *PolicyMap4) Update(sourceIP netip.Addr, destCIDR netip.Prefix, egressIP, gatewayIP netip.Addr) error {
+func (m *policyMap4) Update(sourceIP netip.Addr, destCIDR netip.Prefix, egressIP, gatewayIP netip.Addr) error {
 	key := NewEgressPolicyKey4(sourceIP, destCIDR)
 	val := NewEgressPolicyVal4(egressIP, gatewayIP)
 
 	return m.m.Update(&key, &val)
 }
 
-func (m *PolicyMap4V2) Update(sourceIP netip.Addr, destCIDR netip.Prefix, egressIP, gatewayIP netip.Addr, egressIfindex uint32) error {
+func (m *policyMap4V2) Update(sourceIP netip.Addr, destCIDR netip.Prefix, egressIP, gatewayIP netip.Addr, egressIfindex uint32) error {
 	key := NewEgressPolicyKey4(sourceIP, destCIDR)
 	val := NewEgressPolicyVal4V2(egressIP, gatewayIP, egressIfindex)
 
@@ -407,13 +430,13 @@ func (m *PolicyMap4V2) Update(sourceIP netip.Addr, destCIDR netip.Prefix, egress
 }
 
 // Delete deletes the (sourceIP, destCIDR) egress policy entry.
-func (m *PolicyMap4) Delete(sourceIP netip.Addr, destCIDR netip.Prefix) error {
+func (m *policyMap4) Delete(sourceIP netip.Addr, destCIDR netip.Prefix) error {
 	key := NewEgressPolicyKey4(sourceIP, destCIDR)
 
 	return m.m.Delete(&key)
 }
 
-func (m *PolicyMap4V2) Delete(sourceIP netip.Addr, destCIDR netip.Prefix) error {
+func (m *policyMap4V2) Delete(sourceIP netip.Addr, destCIDR netip.Prefix) error {
 	key := NewEgressPolicyKey4(sourceIP, destCIDR)
 
 	return m.m.Delete(&key)
@@ -427,7 +450,7 @@ type EgressPolicyIterateCallbackV2 func(*EgressPolicyKey4, *EgressPolicyVal4V2)
 
 // IterateWithCallback iterates through all the keys/values of an egress policy
 // map, passing each key/value pair to the cb callback.
-func (m *PolicyMap4) IterateWithCallback(cb EgressPolicyIterateCallback) error {
+func (m *policyMap4) IterateWithCallback(cb EgressPolicyIterateCallback) error {
 	return m.m.DumpWithCallback(func(k bpf.MapKey, v bpf.MapValue) {
 		key := k.(*EgressPolicyKey4)
 		value := v.(*EgressPolicyVal4)
@@ -436,7 +459,7 @@ func (m *PolicyMap4) IterateWithCallback(cb EgressPolicyIterateCallback) error {
 	})
 }
 
-func (m *PolicyMap4V2) IterateWithCallback(cb EgressPolicyIterateCallbackV2) error {
+func (m *policyMap4V2) IterateWithCallback(cb EgressPolicyIterateCallbackV2) error {
 	return m.m.DumpWithCallback(func(k bpf.MapKey, v bpf.MapValue) {
 		key := k.(*EgressPolicyKey4)
 		value := v.(*EgressPolicyVal4V2)
@@ -523,7 +546,7 @@ func (v *EgressPolicyVal6) String() string {
 
 // Lookup returns the egress policy object associated with the provided (source
 // IP, destination CIDR) tuple.
-func (m *PolicyMap6) Lookup(sourceIP netip.Addr, destCIDR netip.Prefix) (*EgressPolicyVal6, error) {
+func (m *policyMap6) Lookup(sourceIP netip.Addr, destCIDR netip.Prefix) (*EgressPolicyVal6, error) {
 	key := NewEgressPolicyKey6(sourceIP, destCIDR)
 	val, err := m.m.Lookup(&key)
 	if err != nil {
@@ -535,7 +558,7 @@ func (m *PolicyMap6) Lookup(sourceIP netip.Addr, destCIDR netip.Prefix) (*Egress
 
 // Update updates the (sourceIP, destCIDR) egress policy entry with the provided
 // egress and gateway IPs.
-func (m *PolicyMap6) Update(sourceIP netip.Addr, destCIDR netip.Prefix, egressIP, gatewayIP netip.Addr, egressIfindex uint32) error {
+func (m *policyMap6) Update(sourceIP netip.Addr, destCIDR netip.Prefix, egressIP, gatewayIP netip.Addr, egressIfindex uint32) error {
 	key := NewEgressPolicyKey6(sourceIP, destCIDR)
 	val := NewEgressPolicyVal6(egressIP, gatewayIP, egressIfindex)
 
@@ -543,7 +566,7 @@ func (m *PolicyMap6) Update(sourceIP netip.Addr, destCIDR netip.Prefix, egressIP
 }
 
 // Delete deletes the (sourceIP, destCIDR) egress policy entry.
-func (m *PolicyMap6) Delete(sourceIP netip.Addr, destCIDR netip.Prefix) error {
+func (m *policyMap6) Delete(sourceIP netip.Addr, destCIDR netip.Prefix) error {
 	key := NewEgressPolicyKey6(sourceIP, destCIDR)
 
 	return m.m.Delete(&key)
@@ -556,7 +579,7 @@ type EgressPolicyIterateCallback6 func(*EgressPolicyKey6, *EgressPolicyVal6)
 
 // IterateWithCallback iterates through all the keys/values of an egress policy
 // map, passing each key/value pair to the cb callback.
-func (m *PolicyMap6) IterateWithCallback(cb EgressPolicyIterateCallback6) error {
+func (m *policyMap6) IterateWithCallback(cb EgressPolicyIterateCallback6) error {
 	return m.m.DumpWithCallback(func(k bpf.MapKey, v bpf.MapValue) {
 		key := k.(*EgressPolicyKey6)
 		value := v.(*EgressPolicyVal6)


### PR DESCRIPTION
Add the minimal scaffolding to allow for script-based controlplane testing.