### PR TITLE
 policy: add policy/mapstate/stage script command 

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -85,6 +85,7 @@ import (
 	"github.com/cilium/cilium/pkg/nodeipamconfig"
 	"github.com/cilium/cilium/pkg/option"
 	policy "github.com/cilium/cilium/pkg/policy/cell"
+	policycommands "github.com/cilium/cilium/pkg/policy/commands"
 	"github.com/cilium/cilium/pkg/policy/compute"
 	policyDirectory "github.com/cilium/cilium/pkg/policy/directory"
 	policyK8s "github.com/cilium/cilium/pkg/policy/k8s"
@@ -310,6 +311,7 @@ var (
 
 		// Provides PolicyRepository (List of policy rules)
 		policy.Cell,
+		policycommands.Cell,
 
 		// Provides PolicyRecomputer (policy computation).
 		compute.Cell,

--- a/pkg/policy/cell/cell.go
+++ b/pkg/policy/cell/cell.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	policyapi "github.com/cilium/cilium/pkg/policy/api"
-	"github.com/cilium/cilium/pkg/policy/commands"
 	"github.com/cilium/cilium/pkg/policy/compute"
 	"github.com/cilium/cilium/pkg/policy/types"
 )
@@ -38,7 +37,6 @@ var Cell = cell.Module(
 	cell.Provide(newIPCacher),
 	cell.Config(defaultConfig),
 	metrics.Metric(newIdentityUpdaterMetrics),
-	cell.Provide(commands.NewPolicyCommands),
 )
 
 type Config struct {

--- a/pkg/policy/commands/cell.go
+++ b/pkg/policy/commands/cell.go
@@ -6,6 +6,8 @@ package commands
 import (
 	"fmt"
 	"math"
+	"os"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -13,17 +15,39 @@ import (
 	"github.com/cilium/hive"
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/script"
+	"github.com/cilium/statedb"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/maps/policymap"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy"
 )
 
 type CmdParams struct {
 	cell.In
 
 	EPL endpointmanager.EndpointsLookup
+
+	// used for staging
+	Repository policy.PolicyRepository
+	DB         *statedb.DB
+	Services   statedb.Table[*loadbalancer.Service]
+	Backends   statedb.Table[*loadbalancer.Backend]
+
+	ClusterMeshPolicyConfig cmtypes.PolicyConfig
+	Config                  *option.DaemonConfig
+	PMFactory               policymap.Factory
 }
+
+var Cell = cell.Module(
+	"policycommands",
+	"Policy script commands",
+	cell.Provide(NewPolicyCommands),
+)
 
 type PolicyCommands map[string]script.Cmd
 
@@ -31,6 +55,7 @@ func NewPolicyCommands(params CmdParams) hive.ScriptCmdsOut {
 	return hive.NewScriptCmds(map[string]script.Cmd{
 		"policy/mapstate/entries": msEntriesCmd(params),
 		"policy/mapstate/topk":    topKCmd(params),
+		"policy/mapstate/stage":   msStageCmd(params),
 	})
 }
 
@@ -39,17 +64,42 @@ func NewPolicyCommands(params CmdParams) hive.ScriptCmdsOut {
 // Accepted values are numeric endpoint IDs or <namespace/name>
 func autocompleteEndpoints(params CmdParams) func(_ *script.State, _ []string, cur string) []string {
 	return func(_ *script.State, _ []string, cur string) []string {
-		eps := params.EPL.GetEndpoints()
-		epNames := make([]string, 0, len(eps)*2)
-		for _, ep := range eps {
-			epNames = append(epNames, fmt.Sprintf("%d", ep.ID))
-			if ep.K8sNamespace != "" && ep.K8sPodName != "" {
-				epNames = append(epNames, fmt.Sprintf("%s/%s", ep.K8sNamespace, ep.K8sPodName))
-			}
-		}
-
-		return filterPrefix(epNames, cur)
+		return autocompleteEndpointsImpl(params, cur)
 	}
+}
+
+func autocompleteEndpointsImpl(params CmdParams, cur string) []string {
+	eps := params.EPL.GetEndpoints()
+	epNames := make([]string, 0, len(eps)*2)
+	for _, ep := range eps {
+		epNames = append(epNames, fmt.Sprintf("%d", ep.ID))
+		if ep.K8sNamespace != "" && ep.K8sPodName != "" {
+			epNames = append(epNames, fmt.Sprintf("%s/%s", ep.K8sNamespace, ep.K8sPodName))
+		}
+	}
+
+	return filterPrefix(epNames, cur)
+}
+
+func autocompleteFilenameImpl(state *script.State, cur string) []string {
+	entries, err := os.ReadDir(state.Path(cur))
+	dir := cur
+	file := ""
+	if err != nil {
+		dir, file = filepath.Split(state.Path(cur))
+		entries, err = os.ReadDir(dir)
+		if err != nil {
+			return nil
+		}
+	}
+
+	var suggestions []string
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), file) {
+			suggestions = append(suggestions, filepath.Join(dir, entry.Name()))
+		}
+	}
+	return suggestions
 }
 
 // lookupEPs returns the set of endpoints that match the given specs,

--- a/pkg/policy/commands/mapstate.go
+++ b/pkg/policy/commands/mapstate.go
@@ -27,11 +27,11 @@ func msEntriesCmd(params CmdParams) script.Cmd {
 			Summary: "Display policy map state for a given endpoint",
 			Args:    "<pod-or-endpoint>+",
 			Flags: func(fs *pflag.FlagSet) {
-				fs.StringP("format", "f", "table", "Format to write in (table, json)")
+				fs.StringP("output", "o", "table", "Format to write in (table, json)")
 			},
 			AutocompleteFlag: func(_ *script.State, _ []string, flag, cur string) []string {
 				switch flag {
-				case "format":
+				case "output":
 					return filterPrefix([]string{"table", "json"}, cur)
 				}
 				return nil
@@ -42,17 +42,17 @@ func msEntriesCmd(params CmdParams) script.Cmd {
 				"The MapState is the *desired* contents of the BPF policy map.",
 				"This command dumps the desired state as understood by the agent.",
 				"",
-				`pod-or-endpoint: either numerical endpoint ID or "namespace/podname", optionall repeateds`,
+				`pod-or-endpoint: either numerical endpoint ID or "namespace/podname", optionally repeated.`,
 			},
 		},
 		func(s *script.State, args ...string) (script.WaitFunc, error) {
 			return func(*script.State) (stdout, stderr string, err error) {
-				format, err := s.Flags.GetString("format")
+				output, err := s.Flags.GetString("output")
 				if err != nil {
 					return "", "", err
 				}
-				if format != "json" && format != "table" {
-					return "", "", fmt.Errorf("unsupported format %s", format)
+				if output != "json" && output != "table" {
+					return "", "", fmt.Errorf("unsupported output format %s", output)
 				}
 
 				// Collect policy from all endpoints
@@ -84,7 +84,7 @@ func msEntriesCmd(params CmdParams) script.Cmd {
 				})
 
 				// Output, in table or json format
-				switch format {
+				switch output {
 				case "json":
 					b, err := json.MarshalIndent(outs, "", "\t")
 					if err != nil {
@@ -118,7 +118,7 @@ func msEntriesCmd(params CmdParams) script.Cmd {
 					return buf.String(), "", nil
 				}
 
-				return "", "", fmt.Errorf("unsupported format %s", format)
+				return "", "", fmt.Errorf("unsupported output format %s", output)
 
 			}, nil
 		},

--- a/pkg/policy/commands/mapstate.go
+++ b/pkg/policy/commands/mapstate.go
@@ -146,6 +146,8 @@ type entryOut struct {
 	Cookie    uint32 `json:"cookie"`
 
 	Origins []origin `json:"origins"`
+
+	mse policy.MapStateEntry `json:"-"`
 }
 
 func makeEntry(key policy.Key, entry policy.MapStateEntry, meta policy.RuleMeta) entryOut {
@@ -159,6 +161,8 @@ func makeEntry(key policy.Key, entry policy.MapStateEntry, meta policy.RuleMeta)
 		Verdict:   "unknown",
 		ProxyPort: entry.ProxyPort,
 		Cookie:    entry.Cookie,
+
+		mse: entry,
 	}
 
 	if key.Nexthdr == 0 {

--- a/pkg/policy/commands/mapstate_diff.go
+++ b/pkg/policy/commands/mapstate_diff.go
@@ -1,0 +1,523 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"os"
+	"strings"
+	"sync"
+	"text/tabwriter"
+
+	"github.com/cilium/hive/script"
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/yaml"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	envoypolicy "github.com/cilium/cilium/pkg/envoy/policy"
+	"github.com/cilium/cilium/pkg/identity"
+	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
+	"github.com/cilium/cilium/pkg/k8s"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/scheme"
+	slim_networkingv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/networking/v1"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
+	policyk8s "github.com/cilium/cilium/pkg/policy/k8s"
+	policytypes "github.com/cilium/cilium/pkg/policy/types"
+	policyutils "github.com/cilium/cilium/pkg/policy/utils"
+	"github.com/cilium/cilium/pkg/u8proto"
+)
+
+var dummyRedirects = map[string]uint16{
+	policy.FallbackRedirectID: math.MaxUint16,
+}
+
+func msStageCmd(params CmdParams) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Display resulting policy map for a proposed policy change.",
+			Flags: func(fs *pflag.FlagSet) {
+				fs.StringP("output", "o", "table", "Format to write in (table, json)")
+				fs.BoolP("diff", "d", false, "Display the difference from the existing policy map.")
+				fs.StringP("endpoint", "e", "", "Endpoint, either numeric ID or <namespace/name>, to stage this policy")
+				fs.StringSliceP("filename", "f", nil, "YAML or JSON policy resource to stage")
+			},
+			AutocompleteFlag: func(state *script.State, _ []string, flag, cur string) []string {
+				switch flag {
+				case "o", "output":
+					return filterPrefix([]string{"table", "json"}, cur)
+				case "e", "endpoint":
+					return autocompleteEndpointsImpl(params, cur)
+				case "f", "filename":
+					return autocompleteFilenameImpl(state, cur)
+				}
+				return nil
+			},
+			Detail: []string{
+				"Display the resulting mapstate for applying a given poliy to an endpoint.",
+				"All existing policies are preserved unless overwritten by the proposed policy.",
+				"Optionally, will display the difference between the existing policy.",
+			},
+		},
+		func(state *script.State, args ...string) (script.WaitFunc, error) {
+			return func(state *script.State) (stdout, stderr string, err error) {
+				format, err := state.Flags.GetString("output")
+				if err != nil {
+					return "", "", err
+				}
+				if format != "json" && format != "table" {
+					return "", "", fmt.Errorf("unsupported output format %s", format)
+				}
+
+				diff, err := state.Flags.GetBool("diff")
+				if err != nil {
+					return "", "", err
+				}
+
+				cmd, err := newStageCmd(params, state)
+				if err != nil {
+					return "", "", err
+				}
+
+				if len(cmd.toAddPaths) == 0 && diff {
+					return "", "", fmt.Errorf("--filename is required")
+				}
+
+				var entriesBefore, entriesAfter map[policytypes.Key]entryOut
+				if diff {
+					entriesBefore, err = cmd.getEPEntries()
+					if err != nil {
+						return "", "", fmt.Errorf("failed to get existing policy map for endpoint: %w", err)
+					}
+				}
+
+				// apply policy
+				err = cmd.applyPolicies()
+				if err != nil {
+					return "", "", fmt.Errorf("failed to apply new policy: %w", err)
+				}
+
+				entriesAfter, err = cmd.getEPEntries()
+				if err != nil {
+					return "", "", fmt.Errorf("failed to compute endpoint's policy map: %w", err)
+				}
+
+				if len(entriesAfter) > params.PMFactory.PolicyMaxEntries() {
+					cmd.log.Warn("Endpoint BPF policy map will overflow!",
+						logfields.Limit, params.PMFactory.PolicyMaxEntries(),
+						logfields.Size, len(entriesAfter),
+					)
+				}
+
+				res := toResult(entriesBefore, entriesAfter)
+
+				// generate json output
+				if format == "json" {
+					b, err := json.MarshalIndent(&res, "", "\t")
+					if err != nil {
+						return "", "", fmt.Errorf("json marshal failed: %w", err)
+					}
+					return string(b), "", nil
+				}
+
+				// Output table
+				buf := &strings.Builder{}
+				tw := tabwriter.NewWriter(buf, 5, 0, 3, ' ', 0)
+				fmt.Fprintf(tw, " \tDirection\tIdentity\tProto+Port\tPriority\tListenerPrio\tVerdict\tProxied\tOrigins\n")
+				if diff {
+					for _, row := range res.Diff {
+						if row.Deleted != nil {
+							printDiffRow(tw, cmd.ids, '-', *row.Deleted)
+						}
+						if row.Added != nil {
+							printDiffRow(tw, cmd.ids, '+', *row.Added)
+						}
+					}
+				} else {
+					for _, row := range res.MapState {
+						printDiffRow(tw, cmd.ids, ' ', row)
+					}
+				}
+				tw.Flush()
+				return buf.String(), "", nil
+			}, nil
+		},
+	)
+}
+
+type stageCmd struct {
+	params CmdParams
+
+	log *slog.Logger
+	pr  *policy.Repository
+	ids identity.IdentityMap
+
+	toAddPaths []string
+
+	ep   *endpoint.Endpoint
+	epID *identity.Identity
+}
+
+type result struct {
+	MapState []entryOut  `json:"mapState"`
+	Diff     []diffEntry `json:"diff"`
+}
+
+type diffEntry struct {
+	Deleted *entryOut `json:"deleted,omitempty"`
+	Added   *entryOut `json:"added,omitempty"`
+}
+
+func newStageCmd(params CmdParams, state *script.State) (*stageCmd, error) {
+	s := &stageCmd{
+		params: params,
+		log:    slog.New(slog.NewTextHandler(state.LogWriter(), nil)),
+	}
+
+	var err error
+	s.toAddPaths, err = state.Flags.GetStringSlice("filename")
+	if err != nil {
+		return nil, err
+	}
+
+	epSpec, _ := state.Flags.GetString("endpoint")
+	if epSpec == "" {
+		return nil, fmt.Errorf("endpoint is required")
+	}
+
+	eps, _ := lookupEPs(params.EPL, []string{epSpec})
+	if len(eps) != 1 {
+		return nil, fmt.Errorf("endpoint not found!")
+	}
+	s.ep = eps[0]
+	s.epID, err = s.ep.GetSecurityIdentity()
+	if err != nil {
+		return nil, err
+	}
+
+	pr := params.Repository.(*policy.Repository)
+	if pr == nil {
+		return nil, fmt.Errorf("BUG: could not cast policy repository")
+	}
+	// Take a snapshot of the repository so we can make changes
+	s.pr, s.ids = pr.Snapshot(s.log,
+		&mockCertificateManager{},
+		envoypolicy.NewEnvoyL7RulesTranslator(s.log, certificatemanager.NewMockSecretManagerSDS()))
+
+	// add this endpoint to the subject selector cache
+	wg := sync.WaitGroup{}
+	s.pr.GetSubjectSelectorCache().UpdateIdentities(identity.IdentityMap{s.epID.ID: s.epID.LabelArray}, nil, &wg)
+	wg.Wait()
+
+	return s, nil
+}
+
+// applyPolicy applies the given policy to the repository
+func (s *stageCmd) applyPolicies() error {
+	for _, path := range s.toAddPaths {
+		// Parse policy file, then apply to repository.
+		fp, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("failed to open file %s: %w", path, err)
+		}
+
+		decoder := yaml.NewYAMLOrJSONDecoder(fp, 4096)
+		applied := false
+		for {
+			u := unstructured.Unstructured{}
+			if err := decoder.Decode(&u); err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				return fmt.Errorf("failed to parse policy: %w", err)
+			}
+			if err := s.applyPolicy(&u); err != nil {
+				return err
+			}
+			applied = true
+		}
+
+		if !applied {
+			return fmt.Errorf("policy file %s was empty", path)
+		}
+	}
+	return nil
+}
+
+type makeEntriesFunc func(s *stageCmd, obj *unstructured.Unstructured) (policytypes.PolicyEntries, ipcacheTypes.ResourceKind, error)
+
+var makeEntriesFuncs = map[schema.GroupKind]makeEntriesFunc{
+	{Group: "cilium.io", Kind: ciliumv2.CNPKindDefinition}:  makeCNPEntries,
+	{Group: "cilium.io", Kind: ciliumv2.CCNPKindDefinition}: makeCNPEntries,
+	{Group: "networking.k8s.io", Kind: "NetworkPolicy"}:     makeKNPEntries,
+}
+
+// applyPolicy inserts the policy in to the repository
+func (s *stageCmd) applyPolicy(obj *unstructured.Unstructured) error {
+	// Sometimes we get an empty object -- ignore
+	if obj.GetKind() == "" {
+		return nil
+	}
+
+	policyDescription := fmt.Sprintf("%s %s/%s", obj.GroupVersionKind().Kind, obj.GetNamespace(), obj.GetName())
+
+	toEntriesFunc, ok := makeEntriesFuncs[obj.GroupVersionKind().GroupKind()]
+	if !ok {
+		s.log.Warn("Non-policy type in yaml, ignoring", logfields.PolicyID, policyDescription)
+		return nil
+	}
+
+	entries, resourceKind, err := toEntriesFunc(s, obj)
+	if err != nil {
+		return fmt.Errorf("could not parse policy %s: %w", policyDescription, err)
+	}
+
+	// allocate CIDR identities
+	s.ensureCIDRIdentities(entries)
+
+	// Insert in to policy repository
+	resourceID := ipcacheTypes.NewResourceID(
+		resourceKind,
+		obj.GetNamespace(),
+		obj.GetName(),
+	)
+	ids, _, _ := s.pr.ReplaceByResource(entries, resourceID)
+	if !ids.Has(s.ep.GetIdentity()) {
+		s.log.Warn("Supplied policy does not select endpoint!", logfields.PolicyID, policyDescription)
+	}
+	s.log.Info("Successfully applied policy", logfields.PolicyID, policyDescription)
+
+	return nil
+}
+
+func makeCNPEntries(s *stageCmd, obj *unstructured.Unstructured) (policytypes.PolicyEntries, ipcacheTypes.ResourceKind, error) {
+	clusterName := cmtypes.LocalClusterNameForPolicies(s.params.ClusterMeshPolicyConfig, s.params.Config.ClusterName)
+	// parse to CNP
+	cnp := ciliumv2.CiliumNetworkPolicy{}
+	if err := convertInto(obj, &cnp); err != nil {
+		return nil, "", err
+	}
+	resourceKind := ipcacheTypes.ResourceKindCNP
+	if obj.GroupVersionKind().Kind == "CiliumClusterwideNetworkPolicy" {
+		resourceKind = ipcacheTypes.ResourceKindCCNP
+	} else if cnp.Namespace == "" {
+		cnp.Namespace = s.ep.GetK8sNamespace()
+	}
+
+	// Translate ToServices
+	policyk8s.ResolveToServices(s.params.DB.ReadTxn(), s.params.Services, s.params.Backends, &cnp)
+	rules, err := cnp.Parse(s.log, clusterName)
+	if err != nil {
+		return nil, "", err
+	}
+	entries := policyutils.RulesToPolicyEntries(rules)
+	return entries, resourceKind, nil
+}
+
+func makeKNPEntries(s *stageCmd, obj *unstructured.Unstructured) (policytypes.PolicyEntries, ipcacheTypes.ResourceKind, error) {
+	clusterName := cmtypes.LocalClusterNameForPolicies(s.params.ClusterMeshPolicyConfig, s.params.Config.ClusterName)
+	knp := slim_networkingv1.NetworkPolicy{}
+	if err := convertInto(obj, &knp); err != nil {
+		return nil, "", err
+	}
+	if knp.Namespace == "" {
+		knp.Namespace = s.ep.GetK8sNamespace()
+	}
+
+	entries, err := k8s.ParseNetworkPolicy(s.log, clusterName, &knp)
+	if err != nil {
+		return nil, "", err
+	}
+	return entries, ipcacheTypes.ResourceKindNetpol, nil
+}
+
+// getExistingEntries evaluates the policy state as-is for the given endpoint,
+func (s *stageCmd) getEPEntries() (map[policytypes.Key]entryOut, error) {
+	sp, err := s.pr.ResolvePolicy(s.epID)
+	if err != nil {
+		return nil, err
+	}
+
+	owner := &dummyPolicyOwner{
+		log: s.log,
+		ep:  s.ep,
+	}
+	epp := sp.DistillPolicy(s.log, owner, dummyRedirects)
+	epp.Ready()
+	epp.Detach(s.log)
+	sp.Detach()
+
+	out := make(map[policytypes.Key]entryOut, epp.Len())
+	for key, entry := range epp.Entries() {
+		entry.Cookie = 0 // don't want to compare cookie
+		meta, _ := epp.GetRuleMeta(key)
+		out[key] = makeEntry(key, entry, meta)
+	}
+
+	return out, nil
+}
+
+// ensureCIDRIdentities emulates allocating identities for CIDR selectors.
+//
+// It just tweaks the SelectorCache, it doesn't actually allocate any identities.
+//
+// Horribly slow, but this is for interactive use, so it should be OK
+func (s *stageCmd) ensureCIDRIdentities(e policytypes.PolicyEntries) {
+	prefixes := policy.GetCIDRPrefixes(e)
+
+	toAllocate := identity.IdentityMap{}
+
+	// For every prefix, see if the IDMap already has an identity with exactly
+	// this CIDR
+prefixLoop:
+	for _, prefix := range prefixes {
+		lbls := labels.GetCIDRLabelArray(prefix)
+		wantLabel := lbls[0]
+		for _, existingLabels := range s.ids {
+			for _, existingLbl := range existingLabels {
+				if existingLbl.Equals(&wantLabel) {
+					continue prefixLoop
+				}
+			}
+		}
+
+		// Need to allocate a new identity for this CIDR
+		for nid := identity.MinLocalIdentity; nid < identity.MaxLocalIdentity; nid++ {
+			if _, exists := s.ids[nid]; exists {
+				continue
+			}
+
+			toAllocate[nid] = lbls
+			s.ids[nid] = lbls
+			break
+		}
+	}
+
+	// Insert allocated identities in to the wait group
+	wg := sync.WaitGroup{}
+	s.pr.GetSelectorCache().UpdateIdentities(toAllocate, nil, &wg)
+	wg.Wait()
+}
+
+// convertInto converts an object using JSON
+func convertInto(input, output runtime.Object) error {
+	b, err := json.Marshal(input)
+	if err != nil {
+		return err // unreachable
+	}
+	return parseInto(b, output)
+}
+
+func parseInto(b []byte, output runtime.Object) error {
+	_, _, err := serializer.NewCodecFactory(scheme.Scheme, serializer.EnableStrict).UniversalDeserializer().Decode(b, nil, output)
+	return err
+}
+
+func toResult(before, after map[policytypes.Key]entryOut) result {
+	out := result{}
+
+	for _, newEntry := range after {
+		out.MapState = append(out.MapState, newEntry)
+	}
+	if before == nil {
+		return out
+	}
+
+	for k, newEntry := range after {
+		oldEntry, exists := before[k]
+		if !exists { // net-new entry
+			out.Diff = append(out.Diff, diffEntry{Added: &newEntry})
+		} else if oldEntry.mse != newEntry.mse { // different datapath entry
+			out.Diff = append(out.Diff, diffEntry{Deleted: &oldEntry, Added: &newEntry})
+		}
+	}
+
+	for k, oldEntry := range before {
+		_, exists := after[k]
+		if !exists {
+			out.Diff = append(out.Diff, diffEntry{Deleted: &oldEntry})
+		}
+	}
+	return out
+}
+
+func printDiffRow(tw *tabwriter.Writer, idm identity.IdentityMap, sigil rune, row entryOut) {
+	id := "unknown"
+	if row.Identity == 0 {
+		id = "*"
+	}
+	if lbls, ok := idm[row.Identity]; ok {
+		id = lbls.String()
+	}
+
+	fmt.Fprintf(tw, "%c\t%s\t%s\t%s\t%d\t%d\t%s\t%t\t%s\n",
+		sigil,
+		row.Direction,
+		id,
+		row.PortProto,
+		row.Priority,
+		row.ListenerPriority,
+		row.Verdict,
+		row.ProxyPort != 0,
+		joinOrigins(row.Origins),
+	)
+}
+
+type mockCertificateManager struct{}
+
+func (_ *mockCertificateManager) GetTLSContext(ctx context.Context, tlsCtx *api.TLSContext, ns string) (ca, public, private string, inlineSecrets bool, err error) {
+	return "", "", "", false, nil // standard SDS response
+}
+
+// dummyPolicyOwner wraps an endpoint, intercepting side-effecting calls
+type dummyPolicyOwner struct {
+	log *slog.Logger
+	ep  *endpoint.Endpoint
+}
+
+var _ policy.PolicyOwner = (*dummyPolicyOwner)(nil)
+
+func (o *dummyPolicyOwner) GetID() uint64 {
+	return o.ep.GetID()
+}
+
+func (o *dummyPolicyOwner) GetIngressNamedPort(name string, proto u8proto.U8proto) uint16 {
+	return o.ep.GetIngressNamedPort(name, proto)
+}
+
+func (o *dummyPolicyOwner) PolicyDebug(msg string, attrs ...any) {
+	if o.log != nil {
+		o.log.Debug(msg, attrs...)
+	}
+}
+
+func (o *dummyPolicyOwner) IsHost() bool {
+	return o.ep.IsHost()
+}
+
+func (o *dummyPolicyOwner) PreviousMapState() *policy.MapState {
+	return o.ep.PreviousMapState()
+}
+
+func (o *dummyPolicyOwner) RegenerateIfAlive(regenMetadata *regeneration.ExternalRegenerationMetadata) <-chan bool {
+	out := make(chan bool)
+	close(out)
+	return out
+}

