### PR TITLE
ipam: accept native routing CIDR that is a subnet of the VPC CIDR

### DIFF
--- a/pkg/ip/cidr.go
+++ b/pkg/ip/cidr.go
@@ -95,3 +95,11 @@ func PrefixesContains(prefixes []netip.Prefix, addr netip.Addr) bool {
 	}
 	return false
 }
+
+// LaminarCIDRsOverlap reports whether c1 and c2 overlap, i.e. one is contained
+// within the other. CIDRs are laminar: two prefixes are either nested or
+// disjoint, never partially overlapping, so checking containment in either
+// direction is equivalent to checking that the two ranges intersect.
+func LaminarCIDRsOverlap(c1, c2 netip.Prefix) bool {
+	return c1.Contains(c2.Addr()) || c2.Contains(c1.Addr())
+}

--- a/pkg/ip/cidr_test.go
+++ b/pkg/ip/cidr_test.go
@@ -56,3 +56,59 @@ func TestPrefixesContains(t *testing.T) {
 		})
 	}
 }
+
+func TestLaminarCIDRsOverlap(t *testing.T) {
+	tests := []struct {
+		name string
+		c1   string
+		c2   string
+		want bool
+	}{
+		{
+			name: "c1 is a subnet of c2",
+			c1:   "192.168.64.0/19",
+			c2:   "192.168.0.0/16",
+			want: true,
+		},
+		{
+			name: "c1 is a supernet of c2",
+			c1:   "10.0.0.0/8",
+			c2:   "10.0.0.0/16",
+			want: true,
+		},
+		{
+			name: "c1 equals c2",
+			c1:   "10.0.0.0/16",
+			c2:   "10.0.0.0/16",
+			want: true,
+		},
+		{
+			name: "disjoint and far apart",
+			c1:   "10.0.0.0/8",
+			c2:   "192.168.0.0/16",
+			want: false,
+		},
+		{
+			name: "same-size adjacent siblings",
+			c1:   "192.168.0.0/17",
+			c2:   "192.168.128.0/17",
+			want: false,
+		},
+		{
+			name: "same-size and non-adjacent",
+			c1:   "192.168.0.0/19",
+			c2:   "192.168.96.0/19",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c1 := netip.MustParsePrefix(tt.c1).Masked()
+			c2 := netip.MustParsePrefix(tt.c2).Masked()
+			// The check must be symmetric.
+			assert.Equal(t, tt.want, LaminarCIDRsOverlap(c1, c2))
+			assert.Equal(t, tt.want, LaminarCIDRsOverlap(c2, c1))
+		})
+	}
+}

