### PR TITLE
chore: Add metrics deregistration for disconnected cluster 

### DIFF
--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -180,6 +180,7 @@ func (cm *ClusterMesh) NewRemoteCluster(name string, status common.StatusFunc) c
 		log:                      cm.conf.Logger.With(logfields.ClusterName, name),
 		featureMetrics:           cm.FeatureMetrics,
 		featureMetricMaxClusters: fmt.Sprintf("%d", cm.conf.ClusterInfo.MaxConnectedClusters),
+		metrics:                  cm.conf.Metrics,
 	}
 	rc.remoteNodes = cm.conf.StoreFactory.NewWatchStore(
 		name,

--- a/pkg/clustermesh/common/clustermesh.go
+++ b/pkg/clustermesh/common/clustermesh.go
@@ -230,6 +230,7 @@ func (cm *clusterMesh) remove(name string) {
 		// Run onRemove in a separate go routing as potentially slow, to avoid
 		// blocking the processing of further events in the meanwhile.
 		cluster.onRemove(cm.rctx)
+		cm.conf.Metrics.DeRegister(name)
 
 		cm.mutex.Lock()
 		path := cm.tombstones[name]

--- a/pkg/clustermesh/common/clustermesh_test.go
+++ b/pkg/clustermesh/common/clustermesh_test.go
@@ -99,6 +99,7 @@ func TestClusterMesh(t *testing.T) {
 	// by a thread at a time only.
 	var clusters []*fakeRemoteCluster
 
+	commonMetrics := MetricsProvider(metrics.SubsystemClusterMesh)()
 	cm := NewClusterMesh(Configuration{
 		Logger:              hivetest.Logger(t),
 		Config:              Config{ClusterMeshConfig: baseDir},
@@ -115,7 +116,7 @@ func TestClusterMesh(t *testing.T) {
 			clusters = append(clusters, rc)
 			return rc
 		},
-		Metrics: MetricsProvider(metrics.SubsystemClusterMesh)(),
+		Metrics: commonMetrics,
 	})
 
 	assertForEachRemoteCluster := func(t *testing.T, expected uint) {
@@ -200,6 +201,56 @@ func TestClusterMesh(t *testing.T) {
 	// ForEachRemoteCluster should correctly propagate errors
 	err := errors.New("error")
 	require.ErrorIs(t, cm.ForEachRemoteCluster(func(rc RemoteCluster) error { return err }), err)
+}
+
+func TestClusterMeshMetricsDeregistration(t *testing.T) {
+	client := kvstore.NewInMemoryClient(statedb.New(), "__all__")
+
+	baseDir := t.TempDir()
+	path := func(name string) string { return filepath.Join(baseDir, name) }
+	data := fmt.Sprintf("endpoints:\n- %s\n", kvstore.EtcdDummyAddress())
+
+	capabilities := types.CiliumClusterConfigCapabilities{Cached: true, MaxConnectedClusters: 511}
+	cfg := types.CiliumClusterConfig{ID: uint32(1), Capabilities: capabilities}
+	require.NoError(t, clustercfg.Set(context.Background(), "cluster1", cfg, client))
+
+	var removed lock.Map[string, bool]
+	is := func(state *lock.Map[string, bool], name string) bool {
+		st, _ := state.Load(name)
+		return st
+	}
+
+	commonMetrics := MetricsProvider(metrics.SubsystemClusterMesh)()
+	cm := NewClusterMesh(Configuration{
+		Logger:              hivetest.Logger(t),
+		Config:              Config{ClusterMeshConfig: baseDir},
+		ClusterInfo:         types.ClusterInfo{ID: 255, Name: "local"},
+		RemoteClientFactory: fakeRemoteClusterFactory(client),
+		NewRemoteCluster: func(name string, sf StatusFunc) RemoteCluster {
+			return &fakeRemoteCluster{
+				onRemove: func(context.Context) { removed.Store(name, true) },
+			}
+		},
+		Metrics: commonMetrics,
+	})
+
+	writeFile(t, path("cluster1"), data)
+	hivetest.Lifecycle(t).Append(cm)
+
+	commonMetrics.ReadinessStatus.WithLabelValues("cluster1").Set(1)
+	commonMetrics.LastFailureTimestamp.WithLabelValues("cluster1").Set(1234)
+	commonMetrics.TotalFailures.WithLabelValues("cluster1").Set(1)
+	commonMetrics.TotalCacheRevocations.WithLabelValues("cluster1").Set(1)
+
+	require.NoError(t, os.Remove(path("cluster1")))
+	require.EventuallyWithT(t, func(c *assert.CollectT) { assert.True(c, is(&removed, "cluster1")) }, timeout, tick, "Cluster1 has not been removed")
+
+	cm.(*clusterMesh).wg.Wait()
+
+	assert.False(t, commonMetrics.ReadinessStatus.DeleteLabelValues("cluster1"))
+	assert.False(t, commonMetrics.LastFailureTimestamp.DeleteLabelValues("cluster1"))
+	assert.False(t, commonMetrics.TotalFailures.DeleteLabelValues("cluster1"))
+	assert.False(t, commonMetrics.TotalCacheRevocations.DeleteLabelValues("cluster1"))
 }
 
 func TestClusterMeshMultipleAddRemove(t *testing.T) {

--- a/pkg/clustermesh/common/metrics.go
+++ b/pkg/clustermesh/common/metrics.go
@@ -4,6 +4,8 @@
 package common
 
 import (
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/metrics/metric"
 )
@@ -12,13 +14,13 @@ type Metrics struct {
 	// TotalRemoteClusters tracks the total number of remote clusters.
 	TotalRemoteClusters metric.Gauge
 	// LastFailureTimestamp tracks the last failure timestamp.
-	LastFailureTimestamp metric.Vec[metric.Gauge]
+	LastFailureTimestamp metric.DeletableVec[metric.Gauge]
 	// ReadinessStatus tracks the readiness status of remote clusters.
-	ReadinessStatus metric.Vec[metric.Gauge]
+	ReadinessStatus metric.DeletableVec[metric.Gauge]
 	// TotalFailure tracks the number of failures when connecting to remote clusters.
-	TotalFailures metric.Vec[metric.Gauge]
+	TotalFailures metric.DeletableVec[metric.Gauge]
 	// TotalCacheRevocations tracks the number of cache revocations for a remote cluster.
-	TotalCacheRevocations metric.Vec[metric.Gauge]
+	TotalCacheRevocations metric.DeletableVec[metric.Gauge]
 }
 
 func MetricsProvider(subsystem string) func() Metrics {
@@ -60,4 +62,11 @@ func MetricsProvider(subsystem string) func() Metrics {
 			}, []string{metrics.LabelTargetCluster}),
 		}
 	}
+}
+
+func (m *Metrics) DeRegister(targetCluster string) {
+	m.LastFailureTimestamp.DeletePartialMatch(prometheus.Labels{metrics.LabelTargetCluster: targetCluster})
+	m.ReadinessStatus.DeletePartialMatch(prometheus.Labels{metrics.LabelTargetCluster: targetCluster})
+	m.TotalFailures.DeletePartialMatch(prometheus.Labels{metrics.LabelTargetCluster: targetCluster})
+	m.TotalCacheRevocations.DeletePartialMatch(prometheus.Labels{metrics.LabelTargetCluster: targetCluster})
 }

--- a/pkg/clustermesh/endpointslice/cell.go
+++ b/pkg/clustermesh/endpointslice/cell.go
@@ -6,6 +6,8 @@ package endpointslice
 import (
 	"log/slog"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/cilium/hive/cell"
 
 	"github.com/cilium/cilium/pkg/clustermesh/observer"
@@ -36,7 +38,7 @@ var Cell = cell.Module(
 )
 
 type Metrics struct {
-	TotalEndpointSlices metric.Vec[metric.Gauge]
+	TotalEndpointSlices metric.DeletableVec[metric.Gauge]
 }
 
 func MetricsProvider(namespace string) func() Metrics {
@@ -50,4 +52,8 @@ func MetricsProvider(namespace string) func() Metrics {
 			}, []string{metrics.LabelTargetCluster}),
 		}
 	}
+}
+
+func (m *Metrics) DeRegister(targetCluster string) {
+	m.TotalEndpointSlices.DeletePartialMatch(prometheus.Labels{metrics.LabelTargetCluster: targetCluster})
 }

