### PR TITLE
gateway-api: reject unsupported Gateway infrastructure.parametersRef

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -104,6 +104,13 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return controllerruntime.Success()
 	}
 
+	// At this point, the GatewayClass is managed by Cilium, so Gateway-level validations are safe to run.
+	if ref := gw.Spec.Infrastructure; ref != nil && ref.ParametersRef != nil {
+		setGatewayAccepted(gw, false, "Invalid Gateway parameters: spec.infrastructure.parametersRef is not supported", gatewayv1.GatewayReasonInvalidParameters)
+		setGatewayProgrammed(gw, metav1.ConditionUnknown, "Waiting for Accepted condition to be True", gatewayv1.GatewayReasonPending)
+		return r.handleReconcileErrorWithStatus(ctx, errors.New("Invalid Gateway"), original, gw)
+	}
+
 	if ref := gwc.Spec.ParametersRef; ref != nil {
 		if !isParameterRefSupported(ref) {
 			setGatewayAccepted(gw, false, "Invalid GatewayClass parameters: spec.parametersRef.kind must be CiliumGatewayClassConfig", gatewayv1.GatewayReasonInvalidParameters)

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -135,6 +135,12 @@ func Test_Conformance(t *testing.T) {
 			gateway: []gwDetails{{FullName: types.NamespacedName{Name: "gateway-with-infrastructure-metadata", Namespace: "gateway-conformance-infra"}}},
 		},
 		{
+			name: "gateway-invalid-parameters-ref",
+			gateway: []gwDetails{
+				{FullName: types.NamespacedName{Name: "gateway-invalid-parameters-ref", Namespace: "gateway-conformance-infra"}, wantErr: true},
+			},
+		},
+		{
 			name: "gateway-invalid-route-kind",
 			gateway: []gwDetails{
 				{FullName: types.NamespacedName{Name: "gateway-only-invalid-route-kind", Namespace: "gateway-conformance-infra"}, wantErr: true},
@@ -708,6 +714,14 @@ func Test_gatewayReconciler_Reconcile_cleansUpResourcesOnHandoff(t *testing.T) {
 				},
 				Spec: gatewayv1.GatewaySpec{
 					GatewayClassName: gatewayv1.ObjectName(tc.gatewayClass),
+					// Ensure handoff cleanup takes precedence over Gateway validation.
+					Infrastructure: &gatewayv1.GatewayInfrastructure{
+						ParametersRef: &gatewayv1.LocalParametersReference{
+							Group: gatewayv1.Group("invalid.io"),
+							Kind:  gatewayv1.Kind("InvalidParameters"),
+							Name:  "invalid",
+						},
+					},
 				},
 			}
 

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-parameters-ref/input/gateway-invalid-parameters-ref.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-parameters-ref/input/gateway-invalid-parameters-ref.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-invalid-parameters-ref
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: "cilium"
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+  infrastructure:
+    parametersRef:
+      group: invalid.io
+      kind: InvalidParameters
+      name: invalid

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-parameters-ref/output/gateway-invalid-parameters-ref.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-invalid-parameters-ref/output/gateway-invalid-parameters-ref.yaml
@@ -1,0 +1,30 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: gateway-invalid-parameters-ref
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  gatewayClassName: "cilium"
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+  infrastructure:
+    parametersRef:
+      group: invalid.io
+      kind: InvalidParameters
+      name: invalid
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T05:06:15Z"
+      message: 'Invalid Gateway parameters: spec.infrastructure.parametersRef is not supported'
+      reason: InvalidParameters
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T05:06:15Z"
+      message: Waiting for Accepted condition to be True
+      reason: Pending
+      status: "Unknown"
+      type: Programmed


### PR DESCRIPTION
Reject `spec.infrastructure.parametersRef` for Cilium-managed Gateways with `InvalidParameters` reason and keep Programmed pending.

Add conformance testdata and verify handoff cleanup still takes precedence.

This behavior matches the Gateway API spec (specifically Gateway `spec.infrastructure` in v1.5) and it is already part of the v1.6 conformance tests.

Once Cilium supports this parameter, the validation should be extended to better reflect if the referent cannot be found, refers to an unsupported kind, or when the data within that resource is malformed.

Refs:
- https://gateway-api.sigs.k8s.io/reference/api-spec/1.6/spec/#gatewayinfrastructure
- https://github.com/kubernetes-sigs/gateway-api/blob/v1.6.0/conformance/tests/gateway-invalid-parameters-ref.go#L37

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
