### PR TITLE
pkg/bpf: introduce [bpf.IterableMap] interface to simplify mock testing

### DIFF
--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -933,10 +933,17 @@ func (m *Map) DumpReliablyWithCallback(cb DumpCallback, stats *DumpStats) error 
 	return ErrMaxLookup
 }
 
+// IterableMap is a map that can be iterated through [BatchIterator].
+type IterableMap interface {
+	BatchLookup(cursor *ebpf.MapBatchCursor, keysOut, valuesOut any, opts *ebpf.BatchOptions) (int, error)
+	MaxEntries() uint32
+	Type() ebpf.MapType
+}
+
 // BatchIterator provides a typed wrapper *Map that allows for batched iteration
 // of bpf maps.
 type BatchIterator[KT, VT any, KP KeyPointer[KT], VP ValuePointer[VT]] struct {
-	m    *Map
+	m    IterableMap
 	err  error
 	keys []KT
 	vals []VT
@@ -974,7 +981,7 @@ type BatchIterator[KT, VT any, KP KeyPointer[KT], VP ValuePointer[VT]] struct {
 //	for k, v := range iter.IterateAll(context.TODO()) {
 //		// ...
 //	}
-func NewBatchIterator[KT any, VT any, KP KeyPointer[KT], VP ValuePointer[VT]](m *Map) *BatchIterator[KT, VT, KP, VP] {
+func NewBatchIterator[KT any, VT any, KP KeyPointer[KT], VP ValuePointer[VT]](m IterableMap) *BatchIterator[KT, VT, KP, VP] {
 	return &BatchIterator[KT, VT, KP, VP]{
 		m: m,
 	}


### PR DESCRIPTION
Currently, [bpf.NewBatchIterator] takes a pointer to the [bpf.Map] structure, which has the downside of preventing the usage of a mock implementation for testing, even if the API surface actually used is relatively small. Let's improve this by introducing a dedicated [bpf.IterableMap] interface, and using that instead.