### PR TITLE
lb (fix): require active state for backend when using topology hints

### DIFF
--- a/pkg/loadbalancer/tests/testdata/topology-aware-starting.txtar
+++ b/pkg/loadbalancer/tests/testdata/topology-aware-starting.txtar
@@ -1,0 +1,135 @@
+#! --enable-service-topology --lb-test-fault-probability=0.0
+#
+# Regression test for the startup-side of PreferSameNode topology preference.
+#
+# A same-node backend that is present but NOT actively serving (a starting Pod,
+# programmed in BackendStateMaintenance; also applies to Quarantined) must NOT
+# win the same-node preference. Otherwise PreferSameNode commits to "same-node
+# only" and pins traffic to a backend that cannot serve, instead of falling back
+# to a ready remote backend.
+#
+# This is the startup-side analogue of the Terminating fix in #46339.
+#
+# NOTE: the expected tables below encode the POST-FIX behaviour. Before the fix
+# (topologyPreferenceCandidate accepting non-Active states), the first
+# `db/cmp frontends frontends-remote.table` selects the local (non-serving)
+# backend instead and this test fails -- which is the bug being fixed.
+#
+
+# Start and wait for watchers
+hive start
+
+# Local-node backend (10.244.1.1 on 'testnode') is starting: ready=false,
+# serving=false, terminating=false -> maps to a non-Active backend state.
+# Remote backend (10.244.2.1 on 'other-node') is ready and serving.
+k8s/add service.yaml
+k8s/add endpointslice.yaml endpointslice2.yaml
+
+# The non-serving local backend must not drive same-node preference: fall back
+# to the ready remote backend.
+db/cmp frontends frontends-remote.table
+
+# Once the local backend becomes ready/serving (Active), PreferSameNode snaps
+# back to it.
+k8s/update endpointslice-ready.yaml
+db/cmp frontends frontends-local.table
+
+#####
+
+-- services.table --
+Name        Source   PortNames  TrafficPolicy  Flags
+test/echo   k8s      http=80    Cluster        TrafficDistribution=PreferSameNode
+
+-- frontends-local.table --
+Address               Type        ServiceName   PortName   Status  Backends
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP
+
+-- frontends-remote.table --
+Address               Type        ServiceName   PortName   Status  Backends
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.2.1:80/TCP
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  type: ClusterIP
+  trafficDistribution: PreferSameNode
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-eps1
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  conditions:
+    ready: false
+    serving: false
+    terminating: false
+  nodeName: testnode
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+
+-- endpointslice-ready.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-eps1
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: testnode
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+
+-- endpointslice2.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-eps2
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.2.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: other-node
+ports:
+- name: http
+  port: 80
+  protocol: TCP

