### PR TITLE
gateway-api: set `retry_on` so HTTPRoute retries actually take effect

### DIFF
--- a/operator/pkg/model/translation/envoy_virtual_host.go
+++ b/operator/pkg/model/translation/envoy_virtual_host.go
@@ -434,6 +434,15 @@ func requestMirrorMutation(mirrors []*model.HTTPRequestMirror) routeActionMutati
 	}
 }
 
+// defaultRetryOn is the Envoy retry_on policy applied whenever an HTTPRoute
+// retry stanza is configured. "retriable-status-codes" is required for the
+// route's RetriableStatusCodes to take effect (Envoy ignores them otherwise,
+// and an empty retry_on disables retries entirely). connect-failure, reset and
+// refused-stream cover connection errors, which GEP-1731 recommends retrying
+// when a retry stanza is set. Note that, like any Envoy retry policy, this
+// applies to all HTTP methods, including non-idempotent ones.
+const defaultRetryOn = "retriable-status-codes,connect-failure,reset,refused-stream"
+
 func retryMutation(retry *model.HTTPRetry) routeActionMutation {
 	return func(route *envoy_config_route_v3.Route_Route) *envoy_config_route_v3.Route_Route {
 		if retry == nil {
@@ -441,6 +450,7 @@ func retryMutation(retry *model.HTTPRetry) routeActionMutation {
 		}
 
 		rp := &envoy_config_route_v3.RetryPolicy{
+			RetryOn:              defaultRetryOn,
 			RetriableStatusCodes: retry.Codes,
 		}
 

--- a/operator/pkg/model/translation/envoy_virtual_host_test.go
+++ b/operator/pkg/model/translation/envoy_virtual_host_test.go
@@ -641,6 +641,7 @@ func Test_retryMutation(t *testing.T) {
 		}
 
 		res := retryMutation(retry)(route)
+		require.Equal(t, "retriable-status-codes,connect-failure,reset,refused-stream", res.Route.RetryPolicy.RetryOn)
 		require.Equal(t, []uint32{500, 503}, res.Route.RetryPolicy.RetriableStatusCodes)
 		require.Empty(t, res.Route.RetryPolicy.RetryBackOff)
 		require.Equal(t, uint32(3), res.Route.RetryPolicy.NumRetries.Value)
@@ -657,11 +658,44 @@ func Test_retryMutation(t *testing.T) {
 		}
 
 		res := retryMutation(retry)(route)
+		require.Equal(t, "retriable-status-codes,connect-failure,reset,refused-stream", res.Route.RetryPolicy.RetryOn)
 		require.Equal(t, []uint32{500, 503}, res.Route.RetryPolicy.RetriableStatusCodes)
 		require.Equal(t, uint32(3), res.Route.RetryPolicy.NumRetries.Value)
 		require.NotEmpty(t, res.Route.RetryPolicy.RetryBackOff)
 		require.Equal(t, int64(10), res.Route.RetryPolicy.RetryBackOff.BaseInterval.Seconds)
 		require.Equal(t, int64(20), res.Route.RetryPolicy.RetryBackOff.MaxInterval.Seconds)
+	})
+
+	t.Run("with retry without codes still retries on connection errors", func(t *testing.T) {
+		route := &envoy_config_route_v3.Route_Route{
+			Route: &envoy_config_route_v3.RouteAction{},
+		}
+		retry := &model.HTTPRetry{
+			Attempts: ptr.To(3),
+		}
+
+		res := retryMutation(retry)(route)
+		// Per GEP-1731, a configured retry stanza should retry connection errors
+		// even when no status codes are specified.
+		require.Equal(t, "retriable-status-codes,connect-failure,reset,refused-stream", res.Route.RetryPolicy.RetryOn)
+		require.Empty(t, res.Route.RetryPolicy.RetriableStatusCodes)
+		require.Equal(t, uint32(3), res.Route.RetryPolicy.NumRetries.Value)
+	})
+
+	t.Run("with retry without attempts leaves num_retries unset", func(t *testing.T) {
+		route := &envoy_config_route_v3.Route_Route{
+			Route: &envoy_config_route_v3.RouteAction{},
+		}
+		retry := &model.HTTPRetry{
+			Codes: []uint32{503},
+		}
+
+		res := retryMutation(retry)(route)
+		require.Equal(t, "retriable-status-codes,connect-failure,reset,refused-stream", res.Route.RetryPolicy.RetryOn)
+		require.Equal(t, []uint32{503}, res.Route.RetryPolicy.RetriableStatusCodes)
+		// Attempts unset -> NumRetries stays nil in the generated config; Envoy
+		// applies its own default of 1 at runtime.
+		require.Nil(t, res.Route.RetryPolicy.NumRetries)
 	})
 }
 


### PR DESCRIPTION
## Description

`retryMutation` produced an Envoy `RetryPolicy` without `retry_on`, which leaves HTTPRoute `retry` configuration inert:

- Envoy only honors `retriable_status_codes` when `retry_on` contains `retriable-status-codes`.
- With an empty `retry_on`, Envoy creates no retry state at all, so `numRetries`/`retriableStatusCodes`/`retryBackOff` have no effect.

This PR sets `RetryOn` to `retriable-status-codes,connect-failure,reset,refused-stream` whenever a retry stanza is configured, which:

1. Makes the `retry.codes` from the `HTTPRoute` actually take effect, and
2. Aligns with [GEP-1731](https://gateway-api.sigs.k8s.io/geps/gep-1731/)'s recommendation that *"implementations SHOULD retry on connection errors (disconnect, reset, timeout, TCP failure) if a retry stanza is configured."*

`Test_retryMutation` is updated to assert `RetryOn`, plus cases for a retry stanza with no `codes` (connection-error retries only) and with no `attempts` (num_retries left to Envoy's default).

**Notes / scope:**
- Like any Envoy retry policy, these retries apply to **all HTTP methods**, including non-idempotent ones (POST/PATCH) — Envoy does not add a method guard for a configured `retry_on`. This is opt-in via the HTTPRoute `retry` stanza.
- Per-try (BackendRequest) timeout retries are **out of scope**: `PerTryTimeout` is not set, so route-timeout exhaustion alone does not trigger a retry.

Fixes: #46432

```release-note
gateway-api: Fix HTTPRoute retry rules so that configured status-code and connection-error retries are actually applied.
```
