### PR TITLE
vtep: Migrate from `net.IP`/`cidr.CIDR` to `netip.{Addr,Prefix}`

### DIFF
--- a/cilium-dbg/cmd/bpf_vtep_delete.go
+++ b/cilium-dbg/cmd/bpf_vtep_delete.go
@@ -4,9 +4,10 @@
 package cmd
 
 import (
+	"net/netip"
+
 	"github.com/spf13/cobra"
 
-	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/maps/vtep"
 )
@@ -23,12 +24,12 @@ var bpfVtepDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf vtep delete <vtep_cidr>")
 
-		vcidr, err := cidr.ParseCIDR(args[0])
+		vcidr, err := netip.ParsePrefix(args[0])
 		if err != nil {
 			Fatalf("error parsing cidr %s: %s", args[0], err)
 		}
 
-		if err := vtep.LoadVTEPMap(log).Delete(vcidr.IP); err != nil {
+		if err := vtep.LoadVTEPMap(log).Delete(vcidr.Addr()); err != nil {
 			Fatalf("error deleting contents of map: %s\n", err)
 		}
 	},

--- a/cilium-dbg/cmd/bpf_vtep_update.go
+++ b/cilium-dbg/cmd/bpf_vtep_update.go
@@ -5,12 +5,11 @@ package cmd
 
 import (
 	"fmt"
-	"net"
+	"net/netip"
 	"os"
 
 	"github.com/spf13/cobra"
 
-	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/maps/vtep"
@@ -29,13 +28,13 @@ var bpfVtepUpdateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf vtep update <vtep_cidr> <vtep_ip> <vtep_mac>")
 
-		vcidr, err := cidr.ParseCIDR(args[0])
+		vcidr, err := netip.ParsePrefix(args[0])
 		if err != nil {
 			Fatalf("error parsing cidr %s: %s", args[0], err)
 		}
 
-		vip := net.ParseIP(args[1]).To4()
-		if vip == nil {
+		vip, err := netip.ParseAddr(args[1])
+		if err != nil || !vip.Is4() {
 			Fatalf("Unable to parse IP '%s'", args[1])
 		}
 

--- a/pkg/datapath/vtep/cell.go
+++ b/pkg/datapath/vtep/cell.go
@@ -6,13 +6,12 @@ package vtep
 import (
 	"fmt"
 	"log/slog"
-	"net"
+	"net/netip"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
 	"github.com/spf13/pflag"
 
-	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/maps/vtep"
@@ -101,23 +100,22 @@ func (r config) validatedConfig() (*vtepManagerConfig, error) {
 	}
 
 	for _, ep := range r.VTEPEndpoint {
-		endpoint := net.ParseIP(ep)
-		if endpoint == nil {
+		endpoint, err := netip.ParseAddr(ep)
+		if err != nil {
 			return nil, fmt.Errorf("Invalid VTEP IP: %v", ep)
 		}
-		ip4 := endpoint.To4()
-		if ip4 == nil {
-			return nil, fmt.Errorf("Invalid VTEP IPv4 address %v", ip4)
+		if !endpoint.Is4() {
+			return nil, fmt.Errorf("Invalid VTEP IPv4 address %v", endpoint)
 		}
 		config.vtepEndpoints = append(config.vtepEndpoints, endpoint)
 	}
 
 	for _, v := range r.VTEPCIDR {
-		externalCIDR, err := cidr.ParseCIDR(v)
+		externalCIDR, err := netip.ParsePrefix(v)
 		if err != nil {
 			return nil, fmt.Errorf("Invalid VTEP CIDR: %v", v)
 		}
-		config.vtepCIDRs = append(config.vtepCIDRs, externalCIDR)
+		config.vtepCIDRs = append(config.vtepCIDRs, externalCIDR.Masked())
 	}
 
 	for _, m := range r.VTEPMAC {

--- a/pkg/datapath/vtep/vtep_manager.go
+++ b/pkg/datapath/vtep/vtep_manager.go
@@ -7,11 +7,12 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net"
+	"net/netip"
 
 	"github.com/vishvananda/netlink"
+	"go4.org/netipx"
+	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
@@ -24,8 +25,8 @@ import (
 )
 
 type vtepManagerConfig struct {
-	vtepEndpoints []net.IP
-	vtepCIDRs     []*cidr.CIDR
+	vtepEndpoints []netip.Addr
+	vtepCIDRs     []netip.Prefix
 	vtepMACs      []mac.MAC
 }
 
@@ -65,7 +66,7 @@ func (r *vtepManager) setupVTEPMapping() error {
 }
 
 func (r *vtepManager) setupRouteToVTEPCidr() error {
-	routeCidrs := []*cidr.CIDR{}
+	routeCidrs := []netip.Prefix{}
 
 	filter := &netlink.Route{
 		Table: linux_defaults.RouteTableVtep,
@@ -76,25 +77,28 @@ func (r *vtepManager) setupRouteToVTEPCidr() error {
 		return fmt.Errorf("failed to list routes: %w", err)
 	}
 	for _, rt := range routes {
-		rtCIDR, err := cidr.ParseCIDR(rt.Dst.String())
-		if err != nil {
-			return fmt.Errorf("Invalid VTEP Route CIDR: %w", err)
+		rtCIDR, ok := netipx.FromStdIPNet(rt.Dst)
+		if !ok {
+			return fmt.Errorf("Invalid VTEP Route CIDR: %v", rt.Dst)
 		}
 		routeCidrs = append(routeCidrs, rtCIDR)
 	}
 
-	addedVtepRoutes, removedVtepRoutes := cidr.DiffCIDRLists(routeCidrs, r.config.vtepCIDRs)
+	// Diff the configured VTEP CIDRs against the routes currently installed.
+	routeSet := sets.New(routeCidrs...)
+	configSet := sets.New(r.config.vtepCIDRs...)
+	addedVtepRoutes := configSet.Difference(routeSet).UnsortedList()
+	removedVtepRoutes := routeSet.Difference(configSet).UnsortedList()
 	vtepMTU := mtu.EthernetMTU - mtu.TunnelOverheadIPv4
 
 	if option.Config.EnableL7Proxy {
 		for _, prefix := range addedVtepRoutes {
-			ip4 := prefix.IP.To4()
-			if ip4 == nil {
-				return fmt.Errorf("Invalid VTEP CIDR IPv4 address: %v", ip4)
+			if !prefix.Addr().Is4() {
+				return fmt.Errorf("Invalid VTEP CIDR IPv4 address: %v", prefix)
 			}
 			rt := route.Route{
 				Device: defaults.HostDevice,
-				Prefix: *prefix.IPNet,
+				Prefix: *netipx.PrefixIPNet(prefix),
 				Scope:  netlink.SCOPE_LINK,
 				MTU:    vtepMTU,
 				Table:  linux_defaults.RouteTableVtep,
@@ -109,7 +113,7 @@ func (r *vtepManager) setupRouteToVTEPCidr() error {
 
 			rule := route.Rule{
 				Priority: linux_defaults.RulePriorityVtep,
-				To:       prefix.IPNet,
+				To:       netipx.PrefixIPNet(prefix),
 				Table:    linux_defaults.RouteTableVtep,
 			}
 			if err := route.ReplaceRule(rule); err != nil {
@@ -121,13 +125,12 @@ func (r *vtepManager) setupRouteToVTEPCidr() error {
 	}
 
 	for _, prefix := range removedVtepRoutes {
-		ip4 := prefix.IP.To4()
-		if ip4 == nil {
-			return fmt.Errorf("Invalid VTEP CIDR IPv4 address: %v", ip4)
+		if !prefix.Addr().Is4() {
+			return fmt.Errorf("Invalid VTEP CIDR IPv4 address: %v", prefix)
 		}
 		rt := route.Route{
 			Device: defaults.HostDevice,
-			Prefix: *prefix.IPNet,
+			Prefix: *netipx.PrefixIPNet(prefix),
 			Scope:  netlink.SCOPE_LINK,
 			MTU:    vtepMTU,
 			Table:  linux_defaults.RouteTableVtep,
@@ -142,7 +145,7 @@ func (r *vtepManager) setupRouteToVTEPCidr() error {
 
 		rule := route.Rule{
 			Priority: linux_defaults.RulePriorityVtep,
-			To:       prefix.IPNet,
+			To:       netipx.PrefixIPNet(prefix),
 			Table:    linux_defaults.RouteTableVtep,
 		}
 		if err := route.DeleteRule(netlink.FAMILY_V4, rule); err != nil {

--- a/pkg/maps/vtep/vtep.go
+++ b/pkg/maps/vtep/vtep.go
@@ -6,12 +6,11 @@ package vtep
 import (
 	"fmt"
 	"log/slog"
-	"net"
+	"net/netip"
 
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/bpf"
-	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/ebpf"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -32,8 +31,8 @@ const (
 
 // Map provides access to the eBPF map vtep.
 type Map interface {
-	Update(newCIDR *cidr.CIDR, newTunnelEndpoint net.IP, vtepMAC mac.MAC) error
-	Delete(tunnelEndpoint net.IP) error
+	Update(newCIDR netip.Prefix, newTunnelEndpoint netip.Addr, vtepMAC mac.MAC) error
+	Delete(tunnelEndpoint netip.Addr) error
 	Dump(hash map[string][]string) error
 }
 
@@ -51,13 +50,16 @@ func (k Key) String() string {
 func (k *Key) New() bpf.MapKey { return &Key{} }
 
 // newKey returns an Key based on the provided IP address and mask.
-func newKey(ip net.IP) Key {
+func newKey(addr netip.Addr) Key {
 	result := Key{}
 
-	if ip4 := ip.To4(); ip4 != nil {
+	if addr.Is4() {
+		ip4 := addr.As4()
 		maskBytes := option.Config.VtepCidrMask.As4()
-		ip4.Mask(net.IPMask(maskBytes[:]))
-		copy(result.IP[:], ip4)
+		for i := range ip4 {
+			ip4[i] &= maskBytes[i]
+		}
+		result.IP = ip4
 	}
 
 	return result
@@ -101,8 +103,8 @@ func (m *vtepMap) close() error {
 }
 
 // Function to update vtep map with VTEP CIDR
-func (m *vtepMap) Update(newCIDR *cidr.CIDR, newTunnelEndpoint net.IP, vtepMAC mac.MAC) error {
-	key := newKey(newCIDR.IP)
+func (m *vtepMap) Update(newCIDR netip.Prefix, newTunnelEndpoint netip.Addr, vtepMAC mac.MAC) error {
+	key := newKey(newCIDR.Addr())
 
 	mac, err := vtepMAC.Uint64()
 	if err != nil {
@@ -110,15 +112,13 @@ func (m *vtepMap) Update(newCIDR *cidr.CIDR, newTunnelEndpoint net.IP, vtepMAC m
 	}
 
 	value := VtepEndpointInfo{
-		VtepMAC: mac,
+		VtepMAC:        mac,
+		TunnelEndpoint: newTunnelEndpoint.As4(),
 	}
-
-	ip4 := newTunnelEndpoint.To4()
-	copy(value.TunnelEndpoint[:], ip4)
 
 	m.logger.Debug(
 		"Updating vtep map entry",
-		logfields.V4Prefix, newCIDR.IP,
+		logfields.V4Prefix, newCIDR.Addr(),
 		logfields.MACAddr, vtepMAC,
 		logfields.Endpoint, newTunnelEndpoint,
 	)
@@ -126,7 +126,7 @@ func (m *vtepMap) Update(newCIDR *cidr.CIDR, newTunnelEndpoint net.IP, vtepMAC m
 	return m.bpfMap.Update(&key, &value)
 }
 
-func (m *vtepMap) Delete(tunnelEndpoint net.IP) error {
+func (m *vtepMap) Delete(tunnelEndpoint netip.Addr) error {
 	key := newKey(tunnelEndpoint)
 	return m.bpfMap.Delete(&key)
 }


### PR DESCRIPTION
Replace the `net.IP`/`*cidr.CIDR` types in the VTEP integration with their `net/netip` equivalents (`netip.Addr` and `netip.Prefix`).

The VTEP CIDRs are now stored as value `netip.Prefix` instead of `*cidr.CIDR`. Since `netip.Prefix` is directly comparable, the route diff in `setupRouteToVTEPCidr` drops `cidr.DiffCIDRLists` in favor of a `sets.Set` based diff with no string keying. Configured CIDRs are masked at parse time to preserve the previous matching behavior against kernel routes.

Related to #24246