### PR TITLE
operator: miscellaneous improvements to the troubleshoot clustermesh command

### DIFF
--- a/cilium-dbg/cmd/troubleshoot/troubleshoot_clustermesh.go
+++ b/cilium-dbg/cmd/troubleshoot/troubleshoot_clustermesh.go
@@ -92,8 +92,8 @@ func TroubleshootClusterMesh(
 	cfgs, err := common.ConfigFiles(cfgdir)
 	if err != nil {
 		fmt.Fprintf(stdout, "Unable to retrieve cluster configurations: %s\n", err)
-		fmt.Fprintf(stdout, "Is %q the correct configuration directory?\n", cfgdir)
-		os.Exit(1)
+		fmt.Fprintf(stdout, "This is expected when Cluster Mesh is disabled\n")
+		return
 	}
 
 	fmt.Fprintf(stdout, "Found %d cluster configurations\n", len(cfgs))

--- a/cilium-dbg/cmd/troubleshoot/troubleshoot_clustermesh.go
+++ b/cilium-dbg/cmd/troubleshoot/troubleshoot_clustermesh.go
@@ -26,6 +26,12 @@ import (
 	cslices "github.com/cilium/cilium/pkg/slices"
 )
 
+// DisableLocalNameLookup allows to disable the lookup of the local cluster
+// name, given that it is not supported on the operator. It is only used to
+// provide a hint if the configuration for the local cluster is present, hence
+// it is not a big deal if don't retrieve it.
+var DisableLocalNameLookup bool
+
 var troubleshootClusterMeshCmd = func() *cobra.Command {
 	var cfg string
 	var timeout time.Duration
@@ -38,7 +44,12 @@ var troubleshootClusterMeshCmd = func() *cobra.Command {
 			initConfig()
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			local := getLocalClusterName(cmd.ErrOrStderr())
+			var local string
+
+			if !DisableLocalNameLookup {
+				local = getLocalClusterName(cmd.ErrOrStderr())
+			}
+
 			TroubleshootClusterMesh(
 				cmd.Context(), cmd.OutOrStdout(),
 				newTroubleshootDialer(cmd.ErrOrStderr(), disableDialer),

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -448,6 +448,7 @@ func NewOperatorCmd(h *hive.Hive) *cobra.Command {
 	// Overwrite the metrics namespace with the one specific for the Operator
 	metrics.Namespace = metrics.CiliumOperatorNamespace
 
+	troubleshoot.DisableLocalNameLookup = true
 	cmd.AddCommand(
 		cmdref.NewCmd(cmd),
 		MetricsCmd,

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3547,13 +3547,6 @@ func InitConfig(logger *slog.Logger, cmd *cobra.Command, programName, configName
 			vp.AddConfigPath("$HOME")    // adding home directory as first search path
 		}
 
-		// We need to check for the debug environment variable or CLI flag before
-		// loading the configuration file since on configuration file read failure
-		// we will emit a debug log entry.
-		if vp.GetBool(DebugArg) {
-			logging.SetLogLevel(slog.LevelDebug)
-		}
-
 		// If a config file is found, read it in.
 		if err := vp.ReadInConfig(); err == nil {
 			logger.Info("Using config from file", logfields.Path, vp.ConfigFileUsed())
@@ -3563,12 +3556,9 @@ func InitConfig(logger *slog.Logger, cmd *cobra.Command, programName, configName
 				logfields.Path, vp.ConfigFileUsed(),
 				logfields.Error, err,
 			)
-		} else {
-			logger.Debug("Skipped reading configuration file", logfields.Error, err)
 		}
 
-		// Check for the debug flag again now that the configuration file may has
-		// been loaded, as it might have changed.
+		// Check for the debug flag now that all configurations have been loaded.
 		if vp.GetBool(DebugArg) {
 			logging.SetLogLevel(slog.LevelDebug)
 		}


### PR DESCRIPTION
Implement minor improvements to the Cilium operator `troubleshoot clustermesh` command, in preparation for collecting the output as part of sysdumps. Refer to the individual commit messages for additional details. Marking for backport to v1.19 as it targets a debug utility.  