### PR TITLE
vendor: bump github.com/cilium/statedb to v0.8.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/cilium/hive v1.0.4
 	github.com/cilium/lumberjack/v2 v2.4.2
 	github.com/cilium/proxy v0.0.0-20260701124752-9c14fdc485a1
-	github.com/cilium/statedb v0.8.2
+	github.com/cilium/statedb v0.8.3
 	github.com/cilium/stream v0.0.1
 	github.com/cilium/workerpool v1.4.0
 	github.com/cloudflare/cfssl v1.6.5

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/cilium/lumberjack/v2 v2.4.2 h1:Wea2z1+ikRhjS5z36I6vgeMlgh7xzvIzqW+t9t
 github.com/cilium/lumberjack/v2 v2.4.2/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
 github.com/cilium/proxy v0.0.0-20260701124752-9c14fdc485a1 h1:F+SGcs1IpZTuy1bGWBVZQgyr65NiiTOjHli7WExSHnU=
 github.com/cilium/proxy v0.0.0-20260701124752-9c14fdc485a1/go.mod h1:GEiA7dAvPLMMt5drHzjQDAwRtVFcHbVR4ExTN5ISRyg=
-github.com/cilium/statedb v0.8.2 h1:wkKb2RVXAziYyx9O/RDITFcmCfvFUijxl0tUC4+nWrU=
-github.com/cilium/statedb v0.8.2/go.mod h1:Dtp96Hmwcw7DJj9kIa2MfkX5Irk4KVyITN40fXyolio=
+github.com/cilium/statedb v0.8.3 h1:FeepHCxKPTyMQUrpai3i8QHDASZ75xR41B3nXSOty3o=
+github.com/cilium/statedb v0.8.3/go.mod h1:2V2x/gwI4JbEwZfvTaqiNc6SeGZ+BcEIGGY50B2fSpY=
 github.com/cilium/stream v0.0.1 h1:82zuM/WwkLiac2Jg5FrzPxZHvIBbxXTi4VY7M+EYLs0=
 github.com/cilium/stream v0.0.1/go.mod h1:/e83AwqvNKpyg4n3C41qmnmj1x2G9DwzI+jb7GkF4lI=
 github.com/cilium/workerpool v1.4.0 h1:Tn0e2Ie1THjepOnj5PobkhZ3CLknostEcKRvEGvbY/Y=

