### PR TITLE
kvstore: introduce circuit breaker to [kvstore.Client] start hook 

### DIFF
--- a/Makefile.kind
+++ b/Makefile.kind
@@ -454,13 +454,15 @@ kind-egressgw-install-cilium: check_deps kind-ready ## Install a local Cilium ve
 
 KVSTORE_POD_NAME ?= "kvstore"
 KVSTORE_POD_PORT ?= "2378"
+KVSTORE_SERVICE_NAME ?= $(KVSTORE_POD_NAME)
+KVSTORE_SERVICE_PORT ?= $(KVSTORE_POD_PORT)
 
 .PHONY: kind-kvstore-install-cilium
 kind-kvstore-install-cilium: check_deps kind-ready kind-kvstore-start ## Install a local Cilium version into the cluster, configured in kvstore mode.
 	$(MAKE) kind-install-cilium KIND_VALUES_FILES="\
 		$(KIND_VALUES_FILES) \
 		--set etcd.enabled=true \
-		--set etcd.endpoints[0]=http://$(shell kubectl --namespace kube-system get pod $(KVSTORE_POD_NAME) -o jsonpath='{.status.hostIP}'):$(KVSTORE_POD_PORT) \
+		--set etcd.endpoints[0]=http://$(KVSTORE_SERVICE_NAME).kube-system.svc:$(KVSTORE_SERVICE_PORT) \
 		--set identityAllocationMode=kvstore \
 	"
 
@@ -473,8 +475,13 @@ kind-kvstore-start: ## Start an etcd pod serving as Cilium's kvstore
 
 	kubectl --namespace kube-system wait --for=condition=Ready pod/$(KVSTORE_POD_NAME)
 
+	kubectl --namespace kube-system get service $(KVSTORE_SERVICE_NAME) >/dev/null 2>/dev/null || \
+		kubectl --namespace kube-system expose pod/$(KVSTORE_POD_NAME) --name $(KVSTORE_SERVICE_NAME) \
+			--port $(KVSTORE_SERVICE_PORT) --target-port $(KVSTORE_POD_PORT)
+
 .PHONY: kind-kvstore-stop
 kind-kvstore-stop: ## Stop the etcd pod serving as Cilium's kvstore
