### PR TITLE
loadbalancer: skip terminating backends in zone-hint topology preference

### DIFF
--- a/pkg/loadbalancer/writer/writer.go
+++ b/pkg/loadbalancer/writer/writer.go
@@ -584,6 +584,15 @@ func (w *Writer) DefaultSelectBackends(txn statedb.ReadTxn, bes iter.Seq2[*loadb
 				}
 			}
 			if checkZoneHints {
+				// Mirror the candidate filtering done when computing
+				// checkZoneHints above: terminating (and, for health-checked
+				// services, quarantined/not-yet-checked) backends must not be
+				// pinned by zone-hint preference, otherwise topology routing can
+				// keep selecting a draining backend instead of falling back to
+				// healthy backends in other zones.
+				if !w.topologyPreferenceCandidate(svc, be) {
+					continue
+				}
 				if be.Zone == nil ||
 					!slices.Contains(be.Zone.ForZones, *thisZone) {
 					continue

--- a/pkg/loadbalancer/writer/writer_test.go
+++ b/pkg/loadbalancer/writer/writer_test.go
@@ -1105,3 +1105,68 @@ func TestWriter_SelectBackends_PreferSameNodeIgnoresTerminating(t *testing.T) {
 	require.Len(t, selected, 1)
 	assert.Equal(t, activeLocalAddr.String(), selected[0].Address.String())
 }
+
+// TestWriter_SelectBackends_PreferCloseIgnoresTerminatingWithMatchingHint verifies
+// that a terminating backend is not pinned by zone-hint preference even when it
+// carries a ForZones hint matching the local zone. The detection loop only counts
+// the Active backend as a candidate (terminating backends are excluded by
+// topologyPreferenceCandidate), so the zone-hint generator must apply the same
+// filter; otherwise the draining backend would keep receiving traffic alongside
+// the healthy one.
+func TestWriter_SelectBackends_PreferCloseIgnoresTerminatingWithMatchingHint(t *testing.T) {
+	p := fixture(t)
+	p.Writer.config.EnableServiceTopology = true
+	p.LocalNodeStore.Update(func(n *node.LocalNode) {
+		if n.Labels == nil {
+			n.Labels = map[string]string{}
+		}
+		n.Labels[corev1.LabelTopologyZone] = "zone-a"
+	})
+
+	svcName := loadbalancer.NewServiceName("test", "svc")
+	feAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(1), 80, loadbalancer.ScopeExternal)
+	activeAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(2), 8080, loadbalancer.ScopeExternal)
+	terminatingAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(3), 8080, loadbalancer.ScopeExternal)
+
+	svc := &loadbalancer.Service{
+		Name:                svcName,
+		Source:              source.Kubernetes,
+		TrafficDistribution: loadbalancer.TrafficDistributionPreferClose,
+	}
+	fe := &loadbalancer.Frontend{
+		FrontendParams: loadbalancer.FrontendParams{
+			ServiceName: svcName,
+			Address:     feAddr,
+			Type:        loadbalancer.SVCTypeClusterIP,
+			ServicePort: feAddr.Port(),
+		},
+		Service: svc,
+	}
+	backends := iter.Seq2[*loadbalancer.Backend, statedb.Revision](func(yield func(*loadbalancer.Backend, statedb.Revision) bool) {
+		for i, be := range []*loadbalancer.Backend{
+			{
+				Address: activeAddr,
+				State:   loadbalancer.BackendStateActive,
+				Zone:    &loadbalancer.BackendZone{Zone: "zone-a", ForZones: []string{"zone-a"}},
+			},
+			{
+				// Terminating backend that still carries a hint for the local
+				// zone. It must not be selected despite the matching hint.
+				Address: terminatingAddr,
+				State:   loadbalancer.BackendStateTerminating,
+				Zone:    &loadbalancer.BackendZone{Zone: "zone-a", ForZones: []string{"zone-a"}},
+			},
+		} {
+			if !yield(be, statedb.Revision(i+1)) {
+				return
+			}
+		}
+	})
+
+	selected := slices.Collect(statedb.ToSeq(p.Writer.SelectBackends(p.DB.ReadTxn(), backends, svc, fe)))
+
+	// Only the active backend should be selected; the terminating backend with a
+	// matching zone hint must be filtered out.
+	require.Len(t, selected, 1)
+	assert.Equal(t, activeAddr.String(), selected[0].Address.String())
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      This PR was prepared with AIL:3. I personally reviewed the change, ran the
      affected test suite, and verified the regression test fails without the fix
      and passes with it.
- [x] Thanks for contributing!

## Summary

This change fixes an inconsistency in the topology-aware backend selection logic for `PreferClose` and `PreferSameZone` traffic distribution modes.

While determining whether zone hints should be honored, the selection logic evaluates backends using `topologyPreferenceCandidate()`. However, the final zone-hint selection path did not apply the same validation and only filtered backends based on locality and matching zone hints.

As a result, a backend that would normally be excluded from topology-preferred routing (for example, a terminating backend) could still be selected if it carried a matching zone hint, keeping a draining backend in rotation alongside healthy ones.

This patch applies the same candidate filtering during final backend selection, ensuring that only eligible backends participate in topology-preferred routing. This mirrors the existing `PreferSameNode` handling.

## Changes

- Add `topologyPreferenceCandidate()` validation to the zone-hint backend selection path.
- Keep backend eligibility checks consistent between candidate detection and final selection.
- Prevent ineligible backends from being preferred solely because they advertise a matching zone hint.
- Add a regression test covering the affected scenario.

## Testing

Added:

- `TestWriter_SelectBackends_PreferCloseIgnoresTerminatingWithMatchingHint`

The test verifies that a terminating backend with a matching zone hint is excluded from topology-preferred backend selection and that only eligible active backends are returned.

Validation performed:

- New regression test fails without the fix.
- New regression test passes with the fix applied.
- Full `pkg/loadbalancer/writer` test suite passes.
- `go vet ./pkg/loadbalancer/writer/...` passes.

```release-note
loadbalancer: Fix terminating backends being kept in rotation under PreferClose/PreferSameZone topology-aware routing
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
