### PR TITLE
ipam/multi-pool: Do now wait for zero prealloc request

### DIFF
--- a/pkg/ipam/multipool_manager.go
+++ b/pkg/ipam/multipool_manager.go
@@ -359,7 +359,8 @@ func newMultiPoolManager(p MultiPoolManagerParams) *multiPoolManager {
 	return mgr
 }
 
-// waitForAllPools waits for all pools in preallocatedIPsPerPool to have IPs available.
+// waitForAllPools waits for all pools with a non-zero preallocation request
+// in preallocatedIPsPerPool to have IPs available.
 // This function blocks the IPAM constructor forever and periodically logs
 // that it is waiting for IPs to be assigned. This blocking behavior is
 // consistent with other IPAM modes.
@@ -367,7 +368,11 @@ func (m *multiPoolManager) waitForAllPools() {
 	allPoolsReady := false
 	for !allPoolsReady {
 		allPoolsReady = true
-		for pool := range m.preallocatedIPsPerPool {
+		for pool, request := range m.preallocatedIPsPerPool {
+			if request == 0 {
+				continue
+			}
+
 			ctx, cancel := context.WithTimeout(context.Background(), waitForPoolTimeout)
 			if m.ipv4Enabled {
 				allPoolsReady = m.waitForPool(ctx, IPv4, pool) && allPoolsReady

--- a/pkg/ipam/multipool_test.go
+++ b/pkg/ipam/multipool_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/netip"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"testing/synctest"
@@ -1476,6 +1477,43 @@ func TestMultiPoolManagerUpdatesFirstLastIPSettingsBeforeAllocation(t *testing.T
 	result, err := mgr.allocateIP(lastIP, "pod-a", "default", IPv4, false)
 	require.NoError(t, err)
 	require.Equal(t, lastIP, result.IP)
+}
+
+func TestMultiPoolManagerWaitForAllPools(t *testing.T) {
+	poolA, poolB := Pool("pool-a"), Pool("pool-b")
+
+	synctest.Test(t, func(t *testing.T) {
+		mgr := &multiPoolManager{
+			logger:                 hivetest.Logger(t),
+			ipv4Enabled:            true,
+			preallocatedIPsPerPool: preAllocatePerPool{poolA: 8, poolB: 0},
+			pools:                  map[Pool]*poolPair{},
+			poolsUpdated:           make(chan struct{}, 1),
+		}
+
+		var wg sync.WaitGroup
+		wg.Go(func() {
+			mgr.waitForAllPools()
+		})
+
+		// wait until waitForAllPools is blocked on poolA
+		synctest.Wait()
+
+		// unblock waitForAllPools by adding poolA, but not poolB (which has zero preallocation)
+		mgr.poolsMutex.Lock()
+		mgr.upsertPoolLocked(poolA, []iputil.Prefix{
+			iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.0/30")),
+		}, false, false)
+		mgr.poolsMutex.Unlock()
+
+		// wait for waitForAllPools to unblock
+		wg.Wait()
+
+		mgr.poolsMutex.Lock()
+		require.Contains(t, mgr.pools, poolA)
+		require.NotContains(t, mgr.pools, poolB)
+		mgr.poolsMutex.Unlock()
+	})
 }
 
 func Test_multiPoolManager_staticIPStatus(t *testing.T) {


### PR DESCRIPTION
Multi-pool IPAM supports preallocating addresses at startup via an optional map. Each map entry specifies how many addresses should be preallocated for a pool. In case the request is zero, that is, no preallocation should take place for that pool, the manager still tries to wait for at least one address from the pool to be available, ultimately blocking the agent forever.

Fix the manager excluding pools with a zero preallocation request from the startup wait.
