### PR TITLE
[v1.18] vendor: Bump StateDB to v0.4.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/cilium/hive v0.0.0-20250611195437-5a5dacdfb354
 	github.com/cilium/lumberjack/v2 v2.4.1
 	github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1
-	github.com/cilium/statedb v0.4.6
+	github.com/cilium/statedb v0.4.9
 	github.com/cilium/stream v0.0.1
 	github.com/cilium/workerpool v1.3.0
 	github.com/cloudflare/cfssl v1.6.5

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/cilium/lumberjack/v2 v2.4.1 h1:tU92KFJmLQ4Uls5vTgok5b5RbfxpawRia7L14y
 github.com/cilium/lumberjack/v2 v2.4.1/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
 github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1 h1:SOOtIfQmW/pF1iW1I4hVUx1pvgX7Xh2E8jHv+itBXQ0=
 github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1/go.mod h1:Kwyyx+cC2H67Aj1sDuqBLvPn6TEmEJRPvULIrJ/kBRo=
-github.com/cilium/statedb v0.4.6 h1:pundFmW0Dhinsv0ZINdFsxzlb6d3ZQkQM7aJW9eMtD8=
-github.com/cilium/statedb v0.4.6/go.mod h1:DlxX9OQi/nM8oumUuz8VjxXUtVRiEfbfo8Ri1YWNCGI=
+github.com/cilium/statedb v0.4.9 h1:BXAmLK7FMsUPVjWx0Mok/5LvKDEfCb0XyDCHtxMKqNE=
+github.com/cilium/statedb v0.4.9/go.mod h1:DlxX9OQi/nM8oumUuz8VjxXUtVRiEfbfo8Ri1YWNCGI=
 github.com/cilium/stream v0.0.1 h1:82zuM/WwkLiac2Jg5FrzPxZHvIBbxXTi4VY7M+EYLs0=
 github.com/cilium/stream v0.0.1/go.mod h1:/e83AwqvNKpyg4n3C41qmnmj1x2G9DwzI+jb7GkF4lI=
 github.com/cilium/workerpool v1.3.0 h1:7BhHxoqNtpqtmce6MxZdgWODze4lYHbWkEUQ+3xEu8M=

