### PR TITLE
Fix pointer-address comparison for Gateway API Route ParentReference status handling

### DIFF
--- a/operator/pkg/gateway-api/helpers/types.go
+++ b/operator/pkg/gateway-api/helpers/types.go
@@ -118,3 +118,36 @@ func GetConcreteObject(schemaType schema.GroupVersionKind) runtime.Object {
 func IsValidGammaService(svc *corev1.Service) bool {
 	return svc.Spec.Type == corev1.ServiceTypeClusterIP
 }
+
+// ParentRefEqual returns true if two ParentReferences are equal in value.
+func ParentRefEqual(a, b gatewayv1.ParentReference) bool {
+	if a.Name != b.Name {
+		return false
+	}
+	if !ptrEqual(a.Group, b.Group) {
+		return false
+	}
+	if !ptrEqual(a.Kind, b.Kind) {
+		return false
+	}
+	if !ptrEqual(a.Namespace, b.Namespace) {
+		return false
+	}
+	if !ptrEqual(a.SectionName, b.SectionName) {
+		return false
+	}
+	if !ptrEqual(a.Port, b.Port) {
+		return false
+	}
+	return true
+}
+
+func ptrEqual[T comparable](a, b *T) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}

--- a/operator/pkg/gateway-api/helpers/types_test.go
+++ b/operator/pkg/gateway-api/helpers/types_test.go
@@ -297,3 +297,79 @@ func TestGetConcreteObject(t *testing.T) {
 		})
 	}
 }
