### PR TITLE
ipam: Migrate `IPAMSpec.PodCIDRs` to `ip.Prefix`

### DIFF
--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -693,7 +693,7 @@ func (ct *ConnectivityTest) detectPodCIDRs() {
 		hostIPs := pod.Pod.Status.PodIPs
 
 		for _, cidr := range n.Spec.IPAM.PodCIDRs {
-			ct.params.PodCIDRs = append(ct.params.PodCIDRs, toPodCIDRs(cidr, hostIPs...)...)
+			ct.params.PodCIDRs = append(ct.params.PodCIDRs, toPodCIDRs(cidr.String(), hostIPs...)...)
 		}
 
 		// additional IP pools from multi-pool IPAM mode

--- a/operator/pkg/ipam/allocator/multipool/migration_test.go
+++ b/operator/pkg/ipam/allocator/multipool/migration_test.go
@@ -45,7 +45,10 @@ func TestMigrateNode(t *testing.T) {
 			},
 			Spec: v2.NodeSpec{
 				IPAM: ipamTypes.IPAMSpec{
-					PodCIDRs: []string{"10.0.0.0/24", "fd00::/124"},
+					PodCIDRs: []iputil.Prefix{
+						iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.0/24")),
+						iputil.PrefixFrom(netip.MustParsePrefix("fd00::/124")),
+					},
 				},
 			},
 		}
@@ -77,7 +80,10 @@ func TestMigrateNode(t *testing.T) {
 			},
 			Spec: v2.NodeSpec{
 				IPAM: ipamTypes.IPAMSpec{
-					PodCIDRs: []string{"10.0.0.0/24", "fd00::/124"},
+					PodCIDRs: []iputil.Prefix{
+						iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.0/24")),
+						iputil.PrefixFrom(netip.MustParsePrefix("fd00::/124")),
+					},
 				},
 			},
 		}
@@ -129,7 +135,10 @@ func TestMigrateNode(t *testing.T) {
 			},
 			Spec: v2.NodeSpec{
 				IPAM: ipamTypes.IPAMSpec{
-					PodCIDRs: []string{"10.0.0.0/24", "fd00::/124"},
+					PodCIDRs: []iputil.Prefix{
+						iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.0/24")),
+						iputil.PrefixFrom(netip.MustParsePrefix("fd00::/124")),
+					},
 				},
 			},
 		}
@@ -191,7 +200,10 @@ func TestMigrateNode(t *testing.T) {
 			},
 			Spec: v2.NodeSpec{
 				IPAM: ipamTypes.IPAMSpec{
-					PodCIDRs: []string{"10.0.0.0/24", "fd00::/124"},
+					PodCIDRs: []iputil.Prefix{
+						iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.0/24")),
+						iputil.PrefixFrom(netip.MustParsePrefix("fd00::/124")),
+					},
 				},
 			},
 		}

--- a/operator/pkg/ipam/allocator/multipool/multipool.go
+++ b/operator/pkg/ipam/allocator/multipool/multipool.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net/netip"
 	"time"
 
 	"github.com/cilium/hive/cell"
@@ -21,7 +20,6 @@ import (
 
 	allocatorTypes "github.com/cilium/cilium/operator/pkg/ipam/allocator"
 	"github.com/cilium/cilium/pkg/defaults"
-	iputil "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipam"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/ipam/types"
@@ -256,19 +254,11 @@ func migrateNode(
 			}
 
 			newNode := node.DeepCopy()
-			cidrs := make([]iputil.Prefix, 0, len(node.Spec.IPAM.PodCIDRs))
-			for _, cidr := range node.Spec.IPAM.PodCIDRs {
-				prefix, err := netip.ParsePrefix(cidr)
-				if err != nil {
-					return true, false, fmt.Errorf("unable to parse CIDR %q: %w", cidr, err)
-				}
-				cidrs = append(cidrs, iputil.PrefixFrom(prefix))
-			}
 			newNode.Spec.IPAM.Pools = types.IPAMPoolSpec{
 				Allocated: []types.IPAMPoolAllocation{
 					{
 						Pool:  pool,
-						CIDRs: cidrs,
+						CIDRs: newNode.Spec.IPAM.PodCIDRs,
 					},
 				},
 			}

--- a/operator/pkg/ipam/allocator/podcidr/podcidr.go
+++ b/operator/pkg/ipam/allocator/podcidr/podcidr.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/cilium/operator/pkg/ipam/allocator"
 	"github.com/cilium/cilium/operator/pkg/ipam/allocator/clusterpool/cidralloc"
 	"github.com/cilium/cilium/pkg/controller"
+	iputil "github.com/cilium/cilium/pkg/ip"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -88,23 +89,20 @@ func (e ErrNoAllocators) Error() string {
 	)
 }
 
