### PR TITLE
cilium-cli: Exclude vendored leader election error

### DIFF
--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -54,7 +54,8 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, extraExc
 	errorLogExceptions := []logMatcher{
 		stringMatcher("Error in delegate stream, restarting"),
 		failedToUpdateLock, failedToReleaseLock,
-		failedToListCRDs, knownIssueWireguardCollision, nilDetailsForService, gobgpFailedCloseTCP}
+		failedToListCRDs, knownIssueWireguardCollision, nilDetailsForService, gobgpFailedCloseTCP,
+		vendoredLeaderElectionLeaseLockError}
 
 	envoyExternalTargetTLSWarning := regexMatcher{regexp.MustCompile(fmt.Sprintf(envoyTLSWarningTemplate, externalTarget))}
 	envoyExternalOtherTargetTLSWarning := regexMatcher{regexp.MustCompile(fmt.Sprintf(envoyTLSWarningTemplate, externalOtherTarget))}
@@ -513,6 +514,8 @@ var (
 	// while we fix this issue.
 	// TODO: Remove this after: #31535 has been fixed.
 	knownIssueWireguardCollision = regexMatcher{regexp.MustCompile("Cannot forward proxied DNS lookup.*:51871.*bind: address already in use")} // from: https://github.com/cilium/cilium/issues/30901
+	// This error originates from vendored client-go code and is retried by its leader election loop.
+	vendoredLeaderElectionLeaseLockError = regexMatcher{regexp.MustCompile(`vendor/k8s\.io/client-go/tools/leaderelection/leaderelection\.go:\d+.*msg="Error retrieving lease lock"`)}
 	// Cf. https://github.com/cilium/cilium/issues/35803
 	endpointMapDeleteFailed = regexMatcher{regexp.MustCompile(`Ignoring error while deleting endpoint.*from map cilium_\w+: delete: key does not exist`)}
 	// envoyTLSWarningTemplate is the legitimate warning log for negative TLS SNI test case

--- a/cilium-cli/connectivity/tests/errors_test.go
+++ b/cilium-cli/connectivity/tests/errors_test.go
@@ -164,6 +164,34 @@ func TestGoBGPv4FailedToSendMatcher(t *testing.T) {
 	}
 }
 
+func TestLeaderElectionLeaseLockErrorMatcher(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		log       string
+		wantMatch bool
+	}{
+		{
+			name:      "ignored: client-go leader election lease retrieval failure",
+			log:       `time=2026-07-10T15:06:16Z level=error source=/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go:461 msg="Error retrieving lease lock" subsys=klog error="Client.Timeout exceeded while awaiting headers"`,
+			wantMatch: true,
+		},
+		{
+			name:      "reported: same message from another package",
+			log:       `time=2026-07-10T15:06:16Z level=error source=/go/src/github.com/cilium/cilium/operator/pkg/leader/leader.go:42 msg="Error retrieving lease lock" subsys=klog`,
+			wantMatch: false,
+		},
+		{
+			name:      "reported: another client-go leader election error",
+			log:       `time=2026-07-10T15:06:16Z level=error source=/go/src/github.com/cilium/cilium/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go:461 msg="Failed to renew lease" subsys=klog`,
+			wantMatch: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantMatch, vendoredLeaderElectionLeaseLockError.IsMatch(tt.log))
+		})
+	}
+}
+
 func TestExtractPathFromLog(t *testing.T) {
 	_, thisPath, _, _ := runtime.Caller(0)
 	repoDir, _ := filepath.Abs(filepath.Join(thisPath, "..", "..", "..", ".."))


### PR DESCRIPTION
Do not fail the CI for vendored leader election error message, if the tests pass otherwise.

AIL:3
