### PR TITLE
gha/net-perf-gke: fall back to other zones on GCE stockout

### DIFF
--- a/.github/actions/setup-gke-cluster/action.yml
+++ b/.github/actions/setup-gke-cluster/action.yml
@@ -7,6 +7,10 @@ inputs:
   zone:
     description: "GCP zone for the cluster"
     required: true
+  fallback-zones:
+    description: "Space-separated list of additional zones to try if the primary zone is out of capacity (GCE STOCKOUT)"
+    required: false
+    default: ""
   cluster-version:
     description: "Explicit GKE cluster version"
     required: false
@@ -31,6 +35,9 @@ outputs:
   native_cidr:
     description: ""
     value: ${{ steps.create-cluster.outputs.native_cidr }}
+  zone:
+    description: "The zone the cluster was actually created in (may differ from the requested zone if a fallback zone was used)"
+    value: ${{ steps.create-cluster.outputs.zone }}
 
 runs:
   using: "composite"
@@ -61,25 +68,62 @@ runs:
           TAINTS="--node-taints ${{ inputs.node-taints }}"
         fi
 
-        gcloud container clusters create "${{ inputs.cluster-name }}" \
-          --zone "${{ inputs.zone }}" \
-          --enable-ip-alias \
-          --create-subnetwork="range=/26" \
-          --cluster-ipv4-cidr="/21" \
-          --services-ipv4-cidr="/24" \
-          --image-type COS_CONTAINERD \
-          --num-nodes "$(( ${{ inputs.nodes }} + 2 ))" \
-          --machine-type "${{ inputs.machine-type }}" \
-          --disk-type pd-standard \
-          --disk-size 20GB \
-          --no-enable-insecure-kubelet-readonly-port \
-          --enable-master-authorized-networks \
-          --master-authorized-networks "${{ steps.get-runner-ip.outputs.cidr }}" \
-          $VERSION \
-          $LABELS \
-          $TAINTS
+        # Try the requested zone first, then any fallback zones in order. This
+        # makes cluster creation resilient to single-zone GCE capacity
+        # exhaustion (STOCKOUT), which otherwise fails the whole job after a
+        # long provisioning wait. Only capacity errors trigger a fallback: any
+        # other failure (bad flag, quota, config) is not zone-specific, so we
+        # fail fast and surface the real error rather than retrying blindly.
+        created_zone=""
+        for zone in "${{ inputs.zone }}" ${{ inputs.fallback-zones }}; do
+          echo "Attempting to create cluster in zone ${zone}"
+          set +e
+          create_out=$(gcloud container clusters create "${{ inputs.cluster-name }}" \
+            --zone "${zone}" \
+            --enable-ip-alias \
+            --create-subnetwork="range=/26" \
+            --cluster-ipv4-cidr="/21" \
+            --services-ipv4-cidr="/24" \
+            --image-type COS_CONTAINERD \
+            --num-nodes "$(( ${{ inputs.nodes }} + 2 ))" \
+            --machine-type "${{ inputs.machine-type }}" \
+            --disk-type pd-standard \
+            --disk-size 20GB \
+            --no-enable-insecure-kubelet-readonly-port \
+            --enable-master-authorized-networks \
+            --master-authorized-networks "${{ steps.get-runner-ip.outputs.cidr }}" \
+            $VERSION \
+            $LABELS \
+            $TAINTS 2>&1)
+          create_rc=$?
+          set -e
+          echo "${create_out}"
 
-        native_cidr=$(gcloud container clusters describe "${{ inputs.cluster-name }}" --zone "${{ inputs.zone }}" --format 'value(clusterIpv4Cidr)')
+          if [[ ${create_rc} -eq 0 ]]; then
+            created_zone="${zone}"
+            break
+          fi
+
+          if ! echo "${create_out}" | grep -qiE 'does not have enough resources|ZONE_RESOURCE_POOL_EXHAUSTED|STOCKOUT'; then
+            echo "::error::Cluster creation in zone ${zone} failed for a non-capacity reason; not retrying in other zones"
+            exit ${create_rc}
+          fi
+
+          echo "::warning::Zone ${zone} is out of capacity (STOCKOUT); deleting any partial cluster before trying the next zone"
+          # A failed create can leave a partial cluster behind; delete it
+          # (best-effort, async) so it does not leak, then try the next zone.
+          gcloud container clusters delete "${{ inputs.cluster-name }}" --zone "${zone}" --quiet --async || true
+        done
+
+        if [[ -z "${created_zone}" ]]; then
+          echo "::error::All requested zones (${{ inputs.zone }} ${{ inputs.fallback-zones }}) are out of capacity for cluster ${{ inputs.cluster-name }}"
+          exit 1
+        fi
+
+        echo "Cluster created in zone ${created_zone}"
+        echo "zone=${created_zone}" >> $GITHUB_OUTPUT
+
+        native_cidr=$(gcloud container clusters describe "${{ inputs.cluster-name }}" --zone "${created_zone}" --format 'value(clusterIpv4Cidr)')
         echo native_cidr=${native_cidr} >> $GITHUB_OUTPUT
 
     - name: Patch nodes without Cilium

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -67,6 +67,10 @@ env:
   test_name: gke-perf
   USE_GKE_GCLOUD_AUTH_PLUGIN: True
   gcp_zone: us-east5-a
