### PR TITLE
Treat skipped jobs as success for commit and workflow status reporting

### DIFF
--- a/.github/workflows/common-post-jobs.yaml
+++ b/.github/workflows/common-post-jobs.yaml
@@ -6,12 +6,12 @@ on:
       context-ref:
         required: true
         type: string
+      results:
+        required: true
+        type: string
       sha:
         required: true
         type: string
-      success:
-        required: true
-        type: boolean
 
 permissions:
   contents: read
@@ -48,29 +48,66 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           separate-directories: true
 
-  commit-status-final:
+  update-status:
     if: ${{ always() }}
-    name: Commit Status Final
+    name: Update commit and workflow results
     runs-on: ubuntu-24.04
     permissions:
       statuses: write
     steps:
+      - name: Aggregate results
+        id: aggregate-results
+        run: |
+          set -eu
+          set -o pipefail
+
+          # Convert a job result into a commit status.
+          #
+          # https://docs.github.com/en/actions/reference/workflows-and-actions/contexts?apiVersion=2026-03-10#jobs-context
+          # https://docs.github.com/en/rest/commits/statuses?apiVersion=2026-03-10#create-a-commit-status--parameters
+          declare -A result_to_status=(
+            [cancelled]="failure"
+            [failure]="failure"
+            [skipped]="success"
+            [success]="success"
+          )
+
+          # Check for unrecognized input.
+          for result in ${{ inputs.results }}; do
+            status="${result_to_status[$result]}"
+            if [ "$status" != 'success' ] && [ "$status" != 'failure' ]; then
+              # Should not occur
+              echo "status=error" >> "$GITHUB_OUTPUT"
+              echo "::error::Workflow failed because job results could not be processed"
+              echo "::error::$results"
+              exit 1
+            fi
+          done
+
+          # Check for any failures in the results and emit failure.
+          for result in ${{ inputs.results }}; do
+            status="${result_to_status[$result]}"
+            if [ "$status" = 'failure' ]; then
+              echo "status=$status" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+
+          echo "status=success" >> "$GITHUB_OUTPUT"
+
       - name: Set final commit status
+        if: ${{ always() }}
         uses: cilium/cilium/.github/actions/set-commit-status@main # main
         with:
           sha: ${{ inputs.sha }}
-          status: ${{ inputs.success && 'success' || 'failure' }}
+          status: ${{ steps.aggregate-results.outputs.status }}
 
-  fail-workflow:
-    if: ${{ inputs.success == false }}
-    name: Fail job if result is failure
-    runs-on: ubuntu-24.04
-    steps:
       - name: Fail job if result is failure
         # Besides reporting in the commit SHA if the test was or not successful,
         # we should also report it in the workflow itself. This will allow to
         # store the failure rate of the workflow on OpenSearch, instead of
         # marking it as successful.
+        if: ${{ steps.aggregate-results.outputs.status != 'success' }}
         run: |
           echo "::error::Workflow failed because one or more jobs failed"
           exit 1

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -482,18 +482,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      # The generate-matrix can be legitimately empty on older branches, so we
-      # consider that as success. On older branches the generated matrix will
-      # get fewer entries since the k8s versions will reach EOL and get removed
-      # from the matrix.
-      success: >-
-        ${{
-          needs.generate-matrix.result == 'success' &&
-        (
-          needs.installation-and-connectivity.result == 'success'
-          ||
-          (
-            needs.generate-matrix.outputs.empty == 'true' &&
-            github.ref_name != github.event.repository.default_branch
-          )
-        ) }}
+      results: ${{ needs.installation-and-connectivity.result }}

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -451,18 +451,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      # The generate-matrix can be legitimately empty on older branches, so we
-      # consider that as success. On older branches the generated matrix will
-      # get fewer entries since the k8s versions will reach EOL and get removed
-      # from the matrix.
-      success: >-
-        ${{
-          needs.generate-matrix.result == 'success' &&
-        (
-          needs.installation-and-connectivity.result == 'success'
-          ||
-          (
-            needs.generate-matrix.outputs.empty == 'true' &&
-            github.ref_name != github.event.repository.default_branch
-          )
-        ) }}
+      results: ${{ needs.installation-and-connectivity.result }}

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -780,4 +780,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.installation-and-connectivity.result == 'success' }}
+      results: ${{ needs.installation-and-connectivity.result }}