-// parsePodCIDRs will return the v4 and v6 CIDRs found in the podCIDRs.
-// Returns an error in case one of the CIDRs are not valid.
-func parsePodCIDRs(podCIDRs []string) (*nodeCIDRs, error) {
+// splitPodCIDRs splits podCIDRs into masked v4 and v6 prefixes. The prefixes are
+// already parsed and validated at the CRD boundary, so this only needs to mask
+// and sort them by family.
+func splitPodCIDRs(podCIDRs []iputil.Prefix) *nodeCIDRs {
 	var cidrs nodeCIDRs
 	for _, podCIDR := range podCIDRs {
-		prefix, err := netip.ParsePrefix(podCIDR)
-		if err != nil {
-			return nil, err
-		}
-		prefix = prefix.Masked()
+		prefix := podCIDR.Masked()
 		if prefix.Addr().Is4() {
 			cidrs.v4PodCIDRs = append(cidrs.v4PodCIDRs, prefix)
 		} else {
 			cidrs.v6PodCIDRs = append(cidrs.v6PodCIDRs, prefix)
 		}
 	}
-	return &cidrs, nil
+	return &cidrs
 }
 
 // nodeCIDRs is a wrapper that contains all the podCIDRs a node can have.
@@ -458,12 +456,12 @@ func (n *NodesPodCIDRManager) allocateNode(node *v2.CiliumNode) (cn *v2.CiliumNo
 			// rebuild the spec to match. upsertLocked will detect the
 			// change and issue a k8sOpUpdate.
 			if nodeCIDRs, ok := n.nodes[node.Name]; ok {
-				cn.Spec.IPAM.PodCIDRs = make([]string, 0, len(nodeCIDRs.v4PodCIDRs)+len(nodeCIDRs.v6PodCIDRs))
+				cn.Spec.IPAM.PodCIDRs = make([]iputil.Prefix, 0, len(nodeCIDRs.v4PodCIDRs)+len(nodeCIDRs.v6PodCIDRs))
 				for _, p := range nodeCIDRs.v4PodCIDRs {
-					cn.Spec.IPAM.PodCIDRs = append(cn.Spec.IPAM.PodCIDRs, p.String())
+					cn.Spec.IPAM.PodCIDRs = append(cn.Spec.IPAM.PodCIDRs, iputil.PrefixFrom(p))
 				}
 				for _, p := range nodeCIDRs.v6PodCIDRs {
-					cn.Spec.IPAM.PodCIDRs = append(cn.Spec.IPAM.PodCIDRs, p.String())
+					cn.Spec.IPAM.PodCIDRs = append(cn.Spec.IPAM.PodCIDRs, iputil.PrefixFrom(p))
 				}
 			}
 			err = nil
@@ -495,12 +493,7 @@ func (n *NodesPodCIDRManager) allocateNode(node *v2.CiliumNode) (cn *v2.CiliumNo
 			logfields.Allocated, allocated,
 		)
 	} else {
-		cidrs, err = parsePodCIDRs(node.Spec.IPAM.PodCIDRs)
-		if err != nil {
-			// We want to log this error in cilium node
-			updateStatus = true
-			return
-		}
+		cidrs = splitPodCIDRs(node.Spec.IPAM.PodCIDRs)
 		// Try to allocate the podCIDRs in the node, if there was a need
 		// for new CIDRs to be allocated the allocated returned value will be
 		// set to true.
@@ -539,13 +532,13 @@ func (n *NodesPodCIDRManager) allocateNode(node *v2.CiliumNode) (cn *v2.CiliumNo
 
 	cn = node.DeepCopy()
 
-	cn.Spec.IPAM.PodCIDRs = make([]string, 0, len(cidrs.v4PodCIDRs)+len(cidrs.v6PodCIDRs))
+	cn.Spec.IPAM.PodCIDRs = make([]iputil.Prefix, 0, len(cidrs.v4PodCIDRs)+len(cidrs.v6PodCIDRs))
 
 	for _, v4CIDR := range cidrs.v4PodCIDRs {
-		cn.Spec.IPAM.PodCIDRs = append(cn.Spec.IPAM.PodCIDRs, v4CIDR.String())
+		cn.Spec.IPAM.PodCIDRs = append(cn.Spec.IPAM.PodCIDRs, iputil.PrefixFrom(v4CIDR))
 	}
 	for _, v6CIDR := range cidrs.v6PodCIDRs {
-		cn.Spec.IPAM.PodCIDRs = append(cn.Spec.IPAM.PodCIDRs, v6CIDR.String())
+		cn.Spec.IPAM.PodCIDRs = append(cn.Spec.IPAM.PodCIDRs, iputil.PrefixFrom(v6CIDR))
 	}
 
 	cn.Status.IPAM.OperatorStatus.Error = ""

--- a/operator/pkg/ipam/allocator/podcidr/podcidr_test.go
+++ b/operator/pkg/ipam/allocator/podcidr/podcidr_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cilium/cilium/operator/pkg/ipam/allocator/clusterpool/cidralloc"
 	"github.com/cilium/cilium/pkg/controller"
+	iputil "github.com/cilium/cilium/pkg/ip"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/trigger"
@@ -27,6 +28,16 @@ func mustNewCIDRs(cidrs ...string) []netip.Prefix {
 	prefixes := make([]netip.Prefix, 0, len(cidrs))
 	for _, cidr := range cidrs {
 		prefixes = append(prefixes, netip.MustParsePrefix(cidr).Masked())
+	}
+	return prefixes
+}
+
+// mustNewIPPrefixes wraps each CIDR in an ip.Prefix, preserving any host bits
+// (as they would appear on the wire) so callers can exercise the masking logic.
+func mustNewIPPrefixes(cidrs ...string) []iputil.Prefix {
+	prefixes := make([]iputil.Prefix, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		prefixes = append(prefixes, iputil.PrefixFrom(netip.MustParsePrefix(cidr)))
 	}
 	return prefixes
 }
@@ -355,9 +366,7 @@ func TestNodesPodCIDRManager_Upsert(t *testing.T) {
 							},
 							Spec: v2.NodeSpec{
 								IPAM: ipamTypes.IPAMSpec{
-									PodCIDRs: []string{
-										"10.10.0.0/24",
-									},
+									PodCIDRs: mustNewIPPrefixes("10.10.0.0/24"),
 								},
 							},
 						},
@@ -462,9 +471,7 @@ func TestNodesPodCIDRManager_Upsert(t *testing.T) {
 					},
 					Spec: v2.NodeSpec{
 						IPAM: ipamTypes.IPAMSpec{
-							PodCIDRs: []string{
-								"10.10.0.0/24",
-							},
+							PodCIDRs: mustNewIPPrefixes("10.10.0.0/24"),
 						},
 					},
 				},
@@ -500,9 +507,7 @@ func TestNodesPodCIDRManager_Upsert(t *testing.T) {
 							},
 							Spec: v2.NodeSpec{
 								IPAM: ipamTypes.IPAMSpec{
-									PodCIDRs: []string{
-										"10.10.0.0/24",
-									},
+									PodCIDRs: mustNewIPPrefixes("10.10.0.0/24"),
 								},
 							},
 						},
