### PR TITLE
network driver: use local variables and avoid racy parallel script test runs

### DIFF
--- a/pkg/networkdriver/script_test.go
+++ b/pkg/networkdriver/script_test.go
@@ -86,21 +86,12 @@ func TestScript(t *testing.T) {
 				testDriver  = "test.cilium.k8s.io"
 			)
 
-			var (
-				daemonCfg = &option.DaemonConfig{
-					EnableCiliumNetworkDriver: true,
-					EnableIPv4:                tc.ipv4,
-					EnableIPv6:                tc.ipv6,
-					IPAMCiliumNodeUpdateRate:  time.Nanosecond,
-				}
-
-				mgr            *ipam.MultiPoolManager
-				cs             *k8sClient.FakeClientset
-				pods           resource.Resource[*corev1.Pod]
-				db             *statedb.DB
-				netCfgs        statedb.Table[resourceNetworkConfig]
-				localNodeStore *node.LocalNodeStore
-			)
+			daemonCfg := &option.DaemonConfig{
+				EnableCiliumNetworkDriver: true,
+				EnableIPv4:                tc.ipv4,
+				EnableIPv6:                tc.ipv6,
+				IPAMCiliumNodeUpdateRate:  time.Nanosecond,
+			}
 
 			// The Kubernetes resources below capture nodeTypes.GetName while the
 			// hive is built, so seed the test node before constructing them.
@@ -111,6 +102,18 @@ func TestScript(t *testing.T) {
 			scripttest.Test(t,
 				t.Context(),
 				func(t testing.TB, args []string) *script.Engine {
+					// These must be local to newEngine. scripttest.Test runs each
+					// .txtar file in a t.Parallel() and may race with other tests
+					// if these are shared.
+					var (
+						mgr            *ipam.MultiPoolManager
+						cs             *k8sClient.FakeClientset
+						pods           resource.Resource[*corev1.Pod]
+						db             *statedb.DB
+						netCfgs        statedb.Table[resourceNetworkConfig]
+						localNodeStore *node.LocalNodeStore
+					)
+
 					h := hive.New(
 						k8sClient.FakeClientCell(),
 						k8s.ResourcesCell,


### PR DESCRIPTION
txtar tests run in parallel. using shared variables for these can cause races between the tests due to conflicting state

avoid races by making each test have their own
managers, watchers, kube state - isolating
itself from other parallel runs.

```release-note
network driver: use local variables and avoid racy parallel script test runs
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail AIL2
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
