### PR TITLE
endpointmanager: Deflake proxy updates test

### DIFF
--- a/pkg/endpointmanager/manager_proxy_test.go
+++ b/pkg/endpointmanager/manager_proxy_test.go
@@ -321,9 +321,7 @@ func TestUpdatePolicyMapsRevertsDeferredNetworkPolicyCallbacksAfterProxyWaitFail
 
 	errCh := make(chan error, 1)
 	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-		defer cancel()
-		errCh <- mgr.UpdatePolicyMaps(ctx)
+		errCh <- mgr.UpdatePolicyMaps(t.Context())
 	}()
 
 	proxy.waitForUpdates(t)
@@ -333,7 +331,6 @@ func TestUpdatePolicyMapsRevertsDeferredNetworkPolicyCallbacksAfterProxyWaitFail
 
 	err := <-errCh
 	require.Error(t, err)
-	require.ErrorContains(t, err, "proxy updates failed")
 	require.Equal(t, 1, proxy.revertCount(ep1.GetID()))
 	require.Equal(t, 1, proxy.revertCount(ep2.GetID()))
 	require.Equal(t, 0, proxy.finalizeCount(ep1.GetID()))


### PR DESCRIPTION
TestUpdatePolicyMapsRevertsDeferredNetworkPolicyCallbacksAfterProxyWaitFailure validates the failure path for a batched endpoint policy update where the policymap step succeeds, but the asynchronous proxy confirmation fails afterward.

However, the test is flaky, since two scenarios may happen:

1) Manager has already entered proxyWaitGroup.Wait(), then Wait() observes the completion error, and waitForProxyCompletions returns with the expected error "proxy updates failed: ..."
2) Manager has not entered Wait() yet, and the failed completion cancels the wait group context first. When the manager later reaches waitForProxyCompletions, the initial context check fires and returns the error "context cancelled before waiting for proxy updates: ..."

The second scenario leads to the following failure:

```
--- FAIL: TestUpdatePolicyMapsRevertsDeferredNetworkPolicyCallbacksAfterProxyWaitFailure (0.01s)
    ...
    logger.go:256: time=2026-06-16T17:37:09.634+02:00 level=WARN source=github.com/cilium/cilium/pkg/endpointmanager/manager.go:246 msg="Failed to apply L7 proxy policy changes. These will be re-applied in future updates." error="context cancelled before waiting for proxy updates: context canceled"
    manager_proxy_test.go:335:
        	Error Trace:	github.com/cilium/cilium/pkg/endpointmanager/manager_proxy_test.go:335
        	Error:      	Error "context cancelled before waiting for proxy updates: context canceled" does not contain "proxy updates failed"
        	Test:       	TestUpdatePolicyMapsRevertsDeferredNetworkPolicyCallbacksAfterProxyWaitFailure
```

Since the test aims to validate that in case of an error the changes to the policymap are correctly reverted, simply remove the assertion about the error string returned and leave the assertion that check an error is returned from UpdatePolicyMaps.


This PR was created with the aid of Codex for confirming the root cause of the test failure (AIL 2).

Observed in https://github.com/cilium/cilium/actions/runs/27606863261/job/81620977901
Related: https://github.com/cilium/cilium/pull/46066
Fixes: https://github.com/cilium/cilium/issues/46825