### PR TITLE
pkg/ipam: Hold agent IPAM while static IP is not assigned

### DIFF
--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -209,7 +209,10 @@ func newNodeStore(logger *slog.Logger, nodeName string, conf *option.DaemonConfi
 			logfields.Required, required,
 			logfields.Available, numAvailable,
 		)
-		if minimumReached {
+		requestedStaticIP, assignedStaticIP := store.staticIPStatus()
+		staticIPReady := !requestedStaticIP || assignedStaticIP != ""
+
+		if minimumReached && staticIPReady {
 			scopedLog.Info(
 				"All required IPs are available in CRD-backed allocation pool",
 			)
@@ -353,6 +356,17 @@ func (n *nodeStore) hasMinimumIPsInPool(localNodeStore *node.LocalNodeStore) (mi
 	}
 
 	return
+}
+
+func (n *nodeStore) staticIPStatus() (requested bool, assigned string) {
+	n.mutex.RLock()
+	defer n.mutex.RUnlock()
+
+	if n.ownNode == nil {
+		return false, ""
+	}
+
+	return len(n.ownNode.Spec.IPAM.StaticIPTags) > 0, n.ownNode.Status.IPAM.AssignedStaticIP
 }
 
 // deleteLocalNodeResource is called when the CiliumNode resource representing

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -19,6 +19,7 @@ import (
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	"github.com/cilium/cilium/pkg/ipmasq"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
@@ -181,6 +182,56 @@ func TestMarkForReleaseNoAllocate(t *testing.T) {
 	cn.Status.IPAM.ReleaseIPs["1.1.1.3"] = ipamOption.IPAMMarkForRelease
 	sharedNodeStore.updateLocalNodeResource(cn)
 	require.Equal(t, ipamOption.IPAMDoNotRelease, string(cn.Status.IPAM.ReleaseIPs["1.1.1.3"]))
+}
+
+func TestNodeStoreStaticIPStatus(t *testing.T) {
+	newNode := func(tags map[string]string, assigned string) *ciliumv2.CiliumNode {
+		cn := newCiliumNode("node1", 0, 0, 0)
+		cn.Spec.IPAM.StaticIPTags = tags
+		cn.Status.IPAM.AssignedStaticIP = assigned
+		return cn
+	}
+
+	tests := []struct {
+		name                  string
+		ownNode               *ciliumv2.CiliumNode
+		wantRequestedStaticIP bool
+		wantAssignedStaticIP  string
+	}{
+		{
+			name:                  "nil node",
+			ownNode:               nil,
+			wantRequestedStaticIP: false,
+			wantAssignedStaticIP:  "",
+		},
+		{
+			name:                  "no static IP requested",
+			ownNode:               newNode(nil, ""),
+			wantRequestedStaticIP: false,
+			wantAssignedStaticIP:  "",
+		},
+		{
+			name:                  "static IP requested but not yet assigned",
+			ownNode:               newNode(map[string]string{"env": "prod"}, ""),
+			wantRequestedStaticIP: true,
+			wantAssignedStaticIP:  "",
+		},
+		{
+			name:                  "static IP requested and assigned",
+			ownNode:               newNode(map[string]string{"env": "prod"}, "1.2.3.4"),
+			wantRequestedStaticIP: true,
+			wantAssignedStaticIP:  "1.2.3.4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &nodeStore{ownNode: tt.ownNode}
+			requested, assigned := store.staticIPStatus()
+			assert.Equal(t, tt.wantRequestedStaticIP, requested)
+			assert.Equal(t, tt.wantAssignedStaticIP, assigned)
+		})
+	}
 }
 
 type ipMasqMapDummy struct{}

--- a/pkg/ipam/multipool_manager.go
+++ b/pkg/ipam/multipool_manager.go
@@ -272,6 +272,7 @@ type multiPoolManager struct {
 	poolsMutex      lock.Mutex
 	pools           map[Pool]*poolPair
 	poolsUpdated    chan struct{}
+	staticIPUpdated chan struct{}
 	finishedRestore map[Family]bool
 
 	nodeMutex lock.Mutex
@@ -303,6 +304,7 @@ func newMultiPoolManager(p MultiPoolManagerParams) *multiPoolManager {
 		pendingIPsPerPool:      newPendingAllocationsPerPool(p.Logger),
 		pools:                  map[Pool]*poolPair{},
 		poolsUpdated:           make(chan struct{}, 1),
+		staticIPUpdated:        make(chan struct{}, 1),
 		jobGroup:               p.JobGroup,
 		k8sUpdater:             job.NewTrigger(job.WithDebounce(p.CiliumNodeUpdateRate)),
 		cnClient:               p.CNClient,
@@ -349,6 +351,7 @@ func newMultiPoolManager(p MultiPoolManagerParams) *multiPoolManager {
 	)
 
 	mgr.waitForAllPools()
+	mgr.waitForStaticIP()
 
 	return mgr
 }
@@ -370,6 +373,27 @@ func (m *multiPoolManager) waitForAllPools() {
 				allPoolsReady = m.waitForPool(ctx, IPv6, pool) && allPoolsReady
 			}
 			cancel()
+		}
+	}
+}
+
+// waitForStaticIP blocks until a requested static IP address has been assigned
+// to the local node by the operator. If no static IP was requested, it returns
+// immediately.
+func (m *multiPoolManager) waitForStaticIP() {
+	for {
+		requested, assigned := m.staticIPStatus()
+		if !requested || assigned != "" {
+			return
+		}
+
+		select {
+		case <-m.staticIPUpdated:
+		case <-time.After(5 * time.Second):
+			m.logger.Info(
+				"Waiting for static IP address to be assigned",
+				logfields.HelpMessage, "Check if cilium-operator pod is running and does not have any warnings or error messages.",
+			)
 		}
 	}
 }
