### PR TITLE
bgp: fix BGP status conditions in BGP operator and manager

### DIFF
--- a/Documentation/network/bgp-control-plane/bgp-control-plane-troubleshooting.rst
+++ b/Documentation/network/bgp-control-plane/bgp-control-plane-troubleshooting.rst
@@ -31,10 +31,10 @@ set:
 
   status:
     conditions:
-    - lastTransitionTime: "2024-10-26T06:15:44Z"
+    - lastTransitionTime: "2026-06-16T12:54:24Z"
       message: No node matches spec.nodeSelector
       observedGeneration: 2
-      reason: NoMatchingNode
+      reason: MatchingNodeUnavailable
       status: "True"
       type: cilium.io/NoMatchingNode
 
@@ -76,10 +76,10 @@ the ``CiliumBGPNodeConfig`` resource. Following status condition will be set on 
 
   status:
     conditions:
-    - lastTransitionTime: "2024-10-26T06:18:04Z"
-      message: 'Selecting the same node(s) with ClusterConfig(s): [cilium-bgp-0]'
+    - lastTransitionTime: "2026-06-16T12:55:24Z"
+      message: 'Selecting the same node(s) with ClusterConfig(s): [tor-control-plane]'
       observedGeneration: 1
-      reason: ConflictingClusterConfigs
+      reason: ClusterConfigConflict
       status: "True"
       type: cilium.io/ConflictingClusterConfig
 
@@ -95,9 +95,9 @@ is not found:
 
   status:
     conditions:
-    - lastTransitionTime: "2024-10-26T06:15:44Z"
-      message: 'Referenced CiliumBGPPeerConfig(s) are missing: [peer-cofnig0]'
+    - lastTransitionTime: "2026-06-16T12:57:47Z"
+      message: 'Referenced CiliumBGPPeerConfig(s) are missing: [peer-config-1]'
       observedGeneration: 1
-      reason: MissingPeerConfigs
+      reason: PeerConfigsMissing
       status: "True"
       type: cilium.io/MissingPeerConfigs

--- a/operator/pkg/bgp/cluster.go
+++ b/operator/pkg/bgp/cluster.go
@@ -306,11 +306,13 @@ func (b *BGPResourceManager) updateConflictingClusterConfigsCondition(config *v2
 		Status:             meta_v1.ConditionFalse,
 		ObservedGeneration: config.Generation,
 		LastTransitionTime: meta_v1.Now(),
-		Reason:             "ConflictingClusterConfigs",
+		Message:            "",
+		Reason:             "ClusterConfigValidated",
 	}
 	if conflictingClusterConfigs.Len() != 0 {
 		cond.Status = meta_v1.ConditionTrue
 		cond.Message = fmt.Sprintf("Selecting the same node(s) with ClusterConfig(s): %v", sets.List(conflictingClusterConfigs))
+		cond.Reason = "ClusterConfigConflict"
 	}
 	return meta.SetStatusCondition(&config.Status.Conditions, cond)
 }
@@ -321,11 +323,13 @@ func (b *BGPResourceManager) updateMissingPeerConfigsCondition(config *v2.Cilium
 		Status:             meta_v1.ConditionFalse,
 		ObservedGeneration: config.Generation,
 		LastTransitionTime: meta_v1.Now(),
-		Reason:             "MissingPeerConfigs",
+		Message:            "",
+		Reason:             "PeerConfigsResolved",
 	}
 	if len(missingPCs) != 0 {
 		cond.Status = meta_v1.ConditionTrue
 		cond.Message = fmt.Sprintf("Referenced CiliumBGPPeerConfig(s) are missing: %v", missingPCs)
+		cond.Reason = "PeerConfigsMissing"
 	}
 	return meta.SetStatusCondition(&config.Status.Conditions, cond)
 }
@@ -336,11 +340,13 @@ func (b *BGPResourceManager) updateNoMatchingNodeCondition(config *v2.CiliumBGPC
 		Status:             meta_v1.ConditionTrue,
 		ObservedGeneration: config.Generation,
 		LastTransitionTime: meta_v1.Now(),
-		Reason:             "NoMatchingNode",
+		Reason:             "MatchingNodeUnavailable",
 		Message:            "No node matches spec.nodeSelector",
 	}
 	if !noMatchingNode {
 		cond.Status = meta_v1.ConditionFalse
+		cond.Message = ""
+		cond.Reason = "MatchingNodeSelected"
 	}
 	return meta.SetStatusCondition(&config.Status.Conditions, cond)
 }

