### PR TITLE
Egress Gateway: handle nil events

### DIFF
--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -348,7 +348,11 @@ func (manager *Manager) processEvents(ctx context.Context) {
 		case <-ctx.Done():
 			return
 
-		case event := <-policyEvents:
+		case event, ok := <-policyEvents:
+			if !ok {
+				policyEvents = nil
+				continue
+			}
 			if event.Kind == resource.Sync {
 				policySync = true
 				maybeTriggerReconcile()
@@ -357,7 +361,11 @@ func (manager *Manager) processEvents(ctx context.Context) {
 				manager.handlePolicyEvent(event)
 			}
 
-		case event := <-nodeEvents:
+		case event, ok := <-nodeEvents:
+			if !ok {
+				nodeEvents = nil
+				continue
+			}
 			if event.Kind == resource.Sync {
 				nodeSync = true
 				maybeTriggerReconcile()
@@ -366,7 +374,11 @@ func (manager *Manager) processEvents(ctx context.Context) {
 				manager.handleNodeEvent(event)
 			}
 
-		case event := <-endpointEvents:
+		case event, ok := <-endpointEvents:
+			if !ok {
+				endpointEvents = nil
+				continue
+			}
 			if event.Kind == resource.Sync {
 				endpointSync = true
 				maybeTriggerReconcile()


### PR DESCRIPTION
egw: handle nil events to avoid panics during hive shutdown.
By not handling the possibility of nil event this can cause
panics if the event is processed before the ctx.Done() causes
the event loop to return (i.e. if the channel is closed, it will
return a nil to any readers).

Similar to other similar event handling code we check for empty
events and set the channel to be nil and continue to safely handle
the case.

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
