### PR TITLE
bpf: Make `snat_v4_needs_masquerade` global

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -623,12 +623,12 @@ static __always_inline void snat_v4_init_tuple(const struct iphdr *ip4,
  * error code (distinct from NAT_PUNT_TO_STACK).
  */
 static __always_inline int
-snat_v4_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
-			 struct ipv4_ct_tuple *tuple __maybe_unused,
-			 struct iphdr *ip4 __maybe_unused,
-			 fraginfo_t fraginfo __maybe_unused,
-			 int l4_off __maybe_unused,
-			 struct ipv4_nat_target *target __maybe_unused)
+__snat_v4_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
+			   struct ipv4_ct_tuple *tuple __maybe_unused,
+			   struct iphdr *ip4 __maybe_unused,
+			   fraginfo_t fraginfo __maybe_unused,
+			   int l4_off __maybe_unused,
+			   struct ipv4_nat_target *target __maybe_unused)
 {
 	const struct endpoint_info *local_ep __maybe_unused;
 	const struct remote_endpoint_info *remote_ep __maybe_unused;
@@ -789,6 +789,21 @@ snat_v4_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 #endif /*ENABLE_MASQUERADE_IPV4 && IS_BPF_HOST */
 
 	return NAT_PUNT_TO_STACK;
+}
+
+static __always_inline int
+snat_v4_needs_masquerade(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
+			 fraginfo_t fraginfo, int l4_off,
+			 struct ipv4_nat_target *target)
+{
+	void *data, *data_end;
+	struct iphdr *ip4;
+
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
+		return DROP_INVALID;
+
+	return __snat_v4_needs_masquerade(ctx, tuple, ip4, fraginfo,
+					  l4_off, target);
 }
 
 static __always_inline __maybe_unused int

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -791,7 +791,7 @@ __snat_v4_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 	return NAT_PUNT_TO_STACK;
 }
 
-static __always_inline int
+__noinline __weak int
 snat_v4_needs_masquerade(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 			 fraginfo_t fraginfo, int l4_off,
 			 struct ipv4_nat_target *target)

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -791,19 +791,28 @@ __snat_v4_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 	return NAT_PUNT_TO_STACK;
 }
 
+/* Store struct ipv6_ct_tuple and struct ipv6_nat_target objects in maps to
+ * optimize stack usage.
+ */
+struct snat_v4_args {
+	struct ipv4_ct_tuple tuple;
+	struct ipv4_nat_target target;
+};
+
+DEFINE_AUX(struct snat_v4_args, snat_v4_args);
+
 __noinline __weak int
