### PR TITLE
endpoint: Guard ENI routing rule teardown by IP ownership

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1258,6 +1258,15 @@ func (e *Endpoint) replaceNonGeneratedIdentityLabels(sourceFilter string, l labe
 type DeleteConfig struct {
 	NoIPRelease       bool
 	NoIdentityRelease bool
+
+	// EndpointOwnsIP reports whether the given IP is still owned by the
+	// endpoint being deleted. It guards the per-endpoint routing rule
+	// teardown against a stale delete: in ENI/Azure IPAM mode the rules are
+	// keyed solely by IP address, so a late teardown for an IP that has since
+	// been reused by another endpoint would otherwise strip the live owner's
+	// rules, silently breaking its egress. When nil, the check is skipped and
+	// rules are always deleted.
+	EndpointOwnsIP func(ip netip.Addr) bool
 }
 
 // leaveLocked removes the endpoint's directory from the system. Must be called
@@ -2675,16 +2684,30 @@ func (e *Endpoint) Delete(conf DeleteConfig) []error {
 		// This is a best-effort attempt to cleanup. We expect there to be one
 		// ingress rule and multiple egress rules. If we find more rules than
 		// expected, we delete all rules referring to a per-ENI routing table ID.
-		if e.IPv4.IsValid() {
-			if err := linuxrouting.Delete(e.getLogger(), e.IPv4); err != nil {
+		//
+		// The routing rules are keyed solely by IP address, so a stale teardown
+		// for an IP that has since been reused by another endpoint would strip
+		// the live owner's rules. Guard against that by only deleting the rules
+		// if this endpoint still owns the IP.
+		deleteRoutingRules := func(ip netip.Addr) {
+			if conf.EndpointOwnsIP != nil && !conf.EndpointOwnsIP(ip) {
+				e.getLogger().Info(
+					"Skipping deletion of endpoint routing rules: IP is no longer owned by this endpoint",
+					logfields.IPAddr, ip,
+				)
+				return
+			}
+			if err := linuxrouting.Delete(e.getLogger(), ip); err != nil {
 				errs = append(errs, fmt.Errorf("unable to delete endpoint routing rules: %w", err))
 			}
 		}
 
+		if e.IPv4.IsValid() {
+			deleteRoutingRules(e.IPv4)
+		}
+
 		if e.IPv6.IsValid() {
-			if err := linuxrouting.Delete(e.getLogger(), e.IPv6); err != nil {
-				errs = append(errs, fmt.Errorf("unable to delete endpoint routing rules: %w", err))
-			}
+			deleteRoutingRules(e.IPv6)
 		}
 	}
 

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -504,6 +504,17 @@ func (mgr *endpointManager) removeEndpoint(ep *endpoint.Endpoint, conf endpoint.
 	isRestored := ep.GetState() == endpoint.StateRestoring
 
 	mgr.unexpose(ep)
+
+	// Guard the per-endpoint routing rule teardown against a stale delete. By
+	// this point unexpose has removed ep from the IP index, so LookupIP returns
+	// nil when no one owns the IP (safe to delete our rules) and the new owner
+	// when the IP has already been reused (skip, deleting would strip its
+	// rules). It can never return ep itself.
+	conf.EndpointOwnsIP = func(ip netip.Addr) bool {
+		owner := mgr.LookupIP(ip)
+		return owner == nil || owner == ep
+	}
+
 	result := ep.Delete(conf)
 
 	// Restored endpoints never had an ID allocated.


### PR DESCRIPTION
In ENI/Azure IPAM mode, per-endpoint ip rules are keyed solely by IP address. Under IP-reuse churn, a stale endpoint teardown can delete the routing rules of a new endpoint that has since been assigned the same IP, silently breaking its egress (traffic falls through to the primary interface with the wrong source IP/SG).

This PR gates `linuxrouting.Delete` on whether the IP is still owned by the endpoint being torn down. `removeEndpoint` already unexposes the endpoint before `Delete`, so a `LookupIP` returning another endpoint means the IP was reused and the rules must be left in place.

This PR is very similar to #44494 both in terms of the class of problem being addressed and the nature of the fix.