### PR TITLE
bgp: migrate CRDs storage version

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -220,6 +220,8 @@ rules:
   resources:
   - ciliumendpointslices
   - ciliumenvoyconfigs
+  - ciliumbgpclusterconfigs
+  - ciliumbgpnodeconfigoverrides
   - ciliumbgppeerconfigs
   - ciliumbgpadvertisements
   - ciliumbgpnodeconfigs
@@ -282,12 +284,22 @@ rules:
 {{- end }}
   - ciliumdatapathplugins.cilium.io
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions/status
+  verbs:
+  - update
+  resourceNames:
+  - ciliumbgpclusterconfigs.cilium.io
+  - ciliumbgppeerconfigs.cilium.io
+  - ciliumbgpadvertisements.cilium.io
+  - ciliumbgpnodeconfigs.cilium.io
+  - ciliumbgpnodeconfigoverrides.cilium.io
+- apiGroups:
   - cilium.io
   resources:
   - ciliumloadbalancerippools
   - ciliumpodippools
-  - ciliumbgpclusterconfigs
-  - ciliumbgpnodeconfigoverrides
   - ciliumbgppeerconfigs
   - ciliumdatapathplugins
   verbs:

--- a/operator/pkg/bgp/fixture_test.go
+++ b/operator/pkg/bgp/fixture_test.go
@@ -140,6 +140,14 @@ func newFixture(t testing.TB, ctx context.Context, req *require.Assertions, dc *
 			)
 		}),
 
+		cell.Provide(func(lc cell.Lifecycle, c k8sClient.Clientset) resource.Resource[*v2.CiliumBGPAdvertisement] {
+			return resource.New[*v2.CiliumBGPAdvertisement](
+				lc, utils.ListerWatcherFromTyped[*v2.CiliumBGPAdvertisementList](
+					c.CiliumV2().CiliumBGPAdvertisements(),
+				), nil,
+			)
+		}),
+
 		cell.Provide(func() *option.DaemonConfig {
 			return dc
 		}),

