### PR TITLE
Improve output for `cilium-dbg policy selectors`

### DIFF
--- a/cilium-dbg/cmd/policy_selectors.go
+++ b/cilium-dbg/cmd/policy_selectors.go
@@ -4,18 +4,22 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
-	"text/tabwriter"
 
+	"github.com/gosuri/uitable"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/command"
-	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/slices"
 )
 
 var verbosePolicySelectors bool
@@ -33,58 +37,61 @@ var policyCacheGetCmd = func(name, description string, f func() (models.Selector
 					os.Exit(1)
 				}
 			} else if resp != nil {
-				w := tabwriter.NewWriter(os.Stdout, 5, 0, 3, ' ', 0)
 				// Sort to keep output stable
 				sort.Slice(resp, func(i, j int) bool {
 					return resp[i].Selector < resp[j].Selector
 				})
-				fmt.Fprintf(w, "SELECTOR\tLABELS\tUSERS\tIDENTITIES\n")
 
 				for _, mapping := range resp {
-					lbls := constructLabelArrayListFromAPIType(mapping.Labels)
-
-					first := true
-					fmt.Fprintf(w, "%s", mapping.Selector)
-					if verbosePolicySelectors {
-						var lstr string
-						if len(lbls) != 0 {
-							lstr = lbls.Sort().String()
-						}
-						fmt.Fprintf(w, "\t%s", lstr)
-					} else {
-						fmt.Fprintf(w, "\t%s", getNameAndNamespaceFromLabels(lbls))
-					}
-					fmt.Fprintf(w, "\t%d", mapping.Users)
-					if len(mapping.Identities) == 0 {
-						fmt.Fprintf(w, "\t\n")
-					}
-					for _, idty := range mapping.Identities {
-						if first {
-							fmt.Fprintf(w, "\t%d\t\n", idty)
-							first = false
-						} else {
-							fmt.Fprintf(w, "\t\t\t%d\t\n", idty)
-						}
-					}
+					table := uitable.New()
+					table.Wrap = true
+					table.MaxColWidth = 50000
+					table.AddRow("Selector:", formatSelector(mapping.Selector))
+					table.AddRow("Owners:", formatLabels(mapping.Labels))
+					table.AddRow("User count:", mapping.Users)
+					table.AddRow("Identities:", strings.Join(
+						slices.Map(mapping.Identities, func(i int64) string {
+							return strconv.FormatInt(i, 10)
+						}),
+						"\n",
+					))
+					fmt.Println(table)
+					fmt.Print("\n\n")
 				}
-
-				w.Flush()
 			}
 		},
 	}
 }
 
