### PR TITLE
datapath: Fix masquerade IP selection with route-discovered node addresses

### DIFF
--- a/pkg/datapath/tables/node_address.go
+++ b/pkg/datapath/tables/node_address.go
@@ -341,10 +341,18 @@ func (n *nodeAddressController) reconcile(health cell.Health) *statedb.WatchSet 
 			nodePort = dev.Name != defaults.HostDevice && ip.PrefixesContains(n.Config.NodePortAddresses, dst.Addr())
 
 		}
+		hasPrimary := false
+		for _, addr := range newAddrsByDevice[dev.Name] {
+			if addr.Primary && addr.Addr.Is4() == dst.Addr().Is4() {
+				hasPrimary = true
+				break
+			}
+		}
+
 		nodeAddr := NodeAddress{
 			Addr:       dst.Addr(),
 			NodePort:   nodePort,
-			Primary:    true, // Preferred source on a route is a strong candidate for a primary address.
+			Primary:    !hasPrimary,
 			DeviceName: dev.Name,
 		}
 		newAddrsByDevice[dev.Name] = append(newAddrsByDevice[dev.Name], nodeAddr)

--- a/pkg/datapath/tables/node_address_test.go
+++ b/pkg/datapath/tables/node_address_test.go
@@ -1029,11 +1029,13 @@ func TestNodeAddressFromRoute(t *testing.T) {
 
 	// Define our test scenarios.
 	testCases := []struct {
-		name               string
-		nodePortAddrs      []string
-		ipAlreadyOnDevice  bool // To test duplicate avoidance
-		customizeRoute     func(*Route)
-		expectNodePortFlag bool
+		name                string
+		nodePortAddrs       []string
+		ipAlreadyOnDevice   bool // To test duplicate avoidance
+		differentIPOnDevice bool // To test primary selection with existing device IP
+		customizeRoute      func(*Route)
+		expectNodePortFlag  bool
+		expectSecondary     bool // Expect Primary to be false
 	}{
 		{
 			name:               "no-nodeport-whitelist",
@@ -1073,6 +1075,21 @@ func TestNodeAddressFromRoute(t *testing.T) {
 			name:               "ipv6-route-no-nodeport-match",
 			nodePortAddrs:      []string{"2001:db9::/64"},
 			expectNodePortFlag: false,
+		},
+		{
+			name:                "device-has-different-primary-ip",
+			differentIPOnDevice: true,
+			expectSecondary:     true,
+		},
+		{
+			name:                "ipv6-route-device-has-different-primary-ip",
+			differentIPOnDevice: true,
+			expectSecondary:     true,
+		},
+		{
+			name:                "ipv6-route-cross-family-device-has-different-primary-ip",
+			differentIPOnDevice: true,
+			expectSecondary:     false,
 		},
 	}
 
@@ -1140,9 +1157,30 @@ func TestNodeAddressFromRoute(t *testing.T) {
 			txn := db.WriteTxn(devices, routes)
 			_, watch := nodeAddrs.AllWatch(txn)
 
+			var differentIP netip.Addr
+			if tc.differentIPOnDevice {
+				if strings.Contains(tc.name, "cross-family") {
+					if strings.Contains(tc.name, "ipv6") {
+						differentIP = netip.MustParseAddr("10.0.0.1")
+					} else {
+						differentIP = netip.MustParseAddr("2001:db8::99")
+					}
+				} else {
+					if strings.Contains(tc.name, "ipv6") {
+						differentIP = netip.MustParseAddr("2001:db8::99")
+					} else {
+						differentIP = netip.MustParseAddr("10.0.0.1")
+					}
+				}
+			}
+
 			if tc.ipAlreadyOnDevice {
 				testDeviceWithAddr := *testDevice // clone
 				testDeviceWithAddr.Addrs = []DeviceAddress{{Addr: routeBasedIP, Scope: RT_SCOPE_UNIVERSE}}
+				devices.Insert(txn, &testDeviceWithAddr)
+			} else if tc.differentIPOnDevice {
+				testDeviceWithAddr := *testDevice // clone
+				testDeviceWithAddr.Addrs = []DeviceAddress{{Addr: differentIP, Scope: RT_SCOPE_UNIVERSE}}
 				devices.Insert(txn, &testDeviceWithAddr)
 			} else {
 				devices.Insert(txn, testDevice)
@@ -1209,7 +1247,7 @@ func TestNodeAddressFromRoute(t *testing.T) {
 
 			require.NotNil(t, foundAddr, "Expected address %s to be discovered from route, but it was not", routeBasedIP)
 			assert.Equal(t, "eth0", foundAddr.DeviceName, "Address should be associated with correct device")
-			assert.True(t, foundAddr.Primary, "Address discovered from a route should be considered Primary")
+			assert.Equal(t, !tc.expectSecondary, foundAddr.Primary, "Address discovered from a route Primary flag was not as expected")
 			assert.Equal(t, tc.expectNodePortFlag, foundAddr.NodePort, "NodePort flag for address %s was not as expected", routeBasedIP)
 
 			// Test route deletion


### PR DESCRIPTION
Cilium harvests node local addresses from the local routing table to support NodePort. However, these harvested route-based IPs were unconditionally marked as 'Primary'.

Because the `node-addresses` StateDB table uses a primary index based on IP address, iterating over it returns addresses sorted by IP (numerically smaller first).

The masquerade IP selection helper `primaryV4` returns the first Primary IP it finds for the interface. If a route-discovered IP (such as a public LoadBalancer VIP in GKE or other virtual IP) is numerically smaller than the node's physical IP, it was incorrectly selected as the masquerade source. This causes pod egress traffic to internal destinations (like the kube-apiserver) to be SNAT'd to the virtual IP, which often cannot be routed back, causing connectivity failures.

Fix this by only marking route-discovered IPs as 'Primary' if the device does not already have a primary IP of the same address family. This preserves route discovery for NodePort while preventing harvested virtual/LB IPs from hijacking masquerading.

Fixes: #46829
