### PR TITLE
ci: Disable identity jitter for the network policy e2e tests

### DIFF
--- a/.github/workflows/k8s-kind-network-policies-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-policies-e2e.yaml
@@ -180,10 +180,17 @@ jobs:
         run: |
           # Note: On Kind, we install Cilium with HostPort (portmap CNI chaining) enabled,
           # to ensure coverage of that feature in cilium connectivity test
+          #
+          # Note: identity-max-jitter is set to 0s to avoid flaking the
+          # "updated pod" netpol tests, which relabel a pod and then retry the
+          # connection for a bounded time. The jitter delays the resulting
+          # identity change, so the new policy can land after the test gives up.
+          # See #46475. It has no helm value of its own, hence extraConfig.
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --helm-set=cni.chainingMode=portmap \
             --helm-set=kubeProxyReplacement=true \
             --helm-set=identityChangeGracePeriod=\"0s\" \
+            --helm-set=extraConfig.identity-max-jitter=\"0s\" \
             --helm-set=sctp.enabled=true"
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT


### PR DESCRIPTION
The "should deny ingress access to updated pod" test relabels a pod so
it gets a new identity that the deny-ingress policy selects, then checks
that the connection to it is now denied. However, this is occasionally
flaking.

The test does not wait for the relabeling to actually result in a new
identity assigned to the pod. There is roughly a ~20s window where there
are connection retries during the test before it considers the test
failed. When a pod is relabeled, the new identity allocation is delayed
by the identity-max-jitter (default 30s) inside the resolve-identity
controller, which sleeps rand(0, jitter) before resolving the new
identity. So the identity change, and the policy that depends on it, may
land after the test has already given up and declared failed.

Why does the jitter even exist? The jitter exists to spread
CiliumIdentity churn on namespace relabels at scale (see #38030).

So what do we do? In order to fix this flake, set the jitter to 0s for
this job.

Reproducing locally, I made a simple test that relabels a pod that has
its policy enforced already to trigger a new identity and ran it 10
cycles per jitter value on a local kind cluster:

```
  jitter   median  max     flaky
  0s       2.6s    2.6s    0/10
  30s      22.2s   30.8s   5/10
```

With jitter set to 0s, it never flaked. With it set to the default, it
failed half of the time.

Fixes: #46475