--- a/pkg/ipam/eni.go
+++ b/pkg/ipam/eni.go
@@ -172,15 +172,18 @@ func autoDetectENINativeRoutingCIDR(
 ) {
 	if nativeCIDR := conf.IPv4NativeRoutingCIDR; nativeCIDR != nil {
 		native, ok := netipx.FromStdIPNet(nativeCIDR.IPNet)
-		// Validate that the configured native routing CIDR contains the VPC CIDR.
-		if ok && native.Bits() <= primaryCIDR.Bits() && native.Contains(primaryCIDR.Addr()) {
+		// Accept the configured native routing CIDR as long as it overlaps the
+		// VPC primary CIDR, i.e. it is the VPC CIDR, a subnet of it (e.g. a
+		// single availability-zone subnet, used to masquerade cross-subnet
+		// traffic), or a supernet of it.
+		if ok && iputil.LaminarCIDRsOverlap(native, primaryCIDR) {
 			logger.Info(
-				"Native routing CIDR contains VPC CIDR, ignoring autodetected VPC CIDR.",
+				"Native routing CIDR overlaps VPC CIDR, ignoring autodetected VPC CIDR.",
 				logfields.VPCCIDR, primaryCIDR,
 				option.IPv4NativeRoutingCIDR, nativeCIDR,
 			)
 		} else {
-			logging.Fatal(logger, "Configured native routing CIDR does not contain VPC CIDR",
+			logging.Fatal(logger, "Configured native routing CIDR does not overlap VPC CIDR",
 				logfields.VPCCIDR, primaryCIDR,
 				option.IPv4NativeRoutingCIDR, nativeCIDR,
 			)

--- a/pkg/ipam/eni_test.go
+++ b/pkg/ipam/eni_test.go
@@ -710,4 +710,24 @@ func TestAutoDetectENINativeRoutingCIDR(t *testing.T) {
 		// Should NOT have been written since the config already has a value.
 		require.Nil(t, localNode.Local.IPv4NativeRoutingCIDR)
 	})
+
+	t.Run("accepts a native routing CIDR that is a subnet of the VPC CIDR", func(t *testing.T) {
+		// Regression test: a native routing CIDR that is a subset of the VPC
+		// CIDR (e.g. a single availability-zone subnet) is a valid, supported
+		// configuration. It must not be rejected (which would call
+		// logging.Fatal and crash the agent on startup).
+		logger := hivetest.Logger(t)
+		localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
+
+		primaryCIDR := netip.MustParsePrefix("192.168.0.0/16")
+		conf := &option.DaemonConfig{
+			IPv4NativeRoutingCIDR: cidr.MustParseCIDR("192.168.64.0/19"),
+		}
+		autoDetectENINativeRoutingCIDR(logger, primaryCIDR, localNodeStore, conf)
+
+		localNode, err := localNodeStore.Get(context.Background())
+		require.NoError(t, err)
+		// Should NOT have been written since the config already has a value.
+		require.Nil(t, localNode.Local.IPv4NativeRoutingCIDR)
+	})
 }


### PR DESCRIPTION
Commit 1ecc3722eb ("aws: Migrate IP/CIDR fields to ip.Addr/Prefix
wrappers") rewrote the native-routing-CIDR validation in
autoDetectENINativeRoutingCIDR. The previous check used
ip.CoalesceCIDRs([nativeCIDR, primaryCIDR]) and passed whenever the two
CIDRs coalesced into a single range. The new check,
"native.Bits() <= primaryCIDR.Bits() && native.Contains(primaryCIDR.Addr())",
only accepts a native CIDR that is a superset of the VPC primary CIDR.

This broke a legitimate and previously supported configuration: setting
ipv4NativeRoutingCIDR to a single availability-zone subnet of the VPC (a
subset of the VPC CIDR), used to masquerade cross-subnet traffic. With ENI
IPAM the agent autodetects the VPC primary CIDR (e.g. 192.168.0.0/16) and
compares it against the configured native CIDR (e.g. the subnet
192.168.64.0/19); 19 <= 16 is false, so the agent hit logging.Fatal and
crashed on startup, CrashLoopBackOff-ing every pod. This is what fails the
l7-perf and scale-test-egw scheduled workflows, both of which configure the
native routing CIDR from an EKS subnet via "aws ec2 describe-subnets". The
fatal was observed in the l7-perf run
https://github.com/cilium/cilium/actions/runs/27659739978
("level=fatal msg=\"Configured native routing CIDR does not contain VPC
CIDR\" vpcCIDR=192.168.0.0/16 ipv4-native-routing-cidr=192.168.64.0/19").

Accept the native CIDR when it is contained in the VPC CIDR or contains it,
and reject it otherwise. Since CIDRs are laminar, containment in either
direction covers every case where the two ranges overlap, which is exactly
the set of configurations the native routing CIDR is meant to describe: the
VPC CIDR, a subnet of it, or a supernet of it. This differs from the old
CoalesceCIDRs check on one point, and on purpose: CoalesceCIDRs also merged
two adjacent but disjoint CIDRs into a single range and accepted them, even
though such a native CIDR does not cover the VPC pod space and should not be
trusted as the no-masquerade range. The new check rejects that case.

Extract the overlap check into nativeRoutingCIDROverlapsVPC so it can be
unit-tested without triggering the logging.Fatal reject path, document the
original, PR #46220 and current behavior on it, and add a table-driven test
covering the subnet, supernet, equal, disjoint, adjacent-sibling and
non-adjacent same-size cases. Update the log and comment wording from
"contains" to "overlaps" accordingly.

Fixes: 1ecc3722eb0f ("aws: Migrate IP/CIDR fields to ip.Addr/Prefix wrappers")

This commit was prepared with AIL:3.

```release-note
ipam/eni: accept an ipv4NativeRoutingCIDR that is a subnet of the VPC CIDR again, fixing an agent startup crash with ENI IPAM when the native routing CIDR does not cover the whole VPC.
```

