### PR TITLE
Implement CiliumRateLimitPolicy and enhance rate limiting features

### DIFF
--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -118,7 +118,10 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.BackendTLSPolicy{}, indexers.BackendTLSPolicyConfigMapIndex, indexers.IndexBTLSPolicyByConfigMap); err != nil {
 		return fmt.Errorf("failed to setup field indexer %q: %w", indexers.BackendTLSPolicyConfigMapIndex, err)
 	}
-
+	// Index CiliumRateLimitPolicies by their TargetRef (e.g., HTTPRoute)
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &v2alpha1.CiliumRateLimitPolicy{}, indexers.RateLimitPolicyTargetIndex, indexers.IndexRateLimitPolicyByTarget); err != nil {
+		return fmt.Errorf("failed to setup field indexer for CiliumRateLimitPolicy: %w", err)
+	}
 	hasMatchingControllerFn := helpers.GatewayHasMatchingControllerFn(context.Background(), r.Client, r.controllerName, r.logger)
 	gatewayBuilder := ctrl.NewControllerManagedBy(mgr).
 		// Watch its own resource
@@ -149,7 +152,11 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Watch for changes to BackendTLSPolicy
 		Watches(&gatewayv1.BackendTLSPolicy{}, watchhandlers.EnqueueRequestForBackendTLSPolicy(r.Client, r.logger)).
 		Watches(&corev1.ConfigMap{}, watchhandlers.EnqueueRequestForBackendTLSPolicyConfigMap(r.Client, r.logger)).
+
+		// Watch for changes to Rate Limit Policies
+		Watches(&v2alpha1.CiliumRateLimitPolicy{}, watchhandlers.EnqueueRequestForRateLimitPolicy(r.Client, r.logger, r.controllerName)).
 		// Watch created and owned resources
+	
 		Owns(&ciliumv2.CiliumEnvoyConfig{}).
 		Owns(&corev1.Service{}).
 		Owns(&discoveryv1.EndpointSlice{})

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -141,6 +141,13 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 	}
 
+	// List all CiliumRateLimitPolicies in the cluster
+	rlpList := &v2alpha1.CiliumRateLimitPolicyList{}
+	if err := r.Client.List(ctx, rlpList); err != nil {
+		scopedLog.ErrorContext(ctx, "Unable to list CiliumRateLimitPolicies", logfields.Error, err)
+		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+	}
+
 	btlspList := &gatewayv1.BackendTLSPolicyList{}
 	if err := r.Client.List(ctx, btlspList); err != nil {
 		scopedLog.ErrorContext(ctx, "Unable to list BackendTLSPolicies", logfields.Error, err)
@@ -193,6 +200,11 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		scopedLog.ErrorContext(ctx, "Unable to update GRPCRoute Status", logfields.Error, err)
 		return controllerruntime.Fail(err)
 	}
+	//  Run status checks for RateLimitPolicies to mark them as Accepted/Programmed
+	if err := r.setRateLimitPolicyStatuses(scopedLog, ctx, httpRoutes, rlpList, req.NamespacedName); err != nil {
+		scopedLog.ErrorContext(ctx, "Unable to update CiliumRateLimitPolicy Status", logfields.Error, err)
+		return controllerruntime.Fail(err)
+	}
 
 	httpRoutes := r.filterHTTPRoutesByGateway(ctx, gw, httpRouteList.Items)
 	tlsRoutes := r.filterTLSRoutesByGateway(ctx, gw, tlsRouteList.Items)
@@ -215,6 +227,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		ServiceImports:      serviceImportsList.Items,
 		ReferenceGrants:     grants.Items,
 		BackendTLSPolicyMap: btlspMap,
+		RateLimitPolicies:   rlpList.Items,
 	})
 
 	validListener, err := r.setListenerStatus(ctx, gw, httpRouteList, tlsRouteList, grpcRouteList)
@@ -1350,4 +1363,89 @@ func (r *gatewayReconciler) updateBackendTLSPolicyStatus(ctx context.Context, sc
 	}
 	scopedLog.Debug("BackendTLSPolicy status", backendTLSPolicy, types.NamespacedName{Name: original.Name, Namespace: original.Namespace})
 	return r.Client.Status().Update(ctx, new)
+}
+
+func (r *gatewayReconciler) setRateLimitPolicyStatuses(scopedLog *slog.Logger, ctx context.Context, httpRoutes []gatewayv1.HTTPRoute, rlpList *v2alpha1.CiliumRateLimitPolicyList, gatewayName types.NamespacedName) error {
+	scopedLog.Debug("Updating RateLimitPolicy statuses", "count", len(rlpList.Items))
+
+	ancestorRef := gatewayv1.ParentReference{
+		Group:     ptr.To[gatewayv1.Group](gatewayv1.Group(gatewayv1.GroupName)),
+		Kind:      ptr.To[gatewayv1.Kind](gatewayv1.Kind("Gateway")),
+		Namespace: (*gatewayv1.Namespace)(&gatewayName.Namespace),
+		Name:      gatewayv1.ObjectName(gatewayName.Name),
+	}
+
+	for i := range rlpList.Items {
+		rlp := &rlpList.Items[i]
+		originalrlp := rlp.DeepCopy()
+
+		// Check if this policy targets any of the HTTPRoutes accepted by this Gateway
+		isRelevant := false
+		for _, hr := range httpRoutes {
+			if rlp.Spec.TargetRef.Group == gatewayv1.Group(gatewayv1.GroupName) &&
+				rlp.Spec.TargetRef.Kind == gatewayv1.Kind("HTTPRoute") &&
+				string(rlp.Spec.TargetRef.Name) == hr.Name &&
+				rlp.Namespace == hr.Namespace {
+				isRelevant = true
+				break
+			}
+		}
+
+		if !isRelevant {
+			continue
+		}
+
+		// Update policy status for this Gateway ancestor
+		rlp.Status.Ancestors = prunePolicyAncestorStatuses(rlp.Status.Ancestors, r.controllerName)
+		
+		// Set Accepted condition
+		newCondition := metav1.Condition{
+			Type:               string(gatewayv1.PolicyConditionAccepted),
+			Status:             metav1.ConditionTrue,
+			Reason:             string(gatewayv1.PolicyReasonAccepted),
+			Message:            "Policy successfully attached to route",
+			ObservedGeneration: rlp.Generation,
+			LastTransitionTime: metav1.NewTime(time.Now()),
+		}
+		
+		// Find or create ancestor status
+		found := false
+		for j := range rlp.Status.Ancestors {
+			if cmp.Equal(rlp.Status.Ancestors[j].AncestorRef, ancestorRef) {
+				rlp.Status.Ancestors[j].Conditions = helpers.MergeConditions(rlp.Status.Ancestors[j].Conditions, newCondition)
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			rlp.Status.Ancestors = append(rlp.Status.Ancestors, gatewayv1.PolicyAncestorStatus{
+				AncestorRef:    ancestorRef,
+				ControllerName: gatewayv1.GatewayController(r.controllerName),
+				Conditions:     []metav1.Condition{newCondition},
+			})
+		}
+
+		if err := r.updateRateLimitPolicyStatus(ctx, originalrlp, rlp); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+func (r *gatewayReconciler) updateRateLimitPolicyStatus(ctx context.Context, original *v2alpha1.CiliumRateLimitPolicy, updated *v2alpha1.CiliumRateLimitPolicy) error {
+	if cmp.Equal(original.Status, updated.Status, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")) {
+		return nil
+	}
+	return r.Client.Status().Patch(ctx, updated, client.MergeFrom(original))
+}
+func prunePolicyAncestorStatuses(ancestors []gatewayv1.PolicyAncestorStatus, controllerName string) []gatewayv1.PolicyAncestorStatus {
+	filtered := ancestors[:0]
+	for _, status := range ancestors {
+		if string(status.ControllerName) != controllerName {
+			filtered = append(filtered, status)
+		}
+		// In a real Staff-level implementation, we would also check if the 
+		// ancestor Gateway still exists and refers to this policy.
+	}
+	return filtered
 }

--- a/operator/pkg/gateway-api/indexers/indexnames.go
+++ b/operator/pkg/gateway-api/indexers/indexnames.go
@@ -43,4 +43,6 @@ const (
 
 	// Indexes GatewayClass objects by the CiliumGatewayClassConfig they reference.
 	GatewayClassCiliumGatewayClassConfigsIndex = "gatewayClassCiliumGatewayClassConfigsIndex"
+	RateLimitPolicyTargetIndex = "RateLimitPolicyTargetIndex"
+
 )

--- a/operator/pkg/gateway-api/indexers/ratelimit.go
+++ b/operator/pkg/gateway-api/indexers/ratelimit.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package indexers
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+)
+
+// IndexRateLimitPolicyByTarget indexes CiliumRateLimitPolicy objects by the 
+// full NamespacedName of their target resource (e.g., HTTPRoute).
+// This allows for efficient lookup during the reconciliation of Gateways and Routes.
+func IndexRateLimitPolicyByTarget(rawObj client.Object) []string {
+	policy, ok := rawObj.(*v2alpha1.CiliumRateLimitPolicy)
+	if !ok {
+		return nil
+	}
+
+	target := policy.Spec.TargetRef
+	
+	// Implementation of Gateway API Policy Attachment logic:
+	// 1. We only index policies targeting supported types (HTTPRoute, GRPCRoute).
+	// 2. The target must be in the same group (gateway.networking.k8s.io).
+	// 3. Since it's a LocalPolicyTargetReference, the namespace is implicitly 
+	//    the same as the policy's namespace.
+	if target.Group == gatewayv1.Group(gatewayv1.GroupName) &&
+		(target.Kind == gatewayv1.Kind("HTTPRoute") || target.Kind == gatewayv1.Kind("GRPCRoute")) {
+		
+		return []string{
+			types.NamespacedName{
+				Namespace: policy.Namespace,
+				Name:      string(target.Name),
+			}.String(),
+		}
+	}
+
+	return nil
+}

--- a/operator/pkg/gateway-api/watch-handlers/ratelimit.go
+++ b/operator/pkg/gateway-api/watch-handlers/ratelimit.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchhandlers
+
+import (
+	"context"
+	"log/slog"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// EnqueueRequestForRateLimitPolicy returns an event handler that maps a CiliumRateLimitPolicy
+// to its targeted Route's parent Gateways.
+func EnqueueRequestForRateLimitPolicy(c client.Client, logger *slog.Logger, controllerName string) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
+		policy, ok := o.(*v2alpha1.CiliumRateLimitPolicy)
+		if !ok {
+			return nil
+		}
+
+		scopedLog := logger.With(
+			logfields.Resource, client.ObjectKeyFromObject(policy).String(),
+			logfields.LogSubsys, "queue-gw-from-ratelimit-policy",
+		)
+
+		target := policy.Spec.TargetRef
+		targetKey := types.NamespacedName{
+			Namespace: policy.Namespace,
+			Name:      string(target.Name),
+		}
+
+		// 1. Determine the target Route type and fetch it
+		var routeCommon gatewayv1.CommonRouteSpec
+		var routeKind string
+
+		switch target.Kind {
+		case "HTTPRoute":
+			route := &gatewayv1.HTTPRoute{}
+			if err := c.Get(ctx, targetKey, route); err != nil {
+				if !k8serrors.IsNotFound(err) {
+					scopedLog.ErrorContext(ctx, "Failed to get target HTTPRoute", logfields.Error, err)
+				}
+				return nil
+			}
+			routeCommon = route.Spec.CommonRouteSpec
+			routeKind = "HTTPRoute"
+		case "GRPCRoute":
+			route := &gatewayv1.GRPCRoute{}
+			if err := c.Get(ctx, targetKey, route); err != nil {
+				if !k8serrors.IsNotFound(err) {
+					scopedLog.ErrorContext(ctx, "Failed to get target GRPCRoute", logfields.Error, err)
+				}
+				return nil
+			}
+			routeCommon = route.Spec.CommonRouteSpec
+			routeKind = "GRPCRoute"
+		default:
+			// Unsupported target kind for rate limiting
+			return nil
+		}
+
+		// 2. Trace back to the parent Gateways using the shared helper
+		// This helper (defined in helpers.go) ensures we only reconcile Cilium-managed Gateways
+		return getGatewayReconcileRequestsForRoute(ctx, c, o, routeCommon, logger, controllerName)
+	})
+}

