### PR TITLE
RFC: bpf: dsr: carry DSR info on mid-flow packets that create the CT entry

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -52,7 +52,8 @@ struct ct_state {
 	      reserved1:1,	/* Was auth_required, not used in production anywhere */
 	      from_tunnel:1,	/* Connection is from tunnel */
 		  closing:1,
-	      reserved:7;
+	      svc_entry_created:1,	/* CT service entry was created by this packet */
+	      reserved:6;
 	__u32 src_sec_id;
 	__u32 backend_id;	/* Backend ID in lb4_backends */
 };

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1452,6 +1452,14 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 		if (IS_ERR(ret))
 			goto drop_err;
 
+		/* Tell callers the entry was just created: DSR uses this to
+		 * attach the DSR info also to a non-SYN packet which created
+		 * the entry (mid-flow packet re-routed to this LB node, e.g.
+		 * after an ECMP rehash), so that the backend node can build
+		 * the reverse-xlate state it never got from a SYN.
+		 */
+		state->svc_entry_created = 1;
+
 #ifdef ENABLE_ACTIVE_CONNECTION_TRACKING
 		_lb_act_conn_open(state->rev_nat_index, backend->zone);
 #endif
@@ -2278,6 +2286,14 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 		 */
 		if (IS_ERR(ret))
 			goto drop_err;
