### PR TITLE
cilium-cli/connectivity: make the test harness resilient to transient exec and service-sync flakes

### DIFF
--- a/cilium-cli/connectivity/check/action.go
+++ b/cilium-cli/connectivity/check/action.go
@@ -342,6 +342,13 @@ func (a *Action) ExecInPod(ctx context.Context, cmd []string) {
 		if err == nil && strings.TrimSpace(pingHeaderPattern.ReplaceAllString(output.String(), "")) == "" {
 			a.Debugf("retrying command %s due to inconclusive results", cmdStr)
 			continue
+		} else if _, lost := lostCurlExitCode(output, errOutput); err == nil && lost {
+			// The exec stream reported success, but curl printed an error to
+			// its output: the command's real exit status was dropped by the
+			// apiserver<->kubelet exec transport. Retry to obtain a reliable
+			// status before interpreting the result.
+			a.Debugf("retrying command %s due to lost exit status", cmdStr)
+			continue
 		} else if err != nil {
 			exitCode, _ := a.extractExitCode(err)
 			if exitCode == ExitInvalidCode {
@@ -374,6 +381,18 @@ func (a *Action) ExecInPod(ctx context.Context, cmd []string) {
 				a.Failf("command %q failed with unexpected exit code: %s (expected %d, found %d)", cmdStr, err, expectedExitCode, exitCode)
 			}
 		}
+	} else if curlCode, lost := lostCurlExitCode(output, errOutput); lost {
+		// The exec transport reported success but curl itself printed an error:
+		// the real exit status was dropped somewhere between the apiserver and
+		// the kubelet (observed during agent rollouts on some clusters). Fall
+		// back to the exit code curl reported in its own output so that a
+		// genuinely failed command is not misread as an unexpected success.
+		if expectedExitCode == ExitAnyError || curlCode == expectedExitCode {
+			a.test.Debugf("command %q failed as expected (recovered from lost exit status): curl exit %d", cmdStr, curlCode)
+		} else {
+			a.Failf("command %q failed with unexpected exit code (recovered from lost exit status): expected %d, found %d", cmdStr, expectedExitCode, curlCode)
+			showOutput = true
+		}
 	} else {
 		if expectedExitCode != 0 {
 			// Command succeeded unexpectedly, display output.
@@ -391,6 +410,35 @@ func (a *Action) ExecInPod(ctx context.Context, cmd []string) {
 }
 
 var exitCodeRegex = regexp.MustCompile("exit code ([0-9]+)")
+
+// curlErrorRegex matches the error curl prints with --show-error, e.g.
+// "curl: (22) The requested URL returned error: 503". The captured number is
+// curl's own exit code.
+var curlErrorRegex = regexp.MustCompile(`curl: \(([0-9]+)\)`)
+
+// lostCurlExitCode detects the case where the pod-exec transport reported the
+// command as successful (err == nil) even though curl actually failed. This
+// happens when the terminating exit-status frame is dropped between the
+// apiserver and the kubelet (observed on some clusters during agent rollouts):
+// client-go then sees no error, but curl's --show-error message is still in the
+// captured output. It returns curl's reported exit code and true in that case,
+// so the caller can fall back to it instead of misreading the command as an
+// unexpected success. A command that genuinely succeeded prints no such marker,
+// so this returns false and the normal success handling applies.
+func lostCurlExitCode(stdout, stderr bytes.Buffer) (ExitCode, bool) {
+	for _, buf := range []string{stderr.String(), stdout.String()} {
+		m := curlErrorRegex.FindStringSubmatch(buf)
+		if len(m) != 2 {
+			continue
+		}
+		i, err := strconv.Atoi(m[1])
+		if err != nil || i < 1 || i > 255 {
+			continue
+		}
+		return ExitCode(i), true
+	}
+	return ExitInvalidCode, false
+}
 
 // extractExitCode extracts command exit code from ExecInPod() error output
 func (a *Action) extractExitCode(err error) (ExitCode, error) {

--- a/cilium-cli/connectivity/check/action.go
+++ b/cilium-cli/connectivity/check/action.go
@@ -263,13 +263,49 @@ func (a *Action) WriteDataToPod(ctx context.Context, filePath string, data []byt
 	}
 	pod := a.src
 
-	output, err := pod.K8sClient.ExecInPod(ctx,
-		pod.Pod.Namespace, pod.Pod.Name, pod.Pod.Spec.Containers[0].Name,
-		[]string{"sh", "-c", fmt.Sprintf("echo %s | base64 -d > %s", encodedData, filePath)})
+	cmd := []string{"sh", "-c", fmt.Sprintf("echo %s | base64 -d > %s", encodedData, filePath)}
+
+	// Retry the exec on transport-level failures only. Unlike ExecInPod, this
+	// is a one-shot setup command with no curl-level --retry, so a transient
+	// failure to establish the exec stream (e.g. an apiserver/konnectivity
+	// upgrade-connection error on managed clusters) would otherwise fail the
+	// whole test before the actual command even runs. A non-zero exit code of
+	// the command itself is not retried: it is a real result and stays fatal.
+	var output bytes.Buffer
+	var err error
+	for i := 1; i <= testCommandRetries; i++ {
+		output, err = pod.K8sClient.ExecInPod(ctx,
+			pod.Pod.Namespace, pod.Pod.Name, pod.Pod.Spec.Containers[0].Name, cmd)
+		if err == nil || !isExecTransportError(err) {
+			break
+		}
+		a.Debugf("retrying writing data to pod due to exec transport error: %s", err)
+		select {
+		case <-ctx.Done():
+		case <-time.After(time.Second):
+		}
+	}
 
 	if err != nil {
 		a.Fatalf("Writing data to pod failed: %s: %s", err, output.String())
 	}
+}
+
+// isExecTransportError reports whether err is a failure to establish the
+// pod-exec stream (as opposed to a non-zero exit code from the command that
+// ran successfully). These are transient infrastructure errors on the path
+// between the apiserver and the kubelet — for example an
+// "unable to upgrade connection: ... error dialing backend: ... 502"
+// returned by the konnectivity/SPDY proxy on managed clusters — and are worth
+// retrying. The upstream error is a plain fmt.Errorf (it is not wrapped in
+// httpstream.UpgradeFailureError), so it is matched by substring.
+func isExecTransportError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "unable to upgrade connection") ||
+		strings.Contains(msg, "error dialing backend")
 }
 
 func (a *Action) ExecInPod(ctx context.Context, cmd []string) {

--- a/cilium-cli/connectivity/check/action_test.go
+++ b/cilium-cli/connectivity/check/action_test.go
@@ -4,6 +4,7 @@
 package check
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -86,6 +87,77 @@ rtt min/avg/max/mdev = 4.572/4.994/5.417/0.422 ms`,
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, strings.TrimSpace(pingHeaderPattern.ReplaceAllString(tt.args.output, "")) == "")
+		})
+	}
+}
+
+func TestLostCurlExitCode(t *testing.T) {
+	// The curl write-out line the connectivity tests use, followed by the
+	// response code. On a 503 with --fail --show-error, curl also prints its
+	// own error to stderr and exits 22.
+	const writeOut = "172.20.0.5:49964 -> 172.20.0.3:30134 = 503\n"
+	const curlErr = "curl: (22) The requested URL returned error: 503"
+
+	tests := []struct {
+		name     string
+		stdout   string
+		stderr   string
+		wantCode ExitCode
+		wantLost bool
+	}{
+		{
+			name:     "curl error on stderr (lost exit status)",
+			stdout:   writeOut,
+			stderr:   curlErr,
+			wantCode: ExitCurlHTTPError,
+			wantLost: true,
+		},
+		{
+			name:     "curl error merged into stdout (TTY)",
+			stdout:   writeOut + curlErr,
+			stderr:   "",
+			wantCode: ExitCurlHTTPError,
+			wantLost: true,
+		},
+		{
+			name:     "curl timeout error",
+			stdout:   "",
+			stderr:   "curl: (28) Connection timed out",
+			wantCode: ExitCurlTimeout,
+			wantLost: true,
+		},
+		{
+			// Genuine success: curl printed a response code but no error
+			// marker. This must NOT be treated as a lost exit status, so a
+			// real unexpected success is still reported as a failure.
+			name:     "successful curl, no error marker",
+			stdout:   "172.20.0.5:49964 -> 172.20.0.3:30134 = 200\n",
+			stderr:   "",
+			wantCode: ExitInvalidCode,
+			wantLost: false,
+		},
+		{
+			name:     "empty output",
+			stdout:   "",
+			stderr:   "",
+			wantCode: ExitInvalidCode,
+			wantLost: false,
+		},
+		{
+			// A word "curl" without the "(NN)" shape must not match.
+			name:     "no parenthesised code",
+			stdout:   "curl said hello",
+			stderr:   "",
+			wantCode: ExitInvalidCode,
+			wantLost: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, lost := lostCurlExitCode(*bytes.NewBufferString(tt.stdout), *bytes.NewBufferString(tt.stderr))
+			assert.Equal(t, tt.wantLost, lost)
+			assert.Equal(t, tt.wantCode, code)
 		})
 	}
 }

--- a/cilium-cli/connectivity/check/wait.go
+++ b/cilium-cli/connectivity/check/wait.go
@@ -211,7 +211,10 @@ func WaitForServiceEndpoints(ctx context.Context, log Logger, agent Pod, service
 	log.Logf("⌛ [%s] Waiting for Service %s to be synchronized by Cilium pod %s",
 		agent.K8sClient.ClusterName(), service.Name(), agent.Name())
 
-	ctx, cancel := context.WithTimeout(ctx, ShortTimeout)
+	// Use the same timeout as WaitForService above: with concurrent tests it
+	// takes a little bit more time for all the services to be synchronized by
+	// every agent, and 30 seconds occasionally isn't enough.
+	ctx, cancel := context.WithTimeout(ctx, 2*ShortTimeout)
 	defer cancel()
 
 	if service.Service.Spec.ClusterIP == corev1.ClusterIPNone {


### PR DESCRIPTION
This bundles three independent fixes to the cilium-cli connectivity test
harness, each addressing a transient CI flake that is unrelated to the code
under test.

`WaitForServiceEndpoints` used a 30s timeout while, under concurrent tests, it
can take longer for every agent to synchronize all services. Its sibling
`WaitForService` already uses 60s (commit a8a955b27d). Align the two. A service
that never synchronizes still fails, just later, so no real failure is masked.

`WriteDataToPod` ran a single, un-retried exec to upload a file before the
curl. On managed clusters a transient apiserver<->kubelet exec-proxy error
(e.g. a konnectivity "unable to upgrade connection ... 502") failed the whole
test before curl ran. Retry only on stream-establishment errors; a non-zero
command exit code stays fatal.

Finally, when the exec transport drops curl's terminating exit-status frame
(observed during agent rollouts), a failed curl was reported as a success,
turning an expected drop into a false "succeeded while it should have failed".
Recover curl's real exit code from its `--show-error` output; a genuinely
successful command prints no such marker, so a real policy-enforcement gap is
still reported.

This PR was prepared with AIL:3. I personally reviewed each change.

```release-note
Improved cilium-cli connectivity test resilience to transient service synchronization delays and pod-exec transport errors.
```
