### PR TITLE
loader/test: Add endpoint-routes to test permutations

### DIFF
--- a/pkg/datapath/loader/verifier_load_test.go
+++ b/pkg/datapath/loader/verifier_load_test.go
@@ -36,6 +36,7 @@ func baseLXCPermutations() *loadPermutationBuilder {
 
 		Increment(func(t *config.BPFLXC, v bool) { t.Node.PolicyDenyResponseEnabled = v }),
 		Increment(func(t *config.BPFLXC, v bool) { t.HybridRoutingEnabled = v }),
+		Increment(func(t *config.BPFLXC, v bool) { t.Node.EnableEndpointRoutes = v }),
 		IncrementOrPermute(func(t *config.BPFLXC, v bool) { t.EnableLRP = v }),
 	)
 	return b
@@ -68,6 +69,7 @@ func baseHostPermutations() *loadPermutationBuilder {
 			}
 		}),
 		Increment(func(t *config.BPFHost, v bool) { t.HybridRoutingEnabled = v }),
+		Increment(func(t *config.BPFHost, v bool) { t.Node.EnableEndpointRoutes = v }),
 	)
 	return b
 }


### PR DESCRIPTION
Previously, the verifier load tests did not include the endpoint-routes. The config is used by bpf_host and bpf_lxc.

