### PR TITLE
datapath/config: don't define unused `HOST_ENDPOINT` macro

### DIFF
--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -667,11 +667,6 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, e endpoint.Conf
 		fmt.Fprintf(fw, "#define ENABLE_ROUTING 1\n")
 	}
 
-	if e.IsHost() {
-		// Only used to differentiate between host endpoint template and other templates.
-		fmt.Fprintf(fw, "#define HOST_ENDPOINT 1\n")
-	}
-
 	// Local delivery metrics should always be set for endpoint programs.
 	fmt.Fprint(fw, "#define LOCAL_DELIVERY_METRICS 1\n")
 


### PR DESCRIPTION
The `HOST_ENDPOINT` define was never used since it was introduced in commit a695f532d060 ("Endpoint for host").