### PR TITLE
ci: Remove merge_group from tests-smoke-conformance.yaml

### DIFF
--- a/.github/workflows/tests-smoke-conformance.yaml
+++ b/.github/workflows/tests-smoke-conformance.yaml
@@ -28,8 +28,6 @@ on:
     branches:
       - main
       - ft/main/**
-  merge_group:
-    types: [checks_requested]
 
 # By specifying the access of one of the scopes, all of those that are not
 # specified are set to 'none'.
@@ -103,7 +101,7 @@ jobs:
     env:
       job_name: "Conformance Smoke Test"
     needs: check_changes
-    if: ${{ needs.check_changes.outputs.tested == 'true' && github.event_name != 'merge_group' }}
+    if: ${{ needs.check_changes.outputs.tested == 'true' }}
     runs-on: ubuntu-24.04
     name: Installation and Conformance Test
     steps:


### PR DESCRIPTION
Since we moved conformance tests to a separate file, skipping the actual test job on merge_group check doesn't make sense anymore, let's just not trigger whole workflow on merge_group.