### PR TITLE
Clamp tunnel device GSO size to its tso_max_size

### DIFF
--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/bigtcp"
+	bigtcptypes "github.com/cilium/cilium/pkg/datapath/linux/bigtcp/types"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/tables"
@@ -329,17 +330,36 @@ func setupVxlanDevice(logger *slog.Logger, sysctl sysctl.Sysctl, port, srcPortLo
 	return nil
 }
 
+// Note that gro_max_size is bounded by the kernel's GRO_MAX_SIZE rather than
+// tso_max_size, so it is not subject to this clamp.
+func tunnelGSOMaxSize(requested, tsoMaxSize int) int {
+	if tsoMaxSize == 0 {
+		tsoMaxSize = bigtcptypes.GROGSOLegacyMaxSize
+	}
+	return min(requested, tsoMaxSize)
+}
+
 func setupTunnelGSOGRO(logger *slog.Logger, device string, bc bigtcp.Config) error {
+	link, err := safenetlink.LinkByName(device)
+	if err != nil {
+		logger.Warn("Tunnel device does not exist, skipping GSO/GRO setup",
+			logfields.Device, device,
+			logfields.Error, err)
+		return nil
+	}
+	tsoMax := int(link.Attrs().TSOMaxSize)
+
 	// IPv6 goes first, because {gso,gro}_ipv4_max_size gets auto-adjusted
 	// if the new size of {gso,gro}_max_size isn't greater than 64KB for
 	// backwards compatibility.
 	if bc.GetGROIPv6MaxSize() != 0 && bc.GetGSOIPv6MaxSize() != 0 {
+		gsoMaxSize := tunnelGSOMaxSize(bc.GetGSOIPv6MaxSize(), tsoMax)
 		logger.Info("Setting IPv6",
 			logfields.Device, device,
-			logfields.GsoMaxSize, bc.GetGSOIPv6MaxSize(),
+			logfields.GsoMaxSize, gsoMaxSize,
 			logfields.GroMaxSize, bc.GetGROIPv6MaxSize(),
 		)
-		err := bigtcp.SetGROGSOIPv6MaxSize(logger, device, bc.GetGROIPv6MaxSize(), bc.GetGSOIPv6MaxSize())
+		err := bigtcp.SetGROGSOIPv6MaxSize(logger, device, bc.GetGROIPv6MaxSize(), gsoMaxSize)
 		if err != nil {
 			logger.Warn("Could not modify IPv6 gro_max_size and gso_max_size",
 				logfields.Device, device,
@@ -348,12 +368,13 @@ func setupTunnelGSOGRO(logger *slog.Logger, device string, bc bigtcp.Config) err
 		}
 	}
 	if bc.GetGROIPv4MaxSize() != 0 && bc.GetGSOIPv4MaxSize() != 0 {
+		gsoMaxSize := tunnelGSOMaxSize(bc.GetGSOIPv4MaxSize(), tsoMax)
 		logger.Info("Setting IPv4",
 			logfields.Device, device,
-			logfields.GsoMaxSize, bc.GetGSOIPv4MaxSize(),
+			logfields.GsoMaxSize, gsoMaxSize,
 			logfields.GroMaxSize, bc.GetGROIPv4MaxSize(),
 		)
-		err := bigtcp.SetGROGSOIPv4MaxSize(logger, device, bc.GetGROIPv4MaxSize(), bc.GetGSOIPv4MaxSize())
+		err := bigtcp.SetGROGSOIPv4MaxSize(logger, device, bc.GetGROIPv4MaxSize(), gsoMaxSize)
 		if err != nil {
 			logger.Warn("Could not modify IPv4 gro_ipv4_max_size and gso_ipv4_max_size",
 				logfields.Device, device,

--- a/pkg/datapath/loader/netlink_test.go
+++ b/pkg/datapath/loader/netlink_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	fakebigtcp "github.com/cilium/cilium/pkg/datapath/linux/bigtcp/fake"
+	bigtcptypes "github.com/cilium/cilium/pkg/datapath/linux/bigtcp/types"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
@@ -209,6 +210,26 @@ func TestPrivilegedSetupTunnelDevice(t *testing.T) {
 			err = netlink.LinkDel(link)
 			require.NoError(t, err)
 
+			return nil
+		})
+	})
+
+	t.Run("VxlanBigTCPClampsGSOToTSO", func(t *testing.T) {
+		ns := netns.NewNetNS(t)
+
+		ns.Do(func() error {
+			bc := &bigTCPStub{groV4: 196608, gsoV4: 196608, groV6: 196608, gsoV6: 196608}
+			err := setupTunnelDevice(logger, sysctl, tunnel.VXLAN, defaults.TunnelPortVXLAN, 0, 0, mtu, bc)
+			require.NoError(t, err)
+
+			link, err := safenetlink.LinkByName(defaults.VxlanDevice)
+			require.NoError(t, err)
+
+			if gso := int(link.Attrs().GSOMaxSize); gso != 0 {
+				require.LessOrEqual(t, gso, bigtcptypes.GROGSOLegacyMaxSize)
+			}
+
+			require.NoError(t, netlink.LinkDel(link))
 			return nil
 		})
 	})
@@ -504,4 +525,56 @@ func TestPrivilegedSetupIPIPDevices(t *testing.T) {
 
 		return nil
 	})
+}
+
+// bigTCPStub is a test stand-in for bigtcp.Config that returns arbitrary
+// GSO/GRO max sizes, used to exercise the tunnel GSO clamping logic.
+type bigTCPStub struct {
+	groV4, gsoV4, groV6, gsoV6 int
+}
+
+func (c *bigTCPStub) IsIPv4Enabled() bool    { return c.gsoV4 != 0 }
+func (c *bigTCPStub) IsIPv6Enabled() bool    { return c.gsoV6 != 0 }
+func (c *bigTCPStub) GetGROIPv4MaxSize() int { return c.groV4 }
+func (c *bigTCPStub) GetGSOIPv4MaxSize() int { return c.gsoV4 }
+func (c *bigTCPStub) GetGROIPv6MaxSize() int { return c.groV6 }
+func (c *bigTCPStub) GetGSOIPv6MaxSize() int { return c.gsoV6 }
+
+func TestTunnelGSOMaxSize(t *testing.T) {
+	tests := []struct {
+		name       string
+		requested  int
+		tsoMaxSize int
+		want       int
+	}{
+		{
+			name:       "high-tso NIC, legacy tunnel ceiling: clamp down",
+			requested:  196608,
+			tsoMaxSize: bigtcptypes.GROGSOLegacyMaxSize,
+			want:       bigtcptypes.GROGSOLegacyMaxSize,
+		},
+		{
+			name:       "tso not reported (old kernel): fall back to legacy limit",
+			requested:  196608,
+			tsoMaxSize: 0,
+			want:       bigtcptypes.GROGSOLegacyMaxSize,
+		},
+		{
+			name:       "tunnel supports BIG TCP: no clamp",
+			requested:  196608,
+			tsoMaxSize: 524280,
+			want:       196608,
+		},
+		{
+			name:       "requested already below tso: unchanged",
+			requested:  bigtcptypes.GROGSOLegacyMaxSize,
+			tsoMaxSize: 524280,
+			want:       bigtcptypes.GROGSOLegacyMaxSize,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tunnelGSOMaxSize(tt.requested, tt.tsoMaxSize))
+		})
+	}
 }


### PR DESCRIPTION
When a NIC advertises a high tso_max_size, BIG TCP derives a 196608 GSO limit and pushes it onto the flow based vxlan device whose own tso_max_size is still 65536. The kernel refuses any GSO size above tso_max_size so the vxlan setup fails with invalid argument and the agent gets stuck retrying. This change clamps the GSO size applied to the tunnel device to that device tso_max_size and leaves GRO untouched since it is bounded by GRO_MAX_SIZE instead. It adds a unit test for the clamp logic and a privileged regression test that reproduces the original failure. Fixes #46337

```release-note
Fix BIG TCP failing to set up the vxlan tunnel device on nodes with NICs that advertise a high tso_max_size
```