### PR TITLE
ci: adjust condition for "Create imagePullSecret"

### DIFF
--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -232,6 +232,7 @@ jobs:
           kind-image: ${{ env.KIND_K8S_IMAGE }}
 
       - name: Create imagePullSecret
+        if: ${{ steps.cilium-config.outputs.skip != 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \

--- a/.github/workflows/conformance-ztunnel-e2e.yaml
+++ b/.github/workflows/conformance-ztunnel-e2e.yaml
@@ -180,6 +180,7 @@ jobs:
           kind-image: ${{ env.KIND_K8S_IMAGE }}
 
       - name: Create imagePullSecret
+        if: ${{ steps.cilium-config.outputs.skip != 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -418,7 +418,7 @@ jobs:
           kind-image: ${{ env.KIND_K8S_IMAGE }}
 
       - name: Create imagePullSecret
-        if: ${{ steps.vars.outputs.downgrade_version != '' }}
+        if: ${{ steps.vars.outputs.downgrade_version != '' && steps.cilium-stable-config.outputs.skip != 'true' && steps.cilium-newest-config.outputs.skip != 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \


### PR DESCRIPTION
The newly added step "Create imagePullSecret" uses a different `if` condition than the pre-steps "Set Kind params" & "Provision K8s on LVH VM".

In case of skipping the k8s cluster creation, the creation of the image pull secret can fail because the cluster coesn't exist.

Therefore this commit aligns the conditions in the github workflows to fix this issue.

Note: Seems like this has been introduced due to a "merge race" between https://github.com/cilium/cilium/pull/45971 & https://github.com/cilium/cilium/pull/46376

Note2: Alternatively we could also gate the image pull secret creation with `steps.lvh-kind.outcome == 'success'` - but imo it doesn't matter that much.