### PR TITLE
sysdump: contain WithFileSink output to the sysdump directory

### DIFF
--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -418,6 +418,13 @@ func (c *Collector) AbsoluteTempPath(f string) string {
 
 func (c *Collector) WithFileSink(filename string, fn func(io.Writer) error) error {
 	path := c.AbsoluteTempPath(filename)
+	// filename can be derived from data collected inside a target pod (for
+	// example the CNI config file names that SubmitCniConflistSubtask reads
+	// from `ls` output), so reject anything that resolves outside the sysdump
+	// directory before opening it.
+	if !strings.HasPrefix(filepath.Clean(path), filepath.Clean(c.sysdumpDir)+string(os.PathSeparator)) {
+		return fmt.Errorf("refusing to write %q outside of the sysdump directory", filename)
+	}
 	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, fileMode)
 	if err != nil {
 		return err

--- a/cilium-cli/sysdump/sysdump_test.go
+++ b/cilium-cli/sysdump/sysdump_test.go
@@ -69,6 +69,65 @@ func TestSysdumpCollector(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestWithFileSinkContainment(t *testing.T) {
+	client := fakeClient{
+		nodeList: &corev1.NodeList{
+			Items: []corev1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}},
+			},
+		},
+	}
+	collector, err := NewCollector(&client, Options{
+		OutputFileName: "my-sysdump-<ts>",
+		Writer:         io.Discard,
+	}, &nopHooks{}, time.Unix(946713600, 0))
+	assert.NoError(t, err)
+
+	// A name that escapes the sysdump directory, e.g. a CNI config filename
+	// listed by a compromised pod.
+	outside := filepath.Join(t.TempDir(), "escape.txt")
+	escaping, err := filepath.Rel(collector.sysdumpDir, outside)
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		filename string
+		// wantPath is checked after the write: it must exist for an accepted
+		// sink and must not exist for a rejected one.
+		wantPath string
+		wantErr  bool
+	}{
+		{
+			name:     "contained filename is written",
+			filename: "cniconf-bridge.conf-pod",
+			wantPath: path.Join(collector.sysdumpDir, "cniconf-bridge.conf-pod"),
+		},
+		{
+			name:     "escaping filename is rejected",
+			filename: escaping,
+			wantPath: outside,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := collector.WithFileSink(tt.filename, func(w io.Writer) error {
+				_, werr := io.WriteString(w, "data")
+				return werr
+			})
+			_, statErr := os.Stat(tt.wantPath)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.True(t, os.IsNotExist(statErr))
+				return
+			}
+			assert.NoError(t, err)
+			assert.NoError(t, statErr)
+		})
+	}
+}
+
 func TestNodeList(t *testing.T) {
 	options := Options{
 		Writer: io.Discard,


### PR DESCRIPTION
- [ ] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

WithFileSink joins a caller-supplied name to the sysdump directory and opens it, with no containment check. SubmitCniConflistSubtask feeds it filenames taken from `ls -1` run inside a target pod, so the names are controlled by the pod rather than the CLI.

- a name like `../../../../etc/foo` resolves outside the sysdump directory through AbsoluteTempPath
- the collected file contents are then written to that path on the host running `cilium sysdump`
- guarded WithFileSink itself so every caller is covered, reusing the prefix check the extractZip helper already applies

Added a regression test covering a normal name and an escaping one.

```release-note
sysdump: reject collected file names that resolve outside the sysdump directory
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
