### PR TITLE
Fix pointer-address comparison for Gateway API Route ParentReference status handling

### DIFF
--- a/operator/pkg/gateway-api/routechecks/grpcroute.go
+++ b/operator/pkg/gateway-api/routechecks/grpcroute.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"reflect"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -176,7 +177,7 @@ func (g *GRPCRouteInput) GetValidProtocols() []gatewayv1.ProtocolType {
 func (g *GRPCRouteInput) mergeStatusConditions(parentRef gatewayv1.ParentReference, updates []metav1.Condition) {
 	index := -1
 	for i, parent := range g.GRPCRoute.Status.RouteStatus.Parents {
-		if parent.ParentRef == parentRef {
+		if reflect.DeepEqual(parent.ParentRef, parentRef) {
 			index = i
 			break
 		}

--- a/operator/pkg/gateway-api/routechecks/httproute.go
+++ b/operator/pkg/gateway-api/routechecks/httproute.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"reflect"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -56,7 +57,7 @@ func (h *HTTPRouteInput) SetAllParentCondition(condition metav1.Condition) {
 func (h *HTTPRouteInput) mergeStatusConditions(parentRef gatewayv1.ParentReference, updates []metav1.Condition) {
 	index := -1
 	for i, parent := range h.HTTPRoute.Status.RouteStatus.Parents {
-		if parent.ParentRef == parentRef {
+		if reflect.DeepEqual(parent.ParentRef, parentRef) {
 			index = i
 			break
 		}

--- a/operator/pkg/gateway-api/routechecks/tlsroute.go
+++ b/operator/pkg/gateway-api/routechecks/tlsroute.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"reflect"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -55,7 +56,7 @@ func (t *TLSRouteInput) SetAllParentCondition(condition metav1.Condition) {
 func (t *TLSRouteInput) mergeStatusConditions(parentRef gatewayv1.ParentReference, updates []metav1.Condition) {
 	index := -1
 	for i, parent := range t.TLSRoute.Status.RouteStatus.Parents {
-		if parent.ParentRef == parentRef {
+		if reflect.DeepEqual(parent.ParentRef, parentRef) {
 			index = i
 			break
 		}

--- a/operator/pkg/gateway-api/status_route.go
+++ b/operator/pkg/gateway-api/status_route.go
@@ -4,6 +4,7 @@
 package gateway_api
 
 import (
+	"reflect"
 	"slices"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -15,7 +16,9 @@ func pruneRouteParentStatuses(parents []gatewayv1.RouteParentStatus, currentPare
 	filtered := parents[:0]
 
 	for _, parentStatus := range parents {
-		if parentStatus.ControllerName != helpers.CiliumDefaultControllerName || slices.Contains(currentParentRefs, parentStatus.ParentRef) {
+		if parentStatus.ControllerName != helpers.CiliumDefaultControllerName || slices.ContainsFunc(currentParentRefs, func(ref gatewayv1.ParentReference) bool {
+			return reflect.DeepEqual(ref, parentStatus.ParentRef)
+		}) {
 			filtered = append(filtered, parentStatus)
 		}
 	}

--- a/operator/pkg/gateway-api/status_route_test.go
+++ b/operator/pkg/gateway-api/status_route_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
@@ -15,8 +16,19 @@ import (
 )
 
 func TestPruneRouteParentStatuses(t *testing.T) {
-	currentParent := gatewayv1.ParentReference{
-		Name: "current-gateway",
+	// currentParentSpec and currentParentStatus have identical values but distinct
+	// pointer instances, simulating spec vs status after an APIServer round-trip.
+	currentParentSpec := gatewayv1.ParentReference{
+		Group:     ptr.To[gatewayv1.Group]("gateway.networking.k8s.io"),
+		Kind:      ptr.To[gatewayv1.Kind]("Gateway"),
+		Namespace: ptr.To[gatewayv1.Namespace]("default"),
+		Name:      "current-gateway",
+	}
+	currentParentStatus := gatewayv1.ParentReference{
+		Group:     ptr.To[gatewayv1.Group]("gateway.networking.k8s.io"),
+		Kind:      ptr.To[gatewayv1.Kind]("Gateway"),
+		Namespace: ptr.To[gatewayv1.Namespace]("default"),
+		Name:      "current-gateway",
 	}
 	ourDetachedParent := gatewayv1.ParentReference{
 		Name: "detached-gateway",
@@ -33,7 +45,7 @@ func TestPruneRouteParentStatuses(t *testing.T) {
 		},
 		Spec: gatewayv1.HTTPRouteSpec{
 			CommonRouteSpec: gatewayv1.CommonRouteSpec{
-				ParentRefs: []gatewayv1.ParentReference{currentParent},
+				ParentRefs: []gatewayv1.ParentReference{currentParentSpec},
 			},
 		},
 		Status: gatewayv1.HTTPRouteStatus{
@@ -53,7 +65,7 @@ func TestPruneRouteParentStatuses(t *testing.T) {
 						ControllerName: gatewayv1.GatewayController("example.com/other-gateway-controller"),
 					},
 					{
-						ParentRef:      currentParent,
+						ParentRef:      currentParentStatus,
 						ControllerName: helpers.CiliumDefaultControllerName,
 						Conditions: []metav1.Condition{{
 							Type:   string(gatewayv1.RouteConditionAccepted),
@@ -71,7 +83,7 @@ func TestPruneRouteParentStatuses(t *testing.T) {
 	require.Len(t, route.Status.Parents, 3)
 	require.Equal(t, ourDetachedParent, route.Status.Parents[0].ParentRef)
 	require.Equal(t, otherControllerDetachedParent, route.Status.Parents[1].ParentRef)
-	require.Equal(t, currentParent, route.Status.Parents[2].ParentRef)
+	require.Equal(t, currentParentStatus, route.Status.Parents[2].ParentRef)
 
 	input.SetAllParentCondition(metav1.Condition{
 		Type:   string(gatewayv1.RouteConditionAccepted),
@@ -82,13 +94,13 @@ func TestPruneRouteParentStatuses(t *testing.T) {
 	require.Len(t, route.Status.Parents, 3, "merge alone keeps both detached statuses")
 	require.Equal(t, ourDetachedParent, route.Status.Parents[0].ParentRef, "merge alone keeps both detached statuses")
 	require.Equal(t, otherControllerDetachedParent, route.Status.Parents[1].ParentRef, "merge alone keeps both detached statuses")
-	require.Equal(t, currentParent, route.Status.Parents[2].ParentRef, "merge alone keeps both detached statuses")
+	require.Equal(t, currentParentStatus, route.Status.Parents[2].ParentRef, "merge alone keeps both detached statuses")
 
 	route.Status.Parents = pruneRouteParentStatuses(route.Status.Parents, route.Spec.ParentRefs)
 
 	require.Len(t, route.Status.Parents, 2, "prune removes only the detached Cilium-owned status")
 	require.Equal(t, otherControllerDetachedParent, route.Status.Parents[0].ParentRef, "prune removes only the detached Cilium-owned status")
 	require.Equal(t, gatewayv1.GatewayController("example.com/other-gateway-controller"), route.Status.Parents[0].ControllerName, "prune removes only the detached Cilium-owned status")
-	require.Equal(t, currentParent, route.Status.Parents[1].ParentRef, "prune removes only the detached Cilium-owned status")
+	require.Equal(t, currentParentStatus, route.Status.Parents[1].ParentRef, "prune removes only the detached Cilium-owned status")
 	require.Equal(t, gatewayv1.GatewayController(helpers.CiliumDefaultControllerName), route.Status.Parents[1].ControllerName, "prune removes only the detached Cilium-owned status")
 }


### PR DESCRIPTION


<!-- Description of change -->

## Issue Trigger Scenario

  A Gateway API Route (HTTPRoute / TLSRoute / GRPCRoute) uses parentRefs with non-nil pointer fields such as namespace, sectionName, port, group, or kind. After APIServer read/write, spec.parentRefs and status.parents[].parentRef can have identical values but different pointer instances.

  Example:
```yaml
  apiVersion: gateway.networking.k8s.io/v1
  kind: HTTPRoute
  metadata:
    name: httproute-example
    namespace: my-app-namespace
  spec:
    parentRefs:
      - name: acme-lb
        namespace: prod
        sectionName: foo
  status:
    parents:
      - parentRef:
          name: acme-lb
          namespace: prod
          sectionName: foo
```

## Issue Failure Manifestation

  Active Cilium-owned RouteParentStatus entries can be misclassified as stale and pruned. They may then be recreated, causing existing conditions to be discarded or rewritten.

  Status merge can also fail to match an existing equivalent ParentRef, which can append duplicate parent status entries instead of updating conditions.

## Expected Behavior

  Active parent statuses are retained when their ParentRef is still present in spec.parentRefs. Condition updates merge into the existing matching parent status entry.

## Root Cause

  PR #46296 added route parent status pruning in status_route.go using slices.Contains over []gatewayv1.ParentReference. It also changed route status merge helpers to usedirect struct comparison with ==.

  gatewayv1.ParentReference contains pointer fields: Group, Kind, Namespace, SectionName, and Port. Go struct comparison compares pointer addresses, not dereferenced values. After APIServer serialization and deserialization, spec.parentRefs and status.parents[].parentRef can have equal field values but different pointer addresses.


## Fix Method
  Add a ParentReference value-comparison helper that compares Name directly and pointer fields by dereferenced value with nil handling.



Fixes: #issue-number

```release-note
<!-- Enter the release note text here or remove this release-note section from your PR description. Do NOT put an "empty" release note here -->
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
