### PR TITLE
endpoint: reap restart-preserved policy map entries once ready

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1583,6 +1583,12 @@ func (e *Endpoint) syncPolicyMapWithDump() error {
 	return err
 }
 
+// syncPolicyMapControllerName is shared by the controller's creation and its
+// callers so the name cannot drift apart.
+func (e *Endpoint) syncPolicyMapControllerName() string {
+	return fmt.Sprintf("sync-policymap-%d", e.ID)
+}
+
 // startSyncPolicyMapController starts the policymap sync controller. Must be called with the endpoint mutex held.
 func (e *Endpoint) startSyncPolicyMapController() {
 	// Skip the controller if the endpoint has no policy map
@@ -1590,7 +1596,7 @@ func (e *Endpoint) startSyncPolicyMapController() {
 		return
 	}
 
-	ctrlName := fmt.Sprintf("sync-policymap-%d", e.ID)
+	ctrlName := e.syncPolicyMapControllerName()
 	e.controllers.CreateController(ctrlName,
 		controller.ControllerParams{
 			Group:  syncPolicymapControllerGroup,

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -557,8 +557,17 @@ func (e *Endpoint) regenerate(ctx *regenerationContext) (retErr error) {
 		// State will remain as waiting-to-regenerate if further
 		// changes are needed. There should be an another regenerate
 		// queued for taking care of it.
-		e.BuilderSetStateLocked(StateReady, "Completed endpoint regeneration with no pending regeneration requests")
+		ready := e.BuilderSetStateLocked(StateReady, "Completed endpoint regeneration with no pending regeneration requests")
+
+		// Reap the restart-preserved leftovers now that the endpoint is ready,
+		// instead of waiting up to 15m for the next periodic reconciliation
+		// (GH-47012).
+		reapPreserved := ready && e.preservedRestoredPolicyEntries
 		e.unlock()
+
+		if reapPreserved {
+			e.controllers.TriggerController(e.syncPolicyMapControllerName())
+		}
 	}()
 
 	revision, err = e.regenerateBPF(ctx)


### PR DESCRIPTION
Fixes: https://github.com/cilium/cilium/issues/47012

This is the main-branch fix for the intermittent IPv6 from-cidr host-netns ingress default-deny bypass observed on the ci-l3-l4 E2E-upgrade downgrade leg (`all-ingress-deny-from-outside/from-cidr-to-pod:host-netns-to-pod` and `echo-ingress-from-outside/...` returning 200 instead of being dropped).

Root cause: #46927 preserves the pre-restart BPF policy map entries on the restore path (skipDeletes) so established connections survive the reload. The leftover entries that are not part of the desired policy are only reaped by the dump-based full reconciliation in `syncPolicyMapWithDump`, which runs from the per-endpoint `sync-policymap` controller and early-returns unless the endpoint is `StateReady`. That controller runs once immediately on creation and then only every `PolicyMapFullReconciliationInterval` (15m). Because it is created while the endpoint is still regenerating, its single immediate run can hit the `StateReady` guard and reap nothing, leaving a stale ingress-allow entry admitting traffic the realized policy denies for up to 15 minutes.

The fix triggers the reconciliation as soon as the endpoint reaches `StateReady` with preserved entries still marked, so the leftovers are reaped promptly. The reap logic itself is unchanged; only its timing is made deterministic, and genuine policy-map discrepancies still emit the existing warning.

The v1.19 backport is #47063 (merged), since the failing job serves the v1.19 image on the downgrade leg.

Validation: before opening this for review, the fix was exercised on the exact downgrade-to-v1.19 restore leg by temporarily pinning the E2E-upgrade downgrade image to a v1.19 build carrying the backport. The from-cidr host-netns ingress-deny tests (cilium-test-4) passed on the misc-7 and kube-proxy-7 configurations that originally reproduced #47012, across two runs.
