### PR TITLE
fix: One-Shot Channel Signal Causes BGP Migration Retries to Deadlock

### DIFF
--- a/operator/pkg/bgp/manager.go
+++ b/operator/pkg/bgp/manager.go
@@ -183,13 +183,13 @@ func (b *BGPResourceManager) initializeJobs() {
 				return err
 			}
 
+			close(b.storesInitialized)
+
 			b.logger.Info("BGP control plane operator started")
 			// restore router IDs for all nodes
 			if err := b.restoreRouterIDs(); err != nil {
 				return err
 			}
-
-			b.storesInitialized <- struct{}{}
 
 			return b.Run(ctx)
 		}),


### PR DESCRIPTION
In a real upgrade scenario with BGP control plane enabled and BGP CRDs still carrying v2alpha1 in status.storedVersions, a transient failure during CRD storage version  migration can permanently stall the migration job.

Once the migration job reads from the channel, the signal is consumed. The problem is that the migration job is configured with  job.WithRetry(3, ...), 

```
func (b *BGPResourceManager) initializeJobs() {
   job.OneShot("bgp-operator-main", func(ctx context.Context, health cell.Health) error {
       b.storesInitialized <- struct{}{}    <---- send
       ....
   }
   ...
   job.OneShot("bgp-operator-crd-storage-version-migrator", func(ctx context.Context, health cell.Health) error {
       <-b.storesInitialized      <------ read signal
       .....
   }, job.WithRetry(3, &job.ExponentialBackoff{Min: 500 * time.Millisecond, Max: 3 * time.Second})),   
}

```

so if the first migration attempt fails, the retry executes the same  wait again. 
At that point, the channel has already been drained and the main job will not send another signal, so the retry blocks forever.

The expected logic is to model store initialization as a completed state, not as a consumable event. Closing the channel does that:

```
close(b.storesInitialized)
```

Reads from a closed channel return immediately and can be repeated safely, so every retry can pass the initialization gate and continue with the actual migration work.




<!-- Description of change -->

Fixes: #issue-number

```release-note
Fix bug where BGP Migration may deadlock
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
