### PR TITLE
v1.19: kvstore: Don't set fake pod CIDRs for remote nodes

### DIFF
--- a/pkg/clustermesh/store/store.go
+++ b/pkg/clustermesh/store/store.go
@@ -105,11 +105,6 @@ func (s *ClusterService) GetKeyName() string {
 	return path.Join(s.Cluster, s.Namespace, s.Name)
 }
 
-// DeepKeyCopy creates a deep copy of the LocalKey
-func (s *ClusterService) DeepKeyCopy() store.LocalKey {
-	return s.DeepCopy()
-}
-
 // Marshal returns the global service object as JSON byte slice
 func (s *ClusterService) Marshal() ([]byte, error) {
 	return json.Marshal(s)

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -116,7 +116,7 @@ type SharedStore struct {
 	// localKeys is a map of keys that are owned by the local instance. All
 	// local keys are synchronized with the kvstore. This map can be
 	// modified with UpdateLocalKey() and DeleteLocalKey().
-	localKeys map[string]LocalKey
+	localKeys map[string]Key
 
 	// sharedKeys is a map of all keys that either have been discovered
 	// from remote collaborators or successfully shared local keys. This
@@ -171,15 +171,7 @@ type Key interface {
 	Unmarshal(key string, data []byte) error
 }
 
-// LocalKey is a Key owned by the local store instance
-type LocalKey interface {
-	Key
-
-	// DeepKeyCopy must return a deep copy of the key
-	DeepKeyCopy() LocalKey
-}
-
-// KVPair represents a basic implementation of the LocalKey interface
+// KVPair represents a basic implementation of the Key interface
 type KVPair struct {
 	Key   string
 	Value []byte
@@ -209,7 +201,7 @@ func JoinSharedStore(logger *slog.Logger, c Configuration) (*SharedStore, error)
 	s := &SharedStore{
 		logger:     logger,
 		conf:       c,
-		localKeys:  map[string]LocalKey{},
+		localKeys:  map[string]Key{},
 		sharedKeys: map[string]Key{},
 		backend:    c.Backend,
 	}
@@ -289,7 +281,7 @@ func (s *SharedStore) keyPath(key NamedKey) string {
 }
 
 // syncLocalKey synchronizes a key to the kvstore
-func (s *SharedStore) syncLocalKey(ctx context.Context, key LocalKey, lease bool) error {
+func (s *SharedStore) syncLocalKey(ctx context.Context, key Key, lease bool) error {
 	jsonValue, err := key.Marshal()
 	if err != nil {
 		return err
@@ -321,7 +313,7 @@ func (s *SharedStore) syncLocalKeys(ctx context.Context, lease bool) error {
 	return nil
 }
 
-func (s *SharedStore) lookupLocalKey(name string) LocalKey {
+func (s *SharedStore) lookupLocalKey(name string) Key {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
@@ -334,42 +326,17 @@ func (s *SharedStore) lookupLocalKey(name string) LocalKey {
 	return nil
 }
 
-// NumEntries returns the number of entries in the store
-func (s *SharedStore) NumEntries() int {
-	if s == nil {
-		return 0
-	}
-
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
-	return len(s.sharedKeys)
-}
-
-// SharedKeysMap returns a copy of the SharedKeysMap, the returned map can
-// be safely modified but the values of the map represent the actual data
-// stored in the internal SharedStore SharedKeys map.
-func (s *SharedStore) SharedKeysMap() map[string]Key {
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
-	return maps.Clone(s.sharedKeys)
-}
-
 // UpdateLocalKeySync synchronously synchronizes a local key with the kvstore
 // and adds it to the list of local keys to be synchronized if the initial
 // synchronous synchronization was successful
-func (s *SharedStore) UpdateLocalKeySync(ctx context.Context, key LocalKey) error {
+func (s *SharedStore) UpdateLocalKeySync(ctx context.Context, key Key) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	err := s.syncLocalKey(ctx, key, true)
 	if err == nil {
-		s.localKeys[key.GetKeyName()] = key.DeepKeyCopy()
+		s.localKeys[key.GetKeyName()] = key
 	}
 	return err
-}
-
-// UpdateKeySync synchronously synchronizes a key with the kvstore.
-func (s *SharedStore) UpdateKeySync(ctx context.Context, key LocalKey, lease bool) error {
-	return s.syncLocalKey(ctx, key, lease)
 }
 
 // DeleteLocalKey removes a key from being synchronized with the kvstore

--- a/pkg/kvstore/store/store_test.go
+++ b/pkg/kvstore/store/store_test.go
@@ -32,7 +32,6 @@ type TestType struct {
 var _ = TestType{}
 
 func (t *TestType) GetKeyName() string                    { return t.Name }
-func (t *TestType) DeepKeyCopy() LocalKey                 { return &TestType{Name: t.Name} }
 func (t *TestType) Marshal() ([]byte, error)              { return json.Marshal(t) }
 func (t *TestType) Unmarshal(_ string, data []byte) error { return json.Unmarshal(data, t) }
 

--- a/pkg/node/store/store.go
+++ b/pkg/node/store/store.go
@@ -167,7 +167,7 @@ func (nr *NodeRegistrar) RegisterNode(ctx context.Context, logger *slog.Logger, 
 		return err
 	}
 
-	err = nodeStore.UpdateLocalKeySync(ctx, n)
+	err = nodeStore.UpdateLocalKeySync(ctx, n.DeepCopy())
 	if err != nil {
 		nodeStore.Release()
 		return err
@@ -183,5 +183,5 @@ func (nr *NodeRegistrar) RegisterNode(ctx context.Context, logger *slog.Logger, 
 // UpdateLocalKeySync synchronizes the local key for the node using the
 // SharedStore.
 func (nr *NodeRegistrar) UpdateLocalKeySync(ctx context.Context, n *nodeTypes.Node) error {
-	return nr.SharedStore.UpdateLocalKeySync(ctx, n)
+	return nr.SharedStore.UpdateLocalKeySync(ctx, n.DeepCopy())
 }

--- a/pkg/node/store/store.go
+++ b/pkg/node/store/store.go
@@ -10,9 +10,11 @@ import (
 	"path"
 
 	"github.com/cilium/cilium/pkg/defaults"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -167,7 +169,7 @@ func (nr *NodeRegistrar) RegisterNode(ctx context.Context, logger *slog.Logger, 
 		return err
 	}
 
-	err = nodeStore.UpdateLocalKeySync(ctx, n.DeepCopy())
+	err = nodeStore.UpdateLocalKeySync(ctx, copyForRemoteNodes(n))
 	if err != nil {
 		nodeStore.Release()
 		return err
@@ -183,5 +185,23 @@ func (nr *NodeRegistrar) RegisterNode(ctx context.Context, logger *slog.Logger, 
 // UpdateLocalKeySync synchronizes the local key for the node using the
 // SharedStore.
 func (nr *NodeRegistrar) UpdateLocalKeySync(ctx context.Context, n *nodeTypes.Node) error {
-	return nr.SharedStore.UpdateLocalKeySync(ctx, n.DeepCopy())
+	return nr.SharedStore.UpdateLocalKeySync(ctx, copyForRemoteNodes(n))
+}
+
+func copyForRemoteNodes(n *nodeTypes.Node) *nodeTypes.Node {
+	node := n.DeepCopy()
+	switch option.Config.IPAM {
+	case ipamOption.IPAMKubernetes, ipamOption.IPAMClusterPool, ipamOption.IPAMMultiPool:
+		// Keep the PodCIDRs as they are valid.
+	default:
+		// Strip the PodCIDRs on non-podCIDR based IPAM modes (e.g. ENI, Azure, AlibabaCloud). In
+		// those cases, the IPv4/IPv6AllocRange is auto-generated and otherwise unused, so it does
+		// not make sense to copy it to the kvstore.
+		// See NodeDiscovery.mutateNodeResource() for the equivalent CRD mode logic.
+		node.IPv4AllocCIDR = nil
+		node.IPv4SecondaryAllocCIDRs = nil
+		node.IPv6AllocCIDR = nil
+		node.IPv6SecondaryAllocCIDRs = nil
+	}
+	return node
 }

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/node/addressing"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
@@ -615,11 +614,6 @@ func GetKeyNodeName(cluster, node string) string {
 // GetKeyName returns the kvstore key to be used for the node
 func (n *Node) GetKeyName() string {
 	return GetKeyNodeName(n.Cluster, n.Name)
-}
-
-// DeepKeyCopy creates a deep copy of the LocalKey
-func (n *Node) DeepKeyCopy() store.LocalKey {
-	return n.DeepCopy()
 }
 
 // Marshal returns the node object as JSON byte slice

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -348,6 +348,7 @@ func (n *NodeDiscovery) mutateNodeResource(ctx context.Context, nodeResource *ci
 		// is no such thing as a podCIDR to begin with. In those cases, the
 		// IPv4/IPv6AllocRange is auto-generated and otherwise unused, so it does not
 		// make sense to copy it into the CiliumNode it either.
+		// See NodeRegistrar.RegisterNode() for the equivalent kvstore mode logic.
 		nodeResource.Spec.IPAM.PodCIDRs = []string{}
 		if cidr := ln.IPv4AllocCIDR; cidr != nil {
 			nodeResource.Spec.IPAM.PodCIDRs = append(nodeResource.Spec.IPAM.PodCIDRs, cidr.String())


### PR DESCRIPTION
Manual backport of https://github.com/cilium/cilium/pull/46299 to v1.19. @giorio94 I also backported one commit from https://github.com/cilium/cilium/pull/45845 to ease the backport of #46299. Please yell if I shouldn't have.