### PR TITLE
ingress: shorten name of resources

### DIFF
--- a/operator/pkg/ingress/ingress_reconcile.go
+++ b/operator/pkg/ingress/ingress_reconcile.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/operator/pkg/model/ingestion"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/shortener"
 )
 
 const (
@@ -174,9 +175,9 @@ func (r *ingressReconciler) createOrUpdateSharedResources(ctx context.Context) e
 
 func (r *ingressReconciler) tryCleanupDedicatedResources(ctx context.Context, ingressNamespacedName types.NamespacedName) error {
 	resources := map[client.Object]types.NamespacedName{
-		&corev1.Service{}:             {Namespace: ingressNamespacedName.Namespace, Name: fmt.Sprintf("%s-%s", ciliumIngressPrefix, ingressNamespacedName.Name)},
-		&discoveryv1.EndpointSlice{}:  {Namespace: ingressNamespacedName.Namespace, Name: fmt.Sprintf("%s-%s", ciliumIngressPrefix, ingressNamespacedName.Name)},
-		&ciliumv2.CiliumEnvoyConfig{}: {Namespace: ingressNamespacedName.Namespace, Name: fmt.Sprintf("%s-%s-%s", ciliumIngressPrefix, ingressNamespacedName.Namespace, ingressNamespacedName.Name)},
+		&corev1.Service{}:             {Namespace: ingressNamespacedName.Namespace, Name: shortener.ShortenK8sResourceName(fmt.Sprintf("%s-%s", ciliumIngressPrefix, ingressNamespacedName.Name))},
+		&discoveryv1.EndpointSlice{}:  {Namespace: ingressNamespacedName.Namespace, Name: shortener.ShortenK8sResourceName(fmt.Sprintf("%s-%s", ciliumIngressPrefix, ingressNamespacedName.Name))},
+		&ciliumv2.CiliumEnvoyConfig{}: {Namespace: ingressNamespacedName.Namespace, Name: shortener.ShortenK8sResourceName(fmt.Sprintf("%s-%s-%s", ciliumIngressPrefix, ingressNamespacedName.Namespace, ingressNamespacedName.Name))},
 	}
 
 	for k, v := range resources {

--- a/operator/pkg/ingress/ingress_reconcile_test.go
+++ b/operator/pkg/ingress/ingress_reconcile_test.go
@@ -5,6 +5,8 @@ package ingress
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,6 +31,7 @@ import (
 	ingressTranslation "github.com/cilium/cilium/operator/pkg/model/translation/ingress"
 	"github.com/cilium/cilium/pkg/envoy"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/shortener"
 )
 
 const (
@@ -42,6 +45,85 @@ const (
 	testDefaultStreamTimout             = 300
 	testIngressDefaultRequestTimeout    = time.Duration(0)
 )
+
+func TestReconcileDedicatedResourcesUseShortenedNames(t *testing.T) {
+	logger := hivetest.Logger(t)
+
+	cfg := translation.Config{
+		SecretsNamespace: testCiliumNamespace,
+		ListenerConfig: translation.ListenerConfig{
+			UseProxyProtocol:         testUseProxyProtocol,
+			StreamIdleTimeoutSeconds: testDefaultStreamTimout,
+		},
+		ClusterConfig: translation.ClusterConfig{
+			IdleTimeoutSeconds: testDefaultTimeout,
+		},
+	}
+
+	longIngressName := strings.Repeat("a", 52)
+	svcName := shortener.ShortenK8sResourceName(fmt.Sprintf("%s-%s", ciliumIngressPrefix, longIngressName))
+	cecName := shortener.ShortenK8sResourceName(fmt.Sprintf("%s-%s-%s", ciliumIngressPrefix, "test", longIngressName))
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(
+			&networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      longIngressName,
+					Annotations: map[string]string{
+						"ingress.cilium.io/loadbalancer-mode": "dedicated",
+					},
+				},
+				Spec: networkingv1.IngressSpec{
+					IngressClassName: ptr.To("cilium"),
+					DefaultBackend:   defaultBackend(),
+				},
+			},
+		).
+		Build()
+
+	cecTranslator := translation.NewCECTranslator(cfg)
+	dedicatedIngressTranslator := ingressTranslation.NewDedicatedIngressTranslator(logger, cecTranslator, false)
+	reconciler := newIngressReconciler(logger, fakeClient, cecTranslator, dedicatedIngressTranslator, testCiliumNamespace, []string{}, testDefaultLoadbalancingServiceName, "dedicated", testDefaultSecretNamespace, testDefaultSecretName, false, testIngressDefaultRequestTimeout, false, 0, 0, 0, 0)
+
+	_, err := reconciler.Reconcile(t.Context(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: "test", Name: longIngressName},
+	})
+	require.NoError(t, err)
+	require.LessOrEqual(t, len(svcName), 63)
+	require.LessOrEqual(t, len(cecName), 63)
+
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: svcName}, &corev1.Service{})
+	require.NoError(t, err, "Dedicated loadbalancer service should exist with shortened name")
+
+	eps := discoveryv1.EndpointSlice{}
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: svcName}, &eps)
+	require.NoError(t, err, "Dedicated EndpointSlice should exist with shortened name")
+	require.Equal(t, svcName, eps.Labels[discoveryv1.LabelServiceName])
+
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: cecName}, &ciliumv2.CiliumEnvoyConfig{})
+	require.NoError(t, err, "Dedicated CiliumEnvoyConfig should exist with shortened name")
+
+	ing := &networkingv1.Ingress{}
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: longIngressName}, ing)
+	require.NoError(t, err)
+	ing.Spec.IngressClassName = ptr.To("other")
+	err = fakeClient.Update(t.Context(), ing)
+	require.NoError(t, err)
+
+	_, err = reconciler.Reconcile(t.Context(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: "test", Name: longIngressName},
+	})
+	require.NoError(t, err)
+
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: svcName}, &corev1.Service{})
+	require.True(t, k8sApiErrors.IsNotFound(err), "Dedicated loadbalancer service should be cleaned up with shortened name")
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: svcName}, &discoveryv1.EndpointSlice{})
+	require.True(t, k8sApiErrors.IsNotFound(err), "Dedicated EndpointSlice should be cleaned up with shortened name")
+	err = fakeClient.Get(t.Context(), types.NamespacedName{Namespace: "test", Name: cecName}, &ciliumv2.CiliumEnvoyConfig{})
+	require.True(t, k8sApiErrors.IsNotFound(err), "Dedicated CiliumEnvoyConfig should be cleaned up with shortened name")
+}
 
 func TestReconcile(t *testing.T) {
 	logger := hivetest.Logger(t)

--- a/operator/pkg/model/translation/ingress/dedicated_ingress.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress.go
@@ -18,6 +18,7 @@ import (
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	slim_networkingv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/networking/v1"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/shortener"
 )
 
 const (
@@ -50,22 +51,19 @@ func (d *dedicatedIngressTranslator) Translate(m *model.Model) (*ciliumv2.Cilium
 	var namespace string
 	var sourceResource model.FullyQualifiedResource
 	var modelService *model.Service
-	var cecName string
 	var tlsOnly bool
 
 	if len(m.HTTP) == 0 {
-		name = fmt.Sprintf("%s-%s", ciliumIngressPrefix, m.TLSPassthrough[0].Sources[0].Name)
+		name = shortener.ShortenK8sResourceName(fmt.Sprintf("%s-%s", ciliumIngressPrefix, m.TLSPassthrough[0].Sources[0].Name))
 		namespace = m.TLSPassthrough[0].Sources[0].Namespace
 		sourceResource = m.TLSPassthrough[0].Sources[0]
 		modelService = m.TLSPassthrough[0].Service
-		cecName = fmt.Sprintf("%s-%s-%s", ciliumIngressPrefix, namespace, m.TLSPassthrough[0].Sources[0].Name)
 		tlsOnly = true
 	} else {
-		name = fmt.Sprintf("%s-%s", ciliumIngressPrefix, m.HTTP[0].Sources[0].Name)
+		name = shortener.ShortenK8sResourceName(fmt.Sprintf("%s-%s", ciliumIngressPrefix, m.HTTP[0].Sources[0].Name))
 		namespace = m.HTTP[0].Sources[0].Namespace
 		sourceResource = m.HTTP[0].Sources[0]
 		modelService = m.HTTP[0].Service
-		cecName = fmt.Sprintf("%s-%s-%s", ciliumIngressPrefix, namespace, m.HTTP[0].Sources[0].Name)
 	}
 
 	// The logic is same as what we have with default cecTranslator, but with a different model
@@ -76,7 +74,7 @@ func (d *dedicatedIngressTranslator) Translate(m *model.Model) (*ciliumv2.Cilium
 	}
 
 	// Set the name to avoid any breaking change during upgrade.
-	cec.Name = cecName
+	cec.Name = shortener.ShortenK8sResourceName(fmt.Sprintf("%s-%s-%s", ciliumIngressPrefix, namespace, sourceResource.Name))
 
 	dedicatedService := d.getService(sourceResource, modelService, tlsOnly)
 
@@ -136,7 +134,7 @@ func (d *dedicatedIngressTranslator) getService(resource model.FullyQualifiedRes
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", ciliumIngressPrefix, resource.Name),
+			Name:      shortener.ShortenK8sResourceName(fmt.Sprintf("%s-%s", ciliumIngressPrefix, resource.Name)),
 			Namespace: resource.Namespace,
 			Labels:    map[string]string{ciliumIngressLabelKey: "true"},
 			OwnerReferences: []metav1.OwnerReference{
@@ -161,11 +159,11 @@ func (d *dedicatedIngressTranslator) getService(resource model.FullyQualifiedRes
 func getEndpointSlice(resource model.FullyQualifiedResource) *discoveryv1.EndpointSlice {
 	return &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", ciliumIngressPrefix, resource.Name),
+			Name:      shortener.ShortenK8sResourceName(fmt.Sprintf("%s-%s", ciliumIngressPrefix, resource.Name)),
 			Namespace: resource.Namespace,
 			Labels: map[string]string{
 				ciliumIngressLabelKey:        "true",
-				discoveryv1.LabelServiceName: fmt.Sprintf("%s-%s", ciliumIngressPrefix, resource.Name),
+				discoveryv1.LabelServiceName: shortener.ShortenK8sResourceName(fmt.Sprintf("%s-%s", ciliumIngressPrefix, resource.Name)),
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{


### PR DESCRIPTION
Currently, names of K8s resources created by
the Cilium Ingress reconcilers aren't shortened.
This can lead to issues when reconciling Ingress
resources with long names.

This commit uses the shortener to fix this issue.