### PR TITLE
datapath: add parent ifindex to VLAN desired device table output

### DIFF
--- a/pkg/datapath/linux/device/scripttest/testdata/persistance.txtar
+++ b/pkg/datapath/linux/device/scripttest/testdata/persistance.txtar
@@ -45,8 +45,8 @@ vlanID: 20
 
 -- desired-device.1.table --
 Owner  Name      Properties
-owner1 eth0.10   Type=vlan, ParentDevice=eth0, VLAN=10
-owner1 eth0.20   Type=vlan, ParentDevice=eth0, VLAN=20
+owner1 eth0.10   Type=vlan, ParentDevice=eth0 (2), VLAN=10
+owner1 eth0.20   Type=vlan, ParentDevice=eth0 (2), VLAN=20
 
 -- devices.1.table --
 Name      Type     MTU     OperStatus
@@ -57,7 +57,7 @@ eth0.20   vlan     1500    up
 
 -- desired-device.2.table --
 Owner  Name      Properties
-owner1 eth0.10   Type=vlan, ParentDevice=eth0, VLAN=10
+owner1 eth0.10   Type=vlan, ParentDevice=eth0 (2), VLAN=10
 
 -- devices.2.table --
 Name      Type     MTU     OperStatus

--- a/pkg/datapath/linux/device/scripttest/testdata/vlan.txtar
+++ b/pkg/datapath/linux/device/scripttest/testdata/vlan.txtar
@@ -46,8 +46,8 @@ mtu: 1400
 
 -- desired-device.1.table --
 Owner  Name      Properties
-owner1 eth0.10   Type=vlan, ParentDevice=eth0, VLAN=10
-owner2 eth0.20   Type=vlan, ParentDevice=eth0, VLAN=20
+owner1 eth0.10   Type=vlan, ParentDevice=eth0 (2), VLAN=10
+owner2 eth0.20   Type=vlan, ParentDevice=eth0 (2), VLAN=20
 
 -- devices.1.table --
 Name      Type     MTU     OperStatus
@@ -58,7 +58,7 @@ eth0.20   vlan     1500    up
 
 -- desired-device.2.table --
 Owner  Name      Properties
-owner2 eth0.20   Type=vlan, ParentDevice=eth0, VLAN=20
+owner2 eth0.20   Type=vlan, ParentDevice=eth0 (2), VLAN=20
 
 -- devices.2.table --
 Name      Type     MTU     OperStatus
@@ -68,7 +68,7 @@ eth0.20   vlan     1500    up
 
 -- desired-device.3.table --
 Owner  Name      Properties
-owner2 eth0.20   Type=vlan, ParentDevice=eth0, VLAN=20
+owner2 eth0.20   Type=vlan, ParentDevice=eth0 (2), VLAN=20
 
 -- devices.3.table --
 Name      Type     MTU     OperStatus

--- a/pkg/datapath/linux/device/vlan.go
+++ b/pkg/datapath/linux/device/vlan.go
@@ -33,7 +33,8 @@ func (d *DesiredVLANDeviceSpec) ToNetlink() (netlink.Link, error) {
 }
 
 func (d *DesiredVLANDeviceSpec) Properties() string {
-	return fmt.Sprintf("Type=vlan, ParentDevice=%s, VLAN=%d", d.ParentName, d.VLANID)
+	return fmt.Sprintf("Type=vlan, ParentDevice=%s (%d), VLAN=%d",
+		d.ParentName, d.ParentIndex, d.VLANID)
 }
 
 func (d *DesiredVLANDeviceSpec) MarshalYAML() (any, error) {


### PR DESCRIPTION
This allows easily checking the actual parent VLAN device ifindex when debugging live systems or in script tests without needing to use JSON output.