### PR TITLE
docs: fix duplicated word in service mesh installation guide

### DIFF
--- a/Documentation/network/servicemesh/installation.rst
+++ b/Documentation/network/servicemesh/installation.rst
@@ -89,4 +89,4 @@ Installation
             $ cilium status
 
 It is also recommended that you :ref:`install Hubble CLI<hubble_cli_install>`
-which will be used used to observe the traffic in later steps.
+which will be used to observe the traffic in later steps.


### PR DESCRIPTION
The Hubble CLI step read "which will be used used to observe the traffic" — removed the duplicated "used".
