### PR TITLE
gha/renovate: use actions/create-github-app-token from renovate envir…

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -17,6 +17,9 @@ jobs:
   renovate:
     name: Run self-hosted Renovate
     runs-on: ubuntu-24.04
+    environment:
+      name: renovate
+      deployment: false
     permissions:
       contents: read
     steps:
@@ -25,10 +28,10 @@ jobs:
       # grained permissions installed in the repository for that.
       - name: Get token
         id: get_token
-        uses: cilium/actions-app-token@61a6271ce92ba02f49bf81c755685d59fb25a59a # v0.21.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          APP_PEM: ${{ secrets.CILIUM_RENOVATE_PEM }}
-          APP_ID: ${{ secrets.CILIUM_RENOVATE_APP_ID }}
+          client-id: ${{ secrets.CILIUM_RENOVATE_CLIENT_ID }}
+          private-key: ${{ secrets.CILIUM_RENOVATE_PEM }}
 
       # renovate clones the repository again in its container fs but it needs
       # the renovate configuration to start.
@@ -46,5 +49,5 @@ jobs:
           docker-user: root
           docker-cmd-file: .github/actions/renovate/entrypoint.sh
           configurationFile: .github/renovate.json5
-          token: '${{ steps.get_token.outputs.app_token }}'
+          token: '${{ steps.get_token.outputs.token }}'
           mount-docker-socket: true


### PR DESCRIPTION
…onment

The Renovate workflow authenticated as a GitHub App via cilium/actions-app-token, reading the App PEM and numeric App ID from repository secrets. Switch to the maintained actions/create-github-app-token action, already used elsewhere in this repo, and source its credentials from a dedicated 'renovate' deployment environment that holds the CILIUM_RENOVATE_CLIENT_ID and CILIUM_RENOVATE_PEM secrets.