### PR TITLE
metrics: add metrics-core-only mode

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -421,6 +421,69 @@ For large clusters, consider disabling high-cardinality metrics like
          cilium-agent --prometheus-serve-addr=:9962 \
              --metrics="-cilium_node_health_connectivity_status -cilium_node_health_connectivity_latency_seconds"
 
+Core-Only Metrics Mode
+~~~~~~~~~~~~~~~~~~~~~~~
+
+For environments requiring minimal metric exposure, Cilium supports a
+``--metrics-core-only`` option that disables all configurable AutoMetrics
+while keeping core runtime, health, process, endpoint and BPF metrics enabled.
+This significantly reduces exported metrics by disabling all configurable
+AutoMetrics while preserving metrics registered outside the AutoMetrics framework.
+
+Core metrics are metrics registered outside the AutoMetrics framework and include
+runtime, health, process, endpoint and BPF collectors. These metrics provide
+essential operational visibility into Cilium's runtime state and resource usage.
+
+To enable core-only mode via CLI:
+
+.. code-block:: shell-session
+
+    cilium-agent --prometheus-serve-addr=:9962 --metrics-core-only=true
+
+Or via ConfigMap:
+
+.. code-block:: yaml
+
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: cilium-config
+      namespace: kube-system
+    data:
+      enable-prometheus-metrics: "true"
+      prometheus-serve-addr: ":9962"
+      metrics-core-only: "true"
+
+When ``metrics-core-only`` is enabled, explicit metric enablement using the
+existing ``+`` syntax takes precedence and re-enables the specified metric.
+You can selectively re-enable specific metrics even in core-only mode:
+
+.. code-block:: shell-session
+
+    cilium-agent --prometheus-serve-addr=:9962 \\
+      --metrics-core-only=true \\
+      --metrics="+cilium_drop_count_total +cilium_forward_count_total"
+
+Or via ConfigMap:
+
+.. code-block:: yaml
+
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: cilium-config
+      namespace: kube-system
+    data:
+      enable-prometheus-metrics: "true"
+      prometheus-serve-addr: ":9962"
+      metrics-core-only: "true"
+      metrics: |
+        +cilium_drop_count_total
+        +cilium_forward_count_total
+
+This approach provides a minimal baseline with the flexibility to enable
+only the metrics you need, without maintaining large deny-lists.
+
 Feature Metrics
 ~~~~~~~~~~~~~~~
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -195,6 +195,9 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableEndpointRoutes, defaults.EnableEndpointRoutes, "Use per endpoint routes instead of routing via cilium_host")
 	option.BindEnv(vp, option.EnableEndpointRoutes)
 
+	flags.Bool(option.MetricsCoreOnly, false, "Disable all configurable AutoMetrics while preserving core runtime and health metrics")
+	option.BindEnv(vp, option.MetricsCoreOnly)
+
 	flags.Int(option.HealthCheckICMPFailureThreshold, defaults.HealthCheckICMPFailureThreshold, "Number of ICMP requests sent for each run of the health checker. If at least one ICMP response is received, the node or endpoint is marked as healthy.")
 	option.BindEnv(vp, option.HealthCheckICMPFailureThreshold)
 

--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -194,6 +194,16 @@ func (r *Registry) registerMetrics() {
 		metrics[autoMetric.Opts().GetConfigName()] = r.params.AutoMetrics[i]
 	}
 
+	// MetricsCoreOnly disables all configurable AutoMetrics.
+	// Collectors registered directly via MustRegister() are unaffected.
+	// This occurs before user overrides, allowing explicit '+' enables
+	// to take precedence.
+	if r.params.DaemonConfig != nil && r.params.DaemonConfig.MetricsCoreOnly {
+		for _, metric := range metrics {
+			metric.SetEnabled(false)
+		}
+	}
+
 	// This is a bodge for a very specific feature, inherited from the old `Daemon.additionalMetrics`.
 	// We should really find a more generic way to handle such cases.
 	metricFlags := r.params.Config.Metrics

