### PR TITLE
cli/features: retry ExecInPod on transient exec-proxy errors

### DIFF
--- a/cilium-cli/features/status.go
+++ b/cilium-cli/features/status.go
@@ -4,6 +4,7 @@
 package features
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -12,6 +13,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,7 +38,53 @@ const (
 	kubeProxyDaemonSetName    = "kube-proxy"
 
 	clusterWide = "cluster-wide"
+
+	// featureExecRetries is the number of attempts for each ExecInPod call, to
+	// tolerate transient Kubernetes API server exec-proxy errors (e.g. spurious
+	// "502 Bad Gateway" responses while dialing the kubelet backend, commonly
+	// observed on managed clusters such as AKS) and truncated (empty) exec
+	// responses that report success but return no output.
+	featureExecRetries = 3
 )
+
+// errEmptyExecOutput is returned by retryTransientExec when ExecInPod keeps
+// reporting success while returning an empty output stream. Surfacing it
+// explicitly avoids the opaque "unexpected end of JSON input" error that
+// nodeStatusFromOutput would otherwise emit when parsing the empty output.
+var errEmptyExecOutput = errors.New("exec returned empty output")
+
+// featureExecRetryBackoff is the delay between ExecInPod retries. It is a
+// variable rather than a constant so that tests can shorten it.
+var featureExecRetryBackoff = 2 * time.Second
+
+// transientExecErrorSubstrings are error message fragments that indicate a
+// transient failure of the Kubernetes API server -> kubelet exec proxy rather
+// than a genuine failure of the executed command, and are therefore worth
+// retrying. They are intentionally specific to the exec-proxy tunnel so that
+// benign command stderr (e.g. cilium-operator "level=debug" log lines, which
+// are tolerated by fetchCiliumOperatorFeatureMetricsFromPod) is not mistaken
+// for a transient error and needlessly retried.
+var transientExecErrorSubstrings = []string{
+	"error dialing backend",
+	"unable to upgrade connection",
+	"Bad Gateway",         // HTTP 502
+	"Service Unavailable", // HTTP 503
+	"Gateway Timeout",     // HTTP 504
+	"TLS handshake timeout",
+}
+
+// isTransientExecError reports whether err looks like a transient failure of
+// the API server exec proxy, as opposed to a genuine failure of the command
+// that was executed in the pod.
+func isTransientExecError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return slices.ContainsFunc(transientExecErrorSubstrings, func(substr string) bool {
+		return strings.Contains(msg, substr)
+	})
+}
 
 // detectClusterWideComponents detects cluster-wide components like kube-proxy and local-node-dns
 // and returns them as metrics with specific names
@@ -246,9 +294,58 @@ func (s *Feature) fetchStatusConcurrently(ctx context.Context, pods []corev1.Pod
 	return data, err
 }
 
