### PR TITLE
renovate: Update regex for Makefile.values ?= assignment

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1085,7 +1085,7 @@
       // similar to the examples shown here:
       //   https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>.*?)\\s+.+_REPO:=(?<depName>.*?)\\s+.+_VERSION:=(?<currentValue>.*)\\s+.+_DIGEST:=(?<currentDigest>sha256:[a-f0-9]+)"
+        "# renovate: datasource=(?<datasource>.*?)\\s+.+_REPO[:?]=(?<depName>.*?)\\s+.+_VERSION[:?]=(?<currentValue>.*)\\s+.+_DIGEST[:?]=(?<currentDigest>sha256:[a-f0-9]+)"
       ]
     },
     {


### PR DESCRIPTION
The below commit switched install/kubernetes/Makefile.values from := to ?= so external images can be overridden, but the renovate custom-manager regex still required :=. It matched nothing and Renovate stopped detecting cilium-envoy (and the other image deps), bumping only the Dockerfile. Accept both := and ?= so version+digest changes land in the same PR as the Dockerfile.

Relates: 30df0caf4a