### PR TITLE
hubble: replace deprecated strings.Title usage

### DIFF
--- a/hubble/cmd/common/template/usage.go
+++ b/hubble/cmd/common/template/usage.go
@@ -4,10 +4,10 @@
 package template
 
 import (
-	"strings"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/cilium/cilium/hubble/cmd/common/config"
 )
@@ -18,7 +18,11 @@ var (
 )
 
 func init() {
-	cobra.AddTemplateFunc("title", strings.Title)
+	// cases.Caser is stateful and not safe for concurrent use, hence the
+	// wrapper function creating a new one on every call.
+	cobra.AddTemplateFunc("title", func(s string) string {
+		return cases.Title(language.Und, cases.NoLower).String(s)
+	})
 	cobra.AddTemplateFunc("getFlagSets", getFlagSets)
 }
 

--- a/hubble/cmd/list/node.go
+++ b/hubble/cmd/list/node.go
@@ -8,12 +8,13 @@ import (
 	"fmt"
 	"io"
 	"sort"
-	"strings"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"google.golang.org/grpc"
 
 	observerpb "github.com/cilium/cilium/api/v1/observer"
@@ -95,6 +96,7 @@ func nodeTableOutput(buf io.Writer, nodes []*observerpb.Node) error {
 	}
 	fmt.Fprintln(tw)
 
+	titleCaser := cases.Title(language.Und, cases.NoLower)
 	for _, n := range nodes {
 		age := notAvailable
 		flowsPerSec := notAvailable
@@ -110,7 +112,7 @@ func nodeTableOutput(buf io.Writer, nodes []*observerpb.Node) error {
 		if v := n.GetVersion(); v != "" {
 			version = v
 		}
-		fmt.Fprint(tw, n.GetName(), "\t", strings.Title(nodeStateToString(n.GetState())), "\t", age, "\t", flowsPerSec, "\t", flowsRatio)
+		fmt.Fprint(tw, n.GetName(), "\t", titleCaser.String(nodeStateToString(n.GetState())), "\t", age, "\t", flowsPerSec, "\t", flowsRatio)
 		if listOpts.output == "wide" {
 			tls := notAvailable
 			if t := n.GetTls(); t != nil {


### PR DESCRIPTION
Ref: #32274

This replaces deprecated strings.Title usage in the Hubble CLI with golang.org/x/text/cases while preserving existing title-casing behavior.

The change is limited to:
- hubble/cmd/common/template/usage.go
- hubble/cmd/list/node.go

Tests:
- go test -count=1 ./hubble/cmd/common/template ./hubble/cmd/list
- go build ./hubble/cmd/...

AI disclosure: This PR was prepared with AIL:3. I used LLM assistance for implementation and test drafting, then personally reviewed the diff, verified the code path, ran the tests above, and take responsibility for the change.

```release-note
Replace deprecated strings.Title usage in Hubble CLI.
```