### PR TITLE
helm: support external TLS certificate sources via volume overrides and extraInitContainers

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -948,6 +948,10 @@
      - X509Subject Full X509 name specification used when clustermesh.apiserver.tls.auto.method=certmanager. https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.X509Subject
      - object
      - ``{}``
+   * - :spelling:ignore:`clustermesh.apiserver.tls.disableDefaultVolumes`
+     - Disable the default TLS certificate volumes and mounts for clustermesh-apiserver (including KVStoreMesh), cilium-agent and cilium-operator, allowing you to provide your own via extraVolumes/extraVolumeMounts. This also disables mounting the clustermesh configuration, which then needs to be provided separately (likely at a different location).
+     - bool
+     - ``false``
    * - :spelling:ignore:`clustermesh.apiserver.tolerations`
      - Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
      - list
@@ -2471,7 +2475,7 @@
    * - :spelling:ignore:`hubble.relay.tls`
      - TLS configuration for Hubble Relay
      - object
-     - ``{"client":{"cert":"","existingSecret":"","key":""},"server":{"cert":"","enabled":false,"existingSecret":"","extraDnsNames":[],"extraIpAddresses":[],"key":"","mtls":false,"relayName":"ui.hubble-relay.cilium.io"}}``
+     - ``{"client":{"cert":"","existingSecret":"","key":""},"disableDefaultVolumes":false,"server":{"cert":"","enabled":false,"existingSecret":"","extraDnsNames":[],"extraIpAddresses":[],"key":"","mtls":false,"relayName":"ui.hubble-relay.cilium.io"}}``
    * - :spelling:ignore:`hubble.relay.tls.client`
      - The hubble-relay client certificate and private key. This keypair is presented to Hubble server instances for mTLS authentication and is required when hubble.tls.enabled is true. These values need to be set manually if hubble.tls.auto.enabled is false.
      - object
@@ -2488,6 +2492,10 @@
      - base64 encoded PEM values for the Hubble relay client key (deprecated). Use existingSecret instead.
      - string
      - ``""``
+   * - :spelling:ignore:`hubble.relay.tls.disableDefaultVolumes`
+     - Disable the default TLS certificate volumes and mounts for Hubble Relay, allowing you to provide your own via extraVolumes/extraVolumeMounts.
+     - bool
+     - ``false``
    * - :spelling:ignore:`hubble.relay.tls.server`
      - The hubble-relay server certificate and private key
      - object
@@ -2535,7 +2543,7 @@
    * - :spelling:ignore:`hubble.tls`
      - TLS configuration for Hubble
      - object
-     - ``{"auto":{"certManagerIssuerRef":{},"certValidityDuration":365,"enabled":true,"method":"helm","privateKey":{},"schedule":"0 0 1 */4 *","subject":{}},"enabled":true,"server":{"cert":"","existingSecret":"","extraDnsNames":[],"extraIpAddresses":[],"key":""}}``
+     - ``{"auto":{"certManagerIssuerRef":{},"certValidityDuration":365,"enabled":true,"method":"helm","privateKey":{},"schedule":"0 0 1 */4 *","subject":{}},"disableDefaultVolumes":false,"enabled":true,"server":{"cert":"","existingSecret":"","extraDnsNames":[],"extraIpAddresses":[],"key":""}}``
    * - :spelling:ignore:`hubble.tls.auto`
      - Configure automatic TLS certificates generation.
      - object
@@ -2568,6 +2576,10 @@
      - X509Subject Full X509 name specification used when hubble.tls.auto.method=certmanager. https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.X509Subject
      - object
      - ``{}``
+   * - :spelling:ignore:`hubble.tls.disableDefaultVolumes`
+     - Disable the default TLS certificate volumes and mounts for the Hubble server, allowing you to provide your own via extraVolumes/extraVolumeMounts.
+     - bool
+     - ``false``
    * - :spelling:ignore:`hubble.tls.enabled`
      - Enable mutual TLS for listenAddress. Setting this value to false is highly discouraged as the Hubble API provides access to potentially sensitive network flow metadata and is exposed on the host network.
      - bool
@@ -2760,6 +2772,10 @@
      - base64 encoded PEM values for the Hubble UI client key (deprecated). Use existingSecret instead.
      - string
      - ``""``
+   * - :spelling:ignore:`hubble.ui.tls.disableDefaultVolumes`
+     - Disable the default TLS certificate volumes and mounts for Hubble UI, allowing you to provide your own via extraVolumes/extraVolumeMounts.
+     - bool
+     - ``false``
    * - :spelling:ignore:`hubble.ui.tmpVolume`
      - Configure temporary volume for hubble-ui
      - object

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -652,6 +652,10 @@
      - Additional clustermesh-apiserver environment variables.
      - list
      - ``[]``
+   * - :spelling:ignore:`clustermesh.apiserver.extraInitContainers`
+     - Additional init containers added to the clustermesh-apiserver Deployment.
+     - list
+     - ``[]``
    * - :spelling:ignore:`clustermesh.apiserver.extraVolumeMounts`
      - Additional clustermesh-apiserver volumeMounts.
      - list
@@ -2288,6 +2292,10 @@
      - Additional hubble-relay environment variables.
      - list
      - ``[]``
+   * - :spelling:ignore:`hubble.relay.extraInitContainers`
+     - Additional init containers added to the hubble-relay Deployment.
+     - list
+     - ``[]``
    * - :spelling:ignore:`hubble.relay.extraVolumeMounts`
      - Additional hubble-relay volumeMounts.
      - list
@@ -2628,6 +2636,10 @@
      - Whether to enable the Hubble UI.
      - bool
      - ``false``
