### PR TITLE
gateway-api: Gateway check for hostNetwork enabled

### DIFF
--- a/Documentation/network/servicemesh/gateway-api/host-network-mode.rst
+++ b/Documentation/network/servicemesh/gateway-api/host-network-mode.rst
@@ -35,7 +35,9 @@ resource and you should choose a port number higher than ``1023`` (see
 `Bind to privileged port`_).
 
 .. warning::
-    Be aware that misconfiguration might result in port clashes. Configure unique ports that are still available on all Cilium Nodes where Gateway API listeners are exposed.
+    Be aware that misconfiguration might result in port clashes. For each gateway, configure unique ports that are still available on all Cilium Nodes where Gateway API listeners are exposed.
+
+The ``GatewayStatusAddress`` field for a gateway has a maximum of 16 addresses. Cilium with host network mode enabled will automatically sort the node addresses to allow for consistency, ensuring that the same addresses are selected.
 
 Bind to privileged port
 =======================

--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -169,6 +169,8 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Watch for changes to BackendTLSPolicy
 		Watches(&gatewayv1.BackendTLSPolicy{}, watchhandlers.EnqueueRequestForBackendTLSPolicy(r.Client, r.logger)).
 		Watches(&corev1.ConfigMap{}, watchhandlers.EnqueueRequestForBackendTLSPolicyConfigMap(r.Client, r.logger)).
