### PR TITLE
.github: Skip wait for lint checks

### DIFF
--- a/.github/workflows/build-images-ci-v1.17.yaml
+++ b/.github/workflows/build-images-ci-v1.17.yaml
@@ -41,7 +41,8 @@ jobs:
     timeout-minutes: 45
     name: Build and Push Images
     runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-latest' }}
-    needs: wait-for-base-images
+    # GH-46482: Lint checks action is broken, skip dependency for now.
+    #needs: wait-for-base-images
     strategy:
       # Only fail-fast on pull_request_target events. For push and merge_group events, we want to run all builds even
       # if some of them fail, to make sure one of the image is not broken accidentally and the PR is still merged.

--- a/.github/workflows/build-images-ci-v1.18.yaml
+++ b/.github/workflows/build-images-ci-v1.18.yaml
@@ -41,7 +41,8 @@ jobs:
     timeout-minutes: 45
     name: Build and Push Images
     runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
-    needs: wait-for-base-images
+    # GH-46482: Lint checks action is broken, skip dependency for now.
+    #needs: wait-for-base-images
     outputs:
       sha: ${{ steps.tag.outputs.sha }}
     strategy:

--- a/.github/workflows/build-images-ci-v1.19.yaml
+++ b/.github/workflows/build-images-ci-v1.19.yaml
@@ -41,7 +41,8 @@ jobs:
     timeout-minutes: 45
     name: Build and Push Images
     runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
-    needs: wait-for-base-images
+    # GH-46482: Lint checks action is broken, skip dependency for now.
+    #needs: wait-for-base-images
     outputs:
       sha: ${{ steps.tag.outputs.sha }}
     strategy:

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -49,7 +49,8 @@ jobs:
     timeout-minutes: 45
     name: Build and Push Images
     runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
-    needs: wait-for-base-images
+    # GH-46482: Lint checks action is broken, skip dependency for now.
+    #needs: wait-for-base-images
     outputs:
       sha: ${{ steps.tag.outputs.sha }}
     strategy:


### PR DESCRIPTION
The job to wait for lint checks before building is currently broken, so disable the dependency for now.

Related: #46482