### PR TITLE
ipam: fix typos and incorrect references in comments

### DIFF
--- a/operator/pkg/ipam/allocator/aws/aws.go
+++ b/operator/pkg/ipam/allocator/aws/aws.go
@@ -123,8 +123,8 @@ func (a *AllocatorAWS) Init(ctx context.Context, logger *slog.Logger) error {
 	return nil
 }
 
-// Start kicks of ENI allocation, the initial connection to AWS
-// APIs is done in a blocking manner, given that is successful, a controller is
+// Start kicks off ENI allocation, the initial connection to AWS
+// APIs is done in a blocking manner, given that this is successful, a controller is
 // started to manage allocation based on CiliumNode custom resources
 func (a *AllocatorAWS) Start(ctx context.Context, getterUpdater allocator.CiliumNodeGetterUpdater, iMetrics nodemanager.MetricsAPI) (allocator.NodeEventHandler, error) {
 	a.logger.Info("Starting ENI allocator...")

--- a/operator/pkg/ipam/allocator/azure/azure.go
+++ b/operator/pkg/ipam/allocator/azure/azure.go
@@ -38,7 +38,7 @@ func (a *AllocatorAzure) Init(ctx context.Context, logger *slog.Logger) error {
 	return nil
 }
 
-// Start kicks of the Azure IP allocation
+// Start kicks off the Azure IP allocation
 func (a *AllocatorAzure) Start(ctx context.Context, getterUpdater allocator.CiliumNodeGetterUpdater, iMetrics nodemanager.MetricsAPI) (allocator.NodeEventHandler, error) {
 	a.logger.Info("Starting Azure IP allocator...")
 

--- a/operator/pkg/ipam/allocator/clusterpool/clusterpool.go
+++ b/operator/pkg/ipam/allocator/clusterpool/clusterpool.go
@@ -75,7 +75,7 @@ func (a *AllocatorOperator) Init(ctx context.Context, logger *slog.Logger) error
 	return nil
 }
 
-// Start kicks of Operator allocation.
+// Start kicks off Operator allocation.
 func (a *AllocatorOperator) Start(ctx context.Context, updater allocator.CiliumNodeGetterUpdater, iMetrics trigger.MetricsObserver) (allocator.NodeEventHandler, error) {
 	a.logger.Info(
 		"Starting ClusterPool IP allocator",

--- a/operator/pkg/ipam/allocator/multipool/node_handler.go
+++ b/operator/pkg/ipam/allocator/multipool/node_handler.go
@@ -73,7 +73,7 @@ func (n *NodeHandler) Delete(resource *v2.CiliumNode) {
 	err := n.poolManager.ReleaseNode(resource.Name)
 	if err != nil {
 		n.logger.Warn(
-			"Errors while release node and its CIDRs",
+			"Errors while releasing node and its CIDRs",
 			logfields.Error, err,
 			logfields.NodeName, resource.Name,
 		)

--- a/operator/pkg/ipam/allocator/multipool/pool.go
+++ b/operator/pkg/ipam/allocator/multipool/pool.go
@@ -67,7 +67,7 @@ func releaseCIDR(allocators []cidralloc.CIDRAllocator, cidr netip.Prefix) error 
 		return alloc.Release(cidr)
 	}
 
-	return fmt.Errorf("released cidr %s was not part the pool", cidr)
+	return fmt.Errorf("released cidr %s was not part of the pool", cidr)
 }
 
 func hasCIDR(allocators []cidralloc.CIDRAllocator, cidr netip.Prefix) bool {

--- a/operator/pkg/ipam/allocator/podcidr/podcidr.go
+++ b/operator/pkg/ipam/allocator/podcidr/podcidr.go
@@ -62,7 +62,7 @@ type ErrCIDRAllocated struct {
 	cidr netip.Prefix
 }
 
-// Error returns the human-readable error for the ErrAllocatorNotFound
+// Error returns the human-readable error for the ErrCIDRAllocated
 func (e *ErrCIDRAllocated) Error() string {
 	return fmt.Sprintf("requested CIDR (%s) is already allocated", e.cidr)
 }
@@ -677,7 +677,7 @@ func (n *NodesPodCIDRManager) reuseIPNets(
 	)
 
 	// The node might want to allocate a new IPv4 podCIDR but it already
-	// has a IPv6 podCIDR. We will only allocate new podCIDRs if
+	// has an IPv6 podCIDR. We will only allocate new podCIDRs if
 	// canAllocateIPv4PodCIDRs is set to true. It's fine that we don't allocate
 	// it now since this node will be put into the map of nodes that require
 	// to be allocated in the future.
@@ -714,7 +714,7 @@ func (n *NodesPodCIDRManager) reuseIPNets(
 	}
 
 	// The node might want to allocate a new IPv6 podCIDR but it already
-	// has a IPv4 podCIDR. We will only allocate new podCIDRs if
+	// has an IPv4 podCIDR. We will only allocate new podCIDRs if
 	// canAllocateIPv6PodCIDRs is set to true. It's fine that we don't allocate
 	// it now since this node will be put into the map of nodes that require
 	// to be allocated in the future.
@@ -770,7 +770,7 @@ func (n *NodesPodCIDRManager) reuseIPNets(
 }
 
 // allocateIPNet allocates the `newCidr` in the cidrSet allocator. If the
-// the `newCIDR` is already allocated an error is returned.
+// `newCIDR` is already allocated an error is returned.
 // In case the function returns successfully, it's up to the caller to execute
 // the revert function provided to revert all state made. If the function
 // returns an error the caller of this function can assume no state was
@@ -834,7 +834,7 @@ func allocateIPNet(allType allocatorType, cidrSets []cidralloc.CIDRAllocator, ne
 			break
 		}
 		// If we were unable to occupy the CIDRs on any allocators then return
-		// immediately as one of the CIDR allocators should be have been able
+		// immediately as one of the CIDR allocators should have been able
 		// to allocate this new CIDR. 'err' is set with the appropriate error.
 		if err != nil {
 			return

--- a/operator/pkg/ipam/nodemanager/node.go
+++ b/operator/pkg/ipam/nodemanager/node.go
@@ -127,7 +127,7 @@ type Node struct {
 	// with external APIs or systems.
 	instanceSync *trigger.Trigger
 
-	// ops is the IPAM implementation to used for this node
+	// ops is the IPAM implementation to use for this node
 	ops NodeOperations
 
 	// retry is the trigger used to retry pool maintenance while the
@@ -203,7 +203,7 @@ type IPStatistics struct {
 	Capacity int
 
 	// NeededIPs is the number of IPs needed to reach the PreAllocate
-	// watermwark
+	// watermark
 	NeededIPs int
 
 	// ExcessIPs is the number of free IPs exceeding MaxAboveWatermark
@@ -824,7 +824,7 @@ type AllocationAction struct {
 	Interface ipamTypes.Interface
 
 	// PoolID is the IPAM pool identifier to allocate the IPs from. This
-	// can correspond to a subnet ID or it can also left blank or set to a
+	// can correspond to a subnet ID or it can also be left blank or set to a
 	// value such as "global" to indicate a single address pool.
 	PoolID ipamTypes.PoolID
 
@@ -839,7 +839,7 @@ type AllocationAction struct {
 // IPAllocationAction is the IP-specific action to be taken to resolve allocation deficits
 // for a particular node.
 type IPAllocationAction struct {
-	// AvailableForAllocation is the number IPs available for allocation.
+	// AvailableForAllocation is the number of IPs available for allocation.
 	// If InterfaceID is set, then this number corresponds to the number of
 	// IPs available for allocation on that interface. This number may be
 	// lower than the number of IPs required to resolve the deficit.
@@ -868,7 +868,7 @@ type ReleaseAction struct {
 	InterfaceID string
 
 	// PoolID is the IPAM pool identifier to release the IPs from. This can
-	// correspond to a subnet ID or it can also left blank or set to a
+	// correspond to a subnet ID or it can also be left blank or set to a
 	// value such as "global" to indicate a single address pool.
 	PoolID ipamTypes.PoolID
 
@@ -1469,7 +1469,7 @@ func (n *Node) syncToAPIServer() error {
 // Note that the `origNode` and `node` pointers will have their underlying
 // values modified in this function! The following is an outline of when
 // `origNode` and `node` pointers are updated:
-//   - `node` is updated when we succeed in updating to update the resource to
+//   - `node` is updated when we succeed in updating the resource to
 //     the apiserver.
 //   - `origNode` and `node` are updated when we fail to update the resource,
 //     but we succeed in retrieving the latest version of it from the

--- a/operator/pkg/ipam/nodemanager/node_manager.go
+++ b/operator/pkg/ipam/nodemanager/node_manager.go
@@ -37,7 +37,7 @@ var ipamNodeIntervalControllerGroup = controller.NewGroup("ipam-node-interval-re
 // NodeOperations implementation which performs operations in the context of
 // that node.
 type NodeOperations interface {
-	// UpdateNode is called when an update to the CiliumNode is received.
+	// UpdatedNode is called when an update to the CiliumNode is received.
 	UpdatedNode(obj *v2.CiliumNode)
 
 	// PopulateStatusFields is called to give the implementation a chance
@@ -237,7 +237,7 @@ func (n *NodeManager) instancesAPIResync(ctx context.Context) (time.Time, error)
 	return syncTime, err
 }
 
-// Start kicks of the NodeManager by performing the initial state
+// Start kicks off the NodeManager by performing the initial state
 // synchronization and starting the background sync goroutine
 func (n *NodeManager) Start(ctx context.Context) error {
 	// Trigger the initial resync in a blocking manner
@@ -325,7 +325,7 @@ func (n *NodeManager) Upsert(resource *v2.CiliumNode) {
 		node.logger.Store(node.rootLogger.With(fieldName, resource.Name))
 
 		ctx, cancel := context.WithCancel(context.Background())
-		// InstanceAPI is stale and the instances API is stable then do resync instancesAPI to sync instances
+		// If InstanceAPI is stale and the instances API is stable then do resync instancesAPI to sync instances
 		if !n.instancesAPI.HasInstance(resource.InstanceID()) && n.stableInstancesAPI {
 			if _, err := n.instancesAPI.InstanceSync(ctx, resource.InstanceID()); err != nil {
 				node.logger.Load().Warn("Failed to resync the instance from the API after new node was found", logfields.Error, err)

--- a/operator/pkg/ipam/nodemanager/node_manager_test.go
+++ b/operator/pkg/ipam/nodemanager/node_manager_test.go
@@ -820,7 +820,7 @@ func TestNodeManagerManyNodes(t *testing.T) {
 	}
 
 	// The above check returns as soon as the address requirements are met.
-	// The metrics may still be oudated, resync all nodes to update
+	// The metrics may still be outdated, resync all nodes to update
 	// metrics.
 	mngr.Resync(t.Context(), time.Now())
 

--- a/operator/pkg/ipam/nodewatcher.go
+++ b/operator/pkg/ipam/nodewatcher.go
@@ -59,7 +59,7 @@ func newNodeWatcherJobFactory(
 func watchCiliumNodes(ctx context.Context, ciliumNodes resource.Resource[*cilium_api_v2.CiliumNode], handler allocator.NodeEventHandler, withResync bool) {
 	// We will use CiliumNodes as the source of truth for the podCIDRs.
 	// Once the CiliumNodes are synchronized with the operator we will
-	// be able to watch for K8s Node events which they will be used
+	// be able to watch for K8s Node events which will be used
 	// to create the remaining CiliumNodes.
 	for ev := range ciliumNodes.Events(ctx) {
 		switch ev.Kind {

--- a/operator/pkg/ipam/podcidroverlap_test.go
+++ b/operator/pkg/ipam/podcidroverlap_test.go
@@ -29,7 +29,7 @@ import (
 // TestPodCIDRAllocatorOverlap tests that, on startup all nodes with assigned podCIDRs are processed so that nodes
 // without pod CIDRs will not get the same CIDR ranges assigned as existing nodes.
 func TestPodCIDRAllocatorOverlap(t *testing.T) {
-	// We need to run the test multiple times since we are testing a race condition which is dependant on the order
+	// We need to run the test multiple times since we are testing a race condition which is dependent on the order
 	// of a hash map.
 	for i := range 5 {
 		fmt.Printf("Run %d/5\n", i+1)

--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -41,14 +41,14 @@ func (ipam *IPAM) determineIPAMPool(owner string, family Family) (Pool, error) {
 	return Pool(pool), nil
 }
 
-// AllocateIP allocates a IP address.
+// AllocateIP allocates an IP address.
 func (ipam *IPAM) AllocateIP(ip net.IP, owner string, pool Pool) error {
 	needSyncUpstream := true
 	_, err := ipam.allocateIP(ip, owner, pool, needSyncUpstream)
 	return err
 }
 
-// AllocateIPWithoutSyncUpstream allocates a IP address without syncing upstream.
+// AllocateIPWithoutSyncUpstream allocates an IP address without syncing upstream.
 func (ipam *IPAM) AllocateIPWithoutSyncUpstream(ip net.IP, owner string, pool Pool) (*AllocationResult, error) {
 	needSyncUpstream := false
 	return ipam.allocateIP(ip, owner, pool, needSyncUpstream)
@@ -345,7 +345,7 @@ func (ipam *IPAM) releaseIPLocked(ip net.IP, pool Pool) error {
 	return nil
 }
 
-// ReleaseIP release a IP address. The pool argument must not be empty, it
+// ReleaseIP releases an IP address. The pool argument must not be empty, it
 // must be set to the pool name returned by the `Allocate*` functions when
 // the IP was allocated.
 func (ipam *IPAM) ReleaseIP(ip net.IP, pool Pool) error {

--- a/pkg/ipam/api/ipam_api_handler.go
+++ b/pkg/ipam/api/ipam_api_handler.go
@@ -135,7 +135,7 @@ func (r *IpamPostIpamHandler) getNodeRouterAddressing(ctx context.Context) (*mod
 	return nodeRouterAddressing, nil
 }
 
-// Handle incoming requests address allocation requests for the daemon.
+// Handle incoming address allocation requests for the daemon.
 func (r *IpamPostIpamIPHandler) Handle(params ipamapi.PostIpamIPParams) middleware.Responder {
 	owner := swag.StringValue(params.Owner)
 	pool := ipam.Pool(swag.StringValue(params.Pool))

--- a/pkg/ipam/cidrset/cidr_set.go
+++ b/pkg/ipam/cidrset/cidr_set.go
@@ -18,7 +18,7 @@ import (
 )
 
 // CidrSet manages a set of CIDR ranges from which blocks of IPs can
-// be allocated from.
+// be allocated.
 type CidrSet struct {
 	lock.Mutex
 	// clusterPrefix is the CIDR assigned to the cluster.
@@ -124,7 +124,7 @@ func (s *CidrSet) indexToCIDRBlock(index int) netip.Prefix {
 				leftClusterIP |= uint64(index) >> btl
 			}
 		}
-		// the right side will be calculated the same way either the
+		// the right side will be calculated the same way since the
 		// subNetMaskSize affects both left and right sides
 		rightClusterIP |= uint64(index) << uint(ipv6Bits-s.nodeMaskSize)
 	}

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -659,7 +659,7 @@ type crdAllocator struct {
 	// represented as string
 	allocated ipamTypes.AllocationMap
 
-	// family is the address family this allocator is allocator for
+	// family is the address family this allocator is allocating for
 	family Family
 
 	conf        *option.DaemonConfig
@@ -925,7 +925,7 @@ func (a *crdAllocator) RestoreFinished() {
 	})
 }
 
-// NewIPNotAvailableInPoolError returns an error resprenting the given IP not
+// NewIPNotAvailableInPoolError returns an error representing the given IP not
 // being available in the IPAM pool.
 func NewIPNotAvailableInPoolError(addr netip.Addr) error {
 	return &ErrIPNotAvailableInPool{addr: addr}

--- a/pkg/ipam/eni.go
+++ b/pkg/ipam/eni.go
@@ -434,7 +434,7 @@ func configureENINetlinkDevice(link netlink.Link, cfg eniDeviceConfig, sysctl sy
 		}
 
 		// Remove the subnet route for this ENI if it got setup by something(like networkd),
-		// as it can cause the traffic to following subnet route using secondary ENI as the outgoing interface.
+		// as it can cause traffic to follow the subnet route using secondary ENI as the outgoing interface.
 		// The Cilium could consider the wrong identity for the node and might drop
 		// the traffic between the host and pods when network policy is in place.
 		err = netlink.RouteDel(&netlink.Route{

--- a/pkg/ipam/multipool_manager.go
+++ b/pkg/ipam/multipool_manager.go
@@ -214,7 +214,7 @@ func (p pendingAllocationsPerOwner) removeExpiredEntries(logger *slog.Logger, no
 	}
 }
 
-// pendingForPool returns how many IP allocations are pending for the given family
+// pendingForFamily returns how many IP allocations are pending for the given family
 func (p pendingAllocationsPerOwner) pendingForFamily(family Family) int {
 	return len(p[family])
 }
@@ -435,7 +435,7 @@ func (m *multiPoolManager) localNodeUpdated() <-chan struct{} {
 //	numIP 16 -> 32
 //	numIP 17 -> 48
 //
-// This always ensures that there we always have a buffer of at least preAlloc
+// This ensures that we always have a buffer of at least preAlloc
 // IPs.
 func neededIPCeil(numIP int, preAlloc int) int {
 	if preAlloc == 0 {

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -118,7 +118,7 @@ type IPAM struct {
 	// mutex covers access to all members of this struct
 	allocatorMutex lock.RWMutex
 
-	// excludedIPS contains excluded IPs and their respective owners per pool. The key is a
+	// excludedIPs contains excluded IPs and their respective owners per pool. The key is a
 	// combination pool:ip to avoid having to maintain a map of maps.
 	excludedIPs map[string]string
 

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -158,7 +158,7 @@ type IPAMSpec struct {
 	MaxAllocate int `json:"max-allocate,omitempty"`
 
 	// PreAllocate defines the number of IP addresses that must be
-	// available for allocation in the IPAMspec. It defines the buffer of
+	// available for allocation in the IPAMSpec. It defines the buffer of
 	// addresses available immediately without requiring cilium-operator to
 	// get involved.
 	//
@@ -240,8 +240,8 @@ type IPAMStatus struct {
 	AssignedStaticIP string `json:"assigned-static-ip,omitempty"`
 }
 
-// IPAMPoolRequest is a request from the agent to the operator, indicating how
-// may IPs it requires from a given pool
+// IPAMPoolDemand is a request from the agent to the operator, indicating how
+// many IPs it requires from a given pool
 type IPAMPoolDemand struct {
 	// IPv4Addrs contains the number of requested IPv4 addresses out of a given
 	// pool

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -418,7 +418,7 @@ spec:
                   pre-allocate:
                     description: |-
                       PreAllocate defines the number of IP addresses that must be
-                      available for allocation in the IPAMspec. It defines the buffer of
+                      available for allocation in the IPAMSpec. It defines the buffer of
                       addresses available immediately without requiring cilium-operator to
                       get involved.
                     minimum: 0


### PR DESCRIPTION
Fix spelling, grammar and wrong type/function references in doc comments and logs across the ipam packages.