### PR TITLE
endpoint: allow wildcard listener proxy redirects

### DIFF
--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -1070,7 +1070,30 @@ func TestProxyID(t *testing.T) {
 	require.Empty(t, resolved)
 
 	resolved = collectProxyIDs(e.proxyIDs(mockSelectorPolicy, &policy.L4Filter{Protocol: api.ProtoTCP, U8Proto: u8proto.TCP, Ingress: true}, "", policy.SelectorSnapshot{}))
-	require.Empty(t, resolved)
+	require.Len(t, resolved, 1)
+	id, port = resolved[0].id, resolved[0].port
+	require.NotEmpty(t, id)
+	require.Equal(t, uint16(0), port)
+	endpointID, ingress, protocol, port, listener, err = policy.ParseProxyID(id)
+	require.Equal(t, uint16(123), endpointID)
+	require.True(t, ingress)
+	require.Equal(t, "TCP", protocol)
+	require.Equal(t, uint16(0), port)
+	require.Empty(t, listener)
+	require.NoError(t, err)
+
+	resolved = collectProxyIDs(e.proxyIDs(mockSelectorPolicy, &policy.L4Filter{Protocol: api.ProtoTCP, U8Proto: u8proto.TCP}, "test-listener", policy.SelectorSnapshot{}))
+	require.Len(t, resolved, 1)
+	id, port = resolved[0].id, resolved[0].port
+	require.NotEmpty(t, id)
+	require.Equal(t, uint16(0), port)
+	endpointID, ingress, protocol, port, listener, err = policy.ParseProxyID(id)
+	require.Equal(t, uint16(123), endpointID)
+	require.False(t, ingress)
+	require.Equal(t, "TCP", protocol)
+	require.Equal(t, uint16(0), port)
+	require.Equal(t, "test-listener", listener)
+	require.NoError(t, err)
 
 	e.SetK8sMetadata(ciliumTypes.NamedPortMap{
 		"http": {Proto: u8proto.TCP, Port: 7070},

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -74,7 +74,9 @@ func (e *Endpoint) proxyIDs(selectorPolicy policy.SelectorPolicy, l4 *policy.L4F
 
 	if port == 0 {
 		if l4.PortName == "" {
-			return func(func(string, uint16) bool) {}
+			return func(yield func(string, uint16) bool) {
+				yield(policy.ProxyID(e.ID, l4.Ingress, string(l4.Protocol), port, listener), port)
+			}
 		}
 		if l4.Ingress {
 			port = e.GetIngressNamedPort(l4.PortName, l4.U8Proto)


### PR DESCRIPTION
Policies that reference a CEC/CCEC listener may use port 0 to redirect all destination ports to the configured Envoy listener. Keep ignoring bare wildcard-port L4 filters, but create a proxy redirect ID when a listener is present so policy map generation can resolve the wildcard proxy port.

Added a regression test for wildcard listener proxy IDs.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request]
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [ ] Thanks for contributing!

<!-- Description of change -->

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
