### PR TITLE
gateway-api: add RE2 validation for HTTPRoute, GRPCRoute matches

### DIFF
--- a/operator/pkg/gateway-api/gamma_reconcile.go
+++ b/operator/pkg/gateway-api/gamma_reconcile.go
@@ -187,6 +187,8 @@ func (r *gammaReconciler) setHTTPRouteStatuses(gammaLogger *slog.Logger, ctx con
 			ControllerName: r.controllerName,
 		}
 
+		badRegexCond, hasBadRegex := i.ValidateMatchRegexps()
+
 		// Route validators
 		for _, parent := range hr.Spec.ParentRefs {
 
@@ -236,6 +238,10 @@ func (r *gammaReconciler) setHTTPRouteStatuses(gammaLogger *slog.Logger, ctx con
 				if !continueCheck {
 					break
 				}
+			}
+
+			if hasBadRegex {
+				i.SetParentCondition(parent, badRegexCond)
 			}
 
 			// Update the cached copy with the same status changes to prevent re-fetching from client cache.
@@ -291,6 +297,8 @@ func (r *gammaReconciler) setGRPCRouteStatuses(gammaLogger *slog.Logger, ctx con
 			ControllerName: r.controllerName,
 		}
 
+		badRegexCond, hasBadRegex := i.ValidateMatchRegexps()
+
 		// Route validators
 		for _, parent := range grpc.Spec.ParentRefs {
 
@@ -340,6 +348,10 @@ func (r *gammaReconciler) setGRPCRouteStatuses(gammaLogger *slog.Logger, ctx con
 				if !continueCheck {
 					break
 				}
+			}
+
+			if hasBadRegex {
+				i.SetParentCondition(parent, badRegexCond)
 			}
 
 			// Update the cached copy with the same status changes to prevent re-fetching from client cache.

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -1834,6 +1834,12 @@ func (r *gatewayReconciler) setHTTPRouteStatuses(scopedLog *slog.Logger, ctx con
 			return r.handleHTTPRouteReconcileErrorWithStatus(ctx, scopedLog, err, &original, hr)
 		}
 
+		if cond, invalid := i.ValidateMatchRegexps(); invalid {
+			for _, parent := range hr.Status.Parents {
+				i.SetParentCondition(parent.ParentRef, cond)
+			}
+		}
+
 		// Checks finished, apply the status to the actual objects.
 		if err := r.updateHTTPRouteStatus(ctx, scopedLog, &original, hr); err != nil {
 			return fmt.Errorf("failed to update HTTPRoute status: %w", err)
@@ -1904,7 +1910,11 @@ func (r *gatewayReconciler) setGRPCRouteStatuses(scopedLog *slog.Logger, ctx con
 			return r.handleGRPCRouteReconcileErrorWithStatus(ctx, scopedLog, err, grpcr, &original)
 		}
 
-		// Route-specific checks will go in here separately if required.
+		if cond, invalid := i.ValidateMatchRegexps(); invalid {
+			for _, parent := range grpcr.Status.Parents {
+				i.SetParentCondition(parent.ParentRef, cond)
+			}
+		}
 
 		// Checks finished, apply the status to the actual objects.
 		if err := r.updateGRPCRouteStatus(ctx, scopedLog, &original, grpcr); err != nil {

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -1327,3 +1327,197 @@ func fakeIndexHTTPRouteByBackendService(rawObj client.Object) []string {
 	}
 	return backendServices
 }
+
+func testReconciler(t *testing.T, obj ...client.Object) (*gatewayReconciler, client.WithWatch) {
+	t.Helper()
+
+	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+		WithObjects(obj...).
+		WithStatusSubresource(&gatewayv1.HTTPRoute{}, &gatewayv1.GRPCRoute{}).
+		Build()
+
+	reconciler := &gatewayReconciler{
+		Client:         fakeClient,
+		logger:         logger,
+		controllerName: defaultControllerName,
+	}
+
+	return reconciler, fakeClient
+}
+
+func findRouteAcceptedCondition(conds []metav1.Condition) *metav1.Condition {
+	for _, cond := range conds {
+		if cond.Type == string(gatewayv1.RouteConditionAccepted) {
+			return &cond
+		}
+	}
+	return nil
+}
+
+func TestGatewayReconciler_statuses(t *testing.T) {
+	ciliumGWClass := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "cilium"},
+		Spec:       gatewayv1.GatewayClassSpec{ControllerName: gatewayv1.GatewayController(defaultControllerName)},
+	}
+	otherGWClass := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "other"},
+		Spec:       gatewayv1.GatewayClassSpec{ControllerName: "example.com/other-controller"},
+	}
+
+	listener := gatewayv1.Listener{
+		Name:     "http",
+		Port:     80,
+		Protocol: gatewayv1.HTTPProtocolType,
+		AllowedRoutes: &gatewayv1.AllowedRoutes{
+			Namespaces: &gatewayv1.RouteNamespaces{From: new(gatewayv1.NamespacesFromAll)},
+		},
+	}
+
+	ciliumGW := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "cilium-gw", Namespace: "default"},
+		Spec:       gatewayv1.GatewaySpec{GatewayClassName: "cilium", Listeners: []gatewayv1.Listener{listener}},
+	}
+	otherGW := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-gw", Namespace: "default"},
+		Spec:       gatewayv1.GatewaySpec{GatewayClassName: "other", Listeners: []gatewayv1.Listener{listener}},
+	}
+
+	t.Run("setHTTPRouteStatuses sets related parent statuses", func(t *testing.T) {
+		ctx := t.Context()
+
+		validRoute := &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "route", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{Name: gatewayv1.ObjectName(ciliumGW.Name)},
+						{Name: gatewayv1.ObjectName(otherGW.Name)},
+					},
+				},
+				Rules: []gatewayv1.HTTPRouteRule{{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  new(gatewayv1.PathMatchRegularExpression),
+							Value: new("^/api/v1$"),
+						},
+					}},
+				}},
+			},
+		}
+
+		invalidRoute := &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "invalid-route", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{Name: gatewayv1.ObjectName(ciliumGW.Name)},
+						{Name: gatewayv1.ObjectName(otherGW.Name)},
+					},
+				},
+				Rules: []gatewayv1.HTTPRouteRule{{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  new(gatewayv1.PathMatchRegularExpression),
+							Value: new("[invalid"),
+						},
+					}},
+				}},
+			},
+		}
+
+		r, c := testReconciler(t, ciliumGWClass, ciliumGW, otherGWClass, otherGW, validRoute, invalidRoute)
+
+		hrList := &gatewayv1.HTTPRouteList{}
+		require.NoError(t, c.List(ctx, hrList))
+		require.NoError(t, r.setHTTPRouteStatuses(r.logger, ctx, hrList, &gatewayv1.ReferenceGrantList{}))
+
+		var updatedValidRoute, updatedInvalidRoute gatewayv1.HTTPRoute
+		require.NoError(t, c.Get(ctx, types.NamespacedName{Name: validRoute.Name, Namespace: validRoute.Namespace}, &updatedValidRoute))
+		require.NoError(t, c.Get(ctx, types.NamespacedName{Name: invalidRoute.Name, Namespace: invalidRoute.Namespace}, &updatedInvalidRoute))
+
+		require.Len(t, updatedValidRoute.Status.Parents, 1, "Should not set status of unrelated parent")
+		assert.EqualValues(t, defaultControllerName, updatedValidRoute.Status.Parents[0].ControllerName)
+
+		validAcceptedCond := findRouteAcceptedCondition(updatedValidRoute.Status.Parents[0].Conditions)
+		assert.NotNil(t, validAcceptedCond)
+		assert.Equal(t, metav1.ConditionTrue, validAcceptedCond.Status)
+
+		require.Len(t, updatedInvalidRoute.Status.Parents, 1, "Should not set status of unrelated parent")
+		assert.EqualValues(t, defaultControllerName, updatedInvalidRoute.Status.Parents[0].ControllerName)
+
+		invalidAcceptedCond := findRouteAcceptedCondition(updatedInvalidRoute.Status.Parents[0].Conditions)
+		assert.NotNil(t, invalidAcceptedCond)
+		assert.Equal(t, metav1.ConditionFalse, invalidAcceptedCond.Status)
+	})
+
+	t.Run("setGRPCRouteStatuses sets related parent statuses", func(t *testing.T) {
+		ctx := t.Context()
+
+		validRoute := &gatewayv1.GRPCRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "route", Namespace: "default"},
+			Spec: gatewayv1.GRPCRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{Name: gatewayv1.ObjectName(ciliumGW.Name)},
+						{Name: gatewayv1.ObjectName(otherGW.Name)},
+					},
+				},
+				Rules: []gatewayv1.GRPCRouteRule{{
+					Matches: []gatewayv1.GRPCRouteMatch{{
+						Method: &gatewayv1.GRPCMethodMatch{
+							Type:    new(gatewayv1.GRPCMethodMatchRegularExpression),
+							Service: new("^ordersV[12]$"),
+						},
+					}},
+				}},
+			},
+		}
+
+		invalidRoute := &gatewayv1.GRPCRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "invalid-route", Namespace: "default"},
+			Spec: gatewayv1.GRPCRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{Name: gatewayv1.ObjectName(ciliumGW.Name)},
+						{Name: gatewayv1.ObjectName(otherGW.Name)},
+					},
+				},
+				Rules: []gatewayv1.GRPCRouteRule{{
+					Matches: []gatewayv1.GRPCRouteMatch{{
+						Method: &gatewayv1.GRPCMethodMatch{
+							Type:    new(gatewayv1.GRPCMethodMatchRegularExpression),
+							Service: new("(unclosed"),
+						},
+					}},
+				}},
+			},
+		}
+
+		r, c := testReconciler(t, ciliumGWClass, ciliumGW, otherGWClass, otherGW, validRoute, invalidRoute)
+
+		hrList := &gatewayv1.GRPCRouteList{}
+		require.NoError(t, c.List(ctx, hrList))
+		require.NoError(t, r.setGRPCRouteStatuses(r.logger, ctx, hrList, &gatewayv1.ReferenceGrantList{}))
+
+		var updatedValidRoute, updatedInvalidRoute gatewayv1.GRPCRoute
+		require.NoError(t, c.Get(ctx, types.NamespacedName{Name: validRoute.Name, Namespace: validRoute.Namespace}, &updatedValidRoute))
+		require.NoError(t, c.Get(ctx, types.NamespacedName{Name: invalidRoute.Name, Namespace: invalidRoute.Namespace}, &updatedInvalidRoute))
+
+		require.Len(t, updatedValidRoute.Status.Parents, 1, "Should not set status of unrelated parent")
+		assert.EqualValues(t, defaultControllerName, updatedValidRoute.Status.Parents[0].ControllerName)
+
+		validAcceptedCond := findRouteAcceptedCondition(updatedValidRoute.Status.Parents[0].Conditions)
+		assert.NotNil(t, validAcceptedCond)
+		assert.Equal(t, metav1.ConditionTrue, validAcceptedCond.Status)
+
+		require.Len(t, updatedInvalidRoute.Status.Parents, 1, "Should not set status of unrelated parent")
+		assert.EqualValues(t, defaultControllerName, updatedInvalidRoute.Status.Parents[0].ControllerName)
+
+		invalidAcceptedCond := findRouteAcceptedCondition(updatedInvalidRoute.Status.Parents[0].Conditions)
+		assert.NotNil(t, invalidAcceptedCond)
+		assert.Equal(t, metav1.ConditionFalse, invalidAcceptedCond.Status)
+	})
+}

