### PR TITLE
bgp: Optimize route policy reconciliation

### DIFF
--- a/pkg/bgp/manager/reconciler/route_policy.go
+++ b/pkg/bgp/manager/reconciler/route_policy.go
@@ -42,13 +42,6 @@ type RoutePolicyReconcilerMetadata struct {
 	RoutePolicies RoutePolicyMap
 }
 
-// routePolicyObjectKey is used to group policy statements with the same key value into a single route policy object.
-type routePolicyObjectKey struct {
-	Instance   string
-	Peer       string
-	PolicyType types.RoutePolicyType
-}
-
 func NewRoutePolicyReconciler(params RoutePolicyReconcilerIn) RoutePolicyReconcilerOut {
 	return RoutePolicyReconcilerOut{
 		Reconciler: &RoutePolicyReconciler{
@@ -121,9 +114,9 @@ func (r *RoutePolicyReconciler) desiredRoutePolicies(instance string) (RoutePoli
 	rx := r.db.ReadTxn()
 
 	// compile desired statements per routePolicyObjectKey
-	desiredStatements := make(map[routePolicyObjectKey][]*bgpTables.DesiredRoutePolicy)
+	desiredStatements := make(map[bgpTables.DesiredRoutePolicyObjectKey][]*bgpTables.DesiredRoutePolicy)
 	for statement := range r.desiredRoutePolicyTable.List(rx, bgpTables.DesiredRoutePoliciesByInstance(instance)) {
-		policyKey := getRoutePolicyObjectKey(statement)
+		policyKey := statement.GetPolicyObjectKey()
 		desiredStatements[policyKey] = append(desiredStatements[policyKey], statement)
 	}
 
@@ -141,7 +134,7 @@ func (r *RoutePolicyReconciler) desiredRoutePolicies(instance string) (RoutePoli
 	return desiredPolicies, nil
 }
 
-func desiredRoutePolicyFromStatements(policyKey routePolicyObjectKey, statements []*bgpTables.DesiredRoutePolicy) (*types.RoutePolicy, error) {
+func desiredRoutePolicyFromStatements(policyKey bgpTables.DesiredRoutePolicyObjectKey, statements []*bgpTables.DesiredRoutePolicy) (*types.RoutePolicy, error) {
 	if len(statements) == 0 {
 		return nil, nil
 	}
@@ -164,14 +157,6 @@ func desiredRoutePolicyFromStatements(policyKey routePolicyObjectKey, statements
 		}
 	}
 	return policy, nil
-}
-
-func getRoutePolicyObjectKey(policy *bgpTables.DesiredRoutePolicy) routePolicyObjectKey {
-	return routePolicyObjectKey{
-		Instance:   policy.Instance,
-		Peer:       policy.Peer,
-		PolicyType: policy.PolicyType,
-	}
 }
 
 func routePolicyName(peer string, policyType types.RoutePolicyType) string {

--- a/pkg/bgp/manager/reconciler/route_policy.go
+++ b/pkg/bgp/manager/reconciler/route_policy.go
@@ -7,13 +7,15 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
 	"sort"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/statedb"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/pkg/bgp/manager/instance"
-	bgpTables "github.com/cilium/cilium/pkg/bgp/manager/tables"
+	"github.com/cilium/cilium/pkg/bgp/manager/tables"
 	"github.com/cilium/cilium/pkg/bgp/types"
 )
 
@@ -28,18 +30,21 @@ type RoutePolicyReconcilerIn struct {
 
 	Logger                  *slog.Logger
 	DB                      *statedb.DB
-	DesiredRoutePolicyTable statedb.Table[*bgpTables.DesiredRoutePolicy]
+	DesiredRoutePolicyTable statedb.Table[*tables.DesiredRoutePolicy]
 }
 
 type RoutePolicyReconciler struct {
 	logger                  *slog.Logger
 	db                      *statedb.DB
-	desiredRoutePolicyTable statedb.Table[*bgpTables.DesiredRoutePolicy]
+	desiredRoutePolicyTable statedb.Table[*tables.DesiredRoutePolicy]
 	metadata                map[string]RoutePolicyReconcilerMetadata
 }
 
 type RoutePolicyReconcilerMetadata struct {
 	RoutePolicies RoutePolicyMap
+
+	DesiredChanges            statedb.ChangeIterator[*tables.DesiredRoutePolicy]
+	DesiredChangesInitialized bool
 }
 
 func NewRoutePolicyReconciler(params RoutePolicyReconcilerIn) RoutePolicyReconcilerOut {
@@ -89,41 +94,115 @@ func (r *RoutePolicyReconciler) Reconcile(ctx context.Context, p ReconcileParams
 	if err := p.ValidateParams(); err != nil {
 		return err
 	}
-	metadata := r.getMetadata(p.BGPInstance)
 
-	desiredPolicies, err := r.desiredRoutePolicies(p.BGPInstance.Name)
+	metadata := r.getMetadata(p.BGPInstance)
+	desiredPolicies, currentPolicies, err := r.routePoliciesToReconcile(p, &metadata)
 	if err != nil {
-		r.setMetadata(p.BGPInstance, metadata)
 		return err
 	}
-
 	updatedPolicies, err := ReconcileRoutePolicies(&ReconcileRoutePoliciesParams{
 		Logger:          r.logger,
 		Ctx:             ctx,
 		Router:          p.BGPInstance.Router,
 		DesiredPolicies: desiredPolicies,
-		CurrentPolicies: metadata.RoutePolicies,
+		CurrentPolicies: currentPolicies,
 	})
-	metadata.RoutePolicies = updatedPolicies
 
+	// Update route policies in the metadata. Note that updatedPolicies may contain just a subset of all policies
+	// in case diff reconciliation, the remaining policies need to stay untouched.
+	for policyName := range currentPolicies {
+		delete(metadata.RoutePolicies, policyName) // ensure stale polices are always deleted
+	}
+	maps.Copy(metadata.RoutePolicies, updatedPolicies)
+
+	if err != nil {
+		// The change iterator has already advanced, so the retry must do a full reconciliation.
+		metadata.DesiredChangesInitialized = false
+	}
 	r.setMetadata(p.BGPInstance, metadata)
 	return err
 }
 
-func (r *RoutePolicyReconciler) desiredRoutePolicies(instance string) (RoutePolicyMap, error) {
-	rx := r.db.ReadTxn()
+func (r *RoutePolicyReconciler) routePoliciesToReconcile(p ReconcileParams, metadata *RoutePolicyReconcilerMetadata) (desired, current RoutePolicyMap, err error) {
+	if !metadata.DesiredChangesInitialized {
+		return r.fullReconciliationRoutePolicies(p, metadata)
+	}
+	return r.diffReconciliationRoutePolicies(p, metadata)
+}
 
-	// compile desired statements per routePolicyObjectKey
-	desiredStatements := make(map[bgpTables.DesiredRoutePolicyObjectKey][]*bgpTables.DesiredRoutePolicy)
-	for statement := range r.desiredRoutePolicyTable.List(rx, bgpTables.DesiredRoutePoliciesByInstance(instance)) {
+func (r *RoutePolicyReconciler) fullReconciliationRoutePolicies(p ReconcileParams, metadata *RoutePolicyReconcilerMetadata) (desired, current RoutePolicyMap, err error) {
+	tx := r.db.WriteTxn(r.desiredRoutePolicyTable)
+	metadata.DesiredChanges, err = r.desiredRoutePolicyTable.Changes(tx)
+	if err != nil {
+		tx.Abort()
+		return nil, nil, fmt.Errorf("error subscribing to desired route policy changes: %w", err)
+	}
+	rx := tx.Commit()
+	metadata.DesiredChangesInitialized = true
+
+	// compile all desired statements per policy object key
+	desiredStatements := make(map[tables.DesiredRoutePolicyObjectKey][]*tables.DesiredRoutePolicy)
+	changes, _ := metadata.DesiredChanges.Next(rx) // the initial Next() call will emit all existing statements
+	for change := range changes {
+		if change.Deleted {
+			continue // this should not really happen for listing initial changes, skip just in case
+		}
+		statement := change.Object
+		if statement.Instance != p.BGPInstance.Name {
+			continue
+		}
 		policyKey := statement.GetPolicyObjectKey()
 		desiredStatements[policyKey] = append(desiredStatements[policyKey], statement)
 	}
 
-	// compile desired route policies
+	desired, err = routePolicyMapFromStatements(desiredStatements)
+	current = metadata.RoutePolicies // all previously reconciled route policies
+	return
+}
+
+func (r *RoutePolicyReconciler) diffReconciliationRoutePolicies(p ReconcileParams, metadata *RoutePolicyReconcilerMetadata) (desired, current RoutePolicyMap, err error) {
+	if !metadata.DesiredChangesInitialized {
+		return nil, nil, fmt.Errorf("BUG: desired route policy changes tracker not initialized, cannot perform diff reconciliation")
+	}
+
+	// list all statements that changed since last reconciliation and collect list of all modified policies
+	rx := r.db.ReadTxn()
+	changes, _ := metadata.DesiredChanges.Next(rx)
+	changedPolicies := sets.New[tables.DesiredRoutePolicyObjectKey]()
+	for change := range changes {
+		statement := change.Object
+		if statement.Instance == p.BGPInstance.Name {
+			changedPolicies.Insert(statement.GetPolicyObjectKey())
+		}
+	}
+
+	// For each modified policy collect:
+	//  - all desired statements,
+	//  - current (previously reconciled) policy from the metadata.
+	// This will also handle policy deletion - for deleted policies,
+	// desired statements will be empty, but current will emit the old policy.
+	desiredStatements := make(map[tables.DesiredRoutePolicyObjectKey][]*tables.DesiredRoutePolicy)
+	current = make(RoutePolicyMap, len(changedPolicies))
+	for policyKey := range changedPolicies {
+		policyName := routePolicyName(policyKey.Peer, policyKey.PolicyType)
+		// desired statements from statedb
+		for statement := range r.desiredRoutePolicyTable.List(rx, tables.DesiredRoutePoliciesByPolicyObject(policyKey)) {
+			desiredStatements[policyKey] = append(desiredStatements[policyKey], statement)
+		}
+		// current (previously reconciled) policy from the metadata
+		if policy, exists := metadata.RoutePolicies[policyName]; exists {
+			current[policyName] = policy
+		}
+	}
+
+	desired, err = routePolicyMapFromStatements(desiredStatements)
+	return
+}
+
+func routePolicyMapFromStatements(desiredStatements map[tables.DesiredRoutePolicyObjectKey][]*tables.DesiredRoutePolicy) (RoutePolicyMap, error) {
 	desiredPolicies := make(RoutePolicyMap, len(desiredStatements))
 	for policyKey, statements := range desiredStatements {
-		policy, err := desiredRoutePolicyFromStatements(policyKey, statements)
+		policy, err := routePolicyFromStatements(policyKey, statements)
 		if err != nil {
 			return nil, err
 		}
@@ -134,7 +213,7 @@ func (r *RoutePolicyReconciler) desiredRoutePolicies(instance string) (RoutePoli
 	return desiredPolicies, nil
 }
 
-func desiredRoutePolicyFromStatements(policyKey bgpTables.DesiredRoutePolicyObjectKey, statements []*bgpTables.DesiredRoutePolicy) (*types.RoutePolicy, error) {
+func routePolicyFromStatements(policyKey tables.DesiredRoutePolicyObjectKey, statements []*tables.DesiredRoutePolicy) (*types.RoutePolicy, error) {
 	if len(statements) == 0 {
 		return nil, nil
 	}

--- a/pkg/bgp/manager/reconciler/service_test.go
+++ b/pkg/bgp/manager/reconciler/service_test.go
@@ -2947,7 +2947,7 @@ func advertisedPoliciesAttributesMatch(
 
 	expectedGroupedPolicies := make(RoutePolicyMap, len(desiredStatementsByObject))
 	for policyKey, statements := range desiredStatementsByObject {
-		policy, err := desiredRoutePolicyFromStatements(policyKey, statements)
+		policy, err := routePolicyFromStatements(policyKey, statements)
 		req.NoError(err)
 		if policy != nil {
 			expectedGroupedPolicies[policy.Name] = policy
@@ -3040,7 +3040,7 @@ func TestServiceReconcilerMetadataPartialFailure(t *testing.T) {
 		}
 		oldPath := types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)) // non-aggregated prefix
 
-		oldPolicy, err := desiredRoutePolicyFromStatements(
+		oldPolicy, err := routePolicyFromStatements(
 			redPeer65001v4LBRP.GetPolicyObjectKey(),
 			[]*bgpTables.DesiredRoutePolicy{redPeer65001v4LBRP},
 		)

--- a/pkg/bgp/manager/reconciler/service_test.go
+++ b/pkg/bgp/manager/reconciler/service_test.go
@@ -2939,9 +2939,9 @@ func advertisedPoliciesAttributesMatch(
 	response, err := bgpInstance.Router.GetRoutePolicies(context.Background())
 	req.NoError(err)
 
-	desiredStatementsByObject := make(map[routePolicyObjectKey][]*bgpTables.DesiredRoutePolicy)
+	desiredStatementsByObject := make(map[bgpTables.DesiredRoutePolicyObjectKey][]*bgpTables.DesiredRoutePolicy)
 	for _, statement := range expectedRoutePolicies {
-		policyKey := getRoutePolicyObjectKey(statement)
+		policyKey := statement.GetPolicyObjectKey()
 		desiredStatementsByObject[policyKey] = append(desiredStatementsByObject[policyKey], statement)
 	}
 
@@ -3041,7 +3041,7 @@ func TestServiceReconcilerMetadataPartialFailure(t *testing.T) {
 		oldPath := types.MustNewPathForPrefix(netip.MustParsePrefix(ingressV4Prefix)) // non-aggregated prefix
 
 		oldPolicy, err := desiredRoutePolicyFromStatements(
-			getRoutePolicyObjectKey(redPeer65001v4LBRP),
+			redPeer65001v4LBRP.GetPolicyObjectKey(),
 			[]*bgpTables.DesiredRoutePolicy{redPeer65001v4LBRP},
 		)
 		req.NoError(err)

--- a/pkg/bgp/manager/tables/route_policies.go
+++ b/pkg/bgp/manager/tables/route_policies.go
@@ -105,6 +105,25 @@ func (p *DesiredRoutePolicy) GetKey() DesiredRoutePolicyKey {
 	}
 }
 
+// DesiredRoutePolicyObjectKey groups policy statements with the same object key value into a single route policy object.
+type DesiredRoutePolicyObjectKey struct {
+	Instance   string
+	Peer       string
+	PolicyType types.RoutePolicyType
+}
+
+func (k DesiredRoutePolicyObjectKey) Key() index.Key {
+	return index.String(k.Instance + indexDelimiter + k.Peer + indexDelimiter + k.PolicyType.String())
+}
+
+func (p *DesiredRoutePolicy) GetPolicyObjectKey() DesiredRoutePolicyObjectKey {
+	return DesiredRoutePolicyObjectKey{
+		Instance:   p.Instance,
+		Peer:       p.Peer,
+		PolicyType: p.PolicyType,
+	}
+}
+
 type desiredRoutePolicyOwnerKey struct {
 	Instance string
 	Owner    string
@@ -150,6 +169,16 @@ var (
 		Unique:     true,
 	}
 
+	desiredRoutePoliciesObjectIndex = statedb.Index[*DesiredRoutePolicy, DesiredRoutePolicyObjectKey]{
+		Name: "object",
+		FromObject: func(obj *DesiredRoutePolicy) index.KeySet {
+			return index.NewKeySet(obj.GetPolicyObjectKey().Key())
+		},
+		FromKey:    DesiredRoutePolicyObjectKey.Key,
+		FromString: index.FromString,
+		Unique:     false,
+	}
+
 	desiredRoutePoliciesInstanceIndex = statedb.Index[*DesiredRoutePolicy, string]{
 		Name: "instance",
 		FromObject: func(obj *DesiredRoutePolicy) index.KeySet {
@@ -180,12 +209,10 @@ var (
 		Unique:     false,
 	}
 
-	DesiredRoutePoliciesByInstance = desiredRoutePoliciesInstanceIndex.Query
+	DesiredRoutePoliciesByKey          = desiredRoutePoliciesKeyIndex.Query
+	DesiredRoutePoliciesByPolicyObject = desiredRoutePoliciesObjectIndex.Query
+	DesiredRoutePoliciesByInstance     = desiredRoutePoliciesInstanceIndex.Query
 )
-
-func DesiredRoutePoliciesByKey(key DesiredRoutePolicyKey) statedb.Query[*DesiredRoutePolicy] {
-	return desiredRoutePoliciesKeyIndex.Query(key)
-}
 
 func DesiredRoutePoliciesByInstanceOwner(instance string, owner string) statedb.Query[*DesiredRoutePolicy] {
 	return desiredRoutePoliciesInstanceOwnerIndex.Query(desiredRoutePolicyOwnerKey{
@@ -207,6 +234,7 @@ func NewDesiredRoutePoliciesTable(db *statedb.DB) (statedb.RWTable[*DesiredRoute
 		db,
 		"bgp-desired-route-policies",
 		desiredRoutePoliciesKeyIndex,
+		desiredRoutePoliciesObjectIndex,
 		desiredRoutePoliciesInstanceIndex,
 		desiredRoutePoliciesInstanceOwnerIndex,
 		desiredRoutePoliciesInstanceOwnerResourceIndex,


### PR DESCRIPTION
The `RoutePolicyReconciler` was reconciling all route policies in the `DesiredRoutePolicy` statedb table on each reconcile, even if there was no change in the table at all.

With this change, the reconciler uses statedb `ChangeIterator` to only reconcile those route policies, which desired statements changed since the previous reconciliation.

While this change has little effect for small-scale setups, for large-scale setups with many service advertisements this can significantly reduce unnecessary processing on the cilium agent.

```release-note
bgp: Optimize route policy reconciliation to reduce unnecessary processing on the cilium agent
```