@@ -1390,94 +1395,64 @@ func TestNodesPodCIDRManager_releaseIPNets(t *testing.T) {
 	}
 }
 
-func Test_parsePodCIDRs(t *testing.T) {
+func Test_splitPodCIDRs(t *testing.T) {
 	type args struct {
-		podCIDRs []string
+		podCIDRs []iputil.Prefix
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    *nodeCIDRs
-		wantErr bool
+		name string
+		args args
+		want *nodeCIDRs
 	}{
 		{
 			name: "test-1",
 			args: args{
-				podCIDRs: []string{
-					"1.1.1.1/20",
-					"1.1.1.1/28",
-				},
+				podCIDRs: mustNewIPPrefixes("1.1.1.1/20", "1.1.1.1/28"),
 			},
 			want: &nodeCIDRs{
 				v4PodCIDRs: mustNewCIDRs("1.1.1.1/20", "1.1.1.1/28"),
 			},
-			wantErr: false,
 		},
 		{
 			name: "test-2",
 			args: args{
-				podCIDRs: []string{
-					"fd00::1/64",
-					"fd01::/64",
-				},
+				podCIDRs: mustNewIPPrefixes("fd00::1/64", "fd01::/64"),
 			},
 			want: &nodeCIDRs{
 				v6PodCIDRs: mustNewCIDRs("fd00::1/64", "fd01::/64"),
 			},
-			wantErr: false,
 		},
 		{
 			name: "test-3",
 			args: args{
-				podCIDRs: []string{
-					"fd00::1/64",
-					"1.1.1.1/28",
-				},
+				podCIDRs: mustNewIPPrefixes("fd00::1/64", "1.1.1.1/28"),
 			},
 			want: &nodeCIDRs{
 				v4PodCIDRs: mustNewCIDRs("1.1.1.0/28"),
 				v6PodCIDRs: mustNewCIDRs("fd00::/64"),
 			},
-			wantErr: false,
 		},
 		{
 			name: "test-4",
 			args: args{
-				podCIDRs: []string{
-					"fd00::1/64",
-				},
+				podCIDRs: mustNewIPPrefixes("fd00::1/64"),
 			},
 			want: &nodeCIDRs{
 				v6PodCIDRs: mustNewCIDRs("fd00::/64"),
 			},
-			wantErr: false,
 		},
 		{
 			name: "test-5",
 			args: args{
-				podCIDRs: []string{
-					"1.1.1.1/28",
-				},
+				podCIDRs: mustNewIPPrefixes("1.1.1.1/28"),
 			},
 			want: &nodeCIDRs{
 				v4PodCIDRs: mustNewCIDRs("1.1.1.0/28"),
 			},
-			wantErr: false,
-		},
-		{
-			name: "test-6",
-			args: args{
-				podCIDRs: []string{
-					"1.1.1.1/280",
-				},
-			},
-			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
-		nodeCIDRs, err := parsePodCIDRs(tt.args.podCIDRs)
-		gotErr := err != nil
-		require.Equal(t, tt.wantErr, gotErr, fmt.Sprintf("Test Name: %s", tt.name), gotErr)
+		nodeCIDRs := splitPodCIDRs(tt.args.podCIDRs)
 		require.Equal(t, tt.want, nodeCIDRs, "Test Name: %s", tt.name)
 	}
 }
@@ -1512,9 +1487,7 @@ func Test_syncToK8s(t *testing.T) {
 							},
 							Spec: v2.NodeSpec{
 								IPAM: ipamTypes.IPAMSpec{
-									PodCIDRs: []string{
-										"10.10.0.0/24",
-									},
+									PodCIDRs: mustNewIPPrefixes("10.10.0.0/24"),
 								},
 							},
 						}, n)
