### PR TITLE
Add preflight checks to e2e upgrade

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -583,6 +583,44 @@ jobs:
         if: ${{ steps.vars.outputs.downgrade_version != '' && steps.cilium-stable-config.outputs.skip != 'true' && steps.cilium-newest-config.outputs.skip != 'true' }}
         uses: ./.github/actions/conn-disrupt-test-setup
 
+      - name: Run upgrade preflight checks
+        if: ${{ steps.vars.outputs.downgrade_version != '' && steps.vars.outputs.skip_upgrade != 'true' && steps.cilium-stable-config.outputs.skip != 'true' && steps.cilium-newest-config.outputs.skip != 'true' }}
+        shell: bash
+        timeout-minutes: 5
+        run: |
+          cilium install --helm-release-name cilium-preflight \
+            ${{ steps.cilium-newest-config.outputs.config }} \
+            --set preflight.enabled=true \
+            --set agent=false --set operator.enabled=false \
+            --set=ingressController.enabled=false \
+            --wait=false
+
+          if kubectl wait pods -n kube-system -l k8s-app=cilium-pre-flight-check \
+                     --timeout=2m --for=condition=Ready; then
+            cilium uninstall --helm-release-name cilium-preflight
+            return
+          fi
+
+          echo "===== Preflight status check ====="
+          kubectl -n kube-system get pods -l k8s-app=cilium-pre-flight-check -o wide
+          echo
+
+          kubectl get pods -n kube-system -l k8s-app=cilium-pre-flight-check \
+                      -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
+          | while read -r pod; do
+            kubectl get pods -n kube-system "$pod" \
+                    -o jsonpath='{range .spec.containers[*]}{.name}{"\n"}{end}' \
+            | while read -r container; do
+              echo "===== Logs for pod: $pod / container: $container ====="
+              kubectl logs -n "kube-system" "$pod" -c "$container"
+              echo
+            done
+          done
+
+          cilium uninstall --helm-release-name cilium-preflight
+          echo "::error::Preflight checks failed prior to upgrade"
+          exit 1
+
       - name: Upgrade Cilium
         if: ${{ steps.vars.outputs.downgrade_version != '' && steps.vars.outputs.skip_upgrade != 'true' && steps.cilium-stable-config.outputs.skip != 'true' && steps.cilium-newest-config.outputs.skip != 'true' }}
         shell: bash

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -2,6 +2,8 @@ name: Cilium E2E Upgrade (ci-e2e-upgrade)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
+  pull_request: {}
+
   workflow_call:
     inputs:
       PR-number:
@@ -115,7 +117,7 @@ jobs:
       - name: Set initial commit status
         uses: cilium/cilium/.github/actions/set-commit-status@main # main
         with:
-          sha: ${{ inputs.SHA || github.sha }}
+          sha: ${{ inputs.SHA || github.event.pull_request.head.sha }}
 
   generate-matrix:
     name: Generate Matrix
@@ -127,7 +129,7 @@ jobs:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ inputs.context-ref || github.sha }}
+          ref: ${{ inputs.context-ref || github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Convert YAML to JSON
@@ -194,12 +196,12 @@ jobs:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ inputs.context-ref || github.sha }}
+          ref: ${{ inputs.context-ref || github.event.pull_request.head.sha }}
           persist-credentials: false
       - name: Wait for images
         uses: ./.github/actions/wait-for-images
         with:
-          SHA: ${{ inputs.SHA || github.sha }}
+          SHA: ${{ inputs.SHA || github.event.pull_request.head.sha }}
           login-host: ${{ vars.DOCKER_READ_HOST }}
           login-username: ${{ vars.DOCKER_READ_USERNAME }}
           login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
@@ -227,7 +229,7 @@ jobs:
       - name: Set commit status to pending
         uses: cilium/cilium/.github/actions/set-commit-status@main # main
         with:
-          sha: ${{ inputs.SHA || github.sha }}
+          sha: ${{ inputs.SHA || github.event.pull_request.head.sha }}
 
       - name: Collect Workflow Telemetry
         uses: cilium/workflow-telemetry-action@b1a318f80a08acede58027afe1455d037379966f # v2.2.0
