### PR TITLE
gateway-api: improve route/gateway listener protocol mismatch message

### DIFF
--- a/operator/pkg/gateway-api/routechecks/gateway_checks.go
+++ b/operator/pkg/gateway-api/routechecks/gateway_checks.go
@@ -238,7 +238,7 @@ func CheckGatewayMatchingProtocol(input Input, parentRef gatewayv1.ParentReferen
 	owner, err := input.GetListenerOwner(parentRef)
 	if err != nil {
 		input.SetParentCondition(parentRef, metav1.Condition{
-			Type:    "Accepted",
+			Type:    string(gatewayv1.RouteConditionAccepted),
 			Status:  metav1.ConditionFalse,
 			Reason:  "Invalid" + input.GetGVK().Kind,
 			Message: err.Error(),
@@ -247,24 +247,19 @@ func CheckGatewayMatchingProtocol(input Input, parentRef gatewayv1.ParentReferen
 		return false, nil
 	}
 
-	supportedProtocols := input.GetValidProtocols()
-
-	found := false
+	routeProtocols := input.GetValidProtocols()
 	for _, listener := range owner.GetListeners() {
-		if slices.Contains(supportedProtocols, listener.Protocol) {
-			found = true
+		if slices.Contains(routeProtocols, listener.Protocol) {
+			return true, nil
 		}
 	}
-	if !found {
-		input.SetParentCondition(parentRef, metav1.Condition{
-			Type:    string(gatewayv1.RouteConditionAccepted),
-			Status:  metav1.ConditionFalse,
-			Reason:  "NotAllowedByListeners",
-			Message: fmt.Sprintf("No Listener with matching Protocol. Allowed protocols: %s", supportedProtocols),
-		})
 
-		return false, nil
-	}
+	input.SetParentCondition(parentRef, metav1.Condition{
+		Type:    string(gatewayv1.RouteConditionAccepted),
+		Status:  metav1.ConditionFalse,
+		Reason:  string(gatewayv1.RouteReasonNotAllowedByListeners),
+		Message: fmt.Sprintf("No matching listener protocol; route requires one of: %v", routeProtocols),
+	})
 
-	return true, nil
+	return false, nil
 }

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-disallowed-kind/output/httproute-disallowed-kind.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-disallowed-kind/output/httproute-disallowed-kind.yaml
@@ -17,7 +17,7 @@ status:
   parents:
     - conditions:
         - lastTransitionTime: "2025-07-01T14:19:43Z"
-          message: "No Listener with matching Protocol. Allowed protocols: [HTTP HTTPS]"
+          message: "No matching listener protocol; route requires one of: [HTTP HTTPS]"
           reason: NotAllowedByListeners
           status: "False"
           type: Accepted

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/tlsroute-tlsroute-not-allowed-protocol-http.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/tlsroute-tlsroute-not-allowed-protocol-http.yaml
@@ -16,7 +16,7 @@ status:
   parents:
     - conditions:
         - lastTransitionTime: "2025-08-15T00:36:04Z"
-          message: "No Listener with matching Protocol. Allowed protocols: [TLS]"
+          message: "No matching listener protocol; route requires one of: [TLS]"
           reason: NotAllowedByListeners
           status: "False"
           type: Accepted

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/tlsroute-tlsroute-not-allowed-protocol-https.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-invalid-no-matching-listener/output/tlsroute-tlsroute-not-allowed-protocol-https.yaml
@@ -16,7 +16,7 @@ status:
   parents:
     - conditions:
         - lastTransitionTime: "2025-08-15T00:36:04Z"
-          message: "No Listener with matching Protocol. Allowed protocols: [TLS]"
+          message: "No matching listener protocol; route requires one of: [TLS]"
           reason: NotAllowedByListeners
           status: "False"
           type: Accepted


### PR DESCRIPTION
Improve the status message when a Route protocol does not match any Gateway Listener protocol.

The previous wording described the Route-supported protocols as "allowed", which could be misleading.

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