+		// Watch for changes to node in order to populate gateway ip addresses if svc of type NodePort
+		Watches(&corev1.Node{}, watchhandlers.EnqueueRequestForNodes(r.Client, r.logger, owningGatewayLabel)).
 		// Watch created and owned resources
 		Owns(&ciliumv2.CiliumEnvoyConfig{}).
 		Owns(&corev1.Service{}).

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -4,6 +4,7 @@
 package gateway_api
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -782,33 +783,43 @@ func (r *gatewayReconciler) setAddressStatus(ctx context.Context, gw *gatewayv1.
 	if len(svcList.Items) == 0 {
 		return fmt.Errorf("no service found")
 	}
-
 	svc := svcList.Items[0]
 
 	var addresses []gatewayv1.GatewayStatusAddress
 	// Check the svc type
 	switch svcType := svc.Spec.Type; svcType {
 	case "NodePort":
-		// hostNetwork enabled
-		// get the nodes ip addresses
+		// NodePort service gets as many Node
+		// IP addresses as we can fit into Status
 		nodes := &corev1.NodeList{}
 		if err := r.Client.List(ctx, nodes); err != nil {
 			return fmt.Errorf("unable to list nodes")
 		}
 
+		ips := make([]net.IP, 0)
 		for _, node := range nodes.Items {
+			if len(node.Status.Addresses) == 0 {
+				continue
+			}
 			nodeAddress := node.Status.Addresses[0]
-			addresses = append(addresses, gatewayv1.GatewayStatusAddress{
-				Type:  GatewayAddressTypePtr(gatewayv1.IPAddressType),
-				Value: nodeAddress.Address,
-			})
+			ips = append(ips, net.ParseIP(nodeAddress.Address))
 		}
 
 		// sort the addresses for consistent ip addresses assigned
-		sort.Slice(addresses, func(i, j int) bool {
-			return addresses[i].Value < addresses[j].Value
+		sort.Slice(ips, func(i, j int) bool {
+			return bytes.Compare(ips[i], ips[j]) < 0
 		})
 
+		// allows for only a max of 16 addresses
+		if len(ips) > 16 {
+			ips = ips[:16]
+		}
+		for _, ipAddress := range ips {
+			addresses = append(addresses, gatewayv1.GatewayStatusAddress{
+				Type:  GatewayAddressTypePtr(gatewayv1.IPAddressType),
+				Value: ipAddress.String(),
+			})
+		}
 	case "LoadBalancer":
 		if len(svc.Status.LoadBalancer.Ingress) == 0 {
 			// Potential loadbalancer service isn't ready yet. No need to report as an error, because

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"sort"
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
@@ -783,26 +784,53 @@ func (r *gatewayReconciler) setAddressStatus(ctx context.Context, gw *gatewayv1.
 	}
 
 	svc := svcList.Items[0]
-	if len(svc.Status.LoadBalancer.Ingress) == 0 {
-		// Potential loadbalancer service isn't ready yet. No need to report as an error, because
-		// reconciliation should be triggered when the loadbalancer services gets updated.
-		return nil
-	}
 
 	var addresses []gatewayv1.GatewayStatusAddress
-	for _, s := range svc.Status.LoadBalancer.Ingress {
-		if len(s.IP) != 0 {
+	// Check the svc type
+	switch svcType := svc.Spec.Type; svcType {
+	case "NodePort":
+		// hostNetwork enabled
+		// get the nodes ip addresses
+		nodes := &corev1.NodeList{}
+		if err := r.Client.List(ctx, nodes); err != nil {
+			return fmt.Errorf("unable to list nodes")
+		}
+
+		for _, node := range nodes.Items {
+			nodeAddress := node.Status.Addresses[0]
 			addresses = append(addresses, gatewayv1.GatewayStatusAddress{
 				Type:  GatewayAddressTypePtr(gatewayv1.IPAddressType),
-				Value: s.IP,
+				Value: nodeAddress.Address,
 			})
 		}
-		if len(s.Hostname) != 0 {
-			addresses = append(addresses, gatewayv1.GatewayStatusAddress{
-				Type:  GatewayAddressTypePtr(gatewayv1.HostnameAddressType),
-				Value: s.Hostname,
-			})
+
+		// sort the addresses for consistent ip addresses assigned
+		sort.Slice(addresses, func(i, j int) bool {
+			return addresses[i].Value < addresses[j].Value
+		})
+
+	case "LoadBalancer":
+		if len(svc.Status.LoadBalancer.Ingress) == 0 {
+			// Potential loadbalancer service isn't ready yet. No need to report as an error, because
+			// reconciliation should be triggered when the loadbalancer services gets updated.
+			return nil
 		}
+		for _, s := range svc.Status.LoadBalancer.Ingress {
+			if len(s.IP) != 0 {
+				addresses = append(addresses, gatewayv1.GatewayStatusAddress{
+					Type:  GatewayAddressTypePtr(gatewayv1.IPAddressType),
+					Value: s.IP,
+				})
+			}
+			if len(s.Hostname) != 0 {
+				addresses = append(addresses, gatewayv1.GatewayStatusAddress{
+					Type:  GatewayAddressTypePtr(gatewayv1.HostnameAddressType),
+					Value: s.Hostname,
+				})
+			}
+		}
+	default:
+		return fmt.Errorf("Invalid service type for gateway")
 	}
 
 	if len(addresses) > 0 {

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -116,6 +116,7 @@ func Test_Conformance(t *testing.T) {
 		disableTCPRoute      bool
 		disableUDPRoute      bool
 		wantErr              bool
+		hostNetwork          bool
 	}{
 		{
 			name: "gateway-http-listener-isolation",
@@ -332,13 +333,15 @@ func Test_Conformance(t *testing.T) {
 		{name: "gateway-cross-protocol-same-hostname", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "cross-protocol-same-hostname", Namespace: "gateway-conformance-infra"}}}},
 		{name: "gateway-cross-protocol-same-port-same-hostname", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "cross-protocol-same-port-same-hostname", Namespace: "gateway-conformance-infra"}, wantErr: true}}},
 		{name: "gateway-ns-restricted-same-hostname", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "ns-restricted-same-hostname", Namespace: "gateway-conformance-infra"}}}},
+		{name: "hostNetwork-enabled-valid", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "hostnetwork-enabled", Namespace: "gateway-conformance-infra"}}}, hostNetwork: true},
+		{name: "hostNetwork-enabled-exceed-max-address", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "hostnetwork-enabled", Namespace: "gateway-conformance-infra"}}}, hostNetwork: true},
+		{name: "gatewayclassconfig-nodeport", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "nodeport-gateway", Namespace: "gateway-conformance-infra"}}}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			base := readInputDir(t, "testdata/gateway/base")
 			input := readInputDir(t, fmt.Sprintf("testdata/gateway/%s/input", tt.name))
-
 			clientBuilder := fake.NewClientBuilder().
 				WithObjects(append(base, input...)...).
 				WithStatusSubresource(&corev1.Service{}).
@@ -381,7 +384,19 @@ func Test_Conformance(t *testing.T) {
 			}
 
 			c := clientBuilder.Build()
