### PR TITLE
ci: reverse logic for docker auth requirement

### DIFF
--- a/.github/actions/wait-for-images/action.yaml
+++ b/.github/actions/wait-for-images/action.yaml
@@ -31,7 +31,7 @@ runs:
     - name: Set environment variables
       uses: ./.github/actions/set-env-variables
     - name: Login to docker registry
-      if: ${{ inputs.auth-required != 'false' && inputs.login-host != '' && inputs.login-username != '' && inputs.login-password != '' }}
+      if: ${{ inputs.auth-required == 'true' && inputs.login-host != '' && inputs.login-username != '' && inputs.login-password != '' }}
       uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:
         registry: ${{ inputs.login-host }}

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -354,7 +354,7 @@ jobs:
           kubeconfig: "~/.kube/config"
 
       - name: Create imagePullSecret
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -349,7 +349,7 @@ jobs:
           kubeconfig: "~/.kube/config"
 
       - name: Create imagePullSecret
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -493,7 +493,7 @@ jobs:
           release-version: ${{ env.CILIUM_CLI_VERSION }}
 
       - name: Create imagePullSecrets
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         run: |
           for ctx in ${{ env.contextName1 }} ${{ env.contextName2 }}; do
              kubectl --context $ctx create secret docker-registry cilium-registry \

--- a/.github/workflows/conformance-delegated-ipam.yaml
+++ b/.github/workflows/conformance-delegated-ipam.yaml
@@ -288,7 +288,7 @@ jobs:
           release-version: ${{ env.CILIUM_CLI_VERSION }}
 
       - name: Create imagePullSecret
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \
@@ -297,7 +297,7 @@ jobs:
             --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
 
       - name: Login to docker registry for image wait
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ vars.DOCKER_READ_HOST}}

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -448,7 +448,7 @@ jobs:
           kubeconfig: "~/.kube/config"
 
       - name: Create imagePullSecret
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -253,7 +253,7 @@ jobs:
           wait: 0 # The control-plane never becomes ready, since no CNI is present
 
       - name: Create imagePullSecret
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -427,7 +427,7 @@ jobs:
           kubeconfig: "~/.kube/config"
 
       - name: Create imagePullSecret
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -212,7 +212,7 @@ jobs:
           wait: 0 # The control-plane never becomes ready, since no CNI is present
 
       - name: Create imagePullSecret
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -233,7 +233,7 @@ jobs:
           kind-image: ${{ env.KIND_K8S_IMAGE }}
 
       - name: Create imagePullSecret
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' && steps.cilium-config.outputs.skip != 'true' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' && steps.cilium-config.outputs.skip != 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \

--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -185,7 +185,7 @@ jobs:
           release-version: ${{ env.CILIUM_CLI_VERSION }}
 
       - name: Create imagePullSecret
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \
@@ -194,7 +194,7 @@ jobs:
             --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
 
       - name: Login to docker registry for image wait
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ vars.DOCKER_READ_HOST}}

--- a/.github/workflows/conformance-kubespray.yaml
+++ b/.github/workflows/conformance-kubespray.yaml
@@ -193,7 +193,7 @@ jobs:
           kubectl wait --for=condition=Ready pods --all -n kube-system --timeout=300s
 
       - name: Create imagePullSecret
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \

--- a/.github/workflows/conformance-mcs-api.yaml
+++ b/.github/workflows/conformance-mcs-api.yaml
@@ -207,7 +207,7 @@ jobs:
           wait: 0 # The control-plane never becomes ready, since no CNI is present
 
       - name: Create imagePullSecrets
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         run: |
           for context in ${{ env.contextName1 }} ${{ env.contextName2 }}; do
             kubectl --context $context create secret docker-registry cilium-registry \

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -287,7 +287,7 @@ jobs:
           wait: 0 # The control-plane never becomes ready, since no CNI is present
 
       - name: Create imagePullSecret
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \

--- a/.github/workflows/conformance-ztunnel-e2e.yaml
+++ b/.github/workflows/conformance-ztunnel-e2e.yaml
@@ -181,7 +181,7 @@ jobs:
           kind-image: ${{ env.KIND_K8S_IMAGE }}
 
       - name: Create imagePullSecret
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' && steps.cilium-config.outputs.skip != 'true' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' && steps.cilium-config.outputs.skip != 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \

--- a/.github/workflows/fqdn-perf.yaml
+++ b/.github/workflows/fqdn-perf.yaml
@@ -146,7 +146,7 @@ jobs:
           echo CLUSTER_NAME=${CLUSTER_NAME} >> $GITHUB_OUTPUT
 
       - name: Login to docker registry for image wait
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ vars.DOCKER_READ_HOST}}
@@ -212,7 +212,7 @@ jobs:
           project_id: ${{ secrets.GCP_PERF_PROJECT_ID }}
 
       - name: Create imagePullSecret
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \

--- a/.github/workflows/hubble-cli-integration-test.yaml
+++ b/.github/workflows/hubble-cli-integration-test.yaml
@@ -155,7 +155,7 @@ jobs:
           wait: 0 # The control-plane never becomes ready, since no CNI is present
 
       - name: Create imagePullSecret
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \
@@ -164,7 +164,7 @@ jobs:
             --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
 
       - name: Login to docker registry for image wait
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ vars.DOCKER_READ_HOST}}

