### PR TITLE
deps: bump GoBGP to latest 4.6.1 pre-release commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.40.0
-	github.com/osrg/gobgp/v4 v4.6.0
+	github.com/osrg/gobgp/v4 v4.6.1-0.20260630022313-d6dee8360046
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/prometheus-community/pro-bing v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -573,8 +573,8 @@ github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b h1:Ff
 github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b/go.mod h1:AC62GU6hc0BrNm+9RK9VSiwa/EUe1bkIeFORAMcHvJU=
 github.com/orcaman/concurrent-map/v2 v2.0.1 h1:jOJ5Pg2w1oeB6PeDurIYf6k9PQ+aTITr/6lP/L/zp6c=
 github.com/orcaman/concurrent-map/v2 v2.0.1/go.mod h1:9Eq3TG2oBe5FirmYWQfYO5iH1q0Jv47PLaNK++uCdOM=
-github.com/osrg/gobgp/v4 v4.6.0 h1:9ga/Pn3NUiM0Sv0K7YI+dy/uMYKyXOsu3dalXTmnX8I=
-github.com/osrg/gobgp/v4 v4.6.0/go.mod h1:j1GLEuE20jm2YAoGmaHGb3y9lGH/KBgCBT4Ss5RY/wQ=
+github.com/osrg/gobgp/v4 v4.6.1-0.20260630022313-d6dee8360046 h1:ODfeKqE8OeylK9DvfCEIL4XlV/Z7SIz5qTKALaoV+gE=
+github.com/osrg/gobgp/v4 v4.6.1-0.20260630022313-d6dee8360046/go.mod h1:j1GLEuE20jm2YAoGmaHGb3y9lGH/KBgCBT4Ss5RY/wQ=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=

--- a/pkg/bgp/test/testdata/commands.txtar
+++ b/pkg/bgp/test/testdata/commands.txtar
@@ -202,6 +202,7 @@ Instance: instance0
       route-refresh
       extended-nexthop:
         nlri: ipv4-unicast, nexthop: ipv6
+      extended-message
       4-octet-as
       fqdn:
         name: <redacted>
@@ -215,6 +216,7 @@ Instance: instance0
       route-refresh
       extended-nexthop:
         nlri: ipv4-unicast, nexthop: ipv6
+      extended-message
       graceful-restart
       4-octet-as
       add-path:
@@ -259,6 +261,7 @@ Instance: instance0
       route-refresh
       extended-nexthop:
         nlri: ipv4-unicast, nexthop: ipv6
+      extended-message
       4-octet-as
       fqdn:
         name: <redacted>
@@ -272,6 +275,7 @@ Instance: instance0
       route-refresh
       extended-nexthop:
         nlri: ipv4-unicast, nexthop: ipv6
+      extended-message
       graceful-restart
       4-octet-as
       add-path:
@@ -317,6 +321,7 @@ Instance: instance1
       route-refresh
       extended-nexthop:
         nlri: ipv4-unicast, nexthop: ipv6
+      extended-message
       4-octet-as
       fqdn:
         name: <redacted>
@@ -330,6 +335,7 @@ Instance: instance1
       route-refresh
       extended-nexthop:
         nlri: ipv4-unicast, nexthop: ipv6
+      extended-message
       graceful-restart
       4-octet-as
       add-path:
@@ -374,6 +380,7 @@ Instance: instance1
       route-refresh
       extended-nexthop:
         nlri: ipv4-unicast, nexthop: ipv6
+      extended-message
       4-octet-as
       fqdn:
         name: <redacted>
@@ -387,6 +394,7 @@ Instance: instance1
       route-refresh
       extended-nexthop:
         nlri: ipv4-unicast, nexthop: ipv6
+      extended-message
       graceful-restart
       4-octet-as
       add-path:

--- a/vendor/github.com/osrg/gobgp/v4/api/attribute.pb.go
+++ b/vendor/github.com/osrg/gobgp/v4/api/attribute.pb.go
@@ -3419,8 +3419,12 @@ type LsAttributeNode struct {
 	SrCapabilities  *LsSrCapabilities      `protobuf:"bytes,7,opt,name=sr_capabilities,json=srCapabilities,proto3" json:"sr_capabilities,omitempty"`
 	SrAlgorithms    []byte                 `protobuf:"bytes,8,opt,name=sr_algorithms,json=srAlgorithms,proto3" json:"sr_algorithms,omitempty"`
 	SrLocalBlock    *LsSrLocalBlock        `protobuf:"bytes,9,opt,name=sr_local_block,json=srLocalBlock,proto3" json:"sr_local_block,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// RFC 9351 Section 3 Flexible Algorithm Definition (FAD) TLVs
+	// observed for this Node NLRI. A node MAY advertise more than one
+	// FAD, one per algorithm in the [128, 255] Flex-Algorithm range.
+	FlexAlgoDefs  []*LsAttributeFlexAlgoDef `protobuf:"bytes,10,rep,name=flex_algo_defs,json=flexAlgoDefs,proto3" json:"flex_algo_defs,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *LsAttributeNode) Reset() {
@@ -3516,6 +3520,133 @@ func (x *LsAttributeNode) GetSrLocalBlock() *LsSrLocalBlock {
 	return nil
 }
 
+func (x *LsAttributeNode) GetFlexAlgoDefs() []*LsAttributeFlexAlgoDef {
+	if x != nil {
+		return x.FlexAlgoDefs
+	}
+	return nil
+}
+
+// LsAttributeFlexAlgoDef is the structured projection of a single FAD
+// TLV (TLV 1039, RFC 9351 Section 3). Reserved Metric-Type values
+// (3..127) are passed through verbatim with metric_type_known=false
+// so consumers can render them without guessing semantics.
+type LsAttributeFlexAlgoDef struct {
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	Algorithm          uint32                 `protobuf:"varint,1,opt,name=algorithm,proto3" json:"algorithm,omitempty"`
+	MetricType         uint32                 `protobuf:"varint,2,opt,name=metric_type,json=metricType,proto3" json:"metric_type,omitempty"`
+	MetricTypeKnown    bool                   `protobuf:"varint,3,opt,name=metric_type_known,json=metricTypeKnown,proto3" json:"metric_type_known,omitempty"`
+	CalcType           uint32                 `protobuf:"varint,4,opt,name=calc_type,json=calcType,proto3" json:"calc_type,omitempty"`
+	Priority           uint32                 `protobuf:"varint,5,opt,name=priority,proto3" json:"priority,omitempty"`
+	ExcludeAnyAffinity []uint32               `protobuf:"varint,6,rep,packed,name=exclude_any_affinity,json=excludeAnyAffinity,proto3" json:"exclude_any_affinity,omitempty"`
+	IncludeAnyAffinity []uint32               `protobuf:"varint,7,rep,packed,name=include_any_affinity,json=includeAnyAffinity,proto3" json:"include_any_affinity,omitempty"`
+	IncludeAllAffinity []uint32               `protobuf:"varint,8,rep,packed,name=include_all_affinity,json=includeAllAffinity,proto3" json:"include_all_affinity,omitempty"`
+	DefinitionFlags    []byte                 `protobuf:"bytes,9,opt,name=definition_flags,json=definitionFlags,proto3" json:"definition_flags,omitempty"`
+	ExcludeSrlg        []uint32               `protobuf:"varint,10,rep,packed,name=exclude_srlg,json=excludeSrlg,proto3" json:"exclude_srlg,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *LsAttributeFlexAlgoDef) Reset() {
+	*x = LsAttributeFlexAlgoDef{}
+	mi := &file_api_attribute_proto_msgTypes[53]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LsAttributeFlexAlgoDef) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LsAttributeFlexAlgoDef) ProtoMessage() {}
+
+func (x *LsAttributeFlexAlgoDef) ProtoReflect() protoreflect.Message {
+	mi := &file_api_attribute_proto_msgTypes[53]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LsAttributeFlexAlgoDef.ProtoReflect.Descriptor instead.
+func (*LsAttributeFlexAlgoDef) Descriptor() ([]byte, []int) {
+	return file_api_attribute_proto_rawDescGZIP(), []int{53}
+}
+
+func (x *LsAttributeFlexAlgoDef) GetAlgorithm() uint32 {
+	if x != nil {
+		return x.Algorithm
+	}
+	return 0
+}
+
+func (x *LsAttributeFlexAlgoDef) GetMetricType() uint32 {
+	if x != nil {
+		return x.MetricType
+	}
+	return 0
+}
+
+func (x *LsAttributeFlexAlgoDef) GetMetricTypeKnown() bool {
+	if x != nil {
+		return x.MetricTypeKnown
+	}
+	return false
+}
+
+func (x *LsAttributeFlexAlgoDef) GetCalcType() uint32 {
+	if x != nil {
+		return x.CalcType
+	}
+	return 0
+}
+
+func (x *LsAttributeFlexAlgoDef) GetPriority() uint32 {
+	if x != nil {
+		return x.Priority
+	}
+	return 0
+}
+
+func (x *LsAttributeFlexAlgoDef) GetExcludeAnyAffinity() []uint32 {
+	if x != nil {
+		return x.ExcludeAnyAffinity
+	}
+	return nil
+}
+
+func (x *LsAttributeFlexAlgoDef) GetIncludeAnyAffinity() []uint32 {
+	if x != nil {
+		return x.IncludeAnyAffinity
+	}
+	return nil
+}
+
+func (x *LsAttributeFlexAlgoDef) GetIncludeAllAffinity() []uint32 {
+	if x != nil {
+		return x.IncludeAllAffinity
+	}
+	return nil
+}
+
+func (x *LsAttributeFlexAlgoDef) GetDefinitionFlags() []byte {
+	if x != nil {
+		return x.DefinitionFlags
+	}
+	return nil
+}
+
+func (x *LsAttributeFlexAlgoDef) GetExcludeSrlg() []uint32 {
+	if x != nil {
+		return x.ExcludeSrlg
+	}
+	return nil
+}
+
 type LsAttributeLink struct {
 	state               protoimpl.MessageState `protogen:"open.v1"`
 	Name                string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -3546,7 +3677,7 @@ type LsAttributeLink struct {
 
 func (x *LsAttributeLink) Reset() {
 	*x = LsAttributeLink{}
-	mi := &file_api_attribute_proto_msgTypes[53]
+	mi := &file_api_attribute_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3558,7 +3689,7 @@ func (x *LsAttributeLink) String() string {
 func (*LsAttributeLink) ProtoMessage() {}
 
 func (x *LsAttributeLink) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[53]
+	mi := &file_api_attribute_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3571,7 +3702,7 @@ func (x *LsAttributeLink) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsAttributeLink.ProtoReflect.Descriptor instead.
 func (*LsAttributeLink) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{53}
+	return file_api_attribute_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *LsAttributeLink) GetName() string {
@@ -3722,17 +3853,30 @@ func (x *LsAttributeLink) GetUnidirectionalDelayVariation() uint32 {
 }
 
 type LsAttributePrefix struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	IgpFlags      *LsIGPFlags            `protobuf:"bytes,1,opt,name=igp_flags,json=igpFlags,proto3" json:"igp_flags,omitempty"`
-	Opaque        []byte                 `protobuf:"bytes,2,opt,name=opaque,proto3" json:"opaque,omitempty"`
-	SrPrefixSid   uint32                 `protobuf:"varint,3,opt,name=sr_prefix_sid,json=srPrefixSid,proto3" json:"sr_prefix_sid,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	IgpFlags *LsIGPFlags            `protobuf:"bytes,1,opt,name=igp_flags,json=igpFlags,proto3" json:"igp_flags,omitempty"`
+	Opaque   []byte                 `protobuf:"bytes,2,opt,name=opaque,proto3" json:"opaque,omitempty"`
+	// sr_prefix_sid is the SR-MPLS Prefix-SID label when the originator
+	// advertised it with Algorithm = 0 (default SPF). Kept for backward
+	// compatibility with the singular Algorithm-0 lookup callers used
+	// before multi-SID aggregation landed.
+	SrPrefixSid uint32 `protobuf:"varint,3,opt,name=sr_prefix_sid,json=srPrefixSid,proto3" json:"sr_prefix_sid,omitempty"`
+	// sr_prefix_sids carries every Prefix-SID TLV (RFC 9085
+	// Section 2.1.1) observed on this Prefix NLRI, including the
+	// Algorithm + Flags fields the singular sr_prefix_sid field drops.
+	// Algorithm 0 entries also populate sr_prefix_sid above.
+	SrPrefixSids []*LsAttributePrefixSID `protobuf:"bytes,4,rep,name=sr_prefix_sids,json=srPrefixSids,proto3" json:"sr_prefix_sids,omitempty"`
+	// fad_prefix_metrics carries every Flexible Algorithm Prefix Metric
+	// TLV (FAPM, TLV 1044, RFC 9351 Section 4) observed on this Prefix
+	// NLRI. One entry per Flex-Algorithm announced.
+	FadPrefixMetrics []*LsAttributeFADPrefixMetric `protobuf:"bytes,5,rep,name=fad_prefix_metrics,json=fadPrefixMetrics,proto3" json:"fad_prefix_metrics,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *LsAttributePrefix) Reset() {
 	*x = LsAttributePrefix{}
-	mi := &file_api_attribute_proto_msgTypes[54]
+	mi := &file_api_attribute_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3744,7 +3888,7 @@ func (x *LsAttributePrefix) String() string {
 func (*LsAttributePrefix) ProtoMessage() {}
 
 func (x *LsAttributePrefix) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[54]
+	mi := &file_api_attribute_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3757,7 +3901,7 @@ func (x *LsAttributePrefix) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsAttributePrefix.ProtoReflect.Descriptor instead.
 func (*LsAttributePrefix) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{54}
+	return file_api_attribute_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *LsAttributePrefix) GetIgpFlags() *LsIGPFlags {
@@ -3781,6 +3925,145 @@ func (x *LsAttributePrefix) GetSrPrefixSid() uint32 {
 	return 0
 }
 
+func (x *LsAttributePrefix) GetSrPrefixSids() []*LsAttributePrefixSID {
+	if x != nil {
+		return x.SrPrefixSids
+	}
+	return nil
+}
+
+func (x *LsAttributePrefix) GetFadPrefixMetrics() []*LsAttributeFADPrefixMetric {
+	if x != nil {
+		return x.FadPrefixMetrics
+	}
+	return nil
+}
+
+// LsAttributePrefixSID is one Prefix-SID TLV (RFC 9085 Section 2.1.1)
+// projected onto the LsAttribute surface so consumers can read the
+// Algorithm and Flags fields without re-parsing the wire bytes.
+type LsAttributePrefixSID struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Algorithm     uint32                 `protobuf:"varint,1,opt,name=algorithm,proto3" json:"algorithm,omitempty"`
+	Flags         uint32                 `protobuf:"varint,2,opt,name=flags,proto3" json:"flags,omitempty"`
+	Sid           uint32                 `protobuf:"varint,3,opt,name=sid,proto3" json:"sid,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LsAttributePrefixSID) Reset() {
+	*x = LsAttributePrefixSID{}
+	mi := &file_api_attribute_proto_msgTypes[56]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LsAttributePrefixSID) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LsAttributePrefixSID) ProtoMessage() {}
+
+func (x *LsAttributePrefixSID) ProtoReflect() protoreflect.Message {
+	mi := &file_api_attribute_proto_msgTypes[56]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LsAttributePrefixSID.ProtoReflect.Descriptor instead.
+func (*LsAttributePrefixSID) Descriptor() ([]byte, []int) {
+	return file_api_attribute_proto_rawDescGZIP(), []int{56}
+}
+
+func (x *LsAttributePrefixSID) GetAlgorithm() uint32 {
+	if x != nil {
+		return x.Algorithm
+	}
+	return 0
+}
+
+func (x *LsAttributePrefixSID) GetFlags() uint32 {
+	if x != nil {
+		return x.Flags
+	}
+	return 0
+}
+
+func (x *LsAttributePrefixSID) GetSid() uint32 {
+	if x != nil {
+		return x.Sid
+	}
+	return 0
+}
+
+// LsAttributeFADPrefixMetric is one FAPM TLV (RFC 9351 Section 4)
+// projected onto the LsAttribute surface.
+type LsAttributeFADPrefixMetric struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Algorithm     uint32                 `protobuf:"varint,1,opt,name=algorithm,proto3" json:"algorithm,omitempty"`
+	Flags         uint32                 `protobuf:"varint,2,opt,name=flags,proto3" json:"flags,omitempty"`
+	Metric        uint32                 `protobuf:"varint,3,opt,name=metric,proto3" json:"metric,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LsAttributeFADPrefixMetric) Reset() {
+	*x = LsAttributeFADPrefixMetric{}
+	mi := &file_api_attribute_proto_msgTypes[57]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LsAttributeFADPrefixMetric) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LsAttributeFADPrefixMetric) ProtoMessage() {}
+
+func (x *LsAttributeFADPrefixMetric) ProtoReflect() protoreflect.Message {
+	mi := &file_api_attribute_proto_msgTypes[57]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LsAttributeFADPrefixMetric.ProtoReflect.Descriptor instead.
+func (*LsAttributeFADPrefixMetric) Descriptor() ([]byte, []int) {
+	return file_api_attribute_proto_rawDescGZIP(), []int{57}
+}
+
+func (x *LsAttributeFADPrefixMetric) GetAlgorithm() uint32 {
+	if x != nil {
+		return x.Algorithm
+	}
+	return 0
+}
+
+func (x *LsAttributeFADPrefixMetric) GetFlags() uint32 {
+	if x != nil {
+		return x.Flags
+	}
+	return 0
+}
+
+func (x *LsAttributeFADPrefixMetric) GetMetric() uint32 {
+	if x != nil {
+		return x.Metric
+	}
+	return 0
+}
+
 type LsBgpPeerSegmentSIDFlags struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Value         bool                   `protobuf:"varint,1,opt,name=value,proto3" json:"value,omitempty"`
@@ -3793,7 +4076,7 @@ type LsBgpPeerSegmentSIDFlags struct {
 
 func (x *LsBgpPeerSegmentSIDFlags) Reset() {
 	*x = LsBgpPeerSegmentSIDFlags{}
-	mi := &file_api_attribute_proto_msgTypes[55]
+	mi := &file_api_attribute_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3805,7 +4088,7 @@ func (x *LsBgpPeerSegmentSIDFlags) String() string {
 func (*LsBgpPeerSegmentSIDFlags) ProtoMessage() {}
 
 func (x *LsBgpPeerSegmentSIDFlags) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[55]
+	mi := &file_api_attribute_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3818,7 +4101,7 @@ func (x *LsBgpPeerSegmentSIDFlags) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsBgpPeerSegmentSIDFlags.ProtoReflect.Descriptor instead.
 func (*LsBgpPeerSegmentSIDFlags) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{55}
+	return file_api_attribute_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *LsBgpPeerSegmentSIDFlags) GetValue() bool {
@@ -3860,7 +4143,7 @@ type LsBgpPeerSegmentSID struct {
 
 func (x *LsBgpPeerSegmentSID) Reset() {
 	*x = LsBgpPeerSegmentSID{}
-	mi := &file_api_attribute_proto_msgTypes[56]
+	mi := &file_api_attribute_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3872,7 +4155,7 @@ func (x *LsBgpPeerSegmentSID) String() string {
 func (*LsBgpPeerSegmentSID) ProtoMessage() {}
 
 func (x *LsBgpPeerSegmentSID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[56]
+	mi := &file_api_attribute_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3885,7 +4168,7 @@ func (x *LsBgpPeerSegmentSID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsBgpPeerSegmentSID.ProtoReflect.Descriptor instead.
 func (*LsBgpPeerSegmentSID) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{56}
+	return file_api_attribute_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *LsBgpPeerSegmentSID) GetFlags() *LsBgpPeerSegmentSIDFlags {
@@ -3920,7 +4203,7 @@ type LsAttributeBgpPeerSegment struct {
 
 func (x *LsAttributeBgpPeerSegment) Reset() {
 	*x = LsAttributeBgpPeerSegment{}
-	mi := &file_api_attribute_proto_msgTypes[57]
+	mi := &file_api_attribute_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3932,7 +4215,7 @@ func (x *LsAttributeBgpPeerSegment) String() string {
 func (*LsAttributeBgpPeerSegment) ProtoMessage() {}
 
 func (x *LsAttributeBgpPeerSegment) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[57]
+	mi := &file_api_attribute_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3945,7 +4228,7 @@ func (x *LsAttributeBgpPeerSegment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsAttributeBgpPeerSegment.ProtoReflect.Descriptor instead.
 func (*LsAttributeBgpPeerSegment) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{57}
+	return file_api_attribute_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *LsAttributeBgpPeerSegment) GetBgpPeerNodeSid() *LsBgpPeerSegmentSID {
@@ -3984,7 +4267,7 @@ type LsSrv6EndXSID struct {
 
 func (x *LsSrv6EndXSID) Reset() {
 	*x = LsSrv6EndXSID{}
-	mi := &file_api_attribute_proto_msgTypes[58]
+	mi := &file_api_attribute_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3996,7 +4279,7 @@ func (x *LsSrv6EndXSID) String() string {
 func (*LsSrv6EndXSID) ProtoMessage() {}
 
 func (x *LsSrv6EndXSID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[58]
+	mi := &file_api_attribute_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4009,7 +4292,7 @@ func (x *LsSrv6EndXSID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsSrv6EndXSID.ProtoReflect.Descriptor instead.
 func (*LsSrv6EndXSID) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{58}
+	return file_api_attribute_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *LsSrv6EndXSID) GetEndpointBehavior() uint32 {
@@ -4073,7 +4356,7 @@ type LsSrv6SIDStructure struct {
 
 func (x *LsSrv6SIDStructure) Reset() {
 	*x = LsSrv6SIDStructure{}
-	mi := &file_api_attribute_proto_msgTypes[59]
+	mi := &file_api_attribute_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4085,7 +4368,7 @@ func (x *LsSrv6SIDStructure) String() string {
 func (*LsSrv6SIDStructure) ProtoMessage() {}
 
 func (x *LsSrv6SIDStructure) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[59]
+	mi := &file_api_attribute_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4098,7 +4381,7 @@ func (x *LsSrv6SIDStructure) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsSrv6SIDStructure.ProtoReflect.Descriptor instead.
 func (*LsSrv6SIDStructure) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{59}
+	return file_api_attribute_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *LsSrv6SIDStructure) GetLocalBlock() uint32 {
@@ -4140,7 +4423,7 @@ type LsSrv6EndpointBehavior struct {
 
 func (x *LsSrv6EndpointBehavior) Reset() {
 	*x = LsSrv6EndpointBehavior{}
-	mi := &file_api_attribute_proto_msgTypes[60]
+	mi := &file_api_attribute_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4152,7 +4435,7 @@ func (x *LsSrv6EndpointBehavior) String() string {
 func (*LsSrv6EndpointBehavior) ProtoMessage() {}
 
 func (x *LsSrv6EndpointBehavior) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[60]
+	mi := &file_api_attribute_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4165,7 +4448,7 @@ func (x *LsSrv6EndpointBehavior) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsSrv6EndpointBehavior.ProtoReflect.Descriptor instead.
 func (*LsSrv6EndpointBehavior) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{60}
+	return file_api_attribute_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *LsSrv6EndpointBehavior) GetEndpointBehavior() uint32 {
@@ -4201,7 +4484,7 @@ type LsSrv6BgpPeerNodeSID struct {
 
 func (x *LsSrv6BgpPeerNodeSID) Reset() {
 	*x = LsSrv6BgpPeerNodeSID{}
-	mi := &file_api_attribute_proto_msgTypes[61]
+	mi := &file_api_attribute_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4213,7 +4496,7 @@ func (x *LsSrv6BgpPeerNodeSID) String() string {
 func (*LsSrv6BgpPeerNodeSID) ProtoMessage() {}
 
 func (x *LsSrv6BgpPeerNodeSID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[61]
+	mi := &file_api_attribute_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4226,7 +4509,7 @@ func (x *LsSrv6BgpPeerNodeSID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsSrv6BgpPeerNodeSID.ProtoReflect.Descriptor instead.
 func (*LsSrv6BgpPeerNodeSID) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{61}
+	return file_api_attribute_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *LsSrv6BgpPeerNodeSID) GetFlags() uint32 {
@@ -4268,7 +4551,7 @@ type LsAttributeSrv6SID struct {
 
 func (x *LsAttributeSrv6SID) Reset() {
 	*x = LsAttributeSrv6SID{}
-	mi := &file_api_attribute_proto_msgTypes[62]
+	mi := &file_api_attribute_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4280,7 +4563,7 @@ func (x *LsAttributeSrv6SID) String() string {
 func (*LsAttributeSrv6SID) ProtoMessage() {}
 
 func (x *LsAttributeSrv6SID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[62]
+	mi := &file_api_attribute_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4293,7 +4576,7 @@ func (x *LsAttributeSrv6SID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsAttributeSrv6SID.ProtoReflect.Descriptor instead.
 func (*LsAttributeSrv6SID) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{62}
+	return file_api_attribute_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *LsAttributeSrv6SID) GetSrv6SidStructure() *LsSrv6SIDStructure {
@@ -4330,7 +4613,7 @@ type LsAttribute struct {
 
 func (x *LsAttribute) Reset() {
 	*x = LsAttribute{}
-	mi := &file_api_attribute_proto_msgTypes[63]
+	mi := &file_api_attribute_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4342,7 +4625,7 @@ func (x *LsAttribute) String() string {
 func (*LsAttribute) ProtoMessage() {}
 
 func (x *LsAttribute) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[63]
+	mi := &file_api_attribute_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4355,7 +4638,7 @@ func (x *LsAttribute) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LsAttribute.ProtoReflect.Descriptor instead.
 func (*LsAttribute) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{63}
+	return file_api_attribute_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *LsAttribute) GetNode() *LsAttributeNode {
@@ -4404,7 +4687,7 @@ type UnknownAttribute struct {
 
 func (x *UnknownAttribute) Reset() {
 	*x = UnknownAttribute{}
-	mi := &file_api_attribute_proto_msgTypes[64]
+	mi := &file_api_attribute_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4416,7 +4699,7 @@ func (x *UnknownAttribute) String() string {
 func (*UnknownAttribute) ProtoMessage() {}
 
 func (x *UnknownAttribute) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[64]
+	mi := &file_api_attribute_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4429,7 +4712,7 @@ func (x *UnknownAttribute) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnknownAttribute.ProtoReflect.Descriptor instead.
 func (*UnknownAttribute) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{64}
+	return file_api_attribute_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *UnknownAttribute) GetFlags() uint32 {
@@ -4468,7 +4751,7 @@ type SRv6StructureSubSubTLV struct {
 
 func (x *SRv6StructureSubSubTLV) Reset() {
 	*x = SRv6StructureSubSubTLV{}
-	mi := &file_api_attribute_proto_msgTypes[65]
+	mi := &file_api_attribute_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4480,7 +4763,7 @@ func (x *SRv6StructureSubSubTLV) String() string {
 func (*SRv6StructureSubSubTLV) ProtoMessage() {}
 
 func (x *SRv6StructureSubSubTLV) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[65]
+	mi := &file_api_attribute_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4493,7 +4776,7 @@ func (x *SRv6StructureSubSubTLV) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SRv6StructureSubSubTLV.ProtoReflect.Descriptor instead.
 func (*SRv6StructureSubSubTLV) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{65}
+	return file_api_attribute_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *SRv6StructureSubSubTLV) GetLocatorBlockLength() uint32 {
@@ -4550,7 +4833,7 @@ type SRv6SubSubTLV struct {
 
 func (x *SRv6SubSubTLV) Reset() {
 	*x = SRv6SubSubTLV{}
-	mi := &file_api_attribute_proto_msgTypes[66]
+	mi := &file_api_attribute_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4562,7 +4845,7 @@ func (x *SRv6SubSubTLV) String() string {
 func (*SRv6SubSubTLV) ProtoMessage() {}
 
 func (x *SRv6SubSubTLV) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[66]
+	mi := &file_api_attribute_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4575,7 +4858,7 @@ func (x *SRv6SubSubTLV) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SRv6SubSubTLV.ProtoReflect.Descriptor instead.
 func (*SRv6SubSubTLV) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{66}
+	return file_api_attribute_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *SRv6SubSubTLV) GetTlv() isSRv6SubSubTLV_Tlv {
@@ -4613,7 +4896,7 @@ type SRv6SubSubTLVs struct {
 
 func (x *SRv6SubSubTLVs) Reset() {
 	*x = SRv6SubSubTLVs{}
-	mi := &file_api_attribute_proto_msgTypes[67]
+	mi := &file_api_attribute_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4625,7 +4908,7 @@ func (x *SRv6SubSubTLVs) String() string {
 func (*SRv6SubSubTLVs) ProtoMessage() {}
 
 func (x *SRv6SubSubTLVs) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[67]
+	mi := &file_api_attribute_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4638,7 +4921,7 @@ func (x *SRv6SubSubTLVs) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SRv6SubSubTLVs.ProtoReflect.Descriptor instead.
 func (*SRv6SubSubTLVs) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{67}
+	return file_api_attribute_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *SRv6SubSubTLVs) GetTlvs() []*SRv6SubSubTLV {
@@ -4658,7 +4941,7 @@ type SRv6SIDFlags struct {
 
 func (x *SRv6SIDFlags) Reset() {
 	*x = SRv6SIDFlags{}
-	mi := &file_api_attribute_proto_msgTypes[68]
+	mi := &file_api_attribute_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4670,7 +4953,7 @@ func (x *SRv6SIDFlags) String() string {
 func (*SRv6SIDFlags) ProtoMessage() {}
 
 func (x *SRv6SIDFlags) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[68]
+	mi := &file_api_attribute_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4683,7 +4966,7 @@ func (x *SRv6SIDFlags) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SRv6SIDFlags.ProtoReflect.Descriptor instead.
 func (*SRv6SIDFlags) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{68}
+	return file_api_attribute_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *SRv6SIDFlags) GetFlag_1() bool {
@@ -4706,7 +4989,7 @@ type SRv6InformationSubTLV struct {
 
 func (x *SRv6InformationSubTLV) Reset() {
 	*x = SRv6InformationSubTLV{}
-	mi := &file_api_attribute_proto_msgTypes[69]
+	mi := &file_api_attribute_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4718,7 +5001,7 @@ func (x *SRv6InformationSubTLV) String() string {
 func (*SRv6InformationSubTLV) ProtoMessage() {}
 
 func (x *SRv6InformationSubTLV) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[69]
+	mi := &file_api_attribute_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4731,7 +5014,7 @@ func (x *SRv6InformationSubTLV) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SRv6InformationSubTLV.ProtoReflect.Descriptor instead.
 func (*SRv6InformationSubTLV) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{69}
+	return file_api_attribute_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *SRv6InformationSubTLV) GetSid() []byte {
@@ -4774,7 +5057,7 @@ type SRv6SubTLV struct {
 
 func (x *SRv6SubTLV) Reset() {
 	*x = SRv6SubTLV{}
-	mi := &file_api_attribute_proto_msgTypes[70]
+	mi := &file_api_attribute_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4786,7 +5069,7 @@ func (x *SRv6SubTLV) String() string {
 func (*SRv6SubTLV) ProtoMessage() {}
 
 func (x *SRv6SubTLV) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[70]
+	mi := &file_api_attribute_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4799,7 +5082,7 @@ func (x *SRv6SubTLV) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SRv6SubTLV.ProtoReflect.Descriptor instead.
 func (*SRv6SubTLV) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{70}
+	return file_api_attribute_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *SRv6SubTLV) GetTlv() isSRv6SubTLV_Tlv {
@@ -4837,7 +5120,7 @@ type SRv6SubTLVs struct {
 
 func (x *SRv6SubTLVs) Reset() {
 	*x = SRv6SubTLVs{}
-	mi := &file_api_attribute_proto_msgTypes[71]
+	mi := &file_api_attribute_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4849,7 +5132,7 @@ func (x *SRv6SubTLVs) String() string {
 func (*SRv6SubTLVs) ProtoMessage() {}
 
 func (x *SRv6SubTLVs) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[71]
+	mi := &file_api_attribute_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4862,7 +5145,7 @@ func (x *SRv6SubTLVs) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SRv6SubTLVs.ProtoReflect.Descriptor instead.
 func (*SRv6SubTLVs) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{71}
+	return file_api_attribute_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *SRv6SubTLVs) GetTlvs() []*SRv6SubTLV {
@@ -4882,7 +5165,7 @@ type SRv6L3ServiceTLV struct {
 
 func (x *SRv6L3ServiceTLV) Reset() {
 	*x = SRv6L3ServiceTLV{}
-	mi := &file_api_attribute_proto_msgTypes[72]
+	mi := &file_api_attribute_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4894,7 +5177,7 @@ func (x *SRv6L3ServiceTLV) String() string {
 func (*SRv6L3ServiceTLV) ProtoMessage() {}
 
 func (x *SRv6L3ServiceTLV) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[72]
+	mi := &file_api_attribute_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4907,7 +5190,7 @@ func (x *SRv6L3ServiceTLV) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SRv6L3ServiceTLV.ProtoReflect.Descriptor instead.
 func (*SRv6L3ServiceTLV) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{72}
+	return file_api_attribute_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *SRv6L3ServiceTLV) GetSubTlvs() map[uint32]*SRv6SubTLVs {
@@ -4927,7 +5210,7 @@ type SRv6L2ServiceTLV struct {
 
 func (x *SRv6L2ServiceTLV) Reset() {
 	*x = SRv6L2ServiceTLV{}
-	mi := &file_api_attribute_proto_msgTypes[73]
+	mi := &file_api_attribute_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4939,7 +5222,7 @@ func (x *SRv6L2ServiceTLV) String() string {
 func (*SRv6L2ServiceTLV) ProtoMessage() {}
 
 func (x *SRv6L2ServiceTLV) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[73]
+	mi := &file_api_attribute_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4952,7 +5235,7 @@ func (x *SRv6L2ServiceTLV) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SRv6L2ServiceTLV.ProtoReflect.Descriptor instead.
 func (*SRv6L2ServiceTLV) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{73}
+	return file_api_attribute_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *SRv6L2ServiceTLV) GetSubTlvs() map[uint32]*SRv6SubTLVs {
@@ -4972,7 +5255,7 @@ type PrefixSID struct {
 
 func (x *PrefixSID) Reset() {
 	*x = PrefixSID{}
-	mi := &file_api_attribute_proto_msgTypes[74]
+	mi := &file_api_attribute_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4984,7 +5267,7 @@ func (x *PrefixSID) String() string {
 func (*PrefixSID) ProtoMessage() {}
 
 func (x *PrefixSID) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[74]
+	mi := &file_api_attribute_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4997,7 +5280,7 @@ func (x *PrefixSID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrefixSID.ProtoReflect.Descriptor instead.
 func (*PrefixSID) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{74}
+	return file_api_attribute_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *PrefixSID) GetTlvs() []*PrefixSID_TLV {
@@ -5020,7 +5303,7 @@ type TunnelEncapSubTLVSRSegmentList_Segment struct {
 
 func (x *TunnelEncapSubTLVSRSegmentList_Segment) Reset() {
 	*x = TunnelEncapSubTLVSRSegmentList_Segment{}
-	mi := &file_api_attribute_proto_msgTypes[75]
+	mi := &file_api_attribute_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5032,7 +5315,7 @@ func (x *TunnelEncapSubTLVSRSegmentList_Segment) String() string {
 func (*TunnelEncapSubTLVSRSegmentList_Segment) ProtoMessage() {}
 
 func (x *TunnelEncapSubTLVSRSegmentList_Segment) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[75]
+	mi := &file_api_attribute_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5112,7 +5395,7 @@ type TunnelEncapTLV_TLV struct {
 
 func (x *TunnelEncapTLV_TLV) Reset() {
 	*x = TunnelEncapTLV_TLV{}
-	mi := &file_api_attribute_proto_msgTypes[76]
+	mi := &file_api_attribute_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5124,7 +5407,7 @@ func (x *TunnelEncapTLV_TLV) String() string {
 func (*TunnelEncapTLV_TLV) ProtoMessage() {}
 
 func (x *TunnelEncapTLV_TLV) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[76]
+	mi := &file_api_attribute_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5344,7 +5627,7 @@ type IP6ExtendedCommunitiesAttribute_Community struct {
 
 func (x *IP6ExtendedCommunitiesAttribute_Community) Reset() {
 	*x = IP6ExtendedCommunitiesAttribute_Community{}
-	mi := &file_api_attribute_proto_msgTypes[77]
+	mi := &file_api_attribute_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5356,7 +5639,7 @@ func (x *IP6ExtendedCommunitiesAttribute_Community) String() string {
 func (*IP6ExtendedCommunitiesAttribute_Community) ProtoMessage() {}
 
 func (x *IP6ExtendedCommunitiesAttribute_Community) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[77]
+	mi := &file_api_attribute_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5428,7 +5711,7 @@ type AigpAttribute_TLV struct {
 
 func (x *AigpAttribute_TLV) Reset() {
 	*x = AigpAttribute_TLV{}
-	mi := &file_api_attribute_proto_msgTypes[78]
+	mi := &file_api_attribute_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5440,7 +5723,7 @@ func (x *AigpAttribute_TLV) String() string {
 func (*AigpAttribute_TLV) ProtoMessage() {}
 
 func (x *AigpAttribute_TLV) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[78]
+	mi := &file_api_attribute_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5511,7 +5794,7 @@ type PrefixSID_TLV struct {
 
 func (x *PrefixSID_TLV) Reset() {
 	*x = PrefixSID_TLV{}
-	mi := &file_api_attribute_proto_msgTypes[82]
+	mi := &file_api_attribute_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5523,7 +5806,7 @@ func (x *PrefixSID_TLV) String() string {
 func (*PrefixSID_TLV) ProtoMessage() {}
 
 func (x *PrefixSID_TLV) ProtoReflect() protoreflect.Message {
-	mi := &file_api_attribute_proto_msgTypes[82]
+	mi := &file_api_attribute_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5536,7 +5819,7 @@ func (x *PrefixSID_TLV) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PrefixSID_TLV.ProtoReflect.Descriptor instead.
 func (*PrefixSID_TLV) Descriptor() ([]byte, []int) {
-	return file_api_attribute_proto_rawDescGZIP(), []int{74, 0}
+	return file_api_attribute_proto_rawDescGZIP(), []int{77, 0}
 }
 
 func (x *PrefixSID_TLV) GetTlv() isPrefixSID_TLV_Tlv {
@@ -5815,7 +6098,7 @@ const file_api_attribute_proto_rawDesc = "" +
 	"\x0eipv6_supported\x18\x02 \x01(\bR\ripv6Supported\x12&\n" +
 	"\x06ranges\x18\x03 \x03(\v2\x0e.api.LsSrRangeR\x06ranges\"8\n" +
 	"\x0eLsSrLocalBlock\x12&\n" +
-	"\x06ranges\x18\x01 \x03(\v2\x0e.api.LsSrRangeR\x06ranges\"\xf7\x02\n" +
+	"\x06ranges\x18\x01 \x03(\v2\x0e.api.LsSrRangeR\x06ranges\"\xba\x03\n" +
 	"\x0fLsAttributeNode\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12&\n" +
 	"\x05flags\x18\x02 \x01(\v2\x10.api.LsNodeFlagsR\x05flags\x12&\n" +
@@ -5825,7 +6108,22 @@ const file_api_attribute_proto_rawDesc = "" +
 	"\x06opaque\x18\x06 \x01(\fR\x06opaque\x12>\n" +
 	"\x0fsr_capabilities\x18\a \x01(\v2\x15.api.LsSrCapabilitiesR\x0esrCapabilities\x12#\n" +
 	"\rsr_algorithms\x18\b \x01(\fR\fsrAlgorithms\x129\n" +
-	"\x0esr_local_block\x18\t \x01(\v2\x13.api.LsSrLocalBlockR\fsrLocalBlock\"\x88\b\n" +
+	"\x0esr_local_block\x18\t \x01(\v2\x13.api.LsSrLocalBlockR\fsrLocalBlock\x12A\n" +
+	"\x0eflex_algo_defs\x18\n" +
+	" \x03(\v2\x1b.api.LsAttributeFlexAlgoDefR\fflexAlgoDefs\"\xa0\x03\n" +
+	"\x16LsAttributeFlexAlgoDef\x12\x1c\n" +
+	"\talgorithm\x18\x01 \x01(\rR\talgorithm\x12\x1f\n" +
+	"\vmetric_type\x18\x02 \x01(\rR\n" +
+	"metricType\x12*\n" +
+	"\x11metric_type_known\x18\x03 \x01(\bR\x0fmetricTypeKnown\x12\x1b\n" +
+	"\tcalc_type\x18\x04 \x01(\rR\bcalcType\x12\x1a\n" +
+	"\bpriority\x18\x05 \x01(\rR\bpriority\x120\n" +
+	"\x14exclude_any_affinity\x18\x06 \x03(\rR\x12excludeAnyAffinity\x120\n" +
+	"\x14include_any_affinity\x18\a \x03(\rR\x12includeAnyAffinity\x120\n" +
+	"\x14include_all_affinity\x18\b \x03(\rR\x12includeAllAffinity\x12)\n" +
+	"\x10definition_flags\x18\t \x01(\fR\x0fdefinitionFlags\x12!\n" +
+	"\fexclude_srlg\x18\n" +
+	" \x03(\rR\vexcludeSrlg\"\x88\b\n" +
 	"\x0fLsAttributeLink\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12&\n" +
 	"\x0flocal_router_id\x18\x02 \x01(\tR\rlocalRouterId\x12+\n" +
@@ -5850,11 +6148,21 @@ const file_api_attribute_proto_rawDesc = "" +
 	"+min_max_unidirectional_link_delay_anomalous\x18\x12 \x01(\bR&minMaxUnidirectionalLinkDelayAnomalous\x12A\n" +
 	"\x1dmin_unidirectional_link_delay\x18\x13 \x01(\rR\x1aminUnidirectionalLinkDelay\x12A\n" +
 	"\x1dmax_unidirectional_link_delay\x18\x14 \x01(\rR\x1amaxUnidirectionalLinkDelay\x12D\n" +
-	"\x1eunidirectional_delay_variation\x18\x15 \x01(\rR\x1cunidirectionalDelayVariation\"}\n" +
+	"\x1eunidirectional_delay_variation\x18\x15 \x01(\rR\x1cunidirectionalDelayVariation\"\x8d\x02\n" +
 	"\x11LsAttributePrefix\x12,\n" +
 	"\tigp_flags\x18\x01 \x01(\v2\x0f.api.LsIGPFlagsR\bigpFlags\x12\x16\n" +
 	"\x06opaque\x18\x02 \x01(\fR\x06opaque\x12\"\n" +
-	"\rsr_prefix_sid\x18\x03 \x01(\rR\vsrPrefixSid\"~\n" +
+	"\rsr_prefix_sid\x18\x03 \x01(\rR\vsrPrefixSid\x12?\n" +
+	"\x0esr_prefix_sids\x18\x04 \x03(\v2\x19.api.LsAttributePrefixSIDR\fsrPrefixSids\x12M\n" +
+	"\x12fad_prefix_metrics\x18\x05 \x03(\v2\x1f.api.LsAttributeFADPrefixMetricR\x10fadPrefixMetrics\"\\\n" +
+	"\x14LsAttributePrefixSID\x12\x1c\n" +
+	"\talgorithm\x18\x01 \x01(\rR\talgorithm\x12\x14\n" +
+	"\x05flags\x18\x02 \x01(\rR\x05flags\x12\x10\n" +
+	"\x03sid\x18\x03 \x01(\rR\x03sid\"h\n" +
+	"\x1aLsAttributeFADPrefixMetric\x12\x1c\n" +
+	"\talgorithm\x18\x01 \x01(\rR\talgorithm\x12\x14\n" +
+	"\x05flags\x18\x02 \x01(\rR\x05flags\x12\x16\n" +
+	"\x06metric\x18\x03 \x01(\rR\x06metric\"~\n" +
 	"\x18LsBgpPeerSegmentSIDFlags\x12\x14\n" +
 	"\x05value\x18\x01 \x01(\bR\x05value\x12\x14\n" +
 	"\x05local\x18\x02 \x01(\bR\x05local\x12\x16\n" +
@@ -6020,7 +6328,7 @@ func file_api_attribute_proto_rawDescGZIP() []byte {
 }
 
 var file_api_attribute_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_api_attribute_proto_msgTypes = make([]protoimpl.MessageInfo, 83)
+var file_api_attribute_proto_msgTypes = make([]protoimpl.MessageInfo, 86)
 var file_api_attribute_proto_goTypes = []any{
 	(SRV6Behavior)(0),                                 // 0: api.SRV6Behavior
 	(ENLPType)(0),                                     // 1: api.ENLPType
@@ -6078,144 +6386,150 @@ var file_api_attribute_proto_goTypes = []any{
 	(*LsSrCapabilities)(nil),                          // 53: api.LsSrCapabilities
 	(*LsSrLocalBlock)(nil),                            // 54: api.LsSrLocalBlock
 	(*LsAttributeNode)(nil),                           // 55: api.LsAttributeNode
-	(*LsAttributeLink)(nil),                           // 56: api.LsAttributeLink
-	(*LsAttributePrefix)(nil),                         // 57: api.LsAttributePrefix
-	(*LsBgpPeerSegmentSIDFlags)(nil),                  // 58: api.LsBgpPeerSegmentSIDFlags
-	(*LsBgpPeerSegmentSID)(nil),                       // 59: api.LsBgpPeerSegmentSID
-	(*LsAttributeBgpPeerSegment)(nil),                 // 60: api.LsAttributeBgpPeerSegment
-	(*LsSrv6EndXSID)(nil),                             // 61: api.LsSrv6EndXSID
-	(*LsSrv6SIDStructure)(nil),                        // 62: api.LsSrv6SIDStructure
-	(*LsSrv6EndpointBehavior)(nil),                    // 63: api.LsSrv6EndpointBehavior
-	(*LsSrv6BgpPeerNodeSID)(nil),                      // 64: api.LsSrv6BgpPeerNodeSID
-	(*LsAttributeSrv6SID)(nil),                        // 65: api.LsAttributeSrv6SID
-	(*LsAttribute)(nil),                               // 66: api.LsAttribute
-	(*UnknownAttribute)(nil),                          // 67: api.UnknownAttribute
-	(*SRv6StructureSubSubTLV)(nil),                    // 68: api.SRv6StructureSubSubTLV
-	(*SRv6SubSubTLV)(nil),                             // 69: api.SRv6SubSubTLV
-	(*SRv6SubSubTLVs)(nil),                            // 70: api.SRv6SubSubTLVs
-	(*SRv6SIDFlags)(nil),                              // 71: api.SRv6SIDFlags
-	(*SRv6InformationSubTLV)(nil),                     // 72: api.SRv6InformationSubTLV
-	(*SRv6SubTLV)(nil),                                // 73: api.SRv6SubTLV
-	(*SRv6SubTLVs)(nil),                               // 74: api.SRv6SubTLVs
-	(*SRv6L3ServiceTLV)(nil),                          // 75: api.SRv6L3ServiceTLV
-	(*SRv6L2ServiceTLV)(nil),                          // 76: api.SRv6L2ServiceTLV
-	(*PrefixSID)(nil),                                 // 77: api.PrefixSID
-	(*TunnelEncapSubTLVSRSegmentList_Segment)(nil),    // 78: api.TunnelEncapSubTLVSRSegmentList.Segment
-	(*TunnelEncapTLV_TLV)(nil),                        // 79: api.TunnelEncapTLV.TLV
-	(*IP6ExtendedCommunitiesAttribute_Community)(nil), // 80: api.IP6ExtendedCommunitiesAttribute.Community
-	(*AigpAttribute_TLV)(nil),                         // 81: api.AigpAttribute.TLV
-	nil,                                               // 82: api.SRv6InformationSubTLV.SubSubTlvsEntry
-	nil,                                               // 83: api.SRv6L3ServiceTLV.SubTlvsEntry
-	nil,                                               // 84: api.SRv6L2ServiceTLV.SubTlvsEntry
-	(*PrefixSID_TLV)(nil),                             // 85: api.PrefixSID.TLV
-	(*Family)(nil),                                    // 86: api.Family
-	(*NLRI)(nil),                                      // 87: api.NLRI
-	(*ExtendedCommunity)(nil),                         // 88: api.ExtendedCommunity
+	(*LsAttributeFlexAlgoDef)(nil),                    // 56: api.LsAttributeFlexAlgoDef
+	(*LsAttributeLink)(nil),                           // 57: api.LsAttributeLink
+	(*LsAttributePrefix)(nil),                         // 58: api.LsAttributePrefix
+	(*LsAttributePrefixSID)(nil),                      // 59: api.LsAttributePrefixSID
+	(*LsAttributeFADPrefixMetric)(nil),                // 60: api.LsAttributeFADPrefixMetric
+	(*LsBgpPeerSegmentSIDFlags)(nil),                  // 61: api.LsBgpPeerSegmentSIDFlags
+	(*LsBgpPeerSegmentSID)(nil),                       // 62: api.LsBgpPeerSegmentSID
+	(*LsAttributeBgpPeerSegment)(nil),                 // 63: api.LsAttributeBgpPeerSegment
+	(*LsSrv6EndXSID)(nil),                             // 64: api.LsSrv6EndXSID
+	(*LsSrv6SIDStructure)(nil),                        // 65: api.LsSrv6SIDStructure
+	(*LsSrv6EndpointBehavior)(nil),                    // 66: api.LsSrv6EndpointBehavior
+	(*LsSrv6BgpPeerNodeSID)(nil),                      // 67: api.LsSrv6BgpPeerNodeSID
+	(*LsAttributeSrv6SID)(nil),                        // 68: api.LsAttributeSrv6SID
+	(*LsAttribute)(nil),                               // 69: api.LsAttribute
+	(*UnknownAttribute)(nil),                          // 70: api.UnknownAttribute
+	(*SRv6StructureSubSubTLV)(nil),                    // 71: api.SRv6StructureSubSubTLV
+	(*SRv6SubSubTLV)(nil),                             // 72: api.SRv6SubSubTLV
+	(*SRv6SubSubTLVs)(nil),                            // 73: api.SRv6SubSubTLVs
+	(*SRv6SIDFlags)(nil),                              // 74: api.SRv6SIDFlags
+	(*SRv6InformationSubTLV)(nil),                     // 75: api.SRv6InformationSubTLV
+	(*SRv6SubTLV)(nil),                                // 76: api.SRv6SubTLV
+	(*SRv6SubTLVs)(nil),                               // 77: api.SRv6SubTLVs
+	(*SRv6L3ServiceTLV)(nil),                          // 78: api.SRv6L3ServiceTLV
+	(*SRv6L2ServiceTLV)(nil),                          // 79: api.SRv6L2ServiceTLV
+	(*PrefixSID)(nil),                                 // 80: api.PrefixSID
+	(*TunnelEncapSubTLVSRSegmentList_Segment)(nil),    // 81: api.TunnelEncapSubTLVSRSegmentList.Segment
+	(*TunnelEncapTLV_TLV)(nil),                        // 82: api.TunnelEncapTLV.TLV
+	(*IP6ExtendedCommunitiesAttribute_Community)(nil), // 83: api.IP6ExtendedCommunitiesAttribute.Community
+	(*AigpAttribute_TLV)(nil),                         // 84: api.AigpAttribute.TLV
+	nil,                                               // 85: api.SRv6InformationSubTLV.SubSubTlvsEntry
+	nil,                                               // 86: api.SRv6L3ServiceTLV.SubTlvsEntry
+	nil,                                               // 87: api.SRv6L2ServiceTLV.SubTlvsEntry
+	(*PrefixSID_TLV)(nil),                             // 88: api.PrefixSID.TLV
+	(*Family)(nil),                                    // 89: api.Family
+	(*NLRI)(nil),                                      // 90: api.NLRI
+	(*ExtendedCommunity)(nil),                         // 91: api.ExtendedCommunity
 }
 var file_api_attribute_proto_depIdxs = []int32{
-	67, // 0: api.Attribute.unknown:type_name -> api.UnknownAttribute
-	4,  // 1: api.Attribute.origin:type_name -> api.OriginAttribute
-	6,  // 2: api.Attribute.as_path:type_name -> api.AsPathAttribute
-	7,  // 3: api.Attribute.next_hop:type_name -> api.NextHopAttribute
-	8,  // 4: api.Attribute.multi_exit_disc:type_name -> api.MultiExitDiscAttribute
-	9,  // 5: api.Attribute.local_pref:type_name -> api.LocalPrefAttribute
-	10, // 6: api.Attribute.atomic_aggregate:type_name -> api.AtomicAggregateAttribute
-	11, // 7: api.Attribute.aggregator:type_name -> api.AggregatorAttribute
-	12, // 8: api.Attribute.communities:type_name -> api.CommunitiesAttribute
-	13, // 9: api.Attribute.originator_id:type_name -> api.OriginatorIdAttribute
-	14, // 10: api.Attribute.cluster_list:type_name -> api.ClusterListAttribute
-	15, // 11: api.Attribute.mp_reach:type_name -> api.MpReachNLRIAttribute
-	16, // 12: api.Attribute.mp_unreach:type_name -> api.MpUnreachNLRIAttribute
-	17, // 13: api.Attribute.extended_communities:type_name -> api.ExtendedCommunitiesAttribute
-	18, // 14: api.Attribute.as4_path:type_name -> api.As4PathAttribute
-	19, // 15: api.Attribute.as4_aggregator:type_name -> api.As4AggregatorAttribute
-	20, // 16: api.Attribute.pmsi_tunnel:type_name -> api.PmsiTunnelAttribute
-	41, // 17: api.Attribute.tunnel_encap:type_name -> api.TunnelEncapAttribute
-	44, // 18: api.Attribute.ip6_extended_communities:type_name -> api.IP6ExtendedCommunitiesAttribute
-	47, // 19: api.Attribute.aigp:type_name -> api.AigpAttribute
-	49, // 20: api.Attribute.large_communities:type_name -> api.LargeCommunitiesAttribute
-	66, // 21: api.Attribute.ls:type_name -> api.LsAttribute
-	77, // 22: api.Attribute.prefix_sid:type_name -> api.PrefixSID
-	2,  // 23: api.AsSegment.type:type_name -> api.AsSegment.Type
-	5,  // 24: api.AsPathAttribute.segments:type_name -> api.AsSegment
-	86, // 25: api.MpReachNLRIAttribute.family:type_name -> api.Family
-	87, // 26: api.MpReachNLRIAttribute.nlris:type_name -> api.NLRI
-	86, // 27: api.MpUnreachNLRIAttribute.family:type_name -> api.Family
-	87, // 28: api.MpUnreachNLRIAttribute.nlris:type_name -> api.NLRI
-	88, // 29: api.ExtendedCommunitiesAttribute.communities:type_name -> api.ExtendedCommunity
-	5,  // 30: api.As4PathAttribute.segments:type_name -> api.AsSegment
-	28, // 31: api.TunnelEncapSubTLVSRBindingSID.sr_binding_sid:type_name -> api.SRBindingSID
-	30, // 32: api.TunnelEncapSubTLVSRBindingSID.srv6_binding_sid:type_name -> api.SRv6BindingSID
-	0,  // 33: api.SRv6EndPointBehavior.behavior:type_name -> api.SRV6Behavior
-	29, // 34: api.SRv6BindingSID.endpoint_behavior_structure:type_name -> api.SRv6EndPointBehavior
-	1,  // 35: api.TunnelEncapSubTLVSRENLP.enlp:type_name -> api.ENLPType
-	33, // 36: api.SegmentTypeA.flags:type_name -> api.SegmentFlags
-	33, // 37: api.SegmentTypeB.flags:type_name -> api.SegmentFlags
-	29, // 38: api.SegmentTypeB.endpoint_behavior_structure:type_name -> api.SRv6EndPointBehavior
-	32, // 39: api.TunnelEncapSubTLVSRSegmentList.weight:type_name -> api.SRWeight
-	78, // 40: api.TunnelEncapSubTLVSRSegmentList.segments:type_name -> api.TunnelEncapSubTLVSRSegmentList.Segment
-	79, // 41: api.TunnelEncapTLV.tlvs:type_name -> api.TunnelEncapTLV.TLV
-	40, // 42: api.TunnelEncapAttribute.tlvs:type_name -> api.TunnelEncapTLV
-	80, // 43: api.IP6ExtendedCommunitiesAttribute.communities:type_name -> api.IP6ExtendedCommunitiesAttribute.Community
-	81, // 44: api.AigpAttribute.tlvs:type_name -> api.AigpAttribute.TLV
-	48, // 45: api.LargeCommunitiesAttribute.communities:type_name -> api.LargeCommunity
-	52, // 46: api.LsSrCapabilities.ranges:type_name -> api.LsSrRange
-	52, // 47: api.LsSrLocalBlock.ranges:type_name -> api.LsSrRange
-	50, // 48: api.LsAttributeNode.flags:type_name -> api.LsNodeFlags
-	53, // 49: api.LsAttributeNode.sr_capabilities:type_name -> api.LsSrCapabilities
-	54, // 50: api.LsAttributeNode.sr_local_block:type_name -> api.LsSrLocalBlock
-	61, // 51: api.LsAttributeLink.srv6_end_x_sid:type_name -> api.LsSrv6EndXSID
-	51, // 52: api.LsAttributePrefix.igp_flags:type_name -> api.LsIGPFlags
-	58, // 53: api.LsBgpPeerSegmentSID.flags:type_name -> api.LsBgpPeerSegmentSIDFlags
-	59, // 54: api.LsAttributeBgpPeerSegment.bgp_peer_node_sid:type_name -> api.LsBgpPeerSegmentSID
-	59, // 55: api.LsAttributeBgpPeerSegment.bgp_peer_adjacency_sid:type_name -> api.LsBgpPeerSegmentSID
-	59, // 56: api.LsAttributeBgpPeerSegment.bgp_peer_set_sid:type_name -> api.LsBgpPeerSegmentSID
-	62, // 57: api.LsSrv6EndXSID.srv6_sid_structure:type_name -> api.LsSrv6SIDStructure
-	62, // 58: api.LsAttributeSrv6SID.srv6_sid_structure:type_name -> api.LsSrv6SIDStructure
-	63, // 59: api.LsAttributeSrv6SID.srv6_endpoint_behavior:type_name -> api.LsSrv6EndpointBehavior
-	64, // 60: api.LsAttributeSrv6SID.srv6_bgp_peer_node_sid:type_name -> api.LsSrv6BgpPeerNodeSID
-	55, // 61: api.LsAttribute.node:type_name -> api.LsAttributeNode
-	56, // 62: api.LsAttribute.link:type_name -> api.LsAttributeLink
-	57, // 63: api.LsAttribute.prefix:type_name -> api.LsAttributePrefix
-	60, // 64: api.LsAttribute.bgp_peer_segment:type_name -> api.LsAttributeBgpPeerSegment
-	65, // 65: api.LsAttribute.srv6_sid:type_name -> api.LsAttributeSrv6SID
-	68, // 66: api.SRv6SubSubTLV.structure:type_name -> api.SRv6StructureSubSubTLV
-	69, // 67: api.SRv6SubSubTLVs.tlvs:type_name -> api.SRv6SubSubTLV
-	71, // 68: api.SRv6InformationSubTLV.flags:type_name -> api.SRv6SIDFlags
-	82, // 69: api.SRv6InformationSubTLV.sub_sub_tlvs:type_name -> api.SRv6InformationSubTLV.SubSubTlvsEntry
-	72, // 70: api.SRv6SubTLV.information:type_name -> api.SRv6InformationSubTLV
-	73, // 71: api.SRv6SubTLVs.tlvs:type_name -> api.SRv6SubTLV
-	83, // 72: api.SRv6L3ServiceTLV.sub_tlvs:type_name -> api.SRv6L3ServiceTLV.SubTlvsEntry
-	84, // 73: api.SRv6L2ServiceTLV.sub_tlvs:type_name -> api.SRv6L2ServiceTLV.SubTlvsEntry
-	85, // 74: api.PrefixSID.tlvs:type_name -> api.PrefixSID.TLV
-	34, // 75: api.TunnelEncapSubTLVSRSegmentList.Segment.a:type_name -> api.SegmentTypeA
-	35, // 76: api.TunnelEncapSubTLVSRSegmentList.Segment.b:type_name -> api.SegmentTypeB
-	39, // 77: api.TunnelEncapTLV.TLV.unknown:type_name -> api.TunnelEncapSubTLVUnknown
-	21, // 78: api.TunnelEncapTLV.TLV.encapsulation:type_name -> api.TunnelEncapSubTLVEncapsulation
-	22, // 79: api.TunnelEncapTLV.TLV.protocol:type_name -> api.TunnelEncapSubTLVProtocol
-	23, // 80: api.TunnelEncapTLV.TLV.color:type_name -> api.TunnelEncapSubTLVColor
-	37, // 81: api.TunnelEncapTLV.TLV.egress_endpoint:type_name -> api.TunnelEncapSubTLVEgressEndpoint
-	38, // 82: api.TunnelEncapTLV.TLV.udp_dest_port:type_name -> api.TunnelEncapSubTLVUDPDestPort
-	24, // 83: api.TunnelEncapTLV.TLV.sr_preference:type_name -> api.TunnelEncapSubTLVSRPreference
-	26, // 84: api.TunnelEncapTLV.TLV.sr_priority:type_name -> api.TunnelEncapSubTLVSRPriority
-	25, // 85: api.TunnelEncapTLV.TLV.sr_candidate_path_name:type_name -> api.TunnelEncapSubTLVSRCandidatePathName
-	31, // 86: api.TunnelEncapTLV.TLV.sr_enlp:type_name -> api.TunnelEncapSubTLVSRENLP
-	27, // 87: api.TunnelEncapTLV.TLV.sr_binding_sid:type_name -> api.TunnelEncapSubTLVSRBindingSID
-	36, // 88: api.TunnelEncapTLV.TLV.sr_segment_list:type_name -> api.TunnelEncapSubTLVSRSegmentList
-	42, // 89: api.IP6ExtendedCommunitiesAttribute.Community.ipv6_address_specific:type_name -> api.IPv6AddressSpecificExtended
-	43, // 90: api.IP6ExtendedCommunitiesAttribute.Community.redirect_ipv6_address_specific:type_name -> api.RedirectIPv6AddressSpecificExtended
-	46, // 91: api.AigpAttribute.TLV.unknown:type_name -> api.AigpTLVUnknown
-	45, // 92: api.AigpAttribute.TLV.igp_metric:type_name -> api.AigpTLVIGPMetric
-	70, // 93: api.SRv6InformationSubTLV.SubSubTlvsEntry.value:type_name -> api.SRv6SubSubTLVs
-	74, // 94: api.SRv6L3ServiceTLV.SubTlvsEntry.value:type_name -> api.SRv6SubTLVs
-	74, // 95: api.SRv6L2ServiceTLV.SubTlvsEntry.value:type_name -> api.SRv6SubTLVs
-	75, // 96: api.PrefixSID.TLV.l3_service:type_name -> api.SRv6L3ServiceTLV
-	76, // 97: api.PrefixSID.TLV.l2_service:type_name -> api.SRv6L2ServiceTLV
-	98, // [98:98] is the sub-list for method output_type
-	98, // [98:98] is the sub-list for method input_type
-	98, // [98:98] is the sub-list for extension type_name
-	98, // [98:98] is the sub-list for extension extendee
-	0,  // [0:98] is the sub-list for field type_name
+	70,  // 0: api.Attribute.unknown:type_name -> api.UnknownAttribute
+	4,   // 1: api.Attribute.origin:type_name -> api.OriginAttribute
+	6,   // 2: api.Attribute.as_path:type_name -> api.AsPathAttribute
+	7,   // 3: api.Attribute.next_hop:type_name -> api.NextHopAttribute
+	8,   // 4: api.Attribute.multi_exit_disc:type_name -> api.MultiExitDiscAttribute
+	9,   // 5: api.Attribute.local_pref:type_name -> api.LocalPrefAttribute
+	10,  // 6: api.Attribute.atomic_aggregate:type_name -> api.AtomicAggregateAttribute
+	11,  // 7: api.Attribute.aggregator:type_name -> api.AggregatorAttribute
+	12,  // 8: api.Attribute.communities:type_name -> api.CommunitiesAttribute
+	13,  // 9: api.Attribute.originator_id:type_name -> api.OriginatorIdAttribute
+	14,  // 10: api.Attribute.cluster_list:type_name -> api.ClusterListAttribute
+	15,  // 11: api.Attribute.mp_reach:type_name -> api.MpReachNLRIAttribute
+	16,  // 12: api.Attribute.mp_unreach:type_name -> api.MpUnreachNLRIAttribute
+	17,  // 13: api.Attribute.extended_communities:type_name -> api.ExtendedCommunitiesAttribute
+	18,  // 14: api.Attribute.as4_path:type_name -> api.As4PathAttribute
+	19,  // 15: api.Attribute.as4_aggregator:type_name -> api.As4AggregatorAttribute
+	20,  // 16: api.Attribute.pmsi_tunnel:type_name -> api.PmsiTunnelAttribute
+	41,  // 17: api.Attribute.tunnel_encap:type_name -> api.TunnelEncapAttribute
+	44,  // 18: api.Attribute.ip6_extended_communities:type_name -> api.IP6ExtendedCommunitiesAttribute
+	47,  // 19: api.Attribute.aigp:type_name -> api.AigpAttribute
+	49,  // 20: api.Attribute.large_communities:type_name -> api.LargeCommunitiesAttribute
+	69,  // 21: api.Attribute.ls:type_name -> api.LsAttribute
+	80,  // 22: api.Attribute.prefix_sid:type_name -> api.PrefixSID
+	2,   // 23: api.AsSegment.type:type_name -> api.AsSegment.Type
+	5,   // 24: api.AsPathAttribute.segments:type_name -> api.AsSegment
+	89,  // 25: api.MpReachNLRIAttribute.family:type_name -> api.Family
+	90,  // 26: api.MpReachNLRIAttribute.nlris:type_name -> api.NLRI
+	89,  // 27: api.MpUnreachNLRIAttribute.family:type_name -> api.Family
+	90,  // 28: api.MpUnreachNLRIAttribute.nlris:type_name -> api.NLRI
+	91,  // 29: api.ExtendedCommunitiesAttribute.communities:type_name -> api.ExtendedCommunity
+	5,   // 30: api.As4PathAttribute.segments:type_name -> api.AsSegment
+	28,  // 31: api.TunnelEncapSubTLVSRBindingSID.sr_binding_sid:type_name -> api.SRBindingSID
+	30,  // 32: api.TunnelEncapSubTLVSRBindingSID.srv6_binding_sid:type_name -> api.SRv6BindingSID
+	0,   // 33: api.SRv6EndPointBehavior.behavior:type_name -> api.SRV6Behavior
+	29,  // 34: api.SRv6BindingSID.endpoint_behavior_structure:type_name -> api.SRv6EndPointBehavior
+	1,   // 35: api.TunnelEncapSubTLVSRENLP.enlp:type_name -> api.ENLPType
+	33,  // 36: api.SegmentTypeA.flags:type_name -> api.SegmentFlags
+	33,  // 37: api.SegmentTypeB.flags:type_name -> api.SegmentFlags
+	29,  // 38: api.SegmentTypeB.endpoint_behavior_structure:type_name -> api.SRv6EndPointBehavior
+	32,  // 39: api.TunnelEncapSubTLVSRSegmentList.weight:type_name -> api.SRWeight
+	81,  // 40: api.TunnelEncapSubTLVSRSegmentList.segments:type_name -> api.TunnelEncapSubTLVSRSegmentList.Segment
+	82,  // 41: api.TunnelEncapTLV.tlvs:type_name -> api.TunnelEncapTLV.TLV
+	40,  // 42: api.TunnelEncapAttribute.tlvs:type_name -> api.TunnelEncapTLV
+	83,  // 43: api.IP6ExtendedCommunitiesAttribute.communities:type_name -> api.IP6ExtendedCommunitiesAttribute.Community
+	84,  // 44: api.AigpAttribute.tlvs:type_name -> api.AigpAttribute.TLV
+	48,  // 45: api.LargeCommunitiesAttribute.communities:type_name -> api.LargeCommunity
+	52,  // 46: api.LsSrCapabilities.ranges:type_name -> api.LsSrRange
+	52,  // 47: api.LsSrLocalBlock.ranges:type_name -> api.LsSrRange
+	50,  // 48: api.LsAttributeNode.flags:type_name -> api.LsNodeFlags
+	53,  // 49: api.LsAttributeNode.sr_capabilities:type_name -> api.LsSrCapabilities
+	54,  // 50: api.LsAttributeNode.sr_local_block:type_name -> api.LsSrLocalBlock
+	56,  // 51: api.LsAttributeNode.flex_algo_defs:type_name -> api.LsAttributeFlexAlgoDef
+	64,  // 52: api.LsAttributeLink.srv6_end_x_sid:type_name -> api.LsSrv6EndXSID
+	51,  // 53: api.LsAttributePrefix.igp_flags:type_name -> api.LsIGPFlags
+	59,  // 54: api.LsAttributePrefix.sr_prefix_sids:type_name -> api.LsAttributePrefixSID
+	60,  // 55: api.LsAttributePrefix.fad_prefix_metrics:type_name -> api.LsAttributeFADPrefixMetric
+	61,  // 56: api.LsBgpPeerSegmentSID.flags:type_name -> api.LsBgpPeerSegmentSIDFlags
+	62,  // 57: api.LsAttributeBgpPeerSegment.bgp_peer_node_sid:type_name -> api.LsBgpPeerSegmentSID
+	62,  // 58: api.LsAttributeBgpPeerSegment.bgp_peer_adjacency_sid:type_name -> api.LsBgpPeerSegmentSID
+	62,  // 59: api.LsAttributeBgpPeerSegment.bgp_peer_set_sid:type_name -> api.LsBgpPeerSegmentSID
+	65,  // 60: api.LsSrv6EndXSID.srv6_sid_structure:type_name -> api.LsSrv6SIDStructure
+	65,  // 61: api.LsAttributeSrv6SID.srv6_sid_structure:type_name -> api.LsSrv6SIDStructure
+	66,  // 62: api.LsAttributeSrv6SID.srv6_endpoint_behavior:type_name -> api.LsSrv6EndpointBehavior
+	67,  // 63: api.LsAttributeSrv6SID.srv6_bgp_peer_node_sid:type_name -> api.LsSrv6BgpPeerNodeSID
+	55,  // 64: api.LsAttribute.node:type_name -> api.LsAttributeNode
+	57,  // 65: api.LsAttribute.link:type_name -> api.LsAttributeLink
+	58,  // 66: api.LsAttribute.prefix:type_name -> api.LsAttributePrefix
+	63,  // 67: api.LsAttribute.bgp_peer_segment:type_name -> api.LsAttributeBgpPeerSegment
+	68,  // 68: api.LsAttribute.srv6_sid:type_name -> api.LsAttributeSrv6SID
+	71,  // 69: api.SRv6SubSubTLV.structure:type_name -> api.SRv6StructureSubSubTLV
+	72,  // 70: api.SRv6SubSubTLVs.tlvs:type_name -> api.SRv6SubSubTLV
+	74,  // 71: api.SRv6InformationSubTLV.flags:type_name -> api.SRv6SIDFlags
+	85,  // 72: api.SRv6InformationSubTLV.sub_sub_tlvs:type_name -> api.SRv6InformationSubTLV.SubSubTlvsEntry
+	75,  // 73: api.SRv6SubTLV.information:type_name -> api.SRv6InformationSubTLV
+	76,  // 74: api.SRv6SubTLVs.tlvs:type_name -> api.SRv6SubTLV
+	86,  // 75: api.SRv6L3ServiceTLV.sub_tlvs:type_name -> api.SRv6L3ServiceTLV.SubTlvsEntry
+	87,  // 76: api.SRv6L2ServiceTLV.sub_tlvs:type_name -> api.SRv6L2ServiceTLV.SubTlvsEntry
+	88,  // 77: api.PrefixSID.tlvs:type_name -> api.PrefixSID.TLV
+	34,  // 78: api.TunnelEncapSubTLVSRSegmentList.Segment.a:type_name -> api.SegmentTypeA
+	35,  // 79: api.TunnelEncapSubTLVSRSegmentList.Segment.b:type_name -> api.SegmentTypeB
+	39,  // 80: api.TunnelEncapTLV.TLV.unknown:type_name -> api.TunnelEncapSubTLVUnknown
+	21,  // 81: api.TunnelEncapTLV.TLV.encapsulation:type_name -> api.TunnelEncapSubTLVEncapsulation
+	22,  // 82: api.TunnelEncapTLV.TLV.protocol:type_name -> api.TunnelEncapSubTLVProtocol
+	23,  // 83: api.TunnelEncapTLV.TLV.color:type_name -> api.TunnelEncapSubTLVColor
+	37,  // 84: api.TunnelEncapTLV.TLV.egress_endpoint:type_name -> api.TunnelEncapSubTLVEgressEndpoint
+	38,  // 85: api.TunnelEncapTLV.TLV.udp_dest_port:type_name -> api.TunnelEncapSubTLVUDPDestPort
+	24,  // 86: api.TunnelEncapTLV.TLV.sr_preference:type_name -> api.TunnelEncapSubTLVSRPreference
+	26,  // 87: api.TunnelEncapTLV.TLV.sr_priority:type_name -> api.TunnelEncapSubTLVSRPriority
+	25,  // 88: api.TunnelEncapTLV.TLV.sr_candidate_path_name:type_name -> api.TunnelEncapSubTLVSRCandidatePathName
+	31,  // 89: api.TunnelEncapTLV.TLV.sr_enlp:type_name -> api.TunnelEncapSubTLVSRENLP
+	27,  // 90: api.TunnelEncapTLV.TLV.sr_binding_sid:type_name -> api.TunnelEncapSubTLVSRBindingSID
+	36,  // 91: api.TunnelEncapTLV.TLV.sr_segment_list:type_name -> api.TunnelEncapSubTLVSRSegmentList
+	42,  // 92: api.IP6ExtendedCommunitiesAttribute.Community.ipv6_address_specific:type_name -> api.IPv6AddressSpecificExtended
+	43,  // 93: api.IP6ExtendedCommunitiesAttribute.Community.redirect_ipv6_address_specific:type_name -> api.RedirectIPv6AddressSpecificExtended
+	46,  // 94: api.AigpAttribute.TLV.unknown:type_name -> api.AigpTLVUnknown
+	45,  // 95: api.AigpAttribute.TLV.igp_metric:type_name -> api.AigpTLVIGPMetric
+	73,  // 96: api.SRv6InformationSubTLV.SubSubTlvsEntry.value:type_name -> api.SRv6SubSubTLVs
+	77,  // 97: api.SRv6L3ServiceTLV.SubTlvsEntry.value:type_name -> api.SRv6SubTLVs
+	77,  // 98: api.SRv6L2ServiceTLV.SubTlvsEntry.value:type_name -> api.SRv6SubTLVs
+	78,  // 99: api.PrefixSID.TLV.l3_service:type_name -> api.SRv6L3ServiceTLV
+	79,  // 100: api.PrefixSID.TLV.l2_service:type_name -> api.SRv6L2ServiceTLV
+	101, // [101:101] is the sub-list for method output_type
+	101, // [101:101] is the sub-list for method input_type
+	101, // [101:101] is the sub-list for extension type_name
+	101, // [101:101] is the sub-list for extension extendee
+	0,   // [0:101] is the sub-list for field type_name
 }
 
 func init() { file_api_attribute_proto_init() }
@@ -6255,17 +6569,17 @@ func file_api_attribute_proto_init() {
 		(*TunnelEncapSubTLVSRBindingSID_SrBindingSid)(nil),
 		(*TunnelEncapSubTLVSRBindingSID_Srv6BindingSid)(nil),
 	}
-	file_api_attribute_proto_msgTypes[66].OneofWrappers = []any{
+	file_api_attribute_proto_msgTypes[69].OneofWrappers = []any{
 		(*SRv6SubSubTLV_Structure)(nil),
 	}
-	file_api_attribute_proto_msgTypes[70].OneofWrappers = []any{
+	file_api_attribute_proto_msgTypes[73].OneofWrappers = []any{
 		(*SRv6SubTLV_Information)(nil),
 	}
-	file_api_attribute_proto_msgTypes[75].OneofWrappers = []any{
+	file_api_attribute_proto_msgTypes[78].OneofWrappers = []any{
 		(*TunnelEncapSubTLVSRSegmentList_Segment_A)(nil),
 		(*TunnelEncapSubTLVSRSegmentList_Segment_B)(nil),
 	}
-	file_api_attribute_proto_msgTypes[76].OneofWrappers = []any{
+	file_api_attribute_proto_msgTypes[79].OneofWrappers = []any{
 		(*TunnelEncapTLV_TLV_Unknown)(nil),
 		(*TunnelEncapTLV_TLV_Encapsulation)(nil),
 		(*TunnelEncapTLV_TLV_Protocol)(nil),
@@ -6279,15 +6593,15 @@ func file_api_attribute_proto_init() {
 		(*TunnelEncapTLV_TLV_SrBindingSid)(nil),
 		(*TunnelEncapTLV_TLV_SrSegmentList)(nil),
 	}
-	file_api_attribute_proto_msgTypes[77].OneofWrappers = []any{
+	file_api_attribute_proto_msgTypes[80].OneofWrappers = []any{
 		(*IP6ExtendedCommunitiesAttribute_Community_Ipv6AddressSpecific)(nil),
 		(*IP6ExtendedCommunitiesAttribute_Community_RedirectIpv6AddressSpecific)(nil),
 	}
-	file_api_attribute_proto_msgTypes[78].OneofWrappers = []any{
+	file_api_attribute_proto_msgTypes[81].OneofWrappers = []any{
 		(*AigpAttribute_TLV_Unknown)(nil),
 		(*AigpAttribute_TLV_IgpMetric)(nil),
 	}
-	file_api_attribute_proto_msgTypes[82].OneofWrappers = []any{
+	file_api_attribute_proto_msgTypes[85].OneofWrappers = []any{
 		(*PrefixSID_TLV_L3Service)(nil),
 		(*PrefixSID_TLV_L2Service)(nil),
 	}
@@ -6297,7 +6611,7 @@ func file_api_attribute_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_attribute_proto_rawDesc), len(file_api_attribute_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   83,
+			NumMessages:   86,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/vendor/github.com/osrg/gobgp/v4/api/capability.pb.go
+++ b/vendor/github.com/osrg/gobgp/v4/api/capability.pb.go
@@ -91,7 +91,7 @@ func (x AddPathCapabilityTuple_Mode) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use AddPathCapabilityTuple_Mode.Descriptor instead.
 func (AddPathCapabilityTuple_Mode) EnumDescriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{9, 0}
+	return file_api_capability_proto_rawDescGZIP(), []int{10, 0}
 }
 
 type Capability struct {
@@ -111,6 +111,7 @@ type Capability struct {
 	//	*Capability_RouteRefreshCisco
 	//	*Capability_Fqdn
 	//	*Capability_SoftwareVersion
+	//	*Capability_ExtendedMessage
 	Cap           isCapability_Cap `protobuf_oneof:"cap"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -270,6 +271,15 @@ func (x *Capability) GetSoftwareVersion() *SoftwareVersionCapability {
 	return nil
 }
 
+func (x *Capability) GetExtendedMessage() *ExtendedMessageCapability {
+	if x != nil {
+		if x, ok := x.Cap.(*Capability_ExtendedMessage); ok {
+			return x.ExtendedMessage
+		}
+	}
+	return nil
+}
+
 type isCapability_Cap interface {
 	isCapability_Cap()
 }
@@ -326,6 +336,10 @@ type Capability_SoftwareVersion struct {
 	SoftwareVersion *SoftwareVersionCapability `protobuf:"bytes,13,opt,name=software_version,json=softwareVersion,proto3,oneof"`
 }
 
+type Capability_ExtendedMessage struct {
+	ExtendedMessage *ExtendedMessageCapability `protobuf:"bytes,14,opt,name=extended_message,json=extendedMessage,proto3,oneof"`
+}
+
 func (*Capability_Unknown) isCapability_Cap() {}
 
 func (*Capability_MultiProtocol) isCapability_Cap() {}
@@ -351,6 +365,8 @@ func (*Capability_RouteRefreshCisco) isCapability_Cap() {}
 func (*Capability_Fqdn) isCapability_Cap() {}
 
 func (*Capability_SoftwareVersion) isCapability_Cap() {}
+
+func (*Capability_ExtendedMessage) isCapability_Cap() {}
 
 type MultiProtocolCapability struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -432,6 +448,46 @@ func (*RouteRefreshCapability) Descriptor() ([]byte, []int) {
 	return file_api_capability_proto_rawDescGZIP(), []int{2}
 }
 
+// ExtendedMessageCapability mirrors the empty TLV for the BGP
+// Extended Message Capability (Capability Code 6, Capability Length 0)
+// defined by RFC 8654. The presence of this oneof on a Capability
+// signals that the peer advertised it; there is no payload.
+type ExtendedMessageCapability struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ExtendedMessageCapability) Reset() {
+	*x = ExtendedMessageCapability{}
+	mi := &file_api_capability_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExtendedMessageCapability) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExtendedMessageCapability) ProtoMessage() {}
+
+func (x *ExtendedMessageCapability) ProtoReflect() protoreflect.Message {
+	mi := &file_api_capability_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExtendedMessageCapability.ProtoReflect.Descriptor instead.
+func (*ExtendedMessageCapability) Descriptor() ([]byte, []int) {
+	return file_api_capability_proto_rawDescGZIP(), []int{3}
+}
+
 type CarryingLabelInfoCapability struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -440,7 +496,7 @@ type CarryingLabelInfoCapability struct {
 
 func (x *CarryingLabelInfoCapability) Reset() {
 	*x = CarryingLabelInfoCapability{}
-	mi := &file_api_capability_proto_msgTypes[3]
+	mi := &file_api_capability_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -452,7 +508,7 @@ func (x *CarryingLabelInfoCapability) String() string {
 func (*CarryingLabelInfoCapability) ProtoMessage() {}
 
 func (x *CarryingLabelInfoCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[3]
+	mi := &file_api_capability_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -465,7 +521,7 @@ func (x *CarryingLabelInfoCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CarryingLabelInfoCapability.ProtoReflect.Descriptor instead.
 func (*CarryingLabelInfoCapability) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{3}
+	return file_api_capability_proto_rawDescGZIP(), []int{4}
 }
 
 type ExtendedNexthopCapabilityTuple struct {
@@ -481,7 +537,7 @@ type ExtendedNexthopCapabilityTuple struct {
 
 func (x *ExtendedNexthopCapabilityTuple) Reset() {
 	*x = ExtendedNexthopCapabilityTuple{}
-	mi := &file_api_capability_proto_msgTypes[4]
+	mi := &file_api_capability_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -493,7 +549,7 @@ func (x *ExtendedNexthopCapabilityTuple) String() string {
 func (*ExtendedNexthopCapabilityTuple) ProtoMessage() {}
 
 func (x *ExtendedNexthopCapabilityTuple) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[4]
+	mi := &file_api_capability_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -506,7 +562,7 @@ func (x *ExtendedNexthopCapabilityTuple) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExtendedNexthopCapabilityTuple.ProtoReflect.Descriptor instead.
 func (*ExtendedNexthopCapabilityTuple) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{4}
+	return file_api_capability_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *ExtendedNexthopCapabilityTuple) GetNlriFamily() *Family {
@@ -532,7 +588,7 @@ type ExtendedNexthopCapability struct {
 
 func (x *ExtendedNexthopCapability) Reset() {
 	*x = ExtendedNexthopCapability{}
-	mi := &file_api_capability_proto_msgTypes[5]
+	mi := &file_api_capability_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -544,7 +600,7 @@ func (x *ExtendedNexthopCapability) String() string {
 func (*ExtendedNexthopCapability) ProtoMessage() {}
 
 func (x *ExtendedNexthopCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[5]
+	mi := &file_api_capability_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -557,7 +613,7 @@ func (x *ExtendedNexthopCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExtendedNexthopCapability.ProtoReflect.Descriptor instead.
 func (*ExtendedNexthopCapability) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{5}
+	return file_api_capability_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ExtendedNexthopCapability) GetTuples() []*ExtendedNexthopCapabilityTuple {
@@ -577,7 +633,7 @@ type GracefulRestartCapabilityTuple struct {
 
 func (x *GracefulRestartCapabilityTuple) Reset() {
 	*x = GracefulRestartCapabilityTuple{}
-	mi := &file_api_capability_proto_msgTypes[6]
+	mi := &file_api_capability_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -589,7 +645,7 @@ func (x *GracefulRestartCapabilityTuple) String() string {
 func (*GracefulRestartCapabilityTuple) ProtoMessage() {}
 
 func (x *GracefulRestartCapabilityTuple) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[6]
+	mi := &file_api_capability_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -602,7 +658,7 @@ func (x *GracefulRestartCapabilityTuple) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GracefulRestartCapabilityTuple.ProtoReflect.Descriptor instead.
 func (*GracefulRestartCapabilityTuple) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{6}
+	return file_api_capability_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *GracefulRestartCapabilityTuple) GetFamily() *Family {
@@ -630,7 +686,7 @@ type GracefulRestartCapability struct {
 
 func (x *GracefulRestartCapability) Reset() {
 	*x = GracefulRestartCapability{}
-	mi := &file_api_capability_proto_msgTypes[7]
+	mi := &file_api_capability_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -642,7 +698,7 @@ func (x *GracefulRestartCapability) String() string {
 func (*GracefulRestartCapability) ProtoMessage() {}
 
 func (x *GracefulRestartCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[7]
+	mi := &file_api_capability_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -655,7 +711,7 @@ func (x *GracefulRestartCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GracefulRestartCapability.ProtoReflect.Descriptor instead.
 func (*GracefulRestartCapability) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{7}
+	return file_api_capability_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *GracefulRestartCapability) GetFlags() uint32 {
@@ -688,7 +744,7 @@ type FourOctetASNCapability struct {
 
 func (x *FourOctetASNCapability) Reset() {
 	*x = FourOctetASNCapability{}
-	mi := &file_api_capability_proto_msgTypes[8]
+	mi := &file_api_capability_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -700,7 +756,7 @@ func (x *FourOctetASNCapability) String() string {
 func (*FourOctetASNCapability) ProtoMessage() {}
 
 func (x *FourOctetASNCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[8]
+	mi := &file_api_capability_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -713,7 +769,7 @@ func (x *FourOctetASNCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FourOctetASNCapability.ProtoReflect.Descriptor instead.
 func (*FourOctetASNCapability) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{8}
+	return file_api_capability_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *FourOctetASNCapability) GetAsn() uint32 {
@@ -733,7 +789,7 @@ type AddPathCapabilityTuple struct {
 
 func (x *AddPathCapabilityTuple) Reset() {
 	*x = AddPathCapabilityTuple{}
-	mi := &file_api_capability_proto_msgTypes[9]
+	mi := &file_api_capability_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -745,7 +801,7 @@ func (x *AddPathCapabilityTuple) String() string {
 func (*AddPathCapabilityTuple) ProtoMessage() {}
 
 func (x *AddPathCapabilityTuple) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[9]
+	mi := &file_api_capability_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -758,7 +814,7 @@ func (x *AddPathCapabilityTuple) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddPathCapabilityTuple.ProtoReflect.Descriptor instead.
 func (*AddPathCapabilityTuple) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{9}
+	return file_api_capability_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *AddPathCapabilityTuple) GetFamily() *Family {
@@ -784,7 +840,7 @@ type AddPathCapability struct {
 
 func (x *AddPathCapability) Reset() {
 	*x = AddPathCapability{}
-	mi := &file_api_capability_proto_msgTypes[10]
+	mi := &file_api_capability_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -796,7 +852,7 @@ func (x *AddPathCapability) String() string {
 func (*AddPathCapability) ProtoMessage() {}
 
 func (x *AddPathCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[10]
+	mi := &file_api_capability_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -809,7 +865,7 @@ func (x *AddPathCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddPathCapability.ProtoReflect.Descriptor instead.
 func (*AddPathCapability) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{10}
+	return file_api_capability_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *AddPathCapability) GetTuples() []*AddPathCapabilityTuple {
@@ -827,7 +883,7 @@ type EnhancedRouteRefreshCapability struct {
 
 func (x *EnhancedRouteRefreshCapability) Reset() {
 	*x = EnhancedRouteRefreshCapability{}
-	mi := &file_api_capability_proto_msgTypes[11]
+	mi := &file_api_capability_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -839,7 +895,7 @@ func (x *EnhancedRouteRefreshCapability) String() string {
 func (*EnhancedRouteRefreshCapability) ProtoMessage() {}
 
 func (x *EnhancedRouteRefreshCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[11]
+	mi := &file_api_capability_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -852,7 +908,7 @@ func (x *EnhancedRouteRefreshCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EnhancedRouteRefreshCapability.ProtoReflect.Descriptor instead.
 func (*EnhancedRouteRefreshCapability) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{11}
+	return file_api_capability_proto_rawDescGZIP(), []int{12}
 }
 
 type LongLivedGracefulRestartCapabilityTuple struct {
@@ -866,7 +922,7 @@ type LongLivedGracefulRestartCapabilityTuple struct {
 
 func (x *LongLivedGracefulRestartCapabilityTuple) Reset() {
 	*x = LongLivedGracefulRestartCapabilityTuple{}
-	mi := &file_api_capability_proto_msgTypes[12]
+	mi := &file_api_capability_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -878,7 +934,7 @@ func (x *LongLivedGracefulRestartCapabilityTuple) String() string {
 func (*LongLivedGracefulRestartCapabilityTuple) ProtoMessage() {}
 
 func (x *LongLivedGracefulRestartCapabilityTuple) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[12]
+	mi := &file_api_capability_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -891,7 +947,7 @@ func (x *LongLivedGracefulRestartCapabilityTuple) ProtoReflect() protoreflect.Me
 
 // Deprecated: Use LongLivedGracefulRestartCapabilityTuple.ProtoReflect.Descriptor instead.
 func (*LongLivedGracefulRestartCapabilityTuple) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{12}
+	return file_api_capability_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *LongLivedGracefulRestartCapabilityTuple) GetFamily() *Family {
@@ -924,7 +980,7 @@ type LongLivedGracefulRestartCapability struct {
 
 func (x *LongLivedGracefulRestartCapability) Reset() {
 	*x = LongLivedGracefulRestartCapability{}
-	mi := &file_api_capability_proto_msgTypes[13]
+	mi := &file_api_capability_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -936,7 +992,7 @@ func (x *LongLivedGracefulRestartCapability) String() string {
 func (*LongLivedGracefulRestartCapability) ProtoMessage() {}
 
 func (x *LongLivedGracefulRestartCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[13]
+	mi := &file_api_capability_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -949,7 +1005,7 @@ func (x *LongLivedGracefulRestartCapability) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use LongLivedGracefulRestartCapability.ProtoReflect.Descriptor instead.
 func (*LongLivedGracefulRestartCapability) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{13}
+	return file_api_capability_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *LongLivedGracefulRestartCapability) GetTuples() []*LongLivedGracefulRestartCapabilityTuple {
@@ -967,7 +1023,7 @@ type RouteRefreshCiscoCapability struct {
 
 func (x *RouteRefreshCiscoCapability) Reset() {
 	*x = RouteRefreshCiscoCapability{}
-	mi := &file_api_capability_proto_msgTypes[14]
+	mi := &file_api_capability_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -979,7 +1035,7 @@ func (x *RouteRefreshCiscoCapability) String() string {
 func (*RouteRefreshCiscoCapability) ProtoMessage() {}
 
 func (x *RouteRefreshCiscoCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[14]
+	mi := &file_api_capability_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -992,7 +1048,7 @@ func (x *RouteRefreshCiscoCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RouteRefreshCiscoCapability.ProtoReflect.Descriptor instead.
 func (*RouteRefreshCiscoCapability) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{14}
+	return file_api_capability_proto_rawDescGZIP(), []int{15}
 }
 
 type FqdnCapability struct {
@@ -1005,7 +1061,7 @@ type FqdnCapability struct {
 
 func (x *FqdnCapability) Reset() {
 	*x = FqdnCapability{}
-	mi := &file_api_capability_proto_msgTypes[15]
+	mi := &file_api_capability_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1017,7 +1073,7 @@ func (x *FqdnCapability) String() string {
 func (*FqdnCapability) ProtoMessage() {}
 
 func (x *FqdnCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[15]
+	mi := &file_api_capability_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1030,7 +1086,7 @@ func (x *FqdnCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FqdnCapability.ProtoReflect.Descriptor instead.
 func (*FqdnCapability) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{15}
+	return file_api_capability_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *FqdnCapability) GetHostName() string {
@@ -1056,7 +1112,7 @@ type SoftwareVersionCapability struct {
 
 func (x *SoftwareVersionCapability) Reset() {
 	*x = SoftwareVersionCapability{}
-	mi := &file_api_capability_proto_msgTypes[16]
+	mi := &file_api_capability_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1068,7 +1124,7 @@ func (x *SoftwareVersionCapability) String() string {
 func (*SoftwareVersionCapability) ProtoMessage() {}
 
 func (x *SoftwareVersionCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[16]
+	mi := &file_api_capability_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1081,7 +1137,7 @@ func (x *SoftwareVersionCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SoftwareVersionCapability.ProtoReflect.Descriptor instead.
 func (*SoftwareVersionCapability) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{16}
+	return file_api_capability_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *SoftwareVersionCapability) GetSoftwareVersion() string {
@@ -1101,7 +1157,7 @@ type UnknownCapability struct {
 
 func (x *UnknownCapability) Reset() {
 	*x = UnknownCapability{}
-	mi := &file_api_capability_proto_msgTypes[17]
+	mi := &file_api_capability_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1113,7 +1169,7 @@ func (x *UnknownCapability) String() string {
 func (*UnknownCapability) ProtoMessage() {}
 
 func (x *UnknownCapability) ProtoReflect() protoreflect.Message {
-	mi := &file_api_capability_proto_msgTypes[17]
+	mi := &file_api_capability_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1126,7 +1182,7 @@ func (x *UnknownCapability) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnknownCapability.ProtoReflect.Descriptor instead.
 func (*UnknownCapability) Descriptor() ([]byte, []int) {
-	return file_api_capability_proto_rawDescGZIP(), []int{17}
+	return file_api_capability_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *UnknownCapability) GetCode() uint32 {
@@ -1147,7 +1203,7 @@ var File_api_capability_proto protoreflect.FileDescriptor
 
 const file_api_capability_proto_rawDesc = "" +
 	"\n" +
-	"\x14api/capability.proto\x12\x03api\x1a\x10api/common.proto\"\xcd\a\n" +
+	"\x14api/capability.proto\x12\x03api\x1a\x10api/common.proto\"\x9a\b\n" +
 	"\n" +
 	"Capability\x122\n" +
 	"\aunknown\x18\x01 \x01(\v2\x16.api.UnknownCapabilityH\x00R\aunknown\x12E\n" +
@@ -1163,11 +1219,13 @@ const file_api_capability_proto_rawDesc = "" +
 	" \x01(\v2'.api.LongLivedGracefulRestartCapabilityH\x00R\x18longLivedGracefulRestart\x12R\n" +
 	"\x13route_refresh_cisco\x18\v \x01(\v2 .api.RouteRefreshCiscoCapabilityH\x00R\x11routeRefreshCisco\x12)\n" +
 	"\x04fqdn\x18\f \x01(\v2\x13.api.FqdnCapabilityH\x00R\x04fqdn\x12K\n" +
-	"\x10software_version\x18\r \x01(\v2\x1e.api.SoftwareVersionCapabilityH\x00R\x0fsoftwareVersionB\x05\n" +
+	"\x10software_version\x18\r \x01(\v2\x1e.api.SoftwareVersionCapabilityH\x00R\x0fsoftwareVersion\x12K\n" +
+	"\x10extended_message\x18\x0e \x01(\v2\x1e.api.ExtendedMessageCapabilityH\x00R\x0fextendedMessageB\x05\n" +
 	"\x03cap\">\n" +
 	"\x17MultiProtocolCapability\x12#\n" +
 	"\x06family\x18\x01 \x01(\v2\v.api.FamilyR\x06family\"\x18\n" +
-	"\x16RouteRefreshCapability\"\x1d\n" +
+	"\x16RouteRefreshCapability\"\x1b\n" +
+	"\x19ExtendedMessageCapability\"\x1d\n" +
 	"\x1bCarryingLabelInfoCapability\"\x82\x01\n" +
 	"\x1eExtendedNexthopCapabilityTuple\x12,\n" +
 	"\vnlri_family\x18\x01 \x01(\v2\v.api.FamilyR\n" +
@@ -1225,59 +1283,61 @@ func file_api_capability_proto_rawDescGZIP() []byte {
 }
 
 var file_api_capability_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_api_capability_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
+var file_api_capability_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
 var file_api_capability_proto_goTypes = []any{
 	(AddPathCapabilityTuple_Mode)(0),                // 0: api.AddPathCapabilityTuple.Mode
 	(*Capability)(nil),                              // 1: api.Capability
 	(*MultiProtocolCapability)(nil),                 // 2: api.MultiProtocolCapability
 	(*RouteRefreshCapability)(nil),                  // 3: api.RouteRefreshCapability
-	(*CarryingLabelInfoCapability)(nil),             // 4: api.CarryingLabelInfoCapability
-	(*ExtendedNexthopCapabilityTuple)(nil),          // 5: api.ExtendedNexthopCapabilityTuple
-	(*ExtendedNexthopCapability)(nil),               // 6: api.ExtendedNexthopCapability
-	(*GracefulRestartCapabilityTuple)(nil),          // 7: api.GracefulRestartCapabilityTuple
-	(*GracefulRestartCapability)(nil),               // 8: api.GracefulRestartCapability
-	(*FourOctetASNCapability)(nil),                  // 9: api.FourOctetASNCapability
-	(*AddPathCapabilityTuple)(nil),                  // 10: api.AddPathCapabilityTuple
-	(*AddPathCapability)(nil),                       // 11: api.AddPathCapability
-	(*EnhancedRouteRefreshCapability)(nil),          // 12: api.EnhancedRouteRefreshCapability
-	(*LongLivedGracefulRestartCapabilityTuple)(nil), // 13: api.LongLivedGracefulRestartCapabilityTuple
-	(*LongLivedGracefulRestartCapability)(nil),      // 14: api.LongLivedGracefulRestartCapability
-	(*RouteRefreshCiscoCapability)(nil),             // 15: api.RouteRefreshCiscoCapability
-	(*FqdnCapability)(nil),                          // 16: api.FqdnCapability
-	(*SoftwareVersionCapability)(nil),               // 17: api.SoftwareVersionCapability
-	(*UnknownCapability)(nil),                       // 18: api.UnknownCapability
-	(*Family)(nil),                                  // 19: api.Family
+	(*ExtendedMessageCapability)(nil),               // 4: api.ExtendedMessageCapability
+	(*CarryingLabelInfoCapability)(nil),             // 5: api.CarryingLabelInfoCapability
+	(*ExtendedNexthopCapabilityTuple)(nil),          // 6: api.ExtendedNexthopCapabilityTuple
+	(*ExtendedNexthopCapability)(nil),               // 7: api.ExtendedNexthopCapability
+	(*GracefulRestartCapabilityTuple)(nil),          // 8: api.GracefulRestartCapabilityTuple
+	(*GracefulRestartCapability)(nil),               // 9: api.GracefulRestartCapability
+	(*FourOctetASNCapability)(nil),                  // 10: api.FourOctetASNCapability
+	(*AddPathCapabilityTuple)(nil),                  // 11: api.AddPathCapabilityTuple
+	(*AddPathCapability)(nil),                       // 12: api.AddPathCapability
+	(*EnhancedRouteRefreshCapability)(nil),          // 13: api.EnhancedRouteRefreshCapability
+	(*LongLivedGracefulRestartCapabilityTuple)(nil), // 14: api.LongLivedGracefulRestartCapabilityTuple
+	(*LongLivedGracefulRestartCapability)(nil),      // 15: api.LongLivedGracefulRestartCapability
+	(*RouteRefreshCiscoCapability)(nil),             // 16: api.RouteRefreshCiscoCapability
+	(*FqdnCapability)(nil),                          // 17: api.FqdnCapability
+	(*SoftwareVersionCapability)(nil),               // 18: api.SoftwareVersionCapability
+	(*UnknownCapability)(nil),                       // 19: api.UnknownCapability
+	(*Family)(nil),                                  // 20: api.Family
 }
 var file_api_capability_proto_depIdxs = []int32{
-	18, // 0: api.Capability.unknown:type_name -> api.UnknownCapability
+	19, // 0: api.Capability.unknown:type_name -> api.UnknownCapability
 	2,  // 1: api.Capability.multi_protocol:type_name -> api.MultiProtocolCapability
 	3,  // 2: api.Capability.route_refresh:type_name -> api.RouteRefreshCapability
-	4,  // 3: api.Capability.carrying_label_info:type_name -> api.CarryingLabelInfoCapability
-	6,  // 4: api.Capability.extended_nexthop:type_name -> api.ExtendedNexthopCapability
-	8,  // 5: api.Capability.graceful_restart:type_name -> api.GracefulRestartCapability
-	9,  // 6: api.Capability.four_octet_asn:type_name -> api.FourOctetASNCapability
-	11, // 7: api.Capability.add_path:type_name -> api.AddPathCapability
-	12, // 8: api.Capability.enhanced_route_refresh:type_name -> api.EnhancedRouteRefreshCapability
-	14, // 9: api.Capability.long_lived_graceful_restart:type_name -> api.LongLivedGracefulRestartCapability
-	15, // 10: api.Capability.route_refresh_cisco:type_name -> api.RouteRefreshCiscoCapability
-	16, // 11: api.Capability.fqdn:type_name -> api.FqdnCapability
-	17, // 12: api.Capability.software_version:type_name -> api.SoftwareVersionCapability
-	19, // 13: api.MultiProtocolCapability.family:type_name -> api.Family
-	19, // 14: api.ExtendedNexthopCapabilityTuple.nlri_family:type_name -> api.Family
-	19, // 15: api.ExtendedNexthopCapabilityTuple.nexthop_family:type_name -> api.Family
-	5,  // 16: api.ExtendedNexthopCapability.tuples:type_name -> api.ExtendedNexthopCapabilityTuple
-	19, // 17: api.GracefulRestartCapabilityTuple.family:type_name -> api.Family
-	7,  // 18: api.GracefulRestartCapability.tuples:type_name -> api.GracefulRestartCapabilityTuple
-	19, // 19: api.AddPathCapabilityTuple.family:type_name -> api.Family
-	0,  // 20: api.AddPathCapabilityTuple.mode:type_name -> api.AddPathCapabilityTuple.Mode
-	10, // 21: api.AddPathCapability.tuples:type_name -> api.AddPathCapabilityTuple
-	19, // 22: api.LongLivedGracefulRestartCapabilityTuple.family:type_name -> api.Family
-	13, // 23: api.LongLivedGracefulRestartCapability.tuples:type_name -> api.LongLivedGracefulRestartCapabilityTuple
-	24, // [24:24] is the sub-list for method output_type
-	24, // [24:24] is the sub-list for method input_type
-	24, // [24:24] is the sub-list for extension type_name
-	24, // [24:24] is the sub-list for extension extendee
-	0,  // [0:24] is the sub-list for field type_name
+	5,  // 3: api.Capability.carrying_label_info:type_name -> api.CarryingLabelInfoCapability
+	7,  // 4: api.Capability.extended_nexthop:type_name -> api.ExtendedNexthopCapability
+	9,  // 5: api.Capability.graceful_restart:type_name -> api.GracefulRestartCapability
+	10, // 6: api.Capability.four_octet_asn:type_name -> api.FourOctetASNCapability
+	12, // 7: api.Capability.add_path:type_name -> api.AddPathCapability
+	13, // 8: api.Capability.enhanced_route_refresh:type_name -> api.EnhancedRouteRefreshCapability
+	15, // 9: api.Capability.long_lived_graceful_restart:type_name -> api.LongLivedGracefulRestartCapability
+	16, // 10: api.Capability.route_refresh_cisco:type_name -> api.RouteRefreshCiscoCapability
+	17, // 11: api.Capability.fqdn:type_name -> api.FqdnCapability
+	18, // 12: api.Capability.software_version:type_name -> api.SoftwareVersionCapability
+	4,  // 13: api.Capability.extended_message:type_name -> api.ExtendedMessageCapability
+	20, // 14: api.MultiProtocolCapability.family:type_name -> api.Family
+	20, // 15: api.ExtendedNexthopCapabilityTuple.nlri_family:type_name -> api.Family
+	20, // 16: api.ExtendedNexthopCapabilityTuple.nexthop_family:type_name -> api.Family
+	6,  // 17: api.ExtendedNexthopCapability.tuples:type_name -> api.ExtendedNexthopCapabilityTuple
+	20, // 18: api.GracefulRestartCapabilityTuple.family:type_name -> api.Family
+	8,  // 19: api.GracefulRestartCapability.tuples:type_name -> api.GracefulRestartCapabilityTuple
+	20, // 20: api.AddPathCapabilityTuple.family:type_name -> api.Family
+	0,  // 21: api.AddPathCapabilityTuple.mode:type_name -> api.AddPathCapabilityTuple.Mode
+	11, // 22: api.AddPathCapability.tuples:type_name -> api.AddPathCapabilityTuple
+	20, // 23: api.LongLivedGracefulRestartCapabilityTuple.family:type_name -> api.Family
+	14, // 24: api.LongLivedGracefulRestartCapability.tuples:type_name -> api.LongLivedGracefulRestartCapabilityTuple
+	25, // [25:25] is the sub-list for method output_type
+	25, // [25:25] is the sub-list for method input_type
+	25, // [25:25] is the sub-list for extension type_name
+	25, // [25:25] is the sub-list for extension extendee
+	0,  // [0:25] is the sub-list for field type_name
 }
 
 func init() { file_api_capability_proto_init() }
@@ -1300,6 +1360,7 @@ func file_api_capability_proto_init() {
 		(*Capability_RouteRefreshCisco)(nil),
 		(*Capability_Fqdn)(nil),
 		(*Capability_SoftwareVersion)(nil),
+		(*Capability_ExtendedMessage)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -1307,7 +1368,7 @@ func file_api_capability_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_capability_proto_rawDesc), len(file_api_capability_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   18,
+			NumMessages:   19,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/vendor/github.com/osrg/gobgp/v4/internal/pkg/netutils/sockopt.go
+++ b/vendor/github.com/osrg/gobgp/v4/internal/pkg/netutils/sockopt.go
@@ -24,8 +24,8 @@ import (
 	"syscall"
 )
 
-func SetTCPMD5SigSockopt(l *net.TCPListener, address string, key string) error {
-	return SetTcpMD5SigSockopt(l, address, key)
+func SetTCPMD5SigSockopt(l *net.TCPListener, bindInterface string, address string, key string) error {
+	return SetTcpMD5SigSockopt(l, bindInterface, address, key)
 }
 
 func SetTCPTTLSockopt(conn net.Conn, ttl int) error {

--- a/vendor/github.com/osrg/gobgp/v4/internal/pkg/netutils/sockopt_bsd.go
+++ b/vendor/github.com/osrg/gobgp/v4/internal/pkg/netutils/sockopt_bsd.go
@@ -27,7 +27,7 @@ const (
 	ipv6MinHopCount = 73   // Generalized TTL Security Mechanism (RFC5082)
 )
 
-func SetTcpMD5SigSockopt(l *net.TCPListener, address string, key string) error {
+func SetTcpMD5SigSockopt(l *net.TCPListener, bindInterface string, address string, key string) error {
 	sc, err := l.SyscallConn()
 	if err != nil {
 		return err

--- a/vendor/github.com/osrg/gobgp/v4/internal/pkg/netutils/sockopt_darwin.go
+++ b/vendor/github.com/osrg/gobgp/v4/internal/pkg/netutils/sockopt_darwin.go
@@ -24,7 +24,7 @@ import (
 	"syscall"
 )
 
-func SetTcpMD5SigSockopt(l *net.TCPListener, address string, key string) error {
+func SetTcpMD5SigSockopt(l *net.TCPListener, bindInterface string, address string, key string) error {
 	return fmt.Errorf("setting md5 is not supported")
 }
 

--- a/vendor/github.com/osrg/gobgp/v4/internal/pkg/netutils/sockopt_linux.go
+++ b/vendor/github.com/osrg/gobgp/v4/internal/pkg/netutils/sockopt_linux.go
@@ -23,10 +23,10 @@ import (
 	"net"
 	"net/netip"
 	"os"
-	"strconv"
 	"strings"
 	"syscall"
 
+	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 )
 
@@ -34,7 +34,7 @@ const (
 	ipv6MinHopCount = 73 // Generalized TTL Security Mechanism (RFC5082)
 )
 
-func buildTcpMD5Sig(address, key string) *unix.TCPMD5Sig {
+func buildTcpMD5Sig(bindInterface netlink.Link, address, key string) *unix.TCPMD5Sig {
 	t := unix.TCPMD5Sig{}
 
 	var addr netip.Addr
@@ -46,7 +46,7 @@ func buildTcpMD5Sig(address, key string) *unix.TCPMD5Sig {
 		}
 		addr = prefix.Addr()
 		t.Prefixlen = uint8(prefix.Bits())
-		t.Flags = unix.TCP_MD5SIG_FLAG_PREFIX
+		t.Flags |= unix.TCP_MD5SIG_FLAG_PREFIX
 	} else {
 		addr, err = netip.ParseAddr(address)
 		if err != nil {
@@ -62,14 +62,18 @@ func buildTcpMD5Sig(address, key string) *unix.TCPMD5Sig {
 		t.Addr.Family = unix.AF_INET6
 		bits := addr.As16()
 		copy(t.Addr.Data[6:], bits[:])
-		if addr.IsLinkLocalUnicast() {
-			t.Ifindex, err = zoneToID(addr.Zone())
-			if err != nil {
-				return nil
-			}
-		}
 	} else {
 		return nil
+	}
+
+	// Ifindex option is only valid for VRF device. It's still valid
+	// to set md5sig for the socket bound to non-VRF device, but in
+	// that case, Ifindex shouldn't be set.
+	//
+	// Ref: https://github.com/torvalds/linux/commit/6b102db50cdde3ba2f78631ed21222edf3a5fb51
+	if bindInterface != nil && bindInterface.Type() == "vrf" {
+		t.Ifindex = int32(bindInterface.Attrs().Index)
+		t.Flags |= unix.TCP_MD5SIG_FLAG_IFINDEX
 	}
 
 	t.Keylen = uint16(len(key))
@@ -78,41 +82,27 @@ func buildTcpMD5Sig(address, key string) *unix.TCPMD5Sig {
 	return &t
 }
 
-func zoneToID(zone string) (int32, error) {
-	if zone == "" {
-		return 0, nil
-	}
-
-	if id, err := strconv.ParseInt(zone, 10, 32); err == nil {
-		return int32(id), nil
-	}
-
-	iface, err := net.InterfaceByName(zone)
-	if err != nil {
-		return 0, fmt.Errorf("interface %q not found: %w", zone, err)
-	}
-	return int32(iface.Index), nil
-}
-
-func SetTCPMD5SigSockopt(l *net.TCPListener, address string, key string) error {
+func SetTCPMD5SigSockopt(l *net.TCPListener, bindInterface string, address string, key string) error {
 	sc, err := l.SyscallConn()
 	if err != nil {
 		return err
 	}
 
+	var link netlink.Link
+	if bindInterface != "" {
+		link, err = netlink.LinkByName(bindInterface)
+		if err != nil {
+			return fmt.Errorf("failed to get link for interface %s: %w", bindInterface, err)
+		}
+	}
+
 	var sockerr error
-	t := buildTcpMD5Sig(address, key)
+	t := buildTcpMD5Sig(link, address, key)
 	if t == nil {
 		return fmt.Errorf("unable to generate TcpMD5Sig from %s", address)
 	}
 	if err := sc.Control(func(s uintptr) {
-		opt := unix.TCP_MD5SIG
-
-		if strings.Contains(address, "/") {
-			opt = unix.TCP_MD5SIG_EXT
-		}
-
-		sockerr = unix.SetsockoptTCPMD5Sig(int(s), unix.IPPROTO_TCP, opt, t)
+		sockerr = unix.SetsockoptTCPMD5Sig(int(s), unix.IPPROTO_TCP, unix.TCP_MD5SIG_EXT, t)
 	}); err != nil {
 		return err
 	}
@@ -199,10 +189,20 @@ func DialerControl(logger *slog.Logger, network, address string, c syscall.RawCo
 
 	var sockerr error
 	if password != "" {
+		var (
+			err  error
+			link netlink.Link
+		)
+		if bindInterface != "" {
+			link, err = netlink.LinkByName(bindInterface)
+			if err != nil {
+				return fmt.Errorf("failed to get link for interface %s: %w", bindInterface, err)
+			}
+		}
 		addr, _, _ := net.SplitHostPort(address)
-		t := buildTcpMD5Sig(addr, password)
+		t := buildTcpMD5Sig(link, addr, password)
 		if err := c.Control(func(fd uintptr) {
-			sockerr = os.NewSyscallError("setSockOpt", unix.SetsockoptTCPMD5Sig(int(fd), unix.IPPROTO_TCP, unix.TCP_MD5SIG, t))
+			sockerr = os.NewSyscallError("setSockOpt", unix.SetsockoptTCPMD5Sig(int(fd), unix.IPPROTO_TCP, unix.TCP_MD5SIG_EXT, t))
 		}); err != nil {
 			return err
 		}

--- a/vendor/github.com/osrg/gobgp/v4/internal/pkg/netutils/sockopt_openbsd.go
+++ b/vendor/github.com/osrg/gobgp/v4/internal/pkg/netutils/sockopt_openbsd.go
@@ -355,7 +355,7 @@ func SetSockOptTcpMD5Sig(sc syscall.RawConn, address string, key string) error {
 	return saDelete(address)
 }
 
-func SetTCPMD5SigSockopt(l *net.TCPListener, address string, key string) error {
+func SetTCPMD5SigSockopt(l *net.TCPListener, bindInterface string, address string, key string) error {
 	sc, err := l.SyscallConn()
 	if err != nil {
 		return err

--- a/vendor/github.com/osrg/gobgp/v4/internal/pkg/netutils/sockopt_stub.go
+++ b/vendor/github.com/osrg/gobgp/v4/internal/pkg/netutils/sockopt_stub.go
@@ -23,7 +23,7 @@ import (
 	"syscall"
 )
 
-func SetTcpMD5SigSockopt(l *net.TCPListener, address string, key string) error {
+func SetTcpMD5SigSockopt(l *net.TCPListener, bindInterface string, address string, key string) error {
 	return fmt.Errorf("setting md5 is not supported")
 }
 

--- a/vendor/github.com/osrg/gobgp/v4/internal/pkg/netutils/sockopt_windows.go
+++ b/vendor/github.com/osrg/gobgp/v4/internal/pkg/netutils/sockopt_windows.go
@@ -31,7 +31,7 @@ const (
 	TCP_MAXSEG      = 0x2  // pulled from https://pkg.go.dev/syscall?GOOS=linux#TCP_MAXSEG
 )
 
-func SetTCPMD5SigSockopt(l *net.TCPListener, address string, key string) error {
+func SetTCPMD5SigSockopt(l *net.TCPListener, bindInterface string, address string, key string) error {
 	return fmt.Errorf("setting md5 is not supported")
 }
 

--- a/vendor/github.com/osrg/gobgp/v4/internal/pkg/table/destination.go
+++ b/vendor/github.com/osrg/gobgp/v4/internal/pkg/table/destination.go
@@ -530,6 +530,41 @@ type Update struct {
 	OldKnownPathList []*Path
 }
 
+// GetMultiBestPathDiff returns multipath delta as update and withdraw lists.
+// update includes both newly added and changed paths.
+func (u *Update) GetMultiBestPathDiff(id string) (update []*Path, withdraw []*Path) {
+	oldM := getMultiBestPath(id, u.OldKnownPathList)
+	newM := getMultiBestPath(id, u.KnownPathList)
+	if len(oldM) == 0 && len(newM) == 0 {
+		return nil, nil
+	}
+
+	matchedOld := make([]bool, len(oldM))
+	for _, n := range newM {
+		match := -1
+		for idx, o := range oldM {
+			if n.EqualBySourceAndPathID(o) {
+				match = idx
+				break
+			}
+		}
+		if match == -1 {
+			update = append(update, n)
+			continue
+		}
+		matchedOld[match] = true
+		if !n.Equal(oldM[match]) {
+			update = append(update, n)
+		}
+	}
+	for idx, o := range oldM {
+		if !matchedOld[idx] {
+			withdraw = append(withdraw, o.Clone(true))
+		}
+	}
+	return update, withdraw
+}
+
 func getMultiBestPath(id string, pathList []*Path) []*Path {
 	// The path list of destinations in the global RIB are sorted
 	// in descending order. One of the criteria for being a better

--- a/vendor/github.com/osrg/gobgp/v4/internal/pkg/table/message.go
+++ b/vendor/github.com/osrg/gobgp/v4/internal/pkg/table/message.go
@@ -26,6 +26,18 @@ import (
 	"github.com/segmentio/fasthash/fnv1a"
 )
 
+// maxUpdateMessageLength returns the per-UPDATE serialisation budget
+// the packer should fill before emitting a message. When the caller
+// signalled the RFC 8654 Extended Message Capability via a
+// MarshallingOption, the cap rises from 4096 to 65535 octets - UPDATE
+// is one of the message types Section 6 of the RFC explicitly extends.
+func maxUpdateMessageLength(options []*bgp.MarshallingOption) int {
+	if bgp.IsExtendedMessageSerialization(options) {
+		return bgp.BGP_MAX_EXTENDED_MESSAGE_LENGTH
+	}
+	return bgp.BGP_MAX_MESSAGE_LENGTH
+}
+
 func UpdatePathAttrs2ByteAs(msg *bgp.BGPUpdate) {
 	ps := msg.PathAttributes
 	msg.PathAttributes = make([]bgp.PathAttributeInterface, len(ps))
@@ -397,7 +409,7 @@ func (p *packerMP) pack(options ...*bgp.MarshallingOption) []*bgp.BGPMessage {
 			return
 		}
 
-		budget := bgp.BGP_MAX_MESSAGE_LENGTH - baseLen
+		budget := maxUpdateMessageLength(options) - baseLen
 		if budget <= 0 {
 			for _, path := range paths {
 				cb([]bgp.PathNLRI{{NLRI: path.GetNlri(), ID: path.localID}})
@@ -501,7 +513,7 @@ func (p *packerMP) pack(options ...*bgp.MarshallingOption) []*bgp.BGPMessage {
 			if sampleReach, err := bgp.NewPathAttributeMpReachNLRI(paths[0].GetFamily(), []bgp.PathNLRI{sampleNLRI}, nexthops...); err == nil {
 				baseReachLen += sampleReach.Len() + 1 - paths[0].GetNlri().Len(options...) // +1 for extended-length attr header
 			} else {
-				baseReachLen = bgp.BGP_MAX_MESSAGE_LENGTH
+				baseReachLen = maxUpdateMessageLength(options)
 			}
 			split(baseReachLen, paths, func(nlris []bgp.PathNLRI) {
 				msgs = append(msgs, createMPReachMessage(paths[0], nlris))
@@ -595,7 +607,7 @@ func (p *packerV4) pack(options ...*bgp.MarshallingOption) []*bgp.BGPMessage {
 	// TotalPathAttributeLen + attributes + maxlen of NLRI).
 	// the max size of NLRI is 5bytes (plus 4bytes with addpath enabled)
 	maxNLRIs := func(attrsLen int) int {
-		return (bgp.BGP_MAX_MESSAGE_LENGTH - (19 + 2 + 2 + attrsLen)) / (5 + addpathNLRILen)
+		return (maxUpdateMessageLength(options) - (19 + 2 + 2 + attrsLen)) / (5 + addpathNLRILen)
 	}
 
 	loop := func(attrsLen int, paths []*Path, cb func([]bgp.PathNLRI)) {

--- a/vendor/github.com/osrg/gobgp/v4/internal/pkg/table/path.go
+++ b/vendor/github.com/osrg/gobgp/v4/internal/pkg/table/path.go
@@ -88,6 +88,7 @@ func NewBitmap(size int) *Bitmap {
 
 type originInfo struct {
 	nlri               bgp.NLRI
+	nlriString         string
 	source             *PeerInfo
 	timestamp          int64
 	noImplicitWithdraw bool
@@ -183,9 +184,14 @@ func NewPath(family bgp.Family, source *PeerInfo, pathnlri bgp.PathNLRI, isWithd
 	if !isWithdraw && pattrs == nil {
 		return nil
 	}
+	nlriString := ""
+	if pathnlri.NLRI != nil {
+		nlriString = pathnlri.NLRI.String()
+	}
 	return &Path{
 		info: &originInfo{
 			nlri:               pathnlri.NLRI,
+			nlriString:         nlriString,
 			source:             source,
 			timestamp:          timestamp.Unix(),
 			noImplicitWithdraw: noImplicitWithdraw,
@@ -623,7 +629,7 @@ func (path *Path) GetLocalKey() PathLocalKey {
 func (path *Path) GetDestLocalKey() PathDestLocalKey {
 	return PathDestLocalKey{
 		Family: path.GetFamily(),
-		Prefix: path.GetNlri().String(),
+		Prefix: path.OriginInfo().nlriString,
 	}
 }
 

--- a/vendor/github.com/osrg/gobgp/v4/internal/pkg/table/policy.go
+++ b/vendor/github.com/osrg/gobgp/v4/internal/pkg/table/policy.go
@@ -2298,14 +2298,14 @@ func (c *ExtCommunityCondition) Evaluate(path *Path, _ *PolicyOptions) bool {
 
 	// General path: loop over path ECs, try each matcher. Semantics preserved from original.
 	result := false
-	for _, x := range es {
+	for _, m := range c.set.matchers {
 		result = false
-		// match only with transitive community. see RFC7153
-		if !isTransitiveType(x) {
-			continue
-		}
-		var xStr string
-		for _, m := range c.set.matchers {
+		for _, x := range es {
+			// match only with transitive community. see RFC7153
+			if !isTransitiveType(x) {
+				continue
+			}
+			var xStr string
 			if m.matchesExtCommunity(x, &xStr) {
 				result = true
 				break
@@ -2314,7 +2314,7 @@ func (c *ExtCommunityCondition) Evaluate(path *Path, _ *PolicyOptions) bool {
 		if c.option == MATCH_OPTION_ALL && !result {
 			break
 		}
-		if c.option == MATCH_OPTION_ANY && result {
+		if (c.option == MATCH_OPTION_ANY || c.option == MATCH_OPTION_INVERT) && result {
 			break
 		}
 	}
@@ -4857,16 +4857,12 @@ func toStatementApi(s *oc.Statement) *api.Statement {
 		cs.RpkiResult = api.ValidationState_VALIDATION_STATE_INVALID
 	}
 	community_action := func(action string) api.CommunityAction_Type {
-		fmt.Println("action0", action)
-		switch oc.BgpSetCommunityOptionType(action) {
+		switch oc.BgpSetCommunityOptionType(strings.ToLower(action)) {
 		case oc.BGP_SET_COMMUNITY_OPTION_TYPE_ADD:
-			fmt.Println("action1", action)
 			return api.CommunityAction_TYPE_ADD
 		case oc.BGP_SET_COMMUNITY_OPTION_TYPE_REMOVE:
-			fmt.Println("action2", action)
 			return api.CommunityAction_TYPE_REMOVE
 		case oc.BGP_SET_COMMUNITY_OPTION_TYPE_REPLACE:
-			fmt.Println("action3", action)
 			return api.CommunityAction_TYPE_REPLACE
 		}
 		return api.CommunityAction_TYPE_UNSPECIFIED
@@ -4882,11 +4878,12 @@ func toStatementApi(s *oc.Statement) *api.Statement {
 			return api.RouteAction_ROUTE_ACTION_UNSPECIFIED
 		}(),
 		Community: func() *api.CommunityAction {
-			if len(s.Actions.BgpActions.SetCommunity.SetCommunityMethod.CommunitiesList) == 0 {
+			t := community_action(s.Actions.BgpActions.SetCommunity.Options)
+			if t == api.CommunityAction_TYPE_UNSPECIFIED {
 				return nil
 			}
 			return &api.CommunityAction{
-				Type:        community_action(s.Actions.BgpActions.SetCommunity.Options),
+				Type:        t,
 				Communities: s.Actions.BgpActions.SetCommunity.SetCommunityMethod.CommunitiesList,
 			}
 		}(),

--- a/vendor/github.com/osrg/gobgp/v4/pkg/apiutil/attribute.go
+++ b/vendor/github.com/osrg/gobgp/v4/pkg/apiutil/attribute.go
@@ -1075,6 +1075,23 @@ func UnmarshalLsAttribute(a *api.LsAttribute) (*bgp.LsAttribute, error) {
 			nodeSrAlgorithms = &a.Node.SrAlgorithms
 		}
 
+		// RFC 9351 Section 3: rehydrate FAD entries from the api side.
+		var nodeFlexAlgoDefs []bgp.LsAttributeFlexAlgoDef
+		for _, fad := range a.Node.FlexAlgoDefs {
+			nodeFlexAlgoDefs = append(nodeFlexAlgoDefs, bgp.LsAttributeFlexAlgoDef{
+				Algorithm:       uint8(fad.Algorithm),
+				MetricType:      uint8(fad.MetricType),
+				MetricTypeKnown: fad.MetricTypeKnown,
+				CalcType:        uint8(fad.CalcType),
+				Priority:        uint8(fad.Priority),
+				ExcludeAny:      append([]uint32(nil), fad.ExcludeAnyAffinity...),
+				IncludeAny:      append([]uint32(nil), fad.IncludeAnyAffinity...),
+				IncludeAll:      append([]uint32(nil), fad.IncludeAllAffinity...),
+				Flags:           append([]byte(nil), fad.DefinitionFlags...),
+				ExcludeSRLG:     append([]uint32(nil), fad.ExcludeSrlg...),
+			})
+		}
+
 		lsAttr.Node = bgp.LsAttributeNode{
 			Flags:           flags,
 			Opaque:          nodeOpaque,
@@ -1085,6 +1102,7 @@ func UnmarshalLsAttribute(a *api.LsAttribute) (*bgp.LsAttribute, error) {
 			SrCapabilties:   srCapabilities,
 			SrAlgorithms:    nodeSrAlgorithms,
 			SrLocalBlock:    lsSrLocalBlock,
+			FlexAlgoDefs:    nodeFlexAlgoDefs,
 		}
 	}
 
@@ -1224,6 +1242,28 @@ func UnmarshalLsAttribute(a *api.LsAttribute) (*bgp.LsAttribute, error) {
 
 	// For AttributePrefix
 	if a.Prefix != nil {
+		// RFC 9085 Section 2.1.1: rehydrate every Prefix-SID entry
+		// from the api side, plus the FAPM entries from RFC 9351
+		// Section 4. These are populated independently of IgpFlags
+		// because a Prefix NLRI can advertise SR or FAPM without
+		// carrying an IGP-Flags TLV.
+		var prefixSIDs []bgp.LsAttributePrefixSID
+		for _, sid := range a.Prefix.SrPrefixSids {
+			prefixSIDs = append(prefixSIDs, bgp.LsAttributePrefixSID{
+				Algorithm: uint8(sid.Algorithm),
+				Flags:     uint8(sid.Flags),
+				SID:       sid.Sid,
+			})
+		}
+		var fapms []bgp.LsAttributeFADPrefixMetric
+		for _, fapm := range a.Prefix.FadPrefixMetrics {
+			fapms = append(fapms, bgp.LsAttributeFADPrefixMetric{
+				Algorithm: uint8(fapm.Algorithm),
+				Flags:     uint8(fapm.Flags),
+				Metric:    fapm.Metric,
+			})
+		}
+
 		if a.Prefix.IgpFlags != nil {
 			lsAttr.Prefix = bgp.LsAttributePrefix{
 				IGPFlags: &bgp.LsIGPFlags{
@@ -1232,8 +1272,16 @@ func UnmarshalLsAttribute(a *api.LsAttribute) (*bgp.LsAttribute, error) {
 					LocalAddress:  a.Prefix.IgpFlags.LocalAddress,
 					PropagateNSSA: a.Prefix.IgpFlags.PropagateNssa,
 				},
-				Opaque:      &a.Prefix.Opaque,
-				SrPrefixSID: &a.Prefix.SrPrefixSid,
+				Opaque:           &a.Prefix.Opaque,
+				SrPrefixSID:      &a.Prefix.SrPrefixSid,
+				SrPrefixSIDs:     prefixSIDs,
+				FadPrefixMetrics: fapms,
+			}
+		} else if len(prefixSIDs) > 0 || len(fapms) > 0 {
+			// IgpFlags absent but SR / FAPM TLVs present.
+			lsAttr.Prefix = bgp.LsAttributePrefix{
+				SrPrefixSIDs:     prefixSIDs,
+				FadPrefixMetrics: fapms,
 			}
 		}
 	}
@@ -2825,6 +2873,45 @@ func NewLsAttributeFromNative(a *bgp.PathAttributeLs) (*api.LsAttribute, error) 
 			LocalAddress:  attr.Prefix.IGPFlags.LocalAddress,
 			PropagateNssa: attr.Prefix.IGPFlags.PropagateNSSA,
 		}
+	}
+
+	// RFC 9351 Section 3: surface every FAD observed for this Node
+	// NLRI. The packet layer keeps reserved Metric-Type values
+	// verbatim with MetricTypeKnown=false; pass that through.
+	for _, fad := range attr.Node.FlexAlgoDefs {
+		apiAttr.Node.FlexAlgoDefs = append(apiAttr.Node.FlexAlgoDefs, &api.LsAttributeFlexAlgoDef{
+			Algorithm:          uint32(fad.Algorithm),
+			MetricType:         uint32(fad.MetricType),
+			MetricTypeKnown:    fad.MetricTypeKnown,
+			CalcType:           uint32(fad.CalcType),
+			Priority:           uint32(fad.Priority),
+			ExcludeAnyAffinity: append([]uint32(nil), fad.ExcludeAny...),
+			IncludeAnyAffinity: append([]uint32(nil), fad.IncludeAny...),
+			IncludeAllAffinity: append([]uint32(nil), fad.IncludeAll...),
+			DefinitionFlags:    append([]byte(nil), fad.Flags...),
+			ExcludeSrlg:        append([]uint32(nil), fad.ExcludeSRLG...),
+		})
+	}
+
+	// RFC 9085 Section 2.1.1: surface every Prefix-SID TLV; the
+	// singular sr_prefix_sid field above is already populated for
+	// Algorithm-0 by the projection path.
+	for _, sid := range attr.Prefix.SrPrefixSIDs {
+		apiAttr.Prefix.SrPrefixSids = append(apiAttr.Prefix.SrPrefixSids, &api.LsAttributePrefixSID{
+			Algorithm: uint32(sid.Algorithm),
+			Flags:     uint32(sid.Flags),
+			Sid:       sid.SID,
+		})
+	}
+
+	// RFC 9351 Section 4: surface every FAPM TLV observed for this
+	// Prefix NLRI.
+	for _, fapm := range attr.Prefix.FadPrefixMetrics {
+		apiAttr.Prefix.FadPrefixMetrics = append(apiAttr.Prefix.FadPrefixMetrics, &api.LsAttributeFADPrefixMetric{
+			Algorithm: uint32(fapm.Algorithm),
+			Flags:     uint32(fapm.Flags),
+			Metric:    fapm.Metric,
+		})
 	}
 
 	return apiAttr, nil

--- a/vendor/github.com/osrg/gobgp/v4/pkg/apiutil/capability.go
+++ b/vendor/github.com/osrg/gobgp/v4/pkg/apiutil/capability.go
@@ -32,6 +32,14 @@ func NewRouteRefreshCapability(a *bgp.CapRouteRefresh) *api.RouteRefreshCapabili
 	return &api.RouteRefreshCapability{}
 }
 
+// NewExtendedMessageCapability mirrors the empty-TLV shape RFC 8654
+// gives the BGP Extended Message capability. There is no payload to
+// project; the API consumer just needs to know the peer advertised
+// the capability.
+func NewExtendedMessageCapability(a *bgp.CapExtendedMessage) *api.ExtendedMessageCapability {
+	return &api.ExtendedMessageCapability{}
+}
+
 func NewCarryingLabelInfoCapability(a *bgp.CapCarryingLabelInfo) *api.CarryingLabelInfoCapability {
 	return &api.CarryingLabelInfoCapability{}
 }
@@ -152,6 +160,8 @@ func MarshalCapability(value bgp.ParameterCapabilityInterface) (*api.Capability,
 		m.Cap = &api.Capability_Fqdn{Fqdn: NewFQDNCapability(n)}
 	case *bgp.CapSoftwareVersion:
 		m.Cap = &api.Capability_SoftwareVersion{SoftwareVersion: NewSoftwareVersionCapability(n)}
+	case *bgp.CapExtendedMessage:
+		m.Cap = &api.Capability_ExtendedMessage{ExtendedMessage: NewExtendedMessageCapability(n)}
 	case *bgp.CapUnknown:
 		m.Cap = &api.Capability_Unknown{Unknown: NewUnknownCapability(n)}
 	default:
@@ -247,6 +257,8 @@ func unmarshalCapability(a *api.Capability) (bgp.ParameterCapabilityInterface, e
 	case *api.Capability_SoftwareVersion:
 		a := cap.SoftwareVersion
 		return bgp.NewCapSoftwareVersion(a.SoftwareVersion), nil
+	case *api.Capability_ExtendedMessage:
+		return bgp.NewCapExtendedMessage(), nil
 	case *api.Capability_Unknown:
 		a := cap.Unknown
 		return bgp.NewCapUnknown(bgp.BGPCapabilityCode(a.Code), a.Value), nil

--- a/vendor/github.com/osrg/gobgp/v4/pkg/config/oc/bgp_configs.go
+++ b/vendor/github.com/osrg/gobgp/v4/pkg/config/oc/bgp_configs.go
@@ -5090,6 +5090,9 @@ type GlobalState struct {
 	// original -> gobgp:local-address
 	// original type is list of inet:ip-address
 	LocalAddressList []netip.Addr `mapstructure:"local-address-list" json:"local-address-list,omitempty"`
+	// original -> gobgp:bind-to-device
+	// Device name for binding the BGP listener socket.
+	BindToDevice string `mapstructure:"bind-to-device" json:"bind-to-device,omitempty"`
 }
 
 // struct for container bgp:config.
@@ -5110,6 +5113,9 @@ type GlobalConfig struct {
 	// original -> gobgp:local-address
 	// original type is list of inet:ip-address
 	LocalAddressList []netip.Addr `mapstructure:"local-address-list" json:"local-address-list,omitempty"`
+	// original -> gobgp:bind-to-device
+	// Device name for binding the BGP listener socket.
+	BindToDevice string `mapstructure:"bind-to-device" json:"bind-to-device,omitempty"`
 }
 
 func (lhs *GlobalConfig) Equal(rhs *GlobalConfig) bool {
@@ -5132,6 +5138,9 @@ func (lhs *GlobalConfig) Equal(rhs *GlobalConfig) bool {
 		if l != rhs.LocalAddressList[idx] {
 			return false
 		}
+	}
+	if lhs.BindToDevice != rhs.BindToDevice {
+		return false
 	}
 	return true
 }

--- a/vendor/github.com/osrg/gobgp/v4/pkg/config/oc/util.go
+++ b/vendor/github.com/osrg/gobgp/v4/pkg/config/oc/util.go
@@ -733,11 +733,12 @@ func NewPeerGroupFromConfigStruct(pconf *PeerGroup) *api.PeerGroup {
 			LocalRestarting:     pconf.GracefulRestart.State.LocalRestarting,
 		},
 		Transport: &api.Transport{
-			RemotePort:   uint32(pconf.Transport.Config.RemotePort),
-			LocalAddress: pconf.Transport.Config.LocalAddress.String(),
-			PassiveMode:  pconf.Transport.Config.PassiveMode,
-			TcpMss:       uint32(pconf.Transport.Config.TcpMss),
-			IpTos:        uint32(pconf.Transport.Config.IpTos),
+			RemotePort:    uint32(pconf.Transport.Config.RemotePort),
+			LocalAddress:  pconf.Transport.Config.LocalAddress.String(),
+			PassiveMode:   pconf.Transport.Config.PassiveMode,
+			BindInterface: pconf.Transport.Config.BindInterface,
+			TcpMss:        uint32(pconf.Transport.Config.TcpMss),
+			IpTos:         uint32(pconf.Transport.Config.IpTos),
 		},
 		AfiSafis: afiSafis,
 		Bfd: &api.BfdPeerConfig{
@@ -768,6 +769,7 @@ func NewGlobalFromConfigStruct(c *Global) *api.Global {
 		ListenAddresses:  l,
 		Families:         families,
 		UseMultiplePaths: c.UseMultiplePaths.Config.Enabled,
+		BindToDevice:     c.Config.BindToDevice,
 		RouteSelectionOptions: &api.RouteSelectionOptionsConfig{
 			AlwaysCompareMed:         c.RouteSelectionOptions.Config.AlwaysCompareMed,
 			IgnoreAsPathLength:       c.RouteSelectionOptions.Config.IgnoreAsPathLength,

--- a/vendor/github.com/osrg/gobgp/v4/pkg/packet/bgp/bgp.go
+++ b/vendor/github.com/osrg/gobgp/v4/pkg/packet/bgp/bgp.go
@@ -37,8 +37,30 @@ type MarshallingOption struct {
 	AddPath    map[Family]BGPAddPathMode
 	MRT        bool
 	Use2ByteAS bool // true if peer does NOT support 4-byte AS capability
+	// ExtendedMessage signals that the BGP Extended Message Capability
+	// (RFC 8654) is negotiated on the session this serialisation is
+	// for. When true the per-message-type length cap rises from 4096
+	// to 65535 octets for UPDATE, NOTIFICATION and ROUTE-REFRESH;
+	// OPEN and KEEPALIVE keep the 4096-octet cap per RFC 8654 Section 6.
+	ExtendedMessage bool
 
 	attributes map[BGPAttrType]bool
+}
+
+// IsExtendedMessageSerialization reports whether any element of
+// options carries the RFC 8654 ExtendedMessage flag set. Used by
+// BGPMessage.Serialize to lift the length cap on the messages where
+// the RFC allows it.
+func IsExtendedMessageSerialization(options []*MarshallingOption) bool {
+	for _, opt := range options {
+		if opt == nil {
+			continue
+		}
+		if opt.ExtendedMessage {
+			return true
+		}
+	}
+	return false
 }
 
 func IsMRTSerialization(options []*MarshallingOption) bool {
@@ -373,6 +395,7 @@ const (
 	BGP_CAP_ROUTE_REFRESH               BGPCapabilityCode = 2
 	BGP_CAP_CARRYING_LABEL_INFO         BGPCapabilityCode = 4
 	BGP_CAP_EXTENDED_NEXTHOP            BGPCapabilityCode = 5
+	BGP_CAP_EXTENDED_MESSAGE            BGPCapabilityCode = 6
 	BGP_CAP_GRACEFUL_RESTART            BGPCapabilityCode = 64
 	BGP_CAP_FOUR_OCTET_AS_NUMBER        BGPCapabilityCode = 65
 	BGP_CAP_ADD_PATH                    BGPCapabilityCode = 69
@@ -389,6 +412,7 @@ var CapNameMap = map[BGPCapabilityCode]string{
 	BGP_CAP_CARRYING_LABEL_INFO:         "carrying-label-info",
 	BGP_CAP_GRACEFUL_RESTART:            "graceful-restart",
 	BGP_CAP_EXTENDED_NEXTHOP:            "extended-nexthop",
+	BGP_CAP_EXTENDED_MESSAGE:            "extended-message",
 	BGP_CAP_FOUR_OCTET_AS_NUMBER:        "4-octet-as",
 	BGP_CAP_ADD_PATH:                    "add-path",
 	BGP_CAP_ENHANCED_ROUTE_REFRESH:      "enhanced-route-refresh",
@@ -547,6 +571,24 @@ func NewCapRouteRefresh() *CapRouteRefresh {
 	return &CapRouteRefresh{
 		DefaultParameterCapability{
 			CapCode: BGP_CAP_ROUTE_REFRESH,
+		},
+	}
+}
+
+// CapExtendedMessage advertises the BGP Extended Message capability
+// from RFC 8654. The capability TLV is empty (Capability Code 6,
+// Capability Length 0). When both peers advertise it the maximum BGP
+// message size for UPDATE, NOTIFICATION and ROUTE-REFRESH grows from
+// 4096 to 65535 octets; OPEN and KEEPALIVE remain capped at 4096
+// (RFC 8654 Section 6).
+type CapExtendedMessage struct {
+	DefaultParameterCapability
+}
+
+func NewCapExtendedMessage() *CapExtendedMessage {
+	return &CapExtendedMessage{
+		DefaultParameterCapability{
+			CapCode: BGP_CAP_EXTENDED_MESSAGE,
 		},
 	}
 }
@@ -1175,6 +1217,8 @@ func DecodeCapability(data []byte) (ParameterCapabilityInterface, error) {
 		c = &CapCarryingLabelInfo{}
 	case BGP_CAP_EXTENDED_NEXTHOP:
 		c = &CapExtendedNexthop{}
+	case BGP_CAP_EXTENDED_MESSAGE:
+		c = &CapExtendedMessage{}
 	case BGP_CAP_GRACEFUL_RESTART:
 		c = &CapGracefulRestart{}
 	case BGP_CAP_FOUR_OCTET_AS_NUMBER:
@@ -5051,9 +5095,26 @@ func (l *LsLinkDescriptor) String() string {
 	default:
 		base = "UNKNOWN"
 	}
-	// MT-ID participates in the destination key (RFC 7752 §3.2.1.5).
-	// Two ISIS-MT advertisements of the same physical link must not
-	// collide in the RIB.
+
+	// The Link Local/Remote Identifier sub-TLV (Type 258, RFC 7752
+	// Table 5) coexists with the interface/neighbor address sub-TLVs
+	// in some NLRI shapes. RFC 9086 Section 5.2 mandates Type 258 on
+	// PeerAdj-SID Link NLRIs and lets the producer also include the
+	// IPv4 or IPv6 address sub-TLVs alongside. PeerNode-SID Link
+	// NLRIs for the same eBGP session may share the addresses but
+	// omit Type 258. The two NLRIs are distinct prefixes in
+	// adj-RIB-in because of Type 258's presence, so the String form
+	// must show the identifier whenever it is set or two distinct
+	// prefixes collide in any caller keyed on this output.
+	if l.LinkLocalID != nil && l.LinkRemoteID != nil &&
+		(l.InterfaceAddrIPv4 != nil || l.NeighborAddrIPv4 != nil ||
+			l.InterfaceAddrIPv6 != nil || l.NeighborAddrIPv6 != nil) {
+		base += fmt.Sprintf("(L:%d,R:%d)", *l.LinkLocalID, *l.LinkRemoteID)
+	}
+
+	// MT-ID participates in the destination key (RFC 7752 Section
+	// 3.2.1.5). Two ISIS-MT advertisements of the same physical link
+	// must not collide in the RIB.
 	return base + multiTopoIDsToString(l.MultiTopoIDs)
 }
 
@@ -5864,6 +5925,19 @@ const (
 	LS_TLV_SR_ALGORITHM    = 1035 // draft-ietf-idr-bgp-ls-segment-routing-ext
 	LS_TLV_SR_LOCAL_BLOCK  = 1036 // draft-ietf-idr-bgp-ls-segment-routing-ext
 	LS_TLV_SRMS_PREFERENCE = 1037 // draft-ietf-idr-bgp-ls-segment-routing-ext, TODO
+
+	// Flexible Algorithm Definition (RFC9351 Section 3, IS-IS source RFC9350).
+	// TLV 1039 is a Node Attribute TLV. 1040, 1041, 1042, 1043, 1045 and 1046
+	// are sub-TLVs nested inside TLV 1039. TLV 1044 (FAPM) is a top-level
+	// Prefix Attribute TLV; see LS_TLV_FAD_PREFIX_METRIC below.
+	LS_TLV_FLEX_ALGO_DEF            = 1039 // RFC9351 Section 3
+	LS_TLV_FAD_EXCLUDE_ANY_AFFINITY = 1040 // RFC9351 Section 3.1
+	LS_TLV_FAD_INCLUDE_ANY_AFFINITY = 1041 // RFC9351 Section 3.2
+	LS_TLV_FAD_INCLUDE_ALL_AFFINITY = 1042 // RFC9351 Section 3.3
+	LS_TLV_FAD_DEFINITION_FLAGS     = 1043 // RFC9351 Section 3.4
+	LS_TLV_FAD_PREFIX_METRIC        = 1044 // RFC9351 Section 4 (FAPM, Prefix-side)
+	LS_TLV_FAD_EXCLUDE_SRLG         = 1045 // RFC9351 Section 3.5
+	LS_TLV_FAD_UNSUPPORTED          = 1046 // RFC9351 Section 3.6
 
 	LS_TLV_ADMIN_GROUP              = 1088
 	LS_TLV_MAX_LINK_BANDWIDTH       = 1089
@@ -7240,7 +7314,10 @@ type LsTLVIPReachability struct {
 
 func (l *LsTLVIPReachability) toPrefix(ipv6 bool) netip.Prefix {
 	b := make([]byte, 16)
-	bytes := (int(l.PrefixLength)-1)/8 + 1
+	bytes := 0
+	if l.PrefixLength > 0 {
+		bytes = (int(l.PrefixLength)-1)/8 + 1
+	}
 	for i := range bytes {
 		if i >= len(l.Prefix) {
 			break
@@ -7273,16 +7350,20 @@ func (l *LsTLVIPReachability) DecodeFromBytes(data []byte) error {
 		return malformedAttrListErr("Unexpected TLV type")
 	}
 
-	if len(value) < 2 {
+	if len(value) < 1 {
 		return malformedAttrListErr("Incorrect IP reachability Info length")
 	}
 
 	// https://tools.ietf.org/html/rfc7752#section-3.2.3.2
-	if value[0] > 128 || value[0] == 0 {
+	// PrefixLength 0 is valid (default route 0.0.0.0/0 or ::/0).
+	if value[0] > 128 {
 		return malformedAttrListErr("Incorrect IP prefix length")
 	}
 
-	ll := (int(value[0])-1)/8 + 1
+	ll := 0
+	if value[0] > 0 {
+		ll = (int(value[0])-1)/8 + 1
+	}
 	if len(value[1:]) != ll {
 		return malformedAttrListErr("Malformed IP reachability TLV")
 	}
@@ -8417,6 +8498,340 @@ func (l *LsTLVSrLocalBlock) MarshalJSON() ([]byte, error) {
 }
 
 func (l *LsTLVSrLocalBlock) GetLsTLV() LsTLV {
+	return l.LsTLV
+}
+
+// LsTLVFlexAlgoDef wire format (RFC 9351 Section 3):
+//
+//	byte 0     Flex Algo ID (128..255 per RFC 9350 Section 4)
+//	byte 1     Metric-Type (0=IGP, 1=Min-Delay, 2=TE per RFC 9350
+//	           Section 5.1)
+//	byte 2     Calc-Type (0=SPF per RFC 9350 Section 5.2)
+//	byte 3     Priority (RFC 9350 Section 5.3)
+//	bytes 4+   zero or more nested sub-TLVs in BGP-LS sub-TLV format
+//	           (Type 2B + Length 2B + Value), codepoints 1040, 1041,
+//	           1042, 1043, 1045, 1046.
+//
+// Sub-TLVs are decoded into typed fields below; unknown sub-TLV types
+// are preserved in the Unknown slice so a future caller can inspect
+// them without re-parsing the value bytes. Multiple FADs MAY be
+// advertised for the same Node NLRI (one per algorithm), so the
+// containing PathAttributeLs Extract aggregates them into a slice.
+
+// LsTLVFlexAlgoSubTLVRaw preserves a sub-TLV whose type is not one of
+// the codepoints RFC 9351 currently defines. Keeping the raw bytes
+// lets callers inspect or re-serialise the FAD without losing data
+// and matches the forward-compatibility requirement in RFC 9351
+// Section 3.
+type LsTLVFlexAlgoSubTLVRaw struct {
+	Type  LsTLVType
+	Value []byte
+}
+
+type LsTLVFlexAlgoDef struct {
+	LsTLV
+	Algorithm   uint8
+	MetricType  uint8
+	CalcType    uint8
+	Priority    uint8
+	ExcludeAny  []uint32                 // RFC9351 Section 3.1 (sub-TLV 1040)
+	IncludeAny  []uint32                 // RFC9351 Section 3.2 (sub-TLV 1041)
+	IncludeAll  []uint32                 // RFC9351 Section 3.3 (sub-TLV 1042)
+	Flags       []byte                   // RFC9351 Section 3.4 (sub-TLV 1043; bit ordering per RFC9350 Section 6.4)
+	ExcludeSRLG []uint32                 // RFC9351 Section 3.5 (sub-TLV 1045)
+	Unsupported *LsTLVFADUnsupported     // RFC9351 Section 3.6 (sub-TLV 1046)
+	Unknown     []LsTLVFlexAlgoSubTLVRaw // forward-compat for sub-TLVs not defined by RFC 9351
+}
+
+// LsTLVFADUnsupported records the Flex-Algorithm Unsupported sub-TLV
+// (RFC 9351 Section 3.6): a Protocol-ID byte plus the list of sub-TLV
+// type codes the originating node could not honour.
+type LsTLVFADUnsupported struct {
+	ProtocolID  uint8
+	SubTLVTypes []uint16
+}
+
+func (l *LsTLVFlexAlgoDef) DecodeFromBytes(data []byte) error {
+	value, err := l.LsTLV.DecodeFromBytes(data)
+	if err != nil {
+		return err
+	}
+	if l.Type != LS_TLV_FLEX_ALGO_DEF {
+		return malformedAttrListErr("Unexpected TLV type")
+	}
+	if len(value) < 4 {
+		return malformedAttrListErr("FAD TLV too short")
+	}
+	l.Algorithm = value[0]
+	l.MetricType = value[1]
+	l.CalcType = value[2]
+	l.Priority = value[3]
+	if l.Algorithm < 128 {
+		return malformedAttrListErr("FAD Algorithm reserved (must be 128..255)")
+	}
+
+	rem := value[4:]
+	for len(rem) >= 4 {
+		stype := binary.BigEndian.Uint16(rem[:2])
+		slen := int(binary.BigEndian.Uint16(rem[2:4]))
+		if 4+slen > len(rem) {
+			return malformedAttrListErr("FAD sub-TLV truncated")
+		}
+		sv := rem[4 : 4+slen]
+		switch LsTLVType(stype) {
+		case LS_TLV_FAD_EXCLUDE_ANY_AFFINITY:
+			if slen == 0 || slen%4 != 0 {
+				return malformedAttrListErr("FAD Exclude-Any length must be non-zero multiple of 4")
+			}
+			for i := 0; i+4 <= slen; i += 4 {
+				l.ExcludeAny = append(l.ExcludeAny, binary.BigEndian.Uint32(sv[i:i+4]))
+			}
+		case LS_TLV_FAD_INCLUDE_ANY_AFFINITY:
+			if slen == 0 || slen%4 != 0 {
+				return malformedAttrListErr("FAD Include-Any length must be non-zero multiple of 4")
+			}
+			for i := 0; i+4 <= slen; i += 4 {
+				l.IncludeAny = append(l.IncludeAny, binary.BigEndian.Uint32(sv[i:i+4]))
+			}
+		case LS_TLV_FAD_INCLUDE_ALL_AFFINITY:
+			if slen == 0 || slen%4 != 0 {
+				return malformedAttrListErr("FAD Include-All length must be non-zero multiple of 4")
+			}
+			for i := 0; i+4 <= slen; i += 4 {
+				l.IncludeAll = append(l.IncludeAll, binary.BigEndian.Uint32(sv[i:i+4]))
+			}
+		case LS_TLV_FAD_DEFINITION_FLAGS:
+			if slen == 0 || slen%4 != 0 {
+				return malformedAttrListErr("FAD Flags length must be non-zero multiple of 4")
+			}
+			l.Flags = append(l.Flags[:0], sv...)
+		case LS_TLV_FAD_EXCLUDE_SRLG:
+			if slen == 0 || slen%4 != 0 {
+				return malformedAttrListErr("FAD Exclude SRLG length must be non-zero multiple of 4")
+			}
+			for i := 0; i+4 <= slen; i += 4 {
+				l.ExcludeSRLG = append(l.ExcludeSRLG, binary.BigEndian.Uint32(sv[i:i+4]))
+			}
+		case LS_TLV_FAD_UNSUPPORTED:
+			if slen < 1 {
+				return malformedAttrListErr("FAD Unsupported sub-TLV must be at least 1 byte")
+			}
+			u := &LsTLVFADUnsupported{ProtocolID: sv[0]}
+			body := sv[1:]
+			if len(body)%2 != 0 {
+				return malformedAttrListErr("FAD Unsupported sub-TLV type list must be a multiple of 2")
+			}
+			for i := 0; i+2 <= len(body); i += 2 {
+				u.SubTLVTypes = append(u.SubTLVTypes, binary.BigEndian.Uint16(body[i:i+2]))
+			}
+			l.Unsupported = u
+		default:
+			cp := make([]byte, slen)
+			copy(cp, sv)
+			l.Unknown = append(l.Unknown, LsTLVFlexAlgoSubTLVRaw{Type: LsTLVType(stype), Value: cp})
+		}
+		rem = rem[4+slen:]
+	}
+	return nil
+}
+
+func (l *LsTLVFlexAlgoDef) Serialize() ([]byte, error) {
+	body := make([]byte, 0, 4)
+	body = append(body, l.Algorithm, l.MetricType, l.CalcType, l.Priority)
+
+	appendSub := func(t LsTLVType, v []byte) {
+		var hdr [4]byte
+		binary.BigEndian.PutUint16(hdr[:2], uint16(t))
+		binary.BigEndian.PutUint16(hdr[2:4], uint16(len(v)))
+		body = append(body, hdr[:]...)
+		body = append(body, v...)
+	}
+	u32slice := func(in []uint32) []byte {
+		out := make([]byte, 4*len(in))
+		for i, v := range in {
+			binary.BigEndian.PutUint32(out[4*i:4*i+4], v)
+		}
+		return out
+	}
+	if len(l.ExcludeAny) > 0 {
+		appendSub(LS_TLV_FAD_EXCLUDE_ANY_AFFINITY, u32slice(l.ExcludeAny))
+	}
+	if len(l.IncludeAny) > 0 {
+		appendSub(LS_TLV_FAD_INCLUDE_ANY_AFFINITY, u32slice(l.IncludeAny))
+	}
+	if len(l.IncludeAll) > 0 {
+		appendSub(LS_TLV_FAD_INCLUDE_ALL_AFFINITY, u32slice(l.IncludeAll))
+	}
+	if len(l.Flags) > 0 {
+		appendSub(LS_TLV_FAD_DEFINITION_FLAGS, l.Flags)
+	}
+	if len(l.ExcludeSRLG) > 0 {
+		appendSub(LS_TLV_FAD_EXCLUDE_SRLG, u32slice(l.ExcludeSRLG))
+	}
+	if l.Unsupported != nil {
+		buf := make([]byte, 1+2*len(l.Unsupported.SubTLVTypes))
+		buf[0] = l.Unsupported.ProtocolID
+		for i, t := range l.Unsupported.SubTLVTypes {
+			binary.BigEndian.PutUint16(buf[1+2*i:1+2*i+2], t)
+		}
+		appendSub(LS_TLV_FAD_UNSUPPORTED, buf)
+	}
+	for _, raw := range l.Unknown {
+		appendSub(raw.Type, raw.Value)
+	}
+	l.Length = uint16(len(body))
+	return l.LsTLV.Serialize(body)
+}
+
+func (l *LsTLVFlexAlgoDef) String() string {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "{Flex-Algo Def: %d metric:%d calc:%d prio:%d",
+		l.Algorithm, l.MetricType, l.CalcType, l.Priority)
+	if len(l.ExcludeAny) > 0 {
+		fmt.Fprintf(&buf, " exclude-any:%s", flexAlgoUint32SliceHex(l.ExcludeAny))
+	}
+	if len(l.IncludeAny) > 0 {
+		fmt.Fprintf(&buf, " include-any:%s", flexAlgoUint32SliceHex(l.IncludeAny))
+	}
+	if len(l.IncludeAll) > 0 {
+		fmt.Fprintf(&buf, " include-all:%s", flexAlgoUint32SliceHex(l.IncludeAll))
+	}
+	if len(l.Flags) > 0 {
+		fmt.Fprintf(&buf, " flags:%s", flexAlgoByteSliceHex(l.Flags))
+	}
+	if len(l.ExcludeSRLG) > 0 {
+		fmt.Fprintf(&buf, " exclude-srlg:%v", l.ExcludeSRLG)
+	}
+	if l.Unsupported != nil {
+		fmt.Fprintf(&buf, " unsupported:{proto:%d types:%v}",
+			l.Unsupported.ProtocolID, l.Unsupported.SubTLVTypes)
+	}
+	buf.WriteString("}")
+	return buf.String()
+}
+
+// flexAlgoUint32SliceHex formats a slice of 32-bit affinity bitmaps
+// as a comma-separated hex list, e.g. [0x0000000F 0x000000F0]. Used
+// by LsTLVFlexAlgoDef.String to keep the CLI render compact and easy
+// to compare against vendor "show isis flex-algorithm" output.
+func flexAlgoUint32SliceHex(in []uint32) string {
+	var buf bytes.Buffer
+	buf.WriteString("[")
+	for i, v := range in {
+		if i > 0 {
+			buf.WriteString(" ")
+		}
+		fmt.Fprintf(&buf, "0x%08x", v)
+	}
+	buf.WriteString("]")
+	return buf.String()
+}
+
+func flexAlgoByteSliceHex(in []byte) string {
+	var buf bytes.Buffer
+	buf.WriteString("[")
+	for i, v := range in {
+		if i > 0 {
+			buf.WriteString(" ")
+		}
+		fmt.Fprintf(&buf, "0x%02x", v)
+	}
+	buf.WriteString("]")
+	return buf.String()
+}
+
+func (l *LsTLVFlexAlgoDef) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type        LsTLVType `json:"type"`
+		Algorithm   uint8     `json:"algorithm"`
+		MetricType  uint8     `json:"metric_type"`
+		CalcType    uint8     `json:"calc_type"`
+		Priority    uint8     `json:"priority"`
+		ExcludeAny  []uint32  `json:"exclude_any_affinity,omitempty"`
+		IncludeAny  []uint32  `json:"include_any_affinity,omitempty"`
+		IncludeAll  []uint32  `json:"include_all_affinity,omitempty"`
+		Flags       []byte    `json:"definition_flags,omitempty"`
+		ExcludeSRLG []uint32  `json:"exclude_srlg,omitempty"`
+	}{
+		Type:        l.Type,
+		Algorithm:   l.Algorithm,
+		MetricType:  l.MetricType,
+		CalcType:    l.CalcType,
+		Priority:    l.Priority,
+		ExcludeAny:  l.ExcludeAny,
+		IncludeAny:  l.IncludeAny,
+		IncludeAll:  l.IncludeAll,
+		Flags:       l.Flags,
+		ExcludeSRLG: l.ExcludeSRLG,
+	})
+}
+
+func (l *LsTLVFlexAlgoDef) GetLsTLV() LsTLV {
+	return l.LsTLV
+}
+
+// LsTLVFADPrefixMetric carries the Flexible Algorithm Prefix Metric
+// (FAPM) Prefix Attribute TLV defined by RFC 9351 Section 4. The
+// codepoint sits in the same registry as the FAD sub-TLVs but the
+// TLV is a top-level Prefix Attribute, not nested inside TLV 1039.
+// Length is fixed at 8 octets.
+type LsTLVFADPrefixMetric struct {
+	LsTLV
+	Algorithm uint8
+	Flags     uint8 // OSPF-specific per RFC9351 Section 4; MUST be 0 for IS-IS
+	Metric    uint32
+}
+
+func (l *LsTLVFADPrefixMetric) DecodeFromBytes(data []byte) error {
+	value, err := l.LsTLV.DecodeFromBytes(data)
+	if err != nil {
+		return err
+	}
+	if l.Type != LS_TLV_FAD_PREFIX_METRIC {
+		return malformedAttrListErr("Unexpected TLV type")
+	}
+	if len(value) != 8 {
+		return malformedAttrListErr("FAPM Prefix Attribute TLV length must be 8")
+	}
+	l.Algorithm = value[0]
+	l.Flags = value[1]
+	// value[2:4] is Reserved per RFC9351 Section 4 and MUST be ignored.
+	l.Metric = binary.BigEndian.Uint32(value[4:8])
+	if l.Algorithm < 128 {
+		return malformedAttrListErr("FAPM Algorithm reserved (must be 128..255)")
+	}
+	return nil
+}
+
+func (l *LsTLVFADPrefixMetric) Serialize() ([]byte, error) {
+	buf := make([]byte, 8)
+	buf[0] = l.Algorithm
+	buf[1] = l.Flags
+	// bytes 2..3 are Reserved (RFC9351 Section 4) and stay zero.
+	binary.BigEndian.PutUint32(buf[4:8], l.Metric)
+	l.Length = 8
+	return l.LsTLV.Serialize(buf)
+}
+
+func (l *LsTLVFADPrefixMetric) String() string {
+	return fmt.Sprintf("{FAPM: algo %d metric %d}", l.Algorithm, l.Metric)
+}
+
+func (l *LsTLVFADPrefixMetric) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type      LsTLVType `json:"type"`
+		Algorithm uint8     `json:"algorithm"`
+		Flags     uint8     `json:"flags,omitempty"`
+		Metric    uint32    `json:"metric"`
+	}{
+		Type:      l.Type,
+		Algorithm: l.Algorithm,
+		Flags:     l.Flags,
+		Metric:    l.Metric,
+	})
+}
+
+func (l *LsTLVFADPrefixMetric) GetLsTLV() LsTLV {
 	return l.LsTLV
 }
 
@@ -10269,6 +10684,30 @@ type LsAttributeNode struct {
 	SrCapabilties *LsSrCapabilities `json:"sr_capabilities,omitempty"`
 	SrAlgorithms  *[]byte           `json:"sr_algorithms,omitempty"`
 	SrLocalBlock  *LsSrLocalBlock   `json:"sr_local_block,omitempty"`
+
+	// Flexible Algorithm (RFC9351 Section 3 / RFC9350 source).
+	// A node MAY advertise more than one FAD, one per algorithm in
+	// [128, 255]; the order is the order in which the TLVs appeared.
+	FlexAlgoDefs []LsAttributeFlexAlgoDef `json:"flex_algo_defs,omitempty"`
+}
+
+// LsAttributeFlexAlgoDef is the structured projection of a single
+// FAD TLV (TLV 1039, RFC 9351 Section 3) into the LsAttribute
+// surface. Per RFC 9350 Section 5.1 reserved Metric-Type values
+// (3..127) are kept verbatim with MetricTypeKnown=false so callers
+// can render them as "advertised but unknown" instead of guessing
+// semantics.
+type LsAttributeFlexAlgoDef struct {
+	Algorithm       uint8    `json:"algorithm"`
+	MetricType      uint8    `json:"metric_type"`
+	MetricTypeKnown bool     `json:"metric_type_known"`
+	CalcType        uint8    `json:"calc_type"`
+	Priority        uint8    `json:"priority"`
+	ExcludeAny      []uint32 `json:"exclude_any_affinity,omitempty"`
+	IncludeAny      []uint32 `json:"include_any_affinity,omitempty"`
+	IncludeAll      []uint32 `json:"include_all_affinity,omitempty"`
+	Flags           []byte   `json:"definition_flags,omitempty"`
+	ExcludeSRLG     []uint32 `json:"exclude_srlg,omitempty"`
 }
 
 type LsAttributeLink struct {
@@ -10301,7 +10740,37 @@ type LsAttributePrefix struct {
 	IGPFlags *LsIGPFlags `json:"igp_flags,omitempty"`
 	Opaque   *[]byte     `json:"opaque,omitempty"`
 
-	SrPrefixSID *uint32 `json:"sr_prefix_sid,omitempty"`
+	// SrPrefixSID holds the SR-MPLS Prefix-SID of the prefix when the
+	// originator advertised it with Algorithm = 0 (default SPF). RFC
+	// 9085 Section 2.1.1 permits several Prefix-SID TLVs on the same
+	// Prefix NLRI, one per algorithm, so SrPrefixSIDs below carries
+	// the full list (Algorithm + Flags + SID) without losing entries.
+	// SrPrefixSID stays for backward compatibility with the singular
+	// Algorithm-0 lookup callers already perform.
+	SrPrefixSID  *uint32                `json:"sr_prefix_sid,omitempty"`
+	SrPrefixSIDs []LsAttributePrefixSID `json:"sr_prefix_sids,omitempty"`
+
+	// FadPrefixMetrics carries any FAPM (Flexible Algorithm Prefix
+	// Metric) Prefix Attribute TLVs (TLV 1044, RFC 9351 Section 4)
+	// attached to the prefix. One entry per Flex-Algorithm announced.
+	FadPrefixMetrics []LsAttributeFADPrefixMetric `json:"fad_prefix_metrics,omitempty"`
+}
+
+// LsAttributePrefixSID projects one Prefix-SID TLV (RFC 9085
+// Section 2.1.1) into the LsAttribute surface so callers can read
+// Algorithm + Flags without re-parsing the wire bytes.
+type LsAttributePrefixSID struct {
+	Algorithm uint8  `json:"algorithm"`
+	Flags     uint8  `json:"flags"`
+	SID       uint32 `json:"sid"`
+}
+
+// LsAttributeFADPrefixMetric projects one FAPM TLV (RFC 9351
+// Section 4) into the LsAttribute surface.
+type LsAttributeFADPrefixMetric struct {
+	Algorithm uint8  `json:"algorithm"`
+	Flags     uint8  `json:"flags,omitempty"`
+	Metric    uint32 `json:"metric"`
 }
 
 type LsAttributeBgpPeerSegment struct {
@@ -10418,7 +10887,44 @@ func (p *PathAttributeLs) Extract() *LsAttribute {
 			l.Prefix.Opaque = &v.Attr
 
 		case *LsTLVPrefixSID:
-			l.Prefix.SrPrefixSID = &v.SID
+			// RFC 9085 Section 2.1.1 allows multiple Prefix-SID TLVs
+			// on the same Prefix NLRI (one per SR algorithm). Append
+			// every observation here so Algorithm 128..255 Flex-Algo
+			// SIDs survive; mirror the Algorithm-0 SID into
+			// SrPrefixSID for the singular legacy field.
+			l.Prefix.SrPrefixSIDs = append(l.Prefix.SrPrefixSIDs, LsAttributePrefixSID{
+				Algorithm: v.Algorithm,
+				Flags:     v.Flags,
+				SID:       v.SID,
+			})
+			if v.Algorithm == 0 && l.Prefix.SrPrefixSID == nil {
+				sid := v.SID
+				l.Prefix.SrPrefixSID = &sid
+			}
+
+		case *LsTLVFlexAlgoDef:
+			// RFC 9351 Section 3: one FAD per algorithm; aggregate
+			// every observation into the slice in the order they
+			// arrived on the wire.
+			l.Node.FlexAlgoDefs = append(l.Node.FlexAlgoDefs, LsAttributeFlexAlgoDef{
+				Algorithm:       v.Algorithm,
+				MetricType:      v.MetricType,
+				MetricTypeKnown: v.MetricType <= 2, // RFC 9350 Section 5.1 known set: 0=IGP, 1=MinDelay, 2=TE
+				CalcType:        v.CalcType,
+				Priority:        v.Priority,
+				ExcludeAny:      v.ExcludeAny,
+				IncludeAny:      v.IncludeAny,
+				IncludeAll:      v.IncludeAll,
+				Flags:           v.Flags,
+				ExcludeSRLG:     v.ExcludeSRLG,
+			})
+
+		case *LsTLVFADPrefixMetric:
+			l.Prefix.FadPrefixMetrics = append(l.Prefix.FadPrefixMetrics, LsAttributeFADPrefixMetric{
+				Algorithm: v.Algorithm,
+				Flags:     v.Flags,
+				Metric:    v.Metric,
+			})
 
 		case *LsTLVPeerNodeSID:
 			l.BgpPeerSegment.BgpPeerNodeSid = v.Extract()
@@ -10488,6 +10994,15 @@ func (p *PathAttributeLs) DecodeFromBytes(data []byte, options ...*MarshallingOp
 
 		case LS_TLV_SR_LOCAL_BLOCK:
 			tlv = &LsTLVSrLocalBlock{}
+
+		// Flex-Algorithm Definition (RFC 9351 Section 3).
+		case LS_TLV_FLEX_ALGO_DEF:
+			tlv = &LsTLVFlexAlgoDef{}
+
+		// Flex-Algorithm Prefix Metric (RFC 9351 Section 4).
+		// Top-level Prefix Attribute, not nested inside TLV 1039.
+		case LS_TLV_FAD_PREFIX_METRIC:
+			tlv = &LsTLVFADPrefixMetric{}
 
 		// Link NLRI-related TLVs (https://tools.ietf.org/html/rfc7752#section-3.3.2)
 		case LS_TLV_IPV4_REMOTE_ROUTER_ID:
@@ -16110,6 +16625,13 @@ type BGPBody interface {
 const (
 	BGP_HEADER_LENGTH      = 19
 	BGP_MAX_MESSAGE_LENGTH = 4096
+	// BGP_MAX_EXTENDED_MESSAGE_LENGTH is the largest BGP message a
+	// peer may exchange once both sides have advertised the RFC 8654
+	// Extended Message capability. RFC 8654 Section 2 fixes the cap
+	// at 65535 octets; Section 6 limits the relaxation to UPDATE,
+	// NOTIFICATION and ROUTE-REFRESH (OPEN and KEEPALIVE keep the
+	// 4096-octet ceiling).
+	BGP_MAX_EXTENDED_MESSAGE_LENGTH = 65535
 )
 
 type BGPHeader struct {
@@ -16201,7 +16723,21 @@ func (msg *BGPMessage) Serialize(options ...*MarshallingOption) ([]byte, error) 
 		return nil, err
 	}
 	if msg.Header.Len == 0 {
-		if BGP_HEADER_LENGTH+len(b) > BGP_MAX_MESSAGE_LENGTH {
+		// RFC 8654 Section 4 + Section 6: with the BGP Extended
+		// Message Capability negotiated the cap rises to 65535 for
+		// UPDATE, NOTIFICATION and ROUTE-REFRESH; OPEN and KEEPALIVE
+		// stay at 4096. The caller sets MarshallingOption.ExtendedMessage
+		// only when the session negotiated the capability, so an
+		// uncapped serialise on a peer that did not advertise the
+		// capability still hits the 4096-octet ceiling.
+		maxLen := BGP_MAX_MESSAGE_LENGTH
+		if IsExtendedMessageSerialization(options) {
+			switch msg.Header.Type {
+			case BGP_MSG_UPDATE, BGP_MSG_NOTIFICATION, BGP_MSG_ROUTE_REFRESH:
+				maxLen = BGP_MAX_EXTENDED_MESSAGE_LENGTH
+			}
+		}
+		if BGP_HEADER_LENGTH+len(b) > maxLen {
 			return nil, NewMessageError(0, 0, nil, fmt.Sprintf("too long message length %d", BGP_HEADER_LENGTH+len(b)))
 		}
 		msg.Header.Len = BGP_HEADER_LENGTH + uint16(len(b))

--- a/vendor/github.com/osrg/gobgp/v4/pkg/packet/bgp/sr_policy.go
+++ b/vendor/github.com/osrg/gobgp/v4/pkg/packet/bgp/sr_policy.go
@@ -230,11 +230,16 @@ func (t *TunnelEncapSubTLVSRCandidatePathName) DecodeFromBytes(data []byte) erro
 	if err != nil {
 		return err
 	}
-	// Skip Reserved byte
-	if int(t.Length) < t.Len() {
+	// Body layout is one Reserved byte followed by the Candidate
+	// Path Name octet string (RFC 9012 Section 2.4.4 / IANA SR
+	// Policy Tunnel Encapsulation Sub-TLVs, type 129). value is
+	// the body slice with length t.Length; the previous code read
+	// value[1:t.Len()] which adds the 3-byte sub-TLV header onto
+	// the upper bound and over-reads into the next sub-TLV.
+	if t.Length < 1 {
 		return malformedAttrListErr("TunnelEncapSubTLVSRCandidatePathName length is too short")
 	}
-	t.CandidatePathName = string(value[1:t.Len()])
+	t.CandidatePathName = string(value[1:])
 	return nil
 }
 

--- a/vendor/github.com/osrg/gobgp/v4/pkg/packet/bgp/validate.go
+++ b/vendor/github.com/osrg/gobgp/v4/pkg/packet/bgp/validate.go
@@ -159,6 +159,9 @@ func ValidateAttribute(a PathAttributeInterface, rfs map[Family]BGPAddPathMode, 
 	case *PathAttributeAsPath:
 		if isEBGP {
 			if isConfed {
+				if len(p.Value) == 0 {
+					return false, NewMessageError(eCode, eSubCodeMalformedAspath, nil, "empty AS_PATH for confederation eBGP")
+				}
 				if segType := p.Value[0].GetType(); segType != BGP_ASPATH_ATTR_TYPE_CONFED_SEQ {
 					return false, NewMessageError(eCode, eSubCodeMalformedAspath, nil, fmt.Sprintf("segment type is not confederation seq (%d)", segType))
 				}

--- a/vendor/github.com/osrg/gobgp/v4/pkg/server/bfd_peer.go
+++ b/vendor/github.com/osrg/gobgp/v4/pkg/server/bfd_peer.go
@@ -187,15 +187,23 @@ func (p *bfdPeer) stop() {
 	)
 }
 
+// remoteUDPAddr builds the BFD peer's UDP address. The zone is preserved so a link-local peer
+// (fe80::…%iface, as used by unnumbered single-hop BFD per RFC 5881) can be reached — dialing a
+// link-local address without its zone fails.
+func (p *bfdPeer) remoteUDPAddr() *net.UDPAddr {
+	return &net.UDPAddr{
+		IP:   p.peerAddress.AsSlice(),
+		Zone: p.peerAddress.Zone(),
+		Port: p.peerPort,
+	}
+}
+
 func (p *bfdPeer) startClient() {
 	localAddress := &net.UDPAddr{
 		Port: randRange(bfdSourcePortMin, bfdSourcePortMax),
 	}
 
-	remoteAddress := &net.UDPAddr{
-		IP:   p.peerAddress.AsSlice(),
-		Port: p.peerPort,
-	}
+	remoteAddress := p.remoteUDPAddr()
 
 	var err error
 	p.udpClient, err = net.DialUDP("udp", localAddress, remoteAddress)

--- a/vendor/github.com/osrg/gobgp/v4/pkg/server/bmp.go
+++ b/vendor/github.com/osrg/gobgp/v4/pkg/server/bmp.go
@@ -83,6 +83,14 @@ func (r ribout) update(p *table.Path) bool {
 	return true
 }
 
+func bmpAddPathMarshallingOption(path *table.Path) *bgp.MarshallingOption {
+	return &bgp.MarshallingOption{
+		AddPath: map[bgp.Family]bgp.BGPAddPathMode{
+			path.GetFamily(): bgp.BGP_ADD_PATH_BOTH,
+		},
+	}
+}
+
 func (b *bmpClient) tryConnect() *net.TCPConn {
 	interval := 1
 	for {
@@ -180,7 +188,14 @@ func (b *bmpClient) loop() {
 			sentLocRIBPeerUp := false
 			if b.c.RouteMonitoringPolicy == oc.BMP_ROUTE_MONITORING_POLICY_TYPE_LOCAL_RIB || b.c.RouteMonitoringPolicy == oc.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL {
 				// For now, use PD=0 and VRF/Table Name="global".
-				if err := write(bmpLocRIBPeerUp(b.s.bgpConfig.Global.Config.As, b.s.bgpConfig.Global.Config.RouterId, "global", 0, time.Now().Unix())); err != nil {
+				if err := write(bmpLocRIBPeerUp(
+					b.s.bgpConfig.Global.Config.As,
+					b.s.bgpConfig.Global.Config.RouterId,
+					"global",
+					0,
+					time.Now().Unix(),
+					table.UseMultiplePaths.Enabled,
+				)); err != nil {
 					return false
 				}
 				sentLocRIBPeerUp = true
@@ -224,9 +239,13 @@ func (b *bmpClient) loop() {
 							AS:      b.s.bgpConfig.Global.Config.As,
 							ID:      b.s.bgpConfig.Global.Config.RouterId,
 						}
-						for _, p := range msg.PathList {
-							u := table.CreateUpdateMsgFromPaths([]*table.Path{p})[0]
-							if payload, err := u.Serialize(); err != nil {
+						for _, p := range locRIBPathsForBMP(msg) {
+							if p == nil {
+								continue
+							}
+							options := bmpAddPathMarshallingOption(p)
+							u := table.CreateUpdateMsgFromPaths([]*table.Path{p}, options)[0]
+							if payload, err := u.Serialize(options); err != nil {
 								return false
 							} else if err = write(bmpPeerRoute(bmp.BMP_PEER_TYPE_LOCAL_RIB, false, 0, true, info, p.GetTimestamp().Unix(), payload)); err != nil {
 								return false
@@ -285,7 +304,7 @@ func (b *bmpClient) loop() {
 	}
 }
 
-func bmpLocRIBPeerUp(localAS uint32, routerID netip.Addr, tableName string, peerDist uint64, timestamp int64) *bmp.BMPMessage {
+func bmpLocRIBPeerUp(localAS uint32, routerID netip.Addr, tableName string, peerDist uint64, timestamp int64, addPathEnabled bool) *bmp.BMPMessage {
 	const asTrans uint16 = 23456
 
 	myAS := asTrans
@@ -295,6 +314,14 @@ func bmpLocRIBPeerUp(localAS uint32, routerID netip.Addr, tableName string, peer
 	} else {
 		opts = append(opts, bgp.NewOptionParameterCapability([]bgp.ParameterCapabilityInterface{
 			bgp.NewCapFourOctetASNumber(localAS),
+		}))
+	}
+	if addPathEnabled {
+		opts = append(opts, bgp.NewOptionParameterCapability([]bgp.ParameterCapabilityInterface{
+			bgp.NewCapAddPath([]*bgp.CapAddPathTuple{
+				bgp.NewCapAddPathTuple(bgp.RF_IPv4_UC, bgp.BGP_ADD_PATH_BOTH),
+				bgp.NewCapAddPathTuple(bgp.RF_IPv6_UC, bgp.BGP_ADD_PATH_BOTH),
+			}),
 		}))
 	}
 

--- a/vendor/github.com/osrg/gobgp/v4/pkg/server/fsm.go
+++ b/vendor/github.com/osrg/gobgp/v4/pkg/server/fsm.go
@@ -410,6 +410,12 @@ type fsm struct {
 	capMap   map[bgp.BGPCapabilityCode][]bgp.ParameterCapabilityInterface
 	recvOpen *bgp.BGPMessage
 
+	// extendedMessage is the RFC 8654 negotiation result: true iff
+	// both sides advertised the Extended Message Capability in OPEN.
+	// Read on the incoming-message hot path (read loop length gate),
+	// so atomic to keep the read lock-free without copying capMap.
+	extendedMessage atomic.Bool
+
 	// safe for concurrent access
 	state                    fsmState
 	familyMap                atomic.Value // map[bgp.Family]bgp.BGPAddPathMode
@@ -556,7 +562,7 @@ func (fsm *fsm) bmpStatsUpdate(statType uint16, increment int) {
 
 func newFSM(gConf *oc.Global, pConf *oc.Neighbor, state bgp.FSMState, logger *slog.Logger) *fsm {
 	pConf.State.SessionState = oc.IntToSessionStateMap[int(state)]
-	pConf.Timers.State.Downtime = time.Now().Unix()
+	pConf.Timers.State.Downtime = 0
 	fsm := &fsm{
 		gConf:                    gConf,
 		outgoingCh:               channels.NewInfiniteChannel(),
@@ -658,6 +664,16 @@ func (fsm *fsm) stateChange(nextState bgp.FSMState, reason *fsmStateReason) {
 		fsm.capMap = capmap
 		fsm.familyMap.Store(rfmap)
 
+		// RFC 8654 Section 4: a speaker MAY send a BGP Extended
+		// Message only if the peer advertised the BGP Extended
+		// Message Capability. We always advertise the capability
+		// (the OPEN-side advertisement is unconditional, like the
+		// 4-byte ASN capability), so the negotiated flag is simply
+		// whether the peer's capability map contains an entry for
+		// the Extended Message Capability.
+		_, peerExt := fsm.capMap[bgp.BGP_CAP_EXTENDED_MESSAGE]
+		fsm.extendedMessage.Store(peerExt)
+
 		// calculate HoldTime
 		// RFC 4271 P.13
 		// a BGP speaker MUST calculate the value of the Hold Timer
@@ -758,8 +774,6 @@ func (fsm *fsm) stateChange(nextState bgp.FSMState, reason *fsmStateReason) {
 		if !y {
 			fsm.twoByteAsTrans = true
 		}
-	default:
-		conf.Timers.State.Downtime = time.Now().Unix()
 	}
 }
 
@@ -1113,6 +1127,14 @@ func capabilitiesFromConfig(pConf *oc.Neighbor) []bgp.ParameterCapabilityInterfa
 		caps = append(caps, bgp.NewCapSoftwareVersion(softwareVersion))
 	}
 
+	// RFC 8654 Section 3: advertise the Extended Message Capability
+	// in OPEN unconditionally, mirroring how the 4-byte ASN capability
+	// is handled. The TLV is empty (Capability Code 6, Length 0);
+	// per Section 4 a side may only emit a message larger than 4096
+	// octets after both peers have advertised, so the actual length
+	// cap flip still depends on the negotiation result on the FSM.
+	caps = append(caps, bgp.NewCapExtendedMessage())
+
 	for _, af := range pConf.AfiSafis {
 		caps = append(caps, bgp.NewCapMultiProtocol(af.State.Family))
 	}
@@ -1279,9 +1301,24 @@ func (h *fsmHandler) recvMessageWithError(conn net.Conn, stateReasonCh chan<- fs
 
 	hd := &bgp.BGPHeader{}
 	err = hd.DecodeFromBytes(headerBuf)
-	// TODO: RFC 8654
-	if err == nil && hd.Len > bgp.BGP_MAX_MESSAGE_LENGTH {
-		err = bgp.NewMessageError(bgp.BGP_ERROR_MESSAGE_HEADER_ERROR, bgp.BGP_ERROR_SUB_BAD_MESSAGE_LENGTH, nil, "too large BGP message length")
+	// RFC 8654 Section 4 + Section 6: once both peers have advertised
+	// the Extended Message Capability the per-message-type cap rises
+	// from 4096 to 65535 octets, but OPEN and KEEPALIVE keep the
+	// legacy ceiling so the initial handshake stays interoperable
+	// with implementations that have not yet negotiated the
+	// capability (the handshake completes before the negotiation
+	// result is known).
+	if err == nil {
+		maxLen := uint16(bgp.BGP_MAX_MESSAGE_LENGTH)
+		if h.fsm.extendedMessage.Load() {
+			switch hd.Type {
+			case bgp.BGP_MSG_UPDATE, bgp.BGP_MSG_NOTIFICATION, bgp.BGP_MSG_ROUTE_REFRESH:
+				maxLen = uint16(bgp.BGP_MAX_EXTENDED_MESSAGE_LENGTH)
+			}
+		}
+		if hd.Len > maxLen {
+			err = bgp.NewMessageError(bgp.BGP_ERROR_MESSAGE_HEADER_ERROR, bgp.BGP_ERROR_SUB_BAD_MESSAGE_LENGTH, nil, "too large BGP message length")
+		}
 	}
 	if err != nil {
 		h.fsm.bgpMessageStateUpdate(0, true)
@@ -1310,8 +1347,9 @@ func (h *fsmHandler) recvMessageWithError(conn net.Conn, stateReasonCh chan<- fs
 	useRevisedError := h.fsm.isTreatAsWithdraw
 
 	m, err := bgp.ParseBGPBody(hd, bodyBuf, &bgp.MarshallingOption{
-		AddPath:    h.fsm.familyMap.Load().(map[bgp.Family]bgp.BGPAddPathMode),
-		Use2ByteAS: h.fsm.twoByteAsTrans, // true if peer does NOT support 4-byte AS
+		AddPath:         h.fsm.familyMap.Load().(map[bgp.Family]bgp.BGPAddPathMode),
+		Use2ByteAS:      h.fsm.twoByteAsTrans, // true if peer does NOT support 4-byte AS
+		ExtendedMessage: h.fsm.extendedMessage.Load(),
 	})
 	if err != nil {
 		if m == nil {
@@ -1726,7 +1764,10 @@ func (h *fsmHandler) sendMessageloop(ctx context.Context, conn net.Conn, stateRe
 			table.UpdatePathAggregator2ByteAs(m.Body.(*bgp.BGPUpdate))
 		}
 
-		b, err := m.Serialize(&bgp.MarshallingOption{AddPath: fsm.familyMap.Load().(map[bgp.Family]bgp.BGPAddPathMode)})
+		b, err := m.Serialize(&bgp.MarshallingOption{
+			AddPath:         fsm.familyMap.Load().(map[bgp.Family]bgp.BGPAddPathMode),
+			ExtendedMessage: fsm.extendedMessage.Load(),
+		})
 		if err != nil {
 			fsm.logger.Warn("failed to serialize",
 				slog.String("State", fsm.state.String()),
@@ -1800,7 +1841,10 @@ func (h *fsmHandler) sendMessageloop(ctx context.Context, conn net.Conn, stateRe
 					break
 				}
 
-				options := &bgp.MarshallingOption{AddPath: fsm.familyMap.Load().(map[bgp.Family]bgp.BGPAddPathMode)}
+				options := &bgp.MarshallingOption{
+					AddPath:         fsm.familyMap.Load().(map[bgp.Family]bgp.BGPAddPathMode),
+					ExtendedMessage: fsm.extendedMessage.Load(),
+				}
 				for _, msg := range table.CreateUpdateMsgFromPaths(paths, options) {
 					if err := send(msg); err != nil {
 						return nil

--- a/vendor/github.com/osrg/gobgp/v4/pkg/server/grpc_server.go
+++ b/vendor/github.com/osrg/gobgp/v4/pkg/server/grpc_server.go
@@ -1263,6 +1263,7 @@ func newPeerGroupFromAPIStruct(a *api.PeerGroup) (*oc.PeerGroup, error) {
 		}
 		pconf.Transport.Config.PassiveMode = a.Transport.PassiveMode
 		pconf.Transport.Config.RemotePort = uint16(a.Transport.RemotePort)
+		pconf.Transport.Config.BindInterface = a.Transport.BindInterface
 		pconf.Transport.Config.TcpMss = uint16(a.Transport.TcpMss)
 		pconf.Transport.Config.IpTos = uint8(a.Transport.IpTos)
 	}
@@ -2433,6 +2434,7 @@ func newGlobalFromAPIStruct(a *api.Global) *oc.Global {
 			RouterId:         netip.MustParseAddr(a.RouterId),
 			Port:             a.ListenPort,
 			LocalAddressList: l,
+			BindToDevice:     a.BindToDevice,
 		},
 		AfiSafis: families,
 		UseMultiplePaths: oc.UseMultiplePaths{

--- a/vendor/github.com/osrg/gobgp/v4/pkg/server/peer.go
+++ b/vendor/github.com/osrg/gobgp/v4/pkg/server/peer.go
@@ -329,14 +329,8 @@ func (peer *peer) hasPathAlreadyBeenSent(path *table.Path) bool {
 }
 
 func (peer *peer) resetAdvertisedRoutes() {
-	peer.sentPaths.Range(func(key, _ any) bool {
-		peer.sentPaths.Delete(key)
-		return true
-	})
-	peer.sendMaxPathFiltered.Range(func(key, _ any) bool {
-		peer.sendMaxPathFiltered.Delete(key)
-		return true
-	})
+	peer.sentPaths.Clear()
+	peer.sendMaxPathFiltered.Clear()
 }
 
 func (peer *peer) isDynamicNeighbor() bool {
@@ -355,29 +349,35 @@ func (peer *peer) setRtcEORWait(waiting bool) {
 	peer.fsm.logger.Debug("Set rtcEORWait", slog.Bool("Data", waiting))
 }
 
+// allNegotiatedEORReceived reports whether EOR has been received for all
+// negotiated GR address families. This applies the post-ESTABLISHED check
+// based on State (negotiated capabilities), not Config.
+func (peer *peer) allNegotiatedEORReceived() bool {
+	for _, a := range peer.fsm.pConf.ReadOnly().AfiSafis {
+		if s := a.MpGracefulRestart.State; s.Enabled && s.Received && !s.EndOfRibReceived {
+			return false
+		}
+	}
+	return true
+}
+
 // receivedAllEOR reports whether the restarting speaker has received EOR from
 // this peer for all negotiated GR address families. Per RFC 4724 Section 4.1,
 // a peer that does not advertise GR capability is excluded from the EOR wait.
 // A peer that has GR configured but has not yet reached ESTABLISHED is treated
 // as pending: its EOR has not been received and cannot be skipped.
 func (peer *peer) receivedAllEOR() bool {
-	conf := peer.fsm.pConf.ReadOnly()
 	if peer.fsm.state.Load() != bgp.BGP_FSM_ESTABLISHED {
 		// Session not yet established: if GR is configured for any family,
 		// we must wait — the peer may still advertise GR capability in its OPEN.
-		for _, a := range conf.AfiSafis {
+		for _, a := range peer.fsm.pConf.ReadOnly().AfiSafis {
 			if a.MpGracefulRestart.Config.Enabled {
 				return false
 			}
 		}
 		return true
 	}
-	for _, a := range conf.AfiSafis {
-		if s := a.MpGracefulRestart.State; s.Enabled && s.Received && !s.EndOfRibReceived {
-			return false
-		}
-	}
-	return true
+	return peer.allNegotiatedEORReceived()
 }
 
 func (peer *peer) configuredRFlist() []bgp.Family {

--- a/vendor/github.com/osrg/gobgp/v4/pkg/server/server.go
+++ b/vendor/github.com/osrg/gobgp/v4/pkg/server/server.go
@@ -369,6 +369,16 @@ func (s *BgpServer) passConnToPeer(conn net.Conn) {
 		}
 
 		s.neighborMap[addr] = peer
+		// register BFD for the dynamic neighbor too (explicit neighbors do this in addNeighbor): the
+		// BFD config is inherited from the peer group. Without this, BFD never runs for dynamic peers.
+		if s.bfdServer != nil && conf.Bfd.Config.Enabled {
+			if err := s.bfdServer.AddPeer(context.Background(), addr, conf.Bfd.Config); err != nil {
+				s.logger.Warn("failed to add BFD peer for dynamic neighbor",
+					slog.String("Topic", "Peer"),
+					slog.String("Key", addr.String()),
+					slog.String("Err", err.Error()))
+			}
+		}
 		s.startFsmHandler(peer)
 		peer.PassConn(conn)
 	} else {
@@ -739,7 +749,7 @@ func (s *BgpServer) setPathVrfIdMap(paths []*table.Path, m map[uint32]bool) {
 
 // Note: the destination would be the same for all the paths passed here
 // The wather (only zapi) needs a unique list of vrf IDs
-func (s *BgpServer) notifyBestWatcher(best []*table.Path, multipath [][]*table.Path) {
+func (s *BgpServer) notifyBestWatcher(best []*table.Path, multipath [][]*table.Path, multipathUpdate []*table.Path, multipathWithdraw []*table.Path) {
 	if table.SelectionOptions.DisableBestPathSelection {
 		// Note: If best path selection disabled, no best path to notify.
 		return
@@ -753,10 +763,18 @@ func (s *BgpServer) notifyBestWatcher(best []*table.Path, multipath [][]*table.P
 		}
 	}
 	clonedB := clonePathList(best)
+	clonedU := clonePathList(multipathUpdate)
+	clonedW := clonePathList(multipathWithdraw)
 	if !table.UseMultiplePaths.Enabled {
 		s.setPathVrfIdMap(clonedB, m)
 	}
-	w := &watchEventBestPath{PathList: clonedB, MultiPathList: clonedM, Timestamp: time.Now()}
+	w := &watchEventBestPath{
+		PathList:         clonedB,
+		MultiPathList:    clonedM,
+		UpdatePathList:   clonedU,
+		WithdrawPathList: clonedW,
+		Timestamp:        time.Now(),
+	}
 	if len(m) > 0 {
 		w.Vrf = m
 	}
@@ -1349,10 +1367,12 @@ func (s *BgpServer) rtcVPNCandidates(peer *peer, isWithdraw bool, rt bgp.Extende
 	fn(nil, s.globalRib.GetBestPathList(peer.TableID(), 0, fs))
 }
 
-func dstsToPaths(id string, as uint32, dsts []*table.Update) ([]*table.Path, []*table.Path, [][]*table.Path) {
+func dstsToPaths(id string, as uint32, dsts []*table.Update) ([]*table.Path, []*table.Path, [][]*table.Path, []*table.Path, []*table.Path) {
 	bestList := make([]*table.Path, 0, len(dsts))
 	oldList := make([]*table.Path, 0, len(dsts))
 	mpathList := make([][]*table.Path, 0, len(dsts))
+	multipathUpdate := make([]*table.Path, 0, len(dsts))
+	multipathWithdraw := make([]*table.Path, 0, len(dsts))
 
 	for _, dst := range dsts {
 		best, old, mpath := dst.GetChanges(id, as, false)
@@ -1361,8 +1381,13 @@ func dstsToPaths(id string, as uint32, dsts []*table.Update) ([]*table.Path, []*
 		if mpath != nil {
 			mpathList = append(mpathList, mpath)
 		}
+		if id == table.GLOBAL_RIB_NAME && table.UseMultiplePaths.Enabled {
+			u, w := dst.GetMultiBestPathDiff(id)
+			multipathUpdate = append(multipathUpdate, u...)
+			multipathWithdraw = append(multipathWithdraw, w...)
+		}
 	}
-	return bestList, oldList, mpathList
+	return bestList, oldList, mpathList, multipathUpdate, multipathWithdraw
 }
 
 func (s *BgpServer) propagateUpdateToNeighbors(rib *table.TableManager, source *peer, newPath *table.Path, dsts []*table.Update, needOld bool) {
@@ -1371,9 +1396,10 @@ func (s *BgpServer) propagateUpdateToNeighbors(rib *table.TableManager, source *
 	}
 	var gBestList, gOldList []*table.Path
 	var mpathList [][]*table.Path
+	var multipathUpdate, multipathWithdraw []*table.Path
 	if source == nil || !source.isRouteServerClient() {
-		gBestList, gOldList, mpathList = dstsToPaths(table.GLOBAL_RIB_NAME, 0, dsts)
-		s.notifyBestWatcher(gBestList, mpathList)
+		gBestList, gOldList, mpathList, multipathUpdate, multipathWithdraw = dstsToPaths(table.GLOBAL_RIB_NAME, 0, dsts)
+		s.notifyBestWatcher(gBestList, mpathList, multipathUpdate, multipathWithdraw)
 	}
 	family := newPath.GetFamily()
 	for _, targetPeer := range s.neighborMap {
@@ -1401,6 +1427,11 @@ func (s *BgpServer) propagateUpdateToNeighbors(rib *table.TableManager, source *
 		func() {
 			targetPeer.routeRefreshInProgress.RLock()
 			defer targetPeer.routeRefreshInProgress.RUnlock()
+			// If the peer is not advertising, return early to avoid rebuilding RIB-out bookkeeping,
+			// as it might have been already cleared by resetAdvertisedRoutes.
+			if !needToAdvertise(targetPeer) {
+				return
+			}
 			var bestList, oldList []*table.Path
 			if targetPeer.isAddPathSendEnabled(f) {
 				// in case of multiple paths to the same destination, we need to
@@ -1495,7 +1526,7 @@ func (s *BgpServer) propagateUpdateToNeighbors(rib *table.TableManager, source *
 						}
 						return
 					}
-					bestList, oldList, _ = dstsToPaths(targetPeer.TableID(), targetPeer.AS(), dsts)
+					bestList, oldList, _, _, _ = dstsToPaths(targetPeer.TableID(), targetPeer.AS(), dsts)
 				} else {
 					bestList = gBestList
 					oldList = gOldList
@@ -1519,6 +1550,16 @@ func (s *BgpServer) stopNeighbor(peer *peer, oldState bgp.FSMState, e *fsmMsg) {
 	key := netip.MustParseAddr(peer.ID())
 	if s.neighborMap[key] == peer {
 		delete(s.neighborMap, key)
+	}
+	// deregister BFD here for both static peers (deleted) and dynamic peers (stopped on session loss);
+	// DeletePeer is a no-op for a peer without BFD, so this only errors if the BFD server is stopped.
+	if s.bfdServer != nil {
+		if err := s.bfdServer.DeletePeer(context.Background(), key); err != nil {
+			s.logger.Warn("failed to delete BFD peer",
+				slog.String("Topic", "Peer"),
+				slog.String("Key", key.String()),
+				slog.String("Err", err.Error()))
+		}
 	}
 	peer.stopFSM()
 	s.broadcastPeerState(peer, bgp.BGP_FSM_IDLE, oldState, e)
@@ -1586,6 +1627,10 @@ func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
 			peer.fsm.pConf.Update(&conf)
 			peer.prefixLimitWarned = make(map[bgp.Family]bool)
 			peer.fsm.lock.Unlock()
+
+			// Publish the down state before clearing advertised-route state.
+			// This avoids rebuilding RIB-out bookkeeping by propagation that starts after the reset.
+			peer.fsm.state.Store(nextState)
 			s.resetAdvertisedRoutes(peer)
 			s.propagateUpdate(peer, peer.DropAll(dropFamilies))
 
@@ -1758,6 +1803,16 @@ func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
 				// the Selection_Deferral_Timer referred to below has expired.
 				allEnd := func() bool {
 					for _, p := range s.neighborMap {
+						if p == peer {
+							// This peer is transitioning to ESTABLISHED inside
+							// this callback, so fsm.state.Store() has not been
+							// called yet. Apply the post-ESTABLISHED EOR check
+							// directly instead of going through receivedAllEOR().
+							if !p.allNegotiatedEORReceived() {
+								return false
+							}
+							continue
+						}
 						if !p.receivedAllEOR() {
 							return false
 						}
@@ -1790,7 +1845,7 @@ func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
 					time.AfterFunc(time.Second*time.Duration(deferral), deferralExpiredFunc(bgp.Family(0), time.Second*time.Duration(deferral)))
 				}
 			}
-		} else {
+		} else if oldState == bgp.BGP_FSM_ESTABLISHED {
 			peer.fsm.lock.Lock()
 			conf := peer.fsm.pConf.ReadCopy()
 			conf.Timers.State.Downtime = time.Now().Unix()
@@ -1947,15 +2002,9 @@ func (s *BgpServer) handleFSMMessage(peer *peer, e *fsmMsg) {
 }
 
 func (s *BgpServer) resetAdvertisedRoutes(peer *peer) {
-	for i := range s.shared.propagateBuckets {
-		s.shared.propagateBuckets[i].Lock()
-	}
 	peer.routeRefreshInProgress.Lock()
+	defer peer.routeRefreshInProgress.Unlock()
 	peer.resetAdvertisedRoutes()
-	peer.routeRefreshInProgress.Unlock()
-	for i := len(s.shared.propagateBuckets) - 1; i >= 0; i-- {
-		s.shared.propagateBuckets[i].Unlock()
-	}
 }
 
 func (s *BgpServer) EnableZebra(ctx context.Context, r *api.EnableZebraRequest) error {
@@ -3403,7 +3452,7 @@ func (s *BgpServer) addNeighbor(c *oc.Neighbor) error {
 	if s.bgpConfig.Global.Config.Port > 0 {
 		for _, l := range s.listListeners(addr) {
 			if c.Config.AuthPassword != "" {
-				if err := netutils.SetTCPMD5SigSockopt(l, addr, c.Config.AuthPassword); err != nil {
+				if err := netutils.SetTCPMD5SigSockopt(l, c.Transport.Config.BindInterface, addr, c.Config.AuthPassword); err != nil {
 					s.logger.Warn("failed to set md5",
 						slog.String("Topic", "Peer"),
 						slog.String("Key", addr),
@@ -3533,7 +3582,7 @@ func (s *BgpServer) AddDynamicNeighbor(ctx context.Context, r *api.AddDynamicNei
 			prefix := r.DynamicNeighbor.Prefix
 			addr, _, _ := net.ParseCIDR(prefix)
 			for _, l := range s.listListeners(addr.String()) {
-				if err := netutils.SetTCPMD5SigSockopt(l, prefix, pConf.Config.AuthPassword); err != nil {
+				if err := netutils.SetTCPMD5SigSockopt(l, pConf.Transport.Config.BindInterface, prefix, pConf.Config.AuthPassword); err != nil {
 					s.logger.Warn("failed to set md5",
 						slog.String("Topic", "Peer"),
 						slog.String("Key", prefix),
@@ -3589,25 +3638,13 @@ func (s *BgpServer) deleteNeighbor(c *oc.Neighbor, code, subcode uint8, sendNoti
 	}
 	for _, l := range s.listListeners(addr) {
 		if c.Config.AuthPassword != "" {
-			if err := netutils.SetTCPMD5SigSockopt(l, addr, ""); err != nil {
+			if err := netutils.SetTCPMD5SigSockopt(l, c.Transport.Config.BindInterface, addr, ""); err != nil {
 				n.fsm.logger.Warn("failed to unset md5", slog.String("Err", err.Error()))
 			}
 		}
 	}
 	n.fsm.logger.Info("Delete a peer configuration")
 
-	if s.bfdServer != nil {
-		ipAddr, err := netip.ParseAddr(addr)
-		if err != nil {
-			return fmt.Errorf("failed to parse IP address: %v", err)
-		}
-		if err := s.bfdServer.DeletePeer(context.Background(), ipAddr); err != nil {
-			s.logger.Warn("failed to delete BFD peer",
-				slog.String("Topic", "Peer"),
-				slog.String("Key", addr),
-				slog.String("Err", err.Error()))
-		}
-	}
 	if sendNotification {
 		n.fsm.deconfiguredNotification <- bgp.NewBGPNotificationMessage(code, subcode, nil)
 	}
@@ -3660,7 +3697,7 @@ func (s *BgpServer) DeleteDynamicNeighbor(ctx context.Context, r *api.DeleteDyna
 				addr, _, perr := net.ParseCIDR(prefix)
 				if perr == nil {
 					for _, l := range s.listListeners(addr.String()) {
-						if err := netutils.SetTCPMD5SigSockopt(l, prefix, ""); err != nil {
+						if err := netutils.SetTCPMD5SigSockopt(l, pConf.Transport.Config.BindInterface, prefix, ""); err != nil {
 							s.logger.Warn("failed to clear md5",
 								slog.String("Topic", "Peer"),
 								slog.String("Key", prefix),
@@ -4596,24 +4633,7 @@ func (s *BgpServer) WatchEvent(ctx context.Context, callbacks WatchEventMessageC
 							}
 							callbacks.OnBestPath(p, msg.Timestamp)
 						}
-
-						if len(msg.MultiPathList) > 0 {
-							plen := 0
-							for _, pa := range msg.MultiPathList {
-								plen += len(pa)
-							}
-							paths := make([]*table.Path, plen)
-							i := 0
-							for _, pa := range msg.MultiPathList {
-								for _, path := range pa {
-									paths[i] = path
-									i++
-								}
-							}
-							callback(paths)
-						} else {
-							callback(msg.PathList)
-						}
+						callback(locRIBPathsForBMP(msg))
 					}
 
 				case *watchEventEor:
@@ -4767,10 +4787,35 @@ type watchEventPeer struct {
 }
 
 type watchEventBestPath struct {
-	PathList      []*table.Path
-	MultiPathList [][]*table.Path
-	Vrf           map[uint32]bool
-	Timestamp     time.Time
+	PathList         []*table.Path
+	MultiPathList    [][]*table.Path
+	UpdatePathList   []*table.Path
+	WithdrawPathList []*table.Path
+	Vrf              map[uint32]bool
+	Timestamp        time.Time
+}
+
+func locRIBPathsForBMP(msg *watchEventBestPath) []*table.Path {
+	// Prefer update/withdraw delta when present.
+	if len(msg.UpdatePathList) > 0 || len(msg.WithdrawPathList) > 0 {
+		paths := make([]*table.Path, 0, len(msg.WithdrawPathList)+len(msg.UpdatePathList))
+		paths = append(paths, msg.WithdrawPathList...)
+		paths = append(paths, msg.UpdatePathList...)
+		return paths
+	}
+	// Fallback for non-multipath and init snapshot behavior.
+	if len(msg.MultiPathList) > 0 {
+		plen := 0
+		for _, pa := range msg.MultiPathList {
+			plen += len(pa)
+		}
+		paths := make([]*table.Path, 0, plen)
+		for _, pa := range msg.MultiPathList {
+			paths = append(paths, pa...)
+		}
+		return paths
+	}
+	return msg.PathList
 }
 
 type watchEventMessage struct {

--- a/vendor/github.com/osrg/gobgp/v4/pkg/server/zclient.go
+++ b/vendor/github.com/osrg/gobgp/v4/pkg/server/zclient.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"net"
 	"net/netip"
 	"strconv"
 	"strings"
@@ -199,6 +200,17 @@ func newIPRouteBody(dst []*table.Path, vrfID uint32, z *zebraClient) (body *zebr
 	for _, p := range paths {
 		nexthop.Gate = p.GetNexthop()
 		nexthop.VrfID = nhVrfID
+		// link-local next-hop requires an interface index for kernel route installation
+		nexthop.Ifindex = 0
+		if nexthop.Gate.Is6() && nexthop.Gate.IsLinkLocalUnicast() {
+			if zone := p.GetSource().Address.Zone(); zone != "" {
+				if id, err := strconv.ParseUint(zone, 10, 32); err == nil {
+					nexthop.Ifindex = uint32(id)
+				} else if ifi, err := net.InterfaceByName(zone); err == nil {
+					nexthop.Ifindex = uint32(ifi.Index)
+				}
+			}
+		}
 		if nhVrfID != vrfID {
 			addLabelToNexthop(path, z, &msgFlags, &nexthop)
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1313,7 +1313,7 @@ github.com/opentracing/opentracing-go/log
 # github.com/orcaman/concurrent-map/v2 v2.0.1
 ## explicit; go 1.18
 github.com/orcaman/concurrent-map/v2
-# github.com/osrg/gobgp/v4 v4.6.0
+# github.com/osrg/gobgp/v4 v4.6.1-0.20260630022313-d6dee8360046
 ## explicit; go 1.24.5
 github.com/osrg/gobgp/v4/api
 github.com/osrg/gobgp/v4/internal/pkg/netutils


### PR DESCRIPTION
Bump github.com/osrg/gobgp/v4 to v4.6.1-0.20260630022313-d6dee8360046.

This includes osrg/gobgp@f6cc73a45117894ce24a592331c1bc14e940b934, which fixes CI failures introduced by osrg/gobgp@748e233f2c5ff9241aa0ff57259e1e774701eefd.
