### PR TITLE
gateway-api: fix startup without optional CRDs

### DIFF
--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -483,11 +483,22 @@ func registerGatewayAPITypesToScheme(scheme *runtime.Scheme, optionalKinds []sch
 
 	addToSchema := make(map[fmt.Stringer]func(s *runtime.Scheme) error)
 
-	// We can safely install the GA resources
-	addToSchema[gatewayv1.GroupVersion] = gatewayv1.AddToScheme
+	// Install all required GVKs.
+	for _, gvk := range helpers.RequiredGVKs {
+		addToSchema[gvk] = func(s *runtime.Scheme) error {
+			s.AddKnownTypes(
+				gvk.GroupVersion(),
+				helpers.GetConcreteObject(gvk),
+				helpers.GetConcreteListObject(gvk),
+			)
+			metav1.AddToGroupVersion(s, gvk.GroupVersion())
+			return nil
+		}
+	}
+
 	// We can also safely install the v1beta1 resources, as these are legacy
 	// and also included in the Standard install
-	addToSchema[gatewayv1beta1.GroupVersion] = gatewayv1beta1.AddToScheme
+	addToSchema[gatewayv1beta1.GroupVersion] = gatewayv1beta1.Install
 
 	for _, optionalKind := range optionalKinds {
 		// Note that we're using the full GVK as the map key here - this is fine
@@ -498,15 +509,11 @@ func registerGatewayAPITypesToScheme(scheme *runtime.Scheme, optionalKinds []sch
 		// AddToScheme, but we can't use that here because we want to only
 		// enable things on a per-resource basis.
 		addToSchema[optionalKind] = func(s *runtime.Scheme) error {
-			s.AddKnownTypes(optionalKind.GroupVersion(), helpers.GetConcreteObject(optionalKind))
-			// We also need to add the List version to the Schema
-			listKind := optionalKind.Kind[:len(optionalKind.Kind)-1] + "lists"
-			optionalKindList := schema.GroupVersionKind{
-				Group:   optionalKind.Group,
-				Version: optionalKind.Version,
-				Kind:    listKind,
-			}
-			s.AddKnownTypes(optionalKind.GroupVersion(), helpers.GetConcreteObject(optionalKindList))
+			s.AddKnownTypes(
+				optionalKind.GroupVersion(),
+				helpers.GetConcreteObject(optionalKind),
+				helpers.GetConcreteListObject(optionalKind),
+			)
 			metav1.AddToGroupVersion(s, optionalKind.GroupVersion())
 			return nil
 		}

--- a/operator/pkg/gateway-api/helpers/schemes.go
+++ b/operator/pkg/gateway-api/helpers/schemes.go
@@ -57,8 +57,18 @@ func RegisterGatewayAPITypesToScheme(scheme *runtime.Scheme, optionalKinds []sch
 
 	addToSchema := make(map[fmt.Stringer]func(s *runtime.Scheme) error)
 
-	// We can safely install the GA resources
-	addToSchema[gatewayv1.GroupVersion] = gatewayv1.AddToScheme
+	// Install all required GVKs.
+	for _, gvk := range RequiredGVKs {
+		addToSchema[gvk] = func(s *runtime.Scheme) error {
+			s.AddKnownTypes(
+				gvk.GroupVersion(),
+				GetConcreteObject(gvk),
+				GetConcreteListObject(gvk),
+			)
+			metav1.AddToGroupVersion(s, gvk.GroupVersion())
+			return nil
+		}
+	}
 
 	for _, optionalKind := range optionalKinds {
 		// Note that we're using the full GVK as the map key here - this is fine
@@ -69,15 +79,11 @@ func RegisterGatewayAPITypesToScheme(scheme *runtime.Scheme, optionalKinds []sch
 		// AddToScheme, but we can't use that here because we want to only
 		// enable things on a per-resource basis.
 		addToSchema[optionalKind] = func(s *runtime.Scheme) error {
-			s.AddKnownTypes(optionalKind.GroupVersion(), GetConcreteObject(optionalKind))
-			// We also need to add the List version to the Schema
-			listKind := optionalKind.Kind[:len(optionalKind.Kind)-1] + "lists"
-			optionalKindList := schema.GroupVersionKind{
-				Group:   optionalKind.Group,
-				Version: optionalKind.Version,
-				Kind:    listKind,
-			}
-			s.AddKnownTypes(optionalKind.GroupVersion(), GetConcreteObject(optionalKindList))
+			s.AddKnownTypes(
+				optionalKind.GroupVersion(),
+				GetConcreteObject(optionalKind),
+				GetConcreteListObject(optionalKind),
+			)
 			metav1.AddToGroupVersion(s, optionalKind.GroupVersion())
 			return nil
 		}

--- a/operator/pkg/gateway-api/helpers/types.go
+++ b/operator/pkg/gateway-api/helpers/types.go
@@ -22,22 +22,17 @@ const (
 	kindSecret        = "Secret"
 	kindConfigMap     = "ConfigMap"
 
-	GatewayClassKind      string = "gatewayclasses"
-	GatewayKind           string = "gateways"
-	HTTPRouteKind         string = "httproutes"
-	GRPCRouteKind         string = "grpcroutes"
-	ReferenceGrantKind    string = "referencegrants"
-	BackendTLSPolicyKind  string = "backendtlspolicies"
-	TLSRouteKind          string = "tlsroutes"
-	TLSRouteListKind      string = "tlsroutelists"
-	TCPRouteKind          string = "tcproutes"
-	TCPRouteListKind      string = "tcproutelists"
-	UDPRouteKind          string = "udproutes"
-	UDPRouteListKind      string = "udproutelists"
-	ListenerSetKind       string = "listenersets"
-	ListenerSetListKind   string = "listenersetlists"
-	ServiceImportKind     string = "serviceimports"
-	ServiceImportListKind string = "serviceimportlists"
+	GatewayClassKind     string = "gatewayclasses"
+	GatewayKind          string = "gateways"
+	HTTPRouteKind        string = "httproutes"
+	GRPCRouteKind        string = "grpcroutes"
+	ReferenceGrantKind   string = "referencegrants"
+	BackendTLSPolicyKind string = "backendtlspolicies"
+	TLSRouteKind         string = "tlsroutes"
+	TCPRouteKind         string = "tcproutes"
+	UDPRouteKind         string = "udproutes"
+	ListenerSetKind      string = "listenersets"
+	ServiceImportKind    string = "serviceimports"
 )
 
 func IsGateway(parent gatewayv1.ParentReference) bool {
@@ -113,29 +108,65 @@ func GetConcreteObject(schemaType schema.GroupVersionKind) runtime.Object {
 	kind := schemaType.Kind
 
 	switch kind {
+	case GatewayClassKind:
+		return &gatewayv1.GatewayClass{}
+	case GatewayKind:
+		return &gatewayv1.Gateway{}
 	case TLSRouteKind:
 		return &gatewayv1.TLSRoute{}
-	case TLSRouteListKind:
-		return &gatewayv1.TLSRouteList{}
+	case HTTPRouteKind:
+		return &gatewayv1.HTTPRoute{}
+	case GRPCRouteKind:
+		return &gatewayv1.GRPCRoute{}
+	case ReferenceGrantKind:
+		return &gatewayv1.ReferenceGrant{}
+	case BackendTLSPolicyKind:
+		return &gatewayv1.BackendTLSPolicy{}
 	case TCPRouteKind:
 		return &gatewayv1alpha2.TCPRoute{}
-	case TCPRouteListKind:
-		return &gatewayv1alpha2.TCPRouteList{}
 	case UDPRouteKind:
 		return &gatewayv1alpha2.UDPRoute{}
-	case UDPRouteListKind:
-		return &gatewayv1alpha2.UDPRouteList{}
 	case ListenerSetKind:
 		return &gatewayv1.ListenerSet{}
-	case ListenerSetListKind:
-		return &gatewayv1.ListenerSetList{}
 	case ServiceImportKind:
 		return &mcsapiv1beta1.ServiceImport{}
-	case ServiceImportListKind:
-		return &mcsapiv1beta1.ServiceImportList{}
 	default:
 		// panic is okay here because this is a progammer error
 		panic(fmt.Sprintf("Tried to get a concrete type that is not implemented, %s", schemaType.Kind))
+	}
+}
+
+// getConcreteListObject returns a list instance of a concrete object type based on the
+// given GroupVersionKind.
+func GetConcreteListObject(schemaType schema.GroupVersionKind) runtime.Object {
+	kind := schemaType.Kind
+
+	switch kind {
+	case GatewayClassKind:
+		return &gatewayv1.GatewayClassList{}
+	case GatewayKind:
+		return &gatewayv1.GatewayList{}
+	case TLSRouteKind:
+		return &gatewayv1.TLSRouteList{}
+	case HTTPRouteKind:
+		return &gatewayv1.HTTPRouteList{}
+	case GRPCRouteKind:
+		return &gatewayv1.GRPCRouteList{}
+	case ReferenceGrantKind:
+		return &gatewayv1.ReferenceGrantList{}
+	case BackendTLSPolicyKind:
+		return &gatewayv1.BackendTLSPolicyList{}
+	case TCPRouteKind:
+		return &gatewayv1alpha2.TCPRouteList{}
+	case UDPRouteKind:
+		return &gatewayv1alpha2.UDPRouteList{}
+	case ListenerSetKind:
+		return &gatewayv1.ListenerSetList{}
+	case ServiceImportKind:
+		return &mcsapiv1beta1.ServiceImportList{}
+	default:
+		// panic is okay here because this is a progammer error
+		panic(fmt.Sprintf("Tried to get a concrete list type that is not implemented, %s", schemaType.Kind))
 	}
 }
 

--- a/operator/pkg/gateway-api/helpers/types_test.go
+++ b/operator/pkg/gateway-api/helpers/types_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 )
 
 func TestIsGammaService(t *testing.T) {
@@ -271,6 +272,24 @@ func TestGetConcreteObject(t *testing.T) {
 		want runtime.Object
 	}{
 		{
+			name: "GatewayClass",
+			gvk: schema.GroupVersionKind{
+				Group:   gatewayv1.GroupVersion.Group,
+				Version: gatewayv1.GroupVersion.Version,
+				Kind:    GatewayClassKind,
+			},
+			want: &gatewayv1.GatewayClass{},
+		},
+		{
+			name: "Gateway",
+			gvk: schema.GroupVersionKind{
+				Group:   gatewayv1.GroupVersion.Group,
+				Version: gatewayv1.GroupVersion.Version,
+				Kind:    GatewayKind,
+			},
+			want: &gatewayv1.Gateway{},
+		},
+		{
 			name: "TLSRoute",
 			gvk: schema.GroupVersionKind{
 				Group:   gatewayv1.GroupVersion.Group,
@@ -280,13 +299,40 @@ func TestGetConcreteObject(t *testing.T) {
 			want: &gatewayv1.TLSRoute{},
 		},
 		{
-			name: "TLSRouteList",
+			name: "HTTPRoute",
 			gvk: schema.GroupVersionKind{
 				Group:   gatewayv1.GroupVersion.Group,
 				Version: gatewayv1.GroupVersion.Version,
-				Kind:    TLSRouteListKind,
+				Kind:    HTTPRouteKind,
 			},
-			want: &gatewayv1.TLSRouteList{},
+			want: &gatewayv1.HTTPRoute{},
+		},
+		{
+			name: "GRPCRoute",
+			gvk: schema.GroupVersionKind{
+				Group:   gatewayv1.GroupVersion.Group,
+				Version: gatewayv1.GroupVersion.Version,
+				Kind:    GRPCRouteKind,
+			},
+			want: &gatewayv1.GRPCRoute{},
+		},
+		{
+			name: "ReferenceGrant",
+			gvk: schema.GroupVersionKind{
+				Group:   gatewayv1.GroupVersion.Group,
+				Version: gatewayv1.GroupVersion.Version,
+				Kind:    ReferenceGrantKind,
+			},
+			want: &gatewayv1.ReferenceGrant{},
+		},
+		{
+			name: "BackendTLSPolicy",
+			gvk: schema.GroupVersionKind{
+				Group:   gatewayv1.GroupVersion.Group,
+				Version: gatewayv1.GroupVersion.Version,
+				Kind:    BackendTLSPolicyKind,
+			},
+			want: &gatewayv1.BackendTLSPolicy{},
 		},
 		{
 			name: "TCPRoute",
@@ -298,15 +344,6 @@ func TestGetConcreteObject(t *testing.T) {
 			want: &gatewayv1alpha2.TCPRoute{},
 		},
 		{
-			name: "TCPRouteList",
-			gvk: schema.GroupVersionKind{
-				Group:   gatewayv1alpha2.GroupVersion.Group,
-				Version: gatewayv1alpha2.GroupVersion.Version,
-				Kind:    TCPRouteListKind,
-			},
-			want: &gatewayv1alpha2.TCPRouteList{},
-		},
-		{
 			name: "UDPRoute",
 			gvk: schema.GroupVersionKind{
 				Group:   gatewayv1alpha2.GroupVersion.Group,
@@ -316,18 +353,143 @@ func TestGetConcreteObject(t *testing.T) {
 			want: &gatewayv1alpha2.UDPRoute{},
 		},
 		{
-			name: "UDPRouteList",
+			name: "ListenerSet",
 			gvk: schema.GroupVersionKind{
-				Group:   gatewayv1alpha2.GroupVersion.Group,
-				Version: gatewayv1alpha2.GroupVersion.Version,
-				Kind:    UDPRouteListKind,
+				Group:   gatewayv1.GroupVersion.Group,
+				Version: gatewayv1.GroupVersion.Version,
+				Kind:    ListenerSetKind,
 			},
-			want: &gatewayv1alpha2.UDPRouteList{},
+			want: &gatewayv1.ListenerSet{},
+		},
+		{
+			name: "ServiceImport",
+			gvk: schema.GroupVersionKind{
+				Group:   mcsapiv1beta1.GroupVersion.Group,
+				Version: mcsapiv1beta1.GroupVersion.Version,
+				Kind:    ServiceImportKind,
+			},
+			want: &mcsapiv1beta1.ServiceImport{},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := GetConcreteObject(tt.gvk)
+			if reflect.TypeOf(got) != reflect.TypeOf(tt.want) {
+				t.Errorf("got a %T, expected a %T", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetConcreteListObject(t *testing.T) {
+	tests := []struct {
+		name string
+		gvk  schema.GroupVersionKind
+		want runtime.Object
+	}{
+		{
+			name: "GatewayClassList",
+			gvk: schema.GroupVersionKind{
+				Group:   gatewayv1.GroupVersion.Group,
+				Version: gatewayv1.GroupVersion.Version,
+				Kind:    GatewayClassKind,
+			},
+			want: &gatewayv1.GatewayClassList{},
+		},
+		{
+			name: "GatewayList",
+			gvk: schema.GroupVersionKind{
+				Group:   gatewayv1.GroupVersion.Group,
+				Version: gatewayv1.GroupVersion.Version,
+				Kind:    GatewayKind,
+			},
+			want: &gatewayv1.GatewayList{},
+		},
+		{
+			name: "TLSRouteList",
+			gvk: schema.GroupVersionKind{
+				Group:   gatewayv1.GroupVersion.Group,
+				Version: gatewayv1.GroupVersion.Version,
+				Kind:    TLSRouteKind,
+			},
+			want: &gatewayv1.TLSRouteList{},
+		},
+		{
+			name: "HTTPRouteList",
+			gvk: schema.GroupVersionKind{
+				Group:   gatewayv1.GroupVersion.Group,
+				Version: gatewayv1.GroupVersion.Version,
+				Kind:    HTTPRouteKind,
+			},
+			want: &gatewayv1.HTTPRouteList{},
+		},
+		{
+			name: "GRPCRouteList",
+			gvk: schema.GroupVersionKind{
+				Group:   gatewayv1.GroupVersion.Group,
+				Version: gatewayv1.GroupVersion.Version,
+				Kind:    GRPCRouteKind,
+			},
+			want: &gatewayv1.GRPCRouteList{},
+		},
+		{
+			name: "ReferenceGrantList",
+			gvk: schema.GroupVersionKind{
+				Group:   gatewayv1.GroupVersion.Group,
+				Version: gatewayv1.GroupVersion.Version,
+				Kind:    ReferenceGrantKind,
+			},
+			want: &gatewayv1.ReferenceGrantList{},
+		},
+		{
+			name: "BackendTLSPolicyList",
+			gvk: schema.GroupVersionKind{
+				Group:   gatewayv1.GroupVersion.Group,
+				Version: gatewayv1.GroupVersion.Version,
+				Kind:    BackendTLSPolicyKind,
+			},
+			want: &gatewayv1.BackendTLSPolicyList{},
+		},
+		{
+			name: "TCPRouteList",
+			gvk: schema.GroupVersionKind{
+				Group:   gatewayv1alpha2.GroupVersion.Group,
+				Version: gatewayv1alpha2.GroupVersion.Version,
+				Kind:    TCPRouteKind,
+			},
+			want: &gatewayv1alpha2.TCPRouteList{},
+		},
+		{
+			name: "UDPRouteList",
+			gvk: schema.GroupVersionKind{
+				Group:   gatewayv1alpha2.GroupVersion.Group,
+				Version: gatewayv1alpha2.GroupVersion.Version,
+				Kind:    UDPRouteKind,
+			},
+			want: &gatewayv1alpha2.UDPRouteList{},
+		},
+		{
+			name: "ListenerSetList",
+			gvk: schema.GroupVersionKind{
+				Group:   gatewayv1.GroupVersion.Group,
+				Version: gatewayv1.GroupVersion.Version,
+				Kind:    ListenerSetKind,
+			},
+			want: &gatewayv1.ListenerSetList{},
+		},
+		{
+			name: "ServiceImportList",
+			gvk: schema.GroupVersionKind{
+				Group:   mcsapiv1beta1.GroupVersion.Group,
+				Version: mcsapiv1beta1.GroupVersion.Version,
+				Kind:    ServiceImportKind,
+			},
+			want: &mcsapiv1beta1.ServiceImportList{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetConcreteListObject(tt.gvk)
 			if reflect.TypeOf(got) != reflect.TypeOf(tt.want) {
 				t.Errorf("got a %T, expected a %T", got, tt.want)
 			}


### PR DESCRIPTION
Register only required Gateway API GVKs explicitly instead of installing the entire v1 scheme. Installing the full v1 scheme registers optional resources such as ListenerSet, TCPRoute, and UDPRoute even when their CRDs are absent, which makes the operator try to set up watches/indexes for resources that are not available.

Add GetConcreteListObject so object and list types are registered explicitly, without deriving list resource names by string manipulation.

```release-note
gateway-api: fix operator startup failures caused by registering optional Gateway API resources when their CRDs are not installed.
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
