### PR TITLE
pkg/metrics: policy_change_total fail enum should be "failure"

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -804,7 +804,7 @@ func NewLegacyMetrics() *LegacyMetrics {
 			},
 			{
 				Name:   LabelOutcome,
-				Values: metric.NewValues(LabelValueOutcomeSuccess, LabelValueOutcomeFailure),
+				Values: metric.NewValues(LabelValueOutcomeSuccess, LabelValueOutcomeFail),
 			},
 		}),
 


### PR DESCRIPTION
The pre-scoped label range should be "success" and "fail". Most uses of this metric use "fail" with one exception. If this metric is called in CI with "failure" then it will cause panics (only in CI).
To prevent this we correctly emit the metric as "fail".

```release-note
Fix instance of cilium having incorrect specified policy_change_total failure label "failure" value which caused unnecessary warnings. 
```