+  # Additional zones to fall back to if the primary zone is out of capacity
+  # (GCE STOCKOUT). All within the same region as gcp_zone to keep perf results
+  # comparable.
+  gcp_fallback_zones: us-east5-b us-east5-c
   # renovate: datasource=docker depName=google/cloud-sdk
   gcloud_version: 574.0.0
 
@@ -111,7 +115,12 @@ jobs:
     name: Installation and Perf Test
     needs: wait-for-images
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    # Allow headroom for a zone fallback: a STOCKOUT can burn ~35m of
+    # provisioning wait per zone before we retry in the next one (partial
+    # clusters are torn down asynchronously, so a failed attempt adds little
+    # beyond that wait). This comfortably covers one fallback on top of the
+    # normal create + install + perf budget.
+    timeout-minutes: 120
     env:
       job_name: "Installation and Perf Test"
     strategy:
@@ -250,6 +259,7 @@ jobs:
         with:
           cluster-name: ${{ env.clusterName }}-${{ matrix.index }}
           zone: ${{ env.gcp_zone }}
+          fallback-zones: ${{ env.gcp_fallback_zones }}
           node-taints: ${{ steps.vars.outputs.node_taints }}
           labels: "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}"
 
@@ -258,11 +268,11 @@ jobs:
         uses: ./.github/actions/gke-create-esp-rule
         with:
           cluster_name: ${{ env.clusterName }}-${{ matrix.index }}
-          cluster_zone: ${{ env.gcp_zone }}
+          cluster_zone: ${{ steps.create-cluster.outputs.zone }}
 
       - name: Get cluster credentials
         run: |
-          gcloud container clusters get-credentials ${{ env.clusterName }}-${{ matrix.index }} --zone ${{ env.gcp_zone }}
+          gcloud container clusters get-credentials ${{ env.clusterName }}-${{ matrix.index }} --zone ${{ steps.create-cluster.outputs.zone }}
 
       - name: Generate cilium-cli kubeconfig
         id: gen-kubeconfig
@@ -329,15 +339,17 @@ jobs:
         uses: ./.github/actions/gke-clean-esp-rule
         with:
           cluster_name: ${{ env.clusterName }}-${{ matrix.index }}
-          cluster_zone: ${{ env.gcp_zone }}
+          cluster_zone: ${{ steps.create-cluster.outputs.zone || env.gcp_zone }}
 
       - name: Clean up GKE
         if: ${{ always() }}
+        env:
+          cluster_zone: ${{ steps.create-cluster.outputs.zone || env.gcp_zone }}
         run: |
-          while [ "$(gcloud container operations list --zone ${{ env.gcp_zone }} --filter="status=RUNNING AND targetLink~${{ env.clusterName }}-${{ matrix.index }}" --format="value(name)")" ];do
+          while [ "$(gcloud container operations list --zone ${cluster_zone} --filter="status=RUNNING AND targetLink~${{ env.clusterName }}-${{ matrix.index }}" --format="value(name)")" ];do
             echo "cluster has an ongoing operation, waiting for all operations to finish"; sleep 15
           done
-          gcloud container clusters delete ${{ env.clusterName }}-${{ matrix.index }} --zone ${{ env.gcp_zone }} --quiet --async
+          gcloud container clusters delete ${{ env.clusterName }}-${{ matrix.index }} --zone ${cluster_zone} --quiet --async
         shell: bash {0} # Disable default fail-fast behavior so that all commands run independently
 
       # We needed to configure a unique suffix to ensure that the artifacts can


### PR DESCRIPTION
The net-perf-gke workflow pins every matrix job to a single zone (us-east5-a), and the seven jobs create their clusters at the same time. That is a burst of roughly 28 n2-standard-2 instances landing in one zone at once, and when the zone cannot absorb it, gcloud container clusters create blocks for the full node provisioning wait (~35m) and then fails with a STOCKOUT error. In a recent scheduled run only two of the seven jobs got their nodes and the other five failed together, for reasons unrelated to Cilium.

Teach the setup-gke-cluster action to try a list of zones in order. On a capacity error it tears down any partial cluster and moves on to the next zone; on any other failure it fails fast and surfaces the real gcloud error rather than retrying blindly across zones. The zone that actually succeeded is exposed as a new output so the downstream steps (ESP firewall create/clean, get-credentials, cleanup) operate on the right zone instead of the fixed env var.

net-perf-gke keeps us-east5-a as the preferred zone so the historical perf trend stays on the same zone in the common case, and falls back to us-east5-b and us-east5-c, all in the same region so the numbers remain comparable. The job timeout is raised to leave headroom for a fallback attempt after a stockout wait.

The fallback-zones input defaults to empty, so the conformance GKE workflows that share this action are unaffected.

This commit was prepared with AIL:3.