### PR TITLE
AWS IPAM IPv6 prefix support on operator

### DIFF
--- a/operator/pkg/ipam/nodemanager/node.go
+++ b/operator/pkg/ipam/nodemanager/node.go
@@ -929,7 +929,13 @@ func (n *Node) determineMaintenanceAction() (*maintenanceAction, error) {
 	stats := n.Stats()
 	// Validate that the node still requires addresses to be released, the
 	// request may have been resolved in the meantime.
-	if n.manager.releaseExcessIPs && stats.IPv4.ExcessIPs > 0 {
+
+	// Multi-pool nodes don't use the 4-state handshake. Release is
+	// handled by handleMultiPoolCIDRRelease.
+	n.mutex.RLock()
+	isMultiPool := n.isMultiPoolNodeLocked()
+	n.mutex.RUnlock()
+	if !isMultiPool && n.manager.releaseExcessIPs && stats.IPv4.ExcessIPs > 0 {
 		a.release = n.ops.PrepareIPRelease(stats.IPv4.ExcessIPs, n.logger.Load())
 		if a.release != nil && len(a.release.IPsToRelease) > 0 {
 			return a, nil

--- a/operator/pkg/ipam/nodemanager/node.go
+++ b/operator/pkg/ipam/nodemanager/node.go
@@ -99,7 +99,10 @@ type Node struct {
 	// ipv4Alloc represents IPv4-specific allocation attributes for this node
 	ipv4Alloc ipAllocAttrs
 
-	// TODO: Add support for IPv6 allocation: https://github.com/cilium/cilium/issues/19251
+	// waitingForPoolMaintenance is true when the node is subject to an
+	// IP address allocation or release which must be performed before
+	// another allocation or release can be attempted
+	waitingForPoolMaintenance bool
 
 	// resyncNeeded is set to the current time when a resync with the
 	// instances API is required. The timestamp is required to ensure that this is
@@ -155,11 +158,6 @@ type Node struct {
 
 // ipAllocAttrs represents IP-specific allocation attributes.
 type ipAllocAttrs struct {
-	// waitingForPoolMaintenance is true when the node is subject to an
-	// IP address allocation or release which must be performed before
-	// another allocation or release can be attempted
-	waitingForPoolMaintenance bool
-
 	// available is the map of IP addresses available to this node
 	available ipamTypes.AllocationMap
 
@@ -197,6 +195,12 @@ type IPStatistics struct {
 	// AvailableIPs is the number of IPs currently allocated and available for assignment.
 	AvailableIPs int
 
+	// AvailablePrefixes is the number of IP prefixes currently allocated and
+	// available for assignment. (Used for IPv6 prefixes)
+	// Since IPv6 prefixes are very large it does not make sense to keep track of
+	// the effective number of IPv6 addresses available for assignment.
+	AvailablePrefixes int
+
 	// Capacity is the max inferred IPAM IP capacity for the node.
 	// In theory, this provides an upper limit on the number of Cilium IPs that
 	// this Node can support.
@@ -205,6 +209,11 @@ type IPStatistics struct {
 	// NeededIPs is the number of IPs needed to reach the PreAllocate
 	// watermark
 	NeededIPs int
+
+	// NeededPrefixes is the number of prefixes needed.
+	//
+	// Used for IPv6 prefixes
+	NeededPrefixes int
 
 	// ExcessIPs is the number of free IPs exceeding MaxAboveWatermark
 	ExcessIPs int
@@ -310,14 +319,14 @@ func (n *Node) getMaxAllocate() int {
 func (n *Node) getStaticIPTags() ipamTypes.Tags {
 	if n.resource.Spec.IPAM.StaticIPTags != nil {
 		return n.resource.Spec.IPAM.StaticIPTags
-	} else {
-		return ipamTypes.Tags{}
 	}
+	return ipamTypes.Tags{}
 }
 
 // GetNeededAddresses returns the number of needed addresses that need to be
 // allocated or released. A positive number is returned to indicate allocation.
 // A negative number is returned to indicate release of addresses.
+// This only checks IPv4 since IPv6 subnets rarely reach exhaustion
 func (n *Node) GetNeededAddresses() int {
 	stats := n.Stats()
 
@@ -355,12 +364,8 @@ func getPendingPodCount(nodeName string) (int, error) {
 	return pendingPods, nil
 }
 
-func calculateNeededIPs(availableIPs, usedIPs, preAllocate, minAllocate, maxAllocate int) (neededIPs int) {
-	neededIPs = preAllocate - (availableIPs - usedIPs)
-
-	if minAllocate > 0 {
-		neededIPs = max(neededIPs, minAllocate-availableIPs)
-	}
+func calculateNeededIPs(availableIPs, usedIPs, preAllocate, minAllocate, maxAllocate int) int {
+	neededIPs := max(preAllocate+usedIPs-availableIPs, minAllocate-availableIPs)
 
 	// If maxAllocate is set (> 0) and neededIPs is higher than the
 	// maxAllocate value, we only return the amount of IPs that can
@@ -369,10 +374,7 @@ func calculateNeededIPs(availableIPs, usedIPs, preAllocate, minAllocate, maxAllo
 		neededIPs = maxAllocate - availableIPs
 	}
 
-	if neededIPs < 0 {
-		neededIPs = 0
-	}
-	return
+	return max(neededIPs, 0)
 }
 
 func calculateExcessIPs(availableIPs, usedIPs, preAllocate, minAllocate, maxAboveWatermark int) (excessIPs int) {
@@ -404,17 +406,17 @@ func calculateExcessIPs(availableIPs, usedIPs, preAllocate, minAllocate, maxAbov
 	return
 }
 
-// poolRequestedIPv4 returns the total IPv4 address demand from the "default"
-// pool in Spec.IPAM.Pools.Requested, if present. This field is written by
-// agents using the multi-pool allocator. Agents using the CRD allocator do
-// not populate this field.
-func poolRequestedIPv4(resource *v2.CiliumNode) (int, bool) {
+// poolRequestedIPs returns the total IPv4 and IPv6 address demand from the
+// "default" pool in Spec.IPAM.Pools.Requested, if present. This field is
+// written by agents using the multi-pool allocator. Agents using the CRD
+// allocator do not populate this field.
+func poolRequestedIPs(resource *v2.CiliumNode) (int, int, bool) {
 	for _, req := range resource.Spec.IPAM.Pools.Requested {
 		if req.Pool == defaults.IPAMDefaultIPPool {
-			return req.Needed.IPv4Addrs, true
+			return req.Needed.IPv4Addrs, req.Needed.IPv6Addrs, true
 		}
 	}
-	return 0, false
+	return 0, 0, false
 }
 
 // isMultiPoolNodeLocked returns true if this node's agent uses the multi-pool
@@ -426,7 +428,7 @@ func (n *Node) isMultiPoolNodeLocked() bool {
 	if n.resource == nil {
 		return false
 	}
-	_, hasPoolRequest := poolRequestedIPv4(n.resource)
+	_, _, hasPoolRequest := poolRequestedIPs(n.resource)
 	return hasPoolRequest && len(n.resource.Status.IPAM.Used) == 0
 }
 
@@ -454,7 +456,7 @@ func (n *Node) trackMultiPoolAllocatedLocked() {
 	now := time.Now()
 
 	if n.previousAllocatedCIDRs == nil {
-		// Seed: mark any CIDR attached on the ENI but missing from
+		// Seed: mark any IPv4 CIDR attached on the ENI but missing from
 		// Allocated. Recovers releases that would otherwise be lost
 		// across operator restart (the agent removed the CIDR while
 		// the operator was down, so there is no transition to observe
@@ -464,7 +466,7 @@ func (n *Node) trackMultiPoolAllocatedLocked() {
 		// excessIPReleaseDelay, and the reconciliation loop below will
 		// clear them from the marked map before any EC2 call happens.
 		for _, cidr := range attachedCIDRs {
-			if !currentCIDRs.Has(cidr) {
+			if cidr.Addr().Is4() && !currentCIDRs.Has(cidr) {
 				n.multiPoolCIDRsMarkedForRelease[cidr] = now
 				n.logger.Load().Debug("Marking CIDR for release at seed", logfields.CIDR, cidr)
 			}
@@ -474,7 +476,7 @@ func (n *Node) trackMultiPoolAllocatedLocked() {
 	}
 
 	for cidr := range n.previousAllocatedCIDRs {
-		if !currentCIDRs.Has(cidr) {
+		if cidr.Addr().Is4() && !currentCIDRs.Has(cidr) {
 			if _, already := n.multiPoolCIDRsMarkedForRelease[cidr]; !already {
 				n.multiPoolCIDRsMarkedForRelease[cidr] = now
 				n.logger.Load().Debug("Marking CIDR for release", logfields.CIDR, cidr)
@@ -577,13 +579,13 @@ func (n *Node) handleMultiPoolCIDRRelease(ctx context.Context) (bool, error) {
 
 func (n *Node) requirePoolMaintenance() {
 	n.mutex.Lock()
-	n.ipv4Alloc.waitingForPoolMaintenance = true
+	n.waitingForPoolMaintenance = true
 	n.mutex.Unlock()
 }
 
 func (n *Node) poolMaintenanceComplete() {
 	n.mutex.Lock()
-	n.ipv4Alloc.waitingForPoolMaintenance = false
+	n.waitingForPoolMaintenance = false
 	n.mutex.Unlock()
 }
 
@@ -675,6 +677,7 @@ func (n *Node) recalculate(ctx context.Context) {
 	n.stats.IPv4.AvailableIPs = len(n.ipv4Alloc.available)
 	n.stats.IPv4.RemainingInterfaces = stats.RemainingAvailableInterfaceCount
 	n.stats.IPv4.Capacity = stats.NodeCapacity
+	n.stats.IPv6.AvailablePrefixes = stats.NodeIPv6Prefixes
 
 	// Starting with 1.20, agents use the multi-pool allocator in ENI IPAM mode
 	// and write their demand to Spec.IPAM.Pools.Requested (and stop writing
@@ -686,10 +689,17 @@ func (n *Node) recalculate(ctx context.Context) {
 	// Both those logic branches exist in order to offer a smooth upgrade/downgrade path
 	// between 1.19 and 1.20: an operator upgraded to 1.20 will still honor the API
 	// contract expected by 1.19 agents.
-	if requested, ok := poolRequestedIPv4(n.resource); ok && len(n.resource.Status.IPAM.Used) == 0 {
+	if requestedIPv4, requestedIPv6, ok := poolRequestedIPs(n.resource); ok && len(n.resource.Status.IPAM.Used) == 0 {
 		// The agent's demand is computed as inUse + preAllocate (linear
 		// pre-allocation). Subtracting preAllocate recovers exact usage.
-		n.stats.IPv4.UsedIPs = max(0, requested-n.getPreAllocate())
+		n.stats.IPv4.UsedIPs = max(0, requestedIPv4-n.getPreAllocate())
+		// If the agent uses IPv6 and no IPv6 prefix is available on the
+		// node, request one. A single prefix is enough and is never
+		// released, so reset to 0 once a prefix is present.
+		n.stats.IPv6.NeededPrefixes = 0
+		if requestedIPv6 > 0 && n.stats.IPv6.AvailablePrefixes == 0 {
+			n.stats.IPv6.NeededPrefixes = 1
+		}
 	} else {
 		n.stats.IPv4.UsedIPs = len(n.resource.Status.IPAM.Used)
 	}
@@ -699,11 +709,13 @@ func (n *Node) recalculate(ctx context.Context) {
 	scopedLog.Debug(
 		"Recalculated needed addresses",
 		logfields.Available, n.stats.IPv4.AvailableIPs,
+		logfields.AvailableIPv6Prefixes, n.stats.IPv6.AvailablePrefixes,
 		logfields.Capacity, n.stats.IPv4.Capacity,
 		logfields.Used, n.stats.IPv4.UsedIPs,
 		logfields.ToAllocate, n.stats.IPv4.NeededIPs,
 		logfields.ToRelease, n.stats.IPv4.ExcessIPs,
-		logfields.WaitingForPoolMaintenance, n.ipv4Alloc.waitingForPoolMaintenance,
+		logfields.NeededIPv6Prefixes, n.stats.IPv6.NeededPrefixes,
+		logfields.WaitingForPoolMaintenance, n.waitingForPoolMaintenance,
 		logfields.ResyncNeeded, n.resyncNeeded,
 		logfields.RemainingInterfaces, stats.RemainingAvailableInterfaceCount,
 	)
@@ -714,7 +726,7 @@ func (n *Node) allocationNeeded() bool {
 	n.mutex.RLock()
 	defer n.mutex.RUnlock()
 
-	if n.ipv4Alloc.waitingForPoolMaintenance {
+	if n.waitingForPoolMaintenance {
 		return false
 	}
 
@@ -722,21 +734,17 @@ func (n *Node) allocationNeeded() bool {
 		return false
 	}
 
-	if n.stats.IPv4.NeededIPs > 0 {
-		return true
-	}
-
 	if len(n.getStaticIPTags()) > 0 && n.stats.IPv4.AssignedStaticIP == "" {
 		return true
 	}
 
-	return false
+	return n.stats.IPv4.NeededIPs > 0 || n.stats.IPv6.NeededPrefixes > 0
 }
 
 // releaseNeeded returns true if this node requires IPs to be released
 func (n *Node) releaseNeeded() (needed bool) {
 	n.mutex.RLock()
-	needed = n.manager.releaseExcessIPs && !n.ipv4Alloc.waitingForPoolMaintenance && n.resyncNeeded.IsZero() && n.stats.IPv4.ExcessIPs > 0
+	needed = n.manager.releaseExcessIPs && !n.waitingForPoolMaintenance && n.resyncNeeded.IsZero() && n.stats.IPv4.ExcessIPs > 0
 	if n.resource != nil {
 		releaseInProgress := len(n.resource.Status.IPAM.ReleaseIPs) > 0
 		needed = needed || releaseInProgress
@@ -834,6 +842,9 @@ type AllocationAction struct {
 
 	// IPv4 represents IPv4-specific allocation actions.
 	IPv4 IPAllocationAction
+
+	// IPv6 represents IPv6-specific allocation actions.
+	IPv6 IPAllocationAction
 }
 
 // IPAllocationAction is the IP-specific action to be taken to resolve allocation deficits
@@ -851,6 +862,11 @@ type IPAllocationAction struct {
 	// defined by NodeOperations.{ MinAllocate() | PreAllocate() |
 	// getMaxAboveWatermark() }.
 	MaxIPsToAllocate int
+
+	// MaxPrefixesToAllocate is set by the core IPAM layer before
+	// NodeOperations.AllocateIPs() is called and defines the maximum
+	// number of prefixes to allocate.
+	MaxPrefixesToAllocate int
 
 	// InterfaceCandidates is the number of attached interfaces with IPs
 	// available for allocation.
@@ -922,7 +938,7 @@ func (n *Node) determineMaintenanceAction() (*maintenanceAction, error) {
 
 	// Validate that the node still requires addresses to be allocated, the
 	// request may have been resolved in the meantime.
-	if stats.IPv4.NeededIPs == 0 {
+	if stats.IPv4.NeededIPs == 0 && stats.IPv6.NeededPrefixes == 0 {
 		return nil, nil
 	}
 
@@ -950,27 +966,25 @@ func (n *Node) determineMaintenanceAction() (*maintenanceAction, error) {
 	a.allocation.IPv4.MaxIPsToAllocate = stats.IPv4.NeededIPs + n.getMaxAboveWatermark() + surgeAllocate
 	n.mutex.RUnlock()
 
-	scopedLog := n.logger.Load()
-	if a.allocation != nil {
-		n.mutex.Lock()
-		n.stats.IPv4.RemainingInterfaces = a.allocation.IPv4.InterfaceCandidates + a.allocation.EmptyInterfaceSlots
-		stats = n.stats
-		n.mutex.Unlock()
-		scopedLog = n.logger.Load().With(
-			logfields.SelectedInterface, a.allocation.InterfaceID,
-			logfields.SelectedPoolID, a.allocation.PoolID,
-			logfields.MaxIPsToAllocate, a.allocation.IPv4.MaxIPsToAllocate,
-			logfields.AvailableForAllocation, a.allocation.IPv4.AvailableForAllocation,
-			logfields.EmptyInterfaceSlots, a.allocation.EmptyInterfaceSlots,
-		)
-	}
+	a.allocation.IPv6.MaxPrefixesToAllocate = stats.IPv6.NeededPrefixes
 
-	scopedLog.Info(
+	n.mutex.Lock()
+	n.stats.IPv4.RemainingInterfaces = a.allocation.IPv4.InterfaceCandidates + a.allocation.EmptyInterfaceSlots
+	stats = n.stats
+	n.mutex.Unlock()
+
+	n.logger.Load().Info(
 		"Resolving IP deficit of node",
 		logfields.Available, stats.IPv4.AvailableIPs,
 		logfields.Used, stats.IPv4.UsedIPs,
 		logfields.NeededIPs, stats.IPv4.NeededIPs,
+		logfields.NeededIPv6Prefixes, stats.IPv6.NeededPrefixes,
 		logfields.RemainingInterfaces, stats.IPv4.RemainingInterfaces,
+		logfields.SelectedInterface, a.allocation.InterfaceID,
+		logfields.SelectedPoolID, a.allocation.PoolID,
+		logfields.MaxIPsToAllocate, a.allocation.IPv4.MaxIPsToAllocate,
+		logfields.AvailableForAllocation, a.allocation.IPv4.AvailableForAllocation,
+		logfields.EmptyInterfaceSlots, a.allocation.EmptyInterfaceSlots,
 	)
 
 	return a, nil
@@ -1204,7 +1218,7 @@ func (n *Node) handleIPAllocation(ctx context.Context, a *maintenanceAction) (in
 	}
 
 	// Assign needed addresses
-	if a.allocation.IPv4.AvailableForAllocation > 0 {
+	if a.allocation.IPv4.AvailableForAllocation > 0 || a.allocation.IPv6.MaxPrefixesToAllocate > 0 {
 		a.allocation.IPv4.AvailableForAllocation = min(a.allocation.IPv4.AvailableForAllocation, a.allocation.IPv4.MaxIPsToAllocate)
 
 		start := time.Now()

--- a/operator/pkg/ipam/nodemanager/node_test.go
+++ b/operator/pkg/ipam/nodemanager/node_test.go
@@ -119,7 +119,7 @@ func TestSyncToAPIServerForNonExistingNode(t *testing.T) {
 }
 
 func TestPoolRequestedIPv4(t *testing.T) {
-	t.Run("returns demand from default pool", func(t *testing.T) {
+	t.Run("returns IPv4 demand from default pool", func(t *testing.T) {
 		cn := &v2.CiliumNode{}
 		cn.Spec.IPAM.Pools.Requested = []ipamTypes.IPAMPoolRequest{
 			{
@@ -127,14 +127,44 @@ func TestPoolRequestedIPv4(t *testing.T) {
 				Needed: ipamTypes.IPAMPoolDemand{IPv4Addrs: 24},
 			},
 		}
-		requested, ok := poolRequestedIPv4(cn)
+		requestedIPv4, _, ok := poolRequestedIPs(cn)
 		require.True(t, ok)
-		require.Equal(t, 24, requested)
+		require.Equal(t, 24, requestedIPv4)
+	})
+
+	t.Run("returns IPv6 demand from default pool", func(t *testing.T) {
+		cn := &v2.CiliumNode{}
+		cn.Spec.IPAM.Pools.Requested = []ipamTypes.IPAMPoolRequest{
+			{
+				Pool:   defaults.IPAMDefaultIPPool,
+				Needed: ipamTypes.IPAMPoolDemand{IPv6Addrs: 48},
+			},
+		}
+		_, requestedIPv6, ok := poolRequestedIPs(cn)
+		require.True(t, ok)
+		require.Equal(t, 48, requestedIPv6)
+	})
+
+	t.Run("returns IPv4/IPv6 demand from default pool", func(t *testing.T) {
+		cn := &v2.CiliumNode{}
+		cn.Spec.IPAM.Pools.Requested = []ipamTypes.IPAMPoolRequest{
+			{
+				Pool: defaults.IPAMDefaultIPPool,
+				Needed: ipamTypes.IPAMPoolDemand{
+					IPv4Addrs: 24,
+					IPv6Addrs: 48,
+				},
+			},
+		}
+		requestedIPv4, requestedIPv6, ok := poolRequestedIPs(cn)
+		require.True(t, ok)
+		require.Equal(t, 24, requestedIPv4)
+		require.Equal(t, 48, requestedIPv6)
 	})
 
 	t.Run("returns false when no Requested entries", func(t *testing.T) {
 		cn := &v2.CiliumNode{}
-		_, ok := poolRequestedIPv4(cn)
+		_, _, ok := poolRequestedIPs(cn)
 		require.False(t, ok)
 	})
 
@@ -146,7 +176,7 @@ func TestPoolRequestedIPv4(t *testing.T) {
 				Needed: ipamTypes.IPAMPoolDemand{IPv4Addrs: 10},
 			},
 		}
-		_, ok := poolRequestedIPv4(cn)
+		_, _, ok := poolRequestedIPs(cn)
 		require.False(t, ok)
 	})
 
@@ -154,13 +184,17 @@ func TestPoolRequestedIPv4(t *testing.T) {
 		cn := &v2.CiliumNode{}
 		cn.Spec.IPAM.Pools.Requested = []ipamTypes.IPAMPoolRequest{
 			{
-				Pool:   defaults.IPAMDefaultIPPool,
-				Needed: ipamTypes.IPAMPoolDemand{IPv4Addrs: 0},
+				Pool: defaults.IPAMDefaultIPPool,
+				Needed: ipamTypes.IPAMPoolDemand{
+					IPv4Addrs: 0,
+					IPv6Addrs: 0,
+				},
 			},
 		}
-		requested, ok := poolRequestedIPv4(cn)
+		requestedIPv4, requestedIPv6, ok := poolRequestedIPs(cn)
 		require.True(t, ok)
-		require.Equal(t, 0, requested)
+		require.Equal(t, 0, requestedIPv4)
+		require.Equal(t, 0, requestedIPv6)
 	})
 }
 

--- a/operator/pkg/ipam/stats/stats.go
+++ b/operator/pkg/ipam/stats/stats.go
@@ -17,11 +17,8 @@ type InterfaceStats struct {
 	// for IPv4 address allocation.
 	RemainingAvailableInterfaceCount int
 
-	// NodeIPv6Capacity is the current inferred total capacity for a Node to schedule
-	// IPv6 addresses.
-	//
-	// This does not account for currently used addresses.
-	NodeIPv6Capacity int
+	// NodeIPv6Prefixes is the current number of IPv6 prefixes available on the node.
+	NodeIPv6Prefixes int
 
 	// RemainingAvailableIPv6InterfaceCount is the number of interfaces currently available
 	// for IPv6 address allocation.

--- a/pkg/aws/api/api.go
+++ b/pkg/aws/api/api.go
@@ -47,6 +47,7 @@ const (
 	OperationNotPermittedStr = "OperationNotPermitted"
 
 	AssignPrivateIpAddresses        = "AssignPrivateIpAddresses"
+	AssignIPv6Addresses             = "AssignIPv6Addresses"
 	AssociateAddress                = "AssociateAddress"
 	AttachNetworkInterface          = "AttachNetworkInterface"
 	CreateNetworkInterface          = "CreateNetworkInterface"
@@ -552,6 +553,14 @@ func parseENI(iface *ec2_types.NetworkInterface, vpcs ipamTypes.VirtualNetworkMa
 		eni.Prefixes = append(eni.Prefixes, iputil.PrefixFrom(p))
 	}
 
+	for _, prefix := range iface.Ipv6Prefixes {
+		p, err := netip.ParsePrefix(aws.ToString(prefix.Ipv6Prefix))
+		if err != nil {
+			return "", nil, fmt.Errorf("unable to parse ENI IPv6 prefix: %w", err)
+		}
+		eni.IPv6Prefixes = append(eni.IPv6Prefixes, iputil.PrefixFrom(p))
+	}
+
 	// An Association can be present without a public IPv4 address (e.g. an
 	// IPv6-only, carrier or customer-owned-IP association), in which case
 	// PublicIp is a non-nil pointer to an empty string. Guard on the
@@ -812,8 +821,7 @@ func (c *Client) GetRouteTables(ctx context.Context, vpcID string) (ipamTypes.Ro
 }
 
 // CreateNetworkInterface creates an ENI with the given parameters
-func (c *Client) CreateNetworkInterface(ctx context.Context, toAllocate int32, subnetID, desc string, groups []string, allocatePrefixes bool) (string, *types.ENI, error) {
-
+func (c *Client) CreateNetworkInterface(ctx context.Context, toAllocate int32, subnetID, desc string, groups []string, allocatePrefixes, allocateIPv6 bool) (string, *types.ENI, error) {
 	input := &ec2.CreateNetworkInterfaceInput{
 		Description: aws.String(desc),
 		SubnetId:    aws.String(subnetID),
@@ -833,6 +841,11 @@ func (c *Client) CreateNetworkInterface(ctx context.Context, toAllocate int32, s
 		input.TagSpecifications = []ec2_types.TagSpecification{
 			c.eniTagSpecification,
 		}
+	}
+
+	if allocateIPv6 {
+		// One AWS IPv6 Prefix has 2^48 addresses which is enormous.
+		input.Ipv6PrefixCount = aws.Int32(1)
 	}
 
 	c.limiter.Limit(ctx, CreateNetworkInterface)
@@ -965,6 +978,21 @@ func (c *Client) AssignENIPrefixes(ctx context.Context, eniID string, prefixes i
 	sinceStart := spanstat.Start()
 	_, err := c.ec2Client.AssignPrivateIpAddresses(ctx, input)
 	c.metricsAPI.ObserveAPICall(AssignPrivateIpAddresses, deriveStatus(err), sinceStart.Seconds())
+	return err
+}
+
+// AssignENIIPv6Prefix assigns one IPv6 prefix to the ENI.
+// One AWS IPv6 Prefix has 2^48 addresses which is enormous.
+func (c *Client) AssignENIIPv6Prefix(ctx context.Context, eniID string) error {
+	input := &ec2.AssignIpv6AddressesInput{
+		NetworkInterfaceId: aws.String(eniID),
+		Ipv6PrefixCount:    aws.Int32(1),
+	}
+
+	c.limiter.Limit(ctx, AssignIPv6Addresses)
+	sinceStart := spanstat.Start()
+	_, err := c.ec2Client.AssignIpv6Addresses(ctx, input)
+	c.metricsAPI.ObserveAPICall(AssignIPv6Addresses, deriveStatus(err), sinceStart.Seconds())
 	return err
 }
 

--- a/pkg/aws/api/mock/mock.go
+++ b/pkg/aws/api/mock/mock.go
@@ -42,6 +42,7 @@ const (
 	AttachNetworkInterface
 	ModifyNetworkInterface
 	AssignPrivateIpAddresses
+	AssignIPv6Addresses
 	UnassignPrivateIpAddresses
 	TagENI
 	AssociateEIP
@@ -61,6 +62,7 @@ type API struct {
 	errors         map[Operation]error
 	allocator      *ipallocator.Range
 	pdAllocator    *cidrset.CidrSet
+	ipv6Allocator  *cidrset.CidrSet
 	limiter        *rate.Limiter
 	delaySim       *helpers.DelaySimulator
 	pdSubnet       netip.Prefix
@@ -80,6 +82,12 @@ func NewAPI(subnets []*ipamTypes.Subnet, vpcs []*ipamTypes.VirtualNetwork, secur
 	// Use 10.10.128.0/17 for prefix allocations
 	pdCidr, _ := cidrSet.AllocateNext()
 	pdCidrRange, err := cidrset.NewCIDRSet(pdCidr, 28)
+	if err != nil {
+		panic(err)
+	}
+
+	// Use fd00:0:0:1::/64 for IPv6 prefixes (allocated as /80s)
+	ipv6CidrRange, err := cidrset.NewCIDRSet(netip.MustParsePrefix("fd00:0:0:1::/64"), 80)
 	if err != nil {
 		panic(err)
 	}
@@ -177,6 +185,7 @@ func NewAPI(subnets []*ipamTypes.Subnet, vpcs []*ipamTypes.VirtualNetwork, secur
 		instanceTypes:  []ec2_types.InstanceTypeInfo{},
 		allocator:      podCidrRange,
 		pdAllocator:    pdCidrRange,
+		ipv6Allocator:  ipv6CidrRange,
 		errors:         map[Operation]error{},
 		delaySim:       helpers.NewDelaySimulator(),
 		pdSubnet:       pdCidr,
@@ -287,7 +296,7 @@ func (e *API) rateLimit() {
 // CreateNetworkInterface mocks the interface creation. As with the upstream
 // EC2 API, the number of IP addresses in toAllocate are the number of
 // secondary IPs, a primary IP is always allocated.
-func (e *API) CreateNetworkInterface(ctx context.Context, toAllocate int32, subnetID, desc string, groups []string, allocatePrefixes bool) (string, *types.ENI, error) {
+func (e *API) CreateNetworkInterface(ctx context.Context, toAllocate int32, subnetID, desc string, groups []string, allocatePrefixes, allocateIPv6 bool) (string, *types.ENI, error) {
 	e.rateLimit()
 	e.delaySim.Delay(CreateNetworkInterface)
 
@@ -337,6 +346,14 @@ func (e *API) CreateNetworkInterface(ctx context.Context, toAllocate int32, subn
 			}
 			eni.Addresses = append(eni.Addresses, iputil.AddrFrom(addr))
 		}
+	}
+
+	if allocateIPv6 {
+		pfx, err := e.ipv6Allocator.AllocateNext()
+		if err != nil {
+			panic("Unable to allocate IPv6 from allocator")
+		}
+		eni.IPv6Prefixes = append(eni.IPv6Prefixes, iputil.PrefixFrom(pfx))
 	}
 
 	subnet.AvailableAddresses -= numAddresses
@@ -633,6 +650,30 @@ func (e *API) UnassignENIPrefixes(ctx context.Context, eniID string, prefixes []
 		}
 		eni.Addresses = addressesAfterRelease
 		return nil
+	}
+	return fmt.Errorf("Unable to find ENI with ID %s", eniID)
+}
+
+func (e *API) AssignENIIPv6Prefix(ctx context.Context, eniID string) error {
+	e.rateLimit()
+	e.delaySim.Delay(AssignIPv6Addresses)
+
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	if err, ok := e.errors[AssignIPv6Addresses]; ok {
+		return err
+	}
+
+	for _, enis := range e.enis {
+		if eni, ok := enis[eniID]; ok {
+			pfx, err := e.ipv6Allocator.AllocateNext()
+			if err != nil {
+				return fmt.Errorf("unable to allocate IPv6 prefix: %w", err)
+			}
+			eni.IPv6Prefixes = append(eni.IPv6Prefixes, iputil.PrefixFrom(pfx))
+			return nil
+		}
 	}
 	return fmt.Errorf("Unable to find ENI with ID %s", eniID)
 }

--- a/pkg/aws/api/mock/mock_test.go
+++ b/pkg/aws/api/mock/mock_test.go
@@ -20,10 +20,10 @@ func TestMock(t *testing.T) {
 	api := NewAPI([]*ipamTypes.Subnet{{ID: "s-1", AvailableAddresses: 100}}, []*ipamTypes.VirtualNetwork{{ID: "v-1"}}, []*types.SecurityGroup{{ID: "sg-1"}}, []*ipamTypes.RouteTable{})
 	require.NotNil(t, api)
 
-	eniID1, _, err := api.CreateNetworkInterface(t.Context(), 8, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := api.CreateNetworkInterface(t.Context(), 8, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
 
-	eniID2, _, err := api.CreateNetworkInterface(t.Context(), 8, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID2, _, err := api.CreateNetworkInterface(t.Context(), 8, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
 
 	_, err = api.AttachNetworkInterface(t.Context(), 0, "i-1", eniID1)
@@ -89,7 +89,7 @@ func TestSetMockError(t *testing.T) {
 	mockError := errors.New("error")
 
 	api.SetMockError(CreateNetworkInterface, mockError)
-	_, _, err := api.CreateNetworkInterface(t.Context(), 8, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	_, _, err := api.CreateNetworkInterface(t.Context(), 8, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.Equal(t, mockError, err)
 
 	api.SetMockError(AttachNetworkInterface, mockError)
@@ -118,7 +118,7 @@ func TestSetLimiter(t *testing.T) {
 	require.NotNil(t, api)
 
 	api.SetLimiter(10.0, 2)
-	_, _, err := api.CreateNetworkInterface(t.Context(), 8, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	_, _, err := api.CreateNetworkInterface(t.Context(), 8, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
 }
 

--- a/pkg/aws/ipam/eni_gc_test.go
+++ b/pkg/aws/ipam/eni_gc_test.go
@@ -49,13 +49,13 @@ func TestStartENIGarbageCollector(t *testing.T) {
 
 	untaggedENIs := map[string]bool{}
 	for range 8 {
-		eniID, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "subnet-1", "desc", []string{"sg-1", "sg-2"}, false)
+		eniID, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "subnet-1", "desc", []string{"sg-1", "sg-2"}, false, false)
 		require.NoError(t, err)
 		untaggedENIs[eniID] = true
 	}
 
 	createTaggedENI := func() string {
-		eniID, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "subnet-2", "desc", []string{"sg-1", "sg-2"}, false)
+		eniID, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "subnet-2", "desc", []string{"sg-1", "sg-2"}, false, false)
 		require.NoError(t, err)
 		err = ec2api.TagENI(t.Context(), eniID, tags)
 		require.NoError(t, err)

--- a/pkg/aws/ipam/instances.go
+++ b/pkg/aws/ipam/instances.go
@@ -44,6 +44,7 @@ type EC2API interface {
 	AssignPrivateIpAddresses(ctx context.Context, eniID string, addresses int32) ([]string, error)
 	UnassignPrivateIpAddresses(ctx context.Context, eniID string, addresses []string) error
 	AssignENIPrefixes(ctx context.Context, eniID string, prefixes int32) error
+	AssignENIIPv6Prefix(ctx context.Context, eniID string) error
 	UnassignENIPrefixes(ctx context.Context, eniID string, prefixes []string) error
 	GetInstanceTypes(context.Context) ([]ec2_types.InstanceTypeInfo, error)
 	AssociateEIP(ctx context.Context, eniID string, eipTags ipamTypes.Tags) (string, error)

--- a/pkg/aws/ipam/instances.go
+++ b/pkg/aws/ipam/instances.go
@@ -37,7 +37,7 @@ type EC2API interface {
 	GetSecurityGroups(ctx context.Context, vpcID string) (types.SecurityGroupMap, error)
 
 	GetDetachedNetworkInterfaces(ctx context.Context, tags ipamTypes.Tags, maxResults int32) ([]string, error)
-	CreateNetworkInterface(ctx context.Context, toAllocate int32, subnetID, desc string, groups []string, allocatePrefixes bool) (string, *types.ENI, error)
+	CreateNetworkInterface(ctx context.Context, toAllocate int32, subnetID, desc string, groups []string, allocatePrefixes, allocateIPv6 bool) (string, *types.ENI, error)
 	AttachNetworkInterface(ctx context.Context, index int32, instanceID, eniID string) (string, error)
 	DeleteNetworkInterface(ctx context.Context, eniID string) error
 	ModifyNetworkInterface(ctx context.Context, eniID, attachmentID string, deleteOnTermination bool) error

--- a/pkg/aws/ipam/node.go
+++ b/pkg/aws/ipam/node.go
@@ -280,6 +280,11 @@ func (n *Node) GetAttachedCIDRs() []netip.Prefix {
 				attached = append(attached, prefix.Prefix)
 			}
 		}
+		for _, prefix := range eni.IPv6Prefixes {
+			if prefix.IsValid() {
+				attached = append(attached, prefix.Prefix)
+			}
+		}
 		for _, addr := range eni.Addresses {
 			if addr.IsValid() {
 				attached = append(attached, netip.PrefixFrom(addr.Addr, addr.BitLen()))
@@ -540,24 +545,33 @@ func (n *Node) AllocateIPs(ctx context.Context, a *nodemanager.AllocationAction)
 	isPrefixDelegated := n.node.Ops().IsPrefixDelegated()
 	n.mutex.RUnlock()
 
-	if isPrefixDelegated {
-		numPrefixes := iputil.PrefixCeil(a.IPv4.AvailableForAllocation, option.ENIPDBlockSizeIPv4)
-		err := n.manager.ec2api.AssignENIPrefixes(ctx, a.InterfaceID, int32(numPrefixes))
-		if !isSubnetAtPrefixCapacity(err) {
+	if a.IPv6.MaxPrefixesToAllocate > 0 {
+		err := n.manager.ec2api.AssignENIIPv6Prefix(ctx, a.InterfaceID)
+		if err != nil {
 			return err
 		}
-		// Subnet might be out of available /28 prefixes, but /32 IP addresses might be available.
-		// We should attempt to allocate /32 IPs.
-		n.logger.Load().Warn(
-			"Subnet might be out of prefixes, Cilium will not allocate prefixes on this node anymore",
-			logfields.Node, n.k8sObj.Name,
-		)
 	}
-	assignedIPs, err := n.manager.ec2api.AssignPrivateIpAddresses(ctx, a.InterfaceID, int32(a.IPv4.AvailableForAllocation))
-	if err != nil {
-		return err
+
+	if a.IPv4.AvailableForAllocation > 0 {
+		if isPrefixDelegated {
+			numPrefixes := iputil.PrefixCeil(a.IPv4.AvailableForAllocation, option.ENIPDBlockSizeIPv4)
+			err := n.manager.ec2api.AssignENIPrefixes(ctx, a.InterfaceID, int32(numPrefixes))
+			if !isSubnetAtPrefixCapacity(err) {
+				return err
+			}
+			// Subnet might be out of available /28 prefixes, but /32 IP addresses might be available.
+			// We should attempt to allocate /32 IPs.
+			n.logger.Load().Warn(
+				"Subnet might be out of prefixes, Cilium will not allocate prefixes on this node anymore",
+				logfields.Node, n.k8sObj.Name,
+			)
+		}
+		assignedIPs, err := n.manager.ec2api.AssignPrivateIpAddresses(ctx, a.InterfaceID, int32(a.IPv4.AvailableForAllocation))
+		if err != nil {
+			return err
+		}
+		n.manager.AddIPsToENI(n.node.InstanceID(), a.InterfaceID, assignedIPs)
 	}
-	n.manager.AddIPsToENI(n.node.InstanceID(), a.InterfaceID, assignedIPs)
 	return nil
 }
 
@@ -725,6 +739,7 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *nodemanager.Allo
 	desc := "Cilium-CNI (" + n.node.InstanceID() + ")"
 
 	// Calculate the number of IPs to allocate for the new ENI.
+	allocateIPv6 := allocation.IPv6.MaxPrefixesToAllocate > 0
 	var toAllocate int
 	if isPrefixDelegated {
 		// For prefix delegation mode, we need to consider the instance type limits.
@@ -739,7 +754,7 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *nodemanager.Allo
 		toAllocate = min(allocation.IPv4.MaxIPsToAllocate, limits.IPv4-1)
 	}
 	// Validate whether request has already been fulfilled in the meantime
-	if toAllocate == 0 {
+	if toAllocate == 0 && !allocateIPv6 {
 		return 0, "", nil
 	}
 
@@ -753,7 +768,7 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *nodemanager.Allo
 	)
 	scopedLog.Info("No more IPs available, creating new ENI")
 
-	eniID, eni, err := n.manager.ec2api.CreateNetworkInterface(ctx, int32(toAllocate), subnet.ID, desc, securityGroupIDs, isPrefixDelegated, false)
+	eniID, eni, err := n.manager.ec2api.CreateNetworkInterface(ctx, int32(toAllocate), subnet.ID, desc, securityGroupIDs, isPrefixDelegated, allocateIPv6)
 	if err != nil {
 		if isPrefixDelegated && isSubnetAtPrefixCapacity(err) {
 			// Subnet might be out of available /28 prefixes, but /32 IP addresses might be available.
@@ -762,7 +777,7 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *nodemanager.Allo
 				"Subnet might be out of prefixes, Cilium will not allocate prefixes on this node anymore",
 				logfields.Node, n.k8sObj.Name,
 			)
-			eniID, eni, err = n.manager.ec2api.CreateNetworkInterface(ctx, int32(toAllocate), subnet.ID, desc, securityGroupIDs, false, false)
+			eniID, eni, err = n.manager.ec2api.CreateNetworkInterface(ctx, int32(toAllocate), subnet.ID, desc, securityGroupIDs, false, allocateIPv6)
 		}
 		if err != nil {
 			return 0, unableToCreateENI, fmt.Errorf("%s: %w", errUnableToCreateENI, err)
@@ -899,9 +914,10 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *slog.Logge
 				// capacity.
 				stats.NodeCapacity -= effectiveLimits
 				return nil
-			} else {
-				stats.NodeCapacity += leftoverPrefixCapcity
 			}
+
+			stats.NodeCapacity += leftoverPrefixCapcity
+			stats.NodeIPv6Prefixes += len(e.IPv6Prefixes)
 
 			availableOnENI := max(effectiveLimits-len(e.Addresses), 0)
 			if availableOnENI > 0 {

--- a/pkg/aws/ipam/node.go
+++ b/pkg/aws/ipam/node.go
@@ -753,7 +753,7 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *nodemanager.Allo
 	)
 	scopedLog.Info("No more IPs available, creating new ENI")
 
-	eniID, eni, err := n.manager.ec2api.CreateNetworkInterface(ctx, int32(toAllocate), subnet.ID, desc, securityGroupIDs, isPrefixDelegated)
+	eniID, eni, err := n.manager.ec2api.CreateNetworkInterface(ctx, int32(toAllocate), subnet.ID, desc, securityGroupIDs, isPrefixDelegated, false)
 	if err != nil {
 		if isPrefixDelegated && isSubnetAtPrefixCapacity(err) {
 			// Subnet might be out of available /28 prefixes, but /32 IP addresses might be available.
@@ -762,7 +762,7 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *nodemanager.Allo
 				"Subnet might be out of prefixes, Cilium will not allocate prefixes on this node anymore",
 				logfields.Node, n.k8sObj.Name,
 			)
-			eniID, eni, err = n.manager.ec2api.CreateNetworkInterface(ctx, int32(toAllocate), subnet.ID, desc, securityGroupIDs, false)
+			eniID, eni, err = n.manager.ec2api.CreateNetworkInterface(ctx, int32(toAllocate), subnet.ID, desc, securityGroupIDs, false, false)
 		}
 		if err != nil {
 			return 0, unableToCreateENI, fmt.Errorf("%s: %w", errUnableToCreateENI, err)

--- a/pkg/aws/ipam/node_ipv6_test.go
+++ b/pkg/aws/ipam/node_ipv6_test.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipam
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/operator/pkg/ipam/nodemanager"
+	apiMock "github.com/cilium/cilium/pkg/aws/api/mock"
+	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+)
+
+// newWiredNode builds a *Node backed by the EC2 mock API with a single primary
+// ENI attached to instanceID and the manager resynced. The returned node is
+// wired exactly like production: n.node.Ops() returns the AWS *Node itself, so
+// methods that call n.node.Ops() (AllocateIPs, CreateInterface) work.
+func newWiredNode(t *testing.T, instanceID, instanceType string) (*Node, *apiMock.API, *InstancesManager) {
+	t.Helper()
+
+	ec2api := apiMock.NewAPI([]*ipamTypes.Subnet{testSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
+	instances, err := NewInstancesManager(t.Context(), hivetest.Logger(t), ec2api, metadataMockapi)
+	require.NoError(t, err)
+
+	eniID, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, testSubnet.ID, "primary", []string{"sg-1"}, false, false)
+	require.NoError(t, err)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID)
+	require.NoError(t, err)
+	_, err = instances.Resync(t.Context())
+	require.NoError(t, err)
+
+	defOpts := []func(*v2.CiliumNode){
+		withTestDefaults(),
+		withInstanceID(instanceID),
+		withInstanceType(instanceType),
+		withNodeSubnetID(testSubnet.ID),
+	}
+	cn := newCiliumNode("node1", defOpts...)
+
+	n := &Node{
+		rootLogger: hivetest.Logger(t),
+		manager:    instances,
+		k8sObj:     cn,
+		instanceID: instanceID,
+	}
+	n.node = &mockIPAMNode{instanceID: instanceID, ops: n}
+	n.logger.Store(n.rootLogger)
+
+	// Populate n.enis from the manager's view.
+	_, _, err = n.ResyncInterfacesAndIPs(t.Context(), hivetest.Logger(t))
+	require.NoError(t, err)
+
+	return n, ec2api, instances
+}
+
+// primaryENIID returns the ID of the node's primary (index 0) ENI.
+func primaryENIID(t *testing.T, n *Node) string {
+	t.Helper()
+	n.mutex.RLock()
+	defer n.mutex.RUnlock()
+	for id, eni := range n.enis {
+		if eni.Number == 0 {
+			return id
+		}
+	}
+	t.Fatal("no primary ENI found")
+	return ""
+}
+
+// attachedIPv6Prefixes resyncs from the EC2 mock and returns the IPv6 prefixes
+// currently attached across all of the node's ENIs.
+func attachedIPv6Prefixes(t *testing.T, n *Node, instances *InstancesManager) []netip.Prefix {
+	t.Helper()
+	_, err := instances.Resync(t.Context())
+	require.NoError(t, err)
+	_, _, err = n.ResyncInterfacesAndIPs(t.Context(), hivetest.Logger(t))
+	require.NoError(t, err)
+
+	var v6 []netip.Prefix
+	for _, p := range n.GetAttachedCIDRs() {
+		if p.Addr().Is6() {
+			v6 = append(v6, p)
+		}
+	}
+	return v6
+}
+
+func TestAllocateIPs_IPv6Prefix(t *testing.T) {
+	n, _, instances := newWiredNode(t, "i-allocate-ipv6", "m5.large")
+	eniID := primaryENIID(t, n)
+
+	// Sanity: no IPv6 prefixes attached yet.
+	require.Empty(t, attachedIPv6Prefixes(t, n, instances))
+
+	a := &nodemanager.AllocationAction{InterfaceID: eniID}
+	a.IPv6.MaxPrefixesToAllocate = 1
+
+	require.NoError(t, n.AllocateIPs(t.Context(), a))
+
+	require.Len(t, attachedIPv6Prefixes(t, n, instances), 1)
+}
+
+func TestAllocateIPs_NoIPv6WhenNotRequested(t *testing.T) {
+	n, _, instances := newWiredNode(t, "i-allocate-no-ipv6", "m5.large")
+	eniID := primaryENIID(t, n)
+
+	a := &nodemanager.AllocationAction{InterfaceID: eniID}
+	a.IPv4.AvailableForAllocation = 2
+	// IPv6.MaxPrefixesToAllocate left at 0.
+
+	require.NoError(t, n.AllocateIPs(t.Context(), a))
+
+	require.Empty(t, attachedIPv6Prefixes(t, n, instances))
+}
+
+func TestCreateInterface_IPv6Only(t *testing.T) {
+	// Request a new ENI for IPv6 only (no IPv4 addresses).
+	n, _, instances := newWiredNode(t, "i-create-ipv6", "m5.large")
+
+	a := &nodemanager.AllocationAction{}
+	a.IPv6.MaxPrefixesToAllocate = 1
+	// IPv4.MaxIPsToAllocate left at 0.
+
+	toAllocate, errStr, err := n.CreateInterface(t.Context(), a, hivetest.Logger(t))
+	require.NoError(t, err)
+	require.Empty(t, errStr)
+	require.Equal(t, 0, toAllocate)
+
+	// The node should now have a primary ENI plus the freshly created one,
+	// and exactly one IPv6 prefix attached.
+	require.Len(t, attachedIPv6Prefixes(t, n, instances), 1)
+
+	n.mutex.RLock()
+	require.Len(t, n.enis, 2)
+	n.mutex.RUnlock()
+}

--- a/pkg/aws/ipam/node_manager_test.go
+++ b/pkg/aws/ipam/node_manager_test.go
@@ -150,7 +150,7 @@ func TestNodeManagerDefaultAllocation(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
@@ -197,7 +197,7 @@ func TestNodeManagerPrefixDelegation(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, true)
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, true, false)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
@@ -269,7 +269,7 @@ func TestNodeManagerENIWithSGTags(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
@@ -332,7 +332,7 @@ func TestNodeManagerMinAllocate20(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
@@ -391,7 +391,7 @@ func TestNodeManagerMinAllocateAndPreallocate(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
@@ -459,7 +459,7 @@ func TestNodeManagerReleaseAddress(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
@@ -567,7 +567,7 @@ func TestNodeManagerENIExcludeInterfaceTags(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
 	err = ec2api.TagENI(t.Context(), eniID1, map[string]string{
 		"foo":                 "bar",
@@ -640,7 +640,7 @@ func TestNodeManagerExceedENICapacity(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
@@ -702,7 +702,7 @@ func TestInterfaceCreatedInInitialSubnet(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, testSubnet.ID, "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, testSubnet.ID, "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
@@ -775,7 +775,7 @@ func TestNodeManagerManyNodes(t *testing.T) {
 	state := make([]*nodeState, numNodes)
 
 	for i := range state {
-		eniID, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "mgmt-1", "desc", []string{"sg1", "sg2"}, false)
+		eniID, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "mgmt-1", "desc", []string{"sg1", "sg2"}, false, false)
 		require.NoError(t, err)
 		_, err = ec2api.AttachNetworkInterface(t.Context(), 0, fmt.Sprintf("i-testNodeManagerManyNodes-%d", i), eniID)
 		require.NoError(t, err)
@@ -833,7 +833,7 @@ func TestNodeManagerInstanceNotRunning(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
@@ -881,11 +881,11 @@ func TestInstanceBeenDeleted(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
-	eniID2, _, err := ec2api.CreateNetworkInterface(t.Context(), 8, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID2, _, err := ec2api.CreateNetworkInterface(t.Context(), 8, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 1, instanceID, eniID2)
 	require.NoError(t, err)
@@ -944,7 +944,7 @@ func TestNodeManagerStaticIP(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
@@ -991,7 +991,7 @@ func TestNodeManagerStaticIPAlreadyAssociated(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, instances)
 
-	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
 	require.NoError(t, err)
@@ -1034,13 +1034,13 @@ func TestNodeManagerStaticIPPrimaryENI(t *testing.T) {
 	require.NotNil(t, instances)
 
 	// Primary ENI (Number == 0).
-	primaryENI, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	primaryENI, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, primaryENI)
 	require.NoError(t, err)
 
 	// Secondary ENI (Number == 1)
-	secondaryENI, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+	secondaryENI, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 	require.NoError(t, err)
 	_, err = ec2api.AttachNetworkInterface(t.Context(), 1, instanceID, secondaryENI)
 	require.NoError(t, err)
@@ -1095,7 +1095,7 @@ func benchmarkAllocWorker(b *testing.B, workers int64, delay time.Duration, rate
 
 	b.ResetTimer()
 	for i := range state {
-		eniID, _, err := ec2api.CreateNetworkInterface(b.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false)
+		eniID, _, err := ec2api.CreateNetworkInterface(b.Context(), 0, "s-1", "desc", []string{"sg1", "sg2"}, false, false)
 		require.NoError(b, err)
 		_, err = ec2api.AttachNetworkInterface(b.Context(), 0, fmt.Sprintf("i-benchmarkAllocWorker-%d", i), eniID)
 		require.NoError(b, err)

--- a/pkg/aws/ipam/node_stat_test.go
+++ b/pkg/aws/ipam/node_stat_test.go
@@ -109,6 +109,7 @@ func TestENIIPAMCapacityAccounting(t *testing.T) {
 type mockIPAMNode struct {
 	instanceID       string
 	prefixDelegation bool
+	ops              nodemanager.NodeOperations
 }
 
 func (m *mockIPAMNode) SetOpts(nodemanager.NodeOperations)           {}
@@ -117,7 +118,7 @@ func (m *mockIPAMNode) UpdatedResource(*v2.CiliumNode) bool          { panic("no
 func (m *mockIPAMNode) Update(*v2.CiliumNode)                        {}
 func (m *mockIPAMNode) InstanceID() string                           { return m.instanceID }
 func (m *mockIPAMNode) IsPrefixDelegationEnabled() bool              { return m.prefixDelegation }
-func (m *mockIPAMNode) Ops() nodemanager.NodeOperations              { panic("not impl") }
+func (m *mockIPAMNode) Ops() nodemanager.NodeOperations              { return m.ops }
 func (m *mockIPAMNode) SetRunning(_ bool)                            { panic("not impl") }
 
 var _ ipamNodeActions = (*mockIPAMNode)(nil)

--- a/pkg/aws/ipam/node_test.go
+++ b/pkg/aws/ipam/node_test.go
@@ -312,8 +312,8 @@ func TestGetAttachedCIDRs(t *testing.T) {
 				Prefixes:  []iputil.Prefix{iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.16/28"))},
 			},
 			"eni-2": {
-				Addresses: []iputil.Addr{iputil.AddrFrom(netip.MustParseAddr("2001:db8::1"))},
-				Prefixes:  []iputil.Prefix{iputil.PrefixFrom(netip.MustParsePrefix("2001:db8:1::/80"))},
+				Addresses:    []iputil.Addr{iputil.AddrFrom(netip.MustParseAddr("2001:db8::1"))},
+				IPv6Prefixes: []iputil.Prefix{iputil.PrefixFrom(netip.MustParsePrefix("2001:db8:1::/80"))},
 			},
 		})
 

--- a/pkg/aws/types/types.go
+++ b/pkg/aws/types/types.go
@@ -165,10 +165,15 @@ type ENI struct {
 	// +optional
 	Addresses []iputil.Addr `json:"addresses,omitempty"`
 
-	// Prefixes is the list of all /28 prefixes associated with the ENI
+	// Prefixes is the list of all IPv4 /28 delegated prefixes associated with the ENI
 	//
 	// +optional
 	Prefixes []iputil.Prefix `json:"prefixes,omitempty"`
+
+	// IPv6Prefixes is the list of all IPv6 /80 delegated prefixes associated with the ENI
+	//
+	// +optional
+	IPv6Prefixes []iputil.Prefix `json:"ipv6-prefixes,omitempty"`
 
 	// SecurityGroups are the security groups associated with the ENI
 	SecurityGroups []string `json:"security-groups,omitempty"`

--- a/pkg/aws/types/zz_generated.deepcopy.go
+++ b/pkg/aws/types/zz_generated.deepcopy.go
@@ -74,6 +74,13 @@ func (in *ENI) DeepCopyInto(out *ENI) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.IPv6Prefixes != nil {
+		in, out := &in.IPv6Prefixes, &out.IPv6Prefixes
+		*out = make([]ip.Prefix, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.SecurityGroups != nil {
 		in, out := &in.SecurityGroups, &out.SecurityGroups
 		*out = make([]string, len(*in))

--- a/pkg/aws/types/zz_generated.deepequal.go
+++ b/pkg/aws/types/zz_generated.deepequal.go
@@ -127,6 +127,23 @@ func (in *ENI) DeepEqual(other *ENI) bool {
 		}
 	}
 
+	if ((in.IPv6Prefixes != nil) && (other.IPv6Prefixes != nil)) || ((in.IPv6Prefixes == nil) != (other.IPv6Prefixes == nil)) {
+		in, other := &in.IPv6Prefixes, &other.IPv6Prefixes
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for i, inElement := range *in {
+				if !inElement.DeepEqual(&(*other)[i]) {
+					return false
+				}
+			}
+		}
+	}
+
 	if ((in.SecurityGroups != nil) && (other.SecurityGroups != nil)) || ((in.SecurityGroups == nil) != (other.SecurityGroups == nil)) {
 		in, other := &in.SecurityGroups, &other.SecurityGroups
 		if other == nil {

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -643,6 +643,13 @@ spec:
                         ip:
                           description: IP is the primary IP of the ENI
                           type: string
+                        ipv6-prefixes:
+                          description: IPv6Prefixes is the list of all IPv6 /80 delegated
+                            prefixes associated with the ENI
+                          items:
+                            format: cidr
+                            type: string
+                          type: array
                         mac:
                           description: MAC is the mac address of the ENI
                           type: string
@@ -652,8 +659,8 @@ spec:
                             FirstInterfaceIndex
                           type: integer
                         prefixes:
-                          description: Prefixes is the list of all /28 prefixes associated
-                            with the ENI
+                          description: Prefixes is the list of all IPv4 /28 delegated
+                            prefixes associated with the ENI
                           items:
                             format: cidr
                             type: string

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -1312,6 +1312,10 @@ const (
 
 	NeededIPs = "neededIPs"
 
+	NeededIPv6Prefixes = "neededIPv6Prefixes"
+
+	AvailableIPv6Prefixes = "availableIPv6Prefixes"
+
 	Releasing = "releasing"
 
 	Excess = "excess"


### PR DESCRIPTION
This PR introduces changes to the IPAM operator, and to ENI IPAM in particular, to support assigning IPv6 prefixes. Following work done by @HadrienPatte on https://github.com/cilium/design-cfps/pull/87, it is no longer necessary to expand prefixes into individual addresses. This makes it possible to assign the full /80 IPv6 prefix and let the agent use all of it.

The design for IPv6 proposed here diverges from the IPv4 implementation, since most of what was done for IPv4 was meant to address IPv4 exhaustion problems (releasing IPs, maintenance action sequencing, enabling/disabling prefix delegation, etc.). For IPv6, IP exhaustion is not a problem, so the operator can skip most of the maintenance logic designed to keep as many addresses free to use as possible.

The design becomes much more straightforward. When the agent has IPv6 enabled, it requests IPv6 addresses (not implemented in this PR). The operator sees that request and checks whether there are already any IPv6 prefixes on any of the ENIs it manages. If it does not find any IPv6 prefix, it assigns one. IPv6 prefixes are usually large enough (2^48 addresses on AWS) that a node should not need more than one IPv6 prefix for its lifetime. Once an IPv6 prefix is allocated to a node, it is not released until the node is deleted. This is fine since IPv6 subnetworks are also large enough to not run out of IPv6 prefixes.

For this work, IPv6 only setups are out of scope. So all testing has been done with IPv4 allocation still enabled. Supporting IPv6 only mode requires further changes since many components assume IPv4 is present when AWS ENI IPAM is used. The goal is to first support and validate dual stack setups before continuing to work on full IPv6 only support.

This PR is related to issues #19251 and #18405.

This PR was prepared with AIL:2. I discussed the design with an AI agent and wrote the code myself. I let the agent write the tests.

```release-note
AWS ENI IPAM mode now supports allocating IPv6 prefixes
```
