### PR TITLE
docs: fix broken gateway-api doc links

### DIFF
--- a/Documentation/network/servicemesh/gateway-api/addresses.rst
+++ b/Documentation/network/servicemesh/gateway-api/addresses.rst
@@ -8,7 +8,7 @@
 Gateway API Addresses Support
 *****************************
 
-Cilium Gateway supports `Addresses <https://gateway-api.sigs.k8s.io/api-types/gateway/?h=addresses>`__ provided by the Gateway API specification.
+Cilium Gateway supports `Addresses <https://gateway-api.sigs.k8s.io/reference/api-types/gateway/?h=addresses>`__ provided by the Gateway API specification.
 The ``spec.addresses`` field is used to specify the IP address of the gateway.
 
 .. note::

--- a/Documentation/network/servicemesh/gateway-api/gamma.rst
+++ b/Documentation/network/servicemesh/gateway-api/gamma.rst
@@ -13,7 +13,7 @@ GAMMA Support
 What is GAMMA?
 ####################
 
-(From the `GAMMA page <https://gateway-api.sigs.k8s.io/mesh/gamma/>`__
+(From the `GAMMA page <https://gateway-api.sigs.k8s.io/docs/mesh/gamma/>`__
 on the Gateway API site):
 
 The GAMMA initiative is a dedicated workstream within the Gateway API
@@ -63,8 +63,8 @@ Cilium GAMMA Support
 
 Cilium supports GAMMA v1.0.0 for the following resources:  
 
-- `HTTPRoute <https://gateway-api.sigs.k8s.io/api-types/httproute/>`_  
-- `ReferenceGrant <https://gateway-api.sigs.k8s.io/api-types/referencegrant/>`_  
+- `HTTPRoute <https://gateway-api.sigs.k8s.io/reference/api-types/httproute/>`_
+- `ReferenceGrant <https://gateway-api.sigs.k8s.io/reference/api-types/referencegrant/>`_
 
 Cilium support is limited to passing the Core conformance  
 tests and two out of three Extended Mesh tests. Note that GAMMA is itself  

--- a/Documentation/network/servicemesh/gateway-api/gateway-api.rst
+++ b/Documentation/network/servicemesh/gateway-api/gateway-api.rst
@@ -37,7 +37,7 @@ tests are passed.
 - `UDPRoute (experimental) <https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#udproute>`__
 
 Additionally, Cilium provides ``CiliumGatewayClassConfig`` CRD, which can be referenced in
-`GatewayClass.parametersRef <https://gateway-api.sigs.k8s.io/api-types/gatewayclass/#gatewayclass-parameters>`_.
+`GatewayClass.parametersRef <https://gateway-api.sigs.k8s.io/reference/api-types/gatewayclass/#gatewayclass-parameters>`_.
 
 .. admonition:: Video
  :class: attention

--- a/Documentation/network/servicemesh/gateway-api/installation.rst
+++ b/Documentation/network/servicemesh/gateway-api/installation.rst
@@ -7,15 +7,15 @@ Prerequisites
 * Cilium must be configured with the L7 proxy enabled using ``l7Proxy=true``
   (enabled by default).
 * The below CRDs from Gateway API v1.5.1 ``must`` be pre-installed.
-  Please refer to this `docs <https://gateway-api.sigs.k8s.io/guides/?h=crds#getting-started-with-gateway-api>`_
+  Please refer to these `docs <https://gateway-api.sigs.k8s.io/guides/getting-started/introduction/#installing-gateway-api>`_
   for installation steps. Alternatively, the below snippet could be used.
 
-    - `GatewayClass <https://gateway-api.sigs.k8s.io/api-types/gatewayclass/>`_
-    - `Gateway <https://gateway-api.sigs.k8s.io/api-types/gateway/>`_
-    - `HTTPRoute <https://gateway-api.sigs.k8s.io/api-types/httproute/>`_
-    - `GRPCRoute <https://gateway-api.sigs.k8s.io/api-types/grpcroute/>`_
-    - `ReferenceGrant <https://gateway-api.sigs.k8s.io/api-types/referencegrant/>`_
-    - `TLSRoute <https://gateway-api.sigs.k8s.io/api-types/tlsroute/>`_
+    - `GatewayClass <https://gateway-api.sigs.k8s.io/reference/api-types/gatewayclass/>`_
+    - `Gateway <https://gateway-api.sigs.k8s.io/reference/api-types/gateway/>`_
+    - `HTTPRoute <https://gateway-api.sigs.k8s.io/reference/api-types/httproute/>`_
+    - `GRPCRoute <https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute/>`_
+    - `ReferenceGrant <https://gateway-api.sigs.k8s.io/reference/api-types/referencegrant/>`_
+    - `TLSRoute <https://gateway-api.sigs.k8s.io/reference/api-types/tlsroute/>`_
 
   If you wish to use the TCPRoute and UDPRoute functionality, you also need to install the TCPRoute and UDPRoute resource.
   If this CRD is not installed, then Cilium will disable TCPRoute and UDPRoute support.

--- a/Documentation/network/servicemesh/ingress-to-gateway/nginx-annotations-migration.rst
+++ b/Documentation/network/servicemesh/ingress-to-gateway/nginx-annotations-migration.rst
@@ -102,12 +102,12 @@ Common Direct Mappings
      - Experimental in Gateway API (GEP-1731). Maps retry count only, not the full ``proxy-next-upstream*`` behavior set.
    * - ``kubernetes.io/ingress.class``
      - ``Gateway.spec.gatewayClassName``
-     - `Gateway API Overview <https://gateway-api.sigs.k8s.io/concepts/api-overview/>`__
+     - `Gateway API Overview <https://gateway-api.sigs.k8s.io/docs/concepts/api-overview/>`__
      - Yes
      - Replace controller selection model. Note: uses the ``kubernetes.io/`` prefix, not ``nginx.ingress.kubernetes.io/``; won't appear in the NGINX-scoped inventory above.
    * - ``server-alias``
      - ``HTTPRoute.spec.hostnames``
-     - `Gateway API Overview <https://gateway-api.sigs.k8s.io/concepts/api-overview/>`__
+     - `Gateway API Overview <https://gateway-api.sigs.k8s.io/docs/concepts/api-overview/>`__
      - Yes
      - Migrate alternate hostnames explicitly.
    * - ``backend-protocol``
@@ -122,17 +122,17 @@ Common Direct Mappings
      - Experimental in Gateway API (GEP-1767).
    * - ``proxy-ssl-secret``
      - ``BackendTLSPolicy.spec.validation.caCertificateRefs``
-     - `BackendTLSPolicy <https://gateway-api.sigs.k8s.io/api-types/backendtlspolicy/>`__
+     - `BackendTLSPolicy <https://gateway-api.sigs.k8s.io/reference/api-types/policy/backendtlspolicy/>`__
      - Yes
      - Backend TLS trust material.
    * - ``proxy-ssl-verify``
      - ``BackendTLSPolicy.spec.validation``
-     - `BackendTLSPolicy <https://gateway-api.sigs.k8s.io/api-types/backendtlspolicy/>`__
+     - `BackendTLSPolicy <https://gateway-api.sigs.k8s.io/reference/api-types/policy/backendtlspolicy/>`__
      - Yes
      - CA and validation behavior.
    * - ``secure-backends``
      - ``BackendTLSPolicy``
-     - `BackendTLSPolicy <https://gateway-api.sigs.k8s.io/api-types/backendtlspolicy/>`__
+     - `BackendTLSPolicy <https://gateway-api.sigs.k8s.io/reference/api-types/policy/backendtlspolicy/>`__
      - Yes
      - Use policy attachment for backend TLS.
 
@@ -180,7 +180,7 @@ does not yet support these mappings**.
      - High
    * - ``tcp-services-configmap``
      - ``TCPRoute`` resources (experimental channel)
-     - `TCPRoute <https://gateway-api.sigs.k8s.io/api-types/tcproute/>`_
+     - `TCPRoute <https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#tcproute>`_
      - Not yet supported
      - High
    * - ``use-forwarded-headers``


### PR DESCRIPTION
The CRD pages have moved from `/api-types/*` to `/reference/api-types/`.

Concept pages moved from `/concepts/*` to `/docs/concept/`.

Experimental CRDs don't have `/reference/api-types/` pages, so the api-spec page is used instead.

See: https://github.com/kubernetes-sigs/gateway-api/pull/4734

```release-note
Fix broken gateway-api documentation links
```