+
+		/* Tell callers the entry was just created: DSR uses this to
+		 * attach the DSR info also to a non-SYN packet which created
+		 * the entry (mid-flow packet re-routed to this LB node, e.g.
+		 * after an ECMP rehash), so that the backend node can build
+		 * the reverse-xlate state it never got from a SYN.
+		 */
+		state->svc_entry_created = 1;
 
 #ifdef ENABLE_ACTIVE_CONNECTION_TRACKING
 		_lb_act_conn_open(state->rev_nat_index, backend->zone);

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -104,6 +104,16 @@ struct dsr_opt_v4 {
 #define DSR_IPV6_OPT_LEN	(sizeof(struct dsr_opt_v6) - 4)
 #define DSR_IPV6_EXT_LEN	((sizeof(struct dsr_opt_v6) - 8) / 8)
 
+/* CB_PORT carries the service port in its lower 16 bits. The GENEVE DSR
+ * path uses the bit below to request that the DSR option be attached even
+ * to a non-SYN packet: set when this very packet created the CT service
+ * entry (see lb{4,6}_local()), which happens when an in-flight packet is
+ * re-routed to a new LB node (e.g. ECMP rehash). Without the option, the
+ * backend node has no way to build the reverse-xlate state, and its
+ * replies (typically a TCP RST) cannot be translated back to the client.
+ */
+#define CB_PORT_DSR_FORCE_OPT	(1U << 16)
+
 static __always_inline bool nodeport_uses_dsr(bool flip __maybe_unused)
 {
 #ifdef ENABLE_DSR
@@ -405,7 +415,7 @@ static __always_inline int dsr_set_ext6(struct __ctx_buff *ctx,
 static __always_inline int encap_geneve_dsr_opt6(struct __ctx_buff *ctx,
 						 struct ipv6hdr *ip6,
 						 const union v6addr *svc_addr,
-						 __be16 svc_port,
+						 __be16 svc_port, bool force_opt,
 						 int *ifindex, int *ohead)
 {
 	const struct remote_endpoint_info *info;
@@ -448,7 +458,7 @@ static __always_inline int encap_geneve_dsr_opt6(struct __ctx_buff *ctx,
 		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
 			return DROP_CT_INVALID_HDR;
 
-		if (!(tcp_flags.value & (TCP_FLAG_SYN)))
+		if (!(tcp_flags.value & (TCP_FLAG_SYN)) && !force_opt)
 			need_opt = false;
 	}
 
@@ -542,9 +552,14 @@ nodeport_extract_dsr_v6(struct __ctx_buff *ctx,
 		ipv6_ct_tuple_reverse(&tmp);
 
 		if (!(tcp_flags.value & TCP_FLAG_SYN)) {
-			*dsr = ct_has_dsr_egress_entry6(get_ct_map6(&tmp), &tmp);
-			*port = 0;
-			return 0;
+			if (ct_has_dsr_egress_entry6(get_ct_map6(&tmp), &tmp)) {
+				*dsr = true;
+				*port = 0;
+				return 0;
+			}
+			/* See nodeport_extract_dsr_v4(): no local DSR state,
+			 * the DSR info may be present on this packet instead.
+			 */
 		}
 	}
 
@@ -710,6 +725,7 @@ int tail_nodeport_ipv6_dsr(struct __ctx_buff *ctx)
 	union v6addr addr __align_stack_8 = {};
 	__s8 ext_err = 0;
 	__be16 port;
+	bool force_opt __maybe_unused = false;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6)) {
 		ret = DROP_INVALID;
@@ -719,6 +735,7 @@ int tail_nodeport_ipv6_dsr(struct __ctx_buff *ctx)
 	ctx_load_meta_ipv6(ctx, &addr, CB_ADDR_V6_1);
 
 	port = (__be16)ctx_load_meta(ctx, CB_PORT);
+	force_opt = !!(ctx_load_meta(ctx, CB_PORT) & CB_PORT_DSR_FORCE_OPT);
 
 #if DSR_ENCAP_MODE == DSR_ENCAP_IPIP
 	ret = dsr_set_ipip6(ctx, ip6, &addr,
@@ -726,7 +743,7 @@ int tail_nodeport_ipv6_dsr(struct __ctx_buff *ctx)
 #elif DSR_ENCAP_MODE == DSR_ENCAP_NONE
 	ret = dsr_set_ext6(ctx, ip6, &addr, port, &ohead);
 #elif DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
-	ret = encap_geneve_dsr_opt6(ctx, ip6, &addr, port, &oif, &ohead);
+	ret = encap_geneve_dsr_opt6(ctx, ip6, &addr, port, force_opt, &oif, &ohead);
 	if (!IS_ERR(ret))
 		fib_params.l.family = AF_INET;
 #else
@@ -1525,7 +1542,9 @@ static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
 			       ((__u32)tuple->sport << 16) | tuple->dport);
 		ctx_store_meta_ipv6(ctx, CB_ADDR_V6_1, &backend->address);
 #elif DSR_ENCAP_MODE == DSR_ENCAP_GENEVE || DSR_ENCAP_MODE == DSR_ENCAP_NONE
-		ctx_store_meta(ctx, CB_PORT, key->dport);
+		ctx_store_meta(ctx, CB_PORT, (__u32)key->dport |
+			       (ct_state_svc.svc_entry_created ?
+				CB_PORT_DSR_FORCE_OPT : 0));
 		ctx_store_meta_ipv6(ctx, CB_ADDR_V6_1, &key->address);
 #endif /* DSR_ENCAP_MODE */
 		return tail_call_internal(ctx, CILIUM_CALL_IPV6_NODEPORT_DSR, ext_err);
@@ -1816,6 +1835,7 @@ static __always_inline int dsr_set_opt4(struct __ctx_buff *ctx,
 # elif DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
 static __always_inline int encap_geneve_dsr_opt4(struct __ctx_buff *ctx, struct iphdr *ip4,
 						 __be32 svc_addr, __be16 svc_port,
+						 bool force_opt,
 						 int *ifindex, __be16 *ohead)
 {
 	const struct remote_endpoint_info *info;
@@ -1851,12 +1871,15 @@ static __always_inline int encap_geneve_dsr_opt4(struct __ctx_buff *ctx, struct 
 		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
 			return DROP_CT_INVALID_HDR;
 
-		/* The GENEVE option is required only for the first packet
-		 * (SYN), in the case of TCP, as for further packets of the
-		 * same connection a remote node will use a NAT entry to
-		 * reverse xlate a reply.
+		/* The GENEVE option is required only for the packet which
+		 * creates the CT service entry: the SYN in the common case,
+		 * but also a non-SYN packet that was re-routed to this LB
+		 * node mid-flow (e.g. ECMP rehash) -- flagged by the caller
+		 * via force_opt. For all other packets of the connection the
+		 * remote node already holds a NAT entry to reverse xlate a
+		 * reply.
 		 */
-		if (!(tcp_flags.value & (TCP_FLAG_SYN)))
+		if (!(tcp_flags.value & (TCP_FLAG_SYN)) && !force_opt)
 			need_opt = false;
 	}
 
@@ -1923,9 +1946,19 @@ nodeport_extract_dsr_v4(struct __ctx_buff *ctx,
 			 * trigger a CT update.
 			 * We don't have any DSR info to report back, and that's ok.
 			 */
-			*dsr = ct_has_dsr_egress_entry4(get_ct_map4(&tmp), &tmp);
-			*port = 0;
-			return 0;
+			if (ct_has_dsr_egress_entry4(get_ct_map4(&tmp), &tmp)) {
+				*dsr = true;
+				*port = 0;
+				return 0;
+			}
+			/* No local DSR state: this node never saw the SYN of
+			 * that connection (in-flight packet re-routed to a new
+			 * LB node which selected a backend on this node). Fall
+			 * through: the LB attaches the DSR info to the packet
+			 * which created its CT entry, so state can be built
+			 * and the backend's reply (typically a TCP RST) can be
+			 * RevDNATed instead of being dropped.
+			 */
 		}
 	}
 
@@ -2101,6 +2134,7 @@ int tail_nodeport_ipv4_dsr(struct __ctx_buff *ctx)
 	__s8 ext_err = 0;
 	__be32 addr;
 	__be16 port;
+	bool force_opt __maybe_unused = false;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4)) {
 		ret = DROP_INVALID;
@@ -2108,6 +2142,7 @@ int tail_nodeport_ipv4_dsr(struct __ctx_buff *ctx)
 	}
 	addr = ctx_load_meta(ctx, CB_ADDR_V4);
 	port = (__be16)ctx_load_meta(ctx, CB_PORT);
+	force_opt = !!(ctx_load_meta(ctx, CB_PORT) & CB_PORT_DSR_FORCE_OPT);
 
 #if DSR_ENCAP_MODE == DSR_ENCAP_IPIP
 	ret = dsr_set_ipip4(ctx, ip4,
@@ -2118,7 +2153,7 @@ int tail_nodeport_ipv4_dsr(struct __ctx_buff *ctx)
 			   addr,
 			   port, &ohead);
 #elif DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
-	ret = encap_geneve_dsr_opt4(ctx, ip4, addr, port, &oif, &ohead);
+	ret = encap_geneve_dsr_opt4(ctx, ip4, addr, port, force_opt, &oif, &ohead);
 #else
 # error "Invalid load balancer DSR encapsulation mode!"
 #endif
@@ -2905,7 +2940,9 @@ static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,
 			       ((__u32)tuple->sport << 16) | tuple->dport);
 		ctx_store_meta(ctx, CB_ADDR_V4, backend->address);
 #elif DSR_ENCAP_MODE == DSR_ENCAP_GENEVE || DSR_ENCAP_MODE == DSR_ENCAP_NONE
-		ctx_store_meta(ctx, CB_PORT, key->dport);
+		ctx_store_meta(ctx, CB_PORT, (__u32)key->dport |
+			       (ct_state_svc.svc_entry_created ?
+				CB_PORT_DSR_FORCE_OPT : 0));
 		ctx_store_meta(ctx, CB_ADDR_V4, key->address);
 #endif /* DSR_ENCAP_MODE */
 		return tail_call_internal(ctx, CILIUM_CALL_IPV4_NODEPORT_DSR, ext_err);


### PR DESCRIPTION
## Summary

In DSR mode with Geneve dispatch, the Geneve option carrying the service VIP:port is attached
only to the **SYN** of a TCP connection. A mid-flow packet that is re-routed to a **different LB
node** (e.g. after an ECMP rehash on the upstream router when a BGP next-hop is added/removed)
does `CT_NEW` on that new node, selects a backend via Maglev, and forwards the packet **without**
the DSR option. If the Maglev table changed in the meantime, the packet reaches a backend whose
node never saw the SYN and holds no reverse-xlate state. The pod replies (typically a **TCP RST**
for an unknown connection); the reply takes the generic egress path, the NAT lookup misses, and
the RST leaves with the **pod/node IP as source instead of the VIP**. The client silently drops it
on a tuple mismatch and keeps retransmitting for the whole ECMP window instead of fast-failing.

**Nothing is dropped anywhere** — every component does its job — so there is no `cilium monitor`
drop event and no `cilium_drop_count_total` increment. It is a *misdelivery*, not a drop, and is
invisible to the standard tooling.

This is a long-standing, previously-reported behaviour:
- #27730 — *"DSR: Client can't receive RST when the backend is switched in long lived connection"*
  (closed as stale). A maintainer diagnosed the exact root cause and proposed exactly this fix:
  *"I think Cilium should set the dsr info into IP option or Geneve option for the non-syn packets."*
- #32091 — *"Cilium LB DSR reply with wrong src ip when syn packet is missed"* (closed as stale),
  including a Geneve repro. The thread stalled on an MTU objection that this PR addresses below.

## What this PR does

Attach the DSR info to the non-SYN packet that **creates** the CT service entry on the LB node,
so the backend node can build the reverse-xlate state it never got from a SYN:

- `struct ct_state` gains a `svc_entry_created` bit (from the `reserved` bitfield), set in the
  `CT_NEW` branch of `lb{4,6}_local()` right after a successful `ct_create{4,6}()`.
- `nodeport_lb{4,6}()` propagates that bit to the DSR tail call via a new `CB_PORT_DSR_FORCE_OPT`
  flag stored in the high bits of `CB_PORT`.
- `encap_geneve_dsr_opt{4,6}()` attaches the Geneve option when the packet is a SYN **or** when
  `force_opt` is set. Steady-state packets are unchanged, so there is **no extra wire cost**.
- `nodeport_extract_dsr_v{4,6}()` reads the option on a non-SYN packet **only when there is no
  local DSR egress entry**, leaving the hot path untouched.

## Two variants / trade-offs

I have two candidate implementations and would appreciate maintainer guidance on which is preferred:

| | **This PR (`svc_entry_created`)** | **Alternative (option on every packet)** |
|---|---|---|
| Wire cost, steady state | **Zero** — option only on the entry-creating packet | +12 B/pkt (`geneve_dsr_opt4`) |
| MTU budget | Unchanged | Already reserved: `DsrTunnelOverhead` in `pkg/mtu` is reserved **unconditionally**, so no change to the effective MTU |
| Robustness | One-shot: if the marked packet is lost between LB and backend, no retry | Robust: any packet re-teaches the backend |
| Complexity | New CT-state bit + CB flag plumbing | Removes the SYN guard; smaller diff |

**On the MTU objection that stalled #32091:** for Geneve dispatch specifically, the option's 12
bytes are already accounted for unconditionally by `DsrTunnelOverhead`, so even the "every packet"
variant does not change the MTU budget. The conservative variant in this PR costs nothing on the
wire regardless.

## Test status

- **Compile-verified**: `make -C bpf` builds clean in the pinned `cilium/cilium-builder` image with
  `-Werror -Wall -Wextra -Wshadow` and DSR enabled; `bpf_alignchecker` passes (the new `ct_state`
  bit does not perturb the struct layout).
- BPF unit-test plan: extend the Geneve-DSR backend test (`bpf/tests/tc_nodeport_lb4_dsr_backend.c`)
  with a case where a **non-SYN** TCP packet carrying a Geneve DSR option arrives with **no
  pre-existing CT entry**, asserting that state is created and the reply is RevDNATed to the VIP
  (today it would early-return with no DSR info). Happy to add this in a follow-up commit here.
- I have cross-node packet captures (LB node / backend node / client) demonstrating the freeze and
  the wrong-source RST; anonymized captures available on request.

## RFC

Marking this **draft/RFC** to get direction on (a) which variant to land and (b) whether to include
the test in this PR. Relates to #27730 and #32091.
