### PR TITLE
Fix multiple regressions in Cilium LocalRedirectPolicy

### DIFF
--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -910,6 +910,21 @@ func (l *L3n4Addr) DeepEqual(other *L3n4Addr) bool {
 	return *l == *other
 }
 
+// Compatible returns true if two instances of an L3n4Addr have the same
+// protocol and address family.
+func (l L3n4Addr) Compatible(other L3n4Addr) bool {
+	lRep := l.rep()
+	otherRep := other.rep()
+
+	if lRep.Protocol != otherRep.Protocol {
+		return false
+	}
+	if lRep.addrCluster.Is6() != otherRep.addrCluster.Is6() {
+		return false
+	}
+	return true
+}
+
 // NewL3n4Addr creates a new L3n4Addr.
 func NewL3n4Addr(protocol L4Type, addrCluster cmtypes.AddrCluster, portNumber uint16, scope uint8) L3n4Addr {
 	lbport := NewL4Addr(protocol, portNumber)

--- a/pkg/loadbalancer/redirectpolicy/api.go
+++ b/pkg/loadbalancer/redirectpolicy/api.go
@@ -4,6 +4,9 @@
 package redirectpolicy
 
 import (
+	"slices"
+	"strings"
+
 	"github.com/cilium/statedb"
 	"github.com/go-openapi/runtime/middleware"
 
@@ -14,25 +17,26 @@ import (
 )
 
 type getLrpHandler struct {
-	db       *statedb.DB
-	lrps     statedb.Table[*LocalRedirectPolicy]
-	backends statedb.Table[*lb.Backend]
-	pods     statedb.Table[k8sTables.LocalPod]
+	db        *statedb.DB
+	lrps      statedb.Table[*LocalRedirectPolicy]
+	frontends statedb.Table[*lb.Frontend]
+	backends  statedb.Table[*lb.Backend]
+	pods      statedb.Table[k8sTables.LocalPod]
 }
 
 func (h *getLrpHandler) Handle(params service.GetLrpParams) middleware.Responder {
-	return service.NewGetLrpOK().WithPayload(getLRPs(h.db.ReadTxn(), h.lrps, h.backends, h.pods))
+	return service.NewGetLrpOK().WithPayload(getLRPs(h.db.ReadTxn(), h.lrps, h.frontends, h.backends, h.pods))
 }
 
-func getLRPs(txn statedb.ReadTxn, lrps statedb.Table[*LocalRedirectPolicy], backends statedb.Table[*lb.Backend], pods statedb.Table[k8sTables.LocalPod]) []*models.LRPSpec {
+func getLRPs(txn statedb.ReadTxn, lrps statedb.Table[*LocalRedirectPolicy], frontends statedb.Table[*lb.Frontend], backends statedb.Table[*lb.Backend], pods statedb.Table[k8sTables.LocalPod]) []*models.LRPSpec {
 	list := make([]*models.LRPSpec, 0, lrps.NumObjects(txn))
 	for lrp := range lrps.All(txn) {
-		list = append(list, lrp.getModel(txn, backends, pods))
+		list = append(list, lrp.getModel(txn, frontends, backends, pods))
 	}
 	return list
 }
 
-func (lrp *LocalRedirectPolicy) getModel(txn statedb.ReadTxn, backends statedb.Table[*lb.Backend], pods statedb.Table[k8sTables.LocalPod]) *models.LRPSpec {
+func (lrp *LocalRedirectPolicy) getModel(txn statedb.ReadTxn, frontends statedb.Table[*lb.Frontend], backends statedb.Table[*lb.Backend], pods statedb.Table[k8sTables.LocalPod]) *models.LRPSpec {
 	if lrp == nil {
 		return nil
 	}
@@ -62,51 +66,6 @@ func (lrp *LocalRedirectPolicy) getModel(txn statedb.ReadTxn, backends statedb.T
 		lrpType = "svc"
 	}
 
-	// Get the pseudo-service name for this LRP
-	lrpSvcName := lrp.RedirectServiceName()
-
-	// Find all backends for the pseudo-service and build the API models for them.
-	beModels := []*models.LRPBackend{}
-	bes, _ := lb.ListBackendsByServiceName(txn, backends, lrpSvcName)
-	preferred := lb.PreferredBackendsByAddress(bes)
-	for be := range preferred {
-		ipStr := be.Address.Addr().String()
-
-		// Find the pod that owns this backend IP.
-		podID := "unknown"
-		for pod := range pods.All(txn) {
-			for _, podIP := range pod.Status.PodIPs {
-				if podIP.IP == ipStr {
-					podID = pod.Namespace + "/" + pod.Name
-					goto foundPod
-				}
-			}
-		}
-	foundPod:
-		// Create the BackendAddress, which contains the IP.
-		beAddrModel := &models.BackendAddress{
-			IP:       &ipStr,
-			Port:     be.Address.Port(),
-			Protocol: be.Address.Protocol(),
-		}
-		state, _ := be.State.String()
-		beAddrModel.State = state
-
-		// Create the LRPBackend model.
-		beModel := &models.LRPBackend{
-			PodID:          podID,
-			BackendAddress: beAddrModel,
-		}
-		beModels = append(beModels, beModel)
-	}
-	feMappingModelArray := make([]*models.FrontendMapping, 0, len(lrp.FrontendMappings))
-	for _, feM := range lrp.FrontendMappings {
-		feMappingModel := feM.getModel()
-		// Attach the resolved backends to the frontend mapping
-		feMappingModel.Backends = beModels
-		feMappingModelArray = append(feMappingModelArray, feMappingModel)
-	}
-
 	return &models.LRPSpec{
 		UID:              string(lrp.UID),
 		Name:             lrp.ID.Name(),
@@ -114,8 +73,208 @@ func (lrp *LocalRedirectPolicy) getModel(txn statedb.ReadTxn, backends statedb.T
 		FrontendType:     feType,
 		LrpType:          lrpType,
 		ServiceID:        lrp.ServiceID.String(),
-		FrontendMappings: feMappingModelArray,
+		FrontendMappings: lrp.getFrontendMappingModels(txn, frontends, backends, pods),
 	}
+}
+
+// Returns a map of Pod IDs (namespace/pod-name), indexed by Pod IP address.
+func getPodIDByIP(txn statedb.ReadTxn, pods statedb.Table[k8sTables.LocalPod]) map[string]string {
+	podIDByIP := map[string]string{}
+	for pod := range pods.All(txn) {
+		podID := pod.Namespace + "/" + pod.Name
+		for _, podIP := range pod.Status.PodIPs {
+			podIDByIP[podIP.IP] = podID
+		}
+	}
+	return podIDByIP
+}
+
+// Returns an array of Backend models, converted from a series of backends from StateDB.
+func getBackendModels(
+	podIDByIP map[string]string,
+	bes lb.BackendsSeq2,
+) []*models.LRPBackend {
+	beModels := []*models.LRPBackend{}
+	if bes == nil {
+		return beModels
+	}
+
+	appendBackendModel := func(podID string, beAddrStr *string, be *lb.Backend) {
+		beAddrModel := &models.BackendAddress{
+			IP:       beAddrStr,
+			Port:     be.Address.Port(),
+			Protocol: be.Address.Protocol(),
+		}
+		state, _ := be.State.String()
+		beAddrModel.State = state
+
+		beModels = append(beModels, &models.LRPBackend{
+			PodID:          podID,
+			BackendAddress: beAddrModel,
+		})
+	}
+
+	// Iterate over all backends. For each entry, we append a new backend model,
+	// using the backend IP to map into a PodID.
+	for be := range bes {
+		beAddrStr := be.Address.Addr().String()
+		podID, found := podIDByIP[beAddrStr]
+		if !found {
+			podID = "unknown"
+		}
+		appendBackendModel(podID, &beAddrStr, be)
+	}
+
+	return beModels
+}
+
+// filterBackendsByFrontendMapping narrows the backend list of a pseudo-service
+// generated from an addressMatcher LRP to a subset of pods that would actually
+// be mapped by the controller.
+func filterBackendsByFrontendMapping(
+	bes lb.BackendsSeq2,
+	feM feMapping,
+	matchPortNames bool,
+) lb.BackendsSeq2 {
+	backendMatchesFrontendMapping := func(be *lb.Backend) bool {
+		if !be.Address.Compatible(feM.feAddr) {
+			return false
+		}
+		if matchPortNames && feM.fePort != "" && len(be.PortNames) > 0 {
+			return slices.ContainsFunc(be.PortNames, func(portName string) bool {
+				return strings.EqualFold(portName, string(feM.fePort))
+			})
+		}
+		return true
+	}
+
+	return func(yield func(*lb.Backend, statedb.Revision) bool) {
+		for be, rev := range bes {
+			if !backendMatchesFrontendMapping(be) {
+				continue
+			}
+			if !yield(be, rev) {
+				return
+			}
+		}
+	}
+}
+
+// Returns an array of FrontendMapping models for a LocalRedirectPolicy based on the
+// StateDB frontend and backend tables.
+func (lrp *LocalRedirectPolicy) getFrontendMappingModels(
+	txn statedb.ReadTxn,
+	frontends statedb.Table[*lb.Frontend],
+	backends statedb.Table[*lb.Backend],
+	pods statedb.Table[k8sTables.LocalPod],
+) []*models.FrontendMapping {
+	podIDByIP := getPodIDByIP(txn, pods)
+
+	switch lrp.LRPType {
+	case lrpConfigTypeAddr:
+		// For addressMatcher LRPs, the configured frontend mappings are the source of
+		// truth for frontend information. Since these mappings do not carry writer-
+		// selected backends, filter the pseudo-service backends per mapping to match
+		// the frontend/backend association the writer would produce.
+		bes, _ := lb.ListBackendsByServiceName(txn, backends, lrp.RedirectServiceName())
+		preferredBackends := lb.BackendsSeq2(lb.PreferredBackendsByAddress(bes))
+
+		numFrontendMapping := len(lrp.FrontendMappings)
+		matchNamedPorts := numFrontendMapping > 1
+
+		feMappingModelArray := make([]*models.FrontendMapping, 0, numFrontendMapping)
+		for _, feM := range lrp.FrontendMappings {
+			feMappingModel := feM.getModel()
+			filteredBackends := filterBackendsByFrontendMapping(preferredBackends, feM, matchNamedPorts)
+			feMappingModel.Backends = getBackendModels(podIDByIP, filteredBackends)
+			feMappingModelArray = append(feMappingModelArray, feMappingModel)
+		}
+		return feMappingModelArray
+
+	case lrpConfigTypeSvc:
+		// for serviceMatcher LRPs, the internal frontendMapping has dummy IP address
+		// information in, so we don't use it here. Instead, we query StateDB for
+		// frontends associated with the matched service. We then build backend models
+		// from the backends associated with those frontends.
+		feMappingModelArray := []*models.FrontendMapping{}
+		appendFrontendMapping := func(fe *lb.Frontend, beModels []*models.LRPBackend) {
+			feMappingModelArray = append(feMappingModelArray, &models.FrontendMapping{
+				FrontendAddress: &models.FrontendAddress{
+					IP:       fe.Address.AddrCluster().String(),
+					Protocol: fe.Address.Protocol(),
+					Port:     fe.Address.Port(),
+				},
+				Backends: beModels,
+			})
+		}
+
+		lrpServiceName := lrp.RedirectServiceName()
+		numFrontendMapping := len(lrp.FrontendMappings)
+
+		// Search for any redirected frontends
+		for fe := range frontends.List(txn, lb.FrontendByServiceName(lrp.ServiceID)) {
+			if fe.Type != lb.SVCTypeClusterIP {
+				continue
+			}
+
+			// Scenario 1, this frontend is redirected. It must be mapped to this LRP
+			// to be displayed.
+			if fe.RedirectTo != nil {
+				if !fe.RedirectTo.Equal(lrpServiceName) {
+					continue
+				}
+
+				beModels := getBackendModels(podIDByIP, fe.Backends)
+				appendFrontendMapping(fe, beModels)
+				continue
+			}
+
+			// Scenario 2, this frontend is not redirected, but whether it's candidate
+			// to be shown depends on the FrontendType.
+			switch lrp.FrontendType {
+			case svcFrontendAll:
+				// On an all-port serviceMatcher, if the service had been properly
+				// redirected then it would be included in scenario 1 above. Instead,
+				// we show this with FE with no backends so it's clear the frontend is
+				// at least matching the LRP criteria, but with little effect.
+				beModels := []*models.LRPBackend{}
+				appendFrontendMapping(fe, beModels)
+
+			case svcFrontendSinglePort:
+				// On a single-port serviceMatcher, we include this frontend if its
+				// address matches the first frontend mapping exactly.
+				if numFrontendMapping == 0 {
+					continue
+				}
+
+				lrpAddr := lrp.FrontendMappings[0].feAddr
+				if lrpAddr.Compatible(fe.Address) && lrpAddr.Port() == fe.Address.Port() {
+					beModels := getBackendModels(podIDByIP, fe.Backends)
+					appendFrontendMapping(fe, beModels)
+				}
+
+			case svcFrontendNamedPorts:
+				// On a named port serviceMatcher, for mapping to be successful the names
+				// must match between redirectBackend.toPorts, pod spec and service ports.
+				// In that case, if this FE matched, it would have been redirected and thus
+				// included via scenario 1 above. If it did not, then either (a) this FE
+				// was not part of the FrontendMapping, or (b) there's no backends
+				// available. In the case of (b), we should still display this FE, so it's
+				// clear it matches the LRP criteria, but with little effect.
+				hasMapping := slices.ContainsFunc(lrp.FrontendMappings, func(feM feMapping) bool {
+					return feM.feAddr.Compatible(fe.Address) && feM.feAddr.Port() == fe.Address.Port()
+				})
+				if hasMapping {
+					beModels := []*models.LRPBackend{}
+					appendFrontendMapping(fe, beModels)
+				}
+			}
+		}
+
+		return feMappingModelArray
+	}
+
+	return nil
 }
 
 func (feM *feMapping) getModel() *models.FrontendMapping {

--- a/pkg/loadbalancer/redirectpolicy/cell.go
+++ b/pkg/loadbalancer/redirectpolicy/cell.go
@@ -70,10 +70,17 @@ func lrpAPI(
 	enabled lrpIsEnabled,
 	db *statedb.DB,
 	lrps statedb.Table[*LocalRedirectPolicy],
+	frontends statedb.Table[*lb.Frontend],
 	backends statedb.Table[*lb.Backend],
 	pods statedb.Table[k8sTables.LocalPod],
 ) service.GetLrpHandler {
-	return &getLrpHandler{db, lrps, backends, pods}
+	return &getLrpHandler{
+		db:        db,
+		lrps:      lrps,
+		frontends: frontends,
+		backends:  backends,
+		pods:      pods,
+	}
 }
 
 type lrpIsEnabled bool

--- a/pkg/loadbalancer/redirectpolicy/cell.go
+++ b/pkg/loadbalancer/redirectpolicy/cell.go
@@ -40,6 +40,9 @@ var Cell = cell.Module(
 
 		// Provide the 'skiplbmap' command for inspecting SkipLBMap.
 		newSkipLBMapCommand,
+
+		// Provide the 'lrp/list' command for inspecting the LRP REST API model.
+		newLRPListCommand,
 	),
 
 	cell.ProvidePrivate(

--- a/pkg/loadbalancer/redirectpolicy/controller.go
+++ b/pkg/loadbalancer/redirectpolicy/controller.go
@@ -380,10 +380,8 @@ func (c *lrpController) updateRedirectBackends(wtxn writer.WriteTxn, lrp *LocalR
 	}
 
 	// Port name checks can be skipped in certain cases.
-	switch lrp.FrontendType {
-	case svcFrontendAll, svcFrontendSinglePort, addrFrontendSinglePort:
+	if !lrp.requiresPortNameMatch() {
 		portNameMatches = nil
-
 	}
 
 	// Function to compare whether the new Backend produced in the loop below

--- a/pkg/loadbalancer/redirectpolicy/controller.go
+++ b/pkg/loadbalancer/redirectpolicy/controller.go
@@ -97,7 +97,7 @@ func (c *lrpController) run(ctx context.Context, health cell.Health) error {
 	// objects.
 	const waitTime = 100 * time.Millisecond
 
-	// Grab table init watch channels for the inputs. Once they allclose the
+	// Grab table init watch channels for the inputs. Once they all close the
 	// Table[desiredSkipLB] is marked initialized to allow pruning the BPF map.
 	txn := c.p.DB.ReadTxn()
 	_, podsInitWatch := c.p.Pods.Initialized(txn)
@@ -300,11 +300,13 @@ func (c *lrpController) updateRedirects(wtxn writer.WriteTxn, ws *statedb.WatchS
 		targetName := lrp.ServiceID
 		fes, watch := c.p.Writer.Frontends().ListWatch(wtxn, lb.FrontendByServiceName(targetName))
 		ws.Add(watch)
+
 		for fe := range fes {
 			// Only ClusterIP services can be redirected.
 			if fe.Type != lb.SVCTypeClusterIP {
 				continue
 			}
+
 			if shouldRedirectFrontend(c.p.Log, lrp, fe, pods) {
 				c.p.Log.Debug("Redirecting frontend",
 					logfields.Frontend, fe,
@@ -395,19 +397,72 @@ func (c *lrpController) updateRedirectBackends(wtxn writer.WriteTxn, lrp *LocalR
 
 	// Construct the Backend from matching pods.
 	beps := make([]lb.Backend, 0, len(pods))
-	lrpServiceName := lrp.RedirectServiceName()
+
+	lrpIncludesBackendPort := func(addr lb.L3n4Addr) bool {
+		// In the case of a single-port LRP, only compare against the first backend port.
+		if lrp.isSinglePort() {
+			return lrp.BackendPorts[0].l4Addr.Port == addr.Port() &&
+				lrp.BackendPorts[0].l4Addr.Protocol == addr.Protocol()
+		}
+		return slices.ContainsFunc(lrp.BackendPorts, func(p bePortInfo) bool {
+			return p.l4Addr.Port == addr.Port() && p.l4Addr.Protocol == addr.Protocol()
+		})
+	}
+
+	appendBackend := func(be lb.Backend) {
+		if portNameMatches != nil && !slices.ContainsFunc(be.PortNames, portNameMatches) {
+			return
+		}
+		if !lrpIncludesBackendPort(be.Address) {
+			return
+		}
+
+		bePortNames := []string{}
+
+		// If we're not matching port names, we don't clone the backend port name.
+		// Otherwise, the loadbalancer Writer will include the portName when mapping
+		// backends to our LRP pseudo-service.
+		if portNameMatches != nil {
+			bePortNames = slices.Clone(be.PortNames)
+		}
+
+		beps = append(beps, lb.Backend{
+			Address:   be.Address,
+			State:     be.State,
+			PortNames: bePortNames,
+			// NOTE: Update [compareBackendParams] if more fields are added here.
+		})
+	}
+
 	for _, podInfo := range pods {
+		// If there are no existing ports associated with this Pod, then perhaps
+		// there's no containerPorts in the pod specs. See if we can reconstruct
+		// the backend pod addresses.
+		if len(podInfo.addrs) == 0 {
+			// We only reconstruct backend port information if this is a single
+			// port LRP which doesn't match on port names. This provides
+			// consistency with earlier versions of Cilium.
+			if portNameMatches != nil {
+				continue
+			}
+
+			for _, podIP := range podInfo.ips {
+				beAddr := lb.NewL3n4Addr(
+					lrp.BackendPorts[0].l4Addr.Protocol,
+					podIP,
+					lrp.BackendPorts[0].l4Addr.Port,
+					lb.ScopeExternal)
+				appendBackend(lb.Backend{
+					Address:   beAddr,
+					State:     lb.BackendStateActive,
+					PortNames: []string{},
+				})
+			}
+			continue
+		}
+
 		for _, addr := range podInfo.addrs {
-			if portNameMatches != nil && !portNameMatches(addr.portName) {
-				continue
-			}
-			portNumberMatches := slices.ContainsFunc(lrp.BackendPorts, func(p bePortInfo) bool {
-				return p.l4Addr.Port == addr.Port() && p.l4Addr.Protocol == addr.Protocol()
-			})
-			if !portNumberMatches {
-				continue
-			}
-			beps = append(beps, lb.Backend{
+			appendBackend(lb.Backend{
 				Address: addr.L3n4Addr,
 				State:   lb.BackendStateActive,
 				PortNames: func() []string {
@@ -416,7 +471,6 @@ func (c *lrpController) updateRedirectBackends(wtxn writer.WriteTxn, lrp *LocalR
 					}
 					return []string{}
 				}(),
-				// NOTE: Update [compareBackendParams] if more fields are added here.
 			})
 		}
 	}
@@ -424,6 +478,7 @@ func (c *lrpController) updateRedirectBackends(wtxn writer.WriteTxn, lrp *LocalR
 	// Validate whether an update is actually needed to avoid no-op changes to the tables.
 	newCount := len(beps)
 	orphanCount := 0
+	lrpServiceName := lrp.RedirectServiceName()
 	bes, _ := lb.ListBackendsByServiceName(wtxn, c.p.Writer.Backends(), lrpServiceName)
 	preferred := lb.PreferredBackendsByAddress(bes)
 	for be := range preferred {
@@ -468,8 +523,8 @@ func shouldRedirectFrontend(log *slog.Logger, lrp *LocalRedirectPolicy, fe *lb.F
 	}
 
 	// 1. First match the frontend based on "RedirectFrontend.ToPorts"
-	// 1.1. All frontends match if no ports are given
-	match := len(lrp.FrontendMappings) == 0
+	// 1.1. All frontends match only when no ports were specified in redirectFrontend.
+	match := lrp.FrontendType == svcFrontendAll
 
 	// 1.2. Frontend matches if the port number matches
 	if !match {
@@ -480,6 +535,7 @@ func shouldRedirectFrontend(log *slog.Logger, lrp *LocalRedirectPolicy, fe *lb.F
 			}
 		}
 	}
+
 	if !match {
 		// RedirectFrontend.ToPorts mismatch, skip.
 		if log != nil {
@@ -497,9 +553,40 @@ func shouldRedirectFrontend(log *slog.Logger, lrp *LocalRedirectPolicy, fe *lb.F
 	// single port (as that doesn't need to be named).
 	match = len(lrp.BackendPorts) <= 1
 
-	// 2.2. Frontend matches if there is a backend whose port name matches.
+	// 2.2. Frontend matches if there is a single frontend port, which filters multiple backend
+	// ports. The mapping will be made to the first backend entry, ignoring name. Note that the
+	// protocol has already been validated in the LRP parser, but we check it again here
+	// for safety.
 	if !match {
+		match = len(lrp.FrontendMappings) == 1 &&
+			lrp.FrontendMappings[0].feAddr.Protocol() == lrp.BackendPorts[0].l4Addr.Protocol
+	}
+
+	// 2.3. Frontend matches if there is a backend whose port name matches.
+	if !match && lrp.requiresPortNameMatch() {
 		_, match = lrp.BackendPortsByPortName[fe.PortName]
+
+		// The port must also be present in at least one pod to be viable for redirect.
+		// While the check itself is on portName, we verify protocols and address families
+		// too, to ensure we don't redirect across boundaries.
+		//
+		// TODO: This may perform poorly with a large range of pods. Perhaps it would be
+		// better to proactively map enabled ports and protocols when podInfo is being
+		// constructed, that way this linear search could be replaced with a lookup.
+		if match {
+			podIncludesBackendPort := func(pod *podInfo) bool {
+				return slices.ContainsFunc(pod.addrs, func(addr podAddr) bool {
+					return addr.Compatible(fe.Address) &&
+						addr.portName == string(fe.PortName)
+				})
+			}
+			for _, pod := range pods {
+				match = podIncludesBackendPort(&pod)
+				if match {
+					break
+				}
+			}
+		}
 	}
 
 	if !match {
@@ -614,17 +701,20 @@ type podAddr struct {
 	portName string
 }
 
-func podAddrs(pod *slim_corev1.Pod) (addrs []podAddr) {
+func podAddrs(pod *slim_corev1.Pod) (ips []cmtypes.AddrCluster, addrs []podAddr) {
 	podIPs := k8sUtils.ValidIPs(pod.Status)
 	if len(podIPs) == 0 {
 		// IPs not available yet.
-		return nil
+		return nil, nil
 	}
 	for _, podIP := range podIPs {
 		addrCluster, err := cmtypes.ParseAddrCluster(podIP)
 		if err != nil {
 			continue
 		}
+		ips = append(ips, addrCluster)
+	}
+	for _, addrCluster := range ips {
 		for _, container := range pod.Spec.Containers {
 			for _, port := range container.Ports {
 				l4addr := lb.NewL4Addr(lb.L4Type(port.Protocol), uint16(port.ContainerPort))
@@ -641,22 +731,31 @@ func podAddrs(pod *slim_corev1.Pod) (addrs []podAddr) {
 			}
 		}
 	}
-	return
+	return ips, addrs
 }
 
 // podInfo is the condensed data from the pod relevant for the LRP processing.
 type podInfo struct {
 	namespace      string
 	namespacedName string
-	addrs          []podAddr
-	labels         map[string]string
+	// ips identify the selected pod independently of declared container
+	// ports. ServiceMatcher LRPs use these to match selected pods back to
+	// reflected service backends when the pod spec does not declare ports.
+	ips []cmtypes.AddrCluster
+	// addrs are the concrete backend addresses derived from the pod spec.
+	// Address-based LRPs rely on these directly, and ServiceMatcher LRPs use
+	// them when container ports are declared.
+	addrs  []podAddr
+	labels map[string]string
 }
 
 func getPodInfo(pod k8sTables.LocalPod) podInfo {
+	ips, addrs := podAddrs(pod.Pod)
 	return podInfo{
 		namespace:      pod.Namespace,
 		namespacedName: pod.Namespace + "/" + pod.Name,
-		addrs:          podAddrs(pod.Pod),
+		ips:            ips,
+		addrs:          addrs,
 		labels:         pod.Labels,
 	}
 }

--- a/pkg/loadbalancer/redirectpolicy/controller.go
+++ b/pkg/loadbalancer/redirectpolicy/controller.go
@@ -97,7 +97,7 @@ func (c *lrpController) run(ctx context.Context, health cell.Health) error {
 	// objects.
 	const waitTime = 100 * time.Millisecond
 
-	// Grab table init watch channels for the inputs. Once they allclose the
+	// Grab table init watch channels for the inputs. Once they all close the
 	// Table[desiredSkipLB] is marked initialized to allow pruning the BPF map.
 	txn := c.p.DB.ReadTxn()
 	_, podsInitWatch := c.p.Pods.Initialized(txn)
@@ -300,11 +300,13 @@ func (c *lrpController) updateRedirects(wtxn writer.WriteTxn, ws *statedb.WatchS
 		targetName := lrp.ServiceID
 		fes, watch := c.p.Writer.Frontends().ListWatch(wtxn, lb.FrontendByServiceName(targetName))
 		ws.Add(watch)
+
 		for fe := range fes {
 			// Only ClusterIP services can be redirected.
 			if fe.Type != lb.SVCTypeClusterIP {
 				continue
 			}
+
 			if shouldRedirectFrontend(c.p.Log, lrp, fe, pods) {
 				c.p.Log.Debug("Redirecting frontend",
 					logfields.Frontend, fe,
@@ -395,19 +397,72 @@ func (c *lrpController) updateRedirectBackends(wtxn writer.WriteTxn, lrp *LocalR
 
 	// Construct the Backend from matching pods.
 	beps := make([]lb.Backend, 0, len(pods))
-	lrpServiceName := lrp.RedirectServiceName()
+
+	lrpIncludesBackendPort := func(addr lb.L3n4Addr) bool {
+		// In the case of a single-port LRP, only compare against the first backend port.
+		if lrp.isSinglePort() {
+			return lrp.BackendPorts[0].l4Addr.Port == addr.Port() &&
+				lrp.BackendPorts[0].l4Addr.Protocol == addr.Protocol()
+		}
+		return slices.ContainsFunc(lrp.BackendPorts, func(p bePortInfo) bool {
+			return p.l4Addr.Port == addr.Port() && p.l4Addr.Protocol == addr.Protocol()
+		})
+	}
+
+	appendBackend := func(be lb.Backend) {
+		if portNameMatches != nil && !slices.ContainsFunc(be.PortNames, portNameMatches) {
+			return
+		}
+		if !lrpIncludesBackendPort(be.Address) {
+			return
+		}
+
+		bePortNames := []string{}
+
+		// If we're not matching port names, we don't clone the backend port name.
+		// Otherwise, the loadbalancer Writer will include the portName when mapping
+		// backends to our LRP pseudo-service.
+		if portNameMatches != nil {
+			bePortNames = slices.Clone(be.PortNames)
+		}
+
+		beps = append(beps, lb.Backend{
+			Address:   be.Address,
+			State:     be.State,
+			PortNames: bePortNames,
+			// NOTE: Update [compareBackendParams] if more fields are added here.
+		})
+	}
+
 	for _, podInfo := range pods {
+		// If there are no existing ports associated with this Pod, then perhaps
+		// there's no containerPorts in the pod specs. See if we can reconstruct
+		// the backend pod addresses.
+		if len(podInfo.addrs) == 0 {
+			// We only reconstruct backend port information if this is a single
+			// port LRP which doesn't match on port names. This provides
+			// consistency with earlier versions of Cilium.
+			if portNameMatches != nil {
+				continue
+			}
+
+			for _, podIP := range podInfo.ips {
+				beAddr := lb.NewL3n4Addr(
+					lrp.BackendPorts[0].l4Addr.Protocol,
+					podIP,
+					lrp.BackendPorts[0].l4Addr.Port,
+					lb.ScopeExternal)
+				appendBackend(lb.Backend{
+					Address:   beAddr,
+					State:     lb.BackendStateActive,
+					PortNames: []string{},
+				})
+			}
+			continue
+		}
+
 		for _, addr := range podInfo.addrs {
-			if portNameMatches != nil && !portNameMatches(addr.portName) {
-				continue
-			}
-			portNumberMatches := slices.ContainsFunc(lrp.BackendPorts, func(p bePortInfo) bool {
-				return p.l4Addr.Port == addr.Port() && p.l4Addr.Protocol == addr.Protocol()
-			})
-			if !portNumberMatches {
-				continue
-			}
-			beps = append(beps, lb.Backend{
+			appendBackend(lb.Backend{
 				Address: addr.L3n4Addr,
 				State:   lb.BackendStateActive,
 				PortNames: func() []string {
@@ -416,7 +471,6 @@ func (c *lrpController) updateRedirectBackends(wtxn writer.WriteTxn, lrp *LocalR
 					}
 					return []string{}
 				}(),
-				// NOTE: Update [compareBackendParams] if more fields are added here.
 			})
 		}
 	}
@@ -424,6 +478,7 @@ func (c *lrpController) updateRedirectBackends(wtxn writer.WriteTxn, lrp *LocalR
 	// Validate whether an update is actually needed to avoid no-op changes to the tables.
 	newCount := len(beps)
 	orphanCount := 0
+	lrpServiceName := lrp.RedirectServiceName()
 	bes, _ := lb.ListBackendsByServiceName(wtxn, c.p.Writer.Backends(), lrpServiceName)
 	preferred := lb.PreferredBackendsByAddress(bes)
 	for be := range preferred {
@@ -468,8 +523,8 @@ func shouldRedirectFrontend(log *slog.Logger, lrp *LocalRedirectPolicy, fe *lb.F
 	}
 
 	// 1. First match the frontend based on "RedirectFrontend.ToPorts"
-	// 1.1. All frontends match if no ports are given
-	match := len(lrp.FrontendMappings) == 0
+	// 1.1. All frontends match only when no ports were specified in redirectFrontend.
+	match := lrp.FrontendType == svcFrontendAll
 
 	// 1.2. Frontend matches if the port number matches
 	if !match {
@@ -480,6 +535,7 @@ func shouldRedirectFrontend(log *slog.Logger, lrp *LocalRedirectPolicy, fe *lb.F
 			}
 		}
 	}
+
 	if !match {
 		// RedirectFrontend.ToPorts mismatch, skip.
 		if log != nil {
@@ -497,9 +553,36 @@ func shouldRedirectFrontend(log *slog.Logger, lrp *LocalRedirectPolicy, fe *lb.F
 	// single port (as that doesn't need to be named).
 	match = len(lrp.BackendPorts) <= 1
 
-	// 2.2. Frontend matches if there is a backend whose port name matches.
+	// 2.2. Frontend matches if there is a single frontend port, which filters multiple backend
+	// ports. The mapping will be made to the first backend entry, ignoring name. Note that the
+	// protocol has already been validated in the LRP parser, but we check it again here
+	// for safety.
 	if !match {
+		match = len(lrp.FrontendMappings) == 1 &&
+			lrp.FrontendMappings[0].feAddr.Protocol() == lrp.BackendPorts[0].l4Addr.Protocol
+	}
+
+	// 2.3. Frontend matches if there is a backend whose port name matches.
+	if !match && lrp.requiresPortNameMatch() {
 		_, match = lrp.BackendPortsByPortName[fe.PortName]
+
+		// The port must also be present in at least one pod to be viable for redirect.
+		// While the check itself is on portName, we verify protocols and address families
+		// too, to ensure we don't redirect across boundaries.
+		if match {
+			podIncludesBackendPort := func(pod *podInfo) bool {
+				return slices.ContainsFunc(pod.addrs, func(addr podAddr) bool {
+					return addr.Compatible(fe.Address) &&
+						addr.portName == string(fe.PortName)
+				})
+			}
+			for _, pod := range pods {
+				match = podIncludesBackendPort(&pod)
+				if match {
+					break
+				}
+			}
+		}
 	}
 
 	if !match {
@@ -614,17 +697,20 @@ type podAddr struct {
 	portName string
 }
 
-func podAddrs(pod *slim_corev1.Pod) (addrs []podAddr) {
+func podAddrs(pod *slim_corev1.Pod) (ips []cmtypes.AddrCluster, addrs []podAddr) {
 	podIPs := k8sUtils.ValidIPs(pod.Status)
 	if len(podIPs) == 0 {
 		// IPs not available yet.
-		return nil
+		return nil, nil
 	}
 	for _, podIP := range podIPs {
 		addrCluster, err := cmtypes.ParseAddrCluster(podIP)
 		if err != nil {
 			continue
 		}
+		ips = append(ips, addrCluster)
+	}
+	for _, addrCluster := range ips {
 		for _, container := range pod.Spec.Containers {
 			for _, port := range container.Ports {
 				l4addr := lb.NewL4Addr(lb.L4Type(port.Protocol), uint16(port.ContainerPort))
@@ -641,22 +727,31 @@ func podAddrs(pod *slim_corev1.Pod) (addrs []podAddr) {
 			}
 		}
 	}
-	return
+	return ips, addrs
 }
 
 // podInfo is the condensed data from the pod relevant for the LRP processing.
 type podInfo struct {
 	namespace      string
 	namespacedName string
-	addrs          []podAddr
-	labels         map[string]string
+	// ips identify the selected pod independently of declared container
+	// ports. ServiceMatcher LRPs use these to match selected pods back to
+	// reflected service backends when the pod spec does not declare ports.
+	ips []cmtypes.AddrCluster
+	// addrs are the concrete backend addresses derived from the pod spec.
+	// Address-based LRPs rely on these directly, and ServiceMatcher LRPs use
+	// them when container ports are declared.
+	addrs  []podAddr
+	labels map[string]string
 }
 
 func getPodInfo(pod k8sTables.LocalPod) podInfo {
+	ips, addrs := podAddrs(pod.Pod)
 	return podInfo{
 		namespace:      pod.Namespace,
 		namespacedName: pod.Namespace + "/" + pod.Name,
-		addrs:          podAddrs(pod.Pod),
+		ips:            ips,
+		addrs:          addrs,
 		labels:         pod.Labels,
 	}
 }

--- a/pkg/loadbalancer/redirectpolicy/controller_benchmark_test.go
+++ b/pkg/loadbalancer/redirectpolicy/controller_benchmark_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package redirectpolicy
+
+import (
+	"fmt"
+	"testing"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+)
+
+// BenchmarkShouldRedirectFrontend measures the worst-case named-port lookup,
+// where only the final pod provides a backend compatible with the frontend.
+func BenchmarkShouldRedirectFrontend(b *testing.B) {
+	for _, podCount := range []int{10, 10_000, 50_000} {
+		b.Run(fmt.Sprintf("pods=%d", podCount), func(b *testing.B) {
+			lrp, frontend, pods := benchmarkFrontendRedirect(podCount)
+
+			// Verify that no earlier pod satisfies the lookup. This ensures each
+			// benchmark operation scans the complete slice before matching the
+			// TCP/53 port on the final pod.
+			if shouldRedirectFrontend(nil, lrp, frontend, pods[:len(pods)-1]) {
+				b.Fatal("frontend unexpectedly matched before the final pod")
+			}
+			if !shouldRedirectFrontend(nil, lrp, frontend, pods) {
+				b.Fatal("frontend did not match the final pod")
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			var redirected bool
+			for b.Loop() {
+				redirected = shouldRedirectFrontend(nil, lrp, frontend, pods)
+			}
+			if !redirected {
+				b.Fatal("frontend did not redirect")
+			}
+			b.ReportMetric(float64(podCount)*float64(b.N)/b.Elapsed().Seconds(), "pods/sec")
+		})
+	}
+}
+
+func benchmarkFrontendRedirect(podCount int) (*LocalRedirectPolicy, *loadbalancer.Frontend, []podInfo) {
+	const (
+		dnsUDPPortName = loadbalancer.FEPortName("dns")
+		dnsTCPPortName = loadbalancer.FEPortName("dns-tcp")
+	)
+
+	dnsUDPPort := bePortInfo{l4Addr: loadbalancer.NewL4Addr(loadbalancer.UDP, 53), name: dnsUDPPortName}
+	dnsTCPPort := bePortInfo{l4Addr: loadbalancer.NewL4Addr(loadbalancer.TCP, 53), name: dnsTCPPortName}
+	lrp := &LocalRedirectPolicy{
+		FrontendType: svcFrontendAll,
+		BackendPorts: []bePortInfo{dnsUDPPort, dnsTCPPort},
+		BackendPortsByPortName: map[loadbalancer.FEPortName]bePortInfo{
+			dnsUDPPortName: dnsUDPPort,
+			dnsTCPPortName: dnsTCPPort,
+		},
+	}
+
+	podIP := cmtypes.MustParseAddrCluster("10.0.0.2")
+	dnsUDPAddr := podAddr{
+		L3n4Addr: loadbalancer.NewL3n4Addr(loadbalancer.UDP, podIP, 53, loadbalancer.ScopeExternal),
+		portName: string(dnsUDPPortName),
+	}
+	dnsTCPAddr := podAddr{
+		L3n4Addr: loadbalancer.NewL3n4Addr(loadbalancer.TCP, podIP, 53, loadbalancer.ScopeExternal),
+		portName: string(dnsTCPPortName),
+	}
+
+	pods := make([]podInfo, podCount)
+	for i := range pods {
+		pods[i].addrs = []podAddr{dnsUDPAddr}
+	}
+	// Only the final pod exposes the TCP port matched by the frontend.
+	pods[len(pods)-1].addrs = append(pods[len(pods)-1].addrs, dnsTCPAddr)
+
+	frontend := &loadbalancer.Frontend{
+		FrontendParams: loadbalancer.FrontendParams{
+			Address:  loadbalancer.NewL3n4Addr(loadbalancer.TCP, cmtypes.MustParseAddrCluster("10.96.0.10"), 53, loadbalancer.ScopeExternal),
+			PortName: dnsTCPPortName,
+		},
+	}
+	return lrp, frontend, pods
+}

--- a/pkg/loadbalancer/redirectpolicy/lrplist.go
+++ b/pkg/loadbalancer/redirectpolicy/lrplist.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package redirectpolicy
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/cilium/hive"
+	"github.com/cilium/hive/script"
+	"github.com/cilium/statedb"
+
+	"github.com/cilium/cilium/api/v1/models"
+	k8sTables "github.com/cilium/cilium/pkg/k8s/tables"
+	lb "github.com/cilium/cilium/pkg/loadbalancer"
+)
+
+// newLRPListCommand provides the "lrp/list" script command for script tests.
+func newLRPListCommand(
+	db *statedb.DB,
+	lrps statedb.Table[*LocalRedirectPolicy],
+	frontends statedb.Table[*lb.Frontend],
+	backends statedb.Table[*lb.Backend],
+	pods statedb.Table[k8sTables.LocalPod],
+) hive.ScriptCmdsOut {
+	return hive.NewScriptCmds(map[string]script.Cmd{
+		"lrp/list": script.Command(
+			script.CmdUsage{
+				Summary: "Write the LRP REST API model ('cilium-dbg lrp list')",
+				Args:    "[output file]",
+				Detail: []string{
+					"Writes the LRP REST API model to either stdout or to a file.",
+					"",
+					"Each LRP will be shown as a line, followed by any mapped frontends with",
+					"an indentation. For example:",
+					"",
+					"kube-system/nodelocaldns type=svc frontend-type=\"clusterIP + all svc ports\" service=kube-system/kube-dns",
+					"  10.96.0.10:53/TCP => 10.244.0.225:53/TCP (kube-system/node-local-dns-1, active), 10.244.0.226:53/TCP (kube-system/node-local-dns-2, active)",
+					"  10.96.0.10:53/UDP => 10.244.0.225:53/UDP (kube-system/node-local-dns-1, active), 10.244.0.226:53/UDP (kube-system/node-local-dns-2, active)",
+					"",
+					"Format is not guaranteed to be stable as this command is only",
+					"for testing and debugging purposes.",
+				},
+			},
+			func(s *script.State, args ...string) (script.WaitFunc, error) {
+				return func(s *script.State) (stdout string, stderr string, err error) {
+					var lines []string
+
+					for _, spec := range getLRPs(db.ReadTxn(), lrps, frontends, backends, pods) {
+						lines = append(lines, formatLRPSpec(spec))
+					}
+
+					data := strings.Join(lines, "\n")
+
+					if len(args) == 1 {
+						err = os.WriteFile(s.Path(args[0]), []byte(data), 0644)
+					} else {
+						stdout = data
+					}
+					return
+				}, nil
+			},
+		),
+	})
+}
+
+func formatLRPSpec(spec *models.LRPSpec) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s/%s type=%s frontend-type=%q", spec.Namespace, spec.Name, spec.LrpType, spec.FrontendType)
+	if svcID := strings.Trim(spec.ServiceID, "/"); svcID != "" {
+		fmt.Fprintf(&b, " service=%s", spec.ServiceID)
+	}
+	b.WriteByte('\n')
+	for _, feM := range spec.FrontendMappings {
+		bes := make([]string, 0, len(feM.Backends))
+		for _, be := range feM.Backends {
+			ip := "<nil>"
+			if be.BackendAddress.IP != nil {
+				ip = *be.BackendAddress.IP
+			}
+			bes = append(bes, fmt.Sprintf("%s:%d/%s (%s, %s)",
+				ip, be.BackendAddress.Port, be.BackendAddress.Protocol, be.PodID, be.BackendAddress.State))
+		}
+		sort.Strings(bes)
+		besStr := "(no backends)"
+		if len(bes) > 0 {
+			besStr = strings.Join(bes, ", ")
+		}
+		fe := feM.FrontendAddress
+		fmt.Fprintf(&b, "  %s:%d/%s => %s\n", fe.IP, fe.Port, fe.Protocol, besStr)
+	}
+	return b.String()
+}

--- a/pkg/loadbalancer/redirectpolicy/redirectpolicy.go
+++ b/pkg/loadbalancer/redirectpolicy/redirectpolicy.go
@@ -141,6 +141,29 @@ func (lrp *LocalRedirectPolicy) RedirectServiceName() lb.ServiceName {
 	return lrpServiceName(lrp.ID)
 }
 
+// Returns true if an LRP requires port names to match across the LRP FrontendMapping,
+// BackendPorts, as well as a Service and Pod spec.
+func (lrp *LocalRedirectPolicy) requiresPortNameMatch() bool {
+	switch lrp.FrontendType {
+	case svcFrontendAll, svcFrontendSinglePort, addrFrontendSinglePort:
+		return false
+	}
+
+	return true
+}
+
+// Returns true if an LRP is a single-port variant, which is a subtle variation on the
+// requirement to match named ports. Unlike requirePortNameMatch(), this will return false
+// with svcFrontendAll with a single back-end port.
+func (lrp *LocalRedirectPolicy) isSinglePort() bool {
+	switch lrp.FrontendType {
+	case svcFrontendSinglePort, addrFrontendSinglePort:
+		return true
+	}
+
+	return false
+}
+
 // feMapping stores frontend address and a list of associated backend addresses.
 type feMapping struct {
 	feAddr lb.L3n4Addr

--- a/pkg/loadbalancer/redirectpolicy/redirectpolicy.go
+++ b/pkg/loadbalancer/redirectpolicy/redirectpolicy.go
@@ -145,7 +145,15 @@ func (lrp *LocalRedirectPolicy) RedirectServiceName() lb.ServiceName {
 // BackendPorts, as well as a Service and Pod spec.
 func (lrp *LocalRedirectPolicy) requiresPortNameMatch() bool {
 	switch lrp.FrontendType {
-	case svcFrontendAll, svcFrontendSinglePort, addrFrontendSinglePort:
+	case svcFrontendAll:
+		// svcFrontendAll tells us there's no ports in the serviceMatcher, but there
+		// may be multiple ports in the redirectBackend. Where only one backend port
+		// exists, we can skip name checks.
+		if len(lrp.BackendPorts) <= 1 {
+			return false
+		}
+	case svcFrontendSinglePort, addrFrontendSinglePort:
+		// In the case of single port redirects, we can skip name checks.
 		return false
 	}
 

--- a/pkg/loadbalancer/redirectpolicy/testdata/address-matcher-single-named-port.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/address-matcher-single-named-port.txtar
@@ -1,0 +1,92 @@
+# An addressMatcher LRP with a SINGLE named frontend port and a pod whose
+
+hive start
+
+# Add the LRP and the matching pod.
+k8s/add lrp-addr.yaml pod.yaml
+
+# Datapath truth: the LocalRedirect frontend carries the pod backend even
+# though the pod's container port name ("dns-upstream") differs from the
+# frontend port name ("dns").
+db/cmp localredirectpolicies lrp.table
+db/cmp services services.table
+db/cmp frontends frontends.table
+db/cmp backends backends.table
+
+# The REST API model must show the same backend for the frontend mapping.
+lrp/list lrp.actual
+cmp lrp.actual lrp-list.expected
+
+-- lrp.table --
+Name           Type     FrontendType      Frontends
+test/lrp-addr  address  addr-single-port  169.254.20.10:80/TCP
+
+-- services.table --
+Name                          Source
+test/lrp-addr:local-redirect  k8s
+
+-- frontends.table --
+Address                Type           ServiceName                   Backends           RedirectTo  Status
+169.254.20.10:80/TCP   LocalRedirect  test/lrp-addr:local-redirect  10.244.2.1:80/TCP              Done
+
+-- backends.table --
+Service                       Address
+test/lrp-addr:local-redirect  10.244.2.1:80/TCP
+
+-- lrp-list.expected --
+test/lrp-addr type=addr frontend-type="IP + port"
+  169.254.20.10:80/TCP => 10.244.2.1:80/TCP (test/lrp-pod, active)
+-- lrp-addr.yaml --
+apiVersion: "cilium.io/v2"
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: "lrp-addr"
+  namespace: test
+spec:
+  redirectFrontend:
+    addressMatcher:
+      ip: "169.254.20.10"
+      toPorts:
+        - port: "80"
+          name: "http"
+          protocol: TCP
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        app: nginx
+    toPorts:
+      - port: "80"
+        protocol: TCP
+
+-- pod.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: lrp-pod
+  namespace: test
+  labels:
+    app: nginx
+spec:
+  containers:
+    - name: lrp-pod
+      image: nginx
+      ports:
+        - containerPort: 80
+          name: wrong-http
+          protocol: TCP
+  nodeName: testnode
+status:
+  hostIP: 172.19.0.3
+  hostIPs:
+  - ip: 172.19.0.3
+  phase: Running
+  podIP: 10.244.2.1
+  podIPs:
+  - ip: 10.244.2.1
+  qosClass: BestEffort
+  startTime: "2024-07-10T16:20:42Z"
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: '2019-07-08T09:41:59Z'
+    status: 'True'
+    type: Ready

--- a/pkg/loadbalancer/redirectpolicy/testdata/node-local-dns-frontend-filtered.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/node-local-dns-frontend-filtered.txtar
@@ -1,0 +1,178 @@
+# Reproducer for issue #43944: a serviceMatcher LRP with named toPorts.
+# Unlike node-local-dns.txtar, the serviceMatcher specifies toPorts, so the
+# policy's internal FrontendMappings are non-empty and carry a placeholder
+# frontend address ("invalid IP") that must never be exposed through the API.
+
+hive start
+
+k8s/add svc-kubedns.yaml eps-kubedns.yaml lrp-kubedns.yaml pod-1-nodelocaldns.yaml
+
+# Datapath truth: the 53/TCP and 53/UDP clusterIP frontends are redirected to
+# the node-local-dns pod; 9153 (metrics) is not redirected.
+db/cmp frontends frontends.table
+
+# The REST API model must agree with the frontends table above.
+lrp/list lrp.actual
+cmp lrp.actual lrp.expected
+
+-- frontends.table --
+Address                    Type        ServiceName           PortName   RedirectTo                               Status  Backends
+10.96.0.10:53/TCP          ClusterIP   kube-system/kube-dns  dns-tcp    kube-system/nodelocaldns:local-redirect  Done    10.244.0.225:53/TCP
+10.96.0.10:53/UDP          ClusterIP   kube-system/kube-dns  dns        kube-system/nodelocaldns:local-redirect  Done    10.244.0.225:53/UDP
+10.96.0.10:9153/TCP        ClusterIP   kube-system/kube-dns  metrics                                             Done    10.244.1.51:9153/TCP, 10.244.1.68:9153/TCP
+
+-- lrp.expected --
+kube-system/nodelocaldns type=svc frontend-type="clusterIP + named ports" service=kube-system/kube-dns
+  10.96.0.10:53/TCP => 10.244.0.225:53/TCP (kube-system/node-local-dns-1, active)
+  10.96.0.10:53/UDP => 10.244.0.225:53/UDP (kube-system/node-local-dns-1, active)
+-- lrp-kubedns.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: nodelocaldns
+  namespace: kube-system
+spec:
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        k8s-app: node-local-dns
+    toPorts:
+    - name: dns
+      port: "53"
+      protocol: UDP
+    - name: dns-tcp
+      port: "53"
+      protocol: TCP
+  redirectFrontend:
+    serviceMatcher:
+      namespace: kube-system
+      serviceName: kube-dns
+      toPorts:
+      - name: dns
+        port: "53"
+        protocol: UDP
+      - name: dns-tcp
+        port: "53"
+        protocol: TCP
+  skipRedirectFromBackend: false
+
+-- svc-kubedns.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/name: CoreDNS
+  name: kube-dns
+  namespace: kube-system
+spec:
+  clusterIP: 10.96.0.10
+  clusterIPs:
+  - 10.96.0.10
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+    targetPort: 53
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+    targetPort: 53
+  - name: metrics
+    port: 9153
+    protocol: TCP
+    targetPort: 9153
+  selector:
+    k8s-app: kube-dns
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}
+
+-- eps-kubedns.yaml --
+addressType: IPv4
+apiVersion: discovery.k8s.io/v1
+endpoints:
+- addresses:
+  - 10.244.1.68
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: testnode
+- addresses:
+  - 10.244.1.51
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: testnode
+kind: EndpointSlice
+metadata:
+  labels:
+    endpointslice.kubernetes.io/managed-by: endpointslice-controller.k8s.io
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: CoreDNS
+    kubernetes.io/service-name: kube-dns
+  name: kube-dns-8x8pw
+  namespace: kube-system
+ports:
+- name: metrics
+  port: 9153
+  protocol: TCP
+- name: dns
+  port: 53
+  protocol: UDP
+- name: dns-tcp
+  port: 53
+  protocol: TCP
+
+-- pod-1-nodelocaldns.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    k8s-app: node-local-dns
+  name: node-local-dns-1
+  namespace: kube-system
+spec:
+  containers:
+  - name: node-cache
+    ports:
+    - containerPort: 53
+      name: dns
+      protocol: UDP
+    - containerPort: 53
+      name: dns-tcp
+      protocol: TCP
+    - containerPort: 9253
+      name: metrics
+      protocol: TCP
+  nodeName: testnode
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: "2025-03-13T09:43:36Z"
+    status: "True"
+    type: Ready
+  containerStatuses:
+  - name: node-cache
+    ready: true
+    started: true
+    state:
+      running:
+        startedAt: "2025-03-13T09:43:36Z"
+  hostIP: 172.19.0.3
+  hostIPs:
+  - ip: 172.19.0.3
+  phase: Running
+  podIP: 10.244.0.225
+  podIPs:
+  - ip: 10.244.0.225
+  qosClass: Burstable
+  startTime: "2025-03-13T09:41:27Z"

--- a/pkg/loadbalancer/redirectpolicy/testdata/node-local-dns.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/node-local-dns.txtar
@@ -24,6 +24,12 @@ k8s/add pod-2-nodelocaldns.yaml
 db/cmp services services-after.table
 db/cmp frontends frontends-after.table
 
+# The REST API model (rendered by 'cilium-dbg lrp list') must agree with the
+# state computed by the controller and writer above: the real clusterIP
+# frontends and the local pod backends.
+lrp/list lrp.actual
+* cmp lrp.actual lrp.expected
+
 # Check BPF maps again
 lb/maps-dump lbmaps.actual
 * cmp lbmaps.actual lbmaps-after.expected
@@ -75,6 +81,11 @@ Address                    Type        ServiceName           PortName   Redirect
 10.96.0.10:53/UDP          ClusterIP   kube-system/kube-dns  dns        kube-system/nodelocaldns:local-redirect  Done    10.244.0.225:53/UDP
 10.96.0.10:9153/TCP        ClusterIP   kube-system/kube-dns  metrics                                             Done    10.244.1.51:9153/TCP, 10.244.1.68:9153/TCP
 
+-- lrp.expected --
+kube-system/nodelocaldns type=svc frontend-type="clusterIP + all svc ports" service=kube-system/kube-dns
+  10.96.0.10:53/TCP => 10.244.0.225:53/TCP (kube-system/node-local-dns-1, active), 10.244.0.226:53/TCP (kube-system/node-local-dns-2, active)
+  10.96.0.10:53/UDP => 10.244.0.225:53/UDP (kube-system/node-local-dns-1, active), 10.244.0.226:53/UDP (kube-system/node-local-dns-2, active)
+  10.96.0.10:9153/TCP => (no backends)
 -- lbmaps-before.expected --
 BE: ID=1 ADDR=10.244.1.51:53/TCP STATE=active
 BE: ID=2 ADDR=10.244.1.68:53/TCP STATE=active

--- a/pkg/loadbalancer/redirectpolicy/testdata/service-matcher-all-ports.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/service-matcher-all-ports.txtar
@@ -1,0 +1,705 @@
+# Verify that serviceMatcher correctly fails to map to backends that are missing
+# any port information in the pod spec, but if a pod is present that contains
+# ports in the specs, mapping is established.
+
+hive start
+
+# Add pods, service and eps for both families
+k8s/add pod-without-ports.yaml
+k8s/add service.yaml eps4.yaml eps6.yaml
+
+# Verify statedb tables
+db/cmp localredirectpolicies lrp-initial.table
+db/cmp services services-initial.table
+db/cmp frontends frontends-initial.table
+db/cmp backends backends-initial.table
+
+# Verify service maps
+lb/maps-dump lbmaps-initial.actual
+* cmp lbmaps-initial.actual lbmaps-initial.expected
+
+# Add the serviceMatcher LRP. This will insert a pseudo-service for the
+# LRP, but should not affect any frontends.
+k8s/add lrp.yaml
+
+# Verify
+db/cmp localredirectpolicies lrp-added.table
+db/cmp services services-lrp.table
+db/cmp frontends frontends-lrp.table
+db/cmp backends backends-lrp.table
+
+lb/maps-dump lbmaps-lrp.actual
+* cmp lbmaps-lrp.actual lbmaps-lrp.expected
+
+lrp/list lrp.actual
+* cmp lrp.actual lrp.expected
+
+# Now introduce a second pod with port mappings. This should trigger
+# redirect of VIPs to backend2 pod only.
+k8s/add pod-with-ports.yaml
+k8s/update eps4-v2.yaml eps6-v2.yaml
+
+# Verify
+db/cmp frontends frontends-lrp-pod2.table
+db/cmp backends backends-lrp-pod2.table
+
+lb/maps-dump lbmaps-lrp-pod2.actual
+* cmp lbmaps-lrp-pod2.actual lbmaps-lrp-pod2.expected
+
+lrp/list lrp-pod2.actual
+* cmp lrp-pod2.actual lrp-pod2.expected
+
+# Now introduce a third pod, with port mapping only on one container, and
+# only on IPv6. This should cause an update only to a single FE.
+k8s/add pod-with-http6-only.yaml
+k8s/update eps6-v3.yaml
+
+# Verify
+db/cmp frontends frontends-lrp-pod2-pod3.table
+db/cmp backends backends-lrp-pod2-pod3.table
+
+lb/maps-dump lbmaps-lrp-pod2-pod3.actual
+* cmp lbmaps-lrp-pod2-pod3.actual lbmaps-lrp-pod2-pod3.expected
+
+lrp/list lrp-pod2-pod3.actual
+* cmp lrp-pod2-pod3.actual lrp-pod2-pod3.expected
+
+# Now delete the LRP. This should restore everything to initial values.
+k8s/delete lrp.yaml
+
+# Verify
+db/cmp localredirectpolicies lrp-initial.table
+db/cmp services services-initial.table
+db/cmp frontends frontends-nolrp-pod2-pod3.table
+db/cmp backends backends-nolrp-pod2-pod3.table
+
+lb/maps-dump lbmaps-nolrp-pod2-pod3.actual
+* cmp lbmaps-nolrp-pod2-pod3.actual lbmaps-nolrp-pod2-pod3.expected
+
+lrp/list lrp-deleted.actual
+* cmp lrp-deleted.actual lrp-deleted.expected
+
+-- lrp-initial.table --
+Name   Type   Service   FrontendType   Frontends   BackendSelector
+-- lrp-added.table --
+Name                     Type      Service              FrontendType   Frontends   BackendSelector
+test/login-service-lrp   service   test/login-service   all                        &LabelSelector{MatchLabels:map[string]string{k8s:app: login,},MatchExpressions:[]LabelSelectorRequirement{},}
+
+-- services-initial.table --
+Name                 Source   PortNames                      TrafficPolicy   Flags
+test/login-service   k8s      dtls=443, http=80, https=443   Cluster
+-- services-lrp.table --
+Name                                    Source   PortNames                      TrafficPolicy   Flags
+test/login-service                      k8s      dtls=443, http=80, https=443   Cluster
+test/login-service-lrp:local-redirect   k8s                                     Cluster
+
+-- frontends-initial.table --
+Address                 Type        ServiceName          PortName   Backends              RedirectTo   Status
+192.168.10.10:80/TCP    ClusterIP   test/login-service   http       10.244.2.1:8080/TCP                Done
+192.168.10.10:443/TCP   ClusterIP   test/login-service   https      10.244.2.1:8443/TCP                Done
+192.168.10.10:443/UDP   ClusterIP   test/login-service   dtls       10.244.2.1:8443/UDP                Done
+[1001::1]:80/TCP        ClusterIP   test/login-service   http       [2001::1]:8080/TCP                 Done
+[1001::1]:443/TCP       ClusterIP   test/login-service   https      [2001::1]:8443/TCP                 Done
+[1001::1]:443/UDP       ClusterIP   test/login-service   dtls       [2001::1]:8443/UDP                 Done
+-- frontends-lrp.table --
+Address                 Type        ServiceName          PortName   Backends              RedirectTo   Status
+192.168.10.10:80/TCP    ClusterIP   test/login-service   http       10.244.2.1:8080/TCP                Done
+192.168.10.10:443/TCP   ClusterIP   test/login-service   https      10.244.2.1:8443/TCP                Done
+192.168.10.10:443/UDP   ClusterIP   test/login-service   dtls       10.244.2.1:8443/UDP                Done
+[1001::1]:80/TCP        ClusterIP   test/login-service   http       [2001::1]:8080/TCP                 Done
+[1001::1]:443/TCP       ClusterIP   test/login-service   https      [2001::1]:8443/TCP                 Done
+[1001::1]:443/UDP       ClusterIP   test/login-service   dtls       [2001::1]:8443/UDP                 Done
+-- frontends-lrp-pod2.table --
+Address                 Type        ServiceName          PortName   Backends              RedirectTo                              Status
+192.168.10.10:80/TCP    ClusterIP   test/login-service   http       10.244.2.2:8080/TCP   test/login-service-lrp:local-redirect   Done
+192.168.10.10:443/TCP   ClusterIP   test/login-service   https      10.244.2.2:8443/TCP   test/login-service-lrp:local-redirect   Done
+192.168.10.10:443/UDP   ClusterIP   test/login-service   dtls       10.244.2.2:8443/UDP   test/login-service-lrp:local-redirect   Done
+[1001::1]:80/TCP        ClusterIP   test/login-service   http       [2001::2]:8080/TCP    test/login-service-lrp:local-redirect   Done
+[1001::1]:443/TCP       ClusterIP   test/login-service   https      [2001::2]:8443/TCP    test/login-service-lrp:local-redirect   Done
+[1001::1]:443/UDP       ClusterIP   test/login-service   dtls       [2001::2]:8443/UDP    test/login-service-lrp:local-redirect   Done
+-- frontends-lrp-pod2-pod3.table --
+Address                 Type        ServiceName          PortName   Backends                                 RedirectTo                              Status
+192.168.10.10:80/TCP    ClusterIP   test/login-service   http       10.244.2.2:8080/TCP                      test/login-service-lrp:local-redirect   Done
+192.168.10.10:443/TCP   ClusterIP   test/login-service   https      10.244.2.2:8443/TCP                      test/login-service-lrp:local-redirect   Done
+192.168.10.10:443/UDP   ClusterIP   test/login-service   dtls       10.244.2.2:8443/UDP                      test/login-service-lrp:local-redirect   Done
+[1001::1]:80/TCP        ClusterIP   test/login-service   http       [2001::2]:8080/TCP, [2001::3]:8080/TCP   test/login-service-lrp:local-redirect   Done
+[1001::1]:443/TCP       ClusterIP   test/login-service   https      [2001::2]:8443/TCP                       test/login-service-lrp:local-redirect   Done
+[1001::1]:443/UDP       ClusterIP   test/login-service   dtls       [2001::2]:8443/UDP                       test/login-service-lrp:local-redirect   Done
+-- frontends-nolrp-pod2-pod3.table --
+Address                 Type        ServiceName          PortName   Backends                                                     RedirectTo   Status
+192.168.10.10:80/TCP    ClusterIP   test/login-service   http       10.244.2.1:8080/TCP, 10.244.2.2:8080/TCP                                  Done
+192.168.10.10:443/TCP   ClusterIP   test/login-service   https      10.244.2.1:8443/TCP, 10.244.2.2:8443/TCP                                  Done
+192.168.10.10:443/UDP   ClusterIP   test/login-service   dtls       10.244.2.1:8443/UDP, 10.244.2.2:8443/UDP                                  Done
+[1001::1]:80/TCP        ClusterIP   test/login-service   http       [2001::1]:8080/TCP, [2001::2]:8080/TCP, [2001::3]:8080/TCP                Done
+[1001::1]:443/TCP       ClusterIP   test/login-service   https      [2001::1]:8443/TCP, [2001::2]:8443/TCP, [2001::3]:8443/TCP                Done
+[1001::1]:443/UDP       ClusterIP   test/login-service   dtls       [2001::1]:8443/UDP, [2001::2]:8443/UDP, [2001::3]:8443/UDP                Done
+
+-- backends-initial.table --
+Service              Address               Source   Priority   State    PortNames   NodeName
+test/login-service   10.244.2.1:8080/TCP   k8s      4          active   http        testnode
+test/login-service   10.244.2.1:8443/TCP   k8s      4          active   https       testnode
+test/login-service   10.244.2.1:8443/UDP   k8s      4          active   dtls        testnode
+test/login-service   [2001::1]:8080/TCP    k8s      4          active   http        testnode
+test/login-service   [2001::1]:8443/TCP    k8s      4          active   https       testnode
+test/login-service   [2001::1]:8443/UDP    k8s      4          active   dtls        testnode
+-- backends-lrp.table --
+Service              Address               Source   Priority   State    PortNames   NodeName
+test/login-service   10.244.2.1:8080/TCP   k8s      4          active   http        testnode
+test/login-service   10.244.2.1:8443/TCP   k8s      4          active   https       testnode
+test/login-service   10.244.2.1:8443/UDP   k8s      4          active   dtls        testnode
+test/login-service   [2001::1]:8080/TCP    k8s      4          active   http        testnode
+test/login-service   [2001::1]:8443/TCP    k8s      4          active   https       testnode
+test/login-service   [2001::1]:8443/UDP    k8s      4          active   dtls        testnode
+-- backends-lrp-pod2.table --
+Service                                 Address               Source   Priority   State    PortNames   NodeName
+test/login-service                      10.244.2.1:8080/TCP   k8s      4          active   http        testnode
+test/login-service                      10.244.2.1:8443/TCP   k8s      4          active   https       testnode
+test/login-service                      10.244.2.1:8443/UDP   k8s      4          active   dtls        testnode
+test/login-service                      10.244.2.2:8080/TCP   k8s      4          active   http        testnode
+test/login-service                      10.244.2.2:8443/TCP   k8s      4          active   https       testnode
+test/login-service                      10.244.2.2:8443/UDP   k8s      4          active   dtls        testnode
+test/login-service                      [2001::1]:8080/TCP    k8s      4          active   http        testnode
+test/login-service                      [2001::1]:8443/TCP    k8s      4          active   https       testnode
+test/login-service                      [2001::1]:8443/UDP    k8s      4          active   dtls        testnode
+test/login-service                      [2001::2]:8080/TCP    k8s      4          active   http        testnode
+test/login-service                      [2001::2]:8443/TCP    k8s      4          active   https       testnode
+test/login-service                      [2001::2]:8443/UDP    k8s      4          active   dtls        testnode
+test/login-service-lrp:local-redirect   10.244.2.2:8080/TCP   k8s      4          active   http
+test/login-service-lrp:local-redirect   10.244.2.2:8443/TCP   k8s      4          active   https
+test/login-service-lrp:local-redirect   10.244.2.2:8443/UDP   k8s      4          active   dtls
+test/login-service-lrp:local-redirect   [2001::2]:8080/TCP    k8s      4          active   http
+test/login-service-lrp:local-redirect   [2001::2]:8443/TCP    k8s      4          active   https
+test/login-service-lrp:local-redirect   [2001::2]:8443/UDP    k8s      4          active   dtls
+-- backends-lrp-pod2-pod3.table --
+Service                                 Address               Source   Priority   State    PortNames   NodeName
+test/login-service                      10.244.2.1:8080/TCP   k8s      4          active   http        testnode
+test/login-service                      10.244.2.1:8443/TCP   k8s      4          active   https       testnode
+test/login-service                      10.244.2.1:8443/UDP   k8s      4          active   dtls        testnode
+test/login-service                      10.244.2.2:8080/TCP   k8s      4          active   http        testnode
+test/login-service                      10.244.2.2:8443/TCP   k8s      4          active   https       testnode
+test/login-service                      10.244.2.2:8443/UDP   k8s      4          active   dtls        testnode
+test/login-service                      [2001::1]:8080/TCP    k8s      4          active   http        testnode
+test/login-service                      [2001::1]:8443/TCP    k8s      4          active   https       testnode
+test/login-service                      [2001::1]:8443/UDP    k8s      4          active   dtls        testnode
+test/login-service                      [2001::2]:8080/TCP    k8s      4          active   http        testnode
+test/login-service                      [2001::2]:8443/TCP    k8s      4          active   https       testnode
+test/login-service                      [2001::2]:8443/UDP    k8s      4          active   dtls        testnode
+test/login-service                      [2001::3]:8080/TCP    k8s      4          active   http        testnode
+test/login-service                      [2001::3]:8443/TCP    k8s      4          active   https       testnode
+test/login-service                      [2001::3]:8443/UDP    k8s      4          active   dtls        testnode
+test/login-service-lrp:local-redirect   10.244.2.2:8080/TCP   k8s      4          active   http
+test/login-service-lrp:local-redirect   10.244.2.2:8443/TCP   k8s      4          active   https
+test/login-service-lrp:local-redirect   10.244.2.2:8443/UDP   k8s      4          active   dtls
+test/login-service-lrp:local-redirect   [2001::2]:8080/TCP    k8s      4          active   http
+test/login-service-lrp:local-redirect   [2001::2]:8443/TCP    k8s      4          active   https
+test/login-service-lrp:local-redirect   [2001::2]:8443/UDP    k8s      4          active   dtls
+test/login-service-lrp:local-redirect   [2001::3]:8080/TCP    k8s      4          active   http
+-- backends-nolrp-pod2-pod3.table --
+Service              Address               Source   Priority   State    PortNames   NodeName
+test/login-service   10.244.2.1:8080/TCP   k8s      4          active   http        testnode
+test/login-service   10.244.2.1:8443/TCP   k8s      4          active   https       testnode
+test/login-service   10.244.2.1:8443/UDP   k8s      4          active   dtls        testnode
+test/login-service   10.244.2.2:8080/TCP   k8s      4          active   http        testnode
+test/login-service   10.244.2.2:8443/TCP   k8s      4          active   https       testnode
+test/login-service   10.244.2.2:8443/UDP   k8s      4          active   dtls        testnode
+test/login-service   [2001::1]:8080/TCP    k8s      4          active   http        testnode
+test/login-service   [2001::1]:8443/TCP    k8s      4          active   https       testnode
+test/login-service   [2001::1]:8443/UDP    k8s      4          active   dtls        testnode
+test/login-service   [2001::2]:8080/TCP    k8s      4          active   http        testnode
+test/login-service   [2001::2]:8443/TCP    k8s      4          active   https       testnode
+test/login-service   [2001::2]:8443/UDP    k8s      4          active   dtls        testnode
+test/login-service   [2001::3]:8080/TCP    k8s      4          active   http        testnode
+test/login-service   [2001::3]:8443/TCP    k8s      4          active   https       testnode
+test/login-service   [2001::3]:8443/UDP    k8s      4          active   dtls        testnode
+
+-- lbmaps-initial.expected --
+BE: ID=1 ADDR=10.244.2.1:8080/TCP STATE=active
+BE: ID=2 ADDR=10.244.2.1:8443/TCP STATE=active
+BE: ID=3 ADDR=10.244.2.1:8443/UDP STATE=active
+BE: ID=4 ADDR=[2001::1]:8080/TCP STATE=active
+BE: ID=5 ADDR=[2001::1]:8443/TCP STATE=active
+BE: ID=6 ADDR=[2001::1]:8443/UDP STATE=active
+REV: ID=1 ADDR=192.168.10.10:80
+REV: ID=2 ADDR=192.168.10.10:443
+REV: ID=3 ADDR=192.168.10.10:443
+REV: ID=4 ADDR=[1001::1]:80
+REV: ID=5 ADDR=[1001::1]:443
+REV: ID=6 ADDR=[1001::1]:443
+SVC: ID=0 ADDR=192.168.10.10:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=[1001::1]:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=192.168.10.10:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=192.168.10.10:443/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=192.168.10.10:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=192.168.10.10:443/UDP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=[1001::1]:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=[1001::1]:80/TCP SLOT=1 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=[1001::1]:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=[1001::1]:443/TCP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=[1001::1]:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=[1001::1]:443/UDP SLOT=1 BEID=6 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- lbmaps-lrp.expected --
+BE: ID=1 ADDR=10.244.2.1:8080/TCP STATE=active
+BE: ID=2 ADDR=10.244.2.1:8443/TCP STATE=active
+BE: ID=3 ADDR=10.244.2.1:8443/UDP STATE=active
+BE: ID=4 ADDR=[2001::1]:8080/TCP STATE=active
+BE: ID=5 ADDR=[2001::1]:8443/TCP STATE=active
+BE: ID=6 ADDR=[2001::1]:8443/UDP STATE=active
+REV: ID=1 ADDR=192.168.10.10:80
+REV: ID=2 ADDR=192.168.10.10:443
+REV: ID=3 ADDR=192.168.10.10:443
+REV: ID=4 ADDR=[1001::1]:80
+REV: ID=5 ADDR=[1001::1]:443
+REV: ID=6 ADDR=[1001::1]:443
+SVC: ID=0 ADDR=192.168.10.10:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=[1001::1]:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=192.168.10.10:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=192.168.10.10:443/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=192.168.10.10:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=192.168.10.10:443/UDP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=[1001::1]:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=[1001::1]:80/TCP SLOT=1 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=[1001::1]:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=[1001::1]:443/TCP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=[1001::1]:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=[1001::1]:443/UDP SLOT=1 BEID=6 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- lbmaps-lrp-pod2.expected --
+BE: ID=10 ADDR=[2001::2]:8080/TCP STATE=active
+BE: ID=11 ADDR=[2001::2]:8443/TCP STATE=active
+BE: ID=12 ADDR=[2001::2]:8443/UDP STATE=active
+BE: ID=7 ADDR=10.244.2.2:8080/TCP STATE=active
+BE: ID=8 ADDR=10.244.2.2:8443/TCP STATE=active
+BE: ID=9 ADDR=10.244.2.2:8443/UDP STATE=active
+REV: ID=1 ADDR=192.168.10.10:80
+REV: ID=2 ADDR=192.168.10.10:443
+REV: ID=3 ADDR=192.168.10.10:443
+REV: ID=4 ADDR=[1001::1]:80
+REV: ID=5 ADDR=[1001::1]:443
+REV: ID=6 ADDR=[1001::1]:443
+SVC: ID=0 ADDR=192.168.10.10:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=[1001::1]:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=2 ADDR=192.168.10.10:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=2 ADDR=192.168.10.10:443/TCP SLOT=1 BEID=8 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=3 ADDR=192.168.10.10:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=3 ADDR=192.168.10.10:443/UDP SLOT=1 BEID=9 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=4 ADDR=[1001::1]:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=4 ADDR=[1001::1]:80/TCP SLOT=1 BEID=10 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=5 ADDR=[1001::1]:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=5 ADDR=[1001::1]:443/TCP SLOT=1 BEID=11 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=6 ADDR=[1001::1]:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=6 ADDR=[1001::1]:443/UDP SLOT=1 BEID=12 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+-- lbmaps-lrp-pod2-pod3.expected --
+BE: ID=10 ADDR=[2001::2]:8080/TCP STATE=active
+BE: ID=11 ADDR=[2001::2]:8443/TCP STATE=active
+BE: ID=12 ADDR=[2001::2]:8443/UDP STATE=active
+BE: ID=13 ADDR=[2001::3]:8080/TCP STATE=active
+BE: ID=7 ADDR=10.244.2.2:8080/TCP STATE=active
+BE: ID=8 ADDR=10.244.2.2:8443/TCP STATE=active
+BE: ID=9 ADDR=10.244.2.2:8443/UDP STATE=active
+REV: ID=1 ADDR=192.168.10.10:80
+REV: ID=2 ADDR=192.168.10.10:443
+REV: ID=3 ADDR=192.168.10.10:443
+REV: ID=4 ADDR=[1001::1]:80
+REV: ID=5 ADDR=[1001::1]:443
+REV: ID=6 ADDR=[1001::1]:443
+SVC: ID=0 ADDR=192.168.10.10:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=[1001::1]:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=2 ADDR=192.168.10.10:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=2 ADDR=192.168.10.10:443/TCP SLOT=1 BEID=8 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=3 ADDR=192.168.10.10:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=3 ADDR=192.168.10.10:443/UDP SLOT=1 BEID=9 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=4 ADDR=[1001::1]:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=4 ADDR=[1001::1]:80/TCP SLOT=1 BEID=10 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=4 ADDR=[1001::1]:80/TCP SLOT=2 BEID=13 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=5 ADDR=[1001::1]:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=5 ADDR=[1001::1]:443/TCP SLOT=1 BEID=11 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=6 ADDR=[1001::1]:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=6 ADDR=[1001::1]:443/UDP SLOT=1 BEID=12 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+-- lbmaps-nolrp-pod2-pod3.expected --
+BE: ID=10 ADDR=[2001::2]:8080/TCP STATE=active
+BE: ID=11 ADDR=[2001::2]:8443/TCP STATE=active
+BE: ID=12 ADDR=[2001::2]:8443/UDP STATE=active
+BE: ID=13 ADDR=[2001::3]:8080/TCP STATE=active
+BE: ID=14 ADDR=10.244.2.1:8080/TCP STATE=active
+BE: ID=15 ADDR=10.244.2.1:8443/TCP STATE=active
+BE: ID=16 ADDR=10.244.2.1:8443/UDP STATE=active
+BE: ID=17 ADDR=[2001::1]:8080/TCP STATE=active
+BE: ID=18 ADDR=[2001::1]:8443/TCP STATE=active
+BE: ID=19 ADDR=[2001::3]:8443/TCP STATE=active
+BE: ID=20 ADDR=[2001::1]:8443/UDP STATE=active
+BE: ID=21 ADDR=[2001::3]:8443/UDP STATE=active
+BE: ID=7 ADDR=10.244.2.2:8080/TCP STATE=active
+BE: ID=8 ADDR=10.244.2.2:8443/TCP STATE=active
+BE: ID=9 ADDR=10.244.2.2:8443/UDP STATE=active
+REV: ID=1 ADDR=192.168.10.10:80
+REV: ID=2 ADDR=192.168.10.10:443
+REV: ID=3 ADDR=192.168.10.10:443
+REV: ID=4 ADDR=[1001::1]:80
+REV: ID=5 ADDR=[1001::1]:443
+REV: ID=6 ADDR=[1001::1]:443
+SVC: ID=0 ADDR=192.168.10.10:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=[1001::1]:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=1 BEID=14 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=2 BEID=7 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=192.168.10.10:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=192.168.10.10:443/TCP SLOT=1 BEID=15 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=192.168.10.10:443/TCP SLOT=2 BEID=8 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=192.168.10.10:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=192.168.10.10:443/UDP SLOT=1 BEID=16 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=192.168.10.10:443/UDP SLOT=2 BEID=9 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=[1001::1]:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=3 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=[1001::1]:80/TCP SLOT=1 BEID=17 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=[1001::1]:80/TCP SLOT=2 BEID=10 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=[1001::1]:80/TCP SLOT=3 BEID=13 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=[1001::1]:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=3 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=[1001::1]:443/TCP SLOT=1 BEID=18 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=[1001::1]:443/TCP SLOT=2 BEID=11 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=[1001::1]:443/TCP SLOT=3 BEID=19 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=[1001::1]:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=3 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=[1001::1]:443/UDP SLOT=1 BEID=20 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=[1001::1]:443/UDP SLOT=2 BEID=12 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=[1001::1]:443/UDP SLOT=3 BEID=21 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- lrp.expected --
+test/login-service-lrp type=svc frontend-type="clusterIP + all svc ports" service=test/login-service
+  192.168.10.10:80/TCP => (no backends)
+  192.168.10.10:443/TCP => (no backends)
+  192.168.10.10:443/UDP => (no backends)
+  1001::1:80/TCP => (no backends)
+  1001::1:443/TCP => (no backends)
+  1001::1:443/UDP => (no backends)
+-- lrp-pod2.expected --
+test/login-service-lrp type=svc frontend-type="clusterIP + all svc ports" service=test/login-service
+  192.168.10.10:80/TCP => 10.244.2.2:8080/TCP (test/backend2, active)
+  192.168.10.10:443/TCP => 10.244.2.2:8443/TCP (test/backend2, active)
+  192.168.10.10:443/UDP => 10.244.2.2:8443/UDP (test/backend2, active)
+  1001::1:80/TCP => 2001::2:8080/TCP (test/backend2, active)
+  1001::1:443/TCP => 2001::2:8443/TCP (test/backend2, active)
+  1001::1:443/UDP => 2001::2:8443/UDP (test/backend2, active)
+-- lrp-pod2-pod3.expected --
+test/login-service-lrp type=svc frontend-type="clusterIP + all svc ports" service=test/login-service
+  192.168.10.10:80/TCP => 10.244.2.2:8080/TCP (test/backend2, active)
+  192.168.10.10:443/TCP => 10.244.2.2:8443/TCP (test/backend2, active)
+  192.168.10.10:443/UDP => 10.244.2.2:8443/UDP (test/backend2, active)
+  1001::1:80/TCP => 2001::2:8080/TCP (test/backend2, active), 2001::3:8080/TCP (test/backend3, active)
+  1001::1:443/TCP => 2001::2:8443/TCP (test/backend2, active)
+  1001::1:443/UDP => 2001::2:8443/UDP (test/backend2, active)
+-- lrp-deleted.expected --
+-- pod-without-ports.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: backend1
+  namespace: test
+  labels:
+    app: login
+spec:
+  containers:
+    - name: backend1-nginx
+      image: nginx
+      # ports intentionally removed
+    - name: backend1-vpn
+      image: vpn
+      # ports intentionally removed
+  nodeName: testnode
+status:
+  hostIP: 172.19.0.1
+  hostIPs:
+  - ip: 172.19.0.1
+  phase: Running
+  podIP: 10.244.2.1
+  podIPs:
+  - ip: 10.244.2.1
+  - ip: 2001::1
+  qosClass: BestEffort
+  conditions:
+  - lastProbeTime: null
+    status: "True"
+    type: Ready
+
+-- pod-with-ports.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: backend2
+  namespace: test
+  labels:
+    app: login
+spec:
+  containers:
+    - name: backend2-nginx
+      image: nginx
+      ports:
+      - containerPort: 8080
+        name: http
+        protocol: TCP
+    - name: backend2-vpn
+      image: vpn
+      ports:
+      - containerPort: 8443
+        name: https
+        protocol: TCP
+      - containerPort: 8443
+        name: dtls
+        protocol: UDP
+  nodeName: testnode
+status:
+  hostIP: 172.19.0.1
+  hostIPs:
+  - ip: 172.19.0.1
+  phase: Running
+  podIP: 10.244.2.2
+  podIPs:
+  - ip: 10.244.2.2
+  - ip: 2001::2
+  qosClass: BestEffort
+  conditions:
+  - lastProbeTime: null
+    status: "True"
+    type: Ready
+
+-- pod-with-http6-only.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: backend3
+  namespace: test
+  labels:
+    app: login
+spec:
+  containers:
+    - name: backend3-nginx
+      image: nginx
+      ports:
+      - containerPort: 8080
+        name: http
+        protocol: TCP
+    - name: backend3-vpn
+      image: vpn
+      # ports intentionally removed
+  nodeName: testnode
+status:
+  hostIP: 172.19.0.1
+  hostIPs:
+  - ip: 172.19.0.1
+  phase: Running
+  podIP: 2001::3
+  podIPs:
+  - ip: 2001::3
+  qosClass: BestEffort
+  conditions:
+  - lastProbeTime: null
+    status: "True"
+    type: Ready
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: login-service
+  namespace: test
+spec:
+  type: ClusterIP
+  selector:
+    app: login
+  clusterIP: 192.168.10.10
+  clusterIPs:
+  - 192.168.10.10
+  - 1001::1
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  - IPv6
+  ipFamilyPolicy: DualStack
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 8443
+  - name: dtls
+    port: 443
+    protocol: UDP
+    targetPort: 8443
+  sessionAffinity: None
+
+-- eps4.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: login-service
+  name: login-service-v4
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.2.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: testnode
+ports:
+- name: http
+  port: 8080
+  protocol: TCP
+- name: https
+  port: 8443
+  protocol: TCP
+- name: dtls
+  port: 8443
+  protocol: UDP
+
+-- eps6.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: login-service
+  name: login-service-v6
+  namespace: test
+addressType: IPv6
+endpoints:
+- addresses:
+  - 2001::1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: testnode
+ports:
+- name: http
+  port: 8080
+  protocol: TCP
+- name: https
+  port: 8443
+  protocol: TCP
+- name: dtls
+  port: 8443
+  protocol: UDP
+
+-- eps4-v2.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: login-service
+  name: login-service-v4
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.2.1
+  - 10.244.2.2
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: testnode
+ports:
+- name: http
+  port: 8080
+  protocol: TCP
+- name: https
+  port: 8443
+  protocol: TCP
+- name: dtls
+  port: 8443
+  protocol: UDP
+
+-- eps6-v2.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: login-service
+  name: login-service-v6
+  namespace: test
+addressType: IPv6
+endpoints:
+- addresses:
+  - 2001::1
+  - 2001::2
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: testnode
+ports:
+- name: http
+  port: 8080
+  protocol: TCP
+- name: https
+  port: 8443
+  protocol: TCP
+- name: dtls
+  port: 8443
+  protocol: UDP
+
+-- eps6-v3.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: login-service
+  name: login-service-v6
+  namespace: test
+addressType: IPv6
+endpoints:
+- addresses:
+  - 2001::1
+  - 2001::2
+  - 2001::3
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: testnode
+ports:
+- name: http
+  port: 8080
+  protocol: TCP
+- name: https
+  port: 8443
+  protocol: TCP
+- name: dtls
+  port: 8443
+  protocol: UDP
+
+-- lrp.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: login-service-lrp
+  namespace: test
+spec:
+  redirectFrontend:
+    serviceMatcher:
+      serviceName: login-service
+      namespace: test
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        app: login
+    toPorts:
+      - name: "http"
+        port: "8080"
+        protocol: TCP
+      - name: "https"
+        port: "8443"
+        protocol: TCP
+      - name: "dtls"
+        port: "8443"
+        protocol: UDP

--- a/pkg/loadbalancer/redirectpolicy/testdata/service-matcher-named-ports.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/service-matcher-named-ports.txtar
@@ -1,0 +1,649 @@
+# Verify that serviceMatcher correctly maps between frontends and backends
+# where multiple ports exist and names are used for mapping. Any pod with
+# ports missing in their spec should be disregarded.
+
+hive start
+
+# Add pods, service and eps for both families
+k8s/add pod.yaml pod-dtls-only.yaml
+k8s/add service.yaml eps4.yaml eps6.yaml
+
+# Verify statedb tables
+db/cmp localredirectpolicies lrp-initial.table
+db/cmp services services-initial.table
+db/cmp frontends frontends-initial.table
+db/cmp backends backends-initial.table
+
+# Verify service maps
+lb/maps-dump lbmaps-initial.actual
+* cmp lbmaps-initial.actual lbmaps-initial.expected
+
+# Add the serviceMatcher LRP with matching ports. This should properly
+# match on http, https, dtls, but ignore the api port. All services should
+# be redirected to backend1, but backend2 should only be mapped for DTLS,
+# because it's missing ports in the pod spec.
+k8s/add lrp-matched.yaml
+
+# Verify
+db/cmp localredirectpolicies lrp-matched.table
+db/cmp services services-lrp-matched.table
+db/cmp frontends frontends-lrp-matched.table
+db/cmp backends backends-lrp-matched.table
+
+lb/maps-dump lbmaps-lrp-matched.actual
+* cmp lbmaps-lrp-matched.actual lbmaps-lrp-matched.expected
+
+lrp/list lrp-matched.actual
+* cmp lrp-matched.actual lrp-matched.expected
+
+# We can now delete the first LRP.
+k8s/delete lrp-matched.yaml
+
+# Verify
+db/cmp localredirectpolicies lrp-initial.table
+db/cmp services services-initial.table
+db/cmp frontends frontends-initial.table
+db/cmp backends backends-initial.table
+
+lb/maps-dump lbmaps-reverted.actual
+* cmp lbmaps-reverted.actual lbmaps-reverted.expected
+
+lrp/list lrp-deleted.actual
+* cmp lrp-deleted.actual lrp-deleted.expected
+
+# Add the serviceMatcher LRP with mismatched ports. Unlike the first,
+# this should only match on http and https, with dtls failing because
+# of a port name mismatch, and the api port being ignored. Because dtls
+# fails to map, there should be no mapping to backend2.
+k8s/add lrp-mismatched.yaml
+
+# Verify
+db/cmp localredirectpolicies lrp-mismatched.table
+db/cmp services services-lrp-mismatched.table
+db/cmp frontends frontends-lrp-mismatched.table
+db/cmp backends backends-lrp-mismatched.table
+
+lb/maps-dump lbmaps-lrp-mismatched.actual
+* cmp lbmaps-lrp-mismatched.actual lbmaps-lrp-mismatched.expected
+
+lrp/list lrp-mismatched.actual
+* cmp lrp-mismatched.actual lrp-mismatched.expected
+
+-- lrp-initial.table --
+Name   Type   Service   FrontendType   Frontends   BackendSelector
+-- lrp-matched.table --
+Name               Type      Service              FrontendType
+test/lrp-matched   service   test/login-service   named-ports
+-- lrp-mismatched.table --
+Name                  Type      Service              FrontendType
+test/lrp-mismatched   service   test/login-service   named-ports
+
+-- services-initial.table --
+Name                 Source   PortNames                              TrafficPolicy   Flags
+test/login-service   k8s      api=81, dtls=443, http=80, https=443   Cluster
+-- services-lrp-matched.table --
+Name                              Source   PortNames                              TrafficPolicy   Flags
+test/login-service                k8s      api=81, dtls=443, http=80, https=443   Cluster
+test/lrp-matched:local-redirect   k8s                                             Cluster
+-- services-lrp-mismatched.table --
+Name                                 Source   PortNames                              TrafficPolicy   Flags
+test/login-service                   k8s      api=81, dtls=443, http=80, https=443   Cluster
+test/lrp-mismatched:local-redirect   k8s                                             Cluster
+
+-- frontends-initial.table --
+Address                 Type        ServiceName          PortName   Backends                                   RedirectTo   Status
+192.168.10.10:80/TCP    ClusterIP   test/login-service   http       10.244.2.1:8080/TCP, 10.244.2.2:8080/TCP                Done
+192.168.10.10:81/TCP    ClusterIP   test/login-service   api        10.244.2.1:8081/TCP, 10.244.2.2:8081/TCP                Done
+192.168.10.10:443/TCP   ClusterIP   test/login-service   https      10.244.2.1:8443/TCP, 10.244.2.2:8443/TCP                Done
+192.168.10.10:443/UDP   ClusterIP   test/login-service   dtls       10.244.2.1:8443/UDP, 10.244.2.2:8443/UDP                Done
+[1001::1]:80/TCP        ClusterIP   test/login-service   http       [2001::1]:8080/TCP, [2001::2]:8080/TCP                  Done
+[1001::1]:81/TCP        ClusterIP   test/login-service   api        [2001::1]:8081/TCP, [2001::2]:8081/TCP                  Done
+[1001::1]:443/TCP       ClusterIP   test/login-service   https      [2001::1]:8443/TCP, [2001::2]:8443/TCP                  Done
+[1001::1]:443/UDP       ClusterIP   test/login-service   dtls       [2001::1]:8443/UDP, [2001::2]:8443/UDP                  Done
+-- frontends-lrp-matched.table --
+Address                 Type        ServiceName          PortName   Backends                                   RedirectTo                        Status
+192.168.10.10:80/TCP    ClusterIP   test/login-service   http       10.244.2.1:8080/TCP                        test/lrp-matched:local-redirect   Done
+192.168.10.10:81/TCP    ClusterIP   test/login-service   api        10.244.2.1:8081/TCP, 10.244.2.2:8081/TCP                                     Done
+192.168.10.10:443/TCP   ClusterIP   test/login-service   https      10.244.2.1:8443/TCP                        test/lrp-matched:local-redirect   Done
+192.168.10.10:443/UDP   ClusterIP   test/login-service   dtls       10.244.2.1:8443/UDP, 10.244.2.2:8443/UDP   test/lrp-matched:local-redirect   Done
+[1001::1]:80/TCP        ClusterIP   test/login-service   http       [2001::1]:8080/TCP                         test/lrp-matched:local-redirect   Done
+[1001::1]:81/TCP        ClusterIP   test/login-service   api        [2001::1]:8081/TCP, [2001::2]:8081/TCP                                       Done
+[1001::1]:443/TCP       ClusterIP   test/login-service   https      [2001::1]:8443/TCP                         test/lrp-matched:local-redirect   Done
+[1001::1]:443/UDP       ClusterIP   test/login-service   dtls       [2001::1]:8443/UDP, [2001::2]:8443/UDP     test/lrp-matched:local-redirect   Done
+-- frontends-lrp-mismatched.table --
+Address                 Type        ServiceName          PortName   Backends                                   RedirectTo                           Status
+192.168.10.10:80/TCP    ClusterIP   test/login-service   http       10.244.2.1:8080/TCP                        test/lrp-mismatched:local-redirect   Done
+192.168.10.10:81/TCP    ClusterIP   test/login-service   api        10.244.2.1:8081/TCP, 10.244.2.2:8081/TCP                                        Done
+192.168.10.10:443/TCP   ClusterIP   test/login-service   https      10.244.2.1:8443/TCP                        test/lrp-mismatched:local-redirect   Done
+192.168.10.10:443/UDP   ClusterIP   test/login-service   dtls       10.244.2.1:8443/UDP, 10.244.2.2:8443/UDP                                        Done
+[1001::1]:80/TCP        ClusterIP   test/login-service   http       [2001::1]:8080/TCP                         test/lrp-mismatched:local-redirect   Done
+[1001::1]:81/TCP        ClusterIP   test/login-service   api        [2001::1]:8081/TCP, [2001::2]:8081/TCP                                          Done
+[1001::1]:443/TCP       ClusterIP   test/login-service   https      [2001::1]:8443/TCP                         test/lrp-mismatched:local-redirect   Done
+[1001::1]:443/UDP       ClusterIP   test/login-service   dtls       [2001::1]:8443/UDP, [2001::2]:8443/UDP                                          Done
+
+-- backends-initial.table --
+Service              Address               Source   Priority   State    PortNames   NodeName
+test/login-service   10.244.2.1:8080/TCP   k8s      4          active   http        testnode
+test/login-service   10.244.2.1:8081/TCP   k8s      4          active   api         testnode
+test/login-service   10.244.2.1:8443/TCP   k8s      4          active   https       testnode
+test/login-service   10.244.2.1:8443/UDP   k8s      4          active   dtls        testnode
+test/login-service   10.244.2.2:8080/TCP   k8s      4          active   http        testnode
+test/login-service   10.244.2.2:8081/TCP   k8s      4          active   api         testnode
+test/login-service   10.244.2.2:8443/TCP   k8s      4          active   https       testnode
+test/login-service   10.244.2.2:8443/UDP   k8s      4          active   dtls        testnode
+test/login-service   [2001::1]:8080/TCP    k8s      4          active   http        testnode
+test/login-service   [2001::1]:8081/TCP    k8s      4          active   api         testnode
+test/login-service   [2001::1]:8443/TCP    k8s      4          active   https       testnode
+test/login-service   [2001::1]:8443/UDP    k8s      4          active   dtls        testnode
+test/login-service   [2001::2]:8080/TCP    k8s      4          active   http        testnode
+test/login-service   [2001::2]:8081/TCP    k8s      4          active   api         testnode
+test/login-service   [2001::2]:8443/TCP    k8s      4          active   https       testnode
+test/login-service   [2001::2]:8443/UDP    k8s      4          active   dtls        testnode
+-- backends-lrp-matched.table --
+Service                           Address               Source   Priority   State    PortNames   NodeName
+test/login-service                10.244.2.1:8080/TCP   k8s      4          active   http        testnode
+test/login-service                10.244.2.1:8081/TCP   k8s      4          active   api         testnode
+test/login-service                10.244.2.1:8443/TCP   k8s      4          active   https       testnode
+test/login-service                10.244.2.1:8443/UDP   k8s      4          active   dtls        testnode
+test/login-service                10.244.2.2:8080/TCP   k8s      4          active   http        testnode
+test/login-service                10.244.2.2:8081/TCP   k8s      4          active   api         testnode
+test/login-service                10.244.2.2:8443/TCP   k8s      4          active   https       testnode
+test/login-service                10.244.2.2:8443/UDP   k8s      4          active   dtls        testnode
+test/login-service                [2001::1]:8080/TCP    k8s      4          active   http        testnode
+test/login-service                [2001::1]:8081/TCP    k8s      4          active   api         testnode
+test/login-service                [2001::1]:8443/TCP    k8s      4          active   https       testnode
+test/login-service                [2001::1]:8443/UDP    k8s      4          active   dtls        testnode
+test/login-service                [2001::2]:8080/TCP    k8s      4          active   http        testnode
+test/login-service                [2001::2]:8081/TCP    k8s      4          active   api         testnode
+test/login-service                [2001::2]:8443/TCP    k8s      4          active   https       testnode
+test/login-service                [2001::2]:8443/UDP    k8s      4          active   dtls        testnode
+test/lrp-matched:local-redirect   10.244.2.1:8080/TCP   k8s      4          active   http
+test/lrp-matched:local-redirect   10.244.2.1:8443/TCP   k8s      4          active   https
+test/lrp-matched:local-redirect   10.244.2.1:8443/UDP   k8s      4          active   dtls
+test/lrp-matched:local-redirect   10.244.2.2:8443/UDP   k8s      4          active   dtls
+test/lrp-matched:local-redirect   [2001::1]:8080/TCP    k8s      4          active   http
+test/lrp-matched:local-redirect   [2001::1]:8443/TCP    k8s      4          active   https
+test/lrp-matched:local-redirect   [2001::1]:8443/UDP    k8s      4          active   dtls
+test/lrp-matched:local-redirect   [2001::2]:8443/UDP    k8s      4          active   dtls
+-- backends-lrp-mismatched.table --
+Service                              Address               Source   Priority   State    PortNames   NodeName
+test/login-service                   10.244.2.1:8080/TCP   k8s      4          active   http        testnode
+test/login-service                   10.244.2.1:8081/TCP   k8s      4          active   api         testnode
+test/login-service                   10.244.2.1:8443/TCP   k8s      4          active   https       testnode
+test/login-service                   10.244.2.1:8443/UDP   k8s      4          active   dtls        testnode
+test/login-service                   10.244.2.2:8080/TCP   k8s      4          active   http        testnode
+test/login-service                   10.244.2.2:8081/TCP   k8s      4          active   api         testnode
+test/login-service                   10.244.2.2:8443/TCP   k8s      4          active   https       testnode
+test/login-service                   10.244.2.2:8443/UDP   k8s      4          active   dtls        testnode
+test/login-service                   [2001::1]:8080/TCP    k8s      4          active   http        testnode
+test/login-service                   [2001::1]:8081/TCP    k8s      4          active   api         testnode
+test/login-service                   [2001::1]:8443/TCP    k8s      4          active   https       testnode
+test/login-service                   [2001::1]:8443/UDP    k8s      4          active   dtls        testnode
+test/login-service                   [2001::2]:8080/TCP    k8s      4          active   http        testnode
+test/login-service                   [2001::2]:8081/TCP    k8s      4          active   api         testnode
+test/login-service                   [2001::2]:8443/TCP    k8s      4          active   https       testnode
+test/login-service                   [2001::2]:8443/UDP    k8s      4          active   dtls        testnode
+test/lrp-mismatched:local-redirect   10.244.2.1:8080/TCP   k8s      4          active   http
+test/lrp-mismatched:local-redirect   10.244.2.1:8443/TCP   k8s      4          active   https
+test/lrp-mismatched:local-redirect   [2001::1]:8080/TCP    k8s      4          active   http
+test/lrp-mismatched:local-redirect   [2001::1]:8443/TCP    k8s      4          active   https
+
+-- lbmaps-initial.expected --
+BE: ID=1 ADDR=10.244.2.1:8080/TCP STATE=active
+BE: ID=10 ADDR=[2001::2]:8080/TCP STATE=active
+BE: ID=11 ADDR=[2001::1]:8081/TCP STATE=active
+BE: ID=12 ADDR=[2001::2]:8081/TCP STATE=active
+BE: ID=13 ADDR=[2001::1]:8443/TCP STATE=active
+BE: ID=14 ADDR=[2001::2]:8443/TCP STATE=active
+BE: ID=15 ADDR=[2001::1]:8443/UDP STATE=active
+BE: ID=16 ADDR=[2001::2]:8443/UDP STATE=active
+BE: ID=2 ADDR=10.244.2.2:8080/TCP STATE=active
+BE: ID=3 ADDR=10.244.2.1:8081/TCP STATE=active
+BE: ID=4 ADDR=10.244.2.2:8081/TCP STATE=active
+BE: ID=5 ADDR=10.244.2.1:8443/TCP STATE=active
+BE: ID=6 ADDR=10.244.2.2:8443/TCP STATE=active
+BE: ID=7 ADDR=10.244.2.1:8443/UDP STATE=active
+BE: ID=8 ADDR=10.244.2.2:8443/UDP STATE=active
+BE: ID=9 ADDR=[2001::1]:8080/TCP STATE=active
+REV: ID=1 ADDR=192.168.10.10:80
+REV: ID=2 ADDR=192.168.10.10:81
+REV: ID=3 ADDR=192.168.10.10:443
+REV: ID=4 ADDR=192.168.10.10:443
+REV: ID=5 ADDR=[1001::1]:80
+REV: ID=6 ADDR=[1001::1]:81
+REV: ID=7 ADDR=[1001::1]:443
+REV: ID=8 ADDR=[1001::1]:443
+SVC: ID=0 ADDR=192.168.10.10:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=[1001::1]:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=192.168.10.10:81/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=192.168.10.10:81/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=192.168.10.10:81/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=192.168.10.10:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=192.168.10.10:443/TCP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=192.168.10.10:443/TCP SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=192.168.10.10:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=192.168.10.10:443/UDP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=192.168.10.10:443/UDP SLOT=2 BEID=8 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=[1001::1]:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=[1001::1]:80/TCP SLOT=1 BEID=9 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=[1001::1]:80/TCP SLOT=2 BEID=10 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=[1001::1]:81/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=[1001::1]:81/TCP SLOT=1 BEID=11 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=[1001::1]:81/TCP SLOT=2 BEID=12 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=7 ADDR=[1001::1]:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=7 ADDR=[1001::1]:443/TCP SLOT=1 BEID=13 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=7 ADDR=[1001::1]:443/TCP SLOT=2 BEID=14 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=8 ADDR=[1001::1]:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=8 ADDR=[1001::1]:443/UDP SLOT=1 BEID=15 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=8 ADDR=[1001::1]:443/UDP SLOT=2 BEID=16 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- lbmaps-lrp-matched.expected --
+BE: ID=1 ADDR=10.244.2.1:8080/TCP STATE=active
+BE: ID=11 ADDR=[2001::1]:8081/TCP STATE=active
+BE: ID=12 ADDR=[2001::2]:8081/TCP STATE=active
+BE: ID=13 ADDR=[2001::1]:8443/TCP STATE=active
+BE: ID=15 ADDR=[2001::1]:8443/UDP STATE=active
+BE: ID=16 ADDR=[2001::2]:8443/UDP STATE=active
+BE: ID=3 ADDR=10.244.2.1:8081/TCP STATE=active
+BE: ID=4 ADDR=10.244.2.2:8081/TCP STATE=active
+BE: ID=5 ADDR=10.244.2.1:8443/TCP STATE=active
+BE: ID=7 ADDR=10.244.2.1:8443/UDP STATE=active
+BE: ID=8 ADDR=10.244.2.2:8443/UDP STATE=active
+BE: ID=9 ADDR=[2001::1]:8080/TCP STATE=active
+REV: ID=1 ADDR=192.168.10.10:80
+REV: ID=2 ADDR=192.168.10.10:81
+REV: ID=3 ADDR=192.168.10.10:443
+REV: ID=4 ADDR=192.168.10.10:443
+REV: ID=5 ADDR=[1001::1]:80
+REV: ID=6 ADDR=[1001::1]:81
+REV: ID=7 ADDR=[1001::1]:443
+REV: ID=8 ADDR=[1001::1]:443
+SVC: ID=0 ADDR=192.168.10.10:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=[1001::1]:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=2 ADDR=192.168.10.10:81/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=192.168.10.10:81/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=192.168.10.10:81/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=192.168.10.10:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=3 ADDR=192.168.10.10:443/TCP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=4 ADDR=192.168.10.10:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=4 ADDR=192.168.10.10:443/UDP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=4 ADDR=192.168.10.10:443/UDP SLOT=2 BEID=8 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=5 ADDR=[1001::1]:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=5 ADDR=[1001::1]:80/TCP SLOT=1 BEID=9 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=6 ADDR=[1001::1]:81/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=[1001::1]:81/TCP SLOT=1 BEID=11 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=[1001::1]:81/TCP SLOT=2 BEID=12 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=7 ADDR=[1001::1]:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=7 ADDR=[1001::1]:443/TCP SLOT=1 BEID=13 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=8 ADDR=[1001::1]:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=8 ADDR=[1001::1]:443/UDP SLOT=1 BEID=15 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=8 ADDR=[1001::1]:443/UDP SLOT=2 BEID=16 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+-- lbmaps-reverted.expected --
+BE: ID=1 ADDR=10.244.2.1:8080/TCP STATE=active
+BE: ID=11 ADDR=[2001::1]:8081/TCP STATE=active
+BE: ID=12 ADDR=[2001::2]:8081/TCP STATE=active
+BE: ID=13 ADDR=[2001::1]:8443/TCP STATE=active
+BE: ID=15 ADDR=[2001::1]:8443/UDP STATE=active
+BE: ID=16 ADDR=[2001::2]:8443/UDP STATE=active
+BE: ID=17 ADDR=10.244.2.2:8080/TCP STATE=active
+BE: ID=18 ADDR=10.244.2.2:8443/TCP STATE=active
+BE: ID=19 ADDR=[2001::2]:8080/TCP STATE=active
+BE: ID=20 ADDR=[2001::2]:8443/TCP STATE=active
+BE: ID=3 ADDR=10.244.2.1:8081/TCP STATE=active
+BE: ID=4 ADDR=10.244.2.2:8081/TCP STATE=active
+BE: ID=5 ADDR=10.244.2.1:8443/TCP STATE=active
+BE: ID=7 ADDR=10.244.2.1:8443/UDP STATE=active
+BE: ID=8 ADDR=10.244.2.2:8443/UDP STATE=active
+BE: ID=9 ADDR=[2001::1]:8080/TCP STATE=active
+REV: ID=1 ADDR=192.168.10.10:80
+REV: ID=2 ADDR=192.168.10.10:81
+REV: ID=3 ADDR=192.168.10.10:443
+REV: ID=4 ADDR=192.168.10.10:443
+REV: ID=5 ADDR=[1001::1]:80
+REV: ID=6 ADDR=[1001::1]:81
+REV: ID=7 ADDR=[1001::1]:443
+REV: ID=8 ADDR=[1001::1]:443
+SVC: ID=0 ADDR=192.168.10.10:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=[1001::1]:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=2 BEID=17 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=192.168.10.10:81/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=192.168.10.10:81/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=192.168.10.10:81/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=192.168.10.10:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=192.168.10.10:443/TCP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=192.168.10.10:443/TCP SLOT=2 BEID=18 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=192.168.10.10:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=192.168.10.10:443/UDP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=192.168.10.10:443/UDP SLOT=2 BEID=8 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=[1001::1]:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=[1001::1]:80/TCP SLOT=1 BEID=9 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=[1001::1]:80/TCP SLOT=2 BEID=19 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=[1001::1]:81/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=[1001::1]:81/TCP SLOT=1 BEID=11 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=[1001::1]:81/TCP SLOT=2 BEID=12 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=7 ADDR=[1001::1]:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=7 ADDR=[1001::1]:443/TCP SLOT=1 BEID=13 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=7 ADDR=[1001::1]:443/TCP SLOT=2 BEID=20 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=8 ADDR=[1001::1]:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=8 ADDR=[1001::1]:443/UDP SLOT=1 BEID=15 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=8 ADDR=[1001::1]:443/UDP SLOT=2 BEID=16 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- lbmaps-lrp-mismatched.expected --
+BE: ID=1 ADDR=10.244.2.1:8080/TCP STATE=active
+BE: ID=11 ADDR=[2001::1]:8081/TCP STATE=active
+BE: ID=12 ADDR=[2001::2]:8081/TCP STATE=active
+BE: ID=13 ADDR=[2001::1]:8443/TCP STATE=active
+BE: ID=15 ADDR=[2001::1]:8443/UDP STATE=active
+BE: ID=16 ADDR=[2001::2]:8443/UDP STATE=active
+BE: ID=3 ADDR=10.244.2.1:8081/TCP STATE=active
+BE: ID=4 ADDR=10.244.2.2:8081/TCP STATE=active
+BE: ID=5 ADDR=10.244.2.1:8443/TCP STATE=active
+BE: ID=7 ADDR=10.244.2.1:8443/UDP STATE=active
+BE: ID=8 ADDR=10.244.2.2:8443/UDP STATE=active
+BE: ID=9 ADDR=[2001::1]:8080/TCP STATE=active
+REV: ID=1 ADDR=192.168.10.10:80
+REV: ID=2 ADDR=192.168.10.10:81
+REV: ID=3 ADDR=192.168.10.10:443
+REV: ID=4 ADDR=192.168.10.10:443
+REV: ID=5 ADDR=[1001::1]:80
+REV: ID=6 ADDR=[1001::1]:81
+REV: ID=7 ADDR=[1001::1]:443
+REV: ID=8 ADDR=[1001::1]:443
+SVC: ID=0 ADDR=192.168.10.10:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=[1001::1]:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=2 ADDR=192.168.10.10:81/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=192.168.10.10:81/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=192.168.10.10:81/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=192.168.10.10:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=3 ADDR=192.168.10.10:443/TCP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=4 ADDR=192.168.10.10:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=192.168.10.10:443/UDP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=192.168.10.10:443/UDP SLOT=2 BEID=8 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=[1001::1]:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=5 ADDR=[1001::1]:80/TCP SLOT=1 BEID=9 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=6 ADDR=[1001::1]:81/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=[1001::1]:81/TCP SLOT=1 BEID=11 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=[1001::1]:81/TCP SLOT=2 BEID=12 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=7 ADDR=[1001::1]:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=7 ADDR=[1001::1]:443/TCP SLOT=1 BEID=13 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=8 ADDR=[1001::1]:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=8 ADDR=[1001::1]:443/UDP SLOT=1 BEID=15 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=8 ADDR=[1001::1]:443/UDP SLOT=2 BEID=16 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- lrp-matched.expected --
+test/lrp-matched type=svc frontend-type="clusterIP + named ports" service=test/login-service
+  192.168.10.10:80/TCP => 10.244.2.1:8080/TCP (test/backend1, active)
+  192.168.10.10:443/TCP => 10.244.2.1:8443/TCP (test/backend1, active)
+  192.168.10.10:443/UDP => 10.244.2.1:8443/UDP (test/backend1, active), 10.244.2.2:8443/UDP (test/backend2, active)
+  1001::1:80/TCP => 2001::1:8080/TCP (test/backend1, active)
+  1001::1:443/TCP => 2001::1:8443/TCP (test/backend1, active)
+  1001::1:443/UDP => 2001::1:8443/UDP (test/backend1, active), 2001::2:8443/UDP (test/backend2, active)
+-- lrp-mismatched.expected --
+test/lrp-mismatched type=svc frontend-type="clusterIP + named ports" service=test/login-service
+  192.168.10.10:80/TCP => 10.244.2.1:8080/TCP (test/backend1, active)
+  192.168.10.10:443/TCP => 10.244.2.1:8443/TCP (test/backend1, active)
+  192.168.10.10:443/UDP => (no backends)
+  1001::1:80/TCP => 2001::1:8080/TCP (test/backend1, active)
+  1001::1:443/TCP => 2001::1:8443/TCP (test/backend1, active)
+-- lrp-deleted.expected --
+-- pod.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: backend1
+  namespace: test
+  labels:
+    app: login
+spec:
+  containers:
+    - name: backend1-nginx
+      image: nginx
+      ports:
+      - containerPort: 8080
+        name: http
+        protocol: TCP
+      - containerPort: 8081
+        name: api
+        protocol: TCP
+    - name: backend1-vpn
+      image: vpn
+      ports:
+      - containerPort: 8443
+        name: https
+        protocol: TCP
+      - containerPort: 8443
+        name: dtls
+        protocol: UDP
+  nodeName: testnode
+status:
+  hostIP: 172.19.0.1
+  hostIPs:
+  - ip: 172.19.0.1
+  phase: Running
+  podIP: 10.244.2.1
+  podIPs:
+  - ip: 10.244.2.1
+  - ip: 2001::1
+  qosClass: BestEffort
+  conditions:
+  - lastProbeTime: null
+    status: "True"
+    type: Ready
+
+-- pod-dtls-only.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: backend2
+  namespace: test
+  labels:
+    app: login
+spec:
+  containers:
+    - name: backend2-nginx
+      image: nginx
+      # ports intentionally missing
+    - name: backend2-vpn
+      image: vpn
+      ports:
+      # https port intentionally missing
+      - containerPort: 8443
+        name: dtls
+        protocol: UDP
+  nodeName: testnode
+status:
+  hostIP: 172.19.0.1
+  hostIPs:
+  - ip: 172.19.0.1
+  phase: Running
+  podIP: 10.244.2.2
+  podIPs:
+  - ip: 10.244.2.2
+  - ip: 2001::2
+  qosClass: BestEffort
+  conditions:
+  - lastProbeTime: null
+    status: "True"
+    type: Ready
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: login-service
+  namespace: test
+spec:
+  type: ClusterIP
+  selector:
+    app: login
+  clusterIP: 192.168.10.10
+  clusterIPs:
+  - 192.168.10.10
+  - 1001::1
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  - IPv6
+  ipFamilyPolicy: DualStack
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  - name: api
+    port: 81
+    protocol: TCP
+    targetPort: 8081
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 8443
+  - name: dtls
+    port: 443
+    protocol: UDP
+    targetPort: 8443
+  sessionAffinity: None
+
+-- eps4.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: login-service
+  name: login-service-v4
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.2.1
+  - 10.244.2.2
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: testnode
+ports:
+- name: http
+  port: 8080
+  protocol: TCP
+- name: api
+  port: 8081
+  protocol: TCP
+- name: https
+  port: 8443
+  protocol: TCP
+- name: dtls
+  port: 8443
+  protocol: UDP
+
+-- eps6.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: login-service
+  name: login-service-v6
+  namespace: test
+addressType: IPv6
+endpoints:
+- addresses:
+  - 2001::1
+  - 2001::2
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: testnode
+ports:
+- name: http
+  port: 8080
+  protocol: TCP
+- name: api
+  port: 8081
+  protocol: TCP
+- name: https
+  port: 8443
+  protocol: TCP
+- name: dtls
+  port: 8443
+  protocol: UDP
+
+-- lrp-matched.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: lrp-matched
+  namespace: test
+spec:
+  redirectFrontend:
+    serviceMatcher:
+      serviceName: login-service
+      namespace: test
+      toPorts:
+      # api is intentionally missing to ensure it's not reported
+      - name: "http"
+        port: "80"
+        protocol: TCP
+      - name: "https"
+        port: "443"
+        protocol: TCP
+      - name: "dtls"
+        port: "443"
+        protocol: UDP
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        app: login
+    toPorts:
+      - name: "http"
+        port: "8080"
+        protocol: TCP
+      - name: "https"
+        port: "8443"
+        protocol: TCP
+      - name: "dtls"
+        port: "8443"
+        protocol: UDP
+
+-- lrp-mismatched.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: lrp-mismatched
+  namespace: test
+spec:
+  redirectFrontend:
+    serviceMatcher:
+      serviceName: login-service
+      namespace: test
+      toPorts:
+      - name: "http"
+        port: "80"
+        protocol: TCP
+      - name: "https"
+        port: "443"
+        protocol: TCP
+      - name: "dtls"
+        port: "443"
+        protocol: UDP
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        app: login
+    toPorts:
+      - name: "http"
+        port: "8080"
+        protocol: TCP
+      - name: "https"
+        port: "8443"
+        protocol: TCP
+      - name: "not-dtls"
+        port: "8443"
+        protocol: UDP

--- a/pkg/loadbalancer/redirectpolicy/testdata/service-matcher-single-port-fallback.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/service-matcher-single-port-fallback.txtar
@@ -1,0 +1,423 @@
+# Verify that single-port serviceMatcher correctly maps frontends when
+# a pod spec is missing port information.
+
+hive start
+
+# Add service-related pod, service and eps for both families
+k8s/add pod.yaml
+k8s/add service.yaml eps-v4.yaml eps-v6.yaml
+
+# Also insert an alternate Pod that does not belong to a service, but is a
+# candidate for mapping into an LRP backend. This should not appear in the
+# first tests.
+k8s/add pod-single.yaml
+
+# Verify statedb tables
+db/cmp localredirectpolicies lrp-initial.table
+db/cmp services services-initial.table
+db/cmp frontends frontends-initial.table
+db/cmp backends backends-initial.table
+
+# Verify service maps
+lb/maps-dump lbmaps-initial.actual
+* cmp lbmaps-initial.actual lbmaps-initial.expected
+
+# Add the serviceMatcher LRP with matching toPort[]
+k8s/add lrp-tcp.yaml
+
+# Verify the LRP mapped properly.
+db/cmp localredirectpolicies lrp-tcp.table
+db/cmp services services-lrp-tcp.table
+db/cmp frontends frontends-lrp-tcp.table
+db/cmp backends backends-lrp-tcp.table
+
+# Verify service maps
+lb/maps-dump lbmaps-lrp-tcp.actual
+* cmp lbmaps-lrp-tcp.actual lbmaps-lrp-tcp.expected
+
+# Verify the REST API model output
+lrp/list lrp-tcp.actual
+* cmp lrp-tcp.actual lrp-tcp.expected
+
+# Delete the serviceMatcher
+k8s/delete lrp-tcp.yaml
+
+# Verify we return back to the initial state
+db/cmp localredirectpolicies lrp-initial.table
+db/cmp services services-initial.table
+db/cmp frontends frontends-initial.table
+db/cmp backends backends-initial.table
+
+lb/maps-dump lbmaps-reverted1.actual
+* cmp lbmaps-reverted1.actual lbmaps-reverted1.expected
+
+lrp/list lrp-empty.actual
+* cmp lrp-empty.actual lrp-empty.expected
+
+# Now we add the serviceMatcher LRP where frontend toPort[0] is set
+# UDP, but the backend toPort[0] is still set TCP. This should fail
+# to parse and be rejected.
+k8s/add lrp-udp.yaml
+
+# The LRP should not be present
+db/cmp localredirectpolicies lrp-initial.table
+db/cmp services services-initial.table
+db/cmp frontends frontends-initial.table
+db/cmp backends backends-initial.table
+
+lb/maps-dump lbmaps-reverted1.actual
+* cmp lbmaps-reverted1.actual lbmaps-reverted1.expected
+
+lrp/list lrp-empty.actual
+* cmp lrp-empty.actual lrp-empty.expected
+
+hive/stop
+
+###
+
+-- lrp-initial.table --
+Name   Type   Service   FrontendType   Frontends   BackendSelector
+-- lrp-tcp.table --
+Name           Type      Service             FrontendType
+test/lrp-tcp   service   test/http-service   svc-single-port
+-- lrp-udp.table --
+Name                  Type      Service             FrontendType
+test/lrp-mismatched   service   test/http-service   svc-single-port
+
+-- services-initial.table --
+Name                Source   PortNames                      TrafficPolicy   Flags
+test/http-service   k8s      dtls=443, http=80, https=443   Cluster
+-- services-lrp-tcp.table --
+Name                          Source   PortNames                      TrafficPolicy   Flags
+test/http-service             k8s      dtls=443, http=80, https=443   Cluster
+test/lrp-tcp:local-redirect   k8s                                     Cluster
+
+-- frontends-initial.table --
+Address                 Type        ServiceName         PortName   Backends              RedirectTo   Status
+192.168.10.10:80/TCP    ClusterIP   test/http-service   http       10.244.2.1:8080/TCP                Done
+192.168.10.10:443/TCP   ClusterIP   test/http-service   https      10.244.2.1:8443/TCP                Done
+192.168.10.10:443/UDP   ClusterIP   test/http-service   dtls       10.244.2.1:8443/UDP                Done
+[1001::1]:80/TCP        ClusterIP   test/http-service   http       [2001::1]:8080/TCP                 Done
+[1001::1]:443/TCP       ClusterIP   test/http-service   https      [2001::1]:8443/TCP                 Done
+[1001::1]:443/UDP       ClusterIP   test/http-service   dtls       [2001::1]:8443/UDP                 Done
+-- frontends-lrp-tcp.table --
+Address                 Type        ServiceName         PortName   Backends              RedirectTo                    Status
+192.168.10.10:80/TCP    ClusterIP   test/http-service   http       10.244.2.1:8080/TCP                                 Done
+192.168.10.10:443/TCP   ClusterIP   test/http-service   https      10.244.2.2:8444/TCP   test/lrp-tcp:local-redirect   Done
+192.168.10.10:443/UDP   ClusterIP   test/http-service   dtls       10.244.2.1:8443/UDP                                 Done
+[1001::1]:80/TCP        ClusterIP   test/http-service   http       [2001::1]:8080/TCP                                  Done
+[1001::1]:443/TCP       ClusterIP   test/http-service   https      [2001::2]:8444/TCP    test/lrp-tcp:local-redirect   Done
+[1001::1]:443/UDP       ClusterIP   test/http-service   dtls       [2001::1]:8443/UDP                                  Done
+
+-- backends-initial.table --
+Service             Address               Source   Priority   State    PortNames   NodeName
+test/http-service   10.244.2.1:8080/TCP   k8s      4          active   http        testnode
+test/http-service   10.244.2.1:8443/TCP   k8s      4          active   https       testnode
+test/http-service   10.244.2.1:8443/UDP   k8s      4          active   dtls        testnode
+test/http-service   [2001::1]:8080/TCP    k8s      4          active   http        testnode
+test/http-service   [2001::1]:8443/TCP    k8s      4          active   https       testnode
+test/http-service   [2001::1]:8443/UDP    k8s      4          active   dtls        testnode
+-- backends-lrp-tcp.table --
+Service                       Address               Source   Priority   State    PortNames   NodeName
+test/http-service             10.244.2.1:8080/TCP   k8s      4          active   http        testnode
+test/http-service             10.244.2.1:8443/TCP   k8s      4          active   https       testnode
+test/http-service             10.244.2.1:8443/UDP   k8s      4          active   dtls        testnode
+test/http-service             [2001::1]:8080/TCP    k8s      4          active   http        testnode
+test/http-service             [2001::1]:8443/TCP    k8s      4          active   https       testnode
+test/http-service             [2001::1]:8443/UDP    k8s      4          active   dtls        testnode
+test/lrp-tcp:local-redirect   10.244.2.2:8444/TCP   k8s      4          active
+test/lrp-tcp:local-redirect   [2001::2]:8444/TCP    k8s      4          active
+
+-- lbmaps-initial.expected --
+BE: ID=1 ADDR=10.244.2.1:8080/TCP STATE=active
+BE: ID=2 ADDR=10.244.2.1:8443/TCP STATE=active
+BE: ID=3 ADDR=10.244.2.1:8443/UDP STATE=active
+BE: ID=4 ADDR=[2001::1]:8080/TCP STATE=active
+BE: ID=5 ADDR=[2001::1]:8443/TCP STATE=active
+BE: ID=6 ADDR=[2001::1]:8443/UDP STATE=active
+REV: ID=1 ADDR=192.168.10.10:80
+REV: ID=2 ADDR=192.168.10.10:443
+REV: ID=3 ADDR=192.168.10.10:443
+REV: ID=4 ADDR=[1001::1]:80
+REV: ID=5 ADDR=[1001::1]:443
+REV: ID=6 ADDR=[1001::1]:443
+SVC: ID=0 ADDR=192.168.10.10:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=[1001::1]:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=192.168.10.10:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=192.168.10.10:443/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=192.168.10.10:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=192.168.10.10:443/UDP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=[1001::1]:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=[1001::1]:80/TCP SLOT=1 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=[1001::1]:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=[1001::1]:443/TCP SLOT=1 BEID=5 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=[1001::1]:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=[1001::1]:443/UDP SLOT=1 BEID=6 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- lbmaps-lrp-tcp.expected --
+BE: ID=1 ADDR=10.244.2.1:8080/TCP STATE=active
+BE: ID=3 ADDR=10.244.2.1:8443/UDP STATE=active
+BE: ID=4 ADDR=[2001::1]:8080/TCP STATE=active
+BE: ID=6 ADDR=[2001::1]:8443/UDP STATE=active
+BE: ID=7 ADDR=10.244.2.2:8444/TCP STATE=active
+BE: ID=8 ADDR=[2001::2]:8444/TCP STATE=active
+REV: ID=1 ADDR=192.168.10.10:80
+REV: ID=2 ADDR=192.168.10.10:443
+REV: ID=3 ADDR=192.168.10.10:443
+REV: ID=4 ADDR=[1001::1]:80
+REV: ID=5 ADDR=[1001::1]:443
+REV: ID=6 ADDR=[1001::1]:443
+SVC: ID=0 ADDR=192.168.10.10:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=[1001::1]:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=192.168.10.10:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=2 ADDR=192.168.10.10:443/TCP SLOT=1 BEID=7 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=3 ADDR=192.168.10.10:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=192.168.10.10:443/UDP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=[1001::1]:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=[1001::1]:80/TCP SLOT=1 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=[1001::1]:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=5 ADDR=[1001::1]:443/TCP SLOT=1 BEID=8 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=6 ADDR=[1001::1]:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=[1001::1]:443/UDP SLOT=1 BEID=6 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- lbmaps-reverted1.expected --
+BE: ID=1 ADDR=10.244.2.1:8080/TCP STATE=active
+BE: ID=10 ADDR=[2001::1]:8443/TCP STATE=active
+BE: ID=3 ADDR=10.244.2.1:8443/UDP STATE=active
+BE: ID=4 ADDR=[2001::1]:8080/TCP STATE=active
+BE: ID=6 ADDR=[2001::1]:8443/UDP STATE=active
+BE: ID=9 ADDR=10.244.2.1:8443/TCP STATE=active
+REV: ID=1 ADDR=192.168.10.10:80
+REV: ID=2 ADDR=192.168.10.10:443
+REV: ID=3 ADDR=192.168.10.10:443
+REV: ID=4 ADDR=[1001::1]:80
+REV: ID=5 ADDR=[1001::1]:443
+REV: ID=6 ADDR=[1001::1]:443
+SVC: ID=0 ADDR=192.168.10.10:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=[1001::1]:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=192.168.10.10:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=192.168.10.10:443/TCP SLOT=1 BEID=9 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=192.168.10.10:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=192.168.10.10:443/UDP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=[1001::1]:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=4 ADDR=[1001::1]:80/TCP SLOT=1 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=[1001::1]:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=[1001::1]:443/TCP SLOT=1 BEID=10 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=[1001::1]:443/UDP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=[1001::1]:443/UDP SLOT=1 BEID=6 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- lrp-tcp.expected --
+test/lrp-tcp type=svc frontend-type="clusterIP + port" service=test/http-service
+  192.168.10.10:443/TCP => 10.244.2.2:8444/TCP (test/http-backend2, active)
+  1001::1:443/TCP => 2001::2:8444/TCP (test/http-backend2, active)
+-- lrp-empty.expected --
+-- pod.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: http-backend1
+  namespace: test
+  labels:
+    app: nginx
+    app-type: web-service
+spec:
+  containers:
+    - name: backend1
+      image: nginx
+      # ports intentionally missing
+  nodeName: testnode
+status:
+  hostIP: 172.19.0.1
+  hostIPs:
+  - ip: 172.19.0.1
+  phase: Running
+  podIP: 10.244.2.1
+  podIPs:
+  - ip: 10.244.2.1
+  - ip: 2001::1
+  qosClass: BestEffort
+  conditions:
+  - lastProbeTime: null
+    status: "True"
+    type: Ready
+
+-- pod-single.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: http-backend2
+  namespace: test
+  labels:
+    app: nginx
+    app-type: alternate-web-service
+spec:
+  containers:
+    - name: backend2
+      image: nginx
+      # ports intentionally missing
+  nodeName: testnode
+status:
+  hostIP: 172.19.0.1
+  hostIPs:
+  - ip: 172.19.0.1
+  phase: Running
+  podIP: 10.244.2.2
+  podIPs:
+  - ip: 10.244.2.2
+  - ip: 2001::2
+  qosClass: BestEffort
+  conditions:
+  - lastProbeTime: null
+    status: "True"
+    type: Ready
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: http-service
+  namespace: test
+spec:
+  type: ClusterIP
+  selector:
+    app: nginx
+    app-type: web-service
+  clusterIP: 192.168.10.10
+  clusterIPs:
+  - 192.168.10.10
+  - 1001::1
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  - IPv6
+  ipFamilyPolicy: DualStack
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 8443
+  - name: dtls
+    port: 443
+    protocol: UDP
+    targetPort: 8443
+  sessionAffinity: None
+
+-- eps-v4.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: http-service
+  name: http-service-v4
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.2.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: testnode
+ports:
+- name: http
+  port: 8080
+  protocol: TCP
+- name: https
+  port: 8443
+  protocol: TCP
+- name: dtls
+  port: 8443
+  protocol: UDP
+
+-- eps-v6.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: http-service
+  name: http-service-v6
+  namespace: test
+addressType: IPv6
+endpoints:
+- addresses:
+  - 2001::1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: testnode
+ports:
+- name: http
+  port: 8080
+  protocol: TCP
+- name: https
+  port: 8443
+  protocol: TCP
+- name: dtls
+  port: 8443
+  protocol: UDP
+
+-- lrp-tcp.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: lrp-tcp
+  namespace: test
+spec:
+  redirectFrontend:
+    serviceMatcher:
+      serviceName: http-service
+      namespace: test
+      toPorts:
+      - name: "https"
+        port: "443"
+        protocol: TCP
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        app: nginx
+        app-type: alternate-web-service
+    toPorts:
+      - name: "https"
+        port: "8444"
+        protocol: TCP
+      - name: "dtls"
+        port: "8444"
+        protocol: UDP
+
+-- lrp-udp.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: lrp-udp
+  namespace: test
+spec:
+  redirectFrontend:
+    serviceMatcher:
+      serviceName: http-service
+      namespace: test
+      toPorts:
+      - name: "https"
+        port: "443"
+        protocol: UDP
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        app: nginx
+    toPorts:
+      - name: "https"
+        port: "8444"
+        # first port is intentionally set TCP
+        protocol: TCP
+      - name: "dtls"
+        port: "8444"
+        protocol: UDP

--- a/pkg/loadbalancer/redirectpolicy/testdata/service-matcher-single-port.txtar
+++ b/pkg/loadbalancer/redirectpolicy/testdata/service-matcher-single-port.txtar
@@ -1,0 +1,400 @@
+# Verify that single-port serviceMatcher correctly maps frontends first
+# with a matched port, and then with a mismatched port. The former should
+# succeed but the latter should not. In all cases, no names should be used
+# to map ports.
+
+hive start
+
+# Add pods, service and eps for both families
+k8s/add pod1.yaml pod2.yaml
+k8s/add service.yaml eps-v4.yaml eps-v6.yaml
+
+# Verify statedb tables
+db/cmp localredirectpolicies lrp-initial.table
+db/cmp services services-initial.table
+db/cmp frontends frontends-initial.table
+db/cmp backends backends-initial.table
+
+# Verify service maps
+lb/maps-dump lbmaps-initial.actual
+* cmp lbmaps-initial.actual lbmaps-initial.expected
+
+# Add the serviceMatcher LRP with a matched toPort[0].
+k8s/add lrp-matched.yaml
+
+# Verify the LRP mapped properly.
+db/cmp localredirectpolicies lrp-matched.table
+db/cmp services services-lrp-matched.table
+db/cmp frontends frontends-lrp-matched.table
+db/cmp backends backends-lrp-matched.table
+
+# Verify service maps
+lb/maps-dump lbmaps-lrp-matched.actual
+* cmp lbmaps-lrp-matched.actual lbmaps-lrp-matched.expected
+
+# Verify the REST API model output
+lrp/list lrp-matched.actual
+* cmp lrp-matched.actual lrp-matched.expected
+
+# Delete the serviceMatcher LRP with matching toPort[0].
+k8s/delete lrp-matched.yaml
+
+# Verify we return back to the initial state
+db/cmp localredirectpolicies lrp-initial.table
+db/cmp services services-initial.table
+db/cmp frontends frontends-initial.table
+db/cmp backends backends-initial.table
+
+lb/maps-dump lbmaps-reverted1.actual
+* cmp lbmaps-reverted1.actual lbmaps-reverted1.expected
+
+lrp/list lrp-empty.actual
+* cmp lrp-empty.actual lrp-empty.expected
+
+# Now we add the serviceMatcher LRP with a mismatched toPort[0].
+k8s/add lrp-mismatched.yaml
+
+# Verify the LRP failed to map to anything.
+db/cmp localredirectpolicies lrp-mismatched.table
+db/cmp services services-lrp-mismatched.table
+db/cmp frontends frontends-lrp-mismatched.table
+db/cmp backends backends-lrp-mismatched.table
+
+# Verify service maps
+lb/maps-dump lbmaps-lrp-mismatched.actual
+* cmp lbmaps-lrp-mismatched.actual lbmaps-lrp-mismatched.expected
+
+# Verify the REST API model output
+lrp/list lrp-mismatched.actual
+* cmp lrp-mismatched.actual lrp-mismatched.expected
+
+###
+
+-- lrp-initial.table --
+Name   Type   Service   FrontendType   Frontends   BackendSelector
+-- lrp-matched.table --
+Name               Type      Service             FrontendType
+test/lrp-matched   service   test/http-service   svc-single-port
+-- lrp-mismatched.table --
+Name                  Type      Service             FrontendType
+test/lrp-mismatched   service   test/http-service   svc-single-port
+
+-- services-initial.table --
+Name                Source   PortNames   TrafficPolicy   Flags
+test/http-service   k8s      http=80     Cluster
+-- services-lrp-matched.table --
+Name                              Source   PortNames   TrafficPolicy   Flags
+test/http-service                 k8s      http=80     Cluster
+test/lrp-matched:local-redirect   k8s                  Cluster
+-- services-lrp-mismatched.table --
+Name                                 Source   PortNames   TrafficPolicy   Flags
+test/http-service                    k8s      http=80     Cluster
+test/lrp-mismatched:local-redirect   k8s                  Cluster
+
+-- frontends-initial.table --
+Address                Type        ServiceName         PortName   Backends                                   RedirectTo   Status
+192.168.10.10:80/TCP   ClusterIP   test/http-service   http       10.244.2.1:8080/TCP, 10.244.2.2:8080/TCP                Done
+[1001::1]:80/TCP       ClusterIP   test/http-service   http       [2001::1]:8080/TCP, [2001::2]:8080/TCP                  Done
+-- frontends-lrp-matched.table --
+Address                Type        ServiceName         PortName   Backends              RedirectTo                        Status
+192.168.10.10:80/TCP   ClusterIP   test/http-service   http       10.244.2.1:8080/TCP   test/lrp-matched:local-redirect   Done
+[1001::1]:80/TCP       ClusterIP   test/http-service   http       [2001::1]:8080/TCP    test/lrp-matched:local-redirect   Done
+-- frontends-lrp-mismatched.table --
+Address                Type        ServiceName         PortName   Backends                                   RedirectTo   Status
+192.168.10.10:80/TCP   ClusterIP   test/http-service   http       10.244.2.1:8080/TCP, 10.244.2.2:8080/TCP                Done
+[1001::1]:80/TCP       ClusterIP   test/http-service   http       [2001::1]:8080/TCP, [2001::2]:8080/TCP                  Done
+
+-- backends-initial.table --
+Service             Address               Source   Priority   State    PortNames   NodeName
+test/http-service   10.244.2.1:8080/TCP   k8s      4          active   http        testnode
+test/http-service   10.244.2.2:8080/TCP   k8s      4          active   http        testnode2
+test/http-service   [2001::1]:8080/TCP    k8s      4          active   http        testnode
+test/http-service   [2001::2]:8080/TCP    k8s      4          active   http        testnode2
+-- backends-lrp-matched.table --
+Service                           Address               Source   Priority   State    PortNames   NodeName
+test/http-service                 10.244.2.1:8080/TCP   k8s      4          active   http        testnode
+test/http-service                 10.244.2.2:8080/TCP   k8s      4          active   http        testnode2
+test/http-service                 [2001::1]:8080/TCP    k8s      4          active   http        testnode
+test/http-service                 [2001::2]:8080/TCP    k8s      4          active   http        testnode2
+test/lrp-matched:local-redirect   10.244.2.1:8080/TCP   k8s      4          active
+test/lrp-matched:local-redirect   [2001::1]:8080/TCP    k8s      4          active
+-- backends-lrp-mismatched.table --
+Service                              Address               Source   Priority   State    PortNames   NodeName
+test/http-service                    10.244.2.1:8080/TCP   k8s      4          active   http        testnode
+test/http-service                    10.244.2.2:8080/TCP   k8s      4          active   http        testnode2
+test/http-service                    [2001::1]:8080/TCP    k8s      4          active   http        testnode
+test/http-service                    [2001::2]:8080/TCP    k8s      4          active   http        testnode2
+test/lrp-mismatched:local-redirect   10.244.2.1:8080/TCP   k8s      4          active
+test/lrp-mismatched:local-redirect   [2001::1]:8080/TCP    k8s      4          active
+
+-- lbmaps-initial.expected --
+BE: ID=1 ADDR=10.244.2.1:8080/TCP STATE=active
+BE: ID=2 ADDR=10.244.2.2:8080/TCP STATE=active
+BE: ID=3 ADDR=[2001::1]:8080/TCP STATE=active
+BE: ID=4 ADDR=[2001::2]:8080/TCP STATE=active
+REV: ID=1 ADDR=192.168.10.10:80
+REV: ID=2 ADDR=[1001::1]:80
+SVC: ID=0 ADDR=192.168.10.10:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=[1001::1]:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=[1001::1]:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=[1001::1]:80/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=[1001::1]:80/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- lbmaps-lrp-matched.expected --
+BE: ID=1 ADDR=10.244.2.1:8080/TCP STATE=active
+BE: ID=3 ADDR=[2001::1]:8080/TCP STATE=active
+REV: ID=1 ADDR=192.168.10.10:80
+REV: ID=2 ADDR=[1001::1]:80
+SVC: ID=0 ADDR=192.168.10.10:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=[1001::1]:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=2 ADDR=[1001::1]:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=LocalRedirect
+SVC: ID=2 ADDR=[1001::1]:80/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=LocalRedirect
+-- lbmaps-reverted1.expected --
+BE: ID=1 ADDR=10.244.2.1:8080/TCP STATE=active
+BE: ID=3 ADDR=[2001::1]:8080/TCP STATE=active
+BE: ID=5 ADDR=10.244.2.2:8080/TCP STATE=active
+BE: ID=6 ADDR=[2001::2]:8080/TCP STATE=active
+REV: ID=1 ADDR=192.168.10.10:80
+REV: ID=2 ADDR=[1001::1]:80
+SVC: ID=0 ADDR=192.168.10.10:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=[1001::1]:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=2 BEID=5 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=[1001::1]:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=[1001::1]:80/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=[1001::1]:80/TCP SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- lbmaps-lrp-mismatched.expected --
+BE: ID=1 ADDR=10.244.2.1:8080/TCP STATE=active
+BE: ID=3 ADDR=[2001::1]:8080/TCP STATE=active
+BE: ID=5 ADDR=10.244.2.2:8080/TCP STATE=active
+BE: ID=6 ADDR=[2001::2]:8080/TCP STATE=active
+REV: ID=1 ADDR=192.168.10.10:80
+REV: ID=2 ADDR=[1001::1]:80
+SVC: ID=0 ADDR=192.168.10.10:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=[1001::1]:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=192.168.10.10:80/TCP SLOT=2 BEID=5 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=[1001::1]:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=[1001::1]:80/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=[1001::1]:80/TCP SLOT=2 BEID=6 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- lrp-matched.expected --
+test/lrp-matched type=svc frontend-type="clusterIP + port" service=test/http-service
+  192.168.10.10:80/TCP => 10.244.2.1:8080/TCP (test/http-backend1, active)
+  1001::1:80/TCP => 2001::1:8080/TCP (test/http-backend1, active)
+-- lrp-mismatched.expected --
+test/lrp-mismatched type=svc frontend-type="clusterIP + port" service=test/http-service
+-- lrp-empty.expected --
+-- pod1.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: http-backend1
+  namespace: test
+  labels:
+    app: nginx
+spec:
+  containers:
+    - name: backend1
+      image: nginx
+      ports:
+        - containerPort: 8080
+          # name intentionally mismatched
+          name: telnet
+          protocol: TCP
+  nodeName: testnode
+status:
+  hostIP: 172.19.0.1
+  hostIPs:
+  - ip: 172.19.0.1
+  phase: Running
+  podIP: 10.244.2.1
+  podIPs:
+  - ip: 10.244.2.1
+  - ip: 2001::1
+  qosClass: BestEffort
+  conditions:
+  - lastProbeTime: null
+    status: "True"
+    type: Ready
+
+-- pod2.yaml --
+apiVersion: v1
+kind: Pod
+metadata:
+  name: http-backend2
+  namespace: test
+  labels:
+    app: nginx
+spec:
+  containers:
+    - name: backend2
+      image: nginx
+      ports:
+        - containerPort: 8080
+          # name intentionally mismatched
+          name: telnet
+          protocol: TCP
+  nodeName: testnode2
+status:
+  hostIP: 172.19.0.2
+  hostIPs:
+  - ip: 172.19.0.2
+  phase: Running
+  podIP: 10.244.2.2
+  podIPs:
+  - ip: 10.244.2.2
+  - ip: 2001::2
+  qosClass: BestEffort
+  conditions:
+  - lastProbeTime: null
+    status: "True"
+    type: Ready
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: http-service
+  namespace: test
+spec:
+  type: ClusterIP
+  selector:
+    app: nginx
+  clusterIP: 192.168.10.10
+  clusterIPs:
+  - 192.168.10.10
+  - 1001::1
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  - IPv6
+  ipFamilyPolicy: DualStack
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  sessionAffinity: None
+
+-- eps-v4.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: http-service
+  name: http-service-v4
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.2.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: testnode
+- addresses:
+  - 10.244.2.2
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: testnode2
+ports:
+- name: http
+  port: 8080
+  protocol: TCP
+
+-- eps-v6.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: http-service
+  name: http-service-v6
+  namespace: test
+addressType: IPv6
+endpoints:
+- addresses:
+  - 2001::1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: testnode
+- addresses:
+  - 2001::2
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: testnode2
+ports:
+- name: http
+  port: 8080
+  protocol: TCP
+
+-- lrp-matched.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: lrp-matched
+  namespace: test
+spec:
+  redirectFrontend:
+    serviceMatcher:
+      serviceName: http-service
+      namespace: test
+      toPorts:
+      # name intentionally mismatched
+      - name: "telnet"
+        # http port matched to the service port
+        port: "80"
+        protocol: TCP
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        app: nginx
+    toPorts:
+      - name: "http"
+        port: "8080"
+        protocol: TCP
+      - name: "https"
+        port: "8443"
+        protocol: TCP
+
+-- lrp-mismatched.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumLocalRedirectPolicy
+metadata:
+  name: lrp-mismatched
+  namespace: test
+spec:
+  redirectFrontend:
+    serviceMatcher:
+      serviceName: http-service
+      namespace: test
+      toPorts:
+      # name intentionally mismatched
+      - name: "telnet"
+        # port intentionally mismatched
+        port: "23"
+        protocol: TCP
+  redirectBackend:
+    localEndpointSelector:
+      matchLabels:
+        app: nginx
+    toPorts:
+      - name: "http"
+        port: "8080"
+        protocol: TCP
+      - name: "https"
+        port: "8443"
+        protocol: TCP

--- a/pkg/loadbalancer/writer/writer.go
+++ b/pkg/loadbalancer/writer/writer.go
@@ -421,10 +421,7 @@ func matchesFrontend(be *loadbalancer.Backend, fe *loadbalancer.Frontend) bool {
 	if fe == nil {
 		return true
 	}
-	if fe.Address.Protocol() != be.Address.Protocol() {
-		return false
-	}
-	if be.Address.IsIPv6() != fe.Address.IsIPv6() {
+	if !be.Address.Compatible(fe.Address) {
 		return false
 	}
 	if fe.PortName != "" && len(be.PortNames) > 0 {

--- a/pkg/loadbalancer/writer/writer.go
+++ b/pkg/loadbalancer/writer/writer.go
@@ -443,10 +443,7 @@ func matchesFrontend(be *loadbalancer.Backend, fe *loadbalancer.Frontend) bool {
 	if fe == nil {
 		return true
 	}
-	if fe.Address.Protocol() != be.Address.Protocol() {
-		return false
-	}
-	if be.Address.IsIPv6() != fe.Address.IsIPv6() {
+	if !be.Address.Compatible(fe.Address) {
 		return false
 	}
 	if fe.PortName != "" && len(be.PortNames) > 0 {


### PR DESCRIPTION
Commit 1 introduces fixes into the LRP API handler to properly render LRP frontend and backend pod mapping. The write-up and before/after examples are provided in the commit log.

Commit 2 introduces a new `lrp/list` command into script test apparatus so we can verify API output in testing.

Commit 3 introduces fixes into the LRP control plane to align behaviour to that of Cilium v1.17. The work primarily affects single-port serviceMatcher LRPs.

These commits (if approved) will require back-porting to Cilium v1.18 and v1.19.

Fixes: #43944
Fixes: #43929

CC: @ysksuzuki 

AIL: 1 (upgraded from 0 following introduction of testing)