### PR TITLE
proxy: install from-egress-proxy rule when Envoy is enabled

### DIFF
--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -119,8 +119,9 @@ func (p *Proxy) ReinstallRoutingRules(ctx context.Context, mtu int, ipsecEnabled
 // and selects the appropriate MTU to set on those routes.
 //
 // Conditions for proxy routes:
-//   - Native routing + Envoy: install only Ingress routes to handle reply packet of
-//     hair-pinning traffic in Ingress L7 proxy (i.e. backend is in the same node).
+//   - Native routing + Envoy: install both Ingress and Egress proxy routes.
+//     Ingress L7 proxy hair-pinning traffic (i.e. backend is in the same node)
+//     enters the host with MagicMarkIngress and needs the Ingress rule.
 //   - Native routing + IPSec: install Ingress+Egress routes for (a) the same reason
 //     as above, and also to account for XFRM overhead on proxy-to-proxy connections.
 //   - Native routing + WireGuard: install only Ingress routes to account for WireGuard
@@ -131,6 +132,7 @@ func requireFromProxyRoutes(ipsecEnabled, wireguardEnabled bool, mtuIn int) (fro
 	}
 	if option.Config.EnableEnvoyConfig {
 		fromIngressProxy = true
+		fromEgressProxy = true
 	}
 	switch {
 	case ipsecEnabled:

--- a/pkg/proxy/routes_test.go
+++ b/pkg/proxy/routes_test.go
@@ -50,6 +50,96 @@ func filterDefaultRouteIPv6(t *testing.T, rt []netlink.Route) netlink.Route {
 	return rt[i]
 }
 
+// TestRequireFromProxyRoutes covers the rule-selection logic in isolation
+// (no privileged netns required) so the from-egress-proxy rule wiring stays
+// honest. Regression coverage for issue #46422: ingress L7 upstream connections
+// from Envoy are stamped with MagicMarkEgress, so the Egress proxy rule must be
+// present whenever Envoy is enabled in native routing, even without IPSec or
+// WireGuard. Otherwise a coexisting third-party tool (e.g. tailscaled) with its
+// own policy-routing rules on the upper mark bits can silently steal the
+// upstream packet before it ever reaches Cilium's BPF datapath.
+func TestRequireFromProxyRoutes(t *testing.T) {
+	defer func(orig *option.DaemonConfig) { option.Config = orig }(option.Config)
+
+	tests := []struct {
+		name             string
+		tunneling        bool
+		envoyConfig      bool
+		ipsecEnabled     bool
+		wireguardEnabled bool
+		mtuIn            int
+		wantFromIngress  bool
+		wantFromEgress   bool
+		wantMTU          int
+	}{
+		{
+			name:            "tunneling on disables both rules",
+			tunneling:       true,
+			envoyConfig:     true,
+			ipsecEnabled:    true,
+			wantFromIngress: false,
+			wantFromEgress:  false,
+			wantMTU:         0,
+		},
+		{
+			name:            "envoy only installs both ingress and egress rules (regression #46422)",
+			envoyConfig:     true,
+			wantFromIngress: true,
+			wantFromEgress:  true,
+			wantMTU:         0,
+		},
+		{
+			name:            "ipsec installs both rules with overhead MTU",
+			ipsecEnabled:    true,
+			mtuIn:           1380,
+			wantFromIngress: true,
+			wantFromEgress:  true,
+			wantMTU:         1380,
+		},
+		{
+			name:             "wireguard installs only ingress rule with overhead MTU",
+			wireguardEnabled: true,
+			mtuIn:            1420,
+			wantFromIngress:  true,
+			wantFromEgress:   false,
+			wantMTU:          1420,
+		},
+		{
+			name:             "envoy + wireguard installs both rules (envoy contributes egress)",
+			envoyConfig:      true,
+			wireguardEnabled: true,
+			mtuIn:            1420,
+			wantFromIngress:  true,
+			wantFromEgress:   true,
+			wantMTU:          1420,
+		},
+		{
+			name:            "no triggers leaves both rules off",
+			wantFromIngress: false,
+			wantFromEgress:  false,
+			wantMTU:         0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			option.Config = &option.DaemonConfig{
+				EnableEnvoyConfig: tc.envoyConfig,
+			}
+			if tc.tunneling {
+				option.Config.RoutingMode = option.RoutingModeTunnel
+			} else {
+				option.Config.RoutingMode = option.RoutingModeNative
+			}
+
+			gotIngress, gotEgress, gotMTU := requireFromProxyRoutes(tc.ipsecEnabled, tc.wireguardEnabled, tc.mtuIn)
+			assert.Equal(t, tc.wantFromIngress, gotIngress, "fromIngressProxy")
+			assert.Equal(t, tc.wantFromEgress, gotEgress, "fromEgressProxy")
+			assert.Equal(t, tc.wantMTU, gotMTU, "mtu")
+		})
+	}
+}
+
 func TestPrivilegedRoutes(t *testing.T) {
 	testutils.PrivilegedTest(t)
 


### PR DESCRIPTION
Fixes #46422. Envoy stamps ingress L7 upstream connections with MagicMarkEgress (0x0B00) instead of MagicMarkIngress, so the from-egress-proxy ip rule has to be present whenever Envoy is enabled in native routing and not only when IPSec is also enabled. Without it, a third-party tool that shares the host's mark namespace, like tailscaled with its policy-routing rules at priority 5200+ matching fwmark 0x80000/0xff0000, can steal the upstream packet before Cilium's own rules are consulted, and the connection blackholes silently with no signal in cilium monitor, hubble, or the NAT table.

The fix is a one line addition in requireFromProxyRoutes so the Envoy branch also flips fromEgressProxy on. The from-egress-proxy rule already exists and is wired through installFromProxyRoutes, it just was not being requested in this configuration. A small unit test for requireFromProxyRoutes is added so the rule selection logic stays honest going forward.