### PR TITLE
gateway-api: Filter UDP/TCP routes by allowedRoutes.namespaces

### DIFF
--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -157,7 +157,7 @@ func GatewayAPI(log *slog.Logger, input Input) *model.Model {
 				},
 				Port:           uint32(l.Port),
 				Protocol:       model.L4ProtocolTCP,
-				Routes:         toTCPRoutes(l, input.TCPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants),
+				Routes:         toTCPRoutes(l, input.Gateway.GetNamespace(), namespaceLabels, input.TCPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants),
 				Infrastructure: infra,
 				Service:        toServiceModel(input.GatewayClassConfig),
 			})
@@ -177,7 +177,7 @@ func GatewayAPI(log *slog.Logger, input Input) *model.Model {
 				},
 				Port:           uint32(l.Port),
 				Protocol:       model.L4ProtocolUDP,
-				Routes:         toUDPRoutes(l, input.UDPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants),
+				Routes:         toUDPRoutes(l, input.Gateway.GetNamespace(), namespaceLabels, input.UDPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants),
 				Infrastructure: infra,
 				Service:        toServiceModel(input.GatewayClassConfig),
 			})
@@ -866,7 +866,7 @@ func sortL4RoutesByAge[T any](routes []T, meta func(T) metav1.ObjectMeta) {
 	})
 }
 
