### PR TITLE
docs: misc improvement to the MCS-API docs and mark MCS-API as stable/recommended

### DIFF
--- a/Documentation/network/clustermesh/affinity.rst
+++ b/Documentation/network/clustermesh/affinity.rst
@@ -4,22 +4,23 @@
 Service Affinity
 ****************
 
-This tutorial will guide you to enable service affinity across multiple
-Kubernetes clusters.
+This tutorial will guide you to enable service affinity for cross-cluster
+services.
 
 Prerequisites
 #############
 
-You need to have a functioning Cluster Mesh with a Global Service, please
-follow the guide :ref:`gs_clustermesh` and :ref:`gs_clustermesh_services`
-to set it up.
+You need to have a functioning Cluster Mesh, please follow the guides
+:ref:`gs_clustermesh` and :ref:`gs_clustermesh_load_balancing` to set it up.
 
 Enabling Global Service Affinity
 ################################
 
 Load-balancing across multiple clusters might not be ideal in some cases.
 The annotation ``service.cilium.io/affinity: "none|local|remote"`` can be used
-to specify the preferred endpoint destination.
+to specify the preferred endpoint destination. With :ref:`MCS-API
+<gs_clustermesh_mcsapi>`, specify this annotation through the ServiceExport
+``exportedAnnotations`` field.
 
 For example, if the value of annotation ``service.cilium.io/affinity`` is local,
 the Global Service will load-balance across healthy ``local`` backends, and only user

--- a/Documentation/network/clustermesh/global-services.rst
+++ b/Documentation/network/clustermesh/global-services.rst
@@ -1,11 +1,11 @@
-.. _gs_clustermesh_services:
+.. _gs_clustermesh_global_services:
 
-**********************************
-Load-balancing & Service Discovery
-**********************************
+***************
+Global Services
+***************
 
-This tutorial will guide you to perform load-balancing and service
-discovery across multiple Kubernetes clusters when using Cilium.
+This tutorial will guide you to perform load-balancing and service discovery
+across multiple Kubernetes clusters using Cilium Global Services.
 
 Prerequisites
 #############

--- a/Documentation/network/clustermesh/index.rst
+++ b/Documentation/network/clustermesh/index.rst
@@ -13,11 +13,11 @@ Multi-cluster Networking
 .. toctree::
    :maxdepth: 2
    :glob:
+   :includehidden:
 
    intro
    setup
-   services
-   mcsapi
+   load-balancing
    policy
    affinity
    aks-clustermesh-prep

--- a/Documentation/network/clustermesh/intro.rst
+++ b/Documentation/network/clustermesh/intro.rst
@@ -19,9 +19,7 @@ extending Cilium networking across multiple Kubernetes clusters and provides:
 
 * Pod-to-pod connectivity between clusters within a flat IP address space
 * Cluster-aware :ref:`network policy enforcement <gs_clustermesh_network_policy>`
-* Cross-cluster service discovery and load-balancing with
-  :ref:`Global Services <gs_clustermesh_services>` or
-  :ref:`MCS-API <gs_clustermesh_mcsapi>`
+* Cross-cluster :ref:`service discovery and load-balancing <gs_clustermesh_load_balancing>`
 * :ref:`Service affinity <gs_clustermesh_service_affinity>` controls to
   prefer local or remote backends
 

--- a/Documentation/network/clustermesh/load-balancing.rst
+++ b/Documentation/network/clustermesh/load-balancing.rst
@@ -1,0 +1,35 @@
+.. _gs_clustermesh_load_balancing:
+
+**********************************
+Load-balancing & Service Discovery
+**********************************
+
+Cilium supports two options for cross-cluster service discovery and
+load-balancing with Cluster Mesh: :ref:`Multi-Cluster Services API (MCS-API)
+<gs_clustermesh_mcsapi>` and :ref:`Global Services <gs_clustermesh_global_services>`.
+You can use either option, or both, depending on your needs and environment.
+
+:ref:`MCS-API <gs_clustermesh_mcsapi>` is a Kubernetes SIG Multicluster standard
+based on the ServiceExport and ServiceImport resources. It provides higher-level
+features such as consistent global service properties, status condition reporting,
+and a dedicated ``clusterset.local`` DNS domain, which requires CoreDNS configuration
+that Cilium can manage automatically when CoreDNS auto-configuration is enabled.
+
+:ref:`Global Services <gs_clustermesh_global_services>` provide Cilium-specific
+cross-cluster load-balancing directly from Service annotations. Global Services
+can be simpler to set up in some environments and are useful when you want
+different Service properties in each cluster or more granular control over how
+backends are shared.
+
+* Use :ref:`MCS-API <gs_clustermesh_mcsapi>` if you want to use a Kubernetes
+  SIG Multicluster standard with higher-level features.
+
+* Use :ref:`Global Services <gs_clustermesh_global_services>` if you want to
+  directly use Cilium Service annotations or need more granular control.
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+   mcsapi
+   global-services

