### PR TITLE
Handle "fragmentation needed" / "packet too big" for Layer 4 Services

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -28,6 +28,7 @@
 #include "proxy_hairpin.h"
 #include "fib.h"
 #include "srv6.h"
+#include "pmtu.h"
 
 DECLARE_CONFIG(bool, enable_no_service_endpoints_routable,
 	       "Enable routes when service has 0 endpoints")
@@ -1604,6 +1605,22 @@ skip_service_lookup:
 #endif
 	ctx_set_xfer(ctx, XFER_PKT_NO_SVC);
 
+#ifdef ENABLE_SVC_ICMP_PMTU_RELAY
+	/* Relay an ICMPv6 packet-too-big addressed to a service VIP to the DSR
+	 * backend that owns the connection. See handle_icmp_svc_pmtu_v6 and the
+	 * IPv4 path for details. */
+	if (!is_svc_proto && tuple.nexthdr == IPPROTO_ICMPV6) {
+		ret = handle_icmp_svc_pmtu_v6(ctx, ip6, l4_off, ext_err);
+		if (ret == CTX_ACT_REDIRECT) {
+			ctx_skip_nodeport_set(ctx);
+			return tail_call_internal(ctx, CILIUM_CALL_IPV6_FROM_NETDEV,
+						  ext_err);
+		}
+		if (IS_ERR(ret))
+			return ret;
+	}
+#endif /* ENABLE_SVC_ICMP_PMTU_RELAY */
+
 #ifdef ENABLE_DSR
 #if (defined(IS_BPF_OVERLAY) && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE) || \
     ((defined(IS_BPF_XDP) || defined(IS_BPF_HOST) || defined(IS_BPF_WIREGUARD)) && \
@@ -2970,6 +2987,34 @@ skip_service_lookup:
 	 * the reverse NAT.
 	 */
 	ctx_set_xfer(ctx, XFER_PKT_NO_SVC);
+
+#ifdef ENABLE_SVC_ICMP_PMTU_RELAY
+	/* Relay an ICMP frag-needed addressed to a service VIP to the DSR
+	 * backend that owns the connection.
+	 *
+	 * In DSR mode with masquerading and the host firewall disabled, an
+	 * inbound ICMP error to a VIP is classified here as a non-service
+	 * protocol (lb4_extract_tuple -> DROP_UNSUPP_SERVICE_PROTO) and would
+	 * otherwise fall through to the local stack, where it is useless (the
+	 * VIP is not a local socket, and BGP/ECMP frequently lands the error on
+	 * a node that is not the one holding the flow). This is the forward
+	 * path the error actually traverses, unlike nodeport_rev_dnat_ipv4().
+	 *
+	 * On success the helper has rewritten the outer destination to the
+	 * backend address; recircle through from-netdev so normal pod routing
+	 * delivers it to the backend (local endpoint or remote node).
+	 */
+	if (!is_svc_proto && ip4->protocol == IPPROTO_ICMP) {
+		ret = handle_icmp_svc_pmtu_v4(ctx, ip4, l4_off, ext_err);
+		if (ret == CTX_ACT_REDIRECT) {
+			ctx_skip_nodeport_set(ctx);
+			return tail_call_internal(ctx, CILIUM_CALL_IPV4_FROM_NETDEV,
+						  ext_err);
+		}
+		if (IS_ERR(ret))
+			return ret;
+	}
+#endif /* ENABLE_SVC_ICMP_PMTU_RELAY */
 
 #ifdef ENABLE_DSR
 #if (defined(IS_BPF_OVERLAY) && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE) || \

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1546,6 +1546,35 @@ static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
 	}
 }
 
+#if defined(ENABLE_SVC_ICMP_PMTU_RELAY) && defined(TUNNEL_MODE) && !defined(IS_BPF_XDP)
+/* Deliver a relayed ICMP PMTU error whose outer destination the relay already
+ * rewrote to the backend: if the backend sits behind a tunnel endpoint,
+ * encapsulate and redirect to its node (mirrors nodeport_rev_dnat_ipv4()).
+ * @info is the looked-up remote endpoint for the backend, @proto the inner
+ * ethertype. Returns CTX_ACT_REDIRECT once encapsulated, a DROP_* error, or
+ * CTX_ACT_OK to let the caller fall back to recirculation (local or
+ * native-routed backend). */
+static __always_inline int
+pmtu_relay_tunnel_redirect(struct __ctx_buff *ctx,
+			   const struct remote_endpoint_info *info,
+			   __be16 src_port, __be16 proto)
+{
+	int oif = 0, ret;
+
+	if (!info || !info->flag_has_tunnel_ep || info->flag_skip_tunnel)
+		return CTX_ACT_OK;
+
+	ret = nodeport_add_tunnel_encap(ctx, IPV4_DIRECT_ROUTING, src_port, info,
+					REMOTE_NODE_ID, TRACE_REASON_UNKNOWN,
+					TRACE_PAYLOAD_LEN, &oif, proto);
+	if (IS_ERR(ret))
+		return ret;
+	if (ret == CTX_ACT_REDIRECT && oif)
+		return ctx_redirect(ctx, oif, 0);
+	return CTX_ACT_OK;
+}
+#endif
+
 /* See nodeport_lb4(). */
 static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 					struct ipv6hdr *ip6,