-snat_v4_needs_masquerade(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
-			 fraginfo_t fraginfo, int l4_off,
-			 struct ipv4_nat_target *target)
+snat_v4_needs_masquerade(struct __ctx_buff *ctx, fraginfo_t fraginfo, int l4_off)
 {
+	struct snat_v4_args *args = AUX(snat_v4_args);
 	void *data, *data_end;
 	struct iphdr *ip4;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
-	return __snat_v4_needs_masquerade(ctx, tuple, ip4, fraginfo,
-					  l4_off, target);
+	return __snat_v4_needs_masquerade(ctx, &args->tuple, ip4, fraginfo,
+					  l4_off, &args->target);
 }
 
 static __always_inline __maybe_unused int

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -623,29 +623,13 @@ static __always_inline void snat_v4_init_tuple(const struct iphdr *ip4,
  * error code (distinct from NAT_PUNT_TO_STACK).
  */
 static __always_inline int
-__snat_v4_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
-			   struct ipv4_ct_tuple *tuple __maybe_unused,
-			   struct iphdr *ip4 __maybe_unused,
-			   fraginfo_t fraginfo __maybe_unused,
-			   int l4_off __maybe_unused,
-			   struct ipv4_nat_target *target __maybe_unused)
+__snat_v4_needs_masquerade(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
+			   struct iphdr *ip4, fraginfo_t fraginfo, int l4_off,
+			   struct ipv4_nat_target *target)
 {
-	const struct endpoint_info *local_ep __maybe_unused;
-	const struct remote_endpoint_info *remote_ep __maybe_unused;
+	const struct endpoint_info *local_ep;
+	const struct remote_endpoint_info *remote_ep;
 
-#if defined(TUNNEL_MODE) && defined(IS_BPF_OVERLAY)
-# if defined(ENABLE_CLUSTER_AWARE_ADDRESSING) && defined(ENABLE_INTER_CLUSTER_SNAT)
-	if (target->cluster_id != 0 &&
-	    target->cluster_id != CONFIG(cluster_id)) {
-		target->addr = IPV4_INTER_CLUSTER_SNAT;
-		target->from_local_endpoint = true;
-
-		return NAT_NEEDED;
-	}
-# endif
-#endif /* TUNNEL_MODE && IS_BPF_OVERLAY */
-
-#if defined(ENABLE_MASQUERADE_IPV4) && defined(IS_BPF_HOST)
 	/* To prevent aliasing with masqueraded connections,
 	 * we need to track all host connections that use config
 	 * nat_ipv4_masquerade.
@@ -786,7 +770,6 @@ __snat_v4_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 		target->addr = CONFIG(nat_ipv4_masquerade).be32;
 		return NAT_NEEDED;
 	}
-#endif /*ENABLE_MASQUERADE_IPV4 && IS_BPF_HOST */
 
 	return NAT_PUNT_TO_STACK;
 }

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -329,14 +329,7 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 						  struct trace_ctx *trace,
 						  __s8 *ext_err)
 {
-	struct ipv4_nat_target target = {
-		.min_port = NODEPORT_PORT_MIN_NAT,
-		.max_port = NODEPORT_PORT_MAX_NAT,
-#if defined(ENABLE_CLUSTER_AWARE_ADDRESSING) && defined(ENABLE_INTER_CLUSTER_SNAT)
-		.cluster_id = cluster_id,
-#endif
-	};
-	struct ipv4_ct_tuple tuple = {};
+	struct snat_v4_args *args;
 	void *data, *data_end;
 	struct iphdr *ip4;
 	fraginfo_t fraginfo;
@@ -347,7 +340,15 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 
 	fraginfo = ipfrag_encode_ipv4(ip4);
 
-	snat_v4_init_tuple(ip4, NAT_DIR_EGRESS, &tuple);
+	args = AUX(snat_v4_args);
+	memset(args, 0, sizeof(*args));
+	args->target.min_port = NODEPORT_PORT_MIN_NAT;
+	args->target.max_port = NODEPORT_PORT_MAX_NAT;
+#if defined(ENABLE_CLUSTER_AWARE_ADDRESSING) && defined(ENABLE_INTER_CLUSTER_SNAT)
+	args->target.cluster_id = cluster_id,
+#endif
+
+	snat_v4_init_tuple(ip4, NAT_DIR_EGRESS, &args->tuple);
 	l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
 
 	if (is_defined(IS_BPF_HOST) && is_defined(ENABLE_MASQUERADE_IPV4)) {
@@ -361,38 +362,38 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 			 * parent interface.
 			 */
 			ret = ct_extract_ports4(ctx, ip4, fraginfo, l4_off,
-						CT_EGRESS, &tuple);
+						CT_EGRESS, &args->tuple);
 			if (ret < 0 && ret != DROP_CT_UNKNOWN_PROTO)
 				return ret;
 
 			if (ret != DROP_CT_UNKNOWN_PROTO &&
-			    ct_is_reply4(get_ct_map4(&tuple), &tuple))
+			    ct_is_reply4(get_ct_map4(&args->tuple), &args->tuple))
 				return redirect_neigh(ep->parent_ifindex, NULL, 0, 0);
 		}
 	}
 
-	if (lb_is_svc_proto(tuple.nexthdr) &&
-	    nodeport_has_nat_conflict_ipv4(ctx, ip4, &target))
+	if (lb_is_svc_proto(args->tuple.nexthdr) &&
+	    nodeport_has_nat_conflict_ipv4(ctx, ip4, &args->target))
 		goto apply_snat;
 
-	ret = snat_v4_needs_masquerade(ctx, &tuple, fraginfo, l4_off, &target);
+	ret = snat_v4_needs_masquerade(ctx, fraginfo, l4_off);
 	if (IS_ERR(ret))
 		goto out;
 
 #if defined(ENABLE_EGRESS_GATEWAY_COMMON) && defined(IS_BPF_HOST)
