### PR TITLE
.github/workflows: run AKS IPsec conformance on AzureLinux nodes

### DIFF
--- a/.github/actions/setup-aks-cluster/action.yml
+++ b/.github/actions/setup-aks-cluster/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: ''
     required: false
     default: ''
+  os_sku:
+    description: 'Node pool OS SKU to pass to "az aks create --os-sku" (e.g. AzureLinux). Empty uses the AKS default (Ubuntu).'
+    required: false
+    default: ''
 runs:
   using: composite
   steps:
@@ -39,6 +43,7 @@ runs:
       run: |
         TAGS=""
         VERSION=""
+        OS_SKU=""
 
         if [[ -n "${{ inputs.tags }}" ]]; then
           TAGS="--tags ${{ inputs.tags }}"
@@ -46,6 +51,10 @@ runs:
 
         if [[ -n "${{ inputs.version }}" ]]; then
           VERSION="--kubernetes-version ${{ inputs.version }}"
+        fi
+
+        if [[ -n "${{ inputs.os_sku }}" ]]; then
+          OS_SKU="--os-sku ${{ inputs.os_sku }}"
         fi
 
         # Create group
@@ -60,6 +69,7 @@ runs:
           --name ${{ inputs.cluster_name }} \
           --location ${{ inputs.location }} \
           $VERSION \
+          $OS_SKU \
           --network-plugin none \
           --node-count "$(( ${{ inputs.node_count }} + 2 ))" \
           --ip-families ipv4,ipv6 \

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -339,6 +339,12 @@ jobs:
           version: ${{ matrix.version }}
           tags: "usage=${{ github.repository_owner }}-${{ github.event.repository.name }} owner=${{ steps.vars.outputs.owner }}"
           taints: ${{ env.cost_reduction }}
+          # IPsec requires the esp4/esp6 kernel modules, which AKS blacklists on
+          # Ubuntu/AzureLinux-2.0 nodes as an LPE mitigation (Azure/AKS#5753).
+          # The blacklist is descoped only on AzureLinux 3.0 (kernel
+          # 6.6.139.1-1.azl3+, Azure/AgentBaker#8546), so run the IPsec job on
+          # AzureLinux where ESP works and cilium-agent can start.
+          os_sku: ${{ steps.vars.outputs.ipsec == 'true' && 'AzureLinux' || '' }}
 
       - name: Generate cilium-cli kubeconfig
         id: gen-kubeconfig


### PR DESCRIPTION
AKS blacklists the esp4/esp6 kernel modules on Ubuntu and AzureLinux 2.0 node images as a mitigation for kernel LPE CVEs ([Azure/AKS#5753](https://github.com/Azure/AKS/issues/5753)). Cilium's IPsec datapath needs ESP, so cilium-agent aborts at daemon config init with "IPSec with tunneling requires support for xfrm state output masks (Linux 4.19 or later): protocol not supported" (EPROTONOSUPPORT from the ESP xfrm probe). The "Conformance AKS with KPR + IPsec" job then fails 100% of runs while waiting for cilium status to be ready.

The blacklist is descoped only on AzureLinux 3.0, where the upstream kernel fix shipped in 6.6.139.1-1.azl3 ([Azure/AgentBaker#8546](https://github.com/Azure/AgentBaker/pull/8546)). Add an os_sku input to the setup-aks-cluster action and select AzureLinux for IPsec jobs so ESP loads and the agent starts. The selection is driven by the ipsec flag, so it also covers the dedicated ci-ipsec AKS job; non-IPsec jobs keep the AKS default (Ubuntu).

This PR was prepared with AIL:3.
Fixes: #46023

```release-note
.github/workflows: run AKS IPsec conformance on AzureLinux nodes
```