### PR TITLE
[v1.19] fix: Fix wildcard namespace bypass for selectorless ipBlock rules

### DIFF
--- a/pkg/k8s/network_policy.go
+++ b/pkg/k8s/network_policy.go
@@ -17,7 +17,6 @@ import (
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	k8sUtils "github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/types"
@@ -74,20 +73,24 @@ func isPodSelectorSelectingCluster(podSelector *slim_metav1.LabelSelector) bool 
 	return false
 }
 
-func parseNetworkPolicyPeer(clusterName, namespace string, peer *slim_networkingv1.NetworkPolicyPeer) types.Selector {
-	if peer == nil || (peer.PodSelector == nil && peer.NamespaceSelector == nil) {
+func parseNetworkPolicyPeer(clusterName, namespace string, peer *slim_networkingv1.NetworkPolicyPeer) types.Selectors {
+	if peer == nil {
 		return nil
+	}
+
+	if peer.IPBlock != nil {
+		return types.ToSelectors(ipBlockToCIDRRule(peer.IPBlock))
 	}
 
 	// peer should not be mutated in this function
 	podSelector := peer.PodSelector.DeepCopy()
+	if podSelector == nil {
+		podSelector = &slim_metav1.LabelSelector{}
+	}
 
 	// The PodSelector should only reflect to the configured cluster unless the selector
 	// explicitly targets another cluster already.
 	if clusterName != cmtypes.PolicyAnyCluster && !isPodSelectorSelectingCluster(podSelector) {
-		if podSelector == nil {
-			podSelector = &slim_metav1.LabelSelector{}
-		}
 		if podSelector.MatchLabels == nil {
 			podSelector.MatchLabels = map[string]slim_metav1.MatchLabelsValue{}
 		}
@@ -126,14 +129,12 @@ func parseNetworkPolicyPeer(clusterName, namespace string, peer *slim_networking
 		}
 
 		es := api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, namespaceSelector, podSelector)
-		return types.NewLabelSelector(es)
-	} else if podSelector != nil {
-		podSelector = parsePodSelector(podSelector, namespace)
-		es := api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, podSelector)
-		return types.NewLabelSelector(es)
+		return types.Selectors{types.NewLabelSelector(es)}
 	}
 
-	return nil
+	podSelector = parsePodSelector(podSelector, namespace)
+	es := api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, podSelector)
+	return types.Selectors{types.NewLabelSelector(es)}
 }
 
 func hasV1PolicyType(pTypes []slim_networkingv1.PolicyType, typ slim_networkingv1.PolicyType) bool {
@@ -159,22 +160,10 @@ func ParseNetworkPolicy(logger *slog.Logger, clusterName string, np *slim_networ
 		fromRules := types.PolicyEntries{}
 		if len(iRule.From) > 0 {
 			for _, rule := range iRule.From {
-				ingress := &types.PolicyEntry{Ingress: true}
-				endpointSelector := parseNetworkPolicyPeer(clusterName, namespace, &rule)
-
-				if endpointSelector != nil {
-					ingress.L3 = append(ingress.L3, endpointSelector)
-				} else {
-					// No label-based selectors were in NetworkPolicyPeer.
-					logger.Debug("NetworkPolicyPeer does not have PodSelector or NamespaceSelector", logfields.K8sNetworkPolicyName, np.Name)
+				ingress := &types.PolicyEntry{
+					Ingress: true,
+					L3:      parseNetworkPolicyPeer(clusterName, namespace, &rule),
 				}
-
-				// Parse CIDR-based parts of rule.
-				if rule.IPBlock != nil {
-					cidrRule := ipBlockToCIDRRule(rule.IPBlock)
-					ingress.L3 = append(ingress.L3, types.ToSelectors(cidrRule)...)
-				}
-
 				fromRules = append(fromRules, ingress)
 			}
 		} else {
@@ -182,9 +171,10 @@ func ParseNetworkPolicy(logger *slog.Logger, clusterName string, np *slim_networ
 			//   From []NetworkPolicyPeer
 			//   If this field is empty or missing, this rule matches all
 			//   sources (traffic not restricted by source).
-			ingress := &types.PolicyEntry{Ingress: true}
-			ingress.L3 = append(ingress.L3, types.WildcardSelector)
-
+			ingress := &types.PolicyEntry{
+				Ingress: true,
+				L3:      types.WildcardSelectors,
+			}
 			fromRules = append(fromRules, ingress)
 		}
 
@@ -207,23 +197,10 @@ func ParseNetworkPolicy(logger *slog.Logger, clusterName string, np *slim_networ
 
 		if len(eRule.To) > 0 {
 			for _, rule := range eRule.To {
-				egress := &types.PolicyEntry{Ingress: false}
-				if rule.NamespaceSelector != nil || rule.PodSelector != nil {
-					endpointSelector := parseNetworkPolicyPeer(clusterName, namespace, &rule)
-
-					if endpointSelector != nil {
-						egress.L3 = append(egress.L3, endpointSelector)
-					} else {
-						logger.Debug("NetworkPolicyPeer does not have PodSelector or NamespaceSelector", logfields.K8sNetworkPolicyName, np.Name)
-					}
+				egress := &types.PolicyEntry{
+					Ingress: false,
+					L3:      parseNetworkPolicyPeer(clusterName, namespace, &rule),
 				}
-
-				// Parse CIDR-based parts of rule.
-				if rule.IPBlock != nil {
-					cidrRule := ipBlockToCIDRRule(rule.IPBlock)
-					egress.L3 = append(egress.L3, types.ToSelector(cidrRule))
-				}
-
 				toRules = append(toRules, egress)
 			}
 		} else {
@@ -231,9 +208,10 @@ func ParseNetworkPolicy(logger *slog.Logger, clusterName string, np *slim_networ
 			//   To []NetworkPolicyPeer
 			//   If this field is empty or missing, this rule matches all
 			//   destinations (traffic not restricted by destination)
-			egress := &types.PolicyEntry{Ingress: false}
-			egress.L3 = append(egress.L3, types.WildcardSelector)
-
+			egress := &types.PolicyEntry{
+				Ingress: false,
+				L3:      types.WildcardSelectors,
+			}
 			toRules = append(toRules, egress)
 		}
 

--- a/pkg/k8s/network_policy.go
+++ b/pkg/k8s/network_policy.go
@@ -75,7 +75,7 @@ func isPodSelectorSelectingCluster(podSelector *slim_metav1.LabelSelector) bool 
 }
 
 func parseNetworkPolicyPeer(clusterName, namespace string, peer *slim_networkingv1.NetworkPolicyPeer) types.Selector {
-	if peer == nil {
+	if peer == nil || (peer.PodSelector == nil && peer.NamespaceSelector == nil) {
 		return nil
 	}
 

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -318,6 +318,26 @@ func TestParseNetworkPolicy(t *testing.T) {
 				L3:          policytypes.ToSelectors(api.NewESFromLabels()),
 			},
 		},
+		{
+			name: "ingress empty peer",
+			in: slim_networkingv1.NetworkPolicySpec{
+				Ingress: []slim_networkingv1.NetworkPolicyIngressRule{
+					{
+						From: []slim_networkingv1.NetworkPolicyPeer{
+							{},
+						},
+					},
+				},
+			},
+			out: policytypes.PolicyEntry{
+				Ingress:     true,
+				DefaultDeny: true,
+				Verdict:     policytypes.Allow,
+				L3: policytypes.ToSelectors(api.NewESFromLabels(
+					labels.NewLabel(k8sConst.PodNamespaceLabel, slim_metav1.NamespaceDefault, labels.LabelSourceK8s),
+				)),
+			},
+		},
 	} {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
 			np := &slim_networkingv1.NetworkPolicy{
@@ -1565,7 +1585,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want policytypes.Selector
+		want policytypes.Selectors
 	}{
 		{
 			name: "peer-with-pod-selector",
@@ -1587,7 +1607,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 					},
 				},
 			},
-			want: getSelectorPointer(
+			want: policytypes.Selectors{getSelectorPointer(
 				api.NewESFromMatchRequirements(
 					map[string]string{
 						"k8s.foo":                          "bar",
@@ -1602,7 +1622,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 						},
 					},
 				),
-			),
+			)},
 		},
 		{
 			name: "peer-nil",
@@ -1641,7 +1661,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 					},
 				},
 			},
-			want: getSelectorPointer(
+			want: policytypes.Selectors{getSelectorPointer(
 				api.NewESFromMatchRequirements(
 					map[string]string{
 						"k8s.foo": "bar",
@@ -1659,7 +1679,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 						},
 					},
 				),
-			),
+			)},
 		},
 		{
 			name: "peer-with-ns-selector",
@@ -1679,7 +1699,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 					},
 				},
 			},