-func toTCPRoutes(listener gatewayv1beta1.Listener, input []gatewayv1alpha2.TCPRoute, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1.ReferenceGrant) []model.L4Route {
+func toTCPRoutes(listener gatewayv1beta1.Listener, gatewayNamespace string, namespaceLabels helpers.NamespaceLabelIndex, input []gatewayv1alpha2.TCPRoute, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1.ReferenceGrant) []model.L4Route {
 	// Collect every TCPRoute that attaches to this listener, then keep only the
 	// oldest. Per Gateway API conflict resolution
 	// (https://gateway-api.sigs.k8s.io/guides/api-design/#conflicts), an L4
@@ -875,6 +875,9 @@ func toTCPRoutes(listener gatewayv1beta1.Listener, input []gatewayv1alpha2.TCPRo
 	// Accepted=True (handled by the status reconciler) but route no traffic.
 	attached := make([]gatewayv1alpha2.TCPRoute, 0, len(input))
 	for _, r := range input {
+		if !helpers.IsListenerNamespaceAllowed(listener, r.GetNamespace(), gatewayNamespace, namespaceLabels) {
+			continue
+		}
 		if l4RouteAttachesToListener(r.Spec.ParentRefs, listener) {
 			attached = append(attached, r)
 		}
@@ -919,10 +922,13 @@ func toTCPRoutes(listener gatewayv1beta1.Listener, input []gatewayv1alpha2.TCPRo
 	return l4Routes
 }
 
-func toUDPRoutes(listener gatewayv1beta1.Listener, input []gatewayv1alpha2.UDPRoute, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1.ReferenceGrant) []model.L4Route {
+func toUDPRoutes(listener gatewayv1beta1.Listener, gatewayNamespace string, namespaceLabels helpers.NamespaceLabelIndex, input []gatewayv1alpha2.UDPRoute, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1.ReferenceGrant) []model.L4Route {
 	// Keep only the oldest attaching UDPRoute. See toTCPRoutes for the rationale.
 	attached := make([]gatewayv1alpha2.UDPRoute, 0, len(input))
 	for _, r := range input {
+		if !helpers.IsListenerNamespaceAllowed(listener, r.GetNamespace(), gatewayNamespace, namespaceLabels) {
+			continue
+		}
 		if l4RouteAttachesToListener(r.Spec.ParentRefs, listener) {
 			attached = append(attached, r)
 		}

--- a/operator/pkg/model/ingestion/gateway_test.go
+++ b/operator/pkg/model/ingestion/gateway_test.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/cilium/hive/hivetest"
 
@@ -183,6 +184,290 @@ func TestHTTPGatewayAPIFiltersSelectorNamespacesPerListener(t *testing.T) {
 	assert.Empty(t, m.HTTP[1].Routes)
 }
 
+func TestHTTPAndGRPCGatewayAPIFiltersRoutesByListenerAllowedNamespaces(t *testing.T) {
+	sameNamespace := gatewayv1.NamespacesFromSame
+	allNamespaces := gatewayv1.NamespacesFromAll
+	redirectStatusCode := 301
+	redirectScheme := "https"
+	grpcService := "grpc.Service"
+	grpcMethod := "Get"
+	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+
+	m := GatewayAPI(logger, Input{
+		Gateway: gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "platform",
+				Namespace: "gateway-ns",
+			},
+			Spec: gatewayv1.GatewaySpec{
+				Listeners: []gatewayv1.Listener{
+					{
+						Name:     "http",
+						Port:     80,
+						Protocol: gatewayv1.HTTPProtocolType,
+						AllowedRoutes: &gatewayv1.AllowedRoutes{
+							Namespaces: &gatewayv1.RouteNamespaces{
+								From: &sameNamespace,
+							},
+						},
+					},
+					{
+						Name:     "https",
+						Hostname: ptr.To[gatewayv1.Hostname]("*.example.test"),
+						Port:     443,
+						Protocol: gatewayv1.HTTPSProtocolType,
+						AllowedRoutes: &gatewayv1.AllowedRoutes{
+							Namespaces: &gatewayv1.RouteNamespaces{
+								From: &allNamespaces,
+							},
+						},
+					},
+				},
+			},
+		},
+		HTTPRoutes: []gatewayv1.HTTPRoute{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "http-to-https-redirect",
+					Namespace: "gateway-ns",
+				},
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:        "platform",
+								SectionName: ptr.To[gatewayv1.SectionName]("http"),
+							},
+						},
+					},
+					Rules: []gatewayv1.HTTPRouteRule{
+						{
+							Matches: []gatewayv1.HTTPRouteMatch{
+								{
+									Path: &gatewayv1.HTTPPathMatch{
+										Type:  ptr.To(gatewayv1.PathMatchPathPrefix),
+										Value: ptr.To("/"),
+									},
+								},
+							},
+							Filters: []gatewayv1.HTTPRouteFilter{
+								{
+									Type: gatewayv1.HTTPRouteFilterRequestRedirect,
+									RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{
+										Scheme:     &redirectScheme,
+										StatusCode: &redirectStatusCode,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "podinfo",
+					Namespace: "app-ns",
+				},
+				Spec: gatewayv1.HTTPRouteSpec{
+					Hostnames: []gatewayv1.Hostname{"podinfo.example.test"},
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:      "platform",
+								Namespace: ptr.To[gatewayv1.Namespace]("gateway-ns"),
+							},
+						},
+					},
+					Rules: []gatewayv1.HTTPRouteRule{
+						{
+							BackendRefs: []gatewayv1.HTTPBackendRef{
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Name: "podinfo",
+											Port: ptr.To[gatewayv1.PortNumber](9898),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		GRPCRoutes: []gatewayv1.GRPCRoute{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "grpc",
+					Namespace: "app-ns",
+				},
+				Spec: gatewayv1.GRPCRouteSpec{
+					Hostnames: []gatewayv1.Hostname{"grpc.example.test"},
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:      "platform",
+								Namespace: ptr.To[gatewayv1.Namespace]("gateway-ns"),
+							},
+						},
+					},
+					Rules: []gatewayv1.GRPCRouteRule{
+						{
+							Matches: []gatewayv1.GRPCRouteMatch{
+								{
+									Method: &gatewayv1.GRPCMethodMatch{
+										Type:    ptr.To(gatewayv1.GRPCMethodMatchExact),
+										Service: &grpcService,
+										Method:  &grpcMethod,
+									},
+								},
+							},
+							BackendRefs: []gatewayv1.GRPCBackendRef{
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Name: "podinfo",
+											Port: ptr.To[gatewayv1.PortNumber](9898),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Services: []corev1.Service{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "podinfo",
+					Namespace: "app-ns",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port: 9898,
+						},
+					},
+				},
+			},
+		},
+	})
+
+	require.Len(t, m.HTTP, 2)
+	require.Equal(t, "http", m.HTTP[0].Name)
+	require.Len(t, m.HTTP[0].Routes, 1)
+	assert.NotNil(t, m.HTTP[0].Routes[0].RequestRedirect)
+	assert.Empty(t, m.HTTP[0].Routes[0].Backends)
+
+	require.Equal(t, "https", m.HTTP[1].Name)
+	require.Len(t, m.HTTP[1].Routes, 2)
+	assert.Equal(t, []string{"podinfo.example.test"}, m.HTTP[1].Routes[0].Hostnames)
+	require.Len(t, m.HTTP[1].Routes[0].Backends, 1)
+	assert.Equal(t, "podinfo", m.HTTP[1].Routes[0].Backends[0].Name)
+	assert.Equal(t, []string{"grpc.example.test"}, m.HTTP[1].Routes[1].Hostnames)
+	assert.True(t, m.HTTP[1].Routes[1].IsGRPC)
+	require.Len(t, m.HTTP[1].Routes[1].Backends, 1)
+	assert.Equal(t, "podinfo", m.HTTP[1].Routes[1].Backends[0].Name)
+}
+
+func TestTLSGatewayAPIFiltersRoutesByListenerAllowedNamespaces(t *testing.T) {
+	sameNamespace := gatewayv1.NamespacesFromSame
+	allNamespaces := gatewayv1.NamespacesFromAll
+	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+
+	m := GatewayAPI(logger, Input{
+		Gateway: gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "platform",
+				Namespace: "gateway-ns",
+			},
+			Spec: gatewayv1.GatewaySpec{
+				Listeners: []gatewayv1.Listener{
+					{
+						Name:     "tls-same",
+						Hostname: ptr.To[gatewayv1.Hostname]("tls.example.test"),
+						Port:     443,
+						Protocol: gatewayv1.TLSProtocolType,
+						AllowedRoutes: &gatewayv1.AllowedRoutes{
+							Namespaces: &gatewayv1.RouteNamespaces{
+								From: &sameNamespace,
+							},
+						},
+					},
+					{
+						Name:     "tls-all",
+						Hostname: ptr.To[gatewayv1.Hostname]("tls.example.test"),
+						Port:     8443,
+						Protocol: gatewayv1.TLSProtocolType,
+						AllowedRoutes: &gatewayv1.AllowedRoutes{
+							Namespaces: &gatewayv1.RouteNamespaces{
+								From: &allNamespaces,
+							},
+						},
+					},
+				},
+			},
+		},
+		TLSRoutes: []gatewayv1.TLSRoute{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tls",
+					Namespace: "app-ns",
+				},
+				Spec: gatewayv1.TLSRouteSpec{
+					Hostnames: []gatewayv1.Hostname{"tls.example.test"},
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:      "platform",
+								Namespace: ptr.To[gatewayv1.Namespace]("gateway-ns"),
+							},
+						},
+					},
+					Rules: []gatewayv1.TLSRouteRule{
+						{
+							BackendRefs: []gatewayv1.BackendRef{
+								{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Name: "podinfo",
+										Port: ptr.To[gatewayv1.PortNumber](9898),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Services: []corev1.Service{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "podinfo",
+					Namespace: "app-ns",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port: 9898,
+						},
+					},
+				},
+			},
+		},
+	})
+
+	require.Len(t, m.TLSPassthrough, 2)
+	require.Equal(t, "tls-same", m.TLSPassthrough[0].Name)
+	assert.Empty(t, m.TLSPassthrough[0].Routes)
+
+	require.Equal(t, "tls-all", m.TLSPassthrough[1].Name)
+	require.Len(t, m.TLSPassthrough[1].Routes, 1)
+	assert.Equal(t, []string{"tls.example.test"}, m.TLSPassthrough[1].Routes[0].Hostnames)
+	require.Len(t, m.TLSPassthrough[1].Routes[0].Backends, 1)
+	assert.Equal(t, "podinfo", m.TLSPassthrough[1].Routes[0].Backends[0].Name)
+}
+
 func TestTLSGatewayAPI(t *testing.T) {
 	tests := map[string]struct{}{
 		"basic tls http": {},
@@ -244,6 +529,222 @@ func TestL4GatewayAPI(t *testing.T) {
 			assert.Equal(t, toYaml(t, expected), toYaml(t, m.L4), "Listeners did not match")
 		})
 	}
