### PR TITLE
bpf: overlay: demote revalidate_data_pull() to revalidate_data()

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -59,7 +59,7 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 	bool is_dsr = false;
 
 	/* verifier workaround (dereference of modified ctx ptr) */
-	if (!revalidate_data_pull(ctx, &data, &data_end, &ip6))
+	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
 	if (!CONFIG(enable_ipv6_fragments)) {
@@ -262,7 +262,7 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx,
 	int ret __maybe_unused;
 
 	/* verifier workaround (dereference of modified ctx ptr) */
-	if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
 	/* If IPv4 fragmentation is disabled AND an IPv4 fragmented packet is


### PR DESCRIPTION
Since cil_from_overlay() now calls pull_l3_hdr() at the first ethertype de-mux point, the L3 header is guaranteed to be in linear memory by the time handle_ipv6() and handle_ipv4() are tail-called. The pull in their opening revalidate_data_pull() is therefore redundant; demote to revalidate_data().

Follow up to  this pr. https://github.com/cilium/cilium/pull/45988