-			want: getSelectorPointer(
+			want: policytypes.Selectors{getSelectorPointer(
 				api.NewESFromMatchRequirements(
 					map[string]string{
 						"k8s.io.cilium.k8s.namespace.labels.ns-foo": "ns-bar",
@@ -1691,7 +1711,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 						},
 					},
 				),
-			),
+			)},
 		},
 		{
 			name: "peer-with-allow-all-ns-selector",
@@ -1701,7 +1721,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 					NamespaceSelector: &slim_metav1.LabelSelector{},
 				},
 			},
-			want: getSelectorPointer(
+			want: policytypes.Selectors{getSelectorPointer(
 				api.NewESFromMatchRequirements(
 					map[string]string{},
 					[]slim_metav1.LabelSelectorRequirement{
@@ -1711,7 +1731,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 						},
 					},
 				),
-			),
+			)},
 		},
 		{
 			name: "peer-with-defaut-cluster",
@@ -1733,7 +1753,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 					},
 				},
 			},
-			want: getSelectorPointer(
+			want: policytypes.Selectors{getSelectorPointer(
 				api.NewESFromMatchRequirements(
 					map[string]string{
 						"k8s.foo":                          "bar",
@@ -1748,7 +1768,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 						},
 					},
 				),
-			),
+			)},
 		},
 		{
 			name: "peer-with-cluster-selector",
@@ -1764,7 +1784,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 					},
 				},
 			},
