### PR TITLE
Fix workflow change detection for single-commit PRs to main

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -268,3 +268,9 @@ workflows:
     paths-regex: (\.github/workflows/tests-cifuzz\.yaml|fuzz_test.go|test/fuzzing/)
   k8s-kind-network-policies-e2e.yaml:
     paths-ignore-regex: (Documentation/|test/)
+  tests-smoke-conformance.yaml:
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules|.github/actions/e2e|.github/actions/ginkgo)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md|.*_test\.go)$)
+  k8s-kind-network-e2e.yaml:
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules|.github/actions/e2e|.github/actions/ginkgo)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md|.*_test\.go)$)
+  tests-smoke-ipv6.yaml:
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules|.github/actions/e2e|.github/actions/ginkgo)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md|.*_test\.go)$)

--- a/.github/workflows/k8s-kind-network-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-e2e.yaml
@@ -60,33 +60,8 @@ jobs:
         with:
           sha: ${{ inputs.SHA || github.sha }}
 
-  check_changes:
-    name: Deduce required tests from code changes
-    runs-on: ubuntu-24.04
-    outputs:
-      tested: ${{ steps.tested-tree.outputs.src }}
-    steps:
-      - name: Checkout code
-        if: ${{ !github.event.workflow_dispatch }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-      - name: Check code changes
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: tested-tree
-        with:
-          # For `push` events, compare against the `ref` base branch
-          # For `workflow_dispatch` events, this is ignored and will compare against the pull request base branch
-          base: ${{ github.ref }}
-          filters: |
-            src:
-              - '!(test|Documentation)/**'
-
   kubernetes-e2e:
     name: K8s Network E2E tests
-    needs: check_changes
-    if: ${{ needs.check_changes.outputs.tested == 'true' }}
     runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
     timeout-minutes: 90
     strategy:

--- a/.github/workflows/tests-smoke-conformance.yaml
+++ b/.github/workflows/tests-smoke-conformance.yaml
@@ -73,35 +73,9 @@ jobs:
         with:
           sha: ${{ inputs.SHA || github.sha }}
 
-  check_changes:
-    name: Deduce required tests from code changes
-    runs-on: ubuntu-24.04
-    outputs:
-      tested: ${{ steps.tested-tree.outputs.src }}
-    steps:
-      - name: Checkout code
-        if: ${{ !github.event.workflow_dispatch }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-      - name: Check code changes
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: tested-tree
-        with:
-          # For `push` events, compare against the `ref` base branch
-          # For `workflow_dispatch` events, this is ignored and will compare against the pull request base branch
-          base: ${{ github.ref }}
-          filters: |
-            src:
-              - '!(test|Documentation)/**'
-              - '!**/*.md'
-
   conformance-test:
     env:
       job_name: "Conformance Smoke Test"
-    needs: check_changes
-    if: ${{ needs.check_changes.outputs.tested == 'true' }}
     runs-on: ubuntu-24.04
     name: Installation and Conformance Test
     steps:

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -64,35 +64,9 @@ jobs:
         with:
           sha: ${{ inputs.SHA || github.sha }}
 
-  check_changes:
-    name: Deduce required tests from code changes
-    runs-on: ubuntu-24.04
-    outputs:
-      tested: ${{ steps.tested-tree.outputs.src }}
-    steps:
-      - name: Checkout code
-        if: ${{ !github.event.workflow_dispatch }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-      - name: Check code changes
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: tested-tree
-        with:
-          # For `push` events, compare against the `ref` base branch
-          # For `workflow_dispatch` events, this is ignored and will compare against the pull request base branch
-          base: ${{ github.ref }}
-          filters: |
-            src:
-              - '!(test|Documentation)/**'
-              - '!**/*.md'
-
   conformance-test-ipv6:
     env:
       job_name: "Conformance Smoke Test with IPv6"
-    needs: check_changes
-    if: ${{ needs.check_changes.outputs.tested == 'true' }}
     runs-on: ubuntu-24.04
     name: Installation and Conformance Test (ipv6)
     steps:


### PR DESCRIPTION
The "Deduce required tests" step was incorrectly computing the set of changed files for single-commit PRs to main. This was caused by using `base: ${{ github.ref }}` in the `dorny/paths-filter` action, which caused it to compare `main` against itself when the `before` field was missing in the event payload.

Instead of adding complex conditionals to `base/ref` for `workflow_dispatch` workflows, this PR takes a more robust approach for Ariane-managed workflows by relying on Ariane's built-in change detection.

**Changes:**
- Removed obsolete `check_changes` jobs entirely from workflows invoked through Ariane (`k8s-kind-network-e2e.yaml`, `tests-smoke-ipv6.yaml`, `tests-smoke-conformance.yaml`).
- Added `paths-ignore-regex` to `.github/ariane-config.yaml` to configure change detection directly in Ariane.
- Non-Ariane-managed workflows (`documentation.yaml` and `tests-smoke.yaml`) retain their `check_changes` jobs as they do not use `workflow_dispatch`.

Fixes: #46676

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read Submitting a pull request
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
description and a Fixes: #XXX line if the commit addresses a particular
GitHub issue.
- [ ] If your commit description contains a Fixes: <commit-id> tag, then
please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section Developer's Certificate of Origin
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
in accordance with the Cilium AI Policy, and indicate the rating using
AI Influence Level.
Example: "This PR was prepared with AIL:1. Me and mentors reviewed the changes and verified the fix addresses the root cause of the incorrect change detection."
- [x] Thanks for contributing!