@@ -435,10 +459,29 @@ func (m *multiPoolManager) ciliumNodeUpdated(newNode *ciliumv2.CiliumNode) {
 	if oldNode == nil {
 		m.k8sUpdater.Trigger()
 	}
+
+	// Signal any goroutine waiting in waitForStaticIP if the static IP
+	// request or assignment changed.
+	if oldNode == nil ||
+		!maps.Equal(oldNode.Spec.IPAM.StaticIPTags, newNode.Spec.IPAM.StaticIPTags) ||
+		oldNode.Status.IPAM.AssignedStaticIP != newNode.Status.IPAM.AssignedStaticIP {
+		select {
+		case m.staticIPUpdated <- struct{}{}:
+		default:
+		}
+	}
 }
 
 func (m *multiPoolManager) localNodeUpdated() <-chan struct{} {
 	return m.localNodeUpdate
+}
+
+func (m *multiPoolManager) staticIPStatus() (requested bool, assigned string) {
+	node := m.getNode()
+	if node == nil {
+		return false, ""
+	}
+	return len(node.Spec.IPAM.StaticIPTags) > 0, node.Status.IPAM.AssignedStaticIP
 }
 
 // neededIPCeil rounds up numIPs to the next but one multiple of preAlloc.

--- a/pkg/ipam/multipool_test.go
+++ b/pkg/ipam/multipool_test.go
@@ -1334,6 +1334,60 @@ func TestMultiPoolManagerUpdatesFirstLastIPSettingsBeforeAllocation(t *testing.T
 	require.Equal(t, lastIP, result.IP)
 }
 
+func Test_multiPoolManager_staticIPStatus(t *testing.T) {
+	newNode := func(tags map[string]string, assigned string) *ciliumv2.CiliumNode {
+		return &ciliumv2.CiliumNode{
+			Spec: ciliumv2.NodeSpec{
+				IPAM: types.IPAMSpec{StaticIPTags: tags},
+			},
+			Status: ciliumv2.NodeStatus{
+				IPAM: types.IPAMStatus{AssignedStaticIP: assigned},
+			},
+		}
+	}
+
+	tests := []struct {
+		name                  string
+		node                  *ciliumv2.CiliumNode
+		wantRequestedStaticIP bool
+		wantAssignedStaticIP  string
+	}{
+		{
+			name:                  "nil node",
+			node:                  nil,
+			wantRequestedStaticIP: false,
+			wantAssignedStaticIP:  "",
+		},
+		{
+			name:                  "no static IP requested",
+			node:                  newNode(nil, ""),
+			wantRequestedStaticIP: false,
+			wantAssignedStaticIP:  "",
+		},
+		{
+			name:                  "static IP requested but not yet assigned",
+			node:                  newNode(map[string]string{"env": "prod"}, ""),
+			wantRequestedStaticIP: true,
+			wantAssignedStaticIP:  "",
+		},
+		{
+			name:                  "static IP requested and assigned",
+			node:                  newNode(map[string]string{"env": "prod"}, "1.2.3.4"),
+			wantRequestedStaticIP: true,
+			wantAssignedStaticIP:  "1.2.3.4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr := &multiPoolManager{node: tt.node}
+			requested, assigned := mgr.staticIPStatus()
+			assert.Equal(t, tt.wantRequestedStaticIP, requested)
+			assert.Equal(t, tt.wantAssignedStaticIP, assigned)
+		})
+	}
+}
+
 func insertPool(t *testing.T, db *statedb.DB, tbl statedb.RWTable[podippool.LocalPodIPPool], name string, skipMasq bool, allowFirstAndLastIPs ...bool) {
 	t.Helper()
 	ann := map[string]string{}


### PR DESCRIPTION
When a node requests a static IP to be assigned, this should be considered a readiness criterion. Having the agent become ready before a static IP is assigned can lead to pods getting scheduled without the node actually being ready.

To remedy that, this PR adds a check on static IP assignment status in the initialization of the CRD and multi-pool allocators. With this change, the agents won't report as ready until a static IP is assigned and reported in the CiliumNode object.

This PR was prepared with AIL:3. I guided the agent in designing this solution and reviewed and modified the output.

```release-note
The Cilium agent now waits for a static IP to be assigned before becoming ready if one is requested.
```
