### PR TITLE
cilium-cli/connectivity: explain conn-disrupt restart on failure

### DIFF
--- a/cilium-cli/connectivity/tests/upgrade.go
+++ b/cilium-cli/connectivity/tests/upgrade.go
@@ -4,15 +4,22 @@
 package tests
 
 import (
+	"bytes"
 	"context"
 	gojson "encoding/json"
+	"fmt"
 	"maps"
 	"os"
 	"strconv"
+	"strings"
+	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/k8s"
 )
 
 // NoInterruptedConnections checks whether there are no interruptions in
@@ -49,6 +56,10 @@ func (n *noInterruptedConnections) Run(ctx context.Context, t *check.Test) {
 	ct := t.Context()
 
 	restartCount := make(map[string]string)
+	// podClients remembers which client a given pod was observed through, so
+	// that a restart-count mismatch can be explained by querying the very same
+	// pod for the reason its container restarted.
+	podClients := make(map[string]*k8s.Client)
 	for _, client := range ct.Clients() {
 		if ct.Params().IncludeConnDisruptTest {
 			pods, err := client.ListPods(ctx, ct.Params().TestNamespace, metav1.ListOptions{LabelSelector: "kind=" + check.KindTestConnDisrupt})
@@ -61,6 +72,7 @@ func (n *noInterruptedConnections) Run(ctx context.Context, t *check.Test) {
 
 			for _, pod := range pods.Items {
 				restartCount[pod.GetObjectMeta().GetName()] = strconv.Itoa(int(pod.Status.ContainerStatuses[0].RestartCount))
+				podClients[pod.GetObjectMeta().GetName()] = client
 			}
 		}
 
@@ -75,6 +87,7 @@ func (n *noInterruptedConnections) Run(ctx context.Context, t *check.Test) {
 
 			for _, pod := range pods.Items {
 				restartCount[pod.GetObjectMeta().GetName()] = strconv.Itoa(int(pod.Status.ContainerStatuses[0].RestartCount))
+				podClients[pod.GetObjectMeta().GetName()] = client
 			}
 		} else {
 			ct.Info("Skipping conn-disrupt-test for NS traffic")
@@ -91,6 +104,7 @@ func (n *noInterruptedConnections) Run(ctx context.Context, t *check.Test) {
 
 			for _, pod := range pods.Items {
 				restartCount[pod.GetObjectMeta().GetName()] = strconv.Itoa(int(pod.Status.ContainerStatuses[0].RestartCount))
+				podClients[pod.GetObjectMeta().GetName()] = client
 			}
 		} else {
 			ct.Info("Skipping conn-disrupt-test for L7 traffic")
@@ -107,6 +121,7 @@ func (n *noInterruptedConnections) Run(ctx context.Context, t *check.Test) {
 
 			for _, pod := range pods.Items {
 				restartCount[pod.GetObjectMeta().GetName()] = strconv.Itoa(int(pod.Status.ContainerStatuses[0].RestartCount))
+				podClients[pod.GetObjectMeta().GetName()] = client
 			}
 		} else {
 			ct.Info("Skipping conn-disrupt-test for Egress Gateway")
@@ -149,8 +164,45 @@ func (n *noInterruptedConnections) Run(ctx context.Context, t *check.Test) {
 		if prevCount, found := prevRestartCount[pod]; !found {
 			t.Fatalf("Could not find Pod %s restart count", pod)
 		} else if prevCount != count {
-			t.Fatalf("Pod %s flow was interrupted (restart count does not match %s != %s)",
-				pod, prevCount, count)
+			t.Fatalf("Pod %s flow was interrupted (restart count does not match %s != %s)%s",
+				pod, prevCount, count, restartReason(ctx, ct, podClients[pod], pod))
 		}
 	}
+}
+
+// restartReason returns a human-readable, best-effort explanation of why the
+// container of the given conn-disrupt client/server pod restarted. It reports
+// the last termination state (exit code, signal, reason) and the tail of the
+// previous container's logs. It is only used to enrich the failure message so
+// that a benign environmental restart can be told apart from a genuine
+// connection disruption; it never changes the pass/fail outcome and swallows
+// its own errors, returning an empty string when nothing can be collected.
+func restartReason(ctx context.Context, ct *check.ConnectivityTest, client *k8s.Client, podName string) string {
+	if client == nil {
+		return ""
+	}
+
+	pod, err := client.GetPod(ctx, ct.Params().TestNamespace, podName, metav1.GetOptions{})
+	if err != nil || len(pod.Status.ContainerStatuses) == 0 {
+		return ""
+	}
+
+	cs := pod.Status.ContainerStatuses[0]
+	var sb strings.Builder
+	if term := cs.LastTerminationState.Terminated; term != nil {
+		fmt.Fprintf(&sb, "; last termination: exitCode=%d signal=%d reason=%q message=%q startedAt=%s finishedAt=%s",
+			term.ExitCode, term.Signal, term.Reason, term.Message,
+			term.StartedAt.Format(time.RFC3339), term.FinishedAt.Format(time.RFC3339))
+	}
+
+	var logs bytes.Buffer
+	err = client.GetLogs(ctx, pod.Namespace, podName, cs.Name,
+		corev1.PodLogOptions{Previous: true, TailLines: ptr.To[int64](20)}, &logs)
+	if err == nil {
+		if trimmed := strings.TrimSpace(logs.String()); trimmed != "" {
+			fmt.Fprintf(&sb, "; previous container logs (tail):\n%s", trimmed)
+		}
+	}
+
+	return sb.String()
 }


### PR DESCRIPTION
When no-interrupted-connections detects a restart-count mismatch it fails with only the before/after counts:

  Pod test-conn-disrupt-client-backend-node-ipv4-internalip-... flow was
  interrupted (restart count does not match 0 != 1)

That is enough to know a container restarted but not why, so a genuine connection disruption is indistinguishable from a benign environmental restart (for example an external HostNetwork NodePort client whose process exits while the agent DaemonSet rolls during an upgrade or downgrade). Triaging then requires digging through a sysdump.

Record which client each pod was observed through, and when the counts mismatch, append a best-effort reason to the failure: the container's last termination state (exit code, signal, reason, timestamps) and the tail of the previous container's logs. This is purely diagnostic, gathered on the failure path only, and it does not change the pass/fail condition or hide any real disruption; it just makes the cause visible in the test output. Collection errors are swallowed, including the case where the previous container's logs have already been garbage-collected.

This commit was prepared with AIL:3.