### PR TITLE
gateway-api: introduce granular listener status classification

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -351,7 +351,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		MergedListeners:     mergedListeners,
 	})
 
-	validListener, err := r.setListenerStatus(ctx, gw, httpRouteList, tlsRouteList, grpcRouteList, tcpRouteList, udpRouteList, namespaceLabels)
+	listenersStatus, err := r.setListenerStatus(ctx, gw, httpRouteList, tlsRouteList, grpcRouteList, tcpRouteList, udpRouteList, namespaceLabels)
 	if err != nil {
 		scopedLog.ErrorContext(ctx, "Unable to set listener status", logfields.Error, err)
 		setGatewayAccepted(gw, false, "Unable to set listener status", gatewayv1.GatewayReasonNoResources)
@@ -359,12 +359,17 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
 
-	if !validListener {
+	switch listenersStatus {
+	case ListenersStatusNoneValid:
 		err := fmt.Errorf("No Accepted Listeners for Gateway")
 		scopedLog.ErrorContext(ctx, "No Accepted Listeners for Gateway", logfields.Error, err)
 		setGatewayAccepted(gw, false, "No Accepted Listeners", gatewayv1.GatewayReasonListenersNotValid)
 		setGatewayProgrammed(gw, metav1.ConditionFalse, "No Accepted Listeners", gatewayv1.GatewayReasonListenersNotValid)
 		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+	case ListenersStatusValidWithUnsupportedProtocol:
+		setGatewayAccepted(gw, true, "Gateway has unsupported listeners", gatewayv1.GatewayReasonListenersNotValid)
+	case ListenersStatusSomeInvalid, ListenersStatusAllValid:
+		setGatewayAccepted(gw, true, "Gateway successfully scheduled", gatewayv1.GatewayReasonAccepted)
 	}
 
 	// ListenerSet status is reported independently from the parent Gateway's
@@ -372,7 +377,6 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// Gateway's local configuration, so valid ListenerSets do not make an
 	// otherwise invalid Gateway accepted or programmed.
 	r.setListenerSetStatuses(ctx, gw, attachedListenerSets, httpRouteList, tlsRouteList, grpcRouteList, tcpRouteList, udpRouteList, namespaceLabels)
-	setGatewayAccepted(gw, true, "Gateway successfully scheduled", gatewayv1.GatewayReasonAccepted)
 
 	// Step 3: Translate the listeners into Cilium model
 	cec, svc, eps, err := r.translator.Translate(m)
@@ -1127,16 +1131,26 @@ func (r *gatewayReconciler) setStaticAddressStatus(ctx context.Context, gw *gate
 	return nil
 }
 
-func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1.Gateway, httpRoutes *gatewayv1.HTTPRouteList, tlsRoutes *gatewayv1.TLSRouteList, grpcRoutes *gatewayv1.GRPCRouteList, tcpRoutes *gatewayv1alpha2.TCPRouteList, udpRoutes *gatewayv1alpha2.UDPRouteList, namespaceLabels helpers.NamespaceLabelIndex) (bool, error) {
+type ListenersStatus string
+
+const (
+	ListenersStatusNoneValid                    ListenersStatus = "NoneValid"
+	ListenersStatusValidWithUnsupportedProtocol ListenersStatus = "SomeValidWithUnsupported"
+	ListenersStatusSomeInvalid                  ListenersStatus = "SomeInvalid"
+	ListenersStatusAllValid                     ListenersStatus = "AllValid"
+)
+
+func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1.Gateway, httpRoutes *gatewayv1.HTTPRouteList, tlsRoutes *gatewayv1.TLSRouteList, grpcRoutes *gatewayv1.GRPCRouteList, tcpRoutes *gatewayv1alpha2.TCPRouteList, udpRoutes *gatewayv1alpha2.UDPRouteList, namespaceLabels helpers.NamespaceLabelIndex) (ListenersStatus, error) {
 	grants := &gatewayv1.ReferenceGrantList{}
 	if err := r.Client.List(ctx, grants); err != nil {
-		return false, fmt.Errorf("failed to retrieve reference grants: %w", err)
+		return "", fmt.Errorf("failed to retrieve reference grants: %w", err)
 	}
 
 	conflictedListeners := conflictedGatewayListeners(gw)
 
-	// Keep track of if there is at least one Valid Listener; if not, the Gateway cannot be Accepted.
-	oneValidListener := false
+	validListeners := 0
+	unsupportedProtocolListeners := 0
+	invalidListeners := 0
 	for _, l := range gw.Spec.Listeners {
 		isValid := true
 		var invalidMessages []string
@@ -1156,20 +1170,23 @@ func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1
 			grants:         grants.Items,
 			ownerRef:       client.ObjectKeyFromObject(gw).String(),
 		})
+		if !res.isValid && res.invalidReason == gatewayv1.ListenerReasonUnsupportedProtocol {
+			unsupportedProtocolListeners++
+		}
 		isValid = isValid && res.isValid
 		invalidMessages = append(invalidMessages, res.invalidMessages...)
 		conds = merge(conds, res.conds...)
 		supportedKinds := res.supportedKinds
 
 		if !isValid {
+			invalidListeners++
 			conds = merge(conds,
 				listenerAcceptedCondition(gw.GetGeneration(), false, res.invalidReason, "Listener not valid. "+strings.Join(invalidMessages, " ")),
 				listenerProgrammedCondition(gw.GetGeneration(), false, gatewayv1.ListenerReasonPending, "Address not ready yet"))
 			// If the Listener is not valid, then no kinds are supported
 			// supportedKinds = []gatewayv1.RouteGroupKind{}
 		} else {
-			// There's at least one Accepted listener, so the Gateway can also be Accepted.
-			oneValidListener = true
+			validListeners++
 			// If ResolvedRefs is not already present, add a successful one.
 			if !helpers.IsConditionPresent(conds, string(gatewayv1.ListenerConditionResolvedRefs)) {
 				conds = merge(conds, metav1.Condition{
@@ -1224,7 +1241,17 @@ func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1
 		}
 	}
 	gw.Status.Listeners = newListenersStatus
-	return oneValidListener, nil
+
+	switch {
+	case validListeners == 0:
+		return ListenersStatusNoneValid, nil
+	case unsupportedProtocolListeners > 0:
+		return ListenersStatusValidWithUnsupportedProtocol, nil
+	case invalidListeners > 0:
+		return ListenersStatusSomeInvalid, nil
+	default:
+		return ListenersStatusAllValid, nil
+	}
 }
 
 type listenerConflict struct {
@@ -1405,6 +1432,7 @@ func (r *gatewayReconciler) validateListener(ctx context.Context, l gatewayv1.Li
 	allSupported := getSupportedRouteKinds(l.Protocol)
 	if allSupported == nil {
 		res.invalidMessages = append(res.invalidMessages, "Unsupported Listener Protocol.")
+		res.invalidReason = gatewayv1.ListenerReasonUnsupportedProtocol
 		res.isValid = false
 	}
 

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -868,6 +868,184 @@ func Test_gatewayReconciler_ensureEnvoyConfig_deletesStaleCEC(t *testing.T) {
 	})
 }
 
+func Test_gatewayReconciler_setListenerStatus(t *testing.T) {
+	tests := []struct {
+		name          string
+		listeners     []gatewayv1.Listener
+		wantStatus    ListenersStatus
+		wantListeners map[gatewayv1.SectionName]metav1.Condition
+	}{
+		{
+			name: "all listeners valid",
+			listeners: []gatewayv1.Listener{
+				{
+					Name:     "http",
+					Port:     80,
+					Protocol: gatewayv1.HTTPProtocolType,
+				},
+				{
+					Name:     "https",
+					Port:     443,
+					Protocol: gatewayv1.HTTPSProtocolType,
+					TLS: &gatewayv1.ListenerTLSConfig{
+						Mode: ptr.To(gatewayv1.TLSModeTerminate),
+					},
+				},
+			},
+			wantStatus: ListenersStatusAllValid,
+			wantListeners: map[gatewayv1.SectionName]metav1.Condition{
+				"http": {
+					Type:   string(gatewayv1.ListenerConditionAccepted),
+					Status: metav1.ConditionTrue,
+					Reason: string(gatewayv1.ListenerReasonAccepted),
+				},
+				"https": {
+					Type:   string(gatewayv1.ListenerConditionAccepted),
+					Status: metav1.ConditionTrue,
+					Reason: string(gatewayv1.ListenerReasonAccepted),
+				},
+			},
+		},
+		{
+			name: "only unsupported protocol",
+			listeners: []gatewayv1.Listener{{
+				Name:     "invalid",
+				Port:     1111,
+				Protocol: gatewayv1.ProtocolType("INVALID"),
+			}},
+			wantStatus: ListenersStatusNoneValid,
+			wantListeners: map[gatewayv1.SectionName]metav1.Condition{
+				"invalid": {
+					Type:   string(gatewayv1.ListenerConditionAccepted),
+					Status: metav1.ConditionFalse,
+					Reason: string(gatewayv1.ListenerReasonUnsupportedProtocol),
+				},
+			},
+		},
+		{
+			name: "valid listener with unsupported protocol listener",
+			listeners: []gatewayv1.Listener{
+				{
+					Name:     "http",
+					Port:     80,
+					Protocol: gatewayv1.HTTPProtocolType,
+				},
+				{
+					Name:     "invalid",
+					Port:     1111,
+					Protocol: gatewayv1.ProtocolType("INVALID"),
+				},
+			},
+			wantStatus: ListenersStatusValidWithUnsupportedProtocol,
+			wantListeners: map[gatewayv1.SectionName]metav1.Condition{
+				"http": {
+					Type:   string(gatewayv1.ListenerConditionAccepted),
+					Status: metav1.ConditionTrue,
+					Reason: string(gatewayv1.ListenerReasonAccepted),
+				},
+				"invalid": {
+					Type:   string(gatewayv1.ListenerConditionAccepted),
+					Status: metav1.ConditionFalse,
+					Reason: string(gatewayv1.ListenerReasonUnsupportedProtocol),
+				},
+			},
+		},
+		{
+			name: "valid listener with invalid route kind listener",
+			listeners: []gatewayv1.Listener{
+				{
+					Name:     "http",
+					Port:     80,
+					Protocol: gatewayv1.HTTPProtocolType,
+				},
+				{
+					Name:     "invalid-route-kind",
+					Port:     81,
+					Protocol: gatewayv1.HTTPProtocolType,
+					AllowedRoutes: &gatewayv1.AllowedRoutes{
+						Kinds: []gatewayv1.RouteGroupKind{{
+							Kind: "InvalidRouteKind",
+						}},
+					},
+				},
+			},
+			wantStatus: ListenersStatusSomeInvalid,
+			wantListeners: map[gatewayv1.SectionName]metav1.Condition{
+				"http": {
+					Type:   string(gatewayv1.ListenerConditionAccepted),
+					Status: metav1.ConditionTrue,
+					Reason: string(gatewayv1.ListenerReasonAccepted),
+				},
+				"invalid-route-kind": {
+					Type:   string(gatewayv1.ListenerConditionAccepted),
+					Status: metav1.ConditionFalse,
+					Reason: string(gatewayv1.ListenerReasonInvalid),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gw := &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "gateway",
+					Namespace:  "gateway-conformance-infra",
+					Generation: 1,
+				},
+				Spec: gatewayv1.GatewaySpec{
+					GatewayClassName: "cilium",
+					Listeners:        tt.listeners,
+				},
+			}
+
+			r := &gatewayReconciler{
+				Client: fake.NewClientBuilder().
+					WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+					Build(),
+			}
+
+			gotStatus, err := r.setListenerStatus(
+				t.Context(),
+				gw,
+				&gatewayv1.HTTPRouteList{},
+				&gatewayv1.TLSRouteList{},
+				&gatewayv1.GRPCRouteList{},
+				&gatewayv1alpha2.TCPRouteList{},
+				&gatewayv1alpha2.UDPRouteList{},
+				helpers.NewNamespaceLabelIndex(nil),
+			)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantStatus, gotStatus)
+
+			for name, wantCond := range tt.wantListeners {
+				gotCond := listenerStatusCondition(t, gw.Status.Listeners, name, string(gatewayv1.ListenerConditionAccepted))
+				require.Equal(t, wantCond.Status, gotCond.Status)
+				require.Equal(t, wantCond.Reason, gotCond.Reason)
+			}
+		})
+	}
+}
+
+func listenerStatusCondition(t *testing.T, listeners []gatewayv1.ListenerStatus, name gatewayv1.SectionName, conditionType string) metav1.Condition {
+	t.Helper()
+
+	for _, listener := range listeners {
+		if listener.Name != name {
+			continue
+		}
+		for _, cond := range listener.Conditions {
+			if cond.Type == conditionType {
+				return cond
+			}
+		}
+		require.Failf(t, "missing listener condition", "listener %q condition %q not found", name, conditionType)
+	}
+
+	require.Failf(t, "missing listener status", "listener %q not found", name)
+	return metav1.Condition{}
+}
+
 func filterHTTPRoute(hrList *gatewayv1.HTTPRouteList, gatewayName string, namespace string) []gatewayv1.HTTPRoute {
 	var filterList []gatewayv1.HTTPRoute
 	for _, hr := range hrList.Items {


### PR DESCRIPTION
Replace binary listener validation checks with a dedicated status enum. This enables more precise reporting of a Gateway's state.

Gateways with at least one valid listener and an unsupported listener protocol now report GatewayReasonListenersNotValid instead of being reported as successfully scheduled.

Refs:

- https://github.com/kubernetes-sigs/gateway-api/blob/v1.6.0/apis/v1/gateway_types.go#L484-L488
- https://github.com/kubernetes-sigs/gateway-api/blob/v1.6.0/conformance/tests/gateway-invalid-listeners-unsupported-protocol.go#L36

```release-note
gateway-api: Gateway status now reports unsupported listener protocols more precisely.
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
