### PR TITLE
cilium-dbg: add deprecation warning to REST API based BGP commands

### DIFF
--- a/cilium-dbg/cmd/bgp_peer_get.go
+++ b/cilium-dbg/cmd/bgp_peer_get.go
@@ -40,6 +40,7 @@ var (
 					Fatalf("error getting output in JSON: %s\n", err)
 				}
 			} else {
+				fmt.Fprint(cmd.OutOrStderr(), "Command \"peers\" is deprecated, Use the subcommand: \"shell bgp/peers\"\n")
 				w := NewTabWriter()
 				payload := res.GetPayload()
 				if showCaps {

--- a/cilium-dbg/cmd/bgp_route_get.go
+++ b/cilium-dbg/cmd/bgp_route_get.go
@@ -90,6 +90,7 @@ var BgpRoutesCmd = &cobra.Command{
 				Fatalf("failed getting output in JSON: %s\n", err)
 			}
 		} else {
+			fmt.Fprint(cmd.OutOrStderr(), "Command \"routes\" is deprecated, Use the subcommand: \"shell bgp/routes\"\n")
 			// print peer addresses for `advertised` routes without specifying a peer
 			printPeer := (params.TableType == adjRIBOutTableType) && (params.Neighbor == nil || *params.Neighbor == "")
 			w := NewTabWriter()

--- a/cilium-dbg/cmd/bgp_route_policy_get.go
+++ b/cilium-dbg/cmd/bgp_route_policy_get.go
@@ -49,6 +49,7 @@ var BgpRoutePoliciesCmd = &cobra.Command{
 				Fatalf("error getting output in JSON: %s\n", err)
 			}
 		} else {
+			fmt.Fprint(cmd.OutOrStderr(), "Command \"route-policies\" is deprecated, Use the subcommand: \"shell bgp/route-policies\"\n")
 			w := NewTabWriter()
 			api.PrintBGPRoutePoliciesTable(w, res.GetPayload())
 		}


### PR DESCRIPTION
BGP local REST API is deprecated add deprecation warning to commands use it: cilim-dbg `bgp peers`, `bgp routes` and `bgp route-policies`.