### PR TITLE
netns: Add missing GetNetNSCookie function for non-linux build

### DIFF
--- a/pkg/netns/netns_other.go
+++ b/pkg/netns/netns_other.go
@@ -36,6 +36,10 @@ func Current() (*NetNS, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
+func GetNetNSCookie() (uint64, error) {
+	return 0, fmt.Errorf("not implemented")
+}
+
 func All() (iter.Seq2[string, *NetNS], <-chan error) {
 	errs := make(chan error, 1)
 	errs <- fmt.Errorf("not implemented")


### PR DESCRIPTION
This function was missing in non-linux compiled file, causing compilation errors in other modules that have a transient dependency on netns from non-linux OSes.
