### PR TITLE
docs: add missing identity default label filters

### DIFF
--- a/Documentation/operations/performance/scalability/identity-relevant-labels.rst
+++ b/Documentation/operations/performance/scalability/identity-relevant-labels.rst
@@ -38,6 +38,7 @@ Label                                               Description
 ``!annotation.*``                                   Ignore all ``annotation`` labels
 ``!controller-uid``                                 Ignore all ``controller-uid`` labels
 ``!etcd_node``                                      Ignore all ``etcd_node`` labels
+``!topology\.kubernetes\.io``                       Ignore all ``topology.kubernetes.io`` labels
 =================================================== =========================================================
 
 The above label patterns are all *exclusive label patterns*, that is to say


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/43725 adds topology.kubernetes.io to the identity default label filters but the document is not updated.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

<!-- Description of change -->

```release-note
docs: Add missing identity default label filter
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
