### PR TITLE
network driver: auto create software interfaces (dummy and macvlan)

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumnetworkdriverclusterconfigs.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumnetworkdriverclusterconfigs.yaml
@@ -114,6 +114,15 @@ spec:
                       dummy:
                         description: Configuration for the dummy device manager
                         properties:
+                          count:
+                            default: 0
+                            description: |-
+                              Number of dummy links to create and advertise. The driver synthesises
+                              Count discrete devices named dummy0..dummy<Count-1>; each is created on
+                              demand when a claim is prepared and destroyed with the pod netns. The
+                              (Count+1)th claim stays Pending.
+                            minimum: 0
+                            type: integer
                           enabled:
                             default: false
                             type: boolean

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumnetworkdrivernodeconfigs.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumnetworkdrivernodeconfigs.yaml
@@ -54,6 +54,15 @@ spec:
                   dummy:
                     description: Configuration for the dummy device manager
                     properties:
+                      count:
+                        default: 0
+                        description: |-
+                          Number of dummy links to create and advertise. The driver synthesises
+                          Count discrete devices named dummy0..dummy<Count-1>; each is created on
+                          demand when a claim is prepared and destroyed with the pod netns. The
+                          (Count+1)th claim stays Pending.
+                        minimum: 0
+                        type: integer
                       enabled:
                         default: false
                         type: boolean

--- a/pkg/k8s/apis/cilium.io/v2alpha1/network_driver_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/network_driver_types.go
@@ -243,6 +243,16 @@ type DummyDeviceManagerConfig struct {
 	// +kubebuilder:default=false
 	// +kubebuilder:validation:Optional
 	Enabled bool `json:"enabled,omitempty"`
+
+	// Number of dummy links to create and advertise. The driver synthesises
+	// Count discrete devices named dummy0..dummy<Count-1>; each is created on
+	// demand when a claim is prepared and destroyed with the pod netns. The
+	// (Count+1)th claim stays Pending.
+	//
+	// +kubebuilder:default=0
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Minimum=0
+	Count int `json:"count,omitempty"`
 }
 
 // Configuration for the macvlan device manager.

--- a/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
@@ -1767,6 +1767,9 @@ func (in *DummyDeviceManagerConfig) DeepEqual(other *DummyDeviceManagerConfig) b
 	if in.Enabled != other.Enabled {
 		return false
 	}
+	if in.Count != other.Count {
+		return false
+	}
 
 	return true
 }

--- a/pkg/networkdriver/dummy/dummy.go
+++ b/pkg/networkdriver/dummy/dummy.go
@@ -10,6 +10,8 @@ import (
 	"log/slog"
 	"slices"
 
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/utils/ptr"
 
@@ -18,13 +20,36 @@ import (
 	"github.com/cilium/cilium/pkg/networkdriver/types"
 )
 
+var (
+	errNotADummy     = errors.New("interface is not a dummy device")
+	errNegativeCount = errors.New("dummy device count must not be negative")
+)
+
+// dummyIfNamePrefix is the fixed prefix for synthesised dummy link names. The
+// manager advertises Count devices named dummy0..dummy<Count-1>.
+const dummyIfNamePrefix = "dummy"
+
+// netlink seams. Setup and Free are value-receiver methods on DummyDevice and
+// therefore cannot reach the manager's state, so the primitives they need live
+// as package-level vars that tests can override.
+var (
+	netlinkLinkByName = safenetlink.LinkByName
+	netlinkLinkAdd    = netlink.LinkAdd
+	netlinkLinkDel    = netlink.LinkDel
+)
+
 type DummyManager struct {
 	logger *slog.Logger
 	config *v2alpha1.DummyDeviceManagerConfig
 }
 
 func (m *DummyManager) init() error {
-	return nil
+	m.logger.Debug("initializing dummy device manager")
+
+	// Dummy links are created on demand in Device.Setup, not at startup.
+	// Validate the configuration here so misconfiguration fails fast instead of
+	// surfacing only when the first pod is scheduled.
+	return validateConfig(m.config.Count)
 }
 
 func NewManager(logger *slog.Logger, cfg *v2alpha1.DummyDeviceManagerConfig) (*DummyManager, error) {
@@ -40,31 +65,23 @@ func (mgr *DummyManager) Type() types.DeviceManagerType {
 	return types.DeviceManagerTypeDummy
 }
 
+// ListDevices advertises the dummy devices derived from configuration.
+//
+// Like macvlan, dummy links are virtual devices that this driver owns: they do
+// not exist in the kernel until a claim is allocated and Device.Setup creates
+// one. ListDevices therefore does not scan the kernel; it synthesises Count
+// discrete devices named dummy0..dummy<Count-1> so DRA can advertise and
+// allocate them. The (Count+1)th claim stays Pending.
 func (mgr *DummyManager) ListDevices() ([]types.Device, error) {
-	links, err := safenetlink.LinkList()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get links: %w", err)
-	}
+	var result []types.Device
 
-	var (
-		devices []types.Device
-		errs    []error
-	)
-
-	for _, link := range links {
-		if link.Type() != "dummy" {
-			continue
-		}
-
-		devices = append(devices, &DummyDevice{
-			Name:   link.Attrs().Name,
-			HWAddr: link.Attrs().HardwareAddr.String(),
-			MTU:    link.Attrs().MTU,
-			Flags:  link.Attrs().Flags.String(),
+	for i := 0; i < mgr.config.Count; i++ {
+		result = append(result, &DummyDevice{
+			Name: fmt.Sprintf("%s%d", dummyIfNamePrefix, i),
 		})
 	}
 
-	return devices, errors.Join(errs...)
+	return result, nil
 }
 
 func (mgr *DummyManager) RestoreDevice(data []byte) (types.Device, error) {
@@ -85,18 +102,80 @@ type DummyDevice struct {
 func (d DummyDevice) GetAttrs() map[resourceapi.QualifiedName]resourceapi.DeviceAttribute {
 	result := make(map[resourceapi.QualifiedName]resourceapi.DeviceAttribute)
 	result[types.IfNameLabel] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.IfName())}
-	result[types.HWAddrLabel] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.HWAddr)}
-	result[types.MTULabel] = resourceapi.DeviceAttribute{IntValue: ptr.To(int64(d.MTU))}
-	result[types.FlagsLabel] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.Flags)}
+	result[types.KernelIfNameLabel] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.KernelIfName())}
 
 	return result
 }
 
+// Setup creates the dummy link in the root network namespace. The caller
+// (RunPodSandbox) subsequently moves it into the pod netns.
+//
+// netlink.LinkAdd uses NLM_F_EXCL and is therefore not idempotent: it returns
+// EEXIST if the interface already exists. On EEXIST we adopt the existing device
+// when it is a dummy (e.g. a leftover from a prior, partially-completed
+// allocation), otherwise we delete and recreate it so we never adopt a stale
+// device of the wrong type.
 func (d DummyDevice) Setup(cfg types.DeviceConfig) error {
+	dummy := &netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{Name: d.Name},
+	}
+
+	err := netlinkLinkAdd(dummy)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, unix.EEXIST) {
+		return fmt.Errorf("failed to create dummy interface %s: %w", d.Name, err)
+	}
+
+	// The interface already exists. Adopt it if it is a dummy, otherwise
+	// replace it.
+	existing, lookupErr := netlinkLinkByName(d.Name)
+	if lookupErr != nil {
+		return fmt.Errorf("dummy interface %s exists but could not be read: %w", d.Name, lookupErr)
+	}
+
+	if _, ok := existing.(*netlink.Dummy); ok {
+		// Same type; adopt the existing device.
+		return nil
+	}
+
+	// Stale or mismatched device. Delete and recreate it.
+	if delErr := netlinkLinkDel(existing); delErr != nil {
+		return fmt.Errorf("failed to delete stale dummy interface %s: %w", d.Name, delErr)
+	}
+	if addErr := netlinkLinkAdd(dummy); addErr != nil {
+		return fmt.Errorf("failed to recreate dummy interface %s: %w", d.Name, addErr)
+	}
+
 	return nil
 }
 
+// Free deletes the dummy link. This is best-effort cleanup for a device that was
+// created by Setup but never attached to a pod (e.g. the pod failed to start
+// after prepare): once the interface is moved into a pod netns and that netns is
+// reaped, the kernel destroys the dummy automatically, so the root-namespace
+// lookup here simply finds nothing and returns nil.
 func (d DummyDevice) Free(cfg types.DeviceConfig) error {
+	l, err := netlinkLinkByName(d.Name)
+	if err != nil {
+		if errors.As(err, &netlink.LinkNotFoundError{}) {
+			// Already gone (moved into a pod netns that was reaped, or never
+			// created). Nothing to do.
+			return nil
+		}
+		return fmt.Errorf("failed to find dummy interface %s: %w", d.Name, err)
+	}
+
+	if _, ok := l.(*netlink.Dummy); !ok {
+		// Not a dummy; refuse to touch an interface we do not own.
+		return fmt.Errorf("%w: %s", errNotADummy, d.Name)
+	}
+
+	if err := netlinkLinkDel(l); err != nil {
+		return fmt.Errorf("failed to delete dummy interface %s: %w", d.Name, err)
+	}
+
 	return nil
 }
 
