### PR TITLE
.github/workflows: fix envoy image check path after trusted/untrusted…

### DIFF
--- a/.github/workflows/lint-images-base.yaml
+++ b/.github/workflows/lint-images-base.yaml
@@ -103,7 +103,7 @@ jobs:
           args: -C untrusted/images check-runtime-image RUNTIME_IMAGE=${{ env.CILIUM_RUNTIME_IMAGE }}
 
       - name: Check Cilium Envoy image
-        run: make -C images check-envoy-image
+        run: make -C trusted/images check-envoy-image
 
   merge-upload-and-status:
     name: Merge Upload and Status


### PR DESCRIPTION
… split

The 'Check Cilium Envoy image' step still invoked 'make -C images check-envoy-image', but the images directory was split into trusted/ and untrusted/ subdirectories, causing the step to fail.

Point the make invocation at trusted/images, consistent with the runtime image checks above.

Fixes: 23f5f6494d44 (".github: Lint Envoy on trusted branch")