+}
+
+func TestL4GatewayAPIFiltersRoutesByListenerAllowedNamespaces(t *testing.T) {
+	sameNamespace := gatewayv1.NamespacesFromSame
+	allNamespaces := gatewayv1.NamespacesFromAll
+	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+
+	m := GatewayAPI(logger, Input{
+		Gateway: gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "platform",
+				Namespace: "gateway-ns",
+			},
+			Spec: gatewayv1.GatewaySpec{
+				Listeners: []gatewayv1.Listener{
+					{
+						Name:     "tcp-same",
+						Port:     9000,
+						Protocol: gatewayv1.TCPProtocolType,
+						AllowedRoutes: &gatewayv1.AllowedRoutes{
+							Namespaces: &gatewayv1.RouteNamespaces{
+								From: &sameNamespace,
+							},
+						},
+					},
+					{
+						Name:     "tcp-all",
+						Port:     9001,
+						Protocol: gatewayv1.TCPProtocolType,
+						AllowedRoutes: &gatewayv1.AllowedRoutes{
+							Namespaces: &gatewayv1.RouteNamespaces{
+								From: &allNamespaces,
+							},
+						},
+					},
+					{
+						Name:     "udp-same",
+						Port:     9002,
+						Protocol: gatewayv1.UDPProtocolType,
+						AllowedRoutes: &gatewayv1.AllowedRoutes{
+							Namespaces: &gatewayv1.RouteNamespaces{
+								From: &sameNamespace,
+							},
+						},
+					},
+					{
+						Name:     "udp-all",
+						Port:     9003,
+						Protocol: gatewayv1.UDPProtocolType,
+						AllowedRoutes: &gatewayv1.AllowedRoutes{
+							Namespaces: &gatewayv1.RouteNamespaces{
+								From: &allNamespaces,
+							},
+						},
+					},
+				},
+			},
+		},
+		TCPRoutes: []gatewayv1alpha2.TCPRoute{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tcp-same",
+					Namespace: "app-ns",
+				},
+				Spec: gatewayv1alpha2.TCPRouteSpec{
+					CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
+						ParentRefs: []gatewayv1alpha2.ParentReference{
+							{
+								Name:        "platform",
+								Namespace:   ptr.To[gatewayv1.Namespace]("gateway-ns"),
+								SectionName: ptr.To[gatewayv1.SectionName]("tcp-same"),
+							},
+						},
+					},
+					Rules: []gatewayv1alpha2.TCPRouteRule{
+						{
+							BackendRefs: []gatewayv1alpha2.BackendRef{
+								{
+									BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+										Name: "tcp-backend",
+										Port: ptr.To[gatewayv1.PortNumber](9000),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tcp-all",
+					Namespace: "app-ns",
+				},
+				Spec: gatewayv1alpha2.TCPRouteSpec{
+					CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
+						ParentRefs: []gatewayv1alpha2.ParentReference{
+							{
+								Name:        "platform",
+								Namespace:   ptr.To[gatewayv1.Namespace]("gateway-ns"),
+								SectionName: ptr.To[gatewayv1.SectionName]("tcp-all"),
+							},
+						},
+					},
+					Rules: []gatewayv1alpha2.TCPRouteRule{
+						{
+							BackendRefs: []gatewayv1alpha2.BackendRef{
+								{
+									BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+										Name: "tcp-backend",
+										Port: ptr.To[gatewayv1.PortNumber](9000),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		UDPRoutes: []gatewayv1alpha2.UDPRoute{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "udp-same",
+					Namespace: "app-ns",
+				},
+				Spec: gatewayv1alpha2.UDPRouteSpec{
+					CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
+						ParentRefs: []gatewayv1alpha2.ParentReference{
+							{
+								Name:        "platform",
+								Namespace:   ptr.To[gatewayv1.Namespace]("gateway-ns"),
+								SectionName: ptr.To[gatewayv1.SectionName]("udp-same"),
+							},
+						},
+					},
+					Rules: []gatewayv1alpha2.UDPRouteRule{
+						{
+							BackendRefs: []gatewayv1alpha2.BackendRef{
+								{
+									BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+										Name: "udp-backend",
+										Port: ptr.To[gatewayv1.PortNumber](9002),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "udp-all",
+					Namespace: "app-ns",
+				},
+				Spec: gatewayv1alpha2.UDPRouteSpec{
+					CommonRouteSpec: gatewayv1alpha2.CommonRouteSpec{
+						ParentRefs: []gatewayv1alpha2.ParentReference{
+							{
+								Name:        "platform",
+								Namespace:   ptr.To[gatewayv1.Namespace]("gateway-ns"),
+								SectionName: ptr.To[gatewayv1.SectionName]("udp-all"),
+							},
+						},
+					},
+					Rules: []gatewayv1alpha2.UDPRouteRule{
+						{
+							BackendRefs: []gatewayv1alpha2.BackendRef{
+								{
+									BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
+										Name: "udp-backend",
+										Port: ptr.To[gatewayv1.PortNumber](9002),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Services: []corev1.Service{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tcp-backend",
+					Namespace: "app-ns",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{Port: 9000}},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "udp-backend",
+					Namespace: "app-ns",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{Port: 9002}},
+				},
+			},
+		},
+	})
+
+	require.Len(t, m.L4, 4)
+	require.Equal(t, "tcp-same", m.L4[0].Name)
+	assert.Empty(t, m.L4[0].Routes)
+
+	require.Equal(t, "tcp-all", m.L4[1].Name)
+	require.Len(t, m.L4[1].Routes, 1)
+	require.Len(t, m.L4[1].Routes[0].Backends, 1)
+	assert.Equal(t, "tcp-backend", m.L4[1].Routes[0].Backends[0].Name)
+
+	require.Equal(t, "udp-same", m.L4[2].Name)
+	assert.Empty(t, m.L4[2].Routes)
+
+	require.Equal(t, "udp-all", m.L4[3].Name)
+	require.Len(t, m.L4[3].Routes, 1)
+	require.Len(t, m.L4[3].Routes[0].Backends, 1)
+	assert.Equal(t, "udp-backend", m.L4[3].Routes[0].Backends[0].Name)
 }
 
 func TestGPRCPathMatch(t *testing.T) {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

<!-- Description of change -->

Resolves #46359

_This PR was prepared with AIL:3. I gave the AI the gateway.go files, specific instructions on the failure, how to use my cluster to check the behavior, how I want it to behave and had the AI fillin the implementation details by doing as few changes as possible to the codebase to make it easy reviewable with the least impact possible. Then after implementation and AI doing testing, I have tested the behavior in the kind cluster. My httproutes now properly do the permanent redirect from http to https._

```release-note
Fix Gateway API UDPRoute/TCPRoute programming so routes accepted by one listener are not emitted into another listener that rejects them via `allowedRoutes.namespaces`.
```

Cilium Gateway reconciliation can filter routes at the Gateway level before
handing them to model ingestion. For an HTTPRoute that omits `sectionName`,
this means a route accepted by one listener, for example an HTTPS listener
with `allowedRoutes.namespaces.from: All`, can still be considered during
model generation for another listener, for example an HTTP listener with
`allowedRoutes.namespaces.from: Same`.

This change makes HTTPRoute model ingestion enforce the listener's
`allowedRoutes.namespaces` before extracting routes for that listener. The
reconciler now provides namespaces to ingestion only when a listener uses a
namespace selector, so selector-based allowed routes continue to work without
adding an unconditional namespace list. The listener allowed-route helper also
handles the default/specified selector cases consistently.

The regression test covers the reported platform setup: a same-namespace HTTP
redirect route on port 80 and a cross-namespace application HTTPRoute accepted
by HTTPS but not by HTTP.

## Testing

  - `go test -count=1 ./operator/pkg/model/ingestion`
  - `env GOOS=linux go test -c -o /private/tmp/cilium-gateway-api.test ./
  operator/pkg/gateway-api`
  - `git diff --check main`
  - `make kind`
  - `make kind-image`
  - `make kind-servicemesh-install-cilium`
  - Applied the Gateway, redirect HTTPRoute, backend, and cross-namespace
  HTTPRoute from #46359 to `kind-kind`
  - Verified generated `CiliumEnvoyConfig` has only the wildcard redirect
  virtual host in `listener-insecure`, and `podinfo.example.test` only in
  `listener-secure`
  - Verified in-cluster HTTP request to the Gateway address returns `HTTP/1.1
  301 Moved Permanently`

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
