### PR TITLE
gw-api-conformance: unskip mesh tests

### DIFF
--- a/operator/pkg/gateway-api/conformance_test.go
+++ b/operator/pkg/gateway-api/conformance_test.go
@@ -72,11 +72,6 @@ func TestConformance(t *testing.T) {
 			})
 		}
 	}
-	// TODO: Run MeshGRPCRouteWeight once it is deflaked upstream. See
-	//       GH-42456 for details.
-	skipTests = append(skipTests, "MeshGRPCRouteWeight")
-	skipTests = append(skipTests, "MeshHTTPRouteMatching")  // same here
-	skipTests = append(skipTests, "MeshHTTPRouteNamedRule") // same here
 	options.TimeoutConfig.DefaultPollInterval = 1 * time.Second
 	options.UnusableNetworkAddresses = unusableNetworkAddresses
 	options.UsableNetworkAddresses = usableNetworkAddresses


### PR DESCRIPTION
<!-- Description of change -->

Previously the mesh tests (`MeshGRPCRouteWeight, MeshHTTPRouteMatching, MeshHTTPRouteNamedRule`) were flaky. Since merging https://github.com/kubernetes-sigs/gateway-api/pull/4917 in upstream and gateway api being bumped to v1.6.0 (https://github.com/cilium/cilium/pull/46827), we can remove skipping these 😌 (ill be keeping an eye on these tests)

Fixes: https://github.com/cilium/cilium/issues/40243


[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