@@ -1612,6 +1641,21 @@ skip_service_lookup:
 	if (!is_svc_proto && tuple.nexthdr == IPPROTO_ICMPV6) {
 		ret = handle_icmp_svc_pmtu_v6(ctx, ip6, l4_off, ext_err);
 		if (ret == CTX_ACT_REDIRECT) {
+			/* Encap to a remote backend in tunnel mode; see the IPv4
+			 * path. Local/native backends fall through to recirculation.
+			 */
+#if defined(TUNNEL_MODE) && !defined(IS_BPF_XDP)
+			void *data, *data_end;
+
+			if (!revalidate_data(ctx, &data, &data_end, &ip6))
+				return DROP_INVALID;
+			ret = pmtu_relay_tunnel_redirect(ctx,
+							 lookup_ip6_remote_endpoint((union v6addr *)&ip6->daddr, 0),
+							 tunnel_gen_src_port_v6(&tuple),
+							 bpf_htons(ETH_P_IPV6));
+			if (ret != CTX_ACT_OK)	/* encapsulated + redirected, or error */
+				return ret;
+#endif
 			ctx_skip_nodeport_set(ctx);
 			return tail_call_internal(ctx, CILIUM_CALL_IPV6_FROM_NETDEV,
 						  ext_err);
@@ -3007,6 +3051,25 @@ skip_service_lookup:
 	if (!is_svc_proto && ip4->protocol == IPPROTO_ICMP) {
 		ret = handle_icmp_svc_pmtu_v4(ctx, ip4, l4_off, ext_err);
 		if (ret == CTX_ACT_REDIRECT) {
+			/* The relay rewrote the outer destination to the backend.
+			 * In tunnel mode a remote backend is only reachable over
+			 * the overlay; recirculating through from-netdev would not
+			 * encapsulate it, so encap here (mirrors
+			 * nodeport_rev_dnat_ipv4()). Local and native-routed
+			 * backends fall through to recirculation.
+			 */
+#if defined(TUNNEL_MODE) && !defined(IS_BPF_XDP)
+			void *data, *data_end;
+
+			if (!revalidate_data(ctx, &data, &data_end, &ip4))
+				return DROP_INVALID;
+			ret = pmtu_relay_tunnel_redirect(ctx,
+							 lookup_ip4_remote_endpoint(ip4->daddr, 0),
+							 tunnel_gen_src_port_v4(&tuple),
+							 bpf_htons(ETH_P_IP));
+			if (ret != CTX_ACT_OK)	/* encapsulated + redirected, or error */
+				return ret;
+#endif
 			ctx_skip_nodeport_set(ctx);
 			return tail_call_internal(ctx, CILIUM_CALL_IPV4_FROM_NETDEV,
 						  ext_err);

--- a/bpf/lib/pmtu.h
+++ b/bpf/lib/pmtu.h
@@ -1,0 +1,465 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+/*
+ * Service PMTU relay for load-balanced service VIPs.
+ *
+ * When a load-balanced service replies to a client, packets are sourced from
+ * the *service VIP*. If such a reply is dropped by a lower-MTU link on the
+ * return path (e.g. a tunnel), the resulting ICMP "fragmentation needed" error
+ * is addressed to the VIP. It arrives at some node (not necessarily the one
+ * holding the flow, because of BGP/ECMP), where the LB datapath cannot classify
+ * it (ICMP is not a service protocol) and passes it to the local stack, where
+ * it is useless: the VIP is not a local socket and the endpoint that actually
+ * needs to lower its PMTU never sees the error, so the connection black-holes.
+ *
+ * This helper intercepts those errors on the forward path (nodeport_lb4) and
+ * relays them to the backend that owns the connection:
+ *
+ *   - DSR backend: re-derive the owning backend statelessly via the same Maglev
+ *     hash used on the forward path (the hash excludes the VIP, so any node
+ *     derives the same backend), rewrite the error to that backend and forward
+ *     it there. The backend's kernel caches the reduced PMTU for the connection.
+ *     This is stateless, so it works even when BGP/ECMP lands the error on a
+ *     node that is not the one holding the flow.
+ *
+ *   - SNAT-mode backend: the backend was chosen statefully on the ingress node
+ *     and only that node holds the service conntrack entry, so recovery is
+ *     best-effort: the backend is read from the CT_SERVICE entry and the relay
+ *     only fires when the error came back to the ingress node (common for
+ *     single-entry / tunnel topologies). Under ECMP the error usually lands on
+ *     another node, where no CT entry exists and the relay falls through.
+ *
+ * On success the helper rewrites the embedded packet and the outer destination
+ * to the backend address and returns CTX_ACT_REDIRECT; the caller delivers the
+ * packet to the backend (recircle for a local/native backend, encapsulate for a
+ * remote backend in tunnel mode). No per-connection PMTU state is stored in the
+ * datapath.
+ */
+
+#pragma once
+
+#include "common.h"
+#include "lb.h"
+#include "nat.h"
+#include "conntrack.h"
+
+#ifdef ENABLE_IPV6
+#include "ipv6.h"
+#include "icmp6.h"
+#endif
+
+#ifdef ENABLE_SVC_ICMP_PMTU_RELAY
+
+/* Bound the relay per service (rev_nat_index) so a spoofed frag-needed spray at
+ * a VIP cannot amplify. 100 relayed errors/s per service, burstable to 1000, is
+ * far above the handful a real connection produces at PMTU-discovery time.
+ * Returns true to drop. */
+static __always_inline bool
+pmtu_relay_ratelimited(__u16 rev_nat_index)
+{
+	struct ratelimit_key rkey = {
+		.usage = RATELIMIT_USAGE_SVC_ICMP_PMTU_RELAY,
+	};
+	const struct ratelimit_settings settings = {
+		.bucket_size = 1000,
+		.tokens_per_topup = 100,
+		.topup_interval_ns = NSEC_PER_SEC,
+	};
+
+	rkey.key.svc_pmtu_relay.rev_nat_index = rev_nat_index;
+	return !ratelimit_check_and_take(&rkey, &settings);
+}
+
+#ifdef ENABLE_IPV4
+
+/* Returns true for the ICMPv4 error types that carry a PMTU signal. */
+static __always_inline bool
+icmp4_is_frag_needed(__u8 type, __u8 code)
+{
+	return type == ICMP_DEST_UNREACH && code == ICMP_FRAG_NEEDED;
+}
+
+/*
+ * handle_icmp_svc_pmtu_v4 - relay an ICMPv4 frag-needed addressed to a service
+ * VIP to the DSR backend owning the connection.
+ *
+ * @l4_off: offset of the (outer) ICMP header.
+ *
+ * Returns CTX_ACT_REDIRECT (packet consumed, rewritten to the backend),
+ * CTX_ACT_OK (not ours / not applicable -> caller keeps its default handling),
+ * or a negative DROP_* code on hard error.
+ */
+static __always_inline int
+handle_icmp_svc_pmtu_v4(struct __ctx_buff *ctx, struct iphdr *ip4, int l4_off,
+			__s8 *ext_err __maybe_unused)
+{
+	__u32 inner_l3_off = (__u32)(l4_off + sizeof(struct icmphdr));
+	struct icmphdr icmphdr __align_stack_8;
+	struct iphdr inner;
+	struct lb4_key key = {};
+	const struct lb4_service *svc;
+	const struct lb4_backend *backend;
+	struct ipv4_ct_tuple tuple = {};
+	__be16 svc_port = 0, client_port = 0;
+	__u32 backend_id;
+	__u32 icmp_l4_off;
+	int ret;
+
+	if (ip4->protocol != IPPROTO_ICMP)
+		return CTX_ACT_OK;
+
+	if (ctx_load_bytes(ctx, l4_off, &icmphdr, sizeof(icmphdr)) < 0)
+		return DROP_INVALID;
+	if (!icmp4_is_frag_needed(icmphdr.type, icmphdr.code))
+		return CTX_ACT_OK;
+
+	/* Inner packet = the original reply the backend sent:
+	 * src = VIP:svc_port, dst = client:client_port. (RFC 5508)
+	 */
+	if (ctx_load_bytes(ctx, inner_l3_off, &inner, sizeof(inner)) < 0)
+		return DROP_INVALID;
+
+	/* Only TCP/UDP services participate. */
+	switch (inner.protocol) {
+	case IPPROTO_TCP:
+	case IPPROTO_UDP:
+		break;
+	default:
+		return CTX_ACT_OK;
+	}
+
+	icmp_l4_off = inner_l3_off + ipv4_hdrlen(&inner);
+	/* Inner L4 ports: sport = svc_port (from the VIP side), dport = client. */
+	if (ctx_load_bytes(ctx, icmp_l4_off, &svc_port, sizeof(svc_port)) < 0)
+		return DROP_INVALID;
+	if (ctx_load_bytes(ctx, icmp_l4_off + 2, &client_port, sizeof(client_port)) < 0)
+		return DROP_INVALID;
+
+	/* Service lookup keyed on the inner packet's VIP:svc_port. */
+	key.address = inner.saddr;
+	key.dport = svc_port;
+	key.proto = inner.protocol;
+
+	/* Only an error addressed to the VIP is handled: its outer destination is
+	 * the VIP, which equals the embedded packet's source. */
+	if (ip4->daddr != inner.saddr)
+		return CTX_ACT_OK;
+
+	svc = lb4_lookup_service(&key, false);
+	if (!svc)
+		return CTX_ACT_OK;			/* not a service VIP */
+
+	/* L7/Ingress services terminate at a cilium-envoy proxy, not at the
+	 * backend the datapath would resolve, so the L4 relay must not touch
+	 * them. They carry SVC_FLAG_FWD_MODE_DSR on DSR clusters, so without
+	 * this guard they would fall into the DSR branch and the error would be
+	 * misdelivered to an arbitrary backend. Leave them for the stack. */
+	if (lb4_svc_is_l7_loadbalancer(svc))
+		return CTX_ACT_OK;
+
+	if (pmtu_relay_ratelimited(svc->rev_nat_index))
+		return DROP_RATE_LIMITED;
+
+	/* Build the flow tuple once; both the DSR and SNAT paths key on it.
+	 *
+	 * Handedness matches lb4_local() / lb4_select_backend_id_maglev(): the
+	 * ports are stored swapped (sport = svc_port, dport = client_port) and the
+	 * hash uses tuple->saddr = client. This equals the forward path's tuple
+	 * (saddr = client, sport = client_port, dport = svc_port before the swap),
+	 * so the Maglev result and the CT_SERVICE key both match the ingress node.
+	 */
+	tuple.saddr = inner.daddr;		/* client */
+	tuple.daddr = inner.saddr;		/* VIP */
+	tuple.nexthdr = inner.protocol;
+	tuple.sport = svc_port;
+	tuple.dport = client_port;
+
+	if (svc->flags2 & SVC_FLAG_FWD_MODE_DSR) {
+		/* DSR: re-derive the backend statelessly. Only the Maglev hash
+		 * excludes the VIP, so the (arbitrary) node the ICMP lands on picks
+		 * the same backend the ingress node did. Under any other algorithm
+		 * (e.g. random) the re-derived backend would differ, so skip. */
+		{
+		__u32 alg = lb4_algorithm(svc);
+
+		if (alg != LB_SELECTION_MAGLEV && alg != LB_SELECTION_RANDOM &&
+		    alg != LB_SELECTION_FIRST)
+			alg = lb_default_algorithm();
+		if (alg != LB_SELECTION_MAGLEV)
+			return CTX_ACT_OK;
+		}
+		backend_id = lb4_select_backend_id(ctx, &key, &tuple, svc);
+	} else {
+		/* SNAT-mode: the backend was chosen statefully on the ingress node
+		 * and only that node holds the service conntrack entry, so this is
+		 * best-effort -- it can only relay when the error came back to the
+		 * ingress node (typical for single-entry / tunnel topologies; never
+		 * under ECMP, where the error lands elsewhere and we fall through).
+		 * Recover the backend by repeating lb4_local()'s CT_SERVICE lookup
+		 * with the same tuple, so the key matches; the embedded reply's L4
+		 * header sits at icmp_l4_off. */
+		/* rev_nat_index must be set for the CT_SERVICE match (see
+		 * ct_entry_matches_types()); lb4_local() sets it before the lookup. */
+		struct ct_state ct_state = { .rev_nat_index = svc->rev_nat_index };
+		__u32 monitor = 0;
+
+		/* We already parsed the ports into the tuple, so tell CT not to read
+		 * the embedded L4 header (it may be truncated in the ICMP payload):
+		 * this is a pure, side-effect-free key lookup. */
+		ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx,
+				      IPFRAG_BIT_NO_L4_HEADER, (int)icmp_l4_off,
+				      CT_SERVICE, SCOPE_REVERSE, CT_ENTRY_SVC,
+				      &ct_state, &monitor);
+		if (ret != CT_REPLY)
+			return CTX_ACT_OK;	/* no local CT entry: not the ingress node */
+		backend_id = ct_state.backend_id;
+	}
+
+	if (!backend_id)
+		return CTX_ACT_OK;
+	backend = __lb4_lookup_backend(backend_id);
+	if (!backend)
+		return CTX_ACT_OK;
+
+	/* Reverse the DSR DNAT on the embedded (inner) packet so the backend
+	 * kernel matches the error to its socket (backend:backend_port <-> client):
+	 * rewrite inner src VIP:svc_port -> backend->address:backend->port (fixing
+	 * the inner IP + inner L4 checksums), then rewrite the OUTER dst VIP ->
+	 * backend and amend the OUTER ICMP checksum for the embedded change. This
+	 * mirrors snat_v4_rev_nat_handle_icmp_error() + snat_v4_rev_nat()'s two-step
+	 * rewrite: fixing only the inner checksums leaves the outer ICMP checksum
+	 * stale and the backend kernel silently drops the error.
+	 */
+	{
+		__u32 total_inner_len = (__u32)ctx_full_len(ctx) - inner_l3_off;
+		bool has_inner_l4_csum = true;
+		__wsum outer_csum_diff = 0;
+
+		/* A frag-needed error may embed only the IP header + 8 L4 bytes,
+		 * which is too short to carry the inner L4 checksum. */
+		if (inner.protocol == IPPROTO_TCP &&
+		    total_inner_len < ipv4_hdrlen(&inner) + TCP_CSUM_OFF + sizeof(__u16))
+			has_inner_l4_csum = false;
+
+		/* For UDP a checksum of 0 means "no checksum"; treat it as absent
+		 * so the outer ICMP diff accounts for the port change only (the
+		 * address change is cancelled by the inner IP checksum). Matches
+		 * snat_v4_rev_nat_handle_icmp_error(). */
+		if (inner.protocol == IPPROTO_UDP) {
+			__be16 l4_csum = 0;
+
+			if (ctx_load_bytes(ctx, icmp_l4_off + offsetof(struct udphdr, check),
+					   &l4_csum, sizeof(l4_csum)) < 0)
+				return DROP_INVALID;
+			if (l4_csum == 0)
+				has_inner_l4_csum = false;
+		}
+
+		snat_v4_calc_icmp_error_csum_diff(inner.saddr, backend->address,
+						  svc_port, backend->port,
+						  has_inner_l4_csum, &outer_csum_diff);
+
+		/* (1) Rewrite the embedded packet. */
+		ret = snat_v4_rewrite_headers(ctx, inner.protocol, (int)inner_l3_off,
+					      true, (int)icmp_l4_off,
+					      inner.saddr, backend->address, IPV4_SADDR_OFF,
+					      svc_port, backend->port, TCP_SPORT_OFF, 0);
+		if (!has_inner_l4_csum && ret == DROP_CSUM_L4)
+			ret = 0;
+		if (IS_ERR(ret))
+			return ret;
+
+		/* (2) Rewrite the outer IP dst VIP -> backend (so normal pod routing
+		 * delivers to the backend) and amend the outer ICMP checksum. The old
+		 * outer daddr == VIP == inner.saddr, a stack value (the packet pointer
+		 * is stale after the write above). No outer port change. */
+		ret = snat_v4_rewrite_headers(ctx, IPPROTO_ICMP, ETH_HLEN, true,
+					      (int)l4_off,
+					      inner.saddr, backend->address, IPV4_DADDR_OFF,
+					      0, 0, 0, outer_csum_diff);
+		if (IS_ERR(ret))
+			return ret;
+	}
+
+	update_metrics(ctx_full_len(ctx), METRIC_EGRESS, REASON_MTU_ERROR_MSG);
+
+	/* Delivery: the outer destination now points at the backend, so return
+	 * CTX_ACT_REDIRECT and let the caller recircle through from-netdev, where
+	 * normal pod routing delivers to the backend (local endpoint or remote
+	 * node) without needing a backend-local vs -remote distinction here.
+	 */
+	return CTX_ACT_REDIRECT;
+}
+
+#endif /* ENABLE_IPV4 */
+
+#ifdef ENABLE_IPV6
+
+/*
+ * IPv6 counterpart. The mechanics mirror the IPv4 path with two differences:
+ *  - the trigger is ICMPv6 "packet too big" (ICMPV6_PKT_TOOBIG);
+ *  - the ICMPv6 checksum has a pseudo-header, so every outer-address rewrite
+ *    must amend it. snat_v6_rewrite_headers() does that (it applies the address
+ *    diff at the ICMPv6 checksum offset with BPF_F_PSEUDO_HDR), so the outer
+ *    destination is rewritten through it rather than by hand. The embedded
+ *    rewrite needs no separate outer-checksum fix: IPv6 has no L3 checksum, so
+ *    the embedded address change and the embedded L4 checksum change cancel out
+ *    in the enclosing ICMPv6 checksum (same reasoning as the stock
+ *    snat_v6_rev_nat_handle_icmp_pkt_toobig()).
+ */
+static __always_inline int
+handle_icmp_svc_pmtu_v6(struct __ctx_buff *ctx, struct ipv6hdr *ip6, int l4_off,
+			__s8 *ext_err __maybe_unused)
+{
+	__u32 inner_l3_off = (__u32)(l4_off + sizeof(struct icmp6hdr));
+	struct ipv6hdr inner;
+	struct lb6_key key = {};
+	const struct lb6_service *svc;
+	const struct lb6_backend *backend;
+	struct ipv6_ct_tuple tuple __align_stack_8 = {};
+	union v6addr vip, baddr;
+	__be16 svc_port = 0, client_port = 0;
+	__u8 inner_nexthdr, type;
+	__u32 backend_id, icmp_l4_off;
+	int hdrlen, ret;
+
+	if (icmp6_load_type(ctx, l4_off, &type) < 0)
+		return DROP_INVALID;
+	if (type != ICMPV6_PKT_TOOBIG)
+		return CTX_ACT_OK;
+
+	/* Inner packet = the original reply: src = VIP:svc_port, dst = client. */
+	if (ctx_load_bytes(ctx, inner_l3_off, &inner, sizeof(inner)) < 0)
+		return DROP_INVALID;
+
+	inner_nexthdr = inner.nexthdr;
+	hdrlen = ipv6_hdrlen_offset(ctx, (int)inner_l3_off, &inner_nexthdr, NULL);
+	if (hdrlen < 0)
+		return DROP_INVALID;
+	icmp_l4_off = inner_l3_off + (__u32)hdrlen;
+
+	switch (inner_nexthdr) {
+	case IPPROTO_TCP:
+	case IPPROTO_UDP:
+		break;
+	default:
+		return CTX_ACT_OK;
+	}
+
+	if (ctx_load_bytes(ctx, icmp_l4_off, &svc_port, sizeof(svc_port)) < 0)
+		return DROP_INVALID;
+	if (ctx_load_bytes(ctx, icmp_l4_off + 2, &client_port, sizeof(client_port)) < 0)
+		return DROP_INVALID;
+
+	ipv6_addr_copy(&vip, (union v6addr *)&inner.saddr);
+
+	/* Sanity: only handle an error addressed to the VIP that sourced the
+	 * dropped packet (outer dst == embedded src). */
+	if (!ipv6_addr_equals((union v6addr *)&ip6->daddr, &vip))
+		return CTX_ACT_OK;
+
+	ipv6_addr_copy(&key.address, &vip);
+	key.dport = svc_port;
+	key.proto = inner_nexthdr;
+
+	svc = lb6_lookup_service(&key, false);
+	if (!svc)
+		return CTX_ACT_OK;
+
+	/* L7/Ingress services are handled by cilium-envoy, not the resolved
+	 * backend; skip them so the L4 relay does not misdeliver the error (see
+	 * the IPv4 path). */
+	if (lb6_svc_is_l7_loadbalancer(svc))
+		return CTX_ACT_OK;
+
+	if (pmtu_relay_ratelimited(svc->rev_nat_index))
+		return DROP_RATE_LIMITED;
+
+	/* Rewriting the embedded packet keeps the outer ICMPv6 checksum valid only
+	 * because the embedded address change and the embedded L4 checksum change
+	 * cancel (IPv6 has no L3 checksum). A UDP reply with checksum 0 ("no
+	 * checksum") has no L4 checksum to cancel the address/port change, so the
+	 * rewrite would leave the outer ICMPv6 checksum wrong and the backend would
+	 * drop the relayed error. Don't emit a malformed error for that rare case;
+	 * fall through to the previous behavior. (The stock
+	 * snat_v6_rev_nat_handle_icmp_pkt_toobig() shares this limitation; fully
+	 * supporting it needs an outer-checksum diff in the shared helper.) */
+	if (inner_nexthdr == IPPROTO_UDP) {
+		__be16 l4_csum = 0;
+
+		if (ctx_load_bytes(ctx, (int)(icmp_l4_off + offsetof(struct udphdr, check)),
+				   &l4_csum, sizeof(l4_csum)) < 0)
+			return DROP_INVALID;
+		if (l4_csum == 0)
+			return CTX_ACT_OK;
+	}
+
+	/* Build the flow tuple once; both paths key on it (see the IPv4 path for
+	 * the handedness rationale). */
+	ipv6_addr_copy(&tuple.saddr, (union v6addr *)&inner.daddr);	/* client */
+	ipv6_addr_copy(&tuple.daddr, &vip);				/* VIP */
+	tuple.nexthdr = inner_nexthdr;
+	tuple.sport = svc_port;
+	tuple.dport = client_port;
+
+	if (svc->flags2 & SVC_FLAG_FWD_MODE_DSR) {
+		/* DSR: re-derive the backend statelessly. Only Maglev picks the same
+		 * backend on any node (see the IPv4 path). */
+		{
+		__u32 alg = lb6_algorithm(svc);
+
+		if (alg != LB_SELECTION_MAGLEV && alg != LB_SELECTION_RANDOM &&
+		    alg != LB_SELECTION_FIRST)
+			alg = lb_default_algorithm();
+		if (alg != LB_SELECTION_MAGLEV)
+			return CTX_ACT_OK;
+		}
+		backend_id = lb6_select_backend_id(ctx, &key, &tuple, svc);
+	} else {
+		/* SNAT-mode: best-effort recovery from the service conntrack entry,
+		 * which only exists on the ingress node (see the IPv4 path). */
+		struct ct_state ct_state = { .rev_nat_index = svc->rev_nat_index };
+		__u32 monitor = 0;
+
+		ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx,
+				      IPFRAG_BIT_NO_L4_HEADER, (int)icmp_l4_off,
+				      CT_SERVICE, SCOPE_REVERSE, CT_ENTRY_SVC,
+				      &ct_state, &monitor);
+		if (ret != CT_REPLY)
+			return CTX_ACT_OK;	/* no local CT entry: not the ingress node */
+		backend_id = ct_state.backend_id;
+	}
+
+	if (!backend_id)
+		return CTX_ACT_OK;
+	backend = __lb6_lookup_backend(backend_id);
+	if (!backend)
+		return CTX_ACT_OK;
+	ipv6_addr_copy(&baddr, (union v6addr *)&backend->address);
+
+	/* (1) Rewrite the embedded packet: inner src VIP:svc_port -> backend.
+	 * The embedded L4 checksum is fixed; the outer ICMPv6 checksum is left
+	 * unchanged (the inner address and inner L4 checksum changes cancel). */
+	ret = snat_v6_rewrite_headers(ctx, inner_nexthdr, (int)inner_l3_off, true,
+				      (int)icmp_l4_off, &vip, &baddr,
+				      IPV6_SADDR_OFF, svc_port, backend->port,
+				      TCP_SPORT_OFF);
+	if (IS_ERR(ret))
+		return ret;
+
+	/* (2) Rewrite the outer dst VIP -> backend and amend the ICMPv6 checksum
+	 * for the address change. old outer daddr == VIP == vip (stack value). */
+	ret = snat_v6_rewrite_headers(ctx, IPPROTO_ICMPV6, ETH_HLEN, true, l4_off,
+				      &vip, &baddr, IPV6_DADDR_OFF, 0, 0, 0);
+	if (IS_ERR(ret))
+		return ret;
+
+	update_metrics(ctx_full_len(ctx), METRIC_EGRESS, REASON_MTU_ERROR_MSG);
+
+	return CTX_ACT_REDIRECT;
+}
+
+#endif /* ENABLE_IPV6 */
+
+#endif /* ENABLE_SVC_ICMP_PMTU_RELAY */

--- a/bpf/lib/ratelimit.h
+++ b/bpf/lib/ratelimit.h
@@ -9,6 +9,7 @@
 #define RATELIMIT_USAGE_ICMPV6 1
 #define RATELIMIT_USAGE_EVENTS_MAP 2
 #define RATELIMIT_USAGE_SOCKET_EVENTS_MAP 3
+#define RATELIMIT_USAGE_SVC_ICMP_PMTU_RELAY 4
 
 struct ratelimit_key {
 	__u32 usage;
@@ -16,6 +17,9 @@ struct ratelimit_key {
 		struct {
 			__u32 netdev_idx;
 		} icmpv6;
+		struct {
+			__u32 rev_nat_index;
+		} svc_pmtu_relay;
 	} key;
 };
 

--- a/bpf/tests/svc_icmp_pmtu_relay.c
+++ b/bpf/tests/svc_icmp_pmtu_relay.c
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+/* Datapath test for the service ICMP PMTU relay.
+ *
+ * Covers the L4/DSR IPv4 path: an ICMPv4 "fragmentation needed" addressed to a
+ * DSR service VIP, carrying the backend's oversized reply (src = VIP:svc_port,
+ * dst = client) embedded, must be rewritten so it is addressed to the backend
+ * that owns the connection -- outer dst and embedded src rewritten to the
+ * backend, embedded L4 source port rewritten to the backend port -- and the
+ * helper must return CTX_ACT_REDIRECT so the caller delivers it to the backend.
+ *
+ * The backend is re-derived via Maglev (the relay is Maglev-only), so the test
+ * mocks the maglev maps and points every LUT slot at the one backend. The L7
+ * flood path is not exercised here (it needs fib_lookup/clone_redirect, which
+ * do not run under BPF_PROG_RUN; that wants a separate mocked test).
+ */
+
+#include <bpf/ctx/skb.h>
+#include <bpf/api.h>
+#include "common.h"
+#include "pktgen.h"
+
+#define ENABLE_IPV4
+#define ENABLE_NODEPORT
+#define ENABLE_DSR
+#define ENABLE_SVC_ICMP_PMTU_RELAY
+#include <bpf/config/global.h>
+
+#define TEST_LB_MAGLEV_MAP_MAX_ENTRIES 65536
+#define TEST_CONDITIONAL_PREALLOC      0
+#define TEST_REVNAT		       1
+#define LB_MAGLEV_EXTERNAL
+
+/* Satisfy the nat.h -> egress_gateway.h -> encap.h include chain; the relay
+ * itself does not use encap. */
+#define ENCAP_IFINDEX	42
+#define ENCAP4_IFINDEX	42
+#define ENCAP6_IFINDEX	42
+
+/* The relay is Maglev-only. Select Maglev as the runtime backend-selection
+ * algorithm via lb_default_alg; this must be defined before the node config
+ * include, which assigns lb_default_alg from LB_DEFAULT_ALG. Defining the
+ * obsolete compile-time LB_SELECTION here would silently mask a real bug: the
+ * agent build has no such macro, so the guard resolves the algorithm at
+ * runtime and must be tested that way. */
+#include <bpf/lb_selection.h>
+#define LB_DEFAULT_ALG LB_SELECTION_MAGLEV
+
+#include "nodeport_defaults.h"
+
+#undef LB_MAGLEV_LUT_SIZE
+#define LB_MAGLEV_LUT_SIZE 20
+
+/* Mock maglev maps used by lb{4,6}_select_backend_id_maglev(). */
+struct lb4_maglev_map_inner {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(value_size, sizeof(__u32) * LB_MAGLEV_LUT_SIZE);
+	__uint(max_entries, 1);
+} test_lb4_maglev_map_inner __section_maps_btf;
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH_OF_MAPS);
+	__type(key, __u32);
+	__type(value, __u32);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+	__uint(max_entries, TEST_LB_MAGLEV_MAP_MAX_ENTRIES);
+	__uint(map_flags, TEST_CONDITIONAL_PREALLOC);
+	__array(values, struct lb4_maglev_map_inner);
+} cilium_lb4_maglev __section_maps_btf = {
+	.values = {[TEST_REVNAT] = &test_lb4_maglev_map_inner, },
+};
+
+#define OVERWRITE_MAGLEV_MAP_FROM_TEST 1
+
+#include <lib/dbg.h>
+#include <lib/eps.h>
+#include <lib/pmtu.h>
+#include "lib/lb.h"
+
+#define ROUTER_IP	bpf_htonl(0x0a000002)	/* 10.0.0.2   (ICMP source) */
+#define VIP_ADDR	bpf_htonl(0x0a00000a)	/* 10.0.0.10  (service VIP)  */
+#define CLIENT_IP	bpf_htonl(0x0a0000f0)	/* 10.0.0.240 (client)       */
+#define BACKEND_IP	bpf_htonl(0x0a000105)	/* 10.0.1.5   (backend pod)  */
+#define SVC_PORT	bpf_htons(80)
+#define CLIENT_PORT	bpf_htons(12345)
+#define BACKEND_PORT	bpf_htons(8080)
+#define BACKEND_ID	124
+
+static volatile const __u8 smac[ETH_ALEN] = {0x02, 0, 0, 0, 0, 1};
+static volatile const __u8 dmac[ETH_ALEN] = {0x02, 0, 0, 0, 0, 2};
+
+PKTGEN("tc", "svc_icmp_pmtu_relay_dsr_v4")
+int svc_icmp_pmtu_relay_dsr_v4_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct iphdr *ip4;
+	struct icmphdr *icmp;
+	struct iphdr inner_ip = {
+		.version = 4,
+		.ihl = 5,
+		.protocol = IPPROTO_TCP,
+		.saddr = VIP_ADDR,	/* backend reply is sourced from the VIP */
+		.daddr = CLIENT_IP,
+	};
+	struct tcphdr inner_tcp = {
+		.source = SVC_PORT,
+		.dest = CLIENT_PORT,
+		.doff = 5,
+	};
+
+	pktgen__init(&builder, ctx);
+
+	/* Outer: ICMPv4 error from the tunnel router, addressed to the VIP. */
+	ip4 = pktgen__push_ipv4_packet(&builder, (__u8 *)smac, (__u8 *)dmac,
+				       ROUTER_IP, VIP_ADDR);
+	if (!ip4)
+		return TEST_ERROR;
+	ip4->protocol = IPPROTO_ICMP;
+
+	icmp = pktgen__push_icmphdr(&builder);
+	if (!icmp)
+		return TEST_ERROR;
+	icmp->type = ICMP_DEST_UNREACH;
+	icmp->code = ICMP_FRAG_NEEDED;
+	icmp->un.frag.mtu = bpf_htons(1400);
+
+	/* Embedded (offending) packet: VIP:svc_port -> client. */
+	if (!pktgen__push_data(&builder, &inner_ip, sizeof(inner_ip)))
+		return TEST_ERROR;
+	if (!pktgen__push_data(&builder, &inner_tcp, sizeof(inner_tcp)))
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "svc_icmp_pmtu_relay_dsr_v4")
+int svc_icmp_pmtu_relay_dsr_v4_setup(struct __ctx_buff *ctx)
+{
+	__u32 backends[LB_MAGLEV_LUT_SIZE];
+	__u32 zero = 0;
+	void *data, *data_end;
+	struct iphdr *ip4;
+	__s8 ext_err = 0;
+	int i, l4_off, ret;
+
+	/* Point every maglev LUT slot at the single backend so the re-derivation
+	 * is deterministic regardless of the hashed tuple. */
+	for (i = 0; i < LB_MAGLEV_LUT_SIZE; i++)
+		backends[i] = BACKEND_ID;
+	map_update_elem(&test_lb4_maglev_map_inner, &zero, backends, BPF_ANY);
+
+	/* DSR service VIP:80 with one backend. */
+	lb_v4_add_service_with_flags(VIP_ADDR, SVC_PORT, IPPROTO_TCP, 1, TEST_REVNAT,
+				     SVC_FLAG_ROUTABLE, SVC_FLAG_FWD_MODE_DSR);
+	lb_v4_add_backend(VIP_ADDR, SVC_PORT, 1, BACKEND_ID,
+			  BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+	ip4 = data + sizeof(struct ethhdr);
+	if ((void *)ip4 + sizeof(*ip4) > data_end)
+		return TEST_ERROR;
+
+	l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
+
+	ret = handle_icmp_svc_pmtu_v4(ctx, ip4, l4_off, &ext_err);
+	if (ret != CTX_ACT_REDIRECT)
+		return TEST_ERROR;
+
+	return TEST_PASS;
+}
+
+CHECK("tc", "svc_icmp_pmtu_relay_dsr_v4")
+int svc_icmp_pmtu_relay_dsr_v4_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct iphdr *ip4, *inner_ip;
+	struct icmphdr *icmp;
+	struct tcphdr *inner_tcp;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+	status_code = data;
+	if (*status_code != TEST_PASS)
+		test_fatal("SETUP failed with status code: %d", *status_code);
+
+	/* Skip the prepended status code, then walk ether/ip/icmp/inner. */
+	ip4 = data + sizeof(*status_code) + sizeof(struct ethhdr);
+	if ((void *)ip4 + sizeof(*ip4) > data_end)
+		test_fatal("outer ip out of bounds");
+	if (ip4->daddr != BACKEND_IP)
+		test_fatal("outer dst not rewritten to the backend");
+
+	icmp = (void *)ip4 + sizeof(*ip4);
+	if ((void *)icmp + sizeof(*icmp) > data_end)
+		test_fatal("icmp out of bounds");
+
+	inner_ip = (void *)icmp + sizeof(*icmp);
+	if ((void *)inner_ip + sizeof(*inner_ip) > data_end)
+		test_fatal("embedded ip out of bounds");
+	if (inner_ip->saddr != BACKEND_IP)
+		test_fatal("embedded src not rewritten to the backend");
+	if (inner_ip->daddr != CLIENT_IP)
+		test_fatal("embedded dst must remain the client");
+
+	inner_tcp = (void *)inner_ip + sizeof(*inner_ip);
+	if ((void *)inner_tcp + sizeof(*inner_tcp) > data_end)
+		test_fatal("embedded tcp out of bounds");
+	if (inner_tcp->source != BACKEND_PORT)
+		test_fatal("embedded L4 source not rewritten to the backend port");
+	if (inner_tcp->dest != CLIENT_PORT)
+		test_fatal("embedded L4 dest must remain the client port");
+
+	test_finish();
+}
+
+BPF_LICENSE("Dual BSD/GPL");