@@ -135,4 +214,13 @@ func (d DummyDevice) MarshalBinary() (data []byte, err error) {
 
 func (d *DummyDevice) UnmarshalBinary(data []byte) error {
 	return json.Unmarshal(data, &d)
+}
+
+// validateConfig checks, at startup, that the configured dummy device count is
+// not negative. It creates nothing.
+func validateConfig(count int) error {
+	if count < 0 {
+		return fmt.Errorf("%w: %d", errNegativeCount, count)
+	}
+	return nil
 }

--- a/pkg/networkdriver/dummy/dummy_test.go
+++ b/pkg/networkdriver/dummy/dummy_test.go
@@ -4,12 +4,76 @@
 package dummy
 
 import (
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/networkdriver/types"
 )
+
+// ── netlink seam fake ────────────────────────────────────────────────────────
+
+// fakeNetlink is an in-memory stand-in for the package-level netlink seams used
+// by DummyDevice.Setup/Free. LinkAdd reflects created interfaces back into the
+// links map so a subsequent LinkByName observes them.
+type fakeNetlink struct {
+	links   map[string]netlink.Link
+	addErrs []error // consumed in order, one per LinkAdd call (nil once exhausted)
+	delErr  error
+	added   []netlink.Link
+	deleted []netlink.Link
+}
+
+func (f *fakeNetlink) linkByName(name string) (netlink.Link, error) {
+	if l, ok := f.links[name]; ok {
+		return l, nil
+	}
+	return nil, netlink.LinkNotFoundError{}
+}
+
+func (f *fakeNetlink) linkAdd(link netlink.Link) error {
+	var err error
+	if len(f.addErrs) > 0 {
+		err, f.addErrs = f.addErrs[0], f.addErrs[1:]
+	}
+	if err != nil {
+		return err
+	}
+	f.added = append(f.added, link)
+	if f.links == nil {
+		f.links = make(map[string]netlink.Link)
+	}
+	f.links[link.Attrs().Name] = link
+	return nil
+}
+
+func (f *fakeNetlink) linkDel(link netlink.Link) error {
+	if f.delErr != nil {
+		return f.delErr
+	}
+	f.deleted = append(f.deleted, link)
+	delete(f.links, link.Attrs().Name)
+	return nil
+}
+
+// install swaps the package-level netlink seams for the fake and restores them
+// when the test ends.
+func (f *fakeNetlink) install(t *testing.T) {
+	t.Helper()
+	origByName, origAdd, origDel := netlinkLinkByName, netlinkLinkAdd, netlinkLinkDel
+	netlinkLinkByName = f.linkByName
+	netlinkLinkAdd = f.linkAdd
+	netlinkLinkDel = f.linkDel
+	t.Cleanup(func() {
+		netlinkLinkByName = origByName
+		netlinkLinkAdd = origAdd
+		netlinkLinkDel = origDel
+	})
+}
 
 func TestDummyDevice_Match(t *testing.T) {
 	dev := DummyDevice{Name: "dummy0"}
@@ -126,4 +190,151 @@ func TestDummyDevice_Match(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// ── ListDevices ──────────────────────────────────────────────────────────────
+
+func TestDummyManager_ListDevices(t *testing.T) {
+	mgr := &DummyManager{
+		logger: slog.Default(),
+		config: &v2alpha1.DummyDeviceManagerConfig{
+			Count: 2,
+		},
+	}
+
+	devices, err := mgr.ListDevices()
+	require.NoError(t, err)
+	require.Len(t, devices, 2)
+
+	var names, kernelNames []string
+	for _, dev := range devices {
+		names = append(names, dev.IfName())
+		kernelNames = append(kernelNames, dev.KernelIfName())
+		_, ok := dev.(*DummyDevice)
+		require.True(t, ok)
+	}
+	require.ElementsMatch(t, []string{"dummy0", "dummy1"}, names)
+	// Dummy has no separate kernel name; ifName == kernelIfName.
+	require.ElementsMatch(t, []string{"dummy0", "dummy1"}, kernelNames)
+}
+
+func TestDummyManager_ListDevices_Empty(t *testing.T) {
+	mgr := &DummyManager{
+		logger: slog.Default(),
+		config: &v2alpha1.DummyDeviceManagerConfig{},
+	}
+	devices, err := mgr.ListDevices()
+	require.NoError(t, err)
+	require.Empty(t, devices)
+}
+
+// ── Setup ────────────────────────────────────────────────────────────────────
+
+func TestDummyDevice_Setup(t *testing.T) {
+	dev := DummyDevice{Name: "dummy0"}
+
+	t.Run("creates dummy in root namespace", func(t *testing.T) {
+		f := &fakeNetlink{}
+		f.install(t)
+
+		require.NoError(t, dev.Setup(types.DeviceConfig{}))
+
+		require.Len(t, f.added, 1)
+		d, ok := f.added[0].(*netlink.Dummy)
+		require.True(t, ok)
+		require.Equal(t, "dummy0", d.Attrs().Name)
+		require.Empty(t, f.deleted)
+	})
+
+	t.Run("EEXIST on an existing dummy adopts it", func(t *testing.T) {
+		existing := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "dummy0"}}
+		f := &fakeNetlink{
+			links:   map[string]netlink.Link{"dummy0": existing},
+			addErrs: []error{unix.EEXIST},
+		}
+		f.install(t)
+
+		require.NoError(t, dev.Setup(types.DeviceConfig{}))
+		// Adopted, not replaced.
+		require.Empty(t, f.deleted)
+		require.Empty(t, f.added)
+	})
+
+	t.Run("EEXIST on a non-dummy replaces it", func(t *testing.T) {
+		// A device of the wrong type squatting on the name.
+		existing := &netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: "dummy0", Index: 7}}
+		f := &fakeNetlink{
+			links:   map[string]netlink.Link{"dummy0": existing},
+			addErrs: []error{unix.EEXIST},
+		}
+		f.install(t)
+
+		require.NoError(t, dev.Setup(types.DeviceConfig{}))
+		require.Len(t, f.deleted, 1)
+		require.Equal(t, "dummy0", f.deleted[0].Attrs().Name)
+		require.Len(t, f.added, 1)
+		_, ok := f.added[0].(*netlink.Dummy)
+		require.True(t, ok)
+	})
+
+	t.Run("non-EEXIST add error is returned", func(t *testing.T) {
+		f := &fakeNetlink{addErrs: []error{unix.EINVAL}}
+		f.install(t)
+
+		err := dev.Setup(types.DeviceConfig{})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "dummy0")
+		require.Empty(t, f.deleted)
+	})
+}
+
+// ── Free ─────────────────────────────────────────────────────────────────────
+
+func TestDummyDevice_Free(t *testing.T) {
+	dev := DummyDevice{Name: "dummy0"}
+
+	t.Run("deletes existing dummy", func(t *testing.T) {
+		d := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "dummy0"}}
+		f := &fakeNetlink{links: map[string]netlink.Link{"dummy0": d}}
+		f.install(t)
+
+		require.NoError(t, dev.Free(types.DeviceConfig{}))
+		require.Len(t, f.deleted, 1)
+		require.Equal(t, "dummy0", f.deleted[0].Attrs().Name)
+	})
+
+	t.Run("interface already gone is a no-op", func(t *testing.T) {
+		f := &fakeNetlink{}
+		f.install(t)
+
+		require.NoError(t, dev.Free(types.DeviceConfig{}))
+		require.Empty(t, f.deleted)
+	})
+
+	t.Run("refuses to delete a non-dummy interface", func(t *testing.T) {
+		existing := &netlink.Device{LinkAttrs: netlink.LinkAttrs{Name: "dummy0", Index: 5}}
+		f := &fakeNetlink{links: map[string]netlink.Link{"dummy0": existing}}
+		f.install(t)
+
+		err := dev.Free(types.DeviceConfig{})
+		require.ErrorIs(t, err, errNotADummy)
+		require.Empty(t, f.deleted)
+	})
+}
+
+// ── validateConfig ───────────────────────────────────────────────────────────
+
+func TestDummyManager_validateConfig(t *testing.T) {
+	t.Run("positive count is valid", func(t *testing.T) {
+		require.NoError(t, validateConfig(3))
+	})
+
+	t.Run("zero count is a no-op", func(t *testing.T) {
+		require.NoError(t, validateConfig(0))
+	})
+
+	t.Run("negative count is rejected", func(t *testing.T) {
+		err := validateConfig(-1)
+		require.ErrorIs(t, err, errNegativeCount)
+	})
 }

--- a/pkg/networkdriver/macvlan/macvlan.go
+++ b/pkg/networkdriver/macvlan/macvlan.go
@@ -13,28 +13,33 @@ import (
 	"strings"
 
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/utils/ptr"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
-	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/networkdriver/types"
 )
 
 var (
 	errInterfaceNotFound = errors.New("interface not found")
+	errNotAMacvlan       = errors.New("interface is not a macvlan device")
 )
 
