### PR TITLE
docs: document Envoy listener redirect and wildcard port in L4 policy

### DIFF
--- a/Documentation/network/servicemesh/l7-traffic-management.rst
+++ b/Documentation/network/servicemesh/l7-traffic-management.rst
@@ -13,6 +13,9 @@ L7-Aware Traffic Management
 Cilium provides a way to control L7 traffic via CRDs (e.g. CiliumEnvoyConfig
 and CiliumClusterwideEnvoyConfig).
 
+To redirect policy-selected traffic to a listener defined in a CiliumEnvoyConfig
+or CiliumClusterwideEnvoyConfig, see :ref:`envoy_listener_redirect`.
+
 Prerequisites
 #############
 

--- a/Documentation/security/policy/layer4.rst
+++ b/Documentation/security/policy/layer4.rst
@@ -200,3 +200,175 @@ Below is the same SSL error while trying to connect to ``cilium.io`` from curl.
     * Closing connection
     curl: (35) Recv failure: Connection reset by peer
     command terminated with exit code 35
+
+.. _envoy_listener_redirect:
+
+Redirect traffic to an Envoy listener
+-------------------------------------
+
+A ``toPorts`` rule can carry a ``listener`` reference that redirects matching
+traffic to a named Envoy listener defined in a CiliumEnvoyConfig (CEC) or
+CiliumClusterwideEnvoyConfig (CCEC). Instead of allowing or denying the traffic,
+Cilium hands the traffic to the Envoy proxy, where the listener can act on the
+traffic, for example to manipulate headers, route, rewrite, or observe requests.
+
+.. warning::
+
+   A ``listener`` redirect offers a lot of flexibility, but it requires writing
+   raw Envoy configuration inside the CiliumEnvoyConfig or
+   CiliumClusterwideEnvoyConfig resource. Cilium performs only minimal validation
+   on that configuration, so small mistakes are easy to make and hard to debug.
+   Prefer solving traffic-management use cases with the higher-level Cilium
+   Gateway API support, including :ref:`GAMMA <gs_gamma>` for mesh (east-west)
+   traffic, and only reach for a ``listener`` redirect when the Gateway API does
+   not cover the use case. See :ref:`gs_gateway_api` and :ref:`gs_gamma`.
+
+Configure the ``listener`` field on egress, alongside the ``ports`` inside a
+``toPorts`` entry. The ``listener`` field contains the following keys:
+
+* ``envoyConfig`` — references the CEC or CCEC that defines the listener, using
+  the ``kind`` and ``name`` keys. When ``kind`` is omitted, Cilium resolves the
+  reference within the policy's own scope: a CiliumNetworkPolicy looks for a
+  namespaced CiliumEnvoyConfig in its own namespace, and a
+  CiliumClusterwideNetworkPolicy looks for a cluster-scoped
+  CiliumClusterwideEnvoyConfig. Setting ``kind`` explicitly states which resource
+  type defines the listener. A CiliumNetworkPolicy can reference either a
+  CiliumEnvoyConfig in its namespace or, by setting
+  ``kind: CiliumClusterwideEnvoyConfig``, a cluster-scoped
+  CiliumClusterwideEnvoyConfig. A CiliumClusterwideNetworkPolicy can only
+  reference a CiliumClusterwideEnvoyConfig.
+* ``name`` — the name of the listener within that config.
+
+The following examples use CiliumNetworkPolicy, but the same ``listener`` field
+works the same way in a CiliumClusterwideNetworkPolicy.
+
+.. note::
+
+   A ``listener`` redirect cannot be combined with Layer 7 ``rules`` (HTTP or
+   DNS) in the same ``toPorts`` entry. Use the Envoy listener itself to express
+   any application-layer behavior.
+
+For how to define the listener and the supporting Envoy resources, see
+:ref:`gs_l7_traffic_management` and :ref:`gs_envoy_custom_listener`.
+
+Example (redirect to Envoy)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following rule allows all endpoints with the label ``app=myService`` to
+emit HTTP traffic to ``example.com`` on TCP port 80, and redirects that traffic
+to the Envoy listener ``add-header-listener``:
+
+.. literalinclude:: ../../../examples/policies/l4/envoy_listener_redirect.yaml
+  :language: yaml
+  :emphasize-lines: 16-20
+
+A separate CiliumClusterwideEnvoyConfig defines the referenced listener. The
+following minimal listener injects an ``X-Request-Source: cilium`` request
+header before forwarding the request upstream:
+
+.. literalinclude:: ../../../examples/policies/l4/envoy_listener_redirect_cec.yaml
+  :language: yaml
+
+The route sends matching requests to ``original-dst-cluster``, an
+``ORIGINAL_DST`` cluster defined in the same CiliumClusterwideEnvoyConfig. The
+cluster forwards each connection to the original destination of the request
+(``example.com`` in this example) after adding the header.
+
+The names in the policy must match the names in the CiliumClusterwideEnvoyConfig:
+
+* ``envoyConfig.name`` in the policy (``add-header-config``) matches the
+  ``metadata.name`` of the CiliumClusterwideEnvoyConfig.
+* ``name`` in the policy (``add-header-listener``) matches the ``name`` of the
+  listener resource inside that CiliumClusterwideEnvoyConfig.
+
+The config sets the annotation
+``cec.cilium.io/use-original-source-address: "false"``. This annotation controls
+the source address Envoy uses for the upstream connection. For a hand-written
+CiliumEnvoyConfig or CiliumClusterwideEnvoyConfig, the annotation defaults to
+``"true"``, which keeps the original pod source address (transparent proxy). For
+pod-originated egress redirects like this example, set it to
+``"false"`` so that Envoy uses its own source address. With the
+default ``"true"``, Cilium binds the upstream socket to the intercepted
+connection's source IP and port, then connects to the same destination via the
+``ORIGINAL_DST`` cluster. The resulting upstream 5-tuple (source IP, source
+port, destination IP, destination port, protocol) is identical to the
+intercepted downstream connection that is still open. The kernel rejects the
+duplicate and the connection fails. Setting ``"false"`` lets Envoy pick a fresh
+source address for the upstream connection, which keeps every 5-tuple unique.
+
+.. note::
+
+   The Cilium Envoy proxy ships with a curated subset of Envoy extensions, not
+   the full set. Before relying on a particular filter or extension, confirm
+   that the proxy build includes it. The enabled extensions are listed in the
+   `Envoy extensions build configuration`_. Check the Cilium version you run and
+   read the configuration for that version, because the set of enabled
+   extensions changes over time.
+
+.. _Envoy extensions build configuration: https://github.com/cilium/proxy/blob/main/envoy_build_config/extensions_build_config.bzl
+
+Example (forward proxy with authentication)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+One use of an Envoy listener redirect routes egress traffic through an external
+HTTP forward proxy and injects the credentials that the forward proxy requires.
+The Envoy listener tunnels the redirected TCP connection through the forward
+proxy and adds a ``Proxy-Authorization`` header, so the application pods do not
+need to be aware of the forward proxy or hold the forward proxy's credentials.
+
+The following policy redirects internet-bound web traffic on port 80 to the
+Envoy listener. The ``toCIDRSet`` selector matches every destination except the
+private (RFC 1918) ranges, so cluster-local and private-network traffic is not
+redirected:
+
+.. literalinclude:: ../../../examples/policies/l4/envoy_forward_proxy.yaml
+  :language: yaml
+  :emphasize-lines: 23-27
+
+The listener uses a TCP proxy with a ``tunneling_config`` that adds the
+``Proxy-Authorization`` header and forwards the connection to the external
+forward proxy at ``10.0.100.10:3128``:
+
+.. literalinclude:: ../../../examples/policies/l4/envoy_forward_proxy_cec.yaml
+  :language: yaml
+
+.. note::
+
+   The example encodes static Basic credentials for illustration, which means
+   the credentials live in plain text inside the CiliumClusterwideEnvoyConfig.
+   The ``headers_to_add`` field of the TCP proxy ``tunneling_config`` accepts
+   only literal values; it cannot reference a Kubernetes secret or an Envoy
+   Secret Discovery Service (SDS) secret. Anyone who can read the
+   CiliumClusterwideEnvoyConfig can therefore read the credentials, so restrict
+   access to the resource with RBAC and treat it as sensitive. To keep
+   credentials out of the configuration entirely, the listener must be
+   redesigned around a filter that supports SDS, which is beyond the scope of
+   this example.
+
+Wildcard port
+~~~~~~~~~~~~~
+
+Setting ``port: "0"`` acts as a wildcard, matching all ports for the given
+protocol. A single rule then applies to every port without enumerating each
+port.
+
+Wildcard ports pair well with a transport-level Envoy listener such as the
+forward-proxy listener in the preceding example. Because a TCP-proxy listener
+operates on the connection rather than parsing an application protocol, the
+listener handles traffic on any port. Setting the port to ``"0"`` sends all egress TCP
+connections through the forward proxy, instead of limiting the redirect to a
+single port such as 80.
+
+The following rule redirects all internet-bound TCP egress traffic through the
+forward-proxy listener. The ``toCIDRSet`` selector matches every destination
+address except the private (RFC 1918) ranges, so traffic that stays inside the
+cluster or the local network is not redirected:
+
+.. literalinclude:: ../../../examples/policies/l4/wildcard_port_listener.yaml
+  :language: yaml
+  :emphasize-lines: 20
+
+.. note::
+
+   ``port: "0"`` cannot be combined with Layer 7 ``rules`` (HTTP or DNS);
+   ``port: "0"`` is a Layer 3/4 construct.

