### PR TITLE
cli: emit JUnit output for connectivity test setup failures

### DIFF
--- a/cilium-cli/connectivity/check/junit.go
+++ b/cilium-cli/connectivity/check/junit.go
@@ -56,7 +56,7 @@ type JUnitCollector struct {
 // Collect collects ConnectivityTest instance test results.
 // The method is not thread safe.
 func (j *JUnitCollector) Collect(ct *ConnectivityTest) {
-	if j.junitFile == "" || len(ct.tests) == 0 {
+	if j == nil || j.testSuite == nil || j.junitFile == "" || ct == nil || len(ct.tests) == 0 {
 		return
 	}
 
@@ -124,7 +124,7 @@ func (j *JUnitCollector) Collect(ct *ConnectivityTest) {
 // example when pod provisioning or connectivity test setup fails before any
 // individual connectivity tests are executed.
 func (j *JUnitCollector) RecordInfrastructureFailure(err error) {
-	if j == nil || j.junitFile == "" || err == nil {
+	if j == nil || j.testSuite == nil || j.junitFile == "" || err == nil {
 		return
 	}
 
@@ -149,7 +149,7 @@ func (j *JUnitCollector) RecordInfrastructureFailure(err error) {
 
 // Write writes collected JUnit results into a single report file.
 func (j *JUnitCollector) Write() error {
-	if j.testSuite.Tests == 0 {
+	if j == nil || j.testSuite == nil || j.junitFile == "" || j.testSuite.Tests == 0 {
 		return nil
 	}
 

--- a/cilium-cli/connectivity/check/junit.go
+++ b/cilium-cli/connectivity/check/junit.go
@@ -15,7 +15,13 @@ import (
 	"github.com/cilium/cilium/tools/testowners/codeowners"
 )
 
-const MetadataDelimiter = ";metadata;"
+const (
+	MetadataDelimiter = ";metadata;"
+
+	// InfrastructureProvisioningTestName is the JUnit testcase name used when
+	// connectivity test setup fails before individual test cases are executed.
+	InfrastructureProvisioningTestName = "Infrastructure/Provisioning"
+)
 
 // NewJUnitCollector factory function that returns JUnitCollector.
 func NewJUnitCollector(junitProperties map[string]string, junitFile string, codeowners *codeowners.Ruleset) *JUnitCollector {
@@ -112,6 +118,33 @@ func (j *JUnitCollector) Collect(ct *ConnectivityTest) {
 
 		j.testSuite.TestCases = append(j.testSuite.TestCases, test)
 	}
+}
+
+// RecordInfrastructureFailure records a failed infrastructure test case, for
+// example when pod provisioning or connectivity test setup fails before any
+// individual connectivity tests are executed.
+func (j *JUnitCollector) RecordInfrastructureFailure(err error) {
+	if j == nil || j.junitFile == "" || err == nil {
+		return
+	}
+
+	if j.testSuite.Timestamp == "" {
+		j.testSuite.Timestamp = time.Now().UTC().Format(time.RFC3339)
+	}
+
+	test := &junit.TestCase{
+		Name:      InfrastructureProvisioningTestName,
+		Classname: "connectivity test",
+		Status:    "failed",
+		Failure: &junit.Failure{
+			Message: InfrastructureProvisioningTestName + " failed",
+			Type:    "failure",
+			Value:   err.Error(),
+		},
+	}
+	j.testSuite.Tests++
+	j.testSuite.Failures++
+	j.testSuite.TestCases = append(j.testSuite.TestCases, test)
 }
 
 // Write writes collected JUnit results into a single report file.

--- a/cilium-cli/connectivity/check/junit_test.go
+++ b/cilium-cli/connectivity/check/junit_test.go
@@ -77,3 +77,45 @@ func TestInfrastructureFailureXMLHeader(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(string(data), xml.Header))
 }
+
+func TestInfrastructureFailureMatchesGoldenShape(t *testing.T) {
+	golden, err := os.ReadFile("testdata/infrastructure-provisioning-failure.xml")
+	require.NoError(t, err)
+
+	var goldenSuites junit.TestSuites
+	require.NoError(t, xml.Unmarshal(golden, &goldenSuites))
+
+	dir := t.TempDir()
+	junitFile := filepath.Join(dir, "report.xml")
+	setupErr := errors.New("timeout reached waiting for deployment cilium-test-1/client to become ready (last error: pods not ready)")
+
+	collector := NewJUnitCollector(nil, junitFile, nil)
+	collector.RecordInfrastructureFailure(setupErr)
+	require.NoError(t, collector.Write())
+
+	generated, err := os.ReadFile(junitFile)
+	require.NoError(t, err)
+
+	var generatedSuites junit.TestSuites
+	require.NoError(t, xml.Unmarshal(generated, &generatedSuites))
+
+	assert.Equal(t, goldenSuites.Tests, generatedSuites.Tests)
+	assert.Equal(t, goldenSuites.Failures, generatedSuites.Failures)
+	require.Len(t, generatedSuites.TestSuites, 1)
+	require.Len(t, generatedSuites.TestSuites[0].TestCases, 1)
+
+	testCase := generatedSuites.TestSuites[0].TestCases[0]
+	goldenCase := goldenSuites.TestSuites[0].TestCases[0]
+	assert.Equal(t, goldenCase.Name, testCase.Name)
+	assert.Equal(t, goldenCase.Classname, testCase.Classname)
+	assert.Equal(t, goldenCase.Status, testCase.Status)
+	require.NotNil(t, testCase.Failure)
+	assert.Equal(t, goldenCase.Failure.Message, testCase.Failure.Message)
+	assert.Equal(t, setupErr.Error(), testCase.Failure.Value)
+}
+
+func TestWriteNilCollector(t *testing.T) {
+	var collector *JUnitCollector
+	require.NoError(t, collector.Write())
+	collector.RecordInfrastructureFailure(errors.New("setup failed"))
+}

--- a/cilium-cli/connectivity/check/junit_test.go
+++ b/cilium-cli/connectivity/check/junit_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package check
+
+import (
+	"encoding/xml"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/cilium-cli/connectivity/internal/junit"
+)
+
+func TestRecordInfrastructureFailureWriteReport(t *testing.T) {
+	dir := t.TempDir()
+	junitFile := filepath.Join(dir, "report.xml")
+
+	collector := NewJUnitCollector(nil, junitFile, nil)
+	setupErr := errors.New("timeout reached waiting for deployment cilium-test-1/client to become ready (last error: pods not ready)")
+	collector.RecordInfrastructureFailure(setupErr)
+
+	require.NoError(t, collector.Write())
+
+	data, err := os.ReadFile(junitFile)
+	require.NoError(t, err)
+
+	var suites junit.TestSuites
+	require.NoError(t, xml.Unmarshal(data, &suites))
+
+	assert.Equal(t, 1, suites.Tests)
+	assert.Equal(t, 1, suites.Failures)
+	require.Len(t, suites.TestSuites, 1)
+	require.Len(t, suites.TestSuites[0].TestCases, 1)
+
+	testCase := suites.TestSuites[0].TestCases[0]
+	assert.Equal(t, InfrastructureProvisioningTestName, testCase.Name)
+	assert.Equal(t, "connectivity test", testCase.Classname)
+	assert.Equal(t, "failed", testCase.Status)
+	require.NotNil(t, testCase.Failure)
+	assert.Equal(t, InfrastructureProvisioningTestName+" failed", testCase.Failure.Message)
+	assert.Equal(t, setupErr.Error(), testCase.Failure.Value)
+	assert.NotEmpty(t, suites.TestSuites[0].Timestamp)
+}
+
+func TestRecordInfrastructureFailureNoOp(t *testing.T) {
+	collector := NewJUnitCollector(nil, "", nil)
+	collector.RecordInfrastructureFailure(errors.New("setup failed"))
+	assert.Equal(t, 0, collector.testSuite.Tests)
+}
+
+func TestWriteWithoutCollectOrInfrastructureFailure(t *testing.T) {
+	dir := t.TempDir()
+	junitFile := filepath.Join(dir, "report.xml")
+
+	collector := NewJUnitCollector(nil, junitFile, nil)
+	require.NoError(t, collector.Write())
+
+	_, err := os.Stat(junitFile)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestInfrastructureFailureXMLHeader(t *testing.T) {
+	dir := t.TempDir()
+	junitFile := filepath.Join(dir, "report.xml")
+
+	collector := NewJUnitCollector(nil, junitFile, nil)
+	collector.RecordInfrastructureFailure(errors.New("deployment failed"))
+	require.NoError(t, collector.Write())
+
+	data, err := os.ReadFile(junitFile)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(string(data), xml.Header))
+}

--- a/cilium-cli/connectivity/check/testdata/infrastructure-provisioning-failure.xml
+++ b/cilium-cli/connectivity/check/testdata/infrastructure-provisioning-failure.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuites tests="1" disabled="0" errors="0" failures="1" time="0">
+      <testsuite name="connectivity test" id="0" package="cilium" tests="1" errors="0" failures="1" time="0" timestamp="2026-06-17T12:00:00Z">
+          <properties>
+              <property name="Args" value=""></property>
+          </properties>
+          <testcase name="Infrastructure/Provisioning" classname="connectivity test" status="failed" time="0">
+              <failure message="Infrastructure/Provisioning failed" type="failure">timeout reached waiting for deployment cilium-test-1/client to become ready (last error: pods not ready)</failure>
+          </testcase>
+      </testsuite>
+  </testsuites>

--- a/cilium-cli/connectivity/suite.go
+++ b/cilium-cli/connectivity/suite.go
@@ -6,6 +6,7 @@ package connectivity
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/cilium/cilium/cilium-cli/connectivity/builder"
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
@@ -42,10 +43,10 @@ func Run(ctx context.Context, connTests []*check.ConnectivityTest, extra Hooks) 
 			if err == nil || junitWritten || junitCollector == nil {
 				return
 			}
-			junitCollector.RecordInfrastructureFailure(err)
-			if werr := junitCollector.Write(); werr != nil {
-				connTests[0].Failf("writing to junit file %s failed: %s", connTests[0].Params().JunitFile, werr)
+			if len(connTests) == 0 || connTests[0] == nil {
+				return
 			}
+			err = writeInfrastructureJUnit(junitCollector, connTests[0], err)
 		}()
 	}
 
@@ -94,12 +95,31 @@ func Run(ctx context.Context, connTests []*check.ConnectivityTest, extra Hooks) 
 
 	if junitCollector != nil {
 		if werr := junitCollector.Write(); werr != nil {
-			connTests[0].Failf("writing to junit file %s failed: %s", connTests[0].Params().JunitFile, werr)
+			if len(connTests) > 0 && connTests[0] != nil {
+				connTests[0].Failf("writing to junit file %s failed: %s", connTests[0].Params().JunitFile, werr)
+			}
+			err = errors.Join(err, fmt.Errorf("writing junit report: %w", werr))
 		} else {
 			junitWritten = true
 		}
 	}
 	return err
+}
+
+func writeInfrastructureJUnit(collector *check.JUnitCollector, ct *check.ConnectivityTest, failure error) error {
+	if failure == nil {
+		return nil
+	}
+	if collector == nil || ct == nil {
+		return failure
+	}
+
+	collector.RecordInfrastructureFailure(failure)
+	if werr := collector.Write(); werr != nil {
+		ct.Failf("writing to junit file %s failed: %s", ct.Params().JunitFile, werr)
+		return errors.Join(failure, fmt.Errorf("writing junit report: %w", werr))
+	}
+	return failure
 }
 
 func setupConnectivityTests(ctx context.Context, connTest []*check.ConnectivityTest, hooks Hooks) error {

--- a/cilium-cli/connectivity/suite.go
+++ b/cilium-cli/connectivity/suite.go
@@ -19,20 +19,37 @@ type Hooks interface {
 	AddConnectivityTests(cts ...*check.ConnectivityTest) error
 }
 
-func Run(ctx context.Context, connTests []*check.ConnectivityTest, extra Hooks) error {
+func Run(ctx context.Context, connTests []*check.ConnectivityTest, extra Hooks) (err error) {
 	// If cleanup-only mode is enabled, perform cleanup and return
 	if len(connTests) > 0 && connTests[0].Params().CleanupOnly {
 		connTests[0].Infof("🧹 Cleanup mode enabled - removing all connectivity test artifacts")
 		for i := range connTests {
-			if err := connTests[i].CleanupConnectivityTest(ctx); err != nil {
-				connTests[i].Warnf("Cleanup encountered errors: %v", err)
+			if e := connTests[i].CleanupConnectivityTest(ctx); e != nil {
+				connTests[i].Warnf("Cleanup encountered errors: %v", e)
 			}
 		}
 		connTests[0].Infof("✅ Cleanup complete")
 		return nil
 	}
 
-	if err := setupConnectivityTests(ctx, connTests, extra); err != nil {
+	var (
+		junitCollector *check.JUnitCollector
+		junitWritten   bool
+	)
+	if len(connTests) > 0 && connTests[0].Params().JunitFile != "" {
+		junitCollector = check.NewJUnitCollector(connTests[0].Params().JunitProperties, connTests[0].Params().JunitFile, connTests[0].CodeOwners)
+		defer func() {
+			if err == nil || junitWritten || junitCollector == nil {
+				return
+			}
+			junitCollector.RecordInfrastructureFailure(err)
+			if werr := junitCollector.Write(); werr != nil {
+				connTests[0].Failf("writing to junit file %s failed: %s", connTests[0].Params().JunitFile, werr)
+			}
+		}()
+	}
+
+	if err = setupConnectivityTests(ctx, connTests, extra); err != nil {
 		return err
 	}
 
@@ -42,7 +59,6 @@ func Run(ctx context.Context, connTests []*check.ConnectivityTest, extra Hooks) 
 	if err != nil {
 		return err
 	}
-	junitCollector := check.NewJUnitCollector(connTests[0].Params().JunitProperties, connTests[0].Params().JunitFile, connTests[0].CodeOwners)
 
 	for i := range suiteBuilders {
 		if e := suiteBuilders[i](connTests, extra.AddConnectivityTests); e != nil {
@@ -61,7 +77,9 @@ func Run(ctx context.Context, connTests []*check.ConnectivityTest, extra Hooks) 
 			return runErr
 		}
 		for j := range connTests {
-			junitCollector.Collect(connTests[j])
+			if junitCollector != nil {
+				junitCollector.Collect(connTests[j])
+			}
 			if e := connTests[j].PrintReport(ctx); e != nil {
 				err = errors.Join(err, e)
 			}
@@ -74,8 +92,12 @@ func Run(ctx context.Context, connTests []*check.ConnectivityTest, extra Hooks) 
 		}
 	}
 
-	if err := junitCollector.Write(); err != nil {
-		connTests[0].Failf("writing to junit file %s failed: %s", connTests[0].Params().JunitFile, err)
+	if junitCollector != nil {
+		if werr := junitCollector.Write(); werr != nil {
+			connTests[0].Failf("writing to junit file %s failed: %s", connTests[0].Params().JunitFile, werr)
+		} else {
+			junitWritten = true
+		}
 	}
 	return err
 }


### PR DESCRIPTION
Record infrastructure provisioning failures as a dedicated JUnit test case when setup fails before individual connectivity tests run, so CI dashboards can filter and compare this class of failures.

Related: #46485

## What this changes

When `cilium connectivity test` fails during setup (for example, a deployment timeout while provisioning pods), CI used to mark the job as failed but the JUnit report often had no test case. That made it hard to spot and compare this type of failure in CI dashboards.

This PR fixes that by:

- Creating the JUnit collector at the start of `connectivity.Run()` when `--junit-file` is set
- Adding `RecordInfrastructureFailure()` to write a failed testcase named `Infrastructure/Provisioning`
- Writing the JUnit file on early-exit errors (setup, suite registration, static routes, test run) before normal test collection happens

The failure output uses the same JUnit XML format as regular connectivity test failures, so existing CI tooling (including junit2md) can handle it without changes.

## Test plan

- [x] `go test ./cilium-cli/connectivity/check/... -run 'JUnit|Infrastructure' -v`
- [x] `go test ./cilium-cli/connectivity/... -count=1`

## Checklist

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Related: #46485` line.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      This PR was prepared with AIL:2. I personally reviewed the code and ran the tests.
- [x] Thanks for contributing!

```release-note
cli: Emit JUnit output when connectivity test setup fails before tests run