### PR TITLE
metrics: make prometheus server listen failure non-fatal

### DIFF
--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -135,7 +135,7 @@ func (reg *Registry) AddServerRuntimeHooks(serverId string, tlsConfigPromise TLS
 				return err
 			}
 			return nil
-		}, job.WithShutdown()),
+		}),
 	)
 }
 

--- a/pkg/metrics/registry_test.go
+++ b/pkg/metrics/registry_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metrics_test
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/cilium/hive"
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/job"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/metrics"
+)
+
+// newTestHive builds a hive carrying a Registry wired to a real job.Group
+// (via job.Cell), with AddServerRuntimeHooks called for the given address
+// before the hive starts, so the OneShot job is queued rather than run
+// immediately. RegistryParams has no Shutdowner field to spy on directly -
+// job.WithShutdown() pulls the hive's own Shutdowner via the job registry -
+// so tests drive the real hive.Run() and observe whether it self-terminates.
+func newTestHive(t *testing.T, addr string) *hive.Hive {
+	t.Helper()
+	log := hivetest.Logger(t)
+
+	return hive.New(
+		job.Cell,
+		cell.Invoke(func(jr job.Registry, lifecycle cell.Lifecycle) {
+			health, _ := cell.NewSimpleHealth()
+			group := jr.NewGroup(health)
+			reg := metrics.NewRegistry(metrics.RegistryParams{
+				Logger:    log,
+				Lifecycle: lifecycle,
+				JobGroup:  group,
+				Config:    metrics.RegistryConfig{PrometheusServeAddr: addr},
+			})
+			reg.AddServerRuntimeHooks("test-prometheus-server", nil, net.ListenConfig{})
+		}),
+	)
+}
+
+// TestAddServerRuntimeHooksListenFailureDoesNotShutdownHive is a
+// regression test: previously, a failure to bind the prometheus metrics
+// address (e.g. EADDRINUSE from a stale process) called
+// Shutdowner.Shutdown() via job.WithShutdown(), taking down the whole
+// agent/operator for a non-critical metrics endpoint. The error must now
+// just be logged.
+func TestAddServerRuntimeHooksListenFailureDoesNotShutdownHive(t *testing.T) {
+	// Occupy the port first so the registry's own Listen() call fails.
+	blocker, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer blocker.Close()
+	addr := blocker.Addr().String()
+
+	log := hivetest.Logger(t)
+	h := newTestHive(t, addr)
+
+	runDone := make(chan error, 1)
+	go func() { runDone <- h.Run(log) }()
+
+	selfTerminated := false
+	select {
+	case <-runDone:
+		selfTerminated = true
+	case <-time.After(2 * time.Second):
+		// Still running after the OneShot's error path had time to fire -
+		// good. Shut it down ourselves so the test can finish.
+		h.Shutdown()
+		<-runDone
+	}
+
+	require.False(t, selfTerminated, "a listen failure must not shut down the hive")
+}
+
+// TestAddServerRuntimeHooksServesMetrics is a baseline check that the
+// happy path still works: the server binds and serves /metrics.
+func TestAddServerRuntimeHooksServesMetrics(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+
+	log := hivetest.Logger(t)
+	h := newTestHive(t, addr)
+
+	runDone := make(chan error, 1)
+	go func() { runDone <- h.Run(log) }()
+	t.Cleanup(func() {
+		h.Shutdown()
+		<-runDone
+	})
+
+	var resp *http.Response
+	require.Eventually(t, func() bool {
+		var getErr error
+		resp, getErr = http.Get(fmt.Sprintf("http://%s/metrics", addr))
+		return getErr == nil
+	}, 2*time.Second, 20*time.Millisecond, "metrics server never became reachable")
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title, description and a `Fixes: #XXX` line if the commit addresses a particular GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI) in accordance with the [Cilium AI Policy](https://github.com/cilium/community/blob/main/AI-POLICY.md), and indicate the rating using [AI Influence Level](https://danielmiessler.com/blog/ai-influence-level-ail). Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

## Summary

Remove `job.WithShutdown()` from the prometheus metrics server OneShot in `AddServerRuntimeHooks`, so that a `Listen` or `Serve` failure is logged by the OneShot framework but does not trigger `hive.Shutdown()`.

## Motivation

When the prometheus metrics server fails to bind its address (e.g. port conflict from a stale process, or `EADDRINUSE` during a fast restart), the `WithShutdown()` option causes the entire hive to shut down. Because the OneShot runs asynchronously after its Start hook returns, the shutdown is deferred — `waitForSignalOrShutdown` drains the buffered `h.shutdown` channel immediately after all Start hooks complete, producing a confusing log sequence:

```
level=info msg="Started hive"
level=info msg="Stopping hive"           ← 150µs later, no visible error
level=fatal msg="Leader election lost"   ← cascade from Stop cancelling the LE context
```

The actual bind error is logged by the OneShot framework (`one-shot job errored`), but it's easily missed among the cascade. More importantly, a metrics endpoint failure should not prevent the control plane from operating — the operator/agent should continue running without metrics rather than entering a crash loop.

### On the JobGroup usage pattern (@joestringer)

There's existing precedent for this exact shape — a network-listening OneShot that should log and continue rather than take down the hive: `daemon/healthz/agenthealth.go`'s `agent-healthz-server-*` OneShot does the same `lc.Listen(...)` + serve, wraps every failure path in a plain `return fmt.Errorf(...)`, and does not use `WithShutdown()` or call `Shutdowner.Shutdown()` anywhere. That's the pattern this PR brings the metrics server in line with. I verified this diff against current upstream `main` to confirm `pkg/metrics/registry.go`'s other error paths (`Listen`, TLS-await, `Serve`) already just `return err` with no separate `Shutdowner.Shutdown()` call, so removing `WithShutdown()` here is sufficient on its own — no other change to this function is needed.

## Test plan

- [x] Verify operator starts successfully when prometheus port is already in use (previously crashed)
- [x] Verify prometheus metrics are still served when port is available
- [x] Verify the listen error is logged at ERROR level when port is unavailable

Added `pkg/metrics/registry_test.go`: drives `AddServerRuntimeHooks` through a real `job.Group`/`hive.Hive` (not mocked), pre-occupies the target port to force a genuine bind failure, and asserts the hive doesn't self-terminate within a bounded window (there's no `Shutdowner` field on `RegistryParams` to spy on directly, since `job.WithShutdown()` pulls the hive's own `Shutdowner` via the job registry - so the test drives `hive.Run()` for real and races it against a timeout). A second test confirms the happy path still serves `/metrics`. Confirmed the failure-path test fails against the pre-fix code (hive shuts itself down, as expected) and passes with the fix.

Also validated live end-to-end on a downstream fork's deployed agent, on the equivalent code path (not this literal binary, since upstream CI has no cluster to deploy to): enabled `--prometheus-serve-addr`, confirmed a clean bind, then deployed a throwaway pod to squat the exact port and restarted the agent while it was held. Result: `level=error msg="Failed to listen for prometheus metrics" ... error="listen tcp 127.0.0.1:9962: bind: address already in use"` and `level=error msg="one-shot job errored"` were logged, the pod stayed `1/1 Running` with 0 restarts, and `cilium status` reported `OK` throughout - the actual `EADDRINUSE` scenario from the Motivation section, reproduced against a real deployed binary.

## AI disclosure (AIL:5)

This PR was prepared with AI assistance. I personally reviewed and verified the diff against current upstream `main`, the `agenthealth.go` precedent cited above, the new regression tests (including confirming they fail on the pre-fix code), and the live test results before posting.

```release-note
metrics: don't shut down the hive if the Prometheus metrics server fails to bind or serve
```
