### PR TITLE
gha/gateway-api: make the conformance job reliable (real skip + CRD-fetch retry)

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -215,6 +215,19 @@ jobs:
             SKIPPED_TESTS+=",MeshConsumerRoute,HTTPRouteListenerPortMatching"
           fi
 
+          # The conformance-profile jobs consume SKIPPED_TESTS through the
+          # framework's --skip-tests flag, which splits on comma and matches the
+          # test ShortName exactly. The non-profile jobs instead pass the value
+          # to go test's -test.skip, which is a regexp matched per test-name
+          # segment: a comma-separated list never matches the nested
+          # TestConformance/<name>/... subtests, so the skip silently does
+          # nothing. Build a prefixed alternation for that path so the skip
+          # actually takes effect. No trailing anchor is used because the value
+          # flows through make's $(GATEWAY_TEST_FLAGS), where a trailing '$'
+          # breaks shell quoting; none of the skipped names is a prefix of
+          # another conformance test, so the alternation cannot over-match.
+          SKIPPED_TESTS_REGEX="TestConformance/(${SKIPPED_TESTS//,/|})"
+
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --helm-set=kubeProxyReplacement=true \
             --helm-set=gatewayAPI.enabled=true \
@@ -226,6 +239,7 @@ jobs:
 
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
           echo skipped_tests=${SKIPPED_TESTS} >> $GITHUB_OUTPUT
+          echo skipped_tests_regex=${SKIPPED_TESTS_REGEX} >> $GITHUB_OUTPUT
           echo exempt-features=${EXEMPT_FEATURES} >> $GITHUB_OUTPUT
 
       # Warning: since this is a privileged workflow, subsequent workflow job
@@ -376,7 +390,7 @@ jobs:
           if [ "${{ matrix.conformance-profile }}" == "true" ]; then
             GATEWAY_TEST_FLAGS="$GATEWAY_TEST_FLAGS --skip-tests \"${{ steps.vars.outputs.skipped_tests }}\" --conformance-profiles GATEWAY-HTTP,GATEWAY-TLS,GATEWAY-GRPC,GATEWAY-TCP,GATEWAY-UDP,MESH-HTTP,MESH-GRPC --organization cilium --project cilium --url github.com/cilium/cilium --version main --contact https://github.com/cilium/community/blob/main/roles/Maintainers.md --report-output report.yaml"
           else
-            GATEWAY_TEST_FLAGS="$GATEWAY_TEST_FLAGS --exempt-features \"${{ steps.vars.outputs.exempt-features }}\" -test.skip \"${{ steps.vars.outputs.skipped_tests }}\""
+            GATEWAY_TEST_FLAGS="$GATEWAY_TEST_FLAGS --exempt-features \"${{ steps.vars.outputs.exempt-features }}\" -test.skip \"${{ steps.vars.outputs.skipped_tests_regex }}\""
           fi
           # Create JUnit output directory and enable owner attribution
           mkdir -p cilium-junits

--- a/Makefile.kind
+++ b/Makefile.kind
@@ -369,6 +369,32 @@ kind-install-cilium: check_deps kind-ready ## Install a local Cilium version int
 GW_VERSION ?= $(shell grep -m 1 "sigs.k8s.io/gateway-api" go.mod | awk '{print $$2}' | awk -F'-' '{print (NF>2)?$$NF:$$0}')
 # Set this to "standard" to use the standard CRDs instead
 GW_CHANNEL ?= experimental
+
+# The upstream Gateway API CRDs that the servicemesh targets install, in the
+# order they must be applied.
+GW_CRDS := gatewayclasses gateways httproutes referencegrants grpcroutes \
+	backendtlspolicies tlsroutes listenersets tcproutes udproutes
+
+# Apply the upstream Gateway API CRDs, retrying each one with a backoff.
+# raw.githubusercontent.com intermittently rate-limits (HTTP 429), and a single
+# transient failure here would abort the whole job before Cilium is even
+# installed. Retrying only re-fetches static upstream YAML, so it cannot mask a
+# Cilium regression; a genuinely persistent error still fails the target once
+# the attempts are exhausted.
+define apply-gateway-api-crds
+	for crd in $(GW_CRDS); do \
+		n=0; \
+		until kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_$$crd.yaml; do \
+			n=$$((n+1)); \
+			if [ $$n -ge 5 ]; then \
+				echo "Failed to apply gateway.networking.k8s.io_$$crd CRD after 5 attempts" >&2; \
+				exit 1; \
+			fi; \
+			echo "Retrying gateway.networking.k8s.io_$$crd CRD apply ($$n/5) in $$((n * 5))s..."; \
+			sleep $$((n * 5)); \
+		done; \
+	done
+endef
 KIND_NET_CIDR ?= $(shell docker network inspect kind-cilium -f '{{json .IPAM.Config}}' | jq -r '.[] | select(.Subnet | test("^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+")) | .Subnet')
 LB_CIDR ?= $(shell echo $(KIND_NET_CIDR) | sed "s@0.0/16@255.200\/28@" | sed -e 's/[\/&]/\\&/g')
 
