### PR TITLE
loadbalancer: clustermesh: wire clustermesh epslice to lb reflector

### DIFF
--- a/pkg/clustermesh/cell.go
+++ b/pkg/clustermesh/cell.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/cilium/daemon/cmd/cni"
 	"github.com/cilium/cilium/pkg/clustermesh/common"
 	cmendpointslice "github.com/cilium/cilium/pkg/clustermesh/endpointslice"
+	cmlb "github.com/cilium/cilium/pkg/clustermesh/loadbalancer"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/clustermesh/wait"
 	"github.com/cilium/cilium/pkg/dial"
@@ -50,11 +51,16 @@ var Cell = cell.Module(
 
 	metrics.Metric(NewMetrics),
 	metrics.Metric(common.MetricsProvider(metrics.SubsystemClusterMesh)),
-	metrics.Metric(cmendpointslice.MetricsProvider(metrics.Namespace)),
-	cmendpointslice.Cell,
 
-	cell.ProvidePrivate(newServiceMerger),
-	cell.Invoke(registerServicesInitialized),
+	cmendpointslice.Cell,
+	metrics.Metric(cmendpointslice.MetricsProvider(metrics.Namespace)),
+	cell.Provide(func(cm *ClusterMesh) cmlb.ServicesSyncedFunc {
+		if cm == nil {
+			return nil
+		}
+		return cm.ServicesSynced
+	}),
+	cmlb.Cell,
 
 	cell.Config(types.DefaultQuirks),
 	cell.Invoke(func(info types.ClusterInfo, dcfg *option.DaemonConfig, cnimgr cni.CNIConfigManager, log *slog.Logger, quirks types.QuirksConfig) error {
@@ -67,5 +73,4 @@ var Cell = cell.Module(
 	}),
 	cell.Invoke(ipsetNotifier),
 	cell.Invoke(nodeManagerNotifier),
-	cell.Invoke(injectSelectBackends),
 )

--- a/pkg/clustermesh/cell.go
+++ b/pkg/clustermesh/cell.go
@@ -60,6 +60,12 @@ var Cell = cell.Module(
 		}
 		return cm.ServicesSynced
 	}),
+	cell.Provide(func(cm *ClusterMesh) cmlb.EndpointSlicesSyncedFunc {
+		if cm == nil {
+			return nil
+		}
+		return cm.EndpointSlicesSynced
+	}),
 	cmlb.Cell,
 
 	cell.Config(types.DefaultQuirks),