+
+func TestParentRefEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		a    gatewayv1.ParentReference
+		b    gatewayv1.ParentReference
+		want bool
+	}{
+		{
+			name: "equal empty",
+			a:    gatewayv1.ParentReference{},
+			b:    gatewayv1.ParentReference{},
+			want: true,
+		},
+		{
+			name: "equal simple",
+			a:    gatewayv1.ParentReference{Name: "gw"},
+			b:    gatewayv1.ParentReference{Name: "gw"},
+			want: true,
+		},
+		{
+			name: "different name",
+			a:    gatewayv1.ParentReference{Name: "gw1"},
+			b:    gatewayv1.ParentReference{Name: "gw2"},
+			want: false,
+		},
+		{
+			name: "same group ptrs",
+			a:    gatewayv1.ParentReference{Name: "gw", Group: ptr.To[gatewayv1.Group]("group1")},
+			b:    gatewayv1.ParentReference{Name: "gw", Group: ptr.To[gatewayv1.Group]("group1")},
+			want: true,
+		},
+		{
+			name: "different group values",
+			a:    gatewayv1.ParentReference{Name: "gw", Group: ptr.To[gatewayv1.Group]("group1")},
+			b:    gatewayv1.ParentReference{Name: "gw", Group: ptr.To[gatewayv1.Group]("group2")},
+			want: false,
+		},
+		{
+			name: "nil vs non-nil group",
+			a:    gatewayv1.ParentReference{Name: "gw", Group: nil},
+			b:    gatewayv1.ParentReference{Name: "gw", Group: ptr.To[gatewayv1.Group]("group1")},
+			want: false,
+		},
+		{
+			name: "different kind values",
+			a:    gatewayv1.ParentReference{Name: "gw", Kind: ptr.To[gatewayv1.Kind]("Gateway")},
+			b:    gatewayv1.ParentReference{Name: "gw", Kind: ptr.To[gatewayv1.Kind]("Service")},
+			want: false,
+		},
+		{
+			name: "different namespaces",
+			a:    gatewayv1.ParentReference{Name: "gw", Namespace: ptr.To[gatewayv1.Namespace]("ns1")},
+			b:    gatewayv1.ParentReference{Name: "gw", Namespace: ptr.To[gatewayv1.Namespace]("ns2")},
+			want: false,
+		},
+		{
+			name: "different sectionNames",
+			a:    gatewayv1.ParentReference{Name: "gw", SectionName: ptr.To[gatewayv1.SectionName]("sec1")},
+			b:    gatewayv1.ParentReference{Name: "gw", SectionName: ptr.To[gatewayv1.SectionName]("sec2")},
+			want: false,
+		},
+		{
+			name: "different ports",
+			a:    gatewayv1.ParentReference{Name: "gw", Port: ptr.To[gatewayv1.PortNumber](80)},
+			b:    gatewayv1.ParentReference{Name: "gw", Port: ptr.To[gatewayv1.PortNumber](443)},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParentRefEqual(tt.a, tt.b)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/operator/pkg/gateway-api/routechecks/grpcroute.go
+++ b/operator/pkg/gateway-api/routechecks/grpcroute.go
@@ -176,7 +176,7 @@ func (g *GRPCRouteInput) GetValidProtocols() []gatewayv1.ProtocolType {
 func (g *GRPCRouteInput) mergeStatusConditions(parentRef gatewayv1.ParentReference, updates []metav1.Condition) {
 	index := -1
 	for i, parent := range g.GRPCRoute.Status.RouteStatus.Parents {
-		if parent.ParentRef == parentRef {
+		if helpers.ParentRefEqual(parent.ParentRef, parentRef) {
 			index = i
 			break
 		}

--- a/operator/pkg/gateway-api/routechecks/httproute.go
+++ b/operator/pkg/gateway-api/routechecks/httproute.go
@@ -56,7 +56,7 @@ func (h *HTTPRouteInput) SetAllParentCondition(condition metav1.Condition) {
 func (h *HTTPRouteInput) mergeStatusConditions(parentRef gatewayv1.ParentReference, updates []metav1.Condition) {
 	index := -1
 	for i, parent := range h.HTTPRoute.Status.RouteStatus.Parents {
-		if parent.ParentRef == parentRef {
+		if helpers.ParentRefEqual(parent.ParentRef, parentRef) {
 			index = i
 			break
 		}

--- a/operator/pkg/gateway-api/routechecks/routechecks_test.go
+++ b/operator/pkg/gateway-api/routechecks/routechecks_test.go
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package routechecks
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestHTTPRouteInput_MergeStatusConditions(t *testing.T) {
+	// 1. Create a parentRef that will be in the route status
+	parentInStatus := gatewayv1.ParentReference{
+		Group:     ptr.To[gatewayv1.Group]("gateway.networking.k8s.io"),
+		Kind:      ptr.To[gatewayv1.Kind]("Gateway"),
+		Namespace: ptr.To[gatewayv1.Namespace]("default"),
+		Name:      gatewayv1.ObjectName("my-gateway"),
+	}
+
+	// 2. Create the route with this parent in its status
+	route := &gatewayv1.HTTPRoute{
+		Status: gatewayv1.HTTPRouteStatus{
+			RouteStatus: gatewayv1.RouteStatus{
+				Parents: []gatewayv1.RouteParentStatus{
+					{
+						ParentRef:      parentInStatus,
+						ControllerName: controllerName,
+						Conditions: []metav1.Condition{
+							{
+								Type:   "Accepted",
+								Status: metav1.ConditionFalse,
+								Reason: "InitialReason",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	input := &HTTPRouteInput{
+		Ctx:       context.Background(),
+		Logger:    slog.Default(),
+		HTTPRoute: route,
+	}
+
+	// 3. Create a parentRef with identical values but different pointer instances to merge into status
+	parentToMerge := gatewayv1.ParentReference{
+		Group:     ptr.To[gatewayv1.Group]("gateway.networking.k8s.io"),
+		Kind:      ptr.To[gatewayv1.Kind]("Gateway"),
+		Namespace: ptr.To[gatewayv1.Namespace]("default"),
+		Name:      gatewayv1.ObjectName("my-gateway"),
+	}
+
+	newCondition := metav1.Condition{
+		Type:   "Accepted",
+		Status: metav1.ConditionTrue,
+		Reason: "MergedReason",
+	}
+
+	// 4. Run SetParentCondition which internally calls mergeStatusConditions
+	input.SetParentCondition(parentToMerge, newCondition)
+
+	// 5. Verify that:
+	// - The parent entry is not duplicated (still only 1 parent entry in status)
+	// - The existing condition was merged/updated with the new condition
+	assert.Len(t, route.Status.RouteStatus.Parents, 1)
+	assert.Equal(t, parentInStatus.Name, route.Status.RouteStatus.Parents[0].ParentRef.Name)
+	assert.Len(t, route.Status.RouteStatus.Parents[0].Conditions, 1)
+	assert.Equal(t, metav1.ConditionTrue, route.Status.RouteStatus.Parents[0].Conditions[0].Status)
+	assert.Equal(t, "MergedReason", route.Status.RouteStatus.Parents[0].Conditions[0].Reason)
+}
+
+func TestGRPCRouteInput_MergeStatusConditions(t *testing.T) {
+	parentInStatus := gatewayv1.ParentReference{
+		Group:     ptr.To[gatewayv1.Group]("gateway.networking.k8s.io"),
+		Kind:      ptr.To[gatewayv1.Kind]("Gateway"),
+		Namespace: ptr.To[gatewayv1.Namespace]("default"),
+		Name:      gatewayv1.ObjectName("my-gateway"),
+	}
+
+	route := &gatewayv1.GRPCRoute{
+		Status: gatewayv1.GRPCRouteStatus{
+			RouteStatus: gatewayv1.RouteStatus{
+				Parents: []gatewayv1.RouteParentStatus{
+					{
+						ParentRef:      parentInStatus,
+						ControllerName: controllerName,
+						Conditions: []metav1.Condition{
+							{
+								Type:   "Accepted",
+								Status: metav1.ConditionFalse,
+								Reason: "InitialReason",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	input := &GRPCRouteInput{
+		Ctx:       context.Background(),
+		Logger:    slog.Default(),
+		GRPCRoute: route,
+	}
+
+	parentToMerge := gatewayv1.ParentReference{
+		Group:     ptr.To[gatewayv1.Group]("gateway.networking.k8s.io"),
+		Kind:      ptr.To[gatewayv1.Kind]("Gateway"),
+		Namespace: ptr.To[gatewayv1.Namespace]("default"),
+		Name:      gatewayv1.ObjectName("my-gateway"),
+	}
+
+	newCondition := metav1.Condition{
+		Type:   "Accepted",
+		Status: metav1.ConditionTrue,
+		Reason: "MergedReason",
+	}
+
+	input.SetParentCondition(parentToMerge, newCondition)
+
+	assert.Len(t, route.Status.RouteStatus.Parents, 1)
+	assert.Equal(t, parentInStatus.Name, route.Status.RouteStatus.Parents[0].ParentRef.Name)
+	assert.Len(t, route.Status.RouteStatus.Parents[0].Conditions, 1)
+	assert.Equal(t, metav1.ConditionTrue, route.Status.RouteStatus.Parents[0].Conditions[0].Status)
+	assert.Equal(t, "MergedReason", route.Status.RouteStatus.Parents[0].Conditions[0].Reason)
+}
+
+func TestTLSRouteInput_MergeStatusConditions(t *testing.T) {
+	parentInStatus := gatewayv1.ParentReference{
+		Group:     ptr.To[gatewayv1.Group]("gateway.networking.k8s.io"),
+		Kind:      ptr.To[gatewayv1.Kind]("Gateway"),
+		Namespace: ptr.To[gatewayv1.Namespace]("default"),
+		Name:      gatewayv1.ObjectName("my-gateway"),
+	}
+
+	route := &gatewayv1.TLSRoute{
+		Status: gatewayv1.TLSRouteStatus{
+			RouteStatus: gatewayv1.RouteStatus{
+				Parents: []gatewayv1.RouteParentStatus{
+					{
+						ParentRef:      parentInStatus,
+						ControllerName: controllerName,
+						Conditions: []metav1.Condition{
+							{
+								Type:   "Accepted",
+								Status: metav1.ConditionFalse,
+								Reason: "InitialReason",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	input := &TLSRouteInput{
+		Ctx:      context.Background(),
+		Logger:   slog.Default(),
+		TLSRoute: route,
+	}
+
+	parentToMerge := gatewayv1.ParentReference{
+		Group:     ptr.To[gatewayv1.Group]("gateway.networking.k8s.io"),
+		Kind:      ptr.To[gatewayv1.Kind]("Gateway"),
+		Namespace: ptr.To[gatewayv1.Namespace]("default"),
+		Name:      gatewayv1.ObjectName("my-gateway"),
+	}
+
+	newCondition := metav1.Condition{
+		Type:   "Accepted",
+		Status: metav1.ConditionTrue,
+		Reason: "MergedReason",
+	}
+
+	input.SetParentCondition(parentToMerge, newCondition)
+
+	assert.Len(t, route.Status.RouteStatus.Parents, 1)
+	assert.Equal(t, parentInStatus.Name, route.Status.RouteStatus.Parents[0].ParentRef.Name)
+	assert.Len(t, route.Status.RouteStatus.Parents[0].Conditions, 1)
+	assert.Equal(t, metav1.ConditionTrue, route.Status.RouteStatus.Parents[0].Conditions[0].Status)
+	assert.Equal(t, "MergedReason", route.Status.RouteStatus.Parents[0].Conditions[0].Reason)
+}

--- a/operator/pkg/gateway-api/routechecks/tlsroute.go
+++ b/operator/pkg/gateway-api/routechecks/tlsroute.go
@@ -55,7 +55,7 @@ func (t *TLSRouteInput) SetAllParentCondition(condition metav1.Condition) {
 func (t *TLSRouteInput) mergeStatusConditions(parentRef gatewayv1.ParentReference, updates []metav1.Condition) {
 	index := -1
 	for i, parent := range t.TLSRoute.Status.RouteStatus.Parents {
-		if parent.ParentRef == parentRef {
+		if helpers.ParentRefEqual(parent.ParentRef, parentRef) {
 			index = i
 			break
 		}

--- a/operator/pkg/gateway-api/status_route.go
+++ b/operator/pkg/gateway-api/status_route.go
@@ -15,7 +15,9 @@ func pruneRouteParentStatuses(parents []gatewayv1.RouteParentStatus, currentPare
 	filtered := parents[:0]
 
 	for _, parentStatus := range parents {
-		if parentStatus.ControllerName != helpers.CiliumDefaultControllerName || slices.Contains(currentParentRefs, parentStatus.ParentRef) {
+		if parentStatus.ControllerName != helpers.CiliumDefaultControllerName || slices.ContainsFunc(currentParentRefs, func(ref gatewayv1.ParentReference) bool {
+			return helpers.ParentRefEqual(ref, parentStatus.ParentRef)
+		}) {
 			filtered = append(filtered, parentStatus)
 		}
 	}

--- a/operator/pkg/gateway-api/status_route_test.go
+++ b/operator/pkg/gateway-api/status_route_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
@@ -15,14 +16,33 @@ import (
 )
 
 func TestPruneRouteParentStatuses(t *testing.T) {
-	currentParent := gatewayv1.ParentReference{
-		Name: "current-gateway",
+	currentParentSpec := gatewayv1.ParentReference{
+		Group:     ptr.To[gatewayv1.Group]("gateway.networking.k8s.io"),
+		Kind:      ptr.To[gatewayv1.Kind]("Gateway"),
+		Namespace: ptr.To[gatewayv1.Namespace]("default"),
+		Name:      "current-gateway",
 	}
+
+	// currentParentStatus has distinct pointer instances but identical values
+	currentParentStatus := gatewayv1.ParentReference{
+		Group:     ptr.To[gatewayv1.Group]("gateway.networking.k8s.io"),
+		Kind:      ptr.To[gatewayv1.Kind]("Gateway"),
+		Namespace: ptr.To[gatewayv1.Namespace]("default"),
+		Name:      "current-gateway",
+	}
+
 	ourDetachedParent := gatewayv1.ParentReference{
-		Name: "detached-gateway",
+		Group:     ptr.To[gatewayv1.Group]("gateway.networking.k8s.io"),
+		Kind:      ptr.To[gatewayv1.Kind]("Gateway"),
+		Namespace: ptr.To[gatewayv1.Namespace]("default"),
+		Name:      "detached-gateway",
 	}
+
 	otherControllerDetachedParent := gatewayv1.ParentReference{
-		Name: "other-controller-gateway",
+		Group:     ptr.To[gatewayv1.Group]("gateway.networking.k8s.io"),
+		Kind:      ptr.To[gatewayv1.Kind]("Gateway"),
+		Namespace: ptr.To[gatewayv1.Namespace]("default"),
+		Name:      "other-controller-gateway",
 	}
 
 	route := &gatewayv1.HTTPRoute{
@@ -33,7 +53,7 @@ func TestPruneRouteParentStatuses(t *testing.T) {
 		},
 		Spec: gatewayv1.HTTPRouteSpec{
 			CommonRouteSpec: gatewayv1.CommonRouteSpec{
-				ParentRefs: []gatewayv1.ParentReference{currentParent},
+				ParentRefs: []gatewayv1.ParentReference{currentParentSpec},
 			},
 		},
 		Status: gatewayv1.HTTPRouteStatus{
@@ -53,7 +73,7 @@ func TestPruneRouteParentStatuses(t *testing.T) {
 						ControllerName: gatewayv1.GatewayController("example.com/other-gateway-controller"),
 					},
 					{
-						ParentRef:      currentParent,
+						ParentRef:      currentParentStatus,
 						ControllerName: helpers.CiliumDefaultControllerName,
 						Conditions: []metav1.Condition{{
 							Type:   string(gatewayv1.RouteConditionAccepted),
@@ -71,7 +91,7 @@ func TestPruneRouteParentStatuses(t *testing.T) {
 	require.Len(t, route.Status.Parents, 3)
 	require.Equal(t, ourDetachedParent, route.Status.Parents[0].ParentRef)
 	require.Equal(t, otherControllerDetachedParent, route.Status.Parents[1].ParentRef)
-	require.Equal(t, currentParent, route.Status.Parents[2].ParentRef)
+	require.Equal(t, currentParentStatus, route.Status.Parents[2].ParentRef)
 
 	input.SetAllParentCondition(metav1.Condition{
 		Type:   string(gatewayv1.RouteConditionAccepted),
@@ -82,13 +102,13 @@ func TestPruneRouteParentStatuses(t *testing.T) {
 	require.Len(t, route.Status.Parents, 3, "merge alone keeps both detached statuses")
 	require.Equal(t, ourDetachedParent, route.Status.Parents[0].ParentRef, "merge alone keeps both detached statuses")
 	require.Equal(t, otherControllerDetachedParent, route.Status.Parents[1].ParentRef, "merge alone keeps both detached statuses")
-	require.Equal(t, currentParent, route.Status.Parents[2].ParentRef, "merge alone keeps both detached statuses")
+	require.Equal(t, currentParentStatus, route.Status.Parents[2].ParentRef, "merge alone keeps both detached statuses")
 
 	route.Status.Parents = pruneRouteParentStatuses(route.Status.Parents, route.Spec.ParentRefs)
 
 	require.Len(t, route.Status.Parents, 2, "prune removes only the detached Cilium-owned status")
 	require.Equal(t, otherControllerDetachedParent, route.Status.Parents[0].ParentRef, "prune removes only the detached Cilium-owned status")
 	require.Equal(t, gatewayv1.GatewayController("example.com/other-gateway-controller"), route.Status.Parents[0].ControllerName, "prune removes only the detached Cilium-owned status")
-	require.Equal(t, currentParent, route.Status.Parents[1].ParentRef, "prune removes only the detached Cilium-owned status")
+	require.Equal(t, currentParentStatus, route.Status.Parents[1].ParentRef, "prune removes only the detached Cilium-owned status")
 	require.Equal(t, gatewayv1.GatewayController(helpers.CiliumDefaultControllerName), route.Status.Parents[1].ControllerName, "prune removes only the detached Cilium-owned status")
 }


### PR DESCRIPTION


<!-- Description of change -->

## Issue Trigger Scenario

  A Gateway API Route (HTTPRoute / TLSRoute / GRPCRoute) uses parentRefs with non-nil pointer fields such as namespace, sectionName, port, group, or kind. After APIServer read/write, spec.parentRefs and status.parents[].parentRef can have identical values but different pointer instances.

  Example:
```yaml
  apiVersion: gateway.networking.k8s.io/v1
  kind: HTTPRoute
  metadata:
    name: httproute-example
    namespace: my-app-namespace
  spec:
    parentRefs:
      - name: acme-lb
        namespace: prod
        sectionName: foo
  status:
    parents:
      - parentRef:
          name: acme-lb
          namespace: prod
          sectionName: foo
```

## Issue Failure Manifestation

  Active Cilium-owned RouteParentStatus entries can be misclassified as stale and pruned. They may then be recreated, causing existing conditions to be discarded or rewritten.

  Status merge can also fail to match an existing equivalent ParentRef, which can append duplicate parent status entries instead of updating conditions.

## Expected Behavior

  Active parent statuses are retained when their ParentRef is still present in spec.parentRefs. Condition updates merge into the existing matching parent status entry.

## Root Cause

  PR #46296 added route parent status pruning in status_route.go using slices.Contains over []gatewayv1.ParentReference. It also changed route status merge helpers to usedirect struct comparison with ==.

  gatewayv1.ParentReference contains pointer fields: Group, Kind, Namespace, SectionName, and Port. Go struct comparison compares pointer addresses, not dereferenced values. After APIServer serialization and deserialization, spec.parentRefs and status.parents[].parentRef can have equal field values but different pointer addresses.


## Fix Method
  Add a ParentReference value-comparison helper that compares Name directly and pointer fields by dereferenced value with nil handling.



Fixes: #issue-number

```release-note
<!-- Enter the release note text here or remove this release-note section from your PR description. Do NOT put an "empty" release note here -->
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
