### PR TITLE
gateway-api: preserve duplicate HTTPRoute rule precedence

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -276,6 +276,8 @@ func Test_Conformance(t *testing.T) {
 		{name: "httproute-matching", gateway: []gwDetails{gatewaySameNamespace}},
 		{name: "httproute-matching-across-routes", gateway: []gwDetails{gatewaySameNamespace}},
 		{name: "httproute-method-matching", gateway: []gwDetails{gatewaySameNamespace}},
+		{name: "httproute-identical-rule-order", gateway: []gwDetails{gatewaySameNamespace}},
+		{name: "httproute-identical-rule-invalid-backend", gateway: []gwDetails{gatewaySameNamespace}},
 		{name: "httproute-observed-generation-bump", gateway: []gwDetails{gatewaySameNamespace}},
 		{name: "httproute-partially-invalid-via-invalid-reference-grant", gateway: []gwDetails{gatewaySameNamespace}},
 		{name: "httproute-path-match-order", gateway: []gwDetails{gatewaySameNamespace}},

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-identical-rule-invalid-backend/input/httproute-identical-rule-invalid-backend.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-identical-rule-invalid-backend/input/httproute-identical-rule-invalid-backend.yaml
@@ -1,0 +1,23 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: identical-rule-invalid-backend
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /same
+    backendRefs:
+    - name: nonexistent
+      port: 8080
+  - matches:
+    - path:
+        type: Exact
+        value: /same
+    backendRefs:
+    - name: infra-backend-v2
+      port: 8080

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-identical-rule-invalid-backend/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-identical-rule-invalid-backend/output/cec-same-namespace.yaml
@@ -1,0 +1,113 @@
+metadata:
+  creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      controller: true
+      kind: Gateway
+      name: same-namespace
+      uid: ""
+  resourceVersion: "1"
+spec:
+  backendServices:
+    - name: infra-backend-v2
+      namespace: gateway-conformance-infra
+      number:
+        - "8080"
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            transportProtocol: raw_buffer
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-insecure
+                statPrefix: listener-insecure
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-insecure
+      virtualHosts:
+        - domains:
+            - "*"
+          name: "*"
+          routes:
+            - directResponse:
+                body:
+                  inlineString: ""
+                status: 500
+              match:
+                path: /same
+            - match:
+                path: /same
+              route:
+                cluster: gateway-conformance-infra:infra-backend-v2:8080
+                maxStreamDuration:
+                  maxStreamDuration: 0s
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/infra-backend-v2:8080
+      name: gateway-conformance-infra:infra-backend-v2:8080
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 60s
+          useDownstreamProtocolConfig:
+            http2ProtocolOptions: {}
+  services:
+    - listener: ""
+      name: cilium-gateway-same-namespace
+      namespace: gateway-conformance-infra
+      ports:
+        - 80

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-identical-rule-invalid-backend/output/httproute-identical-rule-invalid-backend.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-identical-rule-invalid-backend/output/httproute-identical-rule-invalid-backend.yaml
@@ -1,0 +1,41 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  creationTimestamp: null
+  name: identical-rule-invalid-backend
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - backendRefs:
+    - name: nonexistent
+      port: 8080
+    matches:
+    - path:
+        type: Exact
+        value: /same
+  - backendRefs:
+    - name: infra-backend-v2
+      port: 8080
+    matches:
+    - path:
+        type: Exact
+        value: /same
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: "2025-07-01T14:19:43Z"
+      message: Accepted HTTPRoute
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T14:19:43Z"
+      message: services "nonexistent" not found
+      reason: BackendNotFound
+      status: "False"
+      type: ResolvedRefs
+    controllerName: io.cilium/gateway-controller
+    parentRef:
+      name: same-namespace

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-identical-rule-invalid-backend/output/same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-identical-rule-invalid-backend/output/same-namespace.yaml
@@ -1,0 +1,52 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: same-namespace
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T14:29:32Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T05:06:15Z"
+      message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 1
+      conditions:
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: http
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-identical-rule-order/input/httproute-identical-rule-order.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-identical-rule-order/input/httproute-identical-rule-order.yaml
@@ -1,0 +1,43 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: identical-rule-order
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /same
+      headers:
+      - name: x-version
+        value: one
+      - name: x-color
+        value: blue
+      queryParams:
+      - name: color
+        value: green
+      - name: animal
+        value: whale
+    backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+  - matches:
+    - path:
+        type: Exact
+        value: /same
+      headers:
+      - name: x-color
+        value: blue
+      - name: x-version
+        value: one
+      queryParams:
+      - name: animal
+        value: whale
+      - name: color
+        value: green
+    backendRefs:
+    - name: infra-backend-v2
+      port: 8080

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-identical-rule-order/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-identical-rule-order/output/cec-same-namespace.yaml
@@ -1,0 +1,159 @@
+metadata:
+  creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      controller: true
+      kind: Gateway
+      name: same-namespace
+      uid: ""
+  resourceVersion: "1"
+spec:
+  backendServices:
+    - name: infra-backend-v1
+      namespace: gateway-conformance-infra
+      number:
+        - "8080"
+    - name: infra-backend-v2
+      namespace: gateway-conformance-infra
+      number:
+        - "8080"
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            transportProtocol: raw_buffer
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-insecure
+                statPrefix: listener-insecure
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-insecure
+      virtualHosts:
+        - domains:
+            - "*"
+          name: "*"
+          routes:
+            - match:
+                headers:
+                  - name: x-color
+                    stringMatch:
+                      exact: blue
+                  - name: x-version
+                    stringMatch:
+                      exact: one
+                path: /same
+                queryParameters:
+                  - name: animal
+                    stringMatch:
+                      exact: whale
+                  - name: color
+                    stringMatch:
+                      exact: green
+              route:
+                cluster: gateway-conformance-infra:infra-backend-v1:8080
+                maxStreamDuration:
+                  maxStreamDuration: 0s
+            - match:
+                headers:
+                  - name: x-color
+                    stringMatch:
+                      exact: blue
+                  - name: x-version
+                    stringMatch:
+                      exact: one
+                path: /same
+                queryParameters:
+                  - name: animal
+                    stringMatch:
+                      exact: whale
+                  - name: color
+                    stringMatch:
+                      exact: green
+              route:
+                cluster: gateway-conformance-infra:infra-backend-v2:8080
+                maxStreamDuration:
+                  maxStreamDuration: 0s
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/infra-backend-v1:8080
+      name: gateway-conformance-infra:infra-backend-v1:8080
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 60s
+          useDownstreamProtocolConfig:
+            http2ProtocolOptions: {}
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/infra-backend-v2:8080
+      name: gateway-conformance-infra:infra-backend-v2:8080
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 60s
+          useDownstreamProtocolConfig:
+            http2ProtocolOptions: {}
+  services:
+    - listener: ""
+      name: cilium-gateway-same-namespace
+      namespace: gateway-conformance-infra
+      ports:
+        - 80

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-identical-rule-order/output/httproute-identical-rule-order.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-identical-rule-order/output/httproute-identical-rule-order.yaml
@@ -1,0 +1,61 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  creationTimestamp: null
+  name: identical-rule-order
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  parentRefs:
+  - name: same-namespace
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+    matches:
+    - headers:
+      - name: x-version
+        value: one
+      - name: x-color
+        value: blue
+      path:
+        type: Exact
+        value: /same
+      queryParams:
+      - name: color
+        value: green
+      - name: animal
+        value: whale
+  - backendRefs:
+    - name: infra-backend-v2
+      port: 8080
+    matches:
+    - headers:
+      - name: x-color
+        value: blue
+      - name: x-version
+        value: one
+      path:
+        type: Exact
+        value: /same
+      queryParams:
+      - name: animal
+        value: whale
+      - name: color
+        value: green
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: "2025-07-01T14:19:43Z"
+      message: Accepted HTTPRoute
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T14:19:43Z"
+      message: Service reference is valid
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: io.cilium/gateway-controller
+    parentRef:
+      name: same-namespace

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-identical-rule-order/output/same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-identical-rule-order/output/same-namespace.yaml
@@ -1,0 +1,52 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: same-namespace
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T14:29:32Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T05:06:15Z"
+      message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 1
+      conditions:
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: http
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -426,7 +426,7 @@ func extractRoutes(logger *slog.Logger,
 	btlspMap helpers.BackendTLSPolicyServiceMap,
 ) []model.HTTPRoute {
 	var httpRoutes []model.HTTPRoute
-	for _, rule := range hr.Spec.Rules {
+	for ruleIndex, rule := range hr.Spec.Rules {
 		var backendHTTPFilters []*model.BackendHTTPFilter
 		bes := make([]model.Backend, 0, len(rule.BackendRefs))
 		for _, be := range rule.BackendRefs {
@@ -559,6 +559,7 @@ func extractRoutes(logger *slog.Logger,
 
 		if len(rule.Matches) == 0 {
 			httpRoutes = append(httpRoutes, model.HTTPRoute{
+				SourceRule:             sourceHTTPRouteRule(hr, ruleIndex, 0),
 				Hostnames:              hostnames,
 				Backends:               bes,
 				BackendHTTPFilters:     backendHTTPFilters,
@@ -575,8 +576,9 @@ func extractRoutes(logger *slog.Logger,
 			})
 		}
 
-		for _, match := range rule.Matches {
+		for matchIndex, match := range rule.Matches {
 			httpRoutes = append(httpRoutes, model.HTTPRoute{
+				SourceRule:             sourceHTTPRouteRule(hr, ruleIndex, matchIndex),
 				Hostnames:              hostnames,
 				PathMatch:              toPathMatch(match),
 				HeadersMatch:           toHeaderMatch(match),
@@ -597,7 +599,52 @@ func extractRoutes(logger *slog.Logger,
 			})
 		}
 	}
+	retainDuplicateRuleSources(httpRoutes)
 	return httpRoutes
+}
+
+func sourceHTTPRouteRule(hr gatewayv1.HTTPRoute, ruleIndex, matchIndex int) *model.HTTPRouteRule {
+	return &model.HTTPRouteRule{
+		Source: model.FullyQualifiedResource{
+			Name:      hr.GetName(),
+			Namespace: hr.GetNamespace(),
+			Group:     gatewayv1.GroupVersion.Group,
+			Kind:      "HTTPRoute",
+			Version:   gatewayv1.GroupVersion.Version,
+			UID:       string(hr.GetUID()),
+		},
+		RuleIndex:  ruleIndex,
+		MatchIndex: matchIndex,
+	}
+}
+
+// retainDuplicateRuleSources keeps rule identity only when one HTTPRoute has
+// identical request matches in multiple rules. Other routes keep the existing
+// match-key backend aggregation behavior.
+func retainDuplicateRuleSources(routes []model.HTTPRoute) {
+	ruleIndexesByMatch := map[string]map[int]struct{}{}
+	// First, record which rule indexes produced each request match.
+	for i := range routes {
+		if routes[i].SourceRule == nil {
+			continue
+		}
+		key := routes[i].GetMatchKey()
+		if _, ok := ruleIndexesByMatch[key]; !ok {
+			ruleIndexesByMatch[key] = map[int]struct{}{}
+		}
+		ruleIndexesByMatch[key][routes[i].SourceRule.RuleIndex] = struct{}{}
+	}
+
+	// Then, clear rule identity unless the same match came from multiple rules.
+	for i := range routes {
+		if routes[i].SourceRule == nil {
+			continue
+		}
+		key := routes[i].GetMatchKey()
+		if len(ruleIndexesByMatch[key]) < 2 {
+			routes[i].SourceRule = nil
+		}
+	}
 }
 
 func addBackendTLSDetails(log *slog.Logger, be model.Backend, svc *corev1.Service, btlspMap helpers.BackendTLSPolicyServiceMap) (model.Backend, bool) {

--- a/operator/pkg/model/ingestion/gateway_test.go
+++ b/operator/pkg/model/ingestion/gateway_test.go
@@ -77,6 +77,45 @@ func TestHTTPGatewayAPI(t *testing.T) {
 	}
 }
 
+func TestExtractRoutesSetsHTTPRouteRuleSource(t *testing.T) {
+	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+	pathType := gatewayv1.PathMatchExact
+	path := "/same-path"
+	hr := gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "route",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.HTTPRouteSpec{
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{
+						{Path: &gatewayv1.HTTPPathMatch{Type: &pathType, Value: &path}},
+					},
+				},
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{
+						{Path: &gatewayv1.HTTPPathMatch{Type: &pathType, Value: &path}},
+					},
+				},
+			},
+		},
+	}
+
+	routes := extractRoutes(logger, 80, nil, hr, nil, nil, nil, nil)
+
+	require.Len(t, routes, 2)
+	require.NotNil(t, routes[0].SourceRule)
+	require.NotNil(t, routes[1].SourceRule)
+	assert.Equal(t, "route", routes[0].SourceRule.Source.Name)
+	assert.Equal(t, "default", routes[0].SourceRule.Source.Namespace)
+	assert.Equal(t, "HTTPRoute", routes[0].SourceRule.Source.Kind)
+	assert.Equal(t, 0, routes[0].SourceRule.RuleIndex)
+	assert.Equal(t, 0, routes[0].SourceRule.MatchIndex)
+	assert.Equal(t, 1, routes[1].SourceRule.RuleIndex)
+	assert.Equal(t, 0, routes[1].SourceRule.MatchIndex)
+}
+
 func TestHTTPGatewayAPIFiltersSelectorNamespacesPerListener(t *testing.T) {
 	selector := gatewayv1.NamespacesFromSelector
 	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -544,7 +544,7 @@ type Infrastructure struct {
 	Annotations map[string]string
 }
 
-// GetMatchKey returns the key to be used for matching the backend.
+// GetMatchKey returns the key for this route's request match criteria.
 func (r *HTTPRoute) GetMatchKey() string {
 	sb := strings.Builder{}
 
@@ -558,19 +558,21 @@ func (r *HTTPRoute) GetMatchKey() string {
 	sb.WriteString(r.PathMatch.String())
 	sb.WriteString("|")
 
-	sort.Slice(r.HeadersMatch, func(i, j int) bool {
-		return r.HeadersMatch[i].String() < r.HeadersMatch[j].String()
+	headers := append([]KeyValueMatch(nil), r.HeadersMatch...)
+	sort.Slice(headers, func(i, j int) bool {
+		return headers[i].String() < headers[j].String()
 	})
-	for _, hm := range r.HeadersMatch {
+	for _, hm := range headers {
 		sb.WriteString("header:")
 		sb.WriteString(hm.String())
 		sb.WriteString("|")
 	}
 
-	sort.Slice(r.QueryParamsMatch, func(i, j int) bool {
-		return r.QueryParamsMatch[i].String() < r.QueryParamsMatch[j].String()
+	queryParams := append([]KeyValueMatch(nil), r.QueryParamsMatch...)
+	sort.Slice(queryParams, func(i, j int) bool {
+		return queryParams[i].String() < queryParams[j].String()
 	})
-	for _, qm := range r.QueryParamsMatch {
+	for _, qm := range queryParams {
 		sb.WriteString("query:")
 		sb.WriteString(qm.String())
 		sb.WriteString("|")

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -335,6 +335,27 @@ type FullyQualifiedResource struct {
 	UID       string `json:"uid,omitempty"`
 }
 
+// HTTPRouteRule identifies the Gateway API HTTPRoute rule and match that
+// produced a model HTTPRoute.
+type HTTPRouteRule struct {
+	Source     FullyQualifiedResource
+	RuleIndex  int
+	MatchIndex int
+}
+
+func (r HTTPRouteRule) key() string {
+	return "httproute-rule:" + strings.Join([]string{
+		r.Source.Group,
+		r.Source.Version,
+		r.Source.Kind,
+		r.Source.Namespace,
+		r.Source.Name,
+		r.Source.UID,
+		strconv.Itoa(r.RuleIndex),
+		strconv.Itoa(r.MatchIndex),
+	}, "/")
+}
+
 // TLSSecret holds a reference to a secret containing a TLS keypair.
 type TLSSecret struct {
 	Name      string `json:"name,omitempty"`
@@ -471,6 +492,9 @@ type HTTPCORSFilter struct {
 // HTTPRoute holds all the details needed to route HTTP traffic to a backend.
 type HTTPRoute struct {
 	Name string `json:"name,omitempty"`
+	// SourceRule identifies the Gateway API HTTPRoute rule and match that
+	// produced this route when rule identity must be preserved internally.
+	SourceRule *HTTPRouteRule `json:"-"`
 	// Hostnames that the route should match
 	Hostnames []string `json:"hostnames,omitempty"`
 	// PathMatch specifies that the HTTPRoute should match a path.
@@ -599,6 +623,17 @@ func (r *HTTPRoute) GetMatchKey() string {
 	}
 
 	return sb.String()
+}
+
+// GetBackendAggregationKey returns the key used to group backend actions into a
+// single Envoy route. Gateway API routes use rule identity so identical matches
+// from different rules remain separate and retain rule precedence. Legacy
+// callers without rule identity keep the existing match-key aggregation.
+func (r *HTTPRoute) GetBackendAggregationKey() string {
+	if r.SourceRule == nil {
+		return r.GetMatchKey()
+	}
+	return r.SourceRule.key()
 }
 
 // TLSPassthroughRoute holds all the details needed to route TLS traffic to a backend.

--- a/operator/pkg/model/translation/envoy_virtual_host.go
+++ b/operator/pkg/model/translation/envoy_virtual_host.go
@@ -647,8 +647,8 @@ func envoyHTTPRouteNoBackend(route model.HTTPRoute, hostnames []string, hostName
 }
 
 func getRouteMatch(hostnames []string, hostNameSuffixMatch bool, pathMatch model.StringMatch, headers []model.KeyValueMatch, query []model.KeyValueMatch, method *string) *envoy_config_route_v3.RouteMatch {
-	headerMatchers := getHeaderMatchers(hostnames, hostNameSuffixMatch, headers, method)
-	queryMatchers := getQueryMatchers(query)
+	headerMatchers := getHeaderMatchers(hostnames, hostNameSuffixMatch, sortedKeyValueMatches(headers), method)
+	queryMatchers := getQueryMatchers(sortedKeyValueMatches(query))
 
 	switch {
 	case pathMatch.Exact != "":
@@ -694,6 +694,14 @@ func getRouteMatch(hostnames []string, hostNameSuffixMatch bool, pathMatch model
 			QueryParameters: queryMatchers,
 		}
 	}
+}
+
+func sortedKeyValueMatches(matches []model.KeyValueMatch) []model.KeyValueMatch {
+	sorted := append([]model.KeyValueMatch(nil), matches...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].String() < sorted[j].String()
+	})
+	return sorted
 }
 
 func getQueryMatchers(query []model.KeyValueMatch) []*envoy_config_route_v3.QueryParameterMatcher {

--- a/operator/pkg/model/translation/envoy_virtual_host.go
+++ b/operator/pkg/model/translation/envoy_virtual_host.go
@@ -256,12 +256,14 @@ func getTypedPerFilterConfig(routeAuth *model.HTTPExternalAuthFilter, allAuthFil
 func envoyHTTPSRoutes(httpRoutes []model.HTTPRoute, hostnames []string, hostNameSuffixMatch bool, allAuthFilters []*model.HTTPExternalAuthFilter) []*envoy_config_route_v3.Route {
 	matchBackendMap := make(map[string][]model.HTTPRoute)
 	for _, r := range httpRoutes {
-		matchBackendMap[r.GetMatchKey()] = append(matchBackendMap[r.GetMatchKey()], r)
+		key := r.GetBackendAggregationKey()
+		matchBackendMap[key] = append(matchBackendMap[key], r)
 	}
 
 	routes := make([]*envoy_config_route_v3.Route, 0, len(matchBackendMap))
 	for _, r := range httpRoutes {
-		hRoutes, exists := matchBackendMap[r.GetMatchKey()]
+		key := r.GetBackendAggregationKey()
+		hRoutes, exists := matchBackendMap[key]
 		// if not exists, it means this route is already added to the routes
 		if !exists {
 			continue
@@ -284,7 +286,7 @@ func envoyHTTPSRoutes(httpRoutes []model.HTTPRoute, hostnames []string, hostName
 			TypedPerFilterConfig: getTypedPerFilterConfig(nil, allAuthFilters, r),
 		}
 		routes = append(routes, &route)
-		delete(matchBackendMap, r.GetMatchKey())
+		delete(matchBackendMap, key)
 	}
 	return routes
 }
@@ -292,12 +294,14 @@ func envoyHTTPSRoutes(httpRoutes []model.HTTPRoute, hostnames []string, hostName
 func envoyHTTPRoutes(httpRoutes []model.HTTPRoute, hostnames []string, hostNameSuffixMatch bool, listenerPort uint32, allAuthFilters []*model.HTTPExternalAuthFilter) []*envoy_config_route_v3.Route {
 	matchBackendMap := make(map[string][]model.HTTPRoute)
 	for _, r := range httpRoutes {
-		matchBackendMap[r.GetMatchKey()] = append(matchBackendMap[r.GetMatchKey()], r)
+		key := r.GetBackendAggregationKey()
+		matchBackendMap[key] = append(matchBackendMap[key], r)
 	}
 
 	routes := make([]*envoy_config_route_v3.Route, 0, len(matchBackendMap))
 	for _, r := range httpRoutes {
-		hRoutes, exists := matchBackendMap[r.GetMatchKey()]
+		key := r.GetBackendAggregationKey()
+		hRoutes, exists := matchBackendMap[key]
 		if !exists {
 			continue
 		}
@@ -309,6 +313,7 @@ func envoyHTTPRoutes(httpRoutes []model.HTTPRoute, hostnames []string, hostNameS
 		if len(backends) == 0 && hRoutes[0].RequestRedirect == nil {
 			noBackendRoute := envoyHTTPRouteNoBackend(hRoutes[0], hostnames, hostNameSuffixMatch, allAuthFilters)
 			routes = append(routes, noBackendRoute)
+			delete(matchBackendMap, key)
 			continue
 		}
 
@@ -344,7 +349,7 @@ func envoyHTTPRoutes(httpRoutes []model.HTTPRoute, hostnames []string, hostNameS
 			}
 		}
 		routes = append(routes, &route)
-		delete(matchBackendMap, r.GetMatchKey())
+		delete(matchBackendMap, key)
 	}
 	return routes
 }

--- a/operator/pkg/model/translation/envoy_virtual_host_test.go
+++ b/operator/pkg/model/translation/envoy_virtual_host_test.go
@@ -700,6 +700,26 @@ func Test_retryMutation(t *testing.T) {
 }
 
 func Test_envoyHTTPRoutes(t *testing.T) {
+	backend := func(name string, port uint32) model.Backend {
+		return model.Backend{
+			Name:      name,
+			Namespace: "default",
+			Port:      &model.BackendPort{Port: port},
+		}
+	}
+	sourceRule := func(ruleIndex int) *model.HTTPRouteRule {
+		return &model.HTTPRouteRule{
+			Source: model.FullyQualifiedResource{
+				Name:      "route",
+				Namespace: "default",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "HTTPRoute",
+			},
+			RuleIndex: ruleIndex,
+		}
+	}
+
 	t.Run("redirect with x-forwarded-proto and backend", func(t *testing.T) {
 		httpRoutes := []model.HTTPRoute{
 			{
@@ -781,6 +801,80 @@ func Test_envoyHTTPRoutes(t *testing.T) {
 		require.NotNil(t, res[0].GetDirectResponse())
 		require.Equal(t, uint32(500), res[0].GetDirectResponse().GetStatus())
 		require.Equal(t, corsPolicy, res[0].GetTypedPerFilterConfig()["envoy.filters.http.cors"])
+	})
+	t.Run("legacy same-match routes aggregate backends", func(t *testing.T) {
+		httpRoutes := []model.HTTPRoute{
+			{
+				PathMatch: model.StringMatch{Exact: "/same-path"},
+				Backends: []model.Backend{
+					backend("backend-v1", 8080),
+				},
+			},
+			{
+				PathMatch: model.StringMatch{Exact: "/same-path"},
+				Backends: []model.Backend{
+					backend("backend-v2", 8080),
+				},
+			},
+		}
+
+		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, true, 80, nil)
+
+		require.Len(t, res, 1)
+		weightedClusters := res[0].GetRoute().GetWeightedClusters()
+		require.NotNil(t, weightedClusters)
+		require.Len(t, weightedClusters.GetClusters(), 2)
+		require.Equal(t, "default:backend-v1:8080", weightedClusters.GetClusters()[0].GetName())
+		require.Equal(t, "default:backend-v2:8080", weightedClusters.GetClusters()[1].GetName())
+	})
+	t.Run("gateway same-match rules remain separate", func(t *testing.T) {
+		httpRoutes := []model.HTTPRoute{
+			{
+				SourceRule: sourceRule(0),
+				PathMatch:  model.StringMatch{Exact: "/same-path"},
+				Backends: []model.Backend{
+					backend("backend-v1", 8080),
+				},
+			},
+			{
+				SourceRule: sourceRule(1),
+				PathMatch:  model.StringMatch{Exact: "/same-path"},
+				Backends: []model.Backend{
+					backend("backend-v2", 8080),
+				},
+			},
+		}
+
+		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, true, 80, nil)
+
+		require.Len(t, res, 2)
+		require.Equal(t, "default:backend-v1:8080", res[0].GetRoute().GetCluster())
+		require.Equal(t, "default:backend-v2:8080", res[1].GetRoute().GetCluster())
+	})
+	t.Run("gateway first same-match rule with missing backend returns direct response", func(t *testing.T) {
+		httpRoutes := []model.HTTPRoute{
+			{
+				SourceRule: sourceRule(0),
+				PathMatch:  model.StringMatch{Exact: "/same-path"},
+				DirectResponse: &model.DirectResponse{
+					StatusCode: 500,
+				},
+			},
+			{
+				SourceRule: sourceRule(1),
+				PathMatch:  model.StringMatch{Exact: "/same-path"},
+				Backends: []model.Backend{
+					backend("backend-v2", 8080),
+				},
+			},
+		}
+
+		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, true, 80, nil)
+
+		require.Len(t, res, 2)
+		require.NotNil(t, res[0].GetDirectResponse())
+		require.Equal(t, uint32(500), res[0].GetDirectResponse().GetStatus())
+		require.Equal(t, "default:backend-v2:8080", res[1].GetRoute().GetCluster())
 	})
 }
 


### PR DESCRIPTION
Previously, HTTPRoute rules with identical match criteria were merged into one weighted route during translation.

This change adds source rule identity during ingestion when multiple rules produce an indentical match in the same HTTPRoute. When present, this identity is used as the key for backend aggregation and duplicate rules are emitted as separate Envoy routes with ordering preserved, so that Gateway API rule ordering is honored.

Fixes: #42964