### PR TITLE
envoy: cleanup use_nphds in ads code

### DIFF
--- a/pkg/ciliumenvoyconfig/cec_resource_parser_test.go
+++ b/pkg/ciliumenvoyconfig/cec_resource_parser_test.go
@@ -2105,7 +2105,6 @@ func TestGetBPFMetadataListenerFilterADSMode(t *testing.T) {
 		require.NoError(t, err)
 		meta, ok := msg.(*cilium.BpfMetadata)
 		require.True(t, ok)
-		assert.False(t, meta.UseNphds)
 		assert.Nil(t, meta.CiliumConfigSource) // not set for the legacy SotW mode
 	})
 
@@ -2119,7 +2118,6 @@ func TestGetBPFMetadataListenerFilterADSMode(t *testing.T) {
 		require.NoError(t, err)
 		meta, ok := msg.(*cilium.BpfMetadata)
 		require.True(t, ok)
-		assert.False(t, meta.UseNphds)
 		require.NotNil(t, meta.CiliumConfigSource)
 		assert.NotNil(t, meta.CiliumConfigSource.GetAds(), "CiliumConfigSource should use ADS aggregated source")
 		assert.Equal(t, envoy_config_core.ApiVersion_V3, meta.CiliumConfigSource.ResourceApiVersion)

--- a/pkg/envoy/model_test.go
+++ b/pkg/envoy/model_test.go
@@ -25,7 +25,6 @@ func TestGetListenerFilterADSMode(t *testing.T) {
 		require.NoError(t, err)
 		meta, ok := msg.(*cilium.BpfMetadata)
 		require.True(t, ok)
-		assert.False(t, meta.UseNphds)
 		assert.Nil(t, meta.CiliumConfigSource) // not set for the legacy SotW mode
 	})
 
@@ -39,7 +38,6 @@ func TestGetListenerFilterADSMode(t *testing.T) {
 		require.NoError(t, err)
 		meta, ok := msg.(*cilium.BpfMetadata)
 		require.True(t, ok)
-		assert.False(t, meta.UseNphds)
 		require.NotNil(t, meta.CiliumConfigSource)
 		assert.NotNil(t, meta.CiliumConfigSource.GetAds(), "CiliumConfigSource should use ADS aggregated source")
 		assert.Equal(t, envoy_config_core.ApiVersion_V3, meta.CiliumConfigSource.ResourceApiVersion)


### PR DESCRIPTION
Addressing 1 review comments from past [PR](https://github.com/cilium/cilium/pull/43887): [Getting rid of use_nphds validation](https://github.com/cilium/cilium/pull/43887#discussion_r3491876462)

Fixes: #43887