### PR TITLE
ipam/eni: Derive ENI primary address usage from CiliumNode spec

### DIFF
--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -14,7 +14,6 @@ cilium-operator-aws [flags]
       --aws-enable-prefix-delegation                               Allows operator to allocate prefixes to ENIs instead of individual IP addresses
       --aws-max-results-per-call int32                             Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
       --aws-release-excess-ips                                     Enable releasing excess free IP addresses from AWS ENI.
-      --aws-use-primary-address                                    Allows for using primary address of the ENI for allocations on the node
       --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -14,7 +14,6 @@ cilium-operator-aws hive [flags]
       --aws-enable-prefix-delegation                               Allows operator to allocate prefixes to ENIs instead of individual IP addresses
       --aws-max-results-per-call int32                             Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
       --aws-release-excess-ips                                     Enable releasing excess free IP addresses from AWS ENI.
-      --aws-use-primary-address                                    Allows for using primary address of the ENI for allocations on the node
       --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -20,7 +20,6 @@ cilium-operator-aws hive dot-graph [flags]
       --aws-enable-prefix-delegation                               Allows operator to allocate prefixes to ENIs instead of individual IP addresses
       --aws-max-results-per-call int32                             Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
       --aws-release-excess-ips                                     Enable releasing excess free IP addresses from AWS ENI.
-      --aws-use-primary-address                                    Allows for using primary address of the ENI for allocations on the node
       --ces-max-ciliumendpoints-per-ces int                        Maximum number of CiliumEndpoints allowed in a CES (default 100)
       --ces-rate-limits string                                     Configure rate limits for the CES controller. Accepts a list of rate limit configurations, must be a JSON formatted string. (default "[{\"nodes\":0,\"limit\":10,\"burst\":20}]")
       --cilium-endpoint-gc-interval duration                       GC interval for cilium endpoints (default 5m0s)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -17,7 +17,6 @@ cilium-operator [flags]
       --aws-enable-prefix-delegation                               Allows operator to allocate prefixes to ENIs instead of individual IP addresses
       --aws-max-results-per-call int32                             Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
       --aws-release-excess-ips                                     Enable releasing excess free IP addresses from AWS ENI.
-      --aws-use-primary-address                                    Allows for using primary address of the ENI for allocations on the node
       --azure-resource-group string                                Resource group containing the cluster nodes, defaults to cilium operator's own resource group retrieved via Azure Instance Metadata Service (IMDS)
       --azure-subscription-id string                               Subscription ID to access Azure API
       --azure-use-primary-address                                  Use Azure IP address from interface's primary IPConfigurations

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -17,7 +17,6 @@ cilium-operator hive [flags]
       --aws-enable-prefix-delegation                               Allows operator to allocate prefixes to ENIs instead of individual IP addresses
       --aws-max-results-per-call int32                             Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
       --aws-release-excess-ips                                     Enable releasing excess free IP addresses from AWS ENI.
-      --aws-use-primary-address                                    Allows for using primary address of the ENI for allocations on the node
       --azure-resource-group string                                Resource group containing the cluster nodes, defaults to cilium operator's own resource group retrieved via Azure Instance Metadata Service (IMDS)
       --azure-subscription-id string                               Subscription ID to access Azure API
       --azure-use-primary-address                                  Use Azure IP address from interface's primary IPConfigurations

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -23,7 +23,6 @@ cilium-operator hive dot-graph [flags]
       --aws-enable-prefix-delegation                               Allows operator to allocate prefixes to ENIs instead of individual IP addresses
       --aws-max-results-per-call int32                             Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests
       --aws-release-excess-ips                                     Enable releasing excess free IP addresses from AWS ENI.
-      --aws-use-primary-address                                    Allows for using primary address of the ENI for allocations on the node
       --azure-resource-group string                                Resource group containing the cluster nodes, defaults to cilium operator's own resource group retrieved via Azure Instance Metadata Service (IMDS)
       --azure-subscription-id string                               Subscription ID to access Azure API
       --azure-use-primary-address                                  Use Azure IP address from interface's primary IPConfigurations

--- a/Documentation/operations/upgrade-next.inc
+++ b/Documentation/operations/upgrade-next.inc
@@ -52,7 +52,17 @@ Removed Options
 The following options were previously deprecated, and they are now removed
 from Cilium.
 
