### PR TITLE
bpf: include `drop_reasons.h` directly where `DROP_*` constants are used

### DIFF
--- a/bpf/lib/arp.h
+++ b/bpf/lib/arp.h
@@ -7,6 +7,7 @@
 #include <linux/if_ether.h>
 #include "eth.h"
 #include "dbg.h"
+#include "drop_reasons.h"
 
 struct arp_eth {
 	unsigned char		ar_sha[ETH_ALEN];

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -9,6 +9,7 @@
 #include <bpf/config/node.h>
 
 #include "common.h"
+#include "drop_reasons.h"
 #include "utils.h"
 #include "ipv4.h"
 #include "ipv6.h"

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -8,6 +8,7 @@
 #include "icmp_wsum.h"
 #include "eth.h"
 #include "drop.h"
+#include "drop_reasons.h"
 #include "eps.h"
 
 #define ICMP6_TYPE_OFFSET offsetof(struct icmp6hdr, icmp6_type)

--- a/bpf/lib/ipv6.h
+++ b/bpf/lib/ipv6.h
@@ -7,6 +7,7 @@
 
 #include "eth.h"
 #include "dbg.h"
+#include "drop_reasons.h"
 #include "ipv6_core.h"
 #include "l4.h"
 #include "metrics.h"

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "common.h"
+#include "drop_reasons.h"
 #include "ipv6.h"
 #include "ipv4.h"
 #include "eth.h"

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -7,6 +7,7 @@
 #include "bpf/lb_selection.h"
 #include "csum.h"
 #include "conntrack.h"
+#include "drop_reasons.h"
 #include "ipv4.h"
 #include "hash.h"
 #include "eps.h"

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -18,6 +18,7 @@
 #include "conntrack.h"
 #include "conntrack_map.h"
 #include "csum.h"
+#include "drop_reasons.h"
 #include "egress_gateway.h"
 #include "eps.h"
 #include "icmp6.h"

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -14,6 +14,7 @@
 #include "lb.h"
 #include "common.h"
 #include "drop.h"
+#include "drop_reasons.h"
 #include "overloadable.h"
 #include "egress_gateway.h"
 #include "eps.h"

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -7,6 +7,7 @@
 
 #include "common.h"
 #include "dbg.h"
+#include "drop_reasons.h"
 #include "identity.h"
 
 DECLARE_CONFIG(bool, allow_icmp_frag_needed,


### PR DESCRIPTION
Avoid relying on `drop_reasons.h` being transitively included via `common.h` or other headers.