--- a/operator/pkg/bgp/manager.go
+++ b/operator/pkg/bgp/manager.go
@@ -8,11 +8,15 @@ import (
 	"fmt"
 	"log/slog"
 	"net/netip"
+	"slices"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8s_types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/cilium/cilium/operator/pkg/lbipam"
@@ -47,6 +51,7 @@ type BGPParams struct {
 	NodeConfigOverrideResource resource.Resource[*v2.CiliumBGPNodeConfigOverride]
 	NodeConfigResource         resource.Resource[*v2.CiliumBGPNodeConfig]
 	PeerConfigResource         resource.Resource[*v2.CiliumBGPPeerConfig]
+	AdvertisementResource      resource.Resource[*v2.CiliumBGPAdvertisement]
 	NodeResource               resource.Resource[*v2.CiliumNode]
 }
 
@@ -64,16 +69,19 @@ type BGPResourceManager struct {
 	nodeConfig              resource.Resource[*v2.CiliumBGPNodeConfig]
 	ciliumNode              resource.Resource[*v2.CiliumNode]
 	peerConfig              resource.Resource[*v2.CiliumBGPPeerConfig]
+	advertisement           resource.Resource[*v2.CiliumBGPAdvertisement]
 	clusterConfigStore      resource.Store[*v2.CiliumBGPClusterConfig]
 	nodeConfigOverrideStore resource.Store[*v2.CiliumBGPNodeConfigOverride]
 	nodeConfigStore         resource.Store[*v2.CiliumBGPNodeConfig]
 	peerConfigStore         resource.Store[*v2.CiliumBGPPeerConfig]
+	advertisementStore      resource.Store[*v2.CiliumBGPAdvertisement]
 	ciliumNodeStore         resource.Store[*v2.CiliumNode]
 	nodeConfigClient        cilium_client_v2.CiliumBGPNodeConfigInterface
 
 	// internal state
-	reconcileCh      chan struct{}
-	bgpClusterSyncCh chan struct{}
+	reconcileCh       chan struct{}
+	bgpClusterSyncCh  chan struct{}
+	storesInitialized chan struct{}
 
 	// enable/disable status reporting
 	enableStatusReporting bool
@@ -82,6 +90,31 @@ type BGPResourceManager struct {
 	bgpRouterIDIPPoolEnabled bool
 	bgpRouterIDIPPool        *ipalloc.HashAllocator[string]
 	bgpRouterIDMap           map[string]*netip.Addr
+}
+
+// Interface to use during version migration
+type listPatcher interface {
+	List() []string
+	Patch(context.Context, string, k8s_types.PatchType, []byte, metav1.PatchOptions, ...string) (any, error)
+}
+
+// Wrapper around resource.Store and cilium_client_v2.CiliumBGP*Interface
+type resourceClient[T metav1.Object] struct {
+	lister  func() []T
+	patcher func(context.Context, string, k8s_types.PatchType, []byte, metav1.PatchOptions, ...string) (T, error)
+}
+
+func (r resourceClient[T]) List() []string {
+	names := []string{}
+	for _, item := range r.lister() {
+		names = append(names, item.GetName())
+	}
+
+	return names
+}
+
+func (r resourceClient[T]) Patch(ctx context.Context, name string, pt k8s_types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (any, error) {
+	return r.patcher(ctx, name, pt, data, opts, subresources...)
 }
 
 // registerBGPResourceManager creates a new BGPResourceManager operator instance.
@@ -100,11 +133,13 @@ func registerBGPResourceManager(p BGPParams) *BGPResourceManager {
 
 		reconcileCh:           make(chan struct{}, 1),
 		bgpClusterSyncCh:      make(chan struct{}, 1),
+		storesInitialized:     make(chan struct{}, 1),
 		bgpRouterIDMap:        make(map[string]*netip.Addr),
 		clusterConfig:         p.ClusterConfigResource,
 		nodeConfigOverride:    p.NodeConfigOverrideResource,
 		nodeConfig:            p.NodeConfigResource,
 		peerConfig:            p.PeerConfigResource,
+		advertisement:         p.AdvertisementResource,
 		ciliumNode:            p.NodeResource,
 		enableStatusReporting: p.DaemonConfig.EnableBGPControlPlaneStatusReport,
 	}
@@ -153,6 +188,8 @@ func (b *BGPResourceManager) initializeJobs() {
 			if err := b.restoreRouterIDs(); err != nil {
 				return err
 			}
+
+			b.storesInitialized <- struct{}{}
 
 			return b.Run(ctx)
 		}),
@@ -203,6 +240,53 @@ func (b *BGPResourceManager) initializeJobs() {
 			}
 			return nil
 		}),