--- a/vendor/github.com/cilium/statedb/part/cache.go
+++ b/vendor/github.com/cilium/statedb/part/cache.go
@@ -9,28 +9,48 @@ import (
 
 const nodeMutatedSize = 256 // must be power-of-two
 
-type nodeMutated struct {
-	ptrs [nodeMutatedSize]uintptr
+// nodeMutated is a probabilistic check for seeing if a node has
+// been cloned within a transaction and thus can be modified in-place
+// since it has not been seen outside. This significantly speeds up
+// writes within a single write transaction as inner nodes no longer
+// need to be cloned on every change, effectively making the immutable
+// radix tree perform as if it's a mutable one.
+//
+// Earlier versions of StateDB just used a map[*header[T]]struct{}, but
+// that was fairly costly and experiments showed that it's enough to most
+// of the time avoid the clone to perform well.
+//
+// The value for [nodeMutatedSize] is a balance between making Txn()
+// not too costly (due to e.g. clear()) and between giving a high likelyhood
+// that we mutate nodes in-place.
+type nodeMutated[T any] struct {
+	ptrs [nodeMutatedSize]*header[T]
 	used bool
 }
 
-func nodeMutatedSet[T any](nm *nodeMutated, ptr *header[T]) {
+func (nm *nodeMutated[T]) set(n *header[T]) {
 	if nm == nil {
 		return
 	}
-	ptrInt := uintptr(unsafe.Pointer(ptr))
-	nm.ptrs[slot(ptrInt)] = ptrInt
+	ptrInt := uintptr(unsafe.Pointer(n))
+	nm.ptrs[slot(ptrInt)] = n
 	nm.used = true
 }
 
-func nodeMutatedExists[T any](nm *nodeMutated, ptr *header[T]) bool {
+func (nm *nodeMutated[T]) exists(n *header[T]) bool {
 	if nm == nil {
 		return false
 	}
-	ptrInt := uintptr(unsafe.Pointer(ptr))
-	return nm.ptrs[slot(ptrInt)] == ptrInt
+	ptrInt := uintptr(unsafe.Pointer(n))
+	return nm.ptrs[slot(ptrInt)] == n
 }
 
+// slot returns the index in the [ptrs] array for a given pointer.
+// The Go spec allows objects to be moved so it may be that the same
+// instance of an object is assigned to a different memory location in
+// which case we'd no longer report that node as being in the cache.
+// This is fine though as we do compare the actual *header[T] pointers
+// and this is probabilistic anyway as this is a fixed size cache.
 func slot(p uintptr) int {
 	p >>= 4 // ignore low order bits
 	// use some relevant bits from the pointer
@@ -38,7 +58,7 @@ func slot(p uintptr) int {
 	return int(slot & (nodeMutatedSize - 1))
 }
 
-func (nm *nodeMutated) clear() {
+func (nm *nodeMutated[T]) clear() {
 	if nm == nil {
 		return
 	}

--- a/vendor/github.com/cilium/statedb/part/tree.go
+++ b/vendor/github.com/cilium/statedb/part/tree.go
@@ -44,7 +44,7 @@ func newTxn[T any](o options) *Txn[T] {
 		watches: make(map[chan struct{}]struct{}),
 	}
 	if !o.noCache() {
-		txn.mutated = &nodeMutated{}
+		txn.mutated = &nodeMutated[T]{}
 		txn.deleteParentsCache = make([]deleteParent[T], 0, 32)
 	}
 	txn.opts = o

--- a/vendor/github.com/cilium/statedb/part/txn.go
+++ b/vendor/github.com/cilium/statedb/part/txn.go
@@ -20,7 +20,7 @@ type Txn[T any] struct {
 	// that we can keep mutating without cloning them again.
 	// It is cleared if the transaction is cloned or iterated
 	// upon.
-	mutated *nodeMutated
+	mutated *nodeMutated[T]
 
 	// watches contains the channels of cloned nodes that should be closed
 	// when transaction is committed.
@@ -168,6 +168,10 @@ func (txn *Txn[T]) CommitOnly() *Tree[T] {
 	return t
 }
 
+// watchesReuseThreshold is the threshold at which the [txn.watches] hash
+// map is reused for next transaction.
+const watchesReuseThreshold = 64
+
 // Notify closes the watch channels of nodes that were
 // mutated as part of this transaction. Must be called before
 // Tree.Txn() is used again.
@@ -175,8 +179,12 @@ func (txn *Txn[T]) Notify() {
 	for ch := range txn.watches {
 		close(ch)
 	}
-	clear(txn.watches)
-
+	// Clear or reallocate the watches hash map for the next transaction.
+	if len(txn.watches) <= watchesReuseThreshold {
+		clear(txn.watches)
+	} else {
+		txn.watches = make(map[chan struct{}]struct{})
+	}
 	if !txn.opts.rootOnlyWatch() {
 		validateRemovedWatches(txn.oldRoot, txn.root)
 	}
@@ -188,14 +196,14 @@ func (txn *Txn[T]) PrintTree() {
 }
 
 func (txn *Txn[T]) cloneNode(n *header[T]) *header[T] {
-	if nodeMutatedExists(txn.mutated, n) {
+	if txn.mutated.exists(n) {
 		return n
 	}
 	if n.watch != nil {
 		txn.watches[n.watch] = struct{}{}
 	}
 	n = n.clone(!txn.opts.rootOnlyWatch() || n == txn.root)
-	nodeMutatedSet(txn.mutated, n)
+	txn.mutated.set(n)
 	return n
 }
 
@@ -232,7 +240,7 @@ func (txn *Txn[T]) modify(root *header[T], key []byte, mod func(T) T) (oldValue 
 					txn.watches[this.watch] = struct{}{}
 				}
 				this = this.promote(!txn.opts.rootOnlyWatch() || this == root)
-				nodeMutatedSet(txn.mutated, this)
+				txn.mutated.set(this)
 			} else {
 				// Node is big enough, clone it so we can mutate it
 				this = txn.cloneNode(this)
@@ -490,17 +498,49 @@ func validateRemovedWatches[T any](oldRoot *header[T], newRoot *header[T]) {
 	if !runValidation {
 		return
 	}
-	var collectWatches func(depth int, watches map[<-chan struct{}]int, node *header[T])
-	collectWatches = func(depth int, watches map[<-chan struct{}]int, node *header[T]) {
+
+	// nodeStruct memoizes the structure for a node.
+	nodeStruct := map[*header[T]]string{}
+
+	// summarizeNodeStructure "lazily" summarizes the internal structure of a node,
+	// e.g. it's watch channel, size, leaf and children. The lazy construction speeds
+	// things up a lot as we only look at the structure in certain specific cases.
+	var summarizeNodeStructure func(node *header[T]) func() string
+	summarizeNodeStructure = func(node *header[T]) func() string {
+		if node == nil {
+			return func() string { return "" }
+		}
+		if s, found := nodeStruct[node]; found {
+			return func() string { return s }
+		}
+		return func() string {
+			var childS string
+			for _, child := range node.children() {
+				if child != nil {
+					childS += summarizeNodeStructure(child)()
+				}
+			}
+			var leafS string
+			if leaf := node.getLeaf(); leaf != nil && !node.isLeaf() {
+				leafS = summarizeNodeStructure(leaf.self())()
+			}
+			s := fmt.Sprintf("K:%d S:%d W:%p L:[%s] C:[%s]", node.kind(), node.size(), node.watch, leafS, childS)
+			nodeStruct[node] = s
+			return s
+		}
+	}
+
+	var collectWatches func(depth int, watches map[<-chan struct{}]func() string, node *header[T])
+	collectWatches = func(depth int, watches map[<-chan struct{}]func() string, node *header[T]) {
 		if node == nil {
 			return
 		}
 		if node.watch == nil {
 			panic("nil watch channel")
 		}
-		watches[node.watch] = depth
+		watches[node.watch] = summarizeNodeStructure(node)
 		if leaf := node.getLeaf(); leaf != nil && !node.isLeaf() {
-			watches[leaf.watch] = depth
+			watches[leaf.watch] = summarizeNodeStructure(leaf.self())
 		}
 		for _, child := range node.children() {
 			if child != nil {
@@ -508,23 +548,39 @@ func validateRemovedWatches[T any](oldRoot *header[T], newRoot *header[T]) {
 			}
 		}
 	}
-	oldWatches := map[<-chan struct{}]int{}
+
+	oldWatches := map[<-chan struct{}]func() string{}
 	collectWatches(0, oldWatches, oldRoot)
-	newWatches := map[<-chan struct{}]int{}
+	newWatches := map[<-chan struct{}]func() string{}
 	collectWatches(0, newWatches, newRoot)
+
+	// Check that any nodes that kept the old watch channel have exactly
+	// the same leaf and children structure.
+	for watch, oldDescFn := range oldWatches {
+		newDescFn, found := newWatches[watch]
+		if found {
+			oldDesc := oldDescFn()
+			newDesc := newDescFn()
+			if oldDesc != newDesc {
+				panic(fmt.Sprintf("node with retained watch channel has different structure:\nexpected: %s\n     got: %s", oldDesc, newDesc))
+			}
+		}
+
+	}
 
 	// Any nodes that are not part of the new tree must have their watch channels closed.
 	for watch := range newWatches {
 		delete(oldWatches, watch)
 	}
-	for watch, depth := range oldWatches {
+
+	for watch, desc := range oldWatches {
 		select {
 		case <-watch:
 		default:
 			oldRoot.printTree(0)
 			fmt.Println("---")
 			newRoot.printTree(0)
-			panic(fmt.Sprintf("dropped watch channel %p at depth %d not closed", watch, depth))
+			panic(fmt.Sprintf("dropped watch channel %p not closed %s", watch, desc()))
 		}
 	}
 }

--- a/vendor/github.com/cilium/statedb/watchset.go
+++ b/vendor/github.com/cilium/statedb/watchset.go
@@ -77,11 +77,9 @@ func (ws *WatchSet) Merge(other *WatchSet) {
 // Wait for channels in the watch set to close or the context is cancelled.
 // After the first closed channel is seen Wait will wait [settleTime] for
 // more closed channels.
+// If [settleTime] is 0 waits until [ctx] cancelled or any channel closes.
 // Returns the closed channels and removes them from the set.
 func (ws *WatchSet) Wait(ctx context.Context, settleTime time.Duration) ([]<-chan struct{}, error) {
-	innerCtx, cancel := context.WithTimeout(ctx, settleTime)
-	defer cancel()
-
 	ws.mu.Lock()
 	defer ws.mu.Unlock()
 
@@ -94,10 +92,14 @@ func (ws *WatchSet) Wait(ctx context.Context, settleTime time.Duration) ([]<-cha
 	// Construct []SelectCase slice. Reuse the previous allocation.
 	ws.cases = slices.Grow(ws.cases, 1+len(ws.chans))
 	cases := ws.cases[:1+len(ws.chans)]
+
+	// Add [ctx.Done()] to stop when [ctx] is cancelled.
 	cases[0] = reflect.SelectCase{
 		Dir:  reflect.SelectRecv,
-		Chan: reflect.ValueOf(innerCtx.Done()),
+		Chan: reflect.ValueOf(ctx.Done()),
 	}
+
+	// Add the cases from the watch set.
 	casesIndex := 1
 	for ch := range ws.chans {
 		cases[casesIndex] = reflect.SelectCase{
@@ -109,20 +111,41 @@ func (ws *WatchSet) Wait(ctx context.Context, settleTime time.Duration) ([]<-cha
 
 	var closedChannels []<-chan struct{}
 
-	// Collect closed channels until [innerCtx] is cancelled.
-	for {
+	// At the end remove the closed channels from the watch set.
+	defer func() {
+		for _, ch := range closedChannels {
+			delete(ws.chans, ch)
+		}
+	}()
+
+	// Wait for the first channel to close and shift it out from [cases]
+	chosen, _, _ := reflect.Select(cases)
+	if chosen == 0 {
+		return nil, ctx.Err()
+	}
+	closedChannels = append(closedChannels, cases[chosen].Chan.Interface().(<-chan struct{}))
+	cases[chosen] = cases[len(cases)-1]
+	cases = cases[:len(cases)-1]
+
+	// If nothing else than context channel remains or we don't want to wait for further channels
+	// to close then we're done.
+	if len(cases) == 1 || settleTime == 0 {
+		return closedChannels, nil
+	}
+
+	// Swap out the 'ctx.Done()' to a context that times out when [settleTime] expires.
+	settleCtx, cancel := context.WithTimeout(ctx, settleTime)
+	defer cancel()
+	cases[0].Chan = reflect.ValueOf(settleCtx.Done())
+
+	for len(cases) > 1 {
 		chosen, _, _ := reflect.Select(cases)
-		if chosen == 0 /* == innerCtx.Done() */ {
+		if chosen == 0 /* settleCtx.Done() */ {
 			break
 		}
 		closedChannels = append(closedChannels, cases[chosen].Chan.Interface().(<-chan struct{}))
 		cases[chosen] = cases[len(cases)-1]
 		cases = cases[:len(cases)-1]
-	}
-
-	// Remove the closed channels from the watch set.
-	for _, ch := range closedChannels {
-		delete(ws.chans, ch)
 	}
 
 	return closedChannels, ctx.Err()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -290,7 +290,7 @@ github.com/cilium/lumberjack/v2
 ## explicit; go 1.23.0
 github.com/cilium/proxy/go/cilium/api
 github.com/cilium/proxy/pkg/policy/api/kafka
-# github.com/cilium/statedb v0.4.6
+# github.com/cilium/statedb v0.4.9
 ## explicit; go 1.24
 github.com/cilium/statedb
 github.com/cilium/statedb/index


### PR DESCRIPTION
This brings in the fix to not retain a large 'watches' hash map that is passed onto future transactions (v0.4.9).

v0.4.8 fixed an issue in WatchSet.Wait but that was not exercised much in Cilium v1.18.

v0.4.7 backported a fix for an issue in nodeMutated which was not a known problem in v0.4 series but was fixed out of caution.

Related to: https://github.com/cilium/cilium/issues/44310#issuecomment-4668687104

```release-note
Fix memory leak issue with reusing a watch channel hash map from very large StateDB transactions
```