@@ -237,7 +239,7 @@ jobs:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ inputs.context-ref || github.sha }}
+          ref: ${{ inputs.context-ref || github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Set Environment Variables
@@ -253,7 +255,7 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             SHA="${{ inputs.SHA }}"
           else
-            SHA="${{ github.sha }}"
+            SHA="${{ github.event.pull_request.head.sha }}"
           fi
           echo sha=${SHA} >> $GITHUB_OUTPUT
           if [ "${{ matrix.mode }}" = "minor" ]; then
@@ -821,6 +823,6 @@ jobs:
     uses: ./.github/workflows/common-post-jobs.yaml
     secrets: inherit
     with:
-      context-ref: ${{ inputs.context-ref || github.sha }}
-      sha: ${{ inputs.SHA || github.sha }}
+      context-ref: ${{ inputs.context-ref || github.event.pull_request.head.sha }}
+      sha: ${{ inputs.SHA || github.event.pull_request.head.sha }}
       success: ${{ needs.setup-and-test.result == 'success' }}

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -584,6 +584,44 @@ jobs:
         if: ${{ steps.vars.outputs.downgrade_version != '' && steps.cilium-stable-config.outputs.skip != 'true' && steps.cilium-newest-config.outputs.skip != 'true' }}
         uses: ./.github/actions/conn-disrupt-test-setup
 
+      - name: Run upgrade preflight checks
+        if: ${{ steps.vars.outputs.downgrade_version != '' && steps.vars.outputs.skip_upgrade != 'true' && steps.cilium-stable-config.outputs.skip != 'true' && steps.cilium-newest-config.outputs.skip != 'true' }}
+        shell: bash
+        timeout-minutes: 5
+        run: |
+          cilium install --helm-release-name cilium-preflight \
+            ${{ steps.cilium-newest-config.outputs.config }} \
+            --set preflight.enabled=true \
+            --set agent=false --set operator.enabled=false \
+            --set=ingressController.enabled=false \
+            --wait=false
+
+          if kubectl wait pods -n kube-system -l k8s-app=cilium-pre-flight-check \
+                     --timeout=2m --for=condition=Ready; then
+            cilium uninstall --helm-release-name cilium-preflight
+            return
+          fi
+
+          echo "===== Preflight status check ====="
+          kubectl -n kube-system get pods -l k8s-app=cilium-pre-flight-check -o wide
+          echo
+
+          kubectl get pods -n kube-system -l k8s-app=cilium-pre-flight-check \
+                      -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
+          | while read -r pod; do
+            kubectl get pods -n kube-system "$pod" \
+                    -o jsonpath='{range .spec.containers[*]}{.name}{"\n"}{end}' \
+            | while read -r container; do
+              echo "===== Logs for pod: $pod / container: $container ====="
+              kubectl logs -n "kube-system" "$pod" -c "$container"
+              echo
+            done
+          done
+
+          cilium uninstall --helm-release-name cilium-preflight
+          echo "::error::Preflight checks failed prior to upgrade"
+          exit 1
+
       - name: Upgrade Cilium
         if: ${{ steps.vars.outputs.downgrade_version != '' && steps.vars.outputs.skip_upgrade != 'true' && steps.cilium-stable-config.outputs.skip != 'true' && steps.cilium-newest-config.outputs.skip != 'true' }}
         shell: bash

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -2,6 +2,8 @@ name: Cilium E2E Upgrade (ci-e2e-upgrade)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
+  pull_request: {}
+
   workflow_call:
     inputs:
       PR-number:
@@ -115,7 +117,7 @@ jobs:
       - name: Set initial commit status
         uses: cilium/cilium/.github/actions/set-commit-status@main # main
         with:
-          sha: ${{ inputs.SHA || github.sha }}
+          sha: ${{ inputs.SHA || github.event.pull_request.head.sha }}
 
   generate-matrix:
     name: Generate Matrix
@@ -127,7 +129,7 @@ jobs:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.context-ref || github.sha }}
+          ref: ${{ inputs.context-ref || github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Convert YAML to JSON
@@ -194,12 +196,12 @@ jobs:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.context-ref || github.sha }}
+          ref: ${{ inputs.context-ref || github.event.pull_request.head.sha }}
           persist-credentials: false
       - name: Wait for images
         uses: ./.github/actions/wait-for-images
         with:
-          SHA: ${{ inputs.SHA || github.sha }}
+          SHA: ${{ inputs.SHA || github.event.pull_request.head.sha }}
           login-host: ${{ vars.DOCKER_READ_HOST }}
           login-username: ${{ vars.DOCKER_READ_USERNAME }}
           login-password: ${{ secrets.DOCKER_READ_PASSWORD }}
@@ -227,7 +229,7 @@ jobs:
       - name: Set commit status to pending
         uses: cilium/cilium/.github/actions/set-commit-status@main # main
         with:
-          sha: ${{ inputs.SHA || github.sha }}
+          sha: ${{ inputs.SHA || github.event.pull_request.head.sha }}
 
       - name: Collect Workflow Telemetry
         uses: cilium/workflow-telemetry-action@b1a318f80a08acede58027afe1455d037379966f # v2.2.0
@@ -237,7 +239,7 @@ jobs:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.context-ref || github.sha }}
+          ref: ${{ inputs.context-ref || github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Set Environment Variables
@@ -253,7 +255,7 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             SHA="${{ inputs.SHA }}"
           else
-            SHA="${{ github.sha }}"
+            SHA="${{ github.event.pull_request.head.sha }}"
           fi
           echo sha=${SHA} >> $GITHUB_OUTPUT
           if [ "${{ matrix.mode }}" = "minor" ]; then
@@ -820,6 +822,6 @@ jobs:
     uses: ./.github/workflows/common-post-jobs.yaml
     secrets: inherit
     with:
-      context-ref: ${{ inputs.context-ref || github.sha }}
-      sha: ${{ inputs.SHA || github.sha }}
+      context-ref: ${{ inputs.context-ref || github.event.pull_request.head.sha }}
+      sha: ${{ inputs.SHA || github.event.pull_request.head.sha }}
       success: ${{ needs.setup-and-test.result == 'success' }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      k8s-app: cilium-pre-flight-check-deployment
+      k8s-app: cilium-pre-flight-check
       kubernetes.io/cluster-service: "true"
   template:
     metadata:
@@ -28,7 +28,7 @@ spec:
       {{- end }}
       labels:
         app.kubernetes.io/part-of: cilium
-        k8s-app: cilium-pre-flight-check-deployment
+        k8s-app: cilium-pre-flight-check
         kubernetes.io/cluster-service: "true"
         app.kubernetes.io/name: cilium-pre-flight-check
         helm.sh/chart: {{ include "cilium.chart" . }}


### PR DESCRIPTION
Add preflight checks steps to the end-to-end upgrade testsuite. Our
users run steps similar to this, so we should run the same checks in CI.

Fixes: https://github.com/cilium/cilium/issues/45375