### PR TITLE
Improve cilium-dbg status output of module health

### DIFF
--- a/cilium-dbg/cmd/status.go
+++ b/cilium-dbg/cmd/status.go
@@ -126,8 +126,7 @@ func statusDaemon() {
 			}
 
 			healthPkg.GetAndFormatHealthStatus(w, allNodes, verbose, healthLines)
-			fmt.Fprintf(w, "Modules Health:")
-			healthPkg.GetAndFormatModulesHealth(w, ss, allHealth, "\t\t")
+			healthPkg.GetAndFormatModulesHealth(w, ss, allHealth, "  ")
 			fmt.Fprintln(w)
 		} else {
 			fmt.Fprint(w, "Cluster health:\tProbe disabled\n")

--- a/pkg/health/client/modules.go
+++ b/pkg/health/client/modules.go
@@ -28,6 +28,18 @@ func GetAndFormatModulesHealth(w io.Writer, ss []types.Status, verbose bool, pre
 	sort.Slice(ss, func(i, j int) bool {
 		return ss[i].ID.String() < ss[j].ID.String()
 	})
+	tally := make(map[types.Level]int, 4)
+	for _, s := range ss {
+		tally[types.Level(s.Level)] += 1
+	}
+	fmt.Fprintf(w, "Modules Health:\t%s(%d) %s(%d) %s(%d)\n",
+		types.LevelStopped,
+		tally[types.LevelStopped],
+		types.LevelDegraded,
+		tally[types.LevelDegraded],
+		types.LevelOK,
+		tally[types.LevelOK],
+	)
 	if verbose {
 		r := newRoot(rootNode)
 		for _, s := range ss {
@@ -54,20 +66,7 @@ func GetAndFormatModulesHealth(w io.Writer, ss []types.Status, verbose bool, pre
 
 		body = strings.ReplaceAll(body, "\n", "\n"+prefix)
 		fmt.Fprintln(w, prefix+body)
-		return
 	}
-	tally := make(map[types.Level]int, 4)
-	for _, s := range ss {
-		tally[types.Level(s.Level)] += 1
-	}
-	fmt.Fprintf(w, "\t%s(%d) %s(%d) %s(%d)\n",
-		types.LevelStopped,
-		tally[types.LevelStopped],
-		types.LevelDegraded,
-		tally[types.LevelDegraded],
-		types.LevelOK,
-		tally[types.LevelOK],
-	)
 }
 
 type TreeView struct {

--- a/pkg/health/client/modules.go
+++ b/pkg/health/client/modules.go
@@ -17,9 +17,7 @@ import (
 )
 
 const (
-	noPod    = "(/)"
 	rootNode = ""
-	noErr    = "<nil>"
 )
 
 // GetAndFormatModulesHealth retrieves modules health and formats output.

--- a/pkg/health/client/modules_test.go
+++ b/pkg/health/client/modules_test.go
@@ -21,10 +21,11 @@ func TestGetAndFormatModulesHealth(t *testing.T) {
 		v  bool
 	}{
 		"happy": {
-			e: "Stopped(0) Degraded(2) OK(2)",
+			e: "Modules Health:	Stopped(0) Degraded(2) OK(2)",
 		},
 		"happy-verbose": {
-			e: `agent
+			e: `Modules Health:	Stopped(0) Degraded(2) OK(2)
+		agent
 		├── a
 		│   └── b
 		│       └── c

--- a/pkg/hive/health/testdata/health.txtar
+++ b/pkg/hive/health/testdata/health.txtar
@@ -118,6 +118,7 @@ final: ""
 count: 1
 
 -- all.expected.txt --
+Modules Health:	Stopped(1) Degraded(1) OK(3)
 agent
 ├── m0
 │   ├── c0                                          [OK] ok
@@ -130,22 +131,26 @@ agent
     └── stopped                                     [STOPPED] ok
 
 -- m0.expected.txt --
+Modules Health:	Stopped(0) Degraded(1) OK(1)
 agent
 └── m0
     ├── c0                                          [OK] ok
     └── c1                                          [DEGRADED] no!
 
 -- m0.c1.expected.txt --
+Modules Health:	Stopped(0) Degraded(1) OK(0)
 agent
 └── m0
     └── c1                                          [DEGRADED] no!
 
 -- degraded.expected.txt --
+Modules Health:	Stopped(0) Degraded(1) OK(0)
 agent
 └── m0
     └── c1                                          [DEGRADED] no!
 
 -- degraded-stopped.expected.txt --
+Modules Health:	Stopped(1) Degraded(1) OK(0)
 agent
 ├── m0
 │   └── c1                                          [DEGRADED] no!
@@ -153,6 +158,7 @@ agent
     └── stopped                                     [STOPPED] ok
 
 -- foo.expected.txt --
+Modules Health:	Stopped(1) Degraded(1) OK(4)
 agent
 ├── m0
 │   ├── c0                                          [OK] ok


### PR DESCRIPTION
Previously, the `cilium-dbg status --verbose` module health report would
omit the summary status and format the  detailed health tree with
significant unnecessary indentation:

```ShellSession
$ cilium-dbg status --verbose
...
Modules Health:                             agent                                                                                                                                                           
                                            ├── controlplane                                                                                                                                                
                                            │   ├── cilium-agent-dynamic-config                                                                                                                             
                                            │   │   └── job-k8s-reflector-cilium-configs-cm-cilium-config-kube-system      [OK] 168 upserted, 0 deleted, 168 total objects (2m48s, x1)
                                            ...
```

Fix it so that the summary is always printed, and the indentation matches
the rest of the command:

```ShellSession
$ cilium-dbg status --verbose
...
Modules Health:   Stopped(0) Degraded(0) OK(90)
  agent
  ├── controlplane
  │   ├── cilium-agent-dynamic-config
  │   │   └── job-k8s-reflector-cilium-configs-cm-cilium-config-kube-system      [OK] 168 upserted, 0 deleted, 168 total objects (24s, x1)
  ...
```

AIL:0