### PR TITLE
helm: add GatewayAPI HTTPRoute support for hubble-ui

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2652,6 +2652,14 @@
      - Controls server listener for ipv6
      - object
      - ``{"enabled":true}``
+   * - :spelling:ignore:`hubble.ui.httpRoute`
+     - hubble-ui GatewayAPI HTTPRoute configuration.
+     - object
+     - ``{"annotations":{},"enabled":false,"hostnames":["chart-example.local"],"labels":{},"parentRefs":[{"name":"cilium-gateway","namespace":"kube-system"}]}``
+   * - :spelling:ignore:`hubble.ui.httpRoute.parentRefs`
+     - parentRefs define which Gateways this HTTPRoute attaches to.
+     - list
+     - ``[{"name":"cilium-gateway","namespace":"kube-system"}]``
    * - :spelling:ignore:`hubble.ui.ingress`
      - hubble-ui ingress configuration.
      - object

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -713,6 +713,8 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.frontend.resources | object | `{}` | Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment. |
 | hubble.ui.frontend.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}` | Hubble-ui frontend security context. |
 | hubble.ui.frontend.server.ipv6 | object | `{"enabled":true}` | Controls server listener for ipv6 |
+| hubble.ui.httpRoute | object | `{"annotations":{},"enabled":false,"hostnames":["chart-example.local"],"labels":{},"parentRefs":[{"name":"cilium-gateway","namespace":"kube-system"}]}` | hubble-ui GatewayAPI HTTPRoute configuration. |
+| hubble.ui.httpRoute.parentRefs | list | `[{"name":"cilium-gateway","namespace":"kube-system"}]` | parentRefs define which Gateways this HTTPRoute attaches to. |
 | hubble.ui.ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":["chart-example.local"],"labels":{},"tls":[]}` | hubble-ui ingress configuration. |
 | hubble.ui.labels | object | `{}` | Additional labels to be added to 'hubble-ui' deployment object |
 | hubble.ui.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |

--- a/install/kubernetes/cilium/templates/hubble-ui/httproute.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/httproute.yaml
@@ -1,0 +1,45 @@
+{{- if and (or .Values.hubble.enabled .Values.hubble.ui.standalone.enabled) .Values.hubble.ui.enabled .Values.hubble.ui.httpRoute.enabled }}
+{{- $baseUrl := .Values.hubble.ui.baseUrl -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hubble-ui
+  namespace: {{ include "cilium.namespace" . }}
+  labels:
+    k8s-app: hubble-ui
+    app.kubernetes.io/name: hubble-ui
+    app.kubernetes.io/part-of: cilium
+    helm.sh/chart: {{ include "cilium.chart" . }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.hubble.ui.httpRoute.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if or .Values.hubble.ui.annotations .Values.hubble.ui.httpRoute.annotations }}
+  annotations:
+    {{- with .Values.hubble.ui.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.hubble.ui.httpRoute.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.hubble.ui.httpRoute.parentRefs | nindent 4 }}
+  {{- if .Values.hubble.ui.httpRoute.hostnames }}
+  hostnames:
+    {{- range .Values.hubble.ui.httpRoute.hostnames }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ $baseUrl | quote }}
+      backendRefs:
+        - name: hubble-ui
+          port: 80
+{{- end }}

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -4058,6 +4058,47 @@
               },
               "type": "object"
             },
+            "httpRoute": {
+              "properties": {
+                "annotations": {
+                  "type": "object"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "hostnames": {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                },
+                "labels": {
+                  "type": "object"
+                },
+                "parentRefs": {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
             "ingress": {
               "properties": {
                 "annotations": {

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2197,6 +2197,18 @@ hubble:
       #  - secretName: chart-example-tls
       #    hosts:
       #      - chart-example.local
+    # -- hubble-ui GatewayAPI HTTPRoute configuration.
+    httpRoute:
+      enabled: false
+      annotations: {}
+      labels: {}
+      # -- parentRefs define which Gateways this HTTPRoute attaches to.
+      parentRefs:
+        - name: cilium-gateway
+          namespace: kube-system
+          # sectionName: http
+      hostnames:
+        - chart-example.local
     # -- Configure temporary volume for hubble-ui
     tmpVolume: {}
     # emptyDir:

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2214,6 +2214,18 @@ hubble:
       #  - secretName: chart-example-tls
       #    hosts:
       #      - chart-example.local
+    # -- hubble-ui GatewayAPI HTTPRoute configuration.
+    httpRoute:
+      enabled: false
+      annotations: {}
+      labels: {}
+      # -- parentRefs define which Gateways this HTTPRoute attaches to.
+      parentRefs:
+        - name: cilium-gateway
+          namespace: kube-system
+          # sectionName: http
+      hostnames:
+        - chart-example.local
 
     # -- Configure temporary volume for hubble-ui
     tmpVolume: {}


### PR DESCRIPTION
Add a new `hubble.ui.httproute` Helm values section alongside the existing `hubble.ui.ingress` block, and a corresponding `templates/hubble-ui/httproute.yaml` that renders a `gateway.networking.k8s.io/v1 HTTPRoute` resource.

The HTTPRoute is disabled by default and independent of the Ingress — both can be active simultaneously. Callers configure `parentRefs` to attach the route to an existing Gateway; hostnames and annotations follow the same conventions as the ingress values.

Fixes: #45697

AI Influence Level: 1 (setting up dev environment to generate docs via Makefile)