### PR TITLE
cni: Bump default version to 1.0.0

### DIFF
--- a/daemon/cmd/cni/config.go
+++ b/daemon/cmd/cni/config.go
@@ -100,7 +100,7 @@ var cniConfigs map[string]string = map[string]string{
 	// the default
 	"none": `
 {
-  "cniVersion": "0.3.1",
+  "cniVersion": "1.0.0",
   "name": "cilium",
   "plugins": [
     {
@@ -113,7 +113,7 @@ var cniConfigs map[string]string = map[string]string{
 
 	"flannel": `
 {
-  "cniVersion": "0.3.1",
+  "cniVersion": "1.0.0",
   "name": "flannel",
   "plugins": [
     {
@@ -140,7 +140,7 @@ var cniConfigs map[string]string = map[string]string{
 `,
 	"portmap": `
 {
-  "cniVersion": "0.3.1",
+  "cniVersion": "1.0.0",
   "name": "portmap",
   "plugins": [
     {


### PR DESCRIPTION
This commit bumps the CNI version of the default CNI config to version 1.0.0. The default CNI config is written when the user does not set up a custom CNI config.

CNI version 1.0.0 has been out for almost 5 years at this point. Cilium has supported it for about the same time (support for the necessary CHECK verb was added in Cilium 1.13).

Bumping the default CNI version is a breaking change, and prior attempts to do this five years ago caused issues because support it was not yet wide-spread.

Today however, now both the oldest supported versions of containerd and crio support CNI 1.0. Furthermore, OpenShift 4.22 also seems to require CNI plugins to support at least v1.0, which means by bumping the CNI version, we make it easier for OpenShift users to run Cilium.

Note that we do not yet bump the CNI version to 1.1.0, as Cilium does not yet implement the required GC verb.

Users who want to remain on CNI version 0.3.1 are advised to adjust the CNI config as per [our documentation][1].

[1]: https://docs.cilium.io/en/stable/network/kubernetes/configuration/#adjusting-cni-configuration

```release-note
The default CNI configuration version has been bumped from 0.3.1 to 1.0.0. Use the `cni.customConf` Helm value to set it back to 0.3.1 if needed.
```

