### PR TITLE
loadbalancer: Fix dropping traffic L2Announcement with externalTrafficPolicy: Local

### DIFF
--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -153,21 +153,21 @@ func (l2a *L2Announcer) hasLocalBackends(txn statedb.ReadTxn, svc *loadbalancer.
 }
 
 func (l2a *L2Announcer) run(ctx context.Context, health cell.Health) error {
+	wtxn := l2a.params.StateDB.WriteTxn(l2a.params.Services, l2a.params.Backends)
+	defer wtxn.Abort()
+
 	// Start watching the 'services' table for changes.
-	wtxn := l2a.params.StateDB.WriteTxn(l2a.params.Services)
 	svcChangeIter, err := l2a.params.Services.Changes(wtxn)
-	wtxn.Commit()
 	if err != nil {
 		return err
 	}
 
 	// Initialize backends table
-	wtxnBe := l2a.params.StateDB.WriteTxn(l2a.params.Backends)
-	beChangeIter, err := l2a.params.Backends.Changes(wtxnBe)
-	wtxnBe.Commit()
+	beChangeIter, err := l2a.params.Backends.Changes(wtxn)
 	if err != nil {
 		return err
 	}
+	wtxn.Commit()
 
 	// Wait for services to initialize
 	_, servicesInitialized := l2a.params.Services.Initialized(l2a.params.StateDB.ReadTxn())

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -212,7 +212,8 @@ func (l2a *L2Announcer) run(ctx context.Context, health cell.Health) error {
 loop:
 	for {
 		// Processing svc change
-		svcChanges, svcWatch := svcChangeIter.Next(l2a.params.StateDB.ReadTxn())
+		txn := l2a.params.StateDB.ReadTxn()
+		svcChanges, svcWatch := svcChangeIter.Next(txn)
 		for event := range svcChanges {
 			if err := l2a.processSvcEvent(event); err != nil {
 				l2a.params.Logger.Warn("Error processing service event",
@@ -222,13 +223,10 @@ loop:
 		}
 
 		// Processing backend change
-		beChanges, beWatch := beChangeIter.Next(l2a.params.StateDB.ReadTxn())
+		beChanges, beWatch := beChangeIter.Next(txn)
 		for event := range beChanges {
 			// Get the backend struct which changed
 			backend := event.Object
-
-			// Retrieve the relevant service from StateDB and re-execute upsertSvc
-			txn := l2a.params.StateDB.ReadTxn()
 			svc, _, found := l2a.params.Services.Get(txn, loadbalancer.ServiceByName(backend.ServiceName))
 			if found {
 				if err := l2a.upsertSvc(svc); err != nil {

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -72,6 +72,7 @@ type l2AnnouncerParams struct {
 	Clientset            k8sClient.Clientset
 	Services             statedb.Table[*loadbalancer.Service]
 	Frontends            statedb.Table[*loadbalancer.Frontend]
+	Backends             statedb.Table[*loadbalancer.Backend]
 	L2AnnouncementPolicy resource.Resource[*cilium_api_v2alpha1.CiliumL2AnnouncementPolicy]
 	LocalNodeResource    daemon_k8s.LocalCiliumNodeResource
 	L2AnnounceTable      statedb.RWTable[*tables.L2AnnounceEntry]
@@ -137,6 +138,20 @@ func NewL2Announcer(params l2AnnouncerParams) *L2Announcer {
 	return announcer
 }
 
+func (l2a *L2Announcer) hasLocalBackends(txn statedb.ReadTxn, svc *loadbalancer.Service) bool {
+	// Get all backends from svc name
+	seq, _ := loadbalancer.ListBackendsByServiceName(txn, l2a.params.Backends, svc.Name)
+
+	for be := range seq {
+		// Returns `true` if there is at least one backend that belongs to the current node and is alive.
+		if be.NodeName == l2a.localNode.Name && be.IsAlive() {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (l2a *L2Announcer) run(ctx context.Context, health cell.Health) error {
 	// Start watching the 'services' table for changes.
 	wtxn := l2a.params.StateDB.WriteTxn(l2a.params.Services)
@@ -145,6 +160,15 @@ func (l2a *L2Announcer) run(ctx context.Context, health cell.Health) error {
 	if err != nil {
 		return err
 	}
+
+	// Initialize backends table
+	wtxnBe := l2a.params.StateDB.WriteTxn(l2a.params.Backends)
+	beChangeIter, err := l2a.params.Backends.Changes(wtxnBe)
+	wtxnBe.Commit()
+	if err != nil {
+		return err
+	}
+
 	// Wait for services to initialize
 	_, servicesInitialized := l2a.params.Services.Initialized(l2a.params.StateDB.ReadTxn())
 	select {
@@ -187,6 +211,7 @@ func (l2a *L2Announcer) run(ctx context.Context, health cell.Health) error {
 
 loop:
 	for {
+		// Processing svc change
 		svcChanges, svcWatch := svcChangeIter.Next(l2a.params.StateDB.ReadTxn())
 		for event := range svcChanges {
 			if err := l2a.processSvcEvent(event); err != nil {
@@ -196,11 +221,32 @@ loop:
 			}
 		}
 
+		// Processing backend change
+		beChanges, beWatch := beChangeIter.Next(l2a.params.StateDB.ReadTxn())
+		for event := range beChanges {
+			// Get the backend struct which changed
+			backend := event.Object
+
+			// Retrieve the relevant service from StateDB and re-execute upsertSvc
+			txn := l2a.params.StateDB.ReadTxn()
+			svc, _, found := l2a.params.Services.Get(txn, loadbalancer.ServiceByName(backend.ServiceName))
+			if found {
+				if err := l2a.upsertSvc(svc); err != nil {
+					l2a.params.Logger.Warn("Error re-evaluating service on backend change",
+						logfields.Error, err,
+						"service", backend.ServiceName,
+					)
+				}
+			}
+		}
+
 		select {
 		case <-ctx.Done():
 			break loop
 
 		case <-svcWatch:
+
+		case <-beWatch:
 
 		case event, more := <-policyChan:
 			// resource closed, shutting down
@@ -338,6 +384,12 @@ func (l2a *L2Announcer) upsertSvc(svc *loadbalancer.Service) error {
 		}
 	}
 	key := serviceKey(svc)
+
+	// If ext traffic policy is `Local`, check that l2a is assigned to the correct node
+	if svc.ExtTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal && !l2a.hasLocalBackends(txn, svc) {
+		return l2a.delSvc(key)
+	}
+
 	noExternal := len(externalAddresses) == 0
 	noLB := len(lbAddresses) == 0
 	if noExternal && noLB {

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -234,7 +234,7 @@ loop:
 				if err := l2a.upsertSvc(svc); err != nil {
 					l2a.params.Logger.Warn("Error re-evaluating service on backend change",
 						logfields.Error, err,
-						"service", backend.ServiceName,
+						logfields.ServiceName, backend.ServiceName,
 					)
 				}
 			}

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -72,6 +72,7 @@ type l2AnnouncerParams struct {
 	Clientset            k8sClient.Clientset
 	Services             statedb.Table[*loadbalancer.Service]
 	Frontends            statedb.Table[*loadbalancer.Frontend]
+	Backends             statedb.Table[*loadbalancer.Backend]
 	L2AnnouncementPolicy resource.Resource[*cilium_api_v2alpha1.CiliumL2AnnouncementPolicy]
 	LocalNodeResource    daemon_k8s.LocalCiliumNodeResource
 	L2AnnounceTable      statedb.RWTable[*tables.L2AnnounceEntry]
@@ -137,6 +138,20 @@ func NewL2Announcer(params l2AnnouncerParams) *L2Announcer {
 	return announcer
 }
 
+func (l2a *L2Announcer) hasLocalBackends(txn statedb.ReadTxn, svc *loadbalancer.Service) bool {
+	// Get all backends from svc name
+	seq, _ := loadbalancer.ListBackendsByServiceName(txn, l2a.params.Backends, svc.Name)
+
+	for be := range seq {
+		// Returns `true` if there is at least one backend that belongs to the current node and is alive.
+		if be.NodeName == l2a.localNode.Name && be.IsAlive() {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (l2a *L2Announcer) run(ctx context.Context, health cell.Health) error {
 	// Start watching the 'services' table for changes.
 	wtxn := l2a.params.StateDB.WriteTxn(l2a.params.Services)
@@ -152,6 +167,15 @@ func (l2a *L2Announcer) run(ctx context.Context, health cell.Health) error {
 	if err != nil {
 		return err
 	}
+
+	// Initialize backends table
+	wtxnBe := l2a.params.StateDB.WriteTxn(l2a.params.Backends)
+	beChangeIter, err := l2a.params.Backends.Changes(wtxnBe)
+	wtxnBe.Commit()
+	if err != nil {
+		return err
+	}
+
 	// Wait for services to initialize
 	_, servicesInitialized := l2a.params.Services.Initialized(l2a.params.StateDB.ReadTxn())
 	select {
@@ -196,6 +220,7 @@ loop:
 	for {
 		rtxn := l2a.params.StateDB.ReadTxn()
 
+		// Processing svc change
 		svcChanges, svcWatch := svcChangeIter.Next(rtxn)
 		for event := range svcChanges {
 			if err := l2a.processSvcEvent(rtxn, event); err != nil {
@@ -214,6 +239,25 @@ loop:
 			}
 		}
 
+		// Processing backend change
+		beChanges, beWatch := beChangeIter.Next(l2a.params.StateDB.ReadTxn())
+		for event := range beChanges {
+			// Get the backend struct which changed
+			backend := event.Object
+
+			// Retrieve the relevant service from StateDB and re-execute upsertSvc
+			txn := l2a.params.StateDB.ReadTxn()
+			svc, _, found := l2a.params.Services.Get(txn, loadbalancer.ServiceByName(backend.ServiceName))
+			if found {
+				if err := l2a.upsertSvc(txn, svc); err != nil {
+					l2a.params.Logger.Warn("Error re-evaluating service on backend change",
+						logfields.Error, err,
+						"service", backend.ServiceName,
+					)
+				}
+			}
+		}
+
 		select {
 		case <-ctx.Done():
 			break loop
@@ -221,6 +265,7 @@ loop:
 		case <-svcWatch:
 
 		case <-frontendWatch:
+		case <-beWatch:
 
 		case event, more := <-policyChan:
 			// resource closed, shutting down
@@ -356,6 +401,12 @@ func (l2a *L2Announcer) upsertSvc(rtxn statedb.ReadTxn, svc *loadbalancer.Servic
 		}
 	}
 	key := serviceKey(svc)
+
+	// If ext traffic policy is `Local`, check that l2a is assigned to the correct node
+	if svc.ExtTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal && !l2a.hasLocalBackends(rtxn, svc) {
+		return l2a.delSvc(key)
+	}
+
 	noExternal := len(externalAddresses) == 0
 	noLB := len(lbAddresses) == 0
 	if noExternal && noLB {

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -252,7 +252,7 @@ loop:
 				if err := l2a.upsertSvc(txn, svc); err != nil {
 					l2a.params.Logger.Warn("Error re-evaluating service on backend change",
 						logfields.Error, err,
-						"service", backend.ServiceName,
+						logfields.ServiceName, backend.ServiceName,
 					)
 				}
 			}

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -72,6 +72,7 @@ type l2AnnouncerParams struct {
 	Clientset            k8sClient.Clientset
 	Services             statedb.Table[*loadbalancer.Service]
 	Frontends            statedb.Table[*loadbalancer.Frontend]
+	Backends             statedb.Table[*loadbalancer.Backend]
 	L2AnnouncementPolicy resource.Resource[*cilium_api_v2alpha1.CiliumL2AnnouncementPolicy]
 	LocalNodeResource    daemon_k8s.LocalCiliumNodeResource
 	L2AnnounceTable      statedb.RWTable[*tables.L2AnnounceEntry]
@@ -137,21 +138,44 @@ func NewL2Announcer(params l2AnnouncerParams) *L2Announcer {
 	return announcer
 }
 
+func (l2a *L2Announcer) hasLocalBackends(txn statedb.ReadTxn, svc *loadbalancer.Service) bool {
+	// Get all backends from svc name
+	seq, _ := loadbalancer.ListBackendsByServiceName(txn, l2a.params.Backends, svc.Name)
+
+	for be := range seq {
+		// Returns `true` if there is at least one backend that belongs to the current node and is alive.
+		if be.NodeName == l2a.localNode.Name && be.IsAlive() {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (l2a *L2Announcer) run(ctx context.Context, health cell.Health) error {
 	// Start watching the 'services' table for changes.
 	wtxn := l2a.params.StateDB.WriteTxn(l2a.params.Services)
 	svcChangeIter, err := l2a.params.Services.Changes(wtxn)
-	wtxn.Commit()
 	if err != nil {
 		return err
 	}
+	wtxn.Commit()
 
 	wtxn = l2a.params.StateDB.WriteTxn(l2a.params.Frontends)
 	frontendChangeIter, err := l2a.params.Frontends.Changes(wtxn)
-	wtxn.Commit()
 	if err != nil {
 		return err
 	}
+	wtxn.Commit()
+
+	// Initialize backends table
+	wtxn = l2a.params.StateDB.WriteTxn(l2a.params.Backends)
+	beChangeIter, err := l2a.params.Backends.Changes(wtxn)
+	if err != nil {
+		return err
+	}
+	wtxn.Commit()
+
 	// Wait for services to initialize
 	_, servicesInitialized := l2a.params.Services.Initialized(l2a.params.StateDB.ReadTxn())
 	select {
@@ -196,6 +220,7 @@ loop:
 	for {
 		rtxn := l2a.params.StateDB.ReadTxn()
 
+		// Processing svc change
 		svcChanges, svcWatch := svcChangeIter.Next(rtxn)
 		for event := range svcChanges {
 			if err := l2a.processSvcEvent(rtxn, event); err != nil {
@@ -214,13 +239,24 @@ loop:
 			}
 		}
 
+		// Processing backend change
+		beChanges, beWatch := beChangeIter.Next(rtxn)
+		for event := range beChanges {
+			if err := l2a.processBackendEvent(rtxn, event); err != nil {
+				l2a.params.Logger.Warn("Error processing backend event",
+					logfields.Error, err,
+				)
+			}
+		}
+
 		select {
 		case <-ctx.Done():
 			break loop
 
 		case <-svcWatch:
-
 		case <-frontendWatch:
+		case <-beWatch:
+			// Continue, one of our change iterators has new events.
 
 		case event, more := <-policyChan:
 			// resource closed, shutting down
@@ -356,6 +392,7 @@ func (l2a *L2Announcer) upsertSvc(rtxn statedb.ReadTxn, svc *loadbalancer.Servic
 		}
 	}
 	key := serviceKey(svc)
+
 	noExternal := len(externalAddresses) == 0
 	noLB := len(lbAddresses) == 0
 	if noExternal && noLB {
@@ -366,6 +403,11 @@ func (l2a *L2Announcer) upsertSvc(rtxn statedb.ReadTxn, svc *loadbalancer.Servic
 	// Ignore services managed by an unsupported load balancer class.
 	if svc.LoadBalancerClass != nil &&
 		*svc.LoadBalancerClass != cilium_api_v2alpha1.L2AnnounceLoadBalancerClass {
+		return l2a.delSvc(key)
+	}
+
+	// Ignore services that only forward to local backends but have none
+	if svc.ExtTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal && !l2a.hasLocalBackends(rtxn, svc) {
 		return l2a.delSvc(key)
 	}
 
@@ -467,6 +509,16 @@ func (l2a *L2Announcer) processFrontendEvent(rtxn statedb.ReadTxn, event statedb
 		return l2a.upsertSvc(rtxn, svc)
 	}
 	return l2a.delSvc(types.NamespacedName{Namespace: name.Namespace(), Name: name.Name()})
+}
+
+func (l2a *L2Announcer) processBackendEvent(rtxn statedb.ReadTxn, event statedb.Change[*loadbalancer.Backend]) error {
+	name := event.Object.ServiceName
+	svc, _, found := l2a.params.Services.Get(rtxn, loadbalancer.ServiceByName(name))
+	if !found {
+		return nil
+	}
+
+	return l2a.upsertSvc(rtxn, svc)
 }
 
 func policyKey(policy *cilium_api_v2alpha1.CiliumL2AnnouncementPolicy) types.NamespacedName {
@@ -620,6 +672,11 @@ func (l2a *L2Announcer) upsertPolicy(ctx context.Context, policy *cilium_api_v2a
 
 		if !((policy.Spec.ExternalIPs && !noExternal) ||
 			(policy.Spec.LoadBalancerIPs && !noLB)) {
+			continue
+		}
+
+		// Ignore services that only forward to local backends but have none
+		if svc.ExtTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal && !l2a.hasLocalBackends(txn, svc) {
 			continue
 		}
 

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -153,10 +153,11 @@ func (l2a *L2Announcer) hasLocalBackends(txn statedb.ReadTxn, svc *loadbalancer.
 }
 
 func (l2a *L2Announcer) run(ctx context.Context, health cell.Health) error {
+	wtxn := l2a.params.StateDB.WriteTxn(l2a.params.Services, l2a.params.Backends)
+	defer wtxn.Abort()
+
 	// Start watching the 'services' table for changes.
-	wtxn := l2a.params.StateDB.WriteTxn(l2a.params.Services)
 	svcChangeIter, err := l2a.params.Services.Changes(wtxn)
-	wtxn.Commit()
 	if err != nil {
 		return err
 	}
@@ -169,12 +170,11 @@ func (l2a *L2Announcer) run(ctx context.Context, health cell.Health) error {
 	}
 
 	// Initialize backends table
-	wtxnBe := l2a.params.StateDB.WriteTxn(l2a.params.Backends)
-	beChangeIter, err := l2a.params.Backends.Changes(wtxnBe)
-	wtxnBe.Commit()
+	beChangeIter, err := l2a.params.Backends.Changes(wtxn)
 	if err != nil {
 		return err
 	}
+	wtxn.Commit()
 
 	// Wait for services to initialize
 	_, servicesInitialized := l2a.params.Services.Initialized(l2a.params.StateDB.ReadTxn())

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -485,11 +485,20 @@ func (l2a *L2Announcer) upsertSvc(rtxn statedb.ReadTxn, svc *loadbalancer.Servic
 
 func (l2a *L2Announcer) withdrawServiceLeaseAndEntries(ss *selectedService) error {
 	// Stop leader election for this service, if we are leader, this will also remove the entries from the output table.
-	select {
-	case <-ss.done:
-		// if the channel is already closed, we are not leader for this service, so nothing to do.
-	default:
-		close(ss.done)
+	if ss.running {
+		if ss.cancel != nil {
+			ss.cancel()
+			ss.cancel = nil
+		}
+
+		if ss.done != nil {
+			select {
+			case <-ss.done:
+			default:
+				close(ss.done)
+			}
+		}
+		ss.running = false
 	}
 
 	if err := l2a.recalculateL2EntriesTableEntries(ss); err != nil {
@@ -897,7 +906,7 @@ func (l2a *L2Announcer) addSelectedService(svc *loadbalancer.Service, extAddrs, 
 		lbAddresses:       lbAddrs,
 		byPolicies:        byPolicies,
 		lock:              l2a.newLeaseLock(svc),
-		done:              make(chan struct{}),
+		done:              nil,
 		leaderChannel:     l2a.leaderChannel,
 		leaseDuration:     leaseDuration,
 		renewDeadline:     renewDeadline,
@@ -912,18 +921,29 @@ func (l2a *L2Announcer) addSelectedService(svc *loadbalancer.Service, extAddrs, 
 }
 
 func (l2a *L2Announcer) startLeaderElectionJob(ss *selectedService) {
-	// done channel is used to signal the leader election job to stop. If it is already closed, we need to create a new one.
-	select {
-	case <-ss.done:
-		ss.done = make(chan struct{})
-	default:
+	if ss.running {
+		return
 	}
+
+	ss.running = true
+	ss.done = make(chan struct{})
+
+	ss.lock = l2a.newLeaseLock(ss.svc)
 
 	// kick off leader election job
 	l2a.scopedGroup.Add(job.OneShot(
 		shortener.ShortenHiveJobName(fmt.Sprintf("leader-election-%s-%s", ss.svc.Name.Namespace(), ss.svc.Name.Name())),
-		ss.serviceLeaderElection),
-	)
+		func(jobCtx context.Context, health cell.Health) error {
+			ctx, cancel := context.WithCancel(jobCtx)
+			ss.cancel = cancel
+
+			defer func() {
+				ss.running = false
+				cancel()
+			}()
+			return ss.serviceLeaderElection(ctx, health)
+		},
+	))
 }
 
 func (l2a *L2Announcer) leaseNamespace() string {
@@ -1249,9 +1269,10 @@ type selectedService struct {
 	leaderChannel   chan leaderElectionEvent
 
 	// Leader election goroutine lifetime management
-	ctx    context.Context
-	cancel context.CancelFunc
-	done   chan struct{}
+	ctx     context.Context
+	cancel  context.CancelFunc
+	done    chan struct{}
+	running bool
 }
 
 func (ss *selectedService) serviceLeaderElection(ctx context.Context, health cell.Health) error {

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -223,7 +223,7 @@ loop:
 		// Processing svc change
 		svcChanges, svcWatch := svcChangeIter.Next(rtxn)
 		for event := range svcChanges {
-			if err := l2a.processSvcEvent(rtxn, event); err != nil {
+			if err := l2a.processSvcEvent(l2a.params.StateDB.ReadTxn(), event); err != nil {
 				l2a.params.Logger.Warn("Error processing service event",
 					logfields.Error, err,
 				)
@@ -232,7 +232,7 @@ loop:
 
 		frontendChanges, frontendWatch := frontendChangeIter.Next(rtxn)
 		for event := range frontendChanges {
-			if err := l2a.processFrontendEvent(rtxn, event); err != nil {
+			if err := l2a.processFrontendEvent(l2a.params.StateDB.ReadTxn(), event); err != nil {
 				l2a.params.Logger.Warn("Error processing frontend event",
 					logfields.Error, err,
 				)
@@ -242,11 +242,13 @@ loop:
 		// Processing backend change
 		beChanges, beWatch := beChangeIter.Next(rtxn)
 		for event := range beChanges {
-			// Get the backend struct which changed
 			backend := event.Object
-			svc, _, found := l2a.params.Services.Get(rtxn, loadbalancer.ServiceByName(backend.ServiceName))
+
+			latestTxn := l2a.params.StateDB.ReadTxn()
+
+			svc, _, found := l2a.params.Services.Get(latestTxn, loadbalancer.ServiceByName(backend.ServiceName))
 			if found {
-				if err := l2a.upsertSvc(rtxn, svc); err != nil {
+				if err := l2a.upsertSvc(latestTxn, svc); err != nil {
 					l2a.params.Logger.Warn("Error re-evaluating service on backend change",
 						logfields.Error, err,
 						logfields.ServiceName, backend.ServiceName,
@@ -400,7 +402,9 @@ func (l2a *L2Announcer) upsertSvc(rtxn statedb.ReadTxn, svc *loadbalancer.Servic
 	key := serviceKey(svc)
 
 	// If ext traffic policy is `Local`, check that l2a is assigned to the correct node
-	if svc.ExtTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal && !l2a.hasLocalBackends(rtxn, svc) {
+	hasLocal := l2a.hasLocalBackends(rtxn, svc)
+
+	if svc.ExtTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal && !hasLocal {
 		return l2a.delSvc(key)
 	}
 

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -157,6 +157,7 @@ func (l2a *L2Announcer) run(ctx context.Context, health cell.Health) error {
 	wtxn := l2a.params.StateDB.WriteTxn(l2a.params.Services)
 	svcChangeIter, err := l2a.params.Services.Changes(wtxn)
 	if err != nil {
+		wtxn.Abort()
 		return err
 	}
 	wtxn.Commit()
@@ -164,6 +165,7 @@ func (l2a *L2Announcer) run(ctx context.Context, health cell.Health) error {
 	wtxn = l2a.params.StateDB.WriteTxn(l2a.params.Frontends)
 	frontendChangeIter, err := l2a.params.Frontends.Changes(wtxn)
 	if err != nil {
+		wtxn.Abort()
 		return err
 	}
 	wtxn.Commit()
@@ -172,6 +174,7 @@ func (l2a *L2Announcer) run(ctx context.Context, health cell.Health) error {
 	wtxn = l2a.params.StateDB.WriteTxn(l2a.params.Backends)
 	beChangeIter, err := l2a.params.Backends.Changes(wtxn)
 	if err != nil {
+		wtxn.Abort()
 		return err
 	}
 	wtxn.Commit()

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -154,7 +154,7 @@ func (l2a *L2Announcer) hasLocalBackends(txn statedb.ReadTxn, svc *loadbalancer.
 
 func (l2a *L2Announcer) run(ctx context.Context, health cell.Health) error {
 	// Start watching the 'services' table for changes.
-	wtxn := l2a.params.StateDB.WriteTxn(l2a.params.Services, l2a.params.Backends)
+	wtxn := l2a.params.StateDB.WriteTxn(l2a.params.Services)
 	svcChangeIter, err := l2a.params.Services.Changes(wtxn)
 	if err != nil {
 		return err

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -401,13 +401,6 @@ func (l2a *L2Announcer) upsertSvc(rtxn statedb.ReadTxn, svc *loadbalancer.Servic
 	}
 	key := serviceKey(svc)
 
-	// If ext traffic policy is `Local`, check that l2a is assigned to the correct node
-	hasLocal := l2a.hasLocalBackends(rtxn, svc)
-
-	if svc.ExtTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal && !hasLocal {
-		return l2a.delSvc(key)
-	}
-
 	noExternal := len(externalAddresses) == 0
 	noLB := len(lbAddresses) == 0
 	if noExternal && noLB {
@@ -419,6 +412,12 @@ func (l2a *L2Announcer) upsertSvc(rtxn statedb.ReadTxn, svc *loadbalancer.Servic
 	if svc.LoadBalancerClass != nil &&
 		*svc.LoadBalancerClass != cilium_api_v2alpha1.L2AnnounceLoadBalancerClass {
 		return l2a.delSvc(key)
+	}
+
+	// If the service has a local traffic policy, check if there are any backends on this node. If not, we are not eligible to be leader for this service.
+	isEligibleNode := true
+	if svc.ExtTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal {
+		isEligibleNode = l2a.hasLocalBackends(rtxn, svc)
 	}
 
 	ss, found := l2a.selectedServices[key]
@@ -448,6 +447,13 @@ func (l2a *L2Announcer) upsertSvc(rtxn statedb.ReadTxn, svc *loadbalancer.Servic
 			return nil
 		}
 
+		if !isEligibleNode {
+			// selectedServices contains a service which is no longer eligible for this node, withdraw lease and entries.
+			l2a.withdrawServiceLeaseAndEntries(ss)
+			return nil
+		}
+		l2a.startLeaderElectionJob(ss)
+
 		// Since IPs may have changed, re-calculate its entries in the output table, if we are leader
 		err := l2a.recalculateL2EntriesTableEntries(ss)
 		if err != nil {
@@ -471,7 +477,23 @@ func (l2a *L2Announcer) upsertSvc(rtxn statedb.ReadTxn, svc *loadbalancer.Servic
 
 	// Add the services to list of selected services if at least 1 policy matches it.
 	if len(matchingPolicies) >= 1 {
-		l2a.addSelectedService(svc, externalAddresses, lbAddresses, matchingPolicies)
+		l2a.addSelectedService(svc, externalAddresses, lbAddresses, matchingPolicies, isEligibleNode)
+	}
+
+	return nil
+}
+
+func (l2a *L2Announcer) withdrawServiceLeaseAndEntries(ss *selectedService) error {
+	// Stop leader election for this service, if we are leader, this will also remove the entries from the output table.
+	select {
+	case <-ss.done:
+		// if the channel is already closed, we are not leader for this service, so nothing to do.
+	default:
+		close(ss.done)
+	}
+
+	if err := l2a.recalculateL2EntriesTableEntries(ss); err != nil {
+		return fmt.Errorf("recalculateL2EntriesTableEntries: %w", err)
 	}
 
 	return nil
@@ -689,7 +711,13 @@ func (l2a *L2Announcer) upsertPolicy(ctx context.Context, policy *cilium_api_v2a
 			continue
 		}
 
-		l2a.addSelectedService(svc, externalAddresses, lbAddresses, []types.NamespacedName{key})
+		// If the service has a local traffic policy, check if there are any backends on this node. If not, we are not eligible to be leader for this service.
+		isEligibleNode := true
+		if svc.ExtTrafficPolicy == loadbalancer.SVCTrafficPolicyLocal {
+			isEligibleNode = l2a.hasLocalBackends(txn, svc)
+		}
+
+		l2a.addSelectedService(svc, externalAddresses, lbAddresses, []types.NamespacedName{key}, isEligibleNode)
 	}
 
 	err := l2a.gcOrphanedServices()
@@ -861,7 +889,7 @@ func (l2a *L2Announcer) leaseTimings() (leaseDuration, renewDeadline, retryPerio
 	return leaseDuration, renewDeadline, retryPeriod
 }
 
-func (l2a *L2Announcer) addSelectedService(svc *loadbalancer.Service, extAddrs, lbAddrs []netip.Addr, byPolicies []types.NamespacedName) {
+func (l2a *L2Announcer) addSelectedService(svc *loadbalancer.Service, extAddrs, lbAddrs []netip.Addr, byPolicies []types.NamespacedName, isEligible bool) {
 	leaseDuration, renewDeadline, retryPeriod := l2a.leaseTimings()
 	ss := &selectedService{
 		svc:               svc,
@@ -878,9 +906,22 @@ func (l2a *L2Announcer) addSelectedService(svc *loadbalancer.Service, extAddrs, 
 
 	l2a.selectedServices[serviceKey(svc)] = ss
 
+	if isEligible {
+		l2a.startLeaderElectionJob(ss)
+	}
+}
+
+func (l2a *L2Announcer) startLeaderElectionJob(ss *selectedService) {
+	// done channel is used to signal the leader election job to stop. If it is already closed, we need to create a new one.
+	select {
+	case <-ss.done:
+		ss.done = make(chan struct{})
+	default:
+	}
+
 	// kick off leader election job
 	l2a.scopedGroup.Add(job.OneShot(
-		shortener.ShortenHiveJobName(fmt.Sprintf("leader-election-%s-%s", svc.Name.Namespace(), svc.Name.Name())),
+		shortener.ShortenHiveJobName(fmt.Sprintf("leader-election-%s-%s", ss.svc.Name.Namespace(), ss.svc.Name.Name())),
 		ss.serviceLeaderElection),
 	)
 }

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -240,16 +240,13 @@ loop:
 		}
 
 		// Processing backend change
-		beChanges, beWatch := beChangeIter.Next(l2a.params.StateDB.ReadTxn())
+		beChanges, beWatch := beChangeIter.Next(rtxn)
 		for event := range beChanges {
 			// Get the backend struct which changed
 			backend := event.Object
-
-			// Retrieve the relevant service from StateDB and re-execute upsertSvc
-			txn := l2a.params.StateDB.ReadTxn()
-			svc, _, found := l2a.params.Services.Get(txn, loadbalancer.ServiceByName(backend.ServiceName))
+			svc, _, found := l2a.params.Services.Get(rtxn, loadbalancer.ServiceByName(backend.ServiceName))
 			if found {
-				if err := l2a.upsertSvc(txn, svc); err != nil {
+				if err := l2a.upsertSvc(rtxn, svc); err != nil {
 					l2a.params.Logger.Warn("Error re-evaluating service on backend change",
 						logfields.Error, err,
 						logfields.ServiceName, backend.ServiceName,

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -153,14 +153,13 @@ func (l2a *L2Announcer) hasLocalBackends(txn statedb.ReadTxn, svc *loadbalancer.
 }
 
 func (l2a *L2Announcer) run(ctx context.Context, health cell.Health) error {
-	wtxn := l2a.params.StateDB.WriteTxn(l2a.params.Services, l2a.params.Backends)
-	defer wtxn.Abort()
-
 	// Start watching the 'services' table for changes.
+	wtxn := l2a.params.StateDB.WriteTxn(l2a.params.Services, l2a.params.Backends)
 	svcChangeIter, err := l2a.params.Services.Changes(wtxn)
 	if err != nil {
 		return err
 	}
+	wtxn.Commit()
 
 	wtxn = l2a.params.StateDB.WriteTxn(l2a.params.Frontends)
 	frontendChangeIter, err := l2a.params.Frontends.Changes(wtxn)
@@ -170,6 +169,7 @@ func (l2a *L2Announcer) run(ctx context.Context, health cell.Health) error {
 	}
 
 	// Initialize backends table
+	wtxn = l2a.params.StateDB.WriteTxn(l2a.params.Backends)
 	beChangeIter, err := l2a.params.Backends.Changes(wtxn)
 	if err != nil {
 		return err

--- a/pkg/l2announcer/l2announcer_test.go
+++ b/pkg/l2announcer/l2announcer_test.go
@@ -45,14 +45,29 @@ type fixture struct {
 	stateDB            *statedb.DB
 	svcs               statedb.RWTable[*loadbalancer.Service]
 	fes                statedb.RWTable[*loadbalancer.Frontend]
-	fakePolicyStore    *fakeStore[*v2alpha1.CiliumL2AnnouncementPolicy]
+	bes                statedb.RWTable[*loadbalancer.Backend]
+
+	fakePolicyStore *fakeStore[*v2alpha1.CiliumL2AnnouncementPolicy]
 }
 
-func (f *fixture) insertService(svc *loadbalancer.Service, fes ...*loadbalancer.Frontend) {
+func (f *fixture) insertService(svc *loadbalancer.Service) {
 	wtxn := f.stateDB.WriteTxn(f.svcs, f.fes)
 	f.svcs.Insert(wtxn, svc)
+	wtxn.Commit()
+}
+
+func (f *fixture) insertFrontends(fes ...*loadbalancer.Frontend) {
+	wtxn := f.stateDB.WriteTxn(f.fes, f.bes)
 	for _, fe := range fes {
 		f.fes.Insert(wtxn, fe)
+	}
+	wtxn.Commit()
+}
+
+func (f *fixture) insertBackends(bes ...*loadbalancer.Backend) {
+	wtxn := f.stateDB.WriteTxn(f.bes)
+	for _, be := range bes {
+		f.bes.Insert(wtxn, be)
 	}
 	wtxn.Commit()
 }
@@ -62,6 +77,7 @@ func newFixture(t testing.TB) *fixture {
 		tbl    statedb.RWTable[*tables.L2AnnounceEntry]
 		svcs   statedb.RWTable[*loadbalancer.Service]
 		fes    statedb.RWTable[*loadbalancer.Frontend]
+		bes    statedb.RWTable[*loadbalancer.Backend]
 		db     *statedb.DB
 		jg     job.Group
 		logger = hivetest.Logger(t)
@@ -72,14 +88,23 @@ func newFixture(t testing.TB) *fixture {
 			tables.NewL2AnnounceTable,
 			loadbalancer.NewServicesTable,
 			loadbalancer.NewFrontendsTable,
+			loadbalancer.NewBackendsTable,
 			func() loadbalancer.Config { return loadbalancer.DefaultConfig },
 		),
-		cell.Invoke(func(d *statedb.DB, t statedb.RWTable[*tables.L2AnnounceEntry], svcs_ statedb.RWTable[*loadbalancer.Service], fes_ statedb.RWTable[*loadbalancer.Frontend], jg_ job.Group) {
+		cell.Invoke(func(
+			d *statedb.DB,
+			t statedb.RWTable[*tables.L2AnnounceEntry],
+			svcs_ statedb.RWTable[*loadbalancer.Service],
+			fes_ statedb.RWTable[*loadbalancer.Frontend],
+			bes_ statedb.RWTable[*loadbalancer.Backend],
+			jg_ job.Group,
+		) {
 			db = d
 			tbl = t
 			jg = jg_
 			svcs = svcs_
 			fes = fes_
+			bes = bes_
 		}),
 	).Populate(logger)
 
@@ -108,6 +133,7 @@ func newFixture(t testing.TB) *fixture {
 	announcer.params.JobGroup = jg
 	announcer.params.Services = svcs
 	announcer.params.Frontends = fes
+	announcer.params.Backends = bes
 	announcer.scopedGroup = announcer.params.JobGroup.Scoped("leader-election")
 
 	return &fixture{
@@ -116,6 +142,7 @@ func newFixture(t testing.TB) *fixture {
 		stateDB:            db,
 		svcs:               svcs,
 		fes:                fes,
+		bes:                bes,
 		fakePolicyStore:    fakePolicyStore,
 	}
 }
@@ -208,13 +235,14 @@ func bluePolicy() *v2alpha1.CiliumL2AnnouncementPolicy {
 	}
 }
 
-func blueService() (*loadbalancer.Service, *loadbalancer.Frontend) {
+func blueService() (*loadbalancer.Service, *loadbalancer.Frontend, *loadbalancer.Backend) {
 	svc := &loadbalancer.Service{
 		Name: loadbalancer.NewServiceName("default", "blue-service"),
 		Labels: labels.Labels{
 			"color": labels.NewLabel("color", "blue", "k8s"),
 		},
 	}
+
 	var addr loadbalancer.L3n4Addr
 	addr.ParseFromString("192.168.2.1:80/TCP")
 	fe := &loadbalancer.Frontend{
@@ -225,7 +253,17 @@ func blueService() (*loadbalancer.Service, *loadbalancer.Frontend) {
 		},
 		Service: svc,
 	}
-	return svc, fe
+
+	var beAddr loadbalancer.L3n4Addr
+	beAddr.ParseFromString("10.1.2.3:80/TCP")
+	be := &loadbalancer.Backend{
+		ServiceName: svc.Name,
+		Address:     beAddr,
+		NodeName:    blueNode().Name,
+		State:       loadbalancer.BackendStateActive,
+	}
+
+	return svc, fe, be
 }
 
 // Test the happy path, make sure that we create proxy neighbor entries
@@ -252,8 +290,10 @@ func TestHappyPath(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, fix.announcer.selectedPolicies, types.NamespacedName{Namespace: policy.Namespace, Name: policy.Name})
 
-	svc, fe := blueService()
-	fix.insertService(svc, fe)
+	svc, fe, be := blueService()
+	fix.insertService(svc)
+	fix.insertFrontends(fe)
+	fix.insertBackends(be)
 	err = fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
 		Object:  svc,
@@ -309,8 +349,10 @@ func TestHappyPathPermutations(t *testing.T) {
 		assert.NoError(tt, err)
 	}
 	addService := func(fix *fixture, tt *testing.T) {
-		svc, fe := blueService()
-		fix.insertService(svc, fe)
+		svc, fe, be := blueService()
+		fix.insertService(svc)
+		fix.insertFrontends(fe)
+		fix.insertBackends(be)
 		err := fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 			Deleted: false,
 			Object:  svc,
@@ -347,7 +389,7 @@ func TestHappyPathPermutations(t *testing.T) {
 			entries := statedb.Collect(iter)
 			assert.Empty(tt, entries)
 
-			svc, fe := blueService()
+			svc, fe, _ := blueService()
 			if assert.Contains(tt, fix.announcer.selectedServices, serviceKey(svc)) {
 				err = fix.announcer.processLeaderEvent(leaderElectionEvent{
 					typ:             leaderElectionLeading,
@@ -432,8 +474,10 @@ func TestPolicyRedundancy(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Add service policy
-	svc, fe := blueService()
-	fix.insertService(svc, fe)
+	svc, fe, be := blueService()
+	fix.insertService(svc)
+	fix.insertFrontends(fe)
+	fix.insertBackends(be)
 	err = fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
 		Object:  svc,
@@ -526,8 +570,10 @@ func baseUpdateSetup(t *testing.T) *fixture {
 	require.Len(t, fix.announcer.selectedPolicies, 1)
 	require.Empty(t, fix.announcer.selectedServices)
 
-	svc, fe := blueService()
-	fix.insertService(svc, fe)
+	svc, fe, be := blueService()
+	fix.insertService(svc)
+	fix.insertFrontends(fe)
+	fix.insertBackends(be)
 	err = fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
 		Object:  svc,
@@ -606,14 +652,18 @@ func TestUpdateHostLabels_AdditionalMatch(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Add a non matching service
-	svc, fe := blueService()
+	svc, fe, be := blueService()
 	svc.Name = loadbalancer.NewServiceName(svc.Name.Namespace(), "cyan-service")
 	svc.Labels = labels.Labels{
 		"hue": labels.NewLabel("hue", "cyan", "k8s"),
 	}
+	fix.insertService(svc)
+
 	fe.ServiceName = svc.Name
 	require.NoError(t, fe.Address.ParseFromString("192.168.2.2:80/TCP"))
-	fix.insertService(svc, fe)
+	fix.insertFrontends(fe)
+
+	fix.insertBackends(be)
 	err = fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
 		Object:  svc,
@@ -693,14 +743,17 @@ func TestUpdatePolicy_AdditionalMatch(t *testing.T) {
 	fix := baseUpdateSetup(t)
 
 	// Add a non matching service
-	svc, fe := blueService()
+	svc, fe, be := blueService()
 	svc.Name = loadbalancer.NewServiceName(svc.Name.Namespace(), "cyan-service")
 	fe.ServiceName = svc.Name
+	be.ServiceName = svc.Name
 	svc.Labels = labels.Map2Labels(map[string]string{
 		"color": "cyan",
 	}, "k8s")
 	require.NoError(t, fe.Address.ParseFromString("192.168.2.2:80/TCP"))
-	fix.insertService(svc, fe)
+	fix.insertService(svc)
+	fix.insertFrontends(fe)
+	fix.insertBackends(be)
 	err := fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
 		Object:  svc,
@@ -758,9 +811,11 @@ func TestPolicySelection(t *testing.T) {
 	assert.Len(t, fix.announcer.selectedServices, 1)
 
 	// A service with no externalIP and no LB IP should never be selected
-	svc, fe := blueService()
+	svc, fe, be := blueService()
 	fe.Type = loadbalancer.SVCTypeClusterIP
-	fix.insertService(svc, fe)
+	fix.insertService(svc)
+	fix.insertFrontends(fe)
+	fix.insertBackends(be)
 	err = fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
 		Object:  svc,
@@ -788,9 +843,12 @@ func TestPolicySelection(t *testing.T) {
 	// Updating an existing non-selected service should not select it
 	svc = svc.Clone()
 	fe = fe.Clone()
+	be = be.Clone()
 	fe.Type = loadbalancer.SVCTypeExternalIPs
 	require.NoError(t, fe.Address.ParseFromString("192.168.2.2:80/TCP"))
-	fix.insertService(svc, fe)
+	fix.insertService(svc)
+	fix.insertFrontends(fe)
+	fix.insertBackends(be)
 	err = fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
 		Object:  svc,
@@ -803,9 +861,12 @@ func TestPolicySelection(t *testing.T) {
 	// Adding an LB IP to an existing non-selected service should not select it
 	fe = fe.Clone()
 	svc = svc.Clone()
+	be = be.Clone()
 	fe.Type = loadbalancer.SVCTypeLoadBalancer
 	require.NoError(t, fe.Address.ParseFromString("192.168.2.7:80/TCP"))
-	fix.insertService(svc, fe)
+	fix.insertService(svc)
+	fix.insertFrontends(fe)
+	fix.insertBackends(be)
 
 	err = fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
@@ -874,12 +935,10 @@ func TestFrontendUpdateSelectsPreviouslyIgnoredService(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	svc, fe := blueService()
+	svc, fe, be := blueService()
 	fe.Type = loadbalancer.SVCTypeLoadBalancer
 
-	wtxn := fix.stateDB.WriteTxn(fix.svcs)
-	fix.svcs.Insert(wtxn, svc)
-	wtxn.Commit()
+	fix.insertService(svc)
 
 	err = fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
@@ -888,9 +947,8 @@ func TestFrontendUpdateSelectsPreviouslyIgnoredService(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, fix.announcer.selectedServices)
 
-	wtxn = fix.stateDB.WriteTxn(fix.fes)
-	fix.fes.Insert(wtxn, fe)
-	wtxn.Commit()
+	fix.insertFrontends(fe)
+	fix.insertBackends(be)
 
 	err = fix.announcer.processFrontendEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Frontend]{
 		Deleted: false,
@@ -928,10 +986,12 @@ func TestUpdatePolicy_ChangeIPType(t *testing.T) {
 	assert.Empty(t, entries)
 
 	// Adding an LB IP should select the service and create an entry
-	svc, fe := blueService()
+	svc, fe, be := blueService()
 	fe.Type = loadbalancer.SVCTypeLoadBalancer
 	assert.NoError(t, fe.Address.ParseFromString("192.168.2.3:80/TCP"))
-	fix.insertService(svc, fe)
+	fix.insertService(svc)
+	fix.insertFrontends(fe)
+	fix.insertBackends(be)
 	err = fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
 		Object:  svc,
@@ -962,8 +1022,11 @@ func TestUpdatePolicy_ChangeIPType(t *testing.T) {
 	// changing the frontend type should unselect the service
 	svc = svc.Clone()
 	fe = fe.Clone()
+	be = be.Clone()
 	fe.Type = loadbalancer.SVCTypeClusterIP
-	fix.insertService(svc, fe)
+	fix.insertService(svc)
+	fix.insertFrontends(fe)
+	fix.insertBackends(be)
 	err = fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
 		Object:  svc,
@@ -1001,7 +1064,7 @@ func TestUpdatePolicy_ChangeInterfaces(t *testing.T) {
 	assert.Len(t, fix.announcer.selectedPolicies, 1)
 	assert.Len(t, fix.announcer.selectedServices, 1)
 
-	svc, fe := blueService()
+	svc, fe, _ := blueService()
 
 	// Check that the old entry is deleted and the new entry added
 	rtx := fix.stateDB.ReadTxn()
@@ -1021,7 +1084,7 @@ func TestUpdatePolicy_ChangeInterfaces(t *testing.T) {
 func TestUpdateService_DelIP(t *testing.T) {
 	fix := baseUpdateSetup(t)
 
-	svc, fe := blueService()
+	svc, fe, _ := blueService()
 	wtxn := fix.stateDB.WriteTxn(fix.fes)
 	fix.fes.Delete(wtxn, fe)
 	wtxn.Commit()
@@ -1043,13 +1106,15 @@ func TestUpdateService_DelIP(t *testing.T) {
 func TestUpdateService_AddIP(t *testing.T) {
 	fix := baseUpdateSetup(t)
 
-	svc, fe1 := blueService()
+	svc, fe1, be := blueService()
 	svc = svc.Clone()
 	fe1 = fe1.Clone()
 	assert.NoError(t, fe1.Address.ParseFromString("192.168.2.1:80/TCP"))
 	fe2 := fe1.Clone()
 	assert.NoError(t, fe2.Address.ParseFromString("192.168.2.2:80/TCP"))
-	fix.insertService(svc, fe1, fe2)
+	fix.insertService(svc)
+	fix.insertFrontends(fe1, fe2)
+	fix.insertBackends(be)
 
 	err := fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
@@ -1068,9 +1133,11 @@ func TestUpdateService_AddIP(t *testing.T) {
 func TestUpdateService_NoMatch(t *testing.T) {
 	fix := baseUpdateSetup(t)
 
-	svc, fe := blueService()
+	svc, fe, be := blueService()
 	svc.Labels["color"] = labels.NewLabel("color", "red", "k8s")
-	fix.insertService(svc, fe)
+	fix.insertService(svc)
+	fix.insertFrontends(fe)
+	fix.insertBackends(be)
 
 	err := fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
@@ -1090,9 +1157,12 @@ func TestUpdateService_NoMatch(t *testing.T) {
 func TestUpdateService_LoadBalancerClassMatch(t *testing.T) {
 	fix := baseUpdateSetup(t)
 
-	svc, fe := blueService()
+	svc, fe, be := blueService()
+	svc = svc.Clone()
 	svc.LoadBalancerClass = ptr.To[string](v2alpha1.L2AnnounceLoadBalancerClass)
-	fix.insertService(svc, fe)
+	fix.insertService(svc)
+	fix.insertFrontends(fe)
+	fix.insertBackends(be)
 
 	err := fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
@@ -1112,9 +1182,85 @@ func TestUpdateService_LoadBalancerClassMatch(t *testing.T) {
 func TestUpdateService_LoadBalancerClassNotMatch(t *testing.T) {
 	fix := baseUpdateSetup(t)
 
-	svc, fe := blueService()
+	svc, fe, be := blueService()
+	svc = svc.Clone()
 	svc.LoadBalancerClass = ptr.To[string]("unsupported.io/lb-class")
-	fix.insertService(svc, fe)
+	fix.insertService(svc)
+	fix.insertFrontends(fe)
+	fix.insertBackends(be)
+
+	err := fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
+		Deleted: false,
+		Object:  svc,
+	})
+	assert.NoError(t, err)
+
+	// Check that the entry got deleted
+	rtx := fix.stateDB.ReadTxn()
+	iter := fix.proxyNeighborTable.All(rtx)
+	entries := statedb.Collect(iter)
+	assert.Empty(t, entries)
+}
+
+// Test that when a service with external traffic policy local has local backends, it is selected and announced.
+func TestUpdateService_ExternalTrafficPolicyLocal(t *testing.T) {
+	fix := baseUpdateSetup(t)
+
+	svc, fe, be := blueService()
+	svc.ExtTrafficPolicy = loadbalancer.SVCTrafficPolicyLocal
+	fix.insertService(svc)
+	fix.insertFrontends(fe)
+	fix.insertBackends(be)
+
+	err := fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
+		Deleted: false,
+		Object:  svc,
+	})
+	assert.NoError(t, err)
+
+	// Check that the entry got added
+	rtx := fix.stateDB.ReadTxn()
+	iter := fix.proxyNeighborTable.All(rtx)
+	entries := statedb.Collect(iter)
+	assert.Len(t, entries, 1)
+}
+
+// Test that when a service with external traffic policy local has no local backends, its not selected and not announced.
+func TestUpdateService_ExternalTrafficPolicyLocal_NoLocalBackends(t *testing.T) {
+	fix := baseUpdateSetup(t)
+
+	svc, fe, be := blueService()
+	svc.ExtTrafficPolicy = loadbalancer.SVCTrafficPolicyLocal
+	be = be.Clone()
+	be.NodeName = "red-node" // backend on different node
+	fix.insertService(svc)
+	fix.insertFrontends(fe)
+	fix.insertBackends(be)
+
+	err := fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
+		Deleted: false,
+		Object:  svc,
+	})
+	assert.NoError(t, err)
+
+	// Check that the entry got deleted
+	rtx := fix.stateDB.ReadTxn()
+	iter := fix.proxyNeighborTable.All(rtx)
+	entries := statedb.Collect(iter)
+	assert.Empty(t, entries)
+}
+
+// Test that when a service with external traffic policy local only has unhealthy local backends, its not selected and not announced.
+func TestUpdateService_ExternalTrafficPolicyLocal_UnhealthyLocalBackends(t *testing.T) {
+	fix := baseUpdateSetup(t)
+
+	svc, fe, be := blueService()
+	svc.ExtTrafficPolicy = loadbalancer.SVCTrafficPolicyLocal
+	be = be.Clone()
+	be.Unhealthy = true
+	fix.insertService(svc)
+	fix.insertFrontends(fe)
+	fix.insertBackends(be)
 
 	err := fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
@@ -1137,7 +1283,7 @@ func TestDelService(t *testing.T) {
 	fix.svcs.DeleteAll(wtxn)
 	fix.fes.DeleteAll(wtxn)
 	wtxn.Commit()
-	svc, _ := blueService()
+	svc, _, _ := blueService()
 
 	err := fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: true,
@@ -1164,6 +1310,7 @@ func TestL2AnnouncerLifecycle(t *testing.T) {
 		cell.Provide(
 			func() loadbalancer.Config { return loadbalancer.DefaultConfig },
 			loadbalancer.NewFrontendsTable, statedb.RWTable[*loadbalancer.Frontend].ToTable,
+			loadbalancer.NewBackendsTable, statedb.RWTable[*loadbalancer.Backend].ToTable,
 			loadbalancer.NewServicesTable, statedb.RWTable[*loadbalancer.Service].ToTable,
 		),
 		cell.Provide(tables.NewL2AnnounceTable),


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

<!-- Description of change -->

_AIL:1, I used copilot code completion assist_

Previously, l2 announcement drop external traffic if external traffic policy is `Local`.
This patch add monitor where backends are, and allocate leases to correct node.

Fixes: #27800

```release-note
Fix dropping traffic L2Announcement with externalTrafficPolicy: Local
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
