### PR TITLE
Improve robustness of kvstore keys construction to prevent possible surprising behavior in rare circumstances

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -30,6 +30,17 @@ linters:
           deny:
             - pkg: math/rand$
               desc: Use math/rand/v2 instead
+        path:
+          deny:
+            - pkg: "path$"
+              desc: "Use [kvstore.JoinKey] to construct kvstore keys"
+          files:
+            - '**/*clustermesh*/**'
+            - '**/*etcd*/**'
+            - '**/*store*/**'
+            - '**/*clustermesh*.go'
+            - '**/*etcd*.go'
+            - '**/*store*.go'
     forbidigo:
       forbid:
         # List based on https://github.com/vishvananda/netlink/pull/1018

--- a/cilium-dbg/cmd/preflight_identity_crd_migrate.go
+++ b/cilium-dbg/cmd/preflight_identity_crd_migrate.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"context"
 	"errors"
-	"path"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -24,6 +23,7 @@ import (
 	ciliumClient "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/client"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/identitybackend"
+	"github.com/cilium/cilium/pkg/kvstore"
 	kvstoreallocator "github.com/cilium/cilium/pkg/kvstore/allocator"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -250,7 +250,7 @@ func initKVStore(ctx, wctx context.Context) (kvstoreBackend allocator.Backend) {
 	log.Info("Setting up kvstore client")
 	client := setupKvstore(ctx, log)
 
-	idPath := path.Join(cache.IdentitiesPath, "id")
+	idPath := kvstore.JoinKey(cache.IdentitiesPath, "id")
 	kvstoreBackend, err := kvstoreallocator.NewKVStoreBackend(log, kvstoreallocator.KVStoreBackendConfiguration{BasePath: cache.IdentitiesPath, Suffix: idPath, Typ: &cacheKey.GlobalIdentity{}, Backend: client})
 	if err != nil {
 		logging.Fatal(log, "Cannot create kvstore identity backend", logfields.Error, err)

--- a/clustermesh-apiserver/clustermesh/converters.go
+++ b/clustermesh-apiserver/clustermesh/converters.go
@@ -8,7 +8,6 @@ import (
 	"iter"
 	"log/slog"
 	"net"
-	"path"
 	"slices"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -25,6 +24,7 @@ import (
 	cilium_api_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/k8s/types"
+	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -193,7 +193,7 @@ func newCiliumIdentityOptions() Options[*cilium_api_v2.CiliumIdentity] {
 	return Options[*cilium_api_v2.CiliumIdentity]{
 		Enabled:    true,
 		Resource:   "CiliumIdentity",
-		Prefix:     path.Join(identityCache.IdentitiesPath, "id"),
+		Prefix:     kvstore.JoinKey(identityCache.IdentitiesPath, "id"),
 		StoreOpts:  []store.WSSOpt{store.WSSWithSyncedKeyOverride(identityCache.IdentitiesPath)},
 		Namespaced: true,
 	}
@@ -234,7 +234,7 @@ func newCiliumEndpointOptions(cfg cmk8s.CiliumEndpointSliceConfig) Options[*type
 	return Options[*types.CiliumEndpoint]{
 		Enabled:    !cfg.EnableCiliumEndpointSlice,
 		Resource:   "CiliumEndpoint",
-		Prefix:     path.Join(ipcache.IPIdentitiesPath, ipcache.DefaultAddressSpace),
+		Prefix:     kvstore.JoinKey(ipcache.IPIdentitiesPath, ipcache.DefaultAddressSpace),
 		StoreOpts:  []store.WSSOpt{store.WSSWithSyncedKeyOverride(ipcache.IPIdentitiesPath)},
 		Namespaced: true,
 	}
@@ -292,7 +292,7 @@ func newCiliumEndpointSliceOptions(cfg cmk8s.CiliumEndpointSliceConfig) Options[
 	return Options[*cilium_api_v2a1.CiliumEndpointSlice]{
 		Enabled:    cfg.EnableCiliumEndpointSlice,
 		Resource:   "CiliumEndpointSlice",
-		Prefix:     path.Join(ipcache.IPIdentitiesPath, ipcache.DefaultAddressSpace),
+		Prefix:     kvstore.JoinKey(ipcache.IPIdentitiesPath, ipcache.DefaultAddressSpace),
 		StoreOpts:  []store.WSSOpt{store.WSSWithSyncedKeyOverride(ipcache.IPIdentitiesPath)},
 		Namespaced: true,
 	}

--- a/clustermesh-apiserver/clustermesh/users_mgmt_test.go
+++ b/clustermesh-apiserver/clustermesh/users_mgmt_test.go
@@ -6,7 +6,7 @@ package clustermesh
 import (
 	"context"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -62,7 +62,7 @@ func TestUsersManagement(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
-	cfgPath := path.Join(tmpdir, "users.yaml")
+	cfgPath := filepath.Join(tmpdir, "users.yaml")
 	require.NoError(t, os.WriteFile(cfgPath, []byte(users1), 0600))
 
 	hive := hive.New(
@@ -116,7 +116,7 @@ func TestUsersManagement(t *testing.T) {
 	// We first write to a different file and then rename it, to avoid the possible
 	// race condition caused by truncate + write if we detect the event sufficiently
 	// fast (i.e., we first read an empty file, and then the expected one).
-	cfgPath2 := path.Join(tmpdir, "users.yaml.2")
+	cfgPath2 := filepath.Join(tmpdir, "users.yaml.2")
 	require.NoError(t, os.WriteFile(cfgPath2, []byte(users2), 0600))
 	require.NoError(t, os.Rename(cfgPath2, cfgPath))
 

--- a/clustermesh-apiserver/etcdinit/root.go
+++ b/clustermesh-apiserver/etcdinit/root.go
@@ -10,7 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -125,7 +125,7 @@ func InitEtcdLocal(log *slog.Logger) (returnErr error) {
 			logfields.EtcdDataDir, etcdDataDir,
 			logfields.Path, d.Name(),
 		)
-		err = os.RemoveAll(path.Join(etcdDataDir, d.Name()))
+		err = os.RemoveAll(filepath.Join(etcdDataDir, d.Name()))
 		if err != nil {
 			log.Error(
 				"Failed to remove pre-existing file/directory in etcd data directory",

--- a/operator/pkg/kvstore/nodesgc/gc.go
+++ b/operator/pkg/kvstore/nodesgc/gc.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"path"
 	"time"
 
 	"github.com/cilium/hive/cell"
@@ -130,7 +129,7 @@ func newGC(in struct {
 			health.OK("Primed")
 			in.StoreFactory.NewWatchStore(g.cinfo.Name, nodeStore.KeyCreator, &observer{g.queue},
 				store.RWSWithOnSyncCallback(func(context.Context) { health.OK("Synced") }),
-			).Watch(ctx, g.client, path.Join(nodeStore.NodeStorePrefix, g.cinfo.Name))
+			).Watch(ctx, g.client, kvstore.JoinKey(nodeStore.NodeStorePrefix, g.cinfo.Name))
 			return nil
 		}),
 	)
@@ -177,7 +176,7 @@ func (g *gc) run(ctx context.Context, health cell.Health) error {
 			}
 		}
 
-		key := path.Join(nodeStore.NodeStorePrefix, nodeTypes.GetKeyNodeName(g.cinfo.Name, string(nodeName)))
+		key := kvstore.JoinKey(nodeStore.NodeStorePrefix, nodeTypes.GetKeyNodeName(g.cinfo.Name, string(nodeName)))
 		if err := g.client.Delete(ctx, key); err != nil {
 			return fmt.Errorf("deleting node from kvstore: %w", err)
 		}

--- a/pkg/clustermesh/clustercfg/clustercfg.go
+++ b/pkg/clustermesh/clustercfg/clustercfg.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"path"
 	"time"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
@@ -36,7 +35,7 @@ type ClusterConfigBackend interface {
 }
 
 func Set(ctx context.Context, clusterName string, config cmtypes.CiliumClusterConfig, backend ClusterConfigBackend) error {
-	key := path.Join(kvstore.ClusterConfigPrefix, clusterName)
+	key := kvstore.JoinKey(kvstore.ClusterConfigPrefix, clusterName)
 
 	val, err := json.Marshal(config)
 	if err != nil {
@@ -105,7 +104,7 @@ func Get(ctx context.Context, clusterName string, backend ClusterConfigBackend) 
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
-	val, err := backend.Get(ctx, path.Join(kvstore.ClusterConfigPrefix, clusterName))
+	val, err := backend.Get(ctx, kvstore.JoinKey(kvstore.ClusterConfigPrefix, clusterName))
 	if err != nil {
 		return cmtypes.CiliumClusterConfig{}, err
 	}

--- a/pkg/clustermesh/clustercfg/clustercfg_test.go
+++ b/pkg/clustermesh/clustercfg/clustercfg_test.go
@@ -6,7 +6,6 @@ package clustercfg
 import (
 	"context"
 	"errors"
-	"path"
 	"testing"
 	"time"
 
@@ -35,7 +34,7 @@ type mockBackend struct {
 }
 
 func (mb *mockBackend) withError(clusterName string) {
-	mb.errors.Store(path.Join(kvstore.ClusterConfigPrefix, clusterName), errMock)
+	mb.errors.Store(kvstore.JoinKey(kvstore.ClusterConfigPrefix, clusterName), errMock)
 }
 
 func (mb *mockBackend) Get(_ context.Context, key string) ([]byte, error) {
@@ -92,7 +91,7 @@ func TestGetSetClusterConfig(t *testing.T) {
 	require.ErrorIs(t, err, errMock, "kvstore error not propagated correctly")
 
 	// Simulate invalid data stored in the kvstore
-	mb.UpdateIfDifferent(ctx, path.Join(kvstore.ClusterConfigPrefix, "invalid"), []byte("invalid"), true)
+	mb.UpdateIfDifferent(ctx, kvstore.JoinKey(kvstore.ClusterConfigPrefix, "invalid"), []byte("invalid"), true)
 	_, err = Get(ctx, "invalid", &mb)
 	require.ErrorContains(t, err, "invalid character", "unmarshaling error not propagated correctly")
 }

--- a/pkg/clustermesh/clustercfg/enforce.go
+++ b/pkg/clustermesh/clustercfg/enforce.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path"
 	"time"
 
 	"github.com/cilium/hive/cell"
@@ -36,7 +35,7 @@ func RegisterEnforcer(in struct {
 		return nil
 	}
 
-	key := path.Join(kvstore.ClusterConfigPrefix, in.ClusterInfo.Name)
+	key := kvstore.JoinKey(kvstore.ClusterConfigPrefix, in.ClusterInfo.Name)
 	value, err := json.Marshal(in.ClusterConfig)
 	if err != nil {
 		return fmt.Errorf("cannot marshal CiliumClusterConfig: %w", err)

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"path"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -101,13 +101,13 @@ func TestClusterMesh(t *testing.T) {
 		require.NoErrorf(t, err, "Failed to set cluster config for %s", name)
 	}
 
-	config1 := path.Join(dir, "cluster1")
+	config1 := filepath.Join(dir, "cluster1")
 	require.NoError(t, os.WriteFile(config1, etcdConfig, 0644), "Failed to write config file for cluster1")
 
-	config2 := path.Join(dir, "cluster2")
+	config2 := filepath.Join(dir, "cluster2")
 	require.NoError(t, os.WriteFile(config2, etcdConfig, 0644), "Failed to write config file for cluster2")
 
-	config3 := path.Join(dir, "cluster3")
+	config3 := filepath.Join(dir, "cluster3")
 	require.NoError(t, os.WriteFile(config3, etcdConfig, 0644), "Failed to write config file for cluster3")
 
 	ipc := ipcache.NewIPCache(&ipcache.Configuration{

--- a/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
+++ b/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -537,7 +536,7 @@ func TestRemoteClusterRemoveShutdown(t *testing.T) {
 	// Wait until the cluster config key has been removed, to ensure that we are
 	// actually waiting for the grace period expiration.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		key := path.Join(kvstore.ClusterConfigPrefix, "remote")
+		key := kvstore.JoinKey(kvstore.ClusterConfigPrefix, "remote")
 		value, err := local.Get(ctx, key)
 		assert.NoError(c, err, "Failed to retrieve kvstore key %s", key)
 		assert.Empty(c, string(value), "Key %s has not been deleted", key)

--- a/pkg/clustermesh/kvstoremesh/reflector/cell.go
+++ b/pkg/clustermesh/kvstoremesh/reflector/cell.go
@@ -4,8 +4,6 @@
 package reflector
 
 import (
-	"path"
-
 	"github.com/cilium/hive/cell"
 
 	mcsapi "github.com/cilium/cilium/pkg/clustermesh/mcsapi/types"
@@ -20,12 +18,12 @@ import (
 var Cell = cell.Group(
 	cell.Provide(
 		Out(NewFactory(Endpoints, ipcache.IPIdentitiesPath,
-			WithStatePrefixOverride(path.Join(ipcache.IPIdentitiesPath, ipcache.DefaultAddressSpace)),
+			WithStatePrefixOverride(kvstore.JoinKey(ipcache.IPIdentitiesPath, ipcache.DefaultAddressSpace)),
 		)),
 
 		Out(NewFactory(Identities, cache.IdentitiesPath,
-			WithStatePrefixOverride(path.Join(cache.IdentitiesPath, "id")),
-			WithCachePrefixOverride(path.Join(kvstore.StateToCachePrefix(cache.IdentitiesPath), ClusterNamePlaceHolder, "id")),
+			WithStatePrefixOverride(kvstore.JoinKey(cache.IdentitiesPath, "id")),
+			WithCachePrefixOverride(kvstore.JoinKey(kvstore.StateToCachePrefix(cache.IdentitiesPath), ClusterNamePlaceHolder, "id")),
 		)),
 
 		Out(NewFactory(Nodes, node.NodeStorePrefix)),

--- a/pkg/clustermesh/kvstoremesh/reflector/reflector.go
+++ b/pkg/clustermesh/kvstoremesh/reflector/reflector.go
@@ -6,7 +6,6 @@ package reflector
 import (
 	"context"
 	"fmt"
-	"path"
 	"strings"
 	"sync/atomic"
 
@@ -117,8 +116,8 @@ func NewFactory(name Name, prefix string, opts ...opt) Factory {
 			cluster: cluster,
 
 			basePrefix:  prefix,
-			statePrefix: path.Join(prefix, cluster),
-			cachePrefix: path.Join(kvstore.StateToCachePrefix(prefix), cluster),
+			statePrefix: kvstore.JoinKey(prefix, cluster),
+			cachePrefix: kvstore.JoinKey(kvstore.StateToCachePrefix(prefix), cluster),
 
 			shouldRegister: func(types.CiliumClusterConfig) bool { return true },
 			shouldRevoke:   false,

--- a/pkg/clustermesh/kvstoremesh/remote_cluster.go
+++ b/pkg/clustermesh/kvstoremesh/remote_cluster.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
-	"path"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -165,7 +164,7 @@ func (rc *remoteCluster) Remove(ctx context.Context) {
 // removing the rest of the cached data. Indeed, there's no point in retrieving
 // incomplete data, and it is expected that agents will be disconnecting as well.
 func (rc *remoteCluster) drain(ctx context.Context, withGracePeriod bool) (err error) {
-	var cfgkey = path.Join(kvstore.ClusterConfigPrefix, rc.name)
+	var cfgkey = kvstore.JoinKey(kvstore.ClusterConfigPrefix, rc.name)
 	if err = rc.localBackend.Delete(ctx, cfgkey); err != nil {
 		return fmt.Errorf("deleting key %q: %w", cfgkey, err)
 	}
@@ -190,7 +189,7 @@ func (rc *remoteCluster) drain(ctx context.Context, withGracePeriod bool) (err e
 		}
 	}
 
-	var synpfx = path.Join(kvstore.SyncedPrefix, rc.name) + "/"
+	var synpfx = kvstore.JoinKey(kvstore.SyncedPrefix, rc.name) + "/"
 	if err = rc.localBackend.DeletePrefix(ctx, synpfx); err != nil {
 		return fmt.Errorf("deleting prefix %q: %w", synpfx, err)
 	}

--- a/pkg/clustermesh/mcsapi/types/mcsapiservicespec.go
+++ b/pkg/clustermesh/mcsapi/types/mcsapiservicespec.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"path"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,7 +25,7 @@ var (
 	//
 	// WARNING - STABLE API: Changing the structure or values of this will
 	// break backwards compatibility
-	ServiceExportStorePrefix = path.Join(kvstore.BaseKeyPrefix, "state", "serviceexports", "v1")
+	ServiceExportStorePrefix = kvstore.JoinKey(kvstore.BaseKeyPrefix, "state", "serviceexports", "v1")
 )
 
 type MCSAPIServiceSpec struct {
@@ -99,7 +98,7 @@ type MCSAPIServiceSpec struct {
 func (s *MCSAPIServiceSpec) GetKeyName() string {
 	// WARNING - STABLE API: Changing the structure of the key may break
 	// backwards compatibility
-	return path.Join(s.Cluster, s.Namespace, s.Name)
+	return kvstore.JoinKey(s.Cluster, s.Namespace, s.Name)
 }
 
 // NamespaceServiceName returns the namespace and service name

--- a/pkg/clustermesh/operator/remote_cluster.go
+++ b/pkg/clustermesh/operator/remote_cluster.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"path"
 	"sync/atomic"
 
 	"k8s.io/utils/ptr"
@@ -78,13 +77,13 @@ func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperati
 
 	if rc.clusterMeshEnableEndpointSync {
 		mgr.Register(adapter(serviceStore.ServiceStorePrefix), func(ctx context.Context) {
-			rc.remoteServices.Watch(ctx, backend, path.Join(adapter(serviceStore.ServiceStorePrefix), rc.name))
+			rc.remoteServices.Watch(ctx, backend, kvstore.JoinKey(adapter(serviceStore.ServiceStorePrefix), rc.name))
 		})
 	}
 
 	if rc.clusterMeshEnableMCSAPI && config.Capabilities.ServiceExportsEnabled != nil {
 		mgr.Register(adapter(mcsapitypes.ServiceExportStorePrefix), func(ctx context.Context) {
-			rc.remoteServiceExports.Watch(ctx, backend, path.Join(adapter(mcsapitypes.ServiceExportStorePrefix), rc.name))
+			rc.remoteServiceExports.Watch(ctx, backend, kvstore.JoinKey(adapter(mcsapitypes.ServiceExportStorePrefix), rc.name))
 		})
 	} else {
 		// Drain the remote service exports in case the remote cluster no longer supports them

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"path"
 	"sync/atomic"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -138,11 +137,11 @@ func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperati
 	}
 
 	mgr.Register(adapter(nodeStore.NodeStorePrefix), func(ctx context.Context) {
-		rc.remoteNodes.Watch(ctx, backend, path.Join(adapter(nodeStore.NodeStorePrefix), rc.name))
+		rc.remoteNodes.Watch(ctx, backend, kvstore.JoinKey(adapter(nodeStore.NodeStorePrefix), rc.name))
 	})
 
 	mgr.Register(adapter(serviceStore.ServiceStorePrefix), func(ctx context.Context) {
-		rc.remoteServices.Watch(ctx, backend, path.Join(adapter(serviceStore.ServiceStorePrefix), rc.name))
+		rc.remoteServices.Watch(ctx, backend, kvstore.JoinKey(adapter(serviceStore.ServiceStorePrefix), rc.name))
 	})
 
 	mgr.Register(adapter(ipcache.IPIdentitiesPath), func(ctx context.Context) {

--- a/pkg/clustermesh/script_test.go
+++ b/pkg/clustermesh/script_test.go
@@ -9,7 +9,7 @@ import (
 	"log/slog"
 	"maps"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	uhive "github.com/cilium/hive"
@@ -152,11 +152,11 @@ func TestScript(t *testing.T) {
 
 			cell.Invoke(func(client kvstore.Client) {
 				clusterConfig := []byte("endpoints:\n- in-memory\n")
-				config1 := path.Join(configDir, "cluster1")
+				config1 := filepath.Join(configDir, "cluster1")
 				require.NoError(t, os.WriteFile(config1, clusterConfig, 0644), "Failed to write config file for cluster1")
-				config2 := path.Join(configDir, "cluster2")
+				config2 := filepath.Join(configDir, "cluster2")
 				require.NoError(t, os.WriteFile(config2, clusterConfig, 0644), "Failed to write config file for cluster2")
-				config3 := path.Join(configDir, "cluster3")
+				config3 := filepath.Join(configDir, "cluster3")
 				require.NoError(t, os.WriteFile(config3, clusterConfig, 0644), "Failed to write config file for cluster3")
 
 				for i, name := range []string{"cluster1", "cluster2", "cluster3"} {

--- a/pkg/clustermesh/store/store.go
+++ b/pkg/clustermesh/store/store.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
-	"path"
 
 	"k8s.io/apimachinery/pkg/types"
 
@@ -25,7 +24,7 @@ var (
 	//
 	// WARNING - STABLE API: Changing the structure or values of this will
 	// break backwards compatibility
-	ServiceStorePrefix = path.Join(kvstore.BaseKeyPrefix, "state", "services", "v1")
+	ServiceStorePrefix = kvstore.JoinKey(kvstore.BaseKeyPrefix, "state", "services", "v1")
 )
 
 // ServiceMerger is the interface to be implemented by the owner of local
@@ -102,7 +101,7 @@ func (s *ClusterService) NamespaceServiceName() types.NamespacedName {
 func (s *ClusterService) GetKeyName() string {
 	// WARNING - STABLE API: Changing the structure of the key may break
 	// backwards compatibility
-	return path.Join(s.Cluster, s.Namespace, s.Name)
+	return kvstore.JoinKey(s.Cluster, s.Namespace, s.Name)
 }
 
 // Marshal returns the global service object as JSON byte slice

--- a/pkg/clustermesh/types/endpointslice/endpointslice.go
+++ b/pkg/clustermesh/types/endpointslice/endpointslice.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
-	"path"
 	"sync"
 
 	"github.com/klauspost/compress/zstd"
@@ -24,7 +23,7 @@ import (
 //
 // WARNING - STABLE API: Changing the structure or values of this will
 // break backwards compatibility
-var EndpointSliceStorePrefix = path.Join(kvstore.BaseKeyPrefix, "state", "endpointslices", "v1")
+var EndpointSliceStorePrefix = kvstore.JoinKey(kvstore.BaseKeyPrefix, "state", "endpointslices", "v1")
 
 func init() {
 	kvstore.RegisterCommandTranscoder(
@@ -53,7 +52,7 @@ func (eps *ClusterEndpointSlice) NamespacedName() types.NamespacedName {
 func (eps *ClusterEndpointSlice) GetKeyName() string {
 	// WARNING - STABLE API: Changing the structure of the key may break
 	// backwards compatibility
-	return path.Join(eps.Cluster, eps.Namespace, eps.Name)
+	return kvstore.JoinKey(eps.Cluster, eps.Namespace, eps.Name)
 }
 
 var (

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"path"
 	"path/filepath"
 	"testing"
 	"time"
@@ -490,8 +489,8 @@ type kvstoreClient struct{ kvstore.Client }
 
 func (c *kvstoreClient) addIDKVStore(ctx context.Context, id string, lbls labels.Labels) error {
 	key := &cacheKey.GlobalIdentity{LabelArray: lbls.LabelArray()}
-	idPrefix := path.Join(IdentitiesPath, "id")
-	keyPath := path.Join(idPrefix, id)
+	idPrefix := kvstore.JoinKey(IdentitiesPath, "id")
+	keyPath := kvstore.JoinKey(idPrefix, id)
 	success, err := c.CreateOnly(ctx, keyPath, []byte(key.GetKey()), false)
 	if err != nil || !success {
 		return fmt.Errorf("unable to create master key '%s': %w", keyPath, err)
@@ -500,8 +499,8 @@ func (c *kvstoreClient) addIDKVStore(ctx context.Context, id string, lbls labels
 }
 
 func (c *kvstoreClient) removeIDKVStore(ctx context.Context, id string) error {
-	prefix := path.Join(IdentitiesPath, "id")
-	key := path.Join(prefix, id)
+	prefix := kvstore.JoinKey(IdentitiesPath, "id")
+	key := kvstore.JoinKey(prefix, id)
 	return c.Delete(ctx, key)
 }
 

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -44,7 +43,7 @@ import (
 var (
 	// IdentitiesPath is the path to where identities are stored in the
 	// key-value store.
-	IdentitiesPath = path.Join(kvstore.BaseKeyPrefix, "state", "identities", "v1")
+	IdentitiesPath = kvstore.JoinKey(kvstore.BaseKeyPrefix, "state", "identities", "v1")
 )
 
 // The filename for the local allocator checkpoont. This is periodically
@@ -927,7 +926,7 @@ func (m *CachingIdentityAllocator) WatchRemoteIdentities(remoteName string, remo
 
 	prefix := m.identitiesPath
 	if cachedPrefix {
-		prefix = path.Join(kvstore.StateToCachePrefix(prefix), remoteName)
+		prefix = kvstore.JoinKey(kvstore.StateToCachePrefix(prefix), remoteName)
 	}
 
 	remoteAllocatorBackend, err := kvstoreallocator.NewKVStoreBackend(m.logger, kvstoreallocator.KVStoreBackendConfiguration{BasePath: prefix, Suffix: m.owner.GetNodeSuffix(), Typ: &key.GlobalIdentity{}, Backend: backend})

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -10,7 +10,6 @@ import (
 	"log/slog"
 	"net"
 	"net/netip"
-	"path"
 	"sort"
 
 	"github.com/cilium/hive/cell"
@@ -36,7 +35,7 @@ const (
 var (
 	// IPIdentitiesPath is the path to where endpoint IPs are stored in the key-value
 	// store.
-	IPIdentitiesPath = path.Join(kvstore.BaseKeyPrefix, "state", "ip", "v1")
+	IPIdentitiesPath = kvstore.JoinKey(kvstore.BaseKeyPrefix, "state", "ip", "v1")
 
 	// AddressSpace is the address space (cluster, etc.) in which policy is
 	// computed. It is determined by the orchestration system / runtime.
@@ -92,7 +91,7 @@ func (s *IPIdentitySynchronizer) Upsert(ctx context.Context, params *UpsertParam
 		return namedPorts[i].Name < namedPorts[j].Name
 	})
 
-	ipKey := path.Join(IPIdentitiesPath, AddressSpace, params.IP.String())
+	ipKey := kvstore.JoinKey(IPIdentitiesPath, AddressSpace, params.IP.String())
 	ipIDPair := identity.IPIdentityPair{
 		IP:                params.IP.AsSlice(),
 		ID:                params.ID,
@@ -129,7 +128,7 @@ func (s *IPIdentitySynchronizer) Upsert(ctx context.Context, params *UpsertParam
 // from the kvstore, which will subsequently trigger an event in
 // NewIPIdentityWatcher().
 func (s *IPIdentitySynchronizer) Delete(ctx context.Context, ip string) error {
-	ipKey := path.Join(IPIdentitiesPath, AddressSpace, ip)
+	ipKey := kvstore.JoinKey(IPIdentitiesPath, AddressSpace, ip)
 	s.tracker.Delete(ipKey)
 	return s.client.Delete(ctx, ipKey)
 }
@@ -331,9 +330,9 @@ func (iw *IPIdentityWatcher) Watch(ctx context.Context, backend storepkg.WatchSt
 		iw.store.Drain()
 	}
 
-	prefix := path.Join(IPIdentitiesPath, AddressSpace)
+	prefix := kvstore.JoinKey(IPIdentitiesPath, AddressSpace)
 	if iwo.cachedPrefix {
-		prefix = path.Join(kvstore.StateToCachePrefix(IPIdentitiesPath), iw.clusterName)
+		prefix = kvstore.JoinKey(kvstore.StateToCachePrefix(IPIdentitiesPath), iw.clusterName)
 	}
 
 	iw.started = true
@@ -497,7 +496,7 @@ func (iw *IPIdentityWatcher) onSync(context.Context) {
 }
 
 func (iw *IPIdentityWatcher) selfDeletionProtection(ip string) bool {
-	key := path.Join(IPIdentitiesPath, AddressSpace, ip)
+	key := kvstore.JoinKey(IPIdentitiesPath, AddressSpace, ip)
 	if m, ok := iw.syncer.tracker.Load(key); ok {
 		iw.log.Warn(
 			"Received kvstore delete notification for alive ipcache entry",

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"path"
 	"strconv"
 	"strings"
 
@@ -543,14 +542,14 @@ func (k *kvstoreBackend) RunGC(
 							"Unable to delete unused allocator master key",
 							logfields.Error, err,
 							logfields.Key, key,
-							logfields.Identity, path.Base(key),
+							logfields.Identity, identity,
 						)
 					} else {
 						deletedEntries++
 						k.logger.Info(
 							"Deleted unused allocator master key in KVStore",
 							logfields.Key, key,
-							logfields.Identity, path.Base(key),
+							logfields.Identity, identity,
 						)
 					}
 					// consider the key regardless if there was an error from

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -95,9 +95,9 @@ func NewKVStoreBackend(logger *slog.Logger, c KVStoreBackendConfiguration) (allo
 	return &kvstoreBackend{
 		logger:      logger.With(logfields.LogSubsys, "kvstorebackend"),
 		basePrefix:  c.BasePath,
-		idPrefix:    path.Join(c.BasePath, "id"),
-		valuePrefix: path.Join(c.BasePath, "value"),
-		lockPrefix:  path.Join(c.BasePath, "locks"),
+		idPrefix:    kvstore.JoinKey(c.BasePath, "id"),
+		valuePrefix: kvstore.JoinKey(c.BasePath, "value"),
+		lockPrefix:  kvstore.JoinKey(c.BasePath, "locks"),
 		suffix:      c.Suffix,
 		keyType:     c.Typ,
 		backend:     c.Backend,
@@ -107,7 +107,7 @@ func NewKVStoreBackend(logger *slog.Logger, c KVStoreBackendConfiguration) (allo
 // lockPath locks a key in the scope of an allocator
 func (k *kvstoreBackend) lockPath(ctx context.Context, key string) (*kvstore.Lock, error) {
 	suffix := strings.TrimPrefix(key, k.basePrefix)
-	return kvstore.LockPath(ctx, k.logger, k.backend, path.Join(k.lockPrefix, suffix))
+	return kvstore.LockPath(ctx, k.logger, k.backend, kvstore.JoinKey(k.lockPrefix, suffix))
 }
 
 // DeleteAllKeys will delete all keys
@@ -116,13 +116,13 @@ func (k *kvstoreBackend) DeleteAllKeys(ctx context.Context) {
 }
 
 func (k *kvstoreBackend) DeleteID(ctx context.Context, id idpool.ID) error {
-	return k.backend.Delete(ctx, path.Join(k.idPrefix, id.String()))
+	return k.backend.Delete(ctx, kvstore.JoinKey(k.idPrefix, id.String()))
 }
 
 // AllocateID allocates a key->ID mapping in the kvstore.
 func (k *kvstoreBackend) AllocateID(ctx context.Context, id idpool.ID, key allocator.AllocatorKey) (allocator.AllocatorKey, error) {
 	// create /id/<ID> and fail if it already exists
-	keyPath := path.Join(k.idPrefix, id.String())
+	keyPath := kvstore.JoinKey(k.idPrefix, id.String())
 	success, err := k.backend.CreateOnly(ctx, keyPath, []byte(key.GetKey()), false)
 	if err != nil || !success {
 		return nil, fmt.Errorf("unable to create master key '%s': %w", keyPath, err)
@@ -134,7 +134,7 @@ func (k *kvstoreBackend) AllocateID(ctx context.Context, id idpool.ID, key alloc
 // AllocateID allocates a key->ID mapping in the kvstore.
 func (k *kvstoreBackend) AllocateIDIfLocked(ctx context.Context, id idpool.ID, key allocator.AllocatorKey, lock kvstore.KVLocker) (allocator.AllocatorKey, error) {
 	// create /id/<ID> and fail if it already exists
-	keyPath := path.Join(k.idPrefix, id.String())
+	keyPath := kvstore.JoinKey(k.idPrefix, id.String())
 	success, err := k.backend.CreateOnlyIfLocked(ctx, keyPath, []byte(key.GetKey()), false, lock)
 	if err != nil || !success {
 		return nil, fmt.Errorf("unable to create master key '%s': %w", keyPath, err)
@@ -156,7 +156,7 @@ func (k *kvstoreBackend) AcquireReference(ctx context.Context, id idpool.ID, key
 func (k *kvstoreBackend) createValueNodeKey(ctx context.Context, key string, newID idpool.ID, lock kvstore.KVLocker) error {
 	// add a new key /value/<key>/<node> to account for the reference
 	// The key is protected with a TTL/lease and will expire after LeaseTTL
-	valueKey := path.Join(k.valuePrefix, key, k.suffix)
+	valueKey := kvstore.JoinKey(k.valuePrefix, key, k.suffix)
 	if _, err := k.backend.UpdateIfDifferentIfLocked(ctx, valueKey, []byte(newID.String()), true, lock); err != nil {
 		return fmt.Errorf("unable to create value-node key '%s': %w", valueKey, err)
 	}
@@ -167,7 +167,7 @@ func (k *kvstoreBackend) createValueNodeKey(ctx context.Context, key string, new
 // Lock locks a key in the scope of an allocator
 func (k *kvstoreBackend) lock(ctx context.Context, key string) (*kvstore.Lock, error) {
 	suffix := strings.TrimPrefix(key, k.basePrefix)
-	return kvstore.LockPath(ctx, k.logger, k.backend, path.Join(k.lockPrefix, suffix))
+	return kvstore.LockPath(ctx, k.logger, k.backend, kvstore.JoinKey(k.lockPrefix, suffix))
 }
 
 // Lock locks a key in the scope of an allocator
@@ -192,7 +192,7 @@ func (k *kvstoreBackend) Get(ctx context.Context, key allocator.AllocatorKey) (i
 	// key2 := cilium/state/identities/v1/value/label;foo;bar;/172.0.124.60
 	//
 	// Only key1 should match
-	prefix := path.Join(k.valuePrefix, key.GetKey())
+	prefix := kvstore.JoinKey(k.valuePrefix, key.GetKey())
 	pairs, err := k.backend.ListPrefix(ctx, prefix)
 	kvstore.Trace(k.logger, "ListPrefix",
 		logfields.Error, err,
@@ -233,7 +233,7 @@ func (k *kvstoreBackend) GetIfLocked(ctx context.Context, key allocator.Allocato
 	// key2 := cilium/state/identities/v1/value/label;foo;bar;/172.0.124.60
 	//
 	// Only key1 should match
-	prefix := path.Join(k.valuePrefix, key.GetKey())
+	prefix := kvstore.JoinKey(k.valuePrefix, key.GetKey())
 	pairs, err := k.backend.ListPrefixIfLocked(ctx, prefix, lock)
 	kvstore.Trace(k.logger, "ListPrefixLocked",
 		logfields.Prefix, prefix,
@@ -258,7 +258,7 @@ func (k *kvstoreBackend) GetIfLocked(ctx context.Context, key allocator.Allocato
 // GetByID returns the key associated with an ID. Returns nil if no key is
 // associated with the ID.
 func (k *kvstoreBackend) GetByID(ctx context.Context, id idpool.ID) (allocator.AllocatorKey, error) {
-	v, err := k.backend.Get(ctx, path.Join(k.idPrefix, id.String()))
+	v, err := k.backend.Get(ctx, kvstore.JoinKey(k.idPrefix, id.String()))
 	if err != nil {
 		return nil, err
 	}
@@ -277,8 +277,8 @@ func (k *kvstoreBackend) UpdateKey(ctx context.Context, id idpool.ID, key alloca
 	var (
 		err       error
 		recreated bool
-		keyPath   = path.Join(k.idPrefix, id.String())
-		valueKey  = path.Join(k.valuePrefix, key.GetKey(), k.suffix)
+		keyPath   = kvstore.JoinKey(k.idPrefix, id.String())
+		valueKey  = kvstore.JoinKey(k.valuePrefix, key.GetKey(), k.suffix)
 	)
 
 	// Use of CreateOnly() ensures that any existing potentially
@@ -322,8 +322,8 @@ func (k *kvstoreBackend) UpdateKeyIfLocked(ctx context.Context, id idpool.ID, ke
 	var (
 		err       error
 		recreated bool
-		keyPath   = path.Join(k.idPrefix, id.String())
-		valueKey  = path.Join(k.valuePrefix, key.GetKey(), k.suffix)
+		keyPath   = kvstore.JoinKey(k.idPrefix, id.String())
+		valueKey  = kvstore.JoinKey(k.valuePrefix, key.GetKey(), k.suffix)
 	)
 
 	// Use of CreateOnly() ensures that any existing potentially
@@ -365,7 +365,7 @@ func (k *kvstoreBackend) UpdateKeyIfLocked(ctx context.Context, id idpool.ID, ke
 // not guard against concurrent releases. This is currently guarded by
 // Allocator.slaveKeysMutex when called from pkg/allocator.Allocator.Release.
 func (k *kvstoreBackend) Release(ctx context.Context, _ idpool.ID, key allocator.AllocatorKey) (err error) {
-	valueKey := path.Join(k.valuePrefix, key.GetKey(), k.suffix)
+	valueKey := kvstore.JoinKey(k.valuePrefix, key.GetKey(), k.suffix)
 	k.logger.Info(
 		"Released last local use of key, invoking global release",
 		logfields.Key, key,
@@ -508,7 +508,7 @@ func (k *kvstoreBackend) RunGC(
 		}
 
 		// fetch list of all /value/<key> keys
-		valueKeyPrefix := path.Join(k.valuePrefix, string(v.Data))
+		valueKeyPrefix := kvstore.JoinKey(k.valuePrefix, string(v.Data))
 		pairs, err := k.backend.ListPrefixIfLocked(ctx, valueKeyPrefix, lock)
 		if err != nil {
 			k.logger.Warn(

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -9,7 +9,6 @@ import (
 	"iter"
 	"maps"
 	"math"
-	"path"
 	"slices"
 	"strings"
 	"sync"
@@ -385,7 +384,7 @@ func TestAllocateCached(t *testing.T) {
 	staleKeysPreviousRound, _, err = a.RunGC(context.Background(), rateLimiter, staleKeysPreviousRound)
 	require.NoError(t, err)
 
-	v, err := client.ListPrefix(context.TODO(), path.Join(allocatorName, "id"))
+	v, err := client.ListPrefix(context.TODO(), kvstore.JoinKey(allocatorName, "id"))
 	require.NoError(t, err)
 	require.Len(t, v, int(maxID))
 
@@ -401,7 +400,7 @@ func TestAllocateCached(t *testing.T) {
 	_, _, err = a.RunGC(context.Background(), rateLimiter, staleKeysPreviousRound)
 	require.NoError(t, err)
 
-	v, err = client.ListPrefix(context.TODO(), path.Join(allocatorName, "id"))
+	v, err = client.ListPrefix(context.TODO(), kvstore.JoinKey(allocatorName, "id"))
 	require.NoError(t, err)
 	require.Empty(t, v)
 
@@ -422,18 +421,18 @@ func TestKeyToID(t *testing.T) {
 	require.NotNil(t, a)
 
 	// An error is returned because the path is outside the prefix (allocatorName/id)
-	id, err := backend.(*kvstoreBackend).keyToID(path.Join(allocatorName, "invalid"))
+	id, err := backend.(*kvstoreBackend).keyToID(kvstore.JoinKey(allocatorName, "invalid"))
 	require.Error(t, err)
 	require.Equal(t, idpool.NoID, id)
 
 	// An error is returned because the path contains the prefix
 	// (allocatorName/id) but cannot be parsed ("invalid")
-	id, err = backend.(*kvstoreBackend).keyToID(path.Join(allocatorName, "id", "invalid"))
+	id, err = backend.(*kvstoreBackend).keyToID(kvstore.JoinKey(allocatorName, "id", "invalid"))
 	require.Error(t, err)
 	require.Equal(t, idpool.NoID, id)
 
 	// A valid lookup that finds an ID
-	id, err = backend.(*kvstoreBackend).keyToID(path.Join(allocatorName, "id", "10"))
+	id, err = backend.(*kvstoreBackend).keyToID(kvstore.JoinKey(allocatorName, "id", "10"))
 	require.NoError(t, err)
 	require.Equal(t, idpool.ID(10), id)
 }
@@ -636,21 +635,21 @@ func TestRunGC(t *testing.T) {
 		"102": "k8s:foo=bar;fred=true;",
 	} {
 		// Create a primary entry for all identities
-		require.NoError(t, client.Update(ctx, path.Join(base, "id", id), []byte(label), false), "client.Update")
+		require.NoError(t, client.Update(ctx, kvstore.JoinKey(base, "id", id), []byte(label), false), "client.Update")
 
 		// Create two secondary entries for all identities
 		for _, node := range []string{"node-a", "node-b"} {
-			require.NoError(t, client.Update(ctx, path.Join(base, "value", label, node), []byte(id), false), "client.Update")
+			require.NoError(t, client.Update(ctx, kvstore.JoinKey(base, "value", label, node), []byte(id), false), "client.Update")
 		}
 	}
 
 	var (
 		trim = func(in iter.Seq[string]) iter.Seq[string] {
-			return cslices.MapIter(in, func(in string) string { return strings.TrimPrefix(in, path.Join(base, "id")+"/") })
+			return cslices.MapIter(in, func(in string) string { return strings.TrimPrefix(in, kvstore.JoinKey(base, "id")+"/") })
 		}
 
 		getIDs = func() []string {
-			pairs, err := client.ListPrefix(ctx, path.Join(base, "id")+"/")
+			pairs, err := client.ListPrefix(ctx, kvstore.JoinKey(base, "id")+"/")
 			require.NoError(t, err, "client.ListPrefix")
 			return slices.Collect(trim(maps.Keys(pairs)))
 		}
@@ -663,7 +662,7 @@ func TestRunGC(t *testing.T) {
 	require.Equal(t, 0, stats.Deleted, "No identity should have been deleted")
 
 	// Remove the secondary keys for one identity
-	require.NoError(t, client.DeletePrefix(ctx, path.Join(base, "value", "k8s:foo=bar;")+"/"))
+	require.NoError(t, client.DeletePrefix(ctx, kvstore.JoinKey(base, "value", "k8s:foo=bar;")+"/"))
 
 	// The corresponding identity should be treated as stale
 	stale, stats, err = backend.RunGC(ctx, rl, make(map[string]uint64), minID, maxID)
@@ -684,7 +683,7 @@ func TestRunGC(t *testing.T) {
 	// Create a duplicate identity for an already existing set of labels. While this
 	// should never happen thanks to locking, it has been observed in the wild, and
 	// it is better to be robust in this case as well.
-	require.NoError(t, client.Update(ctx, path.Join(base, "id", "103"), []byte("k8s:foo=bar;baz=qux;"), false), "client.Update")
+	require.NoError(t, client.Update(ctx, kvstore.JoinKey(base, "id", "103"), []byte("k8s:foo=bar;baz=qux;"), false), "client.Update")
 
 	// The duplicated identity should be treated as stale
 	stale, _, err = backend.RunGC(ctx, rl, make(map[string]uint64), minID, maxID)

--- a/pkg/kvstore/allocator/doublewrite/backend_test.go
+++ b/pkg/kvstore/allocator/doublewrite/backend_test.go
@@ -6,7 +6,6 @@ package doublewrite
 import (
 	"context"
 	"fmt"
-	"path"
 	"strconv"
 	"sync/atomic"
 	"testing"
@@ -81,7 +80,7 @@ func TestAllocateID(t *testing.T) {
 	)
 
 	// 2. KVStore
-	kvPairs, err := kvstoreClient.ListPrefix(context.Background(), path.Join(kvstorePrefix, "id"))
+	kvPairs, err := kvstoreClient.ListPrefix(context.Background(), kvstore.JoinKey(kvstorePrefix, "id"))
 	require.NoError(t, err)
 	require.Len(t, kvPairs, 1)
 	require.Equal(t,
@@ -99,7 +98,7 @@ func TestAllocateIDFailure(t *testing.T) {
 	identityID := idpool.ID(10)
 
 	// Pre-create the identity in the KVStore so as to trigger failure during allocation
-	_, err := kvstoreClient.CreateOnly(context.Background(), path.Join(kvstorePrefix, "id", strconv.FormatUint(uint64(identityID), 10)), []byte(k.GetKey()), false)
+	_, err := kvstoreClient.CreateOnly(context.Background(), kvstore.JoinKey(kvstorePrefix, "id", strconv.FormatUint(uint64(identityID), 10)), []byte(k.GetKey()), false)
 	require.NoError(t, err)
 
 	_, err = backend.AllocateID(context.Background(), identityID, k)
@@ -137,7 +136,7 @@ func TestGetID(t *testing.T) {
 	require.Equal(t, returnedKey.GetKey(), k.GetKey())
 
 	// Delete the KVStore identity
-	err = kvstoreClient.Delete(context.Background(), path.Join(kvstorePrefix, "id", identityID.String()))
+	err = kvstoreClient.Delete(context.Background(), kvstore.JoinKey(kvstorePrefix, "id", identityID.String()))
 	require.NoError(t, err)
 
 	// Verify that we can't retrieve the identity anymore

--- a/pkg/kvstore/etcd_test.go
+++ b/pkg/kvstore/etcd_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"path"
 	"slices"
 	"sync"
 	"testing"
@@ -1436,16 +1435,16 @@ func TestPaginatedList(t *testing.T) {
 	run := func(t *testing.T, batch int, withParallelOps bool) {
 		cl := client.(*clientImpl).BackendOperations.(*etcdClient)
 		keys := map[string]struct{}{
-			path.Join(prefix, "immortal-finch"):   {},
-			path.Join(prefix, "rare-goshawk"):     {},
-			path.Join(prefix, "cunning-bison"):    {},
-			path.Join(prefix, "amusing-tick"):     {},
-			path.Join(prefix, "prepared-shark"):   {},
-			path.Join(prefix, "exciting-mustang"): {},
-			path.Join(prefix, "ethical-ibex"):     {},
-			path.Join(prefix, "accepted-kite"):    {},
-			path.Join(prefix, "model-javelin"):    {},
-			path.Join(prefix, "inviting-hog"):     {},
+			JoinKey(prefix, "immortal-finch"):   {},
+			JoinKey(prefix, "rare-goshawk"):     {},
+			JoinKey(prefix, "cunning-bison"):    {},
+			JoinKey(prefix, "amusing-tick"):     {},
+			JoinKey(prefix, "prepared-shark"):   {},
+			JoinKey(prefix, "exciting-mustang"): {},
+			JoinKey(prefix, "ethical-ibex"):     {},
+			JoinKey(prefix, "accepted-kite"):    {},
+			JoinKey(prefix, "model-javelin"):    {},
+			JoinKey(prefix, "inviting-hog"):     {},
 		}
 
 		defer func(previous int) {
@@ -1464,7 +1463,7 @@ func TestPaginatedList(t *testing.T) {
 				// paginatedList should observe neither upsertions nor deletions
 				// performed after that the initial chunk of entries was retrieved.
 				postGet: func(ctx context.Context) error {
-					key := path.Join(prefix, rand.String(10))
+					key := JoinKey(prefix, rand.String(10))
 					res, err := cl.client.Put(ctx, key, "value")
 					if err != nil {
 						return err

--- a/pkg/kvstore/etcdinit/init.go
+++ b/pkg/kvstore/etcdinit/init.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"path"
 	"slices"
 	"strings"
 
@@ -288,7 +287,7 @@ func rangesForRemoteRole(clusterName string) []keyRange {
 	return []keyRange{
 		rangeForPrefix(kvstore.HeartbeatPath, withoutTrailingSlash),
 		rangeForPrefix(kvstore.StatePrefix),
-		rangeForKey(path.Join(kvstore.ClusterConfigPrefix, clusterName)),
-		rangeForPrefix(path.Join(kvstore.SyncedPrefix, clusterName)),
+		rangeForKey(kvstore.JoinKey(kvstore.ClusterConfigPrefix, clusterName)),
+		rangeForPrefix(kvstore.JoinKey(kvstore.SyncedPrefix, clusterName)),
 	}
 }

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -59,3 +59,18 @@ func StateToCachePrefix(prefix string) string {
 	}
 	return prefix
 }
+
+// JoinKey joins any number of kvstore key elements into a single key, separating
+// them with slashes. Empty elements are ignored, duplicate and trailing slashes
+// are removed. It provides a similar behavior compared to [path.Key], without
+// applying the [path.Clean] normalizations that are not desired in this context,
+// given that `.` and `..` do not bear any special semantics in the kvstore keys.
+func JoinKey(elems ...string) string {
+	var key = strings.Join(elems, "/")
+
+	for strings.Contains(key, "//") {
+		key = strings.ReplaceAll(key, "//", "/")
+	}
+
+	return strings.TrimRight(key, "/")
+}

--- a/pkg/kvstore/kvstore_test.go
+++ b/pkg/kvstore/kvstore_test.go
@@ -4,6 +4,7 @@
 package kvstore
 
 import (
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -60,6 +61,70 @@ func TestStateToCachePrefix(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, StateToCachePrefix(tt.input))
+		})
+	}
+}
+
+func TestJoinKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected string
+		incompat bool
+	}{
+		{
+			name: "no elements",
+		},
+		{
+			name:     "one element",
+			input:    []string{"foo"},
+			expected: "foo",
+		},
+		{
+			name:     "multiple elements",
+			input:    []string{"foo/bar", "baz", "qux"},
+			expected: "foo/bar/baz/qux",
+		},
+		{
+			name:     "multiple elements, with leading and trailing slashes",
+			input:    []string{"/foo/bar/", "/baz//", "/qux/"},
+			expected: "/foo/bar/baz/qux",
+		},
+		{
+			name:     "multiple elements, some empty",
+			input:    []string{"foo/bar", "", "", "baz", "", "qux"},
+			expected: "foo/bar/baz/qux",
+		},
+		{
+			name:  "multiple elements, all empty",
+			input: []string{"", "", ""},
+		},
+		{
+			name:     "multiple elements, all slashes",
+			input:    []string{"/", "/", "/"},
+			expected: "",
+			// kvstore keys are not rooted at /
+			incompat: true,
+		},
+		{
+			name:     "multiple elements, with . and ..",
+			input:    []string{"foo/bar", "..", ".", "qux"},
+			expected: "foo/bar/.././qux",
+			// . and .. don't bear any special semantics in kvstore keys
+			incompat: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, JoinKey(tt.input...))
+
+			if !tt.incompat {
+				// Assert that [JoinKey] returns the exact same result as
+				// [path.Join] to prevent the risk of backward compatibility
+				// issues.
+				assert.Equal(t, path.Join(tt.input...), JoinKey(tt.input...))
+			}
 		})
 	}
 }

--- a/pkg/kvstore/kvstore_test.go
+++ b/pkg/kvstore/kvstore_test.go
@@ -4,7 +4,7 @@
 package kvstore
 
 import (
-	"path"
+	"path" //nolint:depguard // used to cross-check JoinKey against path.Join
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
-	"path"
 	"slices"
 	"strings"
 	"sync"
@@ -277,7 +276,7 @@ func (s *SharedStore) Close(ctx context.Context) {
 func (s *SharedStore) keyPath(key NamedKey) string {
 	// WARNING - STABLE API: The composition of the absolute key path
 	// cannot be changed without breaking up and downgrades.
-	return path.Join(s.conf.Prefix, key.GetKeyName())
+	return kvstore.JoinKey(s.conf.Prefix, key.GetKeyName())
 }
 
 // syncLocalKey synchronizes a key to the kvstore

--- a/pkg/kvstore/store/syncstore.go
+++ b/pkg/kvstore/store/syncstore.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"path"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -364,9 +363,9 @@ func (wss *wqSyncStore) handleExpiredLease(key string) {
 func (wss *wqSyncStore) keyPath(key string) string {
 	// WARNING - STABLE API: The composition of the absolute key path
 	// cannot be changed without breaking up and downgrades.
-	return path.Join(wss.prefix, key)
+	return kvstore.JoinKey(wss.prefix, key)
 }
 
 func (wss *wqSyncStore) getSyncedKey() string {
-	return path.Join(kvstore.SyncedPrefix, wss.source, wss.syncedKey)
+	return kvstore.JoinKey(kvstore.SyncedPrefix, wss.source, wss.syncedKey)
 }

--- a/pkg/kvstore/store/watchstore_test.go
+++ b/pkg/kvstore/store/watchstore_test.go
@@ -5,7 +5,6 @@ package store
 
 import (
 	"context"
-	"path"
 	"sync"
 	"testing"
 	"time"
@@ -40,7 +39,7 @@ func (fb *fakeLWBackend) ListAndWatch(ctx context.Context, prefix string) kvstor
 		require.Equal(fb.t, fb.prefix, prefix)
 
 		for _, event := range fb.events {
-			event.Key = path.Join(fb.prefix, event.Key)
+			event.Key = kvstore.JoinKey(fb.prefix, event.Key)
 			select {
 			case ch <- event:
 			case <-ctx.Done():

--- a/pkg/kvstore/store/watchstoremgr.go
+++ b/pkg/kvstore/store/watchstoremgr.go
@@ -6,7 +6,6 @@ package store
 import (
 	"context"
 	"log/slog"
-	"path"
 	"sync"
 	"sync/atomic"
 
@@ -112,7 +111,7 @@ func newWatchStoreManagerSync(logger *slog.Logger, backend WatchStoreBackend, cl
 func (mgr *wsmSync) Run(ctx context.Context) {
 	mgr.run()
 	mgr.onUpdate = func(prefix string) { mgr.ready(ctx, prefix) }
-	mgr.store.Watch(ctx, mgr.backend, path.Join(kvstore.SyncedPrefix, mgr.clusterName))
+	mgr.store.Watch(ctx, mgr.backend, kvstore.JoinKey(kvstore.SyncedPrefix, mgr.clusterName))
 	mgr.wait()
 }
 

--- a/pkg/node/store/store.go
+++ b/pkg/node/store/store.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"path"
 
 	"github.com/cilium/cilium/pkg/defaults"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
@@ -24,7 +23,7 @@ var (
 	//
 	// WARNING - STABLE API: Changing the structure or values of this will
 	// break backwards compatibility
-	NodeStorePrefix = path.Join(kvstore.BaseKeyPrefix, "state", "nodes", "v1")
+	NodeStorePrefix = kvstore.JoinKey(kvstore.BaseKeyPrefix, "state", "nodes", "v1")
 
 	// KeyCreator creates a node for a shared store
 	KeyCreator = func() store.Key {

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
-	"path"
 	"slices"
+	"strings"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/cidr"
@@ -29,7 +29,7 @@ type Identity struct {
 
 // String returns the string representation on NodeIdentity.
 func (nn Identity) String() string {
-	return path.Join(nn.Cluster, nn.Name)
+	return GetKeyNodeName(nn.Cluster, nn.Name)
 }
 
 // Node contains the nodes name, the list of addresses to this address
@@ -103,7 +103,7 @@ type Node struct {
 // cluster name value other than the default value has been specified
 func (n *Node) Fullname() string {
 	if n.Cluster != defaults.ClusterName {
-		return path.Join(n.Cluster, n.Name)
+		return n.GetKeyName()
 	}
 
 	return n.Name
@@ -463,8 +463,9 @@ func (n *Node) GetIPv6AllocCIDRs() []*cidr.CIDR {
 // GetKeyNodeName constructs the API name for the given cluster and node name.
 func GetKeyNodeName(cluster, node string) string {
 	// WARNING - STABLE API: Changing the structure of the key may break
-	// backwards compatibility
-	return path.Join(cluster, node)
+	// backwards compatibility. Open-coded, instead of using [kvstore.JoinKey]
+	// to avoid introducing an unnecessary dependency on the kvstore package.
+	return strings.Trim(cluster+"/"+node, "/")
 }
 
 // GetKeyName returns the kvstore key to be used for the node


### PR DESCRIPTION
The keys of the kvstore entries leveraged by Cilium are constructed as a sequence of elements joined by slashes. Currently, we leverage the [path.Join] helper to construct such keys. However, one main drawback is that it also applies the [path.Clean] normalizations that are not desired in this context, given that `.` and `..` do not bear any special semantics. In turn, these extra normalizations can lead to unnecessary overhead, and possible surprising behavior if the special sequences are actually present inside that key.

To avoid this, let's instead introduce a dedicated [kvstore.JoinKey] helper, which implements the exact semantics we desire in this context. To this end, we mostly replicate the behavior of [path.Join], especially around ignoring empty elements and trimming both duplicate and trailing slashes, to prevent possible surprises, and ensure that we don't break backwards compatibility for all well-formed set of elements.
