### PR TITLE
bpf: allow L7LB TCP close packets on stale endpoint marks

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1379,7 +1379,9 @@ int cil_from_host(struct __ctx_buff *ctx)
 		int ret;
 
 		ctx->mark = 0;
-		ret = tail_call_egress_policy(ctx, lxc_id);
+		ret = l7lb_tail_call_egress_policy(ctx, lxc_id, proto);
+		if (ret == CTX_ACT_OK)
+			return ret;
 		return send_drop_notify_error(ctx, UNKNOWN_ID, ret, METRIC_EGRESS);
 	}
 #endif
@@ -1454,7 +1456,9 @@ int cil_to_netdev(struct __ctx_buff *ctx)
 		__u32 lxc_id = get_epid(ctx);
 
 		ctx->mark = 0;
-		ret = tail_call_egress_policy(ctx, (__u16)lxc_id);
+		ret = l7lb_tail_call_egress_policy(ctx, (__u16)lxc_id, proto);
+		if (ret == CTX_ACT_OK)
+			return ret;
 		goto drop_err;
 	}
 #endif

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -2650,7 +2650,9 @@ int cil_to_container(struct __ctx_buff *ctx)
 		__u16 lxc_id = get_epid(ctx);
 
 		ctx->mark = 0;
-		ret = tail_call_egress_policy(ctx, lxc_id);
+		ret = l7lb_tail_call_egress_policy(ctx, lxc_id, proto);
+		if (ret == CTX_ACT_OK)
+			return ret;
 		return send_drop_notify(ctx, lxc_id, sec_label, LXC_ID,
 					ret, METRIC_INGRESS);
 	}

--- a/bpf/lib/l4.h
+++ b/bpf/lib/l4.h
@@ -28,6 +28,11 @@ static __always_inline __u8 tcp_flags_to_u8(__be32 value)
 	return ((union tcp_flags)value).lower_bits;
 }
 
