### PR TITLE
docs: update Gateway API docs to v1.6.0

### DIFF
--- a/Documentation/network/servicemesh/gateway-api/gateway-api.rst
+++ b/Documentation/network/servicemesh/gateway-api/gateway-api.rst
@@ -23,21 +23,22 @@ See the `Gateway API site <https://gateway-api.sigs.k8s.io/>`__ for more details
 Cilium Gateway API Support
 ##########################
 
-Cilium supports Gateway API v1.5.1 for below resources, all the Core conformance
+Cilium supports Gateway API v1.6.0 for below resources, all the Core conformance
 tests are passed.
 
-- `GatewayClass <https://gateway-api.sigs.k8s.io/reference/api-types/gatewayclass/>`_
-- `Gateway <https://gateway-api.sigs.k8s.io/reference/api-types/gateway/>`_
-- `HTTPRoute <https://gateway-api.sigs.k8s.io/reference/api-types/httproute/>`_
+- `GatewayClass <https://gateway-api.sigs.k8s.io/reference/api-types/gatewayclass/>`__
+- `Gateway <https://gateway-api.sigs.k8s.io/reference/api-types/gateway/>`__
+- `HTTPRoute <https://gateway-api.sigs.k8s.io/reference/api-types/httproute/>`__
 - `GRPCRoute <https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute/>`__
 - `TLSRoute <https://gateway-api.sigs.k8s.io/reference/api-types/tlsroute/>`__
 - `BackendTLSPolicy <https://gateway-api.sigs.k8s.io/reference/api-types/policy/backendtlspolicy/>`__
-- `ReferenceGrant <https://gateway-api.sigs.k8s.io/reference/api-types/referencegrant/>`_
-- `TCPRoute (experimental) <https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#tcproute>`__
-- `UDPRoute (experimental) <https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#udproute>`__
+- `ReferenceGrant <https://gateway-api.sigs.k8s.io/reference/api-types/referencegrant/>`__
+- `TCPRoute <https://gateway-api.sigs.k8s.io/reference/api-types/tcproute/>`__
+- `UDPRoute <https://gateway-api.sigs.k8s.io/reference/api-types/udproute/>`__
+- `ListenerSet <https://gateway-api.sigs.k8s.io/reference/api-types/listenerset/>`__
 
 Additionally, Cilium provides ``CiliumGatewayClassConfig`` CRD, which can be referenced in
-`GatewayClass.parametersRef <https://gateway-api.sigs.k8s.io/reference/api-types/gatewayclass/#gatewayclass-parameters>`_.
+`GatewayClass.parametersRef <https://gateway-api.sigs.k8s.io/reference/api-types/gatewayclass/#gatewayclass-parameters>`__.
 
 .. admonition:: Video
  :class: attention
@@ -73,7 +74,7 @@ Cilium's Gateway API features:
    default-tls-certificate
    backendtlspolicy
 
-More examples can be found in the `upstream repository <https://github.com/kubernetes-sigs/gateway-api/tree/v1.3.0/examples/standard>`_.
+More examples can be found in the `upstream repository <https://github.com/kubernetes-sigs/gateway-api/tree/v1.6.0/examples/standard>`__.
 
 Troubleshooting
 ###############

--- a/Documentation/network/servicemesh/gateway-api/installation.rst
+++ b/Documentation/network/servicemesh/gateway-api/installation.rst
@@ -6,41 +6,45 @@ Prerequisites
   replacement <kubeproxy-free>`.
 * Cilium must be configured with the L7 proxy enabled using ``l7Proxy=true``
   (enabled by default).
-* The below CRDs from Gateway API v1.5.1 ``must`` be pre-installed.
-  Please refer to these `docs <https://gateway-api.sigs.k8s.io/guides/getting-started/introduction/#installing-gateway-api>`_
+* The below CRDs from Gateway API v1.6.0 ``must`` be pre-installed.
+  Please refer to these `docs <https://gateway-api.sigs.k8s.io/guides/getting-started/introduction/#installing-gateway-api>`__
   for installation steps. Alternatively, the below snippet could be used.
 
