### PR TITLE
Fix Getting Started docs link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -237,7 +237,7 @@ Getting Started
 ===============
 
 * `Why Cilium?`_
-* `Getting Started <gs>`_
+* `Getting Started <gs_>`_
 * `Architecture and Concepts`_
 * `Installing Cilium`_
 * `Frequently Asked Questions`_


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request]
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [X] Thanks for contributing!

<!-- Description of change -->

The Getting Started link in the docs points to https://github.com/cilium/cilium/blob/main/gs, instead of the docs as intended.

I asked copilot what was wrong with the .rst syntax since I'm not familiar.

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
