### PR TITLE
operator: report accurate cilium_operator_unmanaged_pods gauge

### DIFF
--- a/operator/unmanagedpods/controller.go
+++ b/operator/unmanagedpods/controller.go
@@ -117,88 +117,127 @@ func (c *unmanagedPodsController) enableUnmanagedController() {
 		controller.ControllerParams{
 			Group:       restartUnmanagedPodsControllerGroup,
 			RunInterval: c.interval,
-			DoFunc: func(ctx context.Context) error {
-				// Clean up old entries from lastPodRestart map
-				for podName, lastRestart := range lastPodRestart {
-					if time.Since(lastRestart) > 2*minimalPodRestartInterval {
-						delete(lastPodRestart, podName)
-					}
-				}
-
-				countUnmanagedPods := 0
-				for _, podItem := range watchers.UnmanagedPodStore.List() {
-					pod, ok := podItem.(*slim_corev1.Pod)
-					if !ok {
-						c.logger.ErrorContext(ctx, fmt.Sprintf("unexpected type mapping: found %T, expected %T", pod, &slim_corev1.Pod{}))
-						continue
-					}
-
-					if pod.Spec.HostNetwork {
-						continue
-					}
-
-					cep, exists, err := watchers.HasCE(pod.Namespace, pod.Name)
-					if err != nil {
-						c.logger.ErrorContext(ctx,
-							"Unexpected error when getting CiliumEndpoint",
-							logfields.Error, err,
-							logfields.EndpointID, fmt.Sprintf("%s/%s", pod.Namespace, pod.Name),
-						)
-						continue
-					}
-
-					podID := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
-					if exists {
-						c.logger.DebugContext(ctx,
-							"Found managed pod due to presence of a CEP",
-							logfields.Error, err,
-							logfields.K8sPodName, podID,
-							logfields.Identity, cep.Status.ID,
-						)
-					} else {
-						countUnmanagedPods++
-						c.logger.DebugContext(ctx,
-							"Found unmanaged pod",
-							logfields.K8sPodName, podID,
-						)
-
-						if startTime := pod.Status.StartTime; startTime != nil {
-							if age := time.Since((*startTime).Time); age > unmanagedPodMinimalAge {
-								if lastRestart, ok := lastPodRestart[podID]; ok {
-									if timeSinceRestart := time.Since(lastRestart); timeSinceRestart < minimalPodRestartInterval {
-										c.logger.DebugContext(ctx,
-											"Not restarting unmanaged pod. Not enough time since last restart",
-											logfields.TimeSinceRestart, timeSinceRestart,
-											logfields.K8sPodName, podID,
-										)
-										continue
-									}
-								}
-
-								c.logger.InfoContext(ctx,
-									"Restarting unmanaged pod",
-									logfields.TimeSincePodStarted, age,
-									logfields.K8sPodName, podID,
-								)
-								if err := c.clientset.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); err != nil {
-									c.logger.WarnContext(ctx,
-										"Unable to restart pod",
-										logfields.Error, err,
-										logfields.K8sPodName, podID,
-									)
-								} else {
-									lastPodRestart[podID] = time.Now()
-
-									// Delete a single pod per iteration to avoid killing all replicas at once
-									return nil
-								}
-							}
-						}
-					}
-				}
-
-				c.metrics.UnmanagedPods.Set(float64(countUnmanagedPods))
-				return nil
-			},
+			DoFunc:      c.reconcile,
 		})
