### PR TITLE
docs: add ListenerSet documentation

### DIFF
--- a/Documentation/network/servicemesh/gateway-api/gateway-api.rst
+++ b/Documentation/network/servicemesh/gateway-api/gateway-api.rst
@@ -33,6 +33,7 @@ tests are passed.
 - `TLSRoute <https://gateway-api.sigs.k8s.io/reference/api-types/tlsroute/>`__
 - `BackendTLSPolicy <https://gateway-api.sigs.k8s.io/reference/api-types/policy/backendtlspolicy/>`__
 - `ReferenceGrant <https://gateway-api.sigs.k8s.io/reference/api-types/referencegrant/>`_
+- `ListenerSet <https://gateway-api.sigs.k8s.io/guides/user-guides/listener-set/>`__
 - `TCPRoute (experimental) <https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#tcproute>`__
 - `UDPRoute (experimental) <https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#udproute>`__
 
@@ -44,6 +45,7 @@ Additionally, Cilium provides ``CiliumGatewayClassConfig`` CRD, which can be ref
 
   If you'd like more insights on Cilium's Gateway API support, check out `eCHO episode 58: Cilium Service Mesh and Ingress <https://www.youtube.com/watch?v=60epwCxO8G4&index=80&t=2024s>`__.
 
+.. _gs_gateway_api_prerequisites:
 .. include:: installation.rst
 
 .. include:: ../ingress-reference.rst
@@ -73,6 +75,7 @@ Cilium's Gateway API features:
    default-tls-certificate
    backendtlspolicy
    access-logs
+   listenerset
 
 More examples can be found in the `upstream repository <https://github.com/kubernetes-sigs/gateway-api/tree/v1.3.0/examples/standard>`_.
 

--- a/Documentation/network/servicemesh/gateway-api/installation.rst
+++ b/Documentation/network/servicemesh/gateway-api/installation.rst
@@ -17,13 +17,7 @@ Prerequisites
     - `ReferenceGrant <https://gateway-api.sigs.k8s.io/reference/api-types/referencegrant/>`_
     - `TLSRoute <https://gateway-api.sigs.k8s.io/reference/api-types/tlsroute/>`_
 
-  If you wish to use the TCPRoute and UDPRoute functionality, you also need to install the TCPRoute and UDPRoute resource.
-  If this CRD is not installed, then Cilium will disable TCPRoute and UDPRoute support.
-
-    - `TCPRoute (experimental) <https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#tcproute>`__
-    - `UDPRoute (experimental) <https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#udproute>`__
-
-  You can install the required CRDs like this:
+  You can install the set of required CRDs like this:
 
     .. code-block:: shell-session
 
@@ -35,11 +29,32 @@ Prerequisites
         $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_backendtlspolicies.yaml
         $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_tlsroutes.yaml
 
-  For TCPRoute and UDPRoute, also add the related CRDs with the following snippet:
+  If you wish to use the ListenerSet, TCPRoute, or UDPRoute functionality, you
+  also need to install the related CRDs. For each CRD that is not installed,
+  Cilium will disable support for the feature.
+
+    - `ListenerSet <https://gateway-api.sigs.k8s.io/guides/user-guides/listener-set/>`__
+    - `TCPRoute <https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#tcproute>`__
+    - `UDPRoute <https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#udproute>`__
+
+  Each optional CRD can be installed with these respective commands.
+  
+  ListenerSet:
+
+    .. code-block:: shell-session
+
+        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_listenersets.yaml
+
+  TCPRoute:
 
     .. code-block:: shell-session
 
         $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+
+  UDPRoute:
+
+    .. code-block:: shell-session
+
         $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
 
 * By default, the Gateway API controller creates a service of LoadBalancer type,

