### PR TITLE
bpf: Reduce stack size for `tail_handle_snat_fwd_ipv6`

### DIFF
--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -452,12 +452,7 @@ bool egress_gw_snat_needed_hook_v6(union v6addr *saddr, union v6addr *daddr,
 	return egress_gw_snat_needed_v6(saddr, daddr, snat_addr, egress_ifindex);
 }
 
-struct {
-	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-	__uint(max_entries, 1);
-	__type(key, int);
-	__type(value, struct bpf_fib_lookup_padded);
-} fib_params_storage __section_maps_btf;
+DEFINE_AUX(struct bpf_fib_lookup_padded, fib_params_storage);
 
 static __always_inline
 int egress_gw_fib_lookup_and_redirect_v6(struct __ctx_buff *ctx,
@@ -466,9 +461,8 @@ int egress_gw_fib_lookup_and_redirect_v6(struct __ctx_buff *ctx,
 					 __u32 egress_ifindex, __u32 tbid,
 					 __s8 *ext_err)
 {
-	struct bpf_fib_lookup_padded *fib_params;
-	int ret, zero = 0;
-	int flags = 0;
+	struct bpf_fib_lookup_padded *fib_params = AUX(fib_params_storage);
+	int ret, flags = 0;
 
 	if (egress_ifindex && neigh_resolver_without_nh_available()) {
 		/* Can't use redirect_neigh() when
@@ -478,10 +472,6 @@ int egress_gw_fib_lookup_and_redirect_v6(struct __ctx_buff *ctx,
 		if (!tbid && !THIS_IS_L3_DEV)
 			return redirect_neigh(egress_ifindex, NULL, 0, 0);
 	}
-
-	fib_params = map_lookup_elem(&fib_params_storage, &zero);
-	if (!fib_params)
-		return DROP_INVALID;
 
 	if (tbid) {
 		fib_params->l.tbid = tbid;

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1345,13 +1345,15 @@ set_v6_rtuple(const struct ipv6_ct_tuple *otuple,
 	rtuple->dport = ostate->to_sport;
 }
 
+DEFINE_AUX(struct ipv6_ct_tuple, new_mapping_tuple);
+
 static __always_inline int snat_v6_new_mapping(const struct __ctx_buff *ctx,
 					       const struct ipv6_ct_tuple *otuple,
 					       struct ipv6_nat_entry *ostate,
 					       const struct ipv6_nat_target *target,
 					       bool needs_ct, __s8 *ext_err)
 {
-	struct ipv6_ct_tuple rtuple = {};
+	struct ipv6_ct_tuple *rtuple = AUX(new_mapping_tuple);
 	struct ipv6_nat_entry rstate;
 	__u32 *retries_hist;
 	__u32 retries;
@@ -1367,7 +1369,7 @@ static __always_inline int snat_v6_new_mapping(const struct __ctx_buff *ctx,
 	ostate->to_saddr = target->addr;
 	/* .to_sport is selected below */
 
-	set_v6_rtuple(otuple, ostate, &rtuple);
+	set_v6_rtuple(otuple, ostate, rtuple);
 	/* .dport is selected below */
 
 	port = __snat_try_keep_port(target->min_port,
@@ -1380,9 +1382,9 @@ static __always_inline int snat_v6_new_mapping(const struct __ctx_buff *ctx,
 
 #pragma unroll
 	for (retries = 0; retries < SNAT_COLLISION_RETRIES; retries++) {
-		rtuple.dport = bpf_htons(port);
+		rtuple->dport = bpf_htons(port);
 
-		if (__snat_create(&cilium_snat_v6_external, &rtuple, &rstate, true) == 0)
+		if (__snat_create(&cilium_snat_v6_external, rtuple, &rstate, true) == 0)
 			goto create_nat_entry;
 
 		port = __snat_clamp_port_range(target->min_port,
@@ -1403,12 +1405,12 @@ create_nat_entry:
 	if (retries_hist)
 		++*retries_hist;
 
-	ostate->to_sport = rtuple.dport;
+	ostate->to_sport = rtuple->dport;
 	ostate->common.created = rstate.common.created;
 
 	ret = __snat_create(&cilium_snat_v6_external, otuple, ostate, false);
 	if (ret < 0) {
-		map_delete_elem(&cilium_snat_v6_external, &rtuple); /* rollback */
+		map_delete_elem(&cilium_snat_v6_external, rtuple); /* rollback */
 		if (ext_err)
 			*ext_err = (__s8)ret;
 		ret = DROP_NAT_NO_MAPPING;

--- a/pkg/datapath/types/types_generated.go
+++ b/pkg/datapath/types/types_generated.go
@@ -866,48 +866,6 @@ type SkipLB6Key struct {
 	Pad2 uint16
 }
 
-// SNATV6Args is generated from the BPF C type snat_v6_args.
-type SNATV6Args struct {
-	_     structs.HostLayout
-	Tuple struct {
-		_     structs.HostLayout
-		DAddr struct {
-			_    structs.HostLayout
-			Addr [16]uint8
-		}
-		SAddr struct {
-			_    structs.HostLayout
-			Addr [16]uint8
-		}
-		DPort   uint16
-		SPort   uint16
-		Nexthdr uint8
-		Flags   uint8
-	}
-	_      [2]byte
-	Target struct {
-		_    structs.HostLayout
-		Addr struct {
-			_    structs.HostLayout
-			Addr [16]uint8
-		}
-		MinPort           uint16
-		MaxPort           uint16
-		FromLocalEndpoint bool
-		NeedsCT           bool
-		EgressGateway     bool
-		_                 [1]byte
-		IfIndex           uint32
-		Tbid              uint32
-	}
-	Trace struct {
-		_       structs.HostLayout
-		Reason  uint8
-		_       [3]byte
-		Monitor uint32
-	}
-}
-
 // SRv6PolicyKey4 is generated from the BPF C type srv6_policy_key4.
 type SRv6PolicyKey4 struct {
 	_   structs.HostLayout

--- a/tools/dpgen/types.go
+++ b/tools/dpgen/types.go
@@ -22,6 +22,7 @@ var typesOpts struct {
 }
 
 const typesGoFile = "types_generated.go"
+const auxSection = ".data.aux"
 
 func runTypes(cmd *cobra.Command, args []string) error {
 	// Enable deduplication on the builder to make all equivalent types included
@@ -56,6 +57,10 @@ func runTypes(cmd *cobra.Command, args []string) error {
 		}
 
 		for _, v := range sorted(cs.Variables) {
+			// We can skip aux variables as they are only used from the BPF side.
+			if v.SectionName == auxSection {
+				continue
+			}
 			if err := addVariableType(bb, added, v); err != nil {
 				return fmt.Errorf("adding type for variable %s: %w", v.Name, err)
 			}


### PR DESCRIPTION
First commit is a workaround needed for the second commit. Second commit does some cleanup of former stack variables. Last commit reduces the stack size of `tail_handle_snat_fwd_ipv6` as Tom is hitting the 90% limit on a WIP pull request.