### PR TITLE
gateway-api: fix TLS passthrough translation

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -733,6 +733,9 @@ func (r *gatewayReconciler) filterUDPRoutesByGateway(ctx context.Context, gw *ga
 }
 
 func (r *gatewayReconciler) filterTLSRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1.TLSRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1.TLSRoute {
+	if !helpers.IsTLSPassthroughListener(listener) {
+		return nil
+	}
 	var filtered []gatewayv1.TLSRoute
 	for _, route := range routes {
 		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) &&

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-tls-passthrough/output/cec-multi-port-tls-passthrough.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-tls-passthrough/output/cec-multi-port-tls-passthrough.yaml
@@ -91,8 +91,6 @@ spec:
           intValue: "10"
           level: "6"
           name: "6"
-    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
-      name: listener-insecure
     - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
       edsClusterConfig:
         serviceName: gateway-conformance-infra/tls-backend-2:443

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-disallowed-kind/output/cec-tlsroutes-only.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-disallowed-kind/output/cec-tlsroutes-only.yaml
@@ -15,60 +15,42 @@ metadata:
   resourceVersion: "1"
 spec:
   resources:
-  - '@type': type.googleapis.com/envoy.config.listener.v3.Listener
-    filterChains:
-    - filterChainMatch:
-        transportProtocol: raw_buffer
-      filters:
-      - name: envoy.filters.network.http_connection_manager
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-          commonHttpProtocolOptions:
-            maxStreamDuration: 0s
-          httpFilters:
-          - name: envoy.filters.http.grpc_web
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
-          - name: envoy.filters.http.grpc_stats
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
-              emitFilterState: true
-              enableUpstreamStats: true
-          - name: envoy.filters.http.router
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-          internalAddressConfig: {}
-          rds:
-            routeConfigName: listener-insecure
-          statPrefix: listener-insecure
-          streamIdleTimeout: 300s
-          upgradeConfigs:
-          - upgradeType: websocket
-          useRemoteAddress: true
-    listenerFilters:
-    - name: envoy.filters.listener.tls_inspector
-      typedConfig:
-        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
-    name: listener
-    socketOptions:
-    - description: Enable TCP keep-alive (default to enabled)
-      intValue: "1"
-      level: "1"
-      name: "9"
-    - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
-      intValue: "10"
-      level: "6"
-      name: "4"
-    - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
-      intValue: "5"
-      level: "6"
-      name: "5"
-    - description: TCP keep-alive probe max failures.
-      intValue: "10"
-      level: "6"
-      name: "6"
-  - '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
-    name: listener-insecure
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.tcp_proxy
+              typedConfig:
+                '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: CiliumBlackholeCluster
+                statPrefix: tls-passthrough:tls
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+      connectTimeout: 0.250s
+      name: CiliumBlackholeCluster
+      type: STATIC
   services:
   - listener: ""
     name: cilium-gateway-tlsroutes-only

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-empty-hostname-x-4.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-empty-hostname-x-4.yaml
@@ -27,34 +27,6 @@ spec:
     - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
       filterChains:
         - filterChainMatch:
-            transportProtocol: raw_buffer
-          filters:
-            - name: envoy.filters.network.http_connection_manager
-              typedConfig:
-                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                commonHttpProtocolOptions:
-                  maxStreamDuration: 0s
-                httpFilters:
-                  - name: envoy.filters.http.grpc_web
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
-                  - name: envoy.filters.http.grpc_stats
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
-                      emitFilterState: true
-                      enableUpstreamStats: true
-                  - name: envoy.filters.http.router
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-                internalAddressConfig: {}
-                rds:
-                  routeConfigName: listener-insecure
-                statPrefix: listener-insecure
-                streamIdleTimeout: 300s
-                upgradeConfigs:
-                  - upgradeType: websocket
-                useRemoteAddress: true
-        - filterChainMatch:
             serverNames:
               - "*.com"
             transportProtocol: tls
@@ -96,8 +68,6 @@ spec:
           intValue: "10"
           level: "6"
           name: "6"
-    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
-      name: listener-insecure
     - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
       edsClusterConfig:
         serviceName: gateway-conformance-infra/tls-backend-2:443

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-exact-hostname-x-1.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-exact-hostname-x-1.yaml
@@ -23,34 +23,6 @@ spec:
     - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
       filterChains:
         - filterChainMatch:
-            transportProtocol: raw_buffer
-          filters:
-            - name: envoy.filters.network.http_connection_manager
-              typedConfig:
-                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                commonHttpProtocolOptions:
-                  maxStreamDuration: 0s
-                httpFilters:
-                  - name: envoy.filters.http.grpc_web
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
-                  - name: envoy.filters.http.grpc_stats
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
-                      emitFilterState: true
-                      enableUpstreamStats: true
-                  - name: envoy.filters.http.router
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-                internalAddressConfig: {}
-                rds:
-                  routeConfigName: listener-insecure
-                statPrefix: listener-insecure
-                streamIdleTimeout: 300s
-                upgradeConfigs:
-                  - upgradeType: websocket
-                useRemoteAddress: true
-        - filterChainMatch:
             serverNames:
               - abc.example.com
             transportProtocol: tls
@@ -82,8 +54,6 @@ spec:
           intValue: "10"
           level: "6"
           name: "6"
-    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
-      name: listener-insecure
     - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
       edsClusterConfig:
         serviceName: gateway-conformance-infra/tls-backend:443

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-less-specific-wc-hostname-x-3.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-less-specific-wc-hostname-x-3.yaml
@@ -27,34 +27,6 @@ spec:
     - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
       filterChains:
         - filterChainMatch:
-            transportProtocol: raw_buffer
-          filters:
-            - name: envoy.filters.network.http_connection_manager
-              typedConfig:
-                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                commonHttpProtocolOptions:
-                  maxStreamDuration: 0s
-                httpFilters:
-                  - name: envoy.filters.http.grpc_web
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
-                  - name: envoy.filters.http.grpc_stats
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
-                      emitFilterState: true
-                      enableUpstreamStats: true
-                  - name: envoy.filters.http.router
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-                internalAddressConfig: {}
-                rds:
-                  routeConfigName: listener-insecure
-                statPrefix: listener-insecure
-                streamIdleTimeout: 300s
-                upgradeConfigs:
-                  - upgradeType: websocket
-                useRemoteAddress: true
-        - filterChainMatch:
             serverNames:
               - "*.example.com"
             transportProtocol: tls
@@ -96,8 +68,6 @@ spec:
           intValue: "10"
           level: "6"
           name: "6"
-    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
-      name: listener-insecure
     - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
       edsClusterConfig:
         serviceName: gateway-conformance-infra/tls-backend-2:443

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-more-specific-wc-hostname-x-2.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-hostname-intersection/output/cec-gw-tlsroute-more-specific-wc-hostname-x-2.yaml
@@ -27,34 +27,6 @@ spec:
     - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
       filterChains:
         - filterChainMatch:
-            transportProtocol: raw_buffer
-          filters:
-            - name: envoy.filters.network.http_connection_manager
-              typedConfig:
-                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                commonHttpProtocolOptions:
-                  maxStreamDuration: 0s
-                httpFilters:
-                  - name: envoy.filters.http.grpc_web
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
-                  - name: envoy.filters.http.grpc_stats
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
-                      emitFilterState: true
-                      enableUpstreamStats: true
-                  - name: envoy.filters.http.router
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-                internalAddressConfig: {}
-                rds:
-                  routeConfigName: listener-insecure
-                statPrefix: listener-insecure
-                streamIdleTimeout: 300s
-                upgradeConfigs:
-                  - upgradeType: websocket
-                useRemoteAddress: true
-        - filterChainMatch:
             serverNames:
               - "*.example.com"
             transportProtocol: tls
@@ -96,8 +68,6 @@ spec:
           intValue: "10"
           level: "6"
           name: "6"
-    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
-      name: listener-insecure
     - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
       edsClusterConfig:
         serviceName: gateway-conformance-infra/tls-backend-2:443

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/cec-gateway-tlsroute-tls-passthrough-only.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/cec-gateway-tlsroute-tls-passthrough-only.yaml
@@ -7,44 +7,24 @@ metadata:
   name: cilium-gateway-gateway-tlsroute-tls-passthrough-only
   namespace: gateway-conformance-infra
   ownerReferences:
-    - apiVersion: gateway.networking.k8s.io/v1
-      controller: true
-      kind: Gateway
-      name: gateway-tlsroute-tls-passthrough-only
-      uid: ""
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: gateway-tlsroute-tls-passthrough-only
+    uid: ""
   resourceVersion: "1"
 spec:
   resources:
     - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
       filterChains:
         - filterChainMatch:
-            transportProtocol: raw_buffer
+            transportProtocol: tls
           filters:
-            - name: envoy.filters.network.http_connection_manager
+            - name: envoy.filters.network.tcp_proxy
               typedConfig:
-                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                commonHttpProtocolOptions:
-                  maxStreamDuration: 0s
-                httpFilters:
-                  - name: envoy.filters.http.grpc_web
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
-                  - name: envoy.filters.http.grpc_stats
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
-                      emitFilterState: true
-                      enableUpstreamStats: true
-                  - name: envoy.filters.http.router
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-                internalAddressConfig: {}
-                rds:
-                  routeConfigName: listener-insecure
-                statPrefix: listener-insecure
-                streamIdleTimeout: 300s
-                upgradeConfigs:
-                  - upgradeType: websocket
-                useRemoteAddress: true
+                '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: CiliumBlackholeCluster
+                statPrefix: tls-passthrough:tls-passthrough
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:
@@ -67,11 +47,13 @@ spec:
           intValue: "10"
           level: "6"
           name: "6"
-    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
-      name: listener-insecure
+    - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+      connectTimeout: 0.250s
+      name: CiliumBlackholeCluster
+      type: STATIC
   services:
-    - listener: ""
-      name: cilium-gateway-gateway-tlsroute-tls-passthrough-only
-      namespace: gateway-conformance-infra
-      ports:
-        - 443
+  - listener: ""
+    name: cilium-gateway-gateway-tlsroute-tls-passthrough-only
+    namespace: gateway-conformance-infra
+    ports:
+    - 443

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-reference-grant/output/cec-gateway-tlsroute-referencegrant.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-reference-grant/output/cec-gateway-tlsroute-referencegrant.yaml
@@ -18,33 +18,15 @@ spec:
     - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
       filterChains:
         - filterChainMatch:
-            transportProtocol: raw_buffer
+            serverNames:
+              - abc.example.com
+            transportProtocol: tls
           filters:
-            - name: envoy.filters.network.http_connection_manager
+            - name: envoy.filters.network.tcp_proxy
               typedConfig:
-                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                commonHttpProtocolOptions:
-                  maxStreamDuration: 0s
-                httpFilters:
-                  - name: envoy.filters.http.grpc_web
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
-                  - name: envoy.filters.http.grpc_stats
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
-                      emitFilterState: true
-                      enableUpstreamStats: true
-                  - name: envoy.filters.http.router
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-                internalAddressConfig: {}
-                rds:
-                  routeConfigName: listener-insecure
-                statPrefix: listener-insecure
-                streamIdleTimeout: 300s
-                upgradeConfigs:
-                  - upgradeType: websocket
-                useRemoteAddress: true
+                '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                cluster: CiliumBlackholeCluster
+                statPrefix: tls-passthrough:abc.example.com
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:
@@ -67,8 +49,10 @@ spec:
           intValue: "10"
           level: "6"
           name: "6"
-    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
-      name: listener-insecure
+    - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+      connectTimeout: 0.250s
+      name: CiliumBlackholeCluster
+      type: STATIC
   services:
     - listener: ""
       name: cilium-gateway-gateway-tlsroute-referencegrant

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-simple-same-namespace/output/cec-gateway-tlsroute.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-simple-same-namespace/output/cec-gateway-tlsroute.yaml
@@ -23,34 +23,6 @@ spec:
     - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
       filterChains:
         - filterChainMatch:
-            transportProtocol: raw_buffer
-          filters:
-            - name: envoy.filters.network.http_connection_manager
-              typedConfig:
-                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                commonHttpProtocolOptions:
-                  maxStreamDuration: 0s
-                httpFilters:
-                  - name: envoy.filters.http.grpc_web
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
-                  - name: envoy.filters.http.grpc_stats
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
-                      emitFilterState: true
-                      enableUpstreamStats: true
-                  - name: envoy.filters.http.router
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-                internalAddressConfig: {}
-                rds:
-                  routeConfigName: listener-insecure
-                statPrefix: listener-insecure
-                streamIdleTimeout: 300s
-                upgradeConfigs:
-                  - upgradeType: websocket
-                useRemoteAddress: true
-        - filterChainMatch:
             serverNames:
               - abc.example.com
             transportProtocol: tls
@@ -82,8 +54,6 @@ spec:
           intValue: "10"
           level: "6"
           name: "6"
-    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
-      name: listener-insecure
     - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
       edsClusterConfig:
         serviceName: gateway-conformance-infra/tls-backend:443

--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -87,9 +87,8 @@ func GatewayAPI(log *slog.Logger, input Input) *model.Model {
 	listenerHostnamesByProtocol := make(map[gatewayv1.ProtocolType][]string)
 	for _, l := range input.Gateway.Spec.Listeners {
 		if l.Hostname != nil {
-			_, ok := listenerHostnamesByProtocol[l.Protocol]
-			if !ok {
-				listenerHostnamesByProtocol[l.Protocol] = []string{}
+			if l.Protocol == gatewayv1.TLSProtocolType && !helpers.IsTLSPassthroughListener(&l) {
+				continue
 			}
 			listenerHostnamesByProtocol[l.Protocol] = append(listenerHostnamesByProtocol[l.Protocol], toHostname(l.Hostname))
 		}
@@ -97,7 +96,7 @@ func GatewayAPI(log *slog.Logger, input Input) *model.Model {
 
 	for _, l := range input.Gateway.Spec.Listeners {
 		switch l.Protocol {
-		case gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType, gatewayv1.TLSProtocolType:
+		case gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType:
 			var httpRoutes []model.HTTPRoute
 			httpRoutes = append(httpRoutes, toHTTPRoutes(log, l, input.Gateway.GetNamespace(), namespaceLabels, listenerHostnamesByProtocol, input.HTTPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants, input.BackendTLSPolicyMap)...)
 			httpRoutes = append(httpRoutes, toGRPCRoutes(l, input.Gateway.GetNamespace(), namespaceLabels, listenerHostnamesByProtocol, input.GRPCRoutes, input.Services, input.ServiceImports, input.ReferenceGrants)...)
@@ -120,28 +119,28 @@ func GatewayAPI(log *slog.Logger, input Input) *model.Model {
 				Infrastructure: infra,
 				Service:        toServiceModel(input.GatewayClassConfig),
 			})
-
-			if l.Protocol == gatewayv1.TLSProtocolType {
-				resTLSPassthrough = append(resTLSPassthrough, model.TLSPassthroughListener{
-					Name: string(l.Name),
-					Sources: []model.FullyQualifiedResource{
-						{
-							Name:      input.Gateway.GetName(),
-							Namespace: input.Gateway.GetNamespace(),
-							Group:     gatewayv1.SchemeGroupVersion.Group,
-							Version:   gatewayv1.SchemeGroupVersion.Version,
-							Kind:      "Gateway",
-							UID:       string(input.Gateway.GetUID()),
-						},
-					},
-					Port:           uint32(l.Port),
-					Hostname:       toHostname(l.Hostname),
-					Routes:         toTLSRoutes(l, input.Gateway.GetNamespace(), namespaceLabels, listenerHostnamesByProtocol, input.TLSRoutes, input.Services, input.ServiceImports, input.ReferenceGrants),
-					Infrastructure: infra,
-					Service:        toServiceModel(input.GatewayClassConfig),
-				})
+		case gatewayv1.TLSProtocolType:
+			if !helpers.IsTLSPassthroughListener(&l) {
+				continue
 			}
-
+			resTLSPassthrough = append(resTLSPassthrough, model.TLSPassthroughListener{
+				Name: string(l.Name),
+				Sources: []model.FullyQualifiedResource{
+					{
+						Name:      input.Gateway.GetName(),
+						Namespace: input.Gateway.GetNamespace(),
+						Group:     gatewayv1.SchemeGroupVersion.Group,
+						Version:   gatewayv1.SchemeGroupVersion.Version,
+						Kind:      "Gateway",
+						UID:       string(input.Gateway.GetUID()),
+					},
+				},
+				Port:           uint32(l.Port),
+				Hostname:       toHostname(l.Hostname),
+				Routes:         toTLSRoutes(l, input.Gateway.GetNamespace(), namespaceLabels, listenerHostnamesByProtocol, input.TLSRoutes, input.Services, input.ServiceImports, input.ReferenceGrants),
+				Infrastructure: infra,
+				Service:        toServiceModel(input.GatewayClassConfig),
+			})
 		case gatewayv1.TCPProtocolType:
 			resL4 = append(resL4, model.L4Listener{
 				Name: string(l.Name),
@@ -161,7 +160,6 @@ func GatewayAPI(log *slog.Logger, input Input) *model.Model {
 				Infrastructure: infra,
 				Service:        toServiceModel(input.GatewayClassConfig),
 			})
-
 		case gatewayv1.UDPProtocolType:
 			resL4 = append(resL4, model.L4Listener{
 				Name: string(l.Name),

--- a/operator/pkg/model/ingestion/gateway_test.go
+++ b/operator/pkg/model/ingestion/gateway_test.go
@@ -388,6 +388,9 @@ func TestTLSGatewayAPIFiltersRoutesByListenerAllowedNamespaces(t *testing.T) {
 						Hostname: ptr.To[gatewayv1.Hostname]("tls.example.test"),
 						Port:     443,
 						Protocol: gatewayv1.TLSProtocolType,
+						TLS: &gatewayv1.ListenerTLSConfig{
+							Mode: ptr.To(gatewayv1.TLSModePassthrough),
+						},
 						AllowedRoutes: &gatewayv1.AllowedRoutes{
 							Namespaces: &gatewayv1.RouteNamespaces{
 								From: &sameNamespace,
@@ -399,6 +402,9 @@ func TestTLSGatewayAPIFiltersRoutesByListenerAllowedNamespaces(t *testing.T) {
 						Hostname: ptr.To[gatewayv1.Hostname]("tls.example.test"),
 						Port:     8443,
 						Protocol: gatewayv1.TLSProtocolType,
+						TLS: &gatewayv1.ListenerTLSConfig{
+							Mode: ptr.To(gatewayv1.TLSModePassthrough),
+						},
 						AllowedRoutes: &gatewayv1.AllowedRoutes{
 							Namespaces: &gatewayv1.RouteNamespaces{
 								From: &allNamespaces,

--- a/operator/pkg/model/ingestion/testdata/gateway/basic_tls_http/input-gateway.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/basic_tls_http/input-gateway.yaml
@@ -10,4 +10,6 @@ spec:
   - name: prod-web-gw
     port: 443
     protocol: TLS
+    tls:
+      mode: Passthrough
 status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/tls_weighted_backends/input-gateway.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/tls_weighted_backends/input-gateway.yaml
@@ -10,4 +10,6 @@ spec:
   - name: tls
     port: 443
     protocol: TLS
+    tls:
+      mode: Passthrough
 status: {}

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -774,6 +774,28 @@ func (m *Model) NeedsCrossProtocolSplit() bool {
 	return false
 }
 
+func (m *Model) HasTLSPassthroughListenerWithoutRoutes() bool {
+	for _, listener := range m.TLSPassthrough {
+		if len(listener.Routes) == 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (m *Model) HasTLSPassthroughRouteWithoutBackends() bool {
+	for _, listener := range m.TLSPassthrough {
+		for _, route := range listener.Routes {
+			if len(route.Backends) == 0 {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 type filterChainMatch struct {
 	hostname string
 	port     uint32
@@ -807,6 +829,13 @@ func (m *Model) tlsPassthroughFilterChainMatches() []filterChainMatch {
 	var matches []filterChainMatch
 	seen := map[filterChainMatch]struct{}{}
 	for _, l := range m.TLSPassthrough {
+		if len(l.Routes) == 0 {
+			match := filterChainMatch{hostname: normalizeHostname(l.Hostname), port: l.Port}
+			if _, ok := seen[match]; !ok {
+				seen[match] = struct{}{}
+				matches = append(matches, match)
+			}
+		}
 		for _, r := range l.Routes {
 			if len(r.Hostnames) == 0 {
 				match := filterChainMatch{hostname: allHosts, port: l.Port}
@@ -831,12 +860,7 @@ func (m *Model) tlsPassthroughFilterChainMatches() []filterChainMatch {
 
 // IsTLSPassthroughListenerConfigured returns true if the model has any TLS Passthrough listeners.
 func (m *Model) IsTLSPassthroughListenerConfigured() bool {
-	for _, l := range m.TLSPassthrough {
-		if len(l.Routes) > 0 {
-			return true
-		}
-	}
-	return false
+	return len(m.TLSPassthrough) > 0
 }
 
 // HTTPPorts returns a list of unique ports for all HTTP listeners.
@@ -865,9 +889,7 @@ func (m *Model) IsCORSFilterConfigured() bool {
 func (m *Model) TLSPassthroughPorts() []uint32 {
 	var ports []uint32
 	for _, l := range m.TLSPassthrough {
-		if len(l.Routes) > 0 {
-			ports = append(ports, l.Port)
-		}
+		ports = append(ports, l.Port)
 	}
 	return slices.SortedUnique(ports)
 }

--- a/operator/pkg/model/model_test.go
+++ b/operator/pkg/model/model_test.go
@@ -243,7 +243,7 @@ func TestIsTLSPassthroughListenerConfigured(t *testing.T) {
 					{Port: 443},
 				},
 			},
-			want: false,
+			want: true,
 		},
 		{
 			name: "mixed — one with routes, one without",
@@ -263,7 +263,7 @@ func TestIsTLSPassthroughListenerConfigured(t *testing.T) {
 					{Port: 8443},
 				},
 			},
-			want: false,
+			want: true,
 		},
 	}
 	for _, tt := range tests {
@@ -295,7 +295,7 @@ func TestTLSPassthroughPorts(t *testing.T) {
 			want: []uint32{443, 8443},
 		},
 		{
-			name: "routeless listeners excluded",
+			name: "routeless listeners and listeners with routes",
 			model: Model{
 				TLSPassthrough: []TLSPassthroughListener{
 					{Port: 443},
@@ -303,7 +303,7 @@ func TestTLSPassthroughPorts(t *testing.T) {
 					{Port: 9443},
 				},
 			},
-			want: []uint32{8443},
+			want: []uint32{443, 8443, 9443},
 		},
 		{
 			name: "all routeless",
@@ -313,7 +313,7 @@ func TestTLSPassthroughPorts(t *testing.T) {
 					{Port: 8443},
 				},
 			},
-			want: nil,
+			want: []uint32{443, 8443},
 		},
 		{
 			name: "duplicate ports deduplicated",
@@ -693,6 +693,47 @@ func TestNeedsCrossProtocolSplit(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "routeless TLS passthrough uses listener hostname for split detection",
+			model: Model{
+				HTTP: []HTTPListener{
+					{
+						Port:     443,
+						Hostname: "shared.example.test",
+						TLS:      []TLSSecret{{Name: "cert", Namespace: "ns"}},
+					},
+				},
+				TLSPassthrough: []TLSPassthroughListener{
+					{
+						Port:     9443,
+						Hostname: "shared.example.test",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "routeful TLS passthrough uses route hostname for split detection",
+			model: Model{
+				HTTP: []HTTPListener{
+					{
+						Port:     443,
+						Hostname: "web.example.test",
+						TLS:      []TLSSecret{{Name: "cert", Namespace: "ns"}},
+					},
+				},
+				TLSPassthrough: []TLSPassthroughListener{
+					{
+						Port:     9443,
+						Hostname: "*",
+						Routes: []TLSPassthroughRoute{
+							{Hostnames: []string{"tls.example.test"}},
+						},
+					},
+				},
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -739,4 +780,154 @@ func TestTLSSecretsToListeners(t *testing.T) {
 	}, got[certB])
 
 	assert.Len(t, got, 2)
+}
+
+func TestHasTLSPassthroughListenerWithoutRoutes(t *testing.T) {
+	tests := []struct {
+		name  string
+		model Model
+		want  bool
+	}{
+		{
+			name:  "no TLS passthrough listeners",
+			model: Model{},
+			want:  false,
+		},
+		{
+			name: "TLS passthrough listener without routes",
+			model: Model{
+				TLSPassthrough: []TLSPassthroughListener{{Port: 443}},
+			},
+			want: true,
+		},
+		{
+			name: "TLS passthrough route with backend",
+			model: Model{
+				TLSPassthrough: []TLSPassthroughListener{
+					{
+						Port: 443,
+						Routes: []TLSPassthroughRoute{
+							{
+								Backends: []Backend{{Name: "backend", Namespace: "default", Port: &BackendPort{Port: 443}}},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "TLS passthrough route without backends",
+			model: Model{
+				TLSPassthrough: []TLSPassthroughListener{
+					{
+						Port:   443,
+						Routes: []TLSPassthroughRoute{{Hostnames: []string{"example.com"}}},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "one TLS passthrough route without backends among valid routes",
+			model: Model{
+				TLSPassthrough: []TLSPassthroughListener{
+					{
+						Port: 443,
+						Routes: []TLSPassthroughRoute{
+							{
+								Backends: []Backend{{Name: "backend", Namespace: "default", Port: &BackendPort{Port: 443}}},
+							},
+						},
+					},
+					{
+						Port:   8443,
+						Routes: []TLSPassthroughRoute{{Hostnames: []string{"missing.example.com"}}},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.model.HasTLSPassthroughListenerWithoutRoutes())
+		})
+	}
+}
+
+func TestHasTLSPassthroughRouteWithoutBackends(t *testing.T) {
+	tests := []struct {
+		name  string
+		model Model
+		want  bool
+	}{
+		{
+			name:  "no TLS passthrough listeners",
+			model: Model{},
+			want:  false,
+		},
+		{
+			name: "TLS passthrough listener without routes",
+			model: Model{
+				TLSPassthrough: []TLSPassthroughListener{{Port: 443}},
+			},
+			want: false,
+		},
+		{
+			name: "TLS passthrough route with backend",
+			model: Model{
+				TLSPassthrough: []TLSPassthroughListener{
+					{
+						Port: 443,
+						Routes: []TLSPassthroughRoute{
+							{
+								Backends: []Backend{{Name: "backend", Namespace: "default", Port: &BackendPort{Port: 443}}},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "TLS passthrough route without backends",
+			model: Model{
+				TLSPassthrough: []TLSPassthroughListener{
+					{
+						Port:   443,
+						Routes: []TLSPassthroughRoute{{Hostnames: []string{"example.com"}}},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "one TLS passthrough route without backends among valid routes",
+			model: Model{
+				TLSPassthrough: []TLSPassthroughListener{
+					{
+						Port: 443,
+						Routes: []TLSPassthroughRoute{
+							{
+								Backends: []Backend{{Name: "backend", Namespace: "default", Port: &BackendPort{Port: 443}}},
+							},
+						},
+					},
+					{
+						Port:   8443,
+						Routes: []TLSPassthroughRoute{{Hostnames: []string{"missing.example.com"}}},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.model.HasTLSPassthroughRouteWithoutBackends())
+		})
+	}
 }

--- a/operator/pkg/model/translation/cec_translator.go
+++ b/operator/pkg/model/translation/cec_translator.go
@@ -171,9 +171,7 @@ func (i *cecTranslator) desiredServicesWithPortsCombined(namespace string, name 
 		allPorts[uint16(hl.Port)] = struct{}{}
 	}
 	for _, tlsl := range m.TLSPassthrough {
-		if len(tlsl.Routes) > 0 {
-			allPorts[uint16(tlsl.Port)] = struct{}{}
-		}
+		allPorts[uint16(tlsl.Port)] = struct{}{}
 	}
 
 	ports := make([]uint16, 0, len(allPorts))
@@ -248,9 +246,7 @@ func (i *cecTranslator) desiredServicesWithPortsSplit(namespace string, name str
 	} else {
 		var ptPorts []uint16
 		for _, tlsl := range m.TLSPassthrough {
-			if len(tlsl.Routes) > 0 {
-				ptPorts = append(ptPorts, uint16(tlsl.Port))
-			}
+			ptPorts = append(ptPorts, uint16(tlsl.Port))
 		}
 		goslices.Sort(ptPorts)
 		ptPorts = goslices.Compact(ptPorts)

--- a/operator/pkg/model/translation/cec_translator_test.go
+++ b/operator/pkg/model/translation/cec_translator_test.go
@@ -234,13 +234,13 @@ func TestSharedIngressTranslator_getServices(t *testing.T) {
 					},
 				},
 			},
-			// port not included: TLS passthrough listener has no routes.
 			want: []*ciliumv2.ServiceListener{
 				{
 					Name:      "cilium-ingress",
 					Namespace: "kube-system",
 					Ports: []uint16{
 						80,
+						443,
 					},
 				},
 			},

--- a/operator/pkg/model/translation/envoy_cluster.go
+++ b/operator/pkg/model/translation/envoy_cluster.go
@@ -6,11 +6,13 @@ package translation
 import (
 	"fmt"
 	goslices "slices"
+	"time"
 
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_upstreams_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/cilium/cilium/operator/pkg/model"
 	"github.com/cilium/cilium/pkg/envoy"
@@ -18,7 +20,9 @@ import (
 )
 
 const (
-	httpProtocolOptionsType = "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+	httpProtocolOptionsType        = "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+	blackholeClusterName           = "CiliumBlackholeCluster"
+	blackholeClusterConnectionTime = 250 * time.Millisecond
 )
 
 type HTTPVersionType int
@@ -108,6 +112,11 @@ func (i *cecTranslator) desiredEnvoyCluster(m *model.Model) ([]ciliumv2.XDSResou
 		}
 	}
 
+	if m.HasTLSPassthroughListenerWithoutRoutes() || m.HasTLSPassthroughRouteWithoutBackends() {
+		sortedClusterNames = append(sortedClusterNames, blackholeClusterName)
+		envoyClusters[blackholeClusterName], _ = i.blackholeCluster(blackholeClusterName)
+	}
+
 	goslices.Sort(sortedClusterNames)
 	res := make([]ciliumv2.XDSResource, len(sortedClusterNames))
 	for i, name := range sortedClusterNames {
@@ -162,6 +171,18 @@ func (i *cecTranslator) tcpCluster(clusterName string, clusterServiceName string
 	// Apply mutation functions for customizing the cluster.
 	for _, fn := range i.tcpClusterMutators(mutationFunc...) {
 		cluster = fn(cluster)
+	}
+
+	return toXdsResource(cluster, envoy.ClusterTypeURL)
+}
+
+func (i *cecTranslator) blackholeCluster(name string) (ciliumv2.XDSResource, error) {
+	cluster := &envoy_config_cluster_v3.Cluster{
+		Name: name,
+		ClusterDiscoveryType: &envoy_config_cluster_v3.Cluster_Type{
+			Type: envoy_config_cluster_v3.Cluster_STATIC,
+		},
+		ConnectTimeout: durationpb.New(blackholeClusterConnectionTime),
 	}
 
 	return toXdsResource(cluster, envoy.ClusterTypeURL)

--- a/operator/pkg/model/translation/envoy_cluster_test.go
+++ b/operator/pkg/model/translation/envoy_cluster_test.go
@@ -11,6 +11,7 @@ import (
 	envoy_config_tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/cilium/cilium/operator/pkg/model"
 )
@@ -163,6 +164,22 @@ func Test_tcpCluster(t *testing.T) {
 	require.Equal(t, &envoy_config_cluster_v3.Cluster_Type{
 		Type: envoy_config_cluster_v3.Cluster_EDS,
 	}, cluster.ClusterDiscoveryType)
+}
+
+func Test_blackholeCluster(t *testing.T) {
+	c := &cecTranslator{}
+	res, err := c.blackholeCluster(blackholeClusterName)
+	require.NoError(t, err)
+
+	cluster := &envoy_config_cluster_v3.Cluster{}
+	err = proto.Unmarshal(res.Value, cluster)
+
+	require.NoError(t, err)
+	require.Equal(t, blackholeClusterName, cluster.Name)
+	require.Equal(t, &envoy_config_cluster_v3.Cluster_Type{
+		Type: envoy_config_cluster_v3.Cluster_STATIC,
+	}, cluster.ClusterDiscoveryType)
+	require.Equal(t, durationpb.New(blackholeClusterConnectionTime), cluster.ConnectTimeout)
 }
 
 func extAuthBackend(ns, name string, port uint32, tls *model.BackendTLSOrigination) model.Backend {

--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -662,19 +662,27 @@ func tlsPassthroughFilterChains(m *model.Model) []*envoy_config_listener.FilterC
 	var filterChains []*envoy_config_listener.FilterChain
 
 	for _, listener := range stableTLSPassthroughListeners(m.TLSPassthrough) {
+		if len(listener.Routes) == 0 {
+			filterChains = append(filterChains, &envoy_config_listener.FilterChain{
+				FilterChainMatch: toFilterChainMatch([]string{listener.Hostname}),
+				Filters: []*envoy_config_listener.Filter{
+					{
+						Name: tcpProxyType,
+						ConfigType: &envoy_config_listener.Filter_TypedConfig{
+							TypedConfig: toAny(tcpProxyForTLSPassthroughListener(listener)),
+						},
+					},
+				},
+			})
+		}
 		for _, route := range stableTLSPassthroughRoutes(listener.Routes) {
-			backends := stableTLSPassthroughBackends(route.Backends)
-			if len(backends) == 0 {
-				continue
-			}
-
 			filterChains = append(filterChains, &envoy_config_listener.FilterChain{
 				FilterChainMatch: toFilterChainMatch(route.Hostnames),
 				Filters: []*envoy_config_listener.Filter{
 					{
 						Name: tcpProxyType,
 						ConfigType: &envoy_config_listener.Filter_TypedConfig{
-							TypedConfig: toAny(tcpProxyForTLSPassthroughRoute(route, backends)),
+							TypedConfig: toAny(tcpProxyForTLSPassthroughRoute(route)),
 						},
 					},
 				},
@@ -695,19 +703,27 @@ func tlsPassthroughFilterChainsForPort(port uint32, m *model.Model) []*envoy_con
 		if listener.Port != port {
 			continue
 		}
+		if len(listener.Routes) == 0 {
+			filterChains = append(filterChains, &envoy_config_listener.FilterChain{
+				FilterChainMatch: toFilterChainMatch([]string{listener.Hostname}),
+				Filters: []*envoy_config_listener.Filter{
+					{
+						Name: tcpProxyType,
+						ConfigType: &envoy_config_listener.Filter_TypedConfig{
+							TypedConfig: toAny(tcpProxyForTLSPassthroughListener(listener)),
+						},
+					},
+				},
+			})
+		}
 		for _, route := range stableTLSPassthroughRoutes(listener.Routes) {
-			backends := stableTLSPassthroughBackends(route.Backends)
-			if len(backends) == 0 {
-				continue
-			}
-
 			filterChains = append(filterChains, &envoy_config_listener.FilterChain{
 				FilterChainMatch: toFilterChainMatch(route.Hostnames),
 				Filters: []*envoy_config_listener.Filter{
 					{
 						Name: tcpProxyType,
 						ConfigType: &envoy_config_listener.Filter_TypedConfig{
-							TypedConfig: toAny(tcpProxyForTLSPassthroughRoute(route, backends)),
+							TypedConfig: toAny(tcpProxyForTLSPassthroughRoute(route)),
 						},
 					},
 				},
@@ -771,9 +787,29 @@ func stableTLSPassthroughBackends(backends []model.Backend) []model.Backend {
 	return stable
 }
 
-func tcpProxyForTLSPassthroughRoute(route model.TLSPassthroughRoute, backends []model.Backend) *envoy_extensions_filters_network_tcp_v3.TcpProxy {
+func tcpProxyForTLSPassthroughListener(listener model.TLSPassthroughListener) *envoy_extensions_filters_network_tcp_v3.TcpProxy {
+	tcpProxy := &envoy_extensions_filters_network_tcp_v3.TcpProxy{
+		StatPrefix: "tls-passthrough:" + listener.Name,
+	}
+
+	tcpProxy.ClusterSpecifier = &envoy_extensions_filters_network_tcp_v3.TcpProxy_Cluster{
+		Cluster: blackholeClusterName,
+	}
+
+	return tcpProxy
+}
+
+func tcpProxyForTLSPassthroughRoute(route model.TLSPassthroughRoute) *envoy_extensions_filters_network_tcp_v3.TcpProxy {
 	tcpProxy := &envoy_extensions_filters_network_tcp_v3.TcpProxy{
 		StatPrefix: tlsPassthroughFilterChainStatPrefix(route),
+	}
+
+	backends := stableTLSPassthroughBackends(route.Backends)
+	if len(backends) == 0 {
+		tcpProxy.ClusterSpecifier = &envoy_extensions_filters_network_tcp_v3.TcpProxy_Cluster{
+			Cluster: blackholeClusterName,
+		}
+		return tcpProxy
 	}
 
 	if len(backends) == 1 {

--- a/operator/pkg/model/translation/envoy_listener_test.go
+++ b/operator/pkg/model/translation/envoy_listener_test.go
@@ -259,8 +259,10 @@ func Test_tlsPassthroughFilterChains_Backends(t *testing.T) {
 		wantWeighted     []*envoy_extensions_filters_network_tcp_v3.TcpProxy_WeightedCluster_ClusterWeight
 	}{
 		{
-			name:             "no valid backends emits no filter chain",
-			wantFilterChains: 0,
+			name:             "no valid backends uses blackhole cluster",
+			wantFilterChains: 1,
+			wantStatPrefix:   "tls-passthrough:test.example.com",
+			wantCluster:      blackholeClusterName,
 		},
 		{
 			name: "single backend",
@@ -362,6 +364,50 @@ func Test_tlsPassthroughFilterChains_Backends(t *testing.T) {
 			assert.Equal(t, tt.wantWeighted, tcpProxy.GetWeightedClusters().GetClusters())
 		})
 	}
+}
+
+func Test_tlsPassthroughFilterChainsForPort(t *testing.T) {
+	m := &model.Model{
+		TLSPassthrough: []model.TLSPassthroughListener{
+			{
+				Port: 443,
+				Routes: []model.TLSPassthroughRoute{
+					{
+						Hostnames: []string{"ignored.example.com"},
+					},
+				},
+			},
+			{
+				Port: 8443,
+				Routes: []model.TLSPassthroughRoute{
+					{
+						Hostnames: []string{"blackhole.example.com"},
+					},
+					{
+						Hostnames: []string{"backend.example.com"},
+						Backends: []model.Backend{
+							tlsBackend("default", "backend", 9443, nil),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	filterChains := tlsPassthroughFilterChainsForPort(8443, m)
+	require.Len(t, filterChains, 2)
+
+	assert.Equal(t, []string{"backend.example.com"}, filterChains[0].GetFilterChainMatch().GetServerNames())
+	tcpProxy := getTCPProxy(t, filterChains[0])
+	assert.Equal(t, "tls-passthrough:backend.example.com", tcpProxy.GetStatPrefix())
+	assert.Equal(t, "default:backend:9443", tcpProxy.GetCluster())
+	assert.Nil(t, tcpProxy.GetWeightedClusters())
+
+	assert.Equal(t, []string{"blackhole.example.com"}, filterChains[1].GetFilterChainMatch().GetServerNames())
+	tcpProxy = getTCPProxy(t, filterChains[1])
+	assert.Equal(t, "tls-passthrough:blackhole.example.com", tcpProxy.GetStatPrefix())
+	assert.Equal(t, blackholeClusterName, tcpProxy.GetCluster())
+	assert.Nil(t, tcpProxy.GetWeightedClusters())
 }
 
 func Test_tlsPassthroughFilterChains_DuplicateSNIRoutesPreserveCurrentBehavior(t *testing.T) {


### PR DESCRIPTION
Fix TLS passthrough translation in two related cases.

1. TLS protocol listeners were handled together with HTTP and HTTPS listeners in the Gateway API ingestion model. This caused TLS passthrough listeners to incorrectly produce HTTP resources such as HttpConnectionManager and RDS in addition to TcpProxy.

1. Keep TLS passthrough filter chains for routes whose backend refs do not resolve to any valid backends. These routes now point at a static blackhole cluster instead of being omitted.

This change:
- Separates TLS protocol handling from HTTP/HTTPS in the ingestion model.
- Ensures TLS listeners are only processed if they are in Passthrough mode.
- Prevents redundant HttpConnectionManager and RouteConfiguration resources for
  TLS passthrough listeners.
- Routes TLS passthrough rules without valid backends to a blackhole cluster.
- Updates conformance tests and test data to reflect these changes.

```release-note
gateway-api: fix TLS Passthrough translation to prevent redundant HTTP resources, and route TLS route with unresolved backends to a static blackhole cluster.
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
