### PR TITLE
ci: Upgrade cilium/json-mock to v1.4.1

### DIFF
--- a/Documentation/cmdref/cilium_connectivity_test.md
+++ b/Documentation/cmdref/cilium_connectivity_test.md
@@ -55,7 +55,7 @@ cilium connectivity test [flags]
       --include-conn-disrupt-test-l7-traffic                       Include conn disrupt test for L7 traffic
       --include-conn-disrupt-test-ns-traffic                       Include conn disrupt test for NS traffic
       --ip-families strings                                        Restrict test actions to specific IP families (default [ipv4,ipv6])
-      --json-mock-image string                                     Image path to use for json mock (default "quay.io/cilium/json-mock:v1.4.0@sha256:500dc80291d4f402462e4bb7ecfc2b726f08c8136999e5e91cdd54f9e90eebeb")
+      --json-mock-image string                                     Image path to use for json mock (default "quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195")
       --junit-file string                                          Generate junit report and write to file
       --junit-property map                                         Add key=value properties to the generated junit file
       --k8s-version string                                         Kubernetes server version in case auto-detection fails

--- a/cilium-cli/defaults/defaults.go
+++ b/cilium-cli/defaults/defaults.go
@@ -169,7 +169,7 @@ var (
 		// renovate: datasource=docker
 		"ConnectivityCheckAlpineCurlImage": "quay.io/cilium/alpine-curl:v1.10.0@sha256:913e8c9f3d960dde03882defa0edd3a919d529c2eb167caa7f54194528bde364",
 		// renovate: datasource=docker
-		"ConnectivityCheckJSONMockImage": "quay.io/cilium/json-mock:v1.4.0@sha256:500dc80291d4f402462e4bb7ecfc2b726f08c8136999e5e91cdd54f9e90eebeb",
+		"ConnectivityCheckJSONMockImage": "quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195",
 		// renovate: datasource=docker
 		"ConnectivityDNSTestServerImage": "registry.k8s.io/coredns/coredns:v1.14.4@sha256:3e98f280fd601b37411c5fb7075fd9f337833c480f1644970b727ae0af067782",
 		// renovate: datasource=docker

--- a/examples/kubernetes-dns/dns-sw-app.yaml
+++ b/examples/kubernetes-dns/dns-sw-app.yaml
@@ -9,4 +9,4 @@ metadata:
 spec:
   containers:
   - name: mediabot
-    image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+    image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195

--- a/examples/kubernetes/clustermesh/cluster1.yaml
+++ b/examples/kubernetes/clustermesh/cluster1.yaml
@@ -59,7 +59,7 @@ spec:
     spec:
       containers:
       - name: x-wing-container
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/clustermesh/cluster2.yaml
+++ b/examples/kubernetes/clustermesh/cluster2.yaml
@@ -59,7 +59,7 @@ spec:
     spec:
       containers:
       - name: x-wing-container
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
@@ -23,7 +23,7 @@ spec:
           value: "8080"
         ports:
         - containerPort: 8080
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -81,7 +81,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40000
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -137,7 +137,7 @@ spec:
         - name: PORT
           value: "21000"
         ports: []
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -205,7 +205,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40001
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -261,7 +261,7 @@ spec:
         - name: PORT
           value: "21002"
         ports: []
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:

--- a/examples/kubernetes/connectivity-check/connectivity-check-internal.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-internal.yaml
@@ -23,7 +23,7 @@ spec:
           value: "8080"
         ports:
         - containerPort: 8080
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -81,7 +81,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40000
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -137,7 +137,7 @@ spec:
         - name: PORT
           value: "21000"
         ports: []
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:

--- a/examples/kubernetes/connectivity-check/connectivity-check-netpol-only.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-netpol-only.yaml
@@ -22,7 +22,7 @@ spec:
           value: "8080"
         ports:
         - containerPort: 8080
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -79,7 +79,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40000
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7
@@ -134,7 +134,7 @@ spec:
         - name: PORT
           value: "41000"
         ports: []
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         readinessProbe:
           timeoutSeconds: 7

--- a/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
@@ -24,7 +24,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40001
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -80,7 +80,7 @@ spec:
         - name: PORT
           value: "21002"
         ports: []
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -905,7 +905,7 @@ spec:
           value: "8080"
         ports:
         - containerPort: 8080
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -983,7 +983,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40000
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -1060,7 +1060,7 @@ spec:
         - name: PORT
           value: "21000"
         ports: []
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -1148,7 +1148,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40001
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -1249,7 +1249,7 @@ spec:
         - name: PORT
           value: "21002"
         ports: []
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:

--- a/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
@@ -687,7 +687,7 @@ spec:
           value: "8080"
         ports:
         - containerPort: 8080
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -765,7 +765,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40000
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -842,7 +842,7 @@ spec:
         - name: PORT
           value: "21000"
         ports: []
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -930,7 +930,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40001
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -1031,7 +1031,7 @@ spec:
         - name: PORT
           value: "21002"
         ports: []
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:

--- a/examples/kubernetes/connectivity-check/connectivity-check-single-node.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-single-node.yaml
@@ -23,7 +23,7 @@ spec:
           value: "8080"
         ports:
         - containerPort: 8080
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -81,7 +81,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40000
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -137,7 +137,7 @@ spec:
         - name: PORT
           value: "21000"
         ports: []
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:

--- a/examples/kubernetes/connectivity-check/connectivity-check.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check.yaml
@@ -23,7 +23,7 @@ spec:
           value: "8080"
         ports:
         - containerPort: 8080
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -81,7 +81,7 @@ spec:
         ports:
         - containerPort: 8080
           hostPort: 40000
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
@@ -137,7 +137,7 @@ spec:
         - name: PORT
           value: "21000"
         ports: []
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:

--- a/examples/kubernetes/connectivity-check/echo-servers.cue
+++ b/examples/kubernetes/connectivity-check/echo-servers.cue
@@ -2,7 +2,7 @@ package connectivity_check
 
 // Default parameters for echo servers (may be overridden).
 _echoDeployment: {
-	_image:       "quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603"
+	_image:       "quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195"
 	_probeTarget: *"localhost:8080" | string
 	_probePath:   ""
 }

--- a/examples/kubernetes/servicemesh/envoy/test-application-proxy-circuit-breaker.yaml
+++ b/examples/kubernetes/servicemesh/envoy/test-application-proxy-circuit-breaker.yaml
@@ -92,7 +92,7 @@ spec:
         - env:
             - name: PORT
               value: "8080"
-          image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+          image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
           imagePullPolicy: IfNotPresent
           name: echo-service
           ports:

--- a/examples/kubernetes/servicemesh/envoy/test-application-proxy-loadbalancing.yaml
+++ b/examples/kubernetes/servicemesh/envoy/test-application-proxy-loadbalancing.yaml
@@ -99,7 +99,7 @@ spec:
         - env:
             - name: PORT
               value: "8080"
-          image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+          image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
           imagePullPolicy: IfNotPresent
           name: echo-service
           ports:

--- a/examples/kubernetes/servicemesh/envoy/test-application.yaml
+++ b/examples/kubernetes/servicemesh/envoy/test-application.yaml
@@ -147,7 +147,7 @@ spec:
         - env:
             - name: PORT
               value: "8080"
-          image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+          image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
           imagePullPolicy: IfNotPresent
           name: echo-service-1
           ports:
@@ -238,7 +238,7 @@ spec:
         - env:
             - name: PORT
               value: "8080"
-          image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+          image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
           imagePullPolicy: IfNotPresent
           name: echo-service-2
           ports:

--- a/examples/minikube/http-sw-app.yaml
+++ b/examples/minikube/http-sw-app.yaml
@@ -48,7 +48,7 @@ metadata:
 spec:
   containers:
   - name: spaceship
-    image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+    image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
 ---
 apiVersion: v1
 kind: Pod
@@ -61,4 +61,4 @@ metadata:
 spec:
   containers:
   - name: spaceship
-    image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+    image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195

--- a/examples/policies/kubernetes/namespace/demo-pods.yaml
+++ b/examples/policies/kubernetes/namespace/demo-pods.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: leia-container
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
 ---
 apiVersion: v1
 kind: Service
@@ -50,7 +50,7 @@ metadata:
 spec:
   containers:
   - name: luke-container
-    image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+    image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
 ---
 apiVersion: v1
 kind: Pod
@@ -62,4 +62,4 @@ metadata:
 spec:
   containers:
   - name: vader-container
-    image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+    image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195

--- a/examples/policies/kubernetes/serviceaccount/demo-pods.yaml
+++ b/examples/policies/kubernetes/serviceaccount/demo-pods.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: leia
       containers:
       - name: leia-container
-        image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
 ---
 apiVersion: v1
 kind: Service
@@ -51,7 +51,7 @@ spec:
   serviceAccountName: luke
   containers:
   - name: luke-container
-    image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+    image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
 ---
 apiVersion: v1
 kind: Pod
@@ -61,4 +61,4 @@ spec:
   serviceAccountName: vader
   containers:
   - name: vader-container
-    image: quay.io/cilium/json-mock:v1.3.8@sha256:5aad04835eda9025fe4561ad31be77fd55309af8158ca8663a72f6abb78c2603
+    image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195

--- a/test/k8s/manifests/echo-svc.yaml
+++ b/test/k8s/manifests/echo-svc.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: echo-container
-        image: quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0
+        image: quay.io/cilium/json-mock:v1.4.1@sha256:6a66df90808a39c02e7a9d58af7bf0e54d8f8b7d4bc528f48c891969a7049195
         livenessProbe:
           exec:
             command:


### PR DESCRIPTION
Upgrade cilium/json-mock to v1.4.1 to fix a test flake caused by unnecessary HTTP listener restarts when running with the '--watch' option (removed in v1.4.1). These HTTP listener restart caused intermittent TCP RST induced connection failures and HTTP 503 responses from Envoy when multiple POST requests hit the json-mock at the same time, as when issuing parallel curl POST requests.

```release-note
cilium/json-mock is updated to v1.4.1 to resolve ci test flakes.
```

