### PR TITLE
ci: auth requirement helm defaults & cilium config

### DIFF
--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -73,6 +73,9 @@ inputs:
   image-pull-secret:
     description: 'Image pull secret to access Cilium images'
     default: ''
+  auth-required:
+    description: 'Variable setting up if auth is required or not. Can be found in the repository variable under DOCKER_AUTH_REQUIRED name'
+    default: 'true'
   registry_host:
     description: 'Registry host for Cilium images'
     default: 'quay.io'
@@ -236,7 +239,7 @@ runs:
           fi
 
           PULL_SECRET=""
-          if [ "${{ inputs.image-pull-secret }}" != "" ]; then
+          if [ "${{ inputs.auth-required }}" == "true" ] && [ "${{ inputs.image-pull-secret }}" != "" ]; then
             PULL_SECRET=" --helm-set=imagePullSecrets[0].name=${{ inputs.image-pull-secret }}"
           fi
 

--- a/.github/actions/helm-default/action.yaml
+++ b/.github/actions/helm-default/action.yaml
@@ -21,6 +21,10 @@ inputs:
     description: "Whether to include the image pull secret in the generated defaults"
     required: false
     default: ''
+  auth-required:
+    description: 'Variable setting up if auth is required or not. Can be found in the repository variable under DOCKER_AUTH_REQUIRED name'
+    required: false
+    default: 'true'
   registry_host:
     description: 'Registry host for Cilium images'
     default: 'quay.io'
@@ -101,7 +105,7 @@ runs:
             --helm-set=debug.verbose=envoy"
         fi
 
-        if [ "${{ inputs.image-pull-secret }}" != "" ]; then
+        if [ "${{ inputs.auth-required }}" == "true" ] && [ "${{ inputs.image-pull-secret }}" != "" ]; then
           CILIUM_INSTALL_DEFAULTS+=" --helm-set=imagePullSecrets[0].name=${{ inputs.image-pull-secret }}"
         fi
 

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -263,6 +263,7 @@ jobs:
           registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: ./untrusted/install/kubernetes/cilium
           image-pull-secret: "cilium-registry"
+          auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
 
       - name: Set up job variables
         id: vars

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -221,6 +221,7 @@ jobs:
           registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: ./untrusted/install/kubernetes/cilium
           image-pull-secret: "cilium-registry"
+          auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
 
       - name: Get connectivity test flags
         id: e2e_config

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -296,6 +296,7 @@ jobs:
           registry_host: ${{ vars.DOCKER_READ_HOST }}
           registry_organization: ${{ vars.DOCKER_READ_ORG }}
           image-pull-secret: "cilium-registry"
+          auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
 
       - name: Get connectivity test flags
         id: e2e_config

--- a/.github/workflows/conformance-delegated-ipam.yaml
+++ b/.github/workflows/conformance-delegated-ipam.yaml
@@ -120,6 +120,7 @@ jobs:
           registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: ./untrusted/install/kubernetes/cilium
           image-pull-secret: "cilium-registry"
+          auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
 
       - name: Get connectivity test flags
         id: e2e_config

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -316,6 +316,7 @@ jobs:
           registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: ./untrusted/install/kubernetes/cilium
           image-pull-secret: "cilium-registry"
+          auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
 
       - name: Get connectivity test flags
         id: e2e_config

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -193,6 +193,7 @@ jobs:
           registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: ./untrusted/install/kubernetes/cilium
           image-pull-secret: "cilium-registry"
+          auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
 
       - name: Set image tag
         id: vars

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -327,6 +327,7 @@ jobs:
           registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: ./untrusted/install/kubernetes/cilium
           image-pull-secret: "cilium-registry"
+          auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
 
       - name: Truncate owner label for GKE
         id: truncate-owner

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -170,6 +170,7 @@ jobs:
           registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: ./untrusted/install/kubernetes/cilium
           image-pull-secret: "cilium-registry"
