### PR TITLE
operator/ipam: recover nodes dropped from the instance cache during resync

### DIFF
--- a/operator/pkg/ipam/nodemanager/node.go
+++ b/operator/pkg/ipam/nodemanager/node.go
@@ -96,6 +96,12 @@ type Node struct {
 	// instanceStoppedRunning records when an instance was most recently set to not running
 	instanceStoppedRunning time.Time
 
+	// instanceSyncRetriggered is true when the per-instance sync has been
+	// re-triggered because the instance was missing from the instance
+	// cache. It is reset by the next successful recalculation, or by a
+	// transient failure of the re-triggered sync.
+	instanceSyncRetriggered bool
+
 	// ipv4Alloc represents IPv4-specific allocation attributes for this node
 	ipv4Alloc ipAllocAttrs
 
@@ -647,6 +653,9 @@ func (n *Node) UpdatedResource(resource *v2.CiliumNode) bool {
 
 	n.ops.UpdatedNode(resource)
 
+	// The error is not acted upon here: the caller (NodeManager.Upsert)
+	// holds the NodeManager mutex. Recovery of an instance missing from
+	// the cache is handled by the periodic resync, see resyncNode.
 	n.recalculate(context.Background())
 	allocationNeeded := n.allocationNeeded()
 	releaseNeeded := n.releaseNeeded()
@@ -665,6 +674,8 @@ func (n *Node) resourceAttached() (attached bool) {
 	return
 }
 
+// recalculate the number of needed and excess IPs of the node based on the
+// current state of the instance cache.
 func (n *Node) recalculate(ctx context.Context) {
 	// Skip any recalculation if the CiliumNode resource does not exist yet
 	if !n.resourceAttached() {
@@ -688,6 +699,9 @@ func (n *Node) recalculate(ctx context.Context) {
 		n.stats.IPv4.ExcessIPs = 0
 		return
 	}
+
+	// The instance is back in the cache, re-arm the recovery sync.
+	n.instanceSyncRetriggered = false
 
 	n.ipv4Alloc.available = a
 	if stats.AssignedStaticIP != "" {
@@ -933,6 +947,15 @@ type ReleaseAction struct {
 
 // ErrLimitsNotFound signals lack of limits for given instance type.
 var ErrLimitsNotFound = errors.New("Limits not found")
+
+// ErrInstanceNotFound signals that an external instances API authoritatively
+// reported that an instance no longer exists.
+var ErrInstanceNotFound = errors.New("instance not found")
+
+// instanceNotFoundSyncReason is the trigger reason used when the instance
+// sync is re-triggered to recover an instance missing from the cache. A
+// failed sync run carrying this reason re-arms the re-trigger.
+const instanceNotFoundSyncReason = "instance-not-found-recovery"
 
 // maintenanceAction represents the resources available for allocation for a
 // particular ciliumNode. If an existing interface has IP allocation capacity
@@ -1321,6 +1344,32 @@ func (n *Node) maintainIPPool(ctx context.Context) (instanceMutated bool, err er
 	return n.handleIPAllocation(ctx, a)
 }
 
+// retriggerInstanceSync re-triggers the node's per-instance sync to recover
+// an instance that was dropped from the instance cache by a full resync. To
+// avoid a retry loop for instances that are legitimately gone, the sync is
+// re-triggered at most once until re-armed, either by a recalculation that
+// sees the instance again or by a transient failure of the sync itself.
+// Callers must ensure the instances API is stable. Holding the NodeManager
+// mutex is fine since triggering only signals the sync.
+func (n *Node) retriggerInstanceSync() {
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
+
+	if n.instanceSyncRetriggered || n.instanceSync == nil {
+		return
+	}
+	n.instanceSyncRetriggered = true
+	n.instanceSync.TriggerWithReason(instanceNotFoundSyncReason)
+}
+
+// reArmInstanceSync re-arms the recovery sync after a transient failure of
+// the re-triggered instance sync, so a later recalculation may retry it.
+func (n *Node) reArmInstanceSync() {
+	n.mutex.Lock()
+	n.instanceSyncRetriggered = false
+	n.mutex.Unlock()
+}
+
 func (n *Node) isInstanceRunning() (isRunning bool) {
 	n.mutex.RLock()
 	isRunning = n.instanceRunning
@@ -1368,7 +1417,11 @@ func (n *Node) MaintainIPPool(ctx context.Context) error {
 		n.requireResync()
 	}
 	n.poolMaintenanceComplete()
+
 	n.recalculate(ctx)
+	if n.manager.InstancesAPIIsReady() && !n.manager.instancesAPI.HasInstance(n.InstanceID()) {
+		n.retriggerInstanceSync()
+	}
 	if instanceMutated || err != nil {
 		n.instanceSync.Trigger()
 	}

--- a/operator/pkg/ipam/nodemanager/node_manager.go
+++ b/operator/pkg/ipam/nodemanager/node_manager.go
@@ -7,9 +7,11 @@ package nodemanager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/netip"
+	"slices"
 	"sort"
 
 	"golang.org/x/sync/semaphore"
@@ -140,7 +142,9 @@ type AllocationImplementation interface {
 	Resync(ctx context.Context) (time.Time, error)
 
 	// InstanceSync is called to sync the state of the specified instance with
-	// external APIs or systems.
+	// external APIs or systems. Implementations must return an error wrapping
+	// ErrInstanceNotFound if the external API authoritatively reports that the
+	// instance no longer exists.
 	InstanceSync(ctx context.Context, instanceID string) (time.Time, error)
 
 	// HasInstance returns whether the instance is in instances
@@ -395,6 +399,12 @@ func (n *NodeManager) Upsert(resource *v2.CiliumNode) {
 				syncTime, err := node.manager.instancesAPI.InstanceSync(ctx, resource.InstanceID())
 				if err != nil {
 					node.logger.Load().Warn("Unable to sync instance", logfields.Error, err)
+					// A transient recovery failure must re-arm the node's one-shot re-trigger.
+					// An authoritative instance-not-found error must not re-arm the node's
+					// one-shot re-trigger.
+					if slices.Contains(reasons, instanceNotFoundSyncReason) && !errors.Is(err, ErrInstanceNotFound) {
+						node.reArmInstanceSync()
+					}
 					return
 				}
 				node.manager.Resync(ctx, syncTime)
@@ -506,9 +516,15 @@ type ipResyncStats struct {
 	nodeCapacity        int
 }
 
-func (n *NodeManager) resyncNode(ctx context.Context, node *Node, stats *resyncStats, syncTime time.Time) {
+func (n *NodeManager) resyncNode(ctx context.Context, node *Node, stats *resyncStats, syncTime time.Time, instancesAPIReady bool) {
 	node.updateLastResync(syncTime)
 	node.recalculate(ctx)
+	if instancesAPIReady && !n.instancesAPI.HasInstance(node.InstanceID()) {
+		// Recover a node dropped from the instance cache. The caller
+		// holds the NodeManager mutex, so the instances API readiness
+		// is passed in rather than queried here.
+		node.retriggerInstanceSync()
+	}
 	allocationNeeded := node.allocationNeeded()
 	releaseNeeded := node.releaseNeeded()
 	if allocationNeeded || releaseNeeded {
@@ -569,7 +585,11 @@ func (n *NodeManager) Resync(ctx context.Context, syncTime time.Time) {
 			continue
 		}
 		go func(node *Node, stats *resyncStats) {
-			n.resyncNode(ctx, node, stats, syncTime)
+			// n.mutex is held for the whole duration of Resync, so
+			// n.stableInstancesAPI cannot change concurrently. The
+			// workers must not acquire the mutex themselves as that
+			// would deadlock with the semaphore acquisition below.
+			n.resyncNode(ctx, node, stats, syncTime, n.stableInstancesAPI)
 			sem.Release(1)
 		}(node, &stats)
 	}

--- a/operator/pkg/ipam/nodemanager/node_manager_test.go
+++ b/operator/pkg/ipam/nodemanager/node_manager_test.go
@@ -5,11 +5,13 @@ package nodemanager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/netip"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/testutils"
 	testipam "github.com/cilium/cilium/pkg/testutils/ipam"
+	"github.com/cilium/cilium/pkg/trigger"
 )
 
 var (
@@ -44,14 +47,29 @@ type allocationImplementationMock struct {
 	poolSize     int
 	allocatedIPs int
 	ipGenerator  int
+
+	// nodeResyncErr, when set before a node is created, pre-populates
+	// resyncErr on the node operations returned by CreateNode.
+	nodeResyncErr error
+
+	// instanceSyncErr, when set, is returned by InstanceSync to simulate a
+	// transient API failure.
+	instanceSyncErr error
+
+	// instanceSyncCalls counts the InstanceSync invocations.
+	instanceSyncCalls int
+
+	// hasInstance is returned by HasInstance to simulate an instance being
+	// present in or dropped from the instance cache.
+	hasInstance bool
 }
 
 func newAllocationImplementationMock() *allocationImplementationMock {
-	return &allocationImplementationMock{poolSize: 2048}
+	return &allocationImplementationMock{poolSize: 2048, hasInstance: true}
 }
 
 func (a *allocationImplementationMock) CreateNode(obj *v2.CiliumNode, node *Node) NodeOperations {
-	return &nodeOperationsMock{allocator: a}
+	return &nodeOperationsMock{allocator: a, resyncErr: a.nodeResyncErr}
 }
 
 func (a *allocationImplementationMock) GetPoolQuota() ipamTypes.PoolQuotaMap {
@@ -67,11 +85,38 @@ func (a *allocationImplementationMock) Resync(ctx context.Context) (time.Time, e
 }
 
 func (a *allocationImplementationMock) InstanceSync(ctx context.Context, instanceID string) (time.Time, error) {
+	a.mutex.Lock()
+	a.instanceSyncCalls++
+	err := a.instanceSyncErr
+	a.mutex.Unlock()
+	if err != nil {
+		return time.Time{}, err
+	}
 	return time.Now(), nil
 }
 
+func (a *allocationImplementationMock) setInstanceSyncError(err error) {
+	a.mutex.Lock()
+	a.instanceSyncErr = err
+	a.mutex.Unlock()
+}
+
+func (a *allocationImplementationMock) instanceSyncCallCount() int {
+	a.mutex.RLock()
+	defer a.mutex.RUnlock()
+	return a.instanceSyncCalls
+}
+
 func (a *allocationImplementationMock) HasInstance(instanceID string) bool {
-	return true
+	a.mutex.RLock()
+	defer a.mutex.RUnlock()
+	return a.hasInstance
+}
+
+func (a *allocationImplementationMock) setHasInstance(hasInstance bool) {
+	a.mutex.Lock()
+	a.hasInstance = hasInstance
+	a.mutex.Unlock()
 }
 
 func (a *allocationImplementationMock) DeleteInstance(instanceID string) {
@@ -85,6 +130,16 @@ type nodeOperationsMock struct {
 	allocatedIPs []string
 
 	attachedCIDRs []netip.Prefix
+
+	// resyncErr, when set, is returned by ResyncInterfacesAndIPs to simulate
+	// an instance that is no longer present in the operator's cache.
+	resyncErr error
+}
+
+func (n *nodeOperationsMock) setResyncError(err error) {
+	n.mutex.Lock()
+	n.resyncErr = err
+	n.mutex.Unlock()
 }
 
 func (n *nodeOperationsMock) GetUsedIPWithPrefixes() int {
@@ -106,10 +161,13 @@ func (n *nodeOperationsMock) ResyncInterfacesAndIPs(ctx context.Context, scopedL
 	var stats ipamStats.InterfaceStats
 	available := ipamTypes.AllocationMap{}
 	n.mutex.RLock()
+	defer n.mutex.RUnlock()
+	if n.resyncErr != nil {
+		return nil, stats, n.resyncErr
+	}
 	for _, ip := range n.allocatedIPs {
 		available[ip] = ipamTypes.AllocationIP{}
 	}
-	n.mutex.RUnlock()
 	return available, stats, nil
 }
 
@@ -231,6 +289,225 @@ func TestGetNodeNames(t *testing.T) {
 	names = mngr.GetNames()
 	require.Len(t, names, 1)
 	require.Equal(t, "node2", names[0])
+}
+
+// poolMaintainerMock replaces a node's pool maintainer in tests that count
+// instanceSync invocations: pool maintenance also triggers the instance sync
+// (after interface mutations or on errors), which would pollute the counts.
+type poolMaintainerMock struct{}
+
+func (p *poolMaintainerMock) Trigger()  {}
+func (p *poolMaintainerMock) Shutdown() {}
+
+// newNodeMissingFromCache creates a node and then drops its instance from the
+// instance cache, simulating a full resync evicting a node whose interfaces
+// are not attached yet. The instance is dropped only after the node exists so
+// that Upsert does not run its own instance sync, which would interfere with
+// the tests. The resync error is injected before the node is created so that
+// no recalculation can start pool maintenance before the pool maintainer is
+// swapped out (pool maintenance also triggers the instance sync).
+func newNodeMissingFromCache(t *testing.T, mngr *NodeManager, am *allocationImplementationMock, name string) *Node {
+	t.Helper()
+
+	am.nodeResyncErr = errors.New("instance not found")
+	mngr.Upsert(newCiliumNode(name, 0, 0, 0))
+	node := mngr.Get(name)
+	require.NotNil(t, node)
+
+	node.mutex.Lock()
+	node.poolMaintainer.Shutdown()
+	node.poolMaintainer = &poolMaintainerMock{}
+	node.mutex.Unlock()
+
+	am.setHasInstance(false)
+
+	return node
+}
+
+// newNodeWithCountingSync additionally replaces the node's instanceSync
+// trigger with one that counts how many times it fires.
+func newNodeWithCountingSync(t *testing.T, mngr *NodeManager, am *allocationImplementationMock, name string, count *atomic.Int32) *Node {
+	t.Helper()
+
+	node := newNodeMissingFromCache(t, mngr, am, name)
+
+	countingSync, err := trigger.NewTrigger(trigger.Parameters{
+		Name:        "test-instance-sync-" + name,
+		MinInterval: time.Millisecond,
+		TriggerFunc: func([]string) { count.Add(1) },
+	})
+	require.NoError(t, err)
+	t.Cleanup(countingSync.Shutdown)
+
+	node.mutex.Lock()
+	node.instanceSync.Shutdown()
+	node.instanceSync = countingSync
+	node.mutex.Unlock()
+
+	return node
+}
+
+// runWithTimeout fails the test if fn does not return within the timeout,
+// which indicates that the NodeManager deadlocked.
+func runWithTimeout(t *testing.T, name string, fn func()) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		fn()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("%s did not complete, possible deadlock", name)
+	}
+}
+
+// TestNodeManagerInstanceNotFoundRecovery verifies that a node whose
+// instance was dropped from the instance cache has its per-instance sync
+// re-triggered so the operator recovers without a restart. The scenarios run
+// through Resync and Upsert, which hold the NodeManager mutex while
+// recalculating: the timeout guards protect against re-introducing a
+// deadlock on that mutex.
+func TestNodeManagerInstanceNotFoundRecovery(t *testing.T) {
+	setup := func(t *testing.T) (*NodeManager, *allocationImplementationMock, *Node, *atomic.Int32) {
+		am := newAllocationImplementationMock()
+		mngr, err := NewNodeManager(hivetest.Logger(t), am, k8sapi, metricsmock.NewMockMetrics(), 10, false, 0, false)
+		require.NoError(t, err)
+		t.Cleanup(mngr.Stop)
+
+		var count atomic.Int32
+		node := newNodeWithCountingSync(t, mngr, am, "node-cache-drop", &count)
+		return mngr, am, node, &count
+	}
+
+	t.Run("Resync re-triggers the instance sync", func(t *testing.T) {
+		mngr, _, _, count := setup(t)
+		mngr.SetInstancesAPIReadiness(true)
+
+		runWithTimeout(t, "Resync", func() { mngr.Resync(context.Background(), time.Now()) })
+		require.Eventually(t, func() bool {
+			return count.Load() == 1
+		}, time.Second, time.Millisecond, "expected the instance sync to be re-triggered")
+	})
+
+	t.Run("Resync re-triggers at most once while the instance stays missing", func(t *testing.T) {
+		mngr, _, _, count := setup(t)
+		mngr.SetInstancesAPIReadiness(true)
+
+		runWithTimeout(t, "Resync", func() { mngr.Resync(context.Background(), time.Now()) })
+		runWithTimeout(t, "Resync", func() { mngr.Resync(context.Background(), time.Now()) })
+		require.Eventually(t, func() bool {
+			return count.Load() == 1
+		}, time.Second, time.Millisecond, "expected the instance sync to be re-triggered")
+		require.Never(t, func() bool {
+			return count.Load() > 1
+		}, 100*time.Millisecond, 10*time.Millisecond, "the instance sync must be re-triggered at most once per missing-episode")
+	})
+
+	t.Run("re-trigger re-arms after the instance is found again", func(t *testing.T) {
+		mngr, am, node, count := setup(t)
+		mngr.SetInstancesAPIReadiness(true)
+
+		runWithTimeout(t, "Resync", func() { mngr.Resync(context.Background(), time.Now()) })
+		require.Eventually(t, func() bool {
+			return count.Load() == 1
+		}, time.Second, time.Millisecond, "expected the instance sync to be re-triggered")
+
+		// The instance is back in the cache: re-arms the recovery sync.
+		node.ops.(*nodeOperationsMock).setResyncError(nil)
+		am.setHasInstance(true)
+		runWithTimeout(t, "Resync", func() { mngr.Resync(context.Background(), time.Now()) })
+
+		// The instance is dropped a second time.
+		node.ops.(*nodeOperationsMock).setResyncError(errors.New("instance not found"))
+		am.setHasInstance(false)
+		runWithTimeout(t, "Resync", func() { mngr.Resync(context.Background(), time.Now()) })
+		require.Eventually(t, func() bool {
+			return count.Load() == 2
+		}, time.Second, time.Millisecond, "expected the instance sync to be re-triggered again after recovery")
+	})
+
+	t.Run("transient instance sync failure re-arms the re-trigger", func(t *testing.T) {
+		am := newAllocationImplementationMock()
+		mngr, err := NewNodeManager(hivetest.Logger(t), am, k8sapi, metricsmock.NewMockMetrics(), 10, false, 0, false)
+		require.NoError(t, err)
+		t.Cleanup(mngr.Stop)
+
+		// The node keeps its real instanceSync trigger so the sync
+		// failure exercises the re-arm in the trigger function.
+		am.setInstanceSyncError(errors.New("EC2 throttled"))
+		node := newNodeMissingFromCache(t, mngr, am, "node-transient")
+		mngr.SetInstancesAPIReadiness(true)
+
+		runWithTimeout(t, "Resync", func() { mngr.Resync(context.Background(), time.Now()) })
+		require.Eventually(t, func() bool {
+			return am.instanceSyncCallCount() == 1
+		}, time.Second, time.Millisecond, "expected the recovery sync to run")
+		require.Eventually(t, func() bool {
+			node.mutex.RLock()
+			defer node.mutex.RUnlock()
+			return !node.instanceSyncRetriggered
+		}, time.Second, time.Millisecond, "expected the sync failure to re-arm the re-trigger")
+
+		// With the re-trigger re-armed, the next resync must retry the
+		// recovery sync.
+		runWithTimeout(t, "Resync", func() { mngr.Resync(context.Background(), time.Now()) })
+		require.Eventually(t, func() bool {
+			return am.instanceSyncCallCount() == 2
+		}, time.Second, time.Millisecond, "expected the recovery sync to be retried")
+	})
+
+	t.Run("authoritative instance not found does not re-arm the re-trigger", func(t *testing.T) {
+		am := newAllocationImplementationMock()
+		mngr, err := NewNodeManager(hivetest.Logger(t), am, k8sapi, metricsmock.NewMockMetrics(), 10, false, 0, false)
+		require.NoError(t, err)
+		t.Cleanup(mngr.Stop)
+
+		// A provider that authoritatively reports the instance as gone
+		// consumes the one-shot recovery attempt.
+		am.setInstanceSyncError(fmt.Errorf("provider response: %w", ErrInstanceNotFound))
+		node := newNodeMissingFromCache(t, mngr, am, "node-gone")
+		mngr.SetInstancesAPIReadiness(true)
+
+		runWithTimeout(t, "Resync", func() { mngr.Resync(context.Background(), time.Now()) })
+		require.Eventually(t, func() bool {
+			return am.instanceSyncCallCount() == 1
+		}, time.Second, time.Millisecond, "expected the recovery sync to run")
+		require.Never(t, func() bool {
+			node.mutex.RLock()
+			defer node.mutex.RUnlock()
+			return !node.instanceSyncRetriggered
+		}, 100*time.Millisecond, 10*time.Millisecond, "an authoritative not-found response must leave the re-trigger consumed")
+
+		runWithTimeout(t, "Resync", func() { mngr.Resync(context.Background(), time.Now()) })
+		require.Never(t, func() bool {
+			return am.instanceSyncCallCount() > 1
+		}, 100*time.Millisecond, 10*time.Millisecond, "the recovery sync must not retry an instance known to be gone")
+	})
+
+	t.Run("no re-trigger while the instances API is unstable", func(t *testing.T) {
+		mngr, _, _, count := setup(t)
+		mngr.SetInstancesAPIReadiness(false)
+
+		runWithTimeout(t, "Resync", func() { mngr.Resync(context.Background(), time.Now()) })
+		require.Never(t, func() bool {
+			return count.Load() > 0
+		}, 100*time.Millisecond, 10*time.Millisecond, "the instance sync must not be re-triggered while the API is unstable")
+	})
+
+	t.Run("Upsert with a missing instance does not deadlock", func(t *testing.T) {
+		mngr, _, _, count := setup(t)
+		mngr.SetInstancesAPIReadiness(true)
+
+		runWithTimeout(t, "Upsert", func() { mngr.Upsert(newCiliumNode("node-cache-drop", 0, 0, 0)) })
+		// The Upsert path does not re-trigger the sync itself, recovery
+		// is handled by the periodic resync path.
+		require.Never(t, func() bool {
+			return count.Load() > 0
+		}, 100*time.Millisecond, 10*time.Millisecond, "the Upsert path must not re-trigger the instance sync")
+	})
 }
 
 func TestNodeManagerGet(t *testing.T) {

--- a/pkg/azure/ipam/instances.go
+++ b/pkg/azure/ipam/instances.go
@@ -5,11 +5,14 @@ package ipam
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
+	"net/http"
 	"net/netip"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v10"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -109,6 +112,13 @@ func (m *InstancesManager) resyncInstance(ctx context.Context, instanceID string
 	// Fetch network interfaces once from Azure API
 	networkInterfaces, err := m.api.ListVMNetworkInterfaces(ctx, instanceID)
 	if err != nil {
+		// A 404 from the Azure API is treated as the instance no longer
+		// existing, so that callers can tell an instance that is gone
+		// apart from a transient synchronization failure.
+		var respErr *azcore.ResponseError
+		if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
+			return time.Time{}, fmt.Errorf("%w: synchronize Azure instance %s interface list: %w", nodemanager.ErrInstanceNotFound, instanceID, err)
+		}
 		return time.Time{}, fmt.Errorf("synchronize Azure instance %s interface list: %w", instanceID, err)
 	}
 


### PR DESCRIPTION
In ENI IPAM mode with `eni.subnetTagsFilter` set, a full ENI resync calls `DescribeNetworkInterfaces` and replaces the operator's entire instance cache with the ENIs discovered in the pod subnets. During a large scale-up, a freshly launched node whose pod subnet ENI has not been attached yet is not represented in that refreshed cache.

Once the node disappears from the cache, `ResyncInterfacesAndIPs` returns "instance not found", `recalculate()` sets `NeededIPs=0` and stops trying to allocate, and the node stays stuck at `available=0` until the operator is restarted.

This change re-triggers the node's existing per-instance `instanceSync` when a live node's instance is not in the instance cache, reusing the `HasInstance()` check that `Upsert` already performs. The check is done by the callers of `recalculate()`, where the `NodeManager` lock state is known:

- `Resync` already holds the `NodeManager` mutex and passes the instances API readiness down to its `resyncNode` workers (calling `InstancesAPIIsReady()` from a worker would deadlock against the semaphore).
- `MaintainIPPool` holds no locks and queries `InstancesAPIIsReady()` directly.

The sync is re-triggered at most once while the instance stays missing and is re-armed by the next successful recalculation, or by a transient failure of the re-triggered sync itself. Recovery runs are tagged with a dedicated trigger reason (`instanceNotFoundSyncReason`) so that only their failures re-arm the re-trigger. If the per-instance sync authoritatively reports the instance as gone (`ErrInstanceNotFound`, e.g. Azure returning HTTP 404), the re-trigger is not re-armed; only transient failures retry. This prevents a sync retry loop for instances which were legitimately terminated but whose CiliumNode resource still exists: those get a single probe sync and then revert to the previous warn-only behavior.

Unit tests exercise the recovery through the real `Resync`/`Upsert` entry points with timeout guards, acting as regression tests against re-introducing a deadlock on the `NodeManager` mutex.

Fixes: #46513

_This PR was prepared with AIL:3 (AI-assisted, human-directed and verified). I reviewed the change and own it._

```release-note
operator/ipam: recover ENI IPAM nodes that were dropped from the instance cache by a full ENI resync, instead of requiring an operator restart
```
