### PR TITLE
network driver: synchronize with CRI on startup

### DIFF
--- a/pkg/networkdriver/cell.go
+++ b/pkg/networkdriver/cell.go
@@ -127,6 +127,7 @@ func registerNetworkDriver(params networkDriverParams) *Driver {
 		deviceManagers:         make(map[types.DeviceManagerType]types.DeviceManager),
 		configCRD:              params.Configs,
 		allocations:            make(map[kube_types.UID]map[kube_types.UID][]allocation),
+		podNetns:               make(map[kube_types.UID]string),
 		multiPoolMgr:           params.MultiPoolMgr,
 		ipv4Enabled:            params.DaemonCfg.IPv4Enabled(),
 		ipv6Enabled:            params.DaemonCfg.IPv6Enabled(),

--- a/pkg/networkdriver/driver.go
+++ b/pkg/networkdriver/driver.go
@@ -63,6 +63,13 @@ type Driver struct {
 	deviceManagers map[types.DeviceManagerType]types.DeviceManager
 	// pod.UID: claim.UID: allocation
 	allocations map[kube_types.UID]map[kube_types.UID][]allocation
+	// pod.UID: network namespace path. Captured at RunPodSandbox (and rebuilt on
+	// plugin (re)connect via Synchronize) so StopPodSandbox can recover the netns on
+	// containerd < 2.1, where the stop event carries no namespaces: the sandbox task
+	// is already killed, so the NRI PodSandbox spec comes back empty. containerd
+	// removes the netns only after the StopPodSandbox hook returns, so the cached
+	// path is still valid when we use it. Guarded by lock, like allocations.
+	podNetns map[kube_types.UID]string
 	// manager_type: devices
 	devices map[types.DeviceManagerType][]types.Device
 	// device ifname: pool name — stable cross-reconcile assignment for conflict resolution

--- a/pkg/networkdriver/nri.go
+++ b/pkg/networkdriver/nri.go
@@ -37,14 +37,65 @@ var (
 	rootNetNSPath = "/proc/1/ns/net"
 )
 
-func getNetworkNamespace(pod *api.PodSandbox) string {
-	// get the pod network namespace
+// getNetworkNamespace resolves the pod's network namespace path.
+//
+// On containerd >= 2.1 the NRI PodSandbox carries the OCI namespaces directly, so the
+// first lookup succeeds for both RunPodSandbox and StopPodSandbox. On containerd < 2.1
+// the StopPodSandbox event carries no namespaces (the sandbox task is killed before the
+// NRI hook runs, so the spec comes back empty); we fall back to the path cached at
+// RunPodSandbox / Synchronize. The caller already holds driver.lock.
+//
+// An empty return means a genuine host-network pod (no network namespace at
+// RunPodSandbox either, so nothing was cached), which must be skipped.
+func (driver *Driver) getNetworkNamespace(pod *api.PodSandbox) string {
 	for _, namespace := range pod.Linux.GetNamespaces() {
 		if namespace.Type == "network" {
 			return namespace.Path
 		}
 	}
+
+	// containerd < 2.1 fallback: reuse the path captured while the task was alive.
+	if ns, ok := driver.podNetns[kube_types.UID(pod.Uid)]; ok {
+		return ns
+	}
+
 	return ""
+}
+
+// rememberNetworkNamespace records a pod's netns path keyed by UID, if the PodSandbox
+// carries one. Called from RunPodSandbox and Synchronize, where the sandbox task is
+// alive and the namespaces are populated. The caller already holds driver.lock.
+func (driver *Driver) rememberNetworkNamespace(pod *api.PodSandbox) string {
+	for _, namespace := range pod.Linux.GetNamespaces() {
+		if namespace.Type == "network" {
+			driver.podNetns[kube_types.UID(pod.Uid)] = namespace.Path
+			return namespace.Path
+		}
+	}
+	return ""
+}
+
+// Synchronize is invoked by the runtime when the NRI plugin (re)connects — notably right
+// after an agent restart — with every running pod. The sandbox tasks are alive here, so
+// the netns is populated; we capture it so a later StopPodSandbox can recover the netns
+// on containerd < 2.1 even across an agent restart. This mirrors how driver.allocations
+// is rebuilt from ResourceClaims on restart: node-local runtime state reconstructed from
+// a durable source rather than persisted to disk. We request no container updates.
+func (driver *Driver) Synchronize(ctx context.Context, pods []*api.PodSandbox, _ []*api.Container) ([]*api.ContainerUpdate, error) {
+	err := driver.withLock(func() error {
+		n := 0
+		for _, pod := range pods {
+			if driver.rememberNetworkNamespace(pod) != "" {
+				n++
+			}
+		}
+		driver.logger.DebugContext(ctx, "NRI Synchronize: cached pod network namespaces",
+			logfields.Count, n,
+		)
+		return nil
+	})
+
+	return nil, err
 }
 
 // RunPodSandbox is called by the container runtime when a pod sandbox is started.
@@ -59,7 +110,9 @@ func (driver *Driver) RunPodSandbox(ctx context.Context, podSandbox *api.PodSand
 
 		log.DebugContext(ctx, "RunPodSandbox request received")
 
-		networkNamespace := getNetworkNamespace(podSandbox)
+		// Task is alive here, so the netns is populated. Cache it keyed by UID so a
+		// later StopPodSandbox can recover it on containerd < 2.1.
+		networkNamespace := driver.rememberNetworkNamespace(podSandbox)
 		// host network pods cannot allocate network devices
 		// nothing for us here
 		if networkNamespace == "" {
@@ -152,7 +205,12 @@ func (driver *Driver) StopPodSandbox(ctx context.Context, podSandbox *api.PodSan
 
 		log.DebugContext(ctx, "StopPodSandbox request received")
 
-		networkNamespace := getNetworkNamespace(podSandbox)
+		// On containerd < 2.1 the stop event carries no namespaces; fall back to the
+		// path cached at RunPodSandbox / Synchronize. Evict the cache entry on the way
+		// out: this is the pod's terminal event, so the entry is no longer needed.
+		defer delete(driver.podNetns, kube_types.UID(podSandbox.Uid))
+
+		networkNamespace := driver.getNetworkNamespace(podSandbox)
 		// host network pods cannot allocate network devices because it impacts the host
 		if networkNamespace == "" {
 			log.DebugContext(ctx, "StopPodSandbox pod using host network cannot claim host devices")

--- a/pkg/networkdriver/nri_test.go
+++ b/pkg/networkdriver/nri_test.go
@@ -29,12 +29,22 @@ import (
 	testnetns "github.com/cilium/cilium/pkg/testutils/netns"
 )
 
+// TestPrivilegedRunStopPodSandbox exercises the NRI RunPodSandbox/StopPodSandbox device
+// move-in/move-out flow, including the containerd < 2.1 fallback where StopPodSandbox is
+// delivered with an empty namespace list (the sandbox task is killed before the NRI hook
+// runs). Subtests:
+//
+//   - "run and stop with namespaces present": the happy path on containerd >= 2.1, where
+//     both events carry the netns. Full assertions on addresses, routes and link state.
+//   - "stop recovers netns from RunPodSandbox cache": containerd < 2.1; the netns was
+//     cached while the task was alive at RunPodSandbox and recovered at StopPodSandbox.
+//   - "stop recovers netns from Synchronize after restart": containerd < 2.1 across an
+//     agent restart; the in-memory cache is lost and rebuilt from the NRI Synchronize
+//     replay before the buggy StopPodSandbox arrives.
 func TestPrivilegedRunStopPodSandbox(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	const (
-		rootNSName = "nri-root"
-		podNSName  = "nri-pod"
 		deviceName = "dummy0"
 		podIfName  = "net1"
 	)
@@ -54,206 +64,312 @@ func TestPrivilegedRunStopPodSandbox(t *testing.T) {
 		}
 	)
 
-	rootNS := testnetns.NewNetNS(t)
-	podNS := testnetns.NewNetNS(t)
+	// setup builds a fresh network scaffold and driver for a single subtest: a root and
+	// a pod netns (pinned and wired into the package path globals), a dummy device in the
+	// root netns, and a Driver holding one allocation for that device. Returns the driver
+	// plus the handles each subtest needs. All cleanup is registered on the subtest's t.
+	setup := func(t *testing.T) (driver *Driver, rootNS, podNS *testnetns.NetNS, podNSPath string) {
+		t.Helper()
 
-	pinDir := t.TempDir()
-	rootNSPath := filepath.Join(pinDir, rootNSName)
-	podNSPath := filepath.Join(pinDir, podNSName)
-	pinNetNS(t, rootNS, rootNSPath)
-	pinNetNS(t, podNS, podNSPath)
+		const (
+			rootNSName = "nri-root"
+			podNSName  = "nri-pod"
+		)
 
-	origPodNetNSPath := podNetNSPath
-	origRootNetNSPath := rootNetNSPath
-	t.Cleanup(func() {
-		podNetNSPath = origPodNetNSPath
-		rootNetNSPath = origRootNetNSPath
-	})
-	podNetNSPath = pinDir
-	rootNetNSPath = rootNSPath
+		rootNS = testnetns.NewNetNS(t)
+		podNS = testnetns.NewNetNS(t)
 
-	require.NoError(t, rootNS.Do(func() error {
-		return netlink.LinkAdd(&netlink.Dummy{
-			LinkAttrs: netlink.LinkAttrs{Name: deviceName},
+		pinDir := t.TempDir()
+		rootNSPath := filepath.Join(pinDir, rootNSName)
+		podNSPath = filepath.Join(pinDir, podNSName)
+		pinNetNS(t, rootNS, rootNSPath)
+		pinNetNS(t, podNS, podNSPath)
+
+		origPodNetNSPath := podNetNSPath
+		origRootNetNSPath := rootNetNSPath
+		t.Cleanup(func() {
+			podNetNSPath = origPodNetNSPath
+			rootNetNSPath = origRootNetNSPath
 		})
-	}))
+		podNetNSPath = pinDir
+		rootNetNSPath = rootNSPath
 
-	driver := &Driver{
-		logger: hivetest.Logger(t),
-		allocations: map[kubetypes.UID]map[kubetypes.UID][]allocation{
-			podUID: {
-				claimUID: {
-					{
-						Device: &dummy.DummyDevice{Name: deviceName},
-						Config: types.DeviceConfig{
-							IPv4Addr:  ipv4Addr,
-							PodIfName: podIfName,
-							Routes:    routes,
+		require.NoError(t, rootNS.Do(func() error {
+			return netlink.LinkAdd(&netlink.Dummy{
+				LinkAttrs: netlink.LinkAttrs{Name: deviceName},
+			})
+		}))
+
+		driver = &Driver{
+			logger: hivetest.Logger(t),
+			allocations: map[kubetypes.UID]map[kubetypes.UID][]allocation{
+				podUID: {
+					claimUID: {
+						{
+							Device: &dummy.DummyDevice{Name: deviceName},
+							Config: types.DeviceConfig{
+								IPv4Addr:  ipv4Addr,
+								PodIfName: podIfName,
+								Routes:    routes,
+							},
+							Manager: types.DeviceManagerTypeDummy,
 						},
-						Manager: types.DeviceManagerTypeDummy,
 					},
 				},
 			},
-		},
-		ipv4Enabled: true,
+			podNetns:    make(map[kubetypes.UID]string),
+			ipv4Enabled: true,
+		}
+
+		return driver, rootNS, podNS, podNSPath
 	}
-	podSandbox := &api.PodSandbox{
-		Name:      "test-pod",
-		Uid:       string(podUID),
-		Namespace: "default",
-		Linux: &api.LinuxPodSandbox{
-			Namespaces: []*api.LinuxNamespace{
-				{
-					Type: "network",
-					Path: podNSPath,
+
+	// liveSandbox is a PodSandbox whose sandbox task is still alive, so it carries the
+	// network namespace — what RunPodSandbox and Synchronize see on every containerd.
+	liveSandbox := func(podNSPath string) *api.PodSandbox {
+		return &api.PodSandbox{
+			Name:      "test-pod",
+			Uid:       string(podUID),
+			Namespace: "default",
+			Linux: &api.LinuxPodSandbox{
+				Namespaces: []*api.LinuxNamespace{
+					{Type: "network", Path: podNSPath},
 				},
 			},
-		},
+		}
 	}
 
-	require.NoError(t, rootNS.Do(func() error {
-		return driver.RunPodSandbox(t.Context(), podSandbox)
-	}))
+	// assertBuggyStopRecovers drives the containerd < 2.1 StopPodSandbox (empty namespace
+	// list) against a driver whose cache has already been seeded, and asserts the device
+	// is moved back to the root netns under its kernel name and the cache entry evicted.
+	// It first checks the device is in the pod netns, so a no-op stop can't pass silently.
+	assertBuggyStopRecovers := func(t *testing.T, driver *Driver, rootNS, podNS *testnetns.NetNS) {
+		t.Helper()
 
-	require.NoError(t, rootNS.Do(func() error {
-		if _, err := safenetlink.LinkByName(deviceName); err == nil {
-			return fmt.Errorf("expected %q to be moved out of root netns", deviceName)
-		}
-		return nil
-	}))
-
-	require.NoError(t, podNS.Do(func() error {
-		if _, err := safenetlink.LinkByName(deviceName); err == nil {
-			return fmt.Errorf("expected %q to be renamed in pod netns", deviceName)
-		}
-
-		link, err := safenetlink.LinkByName(podIfName)
-		if err != nil {
-			return fmt.Errorf("expected %q to be moved into pod netns", podIfName)
-		}
-
-		if link.Attrs().Flags&net.FlagUp == 0 {
-			return fmt.Errorf("expected %q to be up", podIfName)
-		}
-
-		addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
-		if err != nil {
-			return fmt.Errorf("failed to list %q addresses", podIfName)
-		}
-		if found := slices.ContainsFunc(addrs, func(addr netlink.Addr) bool {
-			prefix, ok := netipx.FromStdIPNet(addr.IPNet)
-			if !ok {
-				return false
+		// Precondition: the device currently lives in the pod netns under its pod name.
+		require.NoError(t, podNS.Do(func() error {
+			if _, err := safenetlink.LinkByName(podIfName); err != nil {
+				return fmt.Errorf("expected %q in pod netns before StopPodSandbox: %w", podIfName, err)
 			}
-			return ipv4Addr.Compare(prefix) == 0
-		}); !found {
-			return fmt.Errorf("expected address %q to be assigned to %q interface", ipv4Addr, podIfName)
-		}
+			return nil
+		}))
 
-		nlRoutes, err := safenetlink.RouteListFiltered(
-			netlink.FAMILY_V4,
-			&netlink.Route{
-				LinkIndex: link.Attrs().Index,
-				Dst:       netipx.PrefixIPNet(routes[0].Destination),
-				Gw:        routes[0].Gateway.AsSlice(),
-			},
-			netlink.RT_FILTER_OIF|netlink.RT_FILTER_DST|netlink.RT_FILTER_GW,
-		)
-		if err != nil {
-			return fmt.Errorf("failed to list routes for %q", podIfName)
+		// The bug: containerd < 2.1 delivers StopPodSandbox with no namespaces because the
+		// sandbox task is already dead. The driver must fall back to its cache.
+		buggyStopSandbox := &api.PodSandbox{
+			Name:      "test-pod",
+			Uid:       string(podUID),
+			Namespace: "default",
+			Linux:     &api.LinuxPodSandbox{}, // no namespaces, as buggy containerd sends
 		}
-		if len(nlRoutes) != 1 {
-			return fmt.Errorf("no route \"%s via %s dev %s\" found", routes[0].Destination, routes[0].Gateway, podIfName)
-		}
+		require.NoError(t, rootNS.Do(func() error {
+			return driver.StopPodSandbox(t.Context(), buggyStopSandbox)
+		}))
 
-		nlRoutes, err = safenetlink.RouteListFiltered(
-			netlink.FAMILY_V4,
-			&netlink.Route{
-				LinkIndex: link.Attrs().Index,
-				Dst:       netipx.PrefixIPNet(routes[1].Destination),
-			},
-			netlink.RT_FILTER_OIF|netlink.RT_FILTER_DST,
-		)
-		if err != nil {
-			return fmt.Errorf("failed to list routes for %q", podIfName)
-		}
-		if len(nlRoutes) != 1 {
-			return fmt.Errorf("no route \"%s dev %s\" found", routes[1].Destination, podIfName)
-		}
-
-		return nil
-	}))
-
-	require.NoError(t, rootNS.Do(func() error {
-		return driver.StopPodSandbox(t.Context(), podSandbox)
-	}))
-
-	require.NoError(t, podNS.Do(func() error {
-		if _, err := safenetlink.LinkByName(podIfName); err == nil {
-			return fmt.Errorf("expected %q to be moved out of pod netns", podIfName)
-		}
-		return nil
-	}))
-
-	require.NoError(t, rootNS.Do(func() error {
-		if _, err := safenetlink.LinkByName(podIfName); err == nil {
-			return fmt.Errorf("expected %q to be restored to %q in root netns", podIfName, deviceName)
-		}
-
-		link, err := safenetlink.LinkByName(deviceName)
-		if err != nil {
-			return err
-		}
-
-		if link.Attrs().Flags&net.FlagUp != 0 {
-			return fmt.Errorf("expected %q to be down", deviceName)
-		}
-
-		addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
-		if err != nil {
-			return fmt.Errorf("failed to list %q addresses", deviceName)
-		}
-		if found := slices.ContainsFunc(addrs, func(addr netlink.Addr) bool {
-			prefix, ok := netipx.FromStdIPNet(addr.IPNet)
-			if !ok {
-				return false
+		// The device must be restored to the root netns under its kernel name despite the
+		// missing netns in the stop event...
+		require.NoError(t, rootNS.Do(func() error {
+			if _, err := safenetlink.LinkByName(deviceName); err != nil {
+				return fmt.Errorf("expected %q restored to root netns after StopPodSandbox: %w", deviceName, err)
 			}
-			return ipv4Addr.Compare(prefix) == 0
-		}); found {
-			return fmt.Errorf("expected %q to have %s removed", deviceName, ipv4Addr)
-		}
+			return nil
+		}))
 
-		nlRoutes, err := safenetlink.RouteListFiltered(
-			netlink.FAMILY_V4,
-			&netlink.Route{
-				Dst: netipx.PrefixIPNet(routes[0].Destination),
-				Gw:  routes[0].Gateway.AsSlice(),
-			},
-			netlink.RT_FILTER_DST|netlink.RT_FILTER_GW,
-		)
-		if err != nil {
-			return fmt.Errorf("failed to list routes for destination %q", routes[0].Destination)
-		}
-		if len(nlRoutes) > 0 {
-			return fmt.Errorf("expected no routes for destination %q", routes[0].Destination)
-		}
+		// ...and no longer be in the pod netns.
+		require.NoError(t, podNS.Do(func() error {
+			if _, err := safenetlink.LinkByName(podIfName); err == nil {
+				return fmt.Errorf("expected %q to be moved out of pod netns", podIfName)
+			}
+			return nil
+		}))
 
-		nlRoutes, err = safenetlink.RouteListFiltered(
-			netlink.FAMILY_V4,
-			&netlink.Route{
-				Dst: netipx.PrefixIPNet(routes[1].Destination),
-			},
-			netlink.RT_FILTER_DST,
-		)
-		if err != nil {
-			return fmt.Errorf("failed to list routes for destination %q", routes[1].Destination)
-		}
-		if len(nlRoutes) > 0 {
-			return fmt.Errorf("expected no routes for destination %q", routes[1].Destination)
-		}
+		// The cache entry must be evicted on the pod's terminal event.
+		require.NotContains(t, driver.podNetns, podUID, "cache entry should be evicted after StopPodSandbox")
+	}
 
-		return nil
-	}))
+	t.Run("run and stop with namespaces present", func(t *testing.T) {
+		driver, rootNS, podNS, podNSPath := setup(t)
+
+		podSandbox := liveSandbox(podNSPath)
+
+		require.NoError(t, rootNS.Do(func() error {
+			return driver.RunPodSandbox(t.Context(), podSandbox)
+		}))
+
+		require.NoError(t, rootNS.Do(func() error {
+			if _, err := safenetlink.LinkByName(deviceName); err == nil {
+				return fmt.Errorf("expected %q to be moved out of root netns", deviceName)
+			}
+			return nil
+		}))
+
+		require.NoError(t, podNS.Do(func() error {
+			if _, err := safenetlink.LinkByName(deviceName); err == nil {
+				return fmt.Errorf("expected %q to be renamed in pod netns", deviceName)
+			}
+
+			link, err := safenetlink.LinkByName(podIfName)
+			if err != nil {
+				return fmt.Errorf("expected %q to be moved into pod netns", podIfName)
+			}
+
+			if link.Attrs().Flags&net.FlagUp == 0 {
+				return fmt.Errorf("expected %q to be up", podIfName)
+			}
+
+			addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
+			if err != nil {
+				return fmt.Errorf("failed to list %q addresses", podIfName)
+			}
+			if found := slices.ContainsFunc(addrs, func(addr netlink.Addr) bool {
+				prefix, ok := netipx.FromStdIPNet(addr.IPNet)
+				if !ok {
+					return false
+				}
+				return ipv4Addr.Compare(prefix) == 0
+			}); !found {
+				return fmt.Errorf("expected address %q to be assigned to %q interface", ipv4Addr, podIfName)
+			}
+
+			nlRoutes, err := safenetlink.RouteListFiltered(
+				netlink.FAMILY_V4,
+				&netlink.Route{
+					LinkIndex: link.Attrs().Index,
+					Dst:       netipx.PrefixIPNet(routes[0].Destination),
+					Gw:        routes[0].Gateway.AsSlice(),
+				},
+				netlink.RT_FILTER_OIF|netlink.RT_FILTER_DST|netlink.RT_FILTER_GW,
+			)
+			if err != nil {
+				return fmt.Errorf("failed to list routes for %q", podIfName)
+			}
+			if len(nlRoutes) != 1 {
+				return fmt.Errorf("no route \"%s via %s dev %s\" found", routes[0].Destination, routes[0].Gateway, podIfName)
+			}
+
+			nlRoutes, err = safenetlink.RouteListFiltered(
+				netlink.FAMILY_V4,
+				&netlink.Route{
+					LinkIndex: link.Attrs().Index,
+					Dst:       netipx.PrefixIPNet(routes[1].Destination),
+				},
+				netlink.RT_FILTER_OIF|netlink.RT_FILTER_DST,
+			)
+			if err != nil {
+				return fmt.Errorf("failed to list routes for %q", podIfName)
+			}
+			if len(nlRoutes) != 1 {
+				return fmt.Errorf("no route \"%s dev %s\" found", routes[1].Destination, podIfName)
+			}
+
+			return nil
+		}))
+
+		require.NoError(t, rootNS.Do(func() error {
+			return driver.StopPodSandbox(t.Context(), podSandbox)
+		}))
+
+		require.NoError(t, podNS.Do(func() error {
+			if _, err := safenetlink.LinkByName(podIfName); err == nil {
+				return fmt.Errorf("expected %q to be moved out of pod netns", podIfName)
+			}
+			return nil
+		}))
+
+		require.NoError(t, rootNS.Do(func() error {
+			if _, err := safenetlink.LinkByName(podIfName); err == nil {
+				return fmt.Errorf("expected %q to be restored to %q in root netns", podIfName, deviceName)
+			}
+
+			link, err := safenetlink.LinkByName(deviceName)
+			if err != nil {
+				return err
+			}
+
+			if link.Attrs().Flags&net.FlagUp != 0 {
+				return fmt.Errorf("expected %q to be down", deviceName)
+			}
+
+			addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
+			if err != nil {
+				return fmt.Errorf("failed to list %q addresses", deviceName)
+			}
+			if found := slices.ContainsFunc(addrs, func(addr netlink.Addr) bool {
+				prefix, ok := netipx.FromStdIPNet(addr.IPNet)
+				if !ok {
+					return false
+				}
+				return ipv4Addr.Compare(prefix) == 0
+			}); found {
+				return fmt.Errorf("expected %q to have %s removed", deviceName, ipv4Addr)
+			}
+
+			nlRoutes, err := safenetlink.RouteListFiltered(
+				netlink.FAMILY_V4,
+				&netlink.Route{
+					Dst: netipx.PrefixIPNet(routes[0].Destination),
+					Gw:  routes[0].Gateway.AsSlice(),
+				},
+				netlink.RT_FILTER_DST|netlink.RT_FILTER_GW,
+			)
+			if err != nil {
+				return fmt.Errorf("failed to list routes for destination %q", routes[0].Destination)
+			}
+			if len(nlRoutes) > 0 {
+				return fmt.Errorf("expected no routes for destination %q", routes[0].Destination)
+			}
+
+			nlRoutes, err = safenetlink.RouteListFiltered(
+				netlink.FAMILY_V4,
+				&netlink.Route{
+					Dst: netipx.PrefixIPNet(routes[1].Destination),
+				},
+				netlink.RT_FILTER_DST,
+			)
+			if err != nil {
+				return fmt.Errorf("failed to list routes for destination %q", routes[1].Destination)
+			}
+			if len(nlRoutes) > 0 {
+				return fmt.Errorf("expected no routes for destination %q", routes[1].Destination)
+			}
+
+			return nil
+		}))
+	})
+
+	t.Run("stop recovers netns from RunPodSandbox cache", func(t *testing.T) {
+		driver, rootNS, podNS, podNSPath := setup(t)
+
+		// Task alive: RunPodSandbox moves the device in and caches the netns.
+		require.NoError(t, rootNS.Do(func() error {
+			return driver.RunPodSandbox(t.Context(), liveSandbox(podNSPath))
+		}))
+		require.Equal(t, podNSPath, driver.podNetns[podUID],
+			"RunPodSandbox should cache the pod netns while the task is alive")
+
+		assertBuggyStopRecovers(t, driver, rootNS, podNS)
+	})
+
+	t.Run("stop recovers netns from Synchronize after restart", func(t *testing.T) {
+		driver, rootNS, podNS, podNSPath := setup(t)
+
+		// A previous agent instance moved the device into the pod netns.
+		require.NoError(t, rootNS.Do(func() error {
+			return driver.RunPodSandbox(t.Context(), liveSandbox(podNSPath))
+		}))
+
+		// The agent restarts: its in-memory pod→netns cache is lost.
+		driver.podNetns = make(map[kubetypes.UID]string)
+
+		// The NRI plugin reconnects and replays every running pod via Synchronize,
+		// rebuilding the cache from the still-alive sandbox tasks.
+		_, err := driver.Synchronize(t.Context(), []*api.PodSandbox{liveSandbox(podNSPath)}, nil)
+		require.NoError(t, err)
+		require.Equal(t, podNSPath, driver.podNetns[podUID],
+			"Synchronize should rebuild the pod netns cache after a restart")
+
+		assertBuggyStopRecovers(t, driver, rootNS, podNS)
+	})
 }
 
 func pinNetNS(t *testing.T, ns *testnetns.NetNS, target string) {


### PR DESCRIPTION
containerd 1.7.x (through 1.7.29) and 2.0.x
kills the sandbox task before the NRI StopPodSandbox is called, and results in the PodSandbox passed in to not have the netns in it. this way, we can't
find the pod namespace to rename devices

this commit adds a fallback mechanism by
caching the pod -> netns mapping from the
StartPodSandbox hook, while also rebuilding
these mappings on startup (Synchronize hook)
In case the StopPodSandbox runs into a missing
netns, we consult the cache

```release-note
network driver: fix interface renaming due to empty netns on StopPodSandbox hook
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail AIL 3 (bot wrote, human reviewed and tested)
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