+   * - :spelling:ignore:`hubble.ui.extraInitContainers`
+     - Additional init containers added to the hubble-ui Deployment.
+     - list
+     - ``[]``
    * - :spelling:ignore:`hubble.ui.frontend.extraEnv`
      - Additional hubble-ui frontend environment variables.
      - list
@@ -3406,6 +3418,10 @@
      - ``[]``
    * - :spelling:ignore:`operator.extraHostPathMounts`
      - Additional cilium-operator hostPath mounts.
+     - list
+     - ``[]``
+   * - :spelling:ignore:`operator.extraInitContainers`
+     - Additional init containers added to the operator Deployment.
      - list
      - ``[]``
    * - :spelling:ignore:`operator.extraVolumeMounts`

--- a/Documentation/network/clustermesh/setup.rst
+++ b/Documentation/network/clustermesh/setup.rst
@@ -173,6 +173,24 @@ from one cluster to another:
   kubectl --context=$CLUSTER1 get secret -n kube-system cilium-ca -o yaml | \
     kubectl --context $CLUSTER2 create -f -
 
+.. _clustermesh_external_tls:
+
+Custom Per-Pod Certificates
+===========================
+
+You can inject custom certificates for Cluster Mesh components by
+configuring the following Helm settings:
+
+- Set ``disableDefaultVolumes=true``
+- Inject your own certificate agent via ``extraInitContainers``
+- Specify ``extraVolumes``/``extraVolumeMounts`` to share the certificate
+  mount with the init container
+
+This is useful when you want to provide certificates directly to each pod
+rather than through Kubernetes Secrets (e.g., per-pod certificates issued
+at runtime by HashiCorp Vault, the cert-manager CSI driver, or SPIFFE).
+See :ref:`hubble_enable_tls` for the general pattern.
+
 .. _enable_clustermesh:
 
 Enable Cluster Mesh

--- a/Documentation/observability/hubble/configuration/tls.rst
+++ b/Documentation/observability/hubble/configuration/tls.rst
@@ -170,6 +170,66 @@ restart Hubble server or Hubble Relay.
         - ``hubble.metrics.tls.server.existingSecret`` only needs to be provided when ``hubble.metrics.tls.enabled`` (default ``false``).
           For more details on configuring the Hubble metrics API with TLS, see :ref:`hubble_configure_metrics_tls`.
 
+    .. group-tab:: Custom Per-Pod Certificates
+
+        If you want to provide TLS certificates directly to each pod rather
+        than through Kubernetes Secrets (e.g., per-pod certificates issued at
+        runtime by HashiCorp Vault, the cert-manager CSI driver, or SPIFFE),
+        you can disable the default TLS certificate volumes by setting
+        ``disableDefaultVolumes=true`` and provide your own via
+        ``extraVolumes``/``extraVolumeMounts``, and inject a
+        certificate-fetching sidecar via ``extraInitContainers``.
+
+        **Certificate requirements:**
+
+        The external certificate agent is responsible for generating valid
+        certificates. The Common Name (CN) and Subject Alternative Name
+        (SAN) requirements are the same as for user-provided certificates:
+
+        - Hubble server: ``*.{cluster-name}.hubble-grpc.cilium.io`` where
+          ``{cluster-name}`` is the cluster name defined by ``cluster.name``
+          (defaults to ``default``)
+        - Hubble Relay: ``*.hubble-relay.cilium.io``
+        - Hubble UI: ``*.hubble-ui.cilium.io``
+
+        The certificate agent must write files matching the names expected
+        by each component:
+
+        - Hubble server: ``server.crt``, ``server.key``, ``client-ca.crt``
+        - Hubble Relay: ``client.crt``, ``client.key``,
+          ``hubble-server-ca.crt``, and if relay TLS server is enabled:
+          ``server.crt``, ``server.key``
+        - Hubble UI: ``client.crt``, ``client.key``, ``hubble-relay-ca.crt``
+
+        **Configuration:**
+
+        For each component, disable its default TLS volume, provide your own
+        via ``extraVolumes``/``extraVolumeMounts``, and configure the
+        certificate agent under ``extraInitContainers``. Hubble Relay and
+        Hubble UI are optional; only set the values for the components you
+        deploy.
+
+        ::
+
+            # Hubble server (on the cilium-agent DaemonSet)
+            --set hubble.tls.disableDefaultVolumes=true
+            # configure the certificate agent under the top-level extraInitContainers
+
+            # Hubble Relay
+            --set hubble.relay.tls.disableDefaultVolumes=true
+            # configure the certificate agent under hubble.relay.extraInitContainers
+
+            # Hubble UI
+            --set hubble.ui.tls.disableDefaultVolumes=true
+            # configure the certificate agent under hubble.ui.extraInitContainers
+
+        Each component can be configured independently.
+
+        You will need to determine the valid contents of the ``extraVolumes``,
+        ``extraVolumeMounts``, and ``extraInitContainers`` settings based on
+        your own approach to certificate management. The values of these
+        settings are out of scope for this guide.
+
 .. _hubble_enable_tls_troubleshooting:
 
 Troubleshooting
@@ -268,6 +328,45 @@ If you encounter issues after enabling TLS, you can use the following instructio
         of the certificate for Hubble server MUST be set to
         ``*.{cluster-name}.hubble-grpc.cilium.io`` where ``{cluster-name}`` is
         the cluster name defined by ``cluster.name`` (defaults to ``default``).
