### PR TITLE
helm: gate build-config host-firewall bypass on hostFirewall.enabled

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -493,6 +493,10 @@ spec:
         {{- if hasKey .Values.k8s "apiServerURLs" }}
         - "--k8s-api-server-urls={{ .Values.k8s.apiServerURLs }}"
         {{- end }}
+        {{- /* Gate the bypass on hostFirewall.enabled to match the agent (which
+               gates on its DaemonConfig); build-config has no DaemonConfig. Avoids
+               the egress-mark/IPVS upgrade hang in cilium/cilium#44464. */}}
+        - "--enable-k8s-host-firewall-bypass={{ .Values.hostFirewall.enabled }}"
         env:
         - name: K8S_NODE_NAME
           valueFrom:

--- a/pkg/k8s/hostfirewallbypass/bypass_test.go
+++ b/pkg/k8s/hostfirewallbypass/bypass_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package hostfirewallbypass
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// TestNewK8sHostFirewallBypass locks down the decision matrix for whether the
+// SO_MARK host-firewall bypass is installed on the k8s client dialer.
+//
+// The agent gates the bypass on host firewall via its DaemonConfig. The
+// build-config init container, however, has no DaemonConfig (it is nil), so the
+// only signal it has is the enable-k8s-host-firewall-bypass flag, which the Helm
+// chart sets from hostFirewall.enabled. The bug in cilium/cilium#44464 was that
+// the bypass was applied unconditionally in build-config (nil DaemonConfig +
+// default-true flag), marking apiserver connections with the egress-proxy fwmark
+// and breaking upgrades with kube-proxy in IPVS mode.
+//
+// The critical invariant the Helm fix relies on: when the flag is false the
+// bypass MUST NOT be installed, regardless of DaemonConfig.
+func TestNewK8sHostFirewallBypass(t *testing.T) {
+	tests := []struct {
+		name        string
+		daemonCfg   *option.DaemonConfig
+		flagEnabled bool
+		wantBypass  bool
+	}{
+		{
+			// build-config with the Helm fix on a cluster without host firewall:
+			// this is the cilium/cilium#44464 scenario that must NOT bypass.
+			name:        "no daemon config, flag disabled",
+			daemonCfg:   nil,
+			flagEnabled: false,
+			wantBypass:  false,
+		},
+		{
+			// build-config with the Helm fix on a host-firewall cluster: bypass is
+			// needed to traverse the previous agent's host firewall during upgrade.
+			name:        "no daemon config, flag enabled",
+			daemonCfg:   nil,
+			flagEnabled: true,
+			wantBypass:  true,
+		},
+		{
+			// agent: host firewall disabled wins even if the flag is on.
+			name:        "daemon config host firewall disabled, flag enabled",
+			daemonCfg:   &option.DaemonConfig{EnableHostFirewall: false},
+			flagEnabled: true,
+			wantBypass:  false,
+		},
+		{
+			// agent: host firewall enabled and flag enabled -> bypass.
+			name:        "daemon config host firewall enabled, flag enabled",
+			daemonCfg:   &option.DaemonConfig{EnableHostFirewall: true},
+			flagEnabled: true,
+			wantBypass:  true,
+		},
+		{
+			// agent: explicitly disabling the flag must win over host firewall.
+			name:        "daemon config host firewall enabled, flag disabled",
+			daemonCfg:   &option.DaemonConfig{EnableHostFirewall: true},
+			flagEnabled: false,
+			wantBypass:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewK8sHostFirewallBypass(Params{
+				DaemonConfig: tt.daemonCfg,
+				LocalConfig:  config{EnableK8sHostFirewallBypass: tt.flagEnabled},
+			})
+			require.Equal(t, tt.wantBypass, got != nil)
+		})
+	}
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy](https://github.com/cilium/community/blob/main/AI-POLICY.md).
- [x] Thanks for contributing!

> **AI assistance disclosure (AIL:4).** This PR was prepared with substantial AI
> assistance: an AI agent (Claude) performed the root-cause investigation, wrote
> the Helm change and the unit test, ran the validation, and drafted this
> description, under my direction. I reviewed the analysis, code, and test, chose
> the approach (gating on `hostFirewall.enabled` to mirror the agent, rather than
> a Go default change or a datapath fix), and the change was validated end-to-end
> on a kind cluster that reproduces the issue. I take personal responsibility for
> this contribution.

<!-- Description of change -->

## Summary

When upgrading Cilium 1.18.x → 1.19.x on a cluster running **kube-proxy in IPVS
mode**, `cilium-agent` pods get stuck in `Init:0/6`. The `config` init container
(`cilium-dbg build-config`) cannot reach the apiserver and fails with
`dial tcp <ClusterIP>:443: i/o timeout` (#44464).

**Root cause:** the k8s host-firewall bypass (added in 1.19) sets the
egress-proxy `SO_MARK` on apiserver connections so they skip the host firewall.
The agent only installs the bypass when the host firewall is enabled, gating on
its `DaemonConfig`. The `build-config` init container, however, runs a hive that
provides **no `DaemonConfig`**, so the guard in `NewK8sHostFirewallBypass` is
skipped and — because the flag defaults to `true` — the bypass is applied
unconditionally there, even on clusters that don't use the host firewall.

On an upgrade, the node still carries the previous agent's datapath. Its ip
rules match the egress fwmark and route the connection to the apiserver
ClusterIP so that it egresses with the **ClusterIP as its source address**; the
SYN gets no routable reply and the connection times out. A fresh install (no
prior datapath) and `iptables`/`nftables` kube-proxy modes are unaffected, which
matches every report on the issue.

This gates the `build-config` init container's bypass on `hostFirewall.enabled`,
so it makes the same decision the agent does: when the host firewall is disabled
there is nothing to bypass, the egress mark is not set, and the upgrade succeeds.

## Scope / known limitation

This resolves the reported case, where the host firewall is **disabled** (all
reporters run without it). When the host firewall is **enabled**, the bypass is
still required to traverse the previous agent's firewall during the upgrade, so
the mark is intentionally still set and the same mark/IPVS interaction remains.
That is a deeper, separate problem; note that IPVS mode is being deprecated in
kube-proxy (kubernetes/enhancements#5495). For that reason this references the
issue with `Relates:` rather than `Fixes:`, to avoid auto-closing #44464 while
the host-firewall-enabled case is still open.

## Testing

Reproduced and verified on a 3-node kind cluster with kube-proxy in IPVS mode:

- Install 1.18.7, upgrade to stock 1.19.4 → worker `cilium-agent` pods stuck
  `Init:0/6` with `dial tcp 10.96.0.1:443: i/o timeout` (control-plane pod
  unaffected).
- Upgrade 1.18.7 → 1.19.4 **with this change** (`hostFirewall.enabled=false`):
  the init container is invoked with `--enable-k8s-host-firewall-bypass=false`,
  connects to the apiserver in ~8ms, rollout completes (3/3 Running).
- Fresh 1.19.4 install with this change: 3/3 Running (no regression).
- `hostFirewall.enabled=true` renders `--enable-k8s-host-firewall-bypass=true`,
  preserving the existing behaviour where the bypass is required.
- Added a unit test (`pkg/k8s/hostfirewallbypass/bypass_test.go`) covering the
  bypass decision matrix, including the build-config (nil `DaemonConfig`) case.

Relates: #44464

```release-note
Fix cilium-agent getting stuck in init (build-config unable to reach the
apiserver) when upgrading with kube-proxy in IPVS mode and the host firewall
disabled, by gating the k8s host-firewall bypass on hostFirewall.enabled in the
build-config init container.
```
