### PR TITLE
hubble: fix l7 monitor filtering for AccessLog events

### DIFF
--- a/pkg/hubble/monitor/filter.go
+++ b/pkg/hubble/monitor/filter.go
@@ -81,8 +81,6 @@ func (m *monitorFilter) OnMonitorEvent(ctx context.Context, event *observerTypes
 			return !m.capture, nil
 		case monitorAPI.MessageTypeTrace:
 			return !m.trace, nil
-		case monitorAPI.MessageTypeAccessLog: // MessageTypeAccessLog maps to MessageTypeNameL7
-			return !m.l7, nil
 		case monitorAPI.MessageTypePolicyVerdict:
 			return !m.policyVerdict, nil
 		case monitorAPI.MessageTypeTraceSock:
@@ -90,7 +88,15 @@ func (m *monitorFilter) OnMonitorEvent(ctx context.Context, event *observerTypes
 		default:
 			return true, errors.ErrUnknownEventType
 		}
+
 	case *observerTypes.AgentEvent:
+		// L7 flows (HTTP, DNS, Kafka, etc.) are emitted as AgentEvents
+		// with Type = MessageTypeAccessLog. They should be controlled
+		// by the l7 monitor filter rather than the generic agent filter.
+		if payload.Type == monitorAPI.MessageTypeAccessLog {
+			return !m.l7, nil
+		}
+
 		return !m.agent, nil
 	case nil:
 		return true, errors.ErrEmptyData

--- a/pkg/hubble/monitor/filter_test.go
+++ b/pkg/hubble/monitor/filter_test.go
@@ -154,6 +154,15 @@ func Test_OnMonitorEvent(t *testing.T) {
 					stop:        false,
 					expectedErr: nil,
 				},
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.AgentEvent{
+							Type: monitorAPI.MessageTypeAccessLog,
+						},
+					},
+					stop:        true,
+					expectedErr: nil,
+				},
 			},
 		},
 		{
@@ -162,8 +171,8 @@ func Test_OnMonitorEvent(t *testing.T) {
 			events: []testEvent{
 				{
 					event: &observerTypes.MonitorEvent{
-						Payload: &observerTypes.PerfEvent{
-							Data: []byte{monitorAPI.MessageTypeAccessLog},
+						Payload: &observerTypes.AgentEvent{
+							Type: monitorAPI.MessageTypeAccessLog,
 						},
 					},
 					stop:        false,


### PR DESCRIPTION
## Summary

MessageTypeAccessLog events are emitted as AgentEvents by the
Hubble parser, but monitor filtering handled them in the PerfEvent
path.

This caused L7 monitor filtering to be applied incorrectly.

### Changes

- Move AccessLog filtering to the AgentEvent path.
- Update monitor filter test to use AgentEvent for AccessLog events.

Fixes #46214

### Testing

Updated the existing unit test in `pkg/hubble/monitor/filter_test.go`
to reflect that `MessageTypeAccessLog` is emitted as an `AgentEvent`.

Attempted to run:

go test ./pkg/hubble/monitor -v

but local execution on macOS is blocked by Linux-specific datapath dependencies.