### PR TITLE
hubble: Remove dead Kafka L7 protocol handling

### DIFF
--- a/Documentation/network/servicemesh/index.rst
+++ b/Documentation/network/servicemesh/index.rst
@@ -53,7 +53,7 @@ by operating at both the networking and the application protocol layer to provid
 connectivity, load-balancing, security, and observability. For all network
 processing including protocols such as IP, TCP, and UDP, Cilium uses eBPF as the
 highly efficient in-kernel datapath. Protocols at the application layer such as
-HTTP, Kafka, gRPC, and DNS are parsed using a proxy such as Envoy. 
+HTTP, gRPC, and DNS are parsed using a proxy such as Envoy.
 
 .. toctree::
    :maxdepth: 3

--- a/Documentation/overview/intro.rst
+++ b/Documentation/overview/intro.rst
@@ -49,8 +49,7 @@ Service dependencies & communication map
 
 * What services are communicating with each other? How frequently? What does
   the service dependency graph look like?
-* What HTTP calls are being made? What Kafka topics does a service consume from
-  or produce to?
+* What HTTP calls are being made?
 
 Network monitoring & alerting
 -----------------------------

--- a/Documentation/reference-guides/bpf/resources.rst
+++ b/Documentation/reference-guides/bpf/resources.rst
@@ -143,7 +143,7 @@ legacy cBPF:
   between application workloads such as application containers or processes. Cilium
   operates at Layer 3/4 to provide traditional networking and security services
   as well as Layer 7 to protect and secure use of modern application protocols
-  such as HTTP, gRPC and Kafka. It is integrated into orchestration frameworks
+  such as HTTP and gRPC. It is integrated into orchestration frameworks
   such as Kubernetes. BPF is the foundational part of Cilium that operates in
   the kernel's networking data path.
 

--- a/Documentation/security/policy/layer7.rst
+++ b/Documentation/security/policy/layer7.rst
@@ -24,11 +24,6 @@ enumeration of protocol specific fields.
                 // +optional
                 HTTP []PortRuleHTTP `json:"http,omitempty"`
 
-                // Kafka-specific rules.
-                //
-                // +optional
-                Kafka []PortRuleKafka `json:"kafka,omitempty"`
-
                 // DNS-specific rules.
                 //
                 // +optional

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -6,7 +6,7 @@ Cilium is open source software for providing and transparently securing
 network connectivity and loadbalancing between application workloads such as
 application containers or processes. Cilium operates at Layer 3/4 to provide
 traditional networking and security services as well as Layer 7 to protect and
-secure use of modern application protocols such as HTTP, gRPC and Kafka.
+secure use of modern application protocols such as HTTP and gRPC.
 
 A new Linux kernel technology called eBPF is at the foundation of Cilium.
 It supports dynamic insertion of eBPF bytecode into the Linux kernel at various

--- a/install/kubernetes/cilium/README.md.gotmpl
+++ b/install/kubernetes/cilium/README.md.gotmpl
@@ -8,7 +8,7 @@ Cilium is open source software for providing and transparently securing
 network connectivity and loadbalancing between application workloads such as
 application containers or processes. Cilium operates at Layer 3/4 to provide
 traditional networking and security services as well as Layer 7 to protect and
-secure use of modern application protocols such as HTTP, gRPC and Kafka.
+secure use of modern application protocols such as HTTP and gRPC.
 
 A new Linux kernel technology called eBPF is at the foundation of Cilium.
 It supports dynamic insertion of eBPF bytecode into the Linux kernel at various

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1127,10 +1127,6 @@ data:
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if .Values.hubble.redact.kafka }}
-  # Enables redaction of the Kafka API key part in flows
-  hubble-redact-kafka-apikey: {{ .Values.hubble.redact.kafka.apiKey | quote }}
-{{- end }}
 {{- end }}
 {{- end }}
 {{- if .Values.hubble.export }}

--- a/pkg/hubble/api/v1/flow.go
+++ b/pkg/hubble/api/v1/flow.go
@@ -26,8 +26,6 @@ func FlowProtocol(flow *pb.Flow) string {
 				return "DNS"
 			case l7.GetHttp() != nil:
 				return "HTTP"
-			case l7.GetKafka() != nil:
-				return "Kafka"
 			}
 		}
 		return "Unknown L7"

--- a/pkg/hubble/metrics/flow/handler.go
+++ b/pkg/hubble/metrics/flow/handler.go
@@ -82,8 +82,6 @@ func (h *flowHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error 
 				subType = "DNS"
 			case l7.GetHttp() != nil:
 				subType = "HTTP"
-			case l7.GetKafka() != nil:
-				subType = "Kafka"
 			}
 		}
 	case monitorAPI.MessageTypeDrop:

--- a/pkg/hubble/metrics/policy/handler.go
+++ b/pkg/hubble/metrics/policy/handler.go
@@ -115,8 +115,6 @@ func (h *policyHandler) ProcessFlowL7(ctx context.Context, flow *flowpb.Flow) er
 			subType = "dns"
 		case l7.GetHttp() != nil:
 			subType = "http"
-		case l7.GetKafka() != nil:
-			subType = "kafka"
 		}
 	}
 	match := fmt.Sprintf("l7/%s", subType)

--- a/pkg/proxy/accesslog/tags.go
+++ b/pkg/proxy/accesslog/tags.go
@@ -25,13 +25,6 @@ const (
 	FieldMessage  = "message"
 )
 
-// fields used for structured logging of Kafka messages
-const (
-	FieldKafkaAPIKey        = "kafkaApiKey"
-	FieldKafkaAPIVersion    = "kafkaApiVersion"
-	FieldKafkaCorrelationID = "kafkaCorrelationID"
-)
-
 // LogTag attaches a tag to a log record
 type LogTag func(lr *LogRecord, endpointInfoRegistry EndpointInfoRegistry)
 


### PR DESCRIPTION
<!-- Description of change -->

Kafka policy support was removed from Cilium in the below PR. Remove the leftover Kafka case branches from Hubble's flow protocol identification and metrics classification code, as these code paths are now unreachable.

The Kafka message and fields in flow.proto are kept as deprecated for backward compatibility with older Cilium releases.

Relates: #43557
Fixes: #44551


```release-note
hubble: Remove dead Kafka L7 protocol handling
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
