### PR TITLE
Decrease CI costs on AWS

### DIFF
--- a/.github/actions/aws-cni/k8s-versions.yaml
+++ b/.github/actions/aws-cni/k8s-versions.yaml
@@ -7,7 +7,6 @@ include:
     region: us-east-2
   - version: "1.34"
     region: us-east-1
-    default: true
     kpr: true
   - version: "1.35"
     region: us-west-2

--- a/.github/actions/eks/k8s-versions.yaml
+++ b/.github/actions/eks/k8s-versions.yaml
@@ -7,8 +7,8 @@ include:
     region: us-east-2
   - version: "1.34"
     region: us-east-1
-    default: true
     aws-eni-pd: true
   - version: "1.35"
     region: us-west-2
     default: true
+    aws-eni-pd: true


### PR DESCRIPTION
Only run one of the k8s versions for AWS, the latest one. The remaining ones will still run on a scheduled basis.