### PR TITLE
endpointmanager: release endpoint IDs after endpoint teardown

### DIFF
--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -473,37 +473,56 @@ func (mgr *endpointManager) unexpose(ep *endpoint.Endpoint) {
 	defer ep.Close()
 	identifiers := ep.Identifiers()
 
-	previousState := ep.GetState()
-
 	mgr.mutex.Lock()
 	defer mgr.mutex.Unlock()
 
-	// This must be done before the ID is released for the endpoint!
 	delete(mgr.endpoints, ep.ID)
 	mgr.mcastManager.RemoveAddress(ep.IPv6)
+	mgr.removeReferencesLocked(identifiers)
+}
 
+// releaseID returns the endpoint's numeric ID back to the allocation pool, so
+// that it may be reused by a subsequently created endpoint.
+//
+// This must only be called once the endpoint's BPF maps, programs and pins
+// (which are all keyed solely by this numeric ID, e.g. cilium_policy_v2_<id>
+// and cilium_calls_<id>) have been fully removed by ep.Delete(). Releasing the
+// ID any earlier would allow a new endpoint to be allocated the same ID while
+// the old endpoint's BPF state is still being torn down: the new endpoint
+// could then silently load and reuse the old endpoint's stale, pinned policy
+// map (and its now-irrelevant policy entries), or have its own freshly created
+// maps removed by the old endpoint's in-flight cleanup.
+func (mgr *endpointManager) releaseID(ep *endpoint.Endpoint, previousState endpoint.State) {
 	// We haven't yet allocated the ID for a restoring endpoint, so no
 	// need to release it.
-	if previousState != endpoint.StateRestoring {
-		if err := mgr.epIDAllocator.release(ep.ID); err != nil {
-			mgr.logger.Warn(
-				"Unable to release endpoint ID",
-				logfields.Error, err,
-				logfields.State, previousState,
-				logfields.CNIAttachmentID, identifiers[endpointid.CNIAttachmentIdPrefix],
-				logfields.CEPName, identifiers[endpointid.CEPNamePrefix],
-			)
-		}
+	if previousState == endpoint.StateRestoring {
+		return
 	}
 
-	mgr.removeReferencesLocked(identifiers)
+	if err := mgr.epIDAllocator.release(ep.ID); err != nil {
+		identifiers := ep.Identifiers()
+		mgr.logger.Warn(
+			"Unable to release endpoint ID",
+			logfields.Error, err,
+			logfields.State, previousState,
+			logfields.CNIAttachmentID, identifiers[endpointid.CNIAttachmentIdPrefix],
+			logfields.CEPName, identifiers[endpointid.CEPNamePrefix],
+		)
+	}
 }
 
 // removeEndpoint stops the active handling of events by the specified endpoint,
 // and prevents the endpoint from being globally accessible via other packages.
 func (mgr *endpointManager) removeEndpoint(ep *endpoint.Endpoint, conf endpoint.DeleteConfig) []error {
+	previousState := ep.GetState()
+
 	mgr.unexpose(ep)
 	result := ep.Delete(conf)
+
+	// Only release the endpoint's numeric ID for reuse once ep.Delete() above
+	// has finished removing all of the endpoint's ID-keyed BPF maps, programs
+	// and pins. See releaseID for why this ordering matters.
+	mgr.releaseID(ep, previousState)
 
 	if !option.Config.DryMode {
 		_ = mgr.monitorAgent.SendEvent(monitorAPI.MessageTypeAgent, monitorAPI.EndpointDeleteMessage(ep))

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -34,7 +34,12 @@ import (
 )
 
 func (mgr *endpointManager) waitEndpointRemoved(ep *endpoint.Endpoint, conf endpoint.DeleteConfig) []error {
+	previousState := ep.GetState()
 	mgr.unexpose(ep)
+	// Unlike the production removeEndpoint() path, this test helper skips
+	// ep.Delete() (and therefore never tears down any BPF state), so it is
+	// safe to release the endpoint's ID for reuse immediately.
+	mgr.releaseID(ep, previousState)
 	ep.Stop()
 	return nil
 }
@@ -561,6 +566,67 @@ func TestLookupCNIAttachmentID(t *testing.T) {
 
 	bad = mgr.LookupCNIAttachmentID("asdf")
 	require.Nil(t, bad)
+}
+
+// TestRemoveEndpointReleasesIDOnlyAfterDelete is a regression test ensuring
+// that an endpoint's numeric ID is not returned to the allocation pool until
+// ep.Delete() has finished tearing down the endpoint's BPF maps, programs and
+// pins (which are keyed solely by that numeric ID, e.g. cilium_policy_v2_<id>
+// and cilium_calls_<id>).
+//
+// Releasing the ID any earlier would let a newly created endpoint be handed
+// the very same ID while the old endpoint's BPF state is still being removed,
+// allowing it to silently load and reuse the old endpoint's stale, pinned
+// policy map.
+func TestRemoveEndpointReleasesIDOnlyAfterDelete(t *testing.T) {
+	s := setupEndpointManagerSuite(t)
+	logger := hivetest.Logger(t)
+
+	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
+	ep, err := endpoint.NewEndpointFromChangeModel(endpoint.EndpointParams{
+		EPBuildQueue:    &endpoint.MockEndpointBuildQueue{},
+		Allocator:       testidentity.NewMockIdentityAllocator(nil),
+		CTMapGC:         ctmap.NewFakeGCRunner(),
+		WgConfig:        &fakewireguard.Config{},
+		IPSecConfig:     fakeipsec.Config{},
+		Logger:          logger,
+		IdentityManager: identitymanager.NewIDManager(logger),
+		PolicyRepo:      s.repo,
+	}, nil, &endpoint.FakeEndpointProxy{}, &apiv1.EndpointChangeRequest{
+		ContainerID:            "release-id-test",
+		ContainerInterfaceName: "eth0",
+	}, nil)
+	require.NoError(t, err)
+	require.NoError(t, mgr.expose(ep))
+
+	id := ep.ID
+	previousState := ep.GetState()
+
+	// idIsFree probes whether the given ID is currently sitting in the free
+	// pool. reuse() removes the ID from the pool if present (returning nil),
+	// or fails if the ID is not currently free.
+	idIsFree := func(id uint16) bool {
+		if err := mgr.epIDAllocator.reuse(id); err != nil {
+			return false
+		}
+		// Put it back so the pool is left as we found it.
+		require.NoError(t, mgr.epIDAllocator.release(id))
+		return true
+	}
+
+	// Sanity check: the ID is allocated to our endpoint and not free.
+	require.False(t, idIsFree(id), "endpoint ID must be allocated while the endpoint is exposed")
+
+	// unexpose() removes the endpoint from lookups, but must NOT yet release
+	// the ID back to the pool: the endpoint's BPF state is still in place and
+	// ep.Delete() (which removes it) has not run yet.
+	mgr.unexpose(ep)
+	require.False(t, idIsFree(id), "endpoint ID must remain reserved after unexpose() until ep.Delete() has torn down its BPF state")
+
+	// Only once the (simulated) deletion of the endpoint's BPF state has
+	// completed should the ID be handed back to the pool.
+	mgr.releaseID(ep, previousState)
+	require.True(t, idIsFree(id), "endpoint ID must be released back to the pool after deletion completes")
 }
 
 func TestLookupIPv4(t *testing.T) {


### PR DESCRIPTION
unexpose() currently returns an endpoint ID to the allocator before the endpoint deletion path has completed.

Move the ID release out of unexpose() and defer it until after ep.Delete() returns. This keeps the ID allocated for the full lifetime of endpoint teardown while preserving the existing endpoint removal flow.

Also update the test helper that skips ep.Delete() and add a regression test covering the release ordering.

This PR was prepared with AI:3. I personally reviewed the fix and test.

```release-note
  Fixed a race condition where an endpoint ID could be reused before the
  outgoing endpoint's BPF maps and pins were fully removed
```