### PR TITLE
workflows/verifier: Fix commit status

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -288,4 +288,4 @@ jobs:
         uses: cilium/cilium/.github/actions/set-commit-status@main # main
         with:
           sha: ${{ inputs.SHA || github.sha }}
-          status: ${{ needs.setup-and-test.result == 'success' && needs.merge-and-diff.result }}
+          status: ${{ needs.setup-and-test.result == 'success' && needs.merge-and-diff.result || needs.setup-and-test.result }}


### PR DESCRIPTION
When setting the commit status at the end of the verifier workflow, we need to pass a `status` value of `success`, `failure`, or similar. We're currently passing the following logical expression.

    needs.setup-and-test.result == 'success' && needs.merge-and-diff.result

When the `setup-and-test` job is successful, this returns the status of the `merge-and-diff` job and all works fine. However, when the `setup-and-test` job is failing, this returns `false`. The Action doesn't recognize this as a proper status value and fails to set a commit status:

    gh: Validation failed: State is not included in the list (Validation Failed)

This commit fixes it by returning the status of the `setup-and-test` job in that case. I tested it at https://github.com/cilium/cilium/actions/runs/27022964867.

Fixes: https://github.com/cilium/cilium/pull/45899.