### PR TITLE
operator: validate CNP endpointSelector namespace

### DIFF
--- a/operator/pkg/networkpolicy/validator.go
+++ b/operator/pkg/networkpolicy/validator.go
@@ -19,10 +19,12 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8s_client "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -101,10 +103,12 @@ func (pv *policyValidator) handleCNPEvent(ctx context.Context, event resource.Ev
 	var errs error
 	if newPol.Spec != nil {
 		errs = errors.Join(errs, newPol.Spec.Sanitize())
+		errs = errors.Join(errs, validateCNPEndpointSelectorNamespace(pol.Namespace, newPol.Spec))
 		errs = errors.Join(errs, pv.checkMutalAuthUsage(newPol.Spec))
 	}
 	for _, r := range newPol.Specs {
 		errs = errors.Join(errs, r.Sanitize())
+		errs = errors.Join(errs, validateCNPEndpointSelectorNamespace(pol.Namespace, r))
 		errs = errors.Join(errs, pv.checkMutalAuthUsage(r))
 	}
 
@@ -197,6 +201,31 @@ func (pv *policyValidator) checkMutalAuthUsage(spec *api.Rule) error {
 		if r.Authentication != nil && !pv.params.Cfg.MeshAuthEnabled {
 			return errors.New("mutual auth feature is disabled but an egress auth rule is defined in policy")
 		}
+	}
+	return nil
+}
+
+// validateCNPEndpointSelectorNamespace checks that the endpointSelector of a
+// CiliumNetworkPolicy does not select a namespace other than the one the
+// policy is defined in. The endpointSelector always applies in the namespace
+// of the policy resource, so a selector on a different namespace can never
+// select any endpoints.
+func validateCNPEndpointSelectorNamespace(namespace string, spec *api.Rule) error {
+	if spec == nil || spec.EndpointSelector.LabelSelector == nil {
+		return nil
+	}
+	for _, key := range []string{
+		labels.LabelSourceK8sKeyPrefix + k8sConst.PodNamespaceLabel,
+		labels.LabelSourceAnyKeyPrefix + k8sConst.PodNamespaceLabel,
+	} {
+		selectedNamespaces, present := spec.EndpointSelector.GetMatch(key)
+		if !present {
+			continue
+		}
+		if len(selectedNamespaces) == 1 && selectedNamespaces[0] == namespace {
+			continue
+		}
+		return fmt.Errorf("CiliumNetworkPolicy endpointSelector matches namespace(s) %v, but the endpointSelector can only select endpoints in the policy's own namespace %q", selectedNamespaces, namespace)
 	}
 	return nil
 }

--- a/operator/pkg/networkpolicy/validator_test.go
+++ b/operator/pkg/networkpolicy/validator_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package networkpolicy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/policy/api"
+)
+
+func TestValidateCNPEndpointSelectorNamespace(t *testing.T) {
+	testCases := []struct {
+		name        string
+		namespace   string
+		matchLabels map[string]string
+		wantErr     bool
+	}{
+		{
+			name:        "selector matches another namespace",
+			namespace:   "foo",
+			matchLabels: map[string]string{"k8s:io.kubernetes.pod.namespace": "bar"},
+			wantErr:     true,
+		},
+		{
+			name:        "selector matches own namespace",
+			namespace:   "foo",
+			matchLabels: map[string]string{"k8s:io.kubernetes.pod.namespace": "foo"},
+			wantErr:     false,
+		},
+		{
+			name:        "selector without namespace match",
+			namespace:   "foo",
+			matchLabels: map[string]string{"app": "demo-app"},
+			wantErr:     false,
+		},
+		{
+			name:        "unprefixed namespace key matching another namespace",
+			namespace:   "foo",
+			matchLabels: map[string]string{"io.kubernetes.pod.namespace": "bar"},
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := &api.Rule{
+				EndpointSelector: api.EndpointSelector{
+					LabelSelector: &slim_metav1.LabelSelector{
+						MatchLabels: tc.matchLabels,
+					},
+				},
+				Ingress: []api.IngressRule{{}},
+			}
+			require.NoError(t, spec.Sanitize())
+
+			err := validateCNPEndpointSelectorNamespace(tc.namespace, spec)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.ErrorContains(t, err, "CiliumNetworkPolicy")
+				require.ErrorContains(t, err, "endpointSelector")
+				require.ErrorContains(t, err, "namespace")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+
+	t.Run("nil spec", func(t *testing.T) {
+		require.NoError(t, validateCNPEndpointSelectorNamespace("foo", nil))
+	})
+
+	t.Run("nil endpoint selector", func(t *testing.T) {
+		spec := &api.Rule{
+			Ingress: []api.IngressRule{{}},
+		}
+		require.NoError(t, validateCNPEndpointSelectorNamespace("foo", spec))
+	})
+
+	t.Run("matchExpressions In with multiple namespaces", func(t *testing.T) {
+		spec := &api.Rule{
+			EndpointSelector: api.EndpointSelector{
+				LabelSelector: &slim_metav1.LabelSelector{
+					MatchExpressions: []slim_metav1.LabelSelectorRequirement{
+						{
+							Key:      "k8s:io.kubernetes.pod.namespace",
+							Operator: slim_metav1.LabelSelectorOpIn,
+							Values:   []string{"foo", "bar"},
+						},
+					},
+				},
+			},
+			Ingress: []api.IngressRule{{}},
+		}
+		require.NoError(t, spec.Sanitize())
+		require.Error(t, validateCNPEndpointSelectorNamespace("foo", spec))
+	})
+}


### PR DESCRIPTION
Fixes: #45231

This updates the policy validation operator so a namespaced CiliumNetworkPolicy whose endpointSelector explicitly selects a different Kubernetes namespace is marked invalid in status instead of being reported valid.

The validation is limited to CiliumNetworkPolicy because CiliumClusterwideNetworkPolicy is clusterwide. The check runs after rule sanitization and covers both k8s: and any: prefixed namespace label forms.

Tests:
- go test -count=1 ./operator/pkg/networkpolicy

AI disclosure: This PR was prepared with AIL:3. I used LLM assistance for implementation and test drafting, then personally reviewed the diff, verified the code path, ran the test above, and take responsibility for the change.

```release-note
Mark CiliumNetworkPolicy resources invalid when their endpointSelector explicitly selects a different Kubernetes namespace.
```