### PR TITLE
aws/ipam: retry prefix ENI in eligible sibling subnets before /32 fal…

### DIFF
--- a/pkg/aws/api/mock/mock.go
+++ b/pkg/aws/api/mock/mock.go
@@ -51,21 +51,22 @@ const (
 
 // API represents a mocked EC2 API
 type API struct {
-	mutex          lock.RWMutex
-	unattached     map[string]*types.ENI
-	enis           map[string]ENIMap
-	subnets        map[string]*ipamTypes.Subnet
-	vpcs           map[string]*ipamTypes.VirtualNetwork
-	routeTables    map[string]*ipamTypes.RouteTable
-	securityGroups map[string]*types.SecurityGroup
-	instanceTypes  []ec2_types.InstanceTypeInfo
-	errors         map[Operation]error
-	allocator      *ipallocator.Range
-	pdAllocator    *cidrset.CidrSet
-	ipv6Allocator  *cidrset.CidrSet
-	limiter        *rate.Limiter
-	delaySim       *helpers.DelaySimulator
-	pdSubnet       netip.Prefix
+	mutex                   lock.RWMutex
+	unattached              map[string]*types.ENI
+	enis                    map[string]ENIMap
+	subnets                 map[string]*ipamTypes.Subnet
+	vpcs                    map[string]*ipamTypes.VirtualNetwork
+	routeTables             map[string]*ipamTypes.RouteTable
+	securityGroups          map[string]*types.SecurityGroup
+	instanceTypes           []ec2_types.InstanceTypeInfo
+	errors                  map[Operation]error
+	allocator               *ipallocator.Range
+	pdAllocator             *cidrset.CidrSet
+	ipv6Allocator           *cidrset.CidrSet
+	limiter                 *rate.Limiter
+	delaySim                *helpers.DelaySimulator
+	pdSubnet                netip.Prefix
+	subnetsAtPrefixCapacity map[string]bool
 }
 
 // NewAPI returns a new mocked EC2 API
@@ -176,19 +177,20 @@ func NewAPI(subnets []*ipamTypes.Subnet, vpcs []*ipamTypes.VirtualNetwork, secur
 	}
 
 	api := &API{
-		unattached:     map[string]*types.ENI{},
-		enis:           map[string]ENIMap{},
-		subnets:        map[string]*ipamTypes.Subnet{},
-		vpcs:           map[string]*ipamTypes.VirtualNetwork{},
-		routeTables:    map[string]*ipamTypes.RouteTable{},
-		securityGroups: map[string]*types.SecurityGroup{},
-		instanceTypes:  []ec2_types.InstanceTypeInfo{},
-		allocator:      podCidrRange,
-		pdAllocator:    pdCidrRange,
-		ipv6Allocator:  ipv6CidrRange,
-		errors:         map[Operation]error{},
-		delaySim:       helpers.NewDelaySimulator(),
-		pdSubnet:       pdCidr,
+		unattached:              map[string]*types.ENI{},
+		enis:                    map[string]ENIMap{},
+		subnets:                 map[string]*ipamTypes.Subnet{},
+		vpcs:                    map[string]*ipamTypes.VirtualNetwork{},
+		routeTables:             map[string]*ipamTypes.RouteTable{},
+		securityGroups:          map[string]*types.SecurityGroup{},
+		instanceTypes:           []ec2_types.InstanceTypeInfo{},
+		allocator:               podCidrRange,
+		pdAllocator:             pdCidrRange,
+		ipv6Allocator:           ipv6CidrRange,
+		errors:                  map[Operation]error{},
+		delaySim:                helpers.NewDelaySimulator(),
+		pdSubnet:                pdCidr,
+		subnetsAtPrefixCapacity: map[string]bool{},
 	}
 
 	api.UpdateSubnets(subnets)
@@ -258,6 +260,14 @@ func (e *API) SetMockError(op Operation, err error) {
 	defer e.mutex.Unlock()
 	e.errors[op] = err
 
+}
+
+// SetSubnetAtPrefixCapacity marks a subnet as out of free /28 prefix blocks
+// while leaving its free /32 address count (AvailableAddresses) untouched.
+func (e *API) SetSubnetAtPrefixCapacity(subnetID string, atCapacity bool) {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+	e.subnetsAtPrefixCapacity[subnetID] = atCapacity
 }
 
 // SetDelay specifies the delay which should be simulated for an individual EC2
@@ -546,6 +556,13 @@ func assignPrefixToENI(e *API, eni *types.ENI, prefixes int32) error {
 	subnet, ok := e.subnets[eni.Subnet.ID]
 	if !ok {
 		return fmt.Errorf("subnet %s not found", eni.Subnet.ID)
+	}
+
+	if e.subnetsAtPrefixCapacity[eni.Subnet.ID] {
+		return &smithy.GenericAPIError{
+			Code:    api.InvalidParameterValueStr,
+			Message: api.SubnetFullErrMsgStr,
+		}
 	}
 
 	if int(prefixes)*option.ENIPDBlockSizeIPv4 > subnet.AvailableAddresses {

--- a/pkg/aws/ipam/instances.go
+++ b/pkg/aws/ipam/instances.go
@@ -151,47 +151,40 @@ func (m *InstancesManager) GetSubnets(ctx context.Context) ipamTypes.SubnetMap {
 	return subnetsCopy
 }
 
-// FindSubnetByIDs returns the subnet with the most addresses matching VPC ID,
-// availability zone within a provided list of subnet ids
-//
-// The returned subnet is immutable so it can be safely accessed
-func (m *InstancesManager) FindSubnetByIDs(vpcID, availabilityZone string, subnetIDs []string) (bestSubnet *ipamTypes.Subnet) {
+// FindSubnetByIDsSorted returns all subnets matching VPC ID, availability zone
+// and subnet IDs, sorted by AvailableAddresses descending
+func (m *InstancesManager) FindSubnetByIDsSorted(vpcID, availabilityZone string, subnetIDs []string) []*ipamTypes.Subnet {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
-
+	var result []*ipamTypes.Subnet
 	for _, s := range m.subnets {
 		if s.VirtualNetworkID == vpcID && s.AvailabilityZone == availabilityZone {
-			for _, subnetID := range subnetIDs {
-				if s.ID == subnetID {
-					if bestSubnet == nil || bestSubnet.AvailableAddresses < s.AvailableAddresses {
-						bestSubnet = s
-					}
-					continue
-				}
+			if slices.Contains(subnetIDs, s.ID) {
+				result = append(result, s)
 			}
 		}
 	}
-
-	return
+	slices.SortFunc(result, func(a, b *ipamTypes.Subnet) int {
+		return b.AvailableAddresses - a.AvailableAddresses
+	})
+	return result
 }
 
-// FindSubnetByTags returns the subnet with the most addresses matching VPC ID,
-// availability zone and all required tags
-//
-// The returned subnet is immutable so it can be safely accessed
-func (m *InstancesManager) FindSubnetByTags(vpcID, availabilityZone string, required ipamTypes.Tags) (bestSubnet *ipamTypes.Subnet) {
+// FindSubnetByTagsSorted returns all subnets matching VPC ID, availability zone
+// and all required tags, sorted by AvailableAddresses descending.
+func (m *InstancesManager) FindSubnetByTagsSorted(vpcID, availabilityZone string, required ipamTypes.Tags) []*ipamTypes.Subnet {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
-
+	var result []*ipamTypes.Subnet
 	for _, s := range m.subnets {
 		if s.VirtualNetworkID == vpcID && s.AvailabilityZone == availabilityZone && s.Tags.Match(required) {
-			if bestSubnet == nil || bestSubnet.AvailableAddresses < s.AvailableAddresses {
-				bestSubnet = s
-			}
+			result = append(result, s)
 		}
 	}
-
-	return
+	slices.SortFunc(result, func(a, b *ipamTypes.Subnet) int {
+		return b.AvailableAddresses - a.AvailableAddresses
+	})
+	return result
 }
 
 // FindSecurityGroupByTags returns the security groups matching VPC ID and all required tags

--- a/pkg/aws/ipam/instances.go
+++ b/pkg/aws/ipam/instances.go
@@ -194,6 +194,42 @@ func (m *InstancesManager) FindSubnetByTags(vpcID, availabilityZone string, requ
 	return
 }
 
+// FindSubnetByIDsSorted returns all subnets matching VPC ID, availability zone
+// and subnet IDs, sorted by AvailableAddresses descending
+func (m *InstancesManager) FindSubnetByIDsSorted(vpcID, availabilityZone string, subnetIDs []string) []*ipamTypes.Subnet {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	var result []*ipamTypes.Subnet
+	for _, s := range m.subnets {
+		if s.VirtualNetworkID == vpcID && s.AvailabilityZone == availabilityZone {
+			if slices.Contains(subnetIDs, s.ID) {
+				result = append(result, s)
+			}
+		}
+	}
+	slices.SortFunc(result, func(a, b *ipamTypes.Subnet) int {
+		return b.AvailableAddresses - a.AvailableAddresses
+	})
+	return result
+}
+
+// FindSubnetByTagsSorted returns all subnets matching VPC ID, availability zone
+// and all required tags, sorted by AvailableAddresses descending.
+func (m *InstancesManager) FindSubnetByTagsSorted(vpcID, availabilityZone string, required ipamTypes.Tags) []*ipamTypes.Subnet {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	var result []*ipamTypes.Subnet
+	for _, s := range m.subnets {
+		if s.VirtualNetworkID == vpcID && s.AvailabilityZone == availabilityZone && s.Tags.Match(required) {
+			result = append(result, s)
+		}
+	}
+	slices.SortFunc(result, func(a, b *ipamTypes.Subnet) int {
+		return b.AvailableAddresses - a.AvailableAddresses
+	})
+	return result
+}
+
 // FindSecurityGroupByTags returns the security groups matching VPC ID and all required tags
 //
 // The returned security groups slice is immutable so it can be safely accessed

--- a/pkg/aws/ipam/instances.go
+++ b/pkg/aws/ipam/instances.go
@@ -151,49 +151,6 @@ func (m *InstancesManager) GetSubnets(ctx context.Context) ipamTypes.SubnetMap {
 	return subnetsCopy
 }
 
-// FindSubnetByIDs returns the subnet with the most addresses matching VPC ID,
-// availability zone within a provided list of subnet ids
-//
-// The returned subnet is immutable so it can be safely accessed
-func (m *InstancesManager) FindSubnetByIDs(vpcID, availabilityZone string, subnetIDs []string) (bestSubnet *ipamTypes.Subnet) {
-	m.mutex.RLock()
-	defer m.mutex.RUnlock()
-
-	for _, s := range m.subnets {
-		if s.VirtualNetworkID == vpcID && s.AvailabilityZone == availabilityZone {
-			for _, subnetID := range subnetIDs {
-				if s.ID == subnetID {
-					if bestSubnet == nil || bestSubnet.AvailableAddresses < s.AvailableAddresses {
-						bestSubnet = s
-					}
-					continue
-				}
-			}
-		}
-	}
-
-	return
-}
-
-// FindSubnetByTags returns the subnet with the most addresses matching VPC ID,
-// availability zone and all required tags
-//
-// The returned subnet is immutable so it can be safely accessed
-func (m *InstancesManager) FindSubnetByTags(vpcID, availabilityZone string, required ipamTypes.Tags) (bestSubnet *ipamTypes.Subnet) {
-	m.mutex.RLock()
-	defer m.mutex.RUnlock()
-
-	for _, s := range m.subnets {
-		if s.VirtualNetworkID == vpcID && s.AvailabilityZone == availabilityZone && s.Tags.Match(required) {
-			if bestSubnet == nil || bestSubnet.AvailableAddresses < s.AvailableAddresses {
-				bestSubnet = s
-			}
-		}
-	}
-
-	return
-}
-
 // FindSubnetByIDsSorted returns all subnets matching VPC ID, availability zone
 // and subnet IDs, sorted by AvailableAddresses descending
 func (m *InstancesManager) FindSubnetByIDsSorted(vpcID, availabilityZone string, subnetIDs []string) []*ipamTypes.Subnet {

--- a/pkg/aws/ipam/instances_test.go
+++ b/pkg/aws/ipam/instances_test.go
@@ -247,7 +247,7 @@ func TestGetSubnet(t *testing.T) {
 	require.Equal(t, "subnet-3", subnet3.ID)
 }
 
-func TestFindSubnetByIDs(t *testing.T) {
+func TestFindSubnetByIDsSorted(t *testing.T) {
 	api := apiMock.NewAPI(subnets2, vpcs, securityGroups, routeTables)
 	require.NotNil(t, api)
 	metadataMockapi, _ := metadataMock.NewMetadataMock()
@@ -259,35 +259,35 @@ func TestFindSubnetByIDs(t *testing.T) {
 	iteration2(t, api, mngr)
 
 	// exact match subnet-1
-	s := mngr.FindSubnetByIDs("vpc-1", "us-west-1", []string{"subnet-1"})
-	require.Equal(t, "subnet-1", s.ID)
+	s := mngr.FindSubnetByIDsSorted("vpc-1", "us-west-1", []string{"subnet-1"})
+	require.Equal(t, "subnet-1", s[0].ID)
 
 	// exact match subnet-2
-	s = mngr.FindSubnetByIDs("vpc-2", "us-east-1", []string{"subnet-2"})
-	require.Equal(t, "subnet-2", s.ID)
+	s = mngr.FindSubnetByIDsSorted("vpc-2", "us-east-1", []string{"subnet-2"})
+	require.Equal(t, "subnet-2", s[0].ID)
 
 	// exact match subnet-3
-	s = mngr.FindSubnetByIDs("vpc-1", "us-west-1", []string{"subnet-3"})
-	require.Equal(t, "subnet-3", s.ID)
+	s = mngr.FindSubnetByIDsSorted("vpc-1", "us-west-1", []string{"subnet-3"})
+	require.Equal(t, "subnet-3", s[0].ID)
 
-	// empty list shall return nil
-	require.Nil(t, mngr.FindSubnetByIDs("vpc-1", "us-west-1", []string{}))
+	// empty list shall return empty slice
+	require.Empty(t, mngr.FindSubnetByIDsSorted("vpc-1", "us-west-1", []string{}))
 
 	// all subnet match, subnet-1 has more addresses
-	s = mngr.FindSubnetByIDs("vpc-1", "us-west-1", []string{"subnet-1", "subnet-3"})
-	require.Equal(t, "subnet-1", s.ID)
+	s = mngr.FindSubnetByIDsSorted("vpc-1", "us-west-1", []string{"subnet-1", "subnet-3"})
+	require.Equal(t, "subnet-1", s[0].ID)
 
 	// invalid vpc, no match
-	require.Nil(t, mngr.FindSubnetByIDs("vpc-unknown", "us-west-1", []string{"subnet-1"}))
+	require.Empty(t, mngr.FindSubnetByIDsSorted("vpc-unknown", "us-west-1", []string{"subnet-1"}))
 
 	// invalid AZ, no match
-	require.Nil(t, mngr.FindSubnetByIDs("vpc-1", "us-west-unknown", []string{"subnet-1"}))
+	require.Empty(t, mngr.FindSubnetByIDsSorted("vpc-1", "us-west-unknown", []string{"subnet-1"}))
 
 	// invalid ids, no match
-	require.Nil(t, mngr.FindSubnetByIDs("vpc-1", "us-west-1", []string{"subnet-unknown"}))
+	require.Empty(t, mngr.FindSubnetByIDsSorted("vpc-1", "us-west-1", []string{"subnet-unknown"}))
 }
 
-func TestFindSubnetByTags(t *testing.T) {
+func TestFindSubnetByTagsSorted(t *testing.T) {
 	api := apiMock.NewAPI(subnets, vpcs, securityGroups, routeTables)
 	require.NotNil(t, api)
 	metadataMockapi, _ := metadataMock.NewMetadataMock()
@@ -299,29 +299,29 @@ func TestFindSubnetByTags(t *testing.T) {
 	iteration2(t, api, mngr)
 
 	// exact match subnet-1
-	s := mngr.FindSubnetByTags("vpc-1", "us-west-1", ipamTypes.Tags{"tag1": "tag1"})
-	require.Equal(t, "subnet-1", s.ID)
+	s := mngr.FindSubnetByTagsSorted("vpc-1", "us-west-1", ipamTypes.Tags{"tag1": "tag1"})
+	require.Equal(t, "subnet-1", s[0].ID)
 
 	// exact match subnet-2
-	s = mngr.FindSubnetByTags("vpc-2", "us-east-1", ipamTypes.Tags{"tag1": "tag1"})
-	require.Equal(t, "subnet-2", s.ID)
+	s = mngr.FindSubnetByTagsSorted("vpc-2", "us-east-1", ipamTypes.Tags{"tag1": "tag1"})
+	require.Equal(t, "subnet-2", s[0].ID)
 
 	// exact match subnet-3
-	s = mngr.FindSubnetByTags("vpc-1", "us-west-1", ipamTypes.Tags{"tag2": "tag2"})
-	require.Equal(t, "subnet-3", s.ID)
+	s = mngr.FindSubnetByTagsSorted("vpc-1", "us-west-1", ipamTypes.Tags{"tag2": "tag2"})
+	require.Equal(t, "subnet-3", s[0].ID)
 
 	// both subnet-1 and subnet-3 match, subnet-1 has more addresses
-	s = mngr.FindSubnetByTags("vpc-1", "us-west-1", ipamTypes.Tags{})
-	require.Equal(t, "subnet-1", s.ID)
+	s = mngr.FindSubnetByTagsSorted("vpc-1", "us-west-1", ipamTypes.Tags{})
+	require.Equal(t, "subnet-1", s[0].ID)
 
 	// invalid vpc, no match
-	require.Nil(t, mngr.FindSubnetByTags("vpc-unknown", "us-west-1", ipamTypes.Tags{"tag1": "tag1"}))
+	require.Empty(t, mngr.FindSubnetByTagsSorted("vpc-unknown", "us-west-1", ipamTypes.Tags{"tag1": "tag1"}))
 
 	// invalid AZ, no match
-	require.Nil(t, mngr.FindSubnetByTags("vpc-1", "us-west-unknown", ipamTypes.Tags{"tag1": "tag1"}))
+	require.Empty(t, mngr.FindSubnetByTagsSorted("vpc-1", "us-west-unknown", ipamTypes.Tags{"tag1": "tag1"}))
 
 	// invalid tags, no match
-	require.Nil(t, mngr.FindSubnetByTags("vpc-1", "us-west-1", ipamTypes.Tags{"tag1": "tag1", "tag2": "tag2"}))
+	require.Empty(t, mngr.FindSubnetByTagsSorted("vpc-1", "us-west-1", ipamTypes.Tags{"tag1": "tag1", "tag2": "tag2"}))
 }
 
 func TestGetSecurityGroupByTags(t *testing.T) {

--- a/pkg/aws/ipam/node.go
+++ b/pkg/aws/ipam/node.go
@@ -715,8 +715,8 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *nodemanager.Allo
 	isPrefixDelegated := n.node.Ops().IsPrefixDelegated()
 	n.mutex.RUnlock()
 
-	subnet := n.findSuitableSubnet(resource.Spec.ENI, limits)
-	if subnet == nil {
+	subnets := n.findSuitableSubnet(resource.Spec.ENI, limits)
+	if len(subnets) == 0 {
 		return 0,
 			unableToFindSubnet,
 			fmt.Errorf(
@@ -727,6 +727,7 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *nodemanager.Allo
 				resource.Spec.ENI.SubnetTags,
 			)
 	}
+	subnet := subnets[0]
 	allocation.PoolID = ipamTypes.PoolID(subnet.ID)
 
 	securityGroupIDs, err := n.getSecurityGroupIDs(ctx, resource.Spec.ENI)
@@ -769,18 +770,39 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *nodemanager.Allo
 	scopedLog.Info("No more IPs available, creating new ENI")
 
 	eniID, eni, err := n.manager.ec2api.CreateNetworkInterface(ctx, int32(toAllocate), subnet.ID, desc, securityGroupIDs, isPrefixDelegated, allocateIPv6)
+
 	if err != nil {
 		if isPrefixDelegated && isSubnetAtPrefixCapacity(err) {
-			// Subnet might be out of available /28 prefixes, but /32 IP addresses might be available.
-			// We should attempt to allocate /32 IPs.
-			scopedLog.Warn(
-				"Subnet might be out of prefixes, Cilium will not allocate prefixes on this node anymore",
-				logfields.Node, n.k8sObj.Name,
-			)
-			eniID, eni, err = n.manager.ec2api.CreateNetworkInterface(ctx, int32(toAllocate), subnet.ID, desc, securityGroupIDs, false, allocateIPv6)
-		}
-		if err != nil {
-			return 0, unableToCreateENI, fmt.Errorf("%s: %w", errUnableToCreateENI, err)
+			// Subnet might be out of available /28 prefixes. Before falling back to
+			// /32 IPs in the same subnet, try other eligible subnets in the same AZ
+			// that may have free /28 capacity.
+			for _, siblingSubnet := range subnets[1:] {
+				scopedLog.Info("Retrying prefix ENI creation in sibling subnet", logfields.SubnetID, siblingSubnet.ID)
+				eniID, eni, err = n.manager.ec2api.CreateNetworkInterface(ctx, int32(toAllocate), siblingSubnet.ID, desc, securityGroupIDs, true, allocateIPv6)
+				if err == nil {
+					allocation.PoolID = ipamTypes.PoolID(siblingSubnet.ID)
+					subnet = siblingSubnet
+					break
+				}
+			}
+
+			if err != nil {
+				if isPrefixDelegated && isSubnetAtPrefixCapacity(err) {
+					// All eligible subnets are at prefix capacity. Fall back to /32.
+					scopedLog.Warn(
+						"Subnet might be out of prefixes, Cilium will not allocate prefixes on this node anymore",
+						logfields.Node, n.k8sObj.Name,
+					)
+					eniID, eni, err = n.manager.ec2api.CreateNetworkInterface(ctx, int32(toAllocate), subnets[0].ID, desc, securityGroupIDs, false, allocateIPv6)
+					if err == nil {
+						subnet = subnets[0]
+					}
+				}
+
+				if err != nil {
+					return 0, unableToCreateENI, fmt.Errorf("%s: %w", errUnableToCreateENI, err)
+				}
+			}
 		}
 	}
 
@@ -1117,10 +1139,9 @@ func (n *Node) getEffectiveIPLimits(eni *types.ENI, limits int) (leftoverPrefixC
 	return leftoverPrefixCapacity, effectiveLimits
 }
 
-// findSubnetInSameRouteTableWithNodeSubnet returns the subnet with the most addresses
-// that is in the same route table as the node's subnet to make sure the pod traffic
-// leaving secondary interfaces is routed in the same way as the primary interface.
-func (n *Node) findSubnetInSameRouteTableWithNodeSubnet() *ipamTypes.Subnet {
+// findSubnetInSameRouteTableWithNodeSubnetSorted returns all subnets in the
+// same route table as the node's subnet, sorted by AvailableAddresses descending
+func (n *Node) findSubnetInSameRouteTableWithNodeSubnetSorted() []*ipamTypes.Subnet {
 	n.mutex.RLock()
 	defer n.mutex.RUnlock()
 
@@ -1132,7 +1153,7 @@ func (n *Node) findSubnetInSameRouteTableWithNodeSubnet() *ipamTypes.Subnet {
 	defer n.manager.mutex.RUnlock()
 
 	nodeSubnetID := n.k8sObj.Spec.ENI.NodeSubnetID
-	var bestSubnet *ipamTypes.Subnet
+	var result []*ipamTypes.Subnet
 
 	for _, routeTable := range n.manager.routeTables {
 		if _, ok := routeTable.Subnets[nodeSubnetID]; ok && routeTable.VirtualNetworkID == n.k8sObj.Spec.ENI.VpcID {
@@ -1144,14 +1165,18 @@ func (n *Node) findSubnetInSameRouteTableWithNodeSubnet() *ipamTypes.Subnet {
 				if subnet == nil {
 					continue
 				}
-				if (bestSubnet == nil || subnet.AvailableAddresses > bestSubnet.AvailableAddresses) && subnet.AvailabilityZone == n.k8sObj.Spec.ENI.AvailabilityZone {
-					bestSubnet = subnet
+				if subnet.AvailabilityZone == n.k8sObj.Spec.ENI.AvailabilityZone {
+					result = append(result, subnet)
 				}
 			}
 		}
 	}
 
-	return bestSubnet
+	slices.SortFunc(result, func(a, b *ipamTypes.Subnet) int {
+		return b.AvailableAddresses - a.AvailableAddresses
+	})
+
+	return result
 }
 
 // checkSubnetInSameRouteTableWithNodeSubnet checks if the given subnet is in the same route table as the node's subnet
@@ -1190,48 +1215,60 @@ func (n *Node) logSubnetRouteTableMismatch(subnet *ipamTypes.Subnet, matchType s
 	)
 }
 
-// findSuitableSubnet attempts to find a subnet to allocate an ENI in according to the following heuristic.
+// findSuitableSubnet attempts to find subnets to allocate an ENI in according to the following heuristic.
 //  0. In general, the subnet has to be in the same VPC and match the availability zone of the
-//     node. If there are multiple candidates, we choose the subnet with the most addresses
+//     node. If there are multiple candidates, subnets are ordered by AvailableAddresses descending.
+//  1. If the node spec has explicit SubnetIDs set, we use those.
+//  2. If the node spec has SubnetTags set, we use those.
+//  3. We try to use the subnet the node was first created in, to avoid putting the ENI in a
+//     surprising subnet if possible.
+//  4. If we can't use the subnet first ENI in, try to use the subnet in the same route table as the node's subnet.
+//  5. If none of these work, fall back to just choosing the subnet with the most addresses
 //     available.
-//  1. If we have explicit ID or tag constraints, chose a matching subnet. ID constraints take
-//     precedence.
-//  2. If we have no explicit constraints, try to use the subnet the first ENI of the node was
-//     created in, to avoid putting the ENI in a surprising subnet if possible.
-//  3. If we can't use the subnet first ENI in, try to use the subnet in the same route table as the node's subnet.
-//  4. If none of these work, fall back to just choosing the subnet with the most addresses
-//     available.
-func (n *Node) findSuitableSubnet(spec types.ENISpec, limits ipamTypes.Limits) *ipamTypes.Subnet {
+func (n *Node) findSuitableSubnet(spec types.ENISpec, limits ipamTypes.Limits) []*ipamTypes.Subnet {
 	if len(spec.SubnetIDs) > 0 {
-		if subnet := n.manager.FindSubnetByIDs(spec.VpcID, spec.AvailabilityZone, spec.SubnetIDs); subnet != nil {
-			if !n.checkSubnetInSameRouteTableWithNodeSubnet(subnet) {
-				n.logSubnetRouteTableMismatch(subnet, "Specified")
+		subnets := n.manager.FindSubnetByIDsSorted(spec.VpcID, spec.AvailabilityZone, spec.SubnetIDs)
+
+		if len(subnets) > 0 {
+			if !n.checkSubnetInSameRouteTableWithNodeSubnet(subnets[0]) {
+				n.logSubnetRouteTableMismatch(subnets[0], "Specified")
 			}
-			return subnet
+			return subnets
 		}
 	}
 
 	if len(spec.SubnetTags) > 0 {
-		if subnet := n.manager.FindSubnetByTags(spec.VpcID, spec.AvailabilityZone, spec.SubnetTags); subnet != nil {
-			if !n.checkSubnetInSameRouteTableWithNodeSubnet(subnet) {
-				n.logSubnetRouteTableMismatch(subnet, "Tagged")
+		subnets := n.manager.FindSubnetByTagsSorted(spec.VpcID, spec.AvailabilityZone, spec.SubnetTags)
+
+		if len(subnets) > 0 {
+			if !n.checkSubnetInSameRouteTableWithNodeSubnet(subnets[0]) {
+				n.logSubnetRouteTableMismatch(subnets[0], "Tagged")
 			}
-			return subnet
+			return subnets
 		}
 	}
 
 	if subnet := n.manager.GetSubnet(spec.NodeSubnetID); subnet != nil && subnet.AvailableAddresses >= limits.IPv4 {
-		return subnet
+		// Include other subnets in the same AZ as retry candidates for PD fallback.
+		others := n.manager.FindSubnetByTagsSorted(spec.VpcID, spec.AvailabilityZone, nil)
+		result := []*ipamTypes.Subnet{subnet}
+		for _, s := range others {
+			if s.ID != subnet.ID {
+				result = append(result, s)
+			}
+		}
+		return result
 	}
 
-	if subnet := n.findSubnetInSameRouteTableWithNodeSubnet(); subnet != nil {
-		return subnet
+	if subnets := n.findSubnetInSameRouteTableWithNodeSubnetSorted(); len(subnets) > 0 {
+		return subnets
 	}
-	if subnet := n.manager.FindSubnetByTags(spec.VpcID, spec.AvailabilityZone, nil); subnet != nil {
-		if !n.checkSubnetInSameRouteTableWithNodeSubnet(subnet) {
-			n.logSubnetRouteTableMismatch(subnet, "")
+
+	if subnets := n.manager.FindSubnetByTagsSorted(spec.VpcID, spec.AvailabilityZone, nil); len(subnets) > 0 {
+		if !n.checkSubnetInSameRouteTableWithNodeSubnet(subnets[0]) {
+			n.logSubnetRouteTableMismatch(subnets[0], "")
 		}
-		return subnet
+		return subnets
 	}
 
 	return nil

--- a/pkg/aws/ipam/node.go
+++ b/pkg/aws/ipam/node.go
@@ -715,7 +715,7 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *nodemanager.Allo
 	isPrefixDelegated := n.node.Ops().IsPrefixDelegated()
 	n.mutex.RUnlock()
 
-	subnets := n.findSuitableSubnet(resource.Spec.ENI, limits)
+	subnets := n.findSuitableSubnets(resource.Spec.ENI, limits, isPrefixDelegated)
 	if len(subnets) == 0 {
 		return 0,
 			unableToFindSubnet,
@@ -728,6 +728,9 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *nodemanager.Allo
 			)
 	}
 	subnet := subnets[0]
+	if !n.checkSubnetInSameRouteTableWithNodeSubnet(subnet) {
+		n.logSubnetRouteTableMismatch(subnet, "")
+	}
 	allocation.PoolID = ipamTypes.PoolID(subnet.ID)
 
 	securityGroupIDs, err := n.getSecurityGroupIDs(ctx, resource.Spec.ENI)
@@ -787,23 +790,21 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *nodemanager.Allo
 			}
 
 			if err != nil {
-				if isPrefixDelegated && isSubnetAtPrefixCapacity(err) {
-					// All eligible subnets are at prefix capacity. Fall back to /32.
-					scopedLog.Warn(
-						"Subnet might be out of prefixes, Cilium will not allocate prefixes on this node anymore",
-						logfields.Node, n.k8sObj.Name,
-					)
-					eniID, eni, err = n.manager.ec2api.CreateNetworkInterface(ctx, int32(toAllocate), subnets[0].ID, desc, securityGroupIDs, false, allocateIPv6)
-					if err == nil {
-						subnet = subnets[0]
-					}
-				}
-
-				if err != nil {
-					return 0, unableToCreateENI, fmt.Errorf("%s: %w", errUnableToCreateENI, err)
+				// All eligible subnets are at prefix capacity. Fall back to /32.
+				scopedLog.Warn(
+					"Subnet might be out of prefixes, Cilium will not allocate prefixes on this node anymore",
+					logfields.Node, n.k8sObj.Name,
+				)
+				eniID, eni, err = n.manager.ec2api.CreateNetworkInterface(ctx, int32(toAllocate), subnets[0].ID, desc, securityGroupIDs, false, allocateIPv6)
+				if err == nil {
+					subnet = subnets[0]
 				}
 			}
 		}
+	}
+
+	if err != nil {
+		return 0, unableToCreateENI, fmt.Errorf("%s: %w", errUnableToCreateENI, err)
 	}
 
 	scopedLog.Debug("ENI after initial creation", logfields.ENI, eni)
@@ -1215,60 +1216,57 @@ func (n *Node) logSubnetRouteTableMismatch(subnet *ipamTypes.Subnet, matchType s
 	)
 }
 
-// findSuitableSubnet attempts to find subnets to allocate an ENI in according to the following heuristic.
+// findSuitableSubnets attempts to find subnets to allocate an ENI in according to the following heuristic.
 //  0. In general, the subnet has to be in the same VPC and match the availability zone of the
 //     node. If there are multiple candidates, subnets are ordered by AvailableAddresses descending.
+//     For non-PD mode, only the primary subnet is returned. For PD mode, the full ordered list
+//     is returned so CreateInterface can retry across sibling subnets before falling back to /32.
 //  1. If the node spec has explicit SubnetIDs set, we use those.
 //  2. If the node spec has SubnetTags set, we use those.
 //  3. We try to use the subnet the node was first created in, to avoid putting the ENI in a
-//     surprising subnet if possible.
+//     surprising subnet if possible. For PD mode, steps 3 and 4 are combined: route-table
+//     siblings are appended as retry candidates, ensuring consistent routing with the primary
+//     interface and avoiding public subnet selection.
 //  4. If we can't use the subnet first ENI in, try to use the subnet in the same route table as the node's subnet.
 //  5. If none of these work, fall back to just choosing the subnet with the most addresses
 //     available.
-func (n *Node) findSuitableSubnet(spec types.ENISpec, limits ipamTypes.Limits) []*ipamTypes.Subnet {
-	if len(spec.SubnetIDs) > 0 {
-		subnets := n.manager.FindSubnetByIDsSorted(spec.VpcID, spec.AvailabilityZone, spec.SubnetIDs)
+func (n *Node) findSuitableSubnets(spec types.ENISpec, limits ipamTypes.Limits, isPrefixDelegated bool) []*ipamTypes.Subnet {
+	// non-PD only ever uses the primary choice; PD gets the full ordered list.
+	pick := func(subnets []*ipamTypes.Subnet) []*ipamTypes.Subnet {
+		if !isPrefixDelegated && len(subnets) > 1 {
+			return subnets[:1]
+		}
+		return subnets
+	}
 
-		if len(subnets) > 0 {
-			if !n.checkSubnetInSameRouteTableWithNodeSubnet(subnets[0]) {
-				n.logSubnetRouteTableMismatch(subnets[0], "Specified")
-			}
-			return subnets
+	if len(spec.SubnetIDs) > 0 {
+		if subnets := n.manager.FindSubnetByIDsSorted(spec.VpcID, spec.AvailabilityZone, spec.SubnetIDs); len(subnets) > 0 {
+			return pick(subnets)
 		}
 	}
 
 	if len(spec.SubnetTags) > 0 {
-		subnets := n.manager.FindSubnetByTagsSorted(spec.VpcID, spec.AvailabilityZone, spec.SubnetTags)
-
-		if len(subnets) > 0 {
-			if !n.checkSubnetInSameRouteTableWithNodeSubnet(subnets[0]) {
-				n.logSubnetRouteTableMismatch(subnets[0], "Tagged")
-			}
-			return subnets
+		if subnets := n.manager.FindSubnetByTagsSorted(spec.VpcID, spec.AvailabilityZone, spec.SubnetTags); len(subnets) > 0 {
+			return pick(subnets)
 		}
 	}
 
 	if subnet := n.manager.GetSubnet(spec.NodeSubnetID); subnet != nil && subnet.AvailableAddresses >= limits.IPv4 {
-		// Include other subnets in the same AZ as retry candidates for PD fallback.
-		others := n.manager.FindSubnetByTagsSorted(spec.VpcID, spec.AvailabilityZone, nil)
 		result := []*ipamTypes.Subnet{subnet}
-		for _, s := range others {
-			if s.ID != subnet.ID {
-				result = append(result, s)
-			}
+		if isPrefixDelegated {
+			// Retry candidates must share the node subnet's route table so pod
+			// traffic keeps routing consistently with the primary interface.
+			result = append(result, n.findSubnetInSameRouteTableWithNodeSubnetSorted()...)
 		}
 		return result
 	}
 
 	if subnets := n.findSubnetInSameRouteTableWithNodeSubnetSorted(); len(subnets) > 0 {
-		return subnets
+		return pick(subnets)
 	}
 
 	if subnets := n.manager.FindSubnetByTagsSorted(spec.VpcID, spec.AvailabilityZone, nil); len(subnets) > 0 {
-		if !n.checkSubnetInSameRouteTableWithNodeSubnet(subnets[0]) {
-			n.logSubnetRouteTableMismatch(subnets[0], "")
-		}
-		return subnets
+		return pick(subnets)
 	}
 
 	return nil

--- a/pkg/aws/ipam/node.go
+++ b/pkg/aws/ipam/node.go
@@ -782,8 +782,8 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *nodemanager.Allo
 	isPrefixDelegated := n.node.Ops().IsPrefixDelegated()
 	n.mutex.RUnlock()
 
-	subnet := n.findSuitableSubnet(resource.Spec.ENI, limits)
-	if subnet == nil {
+	subnets := n.findSuitableSubnets(resource.Spec.ENI, limits, isPrefixDelegated)
+	if len(subnets) == 0 {
 		return 0,
 			unableToFindSubnet,
 			fmt.Errorf(
@@ -793,6 +793,10 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *nodemanager.Allo
 				resource.Spec.ENI.SubnetIDs,
 				resource.Spec.ENI.SubnetTags,
 			)
+	}
+	subnet := subnets[0]
+	if !n.checkSubnetInSameRouteTableWithNodeSubnet(subnet) {
+		n.logSubnetRouteTableMismatch(subnet, "")
 	}
 	allocation.PoolID = ipamTypes.PoolID(subnet.ID)
 
@@ -836,21 +840,43 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *nodemanager.Allo
 	scopedLog.Info("No more IPs available, creating new ENI")
 
 	eniID, eni, err := n.manager.ec2api.CreateNetworkInterface(ctx, int32(toAllocate), subnet.ID, desc, securityGroupIDs, isPrefixDelegated, allocateIPv6)
+
 	if err != nil {
 		if isPrefixDelegated && isSubnetAtPrefixCapacity(err) {
-			// Subnet might be out of available /28 prefixes, but /32 IP addresses might be available.
-			// We should attempt to allocate /32 IPs.
-			scopedLog.Warn(
-				"Subnet might be out of prefixes, Cilium will not allocate prefixes on this node anymore",
-				logfields.Node, n.k8sObj.Name,
-			)
-			// If subnet is out of prefixes, re-calculate maximum allocatable IPs
-			toAllocate = min(allocation.IPv4.MaxIPsToAllocate, limits.IPv4-1)
-			eniID, eni, err = n.manager.ec2api.CreateNetworkInterface(ctx, int32(toAllocate), subnet.ID, desc, securityGroupIDs, false, allocateIPv6)
+			// Subnet might be out of available /28 prefixes. Before falling back to
+			// /32 IPs in the same subnet, try other eligible subnets in the same AZ
+			// that may have free /28 capacity.
+			for _, siblingSubnet := range subnets[1:] {
+				scopedLog.Info("Retrying prefix ENI creation in sibling subnet", logfields.SubnetID, siblingSubnet.ID)
+				eniID, eni, err = n.manager.ec2api.CreateNetworkInterface(ctx, int32(toAllocate), siblingSubnet.ID, desc, securityGroupIDs, true, allocateIPv6)
+				if err == nil {
+					allocation.PoolID = ipamTypes.PoolID(siblingSubnet.ID)
+					subnet = siblingSubnet
+					if !n.checkSubnetInSameRouteTableWithNodeSubnet(subnet) {
+						n.logSubnetRouteTableMismatch(subnet, "")
+					}
+					break
+				}
+			}
+
+			if err != nil {
+				// All eligible subnets are at prefix capacity. Fall back to /32.
+				scopedLog.Warn(
+					"Subnet might be out of prefixes, Cilium will not allocate prefixes on this node anymore",
+					logfields.Node, n.k8sObj.Name,
+				)
+				// If subnet is out of prefixes, re-calculate maximum allocatable IPs
+				toAllocate = min(allocation.IPv4.MaxIPsToAllocate, limits.IPv4-1)
+				eniID, eni, err = n.manager.ec2api.CreateNetworkInterface(ctx, int32(toAllocate), subnets[0].ID, desc, securityGroupIDs, false, allocateIPv6)
+				if err == nil {
+					subnet = subnets[0]
+				}
+			}
 		}
-		if err != nil {
-			return 0, unableToCreateENI, fmt.Errorf("%s: %w", errUnableToCreateENI, err)
-		}
+	}
+
+	if err != nil {
+		return 0, unableToCreateENI, fmt.Errorf("%s: %w", errUnableToCreateENI, err)
 	}
 
 	scopedLog.Debug("ENI after initial creation", logfields.ENI, eni)
@@ -1178,10 +1204,9 @@ func (n *Node) getEffectiveIPLimits(eni *types.ENI, limits int) (leftoverPrefixC
 	return leftoverPrefixCapacity, effectiveLimits
 }
 
-// findSubnetInSameRouteTableWithNodeSubnet returns the subnet with the most addresses
-// that is in the same route table as the node's subnet to make sure the pod traffic
-// leaving secondary interfaces is routed in the same way as the primary interface.
-func (n *Node) findSubnetInSameRouteTableWithNodeSubnet() *ipamTypes.Subnet {
+// findSubnetInSameRouteTableWithNodeSubnetSorted returns all subnets in the
+// same route table as the node's subnet, sorted by AvailableAddresses descending
+func (n *Node) findSubnetInSameRouteTableWithNodeSubnetSorted() []*ipamTypes.Subnet {
 	n.mutex.RLock()
 	defer n.mutex.RUnlock()
 
@@ -1193,7 +1218,7 @@ func (n *Node) findSubnetInSameRouteTableWithNodeSubnet() *ipamTypes.Subnet {
 	defer n.manager.mutex.RUnlock()
 
 	nodeSubnetID := n.k8sObj.Spec.ENI.NodeSubnetID
-	var bestSubnet *ipamTypes.Subnet
+	var result []*ipamTypes.Subnet
 
 	for _, routeTable := range n.manager.routeTables {
 		if _, ok := routeTable.Subnets[nodeSubnetID]; ok && routeTable.VirtualNetworkID == n.k8sObj.Spec.ENI.VpcID {
@@ -1205,14 +1230,18 @@ func (n *Node) findSubnetInSameRouteTableWithNodeSubnet() *ipamTypes.Subnet {
 				if subnet == nil {
 					continue
 				}
-				if (bestSubnet == nil || subnet.AvailableAddresses > bestSubnet.AvailableAddresses) && subnet.AvailabilityZone == n.k8sObj.Spec.ENI.AvailabilityZone {
-					bestSubnet = subnet
+				if subnet.AvailabilityZone == n.k8sObj.Spec.ENI.AvailabilityZone {
+					result = append(result, subnet)
 				}
 			}
 		}
 	}
 
-	return bestSubnet
+	slices.SortFunc(result, func(a, b *ipamTypes.Subnet) int {
+		return b.AvailableAddresses - a.AvailableAddresses
+	})
+
+	return result
 }
 
 // checkSubnetInSameRouteTableWithNodeSubnet checks if the given subnet is in the same route table as the node's subnet
@@ -1251,48 +1280,57 @@ func (n *Node) logSubnetRouteTableMismatch(subnet *ipamTypes.Subnet, matchType s
 	)
 }
 
-// findSuitableSubnet attempts to find a subnet to allocate an ENI in according to the following heuristic.
+// findSuitableSubnets attempts to find subnets to allocate an ENI in according to the following heuristic.
 //  0. In general, the subnet has to be in the same VPC and match the availability zone of the
-//     node. If there are multiple candidates, we choose the subnet with the most addresses
+//     node. If there are multiple candidates, subnets are ordered by AvailableAddresses descending.
+//     For non-PD mode, only the primary subnet is returned. For PD mode, the full ordered list
+//     is returned so CreateInterface can retry across sibling subnets before falling back to /32.
+//  1. If the node spec has explicit SubnetIDs set, we use those.
+//  2. If the node spec has SubnetTags set, we use those.
+//  3. We try to use the subnet the node was first created in, to avoid putting the ENI in a
+//     surprising subnet if possible. For PD mode, steps 3 and 4 are combined: route-table
+//     siblings are appended as retry candidates, ensuring consistent routing with the primary
+//     interface and avoiding public subnet selection.
+//  4. If we can't use the subnet first ENI in, try to use the subnet in the same route table as the node's subnet.
+//  5. If none of these work, fall back to just choosing the subnet with the most addresses
 //     available.
-//  1. If we have explicit ID or tag constraints, chose a matching subnet. ID constraints take
-//     precedence.
-//  2. If we have no explicit constraints, try to use the subnet the first ENI of the node was
-//     created in, to avoid putting the ENI in a surprising subnet if possible.
-//  3. If we can't use the subnet first ENI in, try to use the subnet in the same route table as the node's subnet.
-//  4. If none of these work, fall back to just choosing the subnet with the most addresses
-//     available.
-func (n *Node) findSuitableSubnet(spec types.ENISpec, limits ipamTypes.Limits) *ipamTypes.Subnet {
+func (n *Node) findSuitableSubnets(spec types.ENISpec, limits ipamTypes.Limits, isPrefixDelegated bool) []*ipamTypes.Subnet {
+	// non-PD only ever uses the primary choice; PD gets the full ordered list.
+	pick := func(subnets []*ipamTypes.Subnet) []*ipamTypes.Subnet {
+		if !isPrefixDelegated && len(subnets) > 1 {
+			return subnets[:1]
+		}
+		return subnets
+	}
+
 	if len(spec.SubnetIDs) > 0 {
-		if subnet := n.manager.FindSubnetByIDs(spec.VpcID, spec.AvailabilityZone, spec.SubnetIDs); subnet != nil {
-			if !n.checkSubnetInSameRouteTableWithNodeSubnet(subnet) {
-				n.logSubnetRouteTableMismatch(subnet, "Specified")
-			}
-			return subnet
+		if subnets := n.manager.FindSubnetByIDsSorted(spec.VpcID, spec.AvailabilityZone, spec.SubnetIDs); len(subnets) > 0 {
+			return pick(subnets)
 		}
 	}
 
 	if len(spec.SubnetTags) > 0 {
-		if subnet := n.manager.FindSubnetByTags(spec.VpcID, spec.AvailabilityZone, spec.SubnetTags); subnet != nil {
-			if !n.checkSubnetInSameRouteTableWithNodeSubnet(subnet) {
-				n.logSubnetRouteTableMismatch(subnet, "Tagged")
-			}
-			return subnet
+		if subnets := n.manager.FindSubnetByTagsSorted(spec.VpcID, spec.AvailabilityZone, spec.SubnetTags); len(subnets) > 0 {
+			return pick(subnets)
 		}
 	}
 
 	if subnet := n.manager.GetSubnet(spec.NodeSubnetID); subnet != nil && subnet.AvailableAddresses >= limits.IPv4 {
-		return subnet
+		result := []*ipamTypes.Subnet{subnet}
+		if isPrefixDelegated {
+			// Retry candidates must share the node subnet's route table so pod
+			// traffic keeps routing consistently with the primary interface.
+			result = append(result, n.findSubnetInSameRouteTableWithNodeSubnetSorted()...)
+		}
+		return result
 	}
 
-	if subnet := n.findSubnetInSameRouteTableWithNodeSubnet(); subnet != nil {
-		return subnet
+	if subnets := n.findSubnetInSameRouteTableWithNodeSubnetSorted(); len(subnets) > 0 {
+		return pick(subnets)
 	}
-	if subnet := n.manager.FindSubnetByTags(spec.VpcID, spec.AvailabilityZone, nil); subnet != nil {
-		if !n.checkSubnetInSameRouteTableWithNodeSubnet(subnet) {
-			n.logSubnetRouteTableMismatch(subnet, "")
-		}
-		return subnet
+
+	if subnets := n.manager.FindSubnetByTagsSorted(spec.VpcID, spec.AvailabilityZone, nil); len(subnets) > 0 {
+		return pick(subnets)
 	}
 
 	return nil

--- a/pkg/aws/ipam/node_prefix_fallback_test.go
+++ b/pkg/aws/ipam/node_prefix_fallback_test.go
@@ -1,0 +1,982 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipam
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/operator/pkg/ipam/nodemanager"
+	ec2mock "github.com/cilium/cilium/pkg/aws/api/mock"
+	metadataMock "github.com/cilium/cilium/pkg/aws/metadata/mock"
+	eniTypes "github.com/cilium/cilium/pkg/aws/types"
+	iputil "github.com/cilium/cilium/pkg/ip"
+	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+// fakeOpsNode lets us drive Node.CreateInterface in a unit test. The default
+// mockIPAMNode.Ops() panics, but CreateInterface calls n.node.Ops().IsPrefixDelegated(),
+// so we return the Node itself as its own NodeOperations.
+type fakeOpsNode struct {
+	mockIPAMNode
+	ops nodemanager.NodeOperations
+}
+
+func (f *fakeOpsNode) Ops() nodemanager.NodeOperations { return f.ops }
+
+// TestPrefixFallbackFallsBackToSameSubnetWhenNoSiblingAvailable documents the
+// correct behavior when a prefix delegated ENI cannot get a /28 in the selected
+// subnet AND no eligible sibling subnet exists: the operator correctly falls back
+// to /32 in the same subnet. This is acceptable — cross-subnet retry only helps
+// when a sibling subnet with /28 capacity is available.
+func TestPrefixFallbackFallsBackToSameSubnetWhenNoSiblingAvailable(t *testing.T) {
+	const subnetID = "subnet-frag"
+
+	// Mock a FRAGMENTED subnet: it has plenty of free /32 addresses (1000, far
+	// more than one /28 of 16), but no free contiguous /28 prefix block. This is
+	// the real-world fragmentation case from the report: AvailableIpAddressCount
+	// stays high, yet the prefix create fails with the AWS subnet full error that
+	// isSubnetAtPrefixCapacity matches. SetSubnetAtPrefixCapacity below models the
+	// missing /28 capacity independently of the /32 count.
+	mockSubnet := &ipamTypes.Subnet{
+		ID:                 subnetID,
+		VirtualNetworkID:   "vpc-1",
+		AvailabilityZone:   "eu-west-1a",
+		AvailableAddresses: 1000,
+	}
+	api := ec2mock.NewAPI(
+		[]*ipamTypes.Subnet{mockSubnet},
+		[]*ipamTypes.VirtualNetwork{{ID: "vpc-1"}},
+		nil,
+		nil,
+	)
+	// The subnet is fragmented: no free /28 block, so prefix allocation fails
+	// while /32 allocation still succeeds.
+	api.SetSubnetAtPrefixCapacity(subnetID, true)
+	metaMock, _ := metadataMock.NewMetadataMock()
+	instances, err := NewInstancesManager(context.Background(), hivetest.Logger(t), api, metaMock)
+	require.NoError(t, err)
+
+	// findSuitableSubnet reads the manager subnet cache directly.
+	instances.subnets = map[string]*ipamTypes.Subnet{
+		subnetID: {
+			ID:                 subnetID,
+			VirtualNetworkID:   "vpc-1",
+			AvailabilityZone:   "eu-west-1a",
+			AvailableAddresses: 1000,
+		},
+	}
+
+	k8sObj := newCiliumNode("node1", withInstanceType("m5.large"))
+	k8sObj.Spec.ENI.VpcID = "vpc-1"
+	k8sObj.Spec.ENI.AvailabilityZone = "eu-west-1a"
+	k8sObj.Spec.ENI.SubnetIDs = []string{subnetID}
+	k8sObj.Spec.ENI.SecurityGroups = []string{"sg-1"}
+
+	fake := &fakeOpsNode{mockIPAMNode: mockIPAMNode{instanceID: "i-123", prefixDelegation: true}}
+	n := &Node{
+		rootLogger: hivetest.Logger(t),
+		manager:    instances,
+		k8sObj:     k8sObj,
+		node:       fake,
+		enis:       map[string]eniTypes.ENI{},
+	}
+	n.logger.Store(n.rootLogger)
+	fake.ops = n // Node is its own NodeOperations
+
+	require.True(t, n.IsPrefixDelegated(), "node should start prefix delegated")
+
+	alloc := &nodemanager.AllocationAction{}
+	alloc.IPv4.MaxIPsToAllocate = 2
+
+	toAllocate, _, err := n.CreateInterface(context.Background(), alloc, hivetest.Logger(t))
+	require.NoError(t, err)
+	require.Equal(t, 2, toAllocate)
+
+	// The ENI was created in the same subnet that could not fit a prefix.
+	require.Equal(t, ipamTypes.PoolID(subnetID), alloc.PoolID)
+
+	// Proof it used the /32 fallback and not a prefix: the mock subnet dropped by
+	// exactly primary + 2 secondary = 3 addresses (1000 -> 997). A successful
+	// prefix would have consumed a /28 block (16 addresses) instead. The subnet
+	// kept hundreds of free /32 addresses throughout, so the fallback was driven
+	// by missing /28 capacity (fragmentation), not by a nearly full subnet.
+	subnetsAfter, err := api.GetSubnets(context.Background(), "vpc-1")
+	require.NoError(t, err)
+	require.Equal(t, 997, subnetsAfter[subnetID].AvailableAddresses)
+}
+
+// TestNoPrefixENIDisablesNodeAndDoesNotRecover proves root cause 3: a single
+// ENI with secondary IPs and no prefixes disables prefix delegation for the
+// whole node, adding more prefix capable ENIs does not undo it, and the node
+// only recovers if that ENI drains down to its primary IP.
+func TestNoPrefixENIDisablesNodeAndDoesNotRecover(t *testing.T) {
+	api := ec2mock.NewAPI(nil, nil, nil, nil)
+	metaMock, _ := metadataMock.NewMetadataMock()
+	instances, err := NewInstancesManager(context.Background(), hivetest.Logger(t), api, metaMock)
+	require.NoError(t, err)
+
+	n := &Node{
+		rootLogger: hivetest.Logger(t),
+		manager:    instances,
+		k8sObj:     newCiliumNode("node1", withInstanceType("m5.large")),
+		node:       &mockIPAMNode{instanceID: "i-123", prefixDelegation: true},
+		enis:       map[string]eniTypes.ENI{},
+	}
+	n.logger.Store(n.rootLogger)
+
+	// 1. One prefix delegated ENI: node is prefix delegated.
+	n.enis["eni-pd"] = eniTypes.ENI{
+		ID:        "eni-pd",
+		IP:        iputil.AddrFrom(netip.MustParseAddr("10.0.0.4")),
+		Addresses: []iputil.Addr{iputil.AddrFrom(netip.MustParseAddr("10.0.0.16")), iputil.AddrFrom(netip.MustParseAddr("10.0.0.17"))},
+		Prefixes:  []iputil.Prefix{iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.16/28"))},
+	}
+	require.True(t, n.IsPrefixDelegated(), "single prefix ENI should be delegated")
+
+	// 2. Add a no prefix ENI with 2 secondary IPs (the /32 fallback result).
+	n.enis["eni-32"] = eniTypes.ENI{
+		ID:        "eni-32",
+		IP:        iputil.AddrFrom(netip.MustParseAddr("10.0.1.4")),
+		Addresses: []iputil.Addr{iputil.AddrFrom(netip.MustParseAddr("10.0.1.4")), iputil.AddrFrom(netip.MustParseAddr("10.0.1.5")), iputil.AddrFrom(netip.MustParseAddr("10.0.1.6"))},
+		Prefixes:  nil,
+	}
+	require.False(t, n.IsPrefixDelegated(), "one no-prefix ENI must disable the whole node")
+
+	// 3. Adding another prefix capable ENI does NOT recover the node.
+	n.enis["eni-pd2"] = eniTypes.ENI{
+		ID:        "eni-pd2",
+		IP:        iputil.AddrFrom(netip.MustParseAddr("10.0.2.4")),
+		Addresses: []iputil.Addr{iputil.AddrFrom(netip.MustParseAddr("10.0.2.16"))},
+		Prefixes:  []iputil.Prefix{iputil.PrefixFrom(netip.MustParsePrefix("10.0.2.16/28"))},
+	}
+	require.False(t, n.IsPrefixDelegated(), "extra prefix ENIs do not undo the disable")
+
+	// 4. Draining the no prefix ENI down to its primary IP recovers the node.
+	n.enis["eni-32"] = eniTypes.ENI{
+		ID:        "eni-32",
+		IP:        iputil.AddrFrom(netip.MustParseAddr("10.0.1.4")),
+		Addresses: []iputil.Addr{iputil.AddrFrom(netip.MustParseAddr("10.0.1.4"))}, // primary only, Addresses[0] == IP
+		Prefixes:  nil,
+	}
+	require.True(t, n.IsPrefixDelegated(), "node recovers only when the no-prefix ENI drains to primary")
+}
+
+// TestPrefixFallbackTriesSiblingTaggedSubnet validates that when prefix ENI
+// creation fails with InsufficientCidrBlocks in the selected subnet, CreateInterface
+// retries prefix creation in other eligible same-AZ subnets before falling back
+// to /32. With eni.subnet-tags-filter set and a healthy sibling subnet available,
+// the retry succeeds and the ENI is created with a /28 prefix in the sibling subnet.
+func TestPrefixFallbackTriesSiblingTaggedSubnet(t *testing.T) {
+	const (
+		fragSubnetID    = "subnet-frag"
+		healthySubnetID = "subnet-healthy"
+	)
+	filterTags := ipamTypes.Tags{"kubernetes.io/role/cni": "1"}
+
+	fragSubnet := &ipamTypes.Subnet{
+		ID:                 fragSubnetID,
+		VirtualNetworkID:   "vpc-1",
+		AvailabilityZone:   "eu-west-1a",
+		AvailableAddresses: 1000,
+		Tags:               filterTags,
+	}
+	healthySubnet := &ipamTypes.Subnet{
+		ID:                 healthySubnetID,
+		VirtualNetworkID:   "vpc-1",
+		AvailabilityZone:   "eu-west-1a",
+		AvailableAddresses: 500,
+		Tags:               filterTags,
+	}
+	api := ec2mock.NewAPI(
+		[]*ipamTypes.Subnet{fragSubnet, healthySubnet},
+		[]*ipamTypes.VirtualNetwork{{ID: "vpc-1"}},
+		nil,
+		nil,
+	)
+	// Only subnet-frag is fragmented. subnet-healthy has full /28 capacity.
+	api.SetSubnetAtPrefixCapacity(fragSubnetID, true)
+
+	metaMock, _ := metadataMock.NewMetadataMock()
+	instances, err := NewInstancesManager(context.Background(), hivetest.Logger(t), api, metaMock)
+	require.NoError(t, err)
+	instances.subnets = map[string]*ipamTypes.Subnet{
+		fragSubnetID:    fragSubnet.DeepCopy(),
+		healthySubnetID: healthySubnet.DeepCopy(),
+	}
+
+	k8sObj := newCiliumNode("node1", withInstanceType("m5.large"))
+	k8sObj.Spec.ENI.VpcID = "vpc-1"
+	k8sObj.Spec.ENI.AvailabilityZone = "eu-west-1a"
+	k8sObj.Spec.ENI.SubnetTags = filterTags
+	k8sObj.Spec.ENI.SecurityGroups = []string{"sg-1"}
+
+	fake := &fakeOpsNode{mockIPAMNode: mockIPAMNode{instanceID: "i-123", prefixDelegation: true}}
+	n := &Node{
+		rootLogger: hivetest.Logger(t),
+		manager:    instances,
+		k8sObj:     k8sObj,
+		node:       fake,
+		enis:       map[string]eniTypes.ENI{},
+	}
+	n.logger.Store(n.rootLogger)
+	fake.ops = n
+
+	require.True(t, n.IsPrefixDelegated(), "node should start prefix delegated")
+
+	alloc := &nodemanager.AllocationAction{}
+	alloc.IPv4.MaxIPsToAllocate = 2
+
+	toAllocate, _, err := n.CreateInterface(context.Background(), alloc, hivetest.Logger(t))
+	require.NoError(t, err)
+	require.Equal(t, 2, toAllocate)
+
+	// The retry found the healthy sibling and created the ENI there with a prefix.
+	require.Equal(t, ipamTypes.PoolID(healthySubnetID), alloc.PoolID,
+		"cross-subnet retry must land the ENI in the healthy sibling subnet")
+
+	subnetsAfter, err := api.GetSubnets(context.Background(), "vpc-1")
+	require.NoError(t, err)
+	// subnet-frag is untouched: the retry moved past it.
+	require.Equal(t, 1000, subnetsAfter[fragSubnetID].AvailableAddresses,
+		"fragmented subnet must be untouched after cross-subnet retry")
+	// subnet-healthy consumed toAllocate+1 (primary+secondaries) + /28 = 19 (500 -> 481).
+	require.Equal(t, 481, subnetsAfter[healthySubnetID].AvailableAddresses,
+		"healthy subnet must show prefix allocation (2 secondary + primary + /28 = 19 addresses)")
+	// Node stays prefix delegated: no /32-only ENI was created.
+	require.True(t, n.IsPrefixDelegated(), "node must remain prefix delegated after successful cross-subnet retry")
+}
+
+// TestMultipleFallbackENIsUseHealthySiblingAndNodeStaysDelegated validates that
+// repeated ENI creations in a fragmented subnet
+// scenario correctly retry and land in the healthy sibling with prefix delegation,
+// and the node never enters degraded /32 mode.
+func TestMultipleFallbackENIsUseHealthySiblingAndNodeStaysDelegated(t *testing.T) {
+	const (
+		fragSubnetID    = "subnet-frag"
+		healthySubnetID = "subnet-healthy"
+	)
+	filterTags := ipamTypes.Tags{"kubernetes.io/role/cni": "1"}
+	fragSubnet := &ipamTypes.Subnet{ID: fragSubnetID, VirtualNetworkID: "vpc-1", AvailabilityZone: "eu-west-1a", AvailableAddresses: 1000, Tags: filterTags}
+	healthySubnet := &ipamTypes.Subnet{ID: healthySubnetID, VirtualNetworkID: "vpc-1", AvailabilityZone: "eu-west-1a", AvailableAddresses: 500, Tags: filterTags}
+	api := ec2mock.NewAPI(
+		[]*ipamTypes.Subnet{fragSubnet, healthySubnet},
+		[]*ipamTypes.VirtualNetwork{{ID: "vpc-1"}},
+		nil,
+		nil,
+	)
+	api.SetSubnetAtPrefixCapacity(fragSubnetID, true)
+	metaMock, _ := metadataMock.NewMetadataMock()
+	instances, err := NewInstancesManager(context.Background(), hivetest.Logger(t), api, metaMock)
+	require.NoError(t, err)
+	instances.subnets = map[string]*ipamTypes.Subnet{
+		fragSubnetID:    fragSubnet.DeepCopy(),
+		healthySubnetID: healthySubnet.DeepCopy(),
+	}
+
+	k8sObj := newCiliumNode("node1", withInstanceType("m5.large"))
+	k8sObj.Spec.ENI.VpcID = "vpc-1"
+	k8sObj.Spec.ENI.AvailabilityZone = "eu-west-1a"
+	k8sObj.Spec.ENI.SubnetTags = filterTags
+	k8sObj.Spec.ENI.SecurityGroups = []string{"sg-1"}
+
+	fake := &fakeOpsNode{mockIPAMNode: mockIPAMNode{instanceID: "i-123", prefixDelegation: true}}
+	n := &Node{
+		rootLogger: hivetest.Logger(t),
+		manager:    instances,
+		k8sObj:     k8sObj,
+		node:       fake,
+		enis:       map[string]eniTypes.ENI{},
+	}
+	n.logger.Store(n.rootLogger)
+	fake.ops = n
+
+	require.True(t, n.IsPrefixDelegated(), "node starts prefix delegated")
+
+	eniKeys := []string{"eni-0", "eni-1", "eni-2"}
+	for i := range 3 {
+		alloc := &nodemanager.AllocationAction{}
+		alloc.IPv4.MaxIPsToAllocate = 2
+		_, _, err := n.CreateInterface(context.Background(), alloc, hivetest.Logger(t))
+		require.NoError(t, err)
+		// Every ENI lands in the healthy sibling via cross-subnet retry.
+		require.Equal(t, ipamTypes.PoolID(healthySubnetID), alloc.PoolID,
+			"cross-subnet retry must land the ENI in the healthy subnet")
+		// Model the resync: ENI has a prefix so node stays delegated.
+		n.enis[eniKeys[i]] = eniTypes.ENI{
+			ID:       eniKeys[i],
+			IP:       iputil.AddrFrom(netip.MustParseAddr("10.9.0.1")),
+			Prefixes: []iputil.Prefix{iputil.PrefixFrom(netip.MustParsePrefix("10.9.0.0/28"))},
+			Subnet:   eniTypes.AwsSubnet{ID: healthySubnetID},
+		}
+		// Node stays prefix delegated: no /32-only ENI was produced.
+		require.True(t, n.IsPrefixDelegated(), "node must stay prefix delegated after cross-subnet retry")
+	}
+
+	subnetsAfter, err := api.GetSubnets(context.Background(), "vpc-1")
+	require.NoError(t, err)
+	// Fragmented subnet untouched across all three ENIs.
+	require.Equal(t, 1000, subnetsAfter[fragSubnetID].AvailableAddresses,
+		"fragmented subnet must be untouched")
+	// Healthy subnet consumed toAllocate+1 + /28 = 19 per ENI, 3 ENIs = 57 (500 -> 443).
+	require.Equal(t, 443, subnetsAfter[healthySubnetID].AvailableAddresses,
+		"healthy subnet consumed by prefix ENIs (19 each: 2 secondary + primary + /28)")
+}
+
+// TestDegradedNodeKeepsAllocatingSlash32InHealthySubnet captures the reporter's
+// exact numbers (fragmented subnet reports far fewer addresses than the healthy
+// sibling) and the precise, honest behavior: once the node is degraded, new ENIs
+// are NOT stuck on the fragmented subnet. findSuitableSubnet re-evaluates and
+// picks the healthy subnet because it reports more free addresses. But because
+// IsPrefixDelegated is false node wide, every new ENI is still created in /32
+// mode, so prefix delegation is never re-enabled even though the healthy subnet
+// has abundant free /28 capacity. The node is stuck in /32 mode, not stuck on a
+// single subnet, and the healthy subnet gets consumed with /32 ENIs.
+func TestDegradedNodeKeepsAllocatingSlash32InHealthySubnet(t *testing.T) {
+	const (
+		fragSubnetID    = "subnet-frag"
+		healthySubnetID = "subnet-healthy"
+	)
+	filterTags := ipamTypes.Tags{"kubernetes.io/role/cni": "1"}
+	// Accurate cache, reporter's numbers.
+	fragSubnet := &ipamTypes.Subnet{ID: fragSubnetID, VirtualNetworkID: "vpc-1", AvailabilityZone: "eu-west-1a", AvailableAddresses: 100, Tags: filterTags}
+	healthySubnet := &ipamTypes.Subnet{ID: healthySubnetID, VirtualNetworkID: "vpc-1", AvailabilityZone: "eu-west-1a", AvailableAddresses: 2000, Tags: filterTags}
+	api := ec2mock.NewAPI(
+		[]*ipamTypes.Subnet{fragSubnet, healthySubnet},
+		[]*ipamTypes.VirtualNetwork{{ID: "vpc-1"}},
+		nil,
+		nil,
+	)
+	api.SetSubnetAtPrefixCapacity(fragSubnetID, true)
+	metaMock, _ := metadataMock.NewMetadataMock()
+	instances, err := NewInstancesManager(context.Background(), hivetest.Logger(t), api, metaMock)
+	require.NoError(t, err)
+	instances.subnets = map[string]*ipamTypes.Subnet{
+		fragSubnetID:    fragSubnet.DeepCopy(),
+		healthySubnetID: healthySubnet.DeepCopy(),
+	}
+
+	k8sObj := newCiliumNode("node1", withInstanceType("m5.large"))
+	k8sObj.Spec.ENI.VpcID = "vpc-1"
+	k8sObj.Spec.ENI.AvailabilityZone = "eu-west-1a"
+	k8sObj.Spec.ENI.SubnetTags = filterTags
+	k8sObj.Spec.ENI.SecurityGroups = []string{"sg-1"}
+
+	fake := &fakeOpsNode{mockIPAMNode: mockIPAMNode{instanceID: "i-123", prefixDelegation: true}}
+	n := &Node{
+		rootLogger: hivetest.Logger(t),
+		manager:    instances,
+		k8sObj:     k8sObj,
+		node:       fake,
+		enis:       map[string]eniTypes.ENI{},
+	}
+	n.logger.Store(n.rootLogger)
+	fake.ops = n
+
+	// Node already degraded: one no-prefix ENI pinned to the fragmented subnet
+	// (the primary ENI that AWS placed there at instance launch).
+	n.enis["primary-x"] = eniTypes.ENI{
+		ID:        "primary-x",
+		IP:        iputil.AddrFrom(netip.MustParseAddr("10.0.0.4")),
+		Addresses: []iputil.Addr{iputil.AddrFrom(netip.MustParseAddr("10.0.0.4")), iputil.AddrFrom(netip.MustParseAddr("10.0.0.5"))},
+		Prefixes:  nil,
+		Subnet:    eniTypes.AwsSubnet{ID: fragSubnetID},
+	}
+	require.False(t, n.IsPrefixDelegated(), "node is already degraded")
+
+	for range 3 {
+		alloc := &nodemanager.AllocationAction{}
+		alloc.IPv4.MaxIPsToAllocate = 2
+		_, _, err := n.CreateInterface(context.Background(), alloc, hivetest.Logger(t))
+		require.NoError(t, err)
+		// Re-evaluation picks the higher-availability subnet, so the ENI is NOT
+		// stuck on the fragmented subnet.
+		require.Equal(t, ipamTypes.PoolID(healthySubnetID), alloc.PoolID, "new ENI placed in the higher-availability subnet")
+		require.False(t, n.IsPrefixDelegated(), "node stays disabled")
+	}
+
+	subnetsAfter, err := api.GetSubnets(context.Background(), "vpc-1")
+	require.NoError(t, err)
+	// Every ENI is created in /32 mode: primary + 2 secondary = 3 per ENI, 3 ENIs
+	// = 9 (2000 -> 1991). A successful /28 would have consumed ~16 per ENI, so the
+	// drop of 9 proves no prefixes were allocated despite the subnet having /28
+	// capacity. Prefix delegation is never re-enabled node wide.
+	require.Equal(t, 1991, subnetsAfter[healthySubnetID].AvailableAddresses, "healthy subnet consumed by /32 ENIs (3 each), proving no prefixes were allocated")
+	require.Equal(t, 100, subnetsAfter[fragSubnetID].AvailableAddresses, "fragmented subnet untouched")
+}
+
+// TestNodeSubnetPreferenceFallsBackToSiblingOnPrefixFailure validates that when
+// the node subnet (NodeSubnetID path) is fragmented, the cross-subnet retry finds
+// a healthy sibling and creates the ENI there with a prefix instead of falling
+// back to /32 in the node subnet.
+func TestNodeSubnetPreferenceFallsBackToSiblingOnPrefixFailure(t *testing.T) {
+	const (
+		nodeSubnetID    = "subnet-x"
+		healthySubnetID = "subnet-y"
+	)
+	x := &ipamTypes.Subnet{ID: nodeSubnetID, VirtualNetworkID: "vpc-1", AvailabilityZone: "eu-west-1a", AvailableAddresses: 15}
+	y := &ipamTypes.Subnet{ID: healthySubnetID, VirtualNetworkID: "vpc-1", AvailabilityZone: "eu-west-1a", AvailableAddresses: 2000}
+	api := ec2mock.NewAPI(
+		[]*ipamTypes.Subnet{x, y},
+		[]*ipamTypes.VirtualNetwork{{ID: "vpc-1"}},
+		nil,
+		nil,
+	)
+	api.SetSubnetAtPrefixCapacity(nodeSubnetID, true)
+	metaMock, _ := metadataMock.NewMetadataMock()
+	instances, err := NewInstancesManager(context.Background(), hivetest.Logger(t), api, metaMock)
+	require.NoError(t, err)
+	instances.subnets = map[string]*ipamTypes.Subnet{
+		nodeSubnetID:    x.DeepCopy(),
+		healthySubnetID: y.DeepCopy(),
+	}
+
+	k8sObj := newCiliumNode("node1", withInstanceType("m5.large"))
+	k8sObj.Spec.ENI.VpcID = "vpc-1"
+	k8sObj.Spec.ENI.AvailabilityZone = "eu-west-1a"
+	k8sObj.Spec.ENI.NodeSubnetID = nodeSubnetID
+	k8sObj.Spec.ENI.SecurityGroups = []string{"sg-1"}
+
+	fake := &fakeOpsNode{mockIPAMNode: mockIPAMNode{instanceID: "i-123", prefixDelegation: true}}
+	n := &Node{
+		rootLogger: hivetest.Logger(t),
+		manager:    instances,
+		k8sObj:     k8sObj,
+		node:       fake,
+		enis:       map[string]eniTypes.ENI{},
+	}
+	n.logger.Store(n.rootLogger)
+	fake.ops = n
+
+	require.True(t, n.IsPrefixDelegated(), "node should start prefix delegated")
+
+	alloc := &nodemanager.AllocationAction{}
+	alloc.IPv4.MaxIPsToAllocate = 2
+	_, _, err = n.CreateInterface(context.Background(), alloc, hivetest.Logger(t))
+	require.NoError(t, err)
+
+	// The cross-subnet retry found the healthy sibling.
+	require.Equal(t, ipamTypes.PoolID(healthySubnetID), alloc.PoolID,
+		"cross-subnet retry must land the ENI in the healthy sibling subnet")
+
+	subnetsAfter, err := api.GetSubnets(context.Background(), "vpc-1")
+	require.NoError(t, err)
+	// Node subnet untouched: /32 fallback never ran there.
+	require.Equal(t, 15, subnetsAfter[nodeSubnetID].AvailableAddresses,
+		"node subnet must be untouched after cross-subnet retry")
+	// Healthy subnet consumed toAllocate+1 + /28 = 19 (2000 -> 1981).
+	require.Equal(t, 1981, subnetsAfter[healthySubnetID].AvailableAddresses,
+		"healthy sibling consumed by prefix allocation")
+	// Node stays delegated.
+	require.True(t, n.IsPrefixDelegated(), "node must remain prefix delegated")
+}
+
+// TestPrepareIPAllocationPrefersExistingENIInNodeSubnet answers the reporter's
+// first question: "will Cilium use the ENI the node already has, even when a /28
+// can no longer be attached?" Yes. PrepareIPAllocation iterates only the node's
+// existing ENIs and selects the first one that still has room and whose subnet
+// reports any free address. It never considers a subnet that has no ENI on the
+// node. So the existing ENI pinned to the fragmented node subnet is selected for
+// top-up before any new ENI or any other subnet is even looked at. AllocateIPs
+// then tops it up (see TestAllocateIPsFallsBackToSlash32OnExistingENIInSameSubnet).
+func TestPrepareIPAllocationPrefersExistingENIInNodeSubnet(t *testing.T) {
+	const (
+		nodeSubnetID    = "subnet-x"
+		healthySubnetID = "subnet-y"
+	)
+	x := &ipamTypes.Subnet{ID: nodeSubnetID, VirtualNetworkID: "vpc-1", AvailabilityZone: "eu-west-1a", AvailableAddresses: 15}
+	y := &ipamTypes.Subnet{ID: healthySubnetID, VirtualNetworkID: "vpc-1", AvailabilityZone: "eu-west-1a", AvailableAddresses: 2000}
+	api := ec2mock.NewAPI(
+		[]*ipamTypes.Subnet{x, y},
+		[]*ipamTypes.VirtualNetwork{{ID: "vpc-1"}},
+		nil,
+		nil,
+	)
+	api.SetSubnetAtPrefixCapacity(nodeSubnetID, true)
+	metaMock, _ := metadataMock.NewMetadataMock()
+	instances, err := NewInstancesManager(context.Background(), hivetest.Logger(t), api, metaMock)
+	require.NoError(t, err)
+	instances.subnets = map[string]*ipamTypes.Subnet{
+		nodeSubnetID:    x.DeepCopy(),
+		healthySubnetID: y.DeepCopy(),
+	}
+
+	k8sObj := newCiliumNode("node1", withInstanceType("m5.large"))
+	k8sObj.Spec.ENI.VpcID = "vpc-1"
+	k8sObj.Spec.ENI.AvailabilityZone = "eu-west-1a"
+	k8sObj.Spec.ENI.NodeSubnetID = nodeSubnetID
+
+	fake := &fakeOpsNode{mockIPAMNode: mockIPAMNode{instanceID: "i-123", prefixDelegation: true}}
+	n := &Node{
+		rootLogger: hivetest.Logger(t),
+		manager:    instances,
+		k8sObj:     k8sObj,
+		node:       fake,
+		enis:       map[string]eniTypes.ENI{},
+	}
+	n.logger.Store(n.rootLogger)
+	fake.ops = n
+
+	// The node's existing prefix-delegated primary ENI in subnet-x, with room.
+	n.enis["eni-primary"] = eniTypes.ENI{
+		ID:        "eni-primary",
+		IP:        iputil.AddrFrom(netip.MustParseAddr("10.0.0.4")),
+		Addresses: []iputil.Addr{iputil.AddrFrom(netip.MustParseAddr("10.0.0.16"))},
+		Prefixes:  []iputil.Prefix{iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.16/28"))},
+		Subnet:    eniTypes.AwsSubnet{ID: nodeSubnetID},
+		Number:    0,
+	}
+	require.True(t, n.IsPrefixDelegated(), "node should be prefix delegated")
+
+	a, err := n.PrepareIPAllocation(hivetest.Logger(t))
+	require.NoError(t, err)
+	// The existing ENI in the node subnet is chosen for top-up.
+	require.Equal(t, "eni-primary", a.InterfaceID, "existing ENI in the node subnet is selected")
+	require.Equal(t, ipamTypes.PoolID(nodeSubnetID), a.PoolID, "top-up targets the node subnet, not the healthy sibling")
+	require.Equal(t, 1, a.IPv4.InterfaceCandidates, "only the node's own ENI is a candidate")
+	require.Positive(t, a.IPv4.AvailableForAllocation, "the existing ENI is topped up rather than creating a new ENI")
+}
+
+// TestAllocateIPsFallsBackToSlash32OnExistingENIInSameSubnet reproduces the
+// "Resolving IP deficit ... selectedInterface=eni-... selectedPoolID=subnet-X"
+// path: once an existing ENI in the fragmented subnet is selected, AllocateIPs
+// tries to add a /28 prefix to it, AssignENIPrefixes fails with the AWS subnet
+// full error, and it falls back to AssignPrivateIpAddresses (/32) on that SAME
+// ENI in the SAME subnet. There is no subnet selection in this path at all, so
+// the healthy sibling subnet is irrelevant: the existing ENI is pinned to the
+// fragmented subnet and that is where the /32 addresses are added.
+func TestAllocateIPsFallsBackToSlash32OnExistingENIInSameSubnet(t *testing.T) {
+	const (
+		nodeSubnetID    = "subnet-x"
+		healthySubnetID = "subnet-y"
+	)
+	x := &ipamTypes.Subnet{ID: nodeSubnetID, VirtualNetworkID: "vpc-1", AvailabilityZone: "eu-west-1a", AvailableAddresses: 15}
+	y := &ipamTypes.Subnet{ID: healthySubnetID, VirtualNetworkID: "vpc-1", AvailabilityZone: "eu-west-1a", AvailableAddresses: 2000}
+	api := ec2mock.NewAPI(
+		[]*ipamTypes.Subnet{x, y},
+		[]*ipamTypes.VirtualNetwork{{ID: "vpc-1"}},
+		nil,
+		nil,
+	)
+	api.SetSubnetAtPrefixCapacity(nodeSubnetID, true)
+	metaMock, _ := metadataMock.NewMetadataMock()
+	instances, err := NewInstancesManager(context.Background(), hivetest.Logger(t), api, metaMock)
+	require.NoError(t, err)
+	instances.subnets = map[string]*ipamTypes.Subnet{
+		nodeSubnetID:    x.DeepCopy(),
+		healthySubnetID: y.DeepCopy(),
+	}
+
+	k8sObj := newCiliumNode("node1", withInstanceType("m5.large"))
+	k8sObj.Spec.ENI.VpcID = "vpc-1"
+	k8sObj.Spec.ENI.AvailabilityZone = "eu-west-1a"
+	k8sObj.Spec.ENI.NodeSubnetID = nodeSubnetID
+	k8sObj.Spec.ENI.SecurityGroups = []string{"sg-1"}
+
+	fake := &fakeOpsNode{mockIPAMNode: mockIPAMNode{instanceID: "i-123", prefixDelegation: true}}
+	n := &Node{
+		rootLogger: hivetest.Logger(t),
+		manager:    instances,
+		k8sObj:     k8sObj,
+		node:       fake,
+		enis:       map[string]eniTypes.ENI{},
+	}
+	n.logger.Store(n.rootLogger)
+	fake.ops = n
+
+	// Register an existing ENI in subnet-x with the mock (prefixes off so the
+	// create succeeds) and mirror it into the node view as prefix-delegated-capable.
+	eniID, _, err := api.CreateNetworkInterface(context.Background(), 0, nodeSubnetID, "desc", []string{"sg-1"}, false, false)
+	require.NoError(t, err)
+	_, err = api.AttachNetworkInterface(context.Background(), 0, "i-123", eniID)
+	require.NoError(t, err)
+	n.enis[eniID] = eniTypes.ENI{
+		ID:        eniID,
+		IP:        iputil.AddrFrom(netip.MustParseAddr("10.0.0.4")),
+		Addresses: []iputil.Addr{iputil.AddrFrom(netip.MustParseAddr("10.0.0.4"))},
+		Prefixes:  nil,
+		Subnet:    eniTypes.AwsSubnet{ID: nodeSubnetID},
+	}
+	require.True(t, n.IsPrefixDelegated(), "node should be prefix delegated")
+
+	subnetsBefore, err := api.GetSubnets(context.Background(), "vpc-1")
+	require.NoError(t, err)
+	xBefore := subnetsBefore[nodeSubnetID].AvailableAddresses
+
+	a := &nodemanager.AllocationAction{InterfaceID: eniID}
+	a.PoolID = ipamTypes.PoolID(nodeSubnetID)
+	a.IPv4.AvailableForAllocation = 2
+	err = n.AllocateIPs(context.Background(), a)
+	require.NoError(t, err, "AllocateIPs falls back to /32 and succeeds on the existing ENI")
+
+	subnetsAfter, err := api.GetSubnets(context.Background(), "vpc-1")
+	require.NoError(t, err)
+	// The two /32 addresses were taken from subnet-x (the existing ENI's subnet),
+	// proving the prefix create failed and the /32 fallback ran in the same subnet.
+	require.Equal(t, xBefore-2, subnetsAfter[nodeSubnetID].AvailableAddresses, "the /32 fallback consumed 2 addresses in the node subnet")
+	// The healthy sibling subnet is untouched: AllocateIPs never does subnet selection.
+	require.Equal(t, 2000, subnetsAfter[healthySubnetID].AvailableAddresses, "healthy sibling subnet untouched")
+}
+
+// TestAllocateIPsProducesMixedPrefixAndSlash32ENI addresses the field observation
+// that mixed ENIs (a single ENI carrying both /28 prefixes and individual /32
+// secondary IPs) are never seen on real nodes. The question it answers is
+// whether Cilium has a hard guard against producing one. It does NOT.
+//
+// AWS allows an ENI to hold both prefixes and individual secondary IPs at once
+// (each secondary IP costs one prefix slot, per the EKS prefix-mode docs), and
+// nothing in AllocateIPs, PrepareIPAllocation, or the IPAM handleIPAllocation
+// loop prevents it. This test gives an existing ENI a real /28 prefix while its
+// subnet is healthy, then fragments the subnet (no free /28 left) and drives
+// AllocateIPs on that same ENI while the node is still prefix delegated. The
+// prefix top-up (AssignENIPrefixes) fails, the /32 fallback (AssignPrivateIp
+// Addresses) succeeds on the SAME ENI, and the ENI ends up MIXED: it keeps its
+// prefix and gains 2 individual /32 addresses.
+//
+// So the reason mixed ENIs are not observed in practice is allocation ordering,
+// not a code guard: in the field, fragmentation usually bites the NEW-ENI path
+// (CreateInterface), which produces a zero-prefix /32-only ENI and immediately
+// disables prefix delegation node wide (IsPrefixDelegated requires zero prefixes
+// on an ENI to trip). Once disabled, Cilium issues no further prefix requests,
+// so the steady state is prefix-only ENIs plus /32-only ENIs, never mixed. The
+// reporter's own warning line (from CreateInterface, addresses=2,
+// isPrefixDelegated=true) confirms the new-ENI path was the trigger. This test
+// proves the mixed state is nonetheless reachable through the top-up path.
+func TestAllocateIPsProducesMixedPrefixAndSlash32ENI(t *testing.T) {
+	const nodeSubnetID = "subnet-x"
+	x := &ipamTypes.Subnet{ID: nodeSubnetID, VirtualNetworkID: "vpc-1", AvailabilityZone: "eu-west-1a", AvailableAddresses: 1000}
+	api := ec2mock.NewAPI(
+		[]*ipamTypes.Subnet{x},
+		[]*ipamTypes.VirtualNetwork{{ID: "vpc-1"}},
+		nil,
+		nil,
+	)
+	metaMock, _ := metadataMock.NewMetadataMock()
+	instances, err := NewInstancesManager(context.Background(), hivetest.Logger(t), api, metaMock)
+	require.NoError(t, err)
+	instances.subnets = map[string]*ipamTypes.Subnet{nodeSubnetID: x.DeepCopy()}
+
+	k8sObj := newCiliumNode("node1", withInstanceType("m5.large"))
+	k8sObj.Spec.ENI.VpcID = "vpc-1"
+	k8sObj.Spec.ENI.AvailabilityZone = "eu-west-1a"
+	k8sObj.Spec.ENI.NodeSubnetID = nodeSubnetID
+	k8sObj.Spec.ENI.SecurityGroups = []string{"sg-1"}
+
+	fake := &fakeOpsNode{mockIPAMNode: mockIPAMNode{instanceID: "i-123", prefixDelegation: true}}
+	n := &Node{
+		rootLogger: hivetest.Logger(t),
+		manager:    instances,
+		k8sObj:     k8sObj,
+		node:       fake,
+		enis:       map[string]eniTypes.ENI{},
+	}
+	n.logger.Store(n.rootLogger)
+	fake.ops = n
+
+	// Create an ENI in subnet-x and give it ONE real /28 prefix while the subnet
+	// is still healthy (this is the normal partial prefix ENI: a new ENI is born
+	// with ceil(toAllocate/16) prefixes, so it has free prefix slots left).
+	eniID, _, err := api.CreateNetworkInterface(context.Background(), 0, nodeSubnetID, "desc", []string{"sg-1"}, false, false)
+	require.NoError(t, err)
+	_, err = api.AttachNetworkInterface(context.Background(), 0, "i-123", eniID)
+	require.NoError(t, err)
+	require.NoError(t, api.AssignENIPrefixes(context.Background(), eniID, 1), "prefix assignment succeeds while subnet is healthy")
+
+	// Snapshot the ENI state after the prefix is assigned: 1 prefix, plus its 16
+	// expanded /28 IPs (and any primary) in Addresses.
+	instBefore, err := api.GetInstance(context.Background(), nil, nil, "i-123")
+	require.NoError(t, err)
+	eniBefore := instBefore.Interfaces[eniID].(*eniTypes.ENI)
+	require.Len(t, eniBefore.Prefixes, 1, "ENI starts with exactly one /28 prefix")
+	addrsAfterPrefix := len(eniBefore.Addresses)
+
+	// Mirror the prefix ENI into the node view so IsPrefixDelegated stays true
+	// (the gate only trips on a zero-prefix ENI). This ENI has a prefix, so the
+	// node is still prefix delegated.
+	n.enis[eniID] = eniTypes.ENI{
+		ID:        eniID,
+		IP:        iputil.AddrFrom(netip.MustParseAddr("10.0.0.4")),
+		Addresses: []iputil.Addr{iputil.AddrFrom(netip.MustParseAddr("10.0.0.4"))},
+		Prefixes:  eniBefore.Prefixes,
+		Subnet:    eniTypes.AwsSubnet{ID: nodeSubnetID},
+	}
+	require.True(t, n.IsPrefixDelegated(), "node is still prefix delegated (the ENI has a prefix)")
+
+	// Now fragment the subnet: free /32s remain, but no free /28 block.
+	api.SetSubnetAtPrefixCapacity(nodeSubnetID, true)
+
+	// Top up the SAME existing prefix ENI. AllocateIPs tries AssignENIPrefixes
+	// (fails, subnet at prefix capacity) and falls back to AssignPrivateIpAddresses
+	// (/32) on the same ENI.
+	a := &nodemanager.AllocationAction{InterfaceID: eniID}
+	a.PoolID = ipamTypes.PoolID(nodeSubnetID)
+	a.IPv4.AvailableForAllocation = 2
+	require.NoError(t, n.AllocateIPs(context.Background(), a), "the /32 fallback succeeds on the existing prefix ENI")
+
+	// Read the ENI back: it now carries BOTH its original /28 prefix AND 2
+	// individual /32 secondary IPs. Cilium produced a mixed ENI; there is no guard.
+	instAfter, err := api.GetInstance(context.Background(), nil, nil, "i-123")
+	require.NoError(t, err)
+	eniAfter := instAfter.Interfaces[eniID].(*eniTypes.ENI)
+	require.Len(t, eniAfter.Prefixes, 1, "the ENI keeps its /28 prefix")
+	require.Len(t, eniAfter.Addresses, addrsAfterPrefix+2,
+		"2 individual /32 addresses were added on top of the prefix: this is a MIXED ENI")
+	// A mixed ENI has more addresses than its prefixes alone account for.
+	require.Greater(t, len(eniAfter.Addresses), 16*len(eniAfter.Prefixes),
+		"the ENI carries /32 secondary IPs beyond what its /28 prefix provides (mixed prefix + /32)")
+}
+
+// TestFullPrefixDelegatedENIIsNotToppedUpNewENIGetsSlash32 validates the field
+// observation that when a node already has a prefix delegated ENI and needs more
+// IPs, Cilium adds a NEW ENI (which falls back to /32 in a fragmented subnet)
+// rather than adding /32 addresses to the existing /28 ENI.
+//
+// The reason is structural, not incidental. handleIPAllocation (pkg/ipam/node.go)
+// creates a new ENI only when no existing ENI has spare capacity in a subnet that
+// still reports free addresses; otherwise it tops up the existing ENI. A prefix
+// delegated ENI is "full" once it holds its maximum prefixes: with prefix
+// delegation getEffectiveIPLimits returns (limits.IPv4-1)*ENIPDBlockSizeIPv4,
+// which for m5.large is (10-1)*16 = 144 addresses = 9 prefixes. At that point
+// availableOnENI is 0 and PrepareIPAllocation will not select the ENI for top-up.
+// So the existing /28 ENI is left untouched and a new ENI is created for the
+// extra demand. In a fragmented subnet that new ENI takes the /32 fallback and
+// becomes the zero-prefix ENI that disables prefix delegation node wide.
+//
+// This is why a mixed ENI is not produced on the steady-state path: by the time a
+// second ENI is needed, the first is full, so it is never topped up with /32. A
+// mixed ENI only arises if a PARTIAL prefix ENI is topped up while its subnet is
+// fragmented, which is the artificial setup in
+// TestAllocateIPsProducesMixedPrefixAndSlash32ENI (reachable, but not how the
+// allocator behaves once an ENI has been filled).
+func TestFullPrefixDelegatedENIIsNotToppedUpNewENIGetsSlash32(t *testing.T) {
+	const nodeSubnetID = "subnet-x"
+	// Fragmented node subnet: free /32s (100) but no free /28 block.
+	x := &ipamTypes.Subnet{ID: nodeSubnetID, VirtualNetworkID: "vpc-1", AvailabilityZone: "eu-west-1a", AvailableAddresses: 100}
+	api := ec2mock.NewAPI(
+		[]*ipamTypes.Subnet{x},
+		[]*ipamTypes.VirtualNetwork{{ID: "vpc-1"}},
+		nil,
+		nil,
+	)
+	api.SetSubnetAtPrefixCapacity(nodeSubnetID, true)
+	metaMock, _ := metadataMock.NewMetadataMock()
+	instances, err := NewInstancesManager(context.Background(), hivetest.Logger(t), api, metaMock)
+	require.NoError(t, err)
+	instances.subnets = map[string]*ipamTypes.Subnet{nodeSubnetID: x.DeepCopy()}
+
+	k8sObj := newCiliumNode("node1", withInstanceType("m5.large"))
+	k8sObj.Spec.ENI.VpcID = "vpc-1"
+	k8sObj.Spec.ENI.AvailabilityZone = "eu-west-1a"
+	k8sObj.Spec.ENI.NodeSubnetID = nodeSubnetID
+	k8sObj.Spec.ENI.SecurityGroups = []string{"sg-1"}
+
+	fake := &fakeOpsNode{mockIPAMNode: mockIPAMNode{instanceID: "i-123", prefixDelegation: true}}
+	n := &Node{
+		rootLogger: hivetest.Logger(t),
+		manager:    instances,
+		k8sObj:     k8sObj,
+		node:       fake,
+		enis:       map[string]eniTypes.ENI{},
+	}
+	n.logger.Store(n.rootLogger)
+	fake.ops = n
+
+	// Build a FULL prefix delegated ENI: 9 /28 prefixes and their 144 expanded
+	// addresses, the maximum for m5.large. availableOnENI = 144 - 144 = 0.
+	var addrs []iputil.Addr
+	var prefixes []iputil.Prefix
+	for p := range 9 {
+		prefixes = append(prefixes, iputil.PrefixFrom(netip.MustParsePrefix(fmt.Sprintf("10.0.%d.0/28", p))))
+		for h := range 16 {
+			addrs = append(addrs, iputil.AddrFrom(netip.MustParseAddr(fmt.Sprintf("10.0.%d.%d", p, h))))
+		}
+	}
+	require.Len(t, addrs, 144)
+	n.enis["eni-full-pd"] = eniTypes.ENI{
+		ID:        "eni-full-pd",
+		IP:        iputil.AddrFrom(netip.MustParseAddr("10.0.255.4")),
+		Addresses: addrs,
+		Prefixes:  prefixes,
+		Subnet:    eniTypes.AwsSubnet{ID: nodeSubnetID},
+		Number:    0,
+	}
+	require.True(t, n.IsPrefixDelegated(), "node is prefix delegated (the existing ENI is all prefixes)")
+
+	// PrepareIPAllocation must NOT select the full prefix ENI for top-up: it has no
+	// spare capacity, so there is no interface candidate and no InterfaceID, which
+	// means AllocateIPs is never called on it and no /32 is added to the /28 ENI.
+	a, err := n.PrepareIPAllocation(hivetest.Logger(t))
+	require.NoError(t, err)
+	require.Equal(t, 0, a.IPv4.InterfaceCandidates, "the full prefix ENI is not a candidate for top-up")
+	require.Empty(t, a.InterfaceID, "no existing ENI is selected, so /32 is never added to the /28 ENI")
+	require.Zero(t, a.IPv4.AvailableForAllocation, "nothing can be allocated on the existing ENI")
+	require.Positive(t, a.EmptyInterfaceSlots, "a new ENI slot is available, so a new ENI is created instead")
+
+	// Creating the new ENI: in the fragmented subnet it falls back to /32. This is
+	// the new /32 ENI the operator observes being added to the node.
+	alloc := &nodemanager.AllocationAction{}
+	alloc.IPv4.MaxIPsToAllocate = 2
+	toAllocate, _, err := n.CreateInterface(context.Background(), alloc, hivetest.Logger(t))
+	require.NoError(t, err)
+	require.Equal(t, 2, toAllocate)
+	require.Equal(t, ipamTypes.PoolID(nodeSubnetID), alloc.PoolID, "the new ENI is created in the node subnet")
+
+	// The original prefix ENI is left exactly as it was: still 9 prefixes and 144
+	// addresses, with no individual /32 secondary IPs added to it.
+	require.Len(t, n.enis["eni-full-pd"].Prefixes, 9, "the existing /28 ENI keeps all its prefixes")
+	require.Len(t, n.enis["eni-full-pd"].Addresses, 144, "no /32 was added to the existing /28 ENI")
+}
+
+// TestEndToEndPartiallyUsedPrefixENIIsToppedUpNotNewENI drives the REAL IPAM
+// maintenance loop (ipam.NodeManager.MaintainIPPool, which runs PrepareIPAllocation
+// then handleIPAllocation then AllocateIPs or CreateInterface) instead of calling
+// AllocateIPs directly. It answers the question: when a node already has a prefix
+// delegated ENI that is barely used (lots of free prefix capacity) and the subnet
+// becomes fragmented (no free /28, but free /32s), does Cilium add /32 to that
+// existing ENI, or does it create a NEW ENI?
+//
+// Verified answer: the existing ENI is topped up with /32 (it becomes a MIXED ENI
+// with both a /28 prefix and individual /32 addresses), and NO new ENI is created.
+// This is the authoritative behavior of the real allocation loop, and it matches
+// Cilium's own TestNodeManagerPrefixDelegation (which adds a single /32 on the
+// fallback, not a new ENI). A new ENI is created only once the existing ENI is
+// full (see TestFullPrefixDelegatedENIIsNotToppedUpNewENIGetsSlash32).
+func TestEndToEndPartiallyUsedPrefixENIIsToppedUpNotNewENI(t *testing.T) {
+	setup(t)
+	const instanceID = "i-e2e-partial-pd-0"
+
+	pdTestSubnet := *testSubnet
+	pdTestSubnet.AvailableAddresses = 1000
+	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{&pdTestSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
+	instances, err := NewInstancesManager(t.Context(), hivetest.Logger(t), ec2api, metadataMockapi)
+	require.NoError(t, err)
+
+	// One prefix delegated ENI on the node (index 0), created while the subnet is
+	// healthy so it gets a real /28 prefix.
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, pdTestSubnet.ID, "desc", []string{"sg1", "sg2"}, true, false)
+	require.NoError(t, err)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
+	require.NoError(t, err)
+	instances.Resync(t.Context())
+
+	mngr, err := nodemanager.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, 0, true)
+	require.NoError(t, err)
+
+	cn := newCiliumNode("node1", withInstanceID(instanceID), withInstanceType("m5.large"), withIPAMPreAllocate(8))
+	mngr.Upsert(cn)
+	require.NoError(t, testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node1", 0) }, 5*time.Second))
+	node := mngr.Get("node1")
+	require.NotNil(t, node)
+	// The node has a single prefix delegated ENI with 16 IPs (one /28) and 0 used:
+	// barely used, with room for 8 more prefixes.
+	require.Equal(t, 16, node.Stats().IPv4.AvailableIPs, "node starts with one /28 prefix")
+	require.Equal(t, 0, node.Stats().IPv4.UsedIPs)
+
+	// Fragment the subnet: free /32s remain (1000) but no free /28 block.
+	ec2api.SetSubnetAtPrefixCapacity(pdTestSubnet.ID, true)
+
+	// Create a deficit on the barely-used ENI (use 12 of 16, so the node needs
+	// 12 + PreAllocate(8) = 20 available).
+	mngr.Upsert(updateCiliumNode(cn, 16, 12))
+	require.NoError(t, testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node1", 0) }, 10*time.Second))
+	node = mngr.Get("node1")
+	require.NotNil(t, node)
+
+	node.Ops().PopulateStatusFields(cn)
+
+	// The real loop topped up the EXISTING ENI with /32, it did NOT create a new ENI.
+	require.Len(t, cn.Status.ENI.ENIs, 1, "no new ENI was created; the existing ENI was topped up")
+	existing := cn.Status.ENI.ENIs[eniID1]
+	require.Len(t, existing.Prefixes, 1, "the existing ENI keeps its single /28 prefix")
+	// 16 IPs from the /28 prefix plus 4 individual /32 addresses = 20: a MIXED ENI.
+	require.Greater(t, len(existing.Addresses), 16*len(existing.Prefixes),
+		"the existing ENI now carries individual /32 addresses on top of its /28 prefix (mixed)")
+	require.Equal(t, 20, node.Stats().IPv4.AvailableIPs, "deficit resolved by adding /32 to the existing ENI (16 -> 20)")
+	require.Equal(t, 12, node.Stats().IPv4.UsedIPs)
+}
+
+// TestPrepareIPAllocationSkipsExistingENIWhenSubnetReportsNoFreeAddresses pins the
+// one condition under which a barely-used existing prefix ENI is NOT topped up and
+// Cilium creates a new ENI instead. The default behavior (verified by
+// TestEndToEndPartiallyUsedPrefixENIIsToppedUpNotNewENI) is to top up the existing
+// ENI, but PrepareIPAllocation only selects an existing ENI for top-up when its
+// subnet's cached AvailableAddresses is greater than 0:
+//
+//	if subnet := n.manager.GetSubnet(e.Subnet.ID); subnet != nil {
+//	    if subnet.AvailableAddresses > 0 && a.InterfaceID == "" { ... select it ... }
+//	}
+//
+// If the subnet reports zero free addresses, the existing ENI is skipped even
+// though it still has spare prefix capacity, so AllocateIPs is never called on it
+// (no /32 is added to the /28 ENI) and handleIPAllocation creates a new ENI
+// instead. The reporter described exactly this input: the fragmented subnet
+// "reported fewer available IPs due to AWS address reservations". When those
+// reservations drive the reported AvailableIpAddressCount to zero, this is the
+// code path that produces "a new ENI is added, the existing /28 ENI is untouched"
+// even when that ENI is barely used.
+func TestPrepareIPAllocationSkipsExistingENIWhenSubnetReportsNoFreeAddresses(t *testing.T) {
+	const nodeSubnetID = "subnet-x"
+	// Subnet reports ZERO free addresses (AWS reservations counted as used), even
+	// though in reality it is only /28-fragmented and still has assignable /32s.
+	x := &ipamTypes.Subnet{ID: nodeSubnetID, VirtualNetworkID: "vpc-1", AvailabilityZone: "eu-west-1a", AvailableAddresses: 0}
+	api := ec2mock.NewAPI(
+		[]*ipamTypes.Subnet{x},
+		[]*ipamTypes.VirtualNetwork{{ID: "vpc-1"}},
+		nil,
+		nil,
+	)
+	metaMock, _ := metadataMock.NewMetadataMock()
+	instances, err := NewInstancesManager(context.Background(), hivetest.Logger(t), api, metaMock)
+	require.NoError(t, err)
+	instances.subnets = map[string]*ipamTypes.Subnet{nodeSubnetID: x.DeepCopy()}
+
+	k8sObj := newCiliumNode("node1", withInstanceType("m5.large"))
+	k8sObj.Spec.ENI.VpcID = "vpc-1"
+	k8sObj.Spec.ENI.AvailabilityZone = "eu-west-1a"
+	k8sObj.Spec.ENI.NodeSubnetID = nodeSubnetID
+
+	fake := &fakeOpsNode{mockIPAMNode: mockIPAMNode{instanceID: "i-123", prefixDelegation: true}}
+	n := &Node{
+		rootLogger: hivetest.Logger(t),
+		manager:    instances,
+		k8sObj:     k8sObj,
+		node:       fake,
+		enis:       map[string]eniTypes.ENI{},
+	}
+	n.logger.Store(n.rootLogger)
+	fake.ops = n
+
+	// A barely-used prefix ENI: one /28 (16 addresses), lots of free prefix room.
+	var addrs []iputil.Addr
+	for i := range 16 {
+		addrs = append(addrs, iputil.AddrFrom(netip.MustParseAddr(fmt.Sprintf("10.0.0.%d", i+16))))
+	}
+	n.enis["eni-pd"] = eniTypes.ENI{
+		ID:        "eni-pd",
+		IP:        iputil.AddrFrom(netip.MustParseAddr("10.0.0.4")),
+		Addresses: addrs,
+		Prefixes:  []iputil.Prefix{iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.16/28"))},
+		Subnet:    eniTypes.AwsSubnet{ID: nodeSubnetID},
+		Number:    0,
+	}
+	require.True(t, n.IsPrefixDelegated(), "node is prefix delegated")
+
+	a, err := n.PrepareIPAllocation(hivetest.Logger(t))
+	require.NoError(t, err)
+	// The ENI has spare prefix capacity, so it is counted as a candidate ...
+	require.Equal(t, 1, a.IPv4.InterfaceCandidates, "the barely-used ENI has spare prefix capacity")
+	// ... but it is NOT selected for top-up because its subnet reports no free
+	// addresses, so AllocateIPs is never called on it and no /32 is added to it.
+	require.Empty(t, a.InterfaceID, "existing ENI is skipped when its subnet reports zero free addresses")
+	require.Zero(t, a.IPv4.AvailableForAllocation, "nothing is allocated on the existing ENI")
+	// A free interface slot remains, so handleIPAllocation creates a NEW ENI.
+	require.Positive(t, a.EmptyInterfaceSlots, "a new ENI is created instead of topping up the existing one")
+}

--- a/pkg/aws/ipam/node_prefix_fallback_test.go
+++ b/pkg/aws/ipam/node_prefix_fallback_test.go
@@ -438,6 +438,16 @@ func TestNodeSubnetPreferenceFallsBackToSiblingOnPrefixFailure(t *testing.T) {
 		nodeSubnetID:    x.DeepCopy(),
 		healthySubnetID: y.DeepCopy(),
 	}
+	instances.routeTables = ipamTypes.RouteTableMap{
+		"rt-1": &ipamTypes.RouteTable{
+			ID:               "rt-1",
+			VirtualNetworkID: "vpc-1",
+			Subnets: map[string]struct{}{
+				nodeSubnetID:    {},
+				healthySubnetID: {},
+			},
+		},
+	}
 
 	k8sObj := newCiliumNode("node1", withInstanceType("m5.large"))
 	k8sObj.Spec.ENI.VpcID = "vpc-1"

--- a/pkg/aws/ipam/node_prefix_fallback_test.go
+++ b/pkg/aws/ipam/node_prefix_fallback_test.go
@@ -1,0 +1,992 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipam
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/operator/pkg/ipam/nodemanager"
+	ec2mock "github.com/cilium/cilium/pkg/aws/api/mock"
+	metadataMock "github.com/cilium/cilium/pkg/aws/metadata/mock"
+	eniTypes "github.com/cilium/cilium/pkg/aws/types"
+	iputil "github.com/cilium/cilium/pkg/ip"
+	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+// fakeOpsNode lets us drive Node.CreateInterface in a unit test. The default
+// mockIPAMNode.Ops() panics, but CreateInterface calls n.node.Ops().IsPrefixDelegated(),
+// so we return the Node itself as its own NodeOperations.
+type fakeOpsNode struct {
+	mockIPAMNode
+	ops nodemanager.NodeOperations
+}
+
+func (f *fakeOpsNode) Ops() nodemanager.NodeOperations { return f.ops }
+
+// TestPrefixFallbackFallsBackToSameSubnetWhenNoSiblingAvailable documents the
+// correct behavior when a prefix delegated ENI cannot get a /28 in the selected
+// subnet AND no eligible sibling subnet exists: the operator correctly falls back
+// to /32 in the same subnet. This is acceptable — cross-subnet retry only helps
+// when a sibling subnet with /28 capacity is available.
+func TestPrefixFallbackFallsBackToSameSubnetWhenNoSiblingAvailable(t *testing.T) {
+	const subnetID = "subnet-frag"
+
+	// Mock a FRAGMENTED subnet: it has plenty of free /32 addresses (1000, far
+	// more than one /28 of 16), but no free contiguous /28 prefix block. This is
+	// the real-world fragmentation case from the report: AvailableIpAddressCount
+	// stays high, yet the prefix create fails with the AWS subnet full error that
+	// isSubnetAtPrefixCapacity matches. SetSubnetAtPrefixCapacity below models the
+	// missing /28 capacity independently of the /32 count.
+	mockSubnet := &ipamTypes.Subnet{
+		ID:                 subnetID,
+		VirtualNetworkID:   "vpc-1",
+		AvailabilityZone:   "eu-west-1a",
+		AvailableAddresses: 1000,
+	}
+	api := ec2mock.NewAPI(
+		[]*ipamTypes.Subnet{mockSubnet},
+		[]*ipamTypes.VirtualNetwork{{ID: "vpc-1"}},
+		nil,
+		nil,
+	)
+	// The subnet is fragmented: no free /28 block, so prefix allocation fails
+	// while /32 allocation still succeeds.
+	api.SetSubnetAtPrefixCapacity(subnetID, true)
+	metaMock, _ := metadataMock.NewMetadataMock()
+	instances, err := NewInstancesManager(context.Background(), hivetest.Logger(t), api, metaMock)
+	require.NoError(t, err)
+
+	// findSuitableSubnet reads the manager subnet cache directly.
+	instances.subnets = map[string]*ipamTypes.Subnet{
+		subnetID: {
+			ID:                 subnetID,
+			VirtualNetworkID:   "vpc-1",
+			AvailabilityZone:   "eu-west-1a",
+			AvailableAddresses: 1000,
+		},
+	}
+
+	k8sObj := newCiliumNode("node1", withInstanceType("m5.large"))
+	k8sObj.Spec.ENI.VpcID = "vpc-1"
+	k8sObj.Spec.ENI.AvailabilityZone = "eu-west-1a"
+	k8sObj.Spec.ENI.SubnetIDs = []string{subnetID}
+	k8sObj.Spec.ENI.SecurityGroups = []string{"sg-1"}
+
+	fake := &fakeOpsNode{mockIPAMNode: mockIPAMNode{instanceID: "i-123", prefixDelegation: true}}
+	n := &Node{
+		rootLogger: hivetest.Logger(t),
+		manager:    instances,
+		k8sObj:     k8sObj,
+		node:       fake,
+		enis:       map[string]eniTypes.ENI{},
+	}
+	n.logger.Store(n.rootLogger)
+	fake.ops = n // Node is its own NodeOperations
+
+	require.True(t, n.IsPrefixDelegated(), "node should start prefix delegated")
+
+	alloc := &nodemanager.AllocationAction{}
+	alloc.IPv4.MaxIPsToAllocate = 2
+
+	toAllocate, _, err := n.CreateInterface(context.Background(), alloc, hivetest.Logger(t))
+	require.NoError(t, err)
+	require.Equal(t, 2, toAllocate)
+
+	// The ENI was created in the same subnet that could not fit a prefix.
+	require.Equal(t, ipamTypes.PoolID(subnetID), alloc.PoolID)
+
+	// Proof it used the /32 fallback and not a prefix: the mock subnet dropped by
+	// exactly primary + 2 secondary = 3 addresses (1000 -> 997). A successful
+	// prefix would have consumed a /28 block (16 addresses) instead. The subnet
+	// kept hundreds of free /32 addresses throughout, so the fallback was driven
+	// by missing /28 capacity (fragmentation), not by a nearly full subnet.
+	subnetsAfter, err := api.GetSubnets(context.Background(), "vpc-1")
+	require.NoError(t, err)
+	require.Equal(t, 997, subnetsAfter[subnetID].AvailableAddresses)
+}
+
+// TestNoPrefixENIDisablesNodeAndDoesNotRecover proves root cause 3: a single
+// ENI with secondary IPs and no prefixes disables prefix delegation for the
+// whole node, adding more prefix capable ENIs does not undo it, and the node
+// only recovers if that ENI drains down to its primary IP.
+func TestNoPrefixENIDisablesNodeAndDoesNotRecover(t *testing.T) {
+	api := ec2mock.NewAPI(nil, nil, nil, nil)
+	metaMock, _ := metadataMock.NewMetadataMock()
+	instances, err := NewInstancesManager(context.Background(), hivetest.Logger(t), api, metaMock)
+	require.NoError(t, err)
+
+	n := &Node{
+		rootLogger: hivetest.Logger(t),
+		manager:    instances,
+		k8sObj:     newCiliumNode("node1", withInstanceType("m5.large")),
+		node:       &mockIPAMNode{instanceID: "i-123", prefixDelegation: true},
+		enis:       map[string]eniTypes.ENI{},
+	}
+	n.logger.Store(n.rootLogger)
+
+	// 1. One prefix delegated ENI: node is prefix delegated.
+	n.enis["eni-pd"] = eniTypes.ENI{
+		ID:        "eni-pd",
+		IP:        iputil.AddrFrom(netip.MustParseAddr("10.0.0.4")),
+		Addresses: []iputil.Addr{iputil.AddrFrom(netip.MustParseAddr("10.0.0.16")), iputil.AddrFrom(netip.MustParseAddr("10.0.0.17"))},
+		Prefixes:  []iputil.Prefix{iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.16/28"))},
+	}
+	require.True(t, n.IsPrefixDelegated(), "single prefix ENI should be delegated")
+
+	// 2. Add a no prefix ENI with 2 secondary IPs (the /32 fallback result).
+	n.enis["eni-32"] = eniTypes.ENI{
+		ID:        "eni-32",
+		IP:        iputil.AddrFrom(netip.MustParseAddr("10.0.1.4")),
+		Addresses: []iputil.Addr{iputil.AddrFrom(netip.MustParseAddr("10.0.1.4")), iputil.AddrFrom(netip.MustParseAddr("10.0.1.5")), iputil.AddrFrom(netip.MustParseAddr("10.0.1.6"))},
+		Prefixes:  nil,
+	}
+	require.False(t, n.IsPrefixDelegated(), "one no-prefix ENI must disable the whole node")
+
+	// 3. Adding another prefix capable ENI does NOT recover the node.
+	n.enis["eni-pd2"] = eniTypes.ENI{
+		ID:        "eni-pd2",
+		IP:        iputil.AddrFrom(netip.MustParseAddr("10.0.2.4")),
+		Addresses: []iputil.Addr{iputil.AddrFrom(netip.MustParseAddr("10.0.2.16"))},
+		Prefixes:  []iputil.Prefix{iputil.PrefixFrom(netip.MustParsePrefix("10.0.2.16/28"))},
+	}
+	require.False(t, n.IsPrefixDelegated(), "extra prefix ENIs do not undo the disable")
+
+	// 4. Draining the no prefix ENI down to its primary IP recovers the node.
+	n.enis["eni-32"] = eniTypes.ENI{
+		ID:        "eni-32",
+		IP:        iputil.AddrFrom(netip.MustParseAddr("10.0.1.4")),
+		Addresses: []iputil.Addr{iputil.AddrFrom(netip.MustParseAddr("10.0.1.4"))}, // primary only, Addresses[0] == IP
+		Prefixes:  nil,
+	}
+	require.True(t, n.IsPrefixDelegated(), "node recovers only when the no-prefix ENI drains to primary")
+}
+
+// TestPrefixFallbackTriesSiblingTaggedSubnet validates that when prefix ENI
+// creation fails with InsufficientCidrBlocks in the selected subnet, CreateInterface
+// retries prefix creation in other eligible same-AZ subnets before falling back
+// to /32. With eni.subnet-tags-filter set and a healthy sibling subnet available,
+// the retry succeeds and the ENI is created with a /28 prefix in the sibling subnet.
+func TestPrefixFallbackTriesSiblingTaggedSubnet(t *testing.T) {
+	const (
+		fragSubnetID    = "subnet-frag"
+		healthySubnetID = "subnet-healthy"
+	)
+	filterTags := ipamTypes.Tags{"kubernetes.io/role/cni": "1"}
+
+	fragSubnet := &ipamTypes.Subnet{
+		ID:                 fragSubnetID,
+		VirtualNetworkID:   "vpc-1",
+		AvailabilityZone:   "eu-west-1a",
+		AvailableAddresses: 1000,
+		Tags:               filterTags,
+	}
+	healthySubnet := &ipamTypes.Subnet{
+		ID:                 healthySubnetID,
+		VirtualNetworkID:   "vpc-1",
+		AvailabilityZone:   "eu-west-1a",
+		AvailableAddresses: 500,
+		Tags:               filterTags,
+	}
+	api := ec2mock.NewAPI(
+		[]*ipamTypes.Subnet{fragSubnet, healthySubnet},
+		[]*ipamTypes.VirtualNetwork{{ID: "vpc-1"}},
+		nil,
+		nil,
+	)
+	// Only subnet-frag is fragmented. subnet-healthy has full /28 capacity.
+	api.SetSubnetAtPrefixCapacity(fragSubnetID, true)
+
+	metaMock, _ := metadataMock.NewMetadataMock()
+	instances, err := NewInstancesManager(context.Background(), hivetest.Logger(t), api, metaMock)
+	require.NoError(t, err)
+	instances.subnets = map[string]*ipamTypes.Subnet{
+		fragSubnetID:    fragSubnet.DeepCopy(),
+		healthySubnetID: healthySubnet.DeepCopy(),
+	}
+
+	k8sObj := newCiliumNode("node1", withInstanceType("m5.large"))
+	k8sObj.Spec.ENI.VpcID = "vpc-1"
+	k8sObj.Spec.ENI.AvailabilityZone = "eu-west-1a"
+	k8sObj.Spec.ENI.SubnetTags = filterTags
+	k8sObj.Spec.ENI.SecurityGroups = []string{"sg-1"}
+
+	fake := &fakeOpsNode{mockIPAMNode: mockIPAMNode{instanceID: "i-123", prefixDelegation: true}}
+	n := &Node{
+		rootLogger: hivetest.Logger(t),
+		manager:    instances,
+		k8sObj:     k8sObj,
+		node:       fake,
+		enis:       map[string]eniTypes.ENI{},
+	}
+	n.logger.Store(n.rootLogger)
+	fake.ops = n
+
+	require.True(t, n.IsPrefixDelegated(), "node should start prefix delegated")
+
+	alloc := &nodemanager.AllocationAction{}
+	alloc.IPv4.MaxIPsToAllocate = 2
+
+	toAllocate, _, err := n.CreateInterface(context.Background(), alloc, hivetest.Logger(t))
+	require.NoError(t, err)
+	require.Equal(t, 2, toAllocate)
+
+	// The retry found the healthy sibling and created the ENI there with a prefix.
+	require.Equal(t, ipamTypes.PoolID(healthySubnetID), alloc.PoolID,
+		"cross-subnet retry must land the ENI in the healthy sibling subnet")
+
+	subnetsAfter, err := api.GetSubnets(context.Background(), "vpc-1")
+	require.NoError(t, err)
+	// subnet-frag is untouched: the retry moved past it.
+	require.Equal(t, 1000, subnetsAfter[fragSubnetID].AvailableAddresses,
+		"fragmented subnet must be untouched after cross-subnet retry")
+	// subnet-healthy consumed toAllocate+1 (primary+secondaries) + /28 = 19 (500 -> 481).
+	require.Equal(t, 481, subnetsAfter[healthySubnetID].AvailableAddresses,
+		"healthy subnet must show prefix allocation (2 secondary + primary + /28 = 19 addresses)")
+	// Node stays prefix delegated: no /32-only ENI was created.
+	require.True(t, n.IsPrefixDelegated(), "node must remain prefix delegated after successful cross-subnet retry")
+}
+
+// TestMultipleFallbackENIsUseHealthySiblingAndNodeStaysDelegated validates that
+// repeated ENI creations in a fragmented subnet
+// scenario correctly retry and land in the healthy sibling with prefix delegation,
+// and the node never enters degraded /32 mode.
+func TestMultipleFallbackENIsUseHealthySiblingAndNodeStaysDelegated(t *testing.T) {
+	const (
+		fragSubnetID    = "subnet-frag"
+		healthySubnetID = "subnet-healthy"
+	)
+	filterTags := ipamTypes.Tags{"kubernetes.io/role/cni": "1"}
+	fragSubnet := &ipamTypes.Subnet{ID: fragSubnetID, VirtualNetworkID: "vpc-1", AvailabilityZone: "eu-west-1a", AvailableAddresses: 1000, Tags: filterTags}
+	healthySubnet := &ipamTypes.Subnet{ID: healthySubnetID, VirtualNetworkID: "vpc-1", AvailabilityZone: "eu-west-1a", AvailableAddresses: 500, Tags: filterTags}
+	api := ec2mock.NewAPI(
+		[]*ipamTypes.Subnet{fragSubnet, healthySubnet},
+		[]*ipamTypes.VirtualNetwork{{ID: "vpc-1"}},
+		nil,
+		nil,
+	)
+	api.SetSubnetAtPrefixCapacity(fragSubnetID, true)
+	metaMock, _ := metadataMock.NewMetadataMock()
+	instances, err := NewInstancesManager(context.Background(), hivetest.Logger(t), api, metaMock)
+	require.NoError(t, err)
+	instances.subnets = map[string]*ipamTypes.Subnet{
+		fragSubnetID:    fragSubnet.DeepCopy(),
+		healthySubnetID: healthySubnet.DeepCopy(),
+	}
+
+	k8sObj := newCiliumNode("node1", withInstanceType("m5.large"))
+	k8sObj.Spec.ENI.VpcID = "vpc-1"
+	k8sObj.Spec.ENI.AvailabilityZone = "eu-west-1a"
+	k8sObj.Spec.ENI.SubnetTags = filterTags
+	k8sObj.Spec.ENI.SecurityGroups = []string{"sg-1"}
+
+	fake := &fakeOpsNode{mockIPAMNode: mockIPAMNode{instanceID: "i-123", prefixDelegation: true}}
+	n := &Node{
+		rootLogger: hivetest.Logger(t),
+		manager:    instances,
+		k8sObj:     k8sObj,
+		node:       fake,
+		enis:       map[string]eniTypes.ENI{},
+	}
+	n.logger.Store(n.rootLogger)
+	fake.ops = n
+
+	require.True(t, n.IsPrefixDelegated(), "node starts prefix delegated")
+
+	eniKeys := []string{"eni-0", "eni-1", "eni-2"}
+	for i := range 3 {
+		alloc := &nodemanager.AllocationAction{}
+		alloc.IPv4.MaxIPsToAllocate = 2
+		_, _, err := n.CreateInterface(context.Background(), alloc, hivetest.Logger(t))
+		require.NoError(t, err)
+		// Every ENI lands in the healthy sibling via cross-subnet retry.
+		require.Equal(t, ipamTypes.PoolID(healthySubnetID), alloc.PoolID,
+			"cross-subnet retry must land the ENI in the healthy subnet")
+		// Model the resync: ENI has a prefix so node stays delegated.
+		n.enis[eniKeys[i]] = eniTypes.ENI{
+			ID:       eniKeys[i],
+			IP:       iputil.AddrFrom(netip.MustParseAddr("10.9.0.1")),
+			Prefixes: []iputil.Prefix{iputil.PrefixFrom(netip.MustParsePrefix("10.9.0.0/28"))},
+			Subnet:   eniTypes.AwsSubnet{ID: healthySubnetID},
+		}
+		// Node stays prefix delegated: no /32-only ENI was produced.
+		require.True(t, n.IsPrefixDelegated(), "node must stay prefix delegated after cross-subnet retry")
+	}
+
+	subnetsAfter, err := api.GetSubnets(context.Background(), "vpc-1")
+	require.NoError(t, err)
+	// Fragmented subnet untouched across all three ENIs.
+	require.Equal(t, 1000, subnetsAfter[fragSubnetID].AvailableAddresses,
+		"fragmented subnet must be untouched")
+	// Healthy subnet consumed toAllocate+1 + /28 = 19 per ENI, 3 ENIs = 57 (500 -> 443).
+	require.Equal(t, 443, subnetsAfter[healthySubnetID].AvailableAddresses,
+		"healthy subnet consumed by prefix ENIs (19 each: 2 secondary + primary + /28)")
+}
+
+// TestDegradedNodeKeepsAllocatingSlash32InHealthySubnet captures the reporter's
+// exact numbers (fragmented subnet reports far fewer addresses than the healthy
+// sibling) and the precise, honest behavior: once the node is degraded, new ENIs
+// are NOT stuck on the fragmented subnet. findSuitableSubnet re-evaluates and
+// picks the healthy subnet because it reports more free addresses. But because
+// IsPrefixDelegated is false node wide, every new ENI is still created in /32
+// mode, so prefix delegation is never re-enabled even though the healthy subnet
+// has abundant free /28 capacity. The node is stuck in /32 mode, not stuck on a
+// single subnet, and the healthy subnet gets consumed with /32 ENIs.
+func TestDegradedNodeKeepsAllocatingSlash32InHealthySubnet(t *testing.T) {
+	const (
+		fragSubnetID    = "subnet-frag"
+		healthySubnetID = "subnet-healthy"
+	)
+	filterTags := ipamTypes.Tags{"kubernetes.io/role/cni": "1"}
+	// Accurate cache, reporter's numbers.
+	fragSubnet := &ipamTypes.Subnet{ID: fragSubnetID, VirtualNetworkID: "vpc-1", AvailabilityZone: "eu-west-1a", AvailableAddresses: 100, Tags: filterTags}
+	healthySubnet := &ipamTypes.Subnet{ID: healthySubnetID, VirtualNetworkID: "vpc-1", AvailabilityZone: "eu-west-1a", AvailableAddresses: 2000, Tags: filterTags}
+	api := ec2mock.NewAPI(
+		[]*ipamTypes.Subnet{fragSubnet, healthySubnet},
+		[]*ipamTypes.VirtualNetwork{{ID: "vpc-1"}},
+		nil,
+		nil,
+	)
+	api.SetSubnetAtPrefixCapacity(fragSubnetID, true)
+	metaMock, _ := metadataMock.NewMetadataMock()
+	instances, err := NewInstancesManager(context.Background(), hivetest.Logger(t), api, metaMock)
+	require.NoError(t, err)
+	instances.subnets = map[string]*ipamTypes.Subnet{
+		fragSubnetID:    fragSubnet.DeepCopy(),
+		healthySubnetID: healthySubnet.DeepCopy(),
+	}
+
+	k8sObj := newCiliumNode("node1", withInstanceType("m5.large"))
+	k8sObj.Spec.ENI.VpcID = "vpc-1"
+	k8sObj.Spec.ENI.AvailabilityZone = "eu-west-1a"
+	k8sObj.Spec.ENI.SubnetTags = filterTags
+	k8sObj.Spec.ENI.SecurityGroups = []string{"sg-1"}
+
+	fake := &fakeOpsNode{mockIPAMNode: mockIPAMNode{instanceID: "i-123", prefixDelegation: true}}
+	n := &Node{
+		rootLogger: hivetest.Logger(t),
+		manager:    instances,
+		k8sObj:     k8sObj,
+		node:       fake,
+		enis:       map[string]eniTypes.ENI{},
+	}
+	n.logger.Store(n.rootLogger)
+	fake.ops = n
+
+	// Node already degraded: one no-prefix ENI pinned to the fragmented subnet
+	// (the primary ENI that AWS placed there at instance launch).
+	n.enis["primary-x"] = eniTypes.ENI{
+		ID:        "primary-x",
+		IP:        iputil.AddrFrom(netip.MustParseAddr("10.0.0.4")),
+		Addresses: []iputil.Addr{iputil.AddrFrom(netip.MustParseAddr("10.0.0.4")), iputil.AddrFrom(netip.MustParseAddr("10.0.0.5"))},
+		Prefixes:  nil,
+		Subnet:    eniTypes.AwsSubnet{ID: fragSubnetID},
+	}
+	require.False(t, n.IsPrefixDelegated(), "node is already degraded")
+
+	for range 3 {
+		alloc := &nodemanager.AllocationAction{}
+		alloc.IPv4.MaxIPsToAllocate = 2
+		_, _, err := n.CreateInterface(context.Background(), alloc, hivetest.Logger(t))
+		require.NoError(t, err)
+		// Re-evaluation picks the higher-availability subnet, so the ENI is NOT
+		// stuck on the fragmented subnet.
+		require.Equal(t, ipamTypes.PoolID(healthySubnetID), alloc.PoolID, "new ENI placed in the higher-availability subnet")
+		require.False(t, n.IsPrefixDelegated(), "node stays disabled")
+	}
+
+	subnetsAfter, err := api.GetSubnets(context.Background(), "vpc-1")
+	require.NoError(t, err)
+	// Every ENI is created in /32 mode: primary + 2 secondary = 3 per ENI, 3 ENIs
+	// = 9 (2000 -> 1991). A successful /28 would have consumed ~16 per ENI, so the
+	// drop of 9 proves no prefixes were allocated despite the subnet having /28
+	// capacity. Prefix delegation is never re-enabled node wide.
+	require.Equal(t, 1991, subnetsAfter[healthySubnetID].AvailableAddresses, "healthy subnet consumed by /32 ENIs (3 each), proving no prefixes were allocated")
+	require.Equal(t, 100, subnetsAfter[fragSubnetID].AvailableAddresses, "fragmented subnet untouched")
+}
+
+// TestNodeSubnetPreferenceFallsBackToSiblingOnPrefixFailure validates that when
+// the node subnet (NodeSubnetID path) is fragmented, the cross-subnet retry finds
+// a healthy sibling and creates the ENI there with a prefix instead of falling
+// back to /32 in the node subnet.
+func TestNodeSubnetPreferenceFallsBackToSiblingOnPrefixFailure(t *testing.T) {
+	const (
+		nodeSubnetID    = "subnet-x"
+		healthySubnetID = "subnet-y"
+	)
+	x := &ipamTypes.Subnet{ID: nodeSubnetID, VirtualNetworkID: "vpc-1", AvailabilityZone: "eu-west-1a", AvailableAddresses: 15}
+	y := &ipamTypes.Subnet{ID: healthySubnetID, VirtualNetworkID: "vpc-1", AvailabilityZone: "eu-west-1a", AvailableAddresses: 2000}
+	api := ec2mock.NewAPI(
+		[]*ipamTypes.Subnet{x, y},
+		[]*ipamTypes.VirtualNetwork{{ID: "vpc-1"}},
+		nil,
+		nil,
+	)
+	api.SetSubnetAtPrefixCapacity(nodeSubnetID, true)
+	metaMock, _ := metadataMock.NewMetadataMock()
+	instances, err := NewInstancesManager(context.Background(), hivetest.Logger(t), api, metaMock)
+	require.NoError(t, err)
+	instances.subnets = map[string]*ipamTypes.Subnet{
+		nodeSubnetID:    x.DeepCopy(),
+		healthySubnetID: y.DeepCopy(),
+	}
+	instances.routeTables = ipamTypes.RouteTableMap{
+		"rt-1": &ipamTypes.RouteTable{
+			ID:               "rt-1",
+			VirtualNetworkID: "vpc-1",
+			Subnets: map[string]struct{}{
+				nodeSubnetID:    {},
+				healthySubnetID: {},
+			},
+		},
+	}
+
+	k8sObj := newCiliumNode("node1", withInstanceType("m5.large"))
+	k8sObj.Spec.ENI.VpcID = "vpc-1"
+	k8sObj.Spec.ENI.AvailabilityZone = "eu-west-1a"
+	k8sObj.Spec.ENI.NodeSubnetID = nodeSubnetID
+	k8sObj.Spec.ENI.SecurityGroups = []string{"sg-1"}
+
+	fake := &fakeOpsNode{mockIPAMNode: mockIPAMNode{instanceID: "i-123", prefixDelegation: true}}
+	n := &Node{
+		rootLogger: hivetest.Logger(t),
+		manager:    instances,
+		k8sObj:     k8sObj,
+		node:       fake,
+		enis:       map[string]eniTypes.ENI{},
+	}
+	n.logger.Store(n.rootLogger)
+	fake.ops = n
+
+	require.True(t, n.IsPrefixDelegated(), "node should start prefix delegated")
+
+	alloc := &nodemanager.AllocationAction{}
+	alloc.IPv4.MaxIPsToAllocate = 2
+	_, _, err = n.CreateInterface(context.Background(), alloc, hivetest.Logger(t))
+	require.NoError(t, err)
+
+	// The cross-subnet retry found the healthy sibling.
+	require.Equal(t, ipamTypes.PoolID(healthySubnetID), alloc.PoolID,
+		"cross-subnet retry must land the ENI in the healthy sibling subnet")
+
+	subnetsAfter, err := api.GetSubnets(context.Background(), "vpc-1")
+	require.NoError(t, err)
+	// Node subnet untouched: /32 fallback never ran there.
+	require.Equal(t, 15, subnetsAfter[nodeSubnetID].AvailableAddresses,
+		"node subnet must be untouched after cross-subnet retry")
+	// Healthy subnet consumed toAllocate+1 + /28 = 19 (2000 -> 1981).
+	require.Equal(t, 1981, subnetsAfter[healthySubnetID].AvailableAddresses,
+		"healthy sibling consumed by prefix allocation")
+	// Node stays delegated.
+	require.True(t, n.IsPrefixDelegated(), "node must remain prefix delegated")
+}
+
+// TestPrepareIPAllocationPrefersExistingENIInNodeSubnet answers the reporter's
+// first question: "will Cilium use the ENI the node already has, even when a /28
+// can no longer be attached?" Yes. PrepareIPAllocation iterates only the node's
+// existing ENIs and selects the first one that still has room and whose subnet
+// reports any free address. It never considers a subnet that has no ENI on the
+// node. So the existing ENI pinned to the fragmented node subnet is selected for
+// top-up before any new ENI or any other subnet is even looked at. AllocateIPs
+// then tops it up (see TestAllocateIPsFallsBackToSlash32OnExistingENIInSameSubnet).
+func TestPrepareIPAllocationPrefersExistingENIInNodeSubnet(t *testing.T) {
+	const (
+		nodeSubnetID    = "subnet-x"
+		healthySubnetID = "subnet-y"
+	)
+	x := &ipamTypes.Subnet{ID: nodeSubnetID, VirtualNetworkID: "vpc-1", AvailabilityZone: "eu-west-1a", AvailableAddresses: 15}
+	y := &ipamTypes.Subnet{ID: healthySubnetID, VirtualNetworkID: "vpc-1", AvailabilityZone: "eu-west-1a", AvailableAddresses: 2000}
+	api := ec2mock.NewAPI(
+		[]*ipamTypes.Subnet{x, y},
+		[]*ipamTypes.VirtualNetwork{{ID: "vpc-1"}},
+		nil,
+		nil,
+	)
+	api.SetSubnetAtPrefixCapacity(nodeSubnetID, true)
+	metaMock, _ := metadataMock.NewMetadataMock()
+	instances, err := NewInstancesManager(context.Background(), hivetest.Logger(t), api, metaMock)
+	require.NoError(t, err)
+	instances.subnets = map[string]*ipamTypes.Subnet{
+		nodeSubnetID:    x.DeepCopy(),
+		healthySubnetID: y.DeepCopy(),
+	}
+
+	k8sObj := newCiliumNode("node1", withInstanceType("m5.large"))
+	k8sObj.Spec.ENI.VpcID = "vpc-1"
+	k8sObj.Spec.ENI.AvailabilityZone = "eu-west-1a"
+	k8sObj.Spec.ENI.NodeSubnetID = nodeSubnetID
+
+	fake := &fakeOpsNode{mockIPAMNode: mockIPAMNode{instanceID: "i-123", prefixDelegation: true}}
+	n := &Node{
+		rootLogger: hivetest.Logger(t),
+		manager:    instances,
+		k8sObj:     k8sObj,
+		node:       fake,
+		enis:       map[string]eniTypes.ENI{},
+	}
+	n.logger.Store(n.rootLogger)
+	fake.ops = n
+
+	// The node's existing prefix-delegated primary ENI in subnet-x, with room.
+	n.enis["eni-primary"] = eniTypes.ENI{
+		ID:        "eni-primary",
+		IP:        iputil.AddrFrom(netip.MustParseAddr("10.0.0.4")),
+		Addresses: []iputil.Addr{iputil.AddrFrom(netip.MustParseAddr("10.0.0.16"))},
+		Prefixes:  []iputil.Prefix{iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.16/28"))},
+		Subnet:    eniTypes.AwsSubnet{ID: nodeSubnetID},
+		Number:    0,
+	}
+	require.True(t, n.IsPrefixDelegated(), "node should be prefix delegated")
+
+	a, err := n.PrepareIPAllocation(hivetest.Logger(t))
+	require.NoError(t, err)
+	// The existing ENI in the node subnet is chosen for top-up.
+	require.Equal(t, "eni-primary", a.InterfaceID, "existing ENI in the node subnet is selected")
+	require.Equal(t, ipamTypes.PoolID(nodeSubnetID), a.PoolID, "top-up targets the node subnet, not the healthy sibling")
+	require.Equal(t, 1, a.IPv4.InterfaceCandidates, "only the node's own ENI is a candidate")
+	require.Positive(t, a.IPv4.AvailableForAllocation, "the existing ENI is topped up rather than creating a new ENI")
+}
+
+// TestAllocateIPsFallsBackToSlash32OnExistingENIInSameSubnet reproduces the
+// "Resolving IP deficit ... selectedInterface=eni-... selectedPoolID=subnet-X"
+// path: once an existing ENI in the fragmented subnet is selected, AllocateIPs
+// tries to add a /28 prefix to it, AssignENIPrefixes fails with the AWS subnet
+// full error, and it falls back to AssignPrivateIpAddresses (/32) on that SAME
+// ENI in the SAME subnet. There is no subnet selection in this path at all, so
+// the healthy sibling subnet is irrelevant: the existing ENI is pinned to the
+// fragmented subnet and that is where the /32 addresses are added.
+func TestAllocateIPsFallsBackToSlash32OnExistingENIInSameSubnet(t *testing.T) {
+	const (
+		nodeSubnetID    = "subnet-x"
+		healthySubnetID = "subnet-y"
+	)
+	x := &ipamTypes.Subnet{ID: nodeSubnetID, VirtualNetworkID: "vpc-1", AvailabilityZone: "eu-west-1a", AvailableAddresses: 15}
+	y := &ipamTypes.Subnet{ID: healthySubnetID, VirtualNetworkID: "vpc-1", AvailabilityZone: "eu-west-1a", AvailableAddresses: 2000}
+	api := ec2mock.NewAPI(
+		[]*ipamTypes.Subnet{x, y},
+		[]*ipamTypes.VirtualNetwork{{ID: "vpc-1"}},
+		nil,
+		nil,
+	)
+	api.SetSubnetAtPrefixCapacity(nodeSubnetID, true)
+	metaMock, _ := metadataMock.NewMetadataMock()
+	instances, err := NewInstancesManager(context.Background(), hivetest.Logger(t), api, metaMock)
+	require.NoError(t, err)
+	instances.subnets = map[string]*ipamTypes.Subnet{
+		nodeSubnetID:    x.DeepCopy(),
+		healthySubnetID: y.DeepCopy(),
+	}
+
+	k8sObj := newCiliumNode("node1", withInstanceType("m5.large"))
+	k8sObj.Spec.ENI.VpcID = "vpc-1"
+	k8sObj.Spec.ENI.AvailabilityZone = "eu-west-1a"
+	k8sObj.Spec.ENI.NodeSubnetID = nodeSubnetID
+	k8sObj.Spec.ENI.SecurityGroups = []string{"sg-1"}
+
+	fake := &fakeOpsNode{mockIPAMNode: mockIPAMNode{instanceID: "i-123", prefixDelegation: true}}
+	n := &Node{
+		rootLogger: hivetest.Logger(t),
+		manager:    instances,
+		k8sObj:     k8sObj,
+		node:       fake,
+		enis:       map[string]eniTypes.ENI{},
+	}
+	n.logger.Store(n.rootLogger)
+	fake.ops = n
+
+	// Register an existing ENI in subnet-x with the mock (prefixes off so the
+	// create succeeds) and mirror it into the node view as prefix-delegated-capable.
+	eniID, _, err := api.CreateNetworkInterface(context.Background(), 0, nodeSubnetID, "desc", []string{"sg-1"}, false, false)
+	require.NoError(t, err)
+	_, err = api.AttachNetworkInterface(context.Background(), 0, "i-123", eniID)
+	require.NoError(t, err)
+	n.enis[eniID] = eniTypes.ENI{
+		ID:        eniID,
+		IP:        iputil.AddrFrom(netip.MustParseAddr("10.0.0.4")),
+		Addresses: []iputil.Addr{iputil.AddrFrom(netip.MustParseAddr("10.0.0.4"))},
+		Prefixes:  nil,
+		Subnet:    eniTypes.AwsSubnet{ID: nodeSubnetID},
+	}
+	require.True(t, n.IsPrefixDelegated(), "node should be prefix delegated")
+
+	subnetsBefore, err := api.GetSubnets(context.Background(), "vpc-1")
+	require.NoError(t, err)
+	xBefore := subnetsBefore[nodeSubnetID].AvailableAddresses
+
+	a := &nodemanager.AllocationAction{InterfaceID: eniID}
+	a.PoolID = ipamTypes.PoolID(nodeSubnetID)
+	a.IPv4.AvailableForAllocation = 2
+	err = n.AllocateIPs(context.Background(), a)
+	require.NoError(t, err, "AllocateIPs falls back to /32 and succeeds on the existing ENI")
+
+	subnetsAfter, err := api.GetSubnets(context.Background(), "vpc-1")
+	require.NoError(t, err)
+	// The two /32 addresses were taken from subnet-x (the existing ENI's subnet),
+	// proving the prefix create failed and the /32 fallback ran in the same subnet.
+	require.Equal(t, xBefore-2, subnetsAfter[nodeSubnetID].AvailableAddresses, "the /32 fallback consumed 2 addresses in the node subnet")
+	// The healthy sibling subnet is untouched: AllocateIPs never does subnet selection.
+	require.Equal(t, 2000, subnetsAfter[healthySubnetID].AvailableAddresses, "healthy sibling subnet untouched")
+}
+
+// TestAllocateIPsProducesMixedPrefixAndSlash32ENI addresses the field observation
+// that mixed ENIs (a single ENI carrying both /28 prefixes and individual /32
+// secondary IPs) are never seen on real nodes. The question it answers is
+// whether Cilium has a hard guard against producing one. It does NOT.
+//
+// AWS allows an ENI to hold both prefixes and individual secondary IPs at once
+// (each secondary IP costs one prefix slot, per the EKS prefix-mode docs), and
+// nothing in AllocateIPs, PrepareIPAllocation, or the IPAM handleIPAllocation
+// loop prevents it. This test gives an existing ENI a real /28 prefix while its
+// subnet is healthy, then fragments the subnet (no free /28 left) and drives
+// AllocateIPs on that same ENI while the node is still prefix delegated. The
+// prefix top-up (AssignENIPrefixes) fails, the /32 fallback (AssignPrivateIp
+// Addresses) succeeds on the SAME ENI, and the ENI ends up MIXED: it keeps its
+// prefix and gains 2 individual /32 addresses.
+//
+// So the reason mixed ENIs are not observed in practice is allocation ordering,
+// not a code guard: in the field, fragmentation usually bites the NEW-ENI path
+// (CreateInterface), which produces a zero-prefix /32-only ENI and immediately
+// disables prefix delegation node wide (IsPrefixDelegated requires zero prefixes
+// on an ENI to trip). Once disabled, Cilium issues no further prefix requests,
+// so the steady state is prefix-only ENIs plus /32-only ENIs, never mixed. The
+// reporter's own warning line (from CreateInterface, addresses=2,
+// isPrefixDelegated=true) confirms the new-ENI path was the trigger. This test
+// proves the mixed state is nonetheless reachable through the top-up path.
+func TestAllocateIPsProducesMixedPrefixAndSlash32ENI(t *testing.T) {
+	const nodeSubnetID = "subnet-x"
+	x := &ipamTypes.Subnet{ID: nodeSubnetID, VirtualNetworkID: "vpc-1", AvailabilityZone: "eu-west-1a", AvailableAddresses: 1000}
+	api := ec2mock.NewAPI(
+		[]*ipamTypes.Subnet{x},
+		[]*ipamTypes.VirtualNetwork{{ID: "vpc-1"}},
+		nil,
+		nil,
+	)
+	metaMock, _ := metadataMock.NewMetadataMock()
+	instances, err := NewInstancesManager(context.Background(), hivetest.Logger(t), api, metaMock)
+	require.NoError(t, err)
+	instances.subnets = map[string]*ipamTypes.Subnet{nodeSubnetID: x.DeepCopy()}
+
+	k8sObj := newCiliumNode("node1", withInstanceType("m5.large"))
+	k8sObj.Spec.ENI.VpcID = "vpc-1"
+	k8sObj.Spec.ENI.AvailabilityZone = "eu-west-1a"
+	k8sObj.Spec.ENI.NodeSubnetID = nodeSubnetID
+	k8sObj.Spec.ENI.SecurityGroups = []string{"sg-1"}
+
+	fake := &fakeOpsNode{mockIPAMNode: mockIPAMNode{instanceID: "i-123", prefixDelegation: true}}
+	n := &Node{
+		rootLogger: hivetest.Logger(t),
+		manager:    instances,
+		k8sObj:     k8sObj,
+		node:       fake,
+		enis:       map[string]eniTypes.ENI{},
+	}
+	n.logger.Store(n.rootLogger)
+	fake.ops = n
+
+	// Create an ENI in subnet-x and give it ONE real /28 prefix while the subnet
+	// is still healthy (this is the normal partial prefix ENI: a new ENI is born
+	// with ceil(toAllocate/16) prefixes, so it has free prefix slots left).
+	eniID, _, err := api.CreateNetworkInterface(context.Background(), 0, nodeSubnetID, "desc", []string{"sg-1"}, false, false)
+	require.NoError(t, err)
+	_, err = api.AttachNetworkInterface(context.Background(), 0, "i-123", eniID)
+	require.NoError(t, err)
+	require.NoError(t, api.AssignENIPrefixes(context.Background(), eniID, 1), "prefix assignment succeeds while subnet is healthy")
+
+	// Snapshot the ENI state after the prefix is assigned: 1 prefix, plus its 16
+	// expanded /28 IPs (and any primary) in Addresses.
+	instBefore, err := api.GetInstance(context.Background(), nil, nil, "i-123")
+	require.NoError(t, err)
+	eniBefore := instBefore.Interfaces[eniID].(*eniTypes.ENI)
+	require.Len(t, eniBefore.Prefixes, 1, "ENI starts with exactly one /28 prefix")
+	addrsAfterPrefix := len(eniBefore.Addresses)
+
+	// Mirror the prefix ENI into the node view so IsPrefixDelegated stays true
+	// (the gate only trips on a zero-prefix ENI). This ENI has a prefix, so the
+	// node is still prefix delegated.
+	n.enis[eniID] = eniTypes.ENI{
+		ID:        eniID,
+		IP:        iputil.AddrFrom(netip.MustParseAddr("10.0.0.4")),
+		Addresses: []iputil.Addr{iputil.AddrFrom(netip.MustParseAddr("10.0.0.4"))},
+		Prefixes:  eniBefore.Prefixes,
+		Subnet:    eniTypes.AwsSubnet{ID: nodeSubnetID},
+	}
+	require.True(t, n.IsPrefixDelegated(), "node is still prefix delegated (the ENI has a prefix)")
+
+	// Now fragment the subnet: free /32s remain, but no free /28 block.
+	api.SetSubnetAtPrefixCapacity(nodeSubnetID, true)
+
+	// Top up the SAME existing prefix ENI. AllocateIPs tries AssignENIPrefixes
+	// (fails, subnet at prefix capacity) and falls back to AssignPrivateIpAddresses
+	// (/32) on the same ENI.
+	a := &nodemanager.AllocationAction{InterfaceID: eniID}
+	a.PoolID = ipamTypes.PoolID(nodeSubnetID)
+	a.IPv4.AvailableForAllocation = 2
+	require.NoError(t, n.AllocateIPs(context.Background(), a), "the /32 fallback succeeds on the existing prefix ENI")
+
+	// Read the ENI back: it now carries BOTH its original /28 prefix AND 2
+	// individual /32 secondary IPs. Cilium produced a mixed ENI; there is no guard.
+	instAfter, err := api.GetInstance(context.Background(), nil, nil, "i-123")
+	require.NoError(t, err)
+	eniAfter := instAfter.Interfaces[eniID].(*eniTypes.ENI)
+	require.Len(t, eniAfter.Prefixes, 1, "the ENI keeps its /28 prefix")
+	require.Len(t, eniAfter.Addresses, addrsAfterPrefix+2,
+		"2 individual /32 addresses were added on top of the prefix: this is a MIXED ENI")
+	// A mixed ENI has more addresses than its prefixes alone account for.
+	require.Greater(t, len(eniAfter.Addresses), 16*len(eniAfter.Prefixes),
+		"the ENI carries /32 secondary IPs beyond what its /28 prefix provides (mixed prefix + /32)")
+}
+
+// TestFullPrefixDelegatedENIIsNotToppedUpNewENIGetsSlash32 validates the field
+// observation that when a node already has a prefix delegated ENI and needs more
+// IPs, Cilium adds a NEW ENI (which falls back to /32 in a fragmented subnet)
+// rather than adding /32 addresses to the existing /28 ENI.
+//
+// The reason is structural, not incidental. handleIPAllocation (pkg/ipam/node.go)
+// creates a new ENI only when no existing ENI has spare capacity in a subnet that
+// still reports free addresses; otherwise it tops up the existing ENI. A prefix
+// delegated ENI is "full" once it holds its maximum prefixes: with prefix
+// delegation getEffectiveIPLimits returns (limits.IPv4-1)*ENIPDBlockSizeIPv4,
+// which for m5.large is (10-1)*16 = 144 addresses = 9 prefixes. At that point
+// availableOnENI is 0 and PrepareIPAllocation will not select the ENI for top-up.
+// So the existing /28 ENI is left untouched and a new ENI is created for the
+// extra demand. In a fragmented subnet that new ENI takes the /32 fallback and
+// becomes the zero-prefix ENI that disables prefix delegation node wide.
+//
+// This is why a mixed ENI is not produced on the steady-state path: by the time a
+// second ENI is needed, the first is full, so it is never topped up with /32. A
+// mixed ENI only arises if a PARTIAL prefix ENI is topped up while its subnet is
+// fragmented, which is the artificial setup in
+// TestAllocateIPsProducesMixedPrefixAndSlash32ENI (reachable, but not how the
+// allocator behaves once an ENI has been filled).
+func TestFullPrefixDelegatedENIIsNotToppedUpNewENIGetsSlash32(t *testing.T) {
+	const nodeSubnetID = "subnet-x"
+	// Fragmented node subnet: free /32s (100) but no free /28 block.
+	x := &ipamTypes.Subnet{ID: nodeSubnetID, VirtualNetworkID: "vpc-1", AvailabilityZone: "eu-west-1a", AvailableAddresses: 100}
+	api := ec2mock.NewAPI(
+		[]*ipamTypes.Subnet{x},
+		[]*ipamTypes.VirtualNetwork{{ID: "vpc-1"}},
+		nil,
+		nil,
+	)
+	api.SetSubnetAtPrefixCapacity(nodeSubnetID, true)
+	metaMock, _ := metadataMock.NewMetadataMock()
+	instances, err := NewInstancesManager(context.Background(), hivetest.Logger(t), api, metaMock)
+	require.NoError(t, err)
+	instances.subnets = map[string]*ipamTypes.Subnet{nodeSubnetID: x.DeepCopy()}
+
+	k8sObj := newCiliumNode("node1", withInstanceType("m5.large"))
+	k8sObj.Spec.ENI.VpcID = "vpc-1"
+	k8sObj.Spec.ENI.AvailabilityZone = "eu-west-1a"
+	k8sObj.Spec.ENI.NodeSubnetID = nodeSubnetID
+	k8sObj.Spec.ENI.SecurityGroups = []string{"sg-1"}
+
+	fake := &fakeOpsNode{mockIPAMNode: mockIPAMNode{instanceID: "i-123", prefixDelegation: true}}
+	n := &Node{
+		rootLogger: hivetest.Logger(t),
+		manager:    instances,
+		k8sObj:     k8sObj,
+		node:       fake,
+		enis:       map[string]eniTypes.ENI{},
+	}
+	n.logger.Store(n.rootLogger)
+	fake.ops = n
+
+	// Build a FULL prefix delegated ENI: 9 /28 prefixes and their 144 expanded
+	// addresses, the maximum for m5.large. availableOnENI = 144 - 144 = 0.
+	var addrs []iputil.Addr
+	var prefixes []iputil.Prefix
+	for p := range 9 {
+		prefixes = append(prefixes, iputil.PrefixFrom(netip.MustParsePrefix(fmt.Sprintf("10.0.%d.0/28", p))))
+		for h := range 16 {
+			addrs = append(addrs, iputil.AddrFrom(netip.MustParseAddr(fmt.Sprintf("10.0.%d.%d", p, h))))
+		}
+	}
+	require.Len(t, addrs, 144)
+	n.enis["eni-full-pd"] = eniTypes.ENI{
+		ID:        "eni-full-pd",
+		IP:        iputil.AddrFrom(netip.MustParseAddr("10.0.255.4")),
+		Addresses: addrs,
+		Prefixes:  prefixes,
+		Subnet:    eniTypes.AwsSubnet{ID: nodeSubnetID},
+		Number:    0,
+	}
+	require.True(t, n.IsPrefixDelegated(), "node is prefix delegated (the existing ENI is all prefixes)")
+
+	// PrepareIPAllocation must NOT select the full prefix ENI for top-up: it has no
+	// spare capacity, so there is no interface candidate and no InterfaceID, which
+	// means AllocateIPs is never called on it and no /32 is added to the /28 ENI.
+	a, err := n.PrepareIPAllocation(hivetest.Logger(t))
+	require.NoError(t, err)
+	require.Equal(t, 0, a.IPv4.InterfaceCandidates, "the full prefix ENI is not a candidate for top-up")
+	require.Empty(t, a.InterfaceID, "no existing ENI is selected, so /32 is never added to the /28 ENI")
+	require.Zero(t, a.IPv4.AvailableForAllocation, "nothing can be allocated on the existing ENI")
+	require.Positive(t, a.EmptyInterfaceSlots, "a new ENI slot is available, so a new ENI is created instead")
+
+	// Creating the new ENI: in the fragmented subnet it falls back to /32. This is
+	// the new /32 ENI the operator observes being added to the node.
+	alloc := &nodemanager.AllocationAction{}
+	alloc.IPv4.MaxIPsToAllocate = 2
+	toAllocate, _, err := n.CreateInterface(context.Background(), alloc, hivetest.Logger(t))
+	require.NoError(t, err)
+	require.Equal(t, 2, toAllocate)
+	require.Equal(t, ipamTypes.PoolID(nodeSubnetID), alloc.PoolID, "the new ENI is created in the node subnet")
+
+	// The original prefix ENI is left exactly as it was: still 9 prefixes and 144
+	// addresses, with no individual /32 secondary IPs added to it.
+	require.Len(t, n.enis["eni-full-pd"].Prefixes, 9, "the existing /28 ENI keeps all its prefixes")
+	require.Len(t, n.enis["eni-full-pd"].Addresses, 144, "no /32 was added to the existing /28 ENI")
+}
+
+// TestEndToEndPartiallyUsedPrefixENIIsToppedUpNotNewENI drives the REAL IPAM
+// maintenance loop (ipam.NodeManager.MaintainIPPool, which runs PrepareIPAllocation
+// then handleIPAllocation then AllocateIPs or CreateInterface) instead of calling
+// AllocateIPs directly. It answers the question: when a node already has a prefix
+// delegated ENI that is barely used (lots of free prefix capacity) and the subnet
+// becomes fragmented (no free /28, but free /32s), does Cilium add /32 to that
+// existing ENI, or does it create a NEW ENI?
+//
+// Verified answer: the existing ENI is topped up with /32 (it becomes a MIXED ENI
+// with both a /28 prefix and individual /32 addresses), and NO new ENI is created.
+// This is the authoritative behavior of the real allocation loop, and it matches
+// Cilium's own TestNodeManagerPrefixDelegation (which adds a single /32 on the
+// fallback, not a new ENI). A new ENI is created only once the existing ENI is
+// full (see TestFullPrefixDelegatedENIIsNotToppedUpNewENIGetsSlash32).
+func TestEndToEndPartiallyUsedPrefixENIIsToppedUpNotNewENI(t *testing.T) {
+	setup(t)
+	const instanceID = "i-e2e-partial-pd-0"
+
+	pdTestSubnet := *testSubnet
+	pdTestSubnet.AvailableAddresses = 1000
+	ec2api := ec2mock.NewAPI([]*ipamTypes.Subnet{&pdTestSubnet}, []*ipamTypes.VirtualNetwork{testVpc}, testSecurityGroups, testRouteTables)
+	instances, err := NewInstancesManager(t.Context(), hivetest.Logger(t), ec2api, metadataMockapi)
+	require.NoError(t, err)
+
+	// One prefix delegated ENI on the node (index 0), created while the subnet is
+	// healthy so it gets a real /28 prefix.
+	eniID1, _, err := ec2api.CreateNetworkInterface(t.Context(), 0, pdTestSubnet.ID, "desc", []string{"sg1", "sg2"}, true, false)
+	require.NoError(t, err)
+	_, err = ec2api.AttachNetworkInterface(t.Context(), 0, instanceID, eniID1)
+	require.NoError(t, err)
+	instances.Resync(t.Context())
+
+	mngr, err := nodemanager.NewNodeManager(hivetest.Logger(t), instances, k8sapi, metricsapi, 10, false, 0, true)
+	require.NoError(t, err)
+
+	cn := newCiliumNode("node1", withInstanceID(instanceID), withInstanceType("m5.large"), withIPAMPreAllocate(8))
+	mngr.Upsert(cn)
+	require.NoError(t, testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node1", 0) }, 5*time.Second))
+	node := mngr.Get("node1")
+	require.NotNil(t, node)
+	// The node has a single prefix delegated ENI with 16 IPs (one /28) and 0 used:
+	// barely used, with room for 8 more prefixes.
+	require.Equal(t, 16, node.Stats().IPv4.AvailableIPs, "node starts with one /28 prefix")
+	require.Equal(t, 0, node.Stats().IPv4.UsedIPs)
+
+	// Fragment the subnet: free /32s remain (1000) but no free /28 block.
+	ec2api.SetSubnetAtPrefixCapacity(pdTestSubnet.ID, true)
+
+	// Create a deficit on the barely-used ENI (use 12 of 16, so the node needs
+	// 12 + PreAllocate(8) = 20 available).
+	mngr.Upsert(updateCiliumNode(cn, 16, 12))
+	require.NoError(t, testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node1", 0) }, 10*time.Second))
+	node = mngr.Get("node1")
+	require.NotNil(t, node)
+
+	node.Ops().PopulateStatusFields(cn)
+
+	// The real loop topped up the EXISTING ENI with /32, it did NOT create a new ENI.
+	require.Len(t, cn.Status.ENI.ENIs, 1, "no new ENI was created; the existing ENI was topped up")
+	existing := cn.Status.ENI.ENIs[eniID1]
+	require.Len(t, existing.Prefixes, 1, "the existing ENI keeps its single /28 prefix")
+	// 16 IPs from the /28 prefix plus 4 individual /32 addresses = 20: a MIXED ENI.
+	require.Greater(t, len(existing.Addresses), 16*len(existing.Prefixes),
+		"the existing ENI now carries individual /32 addresses on top of its /28 prefix (mixed)")
+	require.Equal(t, 20, node.Stats().IPv4.AvailableIPs, "deficit resolved by adding /32 to the existing ENI (16 -> 20)")
+	require.Equal(t, 12, node.Stats().IPv4.UsedIPs)
+}
+
+// TestPrepareIPAllocationSkipsExistingENIWhenSubnetReportsNoFreeAddresses pins the
+// one condition under which a barely-used existing prefix ENI is NOT topped up and
+// Cilium creates a new ENI instead. The default behavior (verified by
+// TestEndToEndPartiallyUsedPrefixENIIsToppedUpNotNewENI) is to top up the existing
+// ENI, but PrepareIPAllocation only selects an existing ENI for top-up when its
+// subnet's cached AvailableAddresses is greater than 0:
+//
+//	if subnet := n.manager.GetSubnet(e.Subnet.ID); subnet != nil {
+//	    if subnet.AvailableAddresses > 0 && a.InterfaceID == "" { ... select it ... }
+//	}
+//
+// If the subnet reports zero free addresses, the existing ENI is skipped even
+// though it still has spare prefix capacity, so AllocateIPs is never called on it
+// (no /32 is added to the /28 ENI) and handleIPAllocation creates a new ENI
+// instead. The reporter described exactly this input: the fragmented subnet
+// "reported fewer available IPs due to AWS address reservations". When those
+// reservations drive the reported AvailableIpAddressCount to zero, this is the
+// code path that produces "a new ENI is added, the existing /28 ENI is untouched"
+// even when that ENI is barely used.
+func TestPrepareIPAllocationSkipsExistingENIWhenSubnetReportsNoFreeAddresses(t *testing.T) {
+	const nodeSubnetID = "subnet-x"
+	// Subnet reports ZERO free addresses (AWS reservations counted as used), even
+	// though in reality it is only /28-fragmented and still has assignable /32s.
+	x := &ipamTypes.Subnet{ID: nodeSubnetID, VirtualNetworkID: "vpc-1", AvailabilityZone: "eu-west-1a", AvailableAddresses: 0}
+	api := ec2mock.NewAPI(
+		[]*ipamTypes.Subnet{x},
+		[]*ipamTypes.VirtualNetwork{{ID: "vpc-1"}},
+		nil,
+		nil,
+	)
+	metaMock, _ := metadataMock.NewMetadataMock()
+	instances, err := NewInstancesManager(context.Background(), hivetest.Logger(t), api, metaMock)
+	require.NoError(t, err)
+	instances.subnets = map[string]*ipamTypes.Subnet{nodeSubnetID: x.DeepCopy()}
+
+	k8sObj := newCiliumNode("node1", withInstanceType("m5.large"))
+	k8sObj.Spec.ENI.VpcID = "vpc-1"
+	k8sObj.Spec.ENI.AvailabilityZone = "eu-west-1a"
+	k8sObj.Spec.ENI.NodeSubnetID = nodeSubnetID
+
+	fake := &fakeOpsNode{mockIPAMNode: mockIPAMNode{instanceID: "i-123", prefixDelegation: true}}
+	n := &Node{
+		rootLogger: hivetest.Logger(t),
+		manager:    instances,
+		k8sObj:     k8sObj,
+		node:       fake,
+		enis:       map[string]eniTypes.ENI{},
+	}
+	n.logger.Store(n.rootLogger)
+	fake.ops = n
+
+	// A barely-used prefix ENI: one /28 (16 addresses), lots of free prefix room.
+	var addrs []iputil.Addr
+	for i := range 16 {
+		addrs = append(addrs, iputil.AddrFrom(netip.MustParseAddr(fmt.Sprintf("10.0.0.%d", i+16))))
+	}
+	n.enis["eni-pd"] = eniTypes.ENI{
+		ID:        "eni-pd",
+		IP:        iputil.AddrFrom(netip.MustParseAddr("10.0.0.4")),
+		Addresses: addrs,
+		Prefixes:  []iputil.Prefix{iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.16/28"))},
+		Subnet:    eniTypes.AwsSubnet{ID: nodeSubnetID},
+		Number:    0,
+	}
+	require.True(t, n.IsPrefixDelegated(), "node is prefix delegated")
+
+	a, err := n.PrepareIPAllocation(hivetest.Logger(t))
+	require.NoError(t, err)
+	// The ENI has spare prefix capacity, so it is counted as a candidate ...
+	require.Equal(t, 1, a.IPv4.InterfaceCandidates, "the barely-used ENI has spare prefix capacity")
+	// ... but it is NOT selected for top-up because its subnet reports no free
+	// addresses, so AllocateIPs is never called on it and no /32 is added to it.
+	require.Empty(t, a.InterfaceID, "existing ENI is skipped when its subnet reports zero free addresses")
+	require.Zero(t, a.IPv4.AvailableForAllocation, "nothing is allocated on the existing ENI")
+	// A free interface slot remains, so handleIPAllocation creates a NEW ENI.
+	require.Positive(t, a.EmptyInterfaceSlots, "a new ENI is created instead of topping up the existing one")
+}

--- a/pkg/aws/ipam/node_test.go
+++ b/pkg/aws/ipam/node_test.go
@@ -106,14 +106,14 @@ func Test_findSubnetInSameRouteTableWithNodeSubnet(t *testing.T) {
 		},
 	}
 
-	got := node.findSubnetInSameRouteTableWithNodeSubnet()
-	require.NotNil(t, got)
-	require.Equal(t, "subnet-2", got.ID)
-	require.Equal(t, 20, got.AvailableAddresses)
+	got := node.findSubnetInSameRouteTableWithNodeSubnetSorted()
+	require.NotEmpty(t, got)
+	require.Equal(t, "subnet-2", got[0].ID)
+	require.Equal(t, 20, got[0].AvailableAddresses)
 
 	node.k8sObj.Spec.ENI.VpcID = "vpc-2"
-	got = node.findSubnetInSameRouteTableWithNodeSubnet()
-	require.Nil(t, got)
+	got = node.findSubnetInSameRouteTableWithNodeSubnetSorted()
+	require.Empty(t, got)
 
 }
 
@@ -168,10 +168,10 @@ func Test_findSubnetInSameRouteTableWithNodeSubnet_UntrackedSubnets(t *testing.T
 	}
 
 	// This should not panic and should return subnet-4 (highest available addresses)
-	got := node.findSubnetInSameRouteTableWithNodeSubnet()
-	require.NotNil(t, got)
-	require.Equal(t, "subnet-4", got.ID)
-	require.Equal(t, 30, got.AvailableAddresses)
+	got := node.findSubnetInSameRouteTableWithNodeSubnetSorted()
+	require.NotEmpty(t, got)
+	require.Equal(t, "subnet-4", got[0].ID)
+	require.Equal(t, 30, got[0].AvailableAddresses)
 }
 
 func Test_checkSubnetInSameRouteTableWithNodeSubnet(t *testing.T) {

--- a/pkg/aws/ipam/node_test.go
+++ b/pkg/aws/ipam/node_test.go
@@ -107,14 +107,14 @@ func Test_findSubnetInSameRouteTableWithNodeSubnet(t *testing.T) {
 		},
 	}
 
-	got := node.findSubnetInSameRouteTableWithNodeSubnet()
-	require.NotNil(t, got)
-	require.Equal(t, "subnet-2", got.ID)
-	require.Equal(t, 20, got.AvailableAddresses)
+	got := node.findSubnetInSameRouteTableWithNodeSubnetSorted()
+	require.NotEmpty(t, got)
+	require.Equal(t, "subnet-2", got[0].ID)
+	require.Equal(t, 20, got[0].AvailableAddresses)
 
 	node.k8sObj.Spec.ENI.VpcID = "vpc-2"
-	got = node.findSubnetInSameRouteTableWithNodeSubnet()
-	require.Nil(t, got)
+	got = node.findSubnetInSameRouteTableWithNodeSubnetSorted()
+	require.Empty(t, got)
 
 }
 
@@ -169,10 +169,10 @@ func Test_findSubnetInSameRouteTableWithNodeSubnet_UntrackedSubnets(t *testing.T
 	}
 
 	// This should not panic and should return subnet-4 (highest available addresses)
-	got := node.findSubnetInSameRouteTableWithNodeSubnet()
-	require.NotNil(t, got)
-	require.Equal(t, "subnet-4", got.ID)
-	require.Equal(t, 30, got.AvailableAddresses)
+	got := node.findSubnetInSameRouteTableWithNodeSubnetSorted()
+	require.NotEmpty(t, got)
+	require.Equal(t, "subnet-4", got[0].ID)
+	require.Equal(t, 30, got[0].AvailableAddresses)
 }
 
 func Test_checkSubnetInSameRouteTableWithNodeSubnet(t *testing.T) {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

Fixes: #46644

When ENI prefix delegation is enabled and CreateNetworkInterface fails with InsufficientCidrBlocks (subnet fragmented: free /32s but no contiguous /28 capacity), the operator previously fell back immediately to /32 in the same subnet without trying eligible sibling subnets in the same AZ.
This PR refactors findSuitableSubnet to return an ordered slice of subnets (by AvailableAddresses descending) instead of a single best subnet. For non-PD cases, subnets[0] is used as before. For PD cases, CreateInterface loops through the slice attempting prefix creation on each subnet before falling back to /32 in the original subnet.

- Add FindSubnetByIDsSorted and FindSubnetByTagsSorted to InstancesManager returning all matching subnets sorted by AvailableAddresses descending
- Replace findSubnetInSameRouteTableWithNodeSubnet with findSubnetInSameRouteTableWithNodeSubnetSorted returning a sorted slice
- In the NodeSubnetID branch, append route-table sibling subnets as retry candidates for PD fallback
- Also ports the reporter's mock patch and test file to main and updates tests to assert correct post-fix behavior

Automatic recovery for already-degraded nodes is deferred to a follow-up PR.
AIL:3. I personally verified all code changes, test correctness, and the fix logic.

```release-note
Fix ENI prefix delegation to retry sibling subnets before falling back to /32 allocation when a subnet is fragmented
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
