### PR TITLE
cli/connectivity: always write a JUnit report, including on early failures

### DIFF
--- a/cilium-cli/connectivity/check/junit.go
+++ b/cilium-cli/connectivity/check/junit.go
@@ -115,6 +115,32 @@ func (j *JUnitCollector) Collect(ct *ConnectivityTest) {
 	}
 }
 
+// CollectFailure records a synthetic failed test case describing an error that
+// aborted the suite before any test produced a result (e.g. a failure during
+// the setup/validation phase). It is a no-op when no JUnit file is configured,
+// when err is nil, or when real test results have already been collected (so a
+// normal test-failure report is never polluted). This guarantees a non-empty
+// JUnit report is written even when the run fails early, so CI always has a
+// cilium-junits artifact to upload.
+func (j *JUnitCollector) CollectFailure(name string, err error) {
+	if j.junitFile == "" || err == nil || j.testSuite.Tests > 0 {
+		return
+	}
+
+	j.testSuite.TestCases = append(j.testSuite.TestCases, &junit.TestCase{
+		Name:      name,
+		Classname: "connectivity test",
+		Status:    "failed",
+		Failure: &junit.Failure{
+			Message: name + " failed",
+			Type:    "failure",
+			Value:   err.Error(),
+		},
+	})
+	j.testSuite.Tests++
+	j.testSuite.Failures++
+}
+
 // Write writes collected JUnit results into a single report file.
 //
 // The report is written to a temporary file in the same directory and then

--- a/cilium-cli/connectivity/suite.go
+++ b/cilium-cli/connectivity/suite.go
@@ -19,7 +19,7 @@ type Hooks interface {
 	AddConnectivityTests(cts ...*check.ConnectivityTest) error
 }
 
-func Run(ctx context.Context, connTests []*check.ConnectivityTest, extra Hooks) error {
+func Run(ctx context.Context, connTests []*check.ConnectivityTest, extra Hooks) (err error) {
 	// If cleanup-only mode is enabled, perform cleanup and return
 	if len(connTests) > 0 && connTests[0].Params().CleanupOnly {
 		connTests[0].Infof("🧹 Cleanup mode enabled - removing all connectivity test artifacts")
@@ -32,7 +32,20 @@ func Run(ctx context.Context, connTests []*check.ConnectivityTest, extra Hooks) 
 		return nil
 	}
 
-	if err := setupConnectivityTests(ctx, connTests, extra); err != nil {
+	// Create the JUnit collector up-front so that a failure aborting the suite
+	// before any test result is collected (e.g. during setup/validation) still
+	// produces a non-empty report. The deferred Write records a synthetic
+	// failure in that case and always flushes the report to disk, so CI has a
+	// cilium-junits artifact to upload regardless of where the run failed.
+	junitCollector := check.NewJUnitCollector(connTests[0].Params().JunitProperties, connTests[0].Params().JunitFile, connTests[0].CodeOwners)
+	defer func() {
+		junitCollector.CollectFailure("connectivity test setup", err)
+		if e := junitCollector.Write(); e != nil {
+			connTests[0].Failf("writing to junit file %s failed: %s", connTests[0].Params().JunitFile, e)
+		}
+	}()
+
+	if err = setupConnectivityTests(ctx, connTests, extra); err != nil {
 		return err
 	}
 
@@ -42,7 +55,6 @@ func Run(ctx context.Context, connTests []*check.ConnectivityTest, extra Hooks) 
 	if err != nil {
 		return err
 	}
-	junitCollector := check.NewJUnitCollector(connTests[0].Params().JunitProperties, connTests[0].Params().JunitFile, connTests[0].CodeOwners)
 
 	for i := range suiteBuilders {
 		if e := suiteBuilders[i](connTests, extra.AddConnectivityTests); e != nil {
@@ -74,9 +86,6 @@ func Run(ctx context.Context, connTests []*check.ConnectivityTest, extra Hooks) 
 		}
 	}
 
-	if err := junitCollector.Write(); err != nil {
-		connTests[0].Failf("writing to junit file %s failed: %s", connTests[0].Params().JunitFile, err)
-	}
 	return err
 }
 


### PR DESCRIPTION
When a connectivity test fails during setup or validation, or hits a fatal
error while running, Run returned before the collected results were written,
so a job that failed early uploaded no cilium-junits artifact even though a
junit file was requested. Write the report from a deferred call on every exit
path, recording a synthetic failed test case when no real result was collected.