-// netlinkLinkByIndex is a variable that can be mocked in tests
-var netlinkLinkByIndex = netlink.LinkByIndex
+// netlink seams. Setup and Free are value-receiver methods on MacvlanDevice and
+// therefore cannot reach the manager's injected funcs, so the primitives they
+// need live as package-level vars that tests can override.
+var (
+	netlinkLinkByName = safenetlink.LinkByName
+	netlinkLinkAdd    = netlink.LinkAdd
+	netlinkLinkDel    = netlink.LinkDel
+)
 
 type MacvlanManager struct {
 	logger            *slog.Logger
 	config            *v2alpha1.MacvlanDeviceManagerConfig
 	netlinkLinkLister func() ([]netlink.Link, error)
-	netlinkLinkAdd    func(link netlink.Link) error
-	netlinkLinkDel    func(link netlink.Link) error
 }
 
 func (m *MacvlanManager) init() error {
@@ -42,7 +47,10 @@ func (m *MacvlanManager) init() error {
 		"initializing macvlan device manager",
 	)
 
-	return m.setupMacvlans(m.config.Ifaces)
+	// macvlan sub-interfaces are created on demand in Device.Setup, not at
+	// startup. Validate the configuration here so misconfiguration fails fast
+	// instead of surfacing only when the first pod is scheduled.
+	return m.validateConfig(m.config.Ifaces)
 }
 
 func NewManager(logger *slog.Logger, cfg *v2alpha1.MacvlanDeviceManagerConfig, opts ...func(*MacvlanManager)) (*MacvlanManager, error) {
@@ -50,8 +58,6 @@ func NewManager(logger *slog.Logger, cfg *v2alpha1.MacvlanDeviceManagerConfig, o
 		logger:            logger,
 		config:            cfg,
 		netlinkLinkLister: safenetlink.LinkList,
-		netlinkLinkAdd:    netlink.LinkAdd,
-		netlinkLinkDel:    netlink.LinkDel,
 	}
 
 	for _, opt := range opts {
@@ -65,47 +71,34 @@ func (mgr *MacvlanManager) Type() types.DeviceManagerType {
 	return types.DeviceManagerTypeMacvlan
 }
 
-// ListDevices scans the system to find macvlan sub-interfaces.
+// ListDevices advertises the macvlan devices derived from configuration.
+//
+// Unlike sr-iov or dummy, macvlan sub-interfaces are virtual devices that this
+// driver owns: they do not exist in the kernel until a claim is allocated and
+// Device.Setup creates one. ListDevices therefore does not scan the kernel; it
+// synthesises Count discrete devices per configured parent interface so DRA can
+// advertise and allocate them. The (Count+1)th claim stays Pending.
 func (mgr *MacvlanManager) ListDevices() ([]types.Device, error) {
-	links, err := mgr.netlinkLinkLister()
-	if err != nil {
-		return nil, err
-	}
+	var result []types.Device
 
-	result := make([]types.Device, 0, len(links))
-
-	for _, link := range links {
-		if link.Type() != "macvlan" {
-			continue
-		}
-
-		macvlan, ok := link.(*netlink.Macvlan)
-		if !ok {
-			continue
-		}
-
-		// Get parent interface name
-		parentLink, err := netlinkLinkByIndex(link.Attrs().ParentIndex)
+	for _, iface := range mgr.config.Ifaces {
+		mode, err := parseMacvlanMode(iface.Mode)
 		if err != nil {
-			mgr.logger.Warn(
-				"failed to get parent link for macvlan device",
-				logfields.Device, link.Attrs().Name,
-				logfields.Error, err,
-			)
-			continue
+			return nil, fmt.Errorf("invalid macvlan mode for parent %s: %w", iface.ParentIfName, err)
 		}
 
-		device := &MacvlanDevice{
-			Name:            strings.ReplaceAll(link.Attrs().Name, ".", "-"),
-			ParentName:      parentLink.Attrs().Name,
-			KernelIfaceName: link.Attrs().Name,
-			HWAddr:          link.Attrs().HardwareAddr.String(),
-			MTU:             link.Attrs().MTU,
-			Flags:           link.Attrs().Flags.String(),
-			Mode:            macvlan.Mode,
-		}
+		for i := 0; i < iface.Count; i++ {
+			// kernel name uses dot notation (eth0.0); the DRA device name uses
+			// dash notation (eth0-0) to satisfy DRA device-name constraints.
+			kernelName := fmt.Sprintf("%s.%d", iface.ParentIfName, i)
 
-		result = append(result, device)
+			result = append(result, &MacvlanDevice{
+				Name:            strings.ReplaceAll(kernelName, ".", "-"),
+				ParentName:      iface.ParentIfName,
+				KernelIfaceName: kernelName,
+				Mode:            mode,
+			})
+		}
 	}
 
 	return result, nil
@@ -123,9 +116,6 @@ type MacvlanDevice struct {
 	Name            string
 	ParentName      string
 	KernelIfaceName string
-	HWAddr          string
-	MTU             int
-	Flags           string
 	Mode            netlink.MacvlanMode
 }
 
@@ -133,24 +123,93 @@ func (d MacvlanDevice) GetAttrs() map[resourceapi.QualifiedName]resourceapi.Devi
 	result := make(map[resourceapi.QualifiedName]resourceapi.DeviceAttribute)
 	result[types.IfNameLabel] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.IfName())}
 	result[types.KernelIfNameLabel] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.KernelIfName())}
-	result[types.HWAddrLabel] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.HWAddr)}
-	result[types.MTULabel] = resourceapi.DeviceAttribute{IntValue: ptr.To(int64(d.MTU))}
-	result[types.FlagsLabel] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.Flags)}
 	result[types.ParentIfNameLabel] = resourceapi.DeviceAttribute{StringValue: ptr.To(d.ParentName)}
 	result[types.MacVlanModeLabel] = resourceapi.DeviceAttribute{StringValue: ptr.To(macvlanModeToString(d.Mode))}
 
 	return result
 }
 
+// Setup creates the macvlan sub-interface in the root network namespace. The
+// caller (RunPodSandbox) subsequently moves it into the pod netns.
+//
+// netlink.LinkAdd uses NLM_F_EXCL and is therefore not idempotent: it returns
+// EEXIST if the interface already exists. On EEXIST we adopt the existing
+// device when its mode and parent match the requested config (e.g. a leftover
+// from a prior, partially-completed allocation), otherwise we delete and
+// recreate it so we never adopt a stale device with the wrong configuration.
 func (d MacvlanDevice) Setup(cfg types.DeviceConfig) error {
-	// For macvlan, setup is minimal - the device is already created
-	// We could potentially set MTU or other settings here if needed
+	parent, err := netlinkLinkByName(d.ParentName)
+	if err != nil {
+		return fmt.Errorf("failed to find parent interface %s: %w", d.ParentName, err)
+	}
+
+	macvlan := &netlink.Macvlan{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:        d.KernelIfaceName,
+			ParentIndex: parent.Attrs().Index,
+		},
+		Mode: d.Mode,
+	}
+
+	err = netlinkLinkAdd(macvlan)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, unix.EEXIST) {
+		return fmt.Errorf("failed to create macvlan interface %s: %w", d.KernelIfaceName, err)
+	}
+
+	// The interface already exists. Adopt it if it matches our config,
+	// otherwise replace it.
+	existing, lookupErr := netlinkLinkByName(d.KernelIfaceName)
+	if lookupErr != nil {
+		return fmt.Errorf("macvlan interface %s exists but could not be read: %w", d.KernelIfaceName, lookupErr)
+	}
+
+	existingMacvlan, ok := existing.(*netlink.Macvlan)
+	if ok &&
+		existingMacvlan.Mode == d.Mode &&
+		existing.Attrs().ParentIndex == parent.Attrs().Index {
+		// Same configuration; adopt the existing device.
+		return nil
+	}
+
+	// Stale or mismatched device. Delete and recreate it.
+	if delErr := netlinkLinkDel(existing); delErr != nil {
+		return fmt.Errorf("failed to delete stale macvlan interface %s: %w", d.KernelIfaceName, delErr)
+	}
+	if addErr := netlinkLinkAdd(macvlan); addErr != nil {
+		return fmt.Errorf("failed to recreate macvlan interface %s: %w", d.KernelIfaceName, addErr)
+	}
+
 	return nil
 }
 
+// Free deletes the macvlan sub-interface. This is best-effort cleanup for a
+// device that was created by Setup but never attached to a pod (e.g. the pod
+// failed to start after prepare): once the interface is moved into a pod netns
+// and that netns is reaped, the kernel destroys the macvlan automatically, so
+// the root-namespace lookup here simply finds nothing and returns nil.
 func (d MacvlanDevice) Free(cfg types.DeviceConfig) error {
-	// For macvlan, we don't delete the device on free
-	// The device is managed by the manager and persists
+	l, err := netlinkLinkByName(d.KernelIfaceName)
+	if err != nil {
+		if errors.As(err, &netlink.LinkNotFoundError{}) {
+			// Already gone (moved into a pod netns that was reaped, or never
+			// created). Nothing to do.
+			return nil
+		}
+		return fmt.Errorf("failed to find macvlan interface %s: %w", d.KernelIfaceName, err)
+	}
+
+	if _, ok := l.(*netlink.Macvlan); !ok {
+		// Not a macvlan; refuse to touch an interface we do not own.
+		return fmt.Errorf("%w: %s", errNotAMacvlan, d.KernelIfaceName)
+	}
+
+	if err := netlinkLinkDel(l); err != nil {
+		return fmt.Errorf("failed to delete macvlan interface %s: %w", d.KernelIfaceName, err)
+	}
+
 	return nil
 }
 
@@ -206,10 +265,9 @@ func (d *MacvlanDevice) UnmarshalBinary(data []byte) error {
 	return json.Unmarshal(data, &d)
 }
 
