### PR TITLE
azure: Standardize package layout

### DIFF
--- a/operator/pkg/ipam/allocator/azure/azure.go
+++ b/operator/pkg/ipam/allocator/azure/azure.go
@@ -10,8 +10,9 @@ import (
 
 	"github.com/cilium/cilium/operator/pkg/ipam/allocator"
 	"github.com/cilium/cilium/operator/pkg/ipam/nodemanager"
-	azureAPI "github.com/cilium/cilium/pkg/azure/api"
-	azureIPAM "github.com/cilium/cilium/pkg/azure/ipam"
+	"github.com/cilium/cilium/pkg/azure/api"
+	"github.com/cilium/cilium/pkg/azure/ipam"
+	"github.com/cilium/cilium/pkg/azure/metadata"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -24,7 +25,7 @@ type AllocatorAzure struct {
 	ParallelAllocWorkers        int64
 	LimitIPAMAPIBurst           int
 	LimitIPAMAPIQPS             float64
-	AzureMetrics                azureAPI.MetricsAPI
+	AzureMetrics                api.MetricsAPI
 
 	rootLogger *slog.Logger
 	logger     *slog.Logger
@@ -42,7 +43,7 @@ func (a *AllocatorAzure) Start(ctx context.Context, getterUpdater allocator.Cili
 	a.logger.Info("Starting Azure IP allocator...")
 
 	a.logger.Debug("Retrieving Azure cloud name via Azure IMS")
-	azureCloudName, err := azureAPI.GetAzureCloudName(ctx, a.rootLogger)
+	azureCloudName, err := metadata.GetAzureCloudName(ctx, a.rootLogger)
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve Azure cloud name: %w", err)
 	}
@@ -50,7 +51,7 @@ func (a *AllocatorAzure) Start(ctx context.Context, getterUpdater allocator.Cili
 	subscriptionID := a.AzureSubscriptionID
 	if subscriptionID == "" {
 		a.logger.Debug("SubscriptionID was not specified via CLI, retrieving it via Azure IMS")
-		subID, err := azureAPI.GetSubscriptionID(ctx, a.rootLogger)
+		subID, err := metadata.GetSubscriptionID(ctx, a.rootLogger)
 		if err != nil {
 			return nil, fmt.Errorf("Azure subscription ID was not specified via CLI and retrieving it from the Azure IMS was not possible: %w", err)
 		}
@@ -61,7 +62,7 @@ func (a *AllocatorAzure) Start(ctx context.Context, getterUpdater allocator.Cili
 	resourceGroupName := a.AzureResourceGroup
 	if resourceGroupName == "" {
 		a.logger.Debug("ResourceGroupName was not specified via CLI, retrieving it via Azure IMS")
-		rgName, err := azureAPI.GetResourceGroupName(ctx, a.rootLogger)
+		rgName, err := metadata.GetResourceGroupName(ctx, a.rootLogger)
 		if err != nil {
 			return nil, fmt.Errorf("Azure resource group name was not specified via CLI and retrieving it from the Azure IMS was not possible: %w", err)
 		}
@@ -69,11 +70,11 @@ func (a *AllocatorAzure) Start(ctx context.Context, getterUpdater allocator.Cili
 		a.logger.Debug("Detected resource group name via Azure IMS", logfields.Resource, resourceGroupName)
 	}
 
-	azureClient, err := azureAPI.NewClient(a.rootLogger, azureCloudName, subscriptionID, resourceGroupName, a.AzureUserAssignedIdentityID, a.AzureMetrics, a.LimitIPAMAPIQPS, a.LimitIPAMAPIBurst, a.AzureUsePrimaryAddress)
+	azureClient, err := api.NewClient(a.rootLogger, azureCloudName, subscriptionID, resourceGroupName, a.AzureUserAssignedIdentityID, a.AzureMetrics, a.LimitIPAMAPIQPS, a.LimitIPAMAPIBurst, a.AzureUsePrimaryAddress)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create Azure client: %w", err)
 	}
-	instances := azureIPAM.NewInstancesManager(a.rootLogger, azureClient, a.AzureUsePrimaryAddress)
+	instances := ipam.NewInstancesManager(a.rootLogger, azureClient, a.AzureUsePrimaryAddress)
 	nodeManager, err := nodemanager.NewNodeManager(a.logger, instances, getterUpdater, iMetrics, a.ParallelAllocWorkers, false, 0, false)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialize Azure node manager: %w", err)

--- a/pkg/azure/ipam/instances.go
+++ b/pkg/azure/ipam/instances.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/operator/pkg/ipam/nodemanager"
-	azureTypes "github.com/cilium/cilium/pkg/azure/types"
+	"github.com/cilium/cilium/pkg/azure/types"
 
 	// Register the Azure resource-ID parser. This is the canonical place
 	// for Azure-IPAM-enabled binaries to wire in pkg/azure/types' parser
@@ -158,7 +158,7 @@ func (m *InstancesManager) extractSubnetIDs(instances *ipamTypes.InstanceMap) []
 	subnetIDs := sets.New[string]()
 
 	instances.ForeachInterface("", func(instanceID, interfaceID string, iface ipamTypes.Interface) error {
-		if azIface, ok := iface.(*azureTypes.AzureInterface); ok && azIface.Subnet.ID != "" {
+		if azIface, ok := iface.(*types.AzureInterface); ok && azIface.Subnet.ID != "" {
 			subnetIDs.Insert(azIface.Subnet.ID)
 		}
 		return nil

--- a/pkg/azure/metadata/metadata.go
+++ b/pkg/azure/metadata/metadata.go
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package api
+package metadata
 
 import (
 	"context"
 	"fmt"
 	"log/slog"
 	"net/http"
-	"time"
 
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/safeio"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const (

--- a/pkg/azure/types/types_test.go
+++ b/pkg/azure/types/types_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	azuretypes "github.com/cilium/cilium/pkg/azure/types"
+	"github.com/cilium/cilium/pkg/azure/types"
 	// Register the Azure resource-ID parser so SetID()/extractIDs() populate
 	// the VMSS/VM/RG fields exercised by TestExtractIDs.
 	_ "github.com/cilium/cilium/pkg/azure/types/azureid"
@@ -40,7 +40,7 @@ func TestExtractIDs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			intf := azuretypes.AzureInterface{}
+			intf := types.AzureInterface{}
 			intf.SetID(tt.resourceID)
 
 			require.Equal(t, tt.expectedRG, intf.GetResourceGroup())


### PR DESCRIPTION
This PR is minimal as azure was already very close to the target layout. This is the same thing as #46349: converging all cloud provider packages to a common layout/structure:
```
pkg/<cloud>/
  api/          # cloud SDK client
    mock/       # where needed/applicable
  metadata/     # IMDS client
    mock/       # when a metadata mock is used
  ipam/         # ipam.NodeOperations implementation
    limits/     # per-instance-type limits
  types/        # single types package per cloud
```