+}
+
+// podRestartCandidate is an unmanaged pod eligible for restart this cycle.
+type podRestartCandidate struct {
+	pod *slim_corev1.Pod
+	id  string
+	age time.Duration
+}
+
+// reconcile is the body of the restart-unmanaged-pods controller, registered as
+// the controller DoFunc. It iterates over the unmanaged pod store, counts the
+// unmanaged pods, and restarts at most one eligible pod per cycle to avoid
+// taking down all replicas at once.
+func (c *unmanagedPodsController) reconcile(ctx context.Context) error {
+	// Clean up old entries from lastPodRestart map
+	for podName, lastRestart := range lastPodRestart {
+		if time.Since(lastRestart) > 2*minimalPodRestartInterval {
+			delete(lastPodRestart, podName)
+		}
+	}
+
+	countUnmanagedPods := 0
+	for _, podItem := range watchers.UnmanagedPodStore.List() {
+		pod, ok := podItem.(*slim_corev1.Pod)
+		if !ok {
+			c.logger.ErrorContext(ctx, fmt.Sprintf("unexpected type mapping: found %T, expected %T", pod, &slim_corev1.Pod{}))
+			continue
+		}
+
+		if pod.Spec.HostNetwork {
+			continue
+		}
+
+		cep, exists, err := watchers.HasCE(pod.Namespace, pod.Name)
+		if err != nil {
+			c.logger.ErrorContext(ctx,
+				"Unexpected error when getting CiliumEndpoint",
+				logfields.Error, err,
+				logfields.EndpointID, fmt.Sprintf("%s/%s", pod.Namespace, pod.Name),
+			)
+			continue
+		}
+
+		podID := fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+		if exists {
+			c.logger.DebugContext(ctx,
+				"Found managed pod due to presence of a CEP",
+				logfields.Error, err,
+				logfields.K8sPodName, podID,
+				logfields.Identity, cep.Status.ID,
+			)
+			continue
+		}
+
+		countUnmanagedPods++
+		c.logger.DebugContext(ctx,
+			"Found unmanaged pod",
+			logfields.K8sPodName, podID,
+		)
+
+		candidate := c.evaluateRestartCandidate(ctx, pod, podID)
+		if candidate == nil {
+			continue
+		}
+
+		if c.restartUnmanagedPod(ctx, candidate) {
+			// Delete a single pod per iteration to avoid killing all replicas at once.
+			return nil
+		}
+	}
+
+	c.metrics.UnmanagedPods.Set(float64(countUnmanagedPods))
+	return nil
+}
+
+// evaluateRestartCandidate returns a candidate if the unmanaged pod is eligible
+// for restart (old enough and past its per-pod restart cooldown), else nil.
+func (c *unmanagedPodsController) evaluateRestartCandidate(ctx context.Context, pod *slim_corev1.Pod, podID string) *podRestartCandidate {
+	startTime := pod.Status.StartTime
+	if startTime == nil {
+		return nil
+	}
+
+	age := time.Since(startTime.Time)
+	if age <= unmanagedPodMinimalAge {
+		return nil
+	}
+
+	if lastRestart, ok := lastPodRestart[podID]; ok {
+		if timeSinceRestart := time.Since(lastRestart); timeSinceRestart < minimalPodRestartInterval {
+			c.logger.DebugContext(ctx,
+				"Not restarting unmanaged pod. Not enough time since last restart",
+				logfields.TimeSinceRestart, timeSinceRestart,
+				logfields.K8sPodName, podID,
+			)
+			return nil
+		}
+	}
+
+	return &podRestartCandidate{pod: pod, id: podID, age: age}
+}
+
+// restartUnmanagedPod deletes a single unmanaged pod so it is recreated and
+// picked up by Cilium. It returns true and records the restart time on success,
+// or false if the delete failed (so the caller can try the next candidate).
+func (c *unmanagedPodsController) restartUnmanagedPod(ctx context.Context, candidate *podRestartCandidate) bool {
+	c.logger.InfoContext(ctx,
+		"Restarting unmanaged pod",
+		logfields.TimeSincePodStarted, candidate.age,
+		logfields.K8sPodName, candidate.id,
+	)
+	if err := c.clientset.CoreV1().Pods(candidate.pod.Namespace).Delete(ctx, candidate.pod.Name, metav1.DeleteOptions{}); err != nil {
+		c.logger.WarnContext(ctx,
+			"Unable to restart pod",
+			logfields.Error, err,
+			logfields.K8sPodName, candidate.id,
+		)
+		return false
+	}
+	lastPodRestart[candidate.id] = time.Now()
+	return true
 }

--- a/operator/unmanagedpods/controller.go
+++ b/operator/unmanagedpods/controller.go
@@ -128,10 +128,10 @@ type podRestartCandidate struct {
 	age time.Duration
 }
 
