### PR TITLE
cilium, bigtcp: Fix the UDP tunnel check

### DIFF
--- a/pkg/datapath/linux/bigtcp/bigtcp.go
+++ b/pkg/datapath/linux/bigtcp/bigtcp.go
@@ -256,7 +256,7 @@ type params struct {
 	Devices      statedb.Table[*tables.Device]
 }
 
-func validateConfig(cfg UserConfig, daemonCfg *option.DaemonConfig, ipsecCfg ipsec.Config, dsrDispatch string, bigtcpTunnel bool) error {
+func validateConfig(cfg UserConfig, daemonCfg *option.DaemonConfig, ipsecCfg ipsec.Config, tunnelConfig tunnel.Config, dsrDispatch string, bigtcpTunnel bool) error {
 	if cfg.EnableIPv6BIGTCP || cfg.EnableIPv4BIGTCP {
 		// Check all configurations where Cilium creates tunnel devices
 		// that don't support BIG TCP.
@@ -264,7 +264,7 @@ func validateConfig(cfg UserConfig, daemonCfg *option.DaemonConfig, ipsecCfg ips
 			return errors.New("bpf-lb-dsr-dispatch ipip creates IPIP tunnels that aren't compatible with BIG TCP")
 		}
 		if !bigtcpTunnel {
-			if daemonCfg.TunnelingEnabled() {
+			if tunnelConfig.EncapProtocol() != tunnel.Disabled {
 				return errors.New("BIG TCP in tunneling mode requires pending kernel support")
 			}
 			if dsrDispatch != loadbalancer.DSRDispatchOption {
@@ -288,7 +288,7 @@ func newBIGTCP(lc cell.Lifecycle, p params) (Config, error) {
 		logfields.State, bigtcpTunnel,
 	)
 
-	if err := validateConfig(p.UserConfig, p.DaemonConfig, p.IPsecConfig, p.LBConfig.DSRDispatch, bigtcpTunnel); err != nil {
+	if err := validateConfig(p.UserConfig, p.DaemonConfig, p.IPsecConfig, p.TunnelConfig, p.LBConfig.DSRDispatch, bigtcpTunnel); err != nil {
 		return nil, err
 	}
 	cfg := newDefaultConfiguration(p.UserConfig)


### PR DESCRIPTION
It's not enough to check daemonCfg.TunnelingEnabled() to detect all cases when VXLAN or GENEVE tunnels are created. Many other features request tunnel creation with tunnel.NewEnabler(true).

Replace the check with the correct one:

tunnelConfig.EncapProtocol() != tunnel.Disabled

Fixes: f8762a6bd9f1 ("cilium, bigtcp: BIG TCP for tunnels")
Fixes: #46337

```release-note
Fix the UDP tunnel check in the BIG TCP probe.
```