### PR TITLE
doc: fix note about ipv4-native-routing-cidr default value

### DIFF
--- a/Documentation/network/concepts/routing.rst
+++ b/Documentation/network/concepts/routing.rst
@@ -294,9 +294,8 @@ Addressing
    distribution.
 
 Masquerading
-   All traffic not staying with the ``ipv4-native-routing-cidr`` (defaults to
-   the Cluster CIDR) will be masqueraded to the node's IP address to become
-   publicly routable.
+   All traffic not staying with the ``ipv4-native-routing-cidr`` will be
+   masqueraded to the node's IP address to become publicly routable.
 
 Load-balancing
    ClusterIP load-balancing will be performed using eBPF for all version of GKE.


### PR DESCRIPTION

<!-- Description of change -->

Fixes: https://github.com/cilium/cilium/issues/12186#issuecomment-2670014127

That issue was closed by https://github.com/cilium/cilium/pull/46419 , but that ended up implementing a new Helm value for convenience. The documentation remained incorrect as described in https://github.com/cilium/cilium/issues/12186 - ipv4-native-routing-cidr needs to be defined and does not take the value of the cluster CIDR as a default.


[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request

```release-note
docs: fix note about ipv4-native-routing-cidr default value
```