### PR TITLE
certloader: replace deprecated Subjects usage in client tests

### DIFF
--- a/pkg/crypto/certloader/client_test.go
+++ b/pkg/crypto/certloader/client_test.go
@@ -139,7 +139,7 @@ func TestNewWatchedClientConfig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, keypair)
 	assert.Equal(t, &expectedKeypair, keypair)
-	assert.Equal(t, expectedCaCertPool.Subjects(), tlsConfig.RootCAs.Subjects())
+	assert.True(t, expectedCaCertPool.Equal(tlsConfig.RootCAs), "unexpected root CA pool")
 	// Check that our base option is honored.
 	assert.Equal(t, uint16(tls.VersionTLS13), tlsConfig.MinVersion)
 }
@@ -219,7 +219,7 @@ func TestWatchedClientConfigRotation(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, keypair)
 	assert.Equal(t, &expectedKeypair, keypair)
-	assert.Equal(t, expectedCaCertPool.Subjects(), tlsConfig.RootCAs.Subjects())
+	assert.True(t, expectedCaCertPool.Equal(tlsConfig.RootCAs), "unexpected root CA pool")
 	// Check that our base option is honored.
 	assert.Equal(t, uint16(tls.VersionTLS13), tlsConfig.MinVersion)
 }


### PR DESCRIPTION
Ref: #32274

This replaces deprecated x509.CertPool.Subjects usage in certloader client tests with x509.CertPool.Equal while preserving the existing certificate pool assertions.

The change is limited to:
- pkg/crypto/certloader/client_test.go

Tests:
- go test -count=1 ./pkg/crypto/certloader

AI disclosure: This PR was prepared with AIL:3. I used LLM assistance for implementation and test drafting, then personally reviewed the diff, verified the code path, ran the test above, and take responsibility for the change.

```release-note
Replace deprecated CertPool.Subjects usage in certloader client tests.
```