--- a/pkg/metrics/registry_test.go
+++ b/pkg/metrics/registry_test.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	metricpkg "github.com/cilium/cilium/pkg/metrics/metric"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// testAutoMetric implements metricpkg.WithMetadata for testing
+type testAutoMetric struct {
+	name    string
+	enabled bool
+	opts    metricpkg.Opts
+}
+
+func (m *testAutoMetric) Opts() metricpkg.Opts {
+	return m.opts
+}
+
+func (m *testAutoMetric) SetEnabled(enabled bool) {
+	m.enabled = enabled
+}
+
+func (m *testAutoMetric) IsEnabled() bool {
+	return m.enabled
+}
+
+func (m *testAutoMetric) Describe(ch chan<- *prometheus.Desc) {}
+func (m *testAutoMetric) Collect(ch chan<- prometheus.Metric) {}
+
+// TestMetricsCoreOnly_DefaultBehavior verifies that existing behavior remains unchanged
+// when metrics-core-only is disabled (default).
+func TestMetricsCoreOnly_DefaultBehavior(t *testing.T) {
+	metric1 := &testAutoMetric{
+		name:    "test_metric_1",
+		enabled: true,
+		opts: metricpkg.Opts{
+			ConfigName: "cilium_test_metric_1",
+		},
+	}
+	metric2 := &testAutoMetric{
+		name:    "test_metric_2",
+		enabled: true,
+		opts: metricpkg.Opts{
+			ConfigName: "cilium_test_metric_2",
+		},
+	}
+
+	params := RegistryParams{
+		DaemonConfig: &option.DaemonConfig{
+			MetricsCoreOnly: false,
+		},
+		Config: RegistryConfig{
+			PrometheusServeAddr: "",
+			Metrics:             []string{},
+		},
+		AutoMetrics: []metricpkg.WithMetadata{metric1, metric2},
+	}
+
+	reg := NewRegistry(params)
+	require.NotNil(t, reg)
+	reg.registerMetrics()
+
+	require.True(t, metric1.IsEnabled(), "metric1 should remain enabled when MetricsCoreOnly is false")
+	require.True(t, metric2.IsEnabled(), "metric2 should remain enabled when MetricsCoreOnly is false")
+}
+
+// TestMetricsCoreOnly_DisablesAllAutoMetrics verifies that all auto metrics are disabled
+// when metrics-core-only is enabled.
+func TestMetricsCoreOnly_DisablesAllAutoMetrics(t *testing.T) {
+	metric1 := &testAutoMetric{
+		name:    "test_metric_1",
+		enabled: true,
+		opts: metricpkg.Opts{
+			ConfigName: "cilium_test_metric_1",
+		},
+	}
+	metric2 := &testAutoMetric{
+		name:    "test_metric_2",
+		enabled: true,
+		opts: metricpkg.Opts{
+			ConfigName: "cilium_test_metric_2",
+		},
+	}
+	metric3 := &testAutoMetric{
+		name:    "test_metric_3",
+		enabled: true,
+		opts: metricpkg.Opts{
+			ConfigName: "cilium_test_metric_3",
+		},
+	}
+
+	params := RegistryParams{
+		DaemonConfig: &option.DaemonConfig{
+			MetricsCoreOnly: true,
+		},
+		Config: RegistryConfig{
+			PrometheusServeAddr: "",
+			Metrics:             []string{},
+		},
+		AutoMetrics: []metricpkg.WithMetadata{metric1, metric2, metric3},
+	}
+
+	reg := NewRegistry(params)
+	require.NotNil(t, reg)
+	reg.registerMetrics()
+
+	require.False(t, metric1.IsEnabled(), "metric1 should be disabled when MetricsCoreOnly is true")
+	require.False(t, metric2.IsEnabled(), "metric2 should be disabled when MetricsCoreOnly is true")
+	require.False(t, metric3.IsEnabled(), "metric3 should be disabled when MetricsCoreOnly is true")
+}
+
+// TestMetricsCoreOnly_WithExplicitEnable verifies that explicitly enabled metrics
+// continue to be registered even when metrics-core-only is enabled.
+func TestMetricsCoreOnly_WithExplicitEnable(t *testing.T) {
+	metric1 := &testAutoMetric{
+		name:    "test_metric_1",
+		enabled: true,
+		opts: metricpkg.Opts{
+			ConfigName: "cilium_test_metric_1",
+		},
+	}
+	metric2 := &testAutoMetric{
+		name:    "test_metric_2",
+		enabled: true,
+		opts: metricpkg.Opts{
+			ConfigName: "cilium_test_metric_2",
+		},
+	}
+
+	params := RegistryParams{
+		DaemonConfig: &option.DaemonConfig{
+			MetricsCoreOnly: true,
+		},
+		Config: RegistryConfig{
+			PrometheusServeAddr: "",
+			Metrics: []string{
+				"+cilium_test_metric_1",
+			},
+		},
+		AutoMetrics: []metricpkg.WithMetadata{metric1, metric2},
+	}
+
+	reg := NewRegistry(params)
+	require.NotNil(t, reg)
+	reg.registerMetrics()
+
+	require.True(t, metric1.IsEnabled(), "metric1 should be enabled due to explicit +cilium_test_metric_1")
+	require.False(t, metric2.IsEnabled(), "metric2 should remain disabled when MetricsCoreOnly is true")
+}
+

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -345,6 +345,9 @@ const (
 	// PrometheusServeAddr IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
 	PrometheusServeAddr = "prometheus-serve-addr"
 
+	// MetricsCoreOnly disables all configurable AutoMetrics while preserving core runtime and health metrics
+	MetricsCoreOnly = "metrics-core-only"
+
 	// ExternalEnvoyProxy defines whether the Envoy is deployed externally in form of a DaemonSet or not.
 	ExternalEnvoyProxy = "external-envoy-proxy"
 
@@ -1524,6 +1527,10 @@ type DaemonConfig struct {
 	// DNS proxy at any given point in time.
 	DNSProxyConcurrencyLimit int
 
+	// MetricsCoreOnly disables all configurable AutoMetrics while preserving
+	// core runtime, health, process, endpoint and BPF metrics
+	MetricsCoreOnly bool
+
 	// DNSProxyEnableTransparentMode enables transparent mode for the DNS proxy.
 	DNSProxyEnableTransparentMode bool
 
@@ -2685,6 +2692,7 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	c.ToFQDNsIdleConnectionGracePeriod = vp.GetDuration(ToFQDNsIdleConnectionGracePeriod)
 	c.FQDNProxyResponseMaxDelay = vp.GetDuration(FQDNProxyResponseMaxDelay)
 	c.DNSProxyConcurrencyLimit = vp.GetInt(DNSProxyConcurrencyLimit)
+	c.MetricsCoreOnly = vp.GetBool(MetricsCoreOnly)
 	c.DNSProxyEnableTransparentMode = vp.GetBool(DNSProxyEnableTransparentMode)
 	c.DNSProxyLockCount = vp.GetInt(DNSProxyLockCount)
 	c.DNSProxyLockTimeout = vp.GetDuration(DNSProxyLockTimeout)


### PR DESCRIPTION
<html><head></head><body><h2>Summary</h2><p>Add an optional <code inline="">metrics-core-only</code> configuration that disables all configurable AutoMetrics while preserving core operational metrics.</p><p>This provides a simple way to run Cilium with a reduced metrics footprint without maintaining large metric exclusion lists.</p><p>Fixes: #46721</p><p>Today metric filtering only supports enabling or disabling metrics by exact metric name.</p><p>For environments that require a minimal metrics footprint, users must maintain large ConfigMaps containing metric exclusion lists because there is currently no support for:</p><ul><li><p>Allowlist mode</p></li><li><p>Wildcard matching</p></li><li><p>Regex matching</p></li><li><p>Disable-all semantics</p></li></ul><p>While investigating this, I validated the current behavior on a v1.19.3 deployment.</p><h3>Scenario 1: Explicitly enable a single metric</h3><pre><code class="language-yaml">metrics: |
  +cilium_drop_count_total
</code></pre><p>Result:</p><pre><code class="language-text">120 metric families exported
</code></pre><p>The current configuration model is additive and does not provide allowlist semantics.</p><h3>Scenario 2: Explicitly disable all exported metric families</h3><p>I configured the metrics ConfigMap to disable all 120 exported metric families and restarted the Cilium DaemonSet.</p><p>Result:</p><pre><code class="language-text">28 metric families exported
</code></pre><p>The remaining metrics are core operational metrics registered outside the configurable AutoMetrics framework.</p><p>While the filtering mechanism works as expected, achieving a minimal metrics footprint requires maintaining a large exclusion list.</p><h2>What does this change do?</h2><p>When <code inline="">metrics-core-only=true</code> is enabled:</p><ul><li><p>All configurable AutoMetrics are disabled by default.</p></li><li><p>Core operational metrics remain enabled.</p></li><li><p>Existing metric override semantics are preserved.</p></li><li><p>Users can explicitly re-enable metrics using the existing <code inline="">+metric</code> syntax.</p></li></ul><p>Example:</p><pre><code class="language-yaml">metrics-core-only: "true"

metrics: |
  +cilium_policy
  +cilium_kubernetes_events_total
  +cilium_k8s_client_api_calls_total
</code></pre><p>Provides a minimal  set of metrics while allowing users to selectively opt additional metrics as required .</p><h2>Implementation</h2><p>The implementation uses the existing AutoMetrics framework.</p><p>When <code inline="">metrics-core-only=true</code>:</p><ol><li><p>AutoMetrics registry is initialized.</p></li><li><p>All configurable AutoMetrics are disabled.</p></li><li><p>Existing metric overrides are processed.</p></li><li><p>Explicit <code inline="">+metric</code> entries re-enable the requested metrics.</p></li></ol><p>This preserves existing behavior while introducing an opt-in minimal metrics mode.

### Unit Tests

Added unit tests covering the key `metrics-core-only` behaviors:

* Default behavior remains unchanged when `metrics-core-only` is disabled.
* All AutoMetrics are disabled when `metrics-core-only` is enabled.
* Explicit `+metric` overrides continue to enable selected metrics in `metrics-core-only` mode.

Executed:

```bash
go test ./pkg/metrics -run TestMetricsCoreOnly -v
```

Result:

```text
=== RUN   TestMetricsCoreOnly_DefaultBehavior
--- PASS: TestMetricsCoreOnly_DefaultBehavior (0.00s)
=== RUN   TestMetricsCoreOnly_DisablesAllAutoMetrics
--- PASS: TestMetricsCoreOnly_DisablesAllAutoMetrics (0.00s)
=== RUN   TestMetricsCoreOnly_WithExplicitEnable
--- PASS: TestMetricsCoreOnly_WithExplicitEnable (0.00s)
PASS
ok      github.com/cilium/cilium/pkg/metrics    1.074s
```

</code></pre><h3>Runtime Tests </h3><p>Validated on a patched Cilium v1.19.3 build:</p>
Scenario | Exported Metric Families
-- | --
Default | 120
metrics-core-only | 28
metrics-core-only + explicit overrides (cilium_policy, cilium_kubernetes_events_total, cilium_k8s_client_api_calls_total) | 31

Disclosure</h2><p>This PR was prepared with AIL:2. AI assistance was used for discussion, brainstorming, documentation, and PR preparation. The implementation, testing, validation, and final code changes were performed, reviewed, and verified manually.</p><pre><code class="language-release-note">Add an optional metrics-core-only mode that disables configurable AutoMetrics by default while preserving core operational metrics. Additional metrics can still be enabled using the existing metrics configuration.
</code></pre></body></html>


[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