--- a/Documentation/network/clustermesh/mcsapi.rst
+++ b/Documentation/network/clustermesh/mcsapi.rst
@@ -1,10 +1,8 @@
 .. _gs_clustermesh_mcsapi:
 
-*********************************
-Multi-Cluster Services API (Beta)
-*********************************
-
-.. include:: ../../beta.rst
+**************************
+Multi-Cluster Services API
+**************************
 
 This tutorial will guide you to through the support of `Multi-Cluster Services API (MCS-API)`_ in Cilium.
 
@@ -81,7 +79,7 @@ with the same name and namespace will be merged and made globally available.
 
 ServiceImports in Cilium are implemented by creating derived Services named
 ``derived-$hash``. These derived Services use the same Global Services mechanism
-that powers :ref:`Cilium Global Services <gs_clustermesh_services>`.
+that powers :ref:`Cilium Global Services <gs_clustermesh_global_services>`.
 
 An exported Service through MCS-API is available by default on the ``<svc>.<ns>.svc.clusterset.local`` domain.
 If you have defined any hostname (via a Statefulset for instance) on your pods

--- a/Documentation/network/clustermesh/mcsapi.rst
+++ b/Documentation/network/clustermesh/mcsapi.rst
@@ -151,18 +151,18 @@ ServiceImport backend, for example:
    spec:
       parentRefs:
       - group: gateway.networking.k8s.io
-         kind: Gateway
-         name: my-gateway
-         namespace: default
+        kind: Gateway
+        name: my-gateway
+        namespace: default
       rules:
       - backendRefs:
-         - group: multicluster.x-k8s.io
-            kind: ServiceImport
-            name: rebel-base-mcsapi
-            port: 80
-         matches:
-         - method: GET
-            path:
+        - group: multicluster.x-k8s.io
+          kind: ServiceImport
+          name: rebel-base-mcsapi
+          port: 80
+        matches:
+        - method: GET
+          path:
             type: PathPrefix
             value: /
 
@@ -171,6 +171,8 @@ The Gateway API implementation of Cilium fully support its own MCS-API implement
 
 If you want to use another Gateway API implementation with the Cilium MCS-API implementation,
 the Gateway API implementation you are using should officially support MCS-API / `GEP1748`_.
+If the alternate Gateway-API implementation relies on EndpointSlice to operate,
+configure Cilium to enable :ref:`EndpointSlice synchronization <endpointslicesync>`.
 
 On the other hands, the Cilium Gateway API implementation only supports MCS-API
 implementations using an underlying Service associated with a ServiceImport, and with

--- a/Documentation/network/clustermesh/mcsapi.rst
+++ b/Documentation/network/clustermesh/mcsapi.rst
@@ -117,6 +117,29 @@ based on ServiceExport creation time from oldest to newest. A conflict may
 resolve to properties that you did not intend to, so you should eventually
 resolve any conflicts between the exported Services.
 
+Exporting labels and annotations
+--------------------------------
+
+To configure labels or annotations on the generated ServiceImport and derived
+Service, specify them with the ServiceExport ``exportedLabels`` and
+``exportedAnnotations`` fields.
+
+For instance, this is useful for adding any of the supported Cilium service
+annotations, such as :ref:`Service affinity <gs_clustermesh_service_affinity>`
+or :ref:`EndpointSlice synchronization <endpointslicesync>`.
+
+   .. code-block:: yaml
+
+      apiVersion: multicluster.x-k8s.io/v1beta1
+      kind: ServiceExport
+      metadata:
+         name: rebel-base
+      spec:
+         exportedLabels:
+            app.kubernetes.io/name: rebel-base
+         exportedAnnotations:
+            service.cilium.io/affinity: local
+
 
 Deploying a Simple Example Service using MCS-API
 ------------------------------------------------

--- a/Documentation/network/clustermesh/mcsapi.rst
+++ b/Documentation/network/clustermesh/mcsapi.rst
@@ -79,6 +79,10 @@ In all the clusters and for each set of exported Services that have the same nam
 a ServiceImport resource will be automatically created. All the Endpoints from those exported Services
 with the same name and namespace will be merged and made globally available.
 
