### PR TITLE
datapath: sockets: add test coverage for v4-in-v6 client termination

### DIFF
--- a/pkg/datapath/sockets/sockets_test.go
+++ b/pkg/datapath/sockets/sockets_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"net/netip"
+	"os"
 	"syscall"
 	"testing"
 
@@ -276,7 +277,8 @@ func (d *testBPFSocketDestroyer) PrepareAddress(cookie uint64, addr string) erro
 	var sockRevMap *bpf.Map
 
 	addrPort := netip.MustParseAddrPort(addr)
-	a := addrPort.Addr()
+	// v4-in-v6 connections are managed by the v4 map
+	a := addrPort.Addr().Unmap()
 	p := addrPort.Port()
 
 	if a.Is4() {
@@ -342,6 +344,68 @@ func startServer(tb testing.TB, network string, addr string) error {
 	return nil
 }
 
+func dial(tb testing.TB, network string, addr string) (net.Conn, error) {
+	var sockType, proto, fd int
+	var sa unix.Sockaddr
+	var err error
+
+	switch network {
+	case "tcp", "tcp6":
+		sockType = unix.SOCK_STREAM
+		proto = unix.IPPROTO_TCP
+	case "udp", "udp6":
+		sockType = unix.SOCK_DGRAM
+		proto = unix.IPPROTO_UDP
+	}
+
+	addrPort := netip.MustParseAddrPort(addr)
+	a := addrPort.Addr()
+	p := addrPort.Port()
+
+	// can't use net.Dial(), as it doesn't support AF_INET6 for a v4-in-v6 address
+	if a.Is4() {
+		fd, err = unix.Socket(unix.AF_INET, sockType, proto)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to create AF_INET socket: %w", err)
+		}
+
+		sa4 := &unix.SockaddrInet4{
+			Addr: a.As4(),
+			Port: int(p),
+		}
+		sa = sa4
+	} else {
+		fd, err = unix.Socket(unix.AF_INET6, sockType, proto)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to create AF_INET6 socket: %w", err)
+		}
+
+		sa6 := &unix.SockaddrInet6{
+			Addr: a.As16(),
+			Port: int(p),
+		}
+		sa = sa6
+	}
+
+	tb.Cleanup(func() {
+		unix.Close(fd)
+	})
+
+	if err := unix.Connect(fd, sa); err != nil {
+		return nil, fmt.Errorf("Failed to connect: %w", err)
+	}
+
+	file := os.NewFile(uintptr(fd), fmt.Sprintf("client-socket:%s/%s", network, addr))
+	defer file.Close()
+
+	conn, err := net.FileConn(file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to bind file descriptor to net.Conn: %w", err)
+	}
+
+	return conn, nil
+}
+
 func prepareConnectionsAndMaps(t *testing.T, servers map[string][]string, sdt socketDestroyerTester) (map[string][]net.Conn, error) {
 	conns := make(map[string][]net.Conn)
 
@@ -351,7 +415,7 @@ func prepareConnectionsAndMaps(t *testing.T, servers map[string][]string, sdt so
 			if err != nil {
 				return nil, fmt.Errorf("starting server: %w", err)
 			}
-			conn, err := net.Dial(network, addr)
+			conn, err := dial(t, network, addr)
 			if err != nil {
 				return nil, fmt.Errorf("dialing %s/%s: %w", network, addr, err)
 			}
@@ -411,11 +475,13 @@ func TestPrivilegedSocketDestroyers(t *testing.T) {
 	bpf.CheckOrMountFS(log, "")
 
 	socketDestroyers := makeSocketDestroyers(t)
+	// network family is only relevant for the server. Client's socket type is based on the actual addr string.
 	servers := map[string][]string{
-		"127.0.0.1:8888": {"udp", "tcp"},
-		"[::1]:8888":     {"udp6", "tcp6"},
-		"127.0.0.1:8889": {"udp", "tcp"},
-		"[::1]:8889":     {"udp6", "tcp6"},
+		"127.0.0.1:8888":          {"udp", "tcp"},
+		"[::1]:8888":              {"udp6", "tcp6"},
+		"127.0.0.1:8889":          {"udp", "tcp"},
+		"[::1]:8889":              {"udp6", "tcp6"},
+		"[::ffff:127.0.0.1]:8890": {"udp", "tcp"},
 	}
 	testCases := map[string]struct {
 		filter         SocketFilter
@@ -468,6 +534,30 @@ func TestPrivilegedSocketDestroyers(t *testing.T) {
 			},
 			expectTCPClose: []string{
 				"[::1]:8888",
+			},
+		},
+		"close [::ffff:127.0.0.1]:8890 (UDP)": {
+			filter: SocketFilter{
+				DestIp:   net.IP{127, 0, 0, 1},
+				DestPort: 8890,
+				Family:   unix.AF_INET,
+				Protocol: unix.IPPROTO_UDP,
+				States:   StateFilterUDP,
+			},
+			expectUDPClose: []string{
+				"[::ffff:127.0.0.1]:8890",
+			},
+		},
+		"close [::ffff:127.0.0.1]:8890 (TCP)": {
+			filter: SocketFilter{
+				DestIp:   net.IP{127, 0, 0, 1},
+				DestPort: 8890,
+				Family:   unix.AF_INET,
+				Protocol: unix.IPPROTO_TCP,
+				States:   StateFilterTCP,
+			},
+			expectTCPClose: []string{
+				"[::ffff:127.0.0.1]:8890",
 			},
 		},
 	}

--- a/pkg/datapath/sockets/sockets_test.go
+++ b/pkg/datapath/sockets/sockets_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/netip"
 	"syscall"
 	"testing"
 
@@ -200,7 +201,7 @@ func BenchmarkSocketDeserialize(b *testing.B) {
 
 type socketDestroyerTester interface {
 	SocketDestroyer
-	PrepareAddress(network string, cookie uint64, addr any) error
+	PrepareAddress(cookie uint64, addr string) error
 	Reset() error
 }
 
@@ -216,7 +217,7 @@ func newTestNetlinkSocketDestroyer(tb testing.TB) socketDestroyerTester {
 	}
 }
 
-func (d *netlinkSocketDestroyer) PrepareAddress(network string, cookie uint64, addr any) error {
+func (d *netlinkSocketDestroyer) PrepareAddress(cookie uint64, addr string) error {
 	return nil
 }
 
@@ -269,34 +270,23 @@ func newTestBPFSocketDestroyer(tb testing.TB) socketDestroyerTester {
 	}
 }
 
-func (d *testBPFSocketDestroyer) PrepareAddress(network string, cookie uint64, addr any) error {
+func (d *testBPFSocketDestroyer) PrepareAddress(cookie uint64, addr string) error {
 	var key bpf.MapKey
 	var value bpf.MapValue
 	var sockRevMap *bpf.Map
-	var ip net.IP
-	var port int
 
-	if udpAddr, ok := addr.(*net.UDPAddr); ok {
-		ip = udpAddr.IP
-		port = udpAddr.Port
-	} else if tcpAddr, ok := addr.(*net.TCPAddr); ok {
-		ip = tcpAddr.IP
-		port = tcpAddr.Port
-	} else {
-		return fmt.Errorf("unknown address type: %v", addr)
-	}
+	addrPort := netip.MustParseAddrPort(addr)
+	a := addrPort.Addr()
+	p := addrPort.Port()
 
-	switch network {
-	case "udp", "tcp":
-		key = maps.NewSockRevNat4Key(cookie, ip, uint16(port))
+	if a.Is4() {
+		key = maps.NewSockRevNat4Key(cookie, a.AsSlice(), p)
 		value = &maps.SockRevNat4Value{}
 		sockRevMap = d.sockRevNat4Map
-	case "udp6", "tcp6":
-		key = maps.NewSockRevNat6Key(cookie, ip, uint16(port))
+	} else {
+		key = maps.NewSockRevNat6Key(cookie, a.AsSlice(), p)
 		value = &maps.SockRevNat6Value{}
 		sockRevMap = d.sockRevNat6Map
-	default:
-		return fmt.Errorf("unknown network: %s", network)
 	}
 
 	return sockRevMap.Update(key, value)
@@ -320,7 +310,7 @@ func makeSocketDestroyers(tb testing.TB) map[string]socketDestroyerTester {
 	}
 }
 
-func startServer(tb testing.TB, network string, addr string) (any, error) {
+func startServer(tb testing.TB, network string, addr string) error {
 	var serverAddr any
 	var listener io.Closer
 	var err error
@@ -329,27 +319,27 @@ func startServer(tb testing.TB, network string, addr string) (any, error) {
 	case "udp", "udp6":
 		serverAddr, err = net.ResolveUDPAddr(network, addr)
 		if err != nil {
-			return nil, fmt.Errorf("resolving UDP address: %w", err)
+			return fmt.Errorf("resolving UDP address: %w", err)
 		}
 		listener, err = net.ListenUDP(network, serverAddr.(*net.UDPAddr))
 		if err != nil {
-			return nil, fmt.Errorf("start listening: %w", err)
+			return fmt.Errorf("start listening: %w", err)
 		}
 	case "tcp", "tcp6":
 		serverAddr, err = net.ResolveTCPAddr(network, addr)
 		if err != nil {
-			return nil, fmt.Errorf("resolving TCP address: %w", err)
+			return fmt.Errorf("resolving TCP address: %w", err)
 		}
 		listener, err = net.ListenTCP(network, serverAddr.(*net.TCPAddr))
 		if err != nil {
-			return nil, fmt.Errorf("start listening: %w", err)
+			return fmt.Errorf("start listening: %w", err)
 		}
 	}
 
 	tb.Cleanup(func() {
 		listener.Close()
 	})
-	return serverAddr, nil
+	return nil
 }
 
 func prepareConnectionsAndMaps(t *testing.T, servers map[string][]string, sdt socketDestroyerTester) (map[string][]net.Conn, error) {
@@ -357,7 +347,7 @@ func prepareConnectionsAndMaps(t *testing.T, servers map[string][]string, sdt so
 
 	for addr, networks := range servers {
 		for _, network := range networks {
-			connectAddr, err := startServer(t, network, addr)
+			err := startServer(t, network, addr)
 			if err != nil {
 				return nil, fmt.Errorf("starting server: %w", err)
 			}
@@ -383,7 +373,7 @@ func prepareConnectionsAndMaps(t *testing.T, servers map[string][]string, sdt so
 			if err != nil {
 				return nil, fmt.Errorf("getting socket cookie: %w", err)
 			}
-			if err := sdt.PrepareAddress(network, cookie, connectAddr); err != nil {
+			if err := sdt.PrepareAddress(cookie, addr); err != nil {
 				return nil, fmt.Errorf("preparing socket filter %s/%s %v: %w", network, addr, cookie, err)
 			}
 			conns[addr] = append(conns[addr], conn)


### PR DESCRIPTION
Test whether connections to a terminated v4 backend are torn down, even
when the client is using a v4-in-v6 address and AF_INET6 socket.

As net.Dial() doesn't support this combination, we need to replace it with
a custom implementation.

The v4-in-v6 support landed with https://github.com/cilium/cilium/pull/39994.
