### PR TITLE
gha/scale: fix scale-5/scale-100 GCE (kops zone + workload node join)

### DIFF
--- a/.github/workflows/scale-test-100-gce.yaml
+++ b/.github/workflows/scale-test-100-gce.yaml
@@ -340,7 +340,7 @@ jobs:
             2>&1 | tee cl2-setup.txt
 
       - name: Create Instance Group for workload deployments
-        uses: cilium/scale-tests-action/create-instance-group@995a08156171644e92e5688b0785b7baf86ce22a # main
+        uses: cilium/scale-tests-action/create-instance-group@688f70c8708f4bdd2ef04ad7710d35aaea1ea57c # main
         timeout-minutes: 30
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}

--- a/.github/workflows/scale-test-5-gce.yaml
+++ b/.github/workflows/scale-test-5-gce.yaml
@@ -307,7 +307,7 @@ jobs:
             2>&1 | tee cl2-setup.txt
 
       - name: Create Instance Group for workload deployments
-        uses: cilium/scale-tests-action/create-instance-group@995a08156171644e92e5688b0785b7baf86ce22a # main
+        uses: cilium/scale-tests-action/create-instance-group@688f70c8708f4bdd2ef04ad7710d35aaea1ea57c # main
         timeout-minutes: 30
         with:
           cluster_name: ${{ steps.vars.outputs.cluster_name }}

--- a/.github/workflows/scale-test-5-gce.yaml
+++ b/.github/workflows/scale-test-5-gce.yaml
@@ -380,8 +380,11 @@ jobs:
         if: ${{ always() && steps.install-cilium.outcome != 'skipped' }}
         uses: ./.github/actions/post-logic
         with:
-          capture_sysdump: "${{ steps.install-cilium.outcome != 'skipped' && steps.install-cilium.outcome != 'cancelled' }}"
-          artifacts_suffix: "${{ env.job_name }}"
+          # The export step below uploads cilium-sysdump-final.zip to GCS on
+          # every run, so the sysdump has to be captured regardless of status
+          # and named "final" to match. Mirrors the node-throughput workflow.
+          always_capture_sysdump: true
+          artifacts_suffix: "final"
           job_status: "${{ job.status }}"
           capture_features_tested: ${{ steps.run-cl2.outcome != 'skipped' }}
 

--- a/.github/workflows/scale-test-5-gce.yaml
+++ b/.github/workflows/scale-test-5-gce.yaml
@@ -348,6 +348,16 @@ jobs:
           CL2_PROMETHEUS_SCRAPE_CILIUM_OPERATOR: "true"
           CL2_PROMETHEUS_SCRAPE_CILIUM_AGENT: "true"
           CL2_PROMETHEUS_MEMORY_SCALE_FACTOR: 2.0
+          # On a 5 node cluster the agent load concentrates on few agents, so
+          # the median agent CPU sits higher than the shared 0.1 default (which
+          # is tuned for the 100 node test). Raise it for this environment.
+          CL2_MEDIAN_CPU_USAGE_THRESHOLD: "0.3"
+          # The LB-IPAM module defaults to 50k services created within a 3m
+          # window (~278/s). The CL2 client rate limiter caps creation far below
+          # that here, so only ~8k get created before the window closes and the
+          # rest time out. Right size the count to what a 5 node cluster can
+          # create within the window while still exercising the operator.
+          CL2_LBIPAM_NUM_SYNTHETIC_SERVICES: "5000"
         run: |
           ./clusterloader \
             -v=2 \


### PR DESCRIPTION
scale-5 and scale-100 have been failing on every run since around March. This gets scale-5 green again and unblocks scale-100 at the same failure point.

There were three separate problems, one commit each.

**1. Instance group creation + workload node join.** The "Create Instance Group for workload deployments" step died with:

    Error: zone flag is required for GCE clusters

kops v1.35 no longer lets us run `kops create ig` on a GCE cluster without a zone set up front. Once that was fixed, the run got further but the workload nodes never joined: the workloads instance group was created with `associatePublicIP=false`, and the kops GCE setup here has no Cloud NAT and no Private Google Access, so those nodes had no way to reach the state store on GCS to bootstrap. Only the control plane and the base node group, which keep their public IPs, came up. The two GCE scale tests that don't create a workloads group (node-throughput, clustermesh) have kept passing, which lines up with this.

Both fixes now live on `cilium/scale-tests-action` main: `79aec7cb9f69` (specify zone) and `688f70c8708f` (give workload nodes a public IP again). This pins both GCE workflows to `688f70c8`, the current main HEAD carrying both.

**2. scale-5 CL2 thresholds.** With the cluster finally reaching CL2, the load test tripped the Cilium agent median CPU (~0.16 against the 0.1 `CL2_MEDIAN_CPU_USAGE_THRESHOLD` default), and the LB-IPAM test timed out. The CPU default is shared with the 100 node test and is fine there; on 5 nodes the same workload concentrates on far fewer agents, so per-agent CPU is legitimately higher (memory, cardinality and watch counts all pass with room to spare). The LB-IPAM test asks for 50k services in a 3m window, but the CL2 client rate limiter throttles creation well below that, so only ~8k get created before the window closes and the rest time out; the operator itself keeps up fine (upsert p99 ~25ms). Both are overridden for scale-5 only, leaving the shared defaults untouched: CPU threshold to 0.3, synthetic services to 5k.

**3. sysdump export.** The export step always uploads `cilium-sysdump-final.zip`, but on a passing run nothing produced it: post-logic only captured a sysdump on failure and named it after the job. So once the test itself started passing, gsutil failed the export with "No URLs matched". Match the node-throughput workflow: capture the sysdump on every run and name it `final`.

scale-100 shares problem 1 (it dies at the same "Create Instance Group" step), so it is re-pinned too. Problems 2 and 3 are scale-5 specific: scale-100 doesn't run the LB-IPAM module, its 100 node CPU sits under the shared threshold, and it already captures `cilium-sysdump-final.zip`.

This PR was prepared with AIL:3.