--- a/operator/pkg/gateway-api/routechecks/grpcroute.go
+++ b/operator/pkg/gateway-api/routechecks/grpcroute.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"reflect"
+	"regexp"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -184,4 +185,34 @@ func (g *GRPCRouteInput) mergeStatusConditions(parentRef gatewayv1.ParentReferen
 		ControllerName: gatewayv1.GatewayController(g.ControllerName),
 		Conditions:     updates,
 	})
+}
+
+func (g *GRPCRouteInput) ValidateMatchRegexps() (metav1.Condition, bool) {
+	for _, rule := range g.GRPCRoute.Spec.Rules {
+		for _, match := range rule.Matches {
+			if methodMatch := match.Method; methodMatch != nil && methodMatch.Type != nil &&
+				*methodMatch.Type == gatewayv1.GRPCMethodMatchRegularExpression {
+				if methodMatch.Service != nil {
+					if _, err := regexp.Compile(*methodMatch.Service); err != nil {
+						return invalidRegexCondition("method.service", err), true
+					}
+				}
+
+				if methodMatch.Method != nil {
+					if _, err := regexp.Compile(*methodMatch.Method); err != nil {
+						return invalidRegexCondition("method.method", err), true
+					}
+				}
+			}
+
+			for _, headerMatch := range match.Headers {
+				if headerMatch.Type != nil && *headerMatch.Type == gatewayv1.GRPCHeaderMatchRegularExpression {
+					if _, err := regexp.Compile(headerMatch.Value); err != nil {
+						return invalidRegexCondition("header", err), true
+					}
+				}
+			}
+		}
+	}
+	return metav1.Condition{}, false
 }

