### PR TITLE
egressgw: populate egressIfIndex for IPv6-only CEGP with default selector

### DIFF
--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -340,6 +340,8 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(manager *Manager, gc *po
 			}
 
 			gwc.ifaceName = iface.Attrs().Name
+			gwc.egressIfindex = uint32(iface.Attrs().Index)
+
 			egressIP6, err = netdevice.GetIfaceFirstIPv6Address(gwc.ifaceName)
 			if err != nil {
 				return fmt.Errorf("failed to retrieve IPv6 address for egress interface: %w", err)


### PR DESCRIPTION
For a CEGP that specifies neither egressInterface nor egressIP, the v4-specific path is no longer executed unconditionally. Therefore we also need to populate the ifindex from the v6-specific path.