-	if (target.egress_gateway) {
+	if (args->target.egress_gateway) {
 		/* from-overlay has already picked the correct egress interface: */
 		if (ctx_egw_done(ctx))
 			goto apply_snat;
 
 		/* Stay on the desired egress interface: */
-		if (target.ifindex && target.ifindex == CONFIG(interface_ifindex))
+		if (args->target.ifindex && args->target.ifindex == CONFIG(interface_ifindex))
 			goto apply_snat;
 
 		/* Send packet to the correct egress interface, and SNAT it there. */
-		ret = egress_gw_fib_lookup_and_redirect(ctx, target.addr,
-							tuple.daddr, target.ifindex,
-							target.tbid, ext_err);
+		ret = egress_gw_fib_lookup_and_redirect(ctx, args->target.addr,
+							args->tuple.daddr, args->target.ifindex,
+							args->target.tbid, ext_err);
 		if (ret != CTX_ACT_OK)
 			return ret;
 
@@ -402,9 +403,9 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 #endif
 
 apply_snat:
-	*saddr = tuple.saddr;
-	ret = snat_v4_nat(ctx, &tuple, ip4, fraginfo, l4_off,
-			  &target, trace, ext_err);
+	*saddr = args->tuple.saddr;
+	ret = snat_v4_nat(ctx, &args->tuple, ip4, fraginfo, l4_off,
+			  &args->target, trace, ext_err);
 	if (IS_ERR(ret))
 		goto out;
 

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -376,7 +376,22 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 	    nodeport_has_nat_conflict_ipv4(ctx, ip4, &args->target))
 		goto apply_snat;
 
+	ret = NAT_PUNT_TO_STACK;
+#if defined(TUNNEL_MODE) && defined(IS_BPF_OVERLAY)
+# if defined(ENABLE_CLUSTER_AWARE_ADDRESSING) && defined(ENABLE_INTER_CLUSTER_SNAT)
+	if (args->target.cluster_id != 0 &&
+	    args->target.cluster_id != CONFIG(cluster_id)) {
+		args->target.addr = IPV4_INTER_CLUSTER_SNAT;
+		args->target.from_local_endpoint = true;
+
+		ret = NAT_NEEDED;
+	}
+# endif
+#endif /* TUNNEL_MODE && IS_BPF_OVERLAY */
+
+#if defined(ENABLE_MASQUERADE_IPV4) && defined(IS_BPF_HOST)
 	ret = snat_v4_needs_masquerade(ctx, fraginfo, l4_off);
+#endif /*ENABLE_MASQUERADE_IPV4 && IS_BPF_HOST */
 	if (IS_ERR(ret))
 		goto out;
 

--- a/bpf/lib/nodeport_egress.h
+++ b/bpf/lib/nodeport_egress.h
@@ -375,7 +375,7 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 	    nodeport_has_nat_conflict_ipv4(ctx, ip4, &target))
 		goto apply_snat;
 
-	ret = snat_v4_needs_masquerade(ctx, &tuple, ip4, fraginfo, l4_off, &target);
+	ret = snat_v4_needs_masquerade(ctx, &tuple, fraginfo, l4_off, &target);
 	if (IS_ERR(ret))
 		goto out;
 