--- a/operator/pkg/gateway-api/routechecks/grpcroute_test.go
+++ b/operator/pkg/gateway-api/routechecks/grpcroute_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package routechecks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestGRPCRouteValidateMatchRegexps(t *testing.T) {
+	tests := []struct {
+		name    string
+		match   gatewayv1.GRPCRouteMatch
+		invalid bool
+	}{
+		{
+			name: "valid method regex",
+			match: gatewayv1.GRPCRouteMatch{Method: &gatewayv1.GRPCMethodMatch{
+				Type:    new(gatewayv1.GRPCMethodMatchRegularExpression),
+				Service: new("^presence$"),
+				Method:  new("^(Hello|Goodbye)$"),
+			}},
+		},
+		{
+			name: "invalid method.service regex",
+			match: gatewayv1.GRPCRouteMatch{Method: &gatewayv1.GRPCMethodMatch{
+				Type:    new(gatewayv1.GRPCMethodMatchRegularExpression),
+				Service: new("^ordersV[12$"),
+			}},
+			invalid: true,
+		},
+		{
+			name: "invalid method.method regex",
+			match: gatewayv1.GRPCRouteMatch{Method: &gatewayv1.GRPCMethodMatch{
+				Type:   new(gatewayv1.GRPCMethodMatchRegularExpression),
+				Method: new(".(unclosed"),
+			}},
+			invalid: true,
+		},
+		{
+			name: "valid header regex",
+			match: gatewayv1.GRPCRouteMatch{Headers: []gatewayv1.GRPCHeaderMatch{{
+				Type:  new(gatewayv1.GRPCHeaderMatchRegularExpression),
+				Name:  "X-Device-Id",
+				Value: "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+			}}},
+		},
+		{
+			name: "invalid header regex",
+			match: gatewayv1.GRPCRouteMatch{Headers: []gatewayv1.GRPCHeaderMatch{{
+				Type:  new(gatewayv1.GRPCHeaderMatchRegularExpression),
+				Name:  "X-Device-Id",
+				Value: "****invalid",
+			}}},
+			invalid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := &GRPCRouteInput{
+				ControllerName: "io.cilium/gateway-controller",
+				GRPCRoute: &gatewayv1.GRPCRoute{
+					Spec: gatewayv1.GRPCRouteSpec{
+						CommonRouteSpec: gatewayv1.CommonRouteSpec{
+							ParentRefs: []gatewayv1.ParentReference{{Name: "my-gw"}},
+						},
+						Rules: []gatewayv1.GRPCRouteRule{{Matches: []gatewayv1.GRPCRouteMatch{tt.match}}},
+					},
+				},
+			}
+
+			cond, invalid := input.ValidateMatchRegexps()
+
+			assert.Equal(t, tt.invalid, invalid)
+			if invalid {
+				assert.Equal(t, string(gatewayv1.RouteConditionAccepted), cond.Type)
+				assert.Equal(t, metav1.ConditionFalse, cond.Status)
+				assert.Equal(t, string(gatewayv1.RouteReasonUnsupportedValue), cond.Reason)
+			}
+		})
+	}
+}

--- a/operator/pkg/gateway-api/routechecks/httproute.go
+++ b/operator/pkg/gateway-api/routechecks/httproute.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"reflect"
+	"regexp"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -197,4 +198,44 @@ func (r *HTTPRouteInput) ValidateHeaderModifier() error {
 		}
 	}
 	return nil
+}
+
+func invalidRegexCondition(field string, err error) metav1.Condition {
+	return metav1.Condition{
+		Type:    string(gatewayv1.RouteConditionAccepted),
+		Status:  metav1.ConditionFalse,
+		Reason:  string(gatewayv1.RouteReasonUnsupportedValue),
+		Message: fmt.Sprintf("Invalid regular expression in %s match: %v", field, err),
+	}
+}
+
+func (h *HTTPRouteInput) ValidateMatchRegexps() (metav1.Condition, bool) {
+	for _, rule := range h.HTTPRoute.Spec.Rules {
+		for _, match := range rule.Matches {
+			if pathMatch := match.Path; pathMatch != nil && pathMatch.Type != nil &&
+				*pathMatch.Type == gatewayv1.PathMatchRegularExpression && pathMatch.Value != nil {
+				if _, err := regexp.Compile(*pathMatch.Value); err != nil {
+					return invalidRegexCondition("path", err), true
+				}
+			}
+
+			for _, headerMatch := range match.Headers {
+				if headerMatch.Type != nil && *headerMatch.Type == gatewayv1.HeaderMatchRegularExpression {
+					if _, err := regexp.Compile(headerMatch.Value); err != nil {
+						return invalidRegexCondition("header", err), true
+					}
+				}
+			}
+
+			for _, queryMatch := range match.QueryParams {
+				if queryMatch.Type != nil && *queryMatch.Type == gatewayv1.QueryParamMatchRegularExpression {
+					if _, err := regexp.Compile(queryMatch.Value); err != nil {
+						return invalidRegexCondition("queryParam", err), true
+					}
+				}
+			}
+		}
+	}
+
+	return metav1.Condition{}, false
 }

