### PR TITLE
standalone-dns-proxy: tolerate disabled config

### DIFF
--- a/standalone-dns-proxy/cmd/root.go
+++ b/standalone-dns-proxy/cmd/root.go
@@ -146,19 +146,32 @@ type hooksParams struct {
 }
 
 func registerStandaloneDNSProxyHooks(params hooksParams) error {
-	if params.SDP.enableL7Proxy && params.SDP.enableStandaloneDNSProxy {
-		params.SDP.logger.Info("Standalone DNS proxy is enabled")
+	sdp := params.SDP
+
+	var onStart, onStop func(cell.HookContext) error
+
+	if sdp.enableL7Proxy && sdp.enableStandaloneDNSProxy {
+		sdp.logger.Info("Standalone DNS proxy is enabled")
+		onStart = func(cell.HookContext) error { return sdp.StartStandaloneDNSProxy() }
+		onStop = func(cell.HookContext) error { return sdp.StopStandaloneDNSProxy() }
 	} else {
-		return fmt.Errorf("standalone DNS proxy requires L7 proxy and standalone DNS proxy to be enabled in the configuration")
+		sdp.logger.Error("Standalone DNS proxy requires both L7 proxy and standalone DNS proxy to be enabled",
+			option.EnableL7Proxy, sdp.enableL7Proxy,
+			service.EnableStandaloneDNSProxy, sdp.enableStandaloneDNSProxy,
+		)
+		onStart = func(cell.HookContext) error {
+			sdp.setReady(true)
+			return nil
+		}
+		onStop = func(cell.HookContext) error {
+			sdp.setReady(false)
+			return nil
+		}
 	}
 
 	params.Lifecycle.Append(cell.Hook{
-		OnStart: func(cell.HookContext) error {
-			return params.SDP.StartStandaloneDNSProxy()
-		},
-		OnStop: func(cell.HookContext) error {
-			return params.SDP.StopStandaloneDNSProxy()
-		},
+		OnStart: onStart,
+		OnStop:  onStop,
 	})
 	return nil
 }

--- a/standalone-dns-proxy/cmd/standalonednsproxy_test.go
+++ b/standalone-dns-proxy/cmd/standalonednsproxy_test.go
@@ -64,6 +64,55 @@ func TestStandaloneDNSProxy(t *testing.T) {
 	connHandler.StopConnection()
 }
 
+func TestStandaloneDNSProxyNoopMode(t *testing.T) {
+	tests := []struct {
+		name                     string
+		enableL7Proxy            bool
+		enableStandaloneDNSProxy bool
+	}{
+		{
+			name:                     "both disabled",
+			enableL7Proxy:            false,
+			enableStandaloneDNSProxy: false,
+		},
+		{
+			name:                     "L7 enabled and standalone disabled",
+			enableL7Proxy:            true,
+			enableStandaloneDNSProxy: false,
+		},
+		{
+			name:                     "L7 disabled and standalone enabled",
+			enableL7Proxy:            false,
+			enableStandaloneDNSProxy: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sdp := &StandaloneDNSProxy{
+				logger:                   hivetest.Logger(t),
+				enableL7Proxy:            tt.enableL7Proxy,
+				enableStandaloneDNSProxy: tt.enableStandaloneDNSProxy,
+			}
+			lifecycle := cell.NewDefaultLifecycle(nil, 0, 0)
+
+			err := registerStandaloneDNSProxyHooks(hooksParams{
+				Lifecycle: lifecycle,
+				SDP:       sdp,
+			})
+			require.NoError(t, err)
+
+			err = lifecycle.Start(hivetest.Logger(t), t.Context())
+			require.NoError(t, err)
+			require.True(t, sdp.IsReady())
+
+			err = lifecycle.Stop(hivetest.Logger(t), context.Background())
+			require.NoError(t, err)
+			require.False(t, sdp.IsReady())
+		})
+	}
+}
+
 func setupTestEnv(t *testing.T) *StandaloneDNSProxy {
 	var sdp *StandaloneDNSProxy
 	h := hive.New(

--- a/standalone-dns-proxy/pkg/client/cell.go
+++ b/standalone-dns-proxy/pkg/client/cell.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/service"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/standalone-dns-proxy/pkg/metrics"
 )
@@ -40,6 +41,7 @@ type clientParams struct {
 	cell.In
 
 	Logger                *slog.Logger
+	DaemonConfig          *option.DaemonConfig
 	JobGroup              job.Group
 	FQDNConfig            service.FQDNConfig
 	DialClient            dialClient
@@ -53,6 +55,11 @@ type clientParams struct {
 // newGRPCClient creates a new gRPC connection handler client for standalone DNS proxy
 func newGRPCClient(params clientParams) ConnectionHandler {
 	c := createGRPCClient(params)
+
+	if !params.DaemonConfig.EnableL7Proxy || !params.FQDNConfig.EnableStandaloneDNSProxy {
+		params.Logger.Info("Standalone DNS proxy gRPC client disabled")
+		return c
+	}
 
 	// The InitClient job initializes the gRPC client for communication with the Cilium agent.
 	err := c.InitClient()

--- a/standalone-dns-proxy/pkg/client/client_test.go
+++ b/standalone-dns-proxy/pkg/client/client_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/service"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/time"
@@ -125,12 +126,20 @@ func setupClientAndServer(t *testing.T) (ConnectionHandler, *mockFqdnDataServer,
 		cell.Provide(func() dialClient {
 			return newMockDialConfig(lis)
 		},
+			func() *option.DaemonConfig {
+				return &option.DaemonConfig{
+					EnableL7Proxy: true,
+				}
+			},
 			newGRPCClient),
 		cell.Provide(metrics.NewMetrics),
 		cell.Invoke(func(_c ConnectionHandler) {
 			connHandler = _c
 		}),
 	)
+	hive.AddConfigOverride(h, func(cfg *service.FQDNConfig) {
+		cfg.EnableStandaloneDNSProxy = true
+	})
 	if err := h.Start(hivetest.Logger(t), t.Context()); err != nil {
 		t.Fatalf("failed to start: %s", err)
 	}


### PR DESCRIPTION
Instead of crashing the daemonset, keep the standalone DNS proxy process ready when L7 or standalone DNS proxy is disabled, and skip the gRPC policy stream timer in that state.
This keeps the SDP pod stable when L7 proxy or standalone DNS proxy is disabled instead of disrupting(Crashloopbackoff) it.
We still log the error for invalid configuration.

This PR was made with AIL: 2

```release-note
standalone-dns-proxy: tolerate disabled config
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
