### PR TITLE
bpf: lxc: allow pod egress with an L2-announced Service VIP as source

### DIFF
--- a/bpf/lib/l2_responder.h
+++ b/bpf/lib/l2_responder.h
@@ -3,44 +3,13 @@
 
 #pragma once
 
-#include <linux/bpf.h>
-#include <bpf/section.h>
-#include <bpf/loader.h>
+/* Map types and declarations (safe to include from any BPF program). */
+#include "l2_responder_maps.h"
+/* Full announcement handler needs global config + ARP + ICMPv6. */
+#include <bpf/config/global.h>
 
-struct l2_responder_v4_key {
-	union v4addr ip4;
-	__u32 ifindex;
-};
-
-struct l2_responder_stats {
-	__u64 responses_sent;
-};
-
-struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__type(key, struct l2_responder_v4_key);
-	__type(value, struct l2_responder_stats);
-	__uint(pinning, LIBBPF_PIN_BY_NAME);
-	__uint(max_entries, L2_RESPONDER_MAP4_SIZE);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
-} cilium_l2_responder_v4 __section_maps_btf;
-
-struct l2_responder_v6_key {
-	union v6addr ip6;
-	__u32 ifindex;
-	__u32 pad;
-};
-
-struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__type(key, struct l2_responder_v6_key);
-	__type(value, struct l2_responder_stats);
-	__uint(pinning, LIBBPF_PIN_BY_NAME);
-	__uint(max_entries, L2_RESPONDER_MAP6_SIZE);
-	__uint(map_flags, BPF_F_NO_PREALLOC);
-} cilium_l2_responder_v6 __section_maps_btf;
-
-DECLARE_CONFIG(bool, enable_l2_announcements, "Enable L2 Announcements")
+/* enable_l2_announcements is declared in l2_responder_maps.h (the gate
+ * for consulting the responder maps). */
 DECLARE_CONFIG(__u64, l2_announcements_max_liveness,
 	       "If the agent is down for longer than the lease duration, stop responding")
 

--- a/bpf/lib/l2_responder_maps.h
+++ b/bpf/lib/l2_responder_maps.h
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+/* Map types and BPF map declarations for the L2 responder.
+ * This header is safe to include from any BPF program — it carries no
+ * function implementations and requires no ARP/ICMPv6/runtime-config
+ * headers.  Programs that need the full announcement handler (arp.h,
+ * icmp6.h, RUNTIME_CONFIG_AGENT_LIVENESS) should include l2_responder.h.
+ */
+
+#pragma once
+
+#include <linux/bpf.h>
+#include <bpf/section.h>
+#include <bpf/loader.h>
+
+#include "static_data.h"
+
+/* The gate for consulting the maps below: a consumer that wants to ask
+ * "is this address one this node currently L2-announces?" must skip the
+ * lookup entirely when L2 announcements are disabled. Declared here (not
+ * in the full l2_responder.h) so map consumers can gate without pulling
+ * the announcement handler's ARP/ICMPv6 include chain. */
+DECLARE_CONFIG(bool, enable_l2_announcements, "Enable L2 Announcements")
+
+struct l2_responder_v4_key {
+	union v4addr ip4;
+	__u32 ifindex;
+};
+
+struct l2_responder_stats {
+	__u64 responses_sent;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, struct l2_responder_v4_key);
+	__type(value, struct l2_responder_stats);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+	__uint(max_entries, L2_RESPONDER_MAP4_SIZE);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+} cilium_l2_responder_v4 __section_maps_btf;
+
+struct l2_responder_v6_key {
+	union v6addr ip6;
+	__u32 ifindex;
+	__u32 pad;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, struct l2_responder_v6_key);
+	__type(value, struct l2_responder_stats);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+	__uint(max_entries, L2_RESPONDER_MAP6_SIZE);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+} cilium_l2_responder_v6 __section_maps_btf;

--- a/bpf/lib/lxc.h
+++ b/bpf/lib/lxc.h
@@ -11,6 +11,7 @@
 #include "dbg.h"
 #include "trace.h"
 #include "l4.h"
+#include "l2_responder_maps.h"
 #include "proxy.h"
 #include "proxy_hairpin.h"
 
