### PR TITLE
cilium-cli/connectivity: retry curl with backoff in L7-proxy expected-OK tests

### DIFF
--- a/cilium-cli/connectivity/builder/client_egress_l7_method.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_method.go
@@ -39,8 +39,8 @@ func clientEgressL7MethodTest(ct *check.ConnectivityTest, templates map[string]s
 		WithCiliumPolicy(templates["clientEgressOnlyDNSPolicyYAML"]). // DNS resolution only
 		WithCiliumPolicy(yamlFile).                                   // L7 allow policy with HTTP introspection (POST only)
 		WithScenarios(
-			tests.PodToPodWithEndpoints(tests.WithMethod("POST"), tests.WithDestinationLabelsOption(map[string]string{"other": "echo"})),
-			tests.PodToPodWithEndpoints(tests.WithDestinationLabelsOption(map[string]string{"first": "echo"})),
+			tests.PodToPodWithEndpoints(tests.WithMethod("POST"), tests.WithDestinationLabelsOption(map[string]string{"other": "echo"}), tests.WithRetryCondition(tests.WithRetryAll())),
+			tests.PodToPodWithEndpoints(tests.WithDestinationLabelsOption(map[string]string{"first": "echo"}), tests.WithRetryCondition(tests.WithRetryAll())),
 		).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			if a.Source().HasLabel("other", "client") && // Only client2 is allowed to make HTTP calls.

--- a/cilium-cli/connectivity/builder/client_egress_l7_tls_headers.go
+++ b/cilium-cli/connectivity/builder/client_egress_l7_tls_headers.go
@@ -38,7 +38,6 @@ func clientEgressL7TlsHeadersTest(ct *check.ConnectivityTest, templates map[stri
 		WithScenarios(tests.PodToWorldWithTLSIntercept(
 			"-H", "X-Very-Secret-Token: 42",
 			"--retry", "5",
-			"--retry-delay", "0",
 			"--retry-all-errors")).
 		WithExpectations(func(_ *check.Action) (egress, ingress check.Result) {
 			return check.ResultOK, check.ResultNone
@@ -61,7 +60,6 @@ func clientEgressL7ExtraTlsHeadersTest(ct *check.ConnectivityTest, templates map
 			"externaltarget-tls",
 			"-H", "X-Very-Secret-Token: 42",
 			"--retry", "5",
-			"--retry-delay", "0",
 			"--retry-all-errors")).
 		WithExpectations(func(_ *check.Action) (egress, ingress check.Result) {
 			return check.ResultOK, check.ResultNone

--- a/cilium-cli/connectivity/builder/client_egress_tls_sni.go
+++ b/cilium-cli/connectivity/builder/client_egress_tls_sni.go
@@ -212,7 +212,6 @@ func clientEgressL7TlsSniTest(ct *check.ConnectivityTest, templates map[string]s
 		WithScenarios(tests.PodToWorldWithTLSIntercept(
 			"-H", "X-Very-Secret-Token: 42",
 			"--retry", "5",
-			"--retry-delay", "0",
 			"--retry-all-errors")).
 		WithExpectations(func(a *check.Action) (egress, ingress check.Result) {
 			return check.ResultOK, check.ResultNone

--- a/cilium-cli/connectivity/builder/echo_ingress_l7.go
+++ b/cilium-cli/connectivity/builder/echo_ingress_l7.go
@@ -39,7 +39,7 @@ func (t echoIngressL7) build(ct *check.ConnectivityTest, templates map[string]st
 	newTest("echo-ingress-l7", ct).
 		WithFeatureRequirements(features.RequireEnabled(features.L7Proxy)).
 		WithCiliumPolicy(echoIngressL7HTTPPolicyYAML). // L7 allow policy with HTTP introspection
-		WithScenarios(tests.PodToPodWithEndpoints()).
+		WithScenarios(tests.PodToPodWithEndpoints(tests.WithRetryCondition(tests.WithRetryAll()))).
 		WithExpectations(expectation)
 
 	newTest("echo-ingress-l7-via-hostport", ct).


### PR DESCRIPTION
This PR reduces flakiness in the L7-proxy expected-OK connectivity tests, which curl an external target through the DNS proxy and Envoy TLS interception and can race the proxy warm-up.

The first two commits give client-egress-l7-method (and its port-range variant) and echo-ingress-l7 the same treatment the sibling L7 tests already have (client-egress-l7, client-egress-l7-named-port, client-egress-l7-set-header): WithRetryCondition(WithRetryAll()) so curl retries with --retry-all-errors. Those two tests drove PodToPodWithEndpoints with an expected-OK proxied action but no retry condition, so a real curl HTTP error (exit 22) from a transient Envoy warm-up 4xx/5xx failed the whole action on the first attempt. Two workflow_dispatch runs failed on a single transient POST to the echo pod while every sibling action in the same scenario passed:

    client-egress-l7-method/pod-to-pod-with-endpoints:curl-ipv6-0-private
    with-header ... command terminated with exit code 22

    client-egress-l7-method-port-range/pod-to-pod-with-endpoints:
    curl-ipv4-1-public ... command terminated with exit code 22

Expected-drop actions are unaffected: a policy-enforced HTTP drop (ResultDropCurlHTTPError) persists across retries, so curl still returns exit 22 and the assertion still holds.

The third commit fixes a related flake in three other expected-OK L7 TLS tests (client-egress-l7-tls-headers, client-egress-l7-extra-tls-headers, client-egress-l7-tls-headers-sni). They already pass --retry 5 --retry-all-errors, but also --retry-delay 0, which disables curl's exponential backoff, so all five attempts fire back to back within a fraction of a second and get spent inside the DNS-proxy / Envoy warm-up window, failing with exit 6 (could not resolve host) or a transient 503. These show up as pod-to-world flakes on ci-kpr-aks. Dropping --retry-delay 0 lets them use curl's default backoff (1s, then doubling), which rides out the warm-up. It only changes the spacing between the existing five attempts, not their number, so it cannot mask anything --retry-delay 0 was not already masking, and a successful request still returns immediately. The deny test keeps --retry-delay 0 on purpose: it expects an HTTP error, so backing off would make --retry-all-errors sit on the expected denial for the full retry window.

The remaining tests are intentionally left alone: the default-deny tests expect every action to drop (retry protects nothing), echo-ingress-l7-via-hostport uses PodToHostPort which takes no scenario options, and echo-ingress-from-client-tiered-wildcard-pass-l7 expects a curl timeout rather than a proxied HTTP success.

```release-note
Reduce flakiness of the L7-proxy connectivity tests (client-egress-l7-method, echo-ingress-l7, and the client-egress-l7-tls-headers family) by letting curl retry transient L7-proxy errors with backoff.
```