### PR TITLE
[v1.19] vendor: bump github.com/cilium/statedb to v0.5.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/cilium/hive v0.0.0-20260108104938-97756f6ff54c
 	github.com/cilium/lumberjack/v2 v2.4.1
 	github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1
-	github.com/cilium/statedb v0.5.8
+	github.com/cilium/statedb v0.5.9
 	github.com/cilium/stream v0.0.1
 	github.com/cilium/workerpool v1.3.0
 	github.com/cloudflare/cfssl v1.6.5

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/cilium/lumberjack/v2 v2.4.1 h1:tU92KFJmLQ4Uls5vTgok5b5RbfxpawRia7L14y
 github.com/cilium/lumberjack/v2 v2.4.1/go.mod h1:yfbtPGmg4i//5oEqzaMxDqSWqgfZFmMoV70Mc2k6v0A=
 github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1 h1:SOOtIfQmW/pF1iW1I4hVUx1pvgX7Xh2E8jHv+itBXQ0=
 github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1/go.mod h1:Kwyyx+cC2H67Aj1sDuqBLvPn6TEmEJRPvULIrJ/kBRo=
-github.com/cilium/statedb v0.5.8 h1:zcHJ+fZ57TwT71x5/vzfPi5Dvda2Z/hl2WLyTxvbxf8=
-github.com/cilium/statedb v0.5.8/go.mod h1:utZbqAU8l3X/2zmbBwoYC2KuRTstuSqo+c4cw4jXsCM=
+github.com/cilium/statedb v0.5.9 h1:HbZhIfos5jld0Gh1hhRIg6h2v84ZrGLq4Bt5Y82ZUUU=
+github.com/cilium/statedb v0.5.9/go.mod h1:utZbqAU8l3X/2zmbBwoYC2KuRTstuSqo+c4cw4jXsCM=
 github.com/cilium/stream v0.0.1 h1:82zuM/WwkLiac2Jg5FrzPxZHvIBbxXTi4VY7M+EYLs0=
 github.com/cilium/stream v0.0.1/go.mod h1:/e83AwqvNKpyg4n3C41qmnmj1x2G9DwzI+jb7GkF4lI=
 github.com/cilium/workerpool v1.3.0 h1:7BhHxoqNtpqtmce6MxZdgWODze4lYHbWkEUQ+3xEu8M=

--- a/vendor/github.com/cilium/statedb/derive.go
+++ b/vendor/github.com/cilium/statedb/derive.go
@@ -52,10 +52,14 @@ type DeriveParams[In, Out any] struct {
 //	)
 func Derive[In, Out any](jobName string, transform func(obj In, deleted bool) (Out, DeriveResult)) func(DeriveParams[In, Out]) {
 	return func(p DeriveParams[In, Out]) {
+		wtxn := p.DB.WriteTxn(p.OutTable)
+		markInit := p.OutTable.RegisterInitializer(wtxn, jobName)
+		wtxn.Commit()
+
 		g := p.Jobs.NewGroup(p.Health, p.Lifecycle)
 		g.Add(job.OneShot(
 			jobName,
-			derive[In, Out]{p, jobName, transform}.loop),
+			derive[In, Out]{p, jobName, transform, markInit}.loop),
 		)
 	}
 }
@@ -64,6 +68,7 @@ type derive[In, Out any] struct {
 	DeriveParams[In, Out]
 	jobName   string
 	transform func(obj In, deleted bool) (Out, DeriveResult)
+	markInit  func(WriteTxn)
 }
 
 func (d derive[In, Out]) loop(ctx context.Context, _ cell.Health) error {
@@ -75,6 +80,8 @@ func (d derive[In, Out]) loop(ctx context.Context, _ cell.Health) error {
 		return err
 	}
 	for {
+		var init <-chan struct{}
+
 		wtxn := d.DB.WriteTxn(out)
 		changes, watch := iter.Next(wtxn)
 		for change := range changes {
@@ -96,10 +103,21 @@ func (d derive[In, Out]) loop(ctx context.Context, _ cell.Health) error {
 				return err
 			}
 		}
+
+		if d.markInit != nil {
+			if ok, ch := d.InTable.Initialized(wtxn); ok {
+				d.markInit(wtxn)
+				d.markInit = nil
+			} else {
+				init = ch
+			}
+		}
+
 		wtxn.Commit()
 
 		select {
 		case <-watch:
+		case <-init:
 		case <-ctx.Done():
 			return nil
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -296,7 +296,7 @@ github.com/cilium/lumberjack/v2
 ## explicit; go 1.23.0
 github.com/cilium/proxy/go/cilium/api
 github.com/cilium/proxy/pkg/policy/api/kafka
-# github.com/cilium/statedb v0.5.8
+# github.com/cilium/statedb v0.5.9
 ## explicit; go 1.24
 github.com/cilium/statedb
 github.com/cilium/statedb/index


### PR DESCRIPTION
v0.5.9 extends [statedb.Derive] to propagate the initialization signal from the upstream table to the downstream table.
