### PR TITLE
envoy/xdsnew: Fix completion callback queueing

### DIFF
--- a/pkg/envoy/xdsnew/callbacks/completion_callbacks.go
+++ b/pkg/envoy/xdsnew/callbacks/completion_callbacks.go
@@ -7,7 +7,9 @@ import (
 	"container/list"
 	"context"
 	"fmt"
+	"iter"
 	"log/slog"
+	"maps"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
@@ -30,11 +32,12 @@ type versionEntry struct {
 	completions map[*completion.Completion]struct{}
 }
 
-// orderedCompletions maintains insertion order of versions with O(1) lookup by version string.
-// When a version is ACKed, all versions up to and including it are completed.
+// orderedCompletions maintains insertion order of versions with O(1) lookup of
+// the latest occurrence of a version string. When a version is ACKed, all
+// versions up to and including its latest occurrence are completed.
 type orderedCompletions struct {
 	list     *list.List
-	elements map[string]*list.Element
+	elements map[string]*list.Element // latest entry with the key version
 }
 
 func newOrderedCompletions() *orderedCompletions {
@@ -44,20 +47,71 @@ func newOrderedCompletions() *orderedCompletions {
 	}
 }
 
-// add adds a completion to the given version entry. If the version doesn't exist
-// yet, a new entry is appended to the end of the list (newest).
+// add adds a completion to the latest occurrence of the given version. If the
+// version doesn't exist yet, a new entry is appended to the end of the list.
 func (vo *orderedCompletions) add(version string, c *completion.Completion) {
 	if elem, ok := vo.elements[version]; ok {
 		entry := elem.Value.(*versionEntry)
 		entry.completions[c] = struct{}{}
 		return
 	}
+	vo.append(version, c)
+}
+
+// append records a new occurrence of a version at the end of the list. A
+// version may occur more than once when snapshot contents change A -> B -> A;
+// elements always points to the last occurrence.
+func (vo *orderedCompletions) append(version string, c *completion.Completion) {
 	entry := &versionEntry{
 		version:     version,
 		completions: map[*completion.Completion]struct{}{c: {}},
 	}
 	elem := vo.list.PushBack(entry)
 	vo.elements[version] = elem
+}
+
+// remove removes an entry and keeps elements pointing at the latest remaining
+// occurrence of its version.
+func (vo *orderedCompletions) remove(elem *list.Element) {
+	entry := elem.Value.(*versionEntry)
+	previous := elem.Prev()
+	vo.list.Remove(elem)
+	if vo.elements[entry.version] != elem {
+		return
+	}
+	delete(vo.elements, entry.version)
+	for e := previous; e != nil; e = e.Prev() {
+		if e.Value.(*versionEntry).version == entry.version {
+			vo.elements[entry.version] = e
+			break
+		}
+	}
+}
+
+// updateUpTo associates the completions for all versions before the latest
+// occurrence of 'version' with that response version. Entries after that
+// occurrence belong to newer snapshots and are left unchanged.
+// Returns the completions associated with the 'version' after the update.
+func (vo *orderedCompletions) updateUpTo(version string) iter.Seq[*completion.Completion] {
+	elem, ok := vo.elements[version]
+	if !ok {
+		return func(func(*completion.Completion) bool) {}
+	}
+
+	target := elem.Value.(*versionEntry)
+	for e := vo.list.Front(); e != elem; {
+		entry := e.Value.(*versionEntry)
+		next := e.Next()
+		// move completions to the target versionEntry
+		for c := range entry.completions {
+			target.completions[c] = struct{}{}
+		}
+		// remove the stale versionEntries and completion references so that they can only
+		// be reached via the target versionEntry.
+		vo.remove(e)
+		e = next
+	}
+	return maps.Keys(target.completions)
 }
 
 // completeUpTo returns all completions for the given version and all versions
@@ -74,8 +128,7 @@ func (vo *orderedCompletions) completeUpTo(version string) []*completion.Complet
 		for c := range entry.completions {
 			completed = append(completed, c)
 		}
-		delete(vo.elements, entry.version)
-		vo.list.Remove(e)
+		vo.remove(e)
 		if e == elem {
 			break
 		}
@@ -108,7 +161,8 @@ type CompletionCallbacks struct {
 
 	// pendingCompletions is the list of updates that are pending completion.
 	pendingCompletions map[*completion.Completion]*pendingCompletion
-	// completionsOrders tracks the order in which versions were sent per (nodeID, typeURL).
+	// completionsOrders tracks the order in which snapshot versions were created
+	// per (nodeID, typeURL).
 	// When an ACK is received for a version, all completions for that version and
 	// all earlier versions are completed.
 	// A separate mutex is not needed here: completionsOrders is always updated
@@ -177,13 +231,12 @@ func (cb *CompletionCallbacks) RemoveTypeVersionCompletion(c *completion.Complet
 // cb.mutex must be held.
 func (cb *CompletionCallbacks) removeFromOrderedCompletions(c *completion.Completion) {
 	for key, vo := range cb.completionsOrders {
-		for _, elem := range vo.elements {
+		for elem := vo.list.Front(); elem != nil; elem = elem.Next() {
 			entry := elem.Value.(*versionEntry)
 			if _, ok := entry.completions[c]; ok {
 				delete(entry.completions, c)
 				if len(entry.completions) == 0 {
-					vo.list.Remove(elem)
-					delete(vo.elements, entry.version)
+					vo.remove(elem)
 				}
 				if vo.list.Len() == 0 {
 					delete(cb.completionsOrders, key)
@@ -246,16 +299,22 @@ func (cb *CompletionCallbacks) addPendingCompletion(c *completion.Completion, ve
 	return pc
 }
 
-// addToCompletionsOrder attaches a pending completion to an xDS response
-// version. cb.mutex must be held.
-func (cb *CompletionCallbacks) addToCompletionsOrder(c *completion.Completion, pc *pendingCompletion, version string) {
+// addToCompletionsOrder attaches a pending completion to a version. When
+// newVersion is true, the version is appended as a new snapshot occurrence;
+// otherwise the completion is attached to the latest existing occurrence.
+// cb.mutex must be held.
+func (cb *CompletionCallbacks) addToCompletionsOrder(c *completion.Completion, pc *pendingCompletion, version string, newVersion bool) {
 	key := completionsOrderKey(pc.nodeID, pc.typeURL)
 	vo, ok := cb.completionsOrders[key]
 	if !ok {
 		vo = newOrderedCompletions()
 		cb.completionsOrders[key] = vo
 	}
-	vo.add(version, c)
+	if newVersion {
+		vo.append(version, c)
+	} else {
+		vo.add(version, c)
+	}
 	pc.inCompletionsOrder = true
 	cb.Log.Debug("Added completion to version order",
 		logfields.XDSTypeURL, pc.typeURL,
@@ -263,20 +322,21 @@ func (cb *CompletionCallbacks) addToCompletionsOrder(c *completion.Completion, p
 		logfields.NodeID, pc.nodeID)
 }
 
-// CompleteUnsentPendingCompletions completes pending updates that were never
-// attached to any xDS response. Call this after the cache has successfully
-// landed on a version Envoy has already accepted; at that point there is no
-// future response that could complete the superseded updates.
+// CompleteUnsentPendingCompletions completes pending updates superseded when
+// the cache successfully lands on a version Envoy has already accepted. These
+// updates may be in the snapshot order, but no response was sent for them and
+// no future response can complete them.
 func (cb *CompletionCallbacks) CompleteUnsentPendingCompletions(nodeID, typeURL string, err error) {
 	var completed []*completion.Completion
 
 	cb.mutex.Lock()
 	for c, pc := range cb.pendingCompletions {
-		if pc.nodeID != nodeID || pc.typeURL != typeURL || pc.inCompletionsOrder {
+		if pc.nodeID != nodeID || pc.typeURL != typeURL {
 			continue
 		}
 		completed = append(completed, c)
 		delete(cb.pendingCompletions, c)
+		cb.removeFromOrderedCompletions(c)
 	}
 	cb.mutex.Unlock()
 
@@ -308,7 +368,7 @@ func (cb *CompletionCallbacks) AddTypeVersionCompletion(c *completion.Completion
 		// Add the completion directly to that response's order so the in-flight
 		// ACK can complete it.
 		pc := cb.addPendingCompletion(c, version, typeURL, nodeID, revertFunc)
-		cb.addToCompletionsOrder(c, pc, version)
+		cb.addToCompletionsOrder(c, pc, version, versionChanged)
 		return true, nil
 	}
 
@@ -322,7 +382,12 @@ func (cb *CompletionCallbacks) AddTypeVersionCompletion(c *completion.Completion
 		return false, state.rejectedErr
 	}
 
-	cb.addPendingCompletion(c, version, typeURL, nodeID, revertFunc)
+	pc := cb.addPendingCompletion(c, version, typeURL, nodeID, revertFunc)
+	if version != "" {
+		// Responses can race snapshot publication, so retain the snapshot order
+		// before a response chooses the prefix it represents.
+		cb.addToCompletionsOrder(c, pc, version, versionChanged)
+	}
 	return true, nil
 }
 
@@ -394,7 +459,7 @@ func (cb *CompletionCallbacks) OnStreamRequest(streamID int64, req *discovery.Di
 
 		// NACK received: find a matching pending completion for the revert function.
 		for c, pc := range cb.pendingCompletions {
-			if pc.typeURL != typeURL || pc.nodeID != nodeID {
+			if pc.typeURL != typeURL || pc.nodeID != nodeID || pc.version != rejectedVersion {
 				continue
 			}
 			cb.Log.Warn(
@@ -408,7 +473,7 @@ func (cb *CompletionCallbacks) OnStreamRequest(streamID int64, req *discovery.Di
 			// Complete this completion and all earlier ones in the version order,
 			// since the revert rolls back all changes up to this point.
 			if vo, ok := cb.completionsOrders[key]; ok {
-				completed = vo.completeUpTo(pc.version)
+				completed = vo.completeUpTo(rejectedVersion)
 				for _, ec := range completed {
 					delete(cb.pendingCompletions, ec)
 				}
@@ -472,17 +537,21 @@ func (cb *CompletionCallbacks) OnStreamResponse(ctx context.Context, streamID in
 
 	cb.mutex.Lock()
 	nodeID := cb.nodeIDForRequest(streamID, req)
+	key := completionsOrderKey(nodeID, typeURL)
 
-	if typeURL == NetworkPolicyTypeURL || typeURL == NetworkPolicyHostsTypeURL {
-		// Check if any completion has been registered for this type URL and node ID, and if so, update resource version.
-		for _, pc := range cb.pendingCompletions {
-			if pc.typeURL == typeURL && pc.nodeID == nodeID {
-				cb.Log.Debug("Updating version completion for type URL and version",
-					logfields.XDSTypeURL, pc.typeURL,
-					logfields.Version, version,
-					logfields.NodeID, nodeID)
-				pc.version = version
+	// A response represents its snapshot and all snapshots before it, but must
+	// not claim completions registered for snapshots after it.
+	if vo, ok := cb.completionsOrders[key]; ok {
+		for c := range vo.updateUpTo(version) {
+			pc, ok := cb.pendingCompletions[c]
+			if !ok {
+				continue
 			}
+			cb.Log.Debug("Updating version completion for type URL and version",
+				logfields.XDSTypeURL, pc.typeURL,
+				logfields.Version, version,
+				logfields.NodeID, nodeID)
+			pc.version = version
 		}
 	}
 
@@ -491,7 +560,6 @@ func (cb *CompletionCallbacks) OnStreamResponse(ctx context.Context, streamID in
 		return
 	}
 
-	key := completionsOrderKey(nodeID, typeURL)
 	state := cb.responseStates[key]
 	if state.pendingVersion == "" && state.acceptedVersion == version {
 		state.rejectedVersion = ""
@@ -531,7 +599,8 @@ func (cb *CompletionCallbacks) OnStreamResponse(ctx context.Context, streamID in
 	// Add matching pending completions to the version order.
 	for c, pc := range cb.pendingCompletions {
 		if pc.typeURL == typeURL && pc.nodeID == nodeID && !pc.inCompletionsOrder {
-			cb.addToCompletionsOrder(c, pc, version)
+			cb.addToCompletionsOrder(c, pc, version, false)
+			pc.version = version
 		}
 	}
 	cb.mutex.Unlock()

--- a/pkg/envoy/xdsnew/callbacks/completion_callbacks.go
+++ b/pkg/envoy/xdsnew/callbacks/completion_callbacks.go
@@ -4,23 +4,25 @@
 package xdsnew
 
 import (
-	"container/list"
 	"context"
 	"fmt"
 	"iter"
 	"log/slog"
-	"maps"
+	"slices"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	sotw "github.com/envoyproxy/go-control-plane/pkg/server/sotw/v3"
 
 	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 const (
+	maxOrderedCompletionsExcessCapacity = 128
+
 	// NetworkPolicyTypeURL is the type URL of NetworkPolicy resources.
 	NetworkPolicyTypeURL      = "type.googleapis.com/cilium.NetworkPolicy"
 	NetworkPolicyHostsTypeURL = "type.googleapis.com/cilium.NetworkPolicyHosts"
@@ -29,63 +31,61 @@ const (
 // versionEntry holds all pending completions associated with a single version.
 type versionEntry struct {
 	version     string
-	completions map[*completion.Completion]struct{}
+	completions set.Set[*completion.Completion]
 }
 
-// orderedCompletions maintains insertion order of versions with O(1) lookup of
-// the latest occurrence of a version string. When a version is ACKed, all
-// versions up to and including its latest occurrence are completed.
-type orderedCompletions struct {
-	list     *list.List
-	elements map[string]*list.Element // latest entry with the key version
-}
+// orderedCompletions maintains the insertion order of snapshot versions. When
+// a version is ACKed, all versions up to and including its latest occurrence
+// are completed.
+type orderedCompletions []versionEntry
 
 func newOrderedCompletions() *orderedCompletions {
-	return &orderedCompletions{
-		list:     list.New(),
-		elements: make(map[string]*list.Element),
+	return new(orderedCompletions)
+}
+
+// lastIndex returns the index of the latest occurrence of version.
+func (vo *orderedCompletions) lastIndex(version string) int {
+	for i, entry := range slices.Backward(*vo) {
+		if entry.version == version {
+			return i
+		}
 	}
+	return -1
 }
 
 // add adds a completion to the latest occurrence of the given version. If the
-// version doesn't exist yet, a new entry is appended to the end of the list.
+// version doesn't exist yet, a new entry is appended to the end of the slice.
 func (vo *orderedCompletions) add(version string, c *completion.Completion) {
-	if elem, ok := vo.elements[version]; ok {
-		entry := elem.Value.(*versionEntry)
-		entry.completions[c] = struct{}{}
+	if i := vo.lastIndex(version); i >= 0 {
+		(*vo)[i].completions.Insert(c)
 		return
 	}
 	vo.append(version, c)
 }
 
-// append records a new occurrence of a version at the end of the list. A
-// version may occur more than once when snapshot contents change A -> B -> A;
-// elements always points to the last occurrence.
+// append records a new occurrence of a version at the end of the slice. A
+// version may occur more than once when snapshot contents change A -> B -> A.
 func (vo *orderedCompletions) append(version string, c *completion.Completion) {
-	entry := &versionEntry{
+	*vo = append(*vo, versionEntry{
 		version:     version,
-		completions: map[*completion.Completion]struct{}{c: {}},
-	}
-	elem := vo.list.PushBack(entry)
-	vo.elements[version] = elem
+		completions: set.NewSet(c),
+	})
 }
 
-// remove removes an entry and keeps elements pointing at the latest remaining
-// occurrence of its version.
-func (vo *orderedCompletions) remove(elem *list.Element) {
-	entry := elem.Value.(*versionEntry)
-	previous := elem.Prev()
-	vo.list.Remove(elem)
-	if vo.elements[entry.version] != elem {
-		return
+// removeRange removes entries in [start, end), preserving order and releasing
+// backing storage when it has excessive spare capacity.
+func (vo *orderedCompletions) removeRange(start, end int) {
+	entries := slices.Delete(*vo, start, end)
+	if cap(entries)-len(entries) > maxOrderedCompletionsExcessCapacity {
+		compacted := make(orderedCompletions, len(entries))
+		copy(compacted, entries)
+		entries = compacted
 	}
-	delete(vo.elements, entry.version)
-	for e := previous; e != nil; e = e.Prev() {
-		if e.Value.(*versionEntry).version == entry.version {
-			vo.elements[entry.version] = e
-			break
-		}
-	}
+	*vo = entries
+}
+
+func (vo *orderedCompletions) remove(index int) {
+	vo.removeRange(index, index+1)
 }
 
 // updateUpTo associates the completions for all versions before the latest
@@ -93,47 +93,35 @@ func (vo *orderedCompletions) remove(elem *list.Element) {
 // occurrence belong to newer snapshots and are left unchanged.
 // Returns the completions associated with the 'version' after the update.
 func (vo *orderedCompletions) updateUpTo(version string) iter.Seq[*completion.Completion] {
-	elem, ok := vo.elements[version]
-	if !ok {
-		return func(func(*completion.Completion) bool) {}
+	targetIndex := vo.lastIndex(version)
+	if targetIndex < 0 {
+		return (set.Set[*completion.Completion]{}).Members()
 	}
 
-	target := elem.Value.(*versionEntry)
-	for e := vo.list.Front(); e != elem; {
-		entry := e.Value.(*versionEntry)
-		next := e.Next()
-		// move completions to the target versionEntry
-		for c := range entry.completions {
-			target.completions[c] = struct{}{}
-		}
-		// remove the stale versionEntries and completion references so that they can only
-		// be reached via the target versionEntry.
-		vo.remove(e)
-		e = next
+	entries := *vo
+	for i := range targetIndex {
+		entries[targetIndex].completions.Merge(entries[i].completions)
 	}
-	return maps.Keys(target.completions)
+	if targetIndex > 0 {
+		vo.removeRange(0, targetIndex)
+	}
+	return (*vo)[0].completions.Members()
 }
 
 // completeUpTo returns all completions for the given version and all versions
-// that were inserted before it, removing them from the list.
+// that were inserted before it, removing them from the slice.
 func (vo *orderedCompletions) completeUpTo(version string) []*completion.Completion {
-	elem, ok := vo.elements[version]
-	if !ok {
+	targetIndex := vo.lastIndex(version)
+	if targetIndex < 0 {
 		return nil
 	}
 	var completed []*completion.Completion
-	for e := vo.list.Front(); e != nil; {
-		entry := e.Value.(*versionEntry)
-		next := e.Next()
-		for c := range entry.completions {
+	for i := 0; i <= targetIndex; i++ {
+		for c := range (*vo)[i].completions.Members() {
 			completed = append(completed, c)
 		}
-		vo.remove(e)
-		if e == elem {
-			break
-		}
-		e = next
 	}
+	vo.removeRange(0, targetIndex+1)
 	return completed
 }
 
@@ -231,14 +219,14 @@ func (cb *CompletionCallbacks) RemoveTypeVersionCompletion(c *completion.Complet
 // cb.mutex must be held.
 func (cb *CompletionCallbacks) removeFromOrderedCompletions(c *completion.Completion) {
 	for key, vo := range cb.completionsOrders {
-		for elem := vo.list.Front(); elem != nil; elem = elem.Next() {
-			entry := elem.Value.(*versionEntry)
-			if _, ok := entry.completions[c]; ok {
-				delete(entry.completions, c)
-				if len(entry.completions) == 0 {
-					vo.remove(elem)
+		for i := range *vo {
+			entry := &(*vo)[i]
+			if entry.completions.Has(c) {
+				entry.completions.Remove(c)
+				if entry.completions.Empty() {
+					vo.remove(i)
 				}
-				if vo.list.Len() == 0 {
+				if len(*vo) == 0 {
 					delete(cb.completionsOrders, key)
 				}
 				return
@@ -477,7 +465,7 @@ func (cb *CompletionCallbacks) OnStreamRequest(streamID int64, req *discovery.Di
 				for _, ec := range completed {
 					delete(cb.pendingCompletions, ec)
 				}
-				if vo.list.Len() == 0 {
+				if len(*vo) == 0 {
 					delete(cb.completionsOrders, key)
 				}
 			} else {
@@ -516,7 +504,7 @@ func (cb *CompletionCallbacks) OnStreamRequest(streamID int64, req *discovery.Di
 				logfields.XDSTypeURL, typeURL,
 				logfields.Version, req.GetVersionInfo())
 		}
-		if vo.list.Len() == 0 {
+		if len(*vo) == 0 {
 			delete(cb.completionsOrders, key)
 		}
 	}
@@ -571,7 +559,7 @@ func (cb *CompletionCallbacks) OnStreamResponse(ctx context.Context, streamID in
 			for _, c := range completed {
 				delete(cb.pendingCompletions, c)
 			}
-			if vo.list.Len() == 0 {
+			if len(*vo) == 0 {
 				delete(cb.completionsOrders, key)
 			}
 		}

--- a/pkg/envoy/xdsnew/callbacks/completion_callbacks_test.go
+++ b/pkg/envoy/xdsnew/callbacks/completion_callbacks_test.go
@@ -16,6 +16,16 @@ import (
 	"github.com/cilium/cilium/pkg/completion"
 )
 
+const listenerTypeURL = "type.googleapis.com/envoy.config.listener.v3.Listener"
+
+var orderedCompletionTypeURLs = []struct {
+	name    string
+	typeURL string
+}{
+	{name: "network-policy", typeURL: NetworkPolicyTypeURL},
+	{name: "listener", typeURL: listenerTypeURL},
+}
+
 func newTestCompletionCallbacks() *CompletionCallbacks {
 	return NewCompletionCallbacks(slog.New(slog.DiscardHandler))
 }
@@ -26,6 +36,44 @@ func newTestCompletion(t *testing.T) (*completion.WaitGroup, *completion.Complet
 	wg := completion.NewWaitGroup(ctx)
 	t.Cleanup(wg.Cancel)
 	return wg, wg.AddCompletionWithCallback(nil, nil)
+}
+
+func registerTypeVersionCompletion(t *testing.T, cb *CompletionCallbacks, comp *completion.Completion, typeURL, version string) {
+	t.Helper()
+	registered, err := cb.AddTypeVersionCompletion(comp, version, typeURL, "node-1", true, nil)
+	require.NoError(t, err)
+	require.True(t, registered)
+}
+
+func sendTypeVersionResponse(cb *CompletionCallbacks, typeURL, version string) {
+	cb.OnStreamResponse(context.Background(), 1,
+		&discovery.DiscoveryRequest{
+			Node:    &core.Node{Id: "node-1"},
+			TypeUrl: typeURL,
+		},
+		&discovery.DiscoveryResponse{
+			VersionInfo: version,
+			TypeUrl:     typeURL,
+		},
+	)
+}
+
+func ackTypeVersionResponse(t *testing.T, cb *CompletionCallbacks, typeURL, version string) {
+	t.Helper()
+	require.NoError(t, cb.OnStreamRequest(1, &discovery.DiscoveryRequest{
+		Node:        &core.Node{Id: "node-1"},
+		TypeUrl:     typeURL,
+		VersionInfo: version,
+	}))
+}
+
+func requireCompletionPending(t *testing.T, comp *completion.Completion) {
+	t.Helper()
+	select {
+	case <-comp.Completed():
+		require.Fail(t, "completion was completed unexpectedly")
+	default:
+	}
 }
 
 func TestAddTypeVersionCompletionCompletesAlreadyAckedVersion(t *testing.T) {
@@ -94,7 +142,6 @@ func TestOnStreamResponseCompletesPendingCompletionForAlreadyAckedVersion(t *tes
 func TestCompletionCallbacksUseStreamNodeIDWhenACKOmitsNode(t *testing.T) {
 	cb := newTestCompletionCallbacks()
 	wg, comp := newTestCompletion(t)
-	const listenerTypeURL = "type.googleapis.com/envoy.config.listener.v3.Listener"
 
 	require.NoError(t, cb.OnStreamRequest(1, &discovery.DiscoveryRequest{
 		Node: &core.Node{Id: "node-1"},
@@ -115,4 +162,78 @@ func TestCompletionCallbacksUseStreamNodeIDWhenACKOmitsNode(t *testing.T) {
 	}))
 	require.NoError(t, wg.Wait())
 	require.Zero(t, cb.PendingCompletionCount())
+}
+
+func TestCompletionFollowsNewerResponseVersion(t *testing.T) {
+	for _, tt := range orderedCompletionTypeURLs {
+		t.Run(tt.name, func(t *testing.T) {
+			cb := newTestCompletionCallbacks()
+			wg1, comp1 := newTestCompletion(t)
+			wg2, comp2 := newTestCompletion(t)
+
+			registerTypeVersionCompletion(t, cb, comp1, tt.typeURL, "version-1")
+			registerTypeVersionCompletion(t, cb, comp2, tt.typeURL, "version-2")
+
+			// The later response must move the earlier completion to version-2 rather
+			// than leave it stranded in version-1's ordered-list entry.
+			sendTypeVersionResponse(cb, tt.typeURL, "version-1")
+			sendTypeVersionResponse(cb, tt.typeURL, "version-2")
+			ackTypeVersionResponse(t, cb, tt.typeURL, "version-2")
+
+			require.Zero(t, cb.PendingCompletionCount())
+			require.NoError(t, wg1.Wait())
+			require.NoError(t, wg2.Wait())
+		})
+	}
+}
+
+func TestOlderResponseDoesNotClaimNewerCompletion(t *testing.T) {
+	for _, tt := range orderedCompletionTypeURLs {
+		t.Run(tt.name, func(t *testing.T) {
+			cb := newTestCompletionCallbacks()
+			wg1, comp1 := newTestCompletion(t)
+			wg2, comp2 := newTestCompletion(t)
+
+			registerTypeVersionCompletion(t, cb, comp1, tt.typeURL, "version-1")
+			registerTypeVersionCompletion(t, cb, comp2, tt.typeURL, "version-2")
+
+			// An ACK for a response created before version-2 must not complete the
+			// version-2 update, even though the response callback runs afterwards.
+			sendTypeVersionResponse(cb, tt.typeURL, "version-1")
+			ackTypeVersionResponse(t, cb, tt.typeURL, "version-1")
+			require.Equal(t, 1, cb.PendingCompletionCount())
+			require.NoError(t, wg1.Wait())
+			requireCompletionPending(t, comp2)
+
+			sendTypeVersionResponse(cb, tt.typeURL, "version-2")
+			ackTypeVersionResponse(t, cb, tt.typeURL, "version-2")
+			require.Zero(t, cb.PendingCompletionCount())
+			require.NoError(t, wg2.Wait())
+		})
+	}
+}
+
+func TestResponseUsesLastMatchingVersion(t *testing.T) {
+	for _, tt := range orderedCompletionTypeURLs {
+		t.Run(tt.name, func(t *testing.T) {
+			cb := newTestCompletionCallbacks()
+			wgA1, compA1 := newTestCompletion(t)
+			wgB, compB := newTestCompletion(t)
+			wgA2, compA2 := newTestCompletion(t)
+
+			registerTypeVersionCompletion(t, cb, compA1, tt.typeURL, "version-a")
+			registerTypeVersionCompletion(t, cb, compB, tt.typeURL, "version-b")
+			registerTypeVersionCompletion(t, cb, compA2, tt.typeURL, "version-a")
+
+			// For A -> B -> A, the response for A represents the last A and therefore
+			// covers both earlier entries as well as the final A entry.
+			sendTypeVersionResponse(cb, tt.typeURL, "version-a")
+			ackTypeVersionResponse(t, cb, tt.typeURL, "version-a")
+
+			require.Zero(t, cb.PendingCompletionCount())
+			require.NoError(t, wgA1.Wait())
+			require.NoError(t, wgB.Wait())
+			require.NoError(t, wgA2.Wait())
+		})
+	}
 }

--- a/pkg/envoy/xdsnew/callbacks/completion_callbacks_test.go
+++ b/pkg/envoy/xdsnew/callbacks/completion_callbacks_test.go
@@ -6,6 +6,7 @@ package xdsnew
 import (
 	"context"
 	"log/slog"
+	"slices"
 	"testing"
 	"time"
 
@@ -74,6 +75,109 @@ func requireCompletionPending(t *testing.T, comp *completion.Completion) {
 		require.Fail(t, "completion was completed unexpectedly")
 	default:
 	}
+}
+
+func TestOrderedCompletionsUpdateUpToLastVersion(t *testing.T) {
+	vo := newOrderedCompletions()
+	compA1 := completion.NewCompletion(nil, nil, nil)
+	compB := completion.NewCompletion(nil, nil, nil)
+	compA2 := completion.NewCompletion(nil, nil, nil)
+	compC := completion.NewCompletion(nil, nil, nil)
+
+	vo.append("version-a", compA1)
+	vo.append("version-b", compB)
+	vo.append("version-a", compA2)
+	vo.append("version-c", compC)
+
+	updated := slices.Collect(vo.updateUpTo("version-a"))
+	require.ElementsMatch(t, []*completion.Completion{compA1, compB, compA2}, updated)
+	require.Len(t, *vo, 2)
+	require.Equal(t, "version-a", (*vo)[0].version)
+	require.Equal(t, 3, (*vo)[0].completions.Len())
+	require.Equal(t, "version-c", (*vo)[1].version)
+	require.True(t, (*vo)[1].completions.Has(compC))
+}
+
+func TestOrderedCompletionsCompleteUpToLastVersion(t *testing.T) {
+	vo := newOrderedCompletions()
+	compA1 := completion.NewCompletion(nil, nil, nil)
+	compB := completion.NewCompletion(nil, nil, nil)
+	compA2 := completion.NewCompletion(nil, nil, nil)
+	compC := completion.NewCompletion(nil, nil, nil)
+
+	vo.append("version-a", compA1)
+	vo.append("version-b", compB)
+	vo.append("version-a", compA2)
+	vo.append("version-c", compC)
+
+	completed := vo.completeUpTo("version-a")
+	require.ElementsMatch(t, []*completion.Completion{compA1, compB, compA2}, completed)
+	require.Len(t, *vo, 1)
+	require.Equal(t, "version-c", (*vo)[0].version)
+	require.True(t, (*vo)[0].completions.Has(compC))
+}
+
+func TestRemoveFromOrderedCompletionsCompactsMiddleEntry(t *testing.T) {
+	cb := newTestCompletionCallbacks()
+	vo := newOrderedCompletions()
+	compA := completion.NewCompletion(nil, nil, nil)
+	compB1 := completion.NewCompletion(nil, nil, nil)
+	compB2 := completion.NewCompletion(nil, nil, nil)
+	compC := completion.NewCompletion(nil, nil, nil)
+
+	vo.append("version-a", compA)
+	vo.append("version-b", compB1)
+	vo.add("version-b", compB2)
+	vo.append("version-c", compC)
+	cb.completionsOrders[completionsOrderKey("node-1", listenerTypeURL)] = vo
+
+	cb.RemoveTypeVersionCompletion(compB1)
+	require.Len(t, *vo, 3)
+	require.Equal(t, "version-b", (*vo)[1].version)
+	require.Equal(t, 1, (*vo)[1].completions.Len())
+	require.True(t, (*vo)[1].completions.Has(compB2))
+
+	cb.RemoveTypeVersionCompletion(compB2)
+	require.Len(t, *vo, 2)
+	require.Equal(t, "version-a", (*vo)[0].version)
+	require.Equal(t, "version-c", (*vo)[1].version)
+}
+
+func TestOrderedCompletionsRemoveCapacity(t *testing.T) {
+	t.Run("ordinary capacity is retained", func(t *testing.T) {
+		entries := make(orderedCompletions, 3, 16)
+		entries[0].version = "version-a"
+		entries[1].version = "version-b"
+		entries[2].version = "version-c"
+
+		entries.remove(1)
+		require.Equal(t, 16, cap(entries))
+		require.Equal(t, []string{"version-a", "version-c"}, []string{entries[0].version, entries[1].version})
+	})
+
+	t.Run("exactly the excess limit is retained", func(t *testing.T) {
+		entries := make(orderedCompletions, 2, maxOrderedCompletionsExcessCapacity+1)
+		entries.remove(0)
+		require.Equal(t, maxOrderedCompletionsExcessCapacity+1, cap(entries))
+		require.Equal(t, maxOrderedCompletionsExcessCapacity, cap(entries)-len(entries))
+	})
+
+	t.Run("capacity above the excess limit is released", func(t *testing.T) {
+		entries := make(orderedCompletions, 2, maxOrderedCompletionsExcessCapacity+2)
+		entries.remove(0)
+		require.Equal(t, len(entries), cap(entries))
+	})
+
+	t.Run("large live slice shrinks only excessive capacity", func(t *testing.T) {
+		entries := make(orderedCompletions, 200, 400)
+		entries.remove(0)
+		require.Len(t, entries, 199)
+		require.Equal(t, 199, cap(entries))
+
+		entries.remove(0)
+		require.Len(t, entries, 198)
+		require.Equal(t, 199, cap(entries))
+	})
 }
 
 func TestAddTypeVersionCompletionCompletesAlreadyAckedVersion(t *testing.T) {


### PR DESCRIPTION
Only update the versions of `orderedCompletions` up to the version being
sent in `OnStreamResponse` callback and move the completions from the updated
entries to the entry of the version in question. This fixes:

- completions remaining stranded in an older version entry after a newer
  response updates their version;
- older responses completing callbacks registered for newer snapshots;
- repeated content versions (A -> B -> A) resolving to the first rather
  than the latest occurrence.

Record completion versions in snapshot creation order for every xDS type
URL. When sending a response, coalesce only the prefix ending at that
response version, leaving completions for newer snapshots untouched.
Keep distinct entries for repeated versions so ACK and NACK processing
uses the latest occurrence.

Add regression coverage for both Cilium NetworkPolicy and standard Envoy
Listener resources.

Fixes: #46874
Fixes: #43887

This PR has been prepared with Codex (AIL:3)