-// reconcile is the body of the restart-unmanaged-pods controller, registered as
-// the controller DoFunc. It iterates over the unmanaged pod store, counts the
-// unmanaged pods, and restarts at most one eligible pod per cycle to avoid
-// taking down all replicas at once.
+// reconcile counts every unmanaged pod, publishes the
+// cilium_operator_unmanaged_pods gauge with that full count, and then restarts
+// at most one eligible pod. Counting happens before any restart so the gauge
+// stays accurate even on cycles where a pod is restarted.
 func (c *unmanagedPodsController) reconcile(ctx context.Context) error {
 	// Clean up old entries from lastPodRestart map
 	for podName, lastRestart := range lastPodRestart {
@@ -141,6 +141,8 @@ func (c *unmanagedPodsController) reconcile(ctx context.Context) error {
 	}
 
 	countUnmanagedPods := 0
+	var candidates []*podRestartCandidate
+
 	for _, podItem := range watchers.UnmanagedPodStore.List() {
 		pod, ok := podItem.(*slim_corev1.Pod)
 		if !ok {
@@ -179,18 +181,23 @@ func (c *unmanagedPodsController) reconcile(ctx context.Context) error {
 			logfields.K8sPodName, podID,
 		)
 
-		candidate := c.evaluateRestartCandidate(ctx, pod, podID)
-		if candidate == nil {
-			continue
-		}
-
-		if c.restartUnmanagedPod(ctx, candidate) {
-			// Delete a single pod per iteration to avoid killing all replicas at once.
-			return nil
+		if candidate := c.evaluateRestartCandidate(ctx, pod, podID); candidate != nil {
+			candidates = append(candidates, candidate)
 		}
 	}
 
+	// Publish the full count before any restart so the gauge is always accurate.
 	c.metrics.UnmanagedPods.Set(float64(countUnmanagedPods))
+
+	// Restart at most one pod per cycle to avoid taking down all replicas at
+	// once. On a failed delete, move on to the next candidate so a single
+	// failure does not stall progress for the whole cycle.
+	for _, candidate := range candidates {
+		if c.restartUnmanagedPod(ctx, candidate) {
+			break
+		}
+	}
+
 	return nil
 }
 

--- a/operator/unmanagedpods/controller.go
+++ b/operator/unmanagedpods/controller.go
@@ -146,7 +146,7 @@ func (c *unmanagedPodsController) reconcile(ctx context.Context) error {
 	for _, podItem := range watchers.UnmanagedPodStore.List() {
 		pod, ok := podItem.(*slim_corev1.Pod)
 		if !ok {
-			c.logger.ErrorContext(ctx, fmt.Sprintf("unexpected type mapping: found %T, expected %T", pod, &slim_corev1.Pod{}))
+			c.logger.ErrorContext(ctx, fmt.Sprintf("unexpected type mapping: found %T, expected %T", podItem, &slim_corev1.Pod{}))
 			continue
 		}
 
@@ -168,7 +168,6 @@ func (c *unmanagedPodsController) reconcile(ctx context.Context) error {
 		if exists {
 			c.logger.DebugContext(ctx,
 				"Found managed pod due to presence of a CEP",
-				logfields.Error, err,
 				logfields.K8sPodName, podID,
 				logfields.Identity, cep.Status.ID,
 			)

--- a/operator/unmanagedpods/controller_test.go
+++ b/operator/unmanagedpods/controller_test.go
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package unmanagedpods
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sTesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/cilium/cilium/operator/watchers"
+	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+)
+
+// newTestController wires an unmanagedPodsController against a fresh set of
+// watcher stores and a fake clientset. It resets all package-level global
+// state so tests do not leak into each other.
+func newTestController(t *testing.T) (*unmanagedPodsController, *k8sClient.FakeClientset) {
+	t.Helper()
+
+	logger := hivetest.Logger(t)
+	fakeClient, clientset := k8sClient.NewFakeClientset(logger)
+
+	// By default pod deletions succeed. Individual tests can prepend their own
+	// reactor to simulate API failures.
+	fakeClient.KubernetesFakeClientset.PrependReactor("delete", "pods",
+		func(action k8sTesting.Action) (bool, runtime.Object, error) {
+			return true, nil, nil
+		})
+
+	// Reset global state shared across reconcile cycles and tests.
+	lastPodRestart = map[string]time.Time{}
+	watchers.UnmanagedPodStore = cache.NewStore(cache.MetaNamespaceKeyFunc)
+	watchers.CiliumEndpointStore = cache.NewIndexer(
+		cache.DeletionHandlingMetaNamespaceKeyFunc,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+	)
+
+	c := &unmanagedPodsController{
+		clientset:          clientset,
+		metrics:            NewMetrics(),
+		logger:             logger,
+		interval:           15 * time.Second,
+		podRestartSelector: "",
+	}
+	return c, fakeClient
+}
+
+// addUnmanagedPod seeds the unmanaged pod store with a Running pod that has no
+// corresponding CiliumEndpoint. startedAgo controls the pod age; pass a value
+// greater than unmanagedPodMinimalAge to make it restart-eligible.
+func addUnmanagedPod(t *testing.T, name, namespace string, startedAgo time.Duration, hostNetwork bool) *slim_corev1.Pod {
+	t.Helper()
+	started := slim_metav1.Time{Time: time.Now().Add(-startedAgo)}
+	pod := &slim_corev1.Pod{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: slim_corev1.PodSpec{
+			HostNetwork: hostNetwork,
+		},
+		Status: slim_corev1.PodStatus{
+			StartTime: &started,
+		},
+	}
+	require.NoError(t, watchers.UnmanagedPodStore.Add(pod))
+	return pod
+}
+
+// addManagedPod seeds a Running pod together with a matching CiliumEndpoint so
+// the controller treats it as managed.
+func addManagedPod(t *testing.T, name, namespace string, startedAgo time.Duration) {
+	t.Helper()
+	addUnmanagedPod(t, name, namespace, startedAgo, false)
+	cep := &cilium_api_v2.CiliumEndpoint{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	require.NoError(t, watchers.CiliumEndpointStore.Add(cep))
+}
+
+// countDeletes returns the number of pod delete actions recorded against the
+// (non-slim) Kubernetes fake clientset, which is what the controller uses to
+// restart pods.
+func countDeletes(fakeClient *k8sClient.FakeClientset) int {
+	deletes := 0
+	for _, action := range fakeClient.KubernetesFakeClientset.Actions() {
+		if action.Matches("delete", "pods") {
+			deletes++
+		}
+	}
+	return deletes
+}
+
+// TestReconcileMetricReflectsCountWhenRestarting is the regression test for
+// GH issue #46197: the gauge must report the real number of unmanaged pods even
+// on a cycle where a pod is restarted.
+func TestReconcileMetricReflectsCountWhenRestarting(t *testing.T) {
+	c, fakeClient := newTestController(t)
+
+	// Three unmanaged, restart-eligible pods (older than the minimal age).
+	addUnmanagedPod(t, "pod-a", "ns", time.Minute, false)
+	addUnmanagedPod(t, "pod-b", "ns", time.Minute, false)
+	addUnmanagedPod(t, "pod-c", "ns", time.Minute, false)
+
+	require.NoError(t, c.reconcile(t.Context()))
+
+	// The gauge must equal the full count (3), not 0 and not a partial count,
+	// despite a restart having been issued this cycle.
+	assert.Equal(t, float64(3), c.metrics.UnmanagedPods.Get(),
+		"gauge must reflect the full unmanaged pod count even when a pod is restarted")
+	// Exactly one pod is restarted per cycle.
+	assert.Equal(t, 1, countDeletes(fakeClient),
+		"controller must restart at most one pod per reconcile cycle")
+}
+
+// TestReconcileMetricWithoutRestart verifies the count is published when no pod
+// is eligible for a restart yet (all pods are younger than the minimal age).
+func TestReconcileMetricWithoutRestart(t *testing.T) {
+	c, fakeClient := newTestController(t)
+
+	addUnmanagedPod(t, "pod-young-1", "ns", time.Second, false)
+	addUnmanagedPod(t, "pod-young-2", "ns", time.Second, false)
+
+	require.NoError(t, c.reconcile(t.Context()))
+
+	assert.Equal(t, float64(2), c.metrics.UnmanagedPods.Get())
+	assert.Equal(t, 0, countDeletes(fakeClient),
+		"pods younger than the minimal age must not be restarted")
+}
+
+// TestReconcileNilStartTimeCountedNotRestarted verifies that an unmanaged pod
+// without a StartTime (e.g. not yet started) is counted in the gauge but is not
+// eligible for restart.
+func TestReconcileNilStartTimeCountedNotRestarted(t *testing.T) {
+	c, fakeClient := newTestController(t)
+
+	pod := &slim_corev1.Pod{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      "no-start-time",
+			Namespace: "ns",
+		},
+	}
+	require.NoError(t, watchers.UnmanagedPodStore.Add(pod))
+
+	require.NoError(t, c.reconcile(t.Context()))
+
+	assert.Equal(t, float64(1), c.metrics.UnmanagedPods.Get(),
+		"a pod without a StartTime must still be counted as unmanaged")
+	assert.Equal(t, 0, countDeletes(fakeClient),
+		"a pod without a StartTime must not be restarted")
+}
+
+// TestReconcileManagedPodsNotCounted verifies that pods with a CiliumEndpoint
+// and host-network pods are neither counted nor restarted.
+func TestReconcileManagedPodsNotCounted(t *testing.T) {
+	c, fakeClient := newTestController(t)
+
+	addManagedPod(t, "managed", "ns", time.Minute)
+	addUnmanagedPod(t, "host-net", "ns", time.Minute, true)
+	addUnmanagedPod(t, "unmanaged", "ns", time.Minute, false)
+
+	require.NoError(t, c.reconcile(t.Context()))
+
+	assert.Equal(t, float64(1), c.metrics.UnmanagedPods.Get(),
+		"only the single non-host-network unmanaged pod must be counted")
+	assert.Equal(t, 1, countDeletes(fakeClient))
+}
+
+// TestReconcileZeroUnmanaged verifies the gauge is reset to 0 when there are no
+// unmanaged pods.
+func TestReconcileZeroUnmanaged(t *testing.T) {
+	c, fakeClient := newTestController(t)
+
+	addManagedPod(t, "managed", "ns", time.Minute)
+
+	require.NoError(t, c.reconcile(t.Context()))
+
+	assert.Equal(t, float64(0), c.metrics.UnmanagedPods.Get())
+	assert.Equal(t, 0, countDeletes(fakeClient))
+}
+
+// TestReconcileRateLimit verifies that a pod restarted in a previous cycle is
+// still counted but is not restarted again until the minimal interval elapses,
+// and that the metric remains accurate across cycles.
+func TestReconcileRateLimit(t *testing.T) {
+	c, fakeClient := newTestController(t)
+
+	addUnmanagedPod(t, "pod-a", "ns", time.Minute, false)
+	// Pretend pod-a was just restarted, so it is on cooldown.
+	lastPodRestart["ns/pod-a"] = time.Now()
+
+	require.NoError(t, c.reconcile(t.Context()))
+
+	assert.Equal(t, float64(1), c.metrics.UnmanagedPods.Get(),
+		"a pod on restart cooldown must still be counted")
+	assert.Equal(t, 0, countDeletes(fakeClient),
+		"a pod on restart cooldown must not be restarted again")
+}
+
+// TestReconcileSurfacesDeleteError verifies that when the API server rejects the
+// delete, the controller does not record a restart time (so it will retry) and
+// the metric still reflects the count.
+func TestReconcileSurfacesDeleteError(t *testing.T) {
+	c, fakeClient := newTestController(t)
+
+	fakeClient.KubernetesFakeClientset.PrependReactor("delete", "pods",
+		func(action k8sTesting.Action) (bool, runtime.Object, error) {
+			return true, nil, fmt.Errorf("synthetic delete failure")
+		})
+
+	addUnmanagedPod(t, "pod-a", "ns", time.Minute, false)
+
+	require.NoError(t, c.reconcile(t.Context()))
+
+	assert.Equal(t, float64(1), c.metrics.UnmanagedPods.Get())
+	_, recorded := lastPodRestart["ns/pod-a"]
+	assert.False(t, recorded, "a failed delete must not record a restart time")
+}
+
+// TestReconcileAllDeletesFailAttemptsEachRecordsNone verifies that when every
+// delete fails, the controller attempts each eligible candidate in the cycle
+// (it does not stall after the first failure) and records no restart, while the
+// gauge still reflects the full count.
+func TestReconcileAllDeletesFailAttemptsEachRecordsNone(t *testing.T) {
+	c, fakeClient := newTestController(t)
+
+	fakeClient.KubernetesFakeClientset.PrependReactor("delete", "pods",
+		func(action k8sTesting.Action) (bool, runtime.Object, error) {
+			return true, nil, fmt.Errorf("synthetic delete failure")
+		})
+
+	addUnmanagedPod(t, "pod-a", "ns", time.Minute, false)
+	addUnmanagedPod(t, "pod-b", "ns", time.Minute, false)
+	addUnmanagedPod(t, "pod-c", "ns", time.Minute, false)
+
+	require.NoError(t, c.reconcile(t.Context()))
+
+	assert.Equal(t, float64(3), c.metrics.UnmanagedPods.Get())
+	assert.Equal(t, 3, countDeletes(fakeClient),
+		"every eligible candidate must be attempted when deletes keep failing")
+	assert.Empty(t, lastPodRestart,
+		"no restart time must be recorded when all deletes fail")
+}
+
+// TestReconcileRetriesNextPodAfterDeleteFailure verifies that when a delete
+// fails, the controller moves on to the next eligible pod in the same cycle
+// (rather than giving up), and stops after the first successful restart.
+func TestReconcileRetriesNextPodAfterDeleteFailure(t *testing.T) {
+	c, fakeClient := newTestController(t)
+
+	// Fail the first delete, then fall through to the default success reactor.
+	failuresLeft := 1
+	fakeClient.KubernetesFakeClientset.PrependReactor("delete", "pods",
+		func(action k8sTesting.Action) (bool, runtime.Object, error) {
+			if failuresLeft > 0 {
+				failuresLeft--
+				return true, nil, fmt.Errorf("synthetic delete failure")
+			}
+			return false, nil, nil
+		})
+
+	addUnmanagedPod(t, "pod-a", "ns", time.Minute, false)
+	addUnmanagedPod(t, "pod-b", "ns", time.Minute, false)
+
+	require.NoError(t, c.reconcile(t.Context()))
+
+	assert.Equal(t, float64(2), c.metrics.UnmanagedPods.Get())
+	// Two delete attempts: the first fails, the controller retries the next.
+	assert.Equal(t, 2, countDeletes(fakeClient),
+		"controller must try the next pod after a failed delete")
+	assert.Len(t, lastPodRestart, 1,
+		"exactly one successful restart must be recorded per cycle")
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].

**AI Disclosure (AIL:3):** I identified the root cause, reproduced the issue on a live cluster, and directed the fix approach. An LLM (Claude) assisted with code authoring and test writing under my full review.

## Problem

The `cilium_operator_unmanaged_pods` gauge was never set on any reconcile
cycle where a pod restart was issued. The controller returned early
immediately after the `Delete` call — before the gauge update — so the
metric reported `0` precisely when an unmanaged pod was being acted on.

## Fix

Split across two commits as requested:

**Commit 1 — refactor only:** Extract the 100-line inline `DoFunc` closure
into three named methods (`reconcile`, `evaluateRestartCandidate`,
`restartUnmanagedPod`) and a `podRestartCandidate` struct. No functional
change.

**Commit 2 — bugfix:** Decouple counting from restarting. The reconcile now
does a full pass over the pod store to count unmanaged pods and publish the
gauge _before_ attempting any restart. At most one pod is still restarted
per cycle. On a failed delete the controller now moves on to the next
candidate instead of giving up, so a transient API error no longer stalls
restarts for other pods in the same cycle. The one-restart-per-cycle rate
limit, per-pod cooldown (`minimalPodRestartInterval`), and minimum age check
(`unmanagedPodMinimalAge`) are all preserved.

**Commit 3 — cleanup:** Remove a pre-existing stray `logfields.Error` field
in the managed pod debug log branch where `err` is always `nil`, and fix the
type-assertion error message to print `podItem` rather than the nil `pod`.

## Testing

**Unit tests** (`operator/unmanagedpods/controller_test.go` — new file):
- `TestReconcileMetricReflectsCountWhenRestarting` — regression test for #46197: gauge equals full count even on a cycle where a pod is restarted
- `TestReconcileMetricWithoutRestart` — gauge set correctly when no pod is eligible for restart yet
- `TestReconcileNilStartTimeCountedNotRestarted` — pod without a StartTime is counted but not restarted
- `TestReconcileManagedPodsNotCounted` — managed pods and host-network pods excluded from count
- `TestReconcileZeroUnmanaged` — gauge resets to 0 when no unmanaged pods
- `TestReconcileRateLimit` — pod on cooldown still counted, not restarted
- `TestReconcileSurfacesDeleteError` — failed delete does not record restart time (pod retried next cycle)
- `TestReconcileNilStartTimeCountedNotRestarted` — pod without a StartTime is counted but not restarted
- `TestReconcileRetriesNextPodAfterDeleteFailure` — controller moves to next candidate after a failed delete

**Live cluster verification** on a dev EKS cluster (Cilium v1.20-dev):
- Deployed the patched operator image
- Created a test pod, force-deleted its CiliumEndpoint and the node's Cilium agent simultaneously to open a sustained unmanaged window
- Confirmed `cilium_operator_unmanaged_pods` transitions `0 → 1` during the unmanaged window and returns to `0` once the Cilium agent restarts and recreates the CEP

Fixes: #46197

Note: this bug is present in v1.19 as well; backport may be warranted.

```release-note
Fix `cilium_operator_unmanaged_pods` gauge reporting 0 on reconcile cycles where an unmanaged pod is restarted.
```