### PR TITLE
docs: fix typos and grammar in documentation

### DIFF
--- a/Documentation/network/bird.rst
+++ b/Documentation/network/bird.rst
@@ -101,7 +101,7 @@ This scheme is simple in that:
 In this scheme, each node just sends pod egress traffic to node's default
 gateway (the core routers), and lets the latter do the routing.
 
-Below is the a reference configuration for fulfilling the above purposes:
+Below is a reference configuration for fulfilling the above purposes:
 
 ::
 

--- a/Documentation/network/servicemesh/mutual-authentication/mutual-authentication.rst
+++ b/Documentation/network/servicemesh/mutual-authentication/mutual-authentication.rst
@@ -41,7 +41,7 @@ For Cilium to meet most of the common requirements for service-to-service authen
     to automatically create and maintain encrypted connections between Pods.
 
 To address the challenge of identity verification in dynamic and heterogeneous environments, 
-mutual authentication requires a framework secure identity verification for distributed systems.
+mutual authentication requires a framework for secure identity verification for distributed systems.
 
 .. Note::
 

--- a/pkg/bgp/README.md
+++ b/pkg/bgp/README.md
@@ -32,7 +32,7 @@ Both control planes are implemented by a `Controller` which follows the `Kuberne
 Both control planes primary listen for `CiliumBGP*` CRDs, along with other Cilium and Kubernetes resources useful for implementing a BGP control plane. 
 
 The Operator-Side control plane processes `CiliumBGPClusterConfig` CRDs, and the CRDs referenced from it,
-and creates/updes/deletes one `CiliumBGPNodeConfig` for each BGP-enabled node in the cluster. The
+and creates/updates/deletes one `CiliumBGPNodeConfig` for each BGP-enabled node in the cluster. The
 `CiliumBGPNodeConfig` with the name of the given node becomes the primary configuration source of the `Agent-Side Control Plane`.
 
 ### Agent-Side Architecture
@@ -112,7 +112,7 @@ This implementation will
 * enable/disable any BGP server specific features
 * inform the caller if the node config cannot be applied
 
-The `Manager` implementation is capable of evaluating each `CiliumBGPNodeInstance` from withing a `CiliumBGPNodeConfig` in isolation.
+The `Manager` implementation is capable of evaluating each `CiliumBGPNodeInstance` from within a `CiliumBGPNodeConfig` in isolation.
 
 This means when applying a `CiliumBGPNodeConfig` the `Manager` will attempt to create each `CiliumBGPNodeInstance`.
 


### PR DESCRIPTION
## Summary

Fixes minor typos and grammar issues in the Cilium documentation:

1. **pkg/bgp/README.md**: Fix typo 'updes' to 'updates' in the Operator-Side control plane description
2. **Documentation/network/bird.rst**: Fix redundant article 'the a' to 'a' in BGP reference configuration section
3. **Documentation/network/servicemesh/mutual-authentication/mutual-authentication.rst**: Add missing word 'for' in the mutual authentication description

These are straightforward documentation improvements that enhance readability.