### PR TITLE
workflows/eks: Increase test concurrency to 5

### DIFF
--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -39,7 +39,7 @@ on:
         description: "Count of namespaces to perform the connectivity tests in parallel."
         required: false
         type: number
-        default: 3
+        default: 5
       quarantine:
         description: "If true, a failure of the installation and connectivity test does not fail the workflow (the job is quarantined). A warning annotation is emitted instead, and all artifacts are still collected so the failure remains visible."
         required: false
@@ -113,7 +113,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  test_concurrency: ${{ inputs.test-concurrency || 3 }}
+  test_concurrency: ${{ inputs.test-concurrency || 5 }}
   clusterNamePrefix: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}-${{ inputs.UID }}-${{ github.run_attempt }}
   # renovate: datasource=github-releases depName=eksctl-io/eksctl
   eksctl_version: v0.228.0


### PR DESCRIPTION
The connectivity tests in `conformance-eks` run with `test-concurrency: 3`. That value dates back to when concurrent runs were first introduced (db42f1ee28) and was kept low because applying a network policy waited on a node-wide `cilium policy wait` that could never settle while sibling test namespaces kept churning policy on the same node.

With #46877 merged, that wait now polls each endpoint for its realized policy revision instead of requiring the whole node to be Ready at the same instant, so the node-wide contention that motivated a low concurrency is gone. This raises the `conformance-eks` reusable-workflow default from 3 to 5, matching the other conformance workflows and speeding up EKS runs.

Scope and risk:

The `conformance-kpr-eks` callers pass an explicit `test-concurrency: 2` and are unaffected. The reductions there (6263cd269e, 9b3dd735fe) were about pod scheduling / ENI IP exhaustion on `t3a.medium` (3 ENIs × 6 = 18 IPs) when IPsec adds conn-disrupt pods on top of the per-namespace test pods — a different failure mode from the policy-wait race, so those stay at 2.

This default bump also raises the scheduled `Conformance EKS with IPsec` job (via `conformance-ipsec.yaml`), which does not override the input. That path deploys conn-disrupt pods and, on scheduled runs, exercises the full k8s matrix including the legs without ENI prefix delegation. Draft on purpose so we can watch whether 5 reintroduces pod-scheduling pressure there before merging.

Draft until CI confirms no regression at concurrency 5.

This change was prepared with AIL:3.