### PR TITLE
ci: always set fail-fast to false on image builds

### DIFF
--- a/.github/workflows/build-images-ci-v1.17.yaml
+++ b/.github/workflows/build-images-ci-v1.17.yaml
@@ -45,9 +45,8 @@ jobs:
     # GH-46482: Lint checks action is broken, skip dependency for now.
     #needs: wait-for-base-images
     strategy:
-      # Only fail-fast on pull_request_target events. For push and merge_group events, we want to run all builds even
-      # if some of them fail, to make sure one of the image is not broken accidentally and the PR is still merged.
-      fail-fast: ${{ github.event_name != 'pull_request_target' }}
+      # Do not cancel the other image builds if one of them fails.
+      fail-fast: false
       matrix:
         include:
           - name: cilium

--- a/.github/workflows/build-images-ci-v1.18.yaml
+++ b/.github/workflows/build-images-ci-v1.18.yaml
@@ -47,9 +47,8 @@ jobs:
     outputs:
       sha: ${{ steps.tag.outputs.sha }}
     strategy:
-      # Only fail-fast on pull_request_target events. For push and merge_group events, we want to run all builds even
-      # if some of them fail, to make sure one of the image is not broken accidentally and the PR is still merged.
-      fail-fast: ${{ github.event_name != 'pull_request_target' }}
+      # Do not cancel the other image builds if one of them fails.
+      fail-fast: false
       matrix:
         include:
           - name: cilium

--- a/.github/workflows/build-images-ci-v1.19.yaml
+++ b/.github/workflows/build-images-ci-v1.19.yaml
@@ -47,9 +47,8 @@ jobs:
     outputs:
       sha: ${{ steps.tag.outputs.sha }}
     strategy:
-      # Only fail-fast on pull_request_target events. For push and merge_group events, we want to run all builds even
-      # if some of them fail, to make sure one of the image is not broken accidentally and the PR is still merged.
-      fail-fast: ${{ github.event_name != 'pull_request_target' }}
+      # Do not cancel the other image builds if one of them fails.
+      fail-fast: false
       matrix:
         include:
           - name: cilium

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -55,9 +55,8 @@ jobs:
     outputs:
       sha: ${{ steps.tag.outputs.sha }}
     strategy:
-      # Only fail-fast on pull_request_target events. For push and merge_group events, we want to run all builds even
-      # if some of them fail, to make sure one of the image is not broken accidentally and the PR is still merged.
-      fail-fast: ${{ github.event_name != 'pull_request_target' }}
+      # Do not cancel the other image builds if one of them fails.
+      fail-fast: false
       matrix:
         include:
           - name: cilium


### PR DESCRIPTION
The `fail-fast` expression evaluated to `true` on push and merge_group events, which cancels the remaining image builds as soon as one of them fails. Only the cilium image is a required check and consumed by downstream tests, so a transient failure while building an image that is not tested anywhere (e.g. `operator-alibabacloud`) could cancel the cilium build and needlessly block a PR on the merge queue.

This sets `fail-fast: false` unconditionally so a failure building one image no longer cancels the others, letting the required images succeed and the failed image be rebuilt on its own. The comment was also inverted with respect to the expression, which made the intended behaviour confusing.


Related with https://github.com/cilium/cilium/pull/45079/changes#r3557892254