### PR TITLE
cilium-dbg: use NodeKey.String() in bpf nodeid list

### DIFF
--- a/cilium-dbg/cmd/bpf_nodeid_list.go
+++ b/cilium-dbg/cmd/bpf_nodeid_list.go
@@ -7,13 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"net"
 	"os"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 
-	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/maps/nodemap"
@@ -38,13 +36,9 @@ var bpfNodeIDListCmd = &cobra.Command{
 
 		bpfNodeValueList := []nodeID{}
 		parse := func(key *nodemap.NodeKey, val *nodemap.NodeValueV2) {
-			address := key.IP.String()
-			if key.Family == bpf.EndpointKeyIPv4 {
-				address = net.IP(key.IP[:net.IPv4len]).String()
-			}
 			bpfNodeValueList = append(bpfNodeValueList, nodeID{
 				ID:      val.NodeID,
-				Address: address,
+				Address: key.String(),
 				SPI:     val.SPI,
 			})
 		}


### PR DESCRIPTION
## description
here i replace duplicated IPv4 address formatting in cilium-dbg bpf nodeid list with nodemap.NodeKey.String(), which already uses netip for both IPv4 and IPv6 ,,

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

No new tests: behavior unchanged; `go test ./cilium-dbg/cmd/...` passes.

Related: #24246

```release-note
cilium-dbg: remove redundant net.IP formatting in bpf nodeid list
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
