### PR TITLE
Policy: add "cluster-mesh" entity, PolicyMap aggregation for cluster and cluster-mesh

### DIFF
--- a/Documentation/security/policy/layer3.rst
+++ b/Documentation/security/policy/layer3.rst
@@ -268,8 +268,11 @@ cluster
     Cluster is the logical group of all network endpoints inside of the local
     cluster. This includes all Cilium-managed endpoints of the local cluster,
     unmanaged endpoints in the local cluster, as well as the host,
-    remote-node, and init identities. This also includes all remote nodes
-    in a clustermesh scenario.
+    remote-node, init, ingress, health, and kube-apiserver entities. This 
+    also includes all remote nodes in a clustermesh scenario.
+cluster-mesh
+    The cluster-mesh entity selects all endpoints in meshed clusters, as well as
+    everything selected by the cluster entity.
 init
     The init entity contains all endpoints in bootstrap phase for which the
     security identity has not been resolved yet. This is typically only

--- a/bpf/lib/identity.h
+++ b/bpf/lib/identity.h
@@ -23,6 +23,7 @@ enum identity {
 	WORLD_IPV4_ID = 9,
 	WORLD_IPV6_ID = 10,
 	POLICY_CLUSTER_ID = 11, /* This ID is not used by endpoints, only policy map */
+	POLICY_CLUSTER_MESH_ID = 12,
 };
 
 EXPORT_TYPE(enum identity);

--- a/bpf/lib/identity.h
+++ b/bpf/lib/identity.h
@@ -22,6 +22,7 @@ enum identity {
 	INGRESS_ID = 8,
 	WORLD_IPV4_ID = 9,
 	WORLD_IPV6_ID = 10,
+	POLICY_CLUSTER_ID = 11, /* This ID is not used by endpoints, only policy map */
 };
 
 EXPORT_TYPE(enum identity);

--- a/bpf/lib/identity.h
+++ b/bpf/lib/identity.h
@@ -373,5 +373,17 @@ static __always_inline __u32 aggregate_for_identity(__u32 identity)
 	if (identity_is_world(identity))
 		return WORLD_ID;
 
-	return 0;
+	if (identity == POLICY_CLUSTER_ID || identity == POLICY_CLUSTER_MESH_ID || identity == 0)
+		return identity;
+	/* Identities 0-99 are special, we cannot easily aggregate them. */
+	if (identity < 100)
+		return 0;
+
+	/* identity is global scope and >= 100.
+	 * It must be an endpoint, either in cluster or cluster mesh.
+	 */
+	if (extract_cluster_id_from_identity(identity) == CONFIG(cluster_id))
+		return POLICY_CLUSTER_ID;
+
+	return POLICY_CLUSTER_MESH_ID;
 }

--- a/bpf/tests/network_policy.c
+++ b/bpf/tests/network_policy.c
@@ -233,5 +233,31 @@ int network_policy_egress_allow_check(struct __ctx_buff *ctx)
 		policy_delete_egress_all_entry();
 	});
 
+	/* tests that partial aggregates are correctly calculated */
+	TEST("aggregate-for-id", {
+		/* all aggregates must aggregate to themselves */
+		assert(aggregate_for_identity(0) == 0);
+		assert(aggregate_for_identity(2) == 2);
+		assert(aggregate_for_identity(6) == 6);
+		assert(aggregate_for_identity(11) == 11);
+		assert(aggregate_for_identity(12) == 12);
+
+		/* in-cluster identity */
+		assert(aggregate_for_identity(400) == POLICY_CLUSTER_ID);
+		/* cluster-mesh identity */
+		assert(aggregate_for_identity(0x0001aabb) == POLICY_CLUSTER_MESH_ID);
+
+		/* world identities */
+		assert(aggregate_for_identity(16777217) == WORLD_ID);
+		assert(aggregate_for_identity(WORLD_IPV4_ID) == WORLD_ID);
+		assert(aggregate_for_identity(WORLD_IPV6_ID) == WORLD_ID);
+		assert(aggregate_for_identity(WORLD_ID) == WORLD_ID);
+
+		/* remote node identities */
+		assert(aggregate_for_identity(REMOTE_NODE_ID) == REMOTE_NODE_ID);
+		assert(aggregate_for_identity(KUBE_APISERVER_NODE_ID) == REMOTE_NODE_ID);
+		assert(aggregate_for_identity(33554432) == REMOTE_NODE_ID);
+	});
+
 	test_finish();
 }

--- a/pkg/datapath/types/types_generated.go
+++ b/pkg/datapath/types/types_generated.go
@@ -255,6 +255,7 @@ const (
 	IdentityWorldIPv4ID         Identity = 9
 	IdentityWorldIPv6ID         Identity = 10
 	IdentityPolicyClusterID     Identity = 11
+	IdentityPolicyClusterMeshID Identity = 12
 )
 
 // IPCacheKey is generated from the BPF C type ipcache_key.