+          auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
 
       - name: Set image tag
         id: vars

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -207,6 +207,7 @@ jobs:
           mutual-auth: false
           misc: ${{ matrix.misc }}
           image-pull-secret: "cilium-registry"
+          auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
 
       - name: Set Kind params
         if: ${{ steps.cilium-config.outputs.skip != 'true' }}

--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -111,6 +111,7 @@ jobs:
           registry_host: ${{ vars.DOCKER_READ_HOST }}
           registry_organization: ${{ vars.DOCKER_READ_ORG }}
           image-pull-secret: "cilium-registry"
+          auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
           chart-dir: 'untrusted/install/kubernetes/cilium'
 
       - name: Add external docker network

--- a/.github/workflows/conformance-kubespray.yaml
+++ b/.github/workflows/conformance-kubespray.yaml
@@ -133,6 +133,7 @@ jobs:
           registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: ./untrusted/install/kubernetes/cilium
           image-pull-secret: "cilium-registry"
+          auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/conformance-mcs-api.yaml
+++ b/.github/workflows/conformance-mcs-api.yaml
@@ -144,6 +144,7 @@ jobs:
           registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: ./untrusted/install/kubernetes/cilium
           image-pull-secret: "cilium-registry"
+          auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
 
       - name: Set up job variables for GHA environment
         id: vars

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -170,6 +170,7 @@ jobs:
           registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: ./untrusted/install/kubernetes/cilium
           image-pull-secret: "cilium-registry"
+          auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
 
       - name: Get connectivity test flags
         id: e2e_config

--- a/.github/workflows/conformance-ztunnel-e2e.yaml
+++ b/.github/workflows/conformance-ztunnel-e2e.yaml
@@ -162,6 +162,7 @@ jobs:
           encryption: 'ztunnel'
           mutual-auth: false
           image-pull-secret: "cilium-registry"
+          auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
 
       - name: Set Kind params
         if: ${{ steps.cilium-config.outputs.skip != 'true' }}

--- a/.github/workflows/fqdn-perf.yaml
+++ b/.github/workflows/fqdn-perf.yaml
@@ -248,7 +248,11 @@ jobs:
       - name: Install Cilium
         id: install-cilium
         run: |
-          cilium install ${{ steps.vars.outputs.cilium_install_defaults }} --helm-set=imagePullSecrets[0].name=cilium-registry
+          PULL_SECRET=""
+          if [ "${{ vars.DOCKER_AUTH_REQUIRED }}" == "true" ]; then
+            PULL_SECRET="--helm-set=imagePullSecrets[0].name=cilium-registry"
+          fi
+          cilium install ${{ steps.vars.outputs.cilium_install_defaults }} $PULL_SECRET
 
       - name: Wait for cluster to be ready
         uses: cilium/scale-tests-action/validate-cluster@688f70c8708f4bdd2ef04ad7710d35aaea1ea57c # main

--- a/.github/workflows/hubble-cli-integration-test.yaml
+++ b/.github/workflows/hubble-cli-integration-test.yaml
@@ -109,6 +109,7 @@ jobs:
           registry_organization: ${{ vars.DOCKER_READ_ORG }}
           chart-dir: ./untrusted/install/kubernetes/cilium
           image-pull-secret: "cilium-registry"
+          auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
 
       - name: Set image tag
         id: vars

--- a/.github/workflows/k8s-kind-network-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-e2e.yaml
@@ -168,6 +168,7 @@ jobs:
           registry_host: ${{ vars.DOCKER_READ_HOST }}
           registry_organization: ${{ vars.DOCKER_READ_ORG }}
           image-pull-secret: "cilium-registry"
+          auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
           chart-dir: ./untrusted/install/kubernetes/cilium
 
       - name: Set up job variables

--- a/.github/workflows/k8s-kind-network-policies-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-policies-e2e.yaml
@@ -173,6 +173,7 @@ jobs:
           registry_host: ${{ vars.DOCKER_READ_HOST }}
           registry_organization: ${{ vars.DOCKER_READ_ORG }}
           image-pull-secret: "cilium-registry"
