### PR TITLE
Add various routing fixes for ENI IPv6 support

### DIFF
--- a/daemon/infraendpoints/infra_ip_allocation.go
+++ b/daemon/infraendpoints/infra_ip_allocation.go
@@ -557,6 +557,32 @@ func (r *infraIPAllocator) allocateIngressIPs(ctx context.Context, oldV4IngressI
 
 		r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv6IngressIP = net.IP(result.IP.AsSlice()).To16() })
 		r.logger.Debug("Allocated IPv6 Ingress address", logfields.IPAddr, result.IP)
+
+		// In ENI mode, we require the gateway, CIDRs, and the
+		// ENI MAC addr in order to set up rules and routes on the local node to
+		// direct ingress traffic out of the ENIs.
+		if r.daemonConfig.IPAM == ipamOption.IPAMENI {
+			if ingressRouting, err := r.parseRoutingInfo(result); err != nil {
+				r.logger.Warn("Unable to allocate ingress information for ENI", logfields.Error, err)
+			} else {
+				// The ingress IP may sit on a different ENI than the router IP, so
+				// wait for its ENI to show up before configuring routes and rules,
+				// to avoid netlink failing to find the ifindex by its MAC.
+				if err := r.waitForENI(ctx, result.PrimaryMAC); err != nil {
+					r.logger.Error("Unable to find ENI netlink interface, this will likely lead to an error in configuring the ingress routes and rules",
+						logfields.MACAddr, result.PrimaryMAC,
+					)
+				}
+
+				if err := ingressRouting.Configure(
+					result.IP,
+					r.mtuManager.GetDeviceMTU(),
+					false,
+				); err != nil {
+					r.logger.Warn("Error while configuring ingress IP rules and routes.", logfields.Error, err)
+				}
+			}
+		}
 	}
 
 	return nil