@@ -1529,9 +1502,7 @@ func Test_syncToK8s(t *testing.T) {
 							},
 							Spec: v2.NodeSpec{
 								IPAM: ipamTypes.IPAMSpec{
-									PodCIDRs: []string{
-										"10.10.0.0/24",
-									},
+									PodCIDRs: mustNewIPPrefixes("10.10.0.0/24"),
 								},
 							},
 						},
@@ -1562,9 +1533,7 @@ func Test_syncToK8s(t *testing.T) {
 							},
 							Spec: v2.NodeSpec{
 								IPAM: ipamTypes.IPAMSpec{
-									PodCIDRs: []string{
-										"10.10.0.0/24",
-									},
+									PodCIDRs: mustNewIPPrefixes("10.10.0.0/24"),
 								},
 							},
 						}, n)
@@ -1582,9 +1551,7 @@ func Test_syncToK8s(t *testing.T) {
 							},
 							Spec: v2.NodeSpec{
 								IPAM: ipamTypes.IPAMSpec{
-									PodCIDRs: []string{
-										"10.10.0.0/24",
-									},
+									PodCIDRs: mustNewIPPrefixes("10.10.0.0/24"),
 								},
 							},
 						}, nil
@@ -1598,9 +1565,7 @@ func Test_syncToK8s(t *testing.T) {
 							},
 							Spec: v2.NodeSpec{
 								IPAM: ipamTypes.IPAMSpec{
-									PodCIDRs: []string{
-										"10.10.0.0/24",
-									},
+									PodCIDRs: mustNewIPPrefixes("10.10.0.0/24"),
 								},
 							},
 						},
@@ -1621,9 +1586,7 @@ func Test_syncToK8s(t *testing.T) {
 							},
 							Spec: v2.NodeSpec{
 								IPAM: ipamTypes.IPAMSpec{
-									PodCIDRs: []string{
-										"10.10.0.0/24",
-									},
+									PodCIDRs: mustNewIPPrefixes("10.10.0.0/24"),
 								},
 							},
 						},
