### PR TITLE
Always propagate proxy policy incremental updates when EnvoyConfig is enabled

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1150,7 +1150,11 @@ func (e *Endpoint) applyPolicyMapChangesLocked(regenContext *regenerationContext
 		// updateEnvoy when policy has changed (due to the possible removed redirects), if
 		// the endpoint has Envoy redirects, or is an Ingress endpoint, which needs to
 		// enforce also the full L3/4 policy.
-		if hasNewPolicy || hasEnvoyRedirect || e.isIngress {
+		//
+		// When EnvoyConfig is enabled, policy filters will be applied on listeners that might
+		// not be referenced in policy rules(eg. L7 load balancing). Always update proxy policy
+		// in such cases to propagate incremental updates.
+		if option.Config.EnableEnvoyConfig || hasNewPolicy || hasEnvoyRedirect || e.isIngress {
 			e.getLogger().Debug("applyPolicyMapChanges: Updating Envoy NetworkPolicy")
 			stats.proxyPolicyCalculation.Start()
 			proxyErr, rf, ff := e.proxy.UpdateNetworkPolicy(context.Background(), e, e.desiredPolicy, proxyWaitGroup)

--- a/pkg/endpointmanager/manager_proxy_test.go
+++ b/pkg/endpointmanager/manager_proxy_test.go
@@ -195,7 +195,13 @@ func (p *recordingEndpointProxy) IsSDPEnabled() bool {
 	return false
 }
 
-func newUpdatePolicyMapsTestRepo(t *testing.T) (*policy.Repository, identitymanager.IDManager, compute.PolicyRecomputer) {
+func (p *recordingEndpointProxy) updateCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.updatesSeen
+}
+
+func newUpdatePolicyMapsTestRepo(t *testing.T, withL7Rules bool) (*policy.Repository, identitymanager.IDManager, compute.PolicyRecomputer) {
 	t.Helper()
 
 	logger := hivetest.Logger(t)
@@ -216,21 +222,24 @@ func newUpdatePolicyMapsTestRepo(t *testing.T) (*policy.Repository, identitymana
 		policy.SetPolicyEnabled(oldPolicyMode)
 	})
 
+	portRule := api.PortRule{
+		Ports: []api.PortProtocol{{
+			Port:     "80",
+			Protocol: api.ProtoTCP,
+		}},
+	}
+	if withL7Rules {
+		portRule.Rules = &api.L7Rules{
+			HTTP: []api.PortRuleHTTP{{
+				Path:   "/",
+				Method: "GET",
+			}},
+		}
+	}
 	repo.MustAddList(api.Rules{{
 		EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("bar")),
 		Ingress: []api.IngressRule{{
-			ToPorts: []api.PortRule{{
-				Ports: []api.PortProtocol{{
-					Port:     "80",
-					Protocol: api.ProtoTCP,
-				}},
-				Rules: &api.L7Rules{
-					HTTP: []api.PortRuleHTTP{{
-						Path:   "/",
-						Method: "GET",
-					}},
-				},
-			}},
+			ToPorts: []api.PortRule{portRule},
 		}},
 	}})
 
@@ -280,7 +289,7 @@ func newUpdatePolicyMapsTestEndpoint(t *testing.T, mgr *endpointManager, repo po
 func TestUpdatePolicyMapsFinalizesDeferredNetworkPolicyCallbacksAfterSuccessfulWait(t *testing.T) {
 	logger := hivetest.Logger(t)
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
-	repo, idmgr, fetcher := newUpdatePolicyMapsTestRepo(t)
+	repo, idmgr, fetcher := newUpdatePolicyMapsTestRepo(t, true)
 	proxy := newRecordingEndpointProxy()
 
 	ep1 := newUpdatePolicyMapsTestEndpoint(t, mgr, repo, idmgr, fetcher, proxy, 101, netip.MustParseAddr("10.0.0.1"))
@@ -311,7 +320,7 @@ func TestUpdatePolicyMapsFinalizesDeferredNetworkPolicyCallbacksAfterSuccessfulW
 func TestUpdatePolicyMapsRevertsDeferredNetworkPolicyCallbacksAfterProxyWaitFailure(t *testing.T) {
 	logger := hivetest.Logger(t)
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
-	repo, idmgr, fetcher := newUpdatePolicyMapsTestRepo(t)
+	repo, idmgr, fetcher := newUpdatePolicyMapsTestRepo(t, true)
 	proxy := newRecordingEndpointProxy()
 
 	ep1 := newUpdatePolicyMapsTestEndpoint(t, mgr, repo, idmgr, fetcher, proxy, 201, netip.MustParseAddr("10.0.1.1"))
@@ -340,7 +349,7 @@ func TestUpdatePolicyMapsRevertsDeferredNetworkPolicyCallbacksAfterProxyWaitFail
 func TestUpdatePolicyMapsDoesNotDeferCallbacksForSynchronousApplyFailure(t *testing.T) {
 	logger := hivetest.Logger(t)
 	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
-	repo, idmgr, fetcher := newUpdatePolicyMapsTestRepo(t)
+	repo, idmgr, fetcher := newUpdatePolicyMapsTestRepo(t, true)
 	proxy := newRecordingEndpointProxy()
 
 	ep1 := newUpdatePolicyMapsTestEndpoint(t, mgr, repo, idmgr, fetcher, proxy, 301, netip.MustParseAddr("10.0.2.1"))
@@ -366,4 +375,54 @@ func TestUpdatePolicyMapsDoesNotDeferCallbacksForSynchronousApplyFailure(t *test
 	require.Equal(t, 0, proxy.finalizeCount(ep1.GetID()))
 	require.Equal(t, 0, proxy.revertCount(ep2.GetID()))
 	require.Equal(t, 1, proxy.finalizeCount(ep2.GetID()))
+}
+
+// TestIncrementalProxyPolicyUpdateNoL7Rule verifies that when an endpoint has no L7 rules,
+// incremental policy updates are sent to Envoy only when EnvoyConfig is enabled.
+func TestIncrementalProxyPolicyUpdateNoL7Rule(t *testing.T) {
+	logger := hivetest.Logger(t)
+	repo, idmgr, fetcher := newUpdatePolicyMapsTestRepo(t, false)
+
+	setEnvoyConfigOption := func(t *testing.T, value bool) {
+		oldValue := option.Config.EnableEnvoyConfig
+		option.Config.EnableEnvoyConfig = value
+		t.Cleanup(func() { option.Config.EnableEnvoyConfig = oldValue })
+	}
+
+	t.Run("EnvoyConfigDisabled", func(t *testing.T) {
+		setEnvoyConfigOption(t, false)
+		mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
+		proxy := newRecordingEndpointProxy()
+
+		_ = newUpdatePolicyMapsTestEndpoint(t, mgr, repo, idmgr, fetcher, proxy, 401, netip.MustParseAddr("10.0.3.1"))
+
+		// Enable tracking so we can detect if the proxy is unexpectedly called.
+		proxy.expectUpdates(1)
+		require.NoError(t, mgr.UpdatePolicyMaps(t.Context()))
+
+		// With EnvoyConfig disabled and no L7 rules, no update should be sent to the proxy.
+		require.Equal(t, 0, proxy.updateCount())
+	})
+
+	t.Run("EnvoyConfigEnabled", func(t *testing.T) {
+		setEnvoyConfigOption(t, true)
+		mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
+		proxy := newRecordingEndpointProxy()
+
+		ep := newUpdatePolicyMapsTestEndpoint(t, mgr, repo, idmgr, fetcher, proxy, 402, netip.MustParseAddr("10.0.3.2"))
+		proxy.expectUpdates(1)
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- mgr.UpdatePolicyMaps(t.Context())
+		}()
+
+		// With EnvoyConfig enabled, the proxy must receive the incremental update even
+		// though there are no L7 rules.
+		proxy.waitForUpdates(t)
+		proxy.completeUpdate(t, ep.GetID(), nil)
+
+		require.NoError(t, <-errCh)
+		require.Equal(t, 1, proxy.updateCount())
+	})
 }


### PR DESCRIPTION
See commit message for details.

### Repro script for the bug

```nushell
#!/usr/bin/env nu

let cilium_root = ($env.HOME | path join "ws/cilium/cilium/main")

do -i { ^make -C $cilium_root kind-down }
make -C $cilium_root kind kind-image

let helm_config = '
l7Proxy: true
envoyConfig:
  enabled: true

envoy:
  debug:
    enabled: true
    admin:
      enabled: true

loadBalancer:
  l7:
    backend: envoy
'

$helm_config | save -f values.yaml
(
  cilium install --wait
  --chart-directory=$"($cilium_root)/install/kubernetes/cilium"
  --helm-values=$"($cilium_root)/contrib/testing/kind-common.yaml"
  --helm-values=$"($cilium_root)/contrib/testing/kind-values.yaml"
  --helm-values=values.yaml
)

^cilium status --wait
^cilium hubble enable --ui

let server_ns = "server"
let server_config = $'
apiVersion: apps/v1
kind: Deployment
metadata:
  name: fortio-server
  namespace: ($server_ns)
spec:
  replicas: 1
  selector:
    matchLabels:
      app: fortio-server
  template:
    metadata:
      labels:
        app: fortio-server
    spec:
      nodeName: kind-control-plane
      containers:
      - name: fortio
        image: fortio/fortio:latest
        args: ["server"]
        ports:
        - containerPort: 8079
          name: grpc
---
apiVersion: v1
kind: Service
metadata:
  name: fortio-server
  namespace: ($server_ns)
  annotations:
    service.cilium.io/lb-l7: enabled
spec:
  selector:
    app: fortio-server
  ports:
    - protocol: TCP
      port: 8079
      targetPort: 8079
      name: grpc
  type: ClusterIP
'

kubectl create namespace $server_ns
$server_config | ^kubectl apply -f -

let client_config = $'
apiVersion: v1
kind: Pod
metadata:
  name: netshoot
  labels:
    app: netshoot
spec:
  nodeName: kind-worker
  terminationGracePeriodSeconds: 1
  containers:
  - name: netshoot
    image: nicolaka/netshoot
    command: ["tail", "-f", "/dev/null"]
'

$client_config | ^kubectl apply -f -

let client_cnp = $'
apiVersion: cilium.io/v2
kind: CiliumNetworkPolicy
metadata:
  name: client-policy
spec:
  endpointSelector:
    matchLabels:
      app: netshoot
  egress:
  - toEndpoints:
    - matchLabels:
        io.kubernetes.pod.namespace: ($server_ns)
    toPorts:
    - ports:
      - port: "8079"
        protocol: TCP
  - toEndpoints:
    - matchLabels:
        "k8s:io.kubernetes.pod.namespace": kube-system
        "k8s:k8s-app": kube-dns
    toPorts:
    - ports:
      - port: "53"
        protocol: ANY
      rules:
        dns:
        - matchPattern: "*"
'
$client_cnp | ^kubectl apply -f -

def validate [] {
  # Changing namespace labels will generate new identity for server pod
  ^kubectl label namespace $server_ns $"id-label=(random int)" --overwrite
  ^kubectl exec netshoot -- fortio load -a -grpc -ping -payload "01234567890" -c 1 -t 3s -qps 1 fortio-server.server.svc.cluster.local:8079
}

sleep 30sec
loop { 
  validate
  sleep 5sec
}
```

```release-note
Fix incorrect policy denials for traffic to L7 load balanced services when remote identity changes
```