### PR TITLE
proxy: use devices table for `cilium_net` IPv6 lookup

### DIFF
--- a/pkg/proxy/routes.go
+++ b/pkg/proxy/routes.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	"github.com/cilium/cilium/pkg/datapath/linux/route/reconciler"
-	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/option"
@@ -50,6 +49,7 @@ func (p *Proxy) ReinstallRoutingRules(ctx context.Context, mtu int, ipsecEnabled
 
 	rxn := p.db.ReadTxn()
 	hostDevice, _, hostDeviceFound := p.devices.Get(rxn, tables.DeviceByName(defaults.HostDevice))
+	ciliumNetDevice, _, ciliumNetDeviceFound := p.devices.Get(rxn, tables.DeviceByName(defaults.SecondHostDevice))
 	lo, _, loFound := p.devices.Get(rxn, tables.DeviceByName("lo"))
 
 	if option.Config.EnableIPv4 && p.enabled {
@@ -88,12 +88,15 @@ func (p *Proxy) ReinstallRoutingRules(ctx context.Context, mtu int, ipsecEnabled
 		}
 
 		if fromIngressProxy || fromEgressProxy {
-			ipv6, err := getCiliumNetIPv6()
-			if err != nil {
-				return err
-			}
 			if !hostDeviceFound {
 				return fmt.Errorf("failed to get host device %s", defaults.HostDevice)
+			}
+			if !ciliumNetDeviceFound {
+				return fmt.Errorf("failed to get second host device %s", defaults.SecondHostDevice)
+			}
+			ipv6, err := getCiliumNetIPv6(ciliumNetDevice)
+			if err != nil {
+				return err
 			}
 			if err := installFromProxyRoutesIPv6(p.routeOwner, p.routeManager, ipv6, hostDevice, fromIngressProxy, fromEgressProxy, mtu); err != nil {
 				return err
@@ -145,16 +148,10 @@ func requireFromProxyRoutes(ipsecEnabled, wireguardEnabled bool, mtuIn int) (fro
 }
 
 // getCiliumNetIPv6 retrieves the first IPv6 address from the cilium_net device.
-func getCiliumNetIPv6() (netip.Addr, error) {
-	link, err := safenetlink.LinkByName(defaults.SecondHostDevice)
-	if err != nil {
-		return netip.Addr{}, fmt.Errorf("cannot find link '%s': %w", defaults.SecondHostDevice, err)
-	}
-
-	addrList, err := safenetlink.AddrList(link, netlink.FAMILY_V6)
-	if err == nil && len(addrList) > 0 {
-		if addr, ok := netip.AddrFromSlice(addrList[0].IP); ok {
-			return addr.Unmap(), nil
+func getCiliumNetIPv6(device *tables.Device) (netip.Addr, error) {
+	for _, addr := range device.Addrs {
+		if addr.Addr.Is6() {
+			return addr.Addr.Unmap(), nil
 		}
 	}
 


### PR DESCRIPTION
Use the devices table to retrieve the `cilium_net` device and its IPv6 address when installing proxy routes instead of issuing a netlink link/address lookup. This mirrors how the `cilium_host` device is already retrieved in the same code path and saves a kernel netlink query.