+static __always_inline int tcp_hdrlen_from_flags(union tcp_flags flags)
+{
+	return (flags.upper_bits >> 4) * 4;
+}
+
 static __always_inline int
 l4_store_port(struct __ctx_buff *ctx, int l4_off, int port_off, __be16 port)
 {

--- a/bpf/lib/local_delivery.h
+++ b/bpf/lib/local_delivery.h
@@ -3,12 +3,17 @@
 
 #pragma once
 
+#include <linux/in.h>
+#include <linux/ip.h>
+#include <linux/ipv6.h>
+
 #include "common.h"
 #include "identity.h"
 #include "dbg.h"
 #include "eps.h"
 #include "l3.h"
 #include "proxy.h"
+#include "l4.h"
 #include "token_bucket.h"
 
 DECLARE_CONFIG(bool, enable_netkit, "Use netkit devices for pods")
@@ -28,6 +33,119 @@ tail_call_egress_policy(struct __ctx_buff *ctx, __u16 endpoint_id)
 	tail_call_dynamic(ctx, &cilium_egresscall_policy, endpoint_id);
 	/* same issue as for the cilium_call_policy calls */
 	return DROP_EP_NOT_READY;
+}
+
+/* L7 LB upstream sockets can outlive the source endpoint whose ID is encoded in
+ * the mark. If that endpoint's egress policy program is already gone, allow only
+ * TCP close packets and payloadless ACKs; SYNs and ACKs with payload still fail.
+ */
+static __always_inline bool
+l7lb_tcp_allows_policy_miss(struct __ctx_buff *ctx, __be16 proto)
+{
+	/* TCP segment length: TCP header plus TCP data. */
+	int tcp_len;
+	int tcp_hdrlen;
+	union tcp_flags tcp_flags = { .value = 0 };
+	int l4_off;
+
+	switch (proto) {
+#ifdef ENABLE_IPV4
+	case bpf_htons(ETH_P_IP): {
+		struct iphdr ip4;
+		fraginfo_t fraginfo;
+		int ip4_hdrlen;
+		int ip4_len;
+
+		if (ctx_load_bytes(ctx, ETH_HLEN, &ip4, sizeof(ip4)) < 0)
+			return false;
+
+		/* Reject non-TCP and fragmented packets before calculating TCP segment length. */
+		if (ip4.protocol != IPPROTO_TCP)
+			return false;
+
+		fraginfo = ipfrag_encode_ipv4(&ip4);
+		if (ipfrag_is_fragment(fraginfo))
+			return false;
+
+		ip4_hdrlen = ipv4_hdrlen(&ip4);
+		if (ip4_hdrlen < (int)sizeof(ip4))
+			return false;
+
+		l4_off = ETH_HLEN + ip4_hdrlen;
+		ip4_len = bpf_ntohs(ip4.tot_len);
+		tcp_len = ip4_len - ip4_hdrlen;
+		break;
+	}
+#endif
+#ifdef ENABLE_IPV6
+	case bpf_htons(ETH_P_IPV6): {
+		struct ipv6hdr ip6;
+		fraginfo_t fraginfo = 0;
+		int ip6_hdrlen;
+		__u8 nexthdr;
+
+		if (ctx_load_bytes(ctx, ETH_HLEN, &ip6, sizeof(ip6)) < 0)
+			return false;
+
+		/* Reject non-TCP and fragmented packets before calculating TCP segment length. */
+		nexthdr = ip6.nexthdr;
+		ip6_hdrlen = ipv6_hdrlen_with_fraginfo(ctx, &nexthdr, &fraginfo);
+		if (ip6_hdrlen < 0)
+			return false;
+
+		if (nexthdr != IPPROTO_TCP)
+			return false;
+
+		if (ipfrag_is_fragment(fraginfo))
+			return false;
+
+		l4_off = ETH_HLEN + ip6_hdrlen;
+		tcp_len = bpf_ntohs(ip6.payload_len) -
+			  (ip6_hdrlen - (int)sizeof(ip6));
+		break;
+	}
+#endif
+	default:
+		return false;
+	}
+
+	if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
+		return false;
+
+	tcp_hdrlen = tcp_hdrlen_from_flags(tcp_flags);
+	if (tcp_hdrlen < (int)sizeof(struct tcphdr))
+		return false;
+
+	/* Reject malformed or truncated TCP segments. */
+	if (tcp_len < tcp_hdrlen)
+		return false;
+
+	if (tcp_flags.value & TCP_FLAG_SYN)
+		return false;
+	/* Allow teardown segments with or without payload since FIN may carry final data. */
+	if (tcp_flags.value & (TCP_FLAG_FIN | TCP_FLAG_RST))
+		return true;
+
+	/* Allow ACKs only when they do not carry payload. */
+	return (tcp_flags.value & TCP_FLAG_ACK) && tcp_len == tcp_hdrlen;
+}
+
+/* L7 LB delivery path enforces the original source endpoint's egress policy
+ * after Envoy selects an upstream backend. Preserve the normal policy tail-call
+ * result, but allow stale proxy upstream connections to be closed when the source
+ * policy program has already disappeared.
+ */
+static __always_inline __must_check int
+l7lb_tail_call_egress_policy(struct __ctx_buff *ctx, __u16 endpoint_id,
+			     __be16 proto)
+{
+	int ret;
+
+	ret = tail_call_egress_policy(ctx, endpoint_id);
+	if (ret == DROP_EP_NOT_READY && l7lb_tcp_allows_policy_miss(ctx, proto))
+		return CTX_ACT_OK;
+
+	return ret;
 }
 
 /* Global map to jump into policy enforcement of receiving endpoint */

--- a/bpf/tests/l7_lb_local_backend.h
+++ b/bpf/tests/l7_lb_local_backend.h
@@ -22,6 +22,7 @@
 #define BACKEND_PORT		tcp_svc_one
 
 #define CLIENT_EP_ID		127
+#define MISSING_CLIENT_EP_ID	128
 
 /* Mockup redirect, so that we track the ifindex used in ctx_redirect calls if needed. */
 static volatile __u32 redirect_ifindex;
@@ -198,6 +199,200 @@ int l7_lb_local_backend_v6_check(const struct __ctx_buff *ctx)
 
 	assert(redirect_ifindex == ctx_get_ifindex(ctx));
 #endif
