### PR TITLE
bpf: tests: clean up re-introduced USE_BPF_PROG_FOR_INGRESS_POLICY

### DIFF
--- a/bpf/tests/tc_nodeport_lb4_ipip_termination.c
+++ b/bpf/tests/tc_nodeport_lb4_ipip_termination.c
@@ -33,7 +33,6 @@
 #define DSR_ENCAP_IPIP		2
 #define DSR_ENCAP_MODE		DSR_ENCAP_IPIP
 #define ENABLE_HOST_ROUTING	1
-#define USE_BPF_PROG_FOR_INGRESS_POLICY	1
 
 /* nodeport_lb4 references this for DSR_ENCAP_IPIP egress (TX side). We only
  * exercise the RX/decap side here, but the symbol needs to resolve.
@@ -203,6 +202,7 @@ int mock_tail_policy(struct __ctx_buff *ctx)
 #include "lib/lb.h"
 
 ASSIGN_CONFIG(__u32, interface_ifindex, DEFAULT_IFACE)
+ASSIGN_CONFIG(bool, enable_endpoint_routes, true)
 ASSIGN_CONFIG(bool, enable_netkit, false)
 ASSIGN_CONFIG(bool, enable_ipip_termination, true)
 

--- a/bpf/tests/tc_nodeport_lb6_ipip_termination.c
+++ b/bpf/tests/tc_nodeport_lb6_ipip_termination.c
@@ -25,7 +25,6 @@
 #define DSR_ENCAP_IPIP		2
 #define DSR_ENCAP_MODE		DSR_ENCAP_IPIP
 #define ENABLE_HOST_ROUTING	1
-#define USE_BPF_PROG_FOR_INGRESS_POLICY	1
 
 #define ENCAP6_IFINDEX		42
 
@@ -164,6 +163,7 @@ int mock_tail_policy(struct __ctx_buff *ctx)
 #include "lib/lb.h"
 
 ASSIGN_CONFIG(__u32, interface_ifindex, DEFAULT_IFACE)
+ASSIGN_CONFIG(bool, enable_endpoint_routes, true)
 ASSIGN_CONFIG(bool, enable_netkit, false)
 ASSIGN_CONFIG(bool, enable_ipip_termination, true)
 

--- a/bpf/tests/xdp_nodeport_lb_dsr_ipip.c
+++ b/bpf/tests/xdp_nodeport_lb_dsr_ipip.c
@@ -15,9 +15,6 @@
 #define DSR_ENCAP_IPIP			2
 #define DSR_ENCAP_MODE			DSR_ENCAP_IPIP
 
-/* Skip ingress policy checks */
-#define USE_BPF_PROG_FOR_INGRESS_POLICY	1
-
 #define CLIENT_IP		v4_ext_one
 #define CLIENT_IPV6		{ .addr = { 0x1 } }
 #define CLIENT_PORT		__bpf_htons(111)

--- a/bpf/tests/xdp_nodeport_lb_dsr_lb.c
+++ b/bpf/tests/xdp_nodeport_lb_dsr_lb.c
@@ -12,9 +12,6 @@
 #define ENABLE_NODEPORT_ACCELERATION	1
 #define ENABLE_DSR			1
 
-/* Skip ingress policy checks */
-#define USE_BPF_PROG_FOR_INGRESS_POLICY	1
-
 #define CLIENT_IP		v4_ext_one
 #define CLIENT_IPV6		{ .addr = { 0x1, 0x0, 0x0, 0x0, 0x0, 0x0 } }
 #define CLIENT_PORT		__bpf_htons(111)


### PR DESCRIPTION
This macro was removed by
28877e0bcb8d ("datapath: remove USE_BPF_PROG_FOR_INGRESS_POLICY"), but some in-flight PR must have introduced new tests that still used it.

Although these tests don't seem to actually rely on the flag, given that they still passed even though this macro had no effect.

Convert the TC tests, but don't bother with the XDP tests (there is no local-delivery path from XDP).