### PR TITLE
 bgp: update container lab documentation to use the new hive shell commands

### DIFF
--- a/contrib/containerlab/auto-discovery/default-gateway/multi-homing/README.md
+++ b/contrib/containerlab/auto-discovery/default-gateway/multi-homing/README.md
@@ -81,19 +81,19 @@ Verification
 ------------
 **BGP Peering**
 ```
-root@bgp-cplane-dev-mh-worker:/home/cilium# cilium bgp peers
-Local AS   Peer AS   Peer Address         Session       Uptime   Family         Received   Advertised
-65001      65000     fd00:11:0:2::1:179   established   21m55s   ipv4/unicast   2          2    
-                                                                 ipv6/unicast   2          2 
+root@bgp-cplane-dev-mh-worker:/home/cilium# cilium-dbg shell -- bgp/peers         
+Instance   Peer         Session State   Uptime   Family         Received   Accepted   Advertised
+65001      ipv6-65000   established     1m27s    ipv4-unicast   2          0          1
+                                                 ipv6-unicast   2          0          1
 
 ```
 
 **BGP Routes**
 
 ```
-root@bgp-cplane-dev-mh-worker:/home/cilium# cilium bgp routes advertised ipv4 unicast
-VRouter   Peer             Prefix        NextHop          Age      Attrs
-65001     fd00:11:0:2::1   10.1.1.0/24   fd00:11:0:2::2   22m18s   [{Origin: i} {AsPath: 65001} {MpReach(ipv4-unicast): {Nexthop: fd00:11:0:2::2, NLRIs: [10.1.1.0/24]}}] 
+root@bgp-cplane-dev-mh-worker:/home/cilium# cilium-dbg shell -- bgp/routes out ipv4 unicast -a
+Instance   Peer         Prefix        NextHop          Age     Attrs
+65001      ipv6-65000   10.1.1.0/24   fd00:11:0:2::2   2m21s   [{Origin: i} {AsPath: 65001}]
 ```
 
 On peering routers we can see 10.1.1.0/24 prefix with appropriate route attributes and configured router ID.
@@ -127,18 +127,18 @@ if the default route fails for any reason like interface going down, it will tri
 **BGP Peering**
 
 ```
-root@bgp-cplane-dev-mh-worker:/home/cilium# cilium bgp peers
-Local AS   Peer AS   Peer Address         Session       Uptime   Family         Received   Advertised
-65001      65000     fd00:10:0:2::1:179   established   42s      ipv4/unicast   2          2    
-                                                                 ipv6/unicast   2          2  
+root@bgp-cplane-dev-mh-worker:/home/cilium# cilium-dbg shell -- bgp/peers
+Instance   Peer         Session State   Uptime   Family         Received   Accepted   Advertised
+65001      ipv6-65000   established     9s       ipv4-unicast   1          0          1
+                                                 ipv6-unicast   1          0          1
 ```
 
 **BGP Routes**
 
 ```
-root@bgp-cplane-dev-mh-worker:/home/cilium# cilium bgp routes advertised ipv4 unicast
-VRouter   Peer             Prefix        NextHop          Age     Attrs
-65001     fd00:10:0:2::1   10.1.1.0/24   fd00:10:0:2::2   3m26s   [{Origin: i} {AsPath: 65001} {MpReach(ipv4-unicast): {Nexthop: fd00:10:0:2::2, NLRIs: [10.1.1.0/24]}}] 
+root@bgp-cplane-dev-mh-worker:/home/cilium# cilium-dbg shell -- bgp/routes out ipv4 unicast -a
+Instance   Peer         Prefix        NextHop          Age      Attrs
+65001      ipv6-65000   10.1.1.0/24   fd00:10:0:2::2   10m39s   [{Origin: i} {AsPath: 65001}]
 ```
 
 On one of the peering router we can see 10.1.1.0/24 prefix with appropriate route attributes and configured router ID.