--- a/vendor/github.com/cilium/statedb/db.go
+++ b/vendor/github.com/cilium/statedb/db.go
@@ -193,12 +193,24 @@ func (db *DB) WriteTxn(tables ...TableMeta) WriteTxn {
 	txn := db.writeTxnPool.Get().(*writeTxnState)
 	txn.db = db
 
+	// Deduplicate the set of tables to avoid acquiring the same table lock
+	// more than once, which would deadlock down the line.
+	seen := make(map[int]struct{}, len(tables))
+	tables = slices.DeleteFunc(slices.Clone(tables), func(table TableMeta) bool {
+		pos := table.tablePos()
+		if pos < 0 {
+			panic(tableError(table.Name(), ErrTableNotRegistered))
+		}
+		if _, exists := seen[pos]; exists {
+			return true
+		}
+		seen[pos] = struct{}{}
+		return false
+	})
+
 	txn.smus = reuseSlice(txn.smus, len(tables))
 	for i, table := range tables {
 		txn.smus[i] = table.sortableMutex()
-		if table.tablePos() < 0 {
-			panic(tableError(table.Name(), ErrTableNotRegistered))
-		}
 	}
 
 	lockAt := time.Now()

--- a/vendor/github.com/cilium/statedb/derive.go
+++ b/vendor/github.com/cilium/statedb/derive.go
@@ -51,9 +51,13 @@ type DeriveParams[In, Out any] struct {
 //	)
 func Derive[In, Out any](jobName string, transform func(obj In, deleted bool) (Out, DeriveResult)) func(DeriveParams[In, Out]) {
 	return func(p DeriveParams[In, Out]) {
+		wtxn := p.DB.WriteTxn(p.OutTable)
+		markInit := p.OutTable.RegisterInitializer(wtxn, jobName)
+		wtxn.Commit()
+
 		p.JobGroup.Add(job.OneShot(
 			jobName,
-			derive[In, Out]{p, jobName, transform}.loop),
+			derive[In, Out]{p, jobName, transform, markInit}.loop),
 		)
 	}
 }
@@ -62,6 +66,7 @@ type derive[In, Out any] struct {
 	DeriveParams[In, Out]
 	jobName   string
 	transform func(obj In, deleted bool) (Out, DeriveResult)
+	markInit  func(WriteTxn)
 }
 
 func (d derive[In, Out]) loop(ctx context.Context, _ cell.Health) error {
@@ -75,6 +80,8 @@ func (d derive[In, Out]) loop(ctx context.Context, _ cell.Health) error {
 	defer iter.Close()
 
 	for {
+		var init <-chan struct{}
+
 		wtxn := d.DB.WriteTxn(out)
 		changes, watch := iter.Next(wtxn)
 		for change := range changes {
@@ -96,10 +103,21 @@ func (d derive[In, Out]) loop(ctx context.Context, _ cell.Health) error {
 				return err
 			}
 		}
+
+		if d.markInit != nil {
+			if ok, ch := d.InTable.Initialized(wtxn); ok {
+				d.markInit(wtxn)
+				d.markInit = nil
+			} else {
+				init = ch
+			}
+		}
+
 		wtxn.Commit()
 
 		select {
 		case <-watch:
+		case <-init:
 		case <-ctx.Done():
 			return nil
 		}

--- a/vendor/github.com/cilium/statedb/write_txn.go
+++ b/vendor/github.com/cilium/statedb/write_txn.go
@@ -156,7 +156,7 @@ func (txn *writeTxnState) modify(meta TableMeta, guardRevision Revision, newData
 		if val.Kind() == reflect.Pointer {
 			oldVal := reflect.ValueOf(oldObj.data)
 			if val.UnsafePointer() == oldVal.UnsafePointer() {
-				panic(fmt.Sprintf(
+				panic(fmt.Errorf(
 					"Insert() of the same object (%T) back into the table. Is the immutable object being mutated?",
 					obj.data))
 			}
@@ -235,15 +235,12 @@ func (txn *writeTxnState) delete(meta TableMeta, guardRevision Revision, data an
 		return object{}, false, ErrTransactionClosed
 	}
 
-	// Look up table and allocate a new revision.
+	// Look up table.
 	tableName := meta.Name()
 	table := txn.tableEntries[meta.tablePos()]
 	if !table.locked {
 		return object{}, false, tableError(tableName, ErrTableNotLockedForWriting)
 	}
-	oldRevision := table.revision
-	table.revision++
-	revision := table.revision
 
 	// Delete from the primary index first to grab the object.
 	// We assume that "data" has only enough defined fields to
@@ -260,10 +257,12 @@ func (txn *writeTxnState) delete(meta TableMeta, guardRevision Revision, data an
 	if guardRevision > 0 {
 		if obj.revision != guardRevision {
 			idIndex.insert(idKey, obj)
-			table.revision = oldRevision
 			return obj, true, ErrRevisionNotEqual
 		}
 	}
+
+	table.revision++
+	revision := table.revision
 
 	// Remove the object from the revision index.
 	binary.BigEndian.PutUint64(txn.revKey[:], obj.revision)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -361,8 +361,8 @@ github.com/cilium/lumberjack/v2
 # github.com/cilium/proxy v0.0.0-20260701124752-9c14fdc485a1
 ## explicit; go 1.25.0
 github.com/cilium/proxy/go/cilium/api
-# github.com/cilium/statedb v0.8.2
-## explicit; go 1.25
+# github.com/cilium/statedb v0.8.3
+## explicit; go 1.25.0
 github.com/cilium/statedb
 github.com/cilium/statedb/index
 github.com/cilium/statedb/internal


### PR DESCRIPTION
Changelog: https://github.com/cilium/statedb/releases/tag/v0.8.3

Bumping manually, instead of relying on renovate, to avoid waiting for the cool-down period, and streamline the backport to v1.20.