--- a/Documentation/security/policy/layer4.rst
+++ b/Documentation/security/policy/layer4.rst
@@ -200,3 +200,193 @@ Below is the same SSL error while trying to connect to ``cilium.io`` from curl.
     * Closing connection
     curl: (35) Recv failure: Connection reset by peer
     command terminated with exit code 35
+
+.. _envoy_listener_redirect:
+
+Redirect traffic to an Envoy listener
+-------------------------------------
+
+A ``toPorts`` rule can carry a ``listener`` reference that redirects matching
+traffic to a named Envoy listener defined in a CiliumEnvoyConfig (CEC) or
+CiliumClusterwideEnvoyConfig (CCEC). Instead of allowing or denying the traffic,
+Cilium hands the traffic to the Envoy proxy, where the listener can act on the
+traffic, for example to manipulate headers, route, rewrite, or observe requests.
+
+.. warning::
+
+   A ``listener`` redirect offers a lot of flexibility, but it requires writing
+   raw Envoy configuration inside the CiliumEnvoyConfig or
+   CiliumClusterwideEnvoyConfig resource. Cilium performs only minimal validation
+   on that configuration, so small mistakes are easy to make and hard to debug.
+   Prefer solving traffic-management use cases with the higher-level Cilium
+   Gateway API support, including :ref:`GAMMA <gs_gamma>` for mesh (east-west)
+   traffic, and only reach for a ``listener`` redirect when the Gateway API does
+   not cover the use case. See :ref:`gs_gateway_api` and :ref:`gs_gamma`.
+
+Configure the ``listener`` field on egress, alongside the ``ports`` inside a
+``toPorts`` entry. The ``listener`` field contains the following keys:
+
+* ``envoyConfig`` — references the CEC or CCEC that defines the listener, using
+  the ``kind`` and ``name`` keys. When ``kind`` is omitted, Cilium resolves the
+  reference within the policy's own scope: a CiliumNetworkPolicy looks for a
+  namespaced CiliumEnvoyConfig in its own namespace, and a
+  CiliumClusterwideNetworkPolicy looks for a cluster-scoped
+  CiliumClusterwideEnvoyConfig. Setting ``kind`` explicitly states which resource
+  type defines the listener. A CiliumNetworkPolicy can reference either a
+  CiliumEnvoyConfig in its namespace or, by setting
+  ``kind: CiliumClusterwideEnvoyConfig``, a cluster-scoped
+  CiliumClusterwideEnvoyConfig. A CiliumClusterwideNetworkPolicy can only
+  reference a CiliumClusterwideEnvoyConfig.
+* ``name`` — the name of the listener within that config.
+
+The following examples use CiliumNetworkPolicy, but the same ``listener`` field
+works the same way in a CiliumClusterwideNetworkPolicy.
+
+.. note::
+
+   A ``listener`` redirect cannot be combined with Layer 7 ``rules`` (HTTP or
+   DNS) in the same ``toPorts`` entry, or any other ``toPorts`` entry for the
+   same port. Use the Envoy listener itself to express any application-layer
+   behavior.
+
+For how to define the listener and the supporting Envoy resources, see
+:ref:`gs_l7_traffic_management` and :ref:`gs_envoy_custom_listener`.
+
+Example (redirect to Envoy)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following rule allows all endpoints with the label ``app=myService`` to
+emit HTTP traffic to ``example.com`` on TCP port 80, and redirects that traffic
+to the Envoy listener ``add-header-listener``:
+
+.. literalinclude:: ../../../examples/policies/l4/envoy_listener_redirect.yaml
+  :language: yaml
+  :emphasize-lines: 16-20
+
+A separate CiliumClusterwideEnvoyConfig defines the referenced listener. The
+following minimal listener injects an ``X-Request-Source: cilium`` request
+header before forwarding the request upstream:
+
+.. literalinclude:: ../../../examples/policies/l4/envoy_listener_redirect_cec.yaml
+  :language: yaml
+
+The route sends matching requests to ``original-dst-cluster``, an
+``ORIGINAL_DST`` cluster defined in the same CiliumClusterwideEnvoyConfig. The
+cluster forwards each connection to the original destination of the request
+(``example.com`` in this example) after adding the header.
+
+The names in the policy must match the names in the CiliumClusterwideEnvoyConfig:
+
+* ``envoyConfig.name`` in the policy (``add-header-config``) matches the
+  ``metadata.name`` of the CiliumClusterwideEnvoyConfig.
+* ``name`` in the policy (``add-header-listener``) matches the ``name`` of the
+  listener resource inside that CiliumClusterwideEnvoyConfig.
+
+The config sets the annotation
+``cec.cilium.io/use-original-source-address: "false"``. This annotation
+controls whether Envoy is allowed to keep the pod's real source IP and port
+on the upstream connection. For a hand-written CiliumEnvoyConfig or
+CiliumClusterwideEnvoyConfig, it defaults to ``"true"``, which leaves the
+decision to Cilium Envoy rather than forcing reuse of the original source
+address in every case.
+
+Cilium intercepts the pod's connection to ``example.com`` transparently, so
+the pod's TCP connection actually terminates at Envoy, not at the real
+``example.com``. The socket Cilium Envoy accepts still carries the pod's real
+source IP:port and the real destination, ``example.com:80``. With the default
+``"true"``, Envoy may reuse that same source IP:port when it opens its own,
+separate upstream connection to ``example.com`` through the ``ORIGINAL_DST``
+cluster. The pod's original connection to Envoy is still open, so Envoy's new
+upstream connection would end up with the exact same source IP, source port,
+destination IP, destination port, and protocol. The kernel will refuse to
+open a second connection with the same 5-tuple if the source pod or the
+destination is in the host networking namespace, or if the destination is a
+pod in the same node and there is an HTTP policy for it. In those cases the
+upstream connection fails. Setting the annotation to ``"false"`` avoids this
+by making Envoy always pick a different source port for its upstream
+connection.
+
+Only override the default to ``"false"`` when the upstream traffic is known
+to leave the cluster, as in this example. There, the source address is
+masqueraded when it crosses the cluster boundary anyway, so forcing Envoy to
+pick its own source address costs nothing. If the upstream traffic instead
+stays inside the cluster, leave the annotation at its default ``"true"`` and
+let Cilium Envoy decide, since it already avoids the source-address collision
+in cases such as redirects to a destination pod on the same node.
+
+.. note::
+
+   The Cilium Envoy proxy ships with a curated subset of Envoy extensions, not
+   the full set. Before relying on a particular filter or extension, confirm
+   that the proxy build includes it. The enabled extensions are listed in the
+   `Envoy extensions build configuration`_. Check the Cilium version you run and
+   read the configuration for that version, because the set of enabled
+   extensions changes over time.
+
+.. _Envoy extensions build configuration: https://github.com/cilium/proxy/blob/main/envoy_build_config/extensions_build_config.bzl
+
+Example (forward proxy with authentication)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+One use of an Envoy listener redirect routes egress traffic through an external
+HTTP forward proxy and injects the credentials that the forward proxy requires.
+The Envoy listener tunnels the redirected TCP connection through the forward
+proxy and adds a ``Proxy-Authorization`` header, so the application pods do not
+need to be aware of the forward proxy or hold the forward proxy's credentials.
+
+The following policy redirects internet-bound web traffic on port 80 to the
+Envoy listener. The ``toCIDRSet`` selector matches every destination except the
+private (RFC 1918) ranges, so cluster-local and private-network traffic is not
+redirected:
+
+.. literalinclude:: ../../../examples/policies/l4/envoy_forward_proxy.yaml
+  :language: yaml
+  :emphasize-lines: 23-27
+
+The listener uses a TCP proxy with a ``tunneling_config`` that adds the
+``Proxy-Authorization`` header and forwards the connection to the external
+forward proxy at ``10.0.100.10:3128``:
+
+.. literalinclude:: ../../../examples/policies/l4/envoy_forward_proxy_cec.yaml
+  :language: yaml
+
+.. note::
+
+   The example encodes static Basic credentials for illustration, which means
+   the credentials live in plain text inside the CiliumClusterwideEnvoyConfig.
+   The ``headers_to_add`` field of the TCP proxy ``tunneling_config`` accepts
+   only literal values; it cannot reference a Kubernetes secret or an Envoy
+   Secret Discovery Service (SDS) secret. Anyone who can read the
+   CiliumClusterwideEnvoyConfig can therefore read the credentials, so restrict
+   access to the resource with RBAC and treat it as sensitive. To keep
+   credentials out of the configuration entirely, the listener must be
+   redesigned around a filter that supports SDS, which is beyond the scope of
+   this example.
+
+Wildcard port
+~~~~~~~~~~~~~
+
+Setting ``port: "0"`` acts as a wildcard, matching all ports for the given
+protocol. A single rule then applies to every port without enumerating each
+port.
+
+Wildcard ports pair well with a transport-level Envoy listener such as the
+forward-proxy listener in the preceding example. Because a TCP-proxy listener
+operates on the connection rather than parsing an application protocol, the
+listener handles traffic on any port. Setting the port to ``"0"`` sends all egress TCP
+connections through the forward proxy, instead of limiting the redirect to a
+single port such as 80.
+
+The following rule redirects all internet-bound TCP egress traffic through the
+forward-proxy listener. The ``toCIDRSet`` selector matches every destination
+address except the private (RFC 1918) ranges, so traffic that stays inside the
+cluster or the local network is not redirected:
+
+.. literalinclude:: ../../../examples/policies/l4/wildcard_port_listener.yaml
+  :language: yaml
+  :emphasize-lines: 20
+
+.. note::
+
+   ``port: "0"`` cannot be combined with Layer 7 ``rules`` (HTTP or DNS);
+   ``port: "0"`` is a Layer 3/4 construct.