+
+	test_finish();
+}
+
+PKTGEN("tc", "l7_lb_missing_policy_teardown_v4")
+int l7_lb_missing_policy_teardown_v4_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)mac_one, (__u8 *)mac_host,
+					  CLIENT_IP, BACKEND_IP,
+					  CLIENT_PORT, BACKEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->syn = 0;
+	l4->ack = 1;
+	l4->psh = 1;
+	l4->fin = 1;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "l7_lb_missing_policy_teardown_v4")
+int l7_lb_missing_policy_teardown_v4_setup(struct __ctx_buff *ctx)
+{
+	return l7lb_tail_call_egress_policy(ctx, MISSING_CLIENT_EP_ID,
+					    bpf_htons(ETH_P_IP));
+}
+
+CHECK("tc", "l7_lb_missing_policy_teardown_v4")
+int l7_lb_missing_policy_teardown_v4_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_OK);
+
+	test_finish();
+}
+
+PKTGEN("tc", "l7_lb_missing_policy_syn_v4")
+int l7_lb_missing_policy_syn_v4_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)mac_one, (__u8 *)mac_host,
+					  CLIENT_IP, BACKEND_IP,
+					  CLIENT_PORT, BACKEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "l7_lb_missing_policy_syn_v4")
+int l7_lb_missing_policy_syn_v4_setup(struct __ctx_buff *ctx)
+{
+	return l7lb_tail_call_egress_policy(ctx, MISSING_CLIENT_EP_ID,
+					    bpf_htons(ETH_P_IP));
+}
+
+CHECK("tc", "l7_lb_missing_policy_syn_v4")
+int l7_lb_missing_policy_syn_v4_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == (__u32)DROP_EP_NOT_READY);
+
+	test_finish();
+}
+
+PKTGEN("tc", "l7_lb_missing_policy_teardown_v6")
+int l7_lb_missing_policy_teardown_v6_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_tcp_packet(&builder,
+					  (__u8 *)mac_one, (__u8 *)mac_host,
+					  (__u8 *)CLIENT_IP6, (__u8 *)BACKEND_IP6,
+					  CLIENT_PORT, BACKEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->syn = 0;
+	l4->ack = 1;
+	l4->psh = 1;
+	l4->fin = 1;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "l7_lb_missing_policy_teardown_v6")
+int l7_lb_missing_policy_teardown_v6_setup(struct __ctx_buff *ctx)
+{
+	return l7lb_tail_call_egress_policy(ctx, MISSING_CLIENT_EP_ID,
+					    bpf_htons(ETH_P_IPV6));
+}
+
+CHECK("tc", "l7_lb_missing_policy_teardown_v6")
+int l7_lb_missing_policy_teardown_v6_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_OK);
+
+	test_finish();
+}
+
+PKTGEN("tc", "l7_lb_missing_policy_syn_v6")
+int l7_lb_missing_policy_syn_v6_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_tcp_packet(&builder,
+					  (__u8 *)mac_one, (__u8 *)mac_host,
+					  (__u8 *)CLIENT_IP6, (__u8 *)BACKEND_IP6,
+					  CLIENT_PORT, BACKEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "l7_lb_missing_policy_syn_v6")
+int l7_lb_missing_policy_syn_v6_setup(struct __ctx_buff *ctx)
+{
+	return l7lb_tail_call_egress_policy(ctx, MISSING_CLIENT_EP_ID,
+					    bpf_htons(ETH_P_IPV6));
+}
+
+CHECK("tc", "l7_lb_missing_policy_syn_v6")
+int l7_lb_missing_policy_syn_v6_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == (__u32)DROP_EP_NOT_READY);
 
 	test_finish();
 }


### PR DESCRIPTION
Envoy L7LB upstream sockets can outlive the source endpoint whose ID is stored in the proxy egress mark. Once that endpoint's policy program is removed, TCP close/control packets on the existing socket can miss the egress policy tail call and get dropped with DROP_EP_NOT_READY.

To allow Envoy to terminate connections to backends, allow only FIN/RST segments and payloadless ACKs if the egress policy has already been removed. SYNs and ACKs with payload will still be dropped.

Fixes: #41970