### PR TITLE
ctmap: Mitigate TOCTOU race in batched GC deletion

### DIFF
--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -1229,6 +1229,33 @@ func (m *Map) Lookup(key MapKey) (MapValue, error) {
 	return value, nil
 }
 
+// LookupTo looks up key and unmarshals the result into the caller-provided
+// value instead of allocating a fresh one via m.value.New() as Lookup does.
+// This avoids a per-call allocation in hot per-entry loops (for example the
+// conntrack GC delete path) that only need to read an existing value into a
+// buffer the caller already owns and reuses.
+func (m *Map) LookupTo(key MapKey, value MapValue) error {
+	if err := m.Open(); err != nil {
+		return err
+	}
+
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	var duration *spanstat.SpanStat
+	if metrics.BPFSyscallDuration.IsEnabled() {
+		duration = spanstat.Start()
+	}
+
+	err := m.m.Lookup(key, value)
+
+	if metrics.BPFSyscallDuration.IsEnabled() {
+		metrics.BPFSyscallDuration.WithLabelValues(metricOpLookup, metrics.Error2Outcome(err)).Observe(duration.End(err == nil).Total().Seconds())
+	}
+
+	return err
+}
+
 func (m *Map) Update(key MapKey, value MapValue) error {
 	var err error
 

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -453,7 +453,29 @@ func (m *Map) doGCForFamily(filter GCFilter, next4, next6 func(GCEvent), ipv6 bo
 	return stats
 }
 
-func (m *Map) purgeCtEntry(key CtKey, entry *CtEntry, natMap *nat.Map, next func(event GCEvent), actCountFailed func(uint16, uint32)) error {
+// errDeferredReopened reports that purgeCtEntry skipped a delete because the
+// datapath reopened the entry mid-GC; benign and expected under churn.
+var errDeferredReopened = errors.New("deferring delete: entry reopened by datapath")
+
+func (m *Map) purgeCtEntry(key CtKey, entry *CtEntry, scratch *CtEntry, natMap *nat.Map, next func(event GCEvent), actCountFailed func(uint16, uint32)) error {
+	// Re-lookup the entry at delete time and compare its Lifetime with the
+	// snapshot value the GC iterator handed us. A changed Lifetime means the
+	// datapath refreshed (typically reopened) the entry between the batch read
+	// and now, so it is live again: skip the delete and let a later GC pass
+	// reconsider it. This narrows but does not fully close the race -- the
+	// datapath can still reopen between this lookup and DeleteLocked.
+	if lookupErr := m.LookupTo(key, scratch); lookupErr == nil {
+		if scratch.Lifetime != entry.Lifetime {
+			return fmt.Errorf("%w: snapshot Lifetime=%d current Lifetime=%d drift=%+d snapshot Flags=0x%04x current Flags=0x%04x",
+				errDeferredReopened,
+				entry.Lifetime,
+				scratch.Lifetime,
+				int64(scratch.Lifetime)-int64(entry.Lifetime),
+				entry.Flags,
+				scratch.Flags)
+		}
+	}
+
 	err := m.DeleteLocked(key)
 	if err != nil {
 		return err
@@ -506,6 +528,9 @@ func (m *Map) cleanup(filter GCFilter, natMap *nat.Map, stats *gcStats, next fun
 			countFailedFn = ACT.CountFailed6
 		}
 	}
+	// scratch is reused by purgeCtEntry's re-lookup for every GC'd entry. The
+	// callback runs sequentially within a single GC pass, so sharing is safe.
+	scratch := &CtEntry{}
 	return func(key bpf.MapKey, value bpf.MapValue) {
 		// TODO: These type assertions are a bit dangerous, make more of this well typed
 		// to avoid having to make these assertions.
@@ -524,15 +549,22 @@ func (m *Map) cleanup(filter GCFilter, natMap *nat.Map, stats *gcStats, next fun
 
 		switch action {
 		case deleteEntry:
-			err := m.purgeCtEntry(ctKey, entry, natMap, next, countFailedFn)
+			err := m.purgeCtEntry(ctKey, entry, scratch, natMap, next, countFailedFn)
 			if err != nil {
-				if errors.Is(err, ebpf.ErrKeyNotExist) {
+				switch {
+				case errors.Is(err, ebpf.ErrKeyNotExist):
 					m.Logger.Debug("key is missing, likely due to lru eviction - skipping",
 						logfields.Error, err,
 						logfields.Key, ctKey.ToHost(),
 					)
 					stats.skipped++
-				} else {
+				case errors.Is(err, errDeferredReopened):
+					m.Logger.Debug("deferred delete: entry reopened between batch read and delete",
+						logfields.Error, err,
+						logfields.Key, ctKey.ToHost(),
+					)
+					stats.skipped++
+				default:
 					m.Logger.Error("key is missing, likely due to lru eviction - skipping",
 						logfields.Error, err,
 						logfields.Key, ctKey.ToHost(),

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -352,6 +352,65 @@ func TestPrivilegedCtGcTcp(t *testing.T) {
 	require.Empty(t, buf)
 }
 
+// TestPrivilegedCtGcReopenedEntry verifies that purgeCtEntry skips deleting an
+// entry whose Lifetime changed since the GC snapshot, and deletes it otherwise.
+func TestPrivilegedCtGcReopenedEntry(t *testing.T) {
+	setupCTMap(t)
+
+	ctMapName := MapNameTCP4Global + "_test"
+	ctMap := newMap(ctMapName, mapTypeIPv4TCPGlobal)
+	err := ctMap.OpenOrCreate()
+	require.NoError(t, err)
+	defer ctMap.Map.Unpin()
+
+	key := &CtKey4Global{
+		tuple.TupleKey4Global{
+			TupleKey4: tuple.TupleKey4{
+				SourceAddr: types.IPv4{192, 168, 61, 12},
+				DestAddr:   types.IPv4{192, 168, 61, 11},
+				SourcePort: 0x3195,
+				DestPort:   0x50,
+				NextHeader: u8proto.TCP,
+				Flags:      tuple.TUPLE_F_OUT,
+			},
+		},
+	}
+
+	t.Run("reopened entry is not deleted", func(t *testing.T) {
+		// Live value: datapath reopened the entry, Lifetime refreshed past expiry.
+		err := ctMap.Map.Update(key, &CtEntry{Packets: 5, Bytes: 600, Lifetime: 50000})
+		require.NoError(t, err)
+
+		// Snapshot: the older, expired value GC captured.
+		snapshot := &CtEntry{Packets: 1, Bytes: 216, Lifetime: 38000}
+		scratch := &CtEntry{}
+
+		err = ctMap.purgeCtEntry(key, snapshot, scratch, nil, func(GCEvent) {}, nil)
+		require.ErrorIs(t, err, errDeferredReopened)
+
+		_, err = ctMap.Map.Lookup(key)
+		require.NoError(t, err, "reopened entry must not be deleted")
+
+		require.NoError(t, ctMap.Map.Delete(key))
+	})
+
+	t.Run("unchanged entry is deleted", func(t *testing.T) {
+		live := &CtEntry{Packets: 1, Bytes: 216, Lifetime: 38000}
+		err := ctMap.Map.Update(key, live)
+		require.NoError(t, err)
+
+		// Snapshot matches the live value: the entry is untouched.
+		snapshot := &CtEntry{Packets: 1, Bytes: 216, Lifetime: 38000}
+		scratch := &CtEntry{}
+
+		err = ctMap.purgeCtEntry(key, snapshot, scratch, nil, func(GCEvent) {}, nil)
+		require.NoError(t, err)
+
+		_, err = ctMap.Map.Lookup(key)
+		require.Error(t, err, "unchanged entry must be deleted")
+	})
+}
+
 // TestPrivilegedCtGcDsr tests whether DSR NAT entries are removed upon a removal of
 // their CT entry (== CT_EGRESS).
 func TestPrivilegedCtGcDsr(t *testing.T) {

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -1023,18 +1023,34 @@ func populateFakeDataCTMap4(tb testing.TB, m CtMap, size int) map[*CtKey4Global]
 }
 
 func BenchmarkPrivilegedCtGcTcpXL(t *testing.B) {
-	benchmarkCtGc(t, 1<<24) // max size
+	benchmarkCtGc(t, 1<<24, false) // max size
 }
 
 func BenchmarkPrivilegedCtGcTcpL(t *testing.B) {
-	benchmarkCtGc(t, 1<<22)
+	benchmarkCtGc(t, 1<<22, false)
 }
 
 func BenchmarkPrivilegedCtGcTcpM(t *testing.B) {
-	benchmarkCtGc(t, 1<<17)
+	benchmarkCtGc(t, 1<<17, false)
 }
 
-func benchmarkCtGc(t *testing.B, size int) {
+// The *Expired variants populate entries that are already expired at GC time,
+// so GC actually deletes them and the per-entry re-lookup + delete path runs.
+// The non-Expired variants above keep entries live, so GC walks but deletes
+// nothing.
+func BenchmarkPrivilegedCtGcTcpXLExpired(t *testing.B) {
+	benchmarkCtGc(t, 1<<24, true) // max size
+}
+
+func BenchmarkPrivilegedCtGcTcpLExpired(t *testing.B) {
+	benchmarkCtGc(t, 1<<22, true)
+}
+
+func BenchmarkPrivilegedCtGcTcpMExpired(t *testing.B) {
+	benchmarkCtGc(t, 1<<17, true)
+}
+
+func benchmarkCtGc(t *testing.B, size int, expireAll bool) {
 	for t.Loop() {
 		t.StopTimer()
 		setupCTMap(t)
@@ -1082,6 +1098,11 @@ func benchmarkCtGc(t *testing.B, size int) {
 				Packets:  1,
 				Bytes:    216,
 				Lifetime: 2,
+			}
+			if expireAll {
+				// Lifetime 0 < GCFilter.Time (1) below, so GC deletes every
+				// entry and the delete path is exercised for the whole map.
+				ctVal.Lifetime = 0
 			}
 			err = ctMap.Map.Update(ctKey, ctVal)
 			assert.NoError(t, err)


### PR DESCRIPTION
_This PR was prepared with AIL:3. I designed the fix and reviewed every line myself. An AI agent drafted the code and tests under my review._

Fixes: #46298

# Problem Statement

- With BPF masquerade (SNAT) and sustained TCP connection churn, the CT GC can delete a CT entry that the datapath has just refreshed for a live connection.
- Deleting the entry also drops its NAT mapping, so the live connection breaks: the next packet gets a new SNAT source port (server replies RST), or the reply misses reverse-NAT and is dropped (silent timeout).
- Observed ~1 failure per 4×10⁵ connections at 7,500 CPS from a single node. Full analysis and reproduction in #46298.

# Root Cause

- CT GC reads entries in batches (`BatchIterator`, #36288) and deletes the expired ones afterwards.
- Between the batch read and the per-key delete, the datapath can reopen the same 5-tuple.
- GC, still acting on the stale snapshot, deletes the now-live entry. Before #36288 the read→delete window was a single per-key op (microseconds); batching widened it to whole-batch processing time, so a larger CT map makes the race easier to hit.

# Solution Summary

```
purgeCtEntry(key, snapshot):
    LookupTo(key, &live)                     # re-read current value (no alloc)
    if live.Lifetime != snapshot.Lifetime:   # datapath touched it after the batch read
        return errDeferredReopened           # skip delete; a later GC pass retries
    DeleteLocked(key)                        # unchanged → safe to delete
```

- Re-look up each entry in `purgeCtEntry` right before deleting and compare its `Lifetime` with the GC snapshot. A changed `Lifetime` means the datapath refreshed the entry after the batch read, so the delete is deferred (`errDeferredReopened`, logged at debug) and a later GC pass reconsiders it.
- The re-lookup runs **only on entries GC already selected for deletion** (expired), not the whole map, and uses the non-allocating `Map.LookupTo` with a single scratch `CtEntry` reused across the GC pass.

# Reproduction rate (24-hour soak, 7,500 CPS, pod → world)

- v1.12.x(non-batched): 0%
- v1.19.4(batched): 1/4×10⁵ = 0.00025%
- proposed change: 0%

# Key Consideration

- This narrows but does not fully close the race. The datapath can still reopen between the re-lookup and `DeleteLocked`. It removes the wide whole-batch window, restoring roughly the pre-batch race probability.
- Comparing `Lifetime` (GC's own deletion criterion) instead of closing flags keeps the check protocol-agnostic.
- Cost is bounded. The extra lookup runs only on GC-selected (expired) entries and is non-allocating. The worst case is a map full of expired entries after a long downtime/restart, which is acceptable since batching targets the common sparse case.
- The existing `bpf.Map.Lookup(key)` allocates a fresh value via `m.value.New()` (`pkg/bpf/map_linux.go`). Adding it to a hot per-entry GC path is expensive in allocations.

Allocation cost — `Map.Lookup` vs `Map.LookupTo` on the GC delete path:

<img width="2626" height="950" alt="Map.Lookup vs Map.LookupTo allocations" src="https://github.com/user-attachments/assets/2201a597-2423-4c6d-a3c8-8663b7c25ed5" />

- Fully closing the race needs atomicity in the datapath. Compare-and-delete was [proposed upstream](https://lore.kernel.org/bpf/20260622071649.31541-1-gyutae.opensource@navercorp.com/T/) but is not being added to the kernel; the long-term direction (from #46298) is to stay within the existing BPF programmability model. This PR lands the re-lookup mitigation now as a practical near-term step.

# Release Note
```release-note
Fix conntrack garbage collection deleting CT entries that the datapath reopened between the GC batch read and the delete, which could cascade into NAT mapping deletion and SNAT source-port reallocation for live connections.
```