--- a/examples/policies/l4/envoy_forward_proxy.yaml
+++ b/examples/policies/l4/envoy_forward_proxy.yaml
@@ -1,0 +1,27 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "egress-via-forward-proxy"
+spec:
+  endpointSelector:
+    matchLabels:
+      app: myService
+  egress:
+    # Redirect internet-bound web traffic to the Envoy listener, which tunnels
+    # it through the external forward proxy. The except list keeps cluster-local
+    # and private-network traffic out of the redirect.
+    - toCIDRSet:
+        - cidr: 0.0.0.0/0
+          except:
+            - 10.0.0.0/8
+            - 172.16.0.0/12
+            - 192.168.0.0/16
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+          listener:
+            envoyConfig:
+              kind: CiliumClusterwideEnvoyConfig
+              name: forward-proxy-redirect
+            name: forward-proxy-listener

--- a/examples/policies/l4/envoy_forward_proxy_cec.yaml
+++ b/examples/policies/l4/envoy_forward_proxy_cec.yaml
@@ -1,0 +1,38 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideEnvoyConfig
+metadata:
+  name: forward-proxy-redirect
+spec:
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      name: forward-proxy-listener
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.tcp_proxy
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                stat_prefix: tcp_stats
+                cluster: forward-proxy-cluster
+                tunneling_config:
+                  hostname: "%DOWNSTREAM_LOCAL_ADDRESS%"
+                  headers_to_add:
+                    # Add Basic credentials for the upstream forward proxy.
+                    # echo -n "user:secret" | base64
+                    - header:
+                        key: Proxy-Authorization
+                        value: Basic dXNlcjpzZWNyZXQ=
+                      append_action: OVERWRITE_IF_EXISTS_OR_ADD
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      name: forward-proxy-cluster
+      connect_timeout: 5s
+      type: STATIC
+      load_assignment:
+        cluster_name: forward-proxy-cluster
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      # Address of the external (off-cluster) forward proxy.
+                      address: 10.0.100.10
+                      port_value: 3128