-
+			if tt.hostNetwork {
+				gatewayAPITranslator = gatewayApiTranslation.NewTranslator(cecTranslator, translation.Config{
+					ServiceConfig: translation.ServiceConfig{
+						ExternalTrafficPolicy: string(corev1.ServiceExternalTrafficPolicyCluster),
+					},
+					OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
+						UseRemoteAddress: true,
+					},
+					HostNetworkConfig: translation.HostNetworkConfig{
+						Enabled: true,
+					},
+				})
+			}
 			r := &gatewayReconciler{
 				Client:         c,
 				translator:     gatewayAPITranslator,

--- a/operator/pkg/gateway-api/helper_test.go
+++ b/operator/pkg/gateway-api/helper_test.go
@@ -131,6 +131,10 @@ func readInput(t *testing.T, file string) []client.Object {
 			obj := &gatewayv1.BackendTLSPolicy{}
 			fromYaml(t, o, obj)
 			res = append(res, obj)
+		case "Node":
+			obj := &corev1.Node{}
+			fromYaml(t, o, obj)
+			res = append(res, obj)
 		}
 	}
 

--- a/operator/pkg/gateway-api/testdata/gateway/gatewayclassconfig-nodeport/input/nodeport-gateway.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gatewayclassconfig-nodeport/input/nodeport-gateway.yaml
@@ -1,0 +1,86 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: nodeport-gateway-class
+spec:
+  controllerName: io.cilium/gateway-controller
+  description: The default Cilium GatewayClass
+  parametersRef:
+    group: cilium.io
+    kind: CiliumGatewayClassConfig
+    name: nodeport-gateway-config
+    namespace: default
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumGatewayClassConfig
+metadata:
+  name: nodeport-gateway-config
+  namespace: default
+spec:
+  service:
+    type: NodePort
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: nodeport-gateway
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: nodeport-gateway-class
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cilium-gateway-nodeport-gateway
+  namespace: gateway-conformance-infra
+  labels:
+    gateway.networking.k8s.io/gateway-name: nodeport-gateway
+    io.cilium.gateway/owning-gateway: nodeport-gateway
+spec:
+  ports:
+    - port: 3000
+      targetPort: 80
+      nodePort: 30020
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.3
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker2
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.4
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname

--- a/operator/pkg/gateway-api/testdata/gateway/gatewayclassconfig-nodeport/output/cec-nodeport-gateway.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gatewayclassconfig-nodeport/output/cec-nodeport-gateway.yaml
@@ -1,0 +1,77 @@
+metadata:
+  creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: nodeport-gateway
+  name: cilium-gateway-nodeport-gateway
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: nodeport-gateway
+    uid: ""
+  resourceVersion: "1"
+spec:
+  resources:
+  - '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    filterChains:
+    - filterChainMatch:
+        transportProtocol: raw_buffer
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            maxStreamDuration: 0s
+          httpFilters:
+          - name: envoy.filters.http.grpc_web
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+          - name: envoy.filters.http.grpc_stats
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+              emitFilterState: true
+              enableUpstreamStats: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig: {}
+          rds:
+            routeConfigName: listener-insecure
+          statPrefix: listener-insecure
+          streamIdleTimeout: 300s
+          upgradeConfigs:
+          - upgradeType: websocket
+          useRemoteAddress: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: listener
+    socketOptions:
+    - description: Enable TCP keep-alive (default to enabled)
+      intValue: "1"
+      level: "1"
+      name: "9"
+    - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+      intValue: "10"
+      level: "6"
+      name: "4"
+    - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+      intValue: "5"
+      level: "6"
+      name: "5"
+    - description: TCP keep-alive probe max failures.
+      intValue: "10"
+      level: "6"
+      name: "6"
+  - '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    name: listener-insecure
+  services:
+  - listener: ""
+    name: cilium-gateway-nodeport-gateway
+    namespace: gateway-conformance-infra
+    ports:
+    - 80