+ServiceImports in Cilium are implemented by creating derived Services named
+``derived-$hash``. These derived Services use the same Global Services mechanism
+that powers :ref:`Cilium Global Services <gs_clustermesh_services>`.
+
 An exported Service through MCS-API is available by default on the ``<svc>.<ns>.svc.clusterset.local`` domain.
 If you have defined any hostname (via a Statefulset for instance) on your pods
 each pods would also be available available through the ``<hostname>.<clustername>.<svc>.<ns>.svc.clusterset.local`` domain.

--- a/Documentation/network/clustermesh/mcsapi.rst
+++ b/Documentation/network/clustermesh/mcsapi.rst
@@ -100,18 +100,22 @@ each pods would also be available available through the ``<hostname>.<clusternam
 
 .. _dedicated section in the MCS-API KEP: https://github.com/kubernetes/enhancements/blob/master/keps/sig-multicluster/1645-multi-cluster-services-api/README.md#not-allowing-cluster-specific-targeting-via-dns
 
-The ServiceImport has also a logic to merge different Service properties:
+For each set of exported Services with the same name and namespace, MCS-API
+provides one globally consistent multi-cluster Service definition. Cilium
+globally reconciles the following properties into the ServiceImport:
 
 - SessionAffinity
 - Ports (Union of the different ServiceExports)
 - Type (ClusterSetIP/Headless)
+- InternalTrafficPolicy
+- TrafficDistribution
 - Annotations & Labels (via the ServiceExport ``exportedLabels`` and ``exportedAnnotations`` fields)
 
-If any conflict arises on any of these properties, the oldest ServiceExport will
-have precedence to resolve the conflict. This means that you should get a
-consistent behavior globally for the same set of exported Services that has
-the same name and namespace. If any conflicts arises, you would be able to see
-details about it in the ServiceExport status Conditions.
+If any conflict arises on any of these properties, Cilium sets a conflict
+condition on the corresponding ServiceExport status and resolves the conflict
+based on ServiceExport creation time from oldest to newest. A conflict may
+resolve to properties that you did not intend to, so you should eventually
+resolve any conflicts between the exported Services.
 
 
 Deploying a Simple Example Service using MCS-API

--- a/Documentation/network/clustermesh/setup.rst
+++ b/Documentation/network/clustermesh/setup.rst
@@ -5,9 +5,10 @@
 Setting up Cluster Mesh
 ***********************
 
-This is a step-by-step guide on how to build a mesh of Kubernetes clusters by
-connecting them together, enable pod-to-pod connectivity across all clusters,
-define global services to load-balance between clusters and enforce security
+This is a step-by-step guide on how to build a mesh of Kubernetes clusters.
+This guide shows you how to connect the clusters together, enable pod-to-pod
+connectivity across all clusters, set up cross-cluster :ref:`service discovery
+and load-balancing <gs_clustermesh_load_balancing>` and finally enforce security
 policies to restrict access.
 
 .. admonition:: Video
@@ -281,7 +282,7 @@ Next Steps
 
 Logical next steps to explore from here are:
 
- * :ref:`gs_clustermesh_services`
+ * :ref:`gs_clustermesh_load_balancing`
  * :ref:`gs_clustermesh_network_policy`
 
 Troubleshooting

--- a/Documentation/redirects.txt
+++ b/Documentation/redirects.txt
@@ -38,6 +38,7 @@
 "network/external-toc.rst" "network/clustermesh/index.rst"
 "network/external-workloads.rst" "network/clustermesh/index.rst"
 "network/clustermesh/clustermesh.rst" "network/clustermesh/setup.rst"
+"network/clustermesh/services.rst" "network/clustermesh/load-balancing.rst"
 "cmdref/cilium-dbg_bpf_recorder.md" "operations/upgrade.rst"
 "cmdref/cilium-dbg_bpf_recorder_list.md" "operations/upgrade.rst"
 "cmdref/cilium-dbg_recorder.md" "operations/upgrade.rst"


### PR DESCRIPTION
I tried to do a general pass of improvements to the MCS-API docs while also marking MCS-API as stable/recommended. As we are releasing 1.20 soon it's probably fine to not backport some of the doc fixes made in the first commit IMO.

See both commits for more details

Used AI with AIL-1 to co-review/write the doc change made here

Fixes: #45928

```release-note
clustermesh: promote Multi-Cluster Services API (MCS-API) to a stable support level and improve its documentation
```
