### PR TITLE
v1.19: endpoint: reap restart-preserved policy map entries once ready

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1559,13 +1559,19 @@ func (e *Endpoint) syncPolicyMapWithDump() error {
 	return err
 }
 
+// syncPolicyMapControllerName is shared by the controller's creation and its
+// callers so the name cannot drift apart.
+func (e *Endpoint) syncPolicyMapControllerName() string {
+	return fmt.Sprintf("sync-policymap-%d", e.ID)
+}
+
 func (e *Endpoint) startSyncPolicyMapController() {
 	// Skip the controller if the endpoint has no policy map
 	if e.isProperty(PropertySkipBPFPolicy) {
 		return
 	}
 
-	ctrlName := fmt.Sprintf("sync-policymap-%d", e.ID)
+	ctrlName := e.syncPolicyMapControllerName()
 	e.controllers.CreateController(ctrlName,
 		controller.ControllerParams{
 			Group:  syncPolicymapControllerGroup,

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -497,8 +497,17 @@ func (e *Endpoint) regenerate(ctx *regenerationContext) (retErr error) {
 		// State will remain as waiting-to-regenerate if further
 		// changes are needed. There should be an another regenerate
 		// queued for taking care of it.
-		e.BuilderSetStateLocked(StateReady, "Completed endpoint regeneration with no pending regeneration requests")
+		ready := e.BuilderSetStateLocked(StateReady, "Completed endpoint regeneration with no pending regeneration requests")
+
+		// Reap the restart-preserved leftovers now that the endpoint is ready,
+		// instead of waiting up to 15m for the next periodic reconciliation
+		// (GH-47012).
+		reapPreserved := ready && e.preservedRestoredPolicyEntries
 		e.unlock()
+
+		if reapPreserved {
+			e.controllers.TriggerController(e.syncPolicyMapControllerName())
+		}
 	}()
 
 	revision, err = e.regenerateBPF(ctx)


### PR DESCRIPTION
Fixes: https://github.com/cilium/cilium/issues/47012

 * [x] #47062 (@aanm)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 47062
```
