### PR TITLE
Move DNS request checking prior to qname extraction

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -896,11 +896,9 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	stat := ProxyRequestContext{DataSource: accesslog.DNSSourceProxy}
 	stat.TotalTime.Start()
 	requestID := request.Id // save the original request ID
-	qname := string(request.Question[0].Name)
 	protocol := w.LocalAddr().Network()
 	epIPPort := w.RemoteAddr().String()
 	scopedLog := p.logger.With(
-		logfields.DNSName, qname,
 		logfields.IPAddr, epIPPort,
 		logfields.DNSRequestID, requestID,
 	)
@@ -928,6 +926,18 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	}
 	stat.ProcessingTime.Start()
 
+	requestDetails, err := ExtractRequestMsgDetails(request)
+	if err != nil {
+		scopedLog.Error("cannot extract DNS message details", logfields.Error, err)
+		stat.Err = fmt.Errorf("cannot extract DNS message details: %w", err)
+		stat.ProcessingTime.End(false)
+		stat.TotalTime.End(false)
+		p.sendErrorResponse(scopedLog, w, request, false)
+		return
+	}
+
+	qname := string(requestDetails.QName)
+	scopedLog = scopedLog.With(logfields.DNSName, qname)
 	scopedLog.Debug("Handling DNS query from endpoint")
 
 	addrPort, err := netip.ParseAddrPort(epIPPort)
@@ -955,15 +965,6 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		logfields.Identity, ep.GetIdentity(),
 	)
 
-	requestDetails, err := ExtractRequestMsgDetails(request)
-	if err != nil {
-		scopedLog.Error("cannot extract DNS message details", logfields.Error, err)
-		stat.Err = fmt.Errorf("cannot extract DNS message details: %w", err)
-		stat.ProcessingTime.End(false)
-		stat.TotalTime.End(false)
-		p.sendErrorResponse(scopedLog, w, request, false)
-		return
-	}
 	proto, targetServer, err := p.lookupTargetDNSServer(w)
 	if err != nil {
 		p.logger.Error("cannot extract destination IP:port from DNS request", logfields.Error, err)


### PR DESCRIPTION
Moves the attempt to access `Question[0]` after `ExtractRequestMsgDetails()` has had an opportunity to do validation and sanitization.