+
+		// If the storedVersion contains v2alpha1 then etcd probably contains BGP resource as v2alpha1.
+		// This can prevent deleting the v2alpha1.
+		// The solution is to add an empty patch to the resource so etcd force to update and store it with the new version.
+		// After that we can delete the v2alpha1 from the storedVersion.
+		job.OneShot("bgp-operator-crd-storage-version-migrator", func(ctx context.Context, health cell.Health) error {
+			<-b.storesInitialized
+
+			crdClient := b.clientset.ApiextensionsV1().CustomResourceDefinitions()
+			resourceClients := map[string]listPatcher{
+				"ciliumbgpclusterconfigs.cilium.io": resourceClient[*v2.CiliumBGPClusterConfig]{
+					lister:  b.clusterConfigStore.List,
+					patcher: b.clientset.CiliumV2().CiliumBGPClusterConfigs().Patch,
+				},
+				"ciliumbgppeerconfigs.cilium.io": resourceClient[*v2.CiliumBGPPeerConfig]{
+					lister:  b.peerConfigStore.List,
+					patcher: b.clientset.CiliumV2().CiliumBGPPeerConfigs().Patch,
+				},
+				"ciliumbgpadvertisements.cilium.io": resourceClient[*v2.CiliumBGPAdvertisement]{
+					lister:  b.advertisementStore.List,
+					patcher: b.clientset.CiliumV2().CiliumBGPAdvertisements().Patch,
+				},
+				"ciliumbgpnodeconfigs.cilium.io": resourceClient[*v2.CiliumBGPNodeConfig]{
+					lister:  b.nodeConfigStore.List,
+					patcher: b.clientset.CiliumV2().CiliumBGPNodeConfigs().Patch,
+				},
+				"ciliumbgpnodeconfigoverrides.cilium.io": resourceClient[*v2.CiliumBGPNodeConfigOverride]{
+					lister:  b.nodeConfigOverrideStore.List,
+					patcher: b.clientset.CiliumV2().CiliumBGPNodeConfigOverrides().Patch,
+				},
+			}
+			versionFromMigrate := "v2alpha1"
+
+			for crdName, client := range resourceClients {
+				migrated, err := storageVersionMigrator(ctx, crdClient, crdName, client, versionFromMigrate)
+
+				if err != nil {
+					return err
+				}
+
+				if migrated {
+					b.logger.Debug("CRD migrated", logfields.ResourceName, crdName)
+				}
+			}
+
+			return nil
+		}, job.WithRetry(3, &job.ExponentialBackoff{Min: 500 * time.Millisecond, Max: 3 * time.Second})),
 	)
 }
 
@@ -227,12 +311,45 @@ func (b *BGPResourceManager) initializeStores(ctx context.Context) (err error) {
 		return
 	}
 
+	b.advertisementStore, err = b.advertisement.Store(ctx)
+	if err != nil {
+		return
+	}
+
 	b.ciliumNodeStore, err = b.ciliumNode.Store(ctx)
 	if err != nil {
 		return
 	}
 
 	return nil
+}
+
+func storageVersionMigrator(ctx context.Context, crdClient v1.CustomResourceDefinitionInterface, crdName string, client listPatcher, versionFromMigrate string) (bool, error) {
+	crdDef, err := crdClient.Get(ctx, crdName, metav1.GetOptions{})
+
+	if err != nil {
+		return false, err
+	}
+
+	if slices.Contains(crdDef.Status.StoredVersions, versionFromMigrate) {
+		for _, name := range client.List() {
+			if _, err := client.Patch(ctx, name, k8s_types.MergePatchType, []byte("{}"), metav1.PatchOptions{}); err != nil {
+				return false, err
+			}
+		}
+
+		storedVersions := slices.DeleteFunc(crdDef.Status.StoredVersions, func(s string) bool {
+			return s == versionFromMigrate
+		})
+		crdDef.Status.StoredVersions = storedVersions
+		if _, err := crdClient.UpdateStatus(ctx, crdDef, metav1.UpdateOptions{}); err != nil {
+			return false, err
+		}
+
+		return true, nil
+	}
+
+	return false, nil
 }
 
 // triggerReconcile initiates level triggered reconciliation.

