### PR TITLE
linux-desired-device: harden link modify codepath

### DIFF
--- a/pkg/datapath/linux/device/reconciler.go
+++ b/pkg/datapath/linux/device/reconciler.go
@@ -139,7 +139,7 @@ func (ops *ops) Stop(_ cell.HookContext) error {
 }
 
 func (ops *ops) Update(_ context.Context, _ statedb.ReadTxn, _ statedb.Revision, obj *DesiredDevice) error {
-	nl, linkExist, err := ops.checkAndGetLink(obj)
+	nl, oldNl, err := ops.resolveOwnedLink(obj)
 	if err != nil {
 		return err
 	}
@@ -153,13 +153,19 @@ func (ops *ops) Update(_ context.Context, _ statedb.ReadTxn, _ statedb.Revision,
 		return fmt.Errorf("failed to write update event to WAL: %w", err)
 	}
 
-	if linkExist {
-		err = ops.handle.LinkModify(nl)
-	} else {
+	if oldNl == nil {
+		// Device does not exist yet — create it.
 		err = ops.handle.LinkAdd(nl)
+	} else if obj.DeviceSpec.NeedsRecreate(oldNl) {
+		err = ops.handle.LinkDel(oldNl)
+		if err == nil {
+			err = ops.handle.LinkAdd(nl)
+		}
+	} else {
+		err = ops.handle.LinkModify(nl)
 	}
 	if err != nil {
-		return fmt.Errorf("failed to add or modify link: %w", err)
+		return fmt.Errorf("failed to upsert link: %w", err)
 	}
 
 	ops.persistedKeys.Insert(obj.GetKey())
@@ -168,16 +174,16 @@ func (ops *ops) Update(_ context.Context, _ statedb.ReadTxn, _ statedb.Revision,
 }
 
 func (ops *ops) Delete(_ context.Context, _ statedb.ReadTxn, _ statedb.Revision, obj *DesiredDevice) error {
-	nl, linkExist, err := ops.checkAndGetLink(obj)
+	_, oldNl, err := ops.resolveOwnedLink(obj)
 	if err != nil {
 		return err
 	}
 
-	if !linkExist {
+	if oldNl == nil {
 		return nil
 	}
 
-	delErr := ops.handle.LinkDel(nl)
+	delErr := ops.handle.LinkDel(oldNl)
 	if delErr == nil {
 		ops.persistedKeys.Remove(obj.GetKey())
 	}
@@ -226,33 +232,43 @@ func (ops *ops) Prune(_ context.Context, txn statedb.ReadTxn, objects iter.Seq2[
 	})
 }
 
-// checkAndGetLink checks that the caller passing DesiredObject is not taking ownership of a device that is not owned by it.
-// Few cases to consider
-//  1. Device created by owner1. Owner2 tries to create device with same name. ( Not allowed )
-//  2. Device already exist in kernel but not managed by Cilium ( persisted key does not exist ). Cilium owner tries
-//     to create/delete a device with same name. ( Not allowed )
-//  3. Device created by owner1. Cilium restart - Owner1 recreates the device ( allowed ). This case works as we
-//     repopulate the persisted keys from the WAL.
-func (ops *ops) checkAndGetLink(obj *DesiredDevice) (netlink.Link, bool, error) {
-	nl, err := obj.DeviceSpec.ToNetlink()
+// resolveOwnedLink translates the desired device into its netlink form (nl) and
+// looks up the matching link already present in the kernel, returning it as
+// oldNl. A nil oldNl means the device does not exist yet and should be created;
+// a non-nil oldNl is the live link to modify or recreate. Any netlink error
+// other than "not found" is returned so the reconciler retries.
+//
+// When a device with that name already exists (non-nil oldNl) it must be owned by this owner,
+// guarding against:
+//  1. owner2 creating a device with a link already owned by owner1;
+//  2. taking over a device present in the kernel but not managed by Cilium
+//     (no persisted key for it).
+//
+// A link present in the kernel without a matching persisted key is therefore
+// rejected. After a restart the persisted keys are repopulated from the WAL, so
+// an owner re-creating its own device is allowed.
+func (ops *ops) resolveOwnedLink(obj *DesiredDevice) (nl netlink.Link, oldNl netlink.Link, err error) {
+	nl, err = obj.DeviceSpec.ToNetlink()
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to translate to netlink link: %w", err)
+		return nil, nil, fmt.Errorf("failed to translate to netlink link: %w", err)
 	}
 
-	var linkExist bool
-	_, err = safenetlink.WithRetryResult(func() (netlink.Link, error) {
+	oldNl, err = safenetlink.WithRetryResult(func() (netlink.Link, error) {
 		//nolint:forbidigo
 		return ops.handle.LinkByName(nl.Attrs().Name)
 	})
-	if err == nil || !errors.As(err, &netlink.LinkNotFoundError{}) {
-		linkExist = true
+	if err != nil {
+		if errors.As(err, &netlink.LinkNotFoundError{}) {
+			return nl, nil, nil
+		}
+		return nil, nil, fmt.Errorf("failed to look up link %s: %w", nl.Attrs().Name, err)
 	}
 
-	if linkExist && !ops.persistedKeys.Has(obj.GetKey()) {
-		return nil, false, fmt.Errorf("device %s exist in kernel but not with desired device owner %s", obj.Name, obj.Owner)
+	if !ops.persistedKeys.Has(obj.GetKey()) {
+		return nil, nil, fmt.Errorf("device %s exist in kernel but not with desired device owner %s", obj.Name, obj.Owner)
 	}
 
-	return nl, linkExist, nil
+	return nl, oldNl, nil
 }
 
 type reconcilerEvent struct {

--- a/pkg/datapath/linux/device/scripttest/testdata/vlan-recreate.txtar
+++ b/pkg/datapath/linux/device/scripttest/testdata/vlan-recreate.txtar
@@ -1,0 +1,69 @@
+# Verify the reconciler's update path: a mutable change (MTU) modifies the device
+# in place via LinkModify, while a change to an immutable kernel attribute (the
+# VLAN ID) deletes and re-adds the device.
+
+netns/create otherns
+link/add eth0 veth --peername veth0 --peerns otherns
+link/set veth0 --netns otherns up
+link/set eth0 up
+
+hive/start
+
+# Create the VLAN device, wait for it to be reconciled and record its ifindex.
+add-device owner1 eth0.10.yaml
+db/cmp devices devices.1.table
+db/get devices --index=name eth0.10 --columns=Index -o index.create.txt
+
+# Re-apply with only the MTU changed (a mutable attribute). The reconciler must
+# call LinkModify. Wait for the MTU update to land (devices.2.table), then assert
+# the ifindex is unchanged -> the device was modified in place, not recreated.
+add-device owner1 eth0.10-mtu.yaml
+db/cmp devices devices.2.table
+db/get devices --index=name eth0.10 --columns=Index -o index.mtu.txt
+cmp index.mtu.txt index.create.txt
+
+# Re-apply with the VLAN ID changed (an immutable attribute). LinkModify cannot
+# change it, so the reconciler deletes and re-adds the device. We also bump the
+# MTU so the devices table has an observable change to wait on.
+# Then assert the ifindex changed -> recreated.
+add-device owner1 eth0.10-vlan.yaml
+db/cmp devices devices.3.table
+db/get devices --index=name eth0.10 --columns=Index -o index.vlan.txt
+! cmp index.vlan.txt index.mtu.txt
+
+hive/stop
+
+-- eth0.10.yaml --
+name: eth0.10
+parentName: eth0
+vlanID: 10
+
+-- eth0.10-mtu.yaml --
+name: eth0.10
+parentName: eth0
+vlanID: 10
+mtu: 1400
+
+-- eth0.10-vlan.yaml --
+name: eth0.10
+parentName: eth0
+vlanID: 20
+mtu: 1300
+
+-- devices.1.table --
+Name      Type     MTU     OperStatus
+lo        device   65536   down
+eth0      veth     1500    up
+eth0.10   vlan     1500    up
+
+-- devices.2.table --
+Name      Type     MTU     OperStatus
+lo        device   65536   down
+eth0      veth     1500    up
+eth0.10   vlan     1400    up
+
+-- devices.3.table --
+Name      Type     MTU     OperStatus
+lo        device   65536   down
+eth0      veth     1500    up
+eth0.10   vlan     1300    up

--- a/pkg/datapath/linux/device/table.go
+++ b/pkg/datapath/linux/device/table.go
@@ -75,6 +75,15 @@ type DesiredDeviceSpec interface {
 	Properties() string
 	MarshalJSON() ([]byte, error)
 	MarshalYAML() (any, error)
+	// NeedsRecreate reports whether the existing kernel device must be deleted
+	// and re-added rather than modified in-place. It is only called when a
+	// device with this name already exists.
+	//
+	// It must return true ONLY when an immutable kernel attribute (e.g. VRF
+	// table ID, VLAN ID) actually differs between the desired spec and the
+	// existing device. Returning true unconditionally causes a destructive
+	// delete+add on every reconcile (including periodic refresh).
+	NeedsRecreate(existing netlink.Link) bool
 }
 
 type DesiredDevice struct {

--- a/pkg/datapath/linux/device/vlan.go
+++ b/pkg/datapath/linux/device/vlan.go
@@ -32,6 +32,20 @@ func (d *DesiredVLANDeviceSpec) ToNetlink() (netlink.Link, error) {
 	}, nil
 }
 
+// NeedsRecreate reports whether the existing VLAN device must be recreated. The
+// VLAN ID and parent interface are immutable, so a recreate is only
+// needed when one of those differs from the desired spec. Mutable attributes (e.g.
+// MTU) are handled in-place via LinkModify.
+func (d *DesiredVLANDeviceSpec) NeedsRecreate(existing netlink.Link) bool {
+	vlan, ok := existing.(*netlink.Vlan)
+	if !ok {
+		// Existing device isn't a VLAN (name collision with a different type) —
+		// recreate to converge to the desired type.
+		return true
+	}
+	return vlan.VlanId != d.VLANID || vlan.ParentIndex != d.ParentIndex
+}
+
 func (d *DesiredVLANDeviceSpec) Properties() string {
 	return fmt.Sprintf("Type=vlan, ParentDevice=%s (%d), VLAN=%d",
 		d.ParentName, d.ParentIndex, d.VLANID)


### PR DESCRIPTION
Current implementation of desired device "update" is brittle. For eg, if an update is made to modify immutable field ( for eg,  vlanid in VLAN device) LinkModify will fail silently. In such cases, it is better to recreated the device by doing delete and add.

Adding script test to cover this code path as well.

( cc @tklauser since you're more familiar with this area. )

AI influence [AIL:3]