+          auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
           chart-dir: ./untrusted/install/kubernetes/cilium
 
       - name: Set up job variables

--- a/.github/workflows/l7-perf.yaml
+++ b/.github/workflows/l7-perf.yaml
@@ -360,9 +360,14 @@ jobs:
             --query 'Subnets[*].CidrBlock' --output text)
           echo "Retrieved native routing CIDR: '${NATIVE_CIDR_BLOCK}'"
 
+          PULL_SECRET=""
+          if [ "${{ vars.DOCKER_AUTH_REQUIRED }}" == "true" ]; then
+            PULL_SECRET="--helm-set=imagePullSecrets[0].name=cilium-registry"
+          fi
+
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }} \
             --set=k8sServiceHost="${K8S_API_SRV_ADDR}" --set=k8sServicePort=443 \
-            --helm-set=imagePullSecrets[0].name=cilium-registry \
+            $PULL_SECRET \
             --set=ipv4NativeRoutingCIDR="${NATIVE_CIDR_BLOCK}"
 
       - name: Delete context ref

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -193,6 +193,7 @@ jobs:
           chart-dir: ./install/kubernetes/cilium
           debug: false
           image-pull-secret: "cilium-registry"
+          auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
 
       - name: Truncate owner label for GKE
         id: truncate-owner

--- a/.github/workflows/scale-test-5-gce.yaml
+++ b/.github/workflows/scale-test-5-gce.yaml
@@ -275,8 +275,12 @@ jobs:
       - name: Install Cilium
         id: install-cilium
         run: |
-          cilium install --dry-run-helm-values ${{ steps.vars.outputs.cilium_install_defaults }} --helm-set=imagePullSecrets[0].name=cilium-registry
-          cilium install ${{ steps.vars.outputs.cilium_install_defaults }} --helm-set=imagePullSecrets[0].name=cilium-registry
+          PULL_SECRET=""
+          if [ "${{ vars.DOCKER_AUTH_REQUIRED }}" == "true" ]; then
+            PULL_SECRET="--helm-set=imagePullSecrets[0].name=cilium-registry"
+          fi
+          cilium install --dry-run-helm-values ${{ steps.vars.outputs.cilium_install_defaults }} $PULL_SECRET
+          cilium install ${{ steps.vars.outputs.cilium_install_defaults }} $PULL_SECRET
 
       - name: Wait for cluster to be ready
         uses: cilium/scale-tests-action/validate-cluster@688f70c8708f4bdd2ef04ad7710d35aaea1ea57c # main

--- a/.github/workflows/scale-test-clustermesh.yaml
+++ b/.github/workflows/scale-test-clustermesh.yaml
@@ -243,6 +243,7 @@ jobs:
           chart-dir: ./untrusted/install/kubernetes/cilium
           debug: false
           image-pull-secret: "cilium-registry"
+          auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
 
       - name: Install Cilium
         id: install-cilium

--- a/.github/workflows/scale-test-egw.yaml
+++ b/.github/workflows/scale-test-egw.yaml
@@ -429,13 +429,18 @@ jobs:
             --query 'Subnets[*].CidrBlock' --output text)
           echo "Retrieved native routing CIDR: '${NATIVE_CIDR_BLOCK}'"
 
+          PULL_SECRET=""
+          if [ "${{ vars.DOCKER_AUTH_REQUIRED }}" == "true" ]; then
+            PULL_SECRET="--helm-set=imagePullSecrets[0].name=cilium-registry"
+          fi
+
           cilium install --dry-run-helm-values ${{ steps.vars.outputs.cilium_install_defaults }} \
             --set=k8sServiceHost="${K8S_API_SRV_ADDR}" --set=k8sServicePort=443 \
-            --helm-set=imagePullSecrets[0].name=cilium-registry \
+            $PULL_SECRET \
             --set=ipv4NativeRoutingCIDR="${NATIVE_CIDR_BLOCK}"
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }} \
             --set=k8sServiceHost="${K8S_API_SRV_ADDR}" --set=k8sServicePort=443 \
