### PR TITLE
[v1.18] loadbalancer: return correct IP family for IPv6 ClusterIP addresses

### DIFF
--- a/pkg/loadbalancer/reflectors/conversions.go
+++ b/pkg/loadbalancer/reflectors/conversions.go
@@ -384,7 +384,7 @@ func getIPFamilies(svc *slim_corev1.Service) []slim_corev1.IPFamily {
 			families = append(families, slim_corev1.IPv4Protocol)
 		}
 		if ipv6 {
-			families = append(families, slim_corev1.IPv4Protocol)
+			families = append(families, slim_corev1.IPv6Protocol)
 		}
 		return families
 	}


### PR DESCRIPTION
Manual backport of upstream commit c22a102bc0e83bbb1e149b7576848b8438e3a002 from PR https://github.com/cilium/cilium/pull/46356 as [suggested](https://github.com/cilium/cilium/pull/46356#pullrequestreview-4456387025) by @julianwiedmann.

Currently, `getIPFamilies` would mistakenly return `slim_corev1.IPv4Protocol` for IPv6. Fix it to return `slim_corev1.IPv6Protocol` instead.