### PR TITLE
gha: let auto-approve match on re-runs

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -13,8 +13,8 @@ jobs:
     permissions: {}
     if: ${{
          github.event.pull_request.user.login == 'cilium-renovate[bot]' &&
-         (github.triggering_actor == 'cilium-renovate[bot]' ||
-          github.triggering_actor == 'auto-committer[bot]')
+         (github.actor == 'cilium-renovate[bot]' ||
+          github.actor == 'auto-committer[bot]')
         }}
     steps:
     - name: Debug
@@ -41,12 +41,12 @@ jobs:
     - name: Approve PR
       # Approve the PR if all the following conditions are true:
       # - the PR was created by renovate bot and
-      # - the PR review was requested by renovate bot or auto-committer[bot] and
-      # - the requested reviewer was the trusted 'ciliumbot'
+      # - the run was originally triggered by renovate bot or auto-committer[bot]
+      #   (github.actor, not github.triggering_actor, so manual re-runs match)
       if: ${{
            github.event.pull_request.user.login == 'cilium-renovate[bot]' &&
-           (github.triggering_actor == 'cilium-renovate[bot]' ||
-            github.triggering_actor == 'auto-committer[bot]')
+           (github.actor == 'cilium-renovate[bot]' ||
+            github.actor == 'auto-committer[bot]')
           }}
       env:
         TOKEN: ${{ secrets.AUTO_APPROVE_TOKEN }}


### PR DESCRIPTION
The Approve Renovate PR workflow gates on github.triggering_actor being cilium-renovate[bot] or auto-committer[bot]. That value only holds for the original run: when a failed run is re-run manually, github.triggering_actor becomes the human who clicked "Re-run", so the gate no longer matches and the Approve job is skipped. This makes re-running a broken auto-approve run (for example after the ciliumbot token was fixed) a no-op.

Switch both gates to github.actor, which preserves the original triggerer across re-runs. The workflow stays hard-gated on the PR author being cilium-renovate[bot], so this only ever approves Renovate-authored dependency PRs.

This commit was prepared with AIL:3.