### PR TITLE
cilium-cli: fix kubeconfig API server parsing when the port is omitted

### DIFF
--- a/cilium-cli/install/autodetect_test.go
+++ b/cilium-cli/install/autodetect_test.go
@@ -4,13 +4,21 @@
 package install
 
 import (
+	"context"
+	"io"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"helm.sh/helm/v4/pkg/cli"
 	"helm.sh/helm/v4/pkg/cli/values"
 	"helm.sh/helm/v4/pkg/getter"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/cilium/cilium/cilium-cli/k8s"
 )
 
 func Test_getClusterName(t *testing.T) {
@@ -53,4 +61,72 @@ func Test_trimEKSClusterName(t *testing.T) {
 
 	vals = "eks-cilium-test-1.ap-northeast-1.eksctl.io"
 	assert.Equal(t, "eks-cilium-test-1", trimEKSClusterName(vals))
+}
+
+type fakeInstallerClient struct {
+	*k8s.Client
+	apiServerHost string
+	apiServerPort string
+}
+
+func (f fakeInstallerClient) ListNodes(context.Context, metav1.ListOptions) (*corev1.NodeList, error) {
+	return &corev1.NodeList{}, nil
+}
+
+func (f fakeInstallerClient) ListDaemonSet(context.Context, string, metav1.ListOptions) (*appsv1.DaemonSetList, error) {
+	return &appsv1.DaemonSetList{}, nil
+}
+
+func (f fakeInstallerClient) GetDaemonSet(context.Context, string, string, metav1.GetOptions) (*appsv1.DaemonSet, error) {
+	return nil, nil
+}
+
+func (f fakeInstallerClient) PatchDaemonSet(context.Context, string, string, types.PatchType, []byte, metav1.PatchOptions) (*appsv1.DaemonSet, error) {
+	return nil, nil
+}
+
+func (f fakeInstallerClient) GetEndpointSlice(context.Context, string, string, metav1.GetOptions) (*discoveryv1.EndpointSlice, error) {
+	return nil, nil
+}
+
+func (f fakeInstallerClient) GetAPIServerHostAndPort() (string, string) {
+	return f.apiServerHost, f.apiServerPort
+}
+
+func (f fakeInstallerClient) AutodetectFlavor(context.Context) k8s.Flavor {
+	return k8s.Flavor{}
+}
+
+func (f fakeInstallerClient) GetNamespace(context.Context, string, metav1.GetOptions) (*corev1.Namespace, error) {
+	return nil, nil
+}
+
+func (f fakeInstallerClient) DeleteNamespace(context.Context, string, metav1.DeleteOptions) error {
+	return nil
+}
+
+func (f fakeInstallerClient) DeletePodCollection(context.Context, string, metav1.DeleteOptions, metav1.ListOptions) error {
+	return nil
+}
+
+func (f fakeInstallerClient) PatchNode(context.Context, string, types.PatchType, []byte) (*corev1.Node, error) {
+	return nil, nil
+}
+
+func TestAutodetectKubeProxyUsesAPIServerPortFromKubeconfig(t *testing.T) {
+	installer := &K8sInstaller{
+		client: fakeInstallerClient{
+			Client:        &k8s.Client{},
+			apiServerHost: "api.example.test",
+			apiServerPort: "443",
+		},
+		params: Parameters{Writer: io.Discard},
+		flavor: k8s.Flavor{},
+	}
+
+	err := installer.autodetectKubeProxy(context.Background(), map[string]any{})
+	assert.NoError(t, err)
+	assert.Contains(t, installer.params.HelmOpts.Values, "kubeProxyReplacement=true")
+	assert.Contains(t, installer.params.HelmOpts.Values, "k8sServiceHost=api.example.test")
+	assert.Contains(t, installer.params.HelmOpts.Values, "k8sServicePort=443")
 }

--- a/cilium-cli/k8s/client.go
+++ b/cilium-cli/k8s/client.go
@@ -179,9 +179,22 @@ func (c *Client) GetAPIServerHostAndPort() (string, string) {
 	if context, ok := c.RawConfig.Contexts[c.ContextName()]; ok {
 		addr := c.RawConfig.Clusters[context.Cluster].Server
 		if addr != "" {
-			url, err := url.Parse(addr)
+			parsedURL, err := url.Parse(addr)
 			if err == nil {
-				host, port, _ := net.SplitHostPort(url.Host)
+				host := parsedURL.Hostname()
+				port := parsedURL.Port()
+				if port == "" {
+					switch parsedURL.Scheme {
+					case "https":
+						port = "443"
+					case "http":
+						port = "80"
+					}
+				}
+				if host != "" && port != "" {
+					return host, port
+				}
+				host, port, _ = net.SplitHostPort(parsedURL.Host)
 				return host, port
 			}
 		}

--- a/cilium-cli/k8s/client_test.go
+++ b/cilium-cli/k8s/client_test.go
@@ -60,3 +60,43 @@ func TestAutodetectFlavorGKE(t *testing.T) {
 		assert.Equal(t, KindGKE, flavor.Kind, "Should detect GKE via node label")
 	})
 }
+
+func TestGetAPIServerHostAndPort(t *testing.T) {
+	t.Run("defaults HTTPS port", func(t *testing.T) {
+		c := &Client{
+			RawConfig: clientcmdapi.Config{
+				Contexts: map[string]*clientcmdapi.Context{
+					"test": {Cluster: "test"},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"test": {Server: "https://api.example.test"},
+				},
+				CurrentContext: "test",
+			},
+			contextName: "test",
+		}
+
+		host, port := c.GetAPIServerHostAndPort()
+		assert.Equal(t, "api.example.test", host)
+		assert.Equal(t, "443", port)
+	})
+
+	t.Run("preserves explicit port", func(t *testing.T) {
+		c := &Client{
+			RawConfig: clientcmdapi.Config{
+				Contexts: map[string]*clientcmdapi.Context{
+					"test": {Cluster: "test"},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"test": {Server: "https://127.0.0.1:6443"},
+				},
+				CurrentContext: "test",
+			},
+			contextName: "test",
+		}
+
+		host, port := c.GetAPIServerHostAndPort()
+		assert.Equal(t, "127.0.0.1", host)
+		assert.Equal(t, "6443", port)
+	})
+}


### PR DESCRIPTION
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits are signed off.
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models in accordance with the Cilium AI Policy.

Kubeconfig server URLs without an explicit port are valid and common.

Right now `GetAPIServerHostAndPort()` uses `SplitHostPort(url.Host)`, so `https://api.example.test` comes back empty. In the kube-proxy free install path that means `cilium install` skips auto setting `k8sServiceHost` and `k8sServicePort`.

Repro
1. Use a kubeconfig with `server: https://api.example.test`
2. Run `cilium install` on a cluster where kube-proxy is not installed
3. The CLI does not auto set `k8sServiceHost` or `k8sServicePort`

This defaults `https` to `443` and `http` to `80`, and keeps explicit ports unchanged.
Added tests for the no-port case, the explicit-port case, and the install autodetect path.

Related: cilium/cilium-cli#3084

This PR was prepared with AIL:1 (minor AI assistance)

```release-note
cilium-cli: fix kubeconfig API server parsing when the server URL omits an explicit port
```
