### PR TITLE
gha: stop scheduled runs emitting spurious artifact warnings

### DIFF
--- a/.github/workflows/common-post-jobs.yaml
+++ b/.github/workflows/common-post-jobs.yaml
@@ -17,6 +17,11 @@ on:
         required: false
         type: boolean
         default: true
+      merge-junits:
+        description: "Whether to merge and upload cilium-junits-* artifacts. Set to false for workflows that do not run cilium connectivity test and therefore produce no JUnit report (e.g. kubectl-wait smoke tests)."
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -39,6 +44,7 @@ jobs:
           persist-credentials: false
 
       - name: Merge JUnits
+        if: ${{ inputs.merge-junits }}
         uses: ./.github/actions/merge-artifacts
         with:
           name: cilium-junits

--- a/.github/workflows/common-post-jobs.yaml
+++ b/.github/workflows/common-post-jobs.yaml
@@ -12,6 +12,11 @@ on:
       success:
         required: true
         type: boolean
+      merge-artifacts:
+        description: "Whether to merge and upload cilium-junits-*/features-tested-* artifacts. Set to false for workflows that run no tests and produce no such artifacts (e.g. pure lint jobs)."
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -20,7 +25,7 @@ permissions:
 
 jobs:
   merge-upload:
-    if: ${{ always() }}
+    if: ${{ always() && inputs.merge-artifacts }}
     name: Merge and Upload Artifacts
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -583,6 +583,7 @@ jobs:
           --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
 
       - name: Features tested
+        if: ${{ always() && steps.install-cilium.outcome == 'success' }}
         uses: ./.github/actions/feature-status
         with:
           title: "Summary of all features tested"

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -420,7 +420,14 @@ jobs:
         with:
           artifacts_suffix: "${{ env.job_name }} (${{ join(matrix.*, ', ') }})"
           job_status: "${{ job.status }}"
-          capture_features_tested: ${{ steps.run-tests.outcome != 'skipped' }}
+          # Cilium runs on the runner host against a live kind cluster, so its
+          # feature status can be captured whenever Cilium installed
+          # successfully. Do not gate feature capture on the basic CLI test
+          # outcome: when the Gateway API conformance test fails or times out
+          # the basic CLI test is skipped, but the cluster is still healthy and
+          # its features must still be collected so features-tested-*.json
+          # exists on every leg.
+          capture_features_tested: ${{ steps.install-cilium.outcome == 'success' }}
 
   merge-upload-and-status:
     name: Merge Upload and Status

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -447,11 +447,14 @@ jobs:
         id: run-tests
         shell: bash
         run: |
+          mkdir -p cilium-junits
           cilium connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
             --log-code-owners --code-owners=${CILIUM_CLI_CODE_OWNERS_PATHS} \
             --exclude-code-owners=${CILIUM_CLI_EXCLUDE_OWNERS} \
             --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
             --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
+            --junit-file "cilium-junits/${{ env.job_name }} ${{ matrix.name }}.xml" \
+            --junit-property github_job_step="Run basic CLI tests" \
             --test 'packet-drops'
 
       - name: Run common post steps
@@ -460,7 +463,7 @@ jobs:
         with:
           artifacts_suffix: "${{ env.job_name }} ${{ matrix.name }}"
           job_status: "${{ job.status }}"
-          capture_features_tested: ${{ steps.run-tests.outcome != 'skipped' }}
+          capture_features_tested: ${{ steps.install-cilium.outcome == 'success' }}
 
   merge-upload-and-status:
     name: Merge Upload and Status

--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -242,6 +242,7 @@ jobs:
             --junit-file "cilium-junits/${{ env.job_name }}.xml" --junit-property github_job_step="Run connectivity test"
 
       - name: Features tested
+        if: ${{ always() && steps.install-cilium.outcome == 'success' }}
         uses: ./.github/actions/feature-status
         with:
           title: "Summary of all features tested"