--- a/daemon/infraendpoints/infra_ip_allocation.go
+++ b/daemon/infraendpoints/infra_ip_allocation.go
@@ -60,7 +60,7 @@ type infraIPAllocatorParams struct {
 
 type InfraIPAllocator interface {
 	AllocateIPs(ctx context.Context) error
-	GetHealthEndpointRouting() *linuxrouting.RoutingInfo
+	GetHealthEndpointRouting() (ipv4, ipv6 *linuxrouting.RoutingInfo)
 }
 
 var _ InfraIPAllocator = &infraIPAllocator{}
@@ -79,8 +79,12 @@ type infraIPAllocator struct {
 	ipAllocator    ipamAllocator
 
 	// healthEndpointRouting is the information required to set up the health
-	// endpoint's routing in ENI or Azure IPAM mode
+	// endpoint's IPv4 routing in ENI or AlibabaCloud IPAM mode
 	healthEndpointRouting *linuxrouting.RoutingInfo
+
+	// healthEndpointRoutingV6 is the information required to set up the health
+	// endpoint's IPv6 routing in ENI or AlibabaCloud IPAM mode
+	healthEndpointRoutingV6 *linuxrouting.RoutingInfo
 }
 
 type ipamAllocator interface {
@@ -109,8 +113,8 @@ const (
 	mismatchRouterIPsMsg = "Mismatch of router IPs found during restoration. The Kubernetes resource contained %s, while the filesystem contained %s. Using the router IP from the filesystem. To change the router IP, specify --%s and/or --%s."
 )
 
-func (r *infraIPAllocator) GetHealthEndpointRouting() *linuxrouting.RoutingInfo {
-	return r.healthEndpointRouting
+func (r *infraIPAllocator) GetHealthEndpointRouting() (ipv4, ipv6 *linuxrouting.RoutingInfo) {
+	return r.healthEndpointRouting, r.healthEndpointRoutingV6
 }
 
 func (r *infraIPAllocator) allocateRouterIPv4(ctx context.Context, family node.AddressingFamily, fromK8s, fromFS net.IP) (net.IP, error) {
@@ -419,7 +423,25 @@ func (r *infraIPAllocator) allocateHealthIPs(oldV4HealthIP netip.Addr, oldV6Heal
 			}
 			r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv6HealthIP = iputil.AddrFrom(result.IP) })
 		}
+
+		// Coalescing multiple CIDRs. GH #18868
+		if r.daemonConfig.EnableIPv6Masquerade &&
+			r.daemonConfig.IPAM == ipamOption.IPAMENI &&
+			result != nil &&
+			len(result.CIDRs) > 0 {
+			result.CIDRs = r.coalesceCIDRs(result.CIDRs)
+		}
+
 		r.logger.Debug("Allocated IPv6 health endpoint address", logfields.IPAddr, result.IP)
+
+		// In ENI mode, we require the gateway, CIDRs, and the ENI MAC addr
+		// in order to set up rules and routes on the local node to direct
+		// endpoint traffic out of the ENIs.
+		if r.daemonConfig.IPAM == ipamOption.IPAMENI {
+			if r.healthEndpointRoutingV6, err = r.parseRoutingInfo(result); err != nil {
+				r.logger.Warn("Unable to allocate health information for ENI", logfields.Error, err)
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -731,17 +731,25 @@ func (n *linuxNodeHandler) NodeConfigurationChanged(newConfig config.Config) err
 	if newConfig.EnableIPSec {
 		// For the ENI ipam mode on EKS, this will be the interface that
 		// the router (cilium_host) IP is associated to.
-		if (option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAzure) &&
-			len(option.Config.IPv4PodSubnets) == 0 {
+		if option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAzure {
 			if info := node.GetRouterInfo(); info != nil {
 				cidrs := info.GetCIDRs()
-				var ipv4PodSubnets []*cidr.CIDR
+				var ipv4PodSubnets, ipv6PodSubnets []*cidr.CIDR
 				for _, c := range cidrs {
 					if c.IP.To4() != nil {
 						ipv4PodSubnets = append(ipv4PodSubnets, cidr.NewCIDR(&c))
+					} else {
+						ipv6PodSubnets = append(ipv6PodSubnets, cidr.NewCIDR(&c))
 					}
 				}
-				n.nodeConfig.IPv4PodSubnets = ipv4PodSubnets
+				// Only derive the pod subnets which have not been explicitly
+				// configured.
+				if len(option.Config.IPv4PodSubnets) == 0 {
+					n.nodeConfig.IPv4PodSubnets = ipv4PodSubnets
+				}
+				if len(option.Config.IPv6PodSubnets) == 0 {
+					n.nodeConfig.IPv6PodSubnets = ipv6PodSubnets
+				}
 			}
 		}
 

--- a/pkg/health/health_connectivity_endpoint.go
+++ b/pkg/health/health_connectivity_endpoint.go
@@ -378,11 +378,13 @@ func (h *ciliumHealthManager) launchAsEndpoint(baseCtx context.Context, endpoint
 	}
 
 	if option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAlibabaCloud {
-		ri := h.infraIPAllocator.GetHealthEndpointRouting()
+		ri, riv6 := h.infraIPAllocator.GetHealthEndpointRouting()
+		if healthIP.Is6() {
+			ri = riv6
+		}
 		if ri == nil {
 			return nil, errors.New("failed to configure health endpoint routing - no IP allocated")
 		}
-		// ENI mode does not support IPv6.
 		if err := ri.Configure(
 			healthIP,
 			mtuConfig.GetDeviceMTU(),


### PR DESCRIPTION
# What is this

This PR fixes three issues with IPv6 on ENI.

1. Fixes a bug where if the health check endpoint IP is an IPv6, the ENI specific routing for IPv6 would not be configured. This removes this limitation by filling the routing table for IPv6 health endpoints.
2. When IPSec is enabled on EKS, the pod subnets are determined using the routing info CIDR. Previously only IPv4 CIDRs were parsed. Now both IPv4 and IPv6 pod subnets are filled.
3. When Ingress IP is used with IPv6 enabled, this change makes sure the routing rules are configured similar to how they are configured for IPv4.

# Testing

For the health check endpoint, I was able to validate that before the fix, on a node with only IPv6 enabled, the main v6 routing table was missing an entry for `lxc_health`. Following the fix, the table now shows the route to the health check endpoint:

```bash
1234:[...]::bded dev lxc_health proto kernel metric 1024 pref medium
```
And curling the endpoint shows it as reachable
```bash
curl http://[1234:[...]::bded ]:4240/hello -v
*   Trying [1234:[...]::bded ]:4240...
* Connected to 1234:[...]::bded  (1234:[...]::bded ) port 4240
> GET /hello HTTP/1.1
> Host: [1234:[...]::bded ]:4240
> User-Agent: curl/8.5.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Length: 0
<
* Connection #0 to host 1234:[...]::bded  left intact
```

For the IPSec bug, I couldn't really test it since we don't run this kind of setup.

# Release note

```release-note
ENI IPv6: Fix IPv6 routing for health check endpoint, ingress address and for IPSec on ENI interfaces.
```

This PR was prepared with AIL:2.
