### PR TITLE
fqdn: defer disabled DNS request log scopes

### DIFF
--- a/pkg/fqdn/bootstrap/dns_proxy.go
+++ b/pkg/fqdn/bootstrap/dns_proxy.go
@@ -48,15 +48,18 @@ func newDNSProxy(params dnsProxyParams) (proxy.DNSProxier, error) {
 	}
 
 	dnsProxyConfig := dnsproxy.DNSProxyConfig{
-		Logger:                 params.Logger,
-		Address:                "",
-		IPv4:                   option.Config.EnableIPv4,
-		IPv6:                   option.Config.EnableIPv6,
-		EnableDNSCompression:   params.FQDNConfig.ToFQDNsEnableDNSCompression,
-		MaxRestoreDNSIPs:       params.FQDNConfig.DNSMaxIPsPerRestoredRule,
-		ConcurrencyLimit:       option.Config.DNSProxyConcurrencyLimit,
-		ConcurrencyGracePeriod: params.FQDNConfig.DNSProxyConcurrencyProcessingGracePeriod,
-		RejectReply:            option.Config.FQDNRejectResponse,
+		Logger: params.Logger,
+		// Cilium's built-in handlers make level decisions independently of
+		// request attributes, so disabled Debug logs need no request scope.
+		SkipDisabledDebugLogScope: true,
+		Address:                   "",
+		IPv4:                      option.Config.EnableIPv4,
+		IPv6:                      option.Config.EnableIPv6,
+		EnableDNSCompression:      params.FQDNConfig.ToFQDNsEnableDNSCompression,
+		MaxRestoreDNSIPs:          params.FQDNConfig.DNSMaxIPsPerRestoredRule,
+		ConcurrencyLimit:          option.Config.DNSProxyConcurrencyLimit,
+		ConcurrencyGracePeriod:    params.FQDNConfig.DNSProxyConcurrencyProcessingGracePeriod,
+		RejectReply:               option.Config.FQDNRejectResponse,
 	}
 
 	proxy := dnsproxy.NewDNSProxy(

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -558,15 +558,20 @@ func (allow perEPAllow) getPortRulesForID(logger *slog.Logger, endpointID uint64
 
 // DNSProxyConfig is the configuration for the DNS proxy.
 type DNSProxyConfig struct {
-	Logger                 *slog.Logger
-	Address                string
-	IPv4                   bool
-	IPv6                   bool
-	EnableDNSCompression   bool
-	MaxRestoreDNSIPs       int
-	ConcurrencyLimit       int
-	ConcurrencyGracePeriod time.Duration
-	RejectReply            string
+	Logger *slog.Logger
+	// SkipDisabledDebugLogScope avoids constructing per-request logger scopes
+	// while Debug is disabled. Enable it only when Logger handlers make Enabled
+	// decisions independently of attributes supplied through With and their
+	// WithAttrs methods have no externally visible side effects.
+	SkipDisabledDebugLogScope bool
+	Address                   string
+	IPv4                      bool
+	IPv6                      bool
+	EnableDNSCompression      bool
+	MaxRestoreDNSIPs          int
+	ConcurrencyLimit          int
+	ConcurrencyGracePeriod    time.Duration
+	RejectReply               string
 }
 
 // NewDNSProxy creates a proxy used for DNS L7 redirects that listens on
@@ -898,10 +903,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	requestID := request.Id // save the original request ID
 	protocol := w.LocalAddr().Network()
 	epIPPort := w.RemoteAddr().String()
-	scopedLog := p.logger.With(
-		logfields.IPAddr, epIPPort,
-		logfields.DNSRequestID, requestID,
-	)
+	scopedLog := newDNSRequestLogger(p.logger, epIPPort, requestID, p.cfg.SkipDisabledDebugLogScope)
 
 	if p.ConcurrencyLimit != nil {
 		// TODO: Consider plumbing the daemon context here.
@@ -914,7 +916,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		if err := p.enforceConcurrencyLimit(ctx); err != nil {
 			stat.SemaphoreAcquireTime.End(false)
 			if p.logLimiter.Allow() {
-				scopedLog.Error("Dropping DNS request due to too many DNS requests already in-flight", logfields.Error, err)
+				scopedLog.logger().Error("Dropping DNS request due to too many DNS requests already in-flight", logfields.Error, err)
 			}
 			stat.Err = err
 			p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, 0, netip.AddrPort{}, &MsgDetails{}, protocol, false, &stat)
@@ -928,7 +930,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 
 	requestDetails, err := ExtractRequestMsgDetails(request)
 	if err != nil {
-		scopedLog.Error("cannot extract DNS message details", logfields.Error, err)
+		scopedLog.logger().Error("cannot extract DNS message details", logfields.Error, err)
 		stat.Err = fmt.Errorf("cannot extract DNS message details: %w", err)
 		stat.ProcessingTime.End(false)
 		stat.TotalTime.End(false)
@@ -937,12 +939,14 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	}
 
 	qname := string(requestDetails.QName)
-	scopedLog = scopedLog.With(logfields.DNSName, qname)
-	scopedLog.Debug("Handling DNS query from endpoint")
+	scopedLog.withName(qname)
+	if logger := scopedLog.debugLogger(); logger != nil {
+		logger.Debug("Handling DNS query from endpoint")
+	}
 
 	addrPort, err := netip.ParseAddrPort(epIPPort)
 	if err != nil {
-		scopedLog.Error("cannot extract endpoint IP from DNS request", logfields.Error, err)
+		scopedLog.logger().Error("cannot extract endpoint IP from DNS request", logfields.Error, err)
 		stat.Err = fmt.Errorf("Cannot extract endpoint IP from DNS request: %w", err)
 		stat.ProcessingTime.End(false)
 		p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, 0, netip.AddrPort{}, &MsgDetails{}, protocol, false, &stat)
@@ -952,7 +956,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	epAddr := addrPort.Addr()
 	ep, _, err := p.LookupEndpointByIP(epAddr)
 	if err != nil {
-		scopedLog.Error("cannot extract endpoint ID from DNS request", logfields.Error, err)
+		scopedLog.logger().Error("cannot extract endpoint ID from DNS request", logfields.Error, err)
 		stat.Err = fmt.Errorf("Cannot extract endpoint ID from DNS request: %w", err)
 		stat.ProcessingTime.End(false)
 		p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, 0, netip.AddrPort{}, &MsgDetails{}, protocol, false, &stat)
@@ -960,10 +964,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		return
 	}
 
-	scopedLog = scopedLog.With(
-		logfields.EndpointID, ep.StringID(),
-		logfields.Identity, ep.GetIdentity(),
-	)
+	scopedLog.withEndpoint(ep.StringID(), ep.GetIdentity())
 
 	proto, targetServer, err := p.lookupTargetDNSServer(w)
 	if err != nil {
@@ -979,17 +980,21 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	// Ignore invalid IP - getter will handle invalid value.
 	targetServerID := identity.GetWorldIdentityFromIP(targetServer.Addr())
 	if serverSecID, exists := p.proxyLookupHandler.LookupSecIDByIP(targetServer.Addr()); !exists {
-		scopedLog.Debug(
-			"cannot find server ip in ipcache, defaulting to WORLD",
-			logfields.Server, targetServer.Addr(),
-		)
+		if logger := scopedLog.debugLogger(); logger != nil {
+			logger.Debug(
+				"cannot find server ip in ipcache, defaulting to WORLD",
+				logfields.Server, targetServer.Addr(),
+			)
+		}
 	} else {
 		targetServerID = serverSecID.ID
-		scopedLog.Debug(
-			"Found target server to of DNS request secID",
-			logfields.SecID, serverSecID,
-			logfields.Server, targetServer.Addr(),
-		)
+		if logger := scopedLog.debugLogger(); logger != nil {
+			logger.Debug(
+				"Found target server to of DNS request secID",
+				logfields.SecID, serverSecID,
+				logfields.Server, targetServer.Addr(),
+			)
+		}
 	}
 
 	// The allowed check is first because we don't want to use DNS responses that
@@ -1002,7 +1007,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	stat.PolicyCheckTime.End(err == nil)
 	switch {
 	case err != nil:
-		scopedLog.Error("Rejecting DNS query from endpoint due to error", logfields.Error, err)
+		scopedLog.logger().Error("Rejecting DNS query from endpoint due to error", logfields.Error, err)
 		stat.Err = fmt.Errorf("Rejecting DNS query from endpoint due to error: %w", err)
 		stat.ProcessingTime.End(false)
 		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServer, requestDetails, protocol, false, &stat)
@@ -1010,7 +1015,9 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		return
 
 	case !allowed:
-		scopedLog.Debug("Rejecting DNS query from endpoint due to policy")
+		if logger := scopedLog.debugLogger(); logger != nil {
+			logger.Debug("Rejecting DNS query from endpoint due to policy")
+		}
 		// Send refused msg before calling NotifyOnDNSMsg() because we know
 		// that this DNS request is rejected anyway. NotifyOnDNSMsg depends on
 		// stat.Err field to be set in order to propagate the correct
@@ -1021,9 +1028,11 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		return
 	}
 
-	scopedLog.Debug("Forwarding DNS request for a name that is allowed")
+	if logger := scopedLog.debugLogger(); logger != nil {
+		logger.Debug("Forwarding DNS request for a name that is allowed")
+	}
 	if err := p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServer, requestDetails, protocol, true, &stat); err != nil {
-		scopedLog.Error("Failed to process DNS query", logfields.Error, err)
+		scopedLog.logger().Error("Failed to process DNS query", logfields.Error, err)
 		p.sendErrorResponse(scopedLog, w, request, false)
 		return
 	}
@@ -1034,7 +1043,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	case "udp":
 	case "tcp":
 	default:
-		scopedLog.Error("Cannot parse DNS proxy client network to select forward client")
+		scopedLog.logger().Error("Cannot parse DNS proxy client network to select forward client")
 		stat.Err = fmt.Errorf("Cannot parse DNS proxy client network to select forward client: %w", err)
 		stat.ProcessingTime.End(false)
 		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServer, requestDetails, protocol, false, &stat)
