### PR TITLE
egressgw: add script testing for sysctl

### DIFF
--- a/pkg/egressgateway/testdata/test.txtar
+++ b/pkg/egressgateway/testdata/test.txtar
@@ -13,6 +13,9 @@ db/insert devices device-eth0.yaml device-eth1.yaml
  egress/policy-maps-dump policymap.actual
  * cmp policymap.actual policymap.expected.1
 
+db/show sysctl --columns Name,Value
+db/cmp --timeout=10s sysctl sysctl.expected.1
+
 # Update the `interface` field in the CEGP, and validate that this is reflected in the agent state.
 # This also covers the support for interface altnames.
  cp policy1.yaml policy1_2.yaml
@@ -23,12 +26,22 @@ db/insert devices device-eth0.yaml device-eth1.yaml
  egress/policy-maps-dump policymap.actual
  * cmp policymap.actual policymap.expected.2
 
+db/show sysctl --columns Name,Value
+db/cmp --timeout=10s sysctl sysctl.expected.2
+
 -- policymap.expected.1 --
 source_ip=10.244.3.91 dest_cidr=0.0.0.0 egress_ip=10.10.0.1 egress_ifindex=1 gateway_ip=172.18.0.3
 source_ip=fd00:10:244:3::9c94 dest_cidr=:: egress_ip=fd00::10:10:0:1 egress_ifindex=1 gateway_ip=172.18.0.3
+-- sysctl.expected.1 --
+Name                               Value
+net.ipv4.conf.eth0.rp_filter       2
 -- policymap.expected.2 --
 source_ip=10.244.3.91 dest_cidr=0.0.0.0 egress_ip=10.10.0.2 egress_ifindex=2 gateway_ip=172.18.0.3
 source_ip=fd00:10:244:3::9c94 dest_cidr=:: egress_ip=fd00::10:10:0:2 egress_ifindex=2 gateway_ip=172.18.0.3
+-- sysctl.expected.2 --
+Name                               Value
+net.ipv4.conf.eth0.rp_filter       2
+net.ipv4.conf.eth1-alt.rp_filter   2
 -- node1.yaml --
 apiVersion: v1
 kind: Node

--- a/pkg/egressgateway/testdata/test_egressip.txtar
+++ b/pkg/egressgateway/testdata/test_egressip.txtar
@@ -13,6 +13,9 @@ db/insert devices device-eth0.yaml device-eth1.yaml
  egress/policy-maps-dump policymap.actual
  * cmp policymap.actual policymap.expected.1
 
+db/show sysctl --columns Name,Value
+db/cmp --timeout=10s sysctl sysctl.expected.1
+
 # Update the `egressIP` field in the CEGP, and validate that this is reflected in the agent state.
  cp policy1.yaml policy1_2.yaml
  sed '    egressIP: 10.10.0.1' '    egressIP: fd00::10:10:0:2' policy1_2.yaml
@@ -22,12 +25,22 @@ db/insert devices device-eth0.yaml device-eth1.yaml
  egress/policy-maps-dump policymap.actual
  * cmp policymap.actual policymap.expected.2
 
+db/show sysctl --columns Name,Value
+db/cmp --timeout=10s sysctl sysctl.expected.2
+
 -- policymap.expected.1 --
 source_ip=10.244.3.91 dest_cidr=0.0.0.0 egress_ip=10.10.0.1 egress_ifindex=0 gateway_ip=172.18.0.3
 source_ip=fd00:10:244:3::9c94 dest_cidr=:: egress_ip=fd00::10:10:0:1 egress_ifindex=0 gateway_ip=172.18.0.3
+-- sysctl.expected.1 --
+Name                               Value
+net.ipv4.conf.eth0.rp_filter       2
 -- policymap.expected.2 --
 source_ip=10.244.3.91 dest_cidr=0.0.0.0 egress_ip=10.10.0.2 egress_ifindex=0 gateway_ip=172.18.0.3
 source_ip=fd00:10:244:3::9c94 dest_cidr=:: egress_ip=fd00::10:10:0:2 egress_ifindex=0 gateway_ip=172.18.0.3
+-- sysctl.expected.2 --
+Name                               Value
+net.ipv4.conf.eth0.rp_filter       2
+net.ipv4.conf.eth1.rp_filter       2
 -- node1.yaml --
 apiVersion: v1
 kind: Node


### PR DESCRIPTION
The egressgw manager sets the rp_filter sysctl for interfaces selected by an CEGP. Assert this in the script tests.

Note that there's currently some limitations in this functionality:
* when a CEGP selects a different interface, we're not rolling back the rp_filter setting on the old interface
* when the CEGP uses the `interface` selector and specifies an interface altname, we don't translate this to the actual interface name