### PR TITLE
 avoid identity lookups for server-independent DNS rules

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -281,26 +281,27 @@ func (p *DNSProxy) GetRules(endpointID uint16) (restore.DNSRules, error) {
 	p.RUnlock()
 
 	restored := make(restore.DNSRules)
-	regexToSelectors := make(map[restore.PortProto]map[*regexp.Regexp]set.Set[policy.CachedSelector])
+	regexToSelectors := make(map[restore.PortProto]map[*regexp.Regexp]*set.Set[policy.CachedSelector])
 	for pp, selRegexes := range portProtoToSelRegex {
 		var ipRules restore.IPRules
 
-		regexToSelectors[pp] = make(map[*regexp.Regexp]set.Set[policy.CachedSelector])
+		regexToSelectors[pp] = make(map[*regexp.Regexp]*set.Set[policy.CachedSelector])
 
 		for _, selRegex := range selRegexes {
 			if regexToSelectors[pp][selRegex.re] == nil {
-				regexToSelectors[pp][selRegex.re] = set.NewSet[policy.CachedSelector]()
+				s := set.NewSet[policy.CachedSelector]()
+				regexToSelectors[pp][selRegex.re] = &s
 			}
 			regexToSelectors[pp][selRegex.re].Insert(selRegex.cs)
 		}
 
-		var firstSelectorSet set.Set[policy.CachedSelector]
+		var firstSelectorSet *set.Set[policy.CachedSelector]
 		allequal := true
 
 		for _, selectorSet := range regexToSelectors[pp] {
 			if firstSelectorSet == nil {
 				firstSelectorSet = selectorSet
-			} else if !selectorSet.Equal(firstSelectorSet) {
+			} else if !selectorSet.Equal(*firstSelectorSet) {
 				allequal = false
 				break
 			}

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/fqdn/lookup"
@@ -36,7 +37,6 @@ import (
 	"go4.org/netipx"
 	"golang.org/x/sync/semaphore"
 	"golang.org/x/sys/unix"
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (
@@ -281,20 +281,20 @@ func (p *DNSProxy) GetRules(endpointID uint16) (restore.DNSRules, error) {
 	p.RUnlock()
 
 	restored := make(restore.DNSRules)
-	regexToSelectors := make(map[restore.PortProto]map[*regexp.Regexp]sets.Set[policy.CachedSelector])
+	regexToSelectors := make(map[restore.PortProto]map[*regexp.Regexp]set.Set[policy.CachedSelector])
 	for pp, selRegexes := range portProtoToSelRegex {
 		var ipRules restore.IPRules
 
-		regexToSelectors[pp] = make(map[*regexp.Regexp]sets.Set[policy.CachedSelector])
+		regexToSelectors[pp] = make(map[*regexp.Regexp]set.Set[policy.CachedSelector])
 
 		for _, selRegex := range selRegexes {
 			if regexToSelectors[pp][selRegex.re] == nil {
-				regexToSelectors[pp][selRegex.re] = sets.New[policy.CachedSelector]()
+				regexToSelectors[pp][selRegex.re] = set.NewSet[policy.CachedSelector]()
 			}
 			regexToSelectors[pp][selRegex.re].Insert(selRegex.cs)
 		}
 
-		var firstSelectorSet sets.Set[policy.CachedSelector]
+		var firstSelectorSet set.Set[policy.CachedSelector]
 		allequal := true
 
 		for _, selectorSet := range regexToSelectors[pp] {

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -284,82 +284,59 @@ func (p *DNSProxy) GetRules(endpointID uint16) (restore.DNSRules, error) {
 	for pp, regexMap := range regexToSelectors {
 		var ipRules restore.IPRules
 
-		regexToSelectors[pp] = make(map[*regexp.Regexp]*set.Set[policy.CachedSelector])
-
-		// Check if all regexes for this pp  have identical selector sets .
-		// if it does we can just skip the ip lookup as there is no change in the policy outcome regardless of which selector is making request.
-		var firstSelectorSet *set.Set[policy.CachedSelector]
-		allequal := true
-
-		for _, selectorSet := range regexMap {
-			if firstSelectorSet == nil {
-				firstSelectorSet = selectorSet
-			} else if !selectorSet.Equal(*firstSelectorSet) {
-				allequal = false
-				break
-			}
-		}
-
-		if allequal {
-			for re := range regexMap {
-				ipRules = append(ipRules, asIPRule(re, nil))
-			}
-			restored[pp] = ipRules
-			continue
-		}
-
 		for regex, selectorSet := range regexMap {
 			for cs := range selectorSet.Members() {
 				if cs.IsWildcard() {
 					ipRules = append(ipRules, asIPRule(regex, nil))
-					continue
-				}
-				ips := make(map[restore.RuleIPOrCIDR]struct{})
-				count := 0
-				nids := cs.GetSelections()
-			Loop:
-				for _, nid := range nids {
-					// Note: p.RLock must not be held during this call to IPCache
-					nidIPs := p.proxyLookupHandler.LookupByIdentity(nid)
-					p.RLock()
-					for _, ip := range nidIPs {
-						rip, err := restore.ParseRuleIPOrCIDR(ip)
-						if err != nil {
-							if errors.Is(err, restore.ErrRemoteClusterAddr) {
-								// ignore non-local IPs or CIDRs
+				} else {
+					ips := make(map[restore.RuleIPOrCIDR]struct{})
+					count := 0
+					nids := cs.GetSelections()
+				Loop:
+					for _, nid := range nids {
+						// Note: p.RLock must not be held during this call to IPCache
+						nidIPs := p.proxyLookupHandler.LookupByIdentity(nid)
+						p.RLock()
+						for _, ip := range nidIPs {
+							rip, err := restore.ParseRuleIPOrCIDR(ip)
+							if err != nil {
+								if errors.Is(err, restore.ErrRemoteClusterAddr) {
+									// ignore non-local IPs or CIDRs
+									continue
+								}
+								p.logger.Warn(
+									"Could not parse IP for a DNS rule (?!), skipping",
+									logfields.EndpointID, endpointID,
+									logfields.Port, pp.Port(),
+									logfields.Protocol, pp.Protocol(),
+									logfields.EndpointLabelSelector, selectorSet,
+									logfields.IPAddr, ip,
+								)
 								continue
 							}
-							p.logger.Warn(
-								"Could not parse IP for a DNS rule (?!), skipping",
-								logfields.EndpointID, endpointID,
-								logfields.Port, pp.Port(),
-								logfields.Protocol, pp.Protocol(),
-								logfields.EndpointLabelSelector, selectorSet,
-								logfields.IPAddr, ip,
-							)
-							continue
+							if rip.IsAddr() && p.skipIPInRestorationRLocked(rip.Addr()) {
+								continue
+							}
+							ips[rip] = struct{}{}
+							count++
+							if count > p.maxIPsPerRestoredDNSRule {
+								p.logger.Warn(
+									"Too many IPs for a DNS rule, skipping the rest",
+									logfields.EndpointID, endpointID,
+									logfields.Port, pp.Port(),
+									logfields.Protocol, pp.Protocol(),
+									logfields.Limit, p.maxIPsPerRestoredDNSRule,
+									logfields.Count, len(nidIPs),
+								)
+								p.RUnlock()
+								break Loop
+							}
 						}
-						if rip.IsAddr() && p.skipIPInRestorationRLocked(rip.Addr()) {
-							continue
-						}
-						ips[rip] = struct{}{}
-						count++
-						if count > p.maxIPsPerRestoredDNSRule {
-							p.logger.Warn(
-								"Too many IPs for a DNS rule, skipping the rest",
-								logfields.EndpointID, endpointID,
-								logfields.Port, pp.Port(),
-								logfields.Protocol, pp.Protocol(),
-								logfields.Limit, p.maxIPsPerRestoredDNSRule,
-								logfields.Count, len(nidIPs),
-							)
-							p.RUnlock()
-							break Loop
-						}
+						p.RUnlock()
 					}
-					p.RUnlock()
+					ipRules = append(ipRules, asIPRule(regex, ips))
 				}
-				ipRules = append(ipRules, asIPRule(regex, ips))
+
 			}
 			restored[pp] = ipRules
 		}

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -16,11 +16,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/cilium/dns"
-	"go4.org/netipx"
-	"golang.org/x/sync/semaphore"
-	"golang.org/x/sys/unix"
-
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/fqdn/lookup"
@@ -37,6 +32,11 @@ import (
 	"github.com/cilium/cilium/pkg/revert"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/u8proto"
+	"github.com/cilium/dns"
+	"go4.org/netipx"
+	"golang.org/x/sync/semaphore"
+	"golang.org/x/sys/unix"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (
@@ -281,25 +281,39 @@ func (p *DNSProxy) GetRules(endpointID uint16) (restore.DNSRules, error) {
 	p.RUnlock()
 
 	restored := make(restore.DNSRules)
+	regexToSelectors := make(map[restore.PortProto]map[*regexp.Regexp]sets.Set[policy.CachedSelector])
 	for pp, selRegexes := range portProtoToSelRegex {
 		var ipRules restore.IPRules
-		if len(selRegexes) > 0 {
-			sameRegex := true
-			firstPattern := selRegexes[0].re.String()
-			// checking for same regex
-			for _, sr := range selRegexes[1:] {
-				if sr.re.String() != firstPattern {
-					sameRegex = false
-					break
-				}
-			}
 
-			if sameRegex {
-				ipRules = append(ipRules, asIPRule(selRegexes[0].re, nil))
-				restored[pp] = ipRules
-				continue
+		regexToSelectors[pp] = make(map[*regexp.Regexp]sets.Set[policy.CachedSelector])
+
+		for _, selRegex := range selRegexes {
+			if regexToSelectors[pp][selRegex.re] == nil {
+				regexToSelectors[pp][selRegex.re] = sets.New[policy.CachedSelector]()
+			}
+			regexToSelectors[pp][selRegex.re].Insert(selRegex.cs)
+		}
+
+		var firstSelectorSet sets.Set[policy.CachedSelector]
+		allequal := true
+
+		for _, selectorSet := range regexToSelectors[pp] {
+			if firstSelectorSet == nil {
+				firstSelectorSet = selectorSet
+			} else if !selectorSet.Equal(firstSelectorSet) {
+				allequal = false
+				break
 			}
 		}
+
+		if allequal {
+			for re := range regexToSelectors[pp] {
+				ipRules = append(ipRules, asIPRule(re, nil))
+			}
+			restored[pp] = ipRules
+			continue
+		}
+
 		for _, selRegex := range selRegexes {
 			if selRegex.cs.IsWildcard() {
 				ipRules = append(ipRules, asIPRule(selRegex.re, nil))

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -283,6 +283,23 @@ func (p *DNSProxy) GetRules(endpointID uint16) (restore.DNSRules, error) {
 	restored := make(restore.DNSRules)
 	for pp, selRegexes := range portProtoToSelRegex {
 		var ipRules restore.IPRules
+		if len(selRegexes) > 0 {
+			sameRegex := true
+			firstPattern := selRegexes[0].re.String()
+			// checking for same regex
+			for _, sr := range selRegexes[1:] {
+				if sr.re.String() != firstPattern {
+					sameRegex = false
+					break
+				}
+			}
+
+			if sameRegex {
+				ipRules = append(ipRules, asIPRule(selRegexes[0].re, nil))
+				restored[pp] = ipRules
+				continue
+			}
+		}
 		for _, selRegex := range selRegexes {
 			if selRegex.cs.IsWildcard() {
 				ipRules = append(ipRules, asIPRule(selRegex.re, nil))

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -253,6 +253,7 @@ func (p *DNSProxy) skipIPInRestorationRLocked(ip netip.Addr) bool {
 // for later restoration.
 //
 // Only used for testing.
+
 func (p *DNSProxy) GetRules(endpointID uint16) (restore.DNSRules, error) {
 	// Lock ordering note: Acquiring the IPCache read lock (as LookupIPsBySecID does) while holding
 	// the proxy lock can lead to a deadlock. Avoid this by reading the state from DNSProxy while
@@ -260,20 +261,18 @@ func (p *DNSProxy) GetRules(endpointID uint16) (restore.DNSRules, error) {
 	// Note that IPCache state may change in between calls to LookupIPsBySecID.
 	p.RLock()
 
-	type selRegex struct {
-		re *regexp.Regexp
-		cs policy.CachedSelector
-	}
-
-	portProtoToSelRegex := make(map[restore.PortProto][]selRegex)
+	regexToSelectors := make(map[restore.PortProto]map[*regexp.Regexp]*set.Set[policy.CachedSelector])
 	for pp, entries := range p.allowed[uint64(endpointID)] {
-		nidRules := make([]selRegex, 0, len(entries))
+		regexToSelectors[pp] = make(map[*regexp.Regexp]*set.Set[policy.CachedSelector])
 		// Copy the entries to avoid racy map accesses after we release the lock. We don't need
 		// constant time access, hence a preallocated slice instead of another map.
 		for cs, regex := range entries {
-			nidRules = append(nidRules, selRegex{cs: cs, re: regex})
+			if regexToSelectors[pp][regex] == nil {
+				s := set.NewSet[policy.CachedSelector]()
+				regexToSelectors[pp][regex] = &s
+			}
+			regexToSelectors[pp][regex].Insert(cs)
 		}
-		portProtoToSelRegex[pp] = nidRules
 	}
 
 	// We've read what we need from the proxy. The following IPCache lookups _must_ occur outside of
@@ -281,24 +280,18 @@ func (p *DNSProxy) GetRules(endpointID uint16) (restore.DNSRules, error) {
 	p.RUnlock()
 
 	restored := make(restore.DNSRules)
-	regexToSelectors := make(map[restore.PortProto]map[*regexp.Regexp]*set.Set[policy.CachedSelector])
-	for pp, selRegexes := range portProtoToSelRegex {
+
+	for pp, regexMap := range regexToSelectors {
 		var ipRules restore.IPRules
 
 		regexToSelectors[pp] = make(map[*regexp.Regexp]*set.Set[policy.CachedSelector])
 
-		for _, selRegex := range selRegexes {
-			if regexToSelectors[pp][selRegex.re] == nil {
-				s := set.NewSet[policy.CachedSelector]()
-				regexToSelectors[pp][selRegex.re] = &s
-			}
-			regexToSelectors[pp][selRegex.re].Insert(selRegex.cs)
-		}
-
+		// Check if all regexes for this pp  have identical selector sets .
+		// if it does we can just skip the ip lookup as there is no change in the policy outcome regardless of which selector is making request.
 		var firstSelectorSet *set.Set[policy.CachedSelector]
 		allequal := true
 
-		for _, selectorSet := range regexToSelectors[pp] {
+		for _, selectorSet := range regexMap {
 			if firstSelectorSet == nil {
 				firstSelectorSet = selectorSet
 			} else if !selectorSet.Equal(*firstSelectorSet) {
@@ -308,66 +301,68 @@ func (p *DNSProxy) GetRules(endpointID uint16) (restore.DNSRules, error) {
 		}
 
 		if allequal {
-			for re := range regexToSelectors[pp] {
+			for re := range regexMap {
 				ipRules = append(ipRules, asIPRule(re, nil))
 			}
 			restored[pp] = ipRules
 			continue
 		}
 
-		for _, selRegex := range selRegexes {
-			if selRegex.cs.IsWildcard() {
-				ipRules = append(ipRules, asIPRule(selRegex.re, nil))
-				continue
-			}
-			ips := make(map[restore.RuleIPOrCIDR]struct{})
-			count := 0
-			nids := selRegex.cs.GetSelections()
-		Loop:
-			for _, nid := range nids {
-				// Note: p.RLock must not be held during this call to IPCache
-				nidIPs := p.proxyLookupHandler.LookupByIdentity(nid)
-				p.RLock()
-				for _, ip := range nidIPs {
-					rip, err := restore.ParseRuleIPOrCIDR(ip)
-					if err != nil {
-						if errors.Is(err, restore.ErrRemoteClusterAddr) {
-							// ignore non-local IPs or CIDRs
+		for regex, selectorSet := range regexMap {
+			for cs := range selectorSet.Members() {
+				if cs.IsWildcard() {
+					ipRules = append(ipRules, asIPRule(regex, nil))
+					continue
+				}
+				ips := make(map[restore.RuleIPOrCIDR]struct{})
+				count := 0
+				nids := cs.GetSelections()
+			Loop:
+				for _, nid := range nids {
+					// Note: p.RLock must not be held during this call to IPCache
+					nidIPs := p.proxyLookupHandler.LookupByIdentity(nid)
+					p.RLock()
+					for _, ip := range nidIPs {
+						rip, err := restore.ParseRuleIPOrCIDR(ip)
+						if err != nil {
+							if errors.Is(err, restore.ErrRemoteClusterAddr) {
+								// ignore non-local IPs or CIDRs
+								continue
+							}
+							p.logger.Warn(
+								"Could not parse IP for a DNS rule (?!), skipping",
+								logfields.EndpointID, endpointID,
+								logfields.Port, pp.Port(),
+								logfields.Protocol, pp.Protocol(),
+								logfields.EndpointLabelSelector, selectorSet,
+								logfields.IPAddr, ip,
+							)
 							continue
 						}
-						p.logger.Warn(
-							"Could not parse IP for a DNS rule (?!), skipping",
-							logfields.EndpointID, endpointID,
-							logfields.Port, pp.Port(),
-							logfields.Protocol, pp.Protocol(),
-							logfields.EndpointLabelSelector, selRegex.cs,
-							logfields.IPAddr, ip,
-						)
-						continue
+						if rip.IsAddr() && p.skipIPInRestorationRLocked(rip.Addr()) {
+							continue
+						}
+						ips[rip] = struct{}{}
+						count++
+						if count > p.maxIPsPerRestoredDNSRule {
+							p.logger.Warn(
+								"Too many IPs for a DNS rule, skipping the rest",
+								logfields.EndpointID, endpointID,
+								logfields.Port, pp.Port(),
+								logfields.Protocol, pp.Protocol(),
+								logfields.Limit, p.maxIPsPerRestoredDNSRule,
+								logfields.Count, len(nidIPs),
+							)
+							p.RUnlock()
+							break Loop
+						}
 					}
-					if rip.IsAddr() && p.skipIPInRestorationRLocked(rip.Addr()) {
-						continue
-					}
-					ips[rip] = struct{}{}
-					count++
-					if count > p.maxIPsPerRestoredDNSRule {
-						p.logger.Warn(
-							"Too many IPs for a DNS rule, skipping the rest",
-							logfields.EndpointID, endpointID,
-							logfields.Port, pp.Port(),
-							logfields.Protocol, pp.Protocol(),
-							logfields.Limit, p.maxIPsPerRestoredDNSRule,
-							logfields.Count, len(nidIPs),
-						)
-						p.RUnlock()
-						break Loop
-					}
+					p.RUnlock()
 				}
-				p.RUnlock()
+				ipRules = append(ipRules, asIPRule(regex, ips))
 			}
-			ipRules = append(ipRules, asIPRule(selRegex.re, ips))
+			restored[pp] = ipRules
 		}
-		restored[pp] = ipRules
 	}
 
 	return restored, nil


### PR DESCRIPTION
## Summary

This PR optimizes DNS rule restoration by skipping identity-to-IP resolution for non-server-dependent DNS rules.

Currently, `GetRules()` restores destination IP mappings via `LookupByIdentity()`. However, once traffic reaches the DNS proxy, L3/L4 policy has already validated the destination IP and port.

This change restores a single wildcard `IPRule` (`IPs=nil`) when a rule is considered non-server-dependent, avoiding unnecessary IP lookups and caching.

## Assumption

This implementation assumes that a rule is non-server-dependent when all selectors for a given `PortProto` resolve to the same DNS regex pattern.

If that interpretation is incorrect, I'm happy to adjust the implementation.

Fixes #45850
