### PR TITLE
ci: Comment out wait-for-base-images

### DIFF
--- a/.github/workflows/build-images-ci-v1.17.yaml
+++ b/.github/workflows/build-images-ci-v1.17.yaml
@@ -23,19 +23,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  wait-for-base-images:
-    name: Wait for lint checks
-    uses: cilium/actions/.github/workflows/wait-for-status-check.yaml@342436e0898719fabc2337b145b91490f33cec2a
-    with:
-      # Only run this job if the event is pull_request_target and if the PR
-      # is not opened from a fork.
-      # This is to avoid waiting for base images on push to main or merge_group
-      # events as the lint-images-base does not run on those events.
-      if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
-      pr-number: ${{ github.event.pull_request.number }}
-      lint-names: 'Lint image build logic'
-      timeout-minutes: 2
-      poll-interval: 15
+  # GH-46482: Lint checks action is broken, skip dependency for now.
+  #wait-for-base-images:
+  #  name: Wait for lint checks
+  #  uses: cilium/actions/.github/workflows/wait-for-status-check.yaml@342436e0898719fabc2337b145b91490f33cec2a
+  #  with:
+  #    # Only run this job if the event is pull_request_target and if the PR
+  #    # is not opened from a fork.
+  #    # This is to avoid waiting for base images on push to main or merge_group
+  #    # events as the lint-images-base does not run on those events.
+  #    if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
+  #    pr-number: ${{ github.event.pull_request.number }}
+  #    lint-names: 'Lint image build logic'
+  #    timeout-minutes: 2
+  #    poll-interval: 15
 
   build-and-push-prs:
     timeout-minutes: 45

--- a/.github/workflows/build-images-ci-v1.18.yaml
+++ b/.github/workflows/build-images-ci-v1.18.yaml
@@ -23,19 +23,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  wait-for-base-images:
-    name: Wait for lint checks
-    uses: cilium/actions/.github/workflows/wait-for-status-check.yaml@342436e0898719fabc2337b145b91490f33cec2a
-    with:
-      # Only run this job if the event is pull_request_target and if the PR
-      # is not opened from a fork.
-      # This is to avoid waiting for base images on push to main or merge_group
-      # events as the lint-images-base does not run on those events.
-      if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
-      pr-number: ${{ github.event.pull_request.number }}
-      lint-names: 'Lint image build logic'
-      timeout-minutes: 2
-      poll-interval: 15
+  # GH-46482: Lint checks action is broken, skip dependency for now.
+  #wait-for-base-images:
+  #  name: Wait for lint checks
+  #  uses: cilium/actions/.github/workflows/wait-for-status-check.yaml@342436e0898719fabc2337b145b91490f33cec2a
+  #  with:
+  #    # Only run this job if the event is pull_request_target and if the PR
+  #    # is not opened from a fork.
+  #    # This is to avoid waiting for base images on push to main or merge_group
+  #    # events as the lint-images-base does not run on those events.
+  #    if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
+  #    pr-number: ${{ github.event.pull_request.number }}
+  #    lint-names: 'Lint image build logic'
+  #    timeout-minutes: 2
+  #    poll-interval: 15
 
   build-and-push-prs:
     timeout-minutes: 45

--- a/.github/workflows/build-images-ci-v1.19.yaml
+++ b/.github/workflows/build-images-ci-v1.19.yaml
@@ -23,19 +23,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  wait-for-base-images:
-    name: Wait for lint checks
-    uses: cilium/actions/.github/workflows/wait-for-status-check.yaml@342436e0898719fabc2337b145b91490f33cec2a
-    with:
-      # Only run this job if the event is pull_request_target and if the PR
-      # is not opened from a fork.
-      # This is to avoid waiting for base images on push to main or merge_group
-      # events as the lint-images-base does not run on those events.
-      if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
-      pr-number: ${{ github.event.pull_request.number }}
-      lint-names: 'Lint image build logic'
-      timeout-minutes: 2
-      poll-interval: 15
+  # GH-46482: Lint checks action is broken, skip dependency for now.
+  #wait-for-base-images:
+  #  name: Wait for lint checks
+  #  uses: cilium/actions/.github/workflows/wait-for-status-check.yaml@342436e0898719fabc2337b145b91490f33cec2a
+  #  with:
+  #    # Only run this job if the event is pull_request_target and if the PR
+  #    # is not opened from a fork.
+  #    # This is to avoid waiting for base images on push to main or merge_group
+  #    # events as the lint-images-base does not run on those events.
+  #    if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
+  #    pr-number: ${{ github.event.pull_request.number }}
+  #    lint-names: 'Lint image build logic'
+  #    timeout-minutes: 2
+  #    poll-interval: 15
 
   build-and-push-prs:
     timeout-minutes: 45

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -31,19 +31,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  wait-for-base-images:
-    name: Wait for lint checks
-    uses: cilium/actions/.github/workflows/wait-for-status-check.yaml@342436e0898719fabc2337b145b91490f33cec2a
-    with:
-      # Only run this job if the event is pull_request_target and if the PR
-      # is not opened from a fork.
-      # This is to avoid waiting for base images on push to main or merge_group
-      # events as the lint-images-base does not run on those events.
-      if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
-      pr-number: ${{ github.event.pull_request.number }}
-      lint-names: 'Lint image build logic'
-      timeout-minutes: 2
-      poll-interval: 15
+  # GH-46482: Lint checks action is broken, skip dependency for now.
+  #wait-for-base-images:
+  #  name: Wait for lint checks
+  #  uses: cilium/actions/.github/workflows/wait-for-status-check.yaml@342436e0898719fabc2337b145b91490f33cec2a
+  #  with:
+  #    # Only run this job if the event is pull_request_target and if the PR
+  #    # is not opened from a fork.
+  #    # This is to avoid waiting for base images on push to main or merge_group
+  #    # events as the lint-images-base does not run on those events.
+  #    if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
+  #    pr-number: ${{ github.event.pull_request.number }}
+  #    lint-names: 'Lint image build logic'
+  #    timeout-minutes: 2
+  #    poll-interval: 15
 
   build-and-push-prs:
     timeout-minutes: 45


### PR DESCRIPTION
This job is currently failing and it's causing Github to mark whole image build workflow as failed, which causes Ariane to not run tests.