### PR TITLE
gateway-api: Reduce duplication + more test coverage

### DIFF
--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -351,69 +351,12 @@ func toHTTPRoutes(log *slog.Logger,
 	btlspMap helpers.BackendTLSPolicyServiceMap,
 ) []model.HTTPRoute {
 	var httpRoutes []model.HTTPRoute
-	for _, r := range input {
-		listenerIsParent := false
-		// Check parents to see if r can attach to them.
-		// We have to consider _both_ SectionName and Port
-		for _, parent := range r.Spec.ParentRefs {
-			// First, if both SectionName and Port are unset, attach
-			if parent.SectionName == nil && parent.Port == nil {
-				listenerIsParent = true
-				break
-			}
-
-			// Then, if SectionName is set, check combinations with Port.
-			if parent.SectionName != nil {
-				if *parent.SectionName != listener.Name {
-					// If SectionName is set but not equal, no other settings
-					// matter, so check the next parent.
-					continue
-				}
-
-				if parent.Port != nil && *parent.Port != listener.Port {
-					// If SectionName is set and equal, but Port is set and _unequal_,
-					continue
-				}
-
-				listenerIsParent = true
-				break
-			}
-
-			if parent.Port != nil {
-				if *parent.Port != listener.Port {
-					// If Port is set but not equal, no other settings
-					// matter, check the next parent.
-					continue
-				}
-
-				listenerIsParent = true
-				break
-			}
-
-		}
-
-		if !listenerIsParent {
-			continue
-		}
-
-		if !namespacesPreFiltered && !helpers.IsListenerNamespaceAllowed(listener, r.GetNamespace(), gatewayNamespace, namespaceLabels) {
-			continue
-		}
-
-		allProtocolHostnames := listenerHostnamesByProtocol[listener.Protocol]
-
-		computedHost := model.ComputeHosts(toStringSlice(r.Spec.Hostnames), (*string)(listener.Hostname), allProtocolHostnames)
-		// No matching host, skip this route
-		if len(computedHost) == 0 {
-			continue
-		}
-
-		if len(computedHost) == 1 && computedHost[0] == allHosts {
-			computedHost = nil
-		}
-
-		httpRoutes = append(httpRoutes, extractRoutes(log, int32(listener.Port), computedHost, r, services, serviceImports, grants, btlspMap)...)
-
+	for _, match := range matchingHostnameRoutes(listener, gatewayNamespace, namespaceLabels, namespacesPreFiltered, listenerHostnamesByProtocol, input,
+		func(r gatewayv1.HTTPRoute) []gatewayv1.ParentReference { return r.Spec.ParentRefs },
+		func(r gatewayv1.HTTPRoute) string { return r.GetNamespace() },
+		func(r gatewayv1.HTTPRoute) []gatewayv1.Hostname { return r.Spec.Hostnames },
+	) {
+		httpRoutes = append(httpRoutes, extractRoutes(log, int32(listener.Port), match.hostnames, match.route, services, serviceImports, grants, btlspMap)...)
 	}
 	return httpRoutes
 }
@@ -432,55 +375,36 @@ func extractRoutes(logger *slog.Logger,
 		var backendHTTPFilters []*model.BackendHTTPFilter
 		bes := make([]model.Backend, 0, len(rule.BackendRefs))
 		for _, be := range rule.BackendRefs {
-			if !helpers.IsBackendReferenceAllowed(hr.GetNamespace(), be.BackendRef, gatewayv1.SchemeGroupVersion.WithKind("HTTPRoute"), grants) {
+			toAppend, svc, ok := resolveBackendRef(hr.GetNamespace(), be.BackendRef, gatewayv1.SchemeGroupVersion.WithKind("HTTPRoute"), services, serviceImports, grants)
+			if !ok {
 				continue
 			}
-			svcName, err := getBackendServiceName(helpers.NamespaceDerefOr(be.Namespace, hr.Namespace), services, serviceImports, be.BackendObjectReference)
-			if err != nil {
+			var include bool
+			toAppend, include = addBackendTLSDetails(logger, toAppend, svc, btlspMap)
+			if !include {
 				continue
 			}
-			if svcName != string(be.Name) {
-				be = *be.DeepCopy()
-				be.BackendRef.BackendObjectReference = gatewayv1beta1.BackendObjectReference{
-					Name:      gatewayv1beta1.ObjectName(svcName),
-					Port:      be.Port,
-					Namespace: be.Namespace,
-				}
-			}
-			if be.BackendRef.Port == nil {
-				// must have port for Service reference
-				continue
-			}
-			svc := getServiceSpec(string(be.Name), helpers.NamespaceDerefOr(be.Namespace, hr.Namespace), services)
-			if svc != nil {
-				toAppend := backendToModelBackend(*svc, be.BackendRef, hr.Namespace)
-				var include bool
-				toAppend, include = addBackendTLSDetails(logger, toAppend, svc, btlspMap)
-				if !include {
-					continue
-				}
-				bes = append(bes, toAppend)
-				for _, f := range be.Filters {
-					switch f.Type {
-					case gatewayv1.HTTPRouteFilterRequestHeaderModifier:
-						backendHTTPFilters = append(backendHTTPFilters, &model.BackendHTTPFilter{
-							Name: fmt.Sprintf("%s:%s:%d", helpers.NamespaceDerefOr(be.Namespace, hr.Namespace), be.Name, uint32(*be.Port)),
-							RequestHeaderFilter: &model.HTTPHeaderFilter{
-								HeadersToAdd:    toHTTPHeaders(f.RequestHeaderModifier.Add),
-								HeadersToSet:    toHTTPHeaders(f.RequestHeaderModifier.Set),
-								HeadersToRemove: f.RequestHeaderModifier.Remove,
-							},
-						})
-					case gatewayv1.HTTPRouteFilterResponseHeaderModifier:
-						backendHTTPFilters = append(backendHTTPFilters, &model.BackendHTTPFilter{
-							Name: fmt.Sprintf("%s:%s:%d", helpers.NamespaceDerefOr(be.Namespace, hr.Namespace), be.Name, uint32(*be.Port)),
-							ResponseHeaderModifier: &model.HTTPHeaderFilter{
-								HeadersToAdd:    toHTTPHeaders(f.ResponseHeaderModifier.Add),
-								HeadersToSet:    toHTTPHeaders(f.ResponseHeaderModifier.Set),
-								HeadersToRemove: f.ResponseHeaderModifier.Remove,
-							},
-						})
-					}
+			bes = append(bes, toAppend)
+			for _, f := range be.Filters {
+				switch f.Type {
+				case gatewayv1.HTTPRouteFilterRequestHeaderModifier:
+					backendHTTPFilters = append(backendHTTPFilters, &model.BackendHTTPFilter{
+						Name: fmt.Sprintf("%s:%s:%d", toAppend.Namespace, toAppend.Name, toAppend.Port.Port),
+						RequestHeaderFilter: &model.HTTPHeaderFilter{
+							HeadersToAdd:    toHTTPHeaders(f.RequestHeaderModifier.Add),
+							HeadersToSet:    toHTTPHeaders(f.RequestHeaderModifier.Set),
+							HeadersToRemove: f.RequestHeaderModifier.Remove,
+						},
+					})
+				case gatewayv1.HTTPRouteFilterResponseHeaderModifier:
+					backendHTTPFilters = append(backendHTTPFilters, &model.BackendHTTPFilter{
+						Name: fmt.Sprintf("%s:%s:%d", toAppend.Namespace, toAppend.Name, toAppend.Port.Port),
+						ResponseHeaderModifier: &model.HTTPHeaderFilter{
+							HeadersToAdd:    toHTTPHeaders(f.ResponseHeaderModifier.Add),
+							HeadersToSet:    toHTTPHeaders(f.ResponseHeaderModifier.Set),
+							HeadersToRemove: f.ResponseHeaderModifier.Remove,
+						},
+					})
 				}
 			}
 		}
@@ -523,15 +447,9 @@ func extractRoutes(logger *slog.Logger,
 					continue
 				}
 
-				if !helpers.IsBackendReferenceAllowed(hr.GetNamespace(),
-					gatewayv1.BackendRef{BackendObjectReference: f.RequestMirror.BackendRef},
-					gatewayv1.SchemeGroupVersion.WithKind("HTTPRoute"), grants) {
-					continue
-				}
-
-				svc := getServiceSpec(string(f.RequestMirror.BackendRef.Name), helpers.NamespaceDerefOr(f.RequestMirror.BackendRef.Namespace, hr.Namespace), services)
-				if svc != nil {
-					requestMirrors = append(requestMirrors, toHTTPRequestMirror(*svc, f.RequestMirror, hr.Namespace))
+				backend, _, ok := resolveBackendRef(hr.GetNamespace(), gatewayv1.BackendRef{BackendObjectReference: f.RequestMirror.BackendRef}, gatewayv1.SchemeGroupVersion.WithKind("HTTPRoute"), services, serviceImports, grants)
+				if ok {
+					requestMirrors = append(requestMirrors, toHTTPRequestMirror(backend, f.RequestMirror))
 				}
 			case gatewayv1.HTTPRouteFilterExternalAuth:
 				if f.ExternalAuth != nil {
@@ -754,34 +672,12 @@ func toGRPCRoutes(listener gatewayv1beta1.Listener,
 	grants []gatewayv1.ReferenceGrant,
 ) []model.HTTPRoute {
 	var grpcRoutes []model.HTTPRoute
-	for _, r := range input {
-		isListener := false
-		for _, parent := range r.Spec.ParentRefs {
-			if parent.SectionName == nil || *parent.SectionName == listener.Name {
-				isListener = true
-				break
-			}
-		}
-		if !isListener {
-			continue
-		}
-
-		if !namespacesPreFiltered && !helpers.IsListenerNamespaceAllowed(listener, r.GetNamespace(), gatewayNamespace, namespaceLabels) {
-			continue
-		}
-
-		allProtocolHostnames := listenerHostnamesByProtocol[listener.Protocol]
-
-		computedHost := model.ComputeHosts(toStringSlice(r.Spec.Hostnames), (*string)(listener.Hostname), allProtocolHostnames)
-		// No matching host, skip this route
-		if len(computedHost) == 0 {
-			continue
-		}
-
-		if len(computedHost) == 1 && computedHost[0] == allHosts {
-			computedHost = nil
-		}
-		grpcRoutes = append(grpcRoutes, extractGRPCRoutes(computedHost, r, services, serviceImports, grants)...)
+	for _, match := range matchingHostnameRoutes(listener, gatewayNamespace, namespaceLabels, namespacesPreFiltered, listenerHostnamesByProtocol, input,
+		func(r gatewayv1.GRPCRoute) []gatewayv1.ParentReference { return r.Spec.ParentRefs },
+		func(r gatewayv1.GRPCRoute) string { return r.GetNamespace() },
+		func(r gatewayv1.GRPCRoute) []gatewayv1.Hostname { return r.Spec.Hostnames },
+	) {
+		grpcRoutes = append(grpcRoutes, extractGRPCRoutes(match.hostnames, match.route, services, serviceImports, grants)...)
 	}
 	return grpcRoutes
 }
@@ -791,28 +687,8 @@ func extractGRPCRoutes(hostnames []string, grpcr gatewayv1.GRPCRoute, services [
 	for _, rule := range grpcr.Spec.Rules {
 		bes := make([]model.Backend, 0, len(rule.BackendRefs))
 		for _, be := range rule.BackendRefs {
-			if !helpers.IsBackendReferenceAllowed(grpcr.GetNamespace(), be.BackendRef, gatewayv1.SchemeGroupVersion.WithKind("GRPCRoute"), grants) {
-				continue
-			}
-			svcName, err := getBackendServiceName(helpers.NamespaceDerefOr(be.Namespace, grpcr.Namespace), services, serviceImports, be.BackendObjectReference)
-			if err != nil {
-				continue
-			}
-			if svcName != string(be.Name) {
-				be = *be.DeepCopy()
-				be.BackendObjectReference = gatewayv1beta1.BackendObjectReference{
-					Name:      gatewayv1beta1.ObjectName(svcName),
-					Port:      be.Port,
-					Namespace: be.Namespace,
-				}
-			}
-			if be.BackendRef.Port == nil {
-				// must have port for Service reference
-				continue
-			}
-			svc := getServiceSpec(string(be.Name), helpers.NamespaceDerefOr(be.Namespace, grpcr.Namespace), services)
-			if svc != nil {
-				bes = append(bes, backendToModelBackend(*svc, be.BackendRef, grpcr.Namespace))
+			if backend, _, ok := resolveBackendRef(grpcr.GetNamespace(), be.BackendRef, gatewayv1.SchemeGroupVersion.WithKind("GRPCRoute"), services, serviceImports, grants); ok {
+				bes = append(bes, backend)
 			}
 		}
 
@@ -846,15 +722,9 @@ func extractGRPCRoutes(hostnames []string, grpcr gatewayv1.GRPCRoute, services [
 					continue
 				}
 
-				if !helpers.IsBackendReferenceAllowed(grpcr.GetNamespace(),
-					gatewayv1.BackendRef{BackendObjectReference: f.RequestMirror.BackendRef},
-					gatewayv1.SchemeGroupVersion.WithKind("GRPCRoute"), grants) {
-					continue
-				}
-
-				svc := getServiceSpec(string(f.RequestMirror.BackendRef.Name), helpers.NamespaceDerefOr(f.RequestMirror.BackendRef.Namespace, grpcr.Namespace), services)
-				if svc != nil {
-					requestMirrors = append(requestMirrors, toHTTPRequestMirror(*svc, f.RequestMirror, grpcr.Namespace))
+				backend, _, ok := resolveBackendRef(grpcr.GetNamespace(), gatewayv1.BackendRef{BackendObjectReference: f.RequestMirror.BackendRef}, gatewayv1.SchemeGroupVersion.WithKind("GRPCRoute"), services, serviceImports, grants)
+				if ok {
+					requestMirrors = append(requestMirrors, toHTTPRequestMirror(backend, f.RequestMirror))
 				}
 			}
 		}
@@ -890,59 +760,22 @@ func extractGRPCRoutes(hostnames []string, grpcr gatewayv1.GRPCRoute, services [
 
 func toTLSRoutes(listener gatewayv1beta1.Listener, gatewayNamespace string, namespaceLabels helpers.NamespaceLabelIndex, namespacesPreFiltered bool, listenerHostnamesByProtocol map[gatewayv1.ProtocolType][]string, input []gatewayv1.TLSRoute, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1.ReferenceGrant) []model.TLSPassthroughRoute {
 	var tlsRoutes []model.TLSPassthroughRoute
-	for _, r := range input {
-		isListener := false
-		for _, parent := range r.Spec.ParentRefs {
-			if parent.SectionName == nil || *parent.SectionName == listener.Name {
-				isListener = true
-				break
-			}
-		}
-		if !isListener {
-			continue
-		}
-
-		if !namespacesPreFiltered && !helpers.IsListenerNamespaceAllowed(listener, r.GetNamespace(), gatewayNamespace, namespaceLabels) {
-			continue
-		}
-
-		allProtocolHostnames := listenerHostnamesByProtocol[listener.Protocol]
-		computedHost := model.ComputeHosts(toStringSlice(r.Spec.Hostnames), (*string)(listener.Hostname), allProtocolHostnames)
-		// No matching host, skip this route
-		if len(computedHost) == 0 {
-			continue
-		}
-
-		if len(computedHost) == 1 && computedHost[0] == allHosts {
-			computedHost = nil
-		}
-
+	for _, match := range matchingHostnameRoutes(listener, gatewayNamespace, namespaceLabels, namespacesPreFiltered, listenerHostnamesByProtocol, input,
+		func(r gatewayv1.TLSRoute) []gatewayv1.ParentReference { return r.Spec.ParentRefs },
+		func(r gatewayv1.TLSRoute) string { return r.GetNamespace() },
+		func(r gatewayv1.TLSRoute) []gatewayv1.Hostname { return r.Spec.Hostnames },
+	) {
+		r := match.route
 		for _, rule := range r.Spec.Rules {
 			bes := make([]model.Backend, 0, len(rule.BackendRefs))
 			for _, be := range rule.BackendRefs {
-				if !helpers.IsBackendReferenceAllowed(r.GetNamespace(), be, gatewayv1.SchemeGroupVersion.WithKind("TLSRoute"), grants) {
-					continue
-				}
-				svcName, err := getBackendServiceName(helpers.NamespaceDerefOr(be.Namespace, r.Namespace), services, serviceImports, be.BackendObjectReference)
-				if err != nil {
-					continue
-				}
-				if svcName != string(be.Name) {
-					be = *be.DeepCopy()
-					be.BackendObjectReference = gatewayv1beta1.BackendObjectReference{
-						Name:      gatewayv1beta1.ObjectName(svcName),
-						Port:      be.Port,
-						Namespace: be.Namespace,
-					}
-				}
-				svc := getServiceSpec(string(be.Name), helpers.NamespaceDerefOr(be.Namespace, r.Namespace), services)
-				if svc != nil {
-					bes = append(bes, backendToModelBackend(*svc, be, r.Namespace))
+				if backend, _, ok := resolveBackendRef(r.GetNamespace(), be, gatewayv1.SchemeGroupVersion.WithKind("TLSRoute"), services, serviceImports, grants); ok {
+					bes = append(bes, backend)
 				}
 			}
 
 			tlsRoutes = append(tlsRoutes, model.TLSPassthroughRoute{
-				Hostnames: computedHost,
+				Hostnames: match.hostnames,
 				Backends:  bes,
 			})
 
@@ -951,10 +784,53 @@ func toTLSRoutes(listener gatewayv1beta1.Listener, gatewayNamespace string, name
 	return tlsRoutes
 }
 
-// l4RouteAttachesToListener reports whether a TCP/UDP route with the given
-// parentRefs attaches to the listener, mirroring the sectionName/port matching
-// rules used by HTTP/TLS routes.
-func l4RouteAttachesToListener(parentRefs []gatewayv1.ParentReference, listener gatewayv1beta1.Listener) bool {
+type hostnameRouteMatch[T any] struct {
+	route     T
+	hostnames []string
+}
+
+func matchingHostnameRoutes[T any](
+	listener gatewayv1.Listener,
+	gatewayNamespace string,
+	namespaceLabels helpers.NamespaceLabelIndex,
+	namespacesPreFiltered bool,
+	listenerHostnamesByProtocol map[gatewayv1.ProtocolType][]string,
+	input []T,
+	parentRefs func(T) []gatewayv1.ParentReference,
+	namespace func(T) string,
+	hostnames func(T) []gatewayv1.Hostname,
+) []hostnameRouteMatch[T] {
+	var routes []hostnameRouteMatch[T]
+	for _, r := range input {
+		if !routeAttachesToListener(parentRefs(r), listener) {
+			continue
+		}
+
+		if !namespacesPreFiltered && !helpers.IsListenerNamespaceAllowed(listener, namespace(r), gatewayNamespace, namespaceLabels) {
+			continue
+		}
+
+		allProtocolHostnames := listenerHostnamesByProtocol[listener.Protocol]
+		computedHost := model.ComputeHosts(toStringSlice(hostnames(r)), (*string)(listener.Hostname), allProtocolHostnames)
+		if len(computedHost) == 0 {
+			continue
+		}
+
+		if len(computedHost) == 1 && computedHost[0] == allHosts {
+			computedHost = nil
+		}
+
+		routes = append(routes, hostnameRouteMatch[T]{
+			route:     r,
+			hostnames: computedHost,
+		})
+	}
+	return routes
+}
+
+// routeAttachesToListener reports whether a route with the given parentRefs
+// attaches to the listener by SectionName and Port.
+func routeAttachesToListener(parentRefs []gatewayv1.ParentReference, listener gatewayv1beta1.Listener) bool {
 	for _, parent := range parentRefs {
 		if parent.SectionName == nil && parent.Port == nil {
 			return true
@@ -1016,7 +892,7 @@ func toTCPRoutes(listener gatewayv1beta1.Listener,
 		if !namespacesPreFiltered && !helpers.IsListenerNamespaceAllowed(listener, r.GetNamespace(), gatewayNamespace, namespaceLabels) {
 			continue
 		}
-		if l4RouteAttachesToListener(r.Spec.ParentRefs, listener) {
+		if routeAttachesToListener(r.Spec.ParentRefs, listener) {
 			attached = append(attached, r)
 		}
 	}
@@ -1031,24 +907,8 @@ func toTCPRoutes(listener gatewayv1beta1.Listener,
 		for _, rule := range r.Spec.Rules {
 			bes := make([]model.Backend, 0, len(rule.BackendRefs))
 			for _, be := range rule.BackendRefs {
-				if !helpers.IsBackendReferenceAllowed(r.GetNamespace(), be, gatewayv1.SchemeGroupVersion.WithKind("TCPRoute"), grants) {
-					continue
-				}
-				svcName, err := getBackendServiceName(helpers.NamespaceDerefOr(be.Namespace, r.Namespace), services, serviceImports, be.BackendObjectReference)
-				if err != nil {
-					continue
-				}
-				if svcName != string(be.Name) {
-					be = *be.DeepCopy()
-					be.BackendObjectReference = gatewayv1beta1.BackendObjectReference{
-						Name:      gatewayv1beta1.ObjectName(svcName),
-						Port:      be.Port,
-						Namespace: be.Namespace,
-					}
-				}
-				svc := getServiceSpec(string(be.Name), helpers.NamespaceDerefOr(be.Namespace, r.Namespace), services)
-				if svc != nil {
-					bes = append(bes, backendToModelBackend(*svc, be, r.Namespace))
+				if backend, _, ok := resolveBackendRef(r.GetNamespace(), be, gatewayv1.SchemeGroupVersion.WithKind("TCPRoute"), services, serviceImports, grants); ok {
+					bes = append(bes, backend)
 				}
 			}
 
@@ -1075,7 +935,7 @@ func toUDPRoutes(listener gatewayv1beta1.Listener,
 		if !namespacesPreFiltered && !helpers.IsListenerNamespaceAllowed(listener, r.GetNamespace(), gatewayNamespace, namespaceLabels) {
 			continue
 		}
-		if l4RouteAttachesToListener(r.Spec.ParentRefs, listener) {
+		if routeAttachesToListener(r.Spec.ParentRefs, listener) {
 			attached = append(attached, r)
 		}
 	}
@@ -1090,24 +950,8 @@ func toUDPRoutes(listener gatewayv1beta1.Listener,
 		for _, rule := range r.Spec.Rules {
 			bes := make([]model.Backend, 0, len(rule.BackendRefs))
 			for _, be := range rule.BackendRefs {
-				if !helpers.IsBackendReferenceAllowed(r.GetNamespace(), be, gatewayv1.SchemeGroupVersion.WithKind("UDPRoute"), grants) {
-					continue
-				}
-				svcName, err := getBackendServiceName(helpers.NamespaceDerefOr(be.Namespace, r.Namespace), services, serviceImports, be.BackendObjectReference)
-				if err != nil {
-					continue
-				}
-				if svcName != string(be.Name) {
-					be = *be.DeepCopy()
-					be.BackendObjectReference = gatewayv1beta1.BackendObjectReference{
-						Name:      gatewayv1beta1.ObjectName(svcName),
-						Port:      be.Port,
-						Namespace: be.Namespace,
-					}
-				}
-				svc := getServiceSpec(string(be.Name), helpers.NamespaceDerefOr(be.Namespace, r.Namespace), services)
-				if svc != nil {
-					bes = append(bes, backendToModelBackend(*svc, be, r.Namespace))
+				if backend, _, ok := resolveBackendRef(r.GetNamespace(), be, gatewayv1.SchemeGroupVersion.WithKind("UDPRoute"), services, serviceImports, grants); ok {
+					bes = append(bes, backend)
 				}
 			}
 
@@ -1232,7 +1076,7 @@ func toHTTPExternalAuthFilter(log *slog.Logger, ea *gatewayv1.HTTPExternalAuthFi
 	return filter
 }
 
-func toHTTPRequestMirror(svc corev1.Service, mirror *gatewayv1.HTTPRequestMirrorFilter, ns string) *model.HTTPRequestMirror {
+func toHTTPRequestMirror(backend model.Backend, mirror *gatewayv1.HTTPRequestMirrorFilter) *model.HTTPRequestMirror {
 	var n, d int32 = 100, 100
 
 	switch {
@@ -1246,7 +1090,7 @@ func toHTTPRequestMirror(svc corev1.Service, mirror *gatewayv1.HTTPRequestMirror
 	}
 
 	return &model.HTTPRequestMirror{
-		Backend:     ptr.To(backendRefToModelBackend(svc, mirror.BackendRef, ns)),
+		Backend:     ptr.To(backend),
 		Numerator:   n,
 		Denominator: d,
 	}
@@ -1275,6 +1119,38 @@ func getServiceImport(svcName, svcNamespace string, serviceImports []mcsapiv1bet
 		}
 	}
 	return nil
+}
+
+func resolveBackendRef(routeNamespace string, be gatewayv1.BackendRef, routeGVK schema.GroupVersionKind, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1.ReferenceGrant) (model.Backend, *corev1.Service, bool) {
+	if !helpers.IsBackendReferenceAllowed(routeNamespace, be, routeGVK, grants) {
+		return model.Backend{}, nil, false
+	}
+
+	backendNamespace := helpers.NamespaceDerefOr(be.Namespace, routeNamespace)
+	svcName, err := getBackendServiceName(backendNamespace, services, serviceImports, be.BackendObjectReference)
+	if err != nil {
+		return model.Backend{}, nil, false
+	}
+
+	if svcName != string(be.Name) {
+		be = *be.DeepCopy()
+		be.BackendObjectReference = gatewayv1beta1.BackendObjectReference{
+			Name:      gatewayv1beta1.ObjectName(svcName),
+			Port:      be.Port,
+			Namespace: be.Namespace,
+		}
+	}
+
+	if be.Port == nil {
+		return model.Backend{}, nil, false
+	}
+
+	svc := getServiceSpec(string(be.Name), helpers.NamespaceDerefOr(be.Namespace, routeNamespace), services)
+	if svc == nil {
+		return model.Backend{}, nil, false
+	}
+
+	return backendToModelBackend(*svc, be, routeNamespace), svc, true
 }
 
 func backendToModelBackend(svc corev1.Service, be gatewayv1.BackendRef, defaultNamespace string) model.Backend {

--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -345,55 +345,36 @@ func extractRoutes(logger *slog.Logger,
 		var backendHTTPFilters []*model.BackendHTTPFilter
 		bes := make([]model.Backend, 0, len(rule.BackendRefs))
 		for _, be := range rule.BackendRefs {
-			if !helpers.IsBackendReferenceAllowed(hr.GetNamespace(), be.BackendRef, helpers.GatewayV1GVK("HTTPRoute"), grants) {
+			toAppend, svc, ok := resolveBackendRef(hr.GetNamespace(), be.BackendRef, gatewayv1.SchemeGroupVersion.WithKind("HTTPRoute"), services, serviceImports, grants)
+			if !ok {
 				continue
 			}
-			svcName, err := getBackendServiceName(helpers.NamespaceDerefOr(be.Namespace, hr.Namespace), services, serviceImports, be.BackendObjectReference)
-			if err != nil {
+			var include bool
+			toAppend, include = addBackendTLSDetails(logger, toAppend, svc, btlspMap)
+			if !include {
 				continue
 			}
-			if svcName != string(be.Name) {
-				be = *be.DeepCopy()
-				be.BackendRef.BackendObjectReference = gatewayv1beta1.BackendObjectReference{
-					Name:      gatewayv1beta1.ObjectName(svcName),
-					Port:      be.Port,
-					Namespace: be.Namespace,
-				}
-			}
-			if be.BackendRef.Port == nil {
-				// must have port for Service reference
-				continue
-			}
-			svc := getServiceSpec(string(be.Name), helpers.NamespaceDerefOr(be.Namespace, hr.Namespace), services)
-			if svc != nil {
-				toAppend := backendToModelBackend(*svc, be.BackendRef, hr.Namespace)
-				var include bool
-				toAppend, include = addBackendTLSDetails(logger, toAppend, svc, btlspMap)
-				if !include {
-					continue
-				}
-				bes = append(bes, toAppend)
-				for _, f := range be.Filters {
-					switch f.Type {
-					case gatewayv1.HTTPRouteFilterRequestHeaderModifier:
-						backendHTTPFilters = append(backendHTTPFilters, &model.BackendHTTPFilter{
-							Name: fmt.Sprintf("%s:%s:%d", helpers.NamespaceDerefOr(be.Namespace, hr.Namespace), be.Name, uint32(*be.Port)),
-							RequestHeaderFilter: &model.HTTPHeaderFilter{
-								HeadersToAdd:    toHTTPHeaders(f.RequestHeaderModifier.Add),
-								HeadersToSet:    toHTTPHeaders(f.RequestHeaderModifier.Set),
-								HeadersToRemove: f.RequestHeaderModifier.Remove,
-							},
-						})
-					case gatewayv1.HTTPRouteFilterResponseHeaderModifier:
-						backendHTTPFilters = append(backendHTTPFilters, &model.BackendHTTPFilter{
-							Name: fmt.Sprintf("%s:%s:%d", helpers.NamespaceDerefOr(be.Namespace, hr.Namespace), be.Name, uint32(*be.Port)),
-							ResponseHeaderModifier: &model.HTTPHeaderFilter{
-								HeadersToAdd:    toHTTPHeaders(f.ResponseHeaderModifier.Add),
-								HeadersToSet:    toHTTPHeaders(f.ResponseHeaderModifier.Set),
-								HeadersToRemove: f.ResponseHeaderModifier.Remove,
-							},
-						})
-					}
+			bes = append(bes, toAppend)
+			for _, f := range be.Filters {
+				switch f.Type {
+				case gatewayv1.HTTPRouteFilterRequestHeaderModifier:
+					backendHTTPFilters = append(backendHTTPFilters, &model.BackendHTTPFilter{
+						Name: fmt.Sprintf("%s:%s:%d", toAppend.Namespace, toAppend.Name, toAppend.Port.Port),
+						RequestHeaderFilter: &model.HTTPHeaderFilter{
+							HeadersToAdd:    toHTTPHeaders(f.RequestHeaderModifier.Add),
+							HeadersToSet:    toHTTPHeaders(f.RequestHeaderModifier.Set),
+							HeadersToRemove: f.RequestHeaderModifier.Remove,
+						},
+					})
+				case gatewayv1.HTTPRouteFilterResponseHeaderModifier:
+					backendHTTPFilters = append(backendHTTPFilters, &model.BackendHTTPFilter{
+						Name: fmt.Sprintf("%s:%s:%d", toAppend.Namespace, toAppend.Name, toAppend.Port.Port),
+						ResponseHeaderModifier: &model.HTTPHeaderFilter{
+							HeadersToAdd:    toHTTPHeaders(f.ResponseHeaderModifier.Add),
+							HeadersToSet:    toHTTPHeaders(f.ResponseHeaderModifier.Set),
+							HeadersToRemove: f.ResponseHeaderModifier.Remove,
+						},
+					})
 				}
 			}
 		}
@@ -430,30 +411,9 @@ func extractRoutes(logger *slog.Logger,
 					continue
 				}
 
-				if !helpers.IsBackendReferenceAllowed(hr.GetNamespace(),
-					gatewayv1.BackendRef{BackendObjectReference: f.RequestMirror.BackendRef},
-					helpers.GatewayV1GVK("HTTPRoute"), grants) {
-					continue
-				}
-
-				namespace := helpers.NamespaceDerefOr(f.RequestMirror.BackendRef.Namespace, hr.Namespace)
-				svcName, err := getBackendServiceName(namespace, services, serviceImports, f.RequestMirror.BackendRef)
-				if err != nil {
-					continue
-				}
-
-				mirror := f.RequestMirror.DeepCopy()
-				if svcName != string(mirror.BackendRef.Name) {
-					mirror.BackendRef = gatewayv1.BackendObjectReference{
-						Name:      gatewayv1.ObjectName(svcName),
-						Namespace: mirror.BackendRef.Namespace,
-						Port:      mirror.BackendRef.Port,
-					}
-				}
-
-				svc := getServiceSpec(svcName, namespace, services)
-				if svc != nil {
-					requestMirrors = append(requestMirrors, toHTTPRequestMirror(*svc, mirror, hr.Namespace))
+				backend, _, ok := resolveBackendRef(hr.GetNamespace(), gatewayv1.BackendRef{BackendObjectReference: f.RequestMirror.BackendRef}, gatewayv1.SchemeGroupVersion.WithKind("HTTPRoute"), services, serviceImports, grants)
+				if ok {
+					requestMirrors = append(requestMirrors, toHTTPRequestMirror(backend, f.RequestMirror))
 				}
 			case gatewayv1.HTTPRouteFilterExternalAuth:
 				if f.ExternalAuth == nil {
@@ -766,28 +726,8 @@ func extractGRPCRoutes(hostnames []string, grpcr gatewayv1.GRPCRoute, services [
 	for _, rule := range grpcr.Spec.Rules {
 		bes := make([]model.Backend, 0, len(rule.BackendRefs))
 		for _, be := range rule.BackendRefs {
-			if !helpers.IsBackendReferenceAllowed(grpcr.GetNamespace(), be.BackendRef, helpers.GatewayV1GVK("GRPCRoute"), grants) {
-				continue
-			}
-			svcName, err := getBackendServiceName(helpers.NamespaceDerefOr(be.Namespace, grpcr.Namespace), services, serviceImports, be.BackendObjectReference)
-			if err != nil {
-				continue
-			}
-			if svcName != string(be.Name) {
-				be = *be.DeepCopy()
-				be.BackendObjectReference = gatewayv1beta1.BackendObjectReference{
-					Name:      gatewayv1beta1.ObjectName(svcName),
-					Port:      be.Port,
-					Namespace: be.Namespace,
-				}
-			}
-			if be.BackendRef.Port == nil {
-				// must have port for Service reference
-				continue
-			}
-			svc := getServiceSpec(string(be.Name), helpers.NamespaceDerefOr(be.Namespace, grpcr.Namespace), services)
-			if svc != nil {
-				bes = append(bes, backendToModelBackend(*svc, be.BackendRef, grpcr.Namespace))
+			if backend, _, ok := resolveBackendRef(grpcr.GetNamespace(), be.BackendRef, gatewayv1.SchemeGroupVersion.WithKind("GRPCRoute"), services, serviceImports, grants); ok {
+				bes = append(bes, backend)
 			}
 		}
 
@@ -821,30 +761,9 @@ func extractGRPCRoutes(hostnames []string, grpcr gatewayv1.GRPCRoute, services [
 					continue
 				}
 
-				if !helpers.IsBackendReferenceAllowed(grpcr.GetNamespace(),
-					gatewayv1.BackendRef{BackendObjectReference: f.RequestMirror.BackendRef},
-					helpers.GatewayV1GVK("GRPCRoute"), grants) {
-					continue
-				}
-
-				namespace := helpers.NamespaceDerefOr(f.RequestMirror.BackendRef.Namespace, grpcr.Namespace)
-				svcName, err := getBackendServiceName(namespace, services, serviceImports, f.RequestMirror.BackendRef)
-				if err != nil {
-					continue
-				}
-
-				mirror := f.RequestMirror.DeepCopy()
-				if svcName != string(mirror.BackendRef.Name) {
-					mirror.BackendRef = gatewayv1.BackendObjectReference{
-						Name:      gatewayv1.ObjectName(svcName),
-						Namespace: mirror.BackendRef.Namespace,
-						Port:      mirror.BackendRef.Port,
-					}
-				}
-
-				svc := getServiceSpec(svcName, namespace, services)
-				if svc != nil {
-					requestMirrors = append(requestMirrors, toHTTPRequestMirror(*svc, mirror, grpcr.Namespace))
+				backend, _, ok := resolveBackendRef(grpcr.GetNamespace(), gatewayv1.BackendRef{BackendObjectReference: f.RequestMirror.BackendRef}, gatewayv1.SchemeGroupVersion.WithKind("GRPCRoute"), services, serviceImports, grants)
+				if ok {
+					requestMirrors = append(requestMirrors, toHTTPRequestMirror(backend, f.RequestMirror))
 				}
 			}
 		}
@@ -899,24 +818,8 @@ func toTLSRoutes(listener gatewayv1beta1.Listener, listenerHostnamesByProtocol m
 		for _, rule := range r.Spec.Rules {
 			bes := make([]model.Backend, 0, len(rule.BackendRefs))
 			for _, be := range rule.BackendRefs {
-				if !helpers.IsBackendReferenceAllowed(r.GetNamespace(), be, helpers.GatewayV1GVK("TLSRoute"), grants) {
-					continue
-				}
-				svcName, err := getBackendServiceName(helpers.NamespaceDerefOr(be.Namespace, r.Namespace), services, serviceImports, be.BackendObjectReference)
-				if err != nil {
-					continue
-				}
-				if svcName != string(be.Name) {
-					be = *be.DeepCopy()
-					be.BackendObjectReference = gatewayv1beta1.BackendObjectReference{
-						Name:      gatewayv1beta1.ObjectName(svcName),
-						Port:      be.Port,
-						Namespace: be.Namespace,
-					}
-				}
-				svc := getServiceSpec(string(be.Name), helpers.NamespaceDerefOr(be.Namespace, r.Namespace), services)
-				if svc != nil {
-					bes = append(bes, backendToModelBackend(*svc, be, r.Namespace))
+				if backend, _, ok := resolveBackendRef(r.GetNamespace(), be, gatewayv1.SchemeGroupVersion.WithKind("TLSRoute"), services, serviceImports, grants); ok {
+					bes = append(bes, backend)
 				}
 			}
 
@@ -990,24 +893,8 @@ func toTCPRoutes(listener gatewayv1beta1.Listener,
 		for _, rule := range r.Spec.Rules {
 			bes := make([]model.Backend, 0, len(rule.BackendRefs))
 			for _, be := range rule.BackendRefs {
-				if !helpers.IsBackendReferenceAllowed(r.GetNamespace(), be, helpers.GatewayV1GVK("TCPRoute"), grants) {
-					continue
-				}
-				svcName, err := getBackendServiceName(helpers.NamespaceDerefOr(be.Namespace, r.Namespace), services, serviceImports, be.BackendObjectReference)
-				if err != nil {
-					continue
-				}
-				if svcName != string(be.Name) {
-					be = *be.DeepCopy()
-					be.BackendObjectReference = gatewayv1beta1.BackendObjectReference{
-						Name:      gatewayv1beta1.ObjectName(svcName),
-						Port:      be.Port,
-						Namespace: be.Namespace,
-					}
-				}
-				svc := getServiceSpec(string(be.Name), helpers.NamespaceDerefOr(be.Namespace, r.Namespace), services)
-				if svc != nil {
-					bes = append(bes, backendToModelBackend(*svc, be, r.Namespace))
+				if backend, _, ok := resolveBackendRef(r.GetNamespace(), be, gatewayv1.SchemeGroupVersion.WithKind("TCPRoute"), services, serviceImports, grants); ok {
+					bes = append(bes, backend)
 				}
 			}
 
@@ -1043,24 +930,8 @@ func toUDPRoutes(listener gatewayv1beta1.Listener,
 		for _, rule := range r.Spec.Rules {
 			bes := make([]model.Backend, 0, len(rule.BackendRefs))
 			for _, be := range rule.BackendRefs {
-				if !helpers.IsBackendReferenceAllowed(r.GetNamespace(), be, helpers.GatewayV1GVK("UDPRoute"), grants) {
-					continue
-				}
-				svcName, err := getBackendServiceName(helpers.NamespaceDerefOr(be.Namespace, r.Namespace), services, serviceImports, be.BackendObjectReference)
-				if err != nil {
-					continue
-				}
-				if svcName != string(be.Name) {
-					be = *be.DeepCopy()
-					be.BackendObjectReference = gatewayv1beta1.BackendObjectReference{
-						Name:      gatewayv1beta1.ObjectName(svcName),
-						Port:      be.Port,
-						Namespace: be.Namespace,
-					}
-				}
-				svc := getServiceSpec(string(be.Name), helpers.NamespaceDerefOr(be.Namespace, r.Namespace), services)
-				if svc != nil {
-					bes = append(bes, backendToModelBackend(*svc, be, r.Namespace))
+				if backend, _, ok := resolveBackendRef(r.GetNamespace(), be, gatewayv1.SchemeGroupVersion.WithKind("UDPRoute"), services, serviceImports, grants); ok {
+					bes = append(bes, backend)
 				}
 			}
 
@@ -1185,7 +1056,7 @@ func toHTTPExternalAuthFilter(log *slog.Logger, ea *gatewayv1.HTTPExternalAuthFi
 	return filter
 }
 
-func toHTTPRequestMirror(svc corev1.Service, mirror *gatewayv1.HTTPRequestMirrorFilter, ns string) *model.HTTPRequestMirror {
+func toHTTPRequestMirror(backend model.Backend, mirror *gatewayv1.HTTPRequestMirrorFilter) *model.HTTPRequestMirror {
 	var n, d int32 = 100, 100
 
 	switch {
@@ -1199,7 +1070,7 @@ func toHTTPRequestMirror(svc corev1.Service, mirror *gatewayv1.HTTPRequestMirror
 	}
 
 	return &model.HTTPRequestMirror{
-		Backend:     ptr.To(backendRefToModelBackend(svc, mirror.BackendRef, ns)),
+		Backend:     ptr.To(backend),
 		Numerator:   n,
 		Denominator: d,
 	}
@@ -1228,6 +1099,38 @@ func getServiceImport(svcName, svcNamespace string, serviceImports []mcsapiv1bet
 		}
 	}
 	return nil
+}
+
+func resolveBackendRef(routeNamespace string, be gatewayv1.BackendRef, routeGVK schema.GroupVersionKind, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1.ReferenceGrant) (model.Backend, *corev1.Service, bool) {
+	if !helpers.IsBackendReferenceAllowed(routeNamespace, be, routeGVK, grants) {
+		return model.Backend{}, nil, false
+	}
+
+	backendNamespace := helpers.NamespaceDerefOr(be.Namespace, routeNamespace)
+	svcName, err := getBackendServiceName(backendNamespace, services, serviceImports, be.BackendObjectReference)
+	if err != nil {
+		return model.Backend{}, nil, false
+	}
+
+	if svcName != string(be.Name) {
+		be = *be.DeepCopy()
+		be.BackendObjectReference = gatewayv1beta1.BackendObjectReference{
+			Name:      gatewayv1beta1.ObjectName(svcName),
+			Port:      be.Port,
+			Namespace: be.Namespace,
+		}
+	}
+
+	if be.Port == nil {
+		return model.Backend{}, nil, false
+	}
+
+	svc := getServiceSpec(string(be.Name), helpers.NamespaceDerefOr(be.Namespace, routeNamespace), services)
+	if svc == nil {
+		return model.Backend{}, nil, false
+	}
+
+	return backendToModelBackend(*svc, be, routeNamespace), svc, true
 }
 
 func backendToModelBackend(svc corev1.Service, be gatewayv1.BackendRef, defaultNamespace string) model.Backend {

--- a/operator/pkg/model/ingestion/gateway_test.go
+++ b/operator/pkg/model/ingestion/gateway_test.go
@@ -371,6 +371,272 @@ func TestHTTPAndGRPCGatewayAPIFiltersRoutesByListenerAllowedNamespaces(t *testin
 	assert.Equal(t, "podinfo", m.HTTP[1].Routes[1].Backends[0].Name)
 }
 
+func TestGRPCGatewayAPIFiltersRoutesByParentRefPort(t *testing.T) {
+	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+
+	m := GatewayAPI(logger, Input{
+		Gateway: gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "platform",
+				Namespace: "gateway-ns",
+			},
+			Spec: gatewayv1.GatewaySpec{
+				Listeners: []gatewayv1.Listener{
+					{
+						Name:     "grpc-443",
+						Port:     443,
+						Protocol: gatewayv1.HTTPSProtocolType,
+					},
+					{
+						Name:     "grpc-8443",
+						Port:     8443,
+						Protocol: gatewayv1.HTTPSProtocolType,
+					},
+				},
+			},
+		},
+		GRPCRoutes: []gatewayv1.GRPCRoute{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "grpc",
+					Namespace: "gateway-ns",
+				},
+				Spec: gatewayv1.GRPCRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name: "platform",
+								Port: ptr.To[gatewayv1.PortNumber](8443),
+							},
+						},
+					},
+					Rules: []gatewayv1.GRPCRouteRule{
+						{
+							BackendRefs: []gatewayv1.GRPCBackendRef{
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Name: "podinfo",
+											Port: ptr.To[gatewayv1.PortNumber](9898),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Services: []corev1.Service{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "podinfo",
+					Namespace: "gateway-ns",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{Port: 9898}},
+				},
+			},
+		},
+	})
+
+	require.Len(t, m.HTTP, 2)
+	require.Equal(t, "grpc-443", m.HTTP[0].Name)
+	assert.Empty(t, m.HTTP[0].Routes)
+
+	require.Equal(t, "grpc-8443", m.HTTP[1].Name)
+	require.Len(t, m.HTTP[1].Routes, 1)
+	require.Len(t, m.HTTP[1].Routes[0].Backends, 1)
+	assert.Equal(t, "podinfo", m.HTTP[1].Routes[0].Backends[0].Name)
+}
+
+func TestHTTPAndGRPCRequestMirrorRequiresReferenceGrant(t *testing.T) {
+	tests := map[string]struct {
+		grpc      bool
+		withGrant bool
+	}{
+		"http without grant": {},
+		"http with grant": {
+			withGrant: true,
+		},
+		"grpc without grant": {
+			grpc: true,
+		},
+		"grpc with grant": {
+			grpc:      true,
+			withGrant: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+
+			input := Input{
+				Gateway: gatewayv1.Gateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "platform",
+						Namespace: "app-ns",
+					},
+					Spec: gatewayv1.GatewaySpec{
+						Listeners: []gatewayv1.Listener{
+							{
+								Name:     "http",
+								Port:     80,
+								Protocol: gatewayv1.HTTPProtocolType,
+							},
+						},
+					},
+				},
+				Services: []corev1.Service{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "main",
+							Namespace: "app-ns",
+						},
+						Spec: corev1.ServiceSpec{
+							Ports: []corev1.ServicePort{{Port: 8080}},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "mirror",
+							Namespace: "mirror-ns",
+						},
+						Spec: corev1.ServiceSpec{
+							Ports: []corev1.ServicePort{{Port: 8081}},
+						},
+					},
+				},
+			}
+
+			routeKind := gatewayv1.Kind("HTTPRoute")
+			if tc.grpc {
+				routeKind = "GRPCRoute"
+				input.GRPCRoutes = []gatewayv1.GRPCRoute{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "grpc",
+							Namespace: "app-ns",
+						},
+						Spec: gatewayv1.GRPCRouteSpec{
+							CommonRouteSpec: gatewayv1.CommonRouteSpec{
+								ParentRefs: []gatewayv1.ParentReference{{Name: "platform"}},
+							},
+							Rules: []gatewayv1.GRPCRouteRule{
+								{
+									BackendRefs: []gatewayv1.GRPCBackendRef{
+										{
+											BackendRef: gatewayv1.BackendRef{
+												BackendObjectReference: gatewayv1.BackendObjectReference{
+													Name: "main",
+													Port: ptr.To[gatewayv1.PortNumber](8080),
+												},
+											},
+										},
+									},
+									Filters: []gatewayv1.GRPCRouteFilter{
+										{
+											Type: gatewayv1.GRPCRouteFilterRequestMirror,
+											RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+												BackendRef: gatewayv1.BackendObjectReference{
+													Name:      "mirror",
+													Namespace: ptr.To[gatewayv1.Namespace]("mirror-ns"),
+													Port:      ptr.To[gatewayv1.PortNumber](8081),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+			} else {
+				input.HTTPRoutes = []gatewayv1.HTTPRoute{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "http",
+							Namespace: "app-ns",
+						},
+						Spec: gatewayv1.HTTPRouteSpec{
+							CommonRouteSpec: gatewayv1.CommonRouteSpec{
+								ParentRefs: []gatewayv1.ParentReference{{Name: "platform"}},
+							},
+							Rules: []gatewayv1.HTTPRouteRule{
+								{
+									BackendRefs: []gatewayv1.HTTPBackendRef{
+										{
+											BackendRef: gatewayv1.BackendRef{
+												BackendObjectReference: gatewayv1.BackendObjectReference{
+													Name: "main",
+													Port: ptr.To[gatewayv1.PortNumber](8080),
+												},
+											},
+										},
+									},
+									Filters: []gatewayv1.HTTPRouteFilter{
+										{
+											Type: gatewayv1.HTTPRouteFilterRequestMirror,
+											RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+												BackendRef: gatewayv1.BackendObjectReference{
+													Name:      "mirror",
+													Namespace: ptr.To[gatewayv1.Namespace]("mirror-ns"),
+													Port:      ptr.To[gatewayv1.PortNumber](8081),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+			}
+
+			if tc.withGrant {
+				input.ReferenceGrants = []gatewayv1.ReferenceGrant{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "allow-mirror",
+							Namespace: "mirror-ns",
+						},
+						Spec: gatewayv1.ReferenceGrantSpec{
+							From: []gatewayv1.ReferenceGrantFrom{
+								{
+									Group:     gatewayv1.Group(gatewayv1.GroupVersion.Group),
+									Kind:      routeKind,
+									Namespace: gatewayv1.Namespace("app-ns"),
+								},
+							},
+							To: []gatewayv1.ReferenceGrantTo{
+								{
+									Group: gatewayv1.Group(""),
+									Kind:  gatewayv1.Kind("Service"),
+									Name:  ptr.To[gatewayv1.ObjectName]("mirror"),
+								},
+							},
+						},
+					},
+				}
+			}
+
+			m := GatewayAPI(logger, input)
+
+			require.Len(t, m.HTTP, 1)
+			require.Len(t, m.HTTP[0].Routes, 1)
+			if tc.withGrant {
+				require.Len(t, m.HTTP[0].Routes[0].RequestMirrors, 1)
+				require.NotNil(t, m.HTTP[0].Routes[0].RequestMirrors[0].Backend)
+				assert.Equal(t, "mirror", m.HTTP[0].Routes[0].RequestMirrors[0].Backend.Name)
+				assert.Equal(t, "mirror-ns", m.HTTP[0].Routes[0].RequestMirrors[0].Backend.Namespace)
+			} else {
+				assert.Empty(t, m.HTTP[0].Routes[0].RequestMirrors)
+			}
+		})
+	}
+}
+
 func TestTLSGatewayAPIFiltersRoutesByListenerAllowedNamespaces(t *testing.T) {
 	sameNamespace := gatewayv1.NamespacesFromSame
 	allNamespaces := gatewayv1.NamespacesFromAll
@@ -464,6 +730,83 @@ func TestTLSGatewayAPIFiltersRoutesByListenerAllowedNamespaces(t *testing.T) {
 	require.Equal(t, "tls-all", m.TLSPassthrough[1].Name)
 	require.Len(t, m.TLSPassthrough[1].Routes, 1)
 	assert.Equal(t, []string{"tls.example.test"}, m.TLSPassthrough[1].Routes[0].Hostnames)
+	require.Len(t, m.TLSPassthrough[1].Routes[0].Backends, 1)
+	assert.Equal(t, "podinfo", m.TLSPassthrough[1].Routes[0].Backends[0].Name)
+}
+
+func TestTLSGatewayAPIFiltersRoutesByParentRefPort(t *testing.T) {
+	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+
+	m := GatewayAPI(logger, Input{
+		Gateway: gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "platform",
+				Namespace: "gateway-ns",
+			},
+			Spec: gatewayv1.GatewaySpec{
+				Listeners: []gatewayv1.Listener{
+					{
+						Name:     "tls-443",
+						Port:     443,
+						Protocol: gatewayv1.TLSProtocolType,
+					},
+					{
+						Name:     "tls-8443",
+						Port:     8443,
+						Protocol: gatewayv1.TLSProtocolType,
+					},
+				},
+			},
+		},
+		TLSRoutes: []gatewayv1.TLSRoute{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tls",
+					Namespace: "gateway-ns",
+				},
+				Spec: gatewayv1.TLSRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name: "platform",
+								Port: ptr.To[gatewayv1.PortNumber](8443),
+							},
+						},
+					},
+					Rules: []gatewayv1.TLSRouteRule{
+						{
+							BackendRefs: []gatewayv1.BackendRef{
+								{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Name: "podinfo",
+										Port: ptr.To[gatewayv1.PortNumber](9898),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Services: []corev1.Service{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "podinfo",
+					Namespace: "gateway-ns",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{Port: 9898}},
+				},
+			},
+		},
+	})
+
+	require.Len(t, m.TLSPassthrough, 2)
+	require.Equal(t, "tls-443", m.TLSPassthrough[0].Name)
+	assert.Empty(t, m.TLSPassthrough[0].Routes)
+
+	require.Equal(t, "tls-8443", m.TLSPassthrough[1].Name)
+	require.Len(t, m.TLSPassthrough[1].Routes, 1)
 	require.Len(t, m.TLSPassthrough[1].Routes[0].Backends, 1)
 	assert.Equal(t, "podinfo", m.TLSPassthrough[1].Routes[0].Backends[0].Name)
 }
@@ -745,6 +1088,232 @@ func TestL4GatewayAPIFiltersRoutesByListenerAllowedNamespaces(t *testing.T) {
 	require.Len(t, m.L4[3].Routes, 1)
 	require.Len(t, m.L4[3].Routes[0].Backends, 1)
 	assert.Equal(t, "udp-backend", m.L4[3].Routes[0].Backends[0].Name)
+}
+
+func TestGatewayAPISkipsBackendsWithMissingPorts(t *testing.T) {
+	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+
+	m := GatewayAPI(logger, Input{
+		Gateway: gatewayv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "platform",
+				Namespace: "app-ns",
+			},
+			Spec: gatewayv1.GatewaySpec{
+				Listeners: []gatewayv1.Listener{
+					{
+						Name:     "http",
+						Port:     80,
+						Protocol: gatewayv1.HTTPProtocolType,
+					},
+					{
+						Name:     "grpc",
+						Port:     81,
+						Protocol: gatewayv1.HTTPProtocolType,
+					},
+					{
+						Name:     "tls",
+						Port:     443,
+						Protocol: gatewayv1.TLSProtocolType,
+					},
+					{
+						Name:     "tcp",
+						Port:     9000,
+						Protocol: gatewayv1.TCPProtocolType,
+					},
+					{
+						Name:     "udp",
+						Port:     9001,
+						Protocol: gatewayv1.UDPProtocolType,
+					},
+				},
+			},
+		},
+		HTTPRoutes: []gatewayv1.HTTPRoute{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "http",
+					Namespace: "app-ns",
+				},
+				Spec: gatewayv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:        "platform",
+								SectionName: ptr.To[gatewayv1.SectionName]("http"),
+							},
+						},
+					},
+					Rules: []gatewayv1.HTTPRouteRule{
+						{
+							BackendRefs: []gatewayv1.HTTPBackendRef{
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Name: "backend",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		GRPCRoutes: []gatewayv1.GRPCRoute{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "grpc",
+					Namespace: "app-ns",
+				},
+				Spec: gatewayv1.GRPCRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:        "platform",
+								SectionName: ptr.To[gatewayv1.SectionName]("grpc"),
+							},
+						},
+					},
+					Rules: []gatewayv1.GRPCRouteRule{
+						{
+							BackendRefs: []gatewayv1.GRPCBackendRef{
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Name: "backend",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		TLSRoutes: []gatewayv1.TLSRoute{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tls",
+					Namespace: "app-ns",
+				},
+				Spec: gatewayv1.TLSRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:        "platform",
+								SectionName: ptr.To[gatewayv1.SectionName]("tls"),
+							},
+						},
+					},
+					Rules: []gatewayv1.TLSRouteRule{
+						{
+							BackendRefs: []gatewayv1.BackendRef{
+								{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Name: "backend",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		TCPRoutes: []gatewayv1.TCPRoute{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tcp",
+					Namespace: "app-ns",
+				},
+				Spec: gatewayv1.TCPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:        "platform",
+								SectionName: ptr.To[gatewayv1.SectionName]("tcp"),
+							},
+						},
+					},
+					Rules: []gatewayv1.TCPRouteRule{
+						{
+							BackendRefs: []gatewayv1.BackendRef{
+								{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Name: "backend",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		UDPRoutes: []gatewayv1.UDPRoute{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "udp",
+					Namespace: "app-ns",
+				},
+				Spec: gatewayv1.UDPRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{
+								Name:        "platform",
+								SectionName: ptr.To[gatewayv1.SectionName]("udp"),
+							},
+						},
+					},
+					Rules: []gatewayv1.UDPRouteRule{
+						{
+							BackendRefs: []gatewayv1.BackendRef{
+								{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Name: "backend",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Services: []corev1.Service{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "backend",
+					Namespace: "app-ns",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{Port: 8080}},
+				},
+			},
+		},
+	})
+
+	require.Len(t, m.HTTP, 3)
+	require.Equal(t, "http", m.HTTP[0].Name)
+	require.Len(t, m.HTTP[0].Routes, 1)
+	assert.Empty(t, m.HTTP[0].Routes[0].Backends)
+	assert.Equal(t, &model.DirectResponse{StatusCode: 500}, m.HTTP[0].Routes[0].DirectResponse)
+
+	require.Equal(t, "grpc", m.HTTP[1].Name)
+	require.Len(t, m.HTTP[1].Routes, 1)
+	assert.Empty(t, m.HTTP[1].Routes[0].Backends)
+	assert.Equal(t, &model.DirectResponse{StatusCode: 500}, m.HTTP[1].Routes[0].DirectResponse)
+
+	require.Equal(t, "tls", m.HTTP[2].Name)
+	assert.Empty(t, m.HTTP[2].Routes)
+
+	require.Len(t, m.TLSPassthrough, 1)
+	require.Len(t, m.TLSPassthrough[0].Routes, 1)
+	assert.Empty(t, m.TLSPassthrough[0].Routes[0].Backends)
+
+	require.Len(t, m.L4, 2)
+	require.Len(t, m.L4[0].Routes, 1)
+	assert.Empty(t, m.L4[0].Routes[0].Backends)
+	require.Len(t, m.L4[1].Routes, 1)
+	assert.Empty(t, m.L4[1].Routes[0].Backends)
 }
 
 func TestGPRCPathMatch(t *testing.T) {
@@ -1402,6 +1971,7 @@ func readGatewayInput(t *testing.T, testName string) Input {
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-httproute.yaml"), &input.HTTPRoutes)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-tlsroute.yaml"), &input.TLSRoutes)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-grpcroute.yaml"), &input.GRPCRoutes)
+	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-referencegrant.yaml"), &input.ReferenceGrants)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-namespace.yaml"), &input.Namespaces)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-tcproute.yaml"), &input.TCPRoutes)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-udproute.yaml"), &input.UDPRoutes)

--- a/operator/pkg/model/ingestion/gateway_test.go
+++ b/operator/pkg/model/ingestion/gateway_test.go
@@ -105,6 +105,15 @@ func TestHTTPGatewayAPI(t *testing.T) {
 		"http external auth http tls":                             {},
 		"http external auth grpc tls":                             {},
 		"http external auth shared and no auth":                   {},
+		"http request mirror cross namespace no grant":            {},
+		"http request mirror cross namespace with grant":          {},
+		"grpc request mirror cross namespace no grant":            {},
+		"grpc request mirror cross namespace with grant":          {},
+		"http skips backends missing port":                        {},
+		"http cross namespace backend no grant":                   {},
+		"http cross namespace backend with grant":                 {},
+		"grpc cross namespace backend no grant":                   {},
+		"grpc cross namespace backend with grant":                 {},
 	}
 
 	for name := range tests {
@@ -672,6 +681,8 @@ func TestTLSGatewayAPI(t *testing.T) {
 		"mixed protocol listeners TLSRoute":        {},
 		"tls weighted backends":                    {},
 		"tls route parent ref filter":              {},
+		"tls route filters by parent ref port":     {},
+		"tls skips backends missing port":          {},
 	}
 
 	for name := range tests {
@@ -690,7 +701,8 @@ func TestTLSGatewayAPI(t *testing.T) {
 
 func TestGRPCGatewayAPI(t *testing.T) {
 	tests := map[string]struct{}{
-		"basic grpc": {},
+		"basic grpc":                            {},
+		"grpc route filters by parent ref port": {},
 	}
 
 	for name := range tests {
@@ -710,7 +722,8 @@ func TestGRPCGatewayAPI(t *testing.T) {
 
 func TestL4GatewayAPI(t *testing.T) {
 	tests := map[string]struct{}{
-		"basic l4": {},
+		"basic l4":                       {},
+		"l4 skips backends missing port": {},
 	}
 
 	for name := range tests {
@@ -1888,6 +1901,7 @@ func readGatewayInput(t *testing.T, testName string) Input {
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-httproute.yaml"), &input.HTTPRoutes)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-tlsroute.yaml"), &input.TLSRoutes)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-grpcroute.yaml"), &input.GRPCRoutes)
+	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-referencegrant.yaml"), &input.ReferenceGrants)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-tcproute.yaml"), &input.TCPRoutes)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-udproute.yaml"), &input.UDPRoutes)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-service.yaml"), &input.Services)

--- a/operator/pkg/model/ingestion/testdata/gateway/grpc_cross_namespace_backend_no_grant/input-gateway.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/grpc_cross_namespace_backend_no_grant/input-gateway.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: platform
+  namespace: app-ns
+spec:
+  gatewayClassName: ""
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/grpc_cross_namespace_backend_no_grant/input-grpcroute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/grpc_cross_namespace_backend_no_grant/input-grpcroute.yaml
@@ -1,0 +1,14 @@
+- metadata:
+    creationTimestamp: null
+    name: grpc
+    namespace: app-ns
+  spec:
+    parentRefs:
+    - name: platform
+    rules:
+    - backendRefs:
+      - name: backend
+        namespace: other-ns
+        port: 8080
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gateway/grpc_cross_namespace_backend_no_grant/input-service.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/grpc_cross_namespace_backend_no_grant/input-service.yaml
@@ -1,0 +1,9 @@
+- metadata:
+    creationTimestamp: null
+    name: backend
+    namespace: other-ns
+  spec:
+    ports:
+    - port: 8080
+  status:
+    loadBalancer: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/grpc_cross_namespace_backend_no_grant/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/grpc_cross_namespace_backend_no_grant/output-listeners.yaml
@@ -1,0 +1,14 @@
+- hostname: "*"
+  name: http
+  port: 80
+  routes:
+  - direct_response:
+      status_code: 500
+    path_match: {}
+    timeout: {}
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: platform
+    namespace: app-ns
+    version: v1

--- a/operator/pkg/model/ingestion/testdata/gateway/grpc_cross_namespace_backend_with_grant/input-gateway.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/grpc_cross_namespace_backend_with_grant/input-gateway.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: platform
+  namespace: app-ns
+spec:
+  gatewayClassName: ""
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/grpc_cross_namespace_backend_with_grant/input-grpcroute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/grpc_cross_namespace_backend_with_grant/input-grpcroute.yaml
@@ -1,0 +1,14 @@
+- metadata:
+    creationTimestamp: null
+    name: grpc
+    namespace: app-ns
+  spec:
+    parentRefs:
+    - name: platform
+    rules:
+    - backendRefs:
+      - name: backend
+        namespace: other-ns
+        port: 8080
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gateway/grpc_cross_namespace_backend_with_grant/input-referencegrant.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/grpc_cross_namespace_backend_with_grant/input-referencegrant.yaml
@@ -1,0 +1,12 @@
+- metadata:
+    creationTimestamp: null
+    name: allow-backend
+    namespace: other-ns
+  spec:
+    from:
+    - group: gateway.networking.k8s.io
+      kind: GRPCRoute
+      namespace: app-ns
+    to:
+    - group: ""
+      kind: Service

--- a/operator/pkg/model/ingestion/testdata/gateway/grpc_cross_namespace_backend_with_grant/input-service.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/grpc_cross_namespace_backend_with_grant/input-service.yaml
@@ -1,0 +1,9 @@
+- metadata:
+    creationTimestamp: null
+    name: backend
+    namespace: other-ns
+  spec:
+    ports:
+    - port: 8080
+  status:
+    loadBalancer: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/grpc_cross_namespace_backend_with_grant/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/grpc_cross_namespace_backend_with_grant/output-listeners.yaml
@@ -1,0 +1,17 @@
+- hostname: "*"
+  name: http
+  port: 80
+  routes:
+  - backends:
+    - name: backend
+      namespace: other-ns
+      port:
+        port: 8080
+    path_match: {}
+    timeout: {}
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: platform
+    namespace: app-ns
+    version: v1

--- a/operator/pkg/model/ingestion/testdata/gateway/grpc_request_mirror_cross_namespace_no_grant/input-gateway.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/grpc_request_mirror_cross_namespace_no_grant/input-gateway.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: platform
+  namespace: app-ns
+spec:
+  gatewayClassName: ""
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/grpc_request_mirror_cross_namespace_no_grant/input-grpcroute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/grpc_request_mirror_cross_namespace_no_grant/input-grpcroute.yaml
@@ -1,0 +1,20 @@
+- metadata:
+    creationTimestamp: null
+    name: grpc
+    namespace: app-ns
+  spec:
+    parentRefs:
+    - name: platform
+    rules:
+    - backendRefs:
+      - name: main
+        port: 8080
+      filters:
+      - requestMirror:
+          backendRef:
+            name: mirror
+            namespace: mirror-ns
+            port: 8081
+        type: RequestMirror
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gateway/grpc_request_mirror_cross_namespace_no_grant/input-service.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/grpc_request_mirror_cross_namespace_no_grant/input-service.yaml
@@ -1,0 +1,18 @@
+- metadata:
+    creationTimestamp: null
+    name: main
+    namespace: app-ns
+  spec:
+    ports:
+    - port: 8080
+  status:
+    loadBalancer: {}
+- metadata:
+    creationTimestamp: null
+    name: mirror
+    namespace: mirror-ns
+  spec:
+    ports:
+    - port: 8081
+  status:
+    loadBalancer: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/grpc_request_mirror_cross_namespace_no_grant/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/grpc_request_mirror_cross_namespace_no_grant/output-listeners.yaml
@@ -1,0 +1,17 @@
+- hostname: "*"
+  name: http
+  port: 80
+  routes:
+  - backends:
+    - name: main
+      namespace: app-ns
+      port:
+        port: 8080
+    path_match: {}
+    timeout: {}
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: platform
+    namespace: app-ns
+    version: v1

--- a/operator/pkg/model/ingestion/testdata/gateway/grpc_request_mirror_cross_namespace_with_grant/input-gateway.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/grpc_request_mirror_cross_namespace_with_grant/input-gateway.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: platform
+  namespace: app-ns
+spec:
+  gatewayClassName: ""
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/grpc_request_mirror_cross_namespace_with_grant/input-grpcroute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/grpc_request_mirror_cross_namespace_with_grant/input-grpcroute.yaml
@@ -1,0 +1,20 @@
+- metadata:
+    creationTimestamp: null
+    name: grpc
+    namespace: app-ns
+  spec:
+    parentRefs:
+    - name: platform
+    rules:
+    - backendRefs:
+      - name: main
+        port: 8080
+      filters:
+      - requestMirror:
+          backendRef:
+            name: mirror
+            namespace: mirror-ns
+            port: 8081
+        type: RequestMirror
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gateway/grpc_request_mirror_cross_namespace_with_grant/input-referencegrant.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/grpc_request_mirror_cross_namespace_with_grant/input-referencegrant.yaml
@@ -1,0 +1,13 @@
+- metadata:
+    creationTimestamp: null
+    name: allow-mirror
+    namespace: mirror-ns
+  spec:
+    from:
+    - group: gateway.networking.k8s.io
+      kind: GRPCRoute
+      namespace: app-ns
+    to:
+    - group: ""
+      kind: Service
+      name: mirror

--- a/operator/pkg/model/ingestion/testdata/gateway/grpc_request_mirror_cross_namespace_with_grant/input-service.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/grpc_request_mirror_cross_namespace_with_grant/input-service.yaml
@@ -1,0 +1,18 @@
+- metadata:
+    creationTimestamp: null
+    name: main
+    namespace: app-ns
+  spec:
+    ports:
+    - port: 8080
+  status:
+    loadBalancer: {}
+- metadata:
+    creationTimestamp: null
+    name: mirror
+    namespace: mirror-ns
+  spec:
+    ports:
+    - port: 8081
+  status:
+    loadBalancer: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/grpc_request_mirror_cross_namespace_with_grant/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/grpc_request_mirror_cross_namespace_with_grant/output-listeners.yaml
@@ -1,0 +1,25 @@
+- hostname: "*"
+  name: http
+  port: 80
+  routes:
+  - backends:
+    - name: main
+      namespace: app-ns
+      port:
+        port: 8080
+    path_match: {}
+    request_mirrors:
+    - backend:
+        name: mirror
+        namespace: mirror-ns
+        port:
+          port: 8081
+      denominator: 100
+      numerator: 100
+    timeout: {}
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: platform
+    namespace: app-ns
+    version: v1

--- a/operator/pkg/model/ingestion/testdata/gateway/grpc_route_filters_by_parent_ref_port/input-gateway.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/grpc_route_filters_by_parent_ref_port/input-gateway.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: platform
+  namespace: gateway-ns
+spec:
+  gatewayClassName: ""
+  listeners:
+  - name: grpc-443
+    port: 443
+    protocol: HTTPS
+  - name: grpc-8443
+    port: 8443
+    protocol: HTTPS
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/grpc_route_filters_by_parent_ref_port/input-grpcroute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/grpc_route_filters_by_parent_ref_port/input-grpcroute.yaml
@@ -1,0 +1,14 @@
+- metadata:
+    creationTimestamp: null
+    name: grpc
+    namespace: gateway-ns
+  spec:
+    parentRefs:
+    - name: platform
+      port: 8443
+    rules:
+    - backendRefs:
+      - name: podinfo
+        port: 9898
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gateway/grpc_route_filters_by_parent_ref_port/input-service.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/grpc_route_filters_by_parent_ref_port/input-service.yaml
@@ -1,0 +1,9 @@
+- metadata:
+    creationTimestamp: null
+    name: podinfo
+    namespace: gateway-ns
+  spec:
+    ports:
+    - port: 9898
+  status:
+    loadBalancer: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/grpc_route_filters_by_parent_ref_port/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/grpc_route_filters_by_parent_ref_port/output-listeners.yaml
@@ -1,0 +1,26 @@
+- hostname: "*"
+  name: grpc-443
+  port: 443
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: platform
+    namespace: gateway-ns
+    version: v1
+- hostname: "*"
+  name: grpc-8443
+  port: 8443
+  routes:
+  - backends:
+    - name: podinfo
+      namespace: gateway-ns
+      port:
+        port: 9898
+    path_match: {}
+    timeout: {}
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: platform
+    namespace: gateway-ns
+    version: v1

--- a/operator/pkg/model/ingestion/testdata/gateway/http_cross_namespace_backend_no_grant/input-gateway.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/http_cross_namespace_backend_no_grant/input-gateway.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: platform
+  namespace: app-ns
+spec:
+  gatewayClassName: ""
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/http_cross_namespace_backend_no_grant/input-httproute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/http_cross_namespace_backend_no_grant/input-httproute.yaml
@@ -1,0 +1,14 @@
+- metadata:
+    creationTimestamp: null
+    name: http
+    namespace: app-ns
+  spec:
+    parentRefs:
+    - name: platform
+    rules:
+    - backendRefs:
+      - name: backend
+        namespace: other-ns
+        port: 8080
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gateway/http_cross_namespace_backend_no_grant/input-service.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/http_cross_namespace_backend_no_grant/input-service.yaml
@@ -1,0 +1,9 @@
+- metadata:
+    creationTimestamp: null
+    name: backend
+    namespace: other-ns
+  spec:
+    ports:
+    - port: 8080
+  status:
+    loadBalancer: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/http_cross_namespace_backend_no_grant/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/http_cross_namespace_backend_no_grant/output-listeners.yaml
@@ -1,0 +1,14 @@
+- hostname: "*"
+  name: http
+  port: 80
+  routes:
+  - direct_response:
+      status_code: 500
+    path_match: {}
+    timeout: {}
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: platform
+    namespace: app-ns
+    version: v1

--- a/operator/pkg/model/ingestion/testdata/gateway/http_cross_namespace_backend_with_grant/input-gateway.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/http_cross_namespace_backend_with_grant/input-gateway.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: platform
+  namespace: app-ns
+spec:
+  gatewayClassName: ""
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/http_cross_namespace_backend_with_grant/input-httproute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/http_cross_namespace_backend_with_grant/input-httproute.yaml
@@ -1,0 +1,14 @@
+- metadata:
+    creationTimestamp: null
+    name: http
+    namespace: app-ns
+  spec:
+    parentRefs:
+    - name: platform
+    rules:
+    - backendRefs:
+      - name: backend
+        namespace: other-ns
+        port: 8080
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gateway/http_cross_namespace_backend_with_grant/input-referencegrant.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/http_cross_namespace_backend_with_grant/input-referencegrant.yaml
@@ -1,0 +1,12 @@
+- metadata:
+    creationTimestamp: null
+    name: allow-backend
+    namespace: other-ns
+  spec:
+    from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: app-ns
+    to:
+    - group: ""
+      kind: Service

--- a/operator/pkg/model/ingestion/testdata/gateway/http_cross_namespace_backend_with_grant/input-service.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/http_cross_namespace_backend_with_grant/input-service.yaml
@@ -1,0 +1,9 @@
+- metadata:
+    creationTimestamp: null
+    name: backend
+    namespace: other-ns
+  spec:
+    ports:
+    - port: 8080
+  status:
+    loadBalancer: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/http_cross_namespace_backend_with_grant/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/http_cross_namespace_backend_with_grant/output-listeners.yaml
@@ -1,0 +1,17 @@
+- hostname: "*"
+  name: http
+  port: 80
+  routes:
+  - backends:
+    - name: backend
+      namespace: other-ns
+      port:
+        port: 8080
+    path_match: {}
+    timeout: {}
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: platform
+    namespace: app-ns
+    version: v1

--- a/operator/pkg/model/ingestion/testdata/gateway/http_request_mirror_cross_namespace_no_grant/input-gateway.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/http_request_mirror_cross_namespace_no_grant/input-gateway.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: platform
+  namespace: app-ns
+spec:
+  gatewayClassName: ""
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/http_request_mirror_cross_namespace_no_grant/input-httproute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/http_request_mirror_cross_namespace_no_grant/input-httproute.yaml
@@ -1,0 +1,20 @@
+- metadata:
+    creationTimestamp: null
+    name: http
+    namespace: app-ns
+  spec:
+    parentRefs:
+    - name: platform
+    rules:
+    - backendRefs:
+      - name: main
+        port: 8080
+      filters:
+      - requestMirror:
+          backendRef:
+            name: mirror
+            namespace: mirror-ns
+            port: 8081
+        type: RequestMirror
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gateway/http_request_mirror_cross_namespace_no_grant/input-service.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/http_request_mirror_cross_namespace_no_grant/input-service.yaml
@@ -1,0 +1,18 @@
+- metadata:
+    creationTimestamp: null
+    name: main
+    namespace: app-ns
+  spec:
+    ports:
+    - port: 8080
+  status:
+    loadBalancer: {}
+- metadata:
+    creationTimestamp: null
+    name: mirror
+    namespace: mirror-ns
+  spec:
+    ports:
+    - port: 8081
+  status:
+    loadBalancer: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/http_request_mirror_cross_namespace_no_grant/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/http_request_mirror_cross_namespace_no_grant/output-listeners.yaml
@@ -1,0 +1,17 @@
+- hostname: "*"
+  name: http
+  port: 80
+  routes:
+  - backends:
+    - name: main
+      namespace: app-ns
+      port:
+        port: 8080
+    path_match: {}
+    timeout: {}
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: platform
+    namespace: app-ns
+    version: v1

--- a/operator/pkg/model/ingestion/testdata/gateway/http_request_mirror_cross_namespace_with_grant/input-gateway.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/http_request_mirror_cross_namespace_with_grant/input-gateway.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: platform
+  namespace: app-ns
+spec:
+  gatewayClassName: ""
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/http_request_mirror_cross_namespace_with_grant/input-httproute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/http_request_mirror_cross_namespace_with_grant/input-httproute.yaml
@@ -1,0 +1,20 @@
+- metadata:
+    creationTimestamp: null
+    name: http
+    namespace: app-ns
+  spec:
+    parentRefs:
+    - name: platform
+    rules:
+    - backendRefs:
+      - name: main
+        port: 8080
+      filters:
+      - requestMirror:
+          backendRef:
+            name: mirror
+            namespace: mirror-ns
+            port: 8081
+        type: RequestMirror
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gateway/http_request_mirror_cross_namespace_with_grant/input-referencegrant.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/http_request_mirror_cross_namespace_with_grant/input-referencegrant.yaml
@@ -1,0 +1,13 @@
+- metadata:
+    creationTimestamp: null
+    name: allow-mirror
+    namespace: mirror-ns
+  spec:
+    from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: app-ns
+    to:
+    - group: ""
+      kind: Service
+      name: mirror

--- a/operator/pkg/model/ingestion/testdata/gateway/http_request_mirror_cross_namespace_with_grant/input-service.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/http_request_mirror_cross_namespace_with_grant/input-service.yaml
@@ -1,0 +1,18 @@
+- metadata:
+    creationTimestamp: null
+    name: main
+    namespace: app-ns
+  spec:
+    ports:
+    - port: 8080
+  status:
+    loadBalancer: {}
+- metadata:
+    creationTimestamp: null
+    name: mirror
+    namespace: mirror-ns
+  spec:
+    ports:
+    - port: 8081
+  status:
+    loadBalancer: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/http_request_mirror_cross_namespace_with_grant/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/http_request_mirror_cross_namespace_with_grant/output-listeners.yaml
@@ -1,0 +1,25 @@
+- hostname: "*"
+  name: http
+  port: 80
+  routes:
+  - backends:
+    - name: main
+      namespace: app-ns
+      port:
+        port: 8080
+    path_match: {}
+    request_mirrors:
+    - backend:
+        name: mirror
+        namespace: mirror-ns
+        port:
+          port: 8081
+      denominator: 100
+      numerator: 100
+    timeout: {}
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: platform
+    namespace: app-ns
+    version: v1

--- a/operator/pkg/model/ingestion/testdata/gateway/http_skips_backends_missing_port/input-gateway.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/http_skips_backends_missing_port/input-gateway.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: platform
+  namespace: app-ns
+spec:
+  gatewayClassName: ""
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+  - name: grpc
+    port: 81
+    protocol: HTTP
+  - name: tls
+    port: 443
+    protocol: TLS
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/http_skips_backends_missing_port/input-grpcroute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/http_skips_backends_missing_port/input-grpcroute.yaml
@@ -1,0 +1,13 @@
+- metadata:
+    creationTimestamp: null
+    name: grpc
+    namespace: app-ns
+  spec:
+    parentRefs:
+    - name: platform
+      sectionName: grpc
+    rules:
+    - backendRefs:
+      - name: backend
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gateway/http_skips_backends_missing_port/input-httproute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/http_skips_backends_missing_port/input-httproute.yaml
@@ -1,0 +1,13 @@
+- metadata:
+    creationTimestamp: null
+    name: http
+    namespace: app-ns
+  spec:
+    parentRefs:
+    - name: platform
+      sectionName: http
+    rules:
+    - backendRefs:
+      - name: backend
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gateway/http_skips_backends_missing_port/input-service.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/http_skips_backends_missing_port/input-service.yaml
@@ -1,0 +1,9 @@
+- metadata:
+    creationTimestamp: null
+    name: backend
+    namespace: app-ns
+  spec:
+    ports:
+    - port: 8080
+  status:
+    loadBalancer: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/http_skips_backends_missing_port/input-tlsroute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/http_skips_backends_missing_port/input-tlsroute.yaml
@@ -1,0 +1,13 @@
+- metadata:
+    creationTimestamp: null
+    name: tls
+    namespace: app-ns
+  spec:
+    parentRefs:
+    - name: platform
+      sectionName: tls
+    rules:
+    - backendRefs:
+      - name: backend
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gateway/http_skips_backends_missing_port/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/http_skips_backends_missing_port/output-listeners.yaml
@@ -1,0 +1,37 @@
+- hostname: "*"
+  name: http
+  port: 80
+  routes:
+  - direct_response:
+      status_code: 500
+    path_match: {}
+    timeout: {}
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: platform
+    namespace: app-ns
+    version: v1
+- hostname: "*"
+  name: grpc
+  port: 81
+  routes:
+  - direct_response:
+      status_code: 500
+    path_match: {}
+    timeout: {}
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: platform
+    namespace: app-ns
+    version: v1
+- hostname: "*"
+  name: tls
+  port: 443
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: platform
+    namespace: app-ns
+    version: v1

--- a/operator/pkg/model/ingestion/testdata/gateway/l4_skips_backends_missing_port/input-gateway.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/l4_skips_backends_missing_port/input-gateway.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: platform
+  namespace: app-ns
+spec:
+  gatewayClassName: ""
+  listeners:
+  - name: tcp
+    port: 9000
+    protocol: TCP
+  - name: udp
+    port: 9001
+    protocol: UDP
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/l4_skips_backends_missing_port/input-service.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/l4_skips_backends_missing_port/input-service.yaml
@@ -1,0 +1,9 @@
+- metadata:
+    creationTimestamp: null
+    name: backend
+    namespace: app-ns
+  spec:
+    ports:
+    - port: 8080
+  status:
+    loadBalancer: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/l4_skips_backends_missing_port/input-tcproute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/l4_skips_backends_missing_port/input-tcproute.yaml
@@ -1,0 +1,13 @@
+- metadata:
+    creationTimestamp: null
+    name: tcp
+    namespace: app-ns
+  spec:
+    parentRefs:
+    - name: platform
+      sectionName: tcp
+    rules:
+    - backendRefs:
+      - name: backend
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gateway/l4_skips_backends_missing_port/input-udproute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/l4_skips_backends_missing_port/input-udproute.yaml
@@ -1,0 +1,13 @@
+- metadata:
+    creationTimestamp: null
+    name: udp
+    namespace: app-ns
+  spec:
+    parentRefs:
+    - name: platform
+      sectionName: udp
+    rules:
+    - backendRefs:
+      - name: backend
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gateway/l4_skips_backends_missing_port/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/l4_skips_backends_missing_port/output-listeners.yaml
@@ -1,0 +1,22 @@
+- name: tcp
+  port: 9000
+  protocol: TCP
+  routes:
+  - {}
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: platform
+    namespace: app-ns
+    version: v1
+- name: udp
+  port: 9001
+  protocol: UDP
+  routes:
+  - {}
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: platform
+    namespace: app-ns
+    version: v1

--- a/operator/pkg/model/ingestion/testdata/gateway/tls_route_filters_by_parent_ref_port/input-gateway.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/tls_route_filters_by_parent_ref_port/input-gateway.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: platform
+  namespace: gateway-ns
+spec:
+  gatewayClassName: ""
+  listeners:
+  - name: tls-443
+    port: 443
+    protocol: TLS
+  - name: tls-8443
+    port: 8443
+    protocol: TLS
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/tls_route_filters_by_parent_ref_port/input-service.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/tls_route_filters_by_parent_ref_port/input-service.yaml
@@ -1,0 +1,9 @@
+- metadata:
+    creationTimestamp: null
+    name: podinfo
+    namespace: gateway-ns
+  spec:
+    ports:
+    - port: 9898
+  status:
+    loadBalancer: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/tls_route_filters_by_parent_ref_port/input-tlsroute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/tls_route_filters_by_parent_ref_port/input-tlsroute.yaml
@@ -1,0 +1,14 @@
+- metadata:
+    creationTimestamp: null
+    name: tls
+    namespace: gateway-ns
+  spec:
+    parentRefs:
+    - name: platform
+      port: 8443
+    rules:
+    - backendRefs:
+      - name: podinfo
+        port: 9898
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gateway/tls_route_filters_by_parent_ref_port/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/tls_route_filters_by_parent_ref_port/output-listeners.yaml
@@ -1,0 +1,24 @@
+- hostname: "*"
+  name: tls-443
+  port: 443
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: platform
+    namespace: gateway-ns
+    version: v1
+- hostname: "*"
+  name: tls-8443
+  port: 8443
+  routes:
+  - backends:
+    - name: podinfo
+      namespace: gateway-ns
+      port:
+        port: 9898
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: platform
+    namespace: gateway-ns
+    version: v1

--- a/operator/pkg/model/ingestion/testdata/gateway/tls_skips_backends_missing_port/input-gateway.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/tls_skips_backends_missing_port/input-gateway.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: platform
+  namespace: app-ns
+spec:
+  gatewayClassName: ""
+  listeners:
+  - name: tls
+    port: 443
+    protocol: TLS
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/tls_skips_backends_missing_port/input-service.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/tls_skips_backends_missing_port/input-service.yaml
@@ -1,0 +1,9 @@
+- metadata:
+    creationTimestamp: null
+    name: backend
+    namespace: app-ns
+  spec:
+    ports:
+    - port: 8080
+  status:
+    loadBalancer: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/tls_skips_backends_missing_port/input-tlsroute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/tls_skips_backends_missing_port/input-tlsroute.yaml
@@ -1,0 +1,13 @@
+- metadata:
+    creationTimestamp: null
+    name: tls
+    namespace: app-ns
+  spec:
+    parentRefs:
+    - name: platform
+      sectionName: tls
+    rules:
+    - backendRefs:
+      - name: backend
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gateway/tls_skips_backends_missing_port/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/tls_skips_backends_missing_port/output-listeners.yaml
@@ -1,0 +1,11 @@
+- hostname: "*"
+  name: tls
+  port: 443
+  routes:
+  - {}
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: platform
+    namespace: app-ns
+    version: v1


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

_AIL:3, I noticed some route types don't do all checks similar, so I used AI to refactor those guardrails to be reusable on various routes, so they all behave consistent._

Deduplicates the per-route-type backend handling in
`operator/pkg/model/ingestion/gateway.go` by extracting a single
`resolveBackendRef` helper, closing several silent correctness gaps that had
crept in between route types:

- **Fix (TLSRoute backends):** Backends without a port were silently included,
  producing a backend entry with `Port: nil` that would generate broken Envoy
  config. They are now dropped, matching the existing behaviour of HTTPRoute and
  GRPCRoute.
- **Fix (TCPRoute backends):** Same nil-port fix as TLSRoute.
- **Fix (UDPRoute backends):** Same nil-port fix as TLSRoute.
- **Fix (HTTPRoute RequestMirror backends):** Mirror backends without a port
  were silently included with `Port: nil`. They are now dropped.
- **Fix (GRPCRoute RequestMirror backends):** Same nil-port fix as HTTPRoute
  mirrors.
- HTTPRoute and GRPCRoute regular backends already enforced the port requirement;
  `resolveBackendRef` unifies all five route types under the same rule.

`resolveBackendRef` consolidates in one place:
- `IsBackendReferenceAllowed` (ReferenceGrant cross-namespace checks)
- `getBackendServiceName` (ServiceImport-to-Service name resolution)
- required-port guard
- `getServiceSpec` lookup
- `backendToModelBackend` model conversion

Added YAML-based tests covering:
- GRPC/TLS `ParentRef.Port` listener matching.
- HTTP/GRPC cross-namespace regular backends, with and without a ReferenceGrant.
- HTTP/GRPC cross-namespace request mirrors, with and without a ReferenceGrant.
- Missing backend ports being dropped consistently across HTTP, TLS, and L4 route types.

```release-note
Fixed Gateway API TLSRoute, TCPRoute, and UDPRoute backends to require a port,
dropping portless entries instead of producing broken nil-port backend config.
Fixed HTTPRoute and GRPCRoute RequestMirror backends to apply the same
port requirement.
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer's Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request