### PR TITLE
feat(endpoint): add managed endpoint table

### DIFF
--- a/pkg/endpoint/cell/cell.go
+++ b/pkg/endpoint/cell/cell.go
@@ -10,6 +10,7 @@ import (
 	endpointapi "github.com/cilium/cilium/pkg/endpoint/api"
 	endpointcreator "github.com/cilium/cilium/pkg/endpoint/creator"
 	endpointmetadata "github.com/cilium/cilium/pkg/endpoint/metadata"
+	endpointtables "github.com/cilium/cilium/pkg/endpoint/tables"
 	"github.com/cilium/cilium/pkg/endpoint/watchdog"
 	"github.com/cilium/cilium/pkg/endpointcleanup"
 	"github.com/cilium/cilium/pkg/endpointmanager"
@@ -36,6 +37,9 @@ var Cell = cell.Group(
 
 	// RegeneratorCell provides extra options and utilities for endpoints regeneration.
 	endpoint.RegeneratorCell,
+
+	// EndpointTables exposes Cilium-managed endpoint metadata through StateDB.
+	endpointtables.Cell,
 
 	// Cell triggers a job to ensure device tc programs remain loaded.
 	watchdog.Cell,

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -1177,6 +1177,7 @@ func (e *Endpoint) runIPIdentitySync(endpointIP netip.Addr) {
 				metadata := e.FormatGlobalEndpointID()
 				k8sNamespace := e.K8sNamespace
 				k8sPodName := e.K8sPodName
+				k8sCEPName := e.GetK8sCEPName()
 
 				k8sServiceAccount := ""
 				if pod := e.GetPod(); pod != nil {
@@ -1195,6 +1196,7 @@ func (e *Endpoint) runIPIdentitySync(endpointIP netip.Addr) {
 					Metadata:          metadata,
 					K8sNamespace:      k8sNamespace,
 					K8sPodName:        k8sPodName,
+					K8sCEPName:        k8sCEPName,
 					K8sServiceAccount: k8sServiceAccount,
 					NPM:               e.GetK8sPorts(),
 				}

--- a/pkg/endpoint/tables/cell.go
+++ b/pkg/endpoint/tables/cell.go
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package tables
+
+import (
+	"context"
+	"sync"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+	"github.com/cilium/statedb"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
+	ciliumv2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	k8stypes "github.com/cilium/cilium/pkg/k8s/types"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// Cell provides a StateDB table of Cilium-managed endpoints.
+var Cell = cell.Module(
+	"endpoint-tables",
+	"Cilium-managed endpoint tables",
+
+	cell.ProvidePrivate(NewEndpointTable),
+	cell.Provide(statedb.RWTable[*Endpoint].ToTable),
+	cell.Invoke(
+		registerEndpointResourceReflector,
+		registerKVStoreIPIdentityReflector,
+	),
+)
+
+type endpointResourceReflectorParams struct {
+	cell.In
+
+	JobGroup     job.Group
+	DB           *statedb.DB
+	Table        statedb.RWTable[*Endpoint]
+	ClusterInfo  cmtypes.ClusterInfo
+	DaemonConfig *option.DaemonConfig
+
+	CEPs resource.Resource[*k8stypes.CiliumEndpoint]
+	CESs resource.Resource[*ciliumv2alpha1.CiliumEndpointSlice]
+}
+
+func registerEndpointResourceReflector(p endpointResourceReflectorParams) {
+	wtxn := p.DB.WriteTxn(p.Table)
+	initDone := p.Table.RegisterInitializer(wtxn, "endpoint-resource-reflector")
+	wtxn.Commit()
+
+	r := endpointResourceReflector{
+		db:          p.DB,
+		table:       p.Table,
+		writer:      NewWriter(p.Table),
+		clusterName: p.ClusterInfo.Name,
+		useCES:      p.DaemonConfig.EnableCiliumEndpointSlice,
+		ceps:        p.CEPs,
+		cess:        p.CESs,
+		initDone:    initDone,
+		cesSources:  make(map[resource.Key][]SourceKey),
+	}
+	p.JobGroup.Add(job.OneShot("endpoint-resource-reflector", r.run))
+}
+
+type endpointResourceReflector struct {
+	db          *statedb.DB
+	table       statedb.RWTable[*Endpoint]
+	writer      *Writer
+	clusterName string
+	useCES      bool
+	ceps        resource.Resource[*k8stypes.CiliumEndpoint]
+	cess        resource.Resource[*ciliumv2alpha1.CiliumEndpointSlice]
+	initDone    func(statedb.WriteTxn)
+	initOnce    sync.Once
+	cesSources  map[resource.Key][]SourceKey
+}
+
+func (r *endpointResourceReflector) run(ctx context.Context, _ cell.Health) error {
+	if r.useCES {
+		return r.runCES(ctx)
+	}
+	return r.runCEP(ctx)
+}
+
+func (r *endpointResourceReflector) markInitialized() {
+	r.initOnce.Do(func() {
+		wtxn := r.db.WriteTxn(r.table)
+		defer wtxn.Abort()
+		r.initDone(wtxn)
+		wtxn.Commit()
+	})
+}
+
+func (r *endpointResourceReflector) runCEP(ctx context.Context) error {
+	if r.ceps == nil {
+		r.markInitialized()
+		return nil
+	}
+
+	for event := range r.ceps.Events(ctx) {
+		var err error
+		switch event.Kind {
+		case resource.Sync:
+			r.markInitialized()
+		case resource.Upsert:
+			err = r.upsertCEP(event.Object)
+		case resource.Delete:
+			err = r.deleteCEP(event.Object)
+		}
+		event.Done(err)
+	}
+	return nil
+}
+
+func (r *endpointResourceReflector) runCES(ctx context.Context) error {
+	if r.cess == nil {
+		r.markInitialized()
+		return nil
+	}
+
+	for event := range r.cess.Events(ctx) {
+		var err error
+		switch event.Kind {
+		case resource.Sync:
+			r.markInitialized()
+		case resource.Upsert:
+			err = r.upsertCES(event.Key, event.Object)
+		case resource.Delete:
+			err = r.deleteCES(event.Key, event.Object)
+		}
+		event.Done(err)
+	}
+	return nil
+}
+
+func (r *endpointResourceReflector) upsertCEP(cep *k8stypes.CiliumEndpoint) error {
+	src, err := SourceFromCEP(r.clusterName, cep)
+	if err != nil {
+		return err
+	}
+
+	wtxn := r.db.WriteTxn(r.table)
+	defer wtxn.Abort()
+	_, err = r.writer.Upsert(wtxn, src)
+	if err != nil {
+		return err
+	}
+	wtxn.Commit()
+	return nil
+}
+
+func (r *endpointResourceReflector) deleteCEP(cep *k8stypes.CiliumEndpoint) error {
+	src, err := SourceFromCEP(r.clusterName, cep)
+	if err != nil {
+		return err
+	}
+
+	wtxn := r.db.WriteTxn(r.table)
+	defer wtxn.Abort()
+	_, _, err = r.writer.DeleteSource(wtxn, src.Key)
+	if err != nil {
+		return err
+	}
+	wtxn.Commit()
+	return nil
+}
+
+func (r *endpointResourceReflector) upsertCES(key resource.Key, ces *ciliumv2alpha1.CiliumEndpointSlice) error {
+	sources, err := SourcesFromCES(r.clusterName, ces)
+	if err != nil {
+		return err
+	}
+
+	current := make(map[SourceKey]struct{}, len(sources))
+	wtxn := r.db.WriteTxn(r.table)
+	defer wtxn.Abort()
+
+	for _, src := range sources {
+		current[src.Key] = struct{}{}
+		if _, err := r.writer.Upsert(wtxn, src); err != nil {
+			return err
+		}
+	}
+
+	for _, oldKey := range r.cesSources[key] {
+		if _, ok := current[oldKey]; ok {
+			continue
+		}
+		if _, _, err := r.writer.DeleteSource(wtxn, oldKey); err != nil {
+			return err
+		}
+	}
+
+	r.cesSources[key] = sourceKeys(sources)
+	wtxn.Commit()
+	return nil
+}
+
+func (r *endpointResourceReflector) deleteCES(key resource.Key, ces *ciliumv2alpha1.CiliumEndpointSlice) error {
+	sourceKeysToDelete := r.cesSources[key]
+	if len(sourceKeysToDelete) == 0 && ces != nil {
+		sources, err := SourcesFromCES(r.clusterName, ces)
+		if err != nil {
+			return err
+		}
+		sourceKeysToDelete = sourceKeys(sources)
+	}
+
+	wtxn := r.db.WriteTxn(r.table)
+	defer wtxn.Abort()
+	for _, sourceKey := range sourceKeysToDelete {
+		if _, _, err := r.writer.DeleteSource(wtxn, sourceKey); err != nil {
+			return err
+		}
+	}
+	delete(r.cesSources, key)
+	wtxn.Commit()
+	return nil
+}
+
+func sourceKeys(sources []Source) []SourceKey {
+	keys := make([]SourceKey, 0, len(sources))
+	for _, src := range sources {
+		keys = append(keys, src.Key)
+	}
+	return keys
+}
+
+type kvstoreIPIdentityReflectorParams struct {
+	cell.In
+
+	DB      *statedb.DB
+	Table   statedb.RWTable[*Endpoint]
+	Watcher *ipcache.LocalIPIdentityWatcher `optional:"true"`
+}
+
+func registerKVStoreIPIdentityReflector(p kvstoreIPIdentityReflectorParams) {
+	if p.Watcher == nil {
+		return
+	}
+	p.Watcher.AddIPIdentityPairObserver(&kvstoreIPIdentityReflector{
+		db:     p.DB,
+		table:  p.Table,
+		writer: NewWriter(p.Table),
+	})
+}
+
+type kvstoreIPIdentityReflector struct {
+	db     *statedb.DB
+	table  statedb.RWTable[*Endpoint]
+	writer *Writer
+}
+
+func (r *kvstoreIPIdentityReflector) OnIPIdentityPairUpsert(clusterName string, pair *identity.IPIdentityPair) error {
+	if pair == nil || !pair.IsHost() {
+		return nil
+	}
+	src, err := SourceFromIPIdentityPair(clusterName, pair)
+	if err != nil {
+		return err
+	}
+
+	wtxn := r.db.WriteTxn(r.table)
+	defer wtxn.Abort()
+	_, err = r.writer.Upsert(wtxn, src)
+	if err != nil {
+		return err
+	}
+	wtxn.Commit()
+	return nil
+}
+
+func (r *kvstoreIPIdentityReflector) OnIPIdentityPairDelete(clusterName string, pair *identity.IPIdentityPair) error {
+	if pair == nil {
+		return nil
+	}
+	prefix := pair.PrefixString()
+	if prefix == "" || prefix == "<nil>" {
+		return nil
+	}
+
+	wtxn := r.db.WriteTxn(r.table)
+	defer wtxn.Abort()
+	_, _, err := r.writer.DeleteSource(wtxn, KVStoreSourceKey(clusterName, prefix))
+	if err != nil {
+		return err
+	}
+	wtxn.Commit()
+	return nil
+}

--- a/pkg/endpoint/tables/endpoint.go
+++ b/pkg/endpoint/tables/endpoint.go
@@ -1,0 +1,746 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package tables
+
+import (
+	"fmt"
+	"maps"
+	"net/netip"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/cilium/statedb"
+	"github.com/cilium/statedb/index"
+
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/endpoint/id"
+	"github.com/cilium/cilium/pkg/identity"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	ciliumv2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	k8stypes "github.com/cilium/cilium/pkg/k8s/types"
+	"github.com/cilium/cilium/pkg/types"
+)
+
+const EndpointTableName = "managed-endpoints"
+
+type EndpointKeyKind string
+
+const (
+	EndpointKeyKindK8s    EndpointKeyKind = "k8s"
+	EndpointKeyKindGlobal EndpointKeyKind = "global"
+	EndpointKeyKindIP     EndpointKeyKind = "ip"
+)
+
+type EndpointKey struct {
+	Kind       EndpointKeyKind
+	Cluster    string
+	Namespace  string
+	Name       string
+	NodeName   string
+	EndpointID string
+	IP         netip.Prefix
+}
+
+func K8sEndpointKey(cluster, namespace, name string) EndpointKey {
+	return EndpointKey{Kind: EndpointKeyKindK8s, Cluster: cluster, Namespace: namespace, Name: name}
+}
+
+func GlobalEndpointKey(cluster, nodeName, endpointID string) EndpointKey {
+	return EndpointKey{Kind: EndpointKeyKindGlobal, Cluster: cluster, NodeName: nodeName, EndpointID: endpointID}
+}
+
+func IPEndpointKey(cluster string, ip netip.Prefix) EndpointKey {
+	return EndpointKey{Kind: EndpointKeyKindIP, Cluster: cluster, IP: ip}
+}
+
+func (k EndpointKey) IsZero() bool {
+	return k.Kind == ""
+}
+
+func (k EndpointKey) String() string {
+	switch k.Kind {
+	case EndpointKeyKindK8s:
+		return fmt.Sprintf("%s:%s/%s/%s", k.Kind, k.Cluster, k.Namespace, k.Name)
+	case EndpointKeyKindGlobal:
+		return fmt.Sprintf("%s:%s/%s/%s", k.Kind, k.Cluster, k.NodeName, k.EndpointID)
+	case EndpointKeyKindIP:
+		return fmt.Sprintf("%s:%s/%s", k.Kind, k.Cluster, k.IP.String())
+	default:
+		return ""
+	}
+}
+
+type SourceKind string
+
+const (
+	SourceKindCEP     SourceKind = "cep"
+	SourceKindCES     SourceKind = "ces"
+	SourceKindKVStore SourceKind = "kvstore"
+)
+
+type SourceKey string
+
+func CEPSourceKey(cluster, namespace, name, uid string) SourceKey {
+	return SourceKey(fmt.Sprintf("%s:%s/%s/%s/%s", SourceKindCEP, cluster, namespace, name, uid))
+}
+
+func CESSourceKey(cluster, cesName, namespace, endpointName, podUID string) SourceKey {
+	return SourceKey(fmt.Sprintf("%s:%s/%s/%s/%s", SourceKindCES, cluster, cesName, namespace, endpointName) + "/" + podUID)
+}
+
+func KVStoreSourceKey(cluster, ipOrPrefix string) SourceKey {
+	return SourceKey(fmt.Sprintf("%s:%s/%s", SourceKindKVStore, cluster, ipOrPrefix))
+}
+
+type Source struct {
+	Key            SourceKey
+	Kind           SourceKind
+	EndpointKey    EndpointKey
+	Aliases        []EndpointKey
+	Cluster        string
+	Namespace      string
+	Name           string
+	PodUID         string
+	NodeName       string
+	EndpointID     string
+	IPs            []netip.Addr
+	HostIP         netip.Addr
+	Identity       identity.NumericIdentity
+	EncryptionKey  uint8
+	ServiceAccount string
+	NamedPorts     types.NamedPortMap
+}
+
+func (s Source) endpointKeys() []EndpointKey {
+	keys := append([]EndpointKey{}, s.Aliases...)
+	if !s.EndpointKey.IsZero() {
+		keys = append(keys, s.EndpointKey)
+	}
+	return dedupeEndpointKeys(keys)
+}
+
+func (s Source) priority() int {
+	switch s.Kind {
+	case SourceKindCEP, SourceKindCES:
+		return 0
+	case SourceKindKVStore:
+		return 1
+	default:
+		return 2
+	}
+}
+
+func (s Source) deepCopy() Source {
+	out := s
+	out.Aliases = append([]EndpointKey{}, s.Aliases...)
+	out.IPs = append([]netip.Addr{}, s.IPs...)
+	out.NamedPorts = copyNamedPorts(s.NamedPorts)
+	return out
+}
+
+type Endpoint struct {
+	Key            EndpointKey
+	Aliases        []EndpointKey
+	Cluster        string
+	Namespace      string
+	Name           string
+	IPs            []netip.Addr
+	HostIP         netip.Addr
+	Identity       identity.NumericIdentity
+	EncryptionKey  uint8
+	ServiceAccount string
+	NamedPorts     types.NamedPortMap
+	Sources        map[SourceKey]Source
+	Conflicts      []string
+}
+
+func (*Endpoint) TableHeader() []string {
+	return []string{"Key", "IPs", "Identity", "HostIP", "Sources"}
+}
+
+func (e *Endpoint) TableRow() []string {
+	ips := make([]string, 0, len(e.IPs))
+	for _, ip := range e.IPs {
+		ips = append(ips, ip.String())
+	}
+	return []string{
+		e.Key.String(),
+		strings.Join(ips, ","),
+		e.Identity.StringID(),
+		e.HostIP.String(),
+		strconv.Itoa(len(e.Sources)),
+	}
+}
+
+func (e *Endpoint) DeepCopy() *Endpoint {
+	if e == nil {
+		return nil
+	}
+	out := *e
+	out.Aliases = append([]EndpointKey{}, e.Aliases...)
+	out.IPs = append([]netip.Addr{}, e.IPs...)
+	out.NamedPorts = copyNamedPorts(e.NamedPorts)
+	out.Conflicts = append([]string{}, e.Conflicts...)
+	out.Sources = make(map[SourceKey]Source, len(e.Sources))
+	for k, src := range e.Sources {
+		out.Sources[k] = src.deepCopy()
+	}
+	return &out
+}
+
+var (
+	EndpointKeyIndex = statedb.Index[*Endpoint, EndpointKey]{
+		Name: "key",
+		FromObject: func(ep *Endpoint) index.KeySet {
+			return index.NewKeySet(index.String(ep.Key.String()))
+		},
+		FromKey: func(key EndpointKey) index.Key {
+			return index.String(key.String())
+		},
+		FromString: index.FromString,
+		Unique:     true,
+	}
+
+	EndpointByKey = EndpointKeyIndex.Query
+
+	EndpointAliasIndex = statedb.Index[*Endpoint, EndpointKey]{
+		Name: "alias",
+		FromObject: func(ep *Endpoint) index.KeySet {
+			keys := make([]index.Key, 0, len(ep.Aliases))
+			for _, alias := range ep.Aliases {
+				keys = append(keys, index.String(alias.String()))
+			}
+			return index.NewKeySet(keys...)
+		},
+		FromKey: func(key EndpointKey) index.Key {
+			return index.String(key.String())
+		},
+		FromString: index.FromString,
+		Unique:     true,
+	}
+
+	EndpointByAlias = EndpointAliasIndex.Query
+
+	EndpointSourceIndex = statedb.Index[*Endpoint, SourceKey]{
+		Name: "source",
+		FromObject: func(ep *Endpoint) index.KeySet {
+			keys := make([]index.Key, 0, len(ep.Sources))
+			for sourceKey := range ep.Sources {
+				keys = append(keys, index.String(string(sourceKey)))
+			}
+			return index.NewKeySet(keys...)
+		},
+		FromKey: func(key SourceKey) index.Key {
+			return index.String(string(key))
+		},
+		FromString: index.FromString,
+		Unique:     true,
+	}
+
+	EndpointBySource = EndpointSourceIndex.Query
+
+	EndpointIPIndex = statedb.Index[*Endpoint, netip.Addr]{
+		Name: "ip",
+		FromObject: func(ep *Endpoint) index.KeySet {
+			keys := make([]index.Key, 0, len(ep.IPs))
+			for _, ip := range ep.IPs {
+				keys = append(keys, index.String(ip.String()))
+			}
+			return index.NewKeySet(keys...)
+		},
+		FromKey: func(ip netip.Addr) index.Key {
+			return index.String(ip.String())
+		},
+		FromString: func(key string) (index.Key, error) {
+			ip, err := netip.ParseAddr(key)
+			if err != nil {
+				return nil, err
+			}
+			return index.String(ip.String()), nil
+		},
+		Unique: false,
+	}
+
+	EndpointByIP = EndpointIPIndex.Query
+)
+
+func NewEndpointTable(db *statedb.DB) (statedb.RWTable[*Endpoint], error) {
+	return statedb.NewTable(
+		db,
+		EndpointTableName,
+		EndpointKeyIndex,
+		EndpointAliasIndex,
+		EndpointSourceIndex,
+		EndpointIPIndex,
+	)
+}
+
+type Writer struct {
+	table statedb.RWTable[*Endpoint]
+}
+
+func NewWriter(table statedb.RWTable[*Endpoint]) *Writer {
+	return &Writer{table: table}
+}
+
+func (w *Writer) Upsert(txn statedb.WriteTxn, src Source) (*Endpoint, error) {
+	if src.Key == "" {
+		return nil, fmt.Errorf("source key is required")
+	}
+	src = src.deepCopy()
+	if src.EndpointKey.IsZero() {
+		return nil, fmt.Errorf("endpoint key is required for source %q", src.Key)
+	}
+
+	if old, _, found := w.table.Get(txn, EndpointBySource(src.Key)); found {
+		if _, err := w.removeSourceFromRow(txn, old, src.Key); err != nil {
+			return nil, err
+		}
+	}
+
+	sources := map[SourceKey]Source{src.Key: src}
+	candidates := map[string]*Endpoint{}
+	for _, key := range src.endpointKeys() {
+		if row, _, found := w.table.Get(txn, EndpointByAlias(key)); found {
+			candidates[row.Key.String()] = row
+		}
+	}
+
+	for _, row := range candidates {
+		for sourceKey, candidateSource := range row.Sources {
+			sources[sourceKey] = candidateSource.deepCopy()
+		}
+		if _, _, err := w.table.Delete(txn, row); err != nil {
+			return nil, err
+		}
+	}
+
+	ep, err := NewEndpointFromSources(sources)
+	if err != nil {
+		return nil, err
+	}
+	if _, _, err := w.table.Insert(txn, ep); err != nil {
+		return nil, err
+	}
+	return ep, nil
+}
+
+func (w *Writer) DeleteSource(txn statedb.WriteTxn, key SourceKey) (*Endpoint, bool, error) {
+	row, _, found := w.table.Get(txn, EndpointBySource(key))
+	if !found {
+		return nil, false, nil
+	}
+	ep, err := w.removeSourceFromRow(txn, row, key)
+	if err != nil {
+		return nil, false, err
+	}
+	return ep, true, nil
+}
+
+func (w *Writer) removeSourceFromRow(txn statedb.WriteTxn, row *Endpoint, key SourceKey) (*Endpoint, error) {
+	remaining := row.DeepCopy()
+	delete(remaining.Sources, key)
+
+	if _, _, err := w.table.Delete(txn, row); err != nil {
+		return nil, err
+	}
+	if len(remaining.Sources) == 0 {
+		return nil, nil
+	}
+
+	ep, err := NewEndpointFromSources(remaining.Sources)
+	if err != nil {
+		return nil, err
+	}
+	if _, _, err := w.table.Insert(txn, ep); err != nil {
+		return nil, err
+	}
+	return ep, nil
+}
+
+func NewEndpointFromSources(sources map[SourceKey]Source) (*Endpoint, error) {
+	if len(sources) == 0 {
+		return nil, fmt.Errorf("at least one source is required")
+	}
+
+	copiedSources := make(map[SourceKey]Source, len(sources))
+	orderedSources := make([]Source, 0, len(sources))
+	aliases := []EndpointKey{}
+	for key, src := range sources {
+		if key == "" {
+			return nil, fmt.Errorf("source key is required")
+		}
+		if src.EndpointKey.IsZero() {
+			return nil, fmt.Errorf("endpoint key is required for source %q", key)
+		}
+		src.Key = key
+		src = src.deepCopy()
+		copiedSources[key] = src
+		orderedSources = append(orderedSources, src)
+		aliases = append(aliases, src.endpointKeys()...)
+	}
+	sortSources(orderedSources)
+
+	aliases = dedupeEndpointKeys(aliases)
+	key, err := chooseEndpointKey(aliases)
+	if err != nil {
+		return nil, err
+	}
+
+	ep := &Endpoint{
+		Key:     key,
+		Aliases: aliases,
+		Sources: copiedSources,
+	}
+	deriveEndpointFields(ep, orderedSources)
+	return ep, nil
+}
+
+func deriveEndpointFields(ep *Endpoint, sources []Source) {
+	if ep.Key.Kind == EndpointKeyKindK8s {
+		ep.Cluster = ep.Key.Cluster
+		ep.Namespace = ep.Key.Namespace
+		ep.Name = ep.Key.Name
+	} else {
+		ep.Cluster = ep.Key.Cluster
+	}
+
+	ipSet := map[netip.Addr]struct{}{}
+	var selected *Source
+	for i := range sources {
+		src := sources[i]
+		if selected == nil {
+			selected = &src
+		}
+		for _, ip := range src.IPs {
+			if ip.IsValid() {
+				ipSet[ip] = struct{}{}
+			}
+		}
+	}
+	for ip := range ipSet {
+		ep.IPs = append(ep.IPs, ip)
+	}
+	sort.Slice(ep.IPs, func(i, j int) bool { return ep.IPs[i].Less(ep.IPs[j]) })
+
+	if selected == nil {
+		return
+	}
+	if ep.Cluster == "" {
+		ep.Cluster = selected.Cluster
+	}
+	if ep.Namespace == "" {
+		ep.Namespace = selected.Namespace
+	}
+	if ep.Name == "" {
+		ep.Name = selected.Name
+	}
+	ep.HostIP = selected.HostIP
+	ep.Identity = selected.Identity
+	ep.EncryptionKey = selected.EncryptionKey
+	ep.ServiceAccount = selected.ServiceAccount
+	ep.NamedPorts = copyNamedPorts(selected.NamedPorts)
+	ep.Conflicts = findConflicts(sources)
+}
+
+func SourceFromCEP(cluster string, cep *k8stypes.CiliumEndpoint) (Source, error) {
+	if cep == nil {
+		return Source{}, fmt.Errorf("nil CiliumEndpoint")
+	}
+	key := K8sEndpointKey(cluster, cep.Namespace, cep.Name)
+	src := Source{
+		Key:            CEPSourceKey(cluster, cep.Namespace, cep.Name, string(cep.UID)),
+		Kind:           SourceKindCEP,
+		EndpointKey:    key,
+		Aliases:        []EndpointKey{key},
+		Cluster:        cluster,
+		Namespace:      cep.Namespace,
+		Name:           cep.Name,
+		ServiceAccount: cep.ServiceAccount,
+	}
+	if cep.Identity != nil {
+		src.Identity = identity.NumericIdentity(cep.Identity.ID)
+	}
+	if cep.Networking != nil {
+		src.IPs = addressesFromNetworking(cep.Networking)
+		src.HostIP = parseAddr(cep.Networking.NodeIP)
+	}
+	if cep.Encryption != nil {
+		src.EncryptionKey = uint8(cep.Encryption.Key)
+	}
+	src.NamedPorts = namedPortsFromModels(cep.NamedPorts)
+	return src, nil
+}
+
+func SourcesFromCES(cluster string, ces *ciliumv2alpha1.CiliumEndpointSlice) ([]Source, error) {
+	if ces == nil {
+		return nil, fmt.Errorf("nil CiliumEndpointSlice")
+	}
+	sources := make([]Source, 0, len(ces.Endpoints))
+	for i := range ces.Endpoints {
+		src, err := SourceFromCoreCEP(cluster, ces.Name, ces.Namespace, &ces.Endpoints[i])
+		if err != nil {
+			return nil, err
+		}
+		sources = append(sources, src)
+	}
+	return sources, nil
+}
+
+func SourceFromCoreCEP(cluster, cesName, namespace string, ep *ciliumv2alpha1.CoreCiliumEndpoint) (Source, error) {
+	if ep == nil {
+		return Source{}, fmt.Errorf("nil CoreCiliumEndpoint")
+	}
+	key := K8sEndpointKey(cluster, namespace, ep.Name)
+	src := Source{
+		Key:            CESSourceKey(cluster, cesName, namespace, ep.Name, ep.PodUID),
+		Kind:           SourceKindCES,
+		EndpointKey:    key,
+		Aliases:        []EndpointKey{key},
+		Cluster:        cluster,
+		Namespace:      namespace,
+		Name:           ep.Name,
+		PodUID:         ep.PodUID,
+		Identity:       identity.NumericIdentity(ep.IdentityID),
+		EncryptionKey:  uint8(ep.Encryption.Key),
+		ServiceAccount: ep.ServiceAccount,
+		NamedPorts:     namedPortsFromModels(ep.NamedPorts),
+	}
+	if ep.Networking != nil {
+		src.IPs = addressesFromNetworking(ep.Networking)
+		src.HostIP = parseAddr(ep.Networking.NodeIP)
+	}
+	return src, nil
+}
+
+func SourceFromIPIdentityPair(cluster string, pair *identity.IPIdentityPair) (Source, error) {
+	if pair == nil {
+		return Source{}, fmt.Errorf("nil IPIdentityPair")
+	}
+	if !pair.IsHost() {
+		return Source{}, fmt.Errorf("non-host IPIdentityPair %q is not a managed endpoint", pair.PrefixString())
+	}
+
+	ip, err := netip.ParseAddr(pair.PrefixString())
+	if err != nil {
+		return Source{}, err
+	}
+	prefix := netip.PrefixFrom(ip, ip.BitLen())
+	metadataCluster, nodeName, endpointID, hasGlobal := ParseGlobalEndpointMetadata(pair.Metadata)
+	if cluster == "" {
+		cluster = metadataCluster
+	}
+	globalCluster := cluster
+	if globalCluster == "" {
+		globalCluster = metadataCluster
+	}
+
+	aliases := []EndpointKey{IPEndpointKey(cluster, prefix)}
+	var key EndpointKey
+	if pair.K8sNamespace != "" {
+		switch {
+		case pair.K8sCEPName != "":
+			key = K8sEndpointKey(cluster, pair.K8sNamespace, pair.K8sCEPName)
+		case pair.K8sPodName != "":
+			key = K8sEndpointKey(cluster, pair.K8sNamespace, pair.K8sPodName)
+		}
+		if !key.IsZero() {
+			aliases = append(aliases, key)
+		}
+	}
+	if hasGlobal {
+		aliases = append(aliases, GlobalEndpointKey(globalCluster, nodeName, endpointID))
+	}
+	if key.IsZero() && hasGlobal {
+		key = GlobalEndpointKey(globalCluster, nodeName, endpointID)
+	}
+	if key.IsZero() {
+		key = IPEndpointKey(cluster, prefix)
+	}
+
+	name := pair.K8sCEPName
+	if name == "" {
+		name = pair.K8sPodName
+	}
+	return Source{
+		Key:            KVStoreSourceKey(cluster, pair.PrefixString()),
+		Kind:           SourceKindKVStore,
+		EndpointKey:    key,
+		Aliases:        aliases,
+		Cluster:        cluster,
+		Namespace:      pair.K8sNamespace,
+		Name:           name,
+		NodeName:       nodeName,
+		EndpointID:     endpointID,
+		IPs:            []netip.Addr{ip},
+		HostIP:         parseAddr(pair.HostIP.String()),
+		Identity:       pair.ID,
+		EncryptionKey:  pair.Key,
+		ServiceAccount: pair.K8sServiceAccount,
+		NamedPorts:     namedPortsFromIdentity(pair.NamedPorts),
+	}, nil
+}
+
+func ParseGlobalEndpointMetadata(metadata string) (cluster, nodeName, endpointID string, ok bool) {
+	parts := strings.Split(metadata, ":")
+	if len(parts) != 4 || parts[0] != id.CiliumGlobalIdPrefix.String() {
+		return "", "", "", false
+	}
+	if parts[1] == "" || parts[2] == "" || parts[3] == "" {
+		return "", "", "", false
+	}
+	return parts[1], parts[2], parts[3], true
+}
+
+func chooseEndpointKey(keys []EndpointKey) (EndpointKey, error) {
+	if len(keys) == 0 {
+		return EndpointKey{}, fmt.Errorf("no endpoint keys available")
+	}
+	for _, kind := range []EndpointKeyKind{EndpointKeyKindK8s, EndpointKeyKindGlobal, EndpointKeyKindIP} {
+		matches := make([]EndpointKey, 0, len(keys))
+		for _, key := range keys {
+			if key.Kind == kind {
+				matches = append(matches, key)
+			}
+		}
+		if len(matches) == 0 {
+			continue
+		}
+		sortEndpointKeys(matches)
+		return matches[0], nil
+	}
+	return EndpointKey{}, fmt.Errorf("no supported endpoint keys available")
+}
+
+func dedupeEndpointKeys(keys []EndpointKey) []EndpointKey {
+	seen := map[string]EndpointKey{}
+	for _, key := range keys {
+		if key.IsZero() {
+			continue
+		}
+		seen[key.String()] = key
+	}
+	out := make([]EndpointKey, 0, len(seen))
+	for _, key := range seen {
+		out = append(out, key)
+	}
+	sortEndpointKeys(out)
+	return out
+}
+
+func sortEndpointKeys(keys []EndpointKey) {
+	sort.Slice(keys, func(i, j int) bool { return keys[i].String() < keys[j].String() })
+}
+
+func sortSources(sources []Source) {
+	sort.Slice(sources, func(i, j int) bool {
+		if sources[i].priority() != sources[j].priority() {
+			return sources[i].priority() < sources[j].priority()
+		}
+		return string(sources[i].Key) < string(sources[j].Key)
+	})
+}
+
+func addressesFromNetworking(networking *ciliumv2.EndpointNetworking) []netip.Addr {
+	if networking == nil {
+		return nil
+	}
+	var out []netip.Addr
+	for _, pair := range networking.Addressing {
+		if pair == nil {
+			continue
+		}
+		if ip := parseAddr(pair.IPV4); ip.IsValid() {
+			out = append(out, ip)
+		}
+		if ip := parseAddr(pair.IPV6); ip.IsValid() {
+			out = append(out, ip)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Less(out[j]) })
+	return out
+}
+
+func parseAddr(s string) netip.Addr {
+	if s == "" || s == "<nil>" {
+		return netip.Addr{}
+	}
+	ip, err := netip.ParseAddr(s)
+	if err != nil {
+		return netip.Addr{}
+	}
+	return ip
+}
+
+func namedPortsFromModels(ports models.NamedPorts) types.NamedPortMap {
+	if len(ports) == 0 {
+		return nil
+	}
+	out := types.NamedPortMap{}
+	for _, port := range ports {
+		if port == nil {
+			continue
+		}
+		_ = out.AddPort(port.Name, int(port.Port), port.Protocol)
+	}
+	return out
+}
+
+func namedPortsFromIdentity(ports []identity.NamedPort) types.NamedPortMap {
+	if len(ports) == 0 {
+		return nil
+	}
+	out := types.NamedPortMap{}
+	for _, port := range ports {
+		_ = out.AddPort(port.Name, int(port.Port), port.Protocol)
+	}
+	return out
+}
+
+func copyNamedPorts(in types.NamedPortMap) types.NamedPortMap {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(types.NamedPortMap, len(in))
+	maps.Copy(out, in)
+	return out
+}
+
+func findConflicts(sources []Source) []string {
+	var conflicts []string
+	conflict := func(field string) {
+		if slices.Contains(conflicts, field) {
+			return
+		}
+		conflicts = append(conflicts, field)
+	}
+
+	var identitySeen identity.NumericIdentity
+	var hostIPSeen netip.Addr
+	var serviceAccountSeen string
+	for _, src := range sources {
+		if src.Identity != 0 {
+			if identitySeen != 0 && identitySeen != src.Identity {
+				conflict("identity")
+			}
+			identitySeen = src.Identity
+		}
+		if src.HostIP.IsValid() {
+			if hostIPSeen.IsValid() && hostIPSeen != src.HostIP {
+				conflict("host-ip")
+			}
+			hostIPSeen = src.HostIP
+		}
+		if src.ServiceAccount != "" {
+			if serviceAccountSeen != "" && serviceAccountSeen != src.ServiceAccount {
+				conflict("service-account")
+			}
+			serviceAccountSeen = src.ServiceAccount
+		}
+	}
+	sort.Strings(conflicts)
+	return conflicts
+}

--- a/pkg/endpoint/tables/endpoint_test.go
+++ b/pkg/endpoint/tables/endpoint_test.go
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package tables
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/statedb"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sTypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/identity"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	ciliumv2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slimmeta "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	k8stypes "github.com/cilium/cilium/pkg/k8s/types"
+)
+
+func TestWriterMergesCEPAndKVStoreByCEPName(t *testing.T) {
+	db, table, writer := newFixture(t)
+
+	cepSource, err := SourceFromCEP("cluster-a", newSlimCEP("default", "netcheck-eth1", "cep-uid", "10.0.0.10"))
+	require.NoError(t, err)
+
+	wtxn := db.WriteTxn(table)
+	_, err = writer.Upsert(wtxn, cepSource)
+	require.NoError(t, err)
+	wtxn.Commit()
+
+	kvSource, err := SourceFromIPIdentityPair("cluster-a", &identity.IPIdentityPair{
+		IP:                net.ParseIP("10.0.0.10"),
+		HostIP:            net.ParseIP("192.0.2.10"),
+		ID:                1001,
+		Key:               4,
+		Metadata:          "cilium-global:cluster-a:node-a:123",
+		K8sNamespace:      "default",
+		K8sPodName:        "netcheck",
+		K8sCEPName:        "netcheck-eth1",
+		K8sServiceAccount: "default",
+	})
+	require.NoError(t, err)
+
+	wtxn = db.WriteTxn(table)
+	ep, err := writer.Upsert(wtxn, kvSource)
+	require.NoError(t, err)
+	wtxn.Commit()
+
+	require.Equal(t, K8sEndpointKey("cluster-a", "default", "netcheck-eth1"), ep.Key)
+	require.Len(t, ep.Sources, 2)
+	require.Equal(t, []netip.Addr{netip.MustParseAddr("10.0.0.10")}, ep.IPs)
+
+	rows := collectEndpoints(db, table)
+	require.Len(t, rows, 1)
+
+	wtxn = db.WriteTxn(table)
+	var found bool
+	ep, found, err = writer.DeleteSource(wtxn, kvSource.Key)
+	require.NoError(t, err)
+	require.True(t, found)
+	wtxn.Commit()
+
+	require.NotNil(t, ep)
+	require.Len(t, ep.Sources, 1)
+	require.Contains(t, ep.Sources, cepSource.Key)
+	require.Len(t, collectEndpoints(db, table), 1)
+}
+
+func TestWriterMergesDualStackKVStorePairsByGlobalEndpointID(t *testing.T) {
+	db, table, writer := newFixture(t)
+	v4 := newKVSource(t, "10.0.0.10", "", "", "cilium-global:cluster-a:node-a:123")
+	v6 := newKVSource(t, "fd00::10", "", "", "cilium-global:cluster-a:node-a:123")
+
+	wtxn := db.WriteTxn(table)
+	_, err := writer.Upsert(wtxn, v4)
+	require.NoError(t, err)
+	ep, err := writer.Upsert(wtxn, v6)
+	require.NoError(t, err)
+	wtxn.Commit()
+
+	require.Equal(t, GlobalEndpointKey("cluster-a", "node-a", "123"), ep.Key)
+	require.Len(t, ep.Sources, 2)
+	require.Equal(t, []netip.Addr{netip.MustParseAddr("10.0.0.10"), netip.MustParseAddr("fd00::10")}, ep.IPs)
+	require.Len(t, collectEndpoints(db, table), 1)
+}
+
+func TestWriterDoesNotGuessMergeByIPAndIdentity(t *testing.T) {
+	db, table, writer := newFixture(t)
+
+	cepSource, err := SourceFromCEP("cluster-a", newSlimCEP("default", "netcheck", "cep-uid", "10.0.0.10"))
+	require.NoError(t, err)
+	kvSource := newKVSource(t, "10.0.0.10", "", "", "cilium-global:cluster-a:node-a:123")
+
+	wtxn := db.WriteTxn(table)
+	_, err = writer.Upsert(wtxn, cepSource)
+	require.NoError(t, err)
+	_, err = writer.Upsert(wtxn, kvSource)
+	require.NoError(t, err)
+	wtxn.Commit()
+
+	rows := collectEndpoints(db, table)
+	require.Len(t, rows, 2)
+	requireEndpointKeys(t, rows,
+		K8sEndpointKey("cluster-a", "default", "netcheck"),
+		GlobalEndpointKey("cluster-a", "node-a", "123"),
+	)
+}
+
+func TestWriterUsesPodNameBridgeForLegacyKVStorePairs(t *testing.T) {
+	db, table, writer := newFixture(t)
+
+	cepSource, err := SourceFromCEP("cluster-a", newSlimCEP("default", "netcheck", "cep-uid", "10.0.0.10"))
+	require.NoError(t, err)
+	kvSource := newKVSource(t, "10.0.0.10", "default", "netcheck", "cilium-global:cluster-a:node-a:123")
+
+	wtxn := db.WriteTxn(table)
+	_, err = writer.Upsert(wtxn, cepSource)
+	require.NoError(t, err)
+	ep, err := writer.Upsert(wtxn, kvSource)
+	require.NoError(t, err)
+	wtxn.Commit()
+
+	require.Equal(t, K8sEndpointKey("cluster-a", "default", "netcheck"), ep.Key)
+	require.Len(t, ep.Sources, 2)
+	require.Len(t, collectEndpoints(db, table), 1)
+}
+
+func TestSourcesFromCES(t *testing.T) {
+	ces := &ciliumv2alpha1.CiliumEndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: "ces-a"},
+		Namespace:  "default",
+		Endpoints: []ciliumv2alpha1.CoreCiliumEndpoint{{
+			Name:       "netcheck",
+			IdentityID: 1001,
+			PodUID:     "pod-uid",
+			Networking: &ciliumv2.EndpointNetworking{
+				Addressing: ciliumv2.AddressPairList{{
+					IPV4: "10.0.0.10",
+					IPV6: "fd00::10",
+				}},
+				NodeIP: "192.0.2.10",
+			},
+			Encryption: ciliumv2.EncryptionSpec{Key: 4},
+			NamedPorts: models.NamedPorts{{
+				Name:     "http",
+				Port:     8080,
+				Protocol: "TCP",
+			}},
+			ServiceAccount: "default",
+		}},
+	}
+
+	sources, err := SourcesFromCES("cluster-a", ces)
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	require.Equal(t, CESSourceKey("cluster-a", "ces-a", "default", "netcheck", "pod-uid"), sources[0].Key)
+	require.Equal(t, K8sEndpointKey("cluster-a", "default", "netcheck"), sources[0].EndpointKey)
+	require.Equal(t, []netip.Addr{netip.MustParseAddr("10.0.0.10"), netip.MustParseAddr("fd00::10")}, sources[0].IPs)
+}
+
+func TestEndpointResourceReflectorUpdatesCESMembership(t *testing.T) {
+	db, table, writer := newFixture(t)
+	reflector := endpointResourceReflector{
+		db:          db,
+		table:       table,
+		writer:      writer,
+		clusterName: "cluster-a",
+		cesSources:  make(map[resource.Key][]SourceKey),
+	}
+	key := resource.Key{Name: "ces-a"}
+	ces := newCES("ces-a", "default",
+		newCoreCEP("netcheck-a", "pod-a", "10.0.0.10"),
+		newCoreCEP("netcheck-b", "pod-b", "10.0.0.11"),
+	)
+
+	require.NoError(t, reflector.upsertCES(key, ces))
+	requireEndpointKeys(t, collectEndpoints(db, table),
+		K8sEndpointKey("cluster-a", "default", "netcheck-a"),
+		K8sEndpointKey("cluster-a", "default", "netcheck-b"),
+	)
+
+	ces.Endpoints = ces.Endpoints[:1]
+	require.NoError(t, reflector.upsertCES(key, ces))
+	requireEndpointKeys(t, collectEndpoints(db, table),
+		K8sEndpointKey("cluster-a", "default", "netcheck-a"),
+	)
+
+	require.NoError(t, reflector.deleteCES(key, ces))
+	require.Empty(t, collectEndpoints(db, table))
+}
+
+func TestKVStoreIPIdentityReflectorMergesAndDeletesSource(t *testing.T) {
+	db, table, writer := newFixture(t)
+	cepSource, err := SourceFromCEP("cluster-a", newSlimCEP("default", "netcheck-eth1", "cep-uid", "10.0.0.10"))
+	require.NoError(t, err)
+
+	wtxn := db.WriteTxn(table)
+	_, err = writer.Upsert(wtxn, cepSource)
+	require.NoError(t, err)
+	wtxn.Commit()
+
+	reflector := kvstoreIPIdentityReflector{
+		db:     db,
+		table:  table,
+		writer: writer,
+	}
+	pair := &identity.IPIdentityPair{
+		IP:                net.ParseIP("10.0.0.10"),
+		HostIP:            net.ParseIP("192.0.2.10"),
+		ID:                1001,
+		Key:               4,
+		Metadata:          "cilium-global:cluster-a:node-a:123",
+		K8sNamespace:      "default",
+		K8sPodName:        "netcheck",
+		K8sCEPName:        "netcheck-eth1",
+		K8sServiceAccount: "default",
+	}
+
+	require.NoError(t, reflector.OnIPIdentityPairUpsert("cluster-a", pair))
+	rows := collectEndpoints(db, table)
+	require.Len(t, rows, 1)
+	require.Equal(t, K8sEndpointKey("cluster-a", "default", "netcheck-eth1"), rows[0].Key)
+	require.Len(t, rows[0].Sources, 2)
+
+	require.NoError(t, reflector.OnIPIdentityPairDelete("cluster-a", pair))
+	rows = collectEndpoints(db, table)
+	require.Len(t, rows, 1)
+	require.Contains(t, rows[0].Sources, cepSource.Key)
+	require.NotContains(t, rows[0].Sources, KVStoreSourceKey("cluster-a", pair.PrefixString()))
+}
+
+func TestSourceFromIPIdentityPairRejectsPrefixes(t *testing.T) {
+	_, err := SourceFromIPIdentityPair("cluster-a", &identity.IPIdentityPair{
+		IP:   net.ParseIP("10.0.0.0"),
+		Mask: net.CIDRMask(24, 32),
+		ID:   1001,
+	})
+	require.Error(t, err)
+}
+
+func newFixture(t *testing.T) (*statedb.DB, statedb.RWTable[*Endpoint], *Writer) {
+	t.Helper()
+	db := statedb.New()
+	table, err := NewEndpointTable(db)
+	require.NoError(t, err)
+	return db, table, NewWriter(table)
+}
+
+func newSlimCEP(namespace, name, uid, ip string) *k8stypes.CiliumEndpoint {
+	return &k8stypes.CiliumEndpoint{
+		ObjectMeta: slimmeta.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			UID:       k8sTypes.UID(uid),
+		},
+		Identity: &ciliumv2.EndpointIdentity{ID: 1001},
+		Networking: &ciliumv2.EndpointNetworking{
+			Addressing: ciliumv2.AddressPairList{{
+				IPV4: ip,
+			}},
+			NodeIP: "192.0.2.10",
+		},
+		Encryption:     &ciliumv2.EncryptionSpec{Key: 4},
+		ServiceAccount: "default",
+	}
+}
+
+func newKVSource(t *testing.T, ip, namespace, podName, metadata string) Source {
+	t.Helper()
+	source, err := SourceFromIPIdentityPair("cluster-a", &identity.IPIdentityPair{
+		IP:                net.ParseIP(ip),
+		HostIP:            net.ParseIP("192.0.2.10"),
+		ID:                1001,
+		Key:               4,
+		Metadata:          metadata,
+		K8sNamespace:      namespace,
+		K8sPodName:        podName,
+		K8sServiceAccount: "default",
+	})
+	require.NoError(t, err)
+	return source
+}
+
+func newCES(name, namespace string, endpoints ...ciliumv2alpha1.CoreCiliumEndpoint) *ciliumv2alpha1.CiliumEndpointSlice {
+	return &ciliumv2alpha1.CiliumEndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Namespace:  namespace,
+		Endpoints:  endpoints,
+	}
+}
+
+func newCoreCEP(name, podUID, ip string) ciliumv2alpha1.CoreCiliumEndpoint {
+	return ciliumv2alpha1.CoreCiliumEndpoint{
+		Name:       name,
+		IdentityID: 1001,
+		PodUID:     podUID,
+		Networking: &ciliumv2.EndpointNetworking{
+			Addressing: ciliumv2.AddressPairList{{
+				IPV4: ip,
+			}},
+			NodeIP: "192.0.2.10",
+		},
+		Encryption:     ciliumv2.EncryptionSpec{Key: 4},
+		ServiceAccount: "default",
+	}
+}
+
+func collectEndpoints(db *statedb.DB, table statedb.Table[*Endpoint]) []*Endpoint {
+	var endpoints []*Endpoint
+	for ep := range table.All(db.ReadTxn()) {
+		endpoints = append(endpoints, ep)
+	}
+	return endpoints
+}
+
+func requireEndpointKeys(t *testing.T, endpoints []*Endpoint, keys ...EndpointKey) {
+	t.Helper()
+	have := make([]EndpointKey, 0, len(endpoints))
+	for _, ep := range endpoints {
+		have = append(have, ep.Key)
+	}
+	require.ElementsMatch(t, keys, have)
+}

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -55,6 +55,7 @@ type IPIdentityPair struct {
 	Metadata          string          `json:"Metadata"`
 	K8sNamespace      string          `json:"K8sNamespace,omitempty"`
 	K8sPodName        string          `json:"K8sPodName,omitempty"`
+	K8sCEPName        string          `json:"K8sCEPName,omitempty"`
 	K8sServiceAccount string          `json:"K8sServiceAccount,omitempty"`
 	NamedPorts        []NamedPort     `json:"NamedPorts,omitempty"`
 }

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -72,6 +72,7 @@ type UpsertParams struct {
 	Metadata          string
 	K8sNamespace      string
 	K8sPodName        string
+	K8sCEPName        string
 	K8sServiceAccount string
 	NPM               types.NamedPortMap
 }
