### PR TITLE
ci: keep AKS nodes-without-cilium ready to stop auto-repair reboots

### DIFF
--- a/.github/actions/generic-external-targets/nginx-external.yaml
+++ b/.github/actions/generic-external-targets/nginx-external.yaml
@@ -87,6 +87,13 @@ spec:
       - key: "node.kubernetes.io/not-ready"
         operator: "Exists"
         effect: "NoSchedule"
+      # On AKS the no-schedule nodes are made Ready with a dummy CNI conf and
+      # then explicitly tainted cilium.io/no-schedule:NoSchedule to keep regular
+      # test pods off. Tolerate it so the external targets still schedule here.
+      # No-op on GKE, where these nodes are only labeled, never tainted.
+      - key: "cilium.io/no-schedule"
+        operator: "Exists"
+        effect: "NoSchedule"
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: nginx

--- a/.github/actions/setup-aks-cluster/action.yml
+++ b/.github/actions/setup-aks-cluster/action.yml
@@ -86,3 +86,22 @@ runs:
 
     - name: Patch nodes without Cilium
       uses: ./.github/actions/nodes-without-cilium
+
+    - name: Make nodes-without-cilium Ready and isolate them
+      shell: bash
+      run: |
+        # The nodes-without-cilium nodes run with --network-plugin none and no
+        # cilium-agent, so kubelet reports NotReady ("cni plugin not
+        # initialized"). A node that stays NotReady trips AKS node auto-repair,
+        # which reboots the VM and takes the external test targets down
+        # mid-test. Taint the nodes first so external-vs-in-cluster topology no
+        # longer depends on the transient node.kubernetes.io/not-ready taint,
+        # then drop a dummy CNI conf via a hostNetwork DaemonSet so kubelet turns
+        # Ready and auto-repair stops rebooting them. This runs before "cilium
+        # install" and the "cilium status --wait", so the nodes flip Ready well
+        # inside the auto-repair window instead of sitting NotReady across it.
+        kubectl taint nodes -l cilium.io/no-schedule=true \
+          cilium.io/no-schedule=true:NoSchedule --overwrite
+        kubectl apply -f "${{ github.action_path }}/dummy-cni-daemonset.yaml"
+        kubectl -n kube-system rollout status daemonset/dummy-cni --timeout=180s
+        kubectl wait --for=condition=Ready node -l cilium.io/no-schedule=true --timeout=180s

--- a/.github/actions/setup-aks-cluster/dummy-cni-daemonset.yaml
+++ b/.github/actions/setup-aks-cluster/dummy-cni-daemonset.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: dummy-cni
+  namespace: kube-system
+  labels:
+    app: dummy-cni
+spec:
+  selector:
+    matchLabels:
+      app: dummy-cni
+  template:
+    metadata:
+      labels:
+        app: dummy-cni
+    spec:
+      # hostNetwork so the pod needs no CNI ADD and runs even while the node is
+      # NotReady ("cni plugin not initialized"), exactly like the existing
+      # hostNetwork external-target pods on these nodes.
+      hostNetwork: true
+      priorityClassName: system-node-critical
+      nodeSelector:
+        cilium.io/no-schedule: "true"
+      # The DaemonSet controller only auto-adds the not-ready NoExecute
+      # toleration, so a blanket Exists is required to land on the NotReady node
+      # and to tolerate the cilium.io/no-schedule:NoSchedule taint we add.
+      tolerations:
+      - operator: Exists
+      containers:
+      - name: install-dummy-cni
+        image: docker.io/library/busybox:1.37.0
+        securityContext:
+          privileged: true
+        command: ["/bin/sh", "-c"]
+        # Write a bare CNI 0.3.1 conf referencing a plugin that need not exist in
+        # /opt/cni/bin. containerd's network-readiness Status() only requires a
+        # config to load (the binary is invoked only at pod-sandbox ADD, which
+        # hostNetwork/off-tainted pods never trigger), so this flips kubelet from
+        # NotReady to Ready and stops AKS node auto-repair reboots. Mirrors the
+        # proven EKS fix in .github/workflows/scale-test-egw.yaml. The guarded
+        # loop re-writes the conf if it is ever removed and survives reboots.
+        args:
+        - |
+          set -eu
+          CONF=/host/etc/cni/net.d/05-dummy.conf
+          while true; do
+            if [ ! -f "$CONF" ]; then
+              echo '{ "cniVersion": "0.3.1", "name": "dummy", "type": "dummy-cni" }' > "$CONF"
+              echo "wrote $CONF"
+            fi
+            sleep 30
+          done
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+        volumeMounts:
+        - name: cni-net-dir
+          mountPath: /host/etc/cni/net.d
+      volumes:
+      - name: cni-net-dir
+        hostPath:
+          path: /etc/cni/net.d
+          type: DirectoryOrCreate

