### PR TITLE
Revert ".github/workflows: do not use deployments for environments"

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -26,9 +26,7 @@ jobs:
   approve:
     name: Approve
     needs: pre-approve
-    environment:
-      name: auto-approve
-      deployment: false
+    environment: auto-approve
     runs-on: ubuntu-24.04
     permissions: {}
     steps:

--- a/.github/workflows/build-images-base-v1.17.yaml
+++ b/.github/workflows/build-images-base-v1.17.yaml
@@ -27,9 +27,7 @@ jobs:
   has-credentials:
     name: Check for Quay secrets
     runs-on: ubuntu-24.04
-    environment:
-      name: 'release-base-images'
-      deployment: false
+    environment: 'release-base-images'
     timeout-minutes: 2
     outputs:
       present: ${{ steps.secrets.outputs.present }}
@@ -48,9 +46,7 @@ jobs:
     if: ${{ needs.has-credentials.outputs.present && ! (github.event_name == 'pull_request_target' && startsWith(github.head_ref, 'renovate/')) }}
     name: Build and Push Images
     timeout-minutes: 60
-    environment:
-      name: 'release-base-images'
-      deployment: false
+    environment: 'release-base-images'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout default branch (trusted)
@@ -330,9 +326,7 @@ jobs:
   image-digests:
     name: Display Digests
     runs-on: ubuntu-24.04
-    environment:
-      name: 'release-base-images'
-      deployment: false
+    environment: 'release-base-images'
     needs: build-and-push
     steps:
       - name: Downloading Image Digests

--- a/.github/workflows/build-images-base-v1.18.yaml
+++ b/.github/workflows/build-images-base-v1.18.yaml
@@ -29,9 +29,7 @@ jobs:
     if: ${{ vars.QUAY_BASE_RELEASE_ENABLED == 'true' && ! (github.event_name == 'pull_request_target' && startsWith(github.head_ref, 'renovate/')) }}
     name: Build and Push Images
     timeout-minutes: 60
-    environment:
-      name: 'release-base-images'
-      deployment: false
+    environment: 'release-base-images'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout base or default branch (trusted)

--- a/.github/workflows/build-images-base-v1.19.yaml
+++ b/.github/workflows/build-images-base-v1.19.yaml
@@ -29,9 +29,7 @@ jobs:
     if: ${{ vars.QUAY_BASE_RELEASE_ENABLED == 'true' && ! (github.event_name == 'pull_request_target' && startsWith(github.head_ref, 'renovate/')) }}
     name: Build and Push Images
     timeout-minutes: 60
-    environment:
-      name: 'release-base-images'
-      deployment: false
+    environment: 'release-base-images'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout base or default branch (trusted)

--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -48,9 +48,7 @@ jobs:
     if: ${{ vars.QUAY_BASE_RELEASE_ENABLED == 'true' && ! (github.event_name == 'pull_request_target' && startsWith(github.head_ref, 'renovate/')) }}
     name: Build and Push Images
     timeout-minutes: 60
-    environment:
-      name: ${{ inputs.environment || 'release-base-images' }}
-      deployment: false
+    environment: ${{ inputs.environment || 'release-base-images' }}
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout base or default branch (trusted)

--- a/.github/workflows/build-images-beta.yaml
+++ b/.github/workflows/build-images-beta.yaml
@@ -30,9 +30,7 @@ jobs:
   build-and-push:
     timeout-minutes: 45
     name: Build and Push Images
-    environment:
-      name: release-beta-images
-      deployment: false
+    environment: release-beta-images
     runs-on: ubuntu-24.04
     strategy:
       matrix:

--- a/.github/workflows/build-images-ci-v1.17.yaml
+++ b/.github/workflows/build-images-ci-v1.17.yaml
@@ -416,9 +416,7 @@ jobs:
     name: Post test comment for Renovate PRs after images built
     runs-on: ubuntu-24.04
     needs: pre-comment
