### PR TITLE
loadbalancer: use `netip` types in `getIPFamilies`

### DIFF
--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -649,16 +649,6 @@ func IPToPrefix(ip net.IP) *net.IPNet {
 	return prefix
 }
 
-// IsIPv4 returns true if the given IP is an IPv4
-func IsIPv4(ip net.IP) bool {
-	return ip.To4() != nil
-}
-
-// IsIPv6 returns if netIP is IPv6.
-func IsIPv6(ip net.IP) bool {
-	return ip != nil && ip.To4() == nil
-}
-
 // ListContainsIP returns whether a list of IPs contains a given IP.
 func ListContainsIP(ipList []net.IP, ip net.IP) bool {
 	for _, e := range ipList {

--- a/pkg/ip/ip_test.go
+++ b/pkg/ip/ip_test.go
@@ -612,50 +612,6 @@ func TestKeepUniqueAddrs(t *testing.T) {
 	}
 }
 
-func TestIPVersion(t *testing.T) {
-	type args struct {
-		ip net.IP
-	}
-	tests := []struct {
-		name string
-		args args
-		v4   bool
-		v6   bool
-	}{
-		{
-			name: "test-1",
-			args: args{
-				ip: nil,
-			},
-			v4: false,
-			v6: false,
-		},
-		{
-			name: "test-2",
-			args: args{
-				ip: net.ParseIP("1.1.1.1"),
-			},
-			v4: true,
-			v6: false,
-		},
-		{
-			name: "test-3",
-			args: args{
-				ip: net.ParseIP("fd00::1"),
-			},
-			v4: false,
-			v6: true,
-		},
-	}
-	for _, tt := range tests {
-		got := IsIPv4(tt.args.ip)
-		require.Equalf(t, tt.v4, got, "v4 test Name: %s", tt.name)
-
-		got = IsIPv6(tt.args.ip)
-		require.Equalf(t, tt.v6, got, "v6 test Name: %s", tt.name)
-	}
-}
-
 func TestPrefixToIpsValidIPv4(t *testing.T) {
 	prefix := "192.168.1.0/30"
 	expectedIPs := []string{"192.168.1.0", "192.168.1.1", "192.168.1.2", "192.168.1.3"}

--- a/pkg/loadbalancer/reflectors/conversions.go
+++ b/pkg/loadbalancer/reflectors/conversions.go
@@ -381,7 +381,7 @@ func getIPFamilies(svc *slim_corev1.Service) []slim_corev1.IPFamily {
 			families = append(families, slim_corev1.IPv4Protocol)
 		}
 		if ipv6 {
-			families = append(families, slim_corev1.IPv4Protocol)
+			families = append(families, slim_corev1.IPv6Protocol)
 		}
 		return families
 	}

--- a/pkg/loadbalancer/reflectors/conversions.go
+++ b/pkg/loadbalancer/reflectors/conversions.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"iter"
 	"log/slog"
-	"net"
 	"net/netip"
 	"slices"
 	"strings"
@@ -18,7 +17,6 @@ import (
 	"github.com/cilium/cilium/pkg/annotation"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/container/cache"
-	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/k8s"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	k8sLabels "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
@@ -357,35 +355,43 @@ func convertService(cfg loadbalancer.Config, extCfg loadbalancer.ExternalConfig,
 }
 
 func getIPFamilies(svc *slim_corev1.Service) []slim_corev1.IPFamily {
-	if len(svc.Spec.IPFamilies) == 0 {
-		// No IP families specified, try to deduce them from the cluster IPs
-		if len(svc.Spec.ClusterIP) == 0 || svc.Spec.ClusterIP == slim_corev1.ClusterIPNone {
-			return nil
-		}
+	if len(svc.Spec.IPFamilies) > 0 {
+		return svc.Spec.IPFamilies
+	}
 
-		ipv4, ipv6 := false, false
-		if len(svc.Spec.ClusterIPs) > 0 {
-			for _, cip := range svc.Spec.ClusterIPs {
-				if ip.IsIPv6(net.ParseIP(cip)) {
+	// No IP families specified, try to deduce them from the cluster IPs
+	if len(svc.Spec.ClusterIP) == 0 || svc.Spec.ClusterIP == slim_corev1.ClusterIPNone {
+		return nil
+	}
+
+	ipv4, ipv6 := false, false
+	if len(svc.Spec.ClusterIPs) > 0 {
+		for _, cip := range svc.Spec.ClusterIPs {
+			if addr, err := netip.ParseAddr(cip); err == nil {
+				if addr.Is6() {
 					ipv6 = true
 				} else {
 					ipv4 = true
 				}
 			}
-		} else {
-			ipv6 = ip.IsIPv6(net.ParseIP(svc.Spec.ClusterIP))
-			ipv4 = !ipv6
 		}
-		families := make([]slim_corev1.IPFamily, 0, 2)
-		if ipv4 {
-			families = append(families, slim_corev1.IPv4Protocol)
+	} else {
+		if addr, err := netip.ParseAddr(svc.Spec.ClusterIP); err == nil {
+			if addr.Is6() {
+				ipv6 = true
+			} else {
+				ipv4 = true
+			}
 		}
-		if ipv6 {
-			families = append(families, slim_corev1.IPv6Protocol)
-		}
-		return families
 	}
-	return svc.Spec.IPFamilies
+	families := make([]slim_corev1.IPFamily, 0, 2)
+	if ipv4 {
+		families = append(families, slim_corev1.IPv4Protocol)
+	}
+	if ipv6 {
+		families = append(families, slim_corev1.IPv6Protocol)
+	}
+	return families
 }
 
 func convertEndpoints(rawlog *slog.Logger, cfg loadbalancer.ExternalConfig, svcName loadbalancer.ServiceName, bes iter.Seq2[cmtypes.AddrCluster, *k8s.Backend]) iter.Seq[loadbalancer.Backend] {


### PR DESCRIPTION
Switch use of `net.ParseIP` to `netip.Addr` which allows to remove the now unused `IsIPv{4,6}` helpers.

See commits for details.

For #24246