### PR TITLE
datapath/linux/config: fix IPV4_DIRECT_ROUTING selection on lo device

### DIFF
--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -367,13 +367,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *config.Config) erro
 	drd := cfg.DirectRoutingDevice
 	if drd != nil {
 		if option.Config.EnableIPv4 {
-			var ipv4 uint32
-			for _, addr := range drd.Addrs {
-				if addr.Addr.Is4() {
-					ipv4 = byteorder.NetIPAddrToHost32(addr.Addr)
-					break
-				}
-			}
+			ipv4 := preferredIPv4Address(drd.Addrs)
 			cDefinesMap["IPV4_DIRECT_ROUTING"] = fmt.Sprintf("%d", ipv4)
 		}
 		if option.Config.EnableIPv6 {
@@ -645,6 +639,17 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, e endpoint.Conf
 func (h *HeaderfileWriter) WriteTemplateConfig(w io.Writer, e endpoint.Config) error {
 	fw := bufio.NewWriter(w)
 	return h.writeTemplateConfig(fw, e)
+}
+
+func preferredIPv4Address(deviceAddresses []tables.DeviceAddress) uint32 {
+	var ip uint32
+	for _, addr := range tables.SortedAddresses(deviceAddresses) {
+		if addr.Addr.Is4() {
+			ip = byteorder.NetIPAddrToHost32(addr.Addr)
+			break
+		}
+	}
+	return ip
 }
 
 func preferredIPv6Address(deviceAddresses []tables.DeviceAddress) netip.Addr {

--- a/pkg/datapath/linux/config/config_test.go
+++ b/pkg/datapath/linux/config/config_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 
+	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath/config"
 	dpdef "github.com/cilium/cilium/pkg/datapath/linux/config/defines"
@@ -366,6 +367,16 @@ func TestPrivilegedWriteNodeConfigExtraDefines(t *testing.T) {
 		return nil
 	})
 	require.NoError(t, err)
+}
+
+func TestPreferredIPv4Address(t *testing.T) {
+	// Verify that the v4 address is picked over the v6 one. Ordering is
+	// already covered by tables.TestSortedAddresses.
+	devices := []tables.DeviceAddress{
+		{Addr: netip.MustParseAddr("2600:1900:4001:2a1:0:2::")},
+		{Addr: netip.MustParseAddr("10.0.0.1")},
+	}
+	require.Equal(t, byteorder.NetIPAddrToHost32(netip.MustParseAddr("10.0.0.1")), preferredIPv4Address(devices))
 }
 
 func TestPreferredIPv6Address(t *testing.T) {


### PR DESCRIPTION
When the node's IPv4 address is carried on the loopback device (possible since #31200), IPV4_DIRECT_ROUTING could be set to 127.0.0.1 instead of the node's actual IP. The address list on lo typically holds 127.0.0.1/8 (scope host) before the real node IP (scope global), and the previous code picked the first IPv4 address without regard to scope:

    for _, addr := range drd.Addrs {
        if addr.Is4() { ... break }
    }

With loadBalancer.Mode=snat this rewrote the source IP of SNATed packets to 127.0.0.1, a non-routable address, breaking load balancing entirely.

Select the IPv4 direct routing address through the existing tables.SortedAddresses() helper, which orders by primary status, scope (UNIVERSE before HOST), public-before-private and finally address value. The loopback address (scope host) is therefore ranked below the real node IP.

This PR was prepared with AIL:2 for the unit test. I personally reviewed it.

This is a bug fix affecting v1.18.x, should be backported if applicable / to supported branches.

Fixes: #46830 