--- a/operator/pkg/bgp/manager_test.go
+++ b/operator/pkg/bgp/manager_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package bgp
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+func TestVersionMigration(t *testing.T) {
+	tests := []struct {
+		name                   string
+		crd                    *v1.CustomResourceDefinition
+		expectedReturnValue    bool
+		expectedStoredVersions []string
+	}{
+		{
+			name: "Migrate v2alpha1",
+			crd: &v1.CustomResourceDefinition{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name: "ciliumbgppeerconfigs.cilium.io",
+				},
+				Status: v1.CustomResourceDefinitionStatus{
+					StoredVersions: []string{"v2", "v2alpha1"},
+				},
+			},
+			expectedReturnValue:    true,
+			expectedStoredVersions: []string{"v2"},
+		},
+		{
+			name: "No Migration",
+			crd: &v1.CustomResourceDefinition{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name: "ciliumbgppeerconfigs.cilium.io",
+				},
+				Status: v1.CustomResourceDefinitionStatus{
+					StoredVersions: []string{"v2"},
+				},
+			},
+			expectedReturnValue:    false,
+			expectedStoredVersions: []string{"v2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), TestTimeout*3)
+			t.Cleanup(func() {
+				cancel()
+			})
+
+			fakeClientSet, _ := k8sClient.NewFakeClientset(slog.Default())
+			crdClient := fakeClientSet.ApiextensionsV1().CustomResourceDefinitions()
+			client := resourceClient[*v2.CiliumBGPPeerConfig]{
+				lister:  list,
+				patcher: fakeClientSet.CiliumV2().CiliumBGPPeerConfigs().Patch,
+			}
+			versionFromMigrate := "v2alpha1"
+			_, err := crdClient.Create(
+				ctx, tt.crd, meta_v1.CreateOptions{},
+			)
+			require.NoError(t, err)
+
+			require.EventuallyWithT(t, func(ct *assert.CollectT) {
+				migrated, err := storageVersionMigrator(
+					ctx, crdClient, tt.crd.Name, client, versionFromMigrate,
+				)
+				if !assert.NoError(ct, err, "Failed to migrate storage version") {
+					return
+				}
+
+				crd, err := crdClient.Get(ctx, tt.crd.Name, meta_v1.GetOptions{})
+				if !assert.NoError(ct, err, "Failed to get CustomResourceDefinition") {
+					return
+				}
+				assert.Equal(ct, tt.expectedStoredVersions, crd.Status.StoredVersions, "Unexpected Status.StoredVersions")
+				assert.Equal(ct, tt.expectedReturnValue, migrated, "Unexpected return value")
+			}, time.Second*3, time.Millisecond*100)
+		})
+	}
+}
+
+func list() []*v2.CiliumBGPPeerConfig {
+	return nil
+}


### PR DESCRIPTION
If the storage version is not migrated, removing deprecated APIs may end up in an error during CRD update in the operator.

The migration logic for every BGP CRD if `.status.storedVersions` contains `v2alpha1`:
1. Apply an empty patch to all resources to for etcd to store objects as v2 API
2. Update the CRD `.status.storedVersions` to remove `v2alpha1`

Changes:
- Modify operator cluster role to be able to update BGP CRDs status and patch all BGP resources.
- Add CiliumBGPAdvertisement store to empty patch the resources.
- Add bgp-operator-crd-storage-version-migrator job to run after initializeStores.

etcd object before migration:
```
{"apiVersion":"cilium.io/v2alpha1","kind":"CiliumBGPPeerConfig","metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"cilium.io/v2\",\"kind\":\"CiliumBGPPeerConfig\",\"metadata\":{\"annotations\":{},\"name\":\"peer-config\"},\"spec\":{\"families\":[{\"afi\":\"ipv6\",\"safi\":\"unicast\"},{\"advertisements\":{\"matchLabels\":{\"advertise\":\"bgp\"}},\"afi\":\"ipv4\",\"safi\":\"unicast\"}],\"gracefulRestart\":{\"enabled\":true,\"restartTimeSeconds\":60}}}\n"},"creationTimestamp":"2026-06-26T19:17:09Z","generation":1,"managedFields":[{"apiVersion":"cilium.io/v2","fieldsType":"FieldsV1","fieldsV1":{"f:status":{".":{},"f:conditions":{".":{},"k:{\"type\":\"cilium.io/MissingAuthSecret\"}":{".":{},"f:lastTransitionTime":{},"f:message":{},"f:observedGeneration":{},"f:reason":{},"f:status":{},"f:type":{}}}}},"manager":"cilium-operator-generic","operation":"Update","subresource":"status","time":"2026-06-26T19:17:09Z"},{"apiVersion":"cilium.io/v2","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:kubectl.kubernetes.io/last-applied-configuration":{}}},"f:spec":{".":{},"f:ebgpMultihop":{},"f:families":{},"f:gracefulRestart":{".":{},"f:enabled":{},"f:restartTimeSeconds":{}}}},"manager":"kubectl-client-side-apply","operation":"Update","time":"2026-06-26T19:17:09Z"}],"name":"peer-config","uid":"1ab5eb4f-f862-470d-89eb-fddbb3a14920"},"spec":{"ebgpMultihop":1,"families":[{"afi":"ipv6","safi":"unicast"},{"advertisements":{"matchLabels":{"advertise":"bgp"}},"afi":"ipv4","safi":"unicast"}],"gracefulRestart":{"enabled":true,"restartTimeSeconds":60}},"status":{"conditions":[{"lastTransitionTime":"2026-06-26T19:17:09Z","message":"","observedGeneration":1,"reason":"MissingAuthSecret","status":"False","type":"cilium.io/MissingAuthSecret"}]}}
```

