### PR TITLE
bpf: pass LWT encap back to kernel

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -804,8 +804,11 @@ ipv6_forward_to_destination(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 					  trace->reason, trace->monitor, bpf_htons(ETH_P_IPV6));
 			return ret;
 		case DROP_NO_FIB:
-			/* Error handling for local routes - just pass the packet to the kernel stack */
-			if (*ext_err == BPF_FIB_LKUP_RET_NOT_FWDED)
+			/* Error handling for local routes and external encap
+			 * - just pass the packet to the kernel stack.
+			 */
+			if (*ext_err == BPF_FIB_LKUP_RET_NOT_FWDED ||
+			    *ext_err == BPF_FIB_LKUP_RET_UNSUPP_LWT)
 				break;
 
 			fallthrough;
@@ -1370,8 +1373,11 @@ ipv4_forward_to_destination(struct __ctx_buff *ctx, struct iphdr *ip4,
 					  trace->reason, trace->monitor, bpf_htons(ETH_P_IP));
 			return ret;
 		case DROP_NO_FIB:
-			/* Error handling for local routes - just pass the packet to the kernel stack */
-			if (*ext_err == BPF_FIB_LKUP_RET_NOT_FWDED)
+			/* Error handling for local routes and external encap
+			 * - just pass the packet to the kernel stack.
+			 */
+			if (*ext_err == BPF_FIB_LKUP_RET_NOT_FWDED ||
+			    *ext_err == BPF_FIB_LKUP_RET_UNSUPP_LWT)
 				break;
 
 			fallthrough;


### PR DESCRIPTION
For "various reasons", I am running a custom LWT based Geneve overlay that needs to intersect with our Cilium deployment. 

I noticed that traffic was not routing into the overlay, and through the pure magic that is `cilium monitor --type drop -v` I was able to get this message:

```
xx drop (FIB lookup failed, 6) flow 0x0 to endpoint 0, ifindex 1344, file bpf_lxc.c:1332, ,
   identity 16009->world: 10.255.33.32 -> 255.209.73.1 EchoRequest
```

Asking Claude to take a look at the code, it lead me to the `DROP_NO_FIB` handling, and this enum:
```
enum {
	BPF_FIB_LKUP_RET_SUCCESS,      /* lookup successful */
	BPF_FIB_LKUP_RET_BLACKHOLE,    /* dest is blackholed; can be dropped */
	BPF_FIB_LKUP_RET_UNREACHABLE,  /* dest is unreachable; can be dropped */
	BPF_FIB_LKUP_RET_PROHIBIT,     /* dest not allowed; can be dropped */
	BPF_FIB_LKUP_RET_NOT_FWDED,    /* packet is not forwarded */
	BPF_FIB_LKUP_RET_FWD_DISABLED, /* fwding is not enabled on ingress */
	BPF_FIB_LKUP_RET_UNSUPP_LWT,   /* fwd requires encapsulation */
	BPF_FIB_LKUP_RET_NO_NEIGH,     /* no neighbor entry for nh */
	BPF_FIB_LKUP_RET_FRAG_NEEDED,  /* fragmentation required to fwd */
};
```

I artisanally patched the code in the PR by hand, and tested out the change and it seems to work.

I realize at this point I should note that I'm using a `BPF_PROG_TYPE_LWT_XMIT` program, with the eBPF program attached to a route encap. I wonder if I'd been using a `BPF_PROG_TYPE_SCHED_CLS` with a `tc` `egress` hook program this may have just worked for free.

Looking back at this `enum` though, I wonder if more of these should punt to the kernel logic, e.g. `BPF_FIB_LKUP_RET_FRAG_NEEDED` etc - so I'm looking for input on that.

I also asked Claude about testing this change, and it seemed to suggest a *lot* of changes so I was looking for some input for that.

```release-note
Fix: Punt unsupported LWT back to the kernel for processing.
```