### PR TITLE
docs: replace echoserver with echo-basic in gateway-api examples

### DIFF
--- a/Documentation/network/servicemesh/echo-app.rst
+++ b/Documentation/network/servicemesh/echo-app.rst
@@ -3,12 +3,12 @@ Deploy the Echo App
 
 We will use a deployment made of echo servers.
 
-The application will reply to the client and, in the body of the reply, will include information about the Pod and Node receiving the original request. 
+The application will reply to the client and, in the body of the reply, will include information about the Pod receiving the original request.
 We will use this information to illustrate how the traffic is manipulated by the Gateway. 
 
 .. parsed-literal::
 
-    $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/gateway/echo.yaml
+    $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/gateway/echo-basic.yaml
 
 Verify the Pods are running as expected. 
 

--- a/Documentation/network/servicemesh/gateway-api/header.rst
+++ b/Documentation/network/servicemesh/gateway-api/header.rst
@@ -54,14 +54,41 @@ Now that the Gateway is ready, you can make HTTP requests.
 
 .. code-block:: shell-session
 
-    $ curl -s http://$GATEWAY/add-a-request-header | grep -A 6 "Request Headers"
-    Request Headers:
-        accept=*/*  
-        host=172.18.255.200  
-        my-header-name=my-header-value  
-        user-agent=curl/7.81.0  
-        x-forwarded-proto=http
-        x-request-id=61a72702-3dfa-4bc3-a21c-7544ef36af7b
+    $ curl -s http://$GATEWAY/add-a-request-header
+    {
+     "path": "/add-a-request-header",
+     "host": "172.18.255.200",
+     "method": "GET",
+     "proto": "HTTP/1.1",
+     "headers": {
+      "Accept": [
+       "*/*"
+      ],
+      "My-Header-Name": [
+       "my-header-value"
+      ],
+      "User-Agent": [
+       "curl/7.81.0"
+      ],
+      "X-Envoy-Internal": [
+       "true"
+      ],
+      "X-Forwarded-For": [
+       "172.18.0.1"
+      ],
+      "X-Forwarded-Proto": [
+       "http"
+      ],
+      "X-Request-Id": [
+       "61a72702-3dfa-4bc3-a21c-7544ef36af7b"
+      ]
+     },
+     "httpPort": "3000",
+     "namespace": "default",
+     "ingress": "",
+     "service": "",
+     "pod": "echo-1-7d88f779b-m6r46"
+    }
 
 If the curl succeeds, you can see the HTTP Header from the incoming request in the body of the response sent back from the echo server. You can also see that the Gateway added the header.
 
@@ -78,12 +105,35 @@ Notice that the ``x-request-id`` header is removed when you add the ``remove-a-r
 
 .. code-block:: shell-session
 
-    $ curl --fail -s http://$GATEWAY/remove-a-request-header | grep -A 6 "Request Headers"
-    Request Headers:
-        accept=*/*  
-        host=172.18.255.200  
-        user-agent=curl/7.81.0  
-        x-forwarded-proto=http  
+    $ curl --fail -s http://$GATEWAY/remove-a-request-header
+    {
+     "path": "/remove-a-request-header",
+     "host": "172.18.255.200",
+     "method": "GET",
+     "proto": "HTTP/1.1",
+     "headers": {
+      "Accept": [
+       "*/*"
+      ],
+      "User-Agent": [
+       "curl/7.81.0"
+      ],
+      "X-Envoy-Internal": [
+       "true"
+      ],
+      "X-Forwarded-For": [
+       "172.18.0.1"
+      ],
+      "X-Forwarded-Proto": [
+       "http"
+      ]
+     },
+     "httpPort": "3000",
+     "namespace": "default",
+     "ingress": "",
+     "service": "",
+     "pod": "echo-1-7d88f779b-m6r46"
+    }
 
 To edit an existing header, use the ``set`` action to specify the value of the header to modify as well as the new header value to set.
 
@@ -100,10 +150,35 @@ Notice that the ``x-request-id`` header is changed when you add the ``edit-a-req
 
 .. code-block:: shell-session
 
-    $ curl -s http://$GATEWAY/edit-a-request-header | grep -A 6 "Request Headers"
-    Request Headers:
-        accept=*/*  
-        host=172.18.255.200  
-        user-agent=curl/7.81.0  
-        x-forwarded-proto=http  
-        x-request-id=set-cilium-header-value
+    $ curl -s http://$GATEWAY/edit-a-request-header
+    {
+     "path": "/edit-a-request-header",
+     "host": "172.18.255.200",
+     "method": "GET",
+     "proto": "HTTP/1.1",
+     "headers": {
+      "Accept": [
+       "*/*"
+      ],
+      "User-Agent": [
+       "curl/7.81.0"
+      ],
+      "X-Envoy-Internal": [
+       "true"
+      ],
+      "X-Forwarded-For": [
+       "172.18.0.1"
+      ],
+      "X-Forwarded-Proto": [
+       "http"
+      ],
+      "X-Request-Id": [
+       "set-cilium-header-value"
+      ]
+     },
+     "httpPort": "3000",
+     "namespace": "default",
+     "ingress": "",
+     "service": "",
+     "pod": "echo-1-7d88f779b-m6r46"
+    }

--- a/Documentation/network/servicemesh/gateway-api/splitting.rst
+++ b/Documentation/network/servicemesh/gateway-api/splitting.rst
@@ -56,42 +56,43 @@ Now that the Gateway is ready, you can make HTTP requests to the services.
 
     $ GATEWAY=$(kubectl get gateway cilium-gw -o jsonpath='{.status.addresses[0].value}')
     $ curl --fail -s http://$GATEWAY/echo