--- a/operator/pkg/gateway-api/testdata/gateway/gatewayclassconfig-nodeport/output/nodeport-gateway.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gatewayclassconfig-nodeport/output/nodeport-gateway.yaml
@@ -1,0 +1,56 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: nodeport-gateway
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  gatewayClassName: nodeport-gateway-class
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+status:
+  addresses:
+    - type: IPAddress
+      value: 172.18.0.3
+    - type: IPAddress
+      value: 172.18.0.4
+  conditions:
+    - lastTransitionTime: "2026-05-05T19:06:19Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-05-05T19:06:19Z"
+      message: Gateway Programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      name: "http"
+      conditions:
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-exceed-max-address/input/gateway.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-exceed-max-address/input/gateway.yaml
@@ -1,0 +1,335 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: hostnetwork-enabled
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cilium-gateway-hostnetwork-enabled
+  namespace: gateway-conformance-infra
+  labels:
+    gateway.networking.k8s.io/gateway-name: hostnetwork-enabled
+    io.cilium.gateway/owning-gateway: hostnetwork-enabled
+spec:
+  ports:
+    - port: 3000
+      targetPort: 80
+      nodePort: 30020
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.3
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker2
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.4
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker3
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.5
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker4
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.6
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker5
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.7
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker6
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.8
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker7
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.9
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker8
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.10
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname
+
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker9
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.11
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker10
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.12
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker11
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.13
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker12
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.14
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker13
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.15
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker14
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.16
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker15
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.17
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker18
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.18
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker19
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.19
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-exceed-max-address/output/cec-hostnetwork-enabled.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-exceed-max-address/output/cec-hostnetwork-enabled.yaml
@@ -1,0 +1,77 @@
+metadata:
+  creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: hostnetwork-enabled
+  name: cilium-gateway-hostnetwork-enabled
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: hostnetwork-enabled
+    uid: ""
+  resourceVersion: "1"
+spec:
+  resources:
+  - '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    filterChains:
+    - filterChainMatch:
+        transportProtocol: raw_buffer
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            maxStreamDuration: 0s
+          httpFilters:
+          - name: envoy.filters.http.grpc_web
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+          - name: envoy.filters.http.grpc_stats
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+              emitFilterState: true
+              enableUpstreamStats: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig: {}
+          rds:
+            routeConfigName: listener-insecure
+          statPrefix: listener-insecure
+          streamIdleTimeout: 300s
+          upgradeConfigs:
+          - upgradeType: websocket
+          useRemoteAddress: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: listener
+    socketOptions:
+    - description: Enable TCP keep-alive (default to enabled)
+      intValue: "1"
+      level: "1"
+      name: "9"
+    - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+      intValue: "10"
+      level: "6"
+      name: "4"
+    - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+      intValue: "5"
+      level: "6"
+      name: "5"
+    - description: TCP keep-alive probe max failures.
+      intValue: "10"
+      level: "6"
+      name: "6"
+  - '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    name: listener-insecure
+  services:
+  - listener: ""
+    name: cilium-gateway-hostnetwork-enabled
+    namespace: gateway-conformance-infra
+    ports:
+    - 80

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-exceed-max-address/output/hostnetwork-enabled.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-exceed-max-address/output/hostnetwork-enabled.yaml
@@ -1,0 +1,84 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: hostnetwork-enabled
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+status:
+  addresses:
+    - type: IPAddress
+      value: 172.18.0.3
+    - type: IPAddress
+      value: 172.18.0.4
+    - type: IPAddress
+      value: 172.18.0.5
+    - type: IPAddress
+      value: 172.18.0.6
+    - type: IPAddress
+      value: 172.18.0.7
+    - type: IPAddress
+      value: 172.18.0.8
+    - type: IPAddress
+      value: 172.18.0.9
+    - type: IPAddress
+      value: 172.18.0.10
+    - type: IPAddress
+      value: 172.18.0.11
+    - type: IPAddress
+      value: 172.18.0.12
+    - type: IPAddress
+      value: 172.18.0.13
+    - type: IPAddress
+      value: 172.18.0.14
+    - type: IPAddress
+      value: 172.18.0.15
+    - type: IPAddress
+      value: 172.18.0.16
+    - type: IPAddress
+      value: 172.18.0.17
+    - type: IPAddress
+      value: 172.18.0.18
+  conditions:
+    - lastTransitionTime: "2026-05-05T19:06:19Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-05-05T19:06:19Z"
+      message: Gateway Programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      name: "http"
+      conditions:
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-valid/input/gateway.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-valid/input/gateway.yaml
@@ -1,0 +1,64 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: hostnetwork-enabled
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cilium-gateway-hostnetwork-enabled
+  namespace: gateway-conformance-infra
+  labels:
+    gateway.networking.k8s.io/gateway-name: hostnetwork-enabled
+    io.cilium.gateway/owning-gateway: hostnetwork-enabled
+spec:
+  ports:
+    - port: 3000
+      targetPort: 80
+      nodePort: 30020
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.3
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker2
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.4
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-valid/output/cec-hostnetwork-enabled.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-valid/output/cec-hostnetwork-enabled.yaml
@@ -1,0 +1,77 @@
+metadata:
+  creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: hostnetwork-enabled
+  name: cilium-gateway-hostnetwork-enabled
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: hostnetwork-enabled
+    uid: ""
+  resourceVersion: "1"
+spec:
+  resources:
+  - '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    filterChains:
+    - filterChainMatch:
+        transportProtocol: raw_buffer
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            maxStreamDuration: 0s
+          httpFilters:
+          - name: envoy.filters.http.grpc_web
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+          - name: envoy.filters.http.grpc_stats
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+              emitFilterState: true
+              enableUpstreamStats: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig: {}
+          rds:
+            routeConfigName: listener-insecure
+          statPrefix: listener-insecure
+          streamIdleTimeout: 300s
+          upgradeConfigs:
+          - upgradeType: websocket
+          useRemoteAddress: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: listener
+    socketOptions:
+    - description: Enable TCP keep-alive (default to enabled)
+      intValue: "1"
+      level: "1"
+      name: "9"
+    - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+      intValue: "10"
+      level: "6"
+      name: "4"
+    - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+      intValue: "5"
+      level: "6"
+      name: "5"
+    - description: TCP keep-alive probe max failures.
+      intValue: "10"
+      level: "6"
+      name: "6"
+  - '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    name: listener-insecure
+  services:
+  - listener: ""
+    name: cilium-gateway-hostnetwork-enabled
+    namespace: gateway-conformance-infra
+    ports:
+    - 80

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-valid/output/hostnetwork-enabled.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-valid/output/hostnetwork-enabled.yaml
@@ -1,0 +1,56 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: hostnetwork-enabled
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+status:
+  addresses:
+    - type: IPAddress
+      value: 172.18.0.3
+    - type: IPAddress
+      value: 172.18.0.4
+  conditions:
+    - lastTransitionTime: "2026-05-05T19:06:19Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-05-05T19:06:19Z"
+      message: Gateway Programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      name: "http"
+      conditions:
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/watch-handlers/node.go
+++ b/operator/pkg/gateway-api/watch-handlers/node.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchhandlers
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// EnqueueRequestForNodes returns an event handler for any changes to a node's IP address, returns reconcile.Requests
+// for all Cilium-relvant Gateways
+func EnqueueRequestForNodes(c client.Client, logger *slog.Logger, owningGatewayLabel string) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, ns client.Object) []reconcile.Request {
+		scopedLog := logger.With(
+			logfields.K8sNamespace, ns.GetName(),
+		)
+		nodeList := &corev1.NodeList{}
+		if err := c.List(ctx, nodeList); err != nil {
+			scopedLog.WarnContext(ctx, "Unable to list nodes", logfields.Error, err)
+			return nil
+		}
+
+		gateways, err := getAllCiliumGatewaysSet(ctx, c)
+
+		if err != nil {
+			scopedLog.ErrorContext(ctx, "Failed to get Cilium Gateways", logfields.Error, err)
+			return []reconcile.Request{}
+		}
+
+		reqs := make([]reconcile.Request, 0, len(gateways))
+		svcList := &corev1.ServiceList{}
+		svcMap := make(map[string]struct{})
+
+		// for each gateway, filter for the services owned by the gateway
+		for gw := range gateways {
+			gwSplit := strings.SplitN(gw, "/", 2)
+			gwName := gwSplit[1]
+			if err := c.List(ctx, svcList, client.MatchingLabels{
+				owningGatewayLabel: gwName,
+			}); err != nil {
+				scopedLog.WarnContext(ctx, "Unable to list services", logfields.Error, err)
+			}
+			// if the service owned by the gateway is a nodeport, add to map of UID
+			for _, svc := range svcList.Items {
+				if svc.Spec.Type == "NodePort" {
+					svcMap[string(svc.GetOwnerReferences()[0].UID)] = struct{}{}
+				}
+			}
+		}
+
+		// queue up a request for every Cilium related gateway
+		for gw := range gateways {
+			gwSplit := strings.SplitN(gw, "/", 2)
+
+			if len(gwSplit) != 2 {
+				scopedLog.ErrorContext(ctx, "Failed to get namespace name", logfields.Error, err)
+				return []reconcile.Request{}
+			}
+
+			gwNamespace, gwName := gwSplit[0], gwSplit[1]
+
+			gatewayNamespaceName := types.NamespacedName{
+				Namespace: gwNamespace,
+				Name:      gwName,
+			}
+
+			gateway := &gatewayv1.Gateway{}
+
+			if err := c.Get(ctx, gatewayNamespaceName, gateway); err != nil {
+				scopedLog.WarnContext(ctx, "Unable to get gateway", logfields.Error, err)
+			}
+			if _, err := svcMap[string(gateway.GetUID())]; err {
+				// there is no nodeport svc for this gateway, no need to reconcile
+				continue
+			}
+			reqs = append(reqs, reconcile.Request{
+				NamespacedName: gatewayNamespaceName,
+			})
+		}
+		return reqs
+	})
+}

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_with_xff_num_trusted_hops/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_with_xff_num_trusted_hops/service-output.yaml
@@ -17,7 +17,7 @@ spec:
     port: 80
     protocol: TCP
     targetPort: 0