--- a/bpf/tests/svc_icmp_pmtu_relay_snat.c
+++ b/bpf/tests/svc_icmp_pmtu_relay_snat.c
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+/* Datapath test for the SNAT-mode branch of the service ICMP PMTU relay.
+ *
+ * Unlike DSR, a SNAT-mode backend cannot be re-derived statelessly, so the
+ * relay recovers it from the service conntrack entry the forward path created
+ * on the ingress node. This test seeds that CT_SERVICE entry (mirroring
+ * lb4_local(): prime the tuple flags via ct_lazy_lookup4(CT_SERVICE,
+ * SCOPE_REVERSE) then ct_create4() with the backend id), sends an ICMPv4
+ * "fragmentation needed" addressed to the VIP, and checks the relay rewrites
+ * the error to the backend and returns CTX_ACT_REDIRECT.
+ *
+ * The "not the ingress node" case (no CT entry -> CTX_ACT_OK) is covered by a
+ * second test that omits the seeding.
+ */
+
+#include <bpf/ctx/skb.h>
+#include <bpf/api.h>
+#include "common.h"
+#include "pktgen.h"
+
+#define ENABLE_IPV4
+#define ENABLE_NODEPORT
+#define ENABLE_DSR
+#define ENABLE_SVC_ICMP_PMTU_RELAY
+#include <bpf/config/global.h>
+
+#define TEST_REVNAT		       1
+
+/* Satisfy the nat.h -> egress_gateway.h -> encap.h include chain. */
+#define ENCAP_IFINDEX	42
+#define ENCAP4_IFINDEX	42
+#define ENCAP6_IFINDEX	42
+
+#include "nodeport_defaults.h"
+
+#include <lib/dbg.h>
+#include <lib/eps.h>
+#include <lib/pmtu.h>
+#include "lib/lb.h"
+
+#define ROUTER_IP	bpf_htonl(0x0a000002)	/* 10.0.0.2   (ICMP source) */
+#define VIP_ADDR	bpf_htonl(0x0a00000a)	/* 10.0.0.10  (service VIP)  */
+#define CLIENT_IP	bpf_htonl(0x0a0000f0)	/* 10.0.0.240 (client)       */
+#define BACKEND_IP	bpf_htonl(0x0a000105)	/* 10.0.1.5   (backend pod)  */
+#define SVC_PORT	bpf_htons(80)
+#define CLIENT_PORT	bpf_htons(12345)
+/* Distinct flow for the miss case: subtests share the same map instance, so the
+ * hit case's seeded CT entry would otherwise be found by the miss case too. */
+#define CLIENT_PORT_MISS bpf_htons(23456)
+#define BACKEND_PORT	bpf_htons(8080)
+#define BACKEND_ID	124
+
+static volatile const __u8 smac[ETH_ALEN] = {0x02, 0, 0, 0, 0, 1};
+static volatile const __u8 dmac[ETH_ALEN] = {0x02, 0, 0, 0, 0, 2};
+
+/* Build the ICMPv4 frag-needed addressed to the VIP, carrying the backend's
+ * oversized reply (VIP:svc_port -> client) embedded. */
+static __always_inline int build_frag_needed(struct __ctx_buff *ctx, __be16 client_port)
+{
+	struct pktgen builder;
+	struct iphdr *ip4;
+	struct icmphdr *icmp;
+	struct iphdr inner_ip = {
+		.version = 4,
+		.ihl = 5,
+		.protocol = IPPROTO_TCP,
+		.saddr = VIP_ADDR,
+		.daddr = CLIENT_IP,
+	};
+	struct tcphdr inner_tcp = {
+		.source = SVC_PORT,
+		.dest = client_port,
+		.doff = 5,
+	};
+
+	pktgen__init(&builder, ctx);
+
+	ip4 = pktgen__push_ipv4_packet(&builder, (__u8 *)smac, (__u8 *)dmac,
+				       ROUTER_IP, VIP_ADDR);
+	if (!ip4)
+		return TEST_ERROR;
+	ip4->protocol = IPPROTO_ICMP;
+
+	icmp = pktgen__push_icmphdr(&builder);
+	if (!icmp)
+		return TEST_ERROR;
+	icmp->type = ICMP_DEST_UNREACH;
+	icmp->code = ICMP_FRAG_NEEDED;
+	icmp->un.frag.mtu = bpf_htons(1400);
+
+	if (!pktgen__push_data(&builder, &inner_ip, sizeof(inner_ip)))
+		return TEST_ERROR;
+	if (!pktgen__push_data(&builder, &inner_tcp, sizeof(inner_tcp)))
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+/* Add a SNAT-mode (no DSR flag) service VIP:80 with one backend. */
+static __always_inline void add_snat_service(void)
+{
+	lb_v4_add_service_with_flags(VIP_ADDR, SVC_PORT, IPPROTO_TCP, 1, TEST_REVNAT,
+				     SVC_FLAG_ROUTABLE, 0);
+	lb_v4_add_backend(VIP_ADDR, SVC_PORT, 1, BACKEND_ID,
+			  BACKEND_IP, BACKEND_PORT, IPPROTO_TCP, 0);
+}
+
+/* Seed the service conntrack entry the ingress node's forward path would have
+ * created for this flow, storing the selected backend id. Mirrors lb4_local():
+ * the CT_SERVICE tuple is stored swapped (sport = svc_port, dport = client_port)
+ * and ct_lazy_lookup4() primes tuple->flags before ct_create4(). */
+static __always_inline void seed_ct_service(struct __ctx_buff *ctx, int l4_off)
+{
+	struct ipv4_ct_tuple ct_tuple = {
+		.saddr = CLIENT_IP,
+		.daddr = VIP_ADDR,
+		.nexthdr = IPPROTO_TCP,
+		.sport = SVC_PORT,
+		.dport = CLIENT_PORT,
+	};
+	struct ct_state seed = {
+		.backend_id = BACKEND_ID,
+		.rev_nat_index = TEST_REVNAT,
+	};
+	struct ct_state tmp = {};
+	__s8 ext_err = 0;
+	__u32 monitor = 0;
+
+	ct_lazy_lookup4(get_ct_map4(&ct_tuple), &ct_tuple, ctx,
+			IPFRAG_BIT_NO_L4_HEADER, l4_off, CT_SERVICE,
+			SCOPE_REVERSE, CT_ENTRY_SVC, &tmp, &monitor);
+	ct_create4(get_ct_map4(&ct_tuple), NULL, &ct_tuple, ctx, CT_SERVICE,
+		   &seed, &ext_err);
+}
+
+static __always_inline int call_relay(struct __ctx_buff *ctx)
+{
+	void *data = (void *)(long)ctx->data;
+	void *data_end = (void *)(long)ctx->data_end;
+	struct iphdr *ip4 = data + sizeof(struct ethhdr);
+	__s8 ext_err = 0;
+
+	if ((void *)ip4 + sizeof(*ip4) > data_end)
+		return TEST_ERROR;
+
+	return handle_icmp_svc_pmtu_v4(ctx, ip4,
+				       ETH_HLEN + ipv4_hdrlen(ip4), &ext_err);
+}
+
+/* ---- Case 1: CT entry present (ingress node) -> relay to the backend. ---- */
+
+PKTGEN("tc", "svc_icmp_pmtu_relay_snat_v4")
+int svc_icmp_pmtu_relay_snat_v4_pktgen(struct __ctx_buff *ctx)
+{
+	return build_frag_needed(ctx, CLIENT_PORT);
+}
+
+SETUP("tc", "svc_icmp_pmtu_relay_snat_v4")
+int svc_icmp_pmtu_relay_snat_v4_setup(struct __ctx_buff *ctx)
+{
+	void *data = (void *)(long)ctx->data;
+	void *data_end = (void *)(long)ctx->data_end;
+	struct iphdr *ip4 = data + sizeof(struct ethhdr);
+	int l4_off;
+
+	if ((void *)ip4 + sizeof(*ip4) > data_end)
+		return TEST_ERROR;
+	l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
+
+	add_snat_service();
+	seed_ct_service(ctx, l4_off);
+
+	if (call_relay(ctx) != CTX_ACT_REDIRECT)
+		return TEST_ERROR;
+
+	return TEST_PASS;
+}
+
+CHECK("tc", "svc_icmp_pmtu_relay_snat_v4")
+int svc_icmp_pmtu_relay_snat_v4_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct iphdr *ip4, *inner_ip;
+	struct icmphdr *icmp;
+	struct tcphdr *inner_tcp;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+	status_code = data;
+	if (*status_code != TEST_PASS)
+		test_fatal("SETUP failed with status code: %d", *status_code);
+
+	ip4 = data + sizeof(*status_code) + sizeof(struct ethhdr);
+	if ((void *)ip4 + sizeof(*ip4) > data_end)
+		test_fatal("outer ip out of bounds");
+	if (ip4->daddr != BACKEND_IP)
+		test_fatal("outer dst not rewritten to the backend");
+
+	icmp = (void *)ip4 + sizeof(*ip4);
+	if ((void *)icmp + sizeof(*icmp) > data_end)
+		test_fatal("icmp out of bounds");
+
+	inner_ip = (void *)icmp + sizeof(*icmp);
+	if ((void *)inner_ip + sizeof(*inner_ip) > data_end)
+		test_fatal("embedded ip out of bounds");
+	if (inner_ip->saddr != BACKEND_IP)
+		test_fatal("embedded src not rewritten to the backend");
+	if (inner_ip->daddr != CLIENT_IP)
+		test_fatal("embedded dst must remain the client");
+
+	inner_tcp = (void *)inner_ip + sizeof(*inner_ip);
+	if ((void *)inner_tcp + sizeof(*inner_tcp) > data_end)
+		test_fatal("embedded tcp out of bounds");
+	if (inner_tcp->source != BACKEND_PORT)
+		test_fatal("embedded L4 source not rewritten to the backend port");
+	if (inner_tcp->dest != CLIENT_PORT)
+		test_fatal("embedded L4 dest must remain the client port");
+
+	test_finish();
+}
+
+/* ---- Case 2: no CT entry (error landed on a non-ingress node) -> no relay. ---- */
+
+PKTGEN("tc", "svc_icmp_pmtu_relay_snat_v4_miss")
+int svc_icmp_pmtu_relay_snat_v4_miss_pktgen(struct __ctx_buff *ctx)
+{
+	return build_frag_needed(ctx, CLIENT_PORT_MISS);
+}
+
+SETUP("tc", "svc_icmp_pmtu_relay_snat_v4_miss")
+int svc_icmp_pmtu_relay_snat_v4_miss_setup(struct __ctx_buff *ctx)
+{
+	/* Service exists but there is no CT_SERVICE entry for the flow, as on a
+	 * node that did not handle the connection. The relay must fall through. */
+	add_snat_service();
+
+	if (call_relay(ctx) != CTX_ACT_OK)
+		return TEST_ERROR;
+
+	return TEST_PASS;
+}
+
+CHECK("tc", "svc_icmp_pmtu_relay_snat_v4_miss")
+int svc_icmp_pmtu_relay_snat_v4_miss_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct iphdr *ip4;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+	status_code = data;
+	if (*status_code != TEST_PASS)
+		test_fatal("SETUP failed with status code: %d", *status_code);
+
+	/* Packet must be untouched: outer dst still the VIP. */
+	ip4 = data + sizeof(*status_code) + sizeof(struct ethhdr);
+	if ((void *)ip4 + sizeof(*ip4) > data_end)
+		test_fatal("outer ip out of bounds");
+	if (ip4->daddr != VIP_ADDR)
+		test_fatal("outer dst must be unchanged when there is no CT entry");
+
+	test_finish();
+}
+
+BPF_LICENSE("Dual BSD/GPL");

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -305,6 +305,19 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *config.Config) erro
 		cDefinesMap["DSR_ENCAP_IPIP"] = fmt.Sprintf("%d", dsrEncapIPIP)
 		cDefinesMap["DSR_ENCAP_GENEVE"] = fmt.Sprintf("%d", dsrEncapGeneve)
 		cDefinesMap["DSR_ENCAP_NONE"] = fmt.Sprintf("%d", dsrEncapNone)
