### PR TITLE
network driver: manifest changes for network driver feature

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
@@ -164,4 +164,15 @@ rules:
   - list
   - watch
 {{- end }}
+{{- if .Values.networkDriver.enabled }}
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkdrivernodeconfigs
+  - ciliumresourceippools
+  verbs:
+  - list
+  - watch
+  - get
+{{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -414,6 +414,18 @@ spec:
           mountPath: /tmp/cilium/config-map
           readOnly: true
         {{- end }}
+        {{- if .Values.networkDriver.enabled }}
+        - name: device-plugin
+          mountPath: /var/lib/kubelet/plugins
+        - name: plugin-registry
+          mountPath: /var/lib/kubelet/plugins_registry
+        - name: nri-plugin
+          mountPath: /var/run/nri
+        - name: host-sys-bus-pci-devices
+          mountPath: /host/sys/bus/pci/devices
+        - name: host-sys-devices
+          mountPath: /host/sys/devices
+        {{- end }}
         {{- range .Values.extraHostPathMounts }}
         - name: {{ .name }}
           mountPath: {{ .mountPath }}
@@ -1064,6 +1076,28 @@ spec:
       - name: host-proc-sys-kernel
         hostPath:
           path: /proc/sys/kernel
+          type: Directory
+      {{- end }}
+      {{- if .Values.networkDriver.enabled }}
+      - name: host-sys-bus-pci-devices
+        hostPath:
+          path: /sys/bus/pci/devices
+          type: Directory
+      - name: host-sys-devices
+        hostPath:
+          path: /sys/devices
+          type: Directory
+      - name: device-plugin
+        hostPath:
+          path: /var/lib/kubelet/plugins
+          type: Directory
+      - name: plugin-registry
+        hostPath:
+          path: /var/lib/kubelet/plugins_registry
+          type: Directory
+      - name: nri-plugin
+        hostPath:
+          path: /var/run/nri
           type: Directory
       {{- end }}
       {{- if and .Values.hubble.enabled .Values.hubble.tls.enabled (hasKey .Values.hubble "listenAddress") (not .Values.hubble.tls.disableDefaultVolumes) }}

--- a/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/clusterrole.yaml
@@ -283,6 +283,11 @@ rules:
   - serviceexports.multicluster.x-k8s.io
 {{- end }}
   - ciliumdatapathplugins.cilium.io
+{{- if .Values.networkDriver.enabled }}
+  - ciliumnetworkdrivernodeconfigs.cilium.io
+  - ciliumnetworkdriverclusterconfigs.cilium.io
+  - ciliumresourceippools.cilium.io
+{{- end }}
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -481,4 +486,32 @@ rules:
   - ciliumendpointslices
   verbs:
   - deletecollection
+{{- if .Values.networkDriver.enabled }}
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkdriverclusterconfigs
+  - ciliumresourceippools
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkdriverclusterconfigs/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkdrivernodeconfigs
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+{{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
@@ -164,4 +164,15 @@ rules:
   - list
   - watch
 {{- end }}
+{{- if .Values.networkDriver.enabled }}
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkdrivernodeconfigs
+  - ciliumresourceippools
+  verbs:
+  - list
+  - watch
+  - get
+{{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -256,3 +256,8 @@
 {{- if and (eq .Values.ipam.mode "eni") (not .Values.eni.enabled) }}
   {{ fail "ipam.mode=eni requires eni.enabled=true" }}
 {{- end }}
+
+{{/* validate networkDriver.enabled flag requires kubernetes >= v1.34 */}}
+{{- if and (.Values.networkDriver.enabled) (semverCompare "<1.34.0" (printf "%d.%d.0" (semver .Capabilities.KubeVersion.Version).Major (semver .Capabilities.KubeVersion.Version).Minor)) }}
+  {{ fail ".Values.networkDriver.enabled requires kubernetes version 1.34 or greater" }}
+{{- end }}


### PR DESCRIPTION
adding the CRDs to both operator and agent clusterrole.yaml file.
adding the mounts needed in the agent for registering with DRA/NRI, also the sysfs path for managing SR-IOV vfs
gated behind the networkDriver.enabled helm flag.

ps: not so sure about the release note tag, please lmk if it needs adjusting

```release-note
network driver: add cluster roles and mounts for the network driver feature
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
