### PR TITLE
sockets: stop iteration after netlink errors

### DIFF
--- a/pkg/datapath/sockets/sockets.go
+++ b/pkg/datapath/sockets/sockets.go
@@ -515,30 +515,40 @@ func iterateNetlinkSockets(proto uint8, family uint8, stateFilter uint32, fn fun
 		return fmt.Errorf("failed to send netlink list request: %w", err)
 	}
 
-loop:
+	// Preserve receive-side error notifications for existing callback users,
+	// but terminate the current dump because it cannot be guaranteed to resume correctly.
+	reportError := func(err error) error {
+		if callbackErr := fn(nil, err); callbackErr != nil {
+			return callbackErr
+		}
+		return err
+	}
+
 	for {
 		msgs, from, err := s.Receive()
 		if err != nil {
-			fn(nil, err)
-			continue loop
+			return reportError(err)
 		}
 		if from.Pid != nl.PidKernel {
-			fn(nil, fmt.Errorf("Wrong sender portid %d, expected %d", from.Pid, nl.PidKernel))
-			continue loop
+			return reportError(fmt.Errorf("Wrong sender portid %d, expected %d", from.Pid, nl.PidKernel))
 		}
 		if len(msgs) == 0 {
-			fn(nil, errors.New("no message nor error from netlink"))
-			continue loop
+			return reportError(errors.New("no message nor error from netlink"))
 		}
 
 		for _, m := range msgs {
 			switch m.Header.Type {
 			case unix.NLMSG_DONE:
-				break loop
+				return nil
 			case unix.NLMSG_ERROR:
-				error := int32(native.Uint32(m.Data[0:4]))
-				fn(nil, syscall.Errno(-error))
-				continue loop
+				if len(m.Data) < 4 {
+					return reportError(fmt.Errorf("short NLMSG_ERROR response: got %d bytes", len(m.Data)))
+				}
+				errno := int32(native.Uint32(m.Data[0:4]))
+				if errno == 0 {
+					return nil
+				}
+				return reportError(syscall.Errno(-errno))
 			}
 			sockInfo := &Socket{}
 			err := sockInfo.Deserialize(m.Data)
@@ -547,5 +557,4 @@ loop:
 			}
 		}
 	}
-	return nil
 }

--- a/pkg/datapath/sockets/sockets_test.go
+++ b/pkg/datapath/sockets/sockets_test.go
@@ -4,6 +4,7 @@
 package sockets
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -11,6 +12,7 @@ import (
 	"os"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/cilium/hive/hivetest"
 
@@ -640,33 +642,69 @@ func BenchmarkDestroyers(b *testing.B) {
 	}
 }
 
-func TestFilterAndDestroySockets_NilSocket(t *testing.T) {
-	// Verify that the callback adapter in filterAndDestroySockets correctly
-	// handles a nil *Socket from iterateNetlinkSockets (error path) without
-	// panicking on a nil pointer dereference.
-	//
-	// iterateNetlinkSockets passes (nil, err) to the callback on netlink
-	// errors. The adapter must forward the error with a zero-value SocketID
-	// instead of dereferencing sockInfo.ID.
+// TestPrivilegedIterateCallbackError verifies that an error returned while
+// visiting a real socket stops iteration and is returned to the caller.
+func TestPrivilegedIterateCallbackError(t *testing.T) {
+	testutils.PrivilegedTest(t)
 
-	adapter := func(sockInfo *Socket, err error) error {
-		var id netlink.SocketID
+	sock, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	defer sock.Close()
+	port := uint16(sock.LocalAddr().(*net.UDPAddr).Port)
+
+	stopErr := errors.New("stop socket iteration")
+	found := false
+	err = Iterate(unix.IPPROTO_UDP, unix.AF_INET, StateFilterUDP, func(sock *netlink.Socket, err error) error {
 		if err != nil {
-			id = netlink.SocketID{}
-		} else {
-			id = sockInfo.ID
+			return err
 		}
-		_ = id
+		if sock.ID.SourcePort == port && sock.ID.Source.Equal(net.IPv4(127, 0, 0, 1)) {
+			found = true
+			return stopErr
+		}
 		return nil
+	})
+
+	require.True(t, found, "failed to find the test UDP socket")
+	require.ErrorIs(t, err, stopErr)
+}
+
+// TestPrivilegedFilterAndDestroySocketsNetlinkError verifies that a real
+// NLMSG_ERROR is forwarded once and returned without blocking iteration.
+func TestPrivilegedFilterAndDestroySocketsNetlinkError(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	// invalidFamily is an address family the kernel does not recognize
+	// (well above AF_MAX). sock_diag rejects a dump request for it with
+	// EINVAL before the dump starts, so the kernel deterministically
+	// replies with a non-zero NLMSG_ERROR and never sends NLMSG_DONE.
+	const invalidFamily = 0xff
+
+	type result struct {
+		err           error
+		callbackErr   error
+		socket        netlink.SocketID
+		callbackCalls int
 	}
 
-	// Should not panic with nil sockInfo
-	assert.NotPanics(t, func() {
-		adapter(nil, fmt.Errorf("NLMSG_ERROR"))
-	})
+	done := make(chan result, 1)
+	go func() {
+		res := result{}
+		res.err = filterAndDestroySockets(invalidFamily, unix.IPPROTO_UDP, StateFilterUDP, func(socket netlink.SocketID, err error) {
+			res.callbackCalls++
+			res.socket = socket
+			res.callbackErr = err
+		})
+		done <- res
+	}()
 
-	// Should work normally with valid sockInfo
-	assert.NotPanics(t, func() {
-		adapter(&Socket{ID: netlink.SocketID{SourcePort: 80}}, nil)
-	})
+	select {
+	case res := <-done:
+		require.ErrorIs(t, res.err, unix.EINVAL)
+		require.ErrorIs(t, res.callbackErr, unix.EINVAL)
+		require.Equal(t, netlink.SocketID{}, res.socket)
+		require.Equal(t, 1, res.callbackCalls)
+	case <-time.After(5 * time.Second):
+		t.Fatal("socket iteration blocked after receiving NLMSG_ERROR")
+	}
 }


### PR DESCRIPTION
iterateNetlinkSockets reports receive-side failures and NLMSG_ERROR responses through the socket callback, ignores the callback result, and continues receiving.

A non-zero NLMSG_ERROR can reject a SOCK_DIAG request before a dump starts. In that case no NLMSG_DONE follows, so the next Receive can block indefinitely.

The original socketDiagUDPExecutor treated receive failures, unexpected senders, empty responses, and NLMSG_ERROR as terminal. When it was generalized into iterateNetlinkSockets by c7760bdab8694de997069ce126e44b6e4e1cb6f1, those returns were changed to callback notifications followed by loop continuation.

Restore the original terminal behavior while preserving error notifications for existing callback users. Notify the callback once, honor its error, and otherwise return the original Netlink error. Per-message deserialization remains callback-controlled.

The caller-side guard added in #44843 prevents a nil pointer dereference in filterAndDestroySockets, but it does not change the receive loop. After a non-zero NLMSG_ERROR, iterateNetlinkSockets can still block indefinitely waiting for a response that will not arrive. This change fixes that remaining issue by terminating the failed dump.

Part of #46950
Related: #44843

```release-note
Fix potential hangs caused by Netlink errors in filterAndDestroySockets.
```