### PR TITLE
networkdriver/ipam: Fix incorrect prealloc flag description

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -415,7 +415,7 @@ cilium-agent [flags]
       --proxy-xff-num-trusted-hops-egress uint32                  Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the egress L7 policy enforcement Envoy listeners.
       --proxy-xff-num-trusted-hops-ingress uint32                 Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the ingress L7 policy enforcement Envoy listeners.
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
-      --resource-ipam-multi-pool-pre-allocation stringToString    Defines the minimum number of IPs for DRA resources a node should pre-allocate from each pool (default default=8) (default [])
+      --resource-ipam-multi-pool-pre-allocation stringToString    Defines the minimum number of IPs for DRA resources a node should pre-allocate from each pool (default [])
       --restored-proxy-ports-age-limit uint                       Time after which a restored proxy ports file is considered stale (in minutes) (default 15)
       --route-metric int                                          Overwrite the metric used by cilium when adding routes to its 'cilium_host' device
       --routing-mode string                                       Routing mode ("native" or "tunnel") (default "tunnel")

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -263,7 +263,7 @@ cilium-agent hive [flags]
       --proxy-xff-num-trusted-hops-egress uint32                  Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the egress L7 policy enforcement Envoy listeners.
       --proxy-xff-num-trusted-hops-ingress uint32                 Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the ingress L7 policy enforcement Envoy listeners.
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
-      --resource-ipam-multi-pool-pre-allocation stringToString    Defines the minimum number of IPs for DRA resources a node should pre-allocate from each pool (default default=8) (default [])
+      --resource-ipam-multi-pool-pre-allocation stringToString    Defines the minimum number of IPs for DRA resources a node should pre-allocate from each pool (default [])
       --restored-proxy-ports-age-limit uint                       Time after which a restored proxy ports file is considered stale (in minutes) (default 15)
       --shell-sock-path string                                    Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --standalone-dns-proxy-server-port int                      Global port on which the gRPC server for standalone DNS proxy should listen (default 10095)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -268,7 +268,7 @@ cilium-agent hive dot-graph [flags]
       --proxy-xff-num-trusted-hops-egress uint32                  Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the egress L7 policy enforcement Envoy listeners.
       --proxy-xff-num-trusted-hops-ingress uint32                 Number of trusted hops regarding the x-forwarded-for and related HTTP headers for the ingress L7 policy enforcement Envoy listeners.
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
-      --resource-ipam-multi-pool-pre-allocation stringToString    Defines the minimum number of IPs for DRA resources a node should pre-allocate from each pool (default default=8) (default [])
+      --resource-ipam-multi-pool-pre-allocation stringToString    Defines the minimum number of IPs for DRA resources a node should pre-allocate from each pool (default [])
       --restored-proxy-ports-age-limit uint                       Time after which a restored proxy ports file is considered stale (in minutes) (default 15)
       --shell-sock-path string                                    Path to the shell UNIX socket (default "/var/run/cilium/shell.sock")
       --standalone-dns-proxy-server-port int                      Global port on which the gRPC server for standalone DNS proxy should listen (default 10095)

--- a/pkg/networkdriver/ipam.go
+++ b/pkg/networkdriver/ipam.go
@@ -4,7 +4,6 @@
 package networkdriver
 
 import (
-	"fmt"
 	"log/slog"
 
 	"github.com/cilium/hive/cell"
@@ -13,7 +12,6 @@ import (
 
 	daemonK8s "github.com/cilium/cilium/daemon/k8s"
 	driverIPAM "github.com/cilium/cilium/operator/pkg/networkdriver/ipam"
-	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/ipam"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -58,7 +56,7 @@ var defaultIPAMConfig = IPAMConfig{}
 
 func (cfg IPAMConfig) Flags(flags *pflag.FlagSet) {
 	flags.StringToString(ResourceIPAMMultiPoolPreAllocation, cfg.ResourceIPAMMultiPoolPreAllocation,
-		fmt.Sprintf("Defines the minimum number of IPs for DRA resources a node should pre-allocate from each pool (default %s=8)", defaults.IPAMDefaultIPPool))
+		"Defines the minimum number of IPs for DRA resources a node should pre-allocate from each pool")
 }
 
 func newMultiPoolManager(


### PR DESCRIPTION
Differently from the CiliumPodIPPool counterpart, the --resource-ipam-multi-pool-pre-allocation does not have a default value. In other words, there is no preallocation for the default pool. Fix the flag description accordingly.