### PR TITLE
gatewayapi: add listenersets to sysdump

### DIFF
--- a/cilium-cli/sysdump/constants.go
+++ b/cilium-cli/sysdump/constants.go
@@ -116,6 +116,7 @@ const (
 	timestampPlaceholderFileName             = "<ts>"
 	gatewayClassesFileName                   = "gatewayapi-gatewayclasses-<ts>.yaml"
 	gatewaysFileName                         = "gatewayapi-gateways-<ts>.yaml"
+	listenerSetsFileName                     = "gatewayapi-listenersets-<ts>.yaml"
 	httpRoutesFileName                       = "gatewayapi-httproutes-<ts>.yaml"
 	tlsRoutesFileName                        = "gatewayapi-tlsroutes-<ts>.yaml"
 	grpcRoutesFileName                       = "gatewayapi-grpcroutes-<ts>.yaml"
@@ -184,6 +185,12 @@ var (
 	gateway = schema.GroupVersionResource{
 		Group:    "gateway.networking.k8s.io",
 		Resource: "gateways",
+		Version:  "v1",
+	}
+
+	listenerSet = schema.GroupVersionResource{
+		Group:    "gateway.networking.k8s.io",
+		Resource: "listenersets",
 		Version:  "v1",
 	}
 

--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -2133,6 +2133,21 @@ func (c *Collector) getGatewayAPITasks() []Task {
 			},
 		},
 		{
+			Description: "Collecting ListenerSet entries",
+			Quick:       true,
+			Task: func(ctx context.Context) error {
+				n := corev1.NamespaceAll
+				v, err := c.Client.ListUnstructured(ctx, listenerSet, &n, metav1.ListOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to collect ListenerSet entries: %w", err)
+				}
+				if err := c.WriteYAML(listenerSetsFileName, v); err != nil {
+					return fmt.Errorf("failed to collect ListenerSet entries: %w", err)
+				}
+				return nil
+			},
+		},
+		{
 			Description: "Collecting ReferenceGrant entries",
 			Quick:       true,
 			Task: func(ctx context.Context) error {


### PR DESCRIPTION
Add collection of ListenerSets to the sysdump command.

```
$ cat cilium-sysdump-20260702-172346/gatewayapi-listenersets-20260702-172346.yaml | grep ListenerSet
  kind: ListenerSet
        {"apiVersion":"gateway.networking.k8s.io/v1","kind":"ListenerSet","metadata":{"annotations":{},"name":"delegated-listeners","namespace":"listenerset-demo"},"spec":{"listeners":[{"hostname":"echo.example.com","name":"echo","port":80,"protocol":"HTTP"}],"parentRef":{"name":"shared-gateway","namespace":"default"}}}
      message: ListenerSet is accepted
      message: ListenerSet is programmed
kind: ListenerSetList
```

Has been tested to produce a file like the above

```release-note
gatewayapi: add listenersets to sysdump
```