### PR TITLE
nodeipam: log excluded Nodes at info level

### DIFF
--- a/operator/pkg/nodeipam/nodesvclb.go
+++ b/operator/pkg/nodeipam/nodesvclb.go
@@ -231,13 +231,11 @@ func (r *nodeSvcLBReconciler) getRelevantNodes(ctx context.Context, svc *corev1.
 		)
 	}
 
+	var excludedNodes []string
 	relevantNodes := []corev1.Node{}
 	for _, node := range nodes.Items {
 		if !shouldIncludeNode(&node) {
-			scopedLog.DebugContext(
-				ctx, "Skipping Node to be deleted or excluded from load balancers",
-				logfields.NodeName, node.Name,
-			)
+			excludedNodes = append(excludedNodes, node.Name)
 			continue
 		}
 		if endpointSliceNames != nil && !endpointSliceNames.Has(node.Name) {
@@ -249,6 +247,13 @@ func (r *nodeSvcLBReconciler) getRelevantNodes(ctx context.Context, svc *corev1.
 		}
 
 		relevantNodes = append(relevantNodes, node)
+	}
+
+	if len(excludedNodes) > 0 {
+		scopedLog.InfoContext(
+			ctx, "Skipping Nodes that are being deleted or are excluded from load balancers",
+			logfields.Nodes, excludedNodes,
+		)
 	}
 
 	if len(nodes.Items) > 0 && len(relevantNodes) == 0 {


### PR DESCRIPTION
When selecting the Nodes for a Service of type LoadBalancer, node IPAM skips Nodes that are being deleted, are tainted by the cluster autoscaler or carry the `node.kubernetes.io/exclude-from-external-load-balancers` label. This was only logged at debug level, so users had no visible hint about why some Nodes were not programmed into the Service ingress, unlike the host network mode where node selection is observable. Aggregate the excluded Node names and log them once per reconciliation at info level so the exclusion is visible with default log settings. This PR was prepared with AIL:3. I personally reviewed the change and ran `go test ./operator/pkg/nodeipam/`.

Fixes: #44847

```release-note
Node IPAM now logs at info level the Nodes it excludes from load balancer selection (deletion, autoscaler taint, or exclude-from-external-load-balancers label).
```