### PR TITLE
fix lb: filter terminating backends from PreferSameNode selection

### DIFF
--- a/pkg/loadbalancer/writer/writer.go
+++ b/pkg/loadbalancer/writer/writer.go
@@ -511,6 +511,9 @@ func (w *Writer) DefaultSelectBackends(txn statedb.ReadTxn, bes iter.Seq2[*loadb
 					if !matchesFrontend(be, fe) {
 						continue
 					}
+					if !w.topologyPreferenceCandidate(svc, be) {
+						continue
+					}
 					if !yield(be, rev) {
 						return
 					}

--- a/pkg/loadbalancer/writer/writer_test.go
+++ b/pkg/loadbalancer/writer/writer_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/kpr"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/node"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/time"
@@ -1047,4 +1048,60 @@ func TestWriter_SelectBackends_PreferCloseFallsBackWhenOnlyTerminating(t *testin
 	addresses := []loadbalancer.L3n4Addr{selected[0].Address, selected[1].Address}
 	assert.Contains(t, addresses, terminatingAddr)
 	assert.Contains(t, addresses, terminatingNoZoneAddr)
+}
+
+func TestWriter_SelectBackends_PreferSameNodeIgnoresTerminating(t *testing.T) {
+	oldName := nodeTypes.GetName()
+	nodeTypes.SetName("node-a")
+	t.Cleanup(func() {
+		nodeTypes.SetName(oldName)
+	})
+
+	p := fixture(t)
+	p.Writer.config.EnableServiceTopology = true
+
+	svcName := loadbalancer.NewServiceName("test", "svc")
+	feAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(1), 80, loadbalancer.ScopeExternal)
+	activeLocalAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(2), 8080, loadbalancer.ScopeExternal)
+	terminatingLocalAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(3), 8080, loadbalancer.ScopeExternal)
+
+	svc := &loadbalancer.Service{
+		Name:                svcName,
+		Source:              source.Kubernetes,
+		TrafficDistribution: loadbalancer.TrafficDistributionPreferSameNode,
+	}
+	fe := &loadbalancer.Frontend{
+		FrontendParams: loadbalancer.FrontendParams{
+			ServiceName: svcName,
+			Address:     feAddr,
+			Type:        loadbalancer.SVCTypeClusterIP,
+			ServicePort: feAddr.Port(),
+		},
+		Service: svc,
+	}
+	backends := iter.Seq2[*loadbalancer.Backend, statedb.Revision](func(yield func(*loadbalancer.Backend, statedb.Revision) bool) {
+		for i, be := range []*loadbalancer.Backend{
+			{
+				Address:  activeLocalAddr,
+				State:    loadbalancer.BackendStateActive,
+				NodeName: "node-a",
+			},
+			{
+				Address:  terminatingLocalAddr,
+				State:    loadbalancer.BackendStateTerminating,
+				NodeName: "node-a",
+			},
+		} {
+			if !yield(be, statedb.Revision(i+1)) {
+				return
+			}
+		}
+	})
+
+	selected := slices.Collect(statedb.ToSeq(p.Writer.SelectBackends(p.DB.ReadTxn(), backends, svc, fe)))
+
+	// Only the active local backend should be selected.
+	// Terminating local backend must be filtered out.
+	require.Len(t, selected, 1)
+	assert.Equal(t, activeLocalAddr.String(), selected[0].Address.String())
 }


### PR DESCRIPTION
 
Root Cause:
  The `PreferSameNode` path in `writer.go` uses two-pass backend selection.

  The first pass checks whether a same-node backend is eligible for topology preference by calling `topologyPreferenceCandidate()`.
  The second pass returns same-node backends from the yield closure, but did not repeat the same eligibility check.

  As a result, once an active same-node backend enables the `PreferSameNode` path, terminating same-node backends can still be  included in the selected backend set.

  Triggering Scenario:
  A Service uses `trafficDistribution: PreferSameNode` with service topology enabled. During a rolling update, one same-node backend  is active while another same-node backend is terminating.

  Failures/Symptoms:
  Cilium may include terminating same-node backends in the frontend selected backend set. This makes the control-plane selection  result inconsistent with the intended topology preference behavior introduced by PR #45947, where terminating backends should not  participate in same-node or same-zone preference decisions.

  Expected Behavior:
  Only eligible same-node backends should be returned by the `PreferSameNode` selection path. Terminating backends should be excluded  from topology preference decisions unless the selection falls back to the default backend handling.

  Resolution:
  Repeat the `topologyPreferenceCandidate()` check in the `PreferSameNode` yield closure, so the backend set returned by the second  pass matches the eligibility rules used by the first pass.
  
  
<!-- Description of change -->


```release-note
fix lb: filter terminating backends from PreferSameNode selection
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
