### PR TITLE
gw-api-ci: Remove crd channel in matrix

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -122,20 +122,13 @@ jobs:
           MATRIX='{
             "include": [
               {
-                "crd-channel": "experimental",
                 "conformance-profile": false,
                 "default": true
               },
               {
-                "crd-channel": "standard",
-                "conformance-profile": false
-              },
-              {
-                "crd-channel": "experimental",
                 "conformance-profile": true
               },
               {
-                "crd-channel": "standard",
                 "conformance-profile": false,
                 "encryption": "ipsec"
               },
@@ -204,11 +197,6 @@ jobs:
         id: vars
         run: |
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT
-
-          EXEMPT_FEATURES="HTTPRouteParentRefPort,MeshConsumerRoute"
-          if [ "${{ matrix.crd-channel }}" == "standard" ]; then
-            EXEMPT_FEATURES+=",HTTPRouteDestinationPortMatching,HTTPRouteRequestTimeout,HTTPRouteBackendTimeout,GatewayInfrastructurePropagation"
-          fi
 
           SKIPPED_TESTS="TCPRouteWeightedRouting,UDPRouteWeightedRouting"
           if [ "${{ matrix.conformance-profile }}" == "true" ]; then
@@ -405,7 +393,7 @@ jobs:
       - name: Upload report artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: report-${{ matrix.conformance-profile }}-${{ matrix.crd-channel }}.yaml
+          name: report-${{ matrix.conformance-profile }}.yaml
           path: operator/pkg/gateway-api/report.yaml
           retention-days: 5
           if-no-files-found: ignore


### PR DESCRIPTION
<!-- Description of change -->
Now that GatewayClass objects list which features are supported, we can remove the use of the `crd-channel` in ci for gateway api. The conformance tests check against that gateway class for which features are supported. 

cc @youngnick 


[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
