### PR TITLE
gateway-api: fix panic on invalid GatewayClass parametersRef

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -5,6 +5,7 @@ package gateway_api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -98,6 +99,20 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return controllerruntime.Fail(err)
 		}
 		return controllerruntime.Success()
+	}
+
+	if ref := gwc.Spec.ParametersRef; ref != nil {
+		if !isParameterRefSupported(ref) {
+			setGatewayAccepted(gw, false, "Invalid GatewayClass parameters: spec.parametersRef.kind must be CiliumGatewayClassConfig", gatewayv1.GatewayReasonInvalidParameters)
+			setGatewayProgrammed(gw, metav1.ConditionUnknown, "Waiting for Accepted condition to be True", gatewayv1.GatewayReasonPending)
+			return r.handleReconcileErrorWithStatus(ctx, errors.New("Invalid GatewayClass"), original, gw)
+		}
+
+		if !hasNamespacedName(ref) {
+			setGatewayAccepted(gw, false, "Invalid GatewayClass parametersRef: both name and namespace are required", gatewayv1.GatewayReasonInvalidParameters)
+			setGatewayProgrammed(gw, metav1.ConditionUnknown, "Waiting for Accepted condition to be True", gatewayv1.GatewayReasonPending)
+			return r.handleReconcileErrorWithStatus(ctx, errors.New("Invalid GatewayClass"), original, gw)
+		}
 	}
 
 	httpRouteList := &gatewayv1.HTTPRouteList{}

--- a/operator/pkg/gateway-api/gatewayclass_reconcile.go
+++ b/operator/pkg/gateway-api/gatewayclass_reconcile.go
@@ -61,7 +61,7 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			return controllerruntime.Fail(nil)
 		}
 
-		if ref.Namespace == nil || ref.Name == "" {
+		if !hasNamespacedName(ref) {
 			scopedLog.ErrorContext(ctx, "ParametersRef must specify namespace and name")
 			setGatewayClassAccepted(gwc, false)
 			if err := r.ensureStatus(ctx, gwc, original); err != nil {
@@ -130,4 +130,12 @@ func isParameterRefSupported(ref *gatewayv1.ParametersReference) bool {
 	}
 	return ref.Group == v2alpha1.CustomResourceDefinitionGroup &&
 		ref.Kind == v2alpha1.CGCCKindDefinition
+}
+
+func hasNamespacedName(ref *gatewayv1.ParametersReference) bool {
+	if ref == nil || ref.Namespace == nil {
+		return false
+	}
+
+	return string(*ref.Namespace) != "" && ref.Name != ""
 }

--- a/operator/pkg/gateway-api/gatewayclass_reconcile_test.go
+++ b/operator/pkg/gateway-api/gatewayclass_reconcile_test.go
@@ -189,3 +189,36 @@ func Test_gatewayClassReconciler_Reconcile(t *testing.T) {
 		require.Empty(t, gwc.Status.Conditions, "Gateway class should not have any conditions")
 	})
 }
+
+func Test_hasNamespacedName(t *testing.T) {
+	t.Run("missing both namespace and name", func(t *testing.T) {
+		ref := &gatewayv1.ParametersReference{}
+		require.False(t, hasNamespacedName(ref))
+	})
+	t.Run("missing namespace but has name", func(t *testing.T) {
+		ref := &gatewayv1.ParametersReference{
+			Name: "fake",
+		}
+		require.False(t, hasNamespacedName(ref))
+	})
+	t.Run("has empty namespace string but has name", func(t *testing.T) {
+		ref := &gatewayv1.ParametersReference{
+			Namespace: ptr.To(gatewayv1.Namespace("")),
+			Name:      "fake",
+		}
+		require.False(t, hasNamespacedName(ref))
+	})
+	t.Run("has namespace but missing name", func(t *testing.T) {
+		ref := &gatewayv1.ParametersReference{
+			Namespace: ptr.To(gatewayv1.Namespace("fake")),
+		}
+		require.False(t, hasNamespacedName(ref))
+	})
+	t.Run("has both valid namespace and name", func(t *testing.T) {
+		ref := &gatewayv1.ParametersReference{
+			Namespace: ptr.To(gatewayv1.Namespace("fake")),
+			Name:      "fake",
+		}
+		require.True(t, hasNamespacedName(ref))
+	})
+}


### PR DESCRIPTION
Add validation for GatewayClass `spec.parametersRef` during the Gateway reconciliation loop. This prevents a potential controller panic if the reference is malformed or missing required fields.

```release-note
fix(gateway-api): Prevent controller panic during Gateway reconciliation when GatewayClass has an invalid or malformed spec.parametersRef.
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
