### PR TITLE
bugtool: collect softnet_stat, snmp and netstat for host packet drops

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -160,14 +160,19 @@ func defaultCommands(confDir string, cmdDir string) []string {
 	commands = append(commands, copyStateDirCommand(cmdDir)...)
 	commands = append(commands, tcInterfaceCommands()...)
 
-	// We want to collect this twice: at the very beginning and at the
+	// We want to collect these twice: at the very beginning and at the
 	// very end of the bugtool collection, to see if the counters are
 	// increasing.
 	// The commands end up being the names of the files where their output
 	// is stored, so we can't have the two commands be the exact same or the
 	// second would overwrite. To avoid that, we use the -u flag in this second
 	// command; that flag is documented as being ignored.
-	commands = append(commands, "cat -u /proc/net/xfrm_stat")
+	commands = append(commands,
+		"cat -u /proc/net/xfrm_stat",
+		"cat -u /proc/net/softnet_stat",
+		"cat -u /proc/net/snmp",
+		"cat -u /proc/net/netstat",
+	)
 
 	return commands
 }
@@ -178,6 +183,18 @@ func miscSystemCommands() []string {
 		// very end of the bugtool collection, to see if the counters are
 		// increasing.
 		"cat /proc/net/xfrm_stat",
+		// Host packet-drop counters, collected at the start and, via the -u
+		// variants in defaultCommands, at the end so the delta over the
+		// collection window is visible. softnet_stat is the only place a packet
+		// dropped before it reaches a netdev or socket queue is counted: column
+		// 2 is the per-CPU backlog drop count (netdev_max_backlog exceeded) and
+		// column 3 is time_squeeze (softirq ran out of budget, i.e. the CPU
+		// could not keep up). snmp and netstat add the IP/TCP layer drop
+		// counters (e.g. ListenDrops, ListenOverflows, TCPBacklogDrop) that tell
+		// a socket accept-queue drop apart from a backlog drop.
+		"cat /proc/net/softnet_stat",
+		"cat /proc/net/snmp",
+		"cat /proc/net/netstat",
 		// Host and misc
 		"ps auxfw",
 		"hostname",


### PR DESCRIPTION
Sysdumps currently can't tell you where a packet went when it leaves one node's datapath and never shows up on another node. We collect per-netdev and qdisc counters, but those only catch a drop at a device or a queue. A packet dropped in the per-CPU backlog before it reaches a netdev, or on a socket queue, doesn't show up anywhere.

I ran into this chasing the client-with-service-account-egress-to-echo-port-range/pod-to-pod curl exit 28 flake (#40813) on the Conformance L3-L4 only (ci-l3-l4) job, run 28933845818 job 85839595054 (misc-3, 6.6 kernel). The server's conntrack showed it sent the SYN,ACK and retransmitted it a few times, the client's conntrack for the same connection never recorded a single reply, and no Cilium drop, netdev drop or qdisc drop was non-zero on either node. That rules out the datapath but leaves the actual drop location unprovable, because /proc/net/softnet_stat isn't in the sysdump.

So collect it, together with /proc/net/snmp and /proc/net/netstat. The second column of softnet_stat is the backlog drop count and the third is time_squeeze, which increases when the softirq runs out of budget and the CPU can't drain the queue in time. snmp and netstat carry the IP and TCP drop counters (ListenDrops, ListenOverflows, TCPBacklogDrop) that tell a socket accept-queue drop apart from a backlog drop. These are cumulative counters, so collect them twice the same way we already do for xfrm_stat, once at the start and once at the end, so the delta across the collection window is visible.

Next time this flake shows up, diff the start and end softnet_stat of the affected node before blaming the datapath.

```release-note
Collect /proc/net/softnet_stat, /proc/net/snmp and /proc/net/netstat in sysdumps to help diagnose host-level packet drops.
```
