### PR TITLE
ciliumenvoyconfig: sort envoy-resources table endpoints

### DIFF
--- a/pkg/ciliumenvoyconfig/tables.go
+++ b/pkg/ciliumenvoyconfig/tables.go
@@ -267,7 +267,7 @@ func (*EnvoyResource) TableHeader() []string {
 }
 
 func (r *EnvoyResource) showListeners() string {
-	return strings.Join(slices.Collect(maps.Keys(r.Resources.Listeners)), ", ")
+	return strings.Join(slices.Sorted(maps.Keys(r.Resources.Listeners)), ", ")
 }
 
 func (r *EnvoyResource) showEndpoints() string {
@@ -287,6 +287,8 @@ func (r *EnvoyResource) showEndpoints() string {
 		out = append(out,
 			la.ClusterName+": "+strings.Join(addrs, ", "))
 	}
+	// Endpoints is a map, so sort for a stable rendering.
+	slices.Sort(out)
 	return strings.Join(out, ", ")
 }
 

--- a/pkg/ciliumenvoyconfig/testdata/clusterwide.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/clusterwide.txtar
@@ -63,7 +63,7 @@ Name                  Selected  Services    Listeners
 
 -- envoy-resources.table --
 Name                       Listeners                                  Endpoints                                          References             Status   Error
-backendsync:test/echo2                                                test/echo2:*: 10.244.1.2, test/echo2: 10.244.1.2   /envoy-lb-listener-2   Done     
+backendsync:test/echo2                                                test/echo2: 10.244.1.2, test/echo2:*: 10.244.1.2   /envoy-lb-listener-2   Done
 cec:/envoy-lb-listener-2   /envoy-lb-listener-2/envoy-lb-listener-2                                                                             Done     
 
 -- envoy-resources-no-backends.table --


### PR DESCRIPTION
`showEndpoints` ranges over the `Endpoints` map, so the rendered order was
nondeterministic and flaked `TestScript/clusterwide.txtar`. Sort the output
(and the listeners, which have the same issue) for a stable rendering.

Fixes: 062d1f2a2074 ("ciliumenvoyconfig: Headless services rewrite")

This PR was prepared with AIL:3. I personally verified the fix by running the affected test with -count.