-* TODO
+* The ``--aws-use-primary-address`` operator flag has been removed. Whether an
+  ENI's primary IP is available for pod allocation is now determined per node by
+  the ``spec.eni.use-primary-address`` field of the ``CiliumNode`` resource,
+  which is populated from the ``--eni-use-primary-address`` agent flag (Helm
+  value ``eni.nodeSpec.usePrimaryAddress``). This makes the CiliumNode spec the
+  single source of truth and removes the possibility of the operator-wide flag
+  disagreeing with the per-node value. Deployments configured through the Helm
+  chart are unaffected, as the chart only ever wired the agent-side value. If
+  you passed ``--aws-use-primary-address`` directly on the operator, set
+  ``eni.nodeSpec.usePrimaryAddress=true`` (equivalently, the
+  ``--eni-use-primary-address`` agent flag) instead to retain the same behavior.
 
 Changes to Metrics
 ~~~~~~~~~~~~~~~~~~

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -458,6 +458,18 @@ from Cilium.
   these secrets outside of the Cilium Helm chart when setting
   ``clustermesh.apiserver.tls.auto.enabled=false``.
 
+* The ``--aws-use-primary-address`` operator flag has been removed. Whether an
+  ENI's primary IP is available for pod allocation is now determined per node by
+  the ``spec.eni.use-primary-address`` field of the ``CiliumNode`` resource,
+  which is populated from the ``--eni-use-primary-address`` agent flag (Helm
+  value ``eni.nodeSpec.usePrimaryAddress``). This makes the CiliumNode spec the
+  single source of truth and removes the possibility of the operator-wide flag
+  disagreeing with the per-node value. Deployments configured through the Helm
+  chart are unaffected, as the chart only ever wired the agent-side value. If
+  you passed ``--aws-use-primary-address`` directly on the operator, set
+  ``eni.nodeSpec.usePrimaryAddress=true`` (equivalently, the
+  ``--eni-use-primary-address`` agent flag) instead to retain the same behavior.
+
 Changes to Metrics
 ~~~~~~~~~~~~~~~~~~
 

--- a/operator/pkg/ipam/allocator/aws/aws.go
+++ b/operator/pkg/ipam/allocator/aws/aws.go
@@ -33,7 +33,6 @@ type AllocatorAWS struct {
 	ENITags                      map[string]string
 	ENIGarbageCollectionTags     map[string]string
 	ENIGarbageCollectionInterval time.Duration
-	AWSUsePrimaryAddress         bool
 	EC2APIEndpoint               string
 	AWSMaxResultsPerCall         int32
 	SubnetsIDs                   []string
@@ -117,8 +116,7 @@ func (a *AllocatorAWS) Init(ctx context.Context, logger *slog.Logger) error {
 	}
 
 	a.client = api.NewClient(a.rootLogger, ec2.NewFromConfig(cfg, optionsFunc), a.AWSMetrics, a.LimitIPAMAPIQPS,
-		a.LimitIPAMAPIBurst, subnetsFilters, instancesFilters, eniCreationTags,
-		a.AWSUsePrimaryAddress, a.AWSMaxResultsPerCall)
+		a.LimitIPAMAPIBurst, subnetsFilters, instancesFilters, eniCreationTags, a.AWSMaxResultsPerCall)
 
 	return nil
 }