--- a/pkg/policy/commands/topk.go
+++ b/pkg/policy/commands/topk.go
@@ -27,11 +27,11 @@ func topKCmd(params CmdParams) script.Cmd {
 			Flags: func(fs *pflag.FlagSet) {
 				fs.IntP("num", "n", 10, "Maxiumum number of rows per endpoint to display")
 				fs.IntP("count", "c", 0, "Maxiumum number of endpoints to display")
-				fs.StringP("format", "f", "table", "Format to write in (table, json)")
+				fs.StringP("output", "o", "table", "Format to write in (table, json)")
 			},
 			AutocompleteFlag: func(_ *script.State, _ []string, flag, cur string) []string {
 				switch flag {
-				case "format":
+				case "output":
 					return filterPrefix([]string{"table", "json"}, cur)
 				}
 				return nil
@@ -56,12 +56,12 @@ func topKCmd(params CmdParams) script.Cmd {
 				if err != nil {
 					return "", "", err
 				}
-				format, err := s.Flags.GetString("format")
+				output, err := s.Flags.GetString("output")
 				if err != nil {
 					return "", "", err
 				}
-				if format != "json" && format != "table" {
-					return "", "", fmt.Errorf("unsupported format %s", format)
+				if output != "json" && output != "table" {
+					return "", "", fmt.Errorf("unsupported output format %s", output)
 				}
 
 				eps, err := lookupEPs(params.EPL, args)
@@ -82,7 +82,7 @@ func topKCmd(params CmdParams) script.Cmd {
 					outs = outs[:min(len(outs), count)]
 				}
 
-				switch format {
+				switch output {
 				case "json":
 					b, err := json.MarshalIndent(outs, "", "\t")
 					if err != nil {

--- a/pkg/policy/k8s/service.go
+++ b/pkg/policy/k8s/service.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/k8s/types"
@@ -252,6 +253,21 @@ func (p *policyWatcher) resolveToServices(key resource.Key, cnp *types.SlimCNP) 
 			p.markCNPForService(key, svc.Name)
 		} else {
 			p.clearCNPForService(key, svc.Name)
+		}
+	}
+}
+
+// ResolveToServices translates all ToServices rules found in the provided
+// CNP to CIDR rules. Mutates the supplied CNP. Used by other policy consumers.
+func ResolveToServices(txn statedb.ReadTxn, services statedb.Table[*loadbalancer.Service], backends statedb.Table[*loadbalancer.Backend], cnp *v2.CiliumNetworkPolicy) {
+	for svc := range services.All(txn) {
+		svcEndpoints := newServiceEndpoints(svc, txn, backends)
+
+		// This extracts the selected service endpoints from the rule
+		// and translates it to a ToCIDRSet/ToEndpoints
+		svcEndpoints.processRule(cnp.Spec)
+		for _, spec := range cnp.Specs {
+			svcEndpoints.processRule(spec)
 		}
 	}
 }

--- a/pkg/policy/lookup.go
+++ b/pkg/policy/lookup.go
@@ -10,6 +10,7 @@ package policy
 import (
 	"fmt"
 	"log/slog"
+	"math"
 
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
@@ -81,7 +82,11 @@ func LookupFlow(logger *slog.Logger, repo PolicyRepository, identityManager iden
 		return types.LookupResult{}, ingress, egress, fmt.Errorf("GetSelectorPolicy(from) failed: %w", err)
 	}
 
-	epp := selPolSrc.DistillPolicy(logger, srcEP, nil)
+	dummyRedirects := map[string]uint16{
+		FallbackRedirectID: math.MaxUint16,
+	}
+
+	epp := selPolSrc.DistillPolicy(logger, srcEP, dummyRedirects)
 	epp.Ready()
 	epp.Detach(logger)
 	key := EgressKey().WithIdentity(flow.To.ID).WithPortProto(flow.Proto, flow.Dport)
@@ -97,7 +102,7 @@ func LookupFlow(logger *slog.Logger, repo PolicyRepository, identityManager iden
 	if err != nil {
 		return types.LookupResult{}, ingress, egress, fmt.Errorf("GetSelectorPolicy(to) failed: %w", err)
 	}
-	epp = selPolDst.DistillPolicy(logger, dstEP, nil)
+	epp = selPolDst.DistillPolicy(logger, dstEP, dummyRedirects)
 	epp.Ready()
 	epp.Detach(logger)
 	key = IngressKey().WithIdentity(flow.From.ID).WithPortProto(flow.Proto, flow.Dport)

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -207,7 +207,6 @@ func (p *Repository) addListLocked(entries types.PolicyEntries) (ruleSlice, uint
 
 func (p *Repository) insert(r *rule) {
 	p.rules[r.key] = r
-	p.metricsManager.AddRule(r.PolicyEntry)
 	namespace := r.key.resource.Namespace()
 	if _, ok := p.rulesByNamespace[namespace]; !ok {
 		p.rulesByNamespace[namespace] = sets.New[ruleKey]()
@@ -221,7 +220,10 @@ func (p *Repository) insert(r *rule) {
 		p.rulesByResource[rid][r.key] = r
 	}
 
-	metrics.Policy.Inc()
+	if p.metricsManager != nil {
+		p.metricsManager.AddRule(r.PolicyEntry)
+		metrics.Policy.Inc()
+	}
 }
 
 func (p *Repository) del(key ruleKey) {
@@ -229,7 +231,6 @@ func (p *Repository) del(key ruleKey) {
 	if r == nil {
 		return
 	}
-	p.metricsManager.DelRule(r.PolicyEntry)
 	delete(p.rules, key)
 	namespace := r.key.resource.Namespace()
 	p.rulesByNamespace[namespace].Delete(key)
@@ -244,7 +245,10 @@ func (p *Repository) del(key ruleKey) {
 			delete(p.rulesByResource, rid)
 		}
 	}
-	metrics.Policy.Dec()
+	if p.metricsManager != nil {
+		p.metricsManager.DelRule(r.PolicyEntry)
+		metrics.Policy.Dec()
+	}
 }
 
 // newRule allocates a CachedSelector for a given rule.
@@ -312,7 +316,9 @@ func (p *Repository) GetRevision() uint64 {
 
 // BumpRevision allows forcing policy regeneration
 func (p *Repository) BumpRevision() uint64 {
-	metrics.PolicyRevision.Inc()
+	if p.metricsManager != nil {
+		metrics.PolicyRevision.Inc()
+	}
 	return p.revision.Add(1)
 }
 
@@ -744,4 +750,44 @@ func RepositoryScriptCmds(p *Repository) map[string]script.Cmd {
 			},
 		),
 	}
+}
+
+// Snapshot returns a repository that is "disconnected" from the rest of the daemon.
+// It includes a static snapshot of the selectorcache and an empty policy cache.
+//
+// It has all existing rules and identities.
+func (p *Repository) Snapshot(logger *slog.Logger, cm certificatemanager.CertificateManager, rt envoypolicy.EnvoyL7RulesTranslator) (*Repository, identity.IdentityMap) {
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
+
+	ids := p.selectorCache.getIdentities()
+
+	out := NewPolicyRepository(
+		logger,
+		ids,
+		cm,
+		rt,
+		identitymanager.NewIDManager(logger),
+		nil, // disable metrics
+	)
+	out.namedPortsGetter = p.namedPortsGetter
+
+	// Insert all rules in to the new policy repository.
+	//
+	// These need to be inserted as if they were coming externally, so selectors
+	// will be allocated in the new selectorcache.
+	for k, r := range p.rules {
+		newRule := out.newRule(r.PolicyEntry, k)
+		out.insert(newRule)
+	}
+
+	return out, ids
+}
+
+// ResolvePolicy directly calculates policy. This should only used be for debug or test code.
+func (p *Repository) ResolvePolicy(securityIdentity *identity.Identity) (SelectorPolicy, error) {
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
+
+	return p.resolvePolicyLocked(securityIdentity)
 }

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -1465,3 +1465,67 @@ func TestReplaceByResource(t *testing.T) {
 	assert.True(t, sc.selectors.Empty())
 	assert.Equal(t, 2, oldRuleCnt)
 }
+
+func TestRepositorySnapshot(t *testing.T) {
+	logger := hivetest.Logger(t)
+	td := newTestData(t, logger).withIDs(ruleTestIDs)
+	orig := td.repo
+
+	resource := ipcachetypes.ResourceID("foo")
+
+	r1 := policytypes.PolicyEntry{
+		Verdict:     types.Allow,
+		Subject:     labelSelectorA,
+		Labels:      labels.LabelArray{labels.NewLabel(k8sConst.PolicyLabelName, "r1", labels.LabelSourceAny)},
+		Ingress:     true,
+		L3:          types.ToSelectors(endpointSelectorC),
+		DefaultDeny: true,
+	}
+
+	r2 := policytypes.PolicyEntry{
+		Verdict:     types.Deny,
+		Subject:     types.NewLabelSelector(endpointSelectorB),
+		Labels:      labels.LabelArray{labels.NewLabel(k8sConst.PolicyLabelName, "r2", labels.LabelSourceAny)},
+		Ingress:     true,
+		L3:          types.ToSelectors(endpointSelectorC),
+		DefaultDeny: true,
+	}
+	orig.ReplaceByResource(policytypes.PolicyEntries{&r1}, resource)
+
+	// Resolve policy for an endpoint
+	selPolicy, err := td.repo.resolvePolicyLocked(idA)
+	require.NoError(t, err)
+	defer selPolicy.Detach()
+	epPolicy := selPolicy.DistillPolicy(logger, DummyOwner{logger: logger}, nil)
+	epPolicy.Ready()
+
+	// Now, take a snapshot.
+	snap, _ := orig.Snapshot(logger, nil, nil)
+
+	assert.Equal(t, orig.selectorCache.getIdentities(), snap.selectorCache.getIdentities())
+	beforeRules := orig.GetRulesList().Policy
+	assert.Equal(t, beforeRules, snap.GetRulesList().Policy)
+
+	// Add a new identity to the "real" policy engine
+
+	// Ensure that adding a new identity to the "original" does not appear in the second
+	td.addIdentity(fooIdentity)
+	assert.NotEqual(t, orig.selectorCache.getIdentities(), snap.selectorCache.getIdentities())
+
+	// Ensure the cloned selector caches make sense:
+	// - no peer selectors, as we've not yet resolved policy
+	// - one subject selector, as we added a new policy
+	assert.Empty(t, snap.selectorCache.selectors.selectors, 0)
+
+	assert.Len(t, snap.subjectSelectorCache.selectors.selectors, 1)
+	assert.Len(t, orig.subjectSelectorCache.selectors.selectors, 1)
+
+	// Ensure that changing `snap` does not touch `orig`
+	snap.ReplaceByResource(policytypes.PolicyEntries{&r2}, "bar")
+	assert.NotEqual(t, orig.GetRulesList().Policy, snap.GetRulesList().Policy)
+	assert.NotEqual(t, orig.subjectSelectorCache.GetModel(), snap.subjectSelectorCache.GetModel())
+	assert.Len(t, snap.subjectSelectorCache.selectors.selectors, 2)
+	assert.Len(t, orig.subjectSelectorCache.selectors.selectors, 1)
+
+	assert.Equal(t, beforeRules, orig.GetRulesList().Policy)
+}

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -150,6 +150,8 @@ func (p *policyContext) PolicyTrace(format string, a ...any) {
 	p.logger.Info(fmt.Sprintf(format, a...))
 }
 
+var FallbackRedirectID = "fallback"
+
 // SelectorPolicy represents a selectorPolicy, previously resolved from
 // the policy repository and ready to be distilled against a set of identities
 // to compute datapath-level policy configuration.
@@ -266,6 +268,11 @@ func (p *EndpointPolicy) GetPolicySelectors() SelectorSnapshot {
 func (p *EndpointPolicy) LookupRedirectPort(ingress bool, protocol string, port uint16, listener string) (uint16, error) {
 	proxyID := ProxyID(uint16(p.PolicyOwner.GetID()), ingress, protocol, port, listener)
 	if proxyPort, exists := p.Redirects[proxyID]; exists {
+		return proxyPort, nil
+	}
+	// When simulating policy, we don't want to actually configure proxy. So, use the special
+	// fallback proxy ID
+	if proxyPort, exists := p.Redirects[FallbackRedirectID]; len(p.Redirects) == 1 && exists {
 		return proxyPort, nil
 	}
 	return 0, fmt.Errorf("Proxy port for redirect %q not found", proxyID)

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -874,3 +874,18 @@ func (sc *SelectorCache) UpdateIdentities(added, deleted identity.IdentityMap, w
 	}
 	return mutated
 }
+
+// getIdentities captures the current set of identities.
+// Used for debugging, staging, and testing.
+func (sc *SelectorCache) getIdentities() identity.IdentityMap {
+	sc.mutex.RLock()
+	defer sc.mutex.RUnlock()
+
+	out := make(identity.IdentityMap, len(sc.idCache.ids))
+
+	for nid, id := range sc.idCache.ids {
+		out[nid] = id.lbls
+	}
+
+	return out
+}


### PR DESCRIPTION
This adds a command that takes an endpoint and a set of proposed
policies, and shows the effect this would have on the policy's mapstate.

It uses the PolicyRepository.Snapshot() functionality, which can freeze
the state of the PolicyRepository and the set of identities. It then
simulates ingesting the set of policies. It then displays the
resulting MapState (or the difference, as desired).

This required duplicating logic from a few places in the codebase. In
particular, copying toService extraction and CIDR identity generation
were both necessary.

```release-note
Added the `policy/mapstate/stage` command to `cilium-dbg shell`. It can show the difference in policy map entries that would be created by a proposed set of policies.
```
