### PR TITLE
gateway-api: ignore redirect guard in route precedence

### DIFF
--- a/operator/pkg/model/translation/envoy_virtual_host.go
+++ b/operator/pkg/model/translation/envoy_virtual_host.go
@@ -76,10 +76,6 @@ func (s SortableRoute) Less(i, j int) bool {
 	// There are two types of prefix match, so get whichever one is bigger
 	prefixMatch1 := max(len(s[i].Match.GetPathSeparatedPrefix()), len(s[i].Match.GetPrefix()))
 	prefixMatch2 := max(len(s[j].Match.GetPathSeparatedPrefix()), len(s[j].Match.GetPrefix()))
-	headerMatch1 := len(s[i].Match.GetHeaders())
-	headerMatch2 := len(s[j].Match.GetHeaders())
-	queryMatch1 := len(s[i].Match.GetQueryParameters())
-	queryMatch2 := len(s[j].Match.GetQueryParameters())
 
 	// Next up, sort by prefix match length
 	if prefixMatch1 != prefixMatch2 {
@@ -101,12 +97,36 @@ func (s SortableRoute) Less(i, j int) bool {
 	}
 
 	// If that's the same, then sort by header length
+	headerMatch1 := countMatchingHeaders(s[i].Match.GetHeaders())
+	headerMatch2 := countMatchingHeaders(s[j].Match.GetHeaders())
 	if headerMatch1 != headerMatch2 {
 		return headerMatch1 > headerMatch2
 	}
 
 	// lastly, sort by query match length
+	queryMatch1 := len(s[i].Match.GetQueryParameters())
+	queryMatch2 := len(s[j].Match.GetQueryParameters())
 	return queryMatch1 > queryMatch2
+}
+
+// countMatchingHeaders returns the number of Gateway API header matches that
+// contribute to HTTPRoute precedence.
+func countMatchingHeaders(headers []*envoy_config_route_v3.HeaderMatcher) int {
+	count := 0
+	for _, header := range headers {
+		sm := header.GetStringMatch()
+		// Cilium adds an inverted X-Forwarded-Proto match to prevent redirect loops.
+		// Since this is an internal scheme redirect guard rather than a Gateway API
+		// header match, ignore it when counting headers for route precedence. Only
+		// Cilium-generated redirect guards set IgnoreCase here, which lets us
+		// distinguish them from user-defined X-Forwarded-Proto matches.
+		if header.Name == "X-Forwarded-Proto" && header.GetInvertMatch() && sm != nil && sm.IgnoreCase {
+			continue
+		}
+		count++
+	}
+
+	return count
 }
 
 func getMethod(headers []*envoy_config_route_v3.HeaderMatcher) *string {

--- a/operator/pkg/model/translation/envoy_virtual_host_test.go
+++ b/operator/pkg/model/translation/envoy_virtual_host_test.go
@@ -743,6 +743,105 @@ func Test_envoyHTTPRoutes(t *testing.T) {
 		require.NotNil(t, res[1].GetRoute())
 		require.Equal(t, "default:backend:31337", res[1].GetRoute().GetCluster())
 	})
+	t.Run("backend and redirect with same match preserve order after x-forwarded-proto guard", func(t *testing.T) {
+		httpRoutes := []model.HTTPRoute{
+			{
+				Name:      "Backend",
+				PathMatch: model.StringMatch{Prefix: "/"},
+				Backends: []model.Backend{
+					{
+						Name:      "backend",
+						Namespace: "default",
+						Port:      &model.BackendPort{Port: 31337},
+					},
+				},
+			},
+			{
+				Name:      "Redirect",
+				PathMatch: model.StringMatch{Prefix: "/"},
+				RequestRedirect: &model.HTTPRequestRedirectFilter{
+					Scheme:     ptr.To("https"),
+					Port:       ptr.To(int32(443)),
+					StatusCode: ptr.To(302),
+				},
+			},
+		}
+		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, true, 80, nil)
+		require.Len(t, res, 2)
+		sort.Stable(SortableRoute(res))
+		// Backend Route
+		require.NotNil(t, res[0])
+		require.Equal(t, "/", res[0].Match.GetPrefix())
+		require.Empty(t, res[0].Match.GetHeaders())
+		require.NotNil(t, res[0].GetRoute())
+		require.Equal(t, "default:backend:31337", res[0].GetRoute().GetCluster())
+		// Redirect Route
+		require.NotNil(t, res[1])
+		require.Equal(t, "/", res[1].Match.GetPrefix())
+		require.Len(t, res[1].Match.GetHeaders(), 1)
+		require.Equal(t, "X-Forwarded-Proto", res[1].Match.GetHeaders()[0].Name)
+		require.True(t, res[1].Match.GetHeaders()[0].InvertMatch)
+		require.Equal(t, "https", res[1].Match.GetHeaders()[0].GetStringMatch().GetExact())
+		require.NotNil(t, res[1].GetRedirect())
+		require.Equal(t, "https", res[1].GetRedirect().GetSchemeRedirect())
+		require.Equal(t, uint32(443), res[1].GetRedirect().PortRedirect)
+		require.Equal(t, envoy_config_route_v3.RedirectAction_FOUND, res[1].GetRedirect().ResponseCode)
+	})
+	t.Run("user x-forwarded-proto header contributes to route precedence", func(t *testing.T) {
+		httpRoutes := []model.HTTPRoute{
+			{
+				Name:      "Redirect",
+				PathMatch: model.StringMatch{Prefix: "/"},
+				RequestRedirect: &model.HTTPRequestRedirectFilter{
+					Scheme:     ptr.To("https"),
+					Port:       ptr.To(int32(443)),
+					StatusCode: ptr.To(302),
+				},
+			},
+			{
+				Name:      "Backend",
+				PathMatch: model.StringMatch{Prefix: "/"},
+				HeadersMatch: []model.KeyValueMatch{
+					{
+						Key:   "X-Forwarded-Proto",
+						Match: model.StringMatch{Exact: "https"},
+					},
+				},
+				Backends: []model.Backend{
+					{
+						Name:      "backend",
+						Namespace: "default",
+						Port:      &model.BackendPort{Port: 31337},
+					},
+				},
+			},
+		}
+
+		res := envoyHTTPRoutes(httpRoutes, []string{"*"}, true, 80, nil)
+		require.Len(t, res, 2)
+
+		sort.Stable(SortableRoute(res))
+
+		// Backend Route with user-defined X-Forwarded-Proto header.
+		require.NotNil(t, res[0])
+		require.Equal(t, "/", res[0].Match.GetPrefix())
+		require.Len(t, res[0].Match.GetHeaders(), 1)
+		require.Equal(t, "X-Forwarded-Proto", res[0].Match.GetHeaders()[0].Name)
+		require.False(t, res[0].Match.GetHeaders()[0].InvertMatch)
+		require.Equal(t, "https", res[0].Match.GetHeaders()[0].GetStringMatch().GetExact())
+		require.NotNil(t, res[0].GetRoute())
+		require.Equal(t, "default:backend:31337", res[0].GetRoute().GetCluster())
+
+		// Redirect Route with generated X-Forwarded-Proto guard.
+		require.NotNil(t, res[1])
+		require.Equal(t, "/", res[1].Match.GetPrefix())
+		require.Len(t, res[1].Match.GetHeaders(), 1)
+		require.Equal(t, "X-Forwarded-Proto", res[1].Match.GetHeaders()[0].Name)
+		require.True(t, res[1].Match.GetHeaders()[0].InvertMatch)
+		require.True(t, res[1].Match.GetHeaders()[0].GetStringMatch().GetIgnoreCase())
+		require.Equal(t, "https", res[1].Match.GetHeaders()[0].GetStringMatch().GetExact())
+		require.NotNil(t, res[1].GetRedirect())
+	})
 	t.Run("http route with CORS filter and no backend", func(t *testing.T) {
 		corsPolicy := toAny(&envoy_extensions_filters_http_cors_v3.CorsPolicy{
 			AllowOriginStringMatch: []*envoy_type_matcher_v3.StringMatcher{

--- a/operator/pkg/model/translation/gateway-api/testdata/httproute_redirect_same_match_order/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/httproute_redirect_same_match_order/cec-output.yaml
@@ -1,0 +1,129 @@
+metadata:
+  creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: same-namespace
+    uid: ""
+spec:
+  backendServices:
+  - name: infra-backend-v1
+    namespace: gateway-conformance-infra
+    number:
+    - "8080"
+  resources:
+  - '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    filterChains:
+    - filterChainMatch:
+        transportProtocol: raw_buffer
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            maxStreamDuration: 0s
+          httpFilters:
+          - name: envoy.filters.http.grpc_web
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+          - name: envoy.filters.http.grpc_stats
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+              emitFilterState: true
+              enableUpstreamStats: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig:
+            cidrRanges:
+            - addressPrefix: 10.0.0.0
+              prefixLen: 8
+            - addressPrefix: 172.16.0.0
+              prefixLen: 12
+            - addressPrefix: 192.168.0.0
+              prefixLen: 16
+            - addressPrefix: 127.0.0.1
+              prefixLen: 32
+            - addressPrefix: ::1
+              prefixLen: 128
+          rds:
+            routeConfigName: listener-insecure
+          statPrefix: listener-insecure
+          streamIdleTimeout: 300s
+          upgradeConfigs:
+          - upgradeType: websocket
+          useRemoteAddress: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: listener
+    socketOptions:
+    - description: Enable TCP keep-alive (default to enabled)
+      intValue: "1"
+      level: "1"
+      name: "9"
+    - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+      intValue: "10"
+      level: "6"
+      name: "4"
+    - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+      intValue: "5"
+      level: "6"
+      name: "5"
+    - description: TCP keep-alive probe max failures.
+      intValue: "10"
+      level: "6"
+      name: "6"
+  - '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    name: listener-insecure
+    virtualHosts:
+    - domains:
+      - '*'
+      name: '*'
+      routes:
+      - match:
+          pathSeparatedPrefix: /same-match
+        route:
+          cluster: gateway-conformance-infra:infra-backend-v1:8080
+          maxStreamDuration:
+            maxStreamDuration: 0s
+      - match:
+          pathSeparatedPrefix: /same-match
+          headers:
+          - invertMatch: true
+            name: X-Forwarded-Proto
+            stringMatch:
+              exact: https
+              ignoreCase: true
+        redirect:
+          portRedirect: 443
+          responseCode: FOUND
+          schemeRedirect: https
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    edsClusterConfig:
+      serviceName: gateway-conformance-infra/infra-backend-v1:8080
+    name: gateway-conformance-infra:infra-backend-v1:8080
+    outlierDetection:
+      splitExternalLocalOriginErrors: true
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 60s
+        useDownstreamProtocolConfig:
+          http2ProtocolOptions: {}
+  services:
+  - listener: ""
+    name: cilium-gateway-same-namespace
+    namespace: gateway-conformance-infra
+    ports:
+    - 80

--- a/operator/pkg/model/translation/gateway-api/testdata/httproute_redirect_same_match_order/config-input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/httproute_redirect_same_match_order/config-input.yaml
@@ -1,0 +1,14 @@
+cluster_config:
+  idle_timeout_seconds: 60
+host_network_config: {}
+ip_config:
+  ipv4_enabled: true
+  ipv6_enabled: true
+listener_config:
+  stream_idle_timeout_seconds: 300
+original_ip_detection_config:
+  use_remote_address: true
+  xff_num_trusted_hops: 0
+route_config:
+  host_name_suffix_match: true
+secrets_namespace: cilium-secrets

--- a/operator/pkg/model/translation/gateway-api/testdata/httproute_redirect_same_match_order/input.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/httproute_redirect_same_match_order/input.yaml
@@ -1,0 +1,25 @@
+http:
+- hostname: '*'
+  name: http
+  port: 80
+  routes:
+  - backends:
+    - name: infra-backend-v1
+      namespace: gateway-conformance-infra
+      port:
+        port: 8080
+    path_match:
+      prefix: /same-match
+    timeout: {}
+  - path_match:
+      prefix: /same-match
+    request_redirect:
+      scheme: https
+      status_code: 302
+    timeout: {}
+  sources:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: same-namespace
+    namespace: gateway-conformance-infra
+    version: v1

--- a/operator/pkg/model/translation/gateway-api/testdata/httproute_redirect_same_match_order/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/httproute_redirect_same_match_order/service-output.yaml
@@ -1,0 +1,22 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+    io.cilium.gateway/owning-gateway: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: Gateway
+    name: same-namespace
+    uid: ""
+spec:
+  ports:
+  - name: port-80
+    port: 80
+    protocol: TCP
+    targetPort: 0
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -64,6 +64,7 @@ func Test_translator_Translate(t *testing.T) {
 		{name: "conformance/httproute_request_mirror"},
 		{name: "conformance/httproute_request_redirect_with_multi_httplisteners"},
 		{name: "conformance/httproute_backend_protocol_h_2_c_app_protocol"},
+		{name: "httproute_redirect_same_match_order"},
 
 		// TLSRoute related tests
 


### PR DESCRIPTION
Do not count the synthetic X-Forwarded-Proto matcher when sorting Envoy routes for Gateway API HTTPRoute precedence.

Cilium adds this matcher to scheme redirects so redirects are skipped when the original request scheme already matches the redirect target. It is not a user-defined Gateway API header match and should not make redirect routes more specific than otherwise equivalent routes.

Add unit and translation fixture coverage to ensure route order is preserved for backend and redirect routes with the same match.

Fixes: #46834

```release-note
gateway-api: fix redirect guards affecting route ordering for similar HTTPRoute matches.
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
