### PR TITLE
v1.19: endpoint: sync desired policy before reload on the restore path

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -806,43 +806,19 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 			return fmt.Errorf("policymap dump failed: %w", err)
 		}
 
-		// Sync policy map before bpf compilation if the bpf policymap is empty.
-		// This allows for upgrades and downgrades from versions using a different policy map
-		if len(datapathRegenCtxt.policyMapDump) == 0 {
-			err = e.policyMapSync(nil, stats)
-			if err != nil {
-				return fmt.Errorf("policymap synchronization failed: %w", err)
-			}
-			datapathRegenCtxt.policyMapSyncDone = true
-		} else {
-			// There is an edge case where on startup, the policy map for an endpoint
-			// is not empty (policyMapDump > 0) but no policy has been realized yet (realizedPolicy is empty).
-			// Default policy may exist in map to allow all ingress/egress traffic, something like this:
-			// --------------------------------------------------------------------------------------------------------------------------
-			// POLICY   DIRECTION   LABELS (source:key[=value])   PORT/PROTO   PROXY PORT   AUTH TYPE   BYTES   PACKETS   PREFIX
-			// Allow    Ingress     ANY                           ANY          NONE         disabled    2426    29        0
-			// Allow    Ingress     reserved:host                 ANY          NONE         disabled    0       0         0
-			// Allow    Egress      ANY                           ANY          NONE         disabled    30639   165       0
-			// ----------------------------------------------------------------------------------------------------------------------------
-			// If the code has reached here, it means:
-			// 1. The endpoint has a policy map that is not empty (default policy exists)
-			// 2. No policies has been realized (realized policy is empty)
-			// 3. New policies need to be applied for this endpoint (hence desiredPolicy != realizedPolicy)
-			// GH-37724: https://github.com/cilium/cilium/issues/37724
-			e.getLogger().Debug(
-				"Policy map is not empty, but no policy has been realized yet, setting policyMapSyncDone to false",
-			)
-			// Ensure that e.realizedPolicy actually represents the
-			// current policy map state in case rollback is
-			// necessary, so we don't try to "roll back" to an empty
-			// map and delete all the entries, even momentarily.
-			// This may be the case if the agent just restarted,
-			// for example. See GH-38998.
-			e.realizedPolicy.CopyMapStateFrom(datapathRegenCtxt.policyMapDump)
-			// Not strictly required to set as false, but it is a good idea to absolutely
-			// ensure that the policy map is in sync with the desired policy.
-			datapathRegenCtxt.policyMapSyncDone = false
+		// Sync the desired policy into the map before bpf compilation, so
+		// upgrades and downgrades between versions that key the policy map
+		// differently have the correctly-keyed entries in place before the
+		// program is loaded. On the first regeneration after an agent restart
+		// the dump may be non-empty while no policy has been realized yet;
+		// policyMapSync then adds the desired keys without deleting the restored
+		// ones, so established connections are not black-holed during the
+		// reload->realization window (GH-37724, GH-38998).
+		e.realizedPolicy.CopyMapStateFrom(datapathRegenCtxt.policyMapDump)
+		if err = e.policyMapSync(datapathRegenCtxt.policyMapDump, stats); err != nil {
+			return fmt.Errorf("policymap synchronization failed: %w", err)
 		}
+		datapathRegenCtxt.policyMapSyncDone = true
 	}
 
 	// sync policy map for fake endpoints, bpf compilation will be skipped for them.


### PR DESCRIPTION
 * [ ] #47075 (@aanm)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 47075
```

Backport of #47075 — a defense-in-depth hardening of the endpoint restore path (sync the desired, this-version-keyed policy entries before the datapath reload instead of after). It does not claim to fix the world-aggregation downgrade drops (#47025, #47014); those are addressed at the root by #47078 and #47080. Included here so the restore-path hardening is present on v1.19 as well; keep or drop depending on whether the standalone hardening is wanted on the stable branch.

Note: not a clean cherry-pick. The upstream commit returns the policymap-sync error via `newRegenerationErrorf(regenerationFailureReasonPolicyBPFError, ...)`, which does not exist on v1.19; adapted to `fmt.Errorf("policymap synchronization failed: %w", err)` to match the sibling empty-dump branch on this path.
