### PR TITLE
helm: add tmpl files to .helmignore

### DIFF
--- a/install/kubernetes/cilium/.helmignore
+++ b/install/kubernetes/cilium/.helmignore
@@ -22,3 +22,5 @@
 .idea/
 *.tmproj
 .vscode/
+*.tmpl
+*.gotmpl


### PR DESCRIPTION
Adding `install/kubernetes/cilium/*.tmpl` to `.helmignore`