### PR TITLE
bgp: gate BGP announcements on host datapath init

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/auth"
 	awsAgent "github.com/cilium/cilium/pkg/aws/agent"
 	"github.com/cilium/cilium/pkg/bgp"
+	bgpagent "github.com/cilium/cilium/pkg/bgp/agent"
 	bgpConfig "github.com/cilium/cilium/pkg/bgp/config"
 	"github.com/cilium/cilium/pkg/bpf/stats"
 	cgroup "github.com/cilium/cilium/pkg/cgroups/manager"
@@ -292,6 +293,9 @@ var (
 
 		// The BGP Control Plane which enables various BGP related interop.
 		bgp.Cell,
+		// Provides the BGP DatapathWaiter that gates route announcements on
+		// host datapath and load-balancing state initialization.
+		cell.Provide(bgpagent.NewDatapathWaiter),
 
 		// The Cilium Network Driver for exposing network devices to workloads via DRA.
 		networkdriver.Cell,

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	"github.com/cilium/cilium/pkg/datapath"
+	loadertypes "github.com/cilium/cilium/pkg/datapath/loader/types"
 	debugapi "github.com/cilium/cilium/pkg/debug/api"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/dial"
@@ -64,6 +65,7 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/l2announcer"
 	"github.com/cilium/cilium/pkg/lbipamconfig"
+	"github.com/cilium/cilium/pkg/loadbalancer"
 	loadbalancer_cell "github.com/cilium/cilium/pkg/loadbalancer/cell"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maglev"
@@ -295,7 +297,14 @@ var (
 		bgp.Cell,
 		// Provides the BGP DatapathWaiter that gates route announcements on
 		// host datapath and load-balancing state initialization.
-		cell.Provide(bgpagent.NewDatapathWaiter),
+		//
+		// We pass the channel from Loader.HostDatapathInitialized() rather than
+		// Loader itself to avoid importing pkg/datapath/loader/types into
+		// pkg/bgp/agent. That package transitively pulls in Linux-specific
+		// packages (bigtcp, iptables) and would break cross-platform builds.
+		cell.Provide(func(loader loadertypes.Loader, lbInitWait loadbalancer.InitWaitFunc) bgpagent.DatapathWaiter {
+			return bgpagent.NewDatapathWaiter(loader.HostDatapathInitialized(), lbInitWait)
+		}),
 
 		// The Cilium Network Driver for exposing network devices to workloads via DRA.
 		networkdriver.Cell,

--- a/pkg/bgp/agent/controller.go
+++ b/pkg/bgp/agent/controller.go
@@ -55,6 +55,10 @@ type Controller struct {
 	// BGPMgr is an implementation of the BGPRouterManager interface
 	// and provides a declarative API for configuring BGP peers.
 	BGPMgr BGPRouterManager
+
+	// DatapathWaiter is called to wait for the datapath to be ready before
+	// allowing BGP route announcements.
+	DatapathWaiter DatapathWaiter
 }
 
 // ControllerParams contains all parameters needed to construct a Controller
@@ -71,6 +75,7 @@ type ControllerParams struct {
 	BGPNodeConfigStore      store.BGPCPResourceStore[*v2.CiliumBGPNodeConfig]
 	BGPConfig               config.BGPConfig
 	LocalCiliumNodeResource daemon_k8s.LocalCiliumNodeResource
+	DatapathWaiter          DatapathWaiter
 }
 
 // NewController constructs a new BGP Control Plane Controller.
@@ -94,14 +99,14 @@ func NewController(params ControllerParams) (*Controller, error) {
 		BGPMgr:             params.RouteMgr,
 		BGPNodeConfigStore: params.BGPNodeConfigStore,
 		CiliumNodeResource: params.LocalCiliumNodeResource,
+		DatapathWaiter:     params.DatapathWaiter,
 	}
 
 	params.JobGroup.Add(
 		job.OneShot("bgp-controller",
 			func(ctx context.Context, health cell.Health) (err error) {
 				// run the controller
-				c.Run(ctx)
-				return nil
+				return c.Run(ctx)
 			},
 			job.WithRetry(3, &job.ExponentialBackoff{Min: 100 * time.Millisecond, Max: time.Second}),
 			job.WithShutdown()),
@@ -116,17 +121,28 @@ func NewController(params ControllerParams) (*Controller, error) {
 //
 // A cancel of the provided ctx will kill the control loop along with the running
 // informers.
-func (c *Controller) Run(ctx context.Context) {
+func (c *Controller) Run(ctx context.Context) error {
 	scopedLog := c.Logger.With(types.ComponentLogField, "Controller.Run")
 
 	scopedLog.Info("Cilium BGP Control Plane Controller now running...")
+
+	// Wait for the datapath BPF programs to be attached and the load-balancing
+	// state to be reconciled to BPF maps before processing any BGP events.
+	// Without this gate, BGP may advertise routes before the datapath is ready
+	// to handle traffic, causing a "No route to host" window.
+	scopedLog.Info("BGP Control Plane waiting for datapath initialization")
+	if err := c.DatapathWaiter.Wait(ctx); err != nil {
+		return err
+	}
+	scopedLog.Info("BGP Control Plane datapath ready, starting event processing")
+
 	ciliumNodeCh := c.CiliumNodeResource.Events(ctx)
 	for {
 		select {
 		case ev, ok := <-ciliumNodeCh:
 			if !ok {
 				scopedLog.Info("LocalCiliumNode resource channel closed, Cilium BGP Control Plane Controller shut down")
-				return
+				return nil
 			}
 			switch ev.Kind {
 			case resource.Upsert:
@@ -138,7 +154,7 @@ func (c *Controller) Run(ctx context.Context) {
 			ev.Done(nil)
 		case <-ctx.Done():
 			scopedLog.Info("Cilium BGP Control Plane Controller shut down")
-			return
+			return nil
 		case <-c.Sig.Sig:
 			if c.LocalCiliumNode == nil {
 				scopedLog.Debug("localCiliumNode has not been set yet")

--- a/pkg/bgp/agent/controller.go
+++ b/pkg/bgp/agent/controller.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/bgp/agent/signaler"
 	"github.com/cilium/cilium/pkg/bgp/manager/store"
 	"github.com/cilium/cilium/pkg/bgp/types"
+	loadertypes "github.com/cilium/cilium/pkg/datapath/loader/types"
 	"github.com/cilium/cilium/pkg/hive"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -57,6 +58,10 @@ type Controller struct {
 	// BGPMgr is an implementation of the BGPRouterManager interface
 	// and provides a declarative API for configuring BGP peers.
 	BGPMgr BGPRouterManager
+
+	// Loader is used to wait for host datapath initialization before
+	// allowing BGP route announcements.
+	Loader loadertypes.Loader
 }
 
 // ControllerParams contains all parameters needed to construct a Controller
@@ -73,6 +78,7 @@ type ControllerParams struct {
 	BGPNodeConfigStore      store.BGPCPResourceStore[*v2.CiliumBGPNodeConfig]
 	DaemonConfig            *option.DaemonConfig
 	LocalCiliumNodeResource daemon_k8s.LocalCiliumNodeResource
+	Loader                  loadertypes.Loader
 }
 
 // NewController constructs a new BGP Control Plane Controller.
@@ -96,6 +102,7 @@ func NewController(params ControllerParams) (*Controller, error) {
 		BGPMgr:             params.RouteMgr,
 		BGPNodeConfigStore: params.BGPNodeConfigStore,
 		CiliumNodeResource: params.LocalCiliumNodeResource,
+		Loader:             params.Loader,
 	}
 
 	params.JobGroup.Add(
@@ -122,6 +129,18 @@ func (c *Controller) Run(ctx context.Context) {
 	scopedLog := c.Logger.With(types.ComponentLogField, "Controller.Run")
 
 	scopedLog.Info("Cilium BGP Control Plane Controller now running...")
+
+	// Wait for bpf_host.c to be attached to native devices before processing
+	// any BGP events. Without this gate, BGP may advertise routes before the
+	// DNAT programs are in place, causing a "No route to host" window.
+	scopedLog.Info("BGP Control Plane waiting for host datapath initialization")
+	select {
+	case <-c.Loader.HostDatapathInitialized():
+		scopedLog.Info("BGP Control Plane host datapath ready, starting event processing")
+	case <-ctx.Done():
+		return
+	}
+
 	ciliumNodeCh := c.CiliumNodeResource.Events(ctx)
 	for {
 		select {

--- a/pkg/bgp/agent/datapath_waiter.go
+++ b/pkg/bgp/agent/datapath_waiter.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package agent
+
+import (
+	"context"
+
+	loadertypes "github.com/cilium/cilium/pkg/datapath/loader/types"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+)
+
+// DatapathWaiter is called by the BGP controller to wait for the datapath to
+// be ready before announcing routes. It abstracts the individual initialization
+// gates so that the controller does not need to know about each component.
+type DatapathWaiter interface {
+	Wait(ctx context.Context) error
+}
+
+// datapathWaiter is the production implementation of DatapathWaiter. It waits
+// for the host datapath BPF programs to be attached (via Loader) and for the
+// load-balancing BPF maps to be populated (via InitWaitFunc).
+type datapathWaiter struct {
+	loader     loadertypes.Loader
+	lbInitWait loadbalancer.InitWaitFunc
+}
+
+// NewDatapathWaiter returns a DatapathWaiter that waits for the host datapath
+// and load-balancing state to be initialized before BGP route announcements
+// are allowed.
+func NewDatapathWaiter(loader loadertypes.Loader, lbInitWait loadbalancer.InitWaitFunc) DatapathWaiter {
+	return &datapathWaiter{
+		loader:     loader,
+		lbInitWait: lbInitWait,
+	}
+}
+
+func (w *datapathWaiter) Wait(ctx context.Context) error {
+	select {
+	case <-w.loader.HostDatapathInitialized():
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return w.lbInitWait(ctx)
+}

--- a/pkg/bgp/agent/datapath_waiter.go
+++ b/pkg/bgp/agent/datapath_waiter.go
@@ -6,7 +6,6 @@ package agent
 import (
 	"context"
 
-	loadertypes "github.com/cilium/cilium/pkg/datapath/loader/types"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 )
 
@@ -18,26 +17,28 @@ type DatapathWaiter interface {
 }
 
 // datapathWaiter is the production implementation of DatapathWaiter. It waits
-// for the host datapath BPF programs to be attached (via Loader) and for the
-// load-balancing BPF maps to be populated (via InitWaitFunc).
+// for the host datapath BPF programs to be attached and for the load-balancing
+// BPF maps to be populated (via InitWaitFunc).
 type datapathWaiter struct {
-	loader     loadertypes.Loader
-	lbInitWait loadbalancer.InitWaitFunc
+	// hostDatapathInitialized is closed when the host datapath BPF programs
+	// are attached. It comes from Loader.HostDatapathInitialized().
+	hostDatapathInitialized <-chan struct{}
+	lbInitWait              loadbalancer.InitWaitFunc
 }
 
 // NewDatapathWaiter returns a DatapathWaiter that waits for the host datapath
 // and load-balancing state to be initialized before BGP route announcements
 // are allowed.
-func NewDatapathWaiter(loader loadertypes.Loader, lbInitWait loadbalancer.InitWaitFunc) DatapathWaiter {
+func NewDatapathWaiter(hostDatapathInitialized <-chan struct{}, lbInitWait loadbalancer.InitWaitFunc) DatapathWaiter {
 	return &datapathWaiter{
-		loader:     loader,
-		lbInitWait: lbInitWait,
+		hostDatapathInitialized: hostDatapathInitialized,
+		lbInitWait:              lbInitWait,
 	}
 }
 
 func (w *datapathWaiter) Wait(ctx context.Context) error {
 	select {
-	case <-w.loader.HostDatapathInitialized():
+	case <-w.hostDatapathInitialized:
 	case <-ctx.Done():
 		return ctx.Err()
 	}

--- a/pkg/bgp/test/commands/datapath.go
+++ b/pkg/bgp/test/commands/datapath.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package commands
+
+import (
+	"context"
+	"sync"
+
+	"github.com/cilium/hive/script"
+)
+
+// DatapathWaiter is a test implementation of agent.DatapathWaiter that blocks
+// until Initialize is called. When a test uses --wait-datapath, the BGP
+// controller blocks on Wait until bgp/datapath-initialized is called.
+type DatapathWaiter struct {
+	once sync.Once
+	ch   chan struct{}
+}
+
+// NewDatapathWaiter creates a new DatapathWaiter. Wait will block until
+// Initialize is called.
+func NewDatapathWaiter() *DatapathWaiter {
+	return &DatapathWaiter{ch: make(chan struct{})}
+}
+
+// Initialize releases the datapath gate. Subsequent calls are no-ops.
+func (w *DatapathWaiter) Initialize() {
+	w.once.Do(func() { close(w.ch) })
+}
+
+// Wait implements agent.DatapathWaiter.
+func (w *DatapathWaiter) Wait(ctx context.Context) error {
+	select {
+	case <-w.ch:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// DatapathScriptCmds returns script commands for controlling the datapath
+// waiter in tests.
+func DatapathScriptCmds(w *DatapathWaiter) map[string]script.Cmd {
+	return map[string]script.Cmd{
+		"bgp/datapath-initialized": datapathInitializedCmd(w),
+	}
+}
+
+func datapathInitializedCmd(w *DatapathWaiter) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Signal that the datapath is initialized",
+			Detail: []string{
+				"Releases the BGP controller's datapath initialization gate,",
+				"allowing BGP route announcements to proceed.",
+				"",
+				"Only meaningful when the test was started with --wait-datapath.",
+			},
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			w.Initialize()
+			return nil, nil
+		},
+	)
+}

--- a/pkg/bgp/test/script_test.go
+++ b/pkg/bgp/test/script_test.go
@@ -68,6 +68,7 @@ const (
 	ipamFlag                      = "ipam"
 	probeTCPMD5Flag               = "probe-tcp-md5"
 	kubeProxyReplacementFlag      = "kube-proxy-replacement"
+	waitDatapathFlag              = "wait-datapath"
 )
 
 func TestPrivilegedScript(t *testing.T) {
@@ -98,7 +99,16 @@ func TestPrivilegedScript(t *testing.T) {
 		probeTCPMD5 := flags.Bool(probeTCPMD5Flag, false, "Probe if TCP_MD5SIG socket option is available")
 		kubeProxyReplacement := flags.Bool(kubeProxyReplacementFlag, true, "")
 		noEndpointsRoutable := flags.Bool(enableNoEndpointsRoutableFlag, true, "")
+		waitDatapath := flags.Bool(waitDatapathFlag, false, "Block datapath initialization until bgp/datapath-initialized is called")
 		require.NoError(t, flags.Parse(args), "Error parsing test flags")
+
+		// Create the DatapathWaiter before the hive so it can be passed to
+		// both the hive cells and the script commands.
+		datapathWaiter := commands.NewDatapathWaiter()
+		if !*waitDatapath {
+			// Release immediately so existing tests are not gated.
+			datapathWaiter.Initialize()
+		}
 
 		if *probeTCPMD5 {
 			available, err := TCPMD5SigAvailable()
@@ -138,6 +148,11 @@ func TestPrivilegedScript(t *testing.T) {
 			reflectors.Cell,
 			lbipamconfig.Cell,
 			nodeipamconfig.Cell,
+
+			// Stub dependency added by the BGP announcement gating.
+			// DatapathWaiter is immediately ready unless --wait-datapath is set,
+			// in which case the test must call bgp/datapath-initialized to unblock.
+			cell.Provide(func() agent.DatapathWaiter { return datapathWaiter }),
 
 			// Provide source.Sources for loadbalancer writer
 			cell.Provide(func() source.Sources { return source.Sources{} }),
@@ -214,6 +229,7 @@ func TestPrivilegedScript(t *testing.T) {
 		maps.Insert(cmds, maps.All(script.DefaultCmds()))
 		maps.Insert(cmds, maps.All(commands.GoBGPScriptCmds(gobgpCmdCtx)))
 		maps.Insert(cmds, maps.All(commands.SvcScriptCmds(lbWriter)))
+		maps.Insert(cmds, maps.All(commands.DatapathScriptCmds(datapathWaiter)))
 
 		return &script.Engine{
 			Cmds: cmds,

--- a/pkg/bgp/test/testdata/svc-lb-init-gating.txtar
+++ b/pkg/bgp/test/testdata/svc-lb-init-gating.txtar
@@ -1,0 +1,147 @@
+#! --wait-datapath --test-peering-ips=10.99.8.101,10.99.8.102
+
+# Tests that BGP route announcements are gated on load-balancing state initialization.
+# The BGP controller must not advertise routes until the LB BPF maps are ready.
+
+# Start the hive. The BGP controller will block on LBInitWait.
+hive start
+
+# Configure gobgp server
+gobgp/add-server test gobgp-server.toml
+
+# Add k8s service with a LoadBalancer IP
+k8s/add service.yaml
+
+# Configure BGP on Cilium
+k8s/add cilium-node.yaml bgp-node-config.yaml bgp-peer-config.yaml bgp-advertisement.yaml
+
+# While LBInitWait is blocking, the BGP controller has not started yet.
+# GoBGP should have no routes since Cilium BGP has not connected or announced anything.
+gobgp/routes -o routes.actual
+* cmp gobgp-routes-empty.expected routes.actual
+
+# Release the datapath initialization gate.
+bgp/datapath-initialized
+
+# Wait for the BGP session to be established now that the gate is released.
+gobgp/wait-state 10.99.8.102 ESTABLISHED
+
+# Validate that the LB IP is now advertised.
+gobgp/routes -o routes.actual
+* cmp gobgp-routes.expected routes.actual
+
+#####
+
+-- gobgp-server.toml --
+[global.config]
+  as = 65010
+  router-id = "10.99.8.101"
+  local-address-list = ["10.99.8.101"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "10.99.8.102"
+    peer-as = 65001
+  [neighbors.transport.config]
+    passive-mode = true
+-- cilium-node.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: test-node
+spec:
+  addresses:
+  - ip: 10.99.8.102
+    type: InternalIP
+  ipam:
+    podCIDRs:
+    - 10.244.1.0/24
+
+-- bgp-node-config.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumBGPNodeConfig
+metadata:
+  name: test-node
+spec:
+  bgpInstances:
+  - localASN: 65001
+    name: tor-65001
+    peers:
+    - name: gobgp-peer-1
+      peerASN: 65010
+      peerAddress: 10.99.8.101
+      localAddress: 10.99.8.102
+      peerConfigRef:
+        name: gobgp-peer-config
+
+-- bgp-peer-config.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumBGPPeerConfig
+metadata:
+  name: gobgp-peer-config
+spec:
+  transport:
+    peerPort: 1790
+  timers:
+    connectRetryTimeSeconds: 1
+  families:
+  - afi: ipv4
+    safi: unicast
+    advertisements:
+      matchLabels:
+        advertise: services
+
+-- bgp-advertisement.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumBGPAdvertisement
+metadata:
+  name: lb-only
+  labels:
+    advertise: services
+spec:
+  advertisements:
+  - advertisementType: Service
+    service:
+      addresses:
+        - LoadBalancerIP
+    selector:
+      matchExpressions:
+        - { key: bgp, operator: In, values: [ advertise ] }
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+  labels:
+    bgp: advertise
+spec:
+  type: LoadBalancer
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  sessionAffinity: None
+status:
+  loadBalancer:
+    ingress:
+    - ip: 172.16.1.1
+
+-- gobgp-routes-empty.expected --
+Prefix   NextHop   Attrs
+-- gobgp-routes.expected --
+Prefix          NextHop       Attrs
+172.16.1.1/32   10.99.8.102   [{Origin: i} {AsPath: 65001} {Nexthop: 10.99.8.102}]


### PR DESCRIPTION
## Description

The BGP Control Plane controller starts reconciling as soon as the CiliumNode resource becomes available, which happens before `bpf_host.c` has been attached to native devices. On node reboot, this caused a "No route to host" window: the upstream router added the node back to its ECMP group, but incoming LB traffic arrived on native devices with no BPF program to DNAT it.

Fix by blocking `Run()` on `Loader.HostDatapathInitialized()` before entering the event loop. The channel is closed by `ReloadDatapath()` once the host endpoint BPF programs have been attached. `Loader` is already available in the Hive dependency graph and is injected via `ControllerParams`.

## Reproduction

**Setup**
- Two nodes acting as BGP ECMP peers for a LoadBalancer service (`externalTrafficPolicy: Cluster`)
- Upstream router distributes traffic across both nodes via ECMP
- Build Cilium with a `time.Sleep(30 * time.Second)` added at the top of `ReloadDatapath()` in `pkg/datapath/loader/endpoint.go`, and deploy the modified image as the cilium-agent on both nodes

**Steps to reproduce**
1. Reboot one of the two nodes
2. Send requests to the LoadBalancer VIP from an external client during the 30-second window after the rebooted node's BGP session re-establishes

**Observed behavior**
"No route to host" errors occur during the window. Depending on which ECMP bucket the client's 5-tuple hashes to, the failure rate should be either 100% or 0% per flow.

**Expected behavior**
No errors: BGP should not advertise routes until BPF programs are attached to native devices.

```release-note
Fix a "No route to host" window on node reboot where BGP advertised routes before BPF programs were attached to native devices.
```

This PR was prepared with AIL:3. I personally checked the datapath attachment sequence and the HostDatapathInitialized channel lifecycle.