### PR TITLE
datapath: hide device table indexes behind query helpers

### DIFF
--- a/pkg/bgp/manager/reconciler/default_gateway.go
+++ b/pkg/bgp/manager/reconciler/default_gateway.go
@@ -168,7 +168,7 @@ func (r *DefaultGatewayReconciler) getDefaultGateway(defaultGateway *v2.DefaultG
 		if !route.Gw.IsValid() || route.Dst != defaultRoute {
 			continue
 		}
-		dev, _, found := r.deviceTable.Get(txn, tables.DeviceIDIndex.Query(route.LinkIndex))
+		dev, _, found := r.deviceTable.Get(txn, tables.DeviceByIndex(route.LinkIndex))
 		// ignore routes if the link through which it is reachable is not up
 		if !found || dev.OperStatus != "up" {
 			continue

--- a/pkg/bgp/manager/reconciler/interface.go
+++ b/pkg/bgp/manager/reconciler/interface.go
@@ -180,7 +180,7 @@ func (r *InterfaceReconciler) getInterfacePrefixes(advert v2.BGPAdvertisement, f
 	if advert.Interface == nil {
 		return nil
 	}
-	dev, _, found := r.deviceTable.Get(txn, tables.DeviceNameIndex.Query(advert.Interface.Name))
+	dev, _, found := r.deviceTable.Get(txn, tables.DeviceByName(advert.Interface.Name))
 	if !found {
 		return nil
 	}

--- a/pkg/bgp/manager/reconciler/neighbor.go
+++ b/pkg/bgp/manager/reconciler/neighbor.go
@@ -380,7 +380,7 @@ func (r *NeighborReconciler) getInterfaceLocalAddress(interfaceName, peerAddress
 		logfields.Interface, interfaceName,
 		types.PeerLogField, peerAddress,
 	)
-	dev, _, deviceFound := r.DeviceTable.Get(r.DB.ReadTxn(), tables.DeviceNameIndex.Query(interfaceName))
+	dev, _, deviceFound := r.DeviceTable.Get(r.DB.ReadTxn(), tables.DeviceByName(interfaceName))
 	if !deviceFound {
 		log.Warn("Interface not found, can not use it as the source interface for the peer.")
 		return "", false, nil

--- a/pkg/datapath/gneigh/processor_test.go
+++ b/pkg/datapath/gneigh/processor_test.go
@@ -243,7 +243,7 @@ func TestProcessorDynamicUpdates(t *testing.T) {
 	proc.EndpointDeleted(ep1, endpoint.DeleteConfig{})
 
 	tx := db.WriteTxn(devices)
-	obj, _, found := devices.Get(tx, tables.DeviceIDIndex.Query(5))
+	obj, _, found := devices.Get(tx, tables.DeviceByIndex(5))
 	require.True(t, found)
 	devices.Delete(tx, obj)
 	tx.Commit()

--- a/pkg/datapath/linux/device/scripttest/device_test.go
+++ b/pkg/datapath/linux/device/scripttest/device_test.go
@@ -154,7 +154,7 @@ func testDesiredDevicesCmds(db *statedb.DB, dm linuxdevice.ManagerOperations, de
 				return nil, fmt.Errorf("failed to unmarshal device file %q: %w", args[1], err)
 			}
 
-			dev, _, found := devTbl.Get(db.ReadTxn(), tables.DeviceNameIndex.Query(device.ParentName))
+			dev, _, found := devTbl.Get(db.ReadTxn(), tables.DeviceByName(device.ParentName))
 			if !found {
 				return nil, fmt.Errorf("parent device %q not found for VLAN device %q", device.ParentName, device.Name)
 			}

--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -434,7 +434,7 @@ func populateFromLink(d *tables.Device, link netlink.Link) {
 func (dc *devicesController) processBatch(txn statedb.WriteTxn, batch map[int][]any) {
 	before := dc.deviceNameSet(txn)
 	for index, updates := range batch {
-		d, _, _ := dc.params.DeviceTable.Get(txn, tables.DeviceIDIndex.Query(index))
+		d, _, _ := dc.params.DeviceTable.Get(txn, tables.DeviceByIndex(index))
 		if d == nil {
 			// Unseen device. We may receive address updates before link updates
 			// and thus the only thing we know at this point is the index.
@@ -666,7 +666,7 @@ func (dc *devicesController) isSelectedDevice(d *tables.Device, txn statedb.Writ
 
 	// Ignore bridge and bonding children devices, but allow VRF device children.
 	if d.MasterIndex != 0 {
-		masterDevice, _, ok := dc.params.DeviceTable.Get(txn, tables.DeviceIDIndex.Query(d.MasterIndex))
+		masterDevice, _, ok := dc.params.DeviceTable.Get(txn, tables.DeviceByIndex(d.MasterIndex))
 		if !ok {
 			return false, fmt.Sprintf("device has parent but parent device could not be found: %d", d.MasterIndex)
 		}

--- a/pkg/datapath/linux/route/reconciler/reconciler.go
+++ b/pkg/datapath/linux/route/reconciler/reconciler.go
@@ -192,7 +192,7 @@ func (ops *ops) Update(_ context.Context, rxn statedb.ReadTxn, _ statedb.Revisio
 
 	if obj.Device != nil {
 		// Verify that the device still exists.
-		_, _, found := ops.devices.Get(rxn, tables.DeviceIDIndex.Query(obj.Device.Index))
+		_, _, found := ops.devices.Get(rxn, tables.DeviceByIndex(obj.Device.Index))
 		if !found {
 			return errDeviceNotFound
 		}

--- a/pkg/datapath/linux/route/reconciler/scripttest/reconciler_test.go
+++ b/pkg/datapath/linux/route/reconciler/scripttest/reconciler_test.go
@@ -169,9 +169,9 @@ func testDesiredRouteCmds(db *statedb.DB, drm *reconciler.DesiredRouteManager, d
 			if route.Device != "" || route.DeviceIfIndex != 0 {
 				var q statedb.Query[*tables.Device]
 				if route.Device != "" {
-					q = tables.DeviceNameIndex.Query(route.Device)
+					q = tables.DeviceByName(route.Device)
 				} else if route.DeviceIfIndex != 0 {
-					q = tables.DeviceIDIndex.Query(route.DeviceIfIndex)
+					q = tables.DeviceByIndex(route.DeviceIfIndex)
 				}
 
 				var found bool
@@ -190,7 +190,7 @@ func testDesiredRouteCmds(db *statedb.DB, drm *reconciler.DesiredRouteManager, d
 				var dev *tables.Device
 				if p.Device != "" {
 					var found bool
-					dev, _, found = devTbl.Get(db.ReadTxn(), tables.DeviceNameIndex.Query(p.Device))
+					dev, _, found = devTbl.Get(db.ReadTxn(), tables.DeviceByName(p.Device))
 					if !found {
 						return nil, fmt.Errorf("device %q not found", p.Device)
 					}

--- a/pkg/datapath/loader/endpoint.go
+++ b/pkg/datapath/loader/endpoint.go
@@ -315,7 +315,7 @@ func upsertEndpointRoute(db *statedb.DB, devices statedb.Table[*tables.Device], 
 	for {
 		var found bool
 		var watch <-chan struct{}
-		epDev, _, watch, found = devices.GetWatch(db.ReadTxn(), tables.DeviceIDIndex.Query(ep.GetIfIndex()))
+		epDev, _, watch, found = devices.GetWatch(db.ReadTxn(), tables.DeviceByIndex(ep.GetIfIndex()))
 		if found {
 			break
 		}

--- a/pkg/datapath/neighbor/desired_neighbor_calculator.go
+++ b/pkg/datapath/neighbor/desired_neighbor_calculator.go
@@ -309,7 +309,7 @@ func (c *desiredNeighborCalculator) getNextHopIP(fip netip.Addr, ifindex int) (n
 }
 
 func l2Devices(tbl statedb.Table[*tables.Device], rx statedb.ReadTxn) ([]*tables.Device, <-chan struct{}) {
-	devIter, watch := tbl.ListWatch(rx, tables.DeviceSelectedIndex.Query(true))
+	devIter, watch := tbl.ListWatch(rx, tables.DevicesBySelected(true))
 
 	return slices.Collect(func(yield func(*tables.Device) bool) {
 		for dev := range devIter {

--- a/pkg/datapath/orchestrator/localnodeconfig.go
+++ b/pkg/datapath/orchestrator/localnodeconfig.go
@@ -136,7 +136,7 @@ func newLocalNodeConfig(
 
 	hostEndpointID, _ := node.GetEndpointID()
 
-	ciliumHostDevice, _, hostWatch, ok := devices.GetWatch(txn, tables.DeviceNameIndex.Query(defaults.HostDevice))
+	ciliumHostDevice, _, hostWatch, ok := devices.GetWatch(txn, tables.DeviceByName(defaults.HostDevice))
 	if !ok {
 		return config.Config{}, hostWatch, fmt.Errorf("failed to look up link '%s'", defaults.HostDevice)
 	}
@@ -146,7 +146,7 @@ func newLocalNodeConfig(
 		return config.Config{}, nil, fmt.Errorf("failed to parse hardware address of '%s': %w", defaults.HostDevice, err)
 	}
 
-	ciliumNetDevice, _, netWatch, ok := devices.GetWatch(txn, tables.DeviceNameIndex.Query(defaults.SecondHostDevice))
+	ciliumNetDevice, _, netWatch, ok := devices.GetWatch(txn, tables.DeviceByName(defaults.SecondHostDevice))
 	if !ok {
 		return config.Config{}, netWatch, fmt.Errorf("failed to look up link '%s'", defaults.SecondHostDevice)
 	}

--- a/pkg/datapath/orchestrator/orchestrator.go
+++ b/pkg/datapath/orchestrator/orchestrator.go
@@ -291,8 +291,8 @@ func (o *orchestrator) waitForHostDevices(ctx context.Context, health cell.Healt
 	health.OK("Waiting for host devices")
 	for {
 		rxt := o.params.DB.ReadTxn()
-		_, _, hostWatch, hostOK := o.params.Devices.GetWatch(rxt, tables.DeviceNameIndex.Query(defaults.HostDevice))
-		_, _, netWatch, netOK := o.params.Devices.GetWatch(rxt, tables.DeviceNameIndex.Query(defaults.SecondHostDevice))
+		_, _, hostWatch, hostOK := o.params.Devices.GetWatch(rxt, tables.DeviceByName(defaults.HostDevice))
+		_, _, netWatch, netOK := o.params.Devices.GetWatch(rxt, tables.DeviceByName(defaults.SecondHostDevice))
 		if hostOK && netOK {
 			return nil
 		}

--- a/pkg/datapath/tables/device.go
+++ b/pkg/datapath/tables/device.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	DeviceIDIndex = statedb.Index[*Device, int]{
+	deviceIndexIndex = statedb.Index[*Device, int]{
 		Name: "id",
 		FromObject: func(d *Device) index.KeySet {
 			return index.NewKeySet(index.Int(d.Index))
@@ -26,7 +26,7 @@ var (
 		Unique:     true,
 	}
 
-	DeviceNameIndex = statedb.Index[*Device, string]{
+	deviceNameIndex = statedb.Index[*Device, string]{
 		Name: "name",
 		FromObject: func(d *Device) index.KeySet {
 			keys := make([]index.Key, 0, 1+len(d.AltNames))
@@ -40,7 +40,7 @@ var (
 		FromString: index.FromString,
 	}
 
-	DeviceSelectedIndex = statedb.Index[*Device, bool]{
+	deviceSelectedIndex = statedb.Index[*Device, bool]{
 		Name: "selected",
 		FromObject: func(d *Device) index.KeySet {
 			return index.NewKeySet(index.Bool(d.Selected))
@@ -48,15 +48,24 @@ var (
 		FromKey:    index.Bool,
 		FromString: index.BoolString,
 	}
+
+	// DeviceByIndex queries the devices table by device index.
+	DeviceByIndex = deviceIndexIndex.Query
+
+	// DeviceByName queries the devices table by device name.
+	DeviceByName = deviceNameIndex.Query
+
+	// DevicesBySelected queries the selected devices from devices table.
+	DevicesBySelected = deviceSelectedIndex.Query
 )
 
 func NewDeviceTable(db *statedb.DB) (statedb.RWTable[*Device], error) {
 	return statedb.NewTable(
 		db,
 		"devices",
-		DeviceIDIndex,
-		DeviceNameIndex,
-		DeviceSelectedIndex,
+		deviceIndexIndex,
+		deviceNameIndex,
+		deviceSelectedIndex,
 	)
 }
 
@@ -185,7 +194,7 @@ func (d *DeviceAddress) DeepEqual(other *DeviceAddress) bool {
 // The invalidated channel is closed when devices have changed and
 // should be requeried with a new transaction.
 func SelectedDevices(tbl statedb.Table[*Device], txn statedb.ReadTxn) ([]*Device, <-chan struct{}) {
-	iter, invalidated := tbl.ListWatch(txn, DeviceSelectedIndex.Query(true))
+	iter, invalidated := tbl.ListWatch(txn, deviceSelectedIndex.Query(true))
 	return statedb.Collect(iter), invalidated
 }
 

--- a/pkg/datapath/tables/node_address.go
+++ b/pkg/datapath/tables/node_address.go
@@ -328,7 +328,7 @@ func (n *nodeAddressController) reconcile() *statedb.WatchSet {
 			continue
 		}
 
-		dev, _, found := n.Devices.Get(rtxn, DeviceIDIndex.Query(route.LinkIndex))
+		dev, _, found := n.Devices.Get(rtxn, DeviceByIndex(route.LinkIndex))
 		if !found {
 			continue
 		}

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -218,7 +218,7 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(manager *Manager, gc *po
 		// interface as egress IPs
 		gwc.ifaceName = gc.iface
 
-		dev, _, found := manager.deviceTable.Get(manager.db.ReadTxn(), tables.DeviceNameIndex.Query(gc.iface))
+		dev, _, found := manager.deviceTable.Get(manager.db.ReadTxn(), tables.DeviceByName(gc.iface))
 		if found {
 			gwc.egressIfindex = uint32(dev.Index)
 

--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -49,8 +49,8 @@ func (p *Proxy) ReinstallRoutingRules(ctx context.Context, mtu int, ipsecEnabled
 	fromIngressProxy, fromEgressProxy, mtu := requireFromProxyRoutes(ipsecEnabled, wireguardEnabled, mtu)
 
 	rxn := p.db.ReadTxn()
-	hostDevice, _, hostDeviceFound := p.devices.Get(rxn, tables.DeviceNameIndex.Query(defaults.HostDevice))
-	lo, _, loFound := p.devices.Get(rxn, tables.DeviceNameIndex.Query("lo"))
+	hostDevice, _, hostDeviceFound := p.devices.Get(rxn, tables.DeviceByName(defaults.HostDevice))
+	lo, _, loFound := p.devices.Get(rxn, tables.DeviceByName("lo"))
 
 	if option.Config.EnableIPv4 && p.enabled {
 		if !loFound {


### PR DESCRIPTION
Callers of the devices table only need to construct queries. They shouldn't depend on the `statedb.Index` values used to define the table. Hence, export `DeviceBy*` helpers and keep the actual index definitions private to reduce the package API surface and to keep the index values internal, while preserving the existing lookup behavior.