### PR TITLE
cilium-cli: exclude non-Cilium nodes from perf node selection

### DIFF
--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
@@ -2292,8 +2293,20 @@ func (ct *ConnectivityTest) deployPerf(ctx context.Context) error {
 		}
 	}
 
-	nodeSelectorServer := labels.SelectorFromSet(ct.params.PerfParameters.NodeSelectorServer).String()
-	nodeSelectorClient := labels.SelectorFromSet(ct.params.PerfParameters.NodeSelectorClient).String()
+	// Exclude nodes that don't run Cilium (labeled with CiliumNoScheduleLabel,
+	// e.g. via `cilium install --nodes-without-cilium`). The default node
+	// selectors are empty, so without this filter ListNodes can return such a
+	// node; perf pods pinned there either never become ready (the
+	// agent-not-ready NoExecute taint is only removed once a Cilium pod runs on
+	// the node) or would measure traffic on a node without Cilium's datapath,
+	// producing meaningless results. NotEquals also matches nodes that do not
+	// carry the label at all, i.e. the Cilium nodes.
+	noSchedule, err := labels.NewRequirement(defaults.CiliumNoScheduleLabel, selection.NotEquals, []string{"true"})
+	if err != nil {
+		return fmt.Errorf("unable to build node selector requirement: %w", err)
+	}
+	nodeSelectorServer := labels.SelectorFromSet(ct.params.PerfParameters.NodeSelectorServer).Add(*noSchedule).String()
+	nodeSelectorClient := labels.SelectorFromSet(ct.params.PerfParameters.NodeSelectorClient).Add(*noSchedule).String()
 
 	serverNodes, err := ct.client.ListNodes(ctx, metav1.ListOptions{LabelSelector: nodeSelectorServer, Limit: 2})
 	if err != nil {


### PR DESCRIPTION
The net-perf-gke workflow installs Cilium with "--nodes-without-cilium",
which labels two nodes with cilium.io/no-schedule=true and keeps the agent
off them. "cilium connectivity perf" (deployPerf) then selects the
server/client nodes via ListNodes with the user node selectors, which are
empty in this workflow, so the API returns the first two nodes by name,
which happen to be exactly the no-schedule nodes.

Perf pods pinned to those nodes never become ready: the GKE agent-not-ready
NoExecute taint is only removed by the operator once a Cilium pod runs on
the node, which never happens there. The perf-client deployment stays at
0/1 and the step times out ("only 0 of 1 replicas are available"), failing
all six matrix legs. Even if the pods could schedule (e.g. via a
toleration), they would measure traffic on nodes without Cilium's datapath,
producing meaningless numbers. The failure was observed in the net-perf-gke
run https://github.com/cilium/cilium/actions/runs/27659884464.

Add a cilium.io/no-schedule!=true requirement to both perf node selectors
so the server and client land only on Cilium nodes. NotEquals also matches
nodes that don't carry the label at all, i.e. the Cilium nodes.

This commit was prepared with AIL:3.
