### PR TITLE
ci: Add ORGANIZATION_STAGING for stable tags

### DIFF
--- a/.github/actions/set-env-variables/action.yml
+++ b/.github/actions/set-env-variables/action.yml
@@ -13,6 +13,7 @@ runs:
         echo "BACKUP_REGISTRY=$BACKUP_REGISTRY" >> $GITHUB_ENV
         echo "ORGANIZATION=cilium" >> $GITHUB_ENV
         echo "ORGANIZATION_DEV=cilium" >> $GITHUB_ENV
+        echo "ORGANIZATION_STAGING=cilium" >> $GITHUB_ENV
         # no prod yet
         echo "CHARTS_ORGANIZATION_DEV=cilium-charts-dev" >> $GITHUB_ENV
         echo "EGRESS_GATEWAY_HELM_VALUES=--helm-set=egressGateway.enabled=true" >> $GITHUB_ENV

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -442,7 +442,7 @@ jobs:
           image-tag: ${{ steps.downgrade-branch.outputs.sha }}
           chart-dir: ./untrusted/cilium-downgrade/install/kubernetes/cilium
           registry_host: ${{ vars.DOCKER_READ_HOST }}
-          registry_organization: ${{ vars.DOCKER_READ_ORG }}
+          registry_organization: ${{ env.ORGANIZATION_STAGING }}
           image-pull-secret: "cilium-registry"
 
       - name: Wait for images to be available (downgrade)
@@ -450,7 +450,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci clustermesh-apiserver-ci ; do
-            until docker manifest inspect ${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_DEV }}/$image:${{ steps.downgrade-branch.outputs.sha }} &> /dev/null; do sleep 45s; done
+            until docker manifest inspect ${{ env.REGISTRY_DEV }}/${{ env.ORGANIZATION_STAGING }}/$image:${{ steps.downgrade-branch.outputs.sha }} &> /dev/null; do sleep 45s; done
           done
 
 


### PR DESCRIPTION
This change adds ORGANIZATION_STAGING env variable for GH workflows that sets the organization in which stable branch tags can be found.

This change is useful for migrating to another registry in which CI images are not available indefinitely from PR standpoint and stable branches need another organization to retain sha tags

This PR was prepared with AIL: 0.