### PR TITLE
ipam/service/allocator: fix IPv6 offset aliasing

### DIFF
--- a/pkg/ipam/service/ipallocator/allocator.go
+++ b/pkg/ipam/service/ipallocator/allocator.go
@@ -237,8 +237,8 @@ func (r *Range) contains(ip netip.Addr) (bool, int) {
 		return false, 0
 	}
 
-	offset := addrOffset(r.base, ip)
-	if offset < 0 || offset >= r.max {
+	offset, ok := addrOffset(r.base, ip)
+	if !ok || offset >= r.max {
 		return false, 0
 	}
 	return true, offset
@@ -265,15 +265,45 @@ func addOffset(base netip.Addr, offset int) netip.Addr {
 }
 
 // addrOffset returns the integer offset of addr from base (addr - base).
-func addrOffset(base, addr netip.Addr) int {
+// The bool is false if addr is before base or if the offset does not fit in an int.
+func addrOffset(base, addr netip.Addr) (int, bool) {
 	if base.Is4() {
 		b := base.As4()
 		a := addr.As4()
-		return int(binary.BigEndian.Uint32(a[:]) - binary.BigEndian.Uint32(b[:]))
+		baseValue := binary.BigEndian.Uint32(b[:])
+		addrValue := binary.BigEndian.Uint32(a[:])
+		if addrValue < baseValue {
+			return 0, false
+		}
+		offset := addrValue - baseValue
+		if uint64(offset) > uint64(^uint(0)>>1) {
+			return 0, false
+		}
+		return int(offset), true
 	}
 	b := base.As16()
 	a := addr.As16()
-	return int(binary.BigEndian.Uint64(a[8:]) - binary.BigEndian.Uint64(b[8:]))
+	baseHi := binary.BigEndian.Uint64(b[:8])
+	baseLo := binary.BigEndian.Uint64(b[8:])
+	addrHi := binary.BigEndian.Uint64(a[:8])
+	addrLo := binary.BigEndian.Uint64(a[8:])
+
+	if addrHi < baseHi || (addrHi == baseHi && addrLo < baseLo) {
+		return 0, false
+	}
+
+	hi := addrHi - baseHi
+	lo := addrLo - baseLo
+	if addrLo < baseLo {
+		hi--
+	}
+	if hi != 0 {
+		return 0, false
+	}
+	if lo > uint64(^uint(0)>>1) {
+		return 0, false
+	}
+	return int(lo), true
 }
 
 // RangeSize returns the size of a range in valid addresses.

--- a/pkg/ipam/service/ipallocator/allocator_test.go
+++ b/pkg/ipam/service/ipallocator/allocator_test.go
@@ -186,6 +186,21 @@ func TestDefaultRangeExcludesFirstLastIPs(t *testing.T) {
 	require.NoError(t, r.Allocate(netip.MustParseAddr("10.0.0.14")))
 }
 
+func TestIPv6WideRangeRejectsAddressOutsideCappedWindow(t *testing.T) {
+	r := NewCIDRRange(netip.MustParsePrefix("2001:db8::/48"))
+
+	firstAllocatable := netip.MustParseAddr("2001:db8::1")
+	sameLowBitsOutsideWindow := netip.MustParseAddr("2001:db8:0:1::1")
+
+	require.NoError(t, r.Allocate(firstAllocatable))
+
+	var notInRange *ErrNotInRange
+	err := r.Allocate(sameLowBitsOutsideWindow)
+	require.ErrorAs(t, err, &notInRange)
+	require.True(t, r.Has(firstAllocatable))
+	require.False(t, r.Has(sameLowBitsOutsideWindow))
+}
+
 func TestRangeSize(t *testing.T) {
 	testCases := []struct {
 		name   string
@@ -286,57 +301,88 @@ func TestAddOffset(t *testing.T) {
 
 func TestAddrOffset(t *testing.T) {
 	testCases := []struct {
-		name string
-		base netip.Addr
-		addr netip.Addr
-		want int
+		name   string
+		base   netip.Addr
+		addr   netip.Addr
+		want   int
+		wantOK bool
 	}{
 		{
-			name: "IPv4 same address",
-			base: netip.MustParseAddr("10.0.0.1"),
-			addr: netip.MustParseAddr("10.0.0.1"),
-			want: 0,
+			name:   "IPv4 same address",
+			base:   netip.MustParseAddr("10.0.0.1"),
+			addr:   netip.MustParseAddr("10.0.0.1"),
+			want:   0,
+			wantOK: true,
 		},
 		{
-			name: "IPv4 +1",
-			base: netip.MustParseAddr("10.0.0.1"),
-			addr: netip.MustParseAddr("10.0.0.2"),
-			want: 1,
+			name:   "IPv4 +1",
+			base:   netip.MustParseAddr("10.0.0.1"),
+			addr:   netip.MustParseAddr("10.0.0.2"),
+			want:   1,
+			wantOK: true,
 		},
 		{
-			name: "IPv4 cross byte boundary",
-			base: netip.MustParseAddr("10.0.0.255"),
-			addr: netip.MustParseAddr("10.0.1.0"),
-			want: 1,
+			name:   "IPv4 cross byte boundary",
+			base:   netip.MustParseAddr("10.0.0.255"),
+			addr:   netip.MustParseAddr("10.0.1.0"),
+			want:   1,
+			wantOK: true,
 		},
 		{
-			name: "IPv4 large offset",
-			base: netip.MustParseAddr("10.0.0.0"),
-			addr: netip.MustParseAddr("10.0.1.0"),
-			want: 256,
+			name:   "IPv4 large offset",
+			base:   netip.MustParseAddr("10.0.0.0"),
+			addr:   netip.MustParseAddr("10.0.1.0"),
+			want:   256,
+			wantOK: true,
 		},
 		{
-			name: "IPv6 same address",
-			base: netip.MustParseAddr("2001:db8::1"),
-			addr: netip.MustParseAddr("2001:db8::1"),
-			want: 0,
+			name:   "IPv6 same address",
+			base:   netip.MustParseAddr("2001:db8::1"),
+			addr:   netip.MustParseAddr("2001:db8::1"),
+			want:   0,
+			wantOK: true,
 		},
 		{
-			name: "IPv6 +1",
-			base: netip.MustParseAddr("2001:db8::1"),
-			addr: netip.MustParseAddr("2001:db8::2"),
-			want: 1,
+			name:   "IPv6 +1",
+			base:   netip.MustParseAddr("2001:db8::1"),
+			addr:   netip.MustParseAddr("2001:db8::2"),
+			want:   1,
+			wantOK: true,
 		},
 		{
-			name: "IPv6 large offset",
-			base: netip.MustParseAddr("2001:db8::"),
-			addr: netip.MustParseAddr("2001:db8::ffff"),
-			want: 65535,
+			name:   "IPv6 low word carry",
+			base:   netip.MustParseAddr("2001:db8::ffff:ffff:ffff:ffff"),
+			addr:   netip.MustParseAddr("2001:db8::1:0:0:0:0"),
+			want:   1,
+			wantOK: true,
+		},
+		{
+			name:   "IPv6 large offset",
+			base:   netip.MustParseAddr("2001:db8::"),
+			addr:   netip.MustParseAddr("2001:db8::ffff"),
+			want:   65535,
+			wantOK: true,
+		},
+		{
+			name:   "IPv6 address before base",
+			base:   netip.MustParseAddr("2001:db8::1"),
+			addr:   netip.MustParseAddr("2001:db8::"),
+			wantOK: false,
+		},
+		{
+			name:   "IPv6 high word delta does not fit in offset",
+			base:   netip.MustParseAddr("2001:db8::"),
+			addr:   netip.MustParseAddr("2001:db8:0:1::"),
+			wantOK: false,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := addrOffset(tc.base, tc.addr)
+			got, ok := addrOffset(tc.base, tc.addr)
+			require.Equal(t, tc.wantOK, ok)
+			if !tc.wantOK {
+				return
+			}
 			require.Equal(t, tc.want, got)
 		})
 	}
@@ -354,7 +400,8 @@ func TestAddOffsetAddrOffsetRoundTrip(t *testing.T) {
 	for _, base := range bases {
 		for _, offset := range offsets {
 			addr := addOffset(base, offset)
-			got := addrOffset(base, addr)
+			got, ok := addrOffset(base, addr)
+			require.True(t, ok, "roundtrip failed for base=%s offset=%d", base, offset)
 			require.Equal(t, offset, got, "roundtrip failed for base=%s offset=%d", base, offset)
 		}
 	}


### PR DESCRIPTION
The IP allocator currently accepts IPv6 addresses based on prefix membership, but computes offsets using only the low 64 bits of the address. For wide IPv6 prefixes, like /48, two different addresses with the same low 64 bits may alias.

Fix this by computing IPv6 offsets with full 128-bit subtraction and reject addresses whose offset is before the range or cannot fit in the allocator offset. Also add a regression test covering a wide IPv6 prefix alias. The test fails without the change to `addrOffset` and passes with the fix in this commit.

Fixes: 69b483c46fc2

(the fixed commit is not part of any released version, thus marking as `release-note/misc` rather than `release-note/bug)

This PR was prepared with AIL:1. I use Claude Code to verify that all corner cases are covered in `addrOffset` (e.g. low word underflows and "borrows" from high word). I personally checked and adjusted the generated code and added explanatory comments.