### PR TITLE
tools/dev-doctor: remove stale FIXME about gomega check

### DIFF
--- a/tools/dev-doctor/rootcmd.go
+++ b/tools/dev-doctor/rootcmd.go
@@ -132,7 +132,6 @@ func rootCmdRun(cmd *cobra.Command, args []string) {
 			maxVersion:    &semver.Version{Major: 2, Minor: 0, Patch: 0},
 			hint:          `Run "go install github.com/onsi/ginkgo/ginkgo@v1.16.5".`,
 		},
-		// FIXME add gomega check?
 		&binaryCheck{
 			name:          "golangci-lint",
 			ifNotFound:    checkWarning,


### PR DESCRIPTION
## Summary

Removes a stale FIXME comment that asked whether to add a gomega check to dev-doctor. gomega is a vendored test assertion library, not a standalone CLI tool — unlike ginkgo or golangci-lint, there's nothing for a contributor to install separately, so a check would never fail.

## Related Issues

Fixes: #46522

```release-note
Remove stale FIXME comment in dev-doctor about checking for gomega installation.
```