### PR TITLE
cilium-dbg: use NodeKey.String() instead of manual net.IP conversion

### DIFF
--- a/cilium-dbg/cmd/bpf_nodeid_list.go
+++ b/cilium-dbg/cmd/bpf_nodeid_list.go
@@ -7,13 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"net"
 	"os"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 
-	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/maps/nodemap"
@@ -38,10 +36,7 @@ var bpfNodeIDListCmd = &cobra.Command{
 
 		bpfNodeValueList := []nodeID{}
 		parse := func(key *nodemap.NodeKey, val *nodemap.NodeValueV2) {
-			address := key.IP.String()
-			if key.Family == bpf.EndpointKeyIPv4 {
-				address = net.IP(key.IP[:net.IPv4len]).String()
-			}
+			address := key.String()
 			bpfNodeValueList = append(bpfNodeValueList, nodeID{
 				ID:      val.NodeID,
 				Address: address,


### PR DESCRIPTION
## What

Replace manual `net.IP` formatting in `bpf_nodeid_list.go` with the existing `NodeKey.String()` method, which already uses `netip.AddrFrom4` for IPv4 and handles IPv6 correctly.

## Why

Part of #24246 (Convert net.IP to netip.Addr). The `NodeKey` type already has a `String()` method that performs the correct conversion — the calling code was duplicating that logic using the deprecated `net.IP` type.

## Changes

- Replace 4-line manual conversion with single `key.String()` call
- Remove unused `net` and `bpf` imports from the file

Ref: #24246