### PR TITLE
fix: handle IPv6 subtraction borrow to avoid pool fragmentation

### DIFF
--- a/pkg/ipalloc/ipalloc.go
+++ b/pkg/ipalloc/ipalloc.go
@@ -638,9 +638,15 @@ func (u uint128) less(other uint128) bool {
 }
 
 func (u uint128) sub(other uint128) uint128 {
+	hi := u.hi - other.hi
+	lo := u.lo - other.lo
+	if u.lo < other.lo {
+		hi--
+	}
+
 	return uint128{
-		hi: u.hi - other.hi,
-		lo: u.lo - other.lo,
+		hi: hi,
+		lo: lo,
 	}
 }
 

--- a/pkg/ipalloc/ipalloc_test.go
+++ b/pkg/ipalloc/ipalloc_test.go
@@ -279,6 +279,22 @@ func TestHashAlloc_AllocAny(t *testing.T) {
 	require.Equal(t, netip.MustParseAddr("10.0.0.0"), ip)
 }
 
+func TestHashAlloc_AllocAnyPrefersSmallestIPv6BlockAcrossLowWordBoundary(t *testing.T) {
+	alloc, err := NewHashAllocator[bool](
+		netip.MustParseAddr("2001:db8::ffff:ffff:ffff:fff0"),
+		netip.MustParseAddr("2001:db8:0:1::30"),
+		10,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, alloc.Alloc(netip.MustParseAddr("2001:db8::ffff:ffff:ffff:fffb"), true))
+	require.NoError(t, alloc.Alloc(netip.MustParseAddr("2001:db8:0:1::3"), true))
+
+	ip, err := alloc.AllocAny(true)
+	require.NoError(t, err)
+	require.Equal(t, netip.MustParseAddr("2001:db8::ffff:ffff:ffff:fffc"), ip)
+}
+
 func TestHashAlloc_AllocAnyFull(t *testing.T) {
 	alloc, err := NewHashAllocator[bool](
 		netip.MustParseAddr("10.0.0.0"),


### PR DESCRIPTION
fix: correct IPv6 arithmetic to avoid IP pool fragmentation


The uint128.sub method performs 128-bit unsigned subtraction, but it does not handle the borrow from the low 64 bits (lo) to the high 64 bits (hi) when u.lo < other.lo. 

As a result, when IPv6 block size calculation requires a borrow, the high 64 bits are not decremented by 1, making the computed size too large by 2^64.

The correct logic is that uint128.sub should handle the borrow case from the low 64 bits to the high 64 bits by decrementing the high 64 bits by 1.

It influences the IP allocation.

For example, a user may create a CiliumLoadBalancerIPPool whose spec.blocks IPv6 start and stop range crosses the low-64-bit boundary:

```
  apiVersion: cilium.io/v2
  kind: CiliumLoadBalancerIPPool
  metadata:
    name: ipv6-cross-low-word-boundary
  spec:
    blocks:
      - start: "2001:0db8:0000:0000:ffff:ffff:ffff:fff0"
        stop:  "2001:0db8:0000:0001:0000:0000:0000:0030"
```

The consequence is that when LB-IPAM later automatically allocates an IPv6 address for a LoadBalancer Service without a requested IP, AllocAny no longer prefers the actual smallest free block. This can cause fragmentation of the address space.

<!-- Description of change -->

Fixes: #issue-number

```release-note
fix: handle IPv6 subtraction borrow to avoid pool fragmentation
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
