### PR TITLE
.github/workflows: fix ci-kpr-eks failures on workflow_dispatch events

### DIFF
--- a/.github/workflows/conformance-kpr-eks.yaml
+++ b/.github/workflows/conformance-kpr-eks.yaml
@@ -175,4 +175,22 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ (needs.conformance-eks-kpr.result == 'success' && needs.conformance-eks-kpr-ipsec.result == 'success' && needs.conformance-eks-kpr-wireguard.result == 'success' && needs.conformance-eks-kpr-netkit.result == 'success' && needs.conformance-eks-kpr-netkit-l2.result == 'success') }}
+      # The netkit jobs only run on scheduled runs, so only require them to
+      # be successful on schedule events.
+      success: >-
+        ${{
+          (
+            github.event_name == 'workflow_dispatch' &&
+            needs.conformance-eks-kpr.result == 'success' &&
+            needs.conformance-eks-kpr-ipsec.result == 'success' &&
+            needs.conformance-eks-kpr-wireguard.result == 'success'
+          )
+          ||
+          (
+            github.event_name == 'schedule' &&
+            needs.conformance-eks-kpr.result == 'success' &&
+            needs.conformance-eks-kpr-ipsec.result == 'success' &&
+            needs.conformance-eks-kpr-wireguard.result == 'success' &&
+            needs.conformance-eks-kpr-netkit.result == 'success' &&
+            needs.conformance-eks-kpr-netkit-l2.result == 'success'
+          ) }}


### PR DESCRIPTION
The netkit jobs only run on schedule events, but the success input of the merge-upload-and-status job required them to be successful on every run. On workflow_dispatch events the netkit jobs are skipped, so success always evaluated to false and the workflow failed even when all executed tests passed.

Only require the netkit jobs to be successful on schedule events, following the same pattern used in tests-with-extra-args.yaml.

Fixes: 7a3159339f9d ("gh: introduce netkit testing in kpr-eks workflow")

cc @ajmmm 