### PR TITLE
bpf: host: pass IPv6 to the stack when the IPv6 datapath is disabled

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1249,6 +1249,19 @@ do_netdev(struct __ctx_buff *ctx, __be16 proto, __u32 identity,
 
 		break;
 #endif /* ENABLE_IPV4 */
+#ifndef ENABLE_IPV6
+	case bpf_htons(ETH_P_IPV6):
+		/* The IPv6 datapath is not compiled in, so the host firewall
+		 * cannot enforce policies on IPv6 and would drop it as unknown
+		 * L3, breaking IPv6 neighbor discovery for the node (e.g. BGP
+		 * unnumbered over link-local addresses). Pass IPv6 to the
+		 * kernel stack instead, as without the host firewall.
+		 */
+		send_trace_notify(ctx, obs_point, identity, UNKNOWN_ID, TRACE_EP_ID_UNKNOWN,
+				  ctx->ingress_ifindex, trace.reason, trace.monitor, proto);
+		ret = CTX_ACT_OK;
+		break;
+#endif /* !ENABLE_IPV6 */
 	default:
 		send_trace_notify(ctx, obs_point, identity, UNKNOWN_ID, TRACE_EP_ID_UNKNOWN,
 				  ctx->ingress_ifindex, trace.reason, trace.monitor, proto);
@@ -1505,6 +1518,12 @@ int cil_to_netdev(struct __ctx_buff *ctx)
 		ret = CTX_ACT_OK;
 		break;
 # endif
+# ifndef ENABLE_IPV6
+	case bpf_htons(ETH_P_IPV6):
+		/* Pass IPv6 to the kernel stack: see do_netdev(). */
+		ret = CTX_ACT_OK;
+		break;
+# endif /* !ENABLE_IPV6 */
 	default:
 		ret = DROP_UNKNOWN_L3;
 		break;
@@ -1737,6 +1756,12 @@ int host_ingress_policy(struct __ctx_buff *ctx, __be16 proto,
 		ret = CTX_ACT_OK;
 		break;
 # endif
+# ifndef ENABLE_IPV6
+	case bpf_htons(ETH_P_IPV6):
+		/* Pass IPv6 to the kernel stack: see do_netdev(). */
+		ret = CTX_ACT_OK;
+		break;
+# endif /* !ENABLE_IPV6 */
 	default:
 		ret = DROP_UNKNOWN_L3;
 		break;
@@ -1935,6 +1960,12 @@ from_host_to_lxc(struct __ctx_buff *ctx, __be16 proto, __s8 *ext_err)
 		ret = CTX_ACT_OK;
 		break;
 # endif
+# ifndef ENABLE_IPV6
+	case bpf_htons(ETH_P_IPV6):
+		/* Pass IPv6 to the kernel stack: see do_netdev(). */
+		ret = CTX_ACT_OK;
+		break;
+# endif /* !ENABLE_IPV6 */
 	default:
 		ret = DROP_UNKNOWN_L3;
 		break;

--- a/bpf/tests/host_hostfw_ipv6_disabled.c
+++ b/bpf/tests/host_hostfw_ipv6_disabled.c
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+/* Enable code paths under test: host firewall without the IPv6 datapath */
+#define ENABLE_IPV4			1
+#define ENABLE_HOST_FIREWALL		1
+
+/* Not defined by lib/icmp6.h, which only names the ND types it handles */
+#define ICMP6_RA_MSG_TYPE		134
+
+static volatile const __u8 *node_mac = mac_one;
+static volatile const __u8 *remote_mac = mac_two;
+
+#include "lib/bpf_host.h"
+
+/* When the IPv6 datapath is not compiled in, the host firewall cannot
+ * enforce policies on IPv6. IPv6 traffic must still reach the kernel
+ * stack (as without the host firewall) instead of being dropped as
+ * unknown L3: otherwise enabling the host firewall on an IPv4-only
+ * Cilium config breaks IPv6 neighbor discovery for the node.
+ */
+
+/* ICMPv6 router advertisement from a fabric peer to the node. */
+PKTGEN("tc", "hostfw_ipv6_disabled_1_ingress")
+int hostfw_ipv6_disabled_ingress_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct icmp6hdr *icmp6;
+
+	pktgen__init(&builder, ctx);
+
+	icmp6 = pktgen__push_ipv6_icmp6_packet(&builder,
+					       (__u8 *)remote_mac, (__u8 *)node_mac,
+					       (__u8 *)v6_ext_node_one,
+					       (__u8 *)v6_node_one,
+					       ICMP6_RA_MSG_TYPE);
+	if (!icmp6)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "hostfw_ipv6_disabled_1_ingress")
+int hostfw_ipv6_disabled_ingress_setup(struct __ctx_buff *ctx)
+{
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "hostfw_ipv6_disabled_1_ingress")
+int hostfw_ipv6_disabled_ingress_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	test_finish();
+}
+
+/* ICMPv6 neighbor solicitation from the node to a fabric peer. */
+PKTGEN("tc", "hostfw_ipv6_disabled_2_egress")
+int hostfw_ipv6_disabled_egress_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct icmp6hdr *icmp6;
+
+	pktgen__init(&builder, ctx);
+
+	icmp6 = pktgen__push_ipv6_icmp6_packet(&builder,
+					       (__u8 *)node_mac, (__u8 *)remote_mac,
+					       (__u8 *)v6_node_one,
+					       (__u8 *)v6_ext_node_one,
+					       ICMP6_NS_MSG_TYPE);
+	if (!icmp6)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "hostfw_ipv6_disabled_2_egress")
+int hostfw_ipv6_disabled_egress_setup(struct __ctx_buff *ctx)
+{
+	return netdev_send_packet(ctx);
+}
+
+CHECK("tc", "hostfw_ipv6_disabled_2_egress")
+int hostfw_ipv6_disabled_egress_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	test_finish();
+}


