### PR TITLE
wireguard: include health and ingress IPs in peer routes

### DIFF
--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cilium/cilium/pkg/counter"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
-	iputil "github.com/cilium/cilium/pkg/ip"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/labels"
@@ -909,21 +908,52 @@ func (ipc *IPCache) LookupByIdentity(id identity.NumericIdentity) (ips []string)
 	return ips
 }
 
-// LookupByHostRLocked returns the list of IPs returns the set of IPs
-// (endpoint or CIDR prefix) that have hostIPv4 or hostIPv6 associated as the
-// host of the entry. Requires the caller to hold the RLock.
+// LookupByHostRLocked returns the list of IPs (endpoint or CIDR prefix) that
+// have hostIPv4 or hostIPv6 associated as the host of the entry.
+// If an endpoint IP and an equivalent single-IP CIDR both
+// exist, the endpoint IP owns the returned prefix. Requires the caller to hold
+// the RLock.
 func (ipc *IPCache) LookupByHostRLocked(hostIPv4, hostIPv6 net.IP) (cidrs []net.IPNet) {
+	type hostEntry struct {
+		ipnet      net.IPNet
+		host       IPKeyPair
+		isEndpoint bool
+	}
+
+	entries := map[netip.Prefix]hostEntry{}
 	for ip, host := range ipc.ipToHostIPCache {
-		if hostIPv4 != nil && host.IP.Equal(hostIPv4) || hostIPv6 != nil && host.IP.Equal(hostIPv6) {
-			_, cidr, err := net.ParseCIDR(ip)
-			if err != nil {
-				endpointIP := net.ParseIP(ip)
-				cidr = iputil.IPToPrefix(endpointIP)
+		pfx, ipnet, isEndpoint, ok := hostEntryPrefix(ip)
+		if !ok {
+			continue
+		}
+		entry, found := entries[pfx]
+		if !found || isEndpoint && !entry.isEndpoint {
+			entries[pfx] = hostEntry{
+				ipnet:      ipnet,
+				host:       host,
+				isEndpoint: isEndpoint,
 			}
-			cidrs = append(cidrs, *cidr)
+		}
+	}
+
+	for _, entry := range entries {
+		if (hostIPv4 != nil && entry.host.IP.Equal(hostIPv4)) ||
+			(hostIPv6 != nil && entry.host.IP.Equal(hostIPv6)) {
+			cidrs = append(cidrs, entry.ipnet)
 		}
 	}
 	return cidrs
+}
+
+func hostEntryPrefix(ip string) (netip.Prefix, net.IPNet, bool, bool) {
+	if cidrCluster, err := cmtypes.ParsePrefixCluster(ip); err == nil {
+		return cidrCluster.AsPrefix(), cidrCluster.AsIPNet(), false, true
+	}
+	if addrCluster, err := cmtypes.ParseAddrCluster(ip); err == nil {
+		cidrCluster := addrCluster.AsPrefixCluster()
+		return cidrCluster.AsPrefix(), cidrCluster.AsIPNet(), true, true
+	}
+	return netip.Prefix{}, net.IPNet{}, false, false
 }
 
 // Equal returns true if two K8sMetadata pointers contain the same data or are

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -244,6 +244,82 @@ func TestIPCache(t *testing.T) {
 	require.Empty(t, s.IPIdentityCache.identityToIPCache)
 }
 
+func TestIPCacheLookupByHostRLockedEndpointOwnsEquivalentCIDR(t *testing.T) {
+	s := setupIPCacheTestSuite(t)
+	t.Parallel()
+
+	endpointIP := "fd00::100"
+	_, ipnet, err := net.ParseCIDR(endpointIP + "/128")
+	require.NoError(t, err)
+
+	cidrHostIP := net.ParseIP("fd01::1")
+	endpointHostIP := net.ParseIP("fd01::2")
+
+	_, err = s.IPIdentityCache.Upsert(endpointIP+"/128", cidrHostIP, 0, nil, Identity{
+		ID:     identityPkg.NumericIdentity(1001),
+		Source: source.Kubernetes,
+	})
+	require.NoError(t, err)
+	_, err = s.IPIdentityCache.Upsert(endpointIP, endpointHostIP, 0, nil, Identity{
+		ID:     identityPkg.NumericIdentity(1002),
+		Source: source.Kubernetes,
+	})
+	require.NoError(t, err)
+
+	requireLookupByHostContains(t, s.IPIdentityCache, nil, endpointHostIP, ipnet)
+	requireLookupByHostMissing(t, s.IPIdentityCache, nil, cidrHostIP, ipnet)
+}
+
+func TestIPCacheLookupByHostRLockedCIDROwnsWhenEndpointHasNoHost(t *testing.T) {
+	s := setupIPCacheTestSuite(t)
+	t.Parallel()
+
+	endpointIP := "fd00::100"
+	_, ipnet, err := net.ParseCIDR(endpointIP + "/128")
+	require.NoError(t, err)
+
+	cidrHostIP := net.ParseIP("fd01::1")
+
+	_, err = s.IPIdentityCache.Upsert(endpointIP, nil, 0, nil, Identity{
+		ID:     identityPkg.NumericIdentity(1001),
+		Source: source.Kubernetes,
+	})
+	require.NoError(t, err)
+	_, err = s.IPIdentityCache.Upsert(endpointIP+"/128", cidrHostIP, 0, nil, Identity{
+		ID:     identityPkg.NumericIdentity(1002),
+		Source: source.Kubernetes,
+	})
+	require.NoError(t, err)
+
+	requireLookupByHostContains(t, s.IPIdentityCache, nil, cidrHostIP, ipnet)
+}
+
+func requireLookupByHostContains(t *testing.T, ipCache *IPCache, hostIPv4, hostIPv6 net.IP, expectedIP *net.IPNet) {
+	t.Helper()
+
+	ipCache.RLock()
+	defer ipCache.RUnlock()
+
+	cidrs := ipCache.LookupByHostRLocked(hostIPv4, hostIPv6)
+	require.True(t, containsIPNet(cidrs, expectedIP), "LookupByHostRLocked does not contain %s", expectedIP.String())
+}
+
+func requireLookupByHostMissing(t *testing.T, ipCache *IPCache, hostIPv4, hostIPv6 net.IP, expectedIP *net.IPNet) {
+	t.Helper()
+
+	ipCache.RLock()
+	defer ipCache.RUnlock()
+
+	cidrs := ipCache.LookupByHostRLocked(hostIPv4, hostIPv6)
+	require.False(t, containsIPNet(cidrs, expectedIP), "LookupByHostRLocked still contains %s", expectedIP.String())
+}
+
+func containsIPNet(cidrs []net.IPNet, expectedIP *net.IPNet) bool {
+	return slices.ContainsFunc(cidrs, func(ipnet net.IPNet) bool {
+		return ipnet.String() == expectedIP.String()
+	})
+}
+
 func TestIPCacheNamedPorts(t *testing.T) {
 	s := setupIPCacheTestSuite(t)
 	t.Parallel()

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -522,10 +522,6 @@ func (a *Agent) updatePeer(nodeName, pubKeyHex string, nodeIPv4, nodeIPv6 net.IP
 	// Initialize peer if this is the first time we are processing this node.
 	if peer == nil {
 		peer = &peerConfig{}
-
-		if a.needsIPCache() {
-			peer.queueAllowedIPsInsert(a.ipCache.LookupByHostRLocked(nodeIPv4, nodeIPv6)...)
-		}
 	}
 
 	// Handle Node IP change
@@ -549,18 +545,27 @@ func (a *Agent) updatePeer(nodeName, pubKeyHex string, nodeIPv4, nodeIPv6 net.IP
 			IP:   nodeIPv4,
 			Mask: net.CIDRMask(net.IPv4len*8, net.IPv4len*8),
 		}
-		if !peer.hasAllowedIP(ipn) {
-			peer.queueAllowedIPsInsert(ipn)
-		}
+		peer.ensureAllowedIPDesired(ipn)
 	}
 	if a.config.EnableIPv6 && nodeIPv6 != nil {
 		ipn := net.IPNet{
 			IP:   nodeIPv6,
 			Mask: net.CIDRMask(net.IPv6len*8, net.IPv6len*8),
 		}
-		if !peer.hasAllowedIP(ipn) {
-			peer.queueAllowedIPsInsert(ipn)
+		peer.ensureAllowedIPDesired(ipn)
+	}
+
+	if a.needsIPCache() {
+		ipCacheAllowedIPs := a.ipCache.LookupByHostRLocked(nodeIPv4, nodeIPv6)
+		if peer.nodeIPv4 != nil && !peer.nodeIPv4.Equal(nodeIPv4) ||
+			peer.nodeIPv6 != nil && !peer.nodeIPv6.Equal(nodeIPv6) {
+			for _, ipn := range a.ipCache.LookupByHostRLocked(peer.nodeIPv4, peer.nodeIPv6) {
+				if peer.hasIPCacheAllowedIP(ipn) || peer.hasAllowedIP(ipn) {
+					ipCacheAllowedIPs = append(ipCacheAllowedIPs, ipn)
+				}
+			}
 		}
+		peer.syncIPCacheAllowedIPs(ipCacheAllowedIPs, nodeIPv4, nodeIPv6)
 	}
 
 	ep := ""
@@ -693,6 +698,8 @@ func (a *Agent) updatePeerByConfig(p *peerConfig) error {
 		if err := a.wgClient.ConfigureDevice(types.IfaceName, cfg); err != nil {
 			return fmt.Errorf("while adding IPs to peer: %w", err)
 		}
+		p.finishAllowedIPSync(addedIPs)
+		a.forgetIPCacheAllowedIPsFromOtherPeers(p, addedIPs)
 	}
 
 	// WireGuard's netlink API does not support direct removal of allowed IPs
@@ -739,10 +746,27 @@ func (a *Agent) updatePeerByConfig(p *peerConfig) error {
 		}
 	}
 
-	p.finishAllowedIPSync(addedIPs)
 	p.finishAllowedIPSync(removedIPs)
 
 	return nil
+}
+
+func (a *Agent) forgetIPCacheAllowedIPsFromOtherPeers(updatedPeer *peerConfig, insertedIPs []net.IPNet) {
+	for _, insertedIP := range insertedIPs {
+		if !updatedPeer.hasIPCacheAllowedIP(insertedIP) {
+			continue
+		}
+
+		for _, peer := range a.peerByNodeName {
+			if peer == updatedPeer || !peer.hasIPCacheAllowedIP(insertedIP) {
+				continue
+			}
+			if isNodeIPPrefix(ipnetToPrefix(insertedIP), peer.nodeIPv4, peer.nodeIPv6) {
+				continue
+			}
+			peer.forgetIPCacheAllowedIP(insertedIP)
+		}
+	}
 }
 
 func loadOrGeneratePrivKey(filePath string) (key wgtypes.Key, err error) {
@@ -797,29 +821,44 @@ func (a *Agent) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidrC
 	// which for which we already know the public key. If a node opts out of
 	// encryption, it will not announce it's public key and thus will not be
 	// part of the nodeNameByNodeIP map.
-	var updatedPeer *peerConfig
-	switch {
-	case modType == ipcache.Delete && oldHostIP != nil:
-		if nodeName, ok := a.nodeNameByNodeIP[oldHostIP.String()]; ok {
-			if peer := a.peerByNodeName[nodeName]; peer != nil {
-				if peer.hasAllowedIP(ipnet) {
-					peer.queueAllowedIPsRemove(ipnet)
-					updatedPeer = peer
-				}
-			}
+	var updatedPeers []*peerConfig
+	seenPeers := map[*peerConfig]struct{}{}
+	addPeerByHostIP := func(hostIP net.IP) {
+		if hostIP == nil {
+			return
 		}
-	case modType == ipcache.Upsert && newHostIP != nil:
-		if nodeName, ok := a.nodeNameByNodeIP[newHostIP.String()]; ok {
-			if peer := a.peerByNodeName[nodeName]; peer != nil {
-				if !peer.hasAllowedIP(ipnet) {
-					peer.queueAllowedIPsInsert(ipnet)
-					updatedPeer = peer
-				}
-			}
+		nodeName, ok := a.nodeNameByNodeIP[hostIP.String()]
+		if !ok {
+			return
 		}
+		peer := a.peerByNodeName[nodeName]
+		if peer == nil {
+			return
+		}
+		if _, ok := seenPeers[peer]; ok {
+			return
+		}
+		seenPeers[peer] = struct{}{}
+		updatedPeers = append(updatedPeers, peer)
 	}
 
-	if updatedPeer != nil {
+	// Process the new host first so an IPCache-owned AllowedIP can transfer to
+	// the new peer by WireGuard's normal "steal" behavior. After a successful
+	// insert, updatePeerByConfig forgets matching IPCache-owned prefixes from
+	// other peers without using the dummy-peer removal path.
+	if modType == ipcache.Upsert {
+		addPeerByHostIP(newHostIP)
+	}
+	if oldHostIP != nil && (newHostIP == nil || !oldHostIP.Equal(newHostIP)) {
+		addPeerByHostIP(oldHostIP)
+	}
+
+	for _, updatedPeer := range updatedPeers {
+		updatedPeer.syncIPCacheAllowedIPs(
+			a.ipCache.LookupByHostRLocked(updatedPeer.nodeIPv4, updatedPeer.nodeIPv6),
+			updatedPeer.nodeIPv4,
+			updatedPeer.nodeIPv6,
+		)
 		if err := a.updatePeerByConfig(updatedPeer); err != nil {
 			a.logger.Error(
 				"Failed to update WireGuard peer after ipcache update",
@@ -830,6 +869,7 @@ func (a *Agent) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidrC
 				logfields.NewNode, newHostIP,
 				logfields.PubKey, updatedPeer.pubKey,
 			)
+			return
 		}
 	}
 }
@@ -928,6 +968,7 @@ type peerConfig struct {
 	allowedIPs         map[netip.Prefix]net.IPNet
 	needsInsert        map[netip.Prefix]net.IPNet
 	needsRemove        map[netip.Prefix]net.IPNet
+	ipCacheAllowedIPs  map[netip.Prefix]net.IPNet
 }
 
 func (p *peerConfig) lazyInitMaps() {
@@ -970,6 +1011,106 @@ func (p *peerConfig) queueAllowedIPsRemove(ips ...net.IPNet) {
 		p.needsRemove[pfx] = ip
 		delete(p.needsInsert, pfx)
 	}
+}
+
+func (p *peerConfig) syncIPCacheAllowedIPs(desiredIPs []net.IPNet, nodeIPv4, nodeIPv6 net.IP) {
+	if p.ipCacheAllowedIPs == nil {
+		p.ipCacheAllowedIPs = map[netip.Prefix]net.IPNet{}
+	}
+
+	desired := map[netip.Prefix]net.IPNet{}
+	for _, ipn := range desiredIPs {
+		pfx := ipnetToPrefix(ipn)
+		desired[pfx] = ipn
+		p.ipCacheAllowedIPs[pfx] = ipn
+		p.ensureAllowedIPDesired(ipn)
+	}
+
+	for pfx, ipn := range p.ipCacheAllowedIPs {
+		if _, ok := desired[pfx]; ok {
+			continue
+		}
+
+		delete(p.ipCacheAllowedIPs, pfx)
+		delete(p.needsInsert, pfx)
+		if isNodeIPPrefix(pfx, nodeIPv4, nodeIPv6) {
+			continue
+		}
+		if p.hasAllowedIP(ipn) {
+			p.queueAllowedIPsRemove(ipn)
+		}
+	}
+
+	if len(p.ipCacheAllowedIPs) == 0 {
+		p.ipCacheAllowedIPs = nil
+	}
+}
+
+func (p *peerConfig) ensureAllowedIPDesired(ip net.IPNet) bool {
+	if p.hasAllowedIP(ip) && !p.hasAllowedIPQueuedForRemoval(ip) {
+		return false
+	}
+	p.queueAllowedIPsInsert(ip)
+	return true
+}
+
+func (p *peerConfig) hasAllowedIPQueuedForRemoval(ip net.IPNet) bool {
+	if p.needsRemove == nil {
+		return false
+	}
+	_, ok := p.needsRemove[ipnetToPrefix(ip)]
+	return ok
+}
+
+func (p *peerConfig) hasIPCacheAllowedIP(ip net.IPNet) bool {
+	if p.ipCacheAllowedIPs == nil {
+		return false
+	}
+	_, ok := p.ipCacheAllowedIPs[ipnetToPrefix(ip)]
+	return ok
+}
+
+func (p *peerConfig) forgetIPCacheAllowedIP(ip net.IPNet) {
+	pfx := ipnetToPrefix(ip)
+	delete(p.ipCacheAllowedIPs, pfx)
+	delete(p.allowedIPs, pfx)
+	delete(p.needsInsert, pfx)
+	delete(p.needsRemove, pfx)
+
+	if len(p.ipCacheAllowedIPs) == 0 {
+		p.ipCacheAllowedIPs = nil
+	}
+	if len(p.allowedIPs) == 0 {
+		p.allowedIPs = nil
+	}
+	if len(p.needsInsert) == 0 {
+		p.needsInsert = nil
+	}
+	if len(p.needsRemove) == 0 {
+		p.needsRemove = nil
+	}
+}
+
+func isNodeIPPrefix(pfx netip.Prefix, nodeIPv4, nodeIPv6 net.IP) bool {
+	if nodeIPv4 != nil {
+		ipn := net.IPNet{
+			IP:   nodeIPv4,
+			Mask: net.CIDRMask(net.IPv4len*8, net.IPv4len*8),
+		}
+		if pfx == ipnetToPrefix(ipn) {
+			return true
+		}
+	}
+	if nodeIPv6 != nil {
+		ipn := net.IPNet{
+			IP:   nodeIPv6,
+			Mask: net.CIDRMask(net.IPv6len*8, net.IPv6len*8),
+		}
+		if pfx == ipnetToPrefix(ipn) {
+			return true
+		}
+	}
+	return false
 }
 
 // queuedAllowedIPUpdates returns the set of allowed IP insertions and removals

--- a/pkg/wireguard/agent/agent_test.go
+++ b/pkg/wireguard/agent/agent_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	iputil "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
+	nodeaddressing "github.com/cilium/cilium/pkg/node/addressing"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/wireguard/types"
@@ -30,6 +32,9 @@ import (
 type fakeWgClient struct {
 	allowedIPs map[netip.Prefix]wgtypes.Key
 	peers      map[wgtypes.Key]wgtypes.Peer
+	err        error
+	errOnCall  int
+	calls      int
 }
 
 func newFakeWgClient(peers ...wgtypes.Peer) *fakeWgClient {
@@ -69,6 +74,11 @@ func (f *fakeWgClient) ConfigureDevice(name string, cfg wgtypes.Config) error {
 
 	if cfg.ReplacePeers {
 		clear(f.peers)
+	}
+
+	f.calls++
+	if f.err != nil && (f.errOnCall == 0 || f.errOnCall == f.calls) {
+		return f.err
 	}
 
 	for _, peer := range cfg.Peers {
@@ -187,6 +197,94 @@ func containsIP(allowedIPs iter.Seq[net.IPNet], ipnet *net.IPNet) bool {
 		}
 	}
 	return false
+}
+
+func testNode(name, pubKey string, ipv4, ipv6, health4, health6, ingress4, ingress6 net.IP) nodeTypes.Node {
+	node := nodeTypes.Node{
+		Name:            name,
+		WireguardPubKey: pubKey,
+		IPv4HealthIP:    health4,
+		IPv6HealthIP:    health6,
+		IPv4IngressIP:   ingress4,
+		IPv6IngressIP:   ingress6,
+	}
+	if ipv4 != nil {
+		node.IPAddresses = append(node.IPAddresses, nodeTypes.Address{
+			Type: nodeaddressing.NodeInternalIP,
+			IP:   ipv4,
+		})
+	}
+	if ipv6 != nil {
+		node.IPAddresses = append(node.IPAddresses, nodeTypes.Address{
+			Type: nodeaddressing.NodeInternalIP,
+			IP:   ipv6,
+		})
+	}
+	return node
+}
+
+func requirePeerAllowedIP(t *testing.T, wgClient *fakeWgClient, pubKey string, ipnet *net.IPNet) {
+	t.Helper()
+
+	allowedIPs := requirePeerAllowedIPs(t, wgClient, pubKey)
+	require.True(t, containsIP(slices.Values(allowedIPs), ipnet), "AllowedIPs does not contain %s", ipnet.String())
+}
+
+func requirePeerMissingAllowedIP(t *testing.T, wgClient *fakeWgClient, pubKey string, ipnet *net.IPNet) {
+	t.Helper()
+
+	allowedIPs := requirePeerAllowedIPs(t, wgClient, pubKey)
+	require.False(t, containsIP(slices.Values(allowedIPs), ipnet), "AllowedIPs still contains %s", ipnet.String())
+}
+
+func requirePeerAllowedIPs(t *testing.T, wgClient *fakeWgClient, pubKey string) []net.IPNet {
+	t.Helper()
+
+	key, err := wgtypes.ParseKey(pubKey)
+	require.NoError(t, err)
+	peer, ok := wgClient.peers[key]
+	require.True(t, ok, "missing peer for public key %s", pubKey)
+	return peer.AllowedIPs
+}
+
+func requireAllowedIPOwner(t *testing.T, wgClient *fakeWgClient, ipnet *net.IPNet, pubKey string) {
+	t.Helper()
+
+	expectedKey, err := wgtypes.ParseKey(pubKey)
+	require.NoError(t, err)
+	actualKey, ok := wgClient.allowedIPs[ipnetToPrefix(*ipnet)]
+	require.True(t, ok, "missing owner for AllowedIP %s", ipnet.String())
+	require.Equal(t, expectedKey, actualKey)
+}
+
+func newIPv6NativeRoutingTestAgent(t *testing.T) (*Agent, *ipcache.IPCache, *fakeWgClient) {
+	t.Helper()
+
+	wgClient := newFakeWgClient()
+	cfg := (&config{
+		RoutingMode: option.RoutingModeNative,
+	}).toAgentConfig()
+	cfg.EnableIPv4 = false
+	cfg.EnableIPv6 = true
+	wgAgent, ipCache := newTestAgent(t.Context(), hivetest.Logger(t), wgClient, cfg)
+	t.Cleanup(func() {
+		ipCache.Shutdown()
+	})
+
+	return wgAgent, ipCache, wgClient
+}
+
+func upsertIPCacheEntry(t *testing.T, ipCache *ipcache.IPCache, ip string, hostIP net.IP, identity ipcache.Identity) {
+	t.Helper()
+
+	_, err := ipCache.Upsert(ip, hostIP, 0, nil, identity)
+	require.NoError(t, err)
+}
+
+func deleteIPCacheEntry(t *testing.T, ipCache *ipcache.IPCache, ip string) {
+	t.Helper()
+
+	ipCache.Delete(ip, source.Kubernetes)
 }
 
 func newTestAgent(ctx context.Context, logger *slog.Logger, wgClient wireguardClient, config Config) (*Agent, *ipcache.IPCache) {
@@ -399,6 +497,136 @@ func TestAgent_PeerConfig(t *testing.T) {
 			require.Empty(t, wgAgent.nodeNameByPubKey)
 		})
 	}
+}
+
+func TestAgent_IPCacheValidationBackfillsShadowedCIDR(t *testing.T) {
+	wgAgent, ipCache, wgClient := newIPv6NativeRoutingTestAgent(t)
+
+	node := testNode(k8s1NodeName, k8s1PubKey, nil, k8s1NodeIPv6, nil, nil, nil, nil)
+	err := wgAgent.NodeAdd(node)
+	require.NoError(t, err)
+
+	ip := net.ParseIP("fd00::100")
+	prefix := iputil.IPToPrefix(ip)
+	upsertIPCacheEntry(t, ipCache, ip.String(), nil, ipcache.Identity{ID: 1001, Source: source.Kubernetes})
+	upsertIPCacheEntry(t, ipCache, prefix.String(), k8s1NodeIPv6, ipcache.Identity{ID: 1002, Source: source.Kubernetes})
+
+	requirePeerMissingAllowedIP(t, wgClient, k8s1PubKey, prefix)
+
+	err = wgAgent.NodeValidateImplementation(node)
+	require.NoError(t, err)
+	requirePeerAllowedIP(t, wgClient, k8s1PubKey, prefix)
+}
+
+func TestAgent_IPCacheExactEndpointHostWins(t *testing.T) {
+	wgAgent, ipCache, wgClient := newIPv6NativeRoutingTestAgent(t)
+
+	node1 := testNode(k8s1NodeName, k8s1PubKey, nil, k8s1NodeIPv6, nil, nil, nil, nil)
+	node2 := testNode(k8s2NodeName, k8s2PubKey, nil, k8s2NodeIPv6, nil, nil, nil, nil)
+	require.NoError(t, wgAgent.NodeAdd(node1))
+	require.NoError(t, wgAgent.NodeAdd(node2))
+
+	ip := net.ParseIP("fd00::100")
+	prefix := iputil.IPToPrefix(ip)
+	upsertIPCacheEntry(t, ipCache, prefix.String(), k8s1NodeIPv6, ipcache.Identity{ID: 1001, Source: source.Kubernetes})
+	requirePeerAllowedIP(t, wgClient, k8s1PubKey, prefix)
+
+	upsertIPCacheEntry(t, ipCache, ip.String(), k8s2NodeIPv6, ipcache.Identity{ID: 1002, Source: source.Kubernetes})
+
+	requirePeerMissingAllowedIP(t, wgClient, k8s1PubKey, prefix)
+	requirePeerAllowedIP(t, wgClient, k8s2PubKey, prefix)
+	requireAllowedIPOwner(t, wgClient, prefix, k8s2PubKey)
+}
+
+func TestAgent_IPCacheHostMoveTransfersAllowedIP(t *testing.T) {
+	wgAgent, ipCache, wgClient := newIPv6NativeRoutingTestAgent(t)
+
+	node1 := testNode(k8s1NodeName, k8s1PubKey, nil, k8s1NodeIPv6, nil, nil, nil, nil)
+	node2 := testNode(k8s2NodeName, k8s2PubKey, nil, k8s2NodeIPv6, nil, nil, nil, nil)
+	require.NoError(t, wgAgent.NodeAdd(node1))
+	require.NoError(t, wgAgent.NodeAdd(node2))
+
+	prefix := iputil.IPToPrefix(net.ParseIP("fd00::100"))
+	upsertIPCacheEntry(t, ipCache, prefix.String(), k8s1NodeIPv6, ipcache.Identity{ID: 1001, Source: source.Kubernetes})
+	requirePeerAllowedIP(t, wgClient, k8s1PubKey, prefix)
+
+	upsertIPCacheEntry(t, ipCache, prefix.String(), k8s2NodeIPv6, ipcache.Identity{ID: 1001, Source: source.Kubernetes})
+
+	requirePeerMissingAllowedIP(t, wgClient, k8s1PubKey, prefix)
+	requirePeerAllowedIP(t, wgClient, k8s2PubKey, prefix)
+	requireAllowedIPOwner(t, wgClient, prefix, k8s2PubKey)
+}
+
+func TestAgent_IPCacheValidationTransfersAfterFailedMove(t *testing.T) {
+	wgAgent, ipCache, wgClient := newIPv6NativeRoutingTestAgent(t)
+
+	node1 := testNode(k8s1NodeName, k8s1PubKey, nil, k8s1NodeIPv6, nil, nil, nil, nil)
+	node2 := testNode(k8s2NodeName, k8s2PubKey, nil, k8s2NodeIPv6, nil, nil, nil, nil)
+	require.NoError(t, wgAgent.NodeAdd(node1))
+	require.NoError(t, wgAgent.NodeAdd(node2))
+
+	prefix := iputil.IPToPrefix(net.ParseIP("fd00::100"))
+	upsertIPCacheEntry(t, ipCache, prefix.String(), k8s1NodeIPv6, ipcache.Identity{ID: 1001, Source: source.Kubernetes})
+	requirePeerAllowedIP(t, wgClient, k8s1PubKey, prefix)
+
+	wgClient.err = unix.EIO
+	upsertIPCacheEntry(t, ipCache, prefix.String(), k8s2NodeIPv6, ipcache.Identity{ID: 1001, Source: source.Kubernetes})
+	requirePeerAllowedIP(t, wgClient, k8s1PubKey, prefix)
+	requirePeerMissingAllowedIP(t, wgClient, k8s2PubKey, prefix)
+
+	wgClient.err = nil
+	err := wgAgent.NodeValidateImplementation(node2)
+	require.NoError(t, err)
+	requirePeerMissingAllowedIP(t, wgClient, k8s1PubKey, prefix)
+	requirePeerAllowedIP(t, wgClient, k8s2PubKey, prefix)
+
+	err = wgAgent.NodeValidateImplementation(node1)
+	require.NoError(t, err)
+	requirePeerMissingAllowedIP(t, wgClient, k8s1PubKey, prefix)
+	requirePeerAllowedIP(t, wgClient, k8s2PubKey, prefix)
+	requireAllowedIPOwner(t, wgClient, prefix, k8s2PubKey)
+}
+
+func TestAgent_IPCacheDeleteCancelsFailedInsert(t *testing.T) {
+	wgAgent, ipCache, wgClient := newIPv6NativeRoutingTestAgent(t)
+
+	node := testNode(k8s1NodeName, k8s1PubKey, nil, k8s1NodeIPv6, nil, nil, nil, nil)
+	require.NoError(t, wgAgent.NodeAdd(node))
+
+	prefix := iputil.IPToPrefix(net.ParseIP("fd00::100"))
+	wgClient.err = unix.EIO
+	upsertIPCacheEntry(t, ipCache, prefix.String(), k8s1NodeIPv6, ipcache.Identity{ID: 1001, Source: source.Kubernetes})
+	requirePeerMissingAllowedIP(t, wgClient, k8s1PubKey, prefix)
+
+	deleteIPCacheEntry(t, ipCache, prefix.String())
+	wgClient.err = nil
+
+	err := wgAgent.NodeValidateImplementation(node)
+	require.NoError(t, err)
+	requirePeerMissingAllowedIP(t, wgClient, k8s1PubKey, prefix)
+}
+
+func TestAgent_IPCacheUpsertCancelsFailedRemoval(t *testing.T) {
+	wgAgent, ipCache, wgClient := newIPv6NativeRoutingTestAgent(t)
+
+	node := testNode(k8s1NodeName, k8s1PubKey, nil, k8s1NodeIPv6, nil, nil, nil, nil)
+	require.NoError(t, wgAgent.NodeAdd(node))
+
+	prefix := iputil.IPToPrefix(net.ParseIP("fd00::100"))
+	upsertIPCacheEntry(t, ipCache, prefix.String(), k8s1NodeIPv6, ipcache.Identity{ID: 1001, Source: source.Kubernetes})
+	requirePeerAllowedIP(t, wgClient, k8s1PubKey, prefix)
+
+	wgClient.err = unix.EIO
+	deleteIPCacheEntry(t, ipCache, prefix.String())
+	requirePeerAllowedIP(t, wgClient, k8s1PubKey, prefix)
+
+	wgClient.err = nil
+	upsertIPCacheEntry(t, ipCache, prefix.String(), k8s1NodeIPv6, ipcache.Identity{ID: 1001, Source: source.Kubernetes})
+	requirePeerAllowedIP(t, wgClient, k8s1PubKey, prefix)
+
+	err := wgAgent.NodeValidateImplementation(node)
+	require.NoError(t, err)
+	requirePeerAllowedIP(t, wgClient, k8s1PubKey, prefix)
 }
 
 // Expectations in TestAgent_PeerConfig are checked as follows:


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
- [x] Thanks for contributing!

WireGuard peers learn remote endpoint IPs from IPCache via `LookupByHostRLocked`. When both an endpoint entry (e.g. `fd00::100`) and an equivalent single-IP CIDR entry (`fd00::100/128`) exist for the same IP with different `host.IP` values, the lookup attributes the `/128` prefix to whichever host the iterator hits first. In IPv6-only node-encryption setups this can leave remote CiliumNode health and ingress IPs out of the WireGuard peer `AllowedIPs`, so traffic to remote cilium-health endpoints fails with `no route to host` while remote host connectivity continues to work.

`LookupByHostRLocked` now deduplicates by prefix and lets the endpoint entry own the prefix when an equivalent CIDR entry also exists. Two new tests in `pkg/ipcache` cover both orderings.

With that fix the WireGuard agent no longer special-cases CiliumNode health and ingress IPs: the peer tracks IPCache-owned prefixes directly from `LookupByHostRLocked`, and a new `forgetIPCacheAllowedIPsFromOtherPeers` keeps state consistent when WireGuard transfers an `AllowedIP` between peers.

Reproduced on an IPv6-only kind cluster with Cilium `v1.19.1`, native routing, WireGuard, and node encryption: before the fix, peers were missing remote health/ingress `/128` AllowedIPs and cilium-health endpoint checks failed; after the fix, `cilium-health status --verbose` reports `3/3 reachable`.

Fixes: #44915

This PR was prepared with AI assistance. I reviewed the generated changes, fixed issues found during critical review, and validated the final diff with unit tests and local E2E repro evidence. AIL:4.

```release-note
[Fix WireGuard node encryption connectivity to remote Cilium health and ingress IPs.](wireguard: include remote Cilium health and ingress endpoint IPs in peer AllowedIPs for node-encryption setups). 
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
