### PR TITLE
helm: Remove unused core Endpoints RBAC from roles

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/clusterrole.yaml
@@ -36,7 +36,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - endpoints
   - namespaces
   - services
   verbs:

--- a/install/kubernetes/cilium/templates/hubble-ui/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/clusterrole.yaml
@@ -19,7 +19,6 @@ rules:
   - ""
   resources:
   - componentstatuses
-  - endpoints
   - namespaces
   - nodes
   - pods


### PR DESCRIPTION
The agent, operator and preflight ClusterRoles already dropped the deprecated `core/v1` Endpoints permission once the codebase migrated to EndpointSlice. The clustermesh-apiserver (which exports via EndpointSlice) and the hubble-ui backend (which only watches namespaces) retained a vestigial `endpoints` grant. Remove it so Cilium no longer references the deprecated v1 Endpoints resource at all.

Followup to #46472

Related: #39105