@@ -20,7 +21,25 @@ int is_valid_lxc_src_ip(struct ipv6hdr *ip6 __maybe_unused)
 {
 #ifdef ENABLE_IPV6
 	union v6addr valid = CONFIG(endpoint_ipv6);
-	return ipv6_addr_equals((union v6addr *)&ip6->saddr, &valid);
+
+	if (ipv6_addr_equals((union v6addr *)&ip6->saddr, &valid))
+		return 1;
+
+	/* Allow a saddr that is a Service VIP this node currently
+	 * L2-announces. An in-pod module (e.g. the kernel AMT relay) may be
+	 * configured with a Service ExternalIP/LoadBalancer VIP and legitimately
+	 * source packets from it. Only consult the responder map when L2
+	 * announcements are enabled — otherwise this is a pure DROP path.
+	 */
+	if (CONFIG(enable_l2_announcements)) {
+		struct l2_responder_v6_key l2key = {};
+
+		l2key.ifindex = CONFIG(direct_routing_dev_ifindex);
+		ipv6_addr_copy(&l2key.ip6, (union v6addr *)&ip6->saddr);
+		if (map_lookup_elem(&cilium_l2_responder_v6, &l2key))
+			return 1;
+	}
+	return 0;
 #else
 	return 0;
 #endif
@@ -30,7 +49,21 @@ static __always_inline
 int is_valid_lxc_src_ipv4(const struct iphdr *ip4 __maybe_unused)
 {
 #ifdef ENABLE_IPV4
-	return ip4->saddr == CONFIG(endpoint_ipv4).be32;
+	if (ip4->saddr == CONFIG(endpoint_ipv4).be32)
+		return 1;
+
+	/* Allow a saddr that is a Service VIP this node L2-announces. See the
+	 * IPv6 path for the rationale and the enable-gate.
+	 */
+	if (CONFIG(enable_l2_announcements)) {
+		struct l2_responder_v4_key l2key = {};
+
+		l2key.ip4.be32 = ip4->saddr;
+		l2key.ifindex = CONFIG(direct_routing_dev_ifindex);
+		if (map_lookup_elem(&cilium_l2_responder_v4, &l2key))
+			return 1;
+	}
+	return 0;
 #else
 	/* Can't send IPv4 if no IPv4 address is configured */
 	return 0;


### PR DESCRIPTION
# bpf: lxc: allow pod egress with an L2-announced Service VIP as source

(fork branch: `omar/upstream-sip-l2announced-vip`, base: `main`,
**stacked on** `omar/upstream-l2responder-maps-split` — first commit is
that PR)

## Problem

`is_valid_lxc_src_ip{,v4}()` — the per-endpoint anti-spoofing guard on
pod egress — drops a packet unless its source address matches the
endpoint's *configured pod IP*. This breaks a pod that legitimately
**sources** packets from a Service ExternalIP/LoadBalancer VIP. Concrete
case: an in-pod kernel AMT relay (`drivers/net/amt.c`) configured with
`local <VIP>`, which must use that VIP as the source of AMT Relay
Advertisements per RFC 7450 §5.1.2. Today the only escape is the
`SourceIPVerification=Disabled` per-endpoint annotation (cilium#43505),
which disables anti-spoofing for the endpoint entirely.

## Approach

When L2 announcements are enabled, allow a source address present in
this node's L2 responder map (keyed on `direct_routing_dev_ifindex`):
the node already answers ARP/NDP for that VIP, so a local pod sourcing
from it is legitimate. The lookup is gated behind
`CONFIG(enable_l2_announcements)`, so it is a no-op on the hot egress
path for clusters without L2 announcements (addressing the review note
on the sibling socket-LB change).

This is narrower than the `#43505` annotation: the pod may source the
announced VIP but still cannot spoof arbitrary addresses.

## Relationship to the socket-LB side (#45672)

The **socket-LB** half of this problem — hostNetwork pods connecting
*to* an L2-announced ExternalIP on the leader node failing
`sock_skip_xlate()`'s `HOST_ID` check — is handled separately in
**#45672**, which (per maintainer guidance) fixes the **ipcache
identity** of announced VIPs rather than adding a BPF map check. That is
the right fix there because the VIP's identity is wrong; the l2announcer
now upserts `HOST_ID` for VIPs it announces.

The lxc anti-spoof check here is different in kind: it does **not**
consult ipcache at all — it's a direct comparison against the endpoint's
own configured IP, and there is no ipcache identity that makes "this pod
may source this VIP" true. So this case genuinely needs either the
per-endpoint `#43505` annotation or the narrow map-check in this PR.

## Security note (please weigh in)

This broadens the allow-set from "pod may source only its endpoint IP"
to "any pod on this node may source any VIP currently in this node's L2
responder map". Replies are not trivially exfiltratable (no Service DNAT
entry for `VIP:ephemeral-port`; CT state lives on the originating node),
but the broadening is real for UDP / one-way protocols and logging/ACL
surfaces. If maintainers prefer, this could remain opt-in per endpoint
via the `#43505` annotation machinery rather than applying whenever L2
announcements are enabled — happy to gate it that way.

## Testing

- `make -C bpf build_all` passes (clang 18).
- Downstream equivalent runs in production (kernel AMT relay sourcing a
  /32 LoadBalancer VIP through lxc egress).
- DCO signed off.
