### PR TITLE
Migrate `Node.IPv{4,6}HealthIP` and `RoutingInfo.Configure` to netip

### DIFF
--- a/daemon/infraendpoints/infra_ip_allocation.go
+++ b/daemon/infraendpoints/infra_ip_allocation.go
@@ -304,7 +304,7 @@ func (r *infraIPAllocator) reallocateRouterIPs(ctx context.Context, family node.
 		}
 
 		if err = routingInfo.Configure(
-			net.IP(result.IP.AsSlice()).To16(),
+			result.IP,
 			r.mtuManager.GetDeviceMTU(),
 			true,
 		); err != nil {
@@ -476,7 +476,7 @@ func (r *infraIPAllocator) allocateIngressIPs(oldV4IngressIP net.IP, oldV6Ingres
 				r.logger.Warn("Unable to allocate ingress information for ENI", logfields.Error, err)
 			} else {
 				if err := ingressRouting.Configure(
-					net.IP(result.IP.AsSlice()).To16(),
+					result.IP,
 					r.mtuManager.GetDeviceMTU(),
 					false,
 				); err != nil {

--- a/daemon/infraendpoints/infra_ip_allocation.go
+++ b/daemon/infraendpoints/infra_ip_allocation.go
@@ -346,32 +346,32 @@ func (r *infraIPAllocator) reallocateRouterIPs(ctx context.Context, family node.
 	return net.IP(result.IP.AsSlice()).To16(), nil
 }
 
-func (r *infraIPAllocator) allocateHealthIPs(oldV4HealthIP net.IP, oldV6HealthIP net.IP) error {
+func (r *infraIPAllocator) allocateHealthIPs(oldV4HealthIP netip.Addr, oldV6HealthIP netip.Addr) error {
 	if !r.daemonConfig.EnableHealthChecking || !r.daemonConfig.EnableEndpointHealthChecking {
 		return nil
 	}
-	var healthIPv4, healthIPv6 net.IP
+	var healthIPv4, healthIPv6 netip.Addr
 	if r.daemonConfig.EnableIPv4 {
 		var result *ipam.AllocationResult
 		var err error
 		healthIPv4 = oldV4HealthIP
-		if healthIPv4 != nil {
-			result, err = r.ipAllocator.AllocateIPWithoutSyncUpstream(iputil.AddrFromIP(healthIPv4), "health", ipam.PoolDefault())
+		if healthIPv4.IsValid() {
+			result, err = r.ipAllocator.AllocateIPWithoutSyncUpstream(healthIPv4, "health", ipam.PoolDefault())
 			if err != nil {
 				r.logger.Warn(
 					"unable to re-allocate health IPv4, a new health IPv4 will be allocated",
 					logfields.Error, err,
 					logfields.IPv4, healthIPv4,
 				)
-				healthIPv4 = nil
+				healthIPv4 = netip.Addr{}
 			}
 		}
-		if healthIPv4 == nil {
+		if !healthIPv4.IsValid() {
 			result, err = r.ipAllocator.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv4, "health", ipam.PoolDefault())
 			if err != nil {
 				return fmt.Errorf("unable to allocate health IPv4: %w, see https://cilium.link/ipam-range-full", err)
 			}
-			r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv4HealthIP = net.IP(result.IP.AsSlice()).To16() })
+			r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv4HealthIP = iputil.AddrFrom(result.IP) })
 		}
 
 		// Coalescing multiple CIDRs. GH #18868
@@ -398,27 +398,27 @@ func (r *infraIPAllocator) allocateHealthIPs(oldV4HealthIP net.IP, oldV6HealthIP
 		var result *ipam.AllocationResult
 		var err error
 		healthIPv6 = oldV6HealthIP
-		if healthIPv6 != nil {
-			result, err = r.ipAllocator.AllocateIPWithoutSyncUpstream(iputil.AddrFromIP(healthIPv6), "health", ipam.PoolDefault())
+		if healthIPv6.IsValid() {
+			result, err = r.ipAllocator.AllocateIPWithoutSyncUpstream(healthIPv6, "health", ipam.PoolDefault())
 			if err != nil {
 				r.logger.Warn(
 					"unable to re-allocate health IPv6, a new health IPv6 will be allocated",
 					logfields.Error, err,
 					logfields.IPv6, healthIPv6,
 				)
-				healthIPv6 = nil
+				healthIPv6 = netip.Addr{}
 			}
 		}
-		if healthIPv6 == nil {
+		if !healthIPv6.IsValid() {
 			result, err = r.ipAllocator.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv6, "health", ipam.PoolDefault())
 			if err != nil {
-				if healthIPv4 != nil {
-					r.ipAllocator.ReleaseIP(iputil.AddrFromIP(healthIPv4), ipam.PoolDefault())
-					r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv4HealthIP = nil })
+				if healthIPv4.IsValid() {
+					r.ipAllocator.ReleaseIP(healthIPv4, ipam.PoolDefault())
+					r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv4HealthIP = iputil.Addr{} })
 				}
 				return fmt.Errorf("unable to allocate health IPv6: %w, see https://cilium.link/ipam-range-full", err)
 			}
-			r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv6HealthIP = net.IP(result.IP.AsSlice()).To16() })
+			r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv6HealthIP = iputil.AddrFrom(result.IP) })
 		}
 		r.logger.Debug("Allocated IPv6 health endpoint address", logfields.IPAddr, result.IP)
 	}
