### PR TITLE
cilium-cli: bump minimum Cilium version to v1.16

### DIFF
--- a/cilium-cli/connectivity/builder/bgp_control_plane.go
+++ b/cilium-cli/connectivity/builder/bgp_control_plane.go
@@ -14,7 +14,7 @@ type bgpControlPlane struct{}
 func (t bgpControlPlane) build(ct *check.ConnectivityTest, _ map[string]string) {
 	newTest("bgp-control-plane-v1", ct).
 		// NOTE: BGPv1 was removed in v1.19, this test can be removed once v1.18 is out of support
-		WithCiliumVersion(">=1.16.0 <1.19.0").
+		WithCiliumVersion("<1.19.0").
 		WithUnsafeTests().
 		WithFeatureRequirements(
 			features.RequireEnabled(features.BGPControlPlane),
@@ -23,7 +23,6 @@ func (t bgpControlPlane) build(ct *check.ConnectivityTest, _ map[string]string) 
 		WithScenarios(tests.BGPAdvertisements(1, bgpPeeringPolicyYAML))
 
 	newTest("bgp-control-plane-v2", ct).
-		WithCiliumVersion(">=1.16.0").
 		WithUnsafeTests().
 		WithFeatureRequirements(
 			features.RequireEnabled(features.BGPControlPlane),

--- a/cilium-cli/connectivity/builder/client_egress_expression.go
+++ b/cilium-cli/connectivity/builder/client_egress_expression.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
-	"github.com/cilium/cilium/cilium-cli/utils/features"
 )
 
 //go:embed manifests/client-egress-to-echo-expression.yaml
@@ -21,9 +20,7 @@ type clientEgressExpression struct{}
 
 func (t clientEgressExpression) build(ct *check.ConnectivityTest, _ map[string]string) {
 	clientEgressExpressionTest(ct, false)
-	if ct.Features[features.PortRanges].Enabled {
-		clientEgressExpressionTest(ct, true)
-	}
+	clientEgressExpressionTest(ct, true)
 }
 
 func clientEgressExpressionTest(ct *check.ConnectivityTest, portRanges bool) {

--- a/cilium-cli/connectivity/builder/client_egress_expression_knp.go
+++ b/cilium-cli/connectivity/builder/client_egress_expression_knp.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
-	"github.com/cilium/cilium/cilium-cli/utils/features"
 )
 
 //go:embed manifests/client-egress-to-echo-expression-knp.yaml
@@ -21,9 +20,7 @@ type clientEgressExpressionKnp struct{}
 
 func (t clientEgressExpressionKnp) build(ct *check.ConnectivityTest, _ map[string]string) {
 	clientEgressExpressionKnpTest(ct, false)
-	if ct.Features[features.PortRanges].Enabled {
-		clientEgressExpressionKnpTest(ct, true)
-	}
+	clientEgressExpressionKnpTest(ct, true)
 }
 
 func clientEgressExpressionKnpTest(ct *check.ConnectivityTest, portRanges bool) {

--- a/cilium-cli/connectivity/builder/client_egress_tls_sni.go
+++ b/cilium-cli/connectivity/builder/client_egress_tls_sni.go
@@ -24,7 +24,7 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 	yamlFile := templates["clientEgressTLSSNIPolicyYAML"]
 	// Test TLS SNI enforcement using an egress policy on the clients.
 	newTest(testName, ct).
-		WithCiliumVersion("!1.15.9 !1.15.10 !1.16.2 !1.16.3").
+		WithCiliumVersion("!1.16.2 !1.16.3").
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithFeatureRequirements(features.RequireDisabled(features.RHEL)).
 		WithCiliumPolicy(yamlFile).                                   // L7 allow policy TLS SNI enforcement for external target
@@ -48,7 +48,7 @@ func clientEgressTlsSniTest(ct *check.ConnectivityTest, templates map[string]str
 	yamlFile = templates["clientEgressTLSSNIOtherPolicyYAML"]
 	newTest(fmt.Sprintf("%s-denied", testName), ct).
 		WithCondition(differentExternalTargets).
-		WithCiliumVersion("!1.15.9 !1.15.10 !1.16.2 !1.16.3").
+		WithCiliumVersion("!1.16.2 !1.16.3").
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithFeatureRequirements(features.RequireDisabled(features.RHEL)).
 		WithCiliumPolicy(yamlFile).                                   // L7 allow policy TLS SNI enforcement for external target
@@ -202,7 +202,7 @@ func clientEgressL7TlsSniTest(ct *check.ConnectivityTest, templates map[string]s
 	yamlFile := templates["clientEgressL7TLSSNIPolicyYAML"]
 	// Test TLS SNI enforcement using an egress policy on the clients.
 	newTest(testName, ct).
-		WithCiliumVersion("!1.15.9 !1.15.10 !1.16.2 !1.16.3").
+		WithCiliumVersion("!1.16.2 !1.16.3").
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithFeatureRequirements(features.RequireEnabled(features.PolicySecretsOnlyFromSecretsNamespace)).
 		WithCABundleSecret().
@@ -223,7 +223,7 @@ func clientEgressL7TlsSniTest(ct *check.ConnectivityTest, templates map[string]s
 	testName = "client-egress-l7-tls-headers-other-sni"
 	yamlFile = templates["clientEgressL7TLSOtherSNIPolicyYAML"]
 	newTest(testName, ct).
-		WithCiliumVersion("!1.15.9 !1.15.10 !1.16.2 !1.16.3").
+		WithCiliumVersion("!1.16.2 !1.16.3").
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithFeatureRequirements(features.RequireEnabled(features.PolicySecretsOnlyFromSecretsNamespace)).
 		WithCABundleSecret().

--- a/cilium-cli/connectivity/builder/client_egress_to_echo_deny.go
+++ b/cilium-cli/connectivity/builder/client_egress_to_echo_deny.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
-	"github.com/cilium/cilium/cilium-cli/utils/features"
 )
 
 //go:embed manifests/client-egress-to-echo-deny.yaml
@@ -21,9 +20,7 @@ type clientEgressToEchoDeny struct{}
 
 func (t clientEgressToEchoDeny) build(ct *check.ConnectivityTest, _ map[string]string) {
 	clientEgressToEchoDenyTest(ct, false)
-	if ct.Features[features.PortRanges].Enabled {
-		clientEgressToEchoDenyTest(ct, true)
-	}
+	clientEgressToEchoDenyTest(ct, true)
 }
 
 func clientEgressToEchoDenyTest(ct *check.ConnectivityTest, portRanges bool) {

--- a/cilium-cli/connectivity/builder/client_egress_to_echo_expression_deny.go
+++ b/cilium-cli/connectivity/builder/client_egress_to_echo_expression_deny.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
-	"github.com/cilium/cilium/cilium-cli/utils/features"
 )
 
 //go:embed manifests/client-egress-to-echo-expression-deny.yaml
@@ -21,9 +20,7 @@ type clientEgressToEchoExpressionDeny struct{}
 
 func (t clientEgressToEchoExpressionDeny) build(ct *check.ConnectivityTest, _ map[string]string) {
 	clientEgressToEchoExpressionDenyTest(ct, false)
-	if ct.Features[features.PortRanges].Enabled {
-		clientEgressToEchoExpressionDenyTest(ct, true)
-	}
+	clientEgressToEchoExpressionDenyTest(ct, true)
 }
 
 func clientEgressToEchoExpressionDenyTest(ct *check.ConnectivityTest, portRanges bool) {

--- a/cilium-cli/connectivity/builder/client_egress_to_echo_service_account.go
+++ b/cilium-cli/connectivity/builder/client_egress_to_echo_service_account.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
-	"github.com/cilium/cilium/cilium-cli/utils/features"
 )
 
 //go:embed manifests/client-egress-to-echo-service-account.yaml
@@ -21,9 +20,7 @@ type clientEgressToEchoServiceAccount struct{}
 
 func (t clientEgressToEchoServiceAccount) build(ct *check.ConnectivityTest, _ map[string]string) {
 	clientEgressToEchoServiceAccountTest(ct, false)
-	if ct.Features[features.PortRanges].Enabled {
-		clientEgressToEchoServiceAccountTest(ct, true)
-	}
+	clientEgressToEchoServiceAccountTest(ct, true)
 }
 
 func clientEgressToEchoServiceAccountTest(ct *check.ConnectivityTest, portRanges bool) {

--- a/cilium-cli/connectivity/builder/client_egress_to_echo_service_account_deny.go
+++ b/cilium-cli/connectivity/builder/client_egress_to_echo_service_account_deny.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
-	"github.com/cilium/cilium/cilium-cli/utils/features"
 )
 
 //go:embed manifests/client-egress-to-echo-service-account-deny.yaml
@@ -21,9 +20,7 @@ type clientEgressToEchoServiceAccountDeny struct{}
 
 func (t clientEgressToEchoServiceAccountDeny) build(ct *check.ConnectivityTest, _ map[string]string) {
 	clientEgressToEchoServiceAccountDenyTest(ct, false)
-	if ct.Features[features.PortRanges].Enabled {
-		clientEgressToEchoServiceAccountDenyTest(ct, true)
-	}
+	clientEgressToEchoServiceAccountDenyTest(ct, true)
 }
 
 func clientEgressToEchoServiceAccountDenyTest(ct *check.ConnectivityTest, portRanges bool) {

--- a/cilium-cli/connectivity/builder/client_with_service_account_egress_to_echo.go
+++ b/cilium-cli/connectivity/builder/client_with_service_account_egress_to_echo.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
-	"github.com/cilium/cilium/cilium-cli/utils/features"
 )
 
 //go:embed manifests/client-with-service-account-egress-to-echo.yaml
@@ -21,9 +20,7 @@ type clientWithServiceAccountEgressToEcho struct{}
 
 func (t clientWithServiceAccountEgressToEcho) build(ct *check.ConnectivityTest, _ map[string]string) {
 	clientWithServiceAccountEgressToEchoTest(ct, false)
-	if ct.Features[features.PortRanges].Enabled {
-		clientWithServiceAccountEgressToEchoTest(ct, true)
-	}
+	clientWithServiceAccountEgressToEchoTest(ct, true)
 }
 
 func clientWithServiceAccountEgressToEchoTest(ct *check.ConnectivityTest, portRanges bool) {

--- a/cilium-cli/connectivity/builder/client_with_service_account_egress_to_echo_deny.go
+++ b/cilium-cli/connectivity/builder/client_with_service_account_egress_to_echo_deny.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
-	"github.com/cilium/cilium/cilium-cli/utils/features"
 )
 
 //go:embed manifests/client-with-service-account-egress-to-echo-deny.yaml
@@ -21,9 +20,7 @@ type clientWithServiceAccountEgressToEchoDeny struct{}
 
 func (t clientWithServiceAccountEgressToEchoDeny) build(ct *check.ConnectivityTest, _ map[string]string) {
 	clientWithServiceAccountEgressToEchoDenyTest(ct, false)
-	if ct.Features[features.PortRanges].Enabled {
-		clientWithServiceAccountEgressToEchoDenyTest(ct, true)
-	}
+	clientWithServiceAccountEgressToEchoDenyTest(ct, true)
 }
 
 func clientWithServiceAccountEgressToEchoDenyTest(ct *check.ConnectivityTest, portRanges bool) {

--- a/cilium-cli/connectivity/builder/echo_ingress_auth_always_fail.go
+++ b/cilium-cli/connectivity/builder/echo_ingress_auth_always_fail.go
@@ -21,9 +21,7 @@ type echoIngressAuthAlwaysFail struct{}
 
 func (t echoIngressAuthAlwaysFail) build(ct *check.ConnectivityTest, _ map[string]string) {
 	echoIngressAuthAlwaysFailTest(ct, false)
-	if ct.Features[features.PortRanges].Enabled {
-		echoIngressAuthAlwaysFailTest(ct, true)
-	}
+	echoIngressAuthAlwaysFailTest(ct, true)
 }
 
 func echoIngressAuthAlwaysFailTest(ct *check.ConnectivityTest, portRanges bool) {

--- a/cilium-cli/connectivity/builder/echo_ingress_l7.go
+++ b/cilium-cli/connectivity/builder/echo_ingress_l7.go
@@ -52,10 +52,6 @@ func (t echoIngressL7) build(ct *check.ConnectivityTest, templates map[string]st
 			// pod->hostport traffic will be policy denied on the
 			// ingress of dest node when routing=tunnel + kpr=1.
 			if ok, _ := ct.Features.MatchRequirements(features.RequireMode(features.EncryptionPod, "wireguard")); ok {
-				if !versioncheck.MustCompile(">=1.16.0")(ct.CiliumVersion) {
-					return false
-				}
-
 				ok, _ = ct.Features.MatchRequirements(features.RequireEnabled(features.EncryptionNode))
 				return ok
 			}

--- a/cilium-cli/connectivity/builder/echo_ingress_mutual_auth_spiffe.go
+++ b/cilium-cli/connectivity/builder/echo_ingress_mutual_auth_spiffe.go
@@ -21,9 +21,7 @@ type echoIngressMutualAuthSpiffe struct{}
 
 func (t echoIngressMutualAuthSpiffe) build(ct *check.ConnectivityTest, _ map[string]string) {
 	echoIngressMutualAuthSpiffeTest(ct, false)
-	if ct.Features[features.PortRanges].Enabled {
-		echoIngressMutualAuthSpiffeTest(ct, true)
-	}
+	echoIngressMutualAuthSpiffeTest(ct, true)
 }
 
 func echoIngressMutualAuthSpiffeTest(ct *check.ConnectivityTest, portRanges bool) {

--- a/cilium-cli/connectivity/builder/egress_gateway_with_l7_policy.go
+++ b/cilium-cli/connectivity/builder/egress_gateway_with_l7_policy.go
@@ -22,7 +22,6 @@ type egressGatewayWithL7Policy struct{}
 
 func (t egressGatewayWithL7Policy) build(ct *check.ConnectivityTest, templates map[string]string) {
 	newTest("egress-gateway-with-l7-policy", ct).
-		WithCiliumVersion(">=1.16.0").
 		WithUnsafeTests().
 		WithCiliumPolicy(clientEgressICMPYAML).
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]).  // DNS resolution only

--- a/cilium-cli/connectivity/builder/local_redirect_policy.go
+++ b/cilium-cli/connectivity/builder/local_redirect_policy.go
@@ -28,7 +28,6 @@ func (t localRedirectPolicy) build(ct *check.ConnectivityTest, _ map[string]stri
 	lrpFrontendIPSkipRedirectV6 := "fd00::169:254:169:248"
 
 	lrpTest := newTest("local-redirect-policy", ct).
-		WithCiliumVersion(">=1.16.0").
 		WithCondition(func() bool {
 			return ct.IsSocketLBFull() || versioncheck.MustCompile(">=1.17.0")(ct.CiliumVersion)
 		}).

--- a/cilium-cli/connectivity/builder/multicast.go
+++ b/cilium-cli/connectivity/builder/multicast.go
@@ -13,7 +13,6 @@ type multicast struct{}
 
 func (t multicast) build(ct *check.ConnectivityTest, _ map[string]string) {
 	newTest("multicast", ct).
-		WithCiliumVersion(">=1.16.0").
 		WithUnsafeTests().
 		WithFeatureRequirements(
 			features.RequireEnabled(features.Multicast),

--- a/cilium-cli/connectivity/builder/pod_to_ingress_service.go
+++ b/cilium-cli/connectivity/builder/pod_to_ingress_service.go
@@ -65,7 +65,7 @@ func (t podToIngressService) build(ct *check.ConnectivityTest, templates map[str
 		})
 
 	newTest("pod-to-ingress-service-deny-source-egress-other-node", ct).
-		WithCiliumVersion(">1.17.1 || >1.16.7 <1.17.0 || >1.15.14 <1.16.0").
+		WithCiliumVersion(">1.17.1 || >1.16.7 <1.17.0").
 		WithFeatureRequirements(features.RequireEnabled(features.IngressController)).
 		WithCiliumPolicy(denyIngressSourceEgressOtherNodePolicyYML).
 		WithCiliumPolicy(templates["clientEgressOnlyPort53PolicyYAML"]). // DNS resolution only

--- a/cilium-cli/connectivity/builder/pod_to_pod_encryption.go
+++ b/cilium-cli/connectivity/builder/pod_to_pod_encryption.go
@@ -33,8 +33,8 @@ func (t podToPodEncryption) build(ct *check.ConnectivityTest, _ map[string]strin
 		WithCiliumVersion("<1.18.0").
 		WithCondition(func() bool {
 			if ok, _ := ct.Features.MatchRequirements(features.RequireMode(features.EncryptionPod, "ipsec")); ok {
-				// Introduced in v1.17.0, backported to v1.15.11 and v1.16.4.
-				if !versioncheck.MustCompile(">=1.15.11 <1.16.0 || >=1.16.4")(ct.CiliumVersion) {
+				// Introduced in v1.17.0, backported to v1.16.4.
+				if !versioncheck.MustCompile(">=1.16.4")(ct.CiliumVersion) {
 					return false
 				}
 			}

--- a/cilium-cli/connectivity/builder/to_entities_world.go
+++ b/cilium-cli/connectivity/builder/to_entities_world.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/connectivity/tests"
-	"github.com/cilium/cilium/cilium-cli/utils/features"
 )
 
 //go:embed manifests/client-egress-to-entities-world.yaml
@@ -21,9 +20,7 @@ type toEntitiesWorld struct{}
 
 func (t toEntitiesWorld) build(ct *check.ConnectivityTest, _ map[string]string) {
 	toEntitiesWorldTest(ct, false)
-	if ct.Features[features.PortRanges].Enabled {
-		toEntitiesWorldTest(ct, true)
-	}
+	toEntitiesWorldTest(ct, true)
 }
 
 func toEntitiesWorldTest(ct *check.ConnectivityTest, portRanges bool) {

--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -35,7 +35,6 @@ import (
 	slimcorev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slimmetav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	policyapi "github.com/cilium/cilium/pkg/policy/api"
-	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
 const (
@@ -1902,11 +1901,6 @@ func (ct *ConnectivityTest) createTestConnDisruptServerDeployAndSvc(ctx context.
 		}
 
 		if enabled, _ := ct.Features.MatchRequirements(features.RequireEnabled(features.CNP)); enabled {
-			ipsec, _ := ct.Features.MatchRequirements(features.RequireMode(features.EncryptionPod, "ipsec"))
-			if ipsec && versioncheck.MustCompile("<1.16.0")(ct.CiliumVersion) {
-				// https://github.com/cilium/cilium/issues/36681
-				continue
-			}
 			for _, client := range ct.Clients() {
 				cnp := cnpFunc(ct.params.TestNamespace)
 				ct.Logf("✨ [%s] Deploying %s CiliumNetworkPolicy...", client.ClusterName(), cnp.Name)

--- a/cilium-cli/install/helm.go
+++ b/cilium-cli/install/helm.go
@@ -17,7 +17,7 @@ func (k *K8sInstaller) getHelmValues() (map[string]any, error) {
 	helmMapOpts := map[string]string{}
 
 	switch {
-	case versioncheck.MustCompile(">=1.15.0")(k.chartVersion):
+	case versioncheck.MustCompile(">=1.16.0")(k.chartVersion):
 		// TODO(aanm) to keep the previous behavior unchanged we will set the number
 		// of the operator replicas to 1. Ideally this should be the default in the helm chart
 		helmMapOpts["operator.replicas"] = "1"

--- a/cilium-cli/install/helm_test.go
+++ b/cilium-cli/install/helm_test.go
@@ -19,7 +19,7 @@ func TestK8sInstaller_getHelmValuesKind(t *testing.T) {
 	installer := K8sInstaller{
 		params:       Parameters{},
 		flavor:       k8s.Flavor{Kind: k8s.KindKind},
-		chartVersion: semver.MustParse("1.15.0"),
+		chartVersion: semver.MustParse("1.16.0"),
 	}
 	values, err := installer.getHelmValues()
 	assert.NoError(t, err)

--- a/cilium-cli/utils/features/features.go
+++ b/cilium-cli/utils/features/features.go
@@ -275,15 +275,11 @@ func RequireModeIsNot(feature Feature, mode string) Requirement {
 
 // ExtractFromCiliumVersion extracts features based on Cilium version.
 func (fs Set) ExtractFromCiliumVersion(ciliumVersion semver.Version) {
-	fs[PortRanges] = ExtractPortRanges(ciliumVersion)
-	fs[L7PortRanges] = ExtractL7PortRanges(ciliumVersion)
-}
-
-func ExtractPortRanges(ciliumVersion semver.Version) Status {
-	enabled := versioncheck.MustCompile(">=1.16.0")(ciliumVersion)
-	return Status{
-		Enabled: enabled,
+	fs[PortRanges] = Status{
+		Enabled: true,
 	}
+
+	fs[L7PortRanges] = ExtractL7PortRanges(ciliumVersion)
 }
 
 func ExtractL7PortRanges(ciliumVersion semver.Version) Status {

--- a/cilium-cli/utils/features/features.go
+++ b/cilium-cli/utils/features/features.go
@@ -22,7 +22,6 @@ const (
 	L7Proxy            Feature = "l7-proxy"
 	HostFirewall       Feature = "host-firewall"
 	ICMPPolicy         Feature = "icmp-policy"
-	PortRanges         Feature = "port-ranges"
 	L7PortRanges       Feature = "l7-port-ranges"
 	Tunnel             Feature = "tunnel"
 	TunnelPort         Feature = "tunnel-port"
@@ -275,10 +274,6 @@ func RequireModeIsNot(feature Feature, mode string) Requirement {
 
 // ExtractFromCiliumVersion extracts features based on Cilium version.
 func (fs Set) ExtractFromCiliumVersion(ciliumVersion semver.Version) {
-	fs[PortRanges] = Status{
-		Enabled: true,
-	}
-
 	fs[L7PortRanges] = ExtractL7PortRanges(ciliumVersion)
 }
 


### PR DESCRIPTION
As CI for v1.17 still downgrades into v1.16, this is the minimum version we need to support.