### PR TITLE
docs: fix version string typo in CRD documentation

### DIFF
--- a/Documentation/contributing/development/introducing_new_crds.rst
+++ b/Documentation/contributing/development/introducing_new_crds.rst
@@ -292,7 +292,7 @@ Your new CRDs must be installed into Kubernetes. This is controlled in
 the ``pkg/k8s/synced/crd.go`` file.
 
 Here is an example diff which installs the CRDs ``v2alpha1.BGPPName``
-and ``v2alpha.BGPPoolName``:
+and ``v2alpha1.BGPPoolName``:
 
 .. code-block:: diff
 


### PR DESCRIPTION
## Summary

Fixes an inconsistency in the introducing_new_crds.rst documentation where the text referenced 'v2alpha.BGPPoolName' but the code example used 'v2alpha1.BGPPoolName'. The text was missing the '1' in the version prefix.

This ensures consistency between the documentation text and the code example shown in the same section.