--- a/.github/workflows/conformance-delegated-ipam.yaml
+++ b/.github/workflows/conformance-delegated-ipam.yaml
@@ -387,4 +387,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.delegated-ipam-conformance-test.result == 'success' }}
+      results: ${{ needs.delegated-ipam-conformance-test.result }}

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -582,18 +582,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      # The generate-matrix can be legitimately empty on older branches, so we
-      # consider that as success. On older branches the generated matrix will
-      # get fewer entries since the k8s versions will reach EOL and get removed
-      # from the matrix.
-      success: >-
-        ${{
-          needs.generate-matrix.result == 'success' &&
-        (
-          needs.installation-and-connectivity.result == 'success'
-          ||
-          (
-            needs.generate-matrix.outputs.empty == 'true' &&
-            github.ref_name != github.event.repository.default_branch
-          )
-        ) }}
+      results: ${{ needs.installation-and-connectivity.result }}

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -414,4 +414,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.gateway-api-conformance-test.result == 'success' }}
+      results: ${{ needs.gateway-api-conformance-test.result }}

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -587,4 +587,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.setup-and-test.result == 'success' }}
+      results: ${{ needs.setup-and-test.result }}

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -597,18 +597,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      # The generate-matrix can be legitimately empty on older branches, so we
-      # consider that as success. On older branches the generated matrix will
-      # get fewer entries since the k8s versions will reach EOL and get removed
-      # from the matrix.
-      success: >-
-        ${{
-          needs.generate-matrix.result == 'success' &&
-        (
-          needs.installation-and-connectivity.result == 'success'
-          ||
-          (
-            needs.generate-matrix.outputs.empty == 'true' &&
-            github.ref_name != github.event.repository.default_branch
-          )
-        ) }}
+      results: ${{ needs.installation-and-connectivity.result }}

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -459,4 +459,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.ingress-conformance-test.result == 'success' }}
+      results: ${{ needs.ingress-conformance-test.result }}

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -477,4 +477,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.setup-and-test.result == 'success' }}
+      results: ${{ needs.setup-and-test.result }}

--- a/.github/workflows/conformance-ipsec.yaml
+++ b/.github/workflows/conformance-ipsec.yaml
@@ -141,4 +141,7 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ (needs.conformance-aks-ipsec.result == 'success' && needs.conformance-eks-ipsec.result == 'success' && needs.conformance-gke-ipsec.result == 'success') }}
+      results: |
+        ${{ needs.conformance-aks-ipsec.result }}
+        ${{ needs.conformance-eks-ipsec.result }}
+        ${{ needs.conformance-gke-ipsec.result }}

--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -280,4 +280,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.installation-and-connectivity.result == 'success' }}
+      results: ${{ needs.installation-and-connectivity.result }}

--- a/.github/workflows/conformance-kpr-aks.yaml
+++ b/.github/workflows/conformance-kpr-aks.yaml
@@ -144,4 +144,7 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ (needs.conformance-aks-kpr.result == 'success' && needs.conformance-aks-kpr-ipsec.result == 'success' && needs.conformance-aks-kpr-wireguard.result == 'success') }}
+      results: |
+        ${{ needs.conformance-aks-kpr.result }}
+        ${{ needs.conformance-aks-kpr-ipsec.result }}
+        ${{ needs.conformance-aks-kpr-wireguard.result }}