@@ -1651,9 +1614,7 @@ func Test_syncToK8s(t *testing.T) {
 							},
 							Spec: v2.NodeSpec{
 								IPAM: ipamTypes.IPAMSpec{
-									PodCIDRs: []string{
-										"10.10.0.0/24",
-									},
+									PodCIDRs: mustNewIPPrefixes("10.10.0.0/24"),
 								},
 							},
 						}, n)
@@ -1679,9 +1640,7 @@ func Test_syncToK8s(t *testing.T) {
 							},
 							Spec: v2.NodeSpec{
 								IPAM: ipamTypes.IPAMSpec{
-									PodCIDRs: []string{
-										"10.10.0.0/24",
-									},
+									PodCIDRs: mustNewIPPrefixes("10.10.0.0/24"),
 								},
 							},
 						},
@@ -1702,9 +1661,7 @@ func Test_syncToK8s(t *testing.T) {
 							},
 							Spec: v2.NodeSpec{
 								IPAM: ipamTypes.IPAMSpec{
-									PodCIDRs: []string{
-										"10.10.0.0/24",
-									},
+									PodCIDRs: mustNewIPPrefixes("10.10.0.0/24"),
 								},
 							},
 						},
@@ -1730,9 +1687,7 @@ func Test_syncToK8s(t *testing.T) {
 							},
 							Spec: v2.NodeSpec{
 								IPAM: ipamTypes.IPAMSpec{
-									PodCIDRs: []string{
-										"10.10.0.0/24",
-									},
+									PodCIDRs: mustNewIPPrefixes("10.10.0.0/24"),
 								},
 							},
 						}, n)
@@ -1750,9 +1705,7 @@ func Test_syncToK8s(t *testing.T) {
 							},
 							Spec: v2.NodeSpec{
 								IPAM: ipamTypes.IPAMSpec{
-									PodCIDRs: []string{
-										"10.10.0.0/24",
-									},
+									PodCIDRs: mustNewIPPrefixes("10.10.0.0/24"),
 								},
 							},
 						},
@@ -1783,9 +1736,7 @@ func Test_syncToK8s(t *testing.T) {
 							},
 							Spec: v2.NodeSpec{
 								IPAM: ipamTypes.IPAMSpec{
-									PodCIDRs: []string{
-										"10.10.0.0/24",
-									},
+									PodCIDRs: mustNewIPPrefixes("10.10.0.0/24"),
 								},
 							},
 						}, n)
@@ -1800,9 +1751,7 @@ func Test_syncToK8s(t *testing.T) {
 							},
 							Spec: v2.NodeSpec{
 								IPAM: ipamTypes.IPAMSpec{
-									PodCIDRs: []string{
-										"10.10.0.0/24",
-									},
+									PodCIDRs: mustNewIPPrefixes("10.10.0.0/24"),
 								},
 							},
 						},
@@ -2053,10 +2002,7 @@ func TestNodesPodCIDRManager_DuplicateIPv6CausesIPv4Duplication(t *testing.T) {
 		},
 		Spec: v2.NodeSpec{
 			IPAM: ipamTypes.IPAMSpec{
-				PodCIDRs: []string{
-					"10.10.0.0/24",
-					"fd00::/80",
-				},
+				PodCIDRs: mustNewIPPrefixes("10.10.0.0/24", "fd00::/80"),
 			},
 		},
 	}
