### PR TITLE
ipam: Migrate IPAM allocator public API to netip

### DIFF
--- a/daemon/cmd/endpoint_restore.go
+++ b/daemon/cmd/endpoint_restore.go
@@ -688,21 +688,21 @@ func (r *endpointRestorer) handleRestoredEndpointsRegeneration(endpoints []*endp
 func (r *endpointRestorer) allocateIPsLocked(ep *endpoint.Endpoint) (err error) {
 	if option.Config.EnableIPv6 && ep.IPv6.IsValid() {
 		ipv6Pool := ipam.PoolOrDefault(ep.IPv6IPAMPool)
-		_, err = r.ipamManager.AllocateIPWithoutSyncUpstream(ep.IPv6.AsSlice(), ep.HumanString()+" [restored]", ipv6Pool)
+		_, err = r.ipamManager.AllocateIPWithoutSyncUpstream(ep.IPv6, ep.HumanString()+" [restored]", ipv6Pool)
 		if err != nil {
 			return fmt.Errorf("unable to reallocate %s IPv6 address: %w", ep.IPv6, err)
 		}
 
 		defer func() {
 			if err != nil {
-				r.ipamManager.ReleaseIP(ep.IPv6.AsSlice(), ipv6Pool)
+				r.ipamManager.ReleaseIP(ep.IPv6, ipv6Pool)
 			}
 		}()
 	}
 
 	if option.Config.EnableIPv4 && ep.IPv4.IsValid() {
 		ipv4Pool := ipam.PoolOrDefault(ep.IPv4IPAMPool)
-		_, err = r.ipamManager.AllocateIPWithoutSyncUpstream(ep.IPv4.AsSlice(), ep.HumanString()+" [restored]", ipv4Pool)
+		_, err = r.ipamManager.AllocateIPWithoutSyncUpstream(ep.IPv4, ep.HumanString()+" [restored]", ipv4Pool)
 		switch {
 		// We only check for BypassIPAllocUponRestore for IPv4 because we
 		// assume that this flag is only turned on for IPv4-only IPAM modes

--- a/daemon/infraendpoints/infra_ip_allocation.go
+++ b/daemon/infraendpoints/infra_ip_allocation.go
@@ -84,10 +84,10 @@ type infraIPAllocator struct {
 }
 
 type ipamAllocator interface {
-	AllocateIPWithoutSyncUpstream(ip net.IP, owner string, pool ipam.Pool) (*ipam.AllocationResult, error)
+	AllocateIPWithoutSyncUpstream(ip netip.Addr, owner string, pool ipam.Pool) (*ipam.AllocationResult, error)
 	AllocateNextFamilyWithoutSyncUpstream(family ipam.Family, owner string, pool ipam.Pool) (result *ipam.AllocationResult, err error)
-	ExcludeIP(ip net.IP, owner string, pool ipam.Pool)
-	ReleaseIP(ip net.IP, pool ipam.Pool) error
+	ExcludeIP(ip netip.Addr, owner string, pool ipam.Pool)
+	ReleaseIP(ip netip.Addr, pool ipam.Pool) error
 }
 
 func newInfraIPAllocator(params infraIPAllocatorParams) InfraIPAllocator {
@@ -186,7 +186,7 @@ func (r *infraIPAllocator) reallocateOldRouterIPs(fromK8s, fromFS net.IP) (resul
 	// filesystem to be the most up-to-date source of truth.
 	var err error
 	if fromFS != nil {
-		result, err = r.ipAllocator.AllocateIPWithoutSyncUpstream(fromFS, "router", ipam.PoolDefault())
+		result, err = r.ipAllocator.AllocateIPWithoutSyncUpstream(iputil.AddrFromIP(fromFS), "router", ipam.PoolDefault())
 		if err != nil {
 			r.logger.Warn(
 				"Unable to restore router IP from filesystem",
@@ -201,7 +201,7 @@ func (r *infraIPAllocator) reallocateOldRouterIPs(fromK8s, fromFS net.IP) (resul
 	// If we were not able to restore the IP from the filesystem, try to use
 	// the IP from the Kubernetes resource.
 	if result == nil && fromK8s != nil {
-		result, err = r.ipAllocator.AllocateIPWithoutSyncUpstream(fromK8s, "router", ipam.PoolDefault())
+		result, err = r.ipAllocator.AllocateIPWithoutSyncUpstream(iputil.AddrFromIP(fromK8s), "router", ipam.PoolDefault())
 		if err != nil {
 			r.logger.Warn(
 				"Unable to restore router IP from kubernetes",
@@ -251,7 +251,7 @@ func (r *infraIPAllocator) waitForENI(ctx context.Context, macAddr string) error
 
 func (r *infraIPAllocator) reallocateRouterIPs(ctx context.Context, family node.AddressingFamily, fromK8s, fromFS net.IP) (routerIP net.IP, err error) {
 	// Avoid allocating external IP
-	r.ipAllocator.ExcludeIP(family.PrimaryExternal(), "node-ip", ipam.PoolDefault())
+	r.ipAllocator.ExcludeIP(iputil.AddrFromIP(family.PrimaryExternal()), "node-ip", ipam.PoolDefault())
 
 	// (Re-)allocate the router IP. If not possible, allocate a fresh IP.
 	// In that case, the old router IP needs to be removed from cilium_host
@@ -356,7 +356,7 @@ func (r *infraIPAllocator) allocateHealthIPs(oldV4HealthIP net.IP, oldV6HealthIP
 		var err error
 		healthIPv4 = oldV4HealthIP
 		if healthIPv4 != nil {
-			result, err = r.ipAllocator.AllocateIPWithoutSyncUpstream(healthIPv4, "health", ipam.PoolDefault())
+			result, err = r.ipAllocator.AllocateIPWithoutSyncUpstream(iputil.AddrFromIP(healthIPv4), "health", ipam.PoolDefault())
 			if err != nil {
 				r.logger.Warn(
 					"unable to re-allocate health IPv4, a new health IPv4 will be allocated",
@@ -399,7 +399,7 @@ func (r *infraIPAllocator) allocateHealthIPs(oldV4HealthIP net.IP, oldV6HealthIP
 		var err error
 		healthIPv6 = oldV6HealthIP
 		if healthIPv6 != nil {
-			result, err = r.ipAllocator.AllocateIPWithoutSyncUpstream(healthIPv6, "health", ipam.PoolDefault())
+			result, err = r.ipAllocator.AllocateIPWithoutSyncUpstream(iputil.AddrFromIP(healthIPv6), "health", ipam.PoolDefault())
 			if err != nil {
 				r.logger.Warn(
 					"unable to re-allocate health IPv6, a new health IPv6 will be allocated",
@@ -413,7 +413,7 @@ func (r *infraIPAllocator) allocateHealthIPs(oldV4HealthIP net.IP, oldV6HealthIP
 			result, err = r.ipAllocator.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv6, "health", ipam.PoolDefault())
 			if err != nil {
 				if healthIPv4 != nil {
-					r.ipAllocator.ReleaseIP(healthIPv4, ipam.PoolDefault())
+					r.ipAllocator.ReleaseIP(iputil.AddrFromIP(healthIPv4), ipam.PoolDefault())
 					r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv4HealthIP = nil })
 				}
 				return fmt.Errorf("unable to allocate health IPv6: %w, see https://cilium.link/ipam-range-full", err)
@@ -437,7 +437,7 @@ func (r *infraIPAllocator) allocateIngressIPs(oldV4IngressIP net.IP, oldV6Ingres
 
 		// Reallocate the same address as before, if possible
 		if ingressIPv4 != nil {
-			result, err = r.ipAllocator.AllocateIPWithoutSyncUpstream(ingressIPv4, "ingress", ipam.PoolDefault())
+			result, err = r.ipAllocator.AllocateIPWithoutSyncUpstream(iputil.AddrFromIP(ingressIPv4), "ingress", ipam.PoolDefault())
 			if err != nil {
 				r.logger.Warn("unable to re-allocate ingress IPv4.",
 					logfields.Error, err,
@@ -494,7 +494,7 @@ func (r *infraIPAllocator) allocateIngressIPs(oldV4IngressIP net.IP, oldV6Ingres
 		// Reallocate the same address as before, if possible
 		ingressIPv6 := oldV6IngressIP
 		if ingressIPv6 != nil {
-			result, err = r.ipAllocator.AllocateIPWithoutSyncUpstream(ingressIPv6, "ingress", ipam.PoolDefault())
+			result, err = r.ipAllocator.AllocateIPWithoutSyncUpstream(iputil.AddrFromIP(ingressIPv6), "ingress", ipam.PoolDefault())
 			if err != nil {
 				r.logger.Warn("unable to re-allocate ingress IPv6.",
 					logfields.Error, err,
@@ -510,7 +510,7 @@ func (r *infraIPAllocator) allocateIngressIPs(oldV4IngressIP net.IP, oldV6Ingres
 			result, err = r.ipAllocator.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv6, "ingress", ipam.PoolDefault())
 			if err != nil {
 				if ingressIPv4 != nil {
-					r.ipAllocator.ReleaseIP(ingressIPv4, ipam.PoolDefault())
+					r.ipAllocator.ReleaseIP(iputil.AddrFromIP(ingressIPv4), ipam.PoolDefault())
 					r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv4IngressIP = nil })
 				}
 				return fmt.Errorf("unable to allocate ingress IPs: %w, see https://cilium.link/ipam-range-full", err)

--- a/daemon/infraendpoints/infra_ip_allocation_test.go
+++ b/daemon/infraendpoints/infra_ip_allocation_test.go
@@ -103,21 +103,20 @@ type mockIPAllocator struct {
 	allocCIDR *cidr.CIDR
 }
 
-func (m *mockIPAllocator) AllocateIPWithoutSyncUpstream(ip net.IP, owner string, pool ipam.Pool) (*ipam.AllocationResult, error) {
-	if !m.allocCIDR.Contains(ip) {
+func (m *mockIPAllocator) AllocateIPWithoutSyncUpstream(ip netip.Addr, owner string, pool ipam.Pool) (*ipam.AllocationResult, error) {
+	if !m.allocCIDR.Contains(ip.AsSlice()) {
 		return nil, fmt.Errorf("cannot allocate IP %s", ip)
 	}
-	addr, _ := netip.AddrFromSlice(ip)
-	return &ipam.AllocationResult{IP: addr.Unmap()}, nil
+	return &ipam.AllocationResult{IP: ip}, nil
 }
 
 func (m *mockIPAllocator) AllocateNextFamilyWithoutSyncUpstream(family ipam.Family, owner string, pool ipam.Pool) (result *ipam.AllocationResult, err error) {
 	return nil, nil
 }
 
-func (m *mockIPAllocator) ExcludeIP(ip net.IP, owner string, pool ipam.Pool) {}
+func (m *mockIPAllocator) ExcludeIP(ip netip.Addr, owner string, pool ipam.Pool) {}
 
-func (m *mockIPAllocator) ReleaseIP(ip net.IP, pool ipam.Pool) error {
+func (m *mockIPAllocator) ReleaseIP(ip netip.Addr, pool ipam.Pool) error {
 	return nil
 }
 

--- a/pkg/endpoint/api/endpoint_api_manager.go
+++ b/pkg/endpoint/api/endpoint_api_manager.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
-	"net"
+	"net/netip"
 	"strconv"
 	"sync"
 
@@ -342,7 +342,7 @@ func (m *endpointAPIManager) CreateEndpoint(ctx context.Context, epTemplate *mod
 	// timers of all attached IPs
 	if addressing := epTemplate.Addressing; addressing != nil {
 		if uuid := addressing.IPv4ExpirationUUID; uuid != "" {
-			if ip := net.ParseIP(addressing.IPv4); ip != nil {
+			if ip, err := netip.ParseAddr(addressing.IPv4); err == nil {
 				pool := ipam.PoolOrDefault(addressing.IPv4PoolName)
 				if err := m.ipam.StopExpirationTimer(ip, pool, uuid); err != nil {
 					return m.errorDuringCreation(ep, err)
@@ -350,7 +350,7 @@ func (m *endpointAPIManager) CreateEndpoint(ctx context.Context, epTemplate *mod
 			}
 		}
 		if uuid := addressing.IPv6ExpirationUUID; uuid != "" {
-			if ip := net.ParseIP(addressing.IPv6); ip != nil {
+			if ip, err := netip.ParseAddr(addressing.IPv6); err == nil {
 				pool := ipam.PoolOrDefault(addressing.IPv6PoolName)
 				if err := m.ipam.StopExpirationTimer(ip, pool, uuid); err != nil {
 					return m.errorDuringCreation(ep, err)

--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -6,7 +6,6 @@ package ipam
 import (
 	"errors"
 	"fmt"
-	"net"
 	"net/netip"
 	"strings"
 
@@ -42,28 +41,28 @@ func (ipam *IPAM) determineIPAMPool(owner string, family Family) (Pool, error) {
 }
 
 // AllocateIP allocates an IP address.
-func (ipam *IPAM) AllocateIP(ip net.IP, owner string, pool Pool) error {
+func (ipam *IPAM) AllocateIP(ip netip.Addr, owner string, pool Pool) error {
 	needSyncUpstream := true
 	_, err := ipam.allocateIP(ip, owner, pool, needSyncUpstream)
 	return err
 }
 
 // AllocateIPWithoutSyncUpstream allocates an IP address without syncing upstream.
-func (ipam *IPAM) AllocateIPWithoutSyncUpstream(ip net.IP, owner string, pool Pool) (*AllocationResult, error) {
+func (ipam *IPAM) AllocateIPWithoutSyncUpstream(ip netip.Addr, owner string, pool Pool) (*AllocationResult, error) {
 	needSyncUpstream := false
 	return ipam.allocateIP(ip, owner, pool, needSyncUpstream)
 }
 
 // AllocateIPString is identical to AllocateIP but takes a string
 func (ipam *IPAM) AllocateIPString(ipAddr, owner string, pool Pool) error {
-	ip := net.ParseIP(ipAddr)
-	if ip == nil {
+	addr, err := netip.ParseAddr(ipAddr)
+	if err != nil {
 		return fmt.Errorf("Invalid IP address: %s", ipAddr)
 	}
-	return ipam.AllocateIP(ip, owner, pool)
+	return ipam.AllocateIP(addr, owner, pool)
 }
 
-func (ipam *IPAM) allocateIP(ip net.IP, owner string, pool Pool, needSyncUpstream bool) (result *AllocationResult, err error) {
+func (ipam *IPAM) allocateIP(ip netip.Addr, owner string, pool Pool, needSyncUpstream bool) (result *AllocationResult, err error) {
 	ipam.allocatorMutex.Lock()
 	defer ipam.allocatorMutex.Unlock()
 
@@ -71,30 +70,28 @@ func (ipam *IPAM) allocateIP(ip net.IP, owner string, pool Pool, needSyncUpstrea
 		return nil, fmt.Errorf("unable to restore IP %s for %q: pool name must be provided", ip, owner)
 	}
 
+	if !ip.IsValid() {
+		return nil, fmt.Errorf("invalid IP address: %v", ip)
+	}
+
 	if ownedBy, ok := ipam.isIPExcluded(ip, pool); ok {
 		err = fmt.Errorf("IP %s is excluded, owned by %s", ip, ownedBy)
 		return
 	}
 
-	addr, ok := netip.AddrFromSlice(ip)
-	if !ok {
-		return nil, fmt.Errorf("invalid IP address: %v", ip)
-	}
-	addr = addr.Unmap()
-
 	family := IPv4
-	if addr.Is4() {
+	if ip.Is4() {
 		if ipam.ipv4Allocator == nil {
 			err = ErrIPv4Disabled
 			return
 		}
 
 		if needSyncUpstream {
-			if result, err = ipam.ipv4Allocator.Allocate(addr, owner, pool); err != nil {
+			if result, err = ipam.ipv4Allocator.Allocate(ip, owner, pool); err != nil {
 				return
 			}
 		} else {
-			if result, err = ipam.ipv4Allocator.AllocateWithoutSyncUpstream(addr, owner, pool); err != nil {
+			if result, err = ipam.ipv4Allocator.AllocateWithoutSyncUpstream(ip, owner, pool); err != nil {
 				return
 			}
 		}
@@ -111,11 +108,11 @@ func (ipam *IPAM) allocateIP(ip net.IP, owner string, pool Pool, needSyncUpstrea
 		}
 
 		if needSyncUpstream {
-			if result, err = ipam.ipv6Allocator.Allocate(addr, owner, pool); err != nil {
+			if result, err = ipam.ipv6Allocator.Allocate(ip, owner, pool); err != nil {
 				return
 			}
 		} else {
-			if result, err = ipam.ipv6Allocator.AllocateWithoutSyncUpstream(addr, owner, pool); err != nil {
+			if result, err = ipam.ipv6Allocator.AllocateWithoutSyncUpstream(ip, owner, pool); err != nil {
 				return
 			}
 		}
@@ -195,7 +192,7 @@ func (ipam *IPAM) allocateNextFamily(family Family, owner string, pool Pool, nee
 			result.IPPoolName = PoolDefault()
 		}
 
-		resultIP := result.IP.AsSlice()
+		resultIP := result.IP
 		if _, ok := ipam.isIPExcluded(resultIP, pool); !ok {
 			ipam.logger.Debug(
 				"Allocated random IP",
@@ -253,7 +250,7 @@ func (ipam *IPAM) AllocateNext(family, owner string, pool Pool) (ipv4Result, ipv
 		ipv4Result, err = ipam.AllocateNextFamily(IPv4, owner, pool)
 		if err != nil {
 			if ipv6Result != nil {
-				ipam.ReleaseIP(ipv6Result.IP.AsSlice(), ipv6Result.IPPoolName)
+				ipam.ReleaseIP(ipv6Result.IP, ipv6Result.IPPoolName)
 			}
 			return
 		}
@@ -274,13 +271,13 @@ func (ipam *IPAM) AllocateNextWithExpiration(family, owner string, pool Pool, ti
 	if timeout != time.Duration(0) {
 		for _, result := range []*AllocationResult{ipv4Result, ipv6Result} {
 			if result != nil {
-				result.ExpirationUUID, err = ipam.StartExpirationTimer(result.IP.AsSlice(), result.IPPoolName, timeout)
+				result.ExpirationUUID, err = ipam.StartExpirationTimer(result.IP, result.IPPoolName, timeout)
 				if err != nil {
 					if ipv4Result != nil {
-						ipam.ReleaseIP(ipv4Result.IP.AsSlice(), ipv4Result.IPPoolName)
+						ipam.ReleaseIP(ipv4Result.IP, ipv4Result.IPPoolName)
 					}
 					if ipv6Result != nil {
-						ipam.ReleaseIP(ipv6Result.IP.AsSlice(), ipv6Result.IPPoolName)
+						ipam.ReleaseIP(ipv6Result.IP, ipv6Result.IPPoolName)
 					}
 					return
 				}
@@ -291,24 +288,22 @@ func (ipam *IPAM) AllocateNextWithExpiration(family, owner string, pool Pool, ti
 	return
 }
 
-func (ipam *IPAM) releaseIPLocked(ip net.IP, pool Pool) error {
+func (ipam *IPAM) releaseIPLocked(ip netip.Addr, pool Pool) error {
 	if pool == "" {
 		return fmt.Errorf("no IPAM pool provided for IP release of %s", ip)
 	}
 
-	addr, ok := netip.AddrFromSlice(ip)
-	if !ok {
+	if !ip.IsValid() {
 		return fmt.Errorf("invalid IP address: %v", ip)
 	}
-	addr = addr.Unmap()
 
 	family := IPv4
-	if addr.Is4() {
+	if ip.Is4() {
 		if ipam.ipv4Allocator == nil {
 			return ErrIPv4Disabled
 		}
 
-		ipam.ipv4Allocator.Release(addr, pool)
+		ipam.ipv4Allocator.Release(ip, pool)
 		if ipam.config.IPAMMode() == ipamOption.IPAMClusterPool || ipam.config.IPAMMode() == ipamOption.IPAMKubernetes {
 			metrics.IPAMCapacity.WithLabelValues(string(family), ipam.nodeAddressing.IPv4().AllocationCIDR().IPNet.String()).Set(float64(ipam.ipv4Allocator.Capacity()))
 		} else {
@@ -320,7 +315,7 @@ func (ipam *IPAM) releaseIPLocked(ip net.IP, pool Pool) error {
 			return ErrIPv6Disabled
 		}
 
-		ipam.ipv6Allocator.Release(addr, pool)
+		ipam.ipv6Allocator.Release(ip, pool)
 		if ipam.config.IPAMMode() == ipamOption.IPAMClusterPool || ipam.config.IPAMMode() == ipamOption.IPAMKubernetes {
 			metrics.IPAMCapacity.WithLabelValues(string(family), ipam.nodeAddressing.IPv6().AllocationCIDR().IPNet.String()).Set(float64(ipam.ipv6Allocator.Capacity()))
 		} else {
@@ -335,7 +330,7 @@ func (ipam *IPAM) releaseIPLocked(ip net.IP, pool Pool) error {
 		logfields.Owner, owner,
 	)
 
-	key := timerKey{ip: ip.String(), pool: pool}
+	key := timerKey{ip: ip, pool: pool}
 	if t, ok := ipam.expirationTimers[key]; ok {
 		close(t.stop)
 		delete(ipam.expirationTimers, key)
@@ -348,7 +343,7 @@ func (ipam *IPAM) releaseIPLocked(ip net.IP, pool Pool) error {
 // ReleaseIP releases an IP address. The pool argument must not be empty, it
 // must be set to the pool name returned by the `Allocate*` functions when
 // the IP was allocated.
-func (ipam *IPAM) ReleaseIP(ip net.IP, pool Pool) error {
+func (ipam *IPAM) ReleaseIP(ip netip.Addr, pool Pool) error {
 	ipam.allocatorMutex.Lock()
 	defer ipam.allocatorMutex.Unlock()
 	return ipam.releaseIPLocked(ip, pool)
@@ -415,11 +410,11 @@ func (ipam *IPAM) Dump() (allocv4 map[string]string, allocv6 map[string]string, 
 // by an external entity and that external entity can disappear. Therefore such
 // users should register an expiration timer before returning the IP and then
 // stop the expiration timer when the IP has been used.
-func (ipam *IPAM) StartExpirationTimer(ip net.IP, pool Pool, timeout time.Duration) (string, error) {
+func (ipam *IPAM) StartExpirationTimer(ip netip.Addr, pool Pool, timeout time.Duration) (string, error) {
 	ipam.allocatorMutex.Lock()
 	defer ipam.allocatorMutex.Unlock()
 
-	key := timerKey{ip: ip.String(), pool: pool}
+	key := timerKey{ip: ip, pool: pool}
 	if _, ok := ipam.expirationTimers[key]; ok {
 		return "", fmt.Errorf("expiration timer already registered")
 	}
@@ -431,7 +426,7 @@ func (ipam *IPAM) StartExpirationTimer(ip net.IP, pool Pool, timeout time.Durati
 		stop: stop,
 	}
 
-	go func(key timerKey, ip net.IP, pool Pool, allocationUUID string, timeout time.Duration, stop <-chan struct{}) {
+	go func(key timerKey, ip netip.Addr, pool Pool, allocationUUID string, timeout time.Duration, stop <-chan struct{}) {
 		timer := time.NewTimerWithoutMaxDelay(timeout)
 		select {
 		case <-stop:
@@ -480,11 +475,11 @@ func (ipam *IPAM) StartExpirationTimer(ip net.IP, pool Pool, timeout time.Durati
 // The UUID returned by the symmetric StartExpirationTimer must be provided.
 // The expiration timer will only be removed if the UUIDs match. Releasing an
 // IP will also stop the expiration timer.
-func (ipam *IPAM) StopExpirationTimer(ip net.IP, pool Pool, allocationUUID string) error {
+func (ipam *IPAM) StopExpirationTimer(ip netip.Addr, pool Pool, allocationUUID string) error {
 	ipam.allocatorMutex.Lock()
 	defer ipam.allocatorMutex.Unlock()
 
-	key := timerKey{ip: ip.String(), pool: pool}
+	key := timerKey{ip: ip, pool: pool}
 	t, ok := ipam.expirationTimers[key]
 	if !ok {
 		return fmt.Errorf("no expiration timer registered")

--- a/pkg/ipam/allocator_test.go
+++ b/pkg/ipam/allocator_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"net/netip"
 	"testing"
 	"time"
 
@@ -83,7 +84,7 @@ func TestAllocatedIPDump(t *testing.T) {
 }
 
 func TestExpirationTimer(t *testing.T) {
-	ip := net.ParseIP("1.1.1.1")
+	ip := netip.MustParseAddr("1.1.1.1")
 	timeout := 50 * time.Millisecond
 
 	fakeAddressing := fakenode.NewAddressing()
@@ -184,24 +185,24 @@ func TestAllocateNextWithExpiration(t *testing.T) {
 	require.NoError(t, err)
 
 	// IPv4 address must be in use
-	err = ipam.AllocateIP(ipv4.IP.AsSlice(), "foo", PoolDefault())
+	err = ipam.AllocateIP(ipv4.IP, "foo", PoolDefault())
 	require.Error(t, err)
 	// IPv6 address must be in use
-	err = ipam.AllocateIP(ipv6.IP.AsSlice(), "foo", PoolDefault())
+	err = ipam.AllocateIP(ipv6.IP, "foo", PoolDefault())
 	require.Error(t, err)
 
 	// Let expiration timer expire
 	time.Sleep(time.Second)
 	// IPv4 address must be available again
-	err = ipam.AllocateIP(ipv4.IP.AsSlice(), "foo", PoolDefault())
+	err = ipam.AllocateIP(ipv4.IP, "foo", PoolDefault())
 	require.NoError(t, err)
 	// IPv6 address must be available again
-	err = ipam.AllocateIP(ipv6.IP.AsSlice(), "foo", PoolDefault())
+	err = ipam.AllocateIP(ipv6.IP, "foo", PoolDefault())
 	require.NoError(t, err)
 	// Release IPs
-	err = ipam.ReleaseIP(ipv4.IP.AsSlice(), PoolDefault())
+	err = ipam.ReleaseIP(ipv4.IP, PoolDefault())
 	require.NoError(t, err)
-	err = ipam.ReleaseIP(ipv6.IP.AsSlice(), PoolDefault())
+	err = ipam.ReleaseIP(ipv6.IP, PoolDefault())
 	require.NoError(t, err)
 
 	// Allocate IPs again and test stopping the expiration timer
@@ -209,18 +210,18 @@ func TestAllocateNextWithExpiration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Stop expiration timer for IPv4 address
-	err = ipam.StopExpirationTimer(ipv4.IP.AsSlice(), PoolDefault(), ipv4.ExpirationUUID)
+	err = ipam.StopExpirationTimer(ipv4.IP, PoolDefault(), ipv4.ExpirationUUID)
 	require.NoError(t, err)
 
 	// Let expiration timer expire
 	time.Sleep(time.Second)
 	// IPv4 address must be in use
-	err = ipam.AllocateIP(ipv4.IP.AsSlice(), "foo", PoolDefault())
+	err = ipam.AllocateIP(ipv4.IP, "foo", PoolDefault())
 	require.Error(t, err)
 	// IPv6 address must be available again
-	err = ipam.AllocateIP(ipv6.IP.AsSlice(), "foo", PoolDefault())
+	err = ipam.AllocateIP(ipv6.IP, "foo", PoolDefault())
 	require.NoError(t, err)
 	// Release IPv4 address
-	err = ipam.ReleaseIP(ipv4.IP.AsSlice(), PoolDefault())
+	err = ipam.ReleaseIP(ipv4.IP, PoolDefault())
 	require.NoError(t, err)
 }

--- a/pkg/ipam/api/ipam_api_handler.go
+++ b/pkg/ipam/api/ipam_api_handler.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net"
 	"net/http"
 	"net/netip"
 	"strings"
@@ -155,9 +154,9 @@ func (r *IpamDeleteIpamIPHandler) Handle(params ipamapi.DeleteIpamIPParams) midd
 		return api.Error(ipamapi.DeleteIpamIPFailureCode, fmt.Errorf("IP is in use by endpoint %d", ep.ID))
 	}
 
-	ip := net.ParseIP(params.IP)
-	if ip == nil {
-		return api.Error(ipamapi.DeleteIpamIPInvalidCode, fmt.Errorf("Invalid IP address: %s", params.IP))
+	ip, err := netip.ParseAddr(params.IP)
+	if err != nil {
+		return api.Error(ipamapi.DeleteIpamIPInvalidCode, fmt.Errorf("Invalid IP address %s: %w", params.IP, err))
 	}
 
 	pool := ipam.Pool(swag.StringValue(params.Pool))

--- a/pkg/ipam/cell/ipam_init.go
+++ b/pkg/ipam/cell/ipam_init.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/netip"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/statedb"
@@ -149,14 +150,14 @@ func (r *IPAMInitializer) AutoComplete(ctx context.Context) error {
 	return nil
 }
 
-func (r *IPAMInitializer) makeIPv6HostIP() net.IP {
+func (r *IPAMInitializer) makeIPv6HostIP() netip.Addr {
 	ipstr := "fc00::10CA:1"
-	ip := net.ParseIP(ipstr)
-	if ip == nil {
-		logging.Fatal(r.logger, "Unable to parse IP", logfields.IPAddr, ipstr)
+	addr, err := netip.ParseAddr(ipstr)
+	if err != nil {
+		logging.Fatal(r.logger, "Unable to parse IP", logfields.Error, err, logfields.IPAddr, ipstr)
 	}
 
-	return ip
+	return addr
 }
 
 func (r *IPAMInitializer) setDefaultPrefix(device string, localNode *node.LocalNode) {
@@ -214,7 +215,7 @@ func (r *IPAMInitializer) setDefaultPrefix(device string, localNode *node.LocalN
 			// Find a IPv6 node address first
 			addr, _ := node.FirstGlobalV6Addr(device, localNode.GetCiliumInternalIP(isIPv6))
 			if addr == nil {
-				addr = r.makeIPv6HostIP()
+				addr = r.makeIPv6HostIP().AsSlice()
 			}
 			localNode.SetNodeInternalIP(addr)
 		}

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -6,7 +6,6 @@ package ipam
 import (
 	"fmt"
 	"log/slog"
-	"net"
 	"net/netip"
 
 	"github.com/cilium/hive/job"
@@ -222,7 +221,7 @@ func (ipam *IPAM) getIPOwner(ip string, pool Pool) string {
 }
 
 // registerIPOwner registers a new owner for an IP in a particular pool.
-func (ipam *IPAM) registerIPOwner(ip net.IP, owner string, pool Pool) {
+func (ipam *IPAM) registerIPOwner(ip netip.Addr, owner string, pool Pool) {
 	if _, ok := ipam.owner[pool]; !ok {
 		ipam.owner[pool] = make(map[string]string)
 	}
@@ -230,7 +229,7 @@ func (ipam *IPAM) registerIPOwner(ip net.IP, owner string, pool Pool) {
 }
 
 // releaseIPOwner releases ip from pool and returns the previous owner.
-func (ipam *IPAM) releaseIPOwner(ip net.IP, pool Pool) string {
+func (ipam *IPAM) releaseIPOwner(ip netip.Addr, pool Pool) string {
 	var owner string
 	if m, ok := ipam.owner[pool]; ok {
 		ipStr := ip.String()
@@ -246,14 +245,14 @@ func (ipam *IPAM) releaseIPOwner(ip net.IP, pool Pool) string {
 // ExcludeIP ensures that a certain IP is never allocated. It is preferred to
 // use this method instead of allocating the IP as the allocation block can
 // change and suddenly cover the IP to be excluded.
-func (ipam *IPAM) ExcludeIP(ip net.IP, owner string, pool Pool) {
+func (ipam *IPAM) ExcludeIP(ip netip.Addr, owner string, pool Pool) {
 	ipam.allocatorMutex.Lock()
 	ipam.excludedIPs[pool.String()+":"+ip.String()] = owner
 	ipam.allocatorMutex.Unlock()
 }
 
 // isIPExcluded is used to check if a particular IP is excluded from being allocated.
-func (ipam *IPAM) isIPExcluded(ip net.IP, pool Pool) (string, bool) {
+func (ipam *IPAM) isIPExcluded(ip netip.Addr, pool Pool) (string, bool) {
 	owner, ok := ipam.excludedIPs[pool.String()+":"+ip.String()]
 	return owner, ok
 }

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -168,22 +168,22 @@ func TestExcludeIP(t *testing.T) {
 	ipv4 := fakeIPv4AllocCIDRIP(fakeAddressing)
 	ipv4 = ipv4.Next()
 
-	ipam.ExcludeIP(ipv4.AsSlice(), "test-foo", PoolDefault())
-	err := ipam.AllocateIP(ipv4.AsSlice(), "test-bar", PoolDefault())
+	ipam.ExcludeIP(ipv4, "test-foo", PoolDefault())
+	err := ipam.AllocateIP(ipv4, "test-bar", PoolDefault())
 	require.Error(t, err)
 	require.ErrorContains(t, err, "owned by test-foo")
-	err = ipam.ReleaseIP(ipv4.AsSlice(), PoolDefault())
+	err = ipam.ReleaseIP(ipv4, PoolDefault())
 	require.NoError(t, err)
 
 	ipv6 := fakeIPv6AllocCIDRIP(fakeAddressing)
 	ipv6 = ipv6.Next()
 
-	ipam.ExcludeIP(ipv6.AsSlice(), "test-foo", PoolDefault())
-	err = ipam.AllocateIP(ipv6.AsSlice(), "test-bar", PoolDefault())
+	ipam.ExcludeIP(ipv6, "test-foo", PoolDefault())
+	err = ipam.AllocateIP(ipv6, "test-bar", PoolDefault())
 	require.Error(t, err)
 	require.ErrorContains(t, err, "owned by test-foo")
-	ipam.ReleaseIP(ipv6.AsSlice(), PoolDefault())
-	err = ipam.ReleaseIP(ipv4.AsSlice(), PoolDefault())
+	ipam.ReleaseIP(ipv6, PoolDefault())
+	err = ipam.ReleaseIP(ipv4, PoolDefault())
 	require.NoError(t, err)
 }
 
@@ -235,17 +235,17 @@ func TestIPAMMetadata(t *testing.T) {
 
 	// Checks AllocateIP
 	specialIP := netip.MustParseAddr("172.18.19.20")
-	_, err := ipam.AllocateIPWithoutSyncUpstream(specialIP.AsSlice(), "special/wants-special-ip", "")
+	_, err := ipam.AllocateIPWithoutSyncUpstream(specialIP, "special/wants-special-ip", "")
 	require.Error(t, err) // pool required
-	resIPv4, err := ipam.AllocateIPWithoutSyncUpstream(specialIP.AsSlice(), "special/wants-special-ip", "special")
+	resIPv4, err := ipam.AllocateIPWithoutSyncUpstream(specialIP, "special/wants-special-ip", "special")
 	require.NoError(t, err)
 	require.Equal(t, Pool("special"), resIPv4.IPPoolName)
 	require.Equal(t, specialIP, resIPv4.IP)
 
 	// Checks ReleaseIP
-	err = ipam.ReleaseIP(specialIP.AsSlice(), "")
+	err = ipam.ReleaseIP(specialIP, "")
 	require.Error(t, err) // pool required
-	err = ipam.ReleaseIP(specialIP.AsSlice(), "special")
+	err = ipam.ReleaseIP(specialIP, "special")
 	require.NoError(t, err)
 
 	// Checks if pool metadata is used if pool is empty
@@ -295,18 +295,18 @@ func TestLegacyAllocatorIPAMMetadata(t *testing.T) {
 	// AllocateIP requires explicit pool
 	ipv4 := fakeIPv4AllocCIDRIP(fakeAddressing)
 	ipv4 = ipv4.Next()
-	_, err := ipam.AllocateIPWithoutSyncUpstream(ipv4.AsSlice(), "default/specific-ip", "")
+	_, err := ipam.AllocateIPWithoutSyncUpstream(ipv4, "default/specific-ip", "")
 	require.Error(t, err)
 
 	// AllocateIP with specific pool
 	ipv4 = ipv4.Next()
-	resIPv4, err := ipam.AllocateIPWithoutSyncUpstream(ipv4.AsSlice(), "default/specific-ip", "override")
+	resIPv4, err := ipam.AllocateIPWithoutSyncUpstream(ipv4, "default/specific-ip", "override")
 	require.NoError(t, err)
 	require.Equal(t, PoolDefault(), resIPv4.IPPoolName)
 
 	// AllocateIP with default pool
 	ipv4 = ipv4.Next()
-	resIPv4, err = ipam.AllocateIPWithoutSyncUpstream(ipv4.AsSlice(), "default/specific-ip", "default")
+	resIPv4, err = ipam.AllocateIPWithoutSyncUpstream(ipv4, "default/specific-ip", "default")
 	require.NoError(t, err)
 	require.Equal(t, PoolDefault(), resIPv4.IPPoolName)
 

--- a/pkg/ipam/migration/script_test.go
+++ b/pkg/ipam/migration/script_test.go
@@ -164,7 +164,7 @@ func commands(initializer *ipamcell.IPAMInitializer, manager *ipam.IPAM) map[str
 				}
 
 				_, err = manager.AllocateIPWithoutSyncUpstream(
-					addr.AsSlice(),
+					addr,
 					args[1],
 					ipam.PoolOrDefault(""), // restored endpoints from cluster-pool should have an empty pool
 				)

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -144,12 +144,12 @@ func (ipam *IPAM) EndpointCreated(ep *endpoint.Endpoint) {}
 func (ipam *IPAM) EndpointDeleted(ep *endpoint.Endpoint, conf endpoint.DeleteConfig) {
 	if !conf.NoIPRelease {
 		if option.Config.EnableIPv4 {
-			if err := ipam.ReleaseIP(ep.IPv4.AsSlice(), PoolOrDefault(ep.IPv4IPAMPool)); err != nil {
+			if err := ipam.ReleaseIP(ep.IPv4, PoolOrDefault(ep.IPv4IPAMPool)); err != nil {
 				ipam.logger.Warn("Unable to release IPv4 address during endpoint deletion", logfields.Error, err)
 			}
 		}
 		if option.Config.EnableIPv6 {
-			if err := ipam.ReleaseIP(ep.IPv6.AsSlice(), PoolOrDefault(ep.IPv6IPAMPool)); err != nil {
+			if err := ipam.ReleaseIP(ep.IPv6, PoolOrDefault(ep.IPv6IPAMPool)); err != nil {
 				ipam.logger.Warn("Unable to release IPv6 address during endpoint deletion", logfields.Error, err)
 			}
 		}
@@ -189,7 +189,7 @@ func (p Pool) String() string {
 }
 
 type timerKey struct {
-	ip   string
+	ip   netip.Addr
 	pool Pool
 }
 


### PR DESCRIPTION
Followup to #46309.
Relates to #24246.

This PR migrates the IPAM allocator interface to netip (`AllocateIP{,WithoutSyncUpstream}`, `ReleaseIP`, `{Start,Stop}ExpirationTimer`).

Most callers of these functions already had netip typed variables, so this PR mostly removes types conversions.