### PR TITLE
.github: Lint Envoy on trusted branch

### DIFF
--- a/.github/workflows/lint-images-base.yaml
+++ b/.github/workflows/lint-images-base.yaml
@@ -103,7 +103,7 @@ jobs:
           args: -C untrusted/images check-runtime-image RUNTIME_IMAGE=${{ env.CILIUM_RUNTIME_IMAGE }}
 
       - name: Check Cilium Envoy image
-        run: make -C untrusted/images check-envoy-image
+        run: make -C images check-envoy-image
 
   merge-upload-and-status:
     name: Merge Upload and Status


### PR DESCRIPTION
Lint Envoy using the scripts from the trusted branch, like was done
before commit 29c832727dad ("ci: handle pull_request workflows by ariane").

Fixes: 29c832727dad ("ci: handle pull_request workflows by ariane")