@@ -379,16 +405,7 @@ kind-servicemesh-install-cilium: check_deps kind-ready ## Install a local Cilium
 	# reinstall here. https://github.com/cilium/cilium-cli/issues/205
 	-@$(CILIUM_CLI) uninstall >/dev/null 2>&1 || true
 
-	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_gatewayclasses.yaml
-	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_gateways.yaml
-	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_httproutes.yaml
-	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_referencegrants.yaml
-	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_grpcroutes.yaml
-	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_backendtlspolicies.yaml
-	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_tlsroutes.yaml
-	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_listenersets.yaml
-	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_tcproutes.yaml
-	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_udproutes.yaml
+	@$(apply-gateway-api-crds)
 
 	$(CILIUM_CLI) install \
 		--chart-directory=$(ROOT_DIR)/install/kubernetes/cilium \
@@ -410,16 +427,7 @@ kind-servicemesh-install-cilium: check_deps kind-ready ## Install a local Cilium
 .PHONY: kind-servicemesh-prereqs
 kind-servicemesh-prereqs: check_deps kind-ready
 	@echo "  SETUP Servicemesh"
-	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_gatewayclasses.yaml
-	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_gateways.yaml
-	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_httproutes.yaml
-	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_referencegrants.yaml
-	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_grpcroutes.yaml
-	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_backendtlspolicies.yaml
-	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_tlsroutes.yaml
-	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_listenersets.yaml
-	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_tcproutes.yaml
-	kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GW_VERSION)/config/crd/$(GW_CHANNEL)/gateway.networking.k8s.io_udproutes.yaml
+	@$(apply-gateway-api-crds)
 
 	$(eval KIND_VALUES_FAST_FILES += --helm-values=$(ROOT_DIR)/contrib/testing/kind-servicemesh.yaml)
 


### PR DESCRIPTION
The disable added in 427451b258 ("gha: disable flaky Gateway API tests")
never took effect for the conformance-profile=false matrix jobs. Those jobs
pass SKIPPED_TESTS to go test's -test.skip, which is a regexp matched per
test-name segment, so the comma-separated value never matches the nested
TestConformance/<name>/... subtests and both TCPRouteWeightedRouting and
UDPRouteWeightedRouting keep running. The conformance-profile=true jobs are
fine because they use the framework's --skip-tests, which splits on comma and
matches the test ShortName exactly.

Compute a separate skipped_tests_regex that prefixes the alternation with
TestConformance/ and feed that to -test.skip on the non-profile branch, while
keeping the comma list for --skip-tests. No trailing anchor is used because the
value flows through make's $(GATEWAY_TEST_FLAGS), where a trailing '$' breaks
shell quoting; neither skipped name is a prefix of another conformance test, so
the alternation cannot over-match.


---

Makefile.kind: retry Gateway API CRD applies on transient failures

The servicemesh targets install the upstream Gateway API CRDs with individual
kubectl apply calls that fetch each YAML from raw.githubusercontent.com. That
host intermittently rate-limits with HTTP 429, and a single transient failure
aborts make kind-servicemesh-prereqs before Cilium is even installed, failing
the whole Gateway API conformance job for a reason unrelated to Cilium.

Collect the CRD names into GW_CRDS and apply them through a shared
apply-gateway-api-crds recipe that retries each apply up to five times with an
escalating backoff. This only re-fetches static upstream YAML, so it cannot
mask a Cilium regression, and a genuinely persistent error still fails the
target once the retries are exhausted.

