### PR TITLE
ipam: enable delegated IPAM calls for allocating gateway ingress IPs

### DIFF
--- a/daemon/cmd/cni/cell.go
+++ b/daemon/cmd/cni/cell.go
@@ -42,6 +42,10 @@ type CNIConfigManager interface {
 	// ExternalRoutingEnabled returns true if the chained plugin implements
 	// routing for Endpoints (Pods).
 	ExternalRoutingEnabled() bool
+
+	// GetDelegatedIPAMCNIBinPath returns the path to the CNI bin directory
+	// used for delegated IPAM plugin invocations.
+	GetDelegatedIPAMCNIBinPath() string
 }
 
 func enableConfigManager(lc cell.Lifecycle, logger *slog.Logger, cfg config.Config, dcfg *option.DaemonConfig /*only for .Debug*/) CNIConfigManager {

--- a/daemon/cmd/cni/config.go
+++ b/daemon/cmd/cni/config.go
@@ -75,6 +75,16 @@ func (c *cniConfigManager) ExternalRoutingEnabled() bool {
 	return c.config.CNIExternalRouting
 }
 
+// GetDelegatedIPAMCNIBinPath returns the path to the CNI bin directory
+// used for delegated IPAM plugin invocations.
+//
+// The path is hardcoded for now. A follow-up will expose it via the
+// --delegated-ipam-cni-bin-path agent flag once the delegated-IPAM
+// gateway-ingress path is activated. See CFP-45607.
+func (c *cniConfigManager) GetDelegatedIPAMCNIBinPath() string {
+	return "/host/opt/cni/bin"
+}
+
 // GetCustomNetConf returns the parsed custom CNI configuration, if provided
 // (In other words, the value to --read-cni-conf).
 // Otherwise, returns nil.

--- a/daemon/cmd/cni/fake/fakecni.go
+++ b/daemon/cmd/cni/fake/fakecni.go
@@ -8,25 +8,45 @@ import (
 	cnitypes "github.com/cilium/cilium/plugins/cilium-cni/types"
 )
 
-type FakeCNIConfigManager struct{}
+// FakeCNIConfigManager is a no-op CNIConfigManager implementation for tests.
+// Fields configure the values returned by the corresponding methods.
+type FakeCNIConfigManager struct {
+	MTU                     int
+	ChainingMode            string
+	ExternalRouting         bool
+	CustomNetConf           *cnitypes.NetConf
+	DelegatedIPAMCNIBinPath string
+}
 
+// GetMTU returns the configured MTU.
 func (f *FakeCNIConfigManager) GetMTU() int {
-	return 0
+	return f.MTU
 }
 
-// GetChainingMode returns the configured CNI chaining mode
+// GetChainingMode returns the configured CNI chaining mode.
 func (f *FakeCNIConfigManager) GetChainingMode() string {
-	return "none"
+	if f.ChainingMode == "" {
+		return "none"
+	}
+	return f.ChainingMode
 }
 
-func (c *FakeCNIConfigManager) ExternalRoutingEnabled() bool {
-	return false
+// ExternalRoutingEnabled returns the configured external-routing flag.
+func (f *FakeCNIConfigManager) ExternalRoutingEnabled() bool {
+	return f.ExternalRouting
 }
 
+// GetCustomNetConf returns the configured custom NetConf, if any.
 func (f *FakeCNIConfigManager) GetCustomNetConf() *cnitypes.NetConf {
-	return nil
+	return f.CustomNetConf
 }
 
+// Status always returns nil.
 func (f *FakeCNIConfigManager) Status() *models.Status {
 	return nil
+}
+
+// GetDelegatedIPAMCNIBinPath returns the configured CNI bin directory used for delegated IPAM.
+func (f *FakeCNIConfigManager) GetDelegatedIPAMCNIBinPath() string {
+	return f.DelegatedIPAMCNIBinPath
 }

--- a/daemon/infraendpoints/delegated_ipam.go
+++ b/daemon/infraendpoints/delegated_ipam.go
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package infraendpoints
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/containernetworking/cni/libcni"
+	cniinvoke "github.com/containernetworking/cni/pkg/invoke"
+	cnitypesv1 "github.com/containernetworking/cni/pkg/types/100"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/netns"
+	"github.com/cilium/cilium/pkg/node"
+)
+
+const (
+	// delegatedIPAMContainerIDPrefix is prefixed to the local node name to form a
+	// stable, per-node CNI container ID for ingress IP allocations.
+	delegatedIPAMContainerIDPrefix = "cilium-ingress-"
+
+	// delegatedIPAMIfName is the CNI_IFNAME used for ingress IP allocations, not a
+	// real interface, but part of the IPAM bookkeeping key so must match ADD/DEL.
+	delegatedIPAMIfName = "eth0"
+
+	// delegatedIPAMPodNamespace is the K8S_POD_NAMESPACE CNI arg, set to kube-system.
+	delegatedIPAMPodNamespace = "kube-system"
+)
+
+func delegatedIPAMContainerID(nodeName string) string {
+	return delegatedIPAMContainerIDPrefix + nodeName
+}
+
+type delegatedIPAMNetNS interface {
+	Path() string
+	// Close releases the netns handle.
+	Close() error
+}
+
+type realDelegatedIPAMNetNS struct {
+	ns *netns.NetNS
+}
+
+// newDelegatedIPAMNetNS creates a fresh, empty network namespace. The returned handle is unpinned.
+func newDelegatedIPAMNetNS() (delegatedIPAMNetNS, error) {
+	ns, err := netns.New()
+	if err != nil {
+		return nil, fmt.Errorf("create delegated IPAM netns: %w", err)
+	}
+	return &realDelegatedIPAMNetNS{ns: ns}, nil
+}
+
+func (s *realDelegatedIPAMNetNS) Path() string { return fmt.Sprintf("/proc/self/fd/%d", s.ns.FD()) }
+func (s *realDelegatedIPAMNetNS) Close() error { return s.ns.Close() }
+
+func newDelegatedIPAMArgs(command, containerID, cniBinPath string, netns delegatedIPAMNetNS) *cniinvoke.Args {
+	return &cniinvoke.Args{
+		Command:     command,
+		ContainerID: containerID,
+		NetNS:       netns.Path(),
+		IfName:      delegatedIPAMIfName,
+		Path:        cniBinPath,
+		PluginArgs: [][2]string{
+			{"IgnoreUnknown", "true"},
+			{"K8S_POD_NAME", containerID},
+			{"K8S_POD_NAMESPACE", delegatedIPAMPodNamespace},
+		},
+	}
+}
+
+// newDefaultCNIExec returns a default CNI exec implementation that pipes plugin stderr
+// to the agent's stderr.
+func newDefaultCNIExec() cniinvoke.Exec {
+	return &cniinvoke.DefaultExec{
+		RawExec: &cniinvoke.RawExec{Stderr: os.Stderr},
+	}
+}
+
+// delegatedIPAMPluginConfig returns the cilium-cni plugin block from --read-cni-conf, surfaced via
+// NetConf.PluginConfig. Verbatim bytes preserve plugin-specific IPAM fields not modeled by NetConf.
+func (r *infraIPAllocator) delegatedIPAMPluginConfig() (*libcni.PluginConfig, error) {
+	netConf := r.cniConfigManager.GetCustomNetConf()
+	if netConf == nil {
+		return nil, errors.New("no CNI configuration available for delegated IPAM, ensure --read-cni-conf is set")
+	}
+	if netConf.PluginConfig == nil {
+		return nil, errors.New("CNI configuration has no plugin config, cannot invoke delegated IPAM without preserving plugin-specific fields")
+	}
+	if netConf.PluginConfig.Network == nil {
+		return nil, errors.New("CNI plugin config has no parsed network section, cannot determine IPAM type for delegated IPAM")
+	}
+	if len(netConf.PluginConfig.Bytes) == 0 {
+		return nil, errors.New("CNI plugin config has no preserved raw bytes, cannot invoke delegated IPAM without plugin-specific fields")
+	}
+	if netConf.PluginConfig.Network.IPAM.Type == "" {
+		return nil, errors.New("CNI configuration does not specify an IPAM type")
+	}
+	return netConf.PluginConfig, nil
+}
+
+// allocateIngressIPsWithDelegatedIPAMExec allocates ingress IPs using an external CNI IPAM plugin.
+func (r *infraIPAllocator) allocateIngressIPsWithDelegatedIPAMExec(ctx context.Context, exec cniinvoke.Exec) error {
+	netns, err := newDelegatedIPAMNetNS()
+	if err != nil {
+		return err
+	}
+	return r.allocateIngressIPsWithDelegatedIPAMExecAndNetNS(ctx, exec, netns)
+}
+
+func (r *infraIPAllocator) allocateIngressIPsWithDelegatedIPAMExecAndNetNS(ctx context.Context, exec cniinvoke.Exec, netns delegatedIPAMNetNS) (retErr error) {
+	defer netns.Close()
+	r.logger.Debug("Created ephemeral netns for delegated IPAM ingress allocation", logfields.NetNSName, netns.Path())
+
+	localNode, err := r.localNodeStore.Get(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get local node for delegated IPAM ingress allocation: %w", err)
+	}
+	if localNode.Name == "" {
+		return errors.New("local node name is empty, cannot derive stable container ID for delegated IPAM ingress allocation")
+	}
+
+	pluginConf, err := r.delegatedIPAMPluginConfig()
+	if err != nil {
+		return err
+	}
+	ipamType := pluginConf.Network.IPAM.Type
+
+	cniBinPath := r.cniConfigManager.GetDelegatedIPAMCNIBinPath()
+	pluginPath, err := exec.FindInPath(ipamType, []string{cniBinPath})
+	if err != nil {
+		return fmt.Errorf("failed to find IPAM plugin %q in %q: %w", ipamType, cniBinPath, err)
+	}
+
+	containerID := delegatedIPAMContainerID(localNode.Name)
+	args := newDelegatedIPAMArgs("ADD", containerID, cniBinPath, netns)
+
+	rawResult, err := cniinvoke.ExecPluginWithResult(ctx, pluginPath, pluginConf.Bytes, args, exec)
+	if err != nil {
+		return fmt.Errorf("failed to execute IPAM plugin %q for ingress IP allocation: %w", ipamType, err)
+	}
+
+	// From this point the plugin holds an external lease keyed on containerID and ifname.
+	// If we return an error later, make a DEL call so retries don't collide with an
+	// orphaned lease.
+	defer func() {
+		if retErr == nil {
+			return
+		}
+		args.Command = "DEL"
+		if delErr := cniinvoke.ExecPluginWithoutResult(ctx, pluginPath, pluginConf.Bytes, args, exec); delErr != nil {
+			r.logger.Warn("Failed to release lease via delegated IPAM after allocation error, lease may be orphaned",
+				logfields.Error, delErr,
+			)
+		}
+	}()
+
+	result, err := cnitypesv1.NewResultFromResult(rawResult)
+	if err != nil {
+		return fmt.Errorf("failed to convert IPAM result: %w", err)
+	}
+
+	if len(result.IPs) == 0 {
+		return errors.New("IPAM plugin returned no IPs")
+	}
+
+	var ipv4, ipv6 net.IP
+	for _, ipConfig := range result.IPs {
+		ip := ipConfig.Address.IP
+		if ip.To4() != nil {
+			if r.daemonConfig.EnableIPv4 {
+				if ipv4 == nil {
+					ipv4 = ip
+				}
+				continue
+			}
+			r.logger.Debug("Ignoring IPv4 ingress IP returned by delegated IPAM, IPv4 is disabled",
+				logfields.IPAddr, ip,
+			)
+			continue
+		}
+
+		if r.daemonConfig.EnableIPv6 {
+			if ipv6 == nil {
+				ipv6 = ip
+			}
+			continue
+		}
+		r.logger.Debug("Ignoring IPv6 ingress IP returned by delegated IPAM, IPv6 is disabled",
+			logfields.IPAddr, ip,
+		)
+	}
+
+	if r.daemonConfig.EnableIPv4 && ipv4 == nil {
+		return fmt.Errorf("delegated IPAM plugin %q did not return an IPv4 ingress address", ipamType)
+	}
+	if r.daemonConfig.EnableIPv6 && ipv6 == nil {
+		return fmt.Errorf("delegated IPAM plugin %q did not return an IPv6 ingress address", ipamType)
+	}
+
+	r.localNodeStore.Update(func(n *node.LocalNode) {
+		if ipv4 != nil {
+			n.IPv4IngressIP = ipv4
+			r.logger.Info("Allocated IPv4 ingress address via delegated IPAM", logfields.IPAddr, ipv4)
+		}
+		if ipv6 != nil {
+			n.IPv6IngressIP = ipv6
+			r.logger.Info("Allocated IPv6 ingress address via delegated IPAM", logfields.IPAddr, ipv6)
+		}
+	})
+
+	return nil
+}
+
+// deallocateIngressIPsWithDelegatedIPAMExec releases ingress IPs via the external CNI IPAM plugin.
+func (r *infraIPAllocator) deallocateIngressIPsWithDelegatedIPAMExec(ctx context.Context, exec cniinvoke.Exec) error {
+	netns, err := newDelegatedIPAMNetNS()
+	if err != nil {
+		return fmt.Errorf("netns unavailable: %w", err)
+	}
+	return r.deallocateIngressIPsWithDelegatedIPAMExecAndNetNS(ctx, exec, netns)
+}
+
+func (r *infraIPAllocator) deallocateIngressIPsWithDelegatedIPAMExecAndNetNS(ctx context.Context, exec cniinvoke.Exec, netns delegatedIPAMNetNS) error {
+	defer netns.Close()
+	r.logger.Debug("Created ephemeral netns for delegated IPAM ingress deallocation", logfields.NetNSName, netns.Path())
+
+	pluginConf, err := r.delegatedIPAMPluginConfig()
+	if err != nil {
+		return err
+	}
+	ipamType := pluginConf.Network.IPAM.Type
+
+	localNode, err := r.localNodeStore.Get(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get local node: %w", err)
+	}
+	if localNode.Name == "" {
+		return errors.New("local node name is empty")
+	}
+
+	cniBinPath := r.cniConfigManager.GetDelegatedIPAMCNIBinPath()
+	pluginPath, err := exec.FindInPath(ipamType, []string{cniBinPath})
+	if err != nil {
+		return fmt.Errorf("failed to find IPAM plugin %q in %q: %w", ipamType, cniBinPath, err)
+	}
+
+	args := newDelegatedIPAMArgs("DEL", delegatedIPAMContainerID(localNode.Name), cniBinPath, netns)
+
+	if err := cniinvoke.ExecPluginWithoutResult(ctx, pluginPath, pluginConf.Bytes, args, exec); err != nil {
+		return fmt.Errorf("failed to execute IPAM plugin %q for ingress IP deallocation: %w", ipamType, err)
+	}
+
+	r.localNodeStore.Update(func(n *node.LocalNode) {
+		n.IPv4IngressIP = nil
+		n.IPv6IngressIP = nil
+	})
+
+	if localNode.IPv4IngressIP != nil {
+		r.logger.Info("Deallocated IPv4 ingress address via delegated IPAM", logfields.IPAddr, localNode.IPv4IngressIP)
+	}
+	if localNode.IPv6IngressIP != nil {
+		r.logger.Info("Deallocated IPv6 ingress address via delegated IPAM", logfields.IPAddr, localNode.IPv6IngressIP)
+	}
+	return nil
+}

--- a/daemon/infraendpoints/delegated_ipam_test.go
+++ b/daemon/infraendpoints/delegated_ipam_test.go
@@ -1,0 +1,573 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package infraendpoints
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/containernetworking/cni/libcni"
+	cnicoretypes "github.com/containernetworking/cni/pkg/types"
+	cnitypesv1 "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/containernetworking/cni/pkg/version"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/daemon/cmd/cni/fake"
+	"github.com/cilium/cilium/pkg/node"
+	nodetypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/option"
+	cnitypes "github.com/cilium/cilium/plugins/cilium-cni/types"
+)
+
+// fakeDelegatedIPAMNetNS is a delegatedIPAMNetNS that doesn't touch the kernel. It lets
+// unit tests exercise the delegated IPAM flow unprivileged.
+type fakeDelegatedIPAMNetNS struct {
+	path   string
+	closed bool
+}
+
+func (f *fakeDelegatedIPAMNetNS) Path() string { return f.path }
+func (f *fakeDelegatedIPAMNetNS) Close() error { f.closed = true; return nil }
+func newFakeNetNS() *fakeDelegatedIPAMNetNS {
+	return &fakeDelegatedIPAMNetNS{path: "/proc/self/fd/1234"}
+}
+
+// mockCNIExec implements cniInvoke.Exec for testing.
+type mockCNIExec struct {
+	version.PluginDecoder
+	execResult []byte
+	execErr    error
+	findErr    error
+	commands   []string
+}
+
+func (m *mockCNIExec) ExecPlugin(_ context.Context, _ string, _ []byte, env []string) ([]byte, error) {
+	for _, kv := range env {
+		if cmd, ok := strings.CutPrefix(kv, "CNI_COMMAND="); ok {
+			m.commands = append(m.commands, cmd)
+			break
+		}
+	}
+	return m.execResult, m.execErr
+}
+
+func (m *mockCNIExec) FindInPath(plugin string, paths []string) (string, error) {
+	if m.findErr != nil {
+		return "", m.findErr
+	}
+	if len(paths) > 0 {
+		return filepath.Join(paths[0], plugin), nil
+	}
+	return "", errors.New("no paths provided")
+}
+
+func TestNewDelegatedIPAMArgs(t *testing.T) {
+	netns := newFakeNetNS()
+	args := newDelegatedIPAMArgs("ADD", "cilium-ingress-node-a", "/opt/cni/bin", netns)
+	require.Equal(t, "ADD", args.Command)
+	require.Equal(t, "cilium-ingress-node-a", args.ContainerID)
+	require.Equal(t, "/proc/self/fd/1234", args.NetNS)
+	require.Equal(t, "eth0", args.IfName)
+	require.Equal(t, "/opt/cni/bin", args.Path)
+	require.Equal(t, [][2]string{
+		{"IgnoreUnknown", "true"},
+		{"K8S_POD_NAME", "cilium-ingress-node-a"},
+		{"K8S_POD_NAMESPACE", "kube-system"},
+	}, args.PluginArgs)
+
+	delArgs := newDelegatedIPAMArgs("DEL", "cilium-ingress-node-a", "/opt/cni/bin", newFakeNetNS())
+	require.Equal(t, "DEL", delArgs.Command)
+	require.Equal(t, args.ContainerID, delArgs.ContainerID)
+	require.Equal(t, args.IfName, delArgs.IfName)
+}
+
+func TestDelegatedIPAMContainerID(t *testing.T) {
+	require.Equal(t, "cilium-ingress-node-a", delegatedIPAMContainerID("node-a"))
+}
+
+func TestDelegatedIPAMPluginConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		netConf   *cnitypes.NetConf
+		expectErr string
+		expectOK  bool
+	}{
+		{
+			name:      "nil netConf",
+			netConf:   nil,
+			expectErr: "no CNI configuration available",
+		},
+		{
+			name:      "nil PluginConfig",
+			netConf:   &cnitypes.NetConf{NetConf: cnicoretypes.NetConf{CNIVersion: "1.0.0", Name: "test"}},
+			expectErr: "no plugin config",
+		},
+		{
+			name: "PluginConfig with nil Network",
+			netConf: &cnitypes.NetConf{
+				NetConf:      cnicoretypes.NetConf{CNIVersion: "1.0.0", Name: "test"},
+				PluginConfig: &libcni.PluginConfig{Network: nil, Bytes: []byte("{}")},
+			},
+			expectErr: "no parsed network section",
+		},
+		{
+			name: "PluginConfig with empty Bytes",
+			netConf: &cnitypes.NetConf{
+				NetConf: cnicoretypes.NetConf{CNIVersion: "1.0.0", Name: "test"},
+				PluginConfig: &libcni.PluginConfig{
+					Network: &cnicoretypes.PluginConf{IPAM: cnicoretypes.IPAM{Type: "host-local"}},
+					Bytes:   nil,
+				},
+			},
+			expectErr: "no preserved raw bytes",
+		},
+		{
+			name: "PluginConfig with empty IPAM type",
+			netConf: &cnitypes.NetConf{
+				NetConf: cnicoretypes.NetConf{CNIVersion: "1.0.0", Name: "test"},
+				PluginConfig: &libcni.PluginConfig{
+					Network: &cnicoretypes.PluginConf{},
+					Bytes:   []byte(`{"cniVersion":"1.0.0","name":"test"}`),
+				},
+			},
+			expectErr: "does not specify an IPAM type",
+		},
+		{
+			name: "valid PluginConfig",
+			netConf: &cnitypes.NetConf{
+				NetConf: cnicoretypes.NetConf{CNIVersion: "1.0.0", Name: "test"},
+				PluginConfig: &libcni.PluginConfig{
+					Network: &cnicoretypes.PluginConf{IPAM: cnicoretypes.IPAM{Type: "host-local"}},
+					Bytes:   []byte(`{"cniVersion":"1.0.0","name":"test","ipam":{"type":"host-local"}}`),
+				},
+			},
+			expectOK: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &infraIPAllocator{
+				cniConfigManager: &fake.FakeCNIConfigManager{CustomNetConf: tt.netConf},
+			}
+			pc, err := r.delegatedIPAMPluginConfig()
+			if tt.expectOK {
+				require.NoError(t, err)
+				require.NotNil(t, pc)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.expectErr)
+		})
+	}
+}
+
+func newTestAllocator(t *testing.T, netConf *cnitypes.NetConf, cniBinPath string, enableIPv4, enableIPv6 bool) *infraIPAllocator {
+	t.Helper()
+	// Seed PluginConfig with raw bytes so delegatedIPAMPluginConfig can forward
+	// them to the plugin.
+	if netConf != nil && netConf.PluginConfig == nil && netConf.IPAM.Type != "" {
+		raw := fmt.Sprintf(
+			`{"cniVersion":"%s","name":"%s","type":"cilium-cni","ipam":{"type":"%s"}}`,
+			netConf.CNIVersion, netConf.Name, netConf.IPAM.Type,
+		)
+		pc, err := libcni.NetworkPluginConfFromBytes([]byte(raw))
+		require.NoError(t, err)
+		netConf.PluginConfig = pc
+	}
+
+	localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{Node: nodetypes.Node{Name: "node-a"}})
+	return &infraIPAllocator{
+		logger: slog.Default(),
+		daemonConfig: &option.DaemonConfig{
+			EnableIPv4: enableIPv4,
+			EnableIPv6: enableIPv6,
+		},
+		localNodeStore: localNodeStore,
+		cniConfigManager: &fake.FakeCNIConfigManager{
+			CustomNetConf:           netConf,
+			DelegatedIPAMCNIBinPath: cniBinPath,
+		},
+	}
+}
+
+func makeCNIResult(t testing.TB, ips ...string) []byte {
+	t.Helper()
+	result := &cnitypesv1.Result{
+		CNIVersion: "1.0.0",
+	}
+	for _, ip := range ips {
+		hostIP, ipNet, err := net.ParseCIDR(ip)
+		require.NoError(t, err)
+		// Use host IP, not network IP
+		ipNet.IP = hostIP
+		result.IPs = append(result.IPs, &cnitypesv1.IPConfig{
+			Address: *ipNet,
+		})
+	}
+	b, err := json.Marshal(result)
+	require.NoError(t, err)
+	return b
+}
+
+func TestAllocateIngressIPsWithDelegatedIPAM(t *testing.T) {
+	tests := []struct {
+		name           string
+		netConf        *cnitypes.NetConf
+		execIPs        []string
+		withExecResult bool
+		execErr        error
+		enableIPv4     bool
+		enableIPv6     bool
+		expectErr      bool
+		expectV4       string
+		expectV6       string
+	}{
+		{
+			name: "IPv4 allocation",
+			netConf: &cnitypes.NetConf{
+				NetConf: cnicoretypes.NetConf{
+					CNIVersion: "1.0.0",
+					Name:       "test",
+					Type:       "cilium-cni",
+				},
+				IPAM: cnitypes.IPAM{
+					IPAM: cnicoretypes.IPAM{Type: "host-local"},
+				},
+			},
+			execIPs:        []string{"10.0.0.1/24"},
+			withExecResult: true,
+			enableIPv4:     true,
+			enableIPv6:     false,
+			expectV4:       "10.0.0.1",
+		},
+		{
+			name: "IPv6 allocation",
+			netConf: &cnitypes.NetConf{
+				NetConf: cnicoretypes.NetConf{
+					CNIVersion: "1.0.0",
+					Name:       "test",
+					Type:       "cilium-cni",
+				},
+				IPAM: cnitypes.IPAM{
+					IPAM: cnicoretypes.IPAM{Type: "host-local"},
+				},
+			},
+			execIPs:        []string{"fd00::1/128"},
+			withExecResult: true,
+			enableIPv4:     false,
+			enableIPv6:     true,
+			expectV6:       "fd00::1",
+		},
+		{
+			name: "dual stack allocation",
+			netConf: &cnitypes.NetConf{
+				NetConf: cnicoretypes.NetConf{
+					CNIVersion: "1.0.0",
+					Name:       "test",
+					Type:       "cilium-cni",
+				},
+				IPAM: cnitypes.IPAM{
+					IPAM: cnicoretypes.IPAM{Type: "host-local"},
+				},
+			},
+			execIPs:        []string{"10.0.0.1/24", "fd00::1/128"},
+			withExecResult: true,
+			enableIPv4:     true,
+			enableIPv6:     true,
+			expectV4:       "10.0.0.1",
+			expectV6:       "fd00::1",
+		},
+		{
+			name: "dual stack missing IPv6 fails",
+			netConf: &cnitypes.NetConf{
+				NetConf: cnicoretypes.NetConf{
+					CNIVersion: "1.0.0",
+					Name:       "test",
+					Type:       "cilium-cni",
+				},
+				IPAM: cnitypes.IPAM{
+					IPAM: cnicoretypes.IPAM{Type: "host-local"},
+				},
+			},
+			execIPs:        []string{"10.0.0.1/24"},
+			withExecResult: true,
+			enableIPv4:     true,
+			enableIPv6:     true,
+			expectErr:      true,
+		},
+		{
+			name: "dual stack missing IPv4 fails",
+			netConf: &cnitypes.NetConf{
+				NetConf: cnicoretypes.NetConf{
+					CNIVersion: "1.0.0",
+					Name:       "test",
+					Type:       "cilium-cni",
+				},
+				IPAM: cnitypes.IPAM{
+					IPAM: cnicoretypes.IPAM{Type: "host-local"},
+				},
+			},
+			execIPs:        []string{"fd00::1/128"},
+			withExecResult: true,
+			enableIPv4:     true,
+			enableIPv6:     true,
+			expectErr:      true,
+		},
+		{
+			name: "IPv4-only ignores IPv6 from plugin",
+			netConf: &cnitypes.NetConf{
+				NetConf: cnicoretypes.NetConf{
+					CNIVersion: "1.0.0",
+					Name:       "test",
+					Type:       "cilium-cni",
+				},
+				IPAM: cnitypes.IPAM{
+					IPAM: cnicoretypes.IPAM{Type: "host-local"},
+				},
+			},
+			execIPs:        []string{"10.0.0.1/24", "fd00::1/128"},
+			withExecResult: true,
+			enableIPv4:     true,
+			enableIPv6:     false,
+			expectV4:       "10.0.0.1",
+		},
+		{
+			name: "plugin exec error",
+			netConf: &cnitypes.NetConf{
+				NetConf: cnicoretypes.NetConf{
+					CNIVersion: "1.0.0",
+					Name:       "test",
+					Type:       "cilium-cni",
+				},
+				IPAM: cnitypes.IPAM{
+					IPAM: cnicoretypes.IPAM{Type: "host-local"},
+				},
+			},
+			execErr:    errors.New("exec failed"),
+			enableIPv4: true,
+			enableIPv6: true,
+			expectErr:  true,
+		},
+		{
+			name:       "no CNI config",
+			netConf:    nil,
+			enableIPv4: true,
+			enableIPv6: true,
+			expectErr:  true,
+		},
+		{
+			name: "no IPAM type",
+			netConf: &cnitypes.NetConf{
+				NetConf: cnicoretypes.NetConf{
+					CNIVersion: "1.0.0",
+					Name:       "test",
+					Type:       "cilium-cni",
+				},
+			},
+			enableIPv4: true,
+			enableIPv6: true,
+			expectErr:  true,
+		},
+		{
+			name: "empty result",
+			netConf: &cnitypes.NetConf{
+				NetConf: cnicoretypes.NetConf{
+					CNIVersion: "1.0.0",
+					Name:       "test",
+					Type:       "cilium-cni",
+				},
+				IPAM: cnitypes.IPAM{
+					IPAM: cnicoretypes.IPAM{Type: "host-local"},
+				},
+			},
+			withExecResult: true,
+			enableIPv4:     true,
+			enableIPv6:     true,
+			expectErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exec := &mockCNIExec{execErr: tt.execErr}
+			if tt.withExecResult {
+				exec.execResult = makeCNIResult(t, tt.execIPs...)
+			}
+			alloc := newTestAllocator(t, tt.netConf, "/opt/cni/bin", tt.enableIPv4, tt.enableIPv6)
+			err := alloc.allocateIngressIPsWithDelegatedIPAMExecAndNetNS(context.Background(), exec, newFakeNetNS())
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			ctx := context.Background()
+			localNode, err := alloc.localNodeStore.Get(ctx)
+			require.NoError(t, err)
+
+			if tt.expectV4 != "" {
+				require.NotNil(t, localNode.IPv4IngressIP)
+				require.Equal(t, tt.expectV4, localNode.IPv4IngressIP.String())
+			} else {
+				require.Nil(t, localNode.IPv4IngressIP)
+			}
+			if tt.expectV6 != "" {
+				require.NotNil(t, localNode.IPv6IngressIP)
+				require.Equal(t, tt.expectV6, localNode.IPv6IngressIP.String())
+			} else {
+				require.Nil(t, localNode.IPv6IngressIP)
+			}
+		})
+	}
+}
+
+// TestAllocateIngressIPsDELOnError asserts that
+// when an ADD succeeds at the plugin layer but allocation later fails due to a
+// missing required family, an offsetting DEL is issued so the plugin's lease
+// is not orphaned.
+func TestAllocateIngressIPsDELOnError(t *testing.T) {
+	netConf := &cnitypes.NetConf{
+		NetConf: cnicoretypes.NetConf{CNIVersion: "1.0.0", Name: "test", Type: "cilium-cni"},
+		IPAM:    cnitypes.IPAM{IPAM: cnicoretypes.IPAM{Type: "host-local"}},
+	}
+	exec := &mockCNIExec{
+		// Plugin returns only IPv4 even though dual-stack is required. This
+		// triggers the post-ADD validation error path.
+		execResult: makeCNIResult(t, "10.0.0.1/24"),
+	}
+	alloc := newTestAllocator(t, netConf, "/opt/cni/bin", true, true)
+	err := alloc.allocateIngressIPsWithDelegatedIPAMExecAndNetNS(context.Background(), exec, newFakeNetNS())
+	require.Error(t, err)
+	require.Equal(t, []string{"ADD", "DEL"}, exec.commands,
+		"failed allocation must issue a compensating DEL to release the plugin lease")
+}
+
+func TestDeallocateIngressIPsWithDelegatedIPAM(t *testing.T) {
+	validNetConf := func() *cnitypes.NetConf {
+		return &cnitypes.NetConf{
+			NetConf: cnicoretypes.NetConf{
+				CNIVersion: "1.0.0",
+				Name:       "test",
+				Type:       "cilium-cni",
+			},
+			IPAM: cnitypes.IPAM{
+				IPAM: cnicoretypes.IPAM{Type: "host-local"},
+			},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		netConf    *cnitypes.NetConf
+		cniBinPath string
+		exec       *mockCNIExec
+		// Pre-existing local-node ingress IPs at the time of deallocation.
+		// Drives the per-family success log assertions.
+		v4Ingress net.IP
+		v6Ingress net.IP
+		// Substrings expected in the returned error message.
+		wantErrContains []string
+		// Substrings expected in INFO log records.
+		wantInfoContains []string
+		// Substrings that must NOT appear in any log record.
+		wantAbsent []string
+	}{
+		{
+			name:             "dual-stack successful deallocation logs both families",
+			netConf:          validNetConf(),
+			cniBinPath:       "/opt/cni/bin",
+			exec:             &mockCNIExec{execResult: []byte("{}")},
+			v4Ingress:        net.ParseIP("10.0.0.1"),
+			v6Ingress:        net.ParseIP("fd00::1"),
+			wantInfoContains: []string{"Deallocated IPv4 ingress address", "Deallocated IPv6 ingress address"},
+		},
+		{
+			name:             "single-stack IPv4 only logs IPv4",
+			netConf:          validNetConf(),
+			cniBinPath:       "/opt/cni/bin",
+			exec:             &mockCNIExec{execResult: []byte("{}")},
+			v4Ingress:        net.ParseIP("10.0.0.1"),
+			wantInfoContains: []string{"Deallocated IPv4 ingress address"},
+			wantAbsent:       []string{"Deallocated IPv6", "<nil>"},
+		},
+		{
+			name:             "single-stack IPv6 only logs IPv6",
+			netConf:          validNetConf(),
+			cniBinPath:       "/opt/cni/bin",
+			exec:             &mockCNIExec{execResult: []byte("{}")},
+			v6Ingress:        net.ParseIP("fd00::1"),
+			wantInfoContains: []string{"Deallocated IPv6 ingress address"},
+			wantAbsent:       []string{"Deallocated IPv4", "<nil>"},
+		},
+		{
+			name:            "no CNI config",
+			netConf:         nil,
+			cniBinPath:      "/opt/cni/bin",
+			exec:            &mockCNIExec{},
+			wantErrContains: []string{"no CNI configuration available"},
+		},
+		{
+			// Both the conflist and the CNI bin path are unusable. The function
+			// short-circuits at the conflist read, the bin path is never consulted.
+			name:            "neither conflist nor CNI bin readable",
+			netConf:         nil,
+			cniBinPath:      "/does/not/exist",
+			exec:            &mockCNIExec{findErr: errors.New("not found")},
+			wantErrContains: []string{"no CNI configuration available"},
+			wantAbsent:      []string{"Failed to find IPAM plugin"},
+		},
+		{
+			name:            "plugin find error",
+			netConf:         validNetConf(),
+			cniBinPath:      "/opt/cni/bin",
+			exec:            &mockCNIExec{findErr: errors.New("not found")},
+			wantErrContains: []string{"failed to find IPAM plugin"},
+		},
+		{
+			name:            "plugin exec error",
+			netConf:         validNetConf(),
+			cniBinPath:      "/opt/cni/bin",
+			exec:            &mockCNIExec{execErr: errors.New("exec failed")},
+			wantErrContains: []string{"failed to execute IPAM plugin"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			alloc := newTestAllocator(t, tt.netConf, tt.cniBinPath, true, true)
+			alloc.localNodeStore.Update(func(n *node.LocalNode) {
+				n.IPv4IngressIP = tt.v4Ingress
+				n.IPv6IngressIP = tt.v6Ingress
+			})
+
+			var buf strings.Builder
+			alloc.logger = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+			err := alloc.deallocateIngressIPsWithDelegatedIPAMExecAndNetNS(context.Background(), tt.exec, newFakeNetNS())
+
+			out := buf.String()
+			if len(tt.wantErrContains) > 0 {
+				require.Error(t, err)
+				for _, want := range tt.wantErrContains {
+					require.Containsf(t, err.Error(), want, "expected error substring %q in: %v", want, err)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+			for _, want := range tt.wantInfoContains {
+				require.Containsf(t, out, want, "expected INFO substring %q in logs:\n%s", want, out)
+			}
+			for _, absent := range tt.wantAbsent {
+				require.NotContainsf(t, out, absent, "did not expect %q in logs:\n%s", absent, out)
+			}
+		})
+	}
+}

--- a/daemon/infraendpoints/infra_ip_allocation.go
+++ b/daemon/infraendpoints/infra_ip_allocation.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/sys/unix"
 	"k8s.io/apimachinery/pkg/util/wait"
 
+	"github.com/cilium/cilium/daemon/cmd/cni"
 	"github.com/cilium/cilium/pkg/common"
 	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
@@ -45,17 +46,18 @@ import (
 type infraIPAllocatorParams struct {
 	cell.In
 
-	Logger         *slog.Logger
-	JobGroup       job.Group
-	DaemonConfig   *option.DaemonConfig
-	Config         config
-	DB             *statedb.DB
-	Routes         statedb.Table[*datapathTables.Route]
-	NodeAddrs      statedb.Table[datapathTables.NodeAddress]
-	NodeAddressing node.Addressing
-	LocalNodeStore *node.LocalNodeStore
-	MTU            mtu.MTU
-	IPAM           *ipam.IPAM
+	Logger           *slog.Logger
+	JobGroup         job.Group
+	DaemonConfig     *option.DaemonConfig
+	Config           config
+	DB               *statedb.DB
+	Routes           statedb.Table[*datapathTables.Route]
+	NodeAddrs        statedb.Table[datapathTables.NodeAddress]
+	NodeAddressing   node.Addressing
+	LocalNodeStore   *node.LocalNodeStore
+	MTU              mtu.MTU
+	IPAM             *ipam.IPAM
+	CNIConfigManager cni.CNIConfigManager
 }
 
 type InfraIPAllocator interface {
@@ -67,16 +69,17 @@ var _ InfraIPAllocator = &infraIPAllocator{}
 
 // infraIPAllocator is responsible to create infra related IPs (router, ingress & health)
 type infraIPAllocator struct {
-	logger         *slog.Logger
-	jobGroup       job.Group
-	daemonConfig   *option.DaemonConfig
-	config         config
-	db             *statedb.DB
-	routes         statedb.Table[*datapathTables.Route]
-	nodeAddressing node.Addressing
-	localNodeStore *node.LocalNodeStore
-	mtuManager     mtu.MTU
-	ipAllocator    ipamAllocator
+	logger           *slog.Logger
+	jobGroup         job.Group
+	daemonConfig     *option.DaemonConfig
+	config           config
+	db               *statedb.DB
+	routes           statedb.Table[*datapathTables.Route]
+	nodeAddressing   node.Addressing
+	localNodeStore   *node.LocalNodeStore
+	mtuManager       mtu.MTU
+	ipAllocator      ipamAllocator
+	cniConfigManager cni.CNIConfigManager
 
 	// healthEndpointRouting is the information required to set up the health
 	// endpoint's routing in ENI or Azure IPAM mode
@@ -92,16 +95,17 @@ type ipamAllocator interface {
 
 func newInfraIPAllocator(params infraIPAllocatorParams) InfraIPAllocator {
 	return &infraIPAllocator{
-		logger:         params.Logger,
-		jobGroup:       params.JobGroup,
-		daemonConfig:   params.DaemonConfig,
-		config:         params.Config,
-		db:             params.DB,
-		routes:         params.Routes,
-		nodeAddressing: params.NodeAddressing,
-		localNodeStore: params.LocalNodeStore,
-		mtuManager:     params.MTU,
-		ipAllocator:    params.IPAM,
+		logger:           params.Logger,
+		jobGroup:         params.JobGroup,
+		daemonConfig:     params.DaemonConfig,
+		config:           params.Config,
+		db:               params.DB,
+		routes:           params.Routes,
+		nodeAddressing:   params.NodeAddressing,
+		localNodeStore:   params.LocalNodeStore,
+		mtuManager:       params.MTU,
+		ipAllocator:      params.IPAM,
+		cniConfigManager: params.CNIConfigManager,
 	}
 }
 
@@ -425,9 +429,15 @@ func (r *infraIPAllocator) allocateHealthIPs(oldV4HealthIP net.IP, oldV6HealthIP
 	return nil
 }
 
-func (r *infraIPAllocator) allocateIngressIPs(oldV4IngressIP net.IP, oldV6IngressIP net.IP) error {
+func (r *infraIPAllocator) allocateIngressIPs(ctx context.Context, oldV4IngressIP net.IP, oldV6IngressIP net.IP) error {
 	if !r.daemonConfig.EnableEnvoyConfig {
 		return nil
+	}
+
+	// When using delegated IPAM, ingress IPs are allocated via the external
+	// CNI IPAM plugin rather than the internal allocator.
+	if r.daemonConfig.IPAM == ipamOption.IPAMDelegatedPlugin {
+		return r.allocateIngressIPsWithDelegatedIPAMExec(ctx, newDefaultCNIExec())
 	}
 
 	ingressIPv4 := oldV4IngressIP
@@ -553,7 +563,19 @@ func (r *infraIPAllocator) AllocateIPs(ctx context.Context) error {
 		return fmt.Errorf("failed to allocate service loopback IPs: %w", err)
 	}
 
-	if err := r.allocateIngressIPs(localNode.IPv4IngressIP, localNode.IPv6IngressIP); err != nil {
+	// When envoy config is disabled but delegated IPAM is in use,
+	// clean up any stale ingress IPs from a previous run.
+	hadStaleIngressIPs := localNode.IPv4IngressIP != nil || localNode.IPv6IngressIP != nil
+	if r.daemonConfig.IPAM == ipamOption.IPAMDelegatedPlugin &&
+		!r.daemonConfig.EnableEnvoyConfig &&
+		hadStaleIngressIPs {
+		if err := r.deallocateIngressIPsWithDelegatedIPAMExec(ctx, newDefaultCNIExec()); err != nil {
+			// Best-effort cleanup: we cannot block agent startup on a misbehaving external plugin.
+			r.logger.Warn("Failed to deallocate stale ingress IPs with delegated IPAM", logfields.Error, err)
+		}
+	}
+
+	if err := r.allocateIngressIPs(ctx, localNode.IPv4IngressIP, localNode.IPv6IngressIP); err != nil {
 		return fmt.Errorf("failed to allocate ingress IPs: %w", err)
 	}
 

--- a/pkg/nodediscovery/nodediscovery_test.go
+++ b/pkg/nodediscovery/nodediscovery_test.go
@@ -42,6 +42,7 @@ func (m *mockCNIConfigManager) GetChainingMode() string             { return "" 
 func (m *mockCNIConfigManager) Status() *apimodels.Status           { return nil }
 func (m *mockCNIConfigManager) GetCustomNetConf() *cnitypes.NetConf { return nil }
 func (m *mockCNIConfigManager) ExternalRoutingEnabled() bool        { return false }
+func (m *mockCNIConfigManager) GetDelegatedIPAMCNIBinPath() string  { return "" }
 
 // TestUpdateCiliumNodeResourceTransientErrorCausesFatal reproduces
 // https://github.com/cilium/cilium/issues/44388: a transient error from the

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3038,9 +3038,12 @@ func (c *DaemonConfig) checkIPAMDelegatedPlugin() error {
 		if c.EnableEndpointHealthChecking {
 			return fmt.Errorf("--%s must be disabled with --%s=%s", EnableEndpointHealthChecking, IPAM, ipamOption.IPAMDelegatedPlugin)
 		}
-		// envoy config (Ingress, Gateway API, ...) require cilium-agent to create an IP address
-		// specifically for differentiating envoy traffic, which is not possible
-		// with delegated IPAM.
+		// Envoy config for Ingress and Gateway API requires cilium-agent to
+		// create an IP address specifically for differentiating envoy traffic,
+		// which is not directly possible with delegated IPAM. CFP-45607
+		// introduces a delegated IPAM path for this. The restriction is
+		// kept here and will be lifted in a later commit once the path is
+		// activated.
 		if c.EnableEnvoyConfig {
 			return fmt.Errorf("--%s must be disabled with --%s=%s", EnableEnvoyConfig, IPAM, ipamOption.IPAMDelegatedPlugin)
 		}

--- a/plugins/cilium-cni/types/types.go
+++ b/plugins/cilium-cni/types/types.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/containernetworking/cni/libcni"
 	cniTypes "github.com/containernetworking/cni/pkg/types"
 	current "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/cni/pkg/version"
@@ -32,6 +33,12 @@ type NetConf struct {
 	LogFormat      string                 `json:"log-format"`
 	LogFile        string                 `json:"log-file"`
 	ChainingMode   string                 `json:"chaining-mode"`
+
+	// PluginConfig holds the cilium-cni plugin block, with name and cniVersion
+	// injected from the conflist envelope, parsed by libcni. It is the complete
+	// plugin configuration handed to a delegated IPAM plugin's stdin, preserving
+	// plugin-specific fields not modeled by NetConf.
+	PluginConfig *libcni.PluginConfig `json:"-"`
 }
 
 // IPAM is the Cilium specific CNI IPAM configuration
@@ -66,6 +73,7 @@ func parsePrevResult(n *NetConf) (*NetConf, error) {
 
 // ReadNetConf reads a CNI configuration file and returns the corresponding
 // NetConf structure
+// For conflists, NetConf.PluginConfig is populated best-effort for delegated IPAM use.
 func ReadNetConf(path string) (*NetConf, error) {
 	b, err := os.ReadFile(path)
 	if err != nil {
@@ -76,6 +84,28 @@ func ReadNetConf(path string) (*NetConf, error) {
 	if err := json.Unmarshal(b, netConfList); err == nil {
 		for _, plugin := range netConfList.Plugins {
 			if plugin.Type == "cilium-cni" {
+				// Best-effort: capture libcni plugin block bytes for delegated IPAM,
+				// with conflist name and cniVersion injected.
+				if confList, err := libcni.NetworkConfFromBytes(b); err == nil {
+					for _, p := range confList.Plugins {
+						if p.Network == nil || p.Network.Type != "cilium-cni" {
+							continue
+						}
+						// InjectConf takes the cilium-cni plugin block as libcni parsed it from
+						// the conflist and returns a new *libcni.PluginConfig whose .Bytes are
+						// the original plugin block with name and cniVersion merged in. That is
+						// the shape a CNI IPAM plugin expects on stdin.
+						ipamInput, err := libcni.InjectConf(p, map[string]any{
+							"name":       confList.Name,
+							"cniVersion": confList.CNIVersion,
+						})
+						if err != nil {
+							return nil, fmt.Errorf("failed to inject name/cniVersion into cilium-cni plugin block of conflist %q: %w", path, err)
+						}
+						plugin.PluginConfig = ipamInput
+						break
+					}
+				}
 				return parsePrevResult(plugin)
 			}
 		}

--- a/plugins/cilium-cni/types/types_test.go
+++ b/plugins/cilium-cni/types/types_test.go
@@ -6,6 +6,7 @@ package types
 import (
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	cnitypes "github.com/containernetworking/cni/pkg/types"
@@ -27,6 +28,10 @@ func testConfRead(t *testing.T, confContent string, netconf *NetConf) {
 
 	netConf, err := ReadNetConf(p)
 	require.NoError(t, err)
+
+	// PluginConfig is verified separately in TestReadCNIConfPluginConfig. Strip it
+	// here for fixture parity.
+	netConf.PluginConfig = nil
 
 	require.Equal(t, netConf, netconf)
 }
@@ -310,4 +315,104 @@ func TestReadCNIConfError(t *testing.T) {
 
 	_, err = ReadNetConf(p)
 	require.Error(t, err)
+}
+
+func TestReadCNIConfPluginConfig(t *testing.T) {
+	// Conflist with delegated IPAM fields such as "ranges" and "dataDir" not
+	// modeled by NetConf.IPAM, PluginConfig.Bytes must preserve them verbatim.
+	conflist := `{
+  "cniVersion": "1.0.0",
+  "name": "cilium",
+  "plugins": [
+    {
+      "type": "cilium-cni",
+      "ipam": {
+        "type": "host-local",
+        "ranges": [[{"subnet": "10.10.0.0/24"}]],
+        "dataDir": "/var/lib/cni/networks/cilium"
+      }
+    }
+  ]
+}`
+
+	p := filepath.Join(t.TempDir(), "conflist")
+	require.NoError(t, os.WriteFile(p, []byte(conflist), 0644))
+
+	nc, err := ReadNetConf(p)
+	require.NoError(t, err)
+
+	// Typed field is populated.
+	require.Equal(t, "host-local", nc.IPAM.Type)
+
+	// PluginConfig pairs the typed parse with verbatim bytes.
+	require.NotNil(t, nc.PluginConfig)
+	require.NotNil(t, nc.PluginConfig.Network)
+	require.Equal(t, "cilium-cni", nc.PluginConfig.Network.Type)
+
+	// Verbatim bytes preserve unknown plugin-specific fields and inject conflist name/cniVersion.
+	require.NotEmpty(t, nc.PluginConfig.Bytes)
+	raw := string(nc.PluginConfig.Bytes)
+	require.Contains(t, raw, `"ranges"`)
+	require.Contains(t, raw, `"10.10.0.0/24"`)
+	require.Contains(t, raw, `"dataDir"`)
+	require.Contains(t, raw, `"/var/lib/cni/networks/cilium"`)
+	require.Contains(t, raw, `"name":"cilium"`)
+	require.Contains(t, raw, `"cniVersion":"1.0.0"`)
+}
+
+func TestLoadNetConfPluginConfig(t *testing.T) {
+	// LoadNetConf is the cilium-cni plugin's bytes-entry path. It does not populate
+	// PluginConfig. Only the daemon's ReadNetConf path does, for delegated IPAM.
+	in := []byte(`{
+  "cniVersion": "1.0.0",
+  "name": "cilium",
+  "type": "cilium-cni",
+  "ipam": {
+    "type": "host-local",
+    "ranges": [[{"subnet": "10.10.0.0/24"}]]
+  }
+}`)
+	nc, err := LoadNetConf(in)
+	require.NoError(t, err)
+	require.Nil(t, nc.PluginConfig)
+}
+
+func TestReadCNIConfPluginConfigChained(t *testing.T) {
+	// Conflist with cilium-cni chained after another plugin. Verifies:
+	//   1. We find cilium-cni even when it is not the first plugin.
+	//   2. PluginConfig.Bytes carries ONLY the cilium-cni block, not sibling
+	//      plugins. Delegated IPAM exec must not see portmap config.
+	conflist := `{
+  "cniVersion": "1.0.0",
+  "name": "cilium",
+  "plugins": [
+    {
+      "type": "portmap",
+      "capabilities": {"portMappings": true}
+    },
+    {
+      "type": "cilium-cni",
+      "ipam": {
+        "type": "host-local",
+        "ranges": [[{"subnet": "10.10.0.0/24"}]]
+      }
+    }
+  ]
+}`
+
+	p := filepath.Join(t.TempDir(), "conflist")
+	require.NoError(t, os.WriteFile(p, []byte(conflist), 0644))
+
+	nc, err := ReadNetConf(p)
+	require.NoError(t, err)
+
+	require.NotNil(t, nc.PluginConfig)
+	require.Equal(t, "cilium-cni", nc.PluginConfig.Network.Type)
+
+	raw := string(nc.PluginConfig.Bytes)
+	require.Contains(t, raw, `"type":"cilium-cni"`)
+	require.Contains(t, raw, `"host-local"`)
+	// Sibling plugin must not leak into the cilium-cni block.
+	require.NotContains(t, raw, "portmap")
+	require.NotContains(t, raw, "portMappings")
 }


### PR DESCRIPTION
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Write a short paragraph that states whether you used machine learning models
      (including LLMs and other generative AI), and indicate the rating using
      [AI Influence Level](https://danielmiessler.com/blog/ai-influence-level-ail).
     The functional go code part of this PR was AIL:3, the unit tests were AIL:3, the actions conformance workflow yaml was AIL:4, see `Subsequent PR's` section

<!-- Description of change -->
### Implements https://github.com/cilium/design-cfps/pull/93

The tl;dr version of this PR is to allow IPAM plugins to be mapped into the cilium-agent, and then when specifying delegated as the IPAM provider, allow cilium-agent to make the IPAM call and allocate an IP to be used for ingress. Full CFP above.

Fixes: https://github.com/cilium/cilium/issues/45607

Note: Below diffs are from effectively fracturing: https://github.com/cilium/cilium/pull/45818 into several PR's to minimize tagging codeowners, which was used as a proof of concept

### Subsequent diffs to be opened relating to the CFP after this PR:
1. Skipping ingress identity restoration with delegated IPAM:
https://github.com/matmerr/cilium/compare/matmerr/gw-delegated-cfp-45607-core...matmerr:cilium:matmerr/gw-delegated-cfp-45607-ipcache-skip

2. Docs, agent flags, and enable:
https://github.com/matmerr/cilium/compare/matmerr/gw-delegated-cfp-45607-ipcache-skip...matmerr:cilium:matmerr/gw-delegated-cfp-45607-activate
###

3. Delegated IPAM + Gateway Conformance:
https://github.com/matmerr/cilium/compare/matmerr/gw-delegated-cfp-45607-activate...matmerr:cilium:matmerr/gw-delegated-cfp-45607-ci


---
```release-note
Add internal infrastructure to allocate gateway ingress IPs via an external delegated IPAM plugin. The path is gated off in this commit and will be activated in the future.
```