### PR TITLE
metrics: Emit native histograms for all histograms by default

### DIFF
--- a/pkg/metrics/metric/histogram.go
+++ b/pkg/metrics/metric/histogram.go
@@ -9,6 +9,21 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	// defaultNativeHistogramBucketFactor and defaultNativeHistogramMaxBucketNumber
+	// enable native histogram exposition for all Cilium histograms by default,
+	// mirroring the Kubernetes defaults (KEP-5808). A bucket factor of 1.1 keeps
+	// each bucket at most 10% wider than the previous one (8 buckets per power of
+	// two). The bucket number is capped to bound the per-histogram memory cost.
+	//
+	// Native histograms are exposed in addition to the classic buckets and are only
+	// ingested by scrapers that negotiate the Prometheus protobuf format and opt in
+	// (e.g. Prometheus with scrape_native_histograms enabled). Text/OpenMetrics
+	// scrapes are unaffected and keep seeing the classic _bucket/_count/_sum series.
+	defaultNativeHistogramBucketFactor    = 1.1
+	defaultNativeHistogramMaxBucketNumber = 160
+)
+
 func NewHistogram(opts HistogramOpts) Histogram {
 	return &histogram{
 		Histogram: prometheus.NewHistogram(opts.toPrometheus()),
@@ -265,6 +280,21 @@ func (ho HistogramOpts) opts() Opts {
 }
 
 func (ho HistogramOpts) toPrometheus() prometheus.HistogramOpts {
+	// Enable native histogram exposition by default for every histogram. Histograms
+	// that configure their own native histogram bucket factor are left untouched.
+	if ho.NativeHistogramBucketFactor == 0 {
+		ho.NativeHistogramBucketFactor = defaultNativeHistogramBucketFactor
+		ho.NativeHistogramMaxBucketNumber = defaultNativeHistogramMaxBucketNumber
+
+		// Setting a native histogram bucket factor flips the client_golang default
+		// for classic buckets from DefBuckets to "no buckets" (see the Buckets field
+		// doc above). Fall back to DefBuckets explicitly so histograms that don't
+		// define their own buckets keep emitting classic buckets for dual exposition.
+		if len(ho.Buckets) == 0 {
+			ho.Buckets = prometheus.DefBuckets
+		}
+	}
+
 	return prometheus.HistogramOpts{
 		Namespace:                       ho.Namespace,
 		Subsystem:                       ho.Subsystem,

--- a/pkg/metrics/metric/histogram_test.go
+++ b/pkg/metrics/metric/histogram_test.go
@@ -10,6 +10,72 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestHistogramNativeDefaults(t *testing.T) {
+	customBuckets := []float64{0.1, 0.5, 1}
+
+	tests := []struct {
+		name                string
+		opts                HistogramOpts
+		wantBucketFactor    float64
+		wantMaxBucketNumber uint32
+		wantBuckets         []float64
+	}{
+		{
+			name:                "native defaults applied and DefBuckets preserved when unset",
+			opts:                HistogramOpts{Name: "test"},
+			wantBucketFactor:    defaultNativeHistogramBucketFactor,
+			wantMaxBucketNumber: defaultNativeHistogramMaxBucketNumber,
+			wantBuckets:         prometheus.DefBuckets,
+		},
+		{
+			name:                "explicit classic buckets kept while native defaults applied",
+			opts:                HistogramOpts{Name: "test", Buckets: customBuckets},
+			wantBucketFactor:    defaultNativeHistogramBucketFactor,
+			wantMaxBucketNumber: defaultNativeHistogramMaxBucketNumber,
+			wantBuckets:         customBuckets,
+		},
+		{
+			name: "explicit native config left untouched",
+			opts: HistogramOpts{
+				Name:                           "test",
+				NativeHistogramBucketFactor:    2,
+				NativeHistogramMaxBucketNumber: 15,
+			},
+			wantBucketFactor:    2,
+			wantMaxBucketNumber: 15,
+			wantBuckets:         nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			promOpts := tt.opts.toPrometheus()
+			assert.Equal(t, tt.wantBucketFactor, promOpts.NativeHistogramBucketFactor)
+			assert.Equal(t, tt.wantMaxBucketNumber, promOpts.NativeHistogramMaxBucketNumber)
+			assert.Equal(t, tt.wantBuckets, promOpts.Buckets)
+		})
+	}
+}
+
+// TestHistogramDualExposition verifies that a histogram created with the default
+// options exposes both classic buckets and native histogram data (dual exposition).
+func TestHistogramDualExposition(t *testing.T) {
+	o := NewHistogram(HistogramOpts{Name: "test"})
+	o.Observe(0.42)
+
+	ms, err := dumpMetrics(o)
+	assert.NoError(t, err)
+	assert.Len(t, ms, 1)
+
+	h := ms[0].Histogram
+	// Classic buckets are still emitted (text/OpenMetrics scrapes).
+	assert.NotEmpty(t, h.GetBucket())
+	// Native histogram data is emitted (protobuf scrapes): a non-zero schema and at
+	// least one positive span indicate sparse buckets are present.
+	assert.Positive(t, h.GetSchema())
+	assert.NotEmpty(t, h.GetPositiveSpan())
+}
+
 func TestHistogramWithLabels(t *testing.T) {
 	o := NewHistogramVecWithLabels(HistogramOpts{
 		Namespace: "cilium",


### PR DESCRIPTION
Mirror Kubernetes [KEP-5808](https://www.kubernetes.dev/resources/keps/5808/) by enabling [Prometheus native histogram](https://prometheus.io/docs/specs/native_histograms/) exposition for every Cilium histogram, using the Kubernetes defaults (bucket factor 1.1, max 160 buckets). Native buckets are added alongside the classic buckets. Scrapers that negotiate protobuf and opt in (with `scrape_native_histograms`) ingest them, while text/OpenMetrics scrapes are unaffected.

See also: https://kubernetes.io/docs/reference/instrumentation/native-histograms/

See the existing very accurate comments for the native histograms parameters:
https://github.com/cilium/cilium/blob/c558832a99c2bd22a02a729f0e48912d12e46e8b/pkg/metrics/metric/histogram.go#L177-L201
https://github.com/cilium/cilium/blob/c558832a99c2bd22a02a729f0e48912d12e46e8b/pkg/metrics/metric/histogram.go#L221-L244