### PR TITLE
bpf: l2_responder: split map declarations into l2_responder_maps.h

### DIFF
--- a/bpf/lib/l2_responder.h
+++ b/bpf/lib/l2_responder.h
@@ -3,44 +3,13 @@
 
 #pragma once
 
-#include <linux/bpf.h>
-#include <bpf/section.h>
-#include <bpf/loader.h>
+/* Map types and declarations (safe to include from any BPF program). */
+#include "l2_responder_maps.h"
+/* Full announcement handler needs global config + ARP + ICMPv6. */
+#include <bpf/config/global.h>
 
-struct l2_responder_v4_key {
-	union v4addr ip4;
-	__u32 ifindex;
-};
-
-struct l2_responder_stats {
-	__u64 responses_sent;
-};
-
-struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__type(key, struct l2_responder_v4_key);
-	__type(value, struct l2_responder_stats);
-	__uint(pinning, LIBBPF_PIN_BY_NAME);
-	__uint(max_entries, L2_RESPONDER_MAP4_SIZE);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
-} cilium_l2_responder_v4 __section_maps_btf;
-
-struct l2_responder_v6_key {
-	union v6addr ip6;
-	__u32 ifindex;
-	__u32 pad;
-};
-
-struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__type(key, struct l2_responder_v6_key);
-	__type(value, struct l2_responder_stats);
-	__uint(pinning, LIBBPF_PIN_BY_NAME);
-	__uint(max_entries, L2_RESPONDER_MAP6_SIZE);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
-} cilium_l2_responder_v6 __section_maps_btf;
-
-DECLARE_CONFIG(bool, enable_l2_announcements, "Enable L2 Announcements")
+/* enable_l2_announcements is declared in l2_responder_maps.h (the gate
+ * for consulting the responder maps). */
 DECLARE_CONFIG(__u64, l2_announcements_max_liveness,
 	       "If the agent is down for longer than the lease duration, stop responding")
 

--- a/bpf/lib/l2_responder_maps.h
+++ b/bpf/lib/l2_responder_maps.h
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+/* Map types and BPF map declarations for the L2 responder.
+ * This header is safe to include from any BPF program — it carries no
+ * function implementations and requires no ARP/ICMPv6/runtime-config
+ * headers.  Programs that need the full announcement handler (arp.h,
+ * icmp6.h, RUNTIME_CONFIG_AGENT_LIVENESS) should include l2_responder.h.
+ */
+
+#pragma once
+
+#include <linux/bpf.h>
+#include <bpf/section.h>
+#include <bpf/loader.h>
+
+#include "static_data.h"
+
+/* The gate for consulting the maps below: a consumer that wants to ask
+ * "is this address one this node currently L2-announces?" must skip the
+ * lookup entirely when L2 announcements are disabled. Declared here (not
+ * in the full l2_responder.h) so map consumers can gate without pulling
+ * the announcement handler's ARP/ICMPv6 include chain. */
+DECLARE_CONFIG(bool, enable_l2_announcements, "Enable L2 Announcements")
+
+struct l2_responder_v4_key {
+	union v4addr ip4;
+	__u32 ifindex;
+};
+
+struct l2_responder_stats {
+	__u64 responses_sent;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, struct l2_responder_v4_key);
+	__type(value, struct l2_responder_stats);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+	__uint(max_entries, L2_RESPONDER_MAP4_SIZE);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+} cilium_l2_responder_v4 __section_maps_btf;
+
+struct l2_responder_v6_key {
+	union v6addr ip6;
+	__u32 ifindex;
+	__u32 pad;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, struct l2_responder_v6_key);
+	__type(value, struct l2_responder_stats);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+	__uint(max_entries, L2_RESPONDER_MAP6_SIZE);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+} cilium_l2_responder_v6 __section_maps_btf;


### PR DESCRIPTION
# bpf: l2_responder: split map declarations into l2_responder_maps.h

(fork branch: `omar/upstream-l2responder-maps-split`, base: `main`)

## Summary

`bpf/lib/l2_responder.h` mixes two things with very different include
requirements:

1. The L2 responder **map types and declarations**
   (`l2_responder_v4_key`/`v6_key`, `cilium_l2_responder_v4`/`v6`) plus
   the `enable_l2_announcements` gate — plain data, includable from any
   BPF program.
2. `handle_l2_announcement()` — which drags in
   `<bpf/config/global.h>` (`interface_mac`/`ifindex` configs), ARP and
   ICMPv6 helpers, and the agent-liveness runtime config.

A program that only wants to **look up** the responder maps (to ask "is
this address a VIP this node currently L2-announces?") is forced to
satisfy the full announcement-handler include chain, which is only
available in `bpf_host`.

This splits the map types/declarations into a new
`bpf/lib/l2_responder_maps.h`; `l2_responder.h` includes it, so existing
consumers are unchanged. The `enable_l2_announcements` config moves to
the maps header too — a consumer deciding whether to consult the maps
needs the gate, and it depends only on the lightweight `static_data.h`.

No behavior change. Single commit, ~60 lines of motion.

## Why

This is the prerequisite for letting `is_valid_lxc_src_ip()` consult the
responder map from `bpf_lxc` (posted as a stacked follow-up: #46530 (#TBD)), and is
useful compile-isolation hygiene on its own.

## Testing

- `make -C bpf build_all` passes (clang 18); `bpf_host`/`bpf_sock`/
  `bpf_lxc` all compile.
- DCO signed off.