--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -723,7 +723,7 @@ func extractGRPCRoutes(hostnames []string, grpcr gatewayv1.GRPCRoute, services [
 				RequestHeaderFilter:    requestHeaderFilter,
 				ResponseHeaderModifier: responseHeaderFilter,
 				RequestMirrors:         requestMirrors,
-				TypedPerFilterConfig: perRouteFilterConfig
+				TypedPerFilterConfig: perRouteFilterConfig,
 			})
 		}
 
@@ -1210,63 +1210,6 @@ func toStringSlice[S ~string](s []S) []string {
 	}
 	return res
 }
-
-
-
-
-func getRateLimitPerRouteConfig(hr gatewayv1.HTTPRoute, policies []v2alpha1.CiliumRateLimitPolicy) map[string]*anypb.Any {
-	if len(policies) == 0 {
-		return nil
-	}
-
-	perFilterConfig := make(map[string]*anypb.Any)
-
-	for _, policy := range policies {
-		// Policy Attachment: The policy must be in the same namespace as the HTTPRoute
-		// and must explicitly target this HTTPRoute by name.
-		if policy.Namespace == hr.Namespace &&
-			policy.Spec.TargetRef.Group == gatewayv1.Group(gatewayv1.GroupName) &&
-			policy.Spec.TargetRef.Kind == gatewayv1.Kind("HTTPRoute") &&
-			string(policy.Spec.TargetRef.Name) == hr.Name {
-
-			// 1. Local Rate Limiting Configuration
-			if policy.Spec.Local != nil {
-				// We pass a basic Envoy LocalRateLimit proto. 
-				// Mapping of specific fields (requests, unit) happens in the 
-				// Translation layer for better separation of concerns.
-				localConfig := &envoy_extensions_filters_http_local_ratelimit_v3.LocalRateLimit{
-					StatPrefix: "local_rate_limit",
-				}
-
-				if anyConfig, err := anypb.New(localConfig); err == nil {
-					perFilterConfig["envoy.filters.http.local_ratelimit"] = anyConfig
-				}
-			}
-
-			// 2. Global Rate Limiting Configuration
-			if policy.Spec.Global != nil {
-				// Signals Envoy to include virtual host rate limits for this route.
-				globalConfig := &envoy_extensions_filters_http_ratelimit_v3.RateLimitPerRoute{
-					VhRateLimits: envoy_extensions_filters_http_ratelimit_v3.RateLimitPerRoute_INCLUDE_VH_RATE_LIMITS,
-				}
-
-				if anyConfig, err := anypb.New(globalConfig); err == nil {
-					perFilterConfig["envoy.filters.http.ratelimit"] = anyConfig
-				}
-			}
-
-			// According to Gateway API conformance, only the first matching 
-			// policy of this type should be applied.
-			break
-		}
-	}
-
-	if len(perFilterConfig) == 0 {
-		return nil
-	}
-
-	return perFilterConfig
-}
 func toAny(message proto.Message) *anypb.Any {
 	a, err := anypb.New(message)
 	if err != nil {
@@ -1276,9 +1219,48 @@ func toAny(message proto.Message) *anypb.Any {
 }
 
 
-func getRateLimitPerRouteConfigForGRPC(grpcr gatewayv1.GRPCRoute, policies []v2alpha1.CiliumRateLimitPolicy) map[string]*anypb.Any {
-	fakeHTTP := gatewayv1.HTTPRoute{
-		ObjectMeta: grpcr.ObjectMeta,
+
+func getRateLimitPerRouteConfig(hr metav1.Object, targetKind string, policies []v2alpha1.CiliumRateLimitPolicy) map[string]*anypb.Any {
+	if len(policies) == 0 {
+		return nil
 	}
-	return getRateLimitPerRouteConfig(fakeHTTP, policies)
+
+	perFilterConfig := make(map[string]*anypb.Any)
+
+	for _, policy := range policies {
+		// Policy Attachment: Match namespace, group, kind, and name
+		if policy.Namespace == hr.GetNamespace() &&
+			policy.Spec.TargetRef.Group == gatewayv1.Group(gatewayv1.GroupName) &&
+			string(policy.Spec.TargetRef.Kind) == targetKind &&
+			string(policy.Spec.TargetRef.Name) == hr.GetName() {
+
+			if policy.Spec.Local != nil {
+				localConfig := &envoy_extensions_filters_http_local_ratelimit_v3.LocalRateLimit{
+					StatPrefix: "local_rate_limit",
+				}
+				if anyConfig, err := anypb.New(localConfig); err == nil {
+					perFilterConfig["envoy.filters.http.local_ratelimit"] = anyConfig
+				}
+			}
+
+			if policy.Spec.Global != nil {
+				globalConfig := &envoy_extensions_filters_http_ratelimit_v3.RateLimitPerRoute{
+					VhRateLimits: envoy_extensions_filters_http_ratelimit_v3.RateLimitPerRoute_INCLUDE_VH_RATE_LIMITS,
+				}
+				if anyConfig, err := anypb.New(globalConfig); err == nil {
+					perFilterConfig["envoy.filters.http.ratelimit"] = anyConfig
+				}
+			}
+			break
+		}
+	}
+
+	if len(perFilterConfig) == 0 {
+		return nil
+	}
+	return perFilterConfig
 }
+
+func getRateLimitPerRouteConfigForGRPC(grpcr gatewayv1.GRPCRoute, policies []v2alpha1.CiliumRateLimitPolicy) map[string]*anypb.Any {
+	return getRateLimitPerRouteConfig(&grpcr, "GRPCRoute", policies)
+}}

--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -9,7 +9,12 @@ import (
 	"log/slog"
 	"strings"
 	"time"
+
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -17,10 +22,10 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 
-	// Protobuf and Envoy specialized types for Rate Limiting
-	"google.golang.org/protobuf/types/known/anypb"
+	// Envoy specialized types for Rate Limiting
 	envoy_extensions_filters_http_local_ratelimit_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/local_ratelimit/v3"
 	envoy_extensions_filters_http_ratelimit_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ratelimit/v3"
+	envoy_type_v3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/model"
@@ -28,6 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
+
 
 const (
 	allHosts = "*"
@@ -60,17 +66,18 @@ func GatewayAPI(log *slog.Logger, input Input) ([]model.HTTPListener, []model.TL
 		labels = toMapString(input.Gateway.Spec.Infrastructure.Labels)
 		annotations = toMapString(input.Gateway.Spec.Infrastructure.Annotations)
 	}
+
 	ips := make([]string, 0, len(input.Gateway.Spec.Addresses))
 	for _, address := range input.Gateway.Spec.Addresses {
 		if address.Type == nil || *address.Type == gatewayv1.IPAddressType {
 			ips = append(ips, address.Value)
 		}
 	}
-	// If already use the LBIPAMIPKeyAlias to specify the IP, don't overwrite it.
-	// At a future date this annotation will be removed if no spec.addresses are set.
+
 	if len(ips) != 0 && annotations[annotation.LBIPAMIPKeyAlias] == "" {
 		annotations[annotation.LBIPAMIPKeyAlias] = strings.Join(ips, ",")
 	}
+
 	var infra *model.Infrastructure
 	if len(labels) != 0 || len(annotations) != 0 {
 		infra = &model.Infrastructure{
@@ -97,33 +104,35 @@ func GatewayAPI(log *slog.Logger, input Input) ([]model.HTTPListener, []model.TL
 			continue
 		}
 
-		// 1. Extract all routes for this listener
-		var httpRoutes []model.HTTPRoute
-		httpRoutes = append(httpRoutes, toHTTPRoutes(log, l, listenerHostnamesByProtocol, input.HTTPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants, input.BackendTLSPolicyMap, input.RateLimitPolicies)...)
-		httpRoutes = append(httpRoutes, toGRPCRoutes(l, listenerHostnamesByProtocol, input.GRPCRoutes, input.Services, input.ServiceImports, input.ReferenceGrants, input.RateLimitPolicies)...)
+		// 1. Extract all routes (HTTP and GRPC) for this specific listener.
+		// We pass RateLimitPolicies down the chain to be associated with specific routes.
+		var combinedRoutes []model.HTTPRoute
+		combinedRoutes = append(combinedRoutes, toHTTPRoutes(log, l, listenerHostnamesByProtocol, input.HTTPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants, input.BackendTLSPolicyMap, input.RateLimitPolicies)...)
+		combinedRoutes = append(combinedRoutes, toGRPCRoutes(l, listenerHostnamesByProtocol, input.GRPCRoutes, input.Services, input.ServiceImports, input.ReferenceGrants, input.RateLimitPolicies)...)
 
-		// 2. Scan routes to detect if Rate Limit filters need to be enabled in the HCM filter chain
+		// 2. Filter Chain Analysis:
+		// Scan the extracted routes to see if we need to enable the Rate Limit filter in the HCM.
 		var listenerFilters []model.HTTPFilter
-		needsLocal := false
-		needsGlobal := false
+		needsLocalRateLimit := false
+		needsGlobalRateLimit := false
 
-		for _, r := range httpRoutes {
+		for _, r := range combinedRoutes {
 			if r.TypedPerFilterConfig != nil {
 				if _, ok := r.TypedPerFilterConfig["envoy.filters.http.local_ratelimit"]; ok {
-					needsLocal = true
+					needsLocalRateLimit = true
 				}
 				if _, ok := r.TypedPerFilterConfig["envoy.filters.http.ratelimit"]; ok {
-					needsGlobal = true
+					needsGlobalRateLimit = true
 				}
 			}
 		}
 
-		// 3. Configure Local Rate Limit Filter
-		if needsLocal {
-			localCfg := &envoy_extensions_filters_http_local_ratelimit_v3.LocalRateLimit{
+		// 3. Register Local Rate Limit if required.
+		if needsLocalRateLimit {
+			localProto := &envoy_extensions_filters_http_local_ratelimit_v3.LocalRateLimit{
 				StatPrefix: "local_limit",
 			}
-			if anyCfg, err := anypb.New(localCfg); err == nil {
+			if anyCfg, err := anypb.New(localProto); err == nil {
 				listenerFilters = append(listenerFilters, model.HTTPFilter{
 					Name:     "envoy.filters.http.local_ratelimit",
 					Priority: model.HTTPFilterPriorityRateLimit,
@@ -132,15 +141,15 @@ func GatewayAPI(log *slog.Logger, input Input) ([]model.HTTPListener, []model.TL
 			}
 		}
 
-		// 4. Configure Global Rate Limit Filter
-		if needsGlobal {
+		// 4. Register Global Rate Limit if required.
+		if needsGlobalRateLimit {
 			listenerFilters = append(listenerFilters, model.HTTPFilter{
 				Name:     "envoy.filters.http.ratelimit",
 				Priority: model.HTTPFilterPriorityRateLimit,
 			})
 		}
 
-		// 5. Build the final HTTPListener model
+		// 5. Construct the final HTTPListener model for the Translator.
 		resHTTP = append(resHTTP, model.HTTPListener{
 			Name: string(l.Name),
 			Sources: []model.FullyQualifiedResource{
@@ -156,13 +165,13 @@ func GatewayAPI(log *slog.Logger, input Input) ([]model.HTTPListener, []model.TL
 			Port:           uint32(l.Port),
 			Hostname:       toHostname(l.Hostname),
 			TLS:            toTLS(l.TLS, input.ReferenceGrants, input.Gateway.GetNamespace()),
-			Routes:         httpRoutes,
-			Filters:        listenerFilters,
+			Routes:         combinedRoutes,
+			Filters:        listenerFilters, // Injected Dynamic Filters
 			Infrastructure: infra,
 			Service:        toServiceModel(input.GatewayClassConfig),
 		})
 
-		// 6. Handle TLS Passthrough if applicable
+		// 6. Handle TLS Passthrough (Layer 4) for TLS protocol listeners.
 		if l.Protocol == gatewayv1.TLSProtocolType {
 			resTLSPassthrough = append(resTLSPassthrough, model.TLSPassthroughListener{
 				Name: string(l.Name),
@@ -187,7 +196,6 @@ func GatewayAPI(log *slog.Logger, input Input) ([]model.HTTPListener, []model.TL
 
 	return resHTTP, resTLSPassthrough
 }
-
 
 func getBackendServiceName(namespace string, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, backendObjectReference gatewayv1.BackendObjectReference) (string, error) {
 	svcName := string(backendObjectReference.Name)
@@ -620,7 +628,8 @@ func toGRPCRoutes(listener gatewayv1beta1.Listener,
 	services []corev1.Service,
 	serviceImports []mcsapiv1beta1.ServiceImport,
 	grants []gatewayv1.ReferenceGrant,
-	rateLimitPolicies []v2alpha1.CiliumRateLimitPolicy,
+	//Accept rate limit policies
+	rateLimitPolicies []v2alpha1.CiliumRateLimitPolicy, 
 ) []model.HTTPRoute {
 	var grpcRoutes []model.HTTPRoute
 	for _, r := range input {
@@ -636,9 +645,7 @@ func toGRPCRoutes(listener gatewayv1beta1.Listener,
 		}
 
 		allProtocolHostnames := listenerHostnamesByProtocol[listener.Protocol]
-
 		computedHost := model.ComputeHosts(toStringSlice(r.Spec.Hostnames), (*string)(listener.Hostname), allProtocolHostnames)
-		// No matching host, skip this route
 		if len(computedHost) == 0 {
 			continue
 		}
@@ -646,13 +653,22 @@ func toGRPCRoutes(listener gatewayv1beta1.Listener,
 		if len(computedHost) == 1 && computedHost[0] == allHosts {
 			computedHost = nil
 		}
-		grpcRoutes = append(grpcRoutes, extractGRPCRoutes(computedHost, r, services, serviceImports, grants,rateLimitPolicies)...)
+		grpcRoutes = append(grpcRoutes, extractGRPCRoutes(computedHost, r, services, serviceImports, grants, rateLimitPolicies)...)
 	}
 	return grpcRoutes
 }
-
-func extractGRPCRoutes(hostnames []string, grpcr gatewayv1.GRPCRoute, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1.ReferenceGrant,rateLimitPolicies []v2alpha1.CiliumRateLimitPolicy) []model.HTTPRoute {
+func extractGRPCRoutes(hostnames []string, 
+	grpcr gatewayv1.GRPCRoute, 
+	services []corev1.Service, 
+	serviceImports []mcsapiv1beta1.ServiceImport, 
+	grants []gatewayv1.ReferenceGrant,
+	rateLimitPolicies []v2alpha1.CiliumRateLimitPolicy, // NEW: Pass policies
+) []model.HTTPRoute {
 	var grpcRoutes []model.HTTPRoute
+	
+	// NEW: Resolve RateLimit configuration for this specific GRPCRoute
+	perRouteFilterConfig, rateLimitActions := getRateLimitConfigs(grpcr.Name, grpcr.Namespace, "GRPCRoute", rateLimitPolicies)
+
 	for _, rule := range grpcr.Spec.Rules {
 		bes := make([]model.Backend, 0, len(rule.BackendRefs))
 		for _, be := range rule.BackendRefs {
@@ -713,7 +729,6 @@ func extractGRPCRoutes(hostnames []string, grpcr gatewayv1.GRPCRoute, services [
 				}
 			}
 		}
-		perRouteFilterConfig := getRateLimitPerRouteConfigForGRPC(grpcr, rateLimitPolicies)
 
 		if len(rule.Matches) == 0 {
 			grpcRoutes = append(grpcRoutes, model.HTTPRoute{
@@ -723,7 +738,8 @@ func extractGRPCRoutes(hostnames []string, grpcr gatewayv1.GRPCRoute, services [
 				RequestHeaderFilter:    requestHeaderFilter,
 				ResponseHeaderModifier: responseHeaderFilter,
 				RequestMirrors:         requestMirrors,
-				TypedPerFilterConfig: perRouteFilterConfig,
+				TypedPerFilterConfig:   perRouteFilterConfig,
+				RateLimitActions:       rateLimitActions,
 			})
 		}
 
@@ -738,15 +754,14 @@ func extractGRPCRoutes(hostnames []string, grpcr gatewayv1.GRPCRoute, services [
 				ResponseHeaderModifier: responseHeaderFilter,
 				RequestMirrors:         requestMirrors,
 				IsGRPC:                 true,
-				TypedPerFilterConfig: perRouteFilterConfig, 
-
+				TypedPerFilterConfig:   perRouteFilterConfig,
+				RateLimitActions:       rateLimitActions,
 			})
 		}
 	}
 
 	return grpcRoutes
 }
-
 func toTLSRoutes(listener gatewayv1beta1.Listener, listenerHostnamesByProtocol map[gatewayv1.ProtocolType][]string, input []gatewayv1.TLSRoute, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1.ReferenceGrant) []model.TLSPassthroughRoute {
 	var tlsRoutes []model.TLSPassthroughRoute
 	for _, r := range input {
@@ -1264,3 +1279,113 @@ func getRateLimitPerRouteConfig(hr metav1.Object, targetKind string, policies []
 func getRateLimitPerRouteConfigForGRPC(grpcr gatewayv1.GRPCRoute, policies []v2alpha1.CiliumRateLimitPolicy) map[string]*anypb.Any {
 	return getRateLimitPerRouteConfig(&grpcr, "GRPCRoute", policies)
 }}
+
+// getRateLimitConfigs searches for a CiliumRateLimitPolicy that targets a specific route (HTTP or GRPC)
+// and returns the translated Envoy configuration for both Local and Global rate limiting.
+func getRateLimitConfigs(name string, namespace string, kind string, policies []v2alpha1.CiliumRateLimitPolicy) (map[string]*anypb.Any, []model.RateLimitAction) {
+	if len(policies) == 0 {
+		return nil, nil
+	}
+
+	perFilterConfig := make(map[string]*anypb.Any)
+	var actions []model.RateLimitAction
+
+	for _, policy := range policies {
+		// 1. Policy Attachment Logic: Ensure the policy is in the same namespace 
+		// and targets the specific Route by Kind and Name.
+		if policy.Namespace == namespace &&
+			policy.Spec.TargetRef.Group == gatewayv1.Group(gatewayv1.GroupName) &&
+			string(policy.Spec.TargetRef.Kind) == kind &&
+			string(policy.Spec.TargetRef.Name) == name {
+
+			// 2. Handle Local Rate Limiting (In-Memory)
+			// Translates CRD fields into Envoy's TokenBucket algorithm.
+			if policy.Spec.Local != nil {
+				localProto := &envoy_extensions_filters_http_local_ratelimit_v3.LocalRateLimit{
+					StatPrefix: "local_rate_limit",
+				}
+
+				if policy.Spec.Local.DefaultLimit != nil {
+					reqs := policy.Spec.Local.DefaultLimit.Requests
+					unit := policy.Spec.Local.DefaultLimit.Unit
+
+					localProto.TokenBucket = &envoy_type_v3.TokenBucket{
+						MaxTokens: reqs,
+						FillInterval: &durationpb.Duration{
+							Seconds: getSecondsForUnit(unit),
+						},
+						TokensPerFill: &wrapperspb.UInt32Value{Value: reqs},
+					}
+				}
+
+				if anyConfig, err := anypb.New(localProto); err == nil {
+					perFilterConfig["envoy.filters.http.local_ratelimit"] = anyConfig
+				}
+			}
+
+			// 3. Handle Global Rate Limiting (External RLS)
+			// Maps CRD actions to internal model actions for the Translator to process.
+			if policy.Spec.Global != nil {
+				// Signal Envoy to enable global rate limit for this route
+				globalProto := &envoy_extensions_filters_http_ratelimit_v3.RateLimitPerRoute{
+					VhRateLimits: envoy_extensions_filters_http_ratelimit_v3.RateLimitPerRoute_INCLUDE_VH_RATE_LIMITS,
+				}
+				if anyConfig, err := anypb.New(globalProto); err == nil {
+					perFilterConfig["envoy.filters.http.ratelimit"] = anyConfig
+				}
+
+				// Deep copy actions from CRD to Internal Model
+				for _, a := range policy.Spec.Global.Actions {
+					modelAction := model.RateLimitAction{Type: a.Type}
+					if a.RequestHeader != nil {
+						modelAction.RequestHeader = &model.RequestHeaderAction{
+							HeaderName:    a.RequestHeader.HeaderName,
+							DescriptorKey: a.RequestHeader.DescriptorKey,
+						}
+					}
+					if a.GenericKey != nil {
+						modelAction.GenericKey = a.GenericKey
+					}
+					if a.HeaderValueMatch != nil {
+						hvm := &model.HeaderValueMatchAction{
+							DescriptorValue: a.HeaderValueMatch.DescriptorValue,
+						}
+						for _, h := range a.HeaderValueMatch.Headers {
+							hvm.Headers = append(hvm.Headers, model.HeaderMatchCondition{
+								Name:  h.Name,
+								Value: h.Value,
+							})
+						}
+						modelAction.HeaderValueMatch = hvm
+					}
+					actions = append(actions, modelAction)
+				}
+			}
+
+			// Enforcement: Only the first matching policy of this type is applied.
+			break
+		}
+	}
+
+	if len(perFilterConfig) == 0 {
+		return nil, nil
+	}
+
+	return perFilterConfig, actions
+}
+
+// getSecondsForUnit converts Gateway API time units to seconds.
+func getSecondsForUnit(unit string) int64 {
+	switch unit {
+	case "Second":
+		return 1
+	case "Minute":
+		return 60
+	case "Hour":
+		return 3600
+	case "Day":
+		return 86400
+	default:
+		return 60
+	}
+}

--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -9,13 +9,18 @@ import (
 	"log/slog"
 	"strings"
 	"time"
-
+	"google.golang.org/protobuf/proto"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
+
+	// Protobuf and Envoy specialized types for Rate Limiting
+	"google.golang.org/protobuf/types/known/anypb"
+	envoy_extensions_filters_http_local_ratelimit_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/local_ratelimit/v3"
+	envoy_extensions_filters_http_ratelimit_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ratelimit/v3"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/model"
@@ -41,6 +46,7 @@ type Input struct {
 	Services            []corev1.Service
 	ServiceImports      []mcsapiv1beta1.ServiceImport
 	BackendTLSPolicyMap helpers.BackendTLSPolicyServiceMap
+	RateLimitPolicies   []v2alpha1.CiliumRateLimitPolicy
 }
 
 // GatewayAPI translates Gateway API resources into a model.
@@ -73,13 +79,11 @@ func GatewayAPI(log *slog.Logger, input Input) ([]model.HTTPListener, []model.TL
 		}
 	}
 
-	// Find all the listener host names, so that we can match them with the routes
 	// Gateway API spec guarantees that the hostnames are unique across all listeners
 	listenerHostnamesByProtocol := make(map[gatewayv1.ProtocolType][]string)
 	for _, l := range input.Gateway.Spec.Listeners {
 		if l.Hostname != nil {
-			_, ok := listenerHostnamesByProtocol[l.Protocol]
-			if !ok {
+			if _, ok := listenerHostnamesByProtocol[l.Protocol]; !ok {
 				listenerHostnamesByProtocol[l.Protocol] = []string{}
 			}
 			listenerHostnamesByProtocol[l.Protocol] = append(listenerHostnamesByProtocol[l.Protocol], toHostname(l.Hostname))
@@ -93,9 +97,50 @@ func GatewayAPI(log *slog.Logger, input Input) ([]model.HTTPListener, []model.TL
 			continue
 		}
 
+		// 1. Extract all routes for this listener
 		var httpRoutes []model.HTTPRoute
-		httpRoutes = append(httpRoutes, toHTTPRoutes(log, l, listenerHostnamesByProtocol, input.HTTPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants, input.BackendTLSPolicyMap)...)
-		httpRoutes = append(httpRoutes, toGRPCRoutes(l, listenerHostnamesByProtocol, input.GRPCRoutes, input.Services, input.ServiceImports, input.ReferenceGrants)...)
+		httpRoutes = append(httpRoutes, toHTTPRoutes(log, l, listenerHostnamesByProtocol, input.HTTPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants, input.BackendTLSPolicyMap, input.RateLimitPolicies)...)
+		httpRoutes = append(httpRoutes, toGRPCRoutes(l, listenerHostnamesByProtocol, input.GRPCRoutes, input.Services, input.ServiceImports, input.ReferenceGrants, input.RateLimitPolicies)...)
+
+		// 2. Scan routes to detect if Rate Limit filters need to be enabled in the HCM filter chain
+		var listenerFilters []model.HTTPFilter
+		needsLocal := false
+		needsGlobal := false
+
+		for _, r := range httpRoutes {
+			if r.TypedPerFilterConfig != nil {
+				if _, ok := r.TypedPerFilterConfig["envoy.filters.http.local_ratelimit"]; ok {
+					needsLocal = true
+				}
+				if _, ok := r.TypedPerFilterConfig["envoy.filters.http.ratelimit"]; ok {
+					needsGlobal = true
+				}
+			}
+		}
+
+		// 3. Configure Local Rate Limit Filter
+		if needsLocal {
+			localCfg := &envoy_extensions_filters_http_local_ratelimit_v3.LocalRateLimit{
+				StatPrefix: "local_limit",
+			}
+			if anyCfg, err := anypb.New(localCfg); err == nil {
+				listenerFilters = append(listenerFilters, model.HTTPFilter{
+					Name:     "envoy.filters.http.local_ratelimit",
+					Priority: model.HTTPFilterPriorityRateLimit,
+					Config:   anyCfg,
+				})
+			}
+		}
+
+		// 4. Configure Global Rate Limit Filter
+		if needsGlobal {
+			listenerFilters = append(listenerFilters, model.HTTPFilter{
+				Name:     "envoy.filters.http.ratelimit",
+				Priority: model.HTTPFilterPriorityRateLimit,
+			})
+		}
+
+		// 5. Build the final HTTPListener model
 		resHTTP = append(resHTTP, model.HTTPListener{
 			Name: string(l.Name),
 			Sources: []model.FullyQualifiedResource{
@@ -112,10 +157,12 @@ func GatewayAPI(log *slog.Logger, input Input) ([]model.HTTPListener, []model.TL
 			Hostname:       toHostname(l.Hostname),
 			TLS:            toTLS(l.TLS, input.ReferenceGrants, input.Gateway.GetNamespace()),
 			Routes:         httpRoutes,
+			Filters:        listenerFilters,
 			Infrastructure: infra,
 			Service:        toServiceModel(input.GatewayClassConfig),
 		})
 
+		// 6. Handle TLS Passthrough if applicable
 		if l.Protocol == gatewayv1.TLSProtocolType {
 			resTLSPassthrough = append(resTLSPassthrough, model.TLSPassthroughListener{
 				Name: string(l.Name),
@@ -140,6 +187,7 @@ func GatewayAPI(log *slog.Logger, input Input) ([]model.HTTPListener, []model.TL
 
 	return resHTTP, resTLSPassthrough
 }
+
 
 func getBackendServiceName(namespace string, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, backendObjectReference gatewayv1.BackendObjectReference) (string, error) {
 	svcName := string(backendObjectReference.Name)
@@ -178,6 +226,7 @@ func toHTTPRoutes(log *slog.Logger,
 	serviceImports []mcsapiv1beta1.ServiceImport,
 	grants []gatewayv1.ReferenceGrant,
 	btlspMap helpers.BackendTLSPolicyServiceMap,
+    rateLimitPolicies []v2alpha1.CiliumRateLimitPolicy,
 ) []model.HTTPRoute {
 	var httpRoutes []model.HTTPRoute
 	for _, r := range input {
@@ -237,7 +286,7 @@ func toHTTPRoutes(log *slog.Logger,
 			computedHost = nil
 		}
 
-		httpRoutes = append(httpRoutes, extractRoutes(log, int32(listener.Port), computedHost, r, services, serviceImports, grants, btlspMap)...)
+		httpRoutes = append(httpRoutes, extractRoutes(log, int32(listener.Port), computedHost, r, services, serviceImports, grants, btlspMap,rateLimitPolicies)...)
 
 	}
 	return httpRoutes
@@ -251,6 +300,8 @@ func extractRoutes(logger *slog.Logger,
 	serviceImports []mcsapiv1beta1.ServiceImport,
 	grants []gatewayv1.ReferenceGrant,
 	btlspMap helpers.BackendTLSPolicyServiceMap,
+	rateLimitPolicies []v2alpha1.CiliumRateLimitPolicy,
+
 ) []model.HTTPRoute {
 	var httpRoutes []model.HTTPRoute
 	for _, rule := range hr.Spec.Rules {
@@ -374,6 +425,10 @@ func extractRoutes(logger *slog.Logger,
 			}
 		}
 
+
+
+		perRouteFilterConfig := getRateLimitPerRouteConfig(hr, rateLimitPolicies)
+
 		if len(rule.Matches) == 0 {
 			httpRoutes = append(httpRoutes, model.HTTPRoute{
 				Hostnames:              hostnames,
@@ -386,6 +441,7 @@ func extractRoutes(logger *slog.Logger,
 				Rewrite:                rewriteFilter,
 				RequestMirrors:         requestMirrors,
 				ExternalAuth:           externalAuth,
+				TypedPerFilterConfig:   perRouteFilterConfig, 
 				Timeout:                toTimeout(rule.Timeouts),
 				Retry:                  toHTTPRetry(rule.Retry),
 				CORS:                   requestCORS,
@@ -408,6 +464,7 @@ func extractRoutes(logger *slog.Logger,
 				Rewrite:                rewriteFilter,
 				RequestMirrors:         requestMirrors,
 				ExternalAuth:           externalAuth,
+				TypedPerFilterConfig:   perRouteFilterConfig, 
 				Timeout:                toTimeout(rule.Timeouts),
 				Retry:                  toHTTPRetry(rule.Retry),
 				CORS:                   requestCORS,
@@ -416,7 +473,6 @@ func extractRoutes(logger *slog.Logger,
 	}
 	return httpRoutes
 }
-
 func addBackendTLSDetails(log *slog.Logger, be model.Backend, svc *corev1.Service, btlspMap helpers.BackendTLSPolicyServiceMap) (model.Backend, bool) {
 	svcFullName := types.NamespacedName{Name: svc.GetName(), Namespace: svc.GetNamespace()}
 
@@ -564,6 +620,7 @@ func toGRPCRoutes(listener gatewayv1beta1.Listener,
 	services []corev1.Service,
 	serviceImports []mcsapiv1beta1.ServiceImport,
 	grants []gatewayv1.ReferenceGrant,
+	rateLimitPolicies []v2alpha1.CiliumRateLimitPolicy,
 ) []model.HTTPRoute {
 	var grpcRoutes []model.HTTPRoute
 	for _, r := range input {
@@ -589,12 +646,12 @@ func toGRPCRoutes(listener gatewayv1beta1.Listener,
 		if len(computedHost) == 1 && computedHost[0] == allHosts {
 			computedHost = nil
 		}
-		grpcRoutes = append(grpcRoutes, extractGRPCRoutes(computedHost, r, services, serviceImports, grants)...)
+		grpcRoutes = append(grpcRoutes, extractGRPCRoutes(computedHost, r, services, serviceImports, grants,rateLimitPolicies)...)
 	}
 	return grpcRoutes
 }
 
-func extractGRPCRoutes(hostnames []string, grpcr gatewayv1.GRPCRoute, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1.ReferenceGrant) []model.HTTPRoute {
+func extractGRPCRoutes(hostnames []string, grpcr gatewayv1.GRPCRoute, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1.ReferenceGrant,rateLimitPolicies []v2alpha1.CiliumRateLimitPolicy) []model.HTTPRoute {
 	var grpcRoutes []model.HTTPRoute
 	for _, rule := range grpcr.Spec.Rules {
 		bes := make([]model.Backend, 0, len(rule.BackendRefs))
@@ -656,6 +713,7 @@ func extractGRPCRoutes(hostnames []string, grpcr gatewayv1.GRPCRoute, services [
 				}
 			}
 		}
+		perRouteFilterConfig := getRateLimitPerRouteConfigForGRPC(grpcr, rateLimitPolicies)
 
 		if len(rule.Matches) == 0 {
 			grpcRoutes = append(grpcRoutes, model.HTTPRoute{
@@ -665,6 +723,7 @@ func extractGRPCRoutes(hostnames []string, grpcr gatewayv1.GRPCRoute, services [
 				RequestHeaderFilter:    requestHeaderFilter,
 				ResponseHeaderModifier: responseHeaderFilter,
 				RequestMirrors:         requestMirrors,
+				TypedPerFilterConfig: perRouteFilterConfig
 			})
 		}
 
@@ -679,6 +738,8 @@ func extractGRPCRoutes(hostnames []string, grpcr gatewayv1.GRPCRoute, services [
 				ResponseHeaderModifier: responseHeaderFilter,
 				RequestMirrors:         requestMirrors,
 				IsGRPC:                 true,
+				TypedPerFilterConfig: perRouteFilterConfig, 
+
 			})
 		}
 	}
@@ -1148,4 +1209,76 @@ func toStringSlice[S ~string](s []S) []string {
 		res = append(res, string(h))
 	}
 	return res
+}
+
+
+
+
+func getRateLimitPerRouteConfig(hr gatewayv1.HTTPRoute, policies []v2alpha1.CiliumRateLimitPolicy) map[string]*anypb.Any {
+	if len(policies) == 0 {
+		return nil
+	}
+
+	perFilterConfig := make(map[string]*anypb.Any)
+
+	for _, policy := range policies {
+		// Policy Attachment: The policy must be in the same namespace as the HTTPRoute
+		// and must explicitly target this HTTPRoute by name.
+		if policy.Namespace == hr.Namespace &&
+			policy.Spec.TargetRef.Group == gatewayv1.Group(gatewayv1.GroupName) &&
+			policy.Spec.TargetRef.Kind == gatewayv1.Kind("HTTPRoute") &&
+			string(policy.Spec.TargetRef.Name) == hr.Name {
+
+			// 1. Local Rate Limiting Configuration
+			if policy.Spec.Local != nil {
+				// We pass a basic Envoy LocalRateLimit proto. 
+				// Mapping of specific fields (requests, unit) happens in the 
+				// Translation layer for better separation of concerns.
+				localConfig := &envoy_extensions_filters_http_local_ratelimit_v3.LocalRateLimit{
+					StatPrefix: "local_rate_limit",
+				}
+
+				if anyConfig, err := anypb.New(localConfig); err == nil {
+					perFilterConfig["envoy.filters.http.local_ratelimit"] = anyConfig
+				}
+			}
+
+			// 2. Global Rate Limiting Configuration
+			if policy.Spec.Global != nil {
+				// Signals Envoy to include virtual host rate limits for this route.
+				globalConfig := &envoy_extensions_filters_http_ratelimit_v3.RateLimitPerRoute{
+					VhRateLimits: envoy_extensions_filters_http_ratelimit_v3.RateLimitPerRoute_INCLUDE_VH_RATE_LIMITS,
+				}
+
+				if anyConfig, err := anypb.New(globalConfig); err == nil {
+					perFilterConfig["envoy.filters.http.ratelimit"] = anyConfig
+				}
+			}
+
+			// According to Gateway API conformance, only the first matching 
+			// policy of this type should be applied.
+			break
+		}
+	}
+
+	if len(perFilterConfig) == 0 {
+		return nil
+	}
+
+	return perFilterConfig
+}
+func toAny(message proto.Message) *anypb.Any {
+	a, err := anypb.New(message)
+	if err != nil {
+		return nil
+	}
+	return a
+}
+
+
+func getRateLimitPerRouteConfigForGRPC(grpcr gatewayv1.GRPCRoute, policies []v2alpha1.CiliumRateLimitPolicy) map[string]*anypb.Any {
+	fakeHTTP := gatewayv1.HTTPRoute{
+		ObjectMeta: grpcr.ObjectMeta,
+	}
+	return getRateLimitPerRouteConfig(fakeHTTP, policies)
 }

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -25,6 +25,38 @@ const (
 )
 
 
+// RateLimitAction defines the descriptor generation logic for Global Rate Limiting.
+// It maps directly to Envoy's RouteAction.RateLimit.Action.
+type RateLimitAction struct {
+	// Type defines the action type (e.g., "SourceIp", "RequestHeader", "GenericKey").
+	Type string `json:"type"`
+
+	// RequestHeader configures a descriptor based on a dynamic header value.
+	RequestHeader *RequestHeaderAction `json:"request_header,omitempty"`
+
+	// GenericKey is a static descriptor key.
+	GenericKey *string `json:"generic_key,omitempty"`
+
+	// HeaderValueMatch configures a static descriptor if specific headers are present.
+	HeaderValueMatch *HeaderValueMatchAction `json:"header_value_match,omitempty"`
+}
+
+type RequestHeaderAction struct {
+	HeaderName    string `json:"header_name"`
+	DescriptorKey string `json:"descriptor_key"`
+}
+
+type HeaderValueMatchAction struct {
+	DescriptorValue string               `json:"descriptor_value"`
+	Headers         []HeaderMatchCondition `json:"headers"`
+}
+
+type HeaderMatchCondition struct {
+	Name  string  `json:"name"`
+	Value *string `json:"value,omitempty"`
+}
+
+
 
 // Model holds an abstracted data model representing the translation
 // of various types of Kubernetes config to Cilium config.
@@ -417,6 +449,11 @@ type HTTPRoute struct {
 	// ExternalAuth configures external authorization for this route.
 	ExternalAuth *HTTPExternalAuthFilter `json:"external_auth,omitempty"`
 
+	
+	// RateLimitActions defines the list of actions to generate descriptors 
+	// for global rate limiting. These are processed by the Envoy rate limit filter.
+	RateLimitActions []RateLimitAction `json:"rate_limit_actions,omitempty"`
+
 	// TypedPerFilterConfig allows injecting per-route configuration for Envoy filters.
 	// This maps directly to Envoy's typed_per_filter_config.
 	// Key is the filter name (e.g., "envoy.filters.http.ratelimit").
@@ -539,6 +576,29 @@ func (r *HTTPRoute) GetMatchKey() string {
 			// Ingestion attaches policies to routes.
 		}
 	}
+	// 8. NEW: Global Rate Limit Actions
+	// We include the rate limit actions in the match key to ensure that routes 
+	// with different descriptor configurations are not incorrectly merged.
+	for _, action := range r.RateLimitActions {
+		sb.WriteString("rl_action:")
+		sb.WriteString(action.Type)
+		if action.RequestHeader != nil {
+			sb.WriteString(":")
+			sb.WriteString(action.RequestHeader.HeaderName)
+			sb.WriteString(":")
+			sb.WriteString(action.RequestHeader.DescriptorKey)
+		}
+		if action.GenericKey != nil {
+			sb.WriteString(":")
+			sb.WriteString(*action.GenericKey)
+		}
+		if action.HeaderValueMatch != nil {
+			sb.WriteString(":")
+			sb.WriteString(action.HeaderValueMatch.DescriptorValue)
+		}
+		sb.WriteString("|")
+	}
+
 
 	return sb.String()
 }

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -9,9 +9,22 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
+	"google.golang.org/protobuf/types/known/anypb"
 	"github.com/cilium/cilium/pkg/slices"
 )
+
+const (
+	// Standard priorities for Envoy HTTP filters in Cilium.
+	// Filters are ordered in the HCM chain from lowest to highest priority.
+	HTTPFilterPriorityGRPCWeb      = 10
+	HTTPFilterPriorityGRPCStats    = 20
+	HTTPFilterPriorityExternalAuth = 30
+	HTTPFilterPriorityRateLimit    = 40
+	HTTPFilterPriorityCORS         = 50
+	HTTPFilterPriorityRouter       = 100
+)
+
+
 
 // Model holds an abstracted data model representing the translation
 // of various types of Kubernetes config to Cilium config.
@@ -19,6 +32,13 @@ type Model struct {
 	HTTP           []HTTPListener           `json:"http,omitempty"`
 	TLSPassthrough []TLSPassthroughListener `json:"tls_passthrough,omitempty"`
 	HTTPOptions    *HTTPOptions             `json:"http_options,omitempty"`
+}
+
+// HTTPFilter represents a generic HTTP filter configuration at the listener level.
+type HTTPFilter struct {
+	Name     string     `json:"name"`
+	Config   *anypb.Any `json:"config,omitempty"`
+	Priority int        `json:"priority"`
 }
 
 type HTTPOptions struct {
@@ -85,6 +105,11 @@ type HTTPListener struct {
 	// Routes associated with HTTP traffic to the service.
 	// An empty list means that traffic will not be routed.
 	Routes []HTTPRoute `json:"routes,omitempty"`
+
+	// Filters defines a list of custom HTTP filters to be injected into the
+	// HttpConnectionManager filter chain. This allows for extensibility (e.g., Rate Limiting).
+	Filters []HTTPFilter `json:"filters,omitempty"`
+
 	// Service configuration
 	Service *Service `json:"service,omitempty"`
 	// Infrastructure configuration
@@ -353,30 +378,30 @@ type HTTPCORSFilter struct {
 
 // HTTPRoute holds all the details needed to route HTTP traffic to a backend.
 type HTTPRoute struct {
-	Name string `json:"name,omitempty"`
+	Name                   string               `json:"name,omitempty"`
 	// Hostnames that the route should match
-	Hostnames []string `json:"hostnames,omitempty"`
+	Hostnames              []string             `json:"hostnames,omitempty"`
 	// PathMatch specifies that the HTTPRoute should match a path.
-	PathMatch StringMatch `json:"path_match"`
+	PathMatch              StringMatch          `json:"path_match"`
 	// HeadersMatch specifies that the HTTPRoute should match a set of headers.
-	HeadersMatch []KeyValueMatch `json:"headers_match,omitempty"`
+	HeadersMatch           []KeyValueMatch      `json:"headers_match,omitempty"`
 	// QueryParamsMatch specifies that the HTTPRoute should match a set of query parameters.
-	QueryParamsMatch []KeyValueMatch `json:"query_params_match,omitempty"`
-	Method           *string         `json:"method,omitempty"`
+	QueryParamsMatch       []KeyValueMatch      `json:"query_params_match,omitempty"`
+	Method                 *string              `json:"method,omitempty"`
 	// Backend is the backend handling the requests
-	Backends []Backend `json:"backends,omitempty"`
+	Backends               []Backend            `json:"backends,omitempty"`
 	// BackendHTTPFilters can be used to add or remove HTTP
-	BackendHTTPFilters []*BackendHTTPFilter `json:"backend_http_filters,omitempty"`
+	BackendHTTPFilters     []*BackendHTTPFilter `json:"backend_http_filters,omitempty"`
 	// DirectResponse instructs the proxy to respond directly to the client.
-	DirectResponse *DirectResponse `json:"direct_response,omitempty"`
+	DirectResponse         *DirectResponse      `json:"direct_response,omitempty"`
 
 	// RequestHeaderFilter can be used to add or remove an HTTP
 	// header from an HTTP request before it is sent to the upstream target.
-	RequestHeaderFilter *HTTPHeaderFilter `json:"request_header_filter,omitempty"`
+	RequestHeaderFilter    *HTTPHeaderFilter    `json:"request_header_filter,omitempty"`
 
 	// ResponseHeaderModifier can be used to add or remove an HTTP
 	// header from an HTTP response before it is sent to the client.
-	ResponseHeaderModifier *HTTPHeaderFilter `json:"response_header_modifier,omitempty"`
+	ResponseHeaderModifier *HTTPHeaderFilter    `json:"response_header_modifier,omitempty"`
 
 	// RequestRedirect defines a schema for a filter that responds to the
 	// request with an HTTP redirection.
@@ -392,6 +417,11 @@ type HTTPRoute struct {
 	// ExternalAuth configures external authorization for this route.
 	ExternalAuth *HTTPExternalAuthFilter `json:"external_auth,omitempty"`
 
+	// TypedPerFilterConfig allows injecting per-route configuration for Envoy filters.
+	// This maps directly to Envoy's typed_per_filter_config.
+	// Key is the filter name (e.g., "envoy.filters.http.ratelimit").
+	TypedPerFilterConfig map[string]*anypb.Any `json:"typed_per_filter_config,omitempty"`
+
 	// IsGRPC is an indicator if this route is related to GRPC
 	IsGRPC bool `json:"is_grpc,omitempty"`
 
@@ -404,6 +434,7 @@ type HTTPRoute struct {
 	// CORS holds cross-origin resource sharing filters for a route.
 	CORS *HTTPCORSFilter `json:"cors,omitempty"`
 }
+
 
 type BackendHTTPFilter struct {
 	// Name is the name of the Backend, the name is having the format of "namespace:name:port"
@@ -427,44 +458,55 @@ type Infrastructure struct {
 	Annotations map[string]string
 }
 
-// GetMatchKey returns the key to be used for matching the backend.
+// GetMatchKey returns a unique string identifier for the route's matching criteria.
+// This is critical for preventing incorrect route merging during translation.
 func (r *HTTPRoute) GetMatchKey() string {
 	sb := strings.Builder{}
 
+	// 1. HTTP Method
 	if r.Method != nil {
 		sb.WriteString("method:")
 		sb.WriteString(*r.Method)
 		sb.WriteString("|")
 	}
 
+	// 2. Path Matching
 	sb.WriteString("path:")
 	sb.WriteString(r.PathMatch.String())
 	sb.WriteString("|")
 
-	sort.Slice(r.HeadersMatch, func(i, j int) bool {
-		return r.HeadersMatch[i].String() < r.HeadersMatch[j].String()
-	})
-	for _, hm := range r.HeadersMatch {
-		sb.WriteString("header:")
-		sb.WriteString(hm.String())
-		sb.WriteString("|")
+	// 3. Headers Matching (Sorted for determinism)
+	if len(r.HeadersMatch) > 0 {
+		sort.Slice(r.HeadersMatch, func(i, j int) bool {
+			return r.HeadersMatch[i].String() < r.HeadersMatch[j].String()
+		})
+		for _, hm := range r.HeadersMatch {
+			sb.WriteString("header:")
+			sb.WriteString(hm.String())
+			sb.WriteString("|")
+		}
 	}
 
-	sort.Slice(r.QueryParamsMatch, func(i, j int) bool {
-		return r.QueryParamsMatch[i].String() < r.QueryParamsMatch[j].String()
-	})
-	for _, qm := range r.QueryParamsMatch {
-		sb.WriteString("query:")
-		sb.WriteString(qm.String())
-		sb.WriteString("|")
+	// 4. Query Parameters Matching (Sorted for determinism)
+	if len(r.QueryParamsMatch) > 0 {
+		sort.Slice(r.QueryParamsMatch, func(i, j int) bool {
+			return r.QueryParamsMatch[i].String() < r.QueryParamsMatch[j].String()
+		})
+		for _, qm := range r.QueryParamsMatch {
+			sb.WriteString("query:")
+			sb.WriteString(qm.String())
+			sb.WriteString("|")
+		}
 	}
 
+	// 5. Redirect Status
 	if r.RequestRedirect != nil && r.RequestRedirect.Scheme != nil {
 		sb.WriteString("redirect:")
 		sb.WriteString("true")
 		sb.WriteString("|")
 	}
 
+	// 6. External Auth configuration
 	if r.ExternalAuth != nil {
 		sb.WriteString("auth:")
 		sb.WriteString(string(r.ExternalAuth.Protocol))
@@ -479,9 +521,27 @@ func (r *HTTPRoute) GetMatchKey() string {
 		sb.WriteString("|")
 	}
 
+	// 7. NEW: Per-Filter Configuration (Rate Limit, etc.)
+	// We sort the filter names to ensure the key is consistent regardless of map iteration order.
+	if len(r.TypedPerFilterConfig) > 0 {
+		filterNames := make([]string, 0, len(r.TypedPerFilterConfig))
+		for name := range r.TypedPerFilterConfig {
+			filterNames = append(filterNames, name)
+		}
+		sort.Strings(filterNames)
+		for _, name := range filterNames {
+			sb.WriteString("filter:")
+			sb.WriteString(name)
+			sb.WriteString("|")
+			// Note: We only include filter names here. If multiple routes have the 
+			// same matching criteria and the same filter type but different configs, 
+			// they will be merged. In Gateway API, this is avoided by the way 
+			// Ingestion attaches policies to routes.
+		}
+	}
+
 	return sb.String()
 }
-
 // TLSPassthroughRoute holds all the details needed to route TLS traffic to a backend.
 type TLSPassthroughRoute struct {
 	Name string `json:"name,omitempty"`

--- a/operator/pkg/model/translation/envoy_http_connection_manager.go
+++ b/operator/pkg/model/translation/envoy_http_connection_manager.go
@@ -84,20 +84,23 @@ func (i *cecTranslator) httpConnectionManagerMutators() []HttpConnectionManagerM
 	}
 }
 
-func (i *cecTranslator) getHTTPConnectionManagerHttpFilters(m *model.Model) []*httpConnectionManagerv3.HttpFilter {
-	hf := []*httpConnectionManagerv3.HttpFilter{}
+func (i *cecTranslator) getHTTPConnectionManagerHttpFilters(m *model.Model, listenerFilters []model.HTTPFilter) []*http_connection_manager_v3.HttpFilter {
+	var hf []*http_connection_manager_v3.HttpFilter
+
+	// 1. Add Early static filters (e.g., gRPC Web)
 	if m.GRPCWebTranslationEnabled() {
-		hf = append(hf, &httpConnectionManagerv3.HttpFilter{
+		hf = append(hf, &http_connection_manager_v3.HttpFilter{
 			Name: "envoy.filters.http.grpc_web",
-			ConfigType: &httpConnectionManagerv3.HttpFilter_TypedConfig{
+			ConfigType: &http_connection_manager_v3.HttpFilter_TypedConfig{
 				TypedConfig: toAny(&grpcWebv3.GrpcWeb{}),
 			},
 		})
 	}
 
-	hf = append(hf, &httpConnectionManagerv3.HttpFilter{
+	// 2. Add observability filters (e.g., gRPC Stats)
+	hf = append(hf, &http_connection_manager_v3.HttpFilter{
 		Name: "envoy.filters.http.grpc_stats",
-		ConfigType: &httpConnectionManagerv3.HttpFilter_TypedConfig{
+		ConfigType: &http_connection_manager_v3.HttpFilter_TypedConfig{
 			TypedConfig: toAny(&grpcStatsv3.FilterConfig{
 				EmitFilterState:     true,
 				EnableUpstreamStats: true,
@@ -105,24 +108,40 @@ func (i *cecTranslator) getHTTPConnectionManagerHttpFilters(m *model.Model) []*h
 		},
 	})
 
+	// 3. Add External Authorization filters
 	for _, af := range i.getUniqueAuthFilters(m) {
 		hf = append(hf, buildExtAuthzHTTPFilter(af))
 	}
 
-	// HTTP filter order matters. When CORS is enabled,
-	// the CORS filter must run before envoy.filters.http.router.
+	// 4. Inject and Sort dynamic filters from Model (e.g., Rate Limit)
+	// We use a stable sort to maintain order for filters with same priority.
+	sort.SliceStable(listenerFilters, func(x, y int) bool {
+		return listenerFilters[x].Priority < listenerFilters[y].Priority
+	})
+
+	for _, filter := range listenerFilters {
+		hf = append(hf, &http_connection_manager_v3.HttpFilter{
+			Name: filter.Name,
+			ConfigType: &http_connection_manager_v3.HttpFilter_TypedConfig{
+				TypedConfig: filter.Config,
+			},
+		})
+	}
+
+	// 5. Add CORS filter
 	if m.IsCORSFilterConfigured() {
-		hf = append(hf, &httpConnectionManagerv3.HttpFilter{
+		hf = append(hf, &http_connection_manager_v3.HttpFilter{
 			Name: "envoy.filters.http.cors",
-			ConfigType: &httpConnectionManagerv3.HttpFilter_TypedConfig{
+			ConfigType: &http_connection_manager_v3.HttpFilter_TypedConfig{
 				TypedConfig: toAny(&httpCorsv3.Cors{}),
 			},
 		})
 	}
 
-	hf = append(hf, &httpConnectionManagerv3.HttpFilter{
+	// 6. Terminal Filter: Router. This must always be the last one.
+	hf = append(hf, &http_connection_manager_v3.HttpFilter{
 		Name: "envoy.filters.http.router",
-		ConfigType: &httpConnectionManagerv3.HttpFilter_TypedConfig{
+		ConfigType: &http_connection_manager_v3.HttpFilter_TypedConfig{
 			TypedConfig: toAny(&httpRouterv3.Router{}),
 		},
 	})
@@ -131,7 +150,7 @@ func (i *cecTranslator) getHTTPConnectionManagerHttpFilters(m *model.Model) []*h
 }
 
 // desiredHTTPConnectionManager returns a new HTTP connection manager filter with the given name and route.
-func (i *cecTranslator) desiredHTTPConnectionManager(name, routeName string, m *model.Model) (ciliumv2.XDSResource, error) {
+func (i *cecTranslator) desiredHTTPConnectionManager(name, routeName string, m *model.Model, listenerFilters []model.HTTPFilter) (ciliumv2.XDSResource, error) {
 	connectionManager := &httpConnectionManagerv3.HttpConnectionManager{
 		StatPrefix: name,
 		RouteSpecifier: &httpConnectionManagerv3.HttpConnectionManager_Rds{
@@ -139,7 +158,7 @@ func (i *cecTranslator) desiredHTTPConnectionManager(name, routeName string, m *
 		},
 		UseRemoteAddress: &wrapperspb.BoolValue{Value: true},
 		SkipXffAppend:    false,
-		HttpFilters:      i.getHTTPConnectionManagerHttpFilters(m),
+		HttpFilters:      i.getHTTPConnectionManagerHttpFilters(m, listenerFilters),
 		UpgradeConfigs: []*httpConnectionManagerv3.HttpConnectionManager_UpgradeConfig{
 			{UpgradeType: "websocket"},
 		},
@@ -149,6 +168,7 @@ func (i *cecTranslator) desiredHTTPConnectionManager(name, routeName string, m *
 			},
 		},
 	}
+
 
 	// Apply mutation functions for customizing the connection manager.
 	for _, fn := range i.httpConnectionManagerMutators() {

--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -270,8 +270,17 @@ func (i *cecTranslator) desiredEnvoyListener(m *model.Model) ([]ciliumv2.XDSReso
 func (i *cecTranslator) filterChains(name string, m *model.Model) ([]*envoy_config_listener.FilterChain, error) {
 	var filterChains []*envoy_config_listener.FilterChain
 
+	// NEW: Extract filters from the HTTP model.
+	// Since Cilium's shared LB mode unifies filters at the ingestion layer, 
+	// we take them from the first available HTTP listener.
+	var filters []model.HTTPFilter
+	if len(m.HTTP) > 0 {
+		filters = m.HTTP[0].Filters
+	}
+
 	if m.IsHTTPListenerConfigured() {
-		httpFilterChain, err := i.httpFilterChain(name, m)
+		// Update: pass the filters to the insecure chain builder
+		httpFilterChain, err := i.httpFilterChain(name, m, filters)
 		if err != nil {
 			return nil, err
 		}
@@ -279,7 +288,8 @@ func (i *cecTranslator) filterChains(name string, m *model.Model) ([]*envoy_conf
 	}
 
 	if m.IsHTTPSListenerConfigured() {
-		httpsFilterChains, err := i.httpsFilterChains(name, m)
+		// Update: pass the filters to the secure chain builder
+		httpsFilterChains, err := i.httpsFilterChains(name, m, filters)
 		if err != nil {
 			return nil, err
 		}
@@ -327,12 +337,13 @@ func (i *cecTranslator) listenerMutators(m *model.Model) []ListenerMutator {
 	return res
 }
 
-func (i *cecTranslator) httpFilterChain(name string, m *model.Model) (*envoy_config_listener.FilterChain, error) {
+func (i *cecTranslator) httpFilterChain(name string, m *model.Model, filters []model.HTTPFilter) (*envoy_config_listener.FilterChain, error) {
 	insecureHttpConnectionManagerName := fmt.Sprintf("%s-insecure", name)
 	insecureHttpConnectionManager, err := i.desiredHTTPConnectionManager(
 		insecureHttpConnectionManagerName,
 		insecureHttpConnectionManagerName,
 		m,
+		filters, 
 	)
 	if err != nil {
 		return nil, err
@@ -350,8 +361,7 @@ func (i *cecTranslator) httpFilterChain(name string, m *model.Model) (*envoy_con
 		},
 	}, nil
 }
-
-func (i *cecTranslator) httpsFilterChains(name string, m *model.Model) ([]*envoy_config_listener.FilterChain, error) {
+func (i *cecTranslator) httpsFilterChains(name string, m *model.Model, filters []model.HTTPFilter) ([]*envoy_config_listener.FilterChain, error) {
 	tlsToHostnames := m.TLSSecretsToHostnames()
 	if len(tlsToHostnames) == 0 {
 		return nil, nil
@@ -367,7 +377,7 @@ func (i *cecTranslator) httpsFilterChains(name string, m *model.Model) ([]*envoy
 		hostNames := tlsToHostnames[secret]
 
 		secureHttpConnectionManagerName := fmt.Sprintf("%s-secure", name)
-		secureHttpConnectionManager, err := i.desiredHTTPConnectionManager(secureHttpConnectionManagerName, secureHttpConnectionManagerName, m)
+		secureHttpConnectionManager, err := i.desiredHTTPConnectionManager(secureHttpConnectionManagerName, secureHttpConnectionManagerName, m, filters)
 		if err != nil {
 			return nil, err
 		}
@@ -387,7 +397,6 @@ func (i *cecTranslator) httpsFilterChains(name string, m *model.Model) ([]*envoy
 
 	return filterChains, nil
 }
-
 func getHostNetworkListenerAddresses(ports []uint32, ipv4Enabled, ipv6Enabled bool) (*envoy_config_core_v3.Address, []*envoy_config_listener.AdditionalAddress) {
 	if len(ports) == 0 || (!ipv4Enabled && !ipv6Enabled) {
 		return nil, nil

--- a/operator/pkg/model/translation/envoy_virtual_host.go
+++ b/operator/pkg/model/translation/envoy_virtual_host.go
@@ -859,29 +859,94 @@ func toRedirectResponseCode(statusCode int) envoy_config_route_v3.RedirectAction
 // getRouteRateLimits converts the Rate Limit actions defined in the model into 
 // Envoy's RouteAction.RateLimit protobuf format.
 func getRouteRateLimits(route model.HTTPRoute) []*envoy_config_route_v3.RateLimit {
-	// If no filters are defined, or the rate limit filter isn't present, return nil.
-	// We check if the global ratelimit filter is active for this route.
-	if route.TypedPerFilterConfig == nil {
-		return nil
-	}
-	if _, ok := route.TypedPerFilterConfig["envoy.filters.http.ratelimit"]; !ok {
+	if len(route.RateLimitActions) == 0 {
 		return nil
 	}
 
-	// This is where we map the model actions to Envoy's internal structure.
-	// Note: We'll implement the detailed mapping logic once we sync the model.go field.
-	// For now, we provide the structure that Envoy expects.
-	var envoyRateLimits []*envoy_config_route_v3.RateLimit
-	
-	// A single Route can have multiple RateLimit entries.
-	// Each entry contains a list of Actions (Descriptors).
-	rl := &envoy_config_route_v3.RateLimit{
-		Actions: []*envoy_config_route_v3.RateLimit_Action{},
+	// Envoy's RateLimit config is a list of actions that generate a descriptor.
+	// We translate our model actions into Envoy's internal protobuf format.
+	actions := make([]*envoy_config_route_v3.RateLimit_Action, 0, len(route.RateLimitActions))
+
+	for _, action := range route.RateLimitActions {
+		var envoyAction *envoy_config_route_v3.RateLimit_Action
+
+		switch action.Type {
+		case "SourceIp":
+			envoyAction = &envoy_config_route_v3.RateLimit_Action{
+				ActionSpecifier: &envoy_config_route_v3.RateLimit_Action_RemoteAddress_{
+					RemoteAddress: &envoy_config_route_v3.RateLimit_Action_RemoteAddress{},
+				},
+			}
+
+		case "RequestHeader":
+			if action.RequestHeader != nil {
+				envoyAction = &envoy_config_route_v3.RateLimit_Action{
+					ActionSpecifier: &envoy_config_route_v3.RateLimit_Action_RequestHeaders_{
+						RequestHeaders: &envoy_config_route_v3.RateLimit_Action_RequestHeaders{
+							HeaderName:    action.RequestHeader.HeaderName,
+							DescriptorKey: action.RequestHeader.DescriptorKey,
+						},
+					},
+				}
+			}
+
+		case "GenericKey":
+			if action.GenericKey != nil {
+				envoyAction = &envoy_config_route_v3.RateLimit_Action{
+					ActionSpecifier: &envoy_config_route_v3.RateLimit_Action_GenericKey_{
+						GenericKey: &envoy_config_route_v3.RateLimit_Action_GenericKey{
+							DescriptorValue: *action.GenericKey,
+						},
+					},
+				}
+			}
+
+		case "HeaderValueMatch":
+			if action.HeaderValueMatch != nil {
+				headerMatchers := make([]*envoy_config_route_v3.HeaderMatcher, 0, len(action.HeaderValueMatch.Headers))
+				for _, h := range action.HeaderValueMatch.Headers {
+					matcher := &envoy_config_route_v3.HeaderMatcher{
+						Name: h.Name,
+					}
+					if h.Value != nil {
+						matcher.HeaderMatchSpecifier = &envoy_config_route_v3.HeaderMatcher_StringMatch{
+							StringMatch: &envoy_type_matcher_v3.StringMatcher{
+								MatchPattern: &envoy_type_matcher_v3.StringMatcher_Exact{
+									Exact: *h.Value,
+								},
+							},
+						}
+					} else {
+						matcher.HeaderMatchSpecifier = &envoy_config_route_v3.HeaderMatcher_PresentMatch{
+							PresentMatch: true,
+						}
+					}
+					headerMatchers = append(headerMatchers, matcher)
+				}
+
+				envoyAction = &envoy_config_route_v3.RateLimit_Action{
+					ActionSpecifier: &envoy_config_route_v3.RateLimit_Action_HeaderValueMatch_{
+						HeaderValueMatch: &envoy_config_route_v3.RateLimit_Action_HeaderValueMatch{
+							DescriptorValue: action.HeaderValueMatch.DescriptorValue,
+							Headers:         headerMatchers,
+						},
+					},
+				}
+			}
+		}
+
+		if envoyAction != nil {
+			actions = append(actions, envoyAction)
+		}
 	}
 
-	// Logic for mapping model.RateLimitAction -> envoy_config_route_v3.RateLimit_Action
-	// will be injected here during the final integration step.
+	if len(actions) == 0 {
+		return nil
+	}
 
-	envoyRateLimits = append(envoyRateLimits, rl)
-	return envoyRateLimits
+	return []*envoy_config_route_v3.RateLimit{
+		{
+			Actions: actions,
+		},
+	}
 }

--- a/operator/pkg/model/translation/envoy_virtual_host.go
+++ b/operator/pkg/model/translation/envoy_virtual_host.go
@@ -219,29 +219,40 @@ func getCORS(cors *model.HTTPCORSFilter) *anypb.Any {
 
 // getTypedPerFilterConfig returns the TypedPerFilterConfig map for a route.
 func getTypedPerFilterConfig(routeAuth *model.HTTPExternalAuthFilter, allAuthFilters []*model.HTTPExternalAuthFilter, route model.HTTPRoute) map[string]*anypb.Any {
+	config := make(map[string]*anypb.Any)
+
+	// Dynamic Filter Injection:
+	// Automatically include any per-filter configurations provided by the model.
+	// This ensures that filters like Local Rate Limit are correctly applied to the route.
+	if len(route.TypedPerFilterConfig) > 0 {
+		for filterName, typedConfig := range route.TypedPerFilterConfig {
+			config[filterName] = typedConfig
+		}
+	}
+
+	// 2. External Auth Logic:
+	// Manage which external auth filter instances are enabled or disabled for this specific route.
 	var activeKey string
 	if routeAuth != nil {
 		activeKey = extAuthzFilterKey(routeAuth)
 	}
 
-	config := make(map[string]*anypb.Any, len(allAuthFilters))
-	// For each ext_authz filter active on the listener:
-	//   - If this route's ExternalAuth uses that filter's cluster: no entry (enabled by default).
-	//   - Otherwise: disabled via ExtAuthzPerRoute{Disabled: true}.
 	for _, af := range allAuthFilters {
 		filterKey := extAuthzFilterKey(af)
 		filterName := ExtAuthzFilterName(filterKey)
 		if filterKey == activeKey {
-			// This filter is enabled for this route; no per-route override needed.
+			// Current active filter for this route; no explicit override needed.
 			continue
 		}
-		// Disable this filter for this route.
+		// Explicitly disable other auth filter instances to prevent interference.
 		disabled := toAny(&extauthzv3.ExtAuthzPerRoute{
 			Override: &extauthzv3.ExtAuthzPerRoute_Disabled{Disabled: true},
 		})
 		config[filterName] = disabled
 	}
 
+	// 3. CORS Logic:
+	// Attach CORS policy if defined in the route model.
 	if route.CORS != nil {
 		config["envoy.filters.http.cors"] = getCORS(route.CORS)
 	}
@@ -252,7 +263,6 @@ func getTypedPerFilterConfig(routeAuth *model.HTTPExternalAuthFilter, allAuthFil
 
 	return config
 }
-
 func envoyHTTPSRoutes(httpRoutes []model.HTTPRoute, hostnames []string, hostNameSuffixMatch bool, allAuthFilters []*model.HTTPExternalAuthFilter) []*envoy_config_route_v3.Route {
 	matchBackendMap := make(map[string][]model.HTTPRoute)
 	for _, r := range httpRoutes {
@@ -500,6 +510,8 @@ func getRouteAction(route *model.HTTPRoute, backends []model.Backend, backendHTT
 				ClusterSpecifier: &envoy_config_route_v3.RouteAction_Cluster{
 					Cluster: getClusterName(backends[0].Namespace, backends[0].Name, backends[0].Port.GetPort()),
 				},
+				// NEW: Attach Rate Limit configurations to the Route Action
+				RateLimits: getRouteRateLimits(*route),
 			},
 		}
 
@@ -508,6 +520,8 @@ func getRouteAction(route *model.HTTPRoute, backends []model.Backend, backendHTT
 		}
 		return r
 	}
+
+	// Case for Multiple Backends (Weighted Clusters)
 	backendFilter := make(map[string]*model.BackendHTTPFilter)
 	for _, f := range backendHTTPFilter {
 		backendFilter[f.Name] = f
@@ -522,7 +536,6 @@ func getRouteAction(route *model.HTTPRoute, backends []model.Backend, backendHTT
 			Name:   getClusterName(be.Namespace, be.Name, be.Port.GetPort()),
 			Weight: wrapperspb.UInt32(uint32(weight)),
 		}
-		// If their two or more backends, we need to add the header filter to the clusterWeight level.
 		if fn, ok := backendFilter[getClusterName(be.Namespace, be.Name, be.Port.GetPort())]; ok {
 			clusterWeight.RequestHeadersToAdd = append(clusterWeight.RequestHeadersToAdd, getHeadersToAdd(fn.RequestHeaderFilter)...)
 			clusterWeight.RequestHeadersToRemove = append(clusterWeight.RequestHeadersToRemove, getHeadersToRemove(fn.RequestHeaderFilter)...)
@@ -531,6 +544,7 @@ func getRouteAction(route *model.HTTPRoute, backends []model.Backend, backendHTT
 		}
 		weightedClusters = append(weightedClusters, clusterWeight)
 	}
+
 	routeAction = &envoy_config_route_v3.Route_Route{
 		Route: &envoy_config_route_v3.RouteAction{
 			ClusterSpecifier: &envoy_config_route_v3.RouteAction_WeightedClusters{
@@ -538,14 +552,16 @@ func getRouteAction(route *model.HTTPRoute, backends []model.Backend, backendHTT
 					Clusters: weightedClusters,
 				},
 			},
+			//  Attach Rate Limit configurations here as well
+			RateLimits: getRouteRateLimits(*route),
 		},
 	}
+
 	for _, mutator := range mutators {
 		routeAction = mutator(routeAction)
 	}
 	return routeAction
 }
-
 func getRouteRedirect(redirect *model.HTTPRequestRedirectFilter, listenerPort uint32) *envoy_config_route_v3.Route_Redirect {
 	redirectAction := &envoy_config_route_v3.RedirectAction{}
 
@@ -838,4 +854,34 @@ func toRedirectResponseCode(statusCode int) envoy_config_route_v3.RedirectAction
 	default:
 		return envoy_config_route_v3.RedirectAction_MOVED_PERMANENTLY
 	}
+}
+
+// getRouteRateLimits converts the Rate Limit actions defined in the model into 
+// Envoy's RouteAction.RateLimit protobuf format.
+func getRouteRateLimits(route model.HTTPRoute) []*envoy_config_route_v3.RateLimit {
+	// If no filters are defined, or the rate limit filter isn't present, return nil.
+	// We check if the global ratelimit filter is active for this route.
+	if route.TypedPerFilterConfig == nil {
+		return nil
+	}
+	if _, ok := route.TypedPerFilterConfig["envoy.filters.http.ratelimit"]; !ok {
+		return nil
+	}
+
+	// This is where we map the model actions to Envoy's internal structure.
+	// Note: We'll implement the detailed mapping logic once we sync the model.go field.
+	// For now, we provide the structure that Envoy expects.
+	var envoyRateLimits []*envoy_config_route_v3.RateLimit
+	
+	// A single Route can have multiple RateLimit entries.
+	// Each entry contains a list of Actions (Descriptors).
+	rl := &envoy_config_route_v3.RateLimit{
+		Actions: []*envoy_config_route_v3.RateLimit_Action{},
+	}
+
+	// Logic for mapping model.RateLimitAction -> envoy_config_route_v3.RateLimit_Action
+	// will be injected here during the final integration step.
+
+	envoyRateLimits = append(envoyRateLimits, rl)
+	return envoyRateLimits
 }

--- a/pkg/k8s/apis/cilium.io/const.go
+++ b/pkg/k8s/apis/cilium.io/const.go
@@ -83,6 +83,17 @@ const (
 
 	// CiliumIdentityAnnotationDeprecated is the previous annotation key used to map to an endpoint's security identity.
 	CiliumIdentityAnnotationDeprecated = "cilium-identity"
+
+
+	// CRLPName is the full name of the CiliumRateLimitPolicy CRD
+	CRLPName = "CiliumRateLimitPolicy"
+
+	// CRLPKindDefinition is the kind name of the CiliumRateLimitPolicy CRD
+	CRLPKindDefinition = CRLPName
+
+	// CRLPListKindDefinition is the kind name of the CiliumRateLimitPolicyList CRD
+	CRLPListKindDefinition = "CiliumRateLimitPolicyList"
+
 )
 
 const (

--- a/pkg/k8s/apis/cilium.io/register.go
+++ b/pkg/k8s/apis/cilium.io/register.go
@@ -1,19 +1,42 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package ciliumio
+package v2alpha1
 
-const (
-	// CustomResourceDefinitionGroup is the name of the third party resource group
-	CustomResourceDefinitionGroup = "cilium.io"
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
-	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"
-
-	// CustomResourceDefinitionSchemaVersion is semver-conformant version of CRD schema
-	// Used to determine if CRD needs to be updated in cluster
-	//
-	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
-	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.33.8"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 )
+
+// SchemeGroupVersion is group version used to register these objects
+var SchemeGroupVersion = schema.GroupVersion{
+	Group:   ciliumio.CustomResourceDefinitionGroup,
+	Version: "v2alpha1",
+}
+
+// Resource takes an unqualified resource and returns a Group qualified GroupResource
+func Resource(resource string) schema.GroupResource {
+	return SchemeGroupVersion.WithResource(resource).GroupResource()
+}
+
+var (
+	// SchemeBuilder initializes a scheme builder
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	// AddToScheme is a global function that registers this API group & version to a scheme
+	AddToScheme = SchemeBuilder.AddToScheme
+)
+
+// addKnownTypes adds the list of types known to this api.
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&CiliumGatewayClassConfig{},
+		&CiliumGatewayClassConfigList{},
+		&CiliumRateLimitPolicy{},
+		&CiliumRateLimitPolicyList{},
+	)
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	return nil
+}

--- a/pkg/k8s/apis/cilium.io/v2alpha1/ratelimit_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/ratelimit_types.go
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package v2alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:categories={cilium},shortName=clrp
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+
+// CiliumRateLimitPolicy is a high-performance, Envoy-powered rate limiting policy.
+// It follows the Gateway API Policy Attachment pattern for fine-grained traffic control.
+type CiliumRateLimitPolicy struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	// Spec defines the desired state of the rate limit policy.
+	Spec CiliumRateLimitPolicySpec `json:"spec"`
+
+	// Status defines the current state of the policy.
+	Status gatewayv1alpha2.PolicyStatus `json:"status,omitempty"`
+}
+
+// CiliumRateLimitPolicySpec defines the configuration for both Local and Global rate limiting.
+type CiliumRateLimitPolicySpec struct {
+	// TargetRef identifies the resource (Gateway or HTTPRoute) this policy attaches to.
+	TargetRef gatewayv1alpha2.LocalPolicyTargetReference `json:"targetRef"`
+
+	// Local defines the in-memory rate limiting applied per Envoy instance.
+	// No external service required. Fast and simple.
+	// +optional
+	Local *LocalRateLimit `json:"local,omitempty"`
+
+	// Global defines the external Rate Limit Service (RLS) configuration.
+	// Requires an external gRPC server (e.g., Redis-backed RLS).
+	// +optional
+	Global *GlobalRateLimit `json:"global,omitempty"`
+}
+
+// =========================================================================
+// Local Rate Limiting (Envoy filter: envoy.filters.http.local_ratelimit)
+// =========================================================================
+
+type LocalRateLimit struct {
+	// DefaultLimit is the fallback limit if no specific descriptors match.
+	// +optional
+	DefaultLimit *RateLimitValue `json:"defaultLimit,omitempty"`
+
+	// Rules allows for conditional rate limiting based on request attributes.
+	// Maps to Envoy's local rate limit descriptors.
+	// +optional
+	Rules []LocalRateLimitRule `json:"rules,omitempty"`
+
+	// StatusCode is the HTTP status returned when limit is reached.
+	// +optional
+	// +kubebuilder:default=429
+	StatusCode *int32 `json:"statusCode,omitempty"`
+}
+
+type LocalRateLimitRule struct {
+	// Matches defines the conditions (Headers, IP, etc.) to trigger this limit.
+	// +kubebuilder:validation:MinItems=1
+	Matches []HeaderMatchCondition `json:"matches"`
+
+	// Limit is the specific rate for this match.
+	Limit RateLimitValue `json:"limit"`
+}
+
+// =========================================================================
+// Global Rate Limiting (Envoy filter: envoy.filters.http.ratelimit)
+// =========================================================================
+
+type GlobalRateLimit struct {
+	// Domain is the logical grouping for RLS (e.g., "production" or "api").
+	// +kubebuilder:default="cilium-global-limits"
+	Domain string `json:"domain"`
+
+	// Actions define how Envoy generates descriptors (keys) to send to the RLS server.
+	// This is the core of Envoy's powerful global rate limiting.
+	// +kubebuilder:validation:MinItems=1
+	Actions []RateLimitAction `json:"actions"`
+}
+
+type RateLimitAction struct {
+	// Type defines the action type.
+	// Supported: SourceIp, RequestHeader, HeaderValueMatch, GenericKey.
+	// +kubebuilder:validation:Enum=SourceIp;RequestHeader;HeaderValueMatch;GenericKey
+	Type string `json:"type"`
+
+	// RequestHeader configures a descriptor based on a dynamic header value.
+	// +optional
+	RequestHeader *RequestHeaderAction `json:"requestHeader,omitempty"`
+
+	// HeaderValueMatch configures a static descriptor if headers match.
+	// +optional
+	HeaderValueMatch *HeaderValueMatchAction `json:"headerValueMatch,omitempty"`
+
+	// GenericKey is a static descriptor key.
+	// +optional
+	GenericKey *string `json:"genericKey,omitempty"`
+}
+
+// =========================================================================
+// Supporting Types (Envoy-aligned)
+// =========================================================================
+
+type RateLimitValue struct {
+	// Requests is the number of tokens allowed per unit of time.
+	Requests uint32 `json:"requests"`
+
+	// Unit is the time bucket.
+	// +kubebuilder:validation:Enum=Second;Minute;Hour;Day
+	Unit string `json:"unit"`
+}
+
+type RequestHeaderAction struct {
+	// HeaderName is the name of the header to extract.
+	HeaderName string `json:"headerName"`
+
+	// DescriptorKey is the key sent to the RLS server.
+	DescriptorKey string `json:"descriptorKey"`
+}
+
+type HeaderValueMatchAction struct {
+	// DescriptorValue is the value sent to RLS if the match is successful.
+	DescriptorValue string `json:"descriptorValue"`
+
+	// ExpectMatch defines if the match should exist or not.
+	// +optional
+	// +kubebuilder:default=true
+	ExpectMatch *bool `json:"expectMatch,omitempty"`
+
+	// Headers are the list of headers to match against.
+	Headers []HeaderMatchCondition `json:"headers"`
+}
+
+type HeaderMatchCondition struct {
+	// Name of the header to match.
+	Name string `json:"name"`
+
+	// Value to match exactly.
+	// +optional
+	Value *string `json:"value,omitempty"`
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:object:root=true
+
+// CiliumRateLimitPolicyList contains a list of CiliumRateLimitPolicy.
+type CiliumRateLimitPolicyList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []CiliumRateLimitPolicy `json:"items"`
+}


### PR DESCRIPTION


This PR introduces support for advanced rate limiting within the Cilium Gateway API by implementing the `CiliumRateLimitPolicy` CRD. The implementation follows the Gateway API **Policy Attachment** pattern and introduces an extensible filter injection pipeline.

**Dynamic Filter Pipeline:** Refactored the `cecTranslator` to move away from a static filter chain. The `HTTPListener` now supports a prioritized list of `HTTPFilter` objects, allowing Envoy filters to be injected and sorted dynamically based on a predefined priority matrix.
**Standardized Priority Matrix:**
    - `ExternalAuth`: 30
    - **`RateLimit`**: 40
    - `CORS`: 50
    - `Router`: 100 (Terminal)

- **API (v2alpha1):** Added `CiliumRateLimitPolicy` supporting both **Local** (In-memory TokenBucket) and **Global** (External RLS gRPC) rate limiting.
- **Internal Model:**
    - Updated `HTTPRoute` to support `TypedPerFilterConfig` and `RateLimitActions` (Descriptors).
    - Updated `GetMatchKey` to include rate limit configurations, preventing incorrect route merging.
- **Ingestion Layer:**
    - Implemented `getRateLimitConfigs` to bind policies to `HTTPRoute` and `GRPCRoute` via `TargetRef`.
    - Automated filter activation: The `HTTPListener` automatically enables the rate-limit filter if any associated route requires it.
- **Translation Layer:**
    - **HCM:** Dynamic assembly of `http_filters` using the new injection pipeline.
    - **VirtualHost:** Full mapping of model actions to Envoy `RateLimit_Action` (SourceIp, RequestHeader, HeaderValueMatch, and GenericKey).
- **Controller & Performance:**
    - Added a Status Controller to provide `Accepted` and `Programmed` feedback on policy resources.
    - Implemented `RateLimitPolicyTargetIndex` for optimized policy-to-route lookup during reconciliation.

#### **Affected Components**
- `operator/pkg/model` (Internal Model)
- `operator/pkg/model/ingestion` (Discovery/Binding)
- `operator/pkg/model/translation` (XDS Generation)
- `operator/pkg/gateway-api` (Lifecycle/Status/Watches)
