### PR TITLE
crdhelpers: replace deprecated wait.Poll usage

### DIFF
--- a/pkg/k8s/apis/crdhelpers/register.go
+++ b/pkg/k8s/apis/crdhelpers/register.go
@@ -235,5 +235,10 @@ func (p defaultPoll) Poll(
 	interval, duration time.Duration,
 	conditionFn func() (bool, error),
 ) error {
-	return wait.Poll(interval, duration, conditionFn)
+	// immediate is false to match the behavior of the deprecated wait.Poll,
+	// which waited one interval before the first condition check.
+	return wait.PollUntilContextTimeout(context.Background(), interval, duration, false,
+		func(context.Context) (bool, error) {
+			return conditionFn()
+		})
 }


### PR DESCRIPTION
Ref: #32274

This replaces deprecated wait.Poll usage in the CRD helper poller with wait.PollUntilContextTimeout while preserving the existing poller interface and delayed first check behavior.

The change is limited to:
- pkg/k8s/apis/crdhelpers/register.go

Tests:
- go test -count=1 ./pkg/k8s/apis/crdhelpers

AI disclosure: This PR was prepared with AIL:3. I used LLM assistance for implementation and test drafting, then personally reviewed the diff, verified the code path, ran the test above, and take responsibility for the change.

```release-note
Replace deprecated wait.Poll usage in the CRD helper poller.
```