--- a/cilium-cli/connectivity/check/wait.go
+++ b/cilium-cli/connectivity/check/wait.go
@@ -287,11 +287,16 @@ func checkServiceEndpoints(ctx context.Context, agent Pod, service Service, back
 	return nil
 }
 
-// WaitForNodePorts waits until all the nodeports in a service are available on a given node.
-func WaitForNodePorts(ctx context.Context, log Logger, client Pod, nodeIP string, service Service) error {
-	ctx, cancel := context.WithTimeout(ctx, ShortTimeout)
-	defer cancel()
+// nodePortExecProxyTimeout bounds how long we keep retrying a single NodePort
+// probe while the only thing failing is the exec proxy itself (not the probe).
+// The kube-apiserver -> kubelet exec proxy on managed clusters (seen on AKS)
+// can be unreachable for tens of seconds at a time, longer than ShortTimeout,
+// so these failures get their own generous allowance instead of consuming the
+// NodePort readiness budget.
+const nodePortExecProxyTimeout = 3 * time.Minute
 
+// WaitForNodePorts waits until all the nodeports in a service are available on a given node.
+func WaitForNodePorts(parentCtx context.Context, log Logger, client Pod, nodeIP string, service Service) error {
 	for _, port := range service.Service.Spec.Ports {
 		nodePort := port.NodePort
 		if nodePort == 0 {
@@ -300,8 +305,16 @@ func WaitForNodePorts(ctx context.Context, log Logger, client Pod, nodeIP string
 
 		log.Logf("⌛ [%s] Waiting for NodePort %s:%d (%s) to become ready...",
 			client.K8sClient.ClusterName(), nodeIP, nodePort, service.Name())
+
+		// The readiness deadline governs how long we wait for the NodePort
+		// itself to come up. Transient exec-proxy failures are tracked
+		// separately (execProxyDeadline) so a proxy outage does not eat into
+		// it; the exec below always runs against parentCtx, not a deadline that
+		// a proxy blip could expire.
+		readinessDeadline := time.Now().Add(ShortTimeout)
+		execProxyDeadline := time.Now().Add(nodePortExecProxyTimeout)
 		for {
-			stdout, err := client.K8sClient.ExecInPod(ctx,
+			stdout, err := client.K8sClient.ExecInPod(parentCtx,
 				client.Namespace(), client.NameWithoutNamespace(), client.Pod.Spec.Containers[0].Name,
 				[]string{"nc", "-w", "3", "-z", nodeIP, strconv.Itoa(int(nodePort))})
 			if err == nil {
@@ -311,9 +324,23 @@ func WaitForNodePorts(ctx context.Context, log Logger, client Pod, nodeIP string
 			log.Debugf("[%s] Error checking NodePort %s:%d (%s): %s: %s",
 				client.K8sClient.ClusterName(), nodeIP, nodePort, service.Name(), err, stdout.String())
 
+			// A transient exec-proxy failure is not a verdict on whether the
+			// NodePort is up, so it is bounded by the generous execProxyDeadline
+			// and must not count against the fixed readinessDeadline. Any other
+			// error means the probe actually ran and the NodePort is not ready
+			// yet, so it is bounded by readinessDeadline as before.
+			deadline := readinessDeadline
+			if k8s.IsTransientExecError(err) {
+				deadline = execProxyDeadline
+			}
+			if time.Now().After(deadline) {
+				return fmt.Errorf("timeout reached waiting for NodePort %s:%d (%s) (last error: %w)",
+					nodeIP, nodePort, service.Name(), err)
+			}
+
 			select {
 			case <-time.After(PollInterval):
-			case <-ctx.Done():
+			case <-parentCtx.Done():
 				return fmt.Errorf("timeout reached waiting for NodePort %s:%d (%s) (last error: %w)",
 					nodeIP, nodePort, service.Name(), err)
 			}

--- a/cilium-cli/features/status.go
+++ b/cilium-cli/features/status.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/cilium-cli/defaults"
+	"github.com/cilium/cilium/cilium-cli/k8s"
 )
 
 var (
@@ -56,35 +57,6 @@ var errEmptyExecOutput = errors.New("exec returned empty output")
 // featureExecRetryBackoff is the delay between ExecInPod retries. It is a
 // variable rather than a constant so that tests can shorten it.
 var featureExecRetryBackoff = 2 * time.Second
-
-// transientExecErrorSubstrings are error message fragments that indicate a
-// transient failure of the Kubernetes API server -> kubelet exec proxy rather
-// than a genuine failure of the executed command, and are therefore worth
-// retrying. They are intentionally specific to the exec-proxy tunnel so that
-// benign command stderr (e.g. cilium-operator "level=debug" log lines, which
-// are tolerated by fetchCiliumOperatorFeatureMetricsFromPod) is not mistaken
-// for a transient error and needlessly retried.
-var transientExecErrorSubstrings = []string{
-	"error dialing backend",
-	"unable to upgrade connection",
-	"Bad Gateway",         // HTTP 502
-	"Service Unavailable", // HTTP 503
-	"Gateway Timeout",     // HTTP 504
-	"TLS handshake timeout",
-}
-
-// isTransientExecError reports whether err looks like a transient failure of
-// the API server exec proxy, as opposed to a genuine failure of the command
-// that was executed in the pod.
-func isTransientExecError(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-	return slices.ContainsFunc(transientExecErrorSubstrings, func(substr string) bool {
-		return strings.Contains(msg, substr)
-	})
-}
 
 // detectClusterWideComponents detects cluster-wide components like kube-proxy and local-node-dns
 // and returns them as metrics with specific names
@@ -296,9 +268,9 @@ func (s *Feature) fetchStatusConcurrently(ctx context.Context, pods []corev1.Pod
 
 // execInPodWithRetry execs the given command in the pod, retrying up to
 // featureExecRetries times when the failure looks like a transient error of the
-// API server exec proxy (see isTransientExecError) or when exec reports success
-// but returns no output. Genuine command failures are returned immediately,
-// without retrying.
+// API server exec proxy (see k8s.IsTransientExecError) or when exec reports
+// success but returns no output. Genuine command failures are returned
+// immediately, without retrying.
 func (s *Feature) execInPodWithRetry(ctx context.Context, namespace, pod, container string, command []string) (bytes.Buffer, error) {
 	return retryTransientExec(ctx, func(ctx context.Context) (bytes.Buffer, error) {
 		return s.client.ExecInPod(ctx, namespace, pod, container, command)
@@ -307,7 +279,7 @@ func (s *Feature) execInPodWithRetry(ctx context.Context, namespace, pod, contai
 
 // retryTransientExec invokes exec, retrying up to featureExecRetries times with
 // featureExecRetryBackoff between attempts while the result looks transient:
-// either a transient exec-proxy error (see isTransientExecError) or a success
+// either a transient exec-proxy error (see k8s.IsTransientExecError) or a success
 // with empty output. The latter happens when the API server exec proxy
 // truncates the response stream and returns no data with a nil error; a healthy
 // features-status command always prints at least an empty JSON array, so an
@@ -322,7 +294,7 @@ func retryTransientExec(ctx context.Context, exec func(context.Context) (bytes.B
 	for attempt := range featureExecRetries {
 		output, err = exec(ctx)
 		if err != nil {
-			if !isTransientExecError(err) {
+			if !k8s.IsTransientExecError(err) {
 				return output, err
 			}
 		} else if output.Len() > 0 {

--- a/cilium-cli/k8s/client.go
+++ b/cilium-cli/k8s/client.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -373,6 +374,39 @@ func (c *Client) ContainerLogs(ctx context.Context, namespace, pod, containerNam
 
 func (c *Client) ListServices(ctx context.Context, namespace string, options metav1.ListOptions) (*corev1.ServiceList, error) {
 	return c.Clientset.CoreV1().Services(namespace).List(ctx, options)
+}
+
+// transientExecErrorSubstrings are error message fragments that indicate a
+// transient failure of the Kubernetes API server -> kubelet exec proxy rather
+// than a genuine failure of the executed command, and are therefore worth
+// retrying. On managed clusters (seen on AKS) the proxy is occasionally
+// unreachable for tens of seconds at a time. They are intentionally specific to
+// the exec-proxy tunnel so that benign command stderr (e.g. cilium-operator
+// "level=debug" log lines) is not mistaken for a transient error and needlessly
+// retried.
+var transientExecErrorSubstrings = []string{
+	"i/o timeout", // e.g. "dial tcp <apiserver>:443: i/o timeout"
+	"error dialing backend",
+	"unable to upgrade connection",
+	"Bad Gateway",         // HTTP 502
+	"Service Unavailable", // HTTP 503
+	"Gateway Timeout",     // HTTP 504
+	"TLS handshake timeout",
+}
+
+// IsTransientExecError reports whether err looks like a transient failure of
+// the Kubernetes API server exec proxy, as opposed to a genuine failure of the
+// command that was executed in the pod. Callers that exec through the proxy in
+// a loop (e.g. waiting for a NodePort or collecting features) use this to retry
+// proxy blips without treating them as a real result.
+func IsTransientExecError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return slices.ContainsFunc(transientExecErrorSubstrings, func(substr string) bool {
+		return strings.Contains(msg, substr)
+	})
 }
 
 func (c *Client) ExecInPodWithStderr(ctx context.Context, namespace, pod, container string, command []string) (bytes.Buffer, bytes.Buffer, error) {


### PR DESCRIPTION
The AKS conformance clusters are created with --network-plugin none, so
Cilium is the CNI. The two nodes labelled cilium.io/no-schedule host the
external test targets and deliberately never run cilium-agent, so they
have no CNI and the kubelet reports NotReady ("cni plugin not
initialized") for their whole lifetime. AKS node auto-repair reboots a
node that stays NotReady for more than a few minutes, and it cannot be
disabled, so these nodes are rebooted on a loop throughout the run.

I analysed the sysdumps from several failing ci-aks and ci-kpr-aks runs.
The node reboot is what actually breaks the tests. The external nodes go
NotReady, the k8s events show "Node auto-repair is initiating a reboot
action due to NotReady status persisting", and the node returns with a
fresh boot id. The nginx external targets and echo-external-node pods
are pinned to those nodes, so their pod sandbox is torn down at the
reboot timestamp and the target disappears mid-test. Because the target
Service is headless with a single backend, that outage surfaces to the
clients as an authoritative NXDOMAIN for the real-DNS tests (curl exit
6) or as a failed connect/TLS handshake to the now-dead pod IP for the
tests that resolve with --resolve (curl exit 28/35). Cilium behaves
correctly throughout: the DNS proxy allows the query, forwards it and
relays CoreDNS's real answer.

Make these nodes Ready with a dummy CNI config so auto-repair leaves
them alone, mirroring what scale-test-egw.yaml already does for EKS.
First taint the nodes cilium.io/no-schedule:NoSchedule, so that once
they turn Ready the auto-applied node.kubernetes.io/not-ready taint
clears without letting regular test pods schedule onto the external
nodes. Then drop a bare /etc/cni/net.d/05-dummy.conf via a hostNetwork
DaemonSet; containerd only needs a config to load to report the network
ready, and the referenced plugin is never invoked because the targets
are hostNetwork. The external nginx DaemonSet gains a matching
cilium.io/no-schedule toleration; the other pods pinned to these nodes
already tolerate any taint. This runs during cluster setup, before the
Cilium install and the ten minute status wait, so the nodes flip Ready
well inside the auto-repair window instead of sitting NotReady across
it.

---

WaitForNodePorts probes every NodePort on every node by exec'ing "nc -z"
into a client pod through the kube-apiserver to kubelet exec proxy. On
managed clusters (seen on AKS) that proxy is occasionally unreachable
for tens of seconds at a time, longer than the ShortTimeout the wait
runs under. When that happens the exec fails with, for example, "dial
tcp <apiserver>:443: i/o timeout" rather than a result from nc, and the
old loop counted those proxy failures against the same 30s readiness
budget as a genuinely-not-ready NodePort. A single ~30s proxy blip
during the concurrent NodePort probing (test-concurrency=5 fires many
execs at once) therefore exhausted the budget and failed the whole
connectivity test during setup, with no real test failure.

Separate the two failure modes. A transient exec-proxy error is not a
verdict on whether the NodePort is up, so it now gets its own generous
allowance and the exec runs against the parent context instead of the
ShortTimeout one, so a proxy outage no longer eats into the readiness
budget. Any other error still means nc actually ran and the NodePort is
not ready yet, so it keeps counting against the ShortTimeout readiness
deadline exactly as before.

The classification of a transient exec-proxy error is the same one cilium
features status already needs, so move it next to ExecInPod as the
exported k8s.IsTransientExecError and have both callers use it, adding
the "i/o timeout" fragment for the dial failure observed here. This keeps
the single list of proxy-tunnel error fragments in one place, in the
package that owns the exec call that produces them.