--- a/pkg/clustermesh/endpointslice/observer.go
+++ b/pkg/clustermesh/endpointslice/observer.go
@@ -23,6 +23,7 @@ func newFactory(params params) observer.Factory {
 			name:          cluster,
 			serviceModeV2: params.ServiceModeV2,
 			onSync:        onSync,
+			metrics:       params.Metrics,
 		}
 
 		obs.store = params.StoreFactory.NewWatchStore(
@@ -49,6 +50,7 @@ type endpointSliceObserver struct {
 	store         store.WatchStore
 	onSync        func()
 	enabled       atomic.Bool
+	metrics       Metrics
 }
 
 func (o *endpointSliceObserver) Name() observer.Name { return Name }
@@ -92,6 +94,10 @@ func (o *endpointSliceObserver) Register(mgr store.WatchStoreManager, backend kv
 
 func (o *endpointSliceObserver) Drain()  { o.store.Drain() }
 func (o *endpointSliceObserver) Revoke() { o.store.Drain() }
+
+func (o *endpointSliceObserver) DeRegister() {
+	o.metrics.DeRegister(o.name)
+}
 
 type dummyObserver struct{}
 

--- a/pkg/clustermesh/metrics.go
+++ b/pkg/clustermesh/metrics.go
@@ -4,19 +4,21 @@
 package clustermesh
 
 import (
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/metrics/metric"
 )
 
 type Metrics struct {
 	// TotalNodes tracks the number of total nodes per remote cluster.
-	TotalNodes metric.Vec[metric.Gauge]
+	TotalNodes metric.DeletableVec[metric.Gauge]
 
 	// TotalServices tracks the number of total services per remote cluster.
-	TotalServices metric.Vec[metric.Gauge]
+	TotalServices metric.DeletableVec[metric.Gauge]
 
 	// TotalEndpoints tracks the number of total IPs per remote cluster.
-	TotalEndpoints metric.Vec[metric.Gauge]
+	TotalEndpoints metric.DeletableVec[metric.Gauge]
 }
 
 func NewMetrics() Metrics {
@@ -42,4 +44,10 @@ func NewMetrics() Metrics {
 			Help:      "The total number of endpoints in the remote cluster",
 		}, []string{metrics.LabelTargetCluster}),
 	}
+}
+
+func (m *Metrics) DeRegister(targetCluster string) {
+	m.TotalNodes.DeletePartialMatch(prometheus.Labels{metrics.LabelTargetCluster: targetCluster})
+	m.TotalServices.DeletePartialMatch(prometheus.Labels{metrics.LabelTargetCluster: targetCluster})
+	m.TotalEndpoints.DeletePartialMatch(prometheus.Labels{metrics.LabelTargetCluster: targetCluster})
 }

