### PR TITLE
gateway-api: configure host-network service node selector

### DIFF
--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_label_selector/with_external_traffic_policy/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_label_selector/with_external_traffic_policy/service-output.yaml
@@ -1,5 +1,7 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    service.cilium.io/node-selector: a=b
   labels:
     gateway.networking.k8s.io/gateway-name: my-gateway
     io.cilium.gateway/owning-gateway: my-gateway

--- a/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_label_selector/without_external_traffic_policy/service-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/host_network/basic_http_listener_with_label_selector/without_external_traffic_policy/service-output.yaml
@@ -1,5 +1,7 @@
 metadata:
   creationTimestamp: null
+  annotations:
+    service.cilium.io/node-selector: a=b
   labels:
     gateway.networking.k8s.io/gateway-name: my-gateway
     io.cilium.gateway/owning-gateway: my-gateway

--- a/operator/pkg/model/translation/gateway-api/translator.go
+++ b/operator/pkg/model/translation/gateway-api/translator.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"sort"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
@@ -429,14 +431,38 @@ func (t *gatewayAPITranslator) desiredL7DummyEndpointSlice(owner *model.FullyQua
 }
 
 func (t *gatewayAPITranslator) toServiceAnnotations(annotations map[string]string, params *model.Service) map[string]string {
-	if params == nil {
-		return annotations
+	if _, exists := annotations[annotation.ServiceNodeSelectorExposure]; !exists && t.cfg.HostNetworkConfig.Enabled {
+		if selector := t.serviceNodeSelectorAnnotationValue(); selector != "" {
+			if annotations == nil {
+				annotations = make(map[string]string)
+			}
+			annotations[annotation.ServiceNodeSelectorExposure] = selector
+		}
 	}
-	if annotations == nil {
-		annotations = make(map[string]string)
+
+	if params != nil {
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[annotation.ServiceSourceRangesPolicy] = params.LoadBalancerSourceRangesPolicy
 	}
-	annotations[annotation.ServiceSourceRangesPolicy] = params.LoadBalancerSourceRangesPolicy
+
 	return annotations
+}
+
+func (t *gatewayAPITranslator) serviceNodeSelectorAnnotationValue() string {
+	selector := t.cfg.HostNetworkConfig.NodeLabelSelector
+	if selector == nil {
+		return ""
+	}
+
+	parts := make([]string, 0, len(selector.MatchLabels))
+	for key, value := range selector.MatchLabels {
+		parts = append(parts, fmt.Sprintf("%s=%s", key, value))
+	}
+	sort.Strings(parts)
+
+	return strings.Join(parts, ",")
 }
 
 func decorateCEC(cec *ciliumv2.CiliumEnvoyConfig, resource *model.FullyQualifiedResource, labels, annotations map[string]string) error {

--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cilium/cilium/operator/pkg/model"
 	"github.com/cilium/cilium/operator/pkg/model/translation"
+	"github.com/cilium/cilium/pkg/annotation"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/shortener"
@@ -440,16 +441,171 @@ func Test_translator_toServicePorts_MixedProtocolsSamePort(t *testing.T) {
 func Test_getService(t *testing.T) {
 	type args struct {
 		resource              *model.FullyQualifiedResource
+		params                *model.Service
 		allPorts              []corev1.ServicePort
 		labels                map[string]string
 		annotations           map[string]string
 		externalTrafficPolicy string
+		hostNetworkEnabled    bool
+		nodeLabelSelector     *slim_metav1.LabelSelector
 	}
 	tests := []struct {
 		name string
 		args args
 		want *corev1.Service
 	}{
+		{
+			name: "configured node selector is ignored when host network is disabled",
+			args: args{
+				resource: &model.FullyQualifiedResource{
+					Name:      "test-node-selector",
+					Namespace: "default",
+					Version:   "v1",
+					Kind:      "Gateway",
+					UID:       "2a79c3f5-c7d1-42c6-b60f-c828f7d78827",
+				},
+				allPorts: []corev1.ServicePort{{Name: "port-80", Port: 80, Protocol: corev1.ProtocolTCP}},
+				nodeLabelSelector: &slim_metav1.LabelSelector{
+					MatchLabels: map[string]slim_metav1.MatchLabelsValue{
+						"component": "gateway-api",
+						"role":      "infra",
+					},
+				},
+			},
+			want: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cilium-gateway-test-node-selector",
+					Namespace: "default",
+					Labels: map[string]string{
+						owningGatewayLabel:                       "test-node-selector",
+						"gateway.networking.k8s.io/gateway-name": "test-node-selector",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: gatewayv1.GroupVersion.String(),
+							Kind:       "Gateway",
+							Name:       "test-node-selector",
+							UID:        types.UID("2a79c3f5-c7d1-42c6-b60f-c828f7d78827"),
+							Controller: ptr.To(true),
+						},
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{
+						Name:     fmt.Sprintf("port-%d", 80),
+						Port:     80,
+						Protocol: corev1.ProtocolTCP,
+					}},
+					Type: corev1.ServiceTypeLoadBalancer,
+				},
+			},
+		},
+		{
+			name: "host network nodeport service inherits configured node selector",
+			args: args{
+				resource: &model.FullyQualifiedResource{
+					Name:      "test-nodeport-selector",
+					Namespace: "default",
+					Version:   "v1",
+					Kind:      "Gateway",
+					UID:       "46965fd5-af46-4b55-9cfd-fdbebbaf2ff6",
+				},
+				params:             &model.Service{Type: string(corev1.ServiceTypeNodePort)},
+				hostNetworkEnabled: true,
+				allPorts:           []corev1.ServicePort{{Name: "port-80", Port: 80, Protocol: corev1.ProtocolTCP}},
+				nodeLabelSelector: &slim_metav1.LabelSelector{
+					MatchLabels: map[string]slim_metav1.MatchLabelsValue{
+						"component": "gateway-api",
+						"role":      "infra",
+					},
+				},
+			},
+			want: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cilium-gateway-test-nodeport-selector",
+					Namespace: "default",
+					Labels: map[string]string{
+						owningGatewayLabel:                       "test-nodeport-selector",
+						"gateway.networking.k8s.io/gateway-name": "test-nodeport-selector",
+					},
+					Annotations: map[string]string{
+						annotation.ServiceNodeSelectorExposure: "component=gateway-api,role=infra",
+						annotation.ServiceSourceRangesPolicy:   "",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: gatewayv1.GroupVersion.String(),
+							Kind:       "Gateway",
+							Name:       "test-nodeport-selector",
+							UID:        types.UID("46965fd5-af46-4b55-9cfd-fdbebbaf2ff6"),
+							Controller: ptr.To(true),
+						},
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{
+						Name:     fmt.Sprintf("port-%d", 80),
+						Port:     80,
+						Protocol: corev1.ProtocolTCP,
+					}},
+					Type: corev1.ServiceTypeNodePort,
+				},
+			},
+		},
+		{
+			name: "explicit infrastructure node selector overrides default",
+			args: args{
+				resource: &model.FullyQualifiedResource{
+					Name:      "test-explicit-node-selector",
+					Namespace: "default",
+					Version:   "v1",
+					Kind:      "Gateway",
+					UID:       "12345678-1234-1234-1234-123456789abc",
+				},
+				params:             &model.Service{Type: string(corev1.ServiceTypeNodePort)},
+				hostNetworkEnabled: true,
+				allPorts:           []corev1.ServicePort{{Name: "port-80", Port: 80, Protocol: corev1.ProtocolTCP}},
+				annotations: map[string]string{
+					annotation.ServiceNodeSelectorExposure: "role=custom",
+				},
+				nodeLabelSelector: &slim_metav1.LabelSelector{
+					MatchLabels: map[string]slim_metav1.MatchLabelsValue{
+						"role": "infra",
+					},
+				},
+			},
+			want: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cilium-gateway-test-explicit-node-selector",
+					Namespace: "default",
+					Labels: map[string]string{
+						owningGatewayLabel:                       "test-explicit-node-selector",
+						"gateway.networking.k8s.io/gateway-name": "test-explicit-node-selector",
+					},
+					Annotations: map[string]string{
+						annotation.ServiceNodeSelectorExposure: "role=custom",
+						annotation.ServiceSourceRangesPolicy:   "",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: gatewayv1.GroupVersion.String(),
+							Kind:       "Gateway",
+							Name:       "test-explicit-node-selector",
+							UID:        types.UID("12345678-1234-1234-1234-123456789abc"),
+							Controller: ptr.To(true),
+						},
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{
+						Name:     fmt.Sprintf("port-%d", 80),
+						Port:     80,
+						Protocol: corev1.ProtocolTCP,
+					}},
+					Type: corev1.ServiceTypeNodePort,
+				},
+			},
+		},
 		{
 			name: "long name - more than 64 characters",
 			args: args{
@@ -551,8 +707,12 @@ func Test_getService(t *testing.T) {
 				ServiceConfig: translation.ServiceConfig{
 					ExternalTrafficPolicy: tt.args.externalTrafficPolicy,
 				},
+				HostNetworkConfig: translation.HostNetworkConfig{
+					Enabled:           tt.args.hostNetworkEnabled,
+					NodeLabelSelector: tt.args.nodeLabelSelector,
+				},
 			}}
-			got := trans.desiredService(nil, tt.args.resource, tt.args.allPorts, tt.args.labels, tt.args.annotations)
+			got := trans.desiredService(tt.args.params, tt.args.resource, tt.args.allPorts, tt.args.labels, tt.args.annotations)
 			assert.Equalf(t, tt.want, got, "desiredService(%v, %v, %v, %v)", tt.args.resource, tt.args.allPorts, tt.args.labels, tt.args.annotations)
 			assert.LessOrEqual(t, len(got.Name), 63, "Service name is too long")
 		})


### PR DESCRIPTION
Gateway API host-network mode already limits the generated CEC to the configured node subset via `gatewayAPI.hostNetwork.nodes.matchLabels`, but the generated Service did not mirror that node restriction.

As a result, host-network mode with a node subset isn't properly supported for the newly added Gateway API TCP- & UDPRoute.

Therefore, this commit configures the node selector subset on the generated Gateway API K8s Service via annotation `service.cilium.io/node-selector` when host-network mode is enabled and a label selector is defined.

Note: Existing annotations on the Service or annotations defined via infrastructure annotations on the `GatewayClass` are prioritized!