+
+    .. group-tab:: Custom Per-Pod Certificates
+
+        **Pod stuck in init / CrashLoopBackOff:**
+
+        The certificate agent init container must write all expected cert files
+        before the main container starts. Check its logs and the pod's events:
+
+        .. code-block:: shell-session
+
+            $ kubectl -n kube-system logs <pod> -c <cert-agent>
+            $ kubectl -n kube-system describe pod <pod>
+
+        Verify the file names match what each component expects (see the
+        "Custom Per-Pod Certificates" configuration tab for the full list).
+
+        **TLS handshake failures:**
+
+        If components start but fail to connect over TLS, check the
+        component logs for TLS errors:
+
+        .. code-block:: shell-session
+
+            $ kubectl -n kube-system logs <pod> -c <container>
+
+        Common causes:
+
+        - The certificate CN/SAN does not match the expected pattern
+          (e.g., ``*.{cluster-name}.hubble-grpc.cilium.io`` for Hubble server)
+        - The CA certificate used to sign the server cert does not match
+          the CA file provided to the client
+        - Certificates have expired
+
+        **Secrets still being generated:**
+
+        If the chart is still generating TLS Secrets, verify that
+        ``tls.auto.enabled`` is set to ``false``. The auto-generated
+        Secrets are controlled by this flag, not by
+        ``disableDefaultVolumes``.
 
 
 Validating the Installation

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -368,6 +368,8 @@ externalIPs
 externalTrafficPolicy
 externallyCreated
 extraConfig
+extraVolumeMounts
+extraVolumes
 facto
 failover
 falsy

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -287,6 +287,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.tls.auto.server.extraDnsNames | list | `[]` | Extra DNS names added to certificate when it's auto generated |
 | clustermesh.apiserver.tls.auto.server.extraIpAddresses | list | `[]` | Extra IP addresses added to certificate when it's auto generated |
 | clustermesh.apiserver.tls.auto.subject | object | `{}` | X509Subject Full X509 name specification used when clustermesh.apiserver.tls.auto.method=certmanager. https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.X509Subject |
+| clustermesh.apiserver.tls.disableDefaultVolumes | bool | `false` | Disable the default TLS certificate volumes and mounts for clustermesh-apiserver (including KVStoreMesh), cilium-agent and cilium-operator, allowing you to provide your own via extraVolumes/extraVolumeMounts. This also disables mounting the clustermesh configuration, which then needs to be provided separately (likely at a different location). |
 | clustermesh.apiserver.tolerations | list | `[]` | Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | clustermesh.apiserver.topologySpreadConstraints | list | `[]` | Pod topology spread constraints for clustermesh-apiserver |
 | clustermesh.apiserver.updateStrategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0},"type":"RollingUpdate"}` | clustermesh-apiserver update strategy |
@@ -667,11 +668,12 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.sortBufferDrainTimeout | string | `nil` | When the per-request flows sort buffer is not full, a flow is drained every time this timeout is reached (only affects requests in follow-mode) (e.g. "1s"). |
 | hubble.relay.sortBufferLenMax | int | `nil` | Max number of flows that can be buffered for sorting before being sent to the client (per request) (e.g. 100). |
 | hubble.relay.terminationGracePeriodSeconds | int | `1` | Configure termination grace period for hubble relay Deployment. |
-| hubble.relay.tls | object | `{"client":{"cert":"","existingSecret":"","key":""},"server":{"cert":"","enabled":false,"existingSecret":"","extraDnsNames":[],"extraIpAddresses":[],"key":"","mtls":false,"relayName":"ui.hubble-relay.cilium.io"}}` | TLS configuration for Hubble Relay |
+| hubble.relay.tls | object | `{"client":{"cert":"","existingSecret":"","key":""},"disableDefaultVolumes":false,"server":{"cert":"","enabled":false,"existingSecret":"","extraDnsNames":[],"extraIpAddresses":[],"key":"","mtls":false,"relayName":"ui.hubble-relay.cilium.io"}}` | TLS configuration for Hubble Relay |
 | hubble.relay.tls.client | object | `{"cert":"","existingSecret":"","key":""}` | The hubble-relay client certificate and private key. This keypair is presented to Hubble server instances for mTLS authentication and is required when hubble.tls.enabled is true. These values need to be set manually if hubble.tls.auto.enabled is false. |
 | hubble.relay.tls.client.cert | string | `""` | base64 encoded PEM values for the Hubble relay client certificate (deprecated). Use existingSecret instead. |
 | hubble.relay.tls.client.existingSecret | string | `""` | Name of the Secret containing the certificate and key for the Hubble metrics server. If specified, cert and key are ignored. |
 | hubble.relay.tls.client.key | string | `""` | base64 encoded PEM values for the Hubble relay client key (deprecated). Use existingSecret instead. |
+| hubble.relay.tls.disableDefaultVolumes | bool | `false` | Disable the default TLS certificate volumes and mounts for Hubble Relay, allowing you to provide your own via extraVolumes/extraVolumeMounts. |
 | hubble.relay.tls.server | object | `{"cert":"","enabled":false,"existingSecret":"","extraDnsNames":[],"extraIpAddresses":[],"key":"","mtls":false,"relayName":"ui.hubble-relay.cilium.io"}` | The hubble-relay server certificate and private key |
 | hubble.relay.tls.server.cert | string | `""` | base64 encoded PEM values for the Hubble relay server certificate (deprecated). Use existingSecret instead. |
 | hubble.relay.tls.server.existingSecret | string | `""` | Name of the Secret containing the certificate and key for the Hubble relay server. If specified, cert and key are ignored. |
@@ -683,7 +685,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}` | hubble-relay update strategy |
 | hubble.skipUnknownCGroupIDs | bool | `true` | Skip Hubble events with unknown cgroup ids |
 | hubble.socketPath | string | `"/var/run/cilium/hubble.sock"` | Unix domain socket path to listen to when Hubble is enabled. |
