### PR TITLE
policy/k8s: record processing start time for k8s NetworkPolicy updates

### DIFF
--- a/pkg/policy/k8s/cluster_network_policy.go
+++ b/pkg/policy/k8s/cluster_network_policy.go
@@ -14,9 +14,12 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	policytypes "github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 func (p *policyWatcher) addK8sClusterNetworkPolicy(k8sCNP *policyv1alpha2.ClusterNetworkPolicy, apiGroup string, dc chan uint64, clusterName string) error {
+	initialRecvTime := time.Now()
+
 	defer func() {
 		p.k8sResourceSynced.SetEventTimestamp(apiGroup)
 	}()
@@ -44,7 +47,8 @@ func (p *policyWatcher) addK8sClusterNetworkPolicy(k8sCNP *policyv1alpha2.Cluste
 			k8sCNP.ObjectMeta.Namespace,
 			k8sCNP.ObjectMeta.Name,
 		),
-		DoneChan: dc,
+		ProcessingStartTime: initialRecvTime,
+		DoneChan:            dc,
 	})
 
 	metrics.PolicyChangeTotal.WithLabelValues(string(source.Kubernetes), metrics.LabelValueUpdateOperation, metrics.LabelValueOutcomeSuccess).Inc()
@@ -57,6 +61,8 @@ func (p *policyWatcher) addK8sClusterNetworkPolicy(k8sCNP *policyv1alpha2.Cluste
 }
 
 func (p *policyWatcher) deleteK8sClusterNetworkPolicy(k8sCNP *policyv1alpha2.ClusterNetworkPolicy, apiGroup string, dc chan uint64) error {
+	initialRecvTime := time.Now()
+
 	defer func() {
 		p.k8sResourceSynced.SetEventTimestamp(apiGroup)
 	}()
@@ -77,7 +83,8 @@ func (p *policyWatcher) deleteK8sClusterNetworkPolicy(k8sCNP *policyv1alpha2.Clu
 			k8sCNP.ObjectMeta.Namespace,
 			k8sCNP.ObjectMeta.Name,
 		),
-		DoneChan: dc,
+		ProcessingStartTime: initialRecvTime,
+		DoneChan:            dc,
 	})
 
 	metrics.PolicyChangeTotal.WithLabelValues(string(source.Kubernetes), metrics.LabelValueDeleteOperation, metrics.LabelValueOutcomeSuccess).Inc()

--- a/pkg/policy/k8s/network_policy.go
+++ b/pkg/policy/k8s/network_policy.go
@@ -12,9 +12,12 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	policytypes "github.com/cilium/cilium/pkg/policy/types"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 func (p *policyWatcher) addK8sNetworkPolicyV1(k8sNP *slim_networkingv1.NetworkPolicy, apiGroup string, dc chan uint64, clusterName string) error {
+	initialRecvTime := time.Now()
+
 	defer func() {
 		p.k8sResourceSynced.SetEventTimestamp(apiGroup)
 	}()
@@ -42,7 +45,8 @@ func (p *policyWatcher) addK8sNetworkPolicyV1(k8sNP *slim_networkingv1.NetworkPo
 			k8sNP.ObjectMeta.Namespace,
 			k8sNP.ObjectMeta.Name,
 		),
-		DoneChan: dc,
+		ProcessingStartTime: initialRecvTime,
+		DoneChan:            dc,
 	})
 
 	metrics.PolicyChangeTotal.WithLabelValues(string(source.Kubernetes), metrics.LabelValueUpdateOperation, metrics.LabelValueOutcomeSuccess).Inc()
@@ -55,6 +59,8 @@ func (p *policyWatcher) addK8sNetworkPolicyV1(k8sNP *slim_networkingv1.NetworkPo
 }
 
 func (p *policyWatcher) deleteK8sNetworkPolicyV1(k8sNP *slim_networkingv1.NetworkPolicy, apiGroup string, dc chan uint64) error {
+	initialRecvTime := time.Now()
+
 	defer func() {
 		p.k8sResourceSynced.SetEventTimestamp(apiGroup)
 	}()
@@ -75,7 +81,8 @@ func (p *policyWatcher) deleteK8sNetworkPolicyV1(k8sNP *slim_networkingv1.Networ
 			k8sNP.ObjectMeta.Namespace,
 			k8sNP.ObjectMeta.Name,
 		),
-		DoneChan: dc,
+		ProcessingStartTime: initialRecvTime,
+		DoneChan:            dc,
 	})
 
 	metrics.PolicyChangeTotal.WithLabelValues(string(source.Kubernetes), metrics.LabelValueDeleteOperation, metrics.LabelValueOutcomeSuccess).Inc()


### PR DESCRIPTION
The policy importer only observes cilium_policy_implementation_delay when the
PolicyUpdate carries a ProcessingStartTime; processUpdates skips the histogram
when it is zero. The CiliumNetworkPolicy path sets it to the event receive
time, but the plain k8s NetworkPolicy add and delete handlers never did, so
cilium_policy_implementation_delay{source=k8s} is always empty and the time
between a NetworkPolicy change and its programming into the datapath is
invisible.

Capture the receive time on entry to the add and delete handlers and pass it
as ProcessingStartTime, mirroring the CiliumNetworkPolicy path. This only
populates a metric and does not change how or when policies are enforced.


