### PR TITLE
.github: auto-label backport PRs via actions/labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,5 @@
+# Add backport labels to any PR opened against this stable branch.
+kind/backports:
+- base-branch: '^v1\.17$'
+backport/1.17:
+- base-branch: '^v1\.17$'


### PR DESCRIPTION
Part of #47068.

Adds backport auto-labeling for PRs opened against `v1.17` using `actions/labeler`
`base-branch` rules, mirroring the `auto-labeler-v1.17.yaml` workflow on the default
branch. A PR targeting `v1.17` gets `kind/backports` and `backport/1.17`.

`actions/labeler` reads `.github/labeler.yml` from the base branch, so the config
must live on this branch.

---

This PR was prepared with AIL:3. I directed the design and reviewed all generated code.