### PR TITLE
ci: fix condition on pull secret creation

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -418,7 +418,7 @@ jobs:
           kind-image: ${{ env.KIND_K8S_IMAGE }}
 
       - name: Create imagePullSecret
-        if: ${{ steps.vars.outputs.downgrade_version != '' }}
+        if: ${{ steps.vars.outputs.downgrade_version != '' && steps.cilium-stable-config.outputs.skip != 'true' && steps.cilium-newest-config.outputs.skip != 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \


### PR DESCRIPTION
Setting the same condition for k8s provisioning, otherwise we might end up with a state where k8s wasn't provisioned but we try to create a pull secret on an inexisting cluster, failing the workflow.