### PR TITLE
Remove docker libnetwork plugin 2/3

### DIFF
--- a/.github/workflows/build-go-caches.yaml
+++ b/.github/workflows/build-go-caches.yaml
@@ -54,9 +54,6 @@ jobs:
 
           - name: clustermesh-apiserver
             make-target: build-container-clustermesh-apiserver
-
-          - name: docker-plugin
-            make-target: -C plugins/cilium-docker
     steps:
       - name: Collect Workflow Telemetry
         uses: cilium/workflow-telemetry-action@b1a318f80a08acede58027afe1455d037379966f # v2.2.0

--- a/.github/workflows/build-images-beta.yaml
+++ b/.github/workflows/build-images-beta.yaml
@@ -59,9 +59,6 @@ jobs:
           - name: clustermesh-apiserver
             dockerfile: ./images/clustermesh-apiserver/Dockerfile
 
-          - name: docker-plugin
-            dockerfile: ./images/cilium-docker-plugin/Dockerfile
-
     steps:
       - name: Checkout main branch to access local actions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -93,10 +93,6 @@ jobs:
             dockerfile: ./images/clustermesh-apiserver/Dockerfile
             platforms: linux/amd64,linux/arm64
 
-          - name: docker-plugin
-            dockerfile: ./images/cilium-docker-plugin/Dockerfile
-            platforms: linux/amd64,linux/arm64
-
     steps:
       - name: Checkout base or default branch (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -45,9 +45,6 @@ jobs:
           - name: clustermesh-apiserver
             dockerfile: ./images/clustermesh-apiserver/Dockerfile
 
-          - name: docker-plugin
-            dockerfile: ./images/cilium-docker-plugin/Dockerfile
-
     steps:
       - name: Checkout main branch to access local actions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
The deprecated cilium-docker libnetwork plugin image is no longer pulled by any test or workflow. Drop the docker-plugin entries from the image build matrices and the go cache build so that nothing builds the image anymore, allowing the plugin code and its Dockerfile to be removed in a follow-up.

The build-images-ci-v1.* workflows are intentionally left untouched: they build images from the stable branches, which still ship the docker-plugin.

Related with https://github.com/cilium/cilium/pull/46489
