### PR TITLE
ci: Fix status check workflow

### DIFF
--- a/.github/workflows/wait-for-status-check.yaml
+++ b/.github/workflows/wait-for-status-check.yaml
@@ -74,6 +74,7 @@ jobs:
 
               if [[ -z "$run_status" ]]; then
                 echo "No status found for PR $pr_number"
+                all_successful=false
                 continue
               fi
 


### PR DESCRIPTION
This change fixes status check workflow. Currently if the status is not found, workflow returns success immediately, which is not the intended behaviour.