### PR TITLE
gatewayapi: fix HTTPRoute rejected on mixed HTTP+TCP Gateway

### DIFF
--- a/operator/pkg/gateway-api/routechecks/gateway_checks.go
+++ b/operator/pkg/gateway-api/routechecks/gateway_checks.go
@@ -102,7 +102,8 @@ func CheckGatewayRouteKindAllowed(input Input, parentRef gatewayv1.ParentReferen
 		}
 
 		if listener.AllowedRoutes == nil || len(listener.AllowedRoutes.Kinds) == 0 {
-			continue
+			// No kind restriction → listener accepts this route; protocol is checked separately.
+			return true, nil
 		}
 
 		hasKindRestriction = true

--- a/operator/pkg/gateway-api/routechecks/gateway_checks_test.go
+++ b/operator/pkg/gateway-api/routechecks/gateway_checks_test.go
@@ -102,6 +102,38 @@ var mixedNamespaceGateway = &gatewayv1.Gateway{
 	},
 }
 
+// Gateway fixture mixing an unrestricted HTTP listener with an explicit-TCPRoute
+// TCP listener; used to test that the TCP restriction doesn't block HTTPRoute.
+var mixedKindGateway = &gatewayv1.Gateway{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "mixed-kind-gateway",
+		Namespace: "default",
+	},
+	Spec: gatewayv1.GatewaySpec{
+		GatewayClassName: "cilium",
+		Listeners: []gatewayv1.Listener{
+			{
+				Name:     "http",
+				Port:     80,
+				Protocol: gatewayv1.HTTPProtocolType,
+			},
+			{
+				Name:     "tcp",
+				Port:     8090,
+				Protocol: gatewayv1.TCPProtocolType,
+				AllowedRoutes: &gatewayv1.AllowedRoutes{
+					Kinds: []gatewayv1.RouteGroupKind{
+						{
+							Group: ptr.To[gatewayv1.Group](gatewayv1.GroupName),
+							Kind:  "TCPRoute",
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
 // Gateway fixture with no kind restrictions on any listener.
 var noKindRestrictedGateway = &gatewayv1.Gateway{
 	ObjectMeta: metav1.ObjectMeta{
@@ -712,7 +744,7 @@ func TestCheckGatewayRouteKindAllowed(t *testing.T) {
 
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(kindRestrictedGateway, noKindRestrictedGateway).
+		WithObjects(kindRestrictedGateway, noKindRestrictedGateway, mixedKindGateway).
 		WithStatusSubresource(&gatewayv1.HTTPRoute{}).
 		Build()
 
@@ -797,6 +829,63 @@ func TestCheckGatewayRouteKindAllowed(t *testing.T) {
 					Name:        "kind-restricted-gateway",
 					Namespace:   ptr.To[gatewayv1.Namespace]("default"),
 					SectionName: ptr.To[gatewayv1.SectionName]("grpcs"),
+				},
+			},
+			want: false,
+		},
+		{
+			// Regression: TCP listener's explicit [TCPRoute] must not poison the unrestricted HTTP listener.
+			name: "HTTPRoute on mixed HTTP+TCP gateway without sectionName (allowed by unrestricted HTTP listener)",
+			args: args{
+				input: &HTTPRouteInput{
+					Client: c,
+					HTTPRoute: &gatewayv1.HTTPRoute{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+						},
+					},
+				},
+				parentRef: gatewayv1.ParentReference{
+					Name:      "mixed-kind-gateway",
+					Namespace: ptr.To[gatewayv1.Namespace]("default"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "HTTPRoute on mixed HTTP+TCP gateway targeting http section (allowed)",
+			args: args{
+				input: &HTTPRouteInput{
+					Client: c,
+					HTTPRoute: &gatewayv1.HTTPRoute{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+						},
+					},
+				},
+				parentRef: gatewayv1.ParentReference{
+					Name:        "mixed-kind-gateway",
+					Namespace:   ptr.To[gatewayv1.Namespace]("default"),
+					SectionName: ptr.To[gatewayv1.SectionName]("http"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "HTTPRoute on mixed HTTP+TCP gateway targeting tcp section (rejected)",
+			args: args{
+				input: &HTTPRouteInput{
+					Client: c,
+					HTTPRoute: &gatewayv1.HTTPRoute{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+						},
+					},
+				},
+				parentRef: gatewayv1.ParentReference{
+					Name:        "mixed-kind-gateway",
+					Namespace:   ptr.To[gatewayv1.Namespace]("default"),
+					SectionName: ptr.To[gatewayv1.SectionName]("tcp"),
 				},
 			},
 			want: false,


### PR DESCRIPTION
Fixes #46754

## Problem

`CheckGatewayRouteKindAllowed` silently skips listeners that have no explicit `AllowedRoutes.Kinds` via `continue`. When a Gateway mixes an unrestricted HTTP listener with a TCP listener carrying `AllowedRoutes.Kinds: [TCPRoute]`, the TCP listener sets `hasKindRestriction = true` while the HTTP listener is ignored. The HTTPRoute is then rejected with `Accepted=False / NotAllowedByListeners` even though the HTTP listener permits it.

## Fix

One-line change: replace `continue` with `return true, nil` when a matching listener has no kind restriction. A listener without explicit kinds does not restrict by kind — protocol enforcement is handled separately by `CheckGatewayMatchingProtocol`.

```go
if listener.AllowedRoutes == nil || len(listener.AllowedRoutes.Kinds) == 0 {
    // No kind restriction → listener accepts this route; protocol is checked separately.
    return true, nil
}
```

## Test plan

- [x] Existing `TestCheckGatewayRouteKindAllowed` cases still pass
- [x] Added `mixedKindGateway` fixture (HTTP listener + TCP listener with explicit `[TCPRoute]`)
- [x] Three new cases: no sectionName (allowed), `sectionName: http` (allowed), `sectionName: tcp` (rejected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)