### PR TITLE
Makefile: Generate full Cilium version in worktree

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -138,7 +138,7 @@ GOLANGCILINT_VERSION = $(shell golangci-lint version --short 2>/dev/null)
 VERSION = $(shell cat $(dir $(lastword $(MAKEFILE_LIST)))/VERSION)
 VERSION_MAJOR = $(shell cat $(dir $(lastword $(MAKEFILE_LIST)))/VERSION | cut -d. -f1)
 # Use git only if in a Git repo
-ifneq ($(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/.git/HEAD),)
+ifneq ($(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/.git),)
     GIT_VERSION = $(shell git show -s --format='format:%h %aI')
 else
     GIT_VERSION = $(shell cat 2>/dev/null $(ROOT_DIR)/GIT_VERSION)


### PR DESCRIPTION
Previously when using a `git worktree` for building Cilium, the Makefile
would fail to detect that the local tree is a worktree, and therefore
skip over the step where the sha and timestamp are included in the
ciliumVersion variable which is subsequently built into each binary.
This can make it difficult to track and understand which version of the
code is running during development from a git worktree.

Rather than depending on the existence of .git/HEAD, rely only on .git
(which for a worktree is a file containing the path to the true git root).
