### PR TITLE
gha: fail fast in external-target provisioning scripts instead of swallowing failures

### DIFF
--- a/.github/actions/generic-external-targets/action.sh
+++ b/.github/actions/generic-external-targets/action.sh
@@ -27,8 +27,10 @@ openssl req -newkey rsa:2048 -nodes \
     -out external-service.cilium.req.pem
 
 # Figure out the addresses of the external nodes.
-mapfile -d ' ' -t IPTARGET < <(kubectl get nodes -l cilium.io/no-schedule=true -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
-mapfile -d ' ' -t IPOTHERTARGET < <(kubectl get nodes -l cilium.io/no-schedule=true -o jsonpath='{.items[1].status.addresses[?(@.type=="InternalIP")].address}')
+IPTARGET_RAW=$(kubectl get nodes -l cilium.io/no-schedule=true -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+IPOTHERTARGET_RAW=$(kubectl get nodes -l cilium.io/no-schedule=true -o jsonpath='{.items[1].status.addresses[?(@.type=="InternalIP")].address}')
+mapfile -d ' ' -t IPTARGET < <(printf '%s' "$IPTARGET_RAW")
+mapfile -d ' ' -t IPOTHERTARGET < <(printf '%s' "$IPOTHERTARGET_RAW")
 
 # Create a config file to tell openssl how to turn the signing request into a certificate
 # Make sure the key usage is such that we can use the cert for HTTPS traffic.
@@ -52,7 +54,8 @@ openssl x509 -req -days 365 -set_serial 01 \
     -CAkey ca-key.pem
 
 # Start the external targets.
-mapfile -t NODES_WITHOUT_CILIUM < <(kubectl get nodes -l cilium.io/no-schedule=true -o name | sed 's@^node/@@')
+NODES_WITHOUT_CILIUM_RAW=$(kubectl get nodes -l cilium.io/no-schedule=true -o name | sed 's@^node/@@')
+mapfile -t NODES_WITHOUT_CILIUM < <(printf '%s' "$NODES_WITHOUT_CILIUM_RAW")
 
 kubectl create ns external
 NGINX_CERT_BASE64="$(base64 -w0 external-service.cilium.crt)" \

--- a/.github/actions/kind-external-network/action.sh
+++ b/.github/actions/kind-external-network/action.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 LVH="$1"
 
 lvh_wrapper() {

--- a/.github/actions/kind-external-targets/action.sh
+++ b/.github/actions/kind-external-targets/action.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 LVH="$1"
 KINDNETWORK="$2"
 IP4TARGET="$3"
@@ -13,6 +15,20 @@ lvh_wrapper() {
 	else
 		"$@"
 	fi
+}
+
+# Run the given command, retrying up to 5 times on failure.
+retry() {
+	local attempt
+	for attempt in $(seq 1 5); do
+		if "$@"; then
+			return 0
+		fi
+		echo "Attempt ${attempt}/5 of '$*' failed, retrying in 5s..." >&2
+		sleep 5
+	done
+	echo "::error::Command '$*' failed after 5 attempts" >&2
+	return 1
 }
 
 TARGETNAME=fake.external.service.cilium
@@ -113,20 +129,29 @@ http {
 EOF
 
 # Start our first external target
-CONTAINERID=$(lvh_wrapper docker run -d --name webserver --network $KINDNETWORK \
+retry lvh_wrapper docker run -d --name webserver --network $KINDNETWORK \
     --ip $IP4TARGET --ip6 $IP6TARGET \
     -v ./nginx.conf:/etc/nginx/nginx.conf:ro \
     -v ./external-service.cilium.crt:/etc/ssl/external-service.cilium.crt:ro \
     -v ./external-service.cilium.key:/etc/ssl/external-service.cilium.key:ro \
-    nginx)
+    nginx
 
 # Start the second external target
-CONTAINERID=$(lvh_wrapper docker run -d --name other-webserver --network $KINDNETWORK \
+retry lvh_wrapper docker run -d --name other-webserver --network $KINDNETWORK \
     --ip $IP4OTHERTARGET --ip6 $IP6OTHERTARGET \
     -v ./nginx.conf:/etc/nginx/nginx.conf:ro \
     -v ./external-service.cilium.crt:/etc/ssl/external-service.cilium.crt:ro \
     -v ./external-service.cilium.key:/etc/ssl/external-service.cilium.key:ro \
-    nginx)
+    nginx
+
+# Fail fast if either target did not actually come up.
+for container in webserver other-webserver; do
+	running=$(lvh_wrapper docker inspect -f '{{.State.Running}}' "$container")
+	if [ "$running" != "true" ]; then
+		echo "::error::External target container '$container' is not running (State.Running=$running)" >&2
+		exit 1
+	fi
+done
 
 # Get the current CoreDNS config file
 kubectl -n kube-system get configmap/coredns -o json | jq ".data.Corefile" -r  > Corefile

--- a/.github/actions/renovate/entrypoint.sh
+++ b/.github/actions/renovate/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 apt update
 
 apt install -y gettext docker-buildx
@@ -12,7 +14,8 @@ ls -lah /var/run/docker.sock
 
 # Add the group of /var/run/docker.sock to ubuntu user
 GROUP_ID=$(stat -c '%g' /var/run/docker.sock)
-GROUP_NAME=$(getent group "$GROUP_ID" | cut -d: -f1)
+# getent exits non-zero when no group matches the id, which is expected here.
+GROUP_NAME=$(getent group "$GROUP_ID" | cut -d: -f1 || true)
 
 if [ -z "$GROUP_NAME" ]; then
   GROUP_NAME="docker_group"


### PR DESCRIPTION
Run 29087267507 timed out with every egress-to-external connectivity test failing on `curl (28)`. The targets were never up: a transient Docker Hub 5xx while pulling `nginx` failed the `docker run` in `kind-external-targets/action.sh`, but the failure went unnoticed. The script is invoked as `bash action.sh`, which does not inherit errexit from the calling step, and it has no `set -e` of its own, so the failed command substitution was swallowed. Provisioning then patched CoreDNS to point at targets that were never listening and exited 0, so the step went green with nothing running behind it.

That is the pattern this fixes, and `kind-external-targets` is not the only place it exists. Every standalone `.sh` under `.github/actions/` that runs failure-prone provisioning commands (docker, kubectl, apt) had the same exposure, because errexit is a per-shell attribute that the child `bash` running the script never picks up from the composite-action step.

`kind-external-targets` now sets errexit/nounset/pipefail, retries each nginx `docker run` a few times so a transient Docker Hub error rides out rather than sinking the run, and asserts both containers are actually running before it touches CoreDNS. `kind-external-network` has the identical shape one action upstream: a failed `docker network inspect` or `docker network create` was swallowed and the script still exported `kind_network=external` for a network that never came up, only to fail far downstream when kind tried to use it; it gets the same errexit/nounset/pipefail treatment. `generic-external-targets` already runs under `set -eu -o pipefail`, but pipefail does not reach into a `mapfile < <(kubectl ...)` process substitution and mapfile returns 0 regardless, so a kubectl failure there was masked and only surfaced later as a confusing unbound-variable error; the kubectl calls now go through checked command substitutions before being split, with the splitting behaviour unchanged. The renovate entrypoint runs with no errexit either, so a failed apt/setup step left renovate running in a half-provisioned environment; it now fails fast, with the one intentionally-failing `getent` lookup guarded so its fallback still works.

The two external-target/network scripts carry the same bug on v1.18 and v1.19 and are used by CI there, so they need backporting; the scripts do not exist on v1.17, `generic-external-targets` is main-only, and the renovate change is only exercised on the default branch.

This PR was prepared with AIL:3. I directed the design and reviewed all generated code.