@@ -1090,25 +1099,27 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	if err != nil {
 		stat.Err = err
 		if stat.IsTimeout() {
-			scopedLog.Warn("Timeout waiting for response to forwarded proxied DNS lookup", logfields.Error, err)
+			scopedLog.logger().Warn("Timeout waiting for response to forwarded proxied DNS lookup", logfields.Error, err)
 			p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServer, requestDetails, protocol, false, &stat)
 			return
 		}
-		scopedLog.Error("Cannot forward proxied DNS lookup", logfields.Error, err)
+		scopedLog.logger().Error("Cannot forward proxied DNS lookup", logfields.Error, err)
 		stat.Err = fmt.Errorf("cannot forward proxied DNS lookup: %w", err)
 		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServer, requestDetails, protocol, false, &stat)
 		p.sendErrorResponse(scopedLog, w, request, false)
 		return
 	}
 
-	scopedLog.Debug("Received DNS response to proxied lookup", logfields.Response, response)
+	if logger := scopedLog.debugLogger(); logger != nil {
+		logger.Debug("Received DNS response to proxied lookup", logfields.Response, response)
+	}
 	stat.Success = true
 
 	stat.ProcessingTime.Start()
 	// Extract response details for the successful response path.
 	responseDetails, err := ExtractResponseMsgDetails(response)
 	if err != nil {
-		scopedLog.Error("cannot extract DNS response details", logfields.Error, err)
+		scopedLog.logger().Error("cannot extract DNS response details", logfields.Error, err)
 		stat.Err = fmt.Errorf("cannot extract DNS response details: %w", err)
 		stat.ProcessingTime.End(false)
 		stat.TotalTime.End(false)
@@ -1117,9 +1128,11 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	}
 	stat.ProcessingTime.End(true)
 
