### PR TITLE
.github: Don't close issues with stable-blocker

### DIFF
--- a/.github/workflows/close-stale-issues.yaml
+++ b/.github/workflows/close-stale-issues.yaml
@@ -20,7 +20,7 @@ jobs:
         operations-per-run: 1000
         stale-issue-label: stale
         exempt-all-issue-assignees: true
-        exempt-issue-labels: pinned,security,good-first-issue,help-wanted
+        exempt-issue-labels: pinned,security,good-first-issue,help-wanted,stable-blocker
 
         days-before-issue-stale: 60
         stale-issue-message: |
@@ -32,7 +32,7 @@ jobs:
           Closing.
 
         stale-pr-label: stale
-        exempt-pr-labels: pinned,security,good-first-issue,help-wanted
+        exempt-pr-labels: pinned,security,good-first-issue,help-wanted,stable-blocker
 
         days-before-pr-stale: 30
         stale-pr-message: |


### PR DESCRIPTION
There's a new label `stable-blocker` which marks an issue which will
block the graduation of a feature to stable. Let's not auto-close those
issues.
