### PR TITLE
renovate: re-enable cilium/ebpf dependency bump

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -392,8 +392,6 @@
         // dependency manually.
         "/github.com/onsi/ginkgo/",
         "/github.com/onsi/gomega/*/",
-        // We can't update it, see https://github.com/cilium/cilium/issues/44063 for more info
-        "github.com/cilium/ebpf",
         // The version upgrade from 9.0.4 to 9.1.0 breaks our CI
         "sphinx"
       ]


### PR DESCRIPTION
This was removed while dealing with cilium/cilium#44063, but can now be re-enabled.

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
