### PR TITLE
Fix Envoy coalesced updates NACK

### DIFF
--- a/pkg/envoy/xdsnew/callbacks/completion_callbacks.go
+++ b/pkg/envoy/xdsnew/callbacks/completion_callbacks.go
@@ -32,6 +32,22 @@ const (
 type versionEntry struct {
 	version     string
 	completions set.Set[*completion.Completion]
+	rollback    func()
+}
+
+// aggregateRollback combines rollback functions in update order. The returned
+// function rolls back the newer update first, followed by the older updates.
+func aggregateRollback(older, newer func()) func() {
+	if older == nil {
+		return newer
+	}
+	if newer == nil {
+		return older
+	}
+	return func() {
+		newer()
+		older()
+	}
 }
 
 // orderedCompletions maintains the insertion order of snapshot versions. When
@@ -55,20 +71,22 @@ func (vo *orderedCompletions) lastIndex(version string) int {
 
 // add adds a completion to the latest occurrence of the given version. If the
 // version doesn't exist yet, a new entry is appended to the end of the slice.
-func (vo *orderedCompletions) add(version string, c *completion.Completion) {
+func (vo *orderedCompletions) add(version string, c *completion.Completion, rollback func()) {
 	if i := vo.lastIndex(version); i >= 0 {
 		(*vo)[i].completions.Insert(c)
+		(*vo)[i].rollback = aggregateRollback((*vo)[i].rollback, rollback)
 		return
 	}
-	vo.append(version, c)
+	vo.append(version, c, rollback)
 }
 
 // append records a new occurrence of a version at the end of the slice. A
 // version may occur more than once when snapshot contents change A -> B -> A.
-func (vo *orderedCompletions) append(version string, c *completion.Completion) {
+func (vo *orderedCompletions) append(version string, c *completion.Completion, rollback func()) {
 	*vo = append(*vo, versionEntry{
 		version:     version,
 		completions: set.NewSet(c),
+		rollback:    rollback,
 	})
 }
 
@@ -102,10 +120,24 @@ func (vo *orderedCompletions) updateUpTo(version string) iter.Seq[*completion.Co
 	for i := range targetIndex {
 		entries[targetIndex].completions.Merge(entries[i].completions)
 	}
+	rollback := entries[0].rollback
+	for i := 1; i <= targetIndex; i++ {
+		rollback = aggregateRollback(rollback, entries[i].rollback)
+	}
+	entries[targetIndex].rollback = rollback
 	if targetIndex > 0 {
 		vo.removeRange(0, targetIndex)
 	}
 	return (*vo)[0].completions.Members()
+}
+
+// rollbackFor returns the aggregate rollback associated with the latest
+// occurrence of version.
+func (vo *orderedCompletions) rollbackFor(version string) func() {
+	if i := vo.lastIndex(version); i >= 0 {
+		return (*vo)[i].rollback
+	}
+	return nil
 }
 
 // completeUpTo returns all completions for the given version and all versions
@@ -299,9 +331,9 @@ func (cb *CompletionCallbacks) addToCompletionsOrder(c *completion.Completion, p
 		cb.completionsOrders[key] = vo
 	}
 	if newVersion {
-		vo.append(version, c)
+		vo.append(version, c, pc.revertFunc)
 	} else {
-		vo.add(version, c)
+		vo.add(version, c, pc.revertFunc)
 	}
 	pc.inCompletionsOrder = true
 	cb.Log.Debug("Added completion to version order",
@@ -445,36 +477,28 @@ func (cb *CompletionCallbacks) OnStreamRequest(streamID int64, req *discovery.Di
 		state.rejectedErr = nackErr
 		cb.responseStates[key] = state
 
-		// NACK received: find a matching pending completion for the revert function.
-		for c, pc := range cb.pendingCompletions {
-			if pc.typeURL != typeURL || pc.nodeID != nodeID || pc.version != rejectedVersion {
-				continue
-			}
-			cb.Log.Warn(
-				"NACK received, reverting resource change",
-				logfields.XDSTypeURL, pc.typeURL,
-				logfields.Version, pc.version,
-				logfields.NodeID, pc.nodeID,
-				logfields.Error, req.GetErrorDetail().GetMessage(),
-			)
-			revertFunc = pc.revertFunc
-			// Complete this completion and all earlier ones in the version order,
-			// since the revert rolls back all changes up to this point.
-			if vo, ok := cb.completionsOrders[key]; ok {
-				completed = vo.completeUpTo(rejectedVersion)
-				for _, ec := range completed {
-					delete(cb.pendingCompletions, ec)
-				}
-				if len(*vo) == 0 {
-					delete(cb.completionsOrders, key)
-				}
-			} else {
-				// Completion wasn't in a version order yet; complete it directly.
-				completed = append(completed, c)
+		// A NACK rejects the entire response. Roll back every snapshot update
+		// coalesced into it, newest first, to restore the last ACKed state.
+		if vo, ok := cb.completionsOrders[key]; ok {
+			revertFunc = vo.rollbackFor(rejectedVersion)
+			completed = vo.completeUpTo(rejectedVersion)
+			for _, c := range completed {
 				delete(cb.pendingCompletions, c)
 			}
+			if len(*vo) == 0 {
+				delete(cb.completionsOrders, key)
+			}
+		}
+
+		if len(completed) > 0 {
+			cb.Log.Warn(
+				"NACK received, reverting resource changes",
+				logfields.XDSTypeURL, typeURL,
+				logfields.Version, rejectedVersion,
+				logfields.NodeID, nodeID,
+				logfields.Error, req.GetErrorDetail().GetMessage(),
+			)
 			completeErr = nackErr
-			break
 		}
 		cb.mutex.Unlock()
 		if revertFunc != nil {

--- a/pkg/envoy/xdsnew/callbacks/completion_callbacks_test.go
+++ b/pkg/envoy/xdsnew/callbacks/completion_callbacks_test.go
@@ -13,6 +13,7 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/status"
 
 	"github.com/cilium/cilium/pkg/completion"
 )
@@ -84,10 +85,10 @@ func TestOrderedCompletionsUpdateUpToLastVersion(t *testing.T) {
 	compA2 := completion.NewCompletion(nil, nil, nil)
 	compC := completion.NewCompletion(nil, nil, nil)
 
-	vo.append("version-a", compA1)
-	vo.append("version-b", compB)
-	vo.append("version-a", compA2)
-	vo.append("version-c", compC)
+	vo.append("version-a", compA1, nil)
+	vo.append("version-b", compB, nil)
+	vo.append("version-a", compA2, nil)
+	vo.append("version-c", compC, nil)
 
 	updated := slices.Collect(vo.updateUpTo("version-a"))
 	require.ElementsMatch(t, []*completion.Completion{compA1, compB, compA2}, updated)
@@ -105,10 +106,10 @@ func TestOrderedCompletionsCompleteUpToLastVersion(t *testing.T) {
 	compA2 := completion.NewCompletion(nil, nil, nil)
 	compC := completion.NewCompletion(nil, nil, nil)
 
-	vo.append("version-a", compA1)
-	vo.append("version-b", compB)
-	vo.append("version-a", compA2)
-	vo.append("version-c", compC)
+	vo.append("version-a", compA1, nil)
+	vo.append("version-b", compB, nil)
+	vo.append("version-a", compA2, nil)
+	vo.append("version-c", compC, nil)
 
 	completed := vo.completeUpTo("version-a")
 	require.ElementsMatch(t, []*completion.Completion{compA1, compB, compA2}, completed)
@@ -125,10 +126,10 @@ func TestRemoveFromOrderedCompletionsCompactsMiddleEntry(t *testing.T) {
 	compB2 := completion.NewCompletion(nil, nil, nil)
 	compC := completion.NewCompletion(nil, nil, nil)
 
-	vo.append("version-a", compA)
-	vo.append("version-b", compB1)
-	vo.add("version-b", compB2)
-	vo.append("version-c", compC)
+	vo.append("version-a", compA, nil)
+	vo.append("version-b", compB1, nil)
+	vo.add("version-b", compB2, nil)
+	vo.append("version-c", compC, nil)
 	cb.completionsOrders[completionsOrderKey("node-1", listenerTypeURL)] = vo
 
 	cb.RemoveTypeVersionCompletion(compB1)
@@ -289,6 +290,166 @@ func TestCompletionFollowsNewerResponseVersion(t *testing.T) {
 			require.NoError(t, wg2.Wait())
 		})
 	}
+}
+
+func TestNACKRevertsAllCoalescedUpdates(t *testing.T) {
+	cb := newTestCompletionCallbacks()
+	reverted := make([]string, 0, 3)
+
+	for _, version := range []string{"version-1", "version-2", "version-3"} {
+		_, comp := newTestCompletion(t)
+		registered, err := cb.AddTypeVersionCompletion(
+			comp,
+			version,
+			listenerTypeURL,
+			"node-1",
+			true,
+			func() { reverted = append(reverted, version) },
+		)
+		require.NoError(t, err)
+		require.True(t, registered)
+	}
+
+	// The response for version-3 coalesces all three pending updates. A NACK
+	// rejects the entire response, so all of its updates must be reverted in
+	// reverse order to restore the snapshot that preceded the response.
+	sendTypeVersionResponse(cb, listenerTypeURL, "version-3")
+	require.NoError(t, cb.OnStreamRequest(1, &discovery.DiscoveryRequest{
+		Node:        &core.Node{Id: "node-1"},
+		TypeUrl:     listenerTypeURL,
+		VersionInfo: "version-0",
+		ErrorDetail: &status.Status{Message: "rejected listener"},
+	}))
+
+	require.Equal(t, []string{"version-3", "version-2", "version-1"}, reverted)
+	require.Zero(t, cb.PendingCompletionCount())
+}
+
+func TestNACKRollbackStopsAtLastACKedVersion(t *testing.T) {
+	cb := newTestCompletionCallbacks()
+	reverted := make([]string, 0, 2)
+
+	_, ackedComp := newTestCompletion(t)
+	registered, err := cb.AddTypeVersionCompletion(
+		ackedComp,
+		"version-1",
+		listenerTypeURL,
+		"node-1",
+		true,
+		func() { reverted = append(reverted, "version-1") },
+	)
+	require.NoError(t, err)
+	require.True(t, registered)
+	sendTypeVersionResponse(cb, listenerTypeURL, "version-1")
+	ackTypeVersionResponse(t, cb, listenerTypeURL, "version-1")
+
+	for _, version := range []string{"version-2", "version-3"} {
+		_, comp := newTestCompletion(t)
+		registered, err = cb.AddTypeVersionCompletion(
+			comp,
+			version,
+			listenerTypeURL,
+			"node-1",
+			true,
+			func() { reverted = append(reverted, version) },
+		)
+		require.NoError(t, err)
+		require.True(t, registered)
+	}
+
+	sendTypeVersionResponse(cb, listenerTypeURL, "version-3")
+	require.NoError(t, cb.OnStreamRequest(1, &discovery.DiscoveryRequest{
+		Node:        &core.Node{Id: "node-1"},
+		TypeUrl:     listenerTypeURL,
+		VersionInfo: "version-1",
+		ErrorDetail: &status.Status{Message: "rejected listener"},
+	}))
+
+	require.Equal(t, []string{"version-3", "version-2"}, reverted)
+	require.Zero(t, cb.PendingCompletionCount())
+}
+
+func TestNACKRollsBackCompletionRegisteredWithoutVersion(t *testing.T) {
+	cb := newTestCompletionCallbacks()
+	_, comp := newTestCompletion(t)
+	reverted := false
+
+	registered, err := cb.AddTypeVersionCompletion(
+		comp,
+		"",
+		listenerTypeURL,
+		"node-1",
+		true,
+		func() { reverted = true },
+	)
+	require.NoError(t, err)
+	require.True(t, registered)
+
+	// The response callback runs before go-control-plane sends the response. It
+	// assigns the response version and attaches the completion to response order
+	// before Envoy can NACK it.
+	sendTypeVersionResponse(cb, listenerTypeURL, "version-1")
+	require.NoError(t, cb.OnStreamRequest(1, &discovery.DiscoveryRequest{
+		Node:        &core.Node{Id: "node-1"},
+		TypeUrl:     listenerTypeURL,
+		VersionInfo: "version-0",
+		ErrorDetail: &status.Status{Message: "rejected listener"},
+	}))
+
+	require.True(t, reverted)
+	require.Zero(t, cb.PendingCompletionCount())
+}
+
+func TestNACKDoesNotRollbackNewerUpdate(t *testing.T) {
+	cb := newTestCompletionCallbacks()
+	reverted := make([]string, 0, 2)
+
+	for _, version := range []string{"version-1", "version-2"} {
+		_, comp := newTestCompletion(t)
+		registered, err := cb.AddTypeVersionCompletion(
+			comp,
+			version,
+			listenerTypeURL,
+			"node-1",
+			true,
+			func() { reverted = append(reverted, version) },
+		)
+		require.NoError(t, err)
+		require.True(t, registered)
+	}
+
+	// version-2 is now in flight. Register version-3 after the response was sent
+	// but before Envoy NACKs it; version-3 was not part of that response.
+	sendTypeVersionResponse(cb, listenerTypeURL, "version-2")
+	wg3, comp3 := newTestCompletion(t)
+	registered, err := cb.AddTypeVersionCompletion(
+		comp3,
+		"version-3",
+		listenerTypeURL,
+		"node-1",
+		true,
+		func() { reverted = append(reverted, "version-3") },
+	)
+	require.NoError(t, err)
+	require.True(t, registered)
+
+	require.NoError(t, cb.OnStreamRequest(1, &discovery.DiscoveryRequest{
+		Node:        &core.Node{Id: "node-1"},
+		TypeUrl:     listenerTypeURL,
+		VersionInfo: "version-0",
+		ErrorDetail: &status.Status{Message: "rejected listener"},
+	}))
+
+	require.Equal(t, []string{"version-2", "version-1"}, reverted)
+	require.Equal(t, 1, cb.PendingCompletionCount())
+	requireCompletionPending(t, comp3)
+
+	// The newer update remains in response order and completes normally when
+	// its own response is sent and ACKed.
+	sendTypeVersionResponse(cb, listenerTypeURL, "version-3")
+	ackTypeVersionResponse(t, cb, listenerTypeURL, "version-3")
+	require.NoError(t, wg3.Wait())
+	require.Zero(t, cb.PendingCompletionCount())
 }
 
 func TestOlderResponseDoesNotClaimNewerCompletion(t *testing.T) {


### PR DESCRIPTION
Commit cc1124ccf18 broke the NACK of coalesced updates test in standalone
Envoy test that is not run in the CI. Add a normal go test regression
test.

Aggregate rollback functions for updates included in the same xDS response.
On NACK, run them newest-first to restore the last ACKed snapshot instead
of selecting an arbitrary pending update.

cc1124ccf18 records completions in snapshot order at registration time,
so pending completions can no longer exist outside the ordered response
queue when a NACK arrives.

Add unit coverage for coalesced updates and the last-ACK boundary, as
well as for preservation of later changes after rollecd back changes due
to a NACK.

Fixes: #46885

This PR was prepared with Codex (AIL: 3)
