### PR TITLE
hubble/observe: add --reply and --not-reply filter flags

### DIFF
--- a/Documentation/observability/hubble/hubble-cli.rst
+++ b/Documentation/observability/hubble/hubble-cli.rst
@@ -104,6 +104,24 @@ To see only unencrypted flows:
 
     $ hubble observe --unencrypted
 
+Filtering Reply Traffic
+=======================
+
+You can filter flows based on whether they are reply packets (server-to-client
+direction) or not.
+
+To see only reply flows:
+
+.. code-block:: shell-session
+
+    $ hubble observe --reply
+
+To see only non-reply flows:
+
+.. code-block:: shell-session
+
+    $ hubble observe --not-reply
+
 Next Steps
 ==========
 

--- a/hubble/cmd/observe/flows.go
+++ b/hubble/cmd/observe/flows.go
@@ -557,6 +557,12 @@ func newFlowsCmdHelper(usage cmdUsage, vp *viper.Viper, ofilter *flowFilter) *co
 	filterFlags.Var(filterVar(
 		"unencrypted", ofilter,
 		"Show only unencrypted flows"))
+	filterFlags.Var(filterVar(
+		"reply", ofilter,
+		"Show only reply flows"))
+	filterFlags.Var(filterVar(
+		"not-reply", ofilter,
+		"Show only non-reply flows"))
 
 	rawFilterFlags.StringArray(allowlistFlag, []string{}, "Specify allowlist as JSON encoded FlowFilters")
 	rawFilterFlags.StringArray(denylistFlag, []string{}, "Specify denylist as JSON encoded FlowFilters")
@@ -664,6 +670,8 @@ func newFlowsCmdHelper(usage cmdUsage, vp *viper.Viper, ofilter *flowFilter) *co
 	flowsCmd.Flags().Lookup("not").NoOptDefVal = "true"
 	flowsCmd.Flags().Lookup("encrypted").NoOptDefVal = "true"
 	flowsCmd.Flags().Lookup("unencrypted").NoOptDefVal = "true"
+	flowsCmd.Flags().Lookup("reply").NoOptDefVal = "true"
+	flowsCmd.Flags().Lookup("not-reply").NoOptDefVal = "true"
 	template.RegisterFlagSets(flowsCmd, flagSets...)
 	return flowsCmd
 }

--- a/hubble/cmd/observe/flows_filter.go
+++ b/hubble/cmd/observe/flows_filter.go
@@ -214,6 +214,7 @@ func newFlowFilter() *flowFilter {
 			{"traffic-direction"},
 			{"cel-expression"},
 			{"encrypted", "unencrypted"},
+			{"reply", "not-reply"},
 		},
 	}
 }
@@ -756,6 +757,14 @@ func (of *flowFilter) set(f *filterTracker, name, val string, track bool) error 
 	case "unencrypted":
 		f.apply(func(f *flowpb.FlowFilter) {
 			f.Encrypted = append(f.GetEncrypted(), false)
+		})
+	case "reply":
+		f.apply(func(f *flowpb.FlowFilter) {
+			f.Reply = append(f.GetReply(), true)
+		})
+	case "not-reply":
+		f.apply(func(f *flowpb.FlowFilter) {
+			f.Reply = append(f.GetReply(), false)
 		})
 	}
 

--- a/hubble/cmd/observe/flows_filter_test.go
+++ b/hubble/cmd/observe/flows_filter_test.go
@@ -793,6 +793,42 @@ func TestTrafficDirection(t *testing.T) {
 	}
 }
 
+func TestReplyFilter(t *testing.T) {
+	tt := []struct {
+		name    string
+		flags   []string
+		filters []*flowpb.FlowFilter
+	}{
+		{
+			name:  "reply",
+			flags: []string{"--reply"},
+			filters: []*flowpb.FlowFilter{
+				{Reply: []bool{true}},
+			},
+		},
+		{
+			name:  "not-reply",
+			flags: []string{"--not-reply"},
+			filters: []*flowpb.FlowFilter{
+				{Reply: []bool{false}},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFlowFilter()
+			cmd := newFlowsCmdWithFilter(viper.New(), f)
+			require.NoError(t, cmd.Flags().Parse(tc.flags))
+			diff := cmp.Diff(tc.filters, f.whitelist.flowFilters(), cmpopts.IgnoreUnexported(flowpb.FlowFilter{}))
+			if diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+			assert.Nil(t, f.blacklist)
+		})
+	}
+}
+
 func TestSnatIp(t *testing.T) {
 	tt := []struct {
 		name    string

--- a/hubble/cmd/observe_help.txt
+++ b/hubble/cmd/observe_help.txt
@@ -72,9 +72,11 @@ Filters Flags:
       --node-label filter                   Show only flows observed on nodes matching the given label filter (e.g. "key1=value1", "io.cilium/egress-gateway")
       --node-name filter                    Show all flows which match the given node names (e.g. "k8s*", "test-cluster/*.company.com")
       --not filter[=true]                   Reverses the next filter to be blacklist i.e. --not --from-ip 2.2.2.2
+      --not-reply filter[=true]             Show only non-reply flows
       --pod filter                          Show all flows related to the given pod name prefix ([namespace/]<pod-name>). If namespace is not provided, 'default' is used.
       --port filter                         Show only flows with given port in either source or destination (e.g. 8080)
       --protocol filter                     Show only flows which match the given L4/L7 flow protocol (e.g. "udp", "http")
+      --reply filter[=true]                 Show only reply flows
       --service filter                      Shows flows where either the source or destination IP address matches the ClusterIP address of the given service name prefix ([namespace/]<svc-name>). If namespace is not provided, 'default' is used. 
       --snat-ip filter                      Show all flows SNATed with the given IP address. Each of the SNAT IPs can be specified as an exact match (e.g. '1.1.1.1') or as a CIDR range (e.g.'1.1.1.0/24').
       --tcp-flags filter                    Show only flows which match the given TCP flags (e.g. "syn", "ack", "fin")


### PR DESCRIPTION
was going through open issues in cilium/hubble and picked this one up - cilium/hubble#1283

the `FlowFilter.Reply` proto field was already there and `ReplyFilter` was already wired into the filter chain, but there were no CLI flags to actually use it. this just adds `--reply` and `--not-reply` to `hubble observe`, following the same pattern as `--encrypted`/`--unencrypted`.

- `--reply` shows only reply flows
- `--not-reply` shows only non-reply flows
- the two flags are mutually exclusive

the tri-state concern raised in the issue is already handled server-side in `pkg/hubble/filters/reply.go` so nothing extra needed on the CLI side.

Fixes: cilium/hubble#1283

---

- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title, description and a `Fixes: #XXX` line if the commit addresses a particular GitHub issue.
- [x] All commits are signed off.
- [ ] For first time contributors, read [Submitting a pull request]
- [x] This PR was prepared with AIL:1. I used AI assistance only for drafting the PR description and commit messages. The implementation, code review and verification were done manually.

```release-note
Add --reply and --not-reply flags to hubble observe to filter flows by reply direction.
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer's Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request