### PR TITLE
pkg/rate: fix TestMaxParallelRequests flake under CI load

### DIFF
--- a/pkg/rate/api_limiter_test.go
+++ b/pkg/rate/api_limiter_test.go
@@ -291,11 +291,18 @@ func TestLimitWaitDurationExceeded(t *testing.T) {
 
 func TestMaxParallelRequests(t *testing.T) {
 	// Test blocking of max-parallel-requests by allowing two parallel
-	// requests and having a third request fail due to a very short
-	// MaxWaitDuration
+	// requests and having a third request fail because both slots are
+	// already taken and never free up within MaxWaitDuration.
+	//
+	// MaxWaitDuration is measured from the moment a request is scheduled,
+	// so it also covers the time spent acquiring the parallel-requests
+	// semaphore. Under a noisy CI environment that scheduling overhead
+	// alone can exceed a sub-millisecond budget and spuriously fail the
+	// first two (uncontended) requests. Keep the budget generous enough
+	// that only the genuinely contended third request fails.
 	a := NewAPILimiter(hivetest.Logger(t), "foo", APILimiterParameters{
 		ParallelRequests: 2,
-		MaxWaitDuration:  time.Millisecond,
+		MaxWaitDuration:  100 * time.Millisecond,
 		AutoAdjust:       true,
 	}, nil)
 


### PR DESCRIPTION
TestMaxParallelRequests configured MaxWaitDuration to 1ms, expecting only the third request to fail once both parallel slots are taken. But MaxWaitDuration is measured from the moment a request is scheduled and also covers the time spent acquiring the parallel-requests semaphore. On a loaded CI runner the scheduling overhead of the very first, uncontended request alone exceeded 1ms, so wait() took the "wait duration exceeds maximum" branch and returned:

  request would have to wait 0s to be served (maximum wait duration: -215.915µs)

failing the require.NoError on request 1 rather than on the intended request 3.

Raise MaxWaitDuration to 100ms. That is far above any realistic scheduling jitter for the two uncontended requests, while the third request still fails deterministically because both slots stay occupied for its entire wait window. The test keeps exercising parallel-slot exhaustion, not wall-clock jitter.

This commit was prepared with AIL:3.