@@ -557,7 +557,7 @@ func (r *infraIPAllocator) AllocateIPs(ctx context.Context) error {
 		return fmt.Errorf("failed to allocate ingress IPs: %w", err)
 	}
 
-	if err := r.allocateHealthIPs(localNode.IPv4HealthIP, localNode.IPv6HealthIP); err != nil {
+	if err := r.allocateHealthIPs(localNode.IPv4HealthIP.Addr, localNode.IPv6HealthIP.Addr); err != nil {
 		return fmt.Errorf("failed to allocate health IPs: %w", err)
 	}
 

--- a/pkg/datapath/linux/routing/routing.go
+++ b/pkg/datapath/linux/routing/routing.go
@@ -43,8 +43,8 @@ func (info *RoutingInfo) useCompatEgressPriority() bool {
 // info: The interface routing info used to create rules and routes.
 // mtu: The interface MTU.
 // host: Whether the IP is a host IP and needs to be routed via the 'local' table
-func (info *RoutingInfo) Configure(ip net.IP, mtu int, host bool) error {
-	if ip == nil || (ip.To4() == nil && ip.To16() == nil) {
+func (info *RoutingInfo) Configure(ip netip.Addr, mtu int, host bool) error {
+	if !ip.IsValid() {
 		info.logger.Warn(
 			"Unable to configure rules and routes because IP is not a valid IP address",
 			logfields.IPAddr, ip,
@@ -57,21 +57,13 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, host bool) error {
 		return fmt.Errorf("unable to find ifindex for interface MAC: %w", err)
 	}
 
-	var ipWithMask net.IPNet
-	var replaceRule func(route.Rule) error
+	ipWithMask := netipx.AddrIPNet(ip)
 
-	if ip.To4() != nil {
+	var replaceRule func(route.Rule) error
+	if ip.Is4() {
 		replaceRule = route.ReplaceRule
-		ipWithMask = net.IPNet{
-			IP:   ip,
-			Mask: net.CIDRMask(32, 32),
-		}
 	} else {
 		replaceRule = route.ReplaceRuleIPv6
-		ipWithMask = net.IPNet{
-			IP:   ip,
-			Mask: net.CIDRMask(128, 128),
-		}
 	}
 
 	// Ingress rule. This rule is not installed for the cilium_host IP, because
@@ -82,7 +74,7 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, host bool) error {
 		// table. Egress rules are created in a per-ENI routing table.
 		if err := replaceRule(route.Rule{
 			Priority: linux_defaults.RulePriorityIngress,
-			To:       &ipWithMask,
+			To:       ipWithMask,
 			Table:    route.MainTable,
 			Protocol: linux_defaults.RTProto,
 		}); err != nil {
@@ -109,7 +101,7 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, host bool) error {
 		for _, cidr := range info.CIDRs {
 			if err := replaceRule(route.Rule{
 				Priority: egressPriority,
-				From:     &ipWithMask,
+				From:     ipWithMask,
 				To:       normalizeRuleToCIDR(&cidr),
 				Table:    tableID,
 				Protocol: linux_defaults.RTProto,
@@ -121,7 +113,7 @@ func (info *RoutingInfo) Configure(ip net.IP, mtu int, host bool) error {
 		// Lookup a VPC specific table for all traffic from an endpoint.
 		if err := replaceRule(route.Rule{
 			Priority: egressPriority,
-			From:     &ipWithMask,
+			From:     ipWithMask,
 			Table:    tableID,
 			Protocol: linux_defaults.RTProto,
 		}); err != nil {
@@ -263,7 +255,7 @@ func (info *RoutingInfo) installRoutes(ifindex, tableID int) error {
 // the IP & priority. In order to avoid leaving stale rules behind, all the
 // matching rules are removed.
 func Delete(logger *slog.Logger, ip netip.Addr) error {
-	if !ip.Is4() && !ip.Is6() && !ip.IsValid() {
+	if !ip.IsValid() {
 		logger.Warn(
 			"Unable to delete rules because IP is not a valid IP address",
 			logfields.IPAddr, ip,

--- a/pkg/datapath/linux/routing/routing_test.go
+++ b/pkg/datapath/linux/routing/routing_test.go
@@ -87,7 +87,7 @@ func TestPrivilegedConfigureRouteWithIncompatibleIP(t *testing.T) {
 	setupLinuxRoutingSuite(t)
 
 	_, ri := getFakes(t, ipamOption.IPAMENI, true, false)
-	err := ri.Configure(nil, 1500, false)
+	err := ri.Configure(netip.Addr{}, 1500, false)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "IP not compatible")
 }
@@ -209,7 +209,7 @@ func runConfigureThenDelete(t *testing.T, ri RoutingInfo, ip netip.Addr, mtu int
 }
 
 func runConfigure(t *testing.T, ri RoutingInfo, ip netip.Addr, mtu int) {
-	err := ri.Configure(ip.AsSlice(), mtu, false)
+	err := ri.Configure(ip, mtu, false)
 	require.NoError(t, err)
 }
 

--- a/pkg/health/health_connectivity_endpoint.go
+++ b/pkg/health/health_connectivity_endpoint.go
@@ -384,7 +384,7 @@ func (h *ciliumHealthManager) launchAsEndpoint(baseCtx context.Context, endpoint
 		}
 		// ENI mode does not support IPv6.
 		if err := ri.Configure(
-			healthIP.AsSlice(),
+			healthIP,
 			mtuConfig.GetDeviceMTU(),
 			false,
 		); err != nil {

--- a/pkg/health/health_connectivity_endpoint.go
+++ b/pkg/health/health_connectivity_endpoint.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -248,7 +249,7 @@ func (h *ciliumHealthManager) launchAsEndpoint(baseCtx context.Context, endpoint
 			State:      models.EndpointStateWaitingDashForDashIdentity.Pointer(),
 			Addressing: &models.AddressPair{},
 		}
-		healthIP               net.IP
+		healthIP               netip.Addr
 		ip4Address, ip6Address *net.IPNet
 	)
 
@@ -257,18 +258,18 @@ func (h *ciliumHealthManager) launchAsEndpoint(baseCtx context.Context, endpoint
 		return nil, fmt.Errorf("failed to get local node: %w", err)
 	}
 
-	if healthIPv6 := ln.IPv6HealthIP; healthIPv6 != nil {
+	if healthIPv6 := ln.IPv6HealthIP; healthIPv6.IsValid() {
 		info.Addressing.IPv6 = healthIPv6.String()
 		info.Addressing.IPv6PoolName = ipam.PoolDefault().String()
-		ip6Address = &net.IPNet{IP: healthIPv6, Mask: defaults.ContainerIPv6Mask}
-		healthIP = healthIPv6
+		ip6Address = &net.IPNet{IP: healthIPv6.AsSlice(), Mask: defaults.ContainerIPv6Mask}
+		healthIP = healthIPv6.Addr
 	}
-	if healthIPv4 := ln.IPv4HealthIP; healthIPv4 != nil {
+	if healthIPv4 := ln.IPv4HealthIP; healthIPv4.IsValid() {
 		info.Addressing.IPv4 = healthIPv4.String()
 		info.Addressing.IPv4PoolName = ipam.PoolDefault().String()
-		ip4Address = &net.IPNet{IP: healthIPv4, Mask: defaults.ContainerIPv4Mask}
+		ip4Address = &net.IPNet{IP: healthIPv4.AsSlice(), Mask: defaults.ContainerIPv4Mask}
 		if !option.Config.PreferIpv6 {
-			healthIP = healthIPv4
+			healthIP = healthIPv4.Addr
 		}
 	}
 
@@ -383,7 +384,7 @@ func (h *ciliumHealthManager) launchAsEndpoint(baseCtx context.Context, endpoint
 		}
 		// ENI mode does not support IPv6.
 		if err := ri.Configure(
-			healthIP,
+			healthIP.AsSlice(),
 			mtuConfig.GetDeviceMTU(),
 			false,
 		); err != nil {
@@ -401,7 +402,7 @@ func (h *ciliumHealthManager) launchAsEndpoint(baseCtx context.Context, endpoint
 	ep.UpdateLabels(ctx, labels.LabelSourceAny, labels.LabelHealth, nil, true)
 
 	// Initialize the health client to talk to this instance.
-	client := &Client{host: "http://" + net.JoinHostPort(healthIP.String(), strconv.Itoa(option.Config.ClusterHealthPort))}
+	client := &Client{host: "http://" + netip.AddrPortFrom(healthIP, uint16(option.Config.ClusterHealthPort)).String()}
 	metrics.SubprocessStart.WithLabelValues(ciliumHealth).Inc()
 
 	return client, nil

--- a/pkg/health/health_manager.go
+++ b/pkg/health/health_manager.go
@@ -246,10 +246,10 @@ func (h *ciliumHealthManager) cleanupHealthEndpoint(ctx context.Context) error {
 	// Clean up agent resources
 	healthIPv4 := ln.IPv4HealthIP
 	healthIPv6 := ln.IPv6HealthIP
-	if healthIPv4 != nil {
+	if healthIPv4.IsValid() {
 		ep = h.endpointManager.LookupIPv4(healthIPv4.String())
 	}
-	if ep == nil && healthIPv6 != nil {
+	if ep == nil && healthIPv6.IsValid() {
 		ep = h.endpointManager.LookupIPv6(healthIPv6.String())
 	}
 	if ep == nil {

--- a/pkg/hubble/peer/service_test.go
+++ b/pkg/hubble/peer/service_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 
 	peerpb "github.com/cilium/cilium/api/v1/peer"
@@ -771,7 +770,7 @@ func TestService_Notify(t *testing.T) {
 				// - name change: 2 notifications
 				// - other change: 1 notification
 				switch {
-				case cmp.Diff(o, n) == "":
+				case o.DeepEqual(&n):
 					// no-op
 				case o.Name != n.Name:
 					wg.Add(2)

--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -7,12 +7,14 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/netip"
 	"strconv"
 
 	"go4.org/netipx"
 
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/cidr"
+	iputil "github.com/cilium/cilium/pkg/ip"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/labelsfilter"
@@ -245,33 +247,35 @@ func ParseNode(logger *slog.Logger, k8sNode *slim_corev1.Node, source source.Sou
 		}
 	}
 
-	if newNode.IPv4HealthIP == nil {
+	if !newNode.IPv4HealthIP.IsValid() {
 		if healthIP, ok := annotation.Get(k8sNode, annotation.V4HealthName, annotation.V4HealthNameAlias); !ok || healthIP == "" {
 			scopedLog.Debug(
 				"Empty IPv4 health endpoint annotation in node",
 			)
-		} else if ip := net.ParseIP(healthIP); ip == nil {
+		} else if addr, err := netip.ParseAddr(healthIP); err != nil {
 			scopedLog.Error(
 				"BUG, invalid IPv4 health endpoint annotation in node",
 				logfields.V4HealthIP, healthIP,
+				logfields.Error, err,
 			)
 		} else {
-			newNode.IPv4HealthIP = ip
+			newNode.IPv4HealthIP = iputil.AddrFrom(addr)
 		}
 	}
 
-	if newNode.IPv6HealthIP == nil {
+	if !newNode.IPv6HealthIP.IsValid() {
 		if healthIP, ok := annotation.Get(k8sNode, annotation.V6HealthName, annotation.V6HealthNameAlias); !ok || healthIP == "" {
 			scopedLog.Debug(
 				"Empty IPv6 health endpoint annotation in node",
 			)
-		} else if ip := net.ParseIP(healthIP); ip == nil {
+		} else if addr, err := netip.ParseAddr(healthIP); err != nil {
 			scopedLog.Error(
 				"BUG, invalid IPv6 health endpoint annotation in node",
 				logfields.V6HealthIP, healthIP,
+				logfields.Error, err,
 			)
 		} else {
-			newNode.IPv6HealthIP = ip
+			newNode.IPv6HealthIP = iputil.AddrFrom(addr)
 		}
 	}
 
@@ -356,8 +360,10 @@ func ParseCiliumNode(n *ciliumv2.CiliumNode) (node nodeTypes.Node) {
 		}
 	}
 
-	node.IPv4HealthIP = net.ParseIP(n.Spec.HealthAddressing.IPv4)
-	node.IPv6HealthIP = net.ParseIP(n.Spec.HealthAddressing.IPv6)
+	v4HealthIP, _ := netip.ParseAddr(n.Spec.HealthAddressing.IPv4)
+	v6HealthIP, _ := netip.ParseAddr(n.Spec.HealthAddressing.IPv6)
+	node.IPv4HealthIP = iputil.AddrFrom(v4HealthIP)
+	node.IPv6HealthIP = iputil.AddrFrom(v6HealthIP)
 
 	node.IPv4IngressIP = net.ParseIP(n.Spec.IngressAddressing.IPV4)
 	node.IPv6IngressIP = net.ParseIP(n.Spec.IngressAddressing.IPV6)

--- a/pkg/k8s/node_test.go
+++ b/pkg/k8s/node_test.go
@@ -441,8 +441,8 @@ func TestParseCiliumNode(t *testing.T) {
 		IPv6AllocCIDR:           cidr.MustParseCIDR("c0de::/96"),
 		IPv4SecondaryAllocCIDRs: []*cidr.CIDR{cidr.MustParseCIDR("10.20.0.0/16")},
 		IPv6SecondaryAllocCIDRs: []*cidr.CIDR{cidr.MustParseCIDR("c0fe::/96")},
-		IPv4HealthIP:            net.ParseIP("1.1.1.1"),
-		IPv6HealthIP:            net.ParseIP("c0de::1"),
+		IPv4HealthIP:            iputil.AddrFrom(netip.MustParseAddr("1.1.1.1")),
+		IPv6HealthIP:            iputil.AddrFrom(netip.MustParseAddr("c0de::1")),
 		IPv4IngressIP:           net.ParseIP("1.1.1.2"),
 		IPv6IngressIP:           net.ParseIP("c0de::2"),
 	}, n)

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -792,8 +792,8 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 		m.ipcache.UpsertMetadataBatch(mu...)
 	}
 
-	for _, address := range []net.IP{n.IPv4HealthIP, n.IPv6HealthIP} {
-		prefix := ip.IPToNetPrefix(address)
+	for _, address := range []netip.Addr{n.IPv4HealthIP.Addr, n.IPv6HealthIP.Addr} {
+		prefix := netip.PrefixFrom(address, address.BitLen())
 		if !prefix.IsValid() {
 			continue
 		}
@@ -1040,8 +1040,8 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 	}
 
 	// Delete the old health IP addresses if they have changed in this node.
-	for _, address := range []net.IP{oldNode.IPv4HealthIP, oldNode.IPv6HealthIP} {
-		prefix := ip.IPToNetPrefix(address)
+	for _, address := range []netip.Addr{oldNode.IPv4HealthIP.Addr, oldNode.IPv6HealthIP.Addr} {
+		prefix := netip.PrefixFrom(address, address.BitLen())
 		if !prefix.IsValid() || slices.Contains(healthIPsAdded, prefix) {
 			continue
 		}

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive/health"
 	"github.com/cilium/cilium/pkg/hive/health/types"
 	"github.com/cilium/cilium/pkg/identity"
+	iputil "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
@@ -794,8 +795,8 @@ func TestIpcacheHealthIP(t *testing.T) {
 		IPAddresses: []nodeTypes.Address{
 			{Type: addressing.NodeCiliumInternalIP, IP: net.ParseIP("1.1.1.1").To4()},
 		},
-		IPv4HealthIP: net.ParseIP("10.0.0.4"),
-		IPv6HealthIP: net.ParseIP("f00d::4"),
+		IPv4HealthIP: iputil.AddrFrom(netip.MustParseAddr("10.0.0.4")),
+		IPv6HealthIP: iputil.AddrFrom(netip.MustParseAddr("f00d::4")),
 	}
 	mngr.NodeUpdated(n1)
 
@@ -972,8 +973,8 @@ func TestNode(t *testing.T) {
 				IP:   net.ParseIP("2001:DB8::1"),
 			},
 		},
-		IPv4HealthIP: net.ParseIP("192.0.2.2"),
-		IPv6HealthIP: net.ParseIP("2001:DB8::2"),
+		IPv4HealthIP: iputil.AddrFrom(netip.MustParseAddr("192.0.2.2")),
+		IPv6HealthIP: iputil.AddrFrom(netip.MustParseAddr("2001:DB8::2")),
 		Source:       source.KVStore,
 	}
 	mngr.NodeUpdated(n1)
@@ -1006,8 +1007,8 @@ func TestNode(t *testing.T) {
 			IP:   net.ParseIP("2001:DB8::1"),
 		},
 	}
-	n1V2.IPv4HealthIP = net.ParseIP("192.0.2.20")
-	n1V2.IPv6HealthIP = net.ParseIP("2001:DB8::20")
+	n1V2.IPv4HealthIP = iputil.AddrFrom(netip.MustParseAddr("192.0.2.20"))
+	n1V2.IPv6HealthIP = iputil.AddrFrom(netip.MustParseAddr("2001:DB8::20"))
 	mngr.NodeUpdated(*n1V2)
 
 	select {
@@ -1343,8 +1344,8 @@ func TestNodeIpset(t *testing.T) {
 				IP:   net.ParseIP("2001:ABCD::1"),
 			},
 		},
-		IPv4HealthIP: net.ParseIP("192.0.2.2"),
-		IPv6HealthIP: net.ParseIP("2001:DB8::2"),
+		IPv4HealthIP: iputil.AddrFrom(netip.MustParseAddr("192.0.2.2")),
+		IPv6HealthIP: iputil.AddrFrom(netip.MustParseAddr("2001:DB8::2")),
 		Source:       source.KVStore,
 	}
 	mngr.NodeUpdated(n1)
@@ -1398,7 +1399,7 @@ func TestNodeIpset(t *testing.T) {
 	ipsetExpect(mngr.ipsetMgr.(*ipsetMock), "10.1.0.1", false)
 	ipsetExpect(mngr.ipsetMgr.(*ipsetMock), "2001:ABCE::1", false)
 
-	n1.IPv4HealthIP = net.ParseIP("192.0.2.20")
+	n1.IPv4HealthIP = iputil.AddrFrom(netip.MustParseAddr("192.0.2.20"))
 	mngr.NodeUpdated(n1)
 
 	select {

--- a/pkg/node/store/store_test.go
+++ b/pkg/node/store/store_test.go
@@ -4,11 +4,13 @@
 package store
 
 import (
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"
 
+	iputil "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/node/types"
 )
 
@@ -23,6 +25,16 @@ func TestValidatingNode(t *testing.T) {
 		{
 			name:      "valid cluster name",
 			node:      types.Node{Cluster: "foo", Name: "qux"},
+			validator: ClusterNameValidator("foo"),
+		},
+		{
+			name: "health IPs round-trip",
+			node: types.Node{
+				Cluster:      "foo",
+				Name:         "qux",
+				IPv4HealthIP: iputil.AddrFrom(netip.MustParseAddr("10.0.0.5")),
+				IPv6HealthIP: iputil.AddrFrom(netip.MustParseAddr("f00d::5")),
+			},
 			validator: ClusterNameValidator("foo"),
 		},
 		{

--- a/pkg/node/sync/local_node_sync.go
+++ b/pkg/node/sync/local_node_sync.go
@@ -9,12 +9,14 @@ import (
 	"log/slog"
 	"maps"
 	"net"
+	"net/netip"
 
 	"github.com/cilium/hive/cell"
 
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	ipsec "github.com/cilium/cilium/pkg/datapath/linux/ipsec/types"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	iputil "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/k8s"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -237,11 +239,13 @@ func (ini *localNodeSynchronizer) initFromK8s(ctx context.Context, node *node.Lo
 
 		if ini.Config.EnableHealthChecking && ini.Config.EnableEndpointHealthChecking {
 			if ini.Config.EnableIPv4 {
-				node.IPv4HealthIP = net.ParseIP(k8sCiliumNode.Spec.HealthAddressing.IPv4)
+				addr, _ := netip.ParseAddr(k8sCiliumNode.Spec.HealthAddressing.IPv4)
+				node.IPv4HealthIP = iputil.AddrFrom(addr)
 			}
 
 			if ini.Config.EnableIPv6 {
-				node.IPv6HealthIP = net.ParseIP(k8sCiliumNode.Spec.HealthAddressing.IPv6)
+				addr, _ := netip.ParseAddr(k8sCiliumNode.Spec.HealthAddressing.IPv6)
+				node.IPv6HealthIP = iputil.AddrFrom(addr)
 			}
 		}
 	} else {

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/cidr"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/defaults"
+	iputil "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/node/addressing"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
@@ -61,13 +62,13 @@ type Node struct {
 	// node allocates IPs for its local endpoints from
 	IPv6SecondaryAllocCIDRs []*cidr.CIDR
 
-	// IPv4HealthIP if not nil, this is the IPv4 address of the
+	// IPv4HealthIP if set, this is the IPv4 address of the
 	// cilium-health endpoint located on the node.
-	IPv4HealthIP net.IP
+	IPv4HealthIP iputil.Addr
 
-	// IPv6HealthIP if not nil, this is the IPv6 address of the
+	// IPv6HealthIP if set, this is the IPv6 address of the
 	// cilium-health endpoint located on the node.
-	IPv6HealthIP net.IP
+	IPv6HealthIP iputil.Addr
 
 	// IPv4IngressIP if not nil, this is the IPv4 address of the
 	// Ingress listener on the node.
@@ -359,15 +360,15 @@ func (n *Node) getSecondaryAddresses() []*models.NodeAddressingElement {
 }
 
 func (n *Node) getHealthAddresses() *models.NodeAddressing {
-	if n.IPv4HealthIP == nil && n.IPv6HealthIP == nil {
+	if !n.IPv4HealthIP.IsValid() && !n.IPv6HealthIP.IsValid() {
 		return nil
 	}
 
 	var v4Str, v6Str string
-	if n.IPv4HealthIP != nil {
+	if n.IPv4HealthIP.IsValid() {
 		v4Str = n.IPv4HealthIP.String()
 	}
-	if n.IPv6HealthIP != nil {
+	if n.IPv6HealthIP.IsValid() {
 		v6Str = n.IPv6HealthIP.String()
 	}
 

--- a/pkg/node/types/zz_generated.deepcopy.go
+++ b/pkg/node/types/zz_generated.deepcopy.go
@@ -73,16 +73,8 @@ func (in *Node) DeepCopyInto(out *Node) {
 			}
 		}
 	}
-	if in.IPv4HealthIP != nil {
-		in, out := &in.IPv4HealthIP, &out.IPv4HealthIP
-		*out = make(net.IP, len(*in))
-		copy(*out, *in)
-	}
-	if in.IPv6HealthIP != nil {
-		in, out := &in.IPv6HealthIP, &out.IPv6HealthIP
-		*out = make(net.IP, len(*in))
-		copy(*out, *in)
-	}
+	in.IPv4HealthIP.DeepCopyInto(&out.IPv4HealthIP)
+	in.IPv6HealthIP.DeepCopyInto(&out.IPv6HealthIP)
 	if in.IPv4IngressIP != nil {
 		in, out := &in.IPv4IngressIP, &out.IPv4IngressIP
 		*out = make(net.IP, len(*in))

--- a/pkg/node/types/zz_generated.deepequal.go
+++ b/pkg/node/types/zz_generated.deepequal.go
@@ -88,38 +88,12 @@ func (in *Node) DeepEqual(other *Node) bool {
 		}
 	}
 
-	if ((in.IPv4HealthIP != nil) && (other.IPv4HealthIP != nil)) || ((in.IPv4HealthIP == nil) != (other.IPv4HealthIP == nil)) {
-		in, other := &in.IPv4HealthIP, &other.IPv4HealthIP
-		if other == nil {
-			return false
-		}
-
-		if len(*in) != len(*other) {
-			return false
-		} else {
-			for i, inElement := range *in {
-				if inElement != (*other)[i] {
-					return false
-				}
-			}
-		}
+	if !in.IPv4HealthIP.DeepEqual(&other.IPv4HealthIP) {
+		return false
 	}
 
-	if ((in.IPv6HealthIP != nil) && (other.IPv6HealthIP != nil)) || ((in.IPv6HealthIP == nil) != (other.IPv6HealthIP == nil)) {
-		in, other := &in.IPv6HealthIP, &other.IPv6HealthIP
-		if other == nil {
-			return false
-		}
-
-		if len(*in) != len(*other) {
-			return false
-		} else {
-			for i, inElement := range *in {
-				if inElement != (*other)[i] {
-					return false
-				}
-			}
-		}
+	if !in.IPv6HealthIP.DeepEqual(&other.IPv6HealthIP) {
+		return false
 	}
 
 	if ((in.IPv4IngressIP != nil) && (other.IPv4IngressIP != nil)) || ((in.IPv4IngressIP == nil) != (other.IPv4IngressIP == nil)) {

--- a/pkg/nodediscovery/k8s_node_annotate.go
+++ b/pkg/nodediscovery/k8s_node_annotate.go
@@ -28,8 +28,6 @@ func (n *NodeDiscovery) prepareNodeAnnotations(localNode nodeTypes.Node) nodeAnn
 	annotationMap := map[string]fmt.Stringer{
 		annotation.V4CIDRName:     localNode.IPv4AllocCIDR,
 		annotation.V6CIDRName:     localNode.IPv6AllocCIDR,
-		annotation.V4HealthName:   localNode.IPv4HealthIP,
-		annotation.V6HealthName:   localNode.IPv6HealthIP,
 		annotation.V4IngressName:  localNode.IPv4IngressIP,
 		annotation.V6IngressName:  localNode.IPv6IngressIP,
 		annotation.CiliumHostIP:   localNode.GetCiliumInternalIP(false),
@@ -41,6 +39,12 @@ func (n *NodeDiscovery) prepareNodeAnnotations(localNode nodeTypes.Node) nodeAnn
 		if !reflect.ValueOf(v).IsNil() {
 			annotations[k] = v.String()
 		}
+	}
+	if localNode.IPv4HealthIP.IsValid() {
+		annotations[annotation.V4HealthName] = localNode.IPv4HealthIP.String()
+	}
+	if localNode.IPv6HealthIP.IsValid() {
+		annotations[annotation.V6HealthName] = localNode.IPv6HealthIP.String()
 	}
 	if localNode.EncryptionKey != 0 {
 		annotations[annotation.CiliumEncryptionKey] = strconv.FormatUint(uint64(localNode.EncryptionKey), 10)

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -363,12 +363,12 @@ func (n *NodeDiscovery) mutateNodeResource(ctx context.Context, nodeResource *ci
 	nodeResource.Spec.Encryption.Key = int(ln.EncryptionKey)
 
 	nodeResource.Spec.HealthAddressing.IPv4 = ""
-	if ip := ln.IPv4HealthIP; ip != nil {
+	if ip := ln.IPv4HealthIP; ip.IsValid() {
 		nodeResource.Spec.HealthAddressing.IPv4 = ip.String()
 	}
 
 	nodeResource.Spec.HealthAddressing.IPv6 = ""
-	if ip := ln.IPv6HealthIP; ip != nil {
+	if ip := ln.IPv6HealthIP; ip.IsValid() {
 		nodeResource.Spec.HealthAddressing.IPv6 = ip.String()
 	}
 

--- a/plugins/cilium-cni/cmd/interface.go
+++ b/plugins/cilium-cni/cmd/interface.go
@@ -69,7 +69,7 @@ func interfaceAdd(logger *slog.Logger, ipConfig *current.IPConfig, ipam *models.
 	}
 
 	if err := routingInfo.Configure(
-		ipConfig.Address.IP,
+		ip.AddrFromIP(ipConfig.Address.IP),
 		int(conf.DeviceMTU),
 		false,
 	); err != nil {


### PR DESCRIPTION
This PR migrates `Node.IPv4HealthIP` and `Node.IPv6HealthIP` from `net.IP` to `ip.Addr`. We are using the `ip.Addr` wrapper over the plain `netip.Addr` type here because the `Node` struct needs generated deepcopy/deepequal methods (see #46047).

Following from that migration, I also updated `RoutingInfo.Configure` to take a `netip.Addr`, matching its `Delete` counterpart (that was the last function taking a `net.IP` in the routing package).

Relates to:
* #46924
* #24246

Note: I am voluntarily not migrating all `net.IP` fields from the `Node` struct in a single PR as this struct has a lot of consumers so such a PR would have a large diff and draw a lot of different reviewer groups. I batched together the two IP families health IPs because they are always both set and read together.