--- a/pkg/loadbalancer/tests/testdata/topology-aware-starting.txtar
+++ b/pkg/loadbalancer/tests/testdata/topology-aware-starting.txtar
@@ -1,0 +1,215 @@
+#! --enable-service-topology --lb-test-fault-probability=0.0
+#
+# Regression test for PreferSameNode during a pod restart lifecycle.
+#
+# A same-node backend that is present but NOT actively serving must NOT win the
+# same-node preference. Otherwise PreferSameNode commits to "same-node only"
+# and pins traffic to a backend that cannot serve, instead of falling back to a
+# ready remote backend.
+#
+# Note that [Frontend.Backends] is not filtered by backend state: terminating
+# and maintenance backends stay associated with the frontend and it is the BPF
+# reconciler that decides how they are programmed (terminating backends are
+# appended after the COUNT active slots, maintenance backends are not
+# load-balanced at all). The datapath-visible outcome is therefore asserted on
+# the BPF map dump.
+#
+
+# Start with both backends ready and verify that PreferSameNode picks the local
+# one while the agent is running.
+k8s/add service.yaml
+k8s/add endpointslice-ready.yaml endpointslice2.yaml
+hive/start
+db/cmp services services.table
+db/cmp backends backends-ready.table
+db/cmp frontends frontends-local.table
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.actual lbmaps-local.expected
+
+# The local backend starts draining: PreferSameNode must not select it as the
+# only candidate. Both backends stay associated with the frontend, but only the
+# remote active one is load-balanced (COUNT=1), the terminating one is parked
+# after it and is used only when no active backends remain.
+k8s/update endpointslice-terminating.yaml
+db/cmp backends backends-terminating.table
+db/cmp frontends frontends-both.table
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.actual lbmaps-terminating.expected
+
+# A replacement local backend that is starting (ready=false, serving=false,
+# terminating=false -> BackendStateMaintenance) must also be ignored by the
+# same-node preference. Pre-fix the maintenance backend was accepted as a
+# candidate, the frontend was pinned to it alone and the service ended up with
+# COUNT=0, i.e. connection refused for same-node clients. Post-fix the remote
+# active backend keeps serving.
+k8s/update endpointslice-starting.yaml
+db/cmp backends backends-starting.table
+db/cmp frontends frontends-both.table
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.actual lbmaps-starting.expected
+
+# Once the replacement local backend becomes ready/serving (Active),
+# PreferSameNode snaps back to it.
+k8s/update endpointslice-ready.yaml
+db/cmp backends backends-ready.table
+db/cmp frontends frontends-local.table
+lb/maps-dump lbmaps.actual
+* cmp lbmaps.actual lbmaps-local.expected
+
+#####
+
+-- services.table --
+Name        Source   PortNames  TrafficPolicy  Flags
+test/echo   k8s      http=80    Cluster        TrafficDistribution=PreferSameNode
+
+-- backends-ready.table --
+Service    Address              State
+test/echo  10.244.1.1:80/TCP    active
+test/echo  10.244.2.1:80/TCP    active
+
+-- backends-terminating.table --
+Service    Address              State
+test/echo  10.244.1.1:80/TCP    terminating
+test/echo  10.244.2.1:80/TCP    active
+
+-- backends-starting.table --
+Service    Address              State
+test/echo  10.244.1.1:80/TCP    maintenance
+test/echo  10.244.2.1:80/TCP    active
+
+-- frontends-local.table --
+Address               Type        ServiceName   PortName   Status  Backends
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP
+
+-- frontends-both.table --
+Address               Type        ServiceName   PortName   Status  Backends
+10.96.50.104:80/TCP   ClusterIP   test/echo     http       Done    10.244.1.1:80/TCP, 10.244.2.1:80/TCP
+
+-- lbmaps-local.expected --
+BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
+REV: ID=1 ADDR=10.96.50.104:80
+SVC: ID=0 ADDR=10.96.50.104:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- lbmaps-terminating.expected --
+BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=terminating
+BE: ID=2 ADDR=10.244.2.1:80/TCP STATE=active
+REV: ID=1 ADDR=10.96.50.104:80
+SVC: ID=0 ADDR=10.96.50.104:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=1 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=2 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- lbmaps-starting.expected --
+BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=maintenance
+BE: ID=2 ADDR=10.244.2.1:80/TCP STATE=active
+REV: ID=1 ADDR=10.96.50.104:80
+SVC: ID=0 ADDR=10.96.50.104:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=1 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    name: echo
+  type: ClusterIP
+  trafficDistribution: PreferSameNode
+
+-- endpointslice-starting.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-eps1
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  conditions:
+    ready: false
+    serving: false
+    terminating: false
+  nodeName: testnode
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+
+-- endpointslice-terminating.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-eps1
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  conditions:
+    ready: false
+    serving: true
+    terminating: true
+  nodeName: testnode
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+
+-- endpointslice-ready.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-eps1
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: testnode
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+
+-- endpointslice2.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-eps2
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.2.1
+  conditions:
+    ready: true
+    serving: true
+    terminating: false
+  nodeName: other-node
+ports:
+- name: http
+  port: 80
+  protocol: TCP

