### PR TITLE
Fix: potential helm validation error with nativeRoutingCIDRFromClusterPool

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -561,13 +561,13 @@ data:
 {{- if eq .Values.routingMode "native" }}
   {{- if and .Values.ipv4.enabled .Values.enableIPv4Masquerade (not .Values.ipMasqAgent.enabled) }}
     {{- if and (ne $ipam "eni") (ne $ipam "alibabacloud") }}
-      {{- if not .Values.ipv4NativeRoutingCIDR }}
+      {{- if and (not .Values.ipv4NativeRoutingCIDR) (not (and (eq $ipam "cluster-pool") .Values.nativeRoutingCIDRFromClusterPool)) }}
         {{- fail " ipv4NativeRoutingCIDR must be set when routingMode is native"}}
       {{- end }}
     {{- end }}
   {{- end }}
   {{- if and .Values.ipv6.enabled .Values.enableIPv6Masquerade (not .Values.ipMasqAgent.enabled) }}
-    {{- if not .Values.ipv6NativeRoutingCIDR }}
+    {{- if and (not .Values.ipv6NativeRoutingCIDR) (not (and (eq $ipam "cluster-pool") .Values.nativeRoutingCIDRFromClusterPool)) }}
       {{- fail "ipv6NativeRoutingCIDR must be set when routingMode is native"  }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION


the PR https://github.com/cilium/cilium/pull/46419 introduced a new helm values `nativeRoutingCIDRFromClusterPool`. When enabled, the chart derives ipv4-native-routing-cidr / ipv6-native-routing-cidr from the cluster-pool CIDR at template rendering time

So, the issue is that actually it fails to deploy with  ipam.mode=cluster-pool ,  routingMode=native ,  enableIPv4Masquerade=true , and nativeRoutingCIDRFromClusterPool=true  while leaving  ipv4NativeRoutingCIDR  unset.

 the root cause is Premature validation in cilium-configmap.yaml requires explicit  ipv4NativeRoutingCIDR  before downstream derivation block runs, breaking  feature design.
 