--- a/.github/workflows/conformance-kpr-eks.yaml
+++ b/.github/workflows/conformance-kpr-eks.yaml
@@ -175,4 +175,9 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ (needs.conformance-eks-kpr.result == 'success' && needs.conformance-eks-kpr-ipsec.result == 'success' && needs.conformance-eks-kpr-wireguard.result == 'success' && needs.conformance-eks-kpr-netkit.result == 'success' && needs.conformance-eks-kpr-netkit-l2.result == 'success') }}
+      results: |
+        ${{ needs.conformance-eks-kpr.result }}
+        ${{ needs.conformance-eks-kpr-ipsec.result }}
+        ${{ needs.conformance-eks-kpr-wireguard.result }}
+        ${{ needs.conformance-eks-kpr-netkit.result }}
+        ${{ needs.conformance-eks-kpr-netkit-l2.result }}

--- a/.github/workflows/conformance-kpr-gke.yaml
+++ b/.github/workflows/conformance-kpr-gke.yaml
@@ -144,4 +144,7 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ (needs.conformance-gke-kpr.result == 'success' && needs.conformance-gke-kpr-ipsec.result == 'success' && needs.conformance-gke-kpr-wireguard.result == 'success') }}
+      results: |
+        ${{ needs.conformance-gke-kpr.result }}
+        ${{ needs.conformance-gke-kpr-ipsec.result }}
+        ${{ needs.conformance-gke-kpr-wireguard.result }}

--- a/.github/workflows/conformance-kubespray.yaml
+++ b/.github/workflows/conformance-kubespray.yaml
@@ -275,4 +275,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.installation-and-connectivity.result == 'success' }}
+      results: ${{ needs.installation-and-connectivity.result }}

--- a/.github/workflows/conformance-l3-l4.yaml
+++ b/.github/workflows/conformance-l3-l4.yaml
@@ -120,4 +120,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.tests-e2e-upgrade.result == 'success' }}
+      results: ${{ needs.tests-e2e-upgrade.result }}

--- a/.github/workflows/conformance-l7.yaml
+++ b/.github/workflows/conformance-l7.yaml
@@ -121,4 +121,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.tests-e2e-upgrade.result == 'success' }}
+      results: ${{ needs.tests-e2e-upgrade.result }}

--- a/.github/workflows/conformance-mcs-api.yaml
+++ b/.github/workflows/conformance-mcs-api.yaml
@@ -358,4 +358,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.mcs-api-conformance-test.result == 'success' }}
+      results: ${{ needs.mcs-api-conformance-test.result }}

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -413,4 +413,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.multi-pool-ipam-conformance-test.result == 'success' }}
+      results: ${{ needs.multi-pool-ipam-conformance-test.result }}

--- a/.github/workflows/conformance-race.yaml
+++ b/.github/workflows/conformance-race.yaml
@@ -109,4 +109,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.conformance-ginkgo-race.result == 'success' }}
+      results: ${{ needs.conformance-ginkgo-race.result }}

--- a/.github/workflows/conformance-ztunnel-e2e.yaml
+++ b/.github/workflows/conformance-ztunnel-e2e.yaml
@@ -274,4 +274,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.setup-and-test.result == 'success' }}
+      results: ${{ needs.setup-and-test.result }}

--- a/.github/workflows/fqdn-perf.yaml
+++ b/.github/workflows/fqdn-perf.yaml
@@ -324,4 +324,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.install-and-fqdn-perf-test.result == 'success' }}
+      results: ${{ needs.install-and-fqdn-perf-test.result }}

--- a/.github/workflows/hubble-cli-integration-test.yaml
+++ b/.github/workflows/hubble-cli-integration-test.yaml
@@ -247,4 +247,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.integration-test.result == 'success' }}
+      results: ${{ needs.integration-test.result }}

--- a/.github/workflows/k8s-kind-network-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-e2e.yaml
@@ -401,4 +401,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.kubernetes-e2e.result == 'success' }}
+      results: ${{ needs.kubernetes-e2e.result }}

--- a/.github/workflows/k8s-kind-network-policies-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-policies-e2e.yaml
@@ -330,4 +330,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.kubernetes-e2e-net.result == 'success' }}
+      results: ${{ needs.kubernetes-e2e-net.result }}

