### PR TITLE
(minor) docs: update reference to aws-cli image

### DIFF
--- a/Documentation/security/aws.rst
+++ b/Documentation/security/aws.rst
@@ -96,7 +96,7 @@ for debugging purposes:
     spec:
       containers:
       - name: aws-cli
-        image: mesosphere/aws-cli
+        image: amazon/aws-cli
         command: ['sh', '-c', 'sleep 3600']
         env:
           - name: AWS_ACCESS_KEY_ID


### PR DESCRIPTION
The example image (mesosphere/aws-cli) has not been updated for 7 years. Point to the [official](https://hub.docker.com/r/amazon/aws-cli) one.