--- a/examples/policies/l4/envoy_listener_redirect.yaml
+++ b/examples/policies/l4/envoy_listener_redirect.yaml
@@ -1,0 +1,20 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "redirect-http-to-envoy"
+spec:
+  endpointSelector:
+    matchLabels:
+      app: myService
+  egress:
+    - toFQDNs:
+        - matchName: "example.com"
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+          listener:
+            envoyConfig:
+              kind: CiliumClusterwideEnvoyConfig
+              name: add-header-config
+            name: add-header-listener

--- a/examples/policies/l4/envoy_listener_redirect_cec.yaml
+++ b/examples/policies/l4/envoy_listener_redirect_cec.yaml
@@ -1,0 +1,41 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideEnvoyConfig
+metadata:
+  name: add-header-config
+  annotations:
+    # For pod-originated egress redirects: Envoy uses its own source address
+    # for the upstream connection instead of the pod's source address.
+    cec.cilium.io/use-original-source-address: "false"
+spec:
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      name: add-header-listener
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: add-header-listener
+                route_config:
+                  name: add_header_route
+                  request_headers_to_add:
+                    - header:
+                        key: X-Request-Source
+                        value: cilium
+                  virtual_hosts:
+                    - name: add_header_vhost
+                      domains: ["*"]
+                      routes:
+                        - match:
+                            prefix: "/"
+                          route:
+                            cluster: original-dst-cluster
+                http_filters:
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      name: original-dst-cluster
+      type: ORIGINAL_DST
+      connect_timeout: 5s
+      lb_policy: CLUSTER_PROVIDED

