### PR TITLE
contrib: fix go test tag check exit status

### DIFF
--- a/contrib/scripts/check-go-test-tags.sh
+++ b/contrib/scripts/check-go-test-tags.sh
@@ -34,4 +34,4 @@ script=$(cat << 'EOF'
 EOF
 )
 
-find . -name "*_test.go" -exec awk -v allowed="^($allowed)$" "$script" {} \;
+find . -name "*_test.go" -exec awk -v allowed="^($allowed)$" "$script" {} +


### PR DESCRIPTION
The `check-go-test-tags.sh` script checks for forbidden tags in Go test files, but currently still exits successfully even if such a tag is found. The script uses `find -exec ... \;`, where a non-zero child exit status only makes the predicate false for that file and does not make `find` itself fail.

Use the grouped `find -exec ... {} +` form so a non-zero awk exit status is propagated through `find` and the script fails as intended if a forbidden tag is encountered.

Fixes: c43d531d1a24 ("contrib: reject tags in *_test.go files other than platform/race")

cc @ti-mo