--- a/.github/workflows/k8s-kind-network-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-e2e.yaml
@@ -194,7 +194,7 @@ jobs:
           release-version: ${{ env.CILIUM_CLI_VERSION }}
 
       - name: Create imagePullSecret
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \
@@ -203,7 +203,7 @@ jobs:
             --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
 
       - name: Login to docker registry for image wait
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ vars.DOCKER_READ_HOST}}

--- a/.github/workflows/k8s-kind-network-policies-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-policies-e2e.yaml
@@ -205,7 +205,7 @@ jobs:
           release-version: ${{ env.CILIUM_CLI_VERSION }}
 
       - name: Create imagePullSecret
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \
@@ -214,7 +214,7 @@ jobs:
             --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
 
       - name: Login to docker registry for image wait
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ vars.DOCKER_READ_HOST}}

--- a/.github/workflows/l7-perf.yaml
+++ b/.github/workflows/l7-perf.yaml
@@ -324,7 +324,7 @@ jobs:
           kubeconfig: "~/.kube/config"
 
       - name: Create imagePullSecret
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \

--- a/.github/workflows/net-perf-gke.yaml
+++ b/.github/workflows/net-perf-gke.yaml
@@ -282,7 +282,7 @@ jobs:
           kubeconfig: "~/.kube/config"
 
       - name: Create imagePullSecret
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' && matrix.mode != 'baseline' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' && matrix.mode != 'baseline' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \

--- a/.github/workflows/scale-test-5-gce.yaml
+++ b/.github/workflows/scale-test-5-gce.yaml
@@ -152,7 +152,7 @@ jobs:
           echo CLUSTER_NAME=${CLUSTER_NAME} >> $GITHUB_OUTPUT
 
       - name: Login to docker registry for image wait
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ vars.DOCKER_READ_HOST}}
@@ -239,7 +239,7 @@ jobs:
           kube_proxy_enabled: false
 
       - name: Create imagePullSecret
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \

--- a/.github/workflows/scale-test-clustermesh.yaml
+++ b/.github/workflows/scale-test-clustermesh.yaml
@@ -189,7 +189,7 @@ jobs:
           kube_proxy_enabled: false
 
       - name: Create imagePullSecret
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \

--- a/.github/workflows/scale-test-egw.yaml
+++ b/.github/workflows/scale-test-egw.yaml
@@ -382,7 +382,7 @@ jobs:
           kubeconfig: "~/.kube/config"
 
       - name: Create imagePullSecret
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \

--- a/.github/workflows/scale-test-node-throughput-gce.yaml
+++ b/.github/workflows/scale-test-node-throughput-gce.yaml
@@ -88,7 +88,7 @@ jobs:
           echo CLUSTER_NAME=${CLUSTER_NAME} >> $GITHUB_OUTPUT
 
       - name: Login to docker registry for image wait
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ vars.DOCKER_READ_HOST}}
@@ -154,7 +154,7 @@ jobs:
           project_id: ${{ secrets.GCP_PERF_PROJECT_ID }}
 
       - name: Create imagePullSecret
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \

--- a/.github/workflows/tests-ces-migrate.yaml
+++ b/.github/workflows/tests-ces-migrate.yaml
@@ -152,7 +152,7 @@ jobs:
           wait: 0 # The control-plane never becomes ready, since no CNI is present
 
       - name: Create imagePullSecret
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -294,7 +294,7 @@ jobs:
           wait: 0 # The control-plane never becomes ready, since no CNI is present
 
       - name: Create imagePullSecrets
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         run: |
           for context in ${{ env.contextName1 }} ${{ env.contextName2 }}; do
             kubectl --context $context create secret docker-registry cilium-registry \

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -419,7 +419,7 @@ jobs:
           kind-image: ${{ env.KIND_K8S_IMAGE }}
 
       - name: Create imagePullSecret
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' && steps.vars.outputs.downgrade_version != '' && steps.cilium-stable-config.outputs.skip != 'true' && steps.cilium-newest-config.outputs.skip != 'true' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' && steps.vars.outputs.downgrade_version != '' && steps.cilium-stable-config.outputs.skip != 'true' && steps.cilium-newest-config.outputs.skip != 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \

--- a/.github/workflows/tests-smoke-conformance.yaml
+++ b/.github/workflows/tests-smoke-conformance.yaml
@@ -124,7 +124,7 @@ jobs:
           wait: 0 # The control-plane never becomes ready, since no CNI is present
 
       - name: Create imagePullSecret
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \
@@ -133,7 +133,7 @@ jobs:
             --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
 
       - name: Login to docker registry for image wait
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ vars.DOCKER_READ_HOST}}

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -126,7 +126,7 @@ jobs:
           wait: 0 # The control-plane never becomes ready, since no CNI is present
 
       - name: Create imagePullSecret
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         run: |
           kubectl create secret docker-registry cilium-registry \
             --namespace kube-system \
@@ -135,7 +135,7 @@ jobs:
             --docker-password="${{ secrets.DOCKER_READ_PASSWORD }}"
 
       - name: Login to docker registry for image wait
-        if: ${{ vars.DOCKER_AUTH_REQUIRED != 'false' }}
+        if: ${{ vars.DOCKER_AUTH_REQUIRED == 'true' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ vars.DOCKER_READ_HOST}}


### PR DESCRIPTION
Previous logic needed DOCKER_AUTH_REQUIRED to be set in the repository otherwise the auth step would always run. With this logic DOCKER_AUTH_REQUIRED isn't required anymore and the default behavior is to not have auth set to read registry.