@@ -270,6 +271,7 @@ jobs:
             --test="l7|sni|check-log-errors"
 
       - name: Features tested
+        if: ${{ always() && steps.install-cilium-secret-sync-disabled.outcome == 'success' }}
         uses: ./.github/actions/feature-status
         with:
           title: "Summary of all features tested"

--- a/.github/workflows/fqdn-perf.yaml
+++ b/.github/workflows/fqdn-perf.yaml
@@ -295,7 +295,7 @@ jobs:
         uses: ./.github/actions/post-logic
         with:
           job_status: "${{ job.status }}"
-          junits-directory: 'report'
+          junits-directory: 'perf-tests/clusterloader2/report'
           always_capture_sysdump: true
           artifacts_suffix: "final"
           capture_features_tested: ${{ steps.run-cl2.outcome != 'skipped' }}

--- a/.github/workflows/l7-perf.yaml
+++ b/.github/workflows/l7-perf.yaml
@@ -513,7 +513,7 @@ jobs:
         with:
           artifacts_suffix: "final-${{ matrix.test_type }}"
           job_status: "${{ job.status }}"
-          junits-directory: 'report'
+          junits-directory: 'perf-tests/clusterloader2/report'
           capture_sysdump: 'false'
           capture_features_tested: 'false'
 

--- a/.github/workflows/lint-images-base.yaml
+++ b/.github/workflows/lint-images-base.yaml
@@ -115,3 +115,7 @@ jobs:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
       success: ${{ needs.lint.result == 'success' }}
+      # This is a pure lint job: it runs no tests and installs no Cilium, so it
+      # never produces cilium-junits-*/features-tested-* artifacts. Skip the
+      # artifact merge to avoid spurious "No matching artifacts found" warnings.
+      merge-artifacts: false

--- a/.github/workflows/scale-test-egw.yaml
+++ b/.github/workflows/scale-test-egw.yaml
@@ -610,7 +610,7 @@ jobs:
         with:
           artifacts_suffix: "final-${{ matrix.test_type }}"
           job_status: "${{ job.status }}"
-          junits-directory: 'report'
+          junits-directory: 'perf-tests/clusterloader2/report'
           capture_sysdump: 'false'
           capture_features_tested: ${{ steps.run-cl2.outcome != 'skipped' }}
 

--- a/.github/workflows/scale-test-node-throughput-gce.yaml
+++ b/.github/workflows/scale-test-node-throughput-gce.yaml
@@ -235,7 +235,7 @@ jobs:
           always_capture_sysdump: true
           artifacts_suffix: "final"
           job_status: "${{ job.status }}"
-          junits-directory: 'report'
+          junits-directory: 'perf-tests/clusterloader2/report'
           capture_features_tested: ${{ steps.run-cl2.outcome != 'skipped' }}
 
       - name: Cleanup cluster

--- a/.github/workflows/tests-smoke-conformance.yaml
+++ b/.github/workflows/tests-smoke-conformance.yaml
@@ -263,3 +263,7 @@ jobs:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
       success: ${{ needs.conformance-test.result == 'success' }}
+      # This job runs a kubectl-based connectivity check rather than cilium
+      # connectivity test, so it produces no JUnit report. Skip the junit merge
+      # to avoid a spurious "No matching cilium-junits-* artifacts found" warning.
+      merge-junits: false

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -222,3 +222,7 @@ jobs:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
       success: ${{ needs.conformance-test-ipv6.result != 'failure' }}
+      # This job runs a kubectl-based connectivity check rather than cilium
+      # connectivity test, so it produces no JUnit report. Skip the junit merge
+      # to avoid a spurious "No matching cilium-junits-* artifacts found" warning.
+      merge-junits: false


### PR DESCRIPTION
Scheduled runs on main emit spurious warning annotations because several jobs
never produce the JUnit or feature-status artifacts that the common post steps
try to upload and merge. Each commit fixes the producer so the artifact is
actually generated, rather than silencing the warning.
