### PR TITLE
renovate: Fix primary GID of the ubuntu user and restore builder.sh root check

### DIFF
--- a/.github/actions/renovate/entrypoint.sh
+++ b/.github/actions/renovate/entrypoint.sh
@@ -24,4 +24,12 @@ fi
 
 usermod -aG "$GROUP_NAME" ubuntu
 
+# The ubuntu user in the Renovate image has primary GID 0, which makes
+# builder.sh take the root path. Swap the primary group to ubuntu and keep
+# root as a supplementary group.
+if [ "$(id -gn ubuntu)" = "root" ]; then
+  usermod -aG root ubuntu
+  usermod -g ubuntu ubuntu
+fi
+
 runuser -u ubuntu renovate

--- a/contrib/scripts/builder.sh
+++ b/contrib/scripts/builder.sh
@@ -129,5 +129,6 @@ if [ "$V" = '0' ]; then
 else
 	docker exec "$CONTAINER" usermod -u "$USERID" ubuntu
 fi
+docker exec "$CONTAINER" mkdir -p /home/ubuntu/.cache
 docker exec "$CONTAINER" chown "${CHOWN_FLAGS[@]}" ubuntu:ubuntu /home/ubuntu/.cache
 docker exec "${USER_OPTION[@]}" ${DOCKER_ARGS:+$DOCKER_ARGS} "$CONTAINER" "$@"

--- a/contrib/scripts/builder.sh
+++ b/contrib/scripts/builder.sh
@@ -15,6 +15,10 @@ GO="$(which go 2> /dev/null || :)"
 
 USERID=$(id -u)
 GROUPID=$(id -g)
+if [ "$USERID" -eq 0 ] || [ "$GROUPID" -eq 0 ]; then
+	echo "Running builder.sh with root privileges is not supported, run it as a regular user." 1>&2
+	exit 1
+fi
 USER_OPTION=(--user "$USERID:$GROUPID")
 USER_PATH="/home/ubuntu"
 CHOWN_FLAGS=("--no-dereference")
@@ -69,13 +73,6 @@ set -u # End workaround for macOS and BASH 3.2.
 
 trap 'docker rm -f "$CONTAINER"' EXIT
 docker start "$CONTAINER"
-
-if [ "$USERID" -eq 0 ] || [ "$GROUPID" -eq 0 ]; then
-	echo "WARNING: Running with root permissions is discouraged, not supported and insecure!" 1>&2
-	echo "Go cache dirs and ccache dir will be mounted at wrong locations. Don't run as root." 1>&2
-	docker exec ${DOCKER_ARGS:+$DOCKER_ARGS} "$CONTAINER" "$@"
-	exit "$?"
-fi
 
 EXISTING_GROUP=$(docker exec "$CONTAINER" getent group "$GROUPID" || :)
 if [ -n "$EXISTING_GROUP" ] && [ "${EXISTING_GROUP%%:*}" != "ubuntu" ]; then


### PR DESCRIPTION
## Summary

The `ubuntu` user in `ghcr.io/renovatebot/renovate` is defined with primary GID 0:

```console
$ docker run --rm ghcr.io/renovatebot/renovate:43.176.5 grep ubuntu /etc/passwd
ubuntu:x:12021:0::/home/ubuntu:/bin/bash
```

so Renovate and everything it spawns run as `12021:0`, and `builder.sh` takes
the temporary root path added in #45663 instead of its normal UID/GID
remapping.

## Changes

**1. Swap the ubuntu user's primary group before dropping privileges**
(`.github/actions/renovate/entrypoint.sh`)

```sh
if [ "$(id -gn ubuntu)" = "root" ]; then
  usermod -aG root ubuntu
  usermod -g ubuntu ubuntu
fi
```

Renovate then runs as `12021:12021`, with root kept as a supplementary group.

**2. Create `/home/ubuntu/.cache` in the builder container before chowning it**
(`contrib/scripts/builder.sh`)

When no cache directory gets mounted (e.g. Go is not installed on the host, as
in the Renovate image), `/home/ubuntu/.cache` doesn't exist and the
unconditional `chown` fails under `set -eu`. A `mkdir -p` before the `chown`
fixes this for every caller.

**3. Remove the temporary root workaround and block root explicitly**
(`contrib/scripts/builder.sh`)

With the GID fixed, the workaround from #45663 is no longer needed. Running
with UID or GID 0 now fails early, so an accidental root run can't reassign
GID 0 files inside the container.

## Testing

Verified end to end with a live Renovate run on a fork, using this branch's
entrypoint and `builder.sh`, without `BUILDER_GOCACHE_DIR`. The genuine
`postUpgradeTask` on the `renovate/all-go-deps-main` branch ran
`contrib/scripts/builder.sh true` to completion:

- `runuser -u ubuntu -- id` → `uid=12021(ubuntu) gid=12021(ubuntu) groups=12021(ubuntu),0(root),118(docker_group)`
- `builder.sh` took the normal UID/GID remapping path (the new root check never
  fired), `mkdir -p /home/ubuntu/.cache` ran, and the `chown` that used to fail
  succeeded; rc=0.

This PR was prepared with AIL:3. I personally verified the container group
membership behavior and the end-to-end Renovate runs described above.

Fixes: #45663

```release-note
Fix the Renovate entrypoint to run with the ubuntu group instead of GID 0, and restore builder.sh's rejection of root.
```