--- a/pkg/clustermesh/observer/observer.go
+++ b/pkg/clustermesh/observer/observer.go
@@ -34,6 +34,9 @@ type Observer interface {
 	// Revoke possibly emits a deletion event for all previously observed entries,
 	// if connectivity to the target remote cluster is lost.
 	Revoke()
+
+	// DeRegister cleans up any metrics associated with the observer.
+	DeRegister()
 }
 
 // Status summarizes the status of an observer.

--- a/pkg/clustermesh/operator/remote_cluster_test.go
+++ b/pkg/clustermesh/operator/remote_cluster_test.go
@@ -259,6 +259,7 @@ type fakeCMObserver struct {
 func (f *fakeCMObserver) Name() observer.Name { return f.name }
 func (f *fakeCMObserver) Revoke()             { f.revoked.Store(true) }
 func (f *fakeCMObserver) Drain()              { f.drained.Store(true) }
+func (f *fakeCMObserver) DeRegister()         {}
 
 func (f *fakeCMObserver) Register(mgr store.WatchStoreManager, backend kvstore.BackendOperations, cfg types.CiliumClusterConfig) {
 	f.registered.Store(true)

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -93,6 +93,8 @@ type remoteCluster struct {
 	// featureMetrics will track which features are enabled with in clustermesh.
 	featureMetrics ClusterMeshMetrics
 
+	metrics Metrics
+
 	// featureMetricMaxClusters contains the max clusters defined for this
 	// clustermesh config.
 	featureMetricMaxClusters string
@@ -192,7 +194,7 @@ func (rc *remoteCluster) RevokeCache(ctx context.Context) {
 	}
 }
 
-func (rc *remoteCluster) Remove(context.Context) {
+func (rc *remoteCluster) Remove(ctx context.Context) {
 	// Draining shall occur only when the configuration for the remote cluster
 	// is removed, and not in case the agent is shutting down, otherwise we
 	// would break existing connections on restart.
@@ -204,7 +206,11 @@ func (rc *remoteCluster) Remove(context.Context) {
 
 	for _, obs := range rc.observers {
 		obs.Drain()
+		obs.DeRegister()
 	}
+
+	rc.metrics.DeRegister(rc.name)
+	rc.storeFactory.DeRegister(rc.name)
 
 	rc.usedIDs.ReleaseClusterID(rc.clusterID)
 }

--- a/pkg/clustermesh/remote_cluster_test.go
+++ b/pkg/clustermesh/remote_cluster_test.go
@@ -431,6 +431,7 @@ type fakeCMObserver struct {
 func (f *fakeCMObserver) Name() observer.Name { return f.name }
 func (f *fakeCMObserver) Revoke()             { f.revoked.Store(true) }
 func (f *fakeCMObserver) Drain()              { f.drained.Store(true) }
+func (f *fakeCMObserver) DeRegister()         {}
 
 func (f *fakeCMObserver) Register(mgr store.WatchStoreManager, backend kvstore.BackendOperations, cfg types.CiliumClusterConfig) {
 	f.registered.Store(true)

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -1578,6 +1578,10 @@ func (e *etcdClient) Close() {
 	// Wait until all child goroutines spawned by the lease managers have terminated.
 	e.leaseManager.Wait()
 	e.lockLeaseManager.Wait()
+
+	if e.limiter != nil {
+		e.limiter.DeRegister()
+	}
 }
 
 // ListAndWatch implements the BackendOperations.ListAndWatch using etcd

--- a/pkg/kvstore/store/cell.go
+++ b/pkg/kvstore/store/cell.go
@@ -24,6 +24,7 @@ type Factory interface {
 	NewSyncStore(clusterName string, backend SyncStoreBackend, prefix string, opts ...WSSOpt) SyncStore
 	NewWatchStore(clusterName string, keyCreator KeyCreator, observer Observer, opts ...RWSOpt) WatchStore
 	NewWatchStoreManager(backend WatchStoreBackend, clusterName string) WatchStoreManager
+	DeRegister(clusterName string)
 }
 
 type factoryImpl struct {
@@ -41,6 +42,10 @@ func (w *factoryImpl) NewWatchStore(clusterName string, keyCreator KeyCreator, o
 
 func (w *factoryImpl) NewWatchStoreManager(backend WatchStoreBackend, clusterName string) WatchStoreManager {
 	return newWatchStoreManagerSync(w.logger, backend, clusterName, w)
+}
+
+func (w *factoryImpl) DeRegister(clusterName string) {
+	w.metrics.DeRegister(clusterName)
 }
 
 func NewFactory(logger *slog.Logger, storeMetrics *Metrics) Factory {

--- a/pkg/kvstore/store/metrics.go
+++ b/pkg/kvstore/store/metrics.go
@@ -4,14 +4,16 @@
 package store
 
 import (
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/metrics/metric"
 )
 
 type Metrics struct {
-	KVStoreSyncQueueSize        metric.Vec[metric.Gauge]
-	KVStoreSyncErrors           metric.Vec[metric.Counter]
-	KVStoreInitialSyncCompleted metric.Vec[metric.Gauge]
+	KVStoreSyncQueueSize        metric.DeletableVec[metric.Gauge]
+	KVStoreSyncErrors           metric.DeletableVec[metric.Counter]
+	KVStoreInitialSyncCompleted metric.DeletableVec[metric.Gauge]
 }
 
 func MetricsProvider() *Metrics {
@@ -35,4 +37,10 @@ func MetricsProvider() *Metrics {
 			Help:      "Whether the initial synchronization from/to the kvstore has completed",
 		}, []string{metrics.LabelScope, metrics.LabelSourceCluster, metrics.LabelAction}),
 	}
+}
+
+func (m *Metrics) DeRegister(sourceCluster string) {
+	m.KVStoreSyncQueueSize.DeletePartialMatch(prometheus.Labels{metrics.LabelSourceCluster: sourceCluster})
+	m.KVStoreSyncErrors.DeletePartialMatch(prometheus.Labels{metrics.LabelSourceCluster: sourceCluster})
+	m.KVStoreInitialSyncCompleted.DeletePartialMatch(prometheus.Labels{metrics.LabelSourceCluster: sourceCluster})
 }

--- a/pkg/metrics/interfaces.go
+++ b/pkg/metrics/interfaces.go
@@ -24,14 +24,15 @@ var (
 	NoOpMetric    prometheus.Metric    = &mockMetric{}
 	NoOpCollector prometheus.Collector = &collector{}
 
-	NoOpCounter           metricpkg.Counter                       = &counter{NoOpMetric, NoOpCollector}
-	NoOpCounterVec        metricpkg.Vec[metricpkg.Counter]        = &counterVec{NoOpCollector}
-	NoOpObserver          metricpkg.Observer                      = &observer{}
-	NoOpHistogram         metricpkg.Histogram                     = &histogram{NoOpCollector}
-	NoOpObserverVec       metricpkg.Vec[metricpkg.Observer]       = &observerVec{NoOpCollector}
-	NoOpGauge             metricpkg.Gauge                         = &gauge{NoOpMetric, NoOpCollector}
-	NoOpGaugeVec          metricpkg.Vec[metricpkg.Gauge]          = &gaugeVec{NoOpCollector}
-	NoOpGaugeDeletableVec metricpkg.DeletableVec[metricpkg.Gauge] = &gaugeDeletableVec{gaugeVec{NoOpCollector}}
+	NoOpCounter             metricpkg.Counter                         = &counter{NoOpMetric, NoOpCollector}
+	NoOpCounterVec          metricpkg.Vec[metricpkg.Counter]          = &counterVec{NoOpCollector}
+	NoOpObserver            metricpkg.Observer                        = &observer{}
+	NoOpHistogram           metricpkg.Histogram                       = &histogram{NoOpCollector}
+	NoOpObserverVec         metricpkg.Vec[metricpkg.Observer]         = &observerVec{NoOpCollector}
+	NoOpCounterDeletableVec metricpkg.DeletableVec[metricpkg.Counter] = &counterDeletableVec{counterVec{NoOpCollector}}
+	NoOpGauge               metricpkg.Gauge                           = &gauge{NoOpMetric, NoOpCollector}
+	NoOpGaugeVec            metricpkg.Vec[metricpkg.Gauge]            = &gaugeVec{NoOpCollector}
+	NoOpGaugeDeletableVec   metricpkg.DeletableVec[metricpkg.Gauge]   = &gaugeDeletableVec{gaugeVec{NoOpCollector}}
 )
 
 // Metric
@@ -86,6 +87,24 @@ func (cv *counterVec) GetMetricWithLabelValues(...string) (metricpkg.Counter, er
 func (cv *counterVec) IsEnabled() bool      { return false }
 func (cv *counterVec) SetEnabled(bool)      {}
 func (cv *counterVec) Opts() metricpkg.Opts { return metricpkg.Opts{} }
+
+type counterDeletableVec struct {
+	counterVec
+}
+
+func (*counterDeletableVec) Delete(ll prometheus.Labels) bool {
+	return false
+}
+
+func (*counterDeletableVec) DeleteLabelValues(lvs ...string) bool {
+	return false
+}
+
+func (*counterDeletableVec) DeletePartialMatch(labels prometheus.Labels) int {
+	return 0
+}
+
+func (*counterDeletableVec) Reset() {}
 
 // Observer
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -539,27 +539,27 @@ var (
 
 	// APILimiterWaitDuration is the gauge of the current mean, min, and
 	// max wait duration
-	APILimiterWaitDuration = NoOpGaugeVec
+	APILimiterWaitDuration = NoOpGaugeDeletableVec
 
 	// APILimiterProcessingDuration is the gauge of the mean and estimated
 	// processing duration
-	APILimiterProcessingDuration = NoOpGaugeVec
+	APILimiterProcessingDuration = NoOpGaugeDeletableVec
 
 	// APILimiterRequestsInFlight is the gauge of the current and max
 	// requests in flight
-	APILimiterRequestsInFlight = NoOpGaugeVec
+	APILimiterRequestsInFlight = NoOpGaugeDeletableVec
 
 	// APILimiterRateLimit is the gauge of the current rate limiting
 	// configuration including limit and burst
-	APILimiterRateLimit = NoOpGaugeVec
+	APILimiterRateLimit = NoOpGaugeDeletableVec
 
 	// APILimiterAdjustmentFactor is the gauge representing the latest
 	// adjustment factor that was applied
-	APILimiterAdjustmentFactor = NoOpGaugeVec
+	APILimiterAdjustmentFactor = NoOpGaugeDeletableVec
 
 	// APILimiterProcessedRequests is the counter of the number of
 	// processed (successful and failed) requests
-	APILimiterProcessedRequests = NoOpCounterVec
+	APILimiterProcessedRequests = NoOpCounterDeletableVec
 
 	// WorkQueueDepth is the depth of the workqueue
 	//
@@ -701,12 +701,12 @@ type LegacyMetrics struct {
 	BPFMapCapacity                          metric.Vec[metric.Gauge]
 	VersionMetric                           metric.Vec[metric.Gauge]
 	APILimiterWaitHistoryDuration           metric.Vec[metric.Observer]
-	APILimiterWaitDuration                  metric.Vec[metric.Gauge]
-	APILimiterProcessingDuration            metric.Vec[metric.Gauge]
-	APILimiterRequestsInFlight              metric.Vec[metric.Gauge]
-	APILimiterRateLimit                     metric.Vec[metric.Gauge]
-	APILimiterAdjustmentFactor              metric.Vec[metric.Gauge]
-	APILimiterProcessedRequests             metric.Vec[metric.Counter]
+	APILimiterWaitDuration                  metric.DeletableVec[metric.Gauge]
+	APILimiterProcessingDuration            metric.DeletableVec[metric.Gauge]
+	APILimiterRequestsInFlight              metric.DeletableVec[metric.Gauge]
+	APILimiterRateLimit                     metric.DeletableVec[metric.Gauge]
+	APILimiterAdjustmentFactor              metric.DeletableVec[metric.Gauge]
+	APILimiterProcessedRequests             metric.DeletableVec[metric.Counter]
 	WorkQueueDepth                          metric.Vec[metric.Gauge]
 	WorkQueueAddsTotal                      metric.Vec[metric.Counter]
 	WorkQueueLatency                        metric.Vec[metric.Observer]

--- a/pkg/rate/api_limiter.go
+++ b/pkg/rate/api_limiter.go
@@ -557,6 +557,13 @@ func (l *APILimiter) requestFinished(r *limitedRequest, err error, code int) {
 	}
 }
 
+// DeRegister cleans up any metrics associated with this APILimiter.
+func (l *APILimiter) DeRegister() {
+	if l.metrics != nil {
+		l.metrics.DeRegister(l.name)
+	}
+}
+
 // calcMeanDuration returns the mean duration in seconds
 func calcMeanDuration(durations []time.Duration) float64 {
 	total := 0.0
@@ -846,6 +853,9 @@ type MetricsValues struct {
 type MetricsObserver interface {
 	// ProcessedRequest is invoked after invocation of an API call
 	ProcessedRequest(name string, values MetricsValues)
+
+	// DeRegister cleans up any metrics associated with the given name
+	DeRegister(name string)
 }
 
 // NewAPILimiterSet creates a new APILimiterSet based on a set of rate limiting
@@ -888,6 +898,14 @@ func NewAPILimiterSet(logger *slog.Logger, config map[string]string, defaults ma
 // Limiter returns the APILimiter with a given name
 func (s *APILimiterSet) Limiter(name string) *APILimiter {
 	return s.limiters[name]
+}
+
+// DeRegister cleans up any metrics associated with the APILimiter of the given name.
+func (s *APILimiterSet) DeRegister(name string) {
+	if l, ok := s.limiters[name]; ok {
+		l.DeRegister()
+		delete(s.limiters, name)
+	}
 }
 
 type dummyRequest struct{}

--- a/pkg/rate/api_limiter_test.go
+++ b/pkg/rate/api_limiter_test.go
@@ -67,6 +67,10 @@ func (m *mockMetrics) ProcessedRequest(name string, v MetricsValues) {
 	me.ReturnCode = v.ReturnCode
 }
 
+func (m *mockMetrics) DeRegister(name string) {
+	delete(m.metrics, name)
+}
+
 func TestNewAPILimiter(t *testing.T) {
 	a := NewAPILimiter(hivetest.Logger(t), "foo", APILimiterParameters{}, nil)
 
@@ -837,4 +841,21 @@ func TestSetRateBurst(t *testing.T) {
 
 	a.SetRateBurst(100)
 	require.Equal(t, 100, a.limiter.Burst())
+}
+
+func TestDeRegister(t *testing.T) {
+	m := newMockMetrics()
+	a := NewAPILimiter(hivetest.Logger(t), "foo", APILimiterParameters{}, m)
+	m.metrics["foo"] = &metrics{}
+
+	a.DeRegister()
+	require.Empty(t, m.metrics)
+
+	set, err := NewAPILimiterSet(hivetest.Logger(t), map[string]string{"bar": "rate-limit:5/s"}, nil, m)
+	require.NoError(t, err)
+	m.metrics["bar"] = &metrics{}
+
+	set.DeRegister("bar")
+	require.Empty(t, m.metrics)
+	require.Nil(t, set.Limiter("bar"))
 }

--- a/pkg/rate/metrics/metrics.go
+++ b/pkg/rate/metrics/metrics.go
@@ -6,6 +6,8 @@ package metrics
 import (
 	"strconv"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/rate"
 )
@@ -38,4 +40,13 @@ func (a *apiRateLimitingMetrics) ProcessedRequest(name string, v rate.MetricsVal
 	}
 
 	metrics.APILimiterProcessedRequests.WithLabelValues(name, v.Outcome, strconv.Itoa(v.ReturnCode)).Inc()
+}
+
+func (a *apiRateLimitingMetrics) DeRegister(name string) {
+	metrics.APILimiterAdjustmentFactor.DeletePartialMatch(prometheus.Labels{"api_call": name})
+	metrics.APILimiterProcessedRequests.DeletePartialMatch(prometheus.Labels{"api_call": name})
+	metrics.APILimiterProcessingDuration.DeletePartialMatch(prometheus.Labels{"api_call": name})
+	metrics.APILimiterRateLimit.DeletePartialMatch(prometheus.Labels{"api_call": name})
+	metrics.APILimiterRequestsInFlight.DeletePartialMatch(prometheus.Labels{"api_call": name})
+	metrics.APILimiterWaitDuration.DeletePartialMatch(prometheus.Labels{"api_call": name})
 }

--- a/pkg/rate/metrics/metrics_test.go
+++ b/pkg/rate/metrics/metrics_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/rate"
+)
+
+func TestAPILimiterMetricsDeregistration(t *testing.T) {
+	metrics.NewLegacyMetrics()
+
+	obs := APILimiterObserver()
+	apiName := "test-api-call"
+
+	obs.ProcessedRequest(apiName, rate.MetricsValues{
+		Outcome:                     "success",
+		ReturnCode:                  200,
+		MeanProcessingDuration:      0.1,
+		EstimatedProcessingDuration: 0.2,
+		MeanWaitDuration:            0.05,
+		MaxWaitDuration:             time.Second,
+		MinWaitDuration:             time.Millisecond,
+		CurrentRequestsInFlight:     2,
+		ParallelRequests:            10,
+		Limit:                       5.0,
+		Burst:                       10,
+		AdjustmentFactor:            1.0,
+	})
+
+	// Verify that the metrics are registered and exist.
+	assert.True(t, metrics.APILimiterProcessingDuration.DeleteLabelValues(apiName, "mean"))
+	assert.True(t, metrics.APILimiterProcessingDuration.DeleteLabelValues(apiName, "estimated"))
+
+	// Re-emit metrics so they are registered again before calling DeRegister.
+	obs.ProcessedRequest(apiName, rate.MetricsValues{
+		Outcome:    "success",
+		ReturnCode: 200,
+	})
+
+	// Call DeRegister on the observer for the given API call name.
+	obs.DeRegister(apiName)
+
+	// Verify all associated metrics series for the API call name were deleted.
+	assert.False(t, metrics.APILimiterProcessingDuration.DeleteLabelValues(apiName, "mean"))
+	assert.False(t, metrics.APILimiterProcessingDuration.DeleteLabelValues(apiName, "estimated"))
+	assert.False(t, metrics.APILimiterWaitDuration.DeleteLabelValues(apiName, "mean"))
+	assert.False(t, metrics.APILimiterWaitDuration.DeleteLabelValues(apiName, "max"))
+	assert.False(t, metrics.APILimiterWaitDuration.DeleteLabelValues(apiName, "min"))
+	assert.False(t, metrics.APILimiterRequestsInFlight.DeleteLabelValues(apiName, "in-flight"))
+	assert.False(t, metrics.APILimiterRequestsInFlight.DeleteLabelValues(apiName, "limit"))
+	assert.False(t, metrics.APILimiterRateLimit.DeleteLabelValues(apiName, "limit"))
+	assert.False(t, metrics.APILimiterRateLimit.DeleteLabelValues(apiName, "burst"))
+	assert.False(t, metrics.APILimiterAdjustmentFactor.DeleteLabelValues(apiName))
+	assert.False(t, metrics.APILimiterProcessedRequests.DeleteLabelValues(apiName, "success", "200"))
+}


### PR DESCRIPTION
Fixes: #40049

Currently, when a cluster gets disconnected from the ClusterMesh, its corresponding metrics are not cleaned up from the `cilium-agent`. There are three categories of affected metrics:

1. `remote_cluster_*` metrics: ClusterMesh-related metrics exported by the agent.
2. KVStore metrics: The agent reports `kvstore` sync metrics, which contain the `source_cluster` label.
3. APILimiter: When `etcd` uses the `APILimiter`, it specifies the `api_call` label as `etcd-<cluster-name>`.

To address this, this PR does the following for each of the subsystems above:

1. Converts metrics that use the disconnected cluster as a label into a `DeletableVec`.
2. Implements a `Deregister` method that deletes the metrics based on the label value.
3. Calls the `Deregister` method:
   - For `remote_cluster` and `kvstore` metrics when the cluster disconnects in `Remove()`.
   - For `etcd` when the etcd session is closed in `Close()`.
4. Adds a new ClusterMesh test, `TestClusterMeshMetricsDeregistration`, which triggers a disconnect event to verify that metrics are successfully deregistered.

### Verification Steps

1. Create the clusters using `kind-clustermesh`.
2. Verify that the metrics are being successfully reported by running:
   ```bash
   docker exec clustermesh2-worker curl -s http://localhost:9962/metrics | grep clustermesh1
   ```
3. Disconnect the ClusterMesh.
4. Re-verify the metrics using the same command to confirm they have been successfully cleared.

Note: The `cilium-operator` and `clustermesh-apiserver` metrics don't have any reference to remote clusters.

This PR was prepared with AIL:3.