### PR TITLE
cilium-dbg: warn in validate-cnp using identity-excluded labels

### DIFF
--- a/cilium-dbg/cmd/preflight_k8s_valid_cnp.go
+++ b/cilium-dbg/cmd/preflight_k8s_valid_cnp.go
@@ -5,8 +5,10 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/cilium/hive/cell"
@@ -14,14 +16,20 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/cilium/cilium/pkg/hive"
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	v2_validation "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2/validator"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/scheme"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/slices"
 )
 
 func validateCNPCmd() *cobra.Command {
@@ -58,6 +66,10 @@ const (
 	ciliumGroup                = "cilium.io"
 )
 
+// errExcludedLabels flags a policy selector referencing labels that are excluded
+// from the security identity.
+var errExcludedLabels = errors.New("selector references labels excluded from the security identity")
+
 func validateCNPs(logger *slog.Logger, clientset k8sClient.Clientset, shutdowner hive.Shutdowner) error {
 	defer shutdowner.Shutdown()
 
@@ -71,90 +83,221 @@ func validateCNPs(logger *slog.Logger, clientset k8sClient.Clientset, shutdowner
 		return err
 	}
 
+	// Initialize the label filter with the built-in defaults so we can warn about
+	// selectors referencing labels excluded from the security identity.
+	if err := labelsfilter.ParseLabelPrefixCfg(logger, nil, nil, ""); err != nil {
+		return err
+	}
+
 	ctx, initCancel := context.WithTimeout(context.Background(), validateK8sPoliciesTimeout)
 	defer initCancel()
-	cnpErr := validateNPResources(ctx, clientset, npValidator.ValidateCNP, "ciliumnetworkpolicies", "CiliumNetworkPolicy")
+	cnpExcluded, cnpErr := validateNPResources(ctx, clientset,
+		validate(npValidator.ValidateCNP, checkCNPExcludedLabels),
+		"ciliumnetworkpolicies", "CiliumNetworkPolicy")
 
 	ctx, initCancel2 := context.WithTimeout(context.Background(), validateK8sPoliciesTimeout)
 	defer initCancel2()
-	ccnpErr := validateNPResources(ctx, clientset, npValidator.ValidateCCNP, "ciliumclusterwidenetworkpolicies", "CiliumClusterwideNetworkPolicy")
+	ccnpExcluded, ccnpErr := validateNPResources(ctx, clientset,
+		validate(npValidator.ValidateCCNP, checkCCNPExcludedLabels),
+		"ciliumclusterwidenetworkpolicies", "CiliumClusterwideNetworkPolicy")
 
-	if cnpErr != nil {
-		return cnpErr
+	if err := errors.Join(cnpErr, ccnpErr); err != nil {
+		return err
 	}
-	if ccnpErr != nil {
-		return ccnpErr
+	if !cnpExcluded && !ccnpExcluded {
+		log.Info("All CCNPs and CNPs valid!")
 	}
-	log.Info("All CCNPs and CNPs valid!")
 	return nil
 }
 
+// policyValidator inspects a single policy object. Validators are composed with
+// validate() and share the unstructured representation returned by the lister.
+type policyValidator func(*unstructured.Unstructured) error
+
+func validate(validators ...policyValidator) policyValidator {
+	return func(policy *unstructured.Unstructured) error {
+		for _, v := range validators {
+			if err := v(policy); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+// validateNPResources runs validate against every policy of the given resource,
+// reporting whether any of them referenced identity-excluded labels.
 func validateNPResources(
 	ctx context.Context,
 	clientset k8sClient.Clientset,
-	validator func(cnp *unstructured.Unstructured) error,
+	validate policyValidator,
 	name,
 	shortName string,
-) error {
+) (bool, error) {
 	// Check if the crd is installed at all.
-	_, err := clientset.ApiextensionsV1().CustomResourceDefinitions().Get(
+	if _, err := clientset.ApiextensionsV1().CustomResourceDefinitions().Get(
 		ctx,
 		name+"."+ciliumGroup,
 		metav1.GetOptions{},
-	)
-	switch {
-	case err == nil:
-	case k8sErrors.IsNotFound(err):
-		return nil
-	default:
-		return err
+	); err != nil {
+		if k8sErrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
 	}
 
 	var (
 		policyErr error
-		cnps      unstructured.UnstructuredList
-		cnpName   string
+		excluded  bool
+		nps       unstructured.UnstructuredList
+		npName    string
 	)
 	for {
 		opts := metav1.ListOptions{
 			Limit:    25,
-			Continue: cnps.GetContinue(),
+			Continue: nps.GetContinue(),
 		}
-		err = clientset.
+		if err := clientset.
 			CiliumV2().
 			RESTClient().
 			Get().
 			VersionedParams(&opts, scheme.ParameterCodec).
 			Resource(name).
 			Do(ctx).
-			Into(&cnps)
-		if err != nil {
-			return err
+			Into(&nps); err != nil {
+			return false, err
 		}
 
-		for _, cnp := range cnps.Items {
-			if cnp.GetNamespace() != "" {
-				cnpName = fmt.Sprintf("%s/%s", cnp.GetNamespace(), cnp.GetName())
+		for _, np := range nps.Items {
+			if np.GetNamespace() != "" {
+				npName = fmt.Sprintf("%s/%s", np.GetNamespace(), np.GetName())
 			} else {
-				cnpName = cnp.GetName()
+				npName = np.GetName()
 			}
-			if err := validator(&cnp); err != nil {
+
+			switch err := validate(&np); {
+			case err == nil:
+				log.Info("Validation OK!",
+					logfields.Type, shortName,
+					logfields.Name, npName,
+				)
+			case errors.Is(err, errExcludedLabels):
+				log.Warn("Policy selector references labels excluded from the security identity; "+
+					"it will not match endpoints unless overridden via --label-prefix-file",
+					logfields.Error, err,
+					logfields.Type, shortName,
+					logfields.Name, npName,
+				)
+				excluded = true
+			default:
 				log.Error("Unexpected validation error",
 					logfields.Error, err,
 					logfields.Type, shortName,
-					logfields.Name, cnpName,
+					logfields.Name, npName,
 				)
 				policyErr = fmt.Errorf("Found invalid %s", shortName)
-			} else {
-				log.Info("Validation OK!",
-					logfields.Type, shortName,
-					logfields.Name, cnpName,
-				)
 			}
 		}
-		if cnps.GetContinue() == "" {
+		if nps.GetContinue() == "" {
 			break
 		}
 	}
-	return policyErr
+
+	if excluded {
+		log.Warn(fmt.Sprintf("Detected %s resources with selectors referencing identity-excluded labels; "+
+			"see the warnings above. Such selectors will not match endpoints unless overridden "+
+			"via --label-prefix-file.", shortName))
+	}
+
+	return excluded, policyErr
+}
+
+// parseable extracts a policy's rules. It is implemented by both
+// CiliumNetworkPolicy and CiliumClusterwideNetworkPolicy.
+type parseable interface {
+	Parse(logger *slog.Logger, clusterName string) (api.Rules, error)
+}
+
+func checkCNPExcludedLabels(rawCNP *unstructured.Unstructured) error {
+	var cnp cilium_v2.CiliumNetworkPolicy
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(rawCNP.Object, &cnp); err != nil {
+		return err
+	}
+	return checkExcludedLabels(&cnp)
+}
+
+func checkCCNPExcludedLabels(rawCCNP *unstructured.Unstructured) error {
+	var ccnp cilium_v2.CiliumClusterwideNetworkPolicy
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(rawCCNP.Object, &ccnp); err != nil {
+		return err
+	}
+	return checkExcludedLabels(&ccnp)
+}
+
+// checkExcludedLabels returns errExcludedLabels listing the policy's selector
+// label keys that the identity label filter would drop, or nil if there is none.
+func checkExcludedLabels(policy parseable) error {
+	rules, err := policy.Parse(log, "")
+	if err != nil {
+		return err
+	}
+
+	var keys []string
+	for _, rule := range rules {
+		for _, sel := range endpointSelectors(rule) {
+			keys = append(keys, excludedSelectorKeys(sel)...)
+		}
+	}
+	if len(keys) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%w: %s", errExcludedLabels, strings.Join(slices.Unique(keys), ", "))
+}
+
+// endpointSelectors returns the rule's EndpointSelectors that are matched against
+// endpoint identities.
+func endpointSelectors(rule *api.Rule) []api.EndpointSelector {
+	sels := []api.EndpointSelector{rule.EndpointSelector}
+	for _, ing := range rule.Ingress {
+		sels = append(sels, ing.FromEndpoints...)
+	}
+	for _, ing := range rule.IngressDeny {
+		sels = append(sels, ing.FromEndpoints...)
+	}
+	for _, egr := range rule.Egress {
+		sels = append(sels, egr.ToEndpoints...)
+	}
+	for _, egr := range rule.EgressDeny {
+		sels = append(sels, egr.ToEndpoints...)
+	}
+	return sels
+}
+
+// excludedSelectorKeys returns the selector's label keys that the identity label
+// filter would drop. Selectors here come from Parse(), whose keys are source
+// encoded (e.g. "any:topology.kubernetes.io/zone"); Map2Labels/NewLabel strip
+// that source prefix, recovering the bare key the filter matches against.
+func excludedSelectorKeys(sel api.EndpointSelector) []string {
+	if sel.LabelSelector == nil {
+		return nil
+	}
+
+	lbls := labels.Map2Labels(sel.MatchLabels, labels.LabelSourceAny)
+	for _, req := range sel.MatchExpressions {
+		l := labels.NewLabel(req.Key, "", labels.LabelSourceAny)
+		lbls[l.Key] = l
+	}
+	if len(lbls) == 0 {
+		return nil
+	}
+
+	identity, _ := labelsfilter.Filter(lbls)
+
+	var excluded []string
+	for k, l := range lbls {
+		if _, kept := identity[k]; !kept {
+			excluded = append(excluded, l.Key)
+		}
+	}
+	return excluded
 }

--- a/cilium-dbg/cmd/preflight_k8s_valid_cnp_test.go
+++ b/cilium-dbg/cmd/preflight_k8s_valid_cnp_test.go
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/labelsfilter"
+	"github.com/cilium/cilium/pkg/policy/api"
+)
+
+// es builds an EndpointSelector from match labels and match-expression keys
+// using the "exists" operator.
+func es(matchLabels map[string]string, exprKeys ...string) api.EndpointSelector {
+	ls := &slim_metav1.LabelSelector{
+		MatchLabels: matchLabels,
+	}
+	for _, k := range exprKeys {
+		ls.MatchExpressions = append(ls.MatchExpressions, slim_metav1.LabelSelectorRequirement{
+			Key:      k,
+			Operator: slim_metav1.LabelSelectorOpExists,
+		})
+	}
+	return api.EndpointSelector{LabelSelector: ls}
+}
+
+func Test_checkExcludedLabels(t *testing.T) {
+	log = hivetest.Logger(t)
+	// Custom "!excluded" prefix keeps the test independent of the default filter.
+	require.NoError(t, labelsfilter.ParseLabelPrefixCfg(log, []string{"!excluded"}, nil, ""))
+
+	ingress := []api.IngressRule{{IngressCommonRule: api.IngressCommonRule{
+		FromEndpoints: []api.EndpointSelector{es(map[string]string{"app": "frontend"})},
+	}}}
+
+	tests := []struct {
+		name    string
+		policy  parseable
+		wantKey string // "" means no finding expected
+		wantErr bool   // a non-advisory error (parse failure)
+	}{
+		{
+			name: "CNP endpoint selector",
+			policy: &cilium_v2.CiliumNetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "warn", Namespace: "default"},
+				Spec:       &api.Rule{EndpointSelector: es(map[string]string{"excluded/zone": "z"}), Ingress: ingress},
+			},
+			wantKey: "excluded/zone",
+		},
+		{
+			name: "CNP ingress selector",
+			policy: &cilium_v2.CiliumNetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "warn-ingress", Namespace: "default"},
+				Spec: &api.Rule{
+					EndpointSelector: es(map[string]string{"app": "web"}),
+					Ingress: []api.IngressRule{{IngressCommonRule: api.IngressCommonRule{
+						FromEndpoints: []api.EndpointSelector{es(map[string]string{"excluded/region": "r"})},
+					}}},
+				},
+			},
+			wantKey: "excluded/region",
+		},
+		{
+			name: "clean CNP reports nothing",
+			policy: &cilium_v2.CiliumNetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "clean", Namespace: "default"},
+				Spec:       &api.Rule{EndpointSelector: es(map[string]string{"app": "web"}), Ingress: ingress},
+			},
+		},
+		{
+			name: "CCNP endpoint selector",
+			policy: &cilium_v2.CiliumClusterwideNetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "ccnp-warn"},
+				Spec:       &api.Rule{EndpointSelector: es(map[string]string{"excluded/zone": "z"}), Ingress: ingress},
+			},
+			wantKey: "excluded/zone",
+		},
+		{
+			name: "clean CCNP reports nothing",
+			policy: &cilium_v2.CiliumClusterwideNetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "ccnp-clean"},
+				Spec:       &api.Rule{EndpointSelector: es(map[string]string{"app": "web"}), Ingress: ingress},
+			},
+		},
+		{
+			// No ingress/egress -> Parse() rejects it.
+			name: "unparseable policy surfaces the parse error",
+			policy: &cilium_v2.CiliumNetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "norules", Namespace: "default"},
+				Spec:       &api.Rule{EndpointSelector: es(map[string]string{"app": "x"})},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkExcludedLabels(tt.policy)
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				require.NotErrorIs(t, err, errExcludedLabels)
+			case tt.wantKey == "":
+				require.NoError(t, err)
+			default:
+				require.ErrorIs(t, err, errExcludedLabels)
+				require.Contains(t, err.Error(), tt.wantKey)
+			}
+		})
+	}
+}
+
+func Test_excludedSelectorKeys(t *testing.T) {
+	// Register a custom "!excluded" ignore prefix so the test is independent of
+	// the default filter expressions in pkg/labelsfilter/filter.go.
+	require.NoError(t, labelsfilter.ParseLabelPrefixCfg(hivetest.Logger(t), []string{"!excluded"}, nil, ""))
+
+	tests := []struct {
+		name     string
+		selector api.EndpointSelector
+		want     []string
+	}{
+		{
+			name:     "excluded label in matchLabels is excluded",
+			selector: es(map[string]string{"excluded/zone": "us-east-1a"}),
+			want:     []string{"excluded/zone"},
+		},
+		{
+			name:     "excluded label with explicit k8s source is excluded",
+			selector: es(map[string]string{"k8s:excluded/region": "us-east-1"}),
+			want:     []string{"excluded/region"},
+		},
+		{
+			name:     "excluded label in matchExpressions is excluded",
+			selector: es(nil, "excluded/zone"),
+			want:     []string{"excluded/zone"},
+		},
+		{
+			name:     "non-excluded label is kept",
+			selector: es(map[string]string{"allowed/name": "nginx"}),
+			want:     nil,
+		},
+		{
+			name: "mixed selector only reports the excluded key",
+			selector: es(map[string]string{
+				"excluded/zone": "us-east-1a",
+				"app":           "backend",
+			}),
+			want: []string{"excluded/zone"},
+		},
+		{
+			name:     "nil label selector returns nothing",
+			selector: api.EndpointSelector{},
+			want:     nil,
+		},
+		{
+			name:     "empty (wildcard) selector returns nothing",
+			selector: es(nil),
+			want:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := excludedSelectorKeys(tt.selector)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/cilium-dbg/cmd/preflight_k8s_valid_cnp_test.go
+++ b/cilium-dbg/cmd/preflight_k8s_valid_cnp_test.go
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/labelsfilter"
+	"github.com/cilium/cilium/pkg/policy/api"
+)
+
+// es builds an EndpointSelector from match labels and match-expression keys
+// using the "exists" operator.
+func es(matchLabels map[string]string, exprKeys ...string) api.EndpointSelector {
+	ls := &slim_metav1.LabelSelector{
+		MatchLabels: matchLabels,
+	}
+	for _, k := range exprKeys {
+		ls.MatchExpressions = append(ls.MatchExpressions, slim_metav1.LabelSelectorRequirement{
+			Key:      k,
+			Operator: slim_metav1.LabelSelectorOpExists,
+		})
+	}
+	return api.EndpointSelector{LabelSelector: ls}
+}
+
+func TestCheckExcludedLabels(t *testing.T) {
+	log = hivetest.Logger(t)
+	// Custom "!excluded" prefix keeps the test independent of the default filter.
+	require.NoError(t, labelsfilter.ParseLabelPrefixCfg(log, []string{"!excluded"}, nil, ""))
+
+	ingress := []api.IngressRule{{IngressCommonRule: api.IngressCommonRule{
+		FromEndpoints: []api.EndpointSelector{es(map[string]string{"app": "frontend"})},
+	}}}
+
+	tests := []struct {
+		name    string
+		policy  parseable
+		wantKey string // "" means no finding expected
+		wantErr bool   // a non-advisory error (parse failure)
+	}{
+		{
+			name: "CNP endpoint selector",
+			policy: &cilium_v2.CiliumNetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "warn", Namespace: "default"},
+				Spec:       &api.Rule{EndpointSelector: es(map[string]string{"excluded/zone": "z"}), Ingress: ingress},
+			},
+			wantKey: "excluded/zone",
+		},
+		{
+			name: "CNP ingress selector",
+			policy: &cilium_v2.CiliumNetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "warn-ingress", Namespace: "default"},
+				Spec: &api.Rule{
+					EndpointSelector: es(map[string]string{"app": "web"}),
+					Ingress: []api.IngressRule{{IngressCommonRule: api.IngressCommonRule{
+						FromEndpoints: []api.EndpointSelector{es(map[string]string{"excluded/region": "r"})},
+					}}},
+				},
+			},
+			wantKey: "excluded/region",
+		},
+		{
+			name: "clean CNP reports nothing",
+			policy: &cilium_v2.CiliumNetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "clean", Namespace: "default"},
+				Spec:       &api.Rule{EndpointSelector: es(map[string]string{"app": "web"}), Ingress: ingress},
+			},
+		},
+		{
+			name: "CCNP endpoint selector",
+			policy: &cilium_v2.CiliumClusterwideNetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "ccnp-warn"},
+				Spec:       &api.Rule{EndpointSelector: es(map[string]string{"excluded/zone": "z"}), Ingress: ingress},
+			},
+			wantKey: "excluded/zone",
+		},
+		{
+			name: "clean CCNP reports nothing",
+			policy: &cilium_v2.CiliumClusterwideNetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "ccnp-clean"},
+				Spec:       &api.Rule{EndpointSelector: es(map[string]string{"app": "web"}), Ingress: ingress},
+			},
+		},
+		{
+			// No ingress/egress -> Parse() rejects it.
+			name: "unparseable policy surfaces the parse error",
+			policy: &cilium_v2.CiliumNetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "norules", Namespace: "default"},
+				Spec:       &api.Rule{EndpointSelector: es(map[string]string{"app": "x"})},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkExcludedLabels(tt.policy)
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				require.NotErrorIs(t, err, errExcludedLabels)
+			case tt.wantKey == "":
+				require.NoError(t, err)
+			default:
+				require.ErrorIs(t, err, errExcludedLabels)
+				require.Contains(t, err.Error(), tt.wantKey)
+			}
+		})
+	}
+}
+
+func TestExcludedSelectorKeys(t *testing.T) {
+	// Register a custom "!excluded" ignore prefix so the test is independent of
+	// the default filter expressions in pkg/labelsfilter/filter.go.
+	require.NoError(t, labelsfilter.ParseLabelPrefixCfg(hivetest.Logger(t), []string{"!excluded"}, nil, ""))
+
+	tests := []struct {
+		name     string
+		selector api.EndpointSelector
+		want     []string
+	}{
+		{
+			name:     "excluded label in matchLabels is excluded",
+			selector: es(map[string]string{"excluded/zone": "us-east-1a"}),
+			want:     []string{"excluded/zone"},
+		},
+		{
+			name:     "excluded label with explicit k8s source is excluded",
+			selector: es(map[string]string{"k8s:excluded/region": "us-east-1"}),
+			want:     []string{"excluded/region"},
+		},
+		{
+			name:     "excluded label in matchExpressions is excluded",
+			selector: es(nil, "excluded/zone"),
+			want:     []string{"excluded/zone"},
+		},
+		{
+			name:     "non-excluded label is kept",
+			selector: es(map[string]string{"allowed/name": "nginx"}),
+			want:     nil,
+		},
+		{
+			name: "mixed selector only reports the excluded key",
+			selector: es(map[string]string{
+				"excluded/zone": "us-east-1a",
+				"app":           "backend",
+			}),
+			want: []string{"excluded/zone"},
+		},
+		{
+			name:     "nil label selector returns nothing",
+			selector: api.EndpointSelector{},
+			want:     nil,
+		},
+		{
+			name:     "empty (wildcard) selector returns nothing",
+			selector: es(nil),
+			want:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := excludedSelectorKeys(tt.selector)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [ ] Thanks for contributing!

<!-- Description of change -->

Since #43725, topology.kubernetes.io labels are excluded from the security identity by default. Existing CNPs/CCNPs that select on such labels stay schema-valid but silently stop matching endpoints after upgrade.

Extend 'preflight validate-cnp' with a non-fatal warning pass that reuses labelsfilter.Filter to flag any endpoint-selector label key that would be dropped from identity. Warnings are advisory and do not affect the exit code.

Closes: #46629

```release-note
cilium-dbg: warn in validate-cnp on selectors using identity-excluded labels
```

*This PR was written by an AI with human supervision. I have reviewed every line prior to opening the PR.*

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
