### PR TITLE
Revert "workflows/verifier: Run consistent version of tests"

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -202,9 +202,6 @@ jobs:
           provision: 'false'
           cmd: |
             cd /host/base
-            if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-              cd /host/pull
-            fi
             export TMPDIR=/var/tmp
             export GOCACHE=/host/gocache
             mkdir -p /host/datapath-verifier /host/gocache


### PR DESCRIPTION
This reverts commit 9cea129a6b81 ("workflows/verifier: Run consistent version of tests"). That change is causing issues when a pull request is introducing new load-time configurations, which will fail to apply.