--- a/operator/pkg/bgp/cluster_test.go
+++ b/operator/pkg/bgp/cluster_test.go
@@ -703,9 +703,11 @@ func TestClusterConfigConditions(t *testing.T) {
 	}
 
 	tests := []struct {
-		name                    string
-		clusterConfig           *v2.CiliumBGPClusterConfig
-		expectedConditionStatus map[string]meta_v1.ConditionStatus
+		name                     string
+		clusterConfig            *v2.CiliumBGPClusterConfig
+		expectedConditionStatus  map[string]meta_v1.ConditionStatus
+		expectedConditionMessage map[string]string
+		expectedConditionReason  map[string]string
 	}{
 		{
 			name: "NoMatchingNode False",
@@ -724,6 +726,12 @@ func TestClusterConfigConditions(t *testing.T) {
 			expectedConditionStatus: map[string]meta_v1.ConditionStatus{
 				v2.BGPClusterConfigConditionNoMatchingNode: meta_v1.ConditionFalse,
 			},
+			expectedConditionMessage: map[string]string{
+				v2.BGPClusterConfigConditionNoMatchingNode: "",
+			},
+			expectedConditionReason: map[string]string{
+				v2.BGPClusterConfigConditionNoMatchingNode: "MatchingNodeSelected",
+			},
 		},
 		{
 			name: "NoMatchingNode False Nil Selector",
@@ -737,6 +745,12 @@ func TestClusterConfigConditions(t *testing.T) {
 			},
 			expectedConditionStatus: map[string]meta_v1.ConditionStatus{
 				v2.BGPClusterConfigConditionNoMatchingNode: meta_v1.ConditionFalse,
+			},
+			expectedConditionMessage: map[string]string{
+				v2.BGPClusterConfigConditionNoMatchingNode: "",
+			},
+			expectedConditionReason: map[string]string{
+				v2.BGPClusterConfigConditionNoMatchingNode: "MatchingNodeSelected",
 			},
 		},
 		{
@@ -755,6 +769,12 @@ func TestClusterConfigConditions(t *testing.T) {
 			},
 			expectedConditionStatus: map[string]meta_v1.ConditionStatus{
 				v2.BGPClusterConfigConditionNoMatchingNode: meta_v1.ConditionTrue,
+			},
+			expectedConditionMessage: map[string]string{
+				v2.BGPClusterConfigConditionNoMatchingNode: "No node matches spec.nodeSelector",
+			},
+			expectedConditionReason: map[string]string{
+				v2.BGPClusterConfigConditionNoMatchingNode: "MatchingNodeUnavailable",
 			},
 		},
 		{
@@ -782,6 +802,12 @@ func TestClusterConfigConditions(t *testing.T) {
 			expectedConditionStatus: map[string]meta_v1.ConditionStatus{
 				v2.BGPClusterConfigConditionMissingPeerConfigs: meta_v1.ConditionFalse,
 			},
+			expectedConditionMessage: map[string]string{
+				v2.BGPClusterConfigConditionMissingPeerConfigs: "",
+			},
+			expectedConditionReason: map[string]string{
+				v2.BGPClusterConfigConditionMissingPeerConfigs: "PeerConfigsResolved",
+			},
 		},
 		{
 			name: "MissingPeerConfig False nil PeerConfigRef",
@@ -804,6 +830,12 @@ func TestClusterConfigConditions(t *testing.T) {
 			},
 			expectedConditionStatus: map[string]meta_v1.ConditionStatus{
 				v2.BGPClusterConfigConditionMissingPeerConfigs: meta_v1.ConditionFalse,
+			},
+			expectedConditionMessage: map[string]string{
+				v2.BGPClusterConfigConditionMissingPeerConfigs: "",
+			},
+			expectedConditionReason: map[string]string{
+				v2.BGPClusterConfigConditionMissingPeerConfigs: "PeerConfigsResolved",
 			},
 		},
 		{
@@ -830,6 +862,12 @@ func TestClusterConfigConditions(t *testing.T) {
 			},
 			expectedConditionStatus: map[string]meta_v1.ConditionStatus{
 				v2.BGPClusterConfigConditionMissingPeerConfigs: meta_v1.ConditionTrue,
+			},
+			expectedConditionMessage: map[string]string{
+				v2.BGPClusterConfigConditionMissingPeerConfigs: "Referenced CiliumBGPPeerConfig(s) are missing: peer0-foo",
+			},
+			expectedConditionReason: map[string]string{
+				v2.BGPClusterConfigConditionMissingPeerConfigs: "PeerConfigsMissing",
 			},
 		},
 	}

--- a/operator/pkg/bgp/cluster_test.go
+++ b/operator/pkg/bgp/cluster_test.go
@@ -1141,7 +1141,13 @@ func TestConflictingClusterConfigCondition(t *testing.T) {
 					}
 
 					if cond.Status == meta_v1.ConditionFalse {
+						if !assert.Equal(ct, "ClusterConfigValidated", cond.Reason, "Expected condition reason to be NoConflictingClusterConfigsFound") {
+							return
+						}
+
 						continue
+					} else if !assert.Equal(ct, "ClusterConfigConflict", cond.Reason, "Expected condition reason to be ConflictingClusterConfigsFound") {
+						return
 					}
 
 					expr, err := regexp.Compile(
@@ -1163,7 +1169,7 @@ func TestConflictingClusterConfigCondition(t *testing.T) {
 				}
 
 				// Short circuit if the number of conflict relations is not the same.
-				if !assert.Len(ct, conflictingRelations, len(tt.conflictingRelations), "Exexpected number of conflicts") {
+				if !assert.Len(ct, conflictingRelations, len(tt.conflictingRelations), "Expected number of conflicts") {
 					return
 				}
 

--- a/operator/pkg/bgp/peer.go
+++ b/operator/pkg/bgp/peer.go
@@ -197,9 +197,9 @@ func (u *peerConfigStatusReconciler) cleanupStatus(ctx context.Context, health c
 func (u *peerConfigStatusReconciler) reconcilePeerConfig(ctx context.Context, config *v2.CiliumBGPPeerConfig) error {
 	updateStatus := false
 
-	authSecretMissing := u.authSecretMissing(config)
+	authSecretConfigured, authSecretMissing := u.authSecretMissing(config)
 
-	if changed := u.updateMissingAuthSecretCondition(config, authSecretMissing); changed {
+	if changed := u.updateMissingAuthSecretCondition(config, authSecretConfigured, authSecretMissing); changed {
 		updateStatus = true
 	}
 
@@ -216,27 +216,34 @@ func (u *peerConfigStatusReconciler) reconcilePeerConfig(ctx context.Context, co
 	return nil
 }
 
-func (u *peerConfigStatusReconciler) authSecretMissing(c *v2.CiliumBGPPeerConfig) bool {
+func (u *peerConfigStatusReconciler) authSecretMissing(c *v2.CiliumBGPPeerConfig) (isConfigured bool, isMissing bool) {
 	if c.Spec.AuthSecretRef == nil {
-		return false
+		return false, false
 	}
 	if _, exists, _ := u.secretStore.GetByKey(resource.Key{Namespace: u.secretNamespace, Name: *c.Spec.AuthSecretRef}); !exists {
-		return true
+		return true, true
 	}
-	return false
+	return true, false
 }
 
-func (u *peerConfigStatusReconciler) updateMissingAuthSecretCondition(config *v2.CiliumBGPPeerConfig, missing bool) bool {
+func (u *peerConfigStatusReconciler) updateMissingAuthSecretCondition(config *v2.CiliumBGPPeerConfig, configured, missing bool) bool {
 	cond := meta_v1.Condition{
 		Type:               v2.BGPPeerConfigConditionMissingAuthSecret,
 		Status:             meta_v1.ConditionFalse,
 		ObservedGeneration: config.Generation,
 		LastTransitionTime: meta_v1.Now(),
-		Reason:             "MissingAuthSecret",
+		Message:            "",
+		Reason:             "AuthSecretValidated",
 	}
-	if missing {
+	if !configured {
+		cond.Status = meta_v1.ConditionFalse
+		cond.Message = "Auth Secret is not configured"
+		cond.Reason = "AuthSecretNotConfigured"
+	}
+	if missing && configured {
 		cond.Status = meta_v1.ConditionTrue
 		cond.Message = fmt.Sprintf("Referenced Auth Secret %q is missing", *config.Spec.AuthSecretRef)
+		cond.Reason = "AuthSecretMissing"
 	}
 	return meta.SetStatusCondition(&config.Status.Conditions, cond)
 }

--- a/operator/pkg/bgp/peer_test.go
+++ b/operator/pkg/bgp/peer_test.go
@@ -151,9 +151,10 @@ func TestMissingAuthSecretCondition(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
-		peerConfig    *v2.CiliumBGPPeerConfig
-		expectedState meta_v1.ConditionStatus
+		name           string
+		peerConfig     *v2.CiliumBGPPeerConfig
+		expectedState  meta_v1.ConditionStatus
+		expectedReason string
 	}{
 		{
 			name: "MissingAuthSecret False",
@@ -165,7 +166,8 @@ func TestMissingAuthSecretCondition(t *testing.T) {
 					AuthSecretRef: ptr.To(secretName),
 				},
 			},
-			expectedState: meta_v1.ConditionFalse,
+			expectedState:  meta_v1.ConditionFalse,
+			expectedReason: "AuthSecretValidated",
 		},
 		{
 			name: "MissingAuthSecret False nil AuthSecretRef",
@@ -175,7 +177,8 @@ func TestMissingAuthSecretCondition(t *testing.T) {
 				},
 				Spec: v2.CiliumBGPPeerConfigSpec{},
 			},
-			expectedState: meta_v1.ConditionFalse,
+			expectedState:  meta_v1.ConditionFalse,
+			expectedReason: "AuthSecretNotConfigured",
 		},
 		{
 			name: "MissingAuthSecret True",
@@ -187,7 +190,8 @@ func TestMissingAuthSecretCondition(t *testing.T) {
 					AuthSecretRef: ptr.To(secretName + "foo"),
 				},
 			},
-			expectedState: meta_v1.ConditionTrue,
+			expectedState:  meta_v1.ConditionTrue,
+			expectedReason: "AuthSecretMissing",
 		},
 	}
 
@@ -238,6 +242,7 @@ func TestMissingAuthSecretCondition(t *testing.T) {
 					return
 				}
 				assert.Equal(ct, tt.expectedState, cond.Status, "Unexpected condition status")
+				assert.Equal(ct, tt.expectedReason, cond.Reason, "Unexpected condition reason")
 			}, time.Second*3, time.Millisecond*100)
 		})
 	}

--- a/pkg/bgp/manager/reconciler/crd_status.go
+++ b/pkg/bgp/manager/reconciler/crd_status.go
@@ -227,12 +227,14 @@ func (r *StatusReconciler) updateErrorConditions() error {
 		Type:               v2.BGPInstanceConditionReconcileError,
 		Status:             metav1.ConditionFalse,
 		ObservedGeneration: bgpNodeConfig.GetGeneration(),
-		Reason:             "BGPReconcileError",
+		Message:            "",
+		Reason:             "ReconcileSucceeded",
 	}
 
 	if len(instanceErrors) > 0 {
 		cond.Status = metav1.ConditionTrue
 		cond.Message = message.String()
+		cond.Reason = "ReconcileFailed"
 	}
 
 	if updated := meta.SetStatusCondition(&r.desiredStatus.Conditions, cond); updated {

--- a/pkg/bgp/manager/reconciler/crd_status_test.go
+++ b/pkg/bgp/manager/reconciler/crd_status_test.go
@@ -171,7 +171,7 @@ func TestCRDConditions(t *testing.T) {
 						{
 							Type:               v2.BGPInstanceConditionReconcileError,
 							Status:             metav1.ConditionTrue,
-							Reason:             "BGPReconcileError",
+							Reason:             "ReconcileFailed",
 							ObservedGeneration: 19,
 							Message: "bgp-instance-0: error 00\n" +
 								"bgp-instance-0: error 01\n" +
@@ -200,7 +200,7 @@ func TestCRDConditions(t *testing.T) {
 						{
 							Type:   v2.BGPInstanceConditionReconcileError,
 							Status: metav1.ConditionTrue,
-							Reason: "BGPReconcileError",
+							Reason: "ReconcileFailed",
 							Message: "bgp-instance-0: error 00\n" +
 								"bgp-instance-0: error 01\n" +
 								"bgp-instance-1: error 10\n",
@@ -217,7 +217,7 @@ func TestCRDConditions(t *testing.T) {
 						{
 							Type:    v2.BGPInstanceConditionReconcileError,
 							Status:  metav1.ConditionTrue,
-							Reason:  "BGPReconcileError",
+							Reason:  "ReconcileFailed",
 							Message: "bgp-instance-0: error 00\n",
 						},
 					},
@@ -237,7 +237,7 @@ func TestCRDConditions(t *testing.T) {
 						{
 							Type:   v2.BGPInstanceConditionReconcileError,
 							Status: metav1.ConditionTrue,
-							Reason: "BGPReconcileError",
+							Reason: "ReconcileFailed",
 							Message: "bgp-instance-0: error 00\n" +
 								"bgp-instance-0: error 01\n" +
 								"bgp-instance-1: error 10\n",
@@ -254,7 +254,7 @@ func TestCRDConditions(t *testing.T) {
 						{
 							Type:    v2.BGPInstanceConditionReconcileError,
 							Status:  metav1.ConditionFalse,
-							Reason:  "BGPReconcileError",
+							Reason:  "ReconcileSucceeded",
 							Message: "",
 						},
 					},


### PR DESCRIPTION
Fix BGP status condition Reason for "cilium.io/MissingAuthSecret", "cilium.io/NoMatchingNode", "cilium.io/MissingPeerConfigs", "cilium.io/ConflictingClusterConfig" and "cilium.io/BGPReconcileError".

According to documentation: reason contains a programmatic identifier indicating the reason for the condition's last transition.
For the above conditions the reason was always the same which mislead users.
With this fix the reason is always indicating the status of the condition.

```release-note
bgp: fix status condition reporting: update reasons to accurately reflect current condition state
```