### PR TITLE
Proposing Flow IR implementation to improve hubble performance

### DIFF
--- a/pkg/hubble/api/v1/flow.go
+++ b/pkg/hubble/api/v1/flow.go
@@ -4,8 +4,8 @@
 package v1
 
 import (
-	pb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/hubble/build"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 )
 
@@ -17,14 +17,14 @@ var FlowEmitterVersion = build.ServerVersion.SemVer()
 
 // FlowProtocol returns the protocol best describing the flow. If available,
 // this is the L7 protocol name, then the L4 protocol name.
-func FlowProtocol(flow *pb.Flow) string {
-	switch flow.GetEventType().GetType() {
+func FlowProtocol(flow *ir.Flow) string {
+	switch flow.EventType.Type {
 	case monitorAPI.MessageTypeAccessLog:
-		if l7 := flow.GetL7(); l7 != nil {
+		if !flow.L7.IsEmpty() {
 			switch {
-			case l7.GetDns() != nil:
+			case !flow.L7.DNS.IsEmpty():
 				return "DNS"
-			case l7.GetHttp() != nil:
+			case !flow.L7.HTTP.IsEmpty():
 				return "HTTP"
 			}
 		}
@@ -32,21 +32,21 @@ func FlowProtocol(flow *pb.Flow) string {
 
 	case monitorAPI.MessageTypeDrop, monitorAPI.MessageTypeTrace,
 		monitorAPI.MessageTypePolicyVerdict, monitorAPI.MessageTypeCapture:
-		if l4 := flow.GetL4(); l4 != nil {
+		if !flow.L4.IsEmpty() {
 			switch {
-			case l4.GetTCP() != nil:
+			case !flow.L4.TCP.IsEmpty():
 				return "TCP"
-			case l4.GetUDP() != nil:
+			case !flow.L4.UDP.IsEmpty():
 				return "UDP"
-			case l4.GetICMPv4() != nil:
+			case !flow.L4.ICMPv4.IsEmpty():
 				return "ICMPv4"
-			case l4.GetICMPv6() != nil:
+			case !flow.L4.ICMPv6.IsEmpty():
 				return "ICMPv6"
-			case l4.GetSCTP() != nil:
+			case !flow.L4.SCTP.IsEmpty():
 				return "SCTP"
-			case l4.GetVRRP() != nil:
+			case !flow.L4.VRRP.IsEmpty():
 				return "VRRP"
-			case l4.GetIGMP() != nil:
+			case !flow.L4.IGMP.IsEmpty():
 				return "IGMP"
 			}
 		}

--- a/pkg/hubble/api/v1/types.go
+++ b/pkg/hubble/api/v1/types.go
@@ -7,6 +7,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 )
 
 // Event represents a single event observed and stored by Hubble
@@ -18,13 +19,17 @@ type Event struct {
 }
 
 // GetFlow returns the decoded flow, or nil if the event is nil or not a flow
-func (ev *Event) GetFlow() *pb.Flow {
+func (ev *Event) GetFlow() *ir.Flow {
 	if ev == nil || ev.Event == nil {
 		return nil
 	}
-	if f, ok := ev.Event.(*pb.Flow); ok {
+	if f, ok := ev.Event.(*ir.Flow); ok {
 		return f
 	}
+	if f, ok := ev.Event.(*pb.Flow); ok {
+		return ir.ProtoToFlow(f)
+	}
+
 	return nil
 }
 

--- a/pkg/hubble/cell/hubbleintegration.go
+++ b/pkg/hubble/cell/hubbleintegration.go
@@ -14,7 +14,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
-	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/api/v1/models"
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 	"github.com/cilium/cilium/pkg/cgroups/manager"
@@ -26,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/dropeventemitter"
 	"github.com/cilium/cilium/pkg/hubble/exporter"
 	exportercell "github.com/cilium/cilium/pkg/hubble/exporter/cell"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/metrics"
 	"github.com/cilium/cilium/pkg/hubble/monitor"
 	"github.com/cilium/cilium/pkg/hubble/observer"
@@ -223,7 +223,7 @@ func (h *hubbleIntegration) launch(ctx context.Context) (*observer.LocalObserver
 
 	if h.dropEventEmitter != nil {
 		observerOpts = append(observerOpts,
-			observeroption.WithOnDecodedFlowFunc(func(ctx context.Context, flow *flowpb.Flow) (bool, error) {
+			observeroption.WithOnDecodedFlowFunc(func(ctx context.Context, flow *ir.Flow) (bool, error) {
 				err := h.dropEventEmitter.ProcessFlow(ctx, flow)
 				if err != nil {
 					h.log.Error("Failed to ProcessFlow in drop events handler", logfields.Error, err)
@@ -260,7 +260,7 @@ func (h *hubbleIntegration) launch(ctx context.Context) (*observer.LocalObserver
 
 	// register metrics flow processor
 	if h.metricsFlowProcessor != nil {
-		observerOpts = append(observerOpts, observeroption.WithOnDecodedFlowFunc(func(ctx context.Context, f *flowpb.Flow) (bool, error) {
+		observerOpts = append(observerOpts, observeroption.WithOnDecodedFlowFunc(func(ctx context.Context, f *ir.Flow) (bool, error) {
 			return false, h.metricsFlowProcessor.ProcessFlow(ctx, f)
 		}))
 	}

--- a/pkg/hubble/cell/hubbleintegration.go
+++ b/pkg/hubble/cell/hubbleintegration.go
@@ -14,7 +14,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
-	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/api/v1/models"
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 	"github.com/cilium/cilium/pkg/cgroups/manager"
@@ -26,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/dropeventemitter"
 	"github.com/cilium/cilium/pkg/hubble/exporter"
 	exportercell "github.com/cilium/cilium/pkg/hubble/exporter/cell"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/metrics"
 	"github.com/cilium/cilium/pkg/hubble/monitor"
 	"github.com/cilium/cilium/pkg/hubble/observer"
@@ -219,7 +219,7 @@ func (h *hubbleIntegration) launch(ctx context.Context) (*observer.LocalObserver
 
 	if h.dropEventEmitter != nil {
 		observerOpts = append(observerOpts,
-			observeroption.WithOnDecodedFlowFunc(func(ctx context.Context, flow *flowpb.Flow) (bool, error) {
+			observeroption.WithOnDecodedFlowFunc(func(ctx context.Context, flow *ir.Flow) (bool, error) {
 				err := h.dropEventEmitter.ProcessFlow(ctx, flow)
 				if err != nil {
 					h.log.Error("Failed to ProcessFlow in drop events handler", logfields.Error, err)
@@ -256,7 +256,7 @@ func (h *hubbleIntegration) launch(ctx context.Context) (*observer.LocalObserver
 
 	// register metrics flow processor
 	if h.metricsFlowProcessor != nil {
-		observerOpts = append(observerOpts, observeroption.WithOnDecodedFlowFunc(func(ctx context.Context, f *flowpb.Flow) (bool, error) {
+		observerOpts = append(observerOpts, observeroption.WithOnDecodedFlowFunc(func(ctx context.Context, f *ir.Flow) (bool, error) {
 			return false, h.metricsFlowProcessor.ProcessFlow(ctx, f)
 		}))
 	}

--- a/pkg/hubble/dropeventemitter/cell.go
+++ b/pkg/hubble/dropeventemitter/cell.go
@@ -13,16 +13,17 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/time"
 )
 
-// FlowProcessor is a wrapper for dropEventEmitter used by Hubble
+// FlowProcessor is a wrapper for dropEventxEmitter used by Hubble
 // to hook into the flow processing pipeline.
 type FlowProcessor interface {
-	ProcessFlow(ctx context.Context, flow *flowpb.Flow) error
+	ProcessFlow(ctx context.Context, flow *ir.Flow) error
 }
 
 var Cell = cell.Module(

--- a/pkg/hubble/dropeventemitter/cell.go
+++ b/pkg/hubble/dropeventemitter/cell.go
@@ -13,6 +13,7 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/time"
@@ -21,7 +22,7 @@ import (
 // FlowProcessor is a wrapper for dropEventEmitter used by Hubble
 // to hook into the flow processing pipeline.
 type FlowProcessor interface {
-	ProcessFlow(ctx context.Context, flow *flowpb.Flow) error
+	ProcessFlow(ctx context.Context, flow *ir.Flow) error
 }
 
 var Cell = cell.Module(

--- a/pkg/hubble/dropeventemitter/dropeventemitter.go
+++ b/pkg/hubble/dropeventemitter/dropeventemitter.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils"
 	client "github.com/cilium/cilium/pkg/k8s/client"
@@ -79,7 +80,7 @@ func new(log *slog.Logger, interval time.Duration, reasons []string, showPolicie
 	}
 }
 
-func (e *dropEventEmitter) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error {
+func (e *dropEventEmitter) ProcessFlow(ctx context.Context, flow *ir.Flow) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -88,7 +89,7 @@ func (e *dropEventEmitter) ProcessFlow(ctx context.Context, flow *flowpb.Flow) e
 
 	// Only handle packet drops due to policy related to a Pod
 	if flow.Verdict != flowpb.Verdict_DROPPED ||
-		!slices.Contains(e.reasons, flow.GetDropReasonDesc()) ||
+		!slices.Contains(e.reasons, flow.DropReasonDesc) ||
 		(flow.TrafficDirection == flowpb.TrafficDirection_INGRESS && flow.Destination.PodName == "") ||
 		(flow.TrafficDirection == flowpb.TrafficDirection_EGRESS && flow.Source.PodName == "") {
 		return nil
@@ -147,7 +148,7 @@ func (e *dropEventEmitter) Shutdown() {
 	e.broadcaster.Shutdown()
 }
 
-func podFromEndpoint(typeMeta metaslimv1.TypeMeta, endpoint *flowpb.Endpoint) *slimv1.Pod {
+func podFromEndpoint(typeMeta metaslimv1.TypeMeta, endpoint ir.Endpoint) *slimv1.Pod {
 	// Leave UID empty when the flow does not include it. Looking up a Pod by its
 	// current name could associate a delayed flow with a replacement Pod.
 	return &slimv1.Pod{
@@ -155,12 +156,12 @@ func podFromEndpoint(typeMeta metaslimv1.TypeMeta, endpoint *flowpb.Endpoint) *s
 		ObjectMeta: metaslimv1.ObjectMeta{
 			Name:      endpoint.PodName,
 			Namespace: endpoint.Namespace,
-			UID:       types.UID(endpoint.PodUid),
+			UID:       types.UID(endpoint.PodUID),
 		},
 	}
 }
 
-func endpointToString(ip string, endpoint *flowpb.Endpoint) string {
+func endpointToString(ip string, endpoint ir.Endpoint) string {
 	if endpoint.PodName != "" {
 		return endpoint.Namespace + "/" + endpoint.PodName + " (" + ip + ")"
 	}
@@ -170,27 +171,28 @@ func endpointToString(ip string, endpoint *flowpb.Endpoint) string {
 	return ip
 }
 
-func l4protocolToString(l4 *flowpb.Layer4) string {
-	switch l4.Protocol.(type) {
-	case *flowpb.Layer4_TCP:
-		return "TCP/" + strconv.Itoa(int(l4.GetTCP().DestinationPort))
-	case *flowpb.Layer4_UDP:
-		return "UDP/" + strconv.Itoa(int(l4.GetUDP().DestinationPort))
-	case *flowpb.Layer4_ICMPv4:
+func l4protocolToString(l4 ir.Layer4) string {
+	switch {
+	case !l4.TCP.IsEmpty():
+		return "TCP/" + strconv.Itoa(int(l4.TCP.DestinationPort))
+	case !l4.UDP.IsEmpty():
+		return "UDP/" + strconv.Itoa(int(l4.UDP.DestinationPort))
+	case !l4.ICMPv4.IsEmpty():
 		return "ICMPv4"
-	case *flowpb.Layer4_ICMPv6:
+	case !l4.ICMPv6.IsEmpty():
 		return "ICMPv6"
-	case *flowpb.Layer4_SCTP:
+	case !l4.SCTP.IsEmpty():
 		return "SCTP"
-	case *flowpb.Layer4_IGMP:
+	case !l4.IGMP.IsEmpty():
 		return "IGMP"
-	case *flowpb.Layer4_VRRP:
+	case !l4.VRRP.IsEmpty():
 		return "VRRP"
 	}
+
 	return ""
 }
 
-func (e *dropEventEmitter) getLocalEndpoint(flow *flowpb.Flow) *endpoint.Endpoint {
+func (e *dropEventEmitter) getLocalEndpoint(flow *ir.Flow) *endpoint.Endpoint {
 	var endpointID uint16
 	if flow.TrafficDirection == flowpb.TrafficDirection_INGRESS {
 		endpointID = uint16(flow.Destination.ID)
@@ -234,8 +236,8 @@ func parsePolicyRules(l4Rules []*models.PolicyRule, policyRevision uint64) (netw
 	return
 }
 
-func parsePolicyCorrelation(direction flowpb.TrafficDirection, ingressDeniedBy []*flowpb.Policy, egressDeniedBy []*flowpb.Policy) (networkPolicies set.Set[string], clusterwideNetworkPolicies set.Set[string]) {
-	var policies []*flowpb.Policy
+func parsePolicyCorrelation(direction flowpb.TrafficDirection, ingressDeniedBy, egressDeniedBy []ir.Policy) (networkPolicies set.Set[string], clusterwideNetworkPolicies set.Set[string]) {
+	var policies []ir.Policy
 	if direction == flowpb.TrafficDirection_INGRESS {
 		policies = ingressDeniedBy
 	} else {
@@ -251,7 +253,7 @@ func parsePolicyCorrelation(direction flowpb.TrafficDirection, ingressDeniedBy [
 	return
 }
 
-func (e *dropEventEmitter) dropEventPoliciesToString(flow *flowpb.Flow) (string, error) {
+func (e *dropEventEmitter) dropEventPoliciesToString(flow *ir.Flow) (string, error) {
 	var parts []string
 	prefix := "Denied by"
 	var networkPolicies, clusterwideNetworkPolicies set.Set[string]

--- a/pkg/hubble/dropeventemitter/dropeventemitter.go
+++ b/pkg/hubble/dropeventemitter/dropeventemitter.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils"
 	client "github.com/cilium/cilium/pkg/k8s/client"
@@ -81,7 +82,7 @@ func new(log *slog.Logger, interval time.Duration, reasons []string, showPolicie
 	}
 }
 
-func (e *dropEventEmitter) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error {
+func (e *dropEventEmitter) ProcessFlow(ctx context.Context, flow *ir.Flow) error {
 	if e.rateLimiter != nil && !e.rateLimiter.Allow() {
 		return nil
 	}
@@ -94,7 +95,7 @@ func (e *dropEventEmitter) ProcessFlow(ctx context.Context, flow *flowpb.Flow) e
 
 	// Only handle packet drops due to policy related to a Pod
 	if flow.Verdict != flowpb.Verdict_DROPPED ||
-		!slices.Contains(e.reasons, flow.GetDropReasonDesc()) ||
+		!slices.Contains(e.reasons, flow.DropReasonDesc) ||
 		(flow.TrafficDirection == flowpb.TrafficDirection_INGRESS && flow.Destination.PodName == "") ||
 		(flow.TrafficDirection == flowpb.TrafficDirection_EGRESS && flow.Source.PodName == "") {
 		return nil
@@ -168,7 +169,7 @@ func (e *dropEventEmitter) Shutdown() {
 	e.broadcaster.Shutdown()
 }
 
-func endpointToString(ip string, endpoint *flowpb.Endpoint) string {
+func endpointToString(ip string, endpoint ir.Endpoint) string {
 	if endpoint.PodName != "" {
 		return endpoint.Namespace + "/" + endpoint.PodName + " (" + ip + ")"
 	}
@@ -178,27 +179,28 @@ func endpointToString(ip string, endpoint *flowpb.Endpoint) string {
 	return ip
 }
 
-func l4protocolToString(l4 *flowpb.Layer4) string {
-	switch l4.Protocol.(type) {
-	case *flowpb.Layer4_TCP:
-		return "TCP/" + strconv.Itoa(int(l4.GetTCP().DestinationPort))
-	case *flowpb.Layer4_UDP:
-		return "UDP/" + strconv.Itoa(int(l4.GetUDP().DestinationPort))
-	case *flowpb.Layer4_ICMPv4:
+func l4protocolToString(l4 ir.Layer4) string {
+	switch {
+	case !l4.TCP.IsEmpty():
+		return "TCP/" + strconv.Itoa(int(l4.TCP.DestinationPort))
+	case !l4.UDP.IsEmpty():
+		return "UDP/" + strconv.Itoa(int(l4.UDP.DestinationPort))
+	case !l4.ICMPv4.IsEmpty():
 		return "ICMPv4"
-	case *flowpb.Layer4_ICMPv6:
+	case !l4.ICMPv6.IsEmpty():
 		return "ICMPv6"
-	case *flowpb.Layer4_SCTP:
+	case !l4.SCTP.IsEmpty():
 		return "SCTP"
-	case *flowpb.Layer4_IGMP:
+	case !l4.IGMP.IsEmpty():
 		return "IGMP"
-	case *flowpb.Layer4_VRRP:
+	case !l4.VRRP.IsEmpty():
 		return "VRRP"
 	}
+
 	return ""
 }
 
-func (e *dropEventEmitter) getLocalEndpoint(flow *flowpb.Flow) *endpoint.Endpoint {
+func (e *dropEventEmitter) getLocalEndpoint(flow *ir.Flow) *endpoint.Endpoint {
 	var endpointID uint16
 	if flow.TrafficDirection == flowpb.TrafficDirection_INGRESS {
 		endpointID = uint16(flow.Destination.ID)
@@ -242,8 +244,8 @@ func parsePolicyRules(l4Rules []*models.PolicyRule, policyRevision uint64) (netw
 	return
 }
 
-func parsePolicyCorrelation(direction flowpb.TrafficDirection, ingressDeniedBy []*flowpb.Policy, egressDeniedBy []*flowpb.Policy) (networkPolicies set.Set[string], clusterwideNetworkPolicies set.Set[string]) {
-	var policies []*flowpb.Policy
+func parsePolicyCorrelation(direction flowpb.TrafficDirection, ingressDeniedBy, egressDeniedBy []ir.Policy) (networkPolicies set.Set[string], clusterwideNetworkPolicies set.Set[string]) {
+	var policies []ir.Policy
 	if direction == flowpb.TrafficDirection_INGRESS {
 		policies = ingressDeniedBy
 	} else {
@@ -259,7 +261,7 @@ func parsePolicyCorrelation(direction flowpb.TrafficDirection, ingressDeniedBy [
 	return
 }
 
-func (e *dropEventEmitter) dropEventPoliciesToString(flow *flowpb.Flow) (string, error) {
+func (e *dropEventEmitter) dropEventPoliciesToString(flow *ir.Flow) (string, error) {
 	var parts []string
 	prefix := "Denied by"
 	var networkPolicies, clusterwideNetworkPolicies set.Set[string]

--- a/pkg/hubble/dropeventemitter/dropeventemitter_test.go
+++ b/pkg/hubble/dropeventemitter/dropeventemitter_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/identity"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
@@ -27,25 +28,25 @@ func TestEndpointToString(t *testing.T) {
 	tests := []struct {
 		name     string
 		ip       string
-		endpoint *flowpb.Endpoint
+		endpoint ir.Endpoint
 		expect   string
 	}{
 		{
 			name:     fakePodName,
 			ip:       "1.2.3.4",
-			endpoint: &flowpb.Endpoint{PodName: fakePodName, Namespace: "namespace"},
+			endpoint: ir.Endpoint{PodName: fakePodName, Namespace: "namespace"},
 			expect:   "namespace/pod (1.2.3.4)",
 		},
 		{
 			name:     "node",
 			ip:       "1.2.3.4",
-			endpoint: &flowpb.Endpoint{Identity: identity.ReservedIdentityRemoteNode.Uint32()},
+			endpoint: ir.Endpoint{Identity: identity.ReservedIdentityRemoteNode.Uint32()},
 			expect:   identity.ReservedIdentityRemoteNode.String() + " (1.2.3.4)",
 		},
 		{
 			name:     "unknown",
 			ip:       "1.2.3.4",
-			endpoint: &flowpb.Endpoint{Identity: identity.MaxLocalIdentity.Uint32() + 1},
+			endpoint: ir.Endpoint{Identity: identity.MaxLocalIdentity.Uint32() + 1},
 			expect:   "1.2.3.4",
 		},
 	}
@@ -60,22 +61,22 @@ func TestEndpointToString(t *testing.T) {
 func TestL4protocolToString(t *testing.T) {
 	tests := []struct {
 		name   string
-		l4     *flowpb.Layer4
+		l4     ir.Layer4
 		expect string
 	}{
 		{
 			name:   "udp/512",
-			l4:     &flowpb.Layer4{Protocol: &flowpb.Layer4_UDP{UDP: &flowpb.UDP{DestinationPort: 512}}},
+			l4:     ir.Layer4{UDP: ir.UDP{DestinationPort: 512}},
 			expect: "UDP/512",
 		},
 		{
 			name:   "tcp/443",
-			l4:     &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{DestinationPort: 443}}},
+			l4:     ir.Layer4{TCP: ir.TCP{DestinationPort: 443}},
 			expect: "TCP/443",
 		},
 		{
 			name:   "unknown",
-			l4:     &flowpb.Layer4{},
+			l4:     ir.Layer4{},
 			expect: "",
 		},
 	}
@@ -90,84 +91,78 @@ func TestL4protocolToString(t *testing.T) {
 func TestProcessFlow(t *testing.T) {
 	tests := []struct {
 		name   string
-		flow   *flowpb.Flow
+		flow   *ir.Flow
 		expect string
 	}{
 		{
 			name: "valid ingress drop event",
-			flow: &flowpb.Flow{
+			flow: &ir.Flow{
 				Verdict:          flowpb.Verdict_DROPPED,
 				DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
-				IP:               &flowpb.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
-				Source:           &flowpb.Endpoint{},
-				Destination:      &flowpb.Endpoint{Namespace: "namespace", PodName: fakePodName},
-				L4:               &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{DestinationPort: 443}}},
+				IP:               ir.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
+				Destination:      ir.Endpoint{Namespace: "namespace", PodName: fakePodName},
+				L4:               ir.Layer4{TCP: ir.TCP{DestinationPort: 443}},
 			},
 			expect: "Incoming packet dropped (policy_denied) from unknown (1.2.3.4) TCP/443",
 		},
 		{
 			name: "valid egress drop event to node",
-			flow: &flowpb.Flow{
+			flow: &ir.Flow{
 				Verdict:          flowpb.Verdict_DROPPED,
 				DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
 				TrafficDirection: flowpb.TrafficDirection_EGRESS,
-				IP:               &flowpb.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
-				Source:           &flowpb.Endpoint{Namespace: "namespace", PodName: fakePodName},
-				Destination:      &flowpb.Endpoint{Identity: identity.ReservedIdentityRemoteNode.Uint32()},
-				L4:               &flowpb.Layer4{Protocol: &flowpb.Layer4_UDP{UDP: &flowpb.UDP{DestinationPort: 512}}},
+				IP:               ir.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
+				Source:           ir.Endpoint{Namespace: "namespace", PodName: fakePodName},
+				Destination:      ir.Endpoint{Identity: identity.ReservedIdentityRemoteNode.Uint32()},
+				L4:               ir.Layer4{UDP: ir.UDP{DestinationPort: 512}},
 			},
 			expect: "Outgoing packet dropped (policy_denied) to remote-node (5.6.7.8) UDP/512",
 		},
 		{
 			name: "ingress drop event not matching reason",
-			flow: &flowpb.Flow{
+			flow: &ir.Flow{
 				Verdict:          flowpb.Verdict_DROPPED,
 				DropReasonDesc:   flowpb.DropReason_AUTH_REQUIRED,
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
-				IP:               &flowpb.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
-				Source:           &flowpb.Endpoint{},
-				Destination:      &flowpb.Endpoint{Namespace: "namespace", PodName: fakePodName},
-				L4:               &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{DestinationPort: 443}}},
+				IP:               ir.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
+				Destination:      ir.Endpoint{Namespace: "namespace", PodName: fakePodName},
+				L4:               ir.Layer4{TCP: ir.TCP{DestinationPort: 443}},
 			},
 			expect: "",
 		},
 		{
 			name: "ingress verdict is not dropped",
-			flow: &flowpb.Flow{
+			flow: &ir.Flow{
 				Verdict:          flowpb.Verdict_ERROR,
 				DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
-				IP:               &flowpb.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
-				Source:           &flowpb.Endpoint{},
-				Destination:      &flowpb.Endpoint{Namespace: "namespace", PodName: fakePodName},
-				L4:               &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{DestinationPort: 443}}},
+				IP:               ir.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
+				Destination:      ir.Endpoint{Namespace: "namespace", PodName: fakePodName},
+				L4:               ir.Layer4{TCP: ir.TCP{DestinationPort: 443}},
 			},
 			expect: "",
 		},
 		{
 			name: "ingress but no destination pod",
-			flow: &flowpb.Flow{
+			flow: &ir.Flow{
 				Verdict:          flowpb.Verdict_DROPPED,
 				DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
-				IP:               &flowpb.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
-				Source:           &flowpb.Endpoint{Namespace: "namespace", PodName: fakePodName},
-				Destination:      &flowpb.Endpoint{},
-				L4:               &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{DestinationPort: 443}}},
+				IP:               ir.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
+				Source:           ir.Endpoint{Namespace: "namespace", PodName: fakePodName},
+				L4:               ir.Layer4{TCP: ir.TCP{DestinationPort: 443}},
 			},
 			expect: "",
 		},
 		{
 			name: "egress but no source pod",
-			flow: &flowpb.Flow{
+			flow: &ir.Flow{
 				Verdict:          flowpb.Verdict_DROPPED,
 				DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
 				TrafficDirection: flowpb.TrafficDirection_EGRESS,
-				IP:               &flowpb.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
-				Source:           &flowpb.Endpoint{},
-				Destination:      &flowpb.Endpoint{},
-				L4:               &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{DestinationPort: 443}}},
+				IP:               ir.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
+				L4:               ir.Layer4{TCP: ir.TCP{DestinationPort: 443}},
 			},
 			expect: "",
 		},
@@ -203,22 +198,22 @@ func TestProcessFlow(t *testing.T) {
 func TestGetLocalEndpoint(t *testing.T) {
 	tests := []struct {
 		name   string
-		flow   *flowpb.Flow
+		flow   ir.Flow
 		expect *endpoint.Endpoint
 	}{
 		{
 			name: "ingress",
-			flow: &flowpb.Flow{
+			flow: ir.Flow{
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
-				Destination:      &flowpb.Endpoint{ID: 1},
+				Destination:      ir.Endpoint{ID: 1},
 			},
 			expect: &endpoint.Endpoint{ID: 1},
 		},
 		{
 			name: "egress",
-			flow: &flowpb.Flow{
+			flow: ir.Flow{
 				TrafficDirection: flowpb.TrafficDirection_EGRESS,
-				Source:           &flowpb.Endpoint{ID: 2},
+				Source:           ir.Endpoint{ID: 2},
 			},
 			expect: &endpoint.Endpoint{ID: 2},
 		},
@@ -228,7 +223,7 @@ func TestGetLocalEndpoint(t *testing.T) {
 			e := &dropEventEmitter{
 				endpointsLookup: &fakeEndpointsLookup{},
 			}
-			ep := e.getLocalEndpoint(tt.flow)
+			ep := e.getLocalEndpoint(&tt.flow)
 			assert.Equal(t, tt.expect, ep)
 		})
 	}
@@ -368,15 +363,15 @@ func TestParsePolicyCorrelation(t *testing.T) {
 	tests := []struct {
 		name                  string
 		direction             flowpb.TrafficDirection
-		ingressDeniedBy       []*flowpb.Policy
-		egressDeniedBy        []*flowpb.Policy
+		ingressDeniedBy       []ir.Policy
+		egressDeniedBy        []ir.Policy
 		expectPolicies        set.Set[string]
 		expectClusterPolicies set.Set[string]
 	}{
 		{
 			name:      "Egress with network policy",
 			direction: flowpb.TrafficDirection_EGRESS,
-			egressDeniedBy: []*flowpb.Policy{
+			egressDeniedBy: []ir.Policy{
 				{
 					Name:      "foo",
 					Namespace: "bar",
@@ -388,7 +383,7 @@ func TestParsePolicyCorrelation(t *testing.T) {
 		{
 			name:      "Ingress with network policy",
 			direction: flowpb.TrafficDirection_INGRESS,
-			ingressDeniedBy: []*flowpb.Policy{
+			ingressDeniedBy: []ir.Policy{
 				{
 					Name:      "foo",
 					Namespace: "bar",
@@ -400,7 +395,7 @@ func TestParsePolicyCorrelation(t *testing.T) {
 		{
 			name:      "Egress with clusterwide network policy",
 			direction: flowpb.TrafficDirection_EGRESS,
-			egressDeniedBy: []*flowpb.Policy{
+			egressDeniedBy: []ir.Policy{
 				{
 					Name: "foo",
 					Kind: "CiliumClusterwideNetworkPolicy",
@@ -411,7 +406,7 @@ func TestParsePolicyCorrelation(t *testing.T) {
 		{
 			name:      "Egress with both namespaced and clusterwide network policies",
 			direction: flowpb.TrafficDirection_EGRESS,
-			egressDeniedBy: []*flowpb.Policy{
+			egressDeniedBy: []ir.Policy{
 				{
 					Name: "foowide",
 					Kind: "CiliumClusterwideNetworkPolicy",

--- a/pkg/hubble/dropeventemitter/dropeventemitter_test.go
+++ b/pkg/hubble/dropeventemitter/dropeventemitter_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/time"
@@ -28,25 +29,25 @@ func TestEndpointToString(t *testing.T) {
 	tests := []struct {
 		name     string
 		ip       string
-		endpoint *flowpb.Endpoint
+		endpoint ir.Endpoint
 		expect   string
 	}{
 		{
 			name:     fakePodName,
 			ip:       "1.2.3.4",
-			endpoint: &flowpb.Endpoint{PodName: fakePodName, Namespace: "namespace"},
+			endpoint: ir.Endpoint{PodName: fakePodName, Namespace: "namespace"},
 			expect:   "namespace/pod (1.2.3.4)",
 		},
 		{
 			name:     "node",
 			ip:       "1.2.3.4",
-			endpoint: &flowpb.Endpoint{Identity: identity.ReservedIdentityRemoteNode.Uint32()},
+			endpoint: ir.Endpoint{Identity: identity.ReservedIdentityRemoteNode.Uint32()},
 			expect:   identity.ReservedIdentityRemoteNode.String() + " (1.2.3.4)",
 		},
 		{
 			name:     "unknown",
 			ip:       "1.2.3.4",
-			endpoint: &flowpb.Endpoint{Identity: identity.MaxLocalIdentity.Uint32() + 1},
+			endpoint: ir.Endpoint{Identity: identity.MaxLocalIdentity.Uint32() + 1},
 			expect:   "1.2.3.4",
 		},
 	}
@@ -61,22 +62,22 @@ func TestEndpointToString(t *testing.T) {
 func TestL4protocolToString(t *testing.T) {
 	tests := []struct {
 		name   string
-		l4     *flowpb.Layer4
+		l4     ir.Layer4
 		expect string
 	}{
 		{
 			name:   "udp/512",
-			l4:     &flowpb.Layer4{Protocol: &flowpb.Layer4_UDP{UDP: &flowpb.UDP{DestinationPort: 512}}},
+			l4:     ir.Layer4{UDP: ir.UDP{DestinationPort: 512}},
 			expect: "UDP/512",
 		},
 		{
 			name:   "tcp/443",
-			l4:     &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{DestinationPort: 443}}},
+			l4:     ir.Layer4{TCP: ir.TCP{DestinationPort: 443}},
 			expect: "TCP/443",
 		},
 		{
 			name:   "unknown",
-			l4:     &flowpb.Layer4{},
+			l4:     ir.Layer4{},
 			expect: "",
 		},
 	}
@@ -94,9 +95,9 @@ func TestProcessFlowRateLimitChargedOnlyToEvents(t *testing.T) {
 		rateLimiter: rate.NewLimiter(time.Second, 1),
 	}
 
-	forwarded := &flowpb.Flow{Verdict: flowpb.Verdict_FORWARDED}
+	forwarded := ir.Flow{Verdict: flowpb.Verdict_FORWARDED}
 	for range 100 {
-		assert.NoError(t, e.ProcessFlow(context.Background(), forwarded))
+		assert.NoError(t, e.ProcessFlow(context.Background(), &forwarded))
 	}
 
 	assert.True(t, e.rateLimiter.Allow(),
@@ -106,113 +107,106 @@ func TestProcessFlowRateLimitChargedOnlyToEvents(t *testing.T) {
 func TestProcessFlow(t *testing.T) {
 	tests := []struct {
 		name         string
-		flow         *flowpb.Flow
+		flow         *ir.Flow
 		expect       string
 		expectPodUID string
 	}{
 		{
 			name: "valid ingress drop event with pod UID",
-			flow: &flowpb.Flow{
+			flow: &ir.Flow{
 				Verdict:          flowpb.Verdict_DROPPED,
 				DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
-				IP:               &flowpb.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
-				Source:           &flowpb.Endpoint{},
-				Destination:      &flowpb.Endpoint{Namespace: "namespace", PodName: fakePodName, PodUid: fakePodUID},
-				L4:               &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{DestinationPort: 443}}},
+				IP:               ir.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
+				Destination:      ir.Endpoint{Namespace: "namespace", PodName: fakePodName, PodUID: fakePodUID},
+				L4:               ir.Layer4{TCP: ir.TCP{DestinationPort: 443}},
 			},
 			expect:       "Incoming packet dropped (policy_denied) from unknown (1.2.3.4) TCP/443",
 			expectPodUID: fakePodUID,
 		},
 		{
 			name: "valid egress drop event with pod UID",
-			flow: &flowpb.Flow{
+			flow: &ir.Flow{
 				Verdict:          flowpb.Verdict_DROPPED,
 				DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
 				TrafficDirection: flowpb.TrafficDirection_EGRESS,
-				IP:               &flowpb.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
-				Source:           &flowpb.Endpoint{Namespace: "namespace", PodName: fakePodName, PodUid: fakePodUID},
-				Destination:      &flowpb.Endpoint{Identity: identity.ReservedIdentityRemoteNode.Uint32()},
-				L4:               &flowpb.Layer4{Protocol: &flowpb.Layer4_UDP{UDP: &flowpb.UDP{DestinationPort: 512}}},
+				IP:               ir.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
+				Source:           ir.Endpoint{Namespace: "namespace", PodName: fakePodName, PodUID: fakePodUID},
+				Destination:      ir.Endpoint{Identity: identity.ReservedIdentityRemoteNode.Uint32()},
+				L4:               ir.Layer4{UDP: ir.UDP{DestinationPort: 512}},
 			},
 			expect:       "Outgoing packet dropped (policy_denied) to remote-node (5.6.7.8) UDP/512",
 			expectPodUID: fakePodUID,
 		},
 		{
 			name: "valid ingress drop event without pod UID",
-			flow: &flowpb.Flow{
+			flow: &ir.Flow{
 				Verdict:          flowpb.Verdict_DROPPED,
 				DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
-				IP:               &flowpb.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
-				Source:           &flowpb.Endpoint{},
-				Destination:      &flowpb.Endpoint{Namespace: "namespace", PodName: fakePodName},
-				L4:               &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{DestinationPort: 443}}},
+				IP:               ir.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
+				Destination:      ir.Endpoint{Namespace: "namespace", PodName: fakePodName},
+				L4:               ir.Layer4{TCP: ir.TCP{DestinationPort: 443}},
 			},
 			expect: "Incoming packet dropped (policy_denied) from unknown (1.2.3.4) TCP/443",
 		},
 		{
-			name: "valid egress drop event without pod UID",
-			flow: &flowpb.Flow{
+			name: "valid egress drop event to node",
+			flow: &ir.Flow{
 				Verdict:          flowpb.Verdict_DROPPED,
 				DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
 				TrafficDirection: flowpb.TrafficDirection_EGRESS,
-				IP:               &flowpb.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
-				Source:           &flowpb.Endpoint{Namespace: "namespace", PodName: fakePodName},
-				Destination:      &flowpb.Endpoint{Identity: identity.ReservedIdentityRemoteNode.Uint32()},
-				L4:               &flowpb.Layer4{Protocol: &flowpb.Layer4_UDP{UDP: &flowpb.UDP{DestinationPort: 512}}},
+				IP:               ir.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
+				Source:           ir.Endpoint{Namespace: "namespace", PodName: fakePodName},
+				Destination:      ir.Endpoint{Identity: identity.ReservedIdentityRemoteNode.Uint32()},
+				L4:               ir.Layer4{UDP: ir.UDP{DestinationPort: 512}},
 			},
 			expect: "Outgoing packet dropped (policy_denied) to remote-node (5.6.7.8) UDP/512",
 		},
 		{
 			name: "ingress drop event not matching reason",
-			flow: &flowpb.Flow{
+			flow: &ir.Flow{
 				Verdict:          flowpb.Verdict_DROPPED,
 				DropReasonDesc:   flowpb.DropReason_AUTH_REQUIRED,
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
-				IP:               &flowpb.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
-				Source:           &flowpb.Endpoint{},
-				Destination:      &flowpb.Endpoint{Namespace: "namespace", PodName: fakePodName},
-				L4:               &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{DestinationPort: 443}}},
+				IP:               ir.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
+				Destination:      ir.Endpoint{Namespace: "namespace", PodName: fakePodName},
+				L4:               ir.Layer4{TCP: ir.TCP{DestinationPort: 443}},
 			},
 			expect: "",
 		},
 		{
 			name: "ingress verdict is not dropped",
-			flow: &flowpb.Flow{
+			flow: &ir.Flow{
 				Verdict:          flowpb.Verdict_ERROR,
 				DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
-				IP:               &flowpb.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
-				Source:           &flowpb.Endpoint{},
-				Destination:      &flowpb.Endpoint{Namespace: "namespace", PodName: fakePodName},
-				L4:               &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{DestinationPort: 443}}},
+				IP:               ir.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
+				Destination:      ir.Endpoint{Namespace: "namespace", PodName: fakePodName},
+				L4:               ir.Layer4{TCP: ir.TCP{DestinationPort: 443}},
 			},
 			expect: "",
 		},
 		{
 			name: "ingress but no destination pod",
-			flow: &flowpb.Flow{
+			flow: &ir.Flow{
 				Verdict:          flowpb.Verdict_DROPPED,
 				DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
-				IP:               &flowpb.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
-				Source:           &flowpb.Endpoint{Namespace: "namespace", PodName: fakePodName},
-				Destination:      &flowpb.Endpoint{},
-				L4:               &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{DestinationPort: 443}}},
+				IP:               ir.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
+				Source:           ir.Endpoint{Namespace: "namespace", PodName: fakePodName},
+				L4:               ir.Layer4{TCP: ir.TCP{DestinationPort: 443}},
 			},
 			expect: "",
 		},
 		{
 			name: "egress but no source pod",
-			flow: &flowpb.Flow{
+			flow: &ir.Flow{
 				Verdict:          flowpb.Verdict_DROPPED,
 				DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
 				TrafficDirection: flowpb.TrafficDirection_EGRESS,
-				IP:               &flowpb.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
-				Source:           &flowpb.Endpoint{},
-				Destination:      &flowpb.Endpoint{},
-				L4:               &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{DestinationPort: 443}}},
+				IP:               ir.IP{Source: "1.2.3.4", Destination: "5.6.7.8"},
+				L4:               ir.Layer4{TCP: ir.TCP{DestinationPort: 443}},
 			},
 			expect: "",
 		},
@@ -245,22 +239,22 @@ func TestProcessFlow(t *testing.T) {
 func TestGetLocalEndpoint(t *testing.T) {
 	tests := []struct {
 		name   string
-		flow   *flowpb.Flow
+		flow   ir.Flow
 		expect *endpoint.Endpoint
 	}{
 		{
 			name: "ingress",
-			flow: &flowpb.Flow{
+			flow: ir.Flow{
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
-				Destination:      &flowpb.Endpoint{ID: 1},
+				Destination:      ir.Endpoint{ID: 1},
 			},
 			expect: &endpoint.Endpoint{ID: 1},
 		},
 		{
 			name: "egress",
-			flow: &flowpb.Flow{
+			flow: ir.Flow{
 				TrafficDirection: flowpb.TrafficDirection_EGRESS,
-				Source:           &flowpb.Endpoint{ID: 2},
+				Source:           ir.Endpoint{ID: 2},
 			},
 			expect: &endpoint.Endpoint{ID: 2},
 		},
@@ -270,7 +264,7 @@ func TestGetLocalEndpoint(t *testing.T) {
 			e := &dropEventEmitter{
 				endpointsLookup: &fakeEndpointsLookup{},
 			}
-			ep := e.getLocalEndpoint(tt.flow)
+			ep := e.getLocalEndpoint(&tt.flow)
 			assert.Equal(t, tt.expect, ep)
 		})
 	}
@@ -410,15 +404,15 @@ func TestParsePolicyCorrelation(t *testing.T) {
 	tests := []struct {
 		name                  string
 		direction             flowpb.TrafficDirection
-		ingressDeniedBy       []*flowpb.Policy
-		egressDeniedBy        []*flowpb.Policy
+		ingressDeniedBy       []ir.Policy
+		egressDeniedBy        []ir.Policy
 		expectPolicies        set.Set[string]
 		expectClusterPolicies set.Set[string]
 	}{
 		{
 			name:      "Egress with network policy",
 			direction: flowpb.TrafficDirection_EGRESS,
-			egressDeniedBy: []*flowpb.Policy{
+			egressDeniedBy: []ir.Policy{
 				{
 					Name:      "foo",
 					Namespace: "bar",
@@ -430,7 +424,7 @@ func TestParsePolicyCorrelation(t *testing.T) {
 		{
 			name:      "Ingress with network policy",
 			direction: flowpb.TrafficDirection_INGRESS,
-			ingressDeniedBy: []*flowpb.Policy{
+			ingressDeniedBy: []ir.Policy{
 				{
 					Name:      "foo",
 					Namespace: "bar",
@@ -442,7 +436,7 @@ func TestParsePolicyCorrelation(t *testing.T) {
 		{
 			name:      "Egress with clusterwide network policy",
 			direction: flowpb.TrafficDirection_EGRESS,
-			egressDeniedBy: []*flowpb.Policy{
+			egressDeniedBy: []ir.Policy{
 				{
 					Name: "foo",
 					Kind: "CiliumClusterwideNetworkPolicy",
@@ -453,7 +447,7 @@ func TestParsePolicyCorrelation(t *testing.T) {
 		{
 			name:      "Egress with both namespaced and clusterwide network policies",
 			direction: flowpb.TrafficDirection_EGRESS,
-			egressDeniedBy: []*flowpb.Policy{
+			egressDeniedBy: []ir.Policy{
 				{
 					Name: "foowide",
 					Kind: "CiliumClusterwideNetworkPolicy",

--- a/pkg/hubble/exporter/aggregator.go
+++ b/pkg/hubble/exporter/aggregator.go
@@ -8,10 +8,12 @@ import (
 	"sync"
 
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	fa "github.com/cilium/cilium/pkg/hubble/parser/fieldaggregate"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -26,7 +28,7 @@ type AggregateValue struct {
 	IngressFlowCount          int
 	EgressFlowCount           int
 	UnknownDirectionFlowCount int
-	ProcessedFlow             *flowpb.Flow
+	ProcessedFlow             *ir.Flow
 }
 
 type Aggregator struct {
@@ -54,45 +56,27 @@ func NewAggregatorWithFields(fieldAggregate fa.FieldAggregate, logger *slog.Logg
 }
 
 func (a *Aggregator) Add(ev *v1.Event) {
+	if ev == nil {
+		return
+	}
 	f := ev.GetFlow()
 	if f == nil {
 		return
 	}
 
-	processedFlow := &flowpb.Flow{}
-	a.fieldAggregate.Copy(processedFlow.ProtoReflect(), f.ProtoReflect())
-
-	k := generateAggregationKey(processedFlow)
+	processedFlow := new(flowpb.Flow)
+	a.fieldAggregate.Copy(processedFlow.ProtoReflect(), f.ToProto().ProtoReflect())
 
 	// Enrich the processed flow with timestamp after key generation.
 	// This ensures timestamp doesn't affect aggregation, but preserves temporal context.
-	processedFlow.Time = f.GetTime()
+	processedFlow.Time = ev.Timestamp
+	k := generateAggregationKey(processedFlow)
 
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	v, ok := a.m[k]
-	if !ok {
-		switch f.GetTrafficDirection() {
-		case flowpb.TrafficDirection_INGRESS:
-			v = &AggregateValue{
-				IngressFlowCount: 1,
-				ProcessedFlow:    processedFlow,
-			}
-		case flowpb.TrafficDirection_EGRESS:
-			v = &AggregateValue{
-				EgressFlowCount: 1,
-				ProcessedFlow:   processedFlow,
-			}
-		default:
-			v = &AggregateValue{
-				UnknownDirectionFlowCount: 1,
-				ProcessedFlow:             processedFlow,
-			}
-		}
-		a.m[k] = v
-	} else {
-		switch f.GetTrafficDirection() {
+	if v, ok := a.m[k]; ok {
+		switch f.TrafficDirection {
 		case flowpb.TrafficDirection_INGRESS:
 			v.IngressFlowCount++
 		case flowpb.TrafficDirection_EGRESS:
@@ -100,7 +84,28 @@ func (a *Aggregator) Add(ev *v1.Event) {
 		default:
 			v.UnknownDirectionFlowCount++
 		}
+		return
 	}
+
+	var v AggregateValue
+	switch f.TrafficDirection {
+	case flowpb.TrafficDirection_INGRESS:
+		v = AggregateValue{
+			IngressFlowCount: 1,
+			ProcessedFlow:    f,
+		}
+	case flowpb.TrafficDirection_EGRESS:
+		v = AggregateValue{
+			EgressFlowCount: 1,
+			ProcessedFlow:   f,
+		}
+	default:
+		v = AggregateValue{
+			UnknownDirectionFlowCount: 1,
+			ProcessedFlow:             f,
+		}
+	}
+	a.m[k] = &v
 }
 
 // Export exports all aggregated flows and clears the aggregator.
@@ -119,11 +124,18 @@ func (a *Aggregator) Export(encoder Encoder) {
 		}
 	}
 
-	a.m = make(map[AggregateKey]*AggregateValue)
+	if a.m == nil {
+		a.m = make(map[AggregateKey]*AggregateValue)
+		return
+	}
+	for k := range a.m {
+		delete(a.m, k)
+	}
 }
 
 func generateAggregationKey(processedFlow *flowpb.Flow) AggregateKey {
 	b, _ := proto.Marshal(processedFlow.ProtoReflect().Interface())
+
 	return AggregateKey(b)
 }
 
@@ -181,20 +193,19 @@ func (r *AggregatorRunner) exportAggregates() {
 }
 
 // processedFlowToAggregatedExportEvent converts a flow to ExportEvent with aggregation counts.
-func processedFlowToAggregatedExportEvent(processedFlow *flowpb.Flow, ingressCount, egressCount, unknownDirectionFlowCount int) *observerpb.ExportEvent {
-	aggregate := &flowpb.Aggregate{
+func processedFlowToAggregatedExportEvent(processedFlow *ir.Flow, ingressCount, egressCount, unknownDirectionFlowCount int) *observerpb.ExportEvent {
+	flow := processedFlow.ToProto()
+	flow.Aggregate = &flowpb.Aggregate{
 		IngressFlowCount:          uint32(ingressCount),
 		EgressFlowCount:           uint32(egressCount),
 		UnknownDirectionFlowCount: uint32(unknownDirectionFlowCount),
 	}
 
-	processedFlow.Aggregate = aggregate
-
 	return &observerpb.ExportEvent{
-		Time:     processedFlow.GetTime(),
-		NodeName: processedFlow.GetNodeName(),
+		Time:     timestamppb.New(processedFlow.Time),
+		NodeName: processedFlow.NodeName,
 		ResponseTypes: &observerpb.ExportEvent_Flow{
-			Flow: processedFlow,
+			Flow: flow,
 		},
 	}
 }

--- a/pkg/hubble/exporter/aggregator.go
+++ b/pkg/hubble/exporter/aggregator.go
@@ -8,10 +8,12 @@ import (
 	"sync"
 
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	fa "github.com/cilium/cilium/pkg/hubble/parser/fieldaggregate"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -26,7 +28,7 @@ type AggregateValue struct {
 	IngressFlowCount          int
 	EgressFlowCount           int
 	UnknownDirectionFlowCount int
-	ProcessedFlow             *flowpb.Flow
+	ProcessedFlow             *ir.Flow
 }
 
 type Aggregator struct {
@@ -54,45 +56,27 @@ func NewAggregatorWithFields(fieldAggregate fa.FieldAggregate, logger *slog.Logg
 }
 
 func (a *Aggregator) Add(ev *v1.Event) {
+	if ev == nil {
+		return
+	}
 	f := ev.GetFlow()
 	if f == nil {
 		return
 	}
 
-	processedFlow := &flowpb.Flow{}
-	a.fieldAggregate.Copy(processedFlow.ProtoReflect(), f.ProtoReflect())
-
-	k := generateAggregationKey(processedFlow)
+	processedFlow := new(flowpb.Flow)
+	a.fieldAggregate.Copy(processedFlow.ProtoReflect(), f.ToProto().ProtoReflect())
 
 	// Enrich the processed flow with timestamp after key generation.
 	// This ensures timestamp doesn't affect aggregation, but preserves temporal context.
-	processedFlow.Time = f.GetTime()
+	processedFlow.Time = ev.Timestamp
+	k := generateAggregationKey(processedFlow)
 
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	v, ok := a.m[k]
-	if !ok {
-		switch f.GetTrafficDirection() {
-		case flowpb.TrafficDirection_INGRESS:
-			v = &AggregateValue{
-				IngressFlowCount: 1,
-				ProcessedFlow:    processedFlow,
-			}
-		case flowpb.TrafficDirection_EGRESS:
-			v = &AggregateValue{
-				EgressFlowCount: 1,
-				ProcessedFlow:   processedFlow,
-			}
-		default:
-			v = &AggregateValue{
-				UnknownDirectionFlowCount: 1,
-				ProcessedFlow:             processedFlow,
-			}
-		}
-		a.m[k] = v
-	} else {
-		switch f.GetTrafficDirection() {
+	if v, ok := a.m[k]; ok {
+		switch f.TrafficDirection {
 		case flowpb.TrafficDirection_INGRESS:
 			v.IngressFlowCount++
 		case flowpb.TrafficDirection_EGRESS:
@@ -100,7 +84,28 @@ func (a *Aggregator) Add(ev *v1.Event) {
 		default:
 			v.UnknownDirectionFlowCount++
 		}
+		return
 	}
+
+	var v AggregateValue
+	switch f.TrafficDirection {
+	case flowpb.TrafficDirection_INGRESS:
+		v = AggregateValue{
+			IngressFlowCount: 1,
+			ProcessedFlow:    f,
+		}
+	case flowpb.TrafficDirection_EGRESS:
+		v = AggregateValue{
+			EgressFlowCount: 1,
+			ProcessedFlow:   f,
+		}
+	default:
+		v = AggregateValue{
+			UnknownDirectionFlowCount: 1,
+			ProcessedFlow:             f,
+		}
+	}
+	a.m[k] = &v
 }
 
 // Export exports all aggregated flows and clears the aggregator.
@@ -119,11 +124,16 @@ func (a *Aggregator) Export(encoder Encoder) {
 		}
 	}
 
-	a.m = make(map[AggregateKey]*AggregateValue)
+	if a.m == nil {
+		a.m = make(map[AggregateKey]*AggregateValue)
+		return
+	}
+	clear(a.m)
 }
 
 func generateAggregationKey(processedFlow *flowpb.Flow) AggregateKey {
 	b, _ := proto.Marshal(processedFlow.ProtoReflect().Interface())
+
 	return AggregateKey(b)
 }
 
@@ -181,20 +191,19 @@ func (r *AggregatorRunner) exportAggregates() {
 }
 
 // processedFlowToAggregatedExportEvent converts a flow to ExportEvent with aggregation counts.
-func processedFlowToAggregatedExportEvent(processedFlow *flowpb.Flow, ingressCount, egressCount, unknownDirectionFlowCount int) *observerpb.ExportEvent {
-	aggregate := &flowpb.Aggregate{
+func processedFlowToAggregatedExportEvent(processedFlow *ir.Flow, ingressCount, egressCount, unknownDirectionFlowCount int) *observerpb.ExportEvent {
+	flow := processedFlow.ToProto()
+	flow.Aggregate = &flowpb.Aggregate{
 		IngressFlowCount:          uint32(ingressCount),
 		EgressFlowCount:           uint32(egressCount),
 		UnknownDirectionFlowCount: uint32(unknownDirectionFlowCount),
 	}
 
-	processedFlow.Aggregate = aggregate
-
 	return &observerpb.ExportEvent{
-		Time:     processedFlow.GetTime(),
-		NodeName: processedFlow.GetNodeName(),
+		Time:     timestamppb.New(processedFlow.Time),
+		NodeName: processedFlow.NodeName,
 		ResponseTypes: &observerpb.ExportEvent_Flow{
-			Flow: processedFlow,
+			Flow: flow,
 		},
 	}
 }

--- a/pkg/hubble/exporter/aggregator_test.go
+++ b/pkg/hubble/exporter/aggregator_test.go
@@ -17,6 +17,7 @@ import (
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/parser/fieldaggregate"
 	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/time"
@@ -64,14 +65,14 @@ func TestGenerateAggregationKey(t *testing.T) {
 	tests := []struct {
 		name       string
 		fieldPaths []string
-		flow       *flowpb.Flow
+		flow       *ir.Flow
 	}{
 		{
 			name:       "basic fields",
 			fieldPaths: []string{"destination.pod_name", "verdict"},
-			flow: &flowpb.Flow{
+			flow: &ir.Flow{
 				Verdict: flowpb.Verdict_FORWARDED,
-				Destination: &flowpb.Endpoint{
+				Destination: ir.Endpoint{
 					PodName: "dest-pod",
 				},
 			},
@@ -79,16 +80,14 @@ func TestGenerateAggregationKey(t *testing.T) {
 		{
 			name:       "empty fields",
 			fieldPaths: []string{},
-			flow: &flowpb.Flow{
+			flow: &ir.Flow{
 				Verdict: flowpb.Verdict_FORWARDED,
 			},
 		},
 		{
 			name:       "missing nested field",
 			fieldPaths: []string{"source.pod_name"},
-			flow: &flowpb.Flow{
-				Source: nil,
-			},
+			flow:       &ir.Flow{},
 		},
 	}
 
@@ -96,23 +95,21 @@ func TestGenerateAggregationKey(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fieldMask, err := fieldmaskpb.New(&flowpb.Flow{}, tt.fieldPaths...)
 			require.NoError(t, err)
-
 			fieldAgg, err := fieldaggregate.New(fieldMask)
 			require.NoError(t, err)
 
-			processedFlow := &flowpb.Flow{}
-			fieldAgg.Copy(processedFlow.ProtoReflect(), tt.flow.ProtoReflect())
+			processedFlow := new(flowpb.Flow)
+			fieldAgg.Copy(processedFlow.ProtoReflect(), tt.flow.ToProto().ProtoReflect())
 
 			key := generateAggregationKey(processedFlow)
-
 			if len(tt.fieldPaths) == 0 {
 				assert.Empty(t, string(key))
 			} else {
 				assert.NotEmpty(t, string(key))
 			}
 
-			processedFlow2 := &flowpb.Flow{}
-			fieldAgg.Copy(processedFlow2.ProtoReflect(), tt.flow.ProtoReflect())
+			processedFlow2 := new(flowpb.Flow)
+			fieldAgg.Copy(processedFlow2.ProtoReflect(), tt.flow.ToProto().ProtoReflect())
 			key2 := generateAggregationKey(processedFlow2)
 			assert.Equal(t, key, key2, "Keys should be deterministic")
 		})
@@ -131,19 +128,19 @@ func TestAggregateAdd(t *testing.T) {
 
 		// Add ingress, egress, and unknown direction flows with same verdict.
 		aggregator.Add(&v1.Event{
-			Event: &flowpb.Flow{
+			Event: &ir.Flow{
 				Verdict:          flowpb.Verdict_FORWARDED,
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
 			},
 		})
 		aggregator.Add(&v1.Event{
-			Event: &flowpb.Flow{
+			Event: &ir.Flow{
 				Verdict:          flowpb.Verdict_FORWARDED,
 				TrafficDirection: flowpb.TrafficDirection_EGRESS,
 			},
 		})
 		aggregator.Add(&v1.Event{
-			Event: &flowpb.Flow{
+			Event: &ir.Flow{
 				Verdict:          flowpb.Verdict_FORWARDED,
 				TrafficDirection: flowpb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN,
 			},
@@ -153,8 +150,8 @@ func TestAggregateAdd(t *testing.T) {
 		assert.Len(t, aggregator.m, 1)
 
 		// Create the expected key for verdict=FORWARDED.
-		expectedFlow := &flowpb.Flow{Verdict: flowpb.Verdict_FORWARDED}
-		expectedKey := generateAggregationKey(expectedFlow)
+		expectedFlow := ir.Flow{Verdict: flowpb.Verdict_FORWARDED}
+		expectedKey := generateAggregationKey(expectedFlow.ToProto())
 
 		value, exists := aggregator.m[expectedKey]
 		require.True(t, exists, "Expected aggregation key should exist")
@@ -202,8 +199,8 @@ func TestAggregateAdd(t *testing.T) {
 		assert.Len(t, aggregator.m, 1)
 
 		// Create the expected key for verdict=FORWARDED.
-		expectedFlow := &flowpb.Flow{Verdict: flowpb.Verdict_FORWARDED}
-		expectedKey := generateAggregationKey(expectedFlow)
+		expectedFlow := ir.Flow{Verdict: flowpb.Verdict_FORWARDED}
+		expectedKey := generateAggregationKey(expectedFlow.ToProto())
 
 		value, exists := aggregator.m[expectedKey]
 		require.True(t, exists, "Expected aggregation key should exist")
@@ -230,18 +227,18 @@ func TestAggregateAdd(t *testing.T) {
 		assert.Len(t, aggregator.m, 1)
 
 		// Find and verify the aggregation (src-pod1 -> dest-pod1).
-		expectedFlow := &flowpb.Flow{
-			Source: &flowpb.Endpoint{
+		expectedFlow := ir.Flow{
+			Source: ir.Endpoint{
 				Namespace: "default",
 				PodName:   "src-pod1",
 			},
-			Destination: &flowpb.Endpoint{
+			Destination: ir.Endpoint{
 				Namespace: "default",
 				PodName:   "dest-pod1",
 			},
 		}
-		processedFlow := &flowpb.Flow{}
-		fieldAgg.Copy(processedFlow.ProtoReflect(), expectedFlow.ProtoReflect())
+		processedFlow := new(flowpb.Flow)
+		fieldAgg.Copy(processedFlow.ProtoReflect(), expectedFlow.ToProto().ProtoReflect())
 		expectedKey := generateAggregationKey(processedFlow)
 
 		value, exists := aggregator.m[expectedKey]
@@ -270,43 +267,34 @@ func TestAggregateAdd(t *testing.T) {
 		aggregator := NewAggregatorWithFields(fieldAgg, hivetest.Logger(t))
 
 		// Create 2 identical TCP+HTTP flows.
-		flow1 := &flowpb.Flow{
-			Source: &flowpb.Endpoint{Namespace: "default"},
-			L4: &flowpb.Layer4{
-				Protocol: &flowpb.Layer4_TCP{
-					TCP: &flowpb.TCP{
-						SourcePort:      33001,
-						DestinationPort: 443,
-					},
+		flow1 := &ir.Flow{
+			Source: ir.Endpoint{Namespace: "default"},
+			L4: ir.Layer4{
+				TCP: ir.TCP{
+					SourcePort:      33001,
+					DestinationPort: 443,
 				},
 			},
-			L7: &flowpb.Layer7{
-				Type: flowpb.L7FlowType_RESPONSE,
-				Record: &flowpb.Layer7_Http{
-					Http: &flowpb.HTTP{
-						Code: 200,
-					},
+			L7: ir.Layer7{
+				HTTP: ir.HTTP{
+					Code: 200,
 				},
 			},
 			TrafficDirection: flowpb.TrafficDirection_INGRESS,
 		}
 
-		flow2 := &flowpb.Flow{
-			Source: &flowpb.Endpoint{Namespace: "default"},
-			L4: &flowpb.Layer4{
-				Protocol: &flowpb.Layer4_TCP{
-					TCP: &flowpb.TCP{
-						SourcePort:      33002, // Different source port (not in mask).
-						DestinationPort: 443,
-					},
+		flow2 := &ir.Flow{
+			Source: ir.Endpoint{Namespace: "default"},
+			L4: ir.Layer4{
+				TCP: ir.TCP{
+					SourcePort:      33002, // Different source port (not in mask).
+					DestinationPort: 443,
 				},
 			},
-			L7: &flowpb.Layer7{
+			L7: ir.Layer7{
 				Type: flowpb.L7FlowType_RESPONSE,
-				Record: &flowpb.Layer7_Http{
-					Http: &flowpb.HTTP{
-						Code: 200,
-					},
+				HTTP: ir.HTTP{
+					Code: 200,
 				},
 			},
 			TrafficDirection: flowpb.TrafficDirection_INGRESS,
@@ -339,19 +327,19 @@ func TestAggregateAdd(t *testing.T) {
 
 		// Add flows with DIFFERENT verdicts - should create 3 separate aggregates.
 		aggregator.Add(&v1.Event{
-			Event: &flowpb.Flow{
+			Event: &ir.Flow{
 				Verdict:          flowpb.Verdict_FORWARDED,
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
 			},
 		})
 		aggregator.Add(&v1.Event{
-			Event: &flowpb.Flow{
+			Event: &ir.Flow{
 				Verdict:          flowpb.Verdict_DROPPED,
 				TrafficDirection: flowpb.TrafficDirection_EGRESS,
 			},
 		})
 		aggregator.Add(&v1.Event{
-			Event: &flowpb.Flow{
+			Event: &ir.Flow{
 				Verdict:          flowpb.Verdict_ERROR,
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
 			},
@@ -359,7 +347,7 @@ func TestAggregateAdd(t *testing.T) {
 
 		// Add another FORWARDED flow - should add to existing FORWARDED aggregate.
 		aggregator.Add(&v1.Event{
-			Event: &flowpb.Flow{
+			Event: &ir.Flow{
 				Verdict:          flowpb.Verdict_FORWARDED,
 				TrafficDirection: flowpb.TrafficDirection_EGRESS,
 			},
@@ -388,7 +376,6 @@ func TestAggregateAdd(t *testing.T) {
 }
 
 func TestAggregateTimeEnrichment(t *testing.T) {
-
 	t.Run("time enriched despite not in fieldmask", func(t *testing.T) {
 		// Field Aggregate excludes time, but the processed flow is enriched anyway.
 		fieldMask, err := fieldmaskpb.New(&flowpb.Flow{}, "verdict")
@@ -400,8 +387,8 @@ func TestAggregateTimeEnrichment(t *testing.T) {
 		aggregator := NewAggregatorWithFields(fieldAgg, hivetest.Logger(t))
 		testTimestamp := &timestamp.Timestamp{Seconds: 1692369601, Nanos: 123456789}
 		aggregator.Add(&v1.Event{
-			Event: &flowpb.Flow{
-				Time:             testTimestamp,
+			Event: &ir.Flow{
+				Time:             testTimestamp.AsTime(),
 				Verdict:          flowpb.Verdict_FORWARDED,
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
 			},
@@ -410,7 +397,7 @@ func TestAggregateTimeEnrichment(t *testing.T) {
 		require.Len(t, aggregator.m, 1)
 		// Verify time is populated even though not in field mask.
 		for _, value := range aggregator.m {
-			assert.Equal(t, testTimestamp, value.ProcessedFlow.Time)
+			assert.Equal(t, testTimestamp.AsTime(), value.ProcessedFlow.Time)
 		}
 	})
 }
@@ -539,17 +526,22 @@ func TestAsyncProcessingEdgeCases(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
 func getEventList() []*v1.Event {
+	t1 := timestamp.Timestamp{Seconds: 1692369601}
+	t2 := timestamp.Timestamp{Seconds: 1692369602}
+	t3 := timestamp.Timestamp{Seconds: 1692369604}
+
 	return []*v1.Event{
 		{
-			Event: &flowpb.Flow{
-				Time:    &timestamp.Timestamp{Seconds: 1692369601},
+			Event: &ir.Flow{
+				Time:    t1.AsTime(),
 				Verdict: flowpb.Verdict_FORWARDED,
-				Source: &flowpb.Endpoint{
+				Source: ir.Endpoint{
 					Namespace: "default",
 					PodName:   "src-pod1",
 				},
-				Destination: &flowpb.Endpoint{
+				Destination: ir.Endpoint{
 					Namespace: "default",
 					PodName:   "dest-pod1",
 				},
@@ -557,14 +549,14 @@ func getEventList() []*v1.Event {
 			},
 		},
 		{
-			Event: &flowpb.Flow{
-				Time:    &timestamp.Timestamp{Seconds: 1692369604},
+			Event: &ir.Flow{
+				Time:    t2.AsTime(),
 				Verdict: flowpb.Verdict_FORWARDED,
-				Source: &flowpb.Endpoint{
+				Source: ir.Endpoint{
 					Namespace: "default",
 					PodName:   "src-pod1",
 				},
-				Destination: &flowpb.Endpoint{
+				Destination: ir.Endpoint{
 					Namespace: "default",
 					PodName:   "dest-pod1",
 				},
@@ -572,14 +564,14 @@ func getEventList() []*v1.Event {
 			},
 		},
 		{
-			Event: &flowpb.Flow{
-				Time:    &timestamp.Timestamp{Seconds: 1692369604},
+			Event: &ir.Flow{
+				Time:    t3.AsTime(),
 				Verdict: flowpb.Verdict_FORWARDED,
-				Source: &flowpb.Endpoint{
+				Source: ir.Endpoint{
 					Namespace: "default",
 					PodName:   "src-pod1",
 				},
-				Destination: &flowpb.Endpoint{
+				Destination: ir.Endpoint{
 					Namespace: "default",
 					PodName:   "dest-pod1",
 				},

--- a/pkg/hubble/exporter/aggregator_test.go
+++ b/pkg/hubble/exporter/aggregator_test.go
@@ -17,6 +17,7 @@ import (
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/parser/fieldaggregate"
 	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/time"
@@ -64,14 +65,14 @@ func TestGenerateAggregationKey(t *testing.T) {
 	tests := []struct {
 		name       string
 		fieldPaths []string
-		flow       *flowpb.Flow
+		flow       *ir.Flow
 	}{
 		{
 			name:       "basic fields",
 			fieldPaths: []string{"destination.pod_name", "verdict"},
-			flow: &flowpb.Flow{
+			flow: &ir.Flow{
 				Verdict: flowpb.Verdict_FORWARDED,
-				Destination: &flowpb.Endpoint{
+				Destination: ir.Endpoint{
 					PodName: "dest-pod",
 				},
 			},
@@ -79,16 +80,14 @@ func TestGenerateAggregationKey(t *testing.T) {
 		{
 			name:       "empty fields",
 			fieldPaths: []string{},
-			flow: &flowpb.Flow{
+			flow: &ir.Flow{
 				Verdict: flowpb.Verdict_FORWARDED,
 			},
 		},
 		{
 			name:       "missing nested field",
 			fieldPaths: []string{"source.pod_name"},
-			flow: &flowpb.Flow{
-				Source: nil,
-			},
+			flow:       &ir.Flow{},
 		},
 	}
 
@@ -96,23 +95,22 @@ func TestGenerateAggregationKey(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fieldMask, err := fieldmaskpb.New(&flowpb.Flow{}, tt.fieldPaths...)
 			require.NoError(t, err)
-
 			fieldAgg, err := fieldaggregate.New(fieldMask)
 			require.NoError(t, err)
 
-			processedFlow := &flowpb.Flow{}
-			fieldAgg.Copy(processedFlow.ProtoReflect(), tt.flow.ProtoReflect())
+			processedFlow := new(flowpb.Flow)
+			fieldAgg.Copy(processedFlow.ProtoReflect(), tt.flow.ToProto().ProtoReflect())
 
 			key := generateAggregationKey(processedFlow)
-
 			if len(tt.fieldPaths) == 0 {
 				assert.Empty(t, string(key))
 			} else {
 				assert.NotEmpty(t, string(key))
 			}
 
-			processedFlow2 := &flowpb.Flow{}
-			fieldAgg.Copy(processedFlow2.ProtoReflect(), tt.flow.ProtoReflect())
+			processedFlow2 := new(flowpb.Flow)
+			fieldAgg.Copy(processedFlow2.ProtoReflect(), tt.flow.ToProto().ProtoReflect())
+			// processedFlow2 := tt.flow
 			key2 := generateAggregationKey(processedFlow2)
 			assert.Equal(t, key, key2, "Keys should be deterministic")
 		})
@@ -131,19 +129,19 @@ func TestAggregateAdd(t *testing.T) {
 
 		// Add ingress, egress, and unknown direction flows with same verdict.
 		aggregator.Add(&v1.Event{
-			Event: &flowpb.Flow{
+			Event: &ir.Flow{
 				Verdict:          flowpb.Verdict_FORWARDED,
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
 			},
 		})
 		aggregator.Add(&v1.Event{
-			Event: &flowpb.Flow{
+			Event: &ir.Flow{
 				Verdict:          flowpb.Verdict_FORWARDED,
 				TrafficDirection: flowpb.TrafficDirection_EGRESS,
 			},
 		})
 		aggregator.Add(&v1.Event{
-			Event: &flowpb.Flow{
+			Event: &ir.Flow{
 				Verdict:          flowpb.Verdict_FORWARDED,
 				TrafficDirection: flowpb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN,
 			},
@@ -153,8 +151,8 @@ func TestAggregateAdd(t *testing.T) {
 		assert.Len(t, aggregator.m, 1)
 
 		// Create the expected key for verdict=FORWARDED.
-		expectedFlow := &flowpb.Flow{Verdict: flowpb.Verdict_FORWARDED}
-		expectedKey := generateAggregationKey(expectedFlow)
+		expectedFlow := ir.Flow{Verdict: flowpb.Verdict_FORWARDED}
+		expectedKey := generateAggregationKey(expectedFlow.ToProto())
 
 		value, exists := aggregator.m[expectedKey]
 		require.True(t, exists, "Expected aggregation key should exist")
@@ -202,8 +200,8 @@ func TestAggregateAdd(t *testing.T) {
 		assert.Len(t, aggregator.m, 1)
 
 		// Create the expected key for verdict=FORWARDED.
-		expectedFlow := &flowpb.Flow{Verdict: flowpb.Verdict_FORWARDED}
-		expectedKey := generateAggregationKey(expectedFlow)
+		expectedFlow := ir.Flow{Verdict: flowpb.Verdict_FORWARDED}
+		expectedKey := generateAggregationKey(expectedFlow.ToProto())
 
 		value, exists := aggregator.m[expectedKey]
 		require.True(t, exists, "Expected aggregation key should exist")
@@ -230,18 +228,18 @@ func TestAggregateAdd(t *testing.T) {
 		assert.Len(t, aggregator.m, 1)
 
 		// Find and verify the aggregation (src-pod1 -> dest-pod1).
-		expectedFlow := &flowpb.Flow{
-			Source: &flowpb.Endpoint{
+		expectedFlow := ir.Flow{
+			Source: ir.Endpoint{
 				Namespace: "default",
 				PodName:   "src-pod1",
 			},
-			Destination: &flowpb.Endpoint{
+			Destination: ir.Endpoint{
 				Namespace: "default",
 				PodName:   "dest-pod1",
 			},
 		}
-		processedFlow := &flowpb.Flow{}
-		fieldAgg.Copy(processedFlow.ProtoReflect(), expectedFlow.ProtoReflect())
+		processedFlow := new(flowpb.Flow)
+		fieldAgg.Copy(processedFlow.ProtoReflect(), expectedFlow.ToProto().ProtoReflect())
 		expectedKey := generateAggregationKey(processedFlow)
 
 		value, exists := aggregator.m[expectedKey]
@@ -270,43 +268,34 @@ func TestAggregateAdd(t *testing.T) {
 		aggregator := NewAggregatorWithFields(fieldAgg, hivetest.Logger(t))
 
 		// Create 2 identical TCP+HTTP flows.
-		flow1 := &flowpb.Flow{
-			Source: &flowpb.Endpoint{Namespace: "default"},
-			L4: &flowpb.Layer4{
-				Protocol: &flowpb.Layer4_TCP{
-					TCP: &flowpb.TCP{
-						SourcePort:      33001,
-						DestinationPort: 443,
-					},
+		flow1 := &ir.Flow{
+			Source: ir.Endpoint{Namespace: "default"},
+			L4: ir.Layer4{
+				TCP: ir.TCP{
+					SourcePort:      33001,
+					DestinationPort: 443,
 				},
 			},
-			L7: &flowpb.Layer7{
-				Type: flowpb.L7FlowType_RESPONSE,
-				Record: &flowpb.Layer7_Http{
-					Http: &flowpb.HTTP{
-						Code: 200,
-					},
+			L7: ir.Layer7{
+				HTTP: ir.HTTP{
+					Code: 200,
 				},
 			},
 			TrafficDirection: flowpb.TrafficDirection_INGRESS,
 		}
 
-		flow2 := &flowpb.Flow{
-			Source: &flowpb.Endpoint{Namespace: "default"},
-			L4: &flowpb.Layer4{
-				Protocol: &flowpb.Layer4_TCP{
-					TCP: &flowpb.TCP{
-						SourcePort:      33002, // Different source port (not in mask).
-						DestinationPort: 443,
-					},
+		flow2 := &ir.Flow{
+			Source: ir.Endpoint{Namespace: "default"},
+			L4: ir.Layer4{
+				TCP: ir.TCP{
+					SourcePort:      33002, // Different source port (not in mask).
+					DestinationPort: 443,
 				},
 			},
-			L7: &flowpb.Layer7{
+			L7: ir.Layer7{
 				Type: flowpb.L7FlowType_RESPONSE,
-				Record: &flowpb.Layer7_Http{
-					Http: &flowpb.HTTP{
-						Code: 200,
-					},
+				HTTP: ir.HTTP{
+					Code: 200,
 				},
 			},
 			TrafficDirection: flowpb.TrafficDirection_INGRESS,
@@ -339,19 +328,19 @@ func TestAggregateAdd(t *testing.T) {
 
 		// Add flows with DIFFERENT verdicts - should create 3 separate aggregates.
 		aggregator.Add(&v1.Event{
-			Event: &flowpb.Flow{
+			Event: &ir.Flow{
 				Verdict:          flowpb.Verdict_FORWARDED,
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
 			},
 		})
 		aggregator.Add(&v1.Event{
-			Event: &flowpb.Flow{
+			Event: &ir.Flow{
 				Verdict:          flowpb.Verdict_DROPPED,
 				TrafficDirection: flowpb.TrafficDirection_EGRESS,
 			},
 		})
 		aggregator.Add(&v1.Event{
-			Event: &flowpb.Flow{
+			Event: &ir.Flow{
 				Verdict:          flowpb.Verdict_ERROR,
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
 			},
@@ -359,7 +348,7 @@ func TestAggregateAdd(t *testing.T) {
 
 		// Add another FORWARDED flow - should add to existing FORWARDED aggregate.
 		aggregator.Add(&v1.Event{
-			Event: &flowpb.Flow{
+			Event: &ir.Flow{
 				Verdict:          flowpb.Verdict_FORWARDED,
 				TrafficDirection: flowpb.TrafficDirection_EGRESS,
 			},
@@ -388,7 +377,6 @@ func TestAggregateAdd(t *testing.T) {
 }
 
 func TestAggregateTimeEnrichment(t *testing.T) {
-
 	t.Run("time enriched despite not in fieldmask", func(t *testing.T) {
 		// Field Aggregate excludes time, but the processed flow is enriched anyway.
 		fieldMask, err := fieldmaskpb.New(&flowpb.Flow{}, "verdict")
@@ -400,8 +388,8 @@ func TestAggregateTimeEnrichment(t *testing.T) {
 		aggregator := NewAggregatorWithFields(fieldAgg, hivetest.Logger(t))
 		testTimestamp := &timestamp.Timestamp{Seconds: 1692369601, Nanos: 123456789}
 		aggregator.Add(&v1.Event{
-			Event: &flowpb.Flow{
-				Time:             testTimestamp,
+			Event: &ir.Flow{
+				Time:             testTimestamp.AsTime(),
 				Verdict:          flowpb.Verdict_FORWARDED,
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
 			},
@@ -410,7 +398,7 @@ func TestAggregateTimeEnrichment(t *testing.T) {
 		require.Len(t, aggregator.m, 1)
 		// Verify time is populated even though not in field mask.
 		for _, value := range aggregator.m {
-			assert.Equal(t, testTimestamp, value.ProcessedFlow.Time)
+			assert.Equal(t, testTimestamp.AsTime(), value.ProcessedFlow.Time)
 		}
 	})
 }
@@ -539,17 +527,22 @@ func TestAsyncProcessingEdgeCases(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
 func getEventList() []*v1.Event {
+	t1 := timestamp.Timestamp{Seconds: 1692369601}
+	t2 := timestamp.Timestamp{Seconds: 1692369602}
+	t3 := timestamp.Timestamp{Seconds: 1692369604}
+
 	return []*v1.Event{
 		{
-			Event: &flowpb.Flow{
-				Time:    &timestamp.Timestamp{Seconds: 1692369601},
+			Event: &ir.Flow{
+				Time:    t1.AsTime(),
 				Verdict: flowpb.Verdict_FORWARDED,
-				Source: &flowpb.Endpoint{
+				Source: ir.Endpoint{
 					Namespace: "default",
 					PodName:   "src-pod1",
 				},
-				Destination: &flowpb.Endpoint{
+				Destination: ir.Endpoint{
 					Namespace: "default",
 					PodName:   "dest-pod1",
 				},
@@ -557,14 +550,14 @@ func getEventList() []*v1.Event {
 			},
 		},
 		{
-			Event: &flowpb.Flow{
-				Time:    &timestamp.Timestamp{Seconds: 1692369604},
+			Event: &ir.Flow{
+				Time:    t2.AsTime(),
 				Verdict: flowpb.Verdict_FORWARDED,
-				Source: &flowpb.Endpoint{
+				Source: ir.Endpoint{
 					Namespace: "default",
 					PodName:   "src-pod1",
 				},
-				Destination: &flowpb.Endpoint{
+				Destination: ir.Endpoint{
 					Namespace: "default",
 					PodName:   "dest-pod1",
 				},
@@ -572,14 +565,14 @@ func getEventList() []*v1.Event {
 			},
 		},
 		{
-			Event: &flowpb.Flow{
-				Time:    &timestamp.Timestamp{Seconds: 1692369604},
+			Event: &ir.Flow{
+				Time:    t3.AsTime(),
 				Verdict: flowpb.Verdict_FORWARDED,
-				Source: &flowpb.Endpoint{
+				Source: ir.Endpoint{
 					Namespace: "default",
 					PodName:   "src-pod1",
 				},
-				Destination: &flowpb.Endpoint{
+				Destination: ir.Endpoint{
 					Namespace: "default",
 					PodName:   "dest-pod1",
 				},

--- a/pkg/hubble/exporter/config_test.go
+++ b/pkg/hubble/exporter/config_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/testutils"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -486,7 +487,7 @@ func TestFlowLogConfigEnd(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			exporter, err := exporterFactory.Create(tc.config)
 			assert.NoError(t, err)
-			err = exporter.Export(t.Context(), &v1.Event{Event: &flow.Flow{Uuid: "1234"}})
+			err = exporter.Export(t.Context(), &v1.Event{Event: &ir.Flow{UUID: "1234"}})
 			assert.NoError(t, err)
 			content, err := os.ReadFile(tc.config.FilePath)
 			assert.NoError(t, err)

--- a/pkg/hubble/exporter/exporter.go
+++ b/pkg/hubble/exporter/exporter.go
@@ -8,11 +8,13 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"sync"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	"github.com/cilium/cilium/pkg/hubble/filters"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 )
@@ -21,6 +23,13 @@ const (
 	DefaultFileMaxSizeMB  = 10
 	DefaultFileMaxBackups = 5
 )
+
+// exportEventPool tracks a pool of exported event vs allocating an event for every exported flows.
+// This yields pressure on GC to free all these objects with short lifecycle so instead
+// we propose using an object pool to reduce short allocations.
+var exportEventPool = sync.Pool{
+	New: func() any { return new(observerpb.ExportEvent) },
+}
 
 // FlowLogExporter is represents a type that can export hubble events.
 type FlowLogExporter interface {
@@ -133,7 +142,6 @@ func (e *exporter) Export(ctx context.Context, ev *v1.Event) error {
 	if !filters.Apply(e.opts.AllowFilters(), e.opts.DenyFilters(), ev) {
 		return nil
 	}
-
 	// Process OnExportEvent hooks
 	for _, f := range e.opts.OnExportEvent {
 		stop, err := f.OnExportEvent(ctx, ev, e.encoder)
@@ -150,7 +158,7 @@ func (e *exporter) Export(ctx context.Context, ev *v1.Event) error {
 	// If aggregation enabled, send only flow events to aggregator.
 	// Non-flow events bypass aggregation and are exported directly.
 	if e.aggregator != nil {
-		if _, ok := ev.Event.(*flowpb.Flow); ok {
+		if _, ok := ev.Event.(*ir.Flow); ok {
 			e.aggregator.Add(ev)
 			return nil
 		}
@@ -160,7 +168,12 @@ func (e *exporter) Export(ctx context.Context, ev *v1.Event) error {
 	if res == nil {
 		return nil
 	}
-	return e.encoder.Encode(res)
+	err := e.encoder.Encode(res)
+
+	// Returns to event object to the pool when done.
+	exportEventPool.Put(res)
+
+	return err
 }
 
 // Stop implements FlowLogExporter.
@@ -182,44 +195,40 @@ func (e *exporter) Stop() error {
 
 // eventToExportEvent converts Event to ExportEvent.
 func (e *exporter) eventToExportEvent(event *v1.Event) *observerpb.ExportEvent {
+	// Leverage the export event pool so we don't keep
+	// allocating new event object for every single exported flow.
+	evt := exportEventPool.Get().(*observerpb.ExportEvent)
+
+	evt.NodeName = nodeTypes.GetName()
+	evt.Time = event.Timestamp
+
 	switch ev := event.Event.(type) {
-	case *flowpb.Flow:
+	case *ir.Flow:
+		flow := ev.ToProto()
 		if e.opts.FieldMask.Active() {
-			e.opts.FieldMask.Copy(e.flow.ProtoReflect(), ev.ProtoReflect())
-			ev = e.flow
+			e.opts.FieldMask.Copy(e.flow.ProtoReflect(), flow.ProtoReflect())
+			flow = e.flow
 		}
-		return &observerpb.ExportEvent{
-			Time:     ev.GetTime(),
-			NodeName: ev.GetNodeName(),
-			ResponseTypes: &observerpb.ExportEvent_Flow{
-				Flow: ev,
-			},
+		evt.Time = flow.GetTime()
+		evt.NodeName = flow.GetNodeName()
+		evt.ResponseTypes = &observerpb.ExportEvent_Flow{
+			Flow: flow,
 		}
 	case *flowpb.LostEvent:
-		return &observerpb.ExportEvent{
-			Time:     event.Timestamp,
-			NodeName: nodeTypes.GetName(),
-			ResponseTypes: &observerpb.ExportEvent_LostEvents{
-				LostEvents: ev,
-			},
+		evt.ResponseTypes = &observerpb.ExportEvent_LostEvents{
+			LostEvents: ev,
 		}
 	case *flowpb.AgentEvent:
-		return &observerpb.ExportEvent{
-			Time:     event.Timestamp,
-			NodeName: nodeTypes.GetName(),
-			ResponseTypes: &observerpb.ExportEvent_AgentEvent{
-				AgentEvent: ev,
-			},
+		evt.ResponseTypes = &observerpb.ExportEvent_AgentEvent{
+			AgentEvent: ev,
 		}
 	case *flowpb.DebugEvent:
-		return &observerpb.ExportEvent{
-			Time:     event.Timestamp,
-			NodeName: nodeTypes.GetName(),
-			ResponseTypes: &observerpb.ExportEvent_DebugEvent{
-				DebugEvent: ev,
-			},
+		evt.ResponseTypes = &observerpb.ExportEvent_DebugEvent{
+			DebugEvent: ev,
 		}
 	default:
 		return nil
 	}
+
+	return evt
 }

--- a/pkg/hubble/exporter/exporter_test.go
+++ b/pkg/hubble/exporter/exporter_test.go
@@ -18,6 +18,7 @@ import (
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -49,11 +50,14 @@ func TestExporter(t *testing.T) {
 	defer func() {
 		nodeTypes.SetName(nodeName)
 	}()
+
+	t1 := timestamp.Timestamp{Seconds: 1}
+
 	events := []*v1.Event{
 		{
-			Event: &observerpb.Flow{
+			Event: &ir.Flow{
 				NodeName: newNodeName,
-				Time:     &timestamp.Timestamp{Seconds: 1},
+				Time:     t1.AsTime(),
 			},
 		},
 		{Timestamp: &timestamp.Timestamp{Seconds: 2}, Event: &observerpb.AgentEvent{}},
@@ -89,6 +93,12 @@ func TestExporterWithFilters(t *testing.T) {
 	denyFilterPod := &flowpb.FlowFilter{SourcePod: []string{"namespace-b/"}}
 	denyFilterNamespace := &flowpb.FlowFilter{NodeName: []string{"bad/node"}}
 
+	t1, t2, t3, t4, t5 := timestamp.Timestamp{Seconds: 12},
+		timestamp.Timestamp{Seconds: 13},
+		timestamp.Timestamp{Seconds: 14},
+		timestamp.Timestamp{Seconds: 15},
+		timestamp.Timestamp{Seconds: 16}
+
 	events := []*v1.Event{
 		// Non-flow events will not be processed when filters are set
 		{Timestamp: &timestamp.Timestamp{Seconds: 2}, Event: &observerpb.AgentEvent{}},
@@ -96,37 +106,37 @@ func TestExporterWithFilters(t *testing.T) {
 		{Timestamp: &timestamp.Timestamp{Seconds: 4}, Event: &observerpb.LostEvent{}},
 		// Does not match allowFilter.
 		{
-			Event: &observerpb.Flow{
-				Time: &timestamp.Timestamp{Seconds: 12},
+			Event: &ir.Flow{
+				Time: t1.AsTime(),
 			},
 		},
 		// Matches allowFilter.
 		{
-			Event: &observerpb.Flow{
-				Source: &flowpb.Endpoint{Namespace: "namespace-a", PodName: "x"},
-				Time:   &timestamp.Timestamp{Seconds: 13},
+			Event: &ir.Flow{
+				Source: ir.Endpoint{Namespace: "namespace-a", PodName: "x"},
+				Time:   t2.AsTime(),
 			},
 		},
 		// Matches denyFilter.
 		{
-			Event: &observerpb.Flow{
-				Source: &flowpb.Endpoint{Namespace: "namespace-b", PodName: "y"},
-				Time:   &timestamp.Timestamp{Seconds: 14},
+			Event: &ir.Flow{
+				Source: ir.Endpoint{Namespace: "namespace-b", PodName: "y"},
+				Time:   t3.AsTime(),
 			},
 		},
 		// Matches allowFilter, but also denyFilter - not processed.
 		{
-			Event: &observerpb.Flow{
-				Source:   &flowpb.Endpoint{Namespace: "namespace-a", PodName: "v"},
+			Event: &ir.Flow{
+				Source:   ir.Endpoint{Namespace: "namespace-a", PodName: "v"},
 				NodeName: "bad/node",
-				Time:     &timestamp.Timestamp{Seconds: 15},
+				Time:     t4.AsTime(),
 			},
 		},
 		// Matches allowFilter, but the context gets canceled below before it is processed.
 		{
-			Event: &observerpb.Flow{
-				Source: &flowpb.Endpoint{Namespace: "namespace-a", PodName: "z"},
-				Time:   &timestamp.Timestamp{Seconds: 16},
+			Event: &ir.Flow{
+				Source: ir.Endpoint{Namespace: "namespace-a", PodName: "z"},
+				Time:   t5.AsTime(),
 			},
 		},
 	}
@@ -166,9 +176,11 @@ func TestExporterWithFilters(t *testing.T) {
 			assert.NoError(t, err)
 		}
 	}
-	assert.JSONEq(t,
-		`{"flow":{"time":"1970-01-01T00:00:13Z","source":{"namespace":"namespace-a","pod_name":"x"}},"time":"1970-01-01T00:00:13Z"}
-`, buf.String())
+	assert.JSONEq(
+		t,
+		`{"flow":{"source":{"namespace":"namespace-a","pod_name":"x"}, "time":"1970-01-01T00:00:13Z"}, "time":"1970-01-01T00:00:13Z"}`,
+		buf.String(),
+	)
 }
 
 func TestEventToExportEvent_DefaultCase(t *testing.T) {
@@ -214,16 +226,16 @@ func TestEventToExportEvent(t *testing.T) {
 
 	// flow
 	ev := v1.Event{
-		Event: &observerpb.Flow{
+		Event: &ir.Flow{
 			NodeName: newNodeName,
-			Time:     &timestamp.Timestamp{Seconds: 1},
+			Time:     time.Now(),
 		},
 	}
 	res := exporter.eventToExportEvent(&ev)
 	expected := &observerpb.ExportEvent{
-		ResponseTypes: &observerpb.ExportEvent_Flow{Flow: ev.Event.(*flowpb.Flow)},
+		ResponseTypes: &observerpb.ExportEvent_Flow{Flow: ev.Event.(*ir.Flow).ToProto()},
 		NodeName:      newNodeName,
-		Time:          ev.GetFlow().Time,
+		Time:          timestamp.New(ev.GetFlow().Time),
 	}
 	assert.Equal(t, expected, res)
 
@@ -270,17 +282,17 @@ func TestEventToExportEvent(t *testing.T) {
 func TestExporterWithFieldMask(t *testing.T) {
 	events := []*v1.Event{
 		{
-			Event: &observerpb.Flow{
+			Event: &ir.Flow{
 				NodeName: "nodeName",
-				Time:     &timestamp.Timestamp{Seconds: 12},
-				Source:   &flowpb.Endpoint{PodName: "podA", Namespace: "nsA"},
+				Time:     time.Now(),
+				Source:   ir.Endpoint{PodName: "podA", Namespace: "nsA"},
 			},
 		},
 		{
-			Event: &observerpb.Flow{
+			Event: &ir.Flow{
 				NodeName:    "nodeName",
-				Time:        &timestamp.Timestamp{Seconds: 13},
-				Destination: &flowpb.Endpoint{PodName: "podB", Namespace: "nsB"}},
+				Time:        time.Now(),
+				Destination: ir.Endpoint{PodName: "podB", Namespace: "nsB"}},
 		},
 	}
 	buf := &bytesWriteCloser{bytes.Buffer{}}
@@ -327,11 +339,12 @@ func TestExporterOnExportEvent(t *testing.T) {
 		nodeTypes.SetName(nodeName)
 	}()
 
+	t1 := timestamp.Timestamp{Seconds: 1}
 	events := []*v1.Event{
 		{
-			Event: &observerpb.Flow{
+			Event: &ir.Flow{
 				NodeName: newNodeName,
-				Time:     &timestamp.Timestamp{Seconds: 1},
+				Time:     t1.AsTime(),
 			},
 		},
 		{Timestamp: &timestamp.Timestamp{Seconds: 2}, Event: &observerpb.DebugEvent{}},
@@ -513,7 +526,7 @@ func TestExporterAggregationDisabledWhenIntervalZero(t *testing.T) {
 
 	// Send two flow events that would otherwise aggregate.
 	for range 2 {
-		err := exporter.Export(t.Context(), &v1.Event{Event: &flowpb.Flow{Verdict: flowpb.Verdict_FORWARDED}})
+		err := exporter.Export(t.Context(), &v1.Event{Event: &ir.Flow{Verdict: flowpb.Verdict_FORWARDED}})
 		assert.NoError(t, err)
 	}
 
@@ -594,7 +607,7 @@ func TestExporterAggregationEventRouting(t *testing.T) {
 		assert.NoError(t, err)
 		defer exporter.Stop()
 
-		flowEvent := &v1.Event{Event: &flowpb.Flow{Verdict: flowpb.Verdict_DROPPED}}
+		flowEvent := &v1.Event{Event: &ir.Flow{Verdict: flowpb.Verdict_DROPPED}}
 		err = exporter.Export(t.Context(), flowEvent)
 		assert.NoError(t, err)
 
@@ -628,9 +641,9 @@ func TestProcessedFlowToAggregatedExportEvent(t *testing.T) {
 	defer exporter.Stop()
 
 	// Create a pre-processed flow.
-	processedFlow := &flowpb.Flow{
+	processedFlow := &ir.Flow{
 		Verdict: flowpb.Verdict_FORWARDED,
-		Source: &flowpb.Endpoint{
+		Source: ir.Endpoint{
 			PodName: "test-pod", // Only pod_name should be present as defined in FieldAggregate.
 
 		},
@@ -644,7 +657,7 @@ func TestProcessedFlowToAggregatedExportEvent(t *testing.T) {
 	flow := result.GetFlow()
 	assert.NotNil(t, flow)
 
-	aggregate := flow.GetAggregate()
+	aggregate := flow.Aggregate
 	assert.NotNil(t, aggregate)
 	assert.Equal(t, uint32(ingressCount), aggregate.IngressFlowCount)
 	assert.Equal(t, uint32(egressCount), aggregate.EgressFlowCount)
@@ -653,8 +666,8 @@ func TestProcessedFlowToAggregatedExportEvent(t *testing.T) {
 	assert.Equal(t, processedFlow.Verdict, flow.Verdict)
 	assert.Equal(t, "test-pod", flow.Source.PodName)
 	assert.Nil(t, flow.Destination) // Should not have any fields not defined in FieldAggregate.
-	assert.Empty(t, flow.GetNodeName())
-	assert.Nil(t, flow.GetTime())
+	assert.Empty(t, flow.NodeName)
+	assert.Nil(t, flow.Time)
 }
 
 func BenchmarkExporter(b *testing.B) {

--- a/pkg/hubble/exporter/script_test.go
+++ b/pkg/hubble/exporter/script_test.go
@@ -21,6 +21,7 @@ import (
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	"github.com/cilium/cilium/pkg/hubble/exporter"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -283,9 +284,8 @@ func eventSendCmd(state *testState) script.Cmd {
 			if err := json.Unmarshal(data, &flow); err != nil {
 				return nil, fmt.Errorf("failed to parse event: %w", err)
 			}
-
 			ev := &v1.Event{
-				Event: &flow,
+				Event: ir.ProtoToFlow(&flow),
 			}
 
 			state.mu.Lock()

--- a/pkg/hubble/filters/cel_expression.go
+++ b/pkg/hubble/filters/cel_expression.go
@@ -85,9 +85,11 @@ func filterByCELExpression(ctx context.Context, log *slog.Logger, exprs []string
 	}
 
 	return func(ev *v1.Event) bool {
+		// !!BOZO!! Revisit!! for now need to convert to proto to make CEL work.
+		fl := ev.GetFlow().ToProto()
 		for _, prg := range programs {
 			out, _, err := prg.ContextEval(ctx, map[string]any{
-				flowVariableName: ev.GetFlow(),
+				flowVariableName: fl,
 			})
 			if err != nil {
 				log.Error("error running CEL program", logfields.Error, err)

--- a/pkg/hubble/filters/cel_expression_test.go
+++ b/pkg/hubble/filters/cel_expression_test.go
@@ -10,6 +10,7 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 )
 
 func TestCELExpressionFilter(t *testing.T) {
@@ -30,9 +31,9 @@ func TestCELExpressionFilter(t *testing.T) {
 					{Experimental: &flowpb.FlowFilter_Experimental{CelExpression: []string{"_flow.verdict == Verdict.FORWARDED || _flow.verdict == Verdict.TRANSLATED"}}},
 				},
 				ev: []*v1.Event{
-					{Event: &flowpb.Flow{Verdict: flowpb.Verdict_FORWARDED}},
-					{Event: &flowpb.Flow{Verdict: flowpb.Verdict_DROPPED}},
-					{Event: &flowpb.Flow{Verdict: flowpb.Verdict_TRANSLATED}},
+					{Event: &ir.Flow{Verdict: flowpb.Verdict_FORWARDED}},
+					{Event: &ir.Flow{Verdict: flowpb.Verdict_DROPPED}},
+					{Event: &ir.Flow{Verdict: flowpb.Verdict_TRANSLATED}},
 				},
 			},
 			want: []bool{
@@ -48,9 +49,9 @@ func TestCELExpressionFilter(t *testing.T) {
 					{Experimental: &flowpb.FlowFilter_Experimental{CelExpression: []string{"_flow.IP.source == '1.1.1.1' || _flow.IP.destination == '8.8.8.8'"}}},
 				},
 				ev: []*v1.Event{
-					{Event: &flowpb.Flow{IP: &flowpb.IP{Source: "1.1.1.1", Destination: "10.0.0.2"}}},
-					{Event: &flowpb.Flow{IP: &flowpb.IP{Source: "10.0.0.2", Destination: "1.1.1.1"}}},
-					{Event: &flowpb.Flow{IP: &flowpb.IP{Source: "10.0.0.2", Destination: "8.8.8.8"}}},
+					{Event: &ir.Flow{IP: ir.IP{Source: "1.1.1.1", Destination: "10.0.0.2"}}},
+					{Event: &ir.Flow{IP: ir.IP{Source: "10.0.0.2", Destination: "1.1.1.1"}}},
+					{Event: &ir.Flow{IP: ir.IP{Source: "10.0.0.2", Destination: "8.8.8.8"}}},
 				},
 			},
 			want: []bool{
@@ -66,9 +67,9 @@ func TestCELExpressionFilter(t *testing.T) {
 					{Experimental: &flowpb.FlowFilter_Experimental{CelExpression: []string{"has(_flow.l4.TCP)"}}},
 				},
 				ev: []*v1.Event{
-					{Event: &flowpb.Flow{L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{SourcePort: 20222, DestinationPort: 80}}}}},
-					{Event: &flowpb.Flow{L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_UDP{UDP: &flowpb.UDP{SourcePort: 30222, DestinationPort: 53}}}}},
-					{Event: &flowpb.Flow{L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{SourcePort: 20222, DestinationPort: 443}}}}},
+					{Event: &ir.Flow{L4: ir.Layer4{TCP: ir.TCP{SourcePort: 20222, DestinationPort: 80}}}},
+					{Event: &ir.Flow{L4: ir.Layer4{UDP: ir.UDP{SourcePort: 30222, DestinationPort: 53}}}},
+					{Event: &ir.Flow{L4: ir.Layer4{TCP: ir.TCP{SourcePort: 20222, DestinationPort: 443}}}},
 				},
 			},
 			want: []bool{
@@ -84,9 +85,9 @@ func TestCELExpressionFilter(t *testing.T) {
 					{Experimental: &flowpb.FlowFilter_Experimental{CelExpression: []string{"has(_flow.l4.TCP) && (_flow.l4.TCP.destination_port == uint(80) || _flow.l4.TCP.destination_port == uint(443))"}}},
 				},
 				ev: []*v1.Event{
-					{Event: &flowpb.Flow{L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{SourcePort: 20222, DestinationPort: 80}}}}},
-					{Event: &flowpb.Flow{L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_UDP{UDP: &flowpb.UDP{SourcePort: 30222, DestinationPort: 53}}}}},
-					{Event: &flowpb.Flow{L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{SourcePort: 20222, DestinationPort: 443}}}}},
+					{Event: &ir.Flow{L4: ir.Layer4{TCP: ir.TCP{SourcePort: 20222, DestinationPort: 80}}}},
+					{Event: &ir.Flow{L4: ir.Layer4{UDP: ir.UDP{SourcePort: 30222, DestinationPort: 53}}}},
+					{Event: &ir.Flow{L4: ir.Layer4{TCP: ir.TCP{SourcePort: 20222, DestinationPort: 443}}}},
 				},
 			},
 			want: []bool{
@@ -123,6 +124,7 @@ func TestCELExpressionFilter(t *testing.T) {
 			wantErr: true,
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			log := hivetest.Logger(t)

--- a/pkg/hubble/filters/cluster_name.go
+++ b/pkg/hubble/filters/cluster_name.go
@@ -13,11 +13,27 @@ import (
 )
 
 func sourceClusterName(ev *v1.Event) string {
-	return ev.GetFlow().GetSource().GetClusterName()
+	if ev == nil {
+		return ""
+	}
+	fl := ev.GetFlow()
+	if fl == nil {
+		return ""
+	}
+
+	return fl.Source.ClusterName
 }
 
 func destinationClusterName(ev *v1.Event) string {
-	return ev.GetFlow().GetDestination().GetClusterName()
+	if ev == nil {
+		return ""
+	}
+	fl := ev.GetFlow()
+	if fl == nil {
+		return ""
+	}
+
+	return fl.Destination.ClusterName
 }
 
 func filterByClusterName(names []string, getClusterName func(*v1.Event) string) (FilterFunc, error) {

--- a/pkg/hubble/filters/cluster_name_test.go
+++ b/pkg/hubble/filters/cluster_name_test.go
@@ -8,6 +8,7 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 )
 
 func TestClusterNameFilter(t *testing.T) {
@@ -24,11 +25,11 @@ func TestClusterNameFilter(t *testing.T) {
 				{SourceClusterName: []string{"aws-south-1", "gke-europe-west1-c"}},
 			},
 			ev: []*v1.Event{
-				{Event: &flowpb.Flow{Source: &flowpb.Endpoint{ClusterName: "aws-south-1"}}},
-				{Event: &flowpb.Flow{Source: &flowpb.Endpoint{ClusterName: "gke-europe-west1-c"}}},
-				{Event: &flowpb.Flow{}},
-				{Event: &flowpb.Flow{Source: &flowpb.Endpoint{ClusterName: "aks-eastus2-1"}}},
-				{Event: &flowpb.Flow{Destination: &flowpb.Endpoint{ClusterName: "gke-europe-west1-c"}}},
+				{Event: &ir.Flow{Source: ir.Endpoint{ClusterName: "aws-south-1"}}},
+				{Event: &ir.Flow{Source: ir.Endpoint{ClusterName: "gke-europe-west1-c"}}},
+				{Event: &ir.Flow{}},
+				{Event: &ir.Flow{Source: ir.Endpoint{ClusterName: "aks-eastus2-1"}}},
+				{Event: &ir.Flow{Destination: ir.Endpoint{ClusterName: "gke-europe-west1-c"}}},
 			},
 			want: []bool{
 				true,
@@ -44,11 +45,11 @@ func TestClusterNameFilter(t *testing.T) {
 				{DestinationClusterName: []string{"aws-south-1", "gke-europe-west1-c"}},
 			},
 			ev: []*v1.Event{
-				{Event: &flowpb.Flow{Destination: &flowpb.Endpoint{ClusterName: "aws-south-1"}}},
-				{Event: &flowpb.Flow{Destination: &flowpb.Endpoint{ClusterName: "gke-europe-west1-c"}}},
-				{Event: &flowpb.Flow{}},
-				{Event: &flowpb.Flow{Destination: &flowpb.Endpoint{ClusterName: "aks-eastus2-1"}}},
-				{Event: &flowpb.Flow{Source: &flowpb.Endpoint{ClusterName: "gke-europe-west1-c"}}},
+				{Event: &ir.Flow{Destination: ir.Endpoint{ClusterName: "aws-south-1"}}},
+				{Event: &ir.Flow{Destination: ir.Endpoint{ClusterName: "gke-europe-west1-c"}}},
+				{Event: &ir.Flow{}},
+				{Event: &ir.Flow{Destination: ir.Endpoint{ClusterName: "aks-eastus2-1"}}},
+				{Event: &ir.Flow{Source: ir.Endpoint{ClusterName: "gke-europe-west1-c"}}},
 			},
 			want: []bool{
 				true,
@@ -67,28 +68,28 @@ func TestClusterNameFilter(t *testing.T) {
 				},
 			},
 			ev: []*v1.Event{
-				{Event: &flowpb.Flow{
-					Source:      &flowpb.Endpoint{ClusterName: "aws-south-1"},
-					Destination: &flowpb.Endpoint{ClusterName: "aks-eastus2-1"},
+				{Event: &ir.Flow{
+					Source:      ir.Endpoint{ClusterName: "aws-south-1"},
+					Destination: ir.Endpoint{ClusterName: "aks-eastus2-1"},
 				}},
-				{Event: &flowpb.Flow{
-					Source:      &flowpb.Endpoint{ClusterName: "gke-europe-west1-c"},
-					Destination: &flowpb.Endpoint{ClusterName: "aks-eastus2-1"},
+				{Event: &ir.Flow{
+					Source:      ir.Endpoint{ClusterName: "gke-europe-west1-c"},
+					Destination: ir.Endpoint{ClusterName: "aks-eastus2-1"},
 				}},
-				{Event: &flowpb.Flow{
-					Source:      &flowpb.Endpoint{ClusterName: "default"},
-					Destination: &flowpb.Endpoint{ClusterName: "aks-eastus2-1"},
+				{Event: &ir.Flow{
+					Source:      ir.Endpoint{ClusterName: "default"},
+					Destination: ir.Endpoint{ClusterName: "aks-eastus2-1"},
 				}},
-				{Event: &flowpb.Flow{
-					Source:      &flowpb.Endpoint{ClusterName: "aks-eastus2-1"},
-					Destination: &flowpb.Endpoint{ClusterName: "aws-south-1"},
+				{Event: &ir.Flow{
+					Source:      ir.Endpoint{ClusterName: "aks-eastus2-1"},
+					Destination: ir.Endpoint{ClusterName: "aws-south-1"},
 				}},
-				{Event: &flowpb.Flow{
-					Source:      &flowpb.Endpoint{ClusterName: "aks-eastus2-1"},
-					Destination: &flowpb.Endpoint{ClusterName: "gke-europe-west1-c"},
+				{Event: &ir.Flow{
+					Source:      ir.Endpoint{ClusterName: "aks-eastus2-1"},
+					Destination: ir.Endpoint{ClusterName: "gke-europe-west1-c"},
 				}},
-				{Event: &flowpb.Flow{
-					Destination: &flowpb.Endpoint{ClusterName: "default"},
+				{Event: &ir.Flow{
+					Destination: ir.Endpoint{ClusterName: "default"},
 				}},
 			},
 			want: []bool{
@@ -107,28 +108,28 @@ func TestClusterNameFilter(t *testing.T) {
 				{DestinationClusterName: []string{"aks-eastus2-1"}},
 			},
 			ev: []*v1.Event{
-				{Event: &flowpb.Flow{
-					Source:      &flowpb.Endpoint{ClusterName: "aws-south-1"},
-					Destination: &flowpb.Endpoint{ClusterName: "default"},
+				{Event: &ir.Flow{
+					Source:      ir.Endpoint{ClusterName: "aws-south-1"},
+					Destination: ir.Endpoint{ClusterName: "default"},
 				}},
-				{Event: &flowpb.Flow{
-					Source:      &flowpb.Endpoint{ClusterName: "gke-europe-west1-c"},
-					Destination: &flowpb.Endpoint{ClusterName: "default"},
+				{Event: &ir.Flow{
+					Source:      ir.Endpoint{ClusterName: "gke-europe-west1-c"},
+					Destination: ir.Endpoint{ClusterName: "default"},
 				}},
-				{Event: &flowpb.Flow{
-					Source:      &flowpb.Endpoint{ClusterName: "default"},
-					Destination: &flowpb.Endpoint{ClusterName: "aks-eastus2-1"},
+				{Event: &ir.Flow{
+					Source:      ir.Endpoint{ClusterName: "default"},
+					Destination: ir.Endpoint{ClusterName: "aks-eastus2-1"},
 				}},
-				{Event: &flowpb.Flow{
-					Source:      &flowpb.Endpoint{ClusterName: "aks-eastus2-1"},
-					Destination: &flowpb.Endpoint{ClusterName: "aws-south-1"},
+				{Event: &ir.Flow{
+					Source:      ir.Endpoint{ClusterName: "aks-eastus2-1"},
+					Destination: ir.Endpoint{ClusterName: "aws-south-1"},
 				}},
-				{Event: &flowpb.Flow{
-					Source:      &flowpb.Endpoint{ClusterName: "aks-eastus2-1"},
-					Destination: &flowpb.Endpoint{ClusterName: "gke-europe-west1-c"},
+				{Event: &ir.Flow{
+					Source:      ir.Endpoint{ClusterName: "aks-eastus2-1"},
+					Destination: ir.Endpoint{ClusterName: "gke-europe-west1-c"},
 				}},
-				{Event: &flowpb.Flow{
-					Destination: &flowpb.Endpoint{ClusterName: "default"},
+				{Event: &ir.Flow{
+					Destination: ir.Endpoint{ClusterName: "default"},
 				}},
 			},
 			want: []bool{
@@ -148,8 +149,8 @@ func TestClusterNameFilter(t *testing.T) {
 			ev: []*v1.Event{
 				nil,
 				{},
-				{Event: &flowpb.Flow{}},
-				{Event: &flowpb.Flow{Source: &flowpb.Endpoint{ClusterName: ""}}},
+				{Event: &ir.Flow{}},
+				{Event: &ir.Flow{Source: ir.Endpoint{ClusterName: ""}}},
 			},
 			want: []bool{
 				false,

--- a/pkg/hubble/filters/drop_reason_desc.go
+++ b/pkg/hubble/filters/drop_reason_desc.go
@@ -17,11 +17,10 @@ func filterByDropReasonDesc(dropReasons []flowpb.DropReason) FilterFunc {
 		if flow == nil {
 			return false
 		}
-		verdict := flow.GetVerdict()
-		if verdict != flowpb.Verdict_DROPPED {
+		if flow.Verdict != flowpb.Verdict_DROPPED {
 			return false
 		}
-		return slices.Contains(dropReasons, flow.GetDropReasonDesc())
+		return slices.Contains(dropReasons, flow.DropReasonDesc)
 	}
 }
 

--- a/pkg/hubble/filters/drop_reason_desc_test.go
+++ b/pkg/hubble/filters/drop_reason_desc_test.go
@@ -8,6 +8,7 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 )
 
 func TestDropReasonDescFilter(t *testing.T) {
@@ -33,10 +34,10 @@ func TestDropReasonDescFilter(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					{Event: &flowpb.Flow{}},
-					{Event: &flowpb.Flow{Verdict: flowpb.Verdict_DROPPED, DropReasonDesc: flowpb.DropReason_UNSUPPORTED_L3_PROTOCOL}},
-					{Event: &flowpb.Flow{Verdict: flowpb.Verdict_VERDICT_UNKNOWN, DropReasonDesc: flowpb.DropReason_INVALID_SOURCE_IP}},
-					{Event: &flowpb.Flow{Verdict: flowpb.Verdict_DROPPED, DropReasonDesc: flowpb.DropReason_POLICY_DENIED}},
+					{Event: &ir.Flow{}},
+					{Event: &ir.Flow{Verdict: flowpb.Verdict_DROPPED, DropReasonDesc: flowpb.DropReason_UNSUPPORTED_L3_PROTOCOL}},
+					{Event: &ir.Flow{Verdict: flowpb.Verdict_VERDICT_UNKNOWN, DropReasonDesc: flowpb.DropReason_INVALID_SOURCE_IP}},
+					{Event: &ir.Flow{Verdict: flowpb.Verdict_DROPPED, DropReasonDesc: flowpb.DropReason_POLICY_DENIED}},
 					{Event: &flowpb.AgentEvent{}},
 					{Event: &flowpb.LostEvent{}},
 				},
@@ -59,9 +60,9 @@ func TestDropReasonDescFilter(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					{Event: &flowpb.Flow{}},
-					{Event: &flowpb.Flow{Verdict: flowpb.Verdict_VERDICT_UNKNOWN, DropReasonDesc: flowpb.DropReason_UNSUPPORTED_L3_PROTOCOL}},
-					{Event: &flowpb.Flow{Verdict: flowpb.Verdict_VERDICT_UNKNOWN, DropReasonDesc: flowpb.DropReason_INVALID_SOURCE_IP}},
+					{Event: &ir.Flow{}},
+					{Event: &ir.Flow{Verdict: flowpb.Verdict_VERDICT_UNKNOWN, DropReasonDesc: flowpb.DropReason_UNSUPPORTED_L3_PROTOCOL}},
+					{Event: &ir.Flow{Verdict: flowpb.Verdict_VERDICT_UNKNOWN, DropReasonDesc: flowpb.DropReason_INVALID_SOURCE_IP}},
 					{Event: &flowpb.AgentEvent{}},
 					{Event: &flowpb.LostEvent{}},
 				},

--- a/pkg/hubble/filters/event_type.go
+++ b/pkg/hubble/filters/event_type.go
@@ -8,15 +8,16 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 )
 
 func filterByEventType(types []*flowpb.EventTypeFilter) FilterFunc {
 	return func(ev *v1.Event) bool {
 		switch ev.Event.(type) {
-		case *flowpb.Flow:
-			event := ev.GetFlow().GetEventType()
-			if event == nil {
+		case *ir.Flow:
+			event := ev.GetFlow().EventType
+			if event.IsEmpty() {
 				return false
 			}
 			for _, typeFilter := range types {

--- a/pkg/hubble/filters/event_type_test.go
+++ b/pkg/hubble/filters/event_type_test.go
@@ -8,6 +8,7 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 )
 
@@ -35,10 +36,10 @@ func TestEventTypeFilter(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					{Event: &flowpb.Flow{}},
-					{Event: &flowpb.Flow{EventType: &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeDrop}}},
-					{Event: &flowpb.Flow{EventType: &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeDrop, SubType: 2}}},
-					{Event: &flowpb.Flow{EventType: &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeCapture}}},
+					{Event: &ir.Flow{}},
+					{Event: &ir.Flow{EventType: ir.CiliumEventType{Type: monitorAPI.MessageTypeDrop}}},
+					{Event: &ir.Flow{EventType: ir.CiliumEventType{Type: monitorAPI.MessageTypeDrop, SubType: 2}}},
+					{Event: &ir.Flow{EventType: ir.CiliumEventType{Type: monitorAPI.MessageTypeCapture}}},
 					{Event: &flowpb.AgentEvent{}},
 					{Event: &flowpb.LostEvent{}},
 				},
@@ -67,10 +68,10 @@ func TestEventTypeFilter(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					{Event: &flowpb.Flow{}},
-					{Event: &flowpb.Flow{EventType: &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeDrop}}},
-					{Event: &flowpb.Flow{EventType: &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeDrop, SubType: 2}}},
-					{Event: &flowpb.Flow{EventType: &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeCapture}}},
+					{Event: &ir.Flow{}},
+					{Event: &ir.Flow{EventType: ir.CiliumEventType{Type: monitorAPI.MessageTypeDrop}}},
+					{Event: &ir.Flow{EventType: ir.CiliumEventType{Type: monitorAPI.MessageTypeDrop, SubType: 2}}},
+					{Event: &ir.Flow{EventType: ir.CiliumEventType{Type: monitorAPI.MessageTypeCapture}}},
 					{Event: &flowpb.AgentEvent{}},
 					{Event: &flowpb.LostEvent{}},
 				},
@@ -97,8 +98,8 @@ func TestEventTypeFilter(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					{Event: &flowpb.Flow{}},
-					{Event: &flowpb.Flow{EventType: &flowpb.CiliumEventType{}}},
+					{Event: &ir.Flow{}},
+					{Event: &ir.Flow{EventType: ir.CiliumEventType{}}},
 					{Event: &flowpb.AgentEvent{}},
 					{Event: &flowpb.AgentEvent{Type: flowpb.AgentEventType_ENDPOINT_CREATED}},
 					{Event: &flowpb.AgentEvent{Type: flowpb.AgentEventType_IPCACHE_UPSERTED}},
@@ -129,9 +130,9 @@ func TestEventTypeFilter(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					{Event: &flowpb.Flow{}},
-					{Event: &flowpb.Flow{EventType: &flowpb.CiliumEventType{}}},
-					{Event: &flowpb.Flow{EventType: &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeAccessLog}}},
+					{Event: &ir.Flow{}},
+					{Event: &ir.Flow{EventType: ir.CiliumEventType{}}},
+					{Event: &ir.Flow{EventType: ir.CiliumEventType{Type: monitorAPI.MessageTypeAccessLog}}},
 					{Event: &flowpb.AgentEvent{}},
 					{Event: &flowpb.AgentEvent{Type: flowpb.AgentEventType_ENDPOINT_CREATED}},
 					{Event: &flowpb.AgentEvent{Type: flowpb.AgentEventType_POLICY_DELETED}},

--- a/pkg/hubble/filters/filters_benchmark_test.go
+++ b/pkg/hubble/filters/filters_benchmark_test.go
@@ -12,11 +12,29 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 )
 
 var (
-	matchingEvent    = &v1.Event{Event: &flowpb.Flow{L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{SourcePort: 20222, DestinationPort: 80}}}}}
-	nonMatchingEvent = &v1.Event{Event: &flowpb.Flow{L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_UDP{UDP: &flowpb.UDP{SourcePort: 30222, DestinationPort: 53}}}}}
+	matchingEvent = &v1.Event{
+		Event: &ir.Flow{
+			L4: ir.Layer4{
+				TCP: ir.TCP{
+					SourcePort:      20222,
+					DestinationPort: 80},
+			},
+		},
+	}
+	nonMatchingEvent = &v1.Event{
+		Event: &ir.Flow{
+			L4: ir.Layer4{
+				UDP: ir.UDP{
+					SourcePort:      30222,
+					DestinationPort: 53,
+				},
+			},
+		},
+	}
 )
 
 func runFilterBenchmark(b *testing.B, ff *flowpb.FlowFilter, events []*v1.Event) {
@@ -74,6 +92,16 @@ var celL4Filter = &flowpb.FlowFilter{
 	Experimental: &flowpb.FlowFilter_Experimental{
 		CelExpression: []string{"has(_flow.l4.TCP) && (_flow.l4.TCP.destination_port == uint(80) || _flow.l4.TCP.destination_port == uint(443))"},
 	},
+}
+
+func TestBlee(t *testing.T) {
+	filterFuncs, err := BuildFilter(t.Context(), celL4Filter, DefaultFilters(hivetest.Logger(t)))
+	require.NoError(t, err)
+
+	events := []*v1.Event{matchingEvent}
+	for _, ev := range events {
+		assert.True(t, filterFuncs.MatchOne(ev))
+	}
 }
 
 func BenchmarkCELL4ProtocolPortFlowFilterMatching1(b *testing.B) {

--- a/pkg/hubble/filters/fqdn.go
+++ b/pkg/hubble/filters/fqdn.go
@@ -14,11 +14,27 @@ import (
 )
 
 func sourceFQDN(ev *v1.Event) []string {
-	return ev.GetFlow().GetSourceNames()
+	if ev == nil {
+		return nil
+	}
+	fl := ev.GetFlow()
+	if fl == nil {
+		return nil
+	}
+
+	return fl.SourceNames
 }
 
 func destinationFQDN(ev *v1.Event) []string {
-	return ev.GetFlow().GetDestinationNames()
+	if ev == nil {
+		return nil
+	}
+	fl := ev.GetFlow()
+	if fl == nil {
+		return nil
+	}
+
+	return fl.DestinationNames
 }
 
 func filterByFQDNs(fqdnPatterns []string, getFQDNs func(*v1.Event) []string) (FilterFunc, error) {
@@ -47,8 +63,8 @@ func filterByDNSQueries(queryPatterns []string) (FilterFunc, error) {
 		queries = append(queries, query)
 	}
 	return func(ev *v1.Event) bool {
-		dns := ev.GetFlow().GetL7().GetDns()
-		if dns == nil {
+		dns := ev.GetFlow().L7.DNS
+		if dns.IsEmpty() {
 			return false
 		}
 		return slices.ContainsFunc(queries, func(query *regexp.Regexp) bool {

--- a/pkg/hubble/filters/fqdn_test.go
+++ b/pkg/hubble/filters/fqdn_test.go
@@ -10,6 +10,7 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 )
 
 func TestFQDNFilter(t *testing.T) {
@@ -30,10 +31,10 @@ func TestFQDNFilter(t *testing.T) {
 					{SourceFqdn: []string{"cilium.io", "ebpf.io"}},
 				},
 				ev: []*v1.Event{
-					{Event: &flowpb.Flow{SourceNames: []string{"cilium.io"}}},
-					{Event: &flowpb.Flow{SourceNames: []string{"ebpf.io"}}},
-					{Event: &flowpb.Flow{DestinationNames: []string{"cilium.io"}}},
-					{Event: &flowpb.Flow{DestinationNames: []string{"ebpf.io"}}},
+					{Event: &ir.Flow{SourceNames: []string{"cilium.io"}}},
+					{Event: &ir.Flow{SourceNames: []string{"ebpf.io"}}},
+					{Event: &ir.Flow{DestinationNames: []string{"cilium.io"}}},
+					{Event: &ir.Flow{DestinationNames: []string{"ebpf.io"}}},
 				},
 			},
 			want: []bool{
@@ -50,10 +51,10 @@ func TestFQDNFilter(t *testing.T) {
 					{DestinationFqdn: []string{"cilium.io", "ebpf.io"}},
 				},
 				ev: []*v1.Event{
-					{Event: &flowpb.Flow{SourceNames: []string{"cilium.io"}}},
-					{Event: &flowpb.Flow{SourceNames: []string{"ebpf.io"}}},
-					{Event: &flowpb.Flow{DestinationNames: []string{"cilium.io"}}},
-					{Event: &flowpb.Flow{DestinationNames: []string{"ebpf.io"}}},
+					{Event: &ir.Flow{SourceNames: []string{"cilium.io"}}},
+					{Event: &ir.Flow{SourceNames: []string{"ebpf.io"}}},
+					{Event: &ir.Flow{DestinationNames: []string{"cilium.io"}}},
+					{Event: &ir.Flow{DestinationNames: []string{"ebpf.io"}}},
 				},
 			},
 			want: []bool{
@@ -73,15 +74,15 @@ func TestFQDNFilter(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					{Event: &flowpb.Flow{
+					{Event: &ir.Flow{
 						SourceNames:      []string{"cilium.io"},
 						DestinationNames: []string{"ebpf.io"},
 					}},
-					{Event: &flowpb.Flow{
+					{Event: &ir.Flow{
 						SourceNames:      []string{"ebpf.io"},
 						DestinationNames: []string{"cilium.io"},
 					}},
-					{Event: &flowpb.Flow{
+					{Event: &ir.Flow{
 						SourceNames:      []string{"deathstar.empire.svc.cluster.local", "docs.cilium.io"},
 						DestinationNames: []string{"ebpf.io"},
 					}},
@@ -101,21 +102,21 @@ func TestFQDNFilter(t *testing.T) {
 					{DestinationFqdn: []string{"ebpf.io"}},
 				},
 				ev: []*v1.Event{
-					{Event: &flowpb.Flow{
+					{Event: &ir.Flow{
 						SourceNames:      []string{"cilium.io"},
 						DestinationNames: []string{"ebpf.io"},
 					}},
-					{Event: &flowpb.Flow{
+					{Event: &ir.Flow{
 						SourceNames:      []string{"ebpf.io"},
 						DestinationNames: []string{"cilium.io"},
 					}},
-					{Event: &flowpb.Flow{
+					{Event: &ir.Flow{
 						SourceNames: []string{"deathstar.empire.svc.cluster.local", "docs.cilium.io"},
 					}},
-					{Event: &flowpb.Flow{
+					{Event: &ir.Flow{
 						DestinationNames: []string{"ebpf.io"},
 					}},
-					{Event: &flowpb.Flow{
+					{Event: &ir.Flow{
 						SourceNames:      []string{"deathstar.empire.svc.cluster.local", "docs.cilium.io"},
 						DestinationNames: []string{"ebpf.io"},
 					}},
@@ -138,10 +139,10 @@ func TestFQDNFilter(t *testing.T) {
 				ev: []*v1.Event{
 					nil,
 					{},
-					{Event: &flowpb.Flow{}},
-					{Event: &flowpb.Flow{SourceNames: []string{"cilium.io."}}}, // should not have trailing dot
-					{Event: &flowpb.Flow{SourceNames: []string{"www.cilium.io"}}},
-					{Event: &flowpb.Flow{SourceNames: []string{""}}},
+					{Event: &ir.Flow{}},
+					{Event: &ir.Flow{SourceNames: []string{"cilium.io."}}}, // should not have trailing dot
+					{Event: &ir.Flow{SourceNames: []string{"www.cilium.io"}}},
+					{Event: &ir.Flow{SourceNames: []string{""}}},
 				},
 			},
 			want: []bool{
@@ -179,13 +180,13 @@ func TestFQDNFilter(t *testing.T) {
 					{DestinationFqdn: []string{"*"}},
 				},
 				ev: []*v1.Event{
-					{Event: &flowpb.Flow{SourceNames: []string{"www.cilium.io"}}},
-					{Event: &flowpb.Flow{SourceNames: []string{"multiple.domains.org"}}},
-					{Event: &flowpb.Flow{SourceNames: []string{"cilium.io"}}},
-					{Event: &flowpb.Flow{SourceNames: []string{"tiefighter", "empire.org"}}},
-					{Event: &flowpb.Flow{DestinationNames: []string{}}},
-					{Event: &flowpb.Flow{DestinationNames: []string{"anything.really"}}},
-					{Event: &flowpb.Flow{DestinationNames: []string{""}}},
+					{Event: &ir.Flow{SourceNames: []string{"www.cilium.io"}}},
+					{Event: &ir.Flow{SourceNames: []string{"multiple.domains.org"}}},
+					{Event: &ir.Flow{SourceNames: []string{"cilium.io"}}},
+					{Event: &ir.Flow{SourceNames: []string{"tiefighter", "empire.org"}}},
+					{Event: &ir.Flow{DestinationNames: []string{}}},
+					{Event: &ir.Flow{DestinationNames: []string{"anything.really"}}},
+					{Event: &ir.Flow{DestinationNames: []string{""}}},
 				},
 			},
 			want: []bool{
@@ -230,7 +231,7 @@ func Test_filterByDNSQuery(t *testing.T) {
 			name: "not-dns",
 			args: args{
 				f:  []*flowpb.FlowFilter{{DnsQuery: []string{".*"}}},
-				ev: &v1.Event{Event: &flowpb.Flow{}},
+				ev: &v1.Event{Event: &ir.Flow{}},
 			},
 			wantErr: false,
 			want:    false,
@@ -246,12 +247,10 @@ func Test_filterByDNSQuery(t *testing.T) {
 			name: "positive",
 			args: args{
 				f: []*flowpb.FlowFilter{{DnsQuery: []string{".*\\.com$", ".*\\.io"}}},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					L7: &flowpb.Layer7{
-						Record: &flowpb.Layer7_Dns{
-							Dns: &flowpb.DNS{
-								Query: "cilium.io",
-							},
+				ev: &v1.Event{Event: &ir.Flow{
+					L7: ir.Layer7{
+						DNS: ir.DNS{
+							Query: "cilium.io",
 						},
 					},
 				}},
@@ -259,32 +258,13 @@ func Test_filterByDNSQuery(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "positive",
-			args: args{
-				f: []*flowpb.FlowFilter{{DnsQuery: []string{".*\\.com$", ".*\\.io"}}},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					L7: &flowpb.Layer7{
-						Record: &flowpb.Layer7_Dns{
-							Dns: &flowpb.DNS{
-								Query: "cilium.io",
-							},
-						},
-					},
-				}},
-			},
-			wantErr: false,
-			want:    true,
-		},
-		{
 			name: "negative",
 			args: args{
 				f: []*flowpb.FlowFilter{{DnsQuery: []string{".*\\.com$", ".*\\.net"}}},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					L7: &flowpb.Layer7{
-						Record: &flowpb.Layer7_Dns{
-							Dns: &flowpb.DNS{
-								Query: "cilium.io",
-							},
+				ev: &v1.Event{Event: &ir.Flow{
+					L7: ir.Layer7{
+						DNS: ir.DNS{
+							Query: "cilium.io",
 						},
 					},
 				}},

--- a/pkg/hubble/filters/http.go
+++ b/pkg/hubble/filters/http.go
@@ -46,9 +46,17 @@ func filterByHTTPStatusCode(statusCodePrefixes []string) (FilterFunc, error) {
 	}
 
 	return func(ev *v1.Event) bool {
-		http := ev.GetFlow().GetL7().GetHttp()
+		if ev == nil {
+			return false
+		}
+		fl := ev.GetFlow()
+		if fl == nil {
+			return false
+		}
+
+		http := fl.L7.HTTP
 		// Not an HTTP response record
-		if http == nil || http.Code == 0 {
+		if http.IsEmpty() {
 			return false
 		}
 
@@ -65,9 +73,15 @@ func filterByHTTPStatusCode(statusCodePrefixes []string) (FilterFunc, error) {
 
 func filterByHTTPMethods(methods []string) FilterFunc {
 	return func(ev *v1.Event) bool {
-		http := ev.GetFlow().GetL7().GetHttp()
-
-		if http == nil || http.Method == "" {
+		if ev == nil {
+			return false
+		}
+		fl := ev.GetFlow()
+		if fl == nil {
+			return false
+		}
+		http := fl.L7.HTTP
+		if http.IsEmpty() {
 			// Not an HTTP or method is missing
 			return false
 		}
@@ -89,28 +103,40 @@ func filterByHTTPUrls(urlRegexpStrs []string) (FilterFunc, error) {
 	}
 
 	return func(ev *v1.Event) bool {
-		http := ev.GetFlow().GetL7().GetHttp()
-
-		if http == nil || http.Url == "" {
+		if ev == nil {
+			return false
+		}
+		fl := ev.GetFlow()
+		if fl == nil {
+			return false
+		}
+		http := fl.L7.HTTP
+		if http.IsEmpty() {
 			return false
 		}
 
 		return slices.ContainsFunc(urlRegexps, func(urlRegexp *regexp.Regexp) bool {
-			return urlRegexp.MatchString(http.Url)
+			return urlRegexp.MatchString(http.URL)
 		})
 	}, nil
 }
 
 func filterByHTTPHeaders(headers []*flowpb.HTTPHeader) FilterFunc {
 	return func(ev *v1.Event) bool {
-		http := ev.GetFlow().GetL7().GetHttp()
-
-		if http == nil || http.GetHeaders() == nil {
+		if ev == nil {
+			return false
+		}
+		fl := ev.GetFlow()
+		if fl == nil {
+			return false
+		}
+		http := fl.L7.HTTP
+		if http.IsEmpty() {
 			// Not an HTTP or headers are missing
 			return false
 		}
 
-		for _, httpHeader := range http.GetHeaders() {
+		for _, httpHeader := range http.Headers {
 			if slices.ContainsFunc(headers, func(header *flowpb.HTTPHeader) bool {
 				return header.Key == httpHeader.Key && header.Value == httpHeader.Value
 			}) {
@@ -133,13 +159,20 @@ func filterByHTTPPaths(pathRegexpStrs []string) (FilterFunc, error) {
 	}
 
 	return func(ev *v1.Event) bool {
-		http := ev.GetFlow().GetL7().GetHttp()
-
-		if http == nil || http.Url == "" {
+		if ev == nil {
+			return false
+		}
+		fl := ev.GetFlow()
+		if fl == nil {
 			return false
 		}
 
-		uri, err := url.ParseRequestURI(http.Url)
+		http := fl.L7.HTTP
+		if http.IsEmpty() {
+			return false
+		}
+
+		uri, err := url.ParseRequestURI(http.URL)
 		if err != nil {
 			// Silently drop all invalid URIs as there is nothing else we can
 			// do.

--- a/pkg/hubble/filters/http_test.go
+++ b/pkg/hubble/filters/http_test.go
@@ -9,20 +9,19 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/monitor/api"
 )
 
 func TestHTTPFilters(t *testing.T) {
-	httpFlow := func(http *flowpb.HTTP) *v1.Event {
+	httpFlow := func(http ir.HTTP) *v1.Event {
 		return &v1.Event{
-			Event: &flowpb.Flow{
-				EventType: &flowpb.CiliumEventType{
+			Event: &ir.Flow{
+				EventType: ir.CiliumEventType{
 					Type: api.MessageTypeAccessLog,
 				},
-				L7: &flowpb.Layer7{
-					Record: &flowpb.Layer7_Http{
-						Http: http,
-					},
+				L7: ir.Layer7{
+					HTTP: http,
 				}},
 		}
 	}
@@ -50,10 +49,10 @@ func TestHTTPFilters(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					httpFlow(&flowpb.HTTP{Code: 200}),
-					httpFlow(&flowpb.HTTP{Code: 302}),
-					httpFlow(&flowpb.HTTP{Code: 404}),
-					httpFlow(&flowpb.HTTP{Code: 500}),
+					httpFlow(ir.HTTP{Code: 200}),
+					httpFlow(ir.HTTP{Code: 302}),
+					httpFlow(ir.HTTP{Code: 404}),
+					httpFlow(ir.HTTP{Code: 500}),
 				},
 			},
 			want: []bool{
@@ -74,15 +73,15 @@ func TestHTTPFilters(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					httpFlow(&flowpb.HTTP{Code: 302}),
-					httpFlow(&flowpb.HTTP{Code: 400}),
-					httpFlow(&flowpb.HTTP{Code: 404}),
-					httpFlow(&flowpb.HTTP{Code: 410}),
-					httpFlow(&flowpb.HTTP{Code: 004}),
-					httpFlow(&flowpb.HTTP{Code: 500}),
-					httpFlow(&flowpb.HTTP{Code: 501}),
-					httpFlow(&flowpb.HTTP{Code: 510}),
-					httpFlow(&flowpb.HTTP{Code: 050}),
+					httpFlow(ir.HTTP{Code: 302}),
+					httpFlow(ir.HTTP{Code: 400}),
+					httpFlow(ir.HTTP{Code: 404}),
+					httpFlow(ir.HTTP{Code: 410}),
+					httpFlow(ir.HTTP{Code: 004}),
+					httpFlow(ir.HTTP{Code: 500}),
+					httpFlow(ir.HTTP{Code: 501}),
+					httpFlow(ir.HTTP{Code: 510}),
+					httpFlow(ir.HTTP{Code: 050}),
 				},
 			},
 			want: []bool{
@@ -108,9 +107,9 @@ func TestHTTPFilters(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					{Event: &flowpb.Flow{}},
-					httpFlow(&flowpb.HTTP{}),
-					httpFlow(&flowpb.HTTP{Code: 777}),
+					{Event: &ir.Flow{}},
+					httpFlow(ir.HTTP{}),
+					httpFlow(ir.HTTP{Code: 777}),
 				},
 			},
 			want: []bool{
@@ -202,7 +201,7 @@ func TestHTTPFilters(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					httpFlow(&flowpb.HTTP{Code: 200}),
+					httpFlow(ir.HTTP{Code: 200}),
 				},
 			},
 			want: []bool{
@@ -223,7 +222,7 @@ func TestHTTPFilters(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					httpFlow(&flowpb.HTTP{Code: 200}),
+					httpFlow(ir.HTTP{Code: 200}),
 				},
 			},
 			want: []bool{
@@ -252,7 +251,7 @@ func TestHTTPFilters(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					httpFlow(&flowpb.HTTP{Method: "gEt"}),
+					httpFlow(ir.HTTP{Method: "gEt"}),
 				},
 			},
 			want: []bool{
@@ -273,7 +272,7 @@ func TestHTTPFilters(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					httpFlow(&flowpb.HTTP{Method: "gEt"}),
+					httpFlow(ir.HTTP{Method: "gEt"}),
 				},
 			},
 			wantErr:         true,
@@ -299,7 +298,7 @@ func TestHTTPFilters(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					httpFlow(&flowpb.HTTP{Method: "DELETE"}),
+					httpFlow(ir.HTTP{Method: "DELETE"}),
 				},
 			},
 			want: []bool{
@@ -318,13 +317,13 @@ func TestHTTPFilters(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					httpFlow(&flowpb.HTTP{Url: "/docs/"}),
-					httpFlow(&flowpb.HTTP{Url: "/docs/tutorial/"}),
-					httpFlow(&flowpb.HTTP{Url: "/post/"}),
-					httpFlow(&flowpb.HTTP{Url: "/post/0"}),
-					httpFlow(&flowpb.HTTP{Url: "/post/slug"}),
-					httpFlow(&flowpb.HTTP{Url: "/post/123?key=value"}),
-					httpFlow(&flowpb.HTTP{Url: "/slug"}),
+					httpFlow(ir.HTTP{URL: "/docs/"}),
+					httpFlow(ir.HTTP{URL: "/docs/tutorial/"}),
+					httpFlow(ir.HTTP{URL: "/post/"}),
+					httpFlow(ir.HTTP{URL: "/post/0"}),
+					httpFlow(ir.HTTP{URL: "/post/slug"}),
+					httpFlow(ir.HTTP{URL: "/post/123?key=value"}),
+					httpFlow(ir.HTTP{URL: "/slug"}),
 				},
 			},
 			want: []bool{
@@ -349,11 +348,11 @@ func TestHTTPFilters(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					httpFlow(&flowpb.HTTP{Url: "http://example.com/"}),
-					httpFlow(&flowpb.HTTP{Url: "http://cilium.io/docs/"}),
-					httpFlow(&flowpb.HTTP{Url: "https://cilium.io/"}),
-					httpFlow(&flowpb.HTTP{Url: "https://not.cilium.io/"}),
-					httpFlow(&flowpb.HTTP{Url: "https://cilium.example.com/"}),
+					httpFlow(ir.HTTP{URL: "http://example.com/"}),
+					httpFlow(ir.HTTP{URL: "http://cilium.io/docs/"}),
+					httpFlow(ir.HTTP{URL: "https://cilium.io/"}),
+					httpFlow(ir.HTTP{URL: "https://not.cilium.io/"}),
+					httpFlow(ir.HTTP{URL: "https://cilium.example.com/"}),
 				},
 			},
 			want: []bool{
@@ -375,9 +374,9 @@ func TestHTTPFilters(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					httpFlow(&flowpb.HTTP{Url: "http://example.com/"}),
-					httpFlow(&flowpb.HTTP{Url: "http://cilium.io/docs/"}),
-					httpFlow(&flowpb.HTTP{Url: "http://cilium.io/"}),
+					httpFlow(ir.HTTP{URL: "http://example.com/"}),
+					httpFlow(ir.HTTP{URL: "http://cilium.io/docs/"}),
+					httpFlow(ir.HTTP{URL: "http://cilium.io/"}),
 				},
 			},
 			want: []bool{
@@ -397,13 +396,13 @@ func TestHTTPFilters(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					httpFlow(&flowpb.HTTP{Url: "http://example.com/post/12"}),
-					httpFlow(&flowpb.HTTP{Url: "http://example.com/post/125?key=value"}),
-					httpFlow(&flowpb.HTTP{Url: "http://cilium.io/post/125?key=value"}),
-					httpFlow(&flowpb.HTTP{Url: "http://cilium.io/docs/example"}),
-					httpFlow(&flowpb.HTTP{Url: "http://cilium.io/docs/example/1243"}),
-					httpFlow(&flowpb.HTTP{Url: "http://cilium.io/"}),
-					httpFlow(&flowpb.HTTP{Url: "http://example.com/docs/post"}),
+					httpFlow(ir.HTTP{URL: "http://example.com/post/12"}),
+					httpFlow(ir.HTTP{URL: "http://example.com/post/125?key=value"}),
+					httpFlow(ir.HTTP{URL: "http://cilium.io/post/125?key=value"}),
+					httpFlow(ir.HTTP{URL: "http://cilium.io/docs/example"}),
+					httpFlow(ir.HTTP{URL: "http://cilium.io/docs/example/1243"}),
+					httpFlow(ir.HTTP{URL: "http://cilium.io/"}),
+					httpFlow(ir.HTTP{URL: "http://example.com/docs/post"}),
 				},
 			},
 			want: []bool{
@@ -428,13 +427,13 @@ func TestHTTPFilters(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					httpFlow(&flowpb.HTTP{Url: "http://example.com/post/12"}),
-					httpFlow(&flowpb.HTTP{Url: "http://example.com/post/125?key=value"}),
-					httpFlow(&flowpb.HTTP{Url: "http://cilium.io/post/125?key=value"}),
-					httpFlow(&flowpb.HTTP{Url: "http://cilium.io/docs/example"}),
-					httpFlow(&flowpb.HTTP{Url: "http://cilium.io/"}),
-					httpFlow(&flowpb.HTTP{Url: "http://example.com/docs/post"}),
-					httpFlow(&flowpb.HTTP{Url: "http://example.org/post/12"}),
+					httpFlow(ir.HTTP{URL: "http://example.com/post/12"}),
+					httpFlow(ir.HTTP{URL: "http://example.com/post/125?key=value"}),
+					httpFlow(ir.HTTP{URL: "http://cilium.io/post/125?key=value"}),
+					httpFlow(ir.HTTP{URL: "http://cilium.io/docs/example"}),
+					httpFlow(ir.HTTP{URL: "http://cilium.io/"}),
+					httpFlow(ir.HTTP{URL: "http://example.com/docs/post"}),
+					httpFlow(ir.HTTP{URL: "http://example.org/post/12"}),
 				},
 			},
 			want: []bool{
@@ -458,8 +457,8 @@ func TestHTTPFilters(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					httpFlow(&flowpb.HTTP{Url: "/post/0"}),
-					httpFlow(&flowpb.HTTP{Url: "?/post/0"}),
+					httpFlow(ir.HTTP{URL: "/post/0"}),
+					httpFlow(ir.HTTP{URL: "?/post/0"}),
 				},
 			},
 			want: []bool{
@@ -496,7 +495,7 @@ func TestHTTPFilters(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					httpFlow(&flowpb.HTTP{Headers: []*flowpb.HTTPHeader{{Key: "Content", Value: "foo"}}}),
+					httpFlow(ir.HTTP{Headers: []ir.HTTPHeader{{Key: "Content", Value: "foo"}}}),
 				},
 			},
 			want: []bool{
@@ -518,7 +517,7 @@ func TestHTTPFilters(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					httpFlow(&flowpb.HTTP{Headers: []*flowpb.HTTPHeader{{Key: "Content", Value: "bar"}}}),
+					httpFlow(ir.HTTP{Headers: []ir.HTTPHeader{{Key: "Content", Value: "bar"}}}),
 				},
 			},
 			want: []bool{
@@ -540,7 +539,7 @@ func TestHTTPFilters(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					httpFlow(&flowpb.HTTP{Headers: []*flowpb.HTTPHeader{
+					httpFlow(ir.HTTP{Headers: []ir.HTTPHeader{
 						{Key: "Cache-control", Value: "no-cache"},
 						{Key: "Cache-control", Value: "no-store"},
 					}}),

--- a/pkg/hubble/filters/identity.go
+++ b/pkg/hubble/filters/identity.go
@@ -9,19 +9,36 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 )
 
-func sourceEndpoint(ev *v1.Event) *flowpb.Endpoint {
-	return ev.GetFlow().GetSource()
+func sourceEndpoint(ev *v1.Event) ir.Endpoint {
+	if ev == nil {
+		return ir.Endpoint{}
+	}
+	fl := ev.GetFlow()
+	if fl == nil {
+		return ir.Endpoint{}
+	}
+
+	return fl.Source
 }
 
-func destinationEndpoint(ev *v1.Event) *flowpb.Endpoint {
-	return ev.GetFlow().GetDestination()
+func destinationEndpoint(ev *v1.Event) ir.Endpoint {
+	if ev == nil {
+		return ir.Endpoint{}
+	}
+	fl := ev.GetFlow()
+	if fl == nil {
+		return ir.Endpoint{}
+	}
+
+	return fl.Destination
 }
 
-func filterByIdentity(identities []uint32, getEndpoint func(*v1.Event) *flowpb.Endpoint) FilterFunc {
+func filterByIdentity(identities []uint32, getEndpoint func(*v1.Event) ir.Endpoint) FilterFunc {
 	return func(ev *v1.Event) bool {
-		if endpoint := getEndpoint(ev); endpoint != nil {
+		if endpoint := getEndpoint(ev); !endpoint.IsEmpty() {
 			return slices.Contains(identities, endpoint.Identity)
 		}
 		return false

--- a/pkg/hubble/filters/ip.go
+++ b/pkg/hubble/filters/ip.go
@@ -15,15 +15,39 @@ import (
 )
 
 func sourceIP(ev *v1.Event) string {
-	return ev.GetFlow().GetIP().GetSource()
+	if ev == nil {
+		return ""
+	}
+	fl := ev.GetFlow()
+	if fl == nil {
+		return ""
+	}
+
+	return fl.IP.Source
 }
 
 func destinationIP(ev *v1.Event) string {
-	return ev.GetFlow().GetIP().GetDestination()
+	if ev == nil {
+		return ""
+	}
+	fl := ev.GetFlow()
+	if fl == nil {
+		return ""
+	}
+
+	return fl.IP.Destination
 }
 
 func sourceIPXlated(ev *v1.Event) string {
-	return ev.GetFlow().GetIP().GetSourceXlated()
+	if ev == nil {
+		return ""
+	}
+	fl := ev.GetFlow()
+	if fl == nil {
+		return ""
+	}
+
+	return fl.IP.SourceXlated
 }
 
 func filterByIPs(ips []string, getIP func(*v1.Event) string) (FilterFunc, error) {
@@ -112,7 +136,7 @@ func filterByIPVersion(ipver []flowpb.IPVersion) FilterFunc {
 		if flow == nil {
 			return false
 		}
-		return slices.Contains(ipver, flow.GetIP().GetIpVersion())
+		return slices.Contains(ipver, flow.IP.IPVersion)
 	}
 }
 

--- a/pkg/hubble/filters/ip_tracing.go
+++ b/pkg/hubble/filters/ip_tracing.go
@@ -13,8 +13,15 @@ import (
 
 func filterByIPTraceID(tids []uint64) FilterFunc {
 	return func(ev *v1.Event) bool {
-		trace := ev.GetFlow().GetIpTraceId().GetTraceId()
-		return slices.Contains(tids, trace)
+		if ev == nil {
+			return false
+		}
+		flow := ev.GetFlow()
+		if flow == nil {
+			return false
+		}
+
+		return slices.Contains(tids, flow.IPTraceID.TraceID)
 	}
 }
 

--- a/pkg/hubble/filters/k8s.go
+++ b/pkg/hubble/filters/k8s.go
@@ -15,23 +15,49 @@ import (
 )
 
 func sourcePod(ev *v1.Event) (ns, pod string) {
-	ep := ev.GetFlow().GetSource()
-	return ep.GetNamespace(), ep.GetPodName()
+	if ev == nil {
+		return "", ""
+	}
+	fl := ev.GetFlow()
+	if fl == nil {
+		return "", ""
+	}
+	return fl.Source.Namespace, fl.Source.PodName
 }
 
 func destinationPod(ev *v1.Event) (ns, pod string) {
-	ep := ev.GetFlow().GetDestination()
-	return ep.GetNamespace(), ep.GetPodName()
+	if ev == nil {
+		return "", ""
+	}
+	fl := ev.GetFlow()
+	if fl == nil {
+		return "", ""
+	}
+
+	return fl.Destination.Namespace, fl.Destination.PodName
 }
 
 func sourceService(ev *v1.Event) (ns, svc string) {
-	s := ev.GetFlow().GetSourceService()
-	return s.GetNamespace(), s.GetName()
+	if ev == nil {
+		return "", ""
+	}
+	fl := ev.GetFlow()
+	if fl == nil {
+		return "", ""
+	}
+
+	return fl.SourceService.Namespace, fl.SourceService.Name
 }
 
 func destinationService(ev *v1.Event) (ns, svc string) {
-	s := ev.GetFlow().GetDestinationService()
-	return s.GetNamespace(), s.GetName()
+	if ev == nil {
+		return "", ""
+	}
+	fl := ev.GetFlow()
+	if fl == nil {
+		return "", ""
+	}
+	return fl.DestinationService.Namespace, fl.DestinationService.Name
 }
 
 func filterByNamespacedName(names []string, getName func(*v1.Event) (ns, name string)) (FilterFunc, error) {

--- a/pkg/hubble/filters/k8s_test.go
+++ b/pkg/hubble/filters/k8s_test.go
@@ -8,6 +8,7 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 )
 
 func TestPodFilter(t *testing.T) {
@@ -28,10 +29,10 @@ func TestPodFilter(t *testing.T) {
 					{SourcePod: []string{"xwing", "default/tiefighter"}},
 				},
 				ev: []*v1.Event{
-					{Event: &flowpb.Flow{Source: &flowpb.Endpoint{Namespace: "default", PodName: "xwing"}}},
-					{Event: &flowpb.Flow{Source: &flowpb.Endpoint{Namespace: "default", PodName: "tiefighter"}}},
-					{Event: &flowpb.Flow{Source: &flowpb.Endpoint{Namespace: "kube-system", PodName: "xwing"}}},
-					{Event: &flowpb.Flow{Destination: &flowpb.Endpoint{Namespace: "default", PodName: "xwing"}}},
+					{Event: &ir.Flow{Source: ir.Endpoint{Namespace: "default", PodName: "xwing"}}},
+					{Event: &ir.Flow{Source: ir.Endpoint{Namespace: "default", PodName: "tiefighter"}}},
+					{Event: &ir.Flow{Source: ir.Endpoint{Namespace: "kube-system", PodName: "xwing"}}},
+					{Event: &ir.Flow{Destination: ir.Endpoint{Namespace: "default", PodName: "xwing"}}},
 				},
 			},
 			want: []bool{
@@ -48,10 +49,10 @@ func TestPodFilter(t *testing.T) {
 					{DestinationPod: []string{"xwing", "default/tiefighter"}},
 				},
 				ev: []*v1.Event{
-					{Event: &flowpb.Flow{Destination: &flowpb.Endpoint{Namespace: "default", PodName: "xwing"}}},
-					{Event: &flowpb.Flow{Destination: &flowpb.Endpoint{Namespace: "default", PodName: "tiefighter"}}},
-					{Event: &flowpb.Flow{Destination: &flowpb.Endpoint{Namespace: "kube-system", PodName: "xwing"}}},
-					{Event: &flowpb.Flow{Source: &flowpb.Endpoint{Namespace: "default", PodName: "xwing"}}},
+					{Event: &ir.Flow{Destination: ir.Endpoint{Namespace: "default", PodName: "xwing"}}},
+					{Event: &ir.Flow{Destination: ir.Endpoint{Namespace: "default", PodName: "tiefighter"}}},
+					{Event: &ir.Flow{Destination: ir.Endpoint{Namespace: "kube-system", PodName: "xwing"}}},
+					{Event: &ir.Flow{Source: ir.Endpoint{Namespace: "default", PodName: "xwing"}}},
 				},
 			},
 			want: []bool{
@@ -71,21 +72,21 @@ func TestPodFilter(t *testing.T) {
 					},
 				},
 				ev: []*v1.Event{
-					{Event: &flowpb.Flow{
-						Source:      &flowpb.Endpoint{Namespace: "default", PodName: "xwing"},
-						Destination: &flowpb.Endpoint{Namespace: "default", PodName: "deathstar"},
+					{Event: &ir.Flow{
+						Source:      ir.Endpoint{Namespace: "default", PodName: "xwing"},
+						Destination: ir.Endpoint{Namespace: "default", PodName: "deathstar"},
 					}},
-					{Event: &flowpb.Flow{
-						Source:      &flowpb.Endpoint{Namespace: "default", PodName: "tiefighter"},
-						Destination: &flowpb.Endpoint{Namespace: "default", PodName: "deathstar"},
+					{Event: &ir.Flow{
+						Source:      ir.Endpoint{Namespace: "default", PodName: "tiefighter"},
+						Destination: ir.Endpoint{Namespace: "default", PodName: "deathstar"},
 					}},
-					{Event: &flowpb.Flow{
-						Source:      &flowpb.Endpoint{Namespace: "default", PodName: "deathstar"},
-						Destination: &flowpb.Endpoint{Namespace: "default", PodName: "xwing"},
+					{Event: &ir.Flow{
+						Source:      ir.Endpoint{Namespace: "default", PodName: "deathstar"},
+						Destination: ir.Endpoint{Namespace: "default", PodName: "xwing"},
 					}},
-					{Event: &flowpb.Flow{
-						Source:      &flowpb.Endpoint{Namespace: "default", PodName: "tiefighter"},
-						Destination: &flowpb.Endpoint{Namespace: "default", PodName: "xwing"},
+					{Event: &ir.Flow{
+						Source:      ir.Endpoint{Namespace: "default", PodName: "tiefighter"},
+						Destination: ir.Endpoint{Namespace: "default", PodName: "xwing"},
 					}},
 				},
 			},
@@ -104,21 +105,21 @@ func TestPodFilter(t *testing.T) {
 					{DestinationPod: []string{"deathstar"}},
 				},
 				ev: []*v1.Event{
-					{Event: &flowpb.Flow{
-						Source:      &flowpb.Endpoint{Namespace: "default", PodName: "xwing"},
-						Destination: &flowpb.Endpoint{Namespace: "default", PodName: "deathstar"},
+					{Event: &ir.Flow{
+						Source:      ir.Endpoint{Namespace: "default", PodName: "xwing"},
+						Destination: ir.Endpoint{Namespace: "default", PodName: "deathstar"},
 					}},
-					{Event: &flowpb.Flow{
-						Source:      &flowpb.Endpoint{Namespace: "default", PodName: "tiefighter"},
-						Destination: &flowpb.Endpoint{Namespace: "default", PodName: "deathstar"},
+					{Event: &ir.Flow{
+						Source:      ir.Endpoint{Namespace: "default", PodName: "tiefighter"},
+						Destination: ir.Endpoint{Namespace: "default", PodName: "deathstar"},
 					}},
-					{Event: &flowpb.Flow{
-						Source:      &flowpb.Endpoint{Namespace: "default", PodName: "deathstar"},
-						Destination: &flowpb.Endpoint{Namespace: "default", PodName: "xwing"},
+					{Event: &ir.Flow{
+						Source:      ir.Endpoint{Namespace: "default", PodName: "deathstar"},
+						Destination: ir.Endpoint{Namespace: "default", PodName: "xwing"},
 					}},
-					{Event: &flowpb.Flow{
-						Source:      &flowpb.Endpoint{Namespace: "default", PodName: "tiefighter"},
-						Destination: &flowpb.Endpoint{Namespace: "default", PodName: "xwing"},
+					{Event: &ir.Flow{
+						Source:      ir.Endpoint{Namespace: "default", PodName: "tiefighter"},
+						Destination: ir.Endpoint{Namespace: "default", PodName: "xwing"},
 					}},
 				},
 			},
@@ -137,21 +138,21 @@ func TestPodFilter(t *testing.T) {
 					{DestinationPod: []string{"kube-system/"}},
 				},
 				ev: []*v1.Event{
-					{Event: &flowpb.Flow{
-						Source:      &flowpb.Endpoint{Namespace: "kube-system", PodName: "coredns"},
-						Destination: &flowpb.Endpoint{Namespace: "kube-system", PodName: "kube-proxy"},
+					{Event: &ir.Flow{
+						Source:      ir.Endpoint{Namespace: "kube-system", PodName: "coredns"},
+						Destination: ir.Endpoint{Namespace: "kube-system", PodName: "kube-proxy"},
 					}},
-					{Event: &flowpb.Flow{
-						Source:      &flowpb.Endpoint{Namespace: "default", PodName: "tiefighter"},
-						Destination: &flowpb.Endpoint{Namespace: "kube-system", PodName: "coredns"},
+					{Event: &ir.Flow{
+						Source:      ir.Endpoint{Namespace: "default", PodName: "tiefighter"},
+						Destination: ir.Endpoint{Namespace: "kube-system", PodName: "coredns"},
 					}},
-					{Event: &flowpb.Flow{
-						Source:      &flowpb.Endpoint{Namespace: "kube-system", PodName: "coredns"},
-						Destination: &flowpb.Endpoint{Namespace: "default", PodName: "xwing"},
+					{Event: &ir.Flow{
+						Source:      ir.Endpoint{Namespace: "kube-system", PodName: "coredns"},
+						Destination: ir.Endpoint{Namespace: "default", PodName: "xwing"},
 					}},
-					{Event: &flowpb.Flow{
-						Source:      &flowpb.Endpoint{Namespace: "default", PodName: "tiefighter"},
-						Destination: &flowpb.Endpoint{Namespace: "default", PodName: "xwing"},
+					{Event: &ir.Flow{
+						Source:      ir.Endpoint{Namespace: "default", PodName: "tiefighter"},
+						Destination: ir.Endpoint{Namespace: "default", PodName: "xwing"},
 					}},
 				},
 			},
@@ -169,20 +170,20 @@ func TestPodFilter(t *testing.T) {
 					{SourcePod: []string{"xwing", "kube-system/coredns-"}},
 				},
 				ev: []*v1.Event{
-					{Event: &flowpb.Flow{
-						Source: &flowpb.Endpoint{Namespace: "default", PodName: "xwing"},
+					{Event: &ir.Flow{
+						Source: ir.Endpoint{Namespace: "default", PodName: "xwing"},
 					}},
-					{Event: &flowpb.Flow{
-						Source: &flowpb.Endpoint{Namespace: "default", PodName: "xwing-t-65b"},
+					{Event: &ir.Flow{
+						Source: ir.Endpoint{Namespace: "default", PodName: "xwing-t-65b"},
 					}},
-					{Event: &flowpb.Flow{
-						Source: &flowpb.Endpoint{Namespace: "kube-system", PodName: "coredns-12345"},
+					{Event: &ir.Flow{
+						Source: ir.Endpoint{Namespace: "kube-system", PodName: "coredns-12345"},
 					}},
-					{Event: &flowpb.Flow{
-						Source: &flowpb.Endpoint{Namespace: "kube-system", PodName: "-coredns-12345"},
+					{Event: &ir.Flow{
+						Source: ir.Endpoint{Namespace: "kube-system", PodName: "-coredns-12345"},
 					}},
-					{Event: &flowpb.Flow{
-						Source: &flowpb.Endpoint{Namespace: "default", PodName: "tiefighter"},
+					{Event: &ir.Flow{
+						Source: ir.Endpoint{Namespace: "default", PodName: "tiefighter"},
 					}},
 				},
 			},
@@ -203,8 +204,8 @@ func TestPodFilter(t *testing.T) {
 				ev: []*v1.Event{
 					nil,
 					{},
-					{Event: &flowpb.Flow{}},
-					{Event: &flowpb.Flow{Source: &flowpb.Endpoint{Namespace: "", PodName: "xwing"}}},
+					{Event: &ir.Flow{}},
+					{Event: &ir.Flow{Source: ir.Endpoint{Namespace: "", PodName: "xwing"}}},
 				},
 			},
 			want: []bool{
@@ -240,29 +241,29 @@ func TestPodFilter(t *testing.T) {
 					{DestinationPod: []string{"/xwing"}},
 				},
 				ev: []*v1.Event{
-					{Event: &flowpb.Flow{
-						Source:      &flowpb.Endpoint{Namespace: "kube-system", PodName: "coredns"},
-						Destination: &flowpb.Endpoint{Namespace: "kube-system", PodName: "kube-proxy"},
+					{Event: &ir.Flow{
+						Source:      ir.Endpoint{Namespace: "kube-system", PodName: "coredns"},
+						Destination: ir.Endpoint{Namespace: "kube-system", PodName: "kube-proxy"},
 					}},
-					{Event: &flowpb.Flow{
-						Source:      &flowpb.Endpoint{Namespace: "default", PodName: "tiefighter"},
-						Destination: &flowpb.Endpoint{Namespace: "kube-system", PodName: "coredns"},
+					{Event: &ir.Flow{
+						Source:      ir.Endpoint{Namespace: "default", PodName: "tiefighter"},
+						Destination: ir.Endpoint{Namespace: "kube-system", PodName: "coredns"},
 					}},
-					{Event: &flowpb.Flow{
-						Source:      &flowpb.Endpoint{Namespace: "kube-system", PodName: "coredns"},
-						Destination: &flowpb.Endpoint{Namespace: "default", PodName: "xwing"},
+					{Event: &ir.Flow{
+						Source:      ir.Endpoint{Namespace: "kube-system", PodName: "coredns"},
+						Destination: ir.Endpoint{Namespace: "default", PodName: "xwing"},
 					}},
-					{Event: &flowpb.Flow{
-						Source:      &flowpb.Endpoint{Namespace: "default", PodName: "tiefighter"},
-						Destination: &flowpb.Endpoint{Namespace: "default", PodName: "xwing"},
+					{Event: &ir.Flow{
+						Source:      ir.Endpoint{Namespace: "default", PodName: "tiefighter"},
+						Destination: ir.Endpoint{Namespace: "default", PodName: "xwing"},
 					}},
-					{Event: &flowpb.Flow{
-						Source:      &flowpb.Endpoint{Namespace: "hoth", PodName: "tiefighter"},
-						Destination: &flowpb.Endpoint{Namespace: "endor", PodName: "xwing"},
+					{Event: &ir.Flow{
+						Source:      ir.Endpoint{Namespace: "hoth", PodName: "tiefighter"},
+						Destination: ir.Endpoint{Namespace: "endor", PodName: "xwing"},
 					}},
-					{Event: &flowpb.Flow{
-						Source:      &flowpb.Endpoint{Namespace: "default", PodName: "tiefighter"},
-						Destination: &flowpb.Endpoint{Namespace: "default", PodName: "ywing"},
+					{Event: &ir.Flow{
+						Source:      ir.Endpoint{Namespace: "default", PodName: "tiefighter"},
+						Destination: ir.Endpoint{Namespace: "default", PodName: "ywing"},
 					}},
 				},
 			},
@@ -310,10 +311,10 @@ func TestServiceFilter(t *testing.T) {
 					{SourceService: []string{"deathstar", "kube-system/kube-dns"}},
 				},
 				ev: []*v1.Event{
-					{Event: &flowpb.Flow{SourceService: &flowpb.Service{Namespace: "default", Name: "xwing"}}},
-					{Event: &flowpb.Flow{SourceService: &flowpb.Service{Namespace: "default", Name: "deathstar"}}},
-					{Event: &flowpb.Flow{SourceService: &flowpb.Service{Namespace: "kube-system", Name: "kube-dns"}}},
-					{Event: &flowpb.Flow{DestinationService: &flowpb.Service{Namespace: "kube-system", Name: "deathstar"}}},
+					{Event: &ir.Flow{SourceService: ir.Service{Namespace: "default", Name: "xwing"}}},
+					{Event: &ir.Flow{SourceService: ir.Service{Namespace: "default", Name: "deathstar"}}},
+					{Event: &ir.Flow{SourceService: ir.Service{Namespace: "kube-system", Name: "kube-dns"}}},
+					{Event: &ir.Flow{DestinationService: ir.Service{Namespace: "kube-system", Name: "deathstar"}}},
 				},
 			},
 			want: []bool{
@@ -330,10 +331,10 @@ func TestServiceFilter(t *testing.T) {
 					{DestinationService: []string{"default/", "kube-system/kube-"}},
 				},
 				ev: []*v1.Event{
-					{Event: &flowpb.Flow{DestinationService: &flowpb.Service{Namespace: "default", Name: "xwing"}}},
-					{Event: &flowpb.Flow{DestinationService: &flowpb.Service{Namespace: "default", Name: "deathstar"}}},
-					{Event: &flowpb.Flow{DestinationService: &flowpb.Service{Namespace: "kube-system", Name: "kube-dns"}}},
-					{Event: &flowpb.Flow{SourceService: &flowpb.Service{Namespace: "kube-system", Name: "deathstar"}}},
+					{Event: &ir.Flow{DestinationService: ir.Service{Namespace: "default", Name: "xwing"}}},
+					{Event: &ir.Flow{DestinationService: ir.Service{Namespace: "default", Name: "deathstar"}}},
+					{Event: &ir.Flow{DestinationService: ir.Service{Namespace: "kube-system", Name: "kube-dns"}}},
+					{Event: &ir.Flow{SourceService: ir.Service{Namespace: "kube-system", Name: "deathstar"}}},
 				},
 			},
 			want: []bool{
@@ -350,11 +351,11 @@ func TestServiceFilter(t *testing.T) {
 					{DestinationService: []string{"/kube-"}},
 				},
 				ev: []*v1.Event{
-					{Event: &flowpb.Flow{DestinationService: &flowpb.Service{Namespace: "default", Name: "xwing"}}},
-					{Event: &flowpb.Flow{DestinationService: &flowpb.Service{Namespace: "default", Name: "deathstar"}}},
-					{Event: &flowpb.Flow{DestinationService: &flowpb.Service{Namespace: "kube-system", Name: "kube-dns"}}},
-					{Event: &flowpb.Flow{SourceService: &flowpb.Service{Namespace: "kube-system", Name: "deathstar"}}},
-					{Event: &flowpb.Flow{DestinationService: &flowpb.Service{Namespace: "monitoring", Name: "kube-prometheus"}}},
+					{Event: &ir.Flow{DestinationService: ir.Service{Namespace: "default", Name: "xwing"}}},
+					{Event: &ir.Flow{DestinationService: ir.Service{Namespace: "default", Name: "deathstar"}}},
+					{Event: &ir.Flow{DestinationService: ir.Service{Namespace: "kube-system", Name: "kube-dns"}}},
+					{Event: &ir.Flow{SourceService: ir.Service{Namespace: "kube-system", Name: "deathstar"}}},
+					{Event: &ir.Flow{DestinationService: ir.Service{Namespace: "monitoring", Name: "kube-prometheus"}}},
 				},
 			},
 			want: []bool{

--- a/pkg/hubble/filters/labels.go
+++ b/pkg/hubble/filters/labels.go
@@ -15,18 +15,39 @@ import (
 )
 
 func sourceLabels(ev *v1.Event) k8sLabels.Labels {
-	labels := ev.GetFlow().GetSource().GetLabels()
-	return ciliumLabels.ParseK8sLabelArrayFromArray(labels)
+	if ev == nil {
+		return nil
+	}
+	fl := ev.GetFlow()
+	if fl == nil {
+		return nil
+	}
+
+	return ciliumLabels.ParseK8sLabelArrayFromArray(fl.Source.Labels)
 }
 
 func destinationLabels(ev *v1.Event) k8sLabels.Labels {
-	labels := ev.GetFlow().GetDestination().GetLabels()
-	return ciliumLabels.ParseK8sLabelArrayFromArray(labels)
+	if ev == nil {
+		return nil
+	}
+	fl := ev.GetFlow()
+	if fl == nil {
+		return nil
+	}
+
+	return ciliumLabels.ParseK8sLabelArrayFromArray(fl.Destination.Labels)
 }
 
 func nodeLabels(ev *v1.Event) k8sLabels.Labels {
-	labels := ev.GetFlow().GetNodeLabels()
-	return ciliumLabels.ParseK8sLabelArrayFromArray(labels)
+	if ev == nil {
+		return nil
+	}
+	fl := ev.GetFlow()
+	if fl == nil {
+		return nil
+	}
+
+	return ciliumLabels.ParseK8sLabelArrayFromArray(fl.NodeLabels)
 }
 
 func parseSelector(selector string) (k8sLabels.Selector, error) {

--- a/pkg/hubble/filters/labels_test.go
+++ b/pkg/hubble/filters/labels_test.go
@@ -10,6 +10,7 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 )
 
 func TestLabelSelectorFilter(t *testing.T) {
@@ -29,29 +30,29 @@ func TestLabelSelectorFilter(t *testing.T) {
 				f: []*flowpb.FlowFilter{{SourceLabel: []string{"label1", "label2"}}},
 				ev: []*v1.Event{
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"label1"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"label1=val1"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"label2", "label3", "label4=val4"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"label3"},
 							},
 						},
@@ -71,57 +72,57 @@ func TestLabelSelectorFilter(t *testing.T) {
 				f: []*flowpb.FlowFilter{{SourceLabel: []string{"label1=val1", "label2=val2"}}},
 				ev: []*v1.Event{
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"label1"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"label1=val1"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"label1=val2", "label2=val1", "label3"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"label2=val2", "label3"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"label3=val1"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{""},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: nil,
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"label1=val1=toomuch"},
 							},
 						},
@@ -145,36 +146,36 @@ func TestLabelSelectorFilter(t *testing.T) {
 				f: []*flowpb.FlowFilter{{SourceLabel: []string{"label1 in (val1, val2), label3 notin ()"}}},
 				ev: []*v1.Event{
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"label1"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"label1=val1"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"label1=val2", "label2=val1", "label3=val3"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"label2=val2", "label3"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"label1=val1", "label3=val3"},
 							},
 						},
@@ -199,20 +200,20 @@ func TestLabelSelectorFilter(t *testing.T) {
 				},
 				ev: []*v1.Event{
 					{
-						Event: &flowpb.Flow{
+						Event: &ir.Flow{
 							NodeLabels: []string{"src1", "src2=val2"},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"src1", "src2=val2"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Destination: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Destination: ir.Endpoint{
 								Labels: []string{"src1", "src2=val2"},
 							},
 						},
@@ -236,45 +237,45 @@ func TestLabelSelectorFilter(t *testing.T) {
 				},
 				ev: []*v1.Event{
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"src1", "src2=val2"},
 							},
-							Destination: &flowpb.Endpoint{
+							Destination: ir.Endpoint{
 								Labels: []string{"dst1", "dst2=val2"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"label1=val1"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Destination: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Destination: ir.Endpoint{
 								Labels: []string{"dst1", "dst2=val2"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"dst1", "dst2=val2"},
 							},
-							Destination: &flowpb.Endpoint{
+							Destination: ir.Endpoint{
 								Labels: []string{"src1", "src2=val2"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"src1"},
 							},
-							Destination: &flowpb.Endpoint{
+							Destination: ir.Endpoint{
 								Labels: []string{"dst1"},
 							},
 						},
@@ -299,22 +300,22 @@ func TestLabelSelectorFilter(t *testing.T) {
 				},
 				ev: []*v1.Event{
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"src1", "src2=val2"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: nil,
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{""},
 							},
 						},
@@ -337,30 +338,30 @@ func TestLabelSelectorFilter(t *testing.T) {
 				},
 				ev: []*v1.Event{
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"k8s:app=bar"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"k8s:foo=baz"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"k8s.app=bar"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
-								Labels: []string{"cni:foo=bar", "reserved:host"},
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
+								Labels: []string{"container:foo=bar", "reserved:host"},
 							},
 						},
 					},
@@ -383,30 +384,30 @@ func TestLabelSelectorFilter(t *testing.T) {
 				},
 				ev: []*v1.Event{
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"k8s:app=bar"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"k8s:app=baz"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"k8s.app=bar"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
-								Labels: []string{"cni:foo=bar", "reserved:host"},
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
+								Labels: []string{"container:foo=bar", "reserved:host"},
 							},
 						},
 					},
@@ -429,22 +430,22 @@ func TestLabelSelectorFilter(t *testing.T) {
 				},
 				ev: []*v1.Event{
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"key"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"reserved:key"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"any.key"},
 							},
 						},
@@ -467,22 +468,22 @@ func TestLabelSelectorFilter(t *testing.T) {
 				},
 				ev: []*v1.Event{
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"key"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"reserved:key"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"any.key"},
 							},
 						},
@@ -505,29 +506,29 @@ func TestLabelSelectorFilter(t *testing.T) {
 				},
 				ev: []*v1.Event{
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"k8s:key.with.dot"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"reserved:key.with.dot"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"any.key.with.dot"},
 							},
 						},
 					},
 					{
-						Event: &flowpb.Flow{
-							Source: &flowpb.Endpoint{
+						Event: &ir.Flow{
+							Source: ir.Endpoint{
 								Labels: []string{"key:with.dot"},
 							},
 						},

--- a/pkg/hubble/filters/network_interface.go
+++ b/pkg/hubble/filters/network_interface.go
@@ -12,15 +12,22 @@ import (
 
 func filterByNetworkInterface(ifaces []*flowpb.NetworkInterface) FilterFunc {
 	return func(ev *v1.Event) bool {
-		iface := ev.GetFlow().GetInterface()
-		if iface == nil {
+		if ev == nil {
+			return false
+		}
+		fl := ev.GetFlow()
+		if fl == nil {
+			return false
+		}
+		iface := fl.Interface
+		if iface.IsEmpty() {
 			return false
 		}
 		for _, f := range ifaces {
-			if idx := f.GetIndex(); idx > 0 && idx != iface.GetIndex() {
+			if idx := f.GetIndex(); idx > 0 && idx != iface.Index {
 				continue
 			}
-			if name := f.GetName(); name != "" && name != iface.GetName() {
+			if name := f.GetName(); name != "" && name != iface.Name {
 				continue
 			}
 			return true

--- a/pkg/hubble/filters/network_interface_test.go
+++ b/pkg/hubble/filters/network_interface_test.go
@@ -10,6 +10,7 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 )
 
 func TestNetworkInterfaceFilter(t *testing.T) {
@@ -44,8 +45,8 @@ func TestNetworkInterfaceFilter(t *testing.T) {
 						{},
 					},
 				}},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Interface: &flowpb.NetworkInterface{
+				ev: &v1.Event{Event: &ir.Flow{
+					Interface: ir.NetworkInterface{
 						Index: 1,
 						Name:  "eth1",
 					},
@@ -61,7 +62,7 @@ func TestNetworkInterfaceFilter(t *testing.T) {
 						{},
 					},
 				}},
-				ev: &v1.Event{Event: &flowpb.Flow{}},
+				ev: &v1.Event{Event: &ir.Flow{}},
 			},
 			want: false,
 		},
@@ -73,8 +74,8 @@ func TestNetworkInterfaceFilter(t *testing.T) {
 						{},
 					},
 				}},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Interface: &flowpb.NetworkInterface{
+				ev: &v1.Event{Event: &ir.Flow{
+					Interface: ir.NetworkInterface{
 						Index: 1,
 						Name:  "eth1",
 					},
@@ -92,8 +93,8 @@ func TestNetworkInterfaceFilter(t *testing.T) {
 						},
 					},
 				}},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Interface: &flowpb.NetworkInterface{
+				ev: &v1.Event{Event: &ir.Flow{
+					Interface: ir.NetworkInterface{
 						Index: 1,
 						Name:  "eth1",
 					},
@@ -111,8 +112,8 @@ func TestNetworkInterfaceFilter(t *testing.T) {
 						},
 					},
 				}},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Interface: &flowpb.NetworkInterface{
+				ev: &v1.Event{Event: &ir.Flow{
+					Interface: ir.NetworkInterface{
 						Index: 1,
 						Name:  "eth1",
 					},
@@ -131,8 +132,8 @@ func TestNetworkInterfaceFilter(t *testing.T) {
 						},
 					},
 				}},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Interface: &flowpb.NetworkInterface{
+				ev: &v1.Event{Event: &ir.Flow{
+					Interface: ir.NetworkInterface{
 						Index: 1,
 						Name:  "eth1",
 					},
@@ -150,8 +151,8 @@ func TestNetworkInterfaceFilter(t *testing.T) {
 						},
 					},
 				}},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Interface: &flowpb.NetworkInterface{
+				ev: &v1.Event{Event: &ir.Flow{
+					Interface: ir.NetworkInterface{
 						Index: 1,
 						Name:  "eth1",
 					},
@@ -169,8 +170,8 @@ func TestNetworkInterfaceFilter(t *testing.T) {
 						},
 					},
 				}},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Interface: &flowpb.NetworkInterface{
+				ev: &v1.Event{Event: &ir.Flow{
+					Interface: ir.NetworkInterface{
 						Index: 1,
 						Name:  "eth1",
 					},

--- a/pkg/hubble/filters/nodename.go
+++ b/pkg/hubble/filters/nodename.go
@@ -21,10 +21,17 @@ func filterByNodeNames(nodeNames []string) (FilterFunc, error) {
 	}
 
 	return func(ev *v1.Event) bool {
-		nodeName := ev.GetFlow().GetNodeName()
-		if nodeName == "" {
+		if ev == nil {
 			return false
 		}
+		fl := ev.GetFlow()
+		if fl == nil {
+			return false
+		}
+		if fl.NodeName == "" {
+			return false
+		}
+		nodeName := fl.NodeName
 		// ensure that the node name always includes a cluster name
 		if !strings.Contains(nodeName, "/") {
 			nodeName = ciliumDefaults.ClusterName + "/" + nodeName

--- a/pkg/hubble/filters/nodename_test.go
+++ b/pkg/hubble/filters/nodename_test.go
@@ -11,6 +11,7 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/monitor/api"
 )
 
@@ -144,8 +145,8 @@ func TestNodeFilter(t *testing.T) {
 
 			for nodeName, want := range tt.want {
 				ev := &v1.Event{
-					Event: &flowpb.Flow{
-						EventType: &flowpb.CiliumEventType{
+					Event: &ir.Flow{
+						EventType: ir.CiliumEventType{
 							Type: api.MessageTypeAccessLog,
 						},
 						NodeName: nodeName,

--- a/pkg/hubble/filters/port.go
+++ b/pkg/hubble/filters/port.go
@@ -14,31 +14,44 @@ import (
 )
 
 func sourcePort(ev *v1.Event) (port uint16, ok bool) {
-	l4 := ev.GetFlow().GetL4()
-	if tcp := l4.GetTCP(); tcp != nil {
-		return uint16(tcp.SourcePort), true
+	if ev == nil {
+		return 0, false
 	}
-	if udp := l4.GetUDP(); udp != nil {
-		return uint16(udp.SourcePort), true
+	fl := ev.GetFlow()
+	if fl == nil {
+		return 0, false
 	}
-	if sctp := l4.GetSCTP(); sctp != nil {
-		return uint16(sctp.SourcePort), true
+	switch {
+	case !fl.L4.TCP.IsEmpty():
+		return uint16(fl.L4.TCP.SourcePort), true
+	case !fl.L4.UDP.IsEmpty():
+		return uint16(fl.L4.UDP.SourcePort), true
+	case !fl.L4.SCTP.IsEmpty():
+		return uint16(fl.L4.SCTP.SourcePort), true
+	default:
+		return 0, false
 	}
-	return 0, false
 }
 
 func destinationPort(ev *v1.Event) (port uint16, ok bool) {
-	l4 := ev.GetFlow().GetL4()
-	if tcp := l4.GetTCP(); tcp != nil {
-		return uint16(tcp.DestinationPort), true
+	if ev == nil {
+		return 0, false
 	}
-	if udp := l4.GetUDP(); udp != nil {
-		return uint16(udp.DestinationPort), true
+	fl := ev.GetFlow()
+	if fl == nil {
+		return 0, false
 	}
-	if sctp := l4.GetSCTP(); sctp != nil {
-		return uint16(sctp.DestinationPort), true
+
+	switch {
+	case !fl.L4.TCP.IsEmpty():
+		return uint16(fl.L4.TCP.DestinationPort), true
+	case !fl.L4.UDP.IsEmpty():
+		return uint16(fl.L4.UDP.DestinationPort), true
+	case !fl.L4.SCTP.IsEmpty():
+		return uint16(fl.L4.SCTP.DestinationPort), true
+	default:
+		return 0, false
 	}
-	return 0, false
 }
 
 func filterByPort(portStrs []string, getPort func(*v1.Event) (port uint16, ok bool)) (FilterFunc, error) {

--- a/pkg/hubble/filters/port_test.go
+++ b/pkg/hubble/filters/port_test.go
@@ -8,6 +8,7 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 )
 
 func TestPortFilter(t *testing.T) {
@@ -28,11 +29,11 @@ func TestPortFilter(t *testing.T) {
 					SourcePort:      []string{"12345"},
 					DestinationPort: []string{"53"},
 				}},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_UDP{UDP: &flowpb.UDP{
+				ev: &v1.Event{Event: &ir.Flow{
+					L4: ir.Layer4{UDP: ir.UDP{
 						SourcePort:      12345,
 						DestinationPort: 53,
-					}}},
+					}},
 				}},
 			},
 			want: true,
@@ -44,11 +45,11 @@ func TestPortFilter(t *testing.T) {
 					SourcePort:      []string{"32320"},
 					DestinationPort: []string{"80"},
 				}},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{
+				ev: &v1.Event{Event: &ir.Flow{
+					L4: ir.Layer4{TCP: ir.TCP{
 						SourcePort:      32320,
 						DestinationPort: 80,
-					}}},
+					}},
 				}},
 			},
 			want: true,
@@ -59,11 +60,11 @@ func TestPortFilter(t *testing.T) {
 				f: []*flowpb.FlowFilter{{
 					DestinationPort: []string{"80"},
 				}},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{
+				ev: &v1.Event{Event: &ir.Flow{
+					L4: ir.Layer4{TCP: ir.TCP{
 						SourcePort:      80,
 						DestinationPort: 32320,
-					}}},
+					}},
 				}},
 			},
 			want: false,
@@ -74,8 +75,8 @@ func TestPortFilter(t *testing.T) {
 				f: []*flowpb.FlowFilter{{
 					DestinationPort: []string{"0"},
 				}},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_ICMPv4{ICMPv4: &flowpb.ICMPv4{}}},
+				ev: &v1.Event{Event: &ir.Flow{
+					L4: ir.Layer4{ICMPv4: ir.ICMP{}},
 				}},
 			},
 			want: false,

--- a/pkg/hubble/filters/protocol.go
+++ b/pkg/hubble/filters/protocol.go
@@ -27,53 +27,61 @@ func filterByProtocol(protocols []string) (FilterFunc, error) {
 	}
 
 	return func(ev *v1.Event) bool {
-		l4 := ev.GetFlow().GetL4()
+		if ev == nil {
+			return false
+		}
+		fl := ev.GetFlow()
+		if fl == nil {
+			return false
+		}
 		for _, proto := range l4Protocols {
 			switch proto {
 			case "icmp":
-				if l4.GetICMPv4() != nil || l4.GetICMPv6() != nil {
+				if !fl.L4.ICMPv4.IsEmpty() || !fl.L4.ICMPv6.IsEmpty() {
 					return true
 				}
 			case "icmpv4":
-				if l4.GetICMPv4() != nil {
+				if !fl.L4.ICMPv4.IsEmpty() {
 					return true
 				}
 			case "icmpv6":
-				if l4.GetICMPv6() != nil {
+				if !fl.L4.ICMPv6.IsEmpty() {
 					return true
 				}
 			case "tcp":
-				if l4.GetTCP() != nil {
+				if !fl.L4.TCP.IsEmpty() {
 					return true
 				}
 			case "udp":
-				if l4.GetUDP() != nil {
+				if !fl.L4.UDP.IsEmpty() {
 					return true
 				}
 			case "sctp":
-				if l4.GetSCTP() != nil {
+				if !fl.L4.SCTP.IsEmpty() {
 					return true
 				}
 			case "vrrp":
-				if l4.GetVRRP() != nil {
+				if !fl.L4.VRRP.IsEmpty() {
 					return true
 				}
 			case "igmp":
-				if l4.GetIGMP() != nil {
+				if !fl.L4.IGMP.IsEmpty() {
 					return true
 				}
 			}
 		}
 
-		l7 := ev.GetFlow().GetL7()
+		if fl.L7.IsEmpty() {
+			return false
+		}
 		for _, proto := range l7Protocols {
 			switch proto {
 			case "dns":
-				if l7.GetDns() != nil {
+				if !fl.L7.DNS.IsEmpty() {
 					return true
 				}
 			case "http":
-				if l7.GetHttp() != nil {
+				if !fl.L7.HTTP.IsEmpty() {
 					return true
 				}
 			}

--- a/pkg/hubble/filters/protocol_test.go
+++ b/pkg/hubble/filters/protocol_test.go
@@ -8,6 +8,7 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 )
 
 func TestFlowProtocolFilter(t *testing.T) {
@@ -25,8 +26,8 @@ func TestFlowProtocolFilter(t *testing.T) {
 			name: "udp",
 			args: args{
 				f: []*flowpb.FlowFilter{{Protocol: []string{"udp"}}},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_UDP{UDP: &flowpb.UDP{}}},
+				ev: &v1.Event{Event: &ir.Flow{
+					L4: ir.Layer4{UDP: ir.UDP{SourcePort: 53}},
 				}},
 			},
 			want: true,
@@ -35,9 +36,9 @@ func TestFlowProtocolFilter(t *testing.T) {
 			name: "http",
 			args: args{
 				f: []*flowpb.FlowFilter{{Protocol: []string{"http"}}},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{}}},
-					L7: &flowpb.Layer7{Record: &flowpb.Layer7_Http{Http: &flowpb.HTTP{}}},
+				ev: &v1.Event{Event: &ir.Flow{
+					L4: ir.Layer4{TCP: ir.TCP{}},
+					L7: ir.Layer7{HTTP: ir.HTTP{Method: "GET"}},
 				}},
 			},
 			want: true,
@@ -46,8 +47,8 @@ func TestFlowProtocolFilter(t *testing.T) {
 			name: "icmp (v4)",
 			args: args{
 				f: []*flowpb.FlowFilter{{Protocol: []string{"icmp"}}},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_ICMPv4{ICMPv4: &flowpb.ICMPv4{}}},
+				ev: &v1.Event{Event: &ir.Flow{
+					L4: ir.Layer4{ICMPv4: ir.ICMP{Type: 1}},
 				}},
 			},
 			want: true,
@@ -56,8 +57,8 @@ func TestFlowProtocolFilter(t *testing.T) {
 			name: "icmp (v6)",
 			args: args{
 				f: []*flowpb.FlowFilter{{Protocol: []string{"icmp"}}},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_ICMPv6{ICMPv6: &flowpb.ICMPv6{}}},
+				ev: &v1.Event{Event: &ir.Flow{
+					L4: ir.Layer4{ICMPv6: ir.ICMP{Type: 1}},
 				}},
 			},
 			want: true,
@@ -66,8 +67,8 @@ func TestFlowProtocolFilter(t *testing.T) {
 			name: "vrrp",
 			args: args{
 				f: []*flowpb.FlowFilter{{Protocol: []string{"vrrp"}}},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_VRRP{VRRP: &flowpb.VRRP{}}},
+				ev: &v1.Event{Event: &ir.Flow{
+					L4: ir.Layer4{VRRP: ir.VRRP{Type: 1}},
 				}},
 			},
 			want: true,
@@ -76,8 +77,8 @@ func TestFlowProtocolFilter(t *testing.T) {
 			name: "igmp",
 			args: args{
 				f: []*flowpb.FlowFilter{{Protocol: []string{"igmp"}}},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_IGMP{IGMP: &flowpb.IGMP{}}},
+				ev: &v1.Event{Event: &ir.Flow{
+					L4: ir.Layer4{IGMP: ir.IGMP{Type: 1}},
 				}},
 			},
 			want: true,
@@ -86,8 +87,8 @@ func TestFlowProtocolFilter(t *testing.T) {
 			name: "multiple protocols",
 			args: args{
 				f: []*flowpb.FlowFilter{{Protocol: []string{"tcp", "icmp"}}},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{}}},
+				ev: &v1.Event{Event: &ir.Flow{
+					L4: ir.Layer4{TCP: ir.TCP{SourcePort: 80}},
 				}},
 			},
 			want: true,

--- a/pkg/hubble/filters/tcp.go
+++ b/pkg/hubble/filters/tcp.go
@@ -12,8 +12,15 @@ import (
 
 func filterByTCPFlags(flags []*flowpb.TCPFlags) FilterFunc {
 	return func(ev *v1.Event) bool {
-		flowFlags := ev.GetFlow().GetL4().GetTCP().GetFlags()
-		if flowFlags == nil {
+		if ev == nil {
+			return false
+		}
+		fl := ev.GetFlow()
+		if fl == nil {
+			return false
+		}
+		flowFlags := fl.L4.TCP.Flags
+		if flowFlags.IsEmpty() {
 			return false
 		}
 		// check if the TCP event has any of the flags mentioned in flowfilter

--- a/pkg/hubble/filters/tcp_test.go
+++ b/pkg/hubble/filters/tcp_test.go
@@ -8,6 +8,7 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 )
 
 func TestFlowTCPFilter(t *testing.T) {
@@ -16,100 +17,105 @@ func TestFlowTCPFilter(t *testing.T) {
 	testflags := []struct {
 		name   string
 		argsf  []*flowpb.TCPFlags
-		argsev *flowpb.TCPFlags
+		argsev ir.TCPFlags
 		want   bool
 	}{
 		{
 			name:   "filterSYNACK___eventSYNACK",
 			argsf:  []*flowpb.TCPFlags{{SYN: true, ACK: true}},
-			argsev: &flowpb.TCPFlags{SYN: true, ACK: true},
+			argsev: ir.TCPFlags{SYN: true, ACK: true},
 			want:   true,
 		},
 		{
 			name:   "filterSYNACK___eventSYN",
 			argsf:  []*flowpb.TCPFlags{{SYN: true, ACK: true}},
-			argsev: &flowpb.TCPFlags{SYN: true},
+			argsev: ir.TCPFlags{SYN: true},
 			want:   false,
 		},
 		{
 			name:   "filterSYN_OR_filterACK___eventSYN",
 			argsf:  []*flowpb.TCPFlags{{SYN: true}, {ACK: true}},
-			argsev: &flowpb.TCPFlags{SYN: true},
+			argsev: ir.TCPFlags{SYN: true},
 			want:   true,
 		},
 		{
 			name:   "filterSYN_OR_filterACK___eventSYNACK",
 			argsf:  []*flowpb.TCPFlags{{SYN: true}, {ACK: true}},
-			argsev: &flowpb.TCPFlags{SYN: true, ACK: true},
+			argsev: ir.TCPFlags{SYN: true, ACK: true},
 			want:   true,
 		},
 		{
 			name:   "filterSYN_OR_filterACK___eventPSHACK",
 			argsf:  []*flowpb.TCPFlags{{SYN: true}, {ACK: true}},
-			argsev: &flowpb.TCPFlags{PSH: true, ACK: true},
+			argsev: ir.TCPFlags{PSH: true, ACK: true},
 			want:   true,
 		},
 		{
 			name:   "filterSYN___eventSYN",
 			argsf:  []*flowpb.TCPFlags{{SYN: true}},
-			argsev: &flowpb.TCPFlags{SYN: true},
+			argsev: ir.TCPFlags{SYN: true},
 			want:   true,
 		},
 		{
 			name:   "filterSYN___eventSYNACK",
 			argsf:  []*flowpb.TCPFlags{{SYN: true}},
-			argsev: &flowpb.TCPFlags{SYN: true, ACK: true},
+			argsev: ir.TCPFlags{SYN: true, ACK: true},
 			want:   true,
 		},
 		{
 			name:   "filterFIN___eventRST",
 			argsf:  []*flowpb.TCPFlags{{FIN: true}},
-			argsev: &flowpb.TCPFlags{RST: true},
+			argsev: ir.TCPFlags{RST: true},
 			want:   false,
 		},
 		{
 			name:   "filterSYN___eventPSH",
 			argsf:  []*flowpb.TCPFlags{{SYN: true}},
-			argsev: &flowpb.TCPFlags{PSH: true},
+			argsev: ir.TCPFlags{PSH: true},
 			want:   false,
 		},
 		{
 			name:   "filterURG___eventPSH",
 			argsf:  []*flowpb.TCPFlags{{URG: true}},
-			argsev: &flowpb.TCPFlags{PSH: true},
+			argsev: ir.TCPFlags{PSH: true},
 			want:   false,
 		},
 		{
 			name:   "filterRST___eventRST",
 			argsf:  []*flowpb.TCPFlags{{RST: true}},
-			argsev: &flowpb.TCPFlags{RST: true},
+			argsev: ir.TCPFlags{RST: true},
 			want:   true,
 		},
 		{
 			name:   "filterFIN___eventFIN",
 			argsf:  []*flowpb.TCPFlags{{FIN: true}},
-			argsev: &flowpb.TCPFlags{FIN: true},
+			argsev: ir.TCPFlags{FIN: true},
 			want:   true,
 		},
 		{
 			name:   "filterPSH___eventPSHACK",
 			argsf:  []*flowpb.TCPFlags{{PSH: true}},
-			argsev: &flowpb.TCPFlags{PSH: true, ACK: true},
+			argsev: ir.TCPFlags{PSH: true, ACK: true},
 			want:   true,
 		},
 		// regression test for GH-18830
 		{
 			name:   "TCP flow without flags",
 			argsf:  []*flowpb.TCPFlags{{SYN: true}},
-			argsev: nil,
+			argsev: ir.TCPFlags{},
 			want:   false,
 		},
 	}
 
 	for _, tt := range testflags {
 		argsfilter = []*flowpb.FlowFilter{{TcpFlags: tt.argsf}}
-		argsevent = &v1.Event{Event: &flowpb.Flow{
-			L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{Flags: tt.argsev}}}}}
+		argsevent = &v1.Event{
+			Event: &ir.Flow{
+				L4: ir.Layer4{
+					TCP: ir.TCP{Flags: tt.argsev},
+				},
+			},
+		}
 		t.Run(tt.name, func(t *testing.T) {
 			fl, err := BuildFilterList(t.Context(), argsfilter, []OnBuildFilter{&TCPFilter{}})
 			if err != nil {

--- a/pkg/hubble/filters/tracing.go
+++ b/pkg/hubble/filters/tracing.go
@@ -13,7 +13,14 @@ import (
 
 func filterByTraceID(tids []string) FilterFunc {
 	return func(ev *v1.Event) bool {
-		return slices.Contains(tids, ev.GetFlow().GetTraceContext().GetParent().GetTraceId())
+		if ev == nil {
+			return false
+		}
+		fl := ev.GetFlow()
+		if fl == nil {
+			return false
+		}
+		return slices.Contains(tids, fl.TraceContext.Parent.TraceID)
 	}
 }
 

--- a/pkg/hubble/filters/tracing_test.go
+++ b/pkg/hubble/filters/tracing_test.go
@@ -10,6 +10,7 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 )
 
 func TestTraceIDFilter(t *testing.T) {
@@ -30,10 +31,10 @@ func TestTraceIDFilter(t *testing.T) {
 						TraceId: []string{"4bf92f3577b34da6a3ce929d0e0e4736"},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					TraceContext: &flowpb.TraceContext{
-						Parent: &flowpb.TraceParent{
-							TraceId: "4bf92f3577b34da6a3ce929d0e0e4736",
+				ev: &v1.Event{Event: &ir.Flow{
+					TraceContext: ir.TraceContext{
+						Parent: ir.TraceParent{
+							TraceID: "4bf92f3577b34da6a3ce929d0e0e4736",
 						},
 					},
 				}},
@@ -50,10 +51,10 @@ func TestTraceIDFilter(t *testing.T) {
 						},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					TraceContext: &flowpb.TraceContext{
-						Parent: &flowpb.TraceParent{
-							TraceId: "4bf92f3577b34da6a3ce929d0e0e4736",
+				ev: &v1.Event{Event: &ir.Flow{
+					TraceContext: ir.TraceContext{
+						Parent: ir.TraceParent{
+							TraceID: "4bf92f3577b34da6a3ce929d0e0e4736",
 						},
 					},
 				}},
@@ -67,7 +68,7 @@ func TestTraceIDFilter(t *testing.T) {
 						TraceId: []string{""},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{}},
+				ev: &v1.Event{Event: &ir.Flow{}},
 			},
 			want: true,
 		}, {
@@ -78,10 +79,10 @@ func TestTraceIDFilter(t *testing.T) {
 						TraceId: []string{""},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					TraceContext: &flowpb.TraceContext{
-						Parent: &flowpb.TraceParent{
-							TraceId: "4bf92f3577b34da6a3ce929d0e0e4736",
+				ev: &v1.Event{Event: &ir.Flow{
+					TraceContext: ir.TraceContext{
+						Parent: ir.TraceParent{
+							TraceID: "4bf92f3577b34da6a3ce929d0e0e4736",
 						},
 					},
 				}},
@@ -95,10 +96,10 @@ func TestTraceIDFilter(t *testing.T) {
 						TraceId: []string{"deadbeefcafe"},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					TraceContext: &flowpb.TraceContext{
-						Parent: &flowpb.TraceParent{
-							TraceId: "4bf92f3577b34da6a3ce929d0e0e4736",
+				ev: &v1.Event{Event: &ir.Flow{
+					TraceContext: ir.TraceContext{
+						Parent: ir.TraceParent{
+							TraceID: "4bf92f3577b34da6a3ce929d0e0e4736",
 						},
 					},
 				}},
@@ -112,7 +113,7 @@ func TestTraceIDFilter(t *testing.T) {
 						TraceId: []string{"4bf92f3577b34da6a3ce929d0e0e4736"},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{}},
+				ev: &v1.Event{Event: &ir.Flow{}},
 			},
 			want: false,
 		},

--- a/pkg/hubble/filters/traffic_direction.go
+++ b/pkg/hubble/filters/traffic_direction.go
@@ -13,11 +13,14 @@ import (
 
 func filterByTrafficDirection(directions []flowpb.TrafficDirection) FilterFunc {
 	return func(ev *v1.Event) bool {
+		if ev == nil {
+			return false
+		}
 		flow := ev.GetFlow()
 		if flow == nil {
 			return false
 		}
-		return slices.Contains(directions, flow.GetTrafficDirection())
+		return slices.Contains(directions, flow.TrafficDirection)
 	}
 }
 

--- a/pkg/hubble/filters/traffic_direction_test.go
+++ b/pkg/hubble/filters/traffic_direction_test.go
@@ -10,6 +10,7 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 )
 
 func TestTrafficDirectionFilter(t *testing.T) {
@@ -42,7 +43,7 @@ func TestTrafficDirectionFilter(t *testing.T) {
 						flowpb.TrafficDirection_INGRESS,
 					},
 				}},
-				ev: &v1.Event{Event: &flowpb.Flow{
+				ev: &v1.Event{Event: &ir.Flow{
 					TrafficDirection: flowpb.TrafficDirection_INGRESS,
 				}},
 			},
@@ -56,7 +57,7 @@ func TestTrafficDirectionFilter(t *testing.T) {
 						flowpb.TrafficDirection_INGRESS,
 					},
 				}},
-				ev: &v1.Event{Event: &flowpb.Flow{
+				ev: &v1.Event{Event: &ir.Flow{
 					TrafficDirection: flowpb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN,
 				}},
 			},

--- a/pkg/hubble/filters/uuid.go
+++ b/pkg/hubble/filters/uuid.go
@@ -13,11 +13,14 @@ import (
 
 func filterByUUID(uuids []string) FilterFunc {
 	return func(ev *v1.Event) bool {
+		if ev == nil {
+			return false
+		}
 		flow := ev.GetFlow()
 		if flow == nil {
 			return false
 		}
-		return slices.Contains(uuids, flow.GetUuid())
+		return slices.Contains(uuids, flow.UUID)
 	}
 }
 

--- a/pkg/hubble/filters/uuid_test.go
+++ b/pkg/hubble/filters/uuid_test.go
@@ -10,6 +10,7 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 )
 
 func TestUUIDFilter(t *testing.T) {
@@ -44,8 +45,8 @@ func TestUUIDFilter(t *testing.T) {
 						"e3549e80-6216-4179-93ed-b00d33b939ff",
 					},
 				}},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Uuid: "a82c2c32-f410-47fb-9343-7788ea734c79",
+				ev: &v1.Event{Event: &ir.Flow{
+					UUID: "a82c2c32-f410-47fb-9343-7788ea734c79",
 				}},
 			},
 			want: true,
@@ -61,8 +62,8 @@ func TestUUIDFilter(t *testing.T) {
 						"e3549e80-6216-4179-93ed-b00d33b939ff",
 					},
 				}},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Uuid: "a82c2c32-f410-47fb-9343-7788ea734c79",
+				ev: &v1.Event{Event: &ir.Flow{
+					UUID: "a82c2c32-f410-47fb-9343-7788ea734c79",
 				}},
 			},
 			want: false,

--- a/pkg/hubble/filters/verdict.go
+++ b/pkg/hubble/filters/verdict.go
@@ -13,11 +13,14 @@ import (
 
 func filterByVerdicts(vs []flowpb.Verdict) FilterFunc {
 	return func(ev *v1.Event) bool {
+		if ev == nil {
+			return false
+		}
 		flow := ev.GetFlow()
 		if flow == nil {
 			return false
 		}
-		return slices.Contains(vs, flow.GetVerdict())
+		return slices.Contains(vs, flow.Verdict)
 	}
 }
 

--- a/pkg/hubble/filters/verdict_test.go
+++ b/pkg/hubble/filters/verdict_test.go
@@ -10,11 +10,12 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 )
 
 func TestVerdictFilter(t *testing.T) {
 	ev := &v1.Event{
-		Event: &flowpb.Flow{
+		Event: &ir.Flow{
 			Verdict: flowpb.Verdict_FORWARDED,
 		},
 	}

--- a/pkg/hubble/filters/workload.go
+++ b/pkg/hubble/filters/workload.go
@@ -9,14 +9,15 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 )
 
-func filterByWorkload(wf []*flowpb.Workload, getEndpoint func(*v1.Event) *flowpb.Endpoint) FilterFunc {
+func filterByWorkload(wf []*flowpb.Workload, getEndpoint func(*v1.Event) ir.Endpoint) FilterFunc {
 	return func(ev *v1.Event) bool {
-		for _, w := range getEndpoint(ev).GetWorkloads() {
+		for _, w := range getEndpoint(ev).Workloads {
 			if slices.ContainsFunc(wf, func(f *flowpb.Workload) bool {
-				return (f.GetName() == "" || f.GetName() == w.GetName()) &&
-					(f.GetKind() == "" || f.GetKind() == w.GetKind())
+				return (f.GetName() == "" || f.GetName() == w.Name) &&
+					(f.GetKind() == "" || f.GetKind() == w.Kind)
 			}) {
 				return true
 			}

--- a/pkg/hubble/filters/workload_test.go
+++ b/pkg/hubble/filters/workload_test.go
@@ -10,6 +10,7 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 )
 
 func TestWorkloadFilterInclude(t *testing.T) {
@@ -64,8 +65,8 @@ func TestWorkloadFilterInclude(t *testing.T) {
 						SourceWorkload: nil,
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Source: &flowpb.Endpoint{Workloads: []*flowpb.Workload{
+				ev: &v1.Event{Event: &ir.Flow{
+					Source: ir.Endpoint{Workloads: []ir.Workload{
 						{
 							Kind: "Deployment",
 							Name: "hubble-relay",
@@ -83,8 +84,8 @@ func TestWorkloadFilterInclude(t *testing.T) {
 						DestinationWorkload: nil,
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Destination: &flowpb.Endpoint{Workloads: []*flowpb.Workload{
+				ev: &v1.Event{Event: &ir.Flow{
+					Destination: ir.Endpoint{Workloads: []ir.Workload{
 						{
 							Kind: "Deployment",
 							Name: "hubble-relay",
@@ -102,8 +103,8 @@ func TestWorkloadFilterInclude(t *testing.T) {
 						SourceWorkload: []*flowpb.Workload{},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Source: &flowpb.Endpoint{Workloads: []*flowpb.Workload{
+				ev: &v1.Event{Event: &ir.Flow{
+					Source: ir.Endpoint{Workloads: []ir.Workload{
 						{
 							Kind: "Deployment",
 							Name: "hubble-relay",
@@ -121,8 +122,8 @@ func TestWorkloadFilterInclude(t *testing.T) {
 						DestinationWorkload: []*flowpb.Workload{},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Destination: &flowpb.Endpoint{Workloads: []*flowpb.Workload{
+				ev: &v1.Event{Event: &ir.Flow{
+					Destination: ir.Endpoint{Workloads: []ir.Workload{
 						{
 							Kind: "Deployment",
 							Name: "hubble-relay",
@@ -146,8 +147,8 @@ func TestWorkloadFilterInclude(t *testing.T) {
 						},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Source: &flowpb.Endpoint{Workloads: []*flowpb.Workload{
+				ev: &v1.Event{Event: &ir.Flow{
+					Source: ir.Endpoint{Workloads: []ir.Workload{
 						{
 							Kind: "Deployment",
 							Name: "hubble-relay",
@@ -170,8 +171,8 @@ func TestWorkloadFilterInclude(t *testing.T) {
 						},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Destination: &flowpb.Endpoint{Workloads: []*flowpb.Workload{
+				ev: &v1.Event{Event: &ir.Flow{
+					Destination: ir.Endpoint{Workloads: []ir.Workload{
 						{
 							Kind: "Deployment",
 							Name: "hubble-relay",
@@ -194,8 +195,8 @@ func TestWorkloadFilterInclude(t *testing.T) {
 						},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Source: &flowpb.Endpoint{Workloads: []*flowpb.Workload{}},
+				ev: &v1.Event{Event: &ir.Flow{
+					Source: ir.Endpoint{Workloads: []ir.Workload{}},
 				}},
 			},
 			want: false,
@@ -213,8 +214,8 @@ func TestWorkloadFilterInclude(t *testing.T) {
 						},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Destination: &flowpb.Endpoint{Workloads: []*flowpb.Workload{}},
+				ev: &v1.Event{Event: &ir.Flow{
+					Destination: ir.Endpoint{Workloads: []ir.Workload{}},
 				}},
 			},
 			want: false,
@@ -232,8 +233,8 @@ func TestWorkloadFilterInclude(t *testing.T) {
 						},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Source: &flowpb.Endpoint{Workloads: []*flowpb.Workload{
+				ev: &v1.Event{Event: &ir.Flow{
+					Source: ir.Endpoint{Workloads: []ir.Workload{
 						{
 							Kind: "Deployment",
 							Name: "hubble-relay",
@@ -256,8 +257,8 @@ func TestWorkloadFilterInclude(t *testing.T) {
 						},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Destination: &flowpb.Endpoint{Workloads: []*flowpb.Workload{
+				ev: &v1.Event{Event: &ir.Flow{
+					Destination: ir.Endpoint{Workloads: []ir.Workload{
 						{
 							Kind: "Deployment",
 							Name: "hubble-relay",
@@ -280,8 +281,8 @@ func TestWorkloadFilterInclude(t *testing.T) {
 						},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Source: &flowpb.Endpoint{Workloads: []*flowpb.Workload{
+				ev: &v1.Event{Event: &ir.Flow{
+					Source: ir.Endpoint{Workloads: []ir.Workload{
 						{
 							Kind: "Deployment",
 							Name: "hubble-relay",
@@ -304,8 +305,8 @@ func TestWorkloadFilterInclude(t *testing.T) {
 						},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Destination: &flowpb.Endpoint{Workloads: []*flowpb.Workload{
+				ev: &v1.Event{Event: &ir.Flow{
+					Destination: ir.Endpoint{Workloads: []ir.Workload{
 						{
 							Kind: "Deployment",
 							Name: "hubble-relay",
@@ -328,8 +329,8 @@ func TestWorkloadFilterInclude(t *testing.T) {
 						},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Source: &flowpb.Endpoint{Workloads: []*flowpb.Workload{
+				ev: &v1.Event{Event: &ir.Flow{
+					Source: ir.Endpoint{Workloads: []ir.Workload{
 						{
 							Kind: "Deployment",
 							Name: "hubble-relay",
@@ -352,8 +353,8 @@ func TestWorkloadFilterInclude(t *testing.T) {
 						},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Destination: &flowpb.Endpoint{Workloads: []*flowpb.Workload{
+				ev: &v1.Event{Event: &ir.Flow{
+					Destination: ir.Endpoint{Workloads: []ir.Workload{
 						{
 							Kind: "Deployment",
 							Name: "hubble-relay",
@@ -376,8 +377,8 @@ func TestWorkloadFilterInclude(t *testing.T) {
 						},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Source: &flowpb.Endpoint{Workloads: []*flowpb.Workload{
+				ev: &v1.Event{Event: &ir.Flow{
+					Source: ir.Endpoint{Workloads: []ir.Workload{
 						{
 							Kind: "Deployment",
 							Name: "hubble-relay",
@@ -400,8 +401,8 @@ func TestWorkloadFilterInclude(t *testing.T) {
 						},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Destination: &flowpb.Endpoint{Workloads: []*flowpb.Workload{
+				ev: &v1.Event{Event: &ir.Flow{
+					Destination: ir.Endpoint{Workloads: []ir.Workload{
 						{
 							Kind: "Deployment",
 							Name: "hubble-relay",
@@ -424,8 +425,8 @@ func TestWorkloadFilterInclude(t *testing.T) {
 						},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Source: &flowpb.Endpoint{Workloads: []*flowpb.Workload{
+				ev: &v1.Event{Event: &ir.Flow{
+					Source: ir.Endpoint{Workloads: []ir.Workload{
 						{
 							Kind: "Deployment",
 							Name: "hubble-relay",
@@ -448,8 +449,8 @@ func TestWorkloadFilterInclude(t *testing.T) {
 						},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Destination: &flowpb.Endpoint{Workloads: []*flowpb.Workload{
+				ev: &v1.Event{Event: &ir.Flow{
+					Destination: ir.Endpoint{Workloads: []ir.Workload{
 						{
 							Kind: "Deployment",
 							Name: "hubble-relay",
@@ -472,8 +473,8 @@ func TestWorkloadFilterInclude(t *testing.T) {
 						},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Source: &flowpb.Endpoint{Workloads: []*flowpb.Workload{
+				ev: &v1.Event{Event: &ir.Flow{
+					Source: ir.Endpoint{Workloads: []ir.Workload{
 						{
 							Kind: "Deployment",
 							Name: "hubble-relay",
@@ -496,8 +497,8 @@ func TestWorkloadFilterInclude(t *testing.T) {
 						},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Destination: &flowpb.Endpoint{Workloads: []*flowpb.Workload{
+				ev: &v1.Event{Event: &ir.Flow{
+					Destination: ir.Endpoint{Workloads: []ir.Workload{
 						{
 							Kind: "Deployment",
 							Name: "hubble-relay",
@@ -542,8 +543,8 @@ func TestWorkloadFilterExclude(t *testing.T) {
 						},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Source: &flowpb.Endpoint{Workloads: []*flowpb.Workload{}},
+				ev: &v1.Event{Event: &ir.Flow{
+					Source: ir.Endpoint{Workloads: []ir.Workload{}},
 				}},
 			},
 			want: true,
@@ -561,8 +562,8 @@ func TestWorkloadFilterExclude(t *testing.T) {
 						},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Destination: &flowpb.Endpoint{Workloads: []*flowpb.Workload{}},
+				ev: &v1.Event{Event: &ir.Flow{
+					Destination: ir.Endpoint{Workloads: []ir.Workload{}},
 				}},
 			},
 			want: true,
@@ -580,8 +581,8 @@ func TestWorkloadFilterExclude(t *testing.T) {
 						},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Source: &flowpb.Endpoint{Workloads: []*flowpb.Workload{
+				ev: &v1.Event{Event: &ir.Flow{
+					Source: ir.Endpoint{Workloads: []ir.Workload{
 						{
 							Kind: "Deployment",
 							Name: "hubble-relay",
@@ -604,8 +605,8 @@ func TestWorkloadFilterExclude(t *testing.T) {
 						},
 					},
 				},
-				ev: &v1.Event{Event: &flowpb.Flow{
-					Destination: &flowpb.Endpoint{Workloads: []*flowpb.Workload{
+				ev: &v1.Event{Event: &ir.Flow{
+					Destination: ir.Endpoint{Workloads: []ir.Workload{
 						{
 							Kind: "Deployment",
 							Name: "hubble-relay",

--- a/pkg/hubble/ir/aggregate.go
+++ b/pkg/hubble/ir/aggregate.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import (
+	flowpb "github.com/cilium/cilium/api/v1/flow"
+)
+
+// Aggregate tracks aggregate flow information.
+type Aggregate struct {
+	IngressFlowCount          uint32 `json:"ingress_flow_count,omitempty"`
+	EgressFlowCount           uint32 `json:"egress_flow_count,omitempty"`
+	UnknownDirectionFlowCount uint32 `json:"unknown_direction_flow_count,omitempty"`
+}
+
+// IsEmpty returns true if target has no data.
+func (a Aggregate) IsEmpty() bool {
+	return a.IngressFlowCount == 0 && a.EgressFlowCount == 0 && a.UnknownDirectionFlowCount == 0
+}
+
+func (a Aggregate) toProto() *flowpb.Aggregate {
+	if a.IsEmpty() {
+		return nil
+	}
+	return &flowpb.Aggregate{
+		IngressFlowCount:          a.IngressFlowCount,
+		EgressFlowCount:           a.EgressFlowCount,
+		UnknownDirectionFlowCount: a.UnknownDirectionFlowCount,
+	}
+}
+
+// ProtoToAggregate converts protobuf.Aggregate to an IR aggregate.
+func ProtoToAggregate(a *flowpb.Aggregate) Aggregate {
+	if a == nil {
+		return Aggregate{}
+	}
+
+	return Aggregate{
+		IngressFlowCount:          a.GetIngressFlowCount(),
+		EgressFlowCount:           a.GetEgressFlowCount(),
+		UnknownDirectionFlowCount: a.GetUnknownDirectionFlowCount(),
+	}
+}

--- a/pkg/hubble/ir/aggregate.go
+++ b/pkg/hubble/ir/aggregate.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import (
+	flowpb "github.com/cilium/cilium/api/v1/flow"
+)
+
+// Aggregate tracks aggregate flow information.
+type Aggregate struct {
+	IngressFlowCount          uint32 `json:"ingress_flow_count,omitempty"`
+	EgressFlowCount           uint32 `json:"egress_flow_count,omitempty"`
+	UnknownDirectionFlowCount uint32 `json:"unknown_direction_flow_count,omitempty"`
+}
+
+func (a Aggregate) IsEmpty() bool {
+	return a.IngressFlowCount == 0 && a.EgressFlowCount == 0
+}
+
+func (a Aggregate) toProto() *flowpb.Aggregate {
+	if a.IsEmpty() {
+		return nil
+	}
+	return &flowpb.Aggregate{
+		IngressFlowCount:          a.IngressFlowCount,
+		EgressFlowCount:           a.EgressFlowCount,
+		UnknownDirectionFlowCount: a.UnknownDirectionFlowCount,
+	}
+}
+
+// ProtoToAggregate converts protobuf.Aggregate to an IR aggregate.
+func ProtoToAggregate(a *flowpb.Aggregate) Aggregate {
+	if a == nil {
+		return Aggregate{}
+	}
+
+	return Aggregate{
+		IngressFlowCount:          a.GetIngressFlowCount(),
+		EgressFlowCount:           a.GetEgressFlowCount(),
+		UnknownDirectionFlowCount: a.GetUnknownDirectionFlowCount(),
+	}
+}

--- a/pkg/hubble/ir/aggregate_test.go
+++ b/pkg/hubble/ir/aggregate_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/api/v1/flow"
+)
+
+func TestIsEmpty(t *testing.T) {
+	uu := map[string]struct {
+		in Emitter
+		e  bool
+	}{
+		"empty": {
+			e: true,
+		},
+
+		"partial": {
+			in: Emitter{
+				Version: "emitter-version",
+			},
+		},
+
+		"full": {
+			in: Emitter{
+				Name:    "emitter-name",
+				Version: "emitter-version",
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.IsEmpty())
+		})
+	}
+}
+
+func TestAggregate_toProto(t *testing.T) {
+	uu := map[string]struct {
+		ag Aggregate
+		e  *flow.Aggregate
+	}{
+		"empty": {},
+
+		"partial": {
+			ag: Aggregate{
+				IngressFlowCount: 1,
+				EgressFlowCount:  2,
+			},
+			e: &flow.Aggregate{
+				IngressFlowCount: 1,
+				EgressFlowCount:  2,
+			},
+		},
+
+		"full": {
+			ag: Aggregate{
+				IngressFlowCount:          1,
+				EgressFlowCount:           2,
+				UnknownDirectionFlowCount: 3,
+			},
+			e: &flow.Aggregate{
+				IngressFlowCount:          1,
+				EgressFlowCount:           2,
+				UnknownDirectionFlowCount: 3,
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, u.ag.toProto())
+		})
+	}
+}
+
+func TestProtoToAggregate(t *testing.T) {
+	uu := map[string]struct {
+		in *flow.Aggregate
+		e  Aggregate
+	}{
+		"empty": {},
+
+		"partial": {
+			in: &flow.Aggregate{
+				IngressFlowCount: 1,
+				EgressFlowCount:  2,
+			},
+			e: Aggregate{
+				IngressFlowCount: 1,
+				EgressFlowCount:  2,
+			},
+		},
+
+		"full": {
+			in: &flow.Aggregate{
+				IngressFlowCount:          1,
+				EgressFlowCount:           2,
+				UnknownDirectionFlowCount: 3,
+			},
+			e: Aggregate{
+				IngressFlowCount:          1,
+				EgressFlowCount:           2,
+				UnknownDirectionFlowCount: 3,
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, ProtoToAggregate(u.in))
+		})
+	}
+}

--- a/pkg/hubble/ir/emitter.go
+++ b/pkg/hubble/ir/emitter.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import "github.com/cilium/cilium/api/v1/flow"
+
+// Emitter tracks flow emitter information.
+type Emitter struct {
+	Name    string `json:"name,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+
+// IsEmpty returns true if target has no data.
+func (e Emitter) IsEmpty() bool {
+	return e.Name == "" && e.Version == ""
+}
+
+func (e Emitter) toProto() *flow.Emitter {
+	if e.IsEmpty() {
+		return nil
+	}
+
+	return &flow.Emitter{
+		Name:    e.Name,
+		Version: e.Version,
+	}
+}
+
+func protoToEmitter(e *flow.Emitter) Emitter {
+	if e == nil {
+		return Emitter{}
+	}
+
+	return Emitter{
+		Name:    e.Name,
+		Version: e.Version,
+	}
+}

--- a/pkg/hubble/ir/emitter_test.go
+++ b/pkg/hubble/ir/emitter_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/api/v1/flow"
+)
+
+func Test_protoToEmitter(t *testing.T) {
+	uu := map[string]struct {
+		in *flow.Emitter
+		e  Emitter
+	}{
+		"empty": {
+			in: nil,
+		},
+
+		"full": {
+			in: &flow.Emitter{
+				Name:    "emitter-name",
+				Version: "emitter-version",
+			},
+			e: Emitter{
+				Name:    "emitter-name",
+				Version: "emitter-version",
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, protoToEmitter(u.in))
+		})
+	}
+}
+
+func TestEmitter_toProto(t *testing.T) {
+	uu := map[string]struct {
+		e   Emitter
+		out *flow.Emitter
+	}{
+		"empty": {},
+
+		"full": {
+			e: Emitter{
+				Name:    "emitter-name",
+				Version: "emitter-version",
+			},
+			out: &flow.Emitter{
+				Name:    "emitter-name",
+				Version: "emitter-version",
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.out, u.e.toProto())
+		})
+	}
+}
+
+func TestEmitterIsEmpty(t *testing.T) {
+	uu := map[string]struct {
+		em Emitter
+		e  bool
+	}{
+		"empty": {
+			em: Emitter{},
+			e:  true,
+		},
+
+		"name only": {
+			em: Emitter{Name: "emitter-name"},
+			e:  false,
+		},
+
+		"version only": {
+			em: Emitter{Version: "emitter-version"},
+			e:  false,
+		},
+
+		"full": {
+			em: Emitter{Name: "emitter-name", Version: "emitter-version"},
+			e:  false,
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, u.em.IsEmpty())
+		})
+	}
+}

--- a/pkg/hubble/ir/ep.go
+++ b/pkg/hubble/ir/ep.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import (
+	"github.com/cilium/cilium/api/v1/flow"
+)
+
+// Endpoint tracks flow endpoint information.
+type Endpoint struct {
+	ClusterName string    `json:"cluster_name,omitempty"`
+	Namespace   string    `json:"namespace,omitempty"`
+	PodName     string    `json:"pod_name,omitempty"`
+	Labels      []string  `json:"labels,omitempty"`
+	Workloads   Workloads `json:"workloads,omitempty"`
+	ID          uint32    `json:"id,omitempty"`
+	Identity    uint32    `json:"identity,omitempty"`
+	PodUID      string    `json:"pod_uid,omitempty"`
+}
+
+// IsEmpty returns true if the endpoint has no information set.
+func (e Endpoint) IsEmpty() bool {
+	return e.ID == 0 && e.Identity == 0 && e.ClusterName == "" && e.Namespace == "" && e.PodName == "" && len(e.Labels) == 0 && len(e.Workloads) == 0 && e.PodUID == ""
+}
+
+// epTestMerge merges 2 endpoints
+// NOTE: This is only used for testing!
+func epTestMerge(e1, e2 Endpoint) Endpoint {
+	if e2.ID != 0 {
+		e1.ID = e2.ID
+	}
+	if e2.Identity != 0 {
+		e1.Identity = e2.Identity
+	}
+
+	if e2.ClusterName != "" {
+		e1.ClusterName = e2.ClusterName
+	}
+	if e2.Namespace != "" {
+		e1.Namespace = e2.Namespace
+	}
+	if e2.PodName != "" {
+		e1.PodName = e2.PodName
+	}
+
+	if e2.Labels != nil {
+		e1.Labels = e2.Labels
+	}
+
+	if len(e2.Workloads) > 0 {
+		e1.Workloads = e2.Workloads
+	}
+	if e2.PodUID != "" {
+		e1.PodUID = e2.PodUID
+	}
+
+	return e1
+}
+
+func (e Endpoint) toProto() *flow.Endpoint {
+	if e.IsEmpty() {
+		return nil
+	}
+
+	return &flow.Endpoint{
+		ID:          e.ID,
+		Identity:    e.Identity,
+		ClusterName: e.ClusterName,
+		Namespace:   e.Namespace,
+		PodName:     e.PodName,
+		Labels:      e.Labels,
+		Workloads:   e.Workloads.toProto(),
+		PodUid:      e.PodUID,
+	}
+}
+
+// ProtoToEp converts protobuf endpoint to its internal representation.
+func ProtoToEp(e *flow.Endpoint) Endpoint {
+	if e == nil {
+		return Endpoint{}
+	}
+
+	// This is necessary for the decoder to assign labels to the empty slice vs the nil slice.
+	var lbls []string
+	if len(e.Labels) > 0 {
+		lbls = e.Labels
+	}
+
+	return Endpoint{
+		ID:          e.ID,
+		Identity:    e.Identity,
+		ClusterName: e.ClusterName,
+		Namespace:   e.Namespace,
+		PodName:     e.PodName,
+		Labels:      lbls,
+		Workloads:   ProtoToWorkloads(e.Workloads),
+		PodUID:      e.PodUid,
+	}
+}

--- a/pkg/hubble/ir/ep.go
+++ b/pkg/hubble/ir/ep.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import "github.com/cilium/cilium/api/v1/flow"
+
+// Endpoint tracks flow endpoint information.
+type Endpoint struct {
+	ClusterName string    `json:"cluster_name,omitempty"`
+	Namespace   string    `json:"namespace,omitempty"`
+	PodName     string    `json:"pod_name,omitempty"`
+	Labels      []string  `json:"labels,omitempty"`
+	Workloads   Workloads `json:"workloads,omitempty"`
+	ID          uint32    `json:"id,omitempty"`
+	Identity    uint32    `json:"identity,omitempty"`
+}
+
+// IsEmpty returns true if the endpoint has no information set.
+func (e Endpoint) IsEmpty() bool {
+	return e.ID == 0 && e.Identity == 0 && e.ClusterName == "" && e.Namespace == "" && e.PodName == "" && len(e.Labels) == 0 && len(e.Workloads) == 0
+}
+
+// epTestMerge merges 2 endpoints
+// NOTE: This is only used for testing!
+func epTestMerge(e1, e2 Endpoint) Endpoint {
+	if e2.ID != 0 {
+		e1.ID = e2.ID
+	}
+	if e2.Identity != 0 {
+		e1.Identity = e2.Identity
+	}
+
+	if e2.ClusterName != "" {
+		e1.ClusterName = e2.ClusterName
+	}
+	if e2.Namespace != "" {
+		e1.Namespace = e2.Namespace
+	}
+	if e2.PodName != "" {
+		e1.PodName = e2.PodName
+	}
+
+	if len(e2.Labels) > 0 {
+		e1.Labels = e2.Labels
+	}
+
+	if len(e2.Workloads) > 0 {
+		e1.Workloads = e2.Workloads
+	}
+
+	return e1
+}
+
+func (e Endpoint) toProto() *flow.Endpoint {
+	if e.IsEmpty() {
+		return nil
+	}
+
+	return &flow.Endpoint{
+		ID:          e.ID,
+		Identity:    e.Identity,
+		ClusterName: e.ClusterName,
+		Namespace:   e.Namespace,
+		PodName:     e.PodName,
+		Labels:      e.Labels,
+		Workloads:   e.Workloads.toProto(),
+	}
+}
+
+// ProtoToEp converts protobuf endpoint to its internal representation.
+func ProtoToEp(e *flow.Endpoint) Endpoint {
+	if e == nil {
+		return Endpoint{}
+	}
+
+	// This is necessary for the decoder to assign labels to the empty slice vs the nil slice.
+	var lbls []string
+	if len(e.Labels) > 0 {
+		lbls = e.Labels
+	}
+
+	return Endpoint{
+		ID:          e.ID,
+		Identity:    e.Identity,
+		ClusterName: e.ClusterName,
+		Namespace:   e.Namespace,
+		PodName:     e.PodName,
+		Labels:      lbls,
+		Workloads:   ProtoToWorkloads(e.Workloads),
+	}
+}

--- a/pkg/hubble/ir/ep_test.go
+++ b/pkg/hubble/ir/ep_test.go
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/api/v1/flow"
+)
+
+func TestEndpointIsEmpty(t *testing.T) {
+	uu := map[string]struct {
+		e    Endpoint
+		want bool
+	}{
+		"empty": {
+			want: true,
+		},
+
+		"partial": {
+			e: Endpoint{
+				ID:       1,
+				Identity: 100,
+			},
+		},
+
+		"full": {
+			e: Endpoint{
+				ID:          100,
+				Identity:    200,
+				ClusterName: "cluster",
+				Namespace:   "namespace",
+				PodName:     "pod",
+				Labels:      []string{"label1", "label2"},
+				Workloads:   []Workload{{Name: "workload1", Kind: "kind1"}},
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.want, u.e.IsEmpty())
+		})
+	}
+}
+
+func TestEndpoint_merge(t *testing.T) {
+	uu := map[string]struct {
+		e1, e2, want Endpoint
+	}{
+		"empty": {},
+
+		"blank-src": {
+			e2: Endpoint{
+				ID:       1,
+				Identity: 100,
+			},
+			want: Endpoint{
+				ID:       1,
+				Identity: 100,
+			},
+		},
+
+		"blank-dst": {
+			e1: Endpoint{
+				ID:       1,
+				Identity: 100,
+			},
+			want: Endpoint{
+				ID:       1,
+				Identity: 100,
+			},
+		},
+
+		"full": {
+			e1: Endpoint{
+				ID:          100,
+				Identity:    200,
+				ClusterName: "cl1",
+				Namespace:   "ns1",
+				PodName:     "p1",
+				Labels:      []string{"l1", "l2"},
+				Workloads:   []Workload{{Name: "wk1", Kind: "po"}},
+			},
+			e2: Endpoint{
+				ID:          300,
+				Identity:    400,
+				ClusterName: "cl2",
+				Namespace:   "ns2",
+				PodName:     "p2",
+				Labels:      []string{"l1-1", "l1-2"},
+				Workloads:   []Workload{{Name: "wk1-2", Kind: "po"}},
+			},
+			want: Endpoint{
+				ID:          300,
+				Identity:    400,
+				ClusterName: "cl2",
+				Namespace:   "ns2",
+				PodName:     "p2",
+				Labels:      []string{"l1-1", "l1-2"},
+				Workloads:   []Workload{{Name: "wk1-2", Kind: "po"}},
+			},
+		},
+
+		"partial": {
+			e1: Endpoint{
+				ID:          100,
+				Identity:    200,
+				ClusterName: "cl1",
+				Namespace:   "ns1",
+				PodName:     "p1",
+				Labels:      []string{"l1", "l2"},
+				Workloads:   []Workload{{Name: "wk1", Kind: "po"}},
+			},
+			e2: Endpoint{
+				Labels:    []string{"l1-1", "l1-2"},
+				Workloads: []Workload{{Name: "wk1-2", Kind: "po"}},
+			},
+			want: Endpoint{
+				ID:          100,
+				Identity:    200,
+				ClusterName: "cl1",
+				Namespace:   "ns1",
+				PodName:     "p1",
+				Labels:      []string{"l1-1", "l1-2"},
+				Workloads:   []Workload{{Name: "wk1-2", Kind: "po"}},
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.want, epTestMerge(u.e1, u.e2))
+		})
+	}
+}
+
+func TestProtoToEP(t *testing.T) {
+	uu := map[string]struct {
+		in   *flow.Endpoint
+		want Endpoint
+	}{
+		"nil": {
+			in:   nil,
+			want: Endpoint{},
+		},
+
+		"empty": {
+			in:   &flow.Endpoint{},
+			want: Endpoint{},
+		},
+
+		"full": {
+			in: &flow.Endpoint{
+				ID:          100,
+				Identity:    200,
+				ClusterName: "cluster",
+				Namespace:   "namespace",
+				PodName:     "pod",
+				Labels:      []string{"label1", "label2"},
+				Workloads: []*flow.Workload{
+					{Name: "workload1", Kind: "kind1"},
+				},
+			},
+			want: Endpoint{
+				ID:          100,
+				Identity:    200,
+				ClusterName: "cluster",
+				Namespace:   "namespace",
+				PodName:     "pod",
+				Labels:      []string{"label1", "label2"},
+				Workloads: []Workload{
+					{Name: "workload1", Kind: "kind1"},
+				},
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.want, ProtoToEp(u.in))
+		})
+	}
+}
+
+func TestEndpoint_toProto(t *testing.T) {
+	uu := map[string]struct {
+		in   Endpoint
+		want *flow.Endpoint
+	}{
+		"empty": {
+			in:   Endpoint{},
+			want: nil,
+		},
+
+		"full": {
+			in: Endpoint{
+				ID:          100,
+				Identity:    200,
+				ClusterName: "cluster",
+				Namespace:   "namespace",
+				PodName:     "pod",
+				Labels:      []string{"label1", "label2"},
+				Workloads: []Workload{
+					{Name: "workload1", Kind: "kind1"},
+				},
+			},
+			want: &flow.Endpoint{
+				ID:          100,
+				Identity:    200,
+				ClusterName: "cluster",
+				Namespace:   "namespace",
+				PodName:     "pod",
+				Labels:      []string{"label1", "label2"},
+				Workloads: []*flow.Workload{
+					{Name: "workload1", Kind: "kind1"},
+				},
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.want, u.in.toProto())
+		})
+	}
+}

--- a/pkg/hubble/ir/ethernet.go
+++ b/pkg/hubble/ir/ethernet.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import (
+	"net"
+
+	"github.com/cilium/cilium/api/v1/flow"
+)
+
+// Ethernet tracks source/destination MAC addresses.
+type Ethernet struct {
+	Source      net.HardwareAddr `json:"source,omitempty"`
+	Destination net.HardwareAddr `json:"destination,omitempty"`
+}
+
+func (e Ethernet) toProto() *flow.Ethernet {
+	if e.IsEmpty() {
+		return nil
+	}
+
+	return &flow.Ethernet{
+		Source:      e.Source.String(),
+		Destination: e.Destination.String(),
+	}
+}
+
+func protoToEther(e *flow.Ethernet) Ethernet {
+	if e == nil {
+		return Ethernet{}
+	}
+
+	s, _ := net.ParseMAC(e.Source)
+	d, _ := net.ParseMAC(e.Destination)
+
+	return Ethernet{
+		Source:      s,
+		Destination: d,
+	}
+}
+
+// IsEmpty returns true if target has no data.
+func (e Ethernet) IsEmpty() bool {
+	return len(e.Source) == 0 && len(e.Destination) == 0
+}

--- a/pkg/hubble/ir/ethernet_test.go
+++ b/pkg/hubble/ir/ethernet_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/api/v1/flow"
+)
+
+func TestEthernet_toProto(t *testing.T) {
+	m1, _ := net.ParseMAC("00:11:22:33:44:55")
+	m2, _ := net.ParseMAC("66:77:88:99:aa:bb")
+
+	uu := map[string]struct {
+		ether Ethernet
+		out   *flow.Ethernet
+	}{
+		"empty": {
+			out: nil,
+		},
+
+		"partial": {
+			ether: Ethernet{
+				Source: m1,
+			},
+			out: &flow.Ethernet{
+				Source: "00:11:22:33:44:55",
+			},
+		},
+
+		"full": {
+			ether: Ethernet{
+				Source:      m1,
+				Destination: m2,
+			},
+			out: &flow.Ethernet{
+				Source:      "00:11:22:33:44:55",
+				Destination: "66:77:88:99:aa:bb",
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.out, u.ether.toProto())
+		})
+	}
+}
+
+func Test_protoToEther(t *testing.T) {
+	m1, _ := net.ParseMAC("00:11:22:33:44:55")
+	m2, _ := net.ParseMAC("66:77:88:99:aa:bb")
+
+	uu := map[string]struct {
+		in *flow.Ethernet
+		e  Ethernet
+	}{
+		"empty": {
+			in: nil,
+		},
+
+		"partial": {
+			in: &flow.Ethernet{
+				Source: "00:11:22:33:44:55",
+			},
+			e: Ethernet{
+				Source: m1,
+			},
+		},
+
+		"full": {
+			in: &flow.Ethernet{
+				Source:      "00:11:22:33:44:55",
+				Destination: "66:77:88:99:aa:bb",
+			},
+			e: Ethernet{
+				Source:      m1,
+				Destination: m2,
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, protoToEther(u.in))
+		})
+	}
+}
+
+func TestEthernetIsEmpty(t *testing.T) {
+	uu := map[string]struct {
+		ether Ethernet
+		e     bool
+	}{
+		"empty": {
+			e: true,
+		},
+
+		"partial": {
+			ether: Ethernet{
+				Source: net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
+			},
+		},
+
+		"full": {
+			ether: Ethernet{
+				Source:      net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
+				Destination: net.HardwareAddr{0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb},
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, u.ether.IsEmpty())
+		})
+	}
+}

--- a/pkg/hubble/ir/event_type.go
+++ b/pkg/hubble/ir/event_type.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import (
+	"github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/monitor/api"
+)
+
+// CiliumEventType tracks flow event type and subtype.
+type CiliumEventType struct {
+	Type    int32 `json:"type,omitempty"`
+	SubType int32 `json:"subType,omitempty"`
+}
+
+// IsEmpty returns true if target has no data.
+func (e CiliumEventType) IsEmpty() bool {
+	return e.Type == api.MessageTypeUnspec &&
+		e.SubType == api.MessageTypeUnspec
+}
+
+func (e CiliumEventType) toProto() *flow.CiliumEventType {
+	if e.IsEmpty() {
+		return nil
+	}
+
+	return &flow.CiliumEventType{
+		Type:    e.Type,
+		SubType: e.SubType,
+	}
+}
+
+// ProtoToEventType converts protobuf event type to its internal representation.
+func ProtoToEventType(e *flow.CiliumEventType) CiliumEventType {
+	if e == nil {
+		return CiliumEventType{}
+	}
+
+	return CiliumEventType{
+		Type:    e.Type,
+		SubType: e.SubType,
+	}
+}

--- a/pkg/hubble/ir/event_type_test.go
+++ b/pkg/hubble/ir/event_type_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/api/v1/flow"
+)
+
+func TestProtoToEventType(t *testing.T) {
+	uu := map[string]struct {
+		in *flow.CiliumEventType
+		e  CiliumEventType
+	}{
+		"empty": {
+			in: nil,
+		},
+
+		"full": {
+			in: &flow.CiliumEventType{
+				Type:    1,
+				SubType: 2,
+			},
+			e: CiliumEventType{
+				Type:    1,
+				SubType: 2,
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, ProtoToEventType(u.in))
+		})
+	}
+}
+
+func TestEventTypeIsEmpty(t *testing.T) {
+	uu := map[string]struct {
+		e    CiliumEventType
+		want bool
+	}{
+		"empty": {
+			want: true,
+		},
+
+		"partial": {
+			e: CiliumEventType{
+				Type: 1,
+			},
+		},
+
+		"full": {
+			e: CiliumEventType{
+				Type:    1,
+				SubType: 2,
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.want, u.e.IsEmpty())
+		})
+	}
+}
+
+func TestEventType_toProto(t *testing.T) {
+	uu := map[string]struct {
+		e   CiliumEventType
+		out *flow.CiliumEventType
+	}{
+		"empty": {},
+
+		"full": {
+			e: CiliumEventType{
+				Type:    1,
+				SubType: 2,
+			},
+			out: &flow.CiliumEventType{
+				Type:    1,
+				SubType: 2,
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.out, u.e.toProto())
+		})
+	}
+}

--- a/pkg/hubble/ir/file_info.go
+++ b/pkg/hubble/ir/file_info.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import "github.com/cilium/cilium/api/v1/flow"
+
+// FileInfo tracks flow file information.
+type FileInfo struct {
+	Name string `json:"name,omitempty"`
+	Line uint32 `json:"line,omitempty"`
+}
+
+// IsEmpty returns true if target has no data.
+func (f FileInfo) IsEmpty() bool {
+	return f.Name == "" && f.Line == 0
+}
+
+func (f FileInfo) toProto() *flow.FileInfo {
+	if f.IsEmpty() {
+		return nil
+	}
+
+	return &flow.FileInfo{
+		Name: f.Name,
+		Line: f.Line,
+	}
+}
+
+func protoToFileInfo(f *flow.FileInfo) FileInfo {
+	if f == nil {
+		return FileInfo{}
+	}
+
+	return FileInfo{
+		Name: f.Name,
+		Line: f.Line,
+	}
+}

--- a/pkg/hubble/ir/file_info_test.go
+++ b/pkg/hubble/ir/file_info_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/api/v1/flow"
+)
+
+func Test_protoToFileInfo(t *testing.T) {
+	uu := map[string]struct {
+		in *flow.FileInfo
+		e  FileInfo
+	}{
+		"empty": {},
+
+		"full": {
+			in: &flow.FileInfo{
+				Name: "f1",
+				Line: 42,
+			},
+			e: FileInfo{
+				Name: "f1",
+				Line: 42,
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, protoToFileInfo(u.in))
+		})
+	}
+}
+
+func TestFileInfoIsEmpty(t *testing.T) {
+	uu := map[string]struct {
+		f    FileInfo
+		want bool
+	}{
+		"empty": {
+			want: true,
+		},
+
+		"partial": {
+			f: FileInfo{
+				Name: "f1",
+			},
+		},
+
+		"full": {
+			f: FileInfo{
+				Name: "f1",
+				Line: 42,
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.want, u.f.IsEmpty())
+		})
+	}
+}
+
+func TestFileInfo_toProto(t *testing.T) {
+	uu := map[string]struct {
+		f   FileInfo
+		out *flow.FileInfo
+	}{
+		"empty": {},
+
+		"full": {
+			f: FileInfo{
+				Name: "f1",
+				Line: 42,
+			},
+			out: &flow.FileInfo{
+				Name: "f1",
+				Line: 42,
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.out, u.f.toProto())
+		})
+	}
+}

--- a/pkg/hubble/ir/flow.go
+++ b/pkg/hubble/ir/flow.go
@@ -1,0 +1,407 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import (
+	"github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/time"
+
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// Flow tracks an internal representation of a flow.
+type Flow struct {
+	L7                    Layer7                      `json:"l7,omitempty"`
+	L4                    Layer4                      `json:"l4,omitempty"`
+	Source                Endpoint                    `json:"source,omitempty"`
+	Destination           Endpoint                    `json:"destination,omitempty"`
+	Emitter               Emitter                     `json:"emitter,omitempty"`
+	Ethernet              Ethernet                    `json:"ethernet,omitempty"`
+	IP                    IP                          `json:"ip,omitempty"`
+	SourceService         Service                     `json:"source_service,omitempty"`
+	DestinationService    Service                     `json:"destination_service,omitempty"`
+	File                  FileInfo                    `json:"file,omitempty"`
+	Interface             NetworkInterface            `json:"interface,omitempty"`
+	TraceContext          TraceContext                `json:"trace_context,omitempty"`
+	Time                  time.Time                   `json:"time,omitempty"`
+	NodeLabels            []string                    `json:"node_labels,omitempty"`
+	SourceNames           []string                    `json:"source_names,omitempty"`
+	DestinationNames      []string                    `json:"destination_names,omitempty"`
+	Extensions            *anypb.Any                  `json:"extensions,omitempty"`
+	EgressAllowedBy       []Policy                    `json:"egress_allowed_by,omitempty"`
+	EgressDeniedBy        []Policy                    `json:"egress_denied_by,omitempty"`
+	IngressAllowedBy      []Policy                    `json:"ingress_allowed_by,omitempty"`
+	IngressDeniedBy       []Policy                    `json:"ingress_denied_by,omitempty"`
+	PolicyLog             []string                    `json:"policy_log,omitempty"`
+	UUID                  string                      `json:"uuid,omitempty"`
+	NodeName              string                      `json:"node_name,omitempty"`
+	Summary               string                      `json:"summary,omitempty"`
+	Tunnel                Tunnel                      `json:"tunnel,omitempty"`
+	IPTraceID             IPTraceID                   `json:"ip_trace_id,omitempty"`
+	EventType             CiliumEventType             `json:"event_type,omitempty"`
+	Aggregate             Aggregate                   `json:"aggregate,omitempty"`
+	SocketCookie          uint64                      `json:"socket_cookie,omitempty"`
+	CgroupID              uint64                      `json:"cgroup_id,omitempty"`
+	PolicyMatchType       uint32                      `json:"policy_match_type,omitempty"`
+	ProxyPort             uint32                      `json:"proxy_port,omitempty"`
+	DropReason            uint32                      `json:"drop_reason,omitempty"`
+	ExtError              int32                       `json:"ext_error,omitempty"`
+	ExtDropReasonDesc     string                      `json:"ext_drop_reason_desc,omitempty"`
+	AuthType              flow.AuthType               `json:"auth_type,omitempty"`
+	Verdict               flow.Verdict                `json:"verdict,omitempty"`
+	DropReasonDesc        flow.DropReason             `json:"drop_reason_desc,omitempty"`
+	TrafficDirection      flow.TrafficDirection       `json:"traffic_direction,omitempty"`
+	TraceObservationPoint flow.TraceObservationPoint  `json:"trace_observation_point,omitempty"`
+	TraceReason           flow.TraceReason            `json:"trace_reason,omitempty"`
+	DebugCapturePoint     flow.DebugCapturePoint      `json:"debug_capture_point,omitempty"`
+	SockXlatePoint        flow.SocketTranslationPoint `json:"sock_xlate_point,omitempty"`
+	Type                  flow.FlowType               `json:"type,omitempty"`
+	Reply                 Reply                       `json:"reply,omitempty"`
+}
+
+// Clone returns a new copy.
+func (f *Flow) Clone() Flow {
+	if f == nil {
+		return Flow{}
+	}
+
+	return Flow{
+		L7:                    f.L7,
+		L4:                    f.L4,
+		Source:                f.Source,
+		Destination:           f.Destination,
+		Emitter:               f.Emitter,
+		Ethernet:              f.Ethernet,
+		IP:                    f.IP,
+		SourceService:         f.SourceService,
+		DestinationService:    f.DestinationService,
+		File:                  f.File,
+		Interface:             f.Interface,
+		TraceContext:          f.TraceContext,
+		Time:                  f.Time,
+		NodeLabels:            f.NodeLabels,
+		SourceNames:           f.SourceNames,
+		DestinationNames:      f.DestinationNames,
+		Extensions:            f.Extensions,
+		EgressAllowedBy:       f.EgressAllowedBy,
+		EgressDeniedBy:        f.EgressDeniedBy,
+		IngressAllowedBy:      f.IngressAllowedBy,
+		IngressDeniedBy:       f.IngressDeniedBy,
+		PolicyLog:             f.PolicyLog,
+		UUID:                  f.UUID,
+		NodeName:              f.NodeName,
+		Summary:               f.Summary,
+		Tunnel:                f.Tunnel,
+		IPTraceID:             f.IPTraceID,
+		EventType:             f.EventType,
+		SocketCookie:          f.SocketCookie,
+		CgroupID:              f.CgroupID,
+		PolicyMatchType:       f.PolicyMatchType,
+		ProxyPort:             f.ProxyPort,
+		DropReason:            f.DropReason,
+		ExtError:              f.ExtError,
+		ExtDropReasonDesc:     f.ExtDropReasonDesc,
+		AuthType:              f.AuthType,
+		Verdict:               f.Verdict,
+		DropReasonDesc:        f.DropReasonDesc,
+		TrafficDirection:      f.TrafficDirection,
+		TraceObservationPoint: f.TraceObservationPoint,
+		TraceReason:           f.TraceReason,
+		DebugCapturePoint:     f.DebugCapturePoint,
+		SockXlatePoint:        f.SockXlatePoint,
+		Aggregate:             f.Aggregate,
+		Type:                  f.Type,
+		Reply:                 f.Reply,
+	}
+}
+
+// ProtoToFlow converts a protobuf flow to an internal representation.
+func ProtoToFlow(fl *flow.Flow) *Flow {
+	if fl == nil {
+		return nil
+	}
+
+	f := Flow{
+		L7:                    protoToL7(fl.GetL7()),
+		L4:                    protoToL4(fl.GetL4()),
+		Source:                ProtoToEp(fl.GetSource()),
+		Destination:           ProtoToEp(fl.GetDestination()),
+		Emitter:               protoToEmitter(fl.GetEmitter()),
+		Ethernet:              protoToEther(fl.GetEthernet()),
+		SourceService:         ProtoToService(fl.GetSourceService()),
+		IP:                    protoToIP(fl.GetIP()),
+		DestinationService:    ProtoToService(fl.GetDestinationService()),
+		File:                  protoToFileInfo(fl.GetFile()),
+		Interface:             ProtoToNetworkInterface(fl.GetInterface()),
+		TraceContext:          ProtoToTraceContext(fl.GetTraceContext()),
+		NodeLabels:            fl.GetNodeLabels(),
+		SourceNames:           fl.GetSourceNames(),
+		DestinationNames:      fl.GetDestinationNames(),
+		Extensions:            fl.GetExtensions(),
+		EgressAllowedBy:       protoToPolicies(fl.GetEgressAllowedBy()),
+		EgressDeniedBy:        protoToPolicies(fl.GetEgressDeniedBy()),
+		IngressAllowedBy:      protoToPolicies(fl.GetIngressAllowedBy()),
+		IngressDeniedBy:       protoToPolicies(fl.GetIngressDeniedBy()),
+		PolicyLog:             fl.GetPolicyLog(),
+		UUID:                  fl.GetUuid(),
+		NodeName:              fl.GetNodeName(),
+		Summary:               fl.GetSummary(),
+		Tunnel:                protoToTunnel(fl.GetTunnel()),
+		IPTraceID:             ProtoToIPTraceID(fl.GetIpTraceId()),
+		EventType:             ProtoToEventType(fl.GetEventType()),
+		Aggregate:             ProtoToAggregate(fl.GetAggregate()),
+		SocketCookie:          fl.GetSocketCookie(),
+		CgroupID:              fl.GetCgroupId(),
+		PolicyMatchType:       fl.GetPolicyMatchType(),
+		ProxyPort:             fl.GetProxyPort(),
+		DropReason:            fl.GetDropReason(),
+		ExtError:              fl.GetExtError(),
+		ExtDropReasonDesc:     fl.GetExtDropReasonDesc(),
+		AuthType:              fl.GetAuthType(),
+		Verdict:               fl.GetVerdict(),
+		DropReasonDesc:        fl.GetDropReasonDesc(),
+		TrafficDirection:      fl.GetTrafficDirection(),
+		TraceObservationPoint: fl.GetTraceObservationPoint(),
+		TraceReason:           fl.GetTraceReason(),
+		DebugCapturePoint:     fl.GetDebugCapturePoint(),
+		SockXlatePoint:        fl.GetSockXlatePoint(),
+		Type:                  fl.GetType(),
+		Reply:                 ProtoToReply(fl.IsReply),
+	}
+
+	if ti := fl.Time; ti != nil {
+		t := ti.AsTime()
+		if !t.IsZero() {
+			f.Time = t
+		}
+	}
+
+	return &f
+}
+
+// ToProto converts a flow internal representation to a protobuf flow.
+func (f *Flow) ToProto() *flow.Flow {
+	fl := flow.Flow{
+		L7:                    f.L7.toProto(),
+		L4:                    f.L4.toProto(),
+		Source:                f.Source.toProto(),
+		Destination:           f.Destination.toProto(),
+		Emitter:               f.Emitter.toProto(),
+		Ethernet:              f.Ethernet.toProto(),
+		IP:                    f.IP.toProto(),
+		SourceService:         f.SourceService.toProto(),
+		DestinationService:    f.DestinationService.toProto(),
+		File:                  f.File.toProto(),
+		Interface:             f.Interface.toProto(),
+		TraceContext:          f.TraceContext.toProto(),
+		NodeLabels:            f.NodeLabels,
+		SourceNames:           f.SourceNames,
+		DestinationNames:      f.DestinationNames,
+		Extensions:            f.Extensions,
+		EgressAllowedBy:       policiesToProto(f.EgressAllowedBy),
+		EgressDeniedBy:        policiesToProto(f.EgressDeniedBy),
+		IngressAllowedBy:      policiesToProto(f.IngressAllowedBy),
+		IngressDeniedBy:       policiesToProto(f.IngressDeniedBy),
+		PolicyLog:             f.PolicyLog,
+		NodeName:              f.NodeName,
+		Summary:               f.Summary,
+		Tunnel:                f.Tunnel.toProto(),
+		IpTraceId:             f.IPTraceID.toProto(),
+		EventType:             f.EventType.toProto(),
+		Aggregate:             f.Aggregate.toProto(),
+		SocketCookie:          f.SocketCookie,
+		CgroupId:              f.CgroupID,
+		PolicyMatchType:       f.PolicyMatchType,
+		ProxyPort:             f.ProxyPort,
+		DropReason:            f.DropReason,
+		AuthType:              f.AuthType,
+		Verdict:               f.Verdict,
+		DropReasonDesc:        f.DropReasonDesc,
+		ExtError:              f.ExtError,
+		ExtDropReasonDesc:     f.ExtDropReasonDesc,
+		TrafficDirection:      f.TrafficDirection,
+		TraceObservationPoint: f.TraceObservationPoint,
+		TraceReason:           f.TraceReason,
+		DebugCapturePoint:     f.DebugCapturePoint,
+		SockXlatePoint:        f.SockXlatePoint,
+		Type:                  f.Type,
+		IsReply:               f.Reply.toProto(),
+		Reply:                 f.Reply.ToBool(),
+	}
+
+	if !f.Time.IsZero() {
+		fl.Time = timestamppb.New(f.Time)
+	}
+
+	return &fl
+}
+
+// IsReply returns true if the flow is a reply.
+func (f *Flow) IsReply() bool {
+	if f != nil {
+		return f.Reply == ReplyYes
+	}
+
+	return false
+}
+
+// TestMerge merges two flows.
+// NOTE: Do not use!! This is for testing purposes only.
+func TestMerge(f1, f2 *Flow) *Flow {
+	if f1 == nil {
+		return f2
+	}
+	if f2 == nil {
+		return f1
+	}
+
+	if !f2.L7.IsEmpty() {
+		f1.L7 = f2.L7
+	}
+	if !f2.L4.IsEmpty() {
+		f1.L4 = f2.L4
+	}
+
+	if !f2.Source.IsEmpty() {
+		f1.Source = epTestMerge(f1.Source, f2.Source)
+	}
+	if !f2.Destination.IsEmpty() {
+		f1.Destination = epTestMerge(f1.Destination, f2.Destination)
+	}
+
+	if !f2.Emitter.IsEmpty() {
+		f1.Emitter = f2.Emitter
+	}
+
+	if !f2.Ethernet.IsEmpty() {
+		f1.Ethernet = f2.Ethernet
+	}
+
+	f1.IP = ipTestMerge(f1.IP, f2.IP)
+
+	if !f2.SourceService.IsEmpty() {
+		f1.SourceService = f2.SourceService
+	}
+	if !f2.DestinationService.IsEmpty() {
+		f1.DestinationService = f2.DestinationService
+	}
+
+	if !f2.File.IsEmpty() {
+		f1.File = f2.File
+	}
+
+	if !f2.Interface.IsEmpty() {
+		f1.Interface = f2.Interface
+	}
+
+	if !f2.TraceContext.IsEmpty() {
+		f1.TraceContext = f2.TraceContext
+	}
+
+	f1.Time = f2.Time
+
+	if len(f2.NodeLabels) > 0 {
+		f1.NodeLabels = f2.NodeLabels
+	}
+
+	if f2.SourceNames != nil {
+		f1.SourceNames = f2.SourceNames
+	}
+	if f2.DestinationNames != nil {
+		f1.DestinationNames = f2.DestinationNames
+	}
+
+	if f2.Extensions != nil {
+		f1.Extensions = f2.Extensions
+	}
+
+	if len(f2.EgressAllowedBy) > 0 {
+		f1.EgressAllowedBy = f2.EgressAllowedBy
+	}
+	if len(f2.EgressDeniedBy) > 0 {
+		f1.EgressDeniedBy = f2.EgressDeniedBy
+	}
+	if len(f2.IngressAllowedBy) > 0 {
+		f1.IngressAllowedBy = f2.IngressAllowedBy
+	}
+	if len(f2.IngressDeniedBy) > 0 {
+		f1.IngressDeniedBy = f2.IngressDeniedBy
+	}
+
+	if len(f2.PolicyLog) > 0 {
+		f1.PolicyLog = f2.PolicyLog
+	}
+
+	f1.UUID = f2.UUID
+
+	if f2.NodeName != "" {
+		f1.NodeName = f2.NodeName
+	}
+
+	if f2.Summary != "" {
+		f1.Summary = f2.Summary
+	}
+
+	if !f2.Tunnel.IsEmpty() {
+		f1.Tunnel = f2.Tunnel
+	}
+
+	f1.IPTraceID = f2.IPTraceID
+
+	if !f2.EventType.IsEmpty() {
+		f1.EventType = f2.EventType
+		f1.EventType.SubType = f2.EventType.SubType
+	}
+
+	f1.Aggregate = f2.Aggregate
+	f1.SocketCookie = f2.SocketCookie
+	f1.CgroupID = f2.CgroupID
+	f1.PolicyMatchType = f2.PolicyMatchType
+	f1.ProxyPort = f2.ProxyPort
+	f1.DropReason = f2.DropReason
+	f1.ExtError = f2.ExtError
+	f1.ExtDropReasonDesc = f2.ExtDropReasonDesc
+	f1.AuthType = f2.AuthType
+	f1.Verdict = f2.Verdict
+	f1.DropReasonDesc = f2.DropReasonDesc
+	f1.TrafficDirection = f2.TrafficDirection
+
+	if f2.TraceObservationPoint != flow.TraceObservationPoint_UNKNOWN_POINT {
+		f1.TraceObservationPoint = f2.TraceObservationPoint
+	}
+
+	f1.TraceReason = f2.TraceReason
+	f1.DebugCapturePoint = f2.DebugCapturePoint
+
+	if f2.SockXlatePoint != flow.SocketTranslationPoint_SOCK_XLATE_POINT_UNKNOWN {
+		f1.SockXlatePoint = f2.SockXlatePoint
+	}
+
+	if f2.Type != flow.FlowType_UNKNOWN_TYPE {
+		f1.Type = f2.Type
+	}
+
+	if f2.Reply != ReplyUnknown {
+		f1.Reply = f2.Reply
+	}
+
+	return f1
+}
+
+func (f *Flow) GetEgressAllowedBy() []Policy {
+	return f.EgressAllowedBy
+}
+
+func (f *Flow) GetEgressDeniedBy() []Policy {
+	return f.EgressDeniedBy
+}
+
+func (f *Flow) GetIngressAllowedBy() []Policy {
+	return f.IngressAllowedBy
+}
+
+func (f *Flow) GetIngressDeniedBy() []Policy {
+	return f.IngressDeniedBy
+}

--- a/pkg/hubble/ir/flow.go
+++ b/pkg/hubble/ir/flow.go
@@ -1,0 +1,380 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import (
+	"github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/time"
+
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// Flow tracks an internal representation of a flow.
+type Flow struct {
+	L7                    Layer7                      `json:"l7,omitempty"`
+	L4                    Layer4                      `json:"l4,omitempty"`
+	Source                Endpoint                    `json:"source,omitempty"`
+	Destination           Endpoint                    `json:"destination,omitempty"`
+	Emitter               Emitter                     `json:"emitter,omitempty"`
+	Ethernet              Ethernet                    `json:"ethernet,omitempty"`
+	IP                    IP                          `json:"ip,omitempty"`
+	SourceService         Service                     `json:"source_service,omitempty"`
+	DestinationService    Service                     `json:"destination_service,omitempty"`
+	File                  FileInfo                    `json:"file,omitempty"`
+	Interface             NetworkInterface            `json:"interface,omitempty"`
+	TraceContext          TraceContext                `json:"trace_context,omitempty"`
+	Time                  time.Time                   `json:"time,omitempty"`
+	NodeLabels            []string                    `json:"node_labels,omitempty"`
+	SourceNames           []string                    `json:"source_names,omitempty"`
+	DestinationNames      []string                    `json:"destination_names,omitempty"`
+	Extensions            *anypb.Any                  `json:"extensions,omitempty"`
+	EgressAllowedBy       []Policy                    `json:"egress_allowed_by,omitempty"`
+	EgressDeniedBy        []Policy                    `json:"egress_denied_by,omitempty"`
+	IngressAllowedBy      []Policy                    `json:"ingress_allowed_by,omitempty"`
+	IngressDeniedBy       []Policy                    `json:"ingress_denied_by,omitempty"`
+	PolicyLog             []string                    `json:"policy_log,omitempty"`
+	UUID                  string                      `json:"uuid,omitempty"`
+	NodeName              string                      `json:"node_name,omitempty"`
+	Summary               string                      `json:"summary,omitempty"`
+	Tunnel                Tunnel                      `json:"tunnel,omitempty"`
+	IPTraceID             IPTraceID                   `json:"ip_trace_id,omitempty"`
+	EventType             CiliumEventType             `json:"event_type,omitempty"`
+	Aggregate             Aggregate                   `json:"aggregate,omitempty"`
+	SocketCookie          uint64                      `json:"socket_cookie,omitempty"`
+	CgroupID              uint64                      `json:"cgroup_id,omitempty"`
+	PolicyMatchType       uint32                      `json:"policy_match_type,omitempty"`
+	ProxyPort             uint32                      `json:"proxy_port,omitempty"`
+	DropReason            uint32                      `json:"drop_reason,omitempty"`
+	AuthType              flow.AuthType               `json:"auth_type,omitempty"`
+	Verdict               flow.Verdict                `json:"verdict,omitempty"`
+	DropReasonDesc        flow.DropReason             `json:"drop_reason_desc,omitempty"`
+	TrafficDirection      flow.TrafficDirection       `json:"traffic_direction,omitempty"`
+	TraceObservationPoint flow.TraceObservationPoint  `json:"trace_observation_point,omitempty"`
+	TraceReason           flow.TraceReason            `json:"trace_reason,omitempty"`
+	DebugCapturePoint     flow.DebugCapturePoint      `json:"debug_capture_point,omitempty"`
+	SockXlatePoint        flow.SocketTranslationPoint `json:"sock_xlate_point,omitempty"`
+	Type                  flow.FlowType               `json:"type,omitempty"`
+	Reply                 Reply                       `json:"reply,omitempty"`
+}
+
+// Clone returns a new copy.
+func (f *Flow) Clone() Flow {
+	if f == nil {
+		return Flow{}
+	}
+
+	return Flow{
+		L7:                    f.L7,
+		L4:                    f.L4,
+		Source:                f.Source,
+		Destination:           f.Destination,
+		Emitter:               f.Emitter,
+		Ethernet:              f.Ethernet,
+		IP:                    f.IP,
+		SourceService:         f.SourceService,
+		DestinationService:    f.DestinationService,
+		File:                  f.File,
+		Interface:             f.Interface,
+		TraceContext:          f.TraceContext,
+		Time:                  f.Time,
+		NodeLabels:            f.NodeLabels,
+		SourceNames:           f.SourceNames,
+		DestinationNames:      f.DestinationNames,
+		Extensions:            f.Extensions,
+		EgressAllowedBy:       f.EgressAllowedBy,
+		EgressDeniedBy:        f.EgressDeniedBy,
+		IngressAllowedBy:      f.IngressAllowedBy,
+		IngressDeniedBy:       f.IngressDeniedBy,
+		PolicyLog:             f.PolicyLog,
+		UUID:                  f.UUID,
+		NodeName:              f.NodeName,
+		Summary:               f.Summary,
+		Tunnel:                f.Tunnel,
+		IPTraceID:             f.IPTraceID,
+		EventType:             f.EventType,
+		SocketCookie:          f.SocketCookie,
+		CgroupID:              f.CgroupID,
+		PolicyMatchType:       f.PolicyMatchType,
+		ProxyPort:             f.ProxyPort,
+		DropReason:            f.DropReason,
+		AuthType:              f.AuthType,
+		Verdict:               f.Verdict,
+		DropReasonDesc:        f.DropReasonDesc,
+		TrafficDirection:      f.TrafficDirection,
+		TraceObservationPoint: f.TraceObservationPoint,
+		TraceReason:           f.TraceReason,
+		DebugCapturePoint:     f.DebugCapturePoint,
+		SockXlatePoint:        f.SockXlatePoint,
+		Aggregate:             f.Aggregate,
+		Type:                  f.Type,
+		Reply:                 f.Reply,
+	}
+}
+
+// ProtoToFlow converts a protobuf flow to an internal representation.
+func ProtoToFlow(fl *flow.Flow) *Flow {
+	if fl == nil {
+		return nil
+	}
+
+	f := Flow{
+		L7:                    protoToL7(fl.GetL7()),
+		L4:                    protoToL4(fl.GetL4()),
+		Source:                ProtoToEp(fl.GetSource()),
+		Destination:           ProtoToEp(fl.GetDestination()),
+		Emitter:               protoToEmitter(fl.GetEmitter()),
+		Ethernet:              protoToEther(fl.GetEthernet()),
+		SourceService:         ProtoToService(fl.GetSourceService()),
+		IP:                    protoToIP(fl.GetIP()),
+		DestinationService:    ProtoToService(fl.GetDestinationService()),
+		File:                  protoToFileInfo(fl.GetFile()),
+		Interface:             ProtoToNetworkInterface(fl.GetInterface()),
+		TraceContext:          ProtoToTraceContext(fl.GetTraceContext()),
+		NodeLabels:            fl.GetNodeLabels(),
+		SourceNames:           fl.GetSourceNames(),
+		DestinationNames:      fl.GetDestinationNames(),
+		Extensions:            fl.GetExtensions(),
+		EgressAllowedBy:       protoToPolicies(fl.GetEgressAllowedBy()),
+		EgressDeniedBy:        protoToPolicies(fl.GetEgressDeniedBy()),
+		IngressAllowedBy:      protoToPolicies(fl.GetIngressAllowedBy()),
+		IngressDeniedBy:       protoToPolicies(fl.GetIngressDeniedBy()),
+		PolicyLog:             fl.GetPolicyLog(),
+		UUID:                  fl.GetUuid(),
+		NodeName:              fl.GetNodeName(),
+		Summary:               fl.GetSummary(),
+		Tunnel:                protoToTunnel(fl.GetTunnel()),
+		IPTraceID:             ProtoToIPTraceID(fl.GetIpTraceId()),
+		EventType:             ProtoToEventType(fl.GetEventType()),
+		Aggregate:             ProtoToAggregate(fl.GetAggregate()),
+		SocketCookie:          fl.GetSocketCookie(),
+		CgroupID:              fl.GetCgroupId(),
+		PolicyMatchType:       fl.GetPolicyMatchType(),
+		ProxyPort:             fl.GetProxyPort(),
+		DropReason:            fl.GetDropReason(),
+		AuthType:              fl.GetAuthType(),
+		Verdict:               fl.GetVerdict(),
+		DropReasonDesc:        fl.GetDropReasonDesc(),
+		TrafficDirection:      fl.GetTrafficDirection(),
+		TraceObservationPoint: fl.GetTraceObservationPoint(),
+		TraceReason:           fl.GetTraceReason(),
+		DebugCapturePoint:     fl.GetDebugCapturePoint(),
+		SockXlatePoint:        fl.GetSockXlatePoint(),
+		Type:                  fl.GetType(),
+		Reply:                 ProtoToReply(fl.IsReply),
+	}
+
+	if ti := fl.Time; ti != nil {
+		t := ti.AsTime()
+		if !t.IsZero() {
+			f.Time = t
+		}
+	}
+
+	return &f
+}
+
+// ToProto converts a flow internal representation to a protobuf flow.
+func (f *Flow) ToProto() *flow.Flow {
+	fl := flow.Flow{
+		L7:                    f.L7.toProto(),
+		L4:                    f.L4.toProto(),
+		Source:                f.Source.toProto(),
+		Destination:           f.Destination.toProto(),
+		Emitter:               f.Emitter.toProto(),
+		Ethernet:              f.Ethernet.toProto(),
+		IP:                    f.IP.toProto(),
+		SourceService:         f.SourceService.toProto(),
+		DestinationService:    f.DestinationService.toProto(),
+		File:                  f.File.toProto(),
+		Interface:             f.Interface.toProto(),
+		TraceContext:          f.TraceContext.toProto(),
+		NodeLabels:            f.NodeLabels,
+		SourceNames:           f.SourceNames,
+		DestinationNames:      f.DestinationNames,
+		Extensions:            f.Extensions,
+		EgressAllowedBy:       policiesToProto(f.EgressAllowedBy),
+		EgressDeniedBy:        policiesToProto(f.EgressDeniedBy),
+		IngressAllowedBy:      policiesToProto(f.IngressAllowedBy),
+		IngressDeniedBy:       policiesToProto(f.IngressDeniedBy),
+		PolicyLog:             f.PolicyLog,
+		NodeName:              f.NodeName,
+		Summary:               f.Summary,
+		Tunnel:                f.Tunnel.toProto(),
+		IpTraceId:             f.IPTraceID.toProto(),
+		EventType:             f.EventType.toProto(),
+		Aggregate:             f.Aggregate.toProto(),
+		SocketCookie:          f.SocketCookie,
+		CgroupId:              f.CgroupID,
+		PolicyMatchType:       f.PolicyMatchType,
+		ProxyPort:             f.ProxyPort,
+		DropReason:            f.DropReason,
+		AuthType:              f.AuthType,
+		Verdict:               f.Verdict,
+		DropReasonDesc:        f.DropReasonDesc,
+		TrafficDirection:      f.TrafficDirection,
+		TraceObservationPoint: f.TraceObservationPoint,
+		TraceReason:           f.TraceReason,
+		DebugCapturePoint:     f.DebugCapturePoint,
+		SockXlatePoint:        f.SockXlatePoint,
+		Type:                  f.Type,
+		IsReply:               f.Reply.toProto(),
+	}
+
+	if !f.Time.IsZero() {
+		fl.Time = timestamppb.New(f.Time)
+	}
+
+	return &fl
+}
+
+// IsReply returns true if the flow is a reply.
+func (f *Flow) IsReply() bool {
+	if f != nil {
+		return f.Reply == ReplyYes
+	}
+
+	return false
+}
+
+// TestMerge merges two flows.
+// NOTE: Do not use!! This is for testing purposes only.
+func TestMerge(f1, f2 *Flow) *Flow {
+	if f1 == nil {
+		return f2
+	}
+	if f2 == nil {
+		return f1
+	}
+
+	if !f2.L7.IsEmpty() {
+		f1.L7 = f2.L7
+	}
+	if !f2.L4.IsEmpty() {
+		f1.L4 = f2.L4
+	}
+
+	if !f2.Source.IsEmpty() {
+		f1.Source = epTestMerge(f1.Source, f2.Source)
+	}
+	if !f2.Destination.IsEmpty() {
+		f1.Destination = epTestMerge(f1.Destination, f2.Destination)
+	}
+
+	if !f2.Emitter.IsEmpty() {
+		f1.Emitter = f2.Emitter
+	}
+
+	if !f2.Ethernet.IsEmpty() {
+		f1.Ethernet = f2.Ethernet
+	}
+
+	f1.IP = ipTestMerge(f1.IP, f2.IP)
+
+	if !f2.SourceService.IsEmpty() {
+		f1.SourceService = f2.SourceService
+	}
+	if !f2.DestinationService.IsEmpty() {
+		f1.DestinationService = f2.DestinationService
+	}
+
+	if !f2.File.IsEmpty() {
+		f1.File = f2.File
+	}
+
+	if !f2.Interface.IsEmpty() {
+		f1.Interface = f2.Interface
+	}
+
+	if !f2.TraceContext.IsEmpty() {
+		f1.TraceContext = f2.TraceContext
+	}
+
+	f1.Time = f2.Time
+
+	if len(f2.NodeLabels) > 0 {
+		f1.NodeLabels = f2.NodeLabels
+	}
+
+	if f2.SourceNames != nil {
+		f1.SourceNames = f2.SourceNames
+	}
+	if f2.DestinationNames != nil {
+		f1.DestinationNames = f2.DestinationNames
+	}
+
+	if f2.Extensions != nil {
+		f1.Extensions = f2.Extensions
+	}
+
+	if len(f2.EgressAllowedBy) > 0 {
+		f1.EgressAllowedBy = f2.EgressAllowedBy
+	}
+	if len(f2.EgressDeniedBy) > 0 {
+		f1.EgressDeniedBy = f2.EgressDeniedBy
+	}
+	if len(f2.IngressAllowedBy) > 0 {
+		f1.IngressAllowedBy = f2.IngressAllowedBy
+	}
+	if len(f2.IngressDeniedBy) > 0 {
+		f1.IngressDeniedBy = f2.IngressDeniedBy
+	}
+
+	if len(f2.PolicyLog) > 0 {
+		f1.PolicyLog = f2.PolicyLog
+	}
+
+	f1.UUID = f2.UUID
+
+	if f2.NodeName != "" {
+		f1.NodeName = f2.NodeName
+	}
+
+	if f2.Summary != "" {
+		f1.Summary = f2.Summary
+	}
+
+	if !f2.Tunnel.IsEmpty() {
+		f1.Tunnel = f2.Tunnel
+	}
+
+	f1.IPTraceID = f2.IPTraceID
+
+	if !f2.EventType.IsEmpty() {
+		f1.EventType = f2.EventType
+		f1.EventType.SubType = f2.EventType.SubType
+	}
+
+	f1.Aggregate = f2.Aggregate
+	f1.SocketCookie = f2.SocketCookie
+	f1.CgroupID = f2.CgroupID
+	f1.PolicyMatchType = f2.PolicyMatchType
+	f1.ProxyPort = f2.ProxyPort
+	f1.DropReason = f2.DropReason
+	f1.AuthType = f2.AuthType
+	f1.Verdict = f2.Verdict
+	f1.DropReasonDesc = f2.DropReasonDesc
+	f1.TrafficDirection = f2.TrafficDirection
+
+	if f2.TraceObservationPoint != flow.TraceObservationPoint_UNKNOWN_POINT {
+		f1.TraceObservationPoint = f2.TraceObservationPoint
+	}
+
+	f1.TraceReason = f2.TraceReason
+	f1.DebugCapturePoint = f2.DebugCapturePoint
+
+	if f2.SockXlatePoint != flow.SocketTranslationPoint_SOCK_XLATE_POINT_UNKNOWN {
+		f1.SockXlatePoint = f2.SockXlatePoint
+	}
+
+	if f2.Type != flow.FlowType_UNKNOWN_TYPE {
+		f1.Type = f2.Type
+	}
+
+	if f2.Reply != ReplyUnknown {
+		f1.Reply = f2.Reply
+	}
+
+	return f1
+}

--- a/pkg/hubble/ir/flow_test.go
+++ b/pkg/hubble/ir/flow_test.go
@@ -1,0 +1,917 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/cilium/cilium/api/v1/flow"
+)
+
+func TestFlowClone(t *testing.T) {
+	m1, _ := net.ParseMAC("00:11:22:33:44:55")
+	m2, _ := net.ParseMAC("66:77:88:99:AA:BB")
+
+	uu := map[string]struct {
+		in *Flow
+		e  Flow
+	}{
+		"null": {
+			in: nil,
+		},
+
+		"empty": {
+			in: &Flow{},
+		},
+
+		"full": {
+			in: &Flow{
+				UUID:    "100",
+				Verdict: flow.Verdict_DROPPED,
+				Emitter: Emitter{
+					Name:    "fred",
+					Version: "1.0",
+				},
+				AuthType: flow.AuthType_DISABLED,
+				Ethernet: Ethernet{
+					Source:      m1,
+					Destination: m2,
+				},
+				IP: IP{
+					Source:      "1.1.1.1",
+					Destination: "2.2.2.2",
+					IPVersion:   flow.IPVersion_IPv4,
+				},
+				L4: Layer4{
+					TCP: TCP{
+						SourcePort:      1234,
+						DestinationPort: 80,
+					},
+				},
+				Tunnel: Tunnel{
+					Protocol: flow.Tunnel_GENEVE,
+				},
+				Source: Endpoint{
+					ID:          100,
+					Identity:    200,
+					ClusterName: "fred",
+					Namespace:   "ns-1",
+					PodName:     "p-1",
+					Labels:      []string{"a", "b"},
+					Workloads: []Workload{
+						{
+							Name: "wk-1",
+							Kind: "zorg",
+						},
+					},
+				},
+				Destination: Endpoint{
+					ID:          200,
+					Identity:    300,
+					ClusterName: "barney",
+					Namespace:   "ns-2",
+					PodName:     "p-2",
+					Labels:      []string{"x", "y"},
+					Workloads: []Workload{
+						{
+							Name: "wk-2",
+							Kind: "flint",
+						},
+					},
+				},
+			},
+			e: Flow{
+				UUID:    "100",
+				Verdict: flow.Verdict_DROPPED,
+				Emitter: Emitter{
+					Name:    "fred",
+					Version: "1.0",
+				},
+				AuthType: flow.AuthType_DISABLED,
+				Ethernet: Ethernet{
+					Source:      m1,
+					Destination: m2,
+				},
+				IP: IP{
+					Source:      "1.1.1.1",
+					Destination: "2.2.2.2",
+					IPVersion:   flow.IPVersion_IPv4,
+				},
+				L4: Layer4{
+					TCP: TCP{
+						SourcePort:      1234,
+						DestinationPort: 80,
+					},
+				},
+				Tunnel: Tunnel{
+					Protocol: flow.Tunnel_GENEVE,
+				},
+				Source: Endpoint{
+					ID:          100,
+					Identity:    200,
+					ClusterName: "fred",
+					Namespace:   "ns-1",
+					PodName:     "p-1",
+					Labels:      []string{"a", "b"},
+					Workloads: []Workload{
+						{
+							Name: "wk-1",
+							Kind: "zorg",
+						},
+					},
+				},
+				Destination: Endpoint{
+					ID:          200,
+					Identity:    300,
+					ClusterName: "barney",
+					Namespace:   "ns-2",
+					PodName:     "p-2",
+					Labels:      []string{"x", "y"},
+					Workloads: []Workload{
+						{
+							Name: "wk-2",
+							Kind: "flint",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.Clone())
+		})
+	}
+}
+
+func TestProtoToFlow(t *testing.T) {
+	m1, _ := net.ParseMAC("00:11:22:33:44:55")
+	m2, _ := net.ParseMAC("66:77:88:99:AA:BB")
+
+	tt := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	uu := map[string]struct {
+		in *flow.Flow
+		e  *Flow
+	}{
+		"null": {},
+
+		"empty": {
+			in: new(flow.Flow),
+			e:  &Flow{},
+		},
+
+		"full": {
+			in: &flow.Flow{
+				Time:    timestamppb.New(tt),
+				Uuid:    "100",
+				Verdict: flow.Verdict_DROPPED,
+				Emitter: &flow.Emitter{
+					Name:    "fred",
+					Version: "1.0",
+				},
+				AuthType: flow.AuthType_DISABLED,
+				Ethernet: &flow.Ethernet{
+					Source:      m1.String(),
+					Destination: m2.String(),
+				},
+				IP: &flow.IP{
+					Source:      "1.1.1.1",
+					Destination: "2.2.2.2",
+					IpVersion:   flow.IPVersion_IPv4,
+				},
+				L4: &flow.Layer4{
+					Protocol: &flow.Layer4_TCP{
+						TCP: &flow.TCP{
+							SourcePort:      1234,
+							DestinationPort: 80,
+						},
+					},
+				},
+				Tunnel: &flow.Tunnel{
+					Protocol: flow.Tunnel_GENEVE,
+				},
+				Source: &flow.Endpoint{
+					ID:          100,
+					Identity:    200,
+					ClusterName: "fred",
+					Namespace:   "ns-1",
+					PodName:     "p-1",
+					Labels:      []string{"a", "b"},
+					Workloads: []*flow.Workload{
+						{
+							Name: "wk-1",
+							Kind: "zorg",
+						},
+					},
+				},
+				Destination: &flow.Endpoint{
+					ID:          200,
+					Identity:    300,
+					ClusterName: "barney",
+					Namespace:   "ns-2",
+					PodName:     "p-2",
+					Labels:      []string{"x", "y"},
+					Workloads: []*flow.Workload{
+						{
+							Name: "wk-2",
+							Kind: "flint",
+						},
+					},
+				},
+			},
+			e: &Flow{
+				Time:    tt,
+				UUID:    "100",
+				Verdict: flow.Verdict_DROPPED,
+				Emitter: Emitter{
+					Name:    "fred",
+					Version: "1.0",
+				},
+				AuthType: flow.AuthType_DISABLED,
+				Ethernet: Ethernet{
+					Source:      m1,
+					Destination: m2,
+				},
+				IP: IP{
+					Source:      "1.1.1.1",
+					Destination: "2.2.2.2",
+					IPVersion:   flow.IPVersion_IPv4,
+				},
+				L4: Layer4{
+					TCP: TCP{
+						SourcePort:      1234,
+						DestinationPort: 80,
+					},
+				},
+				Tunnel: Tunnel{
+					Protocol: flow.Tunnel_GENEVE,
+				},
+				Source: Endpoint{
+					ID:          100,
+					Identity:    200,
+					ClusterName: "fred",
+					Namespace:   "ns-1",
+					PodName:     "p-1",
+					Labels:      []string{"a", "b"},
+					Workloads: []Workload{
+						{
+							Name: "wk-1",
+							Kind: "zorg",
+						},
+					},
+				},
+				Destination: Endpoint{
+					ID:          200,
+					Identity:    300,
+					ClusterName: "barney",
+					Namespace:   "ns-2",
+					PodName:     "p-2",
+					Labels:      []string{"x", "y"},
+					Workloads: []Workload{
+						{
+							Name: "wk-2",
+							Kind: "flint",
+						},
+					},
+				},
+			},
+		},
+
+		"reply": {
+			in: &flow.Flow{
+				Time:    timestamppb.New(tt),
+				Uuid:    "100",
+				Verdict: flow.Verdict_DROPPED,
+				Emitter: &flow.Emitter{
+					Name:    "fred",
+					Version: "1.0",
+				},
+				AuthType: flow.AuthType_DISABLED,
+				IsReply: &wrapperspb.BoolValue{
+					Value: true,
+				},
+				Ethernet: &flow.Ethernet{
+					Source:      m1.String(),
+					Destination: m2.String(),
+				},
+				IP: &flow.IP{
+					Source:      "1.1.1.1",
+					Destination: "2.2.2.2",
+					IpVersion:   flow.IPVersion_IPv4,
+				},
+				L4: &flow.Layer4{
+					Protocol: &flow.Layer4_TCP{
+						TCP: &flow.TCP{
+							SourcePort:      1234,
+							DestinationPort: 80,
+						},
+					},
+				},
+				Tunnel: &flow.Tunnel{
+					Protocol: flow.Tunnel_GENEVE,
+				},
+				Source: &flow.Endpoint{
+					ID:          100,
+					Identity:    200,
+					ClusterName: "fred",
+					Namespace:   "ns-1",
+					PodName:     "p-1",
+					Labels:      []string{"a", "b"},
+					Workloads: []*flow.Workload{
+						{
+							Name: "wk-1",
+							Kind: "zorg",
+						},
+					},
+				},
+				Destination: &flow.Endpoint{
+					ID:          200,
+					Identity:    300,
+					ClusterName: "barney",
+					Namespace:   "ns-2",
+					PodName:     "p-2",
+					Labels:      []string{"x", "y"},
+					Workloads: []*flow.Workload{
+						{
+							Name: "wk-2",
+							Kind: "flint",
+						},
+					},
+				},
+			},
+			e: &Flow{
+				Time:    tt,
+				UUID:    "100",
+				Verdict: flow.Verdict_DROPPED,
+				Emitter: Emitter{
+					Name:    "fred",
+					Version: "1.0",
+				},
+				Reply:    ReplyYes,
+				AuthType: flow.AuthType_DISABLED,
+				Ethernet: Ethernet{
+					Source:      m1,
+					Destination: m2,
+				},
+				IP: IP{
+					Source:      "1.1.1.1",
+					Destination: "2.2.2.2",
+					IPVersion:   flow.IPVersion_IPv4,
+				},
+				L4: Layer4{
+					TCP: TCP{
+						SourcePort:      1234,
+						DestinationPort: 80,
+					},
+				},
+				Tunnel: Tunnel{
+					Protocol: flow.Tunnel_GENEVE,
+				},
+				Source: Endpoint{
+					ID:          100,
+					Identity:    200,
+					ClusterName: "fred",
+					Namespace:   "ns-1",
+					PodName:     "p-1",
+					Labels:      []string{"a", "b"},
+					Workloads: []Workload{
+						{
+							Name: "wk-1",
+							Kind: "zorg",
+						},
+					},
+				},
+				Destination: Endpoint{
+					ID:          200,
+					Identity:    300,
+					ClusterName: "barney",
+					Namespace:   "ns-2",
+					PodName:     "p-2",
+					Labels:      []string{"x", "y"},
+					Workloads: []Workload{
+						{
+							Name: "wk-2",
+							Kind: "flint",
+						},
+					},
+				},
+			},
+		},
+
+		"no-reply": {
+			in: &flow.Flow{
+				Time:    timestamppb.New(tt),
+				Uuid:    "100",
+				Verdict: flow.Verdict_DROPPED,
+				Emitter: &flow.Emitter{
+					Name:    "fred",
+					Version: "1.0",
+				},
+				AuthType: flow.AuthType_DISABLED,
+				IsReply: &wrapperspb.BoolValue{
+					Value: false,
+				},
+				Ethernet: &flow.Ethernet{
+					Source:      m1.String(),
+					Destination: m2.String(),
+				},
+				IP: &flow.IP{
+					Source:      "1.1.1.1",
+					Destination: "2.2.2.2",
+					IpVersion:   flow.IPVersion_IPv4,
+				},
+				L4: &flow.Layer4{
+					Protocol: &flow.Layer4_TCP{
+						TCP: &flow.TCP{
+							SourcePort:      1234,
+							DestinationPort: 80,
+						},
+					},
+				},
+				Tunnel: &flow.Tunnel{
+					Protocol: flow.Tunnel_GENEVE,
+				},
+				Source: &flow.Endpoint{
+					ID:          100,
+					Identity:    200,
+					ClusterName: "fred",
+					Namespace:   "ns-1",
+					PodName:     "p-1",
+					Labels:      []string{"a", "b"},
+					Workloads: []*flow.Workload{
+						{
+							Name: "wk-1",
+							Kind: "zorg",
+						},
+					},
+				},
+				Destination: &flow.Endpoint{
+					ID:          200,
+					Identity:    300,
+					ClusterName: "barney",
+					Namespace:   "ns-2",
+					PodName:     "p-2",
+					Labels:      []string{"x", "y"},
+					Workloads: []*flow.Workload{
+						{
+							Name: "wk-2",
+							Kind: "flint",
+						},
+					},
+				},
+			},
+			e: &Flow{
+				Time:    tt,
+				UUID:    "100",
+				Verdict: flow.Verdict_DROPPED,
+				Emitter: Emitter{
+					Name:    "fred",
+					Version: "1.0",
+				},
+				Reply:    ReplyNo,
+				AuthType: flow.AuthType_DISABLED,
+				Ethernet: Ethernet{
+					Source:      m1,
+					Destination: m2,
+				},
+				IP: IP{
+					Source:      "1.1.1.1",
+					Destination: "2.2.2.2",
+					IPVersion:   flow.IPVersion_IPv4,
+				},
+				L4: Layer4{
+					TCP: TCP{
+						SourcePort:      1234,
+						DestinationPort: 80,
+					},
+				},
+				Tunnel: Tunnel{
+					Protocol: flow.Tunnel_GENEVE,
+				},
+				Source: Endpoint{
+					ID:          100,
+					Identity:    200,
+					ClusterName: "fred",
+					Namespace:   "ns-1",
+					PodName:     "p-1",
+					Labels:      []string{"a", "b"},
+					Workloads: []Workload{
+						{
+							Name: "wk-1",
+							Kind: "zorg",
+						},
+					},
+				},
+				Destination: Endpoint{
+					ID:          200,
+					Identity:    300,
+					ClusterName: "barney",
+					Namespace:   "ns-2",
+					PodName:     "p-2",
+					Labels:      []string{"x", "y"},
+					Workloads: []Workload{
+						{
+							Name: "wk-2",
+							Kind: "flint",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, ProtoToFlow(u.in))
+		})
+	}
+}
+
+func TestFlowToProto(t *testing.T) {
+	tt := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	uu := map[string]struct {
+		in Flow
+		e  *flow.Flow
+	}{
+		"src-dst": {
+			in: Flow{
+				Time: tt,
+				Source: Endpoint{
+					ID:       100,
+					Identity: 1000,
+				},
+				Destination: Endpoint{
+					ID:       200,
+					Identity: 2000,
+				},
+			},
+			e: &flow.Flow{
+				Time: timestamppb.New(tt),
+				Source: &flow.Endpoint{
+					ID:       100,
+					Identity: 1000,
+				},
+				Destination: &flow.Endpoint{
+					ID:       200,
+					Identity: 2000,
+				},
+			},
+		},
+
+		"l34-tcp": {
+			in: Flow{
+				Time: tt,
+				Source: Endpoint{
+					ID:       100,
+					Identity: 1000,
+				},
+				Destination: Endpoint{
+					ID:       200,
+					Identity: 2000,
+				},
+				L4: Layer4{
+					TCP: TCP{
+						SourcePort:      8080,
+						DestinationPort: 80,
+					},
+				},
+			},
+			e: &flow.Flow{
+				Time: timestamppb.New(tt),
+				Source: &flow.Endpoint{
+					ID:       100,
+					Identity: 1000,
+				},
+				Destination: &flow.Endpoint{
+					ID:       200,
+					Identity: 2000,
+				},
+				L4: &flow.Layer4{
+					Protocol: &flow.Layer4_TCP{
+						TCP: &flow.TCP{
+							SourcePort:      8080,
+							DestinationPort: 80,
+						},
+					},
+				},
+			},
+		},
+
+		"l34-udp": {
+			in: Flow{
+				Time: tt,
+				Source: Endpoint{
+					ID:       100,
+					Identity: 1000,
+				},
+				Destination: Endpoint{
+					ID:       200,
+					Identity: 2000,
+				},
+				L4: Layer4{
+					UDP: UDP{
+						SourcePort:      5353,
+						DestinationPort: 53,
+					},
+				},
+			},
+			e: &flow.Flow{
+				Time: timestamppb.New(tt),
+				Source: &flow.Endpoint{
+					ID:       100,
+					Identity: 1000,
+				},
+				Destination: &flow.Endpoint{
+					ID:       200,
+					Identity: 2000,
+				},
+				L4: &flow.Layer4{
+					Protocol: &flow.Layer4_UDP{
+						UDP: &flow.UDP{
+							SourcePort:      5353,
+							DestinationPort: 53,
+						},
+					},
+				},
+			},
+		},
+
+		"l34-tcp-with-flags": {
+			in: Flow{
+				Time: tt,
+				Source: Endpoint{
+					ID:       100,
+					Identity: 1000,
+				},
+				Destination: Endpoint{
+					ID:       200,
+					Identity: 2000,
+				},
+				L4: Layer4{
+					TCP: TCP{
+						SourcePort:      8080,
+						DestinationPort: 80,
+						Flags: TCPFlags{
+							SYN: true,
+							ACK: true,
+						},
+					},
+				},
+			},
+			e: &flow.Flow{
+				Time: timestamppb.New(tt),
+				Source: &flow.Endpoint{
+					ID:       100,
+					Identity: 1000,
+				},
+				Destination: &flow.Endpoint{
+					ID:       200,
+					Identity: 2000,
+				},
+				L4: &flow.Layer4{
+					Protocol: &flow.Layer4_TCP{
+						TCP: &flow.TCP{
+							SourcePort:      8080,
+							DestinationPort: 80,
+							Flags: &flow.TCPFlags{
+								SYN: true,
+								ACK: true,
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"l7-http": {
+			in: Flow{
+				Time: tt,
+				Source: Endpoint{
+					ID:       100,
+					Identity: 1000,
+				},
+				Destination: Endpoint{
+					ID:       200,
+					Identity: 2000,
+				},
+				L7: Layer7{
+					Type: flow.L7FlowType_REQUEST,
+					HTTP: HTTP{
+						Method:   "GET",
+						URL:      "http://blee.com",
+						Protocol: "http",
+					},
+				},
+			},
+			e: &flow.Flow{
+				Time: timestamppb.New(tt),
+				Source: &flow.Endpoint{
+					ID:       100,
+					Identity: 1000,
+				},
+				Destination: &flow.Endpoint{
+					ID:       200,
+					Identity: 2000,
+				},
+				L7: &flow.Layer7{
+					Type: flow.L7FlowType_REQUEST,
+					Record: &flow.Layer7_Http{
+						Http: &flow.HTTP{
+							Method:   "GET",
+							Url:      "http://blee.com",
+							Protocol: "http",
+						},
+					},
+				},
+			},
+		},
+
+		"l7-dns": {
+			in: Flow{
+				Time: tt,
+				Source: Endpoint{
+					ID:       100,
+					Identity: 1000,
+				},
+				Destination: Endpoint{
+					ID:       200,
+					Identity: 2000,
+				},
+				L7: Layer7{
+					Type: flow.L7FlowType_RESPONSE,
+					DNS: DNS{
+						Query: "blee.com",
+						Ips:   []string{"1.1.1.1", "2.2.2.2"},
+					},
+				},
+			},
+			e: &flow.Flow{
+				Time: timestamppb.New(tt),
+				Source: &flow.Endpoint{
+					ID:       100,
+					Identity: 1000,
+				},
+				Destination: &flow.Endpoint{
+					ID:       200,
+					Identity: 2000,
+				},
+				L7: &flow.Layer7{
+					Type: flow.L7FlowType_RESPONSE,
+					Record: &flow.Layer7_Dns{
+						Dns: &flow.DNS{
+							Query: "blee.com",
+							Ips:   []string{"1.1.1.1", "2.2.2.2"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.ToProto())
+		})
+	}
+}
+
+func TestFlowMerge(t *testing.T) {
+	uu := map[string]struct {
+		flow1, flow2, e *Flow
+	}{
+		"all-empty": {},
+
+		"src-empty": {
+			flow2: &Flow{
+				UUID: "100",
+			},
+			e: &Flow{
+				UUID: "100",
+			},
+		},
+
+		"dst-empty": {
+			flow1: &Flow{
+				UUID: "100",
+			},
+			e: &Flow{
+				UUID: "100",
+			},
+		},
+
+		"partial": {
+			flow1: &Flow{
+				UUID:    "100",
+				Verdict: flow.Verdict_DROPPED,
+				Source: Endpoint{
+					ID: 100,
+				},
+				Destination: Endpoint{
+					ID: 200,
+				},
+			},
+			flow2: &Flow{
+				UUID:    "100",
+				Verdict: flow.Verdict_ERROR,
+				Emitter: Emitter{
+					Name:    "fred",
+					Version: "1.0",
+				},
+			},
+			e: &Flow{
+				UUID:    "100",
+				Verdict: flow.Verdict_ERROR,
+				Source: Endpoint{
+					ID: 100,
+				},
+				Destination: Endpoint{
+					ID: 200,
+				},
+				Emitter: Emitter{
+					Name:    "fred",
+					Version: "1.0",
+				},
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, TestMerge(u.flow1, u.flow2))
+		})
+	}
+}
+
+func TestFlowIsReply(t *testing.T) {
+	uu := map[string]struct {
+		f Flow
+		e bool
+	}{
+		"yes": {
+			f: Flow{
+				Reply: ReplyYes,
+			},
+			e: true,
+		},
+
+		"no": {
+			f: Flow{
+				Reply: ReplyNo,
+			},
+		},
+
+		"unknown": {
+			f: Flow{},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, u.f.IsReply())
+		})
+	}
+}
+
+func BenchmarkFlowToProtoL4(b *testing.B) {
+	tt := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+	f := Flow{
+		Time: tt,
+		Emitter: Emitter{
+			Name:    "fred",
+			Version: "1.0",
+		},
+		Ethernet: Ethernet{
+			Source:      net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
+			Destination: net.HardwareAddr{0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB},
+		},
+		Source: Endpoint{
+			ID:       100,
+			Identity: 1000,
+		},
+		Destination: Endpoint{
+			ID:       200,
+			Identity: 2000,
+		},
+		L4: Layer4{
+			TCP: TCP{
+				SourcePort:      8080,
+				DestinationPort: 80,
+			},
+		},
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = f.ToProto()
+	}
+}

--- a/pkg/hubble/ir/ip.go
+++ b/pkg/hubble/ir/ip.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import (
+	"github.com/cilium/cilium/api/v1/flow"
+)
+
+// IP tracks flow source/destination IP information.
+type IP struct {
+	SourceXlated string         `json:"sourceXlated,omitempty"`
+	Source       string         `json:"source,omitempty"`
+	Destination  string         `json:"destination,omitempty"`
+	IPVersion    flow.IPVersion `json:"ipVersion,omitempty"`
+	Encrypted    bool           `json:"encrypted,omitempty"`
+}
+
+// IsEmpty returns true if the struct has no data.
+// NOTE: Leaving encrypted field unchecked since if no other fields are set the IP should be deemed empty.
+func (i IP) IsEmpty() bool {
+	return i.SourceXlated == "" &&
+		i.Source == "" &&
+		i.Destination == "" &&
+		i.IPVersion == flow.IPVersion_IP_NOT_USED
+}
+
+// ipTestMerge merges ips types.
+// NOTE: This is only used for testing!
+func ipTestMerge(i1, i2 IP) IP {
+	if i2.Source != "" {
+		i1.Source = i2.Source
+	}
+	if i2.Destination != "" {
+		i1.Destination = i2.Destination
+	}
+	if i2.SourceXlated != "" {
+		i1.SourceXlated = i2.SourceXlated
+	}
+	if i2.Encrypted != i1.Encrypted {
+		i1.Encrypted = i2.Encrypted
+	}
+	if i2.IPVersion != flow.IPVersion_IP_NOT_USED {
+		i1.IPVersion = i2.IPVersion
+	}
+
+	return i1
+}
+
+func (ip IP) toProto() *flow.IP {
+	if ip.IsEmpty() {
+		return nil
+	}
+
+	return &flow.IP{
+		Source:       ip.Source,
+		Destination:  ip.Destination,
+		IpVersion:    ip.IPVersion,
+		SourceXlated: ip.SourceXlated,
+		Encrypted:    ip.Encrypted,
+	}
+}
+
+func protoToIP(i *flow.IP) IP {
+	if i == nil {
+		return IP{}
+	}
+
+	return IP{
+		Source:       i.Source,
+		Destination:  i.Destination,
+		IPVersion:    i.IpVersion,
+		SourceXlated: i.SourceXlated,
+		Encrypted:    i.Encrypted,
+	}
+}

--- a/pkg/hubble/ir/ip_test.go
+++ b/pkg/hubble/ir/ip_test.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/api/v1/flow"
+)
+
+func Test_ipTestMerge(t *testing.T) {
+	ip1 := "1.2.3.4"
+	ip2 := "4.5.6.7"
+
+	uu := map[string]struct {
+		ip1, ip2 IP
+		e        IP
+	}{
+		"empty": {},
+
+		"blank": {
+			ip2: IP{IPVersion: 4, Source: ip1},
+			e:   IP{IPVersion: 4, Source: ip1},
+		},
+
+		"noop": {
+			ip1: IP{IPVersion: 6, Source: ip1},
+			e:   IP{IPVersion: 6, Source: ip1},
+		},
+
+		"full": {
+			ip1: IP{
+				IPVersion:    4,
+				Source:       ip1,
+				Destination:  ip2,
+				SourceXlated: "1.1.1.1",
+			},
+			ip2: IP{
+				IPVersion:    6,
+				Source:       ip2,
+				Destination:  ip1,
+				SourceXlated: "1.2.2.2",
+				Encrypted:    true,
+			},
+			e: IP{
+				IPVersion:    6,
+				Source:       ip2,
+				Destination:  ip1,
+				SourceXlated: "1.2.2.2",
+				Encrypted:    true,
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, ipTestMerge(u.ip1, u.ip2))
+		})
+	}
+}
+
+func Test_ipToProto(t *testing.T) {
+	ip1 := "1.2.3.4"
+	ip2 := "4.5.6.7"
+	uu := map[string]struct {
+		in *flow.IP
+		e  IP
+	}{
+		"empty": {},
+
+		"full": {
+			in: &flow.IP{
+				Source:       "1.2.3.4",
+				Destination:  "4.5.6.7",
+				SourceXlated: "1.1.1.1",
+				IpVersion:    4,
+				Encrypted:    true,
+			},
+			e: IP{
+				Source:       ip1,
+				Destination:  ip2,
+				SourceXlated: "1.1.1.1",
+				IPVersion:    4,
+				Encrypted:    true,
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, protoToIP(u.in))
+		})
+	}
+}
+
+func TestIP_toProto(t *testing.T) {
+	ip1 := "1.2.3.4"
+	ip2 := "4.5.6.7"
+
+	uu := map[string]struct {
+		in IP
+		e  *flow.IP
+	}{
+		"empty": {},
+
+		"partial": {
+			in: IP{
+				Source:       ip1,
+				SourceXlated: "1.1.1.1",
+				IPVersion:    4,
+				Encrypted:    true,
+			},
+			e: &flow.IP{
+				Source:       "1.2.3.4",
+				SourceXlated: "1.1.1.1",
+				IpVersion:    4,
+				Encrypted:    true,
+			},
+		},
+
+		"full": {
+			in: IP{
+				Source:       ip1,
+				Destination:  ip2,
+				SourceXlated: "1.1.1.1",
+				IPVersion:    4,
+				Encrypted:    true,
+			},
+			e: &flow.IP{
+				Source:       "1.2.3.4",
+				Destination:  "4.5.6.7",
+				SourceXlated: "1.1.1.1",
+				IpVersion:    4,
+				Encrypted:    true,
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.toProto())
+		})
+	}
+}

--- a/pkg/hubble/ir/ip_trace.go
+++ b/pkg/hubble/ir/ip_trace.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import "github.com/cilium/cilium/api/v1/flow"
+
+// IPTraceID tracks flow trace ID.
+type IPTraceID struct {
+	TraceID      uint64 `json:"traceId,omitempty"`
+	IPOptionType uint32 `json:"ipOptionType,omitempty"`
+}
+
+// IsEmpty returns true if target has no data.
+func (t IPTraceID) IsEmpty() bool {
+	return t.TraceID == 0 && t.IPOptionType == 0
+}
+
+func (t IPTraceID) toProto() *flow.IPTraceID {
+	if t.IsEmpty() {
+		return nil
+	}
+
+	return &flow.IPTraceID{
+		TraceId:      t.TraceID,
+		IpOptionType: t.IPOptionType,
+	}
+}
+
+// ProtoToIPTraceID converts a protobuf trace to an internal shape.
+func ProtoToIPTraceID(t *flow.IPTraceID) IPTraceID {
+	if t == nil {
+		return IPTraceID{}
+	}
+
+	return IPTraceID{
+		TraceID:      t.TraceId,
+		IPOptionType: t.IpOptionType,
+	}
+}

--- a/pkg/hubble/ir/ip_trace_test.go
+++ b/pkg/hubble/ir/ip_trace_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/api/v1/flow"
+)
+
+func TestProtoToIPTraceID(t *testing.T) {
+	uu := map[string]struct {
+		in *flow.IPTraceID
+		e  IPTraceID
+	}{
+		"empty": {
+			in: nil,
+		},
+
+		"full": {
+			in: &flow.IPTraceID{
+				TraceId:      12345,
+				IpOptionType: 10,
+			},
+			e: IPTraceID{
+				TraceID:      12345,
+				IPOptionType: 10,
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, ProtoToIPTraceID(u.in))
+		})
+	}
+}
+
+func TestIPTraceIsEmpty(t *testing.T) {
+	uu := map[string]struct {
+		t IPTraceID
+		e bool
+	}{
+		"empty": {
+			e: true,
+		},
+
+		"partial": {
+			t: IPTraceID{
+				TraceID: 12345,
+			},
+		},
+
+		"full": {
+			t: IPTraceID{
+				TraceID:      12345,
+				IPOptionType: 10,
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, u.t.IsEmpty())
+		})
+	}
+}
+
+func TestIPTrace_toProto(t *testing.T) {
+	uu := map[string]struct {
+		t   IPTraceID
+		out *flow.IPTraceID
+	}{
+		"empty": {},
+
+		"full": {
+			t: IPTraceID{
+				TraceID:      12345,
+				IPOptionType: 10,
+			},
+			out: &flow.IPTraceID{
+				TraceId:      12345,
+				IpOptionType: 10,
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.out, u.t.toProto())
+		})
+	}
+}

--- a/pkg/hubble/ir/l4.go
+++ b/pkg/hubble/ir/l4.go
@@ -1,0 +1,375 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import (
+	"github.com/cilium/cilium/api/v1/flow"
+)
+
+// Layer4 tracks L4 protocol specification.
+type Layer4 struct {
+	IGMP   IGMP `json:"IGMP,omitempty"`
+	TCP    TCP  `json:"TCP,omitempty"`
+	SCTP   SCTP `json:"SCTP,omitempty"`
+	VRRP   VRRP `json:"VRRP,omitempty"`
+	UDP    UDP  `json:"UDP,omitempty"`
+	ICMPv4 ICMP `json:"ICMPv4,omitempty"`
+	ICMPv6 ICMP `json:"ICMPv6,omitempty"`
+}
+
+// IsEmpty returns true if target has no data.
+func (l4 Layer4) IsEmpty() bool {
+	return l4.IGMP.IsEmpty() &&
+		l4.TCP.IsEmpty() &&
+		l4.SCTP.IsEmpty() &&
+		l4.VRRP.IsEmpty() &&
+		l4.UDP.IsEmpty() &&
+		l4.ICMPv4.IsEmpty() &&
+		l4.ICMPv6.IsEmpty()
+}
+
+func (l4 Layer4) toProto() *flow.Layer4 {
+	if l4.IsEmpty() {
+		return nil
+	}
+
+	var fl4 flow.Layer4
+	switch {
+	case !l4.IGMP.IsEmpty():
+		fl4.Protocol = &flow.Layer4_IGMP{
+			IGMP: l4.IGMP.toProto(),
+		}
+	case !l4.TCP.IsEmpty():
+		fl4.Protocol = &flow.Layer4_TCP{
+			TCP: l4.TCP.toProto(),
+		}
+	case !l4.SCTP.IsEmpty():
+		fl4.Protocol = &flow.Layer4_SCTP{
+			SCTP: l4.SCTP.toProto(),
+		}
+	case !l4.VRRP.IsEmpty():
+		fl4.Protocol = &flow.Layer4_VRRP{
+			VRRP: l4.VRRP.toProto(),
+		}
+	case !l4.UDP.IsEmpty():
+		fl4.Protocol = &flow.Layer4_UDP{
+			UDP: l4.UDP.toProto(),
+		}
+	case !l4.ICMPv4.IsEmpty():
+		fl4.Protocol = &flow.Layer4_ICMPv4{
+			ICMPv4: l4.ICMPv4.toProtoV4(),
+		}
+	case !l4.ICMPv6.IsEmpty():
+		fl4.Protocol = &flow.Layer4_ICMPv6{
+			ICMPv6: l4.ICMPv6.toProtoV6(),
+		}
+	}
+
+	return &fl4
+}
+
+func protoToL4(l4 *flow.Layer4) Layer4 {
+	var l Layer4
+
+	switch {
+	case l4.GetTCP() != nil:
+		l.TCP = protoToTCP(l4.GetTCP())
+	case l4.GetUDP() != nil:
+		l.UDP = protoToUDP(l4.GetUDP())
+	case l4.GetICMPv4() != nil:
+		l.ICMPv4 = protoToICMPv4(l4.GetICMPv4())
+	case l4.GetICMPv6() != nil:
+		l.ICMPv6 = protoToICMPv6(l4.GetICMPv6())
+	case l4.GetSCTP() != nil:
+		l.SCTP = protoToSCTP(l4.GetSCTP())
+	case l4.GetVRRP() != nil:
+		l.VRRP = protoToVRRP(l4.GetVRRP())
+	case l4.GetIGMP() != nil:
+		l.IGMP = protoToIGMP(l4.GetIGMP())
+	}
+
+	return l
+}
+
+// IGMP tracks IGMP layer information.
+type IGMP struct {
+	GroupAddress string `json:"groupAddress,omitempty"`
+	Type         uint32 `json:"type,omitempty"`
+}
+
+// IsEmpty returns true if target has no data.
+func (i IGMP) IsEmpty() bool {
+	return i.Type == 0 && i.GroupAddress == ""
+}
+
+func (i IGMP) toProto() *flow.IGMP {
+	if i.IsEmpty() {
+		return nil
+	}
+
+	return &flow.IGMP{
+		GroupAddress: i.GroupAddress,
+		Type:         i.Type,
+	}
+}
+
+func protoToIGMP(i *flow.IGMP) IGMP {
+	if i == nil {
+		return IGMP{}
+	}
+
+	return IGMP{
+		Type:         i.Type,
+		GroupAddress: i.GroupAddress,
+	}
+}
+
+// VRRP tracks VRRP layer information.
+type VRRP struct {
+	Type     uint32 `json:"type,omitempty"`
+	VRID     uint32 `json:"vrid,omitempty"`
+	Priority uint32 `json:"priority,omitempty"`
+}
+
+// IsEmpty returns true if target has no data.
+func (v VRRP) IsEmpty() bool {
+	return v.Type == 0 && v.VRID == 0 && v.Priority == 0
+}
+
+func (v VRRP) toProto() *flow.VRRP {
+	if v.IsEmpty() {
+		return nil
+	}
+
+	return &flow.VRRP{
+		Type:     v.Type,
+		Vrid:     v.VRID,
+		Priority: v.Priority,
+	}
+}
+
+func protoToVRRP(i *flow.VRRP) VRRP {
+	if i == nil {
+		return VRRP{}
+	}
+
+	return VRRP{
+		Type:     i.Type,
+		VRID:     i.Vrid,
+		Priority: i.Priority,
+	}
+}
+
+// SCTP tracks SCTP layer information.
+type SCTP struct {
+	SourcePort      uint32             `json:"source_port,omitempty"`
+	DestinationPort uint32             `json:"destination_port,omitempty"`
+	ChunkType       flow.SCTPChunkType `json:"chunk_type,omitempty"`
+}
+
+// IsEmpty returns true if target has no data.
+func (s SCTP) IsEmpty() bool {
+	return s.SourcePort == 0 && s.DestinationPort == 0 && s.ChunkType == flow.SCTPChunkType_UNSUPPORTED
+}
+
+func (s SCTP) toProto() *flow.SCTP {
+	if s.IsEmpty() {
+		return nil
+	}
+
+	return &flow.SCTP{
+		SourcePort:      s.SourcePort,
+		DestinationPort: s.DestinationPort,
+		ChunkType:       s.ChunkType,
+	}
+}
+
+func protoToSCTP(i *flow.SCTP) SCTP {
+	if i == nil {
+		return SCTP{}
+	}
+
+	return SCTP{
+		SourcePort:      i.SourcePort,
+		DestinationPort: i.DestinationPort,
+		ChunkType:       i.ChunkType,
+	}
+}
+
+// ICMP tracks ICMP layer information.
+type ICMP struct {
+	Type uint32 `json:"type,omitempty"`
+	Code uint32 `json:"code,omitempty"`
+}
+
+// IsEmpty returns true if target has no data.
+func (i ICMP) IsEmpty() bool {
+	return i.Type == 0 && i.Code == 0
+}
+
+func (i ICMP) toProtoV6() *flow.ICMPv6 {
+	if i.IsEmpty() {
+		return nil
+	}
+
+	return &flow.ICMPv6{
+		Type: i.Type,
+		Code: i.Code,
+	}
+}
+
+func (i ICMP) toProtoV4() *flow.ICMPv4 {
+	if i.IsEmpty() {
+		return nil
+	}
+
+	return &flow.ICMPv4{
+		Type: i.Type,
+		Code: i.Code,
+	}
+}
+
+func protoToICMPv4(i *flow.ICMPv4) ICMP {
+	if i == nil {
+		return ICMP{}
+	}
+
+	return ICMP{
+		Type: i.Type,
+		Code: i.Code,
+	}
+}
+
+func protoToICMPv6(i *flow.ICMPv6) ICMP {
+	if i == nil {
+		return ICMP{}
+	}
+
+	return ICMP{
+		Type: i.Type,
+		Code: i.Code,
+	}
+}
+
+// UDP tracks UDP layer information.
+type UDP struct {
+	SourcePort      uint32 `json:"source_port,omitempty"`
+	DestinationPort uint32 `json:"destination_port,omitempty"`
+}
+
+// IsEmpty returns true if target has no data.
+func (u UDP) IsEmpty() bool {
+	return u.SourcePort == 0 && u.DestinationPort == 0
+}
+
+func (u UDP) toProto() *flow.UDP {
+	if u.IsEmpty() {
+		return nil
+	}
+
+	return &flow.UDP{
+		SourcePort:      u.SourcePort,
+		DestinationPort: u.DestinationPort,
+	}
+}
+
+func protoToUDP(u *flow.UDP) UDP {
+	if u == nil {
+		return UDP{}
+	}
+
+	return UDP{
+		SourcePort:      u.SourcePort,
+		DestinationPort: u.DestinationPort,
+	}
+}
+
+// TCP tracks TCP layer information.
+type TCP struct {
+	Flags           TCPFlags `json:"flags,omitempty"`
+	SourcePort      uint32   `json:"source_port,omitempty"`
+	DestinationPort uint32   `json:"destination_port,omitempty"`
+}
+
+// IsEmpty returns true if target has no data.
+func (t TCP) IsEmpty() bool {
+	return t.SourcePort == 0 && t.DestinationPort == 0 && t.Flags.IsEmpty()
+}
+
+func (t TCP) toProto() *flow.TCP {
+	if t.IsEmpty() {
+		return nil
+	}
+
+	return &flow.TCP{
+		SourcePort:      t.SourcePort,
+		DestinationPort: t.DestinationPort,
+		Flags:           t.Flags.toProto(),
+	}
+}
+
+func protoToTCP(t *flow.TCP) TCP {
+	if t == nil {
+		return TCP{}
+	}
+
+	return TCP{
+		SourcePort:      t.SourcePort,
+		DestinationPort: t.DestinationPort,
+		Flags:           protoToTCPFlags(t),
+	}
+}
+
+// TCPFlags tracks TCP flags.
+type TCPFlags struct {
+	FIN bool `json:"fin,omitempty"`
+	SYN bool `json:"syn,omitempty"`
+	RST bool `json:"rst,omitempty"`
+	PSH bool `json:"psh,omitempty"`
+	ACK bool `json:"ack,omitempty"`
+	URG bool `json:"urg,omitempty"`
+	ECE bool `json:"ece,omitempty"`
+	CWR bool `json:"cwr,omitempty"`
+	NS  bool `json:"ns,omitempty"`
+}
+
+// IsEmpty returns true if target has no data.
+func (f TCPFlags) IsEmpty() bool {
+	return !f.FIN && !f.SYN && !f.RST && !f.PSH && !f.ACK && !f.URG && !f.ECE && !f.CWR && !f.NS
+}
+
+func (f TCPFlags) toProto() *flow.TCPFlags {
+	if f.IsEmpty() {
+		return nil
+	}
+
+	return &flow.TCPFlags{
+		FIN: f.FIN,
+		SYN: f.SYN,
+		RST: f.RST,
+		PSH: f.PSH,
+		ACK: f.ACK,
+		URG: f.URG,
+		ECE: f.ECE,
+		CWR: f.CWR,
+		NS:  f.NS,
+	}
+}
+
+func protoToTCPFlags(t *flow.TCP) TCPFlags {
+	if t == nil || t.Flags == nil {
+		return TCPFlags{}
+	}
+	return TCPFlags{
+		FIN: t.Flags.FIN,
+		SYN: t.Flags.SYN,
+		RST: t.Flags.RST,
+		PSH: t.Flags.PSH,
+		ACK: t.Flags.ACK,
+		URG: t.Flags.URG,
+		ECE: t.Flags.ECE,
+		CWR: t.Flags.CWR,
+		NS:  t.Flags.NS,
+	}
+}

--- a/pkg/hubble/ir/l4_test.go
+++ b/pkg/hubble/ir/l4_test.go
@@ -1,0 +1,947 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/api/v1/flow"
+)
+
+func Test_fromLayer4(t *testing.T) {
+	uu := map[string]struct {
+		in Layer4
+		e  *flow.Layer4
+	}{
+		"empty": {},
+
+		"tcp": {
+			in: Layer4{
+				TCP: TCP{
+					SourcePort:      1234,
+					DestinationPort: 80,
+					Flags:           TCPFlags{SYN: true, ACK: true},
+				},
+			},
+			e: &flow.Layer4{
+				Protocol: &flow.Layer4_TCP{
+					TCP: &flow.TCP{
+						SourcePort:      1234,
+						DestinationPort: 80,
+						Flags:           &flow.TCPFlags{SYN: true, ACK: true},
+					},
+				},
+			},
+		},
+
+		"udp": {
+			in: Layer4{
+				UDP: UDP{
+					SourcePort:      5678,
+					DestinationPort: 53,
+				},
+			},
+			e: &flow.Layer4{
+				Protocol: &flow.Layer4_UDP{
+					UDP: &flow.UDP{
+						SourcePort:      5678,
+						DestinationPort: 53,
+					},
+				},
+			},
+		},
+
+		"icmpv4": {
+			in: Layer4{
+				ICMPv4: ICMP{
+					Type: 8,
+					Code: 0,
+				},
+			},
+			e: &flow.Layer4{
+				Protocol: &flow.Layer4_ICMPv4{
+					ICMPv4: &flow.ICMPv4{
+						Type: 8,
+						Code: 0,
+					},
+				},
+			},
+		},
+
+		"icmpv6": {
+			in: Layer4{
+				ICMPv6: ICMP{
+					Type: 135,
+					Code: 0,
+				},
+			},
+			e: &flow.Layer4{
+				Protocol: &flow.Layer4_ICMPv6{
+					ICMPv6: &flow.ICMPv6{
+						Type: 135,
+						Code: 0,
+					},
+				},
+			},
+		},
+
+		"sctp": {
+			in: Layer4{
+				SCTP: SCTP{
+					SourcePort:      3456,
+					DestinationPort: 7890,
+				},
+			},
+			e: &flow.Layer4{
+				Protocol: &flow.Layer4_SCTP{
+					SCTP: &flow.SCTP{
+						SourcePort:      3456,
+						DestinationPort: 7890,
+					},
+				},
+			},
+		},
+
+		"vrrp": {
+			in: Layer4{
+				VRRP: VRRP{
+					Type:     1,
+					VRID:     42,
+					Priority: 100,
+				},
+			},
+			e: &flow.Layer4{
+				Protocol: &flow.Layer4_VRRP{
+					VRRP: &flow.VRRP{
+						Type:     1,
+						Vrid:     42,
+						Priority: 100,
+					},
+				},
+			},
+		},
+
+		"igmp": {
+			in: Layer4{
+				IGMP: IGMP{
+					Type:         2,
+					GroupAddress: "224.0.0.1",
+				},
+			},
+			e: &flow.Layer4{
+				Protocol: &flow.Layer4_IGMP{
+					IGMP: &flow.IGMP{
+						Type:         2,
+						GroupAddress: "224.0.0.1",
+					},
+				},
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.toProto())
+		})
+	}
+}
+
+func Test_toLayer4(t *testing.T) {
+	uu := map[string]struct {
+		in *flow.Layer4
+		e  Layer4
+	}{
+		"empty": {
+			e: Layer4{},
+		},
+
+		"tcp": {
+			in: &flow.Layer4{
+				Protocol: &flow.Layer4_TCP{
+					TCP: &flow.TCP{
+						SourcePort:      1234,
+						DestinationPort: 80,
+						Flags:           &flow.TCPFlags{SYN: true, ACK: true},
+					},
+				},
+			},
+			e: Layer4{
+				TCP: TCP{
+					SourcePort:      1234,
+					DestinationPort: 80,
+					Flags:           TCPFlags{SYN: true, ACK: true},
+				},
+			},
+		},
+
+		"udp": {
+			in: &flow.Layer4{
+				Protocol: &flow.Layer4_UDP{
+					UDP: &flow.UDP{
+						SourcePort:      5678,
+						DestinationPort: 53,
+					},
+				},
+			},
+			e: Layer4{
+				UDP: UDP{
+					SourcePort:      5678,
+					DestinationPort: 53,
+				},
+			},
+		},
+
+		"icmpv4": {
+			in: &flow.Layer4{
+				Protocol: &flow.Layer4_ICMPv4{
+					ICMPv4: &flow.ICMPv4{
+						Type: 8,
+						Code: 0,
+					},
+				},
+			},
+			e: Layer4{
+				ICMPv4: ICMP{
+					Type: 8,
+					Code: 0,
+				},
+			},
+		},
+
+		"icmpv6": {
+			in: &flow.Layer4{
+				Protocol: &flow.Layer4_ICMPv6{
+					ICMPv6: &flow.ICMPv6{
+						Type: 135,
+						Code: 0,
+					},
+				},
+			},
+			e: Layer4{
+				ICMPv6: ICMP{
+					Type: 135,
+					Code: 0,
+				},
+			},
+		},
+
+		"sctp": {
+			in: &flow.Layer4{
+				Protocol: &flow.Layer4_SCTP{
+					SCTP: &flow.SCTP{
+						SourcePort:      3456,
+						DestinationPort: 7890,
+					},
+				},
+			},
+			e: Layer4{
+				SCTP: SCTP{
+					SourcePort:      3456,
+					DestinationPort: 7890,
+				},
+			},
+		},
+
+		"vrrp": {
+			in: &flow.Layer4{
+				Protocol: &flow.Layer4_VRRP{
+					VRRP: &flow.VRRP{
+						Type:     1,
+						Vrid:     42,
+						Priority: 100,
+					},
+				},
+			},
+			e: Layer4{
+				VRRP: VRRP{
+					Type:     1,
+					VRID:     42,
+					Priority: 100,
+				},
+			},
+		},
+
+		"igmp": {
+			in: &flow.Layer4{
+				Protocol: &flow.Layer4_IGMP{
+					IGMP: &flow.IGMP{
+						Type:         2,
+						GroupAddress: "1.2.3.4",
+					},
+				},
+			},
+			e: Layer4{
+				IGMP: IGMP{
+					Type:         2,
+					GroupAddress: "1.2.3.4",
+				},
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, protoToL4(u.in))
+		})
+	}
+}
+
+func TestTCPIsEmpty(t *testing.T) {
+	uu := map[string]struct {
+		in TCP
+		e  bool
+	}{
+		"empty": {
+			e: true,
+		},
+
+		"full": {
+			in: TCP{
+				SourcePort:      1234,
+				DestinationPort: 4567,
+				Flags:           TCPFlags{SYN: true},
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.IsEmpty())
+		})
+	}
+}
+
+func TestTCP_toProto(t *testing.T) {
+	uu := map[string]struct {
+		in TCP
+		e  *flow.TCP
+	}{
+		"empty": {},
+
+		"full": {
+			in: TCP{
+				SourcePort:      1234,
+				DestinationPort: 4567,
+				Flags:           TCPFlags{SYN: true},
+			},
+			e: &flow.TCP{
+				SourcePort:      1234,
+				DestinationPort: 4567,
+				Flags:           &flow.TCPFlags{SYN: true},
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.toProto())
+		})
+	}
+}
+
+func TestTCP_protoToTCP(t *testing.T) {
+	uu := map[string]struct {
+		in *flow.TCP
+		e  TCP
+	}{
+		"empty": {},
+		"full": {
+			in: &flow.TCP{
+				SourcePort:      1234,
+				DestinationPort: 4567,
+				Flags:           &flow.TCPFlags{SYN: true},
+			},
+			e: TCP{
+				SourcePort:      1234,
+				DestinationPort: 4567,
+				Flags:           TCPFlags{SYN: true},
+			},
+		},
+	}
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, protoToTCP(u.in))
+		})
+	}
+}
+
+func TestUDPIsEmpty(t *testing.T) {
+	uu := map[string]struct {
+		in UDP
+		e  bool
+	}{
+		"empty": {
+			e: true,
+		},
+
+		"full": {
+			in: UDP{
+				SourcePort:      1234,
+				DestinationPort: 4567,
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.IsEmpty())
+		})
+	}
+}
+
+func TestUDP_toProto(t *testing.T) {
+	uu := map[string]struct {
+		in UDP
+		e  *flow.UDP
+	}{
+		"empty": {},
+
+		"full": {
+			in: UDP{
+				SourcePort:      1234,
+				DestinationPort: 4567,
+			},
+			e: &flow.UDP{
+				SourcePort:      1234,
+				DestinationPort: 4567,
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.toProto())
+		})
+	}
+}
+
+func Test_protoToUDP(t *testing.T) {
+	uu := map[string]struct {
+		in *flow.UDP
+		e  UDP
+	}{
+		"empty": {},
+
+		"full": {
+			in: &flow.UDP{
+				SourcePort:      1234,
+				DestinationPort: 4567,
+			},
+			e: UDP{
+				SourcePort:      1234,
+				DestinationPort: 4567,
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, protoToUDP(u.in))
+		})
+	}
+}
+
+func TestIGMPIsEmpty(t *testing.T) {
+	uu := map[string]struct {
+		in IGMP
+		e  bool
+	}{
+		"empty": {
+			e: true,
+		},
+
+		"full": {
+			in: IGMP{
+				Type:         1,
+				GroupAddress: "bozo",
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.IsEmpty())
+		})
+	}
+}
+
+func TestIGMP_toProto(t *testing.T) {
+	uu := map[string]struct {
+		in IGMP
+		e  *flow.IGMP
+	}{
+		"empty": {},
+
+		"full": {
+			in: IGMP{
+				Type:         1,
+				GroupAddress: "bozo",
+			},
+			e: &flow.IGMP{
+				Type:         1,
+				GroupAddress: "bozo",
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.toProto())
+		})
+	}
+}
+
+func Test_protoToIGMP(t *testing.T) {
+	uu := map[string]struct {
+		in *flow.IGMP
+		e  IGMP
+	}{
+		"empty": {},
+
+		"full": {
+			in: &flow.IGMP{
+				Type:         1,
+				GroupAddress: "bozo",
+			},
+			e: IGMP{
+				Type:         1,
+				GroupAddress: "bozo",
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, protoToIGMP(u.in))
+		})
+	}
+}
+
+func TestVRRPIsEmpty(t *testing.T) {
+	uu := map[string]struct {
+		in VRRP
+		e  bool
+	}{
+		"empty": {
+			e: true,
+		},
+
+		"full": {
+			in: VRRP{
+				Type:     1,
+				VRID:     2,
+				Priority: 3,
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.IsEmpty())
+		})
+	}
+}
+
+func TestVRRP_toProto(t *testing.T) {
+	uu := map[string]struct {
+		in VRRP
+		e  *flow.VRRP
+	}{
+		"empty": {},
+
+		"full": {
+			in: VRRP{
+				Type:     1,
+				VRID:     2,
+				Priority: 3,
+			},
+			e: &flow.VRRP{
+				Type:     1,
+				Vrid:     2,
+				Priority: 3,
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.toProto())
+		})
+	}
+}
+
+func Test_protoToVRRP(t *testing.T) {
+	uu := map[string]struct {
+		in *flow.VRRP
+		e  VRRP
+	}{
+		"empty": {},
+
+		"full": {
+			in: &flow.VRRP{
+				Type:     1,
+				Vrid:     2,
+				Priority: 3,
+			},
+			e: VRRP{
+				Type:     1,
+				VRID:     2,
+				Priority: 3,
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, protoToVRRP(u.in))
+		})
+	}
+}
+
+func TestSCTPIsEmpty(t *testing.T) {
+	uu := map[string]struct {
+		in SCTP
+		e  bool
+	}{
+		"empty": {
+			e: true,
+		},
+
+		"full": {
+			in: SCTP{
+				SourcePort:      1234,
+				DestinationPort: 4567,
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.IsEmpty())
+		})
+	}
+}
+
+func TestSCTYP_toProto(t *testing.T) {
+	uu := map[string]struct {
+		in SCTP
+		e  *flow.SCTP
+	}{
+		"empty": {},
+
+		"full": {
+			in: SCTP{
+				SourcePort:      1234,
+				DestinationPort: 4567,
+			},
+			e: &flow.SCTP{
+				SourcePort:      1234,
+				DestinationPort: 4567,
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.toProto())
+		})
+	}
+}
+
+func Test_protoToSCTP(t *testing.T) {
+	uu := map[string]struct {
+		in *flow.SCTP
+		e  SCTP
+	}{
+		"empty": {},
+
+		"full": {
+			in: &flow.SCTP{
+				SourcePort:      1234,
+				DestinationPort: 4567,
+			},
+			e: SCTP{
+				SourcePort:      1234,
+				DestinationPort: 4567,
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, protoToSCTP(u.in))
+		})
+	}
+}
+
+func TestICMPIsEmpty(t *testing.T) {
+	uu := map[string]struct {
+		in ICMP
+		e  bool
+	}{
+		"empty": {
+			e: true,
+		},
+
+		"full": {
+			in: ICMP{
+				Type: 8,
+				Code: 100,
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.IsEmpty())
+		})
+	}
+}
+
+func TestICMP_toProtoV4(t *testing.T) {
+	uu := map[string]struct {
+		in ICMP
+		e  *flow.ICMPv4
+	}{
+		"empty": {},
+
+		"full": {
+			in: ICMP{
+				Type: 8,
+				Code: 100,
+			},
+			e: &flow.ICMPv4{
+				Type: 8,
+				Code: 100,
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.toProtoV4())
+		})
+	}
+}
+
+func TestICMP_toProtoV6(t *testing.T) {
+	uu := map[string]struct {
+		in ICMP
+		e  *flow.ICMPv6
+	}{
+		"empty": {},
+
+		"full": {
+			in: ICMP{
+				Type: 135,
+				Code: 0,
+			},
+			e: &flow.ICMPv6{
+				Type: 135,
+				Code: 0,
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.toProtoV6())
+		})
+	}
+}
+
+func Test_protoToICMPv4(t *testing.T) {
+	uu := map[string]struct {
+		in *flow.ICMPv4
+		e  ICMP
+	}{
+		"empty": {},
+
+		"full": {
+			in: &flow.ICMPv4{
+				Type: 8,
+				Code: 100,
+			},
+			e: ICMP{
+				Type: 8,
+				Code: 100,
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, protoToICMPv4(u.in))
+		})
+	}
+}
+
+func Test_protoToICMPv6(t *testing.T) {
+	uu := map[string]struct {
+		in *flow.ICMPv6
+		e  ICMP
+	}{
+		"empty": {},
+
+		"full": {
+			in: &flow.ICMPv6{
+				Type: 135,
+				Code: 0,
+			},
+			e: ICMP{
+				Type: 135,
+				Code: 0,
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, protoToICMPv6(u.in))
+		})
+	}
+}
+
+func TestTCPFlagsIsEmpty(t *testing.T) {
+	uu := map[string]struct {
+		in TCPFlags
+		e  bool
+	}{
+		"empty": {
+			e: true,
+		},
+
+		"full": {
+			in: TCPFlags{
+				SYN: true,
+				FIN: true,
+				ACK: true,
+				RST: true,
+				PSH: true,
+				URG: true,
+				ECE: true,
+				CWR: true,
+				NS:  true,
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.IsEmpty())
+		})
+	}
+}
+
+func TestTCPFlags_toProto(t *testing.T) {
+	uu := map[string]struct {
+		in TCPFlags
+		e  *flow.TCPFlags
+	}{
+		"empty": {},
+
+		"partial": {
+			in: TCPFlags{
+				SYN: true,
+				FIN: true,
+				ACK: true,
+			},
+			e: &flow.TCPFlags{
+				SYN: true,
+				FIN: true,
+				ACK: true,
+			},
+		},
+
+		"full": {
+			in: TCPFlags{
+				SYN: true,
+				FIN: true,
+				ACK: true,
+				RST: true,
+				PSH: true,
+				URG: true,
+				ECE: true,
+				CWR: true,
+				NS:  true,
+			},
+			e: &flow.TCPFlags{
+				SYN: true,
+				FIN: true,
+				ACK: true,
+				RST: true,
+				PSH: true,
+				URG: true,
+				ECE: true,
+				CWR: true,
+				NS:  true,
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.toProto())
+		})
+	}
+}
+
+func Test_protoToTCPFlags(t *testing.T) {
+	uu := map[string]struct {
+		in *flow.TCP
+		e  TCPFlags
+	}{
+		"empty": {},
+
+		"partial": {
+			in: &flow.TCP{
+				Flags: &flow.TCPFlags{
+					SYN: true,
+					FIN: true,
+					ACK: true,
+				},
+			},
+			e: TCPFlags{
+				SYN: true,
+				FIN: true,
+				ACK: true,
+			},
+		},
+
+		"full": {
+			in: &flow.TCP{
+				Flags: &flow.TCPFlags{
+					SYN: true,
+					FIN: true,
+					ACK: true,
+					RST: true,
+					PSH: true,
+					URG: true,
+					ECE: true,
+					CWR: true,
+					NS:  true,
+				},
+			},
+			e: TCPFlags{
+				SYN: true,
+				FIN: true,
+				ACK: true,
+				RST: true,
+				PSH: true,
+				URG: true,
+				ECE: true,
+				CWR: true,
+				NS:  true,
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, protoToTCPFlags(u.in))
+		})
+	}
+}

--- a/pkg/hubble/ir/l7.go
+++ b/pkg/hubble/ir/l7.go
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import (
+	"github.com/cilium/cilium/api/v1/flow"
+)
+
+// Layer7 tracks flow layer 7 information.
+type Layer7 struct {
+	DNS       DNS             `json:"dns,omitempty"`
+	HTTP      HTTP            `json:"http,omitempty"`
+	LatencyNs uint64          `json:"latencyNs,omitempty"`
+	Type      flow.L7FlowType `json:"type,omitempty"`
+}
+
+func protoToL7(l7 *flow.Layer7) Layer7 {
+	if l7 == nil {
+		return Layer7{}
+	}
+
+	return Layer7{
+		DNS:       protoToDNS(l7.GetDns()),
+		HTTP:      protoToHTTP(l7.GetHttp()),
+		LatencyNs: l7.LatencyNs,
+		Type:      l7.Type,
+	}
+}
+
+// IsEmpty returns true if target has no data.
+// NOTE: Leaving Type and LatencyNs fields unchecked since if no other fields are set the Layer7 will be deemed empty.
+func (l7 Layer7) IsEmpty() bool {
+	return l7.DNS.IsEmpty() && l7.HTTP.IsEmpty()
+}
+
+func (l7 Layer7) toProto() *flow.Layer7 {
+	if l7.IsEmpty() {
+		return nil
+	}
+
+	l := flow.Layer7{
+		LatencyNs: l7.LatencyNs,
+		Type:      l7.Type,
+	}
+
+	switch {
+	case !l7.DNS.IsEmpty():
+		l.Record = l7.DNS.toProto()
+	case !l7.HTTP.IsEmpty():
+		l.Record = l7.HTTP.toProto()
+	}
+
+	return &l
+}
+
+// DNS tracks flow DNS information.
+type DNS struct {
+	Query             string   `json:"query,omitempty"`
+	Ips               []string `json:"ips,omitempty"`
+	TTL               uint32   `json:"ttl,omitempty"`
+	CNames            []string `json:"cnames,omitempty"`
+	ObservationSource string   `json:"observationSource,omitempty"`
+	RCode             uint32   `json:"rcode,omitempty"`
+	Qtypes            []string `json:"qtypes,omitempty"`
+	Rtypes            []string `json:"rtypes,omitempty"`
+}
+
+// IsEmpty returns true if target has no data.
+// NOTE: Leaving TTL and RCode fields unchecked since if no other fields are set the DNS will be deemed empty.
+func (d DNS) IsEmpty() bool {
+	return d.Query == "" &&
+		d.ObservationSource == "" &&
+		len(d.Ips) == 0 &&
+		len(d.CNames) == 0 &&
+		len(d.Qtypes) == 0 &&
+		len(d.Rtypes) == 0
+}
+
+func (d DNS) toProto() *flow.Layer7_Dns {
+	if d.IsEmpty() {
+		return nil
+	}
+
+	return &flow.Layer7_Dns{
+		Dns: &flow.DNS{
+			Query:             d.Query,
+			Ips:               d.Ips,
+			Ttl:               d.TTL,
+			Cnames:            d.CNames,
+			ObservationSource: d.ObservationSource,
+			Rcode:             d.RCode,
+			Qtypes:            d.Qtypes,
+			Rrtypes:           d.Rtypes,
+		},
+	}
+}
+
+func protoToDNS(d *flow.DNS) DNS {
+	if d == nil {
+		return DNS{}
+	}
+
+	return DNS{
+		Query:             d.Query,
+		Ips:               d.Ips,
+		TTL:               d.Ttl,
+		CNames:            d.Cnames,
+		ObservationSource: d.ObservationSource,
+		RCode:             d.Rcode,
+		Qtypes:            d.Qtypes,
+		Rtypes:            d.Rrtypes,
+	}
+}
+
+type (
+	// HTTP tracks flow HTTP information.
+	HTTP struct {
+		Method   string       `json:"method,omitempty"`
+		URL      string       `json:"url,omitempty"`
+		Protocol string       `json:"protocol,omitempty"`
+		Headers  []HTTPHeader `json:"headers,omitempty"`
+		Code     uint32       `json:"code,omitempty"`
+	}
+
+	// HTTPHeader tracks flow HTTP header information.
+	HTTPHeader struct {
+		Key   string `json:"key,omitempty"`
+		Value string `json:"value,omitempty"`
+	}
+)
+
+func (h HTTP) toProto() *flow.Layer7_Http {
+	if h.IsEmpty() {
+		return nil
+	}
+
+	l := flow.Layer7_Http{
+		Http: &flow.HTTP{
+			Method:   h.Method,
+			Url:      h.URL,
+			Protocol: h.Protocol,
+			Code:     h.Code,
+		},
+	}
+
+	if len(h.Headers) == 0 {
+		return &l
+	}
+
+	l.Http.Headers = make([]*flow.HTTPHeader, 0, len(h.Headers))
+	for i := range h.Headers {
+		l.Http.Headers = append(l.Http.Headers, &flow.HTTPHeader{
+			Key:   h.Headers[i].Key,
+			Value: h.Headers[i].Value,
+		})
+	}
+
+	return &l
+}
+
+func protoToHTTP(h *flow.HTTP) HTTP {
+	if h == nil {
+		return HTTP{}
+	}
+
+	headers := make([]HTTPHeader, 0, len(h.Headers))
+	for i := range h.Headers {
+		headers = append(headers, HTTPHeader{
+			Key:   h.Headers[i].Key,
+			Value: h.Headers[i].Value,
+		})
+	}
+
+	return HTTP{
+		Method:   h.Method,
+		URL:      h.Url,
+		Protocol: h.Protocol,
+		Headers:  headers,
+		Code:     h.Code,
+	}
+}
+
+// IsEmpty returns true if target has no data.
+func (H HTTP) IsEmpty() bool {
+	return H.Method == "" &&
+		H.URL == "" &&
+		H.Protocol == "" &&
+		len(H.Headers) == 0 &&
+		H.Code == 0
+}

--- a/pkg/hubble/ir/l7_test.go
+++ b/pkg/hubble/ir/l7_test.go
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/api/v1/flow"
+)
+
+func Test_protoToL7(t *testing.T) {
+	uu := map[string]struct {
+		in *flow.Layer7
+		e  Layer7
+	}{
+		"empty": {},
+
+		"http": {
+			in: &flow.Layer7{
+				Type:      flow.L7FlowType_REQUEST,
+				LatencyNs: 5,
+				Record: &flow.Layer7_Http{
+					Http: &flow.HTTP{
+						Code:     200,
+						Method:   "GET",
+						Url:      "/index.html",
+						Protocol: "http",
+						Headers: []*flow.HTTPHeader{
+							{Key: "a", Value: "b"},
+							{Key: "b", Value: "c"},
+						},
+					},
+				},
+			},
+			e: Layer7{
+				Type:      flow.L7FlowType_REQUEST,
+				LatencyNs: 5,
+				HTTP: HTTP{
+					Code:     200,
+					Method:   "GET",
+					URL:      "/index.html",
+					Protocol: "http",
+					Headers: []HTTPHeader{
+						{Key: "a", Value: "b"},
+						{Key: "b", Value: "c"},
+					},
+				},
+			},
+		},
+
+		"dns": {
+			in: &flow.Layer7{
+				Type:      flow.L7FlowType_RESPONSE,
+				LatencyNs: 10,
+				Record: &flow.Layer7_Dns{
+					Dns: &flow.DNS{
+						Query:             "example.com",
+						Ips:               []string{"1.2.3.4"},
+						Ttl:               300,
+						Cnames:            []string{"a", "b", "c"},
+						ObservationSource: "blee",
+						Rcode:             100,
+						Qtypes:            []string{"A", "AAAA"},
+						Rrtypes:           []string{"x", "z"},
+					},
+				},
+			},
+			e: Layer7{
+				Type:      flow.L7FlowType_RESPONSE,
+				LatencyNs: 10,
+				DNS: DNS{
+					Query:             "example.com",
+					Ips:               []string{"1.2.3.4"},
+					TTL:               300,
+					CNames:            []string{"a", "b", "c"},
+					ObservationSource: "blee",
+					RCode:             100,
+					Qtypes:            []string{"A", "AAAA"},
+					Rtypes:            []string{"x", "z"},
+				},
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, protoToL7(u.in))
+		})
+	}
+}
+
+func TestDNS_toProto(t *testing.T) {
+	uu := map[string]struct {
+		in DNS
+		e  *flow.Layer7_Dns
+	}{
+		"empty": {},
+
+		"full": {
+			in: DNS{
+				Query:             "example.com",
+				TTL:               10,
+				Ips:               []string{"1.1.1.1", "1.1.1.2"},
+				CNames:            []string{"a", "b"},
+				ObservationSource: "src",
+				RCode:             1,
+				Qtypes:            []string{"A", "AAAA"},
+				Rtypes:            []string{"CNAME"},
+			},
+			e: &flow.Layer7_Dns{
+				Dns: &flow.DNS{
+					Query:             "example.com",
+					Ttl:               10,
+					Ips:               []string{"1.1.1.1", "1.1.1.2"},
+					Cnames:            []string{"a", "b"},
+					ObservationSource: "src",
+					Rcode:             1,
+					Qtypes:            []string{"A", "AAAA"},
+					Rrtypes:           []string{"CNAME"},
+				},
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.toProto())
+		})
+	}
+}
+
+func TestDNSIsEmpty(t *testing.T) {
+	uu := map[string]struct {
+		in DNS
+		e  bool
+	}{
+		"empty": {
+			e: true,
+		},
+
+		"full": {
+			in: DNS{
+				Query:             "example.com",
+				TTL:               10,
+				Ips:               []string{"1.1.1.1"},
+				CNames:            []string{"a"},
+				ObservationSource: "src",
+				RCode:             1,
+				Qtypes:            []string{"A"},
+				Rtypes:            []string{"AAAA"},
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.IsEmpty())
+		})
+	}
+}
+
+func TestHTTP_toProto(t *testing.T) {
+	uu := map[string]struct {
+		in HTTP
+		e  *flow.Layer7_Http
+	}{
+		"empty": {},
+
+		"full": {
+			in: HTTP{
+				Method:   "GET",
+				URL:      "/index.html",
+				Protocol: "http",
+				Code:     200,
+				Headers: []HTTPHeader{
+					{Key: "a", Value: "b"},
+					{Key: "b", Value: "c"},
+				},
+			},
+			e: &flow.Layer7_Http{
+				Http: &flow.HTTP{
+					Method:   "GET",
+					Url:      "/index.html",
+					Protocol: "http",
+					Code:     200,
+					Headers: []*flow.HTTPHeader{
+						{Key: "a", Value: "b"},
+						{Key: "b", Value: "c"},
+					},
+				},
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.toProto())
+		})
+	}
+}
+
+func TestHTTPIsEmpty(t *testing.T) {
+	uu := map[string]struct {
+		in HTTP
+		e  bool
+	}{
+		"empty": {
+			e: true,
+		},
+
+		"full": {
+			in: HTTP{
+				Method:   "GET",
+				URL:      "/index.html",
+				Protocol: "http",
+				Code:     200,
+				Headers: []HTTPHeader{
+					{Key: "a", Value: "b"},
+				},
+			},
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.IsEmpty())
+		})
+	}
+}

--- a/pkg/hubble/ir/network.go
+++ b/pkg/hubble/ir/network.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package ir
+
+import "github.com/cilium/cilium/api/v1/flow"
+
+// NetworkInterface tracks network interface information.
+type NetworkInterface struct {
+	Name  string `json:"name,omitempty"`
+	Index uint32 `json:"index,omitempty"`
+}
+
+// IsEmpty returns true if the network interface has no information set.
+func (n NetworkInterface) IsEmpty() bool {
+	return n.Name == "" && n.Index == 0
+}
+
+func (n NetworkInterface) toProto() *flow.NetworkInterface {
+	if n.IsEmpty() {
+		return nil
+	}
+
+	return &flow.NetworkInterface{
+		Name:  n.Name,
+		Index: n.Index,
+	}
+}
+
+// ProtoToNetworkInterface converts a protobuf NetworkInterface to an internal representation.
+func ProtoToNetworkInterface(n *flow.NetworkInterface) NetworkInterface {
+	if n == nil {
+		return NetworkInterface{}
+	}
+
+	return NetworkInterface{
+		Name:  n.Name,
+		Index: n.Index,
+	}
+}

--- a/pkg/hubble/ir/network_test.go
+++ b/pkg/hubble/ir/network_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package ir
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/api/v1/flow"
+)
+
+func TestProtoToNetworkInterface(t *testing.T) {
+	uu := map[string]struct {
+		in *flow.NetworkInterface
+		e  NetworkInterface
+	}{
+		"empty": {},
+
+		"full": {
+			in: &flow.NetworkInterface{
+				Name:  "eth0",
+				Index: 3,
+			},
+			e: NetworkInterface{
+				Name:  "eth0",
+				Index: 3,
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, ProtoToNetworkInterface(u.in))
+		})
+	}
+}
+
+func TestNetworkInterface_toProto(t *testing.T) {
+	uu := map[string]struct {
+		in NetworkInterface
+		e  *flow.NetworkInterface
+	}{
+		"empty": {},
+
+		"full": {
+			in: NetworkInterface{
+				Name:  "eth0",
+				Index: 3,
+			},
+			e: &flow.NetworkInterface{
+				Name:  "eth0",
+				Index: 3,
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.toProto())
+		})
+	}
+}
+
+func TestNetworkInterfaceIsEmpty(t *testing.T) {
+	uu := map[string]struct {
+		in NetworkInterface
+		e  bool
+	}{
+		"empty": {
+			e: true,
+		},
+
+		"full": {
+			in: NetworkInterface{Name: "eth0", Index: 2},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.IsEmpty())
+		})
+	}
+}

--- a/pkg/hubble/ir/policy.go
+++ b/pkg/hubble/ir/policy.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package ir
+
+import "github.com/cilium/cilium/api/v1/flow"
+
+// Policy tracks flow policy matching information.
+type Policy struct {
+	Kind      string   `json:"kind,omitempty"`
+	Namespace string   `json:"namespace,omitempty"`
+	Name      string   `json:"name,omitempty"`
+	Labels    []string `json:"labels,omitempty"`
+	Revision  uint64   `json:"revision,omitempty"`
+}
+
+// ProtoToPolicy converts a protobuf policy to an internal policy.
+func ProtoToPolicy(p *flow.Policy) Policy {
+	if p == nil {
+		return Policy{}
+	}
+
+	return Policy{
+		Kind:      p.Kind,
+		Namespace: p.Namespace,
+		Name:      p.Name,
+		Labels:    p.Labels,
+		Revision:  p.Revision,
+	}
+}
+
+func protoToPolicies(p []*flow.Policy) []Policy {
+	if len(p) == 0 {
+		return nil
+	}
+
+	policies := make([]Policy, 0, len(p))
+	for i := range p {
+		policies = append(policies, ProtoToPolicy(p[i]))
+	}
+
+	return policies
+}
+
+func policiesToProto(p []Policy) []*flow.Policy {
+	if len(p) == 0 {
+		return nil
+	}
+
+	policies := make([]*flow.Policy, 0, len(p))
+	for i := range p {
+		policies = append(policies, &flow.Policy{
+			Kind:      p[i].Kind,
+			Namespace: p[i].Namespace,
+			Name:      p[i].Name,
+			Labels:    p[i].Labels,
+			Revision:  p[i].Revision,
+		})
+	}
+
+	return policies
+}

--- a/pkg/hubble/ir/policy_test.go
+++ b/pkg/hubble/ir/policy_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package ir
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/api/v1/flow"
+)
+
+func TestFromPolicy(t *testing.T) {
+	uu := map[string]struct {
+		in *flow.Policy
+		e  Policy
+	}{
+		"nil": {
+			e: Policy{},
+		},
+
+		"full": {
+			in: &flow.Policy{
+				Kind:      "Kubernetes",
+				Namespace: "default",
+				Name:      "test-policy",
+				Labels:    []string{"app=frontend", "env=prod"},
+				Revision:  42,
+			},
+			e: Policy{
+				Kind:      "Kubernetes",
+				Namespace: "default",
+				Name:      "test-policy",
+				Labels:    []string{"app=frontend", "env=prod"},
+				Revision:  42,
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, ProtoToPolicy(u.in))
+		})
+	}
+}

--- a/pkg/hubble/ir/reply.go
+++ b/pkg/hubble/ir/reply.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package ir
+
+import "google.golang.org/protobuf/types/known/wrapperspb"
+
+const (
+	ReplyUnknown Reply = iota
+	ReplyYes
+	ReplyNo
+)
+
+// Reply tracks flow reply information.
+type Reply uint8
+
+// IsEmpty returns true if the Reply value is unknown.
+func (r Reply) IsEmpty() bool {
+	return r == ReplyUnknown
+}
+
+// ToBool converts the Reply value to a boolean, treating unknown as false.
+func (r Reply) ToBool() bool {
+	return r == ReplyYes
+}
+
+func (r Reply) toProto() *wrapperspb.BoolValue {
+	if r.IsEmpty() {
+		return nil
+	}
+
+	if r == ReplyYes {
+		return &wrapperspb.BoolValue{Value: true}
+	}
+
+	return &wrapperspb.BoolValue{Value: false}
+}
+
+// ProtoToReply converts a protobuf BoolValue to an internal representation.
+func ProtoToReply(r *wrapperspb.BoolValue) Reply {
+	if r == nil {
+		return ReplyUnknown
+	}
+
+	if r.Value {
+		return ReplyYes
+	}
+
+	return ReplyNo
+}

--- a/pkg/hubble/ir/reply_test.go
+++ b/pkg/hubble/ir/reply_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package ir
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func TestProtoToReply(t *testing.T) {
+	uu := map[string]struct {
+		in *wrapperspb.BoolValue
+		e  Reply
+	}{
+		"nil": {
+			e: ReplyUnknown,
+		},
+
+		"reply": {
+			in: wrapperspb.Bool(true),
+			e:  ReplyYes,
+		},
+
+		"no-reply": {
+			in: wrapperspb.Bool(false),
+			e:  ReplyNo,
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, ProtoToReply(u.in))
+		})
+	}
+}
+
+func TestReplyIsEmpty(t *testing.T) {
+	uu := map[string]struct {
+		in Reply
+		e  bool
+	}{
+		"unset": {
+			in: ReplyUnknown,
+			e:  true,
+		},
+
+		"yes": {
+			in: ReplyYes,
+		},
+
+		"no": {
+			in: ReplyNo,
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.IsEmpty())
+		})
+	}
+}
+
+func TestReply_toProto(t *testing.T) {
+	uu := map[string]struct {
+		in Reply
+		e  *wrapperspb.BoolValue
+	}{
+		"unset": {
+			in: ReplyUnknown,
+		},
+
+		"reply": {
+			in: ReplyYes,
+			e:  wrapperspb.Bool(true),
+		},
+
+		"no-reply": {
+			in: ReplyNo,
+			e:  wrapperspb.Bool(false),
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.toProto())
+		})
+	}
+}

--- a/pkg/hubble/ir/service.go
+++ b/pkg/hubble/ir/service.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import "github.com/cilium/cilium/api/v1/flow"
+
+// Service tracks a k8s service.
+type Service struct {
+	Name      string `json:"name,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+}
+
+// IsEmpty returns true if target has no data.
+func (s Service) IsEmpty() bool {
+	return s.Name == "" && s.Namespace == ""
+}
+
+func (s Service) toProto() *flow.Service {
+	if s.IsEmpty() {
+		return nil
+	}
+
+	return &flow.Service{
+		Name:      s.Name,
+		Namespace: s.Namespace,
+	}
+}
+
+// ProtoToService converts protobuf representation to an internal representation.
+func ProtoToService(s *flow.Service) Service {
+	if s == nil {
+		return Service{}
+	}
+
+	return Service{
+		Name:      s.Name,
+		Namespace: s.Namespace,
+	}
+}

--- a/pkg/hubble/ir/service.go
+++ b/pkg/hubble/ir/service.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import (
+	"github.com/cilium/cilium/api/v1/flow"
+)
+
+// Service tracks a k8s service.
+type Service struct {
+	Name      string `json:"name,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+}
+
+// NewService creates a new instance.
+func NewService(name, namespace string) Service {
+	return Service{
+		Name:      name,
+		Namespace: namespace,
+	}
+}
+
+// IsEmpty returns true if target has no data.
+func (s Service) IsEmpty() bool {
+	return s.Name == "" && s.Namespace == ""
+}
+
+func (s Service) toProto() *flow.Service {
+	if s.IsEmpty() {
+		return nil
+	}
+
+	return &flow.Service{
+		Name:      s.Name,
+		Namespace: s.Namespace,
+	}
+}
+
+// ProtoToService converts protobuf representation to an internal representation.
+func ProtoToService(s *flow.Service) Service {
+	if s == nil {
+		return Service{}
+	}
+
+	return Service{
+		Name:      s.Name,
+		Namespace: s.Namespace,
+	}
+}

--- a/pkg/hubble/ir/service_test.go
+++ b/pkg/hubble/ir/service_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package ir
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/api/v1/flow"
+)
+
+func TestProtoToService(t *testing.T) {
+	uu := map[string]struct {
+		in *flow.Service
+		e  Service
+	}{
+		"none": {
+			e: Service{},
+		},
+
+		"full": {
+			in: &flow.Service{
+				Name:      "svc1",
+				Namespace: "ns1",
+			},
+			e: Service{
+				Name:      "svc1",
+				Namespace: "ns1",
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, ProtoToService(u.in))
+		})
+	}
+}
+
+func TestService_toProto(t *testing.T) {
+	uu := map[string]struct {
+		in Service
+		e  *flow.Service
+	}{
+		"empty": {},
+
+		"full": {
+			in: Service{
+				Name:      "svc1",
+				Namespace: "ns1",
+			},
+			e: &flow.Service{
+				Name:      "svc1",
+				Namespace: "ns1",
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.toProto())
+		})
+	}
+}
+
+func TestService_isEmpty(t *testing.T) {
+	uu := map[string]struct {
+		in Service
+		e  bool
+	}{
+		"empty": {
+			e: true,
+		},
+
+		"full": {
+			in: Service{
+				Name:      "svc1",
+				Namespace: "ns1",
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.IsEmpty())
+		})
+	}
+}

--- a/pkg/hubble/ir/trace.go
+++ b/pkg/hubble/ir/trace.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import (
+	"github.com/cilium/cilium/api/v1/flow"
+)
+
+// TraceParent tracks trace parent information.
+type TraceParent struct {
+	TraceID string `json:"trace_id,omitempty"`
+}
+
+// IsEmpty returns true if target has no data.
+func (t TraceParent) IsEmpty() bool {
+	return t.TraceID == ""
+}
+
+// TraceContext tracks trace context information.
+type TraceContext struct {
+	Parent TraceParent `json:"parent,omitempty"`
+}
+
+// IsEmpty returns true if target has no data.
+func (t TraceContext) IsEmpty() bool {
+	return t.Parent.IsEmpty()
+}
+
+func (t TraceContext) toProto() *flow.TraceContext {
+	if t.IsEmpty() {
+		return nil
+	}
+
+	return &flow.TraceContext{
+		Parent: &flow.TraceParent{
+			TraceId: t.Parent.TraceID,
+		},
+	}
+}
+
+// ProtoToTraceContext converts a protobuf TraceContext to an internal shape.
+func ProtoToTraceContext(t *flow.TraceContext) TraceContext {
+	if t == nil {
+		return TraceContext{}
+	}
+	return TraceContext{
+		Parent: TraceParent{
+			TraceID: t.Parent.TraceId,
+		},
+	}
+}

--- a/pkg/hubble/ir/trace_test.go
+++ b/pkg/hubble/ir/trace_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/api/v1/flow"
+)
+
+func TestProtoToTraceContext(t *testing.T) {
+	uu := map[string]struct {
+		in *flow.TraceContext
+		e  TraceContext
+	}{
+		"empty": {},
+
+		"full": {
+			in: &flow.TraceContext{
+				Parent: &flow.TraceParent{
+					TraceId: "p1",
+				},
+			},
+			e: TraceContext{
+				Parent: TraceParent{
+					TraceID: "p1",
+				},
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, ProtoToTraceContext(u.in))
+		})
+	}
+}
+
+func TestTraceContext_toProto(t *testing.T) {
+	uu := map[string]struct {
+		in TraceContext
+		e  *flow.TraceContext
+	}{
+		"empty": {},
+
+		"full": {
+			in: TraceContext{
+				Parent: TraceParent{
+					TraceID: "p1",
+				},
+			},
+			e: &flow.TraceContext{
+				Parent: &flow.TraceParent{
+					TraceId: "p1",
+				},
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.toProto())
+		})
+	}
+}
+
+func TestTraceContextIsEmpty(t *testing.T) {
+	uu := map[string]struct {
+		in TraceContext
+		e  bool
+	}{
+		"empty": {
+			e: true,
+		},
+
+		"full": {
+			in: TraceContext{
+				Parent: TraceParent{
+					TraceID: "p1",
+				},
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.IsEmpty())
+		})
+	}
+}

--- a/pkg/hubble/ir/tunnel.go
+++ b/pkg/hubble/ir/tunnel.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import "github.com/cilium/cilium/api/v1/flow"
+
+// Tunnel tracks flow tunnel information.
+type Tunnel struct {
+	IP       IP                   `json:"ip,omitempty"`
+	L4       Layer4               `json:"l4,omitempty"`
+	Vni      uint32               `json:"vni,omitempty"`
+	Protocol flow.Tunnel_Protocol `json:"protocol,omitempty"`
+}
+
+// IsEmpty returns true if target has no data.
+// NOTE: Leaving protocol and vni fields unchecked since if no other fields are set the Tunnel should be deemed empty.
+func (t Tunnel) IsEmpty() bool {
+	return t.IP.IsEmpty() && t.L4.IsEmpty()
+}
+
+func (t Tunnel) toProto() *flow.Tunnel {
+	if t.IsEmpty() {
+		return nil
+	}
+
+	return &flow.Tunnel{
+		IP:       t.IP.toProto(),
+		L4:       t.L4.toProto(),
+		Vni:      t.Vni,
+		Protocol: t.Protocol,
+	}
+}
+
+func protoToTunnel(t *flow.Tunnel) Tunnel {
+	if t == nil {
+		return Tunnel{}
+	}
+
+	return Tunnel{
+		IP:       protoToIP(t.GetIP()),
+		L4:       protoToL4(t.GetL4()),
+		Vni:      t.GetVni(),
+		Protocol: t.Protocol,
+	}
+}

--- a/pkg/hubble/ir/tunnel_test.go
+++ b/pkg/hubble/ir/tunnel_test.go
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package ir
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/api/v1/flow"
+)
+
+func Test_protoToTunnel(t *testing.T) {
+	uu := map[string]struct {
+		in *flow.Tunnel
+		e  Tunnel
+	}{
+		"nil": {
+			e: Tunnel{},
+		},
+
+		"tcp": {
+			in: &flow.Tunnel{
+				Protocol: flow.Tunnel_VXLAN,
+				IP: &flow.IP{
+					Source:       "1.1.1.1",
+					Destination:  "2.2.2.2",
+					IpVersion:    flow.IPVersion_IPv4,
+					SourceXlated: "blee",
+					Encrypted:    true,
+				},
+				L4: &flow.Layer4{
+					Protocol: &flow.Layer4_TCP{
+						TCP: &flow.TCP{
+							SourcePort:      4789,
+							DestinationPort: 4789,
+						},
+					},
+				},
+			},
+			e: Tunnel{
+				Protocol: flow.Tunnel_VXLAN,
+				IP: IP{
+					Source:       "1.1.1.1",
+					Destination:  "2.2.2.2",
+					IPVersion:    flow.IPVersion_IPv4,
+					SourceXlated: "blee",
+					Encrypted:    true,
+				},
+				L4: Layer4{
+					TCP: TCP{
+						SourcePort:      4789,
+						DestinationPort: 4789,
+					},
+				},
+			},
+		},
+
+		"udp": {
+			in: &flow.Tunnel{
+				Protocol: flow.Tunnel_GENEVE,
+				IP: &flow.IP{
+					Source:      "2001:db8::1",
+					Destination: "2001:db8::2",
+					IpVersion:   flow.IPVersion_IPv6,
+				},
+				L4: &flow.Layer4{
+					Protocol: &flow.Layer4_UDP{
+						UDP: &flow.UDP{
+							SourcePort:      6081,
+							DestinationPort: 6081,
+						},
+					},
+				},
+			},
+			e: Tunnel{
+				Protocol: flow.Tunnel_GENEVE,
+				IP: IP{
+					Source:      "2001:db8::1",
+					Destination: "2001:db8::2",
+					IPVersion:   flow.IPVersion_IPv6,
+				},
+				L4: Layer4{
+					UDP: UDP{
+						SourcePort:      6081,
+						DestinationPort: 6081,
+					},
+				},
+			},
+		},
+
+		"icmpv4": {
+			in: &flow.Tunnel{
+				Protocol: flow.Tunnel_GENEVE,
+				IP: &flow.IP{
+					Source:      "1.1.1.1",
+					Destination: "2.2.2.2",
+					IpVersion:   flow.IPVersion_IPv4,
+				},
+				L4: &flow.Layer4{
+					Protocol: &flow.Layer4_ICMPv4{
+						ICMPv4: &flow.ICMPv4{
+							Type: 4,
+							Code: 0,
+						},
+					},
+				},
+			},
+			e: Tunnel{
+				Protocol: flow.Tunnel_GENEVE,
+				IP: IP{
+					Destination: "2.2.2.2",
+					Source:      "1.1.1.1",
+					IPVersion:   flow.IPVersion_IPv4,
+				},
+				L4: Layer4{
+					ICMPv4: ICMP{
+						Type: 4,
+						Code: 0,
+					},
+				},
+			},
+		},
+
+		"icmpv6": {
+			in: &flow.Tunnel{
+				Protocol: flow.Tunnel_VXLAN,
+				IP: &flow.IP{
+					Source:      "2001:db8::1",
+					Destination: "2001:db8::2",
+					IpVersion:   flow.IPVersion_IPv6,
+				},
+				L4: &flow.Layer4{
+					Protocol: &flow.Layer4_ICMPv6{
+						ICMPv6: &flow.ICMPv6{
+							Type: 135,
+							Code: 0,
+						},
+					},
+				},
+			},
+			e: Tunnel{
+				Protocol: flow.Tunnel_VXLAN,
+				IP: IP{
+					Source:      "2001:db8::1",
+					Destination: "2001:db8::2",
+					IPVersion:   flow.IPVersion_IPv6,
+				},
+				L4: Layer4{
+					ICMPv6: ICMP{
+						Type: 135,
+						Code: 0,
+					},
+				},
+			},
+		},
+
+		"sctp": {
+			in: &flow.Tunnel{
+				Protocol: flow.Tunnel_VXLAN,
+				IP: &flow.IP{
+					Source:      "1.1.1.1",
+					Destination: "2.2.2.2",
+					IpVersion:   flow.IPVersion_IPv4,
+				},
+				L4: &flow.Layer4{
+					Protocol: &flow.Layer4_SCTP{
+						SCTP: &flow.SCTP{
+							SourcePort:      1234,
+							DestinationPort: 5678,
+						},
+					},
+				},
+			},
+			e: Tunnel{
+				Protocol: flow.Tunnel_VXLAN,
+				IP: IP{
+					Source:      "1.1.1.1",
+					Destination: "2.2.2.2",
+					IPVersion:   flow.IPVersion_IPv4,
+				},
+				L4: Layer4{
+					SCTP: SCTP{
+						SourcePort:      1234,
+						DestinationPort: 5678,
+					},
+				},
+			},
+		},
+
+		"vrrp": {
+			in: &flow.Tunnel{
+				Protocol: flow.Tunnel_GENEVE,
+				IP: &flow.IP{
+					Source:      "2001:db8::1",
+					Destination: "2001:db8::2",
+					IpVersion:   flow.IPVersion_IPv6,
+				},
+				L4: &flow.Layer4{
+					Protocol: &flow.Layer4_VRRP{
+						VRRP: &flow.VRRP{
+							Type:     1,
+							Vrid:     42,
+							Priority: 100,
+						},
+					},
+				},
+			},
+			e: Tunnel{
+				Protocol: flow.Tunnel_GENEVE,
+				IP: IP{
+					Source:      "2001:db8::1",
+					Destination: "2001:db8::2",
+					IPVersion:   flow.IPVersion_IPv6,
+				},
+				L4: Layer4{
+					VRRP: VRRP{
+						Type:     1,
+						VRID:     42,
+						Priority: 100,
+					},
+				},
+			},
+		},
+
+		"igmp": {
+			in: &flow.Tunnel{
+				Protocol: flow.Tunnel_VXLAN,
+				IP: &flow.IP{
+					Source:      "1.1.1.1",
+					Destination: "2.2.2.2",
+					IpVersion:   flow.IPVersion_IPv4,
+				},
+			},
+			e: Tunnel{
+				Protocol: flow.Tunnel_VXLAN,
+				IP: IP{
+					Source:      "1.1.1.1",
+					Destination: "2.2.2.2",
+					IPVersion:   flow.IPVersion_IPv4,
+				},
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, protoToTunnel(u.in))
+		})
+	}
+}
+
+func TestTunnel_toProto(t *testing.T) {
+	uu := map[string]struct {
+		in Tunnel
+		e  *flow.Tunnel
+	}{
+		"empty": {
+			e: nil,
+		},
+
+		"tcp": {
+			in: Tunnel{
+				Protocol: flow.Tunnel_VXLAN,
+				IP: IP{
+					Source:       "1.1.1.1",
+					Destination:  "2.2.2.2",
+					IPVersion:    flow.IPVersion_IPv4,
+					SourceXlated: "3.3.3.3",
+					Encrypted:    true,
+				},
+				L4: Layer4{
+					TCP: TCP{
+						SourcePort:      4789,
+						DestinationPort: 4789,
+					},
+				},
+			},
+			e: &flow.Tunnel{
+				Protocol: flow.Tunnel_VXLAN,
+				IP: &flow.IP{
+					Source:       "1.1.1.1",
+					Destination:  "2.2.2.2",
+					IpVersion:    flow.IPVersion_IPv4,
+					SourceXlated: "3.3.3.3",
+					Encrypted:    true,
+				},
+				L4: &flow.Layer4{
+					Protocol: &flow.Layer4_TCP{
+						TCP: &flow.TCP{
+							SourcePort:      4789,
+							DestinationPort: 4789,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.toProto())
+		})
+	}
+}

--- a/pkg/hubble/ir/workload.go
+++ b/pkg/hubble/ir/workload.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import "github.com/cilium/cilium/api/v1/flow"
+
+// Workloads tracks workloads
+type Workloads []Workload
+
+func (ws Workloads) toProto() []*flow.Workload {
+	if len(ws) == 0 {
+		return nil
+	}
+
+	workloads := make([]*flow.Workload, len(ws))
+	for i := range ws {
+		workloads[i] = &flow.Workload{
+			Name: ws[i].Name,
+			Kind: ws[i].Kind,
+		}
+	}
+
+	return workloads
+}
+
+// ProtoToWorkloads converts a protobuf Workloads slice to an internal representation.
+func ProtoToWorkloads(ww []*flow.Workload) Workloads {
+	if len(ww) == 0 {
+		return nil
+	}
+
+	workloads := make([]Workload, 0, len(ww))
+	for i := range ww {
+		workloads = append(workloads, protoToWorkload(ww[i]))
+	}
+
+	return workloads
+}
+
+// Workload tracks a flow workload information.
+type Workload struct {
+	Name string `json:"name,omitempty"`
+	Kind string `json:"kind,omitempty"`
+}
+
+// IsEmpty returns true if the workload has no information set.
+func (w Workload) IsEmpty() bool {
+	return w.Name == "" && w.Kind == ""
+}
+
+func (w Workload) toProto() *flow.Workload {
+	if w.IsEmpty() {
+		return nil
+	}
+
+	return &flow.Workload{
+		Name: w.Name,
+		Kind: w.Kind,
+	}
+}
+
+func protoToWorkload(w *flow.Workload) Workload {
+	if w == nil {
+		return Workload{}
+	}
+
+	return Workload{
+		Name: w.Name,
+		Kind: w.Kind,
+	}
+}

--- a/pkg/hubble/ir/workload_test.go
+++ b/pkg/hubble/ir/workload_test.go
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ir
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/api/v1/flow"
+)
+
+func TestWorkloads_toProto(t *testing.T) {
+	uu := map[string]struct {
+		in Workloads
+		e  []*flow.Workload
+	}{
+		"none": {},
+
+		"empty": {
+			in: make(Workloads, 0),
+		},
+
+		"full": {
+			in: Workloads{
+				Workload{
+					Name: "blee",
+					Kind: "duh",
+				},
+				Workload{
+					Name: "fred",
+					Kind: "duh",
+				},
+			},
+			e: []*flow.Workload{
+				{
+					Name: "blee",
+					Kind: "duh",
+				},
+				{
+					Name: "fred",
+					Kind: "duh",
+				},
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, u.in.toProto())
+		})
+	}
+}
+
+func TestWorkload_toProto(t *testing.T) {
+	uu := map[string]struct {
+		in Workload
+		e  *flow.Workload
+	}{
+		"empty": {},
+
+		"filled": {
+			in: Workload{
+				Name: "blee",
+				Kind: "duh",
+			},
+			e: &flow.Workload{
+				Name: "blee",
+				Kind: "duh",
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			a := u.in.toProto()
+			assert.Equal(t, u.e, a)
+		})
+	}
+}
+
+func TestProtoToWorkloads(t *testing.T) {
+	uu := map[string]struct {
+		in []*flow.Workload
+		e  Workloads
+	}{
+		"none": {},
+
+		"empty": {
+			in: make([]*flow.Workload, 0),
+		},
+
+		"full": {
+			in: []*flow.Workload{
+				{
+					Name: "blee",
+					Kind: "duh",
+				},
+				{
+					Name: "fred",
+					Kind: "duh",
+				},
+			},
+			e: Workloads{
+				Workload{
+					Name: "blee",
+					Kind: "duh",
+				},
+				Workload{
+					Name: "fred",
+					Kind: "duh",
+				},
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, u.e, ProtoToWorkloads(u.in))
+		})
+	}
+}
+
+func Test_protoToWorkload(t *testing.T) {
+	uu := map[string]struct {
+		in *flow.Workload
+		e  Workload
+	}{
+		"none": {},
+
+		"partial": {
+			in: &flow.Workload{
+				Name: "foo",
+			},
+			e: Workload{
+				Name: "foo",
+			},
+		},
+
+		"full": {
+			in: &flow.Workload{
+				Name: "foo",
+				Kind: "bar",
+			},
+			e: Workload{
+				Name: "foo",
+				Kind: "bar",
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			a := protoToWorkload(u.in)
+			assert.Equal(t, u.e, a)
+		})
+	}
+}
+
+func TestWorkloadIsEmpty(t *testing.T) {
+	uu := map[string]struct {
+		in Workload
+		e  bool
+	}{
+		"empty": {
+			e: true,
+		},
+
+		"partial": {
+			in: Workload{
+				Name: "foo",
+			},
+		},
+
+		"full": {
+			in: Workload{
+				Name: "foo",
+				Kind: "bar",
+			},
+		},
+	}
+
+	for name, u := range uu {
+		t.Run(name, func(t *testing.T) {
+			a := u.in.IsEmpty()
+			assert.Equal(t, u.e, a)
+		})
+	}
+}

--- a/pkg/hubble/metrics/api/api.go
+++ b/pkg/hubble/metrics/api/api.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	pb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
@@ -66,7 +67,7 @@ type Handler interface {
 
 	// ProcessFlow must processes a flow event and perform metrics
 	// accounting
-	ProcessFlow(ctx context.Context, flow *pb.Flow) error
+	ProcessFlow(ctx context.Context, flow *ir.Flow) error
 }
 
 func InitHandlers(log *slog.Logger, registry *prometheus.Registry, in *[]NamedHandler) (*[]NamedHandler, error) {

--- a/pkg/hubble/metrics/api/context.go
+++ b/pkg/hubble/metrics/api/context.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	pb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	ciliumLabels "github.com/cilium/cilium/pkg/labels"
 )
@@ -286,12 +287,12 @@ func (ls labelsSet) String() string {
 	return b.String()
 }
 
-func labelsContext(invertSourceDestination bool, wantedLabels labelsSet, flow *pb.Flow) (outputLabels []string, err error) {
-	source, destination := flow.GetSource(), flow.GetDestination()
-	sourceIp, destinationIp := flow.GetIP().GetSource(), flow.GetIP().GetDestination()
+func labelsContext(invertSourceDestination bool, wantedLabels labelsSet, flow *ir.Flow) (outputLabels []string, err error) {
+	source, destination := flow.Source, flow.Destination
+	sourceIp, destinationIp := flow.IP.Source, flow.IP.Destination
 	if invertSourceDestination {
-		source, destination = flow.GetDestination(), flow.GetSource()
-		sourceIp, destinationIp = flow.GetIP().GetDestination(), flow.GetIP().GetSource()
+		source, destination = flow.Destination, flow.Source
+		sourceIp, destinationIp = flow.IP.Destination, flow.IP.Source
 	}
 	// Iterate over contextLabelsList so that the label order is stable,
 	// otherwise GetLabelNames and GetLabelValues might be mismatched
@@ -302,37 +303,37 @@ func labelsContext(invertSourceDestination bool, wantedLabels labelsSet, flow *p
 			case "source_ip":
 				labelValue = sourceIp
 			case "source_pod":
-				labelValue = source.GetPodName()
+				labelValue = source.PodName
 			case "source_namespace":
-				labelValue = source.GetNamespace()
+				labelValue = source.Namespace
 			case "source_workload":
-				if workloads := source.GetWorkloads(); len(workloads) != 0 {
+				if workloads := source.Workloads; len(workloads) != 0 {
 					labelValue = workloads[0].Name
 				}
 			case "source_workload_kind":
-				if workloads := source.GetWorkloads(); len(workloads) != 0 {
+				if workloads := source.Workloads; len(workloads) != 0 {
 					labelValue = workloads[0].Kind
 				}
 			case "source_app":
-				labelValue = getK8sAppFromLabels(source.GetLabels())
+				labelValue = getK8sAppFromLabels(source.Labels)
 			case "destination_ip":
 				labelValue = destinationIp
 			case "destination_pod":
-				labelValue = destination.GetPodName()
+				labelValue = destination.PodName
 			case "destination_namespace":
-				labelValue = destination.GetNamespace()
+				labelValue = destination.Namespace
 			case "destination_workload":
-				if workloads := destination.GetWorkloads(); len(workloads) != 0 {
+				if workloads := destination.Workloads; len(workloads) != 0 {
 					labelValue = workloads[0].Name
 				}
 			case "destination_workload_kind":
-				if workloads := destination.GetWorkloads(); len(workloads) != 0 {
+				if workloads := destination.Workloads; len(workloads) != 0 {
 					labelValue = workloads[0].Kind
 				}
 			case "destination_app":
-				labelValue = getK8sAppFromLabels(destination.GetLabels())
+				labelValue = getK8sAppFromLabels(destination.Labels)
 			case "traffic_direction":
-				direction := flow.GetTrafficDirection()
+				direction := flow.TrafficDirection
 				if direction == pb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN {
 					labelValue = "unknown"
 				} else {
@@ -380,7 +381,7 @@ func getK8sAppFromLabels(labels []string) string {
 // GetLabelValues returns the values of the context relevant labels according
 // to the configured options. The order of the values is the same as the order
 // of the label names returned by GetLabelNames()
-func (o *ContextOptions) GetLabelValues(flow *pb.Flow) (labels []string, err error) {
+func (o *ContextOptions) GetLabelValues(flow *ir.Flow) (labels []string, err error) {
 	return o.getLabelValues(false, flow)
 }
 
@@ -388,7 +389,7 @@ func (o *ContextOptions) GetLabelValues(flow *pb.Flow) (labels []string, err err
 // source and destination labels are inverted. This is primarily for metrics
 // that leverage the response/return flows where the source and destination are
 // swapped from the request flow.
-func (o *ContextOptions) GetLabelValuesInvertSourceDestination(flow *pb.Flow) (labels []string, err error) {
+func (o *ContextOptions) GetLabelValuesInvertSourceDestination(flow *ir.Flow) (labels []string, err error) {
 	return o.getLabelValues(true, flow)
 }
 
@@ -396,7 +397,7 @@ func (o *ContextOptions) GetLabelValuesInvertSourceDestination(flow *pb.Flow) (l
 // to the configured options. The order of the values is the same as the order
 // of the label names returned by GetLabelNames(). If invert is true, the
 // source and destination related labels are inverted.
-func (o *ContextOptions) getLabelValues(invert bool, flow *pb.Flow) (labels []string, err error) {
+func (o *ContextOptions) getLabelValues(invert bool, flow *ir.Flow) (labels []string, err error) {
 	if len(o.Labels) != 0 {
 		labelsContextLabels, err := labelsContext(invert, o.Labels, flow)
 		if err != nil {
@@ -407,9 +408,9 @@ func (o *ContextOptions) getLabelValues(invert bool, flow *pb.Flow) (labels []st
 
 	var sourceLabel string
 	var sourceContextIdentifiers = o.Source
-	if o.SourceIngress != nil && flow.GetTrafficDirection() == pb.TrafficDirection_INGRESS {
+	if o.SourceIngress != nil && flow.TrafficDirection == pb.TrafficDirection_INGRESS {
 		sourceContextIdentifiers = o.SourceIngress
-	} else if o.SourceEgress != nil && flow.GetTrafficDirection() == pb.TrafficDirection_EGRESS {
+	} else if o.SourceEgress != nil && flow.TrafficDirection == pb.TrafficDirection_EGRESS {
 		sourceContextIdentifiers = o.SourceEgress
 	}
 
@@ -423,9 +424,9 @@ func (o *ContextOptions) getLabelValues(invert bool, flow *pb.Flow) (labels []st
 
 	var destinationLabel string
 	var destinationContextIdentifiers = o.Destination
-	if o.DestinationIngress != nil && flow.GetTrafficDirection() == pb.TrafficDirection_INGRESS {
+	if o.DestinationIngress != nil && flow.TrafficDirection == pb.TrafficDirection_INGRESS {
 		destinationContextIdentifiers = o.DestinationIngress
-	} else if o.DestinationEgress != nil && flow.GetTrafficDirection() == pb.TrafficDirection_EGRESS {
+	} else if o.DestinationEgress != nil && flow.TrafficDirection == pb.TrafficDirection_EGRESS {
 		destinationContextIdentifiers = o.DestinationEgress
 	}
 	for _, contextID := range destinationContextIdentifiers {
@@ -448,53 +449,53 @@ func (o *ContextOptions) getLabelValues(invert bool, flow *pb.Flow) (labels []st
 	return
 }
 
-func getContextIDLabelValue(contextID ContextIdentifier, flow *pb.Flow, source bool) string {
-	var ep *pb.Endpoint
+func getContextIDLabelValue(contextID ContextIdentifier, flow *ir.Flow, source bool) string {
+	var ep ir.Endpoint
 	if source {
-		ep = flow.GetSource()
+		ep = flow.Source
 	} else {
-		ep = flow.GetDestination()
+		ep = flow.Destination
 	}
 	var labelValue string
 	switch contextID {
 	case ContextNamespace:
-		labelValue = ep.GetNamespace()
+		labelValue = ep.Namespace
 	case ContextIdentity:
-		labelValue = strings.Join(ep.GetLabels(), ",")
+		labelValue = strings.Join(ep.Labels, ",")
 	case ContextPod:
-		labelValue = ep.GetPodName()
-		if ep.GetNamespace() != "" {
-			labelValue = ep.GetNamespace() + "/" + labelValue
+		labelValue = ep.PodName
+		if ep.Namespace != "" {
+			labelValue = ep.Namespace + "/" + labelValue
 		}
 	case ContextPodName:
-		labelValue = ep.GetPodName()
+		labelValue = ep.PodName
 	case ContextDNS:
 		if source {
-			labelValue = strings.Join(flow.GetSourceNames(), ",")
+			labelValue = strings.Join(flow.SourceNames, ",")
 		} else {
-			labelValue = strings.Join(flow.GetDestinationNames(), ",")
+			labelValue = strings.Join(flow.DestinationNames, ",")
 		}
 	case ContextIP:
 		if source {
-			labelValue = flow.GetIP().GetSource()
+			labelValue = flow.IP.Source
 		} else {
-			labelValue = flow.GetIP().GetDestination()
+			labelValue = flow.IP.Destination
 		}
 	case ContextReservedIdentity:
-		labelValue = handleReservedIdentityLabels(ep.GetLabels())
+		labelValue = handleReservedIdentityLabels(ep.Labels)
 	case ContextWorkload:
-		if workloads := ep.GetWorkloads(); len(workloads) != 0 {
+		if workloads := ep.Workloads; len(workloads) != 0 {
 			labelValue = workloads[0].Name
 		}
-		if labelValue != "" && ep.GetNamespace() != "" {
-			labelValue = ep.GetNamespace() + "/" + labelValue
+		if labelValue != "" && ep.Namespace != "" {
+			labelValue = ep.Namespace + "/" + labelValue
 		}
 	case ContextWorkloadName:
-		if workloads := ep.GetWorkloads(); len(workloads) != 0 {
+		if workloads := ep.Workloads; len(workloads) != 0 {
 			labelValue = workloads[0].Name
 		}
 	case ContextApp:
-		labelValue = getK8sAppFromLabels(ep.GetLabels())
+		labelValue = getK8sAppFromLabels(ep.Labels)
 	}
 	return labelValue
 }

--- a/pkg/hubble/metrics/api/context_test.go
+++ b/pkg/hubble/metrics/api/context_test.go
@@ -8,10 +8,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/cilium/cilium/api/v1/flow"
 	pb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 )
 
-func mustGetLabelValues(opts *ContextOptions, flow *pb.Flow) []string {
+func mustGetLabelValues(opts *ContextOptions, flow *ir.Flow) []string {
 	labels, err := opts.GetLabelValues(flow)
 	if err != nil {
 		panic(err)
@@ -191,7 +193,7 @@ func TestParseGetLabelValues(t *testing.T) {
 		},
 	)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"foo"}, mustGetLabelValues(opts, &pb.Flow{Source: &pb.Endpoint{Namespace: "foo"}}))
+	assert.Equal(t, []string{"foo"}, mustGetLabelValues(opts, &ir.Flow{Source: ir.Endpoint{Namespace: "foo"}}))
 
 	opts, err = ParseContextOptions(
 		[]*ContextOptionConfig{
@@ -202,7 +204,7 @@ func TestParseGetLabelValues(t *testing.T) {
 		},
 	)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"foo"}, mustGetLabelValues(opts, &pb.Flow{Destination: &pb.Endpoint{Namespace: "foo"}}))
+	assert.Equal(t, []string{"foo"}, mustGetLabelValues(opts, &ir.Flow{Destination: ir.Endpoint{Namespace: "foo"}}))
 
 	opts, err = ParseContextOptions(
 		[]*ContextOptionConfig{
@@ -217,9 +219,9 @@ func TestParseGetLabelValues(t *testing.T) {
 		},
 	)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"foo", "a,b"}, mustGetLabelValues(opts, &pb.Flow{
-		Source:      &pb.Endpoint{Namespace: "foo"},
-		Destination: &pb.Endpoint{Labels: []string{"a", "b"}},
+	assert.Equal(t, []string{"foo", "a,b"}, mustGetLabelValues(opts, &ir.Flow{
+		Source:      ir.Endpoint{Namespace: "foo"},
+		Destination: ir.Endpoint{Labels: []string{"a", "b"}},
 	}))
 
 	opts, err = ParseContextOptions(
@@ -231,7 +233,7 @@ func TestParseGetLabelValues(t *testing.T) {
 		},
 	)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"foo/foo"}, mustGetLabelValues(opts, &pb.Flow{Source: &pb.Endpoint{Namespace: "foo", PodName: "foo"}}))
+	assert.Equal(t, []string{"foo/foo"}, mustGetLabelValues(opts, &ir.Flow{Source: ir.Endpoint{Namespace: "foo", PodName: "foo"}}))
 
 	opts, err = ParseContextOptions(
 		[]*ContextOptionConfig{
@@ -242,7 +244,7 @@ func TestParseGetLabelValues(t *testing.T) {
 		},
 	)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"foo/bar"}, mustGetLabelValues(opts, &pb.Flow{Destination: &pb.Endpoint{Namespace: "foo", PodName: "bar"}}))
+	assert.Equal(t, []string{"foo/bar"}, mustGetLabelValues(opts, &ir.Flow{Destination: ir.Endpoint{Namespace: "foo", PodName: "bar"}}))
 
 	opts, err = ParseContextOptions(
 		[]*ContextOptionConfig{
@@ -253,7 +255,7 @@ func TestParseGetLabelValues(t *testing.T) {
 		},
 	)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"foo-123"}, mustGetLabelValues(opts, &pb.Flow{Source: &pb.Endpoint{Namespace: "foo", PodName: "foo-123"}}))
+	assert.Equal(t, []string{"foo-123"}, mustGetLabelValues(opts, &ir.Flow{Source: ir.Endpoint{Namespace: "foo", PodName: "foo-123"}}))
 
 	opts, err = ParseContextOptions(
 		[]*ContextOptionConfig{
@@ -264,7 +266,7 @@ func TestParseGetLabelValues(t *testing.T) {
 		},
 	)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"bar-123"}, mustGetLabelValues(opts, &pb.Flow{Destination: &pb.Endpoint{Namespace: "foo", PodName: "bar-123"}}))
+	assert.Equal(t, []string{"bar-123"}, mustGetLabelValues(opts, &ir.Flow{Destination: ir.Endpoint{Namespace: "foo", PodName: "bar-123"}}))
 
 	opts, err = ParseContextOptions(
 		[]*ContextOptionConfig{
@@ -275,7 +277,7 @@ func TestParseGetLabelValues(t *testing.T) {
 		},
 	)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"foo,bar"}, mustGetLabelValues(opts, &pb.Flow{SourceNames: []string{"foo", "bar"}}))
+	assert.Equal(t, []string{"foo,bar"}, mustGetLabelValues(opts, &ir.Flow{SourceNames: []string{"foo", "bar"}}))
 
 	opts, err = ParseContextOptions(
 		[]*ContextOptionConfig{
@@ -286,7 +288,7 @@ func TestParseGetLabelValues(t *testing.T) {
 		},
 	)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"bar"}, mustGetLabelValues(opts, &pb.Flow{DestinationNames: []string{"bar"}}))
+	assert.Equal(t, []string{"bar"}, mustGetLabelValues(opts, &ir.Flow{DestinationNames: []string{"bar"}}))
 
 	opts, err = ParseContextOptions(
 		[]*ContextOptionConfig{
@@ -297,7 +299,7 @@ func TestParseGetLabelValues(t *testing.T) {
 		},
 	)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"1.1.1.1"}, mustGetLabelValues(opts, &pb.Flow{IP: &pb.IP{Source: "1.1.1.1"}}))
+	assert.Equal(t, []string{"1.1.1.1"}, mustGetLabelValues(opts, &ir.Flow{IP: ir.IP{Source: "1.1.1.1"}}))
 
 	opts, err = ParseContextOptions(
 		[]*ContextOptionConfig{
@@ -308,7 +310,7 @@ func TestParseGetLabelValues(t *testing.T) {
 		},
 	)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"10.0.0.2"}, mustGetLabelValues(opts, &pb.Flow{IP: &pb.IP{Destination: "10.0.0.2"}}))
+	assert.Equal(t, []string{"10.0.0.2"}, mustGetLabelValues(opts, &ir.Flow{IP: ir.IP{Destination: "10.0.0.2"}}))
 
 	opts, err = ParseContextOptions(
 		[]*ContextOptionConfig{
@@ -325,10 +327,10 @@ func TestParseGetLabelValues(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t,
 		[]string{"foo/foo-123"},
-		mustGetLabelValues(opts, &pb.Flow{Source: &pb.Endpoint{Namespace: "foo", PodName: "foo-123", Workloads: []*pb.Workload{{Name: "worker"}}}, TrafficDirection: pb.TrafficDirection_EGRESS}))
+		mustGetLabelValues(opts, &ir.Flow{Source: ir.Endpoint{Namespace: "foo", PodName: "foo-123", Workloads: []ir.Workload{{Name: "worker"}}}, TrafficDirection: flow.TrafficDirection_EGRESS}))
 	assert.Equal(t,
 		[]string{"worker"},
-		mustGetLabelValues(opts, &pb.Flow{Source: &pb.Endpoint{Namespace: "foo", PodName: "foo-123", Workloads: []*pb.Workload{{Name: "worker"}}}, TrafficDirection: pb.TrafficDirection_INGRESS}))
+		mustGetLabelValues(opts, &ir.Flow{Source: ir.Endpoint{Namespace: "foo", PodName: "foo-123", Workloads: []ir.Workload{{Name: "worker"}}}, TrafficDirection: flow.TrafficDirection_INGRESS}))
 
 	opts, err = ParseContextOptions(
 		[]*ContextOptionConfig{
@@ -350,7 +352,7 @@ func TestParseGetLabelValues(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t,
 		[]string{"worker"},
-		mustGetLabelValues(opts, &pb.Flow{Source: &pb.Endpoint{Namespace: "foo", PodName: "foo-123", Workloads: []*pb.Workload{{Name: "worker"}}}, TrafficDirection: pb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN}))
+		mustGetLabelValues(opts, &ir.Flow{Source: ir.Endpoint{Namespace: "foo", PodName: "foo-123", Workloads: []ir.Workload{{Name: "worker"}}}, TrafficDirection: flow.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN}))
 
 	opts, err = ParseContextOptions(
 		[]*ContextOptionConfig{
@@ -368,10 +370,10 @@ func TestParseGetLabelValues(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t,
 		[]string{"api"},
-		mustGetLabelValues(opts, &pb.Flow{Destination: &pb.Endpoint{Namespace: "foo", PodName: "foo-123", Workloads: []*pb.Workload{{Name: "api"}}}, TrafficDirection: pb.TrafficDirection_EGRESS}))
+		mustGetLabelValues(opts, &ir.Flow{Destination: ir.Endpoint{Namespace: "foo", PodName: "foo-123", Workloads: []ir.Workload{{Name: "api"}}}, TrafficDirection: flow.TrafficDirection_EGRESS}))
 	assert.Equal(t,
 		[]string{"foo/foo-123"},
-		mustGetLabelValues(opts, &pb.Flow{Destination: &pb.Endpoint{Namespace: "foo", PodName: "foo-123", Workloads: []*pb.Workload{{Name: "api"}}}, TrafficDirection: pb.TrafficDirection_INGRESS}))
+		mustGetLabelValues(opts, &ir.Flow{Destination: ir.Endpoint{Namespace: "foo", PodName: "foo-123", Workloads: []ir.Workload{{Name: "api"}}}, TrafficDirection: flow.TrafficDirection_INGRESS}))
 
 	opts, err = ParseContextOptions(
 		[]*ContextOptionConfig{
@@ -392,7 +394,7 @@ func TestParseGetLabelValues(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t,
 		[]string{"api"},
-		mustGetLabelValues(opts, &pb.Flow{Destination: &pb.Endpoint{Namespace: "foo", PodName: "foo-123", Workloads: []*pb.Workload{{Name: "api"}}}, TrafficDirection: pb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN}))
+		mustGetLabelValues(opts, &ir.Flow{Destination: ir.Endpoint{Namespace: "foo", PodName: "foo-123", Workloads: []ir.Workload{{Name: "api"}}}, TrafficDirection: flow.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN}))
 
 	opts, err = ParseContextOptions(
 		[]*ContextOptionConfig{
@@ -409,7 +411,7 @@ func TestParseGetLabelValues(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t,
 		[]string{""},
-		mustGetLabelValues(opts, &pb.Flow{Destination: &pb.Endpoint{Namespace: "foo", PodName: "foo-123"}, TrafficDirection: pb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN}))
+		mustGetLabelValues(opts, &ir.Flow{Destination: ir.Endpoint{Namespace: "foo", PodName: "foo-123"}, TrafficDirection: flow.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN}))
 
 	opts, err = ParseContextOptions(
 		[]*ContextOptionConfig{
@@ -422,13 +424,13 @@ func TestParseGetLabelValues(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t,
 		[]string{""},
-		mustGetLabelValues(opts, &pb.Flow{Source: &pb.Endpoint{Namespace: "foo", PodName: "foo-123", Workloads: []*pb.Workload{{Name: "worker"}}}, TrafficDirection: pb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN}))
+		mustGetLabelValues(opts, &ir.Flow{Source: ir.Endpoint{Namespace: "foo", PodName: "foo-123", Workloads: []ir.Workload{{Name: "worker"}}}, TrafficDirection: flow.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN}))
 	assert.Equal(t,
 		[]string{""},
-		mustGetLabelValues(opts, &pb.Flow{Source: &pb.Endpoint{Namespace: "foo", PodName: "foo-123", Workloads: []*pb.Workload{{Name: "api"}}}, TrafficDirection: pb.TrafficDirection_EGRESS}))
+		mustGetLabelValues(opts, &ir.Flow{Source: ir.Endpoint{Namespace: "foo", PodName: "foo-123", Workloads: []ir.Workload{{Name: "api"}}}, TrafficDirection: flow.TrafficDirection_EGRESS}))
 	assert.Equal(t,
 		[]string{"foo/foo-123"},
-		mustGetLabelValues(opts, &pb.Flow{Source: &pb.Endpoint{Namespace: "foo", PodName: "foo-123", Workloads: []*pb.Workload{{Name: "api"}}}, TrafficDirection: pb.TrafficDirection_INGRESS}))
+		mustGetLabelValues(opts, &ir.Flow{Source: ir.Endpoint{Namespace: "foo", PodName: "foo-123", Workloads: []ir.Workload{{Name: "api"}}}, TrafficDirection: flow.TrafficDirection_INGRESS}))
 
 	opts, err = ParseContextOptions(
 		[]*ContextOptionConfig{
@@ -443,32 +445,32 @@ func TestParseGetLabelValues(t *testing.T) {
 		},
 	)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"foo", "bar/foo-123"}, mustGetLabelValues(opts, &pb.Flow{
-		IP: &pb.IP{
+	assert.Equal(t, []string{"foo", "bar/foo-123"}, mustGetLabelValues(opts, &ir.Flow{
+		IP: ir.IP{
 			Destination: "10.0.0.2",
 		},
-		Source: &pb.Endpoint{
+		Source: ir.Endpoint{
 			Namespace: "foo",
 		},
 		SourceNames: []string{"cilium.io"},
-		Destination: &pb.Endpoint{
+		Destination: ir.Endpoint{
 			Namespace: "bar",
 			PodName:   "foo-123",
 		},
 	}))
-	assert.Equal(t, []string{"cilium.io", "a,b"}, mustGetLabelValues(opts, &pb.Flow{
-		IP: &pb.IP{
+	assert.Equal(t, []string{"cilium.io", "a,b"}, mustGetLabelValues(opts, &ir.Flow{
+		IP: ir.IP{
 			Destination: "10.0.0.2",
 		},
 		SourceNames: []string{"cilium.io"},
-		Destination: &pb.Endpoint{
+		Destination: ir.Endpoint{
 			Namespace: "bar",
 			PodName:   "foo-123",
 			Labels:    []string{"a", "b"},
 		},
 	}))
-	assert.Equal(t, []string{"", "10.0.0.2"}, mustGetLabelValues(opts, &pb.Flow{
-		IP: &pb.IP{
+	assert.Equal(t, []string{"", "10.0.0.2"}, mustGetLabelValues(opts, &ir.Flow{
+		IP: ir.IP{
 			Destination: "10.0.0.2",
 		},
 	}))
@@ -482,10 +484,10 @@ func TestParseGetLabelValues(t *testing.T) {
 		},
 	)
 	assert.NoError(t, err)
-	sourceEndpoint := &pb.Endpoint{
+	sourceEndpoint := ir.Endpoint{
 		Namespace: "foo-ns",
 		PodName:   "foo-deploy-pod",
-		Workloads: []*pb.Workload{{
+		Workloads: []ir.Workload{{
 			Name: "foo-deploy",
 			Kind: "Deployment",
 		}},
@@ -493,10 +495,10 @@ func TestParseGetLabelValues(t *testing.T) {
 			"k8s:app=fooapp",
 		},
 	}
-	destinationEndpoint := &pb.Endpoint{
+	destinationEndpoint := ir.Endpoint{
 		Namespace: "bar-ns",
 		PodName:   "bar-deploy-pod",
-		Workloads: []*pb.Workload{{
+		Workloads: []ir.Workload{{
 			Name: "bar-deploy",
 			Kind: "StatefulSet",
 		}},
@@ -504,8 +506,8 @@ func TestParseGetLabelValues(t *testing.T) {
 			"k8s:app=barapp",
 		},
 	}
-	flow := &pb.Flow{
-		IP: &pb.IP{
+	flow := ir.Flow{
+		IP: ir.IP{
 			Source:      "1.2.3.4",
 			Destination: "5.6.7.8",
 		},
@@ -521,7 +523,7 @@ func TestParseGetLabelValues(t *testing.T) {
 			"5.6.7.8", "bar-deploy-pod", "bar-ns", "bar-deploy", "StatefulSet", "barapp",
 			// traffic_direction
 			"ingress",
-		}, mustGetLabelValues(opts, flow),
+		}, mustGetLabelValues(opts, &flow),
 	)
 
 	// Empty flow should just produce empty values for source/destination labels,
@@ -531,7 +533,7 @@ func TestParseGetLabelValues(t *testing.T) {
 			"", "", "", "", "", "",
 			"", "", "", "", "", "",
 			"unknown",
-		}, mustGetLabelValues(opts, &pb.Flow{}),
+		}, mustGetLabelValues(opts, &ir.Flow{}),
 	)
 }
 
@@ -549,17 +551,17 @@ func Test_reservedIdentityContext(t *testing.T) {
 		},
 	)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"", ""}, mustGetLabelValues(opts, &pb.Flow{
-		Source:      &pb.Endpoint{Labels: []string{"a", "b"}},
-		Destination: &pb.Endpoint{Labels: []string{"c", "d"}},
+	assert.Equal(t, []string{"", ""}, mustGetLabelValues(opts, &ir.Flow{
+		Source:      ir.Endpoint{Labels: []string{"a", "b"}},
+		Destination: ir.Endpoint{Labels: []string{"c", "d"}},
 	}))
-	assert.Equal(t, []string{"reserved:kube-apiserver", "reserved:world"}, mustGetLabelValues(opts, &pb.Flow{
-		Source:      &pb.Endpoint{Labels: []string{"reserved:world", "reserved:kube-apiserver", "cidr:1.2.3.4/32"}},
-		Destination: &pb.Endpoint{Labels: []string{"reserved:world", "cidr:1.2.3.4/32"}},
+	assert.Equal(t, []string{"reserved:kube-apiserver", "reserved:world"}, mustGetLabelValues(opts, &ir.Flow{
+		Source:      ir.Endpoint{Labels: []string{"reserved:world", "reserved:kube-apiserver", "cidr:1.2.3.4/32"}},
+		Destination: ir.Endpoint{Labels: []string{"reserved:world", "cidr:1.2.3.4/32"}},
 	}))
-	assert.Equal(t, []string{"reserved:host", "reserved:remote-node"}, mustGetLabelValues(opts, &pb.Flow{
-		Source:      &pb.Endpoint{Labels: []string{"a", "b", "reserved:host"}},
-		Destination: &pb.Endpoint{Labels: []string{"c", "d", "reserved:remote-node"}},
+	assert.Equal(t, []string{"reserved:host", "reserved:remote-node"}, mustGetLabelValues(opts, &ir.Flow{
+		Source:      ir.Endpoint{Labels: []string{"a", "b", "reserved:host"}},
+		Destination: ir.Endpoint{Labels: []string{"c", "d", "reserved:remote-node"}},
 	}))
 }
 
@@ -578,12 +580,12 @@ func Test_workloadContext(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	assert.Equal(t, []string{"", ""}, mustGetLabelValues(opts, &pb.Flow{
-		Source:      &pb.Endpoint{Namespace: "foo-ns", PodName: "foo-deploy-pod"},
-		Destination: &pb.Endpoint{Namespace: "bar-ns", PodName: "bar-deploy-pod"}}))
-	assert.Equal(t, []string{"foo-ns/foo-deploy", "bar-ns/bar-deploy"}, mustGetLabelValues(opts, &pb.Flow{
-		Source:      &pb.Endpoint{Namespace: "foo-ns", PodName: "foo-deploy-pod", Workloads: []*pb.Workload{{Name: "foo-deploy", Kind: "Deployment"}}},
-		Destination: &pb.Endpoint{Namespace: "bar-ns", PodName: "bar-deploy-pod", Workloads: []*pb.Workload{{Name: "bar-deploy", Kind: "Deployment"}}},
+	assert.Equal(t, []string{"", ""}, mustGetLabelValues(opts, &ir.Flow{
+		Source:      ir.Endpoint{Namespace: "foo-ns", PodName: "foo-deploy-pod"},
+		Destination: ir.Endpoint{Namespace: "bar-ns", PodName: "bar-deploy-pod"}}))
+	assert.Equal(t, []string{"foo-ns/foo-deploy", "bar-ns/bar-deploy"}, mustGetLabelValues(opts, &ir.Flow{
+		Source:      ir.Endpoint{Namespace: "foo-ns", PodName: "foo-deploy-pod", Workloads: []ir.Workload{{Name: "foo-deploy", Kind: "Deployment"}}},
+		Destination: ir.Endpoint{Namespace: "bar-ns", PodName: "bar-deploy-pod", Workloads: []ir.Workload{{Name: "bar-deploy", Kind: "Deployment"}}},
 	}))
 }
 
@@ -602,12 +604,12 @@ func Test_workloadNameContext(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	assert.Equal(t, []string{"", ""}, mustGetLabelValues(opts, &pb.Flow{
-		Source:      &pb.Endpoint{Namespace: "foo-ns", PodName: "foo-deploy-pod"},
-		Destination: &pb.Endpoint{Namespace: "bar-ns", PodName: "bar-deploy-pod"}}))
-	assert.Equal(t, []string{"foo-deploy", "bar-deploy"}, mustGetLabelValues(opts, &pb.Flow{
-		Source:      &pb.Endpoint{Namespace: "foo-ns", PodName: "foo-deploy-pod", Workloads: []*pb.Workload{{Name: "foo-deploy", Kind: "Deployment"}}},
-		Destination: &pb.Endpoint{Namespace: "bar-ns", PodName: "bar-deploy-pod", Workloads: []*pb.Workload{{Name: "bar-deploy", Kind: "Deployment"}}},
+	assert.Equal(t, []string{"", ""}, mustGetLabelValues(opts, &ir.Flow{
+		Source:      ir.Endpoint{Namespace: "foo-ns", PodName: "foo-deploy-pod"},
+		Destination: ir.Endpoint{Namespace: "bar-ns", PodName: "bar-deploy-pod"}}))
+	assert.Equal(t, []string{"foo-deploy", "bar-deploy"}, mustGetLabelValues(opts, &ir.Flow{
+		Source:      ir.Endpoint{Namespace: "foo-ns", PodName: "foo-deploy-pod", Workloads: []ir.Workload{{Name: "foo-deploy", Kind: "Deployment"}}},
+		Destination: ir.Endpoint{Namespace: "bar-ns", PodName: "bar-deploy-pod", Workloads: []ir.Workload{{Name: "bar-deploy", Kind: "Deployment"}}},
 	}))
 }
 
@@ -626,12 +628,12 @@ func Test_appContext(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	assert.Equal(t, []string{"", ""}, mustGetLabelValues(opts, &pb.Flow{
-		Source:      &pb.Endpoint{Namespace: "foo-ns", PodName: "foo-deploy-pod"},
-		Destination: &pb.Endpoint{Namespace: "bar-ns", PodName: "bar-deploy-pod"}}))
-	assert.Equal(t, []string{"fooapp", "barapp"}, mustGetLabelValues(opts, &pb.Flow{
-		Source:      &pb.Endpoint{Namespace: "foo-ns", PodName: "foo-deploy-pod", Labels: []string{"k8s:app=fooapp"}},
-		Destination: &pb.Endpoint{Namespace: "bar-ns", PodName: "bar-deploy-pod", Labels: []string{"k8s:app=barapp"}},
+	assert.Equal(t, []string{"", ""}, mustGetLabelValues(opts, &ir.Flow{
+		Source:      ir.Endpoint{Namespace: "foo-ns", PodName: "foo-deploy-pod"},
+		Destination: ir.Endpoint{Namespace: "bar-ns", PodName: "bar-deploy-pod"}}))
+	assert.Equal(t, []string{"fooapp", "barapp"}, mustGetLabelValues(opts, &ir.Flow{
+		Source:      ir.Endpoint{Namespace: "foo-ns", PodName: "foo-deploy-pod", Labels: []string{"k8s:app=fooapp"}},
+		Destination: ir.Endpoint{Namespace: "bar-ns", PodName: "bar-deploy-pod", Labels: []string{"k8s:app=barapp"}},
 	}))
 }
 

--- a/pkg/hubble/metrics/api/registry_test.go
+++ b/pkg/hubble/metrics/api/registry_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	pb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/k8s/types"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
@@ -67,7 +68,7 @@ func (h *testHandler) HandleConfigurationUpdate(cfg *MetricConfig) error {
 	return nil
 }
 
-func (t *testHandler) ProcessFlow(ctx context.Context, p *pb.Flow) error {
+func (t *testHandler) ProcessFlow(ctx context.Context, p *ir.Flow) error {
 	labels, _ := t.ContextOptions.GetLabelValues(p)
 	t.counter.WithLabelValues(labels...).Inc()
 	t.ProcessCalled++
@@ -75,25 +76,26 @@ func (t *testHandler) ProcessFlow(ctx context.Context, p *pb.Flow) error {
 }
 
 func TestRegister(t *testing.T) {
-	flow1 := &pb.Flow{
-		EventType: &pb.CiliumEventType{Type: monitorAPI.MessageTypeAccessLog},
-		L7: &pb.Layer7{
-			Record: &pb.Layer7_Http{Http: &pb.HTTP{}},
+	flow1 := ir.Flow{
+		EventType: ir.CiliumEventType{Type: monitorAPI.MessageTypeAccessLog},
+		L7: ir.Layer7{
+			HTTP: ir.HTTP{},
 		},
-		Source:      &pb.Endpoint{Namespace: "foo", PodName: "foo-123", Workloads: []*pb.Workload{{Name: "worker"}}},
-		Destination: &pb.Endpoint{Namespace: "bar", PodName: "bar-123", Workloads: []*pb.Workload{{Name: "api"}}},
+		Source:      ir.Endpoint{Namespace: "foo", PodName: "foo-123", Workloads: []ir.Workload{{Name: "worker"}}},
+		Destination: ir.Endpoint{Namespace: "bar", PodName: "bar-123", Workloads: []ir.Workload{{Name: "api"}}},
 		Verdict:     pb.Verdict_FORWARDED,
 	}
 
-	flow2 := &pb.Flow{
-		EventType: &pb.CiliumEventType{Type: monitorAPI.MessageTypeAccessLog},
-		L7: &pb.Layer7{
-			Record: &pb.Layer7_Http{Http: &pb.HTTP{}},
+	flow2 := ir.Flow{
+		EventType: ir.CiliumEventType{Type: monitorAPI.MessageTypeAccessLog},
+		L7: ir.Layer7{
+			HTTP: ir.HTTP{},
 		},
-		Source:      &pb.Endpoint{Namespace: "abc", PodName: "abc-456", Workloads: []*pb.Workload{{Name: "worker"}}},
-		Destination: &pb.Endpoint{Namespace: "bar", PodName: "bar-123", Workloads: []*pb.Workload{{Name: "api"}}},
+		Source:      ir.Endpoint{Namespace: "abc", PodName: "abc-456", Workloads: []ir.Workload{{Name: "worker"}}},
+		Destination: ir.Endpoint{Namespace: "bar", PodName: "bar-123", Workloads: []ir.Workload{{Name: "api"}}},
 		Verdict:     pb.Verdict_FORWARDED,
 	}
+
 	log := hivetest.Logger(t)
 
 	t.Run("Should not register non-enabled handler", func(t *testing.T) {
@@ -152,8 +154,8 @@ func TestRegister(t *testing.T) {
 		opts, _ := ParseContextOptions(options)
 		handlers := initHandlers(t, opts, promRegistry, log)
 
-		ExecuteAllProcessFlow(t.Context(), flow1, *handlers)
-		ExecuteAllProcessFlow(t.Context(), flow2, *handlers)
+		ExecuteAllProcessFlow(t.Context(), &flow1, *handlers)
+		ExecuteAllProcessFlow(t.Context(), &flow2, *handlers)
 		assert.Equal(t, 2, (*handlers)[0].Handler.(*testHandler).ProcessCalled)
 
 		verifyMetricSeriesExists(t, promRegistry, 2)
@@ -194,8 +196,8 @@ func TestRegister(t *testing.T) {
 		opts, _ := ParseContextOptions(options)
 		handlers := initHandlers(t, opts, promRegistry, log)
 
-		ExecuteAllProcessFlow(t.Context(), flow1, *handlers)
-		ExecuteAllProcessFlow(t.Context(), flow2, *handlers)
+		ExecuteAllProcessFlow(t.Context(), &flow1, *handlers)
+		ExecuteAllProcessFlow(t.Context(), &flow2, *handlers)
 		assert.Equal(t, 2, (*handlers)[0].Handler.(*testHandler).ProcessCalled)
 
 		verifyMetricSeriesExists(t, promRegistry, 1)
@@ -232,8 +234,8 @@ func TestRegister(t *testing.T) {
 		opts, _ := ParseContextOptions(options)
 		handlers := initHandlers(t, opts, promRegistry, log)
 
-		ExecuteAllProcessFlow(t.Context(), flow1, *handlers)
-		ExecuteAllProcessFlow(t.Context(), flow2, *handlers)
+		ExecuteAllProcessFlow(t.Context(), &flow1, *handlers)
+		ExecuteAllProcessFlow(t.Context(), &flow2, *handlers)
 		assert.Equal(t, 2, (*handlers)[0].Handler.(*testHandler).ProcessCalled)
 
 		verifyMetricSeriesExists(t, promRegistry, 2)
@@ -270,8 +272,8 @@ func TestRegister(t *testing.T) {
 		opts, _ := ParseContextOptions(options)
 		handlers := initHandlers(t, opts, promRegistry, log)
 
-		ExecuteAllProcessFlow(t.Context(), flow1, *handlers)
-		ExecuteAllProcessFlow(t.Context(), flow2, *handlers)
+		ExecuteAllProcessFlow(t.Context(), &flow1, *handlers)
+		ExecuteAllProcessFlow(t.Context(), &flow2, *handlers)
 		assert.Equal(t, 2, (*handlers)[0].Handler.(*testHandler).ProcessCalled)
 
 		verifyMetricSeriesExists(t, promRegistry, 2)
@@ -342,7 +344,7 @@ func verifyMetricSeriesNotExists(t *testing.T, promRegistry *prometheus.Registry
 	require.Empty(t, metricFamilies)
 }
 
-func ExecuteAllProcessFlow(ctx context.Context, flow *pb.Flow, handlers []NamedHandler) error {
+func ExecuteAllProcessFlow(ctx context.Context, flow *ir.Flow, handlers []NamedHandler) error {
 	var errs error
 	for _, nh := range handlers {
 		errs = errors.Join(errs, nh.Handler.ProcessFlow(ctx, flow))

--- a/pkg/hubble/metrics/drop/handler.go
+++ b/pkg/hubble/metrics/drop/handler.go
@@ -15,6 +15,7 @@ import (
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	"github.com/cilium/cilium/pkg/hubble/filters"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/metrics/api"
 )
 
@@ -61,8 +62,8 @@ func (h *dropHandler) ListMetricVec() []*prometheus.MetricVec {
 	return []*prometheus.MetricVec{h.drops.MetricVec}
 }
 
-func (h *dropHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error {
-	if flow.GetVerdict() != flowpb.Verdict_DROPPED {
+func (h *dropHandler) ProcessFlow(ctx context.Context, flow *ir.Flow) error {
+	if flow.Verdict != flowpb.Verdict_DROPPED {
 		return nil
 	}
 
@@ -75,7 +76,7 @@ func (h *dropHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error 
 		return err
 	}
 
-	labels := append(contextLabels, flow.GetDropReasonDesc().String(), v1.FlowProtocol(flow))
+	labels := append(contextLabels, flow.DropReasonDesc.String(), v1.FlowProtocol(flow))
 
 	h.drops.WithLabelValues(labels...).Inc()
 	return nil

--- a/pkg/hubble/metrics/drop/handler_test.go
+++ b/pkg/hubble/metrics/drop/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	pb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/metrics/api"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 )
@@ -44,18 +45,16 @@ func TestDropHandler(t *testing.T) {
 	})
 
 	t.Run("ProcessFlow_ShouldReportNothingForForwardedFlow", func(t *testing.T) {
-		flow := &pb.Flow{
-			EventType: &pb.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
-			L4: &pb.Layer4{
-				Protocol: &pb.Layer4_TCP{
-					TCP: &pb.TCP{},
-				},
+		flow := ir.Flow{
+			EventType: ir.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
+			L4: ir.Layer4{
+				TCP: ir.TCP{SourcePort: 80},
 			},
-			Source:      &pb.Endpoint{Namespace: "foo"},
-			Destination: &pb.Endpoint{Namespace: "bar"},
+			Source:      ir.Endpoint{Namespace: "foo"},
+			Destination: ir.Endpoint{Namespace: "bar"},
 			Verdict:     pb.Verdict_FORWARDED,
 		}
-		dropHandler.ProcessFlow(t.Context(), flow)
+		dropHandler.ProcessFlow(t.Context(), &flow)
 
 		metricFamilies, err := registry.Gather()
 		require.NoError(t, err)
@@ -64,34 +63,30 @@ func TestDropHandler(t *testing.T) {
 	})
 
 	t.Run("ProcessFlow_ShouldReportDroppedFlow", func(t *testing.T) {
-		flow1 := &pb.Flow{
-			EventType: &pb.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
-			L4: &pb.Layer4{
-				Protocol: &pb.Layer4_TCP{
-					TCP: &pb.TCP{},
-				},
+		flow1 := ir.Flow{
+			EventType: ir.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
+			L4: ir.Layer4{
+				TCP: ir.TCP{SourcePort: 80},
 			},
-			Source:         &pb.Endpoint{Namespace: "foo"},
-			Destination:    &pb.Endpoint{Namespace: "bar"},
+			Source:         ir.Endpoint{Namespace: "foo"},
+			Destination:    ir.Endpoint{Namespace: "bar"},
 			Verdict:        pb.Verdict_DROPPED,
 			DropReason:     uint32(pb.DropReason_POLICY_DENIED),
 			DropReasonDesc: pb.DropReason_POLICY_DENIED,
 		}
-		flow2 := &pb.Flow{
-			EventType: &pb.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
-			L4: &pb.Layer4{
-				Protocol: &pb.Layer4_TCP{
-					TCP: &pb.TCP{},
-				},
+		flow2 := ir.Flow{
+			EventType: ir.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
+			L4: ir.Layer4{
+				TCP: ir.TCP{},
 			},
-			Source:         &pb.Endpoint{Namespace: "deny-pod", PodName: "a"},
-			Destination:    &pb.Endpoint{Namespace: "bar"},
+			Source:         ir.Endpoint{Namespace: "deny-pod", PodName: "a"},
+			Destination:    ir.Endpoint{Namespace: "bar"},
 			Verdict:        pb.Verdict_DROPPED,
 			DropReason:     uint32(pb.DropReason_POLICY_DENIED),
 			DropReasonDesc: pb.DropReason_POLICY_DENIED,
 		}
-		dropHandler.ProcessFlow(t.Context(), flow1)
-		dropHandler.ProcessFlow(t.Context(), flow2)
+		dropHandler.ProcessFlow(t.Context(), &flow1)
+		dropHandler.ProcessFlow(t.Context(), &flow2)
 
 		metricFamilies, err := registry.Gather()
 		require.NoError(t, err)
@@ -115,7 +110,7 @@ func TestDropHandler(t *testing.T) {
 		assert.Equal(t, 1., *metric.Counter.Value)
 
 		//send another flow with same labels
-		dropHandler.ProcessFlow(t.Context(), flow1)
+		dropHandler.ProcessFlow(t.Context(), &flow1)
 		metricFamilies, _ = registry.Gather()
 		metric = metricFamilies[0].Metric[0]
 		assert.Equal(t, 2., *metric.Counter.Value)

--- a/pkg/hubble/metrics/dynamic_flow_processor.go
+++ b/pkg/hubble/metrics/dynamic_flow_processor.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/metrics/api"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -31,13 +31,13 @@ type DynamicFlowProcessor struct {
 }
 
 // ProcessFlow implements FlowProcessor.
-func (p *DynamicFlowProcessor) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error {
+func (p *DynamicFlowProcessor) ProcessFlow(ctx context.Context, flow *ir.Flow) error {
 	_, err := p.OnDecodedFlow(ctx, flow)
 	return err
 }
 
 // OnDecodedEvent distributes events across all managed exporters.
-func (d *DynamicFlowProcessor) OnDecodedFlow(ctx context.Context, flow *flowpb.Flow) (bool, error) {
+func (d *DynamicFlowProcessor) OnDecodedFlow(ctx context.Context, flow *ir.Flow) (bool, error) {
 	select {
 	case <-ctx.Done():
 		return false, d.Stop()

--- a/pkg/hubble/metrics/flow/handler.go
+++ b/pkg/hubble/metrics/flow/handler.go
@@ -12,9 +12,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	"github.com/cilium/cilium/pkg/hubble/filters"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/metrics/api"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 )
@@ -62,7 +62,7 @@ func (h *flowHandler) ListMetricVec() []*prometheus.MetricVec {
 	return []*prometheus.MetricVec{h.flows.MetricVec}
 }
 
-func (h *flowHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error {
+func (h *flowHandler) ProcessFlow(ctx context.Context, flow *ir.Flow) error {
 	if !filters.Apply(h.AllowList, h.DenyList, &v1.Event{Event: flow, Timestamp: &timestamppb.Timestamp{}}) {
 		return nil
 	}
@@ -72,15 +72,15 @@ func (h *flowHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error 
 		return err
 	}
 	var typeName, subType string
-	eventType := flow.GetEventType().GetType()
+	eventType := flow.EventType.Type
 	switch eventType {
 	case monitorAPI.MessageTypeAccessLog:
 		typeName = "L7"
-		if l7 := flow.GetL7(); l7 != nil {
+		if l7 := flow.L7; !l7.IsEmpty() {
 			switch {
-			case l7.GetDns() != nil:
+			case !l7.DNS.IsEmpty():
 				subType = "DNS"
-			case l7.GetHttp() != nil:
+			case !l7.HTTP.IsEmpty():
 				subType = "HTTP"
 			}
 		}
@@ -90,7 +90,7 @@ func (h *flowHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error 
 		typeName = "Capture"
 	case monitorAPI.MessageTypeTrace:
 		typeName = "Trace"
-		subType = monitorAPI.TraceObservationPoints[uint8(flow.GetEventType().SubType)]
+		subType = monitorAPI.TraceObservationPoints[uint8(flow.EventType.SubType)]
 	case monitorAPI.MessageTypePolicyVerdict:
 		typeName = "PolicyVerdict"
 	default:
@@ -98,7 +98,7 @@ func (h *flowHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error 
 		subType = fmt.Sprintf("%d", eventType)
 	}
 
-	labels := []string{v1.FlowProtocol(flow), typeName, subType, flow.GetVerdict().String()}
+	labels := []string{v1.FlowProtocol(flow), typeName, subType, flow.Verdict.String()}
 	labels = append(labels, labelValues...)
 
 	h.flows.WithLabelValues(labels...).Inc()

--- a/pkg/hubble/metrics/flow/handler_test.go
+++ b/pkg/hubble/metrics/flow/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	pb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/metrics/api"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 )
@@ -44,26 +45,26 @@ func TestFlowHandler(t *testing.T) {
 	})
 
 	t.Run("ProcessFlow", func(t *testing.T) {
-		flow0 := &pb.Flow{
-			EventType: &pb.CiliumEventType{Type: monitorAPI.MessageTypeAccessLog},
-			L7: &pb.Layer7{
-				Record: &pb.Layer7_Http{Http: &pb.HTTP{}},
+		flow0 := ir.Flow{
+			EventType: ir.CiliumEventType{Type: monitorAPI.MessageTypeAccessLog},
+			L7: ir.Layer7{
+				HTTP: ir.HTTP{Code: 200},
 			},
-			Source:      &pb.Endpoint{Namespace: "foo"},
-			Destination: &pb.Endpoint{Namespace: "bar"},
+			Source:      ir.Endpoint{Namespace: "foo"},
+			Destination: ir.Endpoint{Namespace: "bar"},
 			Verdict:     pb.Verdict_FORWARDED,
 		}
-		flow1 := &pb.Flow{
-			EventType: &pb.CiliumEventType{Type: monitorAPI.MessageTypeAccessLog},
-			L7: &pb.Layer7{
-				Record: &pb.Layer7_Http{Http: &pb.HTTP{}},
+		flow1 := ir.Flow{
+			EventType: ir.CiliumEventType{Type: monitorAPI.MessageTypeAccessLog},
+			L7: ir.Layer7{
+				HTTP: ir.HTTP{Code: 200},
 			},
-			Source:      &pb.Endpoint{Namespace: "allowNs"},
-			Destination: &pb.Endpoint{Namespace: "bar"},
+			Source:      ir.Endpoint{Namespace: "allowNs"},
+			Destination: ir.Endpoint{Namespace: "bar"},
 			Verdict:     pb.Verdict_FORWARDED,
 		}
-		h.ProcessFlow(t.Context(), flow0)
-		h.ProcessFlow(t.Context(), flow1)
+		h.ProcessFlow(t.Context(), &flow0)
+		h.ProcessFlow(t.Context(), &flow1)
 
 		metricFamilies, err := registry.Gather()
 		require.NoError(t, err)
@@ -91,15 +92,15 @@ func TestFlowHandler(t *testing.T) {
 		assert.Equal(t, "verdict", *metric.Label[5].Name)
 		assert.Equal(t, "FORWARDED", *metric.Label[5].Value)
 
-		flow2 := &pb.Flow{
-			EventType: &pb.CiliumEventType{
+		flow2 := ir.Flow{
+			EventType: ir.CiliumEventType{
 				// flow events cannot be derived from agent events
 				Type: monitorAPI.MessageTypeAgent,
 			},
-			Source: &pb.Endpoint{Namespace: "allowNs"},
+			Source: ir.Endpoint{Namespace: "allowNs"},
 		}
 
-		h.ProcessFlow(t.Context(), flow2)
+		h.ProcessFlow(t.Context(), &flow2)
 
 		metricFamilies, err = registry.Gather()
 		require.NoError(t, err)
@@ -115,23 +116,21 @@ func TestFlowHandler(t *testing.T) {
 		assert.Equal(t, "type", *metric.Label[4].Name)
 		assert.Equal(t, "Unknown", *metric.Label[4].Value)
 
-		flow3 := &pb.Flow{
-			EventType: &pb.CiliumEventType{
+		flow3 := ir.Flow{
+			EventType: ir.CiliumEventType{
 				Type: monitorAPI.MessageTypePolicyVerdict,
 			},
-			L4: &pb.Layer4{
-				Protocol: &pb.Layer4_UDP{
-					UDP: &pb.UDP{
-						DestinationPort: 53,
-						SourcePort:      31313,
-					},
+			L4: ir.Layer4{
+				UDP: ir.UDP{
+					DestinationPort: 53,
+					SourcePort:      31313,
 				},
 			},
 			Verdict: pb.Verdict_DROPPED,
-			Source:  &pb.Endpoint{Namespace: "allowNs"},
+			Source:  ir.Endpoint{Namespace: "allowNs"},
 		}
 
-		h.ProcessFlow(t.Context(), flow3)
+		h.ProcessFlow(t.Context(), &flow3)
 
 		metricFamilies, err = registry.Gather()
 		require.NoError(t, err)

--- a/pkg/hubble/metrics/flow_processor.go
+++ b/pkg/hubble/metrics/flow_processor.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"log/slog"
 
-	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/metrics/api"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
@@ -28,13 +28,13 @@ func NewStaticFlowProcessor(logger *slog.Logger, metrics []api.NamedHandler) *St
 }
 
 // ProcessFlow implements FlowProcessor.
-func (p *StaticFlowProcessor) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error {
+func (p *StaticFlowProcessor) ProcessFlow(ctx context.Context, flow *ir.Flow) error {
 	_, err := p.OnDecodedFlow(ctx, flow)
 	return err
 }
 
 // OnDecodedFlow implements observeroption.OnDecodedFlow.
-func (p *StaticFlowProcessor) OnDecodedFlow(ctx context.Context, flow *flowpb.Flow) (bool, error) {
+func (p *StaticFlowProcessor) OnDecodedFlow(ctx context.Context, flow *ir.Flow) (bool, error) {
 	if len(p.metrics) == 0 {
 		return false, nil
 	}

--- a/pkg/hubble/metrics/flows-to-world/handler.go
+++ b/pkg/hubble/metrics/flows-to-world/handler.go
@@ -18,6 +18,7 @@ import (
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	"github.com/cilium/cilium/pkg/hubble/filters"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/metrics/api"
 	pkglabels "github.com/cilium/cilium/pkg/labels"
 )
@@ -96,7 +97,7 @@ func (h *flowsToWorldHandler) ListMetricVec() []*prometheus.MetricVec {
 	return []*prometheus.MetricVec{h.flowsToWorld.MetricVec}
 }
 
-func (h *flowsToWorldHandler) isReservedWorld(endpoint *flowpb.Endpoint) bool {
+func (h *flowsToWorldHandler) isReservedWorld(endpoint ir.Endpoint) bool {
 	for _, label := range endpoint.Labels {
 		switch label {
 		case reservedWorldLbl, reservedWorldIPv4Lbl, reservedWorldIPv6Lbl:
@@ -106,26 +107,22 @@ func (h *flowsToWorldHandler) isReservedWorld(endpoint *flowpb.Endpoint) bool {
 	return false
 }
 
-func (h *flowsToWorldHandler) ProcessFlow(_ context.Context, flow *flowpb.Flow) error {
-	l4 := flow.GetL4()
-	if flow.GetDestination() == nil ||
-		!h.isReservedWorld(flow.GetDestination()) ||
-		flow.GetEventType() == nil ||
-		l4 == nil {
+func (h *flowsToWorldHandler) ProcessFlow(_ context.Context, flow *ir.Flow) error {
+	l4 := flow.L4
+	if flow.Destination.IsEmpty() || !h.isReservedWorld(flow.Destination) || flow.EventType.IsEmpty() || l4.IsEmpty() {
 		return nil
 	}
 	// if "any-drop" option is not set, non-policy drops are ignored.
-	if flow.GetVerdict() == flowpb.Verdict_DROPPED && !h.anyDrop && flow.GetDropReasonDesc() != flowpb.DropReason_POLICY_DENIED {
+	if flow.Verdict == flowpb.Verdict_DROPPED && !h.anyDrop && flow.DropReasonDesc != flowpb.DropReason_POLICY_DENIED {
 		return nil
 	}
 	// if this is potentially a forwarded reply packet, ignore it to avoid collecting statistics about ephemeral ports
-	isReply := flow.GetIsReply() != nil && flow.GetIsReply().GetValue()
-	if flow.GetVerdict() != flowpb.Verdict_DROPPED && isReply {
+	if flow.Verdict != flowpb.Verdict_DROPPED && flow.IsReply() {
 		return nil
 	}
 
 	// if "syn-only" option is set, only count non-reply SYN packets for TCP.
-	if h.synOnly && (!l4.GetTCP().GetFlags().GetSYN() || isReply) {
+	if h.synOnly && (!l4.TCP.Flags.SYN || flow.IsReply()) {
 		return nil
 	}
 
@@ -138,22 +135,23 @@ func (h *flowsToWorldHandler) ProcessFlow(_ context.Context, flow *flowpb.Flow) 
 		return err
 	}
 
-	labels := []string{v1.FlowProtocol(flow), flow.GetVerdict().String()}
+	labels := []string{v1.FlowProtocol(flow), flow.Verdict.String()}
 
 	// if "port" option is set, add port to the label.
 	if h.port {
-		port := ""
-		if tcp := l4.GetTCP(); tcp != nil {
-			port = strconv.Itoa(int(tcp.GetDestinationPort()))
-		} else if udp := l4.GetUDP(); udp != nil {
-			port = strconv.Itoa(int(udp.GetDestinationPort()))
-		} else if sctp := l4.GetSCTP(); sctp != nil {
-			port = strconv.Itoa(int(sctp.GetDestinationPort()))
+		var port string
+		if !l4.TCP.IsEmpty() {
+			port = strconv.Itoa(int(l4.TCP.DestinationPort))
+		} else if !l4.UDP.IsEmpty() {
+			port = strconv.Itoa(int(l4.UDP.DestinationPort))
+		} else if !l4.SCTP.IsEmpty() {
+			port = strconv.Itoa(int(l4.SCTP.DestinationPort))
 		}
 		labels = append(labels, port)
 	}
 	labels = append(labels, labelValues...)
 	h.flowsToWorld.WithLabelValues(labels...).Inc()
+
 	return nil
 }
 

--- a/pkg/hubble/metrics/flows-to-world/handler_test.go
+++ b/pkg/hubble/metrics/flows-to-world/handler_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/metrics/api"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 )
@@ -35,33 +35,31 @@ func TestFlowsToWorldHandler_MatchingFlow(t *testing.T) {
 	h := &flowsToWorldHandler{}
 	assert.NoError(t, h.Init(registry, opts))
 	assert.NoError(t, testutil.CollectAndCompare(h.flowsToWorld, strings.NewReader("")))
-	flow := flowpb.Flow{
+	flow := ir.Flow{
 		Verdict:        flowpb.Verdict_DROPPED,
 		DropReasonDesc: flowpb.DropReason_POLICY_DENIED,
-		EventType:      &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeDrop},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{DestinationPort: 80},
-			},
+		EventType:      ir.CiliumEventType{Type: monitorAPI.MessageTypeDrop},
+		L4: ir.Layer4{
+			TCP: ir.TCP{DestinationPort: 80},
 		},
-		Source: &flowpb.Endpoint{Namespace: "src-a"},
-		Destination: &flowpb.Endpoint{
+		Source: ir.Endpoint{Namespace: "src-a"},
+		Destination: ir.Endpoint{
 			Labels: []string{"reserved:world"},
 		},
 		DestinationNames: []string{"cilium.io"},
 	}
 
 	h.ProcessFlow(t.Context(), &flow)
-	flow.L4 = &flowpb.Layer4{
-		Protocol: &flowpb.Layer4_UDP{UDP: &flowpb.UDP{DestinationPort: 53}},
+	flow.L4 = ir.Layer4{
+		UDP: ir.UDP{DestinationPort: 53},
 	}
 	h.ProcessFlow(t.Context(), &flow)
-	flow.L4 = &flowpb.Layer4{
-		Protocol: &flowpb.Layer4_ICMPv4{ICMPv4: &flowpb.ICMPv4{}},
+	flow.L4 = ir.Layer4{
+		ICMPv4: ir.ICMP{Type: 1},
 	}
 	h.ProcessFlow(t.Context(), &flow)
-	flow.L4 = &flowpb.Layer4{
-		Protocol: &flowpb.Layer4_ICMPv6{ICMPv6: &flowpb.ICMPv6{}},
+	flow.L4 = ir.Layer4{
+		ICMPv6: ir.ICMP{Type: 1},
 	}
 	h.ProcessFlow(t.Context(), &flow)
 	expected := strings.NewReader(`# HELP hubble_flows_to_world_total Total number of flows to reserved:world
@@ -92,70 +90,64 @@ func TestFlowsToWorldHandler_NonMatchingFlows(t *testing.T) {
 	assert.NoError(t, h.Init(registry, opts))
 
 	// destination is missing.
-	h.ProcessFlow(t.Context(), &flowpb.Flow{
+	h.ProcessFlow(t.Context(), &ir.Flow{
 		Verdict: flowpb.Verdict_FORWARDED,
-		Source:  &flowpb.Endpoint{Namespace: "src-a"},
+		Source:  ir.Endpoint{Namespace: "src-a"},
 	})
 	// destination is not reserved:world
-	h.ProcessFlow(t.Context(), &flowpb.Flow{
+	h.ProcessFlow(t.Context(), &ir.Flow{
 		Verdict: flowpb.Verdict_FORWARDED,
-		Source:  &flowpb.Endpoint{Namespace: "src-a"},
-		Destination: &flowpb.Endpoint{
+		Source:  ir.Endpoint{Namespace: "src-a"},
+		Destination: ir.Endpoint{
 			Labels: []string{"reserved:host"},
 		},
 	})
 	// L4 information is missing.
-	h.ProcessFlow(t.Context(), &flowpb.Flow{
+	h.ProcessFlow(t.Context(), &ir.Flow{
 		Verdict: flowpb.Verdict_FORWARDED,
-		Source:  &flowpb.Endpoint{Namespace: "src-a"},
-		Destination: &flowpb.Endpoint{
+		Source:  ir.Endpoint{Namespace: "src-a"},
+		Destination: ir.Endpoint{
 			Labels: []string{"reserved:world"},
 		},
 	})
 	// EventType is missing.
-	h.ProcessFlow(t.Context(), &flowpb.Flow{
+	h.ProcessFlow(t.Context(), &ir.Flow{
 		Verdict: flowpb.Verdict_FORWARDED,
-		Source:  &flowpb.Endpoint{Namespace: "src-a"},
-		Destination: &flowpb.Endpoint{
+		Source:  ir.Endpoint{Namespace: "src-a"},
+		Destination: ir.Endpoint{
 			Labels: []string{"reserved:world"},
 		},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{DestinationPort: 80},
-			},
+		L4: ir.Layer4{
+			TCP: ir.TCP{DestinationPort: 80},
 		},
 	})
 	// Drop reason is not "Policy denied".
-	h.ProcessFlow(t.Context(), &flowpb.Flow{
+	h.ProcessFlow(t.Context(), &ir.Flow{
 		Verdict:        flowpb.Verdict_DROPPED,
-		EventType:      &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeDrop},
+		EventType:      ir.CiliumEventType{Type: monitorAPI.MessageTypeDrop},
 		DropReasonDesc: flowpb.DropReason_STALE_OR_UNROUTABLE_IP,
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{DestinationPort: 80},
-			},
+		L4: ir.Layer4{
+			TCP: ir.TCP{DestinationPort: 80},
 		},
-		Source: &flowpb.Endpoint{Namespace: "src-a"},
-		Destination: &flowpb.Endpoint{
+		Source: ir.Endpoint{Namespace: "src-a"},
+		Destination: ir.Endpoint{
 			Labels: []string{"reserved:world"},
 		},
 		DestinationNames: []string{"cilium.io"},
 	})
 	// Flow is a reply.
-	h.ProcessFlow(t.Context(), &flowpb.Flow{
+	h.ProcessFlow(t.Context(), &ir.Flow{
 		Verdict:   flowpb.Verdict_FORWARDED,
-		EventType: &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeTrace},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{DestinationPort: 80},
-			},
+		EventType: ir.CiliumEventType{Type: monitorAPI.MessageTypeTrace},
+		L4: ir.Layer4{
+			TCP: ir.TCP{DestinationPort: 80},
 		},
-		Source: &flowpb.Endpoint{Namespace: "src-a"},
-		Destination: &flowpb.Endpoint{
+		Source: ir.Endpoint{Namespace: "src-a"},
+		Destination: ir.Endpoint{
 			Labels: []string{"reserved:world"},
 		},
 		DestinationNames: []string{"cilium.io"},
-		IsReply:          wrapperspb.Bool(true),
+		Reply:            ir.ReplyYes,
 	})
 	assert.NoError(t, testutil.CollectAndCompare(h.flowsToWorld, strings.NewReader("")))
 }
@@ -181,17 +173,15 @@ func TestFlowsToWorldHandler_AnyDrop(t *testing.T) {
 	h := &flowsToWorldHandler{}
 	assert.NoError(t, h.Init(registry, opts))
 	assert.NoError(t, testutil.CollectAndCompare(h.flowsToWorld, strings.NewReader("")))
-	flow := flowpb.Flow{
+	flow := ir.Flow{
 		Verdict:        flowpb.Verdict_DROPPED,
 		DropReasonDesc: flowpb.DropReason_STALE_OR_UNROUTABLE_IP,
-		EventType:      &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeDrop},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{DestinationPort: 80},
-			},
+		EventType:      ir.CiliumEventType{Type: monitorAPI.MessageTypeDrop},
+		L4: ir.Layer4{
+			TCP: ir.TCP{DestinationPort: 80},
 		},
-		Source: &flowpb.Endpoint{Namespace: "src-a"},
-		Destination: &flowpb.Endpoint{
+		Source: ir.Endpoint{Namespace: "src-a"},
+		Destination: ir.Endpoint{
 			Labels: []string{"reserved:world"},
 		},
 		DestinationNames: []string{"cilium.io"},
@@ -225,32 +215,26 @@ func TestFlowsToWorldHandler_IncludePort(t *testing.T) {
 	h := &flowsToWorldHandler{}
 	assert.NoError(t, h.Init(registry, opts))
 	assert.NoError(t, testutil.CollectAndCompare(h.flowsToWorld, strings.NewReader("")))
-	flow := flowpb.Flow{
+	flow := ir.Flow{
 		Verdict:   flowpb.Verdict_FORWARDED,
-		EventType: &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeTrace},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{DestinationPort: 80},
-			},
+		EventType: ir.CiliumEventType{Type: monitorAPI.MessageTypeTrace},
+		L4: ir.Layer4{
+			TCP: ir.TCP{DestinationPort: 80},
 		},
-		Source: &flowpb.Endpoint{Namespace: "src-a"},
-		Destination: &flowpb.Endpoint{
+		Source: ir.Endpoint{Namespace: "src-a"},
+		Destination: ir.Endpoint{
 			Labels: []string{"reserved:world"},
 		},
 		DestinationNames: []string{"cilium.io"},
-		IsReply:          wrapperspb.Bool(false),
+		Reply:            ir.ReplyNo,
 	}
 	h.ProcessFlow(t.Context(), &flow)
-	flow.L4 = &flowpb.Layer4{
-		Protocol: &flowpb.Layer4_UDP{
-			UDP: &flowpb.UDP{DestinationPort: 53},
-		},
+	flow.L4 = ir.Layer4{
+		UDP: ir.UDP{DestinationPort: 53},
 	}
 	h.ProcessFlow(t.Context(), &flow)
-	flow.L4 = &flowpb.Layer4{
-		Protocol: &flowpb.Layer4_SCTP{
-			SCTP: &flowpb.SCTP{DestinationPort: 2905},
-		},
+	flow.L4 = ir.Layer4{
+		SCTP: ir.SCTP{DestinationPort: 2905},
 	}
 	h.ProcessFlow(t.Context(), &flow)
 	expected := strings.NewReader(`# HELP hubble_flows_to_world_total Total number of flows to reserved:world
@@ -283,35 +267,33 @@ func TestFlowsToWorldHandler_SynOnly(t *testing.T) {
 	h := &flowsToWorldHandler{}
 	assert.NoError(t, h.Init(registry, opts))
 	assert.NoError(t, testutil.CollectAndCompare(h.flowsToWorld, strings.NewReader("")))
-	flow := flowpb.Flow{
+	flow := ir.Flow{
 		Verdict:        flowpb.Verdict_DROPPED,
 		DropReasonDesc: flowpb.DropReason_POLICY_DENIED,
-		EventType:      &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeDrop},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{DestinationPort: 80, Flags: &flowpb.TCPFlags{SYN: true}},
-			},
+		EventType:      ir.CiliumEventType{Type: monitorAPI.MessageTypeDrop},
+		L4: ir.Layer4{
+			TCP: ir.TCP{DestinationPort: 80, Flags: ir.TCPFlags{SYN: true}},
 		},
-		Source: &flowpb.Endpoint{Namespace: "src-a"},
-		Destination: &flowpb.Endpoint{
+		Source: ir.Endpoint{Namespace: "src-a"},
+		Destination: ir.Endpoint{
 			Labels: []string{"reserved:world"},
 		},
 		DestinationNames: []string{"cilium.io"},
-		IsReply:          wrapperspb.Bool(false),
+		Reply:            ir.ReplyNo,
 	}
 	h.ProcessFlow(t.Context(), &flow)
 
 	// flows without is_reply field should be counted.
-	flow.IsReply = nil
+	flow.Reply = ir.ReplyUnknown
 	h.ProcessFlow(t.Context(), &flow)
 
 	// reply flows should not be counted
-	flow.IsReply = wrapperspb.Bool(true)
+	flow.Reply = ir.ReplyYes
 	h.ProcessFlow(t.Context(), &flow)
 
 	// Non-SYN should not be counted
-	flow.IsReply = wrapperspb.Bool(false)
-	flow.L4.GetTCP().Flags = &flowpb.TCPFlags{ACK: true}
+	flow.Reply = ir.ReplyNo
+	flow.L4.TCP.Flags = ir.TCPFlags{ACK: true}
 	h.ProcessFlow(t.Context(), &flow)
 
 	expected := strings.NewReader(`# HELP hubble_flows_to_world_total Total number of flows to reserved:world

--- a/pkg/hubble/metrics/http/handler.go
+++ b/pkg/hubble/metrics/http/handler.go
@@ -17,6 +17,7 @@ import (
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	"github.com/cilium/cilium/pkg/hubble/filters"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/metrics/api"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -107,7 +108,7 @@ func (h *httpHandler) ListMetricVec() []*prometheus.MetricVec {
 	return h.registeredMetrics
 }
 
-func (h *httpHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error {
+func (h *httpHandler) ProcessFlow(ctx context.Context, flow *ir.Flow) error {
 	if h.useV2 {
 		return h.processMetricsV2(flow)
 	} else {
@@ -115,13 +116,13 @@ func (h *httpHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error 
 	}
 }
 
-func (h *httpHandler) isHTTP(flow *flowpb.Flow) bool {
-	return flow.GetL7().GetHttp() != nil
+func (h *httpHandler) isHTTP(flow *ir.Flow) bool {
+	return !flow.L7.HTTP.IsEmpty()
 }
 
-func (h *httpHandler) reporter(flow *flowpb.Flow) string {
+func (h *httpHandler) reporter(flow *ir.Flow) string {
 	reporter := "unknown"
-	switch flow.GetTrafficDirection() {
+	switch flow.TrafficDirection {
 	case flowpb.TrafficDirection_EGRESS:
 		reporter = "client"
 	case flowpb.TrafficDirection_INGRESS:
@@ -130,15 +131,15 @@ func (h *httpHandler) reporter(flow *flowpb.Flow) string {
 	return reporter
 }
 
-func (h *httpHandler) traceID(flow *flowpb.Flow) string {
+func (h *httpHandler) traceID(flow *ir.Flow) string {
 	if h.exemplars {
-		return flow.GetTraceContext().GetParent().GetTraceId()
+		return flow.TraceContext.Parent.TraceID
 	}
 	return ""
 }
 
-func (h *httpHandler) processMetricsV2(flow *flowpb.Flow) error {
-	if !h.isHTTP(flow) || flow.GetL7().GetType() != flowpb.L7FlowType_RESPONSE {
+func (h *httpHandler) processMetricsV2(flow *ir.Flow) error {
+	if !h.isHTTP(flow) || flow.L7.Type != flowpb.L7FlowType_RESPONSE {
 		return nil
 	}
 	reporter := h.reporter(flow)
@@ -153,22 +154,22 @@ func (h *httpHandler) processMetricsV2(flow *flowpb.Flow) error {
 		return err
 	}
 
-	http := flow.GetL7().GetHttp()
-	status := strconv.Itoa(int(http.GetCode()))
-	requestsCounter := h.requests.WithLabelValues(append(labelValues, http.GetMethod(), http.GetProtocol(), status, reporter)...)
-	requestDurationHistogram := h.duration.WithLabelValues(append(labelValues, http.GetMethod(), reporter)...)
+	http := flow.L7.HTTP
+	status := strconv.Itoa(int(http.Code))
+	requestsCounter := h.requests.WithLabelValues(append(labelValues, http.Method, http.Protocol, status, reporter)...)
+	requestDurationHistogram := h.duration.WithLabelValues(append(labelValues, http.Method, reporter)...)
 
 	incrementCounter(requestsCounter, traceID)
-	observerObserve(requestDurationHistogram, float64(flow.GetL7().GetLatencyNs())/float64(time.Second), traceID)
+	observerObserve(requestDurationHistogram, float64(flow.L7.LatencyNs)/float64(time.Second), traceID)
 
 	return nil
 }
 
-func (h *httpHandler) processMetricsV1(flow *flowpb.Flow) error {
+func (h *httpHandler) processMetricsV1(flow *ir.Flow) error {
 	if !h.isHTTP(flow) {
 		return nil
 	}
-	flowType := flow.GetL7().GetType()
+	flowType := flow.L7.Type
 	if flowType != flowpb.L7FlowType_REQUEST && flowType != flowpb.L7FlowType_RESPONSE {
 		return nil
 	}
@@ -184,18 +185,18 @@ func (h *httpHandler) processMetricsV1(flow *flowpb.Flow) error {
 		return err
 	}
 
-	http := flow.GetL7().GetHttp()
+	http := flow.L7.HTTP
 	var requestsCounter, responsesCounter prometheus.Counter
-	switch flow.GetL7().GetType() {
+	switch flow.L7.Type {
 	case flowpb.L7FlowType_REQUEST:
-		requestsCounter = h.requests.WithLabelValues(append(labelValues, http.GetMethod(), http.GetProtocol(), reporter)...)
+		requestsCounter = h.requests.WithLabelValues(append(labelValues, http.Method, http.Protocol, reporter)...)
 		incrementCounter(requestsCounter, traceID)
 	case flowpb.L7FlowType_RESPONSE:
-		status := strconv.Itoa(int(http.GetCode()))
-		responsesCounter = h.responses.WithLabelValues(append(labelValues, http.GetMethod(), http.GetProtocol(), status, reporter)...)
-		requestDurationHistogram := h.duration.WithLabelValues(append(labelValues, http.GetMethod(), reporter)...)
+		status := strconv.Itoa(int(http.Code))
+		responsesCounter = h.responses.WithLabelValues(append(labelValues, http.Method, http.Protocol, status, reporter)...)
+		requestDurationHistogram := h.duration.WithLabelValues(append(labelValues, http.Method, reporter)...)
 		incrementCounter(responsesCounter, traceID)
-		observerObserve(requestDurationHistogram, float64(flow.GetL7().GetLatencyNs())/float64(time.Second), traceID)
+		observerObserve(requestDurationHistogram, float64(flow.L7.LatencyNs)/float64(time.Second), traceID)
 	}
 	return nil
 }

--- a/pkg/hubble/metrics/metrics.go
+++ b/pkg/hubble/metrics/metrics.go
@@ -13,7 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"k8s.io/client-go/util/workqueue"
 
-	pb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/metrics/api"
 	_ "github.com/cilium/cilium/pkg/hubble/metrics/dns"               // invoke init
 	_ "github.com/cilium/cilium/pkg/hubble/metrics/drop"              // invoke init
@@ -138,5 +138,5 @@ func ServerHandler(reg *prometheus.Registry, enableOpenMetrics bool) http.Handle
 // FlowProcessor is an abstraction over the static and dynamic flow processors.
 type FlowProcessor interface {
 	// ProcessFlow processes a flow event and perform metrics accounting.
-	ProcessFlow(ctx context.Context, flow *pb.Flow) error
+	ProcessFlow(ctx context.Context, flow *ir.Flow) error
 }

--- a/pkg/hubble/metrics/metrics_test.go
+++ b/pkg/hubble/metrics/metrics_test.go
@@ -26,6 +26,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 
 	pb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/metrics/api"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/k8s/types"
@@ -73,22 +74,20 @@ func ConfigureAndFetchMetrics(t *testing.T, testName string, metricCfg []string,
 			api.ParseStaticMetricsConfig(metricCfg),
 			grpcMetrics)
 
-		flow := &pb.Flow{
-			EventType: &pb.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
-			L4: &pb.Layer4{
-				Protocol: &pb.Layer4_TCP{
-					TCP: &pb.TCP{},
-				},
+		flow := ir.Flow{
+			EventType: ir.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
+			L4: ir.Layer4{
+				TCP: ir.TCP{},
 			},
-			Source:      &pb.Endpoint{Namespace: "foo"},
-			Destination: &pb.Endpoint{Namespace: "bar"},
+			Source:      ir.Endpoint{Namespace: "foo"},
+			Destination: ir.Endpoint{Namespace: "bar"},
 			Verdict:     pb.Verdict_DROPPED,
 			DropReason:  uint32(pb.DropReason_POLICY_DENIED),
 		}
 
 		var err error
 		for _, nh := range EnabledMetrics {
-			err = errors.Join(err, nh.Handler.ProcessFlow(t.Context(), flow))
+			err = errors.Join(err, nh.Handler.ProcessFlow(t.Context(), &flow))
 		}
 		require.NoError(t, err)
 
@@ -251,21 +250,19 @@ func TestMetricReRegisterAndCollect(t *testing.T) {
 	dfp := DynamicFlowProcessor{registry: reg, logger: slog.Default()}
 	dfp.onConfigReload(t.Context(), 0, *cfg)
 
-	flow1 := &pb.Flow{
-		EventType: &pb.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
-		L4: &pb.Layer4{
-			Protocol: &pb.Layer4_TCP{
-				TCP: &pb.TCP{},
-			},
+	flow := ir.Flow{
+		EventType: ir.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
+		L4: ir.Layer4{
+			TCP: ir.TCP{SourcePort: 80},
 		},
-		Source:         &pb.Endpoint{Namespace: "allow", PodName: "src_pod"},
-		Destination:    &pb.Endpoint{Namespace: "allow", PodName: "dst_pod"},
+		Source:         ir.Endpoint{Namespace: "allow", PodName: "src_pod"},
+		Destination:    ir.Endpoint{Namespace: "allow", PodName: "dst_pod"},
 		Verdict:        pb.Verdict_DROPPED,
 		DropReason:     uint32(pb.DropReason_POLICY_DENIED),
 		DropReasonDesc: pb.DropReason_POLICY_DENIED,
 	}
 
-	_, errs := dfp.OnDecodedFlow(t.Context(), flow1)
+	_, errs := dfp.OnDecodedFlow(t.Context(), &flow)
 	assert.NoError(t, errs)
 
 	metricFamilies, err := reg.Gather()
@@ -294,7 +291,7 @@ func TestMetricReRegisterAndCollect(t *testing.T) {
 	dfp.onConfigReload(t.Context(), 0, *cfg)
 	assert.NoError(t, errs)
 
-	_, errs = dfp.OnDecodedFlow(t.Context(), flow1)
+	_, errs = dfp.OnDecodedFlow(t.Context(), &flow)
 	assert.NoError(t, errs)
 
 	metricFamilies, err = reg.Gather()
@@ -340,21 +337,19 @@ func ConfigureAndFetchDynamicMetrics(t *testing.T, testName string, exportedMetr
 		dfp := DynamicFlowProcessor{registry: reg, logger: slog.Default()}
 		dfp.onConfigReload(t.Context(), 0, *cfg)
 
-		flow1 := &pb.Flow{
-			EventType: &pb.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
-			L4: &pb.Layer4{
-				Protocol: &pb.Layer4_TCP{
-					TCP: &pb.TCP{},
-				},
+		flow := ir.Flow{
+			EventType: ir.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
+			L4: ir.Layer4{
+				TCP: ir.TCP{},
 			},
-			Source:         &pb.Endpoint{Namespace: "allow", PodName: "src_pod"},
-			Destination:    &pb.Endpoint{Namespace: "allow", PodName: "dst_pod"},
+			Source:         ir.Endpoint{Namespace: "allow", PodName: "src_pod"},
+			Destination:    ir.Endpoint{Namespace: "allow", PodName: "dst_pod"},
 			Verdict:        pb.Verdict_DROPPED,
 			DropReason:     uint32(pb.DropReason_POLICY_DENIED),
 			DropReasonDesc: pb.DropReason_POLICY_DENIED,
 		}
 
-		_, errs := dfp.OnDecodedFlow(t.Context(), flow1)
+		_, errs := dfp.OnDecodedFlow(t.Context(), &flow)
 		assert.NoError(t, errs)
 
 		resp, err := http.Get("http://" + srv.Listener.Addr().String() + "/metrics")

--- a/pkg/hubble/metrics/policy/handler.go
+++ b/pkg/hubble/metrics/policy/handler.go
@@ -14,9 +14,9 @@ import (
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	"github.com/cilium/cilium/pkg/hubble/filters"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/metrics/api"
 	"github.com/cilium/cilium/pkg/identity"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
@@ -65,25 +65,25 @@ func (h *policyHandler) ListMetricVec() []*prometheus.MetricVec {
 	return []*prometheus.MetricVec{h.verdicts.MetricVec}
 }
 
-func (h *policyHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error {
+func (h *policyHandler) ProcessFlow(ctx context.Context, flow *ir.Flow) error {
 	if !filters.Apply(h.AllowList, h.DenyList, &v1.Event{Event: flow, Timestamp: &timestamppb.Timestamp{}}) {
 		return nil
 	}
 
-	if flow.GetEventType().GetType() == monitorAPI.MessageTypePolicyVerdict {
+	if flow.EventType.Type == monitorAPI.MessageTypePolicyVerdict {
 		return h.ProcessFlowL3L4(ctx, flow)
 	}
 
-	if flow.GetEventType().GetType() == monitorAPI.MessageTypeAccessLog {
+	if flow.EventType.Type == monitorAPI.MessageTypeAccessLog {
 		return h.ProcessFlowL7(ctx, flow)
 	}
 
 	return nil
 }
 
-func (h *policyHandler) ProcessFlowL3L4(ctx context.Context, flow *flowpb.Flow) error {
+func (h *policyHandler) ProcessFlowL3L4(ctx context.Context, flow *ir.Flow) error {
 	// ignore verdict if the source is host since host is allowed to connect to any local endpoints.
-	if flow.GetSource().GetIdentity() == uint32(identity.ReservedIdentityHost) {
+	if flow.Source.Identity == uint32(identity.ReservedIdentityHost) {
 		return nil
 	}
 	labelValues, err := h.context.GetLabelValues(flow)
@@ -91,8 +91,8 @@ func (h *policyHandler) ProcessFlowL3L4(ctx context.Context, flow *flowpb.Flow) 
 		return err
 	}
 
-	direction := strings.ToLower(flow.GetTrafficDirection().String())
-	match := strings.ToLower(monitorAPI.PolicyMatchType(flow.GetPolicyMatchType()).String())
+	direction := strings.ToLower(flow.TrafficDirection.String())
+	match := strings.ToLower(monitorAPI.PolicyMatchType(flow.PolicyMatchType).String())
 	action := strings.ToLower(flow.Verdict.String())
 	labels := []string{direction, match, action}
 	labels = append(labels, labelValues...)
@@ -101,19 +101,19 @@ func (h *policyHandler) ProcessFlowL3L4(ctx context.Context, flow *flowpb.Flow) 
 	return nil
 }
 
-func (h *policyHandler) ProcessFlowL7(ctx context.Context, flow *flowpb.Flow) error {
+func (h *policyHandler) ProcessFlowL7(ctx context.Context, flow *ir.Flow) error {
 	labelValues, err := h.context.GetLabelValues(flow)
 	if err != nil {
 		return err
 	}
 
-	direction := strings.ToLower(flow.GetTrafficDirection().String())
+	direction := strings.ToLower(flow.TrafficDirection.String())
 	var subType string
-	if l7 := flow.GetL7(); l7 != nil {
+	if !flow.L7.IsEmpty() {
 		switch {
-		case l7.GetDns() != nil:
+		case !flow.L7.DNS.IsEmpty():
 			subType = "dns"
-		case l7.GetHttp() != nil:
+		case !flow.L7.HTTP.IsEmpty():
 			subType = "http"
 		}
 	}

--- a/pkg/hubble/metrics/policy/handler_test.go
+++ b/pkg/hubble/metrics/policy/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/metrics/api"
 	"github.com/cilium/cilium/pkg/identity"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
@@ -22,8 +23,8 @@ func TestPolicyHandler(t *testing.T) {
 	h := &policyHandler{}
 	assert.NoError(t, h.Init(registry, &api.MetricConfig{}))
 	assert.NoError(t, testutil.CollectAndCompare(h.verdicts, strings.NewReader("")))
-	flow := flowpb.Flow{
-		EventType:        &flowpb.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
+	flow := ir.Flow{
+		EventType:        ir.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
 		PolicyMatchType:  monitorAPI.PolicyMatchNone,
 		Verdict:          flowpb.Verdict_DROPPED,
@@ -37,19 +38,19 @@ func TestPolicyHandler(t *testing.T) {
 
 	// Policy verdicts from host shouldn't be counted.
 	flow.PolicyMatchType = monitorAPI.PolicyMatchAll
-	flow.Source = &flowpb.Endpoint{Identity: uint32(identity.ReservedIdentityHost)}
+	flow.Source = ir.Endpoint{Identity: uint32(identity.ReservedIdentityHost)}
 	h.ProcessFlow(t.Context(), &flow)
 
 	// l7/http
-	flow.EventType = &flowpb.CiliumEventType{Type: monitorAPI.MessageTypeAccessLog}
+	flow.EventType = ir.CiliumEventType{Type: monitorAPI.MessageTypeAccessLog}
 	flow.Verdict = flowpb.Verdict_DROPPED
-	flow.L7 = &flowpb.Layer7{
-		Record: &flowpb.Layer7_Http{Http: &flowpb.HTTP{
+	flow.L7 = ir.Layer7{
+		HTTP: ir.HTTP{
 			Code:     0,
 			Method:   "POST",
-			Url:      "http://myhost/some/path",
+			URL:      "http://myhost/some/path",
 			Protocol: "http/1.1",
-		}}}
+		}}
 	h.ProcessFlow(t.Context(), &flow)
 
 	expected := strings.NewReader(`# HELP hubble_policy_verdicts_total Total number of Cilium network policy verdicts

--- a/pkg/hubble/metrics/port-distribution/handler.go
+++ b/pkg/hubble/metrics/port-distribution/handler.go
@@ -16,6 +16,7 @@ import (
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	"github.com/cilium/cilium/pkg/hubble/filters"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/metrics/api"
 )
 
@@ -62,12 +63,11 @@ func (h *portDistributionHandler) ListMetricVec() []*prometheus.MetricVec {
 	return []*prometheus.MetricVec{h.portDistribution.MetricVec}
 }
 
-func (h *portDistributionHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error {
-	// if we are not certain if a flow is a reply (i.e. flow.GetIsReply() == nil)
+func (h *portDistributionHandler) ProcessFlow(ctx context.Context, flow *ir.Flow) error {
+	// if we are not certain if a flow is a reply
 	// we do not want to consider its destination port for the metric
-	skipReply := flow.GetIsReply() == nil || flow.GetIsReply().GetValue()
-	if (flow.GetVerdict() != flowpb.Verdict_FORWARDED && flow.GetVerdict() != flowpb.Verdict_REDIRECTED) ||
-		flow.GetL4() == nil || skipReply {
+	skipReply := flow.Reply.IsEmpty() || flow.IsReply()
+	if (flow.Verdict != flowpb.Verdict_FORWARDED && flow.Verdict != flowpb.Verdict_REDIRECTED) || flow.L4.IsEmpty() || skipReply {
 		return nil
 	}
 
@@ -80,37 +80,37 @@ func (h *portDistributionHandler) ProcessFlow(ctx context.Context, flow *flowpb.
 		return err
 	}
 
-	if tcp := flow.GetL4().GetTCP(); tcp != nil {
+	if tcp := flow.L4.TCP; !tcp.IsEmpty() {
 		labels := append([]string{"TCP", fmt.Sprintf("%d", tcp.DestinationPort)}, labelValues...)
 		h.portDistribution.WithLabelValues(labels...).Inc()
 	}
 
-	if udp := flow.GetL4().GetUDP(); udp != nil {
+	if udp := flow.L4.UDP; !udp.IsEmpty() {
 		labels := append([]string{"UDP", fmt.Sprintf("%d", udp.DestinationPort)}, labelValues...)
 		h.portDistribution.WithLabelValues(labels...).Inc()
 	}
 
-	if sctp := flow.GetL4().GetSCTP(); sctp != nil {
+	if sctp := flow.L4.SCTP; !sctp.IsEmpty() {
 		labels := append([]string{"SCTP", fmt.Sprintf("%d", sctp.DestinationPort)}, labelValues...)
 		h.portDistribution.WithLabelValues(labels...).Inc()
 	}
 
-	if flow.GetL4().GetICMPv4() != nil {
+	if !flow.L4.ICMPv4.IsEmpty() {
 		labels := append([]string{"ICMPv4", "0"}, labelValues...)
 		h.portDistribution.WithLabelValues(labels...).Inc()
 	}
 
-	if flow.GetL4().GetICMPv6() != nil {
+	if !flow.L4.ICMPv6.IsEmpty() {
 		labels := append([]string{"ICMPv6", "0"}, labelValues...)
 		h.portDistribution.WithLabelValues(labels...).Inc()
 	}
 
-	if flow.GetL4().GetVRRP() != nil {
+	if !flow.L4.VRRP.IsEmpty() {
 		labels := append([]string{"VRRP", "0"}, labelValues...)
 		h.portDistribution.WithLabelValues(labels...).Inc()
 	}
 
-	if flow.GetL4().GetIGMP() != nil {
+	if !flow.L4.IGMP.IsEmpty() {
 		labels := append([]string{"IGMP", "0"}, labelValues...)
 		h.portDistribution.WithLabelValues(labels...).Inc()
 	}

--- a/pkg/hubble/metrics/port-distribution/handler_test.go
+++ b/pkg/hubble/metrics/port-distribution/handler_test.go
@@ -12,6 +12,7 @@ import (
 	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
 
 	pb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/metrics/api"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 )
@@ -136,19 +137,17 @@ func TestPortDistributionHandler(t *testing.T) {
 
 }
 
-func buildFlow(port uint32, verdict pb.Verdict, reply bool) *pb.Flow {
-	return &pb.Flow{
-		EventType: &pb.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
-		L4: &pb.Layer4{
-			Protocol: &pb.Layer4_TCP{
-				TCP: &pb.TCP{
-					DestinationPort: port,
-				},
+func buildFlow(port uint32, verdict pb.Verdict, reply bool) *ir.Flow {
+	return &ir.Flow{
+		EventType: ir.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				DestinationPort: port,
 			},
 		},
-		Source:      &pb.Endpoint{Namespace: "foo"},
-		Destination: &pb.Endpoint{Namespace: "bar"},
+		Source:      ir.Endpoint{Namespace: "foo"},
+		Destination: ir.Endpoint{Namespace: "bar"},
 		Verdict:     verdict,
-		IsReply:     &wrappers.BoolValue{Value: reply},
+		Reply:       ir.ProtoToReply(wrappers.Bool(reply)),
 	}
 }

--- a/pkg/hubble/metrics/sctp/handler_test.go
+++ b/pkg/hubble/metrics/sctp/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	pb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/metrics/api"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 )
@@ -106,21 +107,19 @@ func TestSCTPHandler(t *testing.T) {
 	}
 }
 
-func buildFlow(chunkType pb.SCTPChunkType) *pb.Flow {
-	return &pb.Flow{
-		EventType: &pb.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
-		IP: &pb.IP{
-			IpVersion: pb.IPVersion_IPv4,
+func buildFlow(chunkType pb.SCTPChunkType) *ir.Flow {
+	return &ir.Flow{
+		EventType: ir.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
+		IP: ir.IP{
+			IPVersion: pb.IPVersion_IPv4,
 		},
-		L4: &pb.Layer4{
-			Protocol: &pb.Layer4_SCTP{
-				SCTP: &pb.SCTP{
-					ChunkType: chunkType,
-				},
+		L4: ir.Layer4{
+			SCTP: ir.SCTP{
+				ChunkType: chunkType,
 			},
 		},
-		Source:      &pb.Endpoint{Namespace: "foo"},
-		Destination: &pb.Endpoint{Namespace: "bar"},
+		Source:      ir.Endpoint{Namespace: "foo"},
+		Destination: ir.Endpoint{Namespace: "bar"},
 		Verdict:     pb.Verdict_FORWARDED,
 	}
 }

--- a/pkg/hubble/metrics/tcp/handler.go
+++ b/pkg/hubble/metrics/tcp/handler.go
@@ -16,6 +16,7 @@ import (
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	"github.com/cilium/cilium/pkg/hubble/filters"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/metrics/api"
 )
 
@@ -62,15 +63,13 @@ func (h *tcpHandler) ListMetricVec() []*prometheus.MetricVec {
 	return []*prometheus.MetricVec{h.tcpFlags.MetricVec}
 }
 
-func (h *tcpHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error {
-	if (flow.GetVerdict() != flowpb.Verdict_FORWARDED && flow.GetVerdict() != flowpb.Verdict_REDIRECTED) ||
-		flow.GetL4() == nil {
+func (h *tcpHandler) ProcessFlow(ctx context.Context, flow *ir.Flow) error {
+	l4 := flow.L4
+	if (flow.Verdict != flowpb.Verdict_FORWARDED && flow.Verdict != flowpb.Verdict_REDIRECTED) || l4.IsEmpty() {
 		return nil
 	}
 
-	ip := flow.GetIP()
-	tcp := flow.GetL4().GetTCP()
-	if ip == nil || tcp == nil || tcp.Flags == nil {
+	if flow.IP.IsEmpty() || l4.TCP.IsEmpty() || l4.TCP.Flags.IsEmpty() {
 		return nil
 	}
 
@@ -82,15 +81,15 @@ func (h *tcpHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error {
 	if err != nil {
 		return err
 	}
-	labels := append([]string{"", ip.IpVersion.String()}, contextLabels...)
+	labels := append([]string{"", flow.IP.IPVersion.String()}, contextLabels...)
 
-	if tcp.Flags.FIN {
+	if l4.TCP.Flags.FIN {
 		labels[0] = "FIN"
 		h.tcpFlags.WithLabelValues(labels...).Inc()
 	}
 
-	if tcp.Flags.SYN {
-		if tcp.Flags.ACK {
+	if l4.TCP.Flags.SYN {
+		if l4.TCP.Flags.ACK {
 			labels[0] = "SYN-ACK"
 			h.tcpFlags.WithLabelValues(labels...).Inc()
 		} else {
@@ -99,7 +98,7 @@ func (h *tcpHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error {
 		}
 	}
 
-	if tcp.Flags.RST {
+	if l4.TCP.Flags.RST {
 		labels[0] = "RST"
 		h.tcpFlags.WithLabelValues(labels...).Inc()
 	}

--- a/pkg/hubble/metrics/tcp/handler_test.go
+++ b/pkg/hubble/metrics/tcp/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	pb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/metrics/api"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 )
@@ -45,14 +46,14 @@ func TestTcpHandler(t *testing.T) {
 
 	var supportedFlags = []struct {
 		name          string
-		flags         *pb.TCPFlags
+		flags         ir.TCPFlags
 		expectedLabel string
 	}{
-		{"SYN", &pb.TCPFlags{SYN: true}, "SYN"},
-		{"SYN_ACK", &pb.TCPFlags{SYN: true, ACK: true}, "SYN-ACK"},
-		{"FIN", &pb.TCPFlags{FIN: true}, "FIN"},
-		{"FIN_ACK", &pb.TCPFlags{FIN: true, ACK: true}, "FIN"},
-		{"RST", &pb.TCPFlags{RST: true}, "RST"},
+		{"SYN", ir.TCPFlags{SYN: true}, "SYN"},
+		{"SYN_ACK", ir.TCPFlags{SYN: true, ACK: true}, "SYN-ACK"},
+		{"FIN", ir.TCPFlags{FIN: true}, "FIN"},
+		{"FIN_ACK", ir.TCPFlags{FIN: true, ACK: true}, "FIN"},
+		{"RST", ir.TCPFlags{RST: true}, "RST"},
 	}
 
 	for _, tc := range supportedFlags {
@@ -108,15 +109,15 @@ func TestTcpHandler(t *testing.T) {
 
 	var unsupportedFlags = []struct {
 		name  string
-		flags *pb.TCPFlags
+		flags ir.TCPFlags
 	}{
-		{"empty", &pb.TCPFlags{}},
-		{"PSH", &pb.TCPFlags{PSH: true}},
-		{"ACK", &pb.TCPFlags{ACK: true}},
-		{"URG", &pb.TCPFlags{URG: true}},
-		{"ECE", &pb.TCPFlags{ECE: true}},
-		{"CWR", &pb.TCPFlags{CWR: true}},
-		{"NS", &pb.TCPFlags{NS: true}},
+		{"empty", ir.TCPFlags{}},
+		{"PSH", ir.TCPFlags{PSH: true}},
+		{"ACK", ir.TCPFlags{ACK: true}},
+		{"URG", ir.TCPFlags{URG: true}},
+		{"ECE", ir.TCPFlags{ECE: true}},
+		{"CWR", ir.TCPFlags{CWR: true}},
+		{"NS", ir.TCPFlags{NS: true}},
 	}
 
 	for _, tc := range unsupportedFlags {
@@ -150,21 +151,19 @@ func TestTcpHandler(t *testing.T) {
 
 }
 
-func buildFlow(flags *pb.TCPFlags) *pb.Flow {
-	return &pb.Flow{
-		EventType: &pb.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
-		IP: &pb.IP{
-			IpVersion: pb.IPVersion_IPv4,
+func buildFlow(flags ir.TCPFlags) *ir.Flow {
+	return &ir.Flow{
+		EventType: ir.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
+		IP: ir.IP{
+			IPVersion: pb.IPVersion_IPv4,
 		},
-		L4: &pb.Layer4{
-			Protocol: &pb.Layer4_TCP{
-				TCP: &pb.TCP{
-					Flags: flags,
-				},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				Flags: flags,
 			},
 		},
-		Source:      &pb.Endpoint{Namespace: "foo"},
-		Destination: &pb.Endpoint{Namespace: "bar"},
+		Source:      ir.Endpoint{Namespace: "foo"},
+		Destination: ir.Endpoint{Namespace: "bar"},
 		Verdict:     pb.Verdict_FORWARDED,
 	}
 }

--- a/pkg/hubble/observer/local_node_watcher.go
+++ b/pkg/hubble/observer/local_node_watcher.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"slices"
 
-	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/node"
 )
@@ -43,7 +43,7 @@ func NewLocalNodeWatcher(ctx context.Context, localNodeStore *node.LocalNodeStor
 
 // OnDecodedFlow implements OnDecodedFlow for LocalNodeWatcher. The
 // LocalNodeWatcher populate the flow's node_labels field.
-func (w *LocalNodeWatcher) OnDecodedFlow(_ context.Context, flow *flowpb.Flow) (bool, error) {
+func (w *LocalNodeWatcher) OnDecodedFlow(_ context.Context, flow *ir.Flow) (bool, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	flow.NodeLabels = w.cache.labels

--- a/pkg/hubble/observer/local_node_watcher_test.go
+++ b/pkg/hubble/observer/local_node_watcher_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/time"
@@ -66,11 +66,11 @@ func Test_LocalNodeWatcher(t *testing.T) {
 	})
 
 	t.Run("OnDecodedFlow", func(t *testing.T) {
-		var flow flowpb.Flow
+		var flow ir.Flow
 		stop, err := watcher.OnDecodedFlow(ctx, &flow)
 		require.False(t, stop)
 		require.NoError(t, err)
-		require.Equal(t, localNodeLabelSlice, flow.GetNodeLabels())
+		require.Equal(t, localNodeLabelSlice, flow.NodeLabels, "node labels mismatch")
 	})
 
 	t.Run("update", func(t *testing.T) {
@@ -80,11 +80,11 @@ func Test_LocalNodeWatcher(t *testing.T) {
 		require.EventuallyWithT(
 			t,
 			func(c *assert.CollectT) {
-				var flow flowpb.Flow
+				var flow ir.Flow
 				stop, err := watcher.OnDecodedFlow(ctx, &flow)
 				if assert.False(c, stop) {
 					assert.NoError(c, err)
-					assert.Equal(c, updatedNodeLabelSlice, flow.GetNodeLabels(), "node labels mismatch")
+					assert.Equal(c, updatedNodeLabelSlice, flow.NodeLabels, "node labels mismatch")
 				}
 			},
 			10*time.Second,
@@ -94,11 +94,11 @@ func Test_LocalNodeWatcher(t *testing.T) {
 
 	t.Run("complete", func(t *testing.T) {
 		watcher.complete(nil)
-		var flow flowpb.Flow
+		var flow ir.Flow
 		stop, err := watcher.OnDecodedFlow(ctx, &flow)
 		require.False(t, stop)
 		require.NoError(t, err)
-		require.Empty(t, flow.GetNodeLabels())
+		require.Empty(t, flow.NodeLabels, "node labels should be empty after complete")
 	})
 }
 

--- a/pkg/hubble/observer/local_observer.go
+++ b/pkg/hubble/observer/local_observer.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/build"
 	"github.com/cilium/cilium/pkg/hubble/container"
 	"github.com/cilium/cilium/pkg/hubble/filters"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/observer/namespace"
 	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	observerTypes "github.com/cilium/cilium/pkg/hubble/observer/types"
@@ -158,7 +159,7 @@ nextEvent:
 			continue
 		}
 
-		if flow, ok := ev.Event.(*flowpb.Flow); ok {
+		if flow, ok := ev.Event.(*ir.Flow); ok {
 			// track namespaces seen.
 			s.trackNamespaces(flow)
 			for _, f := range s.opts.OnDecodedFlow {
@@ -369,10 +370,11 @@ nextEvent:
 		var resp *observerpb.GetFlowsResponse
 
 		switch ev := e.Event.(type) {
-		case *flowpb.Flow:
+		case *ir.Flow:
+			fl := ev.ToProto()
 			eventsReader.eventCount++
 			for _, f := range s.opts.OnFlowDelivery {
-				stop, err := f.OnFlowDelivery(ctx, ev)
+				stop, err := f.OnFlowDelivery(ctx, fl)
 				switch {
 				case err != nil:
 					return err
@@ -382,14 +384,14 @@ nextEvent:
 			}
 			if mask.Active() {
 				// Copy only fields in the mask
-				mask.Copy(flow.ProtoReflect(), ev.ProtoReflect())
-				ev = flow
+				mask.Copy(flow.ProtoReflect(), fl.ProtoReflect())
+				fl = flow
 			}
 			resp = &observerpb.GetFlowsResponse{
-				Time:     ev.GetTime(),
-				NodeName: ev.GetNodeName(),
+				Time:     fl.GetTime(),
+				NodeName: fl.GetNodeName(),
 				ResponseTypes: &observerpb.GetFlowsResponse_Flow{
-					Flow: ev,
+					Flow: fl,
 				},
 			}
 		case *flowpb.LostEvent:
@@ -701,15 +703,15 @@ func (r *eventsReader) Next(ctx context.Context) (*v1.Event, error) {
 	}
 }
 
-func (s *LocalObserverServer) trackNamespaces(flow *flowpb.Flow) {
+func (s *LocalObserverServer) trackNamespaces(flow *ir.Flow) {
 	// track namespaces seen.
-	if srcNs := flow.GetSource().GetNamespace(); srcNs != "" {
+	if srcNs := flow.Source.Namespace; srcNs != "" {
 		s.nsManager.AddNamespace(&observerpb.Namespace{
 			Namespace: srcNs,
 			Cluster:   nodeTypes.GetClusterName(),
 		})
 	}
-	if dstNs := flow.GetDestination().GetNamespace(); dstNs != "" {
+	if dstNs := flow.Destination.Namespace; dstNs != "" {
 		s.nsManager.AddNamespace(&observerpb.Namespace{
 			Namespace: dstNs,
 			Cluster:   nodeTypes.GetClusterName(),

--- a/pkg/hubble/observer/local_observer_test.go
+++ b/pkg/hubble/observer/local_observer_test.go
@@ -25,6 +25,7 @@ import (
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 	hubv1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	"github.com/cilium/cilium/pkg/hubble/container"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/observer/namespace"
 	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	observerTypes "github.com/cilium/cilium/pkg/hubble/observer/types"
@@ -248,7 +249,7 @@ func TestLocalObserverServer_GetFlows(t *testing.T) {
 		m <- event
 		ev, err := pp.Decode(event)
 		require.NoError(t, err)
-		input[i] = ev.GetFlow()
+		input[i] = ev.GetFlow().ToProto()
 	}
 	close(s.GetEventsChannel())
 	<-s.GetStopped()
@@ -494,7 +495,7 @@ func TestHooks(t *testing.T) {
 		}
 		return false, nil
 	}
-	onDecodedFlow := func(ctx context.Context, f *flowpb.Flow) (bool, error) {
+	onDecodedFlow := func(ctx context.Context, f *ir.Flow) (bool, error) {
 		if seenFlows%skipEveryNFlows == 0 {
 			assert.Fail(t, "server did not stop decoding after onMonitorEventFirst")
 		}
@@ -774,14 +775,14 @@ func Benchmark_TrackNamespaces(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	f := &flowpb.Flow{
-		Source:      &flowpb.Endpoint{Namespace: "foo"},
-		Destination: &flowpb.Endpoint{Namespace: "bar"},
+	f := ir.Flow{
+		Source:      ir.Endpoint{Namespace: "foo"},
+		Destination: ir.Endpoint{Namespace: "bar"},
 	}
 
 	b.ReportAllocs()
 
 	for b.Loop() {
-		s.trackNamespaces(f)
+		s.trackNamespaces(&f)
 	}
 }

--- a/pkg/hubble/observer/observeroption/option.go
+++ b/pkg/hubble/observer/observeroption/option.go
@@ -13,6 +13,7 @@ import (
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	"github.com/cilium/cilium/pkg/hubble/container"
 	"github.com/cilium/cilium/pkg/hubble/filters"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	observerTypes "github.com/cilium/cilium/pkg/hubble/observer/types"
 	"github.com/cilium/cilium/pkg/time"
 )
@@ -74,14 +75,14 @@ func (f OnMonitorEventFunc) OnMonitorEvent(ctx context.Context, event *observerT
 
 // OnDecodedFlow is invoked after a flow has been decoded
 type OnDecodedFlow interface {
-	OnDecodedFlow(context.Context, *pb.Flow) (stop, error)
+	OnDecodedFlow(context.Context, *ir.Flow) (stop, error)
 }
 
 // OnDecodedFlowFunc implements OnDecodedFlow for a single function
-type OnDecodedFlowFunc func(context.Context, *pb.Flow) (stop, error)
+type OnDecodedFlowFunc func(context.Context, *ir.Flow) (stop, error)
 
 // OnDecodedFlow is invoked after a flow has been decoded
-func (f OnDecodedFlowFunc) OnDecodedFlow(ctx context.Context, flow *pb.Flow) (stop, error) {
+func (f OnDecodedFlowFunc) OnDecodedFlow(ctx context.Context, flow *ir.Flow) (stop, error) {
 	return f(ctx, flow)
 }
 
@@ -187,7 +188,7 @@ func WithOnDecodedFlow(f OnDecodedFlow) Option {
 }
 
 // WithOnDecodedFlowFunc adds a new callback to be invoked after decoding
-func WithOnDecodedFlowFunc(f func(context.Context, *pb.Flow) (stop, error)) Option {
+func WithOnDecodedFlowFunc(f func(context.Context, *ir.Flow) (stop, error)) Option {
 	return WithOnDecodedFlow(OnDecodedFlowFunc(f))
 }
 

--- a/pkg/hubble/parser/cell/cell.go
+++ b/pkg/hubble/parser/cell/cell.go
@@ -13,12 +13,12 @@ import (
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/statedb"
 
-	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/cgroups/manager"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/link"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/hubble/parser"
+	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	hubbleGetters "github.com/cilium/cilium/pkg/hubble/parser/getters"
 	parserOptions "github.com/cilium/cilium/pkg/hubble/parser/options"
 	"github.com/cilium/cilium/pkg/identity"
@@ -162,9 +162,9 @@ func (h *payloadGetters) GetNamesOf(sourceEpID uint32, ip netip.Addr) []string {
 
 // GetServiceByAddr implements ServiceGetter. It looks up service by IP/port.
 // Hubble uses this function to annotate flows with service information.
-func (h *payloadGetters) GetServiceByAddr(ip netip.Addr, port uint16) *flowpb.Service {
+func (h *payloadGetters) GetServiceByAddr(ip netip.Addr, port uint16) getters.FQN {
 	if !ip.IsValid() {
-		return nil
+		return getters.BlankFQN
 	}
 	addrCluster := cmtypes.AddrClusterFrom(ip, 0)
 	txn := h.db.ReadTxn()
@@ -173,10 +173,8 @@ func (h *payloadGetters) GetServiceByAddr(ip netip.Addr, port uint16) *flowpb.Se
 		fe, found = loadbalancer.LookupFrontendByTuple(txn, h.frontends, addrCluster, loadbalancer.UDP, port, loadbalancer.ScopeExternal)
 	}
 	if !found {
-		return nil
+		return getters.BlankFQN
 	}
-	return &flowpb.Service{
-		Namespace: fe.ServiceName.Namespace(),
-		Name:      fe.ServiceName.Name(),
-	}
+
+	return getters.NewFQN(fe.ServiceName.Namespace(), fe.ServiceName.Name())
 }

--- a/pkg/hubble/parser/cell/cell_test.go
+++ b/pkg/hubble/parser/cell/cell_test.go
@@ -32,18 +32,18 @@ func TestPayloadGetters_GetServiceByAddr(t *testing.T) {
 
 	pg := payloadGetters{db: db, frontends: fes}
 
-	svc := pg.GetServiceByAddr(addrTCP.Addr(), 80)
-	require.NotNil(t, svc)
-	require.Equal(t, svcNameTCP.Namespace(), svc.Namespace)
-	require.Equal(t, svcNameTCP.Name(), svc.Name)
+	fqn := pg.GetServiceByAddr(addrTCP.Addr(), 80)
+	require.False(t, fqn.IsBlank())
+	require.Equal(t, svcNameTCP.Namespace(), fqn.Namespace)
+	require.Equal(t, svcNameTCP.Name(), fqn.Name)
 
-	svc = pg.GetServiceByAddr(addrUDP.Addr(), 80)
-	require.NotNil(t, svc)
-	require.Equal(t, svcNameUDP.Namespace(), svc.Namespace)
-	require.Equal(t, svcNameUDP.Name(), svc.Name)
+	fqn = pg.GetServiceByAddr(addrUDP.Addr(), 80)
+	require.False(t, fqn.IsBlank())
+	require.Equal(t, svcNameUDP.Namespace(), fqn.Namespace)
+	require.Equal(t, svcNameUDP.Name(), fqn.Name)
 
-	svc = pg.GetServiceByAddr(addrUDP.Addr(), 81)
-	require.Nil(t, svc)
+	fqn = pg.GetServiceByAddr(addrUDP.Addr(), 81)
+	require.True(t, fqn.IsBlank())
 }
 
 func BenchmarkGetServiceByAddr(b *testing.B) {
@@ -55,9 +55,9 @@ func BenchmarkGetServiceByAddr(b *testing.B) {
 	b.ResetTimer()
 	for b.Loop() {
 		addr, port := randomAddrPort()
-		svc := pg.GetServiceByAddr(addr, port)
-		if svc != nil {
-			b.Fatal("non-nil svc")
+		fqn := pg.GetServiceByAddr(addr, port)
+		if !fqn.IsBlank() {
+			b.Fatal("non-empty fqn")
 		}
 	}
 

--- a/pkg/hubble/parser/common/endpoint.go
+++ b/pkg/hubble/parser/common/endpoint.go
@@ -8,6 +8,7 @@ import (
 	"net/netip"
 
 	pb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	"github.com/cilium/cilium/pkg/identity"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
@@ -48,7 +49,7 @@ func NewEndpointResolver(
 	}
 }
 
-func (r *EndpointResolver) ResolveEndpoint(ip netip.Addr, datapathSecurityIdentity uint32, context DatapathContext) *pb.Endpoint {
+func (r *EndpointResolver) ResolveEndpoint(ip netip.Addr, datapathSecurityIdentity uint32, context DatapathContext) ir.Endpoint {
 	// The datapathSecurityIdentity parameter is the numeric security identity
 	// obtained from the datapath.
 	// The numeric identity from the datapath can differ from the one we obtain
@@ -140,19 +141,19 @@ func (r *EndpointResolver) ResolveEndpoint(ip netip.Addr, datapathSecurityIdenti
 		if ep, ok := r.endpointGetter.GetEndpointInfo(ip); ok {
 			epIdentity := resolveIdentityConflict(ep.GetIdentity(), true)
 			labels := ep.GetLabels()
-			e := &pb.Endpoint{
+			e := ir.Endpoint{
 				ID:          uint32(ep.GetID()),
 				Identity:    epIdentity,
 				ClusterName: (labels[k8sConst.PolicyLabelCluster]).Value,
 				Namespace:   ep.GetK8sNamespace(),
 				Labels:      SortAndFilterLabels(r.log, labels.GetModel(), identity.NumericIdentity(epIdentity)),
 				PodName:     ep.GetK8sPodName(),
-				PodUid:      ep.GetK8sPodUID(),
+				PodUID:      ep.GetK8sPodUID(),
 			}
 			if pod := ep.GetPod(); pod != nil {
 				workload, workloadTypeMeta, ok := utils.GetWorkloadMetaFromPod(pod)
 				if ok {
-					e.Workloads = []*pb.Workload{{Kind: workloadTypeMeta.Kind, Name: workload.Name}}
+					e.Workloads = []ir.Workload{{Kind: workloadTypeMeta.Kind, Name: workload.Name}}
 				}
 			}
 			return e
@@ -185,12 +186,12 @@ func (r *EndpointResolver) ResolveEndpoint(ip netip.Addr, datapathSecurityIdenti
 		}
 	}
 
-	return &pb.Endpoint{
+	return ir.Endpoint{
 		Identity:    numericIdentity,
 		ClusterName: clusterName,
 		Namespace:   namespace,
 		Labels:      labels,
 		PodName:     podName,
-		PodUid:      podUID,
+		PodUID:      podUID,
 	}
 }

--- a/pkg/hubble/parser/common/endpoint_test.go
+++ b/pkg/hubble/parser/common/endpoint_test.go
@@ -31,7 +31,7 @@ func TestResolveEndpointPodUID(t *testing.T) {
 
 		endpoint := resolver.ResolveEndpoint(ip, 0, DatapathContext{})
 
-		assert.Equal(t, "local-pod-uid", endpoint.GetPodUid())
+		assert.Equal(t, "local-pod-uid", endpoint.PodUID)
 	})
 
 	t.Run("local endpoint Pod fallback", func(t *testing.T) {
@@ -48,7 +48,7 @@ func TestResolveEndpointPodUID(t *testing.T) {
 
 		endpoint := resolver.ResolveEndpoint(ip, 0, DatapathContext{})
 
-		assert.Equal(t, "cached-pod-uid", endpoint.GetPodUid())
+		assert.Equal(t, "cached-pod-uid", endpoint.PodUID)
 	})
 
 	t.Run("remote endpoint", func(t *testing.T) {
@@ -64,7 +64,7 @@ func TestResolveEndpointPodUID(t *testing.T) {
 
 		endpoint := resolver.ResolveEndpoint(ip, 0, DatapathContext{})
 
-		assert.Equal(t, "remote-pod-uid", endpoint.GetPodUid())
+		assert.Equal(t, "remote-pod-uid", endpoint.PodUID)
 	})
 
 	t.Run("unknown UID", func(t *testing.T) {
@@ -72,6 +72,6 @@ func TestResolveEndpointPodUID(t *testing.T) {
 
 		endpoint := resolver.ResolveEndpoint(ip, 0, DatapathContext{})
 
-		assert.Empty(t, endpoint.GetPodUid())
+		assert.Empty(t, endpoint.PodUID)
 	})
 }

--- a/pkg/hubble/parser/getters/fqn.go
+++ b/pkg/hubble/parser/getters/fqn.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package getters
+
+// BlankFQN is an empty FQN.
+var BlankFQN FQN
+
+// FQN represents a fully qualified name of a Kubernetes resource.
+type FQN struct {
+	Namespace, Name string
+}
+
+// NewFQN creates a new instance.
+func NewFQN(namespace, name string) FQN {
+	if namespace == "" && name == "" {
+		return BlankFQN
+	}
+
+	return FQN{
+		Namespace: namespace,
+		Name:      name,
+	}
+}
+
+// IsBlank returns true if the FQN is empty.
+func (f FQN) IsBlank() bool {
+	return f == BlankFQN
+}

--- a/pkg/hubble/parser/getters/fqn_test.go
+++ b/pkg/hubble/parser/getters/fqn_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package getters
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewFQN(t *testing.T) {
+	uu := map[string]struct {
+		name      string
+		namespace string
+		e         FQN
+	}{
+		"blank": {
+			e: BlankFQN,
+		},
+
+		"namespace only": {
+			namespace: "ns",
+			e:         NewFQN("ns", ""),
+		},
+
+		"name only": {
+			name: "name",
+			e:    NewFQN("", "name"),
+		},
+
+		"full": {
+			namespace: "ns",
+			name:      "name",
+			e:         NewFQN("ns", "name"),
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			fqn := NewFQN(u.namespace, u.name)
+			assert.Equal(t, u.e, fqn)
+		})
+	}
+}
+
+func TestFQNIsBlank(t *testing.T) {
+	uu := map[string]struct {
+		fqn FQN
+		e   bool
+	}{
+		"empty": {
+			fqn: FQN{},
+			e:   true,
+		},
+
+		"blank": {
+			fqn: BlankFQN,
+			e:   true,
+		},
+
+		"namespace only": {
+			fqn: NewFQN("ns", ""),
+		},
+
+		"name only": {
+			fqn: NewFQN("", "name"),
+		},
+
+		"full": {
+			fqn: NewFQN("ns", "name"),
+		},
+	}
+
+	for k, u := range uu {
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, u.fqn.IsBlank())
+		})
+	}
+}

--- a/pkg/hubble/parser/getters/getters.go
+++ b/pkg/hubble/parser/getters/getters.go
@@ -6,7 +6,6 @@ package getters
 import (
 	"net/netip"
 
-	flowpb "github.com/cilium/cilium/api/v1/flow"
 	cgroupManager "github.com/cilium/cilium/pkg/cgroups/manager"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -48,7 +47,7 @@ type IPGetter interface {
 
 // ServiceGetter fetches service metadata.
 type ServiceGetter interface {
-	GetServiceByAddr(ip netip.Addr, port uint16) *flowpb.Service
+	GetServiceByAddr(ip netip.Addr, port uint16) FQN
 }
 
 // LinkGetter fetches local link information.

--- a/pkg/hubble/parser/options/options.go
+++ b/pkg/hubble/parser/options/options.go
@@ -7,7 +7,7 @@ import (
 	"net/netip"
 	"strings"
 
-	pb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/monitor"
 )
 
@@ -78,7 +78,7 @@ func WithSkipUnknownCGroupIDs(enabled bool) Option {
 	}
 }
 
-type DropNotifyDecoderFunc func(data []byte, decoded *pb.Flow) (*monitor.DropNotify, error)
+type DropNotifyDecoderFunc func(data []byte, decoded *ir.Flow) (*monitor.DropNotify, error)
 
 func WithDropNotifyDecoder(decode DropNotifyDecoderFunc) Option {
 	return func(opt *Options) {
@@ -94,7 +94,7 @@ func WithDebugMsgDecoder(decode DebugMsgDecoderFunc) Option {
 	}
 }
 
-type DebugCaptureDecoderFunc func(data []byte, decoded *pb.Flow) (*monitor.DebugCapture, error)
+type DebugCaptureDecoderFunc func(data []byte, decoded *ir.Flow) (*monitor.DebugCapture, error)
 
 func WithDebugCaptureDecoder(decode DebugCaptureDecoderFunc) Option {
 	return func(opt *Options) {
@@ -102,7 +102,7 @@ func WithDebugCaptureDecoder(decode DebugCaptureDecoderFunc) Option {
 	}
 }
 
-type TraceNotifyDecoderFunc func(data []byte, decoded *pb.Flow) (*monitor.TraceNotify, error)
+type TraceNotifyDecoderFunc func(data []byte, decoded *ir.Flow) (*monitor.TraceNotify, error)
 
 func WithTraceNotifyDecoder(decode TraceNotifyDecoderFunc) Option {
 	return func(opt *Options) {
@@ -110,7 +110,7 @@ func WithTraceNotifyDecoder(decode TraceNotifyDecoderFunc) Option {
 	}
 }
 
-type PolicyVerdictNotifyDecoderFunc func(data []byte, decoded *pb.Flow) (*monitor.PolicyVerdictNotify, error)
+type PolicyVerdictNotifyDecoderFunc func(data []byte, decoded *ir.Flow) (*monitor.PolicyVerdictNotify, error)
 
 func WithPolicyVerdictNotifyDecoder(decode PolicyVerdictNotifyDecoderFunc) Option {
 	return func(opt *Options) {
@@ -118,7 +118,7 @@ func WithPolicyVerdictNotifyDecoder(decode PolicyVerdictNotifyDecoderFunc) Optio
 	}
 }
 
-type TraceSockNotifyDecoderFunc func(data []byte, decoded *pb.Flow) (*monitor.TraceSockNotify, error)
+type TraceSockNotifyDecoderFunc func(data []byte, decoded *ir.Flow) (*monitor.TraceSockNotify, error)
 
 func WithTraceSockNotifyDecoder(decode TraceSockNotifyDecoderFunc) Option {
 	return func(opt *Options) {
@@ -127,7 +127,7 @@ func WithTraceSockNotifyDecoder(decode TraceSockNotifyDecoderFunc) Option {
 }
 
 type L34PacketDecoder interface {
-	DecodePacket(payload []byte, decoded *pb.Flow, isL3Device, isIPv6, isVXLAN, isGeneve bool) (
+	DecodePacket(payload []byte, decoded *ir.Flow, isL3Device, isIPv6, isVXLAN, isGeneve bool) (
 		sourceIP, destinationIP netip.Addr,
 		sourcePort, destinationPort uint16,
 		err error,

--- a/pkg/hubble/parser/parser.go
+++ b/pkg/hubble/parser/parser.go
@@ -13,6 +13,7 @@ import (
 
 	pb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	observerTypes "github.com/cilium/cilium/pkg/hubble/observer/types"
 	"github.com/cilium/cilium/pkg/hubble/parser/agent"
 	"github.com/cilium/cilium/pkg/hubble/parser/debug"
@@ -114,12 +115,12 @@ func (p *Parser) Decode(monitorEvent *observerTypes.MonitorEvent) (*v1.Event, er
 			return nil, errors.ErrEmptyData
 		}
 
-		flow := &pb.Flow{
-			Emitter: &pb.Emitter{
+		flow := ir.Flow{
+			Emitter: ir.Emitter{
 				Name:    v1.FlowEmitter,
 				Version: v1.FlowEmitterVersion,
 			},
-			Uuid: monitorEvent.UUID.String(),
+			UUID: monitorEvent.UUID.String(),
 		}
 		switch payload.Data[0] {
 		case monitorAPI.MessageTypeDebug:
@@ -133,42 +134,42 @@ func (p *Parser) Decode(monitorEvent *observerTypes.MonitorEvent) (*v1.Event, er
 			ev.Event = dbg
 			return ev, nil
 		case monitorAPI.MessageTypeTraceSock:
-			if err := p.sock.Decode(payload.Data, flow); err != nil {
+			if err := p.sock.Decode(payload.Data, &flow); err != nil {
 				return nil, err
 			}
 		default:
-			if err := p.l34.Decode(payload.Data, flow); err != nil {
+			if err := p.l34.Decode(payload.Data, &flow); err != nil {
 				return nil, err
 			}
 		}
 		// FIXME: Time and NodeName are now part of GetFlowsResponse. We
 		// populate these fields for compatibility with old clients.
-		flow.Time = ts
+		flow.Time = monitorEvent.Timestamp
 		flow.NodeName = monitorEvent.NodeName
-		ev.Event = flow
+		ev.Event = &flow
 		return ev, nil
 	case *observerTypes.AgentEvent:
 		switch payload.Type {
 		case monitorAPI.MessageTypeAccessLog:
-			flow := &pb.Flow{
-				Emitter: &pb.Emitter{
+			flow := ir.Flow{
+				Emitter: ir.Emitter{
 					Name:    v1.FlowEmitter,
 					Version: v1.FlowEmitterVersion,
 				},
-				Uuid: monitorEvent.UUID.String(),
+				UUID: monitorEvent.UUID.String(),
 			}
 			logrecord, ok := payload.Message.(accesslog.LogRecord)
 			if !ok {
 				return nil, errors.ErrInvalidAgentMessageType
 			}
-			if err := p.l7.Decode(&logrecord, flow); err != nil {
+			if err := p.l7.Decode(&logrecord, &flow); err != nil {
 				return nil, err
 			}
 			// FIXME: Time and NodeName are now part of GetFlowsResponse. We
 			// populate these fields for compatibility with old clients.
-			flow.Time = ts
+			flow.Time = monitorEvent.Timestamp
 			flow.NodeName = monitorEvent.NodeName
-			ev.Event = flow
+			ev.Event = &flow
 			return ev, nil
 		case monitorAPI.MessageTypeAgent:
 			agentNotifyMessage, ok := payload.Message.(monitorAPI.AgentNotifyMessage)

--- a/pkg/hubble/parser/parser_test.go
+++ b/pkg/hubble/parser/parser_test.go
@@ -10,11 +10,13 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	observerTypes "github.com/cilium/cilium/pkg/hubble/observer/types"
 	"github.com/cilium/cilium/pkg/hubble/parser/errors"
 	"github.com/cilium/cilium/pkg/hubble/testutils"
@@ -66,10 +68,12 @@ func Test_ParserDispatch(t *testing.T) {
 			Data: data,
 		},
 	})
+	f := e.GetFlow()
+	require.NotNil(t, f)
 	assert.NoError(t, err)
-	assert.Equal(t, flowpb.FlowType_L3_L4, e.GetFlow().GetType())
-	assert.Equal(t, id.String(), e.GetFlow().GetUuid())
-	assert.Equal(t, &flowpb.Emitter{Name: v1.FlowEmitter, Version: v1.FlowEmitterVersion}, e.GetFlow().GetEmitter())
+	assert.Equal(t, flowpb.FlowType_L3_L4, f.Type)
+	assert.Equal(t, id.String(), f.UUID)
+	assert.Equal(t, ir.Emitter{Name: v1.FlowEmitter, Version: v1.FlowEmitterVersion}, f.Emitter)
 
 	// Test L7 dispatch
 	node := "k8s1"
@@ -84,10 +88,12 @@ func Test_ParserDispatch(t *testing.T) {
 		},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, node, e.GetFlow().GetNodeName())
-	assert.Equal(t, flowpb.FlowType_L7, e.GetFlow().GetType())
-	assert.Equal(t, id.String(), e.GetFlow().GetUuid())
-	assert.Equal(t, &flowpb.Emitter{Name: v1.FlowEmitter, Version: v1.FlowEmitterVersion}, e.GetFlow().GetEmitter())
+	f = e.GetFlow()
+	require.NotNil(t, f)
+	assert.Equal(t, node, f.NodeName)
+	assert.Equal(t, flowpb.FlowType_L7, f.Type)
+	assert.Equal(t, id.String(), f.UUID)
+	assert.Equal(t, ir.Emitter{Name: v1.FlowEmitter, Version: v1.FlowEmitterVersion}, f.Emitter)
 }
 
 func Test_EventType_RecordLost(t *testing.T) {

--- a/pkg/hubble/parser/seven/dns.go
+++ b/pkg/hubble/parser/seven/dns.go
@@ -9,23 +9,21 @@ import (
 
 	"github.com/gopacket/gopacket/layers"
 
-	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 )
 
-func decodeDNS(flowType accesslog.FlowType, dns *accesslog.LogRecordDNS) *flowpb.Layer7_Dns {
+func decodeDNS(flowType accesslog.FlowType, dns *accesslog.LogRecordDNS) ir.DNS {
 	qtypes := make([]string, 0, len(dns.QTypes))
 	for _, qtype := range dns.QTypes {
 		qtypes = append(qtypes, layers.DNSType(qtype).String())
 	}
 	if flowType == accesslog.TypeRequest {
 		// Set only fields that are relevant for requests.
-		return &flowpb.Layer7_Dns{
-			Dns: &flowpb.DNS{
-				Query:             dns.Query,
-				ObservationSource: string(dns.ObservationSource),
-				Qtypes:            qtypes,
-			},
+		return ir.DNS{
+			Query:             dns.Query,
+			ObservationSource: string(dns.ObservationSource),
+			Qtypes:            qtypes,
 		}
 	}
 	ips := make([]string, 0, len(dns.IPs))
@@ -36,17 +34,15 @@ func decodeDNS(flowType accesslog.FlowType, dns *accesslog.LogRecordDNS) *flowpb
 	for _, rtype := range dns.AnswerTypes {
 		rtypes = append(rtypes, layers.DNSType(rtype).String())
 	}
-	return &flowpb.Layer7_Dns{
-		Dns: &flowpb.DNS{
-			Query:             dns.Query,
-			Ips:               ips,
-			Ttl:               dns.TTL,
-			Cnames:            dns.CNAMEs,
-			ObservationSource: string(dns.ObservationSource),
-			Rcode:             uint32(dns.RCode),
-			Qtypes:            qtypes,
-			Rrtypes:           rtypes,
-		},
+	return ir.DNS{
+		Query:             dns.Query,
+		Ips:               ips,
+		TTL:               dns.TTL,
+		CNames:            dns.CNAMEs,
+		ObservationSource: string(dns.ObservationSource),
+		RCode:             uint32(dns.RCode),
+		Qtypes:            qtypes,
+		Rtypes:            rtypes,
 	}
 }
 

--- a/pkg/hubble/parser/seven/dns_test.go
+++ b/pkg/hubble/parser/seven/dns_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/testutils"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -52,40 +53,38 @@ func TestDecodeL7DNSRecord(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), dnsGetter, ipGetter, serviceGetter, endpointGetter)
 	require.NoError(t, err)
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(lr, f)
+	var f ir.Flow
+	err = parser.Decode(lr, &f)
 	require.NoError(t, err)
 
-	ts := f.GetTime().AsTime()
-	assert.Equal(t, fakeTimestamp, ts.Format(time.RFC3339Nano))
+	assert.Equal(t, fakeTimestamp, f.Time.Format(time.RFC3339Nano))
+	assert.Equal(t, fakeSourceEndpoint.IPv6, f.IP.Destination)
+	assert.Equal(t, uint32(56789), f.L4.UDP.DestinationPort)
+	assert.Equal(t, []string(nil), f.DestinationNames)
+	assert.Equal(t, fakeSourceEndpoint.Labels.GetModel(), f.Destination.Labels)
+	assert.Empty(t, f.Destination.Namespace)
+	assert.Empty(t, f.Destination.PodName)
+	assert.Empty(t, f.DestinationService.Namespace)
+	assert.Empty(t, f.DestinationService.Name)
 
-	assert.Equal(t, fakeSourceEndpoint.IPv6, f.GetIP().GetDestination())
-	assert.Equal(t, uint32(56789), f.GetL4().GetUDP().GetDestinationPort())
-	assert.Equal(t, []string(nil), f.GetDestinationNames())
-	assert.Equal(t, fakeSourceEndpoint.Labels.GetModel(), f.GetDestination().GetLabels())
-	assert.Empty(t, f.GetDestination().GetNamespace())
-	assert.Empty(t, f.GetDestination().GetPodName())
-	assert.Empty(t, f.GetDestinationService().GetNamespace())
-	assert.Empty(t, f.GetDestinationService().GetName())
+	assert.Equal(t, fakeDestinationEndpoint.IPv6, f.IP.Source)
+	assert.Equal(t, uint32(53), f.L4.UDP.SourcePort)
+	assert.Equal(t, []string(nil), f.SourceNames)
+	assert.Equal(t, fakeDestinationEndpoint.Labels.GetModel(), f.Source.Labels)
+	assert.Empty(t, f.Source.Namespace)
+	assert.Empty(t, f.Source.PodName)
+	assert.Empty(t, f.SourceService.Namespace)
+	assert.Empty(t, f.SourceService.Name)
 
-	assert.Equal(t, fakeDestinationEndpoint.IPv6, f.GetIP().GetSource())
-	assert.Equal(t, uint32(53), f.GetL4().GetUDP().GetSourcePort())
-	assert.Equal(t, []string(nil), f.GetSourceNames())
-	assert.Equal(t, fakeDestinationEndpoint.Labels.GetModel(), f.GetSource().GetLabels())
-	assert.Empty(t, f.GetSource().GetNamespace())
-	assert.Empty(t, f.GetSource().GetPodName())
-	assert.Empty(t, f.GetSourceService().GetNamespace())
-	assert.Empty(t, f.GetSourceService().GetName())
+	assert.Equal(t, flowpb.Verdict_FORWARDED, f.Verdict)
 
-	assert.Equal(t, flowpb.Verdict_FORWARDED, f.GetVerdict())
-
-	assert.Equal(t, &flowpb.DNS{
+	assert.Equal(t, ir.DNS{
 		Query:             "deathstar.empire.svc.cluster.local.",
 		Ips:               []string{"1.2.3.4"},
-		Ttl:               5,
+		TTL:               5,
 		ObservationSource: string(accesslog.DNSSourceProxy),
-		Rcode:             0,
+		RCode:             0,
 		Qtypes:            []string{"A"},
-		Rrtypes:           []string{"A"},
-	}, f.GetL7().GetDns())
+		Rtypes:            []string{"A"},
+	}, f.L7.DNS)
 }

--- a/pkg/hubble/parser/seven/http.go
+++ b/pkg/hubble/parser/seven/http.go
@@ -4,60 +4,64 @@
 package seven
 
 import (
-	"fmt"
 	"maps"
 	"net/url"
 	"slices"
+	"strconv"
 	"strings"
 
-	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/hubble/defaults"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/parser/options"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/time"
 )
 
-func decodeHTTP(flowType accesslog.FlowType, http *accesslog.LogRecordHTTP, opts *options.Options) *flowpb.Layer7_Http {
-	var headers []*flowpb.HTTPHeader
+func decodeHTTP(flowType accesslog.FlowType, http *accesslog.LogRecordHTTP, opts *options.Options) ir.HTTP {
+	var headers []ir.HTTPHeader
+	if len(http.Headers) > 0 {
+		var max int
+		for v := range maps.Values(http.Headers) {
+			max += len(v)
+		}
+		headers = make([]ir.HTTPHeader, 0, max)
+	}
+
+	// !!BOZO!! Why do we need to sort headers?
 	for _, key := range slices.Sorted(maps.Keys(http.Headers)) {
 		for _, value := range http.Headers[key] {
 			filteredValue := filterHeader(key, value, opts.HubbleRedactSettings)
-			headers = append(headers, &flowpb.HTTPHeader{Key: key, Value: filteredValue})
+			headers = append(headers, ir.HTTPHeader{Key: key, Value: filteredValue})
 		}
 	}
 	uri := filteredURL(http.URL, opts.HubbleRedactSettings)
 
 	if flowType == accesslog.TypeRequest {
 		// Set only fields that are relevant for requests.
-		return &flowpb.Layer7_Http{
-			Http: &flowpb.HTTP{
-				Method:   http.Method,
-				Protocol: http.Protocol,
-				Url:      uri.String(),
-				Headers:  headers,
-			},
+		return ir.HTTP{
+			Method:   http.Method,
+			Protocol: http.Protocol,
+			URL:      uri.String(),
+			Headers:  headers,
 		}
 	}
 
-	return &flowpb.Layer7_Http{
-		Http: &flowpb.HTTP{
-			Code:     uint32(http.Code),
-			Method:   http.Method,
-			Protocol: http.Protocol,
-			Url:      uri.String(),
-			Headers:  headers,
-		},
+	return ir.HTTP{
+		Code:     uint32(http.Code),
+		Method:   http.Method,
+		Protocol: http.Protocol,
+		URL:      uri.String(),
+		Headers:  headers,
 	}
 }
 
-func (p *Parser) httpSummary(flowType accesslog.FlowType, http *accesslog.LogRecordHTTP, flow *flowpb.Flow) string {
+func (p *Parser) httpSummary(flowType accesslog.FlowType, http *accesslog.LogRecordHTTP, flow *ir.Flow) string {
 	uri := filteredURL(http.URL, p.opts.HubbleRedactSettings)
-	httpRequest := http.Method + " " + uri.String()
 	switch flowType {
 	case accesslog.TypeRequest:
-		return fmt.Sprintf("%s %s", http.Protocol, httpRequest)
+		return http.Protocol + " " + http.Method + " " + uri.String()
 	case accesslog.TypeResponse:
-		return fmt.Sprintf("%s %d %dms (%s)", http.Protocol, http.Code, uint64(time.Duration(flow.GetL7().LatencyNs)/time.Millisecond), httpRequest)
+		return http.Protocol + " " + strconv.Itoa(http.Code) + " " + strconv.FormatUint(uint64(time.Duration(flow.L7.LatencyNs)/time.Millisecond), 10) + "ms " + http.Method + " " + uri.String()
 	}
 	return ""
 }

--- a/pkg/hubble/parser/seven/http.go
+++ b/pkg/hubble/parser/seven/http.go
@@ -4,60 +4,63 @@
 package seven
 
 import (
-	"fmt"
 	"maps"
 	"net/url"
 	"slices"
+	"strconv"
 	"strings"
 
-	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/hubble/defaults"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/parser/options"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/time"
 )
 
-func decodeHTTP(flowType accesslog.FlowType, http *accesslog.LogRecordHTTP, opts *options.Options) *flowpb.Layer7_Http {
-	var headers []*flowpb.HTTPHeader
+func decodeHTTP(flowType accesslog.FlowType, http *accesslog.LogRecordHTTP, opts *options.Options) ir.HTTP {
+	var headers []ir.HTTPHeader
+	if len(http.Headers) > 0 {
+		var max int
+		for v := range maps.Values(http.Headers) {
+			max += len(v)
+		}
+		headers = make([]ir.HTTPHeader, 0, max)
+	}
+
 	for _, key := range slices.Sorted(maps.Keys(http.Headers)) {
 		for _, value := range http.Headers[key] {
 			filteredValue := filterHeader(key, value, opts.HubbleRedactSettings)
-			headers = append(headers, &flowpb.HTTPHeader{Key: key, Value: filteredValue})
+			headers = append(headers, ir.HTTPHeader{Key: key, Value: filteredValue})
 		}
 	}
 	uri := filteredURL(http.URL, opts.HubbleRedactSettings)
 
 	if flowType == accesslog.TypeRequest {
 		// Set only fields that are relevant for requests.
-		return &flowpb.Layer7_Http{
-			Http: &flowpb.HTTP{
-				Method:   http.Method,
-				Protocol: http.Protocol,
-				Url:      uri.String(),
-				Headers:  headers,
-			},
+		return ir.HTTP{
+			Method:   http.Method,
+			Protocol: http.Protocol,
+			URL:      uri.String(),
+			Headers:  headers,
 		}
 	}
 
-	return &flowpb.Layer7_Http{
-		Http: &flowpb.HTTP{
-			Code:     uint32(http.Code),
-			Method:   http.Method,
-			Protocol: http.Protocol,
-			Url:      uri.String(),
-			Headers:  headers,
-		},
+	return ir.HTTP{
+		Code:     uint32(http.Code),
+		Method:   http.Method,
+		Protocol: http.Protocol,
+		URL:      uri.String(),
+		Headers:  headers,
 	}
 }
 
-func (p *Parser) httpSummary(flowType accesslog.FlowType, http *accesslog.LogRecordHTTP, flow *flowpb.Flow) string {
+func (p *Parser) httpSummary(flowType accesslog.FlowType, http *accesslog.LogRecordHTTP, flow *ir.Flow) string {
 	uri := filteredURL(http.URL, p.opts.HubbleRedactSettings)
-	httpRequest := http.Method + " " + uri.String()
 	switch flowType {
 	case accesslog.TypeRequest:
-		return fmt.Sprintf("%s %s", http.Protocol, httpRequest)
+		return http.Protocol + " " + http.Method + " " + uri.String()
 	case accesslog.TypeResponse:
-		return fmt.Sprintf("%s %d %dms (%s)", http.Protocol, http.Code, uint64(time.Duration(flow.GetL7().LatencyNs)/time.Millisecond), httpRequest)
+		return http.Protocol + " " + strconv.Itoa(http.Code) + " " + strconv.FormatUint(uint64(time.Duration(flow.L7.LatencyNs)/time.Millisecond), 10) + "ms " + http.Method + " " + uri.String()
 	}
 	return ""
 }

--- a/pkg/hubble/parser/seven/http_test.go
+++ b/pkg/hubble/parser/seven/http_test.go
@@ -17,6 +17,7 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/hubble/defaults"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	"github.com/cilium/cilium/pkg/hubble/parser/options"
 	"github.com/cilium/cilium/pkg/hubble/testutils"
@@ -107,41 +108,41 @@ func TestDecodeL7HTTPRequest(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), dnsGetter, IPGetter, serviceGetter, endpointGetter)
 	require.NoError(t, err)
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(lr, f)
+	var f ir.Flow
+	err = parser.Decode(lr, &f)
 	require.NoError(t, err)
 
-	assert.Equal(t, fakeSourceEndpoint.IPv4, f.GetIP().GetSource())
-	assert.Equal(t, uint32(56789), f.GetL4().GetTCP().GetSourcePort())
-	assert.Equal(t, []string{"endpoint-4321"}, f.GetSourceNames())
-	assert.Equal(t, fakeSourceEndpoint.Labels.GetModel(), f.GetSource().GetLabels())
-	assert.Empty(t, f.GetSource().GetNamespace())
-	assert.Empty(t, f.GetSource().GetPodName())
-	assert.Empty(t, f.GetSourceService().GetNamespace())
-	assert.Empty(t, f.GetSourceService().GetName())
+	assert.Equal(t, fakeSourceEndpoint.IPv4, f.IP.Source)
+	assert.Equal(t, uint32(56789), f.L4.TCP.SourcePort)
+	assert.Equal(t, []string{"endpoint-4321"}, f.SourceNames)
+	assert.Equal(t, fakeSourceEndpoint.Labels.GetModel(), f.Source.Labels)
+	assert.Empty(t, f.Source.Namespace)
+	assert.Empty(t, f.Source.PodName)
+	assert.Empty(t, f.SourceService.Namespace)
+	assert.Empty(t, f.SourceService.Name)
 
-	assert.Equal(t, fakeDestinationEndpoint.IPv4, f.GetIP().GetDestination())
-	assert.Equal(t, uint32(80), f.GetL4().GetTCP().GetDestinationPort())
-	assert.Equal(t, []string{"endpoint-1234"}, f.GetDestinationNames())
-	assert.Equal(t, fakeDestinationEndpoint.Labels.GetModel(), f.GetDestination().GetLabels())
-	assert.Equal(t, "default", f.GetDestination().GetNamespace())
-	assert.Equal(t, "pod-1234", f.GetDestination().GetPodName())
-	assert.Equal(t, "default", f.GetDestinationService().GetNamespace())
-	assert.Equal(t, "service-1234", f.GetDestinationService().GetName())
+	assert.Equal(t, fakeDestinationEndpoint.IPv4, f.IP.Destination)
+	assert.Equal(t, uint32(80), f.L4.TCP.DestinationPort)
+	assert.Equal(t, []string{"endpoint-1234"}, f.DestinationNames)
+	assert.Equal(t, fakeDestinationEndpoint.Labels.GetModel(), f.Destination.Labels)
+	assert.Equal(t, "default", f.Destination.Namespace)
+	assert.Equal(t, "pod-1234", f.Destination.PodName)
+	assert.Equal(t, "default", f.DestinationService.Namespace)
+	assert.Equal(t, "service-1234", f.DestinationService.Name)
 
-	assert.Equal(t, flowpb.Verdict_FORWARDED, f.GetVerdict())
+	assert.Equal(t, flowpb.Verdict_FORWARDED, f.Verdict)
 
-	assert.Equal(t, &flowpb.HTTP{
+	assert.Equal(t, ir.HTTP{
 		Code:     0,
 		Method:   "POST",
-		Url:      "http://myhost/some/path",
+		URL:      "http://myhost/some/path",
 		Protocol: "HTTP/1.1",
-		Headers: []*flowpb.HTTPHeader{
+		Headers: []ir.HTTPHeader{
 			{Key: "Host", Value: "myhost"},
 			{Key: "Traceparent", Value: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"},
 		},
-	}, f.GetL7().GetHttp())
-	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", f.GetTraceContext().GetParent().GetTraceId())
+	}, f.L7.HTTP)
+	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", f.TraceContext.Parent.TraceID)
 }
 
 func TestDecodeL7HTTPRecordResponse(t *testing.T) {
@@ -222,36 +223,36 @@ func TestDecodeL7HTTPRecordResponse(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), dnsGetter, IPGetter, serviceGetter, endpointGetter)
 	require.NoError(t, err)
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(lr, f)
+	var f ir.Flow
+	err = parser.Decode(lr, &f)
 	require.NoError(t, err)
 
-	assert.Equal(t, fakeSourceEndpoint.IPv4, f.GetIP().GetDestination())
-	assert.Equal(t, uint32(56789), f.GetL4().GetTCP().GetDestinationPort())
-	assert.Equal(t, []string{"endpoint-4321"}, f.GetDestinationNames())
-	assert.Equal(t, fakeSourceEndpoint.Labels.GetModel(), f.GetDestination().GetLabels())
-	assert.Empty(t, f.GetDestination().GetNamespace())
-	assert.Empty(t, f.GetDestination().GetPodName())
-	assert.Empty(t, f.GetDestinationService().GetNamespace())
-	assert.Empty(t, f.GetDestinationService().GetName())
+	assert.Equal(t, fakeSourceEndpoint.IPv4, f.IP.Destination)
+	assert.Equal(t, uint32(56789), f.L4.TCP.DestinationPort)
+	assert.Equal(t, []string{"endpoint-4321"}, f.DestinationNames)
+	assert.Equal(t, fakeSourceEndpoint.Labels.GetModel(), f.Destination.Labels)
+	assert.Empty(t, f.Destination.Namespace)
+	assert.Empty(t, f.Destination.PodName)
+	assert.Empty(t, f.DestinationService.Namespace)
+	assert.Empty(t, f.DestinationService.Name)
 
-	assert.Equal(t, fakeDestinationEndpoint.IPv4, f.GetIP().GetSource())
-	assert.Equal(t, uint32(80), f.GetL4().GetTCP().GetSourcePort())
-	assert.Equal(t, []string{"endpoint-1234"}, f.GetSourceNames())
-	assert.Equal(t, fakeDestinationEndpoint.Labels.GetModel(), f.GetSource().GetLabels())
-	assert.Equal(t, "default", f.GetSource().GetNamespace())
-	assert.Equal(t, "pod-1234", f.GetSource().GetPodName())
-	assert.Equal(t, "default", f.GetSourceService().GetNamespace())
-	assert.Equal(t, "service-1234", f.GetSourceService().GetName())
+	assert.Equal(t, fakeDestinationEndpoint.IPv4, f.IP.Source)
+	assert.Equal(t, uint32(80), f.L4.TCP.SourcePort)
+	assert.Equal(t, []string{"endpoint-1234"}, f.SourceNames)
+	assert.Equal(t, fakeDestinationEndpoint.Labels.GetModel(), f.Source.Labels)
+	assert.Equal(t, "default", f.Source.Namespace)
+	assert.Equal(t, "pod-1234", f.Source.PodName)
+	assert.Equal(t, "default", f.SourceService.Namespace)
+	assert.Equal(t, "service-1234", f.SourceService.Name)
 
-	assert.Equal(t, flowpb.Verdict_FORWARDED, f.GetVerdict())
+	assert.Equal(t, flowpb.Verdict_FORWARDED, f.Verdict)
 
-	assert.Equal(t, &flowpb.HTTP{
+	assert.Equal(t, ir.HTTP{
 		Code:     404,
 		Method:   "POST",
-		Url:      "http://myhost/some/path",
+		URL:      "http://myhost/some/path",
 		Protocol: "HTTP/1.1",
-	}, f.GetL7().GetHttp())
+	}, f.L7.HTTP)
 }
 
 func TestDecodeL7HTTPResponseTime(t *testing.T) {
@@ -287,24 +288,24 @@ func TestDecodeL7HTTPResponseTime(t *testing.T) {
 		HTTP:      httpRecord,
 	}
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(request, f)
+	var f ir.Flow
+	err = parser.Decode(request, &f)
 	require.NoError(t, err)
 	_, ok := parser.timestampCache.Get(requestID)
 	assert.True(t, ok, "request id should be in the cache")
 
-	f.Reset()
-	err = parser.Decode(response, f)
+	f = ir.Flow{}
+	err = parser.Decode(response, &f)
 	require.NoError(t, err)
-	assert.Equal(t, 1*time.Second, time.Duration(f.GetL7().GetLatencyNs()))
+	assert.Equal(t, 1*time.Second, time.Duration(f.L7.LatencyNs))
 	_, ok = parser.timestampCache.Get(requestID)
 	assert.False(t, ok, "request id should not be in the cache")
 
 	// it should handle the case where the request id is not in the cache for response type.
-	f = &flowpb.Flow{}
-	err = parser.Decode(response, f)
+	f = ir.Flow{}
+	err = parser.Decode(response, &f)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(0), f.GetL7().GetLatencyNs())
+	assert.Equal(t, uint64(0), f.L7.LatencyNs)
 	_, ok = parser.timestampCache.Get(requestID)
 	assert.False(t, ok, "request id should not be in the cache")
 }
@@ -356,25 +357,25 @@ func TestGetL7HTTPResponseTraceID(t *testing.T) {
 		HTTP:      responseRecord,
 	}
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(request, f)
+	var f ir.Flow
+	err = parser.Decode(request, &f)
 	require.NoError(t, err)
 	_, ok := parser.traceContextCache.Get(requestID)
 	assert.True(t, ok, "request id should be in the cache")
 
-	f.Reset()
-	err = parser.Decode(response, f)
+	f = ir.Flow{}
+	err = parser.Decode(response, &f)
 	require.NoError(t, err)
-	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", f.GetTraceContext().GetParent().GetTraceId())
+	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", f.TraceContext.Parent.TraceID)
 	_, ok = parser.traceContextCache.Get(requestID)
 	assert.False(t, ok, "request id should not be in the cache")
 
 	// it should handle the case where the request id is not in the cache for response type.
-	f = &flowpb.Flow{}
-	err = parser.Decode(response, f)
+	f = ir.Flow{}
+	err = parser.Decode(response, &f)
 	require.NoError(t, err)
 	// no requestID means no traceID for response
-	assert.Empty(t, f.GetTraceContext().GetParent().GetTraceId())
+	assert.Empty(t, f.TraceContext.Parent.TraceID)
 	_, ok = parser.traceContextCache.Get(requestID)
 	assert.False(t, ok, "request id should not be in the cache")
 }
@@ -417,21 +418,21 @@ func TestDecodeL7HTTPWithInvalidURL(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(lr, f)
+	var f ir.Flow
+	err = parser.Decode(lr, &f)
 	require.NoError(t, err)
 
-	assert.Equal(t, &flowpb.HTTP{
+	assert.Equal(t, ir.HTTP{
 		Code:     0,
 		Method:   "POST",
-		Url:      "http://myhost%40/some/path",
+		URL:      "http://myhost%40/some/path",
 		Protocol: "HTTP/1.1",
-		Headers: []*flowpb.HTTPHeader{
+		Headers: []ir.HTTPHeader{
 			{Key: "Host", Value: "myhost"},
 			{Key: "Traceparent", Value: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"},
 		},
-	}, f.GetL7().GetHttp())
-	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", f.GetTraceContext().GetParent().GetTraceId())
+	}, f.L7.HTTP)
+	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", f.TraceContext.Parent.TraceID)
 }
 
 func TestDecodeL7HTTPWithNilURL(t *testing.T) {
@@ -462,21 +463,21 @@ func TestDecodeL7HTTPWithNilURL(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(lr, f)
+	var f ir.Flow
+	err = parser.Decode(lr, &f)
 	require.NoError(t, err)
 
-	assert.Equal(t, &flowpb.HTTP{
+	assert.Equal(t, ir.HTTP{
 		Code:     0,
 		Method:   "POST",
-		Url:      "",
+		URL:      "",
 		Protocol: "HTTP/1.1",
-		Headers: []*flowpb.HTTPHeader{
+		Headers: []ir.HTTPHeader{
 			{Key: "Host", Value: "myhost"},
 			{Key: "Traceparent", Value: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"},
 		},
-	}, f.GetL7().GetHttp())
-	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", f.GetTraceContext().GetParent().GetTraceId())
+	}, f.L7.HTTP)
+	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", f.TraceContext.Parent.TraceID)
 }
 
 func TestDecodeL7HTTPRequestRemoveUrlQuery(t *testing.T) {
@@ -512,19 +513,19 @@ func TestDecodeL7HTTPRequestRemoveUrlQuery(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), nil, nil, nil, nil, opts...)
 	require.NoError(t, err)
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(lr, f)
+	var f ir.Flow
+	err = parser.Decode(lr, &f)
 	require.NoError(t, err)
-	assert.Equal(t, &flowpb.HTTP{
+	assert.Equal(t, ir.HTTP{
 		Code:     0,
 		Method:   "POST",
-		Url:      "http://myhost/some/path",
+		URL:      "http://myhost/some/path",
 		Protocol: "HTTP/1.1",
-		Headers: []*flowpb.HTTPHeader{
+		Headers: []ir.HTTPHeader{
 			{Key: "Host", Value: "myhost"},
 			{Key: "Traceparent", Value: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"},
 		},
-	}, f.GetL7().GetHttp())
+	}, f.L7.HTTP)
 }
 
 func TestDecodeL7HTTPRequestHeadersRedact(t *testing.T) {
@@ -560,37 +561,37 @@ func TestDecodeL7HTTPRequestHeadersRedact(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), nil, nil, nil, nil, opts...)
 	require.NoError(t, err)
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(lr, f)
+	var f ir.Flow
+	err = parser.Decode(lr, &f)
 	require.NoError(t, err)
-	assert.Equal(t, &flowpb.HTTP{
+	assert.Equal(t, ir.HTTP{
 		Code:     0,
 		Method:   "POST",
-		Url:      "http://myhost/some/path",
+		URL:      "http://myhost/some/path",
 		Protocol: "HTTP/1.1",
-		Headers: []*flowpb.HTTPHeader{
+		Headers: []ir.HTTPHeader{
 			{Key: "Host", Value: "myhost"},
 			{Key: "traceparent", Value: defaults.SensitiveValueRedacted},
 		},
-	}, f.GetL7().GetHttp())
+	}, f.L7.HTTP)
 
 	opts = []options.Option{options.WithRedact(true, true, []string{}, []string{"host"})}
 	parser, err = New(hivetest.Logger(t), nil, nil, nil, nil, opts...)
 	require.NoError(t, err)
 
-	f = &flowpb.Flow{}
-	err = parser.Decode(lr, f)
+	f = ir.Flow{}
+	err = parser.Decode(lr, &f)
 	require.NoError(t, err)
-	assert.Equal(t, &flowpb.HTTP{
+	assert.Equal(t, ir.HTTP{
 		Code:     0,
 		Method:   "POST",
-		Url:      "http://myhost/some/path",
+		URL:      "http://myhost/some/path",
 		Protocol: "HTTP/1.1",
-		Headers: []*flowpb.HTTPHeader{
+		Headers: []ir.HTTPHeader{
 			{Key: "Host", Value: defaults.SensitiveValueRedacted},
 			{Key: "traceparent", Value: "asdf"},
 		},
-	}, f.GetL7().GetHttp())
+	}, f.L7.HTTP)
 }
 
 func TestFilterHeader(t *testing.T) {
@@ -698,13 +699,13 @@ func TestDecodeL7HTTPRequestPasswordRedact(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), nil, nil, nil, nil, opts...)
 	require.NoError(t, err)
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(lr, f)
+	var f ir.Flow
+	err = parser.Decode(lr, &f)
 	require.NoError(t, err)
-	assert.Equal(t, &flowpb.HTTP{
+	assert.Equal(t, ir.HTTP{
 		Code:     0,
 		Method:   "POST",
-		Url:      fmt.Sprintf("http://user:%s@myhost", defaults.SensitiveValueRedacted),
+		URL:      fmt.Sprintf("http://user:%s@myhost", defaults.SensitiveValueRedacted),
 		Protocol: "HTTP/1.1",
-	}, f.GetL7().GetHttp())
+	}, f.L7.HTTP)
 }

--- a/pkg/hubble/parser/seven/http_test.go
+++ b/pkg/hubble/parser/seven/http_test.go
@@ -17,6 +17,7 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/hubble/defaults"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	"github.com/cilium/cilium/pkg/hubble/parser/options"
 	"github.com/cilium/cilium/pkg/hubble/testutils"
@@ -79,14 +80,11 @@ func TestDecodeL7HTTPRequest(t *testing.T) {
 		},
 	}
 	serviceGetter := &testutils.FakeServiceGetter{
-		OnGetServiceByAddr: func(ip netip.Addr, port uint16) *flowpb.Service {
+		OnGetServiceByAddr: func(ip netip.Addr, port uint16) getters.FQN {
 			if ip == netip.MustParseAddr(fakeDestinationEndpoint.IPv4) && (port == fakeDestinationEndpoint.Port) {
-				return &flowpb.Service{
-					Name:      "service-1234",
-					Namespace: "default",
-				}
+				return getters.NewFQN("default", "service-1234")
 			}
-			return nil
+			return getters.BlankFQN
 		},
 	}
 	endpointGetter := &testutils.FakeEndpointGetter{
@@ -104,43 +102,43 @@ func TestDecodeL7HTTPRequest(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), dnsGetter, IPGetter, serviceGetter, endpointGetter)
 	require.NoError(t, err)
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(lr, f)
+	var f ir.Flow
+	err = parser.Decode(lr, &f)
 	require.NoError(t, err)
 
-	assert.Equal(t, fakeSourceEndpoint.IPv4, f.GetIP().GetSource())
-	assert.Equal(t, uint32(56789), f.GetL4().GetTCP().GetSourcePort())
-	assert.Equal(t, []string{"endpoint-4321"}, f.GetSourceNames())
-	assert.Equal(t, fakeSourceEndpoint.Labels.GetModel(), f.GetSource().GetLabels())
-	assert.Empty(t, f.GetSource().GetNamespace())
-	assert.Empty(t, f.GetSource().GetPodName())
-	assert.Equal(t, "source-pod-uid", f.GetSource().GetPodUid())
-	assert.Empty(t, f.GetSourceService().GetNamespace())
-	assert.Empty(t, f.GetSourceService().GetName())
+	assert.Equal(t, fakeSourceEndpoint.IPv4, f.IP.Source)
+	assert.Equal(t, uint32(56789), f.L4.TCP.SourcePort)
+	assert.Equal(t, []string{"endpoint-4321"}, f.SourceNames)
+	assert.Equal(t, fakeSourceEndpoint.Labels.GetModel(), f.Source.Labels)
+	assert.Empty(t, f.Source.Namespace)
+	assert.Empty(t, f.Source.PodName)
+	assert.Equal(t, "source-pod-uid", f.Source.PodUID)
+	assert.Empty(t, f.SourceService.Namespace)
+	assert.Empty(t, f.SourceService.Name)
 
-	assert.Equal(t, fakeDestinationEndpoint.IPv4, f.GetIP().GetDestination())
-	assert.Equal(t, uint32(80), f.GetL4().GetTCP().GetDestinationPort())
-	assert.Equal(t, []string{"endpoint-1234"}, f.GetDestinationNames())
-	assert.Equal(t, fakeDestinationEndpoint.Labels.GetModel(), f.GetDestination().GetLabels())
-	assert.Equal(t, "default", f.GetDestination().GetNamespace())
-	assert.Equal(t, "pod-1234", f.GetDestination().GetPodName())
-	assert.Equal(t, "pod-1234-uid", f.GetDestination().GetPodUid())
-	assert.Equal(t, "default", f.GetDestinationService().GetNamespace())
-	assert.Equal(t, "service-1234", f.GetDestinationService().GetName())
+	assert.Equal(t, fakeDestinationEndpoint.IPv4, f.IP.Destination)
+	assert.Equal(t, uint32(80), f.L4.TCP.DestinationPort)
+	assert.Equal(t, []string{"endpoint-1234"}, f.DestinationNames)
+	assert.Equal(t, fakeDestinationEndpoint.Labels.GetModel(), f.Destination.Labels)
+	assert.Equal(t, "default", f.Destination.Namespace)
+	assert.Equal(t, "pod-1234", f.Destination.PodName)
+	assert.Equal(t, "pod-1234-uid", f.Destination.PodUID)
+	assert.Equal(t, "default", f.DestinationService.Namespace)
+	assert.Equal(t, "service-1234", f.DestinationService.Name)
 
-	assert.Equal(t, flowpb.Verdict_FORWARDED, f.GetVerdict())
+	assert.Equal(t, flowpb.Verdict_FORWARDED, f.Verdict)
 
-	assert.Equal(t, &flowpb.HTTP{
+	assert.Equal(t, ir.HTTP{
 		Code:     0,
 		Method:   "POST",
-		Url:      "http://myhost/some/path",
+		URL:      "http://myhost/some/path",
 		Protocol: "HTTP/1.1",
-		Headers: []*flowpb.HTTPHeader{
+		Headers: []ir.HTTPHeader{
 			{Key: "Host", Value: "myhost"},
 			{Key: "Traceparent", Value: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"},
 		},
-	}, f.GetL7().GetHttp())
-	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", f.GetTraceContext().GetParent().GetTraceId())
+	}, f.L7.HTTP)
+	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", f.TraceContext.Parent.TraceID)
 }
 
 func TestDecodeL7HTTPRecordResponse(t *testing.T) {
@@ -193,14 +191,11 @@ func TestDecodeL7HTTPRecordResponse(t *testing.T) {
 		},
 	}
 	serviceGetter := &testutils.FakeServiceGetter{
-		OnGetServiceByAddr: func(ip netip.Addr, port uint16) *flowpb.Service {
+		OnGetServiceByAddr: func(ip netip.Addr, port uint16) getters.FQN {
 			if ip == netip.MustParseAddr(fakeDestinationEndpoint.IPv4) && (port == fakeDestinationEndpoint.Port) {
-				return &flowpb.Service{
-					Name:      "service-1234",
-					Namespace: "default",
-				}
+				return getters.NewFQN("default", "service-1234")
 			}
-			return nil
+			return getters.BlankFQN
 		},
 	}
 	endpointGetter := &testutils.FakeEndpointGetter{
@@ -218,38 +213,38 @@ func TestDecodeL7HTTPRecordResponse(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), dnsGetter, IPGetter, serviceGetter, endpointGetter)
 	require.NoError(t, err)
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(lr, f)
+	var f ir.Flow
+	err = parser.Decode(lr, &f)
 	require.NoError(t, err)
 
-	assert.Equal(t, fakeSourceEndpoint.IPv4, f.GetIP().GetDestination())
-	assert.Equal(t, uint32(56789), f.GetL4().GetTCP().GetDestinationPort())
-	assert.Equal(t, []string{"endpoint-4321"}, f.GetDestinationNames())
-	assert.Equal(t, fakeSourceEndpoint.Labels.GetModel(), f.GetDestination().GetLabels())
-	assert.Empty(t, f.GetDestination().GetNamespace())
-	assert.Empty(t, f.GetDestination().GetPodName())
-	assert.Equal(t, "source-pod-uid", f.GetDestination().GetPodUid())
-	assert.Empty(t, f.GetDestinationService().GetNamespace())
-	assert.Empty(t, f.GetDestinationService().GetName())
+	assert.Equal(t, fakeSourceEndpoint.IPv4, f.IP.Destination)
+	assert.Equal(t, uint32(56789), f.L4.TCP.DestinationPort)
+	assert.Equal(t, []string{"endpoint-4321"}, f.DestinationNames)
+	assert.Equal(t, fakeSourceEndpoint.Labels.GetModel(), f.Destination.Labels)
+	assert.Empty(t, f.Destination.Namespace)
+	assert.Empty(t, f.Destination.PodName)
+	assert.Equal(t, "source-pod-uid", f.Destination.PodUID)
+	assert.Empty(t, f.DestinationService.Namespace)
+	assert.Empty(t, f.DestinationService.Name)
 
-	assert.Equal(t, fakeDestinationEndpoint.IPv4, f.GetIP().GetSource())
-	assert.Equal(t, uint32(80), f.GetL4().GetTCP().GetSourcePort())
-	assert.Equal(t, []string{"endpoint-1234"}, f.GetSourceNames())
-	assert.Equal(t, fakeDestinationEndpoint.Labels.GetModel(), f.GetSource().GetLabels())
-	assert.Equal(t, "default", f.GetSource().GetNamespace())
-	assert.Equal(t, "pod-1234", f.GetSource().GetPodName())
-	assert.Equal(t, "pod-1234-uid", f.GetSource().GetPodUid())
-	assert.Equal(t, "default", f.GetSourceService().GetNamespace())
-	assert.Equal(t, "service-1234", f.GetSourceService().GetName())
+	assert.Equal(t, fakeDestinationEndpoint.IPv4, f.IP.Source)
+	assert.Equal(t, uint32(80), f.L4.TCP.SourcePort)
+	assert.Equal(t, []string{"endpoint-1234"}, f.SourceNames)
+	assert.Equal(t, fakeDestinationEndpoint.Labels.GetModel(), f.Source.Labels)
+	assert.Equal(t, "default", f.Source.Namespace)
+	assert.Equal(t, "pod-1234", f.Source.PodName)
+	assert.Equal(t, "pod-1234-uid", f.Source.PodUID)
+	assert.Equal(t, "default", f.SourceService.Namespace)
+	assert.Equal(t, "service-1234", f.SourceService.Name)
 
-	assert.Equal(t, flowpb.Verdict_FORWARDED, f.GetVerdict())
+	assert.Equal(t, flowpb.Verdict_FORWARDED, f.Verdict)
 
-	assert.Equal(t, &flowpb.HTTP{
+	assert.Equal(t, ir.HTTP{
 		Code:     404,
 		Method:   "POST",
-		Url:      "http://myhost/some/path",
+		URL:      "http://myhost/some/path",
 		Protocol: "HTTP/1.1",
-	}, f.GetL7().GetHttp())
+	}, f.L7.HTTP)
 }
 
 func TestDecodeL7HTTPResponseTime(t *testing.T) {
@@ -285,24 +280,24 @@ func TestDecodeL7HTTPResponseTime(t *testing.T) {
 		HTTP:      httpRecord,
 	}
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(request, f)
+	var f ir.Flow
+	err = parser.Decode(request, &f)
 	require.NoError(t, err)
 	_, ok := parser.timestampCache.Get(requestID)
 	assert.True(t, ok, "request id should be in the cache")
 
-	f.Reset()
-	err = parser.Decode(response, f)
+	f = ir.Flow{}
+	err = parser.Decode(response, &f)
 	require.NoError(t, err)
-	assert.Equal(t, 1*time.Second, time.Duration(f.GetL7().GetLatencyNs()))
+	assert.Equal(t, 1*time.Second, time.Duration(f.L7.LatencyNs))
 	_, ok = parser.timestampCache.Get(requestID)
 	assert.False(t, ok, "request id should not be in the cache")
 
 	// it should handle the case where the request id is not in the cache for response type.
-	f = &flowpb.Flow{}
-	err = parser.Decode(response, f)
+	f = ir.Flow{}
+	err = parser.Decode(response, &f)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(0), f.GetL7().GetLatencyNs())
+	assert.Equal(t, uint64(0), f.L7.LatencyNs)
 	_, ok = parser.timestampCache.Get(requestID)
 	assert.False(t, ok, "request id should not be in the cache")
 }
@@ -354,25 +349,25 @@ func TestGetL7HTTPResponseTraceID(t *testing.T) {
 		HTTP:      responseRecord,
 	}
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(request, f)
+	var f ir.Flow
+	err = parser.Decode(request, &f)
 	require.NoError(t, err)
 	_, ok := parser.traceContextCache.Get(requestID)
 	assert.True(t, ok, "request id should be in the cache")
 
-	f.Reset()
-	err = parser.Decode(response, f)
+	f = ir.Flow{}
+	err = parser.Decode(response, &f)
 	require.NoError(t, err)
-	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", f.GetTraceContext().GetParent().GetTraceId())
+	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", f.TraceContext.Parent.TraceID)
 	_, ok = parser.traceContextCache.Get(requestID)
 	assert.False(t, ok, "request id should not be in the cache")
 
 	// it should handle the case where the request id is not in the cache for response type.
-	f = &flowpb.Flow{}
-	err = parser.Decode(response, f)
+	f = ir.Flow{}
+	err = parser.Decode(response, &f)
 	require.NoError(t, err)
 	// no requestID means no traceID for response
-	assert.Empty(t, f.GetTraceContext().GetParent().GetTraceId())
+	assert.Empty(t, f.TraceContext.Parent.TraceID)
 	_, ok = parser.traceContextCache.Get(requestID)
 	assert.False(t, ok, "request id should not be in the cache")
 }
@@ -415,21 +410,21 @@ func TestDecodeL7HTTPWithInvalidURL(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(lr, f)
+	var f ir.Flow
+	err = parser.Decode(lr, &f)
 	require.NoError(t, err)
 
-	assert.Equal(t, &flowpb.HTTP{
+	assert.Equal(t, ir.HTTP{
 		Code:     0,
 		Method:   "POST",
-		Url:      "http://myhost%40/some/path",
+		URL:      "http://myhost%40/some/path",
 		Protocol: "HTTP/1.1",
-		Headers: []*flowpb.HTTPHeader{
+		Headers: []ir.HTTPHeader{
 			{Key: "Host", Value: "myhost"},
 			{Key: "Traceparent", Value: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"},
 		},
-	}, f.GetL7().GetHttp())
-	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", f.GetTraceContext().GetParent().GetTraceId())
+	}, f.L7.HTTP)
+	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", f.TraceContext.Parent.TraceID)
 }
 
 func TestDecodeL7HTTPWithNilURL(t *testing.T) {
@@ -460,21 +455,21 @@ func TestDecodeL7HTTPWithNilURL(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(lr, f)
+	var f ir.Flow
+	err = parser.Decode(lr, &f)
 	require.NoError(t, err)
 
-	assert.Equal(t, &flowpb.HTTP{
+	assert.Equal(t, ir.HTTP{
 		Code:     0,
 		Method:   "POST",
-		Url:      "",
+		URL:      "",
 		Protocol: "HTTP/1.1",
-		Headers: []*flowpb.HTTPHeader{
+		Headers: []ir.HTTPHeader{
 			{Key: "Host", Value: "myhost"},
 			{Key: "Traceparent", Value: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"},
 		},
-	}, f.GetL7().GetHttp())
-	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", f.GetTraceContext().GetParent().GetTraceId())
+	}, f.L7.HTTP)
+	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", f.TraceContext.Parent.TraceID)
 }
 
 func TestDecodeL7HTTPRequestRemoveUrlQuery(t *testing.T) {
@@ -510,19 +505,19 @@ func TestDecodeL7HTTPRequestRemoveUrlQuery(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), nil, nil, nil, nil, opts...)
 	require.NoError(t, err)
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(lr, f)
+	var f ir.Flow
+	err = parser.Decode(lr, &f)
 	require.NoError(t, err)
-	assert.Equal(t, &flowpb.HTTP{
+	assert.Equal(t, ir.HTTP{
 		Code:     0,
 		Method:   "POST",
-		Url:      "http://myhost/some/path",
+		URL:      "http://myhost/some/path",
 		Protocol: "HTTP/1.1",
-		Headers: []*flowpb.HTTPHeader{
+		Headers: []ir.HTTPHeader{
 			{Key: "Host", Value: "myhost"},
 			{Key: "Traceparent", Value: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"},
 		},
-	}, f.GetL7().GetHttp())
+	}, f.L7.HTTP)
 }
 
 func TestDecodeL7HTTPRequestHeadersRedact(t *testing.T) {
@@ -558,37 +553,37 @@ func TestDecodeL7HTTPRequestHeadersRedact(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), nil, nil, nil, nil, opts...)
 	require.NoError(t, err)
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(lr, f)
+	var f ir.Flow
+	err = parser.Decode(lr, &f)
 	require.NoError(t, err)
-	assert.Equal(t, &flowpb.HTTP{
+	assert.Equal(t, ir.HTTP{
 		Code:     0,
 		Method:   "POST",
-		Url:      "http://myhost/some/path",
+		URL:      "http://myhost/some/path",
 		Protocol: "HTTP/1.1",
-		Headers: []*flowpb.HTTPHeader{
+		Headers: []ir.HTTPHeader{
 			{Key: "Host", Value: "myhost"},
 			{Key: "traceparent", Value: defaults.SensitiveValueRedacted},
 		},
-	}, f.GetL7().GetHttp())
+	}, f.L7.HTTP)
 
 	opts = []options.Option{options.WithRedact(true, true, []string{}, []string{"host"})}
 	parser, err = New(hivetest.Logger(t), nil, nil, nil, nil, opts...)
 	require.NoError(t, err)
 
-	f = &flowpb.Flow{}
-	err = parser.Decode(lr, f)
+	f = ir.Flow{}
+	err = parser.Decode(lr, &f)
 	require.NoError(t, err)
-	assert.Equal(t, &flowpb.HTTP{
+	assert.Equal(t, ir.HTTP{
 		Code:     0,
 		Method:   "POST",
-		Url:      "http://myhost/some/path",
+		URL:      "http://myhost/some/path",
 		Protocol: "HTTP/1.1",
-		Headers: []*flowpb.HTTPHeader{
+		Headers: []ir.HTTPHeader{
 			{Key: "Host", Value: defaults.SensitiveValueRedacted},
 			{Key: "traceparent", Value: "asdf"},
 		},
-	}, f.GetL7().GetHttp())
+	}, f.L7.HTTP)
 }
 
 func TestFilterHeader(t *testing.T) {
@@ -696,13 +691,13 @@ func TestDecodeL7HTTPRequestPasswordRedact(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), nil, nil, nil, nil, opts...)
 	require.NoError(t, err)
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(lr, f)
+	var f ir.Flow
+	err = parser.Decode(lr, &f)
 	require.NoError(t, err)
-	assert.Equal(t, &flowpb.HTTP{
+	assert.Equal(t, ir.HTTP{
 		Code:     0,
 		Method:   "POST",
-		Url:      fmt.Sprintf("http://user:%s@myhost", defaults.SensitiveValueRedacted),
+		URL:      fmt.Sprintf("http://user:%s@myhost", defaults.SensitiveValueRedacted),
 		Protocol: "HTTP/1.1",
-	}, f.GetL7().GetHttp())
+	}, f.L7.HTTP)
 }

--- a/pkg/hubble/parser/seven/parser.go
+++ b/pkg/hubble/parser/seven/parser.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/parser/errors"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	"github.com/cilium/cilium/pkg/hubble/parser/options"
@@ -88,7 +89,7 @@ func New(
 }
 
 // Decode decodes the data from 'payload' into 'decoded'
-func (p *Parser) Decode(r *accesslog.LogRecord, decoded *flowpb.Flow) error {
+func (p *Parser) Decode(r *accesslog.LogRecord, decoded *ir.Flow) error {
 	// Safety: This function and all the helpers it invokes are not allowed to
 	// mutate r in any way. We only have read access to the LogRecord, as it
 	// may be shared with other consumers
@@ -96,7 +97,7 @@ func (p *Parser) Decode(r *accesslog.LogRecord, decoded *flowpb.Flow) error {
 		return errors.ErrEmptyData
 	}
 
-	timestamp, pbTimestamp, err := decodeTime(r.Timestamp)
+	timestamp, _, err := decodeTime(r.Timestamp)
 	if err != nil {
 		return err
 	}
@@ -137,7 +138,7 @@ func (p *Parser) Decode(r *accesslog.LogRecord, decoded *flowpb.Flow) error {
 		destinationService = p.serviceGetter.GetServiceByAddr(destinationIP, destinationPort)
 	}
 
-	decoded.Time = pbTimestamp
+	decoded.Time = timestamp
 	decoded.Verdict = decodeVerdict(r.Verdict)
 	decoded.DropReason = 0
 	decoded.DropReasonDesc = flowpb.DropReason_DROP_REASON_UNKNOWN
@@ -150,14 +151,13 @@ func (p *Parser) Decode(r *accesslog.LogRecord, decoded *flowpb.Flow) error {
 	decoded.DestinationNames = destinationNames
 	decoded.L7 = decodeLayer7(r, p.opts)
 	decoded.L7.LatencyNs = p.computeResponseTime(r, timestamp)
-	decoded.IsReply = decodeIsReply(r.Type)
-	decoded.Reply = decoded.GetIsReply().GetValue()
+	decoded.Reply = decodeIsReply(r.Type)
 	decoded.EventType = decodeCiliumEventType(api.MessageTypeAccessLog)
-	decoded.SourceService = sourceService
-	decoded.DestinationService = destinationService
+	decoded.SourceService = ir.ProtoToService(sourceService)
+	decoded.DestinationService = ir.ProtoToService(destinationService)
 	decoded.TrafficDirection = decodeTrafficDirection(r.ObservationPoint)
 	decoded.PolicyMatchType = 0
-	decoded.TraceContext = p.getTraceContext(r)
+	decoded.TraceContext = ir.ProtoToTraceContext(p.getTraceContext(r))
 	decoded.Summary = p.getSummary(r, decoded)
 
 	return nil
@@ -223,12 +223,12 @@ func (p *Parser) computeResponseTime(r *accesslog.LogRecord, timestamp time.Time
 	return 0
 }
 
-func (p *Parser) updateEndpointWorkloads(ip netip.Addr, endpoint *flowpb.Endpoint) {
+func (p *Parser) updateEndpointWorkloads(ip netip.Addr, endpoint ir.Endpoint) {
 	if ep, ok := p.endpointGetter.GetEndpointInfo(ip); ok {
 		if pod := ep.GetPod(); pod != nil {
 			workload, workloadTypeMeta, ok := utils.GetWorkloadMetaFromPod(pod)
 			if ok {
-				endpoint.Workloads = []*flowpb.Workload{{Kind: workloadTypeMeta.Kind, Name: workload.Name}}
+				endpoint.Workloads = []ir.Workload{{Kind: workloadTypeMeta.Kind, Name: workload.Name}}
 			}
 		}
 	}
@@ -271,63 +271,57 @@ func decodeTrafficDirection(direction accesslog.ObservationPoint) flowpb.Traffic
 	}
 }
 
-func decodeIP(version accesslog.IPVersion, source, destination accesslog.EndpointInfo) *flowpb.IP {
+func decodeIP(version accesslog.IPVersion, source, destination accesslog.EndpointInfo) ir.IP {
 	switch version {
 	case accesslog.VersionIPv4:
-		return &flowpb.IP{
+		return ir.IP{
 			Source:      source.IPv4,
 			Destination: destination.IPv4,
-			IpVersion:   flowpb.IPVersion_IPv4,
+			IPVersion:   flowpb.IPVersion_IPv4,
 		}
 	case accesslog.VersionIPV6:
-		return &flowpb.IP{
+		return ir.IP{
 			Source:      source.IPv6,
 			Destination: destination.IPv6,
-			IpVersion:   flowpb.IPVersion_IPv6,
+			IPVersion:   flowpb.IPVersion_IPv6,
 		}
 	default:
-		return nil
+		return ir.IP{}
 	}
 }
 
-func decodeLayer4(protocol accesslog.TransportProtocol, source, destination accesslog.EndpointInfo) (l4 *flowpb.Layer4, srcPort, dstPort uint16) {
+func decodeLayer4(protocol accesslog.TransportProtocol, source, destination accesslog.EndpointInfo) (l4 ir.Layer4, srcPort, dstPort uint16) {
 	switch u8proto.U8proto(protocol) {
 	case u8proto.TCP:
-		return &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					SourcePort:      uint32(source.Port),
-					DestinationPort: uint32(destination.Port),
-				},
+		return ir.Layer4{
+			TCP: ir.TCP{
+				SourcePort:      uint32(source.Port),
+				DestinationPort: uint32(destination.Port),
 			},
 		}, uint16(source.Port), uint16(destination.Port)
 	case u8proto.UDP:
-		return &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_UDP{
-				UDP: &flowpb.UDP{
-					SourcePort:      uint32(source.Port),
-					DestinationPort: uint32(destination.Port),
-				},
+		return ir.Layer4{
+			UDP: ir.UDP{
+				SourcePort:      uint32(source.Port),
+				DestinationPort: uint32(destination.Port),
 			},
 		}, uint16(source.Port), uint16(destination.Port)
 	case u8proto.SCTP:
-		return &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_SCTP{
-				SCTP: &flowpb.SCTP{
-					SourcePort:      uint32(source.Port),
-					DestinationPort: uint32(destination.Port),
-				},
+		return ir.Layer4{
+			SCTP: ir.SCTP{
+				SourcePort:      uint32(source.Port),
+				DestinationPort: uint32(destination.Port),
 			},
 		}, uint16(source.Port), uint16(destination.Port)
 	default:
-		return nil, 0, 0
+		return ir.Layer4{}, 0, 0
 	}
 }
 
-func decodeEndpoint(endpoint accesslog.EndpointInfo, namespace, podName string) *flowpb.Endpoint {
+func decodeEndpoint(endpoint accesslog.EndpointInfo, namespace, podName string) ir.Endpoint {
 	labels := endpoint.Labels.GetModel()
 	slices.Sort(labels)
-	return &flowpb.Endpoint{
+	return ir.Endpoint{
 		ID:          uint32(endpoint.ID),
 		Identity:    uint32(endpoint.Identity),
 		ClusterName: endpoint.Labels.Get(string(source.Kubernetes) + ciliumLabels.SourceDelimiter + k8sConst.PolicyLabelCluster),
@@ -337,7 +331,7 @@ func decodeEndpoint(endpoint accesslog.EndpointInfo, namespace, podName string) 
 	}
 }
 
-func decodeLayer7(r *accesslog.LogRecord, opts *options.Options) *flowpb.Layer7 {
+func decodeLayer7(r *accesslog.LogRecord, opts *options.Options) ir.Layer7 {
 	var flowType flowpb.L7FlowType
 	switch r.Type {
 	case accesslog.TypeRequest:
@@ -350,30 +344,30 @@ func decodeLayer7(r *accesslog.LogRecord, opts *options.Options) *flowpb.Layer7 
 
 	switch {
 	case r.DNS != nil:
-		return &flowpb.Layer7{
-			Type:   flowType,
-			Record: decodeDNS(r.Type, r.DNS),
+		return ir.Layer7{
+			Type: flowType,
+			DNS:  decodeDNS(r.Type, r.DNS),
 		}
 	case r.HTTP != nil:
-		return &flowpb.Layer7{
-			Type:   flowType,
-			Record: decodeHTTP(r.Type, r.HTTP, opts),
+		return ir.Layer7{
+			Type: flowType,
+			HTTP: decodeHTTP(r.Type, r.HTTP, opts),
 		}
 	default:
-		return &flowpb.Layer7{
+		return ir.Layer7{
 			Type: flowType,
 		}
 	}
 }
 
-func decodeIsReply(t accesslog.FlowType) *wrapperspb.BoolValue {
-	return &wrapperspb.BoolValue{
+func decodeIsReply(t accesslog.FlowType) ir.Reply {
+	return ir.ProtoToReply(&wrapperspb.BoolValue{
 		Value: t == accesslog.TypeResponse,
-	}
+	})
 }
 
-func decodeCiliumEventType(eventType uint8) *flowpb.CiliumEventType {
-	return &flowpb.CiliumEventType{
+func decodeCiliumEventType(eventType uint8) ir.CiliumEventType {
+	return ir.CiliumEventType{
 		Type: int32(eventType),
 	}
 }
@@ -382,7 +376,7 @@ func genericSummary(l7 *accesslog.LogRecordL7) string {
 	return fmt.Sprintf("%s Fields: %s", l7.Proto, l7.Fields)
 }
 
-func (p *Parser) getSummary(logRecord *accesslog.LogRecord, flow *flowpb.Flow) string {
+func (p *Parser) getSummary(logRecord *accesslog.LogRecord, flow *ir.Flow) string {
 	if logRecord == nil {
 		return ""
 	}

--- a/pkg/hubble/parser/seven/parser.go
+++ b/pkg/hubble/parser/seven/parser.go
@@ -10,10 +10,9 @@ import (
 	"slices"
 
 	lru "github.com/hashicorp/golang-lru/v2"
-	"google.golang.org/protobuf/types/known/timestamppb"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/parser/errors"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	"github.com/cilium/cilium/pkg/hubble/parser/options"
@@ -88,7 +87,7 @@ func New(
 }
 
 // Decode decodes the data from 'payload' into 'decoded'
-func (p *Parser) Decode(r *accesslog.LogRecord, decoded *flowpb.Flow) error {
+func (p *Parser) Decode(r *accesslog.LogRecord, decoded *ir.Flow) error {
 	// Safety: This function and all the helpers it invokes are not allowed to
 	// mutate r in any way. We only have read access to the LogRecord, as it
 	// may be shared with other consumers
@@ -96,7 +95,7 @@ func (p *Parser) Decode(r *accesslog.LogRecord, decoded *flowpb.Flow) error {
 		return errors.ErrEmptyData
 	}
 
-	timestamp, pbTimestamp, err := decodeTime(r.Timestamp)
+	timestamp, err := decodeTime(r.Timestamp)
 	if err != nil {
 		return err
 	}
@@ -126,18 +125,18 @@ func (p *Parser) Decode(r *accesslog.LogRecord, decoded *flowpb.Flow) error {
 	dstEndpoint := decodeEndpoint(r.DestinationEndpoint, destinationNamespace, destinationPod, destinationPodUID)
 
 	if p.endpointGetter != nil {
-		p.updateEndpointFromLocal(sourceIP, srcEndpoint)
-		p.updateEndpointFromLocal(destinationIP, dstEndpoint)
+		p.updateEndpointWorkloads(sourceIP, &srcEndpoint)
+		p.updateEndpointWorkloads(destinationIP, &dstEndpoint)
 	}
 
 	l4, sourcePort, destinationPort := decodeLayer4(r.TransportProtocol, r.SourceEndpoint, r.DestinationEndpoint)
-	var sourceService, destinationService *flowpb.Service
+	var sourceService, destinationService getters.FQN
 	if p.serviceGetter != nil {
 		sourceService = p.serviceGetter.GetServiceByAddr(sourceIP, sourcePort)
 		destinationService = p.serviceGetter.GetServiceByAddr(destinationIP, destinationPort)
 	}
 
-	decoded.Time = pbTimestamp
+	decoded.Time = timestamp
 	decoded.Verdict = decodeVerdict(r.Verdict)
 	decoded.DropReason = 0
 	decoded.DropReasonDesc = flowpb.DropReason_DROP_REASON_UNKNOWN
@@ -150,11 +149,10 @@ func (p *Parser) Decode(r *accesslog.LogRecord, decoded *flowpb.Flow) error {
 	decoded.DestinationNames = destinationNames
 	decoded.L7 = decodeLayer7(r, p.opts)
 	decoded.L7.LatencyNs = p.computeResponseTime(r, timestamp)
-	decoded.IsReply = decodeIsReply(r.Type)
-	decoded.Reply = decoded.GetIsReply().GetValue()
+	decoded.Reply = decodeIsReply(r.Type)
 	decoded.EventType = decodeCiliumEventType(api.MessageTypeAccessLog)
-	decoded.SourceService = sourceService
-	decoded.DestinationService = destinationService
+	decoded.SourceService = ir.NewService(sourceService.Name, sourceService.Namespace)
+	decoded.DestinationService = ir.NewService(destinationService.Name, destinationService.Namespace)
 	decoded.TrafficDirection = decodeTrafficDirection(r.ObservationPoint)
 	decoded.PolicyMatchType = 0
 	decoded.TraceContext = p.getTraceContext(r)
@@ -171,7 +169,7 @@ func extractRequestID(r *accesslog.LogRecord) string {
 	return requestID
 }
 
-func (p *Parser) getTraceContext(r *accesslog.LogRecord) *flowpb.TraceContext {
+func (p *Parser) getTraceContext(r *accesslog.LogRecord) ir.TraceContext {
 	requestID := extractRequestID(r)
 	switch r.Type {
 	case accesslog.TypeRequest:
@@ -184,19 +182,20 @@ func (p *Parser) getTraceContext(r *accesslog.LogRecord) *flowpb.TraceContext {
 		if requestID != "" {
 			p.traceContextCache.Add(requestID, traceContext)
 		}
-		return traceContext
+		return ir.ProtoToTraceContext(traceContext)
 	case accesslog.TypeResponse:
 		if requestID == "" {
-			return nil
+			return ir.TraceContext{}
 		}
 		traceContext, ok := p.traceContextCache.Get(requestID)
 		if !ok {
 			break
 		}
 		p.traceContextCache.Remove(requestID)
-		return traceContext
+		return ir.ProtoToTraceContext(traceContext)
 	}
-	return nil
+
+	return ir.TraceContext{}
 }
 
 func (p *Parser) computeResponseTime(r *accesslog.LogRecord, timestamp time.Time) uint64 {
@@ -223,36 +222,29 @@ func (p *Parser) computeResponseTime(r *accesslog.LogRecord, timestamp time.Time
 	return 0
 }
 
-func (p *Parser) updateEndpointFromLocal(ip netip.Addr, endpoint *flowpb.Endpoint) {
+func (p *Parser) updateEndpointWorkloads(ip netip.Addr, endpoint *ir.Endpoint) {
 	if ep, ok := p.endpointGetter.GetEndpointInfo(ip); ok {
 		// Access logs are decoded asynchronously. The IP may now belong to a
 		// replacement endpoint, so only use Pod metadata when the IDs match.
-		if ep.GetID() != uint64(endpoint.GetID()) {
+		if ep.GetID() != uint64(endpoint.ID) {
 			return
 		}
 		// Keep the Pod identity tuple tied to the ID-matched endpoint. When the
 		// UID is unknown, empty is safer than retaining metadata resolved by IP.
 		endpoint.Namespace = ep.GetK8sNamespace()
 		endpoint.PodName = ep.GetK8sPodName()
-		endpoint.PodUid = ep.GetK8sPodUID()
+		endpoint.PodUID = ep.GetK8sPodUID()
 		if pod := ep.GetPod(); pod != nil {
 			workload, workloadTypeMeta, ok := utils.GetWorkloadMetaFromPod(pod)
 			if ok {
-				endpoint.Workloads = []*flowpb.Workload{{Kind: workloadTypeMeta.Kind, Name: workload.Name}}
+				endpoint.Workloads = []ir.Workload{{Kind: workloadTypeMeta.Kind, Name: workload.Name}}
 			}
 		}
 	}
 }
 
-func decodeTime(timestamp string) (goTime time.Time, pbTime *timestamppb.Timestamp, err error) {
-	goTime, err = time.Parse(time.RFC3339Nano, timestamp)
-	if err != nil {
-		return
-	}
-
-	pbTime = timestamppb.New(goTime)
-	err = pbTime.CheckValid()
-	return
+func decodeTime(timestamp string) (goTime time.Time, err error) {
+	return time.Parse(time.RFC3339Nano, timestamp)
 }
 
 func decodeVerdict(verdict accesslog.FlowVerdict) flowpb.Verdict {
@@ -281,74 +273,68 @@ func decodeTrafficDirection(direction accesslog.ObservationPoint) flowpb.Traffic
 	}
 }
 
-func decodeIP(version accesslog.IPVersion, source, destination accesslog.EndpointInfo) *flowpb.IP {
+func decodeIP(version accesslog.IPVersion, source, destination accesslog.EndpointInfo) ir.IP {
 	switch version {
 	case accesslog.VersionIPv4:
-		return &flowpb.IP{
+		return ir.IP{
 			Source:      source.IPv4,
 			Destination: destination.IPv4,
-			IpVersion:   flowpb.IPVersion_IPv4,
+			IPVersion:   flowpb.IPVersion_IPv4,
 		}
 	case accesslog.VersionIPV6:
-		return &flowpb.IP{
+		return ir.IP{
 			Source:      source.IPv6,
 			Destination: destination.IPv6,
-			IpVersion:   flowpb.IPVersion_IPv6,
+			IPVersion:   flowpb.IPVersion_IPv6,
 		}
 	default:
-		return nil
+		return ir.IP{}
 	}
 }
 
-func decodeLayer4(protocol accesslog.TransportProtocol, source, destination accesslog.EndpointInfo) (l4 *flowpb.Layer4, srcPort, dstPort uint16) {
+func decodeLayer4(protocol accesslog.TransportProtocol, source, destination accesslog.EndpointInfo) (l4 ir.Layer4, srcPort, dstPort uint16) {
 	switch u8proto.U8proto(protocol) {
 	case u8proto.TCP:
-		return &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					SourcePort:      uint32(source.Port),
-					DestinationPort: uint32(destination.Port),
-				},
+		return ir.Layer4{
+			TCP: ir.TCP{
+				SourcePort:      uint32(source.Port),
+				DestinationPort: uint32(destination.Port),
 			},
 		}, uint16(source.Port), uint16(destination.Port)
 	case u8proto.UDP:
-		return &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_UDP{
-				UDP: &flowpb.UDP{
-					SourcePort:      uint32(source.Port),
-					DestinationPort: uint32(destination.Port),
-				},
+		return ir.Layer4{
+			UDP: ir.UDP{
+				SourcePort:      uint32(source.Port),
+				DestinationPort: uint32(destination.Port),
 			},
 		}, uint16(source.Port), uint16(destination.Port)
 	case u8proto.SCTP:
-		return &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_SCTP{
-				SCTP: &flowpb.SCTP{
-					SourcePort:      uint32(source.Port),
-					DestinationPort: uint32(destination.Port),
-				},
+		return ir.Layer4{
+			SCTP: ir.SCTP{
+				SourcePort:      uint32(source.Port),
+				DestinationPort: uint32(destination.Port),
 			},
 		}, uint16(source.Port), uint16(destination.Port)
 	default:
-		return nil, 0, 0
+		return ir.Layer4{}, 0, 0
 	}
 }
 
-func decodeEndpoint(endpoint accesslog.EndpointInfo, namespace, podName, podUID string) *flowpb.Endpoint {
+func decodeEndpoint(endpoint accesslog.EndpointInfo, namespace, podName, podUID string) ir.Endpoint {
 	labels := endpoint.Labels.GetModel()
 	slices.Sort(labels)
-	return &flowpb.Endpoint{
+	return ir.Endpoint{
 		ID:          uint32(endpoint.ID),
 		Identity:    uint32(endpoint.Identity),
 		ClusterName: endpoint.Labels.Get(string(source.Kubernetes) + ciliumLabels.SourceDelimiter + k8sConst.PolicyLabelCluster),
 		Namespace:   namespace,
 		Labels:      labels,
 		PodName:     podName,
-		PodUid:      podUID,
+		PodUID:      podUID,
 	}
 }
 
-func decodeLayer7(r *accesslog.LogRecord, opts *options.Options) *flowpb.Layer7 {
+func decodeLayer7(r *accesslog.LogRecord, opts *options.Options) ir.Layer7 {
 	var flowType flowpb.L7FlowType
 	switch r.Type {
 	case accesslog.TypeRequest:
@@ -361,30 +347,32 @@ func decodeLayer7(r *accesslog.LogRecord, opts *options.Options) *flowpb.Layer7 
 
 	switch {
 	case r.DNS != nil:
-		return &flowpb.Layer7{
-			Type:   flowType,
-			Record: decodeDNS(r.Type, r.DNS),
+		return ir.Layer7{
+			Type: flowType,
+			DNS:  decodeDNS(r.Type, r.DNS),
 		}
 	case r.HTTP != nil:
-		return &flowpb.Layer7{
-			Type:   flowType,
-			Record: decodeHTTP(r.Type, r.HTTP, opts),
+		return ir.Layer7{
+			Type: flowType,
+			HTTP: decodeHTTP(r.Type, r.HTTP, opts),
 		}
 	default:
-		return &flowpb.Layer7{
+		return ir.Layer7{
 			Type: flowType,
 		}
 	}
 }
 
-func decodeIsReply(t accesslog.FlowType) *wrapperspb.BoolValue {
-	return &wrapperspb.BoolValue{
-		Value: t == accesslog.TypeResponse,
+func decodeIsReply(t accesslog.FlowType) ir.Reply {
+	if t == accesslog.TypeResponse {
+		return ir.ReplyYes
 	}
+
+	return ir.ReplyNo
 }
 
-func decodeCiliumEventType(eventType uint8) *flowpb.CiliumEventType {
-	return &flowpb.CiliumEventType{
+func decodeCiliumEventType(eventType uint8) ir.CiliumEventType {
+	return ir.CiliumEventType{
 		Type: int32(eventType),
 	}
 }
@@ -393,7 +381,7 @@ func genericSummary(l7 *accesslog.LogRecordL7) string {
 	return fmt.Sprintf("%s Fields: %s", l7.Proto, l7.Fields)
 }
 
-func (p *Parser) getSummary(logRecord *accesslog.LogRecord, flow *flowpb.Flow) string {
+func (p *Parser) getSummary(logRecord *accesslog.LogRecord, flow *ir.Flow) string {
 	if logRecord == nil {
 		return ""
 	}

--- a/pkg/hubble/parser/seven/parser_test.go
+++ b/pkg/hubble/parser/seven/parser_test.go
@@ -15,6 +15,7 @@ import (
 	k8sTypes "k8s.io/apimachinery/pkg/types"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	"github.com/cilium/cilium/pkg/hubble/testutils"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -84,11 +85,10 @@ func BenchmarkL7Decode(b *testing.B) {
 	parser, err := New(hivetest.Logger(b), dnsGetter, ipGetter, serviceGetter, endpointGetter)
 	require.NoError(b, err)
 
-	f := &flowpb.Flow{}
+	var f ir.Flow
 	b.ReportAllocs()
-
 	for b.Loop() {
-		_ = parser.Decode(lr, f)
+		_ = parser.Decode(lr, &f)
 	}
 }
 
@@ -113,7 +113,7 @@ func Test_decodeEndpoint(t *testing.T) {
 			"k8s:app.kubernetes.io/part-of=cilium",
 		),
 	}
-	expected := &flowpb.Endpoint{
+	expected := ir.Endpoint{
 		ID:          1234,
 		Identity:    9876,
 		ClusterName: "default",
@@ -127,13 +127,13 @@ func Test_decodeEndpoint(t *testing.T) {
 			"k8s:k8s-app=hubble-ui",
 		},
 		PodName: "hubble-ui",
-		PodUid:  "hubble-ui-uid",
+		PodUID:  "hubble-ui-uid",
 	}
 	ep := decodeEndpoint(epi, "kube-system", "hubble-ui", "hubble-ui-uid")
 	assert.Equal(t, expected, ep)
 
 	ep = decodeEndpoint(epi, "kube-system", "hubble-ui", "")
-	assert.Empty(t, ep.GetPodUid())
+	assert.Empty(t, ep.PodUID)
 }
 
 func TestUpdateEndpointFromLocalPodMetadata(t *testing.T) {
@@ -150,7 +150,7 @@ func TestUpdateEndpointFromLocalPodMetadata(t *testing.T) {
 			}},
 		}}
 	}
-	localWorkload := []*flowpb.Workload{{Kind: "StatefulSet", Name: "local-workload"}}
+	localWorkload := []ir.Workload{{Kind: "StatefulSet", Name: "local-workload"}}
 	tests := []struct {
 		name            string
 		endpointID      uint32
@@ -162,7 +162,7 @@ func TestUpdateEndpointFromLocalPodMetadata(t *testing.T) {
 		wantNamespace   string
 		wantPodName     string
 		wantPodUID      string
-		wantWorkloads   []*flowpb.Workload
+		wantWorkloads   ir.Workloads
 	}{
 		{
 			name:            "CNI UID overrides IPCache metadata",
@@ -227,19 +227,19 @@ func TestUpdateEndpointFromLocalPodMetadata(t *testing.T) {
 					},
 				},
 			}
-			endpoint := &flowpb.Endpoint{
+			endpoint := ir.Endpoint{
 				ID:        tt.endpointID,
 				Namespace: "ipcache-namespace",
 				PodName:   "ipcache-pod",
-				PodUid:    "ipcache-pod-uid",
+				PodUID:    "ipcache-pod-uid",
 			}
 
-			parser.updateEndpointFromLocal(ip, endpoint)
+			parser.updateEndpointWorkloads(ip, &endpoint)
 
-			assert.Equal(t, tt.wantNamespace, endpoint.GetNamespace())
-			assert.Equal(t, tt.wantPodName, endpoint.GetPodName())
-			assert.Equal(t, tt.wantPodUID, endpoint.GetPodUid())
-			assert.Equal(t, tt.wantWorkloads, endpoint.GetWorkloads())
+			assert.Equal(t, tt.wantNamespace, endpoint.Namespace)
+			assert.Equal(t, tt.wantPodName, endpoint.PodName)
+			assert.Equal(t, tt.wantPodUID, endpoint.PodUID)
+			assert.Equal(t, tt.wantWorkloads, endpoint.Workloads)
 		})
 	}
 }

--- a/pkg/hubble/parser/seven/parser_test.go
+++ b/pkg/hubble/parser/seven/parser_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/testutils"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
@@ -79,11 +80,10 @@ func BenchmarkL7Decode(b *testing.B) {
 	parser, err := New(hivetest.Logger(b), dnsGetter, ipGetter, serviceGetter, endpointGetter)
 	require.NoError(b, err)
 
-	f := &flowpb.Flow{}
+	var f ir.Flow
 	b.ReportAllocs()
-
 	for b.Loop() {
-		_ = parser.Decode(lr, f)
+		_ = parser.Decode(lr, &f)
 	}
 }
 
@@ -108,7 +108,7 @@ func Test_decodeEndpoint(t *testing.T) {
 			"k8s:app.kubernetes.io/part-of=cilium",
 		),
 	}
-	expected := &flowpb.Endpoint{
+	expected := ir.Endpoint{
 		ID:          1234,
 		Identity:    9876,
 		ClusterName: "default",

--- a/pkg/hubble/parser/sock/parser.go
+++ b/pkg/hubble/parser/sock/parser.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/parser/common"
 	"github.com/cilium/cilium/pkg/hubble/parser/errors"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
@@ -47,7 +48,7 @@ func New(log *slog.Logger,
 ) (*Parser, error) {
 	args := &options.Options{
 		SkipUnknownCGroupIDs: true,
-		TraceSockNotifyDecoder: func(data []byte, decoded *flowpb.Flow) (*monitor.TraceSockNotify, error) {
+		TraceSockNotifyDecoder: func(data []byte, decoded *ir.Flow) (*monitor.TraceSockNotify, error) {
 			sock := &monitor.TraceSockNotify{}
 			return sock, sock.Decode(data)
 		},
@@ -73,7 +74,7 @@ func New(log *slog.Logger,
 
 // Decode takes a raw trace sock event payload obtained from the perf event ring
 // buffer and decodes it into a flow
-func (p *Parser) Decode(data []byte, decoded *flowpb.Flow) error {
+func (p *Parser) Decode(data []byte, decoded *ir.Flow) error {
 	if len(data) == 0 {
 		return errors.ErrEmptyData
 	}
@@ -122,17 +123,17 @@ func (p *Parser) Decode(data []byte, decoded *flowpb.Flow) error {
 	decoded.Verdict = decodeVerdict(sock.XlatePoint)
 	decoded.IP = decodeL3(srcIP, dstIP, ipVersion)
 	decoded.L4 = decodeL4(sock.L4Proto, srcPort, dstPort)
-	decoded.Source = srcEndpoint
+	decoded.Source = ir.ProtoToEp(srcEndpoint)
 	decoded.SourceNames = p.resolveNames(dstEndpoint.GetID(), srcIP)
 	decoded.SourceService = p.decodeService(srcIP, srcPort)
-	decoded.Destination = dstEndpoint
+	decoded.Destination = ir.ProtoToEp(dstEndpoint)
 	decoded.DestinationService = p.decodeService(dstIP, dstPort)
 	decoded.DestinationNames = p.resolveNames(srcEndpoint.GetID(), dstIP)
 	decoded.Type = flowpb.FlowType_SOCK
 	decoded.EventType = decodeCiliumEventType(sock.Type, sock.XlatePoint)
 	decoded.SockXlatePoint = flowpb.SocketTranslationPoint(sock.XlatePoint)
 	decoded.SocketCookie = sock.SockCookie
-	decoded.CgroupId = sock.CgroupId
+	decoded.CgroupID = sock.CgroupId
 	decoded.Summary = decodeSummary(sock)
 	return nil
 }
@@ -177,7 +178,7 @@ func (p *Parser) decodeEndpointIP(cgroupId uint64, ipVersion flowpb.IPVersion) n
 	return netip.Addr{}
 }
 
-func decodeL3(srcIP, dstIP netip.Addr, ipVersion flowpb.IPVersion) *flowpb.IP {
+func decodeL3(srcIP, dstIP netip.Addr, ipVersion flowpb.IPVersion) ir.IP {
 	var srcIPStr, dstIPStr string
 	if srcIP.IsValid() {
 		srcIPStr = srcIP.String()
@@ -186,36 +187,32 @@ func decodeL3(srcIP, dstIP netip.Addr, ipVersion flowpb.IPVersion) *flowpb.IP {
 		dstIPStr = dstIP.String()
 	}
 
-	return &flowpb.IP{
+	return ir.IP{
 		Source:      srcIPStr,
 		Destination: dstIPStr,
-		IpVersion:   ipVersion,
+		IPVersion:   ipVersion,
 	}
 }
 
-func decodeL4(proto uint8, srcPort, dstPort uint16) *flowpb.Layer4 {
+func decodeL4(proto uint8, srcPort, dstPort uint16) ir.Layer4 {
 	switch proto {
 	case monitor.L4ProtocolTCP:
-		return &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					SourcePort:      uint32(srcPort),
-					DestinationPort: uint32(dstPort),
-				},
+		return ir.Layer4{
+			TCP: ir.TCP{
+				SourcePort:      uint32(srcPort),
+				DestinationPort: uint32(dstPort),
 			},
 		}
 	case monitor.L4ProtocolUDP:
-		return &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_UDP{
-				UDP: &flowpb.UDP{
-					SourcePort:      uint32(srcPort),
-					DestinationPort: uint32(dstPort),
-				},
+		return ir.Layer4{
+			UDP: ir.UDP{
+				SourcePort:      uint32(srcPort),
+				DestinationPort: uint32(dstPort),
 			},
 		}
 	}
 
-	return nil
+	return ir.Layer4{}
 }
 
 func (p *Parser) resolveNames(epID uint32, ip netip.Addr) (names []string) {
@@ -226,12 +223,12 @@ func (p *Parser) resolveNames(epID uint32, ip netip.Addr) (names []string) {
 	return nil
 }
 
-func (p *Parser) decodeService(ip netip.Addr, port uint16) *flowpb.Service {
+func (p *Parser) decodeService(ip netip.Addr, port uint16) ir.Service {
 	if p.serviceGetter != nil {
-		return p.serviceGetter.GetServiceByAddr(ip, port)
+		return ir.ProtoToService(p.serviceGetter.GetServiceByAddr(ip, port))
 	}
 
-	return nil
+	return ir.Service{}
 }
 
 func decodeVerdict(xlatePoint uint8) flowpb.Verdict {
@@ -257,8 +254,8 @@ func decodeRevNat(xlatePoint uint8) bool {
 	return false
 }
 
-func decodeCiliumEventType(eventType, subtype uint8) *flowpb.CiliumEventType {
-	return &flowpb.CiliumEventType{
+func decodeCiliumEventType(eventType, subtype uint8) ir.CiliumEventType {
+	return ir.CiliumEventType{
 		Type:    int32(eventType),
 		SubType: int32(subtype),
 	}

--- a/pkg/hubble/parser/sock/parser.go
+++ b/pkg/hubble/parser/sock/parser.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/parser/common"
 	"github.com/cilium/cilium/pkg/hubble/parser/errors"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
@@ -47,7 +48,7 @@ func New(log *slog.Logger,
 ) (*Parser, error) {
 	args := &options.Options{
 		SkipUnknownCGroupIDs: true,
-		TraceSockNotifyDecoder: func(data []byte, decoded *flowpb.Flow) (*monitor.TraceSockNotify, error) {
+		TraceSockNotifyDecoder: func(data []byte, decoded *ir.Flow) (*monitor.TraceSockNotify, error) {
 			sock := &monitor.TraceSockNotify{}
 			return sock, sock.Decode(data)
 		},
@@ -73,7 +74,7 @@ func New(log *slog.Logger,
 
 // Decode takes a raw trace sock event payload obtained from the perf event ring
 // buffer and decodes it into a flow
-func (p *Parser) Decode(data []byte, decoded *flowpb.Flow) error {
+func (p *Parser) Decode(data []byte, decoded *ir.Flow) error {
 	if len(data) == 0 {
 		return errors.ErrEmptyData
 	}
@@ -123,16 +124,16 @@ func (p *Parser) Decode(data []byte, decoded *flowpb.Flow) error {
 	decoded.IP = decodeL3(srcIP, dstIP, ipVersion)
 	decoded.L4 = decodeL4(sock.L4Proto, srcPort, dstPort)
 	decoded.Source = srcEndpoint
-	decoded.SourceNames = p.resolveNames(dstEndpoint.GetID(), srcIP)
+	decoded.SourceNames = p.resolveNames(dstEndpoint.ID, srcIP)
 	decoded.SourceService = p.decodeService(srcIP, srcPort)
 	decoded.Destination = dstEndpoint
 	decoded.DestinationService = p.decodeService(dstIP, dstPort)
-	decoded.DestinationNames = p.resolveNames(srcEndpoint.GetID(), dstIP)
+	decoded.DestinationNames = p.resolveNames(srcEndpoint.ID, dstIP)
 	decoded.Type = flowpb.FlowType_SOCK
 	decoded.EventType = decodeCiliumEventType(sock.Type, sock.XlatePoint)
 	decoded.SockXlatePoint = flowpb.SocketTranslationPoint(sock.XlatePoint)
 	decoded.SocketCookie = sock.SockCookie
-	decoded.CgroupId = sock.CgroupId
+	decoded.CgroupID = sock.CgroupId
 	decoded.Summary = decodeSummary(sock)
 	return nil
 }
@@ -177,7 +178,7 @@ func (p *Parser) decodeEndpointIP(cgroupId uint64, ipVersion flowpb.IPVersion) n
 	return netip.Addr{}
 }
 
-func decodeL3(srcIP, dstIP netip.Addr, ipVersion flowpb.IPVersion) *flowpb.IP {
+func decodeL3(srcIP, dstIP netip.Addr, ipVersion flowpb.IPVersion) ir.IP {
 	var srcIPStr, dstIPStr string
 	if srcIP.IsValid() {
 		srcIPStr = srcIP.String()
@@ -186,36 +187,32 @@ func decodeL3(srcIP, dstIP netip.Addr, ipVersion flowpb.IPVersion) *flowpb.IP {
 		dstIPStr = dstIP.String()
 	}
 
-	return &flowpb.IP{
+	return ir.IP{
 		Source:      srcIPStr,
 		Destination: dstIPStr,
-		IpVersion:   ipVersion,
+		IPVersion:   ipVersion,
 	}
 }
 
-func decodeL4(proto uint8, srcPort, dstPort uint16) *flowpb.Layer4 {
+func decodeL4(proto uint8, srcPort, dstPort uint16) ir.Layer4 {
 	switch proto {
 	case monitor.L4ProtocolTCP:
-		return &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					SourcePort:      uint32(srcPort),
-					DestinationPort: uint32(dstPort),
-				},
+		return ir.Layer4{
+			TCP: ir.TCP{
+				SourcePort:      uint32(srcPort),
+				DestinationPort: uint32(dstPort),
 			},
 		}
 	case monitor.L4ProtocolUDP:
-		return &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_UDP{
-				UDP: &flowpb.UDP{
-					SourcePort:      uint32(srcPort),
-					DestinationPort: uint32(dstPort),
-				},
+		return ir.Layer4{
+			UDP: ir.UDP{
+				SourcePort:      uint32(srcPort),
+				DestinationPort: uint32(dstPort),
 			},
 		}
 	}
 
-	return nil
+	return ir.Layer4{}
 }
 
 func (p *Parser) resolveNames(epID uint32, ip netip.Addr) (names []string) {
@@ -226,12 +223,13 @@ func (p *Parser) resolveNames(epID uint32, ip netip.Addr) (names []string) {
 	return nil
 }
 
-func (p *Parser) decodeService(ip netip.Addr, port uint16) *flowpb.Service {
+func (p *Parser) decodeService(ip netip.Addr, port uint16) ir.Service {
 	if p.serviceGetter != nil {
-		return p.serviceGetter.GetServiceByAddr(ip, port)
+		fqn := p.serviceGetter.GetServiceByAddr(ip, port)
+		return ir.NewService(fqn.Name, fqn.Namespace)
 	}
 
-	return nil
+	return ir.Service{}
 }
 
 func decodeVerdict(xlatePoint uint8) flowpb.Verdict {
@@ -257,8 +255,8 @@ func decodeRevNat(xlatePoint uint8) bool {
 	return false
 }
 
-func decodeCiliumEventType(eventType, subtype uint8) *flowpb.CiliumEventType {
-	return &flowpb.CiliumEventType{
+func decodeCiliumEventType(eventType, subtype uint8) ir.CiliumEventType {
+	return ir.CiliumEventType{
 		Type:    int32(eventType),
 		SubType: int32(subtype),
 	}

--- a/pkg/hubble/parser/sock/parser_test.go
+++ b/pkg/hubble/parser/sock/parser_test.go
@@ -18,6 +18,7 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	cgroupManager "github.com/cilium/cilium/pkg/cgroups/manager"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	parserErrors "github.com/cilium/cilium/pkg/hubble/parser/errors"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	"github.com/cilium/cilium/pkg/hubble/parser/options"
@@ -200,7 +201,7 @@ func TestDecodeSockEvent(t *testing.T) {
 		opts []options.Option
 
 		rawMsg []byte
-		flow   *flowpb.Flow
+		flow   ir.Flow
 		errMsg string
 	}{
 		{
@@ -242,19 +243,17 @@ func TestDecodeSockEvent(t *testing.T) {
 				SockCookie: 0xc0ffee,
 			},
 			opts: []options.Option{options.WithSkipUnknownCGroupIDs(false)},
-			flow: &flowpb.Flow{
+			flow: ir.Flow{
 				Type:    flowpb.FlowType_SOCK,
 				Verdict: flowpb.Verdict_TRACED,
-				IP: &flowpb.IP{
+				IP: ir.IP{
 					Destination: "10.10.10.10",
-					IpVersion:   flowpb.IPVersion_IPv4,
+					IPVersion:   flowpb.IPVersion_IPv4,
 				},
-				L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_UDP{UDP: &flowpb.UDP{
+				L4: ir.Layer4{UDP: ir.UDP{
 					DestinationPort: 8080,
-				}}},
-				Source:      &flowpb.Endpoint{},
-				Destination: &flowpb.Endpoint{},
-				EventType: &flowpb.CiliumEventType{
+				}},
+				EventType: ir.CiliumEventType{
 					Type:    monitorAPI.MessageTypeTraceSock,
 					SubType: monitor.XlatePointPreDirectionFwd,
 				},
@@ -273,32 +272,31 @@ func TestDecodeSockEvent(t *testing.T) {
 				CgroupId:   xwingCgroupId,
 				L4Proto:    monitor.L4ProtocolTCP,
 			},
-			flow: &flowpb.Flow{
+			flow: ir.Flow{
 				Type:     flowpb.FlowType_SOCK,
 				Verdict:  flowpb.Verdict_TRACED,
-				CgroupId: xwingCgroupId,
-				IP: &flowpb.IP{
+				CgroupID: xwingCgroupId,
+				IP: ir.IP{
 					Source:      xwingIPv4,
 					Destination: deathstarServiceV4,
-					IpVersion:   flowpb.IPVersion_IPv4,
+					IPVersion:   flowpb.IPVersion_IPv4,
 				},
-				L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{
+				L4: ir.Layer4{TCP: ir.TCP{
 					DestinationPort: deathstarServicePort,
-				}}},
-				Source: &flowpb.Endpoint{
+				}},
+				Source: ir.Endpoint{
 					ID:        xwingEndpoint,
 					Identity:  xwingIdentity,
 					PodName:   xwingPodName,
 					Namespace: xwingPodNamespace,
 					Labels:    xwingLabels,
 				},
-				Destination:      &flowpb.Endpoint{},
 				DestinationNames: []string{deathstarServiceDomain},
-				DestinationService: &flowpb.Service{
+				DestinationService: ir.Service{
 					Name:      deathstarServiceName,
 					Namespace: deathstarServiceNamespace,
 				},
-				EventType: &flowpb.CiliumEventType{
+				EventType: ir.CiliumEventType{
 					Type:    monitorAPI.MessageTypeTraceSock,
 					SubType: monitor.XlatePointPreDirectionFwd,
 				},
@@ -316,32 +314,32 @@ func TestDecodeSockEvent(t *testing.T) {
 				CgroupId:   xwingCgroupId,
 				L4Proto:    monitor.L4ProtocolTCP,
 			},
-			flow: &flowpb.Flow{
+			flow: ir.Flow{
 				Type:     flowpb.FlowType_SOCK,
 				Verdict:  flowpb.Verdict_TRANSLATED,
-				CgroupId: xwingCgroupId,
-				IP: &flowpb.IP{
+				CgroupID: xwingCgroupId,
+				IP: ir.IP{
 					Source:      xwingIPv4,
 					Destination: deathstarAltIPv4,
-					IpVersion:   flowpb.IPVersion_IPv4,
+					IPVersion:   flowpb.IPVersion_IPv4,
 				},
-				L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{
+				L4: ir.Layer4{TCP: ir.TCP{
 					DestinationPort: deathstarTargetPort,
-				}}},
-				Source: &flowpb.Endpoint{
+				}},
+				Source: ir.Endpoint{
 					ID:        xwingEndpoint,
 					Identity:  xwingIdentity,
 					PodName:   xwingPodName,
 					Namespace: xwingPodNamespace,
 					Labels:    xwingLabels,
 				},
-				Destination: &flowpb.Endpoint{
+				Destination: ir.Endpoint{
 					Identity:  deathstarIdentity,
 					PodName:   deathstarAltPodName,
 					Namespace: deathstarAltPodNamespace,
 					Labels:    deathstarLabels,
 				},
-				EventType: &flowpb.CiliumEventType{
+				EventType: ir.CiliumEventType{
 					Type:    monitorAPI.MessageTypeTraceSock,
 					SubType: monitor.XlatePointPostDirectionFwd,
 				},
@@ -360,32 +358,31 @@ func TestDecodeSockEvent(t *testing.T) {
 				L4Proto:    monitor.L4ProtocolTCP,
 				Flags:      monitor.TraceSockNotifyFlagIPv6,
 			},
-			flow: &flowpb.Flow{
+			flow: ir.Flow{
 				Type:     flowpb.FlowType_SOCK,
 				Verdict:  flowpb.Verdict_TRANSLATED,
-				CgroupId: xwingCgroupId,
-				IP: &flowpb.IP{
+				CgroupID: xwingCgroupId,
+				IP: ir.IP{
 					Source:      deathstarServiceV6,
 					Destination: xwingIPv6,
-					IpVersion:   flowpb.IPVersion_IPv6,
+					IPVersion:   flowpb.IPVersion_IPv6,
 				},
-				L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{
+				L4: ir.Layer4{TCP: ir.TCP{
 					SourcePort: deathstarServicePort,
-				}}},
-				Source:      &flowpb.Endpoint{},
+				}},
 				SourceNames: []string{deathstarServiceDomain},
-				SourceService: &flowpb.Service{
+				SourceService: ir.Service{
 					Name:      deathstarServiceName,
 					Namespace: deathstarServiceNamespace,
 				},
-				Destination: &flowpb.Endpoint{
+				Destination: ir.Endpoint{
 					ID:        xwingEndpoint,
 					Identity:  xwingIdentity,
 					PodName:   xwingPodName,
 					Namespace: xwingPodNamespace,
 					Labels:    xwingLabels,
 				},
-				EventType: &flowpb.CiliumEventType{
+				EventType: ir.CiliumEventType{
 					Type:    monitorAPI.MessageTypeTraceSock,
 					SubType: monitor.XlatePointPostDirectionRev,
 				},
@@ -405,8 +402,8 @@ func TestDecodeSockEvent(t *testing.T) {
 			},
 			opts: []options.Option{
 				options.WithSkipUnknownCGroupIDs(false),
-				options.WithTraceSockNotifyDecoder(func(data []byte, flow *flowpb.Flow) (*monitor.TraceSockNotify, error) {
-					flow.Uuid = "coffee"
+				options.WithTraceSockNotifyDecoder(func(data []byte, flow *ir.Flow) (*monitor.TraceSockNotify, error) {
+					flow.UUID = "coffee"
 					return &monitor.TraceSockNotify{
 						Type:       monitorAPI.MessageTypeTraceSock,
 						XlatePoint: monitor.XlatePointPostDirectionFwd,
@@ -417,20 +414,18 @@ func TestDecodeSockEvent(t *testing.T) {
 					}, nil
 				}),
 			},
-			flow: &flowpb.Flow{
-				Uuid:    "coffee",
+			flow: ir.Flow{
+				UUID:    "coffee",
 				Type:    flowpb.FlowType_SOCK,
 				Verdict: flowpb.Verdict_TRANSLATED,
-				IP: &flowpb.IP{
+				IP: ir.IP{
 					Destination: "192.10.21.20",
-					IpVersion:   flowpb.IPVersion_IPv4,
+					IPVersion:   flowpb.IPVersion_IPv4,
 				},
-				L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_UDP{UDP: &flowpb.UDP{
+				L4: ir.Layer4{UDP: ir.UDP{
 					DestinationPort: 8081,
-				}}},
-				Source:      &flowpb.Endpoint{},
-				Destination: &flowpb.Endpoint{},
-				EventType: &flowpb.CiliumEventType{
+				}},
+				EventType: ir.CiliumEventType{
 					Type:    monitorAPI.MessageTypeTraceSock,
 					SubType: monitor.XlatePointPostDirectionFwd,
 				},
@@ -454,8 +449,8 @@ func TestDecodeSockEvent(t *testing.T) {
 				assert.NoError(t, err)
 				data = buf.Bytes()
 			}
-			flow := &flowpb.Flow{}
-			err = p.Decode(data, flow)
+			var flow ir.Flow
+			err = p.Decode(data, &flow)
 			if tc.errMsg != "" {
 				assert.ErrorContains(t, err, tc.errMsg)
 			} else {

--- a/pkg/hubble/parser/sock/parser_test.go
+++ b/pkg/hubble/parser/sock/parser_test.go
@@ -18,6 +18,7 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	cgroupManager "github.com/cilium/cilium/pkg/cgroups/manager"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	parserErrors "github.com/cilium/cilium/pkg/hubble/parser/errors"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	"github.com/cilium/cilium/pkg/hubble/parser/options"
@@ -167,17 +168,14 @@ func TestDecodeSockEvent(t *testing.T) {
 		},
 	}
 	serviceGetter := &testutils.FakeServiceGetter{
-		OnGetServiceByAddr: func(ip netip.Addr, port uint16) *flowpb.Service {
+		OnGetServiceByAddr: func(ip netip.Addr, port uint16) getters.FQN {
 			switch ip.String() {
 			case deathstarServiceV4, deathstarServiceV6:
 				if port == deathstarServicePort {
-					return &flowpb.Service{
-						Name:      deathstarServiceName,
-						Namespace: deathstarServiceNamespace,
-					}
+					return getters.NewFQN(deathstarServiceNamespace, deathstarServiceName)
 				}
 			}
-			return nil
+			return getters.BlankFQN
 		},
 	}
 	cgroupGetter := &testutils.FakePodMetadataGetter{
@@ -200,7 +198,7 @@ func TestDecodeSockEvent(t *testing.T) {
 		opts []options.Option
 
 		rawMsg []byte
-		flow   *flowpb.Flow
+		flow   ir.Flow
 		errMsg string
 	}{
 		{
@@ -242,19 +240,17 @@ func TestDecodeSockEvent(t *testing.T) {
 				SockCookie: 0xc0ffee,
 			},
 			opts: []options.Option{options.WithSkipUnknownCGroupIDs(false)},
-			flow: &flowpb.Flow{
+			flow: ir.Flow{
 				Type:    flowpb.FlowType_SOCK,
 				Verdict: flowpb.Verdict_TRACED,
-				IP: &flowpb.IP{
+				IP: ir.IP{
 					Destination: "10.10.10.10",
-					IpVersion:   flowpb.IPVersion_IPv4,
+					IPVersion:   flowpb.IPVersion_IPv4,
 				},
-				L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_UDP{UDP: &flowpb.UDP{
+				L4: ir.Layer4{UDP: ir.UDP{
 					DestinationPort: 8080,
-				}}},
-				Source:      &flowpb.Endpoint{},
-				Destination: &flowpb.Endpoint{},
-				EventType: &flowpb.CiliumEventType{
+				}},
+				EventType: ir.CiliumEventType{
 					Type:    monitorAPI.MessageTypeTraceSock,
 					SubType: monitor.XlatePointPreDirectionFwd,
 				},
@@ -273,32 +269,31 @@ func TestDecodeSockEvent(t *testing.T) {
 				CgroupId:   xwingCgroupId,
 				L4Proto:    monitor.L4ProtocolTCP,
 			},
-			flow: &flowpb.Flow{
+			flow: ir.Flow{
 				Type:     flowpb.FlowType_SOCK,
 				Verdict:  flowpb.Verdict_TRACED,
-				CgroupId: xwingCgroupId,
-				IP: &flowpb.IP{
+				CgroupID: xwingCgroupId,
+				IP: ir.IP{
 					Source:      xwingIPv4,
 					Destination: deathstarServiceV4,
-					IpVersion:   flowpb.IPVersion_IPv4,
+					IPVersion:   flowpb.IPVersion_IPv4,
 				},
-				L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{
+				L4: ir.Layer4{TCP: ir.TCP{
 					DestinationPort: deathstarServicePort,
-				}}},
-				Source: &flowpb.Endpoint{
+				}},
+				Source: ir.Endpoint{
 					ID:        xwingEndpoint,
 					Identity:  xwingIdentity,
 					PodName:   xwingPodName,
 					Namespace: xwingPodNamespace,
 					Labels:    xwingLabels,
 				},
-				Destination:      &flowpb.Endpoint{},
 				DestinationNames: []string{deathstarServiceDomain},
-				DestinationService: &flowpb.Service{
+				DestinationService: ir.Service{
 					Name:      deathstarServiceName,
 					Namespace: deathstarServiceNamespace,
 				},
-				EventType: &flowpb.CiliumEventType{
+				EventType: ir.CiliumEventType{
 					Type:    monitorAPI.MessageTypeTraceSock,
 					SubType: monitor.XlatePointPreDirectionFwd,
 				},
@@ -316,32 +311,32 @@ func TestDecodeSockEvent(t *testing.T) {
 				CgroupId:   xwingCgroupId,
 				L4Proto:    monitor.L4ProtocolTCP,
 			},
-			flow: &flowpb.Flow{
+			flow: ir.Flow{
 				Type:     flowpb.FlowType_SOCK,
 				Verdict:  flowpb.Verdict_TRANSLATED,
-				CgroupId: xwingCgroupId,
-				IP: &flowpb.IP{
+				CgroupID: xwingCgroupId,
+				IP: ir.IP{
 					Source:      xwingIPv4,
 					Destination: deathstarAltIPv4,
-					IpVersion:   flowpb.IPVersion_IPv4,
+					IPVersion:   flowpb.IPVersion_IPv4,
 				},
-				L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{
+				L4: ir.Layer4{TCP: ir.TCP{
 					DestinationPort: deathstarTargetPort,
-				}}},
-				Source: &flowpb.Endpoint{
+				}},
+				Source: ir.Endpoint{
 					ID:        xwingEndpoint,
 					Identity:  xwingIdentity,
 					PodName:   xwingPodName,
 					Namespace: xwingPodNamespace,
 					Labels:    xwingLabels,
 				},
-				Destination: &flowpb.Endpoint{
+				Destination: ir.Endpoint{
 					Identity:  deathstarIdentity,
 					PodName:   deathstarAltPodName,
 					Namespace: deathstarAltPodNamespace,
 					Labels:    deathstarLabels,
 				},
-				EventType: &flowpb.CiliumEventType{
+				EventType: ir.CiliumEventType{
 					Type:    monitorAPI.MessageTypeTraceSock,
 					SubType: monitor.XlatePointPostDirectionFwd,
 				},
@@ -360,32 +355,31 @@ func TestDecodeSockEvent(t *testing.T) {
 				L4Proto:    monitor.L4ProtocolTCP,
 				Flags:      monitor.TraceSockNotifyFlagIPv6,
 			},
-			flow: &flowpb.Flow{
+			flow: ir.Flow{
 				Type:     flowpb.FlowType_SOCK,
 				Verdict:  flowpb.Verdict_TRANSLATED,
-				CgroupId: xwingCgroupId,
-				IP: &flowpb.IP{
+				CgroupID: xwingCgroupId,
+				IP: ir.IP{
 					Source:      deathstarServiceV6,
 					Destination: xwingIPv6,
-					IpVersion:   flowpb.IPVersion_IPv6,
+					IPVersion:   flowpb.IPVersion_IPv6,
 				},
-				L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{
+				L4: ir.Layer4{TCP: ir.TCP{
 					SourcePort: deathstarServicePort,
-				}}},
-				Source:      &flowpb.Endpoint{},
+				}},
 				SourceNames: []string{deathstarServiceDomain},
-				SourceService: &flowpb.Service{
+				SourceService: ir.Service{
 					Name:      deathstarServiceName,
 					Namespace: deathstarServiceNamespace,
 				},
-				Destination: &flowpb.Endpoint{
+				Destination: ir.Endpoint{
 					ID:        xwingEndpoint,
 					Identity:  xwingIdentity,
 					PodName:   xwingPodName,
 					Namespace: xwingPodNamespace,
 					Labels:    xwingLabels,
 				},
-				EventType: &flowpb.CiliumEventType{
+				EventType: ir.CiliumEventType{
 					Type:    monitorAPI.MessageTypeTraceSock,
 					SubType: monitor.XlatePointPostDirectionRev,
 				},
@@ -405,8 +399,8 @@ func TestDecodeSockEvent(t *testing.T) {
 			},
 			opts: []options.Option{
 				options.WithSkipUnknownCGroupIDs(false),
-				options.WithTraceSockNotifyDecoder(func(data []byte, flow *flowpb.Flow) (*monitor.TraceSockNotify, error) {
-					flow.Uuid = "coffee"
+				options.WithTraceSockNotifyDecoder(func(data []byte, flow *ir.Flow) (*monitor.TraceSockNotify, error) {
+					flow.UUID = "coffee"
 					return &monitor.TraceSockNotify{
 						Type:       monitorAPI.MessageTypeTraceSock,
 						XlatePoint: monitor.XlatePointPostDirectionFwd,
@@ -417,20 +411,18 @@ func TestDecodeSockEvent(t *testing.T) {
 					}, nil
 				}),
 			},
-			flow: &flowpb.Flow{
-				Uuid:    "coffee",
+			flow: ir.Flow{
+				UUID:    "coffee",
 				Type:    flowpb.FlowType_SOCK,
 				Verdict: flowpb.Verdict_TRANSLATED,
-				IP: &flowpb.IP{
+				IP: ir.IP{
 					Destination: "192.10.21.20",
-					IpVersion:   flowpb.IPVersion_IPv4,
+					IPVersion:   flowpb.IPVersion_IPv4,
 				},
-				L4: &flowpb.Layer4{Protocol: &flowpb.Layer4_UDP{UDP: &flowpb.UDP{
+				L4: ir.Layer4{UDP: ir.UDP{
 					DestinationPort: 8081,
-				}}},
-				Source:      &flowpb.Endpoint{},
-				Destination: &flowpb.Endpoint{},
-				EventType: &flowpb.CiliumEventType{
+				}},
+				EventType: ir.CiliumEventType{
 					Type:    monitorAPI.MessageTypeTraceSock,
 					SubType: monitor.XlatePointPostDirectionFwd,
 				},
@@ -454,8 +446,8 @@ func TestDecodeSockEvent(t *testing.T) {
 				assert.NoError(t, err)
 				data = buf.Bytes()
 			}
-			flow := &flowpb.Flow{}
-			err = p.Decode(data, flow)
+			var flow ir.Flow
+			err = p.Decode(data, &flow)
 			if tc.errMsg != "" {
 				assert.ErrorContains(t, err, tc.errMsg)
 			} else {

--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -12,10 +12,10 @@ import (
 	"github.com/gopacket/gopacket"
 	"github.com/gopacket/gopacket/layers"
 	"go4.org/netipx"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	pb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/byteorder"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/parser/common"
 	"github.com/cilium/cilium/pkg/hubble/parser/errors"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
@@ -134,19 +134,19 @@ func New(
 
 	args := &options.Options{
 		EnableNetworkPolicyCorrelation: true,
-		DropNotifyDecoder: func(data []byte, decoded *pb.Flow) (*monitor.DropNotify, error) {
+		DropNotifyDecoder: func(data []byte, decoded *ir.Flow) (*monitor.DropNotify, error) {
 			dn := &monitor.DropNotify{}
 			return dn, dn.Decode(data)
 		},
-		DebugCaptureDecoder: func(data []byte, decoded *pb.Flow) (*monitor.DebugCapture, error) {
+		DebugCaptureDecoder: func(data []byte, decoded *ir.Flow) (*monitor.DebugCapture, error) {
 			dbg := &monitor.DebugCapture{}
 			return dbg, dbg.Decode(data)
 		},
-		TraceNotifyDecoder: func(data []byte, decoded *pb.Flow) (*monitor.TraceNotify, error) {
+		TraceNotifyDecoder: func(data []byte, decoded *ir.Flow) (*monitor.TraceNotify, error) {
 			tn := &monitor.TraceNotify{}
 			return tn, tn.Decode(data)
 		},
-		PolicyVerdictNotifyDecoder: func(data []byte, decoded *pb.Flow) (*monitor.PolicyVerdictNotify, error) {
+		PolicyVerdictNotifyDecoder: func(data []byte, decoded *ir.Flow) (*monitor.PolicyVerdictNotify, error) {
 			pvn := &monitor.PolicyVerdictNotify{}
 			return pvn, pvn.Decode(data)
 		},
@@ -176,11 +176,10 @@ func New(
 }
 
 // Decode decodes the data from 'data' into 'decoded'
-func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
+func (p *Parser) Decode(data []byte, decoded *ir.Flow) error {
 	if len(data) == 0 {
 		return errors.ErrEmptyData
 	}
-
 	eventType := data[0]
 
 	var err error
@@ -248,8 +247,8 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 		return err
 	}
 
-	ip := decoded.GetIP()
-	if tn != nil && ip != nil {
+	ip := decoded.IP
+	if tn != nil && !ip.IsEmpty() {
 		if !tn.OriginalIP().IsUnspecified() {
 			srcIP = tn.OriginalIP()
 			// On SNAT the trace notification has OrigIP set to the pre
@@ -257,8 +256,8 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 			// post translation IP. The check is here because sometimes we get
 			// trace notifications with OrigIP set to the header's IP
 			// (pre-translation events?)
-			if ip.GetSource() != srcIP.String() {
-				ip.SourceXlated = ip.GetSource()
+			if sip := ip.Source; sip != srcIP.String() {
+				ip.SourceXlated = sip
 				ip.Source = srcIP.String()
 			}
 		}
@@ -276,7 +275,7 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 	}
 	srcEndpoint := p.epResolver.ResolveEndpoint(srcIP, srcLabelID, datapathContext)
 	dstEndpoint := p.epResolver.ResolveEndpoint(dstIP, dstLabelID, datapathContext)
-	var sourceService, destinationService *pb.Service
+	var sourceService, destinationService getters.FQN
 	if p.serviceGetter != nil {
 		sourceService = p.serviceGetter.GetServiceByAddr(srcIP, srcPort)
 		destinationService = p.serviceGetter.GetServiceByAddr(dstIP, dstPort)
@@ -289,20 +288,25 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 	decoded.ExtError = decodeExtError(dn)
 	decoded.ExtDropReasonDesc = decodeExtDropReasonDesc(dn)
 	decoded.File = decodeFileInfo(dn)
+	decoded.IP = ip
 	decoded.Source = srcEndpoint
 	decoded.Destination = dstEndpoint
 	decoded.Type = pb.FlowType_L3_L4
 	decoded.SourceNames = p.resolveNames(dstEndpoint.ID, srcIP)
 	decoded.DestinationNames = p.resolveNames(srcEndpoint.ID, dstIP)
-	decoded.L7 = nil
-	decoded.IsReply = decodeIsReply(tn, pvn)
-	decoded.Reply = decoded.GetIsReply().GetValue() // false if GetIsReply() is nil
+	decoded.Reply = decodeIsReply(tn, pvn)
 	decoded.TrafficDirection = decodeTrafficDirection(srcEndpoint.ID, dn, tn, pvn)
 	decoded.EventType = decodeCiliumEventType(eventType, eventSubType)
 	decoded.TraceReason = decodeTraceReason(tn)
-	decoded.IpTraceId = decodeIpTraceId(dn, tn)
-	decoded.SourceService = sourceService
-	decoded.DestinationService = destinationService
+	decoded.IPTraceID = decodeIpTraceId(dn, tn)
+	decoded.SourceService = ir.Service{
+		Namespace: sourceService.Namespace,
+		Name:      sourceService.Name,
+	}
+	decoded.DestinationService = ir.Service{
+		Namespace: destinationService.Namespace,
+		Name:      destinationService.Name,
+	}
 	decoded.PolicyMatchType = decodePolicyMatchType(pvn)
 	decoded.DebugCapturePoint = decodeDebugCapturePoint(dbg)
 	decoded.Interface = p.decodeNetworkInterface(tn, dbg)
@@ -323,7 +327,7 @@ func (p *Parser) resolveNames(epID uint32, ip netip.Addr) (names []string) {
 	return nil
 }
 
-func (d *packetDecoder) DecodePacket(payload []byte, decoded *pb.Flow, isL3Device, isIPv6, isVXLAN, isGeneve bool) (
+func (d *packetDecoder) DecodePacket(payload []byte, decoded *ir.Flow, isL3Device, isIPv6, isVXLAN, isGeneve bool) (
 	sourceIP, destinationIP netip.Addr,
 	sourcePort, destinationPort uint16,
 	err error,
@@ -409,16 +413,16 @@ func (d *packetDecoder) DecodePacket(payload []byte, decoded *pb.Flow, isL3Devic
 	// Expect VXLAN/Geneve overlay as first overlay layer, if not we bail out.
 	switch d.overlay.Layers[0] {
 	case layers.LayerTypeVXLAN:
-		decoded.Tunnel = &pb.Tunnel{Protocol: pb.Tunnel_VXLAN, IP: decoded.IP, L4: decoded.L4, Vni: d.overlay.VXLAN.VNI}
+		decoded.Tunnel = ir.Tunnel{Protocol: pb.Tunnel_VXLAN, IP: decoded.IP, L4: decoded.L4, Vni: d.overlay.VXLAN.VNI}
 	case layers.LayerTypeGeneve:
-		decoded.Tunnel = &pb.Tunnel{Protocol: pb.Tunnel_GENEVE, IP: decoded.IP, L4: decoded.L4, Vni: d.overlay.Geneve.VNI}
+		decoded.Tunnel = ir.Tunnel{Protocol: pb.Tunnel_GENEVE, IP: decoded.IP, L4: decoded.L4, Vni: d.overlay.Geneve.VNI}
 	default:
 		return
 	}
 
 	// Reset return values. This ensures the resulting flow does not misrepresent
 	// what is happening (e.g. same IP addresses for overlay and underlay).
-	decoded.Ethernet, decoded.IP, decoded.L4 = nil, nil, nil
+	decoded.Ethernet, decoded.IP, decoded.L4 = ir.Ethernet{}, ir.IP{}, ir.Layer4{}
 	sourceIP, destinationIP = netip.Addr{}, netip.Addr{}
 	sourcePort, destinationPort = 0, 0
 	decoded.Summary = ""
@@ -511,15 +515,15 @@ func decodeExtDropReasonDesc(dn *monitor.DropNotify) string {
 	return monitorAPI.DropReasonExt(dn.SubType, dn.ExtError)
 }
 
-func decodeFileInfo(dn *monitor.DropNotify) *pb.FileInfo {
+func decodeFileInfo(dn *monitor.DropNotify) ir.FileInfo {
 	switch {
 	case dn != nil:
-		return &pb.FileInfo{
+		return ir.FileInfo{
 			Name: monitorAPI.BPFFileName(dn.File),
 			Line: uint32(dn.Line),
 		}
 	}
-	return nil
+	return ir.FileInfo{}
 }
 
 func decodePolicyMatchType(pvn *monitor.PolicyVerdictNotify) uint32 {
@@ -530,67 +534,62 @@ func decodePolicyMatchType(pvn *monitor.PolicyVerdictNotify) uint32 {
 	return 0
 }
 
-func decodeEthernet(ethernet *layers.Ethernet) *pb.Ethernet {
-	return &pb.Ethernet{
-		Source:      ethernet.SrcMAC.String(),
-		Destination: ethernet.DstMAC.String(),
+func decodeEthernet(ethernet *layers.Ethernet) ir.Ethernet {
+	return ir.Ethernet{
+		Source:      ethernet.SrcMAC,
+		Destination: ethernet.DstMAC,
 	}
 }
 
-func decodeIPv4(ipv4 *layers.IPv4) (ip *pb.IP, src, dst netip.Addr) {
+func decodeIPv4(ipv4 *layers.IPv4) (ip ir.IP, src, dst netip.Addr) {
 	// Ignore invalid IPs - getters will handle invalid values.
 	// IPs can be empty for Ethernet-only packets.
 	src, _ = netipx.FromStdIP(ipv4.SrcIP)
 	dst, _ = netipx.FromStdIP(ipv4.DstIP)
-	return &pb.IP{
+	return ir.IP{
 		Source:      ipv4.SrcIP.String(),
 		Destination: ipv4.DstIP.String(),
-		IpVersion:   pb.IPVersion_IPv4,
+		IPVersion:   pb.IPVersion_IPv4,
 	}, src, dst
 }
 
-func decodeIPv6(ipv6 *layers.IPv6) (ip *pb.IP, src, dst netip.Addr) {
+func decodeIPv6(ipv6 *layers.IPv6) (ip ir.IP, src, dst netip.Addr) {
 	// Ignore invalid IPs - getters will handle invalid values.
 	// IPs can be empty for Ethernet-only packets.
 	src, _ = netipx.FromStdIP(ipv6.SrcIP)
 	dst, _ = netipx.FromStdIP(ipv6.DstIP)
-	return &pb.IP{
+	return ir.IP{
 		Source:      ipv6.SrcIP.String(),
 		Destination: ipv6.DstIP.String(),
-		IpVersion:   pb.IPVersion_IPv6,
+		IPVersion:   pb.IPVersion_IPv6,
 	}, src, dst
 }
 
-func decodeTCP(tcp *layers.TCP) (l4 *pb.Layer4, src, dst uint16) {
-	return &pb.Layer4{
-		Protocol: &pb.Layer4_TCP{
-			TCP: &pb.TCP{
-				SourcePort:      uint32(tcp.SrcPort),
-				DestinationPort: uint32(tcp.DstPort),
-				Flags: &pb.TCPFlags{
-					FIN: tcp.FIN, SYN: tcp.SYN, RST: tcp.RST,
-					PSH: tcp.PSH, ACK: tcp.ACK, URG: tcp.URG,
-					ECE: tcp.ECE, CWR: tcp.CWR, NS: tcp.NS,
-				},
+func decodeTCP(tcp *layers.TCP) (l4 ir.Layer4, src, dst uint16) {
+	return ir.Layer4{
+		TCP: ir.TCP{
+			SourcePort:      uint32(tcp.SrcPort),
+			DestinationPort: uint32(tcp.DstPort),
+			Flags: ir.TCPFlags{
+				FIN: tcp.FIN, SYN: tcp.SYN, RST: tcp.RST,
+				PSH: tcp.PSH, ACK: tcp.ACK, URG: tcp.URG,
+				ECE: tcp.ECE, CWR: tcp.CWR, NS: tcp.NS,
 			},
 		},
 	}, uint16(tcp.SrcPort), uint16(tcp.DstPort)
 }
 
-func decodeSCTP(sctp *layers.SCTP) (l4 *pb.Layer4, src, dst uint16) {
-	return &pb.Layer4{
-		Protocol: &pb.Layer4_SCTP{
-			SCTP: &pb.SCTP{
-				SourcePort:      uint32(sctp.SrcPort),
-				DestinationPort: uint32(sctp.DstPort),
-				ChunkType:       decodeSCTPChunkType(sctp.Payload),
-			},
+func decodeSCTP(sctp *layers.SCTP) (l4 ir.Layer4, src, dst uint16) {
+	return ir.Layer4{
+		SCTP: ir.SCTP{
+			SourcePort:      uint32(sctp.SrcPort),
+			DestinationPort: uint32(sctp.DstPort),
+			ChunkType:       decodeSCTPChunkType(sctp.Payload),
 		},
 	}, uint16(sctp.SrcPort), uint16(sctp.DstPort)
 }
 
 func decodeSCTPChunkType(payload []byte) pb.SCTPChunkType {
-
 	var chunktype pb.SCTPChunkType
 
 	if len(payload) != 0 {
@@ -614,78 +613,77 @@ func decodeSCTPChunkType(payload []byte) pb.SCTPChunkType {
 	return chunktype
 }
 
-func decodeUDP(udp *layers.UDP) (l4 *pb.Layer4, src, dst uint16) {
-	return &pb.Layer4{
-		Protocol: &pb.Layer4_UDP{
-			UDP: &pb.UDP{
-				SourcePort:      uint32(udp.SrcPort),
-				DestinationPort: uint32(udp.DstPort),
-			},
+func decodeUDP(udp *layers.UDP) (l4 ir.Layer4, src, dst uint16) {
+	return ir.Layer4{
+		UDP: ir.UDP{
+			SourcePort:      uint32(udp.SrcPort),
+			DestinationPort: uint32(udp.DstPort),
 		},
 	}, uint16(udp.SrcPort), uint16(udp.DstPort)
 }
 
-func decodeICMPv4(icmp *layers.ICMPv4) *pb.Layer4 {
-	return &pb.Layer4{
-		Protocol: &pb.Layer4_ICMPv4{ICMPv4: &pb.ICMPv4{
+func decodeICMPv4(icmp *layers.ICMPv4) ir.Layer4 {
+	return ir.Layer4{
+		ICMPv4: ir.ICMP{
 			Type: uint32(icmp.TypeCode.Type()),
 			Code: uint32(icmp.TypeCode.Code()),
-		}},
+		},
 	}
 }
 
-func decodeICMPv6(icmp *layers.ICMPv6) *pb.Layer4 {
-	return &pb.Layer4{
-		Protocol: &pb.Layer4_ICMPv6{ICMPv6: &pb.ICMPv6{
+func decodeICMPv6(icmp *layers.ICMPv6) ir.Layer4 {
+	return ir.Layer4{
+		ICMPv6: ir.ICMP{
 			Type: uint32(icmp.TypeCode.Type()),
 			Code: uint32(icmp.TypeCode.Code()),
-		}},
+		},
 	}
 }
 
-func decodeVRRP(vrrp *layers.VRRPv2) *pb.Layer4 {
-	return &pb.Layer4{
-		Protocol: &pb.Layer4_VRRP{VRRP: &pb.VRRP{
+func decodeVRRP(vrrp *layers.VRRPv2) ir.Layer4 {
+	return ir.Layer4{
+		VRRP: ir.VRRP{
 			Type:     uint32(vrrp.Type),
-			Vrid:     uint32(vrrp.VirtualRtrID),
+			VRID:     uint32(vrrp.VirtualRtrID),
 			Priority: uint32(vrrp.Priority),
-		}},
+		},
 	}
 }
 
-func decodeIGMP(igmp *layers.IGMPv1or2) *pb.Layer4 {
-	return &pb.Layer4{
-		Protocol: &pb.Layer4_IGMP{IGMP: &pb.IGMP{
+func decodeIGMP(igmp *layers.IGMPv1or2) ir.Layer4 {
+	return ir.Layer4{
+		IGMP: ir.IGMP{
 			Type:         uint32(igmp.Type),
 			GroupAddress: igmp.GroupAddress.String(),
-		}},
+		},
 	}
 }
 
-func decodeIsReply(tn *monitor.TraceNotify, pvn *monitor.PolicyVerdictNotify) *wrapperspb.BoolValue {
+func decodeIsReply(tn *monitor.TraceNotify, pvn *monitor.PolicyVerdictNotify) ir.Reply {
 	switch {
 	case tn != nil && tn.TraceReasonIsKnown():
 		if tn.TraceReasonIsEncap() || tn.TraceReasonIsDecap() {
-			return nil
+			return ir.ReplyUnknown
 		}
 		// Reason was specified by the datapath, just reuse it.
-		return &wrapperspb.BoolValue{
-			Value: tn.TraceReasonIsReply(),
+		if tn.TraceReasonIsReply() {
+			return ir.ReplyYes
 		}
+		return ir.ReplyNo
 	case pvn != nil && pvn.Verdict >= 0:
 		// Forwarded PolicyVerdictEvents are emitted for the first packet of
 		// connection, therefore we statically assume that they are not reply
 		// packets
-		return &wrapperspb.BoolValue{Value: false}
+		return ir.ReplyNo
 	default:
 		// For other events, such as drops, we simply do not know if they were
 		// replies or not.
-		return nil
+		return ir.ReplyUnknown
 	}
 }
 
-func decodeCiliumEventType(eventType, eventSubType uint8) *pb.CiliumEventType {
-	return &pb.CiliumEventType{
+func decodeCiliumEventType(eventType, eventSubType uint8) ir.CiliumEventType {
+	return ir.CiliumEventType{
 		Type:    int32(eventType),
 		SubType: int32(eventSubType),
 	}
@@ -714,7 +712,7 @@ func decodeTraceReason(tn *monitor.TraceNotify) pb.TraceReason {
 	}
 }
 
-func decodeIpTraceId(dn *monitor.DropNotify, tn *monitor.TraceNotify) *pb.IPTraceID {
+func decodeIpTraceId(dn *monitor.DropNotify, tn *monitor.TraceNotify) ir.IPTraceID {
 	var id uint64
 	switch {
 	case dn != nil:
@@ -722,12 +720,14 @@ func decodeIpTraceId(dn *monitor.DropNotify, tn *monitor.TraceNotify) *pb.IPTrac
 	case tn != nil:
 		id = uint64(tn.IPTraceID)
 	}
+
 	if id == 0 {
-		return nil
+		return ir.IPTraceID{}
 	}
-	return &pb.IPTraceID{
-		TraceId:      id,
-		IpOptionType: uint32(option.Config.IPTracingOptionType),
+
+	return ir.IPTraceID{
+		TraceID:      id,
+		IPOptionType: uint32(option.Config.IPTracingOptionType),
 	}
 }
 
@@ -860,7 +860,7 @@ func decodeDebugCapturePoint(dbg *monitor.DebugCapture) pb.DebugCapturePoint {
 	return pb.DebugCapturePoint(dbg.SubType)
 }
 
-func (p *Parser) decodeNetworkInterface(tn *monitor.TraceNotify, dbg *monitor.DebugCapture) *pb.NetworkInterface {
+func (p *Parser) decodeNetworkInterface(tn *monitor.TraceNotify, dbg *monitor.DebugCapture) ir.NetworkInterface {
 	ifIndex := uint32(0)
 	if tn != nil {
 		ifIndex = tn.Ifindex
@@ -877,7 +877,7 @@ func (p *Parser) decodeNetworkInterface(tn *monitor.TraceNotify, dbg *monitor.De
 	}
 
 	if ifIndex == 0 {
-		return nil
+		return ir.NetworkInterface{}
 	}
 
 	var name string
@@ -886,7 +886,8 @@ func (p *Parser) decodeNetworkInterface(tn *monitor.TraceNotify, dbg *monitor.De
 		// omitted in the protobuf message
 		name, _ = p.linkGetter.GetIfNameCached(int(ifIndex))
 	}
-	return &pb.NetworkInterface{
+
+	return ir.NetworkInterface{
 		Index: ifIndex,
 		Name:  name,
 	}

--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -12,10 +12,10 @@ import (
 	"github.com/gopacket/gopacket"
 	"github.com/gopacket/gopacket/layers"
 	"go4.org/netipx"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	pb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/byteorder"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/parser/common"
 	"github.com/cilium/cilium/pkg/hubble/parser/errors"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
@@ -134,19 +134,19 @@ func New(
 
 	args := &options.Options{
 		EnableNetworkPolicyCorrelation: true,
-		DropNotifyDecoder: func(data []byte, decoded *pb.Flow) (*monitor.DropNotify, error) {
+		DropNotifyDecoder: func(data []byte, decoded *ir.Flow) (*monitor.DropNotify, error) {
 			dn := &monitor.DropNotify{}
 			return dn, dn.Decode(data)
 		},
-		DebugCaptureDecoder: func(data []byte, decoded *pb.Flow) (*monitor.DebugCapture, error) {
+		DebugCaptureDecoder: func(data []byte, decoded *ir.Flow) (*monitor.DebugCapture, error) {
 			dbg := &monitor.DebugCapture{}
 			return dbg, dbg.Decode(data)
 		},
-		TraceNotifyDecoder: func(data []byte, decoded *pb.Flow) (*monitor.TraceNotify, error) {
+		TraceNotifyDecoder: func(data []byte, decoded *ir.Flow) (*monitor.TraceNotify, error) {
 			tn := &monitor.TraceNotify{}
 			return tn, tn.Decode(data)
 		},
-		PolicyVerdictNotifyDecoder: func(data []byte, decoded *pb.Flow) (*monitor.PolicyVerdictNotify, error) {
+		PolicyVerdictNotifyDecoder: func(data []byte, decoded *ir.Flow) (*monitor.PolicyVerdictNotify, error) {
 			pvn := &monitor.PolicyVerdictNotify{}
 			return pvn, pvn.Decode(data)
 		},
@@ -176,11 +176,10 @@ func New(
 }
 
 // Decode decodes the data from 'data' into 'decoded'
-func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
+func (p *Parser) Decode(data []byte, decoded *ir.Flow) error {
 	if len(data) == 0 {
 		return errors.ErrEmptyData
 	}
-
 	eventType := data[0]
 
 	var err error
@@ -248,8 +247,8 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 		return err
 	}
 
-	ip := decoded.GetIP()
-	if tn != nil && ip != nil {
+	ip := decoded.IP
+	if tn != nil && !ip.IsEmpty() {
 		if !tn.OriginalIP().IsUnspecified() {
 			srcIP = tn.OriginalIP()
 			// On SNAT the trace notification has OrigIP set to the pre
@@ -257,8 +256,8 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 			// post translation IP. The check is here because sometimes we get
 			// trace notifications with OrigIP set to the header's IP
 			// (pre-translation events?)
-			if ip.GetSource() != srcIP.String() {
-				ip.SourceXlated = ip.GetSource()
+			if sip := ip.Source; sip != srcIP.String() {
+				ip.SourceXlated = sip
 				ip.Source = srcIP.String()
 			}
 		}
@@ -287,23 +286,22 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 	decoded.DropReason = decodeDropReason(dn, pvn)
 	decoded.DropReasonDesc = pb.DropReason(decoded.DropReason)
 	decoded.File = decodeFileInfo(dn)
-	decoded.Source = srcEndpoint
-	decoded.Destination = dstEndpoint
+	decoded.IP = ip
+	decoded.Source = ir.ProtoToEp(srcEndpoint)
+	decoded.Destination = ir.ProtoToEp(dstEndpoint)
 	decoded.Type = pb.FlowType_L3_L4
 	decoded.SourceNames = p.resolveNames(dstEndpoint.ID, srcIP)
 	decoded.DestinationNames = p.resolveNames(srcEndpoint.ID, dstIP)
-	decoded.L7 = nil
-	decoded.IsReply = decodeIsReply(tn, pvn)
-	decoded.Reply = decoded.GetIsReply().GetValue() // false if GetIsReply() is nil
+	decoded.Reply = decodeIsReply(tn, pvn)
 	decoded.TrafficDirection = decodeTrafficDirection(srcEndpoint.ID, dn, tn, pvn)
-	decoded.EventType = decodeCiliumEventType(eventType, eventSubType)
+	decoded.EventType = ir.ProtoToEventType(decodeCiliumEventType(eventType, eventSubType))
 	decoded.TraceReason = decodeTraceReason(tn)
-	decoded.IpTraceId = decodeIpTraceId(dn, tn)
-	decoded.SourceService = sourceService
-	decoded.DestinationService = destinationService
+	decoded.IPTraceID = ir.ProtoToIPTraceID(decodeIpTraceId(dn, tn))
+	decoded.SourceService = ir.ProtoToService(sourceService)
+	decoded.DestinationService = ir.ProtoToService(destinationService)
 	decoded.PolicyMatchType = decodePolicyMatchType(pvn)
 	decoded.DebugCapturePoint = decodeDebugCapturePoint(dbg)
-	decoded.Interface = p.decodeNetworkInterface(tn, dbg)
+	decoded.Interface = ir.ProtoToNetworkInterface(p.decodeNetworkInterface(tn, dbg))
 	decoded.ProxyPort = decodeProxyPort(dbg, tn)
 
 	if p.correlateL3L4Policy && p.endpointGetter != nil {
@@ -321,7 +319,7 @@ func (p *Parser) resolveNames(epID uint32, ip netip.Addr) (names []string) {
 	return nil
 }
 
-func (d *packetDecoder) DecodePacket(payload []byte, decoded *pb.Flow, isL3Device, isIPv6, isVXLAN, isGeneve bool) (
+func (d *packetDecoder) DecodePacket(payload []byte, decoded *ir.Flow, isL3Device, isIPv6, isVXLAN, isGeneve bool) (
 	sourceIP, destinationIP netip.Addr,
 	sourcePort, destinationPort uint16,
 	err error,
@@ -407,16 +405,16 @@ func (d *packetDecoder) DecodePacket(payload []byte, decoded *pb.Flow, isL3Devic
 	// Expect VXLAN/Geneve overlay as first overlay layer, if not we bail out.
 	switch d.overlay.Layers[0] {
 	case layers.LayerTypeVXLAN:
-		decoded.Tunnel = &pb.Tunnel{Protocol: pb.Tunnel_VXLAN, IP: decoded.IP, L4: decoded.L4, Vni: d.overlay.VXLAN.VNI}
+		decoded.Tunnel = ir.Tunnel{Protocol: pb.Tunnel_VXLAN, IP: decoded.IP, L4: decoded.L4, Vni: d.overlay.VXLAN.VNI}
 	case layers.LayerTypeGeneve:
-		decoded.Tunnel = &pb.Tunnel{Protocol: pb.Tunnel_GENEVE, IP: decoded.IP, L4: decoded.L4, Vni: d.overlay.Geneve.VNI}
+		decoded.Tunnel = ir.Tunnel{Protocol: pb.Tunnel_GENEVE, IP: decoded.IP, L4: decoded.L4, Vni: d.overlay.Geneve.VNI}
 	default:
 		return
 	}
 
 	// Reset return values. This ensures the resulting flow does not misrepresent
 	// what is happening (e.g. same IP addresses for overlay and underlay).
-	decoded.Ethernet, decoded.IP, decoded.L4 = nil, nil, nil
+	decoded.Ethernet, decoded.IP, decoded.L4 = ir.Ethernet{}, ir.IP{}, ir.Layer4{}
 	sourceIP, destinationIP = netip.Addr{}, netip.Addr{}
 	sourcePort, destinationPort = 0, 0
 	decoded.Summary = ""
@@ -492,15 +490,15 @@ func decodeDropReason(dn *monitor.DropNotify, pvn *monitor.PolicyVerdictNotify) 
 	return 0
 }
 
-func decodeFileInfo(dn *monitor.DropNotify) *pb.FileInfo {
+func decodeFileInfo(dn *monitor.DropNotify) ir.FileInfo {
 	switch {
 	case dn != nil:
-		return &pb.FileInfo{
+		return ir.FileInfo{
 			Name: monitorAPI.BPFFileName(dn.File),
 			Line: uint32(dn.Line),
 		}
 	}
-	return nil
+	return ir.FileInfo{}
 }
 
 func decodePolicyMatchType(pvn *monitor.PolicyVerdictNotify) uint32 {
@@ -511,67 +509,62 @@ func decodePolicyMatchType(pvn *monitor.PolicyVerdictNotify) uint32 {
 	return 0
 }
 
-func decodeEthernet(ethernet *layers.Ethernet) *pb.Ethernet {
-	return &pb.Ethernet{
-		Source:      ethernet.SrcMAC.String(),
-		Destination: ethernet.DstMAC.String(),
+func decodeEthernet(ethernet *layers.Ethernet) ir.Ethernet {
+	return ir.Ethernet{
+		Source:      ethernet.SrcMAC,
+		Destination: ethernet.DstMAC,
 	}
 }
 
-func decodeIPv4(ipv4 *layers.IPv4) (ip *pb.IP, src, dst netip.Addr) {
+func decodeIPv4(ipv4 *layers.IPv4) (ip ir.IP, src, dst netip.Addr) {
 	// Ignore invalid IPs - getters will handle invalid values.
 	// IPs can be empty for Ethernet-only packets.
 	src, _ = netipx.FromStdIP(ipv4.SrcIP)
 	dst, _ = netipx.FromStdIP(ipv4.DstIP)
-	return &pb.IP{
+	return ir.IP{
 		Source:      ipv4.SrcIP.String(),
 		Destination: ipv4.DstIP.String(),
-		IpVersion:   pb.IPVersion_IPv4,
+		IPVersion:   pb.IPVersion_IPv4,
 	}, src, dst
 }
 
-func decodeIPv6(ipv6 *layers.IPv6) (ip *pb.IP, src, dst netip.Addr) {
+func decodeIPv6(ipv6 *layers.IPv6) (ip ir.IP, src, dst netip.Addr) {
 	// Ignore invalid IPs - getters will handle invalid values.
 	// IPs can be empty for Ethernet-only packets.
 	src, _ = netipx.FromStdIP(ipv6.SrcIP)
 	dst, _ = netipx.FromStdIP(ipv6.DstIP)
-	return &pb.IP{
+	return ir.IP{
 		Source:      ipv6.SrcIP.String(),
 		Destination: ipv6.DstIP.String(),
-		IpVersion:   pb.IPVersion_IPv6,
+		IPVersion:   pb.IPVersion_IPv6,
 	}, src, dst
 }
 
-func decodeTCP(tcp *layers.TCP) (l4 *pb.Layer4, src, dst uint16) {
-	return &pb.Layer4{
-		Protocol: &pb.Layer4_TCP{
-			TCP: &pb.TCP{
-				SourcePort:      uint32(tcp.SrcPort),
-				DestinationPort: uint32(tcp.DstPort),
-				Flags: &pb.TCPFlags{
-					FIN: tcp.FIN, SYN: tcp.SYN, RST: tcp.RST,
-					PSH: tcp.PSH, ACK: tcp.ACK, URG: tcp.URG,
-					ECE: tcp.ECE, CWR: tcp.CWR, NS: tcp.NS,
-				},
+func decodeTCP(tcp *layers.TCP) (l4 ir.Layer4, src, dst uint16) {
+	return ir.Layer4{
+		TCP: ir.TCP{
+			SourcePort:      uint32(tcp.SrcPort),
+			DestinationPort: uint32(tcp.DstPort),
+			Flags: ir.TCPFlags{
+				FIN: tcp.FIN, SYN: tcp.SYN, RST: tcp.RST,
+				PSH: tcp.PSH, ACK: tcp.ACK, URG: tcp.URG,
+				ECE: tcp.ECE, CWR: tcp.CWR, NS: tcp.NS,
 			},
 		},
 	}, uint16(tcp.SrcPort), uint16(tcp.DstPort)
 }
 
-func decodeSCTP(sctp *layers.SCTP) (l4 *pb.Layer4, src, dst uint16) {
-	return &pb.Layer4{
-		Protocol: &pb.Layer4_SCTP{
-			SCTP: &pb.SCTP{
-				SourcePort:      uint32(sctp.SrcPort),
-				DestinationPort: uint32(sctp.DstPort),
-				ChunkType:       decodeSCTPChunkType(sctp.Payload),
-			},
+func decodeSCTP(sctp *layers.SCTP) (l4 ir.Layer4, src, dst uint16) {
+	return ir.Layer4{
+		SCTP: ir.SCTP{
+			SourcePort:      uint32(sctp.SrcPort),
+			DestinationPort: uint32(sctp.DstPort),
+			ChunkType:       decodeSCTPChunkType(sctp.Payload),
 		},
 	}, uint16(sctp.SrcPort), uint16(sctp.DstPort)
 }
 
 func decodeSCTPChunkType(payload []byte) pb.SCTPChunkType {
-
 	var chunktype pb.SCTPChunkType
 
 	if len(payload) != 0 {
@@ -595,73 +588,72 @@ func decodeSCTPChunkType(payload []byte) pb.SCTPChunkType {
 	return chunktype
 }
 
-func decodeUDP(udp *layers.UDP) (l4 *pb.Layer4, src, dst uint16) {
-	return &pb.Layer4{
-		Protocol: &pb.Layer4_UDP{
-			UDP: &pb.UDP{
-				SourcePort:      uint32(udp.SrcPort),
-				DestinationPort: uint32(udp.DstPort),
-			},
+func decodeUDP(udp *layers.UDP) (l4 ir.Layer4, src, dst uint16) {
+	return ir.Layer4{
+		UDP: ir.UDP{
+			SourcePort:      uint32(udp.SrcPort),
+			DestinationPort: uint32(udp.DstPort),
 		},
 	}, uint16(udp.SrcPort), uint16(udp.DstPort)
 }
 
-func decodeICMPv4(icmp *layers.ICMPv4) *pb.Layer4 {
-	return &pb.Layer4{
-		Protocol: &pb.Layer4_ICMPv4{ICMPv4: &pb.ICMPv4{
+func decodeICMPv4(icmp *layers.ICMPv4) ir.Layer4 {
+	return ir.Layer4{
+		ICMPv4: ir.ICMP{
 			Type: uint32(icmp.TypeCode.Type()),
 			Code: uint32(icmp.TypeCode.Code()),
-		}},
+		},
 	}
 }
 
-func decodeICMPv6(icmp *layers.ICMPv6) *pb.Layer4 {
-	return &pb.Layer4{
-		Protocol: &pb.Layer4_ICMPv6{ICMPv6: &pb.ICMPv6{
+func decodeICMPv6(icmp *layers.ICMPv6) ir.Layer4 {
+	return ir.Layer4{
+		ICMPv6: ir.ICMP{
 			Type: uint32(icmp.TypeCode.Type()),
 			Code: uint32(icmp.TypeCode.Code()),
-		}},
+		},
 	}
 }
 
-func decodeVRRP(vrrp *layers.VRRPv2) *pb.Layer4 {
-	return &pb.Layer4{
-		Protocol: &pb.Layer4_VRRP{VRRP: &pb.VRRP{
+func decodeVRRP(vrrp *layers.VRRPv2) ir.Layer4 {
+	return ir.Layer4{
+		VRRP: ir.VRRP{
 			Type:     uint32(vrrp.Type),
-			Vrid:     uint32(vrrp.VirtualRtrID),
+			VRID:     uint32(vrrp.VirtualRtrID),
 			Priority: uint32(vrrp.Priority),
-		}},
+		},
 	}
 }
 
-func decodeIGMP(igmp *layers.IGMPv1or2) *pb.Layer4 {
-	return &pb.Layer4{
-		Protocol: &pb.Layer4_IGMP{IGMP: &pb.IGMP{
+func decodeIGMP(igmp *layers.IGMPv1or2) ir.Layer4 {
+	return ir.Layer4{
+		IGMP: ir.IGMP{
 			Type:         uint32(igmp.Type),
 			GroupAddress: igmp.GroupAddress.String(),
-		}},
+		},
 	}
 }
 
-func decodeIsReply(tn *monitor.TraceNotify, pvn *monitor.PolicyVerdictNotify) *wrapperspb.BoolValue {
+func decodeIsReply(tn *monitor.TraceNotify, pvn *monitor.PolicyVerdictNotify) ir.Reply {
 	switch {
 	case tn != nil && tn.TraceReasonIsKnown():
 		if tn.TraceReasonIsEncap() || tn.TraceReasonIsDecap() {
-			return nil
+			return ir.ReplyUnknown
 		}
 		// Reason was specified by the datapath, just reuse it.
-		return &wrapperspb.BoolValue{
-			Value: tn.TraceReasonIsReply(),
+		if tn.TraceReasonIsReply() {
+			return ir.ReplyYes
 		}
+		return ir.ReplyNo
 	case pvn != nil && pvn.Verdict >= 0:
 		// Forwarded PolicyVerdictEvents are emitted for the first packet of
 		// connection, therefore we statically assume that they are not reply
 		// packets
-		return &wrapperspb.BoolValue{Value: false}
+		return ir.ReplyNo
 	default:
 		// For other events, such as drops, we simply do not know if they were
 		// replies or not.
-		return nil
+		return ir.ReplyUnknown
 	}
 }
 

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -19,13 +19,12 @@ import (
 	"github.com/gopacket/gopacket/layers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/parser/common"
 	"github.com/cilium/cilium/pkg/hubble/parser/errors"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
@@ -101,8 +100,8 @@ func TestL34DecodeEmpty(t *testing.T) {
 	require.NoError(t, err)
 
 	var d []byte
-	f := &flowpb.Flow{}
-	err = parser.Decode(d, f)
+	var f ir.Flow
+	err = parser.Decode(d, &f)
 	assert.Equal(t, err, errors.ErrEmptyData)
 }
 
@@ -140,43 +139,43 @@ func TestL34DecodeVXLANOverlay(t *testing.T) {
 	require.NoError(t, err)
 
 	// decode the payload.
-	f := &flowpb.Flow{}
-	err = parser.Decode(payload, f)
+	var f ir.Flow
+	err = parser.Decode(payload, &f)
 	require.NoError(t, err)
 
 	// Check tunnel containing the underlay info.
-	assert.Equal(t, flowpb.Tunnel_VXLAN, f.GetTunnel().GetProtocol())
-	assert.Equal(t, uint32(2), f.GetTunnel().GetVni())
-	assert.Equal(t, "192.168.1.1", f.GetTunnel().GetIP().GetSource())
-	assert.Equal(t, "192.168.1.2", f.GetTunnel().GetIP().GetDestination())
-	assert.Equal(t, uint32(defaults.TunnelPortVXLAN), f.GetTunnel().GetL4().GetUDP().GetSourcePort())
-	assert.Equal(t, uint32(9999), f.GetTunnel().GetL4().GetUDP().GetDestinationPort())
+	assert.Equal(t, flowpb.Tunnel_VXLAN, f.Tunnel.Protocol)
+	assert.Equal(t, uint32(2), f.Tunnel.Vni)
+	assert.Equal(t, "192.168.1.1", f.Tunnel.IP.Source)
+	assert.Equal(t, "192.168.1.2", f.Tunnel.IP.Destination)
+	assert.Equal(t, uint32(defaults.TunnelPortVXLAN), f.Tunnel.L4.UDP.SourcePort)
+	assert.Equal(t, uint32(9999), f.Tunnel.L4.UDP.DestinationPort)
 	// Check l3 and l4 expecting be the overlay info.
-	assert.Equal(t, "10.1.0.1", f.GetIP().GetSource())
-	assert.Equal(t, "10.1.0.2", f.GetIP().GetDestination())
-	assert.Equal(t, uint32(54222), f.GetL4().GetTCP().GetSourcePort())
-	assert.Equal(t, uint32(8080), f.GetL4().GetTCP().GetDestinationPort())
-	assert.Equal(t, &flowpb.TCPFlags{SYN: true}, f.GetL4().GetTCP().GetFlags())
+	assert.Equal(t, "10.1.0.1", f.IP.Source)
+	assert.Equal(t, "10.1.0.2", f.IP.Destination)
+	assert.Equal(t, uint32(54222), f.L4.TCP.SourcePort)
+	assert.Equal(t, uint32(8080), f.L4.TCP.DestinationPort)
+	assert.Equal(t, ir.TCPFlags{SYN: true}, f.L4.TCP.Flags)
 
 	notunnel := slices.Clone(payload)
 	// reset the trace notification flags, i.e. clear TraceNotifyFlagIsVXLAN
 	notunnel[27] = 0
 	// decode the new payload.
-	f = &flowpb.Flow{}
-	err = parser.Decode(notunnel, f)
+	f = ir.Flow{}
+	err = parser.Decode(notunnel, &f)
 	require.NoError(t, err)
 
 	// since datapath did not inform us of any tunnel protocol, we should not
 	// have attempted to parse tunnel and overlay regardless of the packet
 	// payload received.
-	assert.Equal(t, flowpb.Tunnel_UNKNOWN, f.GetTunnel().GetProtocol())
-	assert.Empty(t, f.GetTunnel().GetIP())
-	assert.Empty(t, f.GetTunnel().GetL4())
+	assert.Equal(t, flowpb.Tunnel_UNKNOWN, f.Tunnel.Protocol)
+	assert.Empty(t, f.Tunnel.IP)
+	assert.Empty(t, f.Tunnel.L4)
 	// and the src/dst info should be the outer layers.
-	assert.Equal(t, "192.168.1.1", f.GetIP().GetSource())
-	assert.Equal(t, "192.168.1.2", f.GetIP().GetDestination())
-	assert.Equal(t, uint32(defaults.TunnelPortVXLAN), f.GetL4().GetUDP().GetSourcePort())
-	assert.Equal(t, uint32(9999), f.GetL4().GetUDP().GetDestinationPort())
+	assert.Equal(t, "192.168.1.1", f.IP.Source)
+	assert.Equal(t, "192.168.1.2", f.IP.Destination)
+	assert.Equal(t, uint32(defaults.TunnelPortVXLAN), f.L4.UDP.SourcePort)
+	assert.Equal(t, uint32(9999), f.L4.UDP.DestinationPort)
 }
 
 func TestL34DecodeGeneveOverlay(t *testing.T) {
@@ -213,43 +212,42 @@ func TestL34DecodeGeneveOverlay(t *testing.T) {
 	require.NoError(t, err)
 
 	// decode the payload.
-	f := &flowpb.Flow{}
-	err = parser.Decode(payload, f)
+	var f ir.Flow
+	err = parser.Decode(payload, &f)
 	require.NoError(t, err)
 
 	// Check tunnel containing the underlay info.
-	assert.Equal(t, flowpb.Tunnel_GENEVE, f.GetTunnel().GetProtocol())
-	assert.Equal(t, uint32(2), f.GetTunnel().GetVni())
-	assert.Equal(t, "192.168.1.1", f.GetTunnel().GetIP().GetSource())
-	assert.Equal(t, "192.168.1.2", f.GetTunnel().GetIP().GetDestination())
-	assert.Equal(t, uint32(defaults.TunnelPortGeneve), f.GetTunnel().GetL4().GetUDP().GetSourcePort())
-	assert.Equal(t, uint32(9999), f.GetTunnel().GetL4().GetUDP().GetDestinationPort())
+	assert.Equal(t, flowpb.Tunnel_GENEVE, f.Tunnel.Protocol)
+	assert.Equal(t, uint32(2), f.Tunnel.Vni)
+	assert.Equal(t, "192.168.1.1", f.Tunnel.IP.Source)
+	assert.Equal(t, "192.168.1.2", f.Tunnel.IP.Destination)
+	assert.Equal(t, uint32(defaults.TunnelPortGeneve), f.Tunnel.L4.UDP.SourcePort)
+	assert.Equal(t, uint32(9999), f.Tunnel.L4.UDP.DestinationPort)
 	// Check l3 and l4 expecting be the overlay info.
-	assert.Equal(t, "10.1.0.1", f.GetIP().GetSource())
-	assert.Equal(t, "10.1.0.2", f.GetIP().GetDestination())
-	assert.Equal(t, uint32(54222), f.GetL4().GetTCP().GetSourcePort())
-	assert.Equal(t, uint32(8080), f.GetL4().GetTCP().GetDestinationPort())
-	assert.Equal(t, &flowpb.TCPFlags{SYN: true}, f.GetL4().GetTCP().GetFlags())
-
+	assert.Equal(t, "10.1.0.1", f.IP.Source)
+	assert.Equal(t, "10.1.0.2", f.IP.Destination)
+	assert.Equal(t, uint32(54222), f.L4.TCP.SourcePort)
+	assert.Equal(t, uint32(8080), f.L4.TCP.DestinationPort)
+	assert.Equal(t, ir.TCPFlags{SYN: true}, f.L4.TCP.Flags)
 	notunnel := slices.Clone(payload)
 	// reset the trace notification flags, i.e. clear TraceNotifyFlagIsGeneve
 	notunnel[27] = 0
 	// decode the new payload.
-	f = &flowpb.Flow{}
-	err = parser.Decode(notunnel, f)
+	f = ir.Flow{}
+	err = parser.Decode(notunnel, &f)
 	require.NoError(t, err)
 
 	// since datapath did not inform us of any tunnel protocol, we should not
 	// have attempted to parse tunnel and overlay regardless of the packet
 	// payload received.
-	assert.Equal(t, flowpb.Tunnel_UNKNOWN, f.GetTunnel().GetProtocol())
-	assert.Empty(t, f.GetTunnel().GetIP())
-	assert.Empty(t, f.GetTunnel().GetL4())
+	assert.Equal(t, flowpb.Tunnel_UNKNOWN, f.Tunnel.Protocol)
+	assert.Empty(t, f.Tunnel.IP)
+	assert.Empty(t, f.Tunnel.L4)
 	// and the src/dst info should be the outer layers.
-	assert.Equal(t, "192.168.1.1", f.GetIP().GetSource())
-	assert.Equal(t, "192.168.1.2", f.GetIP().GetDestination())
-	assert.Equal(t, uint32(defaults.TunnelPortGeneve), f.GetL4().GetUDP().GetSourcePort())
-	assert.Equal(t, uint32(9999), f.GetL4().GetUDP().GetDestinationPort())
+	assert.Equal(t, "192.168.1.1", f.IP.Source)
+	assert.Equal(t, "192.168.1.2", f.IP.Destination)
+	assert.Equal(t, uint32(defaults.TunnelPortGeneve), f.L4.UDP.SourcePort)
+	assert.Equal(t, uint32(9999), f.L4.UDP.DestinationPort)
 }
 
 func BenchmarkL34DecodeOverlay(b *testing.B) {
@@ -270,11 +268,11 @@ func BenchmarkL34DecodeOverlay(b *testing.B) {
 	parser, err := New(hivetest.Logger(b), endpointGetter, identityCache, dnsGetter, ipGetter, serviceGetter, &testutils.NoopLinkGetter)
 	require.NoError(b, err)
 
-	f := &flowpb.Flow{}
+	var f ir.Flow
+	b.ResetTimer()
 	b.ReportAllocs()
-
 	for b.Loop() {
-		_ = parser.Decode(d, f)
+		_ = parser.Decode(d, &f)
 	}
 }
 
@@ -373,41 +371,41 @@ func TestL34Decode(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), endpointGetter, identityCache, dnsGetter, ipGetter, serviceGetter, &testutils.NoopLinkGetter)
 	require.NoError(t, err)
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(d, f)
+	var f ir.Flow
+	err = parser.Decode(d, &f)
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"host-192.168.60.11"}, f.GetSourceNames())
-	assert.Equal(t, "192.168.60.11", f.GetIP().GetSource())
-	assert.Empty(t, f.GetIP().GetSourceXlated())
-	assert.Equal(t, flowpb.TraceReason_ESTABLISHED, f.GetTraceReason())
-	assert.True(t, f.GetIP().GetEncrypted())
-	assert.Equal(t, uint32(6443), f.L4.GetTCP().GetSourcePort())
-	assert.Equal(t, "pod-192.168.60.11", f.GetSource().GetPodName())
-	assert.Equal(t, "remote", f.GetSource().GetNamespace())
-	assert.Equal(t, "service-1234", f.GetSourceService().GetName())
-	assert.Equal(t, "remote", f.GetSourceService().GetNamespace())
-	assert.Equal(t, uint32(1), f.GetSource().GetIdentity())
+	assert.Equal(t, []string{"host-192.168.60.11"}, f.SourceNames)
+	assert.Equal(t, "192.168.60.11", f.IP.Source)
+	assert.Empty(t, f.IP.SourceXlated)
+	assert.Equal(t, flowpb.TraceReason_ESTABLISHED, f.TraceReason)
+	assert.True(t, f.IP.Encrypted)
+	assert.Equal(t, uint32(6443), f.L4.TCP.SourcePort)
+	assert.Equal(t, "pod-192.168.60.11", f.Source.PodName)
+	assert.Equal(t, "remote", f.Source.Namespace)
+	assert.Equal(t, "service-1234", f.SourceService.Name)
+	assert.Equal(t, "remote", f.SourceService.Namespace)
+	assert.Equal(t, uint32(1), f.Source.Identity)
 
-	assert.Equal(t, []string(nil), f.GetDestinationNames())
-	assert.Equal(t, "10.16.236.178", f.GetIP().GetDestination())
-	assert.Equal(t, uint32(54222), f.L4.GetTCP().GetDestinationPort())
-	assert.Equal(t, "pod-10.16.236.178", f.GetDestination().GetPodName())
-	assert.Equal(t, "default", f.GetDestination().GetNamespace())
-	assert.Equal(t, "service-4321", f.GetDestinationService().GetName())
-	assert.Equal(t, "default", f.GetDestinationService().GetNamespace())
-	assert.Equal(t, uint32(5678), f.GetDestination().GetIdentity())
+	assert.Equal(t, []string(nil), f.DestinationNames)
+	assert.Equal(t, "10.16.236.178", f.IP.Destination)
+	assert.Equal(t, uint32(54222), f.L4.TCP.DestinationPort)
+	assert.Equal(t, "pod-10.16.236.178", f.Destination.PodName)
+	assert.Equal(t, "default", f.Destination.Namespace)
+	assert.Equal(t, "service-4321", f.DestinationService.Name)
+	assert.Equal(t, "default", f.DestinationService.Namespace)
+	assert.Equal(t, uint32(5678), f.Destination.Identity)
 
-	assert.Equal(t, int32(monitorAPI.MessageTypeTrace), f.GetEventType().GetType())
-	assert.Equal(t, int32(monitorAPI.TraceFromHost), f.GetEventType().GetSubType())
-	assert.Equal(t, flowpb.Verdict_FORWARDED, f.GetVerdict())
-	assert.Equal(t, &flowpb.TCPFlags{ACK: true}, f.L4.GetTCP().GetFlags())
+	assert.Equal(t, int32(monitorAPI.MessageTypeTrace), f.EventType.Type)
+	assert.Equal(t, int32(monitorAPI.TraceFromHost), f.EventType.SubType)
+	assert.Equal(t, flowpb.Verdict_FORWARDED, f.Verdict)
+	assert.Equal(t, ir.TCPFlags{ACK: true}, f.L4.TCP.Flags)
 
-	assert.Equal(t, flowpb.TraceObservationPoint_FROM_HOST, f.GetTraceObservationPoint())
+	assert.Equal(t, flowpb.TraceObservationPoint_FROM_HOST, f.TraceObservationPoint)
 
 	nilParser, err := New(hivetest.Logger(t), nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
-	err = nilParser.Decode(d, f)
+	err = nilParser.Decode(d, &f)
 	require.NoError(t, err)
 
 	// ICMP packet so no ports until that support is merged into master
@@ -450,30 +448,31 @@ func TestL34Decode(t *testing.T) {
 	parser, err = New(hivetest.Logger(t), endpointGetter, identityCache, dnsGetter, ipGetter, serviceGetter, &testutils.NoopLinkGetter)
 	require.NoError(t, err)
 
-	err = parser.Decode(d2, f)
+	f = ir.Flow{}
+	err = parser.Decode(d2, &f)
 	require.NoError(t, err)
 
 	// second packet is ICMPv6 and the flags should be totally wiped out
-	assert.Equal(t, []string(nil), f.GetSourceNames())
-	assert.Equal(t, "ff02::1:ff00:b3e5", f.GetIP().GetSource())
-	assert.Empty(t, f.GetIP().GetSourceXlated())
-	assert.Equal(t, &flowpb.ICMPv6{Type: 135}, f.L4.GetICMPv6())
-	assert.Empty(t, f.GetSource().GetPodName())
-	assert.Empty(t, f.GetSource().GetNamespace())
+	assert.Equal(t, []string(nil), f.SourceNames)
+	assert.Equal(t, "ff02::1:ff00:b3e5", f.IP.Source)
+	assert.Empty(t, f.IP.SourceXlated)
+	assert.Equal(t, ir.ICMP{Type: 135}, f.L4.ICMPv6)
+	assert.Empty(t, f.Source.PodName)
+	assert.Empty(t, f.Source.Namespace)
 
-	assert.Equal(t, []string{"host-f00d::a10:0:0:9195"}, f.GetDestinationNames())
-	assert.Equal(t, "f00d::a10:0:0:9195", f.GetIP().GetDestination())
-	assert.Empty(t, f.GetDestination().GetPodName())
-	assert.Empty(t, f.GetDestination().GetNamespace())
+	assert.Equal(t, []string{"host-f00d::a10:0:0:9195"}, f.DestinationNames)
+	assert.Equal(t, "f00d::a10:0:0:9195", f.IP.Destination)
+	assert.Empty(t, f.Destination.PodName)
+	assert.Empty(t, f.Destination.Namespace)
 
-	assert.Equal(t, int32(monitorAPI.MessageTypeTrace), f.GetEventType().GetType())
-	assert.Equal(t, int32(monitorAPI.TraceFromLxc), f.GetEventType().GetSubType())
-	assert.Equal(t, flowpb.Verdict_FORWARDED, f.GetVerdict())
-	assert.Equal(t, (*flowpb.TCPFlags)(nil), f.L4.GetTCP().GetFlags())
+	assert.Equal(t, int32(monitorAPI.MessageTypeTrace), f.EventType.Type)
+	assert.Equal(t, int32(monitorAPI.TraceFromLxc), f.EventType.SubType)
+	assert.Equal(t, flowpb.Verdict_FORWARDED, f.Verdict)
+	assert.Equal(t, ir.TCPFlags{}, f.L4.TCP.Flags)
 
-	assert.Equal(t, flowpb.TraceObservationPoint_FROM_ENDPOINT, f.GetTraceObservationPoint())
+	assert.Equal(t, flowpb.TraceObservationPoint_FROM_ENDPOINT, f.TraceObservationPoint)
 
-	err = nilParser.Decode(d, f)
+	err = nilParser.Decode(d, &f)
 	require.NoError(t, err)
 }
 
@@ -493,11 +492,11 @@ func BenchmarkL34Decode(b *testing.B) {
 	parser, err := New(hivetest.Logger(b), endpointGetter, identityCache, dnsGetter, ipGetter, serviceGetter, &testutils.NoopLinkGetter)
 	require.NoError(b, err)
 
-	f := &flowpb.Flow{}
+	var f ir.Flow
 	b.ReportAllocs()
-
+	b.ResetTimer()
 	for b.Loop() {
-		_ = parser.Decode(d, f)
+		_ = parser.Decode(d, &f)
 	}
 }
 
@@ -571,15 +570,15 @@ func TestDecodeTraceNotify(t *testing.T) {
 			parser, err := New(hivetest.Logger(t), &testutils.NoopEndpointGetter, identityGetter, &testutils.NoopDNSGetter, &testutils.NoopIPGetter, &testutils.NoopServiceGetter, &testutils.NoopLinkGetter)
 			require.NoError(t, err)
 
-			f := &flowpb.Flow{}
-			err = parser.Decode(buf.Bytes(), f)
+			var f ir.Flow
+			err = parser.Decode(buf.Bytes(), &f)
 			require.NoError(t, err)
-			assert.Equal(t, []string{"k8s:io.cilium.k8s.policy.cluster=cluster-name", "k8s:src=label"}, f.GetSource().GetLabels())
-			assert.Equal(t, []string{"k8s:dst=label", "k8s:io.cilium.k8s.policy.cluster=cluster-name"}, f.GetDestination().GetLabels())
-			assert.Equal(t, "cluster-name", f.GetSource().GetClusterName())
-			assert.Equal(t, "cluster-name", f.GetDestination().GetClusterName())
-			assert.Equal(t, uint32(23939), f.GetL4().GetUDP().GetSourcePort())
-			assert.Equal(t, uint32(32412), f.GetL4().GetUDP().GetDestinationPort())
+			assert.Equal(t, []string{"k8s:io.cilium.k8s.policy.cluster=cluster-name", "k8s:src=label"}, f.Source.Labels)
+			assert.Equal(t, []string{"k8s:dst=label", "k8s:io.cilium.k8s.policy.cluster=cluster-name"}, f.Destination.Labels)
+			assert.Equal(t, "cluster-name", f.Source.ClusterName)
+			assert.Equal(t, "cluster-name", f.Destination.ClusterName)
+			assert.Equal(t, uint32(23939), f.L4.UDP.SourcePort)
+			assert.Equal(t, uint32(32412), f.L4.UDP.DestinationPort)
 		})
 	}
 }
@@ -635,43 +634,48 @@ func TestDecodeDropNotify(t *testing.T) {
 		},
 	}
 
+	m1, err := net.ParseMAC("01:02:03:04:05:06")
+	require.NoError(t, err)
+	m2, err := net.ParseMAC("04:05:06:07:08:09")
+	require.NoError(t, err)
+
 	testCases := []struct {
 		name      string
 		dn        any
 		srcLabels []string
 		dstLabels []string
-		want      *flowpb.Flow
+		want      ir.Flow
 	}{
 		{
 			name:      "v3",
 			dn:        dropNotify(3),
 			srcLabels: []string{"k8s:src=label"},
 			dstLabels: []string{"k8s:dst=label"},
-			want: &flowpb.Flow{
+			want: ir.Flow{
 				Verdict: flowpb.Verdict_DROPPED,
-				Ethernet: &flowpb.Ethernet{
-					Source:      "01:02:03:04:05:06",
-					Destination: "04:05:06:07:08:09",
+				Ethernet: ir.Ethernet{
+					Source:      m1,
+					Destination: m2,
 				},
-				IP: &flowpb.IP{
+				IP: ir.IP{
 					Source:      "1.2.3.4",
 					Destination: "1.2.3.4",
-					IpVersion:   flowpb.IPVersion_IPv4,
+					IPVersion:   flowpb.IPVersion_IPv4,
 				},
-				Source: &flowpb.Endpoint{
+				Source: ir.Endpoint{
 					Identity: 123,
 					Labels:   []string{"k8s:src=label"},
 				},
-				Destination: &flowpb.Endpoint{
+				Destination: ir.Endpoint{
 					Identity: 456,
 					Labels:   []string{"k8s:dst=label"},
 				},
 				Type: flowpb.FlowType_L3_L4,
-				EventType: &flowpb.CiliumEventType{
+				EventType: ir.CiliumEventType{
 					Type: 1,
 				},
 				Summary: "IPv4",
-				File:    &flowpb.FileInfo{Name: "bpf_host.c"},
+				File:    ir.FileInfo{Name: "bpf_host.c"},
 			},
 		},
 		{
@@ -679,31 +683,31 @@ func TestDecodeDropNotify(t *testing.T) {
 			dn:        dropNotify(3, 0x12345678),
 			srcLabels: []string{"k8s:src=label"},
 			dstLabels: []string{"k8s:dst=label"},
-			want: &flowpb.Flow{
+			want: ir.Flow{
 				Verdict: flowpb.Verdict_DROPPED,
-				Ethernet: &flowpb.Ethernet{
-					Source:      "01:02:03:04:05:06",
-					Destination: "04:05:06:07:08:09",
+				Ethernet: ir.Ethernet{
+					Source:      m1,
+					Destination: m2,
 				},
-				IP: &flowpb.IP{
+				IP: ir.IP{
 					Source:      "1.2.3.4",
 					Destination: "1.2.3.4",
-					IpVersion:   flowpb.IPVersion_IPv4,
+					IPVersion:   flowpb.IPVersion_IPv4,
 				},
-				Source: &flowpb.Endpoint{
+				Source: ir.Endpoint{
 					Identity: 123,
 					Labels:   []string{"k8s:src=label"},
 				},
-				Destination: &flowpb.Endpoint{
+				Destination: ir.Endpoint{
 					Identity: 456,
 					Labels:   []string{"k8s:dst=label"},
 				},
 				Type:      flowpb.FlowType_L3_L4,
-				EventType: &flowpb.CiliumEventType{Type: 1},
+				EventType: ir.CiliumEventType{Type: 1},
 				Summary:   "IPv4",
-				File:      &flowpb.FileInfo{Name: "bpf_host.c"},
-				IpTraceId: &flowpb.IPTraceID{
-					TraceId: 0x12345678,
+				File:      ir.FileInfo{Name: "bpf_host.c"},
+				IPTraceID: ir.IPTraceID{
+					TraceID: 0x12345678,
 				},
 			},
 		},
@@ -722,8 +726,8 @@ func TestDecodeDropNotify(t *testing.T) {
 				t.Fatalf("New parser: %v", err)
 			}
 
-			f := &flowpb.Flow{}
-			if err := parser.Decode(buf.Bytes(), f); err != nil {
+			var f ir.Flow
+			if err := parser.Decode(buf.Bytes(), &f); err != nil {
 				t.Fatalf("parser.Decode(bytes, f): %v", err)
 			}
 
@@ -811,17 +815,17 @@ func TestDecodePolicyVerdictNotify(t *testing.T) {
 	data, err := testutils.CreateL3L4Payload(pvn, &eth, &ip, &tcp)
 	require.NoError(t, err)
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(data, f)
+	var f ir.Flow
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 
-	assert.Equal(t, int32(monitorAPI.MessageTypePolicyVerdict), f.GetEventType().GetType())
-	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(monitorAPI.PolicyMatchL3L4), f.GetPolicyMatchType())
-	assert.Equal(t, flowpb.Verdict_FORWARDED, f.GetVerdict())
-	assert.Equal(t, []string{"k8s:dst=label"}, f.GetDestination().GetLabels())
+	assert.Equal(t, int32(monitorAPI.MessageTypePolicyVerdict), f.EventType.Type)
+	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(monitorAPI.PolicyMatchL3L4), f.PolicyMatchType)
+	assert.Equal(t, flowpb.Verdict_FORWARDED, f.Verdict)
+	assert.Equal(t, []string{"k8s:dst=label"}, f.Destination.Labels)
 
-	expectedPolicy := []*flowpb.Policy{
+	expectedPolicy := []ir.Policy{
 		{
 			Name:      "web-policy",
 			Namespace: "foo-namespace",
@@ -835,7 +839,7 @@ func TestDecodePolicyVerdictNotify(t *testing.T) {
 			Revision: 1,
 		},
 	}
-	if diff := cmp.Diff(expectedPolicy, f.GetEgressAllowedBy(), protocmp.Transform()); diff != "" {
+	if diff := cmp.Diff(expectedPolicy, f.EgressAllowedBy, protocmp.Transform()); diff != "" {
 		t.Errorf("not equal (-want +got):\n%s", diff)
 	}
 
@@ -851,16 +855,16 @@ func TestDecodePolicyVerdictNotify(t *testing.T) {
 	data, err = testutils.CreateL3L4Payload(pvn)
 	require.NoError(t, err)
 
-	f.Reset()
-	err = parser.Decode(data, f)
+	f = ir.Flow{}
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 
-	assert.Equal(t, int32(monitorAPI.MessageTypePolicyVerdict), f.GetEventType().GetType())
-	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(151), f.GetDropReason())
-	assert.Equal(t, flowpb.DropReason(151), f.GetDropReasonDesc())
-	assert.Equal(t, flowpb.Verdict_DROPPED, f.GetVerdict())
-	assert.Equal(t, []string{"k8s:dst=label"}, f.GetSource().GetLabels())
+	assert.Equal(t, int32(monitorAPI.MessageTypePolicyVerdict), f.EventType.Type)
+	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(151), f.DropReason)
+	assert.Equal(t, flowpb.DropReason(151), f.DropReasonDesc)
+	assert.Equal(t, flowpb.Verdict_DROPPED, f.Verdict)
+	assert.Equal(t, []string{"k8s:dst=label"}, f.Source.Labels)
 }
 
 func TestNetworkPolicyCorrelationDisabled(t *testing.T) {
@@ -942,16 +946,16 @@ func TestNetworkPolicyCorrelationDisabled(t *testing.T) {
 
 	require.NoError(t, err)
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(data, f)
+	var f ir.Flow
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 
-	assert.Equal(t, int32(monitorAPI.MessageTypePolicyVerdict), f.GetEventType().GetType())
-	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(monitorAPI.PolicyMatchL3L4), f.GetPolicyMatchType())
-	assert.Equal(t, flowpb.Verdict_FORWARDED, f.GetVerdict())
-	assert.Equal(t, []string{"k8s:dst=label"}, f.GetDestination().GetLabels())
-	assert.Equal(t, []*flowpb.Policy([]*flowpb.Policy(nil)), f.GetEgressAllowedBy())
+	assert.Equal(t, int32(monitorAPI.MessageTypePolicyVerdict), f.EventType.Type)
+	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(monitorAPI.PolicyMatchL3L4), f.PolicyMatchType)
+	assert.Equal(t, flowpb.Verdict_FORWARDED, f.Verdict)
+	assert.Equal(t, []string{"k8s:dst=label"}, f.Destination.Labels)
+	assert.Equal(t, []ir.Policy([]ir.Policy(nil)), f.EgressAllowedBy)
 
 	// PolicyVerdictNotify for forwarded ingress flow
 	flags = monitorAPI.PolicyIngress
@@ -967,16 +971,16 @@ func TestNetworkPolicyCorrelationDisabled(t *testing.T) {
 	data, err = testutils.CreateL3L4Payload(pvn)
 	require.NoError(t, err)
 
-	f.Reset()
-	err = parser.Decode(data, f)
+	f = ir.Flow{}
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 
-	assert.Equal(t, int32(monitorAPI.MessageTypePolicyVerdict), f.GetEventType().GetType())
-	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(monitorAPI.PolicyMatchL3L4), f.GetPolicyMatchType())
-	assert.Equal(t, flowpb.Verdict_FORWARDED, f.GetVerdict())
-	assert.Equal(t, []string{"k8s:dst=label"}, f.GetSource().GetLabels())
-	assert.Equal(t, []*flowpb.Policy([]*flowpb.Policy(nil)), f.GetIngressAllowedBy())
+	assert.Equal(t, int32(monitorAPI.MessageTypePolicyVerdict), f.EventType.Type)
+	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(monitorAPI.PolicyMatchL3L4), f.PolicyMatchType)
+	assert.Equal(t, flowpb.Verdict_FORWARDED, f.Verdict)
+	assert.Equal(t, []string{"k8s:dst=label"}, f.Source.Labels)
+	assert.Equal(t, []ir.Policy([]ir.Policy(nil)), f.IngressAllowedBy)
 }
 
 func TestDecodeDropReason(t *testing.T) {
@@ -992,18 +996,18 @@ func TestDecodeDropReason(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(data, f)
+	var f ir.Flow
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 
-	assert.Equal(t, uint32(reason), f.GetDropReason())
-	assert.Equal(t, flowpb.DropReason(reason), f.GetDropReasonDesc())
+	assert.Equal(t, uint32(reason), f.DropReason)
+	assert.Equal(t, flowpb.DropReason(reason), f.DropReasonDesc)
 }
 
 func TestDecodeTraceReason(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
-	parseFlow := func(event any, srcIPv4, dstIPv4 string) *flowpb.Flow {
+	parseFlow := func(event any, srcIPv4, dstIPv4 string) *ir.Flow {
 		data, err := testutils.CreateL3L4Payload(event,
 			&layers.Ethernet{
 				SrcMAC:       net.HardwareAddr{1, 2, 3, 4, 5, 6},
@@ -1012,10 +1016,10 @@ func TestDecodeTraceReason(t *testing.T) {
 			},
 			&layers.IPv4{SrcIP: net.ParseIP(srcIPv4), DstIP: net.ParseIP(dstIPv4)})
 		require.NoError(t, err)
-		f := &flowpb.Flow{}
-		err = parser.Decode(data, f)
+		var f ir.Flow
+		err = parser.Decode(data, &f)
 		require.NoError(t, err)
-		return f
+		return &f
 	}
 
 	var tt = []struct {
@@ -1067,8 +1071,8 @@ func TestDecodeTraceReason(t *testing.T) {
 				Reason: tc.reason,
 			}
 			f := parseFlow(tn, "1.2.3.4", "5.6.7.8")
-			assert.Equal(t, tc.want, f.GetTraceReason())
-			assert.False(t, f.GetIP().GetEncrypted())
+			assert.Equal(t, tc.want, f.TraceReason)
+			assert.False(t, f.IP.Encrypted)
 		})
 		t.Run(tc.name+" encrypted", func(t *testing.T) {
 			tn := monitor.TraceNotify{
@@ -1076,8 +1080,8 @@ func TestDecodeTraceReason(t *testing.T) {
 				Reason: tc.reason | monitor.TraceReasonEncryptMask,
 			}
 			f := parseFlow(tn, "1.2.3.4", "5.6.7.8")
-			assert.Equal(t, tc.want, f.GetTraceReason())
-			assert.True(t, f.GetIP().GetEncrypted())
+			assert.Equal(t, tc.want, f.TraceReason)
+			assert.True(t, f.IP.Encrypted)
 		})
 	}
 }
@@ -1099,12 +1103,12 @@ func TestDecodeLocalIdentity(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), nil, identityGetter, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(data, f)
+	var f ir.Flow
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"cidr:1.2.3.4/12", "unspec:some=label"}, f.GetSource().GetLabels())
-	assert.Equal(t, []string{"cidr:1.2.3.4/12", "unspec:some=label"}, f.GetDestination().GetLabels())
+	assert.Equal(t, []string{"cidr:1.2.3.4/12", "unspec:some=label"}, f.Source.Labels)
+	assert.Equal(t, []string{"cidr:1.2.3.4/12", "unspec:some=label"}, f.Destination.Labels)
 }
 
 func TestDecodeTrafficDirection(t *testing.T) {
@@ -1133,7 +1137,7 @@ func TestDecodeTrafficDirection(t *testing.T) {
 
 	parser, err := New(hivetest.Logger(t), endpointGetter, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
-	parseFlow := func(event any, srcIPv4, dstIPv4 netip.Addr) *flowpb.Flow {
+	parseFlow := func(event any, srcIPv4, dstIPv4 netip.Addr) *ir.Flow {
 		data, err := testutils.CreateL3L4Payload(event,
 			&layers.Ethernet{
 				SrcMAC:       net.HardwareAddr{1, 2, 3, 4, 5, 6},
@@ -1142,10 +1146,10 @@ func TestDecodeTrafficDirection(t *testing.T) {
 			},
 			&layers.IPv4{SrcIP: srcIPv4.AsSlice(), DstIP: dstIPv4.AsSlice()})
 		require.NoError(t, err)
-		f := &flowpb.Flow{}
-		err = parser.Decode(data, f)
+		var f ir.Flow
+		err = parser.Decode(data, &f)
 		require.NoError(t, err)
-		return f
+		return &f
 	}
 
 	// DROP at unknown endpoint
@@ -1154,8 +1158,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		Version: monitor.DropNotifyVersion2,
 	}
 	f := parseFlow(dn, localIP, remoteIP)
-	assert.Equal(t, flowpb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Source.ID)
 
 	// DROP Egress
 	dn = monitor.DropNotify{
@@ -1164,8 +1168,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		Version: monitor.DropNotifyVersion2,
 	}
 	f = parseFlow(dn, localIP, remoteIP)
-	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Source.ID)
 
 	// DROP Ingress
 	dn = monitor.DropNotify{
@@ -1174,8 +1178,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		Version: monitor.DropNotifyVersion2,
 	}
 	f = parseFlow(dn, remoteIP, localIP)
-	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetDestination().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Destination.ID)
 
 	// TRACE_TO_LXC at unknown endpoint
 	tn := monitor.TraceNotify{
@@ -1183,8 +1187,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		ObsPoint: monitorAPI.TraceToLxc,
 	}
 	f = parseFlow(tn, localIP, remoteIP)
-	assert.Equal(t, flowpb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Source.ID)
 
 	// TRACE_TO_LXC Egress
 	tn = monitor.TraceNotify{
@@ -1193,8 +1197,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		ObsPoint: monitorAPI.TraceToLxc,
 	}
 	f = parseFlow(tn, localIP, remoteIP)
-	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Source.ID)
 
 	// TO_NETWORK Egress (SNAT)
 	tnv1 := monitor.TraceNotify{
@@ -1205,8 +1209,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		OrigIP:   types.IPv6{1, 2, 3, 4}, // localIP
 	}
 	f = parseFlow(tnv1, netip.MustParseAddr("10.11.12.13"), remoteIP)
-	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Source.ID)
 
 	// TRACE_TO_LXC Egress, reversed by CT_REPLY
 	tn = monitor.TraceNotify{
@@ -1216,8 +1220,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		Reason:   monitor.TraceReasonCtReply,
 	}
 	f = parseFlow(tn, localIP, remoteIP)
-	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Source.ID)
 
 	// TRACE_TO_HOST Ingress
 	tn = monitor.TraceNotify{
@@ -1226,8 +1230,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		ObsPoint: monitorAPI.TraceToHost,
 	}
 	f = parseFlow(tn, remoteIP, localIP)
-	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetDestination().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Destination.ID)
 
 	// TRACE_TO_HOST Ingress, reversed by CT_REPLY
 	tn = monitor.TraceNotify{
@@ -1237,8 +1241,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		Reason:   monitor.TraceReasonCtReply,
 	}
 	f = parseFlow(tn, remoteIP, localIP)
-	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetDestination().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Destination.ID)
 
 	// TRACE_FROM_LXC unknown
 	tn = monitor.TraceNotify{
@@ -1248,8 +1252,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		Reason:   monitor.TraceReasonUnknown,
 	}
 	f = parseFlow(tn, localIP, remoteIP)
-	assert.Equal(t, flowpb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Source.ID)
 
 	// TRACE_FROM_LXC unknown (encrypted)
 	tn = monitor.TraceNotify{
@@ -1259,8 +1263,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		Reason:   monitor.TraceReasonUnknown | monitor.TraceReasonEncryptMask,
 	}
 	f = parseFlow(tn, localIP, remoteIP)
-	assert.Equal(t, flowpb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Source.ID)
 
 	// TRACE_TO_STACK SRV6 decap Ingress
 	tn = monitor.TraceNotify{
@@ -1270,8 +1274,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		Reason:   monitor.TraceReasonSRv6Decap,
 	}
 	f = parseFlow(tn, remoteIP, localIP)
-	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetDestination().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Destination.ID)
 
 	// TRACE_TO_STACK SRV6 encap Egress
 	tn = monitor.TraceNotify{
@@ -1281,8 +1285,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		Reason:   monitor.TraceReasonSRv6Encap,
 	}
 	f = parseFlow(tn, localIP, remoteIP)
-	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Source.ID)
 
 	// PolicyVerdictNotify Egress
 	pvn := monitor.PolicyVerdictNotify{
@@ -1292,14 +1296,14 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		RemoteLabel: remoteID,
 	}
 	f = parseFlow(pvn, localIP, remoteIP)
-	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Source.ID)
 
 	ep, ok := endpointGetter.GetEndpointInfo(localIP)
 	assert.True(t, ok)
 	info, ok := ep.GetPolicyCorrelationInfoForKey(
-		policy.KeyForDirection(directionFromProto(f.GetTrafficDirection())).
-			WithIdentity(identity.NumericIdentity(f.GetDestination().GetIdentity())))
+		policy.KeyForDirection(directionFromProto(f.TrafficDirection)).
+			WithIdentity(identity.NumericIdentity(f.Destination.Identity)))
 	assert.True(t, ok)
 	lbls := labels.LabelArrayListFromString(info.RuleLabels)
 	assert.Equal(t, lbls, policyLabel)
@@ -1312,8 +1316,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		Flags:  monitorAPI.PolicyIngress,
 	}
 	f = parseFlow(pvn, remoteIP, localIP)
-	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetDestination().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Destination.ID)
 }
 
 func TestDecodeIsReply(t *testing.T) {
@@ -1324,7 +1328,7 @@ func TestDecodeIsReply(t *testing.T) {
 
 	parser, err := New(hivetest.Logger(t), nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
-	parseFlow := func(event any, srcIPv4, dstIPv4 net.IP) *flowpb.Flow {
+	parseFlow := func(event any, srcIPv4, dstIPv4 net.IP) *ir.Flow {
 		data, err := testutils.CreateL3L4Payload(event,
 			&layers.Ethernet{
 				SrcMAC:       net.HardwareAddr{1, 2, 3, 4, 5, 6},
@@ -1333,10 +1337,10 @@ func TestDecodeIsReply(t *testing.T) {
 			},
 			&layers.IPv4{SrcIP: srcIPv4, DstIP: dstIPv4})
 		require.NoError(t, err)
-		f := &flowpb.Flow{}
-		err = parser.Decode(data, f)
+		var f ir.Flow
+		err = parser.Decode(data, &f)
 		require.NoError(t, err)
-		return f
+		return &f
 	}
 
 	// TRACE_TO_LXC
@@ -1346,9 +1350,7 @@ func TestDecodeIsReply(t *testing.T) {
 		Reason:   monitor.TraceReasonCtReply,
 	}
 	f := parseFlow(tn, localIP, remoteIP)
-	assert.NotNil(t, f.GetIsReply())
-	assert.True(t, f.GetIsReply().GetValue())
-	assert.True(t, f.GetReply())
+	assert.True(t, f.IsReply())
 
 	// TRACE_FROM_LXC
 	tn = monitor.TraceNotify{
@@ -1357,8 +1359,7 @@ func TestDecodeIsReply(t *testing.T) {
 		Reason:   monitor.TraceReasonUnknown,
 	}
 	f = parseFlow(tn, localIP, remoteIP)
-	assert.Nil(t, f.GetIsReply())
-	assert.False(t, f.GetReply())
+	assert.False(t, f.IsReply())
 
 	// TRACE_FROM_LXC encrypted
 	tn = monitor.TraceNotify{
@@ -1367,8 +1368,7 @@ func TestDecodeIsReply(t *testing.T) {
 		Reason:   monitor.TraceReasonUnknown | monitor.TraceReasonEncryptMask,
 	}
 	f = parseFlow(tn, localIP, remoteIP)
-	assert.Nil(t, f.GetIsReply())
-	assert.False(t, f.GetReply())
+	assert.False(t, f.IsReply())
 
 	// TRACE_TO_STACK srv6-decap
 	tn = monitor.TraceNotify{
@@ -1378,8 +1378,7 @@ func TestDecodeIsReply(t *testing.T) {
 		Reason:   monitor.TraceReasonSRv6Decap,
 	}
 	f = parseFlow(tn, remoteIP, localIP)
-	assert.Nil(t, f.GetIsReply())
-	assert.False(t, f.GetReply())
+	assert.False(t, f.IsReply())
 
 	// TRACE_TO_STACK srv6-decap (encrypted)
 	tn = monitor.TraceNotify{
@@ -1389,8 +1388,7 @@ func TestDecodeIsReply(t *testing.T) {
 		Reason:   monitor.TraceReasonSRv6Decap | monitor.TraceReasonEncryptMask,
 	}
 	f = parseFlow(tn, remoteIP, localIP)
-	assert.Nil(t, f.GetIsReply())
-	assert.False(t, f.GetReply())
+	assert.False(t, f.IsReply())
 
 	// TRACE_TO_STACK srv6-encap
 	tn = monitor.TraceNotify{
@@ -1400,8 +1398,7 @@ func TestDecodeIsReply(t *testing.T) {
 		Reason:   monitor.TraceReasonSRv6Encap,
 	}
 	f = parseFlow(tn, localIP, remoteIP)
-	assert.Nil(t, f.GetIsReply())
-	assert.False(t, f.GetReply())
+	assert.False(t, f.IsReply())
 
 	// TRACE_TO_STACK srv6-encap (encrypted)
 	tn = monitor.TraceNotify{
@@ -1411,8 +1408,7 @@ func TestDecodeIsReply(t *testing.T) {
 		Reason:   monitor.TraceReasonSRv6Encap | monitor.TraceReasonEncryptMask,
 	}
 	f = parseFlow(tn, localIP, remoteIP)
-	assert.Nil(t, f.GetIsReply())
-	assert.False(t, f.GetReply())
+	assert.False(t, f.IsReply())
 
 	// PolicyVerdictNotify forward statically assumes is_reply=false
 	pvn := monitor.PolicyVerdictNotify{
@@ -1420,9 +1416,7 @@ func TestDecodeIsReply(t *testing.T) {
 		Verdict: 0,
 	}
 	f = parseFlow(pvn, localIP, remoteIP)
-	assert.NotNil(t, f.GetIsReply())
-	assert.False(t, f.GetIsReply().GetValue())
-	assert.False(t, f.GetReply())
+	assert.False(t, f.IsReply())
 
 	// PolicyVerdictNotify drop statically assumes is_reply=unknown
 	pvn = monitor.PolicyVerdictNotify{
@@ -1430,16 +1424,14 @@ func TestDecodeIsReply(t *testing.T) {
 		Verdict: -151, // drop reason: Stale or unroutable IP
 	}
 	f = parseFlow(pvn, localIP, remoteIP)
-	assert.Nil(t, f.GetIsReply())
-	assert.False(t, f.GetReply())
+	assert.False(t, f.IsReply())
 
 	// DropNotify statically assumes is_reply=unknown
 	dn := monitor.DropNotify{
 		Type: byte(monitorAPI.MessageTypeDrop),
 	}
 	f = parseFlow(dn, localIP, remoteIP)
-	assert.Nil(t, f.GetIsReply())
-	assert.False(t, f.GetReply())
+	assert.False(t, f.IsReply())
 }
 
 func Test_filterCIDRLabels(t *testing.T) {
@@ -1518,7 +1510,7 @@ func Test_filterCIDRLabels(t *testing.T) {
 }
 
 func TestTraceNotifyOriginalIP(t *testing.T) {
-	f := &flowpb.Flow{}
+	var f ir.Flow
 	parser, err := New(hivetest.Logger(t), &testutils.NoopEndpointGetter, nil, &testutils.NoopDNSGetter, &testutils.NoopIPGetter, &testutils.NoopServiceGetter, &testutils.NoopLinkGetter)
 	require.NoError(t, err)
 
@@ -1538,7 +1530,7 @@ func TestTraceNotifyOriginalIP(t *testing.T) {
 	data, err := testutils.CreateL3L4Payload(v0, &eth, &ip, &layers.TCP{})
 	require.NoError(t, err)
 
-	err = parser.Decode(data, f)
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 	assert.Equal(t, "10.0.0.2", f.IP.Source)
 	assert.Empty(t, f.IP.SourceXlated)
@@ -1550,7 +1542,7 @@ func TestTraceNotifyOriginalIP(t *testing.T) {
 	}
 	data, err = testutils.CreateL3L4Payload(v1, &eth, &ip, &layers.TCP{})
 	require.NoError(t, err)
-	err = parser.Decode(data, f)
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 	assert.Equal(t, "1.1.1.1", f.IP.Source)
 	assert.Equal(t, "10.0.0.2", f.IP.SourceXlated)
@@ -1562,7 +1554,7 @@ func TestTraceNotifyOriginalIP(t *testing.T) {
 	}
 	data, err = testutils.CreateL3L4Payload(v1, &eth, &ip, &layers.TCP{})
 	require.NoError(t, err)
-	err = parser.Decode(data, f)
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 	assert.Equal(t, "10.0.0.2", f.IP.Source)
 	assert.Empty(t, f.IP.SourceXlated)
@@ -1592,11 +1584,11 @@ func TestICMP(t *testing.T) {
 	}
 	v4data, err := testutils.CreateL3L4Payload(message, &eth, &ip, &icmpv4)
 	require.NoError(t, err)
-	v4flow := &flowpb.Flow{}
-	err = parser.Decode(v4data, v4flow)
+	var v4flow ir.Flow
+	err = parser.Decode(v4data, &v4flow)
 	require.NoError(t, err)
-	assert.Equal(t, uint32(1), v4flow.GetL4().GetICMPv4().Type)
-	assert.Equal(t, uint32(2), v4flow.GetL4().GetICMPv4().Code)
+	assert.Equal(t, uint32(1), v4flow.L4.ICMPv4.Type)
+	assert.Equal(t, uint32(2), v4flow.L4.ICMPv4.Code)
 
 	// icmpv4
 	ethv6 := layers.Ethernet{
@@ -1615,15 +1607,15 @@ func TestICMP(t *testing.T) {
 	}
 	v6data, err := testutils.CreateL3L4Payload(message, &ethv6, &ipv6, &icmpv6)
 	require.NoError(t, err)
-	v6flow := &flowpb.Flow{}
-	err = parser.Decode(v6data, v6flow)
+	var v6flow ir.Flow
+	err = parser.Decode(v6data, &v6flow)
 	require.NoError(t, err)
-	assert.Equal(t, uint32(3), v6flow.GetL4().GetICMPv6().Type)
-	assert.Equal(t, uint32(4), v6flow.GetL4().GetICMPv6().Code)
+	assert.Equal(t, uint32(3), v6flow.L4.ICMPv6.Type)
+	assert.Equal(t, uint32(4), v6flow.L4.ICMPv6.Code)
 }
 
 func TestTraceNotifyLocalEndpoint(t *testing.T) {
-	f := &flowpb.Flow{}
+	var f ir.Flow
 
 	ep := &testutils.FakeEndpointInfo{
 		ID:           1234,
@@ -1668,19 +1660,19 @@ func TestTraceNotifyLocalEndpoint(t *testing.T) {
 	data, err := testutils.CreateL3L4Payload(v0, &eth, &ip, &layers.TCP{})
 	require.NoError(t, err)
 
-	err = parser.Decode(data, f)
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 
 	assert.Equal(t, uint32(ep.ID), f.Source.ID)
 	assert.Equal(t, uint32(v0.SrcLabel), f.Source.Identity)
-	assert.Equal(t, "default", f.GetSource().GetClusterName())
+	assert.Equal(t, "default", f.Source.ClusterName)
 	assert.Equal(t, ep.PodNamespace, f.Source.Namespace)
 	assert.Equal(t, common.SortAndFilterLabels(hivetest.Logger(t), ep.Labels, ep.Identity), f.Source.Labels)
 	assert.Equal(t, ep.PodName, f.Source.PodName)
 }
 
 func TestDebugCapture(t *testing.T) {
-	f := &flowpb.Flow{}
+	var f ir.Flow
 
 	parser, err := New(hivetest.Logger(t), &testutils.NoopEndpointGetter, &testutils.NoopIdentityGetter, &testutils.NoopDNSGetter, &testutils.NoopIPGetter, &testutils.NoopServiceGetter, &testutils.NoopLinkGetter)
 	require.NoError(t, err)
@@ -1710,7 +1702,7 @@ func TestDebugCapture(t *testing.T) {
 	data, err := testutils.CreateL3L4Payload(dbg, &eth, &ip, &layers.TCP{})
 	require.NoError(t, err)
 
-	err = parser.Decode(data, f)
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(dbg.Type), f.EventType.Type)
@@ -1718,16 +1710,16 @@ func TestDebugCapture(t *testing.T) {
 	assert.Equal(t, flowpb.DebugCapturePoint_DBG_CAPTURE_DELIVERY, f.DebugCapturePoint)
 	assert.Equal(t, ip.SrcIP.String(), f.IP.Source)
 	assert.Equal(t, ip.DstIP.String(), f.IP.Destination)
-	assert.NotNil(t, f.L4.GetTCP())
+	assert.NotNil(t, f.L4.TCP)
 
-	assert.Equal(t, &flowpb.NetworkInterface{
+	assert.Equal(t, ir.NetworkInterface{
 		Index: loIfIndex,
 		Name:  loIfName,
 	}, f.Interface)
 
 	nilParser, err := New(hivetest.Logger(t), nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
-	err = nilParser.Decode(data, f)
+	err = nilParser.Decode(data, &f)
 	require.NoError(t, err)
 
 	dbg = monitor.DebugCapture{
@@ -1738,7 +1730,7 @@ func TestDebugCapture(t *testing.T) {
 	data, err = testutils.CreateL3L4Payload(dbg)
 	require.NoError(t, err)
 
-	err = parser.Decode(data, f)
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(dbg.Type), f.EventType.Type)
@@ -1746,12 +1738,13 @@ func TestDebugCapture(t *testing.T) {
 	assert.Equal(t, flowpb.DebugCapturePoint_DBG_CAPTURE_PROXY_POST, f.DebugCapturePoint)
 	assert.Equal(t, uint32(1234), f.ProxyPort)
 
-	err = nilParser.Decode(data, f)
+	err = nilParser.Decode(data, &f)
 	require.NoError(t, err)
 }
 
 func TestTraceNotifyProxyPort(t *testing.T) {
-	f := &flowpb.Flow{}
+	var f ir.Flow
+
 	parser, err := New(hivetest.Logger(t), &testutils.NoopEndpointGetter, nil, &testutils.NoopDNSGetter, &testutils.NoopIPGetter, &testutils.NoopServiceGetter, &testutils.NoopLinkGetter)
 	require.NoError(t, err)
 
@@ -1773,7 +1766,7 @@ func TestTraceNotifyProxyPort(t *testing.T) {
 	data, err := testutils.CreateL3L4Payload(v0, &eth, &ip, &layers.TCP{})
 	require.NoError(t, err)
 
-	err = parser.Decode(data, f)
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 	assert.Equal(t, uint32(1234), f.ProxyPort)
 
@@ -1786,7 +1779,7 @@ func TestTraceNotifyProxyPort(t *testing.T) {
 	}
 	data, err = testutils.CreateL3L4Payload(v1, &eth, &ip, &layers.TCP{})
 	require.NoError(t, err)
-	err = parser.Decode(data, f)
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 	assert.Equal(t, uint32(4321), f.ProxyPort)
 }
@@ -1795,35 +1788,33 @@ func TestDecode_DropNotify(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), defaultEndpointGetter, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	getTemplate := func(isL3Device bool) *flowpb.Flow {
-		template := &flowpb.Flow{
-			EventType:   &flowpb.CiliumEventType{Type: 1},
-			Summary:     flowpb.IPVersion_IPv4.String(),
-			Type:        flowpb.FlowType_L3_L4,
-			Verdict:     flowpb.Verdict_DROPPED,
-			Source:      &flowpb.Endpoint{},
-			Destination: &flowpb.Endpoint{},
-			Ethernet: &flowpb.Ethernet{
-				Source:      srcMAC.String(),
-				Destination: dstMAC.String(),
+	getTemplate := func(isL3Device bool) *ir.Flow {
+		template := ir.Flow{
+			EventType: ir.CiliumEventType{Type: 1},
+			Summary:   flowpb.IPVersion_IPv4.String(),
+			Type:      flowpb.FlowType_L3_L4,
+			Verdict:   flowpb.Verdict_DROPPED,
+			Ethernet: ir.Ethernet{
+				Source:      srcMAC,
+				Destination: dstMAC,
 			},
-			IP: &flowpb.IP{
-				IpVersion:   flowpb.IPVersion_IPv4,
+			IP: ir.IP{
+				IPVersion:   flowpb.IPVersion_IPv4,
 				Source:      localIP.String(),
 				Destination: remoteIP.String(),
 			},
 		}
 		if isL3Device {
-			template.Ethernet = nil
+			template.Ethernet = ir.Ethernet{}
 		}
-		return template
+		return &template
 	}
 
 	testCases := []struct {
 		name    string
 		event   monitor.DropNotify
 		ipTuple ipTuple
-		want    *flowpb.Flow
+		want    ir.Flow
 	}{
 		{
 			name: "drop_unknown",
@@ -1834,9 +1825,10 @@ func TestDecode_DropNotify(t *testing.T) {
 				Version: monitor.DropNotifyVersion2,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				Source: &flowpb.Endpoint{ID: 1234},
-				File: &flowpb.FileInfo{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_DROPPED,
+				Source:  ir.Endpoint{ID: 1234},
+				File: ir.FileInfo{
 					Name: "bpf_lxc.c",
 					Line: 42,
 				},
@@ -1852,10 +1844,11 @@ func TestDecode_DropNotify(t *testing.T) {
 				Version: monitor.DropNotifyVersion2,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				Source:           &flowpb.Endpoint{ID: 1234},
+			want: ir.Flow{
+				Source:           ir.Endpoint{ID: 1234},
+				Verdict:          flowpb.Verdict_DROPPED,
 				TrafficDirection: flowpb.TrafficDirection_EGRESS,
-				File: &flowpb.FileInfo{
+				File: ir.FileInfo{
 					Name: "bpf_overlay.c",
 					Line: 12,
 				},
@@ -1871,16 +1864,17 @@ func TestDecode_DropNotify(t *testing.T) {
 				Version: monitor.DropNotifyVersion2,
 			},
 			ipTuple: ingressTuple,
-			want: &flowpb.Flow{
-				IP: &flowpb.IP{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_DROPPED,
+				IP: ir.IP{
 					Source:      remoteIP.String(),
 					Destination: localIP.String(),
 				},
-				Destination: &flowpb.Endpoint{
+				Destination: ir.Endpoint{
 					ID: uint32(localEP),
 				},
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
-				File: &flowpb.FileInfo{
+				File: ir.FileInfo{
 					Name: "bpf_xdp.c",
 					Line: 44,
 				},
@@ -1897,22 +1891,24 @@ func TestDecode_DropNotify(t *testing.T) {
 				Flags:   monitor.DropNotifyFlagIsL3Device,
 			},
 			ipTuple: ingressTuple,
-			want: &flowpb.Flow{
-				IP: &flowpb.IP{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_DROPPED,
+				IP: ir.IP{
 					Source:      remoteIP.String(),
 					Destination: localIP.String(),
 				},
-				Destination: &flowpb.Endpoint{
+				Destination: ir.Endpoint{
 					ID: uint32(localEP),
 				},
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
-				File: &flowpb.FileInfo{
+				File: ir.FileInfo{
 					Name: "bpf_wireguard.c",
 					Line: 44,
 				},
 			},
 		},
 	}
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			isL3Device := tc.event.IsL3Device()
@@ -1927,16 +1923,16 @@ func TestDecode_DropNotify(t *testing.T) {
 			}
 			l = append(l, &layers.IPv4{SrcIP: tc.ipTuple.src.AsSlice(), DstIP: tc.ipTuple.dst.AsSlice()})
 
-			want := proto.Clone(getTemplate(isL3Device))
-			proto.Merge(want, tc.want)
+			clone := getTemplate(isL3Device).Clone()
+			want := ir.TestMerge(&clone, &tc.want)
 
 			data, err := testutils.CreateL3L4Payload(tc.event, l...)
 			if err != nil {
 				t.Fatalf("Unexpected error from CreateL3L4Payload(%T, ...): %v", tc.event, err)
 			}
 
-			got := &flowpb.Flow{}
-			if err := parser.Decode(data, got); err != nil {
+			var got ir.Flow
+			if err := parser.Decode(data, &got); err != nil {
 				t.Fatalf("Unexpected error from Decode(data, %T): %v", got, err)
 			}
 
@@ -1944,7 +1940,7 @@ func TestDecode_DropNotify(t *testing.T) {
 				protocmp.Transform(),
 				protocmp.IgnoreFields(&flowpb.Flow{}, "reply"),
 			}
-			if diff := cmp.Diff(want, got, opts...); diff != "" {
+			if diff := cmp.Diff(want, &got, opts...); diff != "" {
 				t.Errorf("Unexpected diff (-want +got):\n%s", diff)
 			}
 		})
@@ -1955,27 +1951,27 @@ func TestDecode_TraceNotify(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), defaultEndpointGetter, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	getTemplate := func(isL3Device bool) *flowpb.Flow {
-		template := &flowpb.Flow{
-			EventType:   &flowpb.CiliumEventType{Type: 4},
+	getTemplate := func(isL3Device bool) ir.Flow {
+		template := ir.Flow{
+			EventType:   ir.CiliumEventType{Type: 4},
 			Summary:     flowpb.IPVersion_IPv4.String(),
 			Type:        flowpb.FlowType_L3_L4,
 			Verdict:     flowpb.Verdict_FORWARDED,
-			Source:      &flowpb.Endpoint{},
-			Destination: &flowpb.Endpoint{},
-			Ethernet: &flowpb.Ethernet{
-				Source:      srcMAC.String(),
-				Destination: dstMAC.String(),
+			Source:      ir.Endpoint{},
+			Destination: ir.Endpoint{},
+			Ethernet: ir.Ethernet{
+				Source:      srcMAC,
+				Destination: dstMAC,
 			},
-			IP: &flowpb.IP{
-				IpVersion:   flowpb.IPVersion_IPv4,
+			IP: ir.IP{
+				IPVersion:   flowpb.IPVersion_IPv4,
 				Source:      localIP.String(),
 				Destination: remoteIP.String(),
 			},
 			TraceObservationPoint: flowpb.TraceObservationPoint_TO_ENDPOINT,
 		}
 		if isL3Device {
-			template.Ethernet = nil
+			template.Ethernet = ir.Ethernet{}
 		}
 		return template
 	}
@@ -1984,7 +1980,7 @@ func TestDecode_TraceNotify(t *testing.T) {
 		name    string
 		event   any
 		ipTuple ipTuple
-		want    *flowpb.Flow
+		want    ir.Flow
 	}{
 		{
 			name: "v0_unknown",
@@ -1993,9 +1989,10 @@ func TestDecode_TraceNotify(t *testing.T) {
 				ObsPoint: monitorAPI.TraceToLxc,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				Source:      &flowpb.Endpoint{ID: 1234},
-				IsReply:     wrapperspb.Bool(false),
+			want: ir.Flow{
+				Verdict:     flowpb.Verdict_FORWARDED,
+				Source:      ir.Endpoint{ID: 1234},
+				Reply:       ir.ReplyNo,
 				TraceReason: flowpb.TraceReason_NEW,
 			},
 		},
@@ -2007,9 +2004,10 @@ func TestDecode_TraceNotify(t *testing.T) {
 				ObsPoint: monitorAPI.TraceToLxc,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				Source:           &flowpb.Endpoint{ID: 1234},
-				IsReply:          wrapperspb.Bool(false),
+			want: ir.Flow{
+				Verdict:          flowpb.Verdict_FORWARDED,
+				Source:           ir.Endpoint{ID: 1234},
+				Reply:            ir.ReplyNo,
 				TraceReason:      flowpb.TraceReason_NEW,
 				TrafficDirection: flowpb.TrafficDirection_EGRESS,
 			},
@@ -2024,15 +2022,17 @@ func TestDecode_TraceNotify(t *testing.T) {
 				OrigIP:   types.IPv6{1, 2, 3, 4}, // localIP
 			},
 			ipTuple: xlatedEgressTuple,
-			want: &flowpb.Flow{
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				EventType: ir.CiliumEventType{
+					Type:    monitorAPI.MessageTypeTrace,
 					SubType: 11,
 				},
-				IP: &flowpb.IP{
+				IP: ir.IP{
 					SourceXlated: xlatedIP.String(),
 				},
-				Source:                &flowpb.Endpoint{ID: 1234},
-				IsReply:               wrapperspb.Bool(false),
+				Source:                ir.Endpoint{ID: 1234},
+				Reply:                 ir.ReplyNo,
 				TraceReason:           flowpb.TraceReason_NEW,
 				TrafficDirection:      flowpb.TrafficDirection_EGRESS,
 				TraceObservationPoint: flowpb.TraceObservationPoint_TO_NETWORK,
@@ -2050,14 +2050,16 @@ func TestDecode_TraceNotify(t *testing.T) {
 				OrigIP:   types.IPv6{1, 2, 3, 4},
 			},
 			ipTuple: xlatedEgressTuple,
-			want: &flowpb.Flow{
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				EventType: ir.CiliumEventType{
+					Type:    monitorAPI.MessageTypeTrace,
 					SubType: 13,
 				},
-				IP: &flowpb.IP{
+				IP: ir.IP{
 					SourceXlated: xlatedIP.String(),
 				},
-				Source:                &flowpb.Endpoint{ID: 1234},
+				Source:                ir.Endpoint{ID: 1234},
 				TraceReason:           flowpb.TraceReason_TRACE_REASON_UNKNOWN,
 				TraceObservationPoint: flowpb.TraceObservationPoint_TO_CRYPTO,
 			},
@@ -2074,14 +2076,16 @@ func TestDecode_TraceNotify(t *testing.T) {
 				OrigIP:   types.IPv6{1, 2, 3, 4},
 			},
 			ipTuple: xlatedEgressTuple,
-			want: &flowpb.Flow{
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				EventType: ir.CiliumEventType{
+					Type:    monitorAPI.MessageTypeTrace,
 					SubType: 12,
 				},
-				IP: &flowpb.IP{
+				IP: ir.IP{
 					SourceXlated: xlatedIP.String(),
 				},
-				Source:                &flowpb.Endpoint{ID: 1234},
+				Source:                ir.Endpoint{ID: 1234},
 				TraceReason:           flowpb.TraceReason_TRACE_REASON_UNKNOWN,
 				TraceObservationPoint: flowpb.TraceObservationPoint_FROM_CRYPTO,
 			},
@@ -2095,13 +2099,14 @@ func TestDecode_TraceNotify(t *testing.T) {
 				Reason:   monitor.TraceReasonCtReply,
 			},
 			ipTuple: xlatedEgressTuple,
-			want: &flowpb.Flow{
-				IP: &flowpb.IP{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				IP: ir.IP{
 					Source: xlatedIP.String(),
 				},
 				TrafficDirection:      flowpb.TrafficDirection_EGRESS,
 				TraceObservationPoint: flowpb.TraceObservationPoint_TO_ENDPOINT,
-				IsReply:               wrapperspb.Bool(true),
+				Reply:                 ir.ReplyYes,
 				TraceReason:           flowpb.TraceReason_REPLY,
 			},
 		},
@@ -2113,16 +2118,18 @@ func TestDecode_TraceNotify(t *testing.T) {
 				ObsPoint: monitorAPI.TraceToHost,
 			},
 			ipTuple: ingressTuple,
-			want: &flowpb.Flow{
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				EventType: ir.CiliumEventType{
+					Type:    monitorAPI.MessageTypeTrace,
 					SubType: 2,
 				},
-				IP: &flowpb.IP{
+				IP: ir.IP{
 					Source:      remoteIP.String(),
 					Destination: localIP.String(),
 				},
-				Destination:           &flowpb.Endpoint{ID: 1234},
-				IsReply:               wrapperspb.Bool(false),
+				Destination:           ir.Endpoint{ID: 1234},
+				Reply:                 ir.ReplyNo,
 				TraceReason:           flowpb.TraceReason_NEW,
 				TrafficDirection:      flowpb.TrafficDirection_INGRESS,
 				TraceObservationPoint: flowpb.TraceObservationPoint_TO_HOST,
@@ -2137,18 +2144,20 @@ func TestDecode_TraceNotify(t *testing.T) {
 				Reason:   monitor.TraceReasonCtReply,
 			},
 			ipTuple: ingressTuple,
-			want: &flowpb.Flow{
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				EventType: ir.CiliumEventType{
+					Type:    monitorAPI.MessageTypeTrace,
 					SubType: 2,
 				},
-				IP: &flowpb.IP{
+				IP: ir.IP{
 					Source:      remoteIP.String(),
 					Destination: localIP.String(),
 				},
-				Destination:           &flowpb.Endpoint{ID: 1234},
+				Destination:           ir.Endpoint{ID: 1234},
 				TrafficDirection:      flowpb.TrafficDirection_EGRESS,
 				TraceObservationPoint: flowpb.TraceObservationPoint_TO_HOST,
-				IsReply:               wrapperspb.Bool(true),
+				Reply:                 ir.ReplyYes,
 				TraceReason:           flowpb.TraceReason_REPLY,
 			},
 		},
@@ -2161,11 +2170,13 @@ func TestDecode_TraceNotify(t *testing.T) {
 				Reason:   monitor.TraceReasonUnknown,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				EventType: ir.CiliumEventType{
+					Type:    monitorAPI.MessageTypeTrace,
 					SubType: 5,
 				},
-				Source:                &flowpb.Endpoint{ID: 1234},
+				Source:                ir.Endpoint{ID: 1234},
 				TraceObservationPoint: flowpb.TraceObservationPoint_FROM_ENDPOINT,
 			},
 		},
@@ -2178,11 +2189,13 @@ func TestDecode_TraceNotify(t *testing.T) {
 				Reason:   monitor.TraceReasonUnknown,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				EventType: ir.CiliumEventType{
+					Type:    monitorAPI.MessageTypeTrace,
 					SubType: 5,
 				},
-				Source:                &flowpb.Endpoint{ID: 1234},
+				Source:                ir.Endpoint{ID: 1234},
 				TraceObservationPoint: flowpb.TraceObservationPoint_FROM_ENDPOINT,
 			},
 		},
@@ -2195,11 +2208,13 @@ func TestDecode_TraceNotify(t *testing.T) {
 				Reason:   monitor.TraceReasonUnknown,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				EventType: ir.CiliumEventType{
+					Type:    monitorAPI.MessageTypeTrace,
 					SubType: 5,
 				},
-				Source:                &flowpb.Endpoint{ID: 1234},
+				Source:                ir.Endpoint{ID: 1234},
 				TraceObservationPoint: flowpb.TraceObservationPoint_FROM_ENDPOINT,
 			},
 		},
@@ -2212,14 +2227,16 @@ func TestDecode_TraceNotify(t *testing.T) {
 				Reason:   monitor.TraceReasonUnknown | monitor.TraceReasonEncryptMask,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				EventType: ir.CiliumEventType{
+					Type:    monitorAPI.MessageTypeTrace,
 					SubType: 5,
 				},
-				IP: &flowpb.IP{
+				IP: ir.IP{
 					Encrypted: true,
 				},
-				Source:                &flowpb.Endpoint{ID: 1234},
+				Source:                ir.Endpoint{ID: 1234},
 				TraceObservationPoint: flowpb.TraceObservationPoint_FROM_ENDPOINT,
 			},
 		},
@@ -2232,11 +2249,13 @@ func TestDecode_TraceNotify(t *testing.T) {
 				Reason:   monitor.TraceReasonSRv6Decap,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				EventType: ir.CiliumEventType{
+					Type:    monitorAPI.MessageTypeTrace,
 					SubType: 3,
 				},
-				Source:                &flowpb.Endpoint{ID: 1234},
+				Source:                ir.Endpoint{ID: 1234},
 				TraceReason:           flowpb.TraceReason_SRV6_DECAP,
 				TrafficDirection:      flowpb.TrafficDirection_INGRESS,
 				TraceObservationPoint: flowpb.TraceObservationPoint_TO_STACK,
@@ -2251,11 +2270,13 @@ func TestDecode_TraceNotify(t *testing.T) {
 				Reason:   monitor.TraceReasonSRv6Encap,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				EventType: ir.CiliumEventType{
+					Type:    monitorAPI.MessageTypeTrace,
 					SubType: 3,
 				},
-				Source:                &flowpb.Endpoint{ID: 1234},
+				Source:                ir.Endpoint{ID: 1234},
 				TraceReason:           flowpb.TraceReason_SRV6_ENCAP,
 				TrafficDirection:      flowpb.TrafficDirection_EGRESS,
 				TraceObservationPoint: flowpb.TraceObservationPoint_TO_STACK,
@@ -2271,11 +2292,13 @@ func TestDecode_TraceNotify(t *testing.T) {
 				Version:  monitor.TraceNotifyVersion2,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				EventType: ir.CiliumEventType{
+					Type:    monitorAPI.MessageTypeTrace,
 					SubType: 5,
 				},
-				Source:                &flowpb.Endpoint{ID: 1234},
+				Source:                ir.Endpoint{ID: 1234},
 				TraceObservationPoint: flowpb.TraceObservationPoint_FROM_ENDPOINT,
 			},
 		},
@@ -2290,14 +2313,16 @@ func TestDecode_TraceNotify(t *testing.T) {
 				IPTraceID: 1234,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				EventType: ir.CiliumEventType{
+					Type:    monitorAPI.MessageTypeTrace,
 					SubType: 5,
 				},
-				Source:                &flowpb.Endpoint{ID: 1234},
+				Source:                ir.Endpoint{ID: 1234},
 				TraceObservationPoint: flowpb.TraceObservationPoint_FROM_ENDPOINT,
-				IpTraceId: &flowpb.IPTraceID{
-					TraceId: 1234,
+				IPTraceID: ir.IPTraceID{
+					TraceID: 1234,
 				},
 			},
 		},
@@ -2319,16 +2344,17 @@ func TestDecode_TraceNotify(t *testing.T) {
 			}
 			l = append(l, &layers.IPv4{SrcIP: tc.ipTuple.src.AsSlice(), DstIP: tc.ipTuple.dst.AsSlice()})
 
-			want := proto.Clone(getTemplate(isL3Device))
-			proto.Merge(want, tc.want)
+			tpl := getTemplate(isL3Device)
+			clone := tpl.Clone()
+			want := ir.TestMerge(&clone, &tc.want)
 
 			data, err := testutils.CreateL3L4Payload(tc.event, l...)
 			if err != nil {
 				t.Fatalf("Unexpected error from CreateL3L4Payload(%T, ...): %v", tc.event, err)
 			}
 
-			got := &flowpb.Flow{}
-			if err := parser.Decode(data, got); err != nil {
+			var got ir.Flow
+			if err := parser.Decode(data, &got); err != nil {
 				t.Fatalf("Unexpected error from Decode(data, %T): %v", got, err)
 			}
 
@@ -2336,7 +2362,7 @@ func TestDecode_TraceNotify(t *testing.T) {
 				protocmp.Transform(),
 				protocmp.IgnoreFields(&flowpb.Flow{}, "reply"),
 			}
-			if diff := cmp.Diff(want, got, opts...); diff != "" {
+			if diff := cmp.Diff(want, &got, opts...); diff != "" {
 				t.Errorf("Unexpected diff (-want +got):\n%s", diff)
 			}
 		})
@@ -2347,36 +2373,35 @@ func TestDecode_PolicyVerdictNotify(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), defaultEndpointGetter, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	getTemplate := func(isL3Device bool) *flowpb.Flow {
-		template := &flowpb.Flow{
-			EventType:   &flowpb.CiliumEventType{Type: 5},
-			Summary:     flowpb.IPVersion_IPv4.String(),
-			Type:        flowpb.FlowType_L3_L4,
-			Verdict:     flowpb.Verdict_FORWARDED,
-			Source:      &flowpb.Endpoint{},
-			Destination: &flowpb.Endpoint{},
-			Ethernet: &flowpb.Ethernet{
-				Source:      srcMAC.String(),
-				Destination: dstMAC.String(),
+	getTemplate := func(isL3Device bool) *ir.Flow {
+		template := ir.Flow{
+			EventType: ir.CiliumEventType{Type: 5},
+			Summary:   flowpb.IPVersion_IPv4.String(),
+			Type:      flowpb.FlowType_L3_L4,
+			Verdict:   flowpb.Verdict_FORWARDED,
+			Ethernet: ir.Ethernet{
+				Source:      srcMAC,
+				Destination: dstMAC,
 			},
-			IP: &flowpb.IP{
-				IpVersion:   flowpb.IPVersion_IPv4,
+			IP: ir.IP{
+				IPVersion:   flowpb.IPVersion_IPv4,
 				Source:      localIP.String(),
 				Destination: remoteIP.String(),
 			},
-			IsReply: wrapperspb.Bool(false),
+			Reply: ir.ReplyNo,
 		}
+
 		if isL3Device {
-			template.Ethernet = nil
+			template.Ethernet = ir.Ethernet{}
 		}
-		return template
+		return &template
 	}
 
 	testCases := []struct {
 		name    string
 		event   any
 		ipTuple ipTuple
-		want    *flowpb.Flow
+		want    ir.Flow
 	}{
 		{
 			name: "egress",
@@ -2387,9 +2412,10 @@ func TestDecode_PolicyVerdictNotify(t *testing.T) {
 				RemoteLabel: identity.NumericIdentity(remoteID),
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				Source:           &flowpb.Endpoint{ID: 1234},
-				Destination:      &flowpb.Endpoint{Identity: 5678},
+			want: ir.Flow{
+				Verdict:          flowpb.Verdict_FORWARDED,
+				Source:           ir.Endpoint{ID: 1234},
+				Destination:      ir.Endpoint{Identity: 5678},
 				TrafficDirection: flowpb.TrafficDirection_EGRESS,
 			},
 		},
@@ -2401,8 +2427,9 @@ func TestDecode_PolicyVerdictNotify(t *testing.T) {
 				Flags:  monitorAPI.PolicyIngress,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				Source:           &flowpb.Endpoint{ID: 1234},
+			want: ir.Flow{
+				Verdict:          flowpb.Verdict_FORWARDED,
+				Source:           ir.Endpoint{ID: 1234},
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
 			},
 		},
@@ -2414,12 +2441,14 @@ func TestDecode_PolicyVerdictNotify(t *testing.T) {
 				Flags:  monitorAPI.PolicyIngress | monitor.PolicyVerdictNotifyFlagIsL3,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				Source:           &flowpb.Endpoint{ID: 1234},
+			want: ir.Flow{
+				Source:           ir.Endpoint{ID: 1234},
+				Verdict:          flowpb.Verdict_FORWARDED,
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
 			},
 		},
 	}
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			isL3Device := false
@@ -2437,16 +2466,16 @@ func TestDecode_PolicyVerdictNotify(t *testing.T) {
 			}
 			l = append(l, &layers.IPv4{SrcIP: tc.ipTuple.src.AsSlice(), DstIP: tc.ipTuple.dst.AsSlice()})
 
-			want := proto.Clone(getTemplate(isL3Device))
-			proto.Merge(want, tc.want)
+			want := getTemplate(isL3Device).Clone()
+			want = *ir.TestMerge(&want, &tc.want)
 
 			data, err := testutils.CreateL3L4Payload(tc.event, l...)
 			if err != nil {
 				t.Fatalf("Unexpected error from CreateL3L4Payload(%T, ...): %v", tc.event, err)
 			}
 
-			got := &flowpb.Flow{}
-			if err := parser.Decode(data, got); err != nil {
+			got := ir.Flow{}
+			if err := parser.Decode(data, &got); err != nil {
 				t.Fatalf("Unexpected error from Decode(data, %T): %v", got, err)
 			}
 
@@ -2462,19 +2491,17 @@ func TestDecode_PolicyVerdictNotify(t *testing.T) {
 }
 
 func TestDecode_CustomMonitorDecoder(t *testing.T) {
-	getTemplate := func() *flowpb.Flow {
-		template := &flowpb.Flow{
-			EventType:   &flowpb.CiliumEventType{Type: 5},
-			Summary:     flowpb.IPVersion_IPv4.String(),
-			Type:        flowpb.FlowType_L3_L4,
-			Source:      &flowpb.Endpoint{},
-			Destination: &flowpb.Endpoint{},
-			Ethernet: &flowpb.Ethernet{
-				Source:      srcMAC.String(),
-				Destination: dstMAC.String(),
+	getTemplate := func() *ir.Flow {
+		template := &ir.Flow{
+			EventType: ir.CiliumEventType{Type: 5},
+			Summary:   flowpb.IPVersion_IPv4.String(),
+			Type:      flowpb.FlowType_L3_L4,
+			Ethernet: ir.Ethernet{
+				Source:      srcMAC,
+				Destination: dstMAC,
 			},
-			IP: &flowpb.IP{
-				IpVersion:   flowpb.IPVersion_IPv4,
+			IP: ir.IP{
+				IPVersion:   flowpb.IPVersion_IPv4,
 				Source:      localIP.String(),
 				Destination: remoteIP.String(),
 			},
@@ -2487,7 +2514,7 @@ func TestDecode_CustomMonitorDecoder(t *testing.T) {
 		opts    []options.Option
 		event   any
 		ipTuple ipTuple
-		want    *flowpb.Flow
+		want    ir.Flow
 	}{
 		{
 			name: "policy",
@@ -2498,8 +2525,8 @@ func TestDecode_CustomMonitorDecoder(t *testing.T) {
 				RemoteLabel: identity.NumericIdentity(remoteID),
 			},
 			opts: []options.Option{
-				options.WithPolicyVerdictNotifyDecoder(func(data []byte, decoded *flowpb.Flow) (*monitor.PolicyVerdictNotify, error) {
-					decoded.Uuid = "foobar"
+				options.WithPolicyVerdictNotifyDecoder(func(data []byte, decoded *ir.Flow) (*monitor.PolicyVerdictNotify, error) {
+					decoded.UUID = "foobar"
 					return &monitor.PolicyVerdictNotify{
 						Type:        byte(monitorAPI.MessageTypePolicyVerdict),
 						Source:      1226,
@@ -2509,12 +2536,12 @@ func TestDecode_CustomMonitorDecoder(t *testing.T) {
 				}),
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				Source:           &flowpb.Endpoint{ID: 1234},
-				Destination:      &flowpb.Endpoint{Identity: 1337},
+			want: ir.Flow{
+				Source:           ir.Endpoint{ID: 1234},
+				Destination:      ir.Endpoint{Identity: 1337},
 				TrafficDirection: flowpb.TrafficDirection_EGRESS,
-				Uuid:             "foobar",
-				IsReply:          wrapperspb.Bool(false),
+				UUID:             "foobar",
+				Reply:            ir.ReplyNo,
 				Verdict:          flowpb.Verdict_FORWARDED,
 			},
 		},
@@ -2528,8 +2555,8 @@ func TestDecode_CustomMonitorDecoder(t *testing.T) {
 				Version:  monitor.TraceNotifyVersion2,
 			},
 			opts: []options.Option{
-				options.WithTraceNotifyDecoder(func(data []byte, decoded *flowpb.Flow) (*monitor.TraceNotify, error) {
-					decoded.Uuid = "foobar-trace"
+				options.WithTraceNotifyDecoder(func(data []byte, decoded *ir.Flow) (*monitor.TraceNotify, error) {
+					decoded.UUID = "foobar-trace"
 					return &monitor.TraceNotify{
 						Type:     byte(monitorAPI.MessageTypePolicyVerdict),
 						Source:   1226,
@@ -2541,15 +2568,15 @@ func TestDecode_CustomMonitorDecoder(t *testing.T) {
 				}),
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				Source:                &flowpb.Endpoint{ID: 1234},
-				Destination:           &flowpb.Endpoint{Identity: 1337},
-				EventType:             &flowpb.CiliumEventType{Type: 4},
+			want: ir.Flow{
+				Source:                ir.Endpoint{ID: 1234},
+				Destination:           ir.Endpoint{Identity: 1337},
+				EventType:             ir.CiliumEventType{Type: 4},
 				TrafficDirection:      flowpb.TrafficDirection_INGRESS,
 				TraceObservationPoint: flowpb.TraceObservationPoint_TO_ENDPOINT,
 				TraceReason:           flowpb.TraceReason_RELATED,
-				Uuid:                  "foobar-trace",
-				IsReply:               wrapperspb.Bool(false),
+				UUID:                  "foobar-trace",
+				Reply:                 ir.ReplyNo,
 				Verdict:               flowpb.Verdict_FORWARDED,
 			},
 		},
@@ -2563,8 +2590,8 @@ func TestDecode_CustomMonitorDecoder(t *testing.T) {
 				DstID:    11,
 			},
 			opts: []options.Option{
-				options.WithDropNotifyDecoder(func(data []byte, decoded *flowpb.Flow) (*monitor.DropNotify, error) {
-					decoded.Uuid = "foobar-drop"
+				options.WithDropNotifyDecoder(func(data []byte, decoded *ir.Flow) (*monitor.DropNotify, error) {
+					decoded.UUID = "foobar-drop"
 					return &monitor.DropNotify{
 						Type:     byte(monitorAPI.MessageTypeDrop),
 						Source:   1226,
@@ -2576,14 +2603,14 @@ func TestDecode_CustomMonitorDecoder(t *testing.T) {
 				}),
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				Source:           &flowpb.Endpoint{ID: 1234},
-				Destination:      &flowpb.Endpoint{Identity: 1337},
-				EventType:        &flowpb.CiliumEventType{Type: 1},
+			want: ir.Flow{
+				Source:           ir.Endpoint{ID: 1234},
+				Destination:      ir.Endpoint{Identity: 1337},
+				EventType:        ir.CiliumEventType{Type: 1},
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
 				Verdict:          flowpb.Verdict_DROPPED,
-				Uuid:             "foobar-drop",
-				File: &flowpb.FileInfo{
+				UUID:             "foobar-drop",
+				File: ir.FileInfo{
 					Name: "bpf_host.c",
 					Line: 0,
 				},
@@ -2600,8 +2627,8 @@ func TestDecode_CustomMonitorDecoder(t *testing.T) {
 				Arg2:                34,
 			},
 			opts: []options.Option{
-				options.WithDebugCaptureDecoder(func(data []byte, decoded *flowpb.Flow) (*monitor.DebugCapture, error) {
-					decoded.Uuid = "foobar-dbg"
+				options.WithDebugCaptureDecoder(func(data []byte, decoded *ir.Flow) (*monitor.DebugCapture, error) {
+					decoded.UUID = "foobar-dbg"
 					return &monitor.DebugCapture{
 						Type:    byte(monitorAPI.MessageTypeCapture),
 						Source:  1226,
@@ -2611,14 +2638,14 @@ func TestDecode_CustomMonitorDecoder(t *testing.T) {
 				}),
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				Source: &flowpb.Endpoint{ID: 1234},
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Source: ir.Endpoint{ID: 1234},
+				EventType: ir.CiliumEventType{
 					Type:    3,
 					SubType: 50,
 				},
 				DebugCapturePoint: 50,
-				Uuid:              "foobar-dbg",
+				UUID:              "foobar-dbg",
 			},
 		},
 	}
@@ -2628,8 +2655,8 @@ func TestDecode_CustomMonitorDecoder(t *testing.T) {
 			var l []gopacket.SerializableLayer
 			l = append(l, &layers.Ethernet{SrcMAC: srcMAC, DstMAC: dstMAC, EthernetType: layers.EthernetTypeIPv4}, &layers.IPv4{SrcIP: tc.ipTuple.src.AsSlice(), DstIP: tc.ipTuple.dst.AsSlice()})
 
-			want := proto.Clone(getTemplate())
-			proto.Merge(want, tc.want)
+			clone := getTemplate().Clone()
+			want := ir.TestMerge(&clone, &tc.want)
 
 			data, err := testutils.CreateL3L4Payload(tc.event, l...)
 			if err != nil {
@@ -2639,8 +2666,8 @@ func TestDecode_CustomMonitorDecoder(t *testing.T) {
 			parser, err := New(hivetest.Logger(t), defaultEndpointGetter, nil, nil, nil, nil, nil, tc.opts...)
 			require.NoError(t, err)
 
-			got := &flowpb.Flow{}
-			if err := parser.Decode(data, got); err != nil {
+			var got ir.Flow
+			if err := parser.Decode(data, &got); err != nil {
 				t.Fatalf("Unexpected error from Decode(data, %T): %v", got, err)
 			}
 
@@ -2648,7 +2675,7 @@ func TestDecode_CustomMonitorDecoder(t *testing.T) {
 				protocmp.Transform(),
 				protocmp.IgnoreFields(&flowpb.Flow{}, "reply"),
 			}
-			if diff := cmp.Diff(want, got, opts...); diff != "" {
+			if diff := cmp.Diff(*want, got, opts...); diff != "" {
 				t.Errorf("Unexpected diff (-want +got):\n%s", diff)
 			}
 		})
@@ -2659,16 +2686,16 @@ type customDecoder struct {
 }
 
 // DecodePacket implements options.L34PacketDecoder.
-func (c customDecoder) DecodePacket(payload []byte, decoded *flowpb.Flow, isL3Device bool, isIPv6 bool, isVXLAN bool, isGeneve bool) (sourceIP netip.Addr, destinationIP netip.Addr, sourcePort uint16, destinationPort uint16, err error) {
+func (c customDecoder) DecodePacket(payload []byte, decoded *ir.Flow, isL3Device bool, isIPv6 bool, isVXLAN bool, isGeneve bool) (sourceIP netip.Addr, destinationIP netip.Addr, sourcePort uint16, destinationPort uint16, err error) {
 	sourceIP = netip.MustParseAddr("10.13.37.1")
 	destinationIP = netip.MustParseAddr("10.13.37.2")
 	sourcePort = 10011
 	destinationPort = 443
 
-	decoded.IP = &flowpb.IP{
+	decoded.IP = ir.IP{
 		Source:      sourceIP.String(),
 		Destination: destinationIP.String(),
-		IpVersion:   flowpb.IPVersion_IPv4,
+		IPVersion:   flowpb.IPVersion_IPv4,
 	}
 
 	return
@@ -2686,23 +2713,21 @@ func TestDecode_CustomPacketDecoder(t *testing.T) {
 	var l []gopacket.SerializableLayer
 	l = append(l, &layers.Ethernet{SrcMAC: srcMAC, DstMAC: dstMAC, EthernetType: layers.EthernetTypeIPv4}, &layers.IPv4{SrcIP: egressTuple.src.AsSlice(), DstIP: egressTuple.dst.AsSlice()})
 
-	want := &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	want := &ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type:    4,
 			SubType: 5,
 		},
-		Type:        flowpb.FlowType_L3_L4,
-		Source:      &flowpb.Endpoint{},
-		Destination: &flowpb.Endpoint{},
-		IP: &flowpb.IP{
-			IpVersion:   flowpb.IPVersion_IPv4,
+		Type: flowpb.FlowType_L3_L4,
+		IP: ir.IP{
+			IPVersion:   flowpb.IPVersion_IPv4,
 			Source:      "10.13.37.1",
 			Destination: "10.13.37.2",
 		},
 		TraceObservationPoint: flowpb.TraceObservationPoint_FROM_ENDPOINT,
 		TraceReason:           flowpb.TraceReason_ESTABLISHED,
 		TrafficDirection:      flowpb.TrafficDirection_INGRESS,
-		IsReply:               wrapperspb.Bool(false),
+		Reply:                 ir.ReplyNo,
 		Verdict:               flowpb.Verdict_FORWARDED,
 	}
 
@@ -2714,7 +2739,7 @@ func TestDecode_CustomPacketDecoder(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), defaultEndpointGetter, nil, nil, nil, nil, nil, options.WithL34PacketDecoder(customDecoder{}))
 	require.NoError(t, err)
 
-	got := &flowpb.Flow{}
+	got := &ir.Flow{}
 	if err := parser.Decode(data, got); err != nil {
 		t.Fatalf("Unexpected error from Decode(data, %T): %v", got, err)
 	}

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -19,13 +19,12 @@ import (
 	"github.com/gopacket/gopacket/layers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/parser/common"
 	"github.com/cilium/cilium/pkg/hubble/parser/errors"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
@@ -101,8 +100,8 @@ func TestL34DecodeEmpty(t *testing.T) {
 	require.NoError(t, err)
 
 	var d []byte
-	f := &flowpb.Flow{}
-	err = parser.Decode(d, f)
+	var f ir.Flow
+	err = parser.Decode(d, &f)
 	assert.Equal(t, err, errors.ErrEmptyData)
 }
 
@@ -140,43 +139,43 @@ func TestL34DecodeVXLANOverlay(t *testing.T) {
 	require.NoError(t, err)
 
 	// decode the payload.
-	f := &flowpb.Flow{}
-	err = parser.Decode(payload, f)
+	var f ir.Flow
+	err = parser.Decode(payload, &f)
 	require.NoError(t, err)
 
 	// Check tunnel containing the underlay info.
-	assert.Equal(t, flowpb.Tunnel_VXLAN, f.GetTunnel().GetProtocol())
-	assert.Equal(t, uint32(2), f.GetTunnel().GetVni())
-	assert.Equal(t, "192.168.1.1", f.GetTunnel().GetIP().GetSource())
-	assert.Equal(t, "192.168.1.2", f.GetTunnel().GetIP().GetDestination())
-	assert.Equal(t, uint32(defaults.TunnelPortVXLAN), f.GetTunnel().GetL4().GetUDP().GetSourcePort())
-	assert.Equal(t, uint32(9999), f.GetTunnel().GetL4().GetUDP().GetDestinationPort())
+	assert.Equal(t, flowpb.Tunnel_VXLAN, f.Tunnel.Protocol)
+	assert.Equal(t, uint32(2), f.Tunnel.Vni)
+	assert.Equal(t, "192.168.1.1", f.Tunnel.IP.Source)
+	assert.Equal(t, "192.168.1.2", f.Tunnel.IP.Destination)
+	assert.Equal(t, uint32(defaults.TunnelPortVXLAN), f.Tunnel.L4.UDP.SourcePort)
+	assert.Equal(t, uint32(9999), f.Tunnel.L4.UDP.DestinationPort)
 	// Check l3 and l4 expecting be the overlay info.
-	assert.Equal(t, "10.1.0.1", f.GetIP().GetSource())
-	assert.Equal(t, "10.1.0.2", f.GetIP().GetDestination())
-	assert.Equal(t, uint32(54222), f.GetL4().GetTCP().GetSourcePort())
-	assert.Equal(t, uint32(8080), f.GetL4().GetTCP().GetDestinationPort())
-	assert.Equal(t, &flowpb.TCPFlags{SYN: true}, f.GetL4().GetTCP().GetFlags())
+	assert.Equal(t, "10.1.0.1", f.IP.Source)
+	assert.Equal(t, "10.1.0.2", f.IP.Destination)
+	assert.Equal(t, uint32(54222), f.L4.TCP.SourcePort)
+	assert.Equal(t, uint32(8080), f.L4.TCP.DestinationPort)
+	assert.Equal(t, ir.TCPFlags{SYN: true}, f.L4.TCP.Flags)
 
 	notunnel := slices.Clone(payload)
 	// reset the trace notification flags, i.e. clear TraceNotifyFlagIsVXLAN
 	notunnel[27] = 0
 	// decode the new payload.
-	f = &flowpb.Flow{}
-	err = parser.Decode(notunnel, f)
+	f = ir.Flow{}
+	err = parser.Decode(notunnel, &f)
 	require.NoError(t, err)
 
 	// since datapath did not inform us of any tunnel protocol, we should not
 	// have attempted to parse tunnel and overlay regardless of the packet
 	// payload received.
-	assert.Equal(t, flowpb.Tunnel_UNKNOWN, f.GetTunnel().GetProtocol())
-	assert.Empty(t, f.GetTunnel().GetIP())
-	assert.Empty(t, f.GetTunnel().GetL4())
+	assert.Equal(t, flowpb.Tunnel_UNKNOWN, f.Tunnel.Protocol)
+	assert.Empty(t, f.Tunnel.IP)
+	assert.Empty(t, f.Tunnel.L4)
 	// and the src/dst info should be the outer layers.
-	assert.Equal(t, "192.168.1.1", f.GetIP().GetSource())
-	assert.Equal(t, "192.168.1.2", f.GetIP().GetDestination())
-	assert.Equal(t, uint32(defaults.TunnelPortVXLAN), f.GetL4().GetUDP().GetSourcePort())
-	assert.Equal(t, uint32(9999), f.GetL4().GetUDP().GetDestinationPort())
+	assert.Equal(t, "192.168.1.1", f.IP.Source)
+	assert.Equal(t, "192.168.1.2", f.IP.Destination)
+	assert.Equal(t, uint32(defaults.TunnelPortVXLAN), f.L4.UDP.SourcePort)
+	assert.Equal(t, uint32(9999), f.L4.UDP.DestinationPort)
 }
 
 func TestL34DecodeGeneveOverlay(t *testing.T) {
@@ -213,43 +212,42 @@ func TestL34DecodeGeneveOverlay(t *testing.T) {
 	require.NoError(t, err)
 
 	// decode the payload.
-	f := &flowpb.Flow{}
-	err = parser.Decode(payload, f)
+	var f ir.Flow
+	err = parser.Decode(payload, &f)
 	require.NoError(t, err)
 
 	// Check tunnel containing the underlay info.
-	assert.Equal(t, flowpb.Tunnel_GENEVE, f.GetTunnel().GetProtocol())
-	assert.Equal(t, uint32(2), f.GetTunnel().GetVni())
-	assert.Equal(t, "192.168.1.1", f.GetTunnel().GetIP().GetSource())
-	assert.Equal(t, "192.168.1.2", f.GetTunnel().GetIP().GetDestination())
-	assert.Equal(t, uint32(defaults.TunnelPortGeneve), f.GetTunnel().GetL4().GetUDP().GetSourcePort())
-	assert.Equal(t, uint32(9999), f.GetTunnel().GetL4().GetUDP().GetDestinationPort())
+	assert.Equal(t, flowpb.Tunnel_GENEVE, f.Tunnel.Protocol)
+	assert.Equal(t, uint32(2), f.Tunnel.Vni)
+	assert.Equal(t, "192.168.1.1", f.Tunnel.IP.Source)
+	assert.Equal(t, "192.168.1.2", f.Tunnel.IP.Destination)
+	assert.Equal(t, uint32(defaults.TunnelPortGeneve), f.Tunnel.L4.UDP.SourcePort)
+	assert.Equal(t, uint32(9999), f.Tunnel.L4.UDP.DestinationPort)
 	// Check l3 and l4 expecting be the overlay info.
-	assert.Equal(t, "10.1.0.1", f.GetIP().GetSource())
-	assert.Equal(t, "10.1.0.2", f.GetIP().GetDestination())
-	assert.Equal(t, uint32(54222), f.GetL4().GetTCP().GetSourcePort())
-	assert.Equal(t, uint32(8080), f.GetL4().GetTCP().GetDestinationPort())
-	assert.Equal(t, &flowpb.TCPFlags{SYN: true}, f.GetL4().GetTCP().GetFlags())
-
+	assert.Equal(t, "10.1.0.1", f.IP.Source)
+	assert.Equal(t, "10.1.0.2", f.IP.Destination)
+	assert.Equal(t, uint32(54222), f.L4.TCP.SourcePort)
+	assert.Equal(t, uint32(8080), f.L4.TCP.DestinationPort)
+	assert.Equal(t, ir.TCPFlags{SYN: true}, f.L4.TCP.Flags)
 	notunnel := slices.Clone(payload)
 	// reset the trace notification flags, i.e. clear TraceNotifyFlagIsGeneve
 	notunnel[27] = 0
 	// decode the new payload.
-	f = &flowpb.Flow{}
-	err = parser.Decode(notunnel, f)
+	f = ir.Flow{}
+	err = parser.Decode(notunnel, &f)
 	require.NoError(t, err)
 
 	// since datapath did not inform us of any tunnel protocol, we should not
 	// have attempted to parse tunnel and overlay regardless of the packet
 	// payload received.
-	assert.Equal(t, flowpb.Tunnel_UNKNOWN, f.GetTunnel().GetProtocol())
-	assert.Empty(t, f.GetTunnel().GetIP())
-	assert.Empty(t, f.GetTunnel().GetL4())
+	assert.Equal(t, flowpb.Tunnel_UNKNOWN, f.Tunnel.Protocol)
+	assert.Empty(t, f.Tunnel.IP)
+	assert.Empty(t, f.Tunnel.L4)
 	// and the src/dst info should be the outer layers.
-	assert.Equal(t, "192.168.1.1", f.GetIP().GetSource())
-	assert.Equal(t, "192.168.1.2", f.GetIP().GetDestination())
-	assert.Equal(t, uint32(defaults.TunnelPortGeneve), f.GetL4().GetUDP().GetSourcePort())
-	assert.Equal(t, uint32(9999), f.GetL4().GetUDP().GetDestinationPort())
+	assert.Equal(t, "192.168.1.1", f.IP.Source)
+	assert.Equal(t, "192.168.1.2", f.IP.Destination)
+	assert.Equal(t, uint32(defaults.TunnelPortGeneve), f.L4.UDP.SourcePort)
+	assert.Equal(t, uint32(9999), f.L4.UDP.DestinationPort)
 }
 
 func BenchmarkL34DecodeOverlay(b *testing.B) {
@@ -270,11 +268,11 @@ func BenchmarkL34DecodeOverlay(b *testing.B) {
 	parser, err := New(hivetest.Logger(b), endpointGetter, identityCache, dnsGetter, ipGetter, serviceGetter, &testutils.NoopLinkGetter)
 	require.NoError(b, err)
 
-	f := &flowpb.Flow{}
+	var f ir.Flow
+	b.ResetTimer()
 	b.ReportAllocs()
-
 	for b.Loop() {
-		_ = parser.Decode(d, f)
+		_ = parser.Decode(d, &f)
 	}
 }
 
@@ -353,61 +351,55 @@ func TestL34Decode(t *testing.T) {
 		},
 	}
 	serviceGetter := &testutils.FakeServiceGetter{
-		OnGetServiceByAddr: func(ip netip.Addr, port uint16) *flowpb.Service {
+		OnGetServiceByAddr: func(ip netip.Addr, port uint16) getters.FQN {
 			if ip == netip.MustParseAddr("192.168.60.11") && (port == 6443) {
-				return &flowpb.Service{
-					Name:      "service-1234",
-					Namespace: "remote",
-				}
+				return getters.NewFQN("remote", "service-1234")
 			}
 			if ip == netip.MustParseAddr("10.16.236.178") && (port == 54222) {
-				return &flowpb.Service{
-					Name:      "service-4321",
-					Namespace: "default",
-				}
+				return getters.NewFQN("default", "service-4321")
 			}
-			return nil
+			return getters.BlankFQN
 		},
 	}
 	identityCache := &testutils.NoopIdentityGetter
 	parser, err := New(hivetest.Logger(t), endpointGetter, identityCache, dnsGetter, ipGetter, serviceGetter, &testutils.NoopLinkGetter)
 	require.NoError(t, err)
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(d, f)
+	var f ir.Flow
+	err = parser.Decode(d, &f)
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"host-192.168.60.11"}, f.GetSourceNames())
-	assert.Equal(t, "192.168.60.11", f.GetIP().GetSource())
-	assert.Empty(t, f.GetIP().GetSourceXlated())
-	assert.Equal(t, flowpb.TraceReason_ESTABLISHED, f.GetTraceReason())
-	assert.True(t, f.GetIP().GetEncrypted())
-	assert.Equal(t, uint32(6443), f.L4.GetTCP().GetSourcePort())
-	assert.Equal(t, "pod-192.168.60.11", f.GetSource().GetPodName())
-	assert.Equal(t, "remote", f.GetSource().GetNamespace())
-	assert.Equal(t, "service-1234", f.GetSourceService().GetName())
-	assert.Equal(t, "remote", f.GetSourceService().GetNamespace())
-	assert.Equal(t, uint32(1), f.GetSource().GetIdentity())
+	assert.Equal(t, []string{"host-192.168.60.11"}, f.SourceNames)
+	assert.Equal(t, "192.168.60.11", f.IP.Source)
+	assert.Empty(t, f.IP.SourceXlated)
+	assert.Equal(t, flowpb.TraceReason_ESTABLISHED, f.TraceReason)
+	assert.True(t, f.IP.Encrypted)
+	assert.Equal(t, uint32(6443), f.L4.TCP.SourcePort)
+	assert.Equal(t, "pod-192.168.60.11", f.Source.PodName)
+	assert.Equal(t, "remote", f.Source.Namespace)
+	assert.Equal(t, "service-1234", f.SourceService.Name)
+	assert.Equal(t, "remote", f.SourceService.Namespace)
+	assert.Equal(t, uint32(1), f.Source.Identity)
 
-	assert.Equal(t, []string(nil), f.GetDestinationNames())
-	assert.Equal(t, "10.16.236.178", f.GetIP().GetDestination())
-	assert.Equal(t, uint32(54222), f.L4.GetTCP().GetDestinationPort())
-	assert.Equal(t, "pod-10.16.236.178", f.GetDestination().GetPodName())
-	assert.Equal(t, "default", f.GetDestination().GetNamespace())
-	assert.Equal(t, "service-4321", f.GetDestinationService().GetName())
-	assert.Equal(t, "default", f.GetDestinationService().GetNamespace())
-	assert.Equal(t, uint32(5678), f.GetDestination().GetIdentity())
+	assert.Equal(t, []string(nil), f.DestinationNames)
+	assert.Equal(t, "10.16.236.178", f.IP.Destination)
+	assert.Equal(t, uint32(54222), f.L4.TCP.DestinationPort)
+	assert.Equal(t, "pod-10.16.236.178", f.Destination.PodName)
+	assert.Equal(t, "default", f.Destination.Namespace)
+	assert.Equal(t, "service-4321", f.DestinationService.Name)
+	assert.Equal(t, "default", f.DestinationService.Namespace)
+	assert.Equal(t, uint32(5678), f.Destination.Identity)
 
-	assert.Equal(t, int32(monitorAPI.MessageTypeTrace), f.GetEventType().GetType())
-	assert.Equal(t, int32(monitorAPI.TraceFromHost), f.GetEventType().GetSubType())
-	assert.Equal(t, flowpb.Verdict_FORWARDED, f.GetVerdict())
-	assert.Equal(t, &flowpb.TCPFlags{ACK: true}, f.L4.GetTCP().GetFlags())
+	assert.Equal(t, int32(monitorAPI.MessageTypeTrace), f.EventType.Type)
+	assert.Equal(t, int32(monitorAPI.TraceFromHost), f.EventType.SubType)
+	assert.Equal(t, flowpb.Verdict_FORWARDED, f.Verdict)
+	assert.Equal(t, ir.TCPFlags{ACK: true}, f.L4.TCP.Flags)
 
-	assert.Equal(t, flowpb.TraceObservationPoint_FROM_HOST, f.GetTraceObservationPoint())
+	assert.Equal(t, flowpb.TraceObservationPoint_FROM_HOST, f.TraceObservationPoint)
 
 	nilParser, err := New(hivetest.Logger(t), nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
-	err = nilParser.Decode(d, f)
+	err = nilParser.Decode(d, &f)
 	require.NoError(t, err)
 
 	// ICMP packet so no ports until that support is merged into master
@@ -450,30 +442,31 @@ func TestL34Decode(t *testing.T) {
 	parser, err = New(hivetest.Logger(t), endpointGetter, identityCache, dnsGetter, ipGetter, serviceGetter, &testutils.NoopLinkGetter)
 	require.NoError(t, err)
 
-	err = parser.Decode(d2, f)
+	f = ir.Flow{}
+	err = parser.Decode(d2, &f)
 	require.NoError(t, err)
 
 	// second packet is ICMPv6 and the flags should be totally wiped out
-	assert.Equal(t, []string(nil), f.GetSourceNames())
-	assert.Equal(t, "ff02::1:ff00:b3e5", f.GetIP().GetSource())
-	assert.Empty(t, f.GetIP().GetSourceXlated())
-	assert.Equal(t, &flowpb.ICMPv6{Type: 135}, f.L4.GetICMPv6())
-	assert.Empty(t, f.GetSource().GetPodName())
-	assert.Empty(t, f.GetSource().GetNamespace())
+	assert.Equal(t, []string(nil), f.SourceNames)
+	assert.Equal(t, "ff02::1:ff00:b3e5", f.IP.Source)
+	assert.Empty(t, f.IP.SourceXlated)
+	assert.Equal(t, ir.ICMP{Type: 135}, f.L4.ICMPv6)
+	assert.Empty(t, f.Source.PodName)
+	assert.Empty(t, f.Source.Namespace)
 
-	assert.Equal(t, []string{"host-f00d::a10:0:0:9195"}, f.GetDestinationNames())
-	assert.Equal(t, "f00d::a10:0:0:9195", f.GetIP().GetDestination())
-	assert.Empty(t, f.GetDestination().GetPodName())
-	assert.Empty(t, f.GetDestination().GetNamespace())
+	assert.Equal(t, []string{"host-f00d::a10:0:0:9195"}, f.DestinationNames)
+	assert.Equal(t, "f00d::a10:0:0:9195", f.IP.Destination)
+	assert.Empty(t, f.Destination.PodName)
+	assert.Empty(t, f.Destination.Namespace)
 
-	assert.Equal(t, int32(monitorAPI.MessageTypeTrace), f.GetEventType().GetType())
-	assert.Equal(t, int32(monitorAPI.TraceFromLxc), f.GetEventType().GetSubType())
-	assert.Equal(t, flowpb.Verdict_FORWARDED, f.GetVerdict())
-	assert.Equal(t, (*flowpb.TCPFlags)(nil), f.L4.GetTCP().GetFlags())
+	assert.Equal(t, int32(monitorAPI.MessageTypeTrace), f.EventType.Type)
+	assert.Equal(t, int32(monitorAPI.TraceFromLxc), f.EventType.SubType)
+	assert.Equal(t, flowpb.Verdict_FORWARDED, f.Verdict)
+	assert.Equal(t, ir.TCPFlags{}, f.L4.TCP.Flags)
 
-	assert.Equal(t, flowpb.TraceObservationPoint_FROM_ENDPOINT, f.GetTraceObservationPoint())
+	assert.Equal(t, flowpb.TraceObservationPoint_FROM_ENDPOINT, f.TraceObservationPoint)
 
-	err = nilParser.Decode(d, f)
+	err = nilParser.Decode(d, &f)
 	require.NoError(t, err)
 }
 
@@ -493,11 +486,11 @@ func BenchmarkL34Decode(b *testing.B) {
 	parser, err := New(hivetest.Logger(b), endpointGetter, identityCache, dnsGetter, ipGetter, serviceGetter, &testutils.NoopLinkGetter)
 	require.NoError(b, err)
 
-	f := &flowpb.Flow{}
+	var f ir.Flow
 	b.ReportAllocs()
-
+	b.ResetTimer()
 	for b.Loop() {
-		_ = parser.Decode(d, f)
+		_ = parser.Decode(d, &f)
 	}
 }
 
@@ -571,15 +564,15 @@ func TestDecodeTraceNotify(t *testing.T) {
 			parser, err := New(hivetest.Logger(t), &testutils.NoopEndpointGetter, identityGetter, &testutils.NoopDNSGetter, &testutils.NoopIPGetter, &testutils.NoopServiceGetter, &testutils.NoopLinkGetter)
 			require.NoError(t, err)
 
-			f := &flowpb.Flow{}
-			err = parser.Decode(buf.Bytes(), f)
+			var f ir.Flow
+			err = parser.Decode(buf.Bytes(), &f)
 			require.NoError(t, err)
-			assert.Equal(t, []string{"k8s:io.cilium.k8s.policy.cluster=cluster-name", "k8s:src=label"}, f.GetSource().GetLabels())
-			assert.Equal(t, []string{"k8s:dst=label", "k8s:io.cilium.k8s.policy.cluster=cluster-name"}, f.GetDestination().GetLabels())
-			assert.Equal(t, "cluster-name", f.GetSource().GetClusterName())
-			assert.Equal(t, "cluster-name", f.GetDestination().GetClusterName())
-			assert.Equal(t, uint32(23939), f.GetL4().GetUDP().GetSourcePort())
-			assert.Equal(t, uint32(32412), f.GetL4().GetUDP().GetDestinationPort())
+			assert.Equal(t, []string{"k8s:io.cilium.k8s.policy.cluster=cluster-name", "k8s:src=label"}, f.Source.Labels)
+			assert.Equal(t, []string{"k8s:dst=label", "k8s:io.cilium.k8s.policy.cluster=cluster-name"}, f.Destination.Labels)
+			assert.Equal(t, "cluster-name", f.Source.ClusterName)
+			assert.Equal(t, "cluster-name", f.Destination.ClusterName)
+			assert.Equal(t, uint32(23939), f.L4.UDP.SourcePort)
+			assert.Equal(t, uint32(32412), f.L4.UDP.DestinationPort)
 		})
 	}
 }
@@ -641,43 +634,48 @@ func TestDecodeDropNotify(t *testing.T) {
 		},
 	}
 
+	m1, err := net.ParseMAC("01:02:03:04:05:06")
+	require.NoError(t, err)
+	m2, err := net.ParseMAC("04:05:06:07:08:09")
+	require.NoError(t, err)
+
 	testCases := []struct {
 		name      string
 		dn        any
 		srcLabels []string
 		dstLabels []string
-		want      *flowpb.Flow
+		want      ir.Flow
 	}{
 		{
 			name:      "v3",
 			dn:        dropNotify(3),
 			srcLabels: []string{"k8s:src=label"},
 			dstLabels: []string{"k8s:dst=label"},
-			want: &flowpb.Flow{
+			want: ir.Flow{
 				Verdict: flowpb.Verdict_DROPPED,
-				Ethernet: &flowpb.Ethernet{
-					Source:      "01:02:03:04:05:06",
-					Destination: "04:05:06:07:08:09",
+				Ethernet: ir.Ethernet{
+					Source:      m1,
+					Destination: m2,
 				},
-				IP: &flowpb.IP{
+				IP: ir.IP{
 					Source:      "1.2.3.4",
 					Destination: "1.2.3.4",
-					IpVersion:   flowpb.IPVersion_IPv4,
+					IPVersion:   flowpb.IPVersion_IPv4,
 				},
-				Source: &flowpb.Endpoint{
+				Source: ir.Endpoint{
 					Identity: 123,
 					Labels:   []string{"k8s:src=label"},
 				},
-				Destination: &flowpb.Endpoint{
+				Destination: ir.Endpoint{
 					Identity: 456,
 					Labels:   []string{"k8s:dst=label"},
 				},
 				Type: flowpb.FlowType_L3_L4,
-				EventType: &flowpb.CiliumEventType{
+				EventType: ir.CiliumEventType{
 					Type: 1,
 				},
 				Summary: "IPv4",
-				File:    &flowpb.FileInfo{Name: "bpf_host.c"},
+				File:    ir.FileInfo{Name: "bpf_host.c"},
 			},
 		},
 		{
@@ -685,29 +683,29 @@ func TestDecodeDropNotify(t *testing.T) {
 			dn:        dropNotifyWithReason(3, 132 /* Invalid source ip */, 7),
 			srcLabels: []string{"k8s:src=label"},
 			dstLabels: []string{"k8s:dst=label"},
-			want: &flowpb.Flow{
+			want: ir.Flow{
 				Verdict: flowpb.Verdict_DROPPED,
-				Ethernet: &flowpb.Ethernet{
-					Source:      "01:02:03:04:05:06",
-					Destination: "04:05:06:07:08:09",
+				Ethernet: ir.Ethernet{
+					Source:      m1,
+					Destination: m2,
 				},
-				IP: &flowpb.IP{
+				IP: ir.IP{
 					Source:      "1.2.3.4",
 					Destination: "1.2.3.4",
-					IpVersion:   flowpb.IPVersion_IPv4,
+					IPVersion:   flowpb.IPVersion_IPv4,
 				},
-				Source: &flowpb.Endpoint{
+				Source: ir.Endpoint{
 					Identity: 123,
 					Labels:   []string{"k8s:src=label"},
 				},
-				Destination: &flowpb.Endpoint{
+				Destination: ir.Endpoint{
 					Identity: 456,
 					Labels:   []string{"k8s:dst=label"},
 				},
 				Type:              flowpb.FlowType_L3_L4,
-				EventType:         &flowpb.CiliumEventType{Type: 1, SubType: 132},
+				EventType:         ir.CiliumEventType{Type: 1, SubType: 132},
 				Summary:           "IPv4",
-				File:              &flowpb.FileInfo{Name: "bpf_host.c"},
+				File:              ir.FileInfo{Name: "bpf_host.c"},
 				DropReason:        132,
 				DropReasonDesc:    flowpb.DropReason_INVALID_SOURCE_IP,
 				ExtError:          7,
@@ -719,29 +717,29 @@ func TestDecodeDropNotify(t *testing.T) {
 			dn:        dropNotifyWithReason(3, 169 /* FIB lookup failed */, 0),
 			srcLabels: []string{"k8s:src=label"},
 			dstLabels: []string{"k8s:dst=label"},
-			want: &flowpb.Flow{
+			want: ir.Flow{
 				Verdict: flowpb.Verdict_DROPPED,
-				Ethernet: &flowpb.Ethernet{
-					Source:      "01:02:03:04:05:06",
-					Destination: "04:05:06:07:08:09",
+				Ethernet: ir.Ethernet{
+					Source:      m1,
+					Destination: m2,
 				},
-				IP: &flowpb.IP{
+				IP: ir.IP{
 					Source:      "1.2.3.4",
 					Destination: "1.2.3.4",
-					IpVersion:   flowpb.IPVersion_IPv4,
+					IPVersion:   flowpb.IPVersion_IPv4,
 				},
-				Source: &flowpb.Endpoint{
+				Source: ir.Endpoint{
 					Identity: 123,
 					Labels:   []string{"k8s:src=label"},
 				},
-				Destination: &flowpb.Endpoint{
+				Destination: ir.Endpoint{
 					Identity: 456,
 					Labels:   []string{"k8s:dst=label"},
 				},
 				Type:              flowpb.FlowType_L3_L4,
-				EventType:         &flowpb.CiliumEventType{Type: 1, SubType: 169},
+				EventType:         ir.CiliumEventType{Type: 1, SubType: 169},
 				Summary:           "IPv4",
-				File:              &flowpb.FileInfo{Name: "bpf_host.c"},
+				File:              ir.FileInfo{Name: "bpf_host.c"},
 				DropReason:        169,
 				DropReasonDesc:    flowpb.DropReason_FIB_LOOKUP_FAILED,
 				ExtDropReasonDesc: "FIB lookup failed",
@@ -752,31 +750,31 @@ func TestDecodeDropNotify(t *testing.T) {
 			dn:        dropNotify(3, 0x12345678),
 			srcLabels: []string{"k8s:src=label"},
 			dstLabels: []string{"k8s:dst=label"},
-			want: &flowpb.Flow{
+			want: ir.Flow{
 				Verdict: flowpb.Verdict_DROPPED,
-				Ethernet: &flowpb.Ethernet{
-					Source:      "01:02:03:04:05:06",
-					Destination: "04:05:06:07:08:09",
+				Ethernet: ir.Ethernet{
+					Source:      m1,
+					Destination: m2,
 				},
-				IP: &flowpb.IP{
+				IP: ir.IP{
 					Source:      "1.2.3.4",
 					Destination: "1.2.3.4",
-					IpVersion:   flowpb.IPVersion_IPv4,
+					IPVersion:   flowpb.IPVersion_IPv4,
 				},
-				Source: &flowpb.Endpoint{
+				Source: ir.Endpoint{
 					Identity: 123,
 					Labels:   []string{"k8s:src=label"},
 				},
-				Destination: &flowpb.Endpoint{
+				Destination: ir.Endpoint{
 					Identity: 456,
 					Labels:   []string{"k8s:dst=label"},
 				},
 				Type:      flowpb.FlowType_L3_L4,
-				EventType: &flowpb.CiliumEventType{Type: 1},
+				EventType: ir.CiliumEventType{Type: 1},
 				Summary:   "IPv4",
-				File:      &flowpb.FileInfo{Name: "bpf_host.c"},
-				IpTraceId: &flowpb.IPTraceID{
-					TraceId: 0x12345678,
+				File:      ir.FileInfo{Name: "bpf_host.c"},
+				IPTraceID: ir.IPTraceID{
+					TraceID: 0x12345678,
 				},
 			},
 		},
@@ -795,8 +793,8 @@ func TestDecodeDropNotify(t *testing.T) {
 				t.Fatalf("New parser: %v", err)
 			}
 
-			f := &flowpb.Flow{}
-			if err := parser.Decode(buf.Bytes(), f); err != nil {
+			var f ir.Flow
+			if err := parser.Decode(buf.Bytes(), &f); err != nil {
 				t.Fatalf("parser.Decode(bytes, f): %v", err)
 			}
 
@@ -884,17 +882,17 @@ func TestDecodePolicyVerdictNotify(t *testing.T) {
 	data, err := testutils.CreateL3L4Payload(pvn, &eth, &ip, &tcp)
 	require.NoError(t, err)
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(data, f)
+	var f ir.Flow
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 
-	assert.Equal(t, int32(monitorAPI.MessageTypePolicyVerdict), f.GetEventType().GetType())
-	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(monitorAPI.PolicyMatchL3L4), f.GetPolicyMatchType())
-	assert.Equal(t, flowpb.Verdict_FORWARDED, f.GetVerdict())
-	assert.Equal(t, []string{"k8s:dst=label"}, f.GetDestination().GetLabels())
+	assert.Equal(t, int32(monitorAPI.MessageTypePolicyVerdict), f.EventType.Type)
+	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(monitorAPI.PolicyMatchL3L4), f.PolicyMatchType)
+	assert.Equal(t, flowpb.Verdict_FORWARDED, f.Verdict)
+	assert.Equal(t, []string{"k8s:dst=label"}, f.Destination.Labels)
 
-	expectedPolicy := []*flowpb.Policy{
+	expectedPolicy := []ir.Policy{
 		{
 			Name:      "web-policy",
 			Namespace: "foo-namespace",
@@ -908,7 +906,7 @@ func TestDecodePolicyVerdictNotify(t *testing.T) {
 			Revision: 1,
 		},
 	}
-	if diff := cmp.Diff(expectedPolicy, f.GetEgressAllowedBy(), protocmp.Transform()); diff != "" {
+	if diff := cmp.Diff(expectedPolicy, f.EgressAllowedBy, protocmp.Transform()); diff != "" {
 		t.Errorf("not equal (-want +got):\n%s", diff)
 	}
 
@@ -924,16 +922,16 @@ func TestDecodePolicyVerdictNotify(t *testing.T) {
 	data, err = testutils.CreateL3L4Payload(pvn)
 	require.NoError(t, err)
 
-	f.Reset()
-	err = parser.Decode(data, f)
+	f = ir.Flow{}
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 
-	assert.Equal(t, int32(monitorAPI.MessageTypePolicyVerdict), f.GetEventType().GetType())
-	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(151), f.GetDropReason())
-	assert.Equal(t, flowpb.DropReason(151), f.GetDropReasonDesc())
-	assert.Equal(t, flowpb.Verdict_DROPPED, f.GetVerdict())
-	assert.Equal(t, []string{"k8s:dst=label"}, f.GetSource().GetLabels())
+	assert.Equal(t, int32(monitorAPI.MessageTypePolicyVerdict), f.EventType.Type)
+	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(151), f.DropReason)
+	assert.Equal(t, flowpb.DropReason(151), f.DropReasonDesc)
+	assert.Equal(t, flowpb.Verdict_DROPPED, f.Verdict)
+	assert.Equal(t, []string{"k8s:dst=label"}, f.Source.Labels)
 }
 
 func TestNetworkPolicyCorrelationDisabled(t *testing.T) {
@@ -1015,16 +1013,16 @@ func TestNetworkPolicyCorrelationDisabled(t *testing.T) {
 
 	require.NoError(t, err)
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(data, f)
+	var f ir.Flow
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 
-	assert.Equal(t, int32(monitorAPI.MessageTypePolicyVerdict), f.GetEventType().GetType())
-	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(monitorAPI.PolicyMatchL3L4), f.GetPolicyMatchType())
-	assert.Equal(t, flowpb.Verdict_FORWARDED, f.GetVerdict())
-	assert.Equal(t, []string{"k8s:dst=label"}, f.GetDestination().GetLabels())
-	assert.Equal(t, []*flowpb.Policy([]*flowpb.Policy(nil)), f.GetEgressAllowedBy())
+	assert.Equal(t, int32(monitorAPI.MessageTypePolicyVerdict), f.EventType.Type)
+	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(monitorAPI.PolicyMatchL3L4), f.PolicyMatchType)
+	assert.Equal(t, flowpb.Verdict_FORWARDED, f.Verdict)
+	assert.Equal(t, []string{"k8s:dst=label"}, f.Destination.Labels)
+	assert.Equal(t, []ir.Policy([]ir.Policy(nil)), f.EgressAllowedBy)
 
 	// PolicyVerdictNotify for forwarded ingress flow
 	flags = monitorAPI.PolicyIngress
@@ -1040,16 +1038,16 @@ func TestNetworkPolicyCorrelationDisabled(t *testing.T) {
 	data, err = testutils.CreateL3L4Payload(pvn)
 	require.NoError(t, err)
 
-	f.Reset()
-	err = parser.Decode(data, f)
+	f = ir.Flow{}
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 
-	assert.Equal(t, int32(monitorAPI.MessageTypePolicyVerdict), f.GetEventType().GetType())
-	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(monitorAPI.PolicyMatchL3L4), f.GetPolicyMatchType())
-	assert.Equal(t, flowpb.Verdict_FORWARDED, f.GetVerdict())
-	assert.Equal(t, []string{"k8s:dst=label"}, f.GetSource().GetLabels())
-	assert.Equal(t, []*flowpb.Policy([]*flowpb.Policy(nil)), f.GetIngressAllowedBy())
+	assert.Equal(t, int32(monitorAPI.MessageTypePolicyVerdict), f.EventType.Type)
+	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(monitorAPI.PolicyMatchL3L4), f.PolicyMatchType)
+	assert.Equal(t, flowpb.Verdict_FORWARDED, f.Verdict)
+	assert.Equal(t, []string{"k8s:dst=label"}, f.Source.Labels)
+	assert.Equal(t, []ir.Policy([]ir.Policy(nil)), f.IngressAllowedBy)
 }
 
 func TestDecodeDropReason(t *testing.T) {
@@ -1065,18 +1063,18 @@ func TestDecodeDropReason(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(data, f)
+	var f ir.Flow
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 
-	assert.Equal(t, uint32(reason), f.GetDropReason())
-	assert.Equal(t, flowpb.DropReason(reason), f.GetDropReasonDesc())
+	assert.Equal(t, uint32(reason), f.DropReason)
+	assert.Equal(t, flowpb.DropReason(reason), f.DropReasonDesc)
 }
 
 func TestDecodeTraceReason(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
-	parseFlow := func(event any, srcIPv4, dstIPv4 string) *flowpb.Flow {
+	parseFlow := func(event any, srcIPv4, dstIPv4 string) *ir.Flow {
 		data, err := testutils.CreateL3L4Payload(event,
 			&layers.Ethernet{
 				SrcMAC:       net.HardwareAddr{1, 2, 3, 4, 5, 6},
@@ -1085,10 +1083,10 @@ func TestDecodeTraceReason(t *testing.T) {
 			},
 			&layers.IPv4{SrcIP: net.ParseIP(srcIPv4), DstIP: net.ParseIP(dstIPv4)})
 		require.NoError(t, err)
-		f := &flowpb.Flow{}
-		err = parser.Decode(data, f)
+		var f ir.Flow
+		err = parser.Decode(data, &f)
 		require.NoError(t, err)
-		return f
+		return &f
 	}
 
 	var tt = []struct {
@@ -1140,8 +1138,8 @@ func TestDecodeTraceReason(t *testing.T) {
 				Reason: tc.reason,
 			}
 			f := parseFlow(tn, "1.2.3.4", "5.6.7.8")
-			assert.Equal(t, tc.want, f.GetTraceReason())
-			assert.False(t, f.GetIP().GetEncrypted())
+			assert.Equal(t, tc.want, f.TraceReason)
+			assert.False(t, f.IP.Encrypted)
 		})
 		t.Run(tc.name+" encrypted", func(t *testing.T) {
 			tn := monitor.TraceNotify{
@@ -1149,8 +1147,8 @@ func TestDecodeTraceReason(t *testing.T) {
 				Reason: tc.reason | monitor.TraceReasonEncryptMask,
 			}
 			f := parseFlow(tn, "1.2.3.4", "5.6.7.8")
-			assert.Equal(t, tc.want, f.GetTraceReason())
-			assert.True(t, f.GetIP().GetEncrypted())
+			assert.Equal(t, tc.want, f.TraceReason)
+			assert.True(t, f.IP.Encrypted)
 		})
 	}
 }
@@ -1172,12 +1170,12 @@ func TestDecodeLocalIdentity(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), nil, identityGetter, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	f := &flowpb.Flow{}
-	err = parser.Decode(data, f)
+	var f ir.Flow
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"cidr:1.2.3.4/12", "unspec:some=label"}, f.GetSource().GetLabels())
-	assert.Equal(t, []string{"cidr:1.2.3.4/12", "unspec:some=label"}, f.GetDestination().GetLabels())
+	assert.Equal(t, []string{"cidr:1.2.3.4/12", "unspec:some=label"}, f.Source.Labels)
+	assert.Equal(t, []string{"cidr:1.2.3.4/12", "unspec:some=label"}, f.Destination.Labels)
 }
 
 func TestDecodeTrafficDirection(t *testing.T) {
@@ -1206,7 +1204,7 @@ func TestDecodeTrafficDirection(t *testing.T) {
 
 	parser, err := New(hivetest.Logger(t), endpointGetter, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
-	parseFlow := func(event any, srcIPv4, dstIPv4 netip.Addr) *flowpb.Flow {
+	parseFlow := func(event any, srcIPv4, dstIPv4 netip.Addr) *ir.Flow {
 		data, err := testutils.CreateL3L4Payload(event,
 			&layers.Ethernet{
 				SrcMAC:       net.HardwareAddr{1, 2, 3, 4, 5, 6},
@@ -1215,10 +1213,10 @@ func TestDecodeTrafficDirection(t *testing.T) {
 			},
 			&layers.IPv4{SrcIP: srcIPv4.AsSlice(), DstIP: dstIPv4.AsSlice()})
 		require.NoError(t, err)
-		f := &flowpb.Flow{}
-		err = parser.Decode(data, f)
+		var f ir.Flow
+		err = parser.Decode(data, &f)
 		require.NoError(t, err)
-		return f
+		return &f
 	}
 
 	// DROP at unknown endpoint
@@ -1227,8 +1225,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		Version: monitor.DropNotifyVersion2,
 	}
 	f := parseFlow(dn, localIP, remoteIP)
-	assert.Equal(t, flowpb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Source.ID)
 
 	// DROP Egress
 	dn = monitor.DropNotify{
@@ -1237,8 +1235,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		Version: monitor.DropNotifyVersion2,
 	}
 	f = parseFlow(dn, localIP, remoteIP)
-	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Source.ID)
 
 	// DROP Ingress
 	dn = monitor.DropNotify{
@@ -1247,8 +1245,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		Version: monitor.DropNotifyVersion2,
 	}
 	f = parseFlow(dn, remoteIP, localIP)
-	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetDestination().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Destination.ID)
 
 	// TRACE_TO_LXC at unknown endpoint
 	tn := monitor.TraceNotify{
@@ -1256,8 +1254,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		ObsPoint: monitorAPI.TraceToLxc,
 	}
 	f = parseFlow(tn, localIP, remoteIP)
-	assert.Equal(t, flowpb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Source.ID)
 
 	// TRACE_TO_LXC Egress
 	tn = monitor.TraceNotify{
@@ -1266,8 +1264,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		ObsPoint: monitorAPI.TraceToLxc,
 	}
 	f = parseFlow(tn, localIP, remoteIP)
-	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Source.ID)
 
 	// TO_NETWORK Egress (SNAT)
 	tnv1 := monitor.TraceNotify{
@@ -1278,8 +1276,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		OrigIP:   types.IPv6{1, 2, 3, 4}, // localIP
 	}
 	f = parseFlow(tnv1, netip.MustParseAddr("10.11.12.13"), remoteIP)
-	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Source.ID)
 
 	// TRACE_TO_LXC Egress, reversed by CT_REPLY
 	tn = monitor.TraceNotify{
@@ -1289,8 +1287,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		Reason:   monitor.TraceReasonCtReply,
 	}
 	f = parseFlow(tn, localIP, remoteIP)
-	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Source.ID)
 
 	// TRACE_TO_HOST Ingress
 	tn = monitor.TraceNotify{
@@ -1299,8 +1297,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		ObsPoint: monitorAPI.TraceToHost,
 	}
 	f = parseFlow(tn, remoteIP, localIP)
-	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetDestination().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Destination.ID)
 
 	// TRACE_TO_HOST Ingress, reversed by CT_REPLY
 	tn = monitor.TraceNotify{
@@ -1310,8 +1308,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		Reason:   monitor.TraceReasonCtReply,
 	}
 	f = parseFlow(tn, remoteIP, localIP)
-	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetDestination().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Destination.ID)
 
 	// TRACE_FROM_LXC unknown
 	tn = monitor.TraceNotify{
@@ -1321,8 +1319,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		Reason:   monitor.TraceReasonUnknown,
 	}
 	f = parseFlow(tn, localIP, remoteIP)
-	assert.Equal(t, flowpb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Source.ID)
 
 	// TRACE_FROM_LXC unknown (encrypted)
 	tn = monitor.TraceNotify{
@@ -1332,8 +1330,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		Reason:   monitor.TraceReasonUnknown | monitor.TraceReasonEncryptMask,
 	}
 	f = parseFlow(tn, localIP, remoteIP)
-	assert.Equal(t, flowpb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Source.ID)
 
 	// TRACE_TO_STACK SRV6 decap Ingress
 	tn = monitor.TraceNotify{
@@ -1343,8 +1341,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		Reason:   monitor.TraceReasonSRv6Decap,
 	}
 	f = parseFlow(tn, remoteIP, localIP)
-	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetDestination().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Destination.ID)
 
 	// TRACE_TO_STACK SRV6 encap Egress
 	tn = monitor.TraceNotify{
@@ -1354,8 +1352,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		Reason:   monitor.TraceReasonSRv6Encap,
 	}
 	f = parseFlow(tn, localIP, remoteIP)
-	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Source.ID)
 
 	// PolicyVerdictNotify Egress
 	pvn := monitor.PolicyVerdictNotify{
@@ -1365,14 +1363,14 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		RemoteLabel: remoteID,
 	}
 	f = parseFlow(pvn, localIP, remoteIP)
-	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetSource().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_EGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Source.ID)
 
 	ep, ok := endpointGetter.GetEndpointInfo(localIP)
 	assert.True(t, ok)
 	info, ok := ep.GetPolicyCorrelationInfoForKey(
-		policy.KeyForDirection(directionFromProto(f.GetTrafficDirection())).
-			WithIdentity(identity.NumericIdentity(f.GetDestination().GetIdentity())))
+		policy.KeyForDirection(directionFromProto(f.TrafficDirection)).
+			WithIdentity(identity.NumericIdentity(f.Destination.Identity)))
 	assert.True(t, ok)
 	lbls := labels.LabelArrayListFromString(info.RuleLabels)
 	assert.Equal(t, lbls, policyLabel)
@@ -1385,8 +1383,8 @@ func TestDecodeTrafficDirection(t *testing.T) {
 		Flags:  monitorAPI.PolicyIngress,
 	}
 	f = parseFlow(pvn, remoteIP, localIP)
-	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.GetTrafficDirection())
-	assert.Equal(t, uint32(localEP), f.GetDestination().GetID())
+	assert.Equal(t, flowpb.TrafficDirection_INGRESS, f.TrafficDirection)
+	assert.Equal(t, uint32(localEP), f.Destination.ID)
 }
 
 func TestDecodeIsReply(t *testing.T) {
@@ -1397,7 +1395,7 @@ func TestDecodeIsReply(t *testing.T) {
 
 	parser, err := New(hivetest.Logger(t), nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
-	parseFlow := func(event any, srcIPv4, dstIPv4 net.IP) *flowpb.Flow {
+	parseFlow := func(event any, srcIPv4, dstIPv4 net.IP) *ir.Flow {
 		data, err := testutils.CreateL3L4Payload(event,
 			&layers.Ethernet{
 				SrcMAC:       net.HardwareAddr{1, 2, 3, 4, 5, 6},
@@ -1406,10 +1404,10 @@ func TestDecodeIsReply(t *testing.T) {
 			},
 			&layers.IPv4{SrcIP: srcIPv4, DstIP: dstIPv4})
 		require.NoError(t, err)
-		f := &flowpb.Flow{}
-		err = parser.Decode(data, f)
+		var f ir.Flow
+		err = parser.Decode(data, &f)
 		require.NoError(t, err)
-		return f
+		return &f
 	}
 
 	// TRACE_TO_LXC
@@ -1419,9 +1417,7 @@ func TestDecodeIsReply(t *testing.T) {
 		Reason:   monitor.TraceReasonCtReply,
 	}
 	f := parseFlow(tn, localIP, remoteIP)
-	assert.NotNil(t, f.GetIsReply())
-	assert.True(t, f.GetIsReply().GetValue())
-	assert.True(t, f.GetReply())
+	assert.True(t, f.IsReply())
 
 	// TRACE_FROM_LXC
 	tn = monitor.TraceNotify{
@@ -1430,8 +1426,7 @@ func TestDecodeIsReply(t *testing.T) {
 		Reason:   monitor.TraceReasonUnknown,
 	}
 	f = parseFlow(tn, localIP, remoteIP)
-	assert.Nil(t, f.GetIsReply())
-	assert.False(t, f.GetReply())
+	assert.False(t, f.IsReply())
 
 	// TRACE_FROM_LXC encrypted
 	tn = monitor.TraceNotify{
@@ -1440,8 +1435,7 @@ func TestDecodeIsReply(t *testing.T) {
 		Reason:   monitor.TraceReasonUnknown | monitor.TraceReasonEncryptMask,
 	}
 	f = parseFlow(tn, localIP, remoteIP)
-	assert.Nil(t, f.GetIsReply())
-	assert.False(t, f.GetReply())
+	assert.False(t, f.IsReply())
 
 	// TRACE_TO_STACK srv6-decap
 	tn = monitor.TraceNotify{
@@ -1451,8 +1445,7 @@ func TestDecodeIsReply(t *testing.T) {
 		Reason:   monitor.TraceReasonSRv6Decap,
 	}
 	f = parseFlow(tn, remoteIP, localIP)
-	assert.Nil(t, f.GetIsReply())
-	assert.False(t, f.GetReply())
+	assert.False(t, f.IsReply())
 
 	// TRACE_TO_STACK srv6-decap (encrypted)
 	tn = monitor.TraceNotify{
@@ -1462,8 +1455,7 @@ func TestDecodeIsReply(t *testing.T) {
 		Reason:   monitor.TraceReasonSRv6Decap | monitor.TraceReasonEncryptMask,
 	}
 	f = parseFlow(tn, remoteIP, localIP)
-	assert.Nil(t, f.GetIsReply())
-	assert.False(t, f.GetReply())
+	assert.False(t, f.IsReply())
 
 	// TRACE_TO_STACK srv6-encap
 	tn = monitor.TraceNotify{
@@ -1473,8 +1465,7 @@ func TestDecodeIsReply(t *testing.T) {
 		Reason:   monitor.TraceReasonSRv6Encap,
 	}
 	f = parseFlow(tn, localIP, remoteIP)
-	assert.Nil(t, f.GetIsReply())
-	assert.False(t, f.GetReply())
+	assert.False(t, f.IsReply())
 
 	// TRACE_TO_STACK srv6-encap (encrypted)
 	tn = monitor.TraceNotify{
@@ -1484,8 +1475,7 @@ func TestDecodeIsReply(t *testing.T) {
 		Reason:   monitor.TraceReasonSRv6Encap | monitor.TraceReasonEncryptMask,
 	}
 	f = parseFlow(tn, localIP, remoteIP)
-	assert.Nil(t, f.GetIsReply())
-	assert.False(t, f.GetReply())
+	assert.False(t, f.IsReply())
 
 	// PolicyVerdictNotify forward statically assumes is_reply=false
 	pvn := monitor.PolicyVerdictNotify{
@@ -1493,9 +1483,7 @@ func TestDecodeIsReply(t *testing.T) {
 		Verdict: 0,
 	}
 	f = parseFlow(pvn, localIP, remoteIP)
-	assert.NotNil(t, f.GetIsReply())
-	assert.False(t, f.GetIsReply().GetValue())
-	assert.False(t, f.GetReply())
+	assert.False(t, f.IsReply())
 
 	// PolicyVerdictNotify drop statically assumes is_reply=unknown
 	pvn = monitor.PolicyVerdictNotify{
@@ -1503,16 +1491,14 @@ func TestDecodeIsReply(t *testing.T) {
 		Verdict: -151, // drop reason: Stale or unroutable IP
 	}
 	f = parseFlow(pvn, localIP, remoteIP)
-	assert.Nil(t, f.GetIsReply())
-	assert.False(t, f.GetReply())
+	assert.False(t, f.IsReply())
 
 	// DropNotify statically assumes is_reply=unknown
 	dn := monitor.DropNotify{
 		Type: byte(monitorAPI.MessageTypeDrop),
 	}
 	f = parseFlow(dn, localIP, remoteIP)
-	assert.Nil(t, f.GetIsReply())
-	assert.False(t, f.GetReply())
+	assert.False(t, f.IsReply())
 }
 
 func Test_filterCIDRLabels(t *testing.T) {
@@ -1591,7 +1577,7 @@ func Test_filterCIDRLabels(t *testing.T) {
 }
 
 func TestTraceNotifyOriginalIP(t *testing.T) {
-	f := &flowpb.Flow{}
+	var f ir.Flow
 	parser, err := New(hivetest.Logger(t), &testutils.NoopEndpointGetter, nil, &testutils.NoopDNSGetter, &testutils.NoopIPGetter, &testutils.NoopServiceGetter, &testutils.NoopLinkGetter)
 	require.NoError(t, err)
 
@@ -1611,7 +1597,7 @@ func TestTraceNotifyOriginalIP(t *testing.T) {
 	data, err := testutils.CreateL3L4Payload(v0, &eth, &ip, &layers.TCP{})
 	require.NoError(t, err)
 
-	err = parser.Decode(data, f)
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 	assert.Equal(t, "10.0.0.2", f.IP.Source)
 	assert.Empty(t, f.IP.SourceXlated)
@@ -1623,7 +1609,7 @@ func TestTraceNotifyOriginalIP(t *testing.T) {
 	}
 	data, err = testutils.CreateL3L4Payload(v1, &eth, &ip, &layers.TCP{})
 	require.NoError(t, err)
-	err = parser.Decode(data, f)
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 	assert.Equal(t, "1.1.1.1", f.IP.Source)
 	assert.Equal(t, "10.0.0.2", f.IP.SourceXlated)
@@ -1635,7 +1621,7 @@ func TestTraceNotifyOriginalIP(t *testing.T) {
 	}
 	data, err = testutils.CreateL3L4Payload(v1, &eth, &ip, &layers.TCP{})
 	require.NoError(t, err)
-	err = parser.Decode(data, f)
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 	assert.Equal(t, "10.0.0.2", f.IP.Source)
 	assert.Empty(t, f.IP.SourceXlated)
@@ -1665,11 +1651,11 @@ func TestICMP(t *testing.T) {
 	}
 	v4data, err := testutils.CreateL3L4Payload(message, &eth, &ip, &icmpv4)
 	require.NoError(t, err)
-	v4flow := &flowpb.Flow{}
-	err = parser.Decode(v4data, v4flow)
+	var v4flow ir.Flow
+	err = parser.Decode(v4data, &v4flow)
 	require.NoError(t, err)
-	assert.Equal(t, uint32(1), v4flow.GetL4().GetICMPv4().Type)
-	assert.Equal(t, uint32(2), v4flow.GetL4().GetICMPv4().Code)
+	assert.Equal(t, uint32(1), v4flow.L4.ICMPv4.Type)
+	assert.Equal(t, uint32(2), v4flow.L4.ICMPv4.Code)
 
 	// icmpv4
 	ethv6 := layers.Ethernet{
@@ -1688,15 +1674,15 @@ func TestICMP(t *testing.T) {
 	}
 	v6data, err := testutils.CreateL3L4Payload(message, &ethv6, &ipv6, &icmpv6)
 	require.NoError(t, err)
-	v6flow := &flowpb.Flow{}
-	err = parser.Decode(v6data, v6flow)
+	var v6flow ir.Flow
+	err = parser.Decode(v6data, &v6flow)
 	require.NoError(t, err)
-	assert.Equal(t, uint32(3), v6flow.GetL4().GetICMPv6().Type)
-	assert.Equal(t, uint32(4), v6flow.GetL4().GetICMPv6().Code)
+	assert.Equal(t, uint32(3), v6flow.L4.ICMPv6.Type)
+	assert.Equal(t, uint32(4), v6flow.L4.ICMPv6.Code)
 }
 
 func TestTraceNotifyLocalEndpoint(t *testing.T) {
-	f := &flowpb.Flow{}
+	var f ir.Flow
 
 	ep := &testutils.FakeEndpointInfo{
 		ID:           1234,
@@ -1741,19 +1727,19 @@ func TestTraceNotifyLocalEndpoint(t *testing.T) {
 	data, err := testutils.CreateL3L4Payload(v0, &eth, &ip, &layers.TCP{})
 	require.NoError(t, err)
 
-	err = parser.Decode(data, f)
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 
 	assert.Equal(t, uint32(ep.ID), f.Source.ID)
 	assert.Equal(t, uint32(v0.SrcLabel), f.Source.Identity)
-	assert.Equal(t, "default", f.GetSource().GetClusterName())
+	assert.Equal(t, "default", f.Source.ClusterName)
 	assert.Equal(t, ep.PodNamespace, f.Source.Namespace)
 	assert.Equal(t, common.SortAndFilterLabels(hivetest.Logger(t), ep.Labels, ep.Identity), f.Source.Labels)
 	assert.Equal(t, ep.PodName, f.Source.PodName)
 }
 
 func TestDebugCapture(t *testing.T) {
-	f := &flowpb.Flow{}
+	var f ir.Flow
 
 	parser, err := New(hivetest.Logger(t), &testutils.NoopEndpointGetter, &testutils.NoopIdentityGetter, &testutils.NoopDNSGetter, &testutils.NoopIPGetter, &testutils.NoopServiceGetter, &testutils.NoopLinkGetter)
 	require.NoError(t, err)
@@ -1783,7 +1769,7 @@ func TestDebugCapture(t *testing.T) {
 	data, err := testutils.CreateL3L4Payload(dbg, &eth, &ip, &layers.TCP{})
 	require.NoError(t, err)
 
-	err = parser.Decode(data, f)
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(dbg.Type), f.EventType.Type)
@@ -1791,16 +1777,16 @@ func TestDebugCapture(t *testing.T) {
 	assert.Equal(t, flowpb.DebugCapturePoint_DBG_CAPTURE_DELIVERY, f.DebugCapturePoint)
 	assert.Equal(t, ip.SrcIP.String(), f.IP.Source)
 	assert.Equal(t, ip.DstIP.String(), f.IP.Destination)
-	assert.NotNil(t, f.L4.GetTCP())
+	assert.NotNil(t, f.L4.TCP)
 
-	assert.Equal(t, &flowpb.NetworkInterface{
+	assert.Equal(t, ir.NetworkInterface{
 		Index: loIfIndex,
 		Name:  loIfName,
 	}, f.Interface)
 
 	nilParser, err := New(hivetest.Logger(t), nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
-	err = nilParser.Decode(data, f)
+	err = nilParser.Decode(data, &f)
 	require.NoError(t, err)
 
 	dbg = monitor.DebugCapture{
@@ -1811,7 +1797,7 @@ func TestDebugCapture(t *testing.T) {
 	data, err = testutils.CreateL3L4Payload(dbg)
 	require.NoError(t, err)
 
-	err = parser.Decode(data, f)
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(dbg.Type), f.EventType.Type)
@@ -1819,12 +1805,13 @@ func TestDebugCapture(t *testing.T) {
 	assert.Equal(t, flowpb.DebugCapturePoint_DBG_CAPTURE_PROXY_POST, f.DebugCapturePoint)
 	assert.Equal(t, uint32(1234), f.ProxyPort)
 
-	err = nilParser.Decode(data, f)
+	err = nilParser.Decode(data, &f)
 	require.NoError(t, err)
 }
 
 func TestTraceNotifyProxyPort(t *testing.T) {
-	f := &flowpb.Flow{}
+	var f ir.Flow
+
 	parser, err := New(hivetest.Logger(t), &testutils.NoopEndpointGetter, nil, &testutils.NoopDNSGetter, &testutils.NoopIPGetter, &testutils.NoopServiceGetter, &testutils.NoopLinkGetter)
 	require.NoError(t, err)
 
@@ -1846,7 +1833,7 @@ func TestTraceNotifyProxyPort(t *testing.T) {
 	data, err := testutils.CreateL3L4Payload(v0, &eth, &ip, &layers.TCP{})
 	require.NoError(t, err)
 
-	err = parser.Decode(data, f)
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 	assert.Equal(t, uint32(1234), f.ProxyPort)
 
@@ -1859,7 +1846,7 @@ func TestTraceNotifyProxyPort(t *testing.T) {
 	}
 	data, err = testutils.CreateL3L4Payload(v1, &eth, &ip, &layers.TCP{})
 	require.NoError(t, err)
-	err = parser.Decode(data, f)
+	err = parser.Decode(data, &f)
 	require.NoError(t, err)
 	assert.Equal(t, uint32(4321), f.ProxyPort)
 }
@@ -1868,35 +1855,33 @@ func TestDecode_DropNotify(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), defaultEndpointGetter, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	getTemplate := func(isL3Device bool) *flowpb.Flow {
-		template := &flowpb.Flow{
-			EventType:   &flowpb.CiliumEventType{Type: 1},
-			Summary:     flowpb.IPVersion_IPv4.String(),
-			Type:        flowpb.FlowType_L3_L4,
-			Verdict:     flowpb.Verdict_DROPPED,
-			Source:      &flowpb.Endpoint{},
-			Destination: &flowpb.Endpoint{},
-			Ethernet: &flowpb.Ethernet{
-				Source:      srcMAC.String(),
-				Destination: dstMAC.String(),
+	getTemplate := func(isL3Device bool) *ir.Flow {
+		template := ir.Flow{
+			EventType: ir.CiliumEventType{Type: 1},
+			Summary:   flowpb.IPVersion_IPv4.String(),
+			Type:      flowpb.FlowType_L3_L4,
+			Verdict:   flowpb.Verdict_DROPPED,
+			Ethernet: ir.Ethernet{
+				Source:      srcMAC,
+				Destination: dstMAC,
 			},
-			IP: &flowpb.IP{
-				IpVersion:   flowpb.IPVersion_IPv4,
+			IP: ir.IP{
+				IPVersion:   flowpb.IPVersion_IPv4,
 				Source:      localIP.String(),
 				Destination: remoteIP.String(),
 			},
 		}
 		if isL3Device {
-			template.Ethernet = nil
+			template.Ethernet = ir.Ethernet{}
 		}
-		return template
+		return &template
 	}
 
 	testCases := []struct {
 		name    string
 		event   monitor.DropNotify
 		ipTuple ipTuple
-		want    *flowpb.Flow
+		want    ir.Flow
 	}{
 		{
 			name: "drop_unknown",
@@ -1907,9 +1892,13 @@ func TestDecode_DropNotify(t *testing.T) {
 				Version: monitor.DropNotifyVersion2,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				Source: &flowpb.Endpoint{ID: 1234},
-				File: &flowpb.FileInfo{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_DROPPED,
+				Source: ir.Endpoint{
+					ID:     1234,
+					Labels: []string{},
+				},
+				File: ir.FileInfo{
 					Name: "bpf_lxc.c",
 					Line: 42,
 				},
@@ -1925,10 +1914,14 @@ func TestDecode_DropNotify(t *testing.T) {
 				Version: monitor.DropNotifyVersion2,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				Source:           &flowpb.Endpoint{ID: 1234},
+			want: ir.Flow{
+				Source: ir.Endpoint{
+					ID:     1234,
+					Labels: []string{},
+				},
+				Verdict:          flowpb.Verdict_DROPPED,
 				TrafficDirection: flowpb.TrafficDirection_EGRESS,
-				File: &flowpb.FileInfo{
+				File: ir.FileInfo{
 					Name: "bpf_overlay.c",
 					Line: 12,
 				},
@@ -1944,16 +1937,18 @@ func TestDecode_DropNotify(t *testing.T) {
 				Version: monitor.DropNotifyVersion2,
 			},
 			ipTuple: ingressTuple,
-			want: &flowpb.Flow{
-				IP: &flowpb.IP{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_DROPPED,
+				IP: ir.IP{
 					Source:      remoteIP.String(),
 					Destination: localIP.String(),
 				},
-				Destination: &flowpb.Endpoint{
-					ID: uint32(localEP),
+				Destination: ir.Endpoint{
+					ID:     uint32(localEP),
+					Labels: []string{},
 				},
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
-				File: &flowpb.FileInfo{
+				File: ir.FileInfo{
 					Name: "bpf_xdp.c",
 					Line: 44,
 				},
@@ -1970,22 +1965,25 @@ func TestDecode_DropNotify(t *testing.T) {
 				Flags:   monitor.DropNotifyFlagIsL3Device,
 			},
 			ipTuple: ingressTuple,
-			want: &flowpb.Flow{
-				IP: &flowpb.IP{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_DROPPED,
+				IP: ir.IP{
 					Source:      remoteIP.String(),
 					Destination: localIP.String(),
 				},
-				Destination: &flowpb.Endpoint{
-					ID: uint32(localEP),
+				Destination: ir.Endpoint{
+					ID:     uint32(localEP),
+					Labels: []string{},
 				},
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
-				File: &flowpb.FileInfo{
+				File: ir.FileInfo{
 					Name: "bpf_wireguard.c",
 					Line: 44,
 				},
 			},
 		},
 	}
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			isL3Device := tc.event.IsL3Device()
@@ -2000,16 +1998,16 @@ func TestDecode_DropNotify(t *testing.T) {
 			}
 			l = append(l, &layers.IPv4{SrcIP: tc.ipTuple.src.AsSlice(), DstIP: tc.ipTuple.dst.AsSlice()})
 
-			want := proto.Clone(getTemplate(isL3Device))
-			proto.Merge(want, tc.want)
+			clone := getTemplate(isL3Device).Clone()
+			want := ir.TestMerge(&clone, &tc.want)
 
 			data, err := testutils.CreateL3L4Payload(tc.event, l...)
 			if err != nil {
 				t.Fatalf("Unexpected error from CreateL3L4Payload(%T, ...): %v", tc.event, err)
 			}
 
-			got := &flowpb.Flow{}
-			if err := parser.Decode(data, got); err != nil {
+			var got ir.Flow
+			if err := parser.Decode(data, &got); err != nil {
 				t.Fatalf("Unexpected error from Decode(data, %T): %v", got, err)
 			}
 
@@ -2017,7 +2015,7 @@ func TestDecode_DropNotify(t *testing.T) {
 				protocmp.Transform(),
 				protocmp.IgnoreFields(&flowpb.Flow{}, "reply"),
 			}
-			if diff := cmp.Diff(want, got, opts...); diff != "" {
+			if diff := cmp.Diff(want, &got, opts...); diff != "" {
 				t.Errorf("Unexpected diff (-want +got):\n%s", diff)
 			}
 		})
@@ -2028,27 +2026,27 @@ func TestDecode_TraceNotify(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), defaultEndpointGetter, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	getTemplate := func(isL3Device bool) *flowpb.Flow {
-		template := &flowpb.Flow{
-			EventType:   &flowpb.CiliumEventType{Type: 4},
+	getTemplate := func(isL3Device bool) ir.Flow {
+		template := ir.Flow{
+			EventType:   ir.CiliumEventType{Type: 4},
 			Summary:     flowpb.IPVersion_IPv4.String(),
 			Type:        flowpb.FlowType_L3_L4,
 			Verdict:     flowpb.Verdict_FORWARDED,
-			Source:      &flowpb.Endpoint{},
-			Destination: &flowpb.Endpoint{},
-			Ethernet: &flowpb.Ethernet{
-				Source:      srcMAC.String(),
-				Destination: dstMAC.String(),
+			Source:      ir.Endpoint{},
+			Destination: ir.Endpoint{},
+			Ethernet: ir.Ethernet{
+				Source:      srcMAC,
+				Destination: dstMAC,
 			},
-			IP: &flowpb.IP{
-				IpVersion:   flowpb.IPVersion_IPv4,
+			IP: ir.IP{
+				IPVersion:   flowpb.IPVersion_IPv4,
 				Source:      localIP.String(),
 				Destination: remoteIP.String(),
 			},
 			TraceObservationPoint: flowpb.TraceObservationPoint_TO_ENDPOINT,
 		}
 		if isL3Device {
-			template.Ethernet = nil
+			template.Ethernet = ir.Ethernet{}
 		}
 		return template
 	}
@@ -2057,7 +2055,7 @@ func TestDecode_TraceNotify(t *testing.T) {
 		name    string
 		event   any
 		ipTuple ipTuple
-		want    *flowpb.Flow
+		want    ir.Flow
 	}{
 		{
 			name: "v0_unknown",
@@ -2066,9 +2064,13 @@ func TestDecode_TraceNotify(t *testing.T) {
 				ObsPoint: monitorAPI.TraceToLxc,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				Source:      &flowpb.Endpoint{ID: 1234},
-				IsReply:     wrapperspb.Bool(false),
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				Source: ir.Endpoint{
+					ID:     1234,
+					Labels: []string{},
+				},
+				Reply:       ir.ReplyNo,
 				TraceReason: flowpb.TraceReason_NEW,
 			},
 		},
@@ -2080,9 +2082,13 @@ func TestDecode_TraceNotify(t *testing.T) {
 				ObsPoint: monitorAPI.TraceToLxc,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				Source:           &flowpb.Endpoint{ID: 1234},
-				IsReply:          wrapperspb.Bool(false),
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				Source: ir.Endpoint{
+					ID:     1234,
+					Labels: []string{},
+				},
+				Reply:            ir.ReplyNo,
 				TraceReason:      flowpb.TraceReason_NEW,
 				TrafficDirection: flowpb.TrafficDirection_EGRESS,
 			},
@@ -2097,15 +2103,20 @@ func TestDecode_TraceNotify(t *testing.T) {
 				OrigIP:   types.IPv6{1, 2, 3, 4}, // localIP
 			},
 			ipTuple: xlatedEgressTuple,
-			want: &flowpb.Flow{
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				EventType: ir.CiliumEventType{
+					Type:    monitorAPI.MessageTypeTrace,
 					SubType: 11,
 				},
-				IP: &flowpb.IP{
+				IP: ir.IP{
 					SourceXlated: xlatedIP.String(),
 				},
-				Source:                &flowpb.Endpoint{ID: 1234},
-				IsReply:               wrapperspb.Bool(false),
+				Source: ir.Endpoint{
+					ID:     1234,
+					Labels: []string{},
+				},
+				Reply:                 ir.ReplyNo,
 				TraceReason:           flowpb.TraceReason_NEW,
 				TrafficDirection:      flowpb.TrafficDirection_EGRESS,
 				TraceObservationPoint: flowpb.TraceObservationPoint_TO_NETWORK,
@@ -2123,14 +2134,19 @@ func TestDecode_TraceNotify(t *testing.T) {
 				OrigIP:   types.IPv6{1, 2, 3, 4},
 			},
 			ipTuple: xlatedEgressTuple,
-			want: &flowpb.Flow{
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				EventType: ir.CiliumEventType{
+					Type:    monitorAPI.MessageTypeTrace,
 					SubType: 13,
 				},
-				IP: &flowpb.IP{
+				IP: ir.IP{
 					SourceXlated: xlatedIP.String(),
 				},
-				Source:                &flowpb.Endpoint{ID: 1234},
+				Source: ir.Endpoint{
+					ID:     1234,
+					Labels: []string{},
+				},
 				TraceReason:           flowpb.TraceReason_TRACE_REASON_UNKNOWN,
 				TraceObservationPoint: flowpb.TraceObservationPoint_TO_CRYPTO,
 			},
@@ -2147,14 +2163,19 @@ func TestDecode_TraceNotify(t *testing.T) {
 				OrigIP:   types.IPv6{1, 2, 3, 4},
 			},
 			ipTuple: xlatedEgressTuple,
-			want: &flowpb.Flow{
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				EventType: ir.CiliumEventType{
+					Type:    monitorAPI.MessageTypeTrace,
 					SubType: 12,
 				},
-				IP: &flowpb.IP{
+				IP: ir.IP{
 					SourceXlated: xlatedIP.String(),
 				},
-				Source:                &flowpb.Endpoint{ID: 1234},
+				Source: ir.Endpoint{
+					ID:     1234,
+					Labels: []string{},
+				},
 				TraceReason:           flowpb.TraceReason_TRACE_REASON_UNKNOWN,
 				TraceObservationPoint: flowpb.TraceObservationPoint_FROM_CRYPTO,
 			},
@@ -2168,13 +2189,14 @@ func TestDecode_TraceNotify(t *testing.T) {
 				Reason:   monitor.TraceReasonCtReply,
 			},
 			ipTuple: xlatedEgressTuple,
-			want: &flowpb.Flow{
-				IP: &flowpb.IP{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				IP: ir.IP{
 					Source: xlatedIP.String(),
 				},
 				TrafficDirection:      flowpb.TrafficDirection_EGRESS,
 				TraceObservationPoint: flowpb.TraceObservationPoint_TO_ENDPOINT,
-				IsReply:               wrapperspb.Bool(true),
+				Reply:                 ir.ReplyYes,
 				TraceReason:           flowpb.TraceReason_REPLY,
 			},
 		},
@@ -2186,16 +2208,21 @@ func TestDecode_TraceNotify(t *testing.T) {
 				ObsPoint: monitorAPI.TraceToHost,
 			},
 			ipTuple: ingressTuple,
-			want: &flowpb.Flow{
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				EventType: ir.CiliumEventType{
+					Type:    monitorAPI.MessageTypeTrace,
 					SubType: 2,
 				},
-				IP: &flowpb.IP{
+				IP: ir.IP{
 					Source:      remoteIP.String(),
 					Destination: localIP.String(),
 				},
-				Destination:           &flowpb.Endpoint{ID: 1234},
-				IsReply:               wrapperspb.Bool(false),
+				Destination: ir.Endpoint{
+					ID:     1234,
+					Labels: []string{},
+				},
+				Reply:                 ir.ReplyNo,
 				TraceReason:           flowpb.TraceReason_NEW,
 				TrafficDirection:      flowpb.TrafficDirection_INGRESS,
 				TraceObservationPoint: flowpb.TraceObservationPoint_TO_HOST,
@@ -2210,18 +2237,23 @@ func TestDecode_TraceNotify(t *testing.T) {
 				Reason:   monitor.TraceReasonCtReply,
 			},
 			ipTuple: ingressTuple,
-			want: &flowpb.Flow{
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				EventType: ir.CiliumEventType{
+					Type:    monitorAPI.MessageTypeTrace,
 					SubType: 2,
 				},
-				IP: &flowpb.IP{
+				IP: ir.IP{
 					Source:      remoteIP.String(),
 					Destination: localIP.String(),
 				},
-				Destination:           &flowpb.Endpoint{ID: 1234},
+				Destination: ir.Endpoint{
+					ID:     1234,
+					Labels: []string{},
+				},
 				TrafficDirection:      flowpb.TrafficDirection_EGRESS,
 				TraceObservationPoint: flowpb.TraceObservationPoint_TO_HOST,
-				IsReply:               wrapperspb.Bool(true),
+				Reply:                 ir.ReplyYes,
 				TraceReason:           flowpb.TraceReason_REPLY,
 			},
 		},
@@ -2234,11 +2266,16 @@ func TestDecode_TraceNotify(t *testing.T) {
 				Reason:   monitor.TraceReasonUnknown,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				EventType: ir.CiliumEventType{
+					Type:    monitorAPI.MessageTypeTrace,
 					SubType: 5,
 				},
-				Source:                &flowpb.Endpoint{ID: 1234},
+				Source: ir.Endpoint{
+					ID:     1234,
+					Labels: []string{},
+				},
 				TraceObservationPoint: flowpb.TraceObservationPoint_FROM_ENDPOINT,
 			},
 		},
@@ -2251,11 +2288,16 @@ func TestDecode_TraceNotify(t *testing.T) {
 				Reason:   monitor.TraceReasonUnknown,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				EventType: ir.CiliumEventType{
+					Type:    monitorAPI.MessageTypeTrace,
 					SubType: 5,
 				},
-				Source:                &flowpb.Endpoint{ID: 1234},
+				Source: ir.Endpoint{
+					ID:     1234,
+					Labels: []string{},
+				},
 				TraceObservationPoint: flowpb.TraceObservationPoint_FROM_ENDPOINT,
 			},
 		},
@@ -2268,11 +2310,16 @@ func TestDecode_TraceNotify(t *testing.T) {
 				Reason:   monitor.TraceReasonUnknown,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				EventType: ir.CiliumEventType{
+					Type:    monitorAPI.MessageTypeTrace,
 					SubType: 5,
 				},
-				Source:                &flowpb.Endpoint{ID: 1234},
+				Source: ir.Endpoint{
+					ID:     1234,
+					Labels: []string{},
+				},
 				TraceObservationPoint: flowpb.TraceObservationPoint_FROM_ENDPOINT,
 			},
 		},
@@ -2285,14 +2332,19 @@ func TestDecode_TraceNotify(t *testing.T) {
 				Reason:   monitor.TraceReasonUnknown | monitor.TraceReasonEncryptMask,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				EventType: ir.CiliumEventType{
+					Type:    monitorAPI.MessageTypeTrace,
 					SubType: 5,
 				},
-				IP: &flowpb.IP{
+				IP: ir.IP{
 					Encrypted: true,
 				},
-				Source:                &flowpb.Endpoint{ID: 1234},
+				Source: ir.Endpoint{
+					ID:     1234,
+					Labels: []string{},
+				},
 				TraceObservationPoint: flowpb.TraceObservationPoint_FROM_ENDPOINT,
 			},
 		},
@@ -2305,11 +2357,16 @@ func TestDecode_TraceNotify(t *testing.T) {
 				Reason:   monitor.TraceReasonSRv6Decap,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				EventType: ir.CiliumEventType{
+					Type:    monitorAPI.MessageTypeTrace,
 					SubType: 3,
 				},
-				Source:                &flowpb.Endpoint{ID: 1234},
+				Source: ir.Endpoint{
+					ID:     1234,
+					Labels: []string{},
+				},
 				TraceReason:           flowpb.TraceReason_SRV6_DECAP,
 				TrafficDirection:      flowpb.TrafficDirection_INGRESS,
 				TraceObservationPoint: flowpb.TraceObservationPoint_TO_STACK,
@@ -2324,11 +2381,16 @@ func TestDecode_TraceNotify(t *testing.T) {
 				Reason:   monitor.TraceReasonSRv6Encap,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				EventType: ir.CiliumEventType{
+					Type:    monitorAPI.MessageTypeTrace,
 					SubType: 3,
 				},
-				Source:                &flowpb.Endpoint{ID: 1234},
+				Source: ir.Endpoint{
+					ID:     1234,
+					Labels: []string{},
+				},
 				TraceReason:           flowpb.TraceReason_SRV6_ENCAP,
 				TrafficDirection:      flowpb.TrafficDirection_EGRESS,
 				TraceObservationPoint: flowpb.TraceObservationPoint_TO_STACK,
@@ -2344,11 +2406,16 @@ func TestDecode_TraceNotify(t *testing.T) {
 				Version:  monitor.TraceNotifyVersion2,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				EventType: ir.CiliumEventType{
+					Type:    monitorAPI.MessageTypeTrace,
 					SubType: 5,
 				},
-				Source:                &flowpb.Endpoint{ID: 1234},
+				Source: ir.Endpoint{
+					ID:     1234,
+					Labels: []string{},
+				},
 				TraceObservationPoint: flowpb.TraceObservationPoint_FROM_ENDPOINT,
 			},
 		},
@@ -2363,14 +2430,19 @@ func TestDecode_TraceNotify(t *testing.T) {
 				IPTraceID: 1234,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				EventType: ir.CiliumEventType{
+					Type:    monitorAPI.MessageTypeTrace,
 					SubType: 5,
 				},
-				Source:                &flowpb.Endpoint{ID: 1234},
+				Source: ir.Endpoint{
+					ID:     1234,
+					Labels: []string{},
+				},
 				TraceObservationPoint: flowpb.TraceObservationPoint_FROM_ENDPOINT,
-				IpTraceId: &flowpb.IPTraceID{
-					TraceId: 1234,
+				IPTraceID: ir.IPTraceID{
+					TraceID: 1234,
 				},
 			},
 		},
@@ -2392,16 +2464,17 @@ func TestDecode_TraceNotify(t *testing.T) {
 			}
 			l = append(l, &layers.IPv4{SrcIP: tc.ipTuple.src.AsSlice(), DstIP: tc.ipTuple.dst.AsSlice()})
 
-			want := proto.Clone(getTemplate(isL3Device))
-			proto.Merge(want, tc.want)
+			tpl := getTemplate(isL3Device)
+			clone := tpl.Clone()
+			want := ir.TestMerge(&clone, &tc.want)
 
 			data, err := testutils.CreateL3L4Payload(tc.event, l...)
 			if err != nil {
 				t.Fatalf("Unexpected error from CreateL3L4Payload(%T, ...): %v", tc.event, err)
 			}
 
-			got := &flowpb.Flow{}
-			if err := parser.Decode(data, got); err != nil {
+			var got ir.Flow
+			if err := parser.Decode(data, &got); err != nil {
 				t.Fatalf("Unexpected error from Decode(data, %T): %v", got, err)
 			}
 
@@ -2409,7 +2482,7 @@ func TestDecode_TraceNotify(t *testing.T) {
 				protocmp.Transform(),
 				protocmp.IgnoreFields(&flowpb.Flow{}, "reply"),
 			}
-			if diff := cmp.Diff(want, got, opts...); diff != "" {
+			if diff := cmp.Diff(want, &got, opts...); diff != "" {
 				t.Errorf("Unexpected diff (-want +got):\n%s", diff)
 			}
 		})
@@ -2420,36 +2493,35 @@ func TestDecode_PolicyVerdictNotify(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), defaultEndpointGetter, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	getTemplate := func(isL3Device bool) *flowpb.Flow {
-		template := &flowpb.Flow{
-			EventType:   &flowpb.CiliumEventType{Type: 5},
-			Summary:     flowpb.IPVersion_IPv4.String(),
-			Type:        flowpb.FlowType_L3_L4,
-			Verdict:     flowpb.Verdict_FORWARDED,
-			Source:      &flowpb.Endpoint{},
-			Destination: &flowpb.Endpoint{},
-			Ethernet: &flowpb.Ethernet{
-				Source:      srcMAC.String(),
-				Destination: dstMAC.String(),
+	getTemplate := func(isL3Device bool) *ir.Flow {
+		template := ir.Flow{
+			EventType: ir.CiliumEventType{Type: 5},
+			Summary:   flowpb.IPVersion_IPv4.String(),
+			Type:      flowpb.FlowType_L3_L4,
+			Verdict:   flowpb.Verdict_FORWARDED,
+			Ethernet: ir.Ethernet{
+				Source:      srcMAC,
+				Destination: dstMAC,
 			},
-			IP: &flowpb.IP{
-				IpVersion:   flowpb.IPVersion_IPv4,
+			IP: ir.IP{
+				IPVersion:   flowpb.IPVersion_IPv4,
 				Source:      localIP.String(),
 				Destination: remoteIP.String(),
 			},
-			IsReply: wrapperspb.Bool(false),
+			Reply: ir.ReplyNo,
 		}
+
 		if isL3Device {
-			template.Ethernet = nil
+			template.Ethernet = ir.Ethernet{}
 		}
-		return template
+		return &template
 	}
 
 	testCases := []struct {
 		name    string
 		event   any
 		ipTuple ipTuple
-		want    *flowpb.Flow
+		want    ir.Flow
 	}{
 		{
 			name: "egress",
@@ -2460,9 +2532,13 @@ func TestDecode_PolicyVerdictNotify(t *testing.T) {
 				RemoteLabel: identity.NumericIdentity(remoteID),
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				Source:           &flowpb.Endpoint{ID: 1234},
-				Destination:      &flowpb.Endpoint{Identity: 5678},
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				Source: ir.Endpoint{
+					ID:     1234,
+					Labels: []string{},
+				},
+				Destination:      ir.Endpoint{Identity: 5678},
 				TrafficDirection: flowpb.TrafficDirection_EGRESS,
 			},
 		},
@@ -2474,8 +2550,12 @@ func TestDecode_PolicyVerdictNotify(t *testing.T) {
 				Flags:  monitorAPI.PolicyIngress,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				Source:           &flowpb.Endpoint{ID: 1234},
+			want: ir.Flow{
+				Verdict: flowpb.Verdict_FORWARDED,
+				Source: ir.Endpoint{
+					ID:     1234,
+					Labels: []string{},
+				},
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
 			},
 		},
@@ -2487,12 +2567,17 @@ func TestDecode_PolicyVerdictNotify(t *testing.T) {
 				Flags:  monitorAPI.PolicyIngress | monitor.PolicyVerdictNotifyFlagIsL3,
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				Source:           &flowpb.Endpoint{ID: 1234},
+			want: ir.Flow{
+				Source: ir.Endpoint{
+					ID:     1234,
+					Labels: []string{},
+				},
+				Verdict:          flowpb.Verdict_FORWARDED,
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
 			},
 		},
 	}
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			isL3Device := false
@@ -2510,16 +2595,16 @@ func TestDecode_PolicyVerdictNotify(t *testing.T) {
 			}
 			l = append(l, &layers.IPv4{SrcIP: tc.ipTuple.src.AsSlice(), DstIP: tc.ipTuple.dst.AsSlice()})
 
-			want := proto.Clone(getTemplate(isL3Device))
-			proto.Merge(want, tc.want)
+			want := getTemplate(isL3Device).Clone()
+			want = *ir.TestMerge(&want, &tc.want)
 
 			data, err := testutils.CreateL3L4Payload(tc.event, l...)
 			if err != nil {
 				t.Fatalf("Unexpected error from CreateL3L4Payload(%T, ...): %v", tc.event, err)
 			}
 
-			got := &flowpb.Flow{}
-			if err := parser.Decode(data, got); err != nil {
+			got := ir.Flow{}
+			if err := parser.Decode(data, &got); err != nil {
 				t.Fatalf("Unexpected error from Decode(data, %T): %v", got, err)
 			}
 
@@ -2535,19 +2620,17 @@ func TestDecode_PolicyVerdictNotify(t *testing.T) {
 }
 
 func TestDecode_CustomMonitorDecoder(t *testing.T) {
-	getTemplate := func() *flowpb.Flow {
-		template := &flowpb.Flow{
-			EventType:   &flowpb.CiliumEventType{Type: 5},
-			Summary:     flowpb.IPVersion_IPv4.String(),
-			Type:        flowpb.FlowType_L3_L4,
-			Source:      &flowpb.Endpoint{},
-			Destination: &flowpb.Endpoint{},
-			Ethernet: &flowpb.Ethernet{
-				Source:      srcMAC.String(),
-				Destination: dstMAC.String(),
+	getTemplate := func() *ir.Flow {
+		template := &ir.Flow{
+			EventType: ir.CiliumEventType{Type: 5},
+			Summary:   flowpb.IPVersion_IPv4.String(),
+			Type:      flowpb.FlowType_L3_L4,
+			Ethernet: ir.Ethernet{
+				Source:      srcMAC,
+				Destination: dstMAC,
 			},
-			IP: &flowpb.IP{
-				IpVersion:   flowpb.IPVersion_IPv4,
+			IP: ir.IP{
+				IPVersion:   flowpb.IPVersion_IPv4,
 				Source:      localIP.String(),
 				Destination: remoteIP.String(),
 			},
@@ -2560,7 +2643,7 @@ func TestDecode_CustomMonitorDecoder(t *testing.T) {
 		opts    []options.Option
 		event   any
 		ipTuple ipTuple
-		want    *flowpb.Flow
+		want    ir.Flow
 	}{
 		{
 			name: "policy",
@@ -2571,8 +2654,8 @@ func TestDecode_CustomMonitorDecoder(t *testing.T) {
 				RemoteLabel: identity.NumericIdentity(remoteID),
 			},
 			opts: []options.Option{
-				options.WithPolicyVerdictNotifyDecoder(func(data []byte, decoded *flowpb.Flow) (*monitor.PolicyVerdictNotify, error) {
-					decoded.Uuid = "foobar"
+				options.WithPolicyVerdictNotifyDecoder(func(data []byte, decoded *ir.Flow) (*monitor.PolicyVerdictNotify, error) {
+					decoded.UUID = "foobar"
 					return &monitor.PolicyVerdictNotify{
 						Type:        byte(monitorAPI.MessageTypePolicyVerdict),
 						Source:      1226,
@@ -2582,12 +2665,17 @@ func TestDecode_CustomMonitorDecoder(t *testing.T) {
 				}),
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				Source:           &flowpb.Endpoint{ID: 1234},
-				Destination:      &flowpb.Endpoint{Identity: 1337},
+			want: ir.Flow{
+				Source: ir.Endpoint{
+					ID:     1234,
+					Labels: []string{},
+				},
+				Destination: ir.Endpoint{
+					Identity: 1337,
+				},
 				TrafficDirection: flowpb.TrafficDirection_EGRESS,
-				Uuid:             "foobar",
-				IsReply:          wrapperspb.Bool(false),
+				UUID:             "foobar",
+				Reply:            ir.ReplyNo,
 				Verdict:          flowpb.Verdict_FORWARDED,
 			},
 		},
@@ -2601,8 +2689,8 @@ func TestDecode_CustomMonitorDecoder(t *testing.T) {
 				Version:  monitor.TraceNotifyVersion2,
 			},
 			opts: []options.Option{
-				options.WithTraceNotifyDecoder(func(data []byte, decoded *flowpb.Flow) (*monitor.TraceNotify, error) {
-					decoded.Uuid = "foobar-trace"
+				options.WithTraceNotifyDecoder(func(data []byte, decoded *ir.Flow) (*monitor.TraceNotify, error) {
+					decoded.UUID = "foobar-trace"
 					return &monitor.TraceNotify{
 						Type:     byte(monitorAPI.MessageTypePolicyVerdict),
 						Source:   1226,
@@ -2614,15 +2702,20 @@ func TestDecode_CustomMonitorDecoder(t *testing.T) {
 				}),
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				Source:                &flowpb.Endpoint{ID: 1234},
-				Destination:           &flowpb.Endpoint{Identity: 1337},
-				EventType:             &flowpb.CiliumEventType{Type: 4},
+			want: ir.Flow{
+				Source: ir.Endpoint{
+					ID:     1234,
+					Labels: []string{},
+				},
+				Destination: ir.Endpoint{
+					Identity: 1337,
+				},
+				EventType:             ir.CiliumEventType{Type: 4},
 				TrafficDirection:      flowpb.TrafficDirection_INGRESS,
 				TraceObservationPoint: flowpb.TraceObservationPoint_TO_ENDPOINT,
 				TraceReason:           flowpb.TraceReason_RELATED,
-				Uuid:                  "foobar-trace",
-				IsReply:               wrapperspb.Bool(false),
+				UUID:                  "foobar-trace",
+				Reply:                 ir.ReplyNo,
 				Verdict:               flowpb.Verdict_FORWARDED,
 			},
 		},
@@ -2636,8 +2729,8 @@ func TestDecode_CustomMonitorDecoder(t *testing.T) {
 				DstID:    11,
 			},
 			opts: []options.Option{
-				options.WithDropNotifyDecoder(func(data []byte, decoded *flowpb.Flow) (*monitor.DropNotify, error) {
-					decoded.Uuid = "foobar-drop"
+				options.WithDropNotifyDecoder(func(data []byte, decoded *ir.Flow) (*monitor.DropNotify, error) {
+					decoded.UUID = "foobar-drop"
 					return &monitor.DropNotify{
 						Type:     byte(monitorAPI.MessageTypeDrop),
 						Source:   1226,
@@ -2649,14 +2742,19 @@ func TestDecode_CustomMonitorDecoder(t *testing.T) {
 				}),
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				Source:           &flowpb.Endpoint{ID: 1234},
-				Destination:      &flowpb.Endpoint{Identity: 1337},
-				EventType:        &flowpb.CiliumEventType{Type: 1},
+			want: ir.Flow{
+				Source: ir.Endpoint{
+					ID:     1234,
+					Labels: []string{},
+				},
+				Destination: ir.Endpoint{
+					Identity: 1337,
+				},
+				EventType:        ir.CiliumEventType{Type: 1},
 				TrafficDirection: flowpb.TrafficDirection_INGRESS,
 				Verdict:          flowpb.Verdict_DROPPED,
-				Uuid:             "foobar-drop",
-				File: &flowpb.FileInfo{
+				UUID:             "foobar-drop",
+				File: ir.FileInfo{
 					Name: "bpf_host.c",
 					Line: 0,
 				},
@@ -2673,8 +2771,8 @@ func TestDecode_CustomMonitorDecoder(t *testing.T) {
 				Arg2:                34,
 			},
 			opts: []options.Option{
-				options.WithDebugCaptureDecoder(func(data []byte, decoded *flowpb.Flow) (*monitor.DebugCapture, error) {
-					decoded.Uuid = "foobar-dbg"
+				options.WithDebugCaptureDecoder(func(data []byte, decoded *ir.Flow) (*monitor.DebugCapture, error) {
+					decoded.UUID = "foobar-dbg"
 					return &monitor.DebugCapture{
 						Type:    byte(monitorAPI.MessageTypeCapture),
 						Source:  1226,
@@ -2684,14 +2782,17 @@ func TestDecode_CustomMonitorDecoder(t *testing.T) {
 				}),
 			},
 			ipTuple: egressTuple,
-			want: &flowpb.Flow{
-				Source: &flowpb.Endpoint{ID: 1234},
-				EventType: &flowpb.CiliumEventType{
+			want: ir.Flow{
+				Source: ir.Endpoint{
+					ID:     1234,
+					Labels: []string{},
+				},
+				EventType: ir.CiliumEventType{
 					Type:    3,
 					SubType: 50,
 				},
 				DebugCapturePoint: 50,
-				Uuid:              "foobar-dbg",
+				UUID:              "foobar-dbg",
 			},
 		},
 	}
@@ -2701,8 +2802,8 @@ func TestDecode_CustomMonitorDecoder(t *testing.T) {
 			var l []gopacket.SerializableLayer
 			l = append(l, &layers.Ethernet{SrcMAC: srcMAC, DstMAC: dstMAC, EthernetType: layers.EthernetTypeIPv4}, &layers.IPv4{SrcIP: tc.ipTuple.src.AsSlice(), DstIP: tc.ipTuple.dst.AsSlice()})
 
-			want := proto.Clone(getTemplate())
-			proto.Merge(want, tc.want)
+			clone := getTemplate().Clone()
+			want := ir.TestMerge(&clone, &tc.want)
 
 			data, err := testutils.CreateL3L4Payload(tc.event, l...)
 			if err != nil {
@@ -2712,8 +2813,8 @@ func TestDecode_CustomMonitorDecoder(t *testing.T) {
 			parser, err := New(hivetest.Logger(t), defaultEndpointGetter, nil, nil, nil, nil, nil, tc.opts...)
 			require.NoError(t, err)
 
-			got := &flowpb.Flow{}
-			if err := parser.Decode(data, got); err != nil {
+			var got ir.Flow
+			if err := parser.Decode(data, &got); err != nil {
 				t.Fatalf("Unexpected error from Decode(data, %T): %v", got, err)
 			}
 
@@ -2721,7 +2822,7 @@ func TestDecode_CustomMonitorDecoder(t *testing.T) {
 				protocmp.Transform(),
 				protocmp.IgnoreFields(&flowpb.Flow{}, "reply"),
 			}
-			if diff := cmp.Diff(want, got, opts...); diff != "" {
+			if diff := cmp.Diff(*want, got, opts...); diff != "" {
 				t.Errorf("Unexpected diff (-want +got):\n%s", diff)
 			}
 		})
@@ -2732,16 +2833,16 @@ type customDecoder struct {
 }
 
 // DecodePacket implements options.L34PacketDecoder.
-func (c customDecoder) DecodePacket(payload []byte, decoded *flowpb.Flow, isL3Device bool, isIPv6 bool, isVXLAN bool, isGeneve bool) (sourceIP netip.Addr, destinationIP netip.Addr, sourcePort uint16, destinationPort uint16, err error) {
+func (c customDecoder) DecodePacket(payload []byte, decoded *ir.Flow, isL3Device bool, isIPv6 bool, isVXLAN bool, isGeneve bool) (sourceIP netip.Addr, destinationIP netip.Addr, sourcePort uint16, destinationPort uint16, err error) {
 	sourceIP = netip.MustParseAddr("10.13.37.1")
 	destinationIP = netip.MustParseAddr("10.13.37.2")
 	sourcePort = 10011
 	destinationPort = 443
 
-	decoded.IP = &flowpb.IP{
+	decoded.IP = ir.IP{
 		Source:      sourceIP.String(),
 		Destination: destinationIP.String(),
-		IpVersion:   flowpb.IPVersion_IPv4,
+		IPVersion:   flowpb.IPVersion_IPv4,
 	}
 
 	return
@@ -2759,23 +2860,21 @@ func TestDecode_CustomPacketDecoder(t *testing.T) {
 	var l []gopacket.SerializableLayer
 	l = append(l, &layers.Ethernet{SrcMAC: srcMAC, DstMAC: dstMAC, EthernetType: layers.EthernetTypeIPv4}, &layers.IPv4{SrcIP: egressTuple.src.AsSlice(), DstIP: egressTuple.dst.AsSlice()})
 
-	want := &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	want := &ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type:    4,
 			SubType: 5,
 		},
-		Type:        flowpb.FlowType_L3_L4,
-		Source:      &flowpb.Endpoint{},
-		Destination: &flowpb.Endpoint{},
-		IP: &flowpb.IP{
-			IpVersion:   flowpb.IPVersion_IPv4,
+		Type: flowpb.FlowType_L3_L4,
+		IP: ir.IP{
+			IPVersion:   flowpb.IPVersion_IPv4,
 			Source:      "10.13.37.1",
 			Destination: "10.13.37.2",
 		},
 		TraceObservationPoint: flowpb.TraceObservationPoint_FROM_ENDPOINT,
 		TraceReason:           flowpb.TraceReason_ESTABLISHED,
 		TrafficDirection:      flowpb.TrafficDirection_INGRESS,
-		IsReply:               wrapperspb.Bool(false),
+		Reply:                 ir.ReplyNo,
 		Verdict:               flowpb.Verdict_FORWARDED,
 	}
 
@@ -2787,7 +2886,7 @@ func TestDecode_CustomPacketDecoder(t *testing.T) {
 	parser, err := New(hivetest.Logger(t), defaultEndpointGetter, nil, nil, nil, nil, nil, options.WithL34PacketDecoder(customDecoder{}))
 	require.NoError(t, err)
 
-	got := &flowpb.Flow{}
+	got := &ir.Flow{}
 	if err := parser.Decode(data, got); err != nil {
 		t.Fatalf("Unexpected error from Decode(data, %T): %v", got, err)
 	}
@@ -2807,7 +2906,7 @@ func TestDecode_PolicyVerdictNotifyHostEndpoint(t *testing.T) {
 	nodeIP := netip.MustParseAddr("10.211.60.1")
 
 	policyLabel := utils.GetPolicyLabels("", "host-fw", "1234-5678", utils.ResourceTypeCiliumClusterwideNetworkPolicy)
-	expectedPolicy := []*flowpb.Policy{
+	expectedPolicy := []ir.Policy{
 		{
 			Name: "host-fw",
 			Kind: "CiliumClusterwideNetworkPolicy",
@@ -2828,35 +2927,35 @@ func TestDecode_PolicyVerdictNotifyHostEndpoint(t *testing.T) {
 		key       policyTypes.Key
 		audited   bool
 		verdict   int32
-		allowedBy func(*flowpb.Flow) []*flowpb.Policy
+		allowedBy func(*ir.Flow) []ir.Policy
 	}{
 		{
 			name:      "ingress_allowed",
 			key:       ingressKey,
-			allowedBy: (*flowpb.Flow).GetIngressAllowedBy,
+			allowedBy: (*ir.Flow).GetIngressAllowedBy,
 		},
 		{
 			name:      "egress_allowed",
 			key:       egressKey,
-			allowedBy: (*flowpb.Flow).GetEgressAllowedBy,
+			allowedBy: (*ir.Flow).GetEgressAllowedBy,
 		},
 		{
 			name:      "ingress_audited",
 			key:       ingressKey,
 			audited:   true,
-			allowedBy: (*flowpb.Flow).GetIngressDeniedBy,
+			allowedBy: (*ir.Flow).GetIngressDeniedBy,
 		},
 		{
 			name:      "ingress_denied",
 			key:       ingressKey,
 			verdict:   -int32(flowpb.DropReason_POLICY_DENIED),
-			allowedBy: (*flowpb.Flow).GetIngressDeniedBy,
+			allowedBy: (*ir.Flow).GetIngressDeniedBy,
 		},
 		{
 			name:      "egress_denied",
 			key:       egressKey,
 			verdict:   -int32(flowpb.DropReason_POLICY_DENIED),
-			allowedBy: (*flowpb.Flow).GetEgressDeniedBy,
+			allowedBy: (*ir.Flow).GetEgressDeniedBy,
 		},
 	}
 	for _, tc := range testCases {
@@ -2912,11 +3011,11 @@ func TestDecode_PolicyVerdictNotifyHostEndpoint(t *testing.T) {
 				&layers.TCP{SrcPort: 37304, DstPort: layers.TCPPort(tc.key.DestPort), SYN: true})
 			require.NoError(t, err)
 
-			f := new(flowpb.Flow)
+			f := new(ir.Flow)
 			require.NoError(t, parser.Decode(data, f))
 
-			require.Zero(t, f.GetSource().GetID())
-			require.Zero(t, f.GetDestination().GetID())
+			require.Zero(t, f.Source.ID)
+			require.Zero(t, f.Destination.ID)
 			testutils.AssertProtoEqual(t, expectedPolicy, tc.allowedBy(f))
 		})
 	}

--- a/pkg/hubble/testutils/fake.go
+++ b/pkg/hubble/testutils/fake.go
@@ -14,7 +14,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 
-	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/api/v1/models"
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 	peerpb "github.com/cilium/cilium/api/v1/peer"
@@ -374,11 +373,11 @@ var NoopIPGetter = FakeIPGetter{
 
 // FakeServiceGetter is used for unit tests that need ServiceGetter.
 type FakeServiceGetter struct {
-	OnGetServiceByAddr func(ip netip.Addr, port uint16) *flowpb.Service
+	OnGetServiceByAddr func(ip netip.Addr, port uint16) getters.FQN
 }
 
 // GetServiceByAddr implements FakeServiceGetter.GetServiceByAddr.
-func (f *FakeServiceGetter) GetServiceByAddr(ip netip.Addr, port uint16) *flowpb.Service {
+func (f *FakeServiceGetter) GetServiceByAddr(ip netip.Addr, port uint16) getters.FQN {
 	if f.OnGetServiceByAddr != nil {
 		return f.OnGetServiceByAddr(ip, port)
 	}
@@ -387,8 +386,8 @@ func (f *FakeServiceGetter) GetServiceByAddr(ip netip.Addr, port uint16) *flowpb
 
 // NoopServiceGetter always returns an empty response.
 var NoopServiceGetter = FakeServiceGetter{
-	OnGetServiceByAddr: func(ip netip.Addr, port uint16) *flowpb.Service {
-		return nil
+	OnGetServiceByAddr: func(ip netip.Addr, port uint16) getters.FQN {
+		return getters.BlankFQN
 	},
 }
 

--- a/pkg/policy/correlation/correlation.go
+++ b/pkg/policy/correlation/correlation.go
@@ -147,5 +147,6 @@ func toProto(info policyTypes.PolicyCorrelationInfo) (policies []ir.Policy) {
 	for model := range labels.ModelsFromLabelArrayListString(info.RuleLabels) {
 		policies = append(policies, ir.ProtoToPolicy(utils.GetPolicyFromLabels(model, info.Revision)))
 	}
+
 	return policies
 }

--- a/pkg/policy/correlation/correlation.go
+++ b/pkg/policy/correlation/correlation.go
@@ -150,5 +150,6 @@ func toProto(info policyTypes.PolicyCorrelationInfo) (policies []*flowpb.Policy)
 	for model := range labels.ModelsFromLabelArrayListString(info.RuleLabels) {
 		policies = append(policies, utils.GetPolicyFromLabels(model, info.Revision))
 	}
+
 	return policies
 }

--- a/pkg/policy/correlation/correlation.go
+++ b/pkg/policy/correlation/correlation.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils"
@@ -24,8 +25,8 @@ import (
 // provided flow. notifyEPID is the endpoint the datapath reported the verdict
 // at, zero if the notification carried none, and takes precedence over the ID
 // derived from the flow, which is unset for the host endpoint.
-func CorrelatePolicy(logger *slog.Logger, endpointGetter getters.EndpointGetter, f *flowpb.Flow, notifyEPID uint16) {
-	if f.GetEventType().GetType() != int32(monitorAPI.MessageTypePolicyVerdict) {
+func CorrelatePolicy(logger *slog.Logger, endpointGetter getters.EndpointGetter, f *ir.Flow, notifyEPID uint16) {
+	if f.EventType.Type != int32(monitorAPI.MessageTypePolicyVerdict) {
 		// If it's not a policy verdict, we don't care.
 		return
 	}
@@ -34,9 +35,9 @@ func CorrelatePolicy(logger *slog.Logger, endpointGetter getters.EndpointGetter,
 	// FORWARDED or REDIRECTED), denied by policy (i.e. DROPPED with a policy deny reason),
 	// or audited (i.e. AUDIT, which represents traffic allowed due to audit mode that would
 	// have been denied otherwise).
-	verdict := f.GetVerdict()
+	verdict := f.Verdict
 	allowed := verdict == flowpb.Verdict_FORWARDED || verdict == flowpb.Verdict_REDIRECTED
-	dropReason := f.GetDropReasonDesc()
+	dropReason := f.DropReasonDesc
 	denied := verdict == flowpb.Verdict_DROPPED &&
 		(dropReason == flowpb.DropReason_POLICY_DENY || dropReason == flowpb.DropReason_POLICY_DENIED)
 	audited := verdict == flowpb.Verdict_AUDIT
@@ -94,48 +95,48 @@ func CorrelatePolicy(logger *slog.Logger, endpointGetter getters.EndpointGetter,
 	f.PolicyLog = info.Log
 }
 
-func extractFlowKey(f *flowpb.Flow) (
+func extractFlowKey(f *ir.Flow) (
 	direction trafficdirection.TrafficDirection,
 	endpointID uint16,
 	remoteIdentity identity.NumericIdentity,
 	proto u8proto.U8proto,
 	dport uint16) {
 
-	switch f.GetTrafficDirection() {
+	switch f.TrafficDirection {
 	case flowpb.TrafficDirection_EGRESS:
 		direction = trafficdirection.Egress
 		// We only get a uint32 because proto has no 16-bit types.
-		endpointID = uint16(f.GetSource().GetID())
-		remoteIdentity = identity.NumericIdentity(f.GetDestination().GetIdentity())
+		endpointID = uint16(f.Source.ID)
+		remoteIdentity = identity.NumericIdentity(f.Destination.Identity)
 	case flowpb.TrafficDirection_INGRESS:
 		direction = trafficdirection.Ingress
-		endpointID = uint16(f.GetDestination().GetID())
-		remoteIdentity = identity.NumericIdentity(f.GetSource().GetIdentity())
+		endpointID = uint16(f.Destination.ID)
+		remoteIdentity = identity.NumericIdentity(f.Source.Identity)
 	default:
 		direction = trafficdirection.Invalid
 		endpointID = 0
 		remoteIdentity = identity.IdentityUnknown
 	}
 
-	if tcp := f.GetL4().GetTCP(); tcp != nil {
+	if tcp := f.L4.TCP; !tcp.IsEmpty() {
 		proto = u8proto.TCP
-		dport = uint16(tcp.GetDestinationPort())
-	} else if udp := f.GetL4().GetUDP(); udp != nil {
+		dport = uint16(tcp.DestinationPort)
+	} else if udp := f.L4.UDP; !udp.IsEmpty() {
 		proto = u8proto.UDP
-		dport = uint16(udp.GetDestinationPort())
-	} else if icmpv4 := f.GetL4().GetICMPv4(); icmpv4 != nil {
+		dport = uint16(udp.DestinationPort)
+	} else if icmpv4 := f.L4.ICMPv4; !icmpv4.IsEmpty() {
 		proto = u8proto.ICMP
 		dport = uint16(icmpv4.Type)
-	} else if icmpv6 := f.GetL4().GetICMPv6(); icmpv6 != nil {
+	} else if icmpv6 := f.L4.ICMPv6; !icmpv6.IsEmpty() {
 		proto = u8proto.ICMPv6
 		dport = uint16(icmpv6.Type)
-	} else if sctp := f.GetL4().GetSCTP(); sctp != nil {
+	} else if sctp := f.L4.SCTP; !sctp.IsEmpty() {
 		proto = u8proto.SCTP
-		dport = uint16(sctp.GetDestinationPort())
-	} else if vrrp := f.GetL4().GetVRRP(); vrrp != nil {
+		dport = uint16(sctp.DestinationPort)
+	} else if vrrp := f.L4.VRRP; !vrrp.IsEmpty() {
 		proto = u8proto.VRRP
 		dport = 0
-	} else if igmp := f.GetL4().GetIGMP(); igmp != nil {
+	} else if igmp := f.L4.IGMP; !igmp.IsEmpty() {
 		proto = u8proto.IGMP
 		dport = 0
 	} else {
@@ -146,9 +147,9 @@ func extractFlowKey(f *flowpb.Flow) (
 	return
 }
 
-func toProto(info policyTypes.PolicyCorrelationInfo) (policies []*flowpb.Policy) {
+func toProto(info policyTypes.PolicyCorrelationInfo) (policies []ir.Policy) {
 	for model := range labels.ModelsFromLabelArrayListString(info.RuleLabels) {
-		policies = append(policies, utils.GetPolicyFromLabels(model, info.Revision))
+		policies = append(policies, ir.ProtoToPolicy(utils.GetPolicyFromLabels(model, info.Revision)))
 	}
 
 	return policies

--- a/pkg/policy/correlation/correlation.go
+++ b/pkg/policy/correlation/correlation.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils"
@@ -21,8 +22,8 @@ import (
 
 // CorrelatePolicy updates the IngressAllowedBy/EgressAllowedBy fields on the
 // provided flow.
-func CorrelatePolicy(logger *slog.Logger, endpointGetter getters.EndpointGetter, f *flowpb.Flow) {
-	if f.GetEventType().GetType() != int32(monitorAPI.MessageTypePolicyVerdict) {
+func CorrelatePolicy(logger *slog.Logger, endpointGetter getters.EndpointGetter, f *ir.Flow) {
+	if f.EventType.Type != int32(monitorAPI.MessageTypePolicyVerdict) {
 		// If it's not a policy verdict, we don't care.
 		return
 	}
@@ -31,9 +32,9 @@ func CorrelatePolicy(logger *slog.Logger, endpointGetter getters.EndpointGetter,
 	// FORWARDED or REDIRECTED), denied by policy (i.e. DROPPED with a policy deny reason),
 	// or audited (i.e. AUDIT, which represents traffic allowed due to audit mode that would
 	// have been denied otherwise).
-	verdict := f.GetVerdict()
+	verdict := f.Verdict
 	allowed := verdict == flowpb.Verdict_FORWARDED || verdict == flowpb.Verdict_REDIRECTED
-	dropReason := f.GetDropReasonDesc()
+	dropReason := f.DropReasonDesc
 	denied := verdict == flowpb.Verdict_DROPPED &&
 		(dropReason == flowpb.DropReason_POLICY_DENY || dropReason == flowpb.DropReason_POLICY_DENIED)
 	audited := verdict == flowpb.Verdict_AUDIT
@@ -90,48 +91,48 @@ func CorrelatePolicy(logger *slog.Logger, endpointGetter getters.EndpointGetter,
 	f.PolicyLog = info.Log
 }
 
-func extractFlowKey(f *flowpb.Flow) (
+func extractFlowKey(f *ir.Flow) (
 	direction trafficdirection.TrafficDirection,
 	endpointID uint16,
 	remoteIdentity identity.NumericIdentity,
 	proto u8proto.U8proto,
 	dport uint16) {
 
-	switch f.GetTrafficDirection() {
+	switch f.TrafficDirection {
 	case flowpb.TrafficDirection_EGRESS:
 		direction = trafficdirection.Egress
 		// We only get a uint32 because proto has no 16-bit types.
-		endpointID = uint16(f.GetSource().GetID())
-		remoteIdentity = identity.NumericIdentity(f.GetDestination().GetIdentity())
+		endpointID = uint16(f.Source.ID)
+		remoteIdentity = identity.NumericIdentity(f.Destination.Identity)
 	case flowpb.TrafficDirection_INGRESS:
 		direction = trafficdirection.Ingress
-		endpointID = uint16(f.GetDestination().GetID())
-		remoteIdentity = identity.NumericIdentity(f.GetSource().GetIdentity())
+		endpointID = uint16(f.Destination.ID)
+		remoteIdentity = identity.NumericIdentity(f.Source.Identity)
 	default:
 		direction = trafficdirection.Invalid
 		endpointID = 0
 		remoteIdentity = identity.IdentityUnknown
 	}
 
-	if tcp := f.GetL4().GetTCP(); tcp != nil {
+	if tcp := f.L4.TCP; !tcp.IsEmpty() {
 		proto = u8proto.TCP
-		dport = uint16(tcp.GetDestinationPort())
-	} else if udp := f.GetL4().GetUDP(); udp != nil {
+		dport = uint16(tcp.DestinationPort)
+	} else if udp := f.L4.UDP; !udp.IsEmpty() {
 		proto = u8proto.UDP
-		dport = uint16(udp.GetDestinationPort())
-	} else if icmpv4 := f.GetL4().GetICMPv4(); icmpv4 != nil {
+		dport = uint16(udp.DestinationPort)
+	} else if icmpv4 := f.L4.ICMPv4; !icmpv4.IsEmpty() {
 		proto = u8proto.ICMP
 		dport = uint16(icmpv4.Type)
-	} else if icmpv6 := f.GetL4().GetICMPv6(); icmpv6 != nil {
+	} else if icmpv6 := f.L4.ICMPv6; !icmpv6.IsEmpty() {
 		proto = u8proto.ICMPv6
 		dport = uint16(icmpv6.Type)
-	} else if sctp := f.GetL4().GetSCTP(); sctp != nil {
+	} else if sctp := f.L4.SCTP; !sctp.IsEmpty() {
 		proto = u8proto.SCTP
-		dport = uint16(sctp.GetDestinationPort())
-	} else if vrrp := f.GetL4().GetVRRP(); vrrp != nil {
+		dport = uint16(sctp.DestinationPort)
+	} else if vrrp := f.L4.VRRP; !vrrp.IsEmpty() {
 		proto = u8proto.VRRP
 		dport = 0
-	} else if igmp := f.GetL4().GetIGMP(); igmp != nil {
+	} else if igmp := f.L4.IGMP; !igmp.IsEmpty() {
 		proto = u8proto.IGMP
 		dport = 0
 	} else {
@@ -142,9 +143,9 @@ func extractFlowKey(f *flowpb.Flow) (
 	return
 }
 
-func toProto(info policyTypes.PolicyCorrelationInfo) (policies []*flowpb.Policy) {
+func toProto(info policyTypes.PolicyCorrelationInfo) (policies []ir.Policy) {
 	for model := range labels.ModelsFromLabelArrayListString(info.RuleLabels) {
-		policies = append(policies, utils.GetPolicyFromLabels(model, info.Revision))
+		policies = append(policies, ir.ProtoToPolicy(utils.GetPolicyFromLabels(model, info.Revision)))
 	}
 	return policies
 }

--- a/pkg/policy/correlation/correlation_test.go
+++ b/pkg/policy/correlation/correlation_test.go
@@ -32,28 +32,26 @@ func TestCorrelatePolicy(t *testing.T) {
 	remoteID := uint32(56)
 	dstPort := uint32(443)
 
-	flow := &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	flow := ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_FORWARDED,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP: &flowpb.IP{
+		IP: ir.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
-				},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				DestinationPort: dstPort,
 			},
 		},
-		Source: &flowpb.Endpoint{
+		Source: ir.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: &flowpb.Endpoint{
+		Destination: ir.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
@@ -87,7 +85,7 @@ func TestCorrelatePolicy(t *testing.T) {
 
 	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
 
-	expected := []*flowpb.Policy{
+	expected := []ir.Policy{
 		{
 			Name:      "web-policy",
 			Namespace: "foo-namespace",
@@ -110,29 +108,27 @@ func TestCorrelatePolicy(t *testing.T) {
 	}
 
 	// check same flow at egress with deny
-	flow = &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	flow = ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_DROPPED,
 		DropReasonDesc:   flowpb.DropReason_POLICY_DENY,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP: &flowpb.IP{
+		IP: ir.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
-				},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				DestinationPort: dstPort,
 			},
 		},
-		Source: &flowpb.Endpoint{
+		Source: ir.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: &flowpb.Endpoint{
+		Destination: ir.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
@@ -148,28 +144,26 @@ func TestCorrelatePolicy(t *testing.T) {
 	}
 
 	// check port+proto rule.
-	flow = &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	flow = ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_FORWARDED,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP: &flowpb.IP{
+		IP: ir.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
-				},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				DestinationPort: dstPort,
 			},
 		},
-		Source: &flowpb.Endpoint{
+		Source: ir.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: &flowpb.Endpoint{
+		Destination: ir.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
@@ -222,28 +216,26 @@ func TestCorrelatePolicy(t *testing.T) {
 	}
 
 	// check protocol-only rule.
-	flow = &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	flow = ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_FORWARDED,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP: &flowpb.IP{
+		IP: ir.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
-				},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				DestinationPort: dstPort,
 			},
 		},
-		Source: &flowpb.Endpoint{
+		Source: ir.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: &flowpb.Endpoint{
+		Destination: ir.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
@@ -273,28 +265,26 @@ func TestCorrelatePolicy(t *testing.T) {
 	}
 
 	// check identity and protocol-only rule.
-	flow = &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	flow = ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_FORWARDED,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP: &flowpb.IP{
+		IP: ir.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
-				},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				DestinationPort: dstPort,
 			},
 		},
-		Source: &flowpb.Endpoint{
+		Source: ir.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: &flowpb.Endpoint{
+		Destination: ir.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
@@ -324,28 +314,26 @@ func TestCorrelatePolicy(t *testing.T) {
 	}
 
 	// check allow-all rule.
-	flow = &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	flow = ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_FORWARDED,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP: &flowpb.IP{
+		IP: ir.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
-				},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				DestinationPort: dstPort,
 			},
 		},
-		Source: &flowpb.Endpoint{
+		Source: ir.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: &flowpb.Endpoint{
+		Destination: ir.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
@@ -375,28 +363,26 @@ func TestCorrelatePolicy(t *testing.T) {
 	}
 
 	// check same flow at ingress
-	flow = &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	flow = ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_FORWARDED,
 		TrafficDirection: flowpb.TrafficDirection_INGRESS,
-		IP: &flowpb.IP{
+		IP: ir.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
-				},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				DestinationPort: dstPort,
 			},
 		},
-		Source: &flowpb.Endpoint{
+		Source: ir.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: &flowpb.Endpoint{
+		Destination: ir.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
@@ -435,29 +421,27 @@ func TestCorrelatePolicy(t *testing.T) {
 	}
 
 	// check same flow at ingress with deny
-	flow = &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	flow = ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_DROPPED,
 		DropReasonDesc:   flowpb.DropReason_POLICY_DENY,
 		TrafficDirection: flowpb.TrafficDirection_INGRESS,
-		IP: &flowpb.IP{
+		IP: ir.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
-				},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				DestinationPort: dstPort,
 			},
 		},
-		Source: &flowpb.Endpoint{
+		Source: ir.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: &flowpb.Endpoint{
+		Destination: ir.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
@@ -473,28 +457,26 @@ func TestCorrelatePolicy(t *testing.T) {
 	}
 
 	// match ccnp
-	flow = &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	flow = ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_FORWARDED,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP: &flowpb.IP{
+		IP: ir.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
-				},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				DestinationPort: dstPort,
 			},
 		},
-		Source: &flowpb.Endpoint{
+		Source: ir.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: &flowpb.Endpoint{
+		Destination: ir.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
@@ -528,7 +510,7 @@ func TestCorrelatePolicy(t *testing.T) {
 
 	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
 
-	expected = []*flowpb.Policy{
+	expected = []ir.Policy{
 		{
 			Name: "ccnp",
 			Kind: utils.ResourceTypeCiliumClusterwideNetworkPolicy,
@@ -559,7 +541,7 @@ func TestCorrelatePolicyAudit(t *testing.T) {
 	dstPort := uint32(443)
 
 	policyLabel := utils.GetPolicyLabels("foo-namespace", "deny-policy", "1234-5678", utils.ResourceTypeCiliumNetworkPolicy)
-	expected := []*flowpb.Policy{
+	expected := []ir.Policy{
 		{
 			Name:      "deny-policy",
 			Namespace: "foo-namespace",
@@ -597,28 +579,26 @@ func TestCorrelatePolicyAudit(t *testing.T) {
 	}
 
 	// Verdict_AUDIT at egress should populate EgressDeniedBy
-	flow := &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	flow := &ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_AUDIT,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP: &flowpb.IP{
+		IP: ir.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
-				},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				DestinationPort: dstPort,
 			},
 		},
-		Source: &flowpb.Endpoint{
+		Source: ir.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: &flowpb.Endpoint{
+		Destination: ir.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
@@ -656,28 +636,26 @@ func TestCorrelatePolicyAudit(t *testing.T) {
 		},
 	}
 
-	flow = &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	flow = &ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_AUDIT,
 		TrafficDirection: flowpb.TrafficDirection_INGRESS,
-		IP: &flowpb.IP{
+		IP: ir.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
-				},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				DestinationPort: dstPort,
 			},
 		},
-		Source: &flowpb.Endpoint{
+		Source: ir.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: &flowpb.Endpoint{
+		Destination: ir.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
@@ -703,7 +681,7 @@ func TestCorrelatePolicyImplicitDeny(t *testing.T) {
 	dstPort := uint32(443)
 
 	policyLabel := utils.GetPolicyLabels("foo-namespace", "web-policy", "1234-5678", utils.ResourceTypeCiliumNetworkPolicy)
-	expected := []*flowpb.Policy{
+	expected := []ir.Policy{
 		{
 			Name:      "web-policy",
 			Namespace: "foo-namespace",
@@ -741,29 +719,27 @@ func TestCorrelatePolicyImplicitDeny(t *testing.T) {
 		},
 	}
 
-	flow := &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	flow := ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_DROPPED,
 		DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP: &flowpb.IP{
+		IP: ir.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
-				},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				DestinationPort: dstPort,
 			},
 		},
-		Source: &flowpb.Endpoint{
+		Source: ir.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: &flowpb.Endpoint{
+		Destination: ir.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
@@ -801,29 +777,27 @@ func TestCorrelatePolicyImplicitDeny(t *testing.T) {
 		},
 	}
 
-	flow = &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	flow = ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_DROPPED,
 		DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
 		TrafficDirection: flowpb.TrafficDirection_INGRESS,
-		IP: &flowpb.IP{
+		IP: ir.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
-				},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				DestinationPort: dstPort,
 			},
 		},
-		Source: &flowpb.Endpoint{
+		Source: ir.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: &flowpb.Endpoint{
+		Destination: ir.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
@@ -848,16 +822,16 @@ func TestCorrelatePolicy_PortRange(t *testing.T) {
 	remoteID := uint32(56)
 	dstPort := uint32(80) // inside [64, 127]
 
-	flow := &flowpb.Flow{
-		EventType:        &flowpb.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
+	flow := ir.Flow{
+		EventType:        ir.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
 		Verdict:          flowpb.Verdict_FORWARDED,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP:               &flowpb.IP{Source: localIP, Destination: remoteIP},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{DestinationPort: dstPort}},
+		IP:               ir.IP{Source: localIP, Destination: remoteIP},
+		L4: ir.Layer4{
+			TCP: ir.TCP{DestinationPort: dstPort},
 		},
-		Source:          &flowpb.Endpoint{ID: localID, Identity: localIdentity},
-		Destination:     &flowpb.Endpoint{ID: remoteID, Identity: remoteIdentity},
+		Source:          ir.Endpoint{ID: localID, Identity: localIdentity},
+		Destination:     ir.Endpoint{ID: remoteID, Identity: remoteIdentity},
 		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
 	}
 
@@ -890,7 +864,7 @@ func TestCorrelatePolicy_PortRange(t *testing.T) {
 
 	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
 
-	expected := []*flowpb.Policy{
+	expected := []ir.Policy{
 		{
 			Name:      "port-range-policy",
 			Namespace: "foo-namespace",

--- a/pkg/policy/correlation/correlation_test.go
+++ b/pkg/policy/correlation/correlation_test.go
@@ -33,28 +33,26 @@ func TestCorrelatePolicy(t *testing.T) {
 	remoteID := uint32(56)
 	dstPort := uint32(443)
 
-	flow := &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	flow := ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_FORWARDED,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP: &flowpb.IP{
+		IP: ir.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
-				},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				DestinationPort: dstPort,
 			},
 		},
-		Source: &flowpb.Endpoint{
+		Source: ir.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: &flowpb.Endpoint{
+		Destination: ir.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
@@ -86,10 +84,9 @@ func TestCorrelatePolicy(t *testing.T) {
 		},
 	}
 
-	flowIR := ir.ProtoToFlow(flow)
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, &flow)
 
-	expected := []*flowpb.Policy{
+	expected := []ir.Policy{
 		{
 			Name:      "web-policy",
 			Namespace: "foo-namespace",
@@ -112,36 +109,33 @@ func TestCorrelatePolicy(t *testing.T) {
 	}
 
 	// check same flow at egress with deny
-	flow = &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	flow = ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_DROPPED,
 		DropReasonDesc:   flowpb.DropReason_POLICY_DENY,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP: &flowpb.IP{
+		IP: ir.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
-				},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				DestinationPort: dstPort,
 			},
 		},
-		Source: &flowpb.Endpoint{
+		Source: ir.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: &flowpb.Endpoint{
+		Destination: ir.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
 	}
-	flowIR = ir.ProtoToFlow(flow)
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, &flow)
 
 	require.Nil(t, flow.EgressAllowedBy)
 	require.Nil(t, flow.IngressAllowedBy)
@@ -151,28 +145,26 @@ func TestCorrelatePolicy(t *testing.T) {
 	}
 
 	// check port+proto rule.
-	flow = &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	flow = ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_FORWARDED,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP: &flowpb.IP{
+		IP: ir.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
-				},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				DestinationPort: dstPort,
 			},
 		},
-		Source: &flowpb.Endpoint{
+		Source: ir.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: &flowpb.Endpoint{
+		Destination: ir.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
@@ -192,8 +184,7 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyRevision: 1,
 	}
 
-	flowIR = ir.ProtoToFlow(flow)
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, &flow)
 
 	require.Nil(t, flow.EgressDeniedBy)
 	require.Nil(t, flow.IngressDeniedBy)
@@ -216,8 +207,7 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyRevision: 1,
 	}
 
-	flowIR = ir.ProtoToFlow(flow)
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, &flow)
 
 	require.Nil(t, flow.EgressDeniedBy)
 	require.Nil(t, flow.IngressDeniedBy)
@@ -227,28 +217,26 @@ func TestCorrelatePolicy(t *testing.T) {
 	}
 
 	// check protocol-only rule.
-	flow = &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	flow = ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_FORWARDED,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP: &flowpb.IP{
+		IP: ir.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
-				},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				DestinationPort: dstPort,
 			},
 		},
-		Source: &flowpb.Endpoint{
+		Source: ir.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: &flowpb.Endpoint{
+		Destination: ir.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
@@ -268,8 +256,7 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyRevision: 1,
 	}
 
-	flowIR = ir.ProtoToFlow(flow)
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, &flow)
 
 	require.Nil(t, flow.EgressDeniedBy)
 	require.Nil(t, flow.IngressDeniedBy)
@@ -279,28 +266,26 @@ func TestCorrelatePolicy(t *testing.T) {
 	}
 
 	// check identity and protocol-only rule.
-	flow = &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	flow = ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_FORWARDED,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP: &flowpb.IP{
+		IP: ir.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
-				},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				DestinationPort: dstPort,
 			},
 		},
-		Source: &flowpb.Endpoint{
+		Source: ir.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: &flowpb.Endpoint{
+		Destination: ir.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
@@ -320,8 +305,7 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyRevision: 1,
 	}
 
-	flowIR = ir.ProtoToFlow(flow)
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, &flow)
 
 	require.Nil(t, flow.EgressDeniedBy)
 	require.Nil(t, flow.IngressDeniedBy)
@@ -331,28 +315,26 @@ func TestCorrelatePolicy(t *testing.T) {
 	}
 
 	// check allow-all rule.
-	flow = &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	flow = ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_FORWARDED,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP: &flowpb.IP{
+		IP: ir.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
-				},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				DestinationPort: dstPort,
 			},
 		},
-		Source: &flowpb.Endpoint{
+		Source: ir.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: &flowpb.Endpoint{
+		Destination: ir.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
@@ -372,8 +354,7 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyRevision: 1,
 	}
 
-	flowIR = ir.ProtoToFlow(flow)
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, &flow)
 
 	require.Nil(t, flow.EgressDeniedBy)
 	require.Nil(t, flow.IngressDeniedBy)
@@ -383,28 +364,26 @@ func TestCorrelatePolicy(t *testing.T) {
 	}
 
 	// check same flow at ingress
-	flow = &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	flow = ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_FORWARDED,
 		TrafficDirection: flowpb.TrafficDirection_INGRESS,
-		IP: &flowpb.IP{
+		IP: ir.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
-				},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				DestinationPort: dstPort,
 			},
 		},
-		Source: &flowpb.Endpoint{
+		Source: ir.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: &flowpb.Endpoint{
+		Destination: ir.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
@@ -434,8 +413,7 @@ func TestCorrelatePolicy(t *testing.T) {
 		},
 	}
 
-	flowIR = ir.ProtoToFlow(flow)
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, &flow)
 
 	require.Nil(t, flow.EgressDeniedBy)
 	require.Nil(t, flow.IngressDeniedBy)
@@ -445,36 +423,33 @@ func TestCorrelatePolicy(t *testing.T) {
 	}
 
 	// check same flow at ingress with deny
-	flow = &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	flow = ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_DROPPED,
 		DropReasonDesc:   flowpb.DropReason_POLICY_DENY,
 		TrafficDirection: flowpb.TrafficDirection_INGRESS,
-		IP: &flowpb.IP{
+		IP: ir.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
-				},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				DestinationPort: dstPort,
 			},
 		},
-		Source: &flowpb.Endpoint{
+		Source: ir.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: &flowpb.Endpoint{
+		Destination: ir.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3Only,
 	}
-	flowIR = ir.ProtoToFlow(flow)
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, &flow)
 
 	require.Nil(t, flow.EgressAllowedBy)
 	require.Nil(t, flow.IngressAllowedBy)
@@ -484,28 +459,26 @@ func TestCorrelatePolicy(t *testing.T) {
 	}
 
 	// match ccnp
-	flow = &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	flow = ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_FORWARDED,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP: &flowpb.IP{
+		IP: ir.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
-				},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				DestinationPort: dstPort,
 			},
 		},
-		Source: &flowpb.Endpoint{
+		Source: ir.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: &flowpb.Endpoint{
+		Destination: ir.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
@@ -537,10 +510,9 @@ func TestCorrelatePolicy(t *testing.T) {
 		},
 	}
 
-	flowIR = ir.ProtoToFlow(flow)
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, &flow)
 
-	expected = []*flowpb.Policy{
+	expected = []ir.Policy{
 		{
 			Name: "ccnp",
 			Kind: utils.ResourceTypeCiliumClusterwideNetworkPolicy,
@@ -571,7 +543,7 @@ func TestCorrelatePolicyAudit(t *testing.T) {
 	dstPort := uint32(443)
 
 	policyLabel := utils.GetPolicyLabels("foo-namespace", "deny-policy", "1234-5678", utils.ResourceTypeCiliumNetworkPolicy)
-	expected := []*flowpb.Policy{
+	expected := []ir.Policy{
 		{
 			Name:      "deny-policy",
 			Namespace: "foo-namespace",
@@ -609,35 +581,32 @@ func TestCorrelatePolicyAudit(t *testing.T) {
 	}
 
 	// Verdict_AUDIT at egress should populate EgressDeniedBy
-	flow := &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	flow := &ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_AUDIT,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP: &flowpb.IP{
+		IP: ir.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
-				},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				DestinationPort: dstPort,
 			},
 		},
-		Source: &flowpb.Endpoint{
+		Source: ir.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: &flowpb.Endpoint{
+		Destination: ir.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
 	}
-	flowIR := ir.ProtoToFlow(flow)
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
 
 	require.Nil(t, flow.EgressAllowedBy)
 	require.Nil(t, flow.IngressAllowedBy)
@@ -669,35 +638,32 @@ func TestCorrelatePolicyAudit(t *testing.T) {
 		},
 	}
 
-	flow = &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	flow = &ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_AUDIT,
 		TrafficDirection: flowpb.TrafficDirection_INGRESS,
-		IP: &flowpb.IP{
+		IP: ir.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
-				},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				DestinationPort: dstPort,
 			},
 		},
-		Source: &flowpb.Endpoint{
+		Source: ir.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: &flowpb.Endpoint{
+		Destination: ir.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
 	}
-	flowIR = ir.ProtoToFlow(flow)
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
 
 	require.Nil(t, flow.EgressAllowedBy)
 	require.Nil(t, flow.IngressAllowedBy)
@@ -717,7 +683,7 @@ func TestCorrelatePolicyImplicitDeny(t *testing.T) {
 	dstPort := uint32(443)
 
 	policyLabel := utils.GetPolicyLabels("foo-namespace", "web-policy", "1234-5678", utils.ResourceTypeCiliumNetworkPolicy)
-	expected := []*flowpb.Policy{
+	expected := []ir.Policy{
 		{
 			Name:      "web-policy",
 			Namespace: "foo-namespace",
@@ -755,36 +721,33 @@ func TestCorrelatePolicyImplicitDeny(t *testing.T) {
 		},
 	}
 
-	flow := &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	flow := ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_DROPPED,
 		DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP: &flowpb.IP{
+		IP: ir.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
-				},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				DestinationPort: dstPort,
 			},
 		},
-		Source: &flowpb.Endpoint{
+		Source: ir.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: &flowpb.Endpoint{
+		Destination: ir.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
 	}
-	flowIR := ir.ProtoToFlow(flow)
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, &flow)
 
 	require.Nil(t, flow.EgressAllowedBy)
 	require.Nil(t, flow.IngressAllowedBy)
@@ -816,36 +779,33 @@ func TestCorrelatePolicyImplicitDeny(t *testing.T) {
 		},
 	}
 
-	flow = &flowpb.Flow{
-		EventType: &flowpb.CiliumEventType{
+	flow = ir.Flow{
+		EventType: ir.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_DROPPED,
 		DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
 		TrafficDirection: flowpb.TrafficDirection_INGRESS,
-		IP: &flowpb.IP{
+		IP: ir.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{
-				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
-				},
+		L4: ir.Layer4{
+			TCP: ir.TCP{
+				DestinationPort: dstPort,
 			},
 		},
-		Source: &flowpb.Endpoint{
+		Source: ir.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: &flowpb.Endpoint{
+		Destination: ir.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
 	}
-	flowIR = ir.ProtoToFlow(flow)
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, &flow)
 
 	require.Nil(t, flow.EgressAllowedBy)
 	require.Nil(t, flow.IngressAllowedBy)
@@ -864,16 +824,16 @@ func TestCorrelatePolicy_PortRange(t *testing.T) {
 	remoteID := uint32(56)
 	dstPort := uint32(80) // inside [64, 127]
 
-	flow := &flowpb.Flow{
-		EventType:        &flowpb.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
+	flow := ir.Flow{
+		EventType:        ir.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
 		Verdict:          flowpb.Verdict_FORWARDED,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP:               &flowpb.IP{Source: localIP, Destination: remoteIP},
-		L4: &flowpb.Layer4{
-			Protocol: &flowpb.Layer4_TCP{TCP: &flowpb.TCP{DestinationPort: dstPort}},
+		IP:               ir.IP{Source: localIP, Destination: remoteIP},
+		L4: ir.Layer4{
+			TCP: ir.TCP{DestinationPort: dstPort},
 		},
-		Source:          &flowpb.Endpoint{ID: localID, Identity: localIdentity},
-		Destination:     &flowpb.Endpoint{ID: remoteID, Identity: remoteIdentity},
+		Source:          ir.Endpoint{ID: localID, Identity: localIdentity},
+		Destination:     ir.Endpoint{ID: remoteID, Identity: remoteIdentity},
 		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
 	}
 
@@ -904,10 +864,9 @@ func TestCorrelatePolicy_PortRange(t *testing.T) {
 		},
 	}
 
-	flowIR := ir.ProtoToFlow(flow)
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, &flow)
 
-	expected := []*flowpb.Policy{
+	expected := []ir.Policy{
 		{
 			Name:      "port-range-policy",
 			Namespace: "foo-namespace",

--- a/pkg/policy/correlation/correlation_test.go
+++ b/pkg/policy/correlation/correlation_test.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	"github.com/cilium/cilium/pkg/hubble/testutils"
 	"github.com/cilium/cilium/pkg/identity"
@@ -32,26 +33,28 @@ func TestCorrelatePolicy(t *testing.T) {
 	remoteID := uint32(56)
 	dstPort := uint32(443)
 
-	flow := ir.Flow{
-		EventType: ir.CiliumEventType{
+	flow := &flowpb.Flow{
+		EventType: &flowpb.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_FORWARDED,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP: ir.IP{
+		IP: &flowpb.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: ir.Layer4{
-			TCP: ir.TCP{
-				DestinationPort: dstPort,
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{
+				TCP: &flowpb.TCP{
+					DestinationPort: dstPort,
+				},
 			},
 		},
-		Source: ir.Endpoint{
+		Source: &flowpb.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: ir.Endpoint{
+		Destination: &flowpb.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
@@ -83,7 +86,8 @@ func TestCorrelatePolicy(t *testing.T) {
 		},
 	}
 
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
+	flowIR := ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR, 0)
 
 	expected := []ir.Policy{
 		{
@@ -103,67 +107,72 @@ func TestCorrelatePolicy(t *testing.T) {
 	require.Nil(t, flow.EgressDeniedBy)
 	require.Nil(t, flow.IngressDeniedBy)
 	require.Nil(t, flow.IngressAllowedBy)
-	if diff := cmp.Diff(expected, flow.EgressAllowedBy, protocmp.Transform()); diff != "" {
+	if diff := cmp.Diff(expected, flowIR.EgressAllowedBy, protocmp.Transform()); diff != "" {
 		t.Fatalf("not equal (-want +got):\n%s", diff)
 	}
 
 	// check same flow at egress with deny
-	flow = ir.Flow{
-		EventType: ir.CiliumEventType{
+	flow = &flowpb.Flow{
+		EventType: &flowpb.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_DROPPED,
 		DropReasonDesc:   flowpb.DropReason_POLICY_DENY,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP: ir.IP{
+		IP: &flowpb.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: ir.Layer4{
-			TCP: ir.TCP{
-				DestinationPort: dstPort,
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{
+				TCP: &flowpb.TCP{
+					DestinationPort: dstPort,
+				},
 			},
 		},
-		Source: ir.Endpoint{
+		Source: &flowpb.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: ir.Endpoint{
+		Destination: &flowpb.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
 	}
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
+	flowIR = ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR, 0)
 
 	require.Nil(t, flow.EgressAllowedBy)
 	require.Nil(t, flow.IngressAllowedBy)
 	require.Nil(t, flow.IngressDeniedBy)
-	if diff := cmp.Diff(expected, flow.EgressDeniedBy, protocmp.Transform()); diff != "" {
+	if diff := cmp.Diff(expected, flowIR.EgressDeniedBy, protocmp.Transform()); diff != "" {
 		t.Fatalf("not equal (-want +got):\n%s", diff)
 	}
 
 	// check port+proto rule.
-	flow = ir.Flow{
-		EventType: ir.CiliumEventType{
+	flow = &flowpb.Flow{
+		EventType: &flowpb.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_FORWARDED,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP: ir.IP{
+		IP: &flowpb.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: ir.Layer4{
-			TCP: ir.TCP{
-				DestinationPort: dstPort,
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{
+				TCP: &flowpb.TCP{
+					DestinationPort: dstPort,
+				},
 			},
 		},
-		Source: ir.Endpoint{
+		Source: &flowpb.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: ir.Endpoint{
+		Destination: &flowpb.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
@@ -183,12 +192,13 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyRevision: 1,
 	}
 
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
+	flowIR = ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR, 0)
 
 	require.Nil(t, flow.EgressDeniedBy)
 	require.Nil(t, flow.IngressDeniedBy)
 	require.Nil(t, flow.IngressAllowedBy)
-	if diff := cmp.Diff(expected, flow.EgressAllowedBy, protocmp.Transform()); diff != "" {
+	if diff := cmp.Diff(expected, flowIR.EgressAllowedBy, protocmp.Transform()); diff != "" {
 		t.Fatalf("not equal (-want +got):\n%s", diff)
 	}
 
@@ -206,36 +216,39 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyRevision: 1,
 	}
 
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
+	flowIR = ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR, 0)
 
 	require.Nil(t, flow.EgressDeniedBy)
 	require.Nil(t, flow.IngressDeniedBy)
 	require.Nil(t, flow.IngressAllowedBy)
-	if diff := cmp.Diff(expected, flow.EgressAllowedBy, protocmp.Transform()); diff != "" {
+	if diff := cmp.Diff(expected, flowIR.EgressAllowedBy, protocmp.Transform()); diff != "" {
 		t.Fatalf("not equal (-want +got):\n%s", diff)
 	}
 
 	// check protocol-only rule.
-	flow = ir.Flow{
-		EventType: ir.CiliumEventType{
+	flow = &flowpb.Flow{
+		EventType: &flowpb.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_FORWARDED,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP: ir.IP{
+		IP: &flowpb.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: ir.Layer4{
-			TCP: ir.TCP{
-				DestinationPort: dstPort,
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{
+				TCP: &flowpb.TCP{
+					DestinationPort: dstPort,
+				},
 			},
 		},
-		Source: ir.Endpoint{
+		Source: &flowpb.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: ir.Endpoint{
+		Destination: &flowpb.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
@@ -255,36 +268,39 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyRevision: 1,
 	}
 
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
+	flowIR = ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR, 0)
 
 	require.Nil(t, flow.EgressDeniedBy)
 	require.Nil(t, flow.IngressDeniedBy)
 	require.Nil(t, flow.IngressAllowedBy)
-	if diff := cmp.Diff(expected, flow.EgressAllowedBy, protocmp.Transform()); diff != "" {
+	if diff := cmp.Diff(expected, flowIR.EgressAllowedBy, protocmp.Transform()); diff != "" {
 		t.Fatalf("not equal (-want +got):\n%s", diff)
 	}
 
 	// check identity and protocol-only rule.
-	flow = ir.Flow{
-		EventType: ir.CiliumEventType{
+	flow = &flowpb.Flow{
+		EventType: &flowpb.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_FORWARDED,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP: ir.IP{
+		IP: &flowpb.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: ir.Layer4{
-			TCP: ir.TCP{
-				DestinationPort: dstPort,
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{
+				TCP: &flowpb.TCP{
+					DestinationPort: dstPort,
+				},
 			},
 		},
-		Source: ir.Endpoint{
+		Source: &flowpb.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: ir.Endpoint{
+		Destination: &flowpb.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
@@ -304,36 +320,39 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyRevision: 1,
 	}
 
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
+	flowIR = ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR, 0)
 
 	require.Nil(t, flow.EgressDeniedBy)
 	require.Nil(t, flow.IngressDeniedBy)
 	require.Nil(t, flow.IngressAllowedBy)
-	if diff := cmp.Diff(expected, flow.EgressAllowedBy, protocmp.Transform()); diff != "" {
+	if diff := cmp.Diff(expected, flowIR.EgressAllowedBy, protocmp.Transform()); diff != "" {
 		t.Fatalf("not equal (-want +got):\n%s", diff)
 	}
 
 	// check allow-all rule.
-	flow = ir.Flow{
-		EventType: ir.CiliumEventType{
+	flow = &flowpb.Flow{
+		EventType: &flowpb.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_FORWARDED,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP: ir.IP{
+		IP: &flowpb.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: ir.Layer4{
-			TCP: ir.TCP{
-				DestinationPort: dstPort,
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{
+				TCP: &flowpb.TCP{
+					DestinationPort: dstPort,
+				},
 			},
 		},
-		Source: ir.Endpoint{
+		Source: &flowpb.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: ir.Endpoint{
+		Destination: &flowpb.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
@@ -353,36 +372,39 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyRevision: 1,
 	}
 
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
+	flowIR = ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR, 0)
 
 	require.Nil(t, flow.EgressDeniedBy)
 	require.Nil(t, flow.IngressDeniedBy)
 	require.Nil(t, flow.IngressAllowedBy)
-	if diff := cmp.Diff(expected, flow.EgressAllowedBy, protocmp.Transform()); diff != "" {
+	if diff := cmp.Diff(expected, flowIR.EgressAllowedBy, protocmp.Transform()); diff != "" {
 		t.Fatalf("not equal (-want +got):\n%s", diff)
 	}
 
 	// check same flow at ingress
-	flow = ir.Flow{
-		EventType: ir.CiliumEventType{
+	flow = &flowpb.Flow{
+		EventType: &flowpb.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_FORWARDED,
 		TrafficDirection: flowpb.TrafficDirection_INGRESS,
-		IP: ir.IP{
+		IP: &flowpb.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: ir.Layer4{
-			TCP: ir.TCP{
-				DestinationPort: dstPort,
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{
+				TCP: &flowpb.TCP{
+					DestinationPort: dstPort,
+				},
 			},
 		},
-		Source: ir.Endpoint{
+		Source: &flowpb.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: ir.Endpoint{
+		Destination: &flowpb.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
@@ -411,72 +433,79 @@ func TestCorrelatePolicy(t *testing.T) {
 			return nil, false
 		},
 	}
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
 
-	require.Nil(t, flow.EgressDeniedBy)
-	require.Nil(t, flow.IngressDeniedBy)
-	require.Nil(t, flow.EgressAllowedBy)
-	if diff := cmp.Diff(expected, flow.IngressAllowedBy, protocmp.Transform()); diff != "" {
+	flowIR = ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR, 0)
+
+	require.Empty(t, flowIR.EgressDeniedBy)
+	require.Empty(t, flowIR.IngressDeniedBy)
+	require.Empty(t, flowIR.EgressAllowedBy)
+	if diff := cmp.Diff(expected, flowIR.IngressAllowedBy, protocmp.Transform()); diff != "" {
 		t.Fatalf("not equal (-want +got):\n%s", diff)
 	}
 
 	// check same flow at ingress with deny
-	flow = ir.Flow{
-		EventType: ir.CiliumEventType{
+	flow = &flowpb.Flow{
+		EventType: &flowpb.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_DROPPED,
 		DropReasonDesc:   flowpb.DropReason_POLICY_DENY,
 		TrafficDirection: flowpb.TrafficDirection_INGRESS,
-		IP: ir.IP{
+		IP: &flowpb.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: ir.Layer4{
-			TCP: ir.TCP{
-				DestinationPort: dstPort,
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{
+				TCP: &flowpb.TCP{
+					DestinationPort: dstPort,
+				},
 			},
 		},
-		Source: ir.Endpoint{
+		Source: &flowpb.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: ir.Endpoint{
+		Destination: &flowpb.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3Only,
 	}
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
+	flowIR = ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR, 0)
 
-	require.Nil(t, flow.EgressAllowedBy)
-	require.Nil(t, flow.IngressAllowedBy)
-	require.Nil(t, flow.EgressDeniedBy)
-	if diff := cmp.Diff(expected, flow.IngressDeniedBy, protocmp.Transform()); diff != "" {
+	require.Empty(t, flowIR.EgressAllowedBy)
+	require.Empty(t, flowIR.IngressAllowedBy)
+	require.Empty(t, flowIR.EgressDeniedBy)
+	if diff := cmp.Diff(expected, flowIR.IngressDeniedBy, protocmp.Transform()); diff != "" {
 		t.Fatalf("not equal (-want +got):\n%s", diff)
 	}
 
 	// match ccnp
-	flow = ir.Flow{
-		EventType: ir.CiliumEventType{
+	flow = &flowpb.Flow{
+		EventType: &flowpb.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_FORWARDED,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP: ir.IP{
+		IP: &flowpb.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: ir.Layer4{
-			TCP: ir.TCP{
-				DestinationPort: dstPort,
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{
+				TCP: &flowpb.TCP{
+					DestinationPort: dstPort,
+				},
 			},
 		},
-		Source: ir.Endpoint{
+		Source: &flowpb.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: ir.Endpoint{
+		Destination: &flowpb.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
@@ -508,7 +537,8 @@ func TestCorrelatePolicy(t *testing.T) {
 		},
 	}
 
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
+	flowIR = ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR, 0)
 
 	expected = []ir.Policy{
 		{
@@ -523,10 +553,10 @@ func TestCorrelatePolicy(t *testing.T) {
 		},
 	}
 
-	require.Nil(t, flow.EgressDeniedBy)
-	require.Nil(t, flow.IngressDeniedBy)
-	require.Nil(t, flow.IngressAllowedBy)
-	if diff := cmp.Diff(expected, flow.EgressAllowedBy, protocmp.Transform()); diff != "" {
+	require.Empty(t, flowIR.EgressDeniedBy)
+	require.Empty(t, flowIR.IngressDeniedBy)
+	require.Empty(t, flowIR.IngressAllowedBy)
+	if diff := cmp.Diff(expected, flowIR.EgressAllowedBy, protocmp.Transform()); diff != "" {
 		t.Fatalf("not equal (-want +got):\n%s", diff)
 	}
 }
@@ -579,37 +609,40 @@ func TestCorrelatePolicyAudit(t *testing.T) {
 	}
 
 	// Verdict_AUDIT at egress should populate EgressDeniedBy
-	flow := &ir.Flow{
-		EventType: ir.CiliumEventType{
+	flow := &flowpb.Flow{
+		EventType: &flowpb.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_AUDIT,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP: ir.IP{
+		IP: &flowpb.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: ir.Layer4{
-			TCP: ir.TCP{
-				DestinationPort: dstPort,
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{
+				TCP: &flowpb.TCP{
+					DestinationPort: dstPort,
+				},
 			},
 		},
-		Source: ir.Endpoint{
+		Source: &flowpb.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: ir.Endpoint{
+		Destination: &flowpb.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
 	}
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
+	flowIR := ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR, 0)
 
-	require.Nil(t, flow.EgressAllowedBy)
-	require.Nil(t, flow.IngressAllowedBy)
-	require.Nil(t, flow.IngressDeniedBy)
-	if diff := cmp.Diff(expected, flow.EgressDeniedBy, protocmp.Transform()); diff != "" {
+	require.Empty(t, flowIR.EgressAllowedBy)
+	require.Empty(t, flowIR.IngressAllowedBy)
+	require.Empty(t, flowIR.IngressDeniedBy)
+	if diff := cmp.Diff(expected, flowIR.EgressDeniedBy, protocmp.Transform()); diff != "" {
 		t.Fatalf("not equal (-want +got):\n%s", diff)
 	}
 
@@ -636,37 +669,40 @@ func TestCorrelatePolicyAudit(t *testing.T) {
 		},
 	}
 
-	flow = &ir.Flow{
-		EventType: ir.CiliumEventType{
+	flow = &flowpb.Flow{
+		EventType: &flowpb.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_AUDIT,
 		TrafficDirection: flowpb.TrafficDirection_INGRESS,
-		IP: ir.IP{
+		IP: &flowpb.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: ir.Layer4{
-			TCP: ir.TCP{
-				DestinationPort: dstPort,
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{
+				TCP: &flowpb.TCP{
+					DestinationPort: dstPort,
+				},
 			},
 		},
-		Source: ir.Endpoint{
+		Source: &flowpb.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: ir.Endpoint{
+		Destination: &flowpb.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
 	}
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
+	flowIR = ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR, 0)
 
-	require.Nil(t, flow.EgressAllowedBy)
-	require.Nil(t, flow.IngressAllowedBy)
-	require.Nil(t, flow.EgressDeniedBy)
-	if diff := cmp.Diff(expected, flow.IngressDeniedBy, protocmp.Transform()); diff != "" {
+	require.Empty(t, flowIR.EgressAllowedBy)
+	require.Empty(t, flowIR.IngressAllowedBy)
+	require.Empty(t, flowIR.EgressDeniedBy)
+	if diff := cmp.Diff(expected, flowIR.IngressDeniedBy, protocmp.Transform()); diff != "" {
 		t.Fatalf("not equal (-want +got):\n%s", diff)
 	}
 }
@@ -719,38 +755,41 @@ func TestCorrelatePolicyImplicitDeny(t *testing.T) {
 		},
 	}
 
-	flow := ir.Flow{
-		EventType: ir.CiliumEventType{
+	flow := &flowpb.Flow{
+		EventType: &flowpb.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_DROPPED,
 		DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP: ir.IP{
+		IP: &flowpb.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: ir.Layer4{
-			TCP: ir.TCP{
-				DestinationPort: dstPort,
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{
+				TCP: &flowpb.TCP{
+					DestinationPort: dstPort,
+				},
 			},
 		},
-		Source: ir.Endpoint{
+		Source: &flowpb.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: ir.Endpoint{
+		Destination: &flowpb.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
 	}
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
+	flowIR := ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR, 0)
 
-	require.Nil(t, flow.EgressAllowedBy)
-	require.Nil(t, flow.IngressAllowedBy)
-	require.Nil(t, flow.IngressDeniedBy)
-	if diff := cmp.Diff(expected, flow.EgressDeniedBy, protocmp.Transform()); diff != "" {
+	require.Empty(t, flowIR.EgressAllowedBy)
+	require.Empty(t, flowIR.IngressAllowedBy)
+	require.Empty(t, flowIR.IngressDeniedBy)
+	if diff := cmp.Diff(expected, flowIR.EgressDeniedBy, protocmp.Transform()); diff != "" {
 		t.Fatalf("not equal (-want +got):\n%s", diff)
 	}
 
@@ -777,38 +816,41 @@ func TestCorrelatePolicyImplicitDeny(t *testing.T) {
 		},
 	}
 
-	flow = ir.Flow{
-		EventType: ir.CiliumEventType{
+	flow = &flowpb.Flow{
+		EventType: &flowpb.CiliumEventType{
 			Type: monitorAPI.MessageTypePolicyVerdict,
 		},
 		Verdict:          flowpb.Verdict_DROPPED,
 		DropReasonDesc:   flowpb.DropReason_POLICY_DENIED,
 		TrafficDirection: flowpb.TrafficDirection_INGRESS,
-		IP: ir.IP{
+		IP: &flowpb.IP{
 			Source:      localIP,
 			Destination: remoteIP,
 		},
-		L4: ir.Layer4{
-			TCP: ir.TCP{
-				DestinationPort: dstPort,
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{
+				TCP: &flowpb.TCP{
+					DestinationPort: dstPort,
+				},
 			},
 		},
-		Source: ir.Endpoint{
+		Source: &flowpb.Endpoint{
 			ID:       localID,
 			Identity: localIdentity,
 		},
-		Destination: ir.Endpoint{
+		Destination: &flowpb.Endpoint{
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
 	}
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
+	flowIR = ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR, 0)
 
-	require.Nil(t, flow.EgressAllowedBy)
-	require.Nil(t, flow.IngressAllowedBy)
-	require.Nil(t, flow.EgressDeniedBy)
-	if diff := cmp.Diff(expected, flow.IngressDeniedBy, protocmp.Transform()); diff != "" {
+	require.Empty(t, flowIR.EgressAllowedBy)
+	require.Empty(t, flowIR.IngressAllowedBy)
+	require.Empty(t, flowIR.EgressDeniedBy)
+	if diff := cmp.Diff(expected, flowIR.IngressDeniedBy, protocmp.Transform()); diff != "" {
 		t.Fatalf("not equal (-want +got):\n%s", diff)
 	}
 }
@@ -822,16 +864,18 @@ func TestCorrelatePolicy_PortRange(t *testing.T) {
 	remoteID := uint32(56)
 	dstPort := uint32(80) // inside [64, 127]
 
-	flow := ir.Flow{
-		EventType:        ir.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
+	flow := &flowpb.Flow{
+		EventType:        &flowpb.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
 		Verdict:          flowpb.Verdict_FORWARDED,
 		TrafficDirection: flowpb.TrafficDirection_EGRESS,
-		IP:               ir.IP{Source: localIP, Destination: remoteIP},
-		L4: ir.Layer4{
-			TCP: ir.TCP{DestinationPort: dstPort},
+		IP:               &flowpb.IP{Source: localIP, Destination: remoteIP},
+		L4: &flowpb.Layer4{
+			Protocol: &flowpb.Layer4_TCP{
+				TCP: &flowpb.TCP{DestinationPort: dstPort},
+			},
 		},
-		Source:          ir.Endpoint{ID: localID, Identity: localIdentity},
-		Destination:     ir.Endpoint{ID: remoteID, Identity: remoteIdentity},
+		Source:          &flowpb.Endpoint{ID: localID, Identity: localIdentity},
+		Destination:     &flowpb.Endpoint{ID: remoteID, Identity: remoteIdentity},
 		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
 	}
 
@@ -862,7 +906,8 @@ func TestCorrelatePolicy_PortRange(t *testing.T) {
 		},
 	}
 
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, 0)
+	flowIR := ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR, 0)
 
 	expected := []ir.Policy{
 		{
@@ -879,10 +924,10 @@ func TestCorrelatePolicy_PortRange(t *testing.T) {
 		},
 	}
 
-	require.Nil(t, flow.IngressAllowedBy)
-	require.Nil(t, flow.EgressDeniedBy)
-	require.Nil(t, flow.IngressDeniedBy)
-	if diff := cmp.Diff(expected, flow.EgressAllowedBy, protocmp.Transform()); diff != "" {
+	require.Empty(t, flowIR.IngressAllowedBy)
+	require.Empty(t, flowIR.EgressDeniedBy)
+	require.Empty(t, flowIR.IngressDeniedBy)
+	if diff := cmp.Diff(expected, flowIR.EgressAllowedBy, protocmp.Transform()); diff != "" {
 		t.Fatalf("not equal (-want +got):\n%s", diff)
 	}
 }
@@ -894,7 +939,7 @@ func TestCorrelatePolicy_NotifyEndpointID(t *testing.T) {
 	hostEPID := uint16(1092)
 	dstPort := uint32(22)
 
-	flow := &flowpb.Flow{
+	flow := flowpb.Flow{
 		EventType:        &flowpb.CiliumEventType{Type: monitorAPI.MessageTypePolicyVerdict},
 		Verdict:          flowpb.Verdict_FORWARDED,
 		TrafficDirection: flowpb.TrafficDirection_INGRESS,
@@ -928,9 +973,10 @@ func TestCorrelatePolicy_NotifyEndpointID(t *testing.T) {
 		},
 	}
 
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow, hostEPID)
+	flowIR := ir.ProtoToFlow(&flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR, hostEPID)
 
-	expected := []*flowpb.Policy{
+	expected := []ir.Policy{
 		{
 			Name: "host-fw",
 			Kind: utils.ResourceTypeCiliumClusterwideNetworkPolicy,
@@ -943,8 +989,8 @@ func TestCorrelatePolicy_NotifyEndpointID(t *testing.T) {
 		},
 	}
 
-	require.Nil(t, flow.EgressAllowedBy)
-	require.Nil(t, flow.EgressDeniedBy)
-	require.Nil(t, flow.IngressDeniedBy)
-	testutils.AssertProtoEqual(t, expected, flow.IngressAllowedBy)
+	require.Empty(t, flowIR.EgressAllowedBy)
+	require.Empty(t, flowIR.EgressDeniedBy)
+	require.Empty(t, flowIR.IngressDeniedBy)
+	testutils.AssertProtoEqual(t, expected, flowIR.IngressAllowedBy)
 }

--- a/pkg/policy/correlation/correlation_test.go
+++ b/pkg/policy/correlation/correlation_test.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/ir"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	"github.com/cilium/cilium/pkg/hubble/testutils"
 	"github.com/cilium/cilium/pkg/identity"
@@ -85,7 +86,8 @@ func TestCorrelatePolicy(t *testing.T) {
 		},
 	}
 
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	flowIR := ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
 
 	expected := []*flowpb.Policy{
 		{
@@ -138,7 +140,8 @@ func TestCorrelatePolicy(t *testing.T) {
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
 	}
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	flowIR = ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
 
 	require.Nil(t, flow.EgressAllowedBy)
 	require.Nil(t, flow.IngressAllowedBy)
@@ -189,7 +192,8 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyRevision: 1,
 	}
 
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	flowIR = ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
 
 	require.Nil(t, flow.EgressDeniedBy)
 	require.Nil(t, flow.IngressDeniedBy)
@@ -212,7 +216,8 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyRevision: 1,
 	}
 
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	flowIR = ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
 
 	require.Nil(t, flow.EgressDeniedBy)
 	require.Nil(t, flow.IngressDeniedBy)
@@ -263,7 +268,8 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyRevision: 1,
 	}
 
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	flowIR = ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
 
 	require.Nil(t, flow.EgressDeniedBy)
 	require.Nil(t, flow.IngressDeniedBy)
@@ -314,7 +320,8 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyRevision: 1,
 	}
 
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	flowIR = ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
 
 	require.Nil(t, flow.EgressDeniedBy)
 	require.Nil(t, flow.IngressDeniedBy)
@@ -365,7 +372,8 @@ func TestCorrelatePolicy(t *testing.T) {
 		PolicyRevision: 1,
 	}
 
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	flowIR = ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
 
 	require.Nil(t, flow.EgressDeniedBy)
 	require.Nil(t, flow.IngressDeniedBy)
@@ -425,7 +433,9 @@ func TestCorrelatePolicy(t *testing.T) {
 			return nil, false
 		},
 	}
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+
+	flowIR = ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
 
 	require.Nil(t, flow.EgressDeniedBy)
 	require.Nil(t, flow.IngressDeniedBy)
@@ -463,7 +473,8 @@ func TestCorrelatePolicy(t *testing.T) {
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3Only,
 	}
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	flowIR = ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
 
 	require.Nil(t, flow.EgressAllowedBy)
 	require.Nil(t, flow.IngressAllowedBy)
@@ -526,7 +537,8 @@ func TestCorrelatePolicy(t *testing.T) {
 		},
 	}
 
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	flowIR = ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
 
 	expected = []*flowpb.Policy{
 		{
@@ -624,7 +636,8 @@ func TestCorrelatePolicyAudit(t *testing.T) {
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
 	}
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	flowIR := ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
 
 	require.Nil(t, flow.EgressAllowedBy)
 	require.Nil(t, flow.IngressAllowedBy)
@@ -683,7 +696,8 @@ func TestCorrelatePolicyAudit(t *testing.T) {
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
 	}
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	flowIR = ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
 
 	require.Nil(t, flow.EgressAllowedBy)
 	require.Nil(t, flow.IngressAllowedBy)
@@ -769,7 +783,8 @@ func TestCorrelatePolicyImplicitDeny(t *testing.T) {
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
 	}
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	flowIR := ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
 
 	require.Nil(t, flow.EgressAllowedBy)
 	require.Nil(t, flow.IngressAllowedBy)
@@ -829,7 +844,8 @@ func TestCorrelatePolicyImplicitDeny(t *testing.T) {
 		},
 		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
 	}
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	flowIR = ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
 
 	require.Nil(t, flow.EgressAllowedBy)
 	require.Nil(t, flow.IngressAllowedBy)
@@ -888,7 +904,8 @@ func TestCorrelatePolicy_PortRange(t *testing.T) {
 		},
 	}
 
-	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
+	flowIR := ir.ProtoToFlow(flow)
+	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flowIR)
 
 	expected := []*flowpb.Policy{
 		{


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request]
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [ ] Thanks for contributing!

<!-- Description of change -->

## Motivation

Hubble flow processing currently requires many allocations and causes GC pressures. This proposal is 2 fold. 
On the one hand it offers a way to isolate exposed flow apis from internal usage. On the other it offers a way to reduce allocations while processing hubble flows. Per our findings we see ~2x reduction in stop the world GC cycles and ~2x CPU usage by leveraging this implementation. 

> NOTE! Currently missing from this proposal are field filtering and CEL parsing which still uses the protobuf implementation.

## Observations...

Ran in cluster load with metrics service and monitored cpu/mem usage using 2 cilium agents and feeding 10k flows.

### Current

  | POD | CPU↓ | CPU↑ | CPUavg | MEM↓ | MEM↑ | MEMavg |
  | :---- | :-----  | :-----  | :------- | :------ | :------ | :-------- |
  | cilium-p4gbb | 42m  | 541m | 124m | 178.0Mi | 278.0Mi |  230.3Mi |
  | cilium-qmqpl  | 38m | 492m  | 111m | 140.0Mi | 273.0Mi | 225.6Mi |

### IR

  | POD | CPU↓ | CPU↑ | CPUavg | MEM↓ | MEM↑ | MEMavg |
  | :---- | :-----  | :-----  | :------- | :------ | :------ | :-------- |
  | cilium-w982c | 22m | 260m | 43m | 129.0Mi |   269.0Mi  |  221.7Mi |
  | cilium-kz4l8   | 22m | 236m |  45m | 149.0Mi |  266.0Mi  | 230.0Mi |

## Benchmarking results...

  > NOTE: This only highlights benchmarks deltas.


  pkg: github.com/cilium/cilium/pkg/hubble/exporter

  | Test             | Current                      | IR                                                             |                   
  | ----------- | -------------------- | ------------------------------------- |
  | Exporter-10 |                                   |                                                                |
  | sec/op      | 17.476µ ± 17%        | 4.887µ ± 12%  -72.04% (p=0.000 n=10)  |
  | B/op        | 1.738Ki ± 41%        | 5.763Ki ± 0%  +231.52% (p=0.000 n=10) |
  | allocs/op   | 35.000 ± 3%          | 4.000 ± 0%  -88.57% (p=0.000 n=10)    |

  pkg: github.com/cilium/cilium/pkg/hubble/parser/seven

  | Test        | Current              | IR                                    |
  | ----------- | -------------------- | ------------------------------------- |
  | L7Decode-10 |                      |                                       |
  | sec/op      | 4.628µ ± 8%          | 3.130µ ± 19%  -32.36% (p=0.000 n=10)  |
  | B/op        | 1792.0 ± 0%          | 776.0 ± 0%  -56.70% (p=0.000 n=10)    |
  | allocs/op   | 36.00 ± 0%           | 19.00 ± 0%  -47.22% (p=0.000 n=10)    |


  pkg: github.com/cilium/cilium/pkg/hubble/parser/threefour

  | Test                | Current              | IR                                    |
  | ------------------  | -------------------- | ------------------------------------- |
  | sec/op              |                      |                                       |
  | L34DecodeOverlay-10 | 4.108µ ± 28%         | 1.911µ ±  38%  -53.49% (p=0.000 n=10) |
  | L34Decode-10        | 2.437µ ± 10%         | 2.021µ ± 497%        ~ (p=0.436 n=10) |
  | geomean             | 3.164µ               | 1.965µ         -37.90%                |
  |                     |                      |                                       |
  | B/op                |                      |                                       |
  | L34DecodeOverlay-10 | 1456.0 ± 0%          | 512.0 ± 0%  -64.84% (p=0.000 n=10)    |
  | L34Decode-10        | 1016.0 ± 0%          | 496.0 ± 0%  -51.18% (p=0.000 n=10)    |
  | geomean             | 1.188Ki              | 503.9       -58.57%                   |
  |                     |                      |                                       |
  | allocs/op           |                      |                                       |
  | L34DecodeOverlay-10 | 28.00 ± 0%           | 10.00 ± 0%  -64.29% (p=0.000 n=10)    |
  | L34Decode-10        | 18.000 ± 0%          | 8.000 ± 0%  -55.56% (p=0.000 n=10)    |
  | geomean             | 22.45                | 8.944       -60.16%                   |


pkg: github.com/cilium/cilium/pkg/hubble/filters

| Test                                            | Current               | IR                                     |
| ----------------------------------------------  | --------------------- | -------------------------------------- |
| sec/op                                          |                       |                                        |
| EmptyFlowFilter1-10                             |         5.790n ± 15%  | 5.630n ± 19%         ~ (p=0.280 n=10)  |
| EmptyFlowFilter100-10                           |         113.0n ± 26%  | 110.3n ±  8%         ~ (p=0.481 n=10)  |
| BasicL4ProtocolPortFlowFilterMatching1-10       |         17.10n ± 55%  | 13.09n ± 12%   -23.43% (p=0.002 n=10)  |
| BasicL4ProtocolPortFlowFilterMatching100-10     |         1.413µ ± 18%  | 1.501µ ± 44%         ~ (p=0.684 n=10)  |
| BasicL4ProtocolPortFlowFilterNonMatching1-10    |         19.15n ± 35%  | 15.41n ± 30%   -19.56% (p=0.009 n=10)  |
| BasicL4ProtocolPortFlowFilterNonMatching100-10  |         1.511µ ± 13%  | 1.506µ ± 14%         ~ (p=0.436 n=10)  |
| CELL4ProtocolPortFlowFilterMatching1-10         |         2.620µ ± 23%  | 4.341µ ± 25%   +65.69% (p=0.000 n=10)  |
| CELL4ProtocolPortFlowFilterMatching100-10       |         240.4µ ± 18%  | 438.4µ ± 36%   +82.38% (p=0.000 n=10)  |
| CELL4ProtocolPortFlowFilterNonMatching1-10      |         2.720µ ± 22%  | 4.040µ ± 10%   +48.58% (p=0.000 n=10)  |
| CELL4ProtocolPortFlowFilterNonMatching100-10    |         183.5µ ± 22%  | 467.8µ ± 20%  +154.95% (p=0.000 n=10)  |
| geomean                                         |         823.7n        | 1.002µ         +21.63%                 |
|                                                 |                       |                                        |
| B/op                                            |                       |                                        |
| EmptyFlowFilter1-10                             |         0.000 ± 0%    |    0.000 ± 0%         ~ (p=1.000 n=10) |
| EmptyFlowFilter100-10                           |         0.000 ± 0%    |    0.000 ± 0%         ~ (p=1.000 n=10) |
| BasicL4ProtocolPortFlowFilterMatching1-10       |         0.000 ± 0%    |    0.000 ± 0%         ~ (p=1.000 n=10) |
| BasicL4ProtocolPortFlowFilterMatching100-10     |         0.000 ± 0%    |    0.000 ± 0%         ~ (p=1.000 n=10) |
| BasicL4ProtocolPortFlowFilterNonMatching1-10    |         0.000 ± 0%    |    0.000 ± 0%         ~ (p=1.000 n=10) |
| BasicL4ProtocolPortFlowFilterNonMatching100-10  |         0.000 ± 0%    |    0.000 ± 0%         ~ (p=1.000 n=10) |
| CELL4ProtocolPortFlowFilterMatching1-10         |         336.0 ± 0%    |   1048.0 ± 0%  +211.90% (p=0.000 n=10) |
| CELL4ProtocolPortFlowFilterMatching100-10       |       32.83Ki ± 0%    | 102.41Ki ± 0%  +211.90% (p=0.000 n=10) |
| CELL4ProtocolPortFlowFilterNonMatching1-10      |         336.0 ± 0%    |   1048.0 ± 0%  +211.90% (p=0.000 n=10) |
| CELL4ProtocolPortFlowFilterNonMatching100-10    |       32.84Ki ± 0%    | 102.41Ki ± 0%  +211.89% (p=0.000 n=10) |
| geomean                                         |                       |                 +57.62%                |
|                                                 |                       |                                        |
| allocs/op                                       |                       |                                        |
| EmptyFlowFilter1-10                             |         0.000 ± 0%    | 0.000 ± 0%         ~ (p=1.000 n=10)    |
| EmptyFlowFilter100-10                           |         0.000 ± 0%    | 0.000 ± 0%         ~ (p=1.000 n=10)    |
| BasicL4ProtocolPortFlowFilterMatching1-10       |         0.000 ± 0%    | 0.000 ± 0%         ~ (p=1.000 n=10)    |
| BasicL4ProtocolPortFlowFilterMatching100-10     |         0.000 ± 0%    | 0.000 ± 0%         ~ (p=1.000 n=10)    |
| BasicL4ProtocolPortFlowFilterNonMatching1-10    |         0.000 ± 0%    | 0.000 ± 0%         ~ (p=1.000 n=10)    |
| BasicL4ProtocolPortFlowFilterNonMatching100-10  |         0.000 ± 0%    | 0.000 ± 0%         ~ (p=1.000 n=10)    |
| CELL4ProtocolPortFlowFilterMatching1-10         |         2.000 ± 0%    | 6.000 ± 0%  +200.00% (p=0.000 n=10)    |
| CELL4ProtocolPortFlowFilterMatching100-10       |         200.0 ± 0%    | 600.0 ± 0%  +200.00% (p=0.000 n=10)    |
| CELL4ProtocolPortFlowFilterNonMatching1-10      |         2.000 ± 0%    | 6.000 ± 0%  +200.00% (p=0.000 n=10)    |
| CELL4ProtocolPortFlowFilterNonMatching100-10    |         200.0 ± 0%    | 600.0 ± 0%  +200.00% (p=0.000 n=10)    |
| geomean                                         |                       |              +55.18%                   |

> NOTE! Filters are worst. There is currently no handling for field/CEL filters in IR. We are currently converting IR to protobuf to keep with functionality and hence the boost in allocations.

Fixes: #issue-number

```release-note
<!-- Enter the release note text here or remove this release-note section from your PR description. Do NOT put an "empty" release note here -->
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
