### PR TITLE
Revert "ci: use PR checks for status check"

### DIFF
--- a/.github/workflows/build-images-ci-v1.17.yaml
+++ b/.github/workflows/build-images-ci-v1.17.yaml
@@ -32,8 +32,8 @@ jobs:
       # This is to avoid waiting for base images on push to main or merge_group
       # events as the lint-images-base does not run on those events.
       if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
-      pr-number: ${{ github.event.pull_request.number }}
-      lint-names: 'Lint image build logic'
+      sha: ${{ github.event.pull_request.head.sha || github.sha }}
+      lint-workflows: "lint-images-base.yaml"
       timeout-minutes: 2
       poll-interval: 15
 

--- a/.github/workflows/build-images-ci-v1.18.yaml
+++ b/.github/workflows/build-images-ci-v1.18.yaml
@@ -32,8 +32,8 @@ jobs:
       # This is to avoid waiting for base images on push to main or merge_group
       # events as the lint-images-base does not run on those events.
       if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
-      pr-number: ${{ github.event.pull_request.number }}
-      lint-names: 'Lint image build logic'
+      sha: ${{ github.event.pull_request.head.sha || github.sha }}
+      lint-workflows: "lint-images-base.yaml"
       timeout-minutes: 2
       poll-interval: 15
 

--- a/.github/workflows/build-images-ci-v1.19.yaml
+++ b/.github/workflows/build-images-ci-v1.19.yaml
@@ -32,8 +32,8 @@ jobs:
       # This is to avoid waiting for base images on push to main or merge_group
       # events as the lint-images-base does not run on those events.
       if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
-      pr-number: ${{ github.event.pull_request.number }}
-      lint-names: 'Lint image build logic'
+      sha: ${{ github.event.pull_request.head.sha || github.sha }}
+      lint-workflows: "lint-images-base.yaml"
       timeout-minutes: 2
       poll-interval: 15
 

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -40,8 +40,8 @@ jobs:
       # This is to avoid waiting for base images on push to main or merge_group
       # events as the lint-images-base does not run on those events.
       if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
-      pr-number: ${{ github.event.pull_request.number }}
-      lint-names: 'Lint image build logic'
+      sha: ${{ github.event.pull_request.head.sha || github.sha }}
+      lint-workflows: "lint-images-base.yaml"
       timeout-minutes: 2
       poll-interval: 15
 

--- a/.github/workflows/wait-for-status-check.yaml
+++ b/.github/workflows/wait-for-status-check.yaml
@@ -7,6 +7,15 @@ on:
         description: "Condition to run the wait (true/false)"
         type: boolean
         default: true
+      sha:
+        description: "SHA to check for lint workflow completion"
+        required: true
+        type: string
+      lint-workflows:
+        description: "Comma-separated list of lint workflow filenames to wait for"
+        required: false
+        type: string
+        default: "lint-images-base.yaml"
       timeout-minutes:
         description: "Maximum time to wait for lint workflows (in minutes)"
         required: false
@@ -17,15 +26,6 @@ on:
         required: false
         type: number
         default: 30
-      lint-names:
-        description: "Comma-separated list of lint workflow filenames to wait for"
-        required: false
-        type: string
-        default: "Lint image build logic"
-      pr-number:
-        description: "PR number to check for lint workflow completion"
-        required: true
-        type: number
 
 permissions:
   actions: read
@@ -43,17 +43,17 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # Parse input parameters
-          lint_names_str="${{ inputs.lint-names }}"
+          check_sha="${{ inputs.sha }}"
+          lint_workflows_str="${{ inputs.lint-workflows }}"
           poll_interval="${{ inputs.poll-interval }}"
           timeout_minutes="${{ inputs.timeout-minutes }}"
-          pr_number="${{ inputs.pr-number }}"
 
-          echo "Waiting for lint workflows to complete for PR: $pr_number"
-          echo "Lint checks: $lint_names_str"
+          echo "Waiting for lint workflows to complete for SHA: $check_sha"
+          echo "Lint workflows to check: $lint_workflows_str"
           echo "Poll interval: ${poll_interval}s, Timeout: ${timeout_minutes}m"
 
           # Convert comma-separated workflows to array
-          IFS=',' read -ra lint_names <<< "$lint_names_str"
+          IFS=',' read -ra lint_workflows <<< "$lint_workflows_str"
 
           max_attempts=$((timeout_minutes * 60 / poll_interval))
           attempt=0
@@ -64,32 +64,35 @@ jobs:
 
             all_successful=true
 
-            for name in "${lint_names[@]}"; do
+            for workflow in "${lint_workflows[@]}"; do
               # Trim whitespace
-              name=$(echo "$name" | xargs)
-              echo "Checking status: $name"
+              workflow=$(echo "$workflow" | xargs)
+              echo "Checking workflow: $workflow"
 
-              # Use gh CLI to get the check status
-              check_status=$(gh pr checks --repo ${{ github.repository }} $pr_number --json name,state --jq ".[] | select( .name==\"$name\").state")
+              # Use gh CLI to get the latest run for this workflow and commit
+              run_status=$(gh --repo ${{ github.repository }} run list --workflow "$workflow" --commit "$check_sha" --limit 1 --json status,conclusion --jq '.[0] // empty')
 
               if [[ -z "$run_status" ]]; then
-                echo "No status found for PR $pr_number"
+                echo "No workflow run found for SHA $check_sha"
+                all_successful=false
                 continue
               fi
 
+              status=$(echo "$run_status" | jq -r '.status')
+              conclusion=$(echo "$run_status" | jq -r '.conclusion')
 
-              case "$check_status" in
-                "SUCCESS")
-                  echo "✅ Workflow completed successfully"
+              echo "Workflow status: $status, conclusion: $conclusion"
+
+              case "$status" in
+                "completed")
+                  if [[ "$conclusion" == "success" ]]; then
+                    echo "✅ Workflow completed successfully"
+                  else
+                    echo "❌ Lint workflow $workflow failed with conclusion: $conclusion"
+                    exit 1
+                  fi
                   ;;
-                "SKIPPED")
-                  echo "✅ Workflow marked as skipped"
-                  ;;
-                "FAILURE")
-                  echo "❌ Lint workflow $workflow failed with conclusion: $conclusion"
-                  all_successful=false
-                  ;;
-                "IN_PROGRESS"|"PENDING")
+                "in_progress"|"queued")
                   echo "⏳ Workflow is still running..."
                   all_successful=false
                   ;;


### PR DESCRIPTION
This reverts commit b3beca5d40f4195c3a2e91f3fe88b4e5ba13a967. The commit
broke a dependency for building container images in the merge_queue.

The `build-and-push-prs` job in the `build-images-ci.yaml` workflow was
never triggered in the merge queue, which causes all queued merges to time
out before the PR is merged into `main` (since building images is a required job).

Example symptom:
<img width="1160" height="125" alt="image" src="https://github.com/user-attachments/assets/53a1d103-f068-4186-aa1c-f6353fcbc4b9" />

Related: https://github.com/cilium/cilium/pull/46429
CC @nebril