--- a/operator/pkg/gateway-api/routechecks/httproute_test.go
+++ b/operator/pkg/gateway-api/routechecks/httproute_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package routechecks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestHTTPRouteValidateMatchRegexps(t *testing.T) {
+	tests := []struct {
+		name    string
+		match   gatewayv1.HTTPRouteMatch
+		invalid bool
+	}{
+		{
+			name: "valid path regex",
+			match: gatewayv1.HTTPRouteMatch{Path: &gatewayv1.HTTPPathMatch{
+				Type:  new(gatewayv1.PathMatchRegularExpression),
+				Value: new("/api/v[0-9]/.+"),
+			}},
+		},
+		{
+			name: "invalid path regex",
+			match: gatewayv1.HTTPRouteMatch{Path: &gatewayv1.HTTPPathMatch{
+				Type:  new(gatewayv1.PathMatchRegularExpression),
+				Value: new("[unterminated"),
+			}},
+			invalid: true,
+		},
+		{
+			name: "valid header regex",
+			match: gatewayv1.HTTPRouteMatch{Headers: []gatewayv1.HTTPHeaderMatch{{
+				Type:  new(gatewayv1.HeaderMatchRegularExpression),
+				Name:  "X-Consumer-Key",
+				Value: "^[A-Za-z0-9]{16,32}$",
+			}}},
+		},
+		{
+			name: "invalid header regex",
+			match: gatewayv1.HTTPRouteMatch{Headers: []gatewayv1.HTTPHeaderMatch{{
+				Type:  new(gatewayv1.HeaderMatchRegularExpression),
+				Name:  "X-Consumer-Key",
+				Value: "(unclosed",
+			}}},
+			invalid: true,
+		},
+		{
+			name: "valid queryParam regex",
+			match: gatewayv1.HTTPRouteMatch{QueryParams: []gatewayv1.HTTPQueryParamMatch{{
+				Type:  new(gatewayv1.QueryParamMatchRegularExpression),
+				Name:  "ref",
+				Value: "^[a-z_]{8,16}[0-9]{1,5}$",
+			}}},
+		},
+		{
+			name: "invalid queryParam regex",
+			match: gatewayv1.HTTPRouteMatch{QueryParams: []gatewayv1.HTTPQueryParamMatch{{
+				Type:  new(gatewayv1.QueryParamMatchRegularExpression),
+				Name:  "ref",
+				Value: "(?invalidflag)",
+			}}},
+			invalid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := &HTTPRouteInput{
+				ControllerName: "io.cilium/gateway-controller",
+				HTTPRoute: &gatewayv1.HTTPRoute{
+					Spec: gatewayv1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayv1.CommonRouteSpec{
+							ParentRefs: []gatewayv1.ParentReference{{Name: "my-gw"}},
+						},
+						Rules: []gatewayv1.HTTPRouteRule{{Matches: []gatewayv1.HTTPRouteMatch{tt.match}}},
+					},
+				},
+			}
+
+			cond, invalid := input.ValidateMatchRegexps()
+
+			assert.Equal(t, tt.invalid, invalid)
+			if invalid {
+				assert.Equal(t, string(gatewayv1.RouteConditionAccepted), cond.Type)
+				assert.Equal(t, metav1.ConditionFalse, cond.Status)
+				assert.Equal(t, string(gatewayv1.RouteReasonUnsupportedValue), cond.Reason)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes: #47000.

Previously, if a RegularExpression match on an HTTPRoute or GRPCRoute rule was not a valid RE2 expression, the route would be accepted and then Envoy would reject the RouteConfiguration with an error. Then not only would this route be not programmed, all changes after are silently rejected until the route is fixed or removed.

This change attempts to compile any regular expressions on HTTPRoutes and GRPCRoutes and sets condition Accepted=false on failures to prevent a NACK from Envoy.

```release-note
Fixes an issue where invalid regex on an HTTPRoute or GRPCRoute matcher is accepted but causes Envoy to NACK
```