### PR TITLE
gatewayapi: fix HTTPRoute rejected on mixed HTTP+TCP Gateway

### DIFF
--- a/operator/pkg/gateway-api/routechecks/gateway_checks.go
+++ b/operator/pkg/gateway-api/routechecks/gateway_checks.go
@@ -92,7 +92,7 @@ func CheckGatewayRouteKindAllowed(input Input, parentRef gatewayv1.ParentReferen
 	}
 
 	routeGVK := input.GetGVK()
-	hasKindRestriction := false
+	matchedListeners := 0
 	for _, listener := range owner.GetListeners() {
 		if parentRef.SectionName != nil && listener.Name != *parentRef.SectionName {
 			continue
@@ -102,20 +102,19 @@ func CheckGatewayRouteKindAllowed(input Input, parentRef gatewayv1.ParentReferen
 		}
 
 		if listener.AllowedRoutes == nil || len(listener.AllowedRoutes.Kinds) == 0 {
-			continue
+			return true, nil
 		}
 
-		hasKindRestriction = true
+		matchedListeners++
 		for _, kind := range listener.AllowedRoutes.Kinds {
 			if (kind.Group == nil || (kind.Group != nil && *kind.Group == gatewayv1.Group(routeGVK.Group))) &&
 				kind.Kind == gatewayv1.Kind(routeGVK.Kind) {
-				// At least one matching listener allows this route kind.
 				return true, nil
 			}
 		}
 	}
 
-	if hasKindRestriction {
+	if matchedListeners > 0 {
 		input.SetParentCondition(parentRef, metav1.Condition{
 			Type:    string(gatewayv1.RouteConditionAccepted),
 			Status:  metav1.ConditionFalse,

--- a/operator/pkg/gateway-api/routechecks/gateway_checks_test.go
+++ b/operator/pkg/gateway-api/routechecks/gateway_checks_test.go
@@ -102,6 +102,38 @@ var mixedNamespaceGateway = &gatewayv1.Gateway{
 	},
 }
 
+// Gateway fixture mixing an unrestricted HTTP listener with an explicit-TCPRoute
+// TCP listener; used to test that the TCP restriction doesn't block HTTPRoute.
+var mixedKindGateway = &gatewayv1.Gateway{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "mixed-kind-gateway",
+		Namespace: "default",
+	},
+	Spec: gatewayv1.GatewaySpec{
+		GatewayClassName: "cilium",
+		Listeners: []gatewayv1.Listener{
+			{
+				Name:     "http",
+				Port:     80,
+				Protocol: gatewayv1.HTTPProtocolType,
+			},
+			{
+				Name:     "tcp",
+				Port:     8090,
+				Protocol: gatewayv1.TCPProtocolType,
+				AllowedRoutes: &gatewayv1.AllowedRoutes{
+					Kinds: []gatewayv1.RouteGroupKind{
+						{
+							Group: ptr.To[gatewayv1.Group](gatewayv1.GroupName),
+							Kind:  "TCPRoute",
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
 // Gateway fixture with no kind restrictions on any listener.
 var noKindRestrictedGateway = &gatewayv1.Gateway{
 	ObjectMeta: metav1.ObjectMeta{
@@ -712,7 +744,7 @@ func TestCheckGatewayRouteKindAllowed(t *testing.T) {
 
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(kindRestrictedGateway, noKindRestrictedGateway).
+		WithObjects(kindRestrictedGateway, noKindRestrictedGateway, mixedKindGateway).
 		WithStatusSubresource(&gatewayv1.HTTPRoute{}).
 		Build()
 
@@ -797,6 +829,63 @@ func TestCheckGatewayRouteKindAllowed(t *testing.T) {
 					Name:        "kind-restricted-gateway",
 					Namespace:   ptr.To[gatewayv1.Namespace]("default"),
 					SectionName: ptr.To[gatewayv1.SectionName]("grpcs"),
+				},
+			},
+			want: false,
+		},
+		{
+			// Regression: TCP listener's explicit [TCPRoute] must not poison the unrestricted HTTP listener.
+			name: "HTTPRoute on mixed HTTP+TCP gateway without sectionName (allowed by unrestricted HTTP listener)",
+			args: args{
+				input: &HTTPRouteInput{
+					Client: c,
+					HTTPRoute: &gatewayv1.HTTPRoute{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+						},
+					},
+				},
+				parentRef: gatewayv1.ParentReference{
+					Name:      "mixed-kind-gateway",
+					Namespace: ptr.To[gatewayv1.Namespace]("default"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "HTTPRoute on mixed HTTP+TCP gateway targeting http section (allowed)",
+			args: args{
+				input: &HTTPRouteInput{
+					Client: c,
+					HTTPRoute: &gatewayv1.HTTPRoute{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+						},
+					},
+				},
+				parentRef: gatewayv1.ParentReference{
+					Name:        "mixed-kind-gateway",
+					Namespace:   ptr.To[gatewayv1.Namespace]("default"),
+					SectionName: ptr.To[gatewayv1.SectionName]("http"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "HTTPRoute on mixed HTTP+TCP gateway targeting tcp section (rejected)",
+			args: args{
+				input: &HTTPRouteInput{
+					Client: c,
+					HTTPRoute: &gatewayv1.HTTPRoute{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+						},
+					},
+				},
+				parentRef: gatewayv1.ParentReference{
+					Name:        "mixed-kind-gateway",
+					Namespace:   ptr.To[gatewayv1.Namespace]("default"),
+					SectionName: ptr.To[gatewayv1.SectionName]("tcp"),
 				},
 			},
 			want: false,


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin]
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      This PR was prepared with AIL:3. I used Claude Code (claude-sonnet-4-6) to
      implement the fix and tests. I identified and traced the root cause myself,
      reviewed all generated code, understand the change, and verified it with the
      test suite.

<!-- Description of change -->

`CheckGatewayRouteKindAllowed` silently skips listeners with no explicit
`AllowedRoutes.Kinds` via `continue`. When a Gateway mixes an unrestricted
HTTP listener with a TCP listener carrying `AllowedRoutes.Kinds: [TCPRoute]`,
the TCP listener sets `hasKindRestriction = true` while the HTTP listener is
ignored. An HTTPRoute is then rejected with `Accepted=False /
NotAllowedByListeners` even though the HTTP listener permits it.

**Fix:** replace `continue` with `return true, nil` when a matching listener
has no kind restriction. A listener without explicit kinds does not restrict
by kind — protocol enforcement is handled separately by
`CheckGatewayMatchingProtocol`, which runs before this check.

Fixes: #46754

```release-note
Fixed an issue where an HTTPRoute referencing a Gateway with mixed listener
protocols (e.g. HTTP and TCP) was incorrectly rejected with
`NotAllowedByListeners` when the TCP listener had an explicit
`AllowedRoutes.Kinds` restriction.
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer's Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request