--- a/pkg/loadbalancer/writer/writer.go
+++ b/pkg/loadbalancer/writer/writer.go
@@ -439,12 +439,13 @@ func matchesFrontend(be *loadbalancer.Backend, fe *loadbalancer.Frontend) bool {
 // same-node and same-zone preference decisions. This mirrors kube-proxy's
 // behaviour where topology hint validation considers Ready endpoints only.
 func (w *Writer) topologyPreferenceCandidate(svc *loadbalancer.Service, be *loadbalancer.Backend) bool {
-	// Terminating backends are excluded from hint computation by the
-	// EndpointSlice controller, so they would always lack hints. Including
-	// them here would either spuriously trip the missing-hints safeguard or
-	// pin traffic to a draining Pod.
-	if be.State == loadbalancer.BackendStateTerminating ||
-		be.State == loadbalancer.BackendStateTerminatingNotServing {
+	// Only backends that are actively serving may drive topology preference.
+	// This excludes terminating, not-yet-serving and quarantined backends so
+	// that a same-node backend which is starting up (or draining) does not win
+	// the preference and pin traffic to a backend that cannot serve, instead
+	// of falling back to ready remote backends. Mirrors kube-proxy, which only
+	// considers Ready endpoints for topology hints.
+	if be.State != loadbalancer.BackendStateActive {
 		return false
 	}
 
@@ -455,9 +456,7 @@ func (w *Writer) topologyPreferenceCandidate(svc *loadbalancer.Service, be *load
 	// Health-checked services should only prefer backends that are currently
 	// usable. Otherwise a quarantined or not-yet-checked local backend would
 	// suppress fallback to healthy remote backends.
-	return be.State == loadbalancer.BackendStateActive &&
-		!be.Unhealthy &&
-		be.UnhealthyUpdatedAt != nil
+	return !be.Unhealthy && be.UnhealthyUpdatedAt != nil
 }
 
 func (w *Writer) DefaultSelectBackends(txn statedb.ReadTxn, bes iter.Seq2[*loadbalancer.Backend, statedb.Revision], svc *loadbalancer.Service, fe *loadbalancer.Frontend) iter.Seq2[*loadbalancer.Backend, statedb.Revision] {

--- a/pkg/loadbalancer/writer/writer.go
+++ b/pkg/loadbalancer/writer/writer.go
@@ -461,12 +461,13 @@ func matchesFrontend(be *loadbalancer.Backend, fe *loadbalancer.Frontend) bool {
 // same-node and same-zone preference decisions. This mirrors kube-proxy's
 // behaviour where topology hint validation considers Ready endpoints only.
 func (w *Writer) topologyPreferenceCandidate(svc *loadbalancer.Service, be *loadbalancer.Backend) bool {
-	// Terminating backends are excluded from hint computation by the
-	// EndpointSlice controller, so they would always lack hints. Including
-	// them here would either spuriously trip the missing-hints safeguard or
-	// pin traffic to a draining Pod.
-	if be.State == loadbalancer.BackendStateTerminating ||
-		be.State == loadbalancer.BackendStateTerminatingNotServing {
+	// Only backends that are actively serving may drive topology preference.
+	// This excludes terminating, not-yet-serving and quarantined backends so
+	// that a same-node backend which is starting up (or draining) does not win
+	// the preference and pin traffic to a backend that cannot serve, instead
+	// of falling back to ready remote backends. Mirrors kube-proxy, which only
+	// considers Ready endpoints for topology hints.
+	if be.State != loadbalancer.BackendStateActive {
 		return false
 	}
 
@@ -477,9 +478,7 @@ func (w *Writer) topologyPreferenceCandidate(svc *loadbalancer.Service, be *load
 	// Health-checked services should only prefer backends that are currently
 	// usable. Otherwise a quarantined or not-yet-checked local backend would
 	// suppress fallback to healthy remote backends.
-	return be.State == loadbalancer.BackendStateActive &&
-		!be.Unhealthy &&
-		be.UnhealthyUpdatedAt != nil
+	return !be.Unhealthy && be.UnhealthyUpdatedAt != nil
 }
 
 func (w *Writer) DefaultSelectBackends(txn statedb.ReadTxn, bes iter.Seq2[*loadbalancer.Backend, statedb.Revision], svc *loadbalancer.Service, fe *loadbalancer.Frontend) iter.Seq2[*loadbalancer.Backend, statedb.Revision] {

--- a/pkg/loadbalancer/writer/writer_test.go
+++ b/pkg/loadbalancer/writer/writer_test.go
@@ -917,12 +917,11 @@ func TestWriter_SelectBackends_PreferCloseFallsBackFromUnhealthySameZone(t *test
 	assert.Contains(t, addresses, remoteAddr)
 }
 
-// TestWriter_SelectBackends_PreferCloseIgnoresTerminatingForMissingHints verifies
-// that backends in BackendStateTerminating / BackendStateTerminatingNotServing are
-// excluded from the missing-hints safeguard. The EndpointSlice controller does not
-// compute zone hints for non-Ready endpoints, so without this exclusion a single
-// terminating Pod would disable topology-aware routing for the entire Service.
-func TestWriter_SelectBackends_PreferCloseIgnoresTerminatingForMissingHints(t *testing.T) {
+// TestWriter_SelectBackends_PreferCloseIgnoresNonActiveForMissingHints verifies
+// that non-active backends are excluded from the missing-hints safeguard.
+// Without this exclusion, a non-serving backend without hints could disable
+// topology-aware routing for the entire Service.
+func TestWriter_SelectBackends_PreferCloseIgnoresNonActiveForMissingHints(t *testing.T) {
 	p := fixture(t)
 	p.Writer.config.EnableServiceTopology = true
 	p.LocalNodeStore.Update(func(n *node.LocalNode) {
@@ -938,6 +937,8 @@ func TestWriter_SelectBackends_PreferCloseIgnoresTerminatingForMissingHints(t *t
 	activeRemoteAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(3), 8080, loadbalancer.ScopeExternal)
 	terminatingAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(4), 8080, loadbalancer.ScopeExternal)
 	terminatingNoZoneAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(5), 8080, loadbalancer.ScopeExternal)
+	maintenanceAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(6), 8080, loadbalancer.ScopeExternal)
+	quarantinedAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(7), 8080, loadbalancer.ScopeExternal)
 
 	svc := &loadbalancer.Service{
 		Name:                svcName,
@@ -978,6 +979,20 @@ func TestWriter_SelectBackends_PreferCloseIgnoresTerminatingForMissingHints(t *t
 				// emit loop would have nil-dereferenced be.Zone.ForZones.
 				Address: terminatingNoZoneAddr,
 				State:   loadbalancer.BackendStateTerminatingNotServing,
+			},
+			{
+				// A backend under maintenance similarly must not participate in
+				// topology safeguards if it is missing zone hints.
+				Address: maintenanceAddr,
+				State:   loadbalancer.BackendStateMaintenance,
+				Zone:    &loadbalancer.BackendZone{Zone: "zone-d"},
+			},
+			{
+				// Quarantined backends are also non-serving and must be ignored
+				// when evaluating whether topology hints are complete.
+				Address: quarantinedAddr,
+				State:   loadbalancer.BackendStateQuarantined,
+				Zone:    &loadbalancer.BackendZone{Zone: "zone-e"},
 			},
 		} {
 			if !yield(be, statedb.Revision(i+1)) {
@@ -1053,7 +1068,7 @@ func TestWriter_SelectBackends_PreferCloseFallsBackWhenOnlyTerminating(t *testin
 	assert.Contains(t, addresses, terminatingNoZoneAddr)
 }
 
-func TestWriter_SelectBackends_PreferSameNodeIgnoresTerminating(t *testing.T) {
+func TestWriter_SelectBackends_PreferSameNodeIgnoresNonActiveBackends(t *testing.T) {
 	oldName := nodeTypes.GetName()
 	nodeTypes.SetName("node-a")
 	t.Cleanup(func() {
@@ -1067,6 +1082,8 @@ func TestWriter_SelectBackends_PreferSameNodeIgnoresTerminating(t *testing.T) {
 	feAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(1), 80, loadbalancer.ScopeExternal)
 	activeLocalAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(2), 8080, loadbalancer.ScopeExternal)
 	terminatingLocalAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(3), 8080, loadbalancer.ScopeExternal)
+	maintenanceLocalAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(4), 8080, loadbalancer.ScopeExternal)
+	quarantinedLocalAddr := loadbalancer.NewL3n4Addr(loadbalancer.TCP, intToAddr(5), 8080, loadbalancer.ScopeExternal)
 
 	svc := &loadbalancer.Service{
 		Name:                svcName,
@@ -1094,6 +1111,16 @@ func TestWriter_SelectBackends_PreferSameNodeIgnoresTerminating(t *testing.T) {
 				State:    loadbalancer.BackendStateTerminating,
 				NodeName: "node-a",
 			},
+			{
+				Address:  maintenanceLocalAddr,
+				State:    loadbalancer.BackendStateMaintenance,
+				NodeName: "node-a",
+			},
+			{
+				Address:  quarantinedLocalAddr,
+				State:    loadbalancer.BackendStateQuarantined,
+				NodeName: "node-a",
+			},
 		} {
 			if !yield(be, statedb.Revision(i+1)) {
 				return
@@ -1104,7 +1131,7 @@ func TestWriter_SelectBackends_PreferSameNodeIgnoresTerminating(t *testing.T) {
 	selected := slices.Collect(statedb.ToSeq(p.Writer.SelectBackends(p.DB.ReadTxn(), backends, svc, fe)))
 
 	// Only the active local backend should be selected.
-	// Terminating local backend must be filtered out.
+	// All other non-active local backends must be filtered out.
 	require.Len(t, selected, 1)
 	assert.Equal(t, activeLocalAddr.String(), selected[0].Address.String())
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

Fixes: trafficDistribution hints on non-active backends

## Summary

- This PR was prepared with AIL:2. I personally implemented fix in code, used AI for tests and better descriptions.

- With `trafficDistribution: PreferSameNode` and a single node-local backend (e.g. a
DaemonSet), restarting that local backend causes a multi-second window where an
in-cluster client on the same node gets `connection refused` instead of falling
back to a ready remote backend.

- The drain side works correctly: while the old local Pod is `Terminating`, traffic
falls back to remote backends. The drop happens only on the **return** side —
while the replacement Pod is starting. During startup the replacement backend is
programmed in `BackendStateMaintenance`, and `topologyPreferenceCandidate` does
not exclude that state, so `PreferSameNode` treats it as a valid same-node
candidate, commits to "same-node only", and pins traffic to a backend that cannot
yet serve.

- This is the startup-side analogue of the draining-side bug fixed for
`Terminating` backends in #46339. That fix excluded
`Terminating`/`TerminatingNotServing` (states 1/2); the candidate check still
accepts `Quarantined` (3) and `Maintenance` (4), and a starting backend lands in
`Maintenance` (4).

### Current behaviour

- During drain of the old local Pod: requests fall back to a remote backend
  (correct, no drop).
- While the replacement Pod is starting: `connection refused` for the
  whole starting window, instead of continued fallback to a remote backend. Recovery
  coincides with the new Pod becoming Ready.

### Expected

- While the returning same-node backend is not yet serving, `PreferSameNode` should
keep falling back to ready remote backends (as it already does during drain), then
snap back to the local backend once it is serving. No connection-refused window.

## PR-implemented fix

- Require `Active` state for topology-preference candidacy even for non-health-checked
services. 
- This subsumes the existing terminating checks and also excludes
`Maintenance`/`Quarantined`.

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request