+// execInPodWithRetry execs the given command in the pod, retrying up to
+// featureExecRetries times when the failure looks like a transient error of the
+// API server exec proxy (see isTransientExecError) or when exec reports success
+// but returns no output. Genuine command failures are returned immediately,
+// without retrying.
+func (s *Feature) execInPodWithRetry(ctx context.Context, namespace, pod, container string, command []string) (bytes.Buffer, error) {
+	return retryTransientExec(ctx, func(ctx context.Context) (bytes.Buffer, error) {
+		return s.client.ExecInPod(ctx, namespace, pod, container, command)
+	})
+}
+
+// retryTransientExec invokes exec, retrying up to featureExecRetries times with
+// featureExecRetryBackoff between attempts while the result looks transient:
+// either a transient exec-proxy error (see isTransientExecError) or a success
+// with empty output. The latter happens when the API server exec proxy
+// truncates the response stream and returns no data with a nil error; a healthy
+// features-status command always prints at least an empty JSON array, so an
+// empty output is never a legitimate result and is worth retrying. It returns as
+// soon as exec succeeds with non-empty output, returns a non-transient error, or
+// the context is done. When exec keeps returning empty output until the attempts
+// are exhausted, it returns errEmptyExecOutput rather than letting the caller
+// fail later with an opaque JSON parse error.
+func retryTransientExec(ctx context.Context, exec func(context.Context) (bytes.Buffer, error)) (bytes.Buffer, error) {
+	var output bytes.Buffer
+	var err error
+	for attempt := range featureExecRetries {
+		output, err = exec(ctx)
+		if err != nil {
+			if !isTransientExecError(err) {
+				return output, err
+			}
+		} else if output.Len() > 0 {
+			return output, nil
+		} else {
+			// Success with empty output: treat as transient and, if this was
+			// the last attempt, surface an explicit error.
+			err = errEmptyExecOutput
+		}
+		if attempt < featureExecRetries-1 {
+			select {
+			case <-ctx.Done():
+				return output, ctx.Err()
+			case <-time.After(featureExecRetryBackoff):
+			}
+		}
+	}
+	return output, err
+}
+
 func (s *Feature) fetchCiliumFeatureMetricsFromPod(ctx context.Context, pod corev1.Pod) ([]*models.Metric, error) {
 	agentCmd := append([]string{"cilium"}, subCmdMetricsList...)
-	output, err := s.client.ExecInPod(ctx, pod.Namespace, pod.Name, defaults.AgentContainerName, agentCmd)
+	output, err := s.execInPodWithRetry(ctx, pod.Namespace, pod.Name, defaults.AgentContainerName, agentCmd)
 	if err != nil {
 		return nil, fmt.Errorf("failed to features status from %s: %w", pod.Name, err)
 	}
@@ -268,7 +365,7 @@ func (s *Feature) fetchCiliumOperatorFeatureMetricsFromPod(ctx context.Context, 
 		}
 	}
 	operatorCmds := append([]string{operatorCmd}, subCmdMetricsList...)
-	output, err := s.client.ExecInPod(ctx, pod.Namespace, pod.Name, defaults.OperatorContainerName, operatorCmds)
+	output, err := s.execInPodWithRetry(ctx, pod.Namespace, pod.Name, defaults.OperatorContainerName, operatorCmds)
 	if err != nil && !strings.Contains(err.Error(), "level=debug") {
 		return []*models.Metric{}, fmt.Errorf("failed to get features status from %s: %w", pod.Name, err)
 	}


### PR DESCRIPTION
`cilium features status` execs into every cilium-agent and operator pod through the kube-apiserver -> kubelet exec proxy. On managed clusters (observed on AKS) that proxy is occasionally unreliable in two ways: it can return a spurious "502 Bad Gateway" / "error dialing backend" while dialing the kubelet backend, and it can truncate the response stream and report success with no output at all. Either way the capture fails, because `fetchStatusConcurrently` joins any single pod's error and `PrintFeatureStatus` then bails, and an empty output leaves `nodeStatusFromOutput` to fail with an opaque "unexpected end of JSON input". Since this runs as an `always()` post step for the GitHub job summary and the features-tested artifact, a transient blip turns an otherwise green conformance job red without any real test failure.

This wraps the two per-pod `ExecInPod` calls in a retry that mirrors the existing retry in `connectivity/sniff`. It retries only on transient exec-proxy errors and on a success with empty output (a healthy features-status command always prints at least an empty JSON array, so empty output is never a legitimate result). Genuine command failures still return immediately, and the substring list is kept specific to the proxy tunnel so the operator's tolerated `level=debug` stderr is not needlessly retried.

The all-or-nothing behaviour is kept on purpose: if a pod still fails after retries the whole command fails rather than reporting a partial feature status.

This PR was prepared with AIL:3. I reviewed the change and the failure analysis.

```release-note
cilium-cli: retry `cilium features status` pod exec on transient API server exec-proxy failures (e.g. 502 Bad Gateway, or a truncated empty response) so CI post-steps are not failed by transient infrastructure blips.
```
