### PR TITLE
status: replace deprecated strings.Title usage

### DIFF
--- a/pkg/status/status_collector.go
+++ b/pkg/status/status_collector.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 
 	"github.com/go-openapi/strfmt"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	versionapi "k8s.io/apimachinery/pkg/version"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -316,6 +318,7 @@ func (d *statusCollector) getKubeProxyReplacementStatus(ctx context.Context) *mo
 		BpfSocketLBHostnsOnly: d.statusParams.DaemonConfig.UnsafeDaemonConfigOption.BPFSocketLBHostnsOnly,
 	}
 	if d.statusParams.KPRConfig.KubeProxyReplacement {
+		titleCaser := cases.Title(language.Und, cases.NoLower)
 		features.NodePort.Enabled = true
 		features.NodePort.Mode = strings.ToUpper(d.statusParams.LBConfig.LBMode)
 		switch d.statusParams.LBConfig.DSRDispatch {
@@ -327,8 +330,7 @@ func (d *statusCollector) getKubeProxyReplacementStatus(ctx context.Context) *mo
 			features.NodePort.DsrMode = models.KubeProxyReplacementFeaturesNodePortDsrModeGeneve
 		}
 		if d.statusParams.LBConfig.LBMode == loadbalancer.LBModeHybrid {
-			//nolint:staticcheck
-			features.NodePort.Mode = strings.Title(d.statusParams.LBConfig.LBMode)
+			features.NodePort.Mode = titleCaser.String(d.statusParams.LBConfig.LBMode)
 		}
 		features.NodePort.Algorithm = models.KubeProxyReplacementFeaturesNodePortAlgorithmRandom
 		if d.statusParams.LBConfig.LBAlgorithm == loadbalancer.LBAlgorithmMaglev {
@@ -341,7 +343,7 @@ func (d *statusCollector) getKubeProxyReplacementStatus(ctx context.Context) *mo
 		if d.statusParams.DaemonConfig.NodePortAcceleration == option.NodePortAccelerationGeneric {
 			features.NodePort.Acceleration = models.KubeProxyReplacementFeaturesNodePortAccelerationGeneric
 		} else {
-			features.NodePort.Acceleration = strings.Title(d.statusParams.DaemonConfig.NodePortAcceleration)
+			features.NodePort.Acceleration = titleCaser.String(d.statusParams.DaemonConfig.NodePortAcceleration)
 		}
 		features.NodePort.PortMin = int64(d.statusParams.LBConfig.NodePortMin)
 		features.NodePort.PortMax = int64(d.statusParams.LBConfig.NodePortMax)


### PR DESCRIPTION
Ref: #32274

This replaces deprecated strings.Title usage in the status collector with golang.org/x/text/cases while preserving the existing title-casing behavior for kube-proxy replacement feature status output.

The change is limited to:
- pkg/status/status_collector.go

Tests:
- go test -count=1 ./pkg/status

AI disclosure: This PR was prepared with AIL:3. I used LLM assistance for implementation and test drafting, then personally reviewed the diff, verified the code path, ran the test above, and take responsibility for the change.

```release-note
Replace deprecated strings.Title usage in the status collector.
```