--- a/examples/policies/l4/envoy_listener_redirect_cec.yaml
+++ b/examples/policies/l4/envoy_listener_redirect_cec.yaml
@@ -1,0 +1,41 @@
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideEnvoyConfig
+metadata:
+  name: add-header-config
+  annotations:
+    # Avoids a 5-tuple collision with the pod's still-open original
+    # connection to the same destination.
+    cec.cilium.io/use-original-source-address: "false"
+spec:
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      name: add-header-listener
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: add-header-listener
+                route_config:
+                  name: add_header_route
+                  request_headers_to_add:
+                    - header:
+                        key: X-Request-Source
+                        value: cilium
+                  virtual_hosts:
+                    - name: add_header_vhost
+                      domains: ["*"]
+                      routes:
+                        - match:
+                            prefix: "/"
+                          route:
+                            cluster: original-dst-cluster
+                http_filters:
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      name: original-dst-cluster
+      type: ORIGINAL_DST
+      connect_timeout: 5s
+      lb_policy: CLUSTER_PROVIDED

--- a/examples/policies/l4/wildcard_port_listener.yaml
+++ b/examples/policies/l4/wildcard_port_listener.yaml
@@ -1,0 +1,26 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "redirect-internet-to-forward-proxy"
+spec:
+  endpointSelector:
+    matchLabels:
+      app: myService
+  egress:
+    # Match all destinations except the private (RFC 1918) ranges, so that only
+    # internet-bound traffic is redirected to the external forward proxy.
+    - toCIDRSet:
+        - cidr: 0.0.0.0/0
+          except:
+            - 10.0.0.0/8
+            - 172.16.0.0/12
+            - 192.168.0.0/16
+      toPorts:
+        - ports:
+            - port: "0"
+              protocol: TCP
+          listener:
+            envoyConfig:
+              kind: CiliumClusterwideEnvoyConfig
+              name: forward-proxy-redirect
+            name: forward-proxy-listener


### PR DESCRIPTION
Add a section to the Layer 4 policy docs covering the toPorts listener field, which redirects matching egress traffic to a named Envoy listener defined in a CiliumEnvoyConfig or CiliumClusterwideEnvoyConfig.

Includes three examples: a header-injection redirect, an external forward proxy with Proxy-Authorization, and a wildcard-port (port 0) variant that redirects all internet-bound egress. Documents the egress-only and no-L7-rules constraints, the use-original-source-address annotation, built-in egress-cluster routing, credential handling limits, and recommends Gateway API/GAMMA for cases they cover. Cross-links the L7 traffic management page.

```release-note
docs: document Envoy listener redirect and wildcard port in L4 policy
```

cc @jrajahalme