+
+		// Relay inbound ICMP "fragmentation needed" / "packet too big" errors
+		// addressed to a service VIP to the backend that owns the connection,
+		// so the backend lowers its path MTU. For DSR the backend is
+		// re-derived statelessly via the same Maglev hash the ingress node
+		// used, so the relay works even when BGP/ECMP lands the error on a
+		// node that is not the one holding the flow. For SNAT-mode services it
+		// is best-effort, recovering the backend from the service conntrack
+		// entry when the error returns to the ingress node.
+		if option.Config.EnablePMTUDiscovery {
+			cDefinesMap["ENABLE_SVC_ICMP_PMTU_RELAY"] = "1"
+		}
+
 		if cfg.LBConfig.LoadBalancerUsesDSR() {
 			cDefinesMap["ENABLE_DSR"] = "1"
 			if option.Config.EnablePMTUDiscovery {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

<!-- Description of change -->

**AI disclosure (AIL:4):** the datapath implementation and tests were
AI-generated from my design and iterative direction. I reviewed all of the
code, and I validated the change on our own cluster. It is deployed there and
serving live traffic, and I ran the datapath/pktgen tests and reproduced the
before/after behaviour (see *Deployment status* and *Testing*).

## Motivation

**Why we built this.** We run our clusters fully layer-3: no layer-2 / ARP
anywhere, [BIRD](https://bird.network.cz/) running on each host, and Cilium's
BGP control plane on top advertising service VIPs. Every node announces the
VIPs, so inbound traffic is ECMP'd across nodes. This is a clean, scalable
design, but it exposes a PMTU black-hole. When there is a link with a smaller
MTU somewhere in the path to the cluster, the router on that link returns an
ICMP "fragmentation needed" / "packet too big" addressed to the **service
VIP**, and Cilium has nowhere to put it. The error is dropped, no endpoint ever
lowers its path MTU, and large transfers to the service hang.

Cilium's native PMTU support (the `EnablePMTUDiscovery` kernel feature) does not
close this gap for us:

- Even where it does kick in, recovery is slow: it took roughly **6 seconds**
  for the path to adapt, versus the few milliseconds it should take. In practice
  that reads as a stall on every affected transfer.
- Under BGP/ECMP it misses the error entirely: the ICMP is addressed to the VIP,
  so the fabric hashes it to whichever node it likes, which is generally not the
  node holding the flow, and the endpoint that must lower its PMTU never sees it.

So the native feature is either too slow or misses the error entirely in our
all-layer-3, BGP/ECMP topology. This change makes
the ICMP error reach the endpoint that actually needs it, statelessly, on
whichever node the error happens to land, which is exactly the case ECMP
produces.

When an external client reaches a load-balanced Cilium service and the reply
path crosses a link with a smaller MTU, the router returns an ICMP
"fragmentation needed" (IPv4) / "packet too big" (IPv6) addressed to the source
of the offending packet. For a service reply that source is the **service VIP**,
not any real node or pod.

Cilium's datapath has nowhere useful to put that error today: `lb4_extract_tuple`
classifies ICMP as a non-service protocol, so it falls through `nodeport_lb4`
at `skip_service_lookup` to the local stack and dies there. The VIP is not a
local socket, and with BGP/ECMP the error frequently lands on a node that is not
the one handling the flow. As a result no endpoint ever lowers its path MTU, and
large transfers to/from the service black-hole.

This is the well-known problem of PMTU discovery behind ECMP / anycast load
balancers: because the ICMP error's source IP differs from the client's, the
upstream ECMP hash steers it to a different node than the one holding the flow.
It is the subject of the long-standing CFP #19720 ("make packet too big work in
ECMP scenarios"), which was otherwise going to be worked around by reimplementing
Cloudflare's `pmtud` daemon as a DaemonSet. This change handles it for
load-balanced L4 services directly in the datapath, by relaying the error
statelessly to the backend that owns the flow.

## What this does

New helper `bpf/lib/pmtu.h` (`handle_icmp_svc_pmtu_v4` / `_v6`), hooked into
`nodeport_lb4`/`nodeport_lb6` at `skip_service_lookup`. It parses the embedded
original packet, looks up the service, and relays:

- **DSR backends**: re-derives the backend that owns the connection
  statelessly, using the same Maglev selection the ingress node used (the hash
  excludes the VIP, so every node picks the same backend), rewrites the error
  to that backend and delivers it via normal pod routing (recirculated, or
  encapsulated over the overlay for a remote backend in tunnel mode). The
  backend's kernel caches the reduced PMTU.
- **SNAT-mode backends**: best-effort. The backend was chosen statefully on the
  ingress node, so it is recovered from that node's service conntrack entry
  (`CT_SERVICE`); the relay therefore only fires when the error returns to the
  ingress node. Under ECMP the error usually lands elsewhere, where no entry
  exists, and the relay falls through.

The DSR relay is stateless: any node that receives the error can perform it,
which is what makes it work under ECMP. It is rate-limited per service
(`RATELIMIT_USAGE_SVC_ICMP_PMTU_RELAY`). Gated by `ENABLE_SVC_ICMP_PMTU_RELAY`,
wired to the existing `EnablePMTUDiscovery` option.

## Scope

- **Implemented and tested:** IPv4 `ICMP_FRAG_NEEDED` and IPv6 `ICMPV6_PKT_TOOBIG`
  to DSR-mode VIPs (stateless direct relay, works under ECMP), plus best-effort
  recovery for SNAT-mode VIPs from the ingress node's service conntrack entry.
- **Out of scope (follow-up):** L7 / Ingress (Envoy) services, whose terminating
  socket lives in a node's host netns and cannot be re-derived statelessly, and
  full SNAT recovery under ECMP. No new PMTU BPF map and no egress
  size-enforcement are introduced; the sender's kernel already implements PMTU
  caching natively.

## Test setup

The repro is a three-node underlay stitched together with IPIP tunnels, with a
deliberately reduced MTU (1400) on the last tunnel leg so a large segment
towards the cluster triggers an ICMP frag-needed. `curl` runs on Node A, the
Cilium/BGP cluster hangs off Node C.

```
NODE A                                              NODE B (transit, ip_forward=1)                                NODE C
┌──────────────────────────────────────────┐        ┌──────────────────────────────────────────────┐              ┌────────────────────────────────┐
│                                          │        │ net.ipv4.ip_forward=1                        │              │ net.ipv4.ip_forward=1          │
│                                          │        │                                              │              │                                │
│ ╔══════ VRF blue ══════════════════════╗ │        │ ╔══════════════ VRF blue ═════════════════╗  │              │ ╔══════ VRF blue ════════════╗ │
│ ║ table 100                            ║ │        │ ║ table 100                               ║  │              │ ║ table 100                  ║ │
│ ║                                      ║ │        │ ║                                         ║  │              │ ║                            ║ │
│ ║ ┌──────────────────┐                 ║ │        │ ║ ┌────────────────┐  ┌────────────────┐  ║  │              │ ║ ┌──────────────────┐       ║ │
│ ║ │ ipipAB           │                 ║ │        │ ║ │ ipipBA         │  │ ipipBC         │  ║  │              │ ║ │ ipipCB           │       ║ │
│ ║ │ 192.168.0.1/32   │                 ║ │        │ ║ │ 192.168.0.2/32 │  │ 192.168.0.3/32 │  ║  │              │ ║ │ 192.168.0.4/32   │       ║ │
│ ║ │                  │   $curl VIP     ║ │        │ ║ │                │  │                │  ║  │            ┌─────│                  │       ║ │
│ ║ │ underlay         │   inside VRF    ║ │        │ ║ │ underlay       │  │ underlay       │  ║  │            │ │ ║ │ underlay         │       ║ │
│ ║ │ 10.0.0.1         │                 ║ │        │ ║ │ 10.0.0.2       │  │ 10.0.0.2       │  ║  │            │ │ ║ │ 10.0.0.3         │       ║ │
│ ║ │                  │                 ║ │        │ ║ │                │  │                │  ║  │            │ │ ║ └──────────────────┘       ║ │
│ ║ └────────┬─────────┘                 ║ │        │ ║ └───────┬────────┘  │                │  ║  │            │ │ ╚════════════╤═══════════════╝ │
│ ╚══════════│═══════════════════════════╝ │        │ ║         │           └───────┬────────┘  ║  │            │ │              │                 │
└────────────│─────────────────────────────┘        │ ╚═════════│═══════════════════│═══════════╝  │            │ │   route leak (blue ⇄ main)     │
             │                                      └───────────│───────────────────│──────────────┘            │ │              │                 │
             │                                                  │                   │                           │ │       ┌──────┴───────┐         │
             │   IPIP  A ◄──────────► B                         │                   │      IPIP  B ◄──────►C    │ │       │ default table│         │
             └──────────────────────────────────────────────────┘                   └───────────────────────────┘ │       │ (main)       │         │
                 outer 10.0.0.1 ◄► 10.0.0.2                                             outer 10.0.0.2◄►10.0.0.3  │       └──────┬───────┘         │
                 tunnel MTU 1500                                                        tunnel MTU 1400           └──────────────│─────────────────┘
                                                                                         ← bottleneck leg                        │
                                                                                                                                 │
                                                                                                                       ┌─────────┴──────────┐
                                                                                                                       │   K8s Cluster      │
                                                                                                                       │   Cilium + BGP     │
                                                                                                                       │                    │
                                                                                                                       │   LB VIP / pods    │
                                                                                                                       └────────────────────┘
 underlay:    9000 MTU between all physical links
 routes:      static routes between devices for IPIP links and default route. Node C must ensure that the 192.168.0.0/24 is
              routed to it.
 overlay:     A 192.168.0.1    B 192.168.0.2    C 192.168.0.4
 path:        A ──ipipAB──► B ──(forwards tunnel→tunnel inside blue)──► ipipBC ──► C
 PMTUD event:
   1. curl on A opens a new TCP connection towards K8s via the IPIP tunnels. MSS advertised here is 1460 (MTU - IPv4
      header - TCP header).
   2. SYN_ACK from K8s advertised 8600 MSS -> both sides agree on the lower 1460 (Note: no packet so far has been large
      enough to cause an issue with the 1400 MTU between B and C)
   3. K8s sends TLS server hello with MSS 1460 -> C emits ICMP frag-needed because it has only a 1400 MTU link towards K8s.
```

Behind Node C sits the actual cluster: three servers, each dual-homed to both
leaf switches and running Cilium with BIRD/BGP on the host, advertising the
service VIP(s) over BGP to leaf1 and leaf2. Because every node advertises the
VIP to both leaves, the fabric learns it via all three next-hops and ECMPs
inbound traffic across them. An ICMP error for a VIP therefore hashes to
whichever node the fabric picks, which is generally not the node holding the
flow. This is exactly the case the stateless relay is built for, and it is why a
single-node setup cannot reproduce the problem.

```
    ┌───────┐
    │ leaf1 │═══════╤═══════════════╤═══════════════╤═══
    └───────┘       │               │               │
    ┌───────┐       │               │               │
    │ leaf2 │═══╤═══╪═══════════╤═══╪═══════════╤═══╪═══
    └───────┘   │   │           │   │           │   │
                │   │           │   │           │   │
              ┌─┴───┴─┐       ┌─┴───┴─┐       ┌─┴───┴─┐
              │ node1 │       │ node2 │       │ node3 │
              │Cilium │       │Cilium │       │Cilium │
              │ BIRD  │       │ BIRD  │       │ BIRD  │
              │ BGP   │       │ BGP   │       │ BGP   │
              └───────┘       └───────┘       └───────┘

   Both leaves sit above the nodes. Each node is dual-homed: its left uplink
   lands on leaf2 and its right uplink passes leaf2 (╪ = crossing, no join) up
   to leaf1. leaf1 and leaf2 peer with each other, and every node BGP-peers with
   BOTH leaves and advertises the VIP on each uplink, so the fabric learns each
   VIP via all three nodes and ECMPs inbound traffic across them.
```

## Testing

- pktgen datapath tests (`bpf/tests/svc_icmp_pmtu_relay.c`,
  `svc_icmp_pmtu_relay_snat.c`) cover the DSR IPv4 path and the SNAT-mode
  recovery (hit and miss); both pass under `BPF_PROG_RUN` on a 6.17 kernel.
- On a live rig reproducing the black-hole (external client → DSR service over a
  1400-MTU tunnel): before, large transfers hang and the oversized segments are
  retransmitted forever; after, the relayed ICMP reaches the endpoint, the PMTU
  is cached, segments shrink and transfers complete. `mtu_error_message_total`
  increments and then settles once the path has adapted.
- **Measured impact** (200 KB transfer to a DSR service over the 1400-MTU
  tunnel): the transfer went from **~6.6 s** (the oversized segments
  retransmitting until TCP works around it) to **~0.007 s** with the relay
  enabled.
- `bpf_host` / `bpf_lxc` / `bpf_xdp` / `bpf_overlay` compile, and the datapath
  loads on a 6.18 kernel.

A note on reproducing this: the effect is hard to see on a single-node /
single-server setup. Without ECMP across multiple nodes there is nothing to
steer the ICMP error to the "wrong" node, so the ~6 s stall does not manifest. It really needs a multi-node, BGP/ECMP topology
with a reduced-MTU link in the path, like the one described under *Test setup*.
If it would help, we're happy to assist with a reproducing test setup,
or record a screenshare showing the before/after difference. Whatever works best
for you.

## Deployment status

This patch is deployed and serving live traffic on one of our clusters, which is
also where the repro above was validated. Relevant configuration:

- Cilium built from this branch, kernel 6.18.
- kube-proxy replacement, DSR with Maglev backend selection.
- netkit datapath devices, BPF host-routing, TCX attach mode.
- XDP acceleration in best-effort mode (the relay is TC-only and unaffected).
- BGP control plane advertising service VIPs per node, so inbound traffic is
  ECMP'd across nodes, i.e. the ICMP errors routinely land on a node other than
  the one holding the flow, exactly the case the stateless relay is designed for.
- External clients reach the services over a reduced-MTU (1400) tunnel.

Enabling the relay resolved the black-holing for DSR services in this
environment, and it has been running without regressions to normal service
traffic.

## References

- The ECMP PMTUD problem (IPv6-focused, applies to IPv4 too):
  https://datatracker.ietf.org/doc/html/draft-jaeggli-v6ops-pmtud-ecmp-problem-00
- Cloudflare `pmtud`, the userspace daemon that broadcasts ICMP PMTU packets to
  all machines behind an anycast/ECMP LB, prior art for handling PMTU under
  anycast/ECMP: https://github.com/cloudflare/pmtud
- Cloudflare, "Path MTU discovery in practice":
  https://blog.cloudflare.com/path-mtu-discovery-in-practice/
- Cloudflare, "Increasing IPv6 MTU":
  https://blog.cloudflare.com/increasing-ipv6-mtu/

Fixes: #19720

```release-note
Relay inbound ICMP PMTU errors addressed to a load-balanced service VIP to the
endpoint that must lower its path MTU, fixing PMTU black-holing for DSR services
(opt-in, enabled with PMTU discovery).
```

