### PR TITLE
fix: IPv6 tunnel MTU overhead detection under native routing with IPv6  Egress Gateway

### DIFF
--- a/pkg/mtu/cell.go
+++ b/pkg/mtu/cell.go
@@ -131,7 +131,7 @@ func newForCell(lc cell.Lifecycle, p mtuParams, cc Config) (MTU, error) {
 	c := &Configuration{}
 	lc.Append(cell.Hook{
 		OnStart: func(ctx cell.HookContext) error {
-			tunnelOverIPv6 := option.Config.TunnelingEnabled() &&
+			tunnelOverIPv6 := p.TunnelConfig.EncapProtocol() != tunnel.Disabled &&
 				p.TunnelConfig.UnderlayProtocol() == tunnel.IPv6
 			*c = NewConfiguration(
 				p.IPsec.AuthKeySize(),


### PR DESCRIPTION
when routing-mode=native && enable-egress-gateway=true && enable-ipv6=true && enable-ipv4=false, Egress Gateway triggers dynamic tunnel creation, and require 70-byte IPv6 tunnel overhead deduction. 
But legacy code config.go returns  false  under native routing.

In result, MTU calculation deducts only 50-byte IPv4 tunnel overhead. Calculated MTU is overestimated by 20 bytes. 

<!-- Description of change -->


```release-note
IPv6 tunnel MTU overhead detection under native routing with IPv6  Egress Gateway
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
