### PR TITLE
ces: avoid panic on empty CiliumNode lookup result

### DIFF
--- a/operator/pkg/ciliumendpointslice/endpointslice.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
@@ -517,7 +517,7 @@ func (c *SlimController) syncCESsInLocalCache(ctx context.Context) error {
 			nodeObj, err := cnodeStore.ByIndex(op_k8s.CiliumNodeIPIndex, cep.Networking.NodeIP)
 			// If the CiliumNode is not found (e.g., deleted during operator restart), we skip restoring the state of this CEP on startup.
 			// We will get the CEP & CiliumNode add events through the resource stores and update the latest state in the local cache.
-			if err != nil {
+			if err != nil || len(nodeObj) == 0 {
 				c.logger.DebugContext(ctx, "Error getting CiliumNode by IP",
 					logfields.Error, err)
 				continue


### PR DESCRIPTION
When restoring CES state on startup, `cnodeStore.ByIndex()` may return an empty slice without an error if no `CiliumNode` matches the endpoint's node IP, e.g. if the node was deleted during an operator restart.

Accessing `nodeObj[0]` further down would cause a slice out-of-bounds access and panic. Fix this by adding a check and skipping the endpoint in that case.

Fixes: 963c5310f228 ("ces: add slim mode CES controller initialization")