etcd object after migration:
```
{"apiVersion":"cilium.io/v2","kind":"CiliumBGPPeerConfig","metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"cilium.io/v2\",\"kind\":\"CiliumBGPPeerConfig\",\"metadata\":{\"annotations\":{},\"name\":\"peer-config\"},\"spec\":{\"families\":[{\"afi\":\"ipv6\",\"safi\":\"unicast\"},{\"advertisements\":{\"matchLabels\":{\"advertise\":\"bgp\"}},\"afi\":\"ipv4\",\"safi\":\"unicast\"}],\"gracefulRestart\":{\"enabled\":true,\"restartTimeSeconds\":60}}}\n"},"creationTimestamp":"2026-06-26T19:17:09Z","generation":1,"managedFields":[{"apiVersion":"cilium.io/v2","fieldsType":"FieldsV1","fieldsV1":{"f:status":{".":{},"f:conditions":{".":{},"k:{\"type\":\"cilium.io/MissingAuthSecret\"}":{".":{},"f:lastTransitionTime":{},"f:message":{},"f:observedGeneration":{},"f:reason":{},"f:status":{},"f:type":{}}}}},"manager":"cilium-operator-generic","operation":"Update","subresource":"status","time":"2026-06-26T19:17:09Z"},{"apiVersion":"cilium.io/v2","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:kubectl.kubernetes.io/last-applied-configuration":{}}},"f:spec":{".":{},"f:ebgpMultihop":{},"f:families":{},"f:gracefulRestart":{".":{},"f:enabled":{},"f:restartTimeSeconds":{}}}},"manager":"kubectl-client-side-apply","operation":"Update","time":"2026-06-26T19:17:09Z"}],"name":"peer-config","uid":"1ab5eb4f-f862-470d-89eb-fddbb3a14920"},"spec":{"ebgpMultihop":1,"families":[{"afi":"ipv6","safi":"unicast"},{"advertisements":{"matchLabels":{"advertise":"bgp"}},"afi":"ipv4","safi":"unicast"}],"gracefulRestart":{"enabled":true,"restartTimeSeconds":60}},"status":{"conditions":[{"lastTransitionTime":"2026-06-26T19:17:09Z","message":"","observedGeneration":1,"reason":"MissingAuthSecret","status":"False","type":"cilium.io/MissingAuthSecret"}]}}
```

storedVersions before migration:
```
$ kubectl get crd ciliumbgpadvertisements.cilium.io -o jsonpath="{.status.storedVersions}"
["v2alpha1","v2"]
```

storedVersions after migration:
```
$ kubectl get crd ciliumbgpadvertisements.cilium.io -o jsonpath="{.status.storedVersions}"
["v2"]
```

```release-note
bgp: migrate CRDs storage version from v2alpha1 to v2
```