--- a/bpf/tests/remote_node_masquerade_skip_test.c
+++ b/bpf/tests/remote_node_masquerade_skip_test.c
@@ -45,7 +45,7 @@ ASSIGN_CONFIG(bool, enable_extended_ip_protocols, false)
 CHECK("tc", "nat4_remote_node_masquerade_skipped_test")
 int test_nat4_remote_node_masquerade_skipped(__maybe_unused struct __ctx_buff *ctx)
 {
-    struct ipv4_ct_tuple tuple = {};
+    struct snat_v4_args *args = AUX(snat_v4_args);
     fraginfo_t fraginfo = 0;
     int l4_off = 0;
     int ret;
@@ -55,33 +55,31 @@ int test_nat4_remote_node_masquerade_skipped(__maybe_unused struct __ctx_buff *c
     ipcache_v4_add_entry(IPV4_DST, 0, REMOTE_NODE_ID, 0, 0);
 
     /* Set up the tuple as if the packet is going to a remote node */
-    tuple.daddr = IPV4_DST;
-    tuple.saddr = bpf_htonl(0xDEADBEEF); /* Unlikely to be a local endpoint */
-    tuple.nexthdr = IPPROTO_TCP;
-    tuple.sport = bpf_htons(12345);
-    tuple.dport = bpf_htons(443);
-    tuple.flags = NAT_DIR_EGRESS;
+    args->tuple.daddr = IPV4_DST;
+    args->tuple.saddr = bpf_htonl(0xDEADBEEF); /* Unlikely to be a local endpoint */
+    args->tuple.nexthdr = IPPROTO_TCP;
+    args->tuple.sport = bpf_htons(12345);
+    args->tuple.dport = bpf_htons(443);
+    args->tuple.flags = NAT_DIR_EGRESS;
 
     /* Setup NAT target structure */
-    struct ipv4_nat_target target = {
-    .min_port            = NODEPORT_PORT_MIN_NAT, /* Standard min port */
-    .max_port            = NODEPORT_PORT_MAX_NAT, /* Standard max port */
-    .addr                = 0,
-    .from_local_endpoint = false,
-    .egress_gateway      = false,
-    .cluster_id          = 0,
-    .needs_ct            = false,
-    .ifindex             = 0,
-    };
+    args->target.min_port = NODEPORT_PORT_MIN_NAT; /* Standard min port */
+    args->target.max_port = NODEPORT_PORT_MAX_NAT; /* Standard max port */
+    args->target.addr = 0;
+    args->target.from_local_endpoint = false;
+    args->target.egress_gateway = false;
+    args->target.cluster_id = 0;
+    args->target.needs_ct = false;
+    args->target.ifindex = 0;
 
     /*
      * Test: With enable_remote_node_masquerade configured as false via ASSIGN_CONFIG.
      * and TUNNEL_MODE undefined.
      * Expect NAT_PUNT_TO_STACK and target.addr to be 0.
      */
-    ret = snat_v4_needs_masquerade(ctx, &tuple, fraginfo, l4_off, &target);
+    ret = snat_v4_needs_masquerade(ctx, fraginfo, l4_off);
     assert(ret == NAT_PUNT_TO_STACK);
-    assert(target.addr == 0); /* Masquerade address should NOT be set */
+    assert(args->target.addr == 0); /* Masquerade address should NOT be set */
 
     test_finish();
     return 0;

--- a/bpf/tests/remote_node_masquerade_skip_test.c
+++ b/bpf/tests/remote_node_masquerade_skip_test.c
@@ -46,9 +46,6 @@ CHECK("tc", "nat4_remote_node_masquerade_skipped_test")
 int test_nat4_remote_node_masquerade_skipped(__maybe_unused struct __ctx_buff *ctx)
 {
     struct ipv4_ct_tuple tuple = {};
-    struct iphdr ip4 = {
-    .protocol = IPPROTO_TCP,
-    };
     fraginfo_t fraginfo = 0;
     int l4_off = 0;
     int ret;
@@ -82,7 +79,7 @@ int test_nat4_remote_node_masquerade_skipped(__maybe_unused struct __ctx_buff *c
      * and TUNNEL_MODE undefined.
      * Expect NAT_PUNT_TO_STACK and target.addr to be 0.
      */
-    ret = snat_v4_needs_masquerade(ctx, &tuple, &ip4, fraginfo, l4_off, &target);
+    ret = snat_v4_needs_masquerade(ctx, &tuple, fraginfo, l4_off, &target);
     assert(ret == NAT_PUNT_TO_STACK);
     assert(target.addr == 0); /* Masquerade address should NOT be set */
 

--- a/bpf/tests/remote_node_masquerade_test.c
+++ b/bpf/tests/remote_node_masquerade_test.c
@@ -45,7 +45,7 @@ ASSIGN_CONFIG(bool, enable_extended_ip_protocols, false)
 CHECK("tc", "nat4_remote_node_masquerade_enabled_test")
 int test_nat4_remote_node_masquerade_enabled(__maybe_unused struct __ctx_buff *ctx)
 {
-    struct ipv4_ct_tuple tuple = {};
+    struct snat_v4_args *args = AUX(snat_v4_args);
     fraginfo_t fraginfo = 0;
     int l4_off = 0;
     int ret;
@@ -55,32 +55,30 @@ int test_nat4_remote_node_masquerade_enabled(__maybe_unused struct __ctx_buff *c
     ipcache_v4_add_entry(IPV4_DST, 0, REMOTE_NODE_ID, 0, 0);
 
     /* Set up the tuple as if the packet is going to a remote node */
-    tuple.daddr = IPV4_DST;
-    tuple.saddr = bpf_htonl(0xDEADBEEF); /* Unlikely to be a local endpoint */
-    tuple.nexthdr = IPPROTO_TCP;
-    tuple.sport = bpf_htons(12345);
-    tuple.dport = bpf_htons(443);
-    tuple.flags = NAT_DIR_EGRESS;
+    args->tuple.daddr = IPV4_DST;
+    args->tuple.saddr = bpf_htonl(0xDEADBEEF); /* Unlikely to be a local endpoint */
+    args->tuple.nexthdr = IPPROTO_TCP;
+    args->tuple.sport = bpf_htons(12345);
+    args->tuple.dport = bpf_htons(443);
+    args->tuple.flags = NAT_DIR_EGRESS;
 
     /* Setup NAT target structure */
-    struct ipv4_nat_target target = {
-    .min_port            = NODEPORT_PORT_MIN_NAT, /* Standard min port */
-    .max_port            = NODEPORT_PORT_MAX_NAT, /* Standard max port */
-    .addr                = 0,
-    .from_local_endpoint = false,
-    .egress_gateway      = false,
-    .cluster_id          = 0,
-    .needs_ct            = false,
-    .ifindex             = 0,
-    };
+    args->target.min_port = NODEPORT_PORT_MIN_NAT; /* Standard min port */
+    args->target.max_port = NODEPORT_PORT_MAX_NAT; /* Standard max port */
+    args->target.addr = 0;
+    args->target.from_local_endpoint = false;
+    args->target.egress_gateway = false;
+    args->target.cluster_id = 0;
+    args->target.needs_ct = false;
+    args->target.ifindex = 0;
 
     /*
      * Test: With enable_remote_node_masquerade configured as true via ASSIGN_CONFIG.
      * Expect NAT_NEEDED and target.addr to be set.
      */
-    ret = snat_v4_needs_masquerade(ctx, &tuple, fraginfo, l4_off, &target);
+    ret = snat_v4_needs_masquerade(ctx, fraginfo, l4_off);
     assert(ret == NAT_NEEDED);
-    assert(target.addr == IPV4_MASQUERADE); /* Masquerade address set */
+    assert(args->target.addr == IPV4_MASQUERADE); /* Masquerade address set */
 
     test_finish();
     return 0;

--- a/bpf/tests/remote_node_masquerade_test.c
+++ b/bpf/tests/remote_node_masquerade_test.c
@@ -46,9 +46,6 @@ CHECK("tc", "nat4_remote_node_masquerade_enabled_test")
 int test_nat4_remote_node_masquerade_enabled(__maybe_unused struct __ctx_buff *ctx)
 {
     struct ipv4_ct_tuple tuple = {};
-    struct iphdr ip4 = {
-    .protocol = IPPROTO_TCP,
-    };
     fraginfo_t fraginfo = 0;
     int l4_off = 0;
     int ret;
@@ -81,7 +78,7 @@ int test_nat4_remote_node_masquerade_enabled(__maybe_unused struct __ctx_buff *c
      * Test: With enable_remote_node_masquerade configured as true via ASSIGN_CONFIG.
      * Expect NAT_NEEDED and target.addr to be set.
      */
-    ret = snat_v4_needs_masquerade(ctx, &tuple, &ip4, fraginfo, l4_off, &target);
+    ret = snat_v4_needs_masquerade(ctx, &tuple, fraginfo, l4_off, &target);
     assert(ret == NAT_NEEDED);
     assert(target.addr == IPV4_MASQUERADE); /* Masquerade address set */
 


### PR DESCRIPTION
This pull request makes `snat_v4_needs_masquerade` global to reduce the complexity of `host/tail_handle_snat_fwd_ipv4`. See commits for details.

### Complexity Impact

| Collection/Program | Min | Max |
| -- | -- | - |
| host/tail_handle_snat_fwd_ipv4 | $${\color{green}-163558}$$ (-50.21%) for v6.1/3/2 | +7250 (7.27%) for v6.6/3/0 |
| overlay/tail_handle_snat_fwd_ipv4 | +7032 (45.69%) for v5.15/1/0 | $${\color{red}+62560}$$ (301.84%) for v6.1/1/0 |
| xdp/tail_nodeport_nat_ingress_ipv4 | -1464 (-6.68%) for bpf-next/2/0 | +0 (0.00%) for bpf-next/1/0 |
| wireguard/tail_handle_snat_fwd_ipv4 | +38 (42.22%) for bpf-next/1/0 | +88 (97.78%) for v5.15/1/0 |

Complexity reduces significantly for `host/tail_handle_snat_fwd_ipv4`, on most-complex BPF program at the moment. Unfortunately, even with the last commit, complexity increases for `overlay/tail_handle_snat_fwd_ipv4` on older kernels. This change is still well worth it as we're reducing our largest complexity across all programs from 325k to 162k instructions. The increase for `overlay/tail_handle_snat_fwd_ipv4` doesn't make a big difference because that program was among the least complex before this change.