### PR TITLE
operator: Remove commented out code from CES package

### DIFF
--- a/operator/pkg/ciliumendpointslice/endpointslice.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
@@ -249,20 +249,8 @@ func (c *SlimController) Start(ctx cell.HookContext) error {
 			return nil
 		}),
 	)
-	// Start the work pools processing CEP events only after syncing CES in local cache.
-	// c.wp = workerpool.New(4)
-	// c.wp.Submit("cilium-pods-updater", c.runCiliumPodsUpdater)
-	// c.wp.Submit("cilium-endpoint-slices-updater", c.runCiliumEndpointSliceUpdater)
-	// c.wp.Submit("cilium-nodes-updater", c.runCiliumNodesUpdater)
-	// c.wp.Submit("cilium-identities-updater", c.runCiliumIdentitiesUpdater)
 
 	c.logger.InfoContext(ctx, "Starting CES controller reconciler.")
-	// c.Job.Add(
-	// 	job.OneShot("proc-queues", func(ctx context.Context, health cell.Health) error {
-	// 		c.worker()
-	// 		return nil
-	// 	}),
-	// )
 
 	return nil
 }
@@ -445,16 +433,6 @@ func (c *SlimController) onPodUpdate(pod *slim_corev1.Pod) error {
 		return err
 	}
 
-	// pCid, err := c.reconciler.getPodIdentity(cidKey)
-	// if err != nil {
-	// 	// Pod CID couldn't be retrieved yet. We store known pod information
-	// 	// in the ces cache, so it can be associated with the CID once it is
-	// 	// created.
-	// 	c.manager.AddPodMapping(pod, node, cidKey)
-	// 	return nil // Reconciles on CID event
-	// }
-
-	// touchedCESs := c.manager.UpsertPodWithIdentity(pod, node, pCid)
 	touchedCESs := c.manager.AddPodMapping(pod, node, cidKey)
 	c.enqueueCESReconciliation(touchedCESs)
 	return nil

--- a/operator/pkg/ciliumendpointslice/manager.go
+++ b/operator/pkg/ciliumendpointslice/manager.go
@@ -321,22 +321,6 @@ func (c *slimManager) AddPodMapping(pod *slim_corev1.Pod, nodeName string, cidKe
 	return []CESKey{NewCESKey(cesName.string(), pod.Namespace)}
 }
 
-// UpsertPodWithIdentity is used to insert coreCEP in local cache, this may result in creating a new
-// CES object or updating an existing CES object.
-// func (c *slimManager) UpsertPodWithIdentity(pod *slim_corev1.Pod, nodeName string, cid *cilium_v2.CiliumIdentity) []CESKey {
-// 	c.mutex.Lock()
-// 	defer c.mutex.Unlock()
-
-// 	cepName, cesName := c.upsertPodIntoCESLocked(pod)
-// 	cidName, gidLabels := cidToGidLabels(cid)
-// 	c.mapping.upsertCEP(cepName, cesName, NodeName(nodeName), gidLabels, cidName)
-// 	c.logger.Debug("CEP mapped to CES",
-// 		logfields.CEPName, cepName.string(),
-// 		logfields.CESName, cesName.string(),
-// 	)
-// 	return []CESKey{NewCESKey(cesName.string(), pod.Namespace)}
-// }
-
 // For a pod, return the associated CEP name and CES name (if none already exist,
 // create a new CES)
 func (c *slimManager) upsertPodIntoCESLocked(pod *slim_corev1.Pod) (CEPName, CESName) {


### PR DESCRIPTION

This PR removes commented out code that was left behind during the implementation of the slim mode CES controller in PR #38388. The current implementation uses a different approach (AddPodMapping with CID key labels) and the commented code represents an abandoned alternative implementation path.

Removed:
- Commented UpsertPodWithIdentity function from manager.go
- Commented pod identity retrieval code from endpointslice.go
- Commented workerpool submission code from endpointslice.go

Fixes #46800

```release-note
operator: Remove commented out dead code from CES package
```

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      This PR was prepared with AIL:1. I personally reviewed the code changes and verified the removed code was indeed dead and not referenced elsewhere.
- [x] Thanks for contributing!
