### PR TITLE
aws: Assign and track EIP only on the primary ENI

### DIFF
--- a/pkg/aws/ipam/node.go
+++ b/pkg/aws/ipam/node.go
@@ -564,13 +564,17 @@ func (n *Node) AllocateIPs(ctx context.Context, a *nodemanager.AllocationAction)
 func (n *Node) AllocateStaticIP(ctx context.Context, staticIPTags ipamTypes.Tags) (string, error) {
 	n.mutex.RLock()
 	defer n.mutex.RUnlock()
+
 	for _, eni := range n.enis {
-		if !eni.PublicIP.IsValid() {
+		if eni.Number == 0 {
+			if eni.PublicIP.IsValid() {
+				return eni.PublicIP.String(), nil
+			}
 			return n.manager.ec2api.AssociateEIP(ctx, eni.ID, staticIPTags)
 		}
 	}
 
-	return "", fmt.Errorf("no ENI found to associate static IP")
+	return "", fmt.Errorf("no primary ENI found")
 }
 
 func (n *Node) getSecurityGroupIDs(ctx context.Context, eniSpec types.ENISpec) ([]string, error) {
@@ -881,6 +885,12 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *slog.Logge
 
 			n.enis[e.ID] = *e
 
+			// Check for public IP on primary ENI before exclusion logic
+			// The primary ENI may be excluded from IPAM but we still need to track its public IP
+			if e.Number == 0 && e.PublicIP.IsValid() {
+				stats.AssignedStaticIP = e.PublicIP.String()
+			}
+
 			// 3. Finally, we iterate any already existing interfaces and add on any extra
 			//		capacity to account for leftover prefix delegated /28 ip slots.
 			leftoverPrefixCapcity, effectiveLimits := n.getEffectiveIPLimits(e, limits.IPv4)
@@ -900,11 +910,6 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *slog.Logge
 
 			for _, addr := range e.Addresses {
 				available[addr.String()] = ipamTypes.AllocationIP{Resource: e.ID}
-			}
-
-			// If the primary ENI has a public IP, we store it
-			if e.Number == 0 && e.PublicIP.IsValid() {
-				stats.AssignedStaticIP = e.PublicIP.String()
 			}
 
 			return nil

--- a/pkg/aws/ipam/node_manager_test.go
+++ b/pkg/aws/ipam/node_manager_test.go
@@ -1015,6 +1015,67 @@ func TestNodeManagerStaticIPAlreadyAssociated(t *testing.T) {
 	require.Equal(t, staticIP, node.Stats().IPv4.AssignedStaticIP)
 }
 
+// TestNodeManagerStaticIPPrimaryENI verifies that the static IP is associated
+// with the primary ENI (Number == 0) even when secondary ENIs are present.
+//
+// - m5.large (3x ENIs, 2x10-2 IPs)
+// - MinAllocate 0
+// - MaxAllocate 0
+// - PreAllocate 8
+// - FirstInterfaceIndex 0
+func TestNodeManagerStaticIPPrimaryENI(t *testing.T) {
+	setup(t)
+
+	const instanceID = "i-testNodeManagerStaticIPPrimaryENI-0"
+
+	ec2api := apiMock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
+	instances, err := NewInstancesManager(t.Context(), hivetest.Logger(t), ec2api, metadataMockapi)
+	require.NoError(t, err)
+	require.NotNil(t, instances)
+
+	// Primary ENI (Number == 0).
+	primaryENI, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	require.NoError(t, err)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, primaryENI)
+	require.NoError(t, err)
+
+	// Secondary ENI (Number == 1)
+	secondaryENI, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	require.NoError(t, err)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 1, instanceID, secondaryENI)
+	require.NoError(t, err)
+
+	_, err = instances.Resync(t.Context())
+	require.NoError(t, err)
+	mngr, err := nodemanager.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, 0, false)
+	require.NoError(t, err)
+	require.NotNil(t, mngr)
+
+	staticIPTags := map[string]string{"some-eip-tag": "some-value"}
+	cn := newCiliumNode("node1", withTestDefaults(), withInstanceID(instanceID), withInstanceType("m5.large"), withIPAMPreAllocate(8), withIPAMStaticIPTags(staticIPTags))
+	mngr.Upsert(cn)
+	require.NoError(t, testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node1", 0) }, 5*time.Second))
+
+	node := mngr.Get("node1")
+	require.NotNil(t, node)
+	// Verify that the static IP has been successfully assigned.
+	require.Equal(t, "192.0.2.254", node.Stats().IPv4.AssignedStaticIP)
+
+	// Verify that the EIP was associated with the primary ENI and not with any
+	// secondary ENI.
+	instance, err := ec2api.GetInstance(t.Context(), nil, nil, instanceID)
+	require.NoError(t, err)
+	for _, iface := range instance.Interfaces {
+		eni, ok := iface.(*types.ENI)
+		require.True(t, ok)
+		if eni.Number == 0 {
+			require.Equal(t, "192.0.2.254", eni.PublicIP.String())
+		} else {
+			require.False(t, eni.PublicIP.IsValid(), "secondary ENI %s (number %d) should not have a public IP", eni.ID, eni.Number)
+		}
+	}
+}
+
 func benchmarkAllocWorker(b *testing.B, workers int64, delay time.Duration, rateLimit float64, burst int) {
 	testSubnet1 := &ipamTypes.Subnet{ID: "s-1", AvailabilityZone: "us-west-1", VirtualNetworkID: "vpc-1", AvailableAddresses: 1000000}
 	testSubnet2 := &ipamTypes.Subnet{ID: "s-2", AvailabilityZone: "us-west-1", VirtualNetworkID: "vpc-1", AvailableAddresses: 1000000}


### PR DESCRIPTION
`AllocateStaticIP` previously iterated over all ENIs and associated an Elastic IP with the first interface that had no public IP, which could lead to an attempt to attach the EIP to a secondary ENI as ENIs are stored in a map and there is no guaranteed keys ordering when iterating a map. This PR restricts association to the primary ENI (`Number == 0`), returning its existing public IP if already set.

This also moves the primary-ENI public IP tracking in `ResyncInterfacesAndIPs` ahead of the `IsExcludedBySpec` early-return, so that a primary ENI excluded from IPAM still has its public IP recorded in `stats.AssignedStaticIP`.