### PR TITLE
Reapply "ci: use PR checks for status check"

### DIFF
--- a/.github/workflows/build-images-ci-v1.17.yaml
+++ b/.github/workflows/build-images-ci-v1.17.yaml
@@ -32,8 +32,8 @@ jobs:
       # This is to avoid waiting for base images on push to main or merge_group
       # events as the lint-images-base does not run on those events.
       if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
-      sha: ${{ github.event.pull_request.head.sha || github.sha }}
-      lint-workflows: "lint-images-base.yaml"
+      pr-number: ${{ github.event.pull_request.number }}
+      lint-names: 'Lint image build logic'
       timeout-minutes: 2
       poll-interval: 15
 

--- a/.github/workflows/build-images-ci-v1.18.yaml
+++ b/.github/workflows/build-images-ci-v1.18.yaml
@@ -32,8 +32,8 @@ jobs:
       # This is to avoid waiting for base images on push to main or merge_group
       # events as the lint-images-base does not run on those events.
       if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
-      sha: ${{ github.event.pull_request.head.sha || github.sha }}
-      lint-workflows: "lint-images-base.yaml"
+      pr-number: ${{ github.event.pull_request.number }}
+      lint-names: 'Lint image build logic'
       timeout-minutes: 2
       poll-interval: 15
 

--- a/.github/workflows/build-images-ci-v1.19.yaml
+++ b/.github/workflows/build-images-ci-v1.19.yaml
@@ -32,8 +32,8 @@ jobs:
       # This is to avoid waiting for base images on push to main or merge_group
       # events as the lint-images-base does not run on those events.
       if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
-      sha: ${{ github.event.pull_request.head.sha || github.sha }}
-      lint-workflows: "lint-images-base.yaml"
+      pr-number: ${{ github.event.pull_request.number }}
+      lint-names: 'Lint image build logic'
       timeout-minutes: 2
       poll-interval: 15
 

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -40,8 +40,8 @@ jobs:
       # This is to avoid waiting for base images on push to main or merge_group
       # events as the lint-images-base does not run on those events.
       if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
-      sha: ${{ github.event.pull_request.head.sha || github.sha }}
-      lint-workflows: "lint-images-base.yaml"
+      pr-number: ${{ github.event.pull_request.number }}
+      lint-names: 'Lint image build logic'
       timeout-minutes: 2
       poll-interval: 15
 

--- a/.github/workflows/wait-for-status-check.yaml
+++ b/.github/workflows/wait-for-status-check.yaml
@@ -7,15 +7,6 @@ on:
         description: "Condition to run the wait (true/false)"
         type: boolean
         default: true
-      sha:
-        description: "SHA to check for lint workflow completion"
-        required: true
-        type: string
-      lint-workflows:
-        description: "Comma-separated list of lint workflow filenames to wait for"
-        required: false
-        type: string
-        default: "lint-images-base.yaml"
       timeout-minutes:
         description: "Maximum time to wait for lint workflows (in minutes)"
         required: false
@@ -26,6 +17,15 @@ on:
         required: false
         type: number
         default: 30
+      lint-names:
+        description: "Comma-separated list of lint workflow filenames to wait for"
+        required: false
+        type: string
+        default: "Lint image build logic"
+      pr-number:
+        description: "PR number to check for lint workflow completion"
+        required: true
+        type: string
 
 permissions:
   actions: read
@@ -43,17 +43,17 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # Parse input parameters
-          check_sha="${{ inputs.sha }}"
-          lint_workflows_str="${{ inputs.lint-workflows }}"
+          lint_names_str="${{ inputs.lint-names }}"
           poll_interval="${{ inputs.poll-interval }}"
           timeout_minutes="${{ inputs.timeout-minutes }}"
+          pr_number="${{ inputs.pr-number }}"
 
-          echo "Waiting for lint workflows to complete for SHA: $check_sha"
-          echo "Lint workflows to check: $lint_workflows_str"
+          echo "Waiting for lint workflows to complete for PR: $pr_number"
+          echo "Lint checks: $lint_names_str"
           echo "Poll interval: ${poll_interval}s, Timeout: ${timeout_minutes}m"
 
           # Convert comma-separated workflows to array
-          IFS=',' read -ra lint_workflows <<< "$lint_workflows_str"
+          IFS=',' read -ra lint_names <<< "$lint_names_str"
 
           max_attempts=$((timeout_minutes * 60 / poll_interval))
           attempt=0
@@ -64,35 +64,32 @@ jobs:
 
             all_successful=true
 
-            for workflow in "${lint_workflows[@]}"; do
+            for name in "${lint_names[@]}"; do
               # Trim whitespace
-              workflow=$(echo "$workflow" | xargs)
-              echo "Checking workflow: $workflow"
+              name=$(echo "$name" | xargs)
+              echo "Checking status: $name"
 
-              # Use gh CLI to get the latest run for this workflow and commit
-              run_status=$(gh --repo ${{ github.repository }} run list --workflow "$workflow" --commit "$check_sha" --limit 1 --json status,conclusion --jq '.[0] // empty')
+              # Use gh CLI to get the check status
+              check_status=$(gh pr checks --repo ${{ github.repository }} $pr_number --json name,state --jq ".[] | select( .name==\"$name\").state")
 
               if [[ -z "$run_status" ]]; then
-                echo "No workflow run found for SHA $check_sha"
-                all_successful=false
+                echo "No status found for PR $pr_number"
                 continue
               fi
 
-              status=$(echo "$run_status" | jq -r '.status')
-              conclusion=$(echo "$run_status" | jq -r '.conclusion')
 
-              echo "Workflow status: $status, conclusion: $conclusion"
-
-              case "$status" in
-                "completed")
-                  if [[ "$conclusion" == "success" ]]; then
-                    echo "✅ Workflow completed successfully"
-                  else
-                    echo "❌ Lint workflow $workflow failed with conclusion: $conclusion"
-                    exit 1
-                  fi
+              case "$check_status" in
+                "SUCCESS")
+                  echo "✅ Workflow completed successfully"
                   ;;
-                "in_progress"|"queued")
+                "SKIPPED")
+                  echo "✅ Workflow marked as skipped"
+                  ;;
+                "FAILURE")
+                  echo "❌ Lint workflow $workflow failed with conclusion: $conclusion"
+                  all_successful=false
+                  ;;
+                "IN_PROGRESS"|"PENDING")
                   echo "⏳ Workflow is still running..."
                   all_successful=false
                   ;;


### PR DESCRIPTION
This reverts commit f6e8d7cf580a538e2eb538f0117d2055a8f297f4.

The bug in the workflow was pr-number type. merge_check trigger events set it to empty, so the workflow fails because number cannot be an empty string.

Changed pr-number input type to string to fix.

<img width="1179" height="183" alt="image" src="https://github.com/user-attachments/assets/6f2daf63-d9ca-47be-874e-2bfb366eda29" />

https://github.com/cilium/cilium/actions/runs/27226787104