-// setupMacvlans creates macvlan sub-interfaces based on the configuration.
-// If any error is encountered, all macvlan interfaces created during this call
-// are deleted before returning.
-func (mgr *MacvlanManager) setupMacvlans(ifaces []v2alpha1.MacvlanDeviceConfig) error {
+// validateConfig checks, at startup, that every configured parent interface
+// exists and every mode is parseable. It creates nothing.
+func (mgr *MacvlanManager) validateConfig(ifaces []v2alpha1.MacvlanDeviceConfig) error {
 	if len(ifaces) == 0 {
 		// nothing to do. early exit.
 		return nil
@@ -220,123 +278,41 @@ func (mgr *MacvlanManager) setupMacvlans(ifaces []v2alpha1.MacvlanDeviceConfig) 
 		return err
 	}
 
-	// Build a map of existing links
-	linkMap := make(map[string]netlink.Link, len(links))
-
+	existing := make(map[string]bool, len(links))
 	for _, link := range links {
-		linkMap[link.Attrs().Name] = link
-	}
-
-	// Track interfaces created during this call so we can clean up on error.
-	var created []*netlink.Macvlan
-
-	cleanup := func() {
-		for _, mv := range created {
-			if err := mgr.netlinkLinkDel(mv); err != nil {
-				mgr.logger.Warn(
-					"failed to delete macvlan sub-interface during cleanup",
-					logfields.Interface, mv.Attrs().Name,
-					logfields.Error, err,
-				)
-			} else {
-				mgr.logger.Debug(
-					"deleted macvlan sub-interface during cleanup",
-					logfields.Interface, mv.Attrs().Name,
-				)
-			}
-		}
+		existing[link.Attrs().Name] = true
 	}
 
 	var errs error
-
 	for _, iface := range ifaces {
-		// Find parent interface
-		parentLink, ok := linkMap[iface.ParentIfName]
-		if !ok {
+		if !existing[iface.ParentIfName] {
 			errs = errors.Join(errs, fmt.Errorf("parent interface %s not found: %w", iface.ParentIfName, errInterfaceNotFound))
-			continue
 		}
-
-		var mode netlink.MacvlanMode
-
-		switch iface.Mode {
-		case "private":
-			mode = netlink.MACVLAN_MODE_PRIVATE
-		case "vepa":
-			mode = netlink.MACVLAN_MODE_VEPA
-		case "bridge":
-			mode = netlink.MACVLAN_MODE_BRIDGE
-		case "passthru":
-			mode = netlink.MACVLAN_MODE_PASSTHRU
-		case "source":
-			mode = netlink.MACVLAN_MODE_SOURCE
-		default:
-			errs = errors.Join(errs, fmt.Errorf("unknown macvlan mode: %s for %s", iface.Mode, iface.ParentIfName))
-			continue
+		if _, err := parseMacvlanMode(iface.Mode); err != nil {
+			errs = errors.Join(errs, fmt.Errorf("parent interface %s: %w", iface.ParentIfName, err))
 		}
-
-		// Create sub-interfaces
-		for i := 0; i < iface.Count; i++ {
-			subIfName := fmt.Sprintf("%s.%d", iface.ParentIfName, i)
-
-			// Check if interface already exists
-			if _, exists := linkMap[subIfName]; exists {
-				mgr.logger.Debug(
-					"macvlan sub-interface already exists, skipping",
-					logfields.Interface, subIfName,
-				)
-
-				continue
-			}
-
-			// else, proceed with creation and bring up.
-			macvlan := &netlink.Macvlan{
-				LinkAttrs: netlink.LinkAttrs{
-					Name:        subIfName,
-					ParentIndex: parentLink.Attrs().Index,
-				},
-				Mode: mode,
-			}
-
-			if err := mgr.netlinkLinkAdd(macvlan); err != nil {
-				errs = errors.Join(errs, fmt.Errorf(
-					"failed to create macvlan sub-interface %s: %w",
-					subIfName, err,
-				))
-
-				continue
-			}
-
-			// Track the newly created interface for potential cleanup.
-			created = append(created, macvlan)
-
-			mgr.logger.Info(
-				"created macvlan sub-interface",
-				logfields.Interface, subIfName,
-				logfields.Mode, macvlanModeToString(mode),
-			)
-		}
-
-		mgr.logger.Info(
-			"macvlan configuration complete for interface",
-			logfields.Interface, iface.ParentIfName,
-			logfields.Count, iface.Count,
-		)
-	}
-
-	if errs != nil {
-		mgr.logger.Error(
-			"errors found during macvlan setup. cleaning up",
-		)
-
-		cleanup()
-	} else {
-		mgr.logger.Info(
-			"macvlan configuration complete",
-		)
 	}
 
 	return errs
+}
+
+// parseMacvlanMode converts a macvlan mode string to a netlink.MacvlanMode. An
+// empty string maps to bridge mode, matching the CRD default.
+func parseMacvlanMode(mode string) (netlink.MacvlanMode, error) {
+	switch mode {
+	case "", "bridge":
+		return netlink.MACVLAN_MODE_BRIDGE, nil
+	case "private":
+		return netlink.MACVLAN_MODE_PRIVATE, nil
+	case "vepa":
+		return netlink.MACVLAN_MODE_VEPA, nil
+	case "passthru":
+		return netlink.MACVLAN_MODE_PASSTHRU, nil
+	case "source":
+		return netlink.MACVLAN_MODE_SOURCE, nil
+	default:
+		return 0, fmt.Errorf("unknown macvlan mode: %q", mode)
+	}
 }
 
 // macvlanModeToString converts a netlink.MacvlanMode to a string.

--- a/pkg/networkdriver/macvlan/macvlan_test.go
+++ b/pkg/networkdriver/macvlan/macvlan_test.go
@@ -4,12 +4,12 @@
 package macvlan
 
 import (
-	"errors"
 	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/networkdriver/types"
@@ -17,43 +17,9 @@ import (
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
-// mockNetlinkOps records calls to LinkAdd and LinkDel so tests can assert the
-// exact sequence of operations performed by setupMacvlans.
-type mockNetlinkOps struct {
-	added   []string
-	deleted []string
-
-	// Injected errors keyed by interface name. A nil value means success.
-	addErrors map[string]error
-	delErrors map[string]error
-}
-
-func newMockNetlinkOps() *mockNetlinkOps {
-	return &mockNetlinkOps{
-		addErrors: make(map[string]error),
-		delErrors: make(map[string]error),
-	}
-}
-
-func (m *mockNetlinkOps) LinkAdd(link netlink.Link) error {
-	name := link.Attrs().Name
-	m.added = append(m.added, name)
-	return m.addErrors[name]
-}
-
-func (m *mockNetlinkOps) LinkDel(link netlink.Link) error {
-	name := link.Attrs().Name
-	m.deleted = append(m.deleted, name)
-	return m.delErrors[name]
-}
-
-// installMockNetlinkOps wires the mock's LinkAdd/LinkDel into the manager.
-func installMockNetlinkOps(mgr *MacvlanManager, m *mockNetlinkOps) {
-	mgr.netlinkLinkAdd = m.LinkAdd
-	mgr.netlinkLinkDel = m.LinkDel
-}
-
 // parentLink returns a minimal Device link that acts as a parent interface.
+// It is deliberately a *netlink.Device (not a *netlink.Macvlan) so it can also
+// be used to exercise the "not a macvlan" guard in Free.
 func parentLink(name string, index int) netlink.Link {
 	return &netlink.Device{
 		LinkAttrs: netlink.LinkAttrs{
@@ -63,18 +29,62 @@ func parentLink(name string, index int) netlink.Link {
 	}
 }
 
-// newTestManager builds a MacvlanManager whose link-lister returns the
-// provided links without touching the real kernel.
-func newTestManager(links []netlink.Link, ifaces []v2alpha1.MacvlanDeviceConfig) *MacvlanManager {
-	return &MacvlanManager{
-		logger: slog.Default(),
-		config: &v2alpha1.MacvlanDeviceManagerConfig{Ifaces: ifaces},
-		netlinkLinkLister: func() ([]netlink.Link, error) {
-			return links, nil
-		},
-		netlinkLinkAdd: func(link netlink.Link) error { return nil },
-		netlinkLinkDel: func(link netlink.Link) error { return nil },
+// fakeNetlink is an in-memory stand-in for the package-level netlink seams used
+// by MacvlanDevice.Setup/Free. LinkAdd reflects created interfaces back into the
+// links map so a subsequent LinkByName observes them.
+type fakeNetlink struct {
+	links   map[string]netlink.Link
+	addErrs []error // consumed in order, one per LinkAdd call (nil once exhausted)
+	delErr  error
+	added   []netlink.Link
+	deleted []netlink.Link
+}
+
+func (f *fakeNetlink) linkByName(name string) (netlink.Link, error) {
+	if l, ok := f.links[name]; ok {
+		return l, nil
 	}
+	return nil, netlink.LinkNotFoundError{}
+}
+
+func (f *fakeNetlink) linkAdd(link netlink.Link) error {
+	var err error
+	if len(f.addErrs) > 0 {
+		err, f.addErrs = f.addErrs[0], f.addErrs[1:]
+	}
+	if err != nil {
+		return err
+	}
+	f.added = append(f.added, link)
+	if f.links == nil {
+		f.links = make(map[string]netlink.Link)
+	}
+	f.links[link.Attrs().Name] = link
+	return nil
+}
+
+func (f *fakeNetlink) linkDel(link netlink.Link) error {
+	if f.delErr != nil {
+		return f.delErr
+	}
+	f.deleted = append(f.deleted, link)
+	delete(f.links, link.Attrs().Name)
+	return nil
+}
+
+// install swaps the package-level netlink seams for the fake and restores them
+// when the test ends.
+func (f *fakeNetlink) install(t *testing.T) {
+	t.Helper()
+	origByName, origAdd, origDel := netlinkLinkByName, netlinkLinkAdd, netlinkLinkDel
+	netlinkLinkByName = f.linkByName
+	netlinkLinkAdd = f.linkAdd
+	netlinkLinkDel = f.linkDel
+	t.Cleanup(func() {
+		netlinkLinkByName = origByName
+		netlinkLinkAdd = origAdd
+		netlinkLinkDel = origDel
+	})
 }
 
 // ── GetAttrs ─────────────────────────────────────────────────────────────────
@@ -84,9 +94,6 @@ func TestMacvlanDevice_GetAttrs(t *testing.T) {
 		Name:            "eth0-0",
 		ParentName:      "eth0",
 		KernelIfaceName: "eth0.0",
-		HWAddr:          "00:11:22:33:44:55",
-		MTU:             1500,
-		Flags:           "up|broadcast|running",
 		Mode:            netlink.MACVLAN_MODE_BRIDGE,
 	}
 
@@ -95,10 +102,17 @@ func TestMacvlanDevice_GetAttrs(t *testing.T) {
 	require.NotNil(t, attrs)
 	require.Equal(t, "eth0-0", *attrs[types.IfNameLabel].StringValue)
 	require.Equal(t, "eth0.0", *attrs[types.KernelIfNameLabel].StringValue)
-	require.Equal(t, "00:11:22:33:44:55", *attrs[types.HWAddrLabel].StringValue)
-	require.Equal(t, int64(1500), *attrs[types.MTULabel].IntValue)
-	require.Equal(t, "eth0", *attrs["parentIfName"].StringValue)
-	require.Equal(t, "bridge", *attrs["macvlanMode"].StringValue)
+	require.Equal(t, "eth0", *attrs[types.ParentIfNameLabel].StringValue)
+	require.Equal(t, "bridge", *attrs[types.MacVlanModeLabel].StringValue)
+
+	// Runtime-only attributes are not known at advertise time for on-demand
+	// devices and must not be published (an mtu:0 would break DRA CEL selectors).
+	_, hasHWAddr := attrs[types.HWAddrLabel]
+	require.False(t, hasHWAddr)
+	_, hasMTU := attrs[types.MTULabel]
+	require.False(t, hasMTU)
+	_, hasFlags := attrs[types.FlagsLabel]
+	require.False(t, hasFlags)
 }
 
 // ── Match ─────────────────────────────────────────────────────────────────────
@@ -262,9 +276,6 @@ func TestMacvlanManager_RestoreDevice(t *testing.T) {
 		Name:            "eth0-0",
 		ParentName:      "eth0",
 		KernelIfaceName: "eth0.0",
-		HWAddr:          "00:11:22:33:44:55",
-		MTU:             1500,
-		Flags:           "up|broadcast|running",
 		Mode:            netlink.MACVLAN_MODE_BRIDGE,
 	}
 
@@ -280,182 +291,259 @@ func TestMacvlanManager_RestoreDevice(t *testing.T) {
 	require.Equal(t, dev, *restoredDev)
 }
 
+// ListDevices advertises Count discrete devices per configured parent, derived
+// purely from configuration with no kernel scan.
 func TestMacvlanManager_ListDevices(t *testing.T) {
-	parentLk := &netlink.Device{
-		LinkAttrs: netlink.LinkAttrs{Name: "eth0", Index: 2, Flags: 1, MTU: 1500},
-	}
-
-	mockLinks := []netlink.Link{
-		&netlink.Macvlan{
-			LinkAttrs: netlink.LinkAttrs{Name: "eth0.0", Index: 10, ParentIndex: 2, Flags: 1, MTU: 1500},
-			Mode:      netlink.MACVLAN_MODE_BRIDGE,
-		},
-		&netlink.Macvlan{
-			LinkAttrs: netlink.LinkAttrs{Name: "eth0.1", Index: 11, ParentIndex: 2, Flags: 1, MTU: 1500},
-			Mode:      netlink.MACVLAN_MODE_BRIDGE,
-		},
-		&netlink.Macvlan{
-			LinkAttrs: netlink.LinkAttrs{Name: "eth0.2", Index: 12, ParentIndex: 2, Flags: 0, MTU: 1500},
-			Mode:      netlink.MACVLAN_MODE_BRIDGE,
-		},
-		parentLk,
-	}
-
-	origLinkByIndex := netlinkLinkByIndex
-	t.Cleanup(func() { netlinkLinkByIndex = origLinkByIndex })
-
-	netlinkLinkByIndex = func(index int) (netlink.Link, error) {
-		if index == 2 {
-			return parentLk, nil
-		}
-		return nil, netlink.LinkNotFoundError{}
-	}
-
 	mgr := &MacvlanManager{
-		logger:            slog.Default(),
-		config:            &v2alpha1.MacvlanDeviceManagerConfig{},
-		netlinkLinkLister: func() ([]netlink.Link, error) { return mockLinks, nil },
+		logger: slog.Default(),
+		config: &v2alpha1.MacvlanDeviceManagerConfig{
+			Ifaces: []v2alpha1.MacvlanDeviceConfig{
+				{ParentIfName: "eth0", Mode: "bridge", Count: 3},
+				{ParentIfName: "eth1", Mode: "private", Count: 1},
+				{ParentIfName: "eth2", Mode: "bridge", Count: 0}, // advertises nothing
+			},
+		},
 	}
 
 	devices, err := mgr.ListDevices()
 	require.NoError(t, err)
-	require.Len(t, devices, 3)
+	require.Len(t, devices, 4)
 
 	var names, kernelNames []string
+	modeByName := make(map[string]netlink.MacvlanMode)
 	for _, dev := range devices {
 		names = append(names, dev.IfName())
 		kernelNames = append(kernelNames, dev.KernelIfName())
+		mv, ok := dev.(*MacvlanDevice)
+		require.True(t, ok)
+		modeByName[dev.IfName()] = mv.Mode
 	}
 
-	t.Run("IfName uses dash notation", func(t *testing.T) {
-		require.ElementsMatch(t, []string{"eth0-0", "eth0-1", "eth0-2"}, names)
+	require.ElementsMatch(t, []string{"eth0-0", "eth0-1", "eth0-2", "eth1-0"}, names)
+	require.ElementsMatch(t, []string{"eth0.0", "eth0.1", "eth0.2", "eth1.0"}, kernelNames)
+	require.Equal(t, netlink.MACVLAN_MODE_BRIDGE, modeByName["eth0-0"])
+	require.Equal(t, netlink.MACVLAN_MODE_PRIVATE, modeByName["eth1-0"])
+}
+
+func TestMacvlanManager_ListDevices_InvalidMode(t *testing.T) {
+	mgr := &MacvlanManager{
+		logger: slog.Default(),
+		config: &v2alpha1.MacvlanDeviceManagerConfig{
+			Ifaces: []v2alpha1.MacvlanDeviceConfig{
+				{ParentIfName: "eth0", Mode: "bogus", Count: 1},
+			},
+		},
+	}
+
+	_, err := mgr.ListDevices()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "bogus")
+}
+
+// ── Setup ──────────────────────────────────────────────────────────────────
+
+func TestMacvlanDevice_Setup(t *testing.T) {
+	dev := MacvlanDevice{
+		Name:            "eth0-0",
+		ParentName:      "eth0",
+		KernelIfaceName: "eth0.0",
+		Mode:            netlink.MACVLAN_MODE_BRIDGE,
+	}
+
+	t.Run("creates macvlan in root namespace", func(t *testing.T) {
+		f := &fakeNetlink{links: map[string]netlink.Link{"eth0": parentLink("eth0", 2)}}
+		f.install(t)
+
+		require.NoError(t, dev.Setup(types.DeviceConfig{}))
+
+		require.Len(t, f.added, 1)
+		mv, ok := f.added[0].(*netlink.Macvlan)
+		require.True(t, ok)
+		require.Equal(t, "eth0.0", mv.Attrs().Name)
+		require.Equal(t, 2, mv.Attrs().ParentIndex)
+		require.Equal(t, netlink.MACVLAN_MODE_BRIDGE, mv.Mode)
+		require.Empty(t, f.deleted)
 	})
-	t.Run("KernelIfName preserves dot notation", func(t *testing.T) {
-		require.ElementsMatch(t, []string{"eth0.0", "eth0.1", "eth0.2"}, kernelNames)
+
+	t.Run("parent interface missing returns error", func(t *testing.T) {
+		f := &fakeNetlink{}
+		f.install(t)
+
+		err := dev.Setup(types.DeviceConfig{})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "eth0")
+		require.Empty(t, f.added)
+	})
+
+	t.Run("EEXIST with matching config adopts existing device", func(t *testing.T) {
+		existing := &netlink.Macvlan{
+			LinkAttrs: netlink.LinkAttrs{Name: "eth0.0", ParentIndex: 2},
+			Mode:      netlink.MACVLAN_MODE_BRIDGE,
+		}
+		f := &fakeNetlink{
+			links: map[string]netlink.Link{
+				"eth0":   parentLink("eth0", 2),
+				"eth0.0": existing,
+			},
+			addErrs: []error{unix.EEXIST},
+		}
+		f.install(t)
+
+		require.NoError(t, dev.Setup(types.DeviceConfig{}))
+		// Adopted, not replaced.
+		require.Empty(t, f.deleted)
+		require.Empty(t, f.added)
+	})
+
+	t.Run("EEXIST with mismatched mode replaces device", func(t *testing.T) {
+		existing := &netlink.Macvlan{
+			LinkAttrs: netlink.LinkAttrs{Name: "eth0.0", ParentIndex: 2},
+			Mode:      netlink.MACVLAN_MODE_PRIVATE, // differs from dev.Mode (bridge)
+		}
+		f := &fakeNetlink{
+			links: map[string]netlink.Link{
+				"eth0":   parentLink("eth0", 2),
+				"eth0.0": existing,
+			},
+			// First add fails EEXIST; the recreate after delete succeeds.
+			addErrs: []error{unix.EEXIST},
+		}
+		f.install(t)
+
+		require.NoError(t, dev.Setup(types.DeviceConfig{}))
+		require.Len(t, f.deleted, 1)
+		require.Equal(t, "eth0.0", f.deleted[0].Attrs().Name)
+		require.Len(t, f.added, 1)
+		mv, ok := f.added[0].(*netlink.Macvlan)
+		require.True(t, ok)
+		require.Equal(t, netlink.MACVLAN_MODE_BRIDGE, mv.Mode)
+	})
+
+	t.Run("EEXIST with mismatched parent replaces device", func(t *testing.T) {
+		existing := &netlink.Macvlan{
+			LinkAttrs: netlink.LinkAttrs{Name: "eth0.0", ParentIndex: 99}, // wrong parent
+			Mode:      netlink.MACVLAN_MODE_BRIDGE,
+		}
+		f := &fakeNetlink{
+			links: map[string]netlink.Link{
+				"eth0":   parentLink("eth0", 2),
+				"eth0.0": existing,
+			},
+			addErrs: []error{unix.EEXIST},
+		}
+		f.install(t)
+
+		require.NoError(t, dev.Setup(types.DeviceConfig{}))
+		require.Len(t, f.deleted, 1)
+		require.Len(t, f.added, 1)
 	})
 }
 
-// ── setupMacvlans ─────────────────────────────────────────────────────────────
+// ── Free ───────────────────────────────────────────────────────────────────
 
-func TestSetupMacvlans(t *testing.T) {
-	t.Run("success creates interfaces and nothing is deleted", func(t *testing.T) {
-		ifaces := []v2alpha1.MacvlanDeviceConfig{
-			{ParentIfName: "eth0", Mode: "bridge", Count: 3},
-		}
-		mock := newMockNetlinkOps()
-		mgr := newTestManager([]netlink.Link{parentLink("eth0", 1)}, ifaces)
-		installMockNetlinkOps(mgr, mock)
+func TestMacvlanDevice_Free(t *testing.T) {
+	dev := MacvlanDevice{
+		Name:            "eth0-0",
+		ParentName:      "eth0",
+		KernelIfaceName: "eth0.0",
+		Mode:            netlink.MACVLAN_MODE_BRIDGE,
+	}
 
-		require.NoError(t, mgr.setupMacvlans(ifaces))
-		require.Equal(t, []string{"eth0.0", "eth0.1", "eth0.2"}, mock.added)
-		require.Empty(t, mock.deleted)
+	t.Run("deletes existing macvlan", func(t *testing.T) {
+		mv := &netlink.Macvlan{LinkAttrs: netlink.LinkAttrs{Name: "eth0.0"}}
+		f := &fakeNetlink{links: map[string]netlink.Link{"eth0.0": mv}}
+		f.install(t)
+
+		require.NoError(t, dev.Free(types.DeviceConfig{}))
+		require.Len(t, f.deleted, 1)
+		require.Equal(t, "eth0.0", f.deleted[0].Attrs().Name)
 	})
 
-	t.Run("empty ifaces is a no-op", func(t *testing.T) {
-		mock := newMockNetlinkOps()
-		mgr := newTestManager(nil, nil)
-		installMockNetlinkOps(mgr, mock)
+	t.Run("interface already gone is a no-op", func(t *testing.T) {
+		f := &fakeNetlink{}
+		f.install(t)
 
-		require.NoError(t, mgr.setupMacvlans(nil))
-		require.Empty(t, mock.added)
-		require.Empty(t, mock.deleted)
+		require.NoError(t, dev.Free(types.DeviceConfig{}))
+		require.Empty(t, f.deleted)
 	})
 
-	t.Run("LinkAdd error triggers cleanup of previously created interfaces", func(t *testing.T) {
-		// eth0.1 will fail; eth0.0 was already created and eth0.2 succeeds after the continue.
-		mock := newMockNetlinkOps()
-		mock.addErrors["eth0.1"] = errors.New("kernel error")
+	t.Run("refuses to delete a non-macvlan interface", func(t *testing.T) {
+		f := &fakeNetlink{links: map[string]netlink.Link{"eth0.0": parentLink("eth0.0", 5)}}
+		f.install(t)
 
-		ifaces := []v2alpha1.MacvlanDeviceConfig{
-			{ParentIfName: "eth0", Mode: "bridge", Count: 3},
-		}
-		mgr := newTestManager([]netlink.Link{parentLink("eth0", 1)}, ifaces)
-		installMockNetlinkOps(mgr, mock)
-
-		err := mgr.setupMacvlans(ifaces)
-		require.Error(t, err)
-		require.ErrorContains(t, err, "eth0.1")
-
-		// All three were attempted; eth0.1 failed (not tracked), so only eth0.0 and eth0.2 are cleaned up.
-		require.Equal(t, []string{"eth0.0", "eth0.1", "eth0.2"}, mock.added)
-		require.Equal(t, []string{"eth0.0", "eth0.2"}, mock.deleted)
+		err := dev.Free(types.DeviceConfig{})
+		require.ErrorIs(t, err, errNotAMacvlan)
+		require.Empty(t, f.deleted)
 	})
+}
 
-	t.Run("cleanup spans multiple parents on error in second parent", func(t *testing.T) {
-		mock := newMockNetlinkOps()
-		mock.addErrors["eth1.0"] = errors.New("kernel error")
+// ── parseMacvlanMode ─────────────────────────────────────────────────────────
 
+func TestParseMacvlanMode(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    netlink.MacvlanMode
+		wantErr bool
+	}{
+		{in: "", want: netlink.MACVLAN_MODE_BRIDGE},
+		{in: "bridge", want: netlink.MACVLAN_MODE_BRIDGE},
+		{in: "private", want: netlink.MACVLAN_MODE_PRIVATE},
+		{in: "vepa", want: netlink.MACVLAN_MODE_VEPA},
+		{in: "passthru", want: netlink.MACVLAN_MODE_PASSTHRU},
+		{in: "source", want: netlink.MACVLAN_MODE_SOURCE},
+		{in: "nonsense", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, err := parseMacvlanMode(tt.in)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// ── validateConfig ───────────────────────────────────────────────────────────
+
+func TestMacvlanManager_validateConfig(t *testing.T) {
+	links := []netlink.Link{parentLink("eth0", 1), parentLink("eth1", 2)}
+	lister := func() ([]netlink.Link, error) { return links, nil }
+
+	t.Run("all parents present and modes valid", func(t *testing.T) {
+		mgr := &MacvlanManager{logger: slog.Default(), netlinkLinkLister: lister}
 		ifaces := []v2alpha1.MacvlanDeviceConfig{
 			{ParentIfName: "eth0", Mode: "bridge", Count: 2},
-			{ParentIfName: "eth1", Mode: "bridge", Count: 1},
+			{ParentIfName: "eth1", Mode: "", Count: 1},
 		}
-		mgr := newTestManager([]netlink.Link{parentLink("eth0", 1), parentLink("eth1", 2)}, ifaces)
-		installMockNetlinkOps(mgr, mock)
-
-		err := mgr.setupMacvlans(ifaces)
-		require.Error(t, err)
-
-		require.Equal(t, []string{"eth0.0", "eth0.1", "eth1.0"}, mock.added)
-		// eth0.0 and eth0.1 created before the error must be cleaned up.
-		require.Equal(t, []string{"eth0.0", "eth0.1"}, mock.deleted)
+		require.NoError(t, mgr.validateConfig(ifaces))
 	})
 
-	t.Run("missing parent interface errors and cleans up earlier interfaces", func(t *testing.T) {
-		mock := newMockNetlinkOps()
+	t.Run("empty config is a no-op", func(t *testing.T) {
+		mgr := &MacvlanManager{logger: slog.Default(), netlinkLinkLister: lister}
+		require.NoError(t, mgr.validateConfig(nil))
+	})
 
+	t.Run("missing parent interface errors", func(t *testing.T) {
+		mgr := &MacvlanManager{logger: slog.Default(), netlinkLinkLister: lister}
 		ifaces := []v2alpha1.MacvlanDeviceConfig{
-			{ParentIfName: "eth0", Mode: "bridge", Count: 2},
-			{ParentIfName: "eth1", Mode: "bridge", Count: 1}, // eth1 not in link list
+			{ParentIfName: "missing0", Mode: "bridge", Count: 1},
 		}
-		mgr := newTestManager([]netlink.Link{parentLink("eth0", 1)}, ifaces)
-		installMockNetlinkOps(mgr, mock)
-
-		err := mgr.setupMacvlans(ifaces)
+		err := mgr.validateConfig(ifaces)
 		require.Error(t, err)
 		require.ErrorIs(t, err, errInterfaceNotFound)
-
-		require.Equal(t, []string{"eth0.0", "eth0.1"}, mock.added)
-		require.Equal(t, []string{"eth0.0", "eth0.1"}, mock.deleted)
 	})
 
-	t.Run("existing interfaces are skipped and not recreated", func(t *testing.T) {
-		mock := newMockNetlinkOps()
-
-		existingMacvlan := &netlink.Macvlan{
-			LinkAttrs: netlink.LinkAttrs{Name: "eth0.0", Index: 10, ParentIndex: 1, Flags: 1},
-			Mode:      netlink.MACVLAN_MODE_BRIDGE,
-		}
-
+	t.Run("invalid mode errors", func(t *testing.T) {
+		mgr := &MacvlanManager{logger: slog.Default(), netlinkLinkLister: lister}
 		ifaces := []v2alpha1.MacvlanDeviceConfig{
-			{ParentIfName: "eth0", Mode: "bridge", Count: 2},
+			{ParentIfName: "eth0", Mode: "bogus", Count: 1},
 		}
-		mgr := newTestManager([]netlink.Link{parentLink("eth0", 1), existingMacvlan}, ifaces)
-		installMockNetlinkOps(mgr, mock)
-
-		require.NoError(t, mgr.setupMacvlans(ifaces))
-		// eth0.0 was skipped; only eth0.1 should have been created.
-		require.Equal(t, []string{"eth0.1"}, mock.added)
-		require.Empty(t, mock.deleted)
-	})
-
-	t.Run("cleanup LinkDel error does not shadow original add error", func(t *testing.T) {
-		mock := newMockNetlinkOps()
-		mock.addErrors["eth0.1"] = errors.New("kernel add error")
-		mock.delErrors["eth0.0"] = errors.New("kernel del error")
-
-		ifaces := []v2alpha1.MacvlanDeviceConfig{
-			{ParentIfName: "eth0", Mode: "bridge", Count: 2},
-		}
-		mgr := newTestManager([]netlink.Link{parentLink("eth0", 1)}, ifaces)
-		installMockNetlinkOps(mgr, mock)
-
-		err := mgr.setupMacvlans(ifaces)
+		err := mgr.validateConfig(ifaces)
 		require.Error(t, err)
-		require.ErrorContains(t, err, "eth0.1")
-		require.ErrorContains(t, err, "kernel add error")
-		require.NotErrorIs(t, err, errors.New("kernel del error"), "cleanup errors must not propagate")
-
-		// Cleanup was still attempted for the successfully created eth0.0.
-		require.Equal(t, []string{"eth0.0"}, mock.deleted)
+		require.ErrorContains(t, err, "bogus")
 	})
 }

--- a/pkg/networkdriver/nri.go
+++ b/pkg/networkdriver/nri.go
@@ -167,13 +167,14 @@ func (driver *Driver) RunPodSandbox(ctx context.Context, podSandbox *api.PodSand
 						return fmt.Errorf("failed to set interface name: %w", err)
 					}
 
+					if err := netlink.LinkSetUp(l); err != nil {
+						return err
+					}
+
 					if err := driver.configureIPs(l, add, a.Config.IPv4Addr, a.Config.IPv6Addr); err != nil {
 						return err
 					}
 					if err := driver.configureRoutes(log, l, add, a.Config.Routes); err != nil {
-						return err
-					}
-					if err := netlink.LinkSetUp(l); err != nil {
 						return err
 					}
 
@@ -245,6 +246,12 @@ func (driver *Driver) StopPodSandbox(ctx context.Context, podSandbox *api.PodSan
 		for _, devices := range alloc {
 			if err := podNs.Do(func() error {
 				for _, a := range devices {
+					if a.Manager == types.DeviceManagerTypeMacvlan {
+						// macvlan does not need cleaning up - netns delete
+						// gets rid of it.
+						continue
+					}
+
 					// Determine the interface name in the pod namespace
 					ifName := a.Device.KernelIfName()
 					if a.Config.PodIfName != "" {

--- a/pkg/networkdriver/nri.go
+++ b/pkg/networkdriver/nri.go
@@ -153,7 +153,38 @@ func (driver *Driver) RunPodSandbox(ctx context.Context, podSandbox *api.PodSand
 			for _, a := range devices {
 				l, err := safenetlink.LinkByName(a.Device.KernelIfName())
 				if err != nil {
-					return err
+					// The kernel link can be absent here when the node
+					// rebooted: the reboot reaped the pod netns (and with
+					// it any on-demand device such as a macvlan
+					// sub-interface), and the restore path rebuilt the
+					// in-memory allocation WITHOUT re-creating the kernel
+					// device — Device.Setup runs only on the prepare path,
+					// which is short-circuited for a restored allocation.
+					//
+					// Only the (re)creation of the sandbox drives
+					// RunPodSandbox, so this is the one moment that
+					// unambiguously means "the device must exist now but
+					// doesn't". An agent restart leaves the sandbox intact
+					// and never reaches here, so re-creating on demand
+					// cannot duplicate a healthy in-pod link. Every
+					// Device.Setup is idempotent (macvlan adopts/recreates
+					// via EEXIST, sr-iov re-applies VLAN, dummy is a no-op),
+					// so this is safe to retry.
+					if !errors.As(err, &netlink.LinkNotFoundError{}) {
+						return err
+					}
+
+					log.InfoContext(ctx, "allocated device link not found; re-creating on demand",
+						logfields.Device, a.Device.KernelIfName())
+
+					if setupErr := a.Device.Setup(a.Config); setupErr != nil {
+						return fmt.Errorf("failed to re-create device %s on demand: %w", a.Device.KernelIfName(), setupErr)
+					}
+
+					l, err = safenetlink.LinkByName(a.Device.KernelIfName())
+					if err != nil {
+						return fmt.Errorf("device %s still not found after re-creating it on demand: %w", a.Device.KernelIfName(), err)
+					}
 				}
 
 				if err := netlink.LinkSetNsFd(l, podNs.FD()); err != nil {
@@ -246,9 +277,11 @@ func (driver *Driver) StopPodSandbox(ctx context.Context, podSandbox *api.PodSan
 		for _, devices := range alloc {
 			if err := podNs.Do(func() error {
 				for _, a := range devices {
-					if a.Manager == types.DeviceManagerTypeMacvlan {
-						// macvlan does not need cleaning up - netns delete
-						// gets rid of it.
+					if a.Manager == types.DeviceManagerTypeMacvlan ||
+						a.Manager == types.DeviceManagerTypeDummy {
+						// macvlan and dummy are on-demand virtual devices: the
+						// netns delete that follows tears them down, so there is
+						// nothing to move back to the root namespace.
 						continue
 					}
 

--- a/pkg/networkdriver/nri_test.go
+++ b/pkg/networkdriver/nri_test.go
@@ -23,7 +23,8 @@ import (
 	kubetypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
-	"github.com/cilium/cilium/pkg/networkdriver/dummy"
+	"github.com/cilium/cilium/pkg/networkdriver/macvlan"
+	"github.com/cilium/cilium/pkg/networkdriver/sriov"
 	"github.com/cilium/cilium/pkg/networkdriver/types"
 	"github.com/cilium/cilium/pkg/testutils"
 	testnetns "github.com/cilium/cilium/pkg/testutils/netns"
@@ -41,11 +42,18 @@ import (
 //   - "stop recovers netns from Synchronize after restart": containerd < 2.1 across an
 //     agent restart; the in-memory cache is lost and rebuilt from the NRI Synchronize
 //     replay before the buggy StopPodSandbox arrives.
+//
+// sr-iov is used deliberately: macvlan and dummy are on-demand virtual devices that
+// StopPodSandbox leaves in the pod netns to be reaped on netns deletion, so sr-iov is the
+// only type that still travels back to root and exercises the rename/move-back/IP-and-route
+// teardown path asserted below. The kernel link is a netlink.Dummy stand-in because a real
+// VF cannot be created in a unit test; only the allocation's Manager (SRIOV) drives the
+// code path under test.
 func TestPrivilegedRunStopPodSandbox(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
 	const (
-		deviceName = "dummy0"
+		deviceName = "sriovvf0"
 		podIfName  = "net1"
 	)
 
@@ -65,9 +73,10 @@ func TestPrivilegedRunStopPodSandbox(t *testing.T) {
 	)
 
 	// setup builds a fresh network scaffold and driver for a single subtest: a root and
-	// a pod netns (pinned and wired into the package path globals), a dummy device in the
-	// root netns, and a Driver holding one allocation for that device. Returns the driver
-	// plus the handles each subtest needs. All cleanup is registered on the subtest's t.
+	// a pod netns (pinned and wired into the package path globals), an sr-iov VF stand-in
+	// (a netlink.Dummy, since a real VF cannot be created in a unit test) in the root
+	// netns, and a Driver holding one allocation for that device. Returns the driver plus
+	// the handles each subtest needs. All cleanup is registered on the subtest's t.
 	setup := func(t *testing.T) (driver *Driver, rootNS, podNS *testnetns.NetNS, podNSPath string) {
 		t.Helper()
 
@@ -106,13 +115,13 @@ func TestPrivilegedRunStopPodSandbox(t *testing.T) {
 				podUID: {
 					claimUID: {
 						{
-							Device: &dummy.DummyDevice{Name: deviceName},
+							Device: &sriov.PciDevice{KernelIfaceName: deviceName},
 							Config: types.DeviceConfig{
 								IPv4Addr:  ipv4Addr,
 								PodIfName: podIfName,
 								Routes:    routes,
 							},
-							Manager: types.DeviceManagerTypeDummy,
+							Manager: types.DeviceManagerTypeSRIOV,
 						},
 					},
 				},
@@ -370,6 +379,150 @@ func TestPrivilegedRunStopPodSandbox(t *testing.T) {
 
 		assertBuggyStopRecovers(t, driver, rootNS, podNS)
 	})
+}
+
+// TestPrivilegedRunPodSandboxRecreatesMissingDevice reproduces the post-reboot
+// state: a macvlan allocation has been restored into driver.allocations, but the
+// on-demand kernel link does not exist (the reboot reaped the pod netns and the
+// link along with it, and the restore path does not call Device.Setup). The first
+// RunPodSandbox after the reboot must re-create the link on demand and move it
+// into the pod, instead of failing with "Link not found" and crash-looping the
+// sandbox.
+//
+// macvlan is used deliberately: it is the only device type whose Setup creates a
+// kernel link, so it is the only type that can reach this state.
+func TestPrivilegedRunPodSandboxRecreatesMissingDevice(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	const (
+		rootNSName = "nri-recreate-root"
+		podNSName  = "nri-recreate-pod"
+		parentName = "nri-parent0"
+		kernelName = "nri-parent0.7"
+		podIfName  = "mvl0"
+	)
+
+	var (
+		podUID   = kubetypes.UID("cccccccc-0000-0000-0000-000000000003")
+		claimUID = kubetypes.UID("dddddddd-0000-0000-0000-000000000004")
+		ipv4Addr = netip.MustParsePrefix("10.20.0.1/24")
+	)
+
+	rootNS := testnetns.NewNetNS(t)
+	podNS := testnetns.NewNetNS(t)
+
+	pinDir := t.TempDir()
+	rootNSPath := filepath.Join(pinDir, rootNSName)
+	podNSPath := filepath.Join(pinDir, podNSName)
+	pinNetNS(t, rootNS, rootNSPath)
+	pinNetNS(t, podNS, podNSPath)
+
+	origPodNetNSPath := podNetNSPath
+	origRootNetNSPath := rootNetNSPath
+	t.Cleanup(func() {
+		podNetNSPath = origPodNetNSPath
+		rootNetNSPath = origRootNetNSPath
+	})
+	podNetNSPath = pinDir
+	rootNetNSPath = rootNSPath
+
+	// Create only the macvlan parent in root. The macvlan sub-interface itself
+	// is deliberately absent — this is the crux of the post-reboot bug.
+	require.NoError(t, rootNS.Do(func() error {
+		return netlink.LinkAdd(&netlink.Dummy{
+			LinkAttrs: netlink.LinkAttrs{Name: parentName},
+		})
+	}))
+
+	require.NoError(t, rootNS.Do(func() error {
+		if _, err := safenetlink.LinkByName(kernelName); err == nil {
+			return fmt.Errorf("precondition failed: %q must not exist before RunPodSandbox", kernelName)
+		}
+		return nil
+	}))
+
+	driver := &Driver{
+		logger: hivetest.Logger(t),
+		allocations: map[kubetypes.UID]map[kubetypes.UID][]allocation{
+			podUID: {
+				claimUID: {
+					{
+						Device: &macvlan.MacvlanDevice{
+							Name:            "nri-parent0-7",
+							ParentName:      parentName,
+							KernelIfaceName: kernelName,
+							Mode:            netlink.MACVLAN_MODE_BRIDGE,
+						},
+						Config: types.DeviceConfig{
+							IPv4Addr:  ipv4Addr,
+							PodIfName: podIfName,
+						},
+						Manager: types.DeviceManagerTypeMacvlan,
+					},
+				},
+			},
+		},
+		podNetns:    make(map[kubetypes.UID]string),
+		ipv4Enabled: true,
+	}
+	podSandbox := &api.PodSandbox{
+		Name:      "test-recreate-pod",
+		Uid:       string(podUID),
+		Namespace: "default",
+		Linux: &api.LinuxPodSandbox{
+			Namespaces: []*api.LinuxNamespace{
+				{
+					Type: "network",
+					Path: podNSPath,
+				},
+			},
+		},
+	}
+
+	// RunPodSandbox must NOT fail even though the kernel link is missing: it
+	// re-creates it on demand via Device.Setup.
+	require.NoError(t, rootNS.Do(func() error {
+		return driver.RunPodSandbox(t.Context(), podSandbox)
+	}))
+
+	// The re-created link must end up in the pod netns under the pod-facing name.
+	require.NoError(t, podNS.Do(func() error {
+		link, err := safenetlink.LinkByName(podIfName)
+		if err != nil {
+			return fmt.Errorf("expected re-created %q to be present in pod netns: %w", podIfName, err)
+		}
+		if _, ok := link.(*netlink.Macvlan); !ok {
+			return fmt.Errorf("expected %q to be a macvlan, got %T", podIfName, link)
+		}
+		if link.Attrs().Flags&net.FlagUp == 0 {
+			return fmt.Errorf("expected %q to be up", podIfName)
+		}
+
+		addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
+		if err != nil {
+			return fmt.Errorf("failed to list %q addresses", podIfName)
+		}
+		if found := slices.ContainsFunc(addrs, func(addr netlink.Addr) bool {
+			prefix, ok := netipx.FromStdIPNet(addr.IPNet)
+			if !ok {
+				return false
+			}
+			return ipv4Addr.Compare(prefix) == 0
+		}); !found {
+			return fmt.Errorf("expected address %q to be assigned to %q", ipv4Addr, podIfName)
+		}
+
+		return nil
+	}))
+
+	// Nothing must be left behind in root: the on-demand link lives only in the
+	// pod, exactly as it would after a healthy initial prepare.
+	require.NoError(t, rootNS.Do(func() error {
+		if _, err := safenetlink.LinkByName(kernelName); err == nil {
+			return fmt.Errorf("expected %q not to remain in root netns", kernelName)
+		}
+		return nil
+	}))
 }
 
 func pinNetNS(t *testing.T, ns *testnetns.NetNS, target string) {

--- a/pkg/networkdriver/script_test.go
+++ b/pkg/networkdriver/script_test.go
@@ -173,9 +173,9 @@ func TestScript(t *testing.T) {
 						},
 						devices: map[types.DeviceManagerType][]types.Device{
 							types.DeviceManagerTypeDummy: {
-								&dummy.DummyDevice{Name: testDevice1},
-								&dummy.DummyDevice{Name: testDevice2},
-								&dummy.DummyDevice{Name: testDevice3},
+								noSetupDummyDevice{&dummy.DummyDevice{Name: testDevice1}},
+								noSetupDummyDevice{&dummy.DummyDevice{Name: testDevice2}},
+								noSetupDummyDevice{&dummy.DummyDevice{Name: testDevice3}},
 							},
 						},
 						allocations:            make(map[kubetypes.UID]map[kubetypes.UID][]allocation),
@@ -423,6 +423,20 @@ func toNamespacedName(s string) (kubetypes.NamespacedName, error) {
 		return kubetypes.NamespacedName{}, fmt.Errorf("invalid claim name: %s", s)
 	}
 }
+
+// noSetupDummyDevice wraps a dummy.DummyDevice for the non-privileged script
+// test. It keeps the embedded device's marshaling, attributes and naming (which
+// the expected.yaml fixtures depend on) but stubs out Setup/Free, whose real
+// implementations call netlink.LinkAdd/LinkDel and require CAP_NET_ADMIN that
+// this unit test does not have.
+type noSetupDummyDevice struct {
+	*dummy.DummyDevice
+}
+
+func (noSetupDummyDevice) Setup(types.DeviceConfig) error { return nil }
+func (noSetupDummyDevice) Free(types.DeviceConfig) error  { return nil }
+
+var _ types.Device = noSetupDummyDevice{}
 
 type testLocalNodeSynchronizer struct{}
 


### PR DESCRIPTION
a problem with relying on software interfaces to exist prior to agent startup is
that the interfaces usually disappear on node reboots, and this can be problematic
for workloads that were assigned a device but remained in the rebooted node (ex: static pods)
another gap in the current implementation is that the discovery is done by inspecting the kernel
devices in the root namespace without remembering the previous state or netns awareness. if a software
device gets assigned, it disappears from the root namespace and the next publish cycle ends up missing
the allocated device.

this PR addresses both of these shortcomings by advertising a "count" of software devices, and upon
pod startup the devices are created on demand (if they do not exist). the devices published are "fake" devices,
the choice of not using consumable capacity right now (the idiomatic way of doing this, imo) is that
it is still a [relatively early feature in k8s ](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#:~:text=Consumable%20capacity,-FEATURE%20STATE%3A%20Kubernetes&text=The%20consumable%20capacity%20feature%20allows,used%20up%20by%20each%20claim.)

```release-note
network driver: agent to create software ifaces on demand instead of just discovering them from the root ns
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail AIL 3
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