-| hubble.tls | object | `{"auto":{"certManagerIssuerRef":{},"certValidityDuration":365,"enabled":true,"method":"helm","privateKey":{},"schedule":"0 0 1 */4 *","subject":{}},"enabled":true,"server":{"cert":"","existingSecret":"","extraDnsNames":[],"extraIpAddresses":[],"key":""}}` | TLS configuration for Hubble |
+| hubble.tls | object | `{"auto":{"certManagerIssuerRef":{},"certValidityDuration":365,"enabled":true,"method":"helm","privateKey":{},"schedule":"0 0 1 */4 *","subject":{}},"disableDefaultVolumes":false,"enabled":true,"server":{"cert":"","existingSecret":"","extraDnsNames":[],"extraIpAddresses":[],"key":""}}` | TLS configuration for Hubble |
 | hubble.tls.auto | object | `{"certManagerIssuerRef":{},"certValidityDuration":365,"enabled":true,"method":"helm","privateKey":{},"schedule":"0 0 1 */4 *","subject":{}}` | Configure automatic TLS certificates generation. |
 | hubble.tls.auto.certManagerIssuerRef | object | `{}` | certmanager issuer used when hubble.tls.auto.method=certmanager. |
 | hubble.tls.auto.certValidityDuration | int | `365` | Generated certificates validity duration in days.  Defaults to 365 days (1 year) because MacOS does not accept self-signed certificates with expirations > 825 days. |
@@ -692,6 +694,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.tls.auto.privateKey | object | `{}` | Private key options. These include the key algorithm and size, the used encoding and the rotation policy used when hubble.tls.auto.method=certmanager. https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificatePrivateKey |
 | hubble.tls.auto.schedule | string | `"0 0 1 */4 *"` | Schedule for certificates regeneration (regardless of their expiration date). Only used if method is "cronJob". If nil, then no recurring job will be created. Instead, only the one-shot job is deployed to generate the certificates at installation time.  Defaults to midnight of the first day of every fourth month. For syntax, see https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#schedule-syntax |
 | hubble.tls.auto.subject | object | `{}` | X509Subject Full X509 name specification used when hubble.tls.auto.method=certmanager. https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.X509Subject |
+| hubble.tls.disableDefaultVolumes | bool | `false` | Disable the default TLS certificate volumes and mounts for the Hubble server, allowing you to provide your own via extraVolumes/extraVolumeMounts. |
 | hubble.tls.enabled | bool | `true` | Enable mutual TLS for listenAddress. Setting this value to false is highly discouraged as the Hubble API provides access to potentially sensitive network flow metadata and is exposed on the host network. |
 | hubble.tls.server | object | `{"cert":"","existingSecret":"","extraDnsNames":[],"extraIpAddresses":[],"key":""}` | The Hubble server certificate and private key |
 | hubble.tls.server.cert | string | `""` | base64 encoded PEM values for the Hubble server certificate (deprecated). Use existingSecret instead. |
@@ -740,6 +743,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.tls.client.cert | string | `""` | base64 encoded PEM values for the Hubble UI client certificate (deprecated). Use existingSecret instead. |
 | hubble.ui.tls.client.existingSecret | string | `""` | Name of the Secret containing the client certificate and key for Hubble UI If specified, cert and key are ignored. |
 | hubble.ui.tls.client.key | string | `""` | base64 encoded PEM values for the Hubble UI client key (deprecated). Use existingSecret instead. |
+| hubble.ui.tls.disableDefaultVolumes | bool | `false` | Disable the default TLS certificate volumes and mounts for Hubble UI, allowing you to provide your own via extraVolumes/extraVolumeMounts. |
 | hubble.ui.tmpVolume | object | `{}` | Configure temporary volume for hubble-ui |
 | hubble.ui.tolerations | list | `[]` | Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | hubble.ui.topologySpreadConstraints | list | `[]` | Pod topology spread constraints for hubble-ui |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -213,6 +213,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.etcdQPS | int | `50` | Rate limit for the apiserver container while syncing Kubernetes resources from the local cluster to the local etcd. |
 | clustermesh.apiserver.extraArgs | list | `[]` | Additional clustermesh-apiserver arguments. |
 | clustermesh.apiserver.extraEnv | list | `[]` | Additional clustermesh-apiserver environment variables. |
+| clustermesh.apiserver.extraInitContainers | list | `[]` | Additional init containers added to the clustermesh-apiserver Deployment. |
 | clustermesh.apiserver.extraVolumeMounts | list | `[]` | Additional clustermesh-apiserver volumeMounts. |
 | clustermesh.apiserver.extraVolumes | list | `[]` | Additional clustermesh-apiserver volumes. |
 | clustermesh.apiserver.healthPort | int | `9880` | TCP port for the clustermesh-apiserver health API. |
@@ -622,6 +623,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.annotations | object | `{}` | Annotations to be added to all top-level hubble-relay objects (resources under templates/hubble-relay) |
 | hubble.relay.enabled | bool | `false` | Enable Hubble Relay (requires hubble.enabled=true) |
 | hubble.relay.extraEnv | list | `[]` | Additional hubble-relay environment variables. |
+| hubble.relay.extraInitContainers | list | `[]` | Additional init containers added to the hubble-relay Deployment. |
 | hubble.relay.extraVolumeMounts | list | `[]` | Additional hubble-relay volumeMounts. |
 | hubble.relay.extraVolumes | list | `[]` | Additional hubble-relay volumes. |
 | hubble.relay.gops.enabled | bool | `true` | Enable gops for hubble-relay |