-            --helm-set=imagePullSecrets[0].name=cilium-registry \
+            $PULL_SECRET \
             --set=ipv4NativeRoutingCIDR="${NATIVE_CIDR_BLOCK}"
 
       - name: Delete context ref

--- a/.github/workflows/scale-test-node-throughput-gce.yaml
+++ b/.github/workflows/scale-test-node-throughput-gce.yaml
@@ -68,6 +68,7 @@ jobs:
           registry_host: ${{ vars.DOCKER_READ_HOST }}
           registry_organization: ${{ vars.DOCKER_READ_ORG }}
           image-pull-secret: "cilium-registry"
+          auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
 
       - name: Set up job variables
         id: vars

--- a/.github/workflows/tests-ces-migrate.yaml
+++ b/.github/workflows/tests-ces-migrate.yaml
@@ -173,6 +173,7 @@ jobs:
           mutual-auth: false
           misc: 'bpfClockProbe=false,cni.uninstall=false'
           image-pull-secret: "cilium-registry"
+          auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
 
       - name: Install Cilium CLI
         if: ${{ steps.cilium-config.outputs.skip != 'true' }}

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -184,6 +184,7 @@ jobs:
           registry_host: ${{ vars.DOCKER_READ_HOST }}
           registry_organization: ${{ vars.DOCKER_READ_ORG }}
           image-pull-secret: "cilium-registry"
+          auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
 
       - name: Get connectivity test flags
         id: e2e_config
@@ -446,6 +447,7 @@ jobs:
           registry_host: ${{ vars.DOCKER_READ_HOST }}
           registry_organization: ${{ env.ORGANIZATION_STAGING }}
           image-pull-secret: "cilium-registry"
+          auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
 
       - name: Wait for images to be available (downgrade)
         timeout-minutes: 10

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -360,6 +360,7 @@ jobs:
           local-redirect-policy: ${{ matrix.local-redirect-policy }}
           bgp-control-plane: ${{ matrix.bgp-control-plane }}
           image-pull-secret: "cilium-registry"
+          auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
 
       - name: Derive newest Cilium installation config
         id: cilium-newest-config
@@ -392,6 +393,7 @@ jobs:
           local-redirect-policy: ${{ matrix.local-redirect-policy }}
           bgp-control-plane: ${{ matrix.bgp-control-plane }}
           image-pull-secret: "cilium-registry"
+          auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
 
       - name: Set Kind params
         if: ${{ steps.vars.outputs.downgrade_version != '' && steps.cilium-stable-config.outputs.skip != 'true' && steps.cilium-newest-config.outputs.skip != 'true' }}

--- a/.github/workflows/tests-smoke-conformance.yaml
+++ b/.github/workflows/tests-smoke-conformance.yaml
@@ -102,6 +102,7 @@ jobs:
           registry_host: ${{ vars.DOCKER_READ_HOST }}
           registry_organization: ${{ vars.DOCKER_READ_ORG }}
           image-pull-secret: "cilium-registry"
+          auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
 
       - name: Set image tag
         id: sha

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -92,6 +92,7 @@ jobs:
           registry_host: ${{ vars.DOCKER_READ_HOST }}
           registry_organization: ${{ vars.DOCKER_READ_ORG }}
           image-pull-secret: "cilium-registry"
+          auth-required: ${{ vars.DOCKER_AUTH_REQUIRED }}
           chart-dir: ./untrusted/install/kubernetes/cilium
 
       - name: Set image tag


### PR DESCRIPTION
Following https://github.com/cilium/cilium/pull/47037 we're gatekeeping the pull secret for registry auth behind the DOCKER_AUTH_REQUIRED github variable in cilium-config & helkm-default action

This will allow the CI to not add the pull secret when auth isn't required in the registry used, depending on DOCKER_AUTH_REQUIRED value