### PR TITLE
endpoint: Fix race when reading endpoint properties

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -229,7 +229,7 @@ func (p *proxyPolicy) GetListener() string {
 // required to implement the given L4 policy.
 // Only called after a new selector policy has been computed.
 func (e *Endpoint) addNewRedirects(selectorPolicy policy.SelectorPolicy, proxyWaitGroup *completion.WaitGroup) (desiredRedirects map[string]uint16, skipped uint, rf revert.RevertFunc) {
-	if e.isProperty(endpointtypes.PropertyFakeEndpoint) || e.IsProxyDisabled() {
+	if e.isPropertyLocked(endpointtypes.PropertyFakeEndpoint) || e.IsProxyDisabled() {
 		return nil, 0, nil
 	}
 
@@ -312,7 +312,7 @@ func (e *Endpoint) addNewRedirects(selectorPolicy policy.SelectorPolicy, proxyWa
 // Must be called with endpoint.mutex locked for writing, as this calls back to
 // 'e.OnDNSPolicyUpdateLocked()'.
 func (e *Endpoint) removeOldRedirects(desiredRedirects, realizedRedirects map[string]uint16) {
-	if e.isProperty(endpointtypes.PropertyFakeEndpoint) || e.IsProxyDisabled() {
+	if e.isPropertyLocked(endpointtypes.PropertyFakeEndpoint) || e.IsProxyDisabled() {
 		return
 	}
 
@@ -383,16 +383,15 @@ func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint
 	defer datapathRegenCtxt.completionCancel()
 
 	err = e.runPreCompilationSteps(regenContext)
-	// Keep track of the side-effects of the regeneration that need to be
-	// reverted in case of failure.
-	// Also keep track of the regeneration finalization code that can't be
-	// reverted, and execute it in case of regeneration success.
-	defer func() {
-		// Ignore finalizing of proxy state in dry mode.
-		if !e.isProperty(endpointtypes.PropertyFakeEndpoint) {
-			e.finalizeEndpointRegeneration(regenContext, reterr)
-		}
-	}()
+
+	// Ignore finalizing of proxy state in dry mode.
+	if !e.IsProperty(endpointtypes.PropertyFakeEndpoint) {
+		// Keep track of the side-effects of the regeneration that need to be
+		// reverted in case of failure.
+		// Also keep track of the regeneration finalization code that can't be
+		// reverted, and execute it in case of regeneration success.
+		defer e.finalizeEndpointRegeneration(regenContext, reterr)
+	}
 
 	if err != nil {
 		return 0, err
@@ -434,15 +433,15 @@ func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint
 	// No need to compile BPF in dry mode. Also, in lb-only mode we do not
 	// support local Pods on the worker node, hence endpoint BPF regeneration
 	// is skipped everywhere.
-	if e.isProperty(endpointtypes.PropertyFakeEndpoint) {
+	if e.IsProperty(endpointtypes.PropertyFakeEndpoint) {
 		return e.desiredPolicyRevision, nil
 	}
 
 	// Skip BPF if the endpoint has no policy map
-	if e.isProperty(endpointtypes.PropertySkipBPFPolicy) {
+	if e.IsProperty(endpointtypes.PropertySkipBPFPolicy) {
 		// Ingress endpoint needs entries in the endpoints map so that the return traffic,
 		// ARP, and IPv6 ND are delivered to the host stack in all datapath configurations.
-		if e.isProperty(endpointtypes.PropertyAtHostNS) {
+		if e.IsProperty(endpointtypes.PropertyAtHostNS) {
 			stats.mapSync.Start()
 			err = e.lxcMap.WriteEndpoint(datapathRegenCtxt.epInfoCache)
 			stats.mapSync.End(err == nil)
@@ -668,7 +667,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 
 	// Once the policy has been calculated, we can update the standalone dns proxy as well.
 	// We need to send the snapshot of the policyRules to SDP.
-	if !e.isProperty(endpointtypes.PropertyFakeEndpoint) && !e.IsProxyDisabled() && e.proxy.IsSDPEnabled() {
+	if !e.IsProperty(endpointtypes.PropertyFakeEndpoint) && !e.IsProxyDisabled() && e.proxy.IsSDPEnabled() {
 		repo := e.policyRepo
 		e.getLogger().Debug("Updating standalone DNS proxy with policy rules")
 		policyRules := repo.GetPolicySnapshot()
@@ -695,7 +694,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 	// pre-existing connections using that IP are now invalid.
 	if !e.ctCleaned {
 		go func() {
-			if !e.isProperty(endpointtypes.PropertyFakeEndpoint) {
+			if !e.isPropertyLocked(endpointtypes.PropertyFakeEndpoint) {
 				e.scrubIPsInConntrackTable()
 			}
 			close(datapathRegenCtxt.ctCleaned)
@@ -758,13 +757,13 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 	e.setDNSRulesLocked(rules)
 
 	// If dry mode is enabled, no further changes to BPF maps are performed
-	if e.isProperty(endpointtypes.PropertySkipBPFPolicy) {
+	if e.isPropertyLocked(endpointtypes.PropertySkipBPFPolicy) {
 		// Ingress endpoint needs epInfoCache for endpointmap population
-		if e.isProperty(endpointtypes.PropertyAtHostNS) {
+		if e.isPropertyLocked(endpointtypes.PropertyAtHostNS) {
 			datapathRegenCtxt.epInfoCache = e.createEpInfoCache(currentDir)
 		}
 
-		if e.isProperty(endpointtypes.PropertyFakeEndpoint) {
+		if e.isPropertyLocked(endpointtypes.PropertyFakeEndpoint) {
 			if err = e.writeHeaderfile(nextDir); err != nil {
 				return newRegenerationErrorf(regenerationFailureReasonDatapathOrchestrationError, "unable to write header file: %w", err)
 			}
@@ -829,14 +828,14 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 	}
 
 	// sync policy map for fake endpoints, bpf compilation will be skipped for them.
-	if e.isProperty(endpointtypes.PropertyFakeEndpoint) {
+	if e.isPropertyLocked(endpointtypes.PropertyFakeEndpoint) {
 		err = e.policyMapSync(nil, stats)
 		if err != nil {
 			return newRegenerationErrorf(regenerationFailureReasonPolicyBPFError, "fake ep policymap synchronization failed: %w", err)
 		}
 	}
 
-	if e.isProperty(endpointtypes.PropertySkipBPFRegeneration) {
+	if e.isPropertyLocked(endpointtypes.PropertySkipBPFRegeneration) {
 		return nil
 	}
 
@@ -1147,7 +1146,7 @@ func (e *Endpoint) applyPolicyMapChangesLocked(regenContext *regenerationContext
 
 	// Ingress endpoint does not need to wait.
 	// This also lets daemon/cmd integration tests to proceed
-	if e.isProperty(endpointtypes.PropertySkipBPFPolicy) {
+	if e.isPropertyLocked(endpointtypes.PropertySkipBPFPolicy) {
 		e.getLogger().Debug(
 			"Ingress Endpoint updating Network policy",
 		)
@@ -1194,7 +1193,7 @@ func (e *Endpoint) applyPolicyMapChangesLocked(regenContext *regenerationContext
 	}
 
 	// Ingress endpoint has no bpf policy maps, so return before applying changes to bpf.
-	if e.isProperty(endpointtypes.PropertySkipBPFPolicy) {
+	if e.isPropertyLocked(endpointtypes.PropertySkipBPFPolicy) {
 		e.getLogger().Debug(
 			"Skipping bpf updates due to dry mode",
 		)
@@ -1584,9 +1583,10 @@ func (e *Endpoint) syncPolicyMapWithDump() error {
 	return err
 }
 
+// startSyncPolicyMapController starts the policymap sync controller. Must be called with the endpoint mutex held.
 func (e *Endpoint) startSyncPolicyMapController() {
 	// Skip the controller if the endpoint has no policy map
-	if e.isProperty(endpointtypes.PropertySkipBPFPolicy) {
+	if e.isPropertyLocked(endpointtypes.PropertySkipBPFPolicy) {
 		return
 	}
 

--- a/pkg/endpoint/cache.go
+++ b/pkg/endpoint/cache.go
@@ -61,7 +61,7 @@ type epInfoCache struct {
 
 // Must be called when endpoint is still locked.
 func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
-	if e.isProperty(endpoint.PropertyAtHostNS) {
+	if e.isPropertyLocked(endpoint.PropertyAtHostNS) {
 		return &epInfoCache{
 			revision: e.desiredPolicyRevision,
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -539,7 +539,7 @@ func (e *Endpoint) LXCMac() mac.MAC {
 }
 
 func (e *Endpoint) IsAtHostNS() bool {
-	return e.isProperty(endpoint.PropertyAtHostNS)
+	return e.IsProperty(endpoint.PropertyAtHostNS)
 }
 
 func (e *Endpoint) IsHost() bool {
@@ -547,11 +547,11 @@ func (e *Endpoint) IsHost() bool {
 }
 
 func (e *Endpoint) SkipMasqueradeV4() bool {
-	return e.isProperty(endpoint.PropertySkipMasqueradeV4)
+	return e.IsProperty(endpoint.PropertySkipMasqueradeV4)
 }
 
 func (e *Endpoint) SkipMasqueradeV6() bool {
-	return e.isProperty(endpoint.PropertySkipMasqueradeV6)
+	return e.IsProperty(endpoint.PropertySkipMasqueradeV6)
 }
 
 // SetIsHost is a convenient method to create host endpoints for testing.
@@ -1331,7 +1331,7 @@ func (e *Endpoint) leaveLocked(conf DeleteConfig) []error {
 	e.controllers.RemoveAll()
 	e.cleanPolicySignals()
 
-	if !e.isProperty(endpoint.PropertyFakeEndpoint) {
+	if !e.isPropertyLocked(endpoint.PropertyFakeEndpoint) {
 		e.scrubIPsInConntrackTableLocked()
 	}
 
@@ -1400,7 +1400,10 @@ type CEPOwnerInterface interface {
 // GetCEPOwner retrieves the cep owner related to this endpoint which will be,
 // by default, the pod associated with this endpoint.
 func (e *Endpoint) GetCEPOwner() CEPOwnerInterface {
-	if cepOwnerInt, ok := e.properties[endpoint.PropertyCEPOwner]; ok {
+	e.mutex.RWMutex.RLock()
+	cepOwnerInt, ok := e.properties[endpoint.PropertyCEPOwner]
+	e.mutex.RWMutex.RUnlock()
+	if ok {
 		cepOwner, ok := cepOwnerInt.(CEPOwnerInterface)
 		if ok {
 			return cepOwner
@@ -2782,7 +2785,7 @@ func (e *Endpoint) Delete(conf DeleteConfig) []error {
 	}
 
 	// If dry mode is enabled, no changes to system state are made.
-	if !e.isProperty(endpoint.PropertyFakeEndpoint) {
+	if !e.isPropertyLocked(endpoint.PropertyFakeEndpoint) {
 		// Set the Endpoint's interface down to prevent it from passing any traffic
 		// after its tc filters are removed.
 		if err := e.setDown(); err != nil {
@@ -2905,14 +2908,14 @@ func (e *Endpoint) SetRTInfo(info uint32, t endpoint.RTInfoEncoding) {
 	defer e.mutex.RWMutex.Unlock()
 
 	e.rtInfo = info
-	e.setPropertyValue(endpoint.PropertyRTInfo, string(t))
+	e.setPropertyValueLocked(endpoint.PropertyRTInfo, string(t))
 
 }
 
 func (e *Endpoint) GetRTInfo() (uint32, endpoint.RTInfoEncoding) {
 	e.mutex.RWMutex.RLock()
 	defer e.mutex.RWMutex.RUnlock()
-	enc, _ := e.getPropertyValue(endpoint.PropertyRTInfo).(string)
+	enc, _ := e.getPropertyValueLocked(endpoint.PropertyRTInfo).(string)
 	return e.rtInfo, endpoint.RTInfoEncoding(enc)
 }
 
@@ -2923,7 +2926,7 @@ func (e *Endpoint) ClearRTInfo() {
 	delete(e.properties, endpoint.PropertyRTInfo)
 }
 
-func (e *Endpoint) getPropertyValue(key string) any {
+func (e *Endpoint) getPropertyValueLocked(key string) any {
 	return e.properties[key]
 }
 
@@ -2931,10 +2934,10 @@ func (e *Endpoint) getPropertyValue(key string) any {
 func (e *Endpoint) GetPropertyValue(key string) any {
 	e.mutex.RWMutex.RLock()
 	defer e.mutex.RWMutex.RUnlock()
-	return e.getPropertyValue(key)
+	return e.getPropertyValueLocked(key)
 }
 
-func (e *Endpoint) setPropertyValue(key string, value any) any {
+func (e *Endpoint) setPropertyValueLocked(key string, value any) any {
 	old := e.properties[key]
 	e.properties[key] = value
 	return old
@@ -2944,7 +2947,7 @@ func (e *Endpoint) setPropertyValue(key string, value any) any {
 func (e *Endpoint) SetPropertyValue(key string, value any) any {
 	e.mutex.RWMutex.Lock()
 	defer e.mutex.RWMutex.Unlock()
-	return e.setPropertyValue(key, value)
+	return e.setPropertyValueLocked(key, value)
 }
 
 // IsProperty checks if the value of the properties map is set, it's a boolean
@@ -2952,12 +2955,12 @@ func (e *Endpoint) SetPropertyValue(key string, value any) any {
 func (e *Endpoint) IsProperty(propertyKey string) bool {
 	e.mutex.RWMutex.RLock()
 	defer e.mutex.RWMutex.RUnlock()
-	return e.isProperty(propertyKey)
+	return e.isPropertyLocked(propertyKey)
 }
 
 // isProperty checks if the value of the properties map is set, it's a boolean
-// and its value is 'true'.
-func (e *Endpoint) isProperty(propertyKey string) bool {
+// and its value is 'true'. Must be called with the endpoint being (read)-locked.
+func (e *Endpoint) isPropertyLocked(propertyKey string) bool {
 	if v, ok := e.properties[propertyKey]; ok {
 		isSet, ok := v.(bool)
 		return ok && isSet

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -248,7 +248,7 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 		return err
 	}
 	// Ingress endpoint needs no redirects
-	if !e.isProperty(endpointtypes.PropertySkipBPFPolicy) {
+	if !e.isPropertyLocked(endpointtypes.PropertySkipBPFPolicy) {
 		stats.proxyConfiguration.Start()
 		desiredRedirects, stats.missingProxyRedirectsCount, rf = e.addNewRedirects(selectorPolicy, datapathRegenCtxt.proxyWaitGroup)
 		stats.proxyConfiguration.End(true)
@@ -626,7 +626,7 @@ func (e *Endpoint) updateRealizedState(stats *regenerationStatistics, origDir st
 
 	// Start periodic background full reconciliation of the policy map.
 	// Does nothing if it has already been started.
-	if !e.isProperty(endpointtypes.PropertyFakeEndpoint) {
+	if !e.isPropertyLocked(endpointtypes.PropertyFakeEndpoint) {
 		e.startSyncPolicyMapController()
 	}
 

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -382,6 +382,7 @@ func (e *Endpoint) restoreIdentity(regenerator *Regenerator) error {
 // toSerializedEndpoint converts the Endpoint to its corresponding
 // serializableEndpoint, which contains all of the fields that are needed upon
 // restoring an Endpoint after cilium-agent restarts.
+// e.mutex must be held.
 func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
 	return &serializableEndpoint{
 		ID:                    e.ID,
@@ -553,6 +554,7 @@ func (ep *Endpoint) UnmarshalJSON(raw []byte) error {
 }
 
 // MarshalJSON marshals the Endpoint as its serializableEndpoint representation.
+// e.mutex must be held.
 func (ep *Endpoint) MarshalJSON() ([]byte, error) {
 	return json.Marshal(ep.toSerializedEndpoint())
 }


### PR DESCRIPTION
The endpoint property map is protected by the endpoint mutex. However, it seems that the internal getter was not always called with the endpoint mutex held.

This commit fixes that issue by renaming the internal accessors to have the commonly used "locked" suffix. All call sites in `pkg/endpoint` were manually inspected if they need to use the protected or unprotected accessor and changed accordingly.

This fixes a rare cilium-agent crash where Go detected the concurrent mutation of the endpoint property map (excerpt):

```
fatal error: concurrent map read and map write
goroutine 9221 [running]:
internal/runtime/maps.fatal({0x567336f?, 0xc28adfbec4e68c4b?})
 /usr/local/go/src/runtime/panic.go:1046 +0x18
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).isProperty(...)
 /go/src/github.com/cilium/cilium/pkg/endpoint/endpoint.go:2749
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).runPreCompilationSteps(0xc0001c6f08, 0xc006ca7688)
 /go/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:667 +0x1a5
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).regenerateBPF(0xc0001c6f08, 0xc006ca7688)
 /go/src/github.com/cilium/cilium/pkg/endpoint/bpf.go:402 +0x1fc
github.com/cilium/cilium/pkg/endpoint.(*Endpoint).regenerate(0xc0001c6f08, 0xc006ca7688)
 /go/src/github.com/cilium/cilium/pkg/endpoint/policy.go:504 +0x65a
github.com/cilium/cilium/pkg/endpoint.(*EndpointRegenerationEvent).Handle(0xc001e08340, 0xc007bc3260)
```