-func getNameAndNamespaceFromLabels(list labels.LabelArrayList) string {
+func formatLabels(in models.LabelArrayList) string {
+	list := constructLabelArrayListFromAPIType(in)
+
 	var sb strings.Builder
+	first := true
 	for _, lbls := range list {
-		ns := lbls.Get(labels.LabelSourceK8sKeyPrefix + k8sconst.PolicyLabelNamespace)
-		if ns != "" {
-			if sb.Len() > 0 {
-				sb.WriteString(",")
+		if !first {
+			sb.WriteRune('\n')
+		} else {
+			first = false
+		}
+		if verbosePolicySelectors {
+			sb.WriteString(lbls.String())
+			continue
+		}
+
+		kind := lbls.Get("io.cilium.k8s.policy.derived-from")
+		ns := lbls.Get("k8s:io.cilium.k8s.policy.namespace")
+		name := lbls.Get("k8s:io.cilium.k8s.policy.name")
+		if kind != "" {
+			sb.WriteString(kind)
+			sb.WriteRune(':')
+			if ns != "" {
+				sb.WriteString(ns)
+				sb.WriteRune('/')
 			}
-			sb.WriteString(ns)
-			sb.WriteRune('/')
-			sb.WriteString(lbls.Get(labels.LabelSourceK8sKeyPrefix + k8sconst.PolicyLabelName))
+			sb.WriteString(name)
+		} else {
+			sb.WriteString(lbls.String())
 		}
 	}
 	return sb.String()
@@ -104,6 +111,23 @@ func constructLabelArrayListFromAPIType(in models.LabelArrayList) labels.LabelAr
 		list = append(list, lbls)
 	}
 	return list
+}
+
+func formatSelector(sel string) string {
+	if !strings.HasPrefix(sel, `{"`) {
+		return sel
+	}
+
+	es := api.EndpointSelector{}
+	err := json.Unmarshal([]byte(sel), &es)
+	if err != nil {
+		return sel
+	}
+	selYaml, err := yaml.Marshal(es)
+	if err != nil {
+		return sel
+	}
+	return strings.TrimSpace(string(selYaml))
 }
 
 func init() {

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/google/renameio/v2 v2.0.2
 	github.com/google/uuid v1.6.0
 	github.com/gopacket/gopacket v1.6.1
+	github.com/gosuri/uitable v0.0.4
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/hashicorp/go-hclog v1.6.3
@@ -229,7 +230,6 @@ require (
 	github.com/google/licenseclassifier/v2 v2.0.0 // indirect
 	github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
-	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/ianlancetaylor/demangle v0.0.0-20250417193237-f615e6bd150b // indirect

--- a/pkg/fqdn/dnsproxy/helpers_test.go
+++ b/pkg/fqdn/dnsproxy/helpers_test.go
@@ -231,6 +231,6 @@ func (m MockCachedSelector) IsNone() bool {
 	return false
 }
 
-func (m MockCachedSelector) String() string {
+func (m MockCachedSelector) Key() string {
 	return m.key
 }

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -1558,7 +1558,7 @@ func (t selectorMock) IsNone() bool {
 	panic("implement me")
 }
 
-func (t selectorMock) String() string {
+func (t selectorMock) Key() string {
 	return t.key
 }
 

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -355,7 +355,7 @@ func (l7 L7DataMap) MarshalJSON() ([]byte, error) {
 	buffer := bytes.NewBufferString("[")
 	for _, cs := range selectors {
 		buffer.WriteString("{\"")
-		buffer.WriteString(cs.String())
+		buffer.WriteString(cs.Key())
 		buffer.WriteString("\":")
 		b, err := json.Marshal(l7[cs])
 		if err == nil {
@@ -1963,7 +1963,7 @@ func (l4 *L4Policy) GetModel() *models.L4Policy {
 		for sel, rules := range v.RuleOrigin {
 			lal := rules.GetLabelArrayList()
 			derivedFrom.MergeSorted(lal)
-			rulesBySelector[sel.String()] = lal.GetModel()
+			rulesBySelector[sel.Key()] = lal.GetModel()
 		}
 		ingress = append(ingress, &models.PolicyRule{
 			Rule:             v.Marshal(),

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -246,7 +246,7 @@ func (td *testData) verifyL4PolicyMapEqual(t *testing.T, expected, actual L4Poli
 
 			for k, v := range l4.PerSelectorPolicies {
 				bV, found := l4B.PerSelectorPolicies[k]
-				require.True(t, found, "Failed to find expected cached selector in PerSelectorPolicy: %s (%v)", k.String(), l4B.PerSelectorPolicies)
+				require.True(t, found, "Failed to find expected cached selector in PerSelectorPolicy: %s (%v)", k.Key(), l4B.PerSelectorPolicies)
 				if found {
 					require.True(t, v.Equal(bV), "Expected: %s\nActual: %s", perSelectorPolicyToString(v), perSelectorPolicyToString(bV))
 
@@ -266,7 +266,7 @@ func (td *testData) verifyL4PolicyMapEqual(t *testing.T, expected, actual L4Poli
 			require.Len(t, l4B.RuleOrigin, len(l4.RuleOrigin), "Actual RuleOrigin length does not match expected")
 			for k, v := range l4.RuleOrigin {
 				bV, found := l4B.RuleOrigin[k]
-				require.True(t, found, "Failed to find expected rule origin: %s (%v)", k.String(), l4B.RuleOrigin)
+				require.True(t, found, "Failed to find expected rule origin: %s (%v)", k.Key(), l4B.RuleOrigin)
 				require.Equal(t, v, bV)
 			}
 			return true

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -254,7 +254,7 @@ func (existingFilter *L4Filter) mergePortProto(policyCtx PolicyContext, filterTo
 				}
 			} else if !newPolicy.TerminatingTLS.Equal(existingPolicy.TerminatingTLS) {
 				policyCtx.PolicyTrace("   Merge conflict: mismatching terminating TLS contexts %s/%s\n", newPolicy.TerminatingTLS, existingPolicy.TerminatingTLS)
-				return fmt.Errorf("cannot merge conflicting terminating TLS contexts for cached selector %s: (%s/%s)", cs.String(), newPolicy.TerminatingTLS, existingPolicy.TerminatingTLS)
+				return fmt.Errorf("cannot merge conflicting terminating TLS contexts for cached selector %s: (%s/%s)", cs.Key(), newPolicy.TerminatingTLS, existingPolicy.TerminatingTLS)
 			}
 			if existingPolicy.OriginatingTLS == nil || newPolicy.OriginatingTLS == nil {
 				if newPolicy.OriginatingTLS != nil {
@@ -262,7 +262,7 @@ func (existingFilter *L4Filter) mergePortProto(policyCtx PolicyContext, filterTo
 				}
 			} else if !newPolicy.OriginatingTLS.Equal(existingPolicy.OriginatingTLS) {
 				policyCtx.PolicyTrace("   Merge conflict: mismatching originating TLS contexts %s/%s\n", newPolicy.OriginatingTLS, existingPolicy.OriginatingTLS)
-				return fmt.Errorf("cannot merge conflicting originating TLS contexts for cached selector %s: (%s/%s)", cs.String(), newPolicy.OriginatingTLS, existingPolicy.OriginatingTLS)
+				return fmt.Errorf("cannot merge conflicting originating TLS contexts for cached selector %s: (%s/%s)", cs.Key(), newPolicy.OriginatingTLS, existingPolicy.OriginatingTLS)
 			}
 
 			// For now we simply merge the set of allowed SNIs from different rules
@@ -293,7 +293,7 @@ func (existingFilter *L4Filter) mergePortProto(policyCtx PolicyContext, filterTo
 			// terminated
 			if len(existingPolicy.ServerNames) > 0 && !existingPolicy.L7Rules.IsEmpty() && existingPolicy.TerminatingTLS == nil {
 				policyCtx.PolicyTrace("   Merge conflict: cannot use SNI filtering with L7 rules without TLS termination: %v\n", existingPolicy.ServerNames)
-				return fmt.Errorf("cannot merge L7 rules for cached selector %s with SNI filtering without TLS termination: %v", cs.String(), existingPolicy.ServerNames)
+				return fmt.Errorf("cannot merge L7 rules for cached selector %s with SNI filtering without TLS termination: %v", cs.Key(), existingPolicy.ServerNames)
 			}
 
 			// empty L7 rules effectively wildcard L7. When merging with a non-empty

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -639,7 +639,7 @@ func (sc *SelectorCache) AddIdentitySelectorForTest(user CachedSelectionUser, es
 // lock must be held
 func (sc *SelectorCache) removeSelectorLocked(selector CachedSelector, user CachedSelectionUser) {
 	start := time.Now()
-	key := selector.String()
+	key := selector.Key()
 	sel, exists := sc.selectors.Get(key)
 	if exists && sel.removeUser(user, sc.localIdentityNotifier) {
 		sc.selectors.Delete(sel)
@@ -669,7 +669,7 @@ func (sc *SelectorCache) RemoveSelectors(selectors CachedSelectorSlice, user Cac
 // ChangeUser changes the CachedSelectionUser that gets updates on the
 // updates on the cached selector.
 func (sc *SelectorCache) ChangeUser(selector CachedSelector, from, to CachedSelectionUser) {
-	key := selector.String()
+	key := selector.Key()
 	sc.mutex.Lock()
 	sel, exists := sc.selectors.Get(key)
 	if exists {

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -316,8 +316,12 @@ func (sc *SelectorCache) GetModel() models.SelectorCache {
 		for i := range selections {
 			ids = append(ids, int64(selections[i]))
 		}
+		s := key
+		if b, err := sel.source.MarshalJSON(); err == nil {
+			s = string(b)
+		}
 		selMdl := &models.SelectorIdentityMapping{
-			Selector:   key,
+			Selector:   s,
 			Identities: ids,
 			Users:      int64(sel.numUsers()),
 			Labels:     labelArrayListToModel(sel.GetMetadataLabels()),

--- a/pkg/policy/selectorcache_selector.go
+++ b/pkg/policy/selectorcache_selector.go
@@ -172,8 +172,8 @@ func (i *identitySelector) IsNone() bool {
 	return i.key == noneSelectorKey
 }
 
-// String returns the map key for this selector
-func (i *identitySelector) String() string {
+// Key returns the map key for this selector
+func (i *identitySelector) Key() string {
 	return i.key
 }
 

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -306,7 +306,7 @@ func (cs *testCachedSelector) IsNone() bool {
 	return false
 }
 
-func (cs *testCachedSelector) String() string {
+func (cs *testCachedSelector) Key() string {
 	return cs.name
 }
 

--- a/pkg/policy/types/selector.go
+++ b/pkg/policy/types/selector.go
@@ -679,9 +679,9 @@ type CachedSelector interface {
 	// IsNone returns true if the selector never selects anything
 	IsNone() bool
 
-	// String returns the string representation of this selector.
+	// Key returns the string representation of this selector.
 	// Used as a map key.
-	String() string
+	Key() string
 }
 
 // CachedSelectorSlice is a slice of CachedSelectors that can be sorted.
@@ -691,7 +691,7 @@ type CachedSelectorSlice []CachedSelector
 func (s CachedSelectorSlice) MarshalJSON() ([]byte, error) {
 	buffer := bytes.NewBufferString("[")
 	for i, selector := range s {
-		buf, err := json.Marshal(selector.String())
+		buf, err := json.Marshal(selector.Key())
 		if err != nil {
 			return nil, err
 		}
@@ -709,7 +709,7 @@ func (s CachedSelectorSlice) Len() int      { return len(s) }
 func (s CachedSelectorSlice) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 
 func (s CachedSelectorSlice) Less(i, j int) bool {
-	return strings.Compare(s[i].String(), s[j].String()) < 0
+	return strings.Compare(s[i].Key(), s[j].Key()) < 0
 }
 
 // SelectsAllEndpoints returns whether the CachedSelectorSlice selects all

--- a/pkg/policy/types/selector.go
+++ b/pkg/policy/types/selector.go
@@ -262,6 +262,8 @@ type Selector interface {
 	GetCIDRPrefixes() []netip.Prefix
 
 	MetricsClass() string
+
+	MarshalJSON() ([]byte, error)
 }
 
 // +deepequal-gen=true

--- a/standalone-dns-proxy/pkg/client/client.go
+++ b/standalone-dns-proxy/pkg/client/client.go
@@ -585,7 +585,7 @@ func (d *DNSServerIdentity) Selects(identity identity.NumericIdentity) bool {
 	return slices.Contains(d.Identities, identity)
 }
 
-func (d *DNSServerIdentity) String() string {
+func (d *DNSServerIdentity) Key() string {
 	identityStrings := make([]string, len(d.Identities))
 	for i, id := range d.Identities {
 		identityStrings[i] = strconv.FormatUint(uint64(id), 10)


### PR DESCRIPTION
Fixes: 35857
AIL: 0

This improves the ux for `cilium-dbg policy selectors`. Which isn't the most important thing in the wold, but it led me to finding a selector leak, so that's nice.

Sample output:

```
root@kind-control-plane:/home/cilium# cilium-dbg policy selectors
Selector:       "MatchName: one.one.one.one, MatchPattern: "
Owners:         CiliumNetworkPolicy:foo/allow-one-fqdn-http 
User count:     1                                           
Identities:     16777220                                    
                16777221                                    

Selector:       "cidr:1.0.0.0/8-[1.2.3.4/32]"
Owners:         CiliumNetworkPolicy:foo/deny 
User count:     1                            
Identities:     16777219  

Selector:       matchLabels:                                  
                  any:io.kubernetes.pod.namespace: kube-system
                  any:k8s-app: kube-dns                       
                  k8s:io.cilium.k8s.policy.cluster: kind-kind 
Owners:         CiliumNetworkPolicy:foo/allow-one-fqdn-http   
                CiliumNetworkPolicy:foo/to-world              
User count:     2                                             
Identities:     6759
```