### PR TITLE
ci: fix external-target readiness and JUnit upload for sig-network E2E

### DIFF
--- a/.github/actions/generic-external-targets/nginx-external.yaml
+++ b/.github/actions/generic-external-targets/nginx-external.yaml
@@ -93,6 +93,21 @@ spec:
         image: nginx:latest
         securityContext:
           allowPrivilegeEscalation: false
+        # Only report ready once nginx actually serves HTTPS on 443. Without
+        # this, numberReady=1 (and the rollout wait in action.sh) can succeed
+        # while nginx is still starting up, so the first L7 TLS-interception
+        # requests race the warm-up and get a connection refused or a transient
+        # 503 from nginx. An HTTPS GET probe exercises the same serving path the
+        # tests use (kubelet skips cert verification for scheme: HTTPS) and only
+        # passes on a 2xx/3xx response.
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 443
+            scheme: HTTPS
+          initialDelaySeconds: 1
+          periodSeconds: 2
+          failureThreshold: 15
         volumeMounts:
         - name: config
           mountPath: /etc/nginx/nginx.conf

--- a/.github/workflows/k8s-kind-network-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-e2e.yaml
@@ -338,7 +338,11 @@ jobs:
           job: "${{ env.job_name }}-${{ matrix.ipFamily }}"
 
       - name: Create Cilium JUnits Directory
-        if: ${{ steps.install-cilium.outcome != 'skipped' }}
+        # always() so the JUnit report produced by the sig-network run is moved
+        # into place (and uploaded by the common post steps) even when the tests
+        # fail, which is exactly when the report is needed to know which spec
+        # failed.
+        if: ${{ always() && steps.install-cilium.outcome != 'skipped' && steps.run-tests.outcome != 'skipped' }}
         run: |
           # Move the all artifacts to cilium-junits directory since that's the
           # directory used in the common post steps.

--- a/.github/workflows/k8s-kind-network-policies-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-policies-e2e.yaml
@@ -299,7 +299,11 @@ jobs:
           done
 
       - name: Create Cilium JUnits Directory
-        if: ${{ steps.install-cilium.outcome != 'skipped' }}
+        # always() so the JUnit report produced by the sig-network run is moved
+        # into place (and uploaded by the common post steps) even when the tests
+        # fail, which is exactly when the report is needed to know which spec
+        # failed.
+        if: ${{ always() && steps.install-cilium.outcome != 'skipped' && steps.run-tests.outcome != 'skipped' }}
         run: |
           # Move the all artifacts to cilium-junits directory since that's the
           # directory used in the common post steps.


### PR DESCRIPTION
Two CI infrastructure fixes for recurring flakes.

The generic external nginx target (used by Conformance KPR AKS and GKE) had no
readiness probe, so the connectivity suite could start before nginx was serving
HTTPS, and the first `pod-to-world-with-tls-intercept` requests raced the
warm-up and got a transient 503. Add an HTTPS GET readiness probe on 443 so the
existing rollout/`numberReady` waits block until nginx actually serves
requests.

The K8s Network (Policy) E2E workflows moved the ginkgo JUnit report into place
with a step that lacked `always()`, so GitHub skipped it whenever the tests
failed - exactly when the report is needed. The report was therefore never
uploaded on failure and the failing spec could not be identified. Guard the
step with `always()` so the report is uploaded on failure.

This PR was prepared with AIL:3. I personally reviewed each change.

```release-note
CI: fixed external-target readiness gating and ensured sig-network E2E JUnit reports are uploaded on failure.
```
