### PR TITLE
operator: register k8s_client metrics

### DIFF
--- a/operator/metrics/metrics.go
+++ b/operator/metrics/metrics.go
@@ -71,6 +71,10 @@ func initializeMetrics(p params) {
 		metrics.WorkQueueUnfinishedWork,
 		metrics.WorkQueueLongestRunningProcessor,
 		metrics.WorkQueueRetries,
+
+		metrics.KubernetesAPIInteractions,
+		metrics.KubernetesAPIRateLimiterLatency,
+		metrics.KubernetesAPICallsTotal,
 	)
 
 	p.Registry.Register(k8sCtrlMetrics.ReadCertificateTotal)


### PR DESCRIPTION
The k8s_client metrics were missing from the manual registration of metrics for the operator.

I did not add tests since the existing operator metrics tests do not assert which specific legacy metrics are registered in initializeMetrics (e.g. workqueue metrics have no coverage either).

You can validate the changes by running following steps.
```
# install cilium on kind cluster 
$ make kind-image
$ make kind-install-cilium
# port forward metrics port on the operator 
$ kubectl port-forward -n kube-system deployment/cilium-operator 9963:9963
# look for the metrics
$ curl -s localhost:9963/metrics | grep k8s_client
```

Fixes: #46352

```release-note
Fix operator not exporting k8s_client metrics (api latency, rate limiter latency, api calls total).
```