--- a/.github/workflows/l7-perf.yaml
+++ b/.github/workflows/l7-perf.yaml
@@ -547,4 +547,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.install-and-perftest.result == 'success' }}
+      results: ${{ needs.install-and-perftest.result }}

--- a/.github/workflows/lint-ariane-config.yaml
+++ b/.github/workflows/lint-ariane-config.yaml
@@ -98,4 +98,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.lint-ariane-config.result == 'success' }}
+      results: ${{ needs.lint-ariane-config.result }}

--- a/.github/workflows/lint-images-base.yaml
+++ b/.github/workflows/lint-images-base.yaml
@@ -114,4 +114,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.lint.result == 'success' }}
+      results: ${{ needs.lint.result }}

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -368,4 +368,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.installation-and-perf.result == 'success' }}
+      results: ${{ needs.installation-and-perf.result }}

--- a/.github/workflows/scale-test-100-gce.yaml
+++ b/.github/workflows/scale-test-100-gce.yaml
@@ -455,4 +455,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.install-and-scaletest.result == 'success' }}
+      results: ${{ needs.install-and-scaletest.result }}

--- a/.github/workflows/scale-test-5-gce.yaml
+++ b/.github/workflows/scale-test-5-gce.yaml
@@ -401,4 +401,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.install-and-scaletest.result == 'success' }}
+      results: ${{ needs.install-and-scaletest.result }}

--- a/.github/workflows/scale-test-clustermesh.yaml
+++ b/.github/workflows/scale-test-clustermesh.yaml
@@ -425,4 +425,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.install-and-test.result == 'success' }}
+      results: ${{ needs.install-and-test.result }}

--- a/.github/workflows/scale-test-egw.yaml
+++ b/.github/workflows/scale-test-egw.yaml
@@ -644,4 +644,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.install-and-scaletest.result == 'success' }}
+      results: ${{ needs.install-and-scaletest.result }}

--- a/.github/workflows/tests-ces-migrate.yaml
+++ b/.github/workflows/tests-ces-migrate.yaml
@@ -252,4 +252,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.setup-and-test.result == 'success' }}
+      results: ${{ needs.setup-and-test.result }}

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -846,4 +846,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.upgrade-and-downgrade.result == 'success' }}
+      results: ${{ needs.upgrade-and-downgrade.result }}

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -784,4 +784,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.setup-and-test.result == 'success' }}
+      results: ${{ needs.setup-and-test.result }}

--- a/.github/workflows/tests-smoke-conformance.yaml
+++ b/.github/workflows/tests-smoke-conformance.yaml
@@ -286,4 +286,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.conformance-test.result == 'success' }}
+      results: ${{ needs.conformance-test.result }}

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -245,4 +245,4 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.conformance-test-ipv6.result != 'failure' }}
+      results: ${{ needs.conformance-test-ipv6.result }}


### PR DESCRIPTION
Pass all job results from various workflows into the common-post-jobs                                                                                                                                                           
workflow rather than just the success status. This will allow the                                                                                                                                                               
common job to consistently convert job results into commit statuses.                                                                                                                                                            
                                                                                                                                                                                                                                
Inside the common-post-jobs workflow, converge the commit and workflow                                                                                                                                                          
status update steps into a single job, and add a new step prior to those                                                                                                                                                        
which aggregates all results passed in from the outer workflows. By                                                                                                                                                             
aggregating in a single place like this, we can apply consistent logic                                                                                                                                                          
across all workflows. For instance, we can treat the presence of any                                                                                                                                                            
failure as a failure, and that all jobs must succeed in order for the                                                                                                                                                           
final result to be 'success'.                                                                                                                                                                                                   
                                                                                                                                                                                                                                
Several of the jobs already had some custom logic to detect skipped jobs                                                                                                                                                        
and treat those as a success, so this extends the same logic across all                                                                                                                                                         
workflows.