### PR TITLE
Reducing stack usage of largest programs

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -812,12 +812,11 @@ handle_ipv4_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 #ifdef ENABLE_VTEP
 	{
 		struct remote_endpoint_info fake_info = {0};
-		struct vtep_key vkey = {
-			.vtep_ip = ip4->daddr & CONFIG(vtep_mask),
-		};
+		struct vtep_key *vkey = AUX(vtep_key);
 		const struct vtep_value *vtep;
 
-		vtep = map_lookup_elem(&cilium_vtep_map, &vkey);
+		vkey->vtep_ip = ip4->daddr & CONFIG(vtep_mask);
+		vtep = map_lookup_elem(&cilium_vtep_map, vkey);
 		if (vtep && vtep->vtep_mac && vtep->tunnel_endpoint) {
 			if (eth_store_daddr(ctx, (__u8 *)&vtep->vtep_mac, 0) < 0)
 				return DROP_WRITE_ERROR;

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1267,12 +1267,11 @@ ipv4_forward_to_destination(struct __ctx_buff *ctx, struct iphdr *ip4,
 	 */
 #if defined(ENABLE_VTEP)
 	{
-		struct vtep_key vkey = {
-			.vtep_ip = ip4->daddr & CONFIG(vtep_mask),
-		};
+		struct vtep_key *vkey = AUX(vtep_key);
 		const struct vtep_value *vtep;
 
-		vtep = map_lookup_elem(&cilium_vtep_map, &vkey);
+		vkey->vtep_ip = ip4->daddr & CONFIG(vtep_mask);
+		vtep = map_lookup_elem(&cilium_vtep_map, vkey);
 		if (vtep && vtep->vtep_mac && vtep->tunnel_endpoint) {
 			if (eth_store_daddr(ctx, (__u8 *)&vtep->vtep_mac, 0) < 0)
 				return DROP_WRITE_ERROR;

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -307,12 +307,11 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx,
 
 #ifdef ENABLE_VTEP
 	{
-		struct vtep_key vkey = {
-			.vtep_ip = ip4->saddr & CONFIG(vtep_mask),
-		};
+		struct vtep_key *vkey = AUX(vtep_key);
 		const struct vtep_value *vtep;
 
-		vtep = map_lookup_elem(&cilium_vtep_map, &vkey);
+		vkey->vtep_ip = ip4->saddr & CONFIG(vtep_mask);
+		vtep = map_lookup_elem(&cilium_vtep_map, vkey);
 		if (vtep && vtep->tunnel_endpoint) {
 			if (!identity_is_world_ipv4(*identity))
 				return DROP_INVALID_VNI;
@@ -438,7 +437,7 @@ int tail_handle_arp(struct __ctx_buff *ctx)
 	__be32 tip;
 	int ret;
 	struct bpf_tunnel_key key = {};
-	struct vtep_key vkey = {};
+	struct vtep_key *vkey = AUX(vtep_key);
 	const struct vtep_value *info;
 	__u32 key_size;
 
@@ -448,8 +447,8 @@ int tail_handle_arp(struct __ctx_buff *ctx)
 
 	if (!arp_validate(ctx, &mac, &smac, &sip, &tip) || !__lookup_ip4_endpoint(tip))
 		goto pass_to_stack;
-	vkey.vtep_ip = sip & CONFIG(vtep_mask);
-	info = map_lookup_elem(&cilium_vtep_map, &vkey);
+	vkey->vtep_ip = sip & CONFIG(vtep_mask);
+	info = map_lookup_elem(&cilium_vtep_map, vkey);
 	if (!info)
 		goto pass_to_stack;
 

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -11,6 +11,7 @@
 #include <linux/in.h>
 #include <linux/socket.h>
 
+#include "auxvars.h"
 #include "endian.h"
 #include "eth.h"
 #include "ipv6_core.h"
@@ -377,6 +378,8 @@ struct ipv6_ct_tuple {
 	__u8		flags;
 } __packed;
 
+DEFINE_AUX(struct ipv6_ct_tuple, ipv6_ct_tuple);
+
 struct ipv4_ct_tuple {
 	/* Address fields are reversed, i.e.,
 	 * these field names are correct for reply direction traffic.
@@ -391,6 +394,8 @@ struct ipv4_ct_tuple {
 	__u8		nexthdr;
 	__u8		flags;
 } __packed;
+
+DEFINE_AUX(struct ipv4_ct_tuple, ipv4_ct_tuple);
 
 struct lb6_reverse_nat {
 	union v6addr address;

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -125,6 +125,8 @@ struct ct_entry {
 	__u32 last_rx_report;
 };
 
+DEFINE_AUX(struct ct_entry, ct_entry);
+
 static __always_inline enum ct_action ct_tcp_select_action(union tcp_flags flags)
 {
 	if (unlikely(flags.value & (TCP_FLAG_RST | TCP_FLAG_FIN)))
@@ -1070,43 +1072,44 @@ static __always_inline int ct_create6(const void *map_main, const void *map_rela
 				      const struct ct_state *ct_state, __s8 *ext_err)
 {
 	/* Create entry in original direction */
-	struct ct_entry entry = { };
+	struct ct_entry *entry = AUX(ct_entry);
 	bool is_tcp = tuple->nexthdr == IPPROTO_TCP;
 	union tcp_flags seen_flags = { .value = 0 };
 	int err;
 
 	if (ct_state)
-		ct_create_fill_entry(&entry, ct_state, dir);
+		ct_create_fill_entry(entry, ct_state, dir);
 
 	seen_flags.value |= is_tcp ? TCP_FLAG_SYN : 0;
-	ct_update_timeout(&entry, is_tcp, dir, seen_flags);
+	ct_update_timeout(entry, is_tcp, dir, seen_flags);
 
-	cilium_dbg3(ctx, DBG_CT_CREATED6, entry.rev_nat_index,
-		    entry.src_sec_id, 0);
+	cilium_dbg3(ctx, DBG_CT_CREATED6, entry->rev_nat_index,
+		    entry->src_sec_id, 0);
 
 	if (map_related != NULL) {
 		/* Create an ICMPv6 entry to relate errors */
-		struct ipv6_ct_tuple icmp_tuple __align_stack_8 = {
+		struct ipv6_ct_tuple *icmp_tuple = AUX(ipv6_ct_tuple);
+		(*icmp_tuple) = (typeof(*icmp_tuple)){
 			.nexthdr = IPPROTO_ICMPV6,
 			.sport = 0,
 			.dport = 0,
 			.flags = tuple->flags | TUPLE_F_RELATED,
 		};
 
-		ipv6_addr_copy(&icmp_tuple.daddr, &tuple->daddr);
-		ipv6_addr_copy(&icmp_tuple.saddr, &tuple->saddr);
+		ipv6_addr_copy(&icmp_tuple->daddr, &tuple->daddr);
+		ipv6_addr_copy(&icmp_tuple->saddr, &tuple->saddr);
 
-		err = map_update_elem(map_related, &icmp_tuple, &entry, 0);
+		err = map_update_elem(map_related, icmp_tuple, entry, 0);
 		if (unlikely(err < 0))
 			goto drop_err;
 	}
 
 	if (CONFIG(enable_conntrack_accounting)) {
-		entry.packets = 1;
-		entry.bytes = ctx_full_len(ctx);
+		entry->packets = 1;
+		entry->bytes = ctx_full_len(ctx);
 	}
 
-	err = map_update_elem(map_main, tuple, &entry, 0);
+	err = map_update_elem(map_main, tuple, entry, 0);
 	if (unlikely(err < 0))
 		goto drop_err;
 
@@ -1126,23 +1129,24 @@ static __always_inline int ct_create4(const void *map_main,
 				      __s8 *ext_err)
 {
 	/* Create entry in original direction */
-	struct ct_entry entry = { };
+	struct ct_entry *entry = AUX(ct_entry);
 	bool is_tcp = tuple->nexthdr == IPPROTO_TCP;
 	union tcp_flags seen_flags = { .value = 0 };
 	int err;
 
 	if (ct_state)
-		ct_create_fill_entry(&entry, ct_state, dir);
+		ct_create_fill_entry(entry, ct_state, dir);
 
 	seen_flags.value |= is_tcp ? TCP_FLAG_SYN : 0;
-	ct_update_timeout(&entry, is_tcp, dir, seen_flags);
+	ct_update_timeout(entry, is_tcp, dir, seen_flags);
 
-	cilium_dbg3(ctx, DBG_CT_CREATED4, entry.rev_nat_index,
-		    entry.src_sec_id, 0);
+	cilium_dbg3(ctx, DBG_CT_CREATED4, entry->rev_nat_index,
+		    entry->src_sec_id, 0);
 
 	if (map_related != NULL) {
 		/* Create an ICMP entry to relate errors */
-		struct ipv4_ct_tuple icmp_tuple = {
+		struct ipv4_ct_tuple *icmp_tuple = AUX(ipv4_ct_tuple);
+		(*icmp_tuple) = (typeof(*icmp_tuple)){
 			.daddr = tuple->daddr,
 			.saddr = tuple->saddr,
 			.nexthdr = IPPROTO_ICMP,
@@ -1151,21 +1155,21 @@ static __always_inline int ct_create4(const void *map_main,
 			.flags = tuple->flags | TUPLE_F_RELATED,
 		};
 
-		err = map_update_elem(map_related, &icmp_tuple, &entry, 0);
+		err = map_update_elem(map_related, icmp_tuple, entry, 0);
 		if (unlikely(err < 0))
 			goto drop_err;
 	}
 
 	if (CONFIG(enable_conntrack_accounting)) {
-		entry.packets = 1;
-		entry.bytes = ctx_full_len(ctx);
+		entry->packets = 1;
+		entry->bytes = ctx_full_len(ctx);
 	}
 
 	/* Previous map update succeeded, we could delete it in case
 	 * the below throws an error, but we might as well just let
 	 * it time out.
 	 */
-	err = map_update_elem(map_main, tuple, &entry, 0);
+	err = map_update_elem(map_main, tuple, entry, 0);
 	if (unlikely(err < 0))
 		goto drop_err;
 

--- a/bpf/lib/eps.h
+++ b/bpf/lib/eps.h
@@ -5,6 +5,7 @@
 
 #include "common.h"
 
+#include "auxvars.h"
 #include <linux/ip.h>
 #include "ipv6.h"
 
@@ -23,6 +24,8 @@ struct endpoint_key {
 	__u8 key;
 	__u16 cluster_id;
 } __packed;
+
+DEFINE_AUX(struct endpoint_key, endpoint_key);
 
 #define ENDPOINT_F_HOST			1 /* Special endpoint representing local host */
 #define ENDPOINT_F_ATHOSTNS		2 /* Endpoint located at the host networking namespace */
@@ -58,12 +61,14 @@ struct {
 static __always_inline __maybe_unused const struct endpoint_info *
 __lookup_ip6_endpoint(const union v6addr *ip6)
 {
-	struct endpoint_key key __align_stack_8 = {};
+	struct endpoint_key *key = AUX(endpoint_key);
 
-	key.ip6 = *ip6;
-	key.family = ENDPOINT_KEY_IPV6;
+	memset(key, 0, sizeof(*key));
+	key->ip6.d1 = ip6->d1;
+	key->ip6.d2 = ip6->d2;
+	key->family = ENDPOINT_KEY_IPV6;
 
-	return map_lookup_elem(&cilium_lxc, &key);
+	return map_lookup_elem(&cilium_lxc, key);
 }
 
 static __always_inline __maybe_unused const struct endpoint_info *
@@ -75,12 +80,13 @@ lookup_ip6_endpoint(const struct ipv6hdr *ip6)
 static __always_inline __maybe_unused const struct endpoint_info *
 __lookup_ip4_endpoint(__u32 ip)
 {
-	struct endpoint_key key __align_stack_8 = {};
+	struct endpoint_key *key = AUX(endpoint_key);
 
-	key.ip4.be32 = ip;
-	key.family = ENDPOINT_KEY_IPV4;
+	memset(key, 0, sizeof(*key));
+	key->ip4.be32 = ip;
+	key->family = ENDPOINT_KEY_IPV4;
 
-	return map_lookup_elem(&cilium_lxc, &key);
+	return map_lookup_elem(&cilium_lxc, key);
 }
 
 static __always_inline __maybe_unused const struct endpoint_info *

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -6,10 +6,13 @@
 #include <bpf/ctx/ctx.h>
 #include <bpf/api.h>
 
+#include "auxvars.h"
 #include "common.h"
 #include "network_device.h"
 #include "neigh.h"
 #include "l3.h"
+
+DEFINE_AUX(struct bpf_fib_lookup_padded, fib_params);
 
 static __always_inline bool
 neigh_resolver_without_nh_available()
@@ -54,6 +57,8 @@ static __always_inline bool fib_ok(int ret)
 {
 	return likely(ret == CTX_ACT_TX || ret == CTX_ACT_REDIRECT);
 }
+
+DEFINE_AUX(struct bpf_redir_neigh, bpf_redir_neigh);
 
  /* fib_do_redirect will redirect the ctx to a particular output interface.
   * @arg ctx			packet
@@ -104,15 +109,15 @@ fib_do_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
 	 */
 	if (neigh_resolver_available()) {
 		if (fib_params) {
-			struct bpf_redir_neigh nh_params;
+			struct bpf_redir_neigh *nh_params = AUX(bpf_redir_neigh);
 
-			nh_params.nh_family = fib_params->l.family;
-			__bpf_memcpy_builtin(&nh_params.ipv6_nh,
+			nh_params->nh_family = fib_params->l.family;
+			__bpf_memcpy_builtin(&nh_params->ipv6_nh,
 					     &fib_params->l.ipv6_dst,
-					     sizeof(nh_params.ipv6_nh));
+					     sizeof(nh_params->ipv6_nh));
 
-			return (int)redirect_neigh(oif, &nh_params,
-						   sizeof(nh_params), 0);
+			return (int)redirect_neigh(oif, nh_params,
+						   sizeof(*nh_params), 0);
 		}
 	}
 
@@ -221,19 +226,20 @@ static __always_inline int
 fib_lookup_src_v6(struct __ctx_buff *ctx, struct in6_addr *src,
 		  const struct in6_addr *dst)
 {
-	struct bpf_fib_lookup_padded fib_params = {0};
+	struct bpf_fib_lookup_padded *fib_params = AUX(fib_params);
 	struct in6_addr zero = {0};
 	int fib_result = 0;
 
 	if (!CONFIG(supports_fib_lookup_src))
 		return BPF_FIB_LKUP_RET_FWD_DISABLED;
 
-	fib_result = fib_lookup_v6(ctx, &fib_params, &zero, dst,
+	memset(fib_params, 0, sizeof(*fib_params));
+	fib_result = fib_lookup_v6(ctx, fib_params, &zero, dst,
 				   BPF_FIB_LOOKUP_SRC);
 
 	if (fib_result == BPF_FIB_LKUP_RET_SUCCESS) {
 		ipv6_addr_copy((union v6addr *)src,
-			       (union v6addr *)&fib_params.l.ipv6_src);
+			       (union v6addr *)&fib_params->l.ipv6_src);
 	}
 	return fib_result;
 }
@@ -244,16 +250,17 @@ fib_redirect_v6(struct __ctx_buff *ctx, int l3_off,
 		bool allow_neigh_map, __s8 *ext_err, int *oif, __u32 tbid)
 {
 	int ret;
-	struct bpf_fib_lookup_padded fib_params = {0};
+	struct bpf_fib_lookup_padded *fib_params = AUX(fib_params);
 	int fib_result;
 	int flags = 0;
 
+	memset(fib_params, 0, sizeof(*fib_params));
 	if (tbid) {
-		fib_params.l.tbid = tbid;
+		fib_params->l.tbid = tbid;
 		flags = (BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_TBID);
 	}
 
-	fib_result = fib_lookup_v6(ctx, &fib_params, &ip6->saddr, &ip6->daddr, flags);
+	fib_result = fib_lookup_v6(ctx, fib_params, &ip6->saddr, &ip6->daddr, flags);
 	switch (fib_result) {
 	case BPF_FIB_LKUP_RET_SUCCESS:
 	case BPF_FIB_LKUP_RET_NO_NEIGH:
@@ -263,13 +270,13 @@ fib_redirect_v6(struct __ctx_buff *ctx, int l3_off,
 		return DROP_NO_FIB;
 	}
 
-	*oif = fib_params.l.ifindex;
+	*oif = fib_params->l.ifindex;
 
 	ret = ipv6_l3(ctx, l3_off, NULL, NULL, METRIC_EGRESS);
 	if (unlikely(ret != CTX_ACT_OK))
 		return ret;
 
-	return fib_do_redirect(ctx, needs_l2_check, &fib_params, allow_neigh_map,
+	return fib_do_redirect(ctx, needs_l2_check, fib_params, allow_neigh_map,
 			       fib_result, *oif, ext_err);
 }
 #endif /* ENABLE_IPV6 */
@@ -306,16 +313,17 @@ fib_lookup_v4(struct __ctx_buff *ctx, struct bpf_fib_lookup_padded *fib_params,
 static __always_inline int
 fib_lookup_src_v4(struct __ctx_buff *ctx, __be32 *src, const __be32 dst)
 {
-	struct bpf_fib_lookup_padded fib_params = {0};
+	struct bpf_fib_lookup_padded *fib_params = AUX(fib_params);
 	int fib_result = 0;
 
 	if (!CONFIG(supports_fib_lookup_src))
 		return BPF_FIB_LKUP_RET_FWD_DISABLED;
 
-	fib_result = fib_lookup_v4(ctx, &fib_params, 0, dst, BPF_FIB_LOOKUP_SRC);
+	memset(fib_params, 0, sizeof(*fib_params));
+	fib_result = fib_lookup_v4(ctx, fib_params, 0, dst, BPF_FIB_LOOKUP_SRC);
 
 	if (fib_result == BPF_FIB_LKUP_RET_SUCCESS)
-		*src = fib_params.l.ipv4_src;
+		*src = fib_params->l.ipv4_src;
 
 	return fib_result;
 }
@@ -326,16 +334,17 @@ fib_redirect_v4(struct __ctx_buff *ctx, int l3_off,
 		bool allow_neigh_map, __s8 *ext_err, int *oif, __u32 tbid)
 {
 	int ret;
-	struct bpf_fib_lookup_padded fib_params = {0};
+	struct bpf_fib_lookup_padded *fib_params = AUX(fib_params);
 	int fib_result;
 	int flags = 0;
 
+	memset(fib_params, 0, sizeof(*fib_params));
 	if (tbid) {
-		fib_params.l.tbid = tbid;
+		fib_params->l.tbid = tbid;
 		flags = (BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_TBID);
 	}
 
-	fib_result = fib_lookup_v4(ctx, &fib_params, ip4->saddr, ip4->daddr, flags);
+	fib_result = fib_lookup_v4(ctx, fib_params, ip4->saddr, ip4->daddr, flags);
 	switch (fib_result) {
 	case BPF_FIB_LKUP_RET_SUCCESS:
 	case BPF_FIB_LKUP_RET_NO_NEIGH:
@@ -345,13 +354,13 @@ fib_redirect_v4(struct __ctx_buff *ctx, int l3_off,
 		return DROP_NO_FIB;
 	}
 
-	*oif = fib_params.l.ifindex;
+	*oif = fib_params->l.ifindex;
 
 	ret = ipv4_l3(ctx, l3_off, NULL, NULL, ip4);
 	if (unlikely(ret != CTX_ACT_OK))
 		return ret;
 
-	return fib_do_redirect(ctx, needs_l2_check, &fib_params, allow_neigh_map,
+	return fib_do_redirect(ctx, needs_l2_check, fib_params, allow_neigh_map,
 			       fib_result, *oif, ext_err);
 }
 #endif /* ENABLE_IPV4 */

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -6,13 +6,10 @@
 #include <bpf/ctx/ctx.h>
 #include <bpf/api.h>
 
-#include "auxvars.h"
 #include "common.h"
 #include "network_device.h"
 #include "neigh.h"
 #include "l3.h"
-
-DEFINE_AUX(struct bpf_fib_lookup_padded, fib_params);
 
 static __always_inline bool
 neigh_resolver_without_nh_available()
@@ -57,8 +54,6 @@ static __always_inline bool fib_ok(int ret)
 {
 	return likely(ret == CTX_ACT_TX || ret == CTX_ACT_REDIRECT);
 }
-
-DEFINE_AUX(struct bpf_redir_neigh, bpf_redir_neigh);
 
  /* fib_do_redirect will redirect the ctx to a particular output interface.
   * @arg ctx			packet
@@ -109,15 +104,15 @@ fib_do_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
 	 */
 	if (neigh_resolver_available()) {
 		if (fib_params) {
-			struct bpf_redir_neigh *nh_params = AUX(bpf_redir_neigh);
+			struct bpf_redir_neigh nh_params;
 
-			nh_params->nh_family = fib_params->l.family;
-			__bpf_memcpy_builtin(&nh_params->ipv6_nh,
+			nh_params.nh_family = fib_params->l.family;
+			__bpf_memcpy_builtin(&nh_params.ipv6_nh,
 					     &fib_params->l.ipv6_dst,
-					     sizeof(nh_params->ipv6_nh));
+					     sizeof(nh_params.ipv6_nh));
 
-			return (int)redirect_neigh(oif, nh_params,
-						   sizeof(*nh_params), 0);
+			return (int)redirect_neigh(oif, &nh_params,
+						   sizeof(nh_params), 0);
 		}
 	}
 
@@ -226,20 +221,19 @@ static __always_inline int
 fib_lookup_src_v6(struct __ctx_buff *ctx, struct in6_addr *src,
 		  const struct in6_addr *dst)
 {
-	struct bpf_fib_lookup_padded *fib_params = AUX(fib_params);
+	struct bpf_fib_lookup_padded fib_params = {0};
 	struct in6_addr zero = {0};
 	int fib_result = 0;
 
 	if (!CONFIG(supports_fib_lookup_src))
 		return BPF_FIB_LKUP_RET_FWD_DISABLED;
 
-	memset(fib_params, 0, sizeof(*fib_params));
-	fib_result = fib_lookup_v6(ctx, fib_params, &zero, dst,
+	fib_result = fib_lookup_v6(ctx, &fib_params, &zero, dst,
 				   BPF_FIB_LOOKUP_SRC);
 
 	if (fib_result == BPF_FIB_LKUP_RET_SUCCESS) {
 		ipv6_addr_copy((union v6addr *)src,
-			       (union v6addr *)&fib_params->l.ipv6_src);
+			       (union v6addr *)&fib_params.l.ipv6_src);
 	}
 	return fib_result;
 }
@@ -250,17 +244,16 @@ fib_redirect_v6(struct __ctx_buff *ctx, int l3_off,
 		bool allow_neigh_map, __s8 *ext_err, int *oif, __u32 tbid)
 {
 	int ret;
-	struct bpf_fib_lookup_padded *fib_params = AUX(fib_params);
+	struct bpf_fib_lookup_padded fib_params = {0};
 	int fib_result;
 	int flags = 0;
 
-	memset(fib_params, 0, sizeof(*fib_params));
 	if (tbid) {
-		fib_params->l.tbid = tbid;
+		fib_params.l.tbid = tbid;
 		flags = (BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_TBID);
 	}
 
-	fib_result = fib_lookup_v6(ctx, fib_params, &ip6->saddr, &ip6->daddr, flags);
+	fib_result = fib_lookup_v6(ctx, &fib_params, &ip6->saddr, &ip6->daddr, flags);
 	switch (fib_result) {
 	case BPF_FIB_LKUP_RET_SUCCESS:
 	case BPF_FIB_LKUP_RET_NO_NEIGH:
@@ -270,13 +263,13 @@ fib_redirect_v6(struct __ctx_buff *ctx, int l3_off,
 		return DROP_NO_FIB;
 	}
 
-	*oif = fib_params->l.ifindex;
+	*oif = fib_params.l.ifindex;
 
 	ret = ipv6_l3(ctx, l3_off, NULL, NULL, METRIC_EGRESS);
 	if (unlikely(ret != CTX_ACT_OK))
 		return ret;
 
-	return fib_do_redirect(ctx, needs_l2_check, fib_params, allow_neigh_map,
+	return fib_do_redirect(ctx, needs_l2_check, &fib_params, allow_neigh_map,
 			       fib_result, *oif, ext_err);
 }
 #endif /* ENABLE_IPV6 */
@@ -313,17 +306,16 @@ fib_lookup_v4(struct __ctx_buff *ctx, struct bpf_fib_lookup_padded *fib_params,
 static __always_inline int
 fib_lookup_src_v4(struct __ctx_buff *ctx, __be32 *src, const __be32 dst)
 {
-	struct bpf_fib_lookup_padded *fib_params = AUX(fib_params);
+	struct bpf_fib_lookup_padded fib_params = {0};
 	int fib_result = 0;
 
 	if (!CONFIG(supports_fib_lookup_src))
 		return BPF_FIB_LKUP_RET_FWD_DISABLED;
 
-	memset(fib_params, 0, sizeof(*fib_params));
-	fib_result = fib_lookup_v4(ctx, fib_params, 0, dst, BPF_FIB_LOOKUP_SRC);
+	fib_result = fib_lookup_v4(ctx, &fib_params, 0, dst, BPF_FIB_LOOKUP_SRC);
 
 	if (fib_result == BPF_FIB_LKUP_RET_SUCCESS)
-		*src = fib_params->l.ipv4_src;
+		*src = fib_params.l.ipv4_src;
 
 	return fib_result;
 }
@@ -334,17 +326,16 @@ fib_redirect_v4(struct __ctx_buff *ctx, int l3_off,
 		bool allow_neigh_map, __s8 *ext_err, int *oif, __u32 tbid)
 {
 	int ret;
-	struct bpf_fib_lookup_padded *fib_params = AUX(fib_params);
+	struct bpf_fib_lookup_padded fib_params = {0};
 	int fib_result;
 	int flags = 0;
 
-	memset(fib_params, 0, sizeof(*fib_params));
 	if (tbid) {
-		fib_params->l.tbid = tbid;
+		fib_params.l.tbid = tbid;
 		flags = (BPF_FIB_LOOKUP_DIRECT | BPF_FIB_LOOKUP_TBID);
 	}
 
-	fib_result = fib_lookup_v4(ctx, fib_params, ip4->saddr, ip4->daddr, flags);
+	fib_result = fib_lookup_v4(ctx, &fib_params, ip4->saddr, ip4->daddr, flags);
 	switch (fib_result) {
 	case BPF_FIB_LKUP_RET_SUCCESS:
 	case BPF_FIB_LKUP_RET_NO_NEIGH:
@@ -354,13 +345,13 @@ fib_redirect_v4(struct __ctx_buff *ctx, int l3_off,
 		return DROP_NO_FIB;
 	}
 
-	*oif = fib_params->l.ifindex;
+	*oif = fib_params.l.ifindex;
 
 	ret = ipv4_l3(ctx, l3_off, NULL, NULL, ip4);
 	if (unlikely(ret != CTX_ACT_OK))
 		return ret;
 
-	return fib_do_redirect(ctx, needs_l2_check, fib_params, allow_neigh_map,
+	return fib_do_redirect(ctx, needs_l2_check, &fib_params, allow_neigh_map,
 			       fib_result, *oif, ext_err);
 }
 #endif /* ENABLE_IPV4 */

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1987,7 +1987,7 @@ static __always_inline int dsr_reply_icmp4(struct __ctx_buff *ctx,
 	__s32 len_new = off + ipv4_hdrlen(ip4) + orig_dgram;
 	__s32 len_old = (__s32)ctx_full_len(ctx);
 	__u8 reason = (__u8)-code;
-	__u8 tmp[l3_max];
+	__u8 tmp[l3_max] __align_stack_8;
 	union macaddr smac, dmac;
 	struct icmphdr icmp __align_stack_8 = {
 		.type		= ICMP_DEST_UNREACH,

--- a/bpf/lib/ratelimit.h
+++ b/bpf/lib/ratelimit.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "auxvars.h"
 #include "common.h"
 #include "bpf/helpers.h"
 
@@ -24,6 +25,8 @@ struct ratelimit_value {
 	__u64 tokens;
 };
 
+DEFINE_AUX(struct ratelimit_value, ratelimit_value);
+
 struct {
 	__uint(type, BPF_MAP_TYPE_LRU_HASH);
 	__type(key, struct ratelimit_key);
@@ -37,9 +40,13 @@ struct ratelimit_metrics_key {
 	__u32 usage;
 };
 
+DEFINE_AUX(struct ratelimit_metrics_key, ratelimit_metrics_key);
+
 struct ratelimit_metrics_value {
 	__u64 dropped;
 };
+
+DEFINE_AUX(struct ratelimit_metrics_value, ratelimit_metrics_value);
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
@@ -63,10 +70,10 @@ static __always_inline bool ratelimit_check_and_take(struct ratelimit_key *key,
 						     const struct ratelimit_settings *settings)
 {
 	struct ratelimit_value *value;
-	struct ratelimit_value new_value;
-	struct ratelimit_metrics_key metrics_key;
 	struct ratelimit_metrics_value *metrics_value;
-	struct ratelimit_metrics_value new_metrics_value;
+	struct ratelimit_value *new_value = AUX(ratelimit_value);
+	struct ratelimit_metrics_key *metrics_key = AUX(ratelimit_metrics_key);
+	struct ratelimit_metrics_value *new_metrics_value = AUX(ratelimit_metrics_value);
 	__u64 since_last_topup;
 	__u64 now;
 	__u64 interval;
@@ -77,12 +84,12 @@ static __always_inline bool ratelimit_check_and_take(struct ratelimit_key *key,
 
 	if (!key)
 		return false;
-	metrics_key.usage = key->usage;
-	metrics_value = map_lookup_elem(&cilium_ratelimit_metrics, &metrics_key);
+	metrics_key->usage = key->usage;
+	metrics_value = map_lookup_elem(&cilium_ratelimit_metrics, metrics_key);
 	if (!metrics_value) {
-		new_metrics_value.dropped = 0;
-		metrics_value = &new_metrics_value;
-		ret = map_update_elem(&cilium_ratelimit_metrics, &metrics_key,
+		new_metrics_value->dropped = 0;
+		metrics_value = new_metrics_value;
+		ret = map_update_elem(&cilium_ratelimit_metrics, metrics_key,
 				      metrics_value, BPF_ANY);
 		/* Check metrics_value to keep verifier happy */
 		if (unlikely(ret < 0 || !metrics_value))
@@ -92,9 +99,9 @@ static __always_inline bool ratelimit_check_and_take(struct ratelimit_key *key,
 	/* Create a new bucket if we do not yet have one for the key */
 	value = map_lookup_elem(&cilium_ratelimit, key);
 	if (!value) {
-		new_value.last_topup = now;
-		new_value.tokens = settings->tokens_per_topup - 1;
-		ret = map_update_elem(&cilium_ratelimit, key, &new_value, BPF_ANY);
+		new_value->last_topup = now;
+		new_value->tokens = settings->tokens_per_topup - 1;
+		ret = map_update_elem(&cilium_ratelimit, key, new_value, BPF_ANY);
 		if (unlikely(ret < 0)) {
 			/* This bucket update is racy and might cause a bit of
 			 * inaccuracy. We allow that since keeping atomicity

--- a/bpf/lib/trace.h
+++ b/bpf/lib/trace.h
@@ -170,6 +170,8 @@ struct trace_notify {
 	TRACE_EXTENSION
 } __align_stack_8;
 
+DEFINE_AUX(struct trace_notify, trace_notify);
+
 #ifdef TRACE_NOTIFY
 
 /* Trace notify version 2 includes IP Trace support. */
@@ -221,7 +223,7 @@ _send_trace_notify(const struct __ctx_buff *ctx, enum trace_point obs_point,
 	struct ratelimit_settings settings = {
 		.topup_interval_ns = NSEC_PER_SEC,
 	};
-	struct trace_notify msg = {};
+	struct trace_notify *msg = AUX(trace_notify);
 	cls_flags_t flags = CLS_FLAG_NONE;
 
 	_update_trace_metrics(ctx, obs_point, reason, line, file);
@@ -239,7 +241,7 @@ _send_trace_notify(const struct __ctx_buff *ctx, enum trace_point obs_point,
 	flags = ctx_classify(ctx, proto, obs_point);
 	cap_len = compute_capture_len(ctx, monitor, flags, obs_point);
 
-	msg = (typeof(msg)) {
+	*msg = (typeof(*msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
 		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len, NOTIFY_TRACE_VER),
 		.src_label	= src,
@@ -250,12 +252,12 @@ _send_trace_notify(const struct __ctx_buff *ctx, enum trace_point obs_point,
 		.ifindex	= ifindex,
 		.ip_trace_id	= ip_trace_id,
 	};
-	memset(&msg.orig_ip6, 0, sizeof(union v6addr));
+	memset(&msg->orig_ip6, 0, sizeof(union v6addr));
 
 	trace_extension_hook(ctx, msg);
 	ctx_event_output(ctx, &cilium_events,
 			 (cap_len << 32) | BPF_F_CURRENT_CPU,
-			 &msg, sizeof(msg));
+			 msg, sizeof(*msg));
 }
 
 static __always_inline void
@@ -273,7 +275,7 @@ _send_trace_notify4(const struct __ctx_buff *ctx, enum trace_point obs_point,
 	struct ratelimit_settings settings = {
 		.topup_interval_ns = NSEC_PER_SEC,
 	};
-	struct trace_notify msg = {};
+	struct trace_notify *msg = AUX(trace_notify);
 	cls_flags_t flags = CLS_FLAG_NONE;
 
 	_update_trace_metrics(ctx, obs_point, reason, line, file);
@@ -291,7 +293,7 @@ _send_trace_notify4(const struct __ctx_buff *ctx, enum trace_point obs_point,
 	flags = ctx_classify(ctx, bpf_htons(ETH_P_IP), obs_point);
 	cap_len = compute_capture_len(ctx, monitor, flags, obs_point);
 
-	msg = (typeof(msg)) {
+	*msg = (typeof(*msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
 		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len, NOTIFY_TRACE_VER),
 		.src_label	= src,
@@ -307,7 +309,7 @@ _send_trace_notify4(const struct __ctx_buff *ctx, enum trace_point obs_point,
 	trace_extension_hook(ctx, msg);
 	ctx_event_output(ctx, &cilium_events,
 			 (cap_len << 32) | BPF_F_CURRENT_CPU,
-			 &msg, sizeof(msg));
+			 msg, sizeof(*msg));
 }
 
 static __always_inline void
@@ -325,7 +327,7 @@ _send_trace_notify6(const struct __ctx_buff *ctx, enum trace_point obs_point,
 	struct ratelimit_settings settings = {
 		.topup_interval_ns = NSEC_PER_SEC,
 	};
-	struct trace_notify msg = {};
+	struct trace_notify *msg = AUX(trace_notify);
 	cls_flags_t flags = CLS_FLAG_NONE;
 
 	_update_trace_metrics(ctx, obs_point, reason, line, file);
@@ -343,7 +345,7 @@ _send_trace_notify6(const struct __ctx_buff *ctx, enum trace_point obs_point,
 	flags = ctx_classify(ctx, bpf_htons(ETH_P_IPV6), obs_point);
 	cap_len = compute_capture_len(ctx, monitor, flags, obs_point);
 
-	msg = (typeof(msg)) {
+	*msg = (typeof(*msg)) {
 		__notify_common_hdr(CILIUM_NOTIFY_TRACE, obs_point),
 		__notify_pktcap_hdr((__u32)ctx_len, (__u16)cap_len, NOTIFY_TRACE_VER),
 		.src_label	= src,
@@ -355,12 +357,12 @@ _send_trace_notify6(const struct __ctx_buff *ctx, enum trace_point obs_point,
 		.ip_trace_id	= ip_trace_id,
 	};
 
-	ipv6_addr_copy(&msg.orig_ip6, orig_addr);
+	ipv6_addr_copy(&msg->orig_ip6, orig_addr);
 
 	trace_extension_hook(ctx, msg);
 	ctx_event_output(ctx, &cilium_events,
 			 (cap_len << 32) | BPF_F_CURRENT_CPU,
-			 &msg, sizeof(msg));
+			 msg, sizeof(*msg));
 }
 #else
 static __always_inline void

--- a/bpf/lib/vtep.h
+++ b/bpf/lib/vtep.h
@@ -12,6 +12,8 @@ struct vtep_key {
 	__u32 vtep_ip;
 };
 
+DEFINE_AUX(struct vtep_key, vtep_key);
+
 struct vtep_value {
 	__u64 vtep_mac;
 	__u32 tunnel_endpoint;


### PR DESCRIPTION
This PR reduces the stack usage of most of our programs, the goal is to have all programs land below 75% stack usage. That goal is almost achieved, unfortunately there is a increase in `tail_handle_ipv4_cont` and `tail_ipv6_to_endpoint`, both of which have enough headroom to not be in the top 15 even after the increase. 

These changes also increase the complexity of `host/tail_nodeport_nat_ingress_ipv4` (going to 182146 (18.21%)) and `overlay/tail_handle_snat_fwd_ipv6` (going to 333685 (33.37%)) significantly, presumably aux variables increase the amount of states due to the verifier being unable to track values. 

These stack and complexity increases seems to outweigh the benefits for the rest of the programs, and can hopefully be improved by future optimizations.

## Top 15 largest differences by stack depth
Collection/Program | Min | Max
-------------------|-----|----
lxc/tail_handle_ipv6_cont | $\color{green}{\textsf{-64 (-18.18\\%) for bpf-next/1/0}}$ | $\color{green}{\textsf{-64 (-18.18\\%) for bpf-next/1/0}}$
host/tail_handle_ipv6_cont_from_host | $\color{green}{\textsf{-80 (-25.00\\%) for bpf-next/1/0}}$ | $\color{green}{\textsf{-32 (-11.76\\%) for bpf-next/7/0}}$
host/tail_handle_ipv6_cont_from_netdev | $\color{green}{\textsf{-48 (-20.00\\%) for bpf-next/1/0}}$ | $\color{green}{\textsf{-48 (-20.00\\%) for bpf-next/1/0}}$
host/tail_nodeport_nat_egress_ipv6 | $\color{green}{\textsf{-48 (-12.00\\%) for bpf-next/1/0}}$ | $\color{green}{\textsf{-48 (-12.00\\%) for bpf-next/1/0}}$
lxc/tail_handle_ipv4_cont | $\color{red}{\textsf{+48 (14.29\\%) for bpf-next/1/0}}$ | $\color{red}{\textsf{+48 (14.29\\%) for bpf-next/1/0}}$
host/tail_handle_snat_fwd_ipv6 | $\color{green}{\textsf{-48 (-11.54\\%) for bpf-next/1/0}}$ | $\color{green}{\textsf{-32 (-7.69\\%) for bpf-next/7/0}}$
host/cil_to_netdev | $\color{green}{\textsf{-48 (-11.54\\%) for bpf-next/1/0}}$ | $\color{green}{\textsf{-16 (-5.56\\%) for bpf-next/3/0}}$
host/tail_nodeport_rev_dnat_ingress_ipv6 | $\color{green}{\textsf{-32 (-10.00\\%) for bpf-next/1/0}}$ | $\color{green}{\textsf{-32 (-10.00\\%) for bpf-next/1/0}}$
host/tail_nodeport_rev_dnat_ipv4 | $\color{green}{\textsf{-32 (-11.76\\%) for bpf-next/1/0}}$ | $\color{green}{\textsf{-32 (-11.76\\%) for bpf-next/1/0}}$
lxc/tail_handle_ipv4 | $\color{green}{\textsf{-32 (-14.29\\%) for bpf-next/1/0}}$ | $\color{green}{\textsf{-32 (-14.29\\%) for bpf-next/1/0}}$
lxc/tail_ipv6_policy | $\color{green}{\textsf{-32 (-9.09\\%) for bpf-next/1/0}}$ | $\color{green}{\textsf{-32 (-9.09\\%) for bpf-next/1/0}}$
lxc/tail_ipv6_to_endpoint | $\color{red}{\textsf{+32 (11.76\\%) for bpf-next/1/0}}$ | $\color{red}{\textsf{+32 (11.76\\%) for bpf-next/1/0}}$
lxc/tail_nodeport_rev_dnat_egress_ipv6 | $\color{green}{\textsf{-32 (-10.00\\%) for bpf-next/1/0}}$ | $\color{green}{\textsf{-32 (-10.00\\%) for bpf-next/1/0}}$
lxc/tail_nodeport_rev_dnat_ipv4 | $\color{green}{\textsf{-32 (-12.50\\%) for bpf-next/1/0}}$ | $\color{green}{\textsf{-32 (-12.50\\%) for bpf-next/1/0}}$
overlay/tail_nodeport_nat_egress_ipv4 | $\color{green}{\textsf{-32 (-9.52\\%) for bpf-next/1/0}}$ | $\color{green}{\textsf{-32 (-9.52\\%) for bpf-next/1/0}}$

## Top 15 largest stack depth
Collection/Program | Min | Max
-------------------|-----|----
lxc/tail_handle_ipv4_cont | $\textsf{384 (75.00\\%) for bpf-next/1/0}$ | $\textsf{384 (75.00\\%) for bpf-next/1/0}$
host/tail_handle_snat_fwd_ipv6 | $\textsf{368 (71.88\\%) for bpf-next/1/0}$ | $\textsf{384 (75.00\\%) for bpf-next/7/0}$
xdp/tail_nodeport_ipv6_dsr | $\textsf{320 (62.50\\%) for bpf-next/1/0}$ | $\color{orange}{\textsf{432 (84.38\\%) for bpf-next/3/0}}$
host/tail_nodeport_ipv6_dsr | $\textsf{336 (65.62\\%) for bpf-next/1/0}$ | $\color{orange}{\textsf{400 (78.12\\%) for bpf-next/2/0}}$
host/tail_handle_snat_fwd_ipv4 | $\textsf{352 (68.75\\%) for bpf-next/7/0}$ | $\textsf{368 (71.88\\%) for bpf-next/1/0}$
host/tail_nodeport_nat_ingress_ipv6 | $\textsf{352 (68.75\\%) for bpf-next/1/0}$ | $\textsf{368 (71.88\\%) for bpf-next/7/0}$
overlay/tail_nodeport_ipv6_dsr | $\textsf{336 (65.62\\%) for bpf-next/1/0}$ | $\textsf{384 (75.00\\%) for bpf-next/2/0}$
host/tail_nodeport_nat_egress_ipv6 | $\textsf{352 (68.75\\%) for bpf-next/1/0}$ | $\textsf{352 (68.75\\%) for bpf-next/1/0}$
overlay/tail_nodeport_nat_egress_ipv6 | $\textsf{352 (68.75\\%) for bpf-next/1/0}$ | $\textsf{352 (68.75\\%) for bpf-next/1/0}$
host/tail_ipv6_host_policy_ingress | $\textsf{336 (65.62\\%) for bpf-next/1/0}$ | $\textsf{352 (68.75\\%) for bpf-next/7/0}$
xdp/tail_nodeport_nat_egress_ipv6 | $\textsf{336 (65.62\\%) for bpf-next/1/0}$ | $\textsf{352 (68.75\\%) for bpf-next/2/0}$
host/tail_handle_ipv6_from_netdev | $\textsf{336 (65.62\\%) for bpf-next/1/0}$ | $\textsf{336 (65.62\\%) for bpf-next/1/0}$
overlay/tail_nodeport_nat_ingress_ipv6 | $\textsf{336 (65.62\\%) for bpf-next/1/0}$ | $\textsf{336 (65.62\\%) for bpf-next/1/0}$
xdp/tail_nodeport_nat_ingress_ipv6 | $\textsf{320 (62.50\\%) for bpf-next/1/0}$ | $\textsf{336 (65.62\\%) for bpf-next/5/0}$
host/cil_to_netdev | $\textsf{272 (53.12\\%) for bpf-next/3/0}$ | $\textsf{368 (71.88\\%) for bpf-next/1/0}$ 