--- a/Documentation/network/servicemesh/gateway-api/listenerset.rst
+++ b/Documentation/network/servicemesh/gateway-api/listenerset.rst
@@ -1,0 +1,121 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+.. _gs_gateway_listenerset:
+
+*******************
+ListenerSet Support
+*******************
+
+`ListenerSet <https://gateway-api.sigs.k8s.io/guides/user-guides/listener-set/>`__
+allows additional groups of listeners, defined in ListenerSet resources, to
+attach to a single Gateway. This lets an infrastructure owner manage the
+Gateway while application owners manage their listeners and TLS certificates
+in separate namespaces. All attached listeners use the parent Gateway's
+address and infrastructure.
+
+Cilium supports the standard ListenerSet API. This feature does not require a
+separate Cilium feature flag. Install the ListenerSet CRD before starting the
+Cilium operator so that ListenerSet support is detected during startup (see
+:ref:`prerequisites <gs_gateway_api_prerequisites>`). When adding the CRD to an existing
+installation, restart the Cilium operator afterward so that it can detect the
+new resource and enable ListenerSet support.
+
+.. note::
+
+    By default, a Gateway resource does not accept ListenerSets. To enable
+    ListenerSet attachment for a Gateway, use ``spec.allowedListeners`` to
+    select the namespaces from which ListenerSets may attach.
+
+Delegate a listener
+===================
+
+The following example creates a Gateway in the ``default`` namespace and
+allows ListenerSets from namespaces with the ``gateway-access: "true"`` label.
+The ListenerSet and HTTPRoute are created in the ``listenerset-demo``
+namespace which has this label.
+
+.. literalinclude:: ../../../../examples/kubernetes/gateway/listenerset.yaml
+     :language: yaml
+
+Apply the configuration and deploy the echo application in the delegated
+namespace:
+
+.. parsed-literal::
+
+    $ kubectl apply -f \ |SCM_WEB|\/examples/kubernetes/gateway/listenerset.yaml
+    $ kubectl -n listenerset-demo apply -f \ |SCM_WEB|\/examples/kubernetes/gateway/echo-basic.yaml
+
+Routes attach directly to the resource that defines their listener. The
+HTTPRoute specifies ``kind: ListenerSet`` and selects the ``echo`` listener. A
+Route which references only the Gateway would not attach to any ListenerSet
+listeners.
+
+Verify the ListenerSet
+======================
+
+Check both the parent Gateway and the ListenerSet:
+
+.. code-block:: shell-session
+
+    $ kubectl get gateway shared-gateway
+    NAME             CLASS    ADDRESS          PROGRAMMED   AGE
+    shared-gateway   cilium   192.0.2.100      True         1m
+
+    $ kubectl get listenerset -n listenerset-demo delegated-listeners
+    NAME                  ACCEPTED   PROGRAMMED   AGE
+    delegated-listeners   True       True         1m
+
+Send a request to the listener:
+
+.. code-block:: shell-session
+
+    $ GATEWAY=$(kubectl get gateway shared-gateway -o jsonpath='{.status.addresses[0].value}')
+    $ curl --fail --header 'Host: echo.example.com' http://$GATEWAY/
+
+The Gateway reports the number of attached ListenerSets that contain at least
+one valid listener in ``status.attachedListenerSets``. Detailed status for
+delegated listeners appears in the ListenerSet's ``status.listeners`` field.
+When troubleshooting, inspect the Accepted, Programmed, ResolvedRefs, and
+Conflicted conditions for each listener. Also confirm that the parent Gateway is
+programmed and has an address.
+
+.. code-block:: shell-session
+
+    $ kubectl describe gateways -n default shared-gateway | grep Attached
+      Attached Listener Sets:  1
+        Attached Routes:  0
+
+    $ kubectl describe listenerset -n listenerset-demo delegated-listeners | grep Attached
+        Attached Routes:  1
+
+Operational considerations
+==========================
+
+- The Gateway controls which ListenerSet namespaces are accepted with
+  ``allowedListeners``. By default, no ListenerSets are allowed.
+- Each ListenerSet listener independently controls Route attachment with
+  ``allowedRoutes``. When this field is omitted, Routes from the ListenerSet's
+  namespace are allowed.
+- A Route parent reference must explicitly set ``kind: ListenerSet``. If the
+  kind is omitted, it defaults to ``Gateway``.
+- HTTPRoute, GRPCRoute, TLSRoute, and the optional TCPRoute and UDPRoute APIs
+  can target compatible listeners in a ListenerSet.
+- Listeners defined directly on the Gateway take precedence over conflicting
+  ListenerSet listeners. Among ListenerSets, older ListenerSets take
+  precedence. Conflicts are reported on the lower-precedence listener.
+- A ListenerSet with a mixture of valid and invalid listeners can be accepted.
+  Check each listener's status instead of relying only on the ListenerSet's
+  top-level conditions.
+- Certificate references are evaluated from the ListenerSet's namespace. A
+  cross-namespace Secret requires a ReferenceGrant for the ListenerSet.
+  Grants made to the parent Gateway are not inherited.
+- The parent Gateway must retain at least one valid listener of its own. A
+  valid ListenerSet does not make an otherwise invalid Gateway accepted.
+
+See the upstream `ListenerSet documentation
+<https://gateway-api.sigs.k8s.io/guides/user-guides/listener-set/>`__ for
+complete attachment, conflict, and status semantics.

--- a/examples/kubernetes/gateway/listenerset.yaml
+++ b/examples/kubernetes/gateway/listenerset.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: listenerset-demo
+  labels:
+    gateway-access: "true"
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: shared-gateway
+  namespace: default
+spec:
+  gatewayClassName: cilium
+  allowedListeners:
+    namespaces:
+      from: Selector
+      selector:
+        matchLabels:
+          gateway-access: "true"
+  listeners:
+  - name: base-http
+    protocol: HTTP
+    port: 8081
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: delegated-listeners
+  namespace: listenerset-demo
+spec:
+  parentRef:
+    name: shared-gateway
+    namespace: default
+  listeners:
+  - name: echo
+    hostname: echo.example.com
+    protocol: HTTP
+    port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: echo
+  namespace: listenerset-demo
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: ListenerSet
+    name: delegated-listeners
+    sectionName: echo
+  hostnames:
+  - echo.example.com
+  rules:
+  - backendRefs:
+    - name: echo-1
+      port: 8080


### PR DESCRIPTION
Add ListenerSet documentation. Includes installation instructions, an example, operational considerations, and links to upstream documentation.

```release-note
docs: add ListenerSet documentation
```
