### PR TITLE
Reapply ".github/workflows: do not use deployments for environments"

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -26,7 +26,9 @@ jobs:
   approve:
     name: Approve
     needs: pre-approve
-    environment: auto-approve
+    environment:
+      name: auto-approve
+      deployment: false
     runs-on: ubuntu-24.04
     permissions: {}
     steps:

--- a/.github/workflows/build-images-base-v1.17.yaml
+++ b/.github/workflows/build-images-base-v1.17.yaml
@@ -27,7 +27,13 @@ jobs:
   has-credentials:
     name: Check for Quay secrets
     runs-on: ubuntu-24.04
-    environment: 'release-base-images'
+    # No 'inputs.environment' here: this workflow has no 'workflow_call' trigger
+    # (it only runs on pull_request_target). The reusable workflow_call variant
+    # that wires 'inputs.environment' only exists on the stable branches, so the
+    # environment is hardcoded to 'release-base-images'.
+    environment:
+      name: 'release-base-images'
+      deployment: false
     timeout-minutes: 2
     outputs:
       present: ${{ steps.secrets.outputs.present }}
@@ -46,7 +52,13 @@ jobs:
     if: ${{ needs.has-credentials.outputs.present && ! (github.event_name == 'pull_request_target' && startsWith(github.head_ref, 'renovate/')) }}
     name: Build and Push Images
     timeout-minutes: 60
-    environment: 'release-base-images'
+    # No 'inputs.environment' here: this workflow has no 'workflow_call' trigger
+    # (it only runs on pull_request_target). The reusable workflow_call variant
+    # that wires 'inputs.environment' only exists on the stable branches, so the
+    # environment is hardcoded to 'release-base-images'.
+    environment:
+      name: 'release-base-images'
+      deployment: false
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout default branch (trusted)
@@ -326,7 +338,13 @@ jobs:
   image-digests:
     name: Display Digests
     runs-on: ubuntu-24.04
-    environment: 'release-base-images'
+    # No 'inputs.environment' here: this workflow has no 'workflow_call' trigger
+    # (it only runs on pull_request_target). The reusable workflow_call variant
+    # that wires 'inputs.environment' only exists on the stable branches, so the
+    # environment is hardcoded to 'release-base-images'.
+    environment:
+      name: 'release-base-images'
+      deployment: false
     needs: build-and-push
     steps:
       - name: Downloading Image Digests

--- a/.github/workflows/build-images-base-v1.18.yaml
+++ b/.github/workflows/build-images-base-v1.18.yaml
@@ -29,7 +29,13 @@ jobs:
     if: ${{ vars.QUAY_BASE_RELEASE_ENABLED == 'true' && ! (github.event_name == 'pull_request_target' && startsWith(github.head_ref, 'renovate/')) }}
     name: Build and Push Images
     timeout-minutes: 60
-    environment: 'release-base-images'
+    # No 'inputs.environment' here: this workflow has no 'workflow_call' trigger
+    # (it only runs on pull_request_target). The reusable workflow_call variant
+    # that wires 'inputs.environment' only exists on the stable branches, so the
+    # environment is hardcoded to 'release-base-images'.
+    environment:
+      name: 'release-base-images'
+      deployment: false
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout base or default branch (trusted)

--- a/.github/workflows/build-images-base-v1.19.yaml
+++ b/.github/workflows/build-images-base-v1.19.yaml
@@ -29,7 +29,13 @@ jobs:
     if: ${{ vars.QUAY_BASE_RELEASE_ENABLED == 'true' && ! (github.event_name == 'pull_request_target' && startsWith(github.head_ref, 'renovate/')) }}
     name: Build and Push Images
     timeout-minutes: 60
-    environment: 'release-base-images'
+    # No 'inputs.environment' here: this workflow has no 'workflow_call' trigger
+    # (it only runs on pull_request_target). The reusable workflow_call variant
+    # that wires 'inputs.environment' only exists on the stable branches, so the
+    # environment is hardcoded to 'release-base-images'.
+    environment:
+      name: 'release-base-images'
+      deployment: false
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout base or default branch (trusted)

--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -48,7 +48,9 @@ jobs:
     if: ${{ vars.QUAY_BASE_RELEASE_ENABLED == 'true' && ! (github.event_name == 'pull_request_target' && startsWith(github.head_ref, 'renovate/')) }}
     name: Build and Push Images
     timeout-minutes: 60
-    environment: ${{ inputs.environment || 'release-base-images' }}
+    environment:
+      name: ${{ inputs.environment || 'release-base-images' }}
+      deployment: false
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout base or default branch (trusted)

--- a/.github/workflows/build-images-beta.yaml
+++ b/.github/workflows/build-images-beta.yaml
@@ -30,7 +30,9 @@ jobs:
   build-and-push:
     timeout-minutes: 45
     name: Build and Push Images
-    environment: release-beta-images
+    environment:
+      name: release-beta-images
+      deployment: false
     runs-on: ubuntu-24.04
     strategy:
       matrix:

--- a/.github/workflows/build-images-ci-v1.17.yaml
+++ b/.github/workflows/build-images-ci-v1.17.yaml
@@ -418,7 +418,9 @@ jobs:
     name: Post test comment for Renovate PRs after images built
     runs-on: ubuntu-24.04
     needs: pre-comment
