### PR TITLE
hubble: report ext_err extended drop reason for drop notifications

### DIFF
--- a/api/v1/flow/README.md
+++ b/api/v1/flow/README.md
@@ -354,6 +354,8 @@ EventTypeFilter is a filter describing a particular event type.
 | file | [FileInfo](#flow-FileInfo) |  | Cilium datapath filename and line number. Currently only applicable when Verdict = DROPPED. |
 | ip_trace_id | [IPTraceID](#flow-IPTraceID) |  | IPTraceID relates to the trace ID in the IP options of a packet. |
 | drop_reason_desc | [DropReason](#flow-DropReason) |  | only applicable to Verdict = DROPPED. |
+| ext_error | [int32](#int32) |  | ext_error is the extended error code reported by the datapath alongside the primary drop reason (see DropNotify.ExtError in pkg/monitor). It provides additional context for the drop (for example, the BPF FIB lookup result for DROP_NO_FIB). Only applicable to Verdict = DROPPED. |
+| ext_drop_reason_desc | [string](#string) |  | ext_drop_reason_desc is the human-readable extended drop reason combining drop_reason_desc with ext_error (equivalent to the string produced by cilium monitor&#39;s DropReasonExt). Only set for drops reported via DropNotify; not populated for policy verdict denials, which carry their reason in drop_reason_desc. |
 | is_reply | [google.protobuf.BoolValue](#google-protobuf-BoolValue) |  | is_reply indicates that this was a packet (L4) or message (L7) in the reply direction. May be absent (in which case it is unknown whether it is a reply or not). |
 | debug_capture_point | [DebugCapturePoint](#flow-DebugCapturePoint) |  | Only applicable to cilium debug capture events, blank for other types |
 | interface | [NetworkInterface](#flow-NetworkInterface) |  | interface is the network interface on which this flow was observed |

--- a/api/v1/flow/flow.pb.go
+++ b/api/v1/flow/flow.pb.go
@@ -1567,6 +1567,17 @@ type Flow struct {
 	IpTraceId *IPTraceID `protobuf:"bytes,40,opt,name=ip_trace_id,json=ipTraceId,proto3" json:"ip_trace_id,omitempty"`
 	// only applicable to Verdict = DROPPED.
 	DropReasonDesc DropReason `protobuf:"varint,25,opt,name=drop_reason_desc,json=dropReasonDesc,proto3,enum=flow.DropReason" json:"drop_reason_desc,omitempty"`
+	// ext_error is the extended error code reported by the datapath alongside
+	// the primary drop reason (see DropNotify.ExtError in pkg/monitor). It
+	// provides additional context for the drop (for example, the BPF FIB
+	// lookup result for DROP_NO_FIB). Only applicable to Verdict = DROPPED.
+	ExtError int32 `protobuf:"varint,42,opt,name=ext_error,json=extError,proto3" json:"ext_error,omitempty"`
+	// ext_drop_reason_desc is the human-readable extended drop reason
+	// combining drop_reason_desc with ext_error (equivalent to the string
+	// produced by cilium monitor's DropReasonExt). Only set for drops
+	// reported via DropNotify; not populated for policy verdict denials,
+	// which carry their reason in drop_reason_desc.
+	ExtDropReasonDesc string `protobuf:"bytes,43,opt,name=ext_drop_reason_desc,json=extDropReasonDesc,proto3" json:"ext_drop_reason_desc,omitempty"`
 	// is_reply indicates that this was a packet (L4) or message (L7) in the
 	// reply direction. May be absent (in which case it is unknown whether it
 	// is a reply or not).
@@ -1852,6 +1863,20 @@ func (x *Flow) GetDropReasonDesc() DropReason {
 		return x.DropReasonDesc
 	}
 	return DropReason_DROP_REASON_UNKNOWN
+}
+
+func (x *Flow) GetExtError() int32 {
+	if x != nil {
+		return x.ExtError
+	}
+	return 0
+}
+
+func (x *Flow) GetExtDropReasonDesc() string {
+	if x != nil {
+		return x.ExtDropReasonDesc
+	}
+	return ""
 }
 
 func (x *Flow) GetIsReply() *wrapperspb.BoolValue {
@@ -5508,7 +5533,7 @@ var File_flow_flow_proto protoreflect.FileDescriptor
 
 const file_flow_flow_proto_rawDesc = "" +
 	"\n" +
-	"\x0fflow/flow.proto\x12\x04flow\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xbf\x10\n" +
+	"\x0fflow/flow.proto\x12\x04flow\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x8d\x11\n" +
 	"\x04Flow\x12.\n" +
 	"\x04time\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x04time\x12\x12\n" +
 	"\x04uuid\x18\" \x01(\tR\x04uuid\x12'\n" +
@@ -5542,7 +5567,9 @@ const file_flow_flow_proto_rawDesc = "" +
 	"\ftrace_reason\x18$ \x01(\x0e2\x11.flow.TraceReasonR\vtraceReason\x12\"\n" +
 	"\x04file\x18& \x01(\v2\x0e.flow.FileInfoR\x04file\x12/\n" +
 	"\vip_trace_id\x18( \x01(\v2\x0f.flow.IPTraceIDR\tipTraceId\x12:\n" +
-	"\x10drop_reason_desc\x18\x19 \x01(\x0e2\x10.flow.DropReasonR\x0edropReasonDesc\x125\n" +
+	"\x10drop_reason_desc\x18\x19 \x01(\x0e2\x10.flow.DropReasonR\x0edropReasonDesc\x12\x1b\n" +
+	"\text_error\x18* \x01(\x05R\bextError\x12/\n" +
+	"\x14ext_drop_reason_desc\x18+ \x01(\tR\x11extDropReasonDesc\x125\n" +
 	"\bis_reply\x18\x1a \x01(\v2\x1a.google.protobuf.BoolValueR\aisReply\x12G\n" +
 	"\x13debug_capture_point\x18\x1b \x01(\x0e2\x17.flow.DebugCapturePointR\x11debugCapturePoint\x124\n" +
 	"\tinterface\x18\x1c \x01(\v2\x16.flow.NetworkInterfaceR\tinterface\x12\x1d\n" +

--- a/api/v1/flow/flow.proto
+++ b/api/v1/flow/flow.proto
@@ -96,6 +96,19 @@ message Flow {
     // only applicable to Verdict = DROPPED.
     DropReason drop_reason_desc = 25;
 
+    // ext_error is the extended error code reported by the datapath alongside
+    // the primary drop reason (see DropNotify.ExtError in pkg/monitor). It
+    // provides additional context for the drop (for example, the BPF FIB
+    // lookup result for DROP_NO_FIB). Only applicable to Verdict = DROPPED.
+    int32 ext_error = 42;
+
+    // ext_drop_reason_desc is the human-readable extended drop reason
+    // combining drop_reason_desc with ext_error (equivalent to the string
+    // produced by cilium monitor's DropReasonExt). Only set for drops
+    // reported via DropNotify; not populated for policy verdict denials,
+    // which carry their reason in drop_reason_desc.
+    string ext_drop_reason_desc = 43;
+
     // is_reply indicates that this was a packet (L4) or message (L7) in the
     // reply direction. May be absent (in which case it is unknown whether it
     // is a reply or not).

--- a/hubble/pkg/defaults/defaults.go
+++ b/hubble/pkg/defaults/defaults.go
@@ -72,6 +72,8 @@ var (
 		"ingress_denied_by",
 		"egress_allowed_by",
 		"egress_denied_by",
+		"ext_error",
+		"ext_drop_reason_desc",
 	}
 )
 

--- a/hubble/pkg/printer/printer.go
+++ b/hubble/pkg/printer/printer.go
@@ -191,6 +191,9 @@ func GetFlowType(f *flowpb.Flow) string {
 	case api.MessageTypeTrace:
 		return api.TraceObservationPoint(uint8(f.GetEventType().GetSubType()))
 	case api.MessageTypeDrop:
+		if desc := f.GetExtDropReasonDesc(); desc != "" {
+			return desc
+		}
 		return api.DropReason(uint8(f.GetEventType().GetSubType()))
 	case api.MessageTypePolicyVerdict:
 		return fmt.Sprintf("%s:%s %s",

--- a/hubble/pkg/printer/printer_test.go
+++ b/hubble/pkg/printer/printer_test.go
@@ -857,6 +857,35 @@ func Test_getFlowType(t *testing.T) {
 			want: "policy-verdict:none INGRESS",
 		},
 		{
+			name: "Drop with extended reason",
+			args: args{
+				f: &flowpb.Flow{
+					Verdict: flowpb.Verdict_DROPPED,
+					EventType: &flowpb.CiliumEventType{
+						Type:    monitorAPI.MessageTypeDrop,
+						SubType: 132,
+					},
+					DropReasonDesc:    flowpb.DropReason_INVALID_SOURCE_IP,
+					ExtError:          7,
+					ExtDropReasonDesc: "Invalid source ip, 7",
+				},
+			},
+			want: "Invalid source ip, 7",
+		},
+		{
+			name: "Drop without extended reason falls back to subtype",
+			args: args{
+				f: &flowpb.Flow{
+					Verdict: flowpb.Verdict_DROPPED,
+					EventType: &flowpb.CiliumEventType{
+						Type:    monitorAPI.MessageTypeDrop,
+						SubType: 169,
+					},
+				},
+			},
+			want: monitorAPI.DropReason(169),
+		},
+		{
 			name: "SockLB pre-translate",
 			args: args{
 				f: &flowpb.Flow{

--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -286,6 +286,8 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 	decoded.AuthType = authType
 	decoded.DropReason = decodeDropReason(dn, pvn)
 	decoded.DropReasonDesc = pb.DropReason(decoded.DropReason)
+	decoded.ExtError = decodeExtError(dn)
+	decoded.ExtDropReasonDesc = decodeExtDropReasonDesc(dn)
 	decoded.File = decodeFileInfo(dn)
 	decoded.Source = srcEndpoint
 	decoded.Destination = dstEndpoint
@@ -490,6 +492,23 @@ func decodeDropReason(dn *monitor.DropNotify, pvn *monitor.PolicyVerdictNotify) 
 		return uint32(-pvn.Verdict)
 	}
 	return 0
+}
+
+func decodeExtError(dn *monitor.DropNotify) int32 {
+	if dn != nil {
+		return int32(dn.ExtError)
+	}
+	return 0
+}
+
+func decodeExtDropReasonDesc(dn *monitor.DropNotify) string {
+	if dn == nil {
+		return ""
+	}
+	if dn.SubType == 0 && dn.ExtError == 0 {
+		return ""
+	}
+	return monitorAPI.DropReasonExt(dn.SubType, dn.ExtError)
 }
 
 func decodeFileInfo(dn *monitor.DropNotify) *pb.FileInfo {

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -620,6 +620,12 @@ func TestDecodeDropNotify(t *testing.T) {
 			IPTraceID: id,
 		}
 	}
+	dropNotifyWithReason := func(version uint8, subType uint8, extError int8) monitor.DropNotify {
+		dn := dropNotify(version)
+		dn.SubType = subType
+		dn.ExtError = extError
+		return dn
+	}
 	identityGetter := &testutils.FakeIdentityGetter{
 		OnGetIdentity: func(securityIdentity uint32) (*identity.Identity, error) {
 			m := map[identity.NumericIdentity][]string{
@@ -672,6 +678,73 @@ func TestDecodeDropNotify(t *testing.T) {
 				},
 				Summary: "IPv4",
 				File:    &flowpb.FileInfo{Name: "bpf_host.c"},
+			},
+		},
+		{
+			name:      "v3 with ext_error",
+			dn:        dropNotifyWithReason(3, 132 /* Invalid source ip */, 7),
+			srcLabels: []string{"k8s:src=label"},
+			dstLabels: []string{"k8s:dst=label"},
+			want: &flowpb.Flow{
+				Verdict: flowpb.Verdict_DROPPED,
+				Ethernet: &flowpb.Ethernet{
+					Source:      "01:02:03:04:05:06",
+					Destination: "04:05:06:07:08:09",
+				},
+				IP: &flowpb.IP{
+					Source:      "1.2.3.4",
+					Destination: "1.2.3.4",
+					IpVersion:   flowpb.IPVersion_IPv4,
+				},
+				Source: &flowpb.Endpoint{
+					Identity: 123,
+					Labels:   []string{"k8s:src=label"},
+				},
+				Destination: &flowpb.Endpoint{
+					Identity: 456,
+					Labels:   []string{"k8s:dst=label"},
+				},
+				Type:              flowpb.FlowType_L3_L4,
+				EventType:         &flowpb.CiliumEventType{Type: 1, SubType: 132},
+				Summary:           "IPv4",
+				File:              &flowpb.FileInfo{Name: "bpf_host.c"},
+				DropReason:        132,
+				DropReasonDesc:    flowpb.DropReason_INVALID_SOURCE_IP,
+				ExtError:          7,
+				ExtDropReasonDesc: "Invalid source ip, 7",
+			},
+		},
+		{
+			name:      "v3 with drop reason but no ext_error",
+			dn:        dropNotifyWithReason(3, 169 /* FIB lookup failed */, 0),
+			srcLabels: []string{"k8s:src=label"},
+			dstLabels: []string{"k8s:dst=label"},
+			want: &flowpb.Flow{
+				Verdict: flowpb.Verdict_DROPPED,
+				Ethernet: &flowpb.Ethernet{
+					Source:      "01:02:03:04:05:06",
+					Destination: "04:05:06:07:08:09",
+				},
+				IP: &flowpb.IP{
+					Source:      "1.2.3.4",
+					Destination: "1.2.3.4",
+					IpVersion:   flowpb.IPVersion_IPv4,
+				},
+				Source: &flowpb.Endpoint{
+					Identity: 123,
+					Labels:   []string{"k8s:src=label"},
+				},
+				Destination: &flowpb.Endpoint{
+					Identity: 456,
+					Labels:   []string{"k8s:dst=label"},
+				},
+				Type:              flowpb.FlowType_L3_L4,
+				EventType:         &flowpb.CiliumEventType{Type: 1, SubType: 169},
+				Summary:           "IPv4",
+				File:              &flowpb.FileInfo{Name: "bpf_host.c"},
+				DropReason:        169,
+				DropReasonDesc:    flowpb.DropReason_FIB_LOOKUP_FAILED,
+				ExtDropReasonDesc: "FIB lookup failed",
 			},
 		},
 		{


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      This PR was prepared with AIL:1. AI assistance was limited to looking up protoc/protoc-gen-* invocations and navigating the repo. The design choices, proto field layout, parser wiring, and tests were reviewed and authored by me.
- [x] Thanks for contributing!

## Description

cilium/cilium#20387 added an extended error code (`ext_err`) to drop notifications so the datapath can report a more specific reason for a drop (for example, the BPF FIB lookup result code for `DROP_NO_FIB`). `cilium monitor` already prints this via `api.DropReasonExt()`, but Hubble's parser was discarding `DropNotify.ExtError` and only forwarding the base `SubType`. Hubble flows had no way to expose the extended reason.

This PR plumbs the extended error through to Hubble.

What changed:

- Added two new fields to the Flow proto: `ext_error` (int32) carries the raw `ExtError` byte from `DropNotify`, and `ext_drop_reason_desc` (string) carries the human readable form equivalent to what `cilium monitor` prints via `api.DropReasonExt(SubType, ExtError)`.
- Updated the threefour parser to populate both fields from `DropNotify`. `ext_drop_reason_desc` is only set for drops that come from a `DropNotify`; PolicyVerdictNotify denials are left alone since they do not carry an `ext_err`.
- Updated the Hubble printer so the flow type column prefers `ext_drop_reason_desc` when present, and falls back to the existing `api.DropReason(SubType)` lookup otherwise. The two new fields were also added to the default `FieldMask` so they survive default field filtering on the wire.

Backwards compatibility:

Proto changes are additive (field numbers 42 and 43, both previously unused on `Flow`). Old clients ignore the new fields. The printer only switches to the new string when it is non empty, so flows from older agents render exactly as before.

Tested with:

`go test ./hubble/pkg/printer/...` passes locally on darwin. `GOOS=linux go test -c` against the parser and printer packages confirms the linux only test paths compile. The parser tests themselves run in CI since they pull in linux only datapath deps.

Fixes: cilium/hubble#1215

```release-note
hubble: surface the datapath ext_err extended drop reason in flows via the new ext_error and ext_drop_reason_desc fields, matching the output of cilium monitor.
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer's Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