-    environment:
-      name: "Trigger CI from renovate PRs"
-      deployment: false
+    environment: "Trigger CI from renovate PRs"
     if: ${{
          github.event_name == 'pull_request_target' &&
          github.event.pull_request.user.login == vars.RENOVATE_BOT_USERNAME

--- a/.github/workflows/build-images-ci-v1.18.yaml
+++ b/.github/workflows/build-images-ci-v1.18.yaml
@@ -442,9 +442,7 @@ jobs:
     name: Post test comment for Renovate PRs after images built
     runs-on: ubuntu-24.04
     needs: pre-comment
-    environment:
-      name: "Trigger CI from renovate PRs"
-      deployment: false
+    environment: "Trigger CI from renovate PRs"
     if: ${{
          github.event_name == 'pull_request_target' &&
          github.event.pull_request.user.login == vars.RENOVATE_BOT_USERNAME

--- a/.github/workflows/build-images-ci-v1.19.yaml
+++ b/.github/workflows/build-images-ci-v1.19.yaml
@@ -419,9 +419,7 @@ jobs:
     name: Post test comment for Renovate PRs after images built
     runs-on: ubuntu-24.04
     needs: pre-comment
-    environment:
-      name: "Trigger CI from renovate PRs"
-      deployment: false
+    environment: "Trigger CI from renovate PRs"
     if: ${{
          github.event_name == 'pull_request_target' &&
          github.event.pull_request.user.login == vars.RENOVATE_BOT_USERNAME

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -427,9 +427,7 @@ jobs:
     name: Post test comment for Renovate PRs after images built
     runs-on: ubuntu-24.04
     needs: pre-comment
-    environment:
-      name: "Trigger CI from renovate PRs"
-      deployment: false
+    environment: "Trigger CI from renovate PRs"
     if: ${{
          github.event_name == 'pull_request_target' &&
          github.event.pull_request.user.login == vars.RENOVATE_BOT_USERNAME

--- a/.github/workflows/build-images-docs-builder-v1.17.yaml
+++ b/.github/workflows/build-images-docs-builder-v1.17.yaml
@@ -27,9 +27,7 @@ jobs:
     name: Build and Push Image
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment:
-      name: docs-builder
-      deployment: false
+    environment: docs-builder
     outputs:
       tag: ${{ steps.docs-builder-tag.outputs.tag }}
       digest: ${{ steps.docker-build-docs-builder.outputs.digest }}

--- a/.github/workflows/build-images-docs-builder-v1.18.yaml
+++ b/.github/workflows/build-images-docs-builder-v1.18.yaml
@@ -27,9 +27,7 @@ jobs:
     name: Build and Push Image
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment:
-      name: docs-builder
-      deployment: false
+    environment: docs-builder
     outputs:
       tag: ${{ steps.docs-builder-tag.outputs.tag }}
       digest: ${{ steps.docker-build-docs-builder.outputs.digest }}

--- a/.github/workflows/build-images-docs-builder-v1.19.yaml
+++ b/.github/workflows/build-images-docs-builder-v1.19.yaml
@@ -27,9 +27,7 @@ jobs:
     name: Build and Push Image
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment:
-      name: docs-builder
-      deployment: false
+    environment: docs-builder
     outputs:
       tag: ${{ steps.docs-builder-tag.outputs.tag }}
       digest: ${{ steps.docker-build-docs-builder.outputs.digest }}

--- a/.github/workflows/build-images-docs-builder.yaml
+++ b/.github/workflows/build-images-docs-builder.yaml
@@ -28,9 +28,7 @@ jobs:
     name: Build and Push Image
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment:
-      name: docs-builder
-      deployment: false
+    environment: docs-builder
     outputs:
       tag: ${{ steps.docs-builder-tag.outputs.tag }}
       digest: ${{ steps.docker-build-docs-builder.outputs.digest }}
@@ -105,6 +103,7 @@ jobs:
     if: needs.build-and-push.outputs.digest
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    environment: docs-builder
     steps:
       - name: Checkout base branch (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -16,9 +16,7 @@ jobs:
   build-and-push:
     timeout-minutes: 45
     name: Build and Push Images
-    environment:
-      name: release
-      deployment: false
+    environment: release
     runs-on: ubuntu-24.04
     strategy:
       matrix:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,9 +51,7 @@ jobs:
   release:
     name: Release
     if: ${{ inputs.step != '5-publish-helm' }}
-    environment:
-      name: release-tool
-      deployment: false
+    environment: release-tool
     timeout-minutes: 40
     runs-on: ubuntu-24.04
     steps:
@@ -122,9 +120,7 @@ jobs:
   release-helm:
     name: Release Helm
     if: ${{ inputs.step == '5-publish-helm' }}
-    environment:
-      name: release-helm
-      deployment: false
+    environment: release-helm
     timeout-minutes: 40
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
This partially reverts commit f3fea47661451167172a33abc03a42edd2d26c6c.

The auto-approve builds for Renovate PRs do not work with "deployment: false", so revert the affected environments back to their previous form.