-    environment: "Trigger CI from renovate PRs"
+    environment:
+      name: "Trigger CI from renovate PRs"
+      deployment: false
     if: ${{
          github.event_name == 'pull_request_target' &&
          github.event.pull_request.user.login == vars.RENOVATE_BOT_USERNAME

--- a/.github/workflows/build-images-ci-v1.18.yaml
+++ b/.github/workflows/build-images-ci-v1.18.yaml
@@ -444,7 +444,9 @@ jobs:
     name: Post test comment for Renovate PRs after images built
     runs-on: ubuntu-24.04
     needs: pre-comment
-    environment: "Trigger CI from renovate PRs"
+    environment:
+      name: "Trigger CI from renovate PRs"
+      deployment: false
     if: ${{
          github.event_name == 'pull_request_target' &&
          github.event.pull_request.user.login == vars.RENOVATE_BOT_USERNAME

--- a/.github/workflows/build-images-ci-v1.19.yaml
+++ b/.github/workflows/build-images-ci-v1.19.yaml
@@ -421,7 +421,9 @@ jobs:
     name: Post test comment for Renovate PRs after images built
     runs-on: ubuntu-24.04
     needs: pre-comment
-    environment: "Trigger CI from renovate PRs"
+    environment:
+      name: "Trigger CI from renovate PRs"
+      deployment: false
     if: ${{
          github.event_name == 'pull_request_target' &&
          github.event.pull_request.user.login == vars.RENOVATE_BOT_USERNAME

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -425,7 +425,9 @@ jobs:
     name: Post test comment for Renovate PRs after images built
     runs-on: ubuntu-24.04
     needs: pre-comment
-    environment: "Trigger CI from renovate PRs"
+    environment:
+      name: "Trigger CI from renovate PRs"
+      deployment: false
     if: ${{
          github.event_name == 'pull_request_target' &&
          github.event.pull_request.user.login == vars.RENOVATE_BOT_USERNAME

--- a/.github/workflows/build-images-docs-builder-v1.17.yaml
+++ b/.github/workflows/build-images-docs-builder-v1.17.yaml
@@ -27,7 +27,9 @@ jobs:
     name: Build and Push Image
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment: docs-builder
+    environment:
+      name: docs-builder
+      deployment: false
     outputs:
       tag: ${{ steps.docs-builder-tag.outputs.tag }}
       digest: ${{ steps.docker-build-docs-builder.outputs.digest }}

--- a/.github/workflows/build-images-docs-builder-v1.18.yaml
+++ b/.github/workflows/build-images-docs-builder-v1.18.yaml
@@ -27,7 +27,9 @@ jobs:
     name: Build and Push Image
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment: docs-builder
+    environment:
+      name: docs-builder
+      deployment: false
     outputs:
       tag: ${{ steps.docs-builder-tag.outputs.tag }}
       digest: ${{ steps.docker-build-docs-builder.outputs.digest }}

--- a/.github/workflows/build-images-docs-builder-v1.19.yaml
+++ b/.github/workflows/build-images-docs-builder-v1.19.yaml
@@ -27,7 +27,9 @@ jobs:
     name: Build and Push Image
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment: docs-builder
+    environment:
+      name: docs-builder
+      deployment: false
     outputs:
       tag: ${{ steps.docs-builder-tag.outputs.tag }}
       digest: ${{ steps.docker-build-docs-builder.outputs.digest }}

--- a/.github/workflows/build-images-docs-builder.yaml
+++ b/.github/workflows/build-images-docs-builder.yaml
@@ -28,7 +28,9 @@ jobs:
     name: Build and Push Image
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment: docs-builder
+    environment:
+      name: docs-builder
+      deployment: false
     outputs:
       tag: ${{ steps.docs-builder-tag.outputs.tag }}
       digest: ${{ steps.docker-build-docs-builder.outputs.digest }}
@@ -103,7 +105,6 @@ jobs:
     if: needs.build-and-push.outputs.digest
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    environment: docs-builder
     steps:
       - name: Checkout base branch (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -16,7 +16,9 @@ jobs:
   build-and-push:
     timeout-minutes: 45
     name: Build and Push Images
-    environment: release
+    environment:
+      name: release
+      deployment: false
     runs-on: ubuntu-24.04
     strategy:
       matrix:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,9 @@ jobs:
   release:
     name: Release
     if: ${{ inputs.step != '5-publish-helm' }}
-    environment: release-tool
+    environment:
+      name: release-tool
+      deployment: false
     timeout-minutes: 40
     runs-on: ubuntu-24.04
     steps:
@@ -120,7 +122,9 @@ jobs:
   release-helm:
     name: Release Helm
     if: ${{ inputs.step == '5-publish-helm' }}
-    environment: release-helm
+    environment:
+      name: release-helm
+      deployment: false
     timeout-minutes: 40
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
This reverts commit 83a928a8ff22014aa4170346950bdcb298a3da3d.

The auto-approve builds for Renovate PRs were not failing because of "deployment: false". They were failing because the base image build used a hardcoded "release-base-images" environment, which needs a manual deployment approval, instead of the environment input passed by the Renovate workflow. Now that the input is used again, bring back "deployment: false" so these jobs stop creating a deployment on every run.