### PR TITLE
docs: clarify TCPRoute/UDPRoute limitation with Gateway API host network node subset

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -430,6 +430,8 @@ Non-presence of the ``service.cilium.io/proxy-delegation`` annotation leaves
 all forwarding to BPF natively which is also the default for the kube-proxy
 replacement case.
 
+.. _Selective Service Node Exposure:
+
 Selective Service Node Exposure
 *******************************
 

--- a/Documentation/network/servicemesh/gateway-api/host-network-mode.rst
+++ b/Documentation/network/servicemesh/gateway-api/host-network-mode.rst
@@ -96,9 +96,14 @@ network mode:
 Deploy Gateway API listeners on subset of nodes
 ===============================================
 
-The Cilium Gateway API Envoy listener can be exposed on a specific subset of
-nodes. This only works in combination with the host network mode and can be
-configured via a node label selector in the Helm values:
+Cilium proxies ``HTTPRoute``, ``GRPCRoute``, and ``TLSRoute`` traffic through
+Envoy. Cilium's eBPF service load balancer programs ``TCPRoute`` and
+``UDPRoute`` directly, bypassing Envoy. The route type therefore determines
+which mechanism controls node exposure for the listeners of a ``Gateway``.
+
+For ``HTTPRoute``, ``GRPCRoute``, and ``TLSRoute``, restrict node exposure by
+configuring a node label selector in the Helm values. This only works in
+combination with the host network mode:
 
 .. code-block:: yaml
 
@@ -114,3 +119,14 @@ configured via a node label selector in the Helm values:
 This will deploy the Gateway API Envoy listener only on the Cilium Nodes
 matching the configured labels. An empty selector selects all nodes and
 continues to expose the functionality on all Cilium nodes.
+
+For ``TCPRoute`` and ``UDPRoute``, this selector has no effect. Their Service
+remains installed on every Cilium node regardless of the selector. To
+restrict node exposure for these route types, use the
+:ref:`Selective Service Node Exposure` annotation
+``service.cilium.io/node-selector`` within
+``spec.infrastructure.annotations`` on the ``Gateway`` instead.
+
+If a ``Gateway`` combines both categories of route types, configure both
+mechanisms with the same label selector to keep node exposure consistent
+across all routes.


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/46184 introduced Gateway API `TCPRoute`/`UDPRoute` support for Cilium's Gateway API implementation, which will be available in the upcoming 1.20 release. However, with that, there's a new limitation around Cilium's existing ["expose GwAPI on a subset of nodes"](https://docs.cilium.io/en/stable/network/servicemesh/gateway-api/gateway-api/#deploy-gateway-api-listeners-on-subset-of-nodes) functionality:

The host network mode's node label selector only restricts Envoy listener placement for HTTPRoute, GRPCRoute, and TLSRoute. TCPRoute and UDPRoute bypass Envoy and are programmed directly into Cilium's eBPF service load-balancer, so the selector has no effect on them. This PR documents this gap and points to the `service.cilium.io/node-selector` annotation as the equivalent mechanism for L4 routes.

```release-note
docs: clarify TCPRoute/UDPRoute limitation with Gateway API host network node subset
```

Looks like this when rendered:

<img width="739" height="798" alt="image" src="https://github.com/user-attachments/assets/b85531a1-2676-4a75-9ca2-69b491f4394a" />