--- a/operator/pkg/ipam/aws.go
+++ b/operator/pkg/ipam/aws.go
@@ -40,7 +40,6 @@ type AWSConfig struct {
 	ENITags                      map[string]string
 	ENIGarbageCollectionTags     map[string]string `mapstructure:"eni-gc-tags"`
 	ENIGarbageCollectionInterval time.Duration     `mapstructure:"eni-gc-interval"`
-	AWSUsePrimaryAddress         bool
 	EC2APIEndpoint               string
 	AWSMaxResultsPerCall         int32
 	IPAMSubnetsIDs               []string          `mapstructure:"subnet-ids-filter"`
@@ -54,7 +53,6 @@ var awsDefaultConfig = AWSConfig{
 	ENITags:                      nil,
 	ENIGarbageCollectionTags:     nil,
 	ENIGarbageCollectionInterval: 5 * time.Minute,
-	AWSUsePrimaryAddress:         false,
 	EC2APIEndpoint:               "",
 	AWSMaxResultsPerCall:         0,
 	IPAMSubnetsIDs:               nil,
@@ -71,7 +69,6 @@ func (cfg AWSConfig) Flags(flags *pflag.FlagSet) {
 		"Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected")
 	flags.Duration("eni-gc-interval", awsDefaultConfig.ENIGarbageCollectionInterval,
 		"Interval for garbage collection of unattached ENIs. Set to 0 to disable")
-	flags.Bool("aws-use-primary-address", awsDefaultConfig.AWSUsePrimaryAddress, "Allows for using primary address of the ENI for allocations on the node")
 	flags.String("ec2-api-endpoint", awsDefaultConfig.EC2APIEndpoint, "AWS API endpoint for the EC2 service")
 	flags.Int32("aws-max-results-per-call", awsDefaultConfig.AWSMaxResultsPerCall, "Maximum results per AWS API call for DescribeNetworkInterfaces and DescribeSecurityGroups. Set to 0 to let AWS determine optimal page size (default). If set to 0 and AWS returns OperationNotPermitted errors, automatically switches to 1000 for all future requests")
 	flags.StringSlice("subnet-ids-filter", awsDefaultConfig.IPAMSubnetsIDs, "Subnets IDs (separated by commas)")
@@ -103,7 +100,6 @@ func startAWSAllocator(p awsParams) {
 		ENITags:                      p.AwsCfg.ENITags,
 		ENIGarbageCollectionTags:     p.AwsCfg.ENIGarbageCollectionTags,
 		ENIGarbageCollectionInterval: p.AwsCfg.ENIGarbageCollectionInterval,
-		AWSUsePrimaryAddress:         p.AwsCfg.AWSUsePrimaryAddress,
 		EC2APIEndpoint:               p.AwsCfg.EC2APIEndpoint,
 		AWSMaxResultsPerCall:         p.AwsCfg.AWSMaxResultsPerCall,
 		SubnetsIDs:                   p.AwsCfg.IPAMSubnetsIDs,

--- a/pkg/aws/api/api.go
+++ b/pkg/aws/api/api.go
@@ -77,7 +77,6 @@ type Client struct {
 	routeTableFilters   []ec2_types.Filter
 	instancesFilters    []ec2_types.Filter
 	eniTagSpecification ec2_types.TagSpecification
-	usePrimary          bool
 	maxResultsPerCall   int32 // Maximum results per API call; 0 means let AWS decide
 }
 
@@ -88,7 +87,7 @@ type MetricsAPI interface {
 }
 
 // NewClient returns a new EC2 client
-func NewClient(logger *slog.Logger, ec2Client *ec2.Client, metrics MetricsAPI, rateLimit float64, burst int, subnetsFilters, instancesFilters []ec2_types.Filter, eniTags map[string]string, usePrimary bool, maxResultsPerCall int32) *Client {
+func NewClient(logger *slog.Logger, ec2Client *ec2.Client, metrics MetricsAPI, rateLimit float64, burst int, subnetsFilters, instancesFilters []ec2_types.Filter, eniTags map[string]string, maxResultsPerCall int32) *Client {
 	eniTagSpecification := ec2_types.TagSpecification{
 		ResourceType: ec2_types.ResourceTypeNetworkInterface,
 		Tags:         createAWSTagSlice(eniTags),
@@ -102,7 +101,6 @@ func NewClient(logger *slog.Logger, ec2Client *ec2.Client, metrics MetricsAPI, r
 		subnetsFilters:      subnetsFilters,
 		instancesFilters:    instancesFilters,
 		eniTagSpecification: eniTagSpecification,
-		usePrimary:          usePrimary,
 		maxResultsPerCall:   maxResultsPerCall,
 	}
 }
@@ -460,7 +458,7 @@ retry:
 // Returns an error on any malformed IP/CIDR string. AWS uses string pointers
 // for these fields, so unset values are nil and any non-nil string is expected
 // to be a valid IP or CIDR.
-func parseENI(iface *ec2_types.NetworkInterface, vpcs ipamTypes.VirtualNetworkMap, subnets ipamTypes.SubnetMap, usePrimary bool) (instanceID string, eni *types.ENI, err error) {
+func parseENI(iface *ec2_types.NetworkInterface, vpcs ipamTypes.VirtualNetworkMap, subnets ipamTypes.SubnetMap) (instanceID string, eni *types.ENI, err error) {
 	if iface.PrivateIpAddress == nil {
 		return "", nil, fmt.Errorf("ENI has no IP address")
 	}
@@ -521,9 +519,11 @@ func parseENI(iface *ec2_types.NetworkInterface, vpcs ipamTypes.VirtualNetworkMa
 	}
 
 	for _, ip := range iface.PrivateIpAddresses {
-		if !usePrimary && ip.Primary != nil && aws.ToBool(ip.Primary) {
-			continue
-		}
+		// The primary address is always included here. Whether it is
+		// available for allocation is decided per-node by the IPAM node
+		// layer based on CiliumNode Spec.ENI.UsePrimaryAddress, since the
+		// EC2 inventory is shared across all nodes and has no per-node
+		// context.
 		if ip.PrivateIpAddress != nil {
 			a, err := netip.ParseAddr(aws.ToString(ip.PrivateIpAddress))
 			if err != nil {
@@ -603,7 +603,7 @@ func (c *Client) GetInstance(ctx context.Context, vpcs ipamTypes.VirtualNetworkM
 
 	for _, iface := range networkInterfaces {
 		ifId := *iface.NetworkInterfaceId
-		_, eni, err := parseENI(&iface, vpcs, subnets, c.usePrimary)
+		_, eni, err := parseENI(&iface, vpcs, subnets)
 		if err != nil {
 			return nil, err
 		}
@@ -631,7 +631,7 @@ func (c *Client) GetInstances(ctx context.Context, vpcs ipamTypes.VirtualNetwork
 	}
 
 	for _, iface := range networkInterfaces {
-		id, eni, err := parseENI(&iface, vpcs, subnets, c.usePrimary)
+		id, eni, err := parseENI(&iface, vpcs, subnets)
 		if err != nil {
 			return nil, err
 		}
@@ -856,7 +856,7 @@ func (c *Client) CreateNetworkInterface(ctx context.Context, toAllocate int32, s
 		return "", nil, err
 	}
 
-	_, eni, err := parseENI(output.NetworkInterface, nil, nil, c.usePrimary)
+	_, eni, err := parseENI(output.NetworkInterface, nil, nil)
 	if err != nil {
 		// The error is ignored on purpose. The allocation itself has
 		// succeeded. The ability to parse and return the ENI

--- a/pkg/aws/api/api_test.go
+++ b/pkg/aws/api/api_test.go
@@ -184,7 +184,7 @@ func TestParseENIPublicIP(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, eni, err := parseENI(newIface(tt.assoc), nil, nil, false)
+			_, eni, err := parseENI(newIface(tt.assoc), nil, nil)
 			require.NoError(t, err)
 			require.NotNil(t, eni)
 			assert.Equal(t, tt.wantValidPubIP, eni.PublicIP.IsValid())

--- a/pkg/aws/ipam/node.go
+++ b/pkg/aws/ipam/node.go
@@ -111,14 +111,14 @@ func (n *Node) updateLogger() {
 func (n *Node) PopulateStatusFields(k8sObj *v2.CiliumNode) {
 	k8sObj.Status.ENI.ENIs = map[string]types.ENI{}
 
-	n.manager.ForeachInstance(n.node.InstanceID(),
-		func(instanceID, interfaceID string, iface ipamTypes.Interface) error {
-			e, ok := iface.(*types.ENI)
-			if ok {
-				k8sObj.Status.ENI.ENIs[interfaceID] = *e.DeepCopy()
-			}
-			return nil
-		})
+	n.mutex.RLock()
+	usePrimary := n.usePrimaryAddress()
+	n.mutex.RUnlock()
+
+	n.foreachENI(usePrimary, func(e *types.ENI) error {
+		k8sObj.Status.ENI.ENIs[e.ID] = *e.DeepCopy()
+		return nil
+	})
 }
 
 // getLimits returns the interface and IP limits of this node
@@ -139,6 +139,45 @@ func (n *Node) getLimitsLocked() (ipamTypes.Limits, bool) {
 		)
 	}
 	return limit, ok
+}
+
+// usePrimaryAddress reports whether this node's ENIs should expose their
+// primary IP as available for allocation, per the CiliumNode spec. It assumes
+// n.mutex is at least read locked, as it reads n.k8sObj.
+func (n *Node) usePrimaryAddress() bool {
+	return n.k8sObj.Spec.ENI.UsePrimaryAddress != nil && *n.k8sObj.Spec.ENI.UsePrimaryAddress
+}
+
+// foreachENI iterates over the ENIs attached to this node's instance, applying
+// the per-node primary-address policy before handing each ENI to fn.
+//
+// The EC2 inventory is shared across all nodes and always includes an ENI's
+// primary IP in its address list (see parseENI). Whether that primary IP is
+// available for allocation is a per-node decision driven by
+// Spec.ENI.UsePrimaryAddress, which is only known here. When usePrimary is
+// false, the primary IP is stripped from the ENI's Addresses so that no
+// downstream consumer treats it as allocatable.
+//
+// fn receives a shallow copy of the inventory ENI whose Addresses slice is
+// freshly allocated when filtering; the shared inventory is never mutated.
+// This method does not take n.mutex; callers pass usePrimary computed under
+// the appropriate lock.
+func (n *Node) foreachENI(usePrimary bool, fn func(e *types.ENI) error) {
+	n.manager.ForeachInstance(n.node.InstanceID(),
+		func(_, _ string, iface ipamTypes.Interface) error {
+			e, ok := iface.(*types.ENI)
+			if !ok {
+				return nil
+			}
+
+			eni := *e
+			if !usePrimary {
+				eni.Addresses = slices.DeleteFunc(slices.Clone(e.Addresses),
+					func(a iputil.Addr) bool { return a.Addr == e.IP.Addr })
+			}
+
+			return fn(&eni)
+		})
 }
 
 // PrepareIPRelease prepares the release of ENI IPs.
@@ -870,9 +909,6 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *slog.Logge
 		return nil, stats, nodemanager.ErrLimitsNotFound
 	}
 
-	// n.node does not need to be protected by n.mutex as it is only written to
-	// upon creation of `n`
-	instanceID := n.node.InstanceID()
 	available = ipamTypes.AllocationMap{}
 
 	n.mutex.Lock()
@@ -891,13 +927,8 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *slog.Logge
 	// * Any excluded interfaces will be subtracted from this total.
 	stats.NodeCapacity *= limits.Adapters
 
-	n.manager.ForeachInstance(instanceID,
-		func(instanceID, interfaceID string, iface ipamTypes.Interface) error {
-			e, ok := iface.(*types.ENI)
-			if !ok {
-				return nil
-			}
-
+	n.foreachENI(n.usePrimaryAddress(),
+		func(e *types.ENI) error {
 			n.enis[e.ID] = *e
 
 			// Check for public IP on primary ENI before exclusion logic
@@ -1103,7 +1134,7 @@ func (n *Node) getEffectiveIPLimits(eni *types.ENI, limits int) (leftoverPrefixC
 	effectiveLimits = limits - 1
 
 	// Include the primary IP when UsePrimaryAddress is set to true on ENI spec.
-	if n.k8sObj.Spec.ENI.UsePrimaryAddress != nil && *n.k8sObj.Spec.ENI.UsePrimaryAddress {
+	if n.usePrimaryAddress() {
 		effectiveLimits++
 	}
 

--- a/pkg/aws/ipam/node_primary_address_test.go
+++ b/pkg/aws/ipam/node_primary_address_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipam
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/aws/types"
+	iputil "github.com/cilium/cilium/pkg/ip"
+	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
+)
+
+// TestForeachENIPrimaryAddressFiltering verifies that the per-node primary
+// address policy is applied when iterating the shared EC2 inventory: the
+// primary IP is stripped from an ENI's Addresses unless
+// Spec.ENI.UsePrimaryAddress is set. The shared inventory itself must never be
+// mutated by the filtering.
+func TestForeachENIPrimaryAddressFiltering(t *testing.T) {
+	instanceID := "i-000"
+	primary := netip.MustParseAddr("10.0.0.1")
+	secondary := netip.MustParseAddr("10.0.0.2")
+
+	im := ipamTypes.NewInstanceMap()
+	im.Update(instanceID, &types.ENI{
+		ID: "eni-1",
+		IP: iputil.AddrFrom(primary),
+		Addresses: []iputil.Addr{
+			iputil.AddrFrom(primary),
+			iputil.AddrFrom(secondary),
+		},
+	})
+
+	n := &Node{
+		node:    &mockIPAMNode{instanceID: instanceID},
+		k8sObj:  newCiliumNode("node1"),
+		manager: &InstancesManager{instances: im},
+	}
+
+	collect := func(usePrimary bool) []netip.Addr {
+		var got []netip.Addr
+		n.foreachENI(usePrimary, func(e *types.ENI) error {
+			for _, a := range e.Addresses {
+				got = append(got, a.Addr)
+			}
+			return nil
+		})
+		return got
+	}
+
+	// UsePrimaryAddress disabled: the primary IP is not available for allocation.
+	assert.ElementsMatch(t, []netip.Addr{secondary}, collect(false))
+
+	// UsePrimaryAddress enabled: the primary IP is available for allocation.
+	assert.ElementsMatch(t, []netip.Addr{primary, secondary}, collect(true))
+
+	// Filtering must not mutate the shared inventory (ForeachInterface hands
+	// out live data; foreachENI must operate on a fresh slice).
+	iface, ok := im.GetInterface(instanceID, "eni-1")
+	require.True(t, ok)
+	eni, ok := iface.(*types.ENI)
+	require.True(t, ok)
+	assert.Len(t, eni.Addresses, 2, "shared inventory must retain the primary address")
+}
+
+// TestUsePrimaryAddress verifies the spec-backed accessor.
+func TestUsePrimaryAddress(t *testing.T) {
+	enabled := true
+	disabled := false
+
+	tests := []struct {
+		name string
+		spec *bool
+		want bool
+	}{
+		{name: "unset defaults to false", spec: nil, want: false},
+		{name: "explicitly false", spec: &disabled, want: false},
+		{name: "explicitly true", spec: &enabled, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cn := newCiliumNode("node1")
+			cn.Spec.ENI.UsePrimaryAddress = tt.spec
+			n := &Node{k8sObj: cn}
+			assert.Equal(t, tt.want, n.usePrimaryAddress())
+		})
+	}
+}


### PR DESCRIPTION
There are two separate flags controlling whether an ENI's primary IP is available for pod allocation today: the operator flag `--aws-use-primary-address` and the agent flag
`--eni-use-primary-address`. They are two halves of one feature and must agree, but nothing enforces that:
* The operator flag is consumed at the shared EC2 inventory layer (in `parseENI`), globally filtering the primary IP out of every ENI's address pool for all nodes at once.
* The agent flag is serialized per node into `spec.eni.use-primary-address`, which the operator then reads back in `getEffectiveIPLimits` to add +1 to the effective IP limit.

The invariant is "primary present in eni.Addresses <=> +1 in effective limits". Because the two settings are independent, they can disagree and break it. Worse, the Helm chart only configures the agent flag (`eni.nodeSpec.usePrimaryAddress` -> ``--eni-use-primary-address``). The operator flag is never templated and defaults to false. So a user attempting to enable primary-address usage via Helm will always get an inconsistent state: the operator strips the primary from the allocatable pool while still counting it in the limit, off by one per ENI.

The root cause is a layer mismatch: primary-address usage is a per-node policy, but it is being applied at a node-agnostic, cluster-wide layer that has no CiliumNode context.

This PR fixes this by making `spec.eni.use-primary-address` the single source of truth. `parseENI` now always includes the primary IP in the inventory (raw AWS truth), and the per-node filtering moves to the Node layer, where the spec is available, via a `foreachENI` helper that both `ResyncInterfacesAndIPs` and `PopulateStatusFields` iterate through. The helper strips the primary from a freshly cloned `Addresses` slice when the spec is not set, so the shared inventory is never mutated.

The now-redundant `--aws-use-primary-address` operator flag is removed. Deployments using the Helm chart are unaffected (the chart only ever set the agent flag) and in fact now behave consistently. Operators that passed the flag directly must set `eni.nodeSpec.usePrimaryAddress=true` (equivalently `--eni-use-primary-address`) instead.