-	scopedLog.Debug("Notifying with DNS response to original DNS query")
+	if logger := scopedLog.debugLogger(); logger != nil {
+		logger.Debug("Notifying with DNS response to original DNS query")
+	}
 	if err := p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServer, responseDetails, protocol, true, &stat); err != nil {
-		scopedLog.Error(
+		scopedLog.logger().Error(
 			"Failed to process DNS response",
 			logfields.Error, err,
 			logfields.Response, response,
@@ -1128,13 +1141,15 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		return
 	}
 
-	scopedLog.Debug("Responding to original DNS query")
+	if logger := scopedLog.debugLogger(); logger != nil {
+		logger.Debug("Responding to original DNS query")
+	}
 	// Ensure the ID matches the initial request - the upstream query may have changed the ID to avoid duplicates.
 	response.Id = requestID
 	response.Compress = p.EnableDNSCompression && shouldCompressResponse(request, response)
 	err = w.WriteMsg(response)
 	if err != nil {
-		scopedLog.Error("Cannot forward proxied DNS response", logfields.Error, err)
+		scopedLog.logger().Error("Cannot forward proxied DNS response", logfields.Error, err)
 		stat.Err = fmt.Errorf("Cannot forward proxied DNS response: %w", err)
 		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServer, responseDetails, protocol, true, &stat)
 	} else {
@@ -1172,7 +1187,7 @@ func (p *DNSProxy) enforceConcurrencyLimit(ctx context.Context) error {
 // sendErrorResponse creates and sends an error response for request to w
 // In case of policy rejection, the response code will be based on the rejectReply option.
 // For all other errors, the response will be a SERVFAIL.
-func (p *DNSProxy) sendErrorResponse(scopedLog *slog.Logger, w dns.ResponseWriter, request *dns.Msg, policyRejection bool) (err error) {
+func (p *DNSProxy) sendErrorResponse(scopedLog *dnsRequestLogger, w dns.ResponseWriter, request *dns.Msg, policyRejection bool) (err error) {
 	response := new(dns.Msg)
 	rcode := dns.RcodeServerFailure
 	if policyRejection {
@@ -1181,7 +1196,7 @@ func (p *DNSProxy) sendErrorResponse(scopedLog *slog.Logger, w dns.ResponseWrite
 	response.SetRcode(request, rcode)
 
 	if err = w.WriteMsg(response); err != nil {
-		scopedLog.Error("Cannot send REFUSED response",
+		scopedLog.logger().Error("Cannot send REFUSED response",
 			logfields.Code, rcode,
 			logfields.Error, err,
 		)

--- a/pkg/fqdn/dnsproxy/request_logger.go
+++ b/pkg/fqdn/dnsproxy/request_logger.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package dnsproxy
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// dnsRequestLogger defers the relatively expensive slog.Logger.With calls
+// until this request emits a log record. Scope extensions are kept separate so
+// handlers observe the same attribute ordering and WithAttrs call boundaries
+// as an eagerly scoped logger.
+type dnsRequestLogger struct {
+	base   *slog.Logger
+	scoped *slog.Logger
+
+	ipPort    string
+	requestID uint16
+
+	name    string
+	hasName bool
+
+	endpointID       string
+	endpointIdentity identity.NumericIdentity
+	hasEndpoint      bool
+}
+
+func newDNSRequestLogger(base *slog.Logger, ipPort string, requestID uint16, skipDisabledDebugLogScope bool) *dnsRequestLogger {
+	logger := &dnsRequestLogger{
+		base:      base,
+		ipPort:    ipPort,
+		requestID: requestID,
+	}
+	if !skipDisabledDebugLogScope {
+		logger.logger()
+	}
+	return logger
+}
+
+func (l *dnsRequestLogger) withName(name string) {
+	l.name = name
+	l.hasName = true
+	if l.scoped != nil {
+		l.scoped = l.scoped.With(logfields.DNSName, name)
+	}
+}
+
+func (l *dnsRequestLogger) withEndpoint(endpointID string, endpointIdentity identity.NumericIdentity) {
+	l.endpointID = endpointID
+	l.endpointIdentity = endpointIdentity
+	l.hasEndpoint = true
+	if l.scoped != nil {
+		l.scoped = l.scoped.With(
+			logfields.EndpointID, endpointID,
+			logfields.Identity, endpointIdentity,
+		)
+	}
+}
+
+func (l *dnsRequestLogger) logger() *slog.Logger {
+	if l.scoped != nil {
+		return l.scoped
+	}
+
+	l.scoped = l.base.With(
+		logfields.IPAddr, l.ipPort,
+		logfields.DNSRequestID, l.requestID,
+	)
+	if l.hasName {
+		l.scoped = l.scoped.With(logfields.DNSName, l.name)
+	}
+	if l.hasEndpoint {
+		l.scoped = l.scoped.With(
+			logfields.EndpointID, l.endpointID,
+			logfields.Identity, l.endpointIdentity,
+		)
+	}
+	return l.scoped
+}
+
+// debugLogger returns nil when debug logging is disabled, avoiding both the
+// scoped logger construction and an unscoped fallback log if levels change.
+func (l *dnsRequestLogger) debugLogger() *slog.Logger {
+	if l.scoped == nil && !l.base.Enabled(context.Background(), slog.LevelDebug) {
+		return nil
+	}
+	return l.logger()
+}

--- a/pkg/fqdn/dnsproxy/request_logger_test.go
+++ b/pkg/fqdn/dnsproxy/request_logger_test.go
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package dnsproxy
+
+import (
+	"context"
+	"log/slog"
+	"runtime"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+const requestLoggerTestIdentity = identity.NumericIdentity(1234)
+
+type requestLoggerTestRecord struct {
+	message string
+	attrs   map[string]any
+	pc      uintptr
+}
+
+type requestLoggerTestState struct {
+	records       []requestLoggerTestRecord
+	withAttrCalls [][]slog.Attr
+}
+
+func (s *requestLoggerTestState) find(t *testing.T, message string) requestLoggerTestRecord {
+	t.Helper()
+	for _, record := range s.records {
+		if record.message == message {
+			return record
+		}
+	}
+	t.Fatalf("log message %q not found in %#v", message, s.records)
+	return requestLoggerTestRecord{}
+}
+
+type requestLoggerTestHandler struct {
+	state        *requestLoggerTestState
+	attrs        []slog.Attr
+	minLevel     slog.Level
+	debugAttrKey string
+}
+
+func (h *requestLoggerTestHandler) Enabled(_ context.Context, level slog.Level) bool {
+	if level >= h.minLevel {
+		return true
+	}
+	return level == slog.LevelDebug && slices.ContainsFunc(h.attrs, func(attr slog.Attr) bool {
+		return attr.Key == h.debugAttrKey
+	})
+}
+
+func (h *requestLoggerTestHandler) Handle(_ context.Context, record slog.Record) error {
+	attrs := make(map[string]any, len(h.attrs)+record.NumAttrs())
+	addAttr := func(attr slog.Attr) bool {
+		attr.Value = attr.Value.Resolve()
+		attrs[attr.Key] = attr.Value.Any()
+		return true
+	}
+	for _, attr := range h.attrs {
+		addAttr(attr)
+	}
+	record.Attrs(addAttr)
+
+	h.state.records = append(h.state.records, requestLoggerTestRecord{
+		message: record.Message,
+		attrs:   attrs,
+		pc:      record.PC,
+	})
+	return nil
+}
+
+func (h *requestLoggerTestHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	h.state.withAttrCalls = append(h.state.withAttrCalls, slices.Clone(attrs))
+	next := *h
+	next.attrs = append(slices.Clone(h.attrs), attrs...)
+	return &next
+}
+
+func (h *requestLoggerTestHandler) WithGroup(string) slog.Handler { return h }
+
+func newRequestLoggerTestLogger(minLevel slog.Level, debugAttrKey string) (*slog.Logger, *requestLoggerTestState) {
+	state := &requestLoggerTestState{}
+	logger := slog.New(&requestLoggerTestHandler{
+		state:        state,
+		minLevel:     minLevel,
+		debugAttrKey: debugAttrKey,
+	}).With(logfields.LogSubsys, "dnsproxy")
+	return logger, state
+}
+
+func TestDNSRequestLoggerDefersDisabledDebugScope(t *testing.T) {
+	logger, state := newRequestLoggerTestLogger(slog.LevelInfo, "")
+	baseWithAttrs := len(state.withAttrCalls)
+
+	requestLog := newDNSRequestLogger(logger, "10.0.0.10:12345", 42, true)
+	requestLog.withName("denied.example.")
+	requestLog.withEndpoint("111", requestLoggerTestIdentity)
+
+	require.Nil(t, requestLog.debugLogger())
+	require.Len(t, state.withAttrCalls, baseWithAttrs)
+	require.Empty(t, state.records)
+
+	requestLog.logger().Error("late-error")
+	require.Equal(t, [][]slog.Attr{
+		{
+			slog.Any(logfields.IPAddr, "10.0.0.10:12345"),
+			slog.Any(logfields.DNSRequestID, uint16(42)),
+		},
+		{slog.Any(logfields.DNSName, "denied.example.")},
+		{
+			slog.Any(logfields.EndpointID, "111"),
+			slog.Any(logfields.Identity, requestLoggerTestIdentity),
+		},
+	}, state.withAttrCalls[baseWithAttrs:])
+
+	record := state.find(t, "late-error")
+	require.Equal(t, "dnsproxy", record.attrs[logfields.LogSubsys])
+	require.Equal(t, "10.0.0.10:12345", record.attrs[logfields.IPAddr])
+	require.Equal(t, uint64(42), record.attrs[logfields.DNSRequestID])
+	require.Equal(t, "denied.example.", record.attrs[logfields.DNSName])
+	require.Equal(t, "111", record.attrs[logfields.EndpointID])
+	require.Equal(t, requestLoggerTestIdentity, record.attrs[logfields.Identity])
+}
+
+func TestDNSRequestLoggerPreservesScopeBoundaries(t *testing.T) {
+	logger, state := newRequestLoggerTestLogger(slog.LevelDebug, "")
+	baseWithAttrs := len(state.withAttrCalls)
+
+	requestLog := newDNSRequestLogger(logger, "10.0.0.10:12345", 42, true)
+	requestLog.withName("denied.example.")
+	require.Len(t, state.withAttrCalls, baseWithAttrs)
+
+	requestLog.debugLogger().Debug("name-scoped")
+	require.Equal(t, [][]slog.Attr{
+		{
+			slog.Any(logfields.IPAddr, "10.0.0.10:12345"),
+			slog.Any(logfields.DNSRequestID, uint16(42)),
+		},
+		{slog.Any(logfields.DNSName, "denied.example.")},
+	}, state.withAttrCalls[baseWithAttrs:])
+
+	requestLog.withEndpoint("111", requestLoggerTestIdentity)
+	require.Equal(t, []slog.Attr{
+		slog.Any(logfields.EndpointID, "111"),
+		slog.Any(logfields.Identity, requestLoggerTestIdentity),
+	}, state.withAttrCalls[baseWithAttrs+2])
+
+	requestLog.logger().Error("endpoint-scoped")
+	require.Len(t, state.withAttrCalls, baseWithAttrs+3, "the materialized logger must be reused")
+	record := state.find(t, "endpoint-scoped")
+	require.Equal(t, "111", record.attrs[logfields.EndpointID])
+	require.Equal(t, requestLoggerTestIdentity, record.attrs[logfields.Identity])
+	require.Contains(t, runtime.FuncForPC(record.pc).Name(), "TestDNSRequestLoggerPreservesScopeBoundaries")
+}
+
+func TestDNSRequestLoggerKeepsEagerFallback(t *testing.T) {
+	logger, state := newRequestLoggerTestLogger(slog.LevelInfo, logfields.DNSName)
+	baseWithAttrs := len(state.withAttrCalls)
+
+	requestLog := newDNSRequestLogger(logger, "10.0.0.10:12345", 42, false)
+	require.Len(t, state.withAttrCalls, baseWithAttrs+1)
+
+	requestLog.withName("denied.example.")
+	require.Len(t, state.withAttrCalls, baseWithAttrs+2)
+
+	requestLog.debugLogger().Debug("attribute-enabled")
+	record := state.find(t, "attribute-enabled")
+	require.Equal(t, "denied.example.", record.attrs[logfields.DNSName])
+}


### PR DESCRIPTION
## Change

`ServeDNS` previously created three request-scoped `slog.Logger` instances before knowing whether a Debug record would be emitted. Because `Logger.With` eagerly invokes `WithAttrs`, the usual Debug-disabled path allocated handler state that no record consumed.

The new request-local logger stores the client address, request ID, query name, endpoint ID, and identity until a record is enabled, then materializes the same progressive scopes. Debug, Warning, and Error records retain their fields, order, and scope boundaries. Cilium's built-in handlers opt in; arbitrary handlers remain eager to preserve attribute-dependent behavior.

## Results

`BenchmarkServeDNSPolicyDenied/debug-disabled`, ten repetitions:

| Metric | Before | After | Change |
|---|---:|---:|---:|
| Time | 4185.5 ns/op | 1222 ns/op | -70.8% |
| Bytes | 3944 B/op | 1056 B/op | -73.2% |
| Allocations | 51 allocs/op | 9 allocs/op | -82.4% |

Debug-enabled allocations were unchanged and runtime was within 0.29% of baseline. In the fixed DNS-heavy kind workload (15,000 requests, 500 QPS, concurrency 32), median cilium-agent CPU moved from 6.83s to 6.09s (-10.8%) with unchanged throughput and outcomes. This is a workload result, not a universal deployment estimate. The benchmark harness is intentionally not included in this PR.

## Validation

- Correctness-only tests cover disabled and enabled Debug paths, late errors, scope boundaries, and the eager custom-handler fallback.
- Linux/arm64 tests and compilation passed.
- The kind workload returned exactly 12,000 successes, 1,500 NXDOMAIN responses, and 1,500 policy denials, with no timeouts or unexpected responses.
- Formatting, linting, generated-code checks, and `git diff --check` passed.

## AI disclosure

This draft PR was prepared with Codex at AIL:4. Codex performed the initial profiling, implementation, and validation. The contributor selected this one-commit scope and reviewed the mechanism, safety constraints, and benchmark results. The PR remains draft for final contributor and maintainer review.

```release-note
Reduce cilium-agent CPU use for DNS proxy traffic when Debug logging is disabled.
```
