### PR TITLE
Datapath Plugins (CFP-41634) Part 4: Plugin Coordination

### DIFF
--- a/pkg/bpf/collection.go
+++ b/pkg/bpf/collection.go
@@ -48,9 +48,9 @@ func isEntrypoint(prog *ebpf.ProgramSpec) bool {
 	return strings.HasSuffix(prog.SectionName, "/entry")
 }
 
-// isTailCall returns true if the program is marked with the __declare_tail()
+// IsTailCall returns true if the program is marked with the __declare_tail()
 // annotation.
-func isTailCall(prog *ebpf.ProgramSpec) bool {
+func IsTailCall(prog *ebpf.ProgramSpec) bool {
 	return strings.HasSuffix(prog.SectionName, "/tail")
 }
 
@@ -58,7 +58,7 @@ func isTailCall(prog *ebpf.ProgramSpec) bool {
 // marked with the __declare_tail() annotation. The slot is the index in the
 // calls map that the program will be called from.
 func tailCallSlot(prog *ebpf.ProgramSpec) (uint32, error) {
-	if !isTailCall(prog) {
+	if !IsTailCall(prog) {
 		return 0, fmt.Errorf("program %s is not a tail call", prog.Name)
 	}
 
@@ -92,7 +92,7 @@ func resolveTailCalls(spec *ebpf.CollectionSpec) error {
 
 	slots := make(map[uint32]struct{})
 	for name, prog := range spec.Programs {
-		if !isTailCall(prog) {
+		if !IsTailCall(prog) {
 			continue
 		}
 

--- a/pkg/bpf/unused_tailcalls.go
+++ b/pkg/bpf/unused_tailcalls.go
@@ -43,7 +43,7 @@ func tailCallSlots(reach reachables) (map[uint32]*reachableSpec, error) {
 	// Build a map of tail call slots to reachableSpecs.
 	tails := make(map[uint32]*reachableSpec)
 	for _, r := range reach {
-		if !isTailCall(r.ProgramSpec) {
+		if !IsTailCall(r.ProgramSpec) {
 			continue
 		}
 
@@ -152,7 +152,7 @@ func visitProgram(r *reachableSpec, tails map[uint32]*reachableSpec, visited *se
 func deleteUnused(spec *ebpf.CollectionSpec, live *set.Set[*ebpf.ProgramSpec], logger *slog.Logger) {
 	var deleted []string
 	for name, prog := range spec.Programs {
-		if !isTailCall(prog) {
+		if !IsTailCall(prog) {
 			continue
 		}
 

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -230,10 +230,11 @@ func reinitializeOverlay(ctx context.Context, logger *slog.Logger, reg *registry
 	return nil
 }
 
-func reinitializeWireguard(ctx context.Context, logger *slog.Logger, reg *registry.MapRegistry, lnc *config.Config) (err error) {
+func reinitializeWireguard(ctx context.Context, logger *slog.Logger, reg *registry.MapRegistry, collLoader *bpfCollectionLoader, lnc *config.Config) (err error) {
 	if !lnc.EnableWireguard {
 		cleanCallsMaps("cilium_calls_wireguard*")
 
+		os.RemoveAll(bpffsDeviceNameDir(bpf.CiliumPath(), wgTypes.IfaceName))
 		os.RemoveAll(bpfStateDeviceDir(wgTypes.IfaceName))
 
 		return
@@ -244,7 +245,7 @@ func reinitializeWireguard(ctx context.Context, logger *slog.Logger, reg *regist
 		return fmt.Errorf("failed to retrieve link for interface %s: %w", wgTypes.IfaceName, err)
 	}
 
-	if err := replaceWireguardDatapath(ctx, logger, reg, lnc, link); err != nil {
+	if err := replaceWireguardDatapath(ctx, logger, reg, collLoader, lnc, link); err != nil {
 		return fmt.Errorf("failed to load wireguard programs: %w", err)
 	}
 	return
@@ -429,7 +430,7 @@ func (l *loader) Reinitialize(ctx context.Context, lnc *config.Config, tunnelCon
 		logging.Fatal(l.logger, "C and Go structs alignment check failed", logfields.Error, err)
 	}
 
-	if err := reinitializeWireguard(ctx, l.logger, l.registry, lnc); err != nil {
+	if err := reinitializeWireguard(ctx, l.logger, l.registry, l.bpfCollectionLoader, lnc); err != nil {
 		return err
 	}
 

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -408,7 +408,7 @@ func (l *loader) Reinitialize(ctx context.Context, lnc *config.Config, tunnelCon
 		if err := compileWithOptions(ctx, l.logger, socketProg, socketObj, nil); err != nil {
 			logging.Fatal(l.logger, "failed to compile bpf_sock.c", logfields.Error, err)
 		}
-		if err := socketlb.Enable(l.logger, l.registry, l.sysctl, lnc); err != nil {
+		if err := socketlb.Enable(ctx, l.logger, l.registry, l.bpfCollectionLoader, l.sysctl, lnc); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -204,15 +204,16 @@ func cleanCallsMaps(mapNamePattern string) error {
 }
 
 func reinitializeOverlay(ctx context.Context, logger *slog.Logger, reg *registry.MapRegistry,
-	lnc *config.Config, tunnelConfig tunnel.Config) error {
+	collLoader *bpfCollectionLoader, lnc *config.Config, tunnelConfig tunnel.Config) error {
 	// tunnelConfig.EncapProtocol() can be one of tunnel.[Disabled, VXLAN, Geneve]
 	// if it is disabled, the overlay network programs don't have to be (re)initialized
 	if tunnelConfig.EncapProtocol() == tunnel.Disabled {
 		cleanCallsMaps("cilium_calls_overlay*")
 
+		os.RemoveAll(bpffsDeviceNameDir(bpf.CiliumPath(), defaults.VxlanDevice))
 		os.RemoveAll(bpfStateDeviceDir(defaults.VxlanDevice))
+		os.RemoveAll(bpffsDeviceNameDir(bpf.CiliumPath(), defaults.GeneveDevice))
 		os.RemoveAll(bpfStateDeviceDir(defaults.GeneveDevice))
-
 		return nil
 	}
 
@@ -222,7 +223,7 @@ func reinitializeOverlay(ctx context.Context, logger *slog.Logger, reg *registry
 		return fmt.Errorf("failed to retrieve link for interface %s: %w", iface, err)
 	}
 
-	if err := replaceOverlayDatapath(ctx, logger, reg, lnc, link); err != nil {
+	if err := replaceOverlayDatapath(ctx, logger, reg, collLoader, lnc, link); err != nil {
 		return fmt.Errorf("failed to load overlay programs: %w", err)
 	}
 
@@ -432,7 +433,7 @@ func (l *loader) Reinitialize(ctx context.Context, lnc *config.Config, tunnelCon
 		return err
 	}
 
-	if err := reinitializeOverlay(ctx, l.logger, l.registry, lnc, tunnelConfig); err != nil {
+	if err := reinitializeOverlay(ctx, l.logger, l.registry, l.bpfCollectionLoader, lnc, tunnelConfig); err != nil {
 		return err
 	}
 

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -252,7 +252,7 @@ func reinitializeWireguard(ctx context.Context, logger *slog.Logger, reg *regist
 }
 
 func reinitializeXDPLocked(ctx context.Context, logger *slog.Logger, reg *registry.MapRegistry,
-	lnc *config.Config, devices []string) error {
+	collLoader *bpfCollectionLoader, lnc *config.Config, devices []string) error {
 	xdpConfig := lnc.XDPConfig
 	maybeUnloadObsoleteXDPPrograms(logger, devices, xdpConfig.Mode(), bpf.CiliumPath())
 	if xdpConfig.Disabled() {
@@ -267,7 +267,7 @@ func reinitializeXDPLocked(ctx context.Context, logger *slog.Logger, reg *regist
 			continue
 		}
 
-		if err := compileAndLoadXDPProg(ctx, logger, reg, lnc, dev, xdpConfig.Mode()); err != nil {
+		if err := compileAndLoadXDPProg(ctx, logger, reg, collLoader, lnc, dev, xdpConfig.Mode()); err != nil {
 			if option.Config.NodePortAcceleration == option.XDPModeBestEffort {
 				logger.Info("Failed to attach XDP program, ignoring due to best-effort mode",
 					logfields.Error, err,
@@ -417,7 +417,7 @@ func (l *loader) Reinitialize(ctx context.Context, lnc *config.Config, tunnelCon
 		}
 	}
 
-	if err := reinitializeXDPLocked(ctx, l.logger, l.registry, lnc, devices); err != nil {
+	if err := reinitializeXDPLocked(ctx, l.logger, l.registry, l.bpfCollectionLoader, lnc, devices); err != nil {
 		logging.Fatal(l.logger, "Failed to compile XDP program", logfields.Error, err)
 	}
 

--- a/pkg/datapath/loader/endpoint.go
+++ b/pkg/datapath/loader/endpoint.go
@@ -109,7 +109,7 @@ func (l *loader) ReloadDatapath(ctx context.Context, ep endpoint.Endpoint, lnc *
 
 	// Reload an lxc endpoint program.
 	stats.BpfLoadProg.Start()
-	err = reloadEndpoint(l.logger, l.registry, l.db, l.devices, l.routeManager, ep, lnc, spec)
+	err = reloadEndpoint(ctx, l.logger, l.registry, l.bpfCollectionLoader, l.db, l.devices, l.routeManager, ep, lnc, spec)
 	stats.BpfLoadProg.End(err == nil)
 	return hash, err
 }
@@ -192,12 +192,12 @@ func defaultEndpointMapRenames(ep endpoint.Config, lnc *config.Config) map[strin
 //
 // spec is modified by the method and it is the callers responsibility to copy
 // it if necessary.
-func reloadEndpoint(logger *slog.Logger, reg *registry.MapRegistry, db *statedb.DB,
-	devices statedb.Table[*tables.Device], rm *routeReconciler.DesiredRouteManager,
+func reloadEndpoint(ctx context.Context, logger *slog.Logger, reg *registry.MapRegistry, collLoader *bpfCollectionLoader,
+	db *statedb.DB, devices statedb.Table[*tables.Device], rm *routeReconciler.DesiredRouteManager,
 	ep endpoint.Endpoint, lnc *config.Config, spec *ebpf.CollectionSpec) error {
 
 	var obj lxcObjects
-	commit, err := bpf.LoadAndAssign(logger, &obj, spec, &bpf.CollectionOptions{
+	commit, cleanup, err := collLoader.LoadAndAssign(ctx, logger, &obj, spec, &bpf.CollectionOptions{
 		MapRegistry: reg,
 		CollectionOptions: ebpf.CollectionOptions{
 			Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
@@ -205,10 +205,11 @@ func reloadEndpoint(logger *slog.Logger, reg *registry.MapRegistry, db *statedb.
 		Constants:      endpointConfiguration(ep, lnc),
 		MapRenames:     endpointMapRenames(ep, lnc),
 		ConfigDumpPath: filepath.Join(ep.StateDir(), endpointConfig),
-	})
+	}, lnc, attachmentContextLXC(ep), bpffsEndpointPluginPinsDir(bpf.CiliumPath(), ep))
 	if err != nil {
 		return err
 	}
+	defer cleanup()
 	defer obj.Close()
 
 	// Insert policy programs before attaching entrypoints to tc hooks.

--- a/pkg/datapath/loader/endpoint.go
+++ b/pkg/datapath/loader/endpoint.go
@@ -96,7 +96,7 @@ func (l *loader) ReloadDatapath(ctx context.Context, ep endpoint.Endpoint, lnc *
 	if ep.IsHost() {
 		// Reload bpf programs on cilium_host and cilium_net.
 		stats.BpfLoadProg.Start()
-		err = reloadHostEndpoint(l.logger, l.registry, ep, lnc, spec)
+		err = reloadHostEndpoint(ctx, l.logger, l.registry, l.bpfCollectionLoader, ep, lnc, spec)
 		stats.BpfLoadProg.End(err == nil)
 
 		l.hostDpInitializedOnce.Do(func() {

--- a/pkg/datapath/loader/host.go
+++ b/pkg/datapath/loader/host.go
@@ -4,6 +4,7 @@
 package loader
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net/netip"
@@ -43,18 +44,19 @@ const (
 
 // reloadHostEndpoint (re)attaches programs from bpf_host.c to cilium_host,
 // cilium_net and external (native) devices.
-func reloadHostEndpoint(logger *slog.Logger, reg *registry.MapRegistry, ep endpoint.Endpoint,
+func reloadHostEndpoint(ctx context.Context, logger *slog.Logger, reg *registry.MapRegistry,
+	collLoader *bpfCollectionLoader, ep endpoint.Endpoint,
 	lnc *config.Config, spec *ebpf.CollectionSpec) error {
 	// Replace programs on cilium_host.
-	if err := attachCiliumHost(logger, reg, ep, lnc, spec); err != nil {
+	if err := attachCiliumHost(ctx, logger, reg, collLoader, ep, lnc, spec); err != nil {
 		return fmt.Errorf("attaching cilium_host: %w", err)
 	}
 
-	if err := attachCiliumNet(logger, reg, ep, lnc, spec); err != nil {
+	if err := attachCiliumNet(ctx, logger, reg, collLoader, ep, lnc, spec); err != nil {
 		return fmt.Errorf("attaching cilium_host: %w", err)
 	}
 
-	if err := attachNetworkDevices(logger, reg, ep, lnc, spec); err != nil {
+	if err := attachNetworkDevices(ctx, logger, reg, collLoader, ep, lnc, spec); err != nil {
 		return fmt.Errorf("attaching cilium_host: %w", err)
 	}
 
@@ -95,7 +97,8 @@ func defaultCiliumHostMapRenames(ep endpoint.Config, lnc *config.Config) map[str
 
 // attachCiliumHost inserts the host endpoint's policy program into the global
 // cilium_call_policy map and attaches programs from bpf_host.c to cilium_host.
-func attachCiliumHost(logger *slog.Logger, reg *registry.MapRegistry, ep endpoint.Endpoint,
+func attachCiliumHost(ctx context.Context, logger *slog.Logger, reg *registry.MapRegistry,
+	collLoader *bpfCollectionLoader, ep endpoint.Endpoint,
 	lnc *config.Config, spec *ebpf.CollectionSpec) error {
 	host, err := safenetlink.LinkByName(ep.InterfaceName())
 	if err != nil {
@@ -103,7 +106,7 @@ func attachCiliumHost(logger *slog.Logger, reg *registry.MapRegistry, ep endpoin
 	}
 
 	var hostObj hostObjects
-	commit, err := bpf.LoadAndAssign(logger, &hostObj, spec, &bpf.CollectionOptions{
+	commit, cleanup, err := collLoader.LoadAndAssign(ctx, logger, &hostObj, spec, &bpf.CollectionOptions{
 		MapRegistry: reg,
 		CollectionOptions: ebpf.CollectionOptions{
 			Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
@@ -111,10 +114,11 @@ func attachCiliumHost(logger *slog.Logger, reg *registry.MapRegistry, ep endpoin
 		Constants:      ciliumHostConfiguration(ep, lnc),
 		MapRenames:     ciliumHostMapRenames(ep, lnc),
 		ConfigDumpPath: filepath.Join(bpfStateDeviceDir(ep.InterfaceName()), hostEndpointConfig),
-	})
+	}, lnc, attachmentContextHost(ep, host), bpffsDevicePluginPinsTcDir(bpf.CiliumPath(), host))
 	if err != nil {
 		return err
 	}
+	defer cleanup()
 	defer hostObj.Close()
 
 	// Insert host endpoint policy program.
@@ -174,7 +178,8 @@ func defaultCiliumNetMapRenames(ep endpoint.Config, lnc *config.Config, link net
 }
 
 // attachCiliumNet attaches programs from bpf_host.c to cilium_net.
-func attachCiliumNet(logger *slog.Logger, reg *registry.MapRegistry, ep endpoint.Endpoint,
+func attachCiliumNet(ctx context.Context, logger *slog.Logger, reg *registry.MapRegistry,
+	collLoader *bpfCollectionLoader, ep endpoint.Endpoint,
 	lnc *config.Config, spec *ebpf.CollectionSpec) error {
 	net, err := safenetlink.LinkByName(defaults.SecondHostDevice)
 	if err != nil {
@@ -182,7 +187,7 @@ func attachCiliumNet(logger *slog.Logger, reg *registry.MapRegistry, ep endpoint
 	}
 
 	var netObj hostNetObjects
-	commit, err := bpf.LoadAndAssign(logger, &netObj, spec, &bpf.CollectionOptions{
+	commit, cleanup, err := collLoader.LoadAndAssign(ctx, logger, &netObj, spec, &bpf.CollectionOptions{
 		MapRegistry: reg,
 		CollectionOptions: ebpf.CollectionOptions{
 			Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
@@ -190,10 +195,11 @@ func attachCiliumNet(logger *slog.Logger, reg *registry.MapRegistry, ep endpoint
 		Constants:      ciliumNetConfiguration(ep, lnc, net),
 		MapRenames:     ciliumNetMapRenames(ep, lnc, net),
 		ConfigDumpPath: filepath.Join(bpfStateDeviceDir(defaults.SecondHostDevice), hostEndpointConfig),
-	})
+	}, lnc, attachmentContextHost(ep, net), bpffsDevicePluginPinsTcDir(bpf.CiliumPath(), net))
 	if err != nil {
 		return err
 	}
+	defer cleanup()
 	defer netObj.Close()
 
 	// Attach cil_to_host to cilium_net.
@@ -246,7 +252,7 @@ func defaultNetdevMapRenames(ep endpoint.Config, lnc *config.Config, link netlin
 // attachNetworkDevices attaches programs from bpf_host.c to externally-facing
 // devices and the wireguard device. Attaches cil_from_netdev to ingress and
 // optionally cil_to_netdev to egress if enabled features require it.
-func attachNetworkDevices(logger *slog.Logger, reg *registry.MapRegistry, ep endpoint.Endpoint, lnc *config.Config, spec *ebpf.CollectionSpec) error {
+func attachNetworkDevices(ctx context.Context, logger *slog.Logger, reg *registry.MapRegistry, collLoader *bpfCollectionLoader, ep endpoint.Endpoint, lnc *config.Config, spec *ebpf.CollectionSpec) error {
 	devices := lnc.DeviceNames()
 
 	// Replace programs on physical devices, ignoring devices that don't exist.
@@ -266,7 +272,7 @@ func attachNetworkDevices(logger *slog.Logger, reg *registry.MapRegistry, ep end
 			option.Config.EnableIPv4Masquerade, option.Config.EnableIPv6Masquerade)
 
 		var netdevObj hostNetdevObjects
-		commit, err := bpf.LoadAndAssign(logger, &netdevObj, spec, &bpf.CollectionOptions{
+		commit, cleanup, err := collLoader.LoadAndAssign(ctx, logger, &netdevObj, spec, &bpf.CollectionOptions{
 			MapRegistry: reg,
 			CollectionOptions: ebpf.CollectionOptions{
 				Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
@@ -274,10 +280,11 @@ func attachNetworkDevices(logger *slog.Logger, reg *registry.MapRegistry, ep end
 			Constants:      netdevConfiguration(ep, lnc, iface, masq4, masq6),
 			MapRenames:     netdevMapRenames(ep, lnc, iface),
 			ConfigDumpPath: filepath.Join(bpfStateDeviceDir(iface.Attrs().Name), hostEndpointConfig),
-		})
+		}, lnc, attachmentContextHost(ep, iface), bpffsDevicePluginPinsTcDir(bpf.CiliumPath(), iface))
 		if err != nil {
 			return err
 		}
+		defer cleanup()
 		defer netdevObj.Close()
 
 		// Attach cil_from_netdev to ingress.

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -48,11 +48,12 @@ type loader struct {
 	hostDpInitializedOnce sync.Once
 	hostDpInitialized     chan struct{}
 
-	sysctl             sysctl.Sysctl
-	prefilter          prefilter.PreFilter
-	compilationLock    types.CompilationLock
-	configWriter       config.Writer
-	nodeConfigNotifier *manager.NodeConfigNotifier
+	sysctl              sysctl.Sysctl
+	prefilter           prefilter.PreFilter
+	compilationLock     types.CompilationLock
+	configWriter        config.Writer
+	nodeConfigNotifier  *manager.NodeConfigNotifier
+	bpfCollectionLoader *bpfCollectionLoader
 
 	db           *statedb.DB
 	devices      statedb.Table[*tables.Device]
@@ -83,20 +84,25 @@ type Params struct {
 // newLoader returns a new loader.
 func newLoader(p Params) *loader {
 	registerRouteInitializer(p)
+	collLoader := newBPFCollectionLoader(
+		option.Config.EnableDatapathPlugins,
+		bpffsPluginsOperationsDir(bpf.CiliumPath()),
+	)
+	collLoader.runGC(p.Logger, p.JobGroup)
 	return &loader{
-		logger:             p.Logger,
-		templateCache:      newObjectCache(p.Logger, p.ConfigWriter, filepath.Join(option.Config.StateDir, defaults.TemplatesDir)),
-		registry:           p.MapRegistry,
-		sysctl:             p.Sysctl,
-		hostDpInitialized:  make(chan struct{}),
-		prefilter:          p.Prefilter,
-		compilationLock:    p.CompilationLock,
-		configWriter:       p.ConfigWriter,
-		nodeConfigNotifier: p.NodeConfigNotifier,
-		routeManager:       p.RouteManager,
-
-		db:      p.DB,
-		devices: p.Devices,
+		logger:              p.Logger,
+		templateCache:       newObjectCache(p.Logger, p.ConfigWriter, filepath.Join(option.Config.StateDir, defaults.TemplatesDir)),
+		registry:            p.MapRegistry,
+		sysctl:              p.Sysctl,
+		hostDpInitialized:   make(chan struct{}),
+		prefilter:           p.Prefilter,
+		compilationLock:     p.CompilationLock,
+		configWriter:        p.ConfigWriter,
+		nodeConfigNotifier:  p.NodeConfigNotifier,
+		routeManager:        p.RouteManager,
+		bpfCollectionLoader: collLoader,
+		db:                  p.DB,
+		devices:             p.Devices,
 	}
 }
 

--- a/pkg/datapath/loader/netdev.go
+++ b/pkg/datapath/loader/netdev.go
@@ -100,12 +100,63 @@ func removeObsoleteNetdevPrograms(logger *slog.Logger, devices []string) error {
 		return fmt.Errorf("retrieving all netlink devices: %w", err)
 	}
 
-	// collect all devices that have netdev programs attached on either ingress or egress.
-	ingressDevs := []netlink.Link{}
-	egressDevs := []netlink.Link{}
 	for _, l := range links {
 		if !isObsoleteDev(l.Attrs().Name, devices) {
 			continue
+		}
+
+		ingressFilters, err := safenetlink.FilterList(l, directionToParent(dirIngress))
+		if err != nil {
+			return fmt.Errorf("listing ingress filters: %w", err)
+		}
+		for _, filter := range ingressFilters {
+			if bpfFilter, ok := filter.(*netlink.BpfFilter); ok {
+				if strings.HasPrefix(bpfFilter.Name, symbolFromHostNetdevEp) {
+					err = removeTCFilters(l, directionToParent(dirIngress))
+					if err != nil {
+						logger.Error(
+							"couldn't remove ingress tc filters",
+							logfields.Error, err,
+							logfields.Device, l.Attrs().Name,
+						)
+					}
+					break
+				}
+			}
+		}
+
+		egressFilters, err := safenetlink.FilterList(l, directionToParent(dirEgress))
+		if err != nil {
+			return fmt.Errorf("listing egress filters: %w", err)
+		}
+		for _, filter := range egressFilters {
+			if bpfFilter, ok := filter.(*netlink.BpfFilter); ok {
+				if strings.HasPrefix(bpfFilter.Name, symbolToHostNetdevEp) {
+					err = removeTCFilters(l, directionToParent(dirEgress))
+					if err != nil {
+						logger.Error(
+							"couldn't remove egress tc filters",
+							logfields.Error, err,
+							logfields.Device, l.Attrs().Name,
+						)
+					}
+					break
+				}
+			}
+		}
+
+		// It's important to remove the device links directory first to
+		// ensure that link-style attachments are removed before
+		// plugin hook freplace links. If these steps are reordered,
+		// plugin hook programs would be detached while the main
+		// attachment is still live, leading to inconsistent or
+		// undefined behavior.
+		linksPath := bpffsDeviceLinksDir(bpf.CiliumPath(), l)
+		if err := bpf.Remove(linksPath); err != nil {
+			logger.Error("Failed to remove bpffs entry",
+				logfields.Error, err,
+				logfields.BPFFSPath, linksPath,
+			)
 		}
 
 		// Remove the per-device bpffs directory containing pinned links and
@@ -124,52 +175,6 @@ func removeObsoleteNetdevPrograms(logger *slog.Logger, devices []string) error {
 			logger.Error("Failed to remove device state directory",
 				logfields.Error, err,
 				logfields.Path, statePath,
-			)
-		}
-
-		ingressFilters, err := safenetlink.FilterList(l, directionToParent(dirIngress))
-		if err != nil {
-			return fmt.Errorf("listing ingress filters: %w", err)
-		}
-		for _, filter := range ingressFilters {
-			if bpfFilter, ok := filter.(*netlink.BpfFilter); ok {
-				if strings.HasPrefix(bpfFilter.Name, symbolFromHostNetdevEp) {
-					ingressDevs = append(ingressDevs, l)
-				}
-			}
-		}
-
-		egressFilters, err := safenetlink.FilterList(l, directionToParent(dirEgress))
-		if err != nil {
-			return fmt.Errorf("listing egress filters: %w", err)
-		}
-		for _, filter := range egressFilters {
-			if bpfFilter, ok := filter.(*netlink.BpfFilter); ok {
-				if strings.HasPrefix(bpfFilter.Name, symbolToHostNetdevEp) {
-					egressDevs = append(egressDevs, l)
-				}
-			}
-		}
-	}
-
-	for _, dev := range ingressDevs {
-		err = removeTCFilters(dev, directionToParent(dirIngress))
-		if err != nil {
-			logger.Error(
-				"couldn't remove ingress tc filters",
-				logfields.Error, err,
-				logfields.Device, dev.Attrs().Name,
-			)
-		}
-	}
-
-	for _, dev := range egressDevs {
-		err = removeTCFilters(dev, directionToParent(dirEgress))
-		if err != nil {
-			logger.Error(
-				"couldn't remove egress tc filters",
-				logfields.Error, err,
-				logfields.Device, dev.Attrs().Name,
 			)
 		}
 	}

--- a/pkg/datapath/loader/overlay.go
+++ b/pkg/datapath/loader/overlay.go
@@ -60,7 +60,7 @@ func defaultOverlayMapRenames(lnc *config.Config, link netlink.Link) (renames ma
 }
 
 func replaceOverlayDatapath(ctx context.Context, logger *slog.Logger, reg *registry.MapRegistry,
-	lnc *config.Config, link netlink.Link) error {
+	collLoader *bpfCollectionLoader, lnc *config.Config, link netlink.Link) error {
 	if err := compileOverlay(ctx, logger); err != nil {
 		return fmt.Errorf("compiling overlay program: %w", err)
 	}
@@ -71,7 +71,7 @@ func replaceOverlayDatapath(ctx context.Context, logger *slog.Logger, reg *regis
 	}
 
 	var obj overlayObjects
-	commit, err := bpf.LoadAndAssign(logger, &obj, spec, &bpf.CollectionOptions{
+	commit, cleanup, err := collLoader.LoadAndAssign(ctx, logger, &obj, spec, &bpf.CollectionOptions{
 
 		MapRegistry: reg,
 		Constants:   overlayConfiguration(lnc, link),
@@ -80,10 +80,11 @@ func replaceOverlayDatapath(ctx context.Context, logger *slog.Logger, reg *regis
 			Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
 		},
 		ConfigDumpPath: filepath.Join(bpfStateDeviceDir(link.Attrs().Name), overlayConfig),
-	})
+	}, lnc, attachmentContextOverlay(link), bpffsDevicePluginPinsTcDir(bpf.CiliumPath(), link))
 	if err != nil {
 		return err
 	}
+	defer cleanup()
 	defer obj.Close()
 
 	linkDir := bpffsDeviceLinksDir(bpf.CiliumPath(), link)

--- a/pkg/datapath/loader/paths.go
+++ b/pkg/datapath/loader/paths.go
@@ -75,6 +75,18 @@ func bpffsEndpointLinksDir(base string, ep endpoint.Endpoint) string {
 	return filepath.Join(bpffsEndpointDir(base, ep), "links")
 }
 
+func bpffsPluginsOperationsDir(base string) string {
+	return filepath.Join(base, "plugins")
+}
+
+func bpffsPluginOperationsDir(base, plugin string) string {
+	return filepath.Join(base, plugin)
+}
+
+func bpffsPluginOperationDir(base, plugin, id string) string {
+	return filepath.Join(bpffsPluginOperationsDir(base, plugin), id)
+}
+
 // bpfStateDeviceDir returns the path to the per-device directory in the Cilium
 // state directory, usually /var/run/cilium/bpf/<device>. It does not ensure the
 // directory exists.

--- a/pkg/datapath/loader/paths.go
+++ b/pkg/datapath/loader/paths.go
@@ -58,6 +58,10 @@ func bpffsDevicePluginPinsTcDir(base string, device netlink.Link) string {
 	return bpffsDevicePluginPinsDir(base, device, "tc")
 }
 
+func bpffsDevicePluginPinsXdpDir(base string, device netlink.Link) string {
+	return bpffsDevicePluginPinsDir(base, device, "xdp")
+}
+
 // bpffsEndpointsDir returns the path to the 'endpoints' directory on bpffs, usually
 // /sys/fs/bpf/cilium/endpoints. It does not ensure the directory exists.
 //

--- a/pkg/datapath/loader/paths.go
+++ b/pkg/datapath/loader/paths.go
@@ -22,18 +22,22 @@ func bpffsDevicesDir(base string) string {
 	return filepath.Join(base, "devices")
 }
 
+func bpffsDeviceNameDir(base string, deviceName string) string {
+	// If a device name contains a "." we must sanitize the string to satisfy bpffs directory path
+	// requirements. The string of a directory path on bpffs is not allowed to contain any "." characters.
+	// By replacing "." with "-", we circurmvent this limitation. This also introduces a small
+	// risk of naming collisions, e.g "eth-0" and "eth.0" would translate to the same bpffs directory.
+	// The probability of this happening in practice should be very small.
+	return filepath.Join(bpffsDevicesDir(base), strings.ReplaceAll(deviceName, ".", "-"))
+}
+
 // bpffsDeviceDir returns the path to the per-device directory on bpffs, usually
 // /sys/fs/bpf/cilium/devices/<device>. It does not ensure the directory exists.
 //
 // base is typically set to /sys/fs/bpf/cilium, but can be a temp directory
 // during tests.
 func bpffsDeviceDir(base string, device netlink.Link) string {
-	// If a device name contains a "." we must sanitize the string to satisfy bpffs directory path
-	// requirements. The string of a directory path on bpffs is not allowed to contain any "." characters.
-	// By replacing "." with "-", we circurmvent this limitation. This also introduces a small
-	// risk of naming collisions, e.g "eth-0" and "eth.0" would translate to the same bpffs directory.
-	// The probability of this happening in practice should be very small.
-	return filepath.Join(bpffsDevicesDir(base), strings.ReplaceAll(device.Attrs().Name, ".", "-"))
+	return bpffsDeviceNameDir(base, device.Attrs().Name)
 }
 
 // bpffsDeviceLinksDir returns the bpffs path to the per-device links directory,

--- a/pkg/datapath/loader/paths.go
+++ b/pkg/datapath/loader/paths.go
@@ -75,6 +75,13 @@ func bpffsEndpointLinksDir(base string, ep endpoint.Endpoint) string {
 	return filepath.Join(bpffsEndpointDir(base, ep), "links")
 }
 
+// Keep this separate from bpffsEndpointLinksDir to ensure that when Unload()
+// runs and calls bpf.Remove() we don't accidentally unpin plugin hook programs
+// before the main attachment, since this would lead to undefined behavior.
+func bpffsEndpointPluginPinsDir(base string, ep endpoint.Endpoint) string {
+	return filepath.Join(bpffsEndpointDir(base, ep), "plugin_pins")
+}
+
 func bpffsPluginsOperationsDir(base string) string {
 	return filepath.Join(base, "plugins")
 }

--- a/pkg/datapath/loader/paths.go
+++ b/pkg/datapath/loader/paths.go
@@ -46,6 +46,14 @@ func bpffsDeviceLinksDir(base string, device netlink.Link) string {
 	return filepath.Join(bpffsDeviceDir(base, device), "links")
 }
 
+func bpffsDevicePluginPinsDir(base string, device netlink.Link, kind string) string {
+	return filepath.Join(bpffsDeviceDir(base, device), "plugins", kind)
+}
+
+func bpffsDevicePluginPinsTcDir(base string, device netlink.Link) string {
+	return bpffsDevicePluginPinsDir(base, device, "tc")
+}
+
 // bpffsEndpointsDir returns the path to the 'endpoints' directory on bpffs, usually
 // /sys/fs/bpf/cilium/endpoints. It does not ensure the directory exists.
 //

--- a/pkg/datapath/loader/plugins.go
+++ b/pkg/datapath/loader/plugins.go
@@ -91,6 +91,16 @@ func attachmentContextWireguard(device netlink.Link) *datapathplugins.Attachment
 	}
 }
 
+func attachmentContextXDP(device netlink.Link) *datapathplugins.AttachmentContext {
+	return &datapathplugins.AttachmentContext{
+		Context: &datapathplugins.AttachmentContext_Xdp{
+			Xdp: &datapathplugins.AttachmentContext_XDP{
+				Iface: linkToInterfaceInfo(device),
+			},
+		},
+	}
+}
+
 // bpfCollectionLoader coordinates between datapath plugins when loading a BPF
 // collection. It provides an interface similar to the usual bpf.Load and
 // bpf.LoadAndAssign functions.

--- a/pkg/datapath/loader/plugins.go
+++ b/pkg/datapath/loader/plugins.go
@@ -81,6 +81,16 @@ func attachmentContextOverlay(device netlink.Link) *datapathplugins.AttachmentCo
 	}
 }
 
+func attachmentContextWireguard(device netlink.Link) *datapathplugins.AttachmentContext {
+	return &datapathplugins.AttachmentContext{
+		Context: &datapathplugins.AttachmentContext_Wireguard_{
+			Wireguard: &datapathplugins.AttachmentContext_Wireguard{
+				Iface: linkToInterfaceInfo(device),
+			},
+		},
+	}
+}
+
 // bpfCollectionLoader coordinates between datapath plugins when loading a BPF
 // collection. It provides an interface similar to the usual bpf.Load and
 // bpf.LoadAndAssign functions.

--- a/pkg/datapath/loader/plugins.go
+++ b/pkg/datapath/loader/plugins.go
@@ -71,6 +71,16 @@ func attachmentContextLXC(ep endpoint.Endpoint) *datapathplugins.AttachmentConte
 	}
 }
 
+func attachmentContextOverlay(device netlink.Link) *datapathplugins.AttachmentContext {
+	return &datapathplugins.AttachmentContext{
+		Context: &datapathplugins.AttachmentContext_Overlay_{
+			Overlay: &datapathplugins.AttachmentContext_Overlay{
+				Iface: linkToInterfaceInfo(device),
+			},
+		},
+	}
+}
+
 // bpfCollectionLoader coordinates between datapath plugins when loading a BPF
 // collection. It provides an interface similar to the usual bpf.Load and
 // bpf.LoadAndAssign functions.

--- a/pkg/datapath/loader/plugins.go
+++ b/pkg/datapath/loader/plugins.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/bpf/analyze"
 	"github.com/cilium/cilium/pkg/datapath/config"
 	plugin "github.com/cilium/cilium/pkg/datapath/plugins/types"
+	endpoint "github.com/cilium/cilium/pkg/endpoint/types"
 	api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -36,6 +37,22 @@ import (
 const (
 	bpfLoaderGCRetryInterval = time.Minute
 )
+
+func attachmentContextLXC(ep endpoint.Endpoint) *datapathplugins.AttachmentContext {
+	return &datapathplugins.AttachmentContext{
+		Context: &datapathplugins.AttachmentContext_Lxc{
+			Lxc: &datapathplugins.AttachmentContext_LXC{
+				Iface: &datapathplugins.AttachmentContext_InterfaceInfo{
+					Name: ep.InterfaceName(),
+				},
+				PodInfo: &datapathplugins.AttachmentContext_PodInfo{
+					Namespace: ep.GetK8sNamespace(),
+					Name:      ep.GetK8sPodName(),
+				},
+			},
+		},
+	}
+}
 
 // bpfCollectionLoader coordinates between datapath plugins when loading a BPF
 // collection. It provides an interface similar to the usual bpf.Load and

--- a/pkg/datapath/loader/plugins.go
+++ b/pkg/datapath/loader/plugins.go
@@ -32,11 +32,28 @@ import (
 	"github.com/cilium/cilium/pkg/time"
 
 	"github.com/google/uuid"
+	"github.com/vishvananda/netlink"
 )
 
 const (
 	bpfLoaderGCRetryInterval = time.Minute
 )
+
+func linkToInterfaceInfo(l netlink.Link) *datapathplugins.AttachmentContext_InterfaceInfo {
+	return &datapathplugins.AttachmentContext_InterfaceInfo{
+		Name: l.Attrs().Name,
+	}
+}
+
+func attachmentContextHost(ep endpoint.Endpoint, device netlink.Link) *datapathplugins.AttachmentContext {
+	return &datapathplugins.AttachmentContext{
+		Context: &datapathplugins.AttachmentContext_Host_{
+			Host: &datapathplugins.AttachmentContext_Host{
+				Iface: linkToInterfaceInfo(device),
+			},
+		},
+	}
+}
 
 func attachmentContextLXC(ep endpoint.Endpoint) *datapathplugins.AttachmentContext {
 	return &datapathplugins.AttachmentContext{

--- a/pkg/datapath/loader/plugins.go
+++ b/pkg/datapath/loader/plugins.go
@@ -4,17 +4,573 @@
 package loader
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/btf"
+	"github.com/cilium/ebpf/link"
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
 
 	"github.com/cilium/cilium/api/v1/datapathplugins"
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/bpf/analyze"
+	"github.com/cilium/cilium/pkg/datapath/config"
+	plugin "github.com/cilium/cilium/pkg/datapath/plugins/types"
+	api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/time"
+
+	"github.com/google/uuid"
 )
+
+const (
+	bpfLoaderGCRetryInterval = time.Minute
+)
+
+// bpfCollectionLoader coordinates between datapath plugins when loading a BPF
+// collection. It provides an interface similar to the usual bpf.Load and
+// bpf.LoadAndAssign functions.
+type bpfCollectionLoader struct {
+	pluginOperationsDir string
+	pluginsEnabled      bool
+	gcWakeup            chan struct{}
+	// gcMu prevents the GC loop from running while Load/LoadAndAssign is
+	// running, since we don't want to accidentally delete the staging
+	// directories for ongoing operations. The GC loop takes a write lock
+	// and releases it after staging directory GC completes.
+	// Load/LoadAndAssign take a read lock which is released by the cleanup
+	// function they return.
+	gcMu lock.RWMutex
+}
+
+func newBPFCollectionLoader(pluginsEnabled bool, pluginOperationsDir string) *bpfCollectionLoader {
+	return &bpfCollectionLoader{
+		pluginOperationsDir: pluginOperationsDir,
+		pluginsEnabled:      pluginsEnabled,
+		gcWakeup:            make(chan struct{}, 1),
+	}
+}
+
+func (l *bpfCollectionLoader) runGC(logger *slog.Logger, jg job.Group) {
+	if !l.pluginsEnabled {
+		return
+	}
+
+	logger = logger.WithGroup("plugins-staging-gc")
+
+	jg.Add(job.OneShot("plugins-staging-gc", func(ctx context.Context, health cell.Health) error {
+		var retry <-chan time.Time
+
+		for {
+			select {
+			case <-l.gcWakeup:
+			case <-retry:
+			}
+
+			retry = nil
+
+			logger.Info("Begin BPF collection loader GC pass")
+			l.gcMu.Lock()
+			if err := bpf.Remove(l.pluginOperationsDir); err != nil {
+				logger.Warn("Unable to finish GC pass", logfields.Error, err)
+				health.Degraded("Unable to finish GC pass", err)
+				retry = time.After(bpfLoaderGCRetryInterval)
+			} else {
+				logger.Info("Finished BPF collection loader GC pass")
+				health.OK("Finished BPF collection loader GC pass")
+			}
+			l.gcMu.Unlock()
+		}
+	}))
+
+	// Run gc at least once on startup
+	l.gc()
+}
+
+// gc is triggered if cleanup of the operation directory fails after a load
+// sequence. It ensures that operation directories from failed or partially
+// completed operations are eventually cleaned up.
+func (l *bpfCollectionLoader) gc() {
+	select {
+	case l.gcWakeup <- struct{}{}:
+	default:
+	}
+}
+
+// LoadAndAssign loads spec into the kernel and assigns the requested eBPF
+// objects to the given object. When datapath plugins are enabled, it
+// coordinates with plugins and instruments the collection accordingly. When
+// datapath plugins are disabled, it acts exactly like bpf.LoadAndAssign.
+//
+// If successful, LoadAndAssign returns two functions, commit and cleanup.
+// Similar to the commit function returned by bpf.LoadCollection, commit commits
+// pending map pins to the bpf file system for maps that that were found to be
+// incompatible with their pinned counterparts, or for maps with certain flags
+// that modify the default pinning behaviour. It also replaces any
+// plugin-provided pins or pinned plugin hook program links for this attachment
+// context with those created by this load operation. cleanup cleans up up
+// transient state related to the operation such as program pins or map pins.
+// cleanup must be invoked after commit regardless of whether or not commit
+// returns an error.
+func (l *bpfCollectionLoader) LoadAndAssign(ctx context.Context, logger *slog.Logger, to any, spec *ebpf.CollectionSpec, opts *bpf.CollectionOptions, lnc *config.Config, attachmentContext *datapathplugins.AttachmentContext, pinsDir string) (func() error, func(), error) {
+	keep, err := analyze.Fields(to)
+	if err != nil {
+		return nil, nil, fmt.Errorf("analyzing fields of %T: %w", to, err)
+	}
+	opts.Keep = keep
+
+	coll, commit, cleanupLinks, err := l.Load(ctx, logger, spec, opts, lnc, attachmentContext, pinsDir)
+	var ve *ebpf.VerifierError
+	if errors.As(err, &ve) {
+		if _, err := fmt.Fprintf(os.Stderr, "Verifier error: %s\nVerifier log: %+v\n", err, ve); err != nil {
+			return nil, nil, fmt.Errorf("writing verifier log to stderr: %w", err)
+		}
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("loading eBPF collection into the kernel: %w", err)
+	}
+
+	if err := coll.Assign(to); err != nil {
+		cleanupLinks()
+		coll.Close()
+		return nil, nil, fmt.Errorf("assigning eBPF objects to %T: %w", to, err)
+	}
+
+	return commit, cleanupLinks, nil
+}
+
+// Load loads the given spec into the kernel with the specified opts. When
+// datapath plugins are enabled, it coordinates with plugins and instruments
+// the collection accordingly. When datapath plugins are disabled, it acts
+// exactly like bpf.LoadCollection.
+//
+// If successful, Load returns two functions, commit and cleanup. Similar to the
+// commit function returned by bpf.LoadCollection, commit commits pending map
+// pins to the bpf file system for maps that that were found to be incompatible
+// with their pinned counterparts, or for maps with certain flags that modify
+// the default pinning behaviour. It also replaces any plugin-provided pins or
+// pinned plugin hook program links for this attachment context with those
+// created by this load operation. cleanup cleans up up transient state related
+// to the operation such as program pins or map pins. cleanup must be invoked
+// after commit regardless of whether or not commit returns an error.
+func (l *bpfCollectionLoader) Load(ctx context.Context, logger *slog.Logger, spec *ebpf.CollectionSpec, opts *bpf.CollectionOptions, lnc *config.Config, attachmentContext *datapathplugins.AttachmentContext, pinsDir string) (coll *ebpf.Collection, commit func() error, cleanup func(), err error) {
+	if !l.pluginsEnabled {
+		// If plugins were previously enabled, clean up any lingering
+		// pinned links in the plugin link directories.
+		if err := bpf.Remove(pinsDir); err != nil {
+			logger.Warn("Failed to purge pins dir",
+				logfields.Error, err,
+				logfields.Path, pinsDir,
+			)
+		}
+
+		coll, commit, err = bpf.LoadCollection(logger, spec, opts)
+		return coll, commit, func() {}, err
+	}
+
+	instrumentCollectionRequests, err := l.prepareCollection(ctx, logger, spec, opts, lnc, attachmentContext)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("preparing hooks: %w", err)
+	}
+
+	coll, commit, err = bpf.LoadCollection(logger, spec, opts)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("loading collection: %w", err)
+	}
+
+	commit, cleanup, err = l.instrumentCollection(ctx, logger, coll, commit, instrumentCollectionRequests, lnc, attachmentContext, l.pluginOperationsDir, pinsDir)
+	if err != nil {
+		coll.Close()
+		return nil, nil, nil, fmt.Errorf("loading hooks: %w", err)
+	}
+
+	return coll, commit, cleanup, nil
+}
+
+// prepareCollection sends a round of PrepareCollection requests to all
+// registered plugins and prepares a set of InstrumentCollection requests for
+// the instrumentation/load phase.
+func (l *bpfCollectionLoader) prepareCollection(ctx context.Context, logger *slog.Logger, spec *ebpf.CollectionSpec, opts *bpf.CollectionOptions, lnc *config.Config, attachmentContext *datapathplugins.AttachmentContext) (_ map[string]*datapathplugins.InstrumentCollectionRequest, err error) {
+	req := &datapathplugins.PrepareCollectionRequest{
+		AttachmentContext: attachmentContext,
+		Collection: &datapathplugins.PrepareCollectionRequest_CollectionSpec{
+			Programs: make(map[string]*datapathplugins.PrepareCollectionRequest_CollectionSpec_ProgramSpec),
+			Maps:     make(map[string]*datapathplugins.PrepareCollectionRequest_CollectionSpec_MapSpec),
+		},
+	}
+
+	for name, p := range spec.Programs {
+		req.Collection.Programs[name] = &datapathplugins.PrepareCollectionRequest_CollectionSpec_ProgramSpec{
+			Type:        uint32(p.Type),
+			AttachType:  uint32(p.AttachType),
+			SectionName: p.SectionName,
+			License:     p.License,
+		}
+	}
+	for name, m := range spec.Maps {
+		req.Collection.Maps[name] = &datapathplugins.PrepareCollectionRequest_CollectionSpec_MapSpec{
+			Type:       uint32(m.Type),
+			KeySize:    m.KeySize,
+			ValueSize:  m.ValueSize,
+			MaxEntries: m.MaxEntries,
+			Flags:      m.Flags,
+			PinType:    uint32(m.Pinning),
+		}
+	}
+
+	type prepareResult struct {
+		plugin plugin.Plugin
+		err    error
+		resp   *datapathplugins.PrepareCollectionResponse
+	}
+
+	prepareResults := make(chan prepareResult)
+	for _, p := range lnc.Plugins {
+		go func(p plugin.Plugin) {
+			resp, err := p.PrepareCollection(ctx, req)
+			prepareResults <- prepareResult{plugin: p, err: err, resp: resp}
+		}(p)
+	}
+
+	responses := make(map[string]*datapathplugins.PrepareCollectionResponse)
+	hooksSpec := newHooksSpec()
+
+	for range len(lnc.Plugins) {
+		r := <-prepareResults
+
+		logger.Debug("PrepareCollection()",
+			logfields.CiliumDatapathPluginName, r.plugin.Name(),
+			logfields.Request, req,
+			logfields.Response, r.resp,
+			logfields.Error, r.err,
+		)
+
+		if r.err != nil {
+			if r.plugin.AttachmentPolicy() == api_v2alpha1.AttachmentPolicyAlways {
+				err = errors.Join(err, fmt.Errorf("%s: PrepareCollection(): %w", r.plugin.Name(), r.err))
+			} else {
+				logger.Info("Datapath plugin preparation failed, ignoring due to best effort attachment policy. See plugin logs for more details.",
+					logfields.CiliumDatapathPluginName, r.plugin.Name(),
+					logfields.Error, r.err,
+				)
+			}
+
+			continue
+		} else {
+			responses[r.plugin.Name()] = r.resp
+		}
+
+	process_hooks:
+		for _, h := range r.resp.Hooks {
+			ps := spec.Programs[h.Target]
+			if ps == nil {
+				err = errors.Join(err, fmt.Errorf("%s: PrepareCollection(): target program \"%s\" does not exist in the collection spec", r.plugin.Name(), h.Target))
+
+				continue
+			} else if canErr := canInstrument(ps, attachmentContext); canErr != nil {
+				err = errors.Join(err, fmt.Errorf("%s: PrepareCollection(): \"%s\": %w", r.plugin.Name(), h.Target, canErr))
+
+				continue
+			}
+
+			if h.Type != datapathplugins.HookType_PRE && h.Type != datapathplugins.HookType_POST {
+				err = errors.Join(err, fmt.Errorf("%s: PrepareCollection(): invalid hook type %v", r.plugin.Name(), h.Type))
+
+				continue
+			}
+
+			hooksSpec.hook(ps.Name, h.Type).addNode(r.plugin.Name())
+
+			for _, c := range h.Constraints {
+				otherPlugin := lnc.Plugins[c.Plugin]
+				if otherPlugin == nil {
+					continue
+				}
+
+				switch c.Order {
+				case datapathplugins.PrepareCollectionResponse_HookSpec_OrderingConstraint_BEFORE:
+					hooksSpec.hook(ps.Name, h.Type).before(r.plugin.Name(), otherPlugin.Name())
+				case datapathplugins.PrepareCollectionResponse_HookSpec_OrderingConstraint_AFTER:
+					hooksSpec.hook(ps.Name, h.Type).after(r.plugin.Name(), otherPlugin.Name())
+				default:
+					err = errors.Join(err, fmt.Errorf("%s: PrepareCollection(): invalid ordering constraint: %v", r.plugin.Name(), c.Order))
+					continue process_hooks
+				}
+			}
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	instrumentCollectionRequests, programPatches, err := hooksSpec.instrumentCollection(spec)
+	if err != nil {
+		return nil, fmt.Errorf("instrumenting collection: %w", err)
+	}
+	opts.ProgramPatches = programPatches
+
+	for plugin, req := range instrumentCollectionRequests {
+		prepareHooksResp := responses[plugin]
+		req.Cookie = prepareHooksResp.Cookie
+		req.Collection = &datapathplugins.InstrumentCollectionRequest_Collection{
+			Programs: make(map[string]*datapathplugins.InstrumentCollectionRequest_Collection_Program),
+			Maps:     make(map[string]*datapathplugins.InstrumentCollectionRequest_Collection_Map),
+		}
+		req.AttachmentContext = attachmentContext
+	}
+
+	return instrumentCollectionRequests, nil
+}
+
+// canInstrument makes sure that a hook can be added to the requested program.
+func canInstrument(prog *ebpf.ProgramSpec, attachmentContext *datapathplugins.AttachmentContext) error {
+	if bpf.IsTailCall(prog) ||
+		(attachmentContext.GetLxc() != nil &&
+			(prog.Name == "cil_lxc_policy" || prog.Name == "cil_lxc_policy_egress")) ||
+		(attachmentContext.GetHost() != nil &&
+			(prog.Name == "cil_host_policy")) {
+		// It is currently not possible to do freplace for programs that are
+		// inside a PROG_ARRAY map, so we have to limit instrumentation to
+		// __section_entry programs.
+		//
+		// https://lore.kernel.org/all/20241015150207.70264-2-leon.hwang@linux.dev/
+		return fmt.Errorf("cannot instrument tail call programs")
+	}
+
+	return nil
+}
+
+func progID(p *ebpf.Program) (uint32, error) {
+	info, err := p.Info()
+	if err != nil {
+		return 0, err
+	}
+
+	id, avail := info.ID()
+	if !avail {
+		return 0, err
+	}
+
+	return uint32(id), nil
+}
+
+func mapID(m *ebpf.Map) (uint32, error) {
+	info, err := m.Info()
+	if err != nil {
+		return 0, err
+	}
+
+	id, avail := info.ID()
+	if !avail {
+		return 0, err
+	}
+
+	return uint32(id), nil
+}
+
+// instrumentCollection sends out the provided set of InstrumentCollection requests
+// and, after hearing back from each plugin, attaches loaded hook programs
+// to hook points inside each dispatcher.
+func (l *bpfCollectionLoader) instrumentCollection(ctx context.Context, logger *slog.Logger, coll *ebpf.Collection, commit func() error, instrumentCollectionRequests map[string]*datapathplugins.InstrumentCollectionRequest, lnc *config.Config, attachmentContext *datapathplugins.AttachmentContext, opsDir string, pinsDir string) (_ func() error, _ func(), err error) {
+	// Make sure the GC loop can't run, since we don't want it to delete our
+	// staging directories. Released on error conditions in
+	// cleanupStagingDirs(); if this function returns success, the callers
+	// *MUST* call cleanup function to unlock.
+	l.gcMu.RLock()
+
+	type loadResult struct {
+		plugin plugin.Plugin
+		err    error
+		resp   *datapathplugins.InstrumentCollectionResponse
+	}
+
+	loadResults := make(chan loadResult)
+	stagingDirs := make(map[string]string)
+	// Staging directories are ephemeral and should be cleaned up if this
+	// operation or a subsequent attachment attempt fails. This function
+	// also unlocks the gcMu, so it *MUST* be called exactly once for this
+	// endpoint "soon" after this function returns.
+	cleanupStagingDirs := func() {
+		var needGC bool
+		for plugin, dir := range stagingDirs {
+			if err := bpf.Remove(dir); err != nil {
+				logger.Error("Failed to clean up InstrumentCollection() staging directory",
+					logfields.Error, err,
+					logfields.CiliumDatapathPluginName, plugin,
+					logfields.Path, dir,
+				)
+				needGC = true
+			}
+		}
+
+		// We're done with our staging directories, so allow the GC loop
+		// to run if necessary.
+		l.gcMu.RUnlock()
+
+		if needGC {
+			// This probably means that something weird happened
+			// and a plugin kept trying to write to the staging
+			// directory after the request hung up on our end.
+			// GC will keep trying until the staging dir is cleaned
+			// up.
+			l.gc()
+		}
+	}
+
+	defer func() {
+		if err != nil {
+			cleanupStagingDirs()
+		}
+	}()
+
+	// Set up staging directories then finalize and send InstrumentCollection
+	// requests.
+	for plugin, req := range instrumentCollectionRequests {
+		requestID := uuid.New().String()
+		stagingDirs[plugin] = bpffsPluginOperationDir(opsDir, plugin, requestID)
+		hookPinsDir := filepath.Join(stagingDirs[plugin], "hooks")
+		req.Pins = filepath.Join(stagingDirs[plugin], "pins")
+
+		if err := bpf.MkdirBPF(hookPinsDir); err != nil {
+			return nil, nil, fmt.Errorf("creating BPF operation hooks directory: %w", err)
+		}
+
+		if err := bpf.MkdirBPF(req.Pins); err != nil {
+			return nil, nil, fmt.Errorf("creating BPF operation pins directory: %w", err)
+		}
+
+		for name, p := range coll.Programs {
+			id, err := progID(p)
+			if err != nil {
+				return nil, nil, fmt.Errorf("getting ID for program %s: %w", name, err)
+			}
+
+			req.Collection.Programs[name] = &datapathplugins.InstrumentCollectionRequest_Collection_Program{
+				Id: id,
+			}
+		}
+		for name, m := range coll.Maps {
+			id, err := mapID(m)
+			if err != nil {
+				return nil, nil, fmt.Errorf("getting ID for map %s: %w", name, err)
+			}
+			req.Collection.Maps[name] = &datapathplugins.InstrumentCollectionRequest_Collection_Map{
+				Id: id,
+			}
+		}
+
+		for _, hook := range req.Hooks {
+			prog := coll.Programs[hook.Target]
+			if prog == nil {
+				return nil, nil, fmt.Errorf("InstrumentCollectionRequest for %s references a non-existent program: %s", plugin, hook.Target)
+			}
+
+			id, err := progID(prog)
+			if err != nil {
+				return nil, nil, fmt.Errorf("getting ID for target program %s: %w", hook.Target, err)
+			}
+
+			hook.AttachTarget.ProgramId = id
+			hook.PinPath = filepath.Join(hookPinsDir, fmt.Sprintf("%s_%s", hook.Target, hook.AttachTarget.SubprogName))
+		}
+
+		go func(req *datapathplugins.InstrumentCollectionRequest) {
+			p := lnc.Plugins[plugin]
+			resp, err := p.InstrumentCollection(ctx, req)
+			loadResults <- loadResult{plugin: p, err: err, resp: resp}
+		}(req)
+	}
+
+	for len(instrumentCollectionRequests) > 0 {
+		r := <-loadResults
+
+		req := instrumentCollectionRequests[r.plugin.Name()]
+		delete(instrumentCollectionRequests, r.plugin.Name())
+
+		logger.Debug("InstrumentCollection()",
+			logfields.CiliumDatapathPluginName, r.plugin.Name(),
+			logfields.Request, req,
+			logfields.Response, r.resp,
+			logfields.Error, r.err,
+		)
+
+		if r.err != nil {
+			err = errors.Join(err, fmt.Errorf("%s: InstrumentCollection(): %w", r.plugin.Name(), r.err))
+
+			continue
+		}
+
+		// Replace the pinned program at each pin path with a pinned
+		// freplace link.
+		for _, hook := range req.Hooks {
+			prog, err := ebpf.LoadPinnedProgram(hook.PinPath, &ebpf.LoadPinOptions{})
+			if err != nil {
+				return nil, nil, fmt.Errorf("load pinned hook program at %s: %w", hook.PinPath, err)
+			}
+			if err := os.Remove(hook.PinPath); err != nil {
+				return nil, nil, fmt.Errorf("removing pinned hook program at %s: %w", hook.PinPath, err)
+			}
+			freplace, err := link.AttachFreplace(coll.Programs[hook.Target], hook.AttachTarget.SubprogName, prog)
+			if err != nil {
+				return nil, nil, fmt.Errorf("creating freplace link for hook: %w", err)
+			}
+			defer freplace.Close()
+			if err := freplace.Pin(hook.PinPath); err != nil {
+				return nil, nil, fmt.Errorf("pinning freplace link for hook to %s: %w", hook.PinPath, err)
+			}
+		}
+	}
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return func() error {
+		// clear out old pinned freplace links or plugin-provided pins.
+		if err := bpf.Remove(pinsDir); err != nil {
+			return fmt.Errorf("purging plugin pins dir %s: %w", pinsDir, err)
+		}
+
+		if err := bpf.MkdirBPF(pinsDir); err != nil {
+			return fmt.Errorf("ensuring the existence of plugin pins dir %s: %w", pinsDir, err)
+		}
+
+		for plugin, pluginStagingDir := range stagingDirs {
+			pluginPinsDir := filepath.Join(pinsDir, plugin)
+
+			if err := bpf.MkdirBPF(pluginPinsDir); err != nil {
+				return fmt.Errorf("ensuring the existence of plugin pins dir %s: %w", pluginPinsDir, err)
+			}
+
+			// move pins from the staging directory to the pins
+			// directory for this plugin and attachment context.
+			for _, subDir := range []string{
+				"hooks",
+				"pins",
+			} {
+				oldPath := filepath.Join(pluginStagingDir, subDir)
+				newPath := filepath.Join(pluginPinsDir, subDir)
+
+				if err := os.Rename(oldPath, newPath); err != nil {
+					return fmt.Errorf("committing pins for plugin %s (%s -> %s): %w", plugin, oldPath, newPath, err)
+				}
+			}
+		}
+
+		return commit()
+	}, cleanupStagingDirs, nil
+}
 
 func preHookSubprogName(pluginName string) string {
 	return fmt.Sprintf("__pre_hook_%s__", pluginName)

--- a/pkg/datapath/loader/plugins_test.go
+++ b/pkg/datapath/loader/plugins_test.go
@@ -4,20 +4,30 @@
 package loader
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
 
+	"github.com/cilium/hive/hivetest"
+
 	"github.com/cilium/cilium/api/v1/datapathplugins"
+	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath/bpf/testprogs"
+	"github.com/cilium/cilium/pkg/datapath/config"
+	plugin "github.com/cilium/cilium/pkg/datapath/plugins/types"
+	api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/testutils"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
@@ -612,6 +622,572 @@ func TestPrivilegedHooksSpec(t *testing.T) {
 				cmp.AllowUnexported(outputValues{}),
 			); diff != "" {
 				t.Fatalf("outputs did not match what was expected (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+type fakePluginRegistry map[string]*fakePlugin
+
+func (r fakePluginRegistry) Register(dpp *api_v2alpha1.CiliumDatapathPlugin) error {
+	return nil
+}
+
+func (r fakePluginRegistry) Unregister(dpp *api_v2alpha1.CiliumDatapathPlugin) error {
+	return nil
+}
+
+func (r fakePluginRegistry) Plugins() plugin.Plugins {
+	result := plugin.Plugins{}
+
+	for _, p := range r {
+		result[p.name] = p
+	}
+
+	return result
+}
+
+func (r fakePluginRegistry) closeAll() {
+	for _, p := range r {
+		if p.coll != nil {
+			p.coll.Close()
+		}
+	}
+}
+
+type transaction struct {
+	prepareHooksReq  *datapathplugins.PrepareCollectionRequest
+	prepareHooksResp *datapathplugins.PrepareCollectionResponse
+	prepareHooksErr  error
+	loadHooksReq     *datapathplugins.InstrumentCollectionRequest
+	loadHooksResp    *datapathplugins.InstrumentCollectionResponse
+	loadHooksErr     error
+}
+
+var _ plugin.Plugin = &fakePlugin{}
+
+type fakePlugin struct {
+	name             string
+	attachmentPolicy api_v2alpha1.CiliumDatapathPluginAttachmentPolicy
+	transaction      *transaction
+
+	coll *ebpf.Collection
+}
+
+func (p *fakePlugin) Name() string {
+	return p.name
+}
+
+func (p *fakePlugin) AttachmentPolicy() api_v2alpha1.CiliumDatapathPluginAttachmentPolicy {
+	return p.attachmentPolicy
+}
+
+func (p *fakePlugin) DeepEqual(o plugin.Plugin) bool {
+	return false
+}
+
+func (p *fakePlugin) PrepareCollection(ctx context.Context, in *datapathplugins.PrepareCollectionRequest, opts ...grpc.CallOption) (*datapathplugins.PrepareCollectionResponse, error) {
+	p.transaction.prepareHooksReq = in
+
+	if p.transaction.prepareHooksErr != nil {
+		return nil, p.transaction.prepareHooksErr
+	}
+
+	return p.transaction.prepareHooksResp, nil
+}
+
+func (p *fakePlugin) InstrumentCollection(ctx context.Context, in *datapathplugins.InstrumentCollectionRequest, opts ...grpc.CallOption) (*datapathplugins.InstrumentCollectionResponse, error) {
+	p.transaction.loadHooksReq = in
+
+	if p.transaction.loadHooksErr != nil {
+		return nil, p.transaction.loadHooksErr
+	}
+
+	spec, err := testprogs.LoadPluginsHooks()
+	if err != nil {
+		return nil, fmt.Errorf("loading plugin hooks spec: %w", err)
+	}
+
+	targetProgs := map[ebpf.ProgramID]*ebpf.Program{}
+	usedHookPrograms := map[string]bool{}
+
+	for _, h := range in.Hooks {
+		progName := chooseHookProgram(h)
+		progSpec := spec.Programs[progName]
+		if progSpec == nil {
+			return nil, fmt.Errorf("unknown program: %s", progName)
+		}
+
+		usedHookPrograms[progName] = true
+		id := ebpf.ProgramID(h.AttachTarget.ProgramId)
+		if targetProgs[id] == nil {
+			targetProg, err := ebpf.NewProgramFromID(id)
+			if err != nil {
+				return nil, fmt.Errorf("loading target program %d: %w", h.AttachTarget.ProgramId, err)
+			}
+			defer targetProg.Close()
+			targetProgs[id] = targetProg
+		}
+
+		progSpec.AttachTarget = targetProgs[id]
+		progSpec.AttachTo = h.AttachTarget.SubprogName
+	}
+
+	// prune any unused hook programs so they aren't loaded
+	for name := range spec.Programs {
+		if !usedHookPrograms[name] {
+			delete(spec.Programs, name)
+		}
+	}
+
+	seqID := in.Collection.Maps["seq"].Id
+	seq, err := ebpf.NewMapFromID(ebpf.MapID(seqID))
+	if err != nil {
+		return nil, fmt.Errorf("loading seq map: %w", err)
+	}
+	defer seq.Close()
+
+	coll, err := ebpf.NewCollectionWithOptions(spec, ebpf.CollectionOptions{
+		MapReplacements: map[string]*ebpf.Map{
+			"seq": seq,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("loading plugin hooks: %w", err)
+	}
+
+	for _, h := range in.Hooks {
+		progName := chooseHookProgram(h)
+		prog := coll.Programs[progName]
+
+		if err := prog.Pin(h.PinPath); err != nil {
+			coll.Close()
+			return nil, fmt.Errorf("pinning program %s to %s: %w", progName, h.PinPath, err)
+		}
+	}
+
+	p.coll = coll
+
+	return p.transaction.loadHooksResp, nil
+}
+
+func TestPrivilegedLoadAndAssignWithPlugins(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	baseSpec, err := testprogs.LoadPluginsBase()
+	require.NoError(t, err)
+
+	baseCollSpec := &datapathplugins.PrepareCollectionRequest_CollectionSpec{
+		Programs: map[string]*datapathplugins.PrepareCollectionRequest_CollectionSpec_ProgramSpec{},
+		Maps:     map[string]*datapathplugins.PrepareCollectionRequest_CollectionSpec_MapSpec{},
+	}
+
+	baseColl := &datapathplugins.InstrumentCollectionRequest_Collection{
+		Programs: map[string]*datapathplugins.InstrumentCollectionRequest_Collection_Program{},
+		Maps:     map[string]*datapathplugins.InstrumentCollectionRequest_Collection_Map{},
+	}
+
+	for name, p := range baseSpec.Programs {
+		baseCollSpec.Programs[name] = &datapathplugins.PrepareCollectionRequest_CollectionSpec_ProgramSpec{
+			License:     p.License,
+			SectionName: p.SectionName,
+			Type:        uint32(p.Type),
+			AttachType:  uint32(p.AttachType),
+		}
+		baseColl.Programs[name] = &datapathplugins.InstrumentCollectionRequest_Collection_Program{}
+	}
+	for name, m := range baseSpec.Maps {
+		baseCollSpec.Maps[name] = &datapathplugins.PrepareCollectionRequest_CollectionSpec_MapSpec{
+			KeySize:    m.KeySize,
+			MaxEntries: m.MaxEntries,
+			Type:       uint32(m.Type),
+			ValueSize:  m.ValueSize,
+		}
+		baseColl.Maps[name] = &datapathplugins.InstrumentCollectionRequest_Collection_Map{}
+	}
+
+	prepareHooksReq := &datapathplugins.PrepareCollectionRequest{
+		Collection:        baseCollSpec,
+		AttachmentContext: &datapathplugins.AttachmentContext{},
+	}
+
+	hookSpec := func(typ datapathplugins.HookType,
+		target string,
+		constraints []*datapathplugins.PrepareCollectionResponse_HookSpec_OrderingConstraint) *datapathplugins.PrepareCollectionResponse_HookSpec {
+		return &datapathplugins.PrepareCollectionResponse_HookSpec{
+			Type:        typ,
+			Target:      target,
+			Constraints: constraints,
+		}
+	}
+
+	pre := func(target string, constraints ...*datapathplugins.PrepareCollectionResponse_HookSpec_OrderingConstraint) *datapathplugins.PrepareCollectionResponse_HookSpec {
+		return hookSpec(datapathplugins.HookType_PRE, target, constraints)
+	}
+
+	post := func(target string, constraints ...*datapathplugins.PrepareCollectionResponse_HookSpec_OrderingConstraint) *datapathplugins.PrepareCollectionResponse_HookSpec {
+		return hookSpec(datapathplugins.HookType_POST, target, constraints)
+	}
+
+	before := func(plugin string) *datapathplugins.PrepareCollectionResponse_HookSpec_OrderingConstraint {
+		return &datapathplugins.PrepareCollectionResponse_HookSpec_OrderingConstraint{
+			Plugin: plugin,
+			Order:  datapathplugins.PrepareCollectionResponse_HookSpec_OrderingConstraint_BEFORE,
+		}
+	}
+
+	pluginAPrepareHooksResp := &datapathplugins.PrepareCollectionResponse{
+		Hooks: []*datapathplugins.PrepareCollectionResponse_HookSpec{
+			pre("program_tc", before("plugin_b")),
+			post("program_tc", before("plugin_b")),
+			pre("program_xdp", before("plugin_b")),
+			post("program_xdp", before("plugin_b")),
+		},
+		Cookie: "plugin_a_cookie",
+	}
+
+	pluginBPrepareHooksResp := &datapathplugins.PrepareCollectionResponse{
+		Hooks: []*datapathplugins.PrepareCollectionResponse_HookSpec{
+			pre("program_tc"),
+			post("program_tc"),
+			pre("program_xdp"),
+			post("program_xdp"),
+		},
+		Cookie: "plugin_b_cookie",
+	}
+
+	loadHooksReq := func(plugin string) *datapathplugins.InstrumentCollectionRequest {
+		return &datapathplugins.InstrumentCollectionRequest{
+			Collection:        baseColl,
+			AttachmentContext: &datapathplugins.AttachmentContext{},
+			Hooks: []*datapathplugins.InstrumentCollectionRequest_Hook{
+				{
+					Type:   datapathplugins.HookType_PRE,
+					Target: "program_tc",
+					AttachTarget: &datapathplugins.InstrumentCollectionRequest_Hook_AttachTarget{
+						SubprogName: preHookSubprogName(plugin),
+					},
+				},
+				{
+					Type:   datapathplugins.HookType_POST,
+					Target: "program_tc",
+					AttachTarget: &datapathplugins.InstrumentCollectionRequest_Hook_AttachTarget{
+						SubprogName: postHookSubprogName(plugin),
+					},
+				},
+				{
+					Type:   datapathplugins.HookType_PRE,
+					Target: "program_xdp",
+					AttachTarget: &datapathplugins.InstrumentCollectionRequest_Hook_AttachTarget{
+						SubprogName: preHookSubprogName(plugin),
+					},
+				},
+				{
+					Type:   datapathplugins.HookType_POST,
+					Target: "program_xdp",
+					AttachTarget: &datapathplugins.InstrumentCollectionRequest_Hook_AttachTarget{
+						SubprogName: postHookSubprogName(plugin),
+					},
+				},
+			},
+			Cookie: fmt.Sprintf("%s_cookie", plugin),
+		}
+	}
+
+	testCases := []struct {
+		name                 string
+		inputValues          inputValues
+		attachmentPolicies   map[string]api_v2alpha1.CiliumDatapathPluginAttachmentPolicy
+		transactions         map[string]transaction
+		expectedOutputValues outputValues
+		expectedErr          error
+	}{
+		{
+			name: "pre and post hooks basic",
+			transactions: map[string]transaction{
+				"plugin_a": {
+					prepareHooksReq:  prepareHooksReq,
+					prepareHooksResp: pluginAPrepareHooksResp,
+					loadHooksReq:     loadHooksReq("plugin_a"),
+					loadHooksResp:    &datapathplugins.InstrumentCollectionResponse{},
+				},
+				"plugin_b": {
+					prepareHooksReq:  prepareHooksReq,
+					prepareHooksResp: pluginBPrepareHooksResp,
+					loadHooksReq:     loadHooksReq("plugin_b"),
+					loadHooksResp:    &datapathplugins.InstrumentCollectionResponse{},
+				},
+			},
+			attachmentPolicies: map[string]api_v2alpha1.CiliumDatapathPluginAttachmentPolicy{
+				"plugin_a": api_v2alpha1.AttachmentPolicyAlways,
+				"plugin_b": api_v2alpha1.AttachmentPolicyAlways,
+			},
+			inputValues: inputValues{
+				hook: map[string]map[string]int32{
+					"plugin_a": {
+						"before_program_tc_ret":  -1,
+						"after_program_tc_ret":   -1,
+						"before_program_xdp_ret": -1,
+						"after_program_xdp_ret":  -1,
+					},
+					"plugin_b": {
+						"before_program_tc_ret":  -1,
+						"after_program_tc_ret":   -1,
+						"before_program_xdp_ret": -1,
+						"after_program_xdp_ret":  -1,
+					},
+				},
+			},
+			expectedOutputValues: outputValues{
+				base: map[string]int32{
+					"program_tc_seq":  3,
+					"program_xdp_seq": 3,
+				},
+				returns: map[string]uint32{
+					"program_tc":  1,
+					"program_xdp": 1,
+				},
+				hook: map[string]map[string]int32{
+					"plugin_a": {
+						"before_program_tc_seq":       1,
+						"before_program_tc_ret":       -1,
+						"after_program_tc_seq":        4,
+						"after_program_tc_ret":        -1,
+						"after_program_tc_ret_param":  1,
+						"before_program_xdp_seq":      1,
+						"before_program_xdp_ret":      -1,
+						"after_program_xdp_seq":       4,
+						"after_program_xdp_ret":       -1,
+						"after_program_xdp_ret_param": 1,
+					},
+					"plugin_b": {
+						"before_program_tc_seq":       2,
+						"before_program_tc_ret":       -1,
+						"after_program_tc_seq":        5,
+						"after_program_tc_ret":        -1,
+						"after_program_tc_ret_param":  1,
+						"before_program_xdp_seq":      2,
+						"before_program_xdp_ret":      -1,
+						"after_program_xdp_seq":       5,
+						"after_program_xdp_ret":       -1,
+						"after_program_xdp_ret_param": 1,
+					},
+				},
+			},
+		},
+		{
+			name: "plugin_b returns an error in PrepareCollection() with AttachmentPolicyAlways",
+			transactions: map[string]transaction{
+				"plugin_a": {
+					prepareHooksReq:  prepareHooksReq,
+					prepareHooksResp: pluginAPrepareHooksResp,
+					loadHooksReq:     loadHooksReq("plugin_a"),
+					loadHooksResp:    &datapathplugins.InstrumentCollectionResponse{},
+				},
+				"plugin_b": {
+					prepareHooksReq: prepareHooksReq,
+					prepareHooksErr: errors.New("some error"),
+				},
+			},
+			attachmentPolicies: map[string]api_v2alpha1.CiliumDatapathPluginAttachmentPolicy{
+				"plugin_a": api_v2alpha1.AttachmentPolicyAlways,
+				"plugin_b": api_v2alpha1.AttachmentPolicyAlways,
+			},
+			expectedErr: errors.New("some error"),
+		},
+		{
+			name: "plugin_b returns an error in PrepareCollection() with AttachmentPolicyBestEffort",
+			transactions: map[string]transaction{
+				"plugin_a": {
+					prepareHooksReq:  prepareHooksReq,
+					prepareHooksResp: pluginAPrepareHooksResp,
+					loadHooksReq:     loadHooksReq("plugin_a"),
+					loadHooksResp:    &datapathplugins.InstrumentCollectionResponse{},
+				},
+				"plugin_b": {
+					prepareHooksReq: prepareHooksReq,
+					prepareHooksErr: errors.New("some error"),
+				},
+			},
+			attachmentPolicies: map[string]api_v2alpha1.CiliumDatapathPluginAttachmentPolicy{
+				"plugin_a": api_v2alpha1.AttachmentPolicyAlways,
+				"plugin_b": api_v2alpha1.AttachmentPolicyBestEffort,
+			},
+			inputValues: inputValues{
+				hook: map[string]map[string]int32{
+					"plugin_a": {
+						"before_program_tc_ret":  -1,
+						"after_program_tc_ret":   -1,
+						"before_program_xdp_ret": -1,
+						"after_program_xdp_ret":  -1,
+					},
+				},
+			},
+			expectedOutputValues: outputValues{
+				base: map[string]int32{
+					"program_tc_seq":  2,
+					"program_xdp_seq": 2,
+				},
+				returns: map[string]uint32{
+					"program_tc":  1,
+					"program_xdp": 1,
+				},
+				hook: map[string]map[string]int32{
+					"plugin_a": {
+						"before_program_tc_seq":       1,
+						"before_program_tc_ret":       -1,
+						"after_program_tc_seq":        3,
+						"after_program_tc_ret":        -1,
+						"after_program_tc_ret_param":  1,
+						"before_program_xdp_seq":      1,
+						"before_program_xdp_ret":      -1,
+						"after_program_xdp_seq":       3,
+						"after_program_xdp_ret":       -1,
+						"after_program_xdp_ret_param": 1,
+					},
+				},
+			},
+		},
+		{
+			name: "plugin_b returns an error in InstrumentCollection() with AttachmentPolicyAlways",
+			transactions: map[string]transaction{
+				"plugin_a": {
+					prepareHooksReq:  prepareHooksReq,
+					prepareHooksResp: pluginAPrepareHooksResp,
+					loadHooksReq:     loadHooksReq("plugin_a"),
+					loadHooksResp:    &datapathplugins.InstrumentCollectionResponse{},
+				},
+				"plugin_b": {
+					prepareHooksReq:  prepareHooksReq,
+					prepareHooksResp: pluginBPrepareHooksResp,
+					loadHooksReq:     loadHooksReq("plugin_b"),
+					loadHooksErr:     errors.New("some error"),
+				},
+			},
+			attachmentPolicies: map[string]api_v2alpha1.CiliumDatapathPluginAttachmentPolicy{
+				"plugin_a": api_v2alpha1.AttachmentPolicyAlways,
+				"plugin_b": api_v2alpha1.AttachmentPolicyAlways,
+			},
+			expectedErr: errors.New("some error"),
+		},
+		{
+			name: "plugin_b returns an error in InstrumentCollection() with AttachmentPolicyBestEffort",
+			transactions: map[string]transaction{
+				"plugin_a": {
+					prepareHooksReq:  prepareHooksReq,
+					prepareHooksResp: pluginAPrepareHooksResp,
+					loadHooksReq:     loadHooksReq("plugin_a"),
+					loadHooksResp:    &datapathplugins.InstrumentCollectionResponse{},
+				},
+				"plugin_b": {
+					prepareHooksReq:  prepareHooksReq,
+					prepareHooksResp: pluginBPrepareHooksResp,
+					loadHooksReq:     loadHooksReq("plugin_b"),
+					loadHooksErr:     errors.New("some error"),
+				},
+			},
+			attachmentPolicies: map[string]api_v2alpha1.CiliumDatapathPluginAttachmentPolicy{
+				"plugin_a": api_v2alpha1.AttachmentPolicyAlways,
+				"plugin_b": api_v2alpha1.AttachmentPolicyBestEffort,
+			},
+			expectedErr: errors.New("some error"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			logger := hivetest.Logger(t)
+			tmp := testutils.TempBPFFS(t)
+			plugins := fakePluginRegistry{}
+			defer plugins.closeAll()
+
+			for p, t := range tc.transactions {
+				plugins[p] = &fakePlugin{
+					name:             p,
+					attachmentPolicy: tc.attachmentPolicies[p],
+					transaction: &transaction{
+						prepareHooksResp: t.prepareHooksResp,
+						prepareHooksErr:  t.prepareHooksErr,
+						loadHooksResp:    t.loadHooksResp,
+						loadHooksErr:     t.loadHooksErr,
+					},
+				}
+			}
+
+			l := newBPFCollectionLoader(true, bpffsPluginsOperationsDir(tmp))
+
+			pinsDir := filepath.Join(tmp, "pins_dir")
+			baseColl, commit, cleanup, err := l.Load(
+				t.Context(),
+				logger,
+				baseSpec,
+				&bpf.CollectionOptions{},
+				&config.Config{
+					Plugins: plugins.Plugins(),
+				},
+				&datapathplugins.AttachmentContext{},
+				pinsDir,
+			)
+			if tc.expectedErr != nil {
+				require.ErrorContains(t, err, tc.expectedErr.Error())
+				return
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.NoError(t, commit())
+			cleanup()
+
+			for name, plugin := range plugins {
+				if diff := cmp.Diff(
+					tc.transactions[name],
+					*plugin.transaction,
+					cmp.AllowUnexported(transaction{}),
+					cmpopts.EquateErrors(),
+					protocmp.Transform(),
+					protocmp.SortRepeated(func(a, b *datapathplugins.InstrumentCollectionRequest_Hook) bool {
+						if a.Target == b.Target {
+							return a.Type < b.Type
+						}
+
+						return a.Target < b.Target
+					}),
+					protocmp.IgnoreFields(&datapathplugins.InstrumentCollectionRequest{}, "pins"),
+					protocmp.IgnoreFields(&datapathplugins.InstrumentCollectionRequest_Collection_Map{}, "id"),
+					protocmp.IgnoreFields(&datapathplugins.InstrumentCollectionRequest_Collection_Program{}, "id"),
+					protocmp.IgnoreFields(&datapathplugins.InstrumentCollectionRequest_Hook{}, "pin_path"),
+					protocmp.IgnoreFields(&datapathplugins.InstrumentCollectionRequest_Hook_AttachTarget{}, "program_id"),
+				); diff != "" {
+					t.Fatalf("transaction for plugin %s did not match what was expected (-want +got):\n%s", name, diff)
+				}
+			}
+
+			// Fill in the blanks
+			pluginHooksObjs := map[string]*ebpf.Collection{}
+			for name, plugin := range plugins {
+				pluginHooksObjs[name] = plugin.coll
+
+				if tc.expectedOutputValues.hook[name] != nil {
+					for varName := range plugin.coll.Variables {
+						if _, ok := tc.expectedOutputValues.hook[name][varName]; !ok {
+							tc.expectedOutputValues.hook[name][varName] = 0
+						}
+					}
+				}
+			}
+			for name := range baseColl.Variables {
+				if _, ok := tc.expectedOutputValues.base[name]; !ok {
+					tc.expectedOutputValues.base[name] = 0
+				}
+			}
+
+			outputs := runTestProgs(t, tc.inputValues, baseColl, pluginHooksObjs)
+			if diff := cmp.Diff(
+				tc.expectedOutputValues,
+				outputs,
+				cmp.AllowUnexported(outputValues{}),
+			); diff != "" {
+				t.Errorf("outputs did not match what was expected (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/datapath/loader/wireguard.go
+++ b/pkg/datapath/loader/wireguard.go
@@ -61,7 +61,7 @@ func defaultWireguardMapRenames(lnc *config.Config, device netlink.Link) (rename
 }
 
 func replaceWireguardDatapath(ctx context.Context, logger *slog.Logger, reg *registry.MapRegistry,
-	lnc *config.Config, device netlink.Link) (err error) {
+	collLoader *bpfCollectionLoader, lnc *config.Config, device netlink.Link) (err error) {
 	if err := compileWireguard(ctx, logger); err != nil {
 		return fmt.Errorf("compiling wireguard program: %w", err)
 	}
@@ -72,7 +72,7 @@ func replaceWireguardDatapath(ctx context.Context, logger *slog.Logger, reg *reg
 	}
 
 	var obj wireguardObjects
-	commit, err := bpf.LoadAndAssign(logger, &obj, spec, &bpf.CollectionOptions{
+	commit, cleanup, err := collLoader.LoadAndAssign(ctx, logger, &obj, spec, &bpf.CollectionOptions{
 		MapRegistry: reg,
 		Constants:   wireguardConfiguration(lnc, device),
 		MapRenames:  wireguardMapRenames(lnc, device),
@@ -80,10 +80,11 @@ func replaceWireguardDatapath(ctx context.Context, logger *slog.Logger, reg *reg
 			Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
 		},
 		ConfigDumpPath: filepath.Join(bpfStateDeviceDir(device.Attrs().Name), wireguardConfig),
-	})
+	}, lnc, attachmentContextWireguard(device), bpffsDevicePluginPinsTcDir(bpf.CiliumPath(), device))
 	if err != nil {
 		return err
 	}
+	defer cleanup()
 	defer obj.Close()
 
 	linkDir := bpffsDeviceLinksDir(bpf.CiliumPath(), device)

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -145,8 +145,8 @@ func maybeUnloadObsoleteXDPPrograms(logger *slog.Logger, keep []string, xdpMode 
 
 // compileAndLoadXDPProg compiles bpf_xdp.c for the given XDP device and loads it.
 func compileAndLoadXDPProg(ctx context.Context, logger *slog.Logger,
-	reg *registry.MapRegistry, lnc *config.Config,
-	xdpDev string, xdpMode xdp.Mode) error {
+	reg *registry.MapRegistry, collLoader *bpfCollectionLoader,
+	lnc *config.Config, xdpDev string, xdpMode xdp.Mode) error {
 	dirs := &directoryInfo{
 		Library: option.Config.BpfDir,
 		Runtime: option.Config.StateDir,
@@ -177,7 +177,7 @@ func compileAndLoadXDPProg(ctx context.Context, logger *slog.Logger,
 		return fmt.Errorf("loading eBPF ELF %s: %w", objPath, err)
 	}
 
-	if err := loadAssignAttach(logger, reg, xdpMode, iface, spec, lnc); err != nil {
+	if err := loadAssignAttach(ctx, logger, reg, collLoader, xdpMode, iface, spec, lnc); err != nil {
 		return err
 	}
 
@@ -228,16 +228,17 @@ func xdpPermutations(spec *ebpf.CollectionSpec) iter.Seq2[int, *ebpf.CollectionS
 	}
 }
 
-func loadAssignAttach(logger *slog.Logger, reg *registry.MapRegistry,
-	xdpMode xdp.Mode, iface netlink.Link, spec *ebpf.CollectionSpec,
-	lnc *config.Config) error {
+func loadAssignAttach(ctx context.Context, logger *slog.Logger, reg *registry.MapRegistry,
+	collLoader *bpfCollectionLoader, xdpMode xdp.Mode, iface netlink.Link,
+	spec *ebpf.CollectionSpec, lnc *config.Config) error {
 	var (
-		obj    xdpObjects
-		commit func() error
-		err    error
+		obj     xdpObjects
+		commit  func() error
+		cleanup func()
+		err     error
 	)
 	for i, spec := range xdpPermutations(spec) {
-		commit, err = bpf.LoadAndAssign(logger, &obj, spec, &bpf.CollectionOptions{
+		commit, cleanup, err = collLoader.LoadAndAssign(ctx, logger, &obj, spec, &bpf.CollectionOptions{
 			MapRegistry: reg,
 			Constants:   xdpConfiguration(lnc, iface),
 			MapRenames:  xdpMapRenames(lnc, iface),
@@ -245,11 +246,12 @@ func loadAssignAttach(logger *slog.Logger, reg *registry.MapRegistry,
 				Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
 			},
 			ConfigDumpPath: filepath.Join(bpfStateDeviceDir(iface.Attrs().Name), xdpConfig),
-		})
+		}, lnc, attachmentContextXDP(iface), bpffsDevicePluginPinsXdpDir(bpf.CiliumPath(), iface))
 		if err != nil {
 			return err
 		}
 		defer obj.Close()
+		defer cleanup()
 
 		err = attachXDPProgram(logger, iface, obj.Entrypoint, symbolFromHostNetdevXDP,
 			bpffsDeviceLinksDir(bpf.CiliumPath(), iface), xdpConfigModeToFlag(xdpMode))

--- a/pkg/endpoint/cache.go
+++ b/pkg/endpoint/cache.go
@@ -47,6 +47,8 @@ type epInfoCache struct {
 	netNsCookie            uint64
 	rtInfo                 uint32
 	properties             map[string]any
+	k8sNamespace           string
+	k8sPodName             string
 
 	// endpoint is used to get the endpoint's logger.
 	//
@@ -63,14 +65,16 @@ func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 		return &epInfoCache{
 			revision: e.desiredPolicyRevision,
 
-			id:         e.GetID(),
-			identity:   e.getIdentity(),
-			ifIndex:    e.GetIfIndex(),
-			mac:        e.GetNodeMAC(),
-			ipv4:       e.IPv4Address(),
-			ipv6:       e.IPv6Address(),
-			atHostNS:   true,
-			properties: maps.Clone(e.properties),
+			id:           e.GetID(),
+			identity:     e.getIdentity(),
+			ifIndex:      e.GetIfIndex(),
+			mac:          e.GetNodeMAC(),
+			ipv4:         e.IPv4Address(),
+			ipv6:         e.IPv6Address(),
+			atHostNS:     true,
+			properties:   maps.Clone(e.properties),
+			k8sNamespace: e.GetK8sNamespace(),
+			k8sPodName:   e.GetK8sPodName(),
 
 			endpoint: e,
 		}
@@ -97,6 +101,8 @@ func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 		netNsCookie:            e.NetNsCookie,
 		rtInfo:                 e.rtInfo,
 		properties:             maps.Clone(e.properties),
+		k8sNamespace:           e.GetK8sNamespace(),
+		k8sPodName:             e.GetK8sPodName(),
 
 		endpoint: e,
 	}
@@ -223,4 +229,12 @@ func (ep *epInfoCache) isProperty(propertyKey string) bool {
 
 func (ep *epInfoCache) GetPropertyValue(key string) any {
 	return ep.properties[key]
+}
+
+func (ep *epInfoCache) GetK8sNamespace() string {
+	return ep.k8sNamespace
+}
+
+func (ep *epInfoCache) GetK8sPodName() string {
+	return ep.k8sPodName
 }

--- a/pkg/endpoint/types/endpoint.go
+++ b/pkg/endpoint/types/endpoint.go
@@ -14,4 +14,6 @@ type Endpoint interface {
 	InterfaceName() string
 	Logger(subsystem string) *slog.Logger
 	StateDir() string
+	GetK8sNamespace() string
+	GetK8sPodName() string
 }

--- a/pkg/socketlb/socketlb.go
+++ b/pkg/socketlb/socketlb.go
@@ -4,6 +4,7 @@
 package socketlb
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/cilium/ebpf"
 
+	"github.com/cilium/cilium/api/v1/datapathplugins"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/cgroups"
 	"github.com/cilium/cilium/pkg/datapath/config"
@@ -58,14 +60,28 @@ func cgroupLinkPath() string {
 // File to dump the socketlb BPF configuration to.
 var configDumpPath = filepath.Join(option.Config.StateDir, "bpf", socketConfig)
 
+func cgroupPluginsLinkPath() string {
+	return filepath.Join(bpf.CiliumPath(), Subsystem, "plugin_links/cgroup")
+}
+
+func attachmentContextSocket() *datapathplugins.AttachmentContext {
+	return &datapathplugins.AttachmentContext{
+		Context: &datapathplugins.AttachmentContext_Socket_{},
+	}
+}
+
+type collectionLoader interface {
+	Load(ctx context.Context, logger *slog.Logger, spec *ebpf.CollectionSpec, opts *bpf.CollectionOptions, lnc *config.Config, attachmentContext *datapathplugins.AttachmentContext, pinsDir string) (*ebpf.Collection, func() error, func(), error)
+}
+
 // Enable attaches necessary bpf programs for socketlb based on ciliums config.
 //
 // On restart, Enable can also detach unnecessary programs if specific configuration
 // options have changed.
 // It expects bpf_sock.c to be compiled previously, so that bpf_sock.o is present
 // in the Runtime dir.
-func Enable(logger *slog.Logger, reg *registry.MapRegistry,
-	sysctl sysctl.Sysctl, lnc *config.Config) error {
+func Enable(ctx context.Context, logger *slog.Logger, reg *registry.MapRegistry,
+	collLoader collectionLoader, sysctl sysctl.Sysctl, lnc *config.Config) error {
 	if err := os.MkdirAll(cgroupLinkPath(), 0777); err != nil {
 		return fmt.Errorf("create bpffs link directory: %w", err)
 	}
@@ -82,14 +98,14 @@ func Enable(logger *slog.Logger, reg *registry.MapRegistry,
 	cfg.TunnelProtocol = lnc.TunnelProtocol
 	cfg.TunnelPort = lnc.TunnelPort
 
-	coll, commit, err := bpf.LoadCollection(logger, spec, &bpf.CollectionOptions{
+	coll, commit, cleanup, err := collLoader.Load(ctx, logger, spec, &bpf.CollectionOptions{
 		MapRegistry: reg,
 		Constants:   cfg,
 		CollectionOptions: ebpf.CollectionOptions{
 			Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
 		},
 		ConfigDumpPath: configDumpPath,
-	})
+	}, lnc, attachmentContextSocket(), cgroupPluginsLinkPath())
 	var ve *ebpf.VerifierError
 	if errors.As(err, &ve) {
 		if _, err := fmt.Fprintf(os.Stderr, "Verifier error: %s\nVerifier log: %+v\n", err, ve); err != nil {
@@ -99,6 +115,7 @@ func Enable(logger *slog.Logger, reg *registry.MapRegistry,
 	if err != nil {
 		return fmt.Errorf("failed loading eBPF collection into the kernel: %w", err)
 	}
+	defer cleanup()
 	defer coll.Close()
 
 	// Map a program name to its enabled status. Programs disabled by default.
@@ -174,6 +191,10 @@ func Disable(logger *slog.Logger) error {
 		if err := detachCgroup(logger, p, cgroups.GetCgroupRoot(), cgroupLinkPath()); err != nil {
 			return fmt.Errorf("detach cgroup: %w", err)
 		}
+	}
+
+	if err := bpf.Remove(filepath.Join(bpf.CiliumPath(), Subsystem)); err != nil {
+		return fmt.Errorf("removing socketlb root bpffs  directory: %w", err)
 	}
 
 	return nil

--- a/pkg/testutils/endpoint.go
+++ b/pkg/testutils/endpoint.go
@@ -122,3 +122,11 @@ func (e *TestEndpoint) StateDir() string {
 	}
 	return "test_loader"
 }
+
+func (e *TestEndpoint) GetK8sNamespace() string {
+	return ""
+}
+
+func (e *TestEndpoint) GetK8sPodName() string {
+	return ""
+}


### PR DESCRIPTION
(review commit by commit)

Core plugin coordination logic and plumbing to make collection instrumentation possible across Cilium.

* [2025 NA Developer Summit](https://github.com/cilium/dev-summits/blob/main/2025-NA/cilium-datapath-plugins.pdf)
* https://github.com/cilium/design-cfps/pull/76

The full implementation of datapath plugins can be found here: https://github.com/cilium/cilium/pull/44881. I'll keep this up to date as things progress for anyone that wants to see the full context for these PRs.

* In `plugins: Implement bpfCollectionLoader` this PR introduces `bpfCollectionLoader` which is meant to orchestrate plugin interactions while loading BPF collections. When datapath plugins are disabled, calls to `LoadAndAssign` and `Load` simply invoke the normal `bpf.LoadAndAssign` and `bpf.Load` functions.
* The rest of the commits wire everything up, plumbing an instance of `bpfCollectionLoader` down to wherever the loader calls `bpf.LoadAndAssign` or `bpf.Load` today. There are a few fixups along the way to ensure that link+pin cleanup ordering doesn't accidentally remove plugin programs before detaching the main Cilium attachment.

### `bpfCollectionLoader` Flow
```mermaid
sequenceDiagram
    Cilium->Cilium: Load collection spec
    par
      Cilium->>Plugin A: PrepareHooksRequest
      Plugin A-->>Cilium: PrepareHooksResponse
    and
      Cilium->>Plugin B: PrepareHooksRequest
      Plugin B-->>Cilium: PrepareHooksResponse
    end
    Cilium->Cilium: Generate dispatcher programs and edit collection spec
    Cilium->Cilium: Load collection into kernel
    par
      Cilium->>Plugin A: LoadHooksRequest
      Plugin A->Plugin A: Load hook programs into kernel
      Plugin A->Plugin A: Pin hook programs to designated paths
      Plugin A-->>Cilium: LoadHooksResponse
    and
      Cilium->>Plugin B: LoadHooksRequest
      Plugin B->Plugin B: Load hook programs into kernel
      Plugin B->Plugin B: Pin hook programs to designated paths
      Plugin B-->>Cilium:LoadHooksResponse
    end
    Cilium->Cilium: Repin hook programs
    Cilium->Cilium: Attach hook programs to dispatcher hooks
    Cilium->Cilium: Attach entrypoints to relevant BPF attachment point
```

Related: https://github.com/cilium/cilium/issues/41634

```release-note
(Beta) Introduce datapath plugins to enable third party datapath extensions.
```