### PR TITLE
aws: do not fail ENI parsing when the association has an empty public IP

### DIFF
--- a/pkg/aws/api/api.go
+++ b/pkg/aws/api/api.go
@@ -552,7 +552,12 @@ func parseENI(iface *ec2_types.NetworkInterface, vpcs ipamTypes.VirtualNetworkMa
 		eni.Prefixes = append(eni.Prefixes, iputil.PrefixFrom(p))
 	}
 
-	if iface.Association != nil && iface.Association.PublicIp != nil {
+	// An Association can be present without a public IPv4 address (e.g. an
+	// IPv6-only, carrier or customer-owned-IP association), in which case
+	// PublicIp is a non-nil pointer to an empty string. Guard on the
+	// dereferenced value rather than the pointer so that case is treated as
+	// "no public IP" instead of failing to parse an empty string.
+	if iface.Association != nil && aws.ToString(iface.Association.PublicIp) != "" {
 		publicIP, err := netip.ParseAddr(aws.ToString(iface.Association.PublicIp))
 		if err != nil {
 			return "", nil, fmt.Errorf("unable to parse ENI public IP %q: %w", aws.ToString(iface.Association.PublicIp), err)

--- a/pkg/aws/api/api_test.go
+++ b/pkg/aws/api/api_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ec2_types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type Filters []ec2_types.Filter
@@ -140,6 +141,56 @@ func TestNewTagsFilters(t *testing.T) {
 			sort.Sort(Filters(got))
 			sort.Sort(Filters(tt.want))
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseENIPublicIP(t *testing.T) {
+	newIface := func(assoc *ec2_types.NetworkInterfaceAssociation) *ec2_types.NetworkInterface {
+		return &ec2_types.NetworkInterface{
+			PrivateIpAddress: aws.String("10.0.0.1"),
+			Association:      assoc,
+		}
+	}
+
+	tests := []struct {
+		name           string
+		assoc          *ec2_types.NetworkInterfaceAssociation
+		wantPublicIP   string
+		wantValidPubIP bool
+	}{
+		{
+			name:           "no association",
+			assoc:          nil,
+			wantValidPubIP: false,
+		},
+		{
+			name:           "association without a public IP (nil pointer)",
+			assoc:          &ec2_types.NetworkInterfaceAssociation{},
+			wantValidPubIP: false,
+		},
+		{
+			name:           "association with an empty public IP",
+			assoc:          &ec2_types.NetworkInterfaceAssociation{PublicIp: aws.String("")},
+			wantValidPubIP: false,
+		},
+		{
+			name:           "association with a valid public IP",
+			assoc:          &ec2_types.NetworkInterfaceAssociation{PublicIp: aws.String("203.0.113.1")},
+			wantPublicIP:   "203.0.113.1",
+			wantValidPubIP: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, eni, err := parseENI(newIface(tt.assoc), nil, nil, false)
+			require.NoError(t, err)
+			require.NotNil(t, eni)
+			assert.Equal(t, tt.wantValidPubIP, eni.PublicIP.IsValid())
+			if tt.wantValidPubIP {
+				assert.Equal(t, tt.wantPublicIP, eni.PublicIP.String())
+			}
 		})
 	}
 }


### PR DESCRIPTION
Commit 1ecc3722eb ("aws: Migrate IP/CIDR fields to ip.Addr/Prefix
wrappers") changed the public-IP guard in parseENI from a non-empty string
check to a non-nil pointer check. It went from

    if iface.Association != nil && aws.ToString(iface.Association.PublicIp) != "" {
        eni.PublicIP = aws.ToString(iface.Association.PublicIp)
    }

to

    if iface.Association != nil && iface.Association.PublicIp != nil {
        publicIP, err := netip.ParseAddr(aws.ToString(iface.Association.PublicIp))
        if err != nil {
            return "", nil, fmt.Errorf(...)
        }
        eni.PublicIP = iputil.AddrFrom(publicIP)
    }

An EC2 NetworkInterfaceAssociation can be present without a public IPv4
address, for example an IPv6-only, carrier or customer-owned-IP
association. In that case the AWS XML deserializer allocates the
Association struct and sets PublicIp to a non-nil pointer to an empty
string. The old code treated a present-but-empty public IP as "no public
IP" and left the field unset. The new pointer guard instead calls
netip.ParseAddr("") which errors, so parseENI returns that error. Both
GetInstances and GetInstance abort the whole instance enumeration on the
first parseENI error, so a single ENI with an empty public IP breaks IPAM
inventory for the entire instance rather than dropping one optional field.

Guard on the dereferenced value being non-empty instead of the pointer
being non-nil, so a present-but-empty public IP is treated as "no public
IP" again while genuinely malformed non-empty values still error.
aws.ToString is nil-safe, so this also covers the nil-pointer case. Add a
parseENI unit test covering no association, a nil PublicIp, an empty
PublicIp and a valid PublicIp.

Fixes: 1ecc3722eb0f ("aws: Migrate IP/CIDR fields to ip.Addr/Prefix wrappers")

This commit was prepared with AIL:3.