### PR TITLE
gatewayapi: always populate listener supportedKinds in status

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -1527,6 +1527,12 @@ func (r *gatewayReconciler) validateListener(ctx context.Context, l gatewayv1.Li
 		}
 	}
 
+	// supportedKinds is serialized with omitzero: a nil slice is dropped from
+	// the listener status, so always emit an explicit (possibly empty) list.
+	if res.supportedKinds == nil {
+		res.supportedKinds = []gatewayv1.RouteGroupKind{}
+	}
+
 	return res
 }
 

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -1089,6 +1089,65 @@ func Test_gatewayReconciler_setListenerStatus(t *testing.T) {
 	}
 }
 
+func Test_gatewayReconciler_validateListener(t *testing.T) {
+	c := fake.NewClientBuilder().
+		WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+		Build()
+	r := &gatewayReconciler{
+		Client: c,
+		logger: hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug)),
+	}
+
+	tests := map[string]struct {
+		listener           gatewayv1.Listener
+		wantValid          bool
+		wantReason         gatewayv1.ListenerConditionReason
+		wantSupportedKinds []gatewayv1.RouteGroupKind
+	}{
+		"valid HTTP listener": {
+			listener: gatewayv1.Listener{
+				Name:     "http",
+				Port:     80,
+				Protocol: gatewayv1.HTTPProtocolType,
+			},
+			wantValid: true,
+			wantSupportedKinds: []gatewayv1.RouteGroupKind{
+				{Group: GroupPtr(gatewayv1.GroupName), Kind: kindHTTPRoute},
+				{Group: GroupPtr(gatewayv1.GroupName), Kind: kindGRPCRoute},
+			},
+		},
+		"unsupported protocol listener": {
+			listener: gatewayv1.Listener{
+				Name:     "invalid",
+				Port:     1111,
+				Protocol: gatewayv1.ProtocolType("INVALID"),
+			},
+			wantValid:          false,
+			wantReason:         gatewayv1.ListenerReasonUnsupportedProtocol,
+			wantSupportedKinds: []gatewayv1.RouteGroupKind{},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			res := r.validateListener(t.Context(), tc.listener, listenerValidationParams{
+				ownerNamespace: "default",
+				ownerKind:      "Gateway",
+				generation:     1,
+			})
+			assert.Equal(t, tc.wantValid, res.isValid)
+			if !tc.wantValid {
+				assert.Equal(t, tc.wantReason, res.invalidReason)
+			}
+			// supportedKinds is serialized with omitzero, so a nil slice is
+			// dropped from the listener status entirely. It must always be an
+			// explicit list (empty for unsupported protocols).
+			assert.NotNil(t, res.supportedKinds)
+			assert.Equal(t, tc.wantSupportedKinds, res.supportedKinds)
+		})
+	}
+}
+
 func listenerStatusCondition(t *testing.T, listeners []gatewayv1.ListenerStatus, name gatewayv1.SectionName, conditionType string) metav1.Condition {
 	t.Helper()
 


### PR DESCRIPTION
## Description

`validateListener` left the listener status `supportedKinds` field nil for listeners using an unsupported protocol. The Gateway API `ListenerStatus.SupportedKinds` field is serialized with `omitzero`, so a nil slice is dropped from the status entirely — the listener ended up with no `supportedKinds` key at all. The `allowedRoutes` and TLS-terminate paths already emit an explicit empty list, so the unsupported-protocol path was inconsistent.

This PR:
- Normalizes `supportedKinds` to an explicit (possibly empty) slice before returning, so it is always present in the listener status.
- Reports the Accepted condition reason as `UnsupportedProtocol` instead of the generic `Invalid` when the protocol is not supported, per the Gateway API spec.

Both the Gateway and ListenerSet reconcile paths call `validateListener`, so both are fixed.

## Testing

Added `Test_gatewayReconciler_validateListener` (valid HTTP listener + unsupported-protocol listener). Full package passes: `go test ./operator/pkg/gateway-api/` → ok.

```release-note
Fix Gateway API listener status to always report supportedKinds and use the UnsupportedProtocol reason for listeners with an unsupported protocol.
```

