### PR TITLE
vendor: bump statedb to v0.5.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/cilium/hive v0.0.0-20260108104938-97756f6ff54c
 	github.com/cilium/lumberjack/v2 v2.4.1
 	github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1
-	github.com/cilium/statedb v0.5.6
+	github.com/cilium/statedb v0.5.8
 	github.com/cilium/stream v0.0.1
 	github.com/cilium/workerpool v1.3.0
 	github.com/cloudflare/cfssl v1.6.5

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/cilium/lumberjack/v2 v2.4.1 h1:tU92KFJmLQ4Uls5vTgok5b5RbfxpawRia7L14y
 github.com/cilium/lumberjack/v2 v2.4.1/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
 github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1 h1:SOOtIfQmW/pF1iW1I4hVUx1pvgX7Xh2E8jHv+itBXQ0=
 github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1/go.mod h1:Kwyyx+cC2H67Aj1sDuqBLvPn6TEmEJRPvULIrJ/kBRo=
-github.com/cilium/statedb v0.5.6 h1:qid1eoMlWAYi02qMHL9Ewdhtd+FCoTF6nGUrcBB36to=
-github.com/cilium/statedb v0.5.6/go.mod h1:utZbqAU8l3X/2zmbBwoYC2KuRTstuSqo+c4cw4jXsCM=
+github.com/cilium/statedb v0.5.8 h1:zcHJ+fZ57TwT71x5/vzfPi5Dvda2Z/hl2WLyTxvbxf8=
+github.com/cilium/statedb v0.5.8/go.mod h1:utZbqAU8l3X/2zmbBwoYC2KuRTstuSqo+c4cw4jXsCM=
 github.com/cilium/stream v0.0.1 h1:82zuM/WwkLiac2Jg5FrzPxZHvIBbxXTi4VY7M+EYLs0=
 github.com/cilium/stream v0.0.1/go.mod h1:/e83AwqvNKpyg4n3C41qmnmj1x2G9DwzI+jb7GkF4lI=
 github.com/cilium/workerpool v1.3.0 h1:7BhHxoqNtpqtmce6MxZdgWODze4lYHbWkEUQ+3xEu8M=

--- a/vendor/github.com/cilium/statedb/part/txn.go
+++ b/vendor/github.com/cilium/statedb/part/txn.go
@@ -182,6 +182,10 @@ func (txn *Txn[T]) Commit() *Tree[T] {
 	return t
 }
 
+// watchesReuseThreshold is the threshold at which the [txn.watches] hash
+// map is reused for next transaction.
+const watchesReuseThreshold = 64
+
 // Notify closes the watch channels of nodes that were
 // mutated as part of this transaction. Must be called before
 // Tree.Txn() is used again.
@@ -189,9 +193,14 @@ func (txn *Txn[T]) Notify() {
 	for ch := range txn.watches {
 		close(ch)
 	}
-	clear(txn.watches)
 	if !txn.dirty && len(txn.watches) > 0 {
 		panic("BUG: watch channels marked but txn not dirty")
+	}
+	// Clear or reallocate the watches hash map for the next transaction.
+	if len(txn.watches) <= watchesReuseThreshold {
+		clear(txn.watches)
+	} else {
+		txn.watches = make(map[chan struct{}]struct{})
 	}
 	if txn.dirty && txn.rootWatch != nil {
 		close(txn.rootWatch)

--- a/vendor/github.com/cilium/statedb/script.go
+++ b/vendor/github.com/cilium/statedb/script.go
@@ -38,6 +38,7 @@ func ScriptCommands(db *DB) hive.ScriptCmdsOut {
 		"db/lowerbound":  LowerBoundCmd(db),
 		"db/watch":       WatchCmd(db),
 		"db/initialized": InitializedCmd(db),
+		"db/dump":        DumpCmd(db),
 	})
 }
 
@@ -60,7 +61,7 @@ func DBCmd(db *DB) script.Cmd {
 				"",
 				"The individual tables can be manipulated and inspected with the",
 				"other commands. See 'help -v db/show' etc. for detailed help.",
-				"Here is some examples to get you statred:",
+				"Here is some examples to get you started:",
 				"",
 				"> db/show example",
 				"Name   X",
@@ -89,6 +90,46 @@ func DBCmd(db *DB) script.Cmd {
 			}
 			w.Flush()
 			return nil, nil
+		},
+	)
+}
+
+func DumpCmd(db *DB) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Dump StateDB contents as JSON",
+			Flags: func(fs *pflag.FlagSet) {
+				fs.StringP("out", "o", "", "File to write to instead of stdout")
+			},
+			Detail: []string{
+				"The contents are written to stdout, but can be written to",
+				"a file instead with the -o flag.",
+			},
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			file, err := s.Flags.GetString("out")
+			if err != nil {
+				return nil, err
+			}
+
+			return func(s *script.State) (stdout string, stderr string, err error) {
+				var (
+					buf strings.Builder
+					w   io.Writer = &buf
+				)
+
+				if file != "" {
+					f, err := os.OpenFile(s.Path(file), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+					if err != nil {
+						return "", "", fmt.Errorf("OpenFile(%s): %w", file, err)
+					}
+					defer f.Close()
+					w = f
+				}
+
+				err = db.ReadTxn().WriteJSON(w)
+				return buf.String(), "", err
+			}, nil
 		},
 	)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -297,7 +297,7 @@ github.com/cilium/lumberjack/v2
 ## explicit; go 1.23.0
 github.com/cilium/proxy/go/cilium/api
 github.com/cilium/proxy/pkg/policy/api/kafka
-# github.com/cilium/statedb v0.5.6
+# github.com/cilium/statedb v0.5.8
 ## explicit; go 1.24
 github.com/cilium/statedb
 github.com/cilium/statedb/index


### PR DESCRIPTION
v0.5.7 introduces a fix to avoid retaining a large 'watches' hash map that is passed onto future transactions, while v0.5.8 introduces the `db/dump` script command for troubleshooting purposes.