-			want: getSelectorPointer(
+			want: policytypes.Selectors{getSelectorPointer(
 				api.NewESFromMatchRequirements(
 					map[string]string{
 						"k8s.foo":                          "bar",
@@ -1773,7 +1793,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 					},
 					nil,
 				),
-			),
+			)},
 		},
 		{
 			name: "peer-with-cluster-selector-expr",
@@ -1792,7 +1812,7 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 					},
 				},
 			},
-			want: getSelectorPointer(
+			want: policytypes.Selectors{getSelectorPointer(
 				api.NewESFromMatchRequirements(
 					map[string]string{
 						"k8s.io.kubernetes.pod.namespace": "foo-namespace",
@@ -1805,7 +1825,26 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 						},
 					},
 				),
-			),
+			)},
+		},
+		{
+			name: "peer-with-ipblock",
+			args: args{
+				namespace:   "foo-namespace",
+				clusterName: "cluster1",
+				peer: &slim_networkingv1.NetworkPolicyPeer{
+					IPBlock: &slim_networkingv1.IPBlock{
+						CIDR:   "10.0.0.0/8",
+						Except: []string{"10.96.0.0/12"},
+					},
+				},
+			},
+			want: policytypes.Selectors{
+				policytypes.ToSelector(api.CIDRRule{
+					Cidr:        "10.0.0.0/8",
+					ExceptCIDRs: []api.CIDR{"10.96.0.0/12"},
+				}),
+			},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -516,10 +516,12 @@ func TestParseNetworkPolicyNoSelectors(t *testing.T) {
 	}
 	expectedRules := policytypes.PolicyEntries{expectedRule}
 
-	rules, err := ParseNetworkPolicy(hivetest.Logger(t), cmtypes.PolicyAnyCluster, &np)
-	require.NoError(t, err)
-	require.NotNil(t, rules)
-	require.Equal(t, expectedRules, rules)
+	for _, clusterName := range []string{cmtypes.PolicyAnyCluster, "my-cluster"} {
+		rules, err := ParseNetworkPolicy(hivetest.Logger(t), clusterName, &np)
+		require.NoError(t, err)
+		require.NotNil(t, rules)
+		require.Equal(t, expectedRules, rules)
+	}
 }
 
 func TestParseNetworkPolicyEgress(t *testing.T) {


### PR DESCRIPTION
Manual backport of commits 6b93e7a18730d82e62eb82db00a5ddc7d6de7042 and 1c84ae3b58a7cd54f7ee355e6c524c82f620eae8 from PR #46305.

Return nil early in parseNetworkPolicyPeer when both PodSelector and NamespaceSelector are nil.

This prevents a regression where a non-wildcard clusterName configuration erroneously instantiated a podSelector on selectorless (ipBlock-only) peers, resulting in an unintended wildcard namespace allow rule.

```upstream-prs
46305
```