### PR TITLE
ci: increase `cilium status` wait timeout

### DIFF
--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -327,7 +327,7 @@ jobs:
 
           cilium install ${{ steps.cilium-config.outputs.config }} ${{ steps.kvstore.outputs.config }} --set extraConfig.boot-id-file=/var/run/cilium/boot_id
 
-          cilium status --wait --interactive=false
+          cilium status --wait --interactive=false --wait-duration=10m
           kubectl get pods --all-namespaces -o wide
           kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium-dbg status
 

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -540,7 +540,7 @@ jobs:
             cilium install ${{ steps.cilium-newest-config.outputs.config }} ${{ steps.kvstore.outputs.config }} --set extraConfig.boot-id-file=/var/run/cilium/boot_id
           fi
 
-          cilium status --wait --interactive=false
+          cilium status --wait --interactive=false --wait-duration=10m
           kubectl get pods --all-namespaces -o wide
           kubectl -n kube-system exec daemonset/cilium -c cilium-agent -- cilium-dbg status
 


### PR DESCRIPTION
We observed multiple times this failure in CI. However, looking at sysdumps, it seems that the agent correctly booted on some worker node, while it was still pulling the image in others when the default 5m timeout expired.

This commit increases the timeout to 10m, which should be enough to avoid this issue in the future. I don't expect problems with the overall workflow timeout.

Fixes: #46259.