-  type: ClusterIP
+  type: NodePort 
   ipFamilies:
   - IPv4
   - IPv6

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_with_xff_num_trusted_hops/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_http_listener_with_xff_num_trusted_hops/service-output.yaml
@@ -17,7 +17,7 @@ spec:
     port: 80
     protocol: TCP
     targetPort: 0
-  type: NodePort 
+  type: NodePort
   ipFamilies:
   - IPv4
   - IPv6

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener/with_external_traffic_policy/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener/with_external_traffic_policy/service-output.yaml
@@ -17,7 +17,7 @@ spec:
     port: 80
     protocol: TCP
     targetPort: 0
-  type: NodePort 
+  type: NodePort
   ipFamilies:
   - IPv4
 status:

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener/with_external_traffic_policy/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener/with_external_traffic_policy/service-output.yaml
@@ -17,7 +17,7 @@ spec:
     port: 80
     protocol: TCP
     targetPort: 0
-  type: ClusterIP
+  type: NodePort 
   ipFamilies:
   - IPv4
 status:

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener/without_external_traffic_policy/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener/without_external_traffic_policy/service-output.yaml
@@ -17,7 +17,7 @@ spec:
     port: 80
     protocol: TCP
     targetPort: 0
-  type: NodePort 
+  type: NodePort
   ipFamilies:
   - IPv4
 status:

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener/without_external_traffic_policy/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener/without_external_traffic_policy/service-output.yaml
@@ -17,7 +17,7 @@ spec:
     port: 80
     protocol: TCP
     targetPort: 0
