### PR TITLE
Mark terminating Envoy backends as DRAINING

### DIFF
--- a/pkg/ciliumenvoyconfig/controller.go
+++ b/pkg/ciliumenvoyconfig/controller.go
@@ -419,8 +419,8 @@ func computeLoadAssignments(
 		}
 	}
 
-	// Keep track of number of active and terminating backends and only use
-	// terminating backends if active are not available.
+	// Keep track of number of active backends. Terminating backends are included
+	// as DRAINING when active backends exist, or as fallbacks when they do not.
 	numActive, numTerminating := 0, 0
 
 	for be := range backends {
@@ -492,10 +492,6 @@ func computeLoadAssignments(
 		var lbEndpoints []*envoy_config_endpoint.LbEndpoint
 		for _, addr := range slices.Sorted(maps.Keys(bes)) {
 			be := bes[addr]
-			if numActive != 0 && be.State == loadbalancer.BackendStateTerminating {
-				// We can skip terminating backends since active backends exist.
-				continue
-			}
 
 			// The below is to make sure that UDP and SCTP are not allowed instead of comparing with lb.TCP
 			// The reason is to avoid extra dependencies with ongoing work to differentiate protocols in datapath,
@@ -504,7 +500,7 @@ func computeLoadAssignments(
 				continue
 			}
 
-			lbEndpoints = append(lbEndpoints, &envoy_config_endpoint.LbEndpoint{
+			lbEp := &envoy_config_endpoint.LbEndpoint{
 				HostIdentifier: &envoy_config_endpoint.LbEndpoint_Endpoint{
 					Endpoint: &envoy_config_endpoint.Endpoint{
 						Address: &envoy_config_core.Address{
@@ -519,7 +515,15 @@ func computeLoadAssignments(
 						},
 					},
 				},
-			})
+			}
+			if be.State == loadbalancer.BackendStateTerminating && numActive > 0 {
+				// Keep terminating backends in the EDS set as DRAINING so Envoy
+				// stops sending new connections while allowing in-flight requests
+				// to complete. Hard-removing them causes immediate connection
+				// resets on endpoint churn.
+				lbEp.HealthStatus = envoy_config_core.HealthStatus_DRAINING
+			}
+			lbEndpoints = append(lbEndpoints, lbEp)
 		}
 
 		endpoints := []*envoy_config_endpoint.LocalityLbEndpoints{{LbEndpoints: lbEndpoints}}

--- a/pkg/ciliumenvoyconfig/controller.go
+++ b/pkg/ciliumenvoyconfig/controller.go
@@ -464,8 +464,8 @@ func computeLoadAssignments(
 		}
 	}
 
-	// Keep track of number of active and terminating backends and only use
-	// terminating backends if active are not available.
+	// Keep track of number of active backends. Terminating backends are included
+	// as DRAINING when active backends exist, or as fallbacks when they do not.
 	numActive, numTerminating := 0, 0
 
 	for be := range backends {
@@ -537,10 +537,6 @@ func computeLoadAssignments(
 		var lbEndpoints []*envoy_config_endpoint.LbEndpoint
 		for _, addr := range slices.Sorted(maps.Keys(bes)) {
 			be := bes[addr]
-			if numActive != 0 && be.State == loadbalancer.BackendStateTerminating {
-				// We can skip terminating backends since active backends exist.
-				continue
-			}
 
 			// The below is to make sure that UDP and SCTP are not allowed instead of comparing with lb.TCP
 			// The reason is to avoid extra dependencies with ongoing work to differentiate protocols in datapath,
@@ -549,7 +545,7 @@ func computeLoadAssignments(
 				continue
 			}
 
-			lbEndpoints = append(lbEndpoints, &envoy_config_endpoint.LbEndpoint{
+			lbEp := &envoy_config_endpoint.LbEndpoint{
 				HostIdentifier: &envoy_config_endpoint.LbEndpoint_Endpoint{
 					Endpoint: &envoy_config_endpoint.Endpoint{
 						Address: &envoy_config_core.Address{
@@ -564,7 +560,15 @@ func computeLoadAssignments(
 						},
 					},
 				},
-			})
+			}
+			if be.State == loadbalancer.BackendStateTerminating && numActive > 0 {
+				// Keep terminating backends in the EDS set as DRAINING so Envoy
+				// stops sending new connections while allowing in-flight requests
+				// to complete. Hard-removing them causes immediate connection
+				// resets on endpoint churn.
+				lbEp.HealthStatus = envoy_config_core.HealthStatus_DRAINING
+			}
+			lbEndpoints = append(lbEndpoints, lbEp)
 		}
 
 		endpoints := []*envoy_config_endpoint.LocalityLbEndpoints{{LbEndpoints: lbEndpoints}}

--- a/pkg/ciliumenvoyconfig/controller_test.go
+++ b/pkg/ciliumenvoyconfig/controller_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumenvoyconfig
+
+import (
+	"testing"
+
+	envoy_config_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+)
+
+func backend(addr string, port uint16, state loadbalancer.BackendState) *loadbalancer.Backend {
+	return &loadbalancer.Backend{
+		Address: loadbalancer.NewL3n4Addr(
+			loadbalancer.TCP,
+			cmtypes.MustParseAddrCluster(addr),
+			port,
+			loadbalancer.ScopeExternal,
+		),
+		PortNames: []string{"http"},
+		State:     state,
+	}
+}
+
+func TestComputeLoadAssignmentsDraining(t *testing.T) {
+	svcName := loadbalancer.NewServiceName("test", "echo")
+	clusterRefs := clusterReferences{
+		{
+			CECName:   CECName{Namespace: "test", Name: "envoy-lb-listener"},
+			PortNames: sets.New("80"),
+		},
+	}
+	portNames := map[string]uint16{"http": 80}
+
+	t.Run("terminating backend marked DRAINING when active backends exist", func(t *testing.T) {
+		backends := func(yield func(*loadbalancer.Backend, uint64) bool) {
+			yield(backend("10.244.1.1", 8080, loadbalancer.BackendStateTerminating), 0)
+			yield(backend("10.244.1.2", 8080, loadbalancer.BackendStateActive), 0)
+		}
+
+		assignments := computeLoadAssignments(svcName, clusterRefs, portNames, backends)
+		require.Len(t, assignments, 1)
+
+		lbEndpoints := assignments[0].Endpoints[0].LbEndpoints
+		require.Len(t, lbEndpoints, 2)
+
+		statusByAddr := map[string]envoy_config_core.HealthStatus{}
+		for _, lep := range lbEndpoints {
+			addr := lep.GetEndpoint().GetAddress().GetSocketAddress().GetAddress()
+			statusByAddr[addr] = lep.GetHealthStatus()
+		}
+
+		require.Equal(t, envoy_config_core.HealthStatus_DRAINING, statusByAddr["10.244.1.1"])
+		require.Equal(t, envoy_config_core.HealthStatus_UNKNOWN, statusByAddr["10.244.1.2"])
+	})
+
+	t.Run("terminating backends used as fallback without DRAINING", func(t *testing.T) {
+		backends := func(yield func(*loadbalancer.Backend, uint64) bool) {
+			yield(backend("10.244.1.1", 8080, loadbalancer.BackendStateTerminating), 0)
+			yield(backend("10.244.1.2", 8080, loadbalancer.BackendStateTerminating), 0)
+		}
+
+		assignments := computeLoadAssignments(svcName, clusterRefs, portNames, backends)
+		require.Len(t, assignments, 1)
+
+		for _, lep := range assignments[0].Endpoints[0].LbEndpoints {
+			require.Equal(t, envoy_config_core.HealthStatus_UNKNOWN, lep.GetHealthStatus())
+		}
+	})
+}

--- a/pkg/ciliumenvoyconfig/controller_test.go
+++ b/pkg/ciliumenvoyconfig/controller_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	envoy_config_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_config_endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -15,16 +16,32 @@ import (
 )
 
 func backend(addr string, port uint16, state loadbalancer.BackendState) *loadbalancer.Backend {
+	return backendWith(addr, port, loadbalancer.TCP, state, []string{"http"})
+}
+
+func backendWith(addr string, port uint16, proto loadbalancer.L4Type, state loadbalancer.BackendState, portNames []string) *loadbalancer.Backend {
 	return &loadbalancer.Backend{
 		Address: loadbalancer.NewL3n4Addr(
-			loadbalancer.TCP,
+			proto,
 			cmtypes.MustParseAddrCluster(addr),
 			port,
 			loadbalancer.ScopeExternal,
 		),
-		PortNames: []string{"http"},
+		PortNames: portNames,
 		State:     state,
 	}
+}
+
+func healthByAddr(t *testing.T, assignments []*envoy_config_endpoint.ClusterLoadAssignment) map[string]envoy_config_core.HealthStatus {
+	t.Helper()
+	require.NotEmpty(t, assignments)
+	require.NotEmpty(t, assignments[0].Endpoints)
+	statusByAddr := map[string]envoy_config_core.HealthStatus{}
+	for _, lep := range assignments[0].Endpoints[0].LbEndpoints {
+		addr := lep.GetEndpoint().GetAddress().GetSocketAddress().GetAddress()
+		statusByAddr[addr] = lep.GetHealthStatus()
+	}
+	return statusByAddr
 }
 
 func TestComputeLoadAssignmentsDraining(t *testing.T) {
@@ -37,6 +54,22 @@ func TestComputeLoadAssignmentsDraining(t *testing.T) {
 	}
 	portNames := map[string]uint16{"http": 80}
 
+	t.Run("only active backends stay healthy", func(t *testing.T) {
+		backends := func(yield func(*loadbalancer.Backend, uint64) bool) {
+			yield(backend("10.244.1.1", 8080, loadbalancer.BackendStateActive), 0)
+			yield(backend("10.244.1.2", 8080, loadbalancer.BackendStateActive), 0)
+		}
+
+		assignments := computeLoadAssignments(svcName, clusterRefs, portNames, backends)
+		require.Len(t, assignments, 1)
+		require.Equal(t, "test/echo:80", assignments[0].ClusterName)
+
+		statusByAddr := healthByAddr(t, assignments)
+		require.Len(t, statusByAddr, 2)
+		require.Equal(t, envoy_config_core.HealthStatus_UNKNOWN, statusByAddr["10.244.1.1"])
+		require.Equal(t, envoy_config_core.HealthStatus_UNKNOWN, statusByAddr["10.244.1.2"])
+	})
+
 	t.Run("terminating backend marked DRAINING when active backends exist", func(t *testing.T) {
 		backends := func(yield func(*loadbalancer.Backend, uint64) bool) {
 			yield(backend("10.244.1.1", 8080, loadbalancer.BackendStateTerminating), 0)
@@ -46,17 +79,27 @@ func TestComputeLoadAssignmentsDraining(t *testing.T) {
 		assignments := computeLoadAssignments(svcName, clusterRefs, portNames, backends)
 		require.Len(t, assignments, 1)
 
-		lbEndpoints := assignments[0].Endpoints[0].LbEndpoints
-		require.Len(t, lbEndpoints, 2)
-
-		statusByAddr := map[string]envoy_config_core.HealthStatus{}
-		for _, lep := range lbEndpoints {
-			addr := lep.GetEndpoint().GetAddress().GetSocketAddress().GetAddress()
-			statusByAddr[addr] = lep.GetHealthStatus()
-		}
-
+		statusByAddr := healthByAddr(t, assignments)
+		require.Len(t, statusByAddr, 2)
 		require.Equal(t, envoy_config_core.HealthStatus_DRAINING, statusByAddr["10.244.1.1"])
 		require.Equal(t, envoy_config_core.HealthStatus_UNKNOWN, statusByAddr["10.244.1.2"])
+	})
+
+	t.Run("multiple terminating backends marked DRAINING when active backends exist", func(t *testing.T) {
+		backends := func(yield func(*loadbalancer.Backend, uint64) bool) {
+			yield(backend("10.244.1.1", 8080, loadbalancer.BackendStateTerminating), 0)
+			yield(backend("10.244.1.2", 8080, loadbalancer.BackendStateTerminating), 0)
+			yield(backend("10.244.1.3", 8080, loadbalancer.BackendStateActive), 0)
+			yield(backend("10.244.1.4", 8080, loadbalancer.BackendStateActive), 0)
+		}
+
+		assignments := computeLoadAssignments(svcName, clusterRefs, portNames, backends)
+		statusByAddr := healthByAddr(t, assignments)
+		require.Len(t, statusByAddr, 4)
+		require.Equal(t, envoy_config_core.HealthStatus_DRAINING, statusByAddr["10.244.1.1"])
+		require.Equal(t, envoy_config_core.HealthStatus_DRAINING, statusByAddr["10.244.1.2"])
+		require.Equal(t, envoy_config_core.HealthStatus_UNKNOWN, statusByAddr["10.244.1.3"])
+		require.Equal(t, envoy_config_core.HealthStatus_UNKNOWN, statusByAddr["10.244.1.4"])
 	})
 
 	t.Run("terminating backends used as fallback without DRAINING", func(t *testing.T) {
@@ -68,8 +111,183 @@ func TestComputeLoadAssignmentsDraining(t *testing.T) {
 		assignments := computeLoadAssignments(svcName, clusterRefs, portNames, backends)
 		require.Len(t, assignments, 1)
 
-		for _, lep := range assignments[0].Endpoints[0].LbEndpoints {
-			require.Equal(t, envoy_config_core.HealthStatus_UNKNOWN, lep.GetHealthStatus())
+		statusByAddr := healthByAddr(t, assignments)
+		require.Len(t, statusByAddr, 2)
+		for _, status := range statusByAddr {
+			require.Equal(t, envoy_config_core.HealthStatus_UNKNOWN, status)
 		}
+	})
+
+	t.Run("single terminating backend used as fallback without DRAINING", func(t *testing.T) {
+		backends := func(yield func(*loadbalancer.Backend, uint64) bool) {
+			yield(backend("10.244.1.1", 8080, loadbalancer.BackendStateTerminating), 0)
+		}
+
+		assignments := computeLoadAssignments(svcName, clusterRefs, portNames, backends)
+		statusByAddr := healthByAddr(t, assignments)
+		require.Len(t, statusByAddr, 1)
+		require.Equal(t, envoy_config_core.HealthStatus_UNKNOWN, statusByAddr["10.244.1.1"])
+	})
+
+	t.Run("quarantined and maintenance backends are skipped", func(t *testing.T) {
+		backends := func(yield func(*loadbalancer.Backend, uint64) bool) {
+			yield(backend("10.244.1.1", 8080, loadbalancer.BackendStateActive), 0)
+			yield(backend("10.244.1.2", 8080, loadbalancer.BackendStateQuarantined), 0)
+			yield(backend("10.244.1.3", 8080, loadbalancer.BackendStateMaintenance), 0)
+			yield(backend("10.244.1.4", 8080, loadbalancer.BackendStateTerminatingNotServing), 0)
+		}
+
+		assignments := computeLoadAssignments(svcName, clusterRefs, portNames, backends)
+		statusByAddr := healthByAddr(t, assignments)
+		require.Len(t, statusByAddr, 1)
+		require.Equal(t, envoy_config_core.HealthStatus_UNKNOWN, statusByAddr["10.244.1.1"])
+	})
+
+	t.Run("quarantined backends do not count as active for DRAINING", func(t *testing.T) {
+		backends := func(yield func(*loadbalancer.Backend, uint64) bool) {
+			yield(backend("10.244.1.1", 8080, loadbalancer.BackendStateTerminating), 0)
+			yield(backend("10.244.1.2", 8080, loadbalancer.BackendStateQuarantined), 0)
+		}
+
+		assignments := computeLoadAssignments(svcName, clusterRefs, portNames, backends)
+		statusByAddr := healthByAddr(t, assignments)
+		require.Len(t, statusByAddr, 1)
+		// Quarantined is skipped, so terminating is a fallback (not DRAINING).
+		require.Equal(t, envoy_config_core.HealthStatus_UNKNOWN, statusByAddr["10.244.1.1"])
+	})
+
+	t.Run("mixed active terminating and quarantined", func(t *testing.T) {
+		backends := func(yield func(*loadbalancer.Backend, uint64) bool) {
+			yield(backend("10.244.1.1", 8080, loadbalancer.BackendStateActive), 0)
+			yield(backend("10.244.1.2", 8080, loadbalancer.BackendStateTerminating), 0)
+			yield(backend("10.244.1.3", 8080, loadbalancer.BackendStateQuarantined), 0)
+			yield(backend("10.244.1.4", 8080, loadbalancer.BackendStateMaintenance), 0)
+		}
+
+		assignments := computeLoadAssignments(svcName, clusterRefs, portNames, backends)
+		statusByAddr := healthByAddr(t, assignments)
+		require.Len(t, statusByAddr, 2)
+		require.Equal(t, envoy_config_core.HealthStatus_UNKNOWN, statusByAddr["10.244.1.1"])
+		require.Equal(t, envoy_config_core.HealthStatus_DRAINING, statusByAddr["10.244.1.2"])
+		_, hasQuarantined := statusByAddr["10.244.1.3"]
+		_, hasMaintenance := statusByAddr["10.244.1.4"]
+		require.False(t, hasQuarantined)
+		require.False(t, hasMaintenance)
+	})
+
+	t.Run("empty backends produce no assignments", func(t *testing.T) {
+		backends := func(yield func(*loadbalancer.Backend, uint64) bool) {}
+
+		assignments := computeLoadAssignments(svcName, clusterRefs, portNames, backends)
+		require.Empty(t, assignments)
+	})
+
+	t.Run("UDP and SCTP backends are skipped", func(t *testing.T) {
+		backends := func(yield func(*loadbalancer.Backend, uint64) bool) {
+			yield(backendWith("10.244.1.1", 8080, loadbalancer.TCP, loadbalancer.BackendStateActive, []string{"http"}), 0)
+			yield(backendWith("10.244.1.2", 8080, loadbalancer.UDP, loadbalancer.BackendStateActive, []string{"http"}), 0)
+			yield(backendWith("10.244.1.3", 8080, loadbalancer.SCTP, loadbalancer.BackendStateActive, []string{"http"}), 0)
+		}
+
+		assignments := computeLoadAssignments(svcName, clusterRefs, portNames, backends)
+		statusByAddr := healthByAddr(t, assignments)
+		require.Len(t, statusByAddr, 1)
+		require.Equal(t, envoy_config_core.HealthStatus_UNKNOWN, statusByAddr["10.244.1.1"])
+	})
+
+	t.Run("backends with unmatched port names are excluded", func(t *testing.T) {
+		backends := func(yield func(*loadbalancer.Backend, uint64) bool) {
+			yield(backendWith("10.244.1.1", 8080, loadbalancer.TCP, loadbalancer.BackendStateActive, []string{"http"}), 0)
+			yield(backendWith("10.244.1.2", 8080, loadbalancer.TCP, loadbalancer.BackendStateActive, []string{"grpc"}), 0)
+			yield(backendWith("10.244.1.3", 8080, loadbalancer.TCP, loadbalancer.BackendStateTerminating, []string{"metrics"}), 0)
+		}
+
+		assignments := computeLoadAssignments(svcName, clusterRefs, portNames, backends)
+		statusByAddr := healthByAddr(t, assignments)
+		require.Len(t, statusByAddr, 1)
+		require.Equal(t, envoy_config_core.HealthStatus_UNKNOWN, statusByAddr["10.244.1.1"])
+	})
+
+	t.Run("backends match ports by service port number", func(t *testing.T) {
+		refsByNumber := clusterReferences{
+			{
+				CECName:   CECName{Namespace: "test", Name: "envoy-lb-listener"},
+				PortNames: sets.New("80"),
+			},
+		}
+		backends := func(yield func(*loadbalancer.Backend, uint64) bool) {
+			// Port name "http" maps to 80 in portNames, and refs filter by "80".
+			yield(backendWith("10.244.1.1", 8080, loadbalancer.TCP, loadbalancer.BackendStateActive, []string{"http"}), 0)
+			yield(backendWith("10.244.1.2", 8080, loadbalancer.TCP, loadbalancer.BackendStateTerminating, []string{"http"}), 0)
+		}
+
+		assignments := computeLoadAssignments(svcName, refsByNumber, portNames, backends)
+		statusByAddr := healthByAddr(t, assignments)
+		require.Len(t, statusByAddr, 2)
+		require.Equal(t, envoy_config_core.HealthStatus_UNKNOWN, statusByAddr["10.244.1.1"])
+		require.Equal(t, envoy_config_core.HealthStatus_DRAINING, statusByAddr["10.244.1.2"])
+	})
+
+	t.Run("nameless backends match nameless service ports", func(t *testing.T) {
+		refsByNumber := clusterReferences{
+			{
+				CECName:   CECName{Namespace: "test", Name: "envoy-lb-listener"},
+				PortNames: sets.New("80"),
+			},
+		}
+		namelessPorts := map[string]uint16{"": 80}
+		backends := func(yield func(*loadbalancer.Backend, uint64) bool) {
+			yield(backendWith("10.244.1.1", 8080, loadbalancer.TCP, loadbalancer.BackendStateActive, nil), 0)
+			yield(backendWith("10.244.1.2", 8080, loadbalancer.TCP, loadbalancer.BackendStateTerminating, nil), 0)
+		}
+
+		assignments := computeLoadAssignments(svcName, refsByNumber, namelessPorts, backends)
+		statusByAddr := healthByAddr(t, assignments)
+		require.Len(t, statusByAddr, 2)
+		require.Equal(t, envoy_config_core.HealthStatus_UNKNOWN, statusByAddr["10.244.1.1"])
+		require.Equal(t, envoy_config_core.HealthStatus_DRAINING, statusByAddr["10.244.1.2"])
+	})
+
+	t.Run("any port publishes service-named assignment", func(t *testing.T) {
+		anyPortRefs := clusterReferences{
+			{
+				CECName:   CECName{Namespace: "test", Name: "envoy-lb-listener"},
+				PortNames: sets.New[string](),
+			},
+		}
+		backends := func(yield func(*loadbalancer.Backend, uint64) bool) {
+			yield(backend("10.244.1.1", 8080, loadbalancer.BackendStateActive), 0)
+			yield(backend("10.244.1.2", 8080, loadbalancer.BackendStateTerminating), 0)
+		}
+
+		assignments := computeLoadAssignments(svcName, anyPortRefs, portNames, backends)
+		require.Len(t, assignments, 2)
+		require.Equal(t, "test/echo:*", assignments[0].ClusterName)
+		require.Equal(t, "test/echo", assignments[1].ClusterName)
+
+		for _, assignment := range assignments {
+			statusByAddr := map[string]envoy_config_core.HealthStatus{}
+			for _, lep := range assignment.Endpoints[0].LbEndpoints {
+				addr := lep.GetEndpoint().GetAddress().GetSocketAddress().GetAddress()
+				statusByAddr[addr] = lep.GetHealthStatus()
+			}
+			require.Len(t, statusByAddr, 2)
+			require.Equal(t, envoy_config_core.HealthStatus_UNKNOWN, statusByAddr["10.244.1.1"])
+			require.Equal(t, envoy_config_core.HealthStatus_DRAINING, statusByAddr["10.244.1.2"])
+		}
+	})
+
+	t.Run("endpoint address and port are preserved", func(t *testing.T) {
+		backends := func(yield func(*loadbalancer.Backend, uint64) bool) {
+			yield(backend("10.244.1.1", 8080, loadbalancer.BackendStateActive), 0)
+		}
+
+		assignments := computeLoadAssignments(svcName, clusterRefs, portNames, backends)
+		require.Len(t, assignments, 1)
+		lep := assignments[0].Endpoints[0].LbEndpoints[0]
+		sock := lep.GetEndpoint().GetAddress().GetSocketAddress()
+		require.Equal(t, "10.244.1.1", sock.GetAddress())
+		require.Equal(t, uint32(8080), sock.GetPortValue())
+		require.Equal(t, envoy_config_core.HealthStatus_UNKNOWN, lep.GetHealthStatus())
 	})
 }

--- a/pkg/ciliumenvoyconfig/testdata/terminating.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/terminating.txtar
@@ -1,5 +1,6 @@
-# Terminating backends should be synced towards Envoy only when no active backends
-# are available.
+# Terminating backends are synced towards Envoy with DRAINING health status when
+# active backends exist so in-flight connections drain gracefully. When no active
+# backends are available terminating backends are used as fallbacks without DRAINING.
 
 # Start the hive and wait for tables to be synchronized before adding k8s objects.
 hive start
@@ -21,8 +22,8 @@ db/cmp envoy-resources envoy-resources.table
 db/cmp services services_redirected.table
 db/cmp frontends frontends.table
 
-# Mark one backend as terminating. Only 10.244.1.2 should now be
-# pushed to Envoy.
+# Mark one backend as terminating. Both backends should still be pushed to
+# Envoy, with the terminating one marked as DRAINING.
 k8s/update endpointslice-1-terminating.yaml
 db/cmp backends backends-1-terminating.table
 db/cmp envoy-resources envoy-resources-1-terminating.table
@@ -73,9 +74,9 @@ cec:test/envoy-lb-listener      test/envoy-lb-listener/envoy-lb-listener        
 
 
 -- envoy-resources-1-terminating.table --
-Name                            Listeners                                  Endpoints                    References             Status   Error
-backendsync:test/echo                                                      test/echo:80: 10.244.1.2     test/envoy-lb-listener Done     
-cec:test/envoy-lb-listener      test/envoy-lb-listener/envoy-lb-listener                                                       Done     
+Name                            Listeners                                  Endpoints                            References             Status   Error
+backendsync:test/echo                                                      test/echo:80: 10.244.1.1, 10.244.1.2 test/envoy-lb-listener Done
+cec:test/envoy-lb-listener      test/envoy-lb-listener/envoy-lb-listener                                                               Done
 
 -- cec.yaml --
 apiVersion: cilium.io/v2


### PR DESCRIPTION
Fix connection resets on L7 load-balancing when backends enter terminating state.

When active backends exist, Cilium previously removed terminating backends
from the Envoy EDS ClusterLoadAssignment. Envoy then immediately closed
connections to those hosts on endpoint churn, surfacing as upstream resets
(e.g. Kong HTTP 104) during deploys, HPA scaledowns, and Karpenter-driven
pod churn.

This change keeps terminating backends in EDS with `HealthStatus: DRAINING`
so Envoy stops sending new connections while allowing in-flight requests
to complete. When no active backends remain, terminating backends continue
to be used as fallbacks without DRAINING.

Used AI (Cursor) to add unit and testdata coverage for active and fallback cases.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Keep terminating backends in EDS when active backends exist and set their health to DRAINING so Envoy can drain in-flight traffic instead of resetting connections.
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
