### PR TITLE
docs: correct Hubble exporter file rotation settings

### DIFF
--- a/Documentation/observability/hubble/configuration/export.rst
+++ b/Documentation/observability/hubble/configuration/export.rst
@@ -67,11 +67,11 @@ Helm chart configuration options include:
 
 - ``hubble.export.static.filePath``: file path of target log file. (default /var/run/cilium/hubble/events.log)
 
-- ``hubble.export.fileMaxSizeMb``: size in MB at which to rotate the Hubble export file. (default 10)
+- ``hubble.export.static.fileMaxSizeMb``: size in MB at which to rotate the Hubble export file. (default 10)
 
-- ``hubble.export.fileMaxBackups``: number of rotated Hubble export files to keep. (default 5)
+- ``hubble.export.static.fileMaxBackups``: number of rotated Hubble export files to keep. (default 5)
 
-- ``hubble.export.fileCompress``: enable compression of rotated files. (default false)
+- ``hubble.export.static.fileCompress``: enable compression of rotated files. (default false)
 
 Performance tuning
 ==================
@@ -236,8 +236,10 @@ Dynamic flow logs can be configured with ``end`` property which means that it wi
 automatically stop logging after specified date time. It supports the same
 field masking and filtering as static hubble exporter.
 
-For max output file size and backup files dynamic exporter reuses the same
-settings as static one: ``hubble.export.fileMaxSizeMb`` and ``hubble.export.fileMaxBackups``
+File rotation is configured per flow log entry. Each entry accepts its own
+``fileMaxSizeMb``, ``fileMaxBackups`` and ``fileCompress`` settings. If an entry
+omits these settings, the defaults are used (``fileMaxSizeMb: 10``,
+``fileMaxBackups: 5``, ``fileCompress: false``).
 
 Sample dynamic flow logs configs:
 
@@ -259,6 +261,9 @@ Sample dynamic flow logs configs:
           - name: "test002"
             filePath: "/var/run/cilium/hubble/test002.log"
             fieldMask: ["source.namespace", "source.pod_name", "destination.namespace", "destination.pod_name", "verdict"]
+            fileMaxSizeMb: 100
+            fileMaxBackups: 2
+            fileCompress: true
             includeFilters:
             - source_pod: ["default/"]
               event_type:


### PR DESCRIPTION
The Hubble exporter docs stated that file rotation reuses the static exporter's global hubble.export.fileMaxSizeMb and hubble.export.fileMaxBackups settings. That is no longer accurate: each dynamic flow log entry honors its own per-entry fileMaxSizeMb, fileMaxBackups and fileCompress fields and static flow uses it's own hubble.export.static.* settings.

This corrects both exporters:
- Static "Configuration options" now use the hubble.export.static.* paths.
- The dynamic section now documents that rotation is configured per flow log entry, and the sample config shows per-entry fileMaxSizeMb, fileMaxBackups and fileCompress.

Please backport to v1.19 and v1.18.

```release-note
docs: clarify Hubble static/dynamic exporter file rotation settings
```