### PR TITLE
ipam: defer static IP readiness check until local node update

### DIFF
--- a/pkg/ipam/eni.go
+++ b/pkg/ipam/eni.go
@@ -723,6 +723,7 @@ func newENIMultiPoolAllocators(p ENIMultiPoolAllocatorParams) (Allocator, Alloca
 
 	// Wait for local node to be updated to avoid propagating spurious updates.
 	waitForLocalNodeUpdate(p.Logger, mgr)
+	mgr.waitForStaticIP()
 	// Independently wait for the alloc-CIDR and native-routing-CIDR observers:
 	// they run in separate jobs from the multi-pool manager and are not
 	// synchronized with mgr.localNodeUpdated().

--- a/pkg/ipam/multipool.go
+++ b/pkg/ipam/multipool.go
@@ -93,6 +93,7 @@ func newMultiPoolAllocators(p MultiPoolAllocatorParams) (Allocator, Allocator) {
 
 	// wait for local node to be updated to avoid propagating spurious updates.
 	waitForLocalNodeUpdate(p.Logger, mgr)
+	mgr.waitForStaticIP()
 	// Independently wait for the alloc-CIDR observer: it runs in its own job
 	// and is not synchronized with mgr.localNodeUpdated().
 	waitForLocalNodeAllocCIDRs(p.Logger, allocCIDRsReady)

--- a/pkg/ipam/multipool_manager.go
+++ b/pkg/ipam/multipool_manager.go
@@ -354,7 +354,6 @@ func newMultiPoolManager(p MultiPoolManagerParams) *multiPoolManager {
 	)
 
 	mgr.waitForAllPools()
-	mgr.waitForStaticIP()
 
 	return mgr
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:


newMultiPoolManager  registers informer listener and calls  waitForStaticIP .

```
func newMultiPoolManager(){
      mgr := &multiPoolManager{...}
      mgr.jobGroup.Add(
         ...
          for ev := range p.Node.Events(ctx) <------ listen
      )
      mgr.waitForStaticIP()

}
```

Due to event distribution latency, local cache  mgr.node  can be  nil  at this time.  This causes  waitForStaticIP  to return early, bypassing PR design

```
func (m *multiPoolManager) waitForStaticIP() {
      for {
            requested, assigned := m.staticIPStatus()    
            if !requested || assigned != "" {      <----- return early
                  return             
            }
            .. wait
     }
}
```

Invoking  waitForStaticIP  after  waitForLocalNodeUpdate()  ensures informer completed initial sync, 
so  mgr.node  is non-nil and contains latest static IP tags. This achieves intended behavior.
 

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