--- a/pkg/datapath/types/types_generated.go
+++ b/pkg/datapath/types/types_generated.go
@@ -254,6 +254,7 @@ const (
 	IdentityIngressID           Identity = 8
 	IdentityWorldIPv4ID         Identity = 9
 	IdentityWorldIPv6ID         Identity = 10
+	IdentityPolicyClusterID     Identity = 11
 )
 
 // IPCacheKey is generated from the BPF C type ipcache_key.

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -33,10 +33,6 @@ import (
 )
 
 var (
-	fakeConfig = &option.DaemonConfig{
-		K8sNamespace: "kube-system",
-	}
-
 	testConfigs = []testConfig{
 		{
 			name:            "disable_operator_manages_identities",
@@ -271,7 +267,7 @@ func testAllocator(t *testing.T, client kvstore.Client) {
 	lbls3 := labels.NewLabelsFromSortedList("id=bar;user=susan")
 
 	owner := newDummyOwner(logger)
-	identity.InitWellKnownIdentities(fakeConfig, cmtypes.ClusterInfo{Name: "default", ID: 5})
+	identity.InitStaticIdentities("kube-system", cmtypes.ClusterInfo{Name: "default", ID: 5}, true)
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	mgr := NewCachingIdentityAllocator(logger, owner, NewTestAllocatorConfig())
 	<-mgr.InitIdentityAllocator(nil, client)
@@ -404,7 +400,7 @@ func testAllocatorOperatorIDManagement(t *testing.T, cl kvstoreClient) {
 			_, kubeClient := k8sClient.NewFakeClientset(logger)
 
 			owner := newDummyOwner(logger)
-			identity.InitWellKnownIdentities(fakeConfig, cmtypes.ClusterInfo{Name: "default", ID: 5})
+			identity.InitStaticIdentities("kube-system", cmtypes.ClusterInfo{Name: "default", ID: 5}, true)
 			mgr := NewCachingIdentityAllocator(logger, owner, testAllocatorConfig(true, 2))
 			<-mgr.InitIdentityAllocator(kubeClient, cl)
 			defer mgr.Close()
@@ -519,7 +515,7 @@ func testLocalAllocation(t *testing.T, testConfig testConfig, client kvstore.Cli
 	logger := hivetest.Logger(t)
 
 	owner := newDummyOwner(logger)
-	identity.InitWellKnownIdentities(fakeConfig, cmtypes.ClusterInfo{Name: "default", ID: 5})
+	identity.InitStaticIdentities("kube-system", cmtypes.ClusterInfo{Name: "default", ID: 5}, true)
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	mgr := NewCachingIdentityAllocator(logger, owner, testConfig.allocatorConfig)
 	<-mgr.InitIdentityAllocator(nil, client)

--- a/pkg/identity/cache/cache_test.go
+++ b/pkg/identity/cache/cache_test.go
@@ -47,7 +47,7 @@ func testLookupReservedIdentity(t *testing.T, testConfig testConfig, client kvst
 	require.NotNil(t, id)
 	require.Equal(t, worldID, id.ID)
 
-	identity.InitWellKnownIdentities(fakeConfig, cmtypes.ClusterInfo{Name: "default", ID: 5})
+	identity.InitStaticIdentities("kube-system", cmtypes.ClusterInfo{Name: "default", ID: 5}, true)
 }
 
 func TestLookupReservedIdentityByLabels(t *testing.T) {

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -137,6 +137,10 @@ const (
 	// ReservedIdentityWorldIPv6 represents any endpoint outside of the cluster
 	// for IPv6 address only.
 	ReservedIdentityWorldIPv6 = NumericIdentity(datapath.IdentityWorldIPv6ID)
+
+	// ReservedIdentityCluster is used for policy map aggregation for all in-cluster traffic.
+	// It is not applied to any endpoints or packets directly.
+	ReservedIdentityCluster = NumericIdentity(datapath.IdentityPolicyClusterID)
 )
 
 // Special identities for well-known cluster components
@@ -237,17 +241,26 @@ func (w wellKnownIdentities) lookupByNumericIdentity(identity NumericIdentity) *
 	return wki.identity
 }
 
-type Configuration interface {
-	CiliumNamespaceName() string
-}
-
 func k8sLabel(key string, value string) string {
 	return "k8s:" + key + "=" + value
 }
 
-// InitWellKnownIdentities establishes all well-known identities. Returns the
-// number of well-known identities initialized.
-func InitWellKnownIdentities(c Configuration, cinfo cmtypes.ClusterInfo) int {
+// InitStaticIdentities establishes all well-known and static identities. Returns the
+// number of well-known (but not reserved) identities initialized.
+func InitStaticIdentities(ciliumNS string, cinfo cmtypes.ClusterInfo, enableWellKnown bool) int {
+
+	// Add the cluster identity to reserved identities.
+	// This cannot be done statically, as we need to know the cluster name.
+	AddReservedIdentityWithLabels(ReservedIdentityCluster,
+		labels.FromSlice([]labels.Label{
+			labels.NewLabel(labels.IDNameCluster, "", labels.LabelSourceReserved),
+			labels.NewLabel(api.PolicyLabelCluster, cinfo.Name, labels.LabelSourceK8s),
+		}))
+
+	if !enableWellKnown {
+		return 0
+	}
+
 	// kube-dns labels
 	//   k8s:io.cilium.k8s.policy.serviceaccount=kube-dns
 	//   k8s:io.kubernetes.pod.namespace=kube-system
@@ -325,13 +338,13 @@ func InitWellKnownIdentities(c Configuration, cinfo cmtypes.ClusterInfo) int {
 		"k8s:io.cilium/app=operator",
 		"k8s:app.kubernetes.io/part-of=cilium",
 		"k8s:app.kubernetes.io/name=cilium-operator",
-		k8sLabel(api.PodNamespaceLabel, c.CiliumNamespaceName()),
+		k8sLabel(api.PodNamespaceLabel, ciliumNS),
 		k8sLabel(api.PolicyLabelServiceAccount, "cilium-operator"),
 		k8sLabel(api.PolicyLabelCluster, cinfo.Name),
 	}
 	WellKnown.add(ReservedCiliumOperator, ciliumOperatorLabels)
 	WellKnown.add(ReservedCiliumOperator2, append(ciliumOperatorLabels,
-		k8sLabel(api.PodNamespaceMetaNameLabel, c.CiliumNamespaceName())))
+		k8sLabel(api.PodNamespaceMetaNameLabel, ciliumNS)))
 
 	return len(WellKnown)
 }

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -141,6 +141,10 @@ const (
 	// ReservedIdentityCluster is used for policy map aggregation for all in-cluster traffic.
 	// It is not applied to any endpoints or packets directly.
 	ReservedIdentityCluster = NumericIdentity(datapath.IdentityPolicyClusterID)
+
+	// ReservedIdentityClusterMesh is used for policy map aggregation for all cluster-mesh traffic.
+	// It is not applied to any endpoints or packets directly.
+	ReservedIdentityClusterMesh = NumericIdentity(datapath.IdentityPolicyClusterMeshID)
 )
 
 // Special identities for well-known cluster components
@@ -255,6 +259,14 @@ func InitStaticIdentities(ciliumNS string, cinfo cmtypes.ClusterInfo, enableWell
 		labels.FromSlice([]labels.Label{
 			labels.NewLabel(labels.IDNameCluster, "", labels.LabelSourceReserved),
 			labels.NewLabel(api.PolicyLabelCluster, cinfo.Name, labels.LabelSourceK8s),
+		}))
+
+	// The ClusterMesh identity has the cluster label name, but with a value of "".
+	// This is selected by the Has selector.
+	AddReservedIdentityWithLabels(ReservedIdentityClusterMesh,
+		labels.FromSlice([]labels.Label{
+			labels.NewLabel(labels.IDNameClusterMesh, "", labels.LabelSourceReserved),
+			labels.NewLabel(api.PolicyLabelCluster, "", labels.LabelSourceK8s),
 		}))
 
 	if !enableWellKnown {

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -43,8 +43,12 @@ const (
 	IDNameWorldIPv6 = "world-ipv6"
 
 	// IDNameCluster is the label used to identify an unspecified endpoint
-	// inside the cluster
+	// inside the cluster.
 	IDNameCluster = "cluster"
+
+	// IDNameClusterMesh is the label used to identify an unspecified endpoint
+	// in the cluster mesh
+	IDNameClusterMesh = "cluster-mesh"
 
 	// IDNameHealth is the label used for the local cilium-health endpoint
 	IDNameHealth = "health"

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2113,12 +2113,6 @@ func (c *DaemonConfig) UnreachableRoutesEnabled() bool {
 	return c.EnableUnreachableRoutes
 }
 
-// CiliumNamespaceName returns the name of the namespace in which Cilium is
-// deployed in
-func (c *DaemonConfig) CiliumNamespaceName() string {
-	return c.K8sNamespace
-}
-
 // AgentNotReadyNodeTaintValue returns the value of the taint key that cilium agents
 // will manage on their nodes
 func (c *DaemonConfig) AgentNotReadyNodeTaintValue() string {

--- a/pkg/policy/aggregate.go
+++ b/pkg/policy/aggregate.go
@@ -20,7 +20,10 @@
 
 package policy
 
-import "github.com/cilium/cilium/pkg/identity"
+import (
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/option"
+)
 
 // aggregateFor returns the numeric identity that aggregates the
 // given nid. If the supplied `nid` is already a wildcard,
@@ -33,6 +36,18 @@ func aggregateFor(nid identity.NumericIdentity) identity.NumericIdentity {
 		return identity.ReservedIdentityRemoteNode
 	case identity.ReservedIdentityWorld, identity.ReservedIdentityWorldIPv4, identity.ReservedIdentityWorldIPv6:
 		return identity.ReservedIdentityWorld
+	case identity.ReservedIdentityCluster:
+		return identity.ReservedIdentityCluster
+	case identity.ReservedIdentityClusterMesh:
+		return identity.ReservedIdentityClusterMesh
+	case identity.IdentityUnknown:
+		return identity.IdentityUnknown
+	}
+
+	// All identities below 100 are special-cased.
+	// They cannot be aggregated.
+	if nid < 100 {
+		return identity.IdentityUnknown
 	}
 
 	switch nid.Scope() {
@@ -42,7 +57,13 @@ func aggregateFor(nid identity.NumericIdentity) identity.NumericIdentity {
 		return identity.ReservedIdentityWorld
 	}
 
-	return identity.IdentityUnknown
+	// NID is global scope and > 100.
+	// Determine if nid is in-cluster.
+	cid := nid.ClusterID()
+	if cid == option.Config.ClusterID {
+		return identity.ReservedIdentityCluster
+	}
+	return identity.ReservedIdentityClusterMesh
 }
 
 // aggregates returns true if child is a child of the wildcard.
@@ -62,4 +83,6 @@ var AllAggregates = []identity.NumericIdentity{
 	identity.IdentityUnknown,
 	identity.ReservedIdentityRemoteNode,
 	identity.ReservedIdentityWorld,
+	identity.ReservedIdentityCluster,
+	identity.ReservedIdentityClusterMesh,
 }

--- a/pkg/policy/aggregate_test.go
+++ b/pkg/policy/aggregate_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 func TestAllAggregates(t *testing.T) {
@@ -25,7 +26,7 @@ func TestAllAggregates(t *testing.T) {
 		nid := i * 100
 		// duplicate of AllAggregates for efficiency.
 		switch nid {
-		case 0, 6, 2:
+		case 0, 6, 2, 11, 12:
 			require.True(t, isAggregate(nid))
 		default:
 			require.False(t, isAggregate(nid))
@@ -34,6 +35,12 @@ func TestAllAggregates(t *testing.T) {
 }
 
 func TestIsAggregate(t *testing.T) {
+	oldCid := option.Config.ClusterID
+	t.Cleanup(func() {
+		option.Config.ClusterID = oldCid
+	})
+	option.Config.ClusterID = 0
+
 	for i, tc := range []struct {
 		in, out identity.NumericIdentity
 	}{
@@ -41,7 +48,9 @@ func TestIsAggregate(t *testing.T) {
 		{identity.ReservedIdentityHost, 0},
 		{identity.ReservedIdentityRemoteNode, 6},
 		{identity.ReservedIdentityKubeAPIServer, 6},
-		{identity.ReservedCoreDNS, 0},
+		{identity.ReservedCoreDNS, 11},
+		{1001, 11},
+		{0x00_01_00_55, 12}, // clustermesh
 		{identity.MinLocalIdentity, 2},
 		{identity.MaxLocalIdentity, 2},
 		{identity.ReservedIdentityWorld, 2},
@@ -50,6 +59,29 @@ func TestIsAggregate(t *testing.T) {
 		{identity.IdentityScopeRemoteNode, 6},
 		{identity.IdentityScopeRemoteNode + 100, 6},
 	} {
-		require.Equal(t, tc.out, aggregateFor(tc.in), "idx %d ID %d", i, tc.in)
+		require.Equal(t, tc.out, aggregateFor(tc.in), "index %d ID %d", i, tc.in)
+	}
+
+	option.Config.ClusterID = 1
+
+	for i, tc := range []struct {
+		in, out identity.NumericIdentity
+	}{
+		{0, 0},
+		{identity.ReservedIdentityHost, 0},
+		{identity.ReservedIdentityRemoteNode, 6},
+		{identity.ReservedIdentityKubeAPIServer, 6},
+		{identity.ReservedCoreDNS, 12},
+		{1001, 12},          // Now ths ID is clustermesh
+		{0x00_01_00_55, 11}, // now in-cluster
+		{identity.MinLocalIdentity, 2},
+		{identity.MaxLocalIdentity, 2},
+		{identity.ReservedIdentityWorld, 2},
+		{identity.ReservedIdentityWorldIPv4, 2},
+		{identity.ReservedIdentityWorldIPv6, 2},
+		{identity.IdentityScopeRemoteNode, 6},
+		{identity.IdentityScopeRemoteNode + 100, 6},
+	} {
+		require.Equal(t, tc.out, aggregateFor(tc.in), "cluster ID 1, index %d ID %d", i, tc.in)
 	}
 }

--- a/pkg/policy/api/entity.go
+++ b/pkg/policy/api/entity.go
@@ -5,6 +5,7 @@ package api
 
 import (
 	k8sapi "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/labels"
 )
 
@@ -36,6 +37,10 @@ const (
 	// EntityCluster is an entity that represents traffic within the
 	// endpoint's cluster, to endpoints not managed by cilium
 	EntityCluster Entity = "cluster"
+
+	// EntityClusterMesh is an entity that represents traffic within the
+	// complete clustermesh
+	EntityClusterMesh Entity = "cluster-mesh"
 
 	// EntityHost is an entity that represents traffic within endpoint host
 	EntityHost Entity = "host"
@@ -85,6 +90,17 @@ var (
 
 	endpointSelectorKubeAPIServer = NewESFromLabels(labels.LabelKubeAPIServer[labels.IDNameKubeAPIServer])
 
+	// used by both cluster and cluster-mesh entities
+	clusterSelectors = EndpointSelectorSlice{
+		endpointSelectorHost,
+		endpointSelectorRemoteNode,
+		endpointSelectorInit,
+		endpointSelectorIngress,
+		endpointSelectorHealth,
+		endpointSelectorUnmanaged,
+		endpointSelectorKubeAPIServer,
+	}
+
 	// EntitySelectorMapping maps special entity names that come in
 	// policies to selectors
 	// If you add an entry here, you must also update the CRD
@@ -112,6 +128,13 @@ var (
 		// initialized at runtime as it depends on user configuration
 		// such as the cluster name. See InitEntities() below.
 		EntityCluster: {},
+
+		// ClusterMesh can be initialized statically, as it selects all endpoints
+		// with the cluster mesh label set.
+		EntityClusterMesh: append(clusterSelectors, NewESFromMatchRequirements(nil, []v1.LabelSelectorRequirement{{
+			Key:      k8sapi.PolicyLabelCluster,
+			Operator: v1.LabelSelectorOpExists,
+		}})),
 	}
 )
 
@@ -133,14 +156,7 @@ func (s EntitySlice) GetAsEndpointSelectors() EndpointSelectorSlice {
 
 // InitEntities is called to initialize the policy API layer
 func InitEntities(clusterName string) {
-	EntitySelectorMapping[EntityCluster] = EndpointSelectorSlice{
-		endpointSelectorHost,
-		endpointSelectorRemoteNode,
-		endpointSelectorInit,
-		endpointSelectorIngress,
-		endpointSelectorHealth,
-		endpointSelectorUnmanaged,
-		endpointSelectorKubeAPIServer,
+	EntitySelectorMapping[EntityCluster] = append(clusterSelectors,
 		NewESFromLabels(labels.NewLabel(k8sapi.PolicyLabelCluster, clusterName, labels.LabelSourceK8s)),
-	}
+	)
 }

--- a/pkg/policy/cell/cell.go
+++ b/pkg/policy/cell/cell.go
@@ -62,6 +62,7 @@ type policyRepoParams struct {
 	Logger            *slog.Logger
 	Lifecycle         cell.Lifecycle
 	Config            Config
+	DaemonConfig      *option.DaemonConfig
 	CertManager       certificatemanager.CertificateManager
 	IdentityManager   identitymanager.IDManager
 	ClusterInfo       cmtypes.ClusterInfo
@@ -70,16 +71,14 @@ type policyRepoParams struct {
 }
 
 func newPolicyRepo(params policyRepoParams) policy.PolicyRepository {
-	if params.Config.EnableWellKnownIdentities {
-		// Must be done before calling policy.NewPolicyRepository() below.
-		num := identity.InitWellKnownIdentities(option.Config, params.ClusterInfo)
-		metrics.Identity.WithLabelValues(identity.WellKnownIdentityType).Add(float64(num))
-		identity.WellKnown.ForEach(func(i *identity.Identity) {
-			for labelSource := range i.Labels.CollectSources() {
-				metrics.IdentityLabelSources.WithLabelValues(labelSource).Inc()
-			}
-		})
-	}
+	// Must be done before calling policy.NewPolicyRepository() below.
+	num := identity.InitStaticIdentities(params.DaemonConfig.K8sNamespace, params.ClusterInfo, params.Config.EnableWellKnownIdentities)
+	metrics.Identity.WithLabelValues(identity.WellKnownIdentityType).Add(float64(num))
+	identity.WellKnown.ForEach(func(i *identity.Identity) {
+		for labelSource := range i.Labels.CollectSources() {
+			metrics.IdentityLabelSources.WithLabelValues(labelSource).Inc()
+		}
+	})
 
 	policyapi.InitEntities(params.ClusterInfo.Name)
 

--- a/pkg/policy/mapstate_iterator_test.go
+++ b/pkg/policy/mapstate_iterator_test.go
@@ -33,7 +33,7 @@ import (
 // proto tcp port 8-15
 // proto tcp port 10
 func multiLevelMapState(t *testing.T) *mapState {
-	ids := []identity.NumericIdentity{0, 257, 258, 6, 7, identity.IdentityScopeRemoteNode}
+	ids := []identity.NumericIdentity{0, 97, 98, 6, 7, identity.IdentityScopeRemoteNode}
 	keys := []types.Key{
 		types.IngressKey(),
 		types.IngressKey().WithProto(u8proto.TCP),
@@ -60,15 +60,15 @@ func TestMapState_CoveringBroaderOrEqualKeys(t *testing.T) {
 
 	cases := []testcase{
 		{
-			startKey: "258:6:10:16", // port 10
+			startKey: "98:6:10:16", // port 10
 			shouldSee: []string{
-				"258:6:10:16",
+				"98:6:10:16",
 				"0:6:10:16",
-				"258:6:8:13",
+				"98:6:8:13",
 				"0:6:8:13",
-				"258:6",
+				"98:6",
 				"0:6",
-				"258",
+				"98",
 				"0",
 			},
 		},
@@ -84,13 +84,13 @@ func TestMapState_CoveringBroaderOrEqualKeys(t *testing.T) {
 		},
 
 		{
-			startKey: "258:6:11:16", // port 11 (not in mapstate directly)
+			startKey: "98:6:11:16", // port 11 (not in mapstate directly)
 			shouldSee: []string{
-				"258:6:8:13",
+				"98:6:8:13",
 				"0:6:8:13",
-				"258:6",
+				"98:6",
 				"0:6",
-				"258",
+				"98",
 				"0",
 			},
 		},
@@ -105,11 +105,11 @@ func TestMapState_CoveringBroaderOrEqualKeys(t *testing.T) {
 		},
 
 		{
-			startKey: "258:6:2:16",
+			startKey: "98:6:2:16",
 			shouldSee: []string{
-				"258:6",
+				"98:6",
 				"0:6",
-				"258",
+				"98",
 				"0",
 			},
 		},
@@ -228,15 +228,15 @@ func TestMapState_BroaderOrEqualKeys(t *testing.T) {
 
 	cases := []testcase{
 		{
-			startKey: "258:6:10:16", // port 10
+			startKey: "98:6:10:16", // port 10
 			shouldSee: []string{
-				"258:6:10:16",
+				"98:6:10:16",
 				"0:6:10:16",
-				"258:6:8:13",
+				"98:6:8:13",
 				"0:6:8:13",
-				"258:6",
+				"98:6",
 				"0:6",
-				"258",
+				"98",
 				"0",
 			},
 		},
@@ -244,29 +244,29 @@ func TestMapState_BroaderOrEqualKeys(t *testing.T) {
 		{
 			startKey: "0:6:10:16", // port 10
 			shouldSee: []string{
-				"257:6:10:16",
-				"258:6:10:16",
+				"97:6:10:16",
+				"98:6:10:16",
 				"0:6:10:16",
-				"257:6:8:13",
-				"258:6:8:13",
+				"97:6:8:13",
+				"98:6:8:13",
 				"0:6:8:13",
-				"257:6",
-				"258:6",
+				"97:6",
+				"98:6",
 				"0:6",
-				"257",
-				"258",
+				"97",
+				"98",
 				"0",
 			},
 		},
 
 		{
-			startKey: "258:6:11:16", // port 11 (not in mapstate directly)
+			startKey: "98:6:11:16", // port 11 (not in mapstate directly)
 			shouldSee: []string{
-				"258:6:8:13",
+				"98:6:8:13",
 				"0:6:8:13",
-				"258:6",
+				"98:6",
 				"0:6",
-				"258",
+				"98",
 				"0",
 			},
 		},
@@ -274,24 +274,24 @@ func TestMapState_BroaderOrEqualKeys(t *testing.T) {
 		{
 			startKey: "0:6:11:16", // port 11 (not in mapstate directly)
 			shouldSee: []string{
-				"257:6:8:13",
-				"258:6:8:13",
+				"97:6:8:13",
+				"98:6:8:13",
 				"0:6:8:13",
-				"257:6",
-				"258:6",
+				"97:6",
+				"98:6",
 				"0:6",
-				"257",
-				"258",
+				"97",
+				"98",
 				"0",
 			},
 		},
 
 		{
-			startKey: "258:6:2:16",
+			startKey: "98:6:2:16",
 			shouldSee: []string{
-				"258:6",
+				"98:6",
 				"0:6",
-				"258",
+				"98",
 				"0",
 			},
 		},
@@ -299,11 +299,11 @@ func TestMapState_BroaderOrEqualKeys(t *testing.T) {
 		{
 			startKey: "0:6:2:16",
 			shouldSee: []string{
-				"257:6",
-				"258:6",
+				"97:6",
+				"98:6",
 				"0:6",
-				"257",
-				"258",
+				"97",
+				"98",
 				"0",
 			},
 		},
@@ -311,8 +311,8 @@ func TestMapState_BroaderOrEqualKeys(t *testing.T) {
 		{
 			startKey: "0",
 			shouldSee: []string{
-				"257",
-				"258",
+				"97",
+				"98",
 				"0",
 			},
 		},
@@ -436,23 +436,23 @@ func TestMapState_CoveredNarrowerOrEqualKeys(t *testing.T) {
 
 	cases := []testcase{
 		{
-			startKey: "258:6:10:16", // port 10
+			startKey: "98:6:10:16", // port 10
 			shouldSee: []string{
-				"258:6:10:16",
+				"98:6:10:16",
 			},
 		},
 
 		{
 			startKey: "0:6:10:16", // port 10
 			shouldSee: []string{
-				"257:6:10:16",
-				"258:6:10:16",
+				"97:6:10:16",
+				"98:6:10:16",
 				"0:6:10:16",
 			},
 		},
 
 		{
-			startKey:  "258:6:11:16", // port 11 (not in mapstate directly)
+			startKey:  "98:6:11:16", // port 11 (not in mapstate directly)
 			shouldSee: []string{},
 		},
 
@@ -462,65 +462,65 @@ func TestMapState_CoveredNarrowerOrEqualKeys(t *testing.T) {
 		},
 
 		{
-			startKey: "258:6:8:14",
+			startKey: "98:6:8:14",
 			shouldSee: []string{
-				"258:6:10:16",
+				"98:6:10:16",
 			},
 		},
 
 		{
 			startKey: "0:6:8:14",
 			shouldSee: []string{
-				"257:6:10:16",
-				"258:6:10:16",
+				"97:6:10:16",
+				"98:6:10:16",
 				"0:6:10:16",
 			},
 		},
 
 		{
-			startKey: "257:6:8:13",
+			startKey: "97:6:8:13",
 			shouldSee: []string{
-				"257:6:10:16",
-				"257:6:8:13",
+				"97:6:10:16",
+				"97:6:8:13",
 			},
 		},
 
 		{
 			startKey: "0:6:8:13",
 			shouldSee: []string{
-				"257:6:10:16",
-				"257:6:8:13",
-				"258:6:10:16",
-				"258:6:8:13",
+				"97:6:10:16",
+				"97:6:8:13",
+				"98:6:10:16",
+				"98:6:8:13",
 				"0:6:10:16",
 				"0:6:8:13",
 			},
 		},
 
 		{
-			startKey: "257",
+			startKey: "97",
 			shouldSee: []string{
-				"257:6:10:16",
-				"257:6:8:13",
-				"257:6",
-				"257",
+				"97:6:10:16",
+				"97:6:8:13",
+				"97:6",
+				"97",
 			},
 		},
 
 		{
 			startKey: "0",
 			shouldSee: []string{
-				"257:6:10:16",
-				"258:6:10:16",
+				"97:6:10:16",
+				"98:6:10:16",
 				"0:6:10:16",
-				"257:6:8:13",
-				"258:6:8:13",
+				"97:6:8:13",
+				"98:6:8:13",
 				"0:6:8:13",
-				"257:6",
-				"258:6",
+				"97:6",
+				"98:6",
 				"0:6",
-				"257",
-				"258",
+				"97",
+				"98",
 				"0",
 			},
 		},
@@ -644,9 +644,9 @@ func TestMapState_NarrowerOrEqualKeys(t *testing.T) {
 
 	cases := []testcase{
 		{
-			startKey: "258:6:10:16", // port 10
+			startKey: "98:6:10:16", // port 10
 			shouldSee: []string{
-				"258:6:10:16",
+				"98:6:10:16",
 				"0:6:10:16",
 			},
 		},
@@ -654,14 +654,14 @@ func TestMapState_NarrowerOrEqualKeys(t *testing.T) {
 		{
 			startKey: "0:6:10:16", // port 10
 			shouldSee: []string{
-				"257:6:10:16",
-				"258:6:10:16",
+				"97:6:10:16",
+				"98:6:10:16",
 				"0:6:10:16",
 			},
 		},
 
 		{
-			startKey:  "258:6:11:16", // port 11 (not in mapstate directly)
+			startKey:  "98:6:11:16", // port 11 (not in mapstate directly)
 			shouldSee: []string{},
 		},
 
@@ -671,9 +671,9 @@ func TestMapState_NarrowerOrEqualKeys(t *testing.T) {
 		},
 
 		{
-			startKey: "258:6:8:14",
+			startKey: "98:6:8:14",
 			shouldSee: []string{
-				"258:6:10:16",
+				"98:6:10:16",
 				"0:6:10:16",
 			},
 		},
@@ -681,18 +681,18 @@ func TestMapState_NarrowerOrEqualKeys(t *testing.T) {
 		{
 			startKey: "0:6:8:14",
 			shouldSee: []string{
-				"257:6:10:16",
-				"258:6:10:16",
+				"97:6:10:16",
+				"98:6:10:16",
 				"0:6:10:16",
 			},
 		},
 
 		{
-			startKey: "257:6:8:13",
+			startKey: "97:6:8:13",
 			shouldSee: []string{
-				"257:6:10:16",
+				"97:6:10:16",
 				"0:6:10:16",
-				"257:6:8:13",
+				"97:6:8:13",
 				"0:6:8:13",
 			},
 		},
@@ -700,25 +700,25 @@ func TestMapState_NarrowerOrEqualKeys(t *testing.T) {
 		{
 			startKey: "0:6:8:13",
 			shouldSee: []string{
-				"257:6:10:16",
-				"257:6:8:13",
-				"258:6:10:16",
-				"258:6:8:13",
+				"97:6:10:16",
+				"97:6:8:13",
+				"98:6:10:16",
+				"98:6:8:13",
 				"0:6:10:16",
 				"0:6:8:13",
 			},
 		},
 
 		{
-			startKey: "257",
+			startKey: "97",
 			shouldSee: []string{
-				"257:6:10:16",
+				"97:6:10:16",
 				"0:6:10:16",
-				"257:6:8:13",
+				"97:6:8:13",
 				"0:6:8:13",
-				"257:6",
+				"97:6",
 				"0:6",
-				"257",
+				"97",
 				"0",
 			},
 		},
@@ -726,17 +726,17 @@ func TestMapState_NarrowerOrEqualKeys(t *testing.T) {
 		{
 			startKey: "0",
 			shouldSee: []string{
-				"257:6:10:16",
-				"258:6:10:16",
+				"97:6:10:16",
+				"98:6:10:16",
 				"0:6:10:16",
-				"257:6:8:13",
-				"258:6:8:13",
+				"97:6:8:13",
+				"98:6:8:13",
 				"0:6:8:13",
-				"257:6",
-				"258:6",
+				"97:6",
+				"98:6",
 				"0:6",
-				"257",
-				"258",
+				"97",
+				"98",
 				"0",
 			},
 		},
@@ -868,12 +868,12 @@ func TestMapState_CoveringKeysWithSameID(t *testing.T) {
 
 	cases := []testcase{
 		{
-			startKey: "258:6:10:16", // port 10
+			startKey: "98:6:10:16", // port 10
 			shouldSee: []string{
-				"258:6:10:16",
-				"258:6:8:13",
-				"258:6",
-				"258",
+				"98:6:10:16",
+				"98:6:8:13",
+				"98:6",
+				"98",
 			},
 		},
 
@@ -888,11 +888,11 @@ func TestMapState_CoveringKeysWithSameID(t *testing.T) {
 		},
 
 		{
-			startKey: "258:6:11:16", // port 11 (not in mapstate directly)
+			startKey: "98:6:11:16", // port 11 (not in mapstate directly)
 			shouldSee: []string{
-				"258:6:8:13",
-				"258:6",
-				"258",
+				"98:6:8:13",
+				"98:6",
+				"98",
 			},
 		},
 
@@ -906,10 +906,10 @@ func TestMapState_CoveringKeysWithSameID(t *testing.T) {
 		},
 
 		{
-			startKey: "258:6:2:16",
+			startKey: "98:6:2:16",
 			shouldSee: []string{
-				"258:6",
-				"258",
+				"98:6",
+				"98",
 			},
 		},
 
@@ -1017,9 +1017,9 @@ func TestMapState_SubsetKeysWithSameID(t *testing.T) {
 
 	cases := []testcase{
 		{
-			startKey: "258:6:10:16", // port 10
+			startKey: "98:6:10:16", // port 10
 			shouldSee: []string{
-				"258:6:10:16",
+				"98:6:10:16",
 			},
 		},
 
@@ -1031,7 +1031,7 @@ func TestMapState_SubsetKeysWithSameID(t *testing.T) {
 		},
 
 		{
-			startKey:  "258:6:11:16", // port 11 (not in mapstate directly)
+			startKey:  "98:6:11:16", // port 11 (not in mapstate directly)
 			shouldSee: []string{},
 		},
 
@@ -1041,9 +1041,9 @@ func TestMapState_SubsetKeysWithSameID(t *testing.T) {
 		},
 
 		{
-			startKey: "258:6:8:14",
+			startKey: "98:6:8:14",
 			shouldSee: []string{
-				"258:6:10:16",
+				"98:6:10:16",
 			},
 		},
 
@@ -1055,10 +1055,10 @@ func TestMapState_SubsetKeysWithSameID(t *testing.T) {
 		},
 
 		{
-			startKey: "257:6:8:13",
+			startKey: "97:6:8:13",
 			shouldSee: []string{
-				"257:6:10:16",
-				"257:6:8:13",
+				"97:6:10:16",
+				"97:6:8:13",
 			},
 		},
 
@@ -1071,12 +1071,12 @@ func TestMapState_SubsetKeysWithSameID(t *testing.T) {
 		},
 
 		{
-			startKey: "257",
+			startKey: "97",
 			shouldSee: []string{
-				"257:6:10:16",
-				"257:6:8:13",
-				"257:6",
-				"257",
+				"97:6:10:16",
+				"97:6:8:13",
+				"97:6",
+				"97",
 			},
 		},
 
@@ -1194,15 +1194,15 @@ func TestMapState_LPMAncestors(t *testing.T) {
 
 	cases := []testcase{
 		{
-			startKey: "258:6:10:16", // port 10
+			startKey: "98:6:10:16", // port 10
 			shouldSee: []string{
-				"258:6:10:16",
+				"98:6:10:16",
 				"0:6:10:16",
-				"258:6:8:13",
+				"98:6:8:13",
 				"0:6:8:13",
-				"258:6",
+				"98:6",
 				"0:6",
-				"258",
+				"98",
 				"0",
 			},
 		},
@@ -1218,13 +1218,13 @@ func TestMapState_LPMAncestors(t *testing.T) {
 		},
 
 		{
-			startKey: "258:6:11:16", // port 11 (not in mapstate directly)
+			startKey: "98:6:11:16", // port 11 (not in mapstate directly)
 			shouldSee: []string{
-				"258:6:8:13",
+				"98:6:8:13",
 				"0:6:8:13",
-				"258:6",
+				"98:6",
 				"0:6",
-				"258",
+				"98",
 				"0",
 			},
 		},
@@ -1239,11 +1239,11 @@ func TestMapState_LPMAncestors(t *testing.T) {
 		},
 
 		{
-			startKey: "258:6:2:16",
+			startKey: "98:6:2:16",
 			shouldSee: []string{
-				"258:6",
+				"98:6",
 				"0:6",
-				"258",
+				"98",
 				"0",
 			},
 		},

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -196,7 +196,7 @@ func BenchmarkRegenerateCIDRDenyPolicyRules(b *testing.B) {
 		epPolicy.Ready()
 	}
 	ip.Detach()
-	assert.Equal(b, 117517, owner.previousMap.Len())
+	assert.Equal(b, 117519, owner.previousMap.Len())
 }
 
 func TestRegenerateCIDRDenyPolicyRules(t *testing.T) {
@@ -211,7 +211,7 @@ func TestRegenerateCIDRDenyPolicyRules(t *testing.T) {
 	owner.previousMap = epPolicy.GetMapState()
 	epPolicy.Ready()
 	ip.Detach()
-	assert.Equal(t, 117517, owner.previousMap.Len())
+	assert.Equal(t, 117519, owner.previousMap.Len())
 }
 
 func TestL3WithIngressDenyWildcard(t *testing.T) {


### PR DESCRIPTION
This PR introduces a new [policy entity](https://docs.cilium.io/en/stable/security/policy/layer3/#entities-based) `cluster-mesh`, which selects all endpoints in all clusters.

Because the `cluster` and `cluster-mesh` entities can be very expensive and easily lead to PolicyMap overflows, this adds two new  [policymap aggregations](https://github.com/cilium/cilium/issues/45847), for `cluster` and `cluster-mesh` accordingly.

This requires creating two new reserved identities. These reserved identities will not be used by endpoints; they only exist as policy aggregation points.

AIL: 0

```release-note
Adds a new policy entity, `cluster-mesh`, which selects all endpoints in all meshed clusters. Also, makes the `cluster` and `cluster-mesh` create significantly fewer policy map entries.
```

