### PR TITLE
Policy: fix overselection for NotIn namespace labels

### DIFF
--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -10,12 +10,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/cilium/cilium/api/v1/flow"
-	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/policy/utils"
 	"github.com/cilium/cilium/pkg/source"
 )
 
@@ -23,23 +23,6 @@ const (
 	// podPrefixLbl is the value the prefix used in the label selector to
 	// represent pods on the default namespace.
 	podPrefixLbl = labels.LabelSourceK8sKeyPrefix + k8sConst.PodNamespaceLabel
-
-	// podAnyPrefixLbl is the value of the prefix used in the label selector to
-	// represent pods in the default namespace for any source type.
-	podAnyPrefixLbl = labels.LabelSourceAnyKeyPrefix + k8sConst.PodNamespaceLabel
-
-	// podK8SNamespaceLabelsPrefix is the prefix use in the label selector for namespace labels.
-	podK8SNamespaceLabelsPrefix = labels.LabelSourceK8sKeyPrefix + k8sConst.PodNamespaceMetaLabelsPrefix
-	// podAnyNamespaceLabelsPrefix is the prefix use in the label selector for namespace labels
-	// for any source type.
-	podAnyNamespaceLabelsPrefix = labels.LabelSourceAnyKeyPrefix + k8sConst.PodNamespaceMetaLabelsPrefix
-
-	// clusterPrefixLbl is the prefix use in the label selector for cluster name.
-	clusterPrefixLbl = labels.LabelSourceK8sKeyPrefix + k8sConst.PolicyLabelCluster
-
-	// clusterAnyPrefixLbl is the prefix use in the label selector for cluster name
-	// for any source type.
-	clusterAnyPrefixLbl = labels.LabelSourceAnyKeyPrefix + k8sConst.PolicyLabelCluster
 
 	// podInitLbl is the label used in a label selector to match on
 	// initializing pods.
@@ -103,14 +86,6 @@ func GetPolicyFromLabels(policyLabels []string, revision uint64) *flow.Policy {
 	return f
 }
 
-// addClusterFilterByDefault attempt to add a cluster filter if the cluster name
-// is defined and that the EndpointSelector doesn't already have a cluster selector
-func addClusterFilterByDefault(es *api.EndpointSelector, clusterName string) {
-	if clusterName != cmtypes.PolicyAnyCluster && !es.HasKey(clusterPrefixLbl) && !es.HasKey(clusterAnyPrefixLbl) {
-		es.AddMatch(clusterPrefixLbl, clusterName)
-	}
-}
-
 // getEndpointSelector converts the provided labelSelector into an EndpointSelector,
 // adding the relevant matches for namespaces and clusters based on the provided options.
 // If no namespace is provided then it is assumed that the selector is global to the cluster
@@ -133,25 +108,14 @@ func getEndpointSelector(clusterName, namespace string, labelSelector *slim_meta
 	// Those pods don't have any labels, so they don't have a namespace label either.
 	// Don't add a namespace label to those endpoint selectors, or we wouldn't be
 	// able to match on those pods.
-	if !es.HasKey(podPrefixLbl) && !es.HasKey(podAnyPrefixLbl) {
-		if namespace == "" {
-			// For a clusterwide policy if a namespace is not specified in the labels we add
-			// a selector to only match endpoints that contains a namespace label.
-			// This is to make sure that we are only allowing traffic for cilium managed k8s endpoints
-			// and even if a wildcard is provided in the selector we don't proceed with a truly
-			// empty(allow all) endpoint selector for the policy.
-			if !matchesInit {
-				es.AddMatchExpression(podPrefixLbl, slim_metav1.LabelSelectorOpExists, []string{})
-			}
-		} else if !es.HasKeyPrefix(podK8SNamespaceLabelsPrefix) && !es.HasKeyPrefix(podAnyNamespaceLabelsPrefix) {
-			es.AddMatch(podPrefixLbl, namespace)
-		}
+	if !matchesInit || namespace != "" {
+		utils.EnsureNamespaceSelector(&es, namespace)
 	}
 
 	// Similarly to namespace, the user can explicitly specify the cluster in the
 	// FromEndpoints selector. If omitted, we limit the
 	// scope to the cluster the policy lives in.
-	addClusterFilterByDefault(&es, clusterName)
+	utils.EnsureClusterSelector(&es, clusterName)
 
 	return es
 }
@@ -172,7 +136,7 @@ func parseToCiliumIngressCommonRule(clusterName, namespace string, es api.Endpoi
 		for j, node := range ing.FromNodes {
 			es = api.NewESFromK8sLabelSelector("", node.LabelSelector)
 			es.AddMatchExpression(labels.LabelSourceReservedKeyPrefix+labels.IDNameRemoteNode, slim_metav1.LabelSelectorOpExists, []string{})
-			addClusterFilterByDefault(&es, clusterName)
+			utils.EnsureClusterSelector(&es, clusterName)
 			retRule.FromNodes[j] = es
 		}
 	}
@@ -278,7 +242,7 @@ func parseToCiliumEgressCommonRule(clusterName, namespace string, es api.Endpoin
 		for j, node := range egr.ToNodes {
 			es = api.NewESFromK8sLabelSelector("", node.LabelSelector)
 			es.AddMatchExpression(labels.LabelSourceReservedKeyPrefix+labels.IDNameRemoteNode, slim_metav1.LabelSelectorOpExists, []string{})
-			addClusterFilterByDefault(&es, clusterName)
+			utils.EnsureClusterSelector(&es, clusterName)
 			retRule.ToNodes[j] = es
 		}
 	}

--- a/pkg/k8s/apis/cilium.io/utils/utils_test.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils_test.go
@@ -19,6 +19,12 @@ import (
 	"github.com/cilium/cilium/pkg/policy/api"
 )
 
+var (
+	podAnyPrefixLbl             = labels.LabelSourceAnyKeyPrefix + k8sConst.PodNamespaceLabel
+	clusterPrefixLbl            = labels.LabelSourceK8sKeyPrefix + k8sConst.PolicyLabelCluster
+	podAnyNamespaceLabelsPrefix = labels.LabelSourceAnyKeyPrefix + k8sConst.PodNamespaceMetaLabelsPrefix
+)
+
 func Test_namespacesAreValid(t *testing.T) {
 	require.True(t, namespacesAreValid("default", []string{}))
 	require.True(t, namespacesAreValid("default", []string{"default"}))
@@ -193,8 +199,9 @@ func Test_ParseToCiliumRule(t *testing.T) {
 			// current namespace
 			name: "parse-init-policy-namespaced",
 			args: args{
-				namespace: slim_metav1.NamespaceDefault,
-				uid:       uuid,
+				namespace:   slim_metav1.NamespaceDefault,
+				uid:         uuid,
+				clusterName: "cluster",
 				rule: &api.Rule{
 					EndpointSelector: api.NewESFromMatchRequirements(
 						nil,
@@ -239,7 +246,8 @@ func Test_ParseToCiliumRule(t *testing.T) {
 									labels.LabelSourceK8sKeyPrefix,
 									&slim_metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											k8sConst.PodNamespaceLabel: "default",
+											k8sConst.PodNamespaceLabel:         "default",
+											"k8s:io.cilium.k8s.policy.cluster": "cluster",
 										},
 									}),
 							},
@@ -274,8 +282,9 @@ func Test_ParseToCiliumRule(t *testing.T) {
 		{
 			name: "set-any-source-for-namespace",
 			args: args{
-				namespace: slim_metav1.NamespaceDefault,
-				uid:       uuid,
+				namespace:   slim_metav1.NamespaceDefault,
+				uid:         uuid,
+				clusterName: "cluster",
 				rule: &api.Rule{
 					EndpointSelector: api.NewESFromMatchRequirements(
 						map[string]string{
@@ -315,7 +324,8 @@ func Test_ParseToCiliumRule(t *testing.T) {
 									labels.LabelSourceAnyKeyPrefix,
 									&slim_metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											k8sConst.PodNamespaceLabel: "ns-2",
+											k8sConst.PodNamespaceLabel:         "ns-2",
+											"k8s:io.cilium.k8s.policy.cluster": "cluster",
 										},
 									}),
 							},
@@ -443,8 +453,9 @@ func Test_ParseToCiliumRule(t *testing.T) {
 			// by the namespace where the rule was inserted.
 			name: "parse-in-namespace-with-ns-labels-selector",
 			args: args{
-				namespace: slim_metav1.NamespaceDefault,
-				uid:       uuid,
+				namespace:   slim_metav1.NamespaceDefault,
+				uid:         uuid,
+				clusterName: "cluster",
 				rule: &api.Rule{
 					EndpointSelector: api.NewESFromMatchRequirements(
 						map[string]string{
@@ -485,6 +496,7 @@ func Test_ParseToCiliumRule(t *testing.T) {
 									&slim_metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											k8sConst.PodNamespaceMetaLabelsPrefix + "team": "team-a",
+											"k8s:io.cilium.k8s.policy.cluster":             "cluster",
 										},
 									}),
 							},
@@ -523,8 +535,9 @@ func Test_ParseToCiliumRule(t *testing.T) {
 			name: "wildcard-to-from-endpoints-with-ccnp",
 			args: args{
 				// Empty namespace for Clusterwide policy
-				namespace: "",
-				uid:       uuid,
+				namespace:   "",
+				uid:         uuid,
+				clusterName: "cluster",
 				rule: &api.Rule{
 					EndpointSelector: api.NewESFromMatchRequirements(
 						map[string]string{
@@ -560,11 +573,12 @@ func Test_ParseToCiliumRule(t *testing.T) {
 								api.NewESFromK8sLabelSelector(
 									labels.LabelSourceK8sKeyPrefix,
 									&slim_metav1.LabelSelector{
+										MatchLabels: map[string]string{"k8s:io.cilium.k8s.policy.cluster": "cluster"},
 										MatchExpressions: []slim_metav1.LabelSelectorRequirement{
 											{
 												Key:      k8sConst.PodNamespaceLabel,
 												Operator: slim_metav1.LabelSelectorOpExists,
-												Values:   []string{},
+												Values:   nil,
 											},
 										},
 									}),

--- a/pkg/k8s/apis/cilium.io/v2/types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/types_test.go
@@ -113,9 +113,15 @@ var (
 			{
 				IngressCommonRule: api.IngressCommonRule{
 					FromEndpoints: []api.EndpointSelector{
-						api.NewESFromLabels(
-							labels.ParseSelectLabel("role=frontend"),
-							labels.ParseSelectLabel("k8s:"+k8sConst.PodNamespaceLabel+"=default"),
+						api.NewESFromMatchRequirements(
+							map[string]string{
+								"role":                              "frontend",
+								"k8s:" + k8sConst.PodNamespaceLabel: "default",
+							},
+							[]slim_metav1.LabelSelectorRequirement{{
+								Key:      "k8s:io.cilium.k8s.policy.cluster",
+								Operator: "Exists",
+							}},
 						),
 						api.NewESFromLabels(
 							labels.ParseSelectLabel("reserved:world"),

--- a/pkg/k8s/cluster_network_policy.go
+++ b/pkg/k8s/cluster_network_policy.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/types"
+	"github.com/cilium/cilium/pkg/policy/utils"
 )
 
 const (
@@ -56,24 +57,31 @@ func toSlimLabelSelector(ls *metav1.LabelSelector) *slim_metav1.LabelSelector {
 	return result
 }
 
-func kcnpProcessNamespaceSelector(namespaces *metav1.LabelSelector) *slim_metav1.LabelSelector {
-	return processNamespaceSelector(toSlimLabelSelector(namespaces))
+func kcnpProcessNamespaceSelector(clusterName string, namespaces *metav1.LabelSelector, isSubject bool) api.EndpointSelector {
+	ls := processNamespaceSelector(toSlimLabelSelector(namespaces))
+	es := api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, ls)
+	if !isSubject {
+		utils.EnsureClusterSelector(&es, clusterName)
+	}
+	utils.EnsureNamespaceSelector(&es, "")
+	return es
 }
 
 // kcnpParseNamespacedPod converts a NamespacedPod into an EndpointSelector,
 // which selects all the specified pods in the specified namespaces. If a
 // cluster name is provided and the pod selector does not already explicitly
 // target a cluster, a selector targeting the named cluster will be added.
-func kcnpParseNamespacedPod(clusterName string, peer policyv1alpha2.NamespacedPod) *types.LabelSelector {
+func kcnpParseNamespacedPod(clusterName string, peer policyv1alpha2.NamespacedPod, subject bool) *types.LabelSelector {
 	podSelector := toSlimLabelSelector(&peer.PodSelector)
 	es := api.NewESFromK8sLabelSelector(
 		labels.LabelSourceK8sKeyPrefix,
-		kcnpProcessNamespaceSelector(&peer.NamespaceSelector),
+		processNamespaceSelector(toSlimLabelSelector(&peer.NamespaceSelector)),
 		podSelector)
-
-	if clusterName != cmtypes.PolicyAnyCluster && !isPodSelectorSelectingCluster(podSelector) {
-		es.AddMatch(clusterPrefixLbl, clusterName)
+	if !subject {
+		utils.EnsureClusterSelector(&es, clusterName)
 	}
+	utils.EnsureNamespaceSelector(&es, "")
+
 	return types.NewLabelSelector(es)
 }
 
@@ -263,12 +271,9 @@ func ParseClusterNetworkPolicy(logger *slog.Logger, clusterName string, cnp *pol
 				// Only one of Namespaces or Pods will be non-nil.
 				switch {
 				case rule.Pods != nil:
-					ingress.L3 = types.Selectors{
-						kcnpParseNamespacedPod(clusterName, *rule.Pods),
-					}
+					ingress.L3 = types.Selectors{kcnpParseNamespacedPod(clusterName, *rule.Pods, false)}
 				case rule.Namespaces != nil:
-					ingress.L3 = types.ToSelectors(
-						api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, kcnpProcessNamespaceSelector(rule.Namespaces)))
+					ingress.L3 = types.ToSelectors(kcnpProcessNamespaceSelector(clusterName, rule.Namespaces, false))
 				default:
 					// If no destination endpoint can be identified, fail closed.
 					// For "Accept" rules, "fail closed" means: "treat the rule as matching no
@@ -316,10 +321,9 @@ func ParseClusterNetworkPolicy(logger *slog.Logger, clusterName string, cnp *pol
 				// Only one of Namespaces, Pods, Nodes, Networks or DomainNames will be non-nil.
 				switch {
 				case rule.Pods != nil:
-					egress.L3 = types.Selectors{kcnpParseNamespacedPod(clusterName, *rule.Pods)}
+					egress.L3 = types.Selectors{kcnpParseNamespacedPod(clusterName, *rule.Pods, false)}
 				case rule.Namespaces != nil:
-					egress.L3 = types.ToSelectors(
-						api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, kcnpProcessNamespaceSelector(rule.Namespaces)))
+					egress.L3 = types.ToSelectors(kcnpProcessNamespaceSelector(clusterName, rule.Namespaces, false))
 				case rule.Nodes != nil:
 					if !option.Config.EnableNodeSelectorLabels {
 						return nil, errors.New("egress.to.nodes is not supported since node selector labels are disabled")
@@ -387,9 +391,9 @@ func ParseClusterNetworkPolicy(logger *slog.Logger, clusterName string, cnp *pol
 	var subject *types.LabelSelector
 	// Only one of Namespaces or Pods will be non-nil.
 	if ns := cnp.Spec.Subject.Namespaces; ns != nil {
-		subject = types.NewLabelSelector(api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, kcnpProcessNamespaceSelector(ns)))
+		subject = types.NewLabelSelector(kcnpProcessNamespaceSelector(clusterName, ns, true))
 	} else if ps := cnp.Spec.Subject.Pods; ps != nil {
-		subject = kcnpParseNamespacedPod("", *ps)
+		subject = kcnpParseNamespacedPod("", *ps, true)
 	}
 
 	rules := append(ingresses, egresses...)

--- a/pkg/k8s/cluster_network_policy_test.go
+++ b/pkg/k8s/cluster_network_policy_test.go
@@ -22,6 +22,7 @@ import (
 
 const (
 	namespaceLabelPrefix = "io.cilium.k8s.namespace.labels."
+	clusterLabel         = "io.cilium.k8s.policy.cluster"
 )
 
 var (
@@ -52,12 +53,18 @@ var (
 	}))
 	l3EnvProdSelector = types.ToSelectors(
 		api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, &slim_metav1.LabelSelector{
-			MatchLabels: map[string]string{namespaceLabelPrefix + "env": "prod"},
+			MatchLabels: map[string]string{
+				namespaceLabelPrefix + "env": "prod",
+				clusterLabel:                 "testCluster",
+			},
 		}),
 	)
 	l3EnvDevSelector = types.ToSelectors(
 		api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, &slim_metav1.LabelSelector{
-			MatchLabels: map[string]string{namespaceLabelPrefix + "env": "dev"},
+			MatchLabels: map[string]string{
+				namespaceLabelPrefix + "env":   "dev",
+				"io.cilium.k8s.policy.cluster": "testCluster",
+			},
 		}),
 	)
 )
@@ -454,7 +461,7 @@ func TestParseClusterNetworkPolicy(t *testing.T) {
 			})),
 			L3: types.ToSelectors(
 				api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, &slim_metav1.LabelSelector{
-					MatchLabels: map[string]string{namespaceLabelPrefix + "role": "ingress-source"},
+					MatchLabels: map[string]string{namespaceLabelPrefix + "role": "ingress-source", clusterLabel: clusterName},
 				}),
 			),
 			L4:     portRule("80", api.ProtoTCP),
@@ -467,7 +474,7 @@ func TestParseClusterNetworkPolicy(t *testing.T) {
 			})),
 			L3: types.ToSelectors(
 				api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, &slim_metav1.LabelSelector{
-					MatchLabels: map[string]string{namespaceLabelPrefix + "role": "egress-dest"},
+					MatchLabels: map[string]string{namespaceLabelPrefix + "role": "egress-dest", clusterLabel: clusterName},
 				}),
 			),
 			L4:     portRule("53", api.ProtoUDP),

--- a/pkg/k8s/network_policy.go
+++ b/pkg/k8s/network_policy.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/types"
+	"github.com/cilium/cilium/pkg/policy/utils"
 )
 
 const (
@@ -74,6 +75,9 @@ func isPodSelectorSelectingCluster(podSelector *slim_metav1.LabelSelector) bool 
 }
 
 func processNamespaceSelector(ns *slim_metav1.LabelSelector) *slim_metav1.LabelSelector {
+	if ns == nil {
+		return nil
+	}
 	namespaceSelector := &slim_metav1.LabelSelector{
 		MatchLabels: make(map[string]string, len(ns.MatchLabels)),
 	}
@@ -131,14 +135,10 @@ func parseNetworkPolicyPeer(clusterName, namespace string, peer *slim_networking
 		podSelector.MatchLabels[k8sConst.PolicyLabelCluster] = clusterName
 	}
 
-	if peer.NamespaceSelector != nil {
-		namespaceSelector := processNamespaceSelector(peer.NamespaceSelector)
-		es := api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, namespaceSelector, podSelector)
-		return types.Selectors{types.NewLabelSelector(es)}
-	}
-
-	podSelector = parsePodSelector(podSelector, namespace)
-	es := api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, podSelector)
+	namespaceSelector := processNamespaceSelector(peer.NamespaceSelector)
+	es := api.NewESFromK8sLabelSelector(labels.LabelSourceK8sKeyPrefix, podSelector, namespaceSelector)
+	utils.EnsureClusterSelector(&es, clusterName)
+	utils.EnsureNamespaceSelector(&es, namespace)
 	return types.Selectors{types.NewLabelSelector(es)}
 }
 

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -33,6 +33,7 @@ import (
 var (
 	labelsA = labels.LabelArray{
 		labels.NewLabel(k8sConst.PodNamespaceLabel, slim_metav1.NamespaceDefault, labels.LabelSourceK8s),
+		labels.NewLabel(k8sConst.PolicyLabelCluster, "cluster", labels.LabelSourceK8s),
 		labels.NewLabel("id", "a", labels.LabelSourceK8s),
 	}.Sort()
 	nidA = identity.NumericIdentity(1001)
@@ -46,6 +47,7 @@ var (
 
 	labelsB = labels.LabelArray{
 		labels.NewLabel(k8sConst.PodNamespaceLabel, slim_metav1.NamespaceDefault, labels.LabelSourceK8s),
+		labels.NewLabel(k8sConst.PolicyLabelCluster, "cluster", labels.LabelSourceK8s),
 		labels.NewLabel("id1", "b", labels.LabelSourceK8s),
 		labels.NewLabel("id2", "c", labels.LabelSourceK8s),
 	}.Sort()
@@ -59,6 +61,7 @@ var (
 
 	labelsC = labels.LabelArray{
 		labels.NewLabel(k8sConst.PodNamespaceLabel, slim_metav1.NamespaceDefault, labels.LabelSourceK8s),
+		labels.NewLabel(k8sConst.PolicyLabelCluster, "cluster", labels.LabelSourceK8s),
 		labels.NewLabel("id", "c", labels.LabelSourceK8s),
 	}.Sort()
 	nidC = identity.NumericIdentity(1003)
@@ -73,6 +76,7 @@ var (
 	labelsOther = labels.LabelArray{
 		labels.NewLabel("io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name", "other", labels.LabelSourceK8s),
 		labels.NewLabel(k8sConst.PodNamespaceLabel, "other", labels.LabelSourceK8s),
+		labels.NewLabel(k8sConst.PolicyLabelCluster, "cluster", labels.LabelSourceK8s),
 		labels.NewLabel("id", "other", labels.LabelSourceK8s),
 	}.Sort()
 	nidOther = identity.NumericIdentity(1004)
@@ -211,6 +215,7 @@ func TestParseNetworkPolicy(t *testing.T) {
 					labels.NewLabel(k8sConst.PodNamespaceLabel, slim_metav1.NamespaceDefault, labels.LabelSourceK8s),
 					labels.NewLabel("foo3", "bar3", labels.LabelSourceK8s),
 					labels.NewLabel("foo4", "bar4", labels.LabelSourceK8s),
+					labels.NewLabel(k8sConst.PolicyLabelCluster, "cluster", labels.LabelSourceK8s),
 				)),
 				L4: api.PortRules{{
 					Ports: []api.PortProtocol{{
@@ -290,6 +295,7 @@ func TestParseNetworkPolicy(t *testing.T) {
 					labels.NewLabel("foo3", "bar3", labels.LabelSourceK8s),
 					labels.NewLabel("foo4", "bar4", labels.LabelSourceK8s),
 					labels.NewLabel("io.cilium.k8s.namespace.labels.nsfoo", "nsbar", labels.LabelSourceK8s),
+					labels.NewLabel(k8sConst.PolicyLabelCluster, "cluster", labels.LabelSourceK8s),
 				)),
 				L4: api.PortRules{{
 					Ports: []api.PortProtocol{{
@@ -342,6 +348,7 @@ func TestParseNetworkPolicy(t *testing.T) {
 				Tier:        policytypes.Normal,
 				L3: policytypes.ToSelectors(api.NewESFromLabels(
 					labels.NewLabel(k8sConst.PodNamespaceLabel, slim_metav1.NamespaceDefault, labels.LabelSourceK8s),
+					labels.NewLabel(k8sConst.PolicyLabelCluster, "cluster", labels.LabelSourceK8s),
 				)),
 			},
 		},
@@ -378,7 +385,7 @@ func TestParseNetworkPolicy(t *testing.T) {
 				"k8s:io.cilium.k8s.policy.uid=test-uid",
 			)
 
-			rules, err := ParseNetworkPolicy(hivetest.Logger(t), cmtypes.PolicyAnyCluster, np)
+			rules, err := ParseNetworkPolicy(hivetest.Logger(t), "cluster", np)
 			require.NoError(t, err)
 			require.Len(t, rules, 1)
 			require.Equal(t, &tc.out, rules[0])
@@ -907,6 +914,7 @@ func TestNetworkPolicyExamples(t *testing.T) {
 	makePod := func(namespace string, podLabels, nsLabels map[string]string) *identity.Identity {
 		lbls := labels.LabelArray{
 			labels.NewLabel(k8sConst.PodNamespaceLabel, namespace, labels.LabelSourceK8s),
+			labels.NewLabel(k8sConst.PolicyLabelCluster, "cluster", labels.LabelSourceK8s),
 		}
 		for k, v := range podLabels {
 			lbls = append(lbls, labels.NewLabel(k, v, labels.LabelSourceK8s))
@@ -1679,13 +1687,17 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 					},
 					[]slim_metav1.LabelSelectorRequirement{
 						{
+							Key:      "k8s:foo",
+							Operator: slim_metav1.LabelSelectorOpIn,
+							Values:   []string{"bar", "baz"},
+						},
+						{
 							Key:      "k8s:io.cilium.k8s.namespace.labels.ns-foo-expression",
 							Operator: slim_metav1.LabelSelectorOpExists,
 						},
 						{
-							Key:      "k8s:foo",
-							Operator: slim_metav1.LabelSelectorOpIn,
-							Values:   []string{"bar", "baz"},
+							Key:      "k8s:" + k8sConst.PolicyLabelCluster,
+							Operator: slim_metav1.LabelSelectorOpExists,
 						},
 					},
 				),
@@ -1719,6 +1731,10 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 							Key:      "k8s:io.cilium.k8s.namespace.labels.ns-foo-expression",
 							Operator: slim_metav1.LabelSelectorOpExists,
 						},
+						{
+							Key:      "k8s:" + k8sConst.PolicyLabelCluster,
+							Operator: slim_metav1.LabelSelectorOpExists,
+						},
 					},
 				),
 			)},
@@ -1737,6 +1753,10 @@ func Test_parseNetworkPolicyPeer(t *testing.T) {
 					[]slim_metav1.LabelSelectorRequirement{
 						{
 							Key:      fmt.Sprintf("%s:%s", labels.LabelSourceK8s, k8sConst.PodNamespaceLabel),
+							Operator: slim_metav1.LabelSelectorOpExists,
+						},
+						{
+							Key:      "k8s:" + k8sConst.PolicyLabelCluster,
 							Operator: slim_metav1.LabelSelectorOpExists,
 						},
 					},

--- a/pkg/policy/k8s/service_test.go
+++ b/pkg/policy/k8s/service_test.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
@@ -430,6 +431,7 @@ func TestPolicyWatcher_updateToServicesPolicies(t *testing.T) {
 	assert.Len(t, rules[0].L3, 1)
 
 	bazEndpointSelector := newEndpointSelectorForServiceSelector(bazSvcID.Namespace(), bazSvcSelector)
+	bazEndpointSelector.AddMatchExpression("k8s:"+k8sConst.PolicyLabelCluster, "Exists", nil)
 	assert.Equal(t, bazEndpointSelector.LabelSelector.String(), rules[0].L3[0].Key())
 
 	// Check that policy has been marked
@@ -537,6 +539,7 @@ func TestPolicyWatcher_updateToServicesPoliciesTransformToEndpoint(t *testing.T)
 	assert.Len(t, rules[0].L3, 1)
 
 	fooEndpointSelector := newEndpointSelectorForServiceSelector(fooSvcID.Namespace(), fooSvcSelector)
+	fooEndpointSelector.AddMatchExpression("k8s:"+k8sConst.PolicyLabelCluster, "Exists", nil)
 	assert.Equal(t, fooEndpointSelector.LabelSelector.String(), rules[0].L3[0].Key())
 
 	// Check that policies have been marked
@@ -615,6 +618,7 @@ func TestPolicyWatcher_updateToServicesPoliciesTransformToEndpoint(t *testing.T)
 	assert.Len(t, rules[0].L3, 1)
 
 	barEndpointSelector := newEndpointSelectorForServiceSelector(barSvcID.Namespace(), barSvcLabels)
+	barEndpointSelector.AddMatchExpression("k8s:"+k8sConst.PolicyLabelCluster, "Exists", nil)
 	assert.Equal(t, barEndpointSelector.LabelSelector.String(), rules[0].L3[0].Key())
 
 	// Check that policies have been marked

--- a/pkg/policy/utils/selector.go
+++ b/pkg/policy/utils/selector.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package utils
+
+import (
+	"strings"
+
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy/api"
+)
+
+var (
+	namespaceLabels = []string{
+		k8sConst.PodNamespaceMetaLabelsPrefix,
+		k8sConst.PodNamespaceLabel,
+	}
+
+	clusterLabel = labels.LabelSourceK8sKeyPrefix + k8sConst.PolicyLabelCluster
+)
+
+// EnsureNamespaceSelector ensures that there is at least some namespace constraint
+// in the given endpoint selector
+func EnsureNamespaceSelector(es *api.EndpointSelector, namespace string) {
+	var positive, negative bool
+
+	// Ensure there is a namespace selector.
+	//
+	// Namespaces can be selected by the namespace label ("io.kubernetes.pod.namespace")
+	// or the special namespae label prefix ("io.cilium.k8s.namespace.labels.<XXX>")
+	for _, lbl := range namespaceLabels {
+		p, n := esSelects(es, lbl)
+		positive = positive || p
+		negative = negative || n
+	}
+
+	// Add a namespace specifier if needed.
+	if !positive {
+		// If there is a negative specifier, or there is no desired namespace (e.g. CCNP),
+		// then just add an Exists specifier
+		if negative || namespace == "" {
+			es.AddMatchExpression(
+				labels.LabelSourceK8sKeyPrefix+k8sConst.PodNamespaceLabel,
+				slim_metav1.LabelSelectorOpExists,
+				nil)
+		} else {
+			es.AddMatch(labels.LabelSourceK8sKeyPrefix+k8sConst.PodNamespaceLabel, namespace)
+		}
+	}
+}
+
+func EnsureClusterSelector(es *api.EndpointSelector, clustername string) {
+	positive, negative := esSelects(es, clusterLabel)
+	if !positive {
+		if negative || clustername == "" {
+			es.AddMatchExpression(
+				labels.LabelSourceK8sKeyPrefix+k8sConst.PolicyLabelCluster,
+				slim_metav1.LabelSelectorOpExists,
+				nil)
+		} else {
+			es.AddMatch(labels.LabelSourceK8sKeyPrefix+k8sConst.PolicyLabelCluster, clustername)
+		}
+	}
+}
+
+// esSelects determines if a given key is selected via a label selector.
+// key is a prefix.
+//
+// positive returns true if there is a positive selector (direct label, In, or Exists)
+// negative returns true if there is a negative selector (NotIn or NotExists)
+// short-cuts as soon as a positive match is found
+func esSelects(es *api.EndpointSelector, key string) (positive, negative bool) {
+	for _, src := range searchSources {
+		wantKey := src + key
+		for k := range es.MatchLabels {
+			if strings.HasPrefix(k, wantKey) {
+				positive = true
+				return
+			}
+		}
+		for _, expr := range es.MatchExpressions {
+			if strings.HasPrefix(expr.Key, wantKey) {
+				if expr.Operator == slim_metav1.LabelSelectorOpIn || expr.Operator == slim_metav1.LabelSelectorOpExists {
+					positive = true
+					return
+				} else {
+					negative = true
+				}
+			}
+		}
+	}
+	return positive, negative
+}
+
+var searchSources = []string{
+	"",
+	labels.LabelSourceK8sKeyPrefix,
+	labels.LabelSourceAnyKeyPrefix,
+}

--- a/pkg/policy/utils/selector_test.go
+++ b/pkg/policy/utils/selector_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package utils
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy/api"
+)
+
+func TestEnsureNamespaceSelector(t *testing.T) {
+	for i, tc := range []struct {
+		in, out api.EndpointSelector
+		ns      string
+	}{
+		{
+			in:  api.NewESFromLabels(labels.NewLabel("io.kubernetes.pod.namespace", "foo", "k8s")),
+			out: api.NewESFromLabels(labels.NewLabel("io.kubernetes.pod.namespace", "foo", "k8s")),
+			ns:  "bar",
+		},
+		{
+			in:  api.NewESFromLabels(labels.NewLabel("other", "", "")),
+			out: api.NewESFromLabels(labels.NewLabel("other", "", ""), labels.NewLabel("io.kubernetes.pod.namespace", "bar", "k8s")),
+			ns:  "bar",
+		},
+		{
+			in: api.NewESFromMatchRequirements(nil, []slim_metav1.LabelSelectorRequirement{{
+				Key:      "io.kubernetes.pod.namespace",
+				Operator: "In",
+				Values:   []string{"foo"},
+			}}),
+			out: api.NewESFromMatchRequirements(nil, []slim_metav1.LabelSelectorRequirement{{
+				Key:      "io.kubernetes.pod.namespace",
+				Operator: "In",
+				Values:   []string{"foo"},
+			}}),
+			ns: "bar",
+		},
+		{
+			in: api.NewESFromMatchRequirements(nil, []slim_metav1.LabelSelectorRequirement{{
+				Key:      "io.kubernetes.pod.namespace",
+				Operator: "NotIn",
+				Values:   []string{"foo"},
+			}}),
+			out: api.NewESFromMatchRequirements(nil, []slim_metav1.LabelSelectorRequirement{
+				{
+					Key:      "io.kubernetes.pod.namespace",
+					Operator: "NotIn",
+					Values:   []string{"foo"},
+				},
+				{
+					Key:      "k8s:io.kubernetes.pod.namespace",
+					Operator: "Exists",
+				},
+			}),
+			ns: "bar",
+		},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			out := tc.in.DeepCopy()
+			EnsureNamespaceSelector(out, tc.ns)
+			require.Equal(t, &tc.out, out)
+		})
+	}
+
+}


### PR DESCRIPTION
Fixes: #46949 

Consider the following k8s network policy:

```yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: allow-ns-notin
spec:
  egress:
  - to:
    - namespaceSelector:
        matchExpressions:
        - key: kubernetes.io/metadata.name
          operator: NotIn
          values:
          - foo2
  podSelector:
    matchLabels: {}
  policyTypes:
  - Egress
```

Or the equivalent CNP:

```yaml
apiVersion: cilium.io/v2
kind: CiliumNetworkPolicy
metadata:
  name: allow-ns-notin
spec:
  endpointSelector:
    matchLabels:
      app: client
  egress:
  - toEndpoints:
      - matchExpressions:
          - key: io.kubernetes.pod.namespace
            operator: NotIn
            values: ["foo2"]
```

Before this change, these would create selectors that inadvertently selected all identities (except those in namespace foo2), including `host`, `world`, `ingress`, etc. This is because the NotIn selector does not require the existence of the label.

There is code that forces namespace selectors, but it incorrectly skipped NotIn selectors.

This change fixes that. It ensures that CNP and KNP always have a namespace and cluster selector. This ensures they only select endpoints.