### PR TITLE
endpoint: preserve restored policy map entries during regeneration

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -553,7 +553,27 @@ func (e *Endpoint) policyMapSync(policyMapDump policy.MapStateMap, stats *regene
 	// Nothing to do if the desired policy is already fully realized.
 	if e.realizedPolicy != e.desiredPolicy {
 		if len(policyMapDump) > 0 {
-			_, _, err = e.syncPolicyMapWith(policyMapDump, false)
+			// A non-empty dump only happens on the first regeneration after an
+			// agent restart, when the BPF policy map still holds the entries
+			// that were enforced before the restart but no policy has been
+			// realized yet (see the caller in runPreCompilationSteps). Those
+			// entries represent the last known good policy, so preserve them:
+			// add the desired keys but do not delete the restored ones against a
+			// desired policy that may not have finished resolving its selectors
+			// yet. Deleting them here breaks established L3/L4 connections until
+			// the desired policy is complete (a POLICY_DENIED black-hole during
+			// upgrade/downgrade).
+			//
+			// The preserved entries that end up not being part of the desired
+			// policy (e.g. entries keyed on identities that were reallocated
+			// across the restart) are left in the map. They are not tracked by
+			// realizedPolicy once regeneration completes, so normal syncs do not
+			// remove them; the periodic full reconciliation (syncPolicyMapWithDump)
+			// removes them once the desired policy is fully realized. Mark the
+			// endpoint so that first reconciliation is treated as expected
+			// convergence rather than a policy-map bug.
+			_, _, err = e.syncPolicyMapWith(policyMapDump, false, true)
+			e.preservedRestoredPolicyEntries = true
 		} else {
 			err = e.syncPolicyMap()
 		}
@@ -1382,7 +1402,16 @@ func (e *Endpoint) syncPolicyMap() error {
 // syncPolicyMapWith updates the bpf policy map state based on the
 // difference between a realized MapStateMap from a recent policy map dump
 // and desired policy state.
-func (e *Endpoint) syncPolicyMapWith(realized policy.MapStateMap, withDiffs bool) (diffCount int, diffs []policy.MapChange, err error) {
+//
+// When skipDeletes is true, entries present in the realized map but missing
+// from the desired policy are left in place instead of being deleted. This is
+// used on the first regeneration after an agent restart, where the realized map
+// is the pre-restart map and the desired policy may not have finished resolving
+// its selectors yet: deleting then would tear down entries that still enforce
+// established L3/L4 connections. The stale entries are cleaned up once the
+// desired policy is fully realized, by a subsequent regeneration and by the
+// periodic full reconciliation (syncPolicyMapWithDump).
+func (e *Endpoint) syncPolicyMapWith(realized policy.MapStateMap, withDiffs bool, skipDeletes bool) (diffCount int, diffs []policy.MapChange, err error) {
 	addErrors, deleteErrors := 0, 0
 
 	e.updatePolicyMapPressureMetric(e.desiredPolicy.Len())
@@ -1420,17 +1449,19 @@ func (e *Endpoint) syncPolicyMapWith(realized policy.MapStateMap, withDiffs bool
 	}
 
 	// Delete policy keys present in the realized state, but not present in the desired state
-	for k, v := range e.desiredPolicy.MissingMap(realized) {
-		if !e.deletePolicyKey(k) {
-			deleteErrors++
-			continue
-		}
-		diffCount++
-		if withDiffs {
-			diffs = append(diffs, policy.MapChange{
-				Key:   k,
-				Value: v,
-			})
+	if !skipDeletes {
+		for k, v := range e.desiredPolicy.MissingMap(realized) {
+			if !e.deletePolicyKey(k) {
+				deleteErrors++
+				continue
+			}
+			diffCount++
+			if withDiffs {
+				diffs = append(diffs, policy.MapChange{
+					Key:   k,
+					Value: v,
+				})
+			}
 		}
 	}
 
@@ -1513,12 +1544,38 @@ func (e *Endpoint) syncPolicyMapWithDump() error {
 	e.PolicyDebug("syncPolicyMapWithDump", logfields.DumpedPolicyMap, currentMap)
 	// Diffs between the maps indicate an error in the policy map update logic.
 	// Collect and log diffs if policy logging is enabled.
-	diffCount, diffs, err := e.syncPolicyMapWith(currentMap, e.getLogger() != nil)
+	//
+	// Always collect diffs (withDiffs=true) so that a restart-preserved cleanup
+	// can be told apart from a genuine bug: on the first reconciliation after a
+	// restart that preserved policy map entries, we expect only deletions of the
+	// leftover entries and no additions. That case is expected convergence, not a
+	// bug, so log it at a lower severity and clear the marker. Any addition, or
+	// any discrepancy once the marker is cleared, still indicates a real policy
+	// map update bug and is logged as a warning (which CI treats as an error).
+	diffCount, diffs, err := e.syncPolicyMapWith(currentMap, true, false)
 
 	if diffCount > 0 {
-		e.getLogger().Warn("Policy map sync fixed errors, consider running with debug verbose = policy to get detailed dumps", logfields.Count, diffCount)
+		onlyDeletes := true
+		for _, d := range diffs {
+			if d.Add {
+				onlyDeletes = false
+				break
+			}
+		}
+		if e.preservedRestoredPolicyEntries && onlyDeletes {
+			e.getLogger().Info(
+				"Removed policy map entries preserved across agent restart now that the desired policy is realized",
+				logfields.Count, diffCount,
+			)
+		} else {
+			e.getLogger().Warn("Policy map sync fixed errors, consider running with debug verbose = policy to get detailed dumps", logfields.Count, diffCount)
+		}
 		e.PolicyDebug("syncPolicyMapWithDump", logfields.DumpedDiffs, diffs)
 	}
+
+	// The reconciliation has converged the map to the desired policy, so any
+	// entries preserved across the restart have now been dealt with.
+	e.preservedRestoredPolicyEntries = false
 
 	return err
 }

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -392,6 +392,17 @@ type Endpoint struct {
 	// ep.mutex must be held.
 	realizedPolicy *policy.EndpointPolicy
 
+	// preservedRestoredPolicyEntries is set on the first regeneration after an
+	// agent restart when the pre-restart policy map entries were preserved
+	// (added to, but not deleted from) while the desired policy was still being
+	// resolved, to avoid dropping established L3/L4 connections. It records that
+	// the BPF policy map may legitimately still hold stale entries that are not
+	// part of realizedPolicy. The first full reconciliation
+	// (syncPolicyMapWithDump) that removes those leftovers is therefore expected
+	// rather than a symptom of a policy-map bug, and clears this flag.
+	// ep.mutex must be held.
+	preservedRestoredPolicyEntries bool
+
 	eventQueue *eventqueue.EventQueue
 
 	// skippedRegenerationLevel is the DatapathRegenerationLevel of the regeneration event that

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -421,7 +421,7 @@ func (e *Endpoint) setDesiredPolicy(datapathRegenCtxt *datapathRegenerationConte
 					return fmt.Errorf("unable to dump PolicyMap when trying to revert failed endpoint regeneration: %w", err)
 				}
 
-				_, _, err = e.syncPolicyMapWith(currentMap, false)
+				_, _, err = e.syncPolicyMapWith(currentMap, false, false)
 				if err != nil {
 					e.getLogger().Error("failed to sync PolicyMap when reverting to last known good policy", logfields.Error, err)
 				}


### PR DESCRIPTION
On the first endpoint regeneration after an agent restart the BPF policy map still holds the entries that were enforced before the restart, while the freshly started agent has an empty realized policy. runPreCompilationSteps already recognises this case: when the dumped map is non-empty but no policy has been realized yet, it seeds realizedPolicy from the dump so that the sync does not roll the map back to empty and delete every entry at once (GH-38998).

The subsequent policyMapSync still called syncPolicyMapWith, which adds the desired keys and then deletes any realized key that is missing from the desired policy. During an upgrade or downgrade the desired policy has often not finished resolving its selectors to identities by the time this runs, so the entries that admit established traffic are absent from the desired set and get deleted. For the duration of that window ingress to the endpoint is POLICY_DENIED, which black-holes established L3/L4 connections until the desired policy is complete. This showed up as a conn-disrupt failure on a netkit downgrade: every external NodePort connection to a restored server endpoint dropped for the reload window while the endpoint itself never restarted, and the drops were POLICY_DENIED at the server ingress coincident with its BPF program reload. Established L3/L4 connections are expected to survive an agent restart or upgrade/downgrade; the datapath re-checks the policy map on every forward-direction packet (only CT_REPLY/CT_RELATED return traffic skips policy), so the admitting entry must remain present throughout.

This is a regression from 2f90a8f390 ("fix(policy): Sync policies on startup", PR #40357, GH-37724). Before that commit, the non-empty-dump restart branch ended with policyMapSyncDone=true, so the dump-based sync was skipped entirely: the restored map kept its entries and only converged to the desired policy on a later, complete regeneration. #40357 flipped that to policyMapSyncDone=false to make sure a policy that was applied before the agent started still gets synced onto the endpoint. That fix is correct in wanting to add the newly desired entries, but running the full dump sync also deletes entries, and the delete half is what tears down established connections while the desired policy is still incomplete.

Keep the eager sync but skip only its delete phase on this one path via a new skipDeletes argument to syncPolicyMapWith, so the desired entries are still added on startup and the pre-restart entries are preserved. Reverting the flag flip instead would reintroduce GH-37724, because it would skip the needed adds as well.

The preserved entries that are not part of the desired policy (for example entries keyed on identities that were reallocated across the restart) are left in the map. Once regeneration completes, realizedPolicy is set to desiredPolicy and no longer tracks them, so a normal sync never removes them; only the periodic full reconciliation in syncPolicyMapWithDump, which dumps the live map, does. To keep that reconciliation from reporting the expected cleanup as a policy-map bug (a warning that the connectivity check treats as fatal), the endpoint is marked when entries were preserved and, on the first reconciliation that only deletes leftover entries, it is logged at info and the marker is cleared. Any addition, or any discrepancy once the marker is cleared, still logs the existing warning, so the reconciliation keeps flagging genuine policy-map update bugs.

The other two callers of syncPolicyMapWith, the periodic reconciler and the failed-regeneration revert, keep deleting as before.

This commit was prepared with AIL:3.

```release-note
Fix a regression that could cause established connections to a Pod to be briefly dropped during Cilium agent restart, upgrade, or downgrade, while the agent was restoring the Pod's network policy.
```