### PR TITLE
gateway-api: unify Gateway API listener parentRef matching

### DIFF
--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -343,47 +343,7 @@ func toHTTPRoutes(log *slog.Logger,
 ) []model.HTTPRoute {
 	var httpRoutes []model.HTTPRoute
 	for _, r := range input {
-		listenerIsParent := false
-		// Check parents to see if r can attach to them.
-		// We have to consider _both_ SectionName and Port
-		for _, parent := range r.Spec.ParentRefs {
-			// First, if both SectionName and Port are unset, attach
-			if parent.SectionName == nil && parent.Port == nil {
-				listenerIsParent = true
-				break
-			}
-
-			// Then, if SectionName is set, check combinations with Port.
-			if parent.SectionName != nil {
-				if *parent.SectionName != listener.Name {
-					// If SectionName is set but not equal, no other settings
-					// matter, so check the next parent.
-					continue
-				}
-
-				if parent.Port != nil && *parent.Port != listener.Port {
-					// If SectionName is set and equal, but Port is set and _unequal_,
-					continue
-				}
-
-				listenerIsParent = true
-				break
-			}
-
-			if parent.Port != nil {
-				if *parent.Port != listener.Port {
-					// If Port is set but not equal, no other settings
-					// matter, check the next parent.
-					continue
-				}
-
-				listenerIsParent = true
-				break
-			}
-
-		}
-
-		if !listenerIsParent {
+		if !parentRefsMatchListener(r.Spec.ParentRefs, listener) {
 			continue
 		}
 
@@ -761,14 +721,7 @@ func toGRPCRoutes(listener gatewayv1beta1.Listener,
 ) []model.HTTPRoute {
 	var grpcRoutes []model.HTTPRoute
 	for _, r := range input {
-		isListener := false
-		for _, parent := range r.Spec.ParentRefs {
-			if parent.SectionName == nil || *parent.SectionName == listener.Name {
-				isListener = true
-				break
-			}
-		}
-		if !isListener {
+		if !parentRefsMatchListener(r.Spec.ParentRefs, listener) {
 			continue
 		}
 
@@ -912,14 +865,7 @@ func extractGRPCRoutes(hostnames []string, grpcr gatewayv1.GRPCRoute, services [
 func toTLSRoutes(listener gatewayv1beta1.Listener, gatewayNamespace string, namespaceLabels helpers.NamespaceLabelIndex, namespacesPreFiltered bool, listenerHostnamesByProtocol map[gatewayv1.ProtocolType][]string, input []gatewayv1.TLSRoute, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1.ReferenceGrant) []model.TLSPassthroughRoute {
 	var tlsRoutes []model.TLSPassthroughRoute
 	for _, r := range input {
-		isListener := false
-		for _, parent := range r.Spec.ParentRefs {
-			if parent.SectionName == nil || *parent.SectionName == listener.Name {
-				isListener = true
-				break
-			}
-		}
-		if !isListener {
+		if !parentRefsMatchListener(r.Spec.ParentRefs, listener) {
 			continue
 		}
 
@@ -972,32 +918,18 @@ func toTLSRoutes(listener gatewayv1beta1.Listener, gatewayNamespace string, name
 	return tlsRoutes
 }
 
-// l4RouteAttachesToListener reports whether a TCP/UDP route with the given
-// parentRefs attaches to the listener, mirroring the sectionName/port matching
-// rules used by HTTP/TLS routes.
-func l4RouteAttachesToListener(parentRefs []gatewayv1.ParentReference, listener gatewayv1beta1.Listener) bool {
+func parentRefsMatchListener(parentRefs []gatewayv1.ParentReference, listener gatewayv1.Listener) bool {
 	for _, parent := range parentRefs {
-		if parent.SectionName == nil && parent.Port == nil {
-			return true
+		if parent.SectionName != nil && *parent.SectionName != listener.Name {
+			continue
+		}
+		if parent.Port != nil && *parent.Port != listener.Port {
+			continue
 		}
 
-		if parent.SectionName != nil {
-			if *parent.SectionName != listener.Name {
-				continue
-			}
-			if parent.Port != nil && *parent.Port != listener.Port {
-				continue
-			}
-			return true
-		}
-
-		if parent.Port != nil {
-			if *parent.Port != listener.Port {
-				continue
-			}
-			return true
-		}
+		return true
 	}
+
 	return false
 }
 
@@ -1037,7 +969,7 @@ func toTCPRoutes(listener gatewayv1beta1.Listener,
 		if !namespacesPreFiltered && !helpers.IsListenerNamespaceAllowed(listener, r.GetNamespace(), gatewayNamespace, namespaceLabels) {
 			continue
 		}
-		if l4RouteAttachesToListener(r.Spec.ParentRefs, listener) {
+		if parentRefsMatchListener(r.Spec.ParentRefs, listener) {
 			attached = append(attached, r)
 		}
 	}
@@ -1096,7 +1028,7 @@ func toUDPRoutes(listener gatewayv1beta1.Listener,
 		if !namespacesPreFiltered && !helpers.IsListenerNamespaceAllowed(listener, r.GetNamespace(), gatewayNamespace, namespaceLabels) {
 			continue
 		}
-		if l4RouteAttachesToListener(r.Spec.ParentRefs, listener) {
+		if parentRefsMatchListener(r.Spec.ParentRefs, listener) {
 			attached = append(attached, r)
 		}
 	}

--- a/operator/pkg/model/ingestion/gateway_test.go
+++ b/operator/pkg/model/ingestion/gateway_test.go
@@ -469,6 +469,112 @@ func TestTLSGatewayAPIFiltersRoutesByListenerAllowedNamespaces(t *testing.T) {
 	assert.Equal(t, "podinfo", m.TLSPassthrough[1].Routes[0].Backends[0].Name)
 }
 
+func TestParentRefsMatchListener(t *testing.T) {
+	listener := gatewayv1.Listener{
+		Name: "http-listener",
+		Port: 80,
+	}
+
+	tests := []struct {
+		name       string
+		parentRefs []gatewayv1.ParentReference
+		want       bool
+	}{
+		{
+			name: "both fields nil matches listener",
+			parentRefs: []gatewayv1.ParentReference{
+				{SectionName: nil, Port: nil},
+			},
+			want: true,
+		},
+		{
+			name: "sectionName matches and port is nil",
+			parentRefs: []gatewayv1.ParentReference{
+				{SectionName: ptr.To[gatewayv1.SectionName]("http-listener"), Port: nil},
+			},
+			want: true,
+		},
+		{
+			name: "sectionName mismatches and port is nil",
+			parentRefs: []gatewayv1.ParentReference{
+				{SectionName: ptr.To[gatewayv1.SectionName]("wrong-listener"), Port: nil},
+			},
+			want: false,
+		},
+		{
+			name: "sectionName is nil and port matches",
+			parentRefs: []gatewayv1.ParentReference{
+				{SectionName: nil, Port: ptr.To[gatewayv1.PortNumber](80)},
+			},
+			want: true,
+		},
+		{
+			name: "sectionName is nil and port mismatches",
+			parentRefs: []gatewayv1.ParentReference{
+				{SectionName: nil, Port: ptr.To[gatewayv1.PortNumber](443)},
+			},
+			want: false,
+		},
+		{
+			name: "sectionName and port match",
+			parentRefs: []gatewayv1.ParentReference{
+				{SectionName: ptr.To[gatewayv1.SectionName]("http-listener"), Port: ptr.To[gatewayv1.PortNumber](80)},
+			},
+			want: true,
+		},
+		{
+			name: "sectionName matches and port mismatches",
+			parentRefs: []gatewayv1.ParentReference{
+				{SectionName: ptr.To[gatewayv1.SectionName]("http-listener"), Port: ptr.To[gatewayv1.PortNumber](443)},
+			},
+			want: false,
+		},
+		{
+			name: "sectionName mismatches and port matches",
+			parentRefs: []gatewayv1.ParentReference{
+				{SectionName: ptr.To[gatewayv1.SectionName]("wrong-listener"), Port: ptr.To[gatewayv1.PortNumber](80)},
+			},
+			want: false,
+		},
+		{
+			name: "multiple parentRefs and second one matches",
+			parentRefs: []gatewayv1.ParentReference{
+				{SectionName: ptr.To[gatewayv1.SectionName]("wrong-listener"), Port: ptr.To[gatewayv1.PortNumber](443)},
+				{SectionName: ptr.To[gatewayv1.SectionName]("http-listener"), Port: ptr.To[gatewayv1.PortNumber](80)},
+			},
+			want: true,
+		},
+		{
+			name: "multiple parentRefs and later port-only ref matches",
+			parentRefs: []gatewayv1.ParentReference{
+				{SectionName: ptr.To[gatewayv1.SectionName]("http-listener"), Port: ptr.To[gatewayv1.PortNumber](443)},
+				{SectionName: nil, Port: ptr.To[gatewayv1.PortNumber](80)},
+			},
+			want: true,
+		},
+		{
+			name: "multiple parentRefs and none match",
+			parentRefs: []gatewayv1.ParentReference{
+				{SectionName: ptr.To[gatewayv1.SectionName]("wrong-listener"), Port: ptr.To[gatewayv1.PortNumber](80)},
+				{SectionName: ptr.To[gatewayv1.SectionName]("http-listener"), Port: ptr.To[gatewayv1.PortNumber](443)},
+			},
+			want: false,
+		},
+		{
+			name:       "empty parentRefs list",
+			parentRefs: []gatewayv1.ParentReference{},
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parentRefsMatchListener(tt.parentRefs, listener)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestTLSGatewayAPI(t *testing.T) {
 	tests := map[string]struct{}{
 		"basic tls http": {},
@@ -476,6 +582,7 @@ func TestTLSGatewayAPI(t *testing.T) {
 		"Conformance/TLSRouteHostnameIntersection": {},
 		"mixed protocol listeners TLSRoute":        {},
 		"tls weighted backends":                    {},
+		"tls route parent ref filter":              {},
 	}
 
 	for name := range tests {

--- a/operator/pkg/model/ingestion/testdata/gateway/tls_route_parent_ref_filter/input-gateway.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/tls_route_parent_ref_filter/input-gateway.yaml
@@ -1,0 +1,22 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: my-gateway
+  namespace: default
+spec:
+  gatewayClassName: ""
+  listeners:
+  - hostname: example.com
+    name: tls-443
+    port: 443
+    protocol: TLS
+    tls:
+      mode: Passthrough
+  - hostname: example.com
+    name: tls-8443
+    port: 8443
+    protocol: TLS
+    tls:
+      mode: Passthrough
+status: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/tls_route_parent_ref_filter/input-service.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/tls_route_parent_ref_filter/input-service.yaml
@@ -1,0 +1,7 @@
+- metadata:
+    creationTimestamp: null
+    name: my-service
+    namespace: default
+  spec: {}
+  status:
+    loadBalancer: {}

--- a/operator/pkg/model/ingestion/testdata/gateway/tls_route_parent_ref_filter/input-tlsroute.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/tls_route_parent_ref_filter/input-tlsroute.yaml
@@ -1,0 +1,17 @@
+- metadata:
+    creationTimestamp: null
+    name: tls
+    namespace: default
+  spec:
+    hostnames:
+    - example.com
+    parentRefs:
+    - name: my-gateway
+      namespace: default
+      port: 443
+    rules:
+    - backendRefs:
+      - name: my-service
+        port: 443
+  status:
+    parents: null

--- a/operator/pkg/model/ingestion/testdata/gateway/tls_route_parent_ref_filter/output-listeners.yaml
+++ b/operator/pkg/model/ingestion/testdata/gateway/tls_route_parent_ref_filter/output-listeners.yaml
@@ -1,0 +1,26 @@
+- hostname: example.com
+  name: tls-443
+  port: 443
+  routes:
+  - backends:
+    - name: my-service
+      namespace: default
+      port:
+        port: 443
+    hostnames:
+    - example.com
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: my-gateway
+    namespace: default
+    version: v1
+- hostname: example.com
+  name: tls-8443
+  port: 8443
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: my-gateway
+    namespace: default
+    version: v1


### PR DESCRIPTION
Extract duplicated route-to-listener parentRef matching into `parentRefsMatchListener`.

HTTP and L4 routes already considered both sectionName and port, while GRPC and TLS routes only checked sectionName. Use the shared helper for HTTP, GRPC, TLS, TCP, and UDP routes so all route types consistently filter listener matches by both fields.

Add table-driven coverage for the shared helper and TLS parentRef port filtering.

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