--- a/pkg/clustermesh/cell.go
+++ b/pkg/clustermesh/cell.go
@@ -54,7 +54,7 @@ var Cell = cell.Module(
 	cmendpointslice.Cell,
 
 	cell.ProvidePrivate(newServiceMerger),
-	cell.Invoke(registerLoadBalancerInitialized),
+	cell.Invoke(registerServicesInitialized),
 
 	cell.Config(types.DefaultQuirks),
 	cell.Invoke(func(info types.ClusterInfo, dcfg *option.DaemonConfig, cnimgr cni.CNIConfigManager, log *slog.Logger, quirks types.QuirksConfig) error {

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/clustermesh/common"
 	cmendpointslice "github.com/cilium/cilium/pkg/clustermesh/endpointslice"
+	cmlb "github.com/cilium/cilium/pkg/clustermesh/loadbalancer"
 	"github.com/cilium/cilium/pkg/clustermesh/observer"
 	serviceStore "github.com/cilium/cilium/pkg/clustermesh/store"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
@@ -47,7 +48,7 @@ type Configuration struct {
 
 	// ServiceMerger is the interface responsible to merge service and
 	// endpoints into an existing cache
-	ServiceMerger ServiceMerger
+	ServiceMerger cmlb.ServiceMerger
 
 	// NodeObserver reacts to node events.
 	NodeObserver nodeStore.NodeManager

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 
 	"github.com/cilium/hive/cell"
-	"github.com/cilium/hive/job"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/allocator"
@@ -26,7 +25,6 @@ import (
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
-	"github.com/cilium/cilium/pkg/loadbalancer/writer"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	nodeStore "github.com/cilium/cilium/pkg/node/store"
 	"github.com/cilium/cilium/pkg/source"
@@ -325,34 +323,4 @@ func (cm *ClusterMesh) Status() (status *models.ClusterMeshStatus) {
 		func(a, b *models.RemoteCluster) int { return cmp.Compare(a.Name, b.Name) })
 
 	return
-}
-
-// registerLoadBalancerInitialized adds a job to wait for the ClusterMesh resources
-// backing the load balancer before marking the load-balancing tables as initialized.
-func registerLoadBalancerInitialized(jobs job.Group, cm *ClusterMesh, cfg cmtypes.ServiceModeV2Config, w *writer.Writer) {
-	if cm == nil {
-		return
-	}
-	markDone := w.RegisterInitializer("clustermesh")
-	jobs.Add(
-		job.OneShot(
-			"loadbalancer-initialized",
-			func(ctx context.Context, health cell.Health) error {
-				var err error
-				if cfg.ServiceModeV2.ShouldWatchLegacyServices() {
-					err = cm.ServicesSynced(ctx)
-				} else if cfg.ServiceModeV2.ShouldWatchEndpointSlices() {
-					err = cm.EndpointSlicesSynced(ctx)
-				}
-				if err != nil {
-					return err
-				}
-
-				txn := w.WriteTxn()
-				markDone(txn)
-				txn.Commit()
-				return nil
-			},
-		),
-	)
 }

--- a/pkg/clustermesh/endpointslice/cell.go
+++ b/pkg/clustermesh/endpointslice/cell.go
@@ -24,6 +24,8 @@ type params struct {
 	StoreFactory store.Factory
 	Metrics      Metrics
 	types.ServiceModeV2Config
+
+	Observer Observer `optional:"true"`
 }
 
 var Cell = cell.Module(
@@ -38,6 +40,8 @@ var Cell = cell.Module(
 type Metrics struct {
 	TotalEndpointSlices metric.Vec[metric.Gauge]
 }
+
+type Observer store.Observer
 
 func MetricsProvider(namespace string) func() Metrics {
 	return func() Metrics {

--- a/pkg/clustermesh/endpointslice/observer.go
+++ b/pkg/clustermesh/endpointslice/observer.go
@@ -25,6 +25,11 @@ func newFactory(params params) observer.Factory {
 			onSync:        onSync,
 		}
 
+		observer := store.Observer(dummyObserver{})
+		if params.Observer != nil {
+			observer = params.Observer
+		}
+
 		obs.store = params.StoreFactory.NewWatchStore(
 			cluster,
 			endpointslicetypes.KeyCreator(
@@ -32,7 +37,7 @@ func newFactory(params params) observer.Factory {
 				endpointslicetypes.NamespacedNameValidator(),
 				endpointslicetypes.ClusterIDValidator(&obs.clusterID),
 			),
-			dummyObserver{},
+			observer,
 			store.RWSWithOnSyncCallback(func(context.Context) { onSync() }),
 			store.RWSWithEntriesMetric(params.Metrics.TotalEndpointSlices.WithLabelValues(cluster)),
 		)

--- a/pkg/clustermesh/loadbalancer/cell.go
+++ b/pkg/clustermesh/loadbalancer/cell.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package loadbalancer
+
+import (
+	"github.com/cilium/hive/cell"
+)
+
+var Cell = cell.Module(
+	"clustermesh-loadbalancer",
+	"ClusterMesh code related to load balancer interactions",
+
+	cell.Invoke(injectSelectBackends),
+
+	cell.Provide(newServiceMerger),
+	cell.Invoke(registerServicesInitialized),
+)

--- a/pkg/clustermesh/loadbalancer/cell.go
+++ b/pkg/clustermesh/loadbalancer/cell.go
@@ -15,4 +15,8 @@ var Cell = cell.Module(
 
 	cell.Provide(newServiceMerger),
 	cell.Invoke(registerServicesInitialized),
+
+	cell.Provide(newEndpointSliceObserver),
+	cell.Invoke(registerEndpointSliceReflector),
+	cell.Invoke((*endpointSliceObserver).registerEndpointSliceSynced),
 )

--- a/pkg/clustermesh/loadbalancer/observer.go
+++ b/pkg/clustermesh/loadbalancer/observer.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package loadbalancer
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+
+	"github.com/cilium/cilium/pkg/clustermesh/common"
+	cmendpointslice "github.com/cilium/cilium/pkg/clustermesh/endpointslice"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	endpointslicetypes "github.com/cilium/cilium/pkg/clustermesh/types/endpointslice"
+	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/kvstore/store"
+	"github.com/cilium/cilium/pkg/loadbalancer/writer"
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+type EndpointSlicesSyncedFunc func(context.Context) error
+
+type endpointSliceEvent struct {
+	kind      resource.EventKind
+	obj       *k8s.Endpoints
+	clusterID uint32
+}
+
+type endpointSliceObserver struct {
+	log *slog.Logger
+
+	buf    []endpointSliceEvent
+	mu     lock.Mutex
+	emitFn func(endpointSliceEvent)
+
+	started atomic.Bool
+}
+
+type observerParams struct {
+	cell.In
+
+	Log    *slog.Logger
+	Writer *writer.Writer
+
+	ClusterInfo cmtypes.ClusterInfo
+	common.Config
+	cmtypes.ServiceModeV2Config
+}
+
+func newEndpointSliceObserver(p observerParams) (cmendpointslice.Observer, *endpointSliceObserver) {
+	if !p.Writer.IsEnabled() || !p.ServiceModeV2.ShouldWatchEndpointSlices() || p.ClusterInfo.ID == 0 || p.ClusterMeshConfig == "" {
+		return nil, nil
+	}
+
+	observer := &endpointSliceObserver{log: p.Log}
+	observer.emitFn = func(ev endpointSliceEvent) {
+		observer.buf = append(observer.buf, ev)
+	}
+
+	return observer, observer
+}
+
+func (o *endpointSliceObserver) registerEndpointSliceSynced(jg job.Group, synced EndpointSlicesSyncedFunc) {
+	if synced == nil || o == nil {
+		return
+	}
+	jg.Add(job.OneShot("synced-endpointslices", func(ctx context.Context, health cell.Health) error {
+		if err := synced(ctx); err != nil {
+			return err
+		}
+		o.emit(endpointSliceEvent{kind: resource.Sync})
+		return nil
+	}))
+}
+
+func (o *endpointSliceObserver) emit(ev endpointSliceEvent) {
+	// [stream.Observable] is the interface that we implement in this struct
+	// and it must not send any concurrent event. The lock below helps to hold
+	// that guarantee in addition to handle a mutation of emitFn when the
+	// observer is initialized.
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	o.emitFn(ev)
+}
+
+func (o *endpointSliceObserver) OnUpdate(k store.Key) {
+	eps, ok := k.(*endpointslicetypes.ValidatingClusterEndpointSlice)
+	if !ok {
+		return
+	}
+	o.emit(endpointSliceEvent{
+		kind:      resource.Upsert,
+		obj:       k8s.ParseEndpointSliceV1(o.log, eps.ClusterEndpointSlice.ToShallowSlimEndpointSlice()),
+		clusterID: eps.ClusterID,
+	})
+}
+
+func (o *endpointSliceObserver) OnDelete(k store.NamedKey) {
+	eps, ok := k.(*endpointslicetypes.ValidatingClusterEndpointSlice)
+	if !ok {
+		return
+	}
+	o.emit(endpointSliceEvent{
+		kind:      resource.Delete,
+		obj:       k8s.ParseEndpointSliceV1(o.log, eps.ClusterEndpointSlice.ToShallowSlimEndpointSlice()),
+		clusterID: eps.ClusterID,
+	})
+}
+
+func (o *endpointSliceObserver) Observe(ctx context.Context, next func(endpointSliceEvent), complete func(error)) {
+	if o.started.Swap(true) {
+		panic("BUG: calling [endpointSliceObserver.Observe] multiple times is not supported")
+	}
+
+	go func() {
+		defer func() {
+			o.mu.Lock()
+			o.emitFn = func(endpointSliceEvent) {}
+			o.mu.Unlock()
+
+			complete(ctx.Err())
+		}()
+
+		o.mu.Lock()
+		for _, el := range o.buf {
+			select {
+			case <-ctx.Done():
+				o.mu.Unlock()
+				return
+
+			default:
+				next(el)
+			}
+		}
+
+		o.buf = nil
+		o.emitFn = next
+		o.mu.Unlock()
+
+		<-ctx.Done()
+	}()
+}

--- a/pkg/clustermesh/loadbalancer/observer_test.go
+++ b/pkg/clustermesh/loadbalancer/observer_test.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package loadbalancer
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cilium/stream"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/time"
+)
+
+func newTestEndpointSliceObserver() *endpointSliceObserver {
+	observer := &endpointSliceObserver{}
+	observer.emitFn = func(ev endpointSliceEvent) {
+		observer.buf = append(observer.buf, ev)
+	}
+	return observer
+}
+
+func TestObserverBufferedStart(t *testing.T) {
+	observer := newTestEndpointSliceObserver()
+
+	// Test to send event before calling Observe
+	observer.emit(endpointSliceEvent{clusterID: 1})
+	observer.emit(endpointSliceEvent{clusterID: 2})
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	completed := make(chan error, 1)
+	events := stream.ToChannel(ctx, observer, stream.WithBufferSize(4), stream.WithErrorChan(completed))
+	observer.emit(endpointSliceEvent{clusterID: 3})
+	observer.emit(endpointSliceEvent{clusterID: 4})
+
+	// Test that all events are received before and after Observe
+	require.EqualValues(t, 1, (<-events).clusterID)
+	require.EqualValues(t, 2, (<-events).clusterID)
+	require.EqualValues(t, 3, (<-events).clusterID)
+	require.EqualValues(t, 4, (<-events).clusterID)
+
+	cancel()
+	require.ErrorIs(t, <-completed, context.Canceled)
+
+	_, ok := <-events
+	require.False(t, ok, "Expected events channel to be closed")
+	require.Nil(t, observer.buf)
+}
+
+func TestObserverShutdownDuringBufferedReplay(t *testing.T) {
+	observer := newTestEndpointSliceObserver()
+
+	observer.emit(endpointSliceEvent{clusterID: 1})
+	observer.emit(endpointSliceEvent{clusterID: 2})
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	events := make(chan uint32, 2)
+	completed := make(chan error, 1)
+	observer.Observe(ctx, func(ev endpointSliceEvent) {
+		events <- ev.clusterID
+		// Cancel after the first event
+		cancel()
+	}, func(err error) {
+		completed <- err
+	})
+
+	require.ErrorIs(t, <-completed, context.Canceled)
+	require.EqualValues(t, 1, <-events)
+	require.Empty(t, events)
+}
+
+// TestObserverSerialization test that the observer enforces strict
+// serialization by emitting two concurrent events and ensure the second one
+// can only be delivered once after the first one is.
+func TestObserverSerialization(t *testing.T) {
+	observer := newTestEndpointSliceObserver()
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	var serializationErr atomic.Bool
+
+	enteredObserve := make(chan struct{}, 2)
+	releasedObserve := make(chan struct{}, 2)
+	events := make(chan uint32, 2)
+
+	var running atomic.Bool
+	completed := make(chan error, 1)
+	observer.Observe(ctx, func(ev endpointSliceEvent) {
+		if !running.CompareAndSwap(false, true) {
+			serializationErr.Store(true)
+		}
+		defer running.Store(false)
+
+		enteredObserve <- struct{}{}
+		events <- ev.clusterID
+		<-releasedObserve
+	}, func(err error) {
+		completed <- err
+	})
+
+	go observer.emit(endpointSliceEvent{clusterID: 1})
+	// Make sure we are processing the first event before sending the second one
+	<-enteredObserve
+
+	go observer.emit(endpointSliceEvent{clusterID: 2})
+
+	// Wait to make sure that the second emit has been called/scheduled while
+	// the first event is being blocked.
+	// Note that this cannot use testing/synctest, as goroutines blocked on
+	// mutex are not considered durably blocked.
+	time.Sleep(time.Millisecond * 10)
+
+	close(releasedObserve)
+	require.Equal(t, uint32(1), <-events)
+	require.Equal(t, uint32(2), <-events)
+
+	cancel()
+	require.ErrorIs(t, <-completed, context.Canceled)
+
+	require.False(t, serializationErr.Load(), "Concurrent calls detected")
+}

--- a/pkg/clustermesh/loadbalancer/reflector.go
+++ b/pkg/clustermesh/loadbalancer/reflector.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package loadbalancer
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/stream"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/container"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	reflectorEndpoints "github.com/cilium/cilium/pkg/loadbalancer/reflectors/endpoints"
+	"github.com/cilium/cilium/pkg/loadbalancer/writer"
+	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+const reflectorBufferSize = 500
+
+type reflectorParams struct {
+	cell.In
+
+	Log        *slog.Logger
+	JobGroup   job.Group
+	Writer     *writer.Writer
+	Config     loadbalancer.Config
+	ExtConfig  loadbalancer.ExternalConfig
+	TestConfig *loadbalancer.TestConfig `optional:"true"`
+	cmtypes.ServiceModeV2Config
+}
+
+func (p reflectorParams) waitTime() time.Duration {
+	if p.TestConfig != nil {
+		// Use a much lower wait time in tests to trigger more edge cases and make them faster.
+		return 10 * time.Millisecond
+	}
+	return p.Config.ReflectorWaitTime
+}
+
+func registerEndpointSliceReflector(p reflectorParams, observer *endpointSliceObserver) {
+	if observer == nil {
+		return
+	}
+
+	initComplete := p.Writer.RegisterInitializer("clustermesh")
+	p.JobGroup.Add(
+		job.OneShot("reflect-endpointslices", func(ctx context.Context, health cell.Health) error {
+			return runEndpointSliceReflector(ctx, p, observer, initComplete)
+		}),
+	)
+}
+
+func runEndpointSliceReflector(ctx context.Context, p reflectorParams, observer *endpointSliceObserver, initComplete func(writer.WriteTxn)) error {
+	currentEndpointsByCluster := map[uint32]reflectorEndpoints.Cache{}
+
+	processEndpointsEvent := func(txn writer.WriteTxn, key bufferKey, val bufferValue) error {
+		if val.synced {
+			initComplete(txn)
+			return nil
+		}
+
+		allEps := val.allEndpoints
+		currentEndpoints := currentEndpointsByCluster[key.clusterID]
+		if currentEndpoints == nil {
+			currentEndpoints = reflectorEndpoints.Cache{}
+			currentEndpointsByCluster[key.clusterID] = currentEndpoints
+		}
+
+		// Convert [k8s.Endpoints] to [loadbalancer.Backend]
+		backends := reflectorEndpoints.Convert(p.Log, p.ExtConfig, key.serviceName, allEps.Backends())
+
+		if err := p.Writer.UpsertAndReleaseBackends(txn, key.serviceName, source.ClusterMesh, key.clusterID, backends, currentEndpoints.Orphans(allEps.All())); err != nil {
+			return err
+		}
+
+		currentEndpoints.UpdateMany(allEps.All())
+		if len(currentEndpoints) == 0 {
+			delete(currentEndpointsByCluster, key.clusterID)
+		}
+
+		return nil
+	}
+
+	bufferPool := sync.Pool{
+		New: func() any {
+			return container.NewInsertOrderedMap[bufferKey, bufferValue]()
+		},
+	}
+
+	events := stream.ToChannel(
+		ctx,
+		stream.Buffer(
+			observer,
+			reflectorBufferSize,
+			p.waitTime(),
+			func(buf buffer, ev endpointSliceEvent) buffer {
+				if buf == nil {
+					buf = bufferPool.Get().(buffer)
+				}
+				return bufferInsert(buf, ev)
+			},
+		),
+	)
+
+	for buf := range events {
+		txn := p.Writer.WriteTxn()
+		for key, val := range buf.All() {
+			if err := processEndpointsEvent(txn, key, val); err != nil {
+				txn.Abort()
+				return err
+			}
+		}
+		txn.Commit()
+		buf.Clear()
+		bufferPool.Put(buf)
+	}
+
+	return nil
+}
+
+type bufferKey struct {
+	serviceName loadbalancer.ServiceName
+	clusterID   uint32
+}
+
+type bufferValue struct {
+	synced       bool
+	allEndpoints reflectorEndpoints.AllEndpoints
+}
+
+// buffer for holding a batch of endpoints event
+type buffer = *container.InsertOrderedMap[bufferKey, bufferValue]
+
+func bufferInsert(buf buffer, ev endpointSliceEvent) buffer {
+	switch ev.kind {
+	case resource.Upsert, resource.Delete:
+		key := bufferKey{
+			ev.obj.ServiceName,
+			ev.clusterID,
+		}
+		var allEps reflectorEndpoints.AllEndpoints
+		if old, ok := buf.Get(key); ok {
+			allEps = old.allEndpoints
+		}
+		// Since we may merge a mixture of Upsert and Delete events together we handle
+		// deletion as an Upsert of [endpoints.Endpoints] with nil backends.
+		allEps = allEps.Insert(ev.kind == resource.Delete, ev.obj)
+		buf.Insert(key, bufferValue{
+			synced:       false,
+			allEndpoints: allEps,
+		})
+	case resource.Sync:
+		buf.Insert(bufferKey{}, bufferValue{synced: true})
+	default:
+		panic("unexpected clustermesh loadbalancer.endpointSliceEvent")
+	}
+	return buf
+}

--- a/pkg/clustermesh/loadbalancer/selectbackends.go
+++ b/pkg/clustermesh/loadbalancer/selectbackends.go
@@ -1,29 +1,42 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package clustermesh
+package loadbalancer
 
 import (
 	"iter"
 	"log/slog"
 
+	"github.com/cilium/hive/cell"
 	"github.com/cilium/statedb"
 
 	"github.com/cilium/cilium/pkg/annotation"
+	"github.com/cilium/cilium/pkg/clustermesh/common"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/loadbalancer/writer"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/source"
 )
 
+type selectBackendsParams struct {
+	cell.In
+
+	Logger *slog.Logger
+	Writer *writer.Writer
+
+	CommonConfig common.Config
+	ClusterInfo  cmtypes.ClusterInfo
+}
+
 // injectSelectBackends overrides the load-balancing backend selection algorithm to implement
 // support for the ServiceAffinity and IncludeExternal annotations.
-func injectSelectBackends(cm *ClusterMesh, expCfg loadbalancer.Config, w *writer.Writer) {
-	if cm == nil {
+func injectSelectBackends(p selectBackendsParams) {
+	if p.ClusterInfo.ID == 0 || p.CommonConfig.ClusterMeshConfig == "" {
 		// ClusterMesh disabled, do not change the backend selection.
 		return
 	}
-	w.SetSelectBackendsFunc(NewClusterMeshSelectBackends(w, cm.conf.Logger).SelectBackends)
+	p.Writer.SetSelectBackendsFunc(NewClusterMeshSelectBackends(p.Writer, p.Logger).SelectBackends)
 }
 
 type ClusterMeshSelectBackends struct {

--- a/pkg/clustermesh/loadbalancer/service_merger.go
+++ b/pkg/clustermesh/loadbalancer/service_merger.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package clustermesh
+package loadbalancer
 
 import (
 	"context"
@@ -11,7 +11,6 @@ import (
 	"github.com/cilium/hive/job"
 	"k8s.io/utils/ptr"
 
-	"github.com/cilium/cilium/pkg/clustermesh/common"
 	serviceStore "github.com/cilium/cilium/pkg/clustermesh/store"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/loadbalancer"
@@ -19,10 +18,12 @@ import (
 	"github.com/cilium/cilium/pkg/source"
 )
 
+type ServicesSyncedFunc func(context.Context) error
+
 // registerServicesInitialized adds a job to wait for the ClusterMesh services to be synchronized
 // before marking the load-balancing tables as initialized.
-func registerServicesInitialized(jobs job.Group, cm *ClusterMesh, cfg cmtypes.ServiceModeV2Config, w *writer.Writer) {
-	if cm == nil || !cfg.ServiceModeV2.ShouldWatchLegacyServices() {
+func registerServicesInitialized(jobs job.Group, synced ServicesSyncedFunc, cfg cmtypes.ServiceModeV2Config, w *writer.Writer) {
+	if synced == nil || !cfg.ServiceModeV2.ShouldWatchLegacyServices() {
 		return
 	}
 	markDone := w.RegisterInitializer("clustermesh")
@@ -30,7 +31,7 @@ func registerServicesInitialized(jobs job.Group, cm *ClusterMesh, cfg cmtypes.Se
 		job.OneShot(
 			"services-initialized",
 			func(ctx context.Context, health cell.Health) error {
-				if err := cm.ServicesSynced(ctx); err != nil {
+				if err := synced(ctx); err != nil {
 					return err
 				}
 				txn := w.WriteTxn()
@@ -50,23 +51,12 @@ type ServiceMerger interface {
 	MergeExternalServiceDelete(service *serviceStore.ClusterService)
 }
 
-type serviceMergerParams struct {
-	cell.In
-
-	ClusterInfo cmtypes.ClusterInfo
-	CMConfig    common.Config
-	LBConfig    loadbalancer.Config
-	Writer      *writer.Writer
+func newServiceMerger(writer *writer.Writer) ServiceMerger {
+	return &serviceMerger{writer: writer}
 }
-
-func newServiceMerger(p serviceMergerParams) ServiceMerger {
-	return &serviceMerger{clusterInfo: p.ClusterInfo, writer: p.Writer}
-}
-
 
 type serviceMerger struct {
-	clusterInfo cmtypes.ClusterInfo
-	writer      *writer.Writer
+	writer *writer.Writer
 }
 
 func (sm *serviceMerger) MergeExternalServiceDelete(service *serviceStore.ClusterService) {

--- a/pkg/clustermesh/script_test.go
+++ b/pkg/clustermesh/script_test.go
@@ -163,7 +163,8 @@ func TestScript(t *testing.T) {
 					config := cmtypes.CiliumClusterConfig{
 						ID: uint32(i + 1),
 						Capabilities: cmtypes.CiliumClusterConfigCapabilities{
-							MaxConnectedClusters: 255,
+							MaxConnectedClusters:     255,
+							EndpointSlicesExportMode: cmtypes.EndpointSlicesExportModeServicesAndEndpointSlices,
 						},
 					}
 					err := clustercfg.Set(context.TODO(), name, config, client)

--- a/pkg/clustermesh/service_merger.go
+++ b/pkg/clustermesh/service_merger.go
@@ -4,9 +4,11 @@
 package clustermesh
 
 import (
+	"context"
 	"slices"
 
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
 	"k8s.io/utils/ptr"
 
 	"github.com/cilium/cilium/pkg/clustermesh/common"
@@ -16,6 +18,29 @@ import (
 	"github.com/cilium/cilium/pkg/loadbalancer/writer"
 	"github.com/cilium/cilium/pkg/source"
 )
+
+// registerServicesInitialized adds a job to wait for the ClusterMesh services to be synchronized
+// before marking the load-balancing tables as initialized.
+func registerServicesInitialized(jobs job.Group, cm *ClusterMesh, cfg cmtypes.ServiceModeV2Config, w *writer.Writer) {
+	if cm == nil || !cfg.ServiceModeV2.ShouldWatchLegacyServices() {
+		return
+	}
+	markDone := w.RegisterInitializer("clustermesh")
+	jobs.Add(
+		job.OneShot(
+			"services-initialized",
+			func(ctx context.Context, health cell.Health) error {
+				if err := cm.ServicesSynced(ctx); err != nil {
+					return err
+				}
+				txn := w.WriteTxn()
+				markDone(txn)
+				txn.Commit()
+				return nil
+			},
+		),
+	)
+}
 
 // ServiceMerger is the interface to be implemented by the owner of local
 // services. The functions have to merge service updates and deletions with
@@ -37,6 +62,7 @@ type serviceMergerParams struct {
 func newServiceMerger(p serviceMergerParams) ServiceMerger {
 	return &serviceMerger{clusterInfo: p.ClusterInfo, writer: p.Writer}
 }
+
 
 type serviceMerger struct {
 	clusterInfo cmtypes.ClusterInfo

--- a/pkg/clustermesh/testdata/clusterservice-service-affinity.txtar
+++ b/pkg/clustermesh/testdata/clusterservice-service-affinity.txtar
@@ -1,4 +1,4 @@
-#! --cluster-id=1 --cluster-name=cluster1 --clustermesh-service-v2=prefer-endpointslice
+#! --cluster-id=1 --cluster-name=cluster1
 
 hive/start
 
@@ -6,8 +6,8 @@ hive/start
 k8s/add service.yaml endpointslice.yaml
 db/cmp frontends frontends-local.table
 
-# Add the endpoint slice from "cluster2"
-kvstore/update cilium/state/endpointslices/v1/cluster2/test/echo clusterendpointslice2.json
+# Add the cluster service from "cluster2"
+kvstore/update cilium/state/services/v1/cluster2/test/echo clusterservice2.json
 
 # As there are healthy local backends the remote backends are ignored
 db/cmp backends backends.table
@@ -28,19 +28,29 @@ k8s/update service.yaml
 db/cmp frontends frontends-remote.table
 
 # Removing the remote backend will make us use the local one.
-kvstore/delete cilium/state/endpointslices/v1/cluster2/test/echo
+kvstore/delete cilium/state/services/v1/cluster2/test/echo
 db/cmp frontends frontends-local.table
 
 # Adding it back gets us back to using the remote one.
-kvstore/update cilium/state/endpointslices/v1/cluster2/test/echo clusterendpointslice2.json
+kvstore/update cilium/state/services/v1/cluster2/test/echo clusterservice2.json
 db/cmp frontends frontends-remote.table
+
+# Flip affinity to "none". Both local and remote are used.
+sed 'affinity: "remote"' 'affinity: "none"' service.yaml
+k8s/update service.yaml
+db/cmp frontends frontends-all.table
+
+# Set an invalid affinity value. Treated as none.
+sed 'affinity: "none"' 'affinity: "invalid_value"' service.yaml
+k8s/update service.yaml
+db/cmp frontends frontends-all.table
 
 # Remove affinity. Now both local and remote are used.
 sed 'affinity:' 'affinity-nope:' service.yaml
 k8s/update service.yaml
 db/cmp frontends frontends-all.table
 
-###
+### Th-th-th-th-That's all Folks!
 
 -- backends.table --
 Address              PortNames  NodeName
@@ -59,33 +69,22 @@ Address            Type       ServiceName   Status  Backends
 Address            Type       ServiceName   Status  Backends
 10.0.0.1:8080/TCP  ClusterIP  test/echo     Done    10.1.0.1:8080/TCP, 20.0.0.2:9090/TCP
 
--- clusterendpointslice2.json --
+-- clusterservice2.json --
 {
+  "name": "echo",
+  "namespace": "test",
+  "includeExternal": true,
+  "shared": true,
   "cluster": "cluster2",
   "clusterID": 2,
-  "namespace": "test",
-  "name": "echo",
-  "labels": {
-    "kubernetes.io/service-name": "echo"
-  },
-  "addressType": "IPv4",
-  "endpoints": [
-    {
-      "addresses": ["20.0.0.2"],
-      "conditions": {
-        "ready": true,
-        "serving": true,
-        "terminating": false
+  "backends": {
+    "20.0.0.2": {
+      "tcp": {
+        "Protocol": "TCP",
+        "Port": 9090
       }
     }
-  ],
-  "ports": [
-    {
-      "name": "tcp",
-      "port": 9090,
-      "protocol": "TCP"
-    }
-  ]
+  }
 }
 
 -- service.yaml --

--- a/pkg/clustermesh/testdata/service-multiport.txtar
+++ b/pkg/clustermesh/testdata/service-multiport.txtar
@@ -1,0 +1,128 @@
+#! --cluster-id=1 --cluster-name=cluster1 --clustermesh-service-v2=prefer-endpointslice
+
+hive/start
+
+# Create a service to which to add the external backends with multiple ports.
+k8s/add service.yaml
+
+# Add a remote endpoint slice with multiple backend IPs and ports.
+# Some ports are the same and should be added to a single backend entry
+# containing all the associated port names.
+kvstore/update cilium/state/endpointslices/v1/cluster2/test/echo clusterendpointslice2.json
+db/cmp backends backends.table
+db/cmp frontends frontends-with-clusterendpointslice.table
+
+# Remove the remote endpoint slice
+kvstore/delete cilium/state/endpointslices/v1/cluster2/test/echo
+
+# Frontends should no longer have backends, and backends should be empty
+db/cmp frontends frontends-without-clusterendpointslice.table
+db/empty backends
+
+###
+
+-- backends.table --
+Address              PortNames                           NodeName
+20.0.0.2:80/TCP      http-alt,http-direct,http-remapped
+20.0.0.2:443/TCP     https
+20.0.0.3:80/TCP      http-alt,http-direct,http-remapped
+20.0.0.3:443/TCP     https
+
+-- frontends-with-clusterendpointslice.table --
+Address            Type       ServiceName   Status  Backends
+10.0.0.1:80/TCP    ClusterIP  test/echo     Done    20.0.0.2:80/TCP, 20.0.0.3:80/TCP
+10.0.0.1:443/TCP   ClusterIP  test/echo     Done    20.0.0.2:443/TCP, 20.0.0.3:443/TCP
+10.0.0.1:8080/TCP  ClusterIP  test/echo     Done    20.0.0.2:80/TCP, 20.0.0.3:80/TCP
+10.0.0.1:9090/TCP  ClusterIP  test/echo     Done    20.0.0.2:80/TCP, 20.0.0.3:80/TCP
+
+-- frontends-without-clusterendpointslice.table --
+Address            Type       ServiceName   Status  Backends
+10.0.0.1:80/TCP    ClusterIP  test/echo     Done
+10.0.0.1:443/TCP   ClusterIP  test/echo     Done
+10.0.0.1:8080/TCP  ClusterIP  test/echo     Done
+10.0.0.1:9090/TCP  ClusterIP  test/echo     Done
+
+-- clusterendpointslice2.json --
+{
+  "cluster": "cluster2",
+  "clusterID": 2,
+  "namespace": "test",
+  "name": "echo",
+  "labels": {
+    "kubernetes.io/service-name": "echo"
+  },
+  "addressType": "IPv4",
+  "endpoints": [
+    {
+      "addresses": ["20.0.0.2"],
+      "conditions": {
+        "ready": true,
+        "serving": true,
+        "terminating": false
+      }
+    },
+    {
+      "addresses": ["20.0.0.3"],
+      "conditions": {
+        "ready": true,
+        "serving": true,
+        "terminating": false
+      }
+    }
+  ],
+  "ports": [
+    {
+      "name": "http-alt",
+      "port": 80,
+      "protocol": "TCP"
+    },
+    {
+      "name": "http-direct",
+      "port": 80,
+      "protocol": "TCP"
+    },
+    {
+      "name": "http-remapped",
+      "port": 80,
+      "protocol": "TCP"
+    },
+    {
+      "name": "https",
+      "port": 443,
+      "protocol": "TCP"
+    }
+  ]
+}
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.cilium.io/global: "true"
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 10.0.0.1
+  clusterIPs:
+  - 10.0.0.1
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ports:
+  - name: http-direct
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  - name: http-remapped
+    port: 8080
+    protocol: TCP
+    targetPort: 80
+  - name: http-alt
+    port: 9090
+    protocol: TCP
+    targetPort: 80
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 443
+  type: ClusterIP

--- a/pkg/clustermesh/testdata/service-without-local-eps.txtar
+++ b/pkg/clustermesh/testdata/service-without-local-eps.txtar
@@ -1,0 +1,134 @@
+#! --cluster-id=1 --cluster-name=cluster1 --clustermesh-service-v2=prefer-endpointslice
+
+hive/start
+
+# Create a service without selector (no epslices) to which to add the external backends.
+k8s/add service.yaml
+db/cmp frontends frontends.table
+
+# Add the endpoint slice from a remote cluster
+kvstore/update cilium/state/endpointslices/v1/cluster2/test/echo clusterendpointslice2.json
+
+# The remote backends should be included
+db/cmp frontends frontends-with-clusterendpointslice.table
+db/cmp backends backends.table
+
+# Removing the endpoint slice brings us back to the initial state
+kvstore/delete cilium/state/endpointslices/v1/cluster2/test/echo
+db/cmp frontends frontends.table
+db/empty backends
+
+# Adding the endpoint slice upserts the backends again
+kvstore/update cilium/state/endpointslices/v1/cluster2/test/echo clusterendpointslice2_v2.json
+db/cmp frontends frontends-with-clusterendpointslice_v2.table
+db/cmp backends backends_v2.table
+
+###
+
+-- backends.table --
+Address              PortNames  NodeName
+20.0.0.2:9090/TCP    tcp
+
+-- backends_v2.table --
+Address              PortNames  NodeName
+20.0.0.2:9090/TCP    tcp
+20.0.0.3:9090/TCP    tcp
+
+-- frontends.table --
+Address            Type       ServiceName   Status  Backends
+10.0.0.1:8080/TCP  ClusterIP  test/echo     Done
+
+-- frontends-with-clusterendpointslice.table --
+Address            Type       ServiceName   Status  Backends
+10.0.0.1:8080/TCP  ClusterIP  test/echo     Done    20.0.0.2:9090/TCP
+
+-- frontends-with-clusterendpointslice_v2.table --
+Address            Type       ServiceName   Status  Backends
+10.0.0.1:8080/TCP  ClusterIP  test/echo     Done    20.0.0.2:9090/TCP, 20.0.0.3:9090/TCP
+
+-- clusterendpointslice2.json --
+{
+  "cluster": "cluster2",
+  "clusterID": 2,
+  "namespace": "test",
+  "name": "echo",
+  "labels": {
+    "kubernetes.io/service-name": "echo"
+  },
+  "addressType": "IPv4",
+  "endpoints": [
+    {
+      "addresses": ["20.0.0.2"],
+      "conditions": {
+        "ready": true,
+        "serving": true,
+        "terminating": false
+      }
+    }
+  ],
+  "ports": [
+    {
+      "name": "tcp",
+      "port": 9090,
+      "protocol": "TCP"
+    }
+  ]
+}
+
+-- clusterendpointslice2_v2.json --
+{
+  "cluster": "cluster2",
+  "clusterID": 2,
+  "namespace": "test",
+  "name": "echo",
+  "labels": {
+    "kubernetes.io/service-name": "echo"
+  },
+  "addressType": "IPv4",
+  "endpoints": [
+    {
+      "addresses": ["20.0.0.2"],
+      "conditions": {
+        "ready": true,
+        "serving": true,
+        "terminating": false
+      }
+    },
+    {
+      "addresses": ["20.0.0.3"],
+      "conditions": {
+        "ready": true,
+        "serving": true,
+        "terminating": false
+      }
+    }
+  ],
+  "ports": [
+    {
+      "name": "tcp",
+      "port": 9090,
+      "protocol": "TCP"
+    }
+  ]
+}
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.cilium.io/global: "true"
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 10.0.0.1
+  clusterIPs:
+  - 10.0.0.1
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ports:
+  - name: tcp
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  type: ClusterIP

--- a/pkg/clustermesh/testdata/service.txtar
+++ b/pkg/clustermesh/testdata/service.txtar
@@ -1,0 +1,213 @@
+#! --cluster-id=1 --cluster-name=cluster1 --clustermesh-service-v2=prefer-endpointslice
+
+hive/start
+
+# Create a service to which to add the external backends.
+k8s/add service.yaml endpointslice.yaml
+db/cmp frontends frontends.table
+
+# Add the endpoint slices from "cluster2" and "cluster3"
+kvstore/update cilium/state/endpointslices/v1/cluster2/test/echo clusterendpointslice2.json
+kvstore/update cilium/state/endpointslices/v1/cluster3/test/echo clusterendpointslice3.json
+
+# The backends from other clusters should be included
+db/cmp backends backends-2+3.table
+db/cmp frontends frontends-with-clusterendpointslice-2+3.table
+
+# Update a backend
+kvstore/update cilium/state/endpointslices/v1/cluster2/test/echo clusterendpointslice2_v2.json
+db/cmp backends backends-2+3_v2.table
+
+# Changing "global" to false will drop remote backends
+sed 'service.cilium.io/global: "true"' 'service.cilium.io/global: "false"' service.yaml
+k8s/update service.yaml
+db/cmp frontends frontends.table
+
+# Switch back for next test
+sed 'service.cilium.io/global: "false"' 'service.cilium.io/global: "true"' service.yaml
+k8s/update service.yaml
+db/cmp backends backends-2+3_v2.table
+
+# Removing the cluster service removes one of the backends
+kvstore/delete cilium/state/endpointslices/v1/cluster2/test/echo
+db/cmp backends backends-3.table
+db/cmp frontends frontends-with-clusterendpointslice-3.table
+
+# Removing the last endpoint slice gets us back to starting point
+kvstore/delete cilium/state/endpointslices/v1/cluster3/test/echo
+db/cmp frontends frontends.table
+
+###
+
+-- backends-2+3.table --
+Address              PortNames  NodeName
+10.1.0.1:8080/TCP    tcp        nodeport-worker
+20.0.0.2:9090/TCP    tcp
+30.0.0.3:9090/TCP    tcp
+
+-- backends-2+3_v2.table --
+Address              PortNames  NodeName
+10.1.0.1:8080/TCP    tcp        nodeport-worker
+20.0.0.2:9090/TCP    tcp
+20.0.0.3:9090/TCP    tcp
+30.0.0.3:9090/TCP    tcp
+
+-- backends-3.table --
+Address              PortNames  NodeName
+10.1.0.1:8080/TCP    tcp        nodeport-worker
+30.0.0.3:9090/TCP    tcp
+
+-- frontends.table --
+Address            Type       ServiceName   Status  Backends
+10.0.0.1:8080/TCP  ClusterIP  test/echo     Done    10.1.0.1:8080/TCP
+
+-- frontends-with-clusterendpointslice-3.table --
+Address            Type       ServiceName   Status  Backends
+10.0.0.1:8080/TCP  ClusterIP  test/echo     Done    10.1.0.1:8080/TCP, 30.0.0.3:9090/TCP
+
+-- frontends-with-clusterendpointslice-2+3.table --
+Address            Type       ServiceName   Status  Backends
+10.0.0.1:8080/TCP  ClusterIP  test/echo     Done    10.1.0.1:8080/TCP, 20.0.0.2:9090/TCP, 30.0.0.3:9090/TCP
+
+
+
+-- clusterendpointslice2.json --
+{
+  "cluster": "cluster2",
+  "clusterID": 2,
+  "namespace": "test",
+  "name": "echo",
+  "labels": {
+    "kubernetes.io/service-name": "echo"
+  },
+  "addressType": "IPv4",
+  "endpoints": [
+    {
+      "addresses": ["20.0.0.2"],
+      "conditions": {
+        "ready": true,
+        "serving": true,
+        "terminating": false
+      }
+    }
+  ],
+  "ports": [
+    {
+      "name": "tcp",
+      "port": 9090,
+      "protocol": "TCP"
+    }
+  ]
+}
+
+-- clusterendpointslice2_v2.json --
+{
+  "cluster": "cluster2",
+  "clusterID": 2,
+  "namespace": "test",
+  "name": "echo",
+  "labels": {
+    "kubernetes.io/service-name": "echo"
+  },
+  "addressType": "IPv4",
+  "endpoints": [
+    {
+      "addresses": ["20.0.0.2"],
+      "conditions": {
+        "ready": true,
+        "serving": true,
+        "terminating": false
+      }
+    },
+    {
+      "addresses": ["20.0.0.3"],
+      "conditions": {
+        "ready": true,
+        "serving": true,
+        "terminating": false
+      }
+    }
+  ],
+  "ports": [
+    {
+      "name": "tcp",
+      "port": 9090,
+      "protocol": "TCP"
+    }
+  ]
+}
+
+-- clusterendpointslice3.json --
+{
+  "cluster": "cluster3",
+  "clusterID": 3,
+  "namespace": "test",
+  "name": "echo",
+  "labels": {
+    "kubernetes.io/service-name": "echo"
+  },
+  "addressType": "IPv4",
+  "endpoints": [
+    {
+      "addresses": ["30.0.0.3"],
+      "conditions": {
+        "ready": true,
+        "serving": true,
+        "terminating": false
+      }
+    }
+  ],
+  "ports": [
+    {
+      "name": "tcp",
+      "port": 9090,
+      "protocol": "TCP"
+    }
+  ]
+}
+
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.cilium.io/global: "true"
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 10.0.0.1
+  clusterIPs:
+  - 10.0.0.1
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ports:
+  - name: tcp
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    name: echo
+  type: ClusterIP
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-kvlm2
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.1.0.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: nodeport-worker
+ports:
+- name: tcp
+  port: 8080
+  protocol: TCP

--- a/pkg/clustermesh/types/endpointslice/endpointslice.go
+++ b/pkg/clustermesh/types/endpointslice/endpointslice.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/clustermesh/types/endpointslice/internal"
 	slim_discovery_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 )
@@ -53,6 +54,22 @@ func (eps *ClusterEndpointSlice) GetKeyName() string {
 	// WARNING - STABLE API: Changing the structure of the key may break
 	// backwards compatibility
 	return kvstore.JoinKey(eps.Cluster, eps.Namespace, eps.Name)
+}
+
+// ToShallowSlimEndpointSlice converts the ClusterEndpointSlice. The returned
+// EndpointSlice is a shallow copy and therefore not safe to mutate.
+func (eps *ClusterEndpointSlice) ToShallowSlimEndpointSlice() *slim_discovery_v1.EndpointSlice {
+	return &slim_discovery_v1.EndpointSlice{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:        eps.Name,
+			Namespace:   eps.Namespace,
+			Labels:      eps.Labels,
+			Annotations: eps.Annotations,
+		},
+		AddressType: eps.AddressType,
+		Endpoints:   eps.Endpoints,
+		Ports:       eps.Ports,
+	}
 }
 
 var (

--- a/pkg/dial/resolver_test.go
+++ b/pkg/dial/resolver_test.go
@@ -283,7 +283,7 @@ func TestServiceBackendResolver(t *testing.T) {
 		},
 	), "Unexpected UpsertServiceAndFrontends error")
 
-	require.NoError(t, wr.UpsertBackends(txn, svc.Name, source.Kubernetes,
+	require.NoError(t, wr.UpsertBackends(txn, svc.Name, source.Kubernetes, writer.LocalClusterID,
 		slices.Values([]lb.Backend{
 			be(lb.TCP, "10.0.0.1", 9090, "alpha", lb.BackendStateActive),
 			be(lb.TCP, "10.0.0.2", 9090, "alpha", lb.BackendStateActive),
@@ -345,7 +345,7 @@ func TestServiceBackendResolver(t *testing.T) {
 
 	// Remove the previously used backend
 	txn = wr.WriteTxn()
-	wr.DeleteBackendsByAddress(txn, svc.Name, slices.Values([]lb.L3n4Addr{toAddr(lb.TCP, host, 9090)}))
+	wr.DeleteBackendsByAddress(txn, svc.Name, source.Kubernetes, writer.LocalClusterID, slices.Values([]lb.L3n4Addr{toAddr(lb.TCP, host, 9090)}))
 	txn.Commit()
 
 	// Should switch to one of the remaining backends

--- a/pkg/loadbalancer/reflectors/conversions.go
+++ b/pkg/loadbalancer/reflectors/conversions.go
@@ -5,7 +5,6 @@ package reflectors
 
 import (
 	"fmt"
-	"iter"
 	"log/slog"
 	"net/netip"
 	"slices"
@@ -17,7 +16,6 @@ import (
 	"github.com/cilium/cilium/pkg/annotation"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/container/cache"
-	"github.com/cilium/cilium/pkg/k8s"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	k8sLabels "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels"
 	"github.com/cilium/cilium/pkg/labels"
@@ -31,19 +29,7 @@ import (
 var (
 	zeroV4 = cmtypes.MustParseAddrCluster("0.0.0.0")
 	zeroV6 = cmtypes.MustParseAddrCluster("::")
-
-	ingressDummyAddress = cmtypes.MustParseAddrCluster("192.192.192.192")
-	ingressDummyPort    = uint16(9999)
 )
-
-func isIngressDummyEndpoint(l3n4Addr loadbalancer.L3n4Addr) bool {
-	// The ingress and gateway-api controllers (operator/pkg/model/translation/{gateway-api,ingress}) create
-	// a dummy endpoint to force Cilium to reconcile the service. This is no longer required with this new
-	// control-plane, but due to rolling upgrades we cannot remove it immediately. Hence we have the
-	// special handling here to just ignore this endpoint to avoid populating the tables with unnecessary
-	// data.
-	return l3n4Addr.AddrCluster() == ingressDummyAddress && l3n4Addr.Port() == ingressDummyPort
-}
 
 func getAnnotationServiceForwardingMode(cfg loadbalancer.Config, svc *slim_corev1.Service) (loadbalancer.SVCForwardingMode, error) {
 	if value, ok := annotation.Get(svc, annotation.ServiceForwardingMode); ok {
@@ -392,100 +378,6 @@ func getIPFamilies(svc *slim_corev1.Service) []slim_corev1.IPFamily {
 		families = append(families, slim_corev1.IPv6Protocol)
 	}
 	return families
-}
-
-func convertEndpoints(rawlog *slog.Logger, cfg loadbalancer.ExternalConfig, svcName loadbalancer.ServiceName, bes iter.Seq2[cmtypes.AddrCluster, *k8s.Backend]) iter.Seq[loadbalancer.Backend] {
-	return func(yield func(be loadbalancer.Backend) bool) {
-		// Lazily construct the augmented logger as we very rarely log here.
-		log := sync.OnceValue(func() *slog.Logger {
-			return rawlog.With(
-				logfields.Service, svcName.Name,
-				logfields.K8sNamespace, svcName.Namespace,
-			)
-		})
-
-		for addrCluster, be := range bes {
-			if (!cfg.EnableIPv6 && addrCluster.Is6()) || (!cfg.EnableIPv4 && addrCluster.Is4()) {
-				log().Debug(
-					"Skipping Backend due to disabled IP family",
-					logfields.IPv4, cfg.EnableIPv4,
-					logfields.IPv6, cfg.EnableIPv6,
-					logfields.Address, addrCluster,
-				)
-				continue
-			}
-			for l4Addr, portNames := range be.Ports {
-				l3n4Addr := loadbalancer.NewL3n4Addr(
-					l4Addr.Protocol,
-					addrCluster,
-					l4Addr.Port,
-					loadbalancer.ScopeExternal,
-				)
-				if isIngressDummyEndpoint(l3n4Addr) {
-					continue
-				}
-
-				// Filter out the unnamed port, if present
-				if idx := slices.Index(portNames, ""); idx != -1 {
-					if len(portNames) == 1 {
-						portNames = nil
-					} else {
-						portNames = slices.Concat(portNames[:idx], portNames[idx+1:])
-					}
-				}
-
-				var state loadbalancer.BackendState
-				switch {
-				case be.Maintenance:
-					state = loadbalancer.BackendStateMaintenance
-				case be.Conditions.IsReady():
-					// A backend that is ready (regardless of serving and terminating) is considered
-					// active. We may see backends that are ready+terminating if 'PublishNotReadyAddresses'
-					// is true. While it would be more logical to set this as terminating, we're following
-					// kube-proxy here and considering it as an active backend and not ignoring it even when
-					// other active backends are available.
-					//
-					// See also kube-proxy implementation at:
-					// https://github.com/kubernetes/kubernetes/blob/790393ae92e97262827d4f1fba24e8ae65bbada0/pkg/proxy/topology.go#L61
-					state = loadbalancer.BackendStateActive
-				case be.Conditions.IsTerminating() && !be.Conditions.IsServing():
-					// A backend that is terminating and not serving should not be used for load-balancing
-					// even if it's the only backend. A terminating backend is kept in the BPF maps until
-					// fully removed to avoid disrupting connections.
-					state = loadbalancer.BackendStateTerminatingNotServing
-				case be.Conditions.IsTerminating():
-					// A backend that is terminating and serving can still be used for new connections
-					// when no active backends are available. A terminating backend is kept in the BPF maps until
-					// fully removed to avoid disrupting connections.
-					state = loadbalancer.BackendStateTerminating
-				default:
-					// In all other cases we mark the backend to be in maintenance. This avoids disruptions
-					// to existing connections when a backend readiness is flapping.
-					state = loadbalancer.BackendStateMaintenance
-				}
-				weight := be.Weight
-				if weight == 0 && !be.Maintenance {
-					weight = loadbalancer.DefaultBackendWeight
-				}
-				bep := loadbalancer.Backend{
-					Address:   l3n4Addr,
-					NodeName:  be.NodeName,
-					PortNames: portNames,
-					Weight:    weight,
-					State:     state,
-				}
-				if be.Zone != "" {
-					bep.Zone = &loadbalancer.BackendZone{
-						Zone:     be.Zone,
-						ForZones: be.HintsForZones,
-					}
-				}
-				if !yield(bep) {
-					break
-				}
-			}
-		}
-	}
 }
 
 func trafficDistribution(svc *slim_corev1.Service) loadbalancer.TrafficDistribution {

--- a/pkg/loadbalancer/reflectors/endpoints/cache.go
+++ b/pkg/loadbalancer/reflectors/endpoints/cache.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package endpoints
+
+import (
+	"iter"
+	"maps"
+
+	"github.com/cilium/cilium/pkg/loadbalancer"
+
+	cslices "github.com/cilium/cilium/pkg/slices"
+)
+
+type EndpointsNamespacedName = string
+
+// Cache stores the latest endpoints state seen by a loadbalancer reflector.
+// Reflectors use it to update backend state when updating an Endpoints. It is
+// especially useful to determine which backends need to be orphaned (see
+// [Cache.Orphans]).
+type Cache map[EndpointsNamespacedName]Endpoints
+
+// All returns all the elements from the cache as a sequence of service name
+// and the corresponding backend addresses essentially "unwrapping" and
+// converting the Endpoints object for the caller.
+func (cache Cache) All() iter.Seq2[loadbalancer.ServiceName, iter.Seq[loadbalancer.L3n4Addr]] {
+	return func(yield func(loadbalancer.ServiceName, iter.Seq[loadbalancer.L3n4Addr]) bool) {
+		for _, ev := range cache {
+			for addr, be := range ev.Backends {
+				if !yield(ev.ServiceName, cslices.MapIter(maps.Keys(be.Ports), func(l4Addr loadbalancer.L4Addr) loadbalancer.L3n4Addr {
+					return loadbalancer.NewL3n4Addr(
+						l4Addr.Protocol,
+						addr,
+						l4Addr.Port,
+						loadbalancer.ScopeExternal,
+					)
+				})) {
+					return
+				}
+			}
+		}
+	}
+}
+
+func (cache Cache) Update(ep Endpoints) {
+	if len(ep.Backends) == 0 {
+		delete(cache, ep.Name)
+		return
+	}
+
+	cache[ep.Name] = ep
+}
+
+func (cache Cache) UpdateMany(endpoints iter.Seq[Endpoints]) {
+	for ep := range endpoints {
+		cache.Update(ep)
+	}
+}
+
+// Orphans returns backend addresses that exist in the cache but are not present
+// in the supplied newEndpoints.
+func (cache Cache) Orphans(newEndpoints iter.Seq[Endpoints]) iter.Seq[loadbalancer.L3n4Addr] {
+	return func(yield func(loadbalancer.L3n4Addr) bool) {
+		for ep := range newEndpoints {
+			previous, found := cache[ep.Name]
+			if !found {
+				continue
+			}
+
+			for addr, prevBe := range previous.Backends {
+				be, foundBe := ep.Backends[addr]
+				for l4Addr := range prevBe.Ports {
+					foundPort := false
+					if foundBe {
+						_, foundPort = be.Ports[l4Addr]
+					}
+					if !foundPort {
+						if !yield(loadbalancer.NewL3n4Addr(l4Addr.Protocol, addr, l4Addr.Port, loadbalancer.ScopeExternal)) {
+							return
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/pkg/loadbalancer/reflectors/endpoints/endpoints.go
+++ b/pkg/loadbalancer/reflectors/endpoints/endpoints.go
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package endpoints
+
+import (
+	"iter"
+	"log/slog"
+	"slices"
+	"sync"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+var (
+	ingressDummyAddress = cmtypes.MustParseAddrCluster("192.192.192.192")
+	ingressDummyPort    = uint16(9999)
+)
+
+func isIngressDummyEndpoint(l3n4Addr loadbalancer.L3n4Addr) bool {
+	// The ingress and gateway-api controllers (operator/pkg/model/translation/{gateway-api,ingress}) create
+	// a dummy endpoint to force Cilium to reconcile the service. This is no longer required with this new
+	// control-plane, but due to rolling upgrades we cannot remove it immediately. Hence we have the
+	// special handling here to just ignore this endpoint to avoid populating the tables with unnecessary
+	// data.
+	return l3n4Addr.AddrCluster() == ingressDummyAddress && l3n4Addr.Port() == ingressDummyPort
+}
+
+type Endpoints struct {
+	Name        string
+	ServiceName loadbalancer.ServiceName
+	Backends    map[cmtypes.AddrCluster]*k8s.Backend
+}
+
+// AllEndpoints holds one or more [k8s.Endpoints] that target the same service within a single buffer.
+// This type is designed to avoid allocations for the usual case of single endpoint slice per service.
+type AllEndpoints struct {
+	head Endpoints
+	tail []Endpoints
+}
+
+func (ae AllEndpoints) Insert(deleted bool, ep *k8s.Endpoints) AllEndpoints {
+	ev := Endpoints{
+		Name:        ep.EndpointSliceName,
+		ServiceName: ep.ServiceName,
+	}
+	if !deleted {
+		ev.Backends = ep.Backends
+	}
+
+	if ae.head.Name == "" || ae.head.Name == ev.Name {
+		ae.head = ev
+		return ae
+	}
+	for i, x := range ae.tail {
+		if ev.Name == x.Name {
+			ae.tail[i] = ev
+			return ae
+		}
+	}
+	ae.tail = append(ae.tail, ev)
+	return ae
+}
+
+func (ae *AllEndpoints) All() iter.Seq[Endpoints] {
+	return func(yield func(Endpoints) bool) {
+		if ae.head.Name != "" {
+			if !yield(ae.head) {
+				return
+			}
+		}
+		for _, ep := range ae.tail {
+			if !yield(ep) {
+				return
+			}
+		}
+	}
+}
+
+func (ae *AllEndpoints) Backends() iter.Seq2[cmtypes.AddrCluster, *k8s.Backend] {
+	return func(yield func(cmtypes.AddrCluster, *k8s.Backend) bool) {
+		for ep := range ae.All() {
+			for addr, be := range ep.Backends {
+				if !yield(addr, be) {
+					return
+				}
+			}
+		}
+	}
+}
+
+func Convert(rawlog *slog.Logger, cfg loadbalancer.ExternalConfig, svcName loadbalancer.ServiceName, bes iter.Seq2[cmtypes.AddrCluster, *k8s.Backend]) iter.Seq[loadbalancer.Backend] {
+	return func(yield func(be loadbalancer.Backend) bool) {
+		// Lazily construct the augmented logger as we very rarely log here.
+		log := sync.OnceValue(func() *slog.Logger {
+			return rawlog.With(
+				logfields.Service, svcName.Name,
+				logfields.K8sNamespace, svcName.Namespace,
+			)
+		})
+
+		for addrCluster, be := range bes {
+			if (!cfg.EnableIPv6 && addrCluster.Is6()) || (!cfg.EnableIPv4 && addrCluster.Is4()) {
+				log().Debug(
+					"Skipping Backend due to disabled IP family",
+					logfields.IPv4, cfg.EnableIPv4,
+					logfields.IPv6, cfg.EnableIPv6,
+					logfields.Address, addrCluster,
+				)
+				continue
+			}
+			for l4Addr, portNames := range be.Ports {
+				l3n4Addr := loadbalancer.NewL3n4Addr(
+					l4Addr.Protocol,
+					addrCluster,
+					l4Addr.Port,
+					loadbalancer.ScopeExternal,
+				)
+				if isIngressDummyEndpoint(l3n4Addr) {
+					continue
+				}
+
+				// Filter out the unnamed port, if present
+				if idx := slices.Index(portNames, ""); idx != -1 {
+					if len(portNames) == 1 {
+						portNames = nil
+					} else {
+						portNames = slices.Concat(portNames[:idx], portNames[idx+1:])
+					}
+				}
+
+				var state loadbalancer.BackendState
+				switch {
+				case be.Maintenance:
+					state = loadbalancer.BackendStateMaintenance
+				case be.Conditions.IsReady():
+					// A backend that is ready (regardless of serving and terminating) is considered
+					// active. We may see backends that are ready+terminating if 'PublishNotReadyAddresses'
+					// is true. While it would be more logical to set this as terminating, we're following
+					// kube-proxy here and considering it as an active backend and not ignoring it even when
+					// other active backends are available.
+					//
+					// See also kube-proxy implementation at:
+					// https://github.com/kubernetes/kubernetes/blob/790393ae92e97262827d4f1fba24e8ae65bbada0/pkg/proxy/topology.go#L61
+					state = loadbalancer.BackendStateActive
+				case be.Conditions.IsTerminating() && !be.Conditions.IsServing():
+					// A backend that is terminating and not serving should not be used for load-balancing
+					// even if it's the only backend. A terminating backend is kept in the BPF maps until
+					// fully removed to avoid disrupting connections.
+					state = loadbalancer.BackendStateTerminatingNotServing
+				case be.Conditions.IsTerminating():
+					// A backend that is terminating and serving can still be used for new connections
+					// when no active backends are available. A terminating backend is kept in the BPF maps until
+					// fully removed to avoid disrupting connections.
+					state = loadbalancer.BackendStateTerminating
+				default:
+					// In all other cases we mark the backend to be in maintenance. This avoids disruptions
+					// to existing connections when a backend readiness is flapping.
+					state = loadbalancer.BackendStateMaintenance
+				}
+				weight := be.Weight
+				if weight == 0 && !be.Maintenance {
+					weight = loadbalancer.DefaultBackendWeight
+				}
+				bep := loadbalancer.Backend{
+					Address:   l3n4Addr,
+					NodeName:  be.NodeName,
+					PortNames: portNames,
+					Weight:    weight,
+					State:     state,
+				}
+				if be.Zone != "" {
+					bep.Zone = &loadbalancer.BackendZone{
+						Zone:     be.Zone,
+						ForZones: be.HintsForZones,
+					}
+				}
+				if !yield(bep) {
+					break
+				}
+			}
+		}
+	}
+}

--- a/pkg/loadbalancer/reflectors/file.go
+++ b/pkg/loadbalancer/reflectors/file.go
@@ -228,7 +228,7 @@ func (s *fileReflector) synchronize(txn writer.WriteTxn, state *StateFile) (numS
 	for i := range state.Endpoints {
 		eps := k8s.ParseEndpointSliceV1(s.log, &state.Endpoints[i])
 		bes := convertEndpoints(s.log, s.extConfig, eps.ServiceName, maps.All(eps.Backends))
-		if err := s.w.UpsertBackends(txn, eps.ServiceName, source.LocalAPI, bes); err != nil {
+		if err := s.w.UpsertBackends(txn, eps.ServiceName, source.LocalAPI, writer.LocalClusterID, bes); err != nil {
 			return 0, 0, 0, fmt.Errorf("failed to upsert backends: %w", err)
 		}
 		numBackends++

--- a/pkg/loadbalancer/reflectors/file.go
+++ b/pkg/loadbalancer/reflectors/file.go
@@ -23,6 +23,7 @@ import (
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_discoveryv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	reflectorEndpoints "github.com/cilium/cilium/pkg/loadbalancer/reflectors/endpoints"
 	"github.com/cilium/cilium/pkg/loadbalancer/writer"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/source"
@@ -227,7 +228,7 @@ func (s *fileReflector) synchronize(txn writer.WriteTxn, state *StateFile) (numS
 	}
 	for i := range state.Endpoints {
 		eps := k8s.ParseEndpointSliceV1(s.log, &state.Endpoints[i])
-		bes := convertEndpoints(s.log, s.extConfig, eps.ServiceName, maps.All(eps.Backends))
+		bes := reflectorEndpoints.Convert(s.log, s.extConfig, eps.ServiceName, maps.All(eps.Backends))
 		if err := s.w.UpsertBackends(txn, eps.ServiceName, source.LocalAPI, writer.LocalClusterID, bes); err != nil {
 			return 0, 0, 0, fmt.Errorf("failed to upsert backends: %w", err)
 		}

--- a/pkg/loadbalancer/reflectors/k8s.go
+++ b/pkg/loadbalancer/reflectors/k8s.go
@@ -300,7 +300,7 @@ func runServiceEndpointsReflector(ctx context.Context, health cell.Health, p ref
 							l4Addr.Port,
 							loadbalancer.ScopeExternal))
 					}
-					if err := p.Writer.DeleteBackendsByAddress(txn, ev.svcName, slices.Values(addrs)); err != nil {
+					if err := p.Writer.DeleteBackendsByAddress(txn, ev.svcName, source.Kubernetes, writer.LocalClusterID, slices.Values(addrs)); err != nil {
 						p.Log.Error("BUG: Unexpected failure to delete backends", logfields.Error, err)
 					}
 				}
@@ -317,7 +317,7 @@ func runServiceEndpointsReflector(ctx context.Context, health cell.Health, p ref
 				// Convert [k8s.Endpoints] to [loadbalancer.Backend]
 				backends := convertEndpoints(p.Log, p.ExtConfig, name, maps.All(eps.Backends))
 
-				err := p.Writer.UpsertBackends(txn, name, source.Kubernetes, backends)
+				err := p.Writer.UpsertBackends(txn, name, source.Kubernetes, writer.LocalClusterID, backends)
 				rh.update("eps:"+name.String(), err)
 				if err != nil {
 					continue
@@ -379,7 +379,7 @@ func runServiceEndpointsReflector(ctx context.Context, health cell.Health, p ref
 				}
 			}
 
-			err = p.Writer.UpsertAndReleaseBackends(txn, name, source.Kubernetes, backends, orphans)
+			err = p.Writer.UpsertAndReleaseBackends(txn, name, source.Kubernetes, writer.LocalClusterID, backends, orphans)
 			if err != nil {
 				rh.update("eps:"+name.String(), err)
 				return

--- a/pkg/loadbalancer/reflectors/k8s.go
+++ b/pkg/loadbalancer/reflectors/k8s.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/utils"
 	k8sUtils "github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	reflectorEndpoints "github.com/cilium/cilium/pkg/loadbalancer/reflectors/endpoints"
 	"github.com/cilium/cilium/pkg/loadbalancer/writer"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -278,7 +279,7 @@ func runServiceEndpointsReflector(ctx context.Context, health cell.Health, p ref
 		}
 	}
 
-	currentEndpoints := map[string]endpointsEvent{}
+	currentEndpoints := reflectorEndpoints.Cache{}
 	processEndpointsEvent := func(txn writer.WriteTxn, key bufferKey, val bufferValue) {
 		switch val.kind {
 		case resource.Sync:
@@ -290,19 +291,9 @@ func runServiceEndpointsReflector(ctx context.Context, health cell.Health, p ref
 			}
 
 			// Delete all previous endpoints
-			for _, ev := range currentEndpoints {
-				for addr, prevBe := range ev.backends {
-					addrs := make([]loadbalancer.L3n4Addr, 0, len(prevBe.Ports))
-					for l4Addr := range prevBe.Ports {
-						addrs = append(addrs, loadbalancer.NewL3n4Addr(
-							l4Addr.Protocol,
-							addr,
-							l4Addr.Port,
-							loadbalancer.ScopeExternal))
-					}
-					if err := p.Writer.DeleteBackendsByAddress(txn, ev.svcName, source.Kubernetes, writer.LocalClusterID, slices.Values(addrs)); err != nil {
-						p.Log.Error("BUG: Unexpected failure to delete backends", logfields.Error, err)
-					}
+			for name, addrs := range currentEndpoints.All() {
+				if err := p.Writer.DeleteBackendsByAddress(txn, name, source.Kubernetes, writer.LocalClusterID, addrs); err != nil {
+					p.Log.Error("BUG: Unexpected failure to delete backends", logfields.Error, err)
 				}
 			}
 			clear(currentEndpoints)
@@ -315,19 +306,18 @@ func runServiceEndpointsReflector(ctx context.Context, health cell.Health, p ref
 				servicesToRefresh.Delete(name)
 
 				// Convert [k8s.Endpoints] to [loadbalancer.Backend]
-				backends := convertEndpoints(p.Log, p.ExtConfig, name, maps.All(eps.Backends))
+				backends := reflectorEndpoints.Convert(p.Log, p.ExtConfig, name, maps.All(eps.Backends))
 
 				err := p.Writer.UpsertBackends(txn, name, source.Kubernetes, writer.LocalClusterID, backends)
 				rh.update("eps:"+name.String(), err)
 				if err != nil {
 					continue
 				}
-
-				currentEndpoints[eps.EndpointSliceName] = endpointsEvent{
-					name:     eps.EndpointSliceName,
-					svcName:  name,
-					backends: eps.Backends,
-				}
+				currentEndpoints.Update(reflectorEndpoints.Endpoints{
+					Name:        eps.EndpointSliceName,
+					ServiceName: name,
+					Backends:    eps.Backends,
+				})
 			}
 
 			// Refresh the remaining frontends that now have no backends.
@@ -347,52 +337,15 @@ func runServiceEndpointsReflector(ctx context.Context, health cell.Health, p ref
 			var err error
 
 			// Convert [k8s.Endpoints] to [loadbalancer.Backend]
-			backends := convertEndpoints(p.Log, p.ExtConfig, name, allEps.Backends())
+			backends := reflectorEndpoints.Convert(p.Log, p.ExtConfig, name, allEps.Backends())
 
-			// Find orphaned backends. We are using iter.Seq to avoid unnecessary allocations.
-			var orphans iter.Seq[loadbalancer.L3n4Addr] = func(yield func(loadbalancer.L3n4Addr) bool) {
-				for ep := range allEps.All() {
-					previous, found := currentEndpoints[ep.name]
-					if !found {
-						continue
-					}
-					for addr, prevBe := range previous.backends {
-						be, foundBe := ep.backends[addr]
-						for l4Addr := range prevBe.Ports {
-							foundPort := false
-							if foundBe {
-								_, foundPort = be.Ports[l4Addr]
-							}
-							if !foundPort {
-								if !yield(
-									loadbalancer.NewL3n4Addr(
-										l4Addr.Protocol,
-										addr,
-										l4Addr.Port,
-										loadbalancer.ScopeExternal,
-									)) {
-									return
-								}
-							}
-						}
-					}
-				}
-			}
-
-			err = p.Writer.UpsertAndReleaseBackends(txn, name, source.Kubernetes, writer.LocalClusterID, backends, orphans)
+			err = p.Writer.UpsertAndReleaseBackends(txn, name, source.Kubernetes, writer.LocalClusterID, backends, currentEndpoints.Orphans(allEps.All()))
 			if err != nil {
 				rh.update("eps:"+name.String(), err)
 				return
 			}
 
-			for ep := range allEps.All() {
-				if len(ep.backends) == 0 {
-					delete(currentEndpoints, ep.name)
-				} else {
-					ep.svcName = name
-					currentEndpoints[ep.name] = ep
-				}
-			}
+			currentEndpoints.UpdateMany(allEps.All())
 
 			rh.update("eps:"+name.String(), err)
 
@@ -456,72 +409,9 @@ type bufferKey struct {
 type bufferValue struct {
 	kind             resource.EventKind
 	svc              *slim_corev1.Service
-	allEndpoints     allEndpoints
+	allEndpoints     reflectorEndpoints.AllEndpoints
 	endpointsReplace []*k8s.Endpoints
 	servicesReplace  []*slim_corev1.Service
-}
-
-type endpointsEvent struct {
-	name     string
-	svcName  loadbalancer.ServiceName
-	backends map[cmtypes.AddrCluster]*k8s.Backend
-}
-
-// allEndpoints holds one or more [k8s.Endpoints] that target the same service within a single buffer.
-// This type is designed to avoid allocations for the usual case of single endpoint slice per service.
-type allEndpoints struct {
-	head endpointsEvent
-	tail []endpointsEvent
-}
-
-func (ae allEndpoints) insert(deleted bool, ep *k8s.Endpoints) allEndpoints {
-	ev := endpointsEvent{
-		name:    ep.EndpointSliceName,
-		svcName: ep.ServiceName,
-	}
-	if !deleted {
-		ev.backends = ep.Backends
-	}
-
-	if ae.head.name == "" || ae.head.name == ev.name {
-		ae.head = ev
-		return ae
-	}
-	for i, x := range ae.tail {
-		if ev.name == x.name {
-			ae.tail[i] = ev
-			return ae
-		}
-	}
-	ae.tail = append(ae.tail, ev)
-	return ae
-}
-
-func (ae *allEndpoints) All() iter.Seq[endpointsEvent] {
-	return func(yield func(endpointsEvent) bool) {
-		if ae.head.name != "" {
-			if !yield(ae.head) {
-				return
-			}
-		}
-		for _, ep := range ae.tail {
-			if !yield(ep) {
-				return
-			}
-		}
-	}
-}
-
-func (ae *allEndpoints) Backends() iter.Seq2[cmtypes.AddrCluster, *k8s.Backend] {
-	return func(yield func(cmtypes.AddrCluster, *k8s.Backend) bool) {
-		for ep := range ae.All() {
-			for addr, be := range ep.backends {
-				if !yield(addr, be) {
-					return
-				}
-			}
-		}
-	}
 }
 
 // buffer for holding a batch of service or endpoint events
@@ -548,11 +438,11 @@ func bufferInsert(buf buffer, ev event) buffer {
 			resource.Key{Name: ev.obj.ServiceName.Name(), Namespace: ev.obj.ServiceName.Namespace()},
 			false,
 		}
-		var allEps allEndpoints
+		var allEps reflectorEndpoints.AllEndpoints
 		if old, ok := buf.Get(key); ok {
 			allEps = old.allEndpoints
 		}
-		allEps = allEps.insert(false, ev.obj)
+		allEps = allEps.Insert(false, ev.obj)
 		buf.Insert(key, bufferValue{
 			kind:         resource.Upsert,
 			allEndpoints: allEps,
@@ -562,13 +452,13 @@ func bufferInsert(buf buffer, ev event) buffer {
 			resource.Key{Name: ev.obj.ServiceName.Name(), Namespace: ev.obj.ServiceName.Namespace()},
 			false,
 		}
-		var allEps allEndpoints
+		var allEps reflectorEndpoints.AllEndpoints
 		if old, ok := buf.Get(key); ok {
 			allEps = old.allEndpoints
 		}
-		allEps = allEps.insert(true, ev.obj)
+		allEps = allEps.Insert(true, ev.obj)
 		// Since we may merge a mixture of Upsert and Delete events together we handle
-		// deletion as an Upsert of [endpointsEvent] with nil backends.
+		// deletion as an Upsert of [endpoints.Endpoints] with nil backends.
 		buf.Insert(key, bufferValue{
 			kind:         resource.Upsert,
 			allEndpoints: allEps,

--- a/pkg/loadbalancer/reflectors/k8s_test.go
+++ b/pkg/loadbalancer/reflectors/k8s_test.go
@@ -20,6 +20,7 @@ import (
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/k8s/testutils"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	reflectorEndpoints "github.com/cilium/cilium/pkg/loadbalancer/reflectors/endpoints"
 	"github.com/cilium/cilium/pkg/source"
 )
 
@@ -69,7 +70,7 @@ func BenchmarkConvertEndpoints(b *testing.B) {
 	backends := maps.All(eps.Backends)
 
 	for b.Loop() {
-		convertEndpoints(logger, benchmarkExternalConfig, eps.ServiceName, backends)
+		reflectorEndpoints.Convert(logger, benchmarkExternalConfig, eps.ServiceName, backends)
 	}
 	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "endpoints/sec")
 }
@@ -100,7 +101,7 @@ func TestConvertEndpointsRespectsEndpointSliceWeight(t *testing.T) {
 		},
 	})
 
-	backends := slices.Collect(convertEndpoints(logger, benchmarkExternalConfig, eps.ServiceName, maps.All(eps.Backends)))
+	backends := slices.Collect(reflectorEndpoints.Convert(logger, benchmarkExternalConfig, eps.ServiceName, maps.All(eps.Backends)))
 	require.Len(t, backends, 1)
 	require.Equal(t, uint16(42), backends[0].Weight)
 	require.Equal(t, loadbalancer.BackendStateActive, backends[0].State)
@@ -138,7 +139,7 @@ func TestConvertEndpointsWeightZeroForcesMaintenance(t *testing.T) {
 		},
 	})
 
-	backends := slices.Collect(convertEndpoints(logger, benchmarkExternalConfig, eps.ServiceName, maps.All(eps.Backends)))
+	backends := slices.Collect(reflectorEndpoints.Convert(logger, benchmarkExternalConfig, eps.ServiceName, maps.All(eps.Backends)))
 	require.Len(t, backends, 1)
 	require.Zero(t, backends[0].Weight)
 	require.Equal(t, loadbalancer.BackendStateMaintenance, backends[0].State)

--- a/pkg/loadbalancer/writer/benchmark_test.go
+++ b/pkg/loadbalancer/writer/benchmark_test.go
@@ -132,6 +132,7 @@ func BenchmarkInsertBackend(b *testing.B) {
 				wtxn,
 				name,
 				source.Kubernetes,
+				LocalClusterID,
 				slices.Values([]loadbalancer.Backend{
 					{
 						Address: beAddr,
@@ -174,6 +175,7 @@ func BenchmarkReplaceBackend(b *testing.B) {
 		wtxn,
 		name,
 		source.Kubernetes,
+		LocalClusterID,
 		slices.Values([]loadbalancer.Backend{
 			{
 				Address: beAddr,
@@ -193,6 +195,7 @@ func BenchmarkReplaceBackend(b *testing.B) {
 			wtxn,
 			name,
 			source.Kubernetes,
+			LocalClusterID,
 			params,
 		)
 	}
@@ -274,7 +277,7 @@ func Benchmark_UpsertBackends_SharedBackendManyServices(b *testing.B) {
 	for b.Loop() {
 		wtxn := p.Writer.WriteTxn()
 		for _, svc := range names {
-			if err := p.Writer.UpsertBackends(wtxn, svc, source.Kubernetes, slices.Values(bes)); err != nil {
+			if err := p.Writer.UpsertBackends(wtxn, svc, source.Kubernetes, LocalClusterID, slices.Values(bes)); err != nil {
 				wtxn.Abort()
 				b.Fatal(err)
 			}

--- a/pkg/loadbalancer/writer/writer.go
+++ b/pkg/loadbalancer/writer/writer.go
@@ -649,8 +649,8 @@ func (w *Writer) DeleteBackendsBySource(txn WriteTxn, source source.Source) erro
 }
 
 // UpsertBackends adds/updates backends for the given service.
-func (w *Writer) UpsertBackends(txn WriteTxn, serviceName loadbalancer.ServiceName, source source.Source, bes iter.Seq[loadbalancer.Backend]) error {
-	changed, err := w.updateBackends(txn, serviceName, source, LocalClusterID, bes)
+func (w *Writer) UpsertBackends(txn WriteTxn, serviceName loadbalancer.ServiceName, source source.Source, clusterID uint32, bes iter.Seq[loadbalancer.Backend]) error {
+	changed, err := w.updateBackends(txn, serviceName, source, clusterID, bes)
 	if err != nil {
 		return err
 	}
@@ -660,7 +660,7 @@ func (w *Writer) UpsertBackends(txn WriteTxn, serviceName loadbalancer.ServiceNa
 	return w.RefreshFrontends(txn, serviceName)
 }
 
-func (w *Writer) UpsertAndReleaseBackends(txn WriteTxn, serviceName loadbalancer.ServiceName, source source.Source, new iter.Seq[loadbalancer.Backend], orphans iter.Seq[loadbalancer.L3n4Addr]) error {
+func (w *Writer) UpsertAndReleaseBackends(txn WriteTxn, serviceName loadbalancer.ServiceName, source source.Source, clusterID uint32, new iter.Seq[loadbalancer.Backend], orphans iter.Seq[loadbalancer.L3n4Addr]) error {
 	// Remove orphaned backends first since [new] might again add them back.
 	hadOrphan := false
 	srcPrio := w.sourcePriority(source)
@@ -678,7 +678,7 @@ func (w *Writer) UpsertAndReleaseBackends(txn WriteTxn, serviceName loadbalancer
 		hadOrphan = hadOrphan || found
 	}
 
-	changed, err := w.updateBackends(txn, serviceName, source, LocalClusterID, new)
+	changed, err := w.updateBackends(txn, serviceName, source, clusterID, new)
 	if err != nil {
 		return err
 	}
@@ -780,12 +780,12 @@ func (w *Writer) DeleteBackendsOfServiceFromCluster(txn WriteTxn, name loadbalan
 	return w.RefreshFrontends(txn, name)
 }
 
-func (w *Writer) DeleteBackendsByAddress(txn WriteTxn, name loadbalancer.ServiceName, addrs iter.Seq[loadbalancer.L3n4Addr]) error {
+func (w *Writer) DeleteBackendsByAddress(txn WriteTxn, name loadbalancer.ServiceName, src source.Source, clusterID uint32, addrs iter.Seq[loadbalancer.L3n4Addr]) error {
 	changed := false
 	for addr := range addrs {
 		bes := w.bes.List(txn, loadbalancer.BackendByAddress(addr))
 		for be := range bes {
-			if be.ServiceName == name {
+			if be.ServiceName == name && be.Source == src && be.ClusterID == clusterID {
 				if _, _, err := w.bes.Delete(txn, be); err != nil {
 					return err
 				}

--- a/pkg/loadbalancer/writer/writer_test.go
+++ b/pkg/loadbalancer/writer/writer_test.go
@@ -237,6 +237,7 @@ func TestWriter_Backend_UpsertDelete(t *testing.T) {
 			wtxn,
 			name1,
 			source.Kubernetes,
+			LocalClusterID,
 			slices.Values([]loadbalancer.Backend{
 				{
 					Address: beAddr1,
@@ -253,6 +254,7 @@ func TestWriter_Backend_UpsertDelete(t *testing.T) {
 			wtxn,
 			name2,
 			source.Kubernetes,
+			LocalClusterID,
 			slices.Values([]loadbalancer.Backend{
 				{
 					Address: beAddr3,
@@ -297,7 +299,7 @@ func TestWriter_Backend_UpsertDelete(t *testing.T) {
 
 		// Release the [name1] reference to [beAddr1].
 		require.Equal(t, 3, p.BackendTable.NumObjects(wtxn))
-		err := p.Writer.DeleteBackendsByAddress(wtxn, name1, slices.Values([]loadbalancer.L3n4Addr{beAddr1}))
+		err := p.Writer.DeleteBackendsByAddress(wtxn, name1, source.Kubernetes, LocalClusterID, slices.Values([]loadbalancer.L3n4Addr{beAddr1}))
 		require.NoError(t, err, "ReleaseBackend failed")
 
 		wtxn.Abort()
@@ -321,6 +323,7 @@ func TestWriter_UpdateBackendHealth_AllSources(t *testing.T) {
 			wtxn,
 			name,
 			src,
+			LocalClusterID,
 			slices.Values([]loadbalancer.Backend{{
 				Address: beAddr,
 				State:   loadbalancer.BackendStateActive,
@@ -720,9 +723,9 @@ func TestWriter_WithConflictingSources(t *testing.T) {
 		{
 			desc: "add backends for two services",
 			action: func(t *testing.T, w *Writer, wtxn WriteTxn) {
-				require.NoError(t, w.UpsertBackends(wtxn, name1, source.Kubernetes,
+				require.NoError(t, w.UpsertBackends(wtxn, name1, source.Kubernetes, LocalClusterID,
 					slices.Values([]loadbalancer.Backend{backend10})))
-				require.NoError(t, w.UpsertBackends(wtxn, name2, source.KubeAPIServer,
+				require.NoError(t, w.UpsertBackends(wtxn, name2, source.KubeAPIServer, LocalClusterID,
 					slices.Values([]loadbalancer.Backend{backend20})))
 			},
 			want: map[loadbalancer.ServiceName]*weight{name1: ptr.To[weight](10), name2: ptr.To[weight](20)},
@@ -730,7 +733,7 @@ func TestWriter_WithConflictingSources(t *testing.T) {
 		{
 			desc: "update backend from higher priority source",
 			action: func(t *testing.T, w *Writer, wtxn WriteTxn) {
-				require.NoError(t, w.UpsertBackends(wtxn, name1, source.KubeAPIServer,
+				require.NoError(t, w.UpsertBackends(wtxn, name1, source.KubeAPIServer, LocalClusterID,
 					slices.Values([]loadbalancer.Backend{backend11})))
 			},
 			want: map[loadbalancer.ServiceName]*weight{name1: ptr.To[weight](11), name2: ptr.To[weight](20)},
@@ -738,7 +741,7 @@ func TestWriter_WithConflictingSources(t *testing.T) {
 		{
 			desc: "update backend from lower priority source",
 			action: func(t *testing.T, w *Writer, wtxn WriteTxn) {
-				require.NoError(t, w.UpsertBackends(wtxn, name1, source.Kubernetes,
+				require.NoError(t, w.UpsertBackends(wtxn, name1, source.Kubernetes, LocalClusterID,
 					slices.Values([]loadbalancer.Backend{backend12})))
 			},
 			want: map[loadbalancer.ServiceName]*weight{name1: ptr.To[weight](11), name2: ptr.To[weight](20)}, // no change here
@@ -754,9 +757,9 @@ func TestWriter_WithConflictingSources(t *testing.T) {
 		{
 			desc: "add deleted backends back",
 			action: func(t *testing.T, w *Writer, wtxn WriteTxn) {
-				require.NoError(t, w.UpsertBackends(wtxn, name1, source.KubeAPIServer,
+				require.NoError(t, w.UpsertBackends(wtxn, name1, source.KubeAPIServer, LocalClusterID,
 					slices.Values([]loadbalancer.Backend{backend11})))
-				require.NoError(t, w.UpsertBackends(wtxn, name2, source.KubeAPIServer,
+				require.NoError(t, w.UpsertBackends(wtxn, name2, source.KubeAPIServer, LocalClusterID,
 					slices.Values([]loadbalancer.Backend{backend20})))
 			},
 			want: map[loadbalancer.ServiceName]*weight{name1: ptr.To[weight](11), name2: ptr.To[weight](20)},


### PR DESCRIPTION
Related to https://github.com/cilium/cilium/issues/41953 / https://github.com/cilium/design-cfps/blob/main/cilium/CFP-41953-clustermesh-service-v2.md

The goal of this PR is to wire the new ClusterMesh endpoint slice resource to the loadbalancer (and in turn allow global services to work). The approach I took here is to wire the source and cluster id in EndpointsEvents within the k8s handling and insert clustermesh events directly in this buffer. I went with that approach since it wasn't that complex to make the k8s reflector source/clusterid awarer and splitting the logic further could make it significantly more complex/means a larger refector. It does mean that k8s.go does process events from clustermesh though which is probably not exactly ideal :(. If you have better suggestion feel free :pray:!

Used AIL-2 to help write this PR