-    - `GatewayClass <https://gateway-api.sigs.k8s.io/reference/api-types/gatewayclass/>`_
-    - `Gateway <https://gateway-api.sigs.k8s.io/reference/api-types/gateway/>`_
-    - `HTTPRoute <https://gateway-api.sigs.k8s.io/reference/api-types/httproute/>`_
-    - `GRPCRoute <https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute/>`_
-    - `ReferenceGrant <https://gateway-api.sigs.k8s.io/reference/api-types/referencegrant/>`_
-    - `TLSRoute <https://gateway-api.sigs.k8s.io/reference/api-types/tlsroute/>`_
-
-  If you wish to use the TCPRoute and UDPRoute functionality, you also need to install the TCPRoute and UDPRoute resource.
-  If this CRD is not installed, then Cilium will disable TCPRoute and UDPRoute support.
-
-    - `TCPRoute (experimental) <https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#tcproute>`__
-    - `UDPRoute (experimental) <https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#udproute>`__
+  - `GatewayClass <https://gateway-api.sigs.k8s.io/reference/api-types/gatewayclass/>`__
+  - `Gateway <https://gateway-api.sigs.k8s.io/reference/api-types/gateway/>`__
+  - `HTTPRoute <https://gateway-api.sigs.k8s.io/reference/api-types/httproute/>`__
+  - `GRPCRoute <https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute/>`__
+  - `TLSRoute <https://gateway-api.sigs.k8s.io/reference/api-types/tlsroute/>`__
+  - `BackendTLSPolicy <https://gateway-api.sigs.k8s.io/reference/api-types/policy/backendtlspolicy/>`__
+  - `ReferenceGrant <https://gateway-api.sigs.k8s.io/reference/api-types/referencegrant/>`__
 
   You can install the required CRDs like this:
 
     .. code-block:: shell-session
 
-        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
-        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
-        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
-        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
-        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
-        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_backendtlspolicies.yaml
-        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_tlsroutes.yaml
+      $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.0/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
+      $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.0/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+      $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.0/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+      $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.0/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
+      $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.0/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
+      $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.0/config/crd/standard/gateway.networking.k8s.io_backendtlspolicies.yaml
+      $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.0/config/crd/standard/gateway.networking.k8s.io_tlsroutes.yaml
 
-  For TCPRoute and UDPRoute, also add the related CRDs with the following snippet:
+* To use ``TCPRoute``, ``UDPRoute``, or ``ListenerSet`` functionality,
+  you must install the corresponding CRD resources. If they are not installed,
+  Cilium will disable support for these features.
+
+  - `TCPRoute <https://gateway-api.sigs.k8s.io/reference/api-types/tcproute/>`__
+  - `UDPRoute <https://gateway-api.sigs.k8s.io/reference/api-types/udproute/>`__
+  - `ListenerSet <https://gateway-api.sigs.k8s.io/reference/api-types/listenerset/>`__
+
+  You can install the optional CRDs like this:
 
     .. code-block:: shell-session
 
-        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
-        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+      $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.0/config/crd/standard/gateway.networking.k8s.io_tcproutes.yaml
+      $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.0/config/crd/standard/gateway.networking.k8s.io_udproutes.yaml
+      $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.0/config/crd/standard/gateway.networking.k8s.io_listenersets.yaml
 
 * By default, the Gateway API controller creates a service of LoadBalancer type,
   so your environment will need to support this. Alternatively, since Cilium 1.16+,

--- a/examples/kubernetes/gateway/echo-basic.yaml
+++ b/examples/kubernetes/gateway/echo-basic.yaml
@@ -31,7 +31,7 @@ spec:
         app: echo-1
     spec:
       containers:
-      - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
+      - image: registry.k8s.io/gateway-api/echo-basic:v1.6.0
         name: echo-1
         ports:
         - containerPort: 3000
@@ -77,7 +77,7 @@ spec:
         app: echo-2
     spec:
       containers:
-      - image: registry.k8s.io/gateway-api/echo-basic:v1.5.1
+      - image: registry.k8s.io/gateway-api/echo-basic:v1.6.0
         name: echo-2
         ports:
         - containerPort: 3000


### PR DESCRIPTION
Update Gateway API CRD installation URLs and echo-basic example images to v1.6.0. Document `ListenerSet` as a supported optional CRD.

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