--- a/contrib/containerlab/multi-homing/README.md
+++ b/contrib/containerlab/multi-homing/README.md
@@ -99,12 +99,12 @@ Verification
 **BGP Peering**
 
 ```
-root@bgp-cplane-dev-multi-homing-worker:/home/cilium# cilium bgp peers
-Local AS   Peer AS   Peer Address     Session       Uptime   Family         Received   Advertised
-65001      65000     fd00:10::1:179   established   4m45s    ipv4/unicast   0          2
-                                                             ipv6/unicast   0          2
-65001      65011     fd00:11::1:179   established   4m47s    ipv4/unicast   0          2
-                                                             ipv6/unicast   0          2
+root@bgp-cplane-dev-multi-homing-worker:/home/cilium# cilium-dbg shell -- bgp/peers
+Instance   Peer    Session State   Uptime   Family         Received   Accepted   Advertised
+65001      65000   established     1m9s     ipv4-unicast   0          0          1
+                                            ipv6-unicast   0          0          1
+           65011   established     1m9s     ipv4-unicast   0          0          1
+                                            ipv6-unicast   0          0          1
 
 ```
 
@@ -113,10 +113,10 @@ Local AS   Peer AS   Peer Address     Session       Uptime   Family         Rece
 PodCIDR is 10.1.1.0 on this node, which is advertised with communities attribute 'no-export'.
 
 ```
-root@bgp-cplane-dev-multi-homing-worker:/home/cilium# cilium bgp routes advertised ipv4 unicast
-VRouter   Peer         Prefix        NextHop          Age     Attrs
-65001     fd00:10::1   10.1.1.0/24   fd00:10:0:2::2   5m35s   [{Origin: i} {AsPath: 65001} {Communities: no-export} {MpReach(ipv4-unicast): {Nexthop: fd00:10:0:2::2, NLRIs: [10.1.1.0/24]}}]
-65001     fd00:11::1   10.1.1.0/24   fd00:11:0:2::2   5m35s   [{Origin: i} {AsPath: 65001} {Communities: no-export} {MpReach(ipv4-unicast): {Nexthop: fd00:11:0:2::2, NLRIs: [10.1.1.0/24]}}]
+root@bgp-cplane-dev-multi-homing-worker:/home/cilium# cilium-dbg shell -- bgp/routes out ipv4 unicast -a
+Instance   Peer    Prefix        NextHop          Age     Attrs
+65001      65000   10.1.1.0/24   fd00:10:0:2::2   1m24s   [{Origin: i} {AsPath: 65001} {Communities: no-export}]
+           65011   10.1.1.0/24   fd00:11:0:2::2   1m24s   [{Origin: i} {AsPath: 65001} {Communities: no-export}]
 ```
 
 On peering routers we can see 10.1.1.0/24 prefix with appropriate route attributes and configured router ID.

