### PR TITLE
helm: opt-in native routing CIDR derivation from cluster-pool CIDR

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -3260,6 +3260,10 @@
      - Enable RFC6052-prefixed translation
      - bool
      - ``false``
+   * - :spelling:ignore:`nativeRoutingCIDRFromClusterPool`
+     - Derive the native routing CIDRs from the cluster-pool IPAM CIDRs when ipv4NativeRoutingCIDR / ipv6NativeRoutingCIDR are not explicitly set. Only effective with ipam.mode=cluster-pool and requires exactly one CIDR per enabled IP family in clusterPoolIPv4PodCIDRList / clusterPoolIPv6PodCIDRList.
+     - bool
+     - ``false``
    * - :spelling:ignore:`nodeIPAM.enabled`
      - Configure Node IPAM ref: https://docs.cilium.io/en/stable/network/node-ipam/
      - bool

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -94,6 +94,7 @@ Multihop
 Multiprotocol
 Mythbusters
 NDP
+NativeRoutingCIDR
 Neovim
 Netlify
 Netronome
@@ -107,6 +108,7 @@ Pepelnjak
 Perfdash
 Pfaff
 PodCIDR
+PodCIDRList
 Polytechnique
 Portworx
 QCon
@@ -249,6 +251,7 @@ cli
 clientsets
 cls
 clusterIP
+clusterPoolIPv
 clustermesh
 clustermeshcertgen
 clustermeshes

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -865,6 +865,7 @@ contributors across the globe, there is almost always someone available to help.
 | nat.mapStatsInterval | string | `"30s"` | Interval between how often SNAT map is counted for stats. |
 | nat46x64Gateway | object | `{"enabled":false}` | Configure standalone NAT46/NAT64 gateway |
 | nat46x64Gateway.enabled | bool | `false` | Enable RFC6052-prefixed translation |
+| nativeRoutingCIDRFromClusterPool | bool | `false` | Derive the native routing CIDRs from the cluster-pool IPAM CIDRs when ipv4NativeRoutingCIDR / ipv6NativeRoutingCIDR are not explicitly set. Only effective with ipam.mode=cluster-pool and requires exactly one CIDR per enabled IP family in clusterPoolIPv4PodCIDRList / clusterPoolIPv6PodCIDRList. |
 | nodeIPAM.enabled | bool | `false` | Configure Node IPAM ref: https://docs.cilium.io/en/stable/network/node-ipam/ |
 | nodePort | object | `{"addresses":null,"autoProtectPortRange":true,"bindProtection":true,"enableDynamicSourceLookup":false,"enableHealthCheck":true,"enableHealthCheckLoadBalancerIP":false}` | Configure N-S k8s service loadbalancing |
 | nodePort.addresses | string | `nil` | List of CIDRs for choosing which IP addresses assigned to native devices are used for NodePort load-balancing. By default this is empty and the first suitable, preferably private, IPv4 and IPv6 address assigned to each device is used.  Example:    addresses: ["192.168.1.0/24", "2001::/64"]  |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1214,10 +1214,26 @@ data:
 {{- if .Values.ipv4.enabled }}
   cluster-pool-ipv4-cidr: {{ .Values.ipam.operator.clusterPoolIPv4PodCIDRList | join " " | quote }}
   cluster-pool-ipv4-mask-size: {{ .Values.ipam.operator.clusterPoolIPv4MaskSize | quote }}
+{{- if and .Values.nativeRoutingCIDRFromClusterPool (not .Values.ipv4NativeRoutingCIDR) }}
+{{- $v4Pools := .Values.ipam.operator.clusterPoolIPv4PodCIDRList }}
+{{- if kindIs "string" $v4Pools }}{{- $v4Pools = splitList " " $v4Pools }}{{- end }}
+{{- if ne (len $v4Pools) 1 }}
+{{- fail "nativeRoutingCIDRFromClusterPool requires exactly one CIDR in ipam.operator.clusterPoolIPv4PodCIDRList; set ipv4NativeRoutingCIDR explicitly instead" }}
+{{- end }}
+  ipv4-native-routing-cidr: {{ first $v4Pools | quote }}
+{{- end }}
 {{- end }}
 {{- if .Values.ipv6.enabled }}
   cluster-pool-ipv6-cidr: {{ .Values.ipam.operator.clusterPoolIPv6PodCIDRList | join " " | quote }}
   cluster-pool-ipv6-mask-size: {{ .Values.ipam.operator.clusterPoolIPv6MaskSize | quote }}
+{{- if and .Values.nativeRoutingCIDRFromClusterPool (not .Values.ipv6NativeRoutingCIDR) }}
+{{- $v6Pools := .Values.ipam.operator.clusterPoolIPv6PodCIDRList }}
+{{- if kindIs "string" $v6Pools }}{{- $v6Pools = splitList " " $v6Pools }}{{- end }}
+{{- if ne (len $v6Pools) 1 }}
+{{- fail "nativeRoutingCIDRFromClusterPool requires exactly one CIDR in ipam.operator.clusterPoolIPv6PodCIDRList; set ipv6NativeRoutingCIDR explicitly instead" }}
+{{- end }}
+  ipv6-native-routing-cidr: {{ first $v6Pools | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- if (eq $ipam "multi-pool") }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -4877,6 +4877,9 @@
       },
       "type": "object"
     },