@@ -2070,7 +2016,7 @@ func TestNodesPodCIDRManager_DuplicateIPv6CausesIPv4Duplication(t *testing.T) {
 
 	require.Contains(t, ciliumNodesToK8s, "node-a")
 	require.Equal(t, k8sOpUpdate, ciliumNodesToK8s["node-a"].op)
-	require.Equal(t, []string{"10.10.0.0/24", "fd00::/80"},
+	require.Equal(t, mustNewIPPrefixes("10.10.0.0/24", "fd00::/80"),
 		ciliumNodesToK8s["node-a"].ciliumNode.Spec.IPAM.PodCIDRs)
 
 	// Node B: different v4, but same v6 as Node A (duplicate).
@@ -2081,10 +2027,7 @@ func TestNodesPodCIDRManager_DuplicateIPv6CausesIPv4Duplication(t *testing.T) {
 		},
 		Spec: v2.NodeSpec{
 			IPAM: ipamTypes.IPAMSpec{
-				PodCIDRs: []string{
-					"10.10.1.0/24",
-					"fd00::/80",
-				},
+				PodCIDRs: mustNewIPPrefixes("10.10.1.0/24", "fd00::/80"),
 			},
 		},
 	}
@@ -2099,7 +2042,7 @@ func TestNodesPodCIDRManager_DuplicateIPv6CausesIPv4Duplication(t *testing.T) {
 	// Spec updated (v6 stripped), status records the conflict.
 	require.Contains(t, ciliumNodesToK8s, "node-b")
 	require.Equal(t, k8sOpUpdate, ciliumNodesToK8s["node-b"].op)
-	require.Equal(t, []string{"10.10.1.0/24"},
+	require.Equal(t, mustNewIPPrefixes("10.10.1.0/24"),
 		ciliumNodesToK8s["node-b"].ciliumNode.Spec.IPAM.PodCIDRs)
 	require.Contains(t, ciliumNodesToK8s["node-b"].ciliumNode.Status.IPAM.OperatorStatus.Error,
 		"already allocated")
@@ -2115,6 +2058,6 @@ func TestNodesPodCIDRManager_DuplicateIPv6CausesIPv4Duplication(t *testing.T) {
 
 	require.Contains(t, nodes, "node-c")
 	require.Contains(t, ciliumNodesToK8s, "node-c")
-	require.NotEqual(t, "10.10.1.0/24",
+	require.NotEqual(t, mustNewIPPrefixes("10.10.1.0/24")[0],
 		ciliumNodesToK8s["node-c"].ciliumNode.Spec.IPAM.PodCIDRs[0])
 }

--- a/operator/pkg/ipam/podcidroverlap_test.go
+++ b/operator/pkg/ipam/podcidroverlap_test.go
@@ -20,6 +20,7 @@ import (
 	operatorK8s "github.com/cilium/cilium/operator/k8s"
 	"github.com/cilium/cilium/operator/pkg/ipam/allocator/clusterpool/cidralloc"
 	"github.com/cilium/cilium/operator/pkg/ipam/allocator/podcidr"
+	iputil "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipam/cidrset"
 	"github.com/cilium/cilium/pkg/ipam/types"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -66,7 +67,7 @@ func podCIDRAllocatorOverlapTestRun(t *testing.T) {
 		},
 		Spec: cilium_api_v2.NodeSpec{
 			IPAM: types.IPAMSpec{
-				PodCIDRs: []string{},
+				PodCIDRs: []iputil.Prefix{},
 			},
 		},
 	}
@@ -76,8 +77,8 @@ func podCIDRAllocatorOverlapTestRun(t *testing.T) {
 		},
 		Spec: cilium_api_v2.NodeSpec{
 			IPAM: types.IPAMSpec{
-				PodCIDRs: []string{
-					"10.129.0.0/24",
+				PodCIDRs: []iputil.Prefix{
+					iputil.PrefixFrom(netip.MustParsePrefix("10.129.0.0/24")),
 				},
 			},
 		},

--- a/pkg/bgp/manager/reconciler/pod_cidr.go
+++ b/pkg/bgp/manager/reconciler/pod_cidr.go
@@ -91,11 +91,7 @@ func (r *PodCIDRReconciler) Reconcile(ctx context.Context, p ReconcileParams) er
 	// get pod CIDR prefixes
 	var podCIDRPrefixes []netip.Prefix
 	for _, cidr := range p.CiliumNode.Spec.IPAM.PodCIDRs {
-		prefix, err := netip.ParsePrefix(cidr)
-		if err != nil {
-			return fmt.Errorf("failed to parse prefix %s: %w", cidr, err)
-		}
-		podCIDRPrefixes = append(podCIDRPrefixes, prefix)
+		podCIDRPrefixes = append(podCIDRPrefixes, cidr.Prefix)
 	}
 
 	// get per peer per family pod cidr advertisements

--- a/pkg/bgp/manager/reconciler/pod_cidr_test.go
+++ b/pkg/bgp/manager/reconciler/pod_cidr_test.go
@@ -17,10 +17,20 @@ import (
 	"github.com/cilium/cilium/pkg/bgp/manager/instance"
 	"github.com/cilium/cilium/pkg/bgp/manager/store"
 	"github.com/cilium/cilium/pkg/bgp/types"
+	iputil "github.com/cilium/cilium/pkg/ip"
 	ipamtypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/option"
 )
+
+// mustNewIPPrefixes wraps each CIDR string in an ip.Prefix.
+func mustNewIPPrefixes(cidrs ...string) []iputil.Prefix {
+	prefixes := make([]iputil.Prefix, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		prefixes = append(prefixes, iputil.PrefixFrom(netip.MustParsePrefix(cidr)))
+	}
+	return prefixes
+}
 
 // test fixtures
 var (
@@ -200,12 +210,7 @@ func Test_PodCIDRAdvertisement(t *testing.T) {
 				},
 				Spec: v2.NodeSpec{
 					IPAM: ipamtypes.IPAMSpec{
-						PodCIDRs: []string{
-							podCIDR1v4,
-							podCIDR2v4,
-							podCIDR1v6,
-							podCIDR2v6,
-						},
+						PodCIDRs: mustNewIPPrefixes(podCIDR1v4, podCIDR2v4, podCIDR1v6, podCIDR2v6),
 					},
 				},
 			},
@@ -248,12 +253,7 @@ func Test_PodCIDRAdvertisement(t *testing.T) {
 				},
 				Spec: v2.NodeSpec{
 					IPAM: ipamtypes.IPAMSpec{
-						PodCIDRs: []string{
-							podCIDR1v4,
-							podCIDR2v4,
-							podCIDR1v6,
-							podCIDR2v6,
-						},
+						PodCIDRs: mustNewIPPrefixes(podCIDR1v4, podCIDR2v4, podCIDR1v6, podCIDR2v6),
 					},
 				},
 			},
@@ -308,7 +308,7 @@ func Test_PodCIDRAdvertisement(t *testing.T) {
 				},
 				Spec: v2.NodeSpec{
 					IPAM: ipamtypes.IPAMSpec{
-						PodCIDRs: []string{podCIDR1v4, podCIDR2v4},
+						PodCIDRs: mustNewIPPrefixes(podCIDR1v4, podCIDR2v4),
 					},
 				},
 			},
@@ -360,7 +360,7 @@ func Test_PodCIDRAdvertisement(t *testing.T) {
 				},
 				Spec: v2.NodeSpec{
 					IPAM: ipamtypes.IPAMSpec{
-						PodCIDRs: []string{podCIDR1v4, podCIDR2v4},
+						PodCIDRs: mustNewIPPrefixes(podCIDR1v4, podCIDR2v4),
 					},
 				},
 			},
@@ -406,7 +406,7 @@ func Test_PodCIDRAdvertisement(t *testing.T) {
 				},
 				Spec: v2.NodeSpec{
 					IPAM: ipamtypes.IPAMSpec{
-						PodCIDRs: []string{podCIDR1v4, podCIDR2v4},
+						PodCIDRs: mustNewIPPrefixes(podCIDR1v4, podCIDR2v4),
 					},
 				},
 			},

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -138,7 +138,7 @@ type IPAMSpec struct {
 	// When an IP is used, the IP will be added to Status.IPAM.Used
 	//
 	// +optional
-	PodCIDRs []string `json:"podCIDRs,omitempty"`
+	PodCIDRs []iputil.Prefix `json:"podCIDRs,omitempty"`
 
 	// MinAllocate is the minimum number of IPs that must be allocated when
 	// the node is first bootstrapped. It defines the minimum base socket

--- a/pkg/ipam/types/zz_generated.deepcopy.go
+++ b/pkg/ipam/types/zz_generated.deepcopy.go
@@ -154,8 +154,10 @@ func (in *IPAMSpec) DeepCopyInto(out *IPAMSpec) {
 	in.Pools.DeepCopyInto(&out.Pools)
 	if in.PodCIDRs != nil {
 		in, out := &in.PodCIDRs, &out.PodCIDRs
-		*out = make([]string, len(*in))
-		copy(*out, *in)
+		*out = make([]ip.Prefix, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	if in.StaticIPTags != nil {
 		in, out := &in.StaticIPTags, &out.StaticIPTags

--- a/pkg/ipam/types/zz_generated.deepequal.go
+++ b/pkg/ipam/types/zz_generated.deepequal.go
@@ -198,7 +198,7 @@ func (in *IPAMSpec) DeepEqual(other *IPAMSpec) bool {
 			return false
 		} else {
 			for i, inElement := range *in {
-				if inElement != (*other)[i] {
+				if !inElement.DeepEqual(&(*other)[i]) {
 					return false
 				}
 			}

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -313,6 +313,7 @@ spec:
                       PodCIDRs is the list of CIDRs available to the node for allocation.
                       When an IP is used, the IP will be added to Status.IPAM.Used
                     items:
+                      format: cidr
                       type: string
                     type: array
                   pool:

--- a/pkg/k8s/apis/cilium.io/register.go
+++ b/pkg/k8s/apis/cilium.io/register.go
@@ -15,5 +15,5 @@ const (
 	//
 	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
 	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.33.8"
+	CustomResourceDefinitionSchemaVersion = "1.33.9"
 )

--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -340,11 +340,11 @@ func ParseCiliumNode(n *ciliumv2.CiliumNode) (node nodeTypes.Node) {
 		BootID:          n.Spec.BootID,
 	}
 
-	for _, cidrString := range n.Spec.IPAM.PodCIDRs {
-		ipnet, err := cidr.ParseCIDR(cidrString)
-		if err == nil {
-			appendAllocCIDR(&node, ipnet)
+	for _, podCIDR := range n.Spec.IPAM.PodCIDRs {
+		if !podCIDR.IsValid() {
+			continue
 		}
+		appendAllocCIDR(&node, cidr.NewCIDR(netipx.PrefixIPNet(podCIDR.Masked())))
 	}
 
 	for _, pool := range n.Spec.IPAM.Pools.Allocated {

--- a/pkg/k8s/node_test.go
+++ b/pkg/k8s/node_test.go
@@ -5,6 +5,7 @@ package k8s
 
 import (
 	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/cidr"
+	iputil "github.com/cilium/cilium/pkg/ip"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -406,11 +408,11 @@ func TestParseCiliumNode(t *testing.T) {
 				Key: 10,
 			},
 			IPAM: ipamTypes.IPAMSpec{
-				PodCIDRs: []string{
-					"10.10.0.0/16",
-					"c0de::/96",
-					"10.20.0.0/16",
-					"c0fe::/96",
+				PodCIDRs: []iputil.Prefix{
+					iputil.PrefixFrom(netip.MustParsePrefix("10.10.0.0/16")),
+					iputil.PrefixFrom(netip.MustParsePrefix("c0de::/96")),
+					iputil.PrefixFrom(netip.MustParsePrefix("10.20.0.0/16")),
+					iputil.PrefixFrom(netip.MustParsePrefix("c0fe::/96")),
 				},
 			},
 			HealthAddressing: ciliumv2.HealthAddressingSpec{

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -10,12 +10,14 @@ import (
 	"slices"
 
 	"github.com/cilium/stream"
+	"go4.org/netipx"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/net"
 
 	"github.com/cilium/cilium/daemon/cmd/cni"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/defaults"
+	iputil "github.com/cilium/cilium/pkg/ip"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/client"
@@ -344,13 +346,17 @@ func (n *NodeDiscovery) mutateNodeResource(ctx context.Context, nodeResource *ci
 		// IPv4/IPv6AllocRange is auto-generated and otherwise unused, so it does not
 		// make sense to copy it into the CiliumNode it either.
 		// See NodeRegistrar.RegisterNode() for the equivalent kvstore mode logic.
-		nodeResource.Spec.IPAM.PodCIDRs = []string{}
+		nodeResource.Spec.IPAM.PodCIDRs = []iputil.Prefix{}
 		if cidr := ln.IPv4AllocCIDR; cidr != nil {
-			nodeResource.Spec.IPAM.PodCIDRs = append(nodeResource.Spec.IPAM.PodCIDRs, cidr.String())
+			if prefix, ok := netipx.FromStdIPNet(cidr.IPNet); ok {
+				nodeResource.Spec.IPAM.PodCIDRs = append(nodeResource.Spec.IPAM.PodCIDRs, iputil.PrefixFrom(prefix))
+			}
 		}
 
 		if cidr := ln.IPv6AllocCIDR; cidr != nil {
-			nodeResource.Spec.IPAM.PodCIDRs = append(nodeResource.Spec.IPAM.PodCIDRs, cidr.String())
+			if prefix, ok := netipx.FromStdIPNet(cidr.IPNet); ok {
+				nodeResource.Spec.IPAM.PodCIDRs = append(nodeResource.Spec.IPAM.PodCIDRs, iputil.PrefixFrom(prefix))
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR continues the netip migration in the IPAM perimeter.

Followup to #46345.
Relates to #24246.

Migrate `IPAMSpec.PodCIDRs` from a `string` to `ip.Prefix`. Previously, every producer serialized it with `.String()` and every consumer re-parsed it with `netip.ParsePrefix`. The producers (the operator podCIDR allocator and the agent's nodediscovery writer) now assign typed prefixes, and the consumers (`pkg/k8s`'s ParseCiliumNode, the BGP podCIDR reconciler, and the cilium-cli) read them directly. The operator's `parsePodCIDRs` collapses to `splitPodCIDRs`, which only masks and sorts by family now that parsing and validation happen at the CRD boundary.