### PR TITLE
.github: Generate CI binaries with correct module version

### DIFF
--- a/.github/workflows/build-images-ci-v1.17.yaml
+++ b/.github/workflows/build-images-ci-v1.17.yaml
@@ -174,6 +174,7 @@ jobs:
           echo normal_tag=${normal_tag} >> $GITHUB_OUTPUT
           echo race_tag=${race_tag} >> $GITHUB_OUTPUT
           echo unstripped_tag=${unstripped_tag} >> $GITHUB_OUTPUT
+          echo parent_tag="$(cat VERSION)" >> $GITHUB_OUTPUT
 
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.
@@ -243,6 +244,18 @@ jobs:
              [[ -d "${{ matrix.require-dir }}" ]]; then
             echo build="true" >> $GITHUB_OUTPUT
           fi
+
+      - name: Tag local module version
+        id: create-local-tag
+        env:
+          PARENT: ${{ steps.tag.outputs.parent_tag }}
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "github-actions@users.noreply.github.com"
+          REV="$(git show -s --date=format:'%Y%m%d%H%M%S' --format='%cd-%h')"
+          LOCAL_TAG="v$PARENT+$REV"
+          git tag -m "$LOCAL_TAG" --no-sign "$LOCAL_TAG" HEAD
+          git log -1 "$LOCAL_TAG"
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2

--- a/.github/workflows/build-images-ci-v1.18.yaml
+++ b/.github/workflows/build-images-ci-v1.18.yaml
@@ -187,6 +187,7 @@ jobs:
           echo normal_tag=${normal_tag} >> $GITHUB_OUTPUT
           echo race_tag=${race_tag} >> $GITHUB_OUTPUT
           echo unstripped_tag=${unstripped_tag} >> $GITHUB_OUTPUT
+          echo parent_tag="$(cat VERSION)" >> $GITHUB_OUTPUT
 
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.
@@ -256,6 +257,18 @@ jobs:
              [[ -d "${{ matrix.require-dir }}" ]]; then
             echo build="true" >> $GITHUB_OUTPUT
           fi
+
+      - name: Tag local module version
+        id: create-local-tag
+        env:
+          PARENT: ${{ steps.tag.outputs.parent_tag }}
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "github-actions@users.noreply.github.com"
+          REV="$(git show -s --date=format:'%Y%m%d%H%M%S' --format='%cd-%h')"
+          LOCAL_TAG="v$PARENT+$REV"
+          git tag -m "$LOCAL_TAG" --no-sign "$LOCAL_TAG" HEAD
+          git log -1 "$LOCAL_TAG"
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2

--- a/.github/workflows/build-images-ci-v1.19.yaml
+++ b/.github/workflows/build-images-ci-v1.19.yaml
@@ -187,6 +187,7 @@ jobs:
           echo normal_tag=${normal_tag} >> $GITHUB_OUTPUT
           echo race_tag=${race_tag} >> $GITHUB_OUTPUT
           echo unstripped_tag=${unstripped_tag} >> $GITHUB_OUTPUT
+          echo parent_tag="$(cat VERSION)" >> $GITHUB_OUTPUT
 
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.
@@ -256,6 +257,18 @@ jobs:
              [[ -d "${{ matrix.require-dir }}" ]]; then
             echo build="true" >> $GITHUB_OUTPUT
           fi
+
+      - name: Tag local module version
+        id: create-local-tag
+        env:
+          PARENT: ${{ steps.tag.outputs.parent_tag }}
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "github-actions@users.noreply.github.com"
+          REV="$(git show -s --date=format:'%Y%m%d%H%M%S' --format='%cd-%h')"
+          LOCAL_TAG="v$PARENT+$REV"
+          git tag -m "$LOCAL_TAG" --no-sign "$LOCAL_TAG" HEAD
+          git log -1 "$LOCAL_TAG"
 
       - name: CI Build ${{ matrix.name }}
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -191,6 +191,7 @@ jobs:
           echo normal_tag=${normal_tag} >> $GITHUB_OUTPUT
           echo race_tag=${race_tag} >> $GITHUB_OUTPUT
           echo unstripped_tag=${unstripped_tag} >> $GITHUB_OUTPUT
+          echo parent_tag="$(cat VERSION)" >> $GITHUB_OUTPUT
 
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.
@@ -260,6 +261,18 @@ jobs:
              [[ -d "${{ matrix.require-dir }}" ]]; then
             echo build="true" >> $GITHUB_OUTPUT
           fi
+
+      - name: Tag local module version
+        id: create-local-tag
+        env:
+          PARENT: ${{ steps.tag.outputs.parent_tag }}
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "github-actions@users.noreply.github.com"
+          REV="$(git show -s --date=format:'%Y%m%d%H%M%S' --format='%cd-%h')"
+          LOCAL_TAG="v$PARENT+$REV"
+          git tag -m "$LOCAL_TAG" --no-sign "$LOCAL_TAG" HEAD
+          git log -1 "$LOCAL_TAG"
 
       - name: CI Build ${{ matrix.name }}
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0


### PR DESCRIPTION
Recently, if you ran 'go version -m path/to/cilium/binary' on a binary
built via the CI jobs, it would report a version number similar to this:

```ShellSession
$ go version -m cilium-dbg | grep 'mod.*cilium'
  mod  github.com/cilium/cilium  v0.0.0-20260625164308-6d1c0fa621de
```

Note that the Go module version here has a v0.0.0 version, but this
version is based on 'main' where the recent release was v1.20.0-pre.3.

By adding a local tag based on the VERSION file, we can ensure that the
Go module version makes sense:

```ShellSession
$ go version -m cilium-dbg | grep 'mod.*cilium'
  mod  github.com/cilium/cilium  v1.20.0-pre.3.0.20260624181112-a5040d689371
```

AIL:0
