### PR TITLE
fix: potential wrong egress interface for egressIP-only gateway policies

### DIFF
--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -258,6 +258,7 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(manager *Manager, gc *po
 		dev := getDeviceWithAddress(manager, gc.egressIP)
 		if dev != nil {
 			gwc.ifaceName = dev.Name
+			gwc.egressIfindex = uint32(dev.Index)
 
 			if gc.egressIP.Is4() {
 				egressIP4 = gc.egressIP
@@ -308,6 +309,12 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(manager *Manager, gc *po
 					}
 				}
 			}
+
+			iface, err := safenetlink.LinkByName(gwc.ifaceName)
+			if err != nil {
+				return fmt.Errorf("failed to retrieve egress interface %s: %w", gwc.ifaceName, err)
+			}
+			gwc.egressIfindex = uint32(iface.Attrs().Index)
 		}
 	default:
 		// If the gateway config doesn't specify any egress IP or interface, use the

--- a/pkg/egressgateway/policy_test.go
+++ b/pkg/egressgateway/policy_test.go
@@ -7,9 +7,12 @@ import (
 	"net/netip"
 	"testing"
 
+	"github.com/cilium/statedb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/cilium/cilium/pkg/datapath/tables"
 	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -211,4 +214,39 @@ func TestPolicyConfig_updateMatchedEndpointIDs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDeriveFromPolicyGatewayConfigSetsIfindexForEgressIP(t *testing.T) {
+	db := statedb.New()
+	deviceTable, err := tables.NewDeviceTable(db)
+	require.NoError(t, err)
+
+	egressIP := netip.MustParseAddr("fd00::10:10:0:1")
+	dev := &tables.Device{
+		Index: 7,
+		Name:  "eth0",
+		Addrs: []tables.DeviceAddress{
+			{Addr: egressIP},
+		},
+	}
+
+	txn := db.WriteTxn(deviceTable)
+	_, _, err = deviceTable.Insert(txn, dev)
+	require.NoError(t, err)
+	txn.Commit()
+
+	manager := &Manager{
+		db:          db,
+		deviceTable: deviceTable,
+	}
+	gwc := &gatewayConfig{}
+	gc := &policyGatewayConfig{
+		egressIP: egressIP,
+	}
+
+	err = gwc.deriveFromPolicyGatewayConfig(manager, gc, false, true)
+	require.NoError(t, err)
+	assert.Equal(t, dev.Name, gwc.ifaceName)
+	assert.Equal(t, uint32(dev.Index), gwc.egressIfindex)
+	assert.Equal(t, egressIP, gwc.egressIP6)
 }


### PR DESCRIPTION
CiliumEgressGatewayPolicy can select egress node output interface through either interface or egressIP. 

When only egressIP is configured, eBPF program on egress node may use wrong output  interface.

This issue affects IPv6 egress gateway policies and IPv4 egress gateway policies that use v2 map format, because both policy values carry egress_ifindex. Legacy IPv4 policy map does not  carry egress_ifindex, so it is not affected by this specific missing assignment.

 Example:
```
  apiVersion: cilium.io/v2
  kind: CiliumEgressGatewayPolicy
  metadata:
    name: egw-egressip-ipv6-only
  spec:
    destinationCIDRs:
    - "2001:db8:100::/64"
    egressGateway:
      nodeSelector:
        matchLabels:
          kubernetes.io/hostname: worker-egw
      egressIP: "fd00::10:10:0:1"
    ...
```

In `deriveFromPolicyGatewayConfig()` API , the gc.egressIP.IsValid() branch only sets gwc.ifaceName, but does not set gwc.egressIfindex. As a result, gwc.egressIfindex keeps default zero value.

This egressIfindex value is later propagated into eBPF map values:

```
  // IPv4 v2:
  type EgressPolicyVal4V2 struct {
      EgressIP      types.IPv4
      GatewayIP     types.IPv4
      EgressIfindex uint32
  }

  // IPv6:
  type EgressPolicyVal6 struct {
      EgressIP      types.IPv6
      GatewayIP     types.IPv4
      EgressIfindex uint32
  }
```

With egress_ifindex=0, eBPF program on egress node falls back to FIB lookup to choose output interface. 
That selected interface is not guaranteed to be interface that owns configured egressIP.

For comparison, default branch in `deriveFromPolicyGatewayConfig()` correctly propagates both interface name and interface index:

  gwc.ifaceName = iface.Attrs().Name
  gwc.egressIfindex = uint32(iface.Attrs().Index)

so , what this fix does is to propagate the interface index 

<!-- Description of change -->

Fixes: #issue-number

```release-note
fix: Avoid wrong egress interface selection for egressIP-only gateway policies
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
