### PR TITLE
bpf: tests: fix up definition for ENABLE_ROUTING

### DIFF
--- a/bpf/tests/eni_nlb_symetric_routing_host.c
+++ b/bpf/tests/eni_nlb_symetric_routing_host.c
@@ -12,10 +12,10 @@
 #include "pktgen.h"
 
 /* Enable code paths under test*/
-#define ENABLE_IPV4
-#define ENABLE_NODEPORT
+#define ENABLE_IPV4		1
+#define ENABLE_NODEPORT		1
 #define ENABLE_MASQUERADE_IPV4	1
-#define ENABLE_ROUTING
+#define ENABLE_ROUTING		1
 
 #define PRIMARY_IFACE 1
 #define SECONDARY_IFACE 2

--- a/bpf/tests/l7_lb_local_backend_host.c
+++ b/bpf/tests/l7_lb_local_backend_host.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
 /* Copyright Authors of Cilium */
 
-#define ENABLE_ROUTING
+#define ENABLE_ROUTING		1
 
 #include "l7_lb_local_backend.h"


### PR DESCRIPTION
Define ENABLE_ROUTING so that usage of is_defined() in the datapath works as expected.