### PR TITLE
network driver: fix deadlock in ipam cell

### DIFF
--- a/operator/pkg/networkdriver/ipam/ipam.go
+++ b/operator/pkg/networkdriver/ipam/ipam.go
@@ -125,8 +125,22 @@ func registerAllocator(p AllocatorParams) {
 					job.OneShot(
 						"network-driver-initial-resync",
 						func(ctx context.Context, health cell.Health) error {
-							<-poolSynced
-							<-nodeSynced
+							// poolSynced and nodeSynced are closed by the
+							// pool/node handler jobs above on resource.Sync.
+							// On shutdown those event loops exit via context
+							// cancellation and may never close their channel,
+							// so we must also observe ctx.Done() here to avoid
+							// blocking Hive.Stop indefinitely.
+							select {
+							case <-poolSynced:
+							case <-ctx.Done():
+								return nil
+							}
+							select {
+							case <-nodeSynced:
+							case <-ctx.Done():
+								return nil
+							}
 							nodeHandler.Resync(ctx, time.Time{})
 							return nil
 						},


### PR DESCRIPTION
fixing a racy deadlock due to a rare race
condition on early exit

this commit attempts to catch the context cancellation at both sync steps and handle early exits
properly

```release-note
network driver: fix deadlock in ipam operator cell
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail AIL 3
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
