### PR TITLE
helm: Avoid operator roles, secret creation in preflight

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-operator/role.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/role.yaml
@@ -1,6 +1,6 @@
 {{- $secretSyncEnabled := eq (include "secretSyncEnabled" .) "true" -}}
 
-{{- if and .Values.operator.enabled .Values.serviceAccounts.operator.create .Values.ingressController.enabled .Values.ingressController.secretsNamespace.sync .Values.ingressController.secretsNamespace.name }}
+{{- if and .Values.operator.enabled (not .Values.preflight.enabled) .Values.serviceAccounts.operator.create .Values.ingressController.enabled .Values.ingressController.secretsNamespace.sync .Values.ingressController.secretsNamespace.name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -29,7 +29,7 @@ rules:
   - patch
 {{- end }}
 
-{{- if and .Values.operator.enabled .Values.serviceAccounts.operator.create .Values.gatewayAPI.enabled .Values.gatewayAPI.secretsNamespace.sync .Values.gatewayAPI.secretsNamespace.name }}
+{{- if and .Values.operator.enabled (not .Values.preflight.enabled) .Values.serviceAccounts.operator.create .Values.gatewayAPI.enabled .Values.gatewayAPI.secretsNamespace.sync .Values.gatewayAPI.secretsNamespace.name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -58,7 +58,7 @@ rules:
   - patch
 {{- end }}
 
-{{- if and .Values.operator.enabled .Values.serviceAccounts.operator.create $secretSyncEnabled .Values.tls.secretsNamespace.name }}
+{{- if and .Values.operator.enabled (not .Values.preflight.enabled) .Values.serviceAccounts.operator.create $secretSyncEnabled .Values.tls.secretsNamespace.name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -87,7 +87,7 @@ rules:
   - patch
 {{- end }}
 
-{{- if and .Values.operator.enabled .Values.serviceAccounts.operator.create }}
+{{- if and .Values.operator.enabled (not .Values.preflight.enabled) .Values.serviceAccounts.operator.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/install/kubernetes/cilium/templates/cilium-operator/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/rolebinding.yaml
@@ -1,6 +1,6 @@
 {{- $secretSyncEnabled := eq (include "secretSyncEnabled" .) "true" -}}
 
-{{- if and .Values.operator.enabled .Values.serviceAccounts.operator.create .Values.ingressController.enabled .Values.ingressController.secretsNamespace.sync .Values.ingressController.secretsNamespace.name }}
+{{- if and .Values.operator.enabled (not .Values.preflight.enabled) .Values.serviceAccounts.operator.create .Values.ingressController.enabled .Values.ingressController.secretsNamespace.sync .Values.ingressController.secretsNamespace.name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -27,7 +27,7 @@ subjects:
   namespace: {{ include "cilium.namespace" . }}
 {{- end }}
 
-{{- if and .Values.operator.enabled .Values.serviceAccounts.operator.create .Values.gatewayAPI.enabled .Values.gatewayAPI.secretsNamespace.sync .Values.gatewayAPI.secretsNamespace.name }}
+{{- if and .Values.operator.enabled (not .Values.preflight.enabled) .Values.serviceAccounts.operator.create .Values.gatewayAPI.enabled .Values.gatewayAPI.secretsNamespace.sync .Values.gatewayAPI.secretsNamespace.name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -54,7 +54,7 @@ subjects:
   namespace: {{ include "cilium.namespace" . }}
 {{- end }}
 
-{{- if and .Values.operator.enabled .Values.serviceAccounts.operator.create $secretSyncEnabled .Values.tls.secretsNamespace.name }}
+{{- if and .Values.operator.enabled (not .Values.preflight.enabled) .Values.serviceAccounts.operator.create $secretSyncEnabled .Values.tls.secretsNamespace.name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -81,7 +81,7 @@ subjects:
   namespace: {{ include "cilium.namespace" . }}
 {{- end }}
 
-{{- if and .Values.operator.enabled .Values.serviceAccounts.operator.create }}
+{{- if and .Values.operator.enabled (not .Values.preflight.enabled) .Values.serviceAccounts.operator.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/install/kubernetes/cilium/templates/cilium-secrets-namespace.yaml
+++ b/install/kubernetes/cilium/templates/cilium-secrets-namespace.yaml
@@ -9,6 +9,7 @@
 {{- $_ := set $secretNamespaces .Values.tls.secretsNamespace.name 1 -}}
 {{- end -}}
 
+{{- if (not .Values.preflight.enabled) -}}
 {{- range $name, $_ := $secretNamespaces }}
 ---
 apiVersion: v1
@@ -28,4 +29,5 @@ metadata:
     {{- with $.Values.secretsNamespaceAnnotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-{{- end}}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
Don't create operator roles/rolebindings as part of preflight, because
the preflight execution should not have permissions to modify cluster
state.
    
Similarly, do not attempt to create secrets namespacse during the preflight setup
because these namespaces may be owned by an existing real installation
of Cilium. Attempting to create them from the preflight Helm release
results in the conflict message:
    
    Error: Unable to install Cilium: Unable to continue with install:
    Namespace "cilium-secrets" in namespace "" exists and cannot be imported
    into the current release: invalid ownership metadata;
    annotation validation error: key "meta.helm.sh/release-name" must equal
    "cilium-preflight": current value is "cilium"