### PR TITLE
endpoint: sync desired policy before reload on the restore path (restore-path hardening)

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -787,43 +787,19 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 			return newRegenerationErrorf(regenerationFailureReasonPolicyBPFError, "policymap dump failed: %w", err)
 		}
 
-		// Sync policy map before bpf compilation if the bpf policymap is empty.
-		// This allows for upgrades and downgrades from versions using a different policy map
-		if len(datapathRegenCtxt.policyMapDump) == 0 {
-			err = e.policyMapSync(nil, stats)
-			if err != nil {
-				return newRegenerationErrorf(regenerationFailureReasonPolicyBPFError, "policymap synchronization failed: %w", err)
-			}
-			datapathRegenCtxt.policyMapSyncDone = true
-		} else {
-			// There is an edge case where on startup, the policy map for an endpoint
-			// is not empty (policyMapDump > 0) but no policy has been realized yet (realizedPolicy is empty).
-			// Default policy may exist in map to allow all ingress/egress traffic, something like this:
-			// --------------------------------------------------------------------------------------------------------------------------
-			// POLICY   DIRECTION   LABELS (source:key[=value])   PORT/PROTO   PROXY PORT   AUTH TYPE   BYTES   PACKETS   PREFIX
-			// Allow    Ingress     ANY                           ANY          NONE         disabled    2426    29        0
-			// Allow    Ingress     reserved:host                 ANY          NONE         disabled    0       0         0
-			// Allow    Egress      ANY                           ANY          NONE         disabled    30639   165       0
-			// ----------------------------------------------------------------------------------------------------------------------------
-			// If the code has reached here, it means:
-			// 1. The endpoint has a policy map that is not empty (default policy exists)
-			// 2. No policies has been realized (realized policy is empty)
-			// 3. New policies need to be applied for this endpoint (hence desiredPolicy != realizedPolicy)
-			// GH-37724: https://github.com/cilium/cilium/issues/37724
-			e.getLogger().Debug(
-				"Policy map is not empty, but no policy has been realized yet, setting policyMapSyncDone to false",
-			)
-			// Ensure that e.realizedPolicy actually represents the
-			// current policy map state in case rollback is
-			// necessary, so we don't try to "roll back" to an empty
-			// map and delete all the entries, even momentarily.
-			// This may be the case if the agent just restarted,
-			// for example. See GH-38998.
-			e.realizedPolicy.CopyMapStateFrom(datapathRegenCtxt.policyMapDump)
-			// Not strictly required to set as false, but it is a good idea to absolutely
-			// ensure that the policy map is in sync with the desired policy.
-			datapathRegenCtxt.policyMapSyncDone = false
+		// Sync the desired policy into the map before bpf compilation, so
+		// upgrades and downgrades between versions that key the policy map
+		// differently have the correctly-keyed entries in place before the
+		// program is loaded. On the first regeneration after an agent restart
+		// the dump may be non-empty while no policy has been realized yet;
+		// policyMapSync then adds the desired keys without deleting the restored
+		// ones, so established connections are not black-holed during the
+		// reload->realization window (GH-37724, GH-38998).
+		e.realizedPolicy.CopyMapStateFrom(datapathRegenCtxt.policyMapDump)
+		if err = e.policyMapSync(datapathRegenCtxt.policyMapDump, stats); err != nil {
+			return newRegenerationErrorf(regenerationFailureReasonPolicyBPFError, "policymap synchronization failed: %w", err)
 		}
+		datapathRegenCtxt.policyMapSyncDone = true
 	}
 
 	// sync policy map for fake endpoints, bpf compilation will be skipped for them.


### PR DESCRIPTION
This is a defense-in-depth hardening of the endpoint restore path, not the primary fix for the world-aggregation downgrade drops.

On the first endpoint regeneration after an agent restart the BPF policy map still holds the entries enforced before the restart, while the freshly started agent has an empty realized policy. `runPreCompilationSteps` recognises this (non-empty dump, empty realized policy), seeds `realizedPolicy` from the dump so nothing is rolled back, and then defers the policy map sync to after the datapath reload by setting `policyMapSyncDone=false`.

Deferring the sync leaves a window between loading the freshly compiled program and realizing the desired policy in which the map only holds the restored entries. That is fine on a same-version restart, where the restored entries are keyed exactly the way the reloaded program expects. It is not fine across an upgrade or downgrade that changes how the policy map is keyed: an established connection whose identity is keyed differently by the two versions is dropped for the whole reload-to-realization window. This was the mechanism behind the v1.20 to v1.19 identity-aggregation downgrade drops (#47025, #47014).

This change syncs the desired policy on this path too, before the program is compiled and loaded, exactly as the empty-dump branch already does. `policyMapSync` routes a non-empty dump to `syncPolicyMapWith` with `skipDeletes` set, so it adds the desired, this-version-keyed entries while still preserving the restored ones, and marks the endpoint so the later full reconciliation reaps the now-stale restored entries as expected convergence rather than a policy-map bug. The desired policy is already resolved at this point, because `regeneratePolicy` and `setDesiredPolicy` run earlier in `runPreCompilationSteps`, so the correct entries are available before the reload.

Relationship to the other PRs: the world-aggregation drops (#47025, #47014) are being fixed at the root by #47078 (make identity aggregation configurable, disabled by default) and #47080 (rename the policy maps to v3 so upgrades/downgrades no longer share a map). Either of those removes the specific incompatibility. This PR does not depend on them and does not claim to fix those issues; it hardens the restore path so that any future keying change across a version boundary re-seeds the correct entries before the reload instead of relying on the post-reload reconciliation window. Keep or drop depending on whether sig-policy wants this as a standalone robustness improvement.

Validation: exercised on the exact downgrade-to-v1.19 restore leg by temporarily pinning the E2E-upgrade downgrade image to a v1.19 build carrying this change; the conn-disrupt no-interrupted-connections tests passed on the downgrade leg across three runs where they previously failed.