@@ -707,6 +709,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.backend.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}` | Hubble-ui backend security context. |
 | hubble.ui.baseUrl | string | `"/"` | Defines base url prefix for all hubble-ui http requests. It needs to be changed in case if ingress for hubble-ui is configured under some sub-path. Trailing `/` is required for custom path, ex. `/service-map/` |
 | hubble.ui.enabled | bool | `false` | Whether to enable the Hubble UI. |
+| hubble.ui.extraInitContainers | list | `[]` | Additional init containers added to the hubble-ui Deployment. |
 | hubble.ui.frontend.extraEnv | list | `[]` | Additional hubble-ui frontend environment variables. |
 | hubble.ui.frontend.extraVolumeMounts | list | `[]` | Additional hubble-ui frontend volumeMounts. |
 | hubble.ui.frontend.extraVolumes | list | `[]` | Additional hubble-ui frontend volumes. |
@@ -902,6 +905,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.extraArgs | list | `[]` | Additional cilium-operator container arguments. |
 | operator.extraEnv | list | `[]` | Additional cilium-operator environment variables. |
 | operator.extraHostPathMounts | list | `[]` | Additional cilium-operator hostPath mounts. |
+| operator.extraInitContainers | list | `[]` | Additional init containers added to the operator Deployment. |
 | operator.extraVolumeMounts | list | `[]` | Additional cilium-operator volumeMounts. |
 | operator.extraVolumes | list | `[]` | Additional cilium-operator volumes. |
 | operator.hostNetwork | bool | `true` | HostNetwork setting |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -362,9 +362,11 @@ spec:
           readOnly: true
         {{- end }}
         {{- end }}
+        {{- if not .Values.clustermesh.apiserver.tls.disableDefaultVolumes }}
         - name: clustermesh-secrets
           mountPath: /var/lib/cilium/clustermesh
           readOnly: true
+        {{- end }}
         {{- if .Values.ipMasqAgent.enabled }}
         - name: ip-masq-agent
           mountPath: /etc/config
@@ -399,7 +401,7 @@ spec:
           mountPath: /var/lib/cilium/tls/hubble-metrics
           readOnly: true
         {{- end }}
-        {{- if and .Values.hubble.enabled .Values.hubble.tls.enabled (hasKey .Values.hubble "listenAddress") }}
+        {{- if and .Values.hubble.enabled .Values.hubble.tls.enabled (hasKey .Values.hubble "listenAddress") (not .Values.hubble.tls.disableDefaultVolumes) }}
         - name: hubble-tls
           mountPath: /var/lib/cilium/tls/hubble
           readOnly: true
@@ -973,7 +975,8 @@ spec:
           optional: true
       {{- end }}
       {{- end }}
-        # To read the clustermesh configuration
+        # To read the clustermesh configuration and TLS certificates
+      {{- if not .Values.clustermesh.apiserver.tls.disableDefaultVolumes }}
       - name: clustermesh-secrets
         projected:
           # note: the leading zero means this number is in octal representation: do not remove it
@@ -1028,6 +1031,7 @@ spec:
               - key: {{ .Values.tls.caBundle.key }}
                 path: local-etcd-client-ca.crt
           {{- end }}
+      {{- end }}
       {{- if and .Values.ipMasqAgent .Values.ipMasqAgent.enabled }}
       - name: ip-masq-agent
         configMap:
@@ -1062,7 +1066,7 @@ spec:
           path: /proc/sys/kernel
           type: Directory
       {{- end }}
-      {{- if and .Values.hubble.enabled .Values.hubble.tls.enabled (hasKey .Values.hubble "listenAddress") }}
+      {{- if and .Values.hubble.enabled .Values.hubble.tls.enabled (hasKey .Values.hubble "listenAddress") (not .Values.hubble.tls.disableDefaultVolumes) }}
       - name: hubble-tls
         projected:
           # note: the leading zero means this number is in octal representation: do not remove it

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -77,6 +77,10 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.operator.extraInitContainers }}
+      initContainers:
+      {{- toYaml .Values.operator.extraInitContainers | nindent 6 }}
+      {{- end }}
       containers:
       - name: cilium-operator
         image: {{ include "cilium.operator.image" . | quote }}

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -244,9 +244,11 @@ spec:
         {{- end }}
         {{- end }}
         {{- if or .Values.clustermesh.enableEndpointSliceSynchronization .Values.clustermesh.mcsapi.enabled }}
+        {{- if not .Values.clustermesh.apiserver.tls.disableDefaultVolumes }}
         - name: clustermesh-secrets
           mountPath: /var/lib/cilium/clustermesh
           readOnly: true
+        {{- end }}
         {{- end }}
         {{- if .Values.kubeConfigPath }}
         - name: kube-config
@@ -387,7 +389,8 @@ spec:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       {{- if or .Values.clustermesh.enableEndpointSliceSynchronization .Values.clustermesh.mcsapi.enabled }}
-        # To read the clustermesh configuration
+        # To read the clustermesh configuration and TLS certificates
+      {{- if not .Values.clustermesh.apiserver.tls.disableDefaultVolumes }}
       - name: clustermesh-secrets
         projected:
           # note: the leading zero means this number is in octal representation: do not remove it
@@ -442,6 +445,7 @@ spec:
               - key: {{ .Values.tls.caBundle.key }}
                 path: local-etcd-client-ca.crt
           {{- end }}
+      {{- end }}
       {{- end }}
       {{- if and .Values.operator.prometheus.enabled .Values.operator.prometheus.tls.enabled }}
       # To read the prometheus configuration

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -116,6 +116,12 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
       {{- end }}
+      {{- if .Values.clustermesh.apiserver.extraInitContainers }}
+      {{- if ne .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal" }}
+      initContainers:
+      {{- end }}
+      {{- toYaml .Values.clustermesh.apiserver.extraInitContainers | nindent 6 }}
+      {{- end }}
       containers:
       {{- if eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal" }}
       - name: etcd

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -167,9 +167,11 @@ spec:
           protocol: TCP
         {{- end }}
         volumeMounts:
+        {{- if not .Values.clustermesh.apiserver.tls.disableDefaultVolumes }}
         - name: etcd-server-secrets
           mountPath: /var/lib/etcd-secrets
           readOnly: true
+        {{- end }}
         - name: etcd-data-dir
           mountPath: /var/run/etcd
         {{- with .Values.clustermesh.apiserver.extraVolumeMounts }}
@@ -270,9 +272,11 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         volumeMounts:
+        {{- if not .Values.clustermesh.apiserver.tls.disableDefaultVolumes }}
         - name: etcd-admin-client
           mountPath: /var/lib/cilium/etcd-secrets
           readOnly: true
+        {{- end }}
         {{- if ne .Values.clustermesh.apiserver.tls.authMode "legacy" }}
         - name: etcd-users-config
           mountPath: /var/lib/cilium/etcd-config
@@ -360,14 +364,16 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         volumeMounts:
-        {{- if (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") }}
+        {{- if and (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") (not .Values.clustermesh.apiserver.tls.disableDefaultVolumes) }}
         - name: etcd-admin-client
           mountPath: /var/lib/cilium/etcd-secrets
           readOnly: true
         {{- end }}
+        {{- if not .Values.clustermesh.apiserver.tls.disableDefaultVolumes }}
         - name: kvstoremesh-secrets
           mountPath: /var/lib/cilium/clustermesh
           readOnly: true
+        {{- end }}
         {{- if eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "external"}}
         - name: etcd-config
           mountPath: /var/lib/cilium
@@ -388,6 +394,7 @@ spec:
       {{- end }}
       volumes:
       {{- if (eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "internal") }}
+      {{- if not .Values.clustermesh.apiserver.tls.disableDefaultVolumes }}
       - name: etcd-server-secrets
         projected:
           # note: the leading zero means this number is in octal representation: do not remove it
@@ -410,6 +417,7 @@ spec:
               - key: {{ .Values.tls.caBundle.key }}
                 path: ca.crt
           {{- end }}
+      {{- end }}
       - name: etcd-admin-client
         projected:
           # note: the leading zero means this number is in octal representation: do not remove it
@@ -444,6 +452,8 @@ spec:
           medium: {{ ternary "Memory" "" (eq .Values.clustermesh.apiserver.etcd.storageMedium "Memory") | quote }}
       {{- end }}
       {{- if .Values.clustermesh.apiserver.kvstoremesh.enabled }}
+        # To read the kvstoremesh configuration and TLS certificates
+      {{- if not .Values.clustermesh.apiserver.tls.disableDefaultVolumes }}
       - name: kvstoremesh-secrets
         projected:
           # note: the leading zero means this number is in octal representation: do not remove it
@@ -475,6 +485,7 @@ spec:
               - key: {{ .Values.tls.caBundle.key }}
                 path: common-etcd-client-ca.crt
           {{- end }}
+      {{- end }}
       {{- if eq .Values.clustermesh.apiserver.kvstoremesh.kvstoreMode "external"}}
       - configMap:
           defaultMode: 0400

--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -65,6 +65,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.hubble.relay.extraInitContainers }}
+      initContainers:
+      {{- toYaml .Values.hubble.relay.extraInitContainers | nindent 6 }}
+      {{- end }}
       containers:
         - name: hubble-relay
           {{- with .Values.hubble.relay.securityContext }}

--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -138,7 +138,7 @@ spec:
           - name: config
             mountPath: /etc/hubble-relay
             readOnly: true
-          {{- if .Values.hubble.tls.enabled }}
+          {{- if and .Values.hubble.tls.enabled (not .Values.hubble.relay.tls.disableDefaultVolumes) }}
           - name: tls
             mountPath: /var/lib/hubble-relay/tls
             readOnly: true
@@ -185,7 +185,7 @@ spec:
           items:
           - key: config.yaml
             path: config.yaml
-      {{- if .Values.hubble.tls.enabled }}
+      {{- if and .Values.hubble.tls.enabled (not .Values.hubble.relay.tls.disableDefaultVolumes) }}
       - name: tls
         projected:
           # note: the leading zero means this number is in octal representation: do not remove it

--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -67,6 +67,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.hubble.ui.extraInitContainers }}
+      initContainers:
+      {{- toYaml .Values.hubble.ui.extraInitContainers | nindent 6 }}
+      {{- end }}
       containers:
       - name: frontend
         image: {{ include "cilium.image" .Values.hubble.ui.frontend.image | quote }}

--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -142,7 +142,7 @@ spec:
           {{- toYaml .  | trim | nindent 10 }}
         {{- end }}
         volumeMounts:
-        {{- if .Values.hubble.relay.tls.server.enabled }}
+        {{- if and .Values.hubble.relay.tls.server.enabled (not .Values.hubble.ui.tls.disableDefaultVolumes) }}
         - name: hubble-ui-client-certs
           mountPath: /var/lib/hubble-ui/certs
           readOnly: true
@@ -190,7 +190,7 @@ spec:
         emptyDir:
           sizeLimit: 256Mi
         {{- end }}
-      {{- if .Values.hubble.relay.tls.server.enabled }}
+      {{- if and .Values.hubble.relay.tls.server.enabled (not .Values.hubble.ui.tls.disableDefaultVolumes) }}
       - name: hubble-ui-client-certs
       {{- if .Values.hubble.ui.standalone.enabled }}
         {{- toYaml .Values.hubble.ui.standalone.tls.certsVolume | nindent 8 }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1029,6 +1029,10 @@
               "items": {},
               "type": "array"
             },
+            "extraInitContainers": {
+              "items": {},
+              "type": "array"
+            },
             "extraVolumeMounts": {
               "items": {},
               "type": "array"
@@ -3477,6 +3481,10 @@
               "items": {},
               "type": "array"
             },
+            "extraInitContainers": {
+              "items": {},
+              "type": "array"
+            },
             "extraVolumeMounts": {
               "items": {},
               "type": "array"
@@ -3983,6 +3991,10 @@
             },
             "enabled": {
               "type": "boolean"
+            },
+            "extraInitContainers": {
+              "items": {},
+              "type": "array"
             },
             "frontend": {
               "properties": {
@@ -5201,6 +5213,10 @@
           "type": "array"
         },
         "extraHostPathMounts": {
+          "items": {},
+          "type": "array"
+        },
+        "extraInitContainers": {
           "items": {},
           "type": "array"
         },

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1452,6 +1452,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "disableDefaultVolumes": {
+                  "type": "boolean"
                 }
               },
               "type": "object"
@@ -3780,6 +3783,9 @@
                   },
                   "type": "object"
                 },
+                "disableDefaultVolumes": {
+                  "type": "boolean"
+                },
                 "server": {
                   "properties": {
                     "cert": {
@@ -3880,6 +3886,9 @@
                 }
               },
               "type": "object"
+            },
+            "disableDefaultVolumes": {
+              "type": "boolean"
             },
             "enabled": {
               "type": "boolean"
@@ -4236,6 +4245,9 @@
                     }
                   },
                   "type": "object"
+                },
+                "disableDefaultVolumes": {
+                  "type": "boolean"
                 }
               },
               "type": "object"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1689,6 +1689,9 @@ hubble:
     # highly discouraged as the Hubble API provides access to potentially
     # sensitive network flow metadata and is exposed on the host network.
     enabled: true
+    # -- Disable the default TLS certificate volumes and mounts for the Hubble
+    # server, allowing you to provide your own via extraVolumes/extraVolumeMounts.
+    disableDefaultVolumes: false
     # -- Configure automatic TLS certificates generation.
     auto:
       # -- Auto-generate certificates.
@@ -1872,6 +1875,9 @@ hubble:
     listenPort: "4245"
     # -- TLS configuration for Hubble Relay
     tls:
+      # -- Disable the default TLS certificate volumes and mounts for Hubble Relay,
+      # allowing you to provide your own via extraVolumes/extraVolumeMounts.
+      disableDefaultVolumes: false
       # -- The hubble-relay client certificate and private key.
       # This keypair is presented to Hubble server instances for mTLS
       # authentication and is required when hubble.tls.enabled is true.
@@ -2029,6 +2035,9 @@ hubble:
     # -- Additional init containers added to the hubble-ui Deployment.
     extraInitContainers: []
     tls:
+      # -- Disable the default TLS certificate volumes and mounts for Hubble UI,
+      # allowing you to provide your own via extraVolumes/extraVolumeMounts.
+      disableDefaultVolumes: false
       client:
         # -- Name of the Secret containing the client certificate and key for Hubble UI
         # If specified, cert and key are ignored.
@@ -4119,6 +4128,13 @@ clustermesh:
     # -- The priority class to use for clustermesh-apiserver
     priorityClassName: ""
     tls:
+      # -- Disable the default TLS certificate volumes and mounts for
+      # clustermesh-apiserver (including KVStoreMesh), cilium-agent and
+      # cilium-operator, allowing you to provide your own via
+      # extraVolumes/extraVolumeMounts. This also disables mounting the
+      # clustermesh configuration, which then needs to be provided
+      # separately (likely at a different location).
+      disableDefaultVolumes: false
       # -- Configure the clustermesh authentication mode.
       # Supported values:
       # - legacy:     All clusters access remote clustermesh instances with the same

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1841,6 +1841,8 @@ hubble:
     extraVolumes: []
     # -- Additional hubble-relay volumeMounts.
     extraVolumeMounts: []
+    # -- Additional init containers added to the hubble-relay Deployment.
+    extraInitContainers: []
     # -- hubble-relay pod security context
     podSecurityContext:
       fsGroup: 65532
@@ -2024,6 +2026,8 @@ hubble:
         #           path: hubble-relay-ca.crt
     # -- Roll out Hubble-ui pods automatically when configmap is updated.
     rollOutPods: false
+    # -- Additional init containers added to the hubble-ui Deployment.
+    extraInitContainers: []
     tls:
       client:
         # -- Name of the Secret containing the client certificate and key for Hubble UI
@@ -3314,6 +3318,8 @@ operator:
   extraVolumes: []
   # -- Additional cilium-operator volumeMounts.
   extraVolumeMounts: []
+  # -- Additional init containers added to the operator Deployment.
+  extraInitContainers: []
   # -- Annotations to be added to all top-level cilium-operator objects (resources under templates/cilium-operator)
   annotations: {}
   # -- HostNetwork setting
@@ -4027,6 +4033,8 @@ clustermesh:
     extraVolumes: []
     # -- Additional clustermesh-apiserver volumeMounts.
     extraVolumeMounts: []
+    # -- Additional init containers added to the clustermesh-apiserver Deployment.
+    extraInitContainers: []
     # -- Security context to be added to clustermesh-apiserver containers
     securityContext:
       allowPrivilegeEscalation: false

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1706,6 +1706,9 @@ hubble:
     # highly discouraged as the Hubble API provides access to potentially
     # sensitive network flow metadata and is exposed on the host network.
     enabled: true
+    # -- Disable the default TLS certificate volumes and mounts for the Hubble
+    # server, allowing you to provide your own via extraVolumes/extraVolumeMounts.
+    disableDefaultVolumes: false
     # -- Configure automatic TLS certificates generation.
     auto:
       # -- Auto-generate certificates.
@@ -1889,6 +1892,9 @@ hubble:
     listenPort: "4245"
     # -- TLS configuration for Hubble Relay
     tls:
+      # -- Disable the default TLS certificate volumes and mounts for Hubble Relay,
+      # allowing you to provide your own via extraVolumes/extraVolumeMounts.
+      disableDefaultVolumes: false
       # -- The hubble-relay client certificate and private key.
       # This keypair is presented to Hubble server instances for mTLS
       # authentication and is required when hubble.tls.enabled is true.
@@ -2046,6 +2052,9 @@ hubble:
     # -- Additional init containers added to the hubble-ui Deployment.
     extraInitContainers: []
     tls:
+      # -- Disable the default TLS certificate volumes and mounts for Hubble UI,
+      # allowing you to provide your own via extraVolumes/extraVolumeMounts.
+      disableDefaultVolumes: false
       client:
         # -- Name of the Secret containing the client certificate and key for Hubble UI
         # If specified, cert and key are ignored.
@@ -4160,6 +4169,13 @@ clustermesh:
     # -- The priority class to use for clustermesh-apiserver
     priorityClassName: ""
     tls:
+      # -- Disable the default TLS certificate volumes and mounts for
+      # clustermesh-apiserver (including KVStoreMesh), cilium-agent and
+      # cilium-operator, allowing you to provide your own via
+      # extraVolumes/extraVolumeMounts. This also disables mounting the
+      # clustermesh configuration, which then needs to be provided
+      # separately (likely at a different location).
+      disableDefaultVolumes: false
       # -- Configure the clustermesh authentication mode.
       # Supported values:
       # - legacy:     All clusters access remote clustermesh instances with the same

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1858,6 +1858,8 @@ hubble:
     extraVolumes: []
     # -- Additional hubble-relay volumeMounts.
     extraVolumeMounts: []
+    # -- Additional init containers added to the hubble-relay Deployment.
+    extraInitContainers: []
     # -- hubble-relay pod security context
     podSecurityContext:
       fsGroup: 65532
@@ -2041,6 +2043,8 @@ hubble:
         #           path: hubble-relay-ca.crt
     # -- Roll out Hubble-ui pods automatically when configmap is updated.
     rollOutPods: false
+    # -- Additional init containers added to the hubble-ui Deployment.
+    extraInitContainers: []
     tls:
       client:
         # -- Name of the Secret containing the client certificate and key for Hubble UI
@@ -3348,6 +3352,8 @@ operator:
   extraVolumes: []
   # -- Additional cilium-operator volumeMounts.
   extraVolumeMounts: []
+  # -- Additional init containers added to the operator Deployment.
+  extraInitContainers: []
   # -- Annotations to be added to all top-level cilium-operator objects (resources under templates/cilium-operator)
   annotations: {}
   # -- HostNetwork setting
@@ -4068,6 +4074,8 @@ clustermesh:
     extraVolumes: []
     # -- Additional clustermesh-apiserver volumeMounts.
     extraVolumeMounts: []
+    # -- Additional init containers added to the clustermesh-apiserver Deployment.
+    extraInitContainers: []
     # -- Security context to be added to clustermesh-apiserver containers
     securityContext:
       allowPrivilegeEscalation: false


### PR DESCRIPTION
This PR adds support for external TLS certificate management in the Cilium Helm chart by introducing two features:

1. extraInitContainers for cilium-operator, clustermesh-apiserver, hubble-relay, and hubble-ui — enabling sidecar injection (e.g., vault-agent) without Kustomize overlays
2. disableDefaultVolumes per-component flags that remove the default projected TLS certificate volumes and mounts, allowing users to provide their own via extraVolumes/extraVolumeMounts

This enables integration with external certificate sources (Vault, cert-manager CSI, SPIFFE) purely through Helm values.

See the [CFP design document](https://docs.google.com/document/d/1rBrPLwJOtoqnV9pLePsJpN92pwQmMbc60Uf0rdEO3C8/edit?usp=sharing) for full motivation and design rationale.

Fixes: #46689

helm: Add extraInitContainers support to cilium-operator, clustermesh-apiserver, hubble-relay, and hubble-ui. Add per-volume TLS overrides that replace projected volumes and suppress native Secret generation, enabling external certificate management (Vault, cert-manager CSI, SPIFFE) without Kustomize overlays.

**Testing:**
- Default helm template renders identically to unmodified chart
- With disableDefaultVolumes=true, projected volumes and mounts are removed
- Users can provide custom volumes via extraVolumes/extraVolumeMounts
- No existing tests broken

This PR was prepared with AIL:2. AI assisted with identifying affected files and drafting template changes. All code was personally reviewed, modified, tested, and verified.

```release-note
helm: Add extraInitContainers and disableDefaultVolumes to support external certificate management for Hubble and ClusterMesh components.
```