-  type: ClusterIP
+  type: NodePort 
   ipFamilies:
   - IPv4
 status:

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port/with_external_traffic_policy/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port/with_external_traffic_policy/service-output.yaml
@@ -17,7 +17,7 @@ spec:
     port: 55555
     protocol: TCP
     targetPort: 0
-  type: ClusterIP
+  type: NodePort 
   ipFamilies:
   - IPv4
 status:

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port/with_external_traffic_policy/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port/with_external_traffic_policy/service-output.yaml
@@ -17,7 +17,7 @@ spec:
     port: 55555
     protocol: TCP
     targetPort: 0
-  type: NodePort 
+  type: NodePort
   ipFamilies:
   - IPv4
 status:

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port/without_external_traffic_policy/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port/without_external_traffic_policy/service-output.yaml
@@ -17,7 +17,7 @@ spec:
     port: 55555
     protocol: TCP
     targetPort: 0
-  type: ClusterIP
+  type: NodePort 
   ipFamilies:
   - IPv4
 status:

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port/without_external_traffic_policy/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port/without_external_traffic_policy/service-output.yaml
@@ -17,7 +17,7 @@ spec:
     port: 55555
     protocol: TCP
     targetPort: 0
-  type: NodePort 
+  type: NodePort
   ipFamilies:
   - IPv4
 status:

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port_and_ipv_6/with_external_traffic_policy/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port_and_ipv_6/with_external_traffic_policy/service-output.yaml
@@ -17,7 +17,7 @@ spec:
     port: 55555
     protocol: TCP
     targetPort: 0
-  type: NodePort 
+  type: NodePort
   ipFamilies:
   - IPv6
 status:

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port_and_ipv_6/with_external_traffic_policy/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port_and_ipv_6/with_external_traffic_policy/service-output.yaml
@@ -17,7 +17,7 @@ spec:
     port: 55555
     protocol: TCP
     targetPort: 0
