### PR TITLE
github: reinstall Cilium with the same chart

### DIFF
--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -248,7 +248,7 @@ jobs:
       - name: Install Cilium with secret sync disabled
         id: install-cilium-secret-sync-disabled
         run: |
-          helm upgrade cilium ./install/kubernetes/cilium \
+          helm upgrade cilium untrusted/install/kubernetes/cilium \
             --namespace kube-system \
             --reuse-values \
             --set=tls.readSecretsOnlyFromSecretsNamespace=false \


### PR DESCRIPTION
Use the same chart that was used in install in the reinstall.

This avoids the problem where the values used in the original install would not be accepted by the outdated charts, e.g.:

Run helm upgrade cilium ./install/kubernetes/cilium \ Error: UPGRADE FAILED: values don't meet the specifications of the schema(s) in the following chart(s): cilium:
- at '/envoy/xdsMode': value must be one of '', 'split', 'ads', 'strict-ads'

Fixes: #36040

```release-note
Use correct helm chart in reinstall step in conformance-kind-proxy-embedded workflow.
```