@@ -100,6 +101,7 @@ func (s *IPIdentitySynchronizer) Upsert(ctx context.Context, params *UpsertParam
 		Key:               params.Key,
 		K8sNamespace:      params.K8sNamespace,
 		K8sPodName:        params.K8sPodName,
+		K8sCEPName:        params.K8sCEPName,
 		K8sServiceAccount: params.K8sServiceAccount,
 		NamedPorts:        namedPorts,
 	}
@@ -203,6 +205,10 @@ func (liw *LocalIPIdentityWatcher) IsEnabled() bool {
 	return liw.client.IsEnabled()
 }
 
+func (liw *LocalIPIdentityWatcher) AddIPIdentityPairObserver(observer IPIdentityPairObserver) {
+	liw.watcher.AddIPIdentityPairObserver(observer)
+}
+
 // IPIdentityWatcher is a watcher that will notify when IP<->identity mappings
 // change in the kvstore.
 type IPIdentityWatcher struct {
@@ -215,6 +221,7 @@ type IPIdentityWatcher struct {
 	source                     source.Source
 	withSelfDeletionProtection bool
 	validators                 []ipIdentityValidator
+	pairObservers              []IPIdentityPairObserver
 
 	// Set only when withSelfDeletionProtection is true
 	syncer *IPIdentitySynchronizer
@@ -226,6 +233,18 @@ type IPIdentityWatcher struct {
 type IPCacher interface {
 	Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *K8sMetadata, newIdentity Identity) (bool, error)
 	Delete(IP string, source source.Source) (namedPortsChanged bool)
+}
+
+type IPIdentityPairObserver interface {
+	OnIPIdentityPairUpsert(clusterName string, pair *identity.IPIdentityPair) error
+	OnIPIdentityPairDelete(clusterName string, pair *identity.IPIdentityPair) error
+}
+
+func (iw *IPIdentityWatcher) AddIPIdentityPairObserver(observer IPIdentityPairObserver) {
+	if observer == nil {
+		return
+	}
+	iw.pairObservers = append(iw.pairObservers, observer)
 }
 
 // NewIPIdentityWatcher creates a new IPIdentityWatcher for the given cluster.
@@ -409,6 +428,16 @@ func (iw *IPIdentityWatcher) OnUpdate(k storepkg.Key) {
 		}
 	}
 
+	for _, observer := range iw.pairObservers {
+		if err := observer.OnIPIdentityPairUpsert(iw.clusterName, ipIDPair); err != nil {
+			iw.log.Warn(
+				"Failed to update IP identity pair observer",
+				logfields.Error, err,
+				logfields.IPAddr, ip,
+			)
+		}
+	}
+
 	var k8sMeta *K8sMetadata
 	if ipIDPair.K8sNamespace != "" || ipIDPair.K8sPodName != "" || len(ipIDPair.NamedPorts) > 0 {
 		k8sMeta = &K8sMetadata{
@@ -478,6 +507,16 @@ func (iw *IPIdentityWatcher) OnDelete(k storepkg.NamedKey) {
 
 	if iw.withSelfDeletionProtection && iw.selfDeletionProtection(ip) {
 		return
+	}
+
+	for _, observer := range iw.pairObservers {
+		if err := observer.OnIPIdentityPairDelete(iw.clusterName, ipIDPair); err != nil {
+			iw.log.Warn(
+				"Failed to delete IP identity pair observer",
+				logfields.Error, err,
+				logfields.IPAddr, ip,
+			)
+		}
 	}
 
 	if iw.clusterID != 0 {


### PR DESCRIPTION
Add a StateDB table for Cilium-managed endpoint metadata. The table is populated from CEP/CES resources and kvstore IPIdentityPair updates, and it stores per-producer source assertions so doublewrite mode can merge equivalent CRD/CES and kvstore entries without guessing by IP, identity, or labels.

Kvstore IPIdentityPair metadata now carries the CEP name written by the local endpoint. That gives kvstore entries a semantic bridge back to the CEP/CES endpoint key while preserving the existing global endpoint metadata as an alias for grouping kvstore IPv4/IPv6 entries.

This is the first PR in the endpoint-table direction discussed in #46459. It intentionally stops before moving egress gateway onto the table; that consumer change will follow separately once the table shape is reviewed.

Preview consumer branch, not an upstream PR: [EGW managed endpoint table consumer](https://github.com/pamelia/cilium/compare/codex%2Fmanaged-endpoint-table...codex%2Fegw-managed-endpoint-preview). The compare is against this PR's branch, so it shows only the follow-up egress gateway consumer changes.

Related: #46459

```release-note
Cilium now maintains an internal StateDB table for Cilium-managed endpoint metadata from CEP/CES and kvstore sources.
```

This PR has no direct user-facing behavior change and is labeled `release-note/misc`.

This PR was prepared with LLM assistance (AIL:4). I reviewed the resulting diff, kept the scope to the endpoint metadata/table layer, removed environment-specific test data, and ran focused package tests locally.

Signed-off-by: Marcus Pamelia <kore@mindwipe.org>