-  type: ClusterIP
+  type: NodePort 
   ipFamilies:
   - IPv6
 status:

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port_and_ipv_6/without_external_traffic_policy/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port_and_ipv_6/without_external_traffic_policy/service-output.yaml
@@ -17,7 +17,7 @@ spec:
     port: 55555
     protocol: TCP
     targetPort: 0
-  type: NodePort 
+  type: NodePort
   ipFamilies:
   - IPv6
 status:

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port_and_ipv_6/without_external_traffic_policy/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_different_port_and_ipv_6/without_external_traffic_policy/service-output.yaml
@@ -17,7 +17,7 @@ spec:
     port: 55555
     protocol: TCP
     targetPort: 0
-  type: ClusterIP
+  type: NodePort 
   ipFamilies:
   - IPv6
 status:

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_label_selector/with_external_traffic_policy/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_label_selector/with_external_traffic_policy/service-output.yaml
@@ -17,7 +17,7 @@ spec:
     port: 55555
     protocol: TCP
     targetPort: 0
-  type: ClusterIP
+  type: NodePort 
   ipFamilies:
   - IPv4
 status:

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_label_selector/with_external_traffic_policy/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_label_selector/with_external_traffic_policy/service-output.yaml
@@ -17,7 +17,7 @@ spec:
     port: 55555
     protocol: TCP
     targetPort: 0
-  type: NodePort 
+  type: NodePort
   ipFamilies:
   - IPv4
 status:

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_label_selector/without_external_traffic_policy/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_label_selector/without_external_traffic_policy/service-output.yaml
@@ -17,7 +17,7 @@ spec:
     port: 55555
     protocol: TCP
     targetPort: 0
-  type: ClusterIP
+  type: NodePort
   ipFamilies:
   - IPv4
 status:

--- a/operator/pkg/model/translation/gateway-api/translator.go
+++ b/operator/pkg/model/translation/gateway-api/translator.go
@@ -264,7 +264,7 @@ func (t *gatewayAPITranslator) toServicePorts(listeners []model.Listener) []core
 // If hostNetwork is enabled, it returns ServiceTypeClusterIP. The default value is ServiceTypeLoadBalancer.
 func (t *gatewayAPITranslator) toServiceType(params *model.Service) corev1.ServiceType {
 	if t.cfg.HostNetworkConfig.Enabled {
-		return corev1.ServiceTypeClusterIP
+		return corev1.ServiceTypeNodePort
 	}
 	if params == nil {
 		return corev1.ServiceTypeLoadBalancer

--- a/operator/pkg/model/translation/gateway-api/translator.go
+++ b/operator/pkg/model/translation/gateway-api/translator.go
@@ -261,7 +261,7 @@ func (t *gatewayAPITranslator) toServicePorts(listeners []model.Listener) []core
 }
 
 // toServiceType returns the ServiceType from the given Service object.
-// If hostNetwork is enabled, it returns ServiceTypeClusterIP. The default value is ServiceTypeLoadBalancer.
+// If hostNetwork is enabled, it returns ServiceTypeNodePort. The default value is ServiceTypeLoadBalancer.
 func (t *gatewayAPITranslator) toServiceType(params *model.Service) corev1.ServiceType {
 	if t.cfg.HostNetworkConfig.Enabled {
 		return corev1.ServiceTypeNodePort

--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -295,7 +295,7 @@ func Test_translator_Translate_WithXffNumTrustedHops(t *testing.T) {
 			}
 
 			require.NotNil(t, svc)
-			assert.Equal(t, corev1.ServiceTypeClusterIP, svc.Spec.Type)
+			assert.Equal(t, corev1.ServiceTypeNodePort, svc.Spec.Type)
 
 			require.NotNil(t, ep)
 		})


### PR DESCRIPTION
Add switch statement for when hostNetwork is enabled. This will ensure the Gateway's ExternalIP is populated with the node's ip addresses.



<!-- Description of change -->
After v1.18.3, having `hostEnabled` would set a gateway's status to be `Programmed: FALSE`. This is due to no addresses being assigned in the external ip address field. Now populating the address field, allowing the gateway to be set to `Programmed: TRUE`

Related to https://github.com/cilium/cilium/issues/42786

```release-note
gateway-api: Add Gateway check for when hostNetwork is enabled
```

