### PR TITLE
egressgateway: consume IPCache-backed pod endpoint source

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -659,6 +659,7 @@ Makefile* @cilium/build
 /pkg/nodeipamconfig @cilium/sig-ipam
 /pkg/option @cilium/sig-agent @cilium/cli
 /pkg/pidfile @cilium/sig-agent
+/pkg/podendpointsource/ @cilium/ipcache @cilium/egress-gateway
 /pkg/policy @cilium/sig-policy
 /pkg/policy/api/ @cilium/api @cilium/sig-policy
 /pkg/policy/groups/aws/ @cilium/sig-policy @cilium/aws

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -84,6 +84,7 @@ import (
 	_ "github.com/cilium/cilium/pkg/nodediscovery/eni"
 	"github.com/cilium/cilium/pkg/nodeipamconfig"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/podendpointsource"
 	policy "github.com/cilium/cilium/pkg/policy/cell"
 	"github.com/cilium/cilium/pkg/policy/compute"
 	policyDirectory "github.com/cilium/cilium/pkg/policy/directory"
@@ -295,6 +296,11 @@ var (
 
 		// IPAM provides IP address management.
 		ipamcell.Cell,
+
+		// Observes pod endpoints from the IPCache and exposes them as a
+		// typed event stream consumed by the Egress Gateway (and
+		// potentially other components in the future).
+		podendpointsource.Cell,
 
 		// Egress Gateway allows originating traffic from specific IPv4 addresses.
 		egressgateway.Cell,

--- a/pkg/egressgateway/endpoint.go
+++ b/pkg/egressgateway/endpoint.go
@@ -4,70 +4,22 @@
 package egressgateway
 
 import (
-	"fmt"
 	"net/netip"
 
-	"k8s.io/apimachinery/pkg/types"
-
-	k8sTypes "github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/labels"
 )
 
-// endpointMetadata stores relevant metadata associated with a endpoint that's updated during endpoint
-// add/update events
+// endpointMetadata stores the pod data used by egress gateway policy matching.
 type endpointMetadata struct {
-	// Endpoint labels
-	labels map[string]string
-	// Endpoint ID
-	id endpointID
-	// ips are endpoint's unique IPs
+	// labels are the endpoint's identity labels.
+	labels labels.LabelArray
+	// key uniquely identifies the pod (namespace/podName)
+	key endpointKey
+	// ips are the endpoint's unique IPs
 	ips []netip.Addr
-	// nodeIP is the IP of the node the endpoint is on
+	// nodeIP is the IP of the node the endpoint is running on
 	nodeIP string
 }
 
-// endpointID is based on endpoint's UID
-type endpointID = types.UID
-
-func getEndpointMetadata(endpoint *k8sTypes.CiliumEndpoint, identityLabels labels.Labels) (*endpointMetadata, error) {
-	var addrs []netip.Addr
-
-	if endpoint.UID == "" {
-		// this can happen when CiliumEndpointSlices are in use - which is not supported in the EGW yet
-		return nil, fmt.Errorf("endpoint has empty UID")
-	}
-
-	if endpoint.Networking == nil {
-		return nil, fmt.Errorf("endpoint has no networking metadata")
-	}
-
-	if len(endpoint.Networking.Addressing) == 0 {
-		return nil, fmt.Errorf("failed to get valid endpoint IPs")
-	}
-
-	for _, pair := range endpoint.Networking.Addressing {
-		if pair.IPV4 != "" {
-			addr, err := netip.ParseAddr(pair.IPV4)
-			if err != nil || !addr.Is4() {
-				continue
-			}
-			addrs = append(addrs, addr)
-		}
-		if pair.IPV6 != "" {
-			addr, err := netip.ParseAddr(pair.IPV6)
-			if err != nil || !addr.Is6() {
-				continue
-			}
-			addrs = append(addrs, addr)
-		}
-	}
-
-	data := &endpointMetadata{
-		ips:    addrs,
-		labels: identityLabels.K8sStringMap(),
-		id:     endpoint.UID,
-		nodeIP: endpoint.Networking.NodeIP,
-	}
-
-	return data, nil
-}
+// endpointKey uniquely identifies a pod using namespace/podName.
+type endpointKey = string

--- a/pkg/egressgateway/helpers_test.go
+++ b/pkg/egressgateway/helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"net/netip"
+	"slices"
 	"testing"
 	"time"
 
@@ -19,6 +20,8 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	k8sTypes "github.com/cilium/cilium/pkg/k8s/types"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/podendpointsource"
 	"github.com/cilium/cilium/pkg/policy/api"
 	policyTypes "github.com/cilium/cilium/pkg/policy/types"
 )
@@ -228,30 +231,101 @@ func newCEGP(params *policyParams) (*v2.CiliumEgressGatewayPolicy, *PolicyConfig
 	return cegp, policy
 }
 
-func addEndpointAndReconcile(tb testing.TB, egressGatewayManager *Manager, endpoints fakeResource[*k8sTypes.CiliumEndpoint], ep *k8sTypes.CiliumEndpoint) {
+// addEndpointAndReconcile delivers a pod endpoint Upsert directly to the
+// manager, mirroring what the podendpointsource would emit in production,
+// and waits for reconciliation to complete.
+func addEndpointAndReconcile(tb testing.TB, egressGatewayManager *Manager, _ fakeResource[*k8sTypes.CiliumEndpoint], ep *k8sTypes.CiliumEndpoint) {
 	currentRun := egressGatewayManager.reconciliationEventsCount.Load()
-	addEndpoint(tb, endpoints, ep)
+	addEndpoint(tb, egressGatewayManager, ep)
 	waitForReconciliationRun(tb, egressGatewayManager, currentRun)
 }
 
-func addEndpoint(tb testing.TB, endpoints fakeResource[*k8sTypes.CiliumEndpoint], ep *k8sTypes.CiliumEndpoint) {
-	endpoints.process(tb, resource.Event[*k8sTypes.CiliumEndpoint]{
-		Kind:   resource.Upsert,
-		Object: ep,
-	})
+// addEndpoint constructs a PodEndpoint from the given CiliumEndpoint and
+// hands it to the manager as an Upsert event. All IPs of the endpoint are
+// aggregated into a single event, as the podendpointsource does.
+func addEndpoint(tb testing.TB, manager *Manager, ep *k8sTypes.CiliumEndpoint) {
+	tb.Helper()
+
+	pe := podEndpointFromCiliumEndpoint(tb, ep)
+	if err := manager.handleEndpointEvent(context.Background(), podendpointsource.Event{
+		Kind:     podendpointsource.EventKindUpsert,
+		Endpoint: pe,
+	}); err != nil {
+		tb.Fatalf("handleEndpointEvent upsert: %v", err)
+	}
 }
 
-func deleteEndpointAndReconcile(tb testing.TB, egressGatewayManager *Manager, endpoints fakeResource[*k8sTypes.CiliumEndpoint], ep *k8sTypes.CiliumEndpoint) {
+// deleteEndpointAndReconcile delivers a pod endpoint Delete to the manager
+// and waits for reconciliation.
+func deleteEndpointAndReconcile(tb testing.TB, egressGatewayManager *Manager, _ fakeResource[*k8sTypes.CiliumEndpoint], ep *k8sTypes.CiliumEndpoint) {
 	currentRun := egressGatewayManager.reconciliationEventsCount.Load()
-	deleteEndpoint(tb, endpoints, ep)
+	deleteEndpoint(tb, egressGatewayManager, ep)
 	waitForReconciliationRun(tb, egressGatewayManager, currentRun)
 }
 
-func deleteEndpoint(tb testing.TB, endpoints fakeResource[*k8sTypes.CiliumEndpoint], ep *k8sTypes.CiliumEndpoint) {
-	endpoints.process(tb, resource.Event[*k8sTypes.CiliumEndpoint]{
-		Kind:   resource.Delete,
-		Object: ep,
+// deleteEndpoint hands the manager a whole-endpoint Delete event.
+func deleteEndpoint(tb testing.TB, manager *Manager, ep *k8sTypes.CiliumEndpoint) {
+	tb.Helper()
+
+	if err := manager.handleEndpointEvent(context.Background(), podendpointsource.Event{
+		Kind: podendpointsource.EventKindDelete,
+		Endpoint: podendpointsource.PodEndpoint{
+			Key: ep.Namespace + "/" + ep.Name,
+		},
+	}); err != nil {
+		tb.Fatalf("handleEndpointEvent delete: %v", err)
+	}
+}
+
+// podEndpointFromCiliumEndpoint turns a test CiliumEndpoint into the shape
+// the podendpointsource would emit. IPs are sorted IPv4-first then IPv6, as
+// the production Source does.
+func podEndpointFromCiliumEndpoint(tb testing.TB, ep *k8sTypes.CiliumEndpoint) podendpointsource.PodEndpoint {
+	tb.Helper()
+
+	var nodeIP string
+	if ep.Networking != nil {
+		nodeIP = ep.Networking.NodeIP
+	}
+
+	pe := podendpointsource.PodEndpoint{
+		Key:    ep.Namespace + "/" + ep.Name,
+		NodeIP: nodeIP,
+	}
+
+	if ep.Networking != nil {
+		for _, pair := range ep.Networking.Addressing {
+			if pair.IPV4 != "" {
+				addr, err := netip.ParseAddr(pair.IPV4)
+				if err != nil {
+					tb.Fatalf("invalid IPv4 %q: %v", pair.IPV4, err)
+				}
+				pe.IPs = append(pe.IPs, addr)
+			}
+			if pair.IPV6 != "" {
+				addr, err := netip.ParseAddr(pair.IPV6)
+				if err != nil {
+					tb.Fatalf("invalid IPv6 %q: %v", pair.IPV6, err)
+				}
+				pe.IPs = append(pe.IPs, addr)
+			}
+		}
+	}
+	slices.SortFunc(pe.IPs, func(a, b netip.Addr) int {
+		switch {
+		case a.Is4() && !b.Is4():
+			return -1
+		case !a.Is4() && b.Is4():
+			return 1
+		default:
+			return a.Compare(b)
+		}
 	})
+
+	if ep.Identity != nil {
+		pe.Labels = labels.ParseLabelArrayFromArray(ep.Identity.Labels)
+	}
+	return pe
 }
 
 func addNodeAndReconcile(tb testing.TB, k *EgressGatewayTestSuite, egressGatewayManager *Manager, node *cilium_api_v2.CiliumNode) {
@@ -277,3 +351,8 @@ func waitForReconciliationRun(tb testing.TB, egressGatewayManager *Manager, curr
 	tb.Fatal("Reconciliation is taking too long to run")
 	return 0
 }
+
+// Remote-cluster filtering is now the responsibility of the
+// podendpointsource, so the egress gateway manager never sees events for
+// non-local endpoints. The corresponding test lives alongside the source
+// implementation in pkg/podendpointsource.

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -15,27 +15,24 @@ import (
 	"sync/atomic"
 
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/util/workqueue"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/config/defines"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
-	"github.com/cilium/cilium/pkg/identity"
-	identityCache "github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
-	k8sTypes "github.com/cilium/cilium/pkg/k8s/types"
-	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/egressmap"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/podendpointsource"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/trigger"
 )
@@ -87,6 +84,9 @@ func (def Config) Flags(flags *pflag.FlagSet) {
 // The egressgateway manager stores the internal data tracking the node, policy,
 // endpoint, and lease mappings. It also hooks up all the callbacks to update
 // egress bpf policy map accordingly.
+//
+// Endpoint data is obtained from [podendpointsource.Source]. The manager only
+// consumes the typed event stream.
 type Manager struct {
 	logger *slog.Logger
 
@@ -108,17 +108,11 @@ type Manager struct {
 	// nodesResource allows reading node CRD from k8s.
 	ciliumNodes resource.Resource[*cilium_api_v2.CiliumNode]
 
-	// endpoints allows reading endpoint CRD from k8s.
-	endpoints resource.Resource[*k8sTypes.CiliumEndpoint]
-
 	// policyConfigs stores policy configs indexed by policyID
 	policyConfigs map[policyID]*PolicyConfig
 
-	// epDataStore stores endpointId to endpoint metadata mapping
-	epDataStore map[endpointID]*endpointMetadata
-
-	// identityAllocator is used to fetch identity labels for endpoint updates
-	identityAllocator identityCache.IdentityAllocator
+	// epDataStore stores endpoint metadata by pod key.
+	epDataStore map[endpointKey]*endpointMetadata
 
 	// policyMap4 communicates the active IPv4 policies to the datapath.
 	policyMap4   egressmap.PolicyMap4
@@ -156,22 +150,22 @@ type Params struct {
 
 	Logger *slog.Logger
 
-	Config            Config
-	DaemonConfig      *option.DaemonConfig
-	TunnelConfig      tunnel.Config
-	IdentityAllocator identityCache.IdentityAllocator
-	PolicyMap4        egressmap.PolicyMap4
-	PolicyMap4V2      egressmap.PolicyMap4V2
-	PolicyMap6        egressmap.PolicyMap6
-	Policies          resource.Resource[*Policy]
-	Nodes             resource.Resource[*cilium_api_v2.CiliumNode]
-	Endpoints         resource.Resource[*k8sTypes.CiliumEndpoint]
-	Sysctl            sysctl.Sysctl
+	Config       Config
+	DaemonConfig *option.DaemonConfig
+	TunnelConfig tunnel.Config
+	PodEndpoints podendpointsource.Source
+	PolicyMap4   egressmap.PolicyMap4
+	PolicyMap4V2 egressmap.PolicyMap4V2
+	PolicyMap6   egressmap.PolicyMap6
+	Policies     resource.Resource[*Policy]
+	Nodes        resource.Resource[*cilium_api_v2.CiliumNode]
+	Sysctl       sysctl.Sysctl
 
 	DB          *statedb.DB
 	DeviceTable statedb.Table[*tables.Device]
 
 	Lifecycle cell.Lifecycle
+	JobGroup  job.Group
 }
 
 func NewEgressGatewayManager(p Params) (out struct {
@@ -188,10 +182,6 @@ func NewEgressGatewayManager(p Params) (out struct {
 
 	if dcfg.IdentityAllocationMode != option.IdentityAllocationModeCRD {
 		return out, fmt.Errorf("egress gateway is not supported in %s identity allocation mode", dcfg.IdentityAllocationMode)
-	}
-
-	if dcfg.EnableCiliumEndpointSlice {
-		return out, errors.New("egress gateway is not supported in combination with the CiliumEndpointSlice feature")
 	}
 
 	// TODO: refactor config checks for both ipv4 and ipv6, and derive whether the environment supports egress gateway policies for either protocol
@@ -224,15 +214,13 @@ func newEgressGatewayManager(p Params) (*Manager, error) {
 	manager := &Manager{
 		logger:                        p.Logger,
 		policyConfigs:                 make(map[policyID]*PolicyConfig),
-		epDataStore:                   make(map[endpointID]*endpointMetadata),
-		identityAllocator:             p.IdentityAllocator,
+		epDataStore:                   make(map[endpointKey]*endpointMetadata),
 		reconciliationTriggerInterval: p.Config.EgressGatewayReconciliationTriggerInterval,
 		policyMap4:                    p.PolicyMap4,
 		policyMap4V2:                  p.PolicyMap4V2,
 		policyMap6:                    p.PolicyMap6,
 		policies:                      p.Policies,
 		ciliumNodes:                   p.Nodes,
-		endpoints:                     p.Endpoints,
 		sysctl:                        p.Sysctl,
 		db:                            p.DB,
 		deviceTable:                   p.DeviceTable,
@@ -257,6 +245,15 @@ func newEgressGatewayManager(p Params) (*Manager, error) {
 
 	manager.reconciliationTrigger = t
 
+	// Source replay replaces the old "endpoints synced" signal.
+	if p.PodEndpoints != nil {
+		p.JobGroup.Add(job.Observer(
+			"egressgateway-endpoint-events",
+			manager.handleEndpointEvent,
+			p.PodEndpoints,
+		))
+	}
+
 	var wg sync.WaitGroup
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -265,12 +262,10 @@ func newEgressGatewayManager(p Params) (*Manager, error) {
 			wg.Go(func() {
 				manager.processEvents(ctx)
 			})
-
 			return nil
 		},
 		OnStop: func(hc cell.HookContext) error {
 			cancel()
-
 			wg.Wait()
 			return nil
 		},
@@ -295,26 +290,38 @@ func (manager *Manager) eventBitmapIsSet(events ...eventType) bool {
 	return false
 }
 
-// getIdentityLabels waits for the global identities to be populated to the cache,
-// then looks up identity by ID from the cached identity allocator and return its labels.
-func (manager *Manager) getIdentityLabels(securityIdentity uint32) (labels.Labels, error) {
-	if err := manager.identityAllocator.WaitForInitialGlobalIdentities(context.Background()); err != nil {
-		return nil, fmt.Errorf("failed to wait for initial global identities: %w", err)
+// handleEndpointEvent mirrors pod endpoint events into epDataStore.
+func (manager *Manager) handleEndpointEvent(_ context.Context, ev podendpointsource.Event) error {
+	manager.Lock()
+	defer manager.Unlock()
+
+	switch ev.Kind {
+	case podendpointsource.EventKindUpsert:
+		ep := ev.Endpoint
+		manager.epDataStore[endpointKey(ep.Key)] = &endpointMetadata{
+			key:    endpointKey(ep.Key),
+			labels: ep.Labels,
+			ips:    ep.IPs,
+			nodeIP: ep.NodeIP,
+		}
+		manager.setEventBitmap(eventUpdateEndpoint)
+	case podendpointsource.EventKindDelete:
+		if _, ok := manager.epDataStore[endpointKey(ev.Endpoint.Key)]; !ok {
+			return nil
+		}
+		delete(manager.epDataStore, endpointKey(ev.Endpoint.Key))
+		manager.setEventBitmap(eventDeleteEndpoint)
 	}
 
-	identity := manager.identityAllocator.LookupIdentityByID(context.Background(), identity.NumericIdentity(securityIdentity))
-	if identity == nil {
-		return nil, fmt.Errorf("identity %d not found", securityIdentity)
-	}
-	return identity.Labels, nil
+	manager.reconciliationTrigger.TriggerWithReason("endpoint changed")
+	return nil
 }
 
-// processEvents spawns a goroutine that waits for the agent to
-// sync with k8s and then runs the first reconciliation.
+// processEvents waits for policy and node sync before first reconciliation.
 func (manager *Manager) processEvents(ctx context.Context) {
-	var policySync, nodeSync, endpointSync bool
+	var policySync, nodeSync bool
 	maybeTriggerReconcile := func() {
-		if !policySync || !nodeSync || !endpointSync {
+		if !policySync || !nodeSync {
 			return
 		}
 
@@ -330,18 +337,8 @@ func (manager *Manager) processEvents(ctx context.Context) {
 		manager.reconciliationTrigger.TriggerWithReason("k8s sync done")
 	}
 
-	// here we try to mimic the same exponential backoff retry logic used by
-	// the identity allocator, where the minimum retry timeout is set to 20
-	// milliseconds and the max number of attempts is 16 (so 20ms * 2^16 ==
-	// ~20 minutes)
-	endpointsRateLimit := workqueue.NewTypedItemExponentialFailureRateLimiter[resource.WorkItem](
-		time.Millisecond*20,
-		time.Minute*20,
-	)
-
 	policyEvents := manager.policies.Events(ctx)
 	nodeEvents := manager.ciliumNodes.Events(ctx)
-	endpointEvents := manager.endpoints.Events(ctx, resource.WithRateLimiter(endpointsRateLimit))
 
 	for {
 		select {
@@ -364,15 +361,6 @@ func (manager *Manager) processEvents(ctx context.Context) {
 				event.Done(nil)
 			} else {
 				manager.handleNodeEvent(event)
-			}
-
-		case event := <-endpointEvents:
-			if event.Kind == resource.Sync {
-				endpointSync = true
-				maybeTriggerReconcile()
-				event.Done(nil)
-			} else {
-				manager.handleEndpointEvent(event)
 			}
 		}
 	}
@@ -420,7 +408,7 @@ func (manager *Manager) onAddEgressPolicy(policy *Policy) error {
 		)
 	}
 
-	config.updateMatchedEndpointIDs(manager.epDataStore, manager.nodesAddresses2Labels)
+	config.updateMatchedEndpointKeys(manager.epDataStore, manager.nodesAddresses2Labels)
 
 	manager.policyConfigs[config.id] = config
 
@@ -453,90 +441,6 @@ func (manager *Manager) onDeleteEgressPolicy(policy *Policy) {
 
 	manager.setEventBitmap(eventDeletePolicy)
 	manager.reconciliationTrigger.TriggerWithReason("policy deleted")
-}
-
-func (manager *Manager) addEndpoint(endpoint *k8sTypes.CiliumEndpoint) error {
-	var epData *endpointMetadata
-	var err error
-	var identityLabels labels.Labels
-
-	manager.Lock()
-	defer manager.Unlock()
-
-	logger := manager.logger.With(
-		logfields.K8sEndpointName, endpoint.Name,
-		logfields.K8sNamespace, endpoint.Namespace,
-		logfields.K8sUID, endpoint.UID,
-	)
-
-	if endpoint.Identity == nil {
-		logger.Warn(
-			"Endpoint is missing identity metadata, skipping update to egress policy.",
-		)
-		return nil
-	}
-
-	if identityLabels, err = manager.getIdentityLabels(uint32(endpoint.Identity.ID)); err != nil {
-		logger.Warn(
-			"Failed to get identity labels for endpoint",
-			logfields.Error, err,
-		)
-		return err
-	}
-
-	if epData, err = getEndpointMetadata(endpoint, identityLabels); err != nil {
-		logger.Error(
-			"Failed to get valid endpoint metadata, skipping update to egress policy.",
-			logfields.Error, err,
-		)
-		return nil
-	}
-
-	if _, ok := manager.epDataStore[epData.id]; ok {
-		logger.Debug(
-			"Updated CiliumEndpoint",
-			logfields.Error, err,
-		)
-	} else {
-		logger.Debug(
-			"Added CiliumEndpoint",
-			logfields.Error, err,
-		)
-	}
-
-	manager.epDataStore[epData.id] = epData
-
-	manager.setEventBitmap(eventUpdateEndpoint)
-	manager.reconciliationTrigger.TriggerWithReason("endpoint updated")
-
-	return nil
-}
-
-func (manager *Manager) deleteEndpoint(endpoint *k8sTypes.CiliumEndpoint) {
-	manager.Lock()
-	defer manager.Unlock()
-
-	manager.logger.Debug(
-		"Deleted CiliumEndpoint",
-		logfields.K8sEndpointName, endpoint.Name,
-		logfields.K8sNamespace, endpoint.Namespace,
-		logfields.K8sUID, endpoint.UID,
-	)
-	delete(manager.epDataStore, endpoint.UID)
-
-	manager.setEventBitmap(eventDeleteEndpoint)
-	manager.reconciliationTrigger.TriggerWithReason("endpoint deleted")
-}
-
-func (manager *Manager) handleEndpointEvent(event resource.Event[*k8sTypes.CiliumEndpoint]) {
-	endpoint := event.Object
-
-	if event.Kind == resource.Upsert {
-		event.Done(manager.addEndpoint(endpoint))
-	} else {
-		manager.deleteEndpoint(endpoint)
-		event.Done(nil)
-	}
 }
 
 // handleNodeEvent takes care of node upserts and removals.
@@ -580,9 +484,9 @@ func (manager *Manager) handleNodeEvent(event resource.Event[*cilium_api_v2.Cili
 	manager.reconciliationTrigger.TriggerWithReason("node updated")
 }
 
-func (manager *Manager) updatePoliciesMatchedEndpointIDs() {
+func (manager *Manager) updatePoliciesMatchedEndpointKeys() {
 	for _, policy := range manager.policyConfigs {
-		policy.updateMatchedEndpointIDs(manager.epDataStore, manager.nodesAddresses2Labels)
+		policy.updateMatchedEndpointKeys(manager.epDataStore, manager.nodesAddresses2Labels)
 	}
 }
 
@@ -874,7 +778,7 @@ func (manager *Manager) reconcileLocked() {
 	// we don't know which k8s events/resources were received during the
 	// initial k8s sync
 	case manager.eventBitmapIsSet(eventUpdateEndpoint, eventDeleteEndpoint, eventUpdateNode, eventDeleteNode, eventK8sSyncDone):
-		manager.updatePoliciesMatchedEndpointIDs()
+		manager.updatePoliciesMatchedEndpointKeys()
 	}
 
 	if manager.eventBitmapIsSet(eventK8sSyncDone, eventAddPolicy, eventDeletePolicy, eventUpdateNode, eventDeleteNode) {

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -141,11 +141,10 @@ type rpFilterSetting struct {
 }
 
 type EgressGatewayTestSuite struct {
-	manager   *Manager
-	policies  fakeResource[*Policy]
-	nodes     fakeResource[*cilium_api_v2.CiliumNode]
-	endpoints fakeResource[*k8sTypes.CiliumEndpoint]
-	sysctl    sysctl.Sysctl
+	manager  *Manager
+	policies fakeResource[*Policy]
+	nodes    fakeResource[*cilium_api_v2.CiliumNode]
+	sysctl   sysctl.Sysctl
 }
 
 func setupEgressGatewayTestSuite(t *testing.T) *EgressGatewayTestSuite {
@@ -162,7 +161,6 @@ func setupEgressGatewayTestSuite(t *testing.T) *EgressGatewayTestSuite {
 	k := &EgressGatewayTestSuite{}
 	k.policies = make(fakeResource[*Policy])
 	k.nodes = make(fakeResource[*cilium_api_v2.CiliumNode])
-	k.endpoints = make(fakeResource[*k8sTypes.CiliumEndpoint])
 	k.sysctl = sysctl.NewDirectSysctl(afero.NewOsFs(), "/proc")
 
 	lc := hivetest.Lifecycle(t)
@@ -195,20 +193,20 @@ func setupEgressGatewayTestSuite(t *testing.T) *EgressGatewayTestSuite {
 	})
 
 	k.manager, err = newEgressGatewayManager(Params{
-		Logger:            logger,
-		Lifecycle:         lc,
-		Config:            Config{1 * time.Millisecond},
-		DaemonConfig:      &option.DaemonConfig{},
-		IdentityAllocator: identityAllocator,
-		PolicyMap4:        policyMap4,
-		PolicyMap4V2:      policyMap4V2,
-		PolicyMap6:        policyMap6,
-		Policies:          k.policies,
-		Nodes:             k.nodes,
-		Endpoints:         k.endpoints,
-		Sysctl:            k.sysctl,
-		DB:                db,
-		DeviceTable:       deviceTable,
+		Logger:       logger,
+		Lifecycle:    lc,
+		JobGroup:     nil, // pod endpoint events are delivered synchronously via handleEndpointEvent
+		Config:       Config{1 * time.Millisecond},
+		DaemonConfig: &option.DaemonConfig{},
+		PodEndpoints: nil, // tests drive events directly; no live subscription needed
+		PolicyMap4:   policyMap4,
+		PolicyMap4V2: policyMap4V2,
+		PolicyMap6:   policyMap6,
+		Policies:     k.policies,
+		Nodes:        k.nodes,
+		Sysctl:       k.sysctl,
+		DB:           db,
+		DeviceTable:  deviceTable,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, k.manager)
@@ -482,7 +480,7 @@ func TestPrivilegedEgressGatewayManager(t *testing.T) {
 
 	k.policies.sync(t)
 	k.nodes.sync(t)
-	k.endpoints.sync(t)
+	// endpoints are now received via IPCache callbacks (no sync needed)
 
 	node1 := newCiliumNode(node1, node1IP, nodeGroup1Labels)
 	addNodeAndReconcile(t, k, egressGatewayManager, &node1)
@@ -513,7 +511,7 @@ func TestPrivilegedEgressGatewayManager(t *testing.T) {
 
 	// Add a new endpoint & ID which matches policy-1
 	ep1, id1 := newEndpointAndIdentity("ep-1", ep1IP, ep1IPv6, ep1Labels)
-	addEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep1)
+	addEndpointAndReconcile(t, egressGatewayManager, nil, &ep1)
 
 	assertEgressRules4(t, policyMap4, []egressRule{
 		{ep1IP, destCIDR, egressIP1, node1IP, ifIndex1},
@@ -524,14 +522,14 @@ func TestPrivilegedEgressGatewayManager(t *testing.T) {
 
 	// Update the endpoint labels in order for it to not be a match
 	id1 = updateEndpointAndIdentity(&ep1, id1, map[string]string{})
-	addEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep1)
+	addEndpointAndReconcile(t, egressGatewayManager, nil, &ep1)
 
 	assertEgressRules4(t, policyMap4, []egressRule{})
 	assertEgressRules6(t, policyMap6, []egressRule{})
 
 	// Restore the old endpoint lables in order for it to be a match
 	id1 = updateEndpointAndIdentity(&ep1, id1, ep1Labels)
-	addEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep1)
+	addEndpointAndReconcile(t, egressGatewayManager, nil, &ep1)
 
 	assertEgressRules4(t, policyMap4, []egressRule{
 		{ep1IP, destCIDR, egressIP1, node1IP, ifIndex1},
@@ -579,7 +577,7 @@ func TestPrivilegedEgressGatewayManager(t *testing.T) {
 
 	// Add a new endpoint and ID which matches policy-2
 	ep2, _ := newEndpointAndIdentity("ep-2", ep2IP, ep2IPv6, ep2Labels)
-	addEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep2)
+	addEndpointAndReconcile(t, egressGatewayManager, nil, &ep2)
 
 	assertEgressRules4(t, policyMap4, []egressRule{
 		{ep1IP, destCIDR, egressIP1, node1IP, ifIndex1},
@@ -737,7 +735,7 @@ func TestPrivilegedEgressGatewayManager(t *testing.T) {
 
 	// Update the endpoint labels in order for it to not be a match
 	_ = updateEndpointAndIdentity(&ep1, id1, map[string]string{})
-	addEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep1)
+	addEndpointAndReconcile(t, egressGatewayManager, nil, &ep1)
 
 	assertEgressRules4(t, policyMap4, []egressRule{
 		{ep2IP, destCIDR, zeroIP4, node2IP, 0},
@@ -764,7 +762,7 @@ func TestPrivilegedNodeSelector(t *testing.T) {
 
 	k.policies.sync(t)
 	k.nodes.sync(t)
-	k.endpoints.sync(t)
+	// endpoints are now received via IPCache callbacks (no sync needed)
 
 	node1 := newCiliumNode(node1, node1IP, nodeGroup1Labels)
 	addNodeAndReconcile(t, k, egressGatewayManager, &node1)
@@ -793,7 +791,7 @@ func TestPrivilegedNodeSelector(t *testing.T) {
 
 	// Add a new endpoint & ID which matches policy-1
 	ep1, _ := newEndpointAndIdentityWithNodeIP("ep-1", ep1IP, ep1IPv6, node1IP, ep1Labels)
-	addEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep1)
+	addEndpointAndReconcile(t, egressGatewayManager, nil, &ep1)
 
 	assertEgressRules4(t, policyMap4, []egressRule{}) // This ep1 should not match the policy-1
 	assertEgressRules6(t, policyMap6, []egressRule{})
@@ -803,8 +801,8 @@ func TestPrivilegedNodeSelector(t *testing.T) {
 	ep2, _ := newEndpointAndIdentityWithNodeIP(ep1.Name, ep2IP, ep2IPv6, node2IP, ep1Labels)
 
 	// Test event order: add new -> delete old
-	addEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep2)
-	deleteEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep1)
+	addEndpointAndReconcile(t, egressGatewayManager, nil, &ep2)
+	deleteEndpointAndReconcile(t, egressGatewayManager, nil, &ep1)
 
 	assertEgressRules4(t, policyMap4, []egressRule{ // This ep2 should match the policy-1
 		{ep2IP, destCIDR, egressIP1, node1IP, ifIndex1},
@@ -817,8 +815,8 @@ func TestPrivilegedNodeSelector(t *testing.T) {
 	ep3, _ := newEndpointAndIdentityWithNodeIP(ep1.Name, ep3IP, ep3IPv6, node1IP, ep1Labels)
 
 	// Test event order: delete old -> update new
-	deleteEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep2)
-	addEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep3)
+	deleteEndpointAndReconcile(t, egressGatewayManager, nil, &ep2)
+	addEndpointAndReconcile(t, egressGatewayManager, nil, &ep3)
 
 	assertEgressRules4(t, policyMap4, []egressRule{}) // This ep3 should not match the policy-1
 	assertEgressRules6(t, policyMap6, []egressRule{})
@@ -841,7 +839,7 @@ func TestPrivilegedEndpointDataStore(t *testing.T) {
 
 	k.policies.sync(t)
 	k.nodes.sync(t)
-	k.endpoints.sync(t)
+	// endpoints are now received via IPCache callbacks (no sync needed)
 
 	node1 := newCiliumNode(node1, node1IP, nodeGroup1Labels)
 	addNodeAndReconcile(t, k, egressGatewayManager, &node1)
@@ -866,7 +864,7 @@ func TestPrivilegedEndpointDataStore(t *testing.T) {
 
 	// Add a new endpoint & ID which matches policy-1
 	ep1, _ := newEndpointAndIdentity("ep-1", ep1IP, ep1IPv6, ep1Labels)
-	addEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep1)
+	addEndpointAndReconcile(t, egressGatewayManager, nil, &ep1)
 
 	assertEgressRules4(t, policyMap4, []egressRule{
 		{ep1IP, destCIDR, egressIP1, node1IP, ifIndex1},
@@ -882,8 +880,8 @@ func TestPrivilegedEndpointDataStore(t *testing.T) {
 	ep2, _ := newEndpointAndIdentity(ep1.Name, ep2IP, ep2IPv6, ep1Labels)
 
 	// Test event order: add new -> delete old
-	addEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep2)
-	deleteEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep1)
+	addEndpointAndReconcile(t, egressGatewayManager, nil, &ep2)
+	deleteEndpointAndReconcile(t, egressGatewayManager, nil, &ep1)
 
 	assertEgressRules4(t, policyMap4, []egressRule{
 		{ep2IP, destCIDR, egressIP1, node1IP, ifIndex1},
@@ -896,8 +894,8 @@ func TestPrivilegedEndpointDataStore(t *testing.T) {
 	ep3, _ := newEndpointAndIdentity(ep1.Name, ep3IP, ep3IPv6, ep1Labels)
 
 	// Test event order: delete old -> update new
-	deleteEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep2)
-	addEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &ep3)
+	deleteEndpointAndReconcile(t, egressGatewayManager, nil, &ep2)
+	addEndpointAndReconcile(t, egressGatewayManager, nil, &ep3)
 
 	assertEgressRules4(t, policyMap4, []egressRule{
 		{ep3IP, destCIDR, egressIP1, node1IP, ifIndex1},
@@ -925,7 +923,7 @@ func TestPrivilegedMultigatewayPolicy(t *testing.T) {
 
 	k.policies.sync(t)
 	k.nodes.sync(t)
-	k.endpoints.sync(t)
+	// endpoints are now received via IPCache callbacks (no sync needed)
 
 	_ = waitForReconciliationRun(t, egressGatewayManager, reconciliationEventsCount)
 
@@ -967,7 +965,7 @@ func TestPrivilegedMultigatewayPolicy(t *testing.T) {
 	}
 	for i, ep := range eps {
 		newEP, newID := newEndpointAndIdentity(ep.name, ep.ipv4, ep.ipv6, ep1Labels)
-		addEndpointAndReconcile(t, egressGatewayManager, k.endpoints, &newEP)
+		addEndpointAndReconcile(t, egressGatewayManager, nil, &newEP)
 		eps[i].ep = &newEP
 		eps[i].id = newID
 	}
@@ -978,7 +976,7 @@ func TestPrivilegedMultigatewayPolicy(t *testing.T) {
 		var rules []egressRule
 
 		for _, endpoint := range endpoints {
-			h := computeEndpointHash(endpoint.ep.UID)
+			h := computeEndpointHash(endpointKey(endpoint.ep.Namespace + "/" + endpoint.ep.Name))
 			gw := gateways[h%uint32(len(gateways))]
 			ifindex := egressIfindex
 
@@ -1047,12 +1045,12 @@ func TestPrivilegedMultigatewayPolicy(t *testing.T) {
 	assertEgressRules6(t, policyMap6, ipV6ExpectedpolicyMap)
 
 	// Remove one endpoint and check that the remaining endpoints have not changed gateways.
-	deleteEndpointAndReconcile(t, egressGatewayManager, k.endpoints, eps[0].ep)
+	deleteEndpointAndReconcile(t, egressGatewayManager, nil, eps[0].ep)
 	assertEgressRules4(t, policyMap4, ipV4ExpectedpolicyMap[1:])
 	assertEgressRules6(t, policyMap6, ipV6ExpectedpolicyMap[1:])
 
 	// Add one endpoint and check the configuration went back to the previous state.
-	addEndpointAndReconcile(t, egressGatewayManager, k.endpoints, eps[0].ep)
+	addEndpointAndReconcile(t, egressGatewayManager, nil, eps[0].ep)
 	assertEgressRules4(t, policyMap4, ipV4ExpectedpolicyMap)
 	assertEgressRules6(t, policyMap6, ipV6ExpectedpolicyMap)
 
@@ -1178,6 +1176,11 @@ func newCiliumNode(name, nodeIP string, nodeLabels map[string]string) cilium_api
 }
 
 // Mock the creation of endpoint and its corresponding identity, returns endpoint and ID.
+//
+// The CiliumEndpoint's Identity.Labels field is populated with the K8s-form
+// labels so that the test's podendpointsource emulation (see
+// podEndpointFromCiliumEndpoint in helpers_test.go) can resolve them without
+// querying the identity allocator.
 func newEndpointAndIdentity(name, ipv4, ipv6 string, epLabels map[string]string) (k8sTypes.CiliumEndpoint, *identity.Identity) {
 	id, _, _ := identityAllocator.AllocateIdentity(context.Background(), labels.Map2Labels(epLabels, labels.LabelSourceK8s), true, identity.InvalidIdentity)
 
@@ -1187,7 +1190,8 @@ func newEndpointAndIdentity(name, ipv4, ipv6 string, epLabels map[string]string)
 			UID:  types.UID(uuid.New().String()),
 		},
 		Identity: &cilium_api_v2.EndpointIdentity{
-			ID: int64(id.ID),
+			ID:     int64(id.ID),
+			Labels: identityLabelsFor(epLabels),
 		},
 		Networking: &cilium_api_v2.EndpointNetworking{
 			Addressing: cilium_api_v2.AddressPairList{
@@ -1210,7 +1214,8 @@ func newEndpointAndIdentityWithNodeIP(name, ipv4, ipv6, nodeIP string, epLabels 
 			UID:  types.UID(uuid.New().String()),
 		},
 		Identity: &cilium_api_v2.EndpointIdentity{
-			ID: int64(id.ID),
+			ID:     int64(id.ID),
+			Labels: identityLabelsFor(epLabels),
 		},
 		Networking: &cilium_api_v2.EndpointNetworking{
 			Addressing: cilium_api_v2.AddressPairList{
@@ -1231,7 +1236,18 @@ func updateEndpointAndIdentity(endpoint *k8sTypes.CiliumEndpoint, oldID *identit
 	identityAllocator.Release(ctx, oldID, true)
 	newID, _, _ := identityAllocator.AllocateIdentity(ctx, labels.Map2Labels(newEpLabels, labels.LabelSourceK8s), true, identity.InvalidIdentity)
 	endpoint.Identity.ID = int64(newID.ID)
+	endpoint.Identity.Labels = identityLabelsFor(newEpLabels)
 	return newID
+}
+
+// identityLabelsFor renders a k8s label map as the "<source>:<key>=<value>"
+// slice that CiliumEndpoint.Identity.Labels contains in the real world.
+func identityLabelsFor(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k, v := range m {
+		out = append(out, "k8s:"+k+"="+v)
+	}
+	return out
 }
 
 func parseEgressRule(sourceIP, destCIDR, egressIP, gatewayIP string, egressIfindex uint32) parsedEgressRule {
@@ -1349,6 +1365,11 @@ func tryAssertEgressRules6(policyMap egressmap.PolicyMap6, rules []egressRule) e
 
 	return nil
 }
+
+// Note: remote-cluster filtering is now tested at the podendpointsource
+// layer (see pkg/podendpointsource/source_test.go:TestRemoteClusterIgnored).
+// The egress gateway manager never observes non-local endpoints because the
+// source filters them out before emitting.
 
 func assertRPFilter(t *testing.T, sysctl sysctl.Sysctl, rpFilterSettings []rpFilterSetting) {
 	t.Helper()

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -70,7 +70,7 @@ type PolicyConfig struct {
 	excludedCIDRs     []netip.Prefix
 	policyGwConfigs   []policyGatewayConfig
 	gatewayConfigs    []gatewayConfig
-	matchedEndpoints  map[endpointID]*endpointMetadata
+	matchedEndpoints  map[endpointKey]*endpointMetadata
 	v4Needed          bool
 	v6Needed          bool
 }
@@ -81,10 +81,8 @@ type policyID = types.NamespacedName
 // matchesEndpointLabels determines if the given endpoint is a match for the
 // policy config based on matching labels.
 func (config *PolicyConfig) matchesEndpointLabels(endpointInfo *endpointMetadata) bool {
-	labelsToMatch := labels.K8sSet(endpointInfo.labels)
-
 	for i := range config.endpointSelectors {
-		if policyTypes.Matches(config.endpointSelectors[i], labelsToMatch) {
+		if policyTypes.Matches(config.endpointSelectors[i], endpointInfo.labels) {
 			return true
 		}
 	}
@@ -106,12 +104,12 @@ func (config *PolicyConfig) matchesNodeLabels(nodeLabels map[string]string) bool
 	return false
 }
 
-// updateMatchedEndpointIDs update the policy's cache of matched endpoint IDs
-func (config *PolicyConfig) updateMatchedEndpointIDs(epDataStore map[endpointID]*endpointMetadata, nodesAddresses2Labels map[string]map[string]string) {
-	config.matchedEndpoints = make(map[endpointID]*endpointMetadata)
+// updateMatchedEndpointKeys refreshes the endpoints selected by this policy.
+func (config *PolicyConfig) updateMatchedEndpointKeys(epDataStore map[endpointKey]*endpointMetadata, nodesAddresses2Labels map[string]map[string]string) {
+	config.matchedEndpoints = make(map[endpointKey]*endpointMetadata)
 	for _, endpoint := range epDataStore {
 		if config.matchesEndpointLabels(endpoint) && config.matchesNodeLabels(nodesAddresses2Labels[endpoint.nodeIP]) {
-			config.matchedEndpoints[endpoint.id] = endpoint
+			config.matchedEndpoints[endpoint.key] = endpoint
 		}
 	}
 }
@@ -358,9 +356,9 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(manager *Manager, gc *po
 	return nil
 }
 
-func computeEndpointHash(endpointUID types.UID) uint32 {
+func computeEndpointHash(id endpointKey) uint32 {
 	h := fnv.New32a()
-	h.Write([]byte(endpointUID))
+	h.Write([]byte(id))
 	return h.Sum32()
 }
 
@@ -370,7 +368,7 @@ func computeEndpointHash(endpointUID types.UID) uint32 {
 // with a boolean value indicating if the CIDR belongs to the excluded ones and
 // the gatewayConfig of the receiver policy.
 // For multigateway policies the gateways are ordered by IP and paired with each
-// endpoint using the hash of the endpoint UID.
+// endpoint using the hash of the endpoint key.
 func (config *PolicyConfig) forEachEndpointAndCIDR(f func(netip.Addr, netip.Prefix, bool, *gatewayConfig)) {
 	// Sort gateways to get consistent assignments across nodes.
 	slices.SortFunc(config.gatewayConfigs, func(a, b gatewayConfig) int {
@@ -380,7 +378,7 @@ func (config *PolicyConfig) forEachEndpointAndCIDR(f func(netip.Addr, netip.Pref
 	for _, endpoint := range config.matchedEndpoints {
 		var gateway *gatewayConfig
 		if len(config.gatewayConfigs) > 1 {
-			index := computeEndpointHash(endpoint.id) % uint32(len(config.gatewayConfigs))
+			index := computeEndpointHash(endpoint.key) % uint32(len(config.gatewayConfigs))
 			gateway = &config.gatewayConfigs[index]
 		} else {
 			gateway = &config.gatewayConfigs[0]
@@ -538,7 +536,7 @@ func ParseCEGP(cegp *v2.CiliumEgressGatewayPolicy) (*PolicyConfig, error) {
 		nodeSelectors:     nodeSelectorList,
 		dstCIDRs:          dstCidrList,
 		excludedCIDRs:     excludedCIDRs,
-		matchedEndpoints:  make(map[endpointID]*endpointMetadata),
+		matchedEndpoints:  make(map[endpointKey]*endpointMetadata),
 		policyGwConfigs:   policyGwConfigs,
 		v4Needed:          v4Needed,
 		v6Needed:          v6Needed,

--- a/pkg/egressgateway/policy_test.go
+++ b/pkg/egressgateway/policy_test.go
@@ -23,7 +23,7 @@ func getAsPolicyLabelSelectors(k8sLss []*slimv1.LabelSelector) (lss []*policyTyp
 	return lss
 }
 
-func TestPolicyConfig_updateMatchedEndpointIDs(t *testing.T) {
+func TestPolicyConfig_updateMatchedEndpointKeys(t *testing.T) {
 	type fields struct {
 		id                types.NamespacedName
 		endpointSelectors []*slimv1.LabelSelector
@@ -31,22 +31,22 @@ func TestPolicyConfig_updateMatchedEndpointIDs(t *testing.T) {
 		dstCIDRs          []netip.Prefix
 		excludedCIDRs     []netip.Prefix
 		policyGwConfigs   []policyGatewayConfig
-		matchedEndpoints  map[endpointID]*endpointMetadata
+		matchedEndpoints  map[endpointKey]*endpointMetadata
 		gatewayConfigs    []gatewayConfig
 	}
 	type args struct {
-		epDataStore           map[endpointID]*endpointMetadata
+		epDataStore           map[endpointKey]*endpointMetadata
 		nodesAddresses2Labels map[string]map[string]string
 	}
 	tests := []struct {
-		name           string
-		fields         fields
-		args           args
-		want           int
-		wantEndpointID endpointID
+		name            string
+		fields          fields
+		args            args
+		want            int
+		wantEndpointKey endpointKey
 	}{
 		{
-			name: "Test updateMatchedEndpointIDs with endpoints and nodes",
+			name: "Test updateMatchedEndpointKeys with endpoints and nodes",
 			fields: fields{
 				id: types.NamespacedName{
 					Name: "test",
@@ -63,12 +63,12 @@ func TestPolicyConfig_updateMatchedEndpointIDs(t *testing.T) {
 				}},
 			},
 			args: args{
-				epDataStore: map[endpointID]*endpointMetadata{
+				epDataStore: map[endpointKey]*endpointMetadata{
 					"123456": {
-						id: "123456",
-						labels: map[string]string{
+						key: "123456",
+						labels: labels.Map2LabelArray(map[string]string{
 							"app": "test",
-						},
+						}, labels.LabelSourceK8s),
 						nodeIP: "192.168.1.10",
 					},
 				},
@@ -78,11 +78,11 @@ func TestPolicyConfig_updateMatchedEndpointIDs(t *testing.T) {
 					},
 				},
 			},
-			want:           1,
-			wantEndpointID: endpointID("123456"),
+			want:            1,
+			wantEndpointKey: endpointKey("123456"),
 		},
 		{
-			name: "Test updateMatchedEndpointIDs with namespaced endpoints and nodes",
+			name: "Test updateMatchedEndpointKeys with namespaced endpoints and nodes",
 			fields: fields{
 				id: types.NamespacedName{
 					Name: "test",
@@ -100,13 +100,13 @@ func TestPolicyConfig_updateMatchedEndpointIDs(t *testing.T) {
 				}},
 			},
 			args: args{
-				epDataStore: map[endpointID]*endpointMetadata{
+				epDataStore: map[endpointKey]*endpointMetadata{
 					"123456": {
-						id: "123456",
-						labels: map[string]string{
+						key: "123456",
+						labels: labels.Map2LabelArray(map[string]string{
 							"io.kubernetes.pod.namespace": "default",
 							"app":                         "test",
-						},
+						}, labels.LabelSourceK8s),
 						nodeIP: "192.168.1.10",
 					},
 				},
@@ -116,11 +116,11 @@ func TestPolicyConfig_updateMatchedEndpointIDs(t *testing.T) {
 					},
 				},
 			},
-			want:           1,
-			wantEndpointID: endpointID("123456"),
+			want:            1,
+			wantEndpointKey: endpointKey("123456"),
 		},
 		{
-			name: "Test updateMatchedEndpointIDs endpoints and nodes with no match",
+			name: "Test updateMatchedEndpointKeys endpoints and nodes with no match",
 			fields: fields{
 				id: types.NamespacedName{
 					Name: "test",
@@ -137,12 +137,12 @@ func TestPolicyConfig_updateMatchedEndpointIDs(t *testing.T) {
 				}},
 			},
 			args: args{
-				epDataStore: map[endpointID]*endpointMetadata{
+				epDataStore: map[endpointKey]*endpointMetadata{
 					"123456": {
-						id: "123456",
-						labels: map[string]string{
+						key: "123456",
+						labels: labels.Map2LabelArray(map[string]string{
 							"app": "test",
-						},
+						}, labels.LabelSourceK8s),
 						nodeIP: "192.168.1.10",
 					},
 				},
@@ -152,11 +152,11 @@ func TestPolicyConfig_updateMatchedEndpointIDs(t *testing.T) {
 					},
 				},
 			},
-			want:           0,
-			wantEndpointID: "",
+			want:            0,
+			wantEndpointKey: "",
 		},
 		{
-			name: "Test updateMatchedEndpointIDs endpoints and nodes with no match label",
+			name: "Test updateMatchedEndpointKeys endpoints and nodes with no match label",
 			fields: fields{
 				id: types.NamespacedName{
 					Name: "test",
@@ -173,12 +173,12 @@ func TestPolicyConfig_updateMatchedEndpointIDs(t *testing.T) {
 				}},
 			},
 			args: args{
-				epDataStore: map[endpointID]*endpointMetadata{
+				epDataStore: map[endpointKey]*endpointMetadata{
 					"123456": {
-						id: "123456",
-						labels: map[string]string{
+						key: "123456",
+						labels: labels.Map2LabelArray(map[string]string{
 							"app": "test",
-						},
+						}, labels.LabelSourceK8s),
 						nodeIP: "192.168.1.10",
 					},
 				},
@@ -188,8 +188,8 @@ func TestPolicyConfig_updateMatchedEndpointIDs(t *testing.T) {
 					},
 				},
 			},
-			want:           0,
-			wantEndpointID: "",
+			want:            0,
+			wantEndpointKey: "",
 		},
 	}
 	for _, tt := range tests {
@@ -204,10 +204,10 @@ func TestPolicyConfig_updateMatchedEndpointIDs(t *testing.T) {
 				matchedEndpoints:  tt.fields.matchedEndpoints,
 				gatewayConfigs:    tt.fields.gatewayConfigs,
 			}
-			config.updateMatchedEndpointIDs(tt.args.epDataStore, tt.args.nodesAddresses2Labels)
+			config.updateMatchedEndpointKeys(tt.args.epDataStore, tt.args.nodesAddresses2Labels)
 			assert.Len(t, config.matchedEndpoints, tt.want)
 			if tt.want > 0 {
-				assert.Contains(t, config.matchedEndpoints, endpointID(tt.wantEndpointID))
+				assert.Contains(t, config.matchedEndpoints, endpointKey(tt.wantEndpointKey))
 			}
 		})
 	}

--- a/pkg/podendpointsource/cell.go
+++ b/pkg/podendpointsource/cell.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// Package podendpointsource turns IPCache pod entries into local-cluster
+// per-pod events with IPs, node IP, and identity labels.
+package podendpointsource
+
+import (
+	"github.com/cilium/hive/cell"
+)
+
+// Cell provides a [Source] backed by IPCache.
+var Cell = cell.Module(
+	"pod-endpoint-source",
+	"Observes pod endpoints from the IPCache and exposes them as a stream",
+
+	cell.Provide(newSource),
+)

--- a/pkg/podendpointsource/cell_test.go
+++ b/pkg/podendpointsource/cell_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package podendpointsource
+
+import (
+	"testing"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/identity"
+	identityCache "github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
+)
+
+// TestCell verifies that the cell can be populated with a minimal set of
+// external dependencies. The lifecycle hook (AddListener,
+// WaitForInitialGlobalIdentities) is not exercised here; it runs only when
+// the hive is Start()-ed. Populate is enough to catch wiring regressions.
+func TestCell(t *testing.T) {
+	logger := hivetest.Logger(t)
+
+	err := hive.New(
+		Cell,
+		cell.Provide(
+			func() identityCache.IdentityAllocator {
+				return testidentity.NewMockIdentityAllocator(nil)
+			},
+			func() *ipcache.IPCache {
+				return ipcache.NewIPCache(&ipcache.Configuration{
+					Context:           t.Context(),
+					Logger:            logger,
+					IdentityAllocator: testidentity.NewMockIdentityAllocator(nil),
+					IdentityUpdater:   &noopIdentityUpdater{},
+				})
+			},
+		),
+	).Populate(logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// noopIdentityUpdater satisfies the ipcachetypes.IdentityUpdater contract
+// required by the IPCache constructor without performing any work.
+type noopIdentityUpdater struct{}
+
+func (*noopIdentityUpdater) UpdateIdentities(_, _ identity.IdentityMap) <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}

--- a/pkg/podendpointsource/source.go
+++ b/pkg/podendpointsource/source.go
@@ -1,0 +1,357 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package podendpointsource
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"net/netip"
+	"slices"
+	"sync/atomic"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/stream"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/identity"
+	identityCache "github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// Source exposes local-cluster pod endpoints as per-pod [Event]s.
+//
+// It filters IPCache updates down to local-cluster single-IP entries with pod
+// metadata, resolves identity labels, and replays current state to new
+// subscribers before live updates.
+type Source interface {
+	stream.Observable[Event]
+}
+
+// queueSize absorbs short IPCache update bursts without dropping events.
+const queueSize = 4096
+
+// callbackEvent contains only the IPCache fields needed after the callback
+// returns. For deletes, metadata identifies the previous owner.
+type callbackEvent struct {
+	modType ipcache.CacheModification
+	addr    netip.Addr
+	newID   identity.NumericIdentity
+	hostIP  string
+
+	namespace string
+	podName   string
+	hasMeta   bool
+}
+
+// source is the default [Source] implementation backed by an IPCache
+// listener.
+type source struct {
+	logger *slog.Logger
+
+	identityAllocator identityCache.IdentityAllocator
+
+	// queue is bounded; the IPCache callback blocks when it is full.
+	queue chan callbackEvent
+
+	// mu protects Observe replay against the single writer goroutine.
+	mu        lock.RWMutex
+	endpoints map[string]*PodEndpoint
+	ipToKey   map[netip.Addr]string
+
+	observable stream.Observable[Event]
+	emit       func(Event)
+	complete   func(error)
+
+	queueWasFull atomic.Bool
+}
+
+type params struct {
+	cell.In
+
+	Logger            *slog.Logger
+	Lifecycle         cell.Lifecycle
+	JobGroup          job.Group
+	IPCache           *ipcache.IPCache
+	IdentityAllocator identityCache.IdentityAllocator
+}
+
+func newSource(p params) Source {
+	s := &source{
+		logger:            p.Logger,
+		identityAllocator: p.IdentityAllocator,
+		queue:             make(chan callbackEvent, queueSize),
+		endpoints:         map[string]*PodEndpoint{},
+		ipToKey:           map[netip.Addr]string{},
+	}
+	s.observable, s.emit, s.complete = stream.Multicast[Event]()
+
+	// Run the consumer goroutine for the lifetime of the cell.
+	p.JobGroup.Add(job.OneShot("pod-endpoint-source", s.run))
+
+	// Wait here rather than in OnStart; the identity allocator warms up
+	// from other lifecycle hooks.
+	p.JobGroup.Add(job.OneShot(
+		"pod-endpoint-listener-registration",
+		func(ctx context.Context, _ cell.Health) error {
+			if err := p.IdentityAllocator.WaitForInitialGlobalIdentities(ctx); err != nil {
+				return err
+			}
+			p.IPCache.AddListener(s)
+			return nil
+		},
+	))
+
+	p.Lifecycle.Append(cell.Hook{
+		OnStop: func(cell.HookContext) error {
+			s.complete(nil)
+			return nil
+		},
+	})
+
+	return s
+}
+
+// Observe replays current endpoints as Upsert events, then streams live
+// updates.
+func (s *source) Observe(ctx context.Context, next func(Event), complete func(error)) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for _, ep := range s.endpoints {
+		select {
+		case <-ctx.Done():
+			complete(ctx.Err())
+			return
+		default:
+		}
+		next(Event{Kind: EventKindUpsert, Endpoint: cloneEndpoint(ep)})
+	}
+
+	s.observable.Observe(ctx, next, complete)
+}
+
+// OnIPIdentityCacheChange implements [ipcache.IPIdentityMappingListener].
+//
+// The listener runs with the IPCache lock held; keep it to cheap filtering
+// and enqueueing.
+func (s *source) OnIPIdentityCacheChange(
+	modType ipcache.CacheModification,
+	cidrCluster cmtypes.PrefixCluster,
+	_ net.IP, newHostIP net.IP,
+	_ *ipcache.Identity, newID ipcache.Identity,
+	_ uint8,
+	k8sMeta *ipcache.K8sMetadata,
+	_ uint8,
+) {
+	// namespace/podName is only unique within the local cluster.
+	if cidrCluster.ClusterID() != 0 {
+		return
+	}
+
+	prefix := cidrCluster.AsPrefix()
+	addr := prefix.Addr()
+	if !addr.IsValid() || !cidrCluster.IsSingleIP() {
+		return
+	}
+
+	ev := callbackEvent{
+		modType: modType,
+		addr:    addr,
+		newID:   newID.ID,
+	}
+	if newHostIP != nil {
+		ev.hostIP = newHostIP.String()
+	}
+	if k8sMeta != nil && k8sMeta.Namespace != "" && k8sMeta.PodName != "" {
+		ev.namespace = k8sMeta.Namespace
+		ev.podName = k8sMeta.PodName
+		ev.hasMeta = true
+	}
+
+	select {
+	case s.queue <- ev:
+	default:
+		s.queueWasFull.Store(true)
+		s.queue <- ev
+	}
+}
+
+// run consumes events from the queue until ctx is cancelled.
+func (s *source) run(ctx context.Context, health cell.Health) error {
+	if health != nil {
+		health.OK("Running")
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case ev := <-s.queue:
+			wasFull := s.queueWasFull.Swap(false)
+			if wasFull && health != nil {
+				health.Degraded("Event queue full; IPCache listener blocked", nil)
+			}
+			s.handleEvent(ctx, ev)
+			if !wasFull && len(s.queue) == 0 && health != nil {
+				health.OK("Running")
+			}
+		}
+	}
+}
+
+func (s *source) handleEvent(ctx context.Context, ev callbackEvent) {
+	switch ev.modType {
+	case ipcache.Upsert:
+		if ev.hasMeta {
+			s.upsertPodIP(ctx, ev)
+		} else {
+			// A single-IP entry can lose pod metadata during replacement.
+			s.evictIP(ev.addr)
+		}
+	case ipcache.Delete:
+		if ev.hasMeta {
+			// Ignore stale deletes after pod-to-pod IP reassignment.
+			s.evictIPForPod(ev.addr, ev.namespace+"/"+ev.podName)
+		} else {
+			s.evictIP(ev.addr)
+		}
+	}
+}
+
+// upsertPodIP applies a pod IP add, update, or reassignment.
+func (s *source) upsertPodIP(ctx context.Context, ev callbackEvent) {
+	podKey := ev.namespace + "/" + ev.podName
+
+	labels, identityOK := s.lookupIdentityLabels(ctx, ev.newID)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if prevKey, owned := s.ipToKey[ev.addr]; owned && prevKey != podKey {
+		if evicted := s.removeIPLocked(prevKey, ev.addr); evicted != nil {
+			s.emit(*evicted)
+		}
+	}
+
+	ep, exists := s.endpoints[podKey]
+	if !identityOK {
+		if !exists {
+			s.logger.Debug(
+				"Skipping pod endpoint upsert: identity not resolvable",
+				logfields.Identity, ev.newID,
+				logfields.K8sNamespace, ev.namespace,
+				logfields.K8sPodName, ev.podName,
+			)
+			return
+		}
+		labels = ep.Labels
+		s.logger.Debug(
+			"Preserving last-known labels for pod endpoint: identity not resolvable",
+			logfields.Identity, ev.newID,
+			logfields.K8sNamespace, ev.namespace,
+			logfields.K8sPodName, ev.podName,
+		)
+	}
+
+	if !exists {
+		ep = &PodEndpoint{
+			Key:    podKey,
+			IPs:    []netip.Addr{ev.addr},
+			Labels: labels,
+			NodeIP: ev.hostIP,
+		}
+		s.endpoints[podKey] = ep
+	} else {
+		ep.Labels = labels
+		ep.NodeIP = ev.hostIP
+		if !slices.Contains(ep.IPs, ev.addr) {
+			ep.IPs = append(ep.IPs, ev.addr)
+			sortIPs(ep.IPs)
+		}
+	}
+	s.ipToKey[ev.addr] = podKey
+
+	s.emit(Event{Kind: EventKindUpsert, Endpoint: cloneEndpoint(ep)})
+}
+
+// evictIP drops an IP from whichever endpoint currently owns it.
+func (s *source) evictIP(addr netip.Addr) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	prevKey, owned := s.ipToKey[addr]
+	if !owned {
+		return
+	}
+	if ev := s.removeIPLocked(prevKey, addr); ev != nil {
+		s.emit(*ev)
+	}
+}
+
+// evictIPForPod drops an IP only if the given pod still owns it.
+func (s *source) evictIPForPod(addr netip.Addr, podKey string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	prevKey, owned := s.ipToKey[addr]
+	if !owned || prevKey != podKey {
+		return
+	}
+	if ev := s.removeIPLocked(prevKey, addr); ev != nil {
+		s.emit(*ev)
+	}
+}
+
+// removeIPLocked removes addr and returns the event to emit. s.mu must be held.
+func (s *source) removeIPLocked(podKey string, addr netip.Addr) *Event {
+	delete(s.ipToKey, addr)
+
+	ep, ok := s.endpoints[podKey]
+	if !ok {
+		return nil
+	}
+	ep.IPs = slices.DeleteFunc(ep.IPs, func(a netip.Addr) bool { return a == addr })
+	if len(ep.IPs) == 0 {
+		delete(s.endpoints, podKey)
+		return &Event{
+			Kind:     EventKindDelete,
+			Endpoint: PodEndpoint{Key: podKey},
+		}
+	}
+	return &Event{Kind: EventKindUpsert, Endpoint: cloneEndpoint(ep)}
+}
+
+// lookupIdentityLabels resolves an identity ID to identity labels.
+func (s *source) lookupIdentityLabels(ctx context.Context, id identity.NumericIdentity) (labels.LabelArray, bool) {
+	ident := s.identityAllocator.LookupIdentityByID(ctx, id)
+	if ident == nil {
+		return nil, false
+	}
+	return ident.Labels.LabelArray(), true
+}
+
+// cloneEndpoint returns an event snapshot detached from source state.
+func cloneEndpoint(ep *PodEndpoint) PodEndpoint {
+	out := PodEndpoint{
+		Key:    ep.Key,
+		NodeIP: ep.NodeIP,
+		IPs:    slices.Clone(ep.IPs),
+		Labels: slices.Clone(ep.Labels),
+	}
+	return out
+}
+
+func sortIPs(ips []netip.Addr) {
+	slices.SortFunc(ips, netip.Addr.Compare)
+}
+
+// Ensure interface satisfaction at compile time.
+var (
+	_ ipcache.IPIdentityMappingListener = (*source)(nil)
+	_ Source                            = (*source)(nil)
+)

--- a/pkg/podendpointsource/source_test.go
+++ b/pkg/podendpointsource/source_test.go
@@ -1,0 +1,581 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package podendpointsource
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/stream"
+	"github.com/stretchr/testify/require"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/lock"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
+)
+
+// newTestSource constructs a source without hive/IPCache/job wiring so that
+// unit tests can drive OnIPIdentityCacheChange directly and observe emitted
+// events. The caller is responsible for stopping the source via the returned
+// cancel func.
+func newTestSource(t *testing.T) (s *source, stop func()) {
+	t.Helper()
+
+	allocator := testidentity.NewMockIdentityAllocator(nil)
+	s = &source{
+		logger:            hivetest.Logger(t),
+		identityAllocator: allocator,
+		queue:             make(chan callbackEvent, queueSize),
+		endpoints:         map[string]*PodEndpoint{},
+		ipToKey:           map[netip.Addr]string{},
+	}
+	s.observable, s.emit, s.complete = stream.Multicast[Event]()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		_ = s.run(ctx, nil)
+		close(done)
+	}()
+
+	stop = func() {
+		cancel()
+		<-done
+		s.complete(nil)
+	}
+	return s, stop
+}
+
+// allocateIdentity creates an identity in the mock allocator so that the
+// source's lookupIdentityLabels can resolve it. Returns the numeric ID.
+func allocateIdentity(t *testing.T, s *source, lbls map[string]string) identity.NumericIdentity {
+	t.Helper()
+	alloc := s.identityAllocator.(*testidentity.MockIdentityAllocator)
+	id, _, err := alloc.AllocateIdentity(context.Background(), labels.Map2Labels(lbls, labels.LabelSourceK8s), false, 0)
+	require.NoError(t, err)
+	return id.ID
+}
+
+func requireK8sLabels(t *testing.T, got labels.LabelArray, want map[string]string) {
+	t.Helper()
+	require.Equal(t, want, got.K8sStringMap())
+}
+
+type recordingHealth struct {
+	lock.Mutex
+	degraded bool
+}
+
+func (h *recordingHealth) OK(string) {}
+
+func (h *recordingHealth) Stopped(string) {}
+
+func (h *recordingHealth) Degraded(string, error) {
+	h.Lock()
+	defer h.Unlock()
+	h.degraded = true
+}
+
+func (h *recordingHealth) NewScope(string) cell.Health { return h }
+
+func (h *recordingHealth) Close() {}
+
+func (h *recordingHealth) isDegraded() bool {
+	h.Lock()
+	defer h.Unlock()
+	return h.degraded
+}
+
+// subscribe returns a channel that receives events emitted by s after the
+// call returns. The subscription is cancelled when the test ends.
+func subscribe(t *testing.T, s *source) <-chan Event {
+	t.Helper()
+	ch := make(chan Event, 64)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	done := make(chan struct{})
+	go func() {
+		s.Observe(ctx, func(ev Event) { ch <- ev }, func(error) { close(done) })
+	}()
+	return ch
+}
+
+// waitForEvent reads one event with a timeout.
+func waitForEvent(t *testing.T, ch <-chan Event) Event {
+	t.Helper()
+	select {
+	case ev := <-ch:
+		return ev
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for event")
+		return Event{}
+	}
+}
+
+// drainFor drains events from ch until no event arrives for idleFor. This is
+// used when a single IPCache change is expected to produce a fixed small
+// number of events and we want the entire sequence.
+func drainFor(ch <-chan Event, idleFor time.Duration) []Event {
+	var out []Event
+	for {
+		select {
+		case ev := <-ch:
+			out = append(out, ev)
+		case <-time.After(idleFor):
+			return out
+		}
+	}
+}
+
+func mustAddr(s string) netip.Addr {
+	a, err := netip.ParseAddr(s)
+	if err != nil {
+		panic(err)
+	}
+	return a
+}
+
+func prefixCluster(addr netip.Addr, bits int, clusterID uint32) cmtypes.PrefixCluster {
+	return cmtypes.PrefixClusterFrom(
+		netip.PrefixFrom(addr, bits),
+		cmtypes.WithClusterID(clusterID),
+	)
+}
+
+func pushUpsert(s *source, addr netip.Addr, bits int, clusterID uint32,
+	id identity.NumericIdentity, namespace, podName string, hostIP string,
+) {
+	var k8sMeta *ipcache.K8sMetadata
+	if namespace != "" || podName != "" {
+		k8sMeta = &ipcache.K8sMetadata{Namespace: namespace, PodName: podName}
+	}
+	var hostIPnet net.IP
+	if hostIP != "" {
+		hostIPnet = net.ParseIP(hostIP)
+	}
+	s.OnIPIdentityCacheChange(
+		ipcache.Upsert,
+		prefixCluster(addr, bits, clusterID),
+		nil, hostIPnet,
+		nil, ipcache.Identity{ID: id},
+		0, k8sMeta, 0,
+	)
+}
+
+func pushDelete(s *source, addr netip.Addr, bits int, clusterID uint32,
+	namespace, podName string,
+) {
+	var k8sMeta *ipcache.K8sMetadata
+	if namespace != "" || podName != "" {
+		k8sMeta = &ipcache.K8sMetadata{Namespace: namespace, PodName: podName}
+	}
+	s.OnIPIdentityCacheChange(
+		ipcache.Delete,
+		prefixCluster(addr, bits, clusterID),
+		nil, nil,
+		nil, ipcache.Identity{},
+		0, k8sMeta, 0,
+	)
+}
+
+// TestPrefixFilter verifies that only /32 and /128 entries are accepted.
+func TestPrefixFilter(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	id := allocateIdentity(t, s, map[string]string{"app": "test"})
+	ch := subscribe(t, s)
+
+	// /24 rejected.
+	pushUpsert(s, mustAddr("10.0.0.0"), 24, 0, id, "default", "pod", "192.168.1.1")
+	// /64 rejected.
+	pushUpsert(s, mustAddr("fd00::"), 64, 0, id, "default", "pod", "192.168.1.1")
+	// /32 accepted.
+	pushUpsert(s, mustAddr("10.0.0.1"), 32, 0, id, "default", "pod", "192.168.1.1")
+
+	ev := waitForEvent(t, ch)
+	require.Equal(t, EventKindUpsert, ev.Kind)
+	require.Equal(t, "default/pod", ev.Endpoint.Key)
+	require.Equal(t, []netip.Addr{mustAddr("10.0.0.1")}, ev.Endpoint.IPs)
+
+	// No further events should have fired from the rejected prefixes.
+	require.Empty(t, drainFor(ch, 100*time.Millisecond))
+}
+
+// TestIPv128Accepted verifies that /128 prefixes are accepted.
+func TestIPv128Accepted(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	id := allocateIdentity(t, s, map[string]string{"app": "v6"})
+	ch := subscribe(t, s)
+
+	pushUpsert(s, mustAddr("fd00::1"), 128, 0, id, "default", "v6pod", "192.168.1.1")
+
+	ev := waitForEvent(t, ch)
+	require.Equal(t, EventKindUpsert, ev.Kind)
+	require.Equal(t, []netip.Addr{mustAddr("fd00::1")}, ev.Endpoint.IPs)
+}
+
+// TestRemoteClusterIgnored verifies that entries from remote clustermesh
+// clusters are not processed.
+func TestRemoteClusterIgnored(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	id := allocateIdentity(t, s, map[string]string{"app": "remote"})
+	ch := subscribe(t, s)
+
+	pushUpsert(s, mustAddr("10.0.0.99"), 32, 2, id, "default", "remote", "192.168.1.1")
+	require.Empty(t, drainFor(ch, 100*time.Millisecond))
+
+	// The same IP from the local cluster should still be processed.
+	pushUpsert(s, mustAddr("10.0.0.99"), 32, 0, id, "default", "local", "192.168.1.1")
+	ev := waitForEvent(t, ch)
+	require.Equal(t, "default/local", ev.Endpoint.Key)
+}
+
+// TestUpsertAndDelete covers the basic lifecycle of a pod endpoint.
+func TestUpsertAndDelete(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	id := allocateIdentity(t, s, map[string]string{"app": "web"})
+	ch := subscribe(t, s)
+
+	pushUpsert(s, mustAddr("10.0.0.1"), 32, 0, id, "default", "web", "192.168.1.1")
+	ev := waitForEvent(t, ch)
+	require.Equal(t, EventKindUpsert, ev.Kind)
+	require.Equal(t, "default/web", ev.Endpoint.Key)
+	requireK8sLabels(t, ev.Endpoint.Labels, map[string]string{"app": "web"})
+	require.Equal(t, "192.168.1.1", ev.Endpoint.NodeIP)
+
+	pushDelete(s, mustAddr("10.0.0.1"), 32, 0, "default", "web")
+	ev = waitForEvent(t, ch)
+	require.Equal(t, EventKindDelete, ev.Kind)
+	require.Equal(t, "default/web", ev.Endpoint.Key)
+}
+
+// TestIPOrdering verifies IPs are sorted IPv4-first then numeric within each
+// family, regardless of insertion order.
+func TestIPOrdering(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	id := allocateIdentity(t, s, map[string]string{"app": "dual"})
+	ch := subscribe(t, s)
+
+	// Push an IPv6 first, then two IPv4s out of numeric order.
+	pushUpsert(s, mustAddr("fd00::10"), 128, 0, id, "default", "dual", "192.168.1.1")
+	<-ch
+	pushUpsert(s, mustAddr("10.0.0.2"), 32, 0, id, "default", "dual", "192.168.1.1")
+	<-ch
+	pushUpsert(s, mustAddr("10.0.0.1"), 32, 0, id, "default", "dual", "192.168.1.1")
+	ev := waitForEvent(t, ch)
+
+	require.Equal(t, []netip.Addr{
+		mustAddr("10.0.0.1"),
+		mustAddr("10.0.0.2"),
+		mustAddr("fd00::10"),
+	}, ev.Endpoint.IPs)
+}
+
+// TestIPReassignmentBetweenPods covers the O2 leak scenario where an IP is
+// reclaimed by a different pod before the original pod's Delete arrives,
+// and additionally verifies that a subsequently-arriving stale Delete for
+// the original pod does not clobber the new pod.
+func TestIPReassignmentBetweenPods(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	idA := allocateIdentity(t, s, map[string]string{"app": "a"})
+	idB := allocateIdentity(t, s, map[string]string{"app": "b"})
+	ch := subscribe(t, s)
+
+	addr := mustAddr("10.0.0.5")
+
+	pushUpsert(s, addr, 32, 0, idA, "default", "pod-a", "192.168.1.1")
+	ev := waitForEvent(t, ch)
+	require.Equal(t, "default/pod-a", ev.Endpoint.Key)
+
+	// Reassign the same IP before the old Delete arrives.
+	pushUpsert(s, addr, 32, 0, idB, "default", "pod-b", "192.168.1.1")
+	events := drainFor(ch, 200*time.Millisecond)
+	require.Len(t, events, 2, "expected eviction + upsert, got %v", events)
+
+	require.Equal(t, EventKindDelete, events[0].Kind)
+	require.Equal(t, "default/pod-a", events[0].Endpoint.Key)
+
+	require.Equal(t, EventKindUpsert, events[1].Kind)
+	require.Equal(t, "default/pod-b", events[1].Endpoint.Key)
+	require.Equal(t, []netip.Addr{addr}, events[1].Endpoint.IPs)
+
+	// Stale Delete for pod-a must not evict the current owner.
+	pushDelete(s, addr, 32, 0, "default", "pod-a")
+	require.Empty(t, drainFor(ch, 200*time.Millisecond),
+		"stale delete for pod-a must not evict pod-b or emit any event")
+
+	s.mu.RLock()
+	remaining, ok := s.endpoints["default/pod-b"]
+	owner, owned := s.ipToKey[addr]
+	s.mu.RUnlock()
+	require.True(t, ok, "pod-b must still exist after stale delete for pod-a")
+	require.Equal(t, []netip.Addr{addr}, remaining.IPs)
+	require.True(t, owned)
+	require.Equal(t, "default/pod-b", owner)
+}
+
+// TestDeleteOwnershipCheckForUnrelatedPod is the direct regression test for
+// the stale-Delete ownership bug: IPCache emits a Delete whose oldK8sMeta
+// identifies a pod that no longer owns the IP, and the source must ignore
+// it.
+func TestDeleteOwnershipCheckForUnrelatedPod(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	id := allocateIdentity(t, s, map[string]string{"app": "owner"})
+	ch := subscribe(t, s)
+
+	addr := mustAddr("10.0.0.42")
+	pushUpsert(s, addr, 32, 0, id, "ns", "owner", "192.168.1.1")
+	ev := waitForEvent(t, ch)
+	require.Equal(t, "ns/owner", ev.Endpoint.Key)
+
+	// Delete for an unrelated pod must not affect the current owner.
+	pushDelete(s, addr, 32, 0, "other-ns", "ghost")
+	require.Empty(t, drainFor(ch, 150*time.Millisecond),
+		"delete targeted at an unrelated pod must be a no-op")
+
+	s.mu.RLock()
+	_, stillThere := s.endpoints["ns/owner"]
+	owner := s.ipToKey[addr]
+	s.mu.RUnlock()
+	require.True(t, stillThere)
+	require.Equal(t, "ns/owner", owner)
+
+	// A correctly-targeted Delete still evicts the pod.
+	pushDelete(s, addr, 32, 0, "ns", "owner")
+	ev = waitForEvent(t, ch)
+	require.Equal(t, EventKindDelete, ev.Kind)
+	require.Equal(t, "ns/owner", ev.Endpoint.Key)
+}
+
+// TestUpsertWithoutMetaEvictsExistingIP covers a single-IP entry that loses
+// pod metadata.
+func TestUpsertWithoutMetaEvictsExistingIP(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	id := allocateIdentity(t, s, map[string]string{"app": "x"})
+	ch := subscribe(t, s)
+
+	addr := mustAddr("10.0.0.7")
+	pushUpsert(s, addr, 32, 0, id, "default", "pod-x", "192.168.1.1")
+	<-ch
+
+	// The same single-IP entry is re-upserted without pod metadata.
+	pushUpsert(s, addr, 32, 0, identity.ReservedIdentityWorld, "", "", "")
+	ev := waitForEvent(t, ch)
+	require.Equal(t, EventKindDelete, ev.Kind)
+	require.Equal(t, "default/pod-x", ev.Endpoint.Key)
+
+	// The source's internal mirror must agree.
+	s.mu.RLock()
+	_, exists := s.endpoints["default/pod-x"]
+	_, owned := s.ipToKey[addr]
+	s.mu.RUnlock()
+	require.False(t, exists)
+	require.False(t, owned)
+}
+
+// TestMultipleIPsPartialDelete checks that deleting one of two IPs from an
+// endpoint emits an Upsert (not a Delete) with the remaining IP.
+func TestMultipleIPsPartialDelete(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	id := allocateIdentity(t, s, map[string]string{"app": "multi"})
+	ch := subscribe(t, s)
+
+	v4 := mustAddr("10.0.0.8")
+	v6 := mustAddr("fd00::8")
+
+	pushUpsert(s, v4, 32, 0, id, "default", "multi", "192.168.1.1")
+	<-ch
+	pushUpsert(s, v6, 128, 0, id, "default", "multi", "192.168.1.1")
+	<-ch
+
+	pushDelete(s, v4, 32, 0, "default", "multi")
+	ev := waitForEvent(t, ch)
+	require.Equal(t, EventKindUpsert, ev.Kind)
+	require.Equal(t, []netip.Addr{v6}, ev.Endpoint.IPs)
+
+	pushDelete(s, v6, 128, 0, "default", "multi")
+	ev = waitForEvent(t, ch)
+	require.Equal(t, EventKindDelete, ev.Kind)
+}
+
+// TestNilIdentityOnExistingEndpointPreservesLabels covers T2: when a later
+// Upsert arrives with an identity that cannot be resolved, the endpoint's
+// existing labels are preserved rather than being wiped.
+func TestNilIdentityOnExistingEndpointPreservesLabels(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	id := allocateIdentity(t, s, map[string]string{"app": "stable"})
+	ch := subscribe(t, s)
+
+	addr := mustAddr("10.0.0.9")
+	pushUpsert(s, addr, 32, 0, id, "default", "stable", "192.168.1.1")
+	ev := waitForEvent(t, ch)
+	requireK8sLabels(t, ev.Endpoint.Labels, map[string]string{"app": "stable"})
+
+	// Push an Upsert for a numeric identity that was never allocated;
+	// the mock allocator returns nil for unknown IDs.
+	unresolved := identity.NumericIdentity(9_999_999)
+	pushUpsert(s, addr, 32, 0, unresolved, "default", "stable", "192.168.2.2")
+	ev = waitForEvent(t, ch)
+	requireK8sLabels(t, ev.Endpoint.Labels, map[string]string{"app": "stable"})
+	require.Equal(t, "192.168.2.2", ev.Endpoint.NodeIP)
+}
+
+// TestNilIdentityOnNewEndpointIsSkipped verifies that an Upsert for a pod
+// we have not seen before, with an unresolvable identity, is dropped rather
+// than creating a degenerate entry.
+func TestNilIdentityOnNewEndpointIsSkipped(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	ch := subscribe(t, s)
+
+	unresolved := identity.NumericIdentity(9_999_999)
+	pushUpsert(s, mustAddr("10.0.0.10"), 32, 0, unresolved, "default", "ghost", "192.168.1.1")
+	require.Empty(t, drainFor(ch, 100*time.Millisecond))
+
+	s.mu.RLock()
+	_, exists := s.endpoints["default/ghost"]
+	s.mu.RUnlock()
+	require.False(t, exists)
+}
+
+// TestObserveReplaysCurrentState verifies that a subscriber joining after
+// some upserts have been processed receives them as Upsert events on
+// subscription.
+func TestObserveReplaysCurrentState(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	id := allocateIdentity(t, s, map[string]string{"app": "r"})
+
+	pushUpsert(s, mustAddr("10.0.0.20"), 32, 0, id, "default", "r1", "192.168.1.1")
+	pushUpsert(s, mustAddr("10.0.0.21"), 32, 0, id, "default", "r2", "192.168.1.1")
+
+	// Give the consumer time to process both events before subscribing.
+	require.Eventually(t, func() bool {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		return len(s.endpoints) == 2
+	}, time.Second, 10*time.Millisecond)
+
+	ch := subscribe(t, s)
+	events := drainFor(ch, 200*time.Millisecond)
+	require.Len(t, events, 2)
+
+	ids := map[string]bool{}
+	for _, ev := range events {
+		require.Equal(t, EventKindUpsert, ev.Kind)
+		ids[ev.Endpoint.Key] = true
+	}
+	require.True(t, ids["default/r1"])
+	require.True(t, ids["default/r2"])
+}
+
+func TestQueueFullReportsHealth(t *testing.T) {
+	s := &source{
+		queue:     make(chan callbackEvent, 1),
+		endpoints: map[string]*PodEndpoint{},
+		ipToKey:   map[netip.Addr]string{},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	health := &recordingHealth{}
+	done := make(chan error, 1)
+	go func() {
+		done <- s.run(ctx, health)
+	}()
+
+	s.queueWasFull.Store(true)
+	s.queue <- callbackEvent{modType: ipcache.Delete, addr: mustAddr("10.0.0.1")}
+
+	require.Eventually(t, health.isDegraded, time.Second, 10*time.Millisecond)
+	cancel()
+	require.NoError(t, <-done)
+}
+
+// TestConcurrentIPCacheEvents stresses the queue path with many concurrent
+// OnIPIdentityCacheChange callers and verifies that the consumer drains
+// them all without data races. Run with `go test -race`.
+func TestConcurrentIPCacheEvents(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	id := allocateIdentity(t, s, map[string]string{"app": "stress"})
+
+	const pods = 50
+	var wg sync.WaitGroup
+	for i := range pods {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			addr := netip.AddrFrom4([4]byte{10, 0, byte(i >> 8), byte(i)})
+			pushUpsert(s, addr, 32, 0, id, "default", "pod", "192.168.1.1")
+			pushDelete(s, addr, 32, 0, "default", "pod")
+		}(i)
+	}
+	wg.Wait()
+
+	// Every pod shares the same name so the final state is either
+	// "pod" with no IPs (so the entry is gone) or with some subset of
+	// IPs, but never panics.
+	require.Eventually(t, func() bool {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		return len(s.queue) == 0
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+// TestCloneEndpointIsolatesSubscribers ensures that mutating the labels or
+// IPs of a received event does not corrupt the source's internal state.
+func TestCloneEndpointIsolatesSubscribers(t *testing.T) {
+	s, stop := newTestSource(t)
+	defer stop()
+
+	id := allocateIdentity(t, s, map[string]string{"app": "iso"})
+	ch := subscribe(t, s)
+
+	pushUpsert(s, mustAddr("10.0.0.50"), 32, 0, id, "default", "iso", "192.168.1.1")
+	ev := waitForEvent(t, ch)
+
+	// Mutate the received event payload.
+	ev.Endpoint.Labels[0] = labels.NewLabel("evil", "mutation", labels.LabelSourceK8s)
+	ev.Endpoint.IPs[0] = mustAddr("127.0.0.1")
+
+	// Internal state must be unaffected.
+	s.mu.RLock()
+	internal := s.endpoints["default/iso"]
+	s.mu.RUnlock()
+	require.NotContains(t, internal.Labels.K8sStringMap(), "evil")
+	require.Equal(t, mustAddr("10.0.0.50"), internal.IPs[0])
+}

--- a/pkg/podendpointsource/types.go
+++ b/pkg/podendpointsource/types.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package podendpointsource
+
+import (
+	"net/netip"
+
+	"github.com/cilium/cilium/pkg/labels"
+)
+
+// EventKind describes the kind of change an Event carries.
+type EventKind int
+
+const (
+	// EventKindUpsert signals that a pod endpoint was added or updated.
+	//
+	// Consumers may replace any cached copy keyed by Endpoint.Key.
+	EventKindUpsert EventKind = iota
+
+	// EventKindDelete signals that a pod endpoint was removed.
+	//
+	// The PodEndpoint field identifies the deleted endpoint by Key; its
+	// other fields are best-effort and MUST NOT be relied upon.
+	EventKindDelete
+)
+
+// PodEndpoint is a snapshot of a pod endpoint assembled from IPCache state.
+//
+// A PodEndpoint is uniquely identified by Key (namespace/podName). Consumers
+// should treat all fields as immutable.
+type PodEndpoint struct {
+	// Key is "namespace/podName".
+	Key string
+
+	// IPs are sorted by netip.Addr.Compare.
+	IPs []netip.Addr
+
+	// Labels are the endpoint's identity labels.
+	// Nil iff the labels could not be resolved.
+	Labels labels.LabelArray
+
+	// NodeIP is the IP of the node the endpoint runs on. May be empty if
+	// the IPCache entry did not carry a host IP.
+	NodeIP string
+}
+
+// Event is emitted by a Source whenever a pod endpoint changes.
+type Event struct {
+	Kind     EventKind
+	Endpoint PodEndpoint
+}


### PR DESCRIPTION
Switch egress gateway endpoint tracking to a new IPCache-backed `podendpointsource`.

This is the narrowed follow-up from #45328. It addresses stale endpoint state when pod IP ownership changes, and makes the egress gateway endpoint data path independent of whether IPCache was populated from CiliumEndpoint or CiliumEndpointSlice. The consumer is included in this PR so the source contract is reviewable at the use site.

Data contract:
- scope: local Kubernetes cluster only; clustermesh endpoints are ignored
- pod key: namespace/name from IPCache Kubernetes metadata
- payload: pod IPs, identity labels, and node IP
- IPCache callbacks only filter and enqueue; identity lookup and state mutation happen in the source job
- queue backpressure blocks rather than dropping events and reports degraded health if it occurs

Egress gateway keeps policy matching, node matching, and gateway selection in `pkg/egressgateway`. It also keeps the existing CRD identity-allocation requirement; this PR only removes the direct endpoint-resource watch dependency for pod endpoint state.

AI disclosure: This PR was prepared with LLM assistance (AIL:4). I reviewed the resulting diff, resolved conflicts/rebase fallout, and ran the checks listed below before pushing.

Testing:
- `contrib/scripts/check-fmt.sh`
- `contrib/scripts/check-log-newlines.sh`
- `contrib/scripts/lock-check.sh`
- `go test ./pkg/podendpointsource`
- `go test -race ./pkg/podendpointsource`
- `GOCACHE=/private/tmp/cilium-go-build GOOS=linux go test -c ./pkg/egressgateway -o /private/tmp/egressgateway.test`
- `GOCACHE=/private/tmp/cilium-go-build GOOS=linux go test -c ./daemon/cmd -o /private/tmp/daemon-cmd.test`

```release-note
Egress gateway now tracks pod endpoints from IPCache, including when CiliumEndpointSlice is enabled, and evicts stale endpoint state when pod IP ownership changes.
```
