### PR TITLE
sysdump: contain bugtool archive extraction to destination dir

### DIFF
--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -2450,6 +2450,9 @@ func untar(src string, dst string) error {
 			return err
 		}
 		filename := filepath.Join(dst, name)
+		if !strings.HasPrefix(filename, filepath.Clean(dst)+string(os.PathSeparator)) {
+			return fmt.Errorf("file path escapes destination directory: %s", filename)
+		}
 		directory := filepath.Dir(filename)
 		if err := os.MkdirAll(directory, 0755); err != nil {
 			return err

--- a/cilium-cli/sysdump/untar_test.go
+++ b/cilium-cli/sysdump/untar_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package sysdump
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeTarGz(t *testing.T, entries map[string]string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, content := range entries {
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Name:     name,
+			Mode:     0644,
+			Size:     int64(len(content)),
+			Typeflag: tar.TypeReg,
+		}))
+		_, err := tw.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+
+	src := filepath.Join(t.TempDir(), "archive.tar.gz")
+	require.NoError(t, os.WriteFile(src, buf.Bytes(), 0644))
+	return src
+}
+
+func TestUntar(t *testing.T) {
+	t.Run("extracts regular files under the top directory", func(t *testing.T) {
+		src := writeTarGz(t, map[string]string{"top/sub/file.txt": "ok"})
+		dst := t.TempDir()
+		require.NoError(t, untar(src, dst))
+
+		got, err := os.ReadFile(filepath.Join(dst, "sub", "file.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, "ok", string(got))
+	})
+
+	t.Run("rejects entries that escape the destination", func(t *testing.T) {
+		// removeTopDirectory turns "top/../escape.txt" into "../escape.txt",
+		// which would resolve outside dst.
+		src := writeTarGz(t, map[string]string{"top/../escape.txt": "owned"})
+		root := t.TempDir()
+		dst := filepath.Join(root, "out")
+		require.NoError(t, os.MkdirAll(dst, 0755))
+
+		assert.Error(t, untar(src, dst))
+		_, err := os.Stat(filepath.Join(root, "escape.txt"))
+		assert.True(t, os.IsNotExist(err), "no file should be written outside dst")
+	})
+}


### PR DESCRIPTION
- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title
      and description.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

untar handles the cilium-bugtool and tetragon-bugtool tar.gz files that are produced by running the bugtool inside a target pod and then copied back to the host running `cilium sysdump`, so the archive contents are controlled by the pod rather than the CLI.

- entry names are joined to the destination with filepath.Join but never checked for containment
- removeTopDirectory only strips the leading path component, so `top/../../x` survives as `../../x` and resolves outside the destination
- a crafted bugtool archive can then write files anywhere the user running sysdump can write

extractZip in cilium-cli/features already guards this case; applied the same prefix check in untar and added a regression test covering a normal archive and an escaping entry.

```release-note
sysdump: reject tar entries that escape the destination directory when extracting bugtool archives
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