+	kubectl --namespace kube-system delete service $(KVSTORE_SERVICE_NAME) --ignore-not-found
 	kubectl --namespace kube-system delete pod $(KVSTORE_POD_NAME) --ignore-not-found
 	kubectl --namespace kube-system wait --for=delete pod/$(KVSTORE_POD_NAME)
 

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -144,7 +144,7 @@ var (
 
 		// Provides the Client to access the KVStore.
 		cell.Provide(kvstoreExtraOptions),
-		kvstore.Cell(kvstore.DisabledBackendName),
+		kvstore.Cell(kvstore.DisabledBackendName, kvstore.OptAsyncWaitForEstablished),
 		cell.Invoke(kvstoreLocksGC),
 
 		cni.Cell,

--- a/operator/api/health.go
+++ b/operator/api/health.go
@@ -65,12 +65,10 @@ func (h *healthHandler) Handle(params operator.GetHealthzParams) middleware.Resp
 	}
 
 	if err := h.checkStatus(); err != nil {
-		if h.consecutiveErrors.Add(1) <= 3 {
-			h.log.Info("Health check failed", logfields.Error, err)
-		} else {
-			h.log.Warn("Health check failed", logfields.Error, err)
-		}
-
+		h.log.Info("Health check failed",
+			logfields.Error, err,
+			logfields.Count, h.consecutiveErrors.Add(1),
+		)
 		return operator.NewGetHealthzInternalServerError().WithPayload(err.Error())
 	}
 

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -126,7 +126,7 @@ var (
 
 		// Provides the Client to access the KVStore.
 		cell.Provide(kvstoreExtraOptions),
-		kvstore.Cell(kvstore.DisabledBackendName),
+		kvstore.Cell(kvstore.DisabledBackendName, kvstore.OptAsyncWaitForEstablished),
 
 		// Provides the modular metrics registry, metric HTTP server and legacy metrics cell.
 		operatorMetrics.Cell,

--- a/pkg/kvstore/cell.go
+++ b/pkg/kvstore/cell.go
@@ -7,9 +7,11 @@ import (
 	"cmp"
 	"fmt"
 	"log/slog"
+	"slices"
 
 	"github.com/cilium/hive"
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
 	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/pkg/defaults"
@@ -21,8 +23,19 @@ import (
 // DisabledBackendName disables the kvstore client.
 const DisabledBackendName = ""
 
+type Option uint
+
+const (
+	// OptAsyncWaitForEstablished configures the kvstore cell with a circuit
+	// breaker to unblock the start hook if the connection cannot be established
+	// within a pre-determined timeout, in order to break possible chicken and
+	// egg dependencies. One example is represented by Cilium (or the etcd
+	// cluster itself) depending on a service to establish the connection.
+	OptAsyncWaitForEstablished Option = iota
+)
+
 // Cell returns a cell which provides the global kvstore client.
-func Cell(defaultBackend string) cell.Cell {
+func Cell(defaultBackend string, opts ...Option) cell.Cell {
 	return cell.Module(
 		"kvstore-client",
 		"KVStore Client",
@@ -39,6 +52,7 @@ func Cell(defaultBackend string) cell.Cell {
 
 			Logger    *slog.Logger
 			Lifecycle cell.Lifecycle
+			JobGroup  job.Group
 			Config    Config
 			Opts      ExtraOptions `optional:"true"`
 		},
@@ -54,6 +68,7 @@ func Cell(defaultBackend string) cell.Cell {
 			cl := &clientImpl{
 				enabled: true, cfg: in.Config, opts: in.Opts,
 				logger: in.Logger.With(logfields.BackendName, in.Config.KVStore),
+				jg:     in.JobGroup, asyncWait: slices.Contains(opts, OptAsyncWaitForEstablished),
 			}
 
 			in.Lifecycle.Append(cl)

--- a/pkg/kvstore/client.go
+++ b/pkg/kvstore/client.go
@@ -9,7 +9,11 @@ import (
 	"log/slog"
 
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
 	"github.com/cilium/hive/script"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // Client is the client to interact with the kvstore (i.e., etcd).
@@ -28,6 +32,9 @@ type clientImpl struct {
 	opts   ExtraOptions
 	logger *slog.Logger
 
+	jg        job.Group
+	asyncWait bool
+
 	BackendOperations
 }
 
@@ -36,11 +43,24 @@ func (cl *clientImpl) IsEnabled() bool {
 }
 
 func (cl *clientImpl) Start(hctx cell.HookContext) (err error) {
+	const timeout = 5 * time.Second
+
+	var (
+		circuitBreaker <-chan time.Time
+		timedOut       bool
+	)
+
+	if cl.asyncWait {
+		circuitBreaker = time.After(timeout)
+	}
+
 	cl.logger.Info("Establishing connection to kvstore")
 	client, errCh := NewClient(context.Background(), cl.logger, cl.cfg.KVStore, cl.cfg.KVStoreOpt, cl.opts)
 
 	select {
 	case err = <-errCh:
+	case <-circuitBreaker:
+		timedOut = true
 	case <-hctx.Done():
 		err = hctx.Err()
 	}
@@ -53,7 +73,32 @@ func (cl *clientImpl) Start(hctx cell.HookContext) (err error) {
 		return fmt.Errorf("failed to establish connection to kvstore: %w", err)
 	}
 
-	cl.logger.Info("Connection to kvstore successfully established")
+	if !timedOut {
+		cl.logger.Info("Connection to kvstore successfully established")
+	} else {
+		cl.logger.Info("Failed to establish connection to kvstore within timeout, continuing in background", logfields.Timeout, timeout)
+		cl.jg.Add(
+			job.OneShot(
+				"kvstore-wait-for-connection",
+				func(ctx context.Context, _ cell.Health) error {
+					select {
+					case err := <-errCh:
+						if err != nil {
+							return fmt.Errorf("failed to establish connection to kvstore: %w", err)
+						}
+
+						cl.logger.Info("Connection to kvstore successfully established")
+						return nil
+
+					case <-ctx.Done():
+						return nil
+					}
+				},
+				job.WithShutdown(),
+			),
+		)
+	}
+
 	cl.BackendOperations = client
 
 	return nil


### PR DESCRIPTION
Currently, the start hook of the [kvstore.Client] cell synchronously waits for the connection to the target kvstore to be established before returning. The main rationale is to ensure that all downstream consumers are guaranteed that the client has connected at least once when they start.

However, this constraint has also been shown to be the cause of possible chicken and egg dependencies, especially in case the etcd cluster is reachable through a service, or a service is leveraged by the etcd replicas to form the cluster. One such example is represented by #44527, in case kube-proxy is used, which got later fixed by #44653. However, the same problem also applies if KPR is used (#45844), in which case Cilium needs to be able to program the lb BPF maps, and attach the necessary BPF programs without depending on the connection to etcd. These setups used to work in Cilium v1.17 and earlier.

In order to restore the support for these setups, let's relax the start hook validation, and add a circuit breaker to eventually switch to waiting for the connection in background, and allow the rest of the Cilium initialization to continue in parallel, breaking the chicken-and-egg dependency. Still, neither the Cilium agents nor the operator are marked as ready until the connection has been actually established, correctly reporting possible problems. The main drawback of this change, though, is that subsystems that actually depend on the kvstore client may start too early in case of real issues, emitting spurious logs once the associated timeout hits. Yet, this is not expected to cause any functional problems. 

It is worth mentioning that this change does not restore in any ways the support for running etcd in pod network, but only allows exposing the etcd cluster through a Kubernetes service. Additionally, while the Cilium components internally perform DNS name to ClusterIP translation without relying on CoreDNS, the same does not apply for the etcd replicas themselves, and users are responsible for either running CoreDNS in host network, or directly configuring the service IPs.

The relaxed start hook validation is only enabled for Cilium agents and operator. The clustermesh-apiserver strictly depends on the etcd connection to be established, and the previous behavior is preserved there.

<!-- Description of change -->

Fixes: #45844

```release-note
Fix regression preventing Cilium from starting when configured in kvstore mode with KPR enabled, if etcd is behind a Kubernetes service
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
