### PR TITLE
hubble: count ring-buffer lost events on forward reads only

### DIFF
--- a/pkg/hubble/container/ring.go
+++ b/pkg/hubble/container/ring.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strings"
 	"sync/atomic"
 	"unsafe"
 
@@ -16,7 +15,6 @@ import (
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	"github.com/cilium/cilium/pkg/hubble/math"
-	"github.com/cilium/cilium/pkg/hubble/metrics"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -217,7 +215,6 @@ func (r *Ring) OldestWrite() uint64 {
 }
 
 func getLostEvent() *v1.Event {
-	metrics.LostEvents.WithLabelValues(strings.ToLower(flowpb.LostEventSource_HUBBLE_RING_BUFFER.String())).Inc()
 	now := time.Now().UTC()
 	return &v1.Event{
 		Timestamp: &timestamppb.Timestamp{

--- a/pkg/hubble/container/ring_reader.go
+++ b/pkg/hubble/container/ring_reader.go
@@ -5,9 +5,12 @@ package container
 
 import (
 	"context"
+	"strings"
 	"sync"
 
+	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/metrics"
 	"github.com/cilium/cilium/pkg/lock"
 )
 
@@ -67,6 +70,10 @@ func (r *RingReader) Next() (*v1.Event, error) {
 		return nil, err
 	}
 	r.idx++
+	if lost, ok := e.Event.(*flowpb.LostEvent); ok && lost.Source == flowpb.LostEventSource_HUBBLE_RING_BUFFER {
+		// count hubble_ring_buffer lost events
+		metrics.LostEvents.WithLabelValues(strings.ToLower(flowpb.LostEventSource_HUBBLE_RING_BUFFER.String())).Inc()
+	}
 	return e, nil
 }
 
@@ -115,6 +122,10 @@ func (r *RingReader) NextFollow(ctx context.Context) *v1.Event {
 		// increment idx so that future calls to the ring reader will
 		// continue reading from were we stopped.
 		r.idx++
+		if lost, ok := e.Event.(*flowpb.LostEvent); ok && lost.Source == flowpb.LostEventSource_HUBBLE_RING_BUFFER {
+			// count hubble_ring_buffer lost events
+			metrics.LostEvents.WithLabelValues(strings.ToLower(flowpb.LostEventSource_HUBBLE_RING_BUFFER.String())).Inc()
+		}
 		return e
 	case <-ctx.Done():
 		return nil


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

---
<!-- Description of change -->

The `hubble_ring_buffer` lost events metric was incremented whenever a reader reached the ring buffer boundary. However, reaching the boundary does not always mean events were actually lost. Hitting the boundary in backward scans is an expected stop condition rather than a real loss.

This PR moves the metric count from the producer (ring.getLostEvent) to the consumer's forward-reading paths (RingReader.Next/NextFollow). The metric is now counted only when a consumer actually catches a lost event.
Normal ring scans no longer count the metric when they expectedly reach that boundary.

Fixes: #46584

```release-note
hubble: Fixed false-positive increments of the `hubble_ring_buffer` lost events metric.
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