--- a/contrib/containerlab/pod-ip-pool/README.md
+++ b/contrib/containerlab/pod-ip-pool/README.md
@@ -90,15 +90,15 @@ Verification
 **BGP Advertisement**
 
 ```
-root@bgp-cplane-dev-pod-ip-pool-worker:/home/cilium# cilium bgp routes advertised ipv4 unicast
-VRouter   Peer         Prefix          NextHop          Age     Attrs
-65001     fd00:10::1   10.100.1.0/24   fd00:10:0:2::2   4m14s   [{Origin: i} {AsPath: 65001} {Communities: 65000:100} {MpReach(ipv4-unicast): {Nexthop: fd00:10:0:2::2, NLRIs: [10.100.1.0/24]}}]
-65001     fd00:10::1   10.200.0.0/24   fd00:10:0:2::2   3m57s   [{Origin: i} {AsPath: 65001} {Communities: 65000:200} {MpReach(ipv4-unicast): {Nexthop: fd00:10:0:2::2, NLRIs: [10.200.0.0/24]}}]
+root@bgp-cplane-dev-pod-ip-pool-worker:/home/cilium# cilium-dbg shell -- bgp/routes out ipv4 unicast -a
+Instance   Peer    Prefix          NextHop          Age    Attrs
+65001      65000   10.100.0.0/24   fd00:10:0:2::2   1m6s   [{Origin: i} {AsPath: 65001} {Communities: 65000:100}]
+                   10.200.1.0/24   fd00:10:0:2::2   1m6s   [{Origin: i} {AsPath: 65001} {Communities: 65000:200}]
 
-root@bgp-cplane-dev-pod-ip-pool-worker:/home/cilium# cilium bgp routes advertised ipv6 unicast
-VRouter   Peer         Prefix              NextHop          Age     Attrs
-65001     fd00:10::1   fd00:100:1:1::/64   fd00:10:0:2::2   4m43s   [{Origin: i} {AsPath: 65001} {Communities: 65000:100} {MpReach(ipv6-unicast): {Nexthop: fd00:10:0:2::2, NLRIs: [fd00:100:1:1::/64]}}]
-65001     fd00:10::1   fd00:200:1:2::/64   fd00:10:0:2::2   4m11s   [{Origin: i} {AsPath: 65001} {Communities: 65000:200} {MpReach(ipv6-unicast): {Nexthop: fd00:10:0:2::2, NLRIs: [fd00:200:1:2::/64]}}]
+root@bgp-cplane-dev-pod-ip-pool-worker:/home/cilium# cilium-dbg shell -- bgp/routes out ipv6 unicast -a
+Instance   Peer    Prefix              NextHop          Age    Attrs
+65001      65000   fd00:100:1:2::/64   fd00:10:0:2::2   1m9s   [{Origin: i} {AsPath: 65001} {Communities: 65000:100}]
+                   fd00:200:1:3::/64   fd00:10:0:2::2   1m9s   [{Origin: i} {AsPath: 65001} {Communities: 65000:200}]
 ```
 
 **Router0**

--- a/contrib/containerlab/pod-ip-pool/bgp.yaml
+++ b/contrib/containerlab/pod-ip-pool/bgp.yaml
@@ -1,7 +1,7 @@
 apiVersion: cilium.io/v2alpha1
 kind: CiliumPodIPPool
 metadata:
-  name: default
+  name: blue-pool
   labels:
     pool: blue
 spec:
@@ -93,6 +93,26 @@ spec:
       attributes:
         communities:
           standard: [ "65000:200" ]
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: curl-blue
+spec:
+  selector:
+    matchLabels:
+      app: curl-blue
+  template:
+    metadata:
+      labels:
+        app: curl-blue
+      annotations:
+        "ipam.cilium.io/ip-pool": "blue-pool"
+    spec:
+      containers:
+        - name: curl
+          image: curlimages/curl
+          command: ["sleep", "infinit"]
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/contrib/containerlab/pod-ip-pool/values.yaml
+++ b/contrib/containerlab/pod-ip-pool/values.yaml
@@ -16,10 +16,22 @@ ipv6NativeRoutingCIDR: fd00::/16
 
 ipam:
   mode: multi-pool
+  operator:
+    autoCreateCiliumPodIPPools:
+      default:
+        ipv4:
+          cidrs:
+            - 10.10.0.0/16
+          maskSize: 24
+        ipv6:
+          cidrs:
+            - fd00:10:1::/48
+          maskSize: 64
 
-k8s:
-  requireIPv4PodCIDR: true
-  requireIPv6PodCIDR: true
+kubeProxyReplacement: true
+
+bpf:
+  masquerade: true
 
 operator:
   enabled: true


### PR DESCRIPTION
 - Add default CiliumPodIPPool to autocreate in values.yaml.
- Add blue-pool instead of default CiliumPodIPPool in bgp.yaml.
- Update auto-discovery, multi-homing and pod-ip-pool container labs to use the new hive shell commands in `README.md`.