### PR TITLE
Revert "ci: Log in for image registry pulls"

### DIFF
--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -70,15 +70,6 @@ inputs:
   bgp-control-plane:
     description: 'Enable BGP Control Plane'
     default: 'false'
-  image-pull-secret:
-    description: 'Image pull secret to access Cilium images'
-    default: ''
-  registry_host:
-    description: 'Registry host for Cilium images'
-    default: 'quay.io'
-  registry_organization:
-    description: 'Registry organization for Cilium images'
-    default: 'cilium'
 outputs:
   config:
     description: 'Cilium installation config'
@@ -132,14 +123,14 @@ runs:
 
           IMAGE=""
           if [ "${{ inputs.image-tag }}" != "" ]; then
-            IMAGE="--helm-set=image.repository=${{ inputs.registry_host }}/${{ inputs.registry_organization }}/cilium-ci \
+            IMAGE="--helm-set=image.repository=${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/cilium-ci \
             --helm-set=image.useDigest=false \
             --helm-set=image.tag=${{ inputs.image-tag }} \
-            --helm-set=operator.image.repository=${{ inputs.registry_host }}/${{ inputs.registry_organization }}/operator \
+            --helm-set=operator.image.repository=${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/operator \
             --helm-set=operator.image.suffix=-ci \
             --helm-set=operator.image.tag=${{ inputs.image-tag }} \
             --helm-set=operator.image.useDigest=false \
-            --helm-set=hubble.relay.image.repository=${{ inputs.registry_host }}/${{ inputs.registry_organization }}/hubble-relay-ci \
+            --helm-set=hubble.relay.image.repository=${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/hubble-relay-ci \
             --helm-set=hubble.relay.image.tag=${{ inputs.image-tag }} \
             --helm-set=hubble.relay.image.useDigest=false"
           fi
@@ -235,12 +226,7 @@ runs:
             BGP_CONTROL_PLANE="${{ env.BGP_CONTROL_PLANE_HELM_VALUES }}"
           fi
 
-          PULL_SECRET=""
-          if [ "${{ inputs.image-pull-secret }}" != "" ]; then
-            PULL_SECRET=" --helm-set=imagePullSecrets[0].name=${{ inputs.image-pull-secret }}"
-          fi
-
-          CONFIG="${DEFAULTS} ${IMAGE} ${TUNNEL} ${DEVICES} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV4} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION} ${INGRESS_CONTROLLER} ${CILIUMENDPOINTSLICE} ${LOCAL_REDIRECT_POLICY} ${BGP_CONTROL_PLANE} ${PULL_SECRET}"
+          CONFIG="${DEFAULTS} ${IMAGE} ${TUNNEL} ${DEVICES} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV4} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION} ${INGRESS_CONTROLLER} ${CILIUMENDPOINTSLICE} ${LOCAL_REDIRECT_POLICY} ${BGP_CONTROL_PLANE}"
           echo "config=${CONFIG}" >> $GITHUB_OUTPUT
 
     - shell: bash

--- a/.github/actions/helm-default/action.yaml
+++ b/.github/actions/helm-default/action.yaml
@@ -17,16 +17,6 @@ inputs:
     description: "Enable the kube cache mutation detection"
     required: false
     default: 'false'
-  image-pull-secret:
-    description: "Whether to include the image pull secret in the generated defaults"
-    required: false
-    default: ''
-  registry_host:
-    description: 'Registry host for Cilium images'
-    default: 'quay.io'
-  registry_organization:
-    description: 'Registry organization for Cilium images'
-    default: 'cilium'
 outputs:
   cilium_install_defaults:
     description: "Generated values to be used with Cilium CLI"
@@ -47,17 +37,17 @@ runs:
         CILIUM_INSTALL_DEFAULTS="--chart-directory=${{ inputs.chart-dir }} \
           --helm-set=hubble.relay.retryTimeout=5s \
           --helm-set=debug.metricsSamplingInterval=30s \
-          --helm-set=image.repository=${{ inputs.registry_host}}/${{ inputs.registry_organization }}/cilium-ci \
+          --helm-set=image.repository=${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/cilium-ci \
           --helm-set=image.useDigest=false \
           --helm-set=image.tag=${{ inputs.image-tag }} \
-          --helm-set=operator.image.repository=${{ inputs.registry_host}}/${{ inputs.registry_organization }}/operator \
+          --helm-set=operator.image.repository=${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/operator \
           --helm-set=operator.image.suffix=-ci \
           --helm-set=operator.image.tag=${{ inputs.image-tag }} \
           --helm-set=operator.image.useDigest=false \
-          --helm-set=clustermesh.apiserver.image.repository=${{ inputs.registry_host}}/${{ inputs.registry_organization }}/clustermesh-apiserver-ci \
+          --helm-set=clustermesh.apiserver.image.repository=${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/clustermesh-apiserver-ci \
           --helm-set=clustermesh.apiserver.image.tag=${{ inputs.image-tag }} \
           --helm-set=clustermesh.apiserver.image.useDigest=false \
-          --helm-set=hubble.relay.image.repository=${{ inputs.registry_host}}/${{ inputs.registry_organization }}/hubble-relay-ci \
+          --helm-set=hubble.relay.image.repository=${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/hubble-relay-ci \
           --helm-set=hubble.relay.image.tag=${{ inputs.image-tag }} \
           --helm-set=hubble.relay.image.useDigest=false \
           --set-string=extraEnv[0].name=CILIUM_FEATURE_METRICS_WITH_DEFAULTS \
@@ -99,10 +89,6 @@ runs:
         if [ "${{ inputs.debug }}" == "true" ]; then
           CILIUM_INSTALL_DEFAULTS+=" --helm-set=debug.enabled=true \
             --helm-set=debug.verbose=envoy"
-        fi
-
-        if [ "${{ inputs.image-pull-secret }}" != "" ]; then
-          CILIUM_INSTALL_DEFAULTS+=" --helm-set=imagePullSecrets[0].name=${{ inputs.image-pull-secret }}"
         fi
 
         echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT

--- a/.github/actions/wait-for-images/action.yaml
+++ b/.github/actions/wait-for-images/action.yaml
@@ -9,30 +9,11 @@ inputs:
     description: 'list of images to wait for'
     required: false
     default: 'cilium-ci operator-generic-ci hubble-relay-ci cilium-cli-ci'
-  login-host:
-    description: 'The host to login to if login is set to true.'
-    required: false
-    default: ''
-  login-username:
-    description: 'The username to login to the registry if login is set to true.'
-    required: false
-    default: ''
-  login-password:
-    description: 'The password to login to the registry if login is set to true.'
-    required: false
-    default: ''
 runs:
   using: composite
   steps:
     - name: Set environment variables
       uses: ./.github/actions/set-env-variables
-    - name: Login to docker registry
-      if: ${{ inputs.login-host != '' && inputs.login-username != '' && inputs.login-password != '' }}
-      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-      with:
-        registry: ${{ inputs.login-host }}
-        username: ${{ inputs.login-username }}
-        password: ${{ inputs.login-password }}
     - name: Wait for images
       shell: bash
       run: |

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -197,8 +197,6 @@ jobs:
     name: Wait for images
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment:
-      name: test-with-images
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -211,9 +209,6 @@ jobs:
         with:
           SHA: ${{ inputs.SHA || github.sha }}
           images: cilium-ci operator-azure-ci hubble-relay-ci cilium-cli-ci
-          login-host: ${{ vars.DOCKER_READ_HOST }}
-          login-username: ${{ vars.DOCKER_READ_USERNAME }}
-          login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
 
   installation-and-connectivity:
     name: Installation and Connectivity Test
@@ -223,8 +218,6 @@ jobs:
     timeout-minutes: 90
     env:
       job_name: "Installation and Connectivity Test"
-    environment:
-      name: test-with-images
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
@@ -262,10 +255,7 @@ jobs:
         uses: ./.github/actions/helm-default
         with:
           image-tag: ${{ inputs.SHA || github.sha }}
-          registry_host: ${{ vars.DOCKER_READ_HOST }}
-          registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: ./untrusted/install/kubernetes/cilium
-          image-pull-secret: "cilium-registry"
 
       - name: Set up job variables
         id: vars
@@ -349,14 +339,6 @@ jobs:
         uses: ./.github/actions/get-cloud-kubeconfig
         with:
           kubeconfig: "~/.kube/config"
-
-      - name: Create imagePullSecret
-        run: |
-          kubectl create secret docker-registry cilium-registry \
-            --namespace kube-system \
-            --docker-server=${{ vars.DOCKER_READ_HOST }} \
-            --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-            --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
 
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@2c40f81b9180be6a5e52b8caf7f1de75202ec0fc # v0.19.4

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -153,8 +153,6 @@ jobs:
     name: Wait for images
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment:
-      name: test-with-images
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -166,9 +164,6 @@ jobs:
         uses: ./.github/actions/wait-for-images
         with:
           SHA: ${{ inputs.SHA || github.sha }}
-          login-host: ${{ vars.DOCKER_READ_HOST }}
-          login-username: ${{ vars.DOCKER_READ_USERNAME }}
-          login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
 
   installation-and-connectivity:
     permissions:
@@ -189,8 +184,6 @@ jobs:
     timeout-minutes: 45
     env:
       job_name: "Installation and Connectivity Test"
-    environment:
-      name: test-with-images
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
@@ -220,10 +213,7 @@ jobs:
         uses: ./.github/actions/helm-default
         with:
           image-tag: ${{ inputs.SHA || github.sha }}
-          registry_host: ${{ vars.DOCKER_READ_HOST }}
-          registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: ./untrusted/install/kubernetes/cilium
-          image-pull-secret: "cilium-registry"
 
       - name: Get connectivity test flags
         id: e2e_config
@@ -350,14 +340,6 @@ jobs:
         uses: ./.github/actions/get-cloud-kubeconfig
         with:
           kubeconfig: "~/.kube/config"
-
-      - name: Create imagePullSecret
-        run: |
-          kubectl create secret docker-registry cilium-registry \
-            --namespace kube-system \
-            --docker-server=${{ vars.DOCKER_READ_HOST }} \
-            --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-            --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
 
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@2c40f81b9180be6a5e52b8caf7f1de75202ec0fc # v0.19.4

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -91,8 +91,6 @@ jobs:
     name: Wait for images
     runs-on: ${{ vars.UBUNTU_2404_2CPU_1GB || 'ubuntu-24.04' }}
     timeout-minutes: 30
-    environment:
-      name: test-with-images
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -104,9 +102,6 @@ jobs:
         with:
           SHA: ${{ inputs.SHA || github.sha }}
           images: cilium-ci operator-generic-ci hubble-relay-ci clustermesh-apiserver-ci cilium-cli-ci
-          login-host: ${{ vars.DOCKER_READ_HOST }}
-          login-username: ${{ vars.DOCKER_READ_USERNAME }}
-          login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
 
   installation-and-connectivity:
     needs: [wait-for-images]
@@ -115,8 +110,7 @@ jobs:
     timeout-minutes: 60
     env:
       job_name: "Installation and Connectivity Test"
-    environment:
-      name: test-with-images
+
     strategy:
       fail-fast: false
       matrix:
@@ -295,9 +289,6 @@ jobs:
         with:
           image-tag: ${{ inputs.SHA || github.sha }}
           chart-dir: ./untrusted/install/kubernetes/cilium
-          registry_host: ${{ vars.DOCKER_READ_HOST }}
-          registry_organization: ${{ vars.DOCKER_READ_ORG }}
-          image-pull-secret: "cilium-registry"
 
       - name: Get connectivity test flags
         id: e2e_config
@@ -493,16 +484,6 @@ jobs:
           image-tag: ${{ steps.vars.outputs.sha }}
           repository: ${{ env.CILIUM_CLI_RELEASE_REPO }}
           release-version: ${{ env.CILIUM_CLI_VERSION }}
-
-      - name: Create imagePullSecrets
-        run: |
-          for ctx in ${{ env.contextName1 }} ${{ env.contextName2 }}; do
-             kubectl --context $ctx create secret docker-registry cilium-registry \
-              --namespace kube-system \
-              --docker-server=${{ vars.DOCKER_READ_HOST }} \
-              --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-              --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
-          done
 
       - name: Label one of the nodes as external to the cluster
         run: |

--- a/.github/workflows/conformance-delegated-ipam.yaml
+++ b/.github/workflows/conformance-delegated-ipam.yaml
@@ -85,8 +85,6 @@ jobs:
     name: Install and Connectivity Test
     env:
       job_name: "Install and Connectivity Test"
-    environment:
-      name: test-with-images
     runs-on: ubuntu-24.04
     timeout-minutes: 120
     strategy:
@@ -118,10 +116,7 @@ jobs:
         uses: ./.github/actions/helm-default
         with:
           image-tag: ${{ inputs.SHA || github.sha }}
-          registry_host: ${{ vars.DOCKER_READ_HOST }}
-          registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: ./untrusted/install/kubernetes/cilium
-          image-pull-secret: "cilium-registry"
 
       - name: Get connectivity test flags
         id: e2e_config
@@ -289,27 +284,12 @@ jobs:
           repository: ${{ env.CILIUM_CLI_RELEASE_REPO }}
           release-version: ${{ env.CILIUM_CLI_VERSION }}
 
-      - name: Create imagePullSecret
-        run: |
-          kubectl create secret docker-registry cilium-registry \
-            --namespace kube-system \
-            --docker-server=${{ vars.DOCKER_READ_HOST }} \
-            --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-            --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
-
-      - name: Login to docker registry for image wait
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ vars.DOCKER_READ_HOST}}
-          username: ${{ vars.DOCKER_READ_USERNAME}}
-          password: ${{ secrets.DOCKER_READ_PASSWORD }}
-
       - name: Wait for images to be available
         timeout-minutes: 30
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci; do
-            until docker manifest inspect ${{ vars.DOCKER_READ_HOST }}/${{ vars.DOCKER_READ_ORG }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
+            until docker manifest inspect ${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
           done
 
       - name: Wait for nodes to become ready

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -40,6 +40,9 @@ on:
         required: false
         type: number
         default: 3
+    secrets:
+      AWS_PR_ASSUME_ROLE:
+        required: true
 
   workflow_dispatch:
     inputs:
@@ -138,8 +141,6 @@ jobs:
     name: Wait for images
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment:
-      name: test-with-images
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -152,9 +153,6 @@ jobs:
         with:
           SHA: ${{ inputs.SHA || github.sha }}
           images: cilium-ci operator-aws-ci hubble-relay-ci cilium-cli-ci
-          login-host: ${{ vars.DOCKER_READ_HOST }}
-          login-username: ${{ vars.DOCKER_READ_USERNAME }}
-          login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
 
   generate-matrix:
     name: Generate Matrix
@@ -260,8 +258,6 @@ jobs:
     timeout-minutes: 90
     env:
       job_name: "Installation and Connectivity Test"
-    environment:
-      name: test-with-images
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
@@ -294,10 +290,7 @@ jobs:
         uses: ./.github/actions/helm-default
         with:
           image-tag: ${{ inputs.SHA || github.sha }}
-          registry_host: ${{ vars.DOCKER_READ_HOST }}
-          registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: ./untrusted/install/kubernetes/cilium
-          image-pull-secret: "cilium-registry"
 
       - name: Get connectivity test flags
         id: e2e_config
@@ -421,14 +414,6 @@ jobs:
         uses: ./.github/actions/get-cloud-kubeconfig
         with:
           kubeconfig: "~/.kube/config"
-
-      - name: Create imagePullSecret
-        run: |
-          kubectl create secret docker-registry cilium-registry \
-            --namespace kube-system \
-            --docker-server=${{ vars.DOCKER_READ_HOST }} \
-            --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-            --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
 
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@2c40f81b9180be6a5e52b8caf7f1de75202ec0fc # v0.19.4

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -92,8 +92,6 @@ jobs:
     name: Wait for images
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment:
-      name: test-with-images
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -106,9 +104,6 @@ jobs:
         with:
           SHA: ${{ inputs.SHA || github.sha }}
           images: cilium-ci operator-generic-ci
-          login-host: ${{ vars.DOCKER_READ_HOST }}
-          login-username: ${{ vars.DOCKER_READ_USERNAME }}
-          login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
 
   generate-matrix:
     name: Generate Matrix
@@ -158,8 +153,6 @@ jobs:
     name: Gateway API Conformance Test
     env:
       job_name: "Gateway API Conformance Test"
-    environment:
-      name: test-with-images
     needs: [generate-matrix, wait-for-images]
     runs-on: ubuntu-24.04
     timeout-minutes: 120
@@ -194,10 +187,7 @@ jobs:
         uses: ./.github/actions/helm-default
         with:
           image-tag: ${{ inputs.SHA || github.sha }}
-          registry_host: ${{ vars.DOCKER_READ_HOST }}
-          registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: ./untrusted/install/kubernetes/cilium
-          image-pull-secret: "cilium-registry"
 
       - name: Set image tag
         id: vars
@@ -242,14 +232,6 @@ jobs:
           kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.kind_config }}
           wait: 0 # The control-plane never becomes ready, since no CNI is present
-
-      - name: Create imagePullSecret
-        run: |
-          kubectl create secret docker-registry cilium-registry \
-            --namespace kube-system \
-            --docker-server=${{ vars.DOCKER_READ_HOST }} \
-            --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-            --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
 
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@2c40f81b9180be6a5e52b8caf7f1de75202ec0fc # v0.19.4

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -211,8 +211,6 @@ jobs:
     runs-on: ubuntu-24.04
     name: Wait for images
     timeout-minutes: 30
-    environment:
-      name: test-with-images
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -227,9 +225,6 @@ jobs:
         uses: ./.github/actions/wait-for-images
         with:
           SHA: ${{ inputs.SHA || github.sha }}${{ needs.setup-vars.outputs.image_tag_suffix }}
-          login-host: ${{ vars.DOCKER_READ_HOST }}
-          login-username: ${{ vars.DOCKER_READ_USERNAME }}
-          login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
 
   generate-matrix:
     name: Generate Job Matrix from YAMLs

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -269,8 +269,6 @@ jobs:
     name: Wait for images
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment:
-      name: test-with-images
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -283,9 +281,6 @@ jobs:
         with:
           SHA: ${{ inputs.SHA || github.sha }}
           images: cilium-ci operator-generic-ci hubble-relay-ci
-          login-host: ${{ vars.DOCKER_READ_HOST }}
-          login-username: ${{ vars.DOCKER_READ_USERNAME }}
-          login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
 
   installation-and-connectivity:
     name: Installation and Connectivity Test
@@ -295,8 +290,6 @@ jobs:
     timeout-minutes: 75
     env:
       job_name: "Installation and Connectivity Test"
-    environment:
-      name: test-with-images
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
@@ -326,10 +319,7 @@ jobs:
         uses: ./.github/actions/helm-default
         with:
           image-tag: ${{ inputs.SHA || github.sha }}
-          registry_host: ${{ vars.DOCKER_READ_HOST }}
-          registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: ./untrusted/install/kubernetes/cilium
-          image-pull-secret: "cilium-registry"
 
       - name: Truncate owner label for GKE
         id: truncate-owner
@@ -428,14 +418,6 @@ jobs:
         uses: ./.github/actions/get-cloud-kubeconfig
         with:
           kubeconfig: "~/.kube/config"
-
-      - name: Create imagePullSecret
-        run: |
-          kubectl create secret docker-registry cilium-registry \
-            --namespace kube-system \
-            --docker-server=${{ vars.DOCKER_READ_HOST }} \
-            --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-            --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
 
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@2c40f81b9180be6a5e52b8caf7f1de75202ec0fc # v0.19.4

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -86,8 +86,6 @@ jobs:
     name: Wait for images
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment:
-      name: test-with-images
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -100,16 +98,11 @@ jobs:
         with:
           SHA: ${{ inputs.SHA || github.sha }}
           images: cilium-ci operator-generic-ci
-          login-host: ${{ vars.DOCKER_READ_HOST }}
-          login-username: ${{ vars.DOCKER_READ_USERNAME }}
-          login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
 
   ingress-conformance-test:
     name: Ingress Conformance Test
     env:
       job_name: "Ingress Conformance Test"
-    environment:
-      name: test-with-images
     needs: [wait-for-images]
     runs-on: ubuntu-24.04
     timeout-minutes: 120
@@ -163,10 +156,7 @@ jobs:
         uses: ./.github/actions/helm-default
         with:
           image-tag: ${{ inputs.SHA || github.sha }}
-          registry_host: ${{ vars.DOCKER_READ_HOST }}
-          registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: ./untrusted/install/kubernetes/cilium
-          image-pull-secret: "cilium-registry"
 
       - name: Set image tag
         id: vars
@@ -203,14 +193,6 @@ jobs:
           kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ${{ env.kind_config }}
           wait: 0 # The control-plane never becomes ready, since no CNI is present
-
-      - name: Create imagePullSecret
-        run: |
-          kubectl create secret docker-registry cilium-registry \
-            --namespace kube-system \
-            --docker-server=${{ vars.DOCKER_READ_HOST }} \
-            --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-            --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
 
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@2c40f81b9180be6a5e52b8caf7f1de75202ec0fc # v0.19.4

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -109,8 +109,6 @@ jobs:
     name: Wait for images
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment:
-      name: test-with-images
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -121,9 +119,6 @@ jobs:
         uses: ./.github/actions/wait-for-images
         with:
           SHA: ${{ inputs.SHA || github.sha }}
-          login-host: ${{ vars.DOCKER_READ_HOST }}
-          login-username: ${{ vars.DOCKER_READ_USERNAME }}
-          login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
 
   setup-and-test:
     needs: [wait-for-images, generate-matrix]
@@ -131,8 +126,6 @@ jobs:
     runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
     env:
       job_name: 'Setup & Test'
-    environment:
-      name: test-with-images
     strategy:
       fail-fast: false
       max-parallel: 100
@@ -190,8 +183,6 @@ jobs:
         uses: ./.github/actions/cilium-config
         with:
           image-tag: ${{ steps.vars.outputs.sha }}
-          registry_host: ${{ vars.DOCKER_READ_HOST }}
-          registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: './untrusted/install/kubernetes/cilium'
           tunnel: ${{ matrix.tunnel }}
           devices: ${{ matrix.devices }}
@@ -209,7 +200,6 @@ jobs:
           ingress-controller: ${{ matrix.ingress-controller }}
           mutual-auth: false
           misc: ${{ matrix.misc }}
-          image-pull-secret: "cilium-registry"
 
       - name: Set Kind params
         if: ${{ steps.cilium-config.outputs.skip != 'true' }}
@@ -234,14 +224,6 @@ jobs:
           kernel: ${{ steps.kernel-version.outputs.full }}
           kind-params: "${{ steps.kind-params.outputs.params }}"
           kind-image: ${{ env.KIND_K8S_IMAGE }}
-
-      - name: Create imagePullSecret
-        run: |
-          kubectl create secret docker-registry cilium-registry \
-            --namespace kube-system \
-            --docker-server=${{ vars.DOCKER_READ_HOST }} \
-            --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-            --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
 
       - name: Set up job variables for connectivity tests
         if: ${{ steps.cilium-config.outputs.skip != 'true' }}

--- a/.github/workflows/conformance-ipsec.yaml
+++ b/.github/workflows/conformance-ipsec.yaml
@@ -83,8 +83,6 @@ jobs:
     name: Wait for images
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment:
-      name: test-with-images
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -97,9 +95,6 @@ jobs:
         with:
           SHA: ${{ inputs.SHA || github.sha }}
           images: cilium-ci operator-generic-ci hubble-relay-ci
-          login-host: ${{ vars.DOCKER_READ_HOST }}
-          login-username: ${{ vars.DOCKER_READ_USERNAME }}
-          login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
 
   conformance-aks-ipsec:
     name: Conformance AKS with IPsec

--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -30,8 +30,6 @@ jobs:
     timeout-minutes: 60
     env:
       job_name: "Installation and Connectivity Test"
-    environment:
-      name: test-with-images
     steps:
       - name: Collect Workflow Telemetry
         uses: cilium/workflow-telemetry-action@b1a318f80a08acede58027afe1455d037379966f # v2.2.0
@@ -51,9 +49,6 @@ jobs:
         uses: ./.github/actions/helm-default
         with:
           image-tag: ${{ github.event.pull_request.head.sha || github.sha }}
-          registry_host: ${{ vars.DOCKER_READ_HOST }}
-          registry_organization: ${{ vars.DOCKER_READ_ORG }}
-          image-pull-secret: "cilium-registry"
 
       - name: Add external docker network
         uses: ./.github/actions/kind-external-network
@@ -126,27 +121,12 @@ jobs:
           repository: ${{ env.CILIUM_CLI_RELEASE_REPO }}
           release-version: ${{ env.CILIUM_CLI_VERSION }}
 
-      - name: Create imagePullSecret
-        run: |
-          kubectl create secret docker-registry cilium-registry \
-            --namespace kube-system \
-            --docker-server=${{ vars.DOCKER_READ_HOST }} \
-            --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-            --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
-
-      - name: Login to docker registry for image wait
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ vars.DOCKER_READ_HOST}}
-          username: ${{ vars.DOCKER_READ_USERNAME}}
-          password: ${{ secrets.DOCKER_READ_PASSWORD }}
-
       - name: Wait for images to be available
         timeout-minutes: 30
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until docker manifest inspect ${{ vars.DOCKER_READ_HOST }}/${{ vars.DOCKER_READ_ORG }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
+            until docker manifest inspect ${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium

--- a/.github/workflows/conformance-kpr-aks.yaml
+++ b/.github/workflows/conformance-kpr-aks.yaml
@@ -83,8 +83,6 @@ jobs:
     name: Wait for images
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment:
-      name: test-with-images
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -97,9 +95,6 @@ jobs:
         with:
           SHA: ${{ inputs.SHA || github.sha }}
           images: cilium-ci operator-generic-ci hubble-relay-ci
-          login-host: ${{ vars.DOCKER_READ_HOST }}
-          login-username: ${{ vars.DOCKER_READ_USERNAME }}
-          login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
 
   conformance-aks-kpr:
     name: Conformance AKS with KPR

--- a/.github/workflows/conformance-kpr-eks.yaml
+++ b/.github/workflows/conformance-kpr-eks.yaml
@@ -83,8 +83,6 @@ jobs:
     name: Wait for images
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment:
-      name: test-with-images
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -97,9 +95,6 @@ jobs:
         with:
           SHA: ${{ inputs.SHA || github.sha }}
           images: cilium-ci operator-generic-ci hubble-relay-ci
-          login-host: ${{ vars.DOCKER_READ_HOST }}
-          login-username: ${{ vars.DOCKER_READ_USERNAME }}
-          login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
 
   conformance-eks-kpr:
     name: Conformance EKS with KPR

--- a/.github/workflows/conformance-kpr-gke.yaml
+++ b/.github/workflows/conformance-kpr-gke.yaml
@@ -83,8 +83,6 @@ jobs:
     name: Wait for images
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment:
-      name: test-with-images
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -97,9 +95,6 @@ jobs:
         with:
           SHA: ${{ inputs.SHA || github.sha }}
           images: cilium-ci operator-generic-ci hubble-relay-ci
-          login-host: ${{ vars.DOCKER_READ_HOST }}
-          login-username: ${{ vars.DOCKER_READ_USERNAME }}
-          login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
 
   conformance-gke-kpr:
     name: Conformance GKE with KPR

--- a/.github/workflows/conformance-kubespray.yaml
+++ b/.github/workflows/conformance-kubespray.yaml
@@ -85,8 +85,6 @@ jobs:
           sha: ${{ inputs.SHA || github.event.pull_request.head.sha || github.sha }}
 
   wait-for-images:
-    environment:
-      name: test-with-images
     name: Wait for images
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -102,9 +100,6 @@ jobs:
         with:
           SHA: ${{ inputs.SHA || github.event.pull_request.head.sha || github.sha }}
           images: cilium-ci operator-generic-ci
-          login-host: ${{ vars.DOCKER_READ_HOST }}
-          login-username: ${{ vars.DOCKER_READ_USERNAME }}
-          login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
 
   installation-and-connectivity:
     name: Installation and Connectivity Test
@@ -113,8 +108,6 @@ jobs:
     timeout-minutes: 60
     env:
       job_name: "Installation and Connectivity Test"
-    environment:
-      name: test-with-images
     steps:
       - name: Set commit status to pending
         uses: cilium/cilium/.github/actions/set-commit-status@main # main
@@ -135,10 +128,7 @@ jobs:
         uses: ./.github/actions/helm-default
         with:
           image-tag: ${{ inputs.SHA || github.event.pull_request.head.sha || github.sha }}
-          registry_host: ${{ vars.DOCKER_READ_HOST }}
-          registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: ./untrusted/install/kubernetes/cilium
-          image-pull-secret: "cilium-registry"
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -197,14 +187,6 @@ jobs:
           sudo chown "$(id -u)":"$(id -g)" $HOME/.kube/config
 
           kubectl wait --for=condition=Ready pods --all -n kube-system --timeout=300s
-
-      - name: Create imagePullSecret
-        run: |
-          kubectl create secret docker-registry cilium-registry \
-            --namespace kube-system \
-            --docker-server=${{ vars.DOCKER_READ_HOST }} \
-            --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-            --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
 
       - name: Get connectivity test flags
         id: e2e_config

--- a/.github/workflows/conformance-l3-l4.yaml
+++ b/.github/workflows/conformance-l3-l4.yaml
@@ -84,8 +84,6 @@ jobs:
     name: Wait for images
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment:
-      name: test-with-images
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -97,9 +95,6 @@ jobs:
         uses: ./.github/actions/wait-for-images
         with:
           SHA: ${{ inputs.SHA || github.sha }}
-          login-host: ${{ vars.DOCKER_READ_HOST }}
-          login-username: ${{ vars.DOCKER_READ_USERNAME }}
-          login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
 
   tests-e2e-upgrade:
     name: E2E Upgrade with L3-L4 Tests
@@ -123,3 +118,4 @@ jobs:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
       success: ${{ needs.tests-e2e-upgrade.result == 'success' }}
+

--- a/.github/workflows/conformance-l7.yaml
+++ b/.github/workflows/conformance-l7.yaml
@@ -84,8 +84,6 @@ jobs:
     name: Wait for images
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment:
-      name: test-with-images
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -97,9 +95,6 @@ jobs:
         uses: ./.github/actions/wait-for-images
         with:
           SHA: ${{ inputs.SHA || github.sha }}
-          login-host: ${{ vars.DOCKER_READ_HOST }}
-          login-username: ${{ vars.DOCKER_READ_USERNAME }}
-          login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
 
   tests-e2e-upgrade:
     name: E2E Upgrade with L7 Tests
@@ -124,3 +119,4 @@ jobs:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
       success: ${{ needs.tests-e2e-upgrade.result == 'success' }}
+

--- a/.github/workflows/conformance-mcs-api.yaml
+++ b/.github/workflows/conformance-mcs-api.yaml
@@ -86,8 +86,6 @@ jobs:
     name: Wait for images
     runs-on: ${{ vars.UBUNTU_2404_2CPU_1GB || 'ubuntu-24.04' }}
     timeout-minutes: 30
-    environment:
-      name: test-with-images
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -100,14 +98,9 @@ jobs:
         with:
           SHA: ${{ inputs.SHA || github.sha }}
           images: cilium-ci operator-generic-ci clustermesh-apiserver-ci cilium-cli-ci
-          login-host: ${{ vars.DOCKER_READ_HOST }}
-          login-username: ${{ vars.DOCKER_READ_USERNAME }}
-          login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
 
   mcs-api-conformance-test:
     name: MCS API Conformance Test
-    environment:
-      name: test-with-images
     env:
       job_name: "MCS API Conformance Test"
     needs: [wait-for-images]
@@ -143,10 +136,7 @@ jobs:
         uses: ./.github/actions/helm-default
         with:
           image-tag: ${{ inputs.SHA || github.sha }}
-          registry_host: ${{ vars.DOCKER_READ_HOST }}
-          registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: ./untrusted/install/kubernetes/cilium
-          image-pull-secret: "cilium-registry"
 
       - name: Set up job variables for GHA environment
         id: vars
@@ -208,16 +198,6 @@ jobs:
           kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ./.github/kind-config-cluster2.yaml
           wait: 0 # The control-plane never becomes ready, since no CNI is present
-
-      - name: Create imagePullSecrets
-        run: |
-          for context in ${{ env.contextName1 }} ${{ env.contextName2 }}; do
-            kubectl --context $context create secret docker-registry cilium-registry \
-              --namespace kube-system \
-              --docker-server=${{ vars.DOCKER_READ_HOST }} \
-              --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-              --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
-          done
 
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@2c40f81b9180be6a5e52b8caf7f1de75202ec0fc # v0.19.4

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -85,8 +85,6 @@ jobs:
     name: Wait for images
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment:
-      name: test-with-images
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -98,9 +96,6 @@ jobs:
         uses: ./.github/actions/wait-for-images
         with:
           SHA: ${{ inputs.SHA || github.sha }}
-          login-host: ${{ vars.DOCKER_READ_HOST }}
-          login-username: ${{ vars.DOCKER_READ_USERNAME }}
-          login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
 
   generate-matrix:
     name: Generate Matrix
@@ -140,8 +135,6 @@ jobs:
     name: Install and Connectivity Test
     env:
       job_name: "Install and Connectivity Test"
-    environment:
-      name: test-with-images
     runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
     timeout-minutes: 120
     steps:
@@ -169,10 +162,7 @@ jobs:
         uses: ./.github/actions/helm-default
         with:
           image-tag: ${{ inputs.SHA || github.sha }}
-          registry_host: ${{ vars.DOCKER_READ_HOST }}
-          registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: ./untrusted/install/kubernetes/cilium
-          image-pull-secret: "cilium-registry"
 
       - name: Get connectivity test flags
         id: e2e_config
@@ -288,14 +278,6 @@ jobs:
           kubectl_version: ${{ env.KIND_K8S_VERSION }}
           config: ./.github/kind-config-multi-pool.yaml
           wait: 0 # The control-plane never becomes ready, since no CNI is present
-
-      - name: Create imagePullSecret
-        run: |
-          kubectl create secret docker-registry cilium-registry \
-            --namespace kube-system \
-            --docker-server=${{ vars.DOCKER_READ_HOST }} \
-            --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-            --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
 
       - name: Start Cilium KVStore
         id: kvstore

--- a/.github/workflows/conformance-ztunnel-e2e.yaml
+++ b/.github/workflows/conformance-ztunnel-e2e.yaml
@@ -73,8 +73,6 @@ jobs:
     name: Wait for images
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment:
-      name: test-with-images
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -85,9 +83,6 @@ jobs:
         uses: ./.github/actions/wait-for-images
         with:
           SHA: ${{ inputs.SHA || github.sha }}
-          login-host: ${{ vars.DOCKER_READ_HOST }}
-          login-username: ${{ vars.DOCKER_READ_USERNAME }}
-          login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
 
   setup-and-test:
     needs: [wait-for-images]
@@ -95,8 +90,6 @@ jobs:
     runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
     env:
       job_name: 'Setup & Test'
-    environment:
-      name: test-with-images
     strategy:
       fail-fast: false
       matrix:
@@ -157,14 +150,11 @@ jobs:
         uses: ./.github/actions/cilium-config
         with:
           image-tag: ${{ steps.vars.outputs.sha }}
-          registry_host: ${{ vars.DOCKER_READ_HOST }}
-          registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: './untrusted/install/kubernetes/cilium'
           tunnel: ${{ matrix.tunnel }}
           kpr: ${{ matrix.kpr }}
           encryption: 'ztunnel'
           mutual-auth: false
-          image-pull-secret: "cilium-registry"
 
       - name: Set Kind params
         if: ${{ steps.cilium-config.outputs.skip != 'true' }}
@@ -182,14 +172,6 @@ jobs:
           kernel: ${{ steps.kernel-version.outputs.full }}
           kind-params: "${{ steps.kind-params.outputs.params }}"
           kind-image: ${{ env.KIND_K8S_IMAGE }}
-
-      - name: Create imagePullSecret
-        run: |
-          kubectl create secret docker-registry cilium-registry \
-            --namespace kube-system \
-            --docker-server=${{ vars.DOCKER_READ_HOST }} \
-            --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-            --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
 
       - name: Install Cilium CLI
         if: ${{ steps.cilium-config.outputs.skip != 'true' }}

--- a/.github/workflows/fqdn-perf.yaml
+++ b/.github/workflows/fqdn-perf.yaml
@@ -88,8 +88,6 @@ jobs:
     timeout-minutes: 60
     env:
       job_name: "Install and FQDN Perf Test"
-    environment:
-      name: test-with-images
     steps:
       - name: Set commit status to pending
         uses: cilium/cilium/.github/actions/set-commit-status@main # main
@@ -124,17 +122,17 @@ jobs:
           # only add SHA to the image tags if it was set
           if [ -n "${SHA}" ]; then
             echo sha=${SHA} >> $GITHUB_OUTPUT
-            CILIUM_INSTALL_DEFAULTS+=" --helm-set=image.repository=${{ vars.DOCKER_READ_HOST }}/${{ vars.DOCKER_READ_ORG }}/cilium-ci \
+            CILIUM_INSTALL_DEFAULTS+=" --helm-set=image.repository=${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/cilium-ci \
             --helm-set=image.useDigest=false \
             --helm-set=image.tag=${SHA} \
-            --helm-set=operator.image.repository=${{ vars.DOCKER_READ_HOST }}/${{ vars.DOCKER_READ_ORG }}/operator \
+            --helm-set=operator.image.repository=${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/operator \
             --helm-set=operator.image.suffix=-ci \
             --helm-set=operator.image.tag=${SHA} \
             --helm-set=operator.image.useDigest=false \
-            --helm-set=clustermesh.apiserver.image.repository=${{ vars.DOCKER_READ_HOST }}/${{ vars.DOCKER_READ_ORG }}/clustermesh-apiserver-ci \
+            --helm-set=clustermesh.apiserver.image.repository=${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/clustermesh-apiserver-ci \
             --helm-set=clustermesh.apiserver.image.tag=${SHA} \
             --helm-set=clustermesh.apiserver.image.useDigest=false \
-            --helm-set=hubble.relay.image.repository=${{ vars.DOCKER_READ_HOST }}/${{ vars.DOCKER_READ_ORG }}/hubble-relay-ci \
+            --helm-set=hubble.relay.image.repository=${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/hubble-relay-ci \
             --helm-set=hubble.relay.image.tag=${SHA} \
             --helm-set=hubble.relay.image.useDigest=false"
           fi
@@ -147,19 +145,12 @@ jobs:
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
           echo CLUSTER_NAME=${CLUSTER_NAME} >> $GITHUB_OUTPUT
 
-      - name: Login to docker registry for image wait
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ vars.DOCKER_READ_HOST}}
-          username: ${{ vars.DOCKER_READ_USERNAME}}
-          password: ${{ secrets.DOCKER_READ_PASSWORD }}
-
       - name: Wait for images to be available
         timeout-minutes: 30
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until docker manifest inspect ${{ vars.DOCKER_READ_HOST }}/${{ vars.DOCKER_READ_ORG }}/$image:${{ steps.vars.outputs.SHA }} &> /dev/null; do sleep 45s; done
+            until docker manifest inspect ${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.SHA }} &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Go
@@ -212,14 +203,6 @@ jobs:
           kops_state: ${{ secrets.GCP_PERF_KOPS_STATE_STORE }}
           project_id: ${{ secrets.GCP_PERF_PROJECT_ID }}
 
-      - name: Create imagePullSecret
-        run: |
-          kubectl create secret docker-registry cilium-registry \
-            --namespace kube-system \
-            --docker-server=${{ vars.DOCKER_READ_HOST }} \
-            --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-            --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
-
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@2c40f81b9180be6a5e52b8caf7f1de75202ec0fc # v0.19.4
         with:
@@ -248,7 +231,7 @@ jobs:
       - name: Install Cilium
         id: install-cilium
         run: |
-          cilium install ${{ steps.vars.outputs.cilium_install_defaults }} --helm-set=imagePullSecrets[0].name=cilium-registry
+          cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
 
       - name: Wait for cluster to be ready
         uses: cilium/scale-tests-action/validate-cluster@995a08156171644e92e5688b0785b7baf86ce22a # main

--- a/.github/workflows/hubble-cli-integration-test.yaml
+++ b/.github/workflows/hubble-cli-integration-test.yaml
@@ -78,8 +78,6 @@ jobs:
       statuses: write
     env:
       job_name: "Integration Test"
-    environment:
-      name: test-with-images
     name: Hubble CLI Integration Test
     timeout-minutes: 20
     steps:
@@ -107,10 +105,7 @@ jobs:
         uses: ./.github/actions/helm-default
         with:
           image-tag: ${{ inputs.SHA || github.sha }}
-          registry_host: ${{ vars.DOCKER_READ_HOST }}
-          registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: ./untrusted/install/kubernetes/cilium
-          image-pull-secret: "cilium-registry"
 
       - name: Set image tag
         id: vars
@@ -156,27 +151,12 @@ jobs:
           config: ${{ env.KIND_CONFIG }}
           wait: 0 # The control-plane never becomes ready, since no CNI is present
 
-      - name: Create imagePullSecret
-        run: |
-          kubectl create secret docker-registry cilium-registry \
-            --namespace kube-system \
-            --docker-server=${{ vars.DOCKER_READ_HOST }} \
-            --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-            --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
-
-      - name: Login to docker registry for image wait
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ vars.DOCKER_READ_HOST}}
-          username: ${{ vars.DOCKER_READ_USERNAME}}
-          password: ${{ secrets.DOCKER_READ_PASSWORD }}
-
       - name: Wait for images to be available
         timeout-minutes: 30
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until docker manifest inspect ${{ vars.DOCKER_READ_HOST }}/${{ vars.DOCKER_READ_ORG }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
+            until docker manifest inspect ${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium CLI

--- a/.github/workflows/k8s-kind-network-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-e2e.yaml
@@ -55,8 +55,6 @@ jobs:
     env:
       IP_FAMILY: ${{ matrix.ipFamily }}
       job_name: "Installation and Conformance Test"
-    environment:
-      name: test-with-images
 
     steps:
       - name: Collect Workflow Telemetry
@@ -149,9 +147,6 @@ jobs:
         uses: ./.github/actions/helm-default
         with:
           image-tag: ${{ github.event.pull_request.head.sha || github.sha }}
-          registry_host: ${{ vars.DOCKER_READ_HOST }}
-          registry_organization: ${{ vars.DOCKER_READ_ORG }}
-          image-pull-secret: "cilium-registry"
 
       - name: Set up job variables
         id: vars
@@ -176,27 +171,12 @@ jobs:
           repository: ${{ env.CILIUM_CLI_RELEASE_REPO }}
           release-version: ${{ env.CILIUM_CLI_VERSION }}
 
-      - name: Create imagePullSecret
-        run: |
-          kubectl create secret docker-registry cilium-registry \
-            --namespace kube-system \
-            --docker-server=${{ vars.DOCKER_READ_HOST }} \
-            --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-            --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
-
-      - name: Login to docker registry for image wait
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ vars.DOCKER_READ_HOST}}
-          username: ${{ vars.DOCKER_READ_USERNAME}}
-          password: ${{ secrets.DOCKER_READ_PASSWORD }}
-
       - name: Wait for images to be available
         timeout-minutes: 30
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until docker manifest inspect ${{ vars.DOCKER_READ_HOST }}/${{ vars.DOCKER_READ_ORG }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
+            until docker manifest inspect ${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium

--- a/.github/workflows/k8s-kind-network-policies-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-policies-e2e.yaml
@@ -39,8 +39,6 @@ jobs:
     env:
       IP_FAMILY: ${{ matrix.ipFamily }}
       job_name: "K8s network policy tests"
-    environment:
-      name: test-with-images
 
     steps:
       - name: Collect Workflow Telemetry
@@ -132,9 +130,6 @@ jobs:
         uses: ./.github/actions/helm-default
         with:
           image-tag: ${{ github.event.pull_request.head.sha || github.sha }}
-          registry_host: ${{ vars.DOCKER_READ_HOST }}
-          registry_organization: ${{ vars.DOCKER_READ_ORG }}
-          image-pull-secret: "cilium-registry"
 
       - name: Set up job variables
         id: vars
@@ -158,27 +153,12 @@ jobs:
           repository: ${{ env.CILIUM_CLI_RELEASE_REPO }}
           release-version: ${{ env.CILIUM_CLI_VERSION }}
 
-      - name: Create imagePullSecret
-        run: |
-          kubectl create secret docker-registry cilium-registry \
-            --namespace kube-system \
-            --docker-server=${{ vars.DOCKER_READ_HOST }} \
-            --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-            --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
-
-      - name: Login to docker registry for image wait
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ vars.DOCKER_READ_HOST}}
-          username: ${{ vars.DOCKER_READ_USERNAME}}
-          password: ${{ secrets.DOCKER_READ_PASSWORD }}
-
       - name: Wait for images to be available
         timeout-minutes: 30
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until docker manifest inspect ${{ vars.DOCKER_READ_HOST }}/${{ vars.DOCKER_READ_ORG }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
+            until docker manifest inspect ${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium

--- a/.github/workflows/l7-perf.yaml
+++ b/.github/workflows/l7-perf.yaml
@@ -107,8 +107,6 @@ jobs:
     runs-on: ubuntu-24.04
     name: Install and Perf Test
     timeout-minutes: 60
-    environment:
-      name: test-with-images
     strategy:
       fail-fast: false
       matrix:
@@ -168,8 +166,8 @@ jobs:
           if [ -z "${VERSION}" ]; then
             CILIUM_INSTALL_DEFAULTS="--chart-directory=untrusted/install/kubernetes/cilium \
               ${CILIUM_INSTALL_DEFAULTS} \
-              --set=image.override=${{ vars.DOCKER_READ_HOST }}/${{ vars.DOCKER_READ_ORG }}/cilium-ci:${SHA} \
-              --set=operator.image.override=${{ vars.DOCKER_READ_HOST }}/${{ vars.DOCKER_READ_ORG }}/operator-aws-ci:${SHA}"
+              --set=image.override=${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/cilium-ci:${SHA} \
+              --set=operator.image.override=${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/operator-aws-ci:${SHA}"
           else
             CILIUM_INSTALL_DEFAULTS="--version ${VERSION} ${CILIUM_INSTALL_DEFAULTS}"
           fi
@@ -230,9 +228,6 @@ jobs:
         with:
           SHA: ${{ steps.vars.outputs.SHA }}
           images: cilium-ci operator-aws-ci cilium-cli-ci
-          login-host: ${{ vars.DOCKER_READ_HOST }}
-          login-username: ${{ vars.DOCKER_READ_USERNAME }}
-          login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
 
       - name: Wait for Nighthawk Benchmarking framework image
         shell: bash
@@ -324,14 +319,6 @@ jobs:
         with:
           kubeconfig: "~/.kube/config"
 
-      - name: Create imagePullSecret
-        run: |
-          kubectl create secret docker-registry cilium-registry \
-            --namespace kube-system \
-            --docker-server=${{ vars.DOCKER_READ_HOST }} \
-            --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-            --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
-
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@2c40f81b9180be6a5e52b8caf7f1de75202ec0fc # v0.19.4
         with:
@@ -362,7 +349,6 @@ jobs:
 
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }} \
             --set=k8sServiceHost="${K8S_API_SRV_ADDR}" --set=k8sServicePort=443 \
-            --helm-set=imagePullSecrets[0].name=cilium-registry \
             --set=ipv4NativeRoutingCIDR="${NATIVE_CIDR_BLOCK}"
 
       - name: Delete context ref

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -92,8 +92,6 @@ jobs:
     name: Wait for images
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment:
-      name: test-with-images
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -105,9 +103,6 @@ jobs:
         uses: ./.github/actions/wait-for-images
         with:
           SHA: ${{ inputs.SHA || github.sha }}
-          login-host: ${{ vars.DOCKER_READ_HOST }}
-          login-username: ${{ vars.DOCKER_READ_USERNAME }}
-          login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
 
   installation-and-perf:
     name: Installation and Perf Test
@@ -116,8 +111,6 @@ jobs:
     timeout-minutes: 60
     env:
       job_name: "Installation and Perf Test"
-    environment:
-      name: test-with-images
     strategy:
       fail-fast: false
       matrix:
@@ -182,11 +175,8 @@ jobs:
         uses: ./.github/actions/helm-default
         with:
           image-tag: ${{ inputs.SHA || github.sha }}
-          registry_host: ${{ vars.DOCKER_READ_HOST }}
-          registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: ./install/kubernetes/cilium
           debug: false
-          image-pull-secret: "cilium-registry"
 
       - name: Truncate owner label for GKE
         id: truncate-owner
@@ -273,15 +263,6 @@ jobs:
         uses: ./.github/actions/get-cloud-kubeconfig
         with:
           kubeconfig: "~/.kube/config"
-
-      - name: Create imagePullSecret
-        if: ${{ matrix.mode != 'baseline' }}
-        run: |
-          kubectl create secret docker-registry cilium-registry \
-            --namespace kube-system \
-            --docker-server=${{ vars.DOCKER_READ_HOST }} \
-            --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-            --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
 
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@2c40f81b9180be6a5e52b8caf7f1de75202ec0fc # v0.19.4

--- a/.github/workflows/scale-test-100-gce.yaml
+++ b/.github/workflows/scale-test-100-gce.yaml
@@ -89,8 +89,6 @@ jobs:
     timeout-minutes: 300
     env:
       job_name: "Install and Scale Test"
-    environment:
-      name: test-with-images
     steps:
       - name: Set commit status to pending
         uses: cilium/cilium/.github/actions/set-commit-status@main # main
@@ -158,17 +156,17 @@ jobs:
 
           # only add SHA to the image tags if VERSION is not set
           if [ -z "${VERSION}" ]; then
-            CILIUM_INSTALL_DEFAULTS+=" --set=image.repository=${{ vars.DOCKER_READ_HOST }}/${{ vars.DOCKER_READ_ORG }}/cilium-ci \
+            CILIUM_INSTALL_DEFAULTS+=" --set=image.repository=${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/cilium-ci \
             --set=image.useDigest=false \
             --set=image.tag=${SHA} \
-            --set=operator.image.repository=${{ vars.DOCKER_READ_HOST }}/${{ vars.DOCKER_READ_ORG }}/operator \
+            --set=operator.image.repository=${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/operator \
             --set=operator.image.suffix=-ci \
             --set=operator.image.tag=${SHA} \
             --set=operator.image.useDigest=false \
-            --set=clustermesh.apiserver.image.repository=${{ vars.DOCKER_READ_HOST }}/${{ vars.DOCKER_READ_ORG }}/clustermesh-apiserver-ci \
+            --set=clustermesh.apiserver.image.repository=${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/clustermesh-apiserver-ci \
             --set=clustermesh.apiserver.image.tag=${SHA} \
             --set=clustermesh.apiserver.image.useDigest=false \
-            --set=hubble.relay.image.repository=${{ vars.DOCKER_READ_HOST }}/${{ vars.DOCKER_READ_ORG }}/hubble-relay-ci \
+            --set=hubble.relay.image.repository=${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/hubble-relay-ci \
             --set=hubble.relay.image.tag=${SHA} \
             --set=hubble.relay.image.useDigest=false"
           fi
@@ -195,9 +193,6 @@ jobs:
         with:
           SHA: ${{ steps.vars.outputs.SHA }}
           images: cilium-ci operator-generic-ci hubble-relay-ci
-          login-host: ${{ vars.DOCKER_READ_HOST }}
-          login-username: ${{ vars.DOCKER_READ_USERNAME }}
-          login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
 
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/scale-test-5-gce.yaml
+++ b/.github/workflows/scale-test-5-gce.yaml
@@ -91,8 +91,6 @@ jobs:
     timeout-minutes: 150
     env:
       job_name: "Install and Scale Test"
-    environment:
-      name: test-with-images
     steps:
       - name: Set commit status to pending
         uses: cilium/cilium/.github/actions/set-commit-status@main # main
@@ -134,17 +132,17 @@ jobs:
           # only add SHA to the image tags if it was set
           if [ -n "${SHA}" ]; then
             echo sha=${SHA} >> $GITHUB_OUTPUT
-            CILIUM_INSTALL_DEFAULTS+=" --helm-set=image.repository=${{ vars.DOCKER_READ_HOST }}/${{ vars.DOCKER_READ_ORG }}/cilium-ci \
+            CILIUM_INSTALL_DEFAULTS+=" --helm-set=image.repository=${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/cilium-ci \
             --helm-set=image.useDigest=false \
             --helm-set=image.tag=${SHA} \
-            --helm-set=operator.image.repository=${{ vars.DOCKER_READ_HOST }}/${{ vars.DOCKER_READ_ORG }}/operator \
+            --helm-set=operator.image.repository=${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/operator \
             --helm-set=operator.image.suffix=-ci \
             --helm-set=operator.image.tag=${SHA} \
             --helm-set=operator.image.useDigest=false \
-            --helm-set=clustermesh.apiserver.image.repository=${{ vars.DOCKER_READ_HOST }}/${{ vars.DOCKER_READ_ORG }}/clustermesh-apiserver-ci \
+            --helm-set=clustermesh.apiserver.image.repository=${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/clustermesh-apiserver-ci \
             --helm-set=clustermesh.apiserver.image.tag=${SHA} \
             --helm-set=clustermesh.apiserver.image.useDigest=false \
-            --helm-set=hubble.relay.image.repository=${{ vars.DOCKER_READ_HOST }}/${{ vars.DOCKER_READ_ORG }}/hubble-relay-ci \
+            --helm-set=hubble.relay.image.repository=${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/hubble-relay-ci \
             --helm-set=hubble.relay.image.tag=${SHA} \
             --helm-set=hubble.relay.image.useDigest=false"
           fi
@@ -153,19 +151,12 @@ jobs:
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
           echo CLUSTER_NAME=${CLUSTER_NAME} >> $GITHUB_OUTPUT
 
-      - name: Login to docker registry for image wait
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ vars.DOCKER_READ_HOST}}
-          username: ${{ vars.DOCKER_READ_USERNAME}}
-          password: ${{ secrets.DOCKER_READ_PASSWORD }}
-
       - name: Wait for images to be available
         timeout-minutes: 30
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until docker manifest inspect ${{ vars.DOCKER_READ_HOST }}/${{ vars.DOCKER_READ_ORG }}/$image:${{ steps.vars.outputs.SHA }} &> /dev/null; do sleep 45s; done
+            until docker manifest inspect ${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.SHA }} &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Go
@@ -239,14 +230,6 @@ jobs:
           project_id: ${{ secrets.GCP_PERF_PROJECT_ID }}
           kube_proxy_enabled: false
 
-      - name: Create imagePullSecret
-        run: |
-          kubectl create secret docker-registry cilium-registry \
-            --namespace kube-system \
-            --docker-server=${{ vars.DOCKER_READ_HOST }} \
-            --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-            --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
-
       - name: Setup firewall rules
         uses: cilium/scale-tests-action/setup-firewall@995a08156171644e92e5688b0785b7baf86ce22a  # main
         with:
@@ -275,8 +258,8 @@ jobs:
       - name: Install Cilium
         id: install-cilium
         run: |
-          cilium install --dry-run-helm-values ${{ steps.vars.outputs.cilium_install_defaults }} --helm-set=imagePullSecrets[0].name=cilium-registry
-          cilium install ${{ steps.vars.outputs.cilium_install_defaults }} --helm-set=imagePullSecrets[0].name=cilium-registry
+          cilium install --dry-run-helm-values ${{ steps.vars.outputs.cilium_install_defaults }}
+          cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
 
       - name: Wait for cluster to be ready
         uses: cilium/scale-tests-action/validate-cluster@995a08156171644e92e5688b0785b7baf86ce22a # main

--- a/.github/workflows/scale-test-clustermesh.yaml
+++ b/.github/workflows/scale-test-clustermesh.yaml
@@ -94,8 +94,6 @@ jobs:
     timeout-minutes: 60
     env:
       job_name: "Install and Cluster Mesh Scale Test"
-    environment:
-      name: test-with-images
     steps:
       - name: Set commit status to pending
         uses: cilium/cilium/.github/actions/set-commit-status@main # main
@@ -124,9 +122,6 @@ jobs:
         with:
           SHA: ${{ inputs.SHA || github.sha }}
           images: cilium-ci operator-generic-ci clustermesh-apiserver-ci cilium-cli-ci
-          login-host: ${{ vars.DOCKER_READ_HOST }}
-          login-username: ${{ vars.DOCKER_READ_USERNAME }}
-          login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
 
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -189,14 +184,6 @@ jobs:
           project_id: ${{ secrets.GCP_PERF_PROJECT_ID }}
           kube_proxy_enabled: false
 
-      - name: Create imagePullSecret
-        run: |
-          kubectl create secret docker-registry cilium-registry \
-            --namespace kube-system \
-            --docker-server=${{ vars.DOCKER_READ_HOST }} \
-            --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-            --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
-
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@2c40f81b9180be6a5e52b8caf7f1de75202ec0fc # v0.19.4
         with:
@@ -238,11 +225,8 @@ jobs:
         uses: ./.github/actions/helm-default
         with:
           image-tag: ${{ inputs.SHA || github.sha }}
-          registry_host: ${{ vars.DOCKER_READ_HOST }}
-          registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: ./untrusted/install/kubernetes/cilium
           debug: false
-          image-pull-secret: "cilium-registry"
 
       - name: Install Cilium
         id: install-cilium

--- a/.github/workflows/scale-test-egw.yaml
+++ b/.github/workflows/scale-test-egw.yaml
@@ -107,8 +107,6 @@ jobs:
     name: Wait for images
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment:
-      name: test-with-images
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -120,9 +118,6 @@ jobs:
         with:
           SHA: ${{ inputs.SHA || github.sha }}
           images: cilium-ci operator-aws-ci cilium-cli-ci
-          login-host: ${{ vars.DOCKER_READ_HOST }}
-          login-username: ${{ vars.DOCKER_READ_USERNAME }}
-          login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
 
   install-and-scaletest:
     permissions:
@@ -140,8 +135,6 @@ jobs:
     name: Install and Scale Test
     needs: wait-for-images
     timeout-minutes: 150
-    environment:
-      name: test-with-images
     strategy:
       fail-fast: false
       matrix:
@@ -199,8 +192,8 @@ jobs:
             --set=extraConfig.cilium-endpoint-gc-interval=24h \
             --set-string=extraConfig.enable-stale-cilium-endpoint-cleanup=false \
             --set=prometheus.metrics=\"{+cilium_datapath_nat_gc_entries}\" \
-            --set=image.override=${{ vars.DOCKER_READ_HOST }}/${{ vars.DOCKER_READ_ORG }}/cilium-ci:${SHA} \
-            --set=operator.image.override=${{ vars.DOCKER_READ_HOST }}/${{ vars.DOCKER_READ_ORG }}/operator-aws-ci:${SHA} \
+            --set=image.override=${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/cilium-ci:${SHA} \
+            --set=operator.image.override=${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/operator-aws-ci:${SHA} \
             --values=values-dummy-health-server.yaml \
             --nodes-without-cilium"
 
@@ -211,7 +204,7 @@ jobs:
           cat<<EOF > values-dummy-health-server.yaml
           extraInitContainers:
           - name: iptables-config
-            image: ${{ vars.DOCKER_READ_HOST }}/${{ vars.DOCKER_READ_ORG }}/cilium-ci:${SHA}
+            image: ${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/cilium-ci:${SHA}
             command:
             - /bin/bash
             - -c
@@ -384,14 +377,6 @@ jobs:
         with:
           kubeconfig: "~/.kube/config"
 
-      - name: Create imagePullSecret
-        run: |
-          kubectl create secret docker-registry cilium-registry \
-            --namespace kube-system \
-            --docker-server=${{ vars.DOCKER_READ_HOST }} \
-            --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-            --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
-
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@2c40f81b9180be6a5e52b8caf7f1de75202ec0fc # v0.19.4
         with:
@@ -433,11 +418,9 @@ jobs:
 
           cilium install --dry-run-helm-values ${{ steps.vars.outputs.cilium_install_defaults }} \
             --set=k8sServiceHost="${K8S_API_SRV_ADDR}" --set=k8sServicePort=443 \
-            --helm-set=imagePullSecrets[0].name=cilium-registry \
             --set=ipv4NativeRoutingCIDR="${NATIVE_CIDR_BLOCK}"
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }} \
             --set=k8sServiceHost="${K8S_API_SRV_ADDR}" --set=k8sServicePort=443 \
-            --helm-set=imagePullSecrets[0].name=cilium-registry \
             --set=ipv4NativeRoutingCIDR="${NATIVE_CIDR_BLOCK}"
 
       - name: Delete context ref

--- a/.github/workflows/scale-test-node-throughput-gce.yaml
+++ b/.github/workflows/scale-test-node-throughput-gce.yaml
@@ -50,8 +50,6 @@ jobs:
     timeout-minutes: 120
     env:
       job_name: "Install and Scale Test"
-    environment:
-      name: test-with-images
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -67,9 +65,6 @@ jobs:
         uses: ./.github/actions/helm-default
         with:
           image-tag: ${{ github.sha }}
-          registry_host: ${{ vars.DOCKER_READ_HOST }}
-          registry_organization: ${{ vars.DOCKER_READ_ORG }}
-          image-pull-secret: "cilium-registry"
 
       - name: Set up job variables
         id: vars
@@ -89,19 +84,12 @@ jobs:
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
           echo CLUSTER_NAME=${CLUSTER_NAME} >> $GITHUB_OUTPUT
 
-      - name: Login to docker registry for image wait
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ vars.DOCKER_READ_HOST}}
-          username: ${{ vars.DOCKER_READ_USERNAME}}
-          password: ${{ secrets.DOCKER_READ_PASSWORD }}
-
       - name: Wait for images to be available
         timeout-minutes: 30
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until docker manifest inspect ${{ vars.DOCKER_READ_HOST }}/${{ vars.DOCKER_READ_ORG }}/$image:${{ steps.vars.outputs.SHA }} &> /dev/null; do sleep 45s; done
+            until docker manifest inspect ${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.SHA }} &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Go
@@ -153,14 +141,6 @@ jobs:
           node_count: 1
           kops_state: ${{ secrets.GCP_PERF_KOPS_STATE_STORE }}
           project_id: ${{ secrets.GCP_PERF_PROJECT_ID }}
-
-      - name: Create imagePullSecret
-        run: |
-          kubectl create secret docker-registry cilium-registry \
-            --namespace kube-system \
-            --docker-server=${{ vars.DOCKER_READ_HOST }} \
-            --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-            --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
 
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@2c40f81b9180be6a5e52b8caf7f1de75202ec0fc # v0.19.4

--- a/.github/workflows/tests-ces-migrate.yaml
+++ b/.github/workflows/tests-ces-migrate.yaml
@@ -81,8 +81,6 @@ jobs:
     name: Wait for images
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment:
-      name: test-with-images
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -94,9 +92,6 @@ jobs:
         with:
           SHA: ${{ inputs.SHA || github.sha }}
           images: cilium-ci operator-generic-ci hubble-relay-ci cilium-cli-ci
-          login-host: ${{ vars.DOCKER_READ_HOST }}
-          login-username: ${{ vars.DOCKER_READ_USERNAME }}
-          login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
 
   setup-and-test:
     needs: [wait-for-images]
@@ -105,8 +100,6 @@ jobs:
     timeout-minutes: 30
     env:
       job_name: "Installation and Migration Test"
-    environment:
-      name: test-with-images
     steps:
       - name: Set commit status to pending
         uses: cilium/cilium/.github/actions/set-commit-status@main # main
@@ -154,27 +147,16 @@ jobs:
           config: ${{ env.KIND_CONFIG }}
           wait: 0 # The control-plane never becomes ready, since no CNI is present
 
-      - name: Create imagePullSecret
-        run: |
-          kubectl create secret docker-registry cilium-registry \
-            --namespace kube-system \
-            --docker-server=${{ vars.DOCKER_READ_HOST }} \
-            --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-            --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
-
       - name: Set up install variables
         id: cilium-config
         uses: ./.github/actions/cilium-config
         with:
           image-tag: ${{ steps.vars.outputs.sha }}
-          registry_host: ${{ vars.DOCKER_READ_HOST }}
-          registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: 'install/kubernetes/cilium'
           ipv6: false
           egress-gateway: false # Currently incompatible with CES
           mutual-auth: false
           misc: 'bpfClockProbe=false,cni.uninstall=false'
-          image-pull-secret: "cilium-registry"
 
       - name: Install Cilium CLI
         if: ${{ steps.cilium-config.outputs.skip != 'true' }}

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -86,8 +86,6 @@ jobs:
     name: Wait for images
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment:
-      name: test-with-images
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -100,9 +98,6 @@ jobs:
         with:
           SHA: ${{ inputs.SHA || github.sha }}
           images: cilium-ci operator-generic-ci hubble-relay-ci cilium-cli-ci clustermesh-apiserver-ci
-          login-host: ${{ vars.DOCKER_READ_HOST }}
-          login-username: ${{ vars.DOCKER_READ_USERNAME }}
-          login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
 
   upgrade-and-downgrade:
     name: "Upgrade and Downgrade Test"

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -190,8 +190,6 @@ jobs:
     name: Wait for images
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment:
-      name: test-with-images
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -202,9 +200,6 @@ jobs:
         uses: ./.github/actions/wait-for-images
         with:
           SHA: ${{ inputs.SHA || github.sha }}
-          login-host: ${{ vars.DOCKER_READ_HOST }}
-          login-username: ${{ vars.DOCKER_READ_USERNAME }}
-          login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
 
   setup-and-test:
     needs: [wait-for-images, generate-matrix]
@@ -212,8 +207,6 @@ jobs:
     name: 'Setup & Test (${{ matrix.name }}, ${{ matrix.mode }}, ${{ matrix.kernel }})'
     env:
       job_name: 'Setup & Test (${{ matrix.name }}, ${{ matrix.mode }}, ${{ matrix.kernel }})'
-    environment:
-      name: test-with-images
     strategy:
       fail-fast: false
       max-parallel: 100
@@ -338,8 +331,6 @@ jobs:
         uses: ./.github/actions/cilium-config
         with:
           image-tag: ${{ steps.vars.outputs.image_tag }}
-          registry_host: ${{ vars.DOCKER_READ_HOST }}
-          registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: './untrusted/cilium-downgrade/install/kubernetes/cilium/'
           tunnel: ${{ matrix.tunnel }}
           devices: ${{ matrix.devices }}
@@ -362,7 +353,6 @@ jobs:
           ciliumendpointslice: ${{ matrix.ciliumendpointslice }}
           local-redirect-policy: ${{ matrix.local-redirect-policy }}
           bgp-control-plane: ${{ matrix.bgp-control-plane }}
-          image-pull-secret: "cilium-registry"
 
       - name: Derive newest Cilium installation config
         id: cilium-newest-config
@@ -370,8 +360,6 @@ jobs:
         uses: ./.github/actions/cilium-config
         with:
           image-tag: ${{ steps.vars.outputs.sha }}
-          registry_host: ${{ vars.DOCKER_READ_HOST }}
-          registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: './untrusted/cilium-newest/install/kubernetes/cilium'
           tunnel: ${{ matrix.tunnel }}
           devices: ${{ matrix.devices }}
@@ -394,7 +382,6 @@ jobs:
           ciliumendpointslice: ${{ matrix.ciliumendpointslice }}
           local-redirect-policy: ${{ matrix.local-redirect-policy }}
           bgp-control-plane: ${{ matrix.bgp-control-plane }}
-          image-pull-secret: "cilium-registry"
 
       - name: Set Kind params
         if: ${{ steps.vars.outputs.downgrade_version != '' && steps.cilium-stable-config.outputs.skip != 'true' && steps.cilium-newest-config.outputs.skip != 'true' }}
@@ -420,15 +407,6 @@ jobs:
           kernel: ${{ steps.kernel-version.outputs.full }}
           kind-params: "${{ steps.kind-params.outputs.params }}"
           kind-image: ${{ env.KIND_K8S_IMAGE }}
-
-      - name: Create imagePullSecret
-        if: ${{ steps.vars.outputs.downgrade_version != '' }}
-        run: |
-          kubectl create secret docker-registry cilium-registry \
-            --namespace kube-system \
-            --docker-server=${{ vars.DOCKER_READ_HOST }} \
-            --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-            --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
 
       - name: Set up job variables for connectivity tests
         id: vars-conn

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -49,8 +49,6 @@ jobs:
   conformance-test-ipv6:
     env:
       job_name: "Conformance Smoke Test with IPv6"
-    environment:
-      name: test-with-images
     needs: check_changes
     if: ${{ needs.check_changes.outputs.tested == 'true' }}
     runs-on: ubuntu-24.04
@@ -74,9 +72,6 @@ jobs:
         uses: ./.github/actions/helm-default
         with:
           image-tag: ${{ github.event.pull_request.head.sha || github.sha }}
-          registry_host: ${{ vars.DOCKER_READ_HOST }}
-          registry_organization: ${{ vars.DOCKER_READ_ORG }}
-          image-pull-secret: "cilium-registry"
 
       - name: Set image tag
         id: sha
@@ -109,27 +104,12 @@ jobs:
           config: ${{ env.KIND_CONFIG }}
           wait: 0 # The control-plane never becomes ready, since no CNI is present
 
-      - name: Create imagePullSecret
-        run: |
-          kubectl create secret docker-registry cilium-registry \
-            --namespace kube-system \
-            --docker-server=${{ vars.DOCKER_READ_HOST }} \
-            --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-            --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
-
-      - name: Login to docker registry for image wait
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ vars.DOCKER_READ_HOST}}
-          username: ${{ vars.DOCKER_READ_USERNAME}}
-          password: ${{ secrets.DOCKER_READ_PASSWORD }}
-
       - name: Wait for images to be available
         timeout-minutes: 30
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until docker manifest inspect ${{ vars.DOCKER_READ_HOST }}/${{ vars.DOCKER_READ_ORG }}/$image:${{ steps.sha.outputs.sha }} &> /dev/null; do sleep 45s; done
+            until docker manifest inspect ${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/$image:${{ steps.sha.outputs.sha }} &> /dev/null; do sleep 45s; done
           done
 
       - name: Set up install variables

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -81,9 +81,6 @@ jobs:
     if: ${{ needs.check_changes.outputs.tested == 'true' && github.event_name != 'merge_group' }}
     runs-on: ubuntu-24.04
     name: Installation and Conformance Test
-    environment:
-      name: test-with-images
-
     steps:
       - name: Collect Workflow Telemetry
         uses: cilium/workflow-telemetry-action@b1a318f80a08acede58027afe1455d037379966f # v2.2.0
@@ -103,9 +100,6 @@ jobs:
         uses: ./.github/actions/helm-default
         with:
           image-tag: ${{ github.event.pull_request.head.sha || github.sha }}
-          registry_host: ${{ vars.DOCKER_READ_HOST }}
-          registry_organization: ${{ vars.DOCKER_READ_ORG }}
-          image-pull-secret: "cilium-registry"
 
       - name: Set image tag
         id: sha
@@ -127,27 +121,12 @@ jobs:
           config: ${{ env.KIND_CONFIG }}
           wait: 0 # The control-plane never becomes ready, since no CNI is present
 
-      - name: Create imagePullSecret
-        run: |
-          kubectl create secret docker-registry cilium-registry \
-            --namespace kube-system \
-            --docker-server=${{ vars.DOCKER_READ_HOST }} \
-            --docker-username="${{ vars.DOCKER_READ_USERNAME }}" \
-            --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
-
-      - name: Login to docker registry for image wait
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ vars.DOCKER_READ_HOST}}
-          username: ${{ vars.DOCKER_READ_USERNAME}}
-          password: ${{ secrets.DOCKER_READ_PASSWORD }}
-
       - name: Wait for images to be available
         timeout-minutes: 30
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until docker manifest inspect ${{ vars.DOCKER_READ_HOST }}/${{ vars.DOCKER_READ_ORG }}/$image:${{ steps.sha.outputs.sha }} &> /dev/null; do sleep 45s; done
+            until docker manifest inspect ${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/$image:${{ steps.sha.outputs.sha }} &> /dev/null; do sleep 45s; done
           done
 
       - name: Generate CA, Server and Client certs for Operator Prometheus


### PR DESCRIPTION
This reverts commit adc9be103b8f620c52d6ccb6039f7576b32f5914. The commit
broke submissions from external contributors.

Related: https://github.com/cilium/cilium/issues/46371
Related: https://github.com/cilium/cilium/pull/46036
CC: @nebril