+    {
+     "path": "/echo",
+     "host": "172.18.255.200",
+     "method": "GET",
+     "proto": "HTTP/1.1",
+     "headers": {
+      "Accept": [
+       "*/*"
+      ],
+      "User-Agent": [
+       "curl/7.81.0"
+      ],
+      "X-Envoy-Internal": [
+       "true"
+      ],
+      "X-Forwarded-For": [
+       "172.18.0.1"
+      ],
+      "X-Forwarded-Proto": [
+       "http"
+      ],
+      "X-Request-Id": [
+       "ee152a07-2be2-4539-b74d-ebcebf912907"
+      ]
+     },
+     "httpPort": "3000",
+     "namespace": "default",
+     "ingress": "",
+     "service": "",
+     "pod": "echo-1-7d88f779b-m6r46"
+    }
 
-    Hostname: echo-1-7d88f779b-m6r46
-
-    Pod Information:
-        node name:      kind-worker2
-        pod name:       echo-1-7d88f779b-m6r46
-        pod namespace:  default
-        pod IP: 10.0.2.15
-
-    Server values:
-        server_version=nginx: 1.12.2 - lua: 10010
-
-    Request Information:
-        client_address=10.0.2.252
-        method=GET
-        real path=/echo
-        query=
-        request_version=1.1
-        request_scheme=http
-        request_uri=http://172.18.255.200:8080/echo
-
-    Request Headers:
-        accept=*/*  
-        host=172.18.255.200  
-        user-agent=curl/7.81.0  
-        x-forwarded-proto=http  
-        x-request-id=ee152a07-2be2-4539-b74d-ebcebf912907  
-
-    Request Body:
-        -no body in request-
-
-Notice that the reply includes the name of the Pod that received the query. For example:
+Notice that the reply includes the name of the Pod that received the query in the ``pod`` field. For example:
 
 .. code-block:: shell-session
 
-    Hostname: echo-2-5bfb6668b4-2rl4t
+     "pod": "echo-2-5bfb6668b4-2rl4t"
 
 Repeat the command several times.
 You should see the reply balanced evenly across both Pods and Nodes.
@@ -99,16 +100,16 @@ Verify that traffic is evenly split across multiple Pods by running a loop and c
 
 .. code-block:: shell-session
 
-    while true; do curl -s -k "http://$GATEWAY/echo" >> curlresponses.txt ;done
+    $ while true; do curl -s -k "http://$GATEWAY/echo" >> curlresponses.txt ;done
 
 Stop the loop with ``Ctrl+C``.
 Verify that the responses are more or less evenly distributed.
 
 .. code-block:: shell-session
 
-    $ cat curlresponses.txt| grep -c "Hostname: echo-1"
+    $ cat curlresponses.txt| grep -c '"pod": "echo-1'
     1221
-    $ cat curlresponses.txt| grep -c "Hostname: echo-2"
+    $ cat curlresponses.txt| grep -c '"pod": "echo-2'
     1162
 
 Uneven (99/1) traffic split
@@ -133,14 +134,14 @@ Verify that traffic is unevenly split across multiple Pods by running a loop and
 
 .. code-block:: shell-session
 
-    while true; do curl -s -k "http://$GATEWAY/echo" >> curlresponses991.txt ;done
+    $ while true; do curl -s -k "http://$GATEWAY/echo" >> curlresponses991.txt ;done
 
 Stop the loop with ``Ctrl+C``.
 Verify that responses are more or less evenly distributed.
 
 .. code-block:: shell-session
 
-    $ cat curlresponses991.txt| grep -c "Hostname: echo-1"
+    $ cat curlresponses991.txt| grep -c '"pod": "echo-1'
     24739
-    $ cat curlresponses991.txt| grep -c "Hostname: echo-2"
+    $ cat curlresponses991.txt| grep -c '"pod": "echo-2'
     239

--- a/examples/kubernetes/gateway/echo-basic.yaml
+++ b/examples/kubernetes/gateway/echo-basic.yaml
@@ -10,7 +10,7 @@ spec:
   - port: 8080
     name: high
     protocol: TCP
-    targetPort: 8080
+    targetPort: 3000
   selector:
     app: echo-1
 ---
@@ -31,27 +31,19 @@ spec:
         app: echo-1
     spec:
       containers:
-      - image: gcr.io/kubernetes-e2e-test-images/echoserver:2.2
+      - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
         name: echo-1
         ports:
-        - containerPort: 8080
+        - containerPort: 3000
         env:
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
           - name: POD_NAME
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-          - name: POD_NAMESPACE
+          - name: NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: POD_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
 ---
 apiVersion: v1
 kind: Service
@@ -64,7 +56,7 @@ spec:
   - port: 8090
     name: high
     protocol: TCP
-    targetPort: 8080
+    targetPort: 3000
   selector:
     app: echo-2
 ---
@@ -85,24 +77,16 @@ spec:
         app: echo-2
     spec:
       containers:
-      - image: gcr.io/kubernetes-e2e-test-images/echoserver:2.2
+      - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
         name: echo-2
         ports:
-        - containerPort: 8080
+        - containerPort: 3000
         env:
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
           - name: POD_NAME
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-          - name: POD_NAMESPACE
+          - name: NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: POD_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP


### PR DESCRIPTION
The gcr.io/kubernetes-e2e-test-images/echoserver:2.2 image is based on nginx and Lua, and its arm64 variant is broken (despite starting up, the libraries linked to nginx in the container image are amd64 only).

Replace it with registry.k8s.io/gateway-api/echo-basic:v1.5.1, the upstream gateway-api conformance echo server with working arm64 support. Update the example manifests and all dependent documentation to reflect the new response format.

```release-note
docs: replace echoserver with echo-basic, for arm64 support
```
