### PR TITLE
endpoint: make named-ports identity labels k8s-safe

### DIFF
--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -577,22 +577,38 @@ func TestInitialNamedPortsIdentityLabel(t *testing.T) {
 			"app": "backend",
 		}, labels.LabelSourceK8s)
 	}
-	assertNamedPortsLabel := func(t *testing.T, e *Endpoint, value string) {
-		label, ok := e.labels.IdentityLabels()[ciliumio.NamedPortsIdentityLabelName]
-		require.True(t, ok)
-		require.Equal(t, value, label.Value)
-		require.Equal(t, labels.LabelSourceGenerated, label.Source)
+	assertNamedPortsLabels := func(t *testing.T, e *Endpoint, values ...string) {
+		t.Helper()
+
+		expected := map[string]string{}
+		identityLabels := e.labels.IdentityLabels()
+		for i, value := range values {
+			key := ciliumio.NamedPortsIdentityLabelNameForIndex(i)
+			expected[key] = value
+
+			label, ok := identityLabels[key]
+			require.True(t, ok)
+			require.Equal(t, value, label.Value)
+			require.Equal(t, labels.LabelSourceGenerated, label.Source)
+		}
+		for key := range identityLabels {
+			if ciliumio.IsNamedPortsIdentityLabelName(key) {
+				require.Contains(t, expected, key)
+			}
+		}
 	}
-	assertNoNamedPortsLabel := func(t *testing.T, e *Endpoint) {
-		_, ok := e.labels.IdentityLabels()[ciliumio.NamedPortsIdentityLabelName]
-		require.False(t, ok)
+	assertNoNamedPortsLabels := func(t *testing.T, lbls labels.Labels) {
+		t.Helper()
+
+		for key := range lbls {
+			require.False(t, ciliumio.IsNamedPortsIdentityLabelName(key), key)
+		}
 	}
 	resolveMetadata := func(namedPorts ciliumTypes.NamedPortMap) MetadataResolverCB {
 		return func(ns, podName, uid string, newPod bool) (*corev1.Pod, *K8sMetadata, error) {
 			lbls := incoming()
 			if newPod {
-				lbl, haveLbl := k8s.NamedPortsIdentityLabel(namedPorts)
-				if haveLbl {
+				for _, lbl := range k8s.NamedPortsIdentityLabels(namedPorts) {
 					lbls[lbl.Key] = lbl
 				}
 			}
@@ -620,7 +636,24 @@ func TestInitialNamedPortsIdentityLabel(t *testing.T) {
 
 		resolvePodMetadata(t, e, false, namedPorts)
 
-		assertNamedPortsLabel(t, e, "http:TCP:80,https:TCP:443")
+		assertNamedPortsLabels(t, e, "http.TCP.80_https.TCP.443")
+	})
+
+	t.Run("new endpoint gains split generated labels from metadata", func(t *testing.T) {
+		e := newEndpoint(t, nil, nil)
+
+		resolvePodMetadata(t, e, false, ciliumTypes.NamedPortMap{
+			"port-a": {Port: 8000, Proto: u8proto.TCP},
+			"port-b": {Port: 8001, Proto: u8proto.TCP},
+			"port-c": {Port: 8002, Proto: u8proto.TCP},
+			"port-d": {Port: 8003, Proto: u8proto.TCP},
+			"port-e": {Port: 8004, Proto: u8proto.TCP},
+		})
+
+		assertNamedPortsLabels(t, e,
+			"port-a.TCP.8000_port-b.TCP.8001_port-c.TCP.8002_port-d.TCP.8003",
+			"port-e.TCP.8004",
+		)
 	})
 
 	t.Run("new endpoint without named ports does not gain generated label", func(t *testing.T) {
@@ -628,7 +661,7 @@ func TestInitialNamedPortsIdentityLabel(t *testing.T) {
 
 		resolvePodMetadata(t, e, false, nil)
 
-		assertNoNamedPortsLabel(t, e)
+		assertNoNamedPortsLabels(t, e.labels.IdentityLabels())
 	})
 
 	t.Run("restored endpoint does not gain generated label from metadata", func(t *testing.T) {
@@ -636,20 +669,19 @@ func TestInitialNamedPortsIdentityLabel(t *testing.T) {
 
 		resolvePodMetadata(t, e, true, namedPorts)
 
-		assertNoNamedPortsLabel(t, e)
+		assertNoNamedPortsLabels(t, e.labels.IdentityLabels())
 	})
 
 	t.Run("init identity removes disabled generated label", func(t *testing.T) {
 		e := newEndpoint(t, identity.NewIdentity(identity.ReservedIdentityInit, nil), incoming())
-		e.labels.Disabled[ciliumio.NamedPortsIdentityLabelName] = labels.NewLabel(ciliumio.NamedPortsIdentityLabelName, "http:TCP:80", labels.LabelSourceGenerated)
+		e.labels.Disabled[ciliumio.NamedPortsIdentityLabelName] = labels.NewLabel(ciliumio.NamedPortsIdentityLabelName, "http.TCP.80", labels.LabelSourceGenerated)
+		e.labels.Disabled[ciliumio.NamedPortsIdentityLabelNameForIndex(1)] = labels.NewLabel(ciliumio.NamedPortsIdentityLabelNameForIndex(1), "https.TCP.443", labels.LabelSourceGenerated)
 
 		e.SetK8sMetadata(nil)
 		e.UpdateLabels(t.Context(), labels.LabelSourceAny, incoming(), nil, false)
 
-		_, ok := e.labels.Disabled[ciliumio.NamedPortsIdentityLabelName]
-		require.False(t, ok)
-		_, ok = e.labels.IdentityLabels()[ciliumio.NamedPortsIdentityLabelName]
-		require.False(t, ok)
+		assertNoNamedPortsLabels(t, e.labels.Disabled)
+		assertNoNamedPortsLabels(t, e.labels.IdentityLabels())
 	})
 
 	t.Run("real identity does not gain generated label", func(t *testing.T) {
@@ -657,37 +689,43 @@ func TestInitialNamedPortsIdentityLabel(t *testing.T) {
 
 		e.UpdateLabels(t.Context(), labels.LabelSourceK8s, incoming(), nil, false)
 
-		assertNoNamedPortsLabel(t, e)
+		assertNoNamedPortsLabels(t, e.labels.IdentityLabels())
 	})
 
 	t.Run("real identity preserves generated label on k8s refresh", func(t *testing.T) {
 		current := labels.Labels{
 			"app":                                labels.NewLabel("app", "backend", labels.LabelSourceK8s),
-			ciliumio.NamedPortsIdentityLabelName: labels.NewLabel(ciliumio.NamedPortsIdentityLabelName, "http:TCP:80", labels.LabelSourceGenerated),
+			ciliumio.NamedPortsIdentityLabelName: labels.NewLabel(ciliumio.NamedPortsIdentityLabelName, "http.TCP.80", labels.LabelSourceGenerated),
+			ciliumio.NamedPortsIdentityLabelNameForIndex(1): labels.NewLabel(
+				ciliumio.NamedPortsIdentityLabelNameForIndex(1), "https.TCP.443", labels.LabelSourceGenerated),
 		}
 		e := newEndpoint(t, identity.NewIdentity(12345, nil), current)
 
 		require.False(t, e.UpdateLabels(t.Context(), labels.LabelSourceK8s, incoming(), nil, false))
 
-		assertNamedPortsLabel(t, e, "http:TCP:80")
+		assertNamedPortsLabels(t, e, "http.TCP.80", "https.TCP.443")
 	})
 
 	t.Run("real identity preserves generated label on source any label refresh", func(t *testing.T) {
 		current := labels.Labels{
 			"app":                                labels.NewLabel("app", "backend", labels.LabelSourceK8s),
-			ciliumio.NamedPortsIdentityLabelName: labels.NewLabel(ciliumio.NamedPortsIdentityLabelName, "http:TCP:80", labels.LabelSourceGenerated),
+			ciliumio.NamedPortsIdentityLabelName: labels.NewLabel(ciliumio.NamedPortsIdentityLabelName, "http.TCP.80", labels.LabelSourceGenerated),
+			ciliumio.NamedPortsIdentityLabelNameForIndex(1): labels.NewLabel(
+				ciliumio.NamedPortsIdentityLabelNameForIndex(1), "https.TCP.443", labels.LabelSourceGenerated),
 		}
 		e := newEndpoint(t, identity.NewIdentity(12345, nil), current)
 
 		e.UpdateLabels(t.Context(), labels.LabelSourceAny, incoming(), nil, false)
 
-		assertNamedPortsLabel(t, e, "http:TCP:80")
+		assertNamedPortsLabels(t, e, "http.TCP.80", "https.TCP.443")
 	})
 
 	t.Run("real identity preserves generated label on source any metadata refresh", func(t *testing.T) {
 		current := labels.Labels{
 			"app":                                labels.NewLabel("app", "backend", labels.LabelSourceK8s),
-			ciliumio.NamedPortsIdentityLabelName: labels.NewLabel(ciliumio.NamedPortsIdentityLabelName, "http:TCP:80", labels.LabelSourceGenerated),
+			ciliumio.NamedPortsIdentityLabelName: labels.NewLabel(ciliumio.NamedPortsIdentityLabelName, "http.TCP.80", labels.LabelSourceGenerated),
+			ciliumio.NamedPortsIdentityLabelNameForIndex(1): labels.NewLabel(
+				ciliumio.NamedPortsIdentityLabelNameForIndex(1), "https.TCP.443", labels.LabelSourceGenerated),
 		}
 		e := newEndpoint(t, identity.NewIdentity(12345, nil), current)
 
@@ -696,25 +734,26 @@ func TestInitialNamedPortsIdentityLabel(t *testing.T) {
 		})
 		e.UpdateLabels(t.Context(), labels.LabelSourceAny, incoming(), nil, false)
 
-		assertNamedPortsLabel(t, e, "http:TCP:80")
+		assertNamedPortsLabels(t, e, "http.TCP.80", "https.TCP.443")
 	})
 
 	t.Run("real identity does not preserve disabled generated label", func(t *testing.T) {
 		e := newEndpoint(t, identity.NewIdentity(12345, nil), incoming())
-		e.labels.Disabled[ciliumio.NamedPortsIdentityLabelName] = labels.NewLabel(ciliumio.NamedPortsIdentityLabelName, "http:TCP:80", labels.LabelSourceGenerated)
+		e.labels.Disabled[ciliumio.NamedPortsIdentityLabelName] = labels.NewLabel(ciliumio.NamedPortsIdentityLabelName, "http.TCP.80", labels.LabelSourceGenerated)
+		e.labels.Disabled[ciliumio.NamedPortsIdentityLabelNameForIndex(1)] = labels.NewLabel(ciliumio.NamedPortsIdentityLabelNameForIndex(1), "https.TCP.443", labels.LabelSourceGenerated)
 
 		e.UpdateLabels(t.Context(), labels.LabelSourceAny, incoming(), nil, false)
 
-		_, ok := e.labels.Disabled[ciliumio.NamedPortsIdentityLabelName]
-		require.False(t, ok)
-		_, ok = e.labels.IdentityLabels()[ciliumio.NamedPortsIdentityLabelName]
-		require.False(t, ok)
+		assertNoNamedPortsLabels(t, e.labels.Disabled)
+		assertNoNamedPortsLabels(t, e.labels.IdentityLabels())
 	})
 
 	t.Run("real identity ignores changed named ports", func(t *testing.T) {
 		current := labels.Labels{
 			"app":                                labels.NewLabel("app", "backend", labels.LabelSourceK8s),
-			ciliumio.NamedPortsIdentityLabelName: labels.NewLabel(ciliumio.NamedPortsIdentityLabelName, "http:TCP:80", labels.LabelSourceGenerated),
+			ciliumio.NamedPortsIdentityLabelName: labels.NewLabel(ciliumio.NamedPortsIdentityLabelName, "http.TCP.80", labels.LabelSourceGenerated),
+			ciliumio.NamedPortsIdentityLabelNameForIndex(1): labels.NewLabel(
+				ciliumio.NamedPortsIdentityLabelNameForIndex(1), "https.TCP.443", labels.LabelSourceGenerated),
 		}
 		e := newEndpoint(t, identity.NewIdentity(12345, nil), current)
 
@@ -723,7 +762,7 @@ func TestInitialNamedPortsIdentityLabel(t *testing.T) {
 		})
 		e.UpdateLabels(t.Context(), labels.LabelSourceK8s, incoming(), nil, false)
 
-		assertNamedPortsLabel(t, e, "http:TCP:80")
+		assertNamedPortsLabels(t, e, "http.TCP.80", "https.TCP.443")
 	})
 }
 

--- a/pkg/endpoint/metadata/k8s_metadatafetcher.go
+++ b/pkg/endpoint/metadata/k8s_metadatafetcher.go
@@ -61,8 +61,7 @@ func (cemf *cachedEndpointMetadataFetcher) FetchK8sMetadataForEndpoint(nsName, p
 
 	// set the named ports identity label on new (non-restored) endpoints
 	if err == nil && newPod {
-		lbl, haveLbl := k8s.NamedPortsIdentityLabel(metadata.NamedPorts)
-		if haveLbl {
+		for _, lbl := range k8s.NamedPortsIdentityLabels(metadata.NamedPorts) {
 			metadata.IdentityLabels[lbl.Key] = lbl
 		}
 	}

--- a/pkg/k8s/apis/cilium.io/named_ports.go
+++ b/pkg/k8s/apis/cilium.io/named_ports.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumio
+
+import (
+	"strconv"
+	"strings"
+)
+
+// NamedPortsIdentityLabelNameForIndex returns the generated named-ports label
+// key for the chunk at index. Index zero uses the base label key.
+func NamedPortsIdentityLabelNameForIndex(index int) string {
+	if index == 0 {
+		return NamedPortsIdentityLabelName
+	}
+	return NamedPortsIdentityLabelName + "-" + strconv.Itoa(index)
+}
+
+// IsNamedPortsIdentityLabelName returns true if key is the base named-ports
+// identity label key or one of its numbered continuation keys.
+func IsNamedPortsIdentityLabelName(key string) bool {
+	if key == NamedPortsIdentityLabelName {
+		return true
+	}
+	suffix, ok := strings.CutPrefix(key, NamedPortsIdentityLabelName+"-")
+	if !ok || suffix == "" {
+		return false
+	}
+	for _, r := range suffix {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/api/validate/content"
+
 	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	k8sUtils "github.com/cilium/cilium/pkg/k8s/utils"
@@ -58,22 +60,52 @@ func GetPodMetadata(logger *slog.Logger, k8sNs nameLabelsGetter, pod *slim_corev
 	return namedPorts, labels
 }
 
-// NamedPortsIdentityLabel returns the generated identity label for named ports.
-func NamedPortsIdentityLabel(namedPorts ciliumTypes.NamedPortMap) (ciliumLabels.Label, bool) {
+// NamedPortsIdentityLabels returns the generated identity labels for named ports.
+// Use delimiters allowed in k8s label values:
+// '.' - separate fields
+// '_' - separate multiple values
+//
+// Note that a single named port always fits into a single label, as the named port name is limited
+// to 15 characters (IANA service name limitation), and a single label can be upto 63 characters
+// long.
+func NamedPortsIdentityLabels(namedPorts ciliumTypes.NamedPortMap) ciliumLabels.LabelArray {
 	if len(namedPorts) == 0 {
-		return ciliumLabels.Label{}, false
+		return nil
 	}
 
+	var labels ciliumLabels.LabelArray
 	var value strings.Builder
-	for i, name := range slices.Sorted(maps.Keys(namedPorts)) {
-		if i > 0 {
-			value.WriteByte(',')
+
+	appendLabel := func() {
+		labels = append(labels, ciliumLabels.NewLabel(
+			ciliumio.NamedPortsIdentityLabelNameForIndex(len(labels)),
+			value.String(),
+			ciliumLabels.LabelSourceGenerated,
+		))
+		value.Reset()
+	}
+
+	for _, name := range slices.Sorted(maps.Keys(namedPorts)) {
+		port := namedPorts[name]
+		portProto := port.Proto.String()
+		portNum := strconv.Itoa(int(port.Port))
+
+		partLen := len(name) + 1 + len(portProto) + 1 + len(portNum)
+		if value.Len() > 0 && value.Len()+1+partLen > content.LabelValueMaxLength {
+			appendLabel()
+		}
+
+		if value.Len() > 0 {
+			value.WriteByte('_')
 		}
 		value.WriteString(name)
-		value.WriteByte(':')
-		value.WriteString(namedPorts[name].Proto.String())
-		value.WriteByte(':')
-		value.WriteString(strconv.Itoa(int(namedPorts[name].Port)))
+		value.WriteByte('.')
+		value.WriteString(portProto)
+		value.WriteByte('.')
+		value.WriteString(portNum)
 	}
-	return ciliumLabels.NewLabel(ciliumio.NamedPortsIdentityLabelName, value.String(), ciliumLabels.LabelSourceGenerated), true
+	if value.Len() > 0 {
+		appendLabel()
+	}
+	return labels
 }

--- a/pkg/k8s/labels_test.go
+++ b/pkg/k8s/labels_test.go
@@ -75,6 +75,7 @@ func TestGetPodMetadata(t *testing.T) {
 	t.Run("named ports metadata", func(t *testing.T) {
 		pod := pod.DeepCopy()
 		pod.Labels[ciliumio.NamedPortsIdentityLabelName] = "spoofed"
+		pod.Labels[ciliumio.NamedPortsIdentityLabelNameForIndex(1)] = "spoofed"
 		pod.Spec.Containers = []slim_corev1.Container{{
 			Ports: []slim_corev1.ContainerPort{
 				{Name: "https", ContainerPort: 443, Protocol: slim_corev1.ProtocolTCP},
@@ -94,17 +95,37 @@ func TestGetPodMetadata(t *testing.T) {
 	})
 }
 
-func TestNamedPortsIdentityLabel(t *testing.T) {
-	label, ok := NamedPortsIdentityLabel(ciliumTypes.NamedPortMap{
+func TestNamedPortsIdentityLabels(t *testing.T) {
+	labelArray := NamedPortsIdentityLabels(ciliumTypes.NamedPortMap{
 		"https": {Port: 443, Proto: u8proto.TCP},
 		"dns":   {Port: 53, Proto: u8proto.UDP},
 		"http":  {Port: 80, Proto: u8proto.TCP},
 	})
-	require.True(t, ok)
-	require.Equal(t, ciliumio.NamedPortsIdentityLabelName, label.Key)
-	require.Equal(t, "dns:UDP:53,http:TCP:80,https:TCP:443", label.Value)
-	require.Equal(t, ciliumLabels.LabelSourceGenerated, label.Source)
+	require.Equal(t, ciliumLabels.LabelArray{ciliumLabels.NewLabel(
+		ciliumio.NamedPortsIdentityLabelName,
+		"dns.UDP.53_http.TCP.80_https.TCP.443",
+		ciliumLabels.LabelSourceGenerated,
+	)}, labelArray)
 
-	_, ok = NamedPortsIdentityLabel(nil)
-	require.False(t, ok)
+	labelArray = NamedPortsIdentityLabels(ciliumTypes.NamedPortMap{
+		"port-a": {Port: 8000, Proto: u8proto.TCP},
+		"port-b": {Port: 8001, Proto: u8proto.TCP},
+		"port-c": {Port: 8002, Proto: u8proto.TCP},
+		"port-d": {Port: 8003, Proto: u8proto.TCP},
+		"port-e": {Port: 8004, Proto: u8proto.TCP},
+	})
+	require.Equal(t, ciliumLabels.LabelArray{
+		ciliumLabels.NewLabel(
+			ciliumio.NamedPortsIdentityLabelName,
+			"port-a.TCP.8000_port-b.TCP.8001_port-c.TCP.8002_port-d.TCP.8003",
+			ciliumLabels.LabelSourceGenerated,
+		),
+		ciliumLabels.NewLabel(
+			ciliumio.NamedPortsIdentityLabelNameForIndex(1),
+			"port-e.TCP.8004",
+			ciliumLabels.LabelSourceGenerated,
+		),
+	}, labelArray)
+
+	require.Empty(t, NamedPortsIdentityLabels(nil))
 }

--- a/pkg/k8s/utils/utils_test.go
+++ b/pkg/k8s/utils/utils_test.go
@@ -467,12 +467,13 @@ func TestSanitizePodLabels(t *testing.T) {
 	namespaceLabelKey := "wow-very-key"
 	namespaceMetaLabelKey := joinPath(k8sconst.PodNamespaceMetaLabels, namespaceLabelKey)
 	testedLabels := map[string]string{
-		k8sconst.PodNamespaceLabel:           "fake-namespace",
-		k8sconst.PolicyLabelServiceAccount:   "fake-sa",
-		k8sconst.PolicyLabelCluster:          "fake-cluster-name",
-		k8sconst.NamedPortsIdentityLabelName: "fake-named-ports",
-		namespaceMetaLabelKey:                "fake-namespace-label-val",
-		k8sconst.PodNameLabel:                "fake-pod-name",
+		k8sconst.PodNamespaceLabel:                      "fake-namespace",
+		k8sconst.PolicyLabelServiceAccount:              "fake-sa",
+		k8sconst.PolicyLabelCluster:                     "fake-cluster-name",
+		k8sconst.NamedPortsIdentityLabelName:            "fake-named-ports",
+		k8sconst.NamedPortsIdentityLabelNameForIndex(1): "fake-named-ports-1",
+		namespaceMetaLabelKey:                           "fake-namespace-label-val",
+		k8sconst.PodNameLabel:                           "fake-pod-name",
 	}
 	trueNamespace := "true-namespace"
 	trueSA := "true-sa"
@@ -551,6 +552,7 @@ func TestStripPodLabels(t *testing.T) {
 				"io.cilium.k8s.policy.namespace":             "kube-system",
 				"io.cilium.k8s.something":                    "cilium internal",
 				"io.cilium.k8s.named-ports":                  "http=80",
+				"io.cilium.k8s.named-ports-1":                "https=443",
 				"io.cilium.k8s.namespace.labels.foo.bar/baz": "foobar",
 			},
 			want: map[string]string{


### PR DESCRIPTION
Generated named-ports identity labels encode pod named-port metadata into Kubernetes label values. The previous encoding used separator characters that are not valid in Kubernetes label values, and pods with many named ports could also exceed the 63-character label value limit.

Encode named ports using only Kubernetes label-value-safe separators, and split long encodings across multiple generated identity labels. Keep the first label at the existing key and use numbered continuation keys for overflow chunks:

`io.cilium.k8s.named-ports`
`io.cilium.k8s.named-ports-1`
`io.cilium.k8s.named-ports-2`

Rename the helper to `NamedPortsIdentityLabels()` and return a `LabelArray`. Update callers to add all generated labels, and update special-case checks to recognize the full named-ports label family.

This keeps generated named-port identity labels deterministic while making them valid Kubernetes label values for pods with both simple and large named-port sets.

Prepared with Codex (AIL:3).

Fixes: #45760