+    "nativeRoutingCIDRFromClusterPool": {
+      "type": "boolean"
+    },
     "nodeIPAM": {
       "properties": {
         "enabled": {

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2529,6 +2529,12 @@ ipv4NativeRoutingCIDR: ""
 # the user must configure the routes to reach pods, either manually or by
 # setting the auto-direct-node-routes flag.
 ipv6NativeRoutingCIDR: ""
+# -- Derive the native routing CIDRs from the cluster-pool IPAM CIDRs when
+# ipv4NativeRoutingCIDR / ipv6NativeRoutingCIDR are not explicitly set.
+# Only effective with ipam.mode=cluster-pool and requires exactly one CIDR
+# per enabled IP family in clusterPoolIPv4PodCIDRList /
+# clusterPoolIPv6PodCIDRList.
+nativeRoutingCIDRFromClusterPool: false
 # -- cilium-monitor sidecar.
 monitor:
   # -- Enable the cilium-monitor sidecar.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2556,6 +2556,12 @@ ipv4NativeRoutingCIDR: ""
 # the user must configure the routes to reach pods, either manually or by
 # setting the auto-direct-node-routes flag.
 ipv6NativeRoutingCIDR: ""
+# -- Derive the native routing CIDRs from the cluster-pool IPAM CIDRs when
+# ipv4NativeRoutingCIDR / ipv6NativeRoutingCIDR are not explicitly set.
+# Only effective with ipam.mode=cluster-pool and requires exactly one CIDR
+# per enabled IP family in clusterPoolIPv4PodCIDRList /
+# clusterPoolIPv6PodCIDRList.
+nativeRoutingCIDRFromClusterPool: false
 # -- cilium-monitor sidecar.
 monitor:
   # -- Enable the cilium-monitor sidecar.


### PR DESCRIPTION
# Helm: opt-in native routing CIDR derivation from cluster-pool CIDR

## Summary

When using `ipam=cluster-pool` with `routing-mode=native` and IPv4
masquerading, the agent fails validation at startup unless
`ipv4-native-routing-cidr` is explicitly set — even though the pod CIDR is
already configured via `cluster-pool-ipv4-cidr`. Users have to duplicate the
same CIDR in two places.

This PR adds an opt-in Helm value `nativeRoutingCIDRFromClusterPool`
(default `false`). When enabled, the chart derives
`ipv4-native-routing-cidr` / `ipv6-native-routing-cidr` from the
cluster-pool CIDR at template rendering time. The agent and operator are
unchanged.

Fixes: #12186

## Problem

```yaml
ipam: cluster-pool
routing-mode: native
enable-ipv4-masquerade: "true"
cluster-pool-ipv4-cidr: "10.0.0.0/8"   # set
# ipv4-native-routing-cidr: not set
```

```
native routing cidr must be configured with option --ipv4-native-routing-cidr
in combination with --enable-ipv4=true --enable-ipv4-masquerade=true
--enable-ip-masq-agent=false --routing-mode=native --ipam=cluster-pool
```

## Design

Based on review feedback, this is implemented purely at the Helm level rather
than in the agent:

- **Opt-in, default off** — no behavior change for existing users.
- **Explicit values always win** — `ipv4NativeRoutingCIDR` /
  `ipv6NativeRoutingCIDR` take precedence; the derived key is only emitted
  when they are unset.
- **Multiple cluster-pool CIDRs fail loudly** — if
  `clusterPoolIPv4PodCIDRList` (or the IPv6 list) contains more than one
  entry, rendering fails with an actionable error instead of silently
  picking one.
- **Cluster-pool only** — the logic lives inside the existing
  `ipam=cluster-pool` block, so multi-pool and other IPAM modes are
  unaffected.

## Files changed

| File | Change |
|------|--------|
| `install/kubernetes/cilium/values.yaml.tmpl` | new value `nativeRoutingCIDRFromClusterPool: false` |
| `install/kubernetes/cilium/templates/cilium-configmap.yaml` | derivation + multi-CIDR guard in the cluster-pool block |
| `install/kubernetes/cilium/values.yaml` | regenerated |
| `install/kubernetes/cilium/values.schema.json` | regenerated |
| `Documentation/helm-values.rst` | regenerated |

## Behaviour matrix

| `nativeRoutingCIDRFromClusterPool` | explicit native CIDR | cluster-pool CIDRs | result |
|---|---|---|---|
| false (default) | — | — | unchanged, key not emitted |
| true | unset | one | derived from cluster-pool CIDR |
| true | set | any | explicit value wins |
| true | unset | multiple | `helm template` fails with clear error |

## Testing

Verified with `helm template` against `templates/cilium-configmap.yaml`:

1. Defaults (flag off): no `native-routing-cidr` key emitted.
2. Opt-in, single CIDR: `ipv4-native-routing-cidr: "10.0.0.0/8"` derived.
3. Opt-in + explicit `ipv4NativeRoutingCIDR`: explicit value emitted, no duplicate key.
4. Opt-in, two CIDRs: rendering fails with
   `nativeRoutingCIDRFromClusterPool requires exactly one CIDR in ipam.operator.clusterPoolIPv4PodCIDRList; set ipv4NativeRoutingCIDR explicitly instead`.
5. Opt-in + `ipv6.enabled=true`: both v4 and v6 derived.
6. Opt-in, string-form CIDR list: handled correctly.

```release-note
Add opt-in Helm value `nativeRoutingCIDRFromClusterPool` to derive the native routing CIDR from the cluster-pool IPAM CIDR when it is not explicitly configured.
```

## AI disclosure

AIL:1 — the investigation, design decisions, and implementation are my own;
AI was used for small assistance (clarifications and wording). I rendered and
verified all `helm template` scenarios locally.