### PR TITLE
AWS IPAM IPv6 prefix support on agent

### DIFF
--- a/install/kubernetes/cilium/templates/warnings.txt
+++ b/install/kubernetes/cilium/templates/warnings.txt
@@ -21,4 +21,8 @@
   to secure access with HTTPS. For more information about the security implications
   and suggested controls, please see: https://docs.cilium.io/en/stable/security/threat-model/#hubble-data-attacker
 {{- end -}}
+{{- if and (eq .Values.ipam.mode "eni") .Values.ipv6.enabled -}}
+- WARNING: IPv6 support in the ENI IPAM mode (ipam.mode=eni, ipv6.enabled=true) is a beta feature.
+  Please use it with caution and report any issues you encounter: https://github.com/cilium/cilium/issues/new?template=bug_report.yaml
+{{- end -}}
 {{- end -}}

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -2117,37 +2117,61 @@ func (m *manager) addNoTrackPodTrafficRules(prog runnable, podsCIDR string) erro
 }
 
 func (m *manager) addCiliumENIRules() error {
-	if !m.sharedCfg.EnableIPv4 {
-		return nil
-	}
-
-	iface, err := route.NodeDeviceWithDefaultRoute(m.logger, m.sharedCfg.EnableIPv4, m.sharedCfg.EnableIPv6)
-	if err != nil {
-		return fmt.Errorf("failed to find interface with default route: %w", err)
-	}
-
 	nfmask := fmt.Sprintf("%#08x", linux_defaults.MarkMultinodeNodeport)
 	ctmask := fmt.Sprintf("%#08x", linux_defaults.MaskMultinodeNodeport)
 
-	// Note: these rules need the xt_connmark module (iptables usually
-	// loads it when required, unless loading modules after boot has been
-	// disabled).
-	if err := m.ip4tables.runProg([]string{
-		"-t", "mangle",
-		"-A", ciliumPreMangleChain,
-		"-i", iface.Attrs().Name,
-		"-m", "comment", "--comment", "cilium: primary ENI",
-		"-m", "addrtype", "--dst-type", "LOCAL", "--limit-iface-in",
-		"-j", "CONNMARK", "--set-xmark", nfmask + "/" + ctmask}); err != nil {
-		return err
+	if m.sharedCfg.EnableIPv4 {
+		iface, err := route.NodeDeviceWithDefaultRoute(m.logger, true, false)
+		if err != nil {
+			return fmt.Errorf("failed to find interface with IPv4 default route: %w", err)
+		}
+		// Note: these rules need the xt_connmark module (iptables usually
+		// loads it when required, unless loading modules after boot has been
+		// disabled).
+		if err := m.ip4tables.runProg([]string{
+			"-t", "mangle",
+			"-A", ciliumPreMangleChain,
+			"-i", iface.Attrs().Name,
+			"-m", "comment", "--comment", "cilium: primary ENI",
+			"-m", "addrtype", "--dst-type", "LOCAL", "--limit-iface-in",
+			"-j", "CONNMARK", "--set-xmark", nfmask + "/" + ctmask}); err != nil {
+			return err
+		}
+		if err := m.ip4tables.runProg([]string{
+			"-t", "mangle",
+			"-A", ciliumPreMangleChain,
+			"-i", "lxc+",
+			"-m", "comment", "--comment", "cilium: primary ENI",
+			"-j", "CONNMARK", "--restore-mark", "--nfmask", nfmask, "--ctmask", ctmask}); err != nil {
+			return err
+		}
 	}
 
-	return m.ip4tables.runProg([]string{
-		"-t", "mangle",
-		"-A", ciliumPreMangleChain,
-		"-i", "lxc+",
-		"-m", "comment", "--comment", "cilium: primary ENI",
-		"-j", "CONNMARK", "--restore-mark", "--nfmask", nfmask, "--ctmask", ctmask})
+	if m.sharedCfg.EnableIPv6 {
+		iface, err := route.NodeDeviceWithDefaultRoute(m.logger, false, true)
+		if err != nil {
+			return fmt.Errorf("failed to find interface with IPv6 default route: %w", err)
+		}
+		if err := m.ip6tables.runProg([]string{
+			"-t", "mangle",
+			"-A", ciliumPreMangleChain,
+			"-i", iface.Attrs().Name,
+			"-m", "comment", "--comment", "cilium: primary ENI",
+			"-m", "addrtype", "--dst-type", "LOCAL", "--limit-iface-in",
+			"-j", "CONNMARK", "--set-xmark", nfmask + "/" + ctmask}); err != nil {
+			return err
+		}
+
+		if err := m.ip6tables.runProg([]string{
+			"-t", "mangle",
+			"-A", ciliumPreMangleChain,
+			"-i", "lxc+",
+			"-m", "comment", "--comment", "cilium: primary ENI",
+			"-j", "CONNMARK", "--restore-mark", "--nfmask", nfmask, "--ctmask", ctmask}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func nodeIpsetNATCmds(allocRange string, ipset string, masqueradeInterfaces []string) [][]string {

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -96,7 +96,7 @@ func writePreFilterHeader(logger *slog.Logger, preFilter prefilter.PreFilter, di
 	return fw.Flush()
 }
 
-func addENIRules(logger *slog.Logger, sysSettings []tables.Sysctl) ([]tables.Sysctl, error) {
+func addIPv4ENIRules(logger *slog.Logger, sysSettings []tables.Sysctl) ([]tables.Sysctl, error) {
 	// AWS ENI mode requires symmetric routing, see
 	// iptables.addCiliumENIRules().
 	// The default AWS daemonset installs the following rules that are used
@@ -118,7 +118,7 @@ func addENIRules(logger *slog.Logger, sysSettings []tables.Sysctl) ([]tables.Sys
 		return sysSettings, nil
 	}
 
-	iface, err := route.NodeDeviceWithDefaultRoute(logger, option.Config.EnableIPv4, option.Config.EnableIPv6)
+	iface, err := route.NodeDeviceWithDefaultRoute(logger, true, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find interface with default route: %w", err)
 	}
@@ -135,10 +135,33 @@ func addENIRules(logger *slog.Logger, sysSettings []tables.Sysctl) ([]tables.Sys
 		Table:    route.MainTable,
 		Protocol: linux_defaults.RTProto,
 	}); err != nil {
-		return nil, fmt.Errorf("unable to install ip rule for ENI multi-node NodePort: %w", err)
+		return nil, fmt.Errorf("unable to install IPv4 rule for ENI multi-node NodePort: %w", err)
 	}
 
 	return retSettings, nil
+}
+
+func addIPv6ENIRules() error {
+	// AWS ENI mode requires symmetric routing, see addIPv4ENIRules() and
+	// iptables.addCiliumENIRules() for details.
+	//
+	// Note there is no IPv6 counterpart to net.ipv4.conf.<iface>.rp_filter,
+	// so unlike addIPv4ENIRules() there is no sysctl to set here.
+	if !option.Config.EnableIPv6 {
+		return nil
+	}
+
+	if err := route.ReplaceRuleIPv6(route.Rule{
+		Priority: linux_defaults.RulePriorityNodeport,
+		Mark:     linux_defaults.MarkMultinodeNodeport,
+		Mask:     linux_defaults.MaskMultinodeNodeport,
+		Table:    route.MainTable,
+		Protocol: linux_defaults.RTProto,
+	}); err != nil {
+		return fmt.Errorf("unable to install IPv6 rule for ENI multi-node NodePort: %w", err)
+	}
+
+	return nil
 }
 
 func cleanIngressQdisc(logger *slog.Logger, devices []string) error {
@@ -331,8 +354,11 @@ func (l *loader) Reinitialize(ctx context.Context, lnc *config.Config, tunnelCon
 
 	if option.Config.IPAM == ipamOption.IPAMENI {
 		var err error
-		if sysSettings, err = addENIRules(l.logger, sysSettings); err != nil {
+		if sysSettings, err = addIPv4ENIRules(l.logger, sysSettings); err != nil {
 			return fmt.Errorf("unable to install ip rule for ENI multi-node NodePort: %w", err)
+		}
+		if err = addIPv6ENIRules(); err != nil {
+			return fmt.Errorf("unable to install ipv6 ip rule for ENI multi-node NodePort: %w", err)
 		}
 	}
 

--- a/pkg/ipam/eni.go
+++ b/pkg/ipam/eni.go
@@ -495,8 +495,13 @@ func buildENIAllocationResult(
 		}
 
 		// Add manually configured Native Routing CIDR
-		if conf.IPv4NativeRoutingCIDR != nil {
+		if conf.IPv4NativeRoutingCIDR != nil && conf.EnableIPv4 {
 			if p, ok := netipx.FromStdIPNet(conf.IPv4NativeRoutingCIDR.IPNet); ok {
+				result.CIDRs = append(result.CIDRs, p)
+			}
+		}
+		if conf.IPv6NativeRoutingCIDR != nil && conf.EnableIPv6 {
+			if p, ok := netipx.FromStdIPNet(conf.IPv6NativeRoutingCIDR.IPNet); ok {
 				result.CIDRs = append(result.CIDRs, p)
 			}
 		}
@@ -514,10 +519,16 @@ func buildENIAllocationResult(
 			}
 		}
 
-		if eni.Subnet.CIDR.IsValid() {
-			// AWS reserves the first subnet IP for the gateway.
-			// Ref: https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html
-			result.GatewayIP = eni.Subnet.CIDR.Addr().Next()
+		if allocatedAddr.Is4() {
+			if eni.Subnet.CIDR.IsValid() {
+				// AWS reserves the first subnet IP for the gateway.
+				// Ref: https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html
+				result.GatewayIP = eni.Subnet.CIDR.Addr().Next()
+			}
+		} else {
+			// On AWS/VPC, the subnet gateway can always be reached at FE80:EC2::1
+			// https://aws.amazon.com/about-aws/whats-new/2022/11/ipv6-subnet-default-gateway-router-multiple-addresses/
+			result.GatewayIP = netip.MustParseAddr("fe80:ec2::1")
 		}
 		result.InterfaceNumber = strconv.Itoa(eni.Number)
 
@@ -537,7 +548,7 @@ func eniContainsIP(eni awsTypes.ENI, addr netip.Addr) bool {
 		return true
 	}
 
-	for _, prefix := range eni.Prefixes {
+	for _, prefix := range slices.Concat(eni.Prefixes, eni.IPv6Prefixes) {
 		if !prefix.IsValid() {
 			continue
 		}
@@ -582,6 +593,8 @@ var eniPoolAccessor = PoolSpecAccessors{
 					prefixes = append(prefixes, p.Prefix)
 				}
 			}
+
+			cidrs = append(cidrs, eni.IPv6Prefixes...)
 
 			// In parseENI (pkg/aws/api), we currently use PrefixToIps to flatten each prefixes
 			// into 16 individual IPs and append those IPs to the ENI Addresses field.

--- a/pkg/ipam/eni_test.go
+++ b/pkg/ipam/eni_test.go
@@ -341,11 +341,21 @@ func TestBuildENIAllocationResult(t *testing.T) {
 
 	t.Run("native routing CIDR is appended", func(t *testing.T) {
 		confWithNative := &option.DaemonConfig{
+			EnableIPv4:            true,
 			IPv4NativeRoutingCIDR: cidr.MustParseCIDR("10.0.0.0/8"),
 		}
 		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.10"), "", node.Status.ENI.ENIs, confWithNative, nil)
 		require.NoError(t, err)
 		require.Contains(t, result.CIDRs, netip.MustParsePrefix("10.0.0.0/8"))
+	})
+
+	t.Run("IPv4 native routing CIDR is not appended when IPv4 is disabled", func(t *testing.T) {
+		confWithNative := &option.DaemonConfig{
+			IPv4NativeRoutingCIDR: cidr.MustParseCIDR("10.0.0.0/8"),
+		}
+		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.10"), "", node.Status.ENI.ENIs, confWithNative, nil)
+		require.NoError(t, err)
+		require.NotContains(t, result.CIDRs, netip.MustParsePrefix("10.0.0.0/8"))
 	})
 }
 
@@ -358,6 +368,9 @@ func TestBuildENIAllocationResultPrefixDelegation(t *testing.T) {
 			Prefixes: prefixes(
 				"10.1.1.0/28",
 				"10.1.1.16/28",
+			),
+			IPv6Prefixes: prefixes(
+				"2001:db8::/80",
 			),
 			Number: 1,
 			Subnet: awsTypes.AwsSubnet{
@@ -388,6 +401,33 @@ func TestBuildENIAllocationResultPrefixDelegation(t *testing.T) {
 	t.Run("IP outside all prefixes", func(t *testing.T) {
 		_, err := buildENIAllocationResult(logger, netip.MustParseAddr("10.1.1.32"), "", node.Status.ENI.ENIs, conf, nil)
 		require.Error(t, err)
+	})
+
+	t.Run("IP in IPv6 prefix", func(t *testing.T) {
+		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("2001:db8::1"), "", node.Status.ENI.ENIs, conf, nil)
+		require.NoError(t, err)
+		require.Equal(t, "aa:bb:cc:dd:ee:01", result.PrimaryMAC)
+		require.Equal(t, "1", result.InterfaceNumber)
+		require.Equal(t, netip.MustParseAddr("fe80:ec2::1"), result.GatewayIP)
+	})
+
+	t.Run("IPv6 native routing CIDR is appended", func(t *testing.T) {
+		confWithNative := &option.DaemonConfig{
+			EnableIPv6:            true,
+			IPv6NativeRoutingCIDR: cidr.MustParseCIDR("2001:db8::/64"),
+		}
+		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("2001:db8::1"), "", node.Status.ENI.ENIs, confWithNative, nil)
+		require.NoError(t, err)
+		require.Contains(t, result.CIDRs, netip.MustParsePrefix("2001:db8::/64"))
+	})
+
+	t.Run("IPv6 native routing CIDR is not appended when IPv6 is disabled", func(t *testing.T) {
+		confWithNative := &option.DaemonConfig{
+			IPv6NativeRoutingCIDR: cidr.MustParseCIDR("2001:db8::/64"),
+		}
+		result, err := buildENIAllocationResult(logger, netip.MustParseAddr("2001:db8::1"), "", node.Status.ENI.ENIs, confWithNative, nil)
+		require.NoError(t, err)
+		require.NotContains(t, result.CIDRs, netip.MustParsePrefix("2001:db8::/64"))
 	})
 }
 
@@ -445,11 +485,38 @@ func TestBuildENIAllocationResultIPMasq(t *testing.T) {
 	)
 }
 
+func TestBuildENIAllocationResultIPMasqIPv6(t *testing.T) {
+	enis := map[string]awsTypes.ENI{
+		"eni-1": {
+			ID:           "eni-1",
+			IPv6Prefixes: prefixes("2001:db8::/80"),
+			Subnet: awsTypes.AwsSubnet{
+				CIDR: iputil.PrefixFrom(netip.MustParsePrefix("2001:db8::/64")),
+			},
+		},
+	}
+
+	conf := &option.DaemonConfig{EnableIPv6: true, EnableIPMasqAgent: true}
+	ipMasqAgent := ipmasq.NewIPMasqAgent(hivetest.Logger(t), "", ipMasqMapDummy{})
+	require.NoError(t, ipMasqAgent.Start())
+	defer ipMasqAgent.Stop()
+
+	result, err := buildENIAllocationResult(hivetest.Logger(t), netip.MustParseAddr("2001:db8::1"), "", enis, conf, ipMasqAgent)
+	require.NoError(t, err)
+	// Only the IPv6 ip-masq-agent CIDRs should be appended; the family
+	// filter in buildENIAllocationResult must exclude the IPv4 defaults.
+	require.Contains(t, result.CIDRs, netip.MustParsePrefix("fe80::/10"))
+	for _, c := range result.CIDRs {
+		require.True(t, c.Addr().Is6(), "unexpected IPv4 CIDR %s for an IPv6 allocation", c)
+	}
+}
+
 func TestEniContainsIP(t *testing.T) {
 	eni := awsTypes.ENI{
-		IP:        iputil.AddrFrom(netip.MustParseAddr("10.0.0.100")),
-		Addresses: addrs("10.0.0.1", "10.0.0.2"),
-		Prefixes:  prefixes("10.0.1.0/28"),
+		IP:           iputil.AddrFrom(netip.MustParseAddr("10.0.0.100")),
+		Addresses:    addrs("10.0.0.1", "10.0.0.2"),
+		Prefixes:     prefixes("10.0.1.0/28"),
+		IPv6Prefixes: prefixes("2001:db8::/80"),
 	}
 
 	// Primary IP match
@@ -464,6 +531,11 @@ func TestEniContainsIP(t *testing.T) {
 	require.True(t, eniContainsIP(eni, netip.MustParseAddr("10.0.1.0")))
 	require.True(t, eniContainsIP(eni, netip.MustParseAddr("10.0.1.15")))
 	require.False(t, eniContainsIP(eni, netip.MustParseAddr("10.0.1.16")))
+
+	// IPv6 prefix match
+	require.True(t, eniContainsIP(eni, netip.MustParseAddr("2001:db8::")))
+	require.True(t, eniContainsIP(eni, netip.MustParseAddr("2001:db8::1")))
+	require.False(t, eniContainsIP(eni, netip.MustParseAddr("2001:db8:0:0:1::")))
 
 	// Empty ENI
 	require.False(t, eniContainsIP(awsTypes.ENI{}, netip.MustParseAddr("10.0.0.1")))
@@ -549,6 +621,23 @@ func TestENIPoolsAccessorFromResource(t *testing.T) {
 		require.Contains(t, result.Allocated[0].CIDRs, iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.16/28")))
 		require.Contains(t, result.Allocated[0].CIDRs, iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.1/32")))
 		require.Len(t, result.Allocated[0].CIDRs, 2) // 1 prefix + 1 primary IP
+	})
+
+	t.Run("IPv6 prefixes are advertised as pool CIDRs", func(t *testing.T) {
+		node := &ciliumv2.CiliumNode{}
+		node.Status.ENI.ENIs = map[string]awsTypes.ENI{
+			"eni-1": {
+				Addresses:    addrs("10.0.0.1"),
+				Prefixes:     prefixes("10.0.0.16/28"),
+				IPv6Prefixes: prefixes("2001:db8::/80"),
+			},
+		}
+
+		result := eniPoolAccessor.FromResource(node)
+		require.Len(t, result.Allocated, 1)
+		require.Contains(t, result.Allocated[0].CIDRs, iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.16/28")))
+		require.Contains(t, result.Allocated[0].CIDRs, iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.1/32")))
+		require.Contains(t, result.Allocated[0].CIDRs, iputil.PrefixFrom(netip.MustParsePrefix("2001:db8::/80")))
 	})
 
 	t.Run("excluded ENIs are skipped", func(t *testing.T) {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2610,6 +2610,10 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 		}
 	}
 
+	if c.IPAMMode() == ipamOption.IPAMENI && c.EnableIPv6 {
+		logger.Warn("IPv6 support in the ENI IPAM mode (ipam.mode=eni, ipv6.enabled=true) is a beta feature. Please use it with caution and report any issues you encounter: https://github.com/cilium/cilium/issues/new?template=bug_report.yaml")
+	}
+
 	encryptionStrictModeEgressEnabled := vp.GetBool(EnableEncryptionStrictModeEgress)
 	if encryptionStrictModeEgressEnabled {
 		if c.EnableIPv6 {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2237,10 +2237,6 @@ func (c *DaemonConfig) Validate(vp *viper.Viper) error {
 		return fmt.Errorf("RouteMetric '%d' cannot be negative", c.RouteMetric)
 	}
 
-	if c.IPAM == ipamOption.IPAMENI && c.EnableIPv6 {
-		return fmt.Errorf("IPv6 cannot be enabled in ENI IPAM mode")
-	}
-
 	if c.EnableIPv6NDP {
 		if !c.EnableIPv6 {
 			return fmt.Errorf("IPv6NDP cannot be enabled when IPv6 is not enabled")


### PR DESCRIPTION
Follow up to PR #46619 and related to issues #19251 and #18405.

This PR implements ENI IPAM IPv6 prefix support on the agent side. This includes parsing the IPv6 prefixes reported in ENI status and adding them to the stored CIDRs. This also includes setting up the per-ENI routing table for IPv6 in parallel to IPv4 by setting the universal EC2 IPv6 gateway FE80:EC2::1 as desribed in https://aws.amazon.com/about-aws/whats-new/2022/11/ipv6-subnet-default-gateway-router-multiple-addresses/. This also matches the design of the [AWS VPC CNI](https://github.com/aws/amazon-vpc-cni-k8s/blob/6df3cfa14693b293177ce65380f1552f2bd837ba/pkg/networkutils/network.go#L929-L933).

IPv6 Nodeport specific rules were also created to match the IPv4 rules.

# Testing in a live cluster

We deployed this change on one of our AWS clusters and enabled IPv6 in the agent config. In the following, we can see the CiliumNode spec requesting an ipv6 address and having it allocated in the multi-pool mode fashion:

```yaml
# Cilium Node for an AWS node requesting IPv6 and having them allocated
apiVersion: cilium.io/v2
kind: CiliumNode
metadata:
  creationTimestamp: "2026-07-01T10:03:21Z"
  generation: 6
  labels:
    # [...]
  name: ip-10-x-y-z.ec2.internal
spec:
  # [...]
  addresses:
  - ip: 10.[...].106
    type: InternalIP
  - ip: fc00::10ca:1
    type: InternalIP
  - ip: 10.[...].162
    type: CiliumInternalIP
  - ip: 2600:[...]::cb13
    type: CiliumInternalIP
  ipam:
    pools:
      allocated:
      - allowFirstIP: true
        allowLastIP: true
        cidrs:
        - 10.[...].35/32
        - 10.[...].35/32
        - 10.[...].162/32
        - 2600:[...]:ca77::/80
        pool: default
      requested:
      - needed:
          ipv4-addrs: 3
          ipv6-addrs: 3
        pool: default
    pre-allocate: 1
status:
  alibaba-cloud: {}
  azure: {}
  eni:
    enis:
      [...]
      eni-xyz:
        addresses:
        - 10.[...].162
        - 10.[...].35
        # [...]
        description: Cilium-CNI (i-xyz)
        id: eni-xyz
        ip: 10.[...].162
        ipv6-prefixes:
        - 2600:[...]:ca77::/80
        # [...]
```

Since the agent sees the IPv6 addresses and adds them properly to its cidr list, it uses all the already built-in mechanisms to assign both an IPv4 and an IPv6 for each pod on the node.

So here is a pod on the node that has been allocated an IPv6:
```yaml
apiVersion: v1
kind: Pod
# [...]
status:
  # [...]
  hostIP: 10.[...].106
  hostIPs:
  - ip: 10.[...].106
  phase: Running
  podIP: 10.[...].35
  podIPs:
  - ip: 10.[...].35
  - ip: 2600:[...]:ca77::c26
  # [...]
```
We can finally run a quick connectivity test to check IPv6 can be routed:
```
root@alex-test-bc758d5cd-2684c:/# curl -6 ifconfig.me
2600:[...]:ca77::c26
```

# Future steps

Some of the work left to make this feature complete:
- Update the IPAM ENI docs to explain IPv6 support.
- Add EKS e2e testing with IPv6 enabled.

# Use of AI agents

This PR was prepared with AIL:3. It's a mix of human and AI generated code with all of it reviewed by a human.

```release-note
(Beta) ENI IPAM mode with IPv6: The ENI IPAM mode now supports allocating and using IPv6 prefixes.
```