### PR TITLE
renovate: do not pinDigest for golangci/golangci-lint

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -141,6 +141,23 @@
       "pinDigests": false
     },
     {
+      // Do not pin digests for the golangci/golangci-lint dependency that the
+      // github-actions manager auto-extracts from the 'version:' input of the
+      // golangci/golangci-lint-action step. A plain 'version: vX.Y.Z' value has
+      // nowhere to store a commit SHA, so Renovate can never apply the digest
+      // pin and the whole grouped branch fails with "update failure". The
+      // version itself is still tracked through the
+      // 'datasource=docker depName=golangci/golangci-lint' comment handled by
+      // the custom regex manager.
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchPackageNames": [
+        "golangci/golangci-lint"
+      ],
+      "pinDigests": false
+    },
+    {
       "matchPackageNames": [
         "bufbuild/buf", // Protocol buffer toolkit
         "docker.io/alpine/socat", // Alpine socat package


### PR DESCRIPTION
The github-actions manager auto-extracts the "version:" input of the
golangci/golangci-lint-action step as a github-releases
"golangci/golangci-lint" dependency. With "pinDigests: true" Renovate
tries to pin it to a commit SHA, but a plain "version: vX.Y.Z" value has
nowhere to store a digest, so the update can never be applied. Renovate
fails with "Error updating branch: update failure" and, since the
dependency is grouped into the all-dependencies branch, every other bump
in that branch (e.g. the docker.io/library/ubuntu base image) is dropped
as well.

The golangci-lint version is already tracked through the
"datasource=docker depName=golangci/golangci-lint" comment handled by the
custom regex manager, so disable digest pinning for the github-actions
occurrence only.

Fixes: e0b87040a0d1 ("renovate: allow golangci-lint to be automatically updated")