### PR TITLE
Makefile.kind: give kvstore readiness wait an explicit timeout

### DIFF
--- a/Makefile.kind
+++ b/Makefile.kind
@@ -471,7 +471,7 @@ kind-kvstore-start: ## Start an etcd pod serving as Cilium's kvstore
 			--overrides='{ "apiVersion": "v1", "spec": { "hostNetwork": true, "nodeSelector": {"node-role.kubernetes.io/control-plane": ""},  "tolerations": [{ "operator": "Exists" }] }}' \
 			-- etcd --listen-client-urls=http://0.0.0.0:$(KVSTORE_POD_PORT) --advertise-client-urls=http://0.0.0.0:$(KVSTORE_POD_PORT)
 
-	kubectl --namespace kube-system wait --for=condition=Ready pod/$(KVSTORE_POD_NAME)
+	kubectl --namespace kube-system wait --for=condition=Ready pod/$(KVSTORE_POD_NAME) --timeout=300s
 
 .PHONY: kind-kvstore-stop
 kind-kvstore-stop: ## Stop the etcd pod serving as Cilium's kvstore


### PR DESCRIPTION
kind-kvstore-start creates the etcd pod and then runs

    kubectl --namespace kube-system wait --for=condition=Ready pod/kvstore

with no --timeout, so it inherits kubectl's 30s default. The etcd image is pulled from gcr.io/etcd-development at pod-run time rather than being preloaded into kind, so when that pull takes longer than 30s the wait fails while the container is still ContainerCreating, even though the enclosing GitHub step has a 5m timeout:

    pod/kvstore created
    kubectl ... wait --for=condition=Ready pod/kvstore
    error: timed out waiting for the condition on pods/kvstore
    container "kvstore" in pod "kvstore" is waiting to start: ContainerCreating

This tripped the "Start Cilium KVStore" step in a conformance-multi-pool run. Give the wait an explicit --timeout=300s so a slow image pull no longer flakes the step; --for=condition=Ready already covers the full ContainerCreating -> Running -> Ready progression and returns as soon as the pod is ready, so fast starts are unaffected. The same target backs the kvstore step in conformance-multi-pool, conformance-ipsec-e2e and tests-e2e-upgrade, so all three benefit.

```release-note
Increase the timeout for the kvstore readiness wait in kind-based CI to avoid flakes on slow etcd image pulls.
```

Seen in https://github.com/cilium/cilium/actions/runs/28646624541/job/84954704111#step:13:1