### PR TITLE
bpf: policy: constify __ctx_buff & friends

### DIFF
--- a/bpf/lib/auth.h
+++ b/bpf/lib/auth.h
@@ -19,7 +19,7 @@ struct {
 } cilium_auth_map __section_maps_btf;
 
 static __always_inline int
-auth_lookup(struct __ctx_buff *ctx, __u32 local_id, __u32 remote_id, __u32 remote_node_ip,
+auth_lookup(const struct __ctx_buff *ctx, __u32 local_id, __u32 remote_id, __u32 remote_node_ip,
 	    __u8 auth_type)
 {
 	const struct node_value *node_value = NULL;

--- a/bpf/lib/classifiers.h
+++ b/bpf/lib/classifiers.h
@@ -111,7 +111,7 @@ can_observe_overlay_hdr(enum trace_point obs_point)
  * outer L4 header is UDP and the destination port matches tunnel_port.
  */
 static __always_inline bool
-ctx_is_overlay_hdr(struct __ctx_buff *ctx, __be16 proto)
+ctx_is_overlay_hdr(const struct __ctx_buff *ctx, __be16 proto)
 {
 	void __maybe_unused *data;
 	void __maybe_unused *data_end;
@@ -175,7 +175,7 @@ ctx_is_overlay_hdr(struct __ctx_buff *ctx, __be16 proto)
  * so we don't want to skip the `ctx_is_overlay_hdr` parsing in `ctx_classify`.
  */
 static __always_inline bool
-ctx_is_encrypted_by_point(struct __ctx_buff *ctx __maybe_unused,
+ctx_is_encrypted_by_point(const struct __ctx_buff *ctx __maybe_unused,
 			  enum trace_point obs_point __maybe_unused)
 {
 #if __ctx_is == __ctx_skb
@@ -211,7 +211,7 @@ ctx_is_encrypted_by_point(struct __ctx_buff *ctx __maybe_unused,
  * performance and verifier complexity.
  */
 static __always_inline cls_flags_t
-ctx_classify(struct __ctx_buff *ctx, __be16 proto, enum trace_point obs_point)
+ctx_classify(const struct __ctx_buff *ctx, __be16 proto, enum trace_point obs_point)
 {
 	cls_flags_t flags = CLS_FLAG_NONE;
 
@@ -262,7 +262,7 @@ out: __maybe_unused
  * packets, reuse the `obs_point` to save complexity.
  */
 static __always_inline __u64
-compute_capture_len(struct __ctx_buff *ctx, __u64 monitor,
+compute_capture_len(const struct __ctx_buff *ctx, __u64 monitor,
 		    cls_flags_t flags, enum trace_point obs_point)
 {
 	__u32 cap_len_default = CONFIG(trace_payload_len);

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -584,7 +584,7 @@ ipv6_ct_reverse_tuple_daddr(const struct ipv6_ct_tuple *rtuple)
 }
 
 static __always_inline int
-ct_extract_ports6(const struct __ctx_buff *ctx, struct ipv6hdr *ip6, fraginfo_t fraginfo,
+ct_extract_ports6(const struct __ctx_buff *ctx, const struct ipv6hdr *ip6, fraginfo_t fraginfo,
 		  int off, enum ct_dir dir, struct ipv6_ct_tuple *tuple)
 {
 	switch (tuple->nexthdr) {
@@ -734,7 +734,7 @@ ct_lazy_lookup6(const void *map, struct ipv6_ct_tuple *tuple, const struct __ctx
 /* Offset must point to IPv6 */
 static __always_inline int ct_lookup6(const void *map,
 				      struct ipv6_ct_tuple *tuple,
-				      const struct __ctx_buff *ctx, struct ipv6hdr *ip6,
+				      const struct __ctx_buff *ctx, const struct ipv6hdr *ip6,
 				      fraginfo_t fraginfo, int l4_off,
 				      enum ct_dir dir, enum ct_scope scope,
 				      struct ct_state *ct_state,
@@ -842,7 +842,7 @@ ipv4_ct_reverse_tuple_daddr(const struct ipv4_ct_tuple *rtuple)
 }
 
 static __always_inline int
-ct_extract_ports4(const struct __ctx_buff *ctx, struct iphdr *ip4, fraginfo_t fraginfo,
+ct_extract_ports4(const struct __ctx_buff *ctx, const struct iphdr *ip4, fraginfo_t fraginfo,
 		  int off, enum ct_dir dir, struct ipv4_ct_tuple *tuple)
 {
 	switch (tuple->nexthdr) {
@@ -1015,7 +1015,7 @@ ct_lazy_lookup4(const void *map, struct ipv4_ct_tuple *tuple, const struct __ctx
 /* Offset must point to IPv4 header */
 static __always_inline int ct_lookup4(const void *map,
 				      struct ipv4_ct_tuple *tuple,
-				      const struct __ctx_buff *ctx, struct iphdr *ip4,
+				      const struct __ctx_buff *ctx, const struct iphdr *ip4,
 				      int off, enum ct_dir dir, enum ct_scope scope,
 				      struct ct_state *ct_state, __u32 *monitor)
 {
@@ -1065,7 +1065,7 @@ ct_create_fill_entry(struct ct_entry *entry, const struct ct_state *state,
 
 /* Offset must point to IPv6 */
 static __always_inline int ct_create6(const void *map_main, const void *map_related,
-				      struct ipv6_ct_tuple *tuple,
+				      const struct ipv6_ct_tuple *tuple,
 				      const struct __ctx_buff *ctx, const enum ct_dir dir,
 				      const struct ct_state *ct_state, __s8 *ext_err)
 {
@@ -1120,7 +1120,7 @@ drop_err:
 
 static __always_inline int ct_create4(const void *map_main,
 				      const void *map_related,
-				      struct ipv4_ct_tuple *tuple,
+				      const struct ipv4_ct_tuple *tuple,
 				      const struct __ctx_buff *ctx, const enum ct_dir dir,
 				      const struct ct_state *ct_state,
 				      __s8 *ext_err)

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -48,8 +48,8 @@ need_apply_host_policy_egress(bool is_host_id, bool is_from_proxy)
 
 # ifdef ENABLE_IPV6
 static __always_inline bool
-ipv6_host_policy_egress_lookup(struct __ctx_buff *ctx, __u32 src_sec_identity,
-			       __u32 ipcache_srcid, struct ipv6hdr *ip6,
+ipv6_host_policy_egress_lookup(const struct __ctx_buff *ctx, __u32 src_sec_identity,
+			       __u32 ipcache_srcid, const struct ipv6hdr *ip6,
 			       struct ct_buffer6 *ct_buffer)
 {
 	struct ipv6_ct_tuple *tuple = &ct_buffer->tuple;
@@ -83,10 +83,10 @@ ipv6_host_policy_egress_lookup(struct __ctx_buff *ctx, __u32 src_sec_identity,
 
 static __always_inline int
 __ipv6_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id, bool is_from_proxy,
-			  struct ipv6hdr *ip6, struct ct_buffer6 *ct_buffer,
+			  const struct ipv6hdr *ip6, const struct ct_buffer6 *ct_buffer,
 			  struct trace_ctx *trace, __s8 *ext_err)
 {
-	struct ipv6_ct_tuple *tuple = &ct_buffer->tuple;
+	const struct ipv6_ct_tuple *tuple = &ct_buffer->tuple;
 	int ret = ct_buffer->ret;
 	int verdict = CTX_ACT_OK;
 	__u8 policy_match_type = POLICY_MATCH_NONE;
@@ -170,7 +170,7 @@ __ipv6_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id, bool is_from_
 
 static __always_inline int
 ipv6_host_policy_egress(struct __ctx_buff *ctx,  bool is_from_proxy, __u32 src_id,
-			__u32 ipcache_srcid, struct ipv6hdr *ip6,
+			__u32 ipcache_srcid, const struct ipv6hdr *ip6,
 			struct trace_ctx *trace, __s8 *ext_err)
 {
 	struct ct_buffer6 ct_buffer = {};
@@ -185,7 +185,7 @@ ipv6_host_policy_egress(struct __ctx_buff *ctx,  bool is_from_proxy, __u32 src_i
 }
 
 static __always_inline bool
-ipv6_host_policy_ingress_lookup(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
+ipv6_host_policy_ingress_lookup(const struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 				struct ct_buffer6 *ct_buffer)
 {
 	__u32 dst_sec_identity = WORLD_IPV6_ID;
@@ -224,11 +224,11 @@ ipv6_host_policy_ingress_lookup(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 }
 
 static __always_inline int
-__ipv6_host_policy_ingress(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
-			   struct ct_buffer6 *ct_buffer, __u32 *src_sec_identity,
+__ipv6_host_policy_ingress(struct __ctx_buff *ctx, const struct ipv6hdr *ip6,
+			   const struct ct_buffer6 *ct_buffer, __u32 *src_sec_identity,
 			   struct trace_ctx *trace, __s8 *ext_err)
 {
-	struct ipv6_ct_tuple *tuple = &ct_buffer->tuple;
+	const struct ipv6_ct_tuple *tuple = &ct_buffer->tuple;
 	__u32 tunnel_endpoint = 0;
 	int ret = ct_buffer->ret;
 	int verdict = CTX_ACT_OK;
@@ -328,8 +328,8 @@ ipv6_host_policy_ingress(struct __ctx_buff *ctx, __u32 *src_sec_identity,
 
 # ifdef ENABLE_IPV4
 static __always_inline bool
-ipv4_host_policy_egress_lookup(struct __ctx_buff *ctx, __u32 src_sec_identity,
-			       __u32 ipcache_srcid, struct iphdr *ip4,
+ipv4_host_policy_egress_lookup(const struct __ctx_buff *ctx, __u32 src_sec_identity,
+			       __u32 ipcache_srcid, const struct iphdr *ip4,
 			       struct ct_buffer4 *ct_buffer)
 {
 	struct ipv4_ct_tuple *tuple = &ct_buffer->tuple;
@@ -355,10 +355,10 @@ ipv4_host_policy_egress_lookup(struct __ctx_buff *ctx, __u32 src_sec_identity,
 
 static __always_inline int
 __ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id, bool is_from_proxy,
-			  struct iphdr *ip4, struct ct_buffer4 *ct_buffer,
+			  const struct iphdr *ip4, const struct ct_buffer4 *ct_buffer,
 			  struct trace_ctx *trace, __s8 *ext_err)
 {
-	struct ipv4_ct_tuple *tuple = &ct_buffer->tuple;
+	const struct ipv4_ct_tuple *tuple = &ct_buffer->tuple;
 	int ret = ct_buffer->ret;
 	int verdict = CTX_ACT_OK;
 	__u8 policy_match_type = POLICY_MATCH_NONE;
@@ -442,7 +442,7 @@ __ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id, bool is_from_
 
 static __always_inline int
 ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_from_proxy, __u32 src_id,
-			__u32 ipcache_srcid, struct iphdr *ip4,
+			__u32 ipcache_srcid, const struct iphdr *ip4,
 			struct trace_ctx *trace, __s8 *ext_err)
 {
 	struct ct_buffer4 ct_buffer = {};
@@ -457,7 +457,7 @@ ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_from_proxy, __u32 src_id
 }
 
 static __always_inline bool
-ipv4_host_policy_ingress_lookup(struct __ctx_buff *ctx, struct iphdr *ip4,
+ipv4_host_policy_ingress_lookup(const struct __ctx_buff *ctx, const struct iphdr *ip4,
 				struct ct_buffer4 *ct_buffer)
 {
 	__u32 dst_sec_identity = WORLD_IPV4_ID;
@@ -488,11 +488,11 @@ ipv4_host_policy_ingress_lookup(struct __ctx_buff *ctx, struct iphdr *ip4,
 }
 
 static __always_inline int
-__ipv4_host_policy_ingress(struct __ctx_buff *ctx, struct iphdr *ip4,
-			   struct ct_buffer4 *ct_buffer, __u32 *src_sec_identity,
+__ipv4_host_policy_ingress(struct __ctx_buff *ctx, const struct iphdr *ip4,
+			   const struct ct_buffer4 *ct_buffer, __u32 *src_sec_identity,
 			   struct trace_ctx *trace, __s8 *ext_err)
 {
-	struct ipv4_ct_tuple *tuple = &ct_buffer->tuple;
+	const struct ipv4_ct_tuple *tuple = &ct_buffer->tuple;
 	__u32 tunnel_endpoint = 0;
 	int ret = ct_buffer->ret;
 	int verdict = CTX_ACT_OK;

--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -141,7 +141,7 @@ ipv4_handle_fragmentation(const struct __ctx_buff *ctx,
 }
 
 static __always_inline int
-ipv4_load_l4_ports(const struct __ctx_buff *ctx, struct iphdr *ip4 __maybe_unused,
+ipv4_load_l4_ports(const struct __ctx_buff *ctx, const struct iphdr *ip4 __maybe_unused,
 		   fraginfo_t fraginfo, int l4_off, enum ct_dir dir __maybe_unused,
 		   __be16 *ports)
 {

--- a/bpf/lib/ipv6.h
+++ b/bpf/lib/ipv6.h
@@ -431,7 +431,7 @@ out:
 }
 
 static __always_inline int
-ipv6_load_l4_ports(const struct __ctx_buff *ctx, struct ipv6hdr *ip6 __maybe_unused,
+ipv6_load_l4_ports(const struct __ctx_buff *ctx, const struct ipv6hdr *ip6 __maybe_unused,
 		   fraginfo_t fraginfo, int l4_off, enum ct_dir dir __maybe_unused,
 		   __be16 *ports)
 {

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -216,7 +216,7 @@ __policy_check(const struct policy_entry *policy, const struct policy_entry *pol
 
 /* Allow experimental access to the @map parameter. */
 static __always_inline int
-__policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
+__policy_can_access(const void *map, const struct __ctx_buff *ctx, __u32 local_id,
 		    __u32 remote_id, __u16 ethertype, __be16 dport, __u8 proto,
 		    int off, int dir, bool is_untracked_fragment,
 		    __u8 *match_type, __s8 *ext_err, __u16 *proxy_port,
@@ -348,7 +348,7 @@ check_l4_policy:
 }
 
 static __always_inline int
-policy_can_access(struct __ctx_buff *ctx, __u32 local_id, __u32 remote_id,
+policy_can_access(const struct __ctx_buff *ctx, __u32 local_id, __u32 remote_id,
 		  __u16 ethertype, __be16 dport, __u8 proto, int off, int dir,
 		  bool is_untracked_fragment, __u8 *match_type, __s8 *ext_err,
 		  __u16 *proxy_port, __u32 *cookie)
@@ -381,7 +381,7 @@ policy_can_access(struct __ctx_buff *ctx, __u32 local_id, __u32 remote_id,
  *   - Negative error code if the packet should be dropped
  */
 static __always_inline int
-policy_can_ingress(struct __ctx_buff *ctx, __u32 src_id, __u32 dst_id,
+policy_can_ingress(const struct __ctx_buff *ctx, __u32 src_id, __u32 dst_id,
 		   __u16 ethertype, __be16 dport, __u8 proto, int l4_off,
 		   bool is_untracked_fragment, __u8 *match_type, __u8 *audited,
 		   __s8 *ext_err, __u16 *proxy_port, __u32 *cookie)
@@ -407,7 +407,7 @@ policy_can_ingress(struct __ctx_buff *ctx, __u32 src_id, __u32 dst_id,
 	return ret;
 }
 
-static __always_inline int policy_can_ingress6(struct __ctx_buff *ctx,
+static __always_inline int policy_can_ingress6(const struct __ctx_buff *ctx,
 					       const struct ipv6_ct_tuple *tuple,
 					       int l4_off, bool is_untracked_fragment,
 					       __u32 src_id, __u32 dst_id,
@@ -420,7 +420,7 @@ static __always_inline int policy_can_ingress6(struct __ctx_buff *ctx,
 				 match_type, audited, ext_err, proxy_port, cookie);
 }
 
-static __always_inline int policy_can_ingress4(struct __ctx_buff *ctx,
+static __always_inline int policy_can_ingress4(const struct __ctx_buff *ctx,
 					       const struct ipv4_ct_tuple *tuple,
 					       int l4_off, bool is_untracked_fragment,
 					       __u32 src_id, __u32 dst_id,
@@ -441,7 +441,7 @@ static __always_inline bool is_encap(__be16 dport, __u8 proto)
 #endif
 
 static __always_inline int
-policy_can_egress(struct __ctx_buff *ctx, __u32 src_id, __u32 dst_id,
+policy_can_egress(const struct __ctx_buff *ctx, __u32 src_id, __u32 dst_id,
 		  __u16 ethertype, __be16 dport, __u8 proto, int l4_off, __u8 *match_type,
 		  __u8 *audited, __s8 *ext_err, __u16 *proxy_port, __u32 *cookie)
 {
@@ -467,7 +467,7 @@ policy_can_egress(struct __ctx_buff *ctx, __u32 src_id, __u32 dst_id,
 	return ret;
 }
 
-static __always_inline int policy_can_egress6(struct __ctx_buff *ctx,
+static __always_inline int policy_can_egress6(const struct __ctx_buff *ctx,
 					      const struct ipv6_ct_tuple *tuple,
 					      int l4_off, __u32 src_id, __u32 dst_id,
 					      __u8 *match_type, __u8 *audited, __s8 *ext_err,
@@ -478,7 +478,7 @@ static __always_inline int policy_can_egress6(struct __ctx_buff *ctx,
 				 ext_err, proxy_port, cookie);
 }
 
-static __always_inline int policy_can_egress4(struct __ctx_buff *ctx,
+static __always_inline int policy_can_egress4(const struct __ctx_buff *ctx,
 					      const struct ipv4_ct_tuple *tuple,
 					      int l4_off, __u32 src_id, __u32 dst_id,
 					      __u8 *match_type, __u8 *audited, __s8 *ext_err,

--- a/bpf/lib/policy_log.h
+++ b/bpf/lib/policy_log.h
@@ -55,7 +55,7 @@ static __always_inline bool policy_verdict_filter_allow(__u32 filter, __u8 dir)
 }
 
 static __always_inline void
-send_policy_verdict_notify(struct __ctx_buff *ctx, __u32 remote_label, __u16 dst_port,
+send_policy_verdict_notify(const struct __ctx_buff *ctx, __u32 remote_label, __u16 dst_port,
 			   __u8 proto, __u8 dir, __u8 is_ipv6, int verdict, __u16 proxy_port,
 			   __u8 match_type, __u8 is_audited, __u8 auth_type, __u32 cookie)
 {
@@ -123,7 +123,7 @@ send_policy_verdict_notify(struct __ctx_buff *ctx, __u32 remote_label, __u16 dst
 }
 #else
 static __always_inline void
-send_policy_verdict_notify(struct __ctx_buff *ctx __maybe_unused,
+send_policy_verdict_notify(const struct __ctx_buff *ctx __maybe_unused,
 			   __u32 remote_label __maybe_unused, __u16 dst_port __maybe_unused,
 			   __u8 proto __maybe_unused, __u8 dir __maybe_unused,
 			   __u8 is_ipv6 __maybe_unused, int verdict __maybe_unused,

--- a/bpf/lib/signal.h
+++ b/bpf/lib/signal.h
@@ -61,7 +61,7 @@ static __always_inline void send_signal_ct_fill_up(struct __ctx_buff *ctx,
 	SEND_SIGNAL(ctx, SIGNAL_CT_FILL_UP, proto, proto);
 }
 
-static __always_inline void send_signal_auth_required(struct __ctx_buff *ctx,
+static __always_inline void send_signal_auth_required(const struct __ctx_buff *ctx,
 						      const struct auth_key *auth)
 {
 	SEND_SIGNAL(ctx, SIGNAL_AUTH_REQUIRED, auth, *auth);

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -78,7 +78,7 @@ enum {
 #define update_trace_metrics(ctx, obs_point, reason) \
 	_update_trace_metrics(ctx, obs_point, reason, __MAGIC_LINE__, __MAGIC_FILE__)
 static __always_inline void
-_update_trace_metrics(struct __ctx_buff *ctx, enum trace_point obs_point,
+_update_trace_metrics(const struct __ctx_buff *ctx, enum trace_point obs_point,
 		      enum trace_reason reason, __u16 line, __u8 file)
 {
 	__u8 encrypted;
@@ -207,7 +207,7 @@ emit_trace_notify(enum trace_point obs_point, __u32 monitor)
 }
 
 static __always_inline void
-_send_trace_notify(struct __ctx_buff *ctx, enum trace_point obs_point,
+_send_trace_notify(const struct __ctx_buff *ctx, enum trace_point obs_point,
 		   __u32 src, __u32 dst, __u16 dst_id, __u32 ifindex,
 		   enum trace_reason reason, __u32 monitor,
 		   __be16 proto, __u16 line, __u8 file)
@@ -259,7 +259,7 @@ _send_trace_notify(struct __ctx_buff *ctx, enum trace_point obs_point,
 }
 
 static __always_inline void
-_send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
+_send_trace_notify4(const struct __ctx_buff *ctx, enum trace_point obs_point,
 		    __u32 src, __u32 dst, __be32 orig_addr, __u16 dst_id,
 		    __u32 ifindex, enum trace_reason reason, __u32 monitor,
 		    __u16 line, __u8 file)
@@ -311,7 +311,7 @@ _send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
 }
 
 static __always_inline void
-_send_trace_notify6(struct __ctx_buff *ctx, enum trace_point obs_point,
+_send_trace_notify6(const struct __ctx_buff *ctx, enum trace_point obs_point,
 		    __u32 src, __u32 dst, const union v6addr *orig_addr,
 		    __u16 dst_id, __u32 ifindex, enum trace_reason reason,
 		    __u32 monitor, __u16 line, __u8 file)
@@ -364,7 +364,7 @@ _send_trace_notify6(struct __ctx_buff *ctx, enum trace_point obs_point,
 }
 #else
 static __always_inline void
-_send_trace_notify(struct __ctx_buff *ctx, enum trace_point obs_point,
+_send_trace_notify(const struct __ctx_buff *ctx, enum trace_point obs_point,
 		   __u32 src __maybe_unused, __u32 dst __maybe_unused,
 		   __u16 dst_id __maybe_unused, __u32 ifindex __maybe_unused,
 		   enum trace_reason reason, __u32 monitor __maybe_unused,
@@ -374,7 +374,7 @@ _send_trace_notify(struct __ctx_buff *ctx, enum trace_point obs_point,
 }
 
 static __always_inline void
-_send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
+_send_trace_notify4(const struct __ctx_buff *ctx, enum trace_point obs_point,
 		    __u32 src __maybe_unused, __u32 dst __maybe_unused,
 		    __be32 orig_addr __maybe_unused, __u16 dst_id __maybe_unused,
 		    __u32 ifindex __maybe_unused, enum trace_reason reason,
@@ -385,7 +385,7 @@ _send_trace_notify4(struct __ctx_buff *ctx, enum trace_point obs_point,
 }
 
 static __always_inline void
-_send_trace_notify6(struct __ctx_buff *ctx, enum trace_point obs_point,
+_send_trace_notify6(const struct __ctx_buff *ctx, enum trace_point obs_point,
 		    __u32 src __maybe_unused, __u32 dst __maybe_unused,
 		    union v6addr *orig_addr __maybe_unused,
 		    __u16 dst_id __maybe_unused, __u32 ifindex __maybe_unused,


### PR DESCRIPTION
Convince ourselves that the network policy code (to a large degree) doesn't touch the packet. Adjust a bunch of low-level helpers as needed.

There's some minor exceptions in the HostFW parts which are currently needed for routing the packet to its destination, and therefore need to touch the __ctx_buff.