### PR TITLE
ci: kind add support for kubeadm.k8s.io/v1beta4 InitConfiguration patch

### DIFF
--- a/.github/kind-config.yaml.tmpl
+++ b/.github/kind-config.yaml.tmpl
@@ -5,8 +5,17 @@ nodes:
     kubeadmConfigPatches:
       # To make sure that there is no taint for master node.
       # Otherwise additional worker node might be required for conformance testing.
+      # kind picks the kubeadm apiVersion based on the Kubernetes version: v1beta3
+      # up to k8s v1.35 and v1beta4 from k8s v1.36 (kind v0.32+). A patch whose
+      # apiVersion does not match the generated config is silently ignored, so we
+      # list both to keep the taint removed across kind and Kubernetes versions.
       - |
         apiVersion: kubeadm.k8s.io/v1beta3
+        kind: InitConfiguration
+        nodeRegistration:
+          taints: []
+      - |
+        apiVersion: kubeadm.k8s.io/v1beta4
         kind: InitConfiguration
         nodeRegistration:
           taints: []


### PR DESCRIPTION
This updates CI Kind template with support of `kubeadm.k8s.io/v1beta4 InitConfiguration patch` which was introduced in https://github.com/cilium/cilium/commit/2323acac47e99fdc42f988ac9e90d20bd8ddb60d.