### PR TITLE
gateway-api: cleanup use of default gateway api gatewayclass controllername

### DIFF
--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -39,6 +39,10 @@ import (
 )
 
 // Cell manages the Gateway API related controllers.
+const (
+	defaultControllerName = "io.cilium/gateway-controller"
+)
+
 var Cell = cell.Module(
 	"gateway-api",
 	"Manages the Gateway API controllers",
@@ -285,7 +289,7 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 		params.CtrlRuntimeManager,
 		gatewayAPITranslator,
 		params.Logger,
-		helpers.CiliumDefaultControllerName,
+		defaultControllerName,
 		installedKinds,
 	); err != nil {
 		return fmt.Errorf("failed to create gateway controller: %w", err)
@@ -317,7 +321,7 @@ func registerSecretSync(params secretSyncParams) secretsync.SecretSyncRegistrati
 		return secretsync.SecretSyncRegistrationOut{}
 	}
 
-	handler := NewSecretSyncHandler(params.CtrlRuntimeManager.GetClient(), params.Logger, helpers.CiliumDefaultControllerName)
+	handler := NewSecretSyncHandler(params.CtrlRuntimeManager.GetClient(), params.Logger, defaultControllerName)
 
 	return secretsync.SecretSyncRegistrationOut{
 		SecretSyncRegistration: &secretsync.SecretSyncRegistration{

--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -316,17 +316,19 @@ func registerSecretSync(params secretSyncParams) secretsync.SecretSyncRegistrati
 		return secretsync.SecretSyncRegistrationOut{}
 	}
 
+	handler := NewSecretSyncHandler(params.CtrlRuntimeManager.GetClient(), params.Logger, helpers.CiliumDefaultControllerName)
+
 	return secretsync.SecretSyncRegistrationOut{
 		SecretSyncRegistration: &secretsync.SecretSyncRegistration{
 			RefObject:            &gatewayv1.Gateway{},
-			RefObjectEnqueueFunc: EnqueueTLSSecrets(params.CtrlRuntimeManager.GetClient(), params.Logger),
-			RefObjectCheckFunc:   IsReferencedByCiliumGateway,
+			RefObjectEnqueueFunc: handler.EnqueueTLSSecrets(),
+			RefObjectCheckFunc:   handler.IsReferencedByGateway,
 			SecretsNamespace:     params.GatewayApiConfig.GatewayAPISecretsNamespace,
 		},
 		ConfigMapSyncRegistration: &secretsync.ConfigMapSyncRegistration{
 			RefObject:            &gatewayv1.BackendTLSPolicy{},
-			RefObjectEnqueueFunc: EnqueueBackendTLSPolicyConfigMaps(params.CtrlRuntimeManager.GetClient(), params.Logger),
-			RefObjectCheckFunc:   ConfigMapIsReferencedInCiliumGateway,
+			RefObjectEnqueueFunc: handler.EnqueueBackendTLSPolicyConfigMaps(),
+			RefObjectCheckFunc:   handler.ConfigMapIsReferencedInGateway,
 			SecretsNamespace:     params.GatewayApiConfig.GatewayAPISecretsNamespace,
 		},
 	}

--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -285,6 +285,7 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 		params.CtrlRuntimeManager,
 		gatewayAPITranslator,
 		params.Logger,
+		helpers.CiliumDefaultControllerName,
 		installedKinds,
 	); err != nil {
 		return fmt.Errorf("failed to create gateway controller: %w", err)
@@ -425,13 +426,13 @@ func checkCRDs(ctx context.Context, clientset k8sClient.Clientset, logger *slog.
 
 // registerReconcilers registers Gateway API reconcilers to the controller-runtime library manager.
 // optionalKinds are previously autodetected based on what CRDs are present in the cluster.
-func registerReconcilers(mgr ctrlRuntime.Manager, translator translation.Translator, logger *slog.Logger, installedCRDs []schema.GroupVersionKind) error {
+func registerReconcilers(mgr ctrlRuntime.Manager, translator translation.Translator, logger *slog.Logger, controllerName string, installedCRDs []schema.GroupVersionKind) error {
 	requiredReconcilers := []interface {
 		SetupWithManager(mgr ctrlRuntime.Manager) error
 	}{
-		newGatewayClassReconciler(mgr, logger),
-		newGatewayReconciler(mgr, translator, logger, installedCRDs),
-		newGammaReconciler(mgr, translator, logger),
+		newGatewayClassReconciler(mgr, logger, controllerName),
+		newGatewayReconciler(mgr, translator, logger, controllerName, installedCRDs),
+		newGammaReconciler(mgr, translator, logger, controllerName),
 		newGatewayClassConfigReconciler(mgr, logger),
 	}
 

--- a/operator/pkg/gateway-api/gamma.go
+++ b/operator/pkg/gateway-api/gamma.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
 	watchhandlers "github.com/cilium/cilium/operator/pkg/gateway-api/watch-handlers"
 	"github.com/cilium/cilium/operator/pkg/model/translation"
@@ -26,7 +27,8 @@ type gammaReconciler struct {
 	Scheme     *runtime.Scheme
 	translator translation.Translator
 
-	logger *slog.Logger
+	logger         *slog.Logger
+	controllerName string
 }
 
 func newGammaReconciler(mgr ctrl.Manager, translator translation.Translator, logger *slog.Logger) *gammaReconciler {
@@ -37,6 +39,7 @@ func newGammaReconciler(mgr ctrl.Manager, translator translation.Translator, log
 		logger: logger.With(
 			logfields.Controller, gamma,
 		),
+		controllerName: helpers.CiliumDefaultControllerName,
 	}
 }
 

--- a/operator/pkg/gateway-api/gamma.go
+++ b/operator/pkg/gateway-api/gamma.go
@@ -13,7 +13,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
 	watchhandlers "github.com/cilium/cilium/operator/pkg/gateway-api/watch-handlers"
 	"github.com/cilium/cilium/operator/pkg/model/translation"
@@ -31,7 +30,7 @@ type gammaReconciler struct {
 	controllerName string
 }
 
-func newGammaReconciler(mgr ctrl.Manager, translator translation.Translator, logger *slog.Logger) *gammaReconciler {
+func newGammaReconciler(mgr ctrl.Manager, translator translation.Translator, logger *slog.Logger, controllerName string) *gammaReconciler {
 	return &gammaReconciler{
 		Client:     mgr.GetClient(),
 		Scheme:     mgr.GetScheme(),
@@ -39,7 +38,7 @@ func newGammaReconciler(mgr ctrl.Manager, translator translation.Translator, log
 		logger: logger.With(
 			logfields.Controller, gamma,
 		),
-		controllerName: helpers.CiliumDefaultControllerName,
+		controllerName: controllerName,
 	}
 }
 

--- a/operator/pkg/gateway-api/gamma_reconcile.go
+++ b/operator/pkg/gateway-api/gamma_reconcile.go
@@ -175,11 +175,12 @@ func (r *gammaReconciler) setHTTPRouteStatuses(gammaLogger *slog.Logger, ctx con
 		}
 		// input for the validators
 		i := &routechecks.HTTPRouteInput{
-			Ctx:       ctx,
-			Logger:    gammaLogger.With(httpRoute, hrName),
-			Client:    r.Client,
-			Grants:    grants,
-			HTTPRoute: hr,
+			Ctx:            ctx,
+			Logger:         gammaLogger.With(httpRoute, hrName),
+			Client:         r.Client,
+			Grants:         grants,
+			HTTPRoute:      hr,
+			ControllerName: r.controllerName,
 		}
 
 		// Route validators
@@ -278,11 +279,12 @@ func (r *gammaReconciler) setGRPCRouteStatuses(gammaLogger *slog.Logger, ctx con
 		}
 		// input for the validators
 		i := &routechecks.GRPCRouteInput{
-			Ctx:       ctx,
-			Logger:    gammaLogger.With(grpcRoute, grpcName),
-			Client:    r.Client,
-			Grants:    grants,
-			GRPCRoute: grpc,
+			Ctx:            ctx,
+			Logger:         gammaLogger.With(grpcRoute, grpcName),
+			Client:         r.Client,
+			Grants:         grants,
+			GRPCRoute:      grpc,
+			ControllerName: r.controllerName,
 		}
 
 		// Route validators

--- a/operator/pkg/gateway-api/gamma_reconcile.go
+++ b/operator/pkg/gateway-api/gamma_reconcile.go
@@ -167,7 +167,7 @@ func (r *gammaReconciler) setHTTPRouteStatuses(gammaLogger *slog.Logger, ctx con
 	for httpRouteIndex, original := range httpRoutes.Items {
 
 		hr := original.DeepCopy()
-		hr.Status.Parents = pruneRouteParentStatuses(hr.Status.Parents, hr.Spec.ParentRefs)
+		hr.Status.Parents = pruneRouteParentStatuses(hr.Status.Parents, hr.Spec.ParentRefs, r.controllerName)
 
 		hrName := types.NamespacedName{
 			Name:      hr.Name,
@@ -271,7 +271,7 @@ func (r *gammaReconciler) setGRPCRouteStatuses(gammaLogger *slog.Logger, ctx con
 	for grpcRouteIndex, original := range grpcRoutes.Items {
 
 		grpc := original.DeepCopy()
-		grpc.Status.Parents = pruneRouteParentStatuses(grpc.Status.Parents, grpc.Spec.ParentRefs)
+		grpc.Status.Parents = pruneRouteParentStatuses(grpc.Status.Parents, grpc.Spec.ParentRefs, r.controllerName)
 
 		grpcName := types.NamespacedName{
 			Name:      grpc.Name,

--- a/operator/pkg/gateway-api/gamma_reconcile_test.go
+++ b/operator/pkg/gateway-api/gamma_reconcile_test.go
@@ -107,9 +107,10 @@ func Test_gammaReconciler_Reconcile(t *testing.T) {
 						Build()
 
 					r := &gammaReconciler{
-						Client:     c,
-						translator: gatewayAPITranslator,
-						logger:     logger,
+						Client:         c,
+						translator:     gatewayAPITranslator,
+						logger:         logger,
+						controllerName: helpers.CiliumDefaultControllerName,
 					}
 
 					// Reconcile all related HTTPRoute objects

--- a/operator/pkg/gateway-api/gamma_reconcile_test.go
+++ b/operator/pkg/gateway-api/gamma_reconcile_test.go
@@ -110,7 +110,7 @@ func Test_gammaReconciler_Reconcile(t *testing.T) {
 						Client:         c,
 						translator:     gatewayAPITranslator,
 						logger:         logger,
-						controllerName: helpers.CiliumDefaultControllerName,
+						controllerName: defaultControllerName,
 					}
 
 					// Reconcile all related HTTPRoute objects

--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -46,7 +46,7 @@ type gatewayReconciler struct {
 	controllerName string
 }
 
-func newGatewayReconciler(mgr ctrl.Manager, translator translation.Translator, logger *slog.Logger, installedCRDs []schema.GroupVersionKind) *gatewayReconciler {
+func newGatewayReconciler(mgr ctrl.Manager, translator translation.Translator, logger *slog.Logger, controllerName string, installedCRDs []schema.GroupVersionKind) *gatewayReconciler {
 	scopedLog := logger.With(logfields.Controller, gateway)
 
 	return &gatewayReconciler{
@@ -55,7 +55,7 @@ func newGatewayReconciler(mgr ctrl.Manager, translator translation.Translator, l
 		translator:     translator,
 		logger:         scopedLog,
 		installedCRDs:  installedCRDs,
-		controllerName: helpers.CiliumDefaultControllerName,
+		controllerName: controllerName,
 	}
 }
 

--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -41,19 +41,21 @@ type gatewayReconciler struct {
 	Scheme     *runtime.Scheme
 	translator translation.Translator
 
-	logger        *slog.Logger
-	installedCRDs []schema.GroupVersionKind
+	logger         *slog.Logger
+	installedCRDs  []schema.GroupVersionKind
+	controllerName string
 }
 
 func newGatewayReconciler(mgr ctrl.Manager, translator translation.Translator, logger *slog.Logger, installedCRDs []schema.GroupVersionKind) *gatewayReconciler {
 	scopedLog := logger.With(logfields.Controller, gateway)
 
 	return &gatewayReconciler{
-		Client:        mgr.GetClient(),
-		Scheme:        mgr.GetScheme(),
-		translator:    translator,
-		logger:        scopedLog,
-		installedCRDs: installedCRDs,
+		Client:         mgr.GetClient(),
+		Scheme:         mgr.GetScheme(),
+		translator:     translator,
+		logger:         scopedLog,
+		installedCRDs:  installedCRDs,
+		controllerName: helpers.CiliumDefaultControllerName,
 	}
 }
 
@@ -88,7 +90,7 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	// Index Gateways by implementation (ie `cilium`)
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.Gateway{}, indexers.ImplementationGatewayIndex, indexers.GenerateIndexerGatewayByImplementation(r.Client, helpers.CiliumDefaultControllerName)); err != nil {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.Gateway{}, indexers.ImplementationGatewayIndex, indexers.GenerateIndexerGatewayByImplementation(r.Client, gatewayv1.GatewayController(r.controllerName))); err != nil {
 		return fmt.Errorf("failed to setup field indexer %q: %w", indexers.ImplementationGatewayIndex, err)
 	}
 
@@ -117,7 +119,7 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return fmt.Errorf("failed to setup field indexer %q: %w", indexers.BackendTLSPolicyConfigMapIndex, err)
 	}
 
-	hasMatchingControllerFn := helpers.GatewayHasMatchingControllerFn(context.Background(), r.Client, helpers.CiliumDefaultControllerName, r.logger)
+	hasMatchingControllerFn := helpers.GatewayHasMatchingControllerFn(context.Background(), r.Client, r.controllerName, r.logger)
 	gatewayBuilder := ctrl.NewControllerManagedBy(mgr).
 		// Watch its own resource
 		For(&gatewayv1.Gateway{},
@@ -125,16 +127,16 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Watch GatewayClass resources, which are linked to Gateway
 		Watches(&gatewayv1.GatewayClass{},
 			watchhandlers.EnqueueRequestForOwningGatewayClass(r.Client, *r.logger),
-			builder.WithPredicates(predicates.GatewayClassOwnedByController(helpers.CiliumDefaultControllerName))).
+			builder.WithPredicates(predicates.GatewayClassOwnedByController(r.controllerName))).
 		// Watch related backend Service for status
 		// LB Services are handled by the Owns call later.
 		Watches(&corev1.Service{}, watchhandlers.EnqueueRequestForBackendService(r.Client, *r.logger)).
 		// Watch HTTPRoute linked to Gateway
-		Watches(&gatewayv1.HTTPRoute{}, watchhandlers.EnqueueRequestForOwningHTTPRoute(r.Client, r.logger, helpers.CiliumDefaultControllerName)).
+		Watches(&gatewayv1.HTTPRoute{}, watchhandlers.EnqueueRequestForOwningHTTPRoute(r.Client, r.logger, r.controllerName)).
 		// Watch GRPCRoute linked to Gateway
-		Watches(&gatewayv1.GRPCRoute{}, watchhandlers.EnqueueRequestForOwningGRPCRoute(r.Client, r.logger, helpers.CiliumDefaultControllerName)).
+		Watches(&gatewayv1.GRPCRoute{}, watchhandlers.EnqueueRequestForOwningGRPCRoute(r.Client, r.logger, r.controllerName)).
 		// Watch TLSRoute linked to Gateway
-		Watches(&gatewayv1.TLSRoute{}, watchhandlers.EnqueueRequestForOwningTLSRoute(r.Client, r.logger, helpers.CiliumDefaultControllerName)).
+		Watches(&gatewayv1.TLSRoute{}, watchhandlers.EnqueueRequestForOwningTLSRoute(r.Client, r.logger, r.controllerName)).
 		// Watch related secrets used to configure TLS
 		Watches(&corev1.Secret{},
 			watchhandlers.EnqueueRequestForTLSSecret(r.Client, r.logger),

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -90,7 +90,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return controllerruntime.Success()
 	}
 
-	if string(gwc.Spec.ControllerName) != helpers.CiliumDefaultControllerName {
+	if string(gwc.Spec.ControllerName) != r.controllerName {
 		scopedLog.InfoContext(ctx, "GatewayClass does not have matching controller name, cleaning up previously managed resources",
 			gatewayClass, gw.Spec.GatewayClassName,
 			logfields.Controller, gwc.Spec.ControllerName)
@@ -908,7 +908,7 @@ func (r *gatewayReconciler) setHTTPRouteStatuses(scopedLog *slog.Logger, ctx con
 	for httpRouteIndex, original := range httpRoutes.Items {
 
 		hr := original.DeepCopy()
-		hr.Status.Parents = pruneRouteParentStatuses(hr.Status.Parents, hr.Spec.ParentRefs)
+		hr.Status.Parents = pruneRouteParentStatuses(hr.Status.Parents, hr.Spec.ParentRefs, r.controllerName)
 
 		// input for the validators
 		// The validators will mutate the HTTPRoute as required, setting its status correctly.
@@ -949,7 +949,7 @@ func (r *gatewayReconciler) setTLSRouteStatuses(scopedLog *slog.Logger, ctx cont
 	for tlsRouteIndex, original := range tlsRoutes.Items {
 
 		tlsr := original.DeepCopy()
-		tlsr.Status.Parents = pruneRouteParentStatuses(tlsr.Status.Parents, tlsr.Spec.ParentRefs)
+		tlsr.Status.Parents = pruneRouteParentStatuses(tlsr.Status.Parents, tlsr.Spec.ParentRefs, r.controllerName)
 
 		// input for the validators
 		// The validators will mutate the TLSRoute as required, setting its status correctly.
@@ -985,7 +985,7 @@ func (r *gatewayReconciler) setGRPCRouteStatuses(scopedLog *slog.Logger, ctx con
 	for grpcRouteIndex, original := range grpcRoutes.Items {
 
 		grpcr := original.DeepCopy()
-		grpcr.Status.Parents = pruneRouteParentStatuses(grpcr.Status.Parents, grpcr.Spec.ParentRefs)
+		grpcr.Status.Parents = pruneRouteParentStatuses(grpcr.Status.Parents, grpcr.Spec.ParentRefs, r.controllerName)
 
 		// input for the validators
 		// The validators will mutate the GRPCRoute as required, setting its status correctly.

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -889,7 +889,7 @@ func (r *gatewayReconciler) runCommonRouteChecks(input routechecks.Input, parent
 }
 
 func (r *gatewayReconciler) parentIsMatchingGateway(parent gatewayv1.ParentReference, namespace string) bool {
-	hasMatchingControllerFn := helpers.GatewayHasMatchingControllerFn(context.Background(), r.Client, helpers.CiliumDefaultControllerName, r.logger)
+	hasMatchingControllerFn := helpers.GatewayHasMatchingControllerFn(context.Background(), r.Client, r.controllerName, r.logger)
 	if !helpers.IsGateway(parent) {
 		return false
 	}
@@ -913,11 +913,12 @@ func (r *gatewayReconciler) setHTTPRouteStatuses(scopedLog *slog.Logger, ctx con
 		// input for the validators
 		// The validators will mutate the HTTPRoute as required, setting its status correctly.
 		i := &routechecks.HTTPRouteInput{
-			Ctx:       ctx,
-			Logger:    scopedLog.With(logfields.HTTPRoute, hr),
-			Client:    r.Client,
-			Grants:    grants,
-			HTTPRoute: hr,
+			Ctx:            ctx,
+			Logger:         scopedLog.With(logfields.HTTPRoute, hr),
+			Client:         r.Client,
+			Grants:         grants,
+			HTTPRoute:      hr,
+			ControllerName: r.controllerName,
 		}
 
 		if err := r.runCommonRouteChecks(i, hr.Spec.ParentRefs, hr.Namespace); err != nil {
@@ -953,11 +954,12 @@ func (r *gatewayReconciler) setTLSRouteStatuses(scopedLog *slog.Logger, ctx cont
 		// input for the validators
 		// The validators will mutate the TLSRoute as required, setting its status correctly.
 		i := &routechecks.TLSRouteInput{
-			Ctx:      ctx,
-			Logger:   scopedLog.With(logfields.TLSRoute, tlsr),
-			Client:   r.Client,
-			Grants:   grants,
-			TLSRoute: tlsr,
+			Ctx:            ctx,
+			Logger:         scopedLog.With(logfields.TLSRoute, tlsr),
+			Client:         r.Client,
+			Grants:         grants,
+			TLSRoute:       tlsr,
+			ControllerName: r.controllerName,
 		}
 
 		if err := r.runCommonRouteChecks(i, tlsr.Spec.ParentRefs, tlsr.Namespace); err != nil {
@@ -988,11 +990,12 @@ func (r *gatewayReconciler) setGRPCRouteStatuses(scopedLog *slog.Logger, ctx con
 		// input for the validators
 		// The validators will mutate the GRPCRoute as required, setting its status correctly.
 		i := &routechecks.GRPCRouteInput{
-			Ctx:       ctx,
-			Logger:    scopedLog.With(logfields.GRPCRoute, grpcr),
-			Client:    r.Client,
-			Grants:    grants,
-			GRPCRoute: grpcr,
+			Ctx:            ctx,
+			Logger:         scopedLog.With(logfields.GRPCRoute, grpcr),
+			Client:         r.Client,
+			Grants:         grants,
+			GRPCRoute:      grpcr,
+			ControllerName: r.controllerName,
 		}
 
 		if err := r.runCommonRouteChecks(i, grpcr.Spec.ParentRefs, grpcr.Namespace); err != nil {
@@ -1126,6 +1129,7 @@ func (r *gatewayReconciler) setBackendTLSPolicyStatuses(scopedLog *slog.Logger,
 				input := &policychecks.BackendTLSPolicyInput{
 					Client:           r.Client,
 					BackendTLSPolicy: btlsp,
+					ControllerName:   r.controllerName,
 				}
 				input.SetAncestorCondition(currentGatewayRef, metav1.Condition{
 					Type:    string(gatewayv1.PolicyConditionAccepted),
@@ -1165,6 +1169,7 @@ func (r *gatewayReconciler) setBackendTLSPolicyStatuses(scopedLog *slog.Logger,
 				input := &policychecks.BackendTLSPolicyInput{
 					Client:           r.Client,
 					BackendTLSPolicy: btlsp,
+					ControllerName:   r.controllerName,
 				}
 				input.SetAncestorCondition(currentGatewayRef, metav1.Condition{
 					Type:    string(gatewayv1.PolicyConditionAccepted),
@@ -1202,6 +1207,7 @@ func (r *gatewayReconciler) setBackendTLSPolicyStatuses(scopedLog *slog.Logger,
 			input := &policychecks.BackendTLSPolicyInput{
 				Client:           r.Client,
 				BackendTLSPolicy: btlsp,
+				ControllerName:   r.controllerName,
 			}
 
 			// Now, we run the Policy checks against it, which will update the status correctly.
@@ -1260,6 +1266,7 @@ func (r *gatewayReconciler) setBackendTLSPolicyStatuses(scopedLog *slog.Logger,
 			input := &policychecks.BackendTLSPolicyInput{
 				Client:           r.Client,
 				BackendTLSPolicy: btlsp,
+				ControllerName:   r.controllerName,
 			}
 
 			input.SetAncestorCondition(currentGatewayRef, metav1.Condition{

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -329,9 +329,10 @@ func Test_Conformance(t *testing.T) {
 			c := clientBuilder.Build()
 
 			r := &gatewayReconciler{
-				Client:     c,
-				translator: gatewayAPITranslator,
-				logger:     logger,
+				Client:         c,
+				translator:     gatewayAPITranslator,
+				logger:         logger,
+				controllerName: helpers.CiliumDefaultControllerName,
 			}
 
 			// Reconcile all related HTTPRoute objects
@@ -575,8 +576,9 @@ func Test_gatewayReconciler_Reconcile_cleansUpResourcesOnHandoff(t *testing.T) {
 				Build()
 
 			r := &gatewayReconciler{
-				Client: c,
-				logger: hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug)),
+				Client:         c,
+				logger:         hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug)),
+				controllerName: helpers.CiliumDefaultControllerName,
 			}
 
 			result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(gw)})

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -332,7 +332,7 @@ func Test_Conformance(t *testing.T) {
 				Client:         c,
 				translator:     gatewayAPITranslator,
 				logger:         logger,
-				controllerName: helpers.CiliumDefaultControllerName,
+				controllerName: defaultControllerName,
 			}
 
 			// Reconcile all related HTTPRoute objects
@@ -578,7 +578,7 @@ func Test_gatewayReconciler_Reconcile_cleansUpResourcesOnHandoff(t *testing.T) {
 			r := &gatewayReconciler{
 				Client:         c,
 				logger:         hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug)),
-				controllerName: helpers.CiliumDefaultControllerName,
+				controllerName: defaultControllerName,
 			}
 
 			result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(gw)})

--- a/operator/pkg/gateway-api/gatewayclass.go
+++ b/operator/pkg/gateway-api/gatewayclass.go
@@ -27,21 +27,23 @@ type gatewayClassReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 
-	logger *slog.Logger
+	logger         *slog.Logger
+	controllerName string
 }
 
 func newGatewayClassReconciler(mgr ctrl.Manager, logger *slog.Logger) *gatewayClassReconciler {
 	return &gatewayClassReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		logger: logger,
+		Client:         mgr.GetClient(),
+		Scheme:         mgr.GetScheme(),
+		logger:         logger,
+		controllerName: helpers.CiliumDefaultControllerName,
 	}
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *gatewayClassReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	for indexName, indexerFunc := range map[string]client.IndexerFunc{
-		indexers.GatewayClassCiliumGatewayClassConfigsIndex: referencedConfig,
+		indexers.GatewayClassCiliumGatewayClassConfigsIndex: r.referencedConfig,
 	} {
 		if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.GatewayClass{}, indexName, indexerFunc); err != nil {
 			return fmt.Errorf("failed to setup field indexer %q: %w", indexName, err)
@@ -50,7 +52,7 @@ func (r *gatewayClassReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&gatewayv1.GatewayClass{},
-			builder.WithPredicates(predicates.GatewayClassOwnedByController(helpers.CiliumDefaultControllerName))).
+			builder.WithPredicates(predicates.GatewayClassOwnedByController(r.controllerName))).
 		Watches(&v2alpha1.CiliumGatewayClassConfig{}, watchhandlers.EnqueueRequestForCiliumGatewayClassConfig(r.Client, r.logger)).
 		Complete(r)
 }
@@ -66,13 +68,13 @@ func matchesControllerName(controllerName string) func(object client.Object) boo
 }
 
 // referencedConfig returns a list of CiliumGatewayClassConfig names referenced by the GatewayClass.
-func referencedConfig(rawObj client.Object) []string {
+func (r *gatewayClassReconciler) referencedConfig(rawObj client.Object) []string {
 	gwc, ok := rawObj.(*gatewayv1.GatewayClass)
 	if !ok {
 		return nil
 	}
 
-	if string(gwc.Spec.ControllerName) != helpers.CiliumDefaultControllerName {
+	if string(gwc.Spec.ControllerName) != r.controllerName {
 		return nil
 	}
 

--- a/operator/pkg/gateway-api/gatewayclass.go
+++ b/operator/pkg/gateway-api/gatewayclass.go
@@ -15,7 +15,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/predicates"
 	watchhandlers "github.com/cilium/cilium/operator/pkg/gateway-api/watch-handlers"
@@ -31,12 +30,12 @@ type gatewayClassReconciler struct {
 	controllerName string
 }
 
-func newGatewayClassReconciler(mgr ctrl.Manager, logger *slog.Logger) *gatewayClassReconciler {
+func newGatewayClassReconciler(mgr ctrl.Manager, logger *slog.Logger, controllerName string) *gatewayClassReconciler {
 	return &gatewayClassReconciler{
 		Client:         mgr.GetClient(),
 		Scheme:         mgr.GetScheme(),
 		logger:         logger,
-		controllerName: helpers.CiliumDefaultControllerName,
+		controllerName: controllerName,
 	}
 }
 

--- a/operator/pkg/gateway-api/gatewayclass_test.go
+++ b/operator/pkg/gateway-api/gatewayclass_test.go
@@ -118,7 +118,8 @@ func Test_referencedConfig(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expected, referencedConfig(tc.object))
+			r := &gatewayClassReconciler{controllerName: helpers.CiliumDefaultControllerName}
+			require.Equal(t, tc.expected, r.referencedConfig(tc.object))
 		})
 	}
 }

--- a/operator/pkg/gateway-api/gatewayclass_test.go
+++ b/operator/pkg/gateway-api/gatewayclass_test.go
@@ -12,7 +12,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 )
@@ -65,7 +64,7 @@ func Test_referencedConfig(t *testing.T) {
 			name: "cilium GatewayClass with supported parametersRef",
 			object: &gatewayv1.GatewayClass{
 				Spec: gatewayv1.GatewayClassSpec{
-					ControllerName: helpers.CiliumDefaultControllerName,
+					ControllerName: defaultControllerName,
 					ParametersRef: &gatewayv1.ParametersReference{
 						Group:     v2alpha1.CustomResourceDefinitionGroup,
 						Kind:      v2alpha1.CGCCKindDefinition,
@@ -98,7 +97,7 @@ func Test_referencedConfig(t *testing.T) {
 			name: "cilium GatewayClass with unsupported parametersRef",
 			object: &gatewayv1.GatewayClass{
 				Spec: gatewayv1.GatewayClassSpec{
-					ControllerName: helpers.CiliumDefaultControllerName,
+					ControllerName: defaultControllerName,
 					ParametersRef: &gatewayv1.ParametersReference{
 						Group:     "v1",
 						Kind:      "ConfigMap",
@@ -118,7 +117,7 @@ func Test_referencedConfig(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			r := &gatewayClassReconciler{controllerName: helpers.CiliumDefaultControllerName}
+			r := &gatewayClassReconciler{controllerName: defaultControllerName}
 			require.Equal(t, tc.expected, r.referencedConfig(tc.object))
 		})
 	}

--- a/operator/pkg/gateway-api/helpers/consts.go
+++ b/operator/pkg/gateway-api/helpers/consts.go
@@ -1,9 +1,0 @@
-// SPDX-License-Identifier: Apache-2.0
-// Copyright Authors of Cilium
-
-package helpers
-
-const (
-	// CiliumDefaultControllerName is the gateway controller name used in cilium.
-	CiliumDefaultControllerName = "io.cilium/gateway-controller"
-)

--- a/operator/pkg/gateway-api/policychecks/backendtlspolicy.go
+++ b/operator/pkg/gateway-api/policychecks/backendtlspolicy.go
@@ -21,14 +21,10 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
-const (
-	// controllerName is the gateway controller name used in cilium.
-	controllerName = "io.cilium/gateway-controller"
-)
-
 type BackendTLSPolicyInput struct {
 	Client           client.Client
 	BackendTLSPolicy *gatewayv1.BackendTLSPolicy
+	ControllerName   string
 }
 
 func (b *BackendTLSPolicyInput) SetAncestorCondition(parentRef gatewayv1.ParentReference, condition metav1.Condition) {
@@ -51,7 +47,7 @@ func (b *BackendTLSPolicyInput) SetAncestorCondition(parentRef gatewayv1.ParentR
 
 	b.BackendTLSPolicy.Status.Ancestors = append(b.BackendTLSPolicy.Status.Ancestors, gatewayv1.PolicyAncestorStatus{
 		AncestorRef:    parentRef,
-		ControllerName: gatewayv1.GatewayController(controllerName),
+		ControllerName: gatewayv1.GatewayController(b.ControllerName),
 		Conditions: []metav1.Condition{
 			condition,
 		},

--- a/operator/pkg/gateway-api/policychecks/backendtlspolicy_test.go
+++ b/operator/pkg/gateway-api/policychecks/backendtlspolicy_test.go
@@ -425,6 +425,7 @@ func TestBackendTLSPolicyInput_ValidateSpec(t *testing.T) {
 			b := BackendTLSPolicyInput{
 				Client:           c,
 				BackendTLSPolicy: tt.btlsp,
+				ControllerName:   string(controllerName),
 			}
 			gotvalid, gotErr := b.ValidateSpec(context.Background(), logger, echoaAncestorRef)
 			statusDiff := cmp.Diff(tt.wantStatus, b.BackendTLSPolicy.Status, cmpIgnoreFields...)

--- a/operator/pkg/gateway-api/predicates/gateway_test.go
+++ b/operator/pkg/gateway-api/predicates/gateway_test.go
@@ -16,10 +16,12 @@ import (
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers/testhelpers"
 )
 
+const testGatewayControllerName = "io.cilium/gateway-controller"
+
 func Test_gatewayReconcilePredicate(t *testing.T) {
 	logger := hivetest.Logger(t)
 	c := fake.NewClientBuilder().WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).WithObjects(testhelpers.ControllerTestFixture...).Build()
-	predicate := GatewayOwnedByController(helpers.GatewayHasMatchingControllerFn(t.Context(), c, helpers.CiliumDefaultControllerName, logger))
+	predicate := GatewayOwnedByController(helpers.GatewayHasMatchingControllerFn(t.Context(), c, testGatewayControllerName, logger))
 
 	t.Run("update keeps handoff reconcile when old gateway matched", func(t *testing.T) {
 		require.True(t, predicate.Update(event.UpdateEvent{

--- a/operator/pkg/gateway-api/predicates/gatewayclass_test.go
+++ b/operator/pkg/gateway-api/predicates/gatewayclass_test.go
@@ -9,17 +9,17 @@ import (
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-
-	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 )
 
+const testGatewayClassControllerName = "example.com/test-gateway-controller"
+
 func Test_gatewayClassReconcilePredicate(t *testing.T) {
-	predicate := GatewayClassOwnedByController(helpers.CiliumDefaultControllerName)
+	predicate := GatewayClassOwnedByController(testGatewayClassControllerName)
 
 	t.Run("update keeps handoff reconcile when old gatewayclass matched", func(t *testing.T) {
 		require.True(t, predicate.Update(event.UpdateEvent{
 			ObjectOld: &gatewayv1.GatewayClass{
-				Spec: gatewayv1.GatewayClassSpec{ControllerName: helpers.CiliumDefaultControllerName},
+				Spec: gatewayv1.GatewayClassSpec{ControllerName: testGatewayClassControllerName},
 			},
 			ObjectNew: &gatewayv1.GatewayClass{
 				Spec: gatewayv1.GatewayClassSpec{ControllerName: "example.com/other-controller"},

--- a/operator/pkg/gateway-api/routechecks/grpcroute.go
+++ b/operator/pkg/gateway-api/routechecks/grpcroute.go
@@ -25,11 +25,12 @@ var _ Input = (*GRPCRouteInput)(nil)
 
 // GRPCRouteInput is used to implement the Input interface for GRPCRoute
 type GRPCRouteInput struct {
-	Ctx       context.Context
-	Logger    *slog.Logger
-	Client    client.Client
-	Grants    *gatewayv1.ReferenceGrantList
-	GRPCRoute *gatewayv1.GRPCRoute
+	Ctx            context.Context
+	Logger         *slog.Logger
+	Client         client.Client
+	Grants         *gatewayv1.ReferenceGrantList
+	GRPCRoute      *gatewayv1.GRPCRoute
+	ControllerName string
 
 	gateways      map[gatewayv1.ParentReference]*gatewayv1.Gateway
 	gammaServices map[gatewayv1.ParentReference]*corev1.Service
@@ -188,7 +189,7 @@ func (g *GRPCRouteInput) mergeStatusConditions(parentRef gatewayv1.ParentReferen
 	}
 	g.GRPCRoute.Status.RouteStatus.Parents = append(g.GRPCRoute.Status.RouteStatus.Parents, gatewayv1.RouteParentStatus{
 		ParentRef:      parentRef,
-		ControllerName: controllerName,
+		ControllerName: gatewayv1.GatewayController(g.ControllerName),
 		Conditions:     updates,
 	})
 }

--- a/operator/pkg/gateway-api/routechecks/httproute.go
+++ b/operator/pkg/gateway-api/routechecks/httproute.go
@@ -22,11 +22,12 @@ import (
 
 // HTTPRouteInput is used to implement the Input interface for HTTPRoute
 type HTTPRouteInput struct {
-	Ctx       context.Context
-	Logger    *slog.Logger
-	Client    client.Client
-	Grants    *gatewayv1.ReferenceGrantList
-	HTTPRoute *gatewayv1.HTTPRoute
+	Ctx            context.Context
+	Logger         *slog.Logger
+	Client         client.Client
+	Grants         *gatewayv1.ReferenceGrantList
+	HTTPRoute      *gatewayv1.HTTPRoute
+	ControllerName string
 
 	gateways      map[gatewayv1.ParentReference]*gatewayv1.Gateway
 	gammaServices map[gatewayv1.ParentReference]*corev1.Service
@@ -68,7 +69,7 @@ func (h *HTTPRouteInput) mergeStatusConditions(parentRef gatewayv1.ParentReferen
 	}
 	h.HTTPRoute.Status.RouteStatus.Parents = append(h.HTTPRoute.Status.RouteStatus.Parents, gatewayv1.RouteParentStatus{
 		ParentRef:      parentRef,
-		ControllerName: controllerName,
+		ControllerName: gatewayv1.GatewayController(h.ControllerName),
 		Conditions:     updates,
 	})
 }

--- a/operator/pkg/gateway-api/routechecks/input.go
+++ b/operator/pkg/gateway-api/routechecks/input.go
@@ -14,11 +14,6 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-const (
-	// controllerName is the gateway controller name used in cilium.
-	controllerName = "io.cilium/gateway-controller"
-)
-
 type GenericRule interface {
 	GetBackendRefs() []gatewayv1.BackendRef
 }

--- a/operator/pkg/gateway-api/routechecks/tlsroute.go
+++ b/operator/pkg/gateway-api/routechecks/tlsroute.go
@@ -22,11 +22,12 @@ import (
 
 // TLSRouteInput is used to implement the Input interface for TLSRoute
 type TLSRouteInput struct {
-	Ctx      context.Context
-	Logger   *slog.Logger
-	Client   client.Client
-	Grants   *gatewayv1.ReferenceGrantList
-	TLSRoute *gatewayv1.TLSRoute
+	Ctx            context.Context
+	Logger         *slog.Logger
+	Client         client.Client
+	Grants         *gatewayv1.ReferenceGrantList
+	TLSRoute       *gatewayv1.TLSRoute
+	ControllerName string
 
 	gateways map[gatewayv1.ParentReference]*gatewayv1.Gateway
 }
@@ -67,7 +68,7 @@ func (t *TLSRouteInput) mergeStatusConditions(parentRef gatewayv1.ParentReferenc
 	}
 	t.TLSRoute.Status.RouteStatus.Parents = append(t.TLSRoute.Status.RouteStatus.Parents, gatewayv1.RouteParentStatus{
 		ParentRef:      parentRef,
-		ControllerName: controllerName,
+		ControllerName: gatewayv1.GatewayController(t.ControllerName),
 		Conditions:     updates,
 	})
 }

--- a/operator/pkg/gateway-api/secretsync.go
+++ b/operator/pkg/gateway-api/secretsync.go
@@ -20,9 +20,23 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
-func EnqueueTLSSecrets(c client.Client, logger *slog.Logger) handler.EventHandler {
+type SecretSyncHandler struct {
+	client         client.Client
+	logger         *slog.Logger
+	controllerName string
+}
+
+func NewSecretSyncHandler(c client.Client, logger *slog.Logger, controllerName string) *SecretSyncHandler {
+	return &SecretSyncHandler{
+		client:         c,
+		logger:         logger,
+		controllerName: controllerName,
+	}
+}
+
+func (h *SecretSyncHandler) EnqueueTLSSecrets() handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
-		scopedLog := logger.With(
+		scopedLog := h.logger.With(
 			logfields.Resource, obj.GetName(),
 		)
 
@@ -32,7 +46,7 @@ func EnqueueTLSSecrets(c client.Client, logger *slog.Logger) handler.EventHandle
 		}
 
 		// Check whether Gateway is managed by Cilium
-		if !helpers.GatewayHasMatchingControllerFn(ctx, c, helpers.CiliumDefaultControllerName, logger)(gw) {
+		if !helpers.GatewayHasMatchingControllerFn(ctx, h.client, h.controllerName, h.logger)(gw) {
 			return nil
 		}
 
@@ -57,10 +71,10 @@ func EnqueueTLSSecrets(c client.Client, logger *slog.Logger) handler.EventHandle
 	})
 }
 
-func IsReferencedByCiliumGateway(ctx context.Context, c client.Client, logger *slog.Logger, obj *corev1.Secret) bool {
-	gateways := helpers.GetGatewaysForSecret(ctx, c, obj, logger)
+func (h *SecretSyncHandler) IsReferencedByGateway(ctx context.Context, _ client.Client, _ *slog.Logger, obj *corev1.Secret) bool {
+	gateways := helpers.GetGatewaysForSecret(ctx, h.client, obj, h.logger)
 	for _, gw := range gateways {
-		if helpers.GatewayHasMatchingControllerFn(ctx, c, helpers.CiliumDefaultControllerName, logger)(gw) {
+		if helpers.GatewayHasMatchingControllerFn(ctx, h.client, h.controllerName, h.logger)(gw) {
 			return true
 		}
 	}
@@ -70,9 +84,9 @@ func IsReferencedByCiliumGateway(ctx context.Context, c client.Client, logger *s
 
 // Enqueue BackendTLSPolicyConfigmaps produces a handler.EventHandler that, when it is passed a
 // BackendTLSPolicy as the object.Object, returns any ConfigMaps referenced.
-func EnqueueBackendTLSPolicyConfigMaps(c client.Client, logger *slog.Logger) handler.EventHandler {
+func (h *SecretSyncHandler) EnqueueBackendTLSPolicyConfigMaps() handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
-		scopedLog := logger.With(
+		scopedLog := h.logger.With(
 			logfields.Resource, obj.GetName(),
 		)
 
@@ -87,26 +101,26 @@ func EnqueueBackendTLSPolicyConfigMaps(c client.Client, logger *slog.Logger) han
 			if !helpers.IsConfigMap(certRef) {
 				continue
 			}
-			c := types.NamespacedName{
+			cfg := types.NamespacedName{
 				Namespace: btlsp.GetNamespace(),
 				Name:      string(certRef.Name),
 			}
-			reqs = append(reqs, reconcile.Request{NamespacedName: c})
-			scopedLog.DebugContext(ctx, "Enqueued configmap for backendtlspolicy", logfields.ConfigMapName, c)
+			reqs = append(reqs, reconcile.Request{NamespacedName: cfg})
+			scopedLog.DebugContext(ctx, "Enqueued configmap for backendtlspolicy", logfields.ConfigMapName, cfg)
 		}
 		return reqs
 	})
 }
 
-func ConfigMapIsReferencedInCiliumGateway(ctx context.Context, c client.Client, logger *slog.Logger, cfgMap *corev1.ConfigMap) bool {
-	scopedLog := logger.With(logfields.LogSubsys, "queue-gw-from-backendtlspolicy-configmap")
+func (h *SecretSyncHandler) ConfigMapIsReferencedInGateway(ctx context.Context, _ client.Client, _ *slog.Logger, cfgMap *corev1.ConfigMap) bool {
+	scopedLog := h.logger.With(logfields.LogSubsys, "queue-gw-from-backendtlspolicy-configmap")
 
 	cfgMapName := client.ObjectKeyFromObject(cfgMap)
 
 	// Fetch all BackendTLSPolicies that reference this ConfigMap
 	btlspList := &gatewayv1.BackendTLSPolicyList{}
 
-	if err := c.List(ctx, btlspList, &client.ListOptions{
+	if err := h.client.List(ctx, btlspList, &client.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector(indexers.BackendTLSPolicyConfigMapIndex, cfgMapName.String()),
 	}); err != nil {
 		scopedLog.ErrorContext(ctx, "Failed to get related BackendTLSPolicies for ConfigMap", logfields.Error, err)
@@ -121,7 +135,7 @@ func ConfigMapIsReferencedInCiliumGateway(ctx context.Context, c client.Client, 
 		for _, ancestorStatus := range btlsp.Status.Ancestors {
 			// An Ancestor Status with the Cilium controller name and Accepted: True is only added by Cilium if
 			// everything is good, so we are covered.
-			if ancestorStatus.ControllerName == helpers.CiliumDefaultControllerName && helpers.IsAccepted(ancestorStatus.Conditions) {
+			if string(ancestorStatus.ControllerName) == h.controllerName && helpers.IsAccepted(ancestorStatus.Conditions) {
 				return true
 			}
 		}

--- a/operator/pkg/gateway-api/status_route.go
+++ b/operator/pkg/gateway-api/status_route.go
@@ -8,15 +8,13 @@ import (
 	"slices"
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-
-	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 )
 
-func pruneRouteParentStatuses(parents []gatewayv1.RouteParentStatus, currentParentRefs []gatewayv1.ParentReference) []gatewayv1.RouteParentStatus {
+func pruneRouteParentStatuses(parents []gatewayv1.RouteParentStatus, currentParentRefs []gatewayv1.ParentReference, controllerName string) []gatewayv1.RouteParentStatus {
 	filtered := parents[:0]
 
 	for _, parentStatus := range parents {
-		if parentStatus.ControllerName != helpers.CiliumDefaultControllerName || slices.ContainsFunc(currentParentRefs, func(ref gatewayv1.ParentReference) bool {
+		if string(parentStatus.ControllerName) != controllerName || slices.ContainsFunc(currentParentRefs, func(ref gatewayv1.ParentReference) bool {
 			return reflect.DeepEqual(ref, parentStatus.ParentRef)
 		}) {
 			filtered = append(filtered, parentStatus)

--- a/operator/pkg/gateway-api/status_route_test.go
+++ b/operator/pkg/gateway-api/status_route_test.go
@@ -96,7 +96,7 @@ func TestPruneRouteParentStatuses(t *testing.T) {
 	require.Equal(t, otherControllerDetachedParent, route.Status.Parents[1].ParentRef, "merge alone keeps both detached statuses")
 	require.Equal(t, currentParentStatus, route.Status.Parents[2].ParentRef, "merge alone keeps both detached statuses")
 
-	route.Status.Parents = pruneRouteParentStatuses(route.Status.Parents, route.Spec.ParentRefs)
+	route.Status.Parents = pruneRouteParentStatuses(route.Status.Parents, route.Spec.ParentRefs, helpers.CiliumDefaultControllerName)
 
 	require.Len(t, route.Status.Parents, 2, "prune removes only the detached Cilium-owned status")
 	require.Equal(t, otherControllerDetachedParent, route.Status.Parents[0].ParentRef, "prune removes only the detached Cilium-owned status")

--- a/operator/pkg/gateway-api/status_route_test.go
+++ b/operator/pkg/gateway-api/status_route_test.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/routechecks"
 )
 
@@ -53,7 +52,7 @@ func TestPruneRouteParentStatuses(t *testing.T) {
 				Parents: []gatewayv1.RouteParentStatus{
 					{
 						ParentRef:      ourDetachedParent,
-						ControllerName: helpers.CiliumDefaultControllerName,
+						ControllerName: defaultControllerName,
 						Conditions: []metav1.Condition{{
 							Type:   string(gatewayv1.RouteConditionAccepted),
 							Status: metav1.ConditionFalse,
@@ -66,7 +65,7 @@ func TestPruneRouteParentStatuses(t *testing.T) {
 					},
 					{
 						ParentRef:      currentParentStatus,
-						ControllerName: helpers.CiliumDefaultControllerName,
+						ControllerName: defaultControllerName,
 						Conditions: []metav1.Condition{{
 							Type:   string(gatewayv1.RouteConditionAccepted),
 							Status: metav1.ConditionTrue,
@@ -96,11 +95,11 @@ func TestPruneRouteParentStatuses(t *testing.T) {
 	require.Equal(t, otherControllerDetachedParent, route.Status.Parents[1].ParentRef, "merge alone keeps both detached statuses")
 	require.Equal(t, currentParentStatus, route.Status.Parents[2].ParentRef, "merge alone keeps both detached statuses")
 
-	route.Status.Parents = pruneRouteParentStatuses(route.Status.Parents, route.Spec.ParentRefs, helpers.CiliumDefaultControllerName)
+	route.Status.Parents = pruneRouteParentStatuses(route.Status.Parents, route.Spec.ParentRefs, defaultControllerName)
 
 	require.Len(t, route.Status.Parents, 2, "prune removes only the detached Cilium-owned status")
 	require.Equal(t, otherControllerDetachedParent, route.Status.Parents[0].ParentRef, "prune removes only the detached Cilium-owned status")
 	require.Equal(t, gatewayv1.GatewayController("example.com/other-gateway-controller"), route.Status.Parents[0].ControllerName, "prune removes only the detached Cilium-owned status")
 	require.Equal(t, currentParentStatus, route.Status.Parents[1].ParentRef, "prune removes only the detached Cilium-owned status")
-	require.Equal(t, gatewayv1.GatewayController(helpers.CiliumDefaultControllerName), route.Status.Parents[1].ControllerName, "prune removes only the detached Cilium-owned status")
+	require.Equal(t, gatewayv1.GatewayController(defaultControllerName), route.Status.Parents[1].ControllerName, "prune removes only the detached Cilium-owned status")
 }

--- a/operator/pkg/secretsync/configmapsync_reconcile_test.go
+++ b/operator/pkg/secretsync/configmapsync_reconcile_test.go
@@ -19,10 +19,11 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	gateway_api "github.com/cilium/cilium/operator/pkg/gateway-api"
-	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
 	"github.com/cilium/cilium/operator/pkg/secretsync"
 )
+
+const testConfigMapSyncControllerName = "example.com/test-gateway-controller"
 
 var configMapFixture = []client.Object{
 	&corev1.Secret{
@@ -97,7 +98,7 @@ var configMapFixture = []client.Object{
 		Status: gatewayv1.PolicyStatus{
 			Ancestors: []gatewayv1.PolicyAncestorStatus{
 				{
-					ControllerName: "io.cilium/gateway-controller",
+					ControllerName: testConfigMapSyncControllerName,
 					Conditions: []metav1.Condition{
 						{
 							Type:   "Accepted",
@@ -189,7 +190,7 @@ var configMapFixture = []client.Object{
 		Status: gatewayv1.PolicyStatus{
 			Ancestors: []gatewayv1.PolicyAncestorStatus{
 				{
-					ControllerName: "io.cilium/gateway-controller",
+					ControllerName: testConfigMapSyncControllerName,
 					Conditions: []metav1.Condition{
 						{
 							Type:   "Accepted",
@@ -211,7 +212,7 @@ func Test_ConfigMapSync_Reconcile(t *testing.T) {
 		WithIndex(&gatewayv1.BackendTLSPolicy{}, indexers.BackendTLSPolicyConfigMapIndex, indexers.IndexBTLSPolicyByConfigMap).
 		Build()
 
-	gatewayHandler := gateway_api.NewSecretSyncHandler(c, logger, helpers.CiliumDefaultControllerName)
+	gatewayHandler := gateway_api.NewSecretSyncHandler(c, logger, testConfigMapSyncControllerName)
 
 	r := secretsync.NewConfigMapSyncReconciler(c, logger, []*secretsync.ConfigMapSyncRegistration{
 		{

--- a/operator/pkg/secretsync/configmapsync_reconcile_test.go
+++ b/operator/pkg/secretsync/configmapsync_reconcile_test.go
@@ -19,6 +19,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	gateway_api "github.com/cilium/cilium/operator/pkg/gateway-api"
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
 	"github.com/cilium/cilium/operator/pkg/secretsync"
 )
@@ -210,11 +211,13 @@ func Test_ConfigMapSync_Reconcile(t *testing.T) {
 		WithIndex(&gatewayv1.BackendTLSPolicy{}, indexers.BackendTLSPolicyConfigMapIndex, indexers.IndexBTLSPolicyByConfigMap).
 		Build()
 
+	gatewayHandler := gateway_api.NewSecretSyncHandler(c, logger, helpers.CiliumDefaultControllerName)
+
 	r := secretsync.NewConfigMapSyncReconciler(c, logger, []*secretsync.ConfigMapSyncRegistration{
 		{
 			RefObject:            &gatewayv1.Gateway{},
-			RefObjectEnqueueFunc: gateway_api.EnqueueBackendTLSPolicyConfigMaps(c, logger),
-			RefObjectCheckFunc:   gateway_api.ConfigMapIsReferencedInCiliumGateway,
+			RefObjectEnqueueFunc: gatewayHandler.EnqueueBackendTLSPolicyConfigMaps(),
+			RefObjectCheckFunc:   gatewayHandler.ConfigMapIsReferencedInGateway,
 			SecretsNamespace:     secretsNamespace,
 		},
 	},

--- a/operator/pkg/secretsync/secretsync_reconcile_test.go
+++ b/operator/pkg/secretsync/secretsync_reconcile_test.go
@@ -25,6 +25,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	gateway_api "github.com/cilium/cilium/operator/pkg/gateway-api"
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/ingress"
 	"github.com/cilium/cilium/operator/pkg/secretsync"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -203,11 +204,13 @@ func Test_SecretSync_Reconcile(t *testing.T) {
 		WithObjects(secretFixture...).
 		Build()
 
+	gatewayHandler := gateway_api.NewSecretSyncHandler(c, logger, helpers.CiliumDefaultControllerName)
+
 	r := secretsync.NewSecretSyncReconciler(c, logger, []*secretsync.SecretSyncRegistration{
 		{
 			RefObject:            &gatewayv1.Gateway{},
-			RefObjectEnqueueFunc: gateway_api.EnqueueTLSSecrets(c, logger),
-			RefObjectCheckFunc:   gateway_api.IsReferencedByCiliumGateway,
+			RefObjectEnqueueFunc: gatewayHandler.EnqueueTLSSecrets(),
+			RefObjectCheckFunc:   gatewayHandler.IsReferencedByGateway,
 			SecretsNamespace:     secretsNamespace,
 		},
 		{
@@ -416,11 +419,13 @@ func Test_SecretSync_Reconcile_TypeChange(t *testing.T) {
 		WithObjects(secretFixtureTypeChange...).
 		Build()
 
+	gatewayHandler := gateway_api.NewSecretSyncHandler(c, logger, helpers.CiliumDefaultControllerName)
+
 	r := secretsync.NewSecretSyncReconciler(c, logger, []*secretsync.SecretSyncRegistration{
 		{
 			RefObject:            &gatewayv1.Gateway{},
-			RefObjectEnqueueFunc: gateway_api.EnqueueTLSSecrets(c, logger),
-			RefObjectCheckFunc:   gateway_api.IsReferencedByCiliumGateway,
+			RefObjectEnqueueFunc: gatewayHandler.EnqueueTLSSecrets(),
+			RefObjectCheckFunc:   gatewayHandler.IsReferencedByGateway,
 			SecretsNamespace:     secretsNamespace,
 		},
 	},
@@ -469,11 +474,12 @@ func Test_SecretSync_Reconcile_WithDefaultSecret(t *testing.T) {
 		WithScheme(testScheme()).
 		WithObjects(secretFixtureDefaultSecret...).
 		Build()
+	gatewayHandler := gateway_api.NewSecretSyncHandler(c, logger, helpers.CiliumDefaultControllerName)
 	r := secretsync.NewSecretSyncReconciler(c, logger, []*secretsync.SecretSyncRegistration{
 		{
 			RefObject:            &gatewayv1.Gateway{},
-			RefObjectEnqueueFunc: gateway_api.EnqueueTLSSecrets(c, logger),
-			RefObjectCheckFunc:   gateway_api.IsReferencedByCiliumGateway,
+			RefObjectEnqueueFunc: gatewayHandler.EnqueueTLSSecrets(),
+			RefObjectCheckFunc:   gatewayHandler.IsReferencedByGateway,
 			SecretsNamespace:     secretsNamespace,
 			DefaultSecret: &secretsync.DefaultSecret{
 				Namespace: "test",

--- a/operator/pkg/secretsync/secretsync_reconcile_test.go
+++ b/operator/pkg/secretsync/secretsync_reconcile_test.go
@@ -25,13 +25,14 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	gateway_api "github.com/cilium/cilium/operator/pkg/gateway-api"
-	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/ingress"
 	"github.com/cilium/cilium/operator/pkg/secretsync"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 )
 
 var secretsNamespace = "cilium-secrets-test"
+
+const testSecretSyncControllerName = "example.com/test-gateway-controller"
 
 var secretFixture = []client.Object{
 	&corev1.Secret{
@@ -81,7 +82,7 @@ var secretFixture = []client.Object{
 			Name: "cilium",
 		},
 		Spec: gatewayv1.GatewayClassSpec{
-			ControllerName: "io.cilium/gateway-controller",
+			ControllerName: testSecretSyncControllerName,
 		},
 	},
 	&gatewayv1.Gateway{
@@ -204,7 +205,7 @@ func Test_SecretSync_Reconcile(t *testing.T) {
 		WithObjects(secretFixture...).
 		Build()
 
-	gatewayHandler := gateway_api.NewSecretSyncHandler(c, logger, helpers.CiliumDefaultControllerName)
+	gatewayHandler := gateway_api.NewSecretSyncHandler(c, logger, testSecretSyncControllerName)
 
 	r := secretsync.NewSecretSyncReconciler(c, logger, []*secretsync.SecretSyncRegistration{
 		{
@@ -384,7 +385,7 @@ var secretFixtureTypeChange = []client.Object{
 			Name: "cilium",
 		},
 		Spec: gatewayv1.GatewayClassSpec{
-			ControllerName: "io.cilium/gateway-controller",
+			ControllerName: testSecretSyncControllerName,
 		},
 	},
 	&gatewayv1.Gateway{
@@ -419,7 +420,7 @@ func Test_SecretSync_Reconcile_TypeChange(t *testing.T) {
 		WithObjects(secretFixtureTypeChange...).
 		Build()
 
-	gatewayHandler := gateway_api.NewSecretSyncHandler(c, logger, helpers.CiliumDefaultControllerName)
+	gatewayHandler := gateway_api.NewSecretSyncHandler(c, logger, testSecretSyncControllerName)
 
 	r := secretsync.NewSecretSyncReconciler(c, logger, []*secretsync.SecretSyncRegistration{
 		{
@@ -474,7 +475,7 @@ func Test_SecretSync_Reconcile_WithDefaultSecret(t *testing.T) {
 		WithScheme(testScheme()).
 		WithObjects(secretFixtureDefaultSecret...).
 		Build()
-	gatewayHandler := gateway_api.NewSecretSyncHandler(c, logger, helpers.CiliumDefaultControllerName)
+	gatewayHandler := gateway_api.NewSecretSyncHandler(c, logger, testSecretSyncControllerName)
 	r := secretsync.NewSecretSyncReconciler(c, logger, []*secretsync.SecretSyncRegistration{
 		{
 			RefObject:            &gatewayv1.Gateway{},


### PR DESCRIPTION
This PR cleans up the usage and definitions of the Default Cilium Gateway API GatewayClass controllername `io.cilium/gateway-controller`.

* Remove duplicate definitions of consts
* Pass controllername value to components instead of accessing global consts from everywhere