### PR TITLE
test/cyclonus: capture logs of every job pod so a runner crash is diagnosable

### DIFF
--- a/test/k8s/manifests/netpol-cyclonus/test-cyclonus.sh
+++ b/test/k8s/manifests/netpol-cyclonus/test-cyclonus.sh
@@ -14,7 +14,19 @@ set +e
 time kubectl wait --for=condition=complete --timeout=20m -n kube-system job.batch/cyclonus
 rc=$?
 
-# grab the job logs
+# Dump the logs of every pod that ever backed the job, current and previous
+# containers alike. A single "kubectl logs job.batch/cyclonus" only resolves to
+# one pod, so when the original runner crashes and the Job controller starts a
+# replacement, the crashed pod's output (e.g. a Go panic stack) is lost. Iterate
+# explicitly so a crash is always diagnosable.
+for pod in $(kubectl get pods -n kube-system -l job-name=cyclonus -o jsonpath='{.items[*].metadata.name}'); do
+    echo "===== logs for pod $pod ====="
+    kubectl logs -n kube-system "$pod" || true
+    echo "===== previous-container logs for pod $pod (if any) ====="
+    kubectl logs -n kube-system "$pod" --previous 2>/dev/null || true
+done
+
+# grab the job logs used for the pass/fail check below
 LOG_FILE=$(mktemp)
 kubectl logs -n kube-system job.batch/cyclonus > "$LOG_FILE"
 cat "$LOG_FILE"


### PR DESCRIPTION
When the cyclonus runner pod crashes mid-suite the Job controller starts a
replacement, and the single "kubectl logs job.batch/cyclonus" only resolves to
one of the pods, so the crashed pod's output is never collected. A recent run
timed out with the first pod in Error and no way to tell why, because its logs
were gone by the time we looked.

Before grabbing the job logs for the pass/fail check, iterate over every pod
that backed the job and dump its current and previous-container logs. This is
diagnostics only and does not change the test's pass/fail behaviour, so it
cannot hide a real failure; it just makes the next crash explainable.


