### PR TITLE
cilium-cli/connectivity: retry curl in echo-ingress-l7-named-port

### DIFF
--- a/cilium-cli/connectivity/builder/echo_ingress_l7_named_port.go
+++ b/cilium-cli/connectivity/builder/echo_ingress_l7_named_port.go
@@ -21,7 +21,7 @@ func (t echoIngressL7NamedPort) build(ct *check.ConnectivityTest, _ map[string]s
 	newTest("echo-ingress-l7-named-port", ct).
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithCiliumPolicy(echoIngressL7HTTPNamedPortPolicyYAML). // L7 allow policy with HTTP introspection (named port)
-		WithScenarios(tests.PodToPodWithEndpoints()).
+		WithScenarios(tests.PodToPodWithEndpoints(tests.WithRetryCondition(tests.WithRetryAll()))).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Source().HasLabel("other", "client") { // Only client2 is allowed to make HTTP calls.
 				// Trying to access private endpoint without "secret" header set


### PR DESCRIPTION
The echo-ingress-l7-named-port test drives PodToPodWithEndpoints without a retry condition, so the L7-proxied curl runs with only --connect-timeout and --max-time and no --retry. The action-level retry loop only re-runs a command on inconclusive (empty) output or an unparseable exit code, so a plain curl timeout (exit 28) fails the whole action on the first attempt.

Under IPsec on kernel 6.1 a single IPv6 request to the echo pod timed out once, while every sibling IPv4/IPv6 public and private action in the same scenario passed:

  echo-ingress-l7-named-port/pod-to-pod-with-endpoints:curl-ipv6-2-private
  with-header ... command terminated with exit code 28

That single-attempt sensitivity to a transient first-packet loss / Envoy warm-up is exactly what the sibling L7 tests already guard against: client-egress-l7-named-port and client-egress-l7 pass a retry condition, and client-egress-l7-set-header uses WithRetryAll. Give this test the same treatment by attaching WithRetryCondition(WithRetryAll()) so curl retries with --retry-all-errors. Expected-drop actions are unaffected: they still return their non-zero exit code after the retries, only adding retry delay.

This commit was prepared with AIL:3.