### PR TITLE
renovate: restore updates of docker images

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -126,6 +126,15 @@
       "minimumReleaseAge": "5 days"
     },
     {
+      // Docker Hub is the only Docker registry that currently supports release
+      // timestamps, causing updates to be never proposed by Renovate for all
+      // other registries. Hence, let's enable the "timestamp-optional" option,
+      // which unfortunately effectively disables the cooldown period for them.
+      // https://docs.renovatebot.com/key-concepts/minimum-release-age/#which-registries-support-release-timestamps
+      "matchDatasources": ["docker"],
+      "minimumReleaseAgeBehaviour": "timestamp-optional",
+    },
+    {
       // Do not pin or update digests for self-referenced cilium/cilium GitHub
       // Actions and reusable workflows (e.g.,
       // cilium/cilium/.github/actions/set-commit-status@<sha> # main or


### PR DESCRIPTION
The blamed commit introduced a 5-days cooldown period for all dependency updates. However, it appears that no docker registry, except Docker Hub, reliably supports release timestamps today \[1], in turn causing docker dependencies to not be updated by renovate anymore. This is confirmed by renovate log lines along the lines of:

> Marking ... release(s) as pending, as they do not have a releaseTimestamp
> and we're running with minimumReleaseAgeBehaviour=timestamp-required

Specifically, we hit occurrences with images hosted on quay.io, gcr.io, registry.k8s.io and ghcr.io.

Let's restore updates of docker images again by enabling timestamp-optional mode for docker dependencies, which effectively disables the cooldown period if the registry does not provide timestamp information. That's suboptimal, but still better than having no updates at all.

\[1]: https://docs.renovatebot.com/key-concepts/minimum-release-age/#which-registries-support-release-timestamps

Fixes: 8f7e55af902d ("renovate: add dependency cooldown")
Fixes: #47013