### PR TITLE
policy: remove stale identity entry from selector cache namespace index

### DIFF
--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -56,6 +56,13 @@ func (c *scIdentityCache) Len() int {
 }
 
 func (c *scIdentityCache) insert(nid identity.NumericIdentity, lbls labels.LabelArray) *scIdentity {
+	// Remove any existing entry for this identity first. UpdateIdentities()
+	// calls insert() both for brand new identities and for identities whose
+	// labels changed, and byNamespace is indexed by *scIdentity pointer, so
+	// otherwise the old entry would be left behind in byNamespace under its
+	// old namespace.
+	c.delete(nid)
+
 	namespace, _ := lbls.LookupLabel(&podNamespaceLabel)
 	id := &scIdentity{
 		NID:       nid,

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -491,6 +491,60 @@ func TestIdentityUpdates(t *testing.T) {
 	require.True(t, sc.selectors.Empty())
 }
 
+// TestIdentityUpdateChangingNamespaceLabel covers the case where an existing
+// identity's labels are updated in place (e.g. a reserved identity whose
+// labels can be changed at runtime), and the namespace label changes as part
+// of that update. A selector for the identity's old namespace that is added
+// after the update should not match the identity based on its old labels.
+func TestIdentityUpdateChangingNamespaceLabel(t *testing.T) {
+	sc := testNewSelectorCache(t, hivetest.Logger(t), identity.IdentityMap{})
+
+	const podID = identity.NumericIdentity(1234)
+
+	wg := &sync.WaitGroup{}
+	sc.UpdateIdentities(identity.IdentityMap{
+		podID: labels.Labels{
+			"app":                      labels.NewLabel("app", "test", labels.LabelSourceK8s),
+			k8sConst.PodNamespaceLabel: labels.NewLabel(k8sConst.PodNamespaceLabel, "ns1", labels.LabelSourceK8s),
+		}.LabelArray(),
+	}, nil, wg)
+	wg.Wait()
+
+	// Update the identity's labels so that it now belongs to "ns2" instead
+	// of "ns1".
+	wg = &sync.WaitGroup{}
+	sc.UpdateIdentities(identity.IdentityMap{
+		podID: labels.Labels{
+			"app":                      labels.NewLabel("app", "test", labels.LabelSourceK8s),
+			k8sConst.PodNamespaceLabel: labels.NewLabel(k8sConst.PodNamespaceLabel, "ns2", labels.LabelSourceK8s),
+		}.LabelArray(),
+	}, nil, wg)
+	wg.Wait()
+
+	user1 := newUser(t, "user1", sc)
+
+	// A selector for "ns1" added after the update must not select the
+	// identity based on its stale "ns1" labels.
+	ns1Selector := api.NewESFromLabels(
+		labels.NewLabel("app", "test", labels.LabelSourceK8s),
+		labels.NewLabel(k8sConst.PodNamespaceLabel, "ns1", labels.LabelSourceK8s),
+	)
+	cachedNs1 := user1.AddIdentitySelector(ns1Selector)
+	require.Empty(t, cachedNs1.GetSelections())
+
+	// A selector for "ns2" should select the identity based on its current
+	// labels.
+	ns2Selector := api.NewESFromLabels(
+		labels.NewLabel("app", "test", labels.LabelSourceK8s),
+		labels.NewLabel(k8sConst.PodNamespaceLabel, "ns2", labels.LabelSourceK8s),
+	)
+	cachedNs2 := user1.AddIdentitySelector(ns2Selector)
+	require.Equal(t, identity.NumericIdentitySlice{podID}, cachedNs2.GetSelections())
+
+	user1.RemoveSelector(cachedNs1)
+	user1.RemoveSelector(cachedNs2)
+}
+
 func TestIdentityUpdatesMultipleUsers(t *testing.T) {
 	sc := testNewSelectorCache(t, hivetest.Logger(t), identity.IdentityMap{})
 


### PR DESCRIPTION
scIdentityCache.insert() always builds a new *scIdentity and adds it to byNamespace, but never removes the previous entry for the same numeric identity from its old namespace bucket. byNamespace is keyed by pointer, so the old entry is left behind and is no longer reachable from delete(), which only removes the current c.ids[nid] entry.

UpdateIdentities() calls insert() again whenever an identity's labels change in place, which is expected for the local host identity at runtime (ipcache.TriggerLabelInjection can update reserved:host labels). After such an update, any selector added later re-scans byNamespace via selections() and can match the leftover entry using its stale labels.

Fix: drop the previous entry for the identity before inserting the new one.

Added a test covering an identity whose namespace label changes in place, checking that a selector for the old namespace doesn't pick it up afterwards.

```release-note
Fix a stale entry leak in the policy selector cache that could cause a selector added after an identity's labels change to be seeded with that identity based on its old labels.
```

AIL:2 - drafted with AI assistance, I reviewed the root cause and verified the fix and test.