### PR DESCRIPTION
When the host firewall is enabled but the IPv6 datapath is compiled out (`enable-ipv6=false`), bpf_host drops all IPv6 packets on managed devices as `DROP_UNKNOWN_L3` ("Unsupported L3 protocol") — in both directions and before any policy evaluation. This breaks IPv6 neighbor discovery for the node and, with it, any node-level IPv6 connectivity, e.g. BGP unnumbered peering over link-local addresses on L3 fabrics. No host policy can allow the traffic back, since the drop happens before policy enforcement.

Without the host firewall, the same packets are passed to the kernel stack. This PR restores that behavior for the IPv6 ethertype when `ENABLE_IPV6` is not compiled in: the host firewall cannot enforce policies on a protocol it cannot parse, and dropping it breaks the node instead of protecting it. The change mirrors the existing ARP passthrough cases in the same protocol switches (`do_netdev`, `cil_to_netdev`, `host_ingress_policy`, `from_host_to_lxc`).

New BPF test `bpf/tests/host_hostfw_ipv6_disabled.c` (host firewall enabled, no IPv6 datapath) asserts that an ICMPv6 router advertisement from a peer (ingress) and a neighbor solicitation from the node (egress) reach the stack. Without the fix, both fail with exactly the "Unsupported L3 protocol" drop reported in #33155.

This is not a theoretical setup: users of [Cozystack](https://github.com/cozystack/cozystack) (a CNCF project) run this exact combination — host firewall enabled, Cilium without the IPv6 datapath, nodes on IPv6/L3 fabrics — and confirm both the breakage and that the passthrough restores node connectivity ([cozystack/cozystack#2806](https://github.com/cozystack/cozystack/issues/2806)). This PR upstreams the patch we currently carry downstream in our Cilium image; we will drop the downstream copy once an equivalent fix is available upstream.

This PR was prepared with AIL:3 — I defined the problem, the mechanism, and the fix design; an LLM produced the patch and the test under my direction. I personally reviewed the diff and ran the BPF tests: the new test fails without the fix and passes with it, and the neighboring host-firewall/IPv6 tests still compile.

Fixes: #33155

```release-note
host-firewall: IPv6 traffic is passed to the kernel stack instead of being dropped when the IPv6 datapath is disabled.
```

