### PR TITLE
ipam: Reclaim still-advertised released CIDRs on renewed demand

### DIFF
--- a/pkg/ipam/pool.go
+++ b/pkg/ipam/pool.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net/netip"
 	"slices"
 
@@ -56,6 +57,20 @@ func newCIDRPool(logger *slog.Logger, allowFirstIP, allowLastIP bool) *cidrPool 
 		allowFirstIP: allowFirstIP,
 		allowLastIP:  allowLastIP,
 	}
+}
+
+// cidrRangeOpts returns the ipallocator range options matching the pool's
+// first/last IP settings. Delegated prefixes set both, so the network and
+// broadcast addresses of each CIDR become allocatable.
+func (p *cidrPool) cidrRangeOpts() []ipallocator.CIDRRangeOption {
+	var opts []ipallocator.CIDRRangeOption
+	if p.allowFirstIP {
+		opts = append(opts, ipallocator.WithAllowFirstIP())
+	}
+	if p.allowLastIP {
+		opts = append(opts, ipallocator.WithAllowLastIP())
+	}
+	return opts
 }
 
 func (p *cidrPool) allocate(addr netip.Addr) error {
@@ -186,6 +201,41 @@ func (p *cidrPool) releaseExcessCIDRsMultiPool(neededIPs int) {
 		totalFree += ipAllocator.Free()
 	}
 
+	// Reclaim previously-released CIDRs when demand has grown back and we
+	// no longer have enough free IPs. A CIDR stays in p.released only while
+	// it is still advertised in the CiliumNode (updatePool removes it from
+	// the set as soon as the operator stops advertising it), so reclaiming
+	// here never re-adds a CIDR that has actually been detached. Without
+	// this, a released-but-still-attached prefix is stranded forever: the
+	// operator may not detach it (e.g. release-excess-ips disabled), so it
+	// never leaves the advertised set, while updatePool refuses to recreate
+	// its allocator because it is still in p.released. The result is
+	// permanent exhaustion until the agent restarts.
+	if totalFree < neededIPs && len(p.released) > 0 {
+		// Reclaim in a deterministic order to avoid churn across calls.
+		reclaim := slices.SortedFunc(maps.Keys(p.released), func(a, b netip.Prefix) int {
+			if c := a.Addr().Compare(b.Addr()); c != 0 {
+				return c
+			}
+			return a.Bits() - b.Bits()
+		})
+
+		rangeOpts := p.cidrRangeOpts()
+		for _, prefix := range reclaim {
+			if totalFree >= neededIPs {
+				break
+			}
+			ipAllocator := ipallocator.NewCIDRRange(prefix, rangeOpts...)
+			if ipAllocator.Free() == 0 {
+				continue // too-small CIDR, keep it released
+			}
+			p.ipAllocators = append(p.ipAllocators, ipAllocator)
+			delete(p.released, prefix)
+			totalFree += ipAllocator.Free()
+			p.logger.Debug("reclaiming released CIDR", logfields.CIDR, prefix)
+		}
+	}
+
 	// Iterate over CIDRs in reverse order, so we prioritize releasing
 	// later CIDRs.
 	retainedAllocators := []*ipallocator.Range{}
@@ -277,13 +327,7 @@ func (p *cidrPool) updatePool(prefixes []netip.Prefix) {
 	}
 
 	// Create and add new IP allocators to newIPAllocators.
-	var rangeOpts []ipallocator.CIDRRangeOption
-	if p.allowFirstIP {
-		rangeOpts = append(rangeOpts, ipallocator.WithAllowFirstIP())
-	}
-	if p.allowLastIP {
-		rangeOpts = append(rangeOpts, ipallocator.WithAllowLastIP())
-	}
+	rangeOpts := p.cidrRangeOpts()
 	for _, prefix := range prefixes {
 		if _, ok := existingAllocators[prefix]; ok {
 			continue

--- a/pkg/ipam/pool_test.go
+++ b/pkg/ipam/pool_test.go
@@ -71,3 +71,51 @@ func TestCIDRPoolAllowFirstAndLastIPs(t *testing.T) {
 		require.NoError(t, pool.allocate(netip.MustParseAddr("10.0.0.16")))
 	})
 }
+
+// TestCIDRPoolReclaimsStillAdvertisedReleasedCIDR is a regression test for
+// the ENI multi-pool exhaustion reported in cilium/cilium#46598. When a
+// released CIDR is still advertised in the CiliumNode (e.g. the operator does
+// not physically detach it because release-excess-ips is disabled), the agent
+// must be able to reclaim it once demand grows back, instead of stranding it
+// in p.released forever and exhausting the pool until a restart.
+func TestCIDRPoolReclaimsStillAdvertisedReleasedCIDR(t *testing.T) {
+	logger := hivetest.Logger(t)
+
+	// Delegated prefixes: first and last IPs of each /28 are allocatable.
+	pool := newCIDRPool(logger, true, true)
+
+	p1 := netip.MustParsePrefix("10.0.0.0/28")
+	p2 := netip.MustParsePrefix("10.0.0.16/28")
+
+	// Both prefixes are attached and advertised: 32 usable IPs.
+	pool.updatePool([]netip.Prefix{p1, p2})
+	require.Equal(t, 32, pool.capacity())
+
+	// Keep p1 in use so it is retained, then drop demand so p2 is released.
+	require.NoError(t, pool.allocate(netip.MustParseAddr("10.0.0.0")))
+	require.NoError(t, pool.allocate(netip.MustParseAddr("10.0.0.1")))
+
+	// neededIPs is the number of free IPs that must remain. With near-zero
+	// demand, the unused p2 is released.
+	pool.releaseExcessCIDRsMultiPool(0)
+	require.Contains(t, pool.released, p2, "p2 should be released")
+	require.Equal(t, 14, pool.capacity(), "only p1 remains usable")
+
+	// The operator does NOT detach p2 (release-excess-ips disabled), so it
+	// stays advertised. updatePool alone must not reclaim it: the release
+	// signal to the operator depends on p2 staying out of the in-use set.
+	pool.updatePool([]netip.Prefix{p1, p2})
+	require.Contains(t, pool.released, p2, "p2 stays released while merely re-advertised")
+	require.Equal(t, 14, pool.capacity())
+
+	// Demand grows back beyond what p1 can satisfy. The agent must reclaim
+	// the still-advertised p2 rather than report exhaustion.
+	pool.releaseExcessCIDRsMultiPool(20)
+	require.NotContains(t, pool.released, p2, "p2 should be reclaimed")
+	require.Equal(t, 30, pool.capacity(), "p2's 16 IPs are usable again")
+
+	// p2 is back in the in-use CIDR set, so it is re-advertised to the
+	// operator as allocated, and its IPs are allocatable.
+	require.Len(t, pool.inUseCIDRs(), 2)
+	require.NoError(t, pool.allocate(netip.MustParseAddr("10.0.0.16")))
+}


### PR DESCRIPTION
In multi-pool IPAM, when the agent releases an unused CIDR it is recorded in the in-memory p.released set and its allocator is dropped. The only way out of p.released is updatePool()'s forget branch, which fires only once the CIDR stops being advertised in the CiliumNode. With release-excess-ips disabled (the default), the operator never physically detaches the prefix, so it stays advertised indefinitely, and updatePool() refuses to recreate its allocator because it is still in p.released. When demand grows back there was no path to reclaim the CIDR, leaving it stranded: the node sits exhausted ("all CIDR ranges are exhausted") for as long as the agent runs, and only an agent restart recovers it by rebuilding p.released empty.

This is latent in the shared cidrPool code and was surfaced by the 1.20 migration of ENI IPAM onto the multi-pool backend, which sources CIDRs from physical ENI prefix attachment rather than the operator-controlled Spec.IPAM.Pools.Allocated.

This PR makes releaseExcessCIDRsMultiPool() symmetric: it is the only place with demand context, so before releasing further it now reclaims released CIDRs when the free count has dropped below what is needed. This is safe because a CIDR remains in p.released only while it is still advertised (updatePool() evicts it as soon as the operator stops advertising it), and both functions are serialized under the manager poolsMutex, so a genuinely-detached prefix is never reclaimed.

The reclaimed CIDR re-enters the in-use set and is advertised back to the operator in the same update cycle, keeping the release/detach handshake consistent.

Fixes: #46598