### PR TITLE
clustermesh: fix service affinity annotation "none" dropping remote backends

### DIFF
--- a/Documentation/network/clustermesh/affinity.rst
+++ b/Documentation/network/clustermesh/affinity.rst
@@ -18,7 +18,7 @@ Enabling Global Service Affinity
 ################################
 
 Load-balancing across multiple clusters might not be ideal in some cases.
-The annotation ``service.cilium.io/affinity: "local|remote|none"`` can be used
+The annotation ``service.cilium.io/affinity: "none|local|remote"`` can be used
 to specify the preferred endpoint destination.
 
 For example, if the value of annotation ``service.cilium.io/affinity`` is local,
@@ -34,12 +34,12 @@ remote endpoints if and only if all of local backends are not available or unhea
      annotations:
         service.cilium.io/global: "true"
         # Possible values:
+        # - none (default)
+        #    no preference. Default behavior if this annotation does not exist
         # - local
         #    preferred endpoints from local cluster if available
         # - remote
         #    preferred endpoints from remote cluster if available
-        # none (default)
-        #    no preference. Default behavior if this annotation does not exist
         service.cilium.io/affinity: "local"
    spec:
      type: ClusterIP

--- a/pkg/annotation/clustermesh.go
+++ b/pkg/annotation/clustermesh.go
@@ -3,7 +3,10 @@
 
 package annotation
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 const (
 	ServiceAffinityNone   = ""
@@ -33,15 +36,24 @@ func GetAnnotationShared(obj annotatedObject) bool {
 	return true
 }
 
-func GetAnnotationServiceAffinity(obj annotatedObject) string {
+func GetAnnotationServiceAffinity(obj annotatedObject) (string, error) {
 	// The ServiceAffinity annotation is ignored if the service is not declared as global.
 	if !GetAnnotationIncludeExternal(obj) {
-		return ServiceAffinityNone
+		return ServiceAffinityNone, nil
 	}
 
 	if value, ok := Get(obj, ServiceAffinity, ServiceAffinityAlias); ok {
-		return strings.ToLower(value)
+		switch strings.ToLower(value) {
+		case "none", "":
+			return ServiceAffinityNone, nil
+		case "local":
+			return ServiceAffinityLocal, nil
+		case "remote":
+			return ServiceAffinityRemote, nil
+		default:
+			return ServiceAffinityNone, fmt.Errorf("unrecognized service affinity value: %q", value)
+		}
 	}
 
-	return ServiceAffinityNone
+	return ServiceAffinityNone, nil
 }

--- a/pkg/annotation/clustermesh_test.go
+++ b/pkg/annotation/clustermesh_test.go
@@ -67,25 +67,49 @@ func TestGetAnnotationServiceAffinity(t *testing.T) {
 	obj := &object{
 		Annotations: map[string]string{GlobalService: "true", ServiceAffinity: "local"},
 	}
-	require.Equal(t, ServiceAffinityLocal, GetAnnotationServiceAffinity(obj))
+	affinity, err := GetAnnotationServiceAffinity(obj)
+	require.NoError(t, err)
+	require.Equal(t, ServiceAffinityLocal, affinity)
 
 	obj = &object{
 		Annotations: map[string]string{GlobalService: "true", ServiceAffinity: "remote"},
 	}
-	require.Equal(t, ServiceAffinityRemote, GetAnnotationServiceAffinity(obj))
+	affinity, err = GetAnnotationServiceAffinity(obj)
+	require.NoError(t, err)
+	require.Equal(t, ServiceAffinityRemote, affinity)
 
 	obj = &object{
 		Annotations: map[string]string{GlobalService: "true", ServiceAffinityAlias: "local"},
 	}
-	require.Equal(t, ServiceAffinityLocal, GetAnnotationServiceAffinity(obj))
+	affinity, err = GetAnnotationServiceAffinity(obj)
+	require.NoError(t, err)
+	require.Equal(t, ServiceAffinityLocal, affinity)
 
 	obj = &object{
 		Annotations: map[string]string{ServiceAffinity: "remote"},
 	}
-	require.Equal(t, ServiceAffinityNone, GetAnnotationServiceAffinity(obj))
+	affinity, err = GetAnnotationServiceAffinity(obj)
+	require.NoError(t, err)
+	require.Equal(t, ServiceAffinityNone, affinity)
 
 	obj = &object{
 		Annotations: map[string]string{},
 	}
-	require.Equal(t, ServiceAffinityNone, GetAnnotationServiceAffinity(obj))
+	affinity, err = GetAnnotationServiceAffinity(obj)
+	require.NoError(t, err)
+	require.Equal(t, ServiceAffinityNone, affinity)
+
+	obj = &object{
+		Annotations: map[string]string{GlobalService: "true", ServiceAffinity: "none"},
+	}
+	affinity, err = GetAnnotationServiceAffinity(obj)
+	require.NoError(t, err)
+	require.Equal(t, ServiceAffinityNone, affinity)
+
+	obj = &object{
+		Annotations: map[string]string{GlobalService: "true", ServiceAffinity: "invalid_value"},
+	}
+	affinity, err = GetAnnotationServiceAffinity(obj)
+	require.Error(t, err)
+	require.Equal(t, ServiceAffinityNone, affinity)
 }

--- a/pkg/clustermesh/selectbackends.go
+++ b/pkg/clustermesh/selectbackends.go
@@ -5,12 +5,14 @@ package clustermesh
 
 import (
 	"iter"
+	"log/slog"
 
 	"github.com/cilium/statedb"
 
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/loadbalancer/writer"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/source"
 )
 
@@ -21,24 +23,32 @@ func injectSelectBackends(cm *ClusterMesh, expCfg loadbalancer.Config, w *writer
 		// ClusterMesh disabled, do not change the backend selection.
 		return
 	}
-	w.SetSelectBackendsFunc(NewClusterMeshSelectBackends(w).SelectBackends)
+	w.SetSelectBackendsFunc(NewClusterMeshSelectBackends(w, cm.conf.Logger).SelectBackends)
 }
 
 type ClusterMeshSelectBackends struct {
-	w *writer.Writer
+	w   *writer.Writer
+	log *slog.Logger
 }
 
 // NewClusterMeshSelectBackends returns a reusable selector wrapper for the
 // ClusterMesh ServiceAffinity and IncludeExternal backend selection policy.
 // This allows other packages to compose the ClusterMesh behavior instead of
 // duplicating it.
-func NewClusterMeshSelectBackends(w *writer.Writer) ClusterMeshSelectBackends {
-	return ClusterMeshSelectBackends{w: w}
+func NewClusterMeshSelectBackends(w *writer.Writer, log *slog.Logger) ClusterMeshSelectBackends {
+	return ClusterMeshSelectBackends{w: w, log: log}
 }
 
 func (sb ClusterMeshSelectBackends) SelectBackends(txn statedb.ReadTxn, bes iter.Seq2[*loadbalancer.Backend, statedb.Revision], svc *loadbalancer.Service, optionalFrontend *loadbalancer.Frontend) iter.Seq2[*loadbalancer.Backend, statedb.Revision] {
 	defaultBackends := sb.w.DefaultSelectBackends(txn, bes, svc, optionalFrontend)
-	affinity := annotation.GetAnnotationServiceAffinity(svc)
+	affinity, err := annotation.GetAnnotationServiceAffinity(svc)
+	if err != nil {
+		sb.log.Warn("Ignoring annotation",
+			logfields.Service, svc.Name.Name(),
+			logfields.K8sNamespace, svc.Name.Namespace(),
+			logfields.Error, err,
+		)
+	}
 
 	useLocal := true
 	localActiveBackends := 0

--- a/pkg/clustermesh/testdata/service-affinity.txtar
+++ b/pkg/clustermesh/testdata/service-affinity.txtar
@@ -35,6 +35,16 @@ db/cmp frontends frontends-local.table
 kvstore/update cilium/state/services/v1/cluster2/test/echo clusterservice2.json
 db/cmp frontends frontends-remote.table
 
+# Flip affinity to "none". Both local and remote are used.
+sed 'affinity: "remote"' 'affinity: "none"' service.yaml
+k8s/update service.yaml
+db/cmp frontends frontends-all.table
+
+# Set an invalid affinity value. Treated as none.
+sed 'affinity: "none"' 'affinity: "invalid_value"' service.yaml
+k8s/update service.yaml
+db/cmp frontends frontends-all.table
+
 # Remove affinity. Now both local and remote are used.
 sed 'affinity:' 'affinity-nope:' service.yaml
 k8s/update service.yaml


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
- [x] Thanks for contributing!

---

## Summary

`GetAnnotationServiceAffinity()` returned the literal string `"none"` when the annotation `service.cilium.io/affinity` was set to that value. However, `ServiceAffinityNone` is defined as an empty string (`""`). This caused `SelectBackends` to treat `"none"` as an unrecognized value, dropping all remote backends and blackholing traffic when no local endpoints exist.

> [!NOTE]
> **AI Disclosure (AIL:3):** I identified the root cause, reproduced the issue on staging clusters, and directed the fix approach (explicit switch normalization). An LLM (Claude Opus 4.6) assisted with code authoring and test writing under my full review.

## Changes

Normalize the annotation value in `GetAnnotationServiceAffinity()` through an explicit switch:

- `"none"` / `""` → `ServiceAffinityNone`
- `"local"` → `ServiceAffinityLocal`
- `"remote"` → `ServiceAffinityRemote`
- Otherwise, will emit a warning log and treating affinity as `ServiceAffinityNone`

Added a test case for `"none"` and one for an unrecognized value (`"invalid_value"`), both asserting `ServiceAffinity`.

## Testing

- Issue reproduced on staging clusters (2x EKS with ClusterMesh): setting `affinity: "none"` causes empty BPF backend maps; removing the annotation restores remote backends. Full reproduction details in #46623.
- `go test ./pkg/annotation/` passes with updated tests for handling explicit `"none"` and  invalid values.
- Similarly added `testdata` entry with cases to be checked

Fixes: #46623

```release-note
Fix ClusterMesh service affinity annotation `service.cilium.io/affinity: "none"` incorrectly dropping all remote backends, causing traffic blackhole when no local endpoints exist.
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer's Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request