### PR TITLE
gateway-api: remove SetAllParentCondition route helpers

### DIFF
--- a/operator/pkg/gateway-api/routechecks/grpcroute.go
+++ b/operator/pkg/gateway-api/routechecks/grpcroute.go
@@ -148,18 +148,6 @@ func (g *GRPCRouteInput) SetParentCondition(ref gatewayv1beta1.ParentReference, 
 	})
 }
 
-func (g *GRPCRouteInput) SetAllParentCondition(condition metav1.Condition) {
-	// fill in the condition
-	condition.LastTransitionTime = metav1.NewTime(time.Now())
-	condition.ObservedGeneration = g.GRPCRoute.GetGeneration()
-
-	for _, parent := range g.GRPCRoute.Spec.ParentRefs {
-		g.mergeStatusConditions(parent, []metav1.Condition{
-			condition,
-		})
-	}
-}
-
 func (g *GRPCRouteInput) Log() *slog.Logger {
 	return g.Logger
 }

--- a/operator/pkg/gateway-api/routechecks/httproute.go
+++ b/operator/pkg/gateway-api/routechecks/httproute.go
@@ -44,18 +44,6 @@ func (h *HTTPRouteInput) SetParentCondition(ref gatewayv1.ParentReference, condi
 	})
 }
 
-func (h *HTTPRouteInput) SetAllParentCondition(condition metav1.Condition) {
-	// fill in the condition
-	condition.LastTransitionTime = metav1.NewTime(time.Now())
-	condition.ObservedGeneration = h.HTTPRoute.GetGeneration()
-
-	for _, parent := range h.HTTPRoute.Spec.ParentRefs {
-		h.mergeStatusConditions(parent, []metav1.Condition{
-			condition,
-		})
-	}
-}
-
 func (h *HTTPRouteInput) mergeStatusConditions(parentRef gatewayv1.ParentReference, updates []metav1.Condition) {
 	index := -1
 	for i, parent := range h.HTTPRoute.Status.RouteStatus.Parents {

--- a/operator/pkg/gateway-api/routechecks/tcproute.go
+++ b/operator/pkg/gateway-api/routechecks/tcproute.go
@@ -40,18 +40,6 @@ func (t *TCPRouteInput) SetParentCondition(ref gatewayv1.ParentReference, condit
 	})
 }
 
-func (t *TCPRouteInput) SetAllParentCondition(condition metav1.Condition) {
-	// fill in the condition
-	condition.LastTransitionTime = metav1.NewTime(time.Now())
-	condition.ObservedGeneration = t.TCPRoute.GetGeneration()
-
-	for _, parent := range t.TCPRoute.Spec.ParentRefs {
-		t.mergeStatusConditions(parent, []metav1.Condition{
-			condition,
-		})
-	}
-}
-
 func (t *TCPRouteInput) mergeStatusConditions(parentRef gatewayv1.ParentReference, updates []metav1.Condition) {
 	index := -1
 	for i, parent := range t.TCPRoute.Status.RouteStatus.Parents {

--- a/operator/pkg/gateway-api/routechecks/tlsroute.go
+++ b/operator/pkg/gateway-api/routechecks/tlsroute.go
@@ -41,18 +41,6 @@ func (t *TLSRouteInput) SetParentCondition(ref gatewayv1.ParentReference, condit
 	})
 }
 
-func (t *TLSRouteInput) SetAllParentCondition(condition metav1.Condition) {
-	// fill in the condition
-	condition.LastTransitionTime = metav1.NewTime(time.Now())
-	condition.ObservedGeneration = t.TLSRoute.GetGeneration()
-
-	for _, parent := range t.TLSRoute.Spec.ParentRefs {
-		t.mergeStatusConditions(parent, []metav1.Condition{
-			condition,
-		})
-	}
-}
-
 func (t *TLSRouteInput) mergeStatusConditions(parentRef gatewayv1.ParentReference, updates []metav1.Condition) {
 	index := -1
 	for i, parent := range t.TLSRoute.Status.RouteStatus.Parents {

--- a/operator/pkg/gateway-api/routechecks/udproute.go
+++ b/operator/pkg/gateway-api/routechecks/udproute.go
@@ -40,18 +40,6 @@ func (u *UDPRouteInput) SetParentCondition(ref gatewayv1.ParentReference, condit
 	})
 }
 
-func (u *UDPRouteInput) SetAllParentCondition(condition metav1.Condition) {
-	// fill in the condition
-	condition.LastTransitionTime = metav1.NewTime(time.Now())
-	condition.ObservedGeneration = u.UDPRoute.GetGeneration()
-
-	for _, parent := range u.UDPRoute.Spec.ParentRefs {
-		u.mergeStatusConditions(parent, []metav1.Condition{
-			condition,
-		})
-	}
-}
-
 func (u *UDPRouteInput) mergeStatusConditions(parentRef gatewayv1.ParentReference, updates []metav1.Condition) {
 	index := -1
 	for i, parent := range u.UDPRoute.Status.RouteStatus.Parents {

--- a/operator/pkg/gateway-api/status_route_test.go
+++ b/operator/pkg/gateway-api/status_route_test.go
@@ -84,11 +84,17 @@ func TestPruneRouteParentStatuses(t *testing.T) {
 	require.Equal(t, otherControllerDetachedParent, route.Status.Parents[1].ParentRef)
 	require.Equal(t, currentParentStatus, route.Status.Parents[2].ParentRef)
 
-	input.SetAllParentCondition(metav1.Condition{
-		Type:   string(gatewayv1.RouteConditionAccepted),
-		Status: metav1.ConditionTrue,
-		Reason: string(gatewayv1.RouteReasonAccepted),
-	})
+	acceptedCond := metav1.Condition{
+		Type:               string(gatewayv1.RouteConditionAccepted),
+		Status:             metav1.ConditionTrue,
+		Reason:             string(gatewayv1.RouteReasonAccepted),
+		ObservedGeneration: input.HTTPRoute.GetGeneration(),
+		LastTransitionTime: metav1.Now(),
+	}
+
+	for _, parent := range input.HTTPRoute.Spec.ParentRefs {
+		input.SetParentCondition(parent, acceptedCond)
+	}
 
 	require.Len(t, route.Status.Parents, 3, "merge alone keeps both detached statuses")
 	require.Equal(t, ourDetachedParent, route.Status.Parents[0].ParentRef, "merge alone keeps both detached statuses")


### PR DESCRIPTION
Follow up to: https://github.com/cilium/cilium/pull/47005#discussion_r3554725980

Removes SetAllParentCondition helper from Route structs. Conditions should be returned from validators and set on parents only after pruneRouteParentStatuses is called to ensure we aren't setting status for parents we do not own (e.g. not managed by cilium).

cc @mhofstetter 