### PR TITLE
status,helm: gate agent readiness on eBPF datapath and add configurable operator probes

### DIFF
--- a/daemon/healthz/agenthealth.go
+++ b/daemon/healthz/agenthealth.go
@@ -144,6 +144,20 @@ func (h *agentHealthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			requireK8sConnectivity = res
 		}
 	}
+
+	requireDatapathReady := false
+	if v := r.Header.Get("require-datapath-ready"); v != "" {
+		res, err := strconv.ParseBool(v)
+		if err != nil {
+			h.logger.Warn("require-datapath-ready should be bool",
+				logfields.Value, v,
+				logfields.Error, err,
+			)
+		} else {
+			requireDatapathReady = res
+		}
+	}
+
 	isUnhealthy := func(sr *models.StatusResponse) bool {
 		if sr.Cilium != nil {
 			state := sr.Cilium.State
@@ -152,7 +166,7 @@ func (h *agentHealthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return false
 	}
 	statusCode := http.StatusOK
-	sr := h.statusCollector.GetStatus(true, requireK8sConnectivity)
+	sr := h.statusCollector.GetStatus(true, requireK8sConnectivity, requireDatapathReady)
 	if isUnhealthy(&sr) {
 		h.logger.Info("/healthz returning unhealthy",
 			logfields.State, sr.Cilium.State,

--- a/daemon/healthz/kube_proxy_healthz.go
+++ b/daemon/healthz/kube_proxy_healthz.go
@@ -147,7 +147,7 @@ func (h kubeproxyHealthzHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	// We piggy back here on Cilium daemon health. If Cilium is healthy, we can
 	// reasonably assume that the node networking is ready.
 	// If node is in terminating state, we return ServiceUnavailable.
-	sr := h.statusCollector.GetStatus(true, false)
+	sr := h.statusCollector.GetStatus(true, false, false)
 	ln, _ := h.localNode.Get(r.Context())
 	if isUnhealthy(&sr) || ln.Local.IsBeingDeleted {
 		statusCode = http.StatusServiceUnavailable

--- a/daemon/healthz/kube_proxy_healthz_test.go
+++ b/daemon/healthz/kube_proxy_healthz_test.go
@@ -23,7 +23,7 @@ type mockStatusCollector struct {
 	statusResponse models.StatusResponse
 }
 
-func (m *mockStatusCollector) GetStatus(bool, bool) models.StatusResponse {
+func (m *mockStatusCollector) GetStatus(bool, bool, bool) models.StatusResponse {
 	return m.statusResponse
 }
 

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -188,6 +188,8 @@ spec:
             httpHeaders:
             - name: "brief"
               value: "true"
+            - name: "require-datapath-ready"
+              value: {{ .Values.readinessProbe.requireDatapathReady | quote }}
           {{- end }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           successThreshold: 1

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -202,6 +202,17 @@ spec:
         {{- end }}
           protocol: TCP
         {{- end }}
+        startupProbe:
+          httpGet:
+        {{- if .Values.operator.hostNetwork }}
+            host: {{ .Values.ipv4.enabled | ternary "127.0.0.1" "::1" | quote }}
+        {{- end }}
+            path: /healthz
+            port: health
+            scheme: HTTP
+          failureThreshold: {{ .Values.operator.startupProbe.failureThreshold }}
+          periodSeconds: {{ .Values.operator.startupProbe.periodSeconds }}
+          successThreshold: 1
         livenessProbe:
           httpGet:
         {{- if .Values.operator.hostNetwork }}
@@ -210,9 +221,8 @@ spec:
             path: /healthz
             port: health
             scheme: HTTP
-          initialDelaySeconds: 60
-          periodSeconds: 10
-          timeoutSeconds: 3
+          periodSeconds: {{ .Values.operator.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.operator.livenessProbe.timeoutSeconds }}
         readinessProbe:
           httpGet:
         {{- if .Values.operator.hostNetwork }}
@@ -221,10 +231,9 @@ spec:
             path: /healthz
             port: health
             scheme: HTTP
-          initialDelaySeconds: 0
-          periodSeconds: 5
-          timeoutSeconds: 3
-          failureThreshold: 5
+          periodSeconds: {{ .Values.operator.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.operator.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.operator.readinessProbe.failureThreshold }}
         volumeMounts:
         - name: cilium-config-path
           mountPath: /tmp/cilium/config-map

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -5254,6 +5254,17 @@
           },
           "type": "object"
         },
+        "livenessProbe": {
+          "properties": {
+            "periodSeconds": {
+              "type": "integer"
+            },
+            "timeoutSeconds": {
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
         "nodeGCInterval": {
           "type": "string"
         },
@@ -5411,6 +5422,20 @@
           },
           "type": "object"
         },
+        "readinessProbe": {
+          "properties": {
+            "failureThreshold": {
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "type": "integer"
+            },
+            "timeoutSeconds": {
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
         "removeNodeTaints": {
           "type": "boolean"
         },
@@ -5457,6 +5482,17 @@
         },
         "skipCRDCreation": {
           "type": "boolean"
+        },
+        "startupProbe": {
+          "properties": {
+            "failureThreshold": {
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "type": "integer"
+            }
+          },
+          "type": "object"
         },
         "tolerations": {
           "items": {

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -5965,6 +5965,9 @@
         },
         "periodSeconds": {
           "type": "integer"
+        },
+        "requireDatapathReady": {
+          "type": "boolean"
         }
       },
       "type": "object"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2430,6 +2430,8 @@ readinessProbe:
   failureThreshold: 3
   # -- interval between checks of the readiness probe
   periodSeconds: 30
+  # -- whether to require datapath readiness as part of the check.
+  requireDatapathReady: false
 # -- Configure the kube-proxy replacement in Cilium BPF datapath
 # Valid options are "true" or "false".
 # ref: https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3271,6 +3271,31 @@ operator:
   #     topologyKey: topology.kubernetes.io/zone
   #     whenUnsatisfiable: DoNotSchedule
 
+  # -- Startup probe configuration for cilium-operator.
+  # Allows the operator to take longer to initialize on resource-constrained nodes
+  # (e.g., 2-vCPU instances where startup can exceed the default 90s liveness window).
+  # Once the startup probe succeeds, the liveness probe takes over for fast crash detection.
+  startupProbe:
+    # -- failure threshold of startup probe.
+    # 30 * 10s = 300s maximum startup time.
+    failureThreshold: 30
+    # -- interval between checks of the startup probe
+    periodSeconds: 10
+  # -- Liveness probe configuration for cilium-operator.
+  livenessProbe:
+    # -- interval between checks of the liveness probe
+    periodSeconds: 10
+    # -- timeout of the liveness probe
+    timeoutSeconds: 3
+  # -- Readiness probe configuration for cilium-operator.
+  readinessProbe:
+    # -- interval between checks of the readiness probe
+    periodSeconds: 5
+    # -- timeout of the readiness probe
+    timeoutSeconds: 3
+    # -- failure threshold of the readiness probe
+    failureThreshold: 5
+
   # -- Node labels for cilium-operator pod assignment
   # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
   nodeSelector:

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2452,6 +2452,8 @@ readinessProbe:
   failureThreshold: 3
   # -- interval between checks of the readiness probe
   periodSeconds: 30
+  # -- whether to require datapath readiness as part of the check.
+  requireDatapathReady: false
 # -- Configure the kube-proxy replacement in Cilium BPF datapath
 # Valid options are "true" or "false".
 # ref: https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -3305,6 +3305,31 @@ operator:
   #     topologyKey: topology.kubernetes.io/zone
   #     whenUnsatisfiable: DoNotSchedule
 
+  # -- Startup probe configuration for cilium-operator.
+  # Allows the operator to take longer to initialize on resource-constrained nodes
+  # (e.g., 2-vCPU instances where startup can exceed the default 90s liveness window).
+  # Once the startup probe succeeds, the liveness probe takes over for fast crash detection.
+  startupProbe:
+    # -- failure threshold of startup probe.
+    # 30 * 10s = 300s maximum startup time.
+    failureThreshold: 30
+    # -- interval between checks of the startup probe
+    periodSeconds: 10
+  # -- Liveness probe configuration for cilium-operator.
+  livenessProbe:
+    # -- interval between checks of the liveness probe
+    periodSeconds: 10
+    # -- timeout of the liveness probe
+    timeoutSeconds: 3
+  # -- Readiness probe configuration for cilium-operator.
+  readinessProbe:
+    # -- interval between checks of the readiness probe
+    periodSeconds: 5
+    # -- timeout of the readiness probe
+    timeoutSeconds: 3
+    # -- failure threshold of the readiness probe
+    failureThreshold: 5
+
   # -- Node labels for cilium-operator pod assignment
   # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
   nodeSelector:

--- a/pkg/debug/api/debug_api_handler.go
+++ b/pkg/debug/api/debug_api_handler.go
@@ -46,7 +46,7 @@ func (h *GetDebuginfoHandler) Handle(params restapi.GetDebuginfoParams) middlewa
 		dr.KernelVersion = kver.String()
 	}
 
-	status := h.statusCollector.GetStatus(false, true)
+	status := h.statusCollector.GetStatus(false, true, false)
 	dr.CiliumStatus = &status
 
 	dr.EndpointList = h.endpointManager.GetEndpointList(endpoint.GetEndpointParams{})

--- a/pkg/status/cell.go
+++ b/pkg/status/cell.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/connector"
 	"github.com/cilium/cilium/pkg/datapath/linux/bandwidth"
 	"github.com/cilium/cilium/pkg/datapath/linux/bigtcp"
+	loadertypes "github.com/cilium/cilium/pkg/datapath/loader/types"
 	ipsec "github.com/cilium/cilium/pkg/datapath/linux/ipsec/types"
 	datapathTables "github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
@@ -60,6 +61,7 @@ var Cell = cell.Module(
 		StatusCollectorInterval:          5 * time.Second,
 		StatusCollectorProbeCheckTimeout: 5 * time.Minute,
 		StatusCollectorStackdumpPath:     "/run/cilium/state/agent.stack.gz",
+		DatapathReadyTimeout:             120 * time.Second,
 	}),
 	cell.Provide(newStatusCollector),
 	cell.Provide(newStatusAPIHandler),
@@ -107,6 +109,7 @@ type statusParams struct {
 	WireguardAgent   wgTypes.Agent
 	ZtunnelConfig    zconfig.Config
 	ConnectorConfig  connector.Config
+	Loader           loadertypes.Loader // for datapath readiness check
 }
 
 // Config is the collector configuration
@@ -116,6 +119,7 @@ type Config struct {
 	StatusCollectorInterval          time.Duration
 	StatusCollectorProbeCheckTimeout time.Duration
 	StatusCollectorStackdumpPath     string
+	DatapathReadyTimeout             time.Duration
 }
 
 func (r Config) Flags(flags *pflag.FlagSet) {
@@ -124,12 +128,14 @@ func (r Config) Flags(flags *pflag.FlagSet) {
 	flags.Duration("status-collector-interval", r.StatusCollectorInterval, "The interval between probe invocations")
 	flags.Duration("status-collector-probe-check-timeout", r.StatusCollectorProbeCheckTimeout, "The timeout after which all probes should have finished at least once")
 	flags.String("status-collector-stackdump-path", r.StatusCollectorStackdumpPath, "The path where probe stackdumps should be written to")
+	flags.Duration("datapath-ready-timeout", r.DatapathReadyTimeout, "Maximum time to wait for eBPF datapath initialization before reporting ready anyway")
 }
 
 func newStatusCollector(params statusParams) StatusCollector {
 	collector := &statusCollector{
 		statusParams:    params,
 		statusCollector: newCollector(params.Logger, params.Config),
+		startTime:       time.Now(),
 	}
 
 	params.JobGroup.Add(job.OneShot("probes", func(ctx context.Context, health cell.Health) error {

--- a/pkg/status/status_api_handler.go
+++ b/pkg/status/status_api_handler.go
@@ -16,6 +16,6 @@ type GetHealthzHandler struct {
 func (h *GetHealthzHandler) Handle(params daemonapi.GetHealthzParams) middleware.Responder {
 	brief := params.Brief != nil && *params.Brief
 	requireK8sConnectivity := params.RequireK8sConnectivity != nil && *params.RequireK8sConnectivity
-	sr := h.collector.GetStatus(brief, requireK8sConnectivity)
+	sr := h.collector.GetStatus(brief, requireK8sConnectivity, false)
 	return daemonapi.NewGetHealthzOK().WithPayload(&sr)
 }

--- a/pkg/status/status_collector.go
+++ b/pkg/status/status_collector.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/go-openapi/strfmt"
 	versionapi "k8s.io/apimachinery/pkg/version"
@@ -37,7 +38,7 @@ import (
 )
 
 type StatusCollector interface {
-	GetStatus(brief bool, requireK8sConnectivity bool) models.StatusResponse
+	GetStatus(brief bool, requireK8sConnectivity bool, requireDatapathReady bool) models.StatusResponse
 }
 
 type statusCollector struct {
@@ -46,6 +47,9 @@ type statusCollector struct {
 	statusCollector    *Collector
 
 	allProbesInitialized bool
+
+	startTime           time.Time
+	datapathTimeoutOnce sync.Once
 
 	statusParams statusParams
 }
@@ -551,7 +555,7 @@ func (d *statusCollector) dumpIPAM() *models.IPAMStatus {
 
 // getStatus returns the daemon status. If brief is provided a minimal version
 // of the StatusResponse is provided.
-func (d *statusCollector) GetStatus(brief bool, requireK8sConnectivity bool) models.StatusResponse {
+func (d *statusCollector) GetStatus(brief bool, requireK8sConnectivity bool, requireDatapathReady bool) models.StatusResponse {
 	staleProbes := d.statusCollector.GetStaleProbes()
 	stale := make(map[string]strfmt.DateTime, len(staleProbes))
 	for probe, startTime := range staleProbes {
@@ -632,6 +636,12 @@ func (d *statusCollector) GetStatus(brief bool, requireK8sConnectivity bool) mod
 			State: models.StatusStateFailure,
 			Msg:   fmt.Sprintf("%s    %s", ciliumVer, msg),
 		}
+	case requireDatapathReady && !d.isDatapathReady():
+		msg := "Waiting for eBPF datapath to be ready"
+		sr.Cilium = &models.Status{
+			State: models.StatusStateFailure,
+			Msg:   fmt.Sprintf("%s    %s", ciliumVer, msg),
+		}
 	default:
 		sr.Cilium = &models.Status{
 			State: models.StatusStateOk,
@@ -640,6 +650,36 @@ func (d *statusCollector) GetStatus(brief bool, requireK8sConnectivity bool) mod
 	}
 
 	return sr
+}
+
+// isDatapathReady checks if the host eBPF datapath has been initialized.
+// Returns true if:
+//   - The host datapath channel is closed (BPF programs loaded), OR
+//   - The timeout has elapsed (deadlock prevention)
+func (d *statusCollector) isDatapathReady() bool {
+	if d.statusParams.Loader == nil {
+		return true
+	}
+	select {
+	case <-d.statusParams.Loader.HostDatapathInitialized():
+		return true
+	default:
+	}
+	// Timeout fallback: if we've been running longer than DatapathReadyTimeout,
+	// report ready anyway to prevent permanent node deadlock.
+	if d.startTime.IsZero() {
+		return true
+	}
+	if time.Since(d.startTime) > d.statusParams.Config.DatapathReadyTimeout {
+		d.datapathTimeoutOnce.Do(func() {
+			d.statusParams.Logger.Warn(
+				"Datapath readiness timeout elapsed, reporting ready without eBPF confirmation",
+				"timeout", d.statusParams.Config.DatapathReadyTimeout,
+			)
+		})
+		return true
+	}
+	return false
 }
 
 func (d *statusCollector) getProbes() []Probe {

--- a/pkg/status/status_collector_test.go
+++ b/pkg/status/status_collector_test.go
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package status
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/datapath/config"
+	"github.com/cilium/cilium/pkg/datapath/iptables"
+	"github.com/cilium/cilium/pkg/datapath/linux/bigtcp"
+	"github.com/cilium/cilium/pkg/datapath/loader/metrics"
+	loadertypes "github.com/cilium/cilium/pkg/datapath/loader/types"
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	endpoint "github.com/cilium/cilium/pkg/endpoint/types"
+	k8sClientTestutils "github.com/cilium/cilium/pkg/k8s/client/testutils"
+	proxy "github.com/cilium/cilium/pkg/proxy/types"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// testLoader is a minimal loadertypes.Loader implementation for testing
+// HostDatapathInitialized behavior. The channel is created but never closed
+// to simulate a not-yet-ready datapath. Call closeLoader() to signal readiness.
+type testLoader struct {
+	ch chan struct{}
+}
+
+func newTestLoader() *testLoader {
+	return &testLoader{ch: make(chan struct{})}
+}
+
+// closeLoader signals that the datapath is ready.
+func (f *testLoader) closeLoader() {
+	close(f.ch)
+}
+
+func (f *testLoader) HostDatapathInitialized() <-chan struct{} { return f.ch }
+func (f *testLoader) CallsMapPath(_ uint16) string             { return "" }
+func (f *testLoader) Unload(_ endpoint.Endpoint)               {}
+func (f *testLoader) ReloadDatapath(_ context.Context, _ endpoint.Endpoint, _ *config.Config, _ *metrics.SpanStat) (string, error) {
+	return "", nil
+}
+func (f *testLoader) EndpointHash(_ endpoint.Config, _ *config.Config) (string, error) {
+	return "", nil
+}
+func (f *testLoader) ReinitializeHostDev(_ context.Context, _ int) error { return nil }
+func (f *testLoader) Reinitialize(_ context.Context, _ *config.Config, _ tunnel.Config, _ iptables.Manager, _ proxy.Proxy, _ bigtcp.Config) error {
+	return nil
+}
+func (f *testLoader) WriteEndpointConfig(_ io.Writer, _ endpoint.Config) error {
+	return nil
+}
+
+// newTestStatusCollector creates a minimal statusCollector for use in tests.
+// allProbesInitialized is set to true so the switch falls through to the relevant cases.
+// The fake clientset has Kubernetes disabled to avoid hitting the k8s check.
+func newTestStatusCollector(t *testing.T, loader loadertypes.Loader, datapathReadyTimeout time.Duration) *statusCollector {
+	t.Helper()
+	logger := hivetest.Logger(t)
+	config := Config{
+		StatusCollectorWarningThreshold:  15 * time.Second,
+		StatusCollectorFailureThreshold:  1 * time.Minute,
+		StatusCollectorInterval:          5 * time.Second,
+		StatusCollectorProbeCheckTimeout: 5 * time.Minute,
+		StatusCollectorStackdumpPath:     "",
+		DatapathReadyTimeout:             datapathReadyTimeout,
+	}
+
+	// Use a disabled fake clientset so Clientset.IsEnabled() returns false.
+	fakeClientset, _ := k8sClientTestutils.NewFakeClientset(logger)
+	fakeClientset.Disable()
+
+	return &statusCollector{
+		statusCollector:      newCollector(logger, config),
+		allProbesInitialized: true,
+		startTime:            time.Now(),
+		statusParams: statusParams{
+			Logger:    logger,
+			Config:    config,
+			Clientset: fakeClientset,
+			Loader:    loader,
+		},
+	}
+}
+
+// TestDatapathReadiness_NotReady verifies that GetStatus returns a non-OK
+// Failure state when requireDatapathReady=true and the eBPF datapath has not
+// yet been initialized (channel open).
+func TestDatapathReadiness_NotReady(t *testing.T) {
+	loader := newTestLoader() // channel never closed = not ready
+
+	collector := newTestStatusCollector(t, loader, 120*time.Second)
+	sr := collector.GetStatus(true, false, true)
+
+	require.NotNil(t, sr.Cilium, "expected Cilium status to be set")
+	assert.Equal(t, models.StatusStateFailure, sr.Cilium.State,
+		"expected Failure state when datapath not ready")
+	assert.True(t, strings.Contains(strings.ToLower(sr.Cilium.Msg), "datapath"),
+		"expected 'datapath' in status message, got: %q", sr.Cilium.Msg)
+}
+
+// TestDatapathReadiness_Ready verifies that GetStatus returns OK when
+// requireDatapathReady=true and the eBPF datapath channel is closed.
+func TestDatapathReadiness_Ready(t *testing.T) {
+	loader := newTestLoader()
+	loader.closeLoader() // signal datapath is ready
+
+	collector := newTestStatusCollector(t, loader, 120*time.Second)
+	sr := collector.GetStatus(true, false, true)
+
+	require.NotNil(t, sr.Cilium, "expected Cilium status to be set")
+	assert.Equal(t, models.StatusStateOk, sr.Cilium.State,
+		"expected OK state when datapath is ready")
+}
+
+// TestDatapathReadiness_NotRequired verifies that GetStatus returns OK when
+// requireDatapathReady=false even if the datapath is not yet initialized.
+func TestDatapathReadiness_NotRequired(t *testing.T) {
+	loader := newTestLoader() // not ready, but not required
+
+	collector := newTestStatusCollector(t, loader, 120*time.Second)
+	sr := collector.GetStatus(true, false, false)
+
+	require.NotNil(t, sr.Cilium, "expected Cilium status to be set")
+	assert.Equal(t, models.StatusStateOk, sr.Cilium.State,
+		"expected OK state when datapath readiness not required")
+}
+
+// TestDatapathReadiness_NilLoader verifies that GetStatus treats a nil Loader
+// as "datapath ready", avoiding a false unhealthy state on agents that don't
+// wire up the loader (e.g. tests, non-BPF modes).
+func TestDatapathReadiness_NilLoader(t *testing.T) {
+	collector := newTestStatusCollector(t, nil, 120*time.Second)
+	sr := collector.GetStatus(true, false, true)
+
+	require.NotNil(t, sr.Cilium, "expected Cilium status to be set")
+	assert.Equal(t, models.StatusStateOk, sr.Cilium.State,
+		"expected OK state when Loader is nil")
+}
+
+// TestDatapathReadiness_TimeoutFallback verifies that once DatapathReadyTimeout
+// elapses, GetStatus reports OK even if the datapath channel is still open.
+// This prevents permanent node deadlock if BPF programs never load.
+func TestDatapathReadiness_TimeoutFallback(t *testing.T) {
+	loader := newTestLoader() // channel never closed
+
+	logger := hivetest.Logger(t)
+	config := Config{
+		StatusCollectorWarningThreshold:  15 * time.Second,
+		StatusCollectorFailureThreshold:  1 * time.Minute,
+		StatusCollectorInterval:          5 * time.Second,
+		StatusCollectorProbeCheckTimeout: 5 * time.Minute,
+		StatusCollectorStackdumpPath:     "",
+		DatapathReadyTimeout:             1 * time.Nanosecond, // instant timeout
+	}
+	fakeClientset, _ := k8sClientTestutils.NewFakeClientset(logger)
+	fakeClientset.Disable()
+
+	collector := &statusCollector{
+		statusCollector:      newCollector(logger, config),
+		allProbesInitialized: true,
+		startTime:            time.Now().Add(-2 * time.Second), // well in the past
+		statusParams: statusParams{
+			Logger:    logger,
+			Config:    config,
+			Clientset: fakeClientset,
+			Loader:    loader,
+		},
+	}
+
+	sr := collector.GetStatus(true, false, true)
+
+	require.NotNil(t, sr.Cilium, "expected Cilium status to be set")
+	assert.Equal(t, models.StatusStateOk, sr.Cilium.State,
+		"expected OK state after DatapathReadyTimeout elapsed")
+}


### PR DESCRIPTION
## Summary

Gate the Cilium agent's readiness probe on eBPF host datapath initialization, and add configurable probes to the operator deployment. These changes work together to fix the ~5-15s window where pods get scheduled on nodes without a working datapath.

- **Commit 1:** Extend `GetStatus()` with a `requireDatapathReady` parameter that checks `HostDatapathInitialized()` before reporting ready. Includes a 120s timeout fallback to prevent permanent node deadlock.
- **Commit 2:** Wire the new gate as a Helm value `readinessProbe.requireDatapathReady` (default `false`) passed as an HTTP header on the readiness probe, following the `require-k8s-connectivity` pattern.
- **Commit 3:** Add `startupProbe` and configurable `livenessProbe`/`readinessProbe` to the operator deployment. The operator had hardcoded `initialDelaySeconds: 60` while the agent and envoy templates already support configurable probes. In ENI mode replacing VPC-CNI on resource-constrained nodes, the operator needs ~87s to initialize — the hardcoded 90s window causes CrashLoopBackOff, especially when the datapath gate correctly extends the agent startup timeline.

## Root Cause

Traced in detail in #29405 (comment from 2026-06-18):

1. Operator removes `node.cilium.io/agent-not-ready` taint based on agent pod readiness (`operator/watchers/node_taint.go:211`)
2. Agent readiness = `/healthz` probe (`daemon/healthz/agenthealth.go:155` → `GetStatus(brief=true)`)
3. Brief mode only checks CNI file presence (`pkg/status/status_collector.go:603-648`) — **not datapath state**
4. In ENI mode, CNI config file is written well before BPF programs load
5. Pods scheduled in the gap have no working datapath → DNS timeouts, API failures, persistent CrashLoopBackOff

PR #32168 added a gate on CNI config file write (present in v1.19+), but in ENI mode the file appears early — the gate has no effect.

## Design

**Signal:** `HostDatapathInitialized()` — a channel closed when host BPF programs (`bpf_host`, `bpf_lxc`) finish loading (`pkg/datapath/loader/endpoint.go`). This is the precise event that marks the datapath functional. No connectivity probes (too slow, can false-negative).

**Deadlock prevention:** 120s timeout (`--datapath-ready-timeout`). If BPF programs never load, the agent reports ready anyway with a warning log. Prevents permanent node deadlock (taint never removed = no pods = cluster dead).

**Backward compatibility:** `readinessProbe.requireDatapathReady` defaults to `false`. Zero impact on existing deployments. Only the readiness probe carries the header (not liveness, not startup).

**Operator probes:** `startupProbe` (30×10s = 300s max) handles slow initialization; `livenessProbe` (no `initialDelaySeconds`) provides fast crash detection post-startup. All three probes configurable from `values.yaml`, consistent with the agent DaemonSet pattern.

## Validation

Tested on EKS 1.34, Cilium 1.19.4, ENI mode, Karpenter (spot + on-demand). 9 node rotations across 4 instance types:

### With gate (`requireDatapathReady: true`)

| Node | Instance | Node→Cilium Ready | Cilium Restarts | Pod Restarts | DNS Errors |
|------|----------|-------------------|-----------------|--------------|------------|
| ip-10-111-2-69 | m8i.large | 38s | 0 | 0 | 0 |
| ip-10-111-0-249 | m8i.large | 39s | 0 | 0 | 0 |
| ip-10-111-2-190 | c5a.xlarge | 37s | 0 | 0 | 0 |
| ip-10-111-1-154 | r8a.medium | 37s | 0 | 0 | 0 |
| ip-10-111-1-114 | r8a.medium | 37s | 0 | 0 | 0 |

### Without gate (stock Cilium v1.19.4 — baseline)

| Node | Instance | Node→Cilium Ready | Cilium Restarts | Pod Restarts | DNS Errors |
|------|----------|-------------------|-----------------|--------------|------------|
| ip-10-111-0-149 | r8a.medium | 40s | 0 | 0 | 0 |
| ip-10-111-0-158 | r8a.medium | 40s | 0 | 5 ⚠ | 0 |
| ip-10-111-1-54 | c7i-flex.xlarge | 38s | 0 | 0 | 0 |
| ip-10-111-2-189 | m8i.large | 38s | 0 | 0 | 0 |

**Zero measurable overhead** (avg 37.6s vs 39.0s — within noise). Gate holds taint ~9s after node Ready until BPF programs load, then releases. Timeline from polling:

```
Node created by Karpenter
Node NotReady, taints=[ebs+cilium+not-ready]
Node Ready, Cilium pending (BPF NOT loaded)          ← GATE HOLDING
Cilium agent container started
Cilium ready=true (BPF loaded)                       ← GATE RELEASED
agent-not-ready taint removed by operator
All taints clear, pods scheduled with working datapath
```

## Related

Fixes: #29405

Design proposal: https://github.com/cilium/cilium/discussions/46639

Compounding issues in 1.19.x that widen the failure window:
- #46010 — Host networking breaks during BPF init (regression)
- #44268 — `unmanagedPodWatcher` broken (Helm renders `intervalSeconds` as string)
- #40273 — `eks-pod-identity-agent` broken in ENI + KPR mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)