### PR TITLE
images/builder: Base on Ubuntu directly instead of the runtime image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Cilium",
-  "image": "quay.io/cilium/cilium-builder:39429894243c8cb291bbd55f91e9747da795eaac@sha256:4e43f3e5b6c8541e2a0241828342c65b0c136e67a4dbce264a26ac1f6eb4b893",
+  "image": "quay.io/cilium/cilium-builder:5d708e8fa184421af3d98a69a23b0600210c7b74@sha256:a03269d07dc6909df859525f153b21df9cdc8168317af61c9d85af16da0c938e",
   "workspaceFolder": "/go/src/github.com/cilium/cilium",
   "workspaceMount": "source=${localWorkspaceFolder},target=/go/src/github.com/cilium/cilium,type=bind",
   "features": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Cilium",
-  "image": "quay.io/cilium/cilium-builder:8398ec631aeeb622c44654c3c6220a465ebdbe51@sha256:e48cbde32038e4be9153e1743c6ae7b61df65d552420ec4e21b987710964b7a8",
+  "image": "quay.io/cilium/cilium-builder:2db810de99c504c5eb4c51baf7e836acb38d0050@sha256:8e62d9e0921c81ba4cd7f3a01ef736ae34c002fe0ab3f670e61585e46b2bbf9f",
   "workspaceFolder": "/go/src/github.com/cilium/cilium",
   "workspaceMount": "source=${localWorkspaceFolder},target=/go/src/github.com/cilium/cilium,type=bind",
   "features": {

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -191,7 +191,7 @@ jobs:
             rm -rf /usr/local/go
 
             # The LVH image ships with LLVM taken from a release Cilium version.
-            # Replace it with the one extracted from the cilium-builder image.
+            # Replace it with the one extracted from the cilium-llvm image.
             /host/base/contrib/scripts/extract-llvm.sh /var/tmp/llvm
             mv /var/tmp/llvm/usr/local/bin/{clang,llc} /bin/
             rm -r /var/tmp/llvm

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -193,7 +193,7 @@ jobs:
             rm -rf /usr/local/go
 
             # The LVH image ships with LLVM taken from a release Cilium version.
-            # Replace it with the one extracted from the cilium-builder image.
+            # Replace it with the one extracted from the cilium-llvm image.
             /host/base/contrib/scripts/extract-llvm.sh /var/tmp/llvm
             mv /var/tmp/llvm/usr/local/bin/{clang,llc} /bin/
             rm -r /var/tmp/llvm

--- a/Documentation/contributing/development/images.rst
+++ b/Documentation/contributing/development/images.rst
@@ -105,23 +105,18 @@ Images dependency:
 ::
 
     cilium/cilium
-    └── cilium/cilium-builder
-        └── cilium/cilium-runtime
-            ├── cilium/cilium-bpftool
-            └── cilium/cilium-llvm
+    ├── cilium/cilium-builder
+    │   └── cilium/cilium-llvm
+    └── cilium/cilium-runtime
+        ├── cilium/cilium-bpftool
+        └── cilium/cilium-llvm
 
     cilium/cilium-envoy
     └── cilium/cilium-envoy-builder
-        └── cilium/cilium-builder
-            └── cilium/cilium-runtime
-                ├── cilium/cilium-bpftool
-                └── cilium/cilium-llvm
 
     cilium/operator
     └── cilium/cilium-builder
-        └── cilium/cilium-runtime
-            ├── cilium/cilium-bpftool
-            └── cilium/cilium-llvm
+        └── cilium/cilium-llvm
 
 
 
@@ -153,7 +148,6 @@ different value and then proceed with the steps below.
 
 #. Ping one of the members of `team/build <https://github.com/orgs/cilium/teams/build/members>`__
    to approve the build that was created by GitHub Actions `here <https://github.com/cilium/cilium/actions?query=workflow:%22Base+Image+Release+Build%22>`__.
-   Note that at this step cilium-builder build failure is expected since we have yet to update the runtime digest.
 
 #. Wait for build to complete. If the PR was opened from an external fork the
    build will fail while trying to push the changes, this is expected.

--- a/contrib/scripts/extract-llvm.sh
+++ b/contrib/scripts/extract-llvm.sh
@@ -6,7 +6,7 @@ OUT=${1:-"$PWD"}
 
 cd "$(dirname "$0")/../.."
 
-IMAGE=$(cat images/cilium/Dockerfile | grep '^ARG CILIUM_BUILDER_IMAGE=' | cut -d '=' -f 2)
+IMAGE=$(cat images/runtime/Dockerfile | grep '^ARG CILIUM_LLVM_IMAGE=' | cut -d '=' -f 2)
 NAME=$(docker create "$IMAGE" /bin/true)
 trap 'docker rm "$NAME" > /dev/null' EXIT
 mkdir -p "$OUT"

--- a/images/README.md
+++ b/images/README.md
@@ -9,24 +9,30 @@ anyone reading this document should also read [`cilium/image-tools` documentatio
 
 ### [`builder`](builder/Dockerfile)
 
-This image is based on `runtime` image.
+This image is based on the Ubuntu image.
 
-It adds `protoc` and plugins and the Go toolchain.
+It adds `protoc` and plugins, the Go toolchain, the cross-compilation
+toolchains, and the `clang` compiler (from the [`llvm`](https://github.com/cilium/image-tools#imagesllvm)
+image) used to build the BPF datapath.
 
 ### [`runtime`](runtime/Dockerfile)
 
-This image is based on [`bpftool`](https://github.com/cilium/image-tools#imagesbpftool),
-and [`llvm`](https://github.com/cilium/image-tools#imagesllvm) from `cilium/image-tools`.
+This image is based on the Ubuntu image. It provides the user-space the
+`cilium-agent` needs at runtime: networking tooling (`iproute2`, `iptables`,
+`ipset`, `kmod`), the `clang`/`llc` toolchain (from the [`llvm`](https://github.com/cilium/image-tools#imagesllvm) image)
+and [`bpftool`](https://github.com/cilium/image-tools#imagesbpftool) (both from
+`cilium/image-tools`) used to compile and inspect the BPF datapath on the node,
+and the CNI loopback plugin.
 
-At present, it also includes [`gops`](https://github.com/google/gops) for
-debugging as well as Ubuntu user-space for troubleshooting.
+It also includes [`gops`](https://github.com/google/gops) for debugging as well
+as Ubuntu user-space for troubleshooting.
 
 ### [`cilium`](cilium/Dockerfile)
 
-It includes `cilium-agent` and other binaries, including `cilium`, `envoy`,
+It includes `cilium-agent` and other binaries, including `cilium-dbg`, `envoy`,
 `cilium-health` and `hubble-cli`.
 
-This image is based on `runtime` image, and it contains Ubuntu user-space for
+This image is based on the `runtime` image, and it contains Ubuntu user-space for
 troubleshooting.
 
 ### [`operator`](operator/Dockerfile)
@@ -34,13 +40,11 @@ troubleshooting.
 This image includes only `cilium-operator` binaries (plus CA certificates),
 no other binaries or libraries are included.
 
-For other operators such as: aws, aks, generic, a copy of the same Dockerfile is
-used on all of them. Ideally we will re-use the same Dockerfile to build all the
-different operators.
+That same Dockerfile is used to build other operator variants (alibabacloud, aws, azure and generic) based on the value of the `OPERATOR_VARIANT` build-arg.
 
 ### [`hubble-relay`](hubble-relay/Dockerfile)
 
-This image includes only `hubble-relay` binary (plus CA certificates), no other
+This image includes only the `hubble-relay` binary (plus CA certificates), no other
 binaries or libraries are included.
 
 ## Tooling

--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG COMPILERS_IMAGE=quay.io/cilium/image-compilers:1782994507-725357c@sha256:004fa5966bba637f748bc7fa129ad61500b43410177f11f590a75b29431279de
-ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:9fb4b62767149e8cd391f9341f166b6fe03423fa@sha256:2b7598259ecd021662106e03dc11aca4e437d81732b565b9e1dee2792b2efcd8
+ARG UBUNTU_IMAGE=docker.io/library/ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
 ARG TESTER_IMAGE=quay.io/cilium/image-tester:1782916218-36ae25f@sha256:238a8309872dc1905bf559f6a7ed5101775aa38ed920cf992184af557b1e5f53
 ARG GOLANG_IMAGE=docker.io/library/golang:1.26.5@sha256:63f132d58c1f589f0dcda584933a9bb44bfda1150f1506377f5a902f34d86033
 ARG CILIUM_LLVM_IMAGE=quay.io/cilium/cilium-llvm:19.1.7-1782898005-bed4da5@sha256:270bf0e70853c388b72c2247e4ade91d35d74898e2ec12edd5b72ace9ee34333
@@ -15,7 +15,7 @@ FROM ${GOLANG_IMAGE} AS golang-dist
 
 FROM ${CILIUM_LLVM_IMAGE} AS llvm-dist
 
-FROM ${CILIUM_RUNTIME_IMAGE} AS rootfs
+FROM ${UBUNTU_IMAGE} AS rootfs
 
 # Change the number to force the generation of a new git-tree SHA. Useful when
 # we want to re-run 'apt-get upgrade' for stale images.
@@ -24,6 +24,7 @@ ENV FORCE_BUILD=1
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETARCH
 RUN \
+    export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     apt-get upgrade -y --no-install-recommends && \
     apt-get install -y --no-install-recommends \
@@ -40,6 +41,7 @@ RUN \
     unzip \
     # Base Cilium-build dependencies
     binutils \
+    ca-certificates \
     coreutils \
     curl \
     gcc \
@@ -84,8 +86,13 @@ WORKDIR /go/src/github.com/cilium/cilium/images/builder
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium/images/builder \
     ./install-test-formatters.sh
 
-# used to facilitate the verifier tests
-COPY --from=llvm-dist /usr/local/bin/llvm-objcopy /usr/local/bin/llvm-strip /bin/
+# clang compiles the BPF datapath in the builder (e.g. 'make -C bpf build_all',
+# 'make run_bpf_tests')
+# llvm-objcopy/llvm-strip are used by the BPF Go tests (pkg/bpf/testdata).
+# llc is intentionally not copied: the BPF build is clang-only, and the datapath
+# verifier tests extract the toolchain from the cilium-llvm image (see
+# contrib/scripts/extract-llvm.sh), not from this image.
+COPY --from=llvm-dist /usr/local/bin/clang /usr/local/bin/llvm-objcopy /usr/local/bin/llvm-strip /bin/
 
 # Create a cache directory with 777 so that we can run the builder image and
 # compile golang code from any UID.

--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:2d07594c8751abfdd7c1ce5d8d6626d6e9049f6c@sha256:f34841d908bc365dd7233a8858fce9abde9d824044402a3ca398521acec61ebc
+ARG UBUNTU_IMAGE=docker.io/library/ubuntu:26.04@sha256:2260313b31c8c011cd2eebe728008efac1b3982be73eb71348ea2648d2c0e09b
 ARG TESTER_IMAGE=quay.io/cilium/image-tester:1787138071-3b8cd9a@sha256:d460f28d759ec06f5e7fbc9a91ef7f556d84f6e763f8b78ca128907455ffbc7c
 ARG GOLANG_IMAGE=docker.io/library/golang:1.27.0@sha256:65b6f280bf050ec5af12716857e8ea8439d694dbba8f31ceeb7630670071f2bb
 ARG CILIUM_LLVM_IMAGE=quay.io/cilium/cilium-llvm:19.1.7-1785833026-d8383c5@sha256:80ae6ceb1a1556d5f65f7a086d873c4706ed548444c4d49d89cbeedf24f817d4
@@ -12,7 +12,7 @@ FROM ${GOLANG_IMAGE} AS golang-dist
 
 FROM ${CILIUM_LLVM_IMAGE} AS llvm-dist
 
-FROM ${CILIUM_RUNTIME_IMAGE} AS rootfs
+FROM ${UBUNTU_IMAGE} AS rootfs
 
 # Change the number to force the generation of a new git-tree SHA. Useful when
 # we want to re-run 'apt-get upgrade' for stale images.
@@ -21,6 +21,7 @@ ENV FORCE_BUILD=1
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETARCH
 RUN \
+    export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     apt-get upgrade -y --no-install-recommends && \
     apt-get install -y --no-install-recommends \
@@ -37,6 +38,7 @@ RUN \
     unzip \
     # Base Cilium-build dependencies
     binutils \
+    ca-certificates \
     coreutils \
     curl \
     gcc \
@@ -79,8 +81,13 @@ WORKDIR /go/src/github.com/cilium/cilium/images/builder
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium/images/builder \
     ./install-test-formatters.sh
 
-# used to facilitate the verifier tests
-COPY --from=llvm-dist /usr/local/bin/llvm-objcopy /usr/local/bin/llvm-strip /bin/
+# clang compiles the BPF datapath in the builder (e.g. 'make -C bpf build_all',
+# 'make run_bpf_tests')
+# llvm-objcopy/llvm-strip are used by the BPF Go tests (pkg/bpf/testdata).
+# llc is intentionally not copied: the BPF build is clang-only, and the datapath
+# verifier tests extract the toolchain from the cilium-llvm image (see
+# contrib/scripts/extract-llvm.sh), not from this image.
+COPY --from=llvm-dist /usr/local/bin/clang /usr/local/bin/llvm-objcopy /usr/local/bin/llvm-strip /bin/
 
 # Create a cache directory with 777 so that we can run the builder image and
 # compile golang code from any UID.

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:39429894243c8cb291bbd55f91e9747da795eaac@sha256:4e43f3e5b6c8541e2a0241828342c65b0c136e67a4dbce264a26ac1f6eb4b893
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:5d708e8fa184421af3d98a69a23b0600210c7b74@sha256:a03269d07dc6909df859525f153b21df9cdc8168317af61c9d85af16da0c938e
 ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:9fb4b62767149e8cd391f9341f166b6fe03423fa@sha256:2b7598259ecd021662106e03dc11aca4e437d81732b565b9e1dee2792b2efcd8
 #
 # cilium-envoy from github.com/cilium/proxy

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:8398ec631aeeb622c44654c3c6220a465ebdbe51@sha256:e48cbde32038e4be9153e1743c6ae7b61df65d552420ec4e21b987710964b7a8
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:2db810de99c504c5eb4c51baf7e836acb38d0050@sha256:8e62d9e0921c81ba4cd7f3a01ef736ae34c002fe0ab3f670e61585e46b2bbf9f
 ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:2d07594c8751abfdd7c1ce5d8d6626d6e9049f6c@sha256:f34841d908bc365dd7233a8858fce9abde9d824044402a3ca398521acec61ebc
 #
 # cilium-envoy from github.com/cilium/proxy

--- a/images/hubble-relay/Dockerfile
+++ b/images/hubble-relay/Dockerfile
@@ -7,7 +7,7 @@
 # $ cosign verify $IMAGE_NAME --certificate-oidc-issuer https://accounts.google.com --certificate-identity keyless@distroless.iam.gserviceaccount.com
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:d29e660cc75a5b6b1334e03c5c81ccf9bc0884a002c6000dbf0fb96034814478
 ARG GOLANG_IMAGE=docker.io/library/golang:1.26.5@sha256:63f132d58c1f589f0dcda584933a9bb44bfda1150f1506377f5a902f34d86033
-ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:39429894243c8cb291bbd55f91e9747da795eaac@sha256:4e43f3e5b6c8541e2a0241828342c65b0c136e67a4dbce264a26ac1f6eb4b893
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:5d708e8fa184421af3d98a69a23b0600210c7b74@sha256:a03269d07dc6909df859525f153b21df9cdc8168317af61c9d85af16da0c938e
 
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with

--- a/images/hubble-relay/Dockerfile
+++ b/images/hubble-relay/Dockerfile
@@ -7,7 +7,7 @@
 # $ cosign verify $IMAGE_NAME --certificate-oidc-issuer https://accounts.google.com --certificate-identity keyless@distroless.iam.gserviceaccount.com
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:1c2c046bc09ed40fad370b599a0b1ae7987f55b01e247cf27a7c27cd97e5bbc7
 ARG GOLANG_IMAGE=docker.io/library/golang:1.27.0@sha256:65b6f280bf050ec5af12716857e8ea8439d694dbba8f31ceeb7630670071f2bb
-ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:8398ec631aeeb622c44654c3c6220a465ebdbe51@sha256:e48cbde32038e4be9153e1743c6ae7b61df65d552420ec4e21b987710964b7a8
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:2db810de99c504c5eb4c51baf7e836acb38d0050@sha256:8e62d9e0921c81ba4cd7f3a01ef736ae34c002fe0ab3f670e61585e46b2bbf9f
 
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -6,7 +6,7 @@
 ARG BASE_IMAGE=scratch
 ARG GOLANG_IMAGE=docker.io/library/golang:1.26.5@sha256:63f132d58c1f589f0dcda584933a9bb44bfda1150f1506377f5a902f34d86033
 ARG ALPINE_IMAGE=docker.io/library/alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
-ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:39429894243c8cb291bbd55f91e9747da795eaac@sha256:4e43f3e5b6c8541e2a0241828342c65b0c136e67a4dbce264a26ac1f6eb4b893
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:5d708e8fa184421af3d98a69a23b0600210c7b74@sha256:a03269d07dc6909df859525f153b21df9cdc8168317af61c9d85af16da0c938e
 
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -6,7 +6,7 @@
 ARG BASE_IMAGE=scratch
 ARG GOLANG_IMAGE=docker.io/library/golang:1.27.0@sha256:65b6f280bf050ec5af12716857e8ea8439d694dbba8f31ceeb7630670071f2bb
 ARG ALPINE_IMAGE=docker.io/library/alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
-ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:8398ec631aeeb622c44654c3c6220a465ebdbe51@sha256:e48cbde32038e4be9153e1743c6ae7b61df65d552420ec4e21b987710964b7a8
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:2db810de99c504c5eb4c51baf7e836acb38d0050@sha256:8e62d9e0921c81ba4cd7f3a01ef736ae34c002fe0ab3f670e61585e46b2bbf9f
 
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with


### PR DESCRIPTION
Currently, both the cilium-agent and the cilium-builder images are based on the same shared cilium-runtime base. This is causing challenges because those two images have different destinations:
* The cilium-agent image is meant to be running in production, hence we want it to be as slim and light as possible (see #47065)
* The cilium-builder image is used in CI and development environments and as such is not optimized to be light but rather to be quite full, including exhaustive cross-arch compiler toolchains and various utils tools

This situation makes the common cilium-runtime base awkward: when we want to optimize the cilium-agent image, the leverage is at the source, but attempts to shrink the cilium-runtime base to achieve gains on the cilium-agent image cause problems for the cilium-builder image that needs what we want to remove from the cilium-agent image.

A concrete example of that situation can be observed in PR #46446: That PR aims to remove the package manager suite from the cilium-agent image. In order to achieve that, it removes it at the source in the cilium-runtime image. But doing so breaks the cilium-builder image that does need a package manager.

In order to unblock this situation, this PR changes the base of the cilium-builder image from the cilium-runtime image to a regular ubuntu base image. That way the cilium-runtime becomes only the base for the cilium-agent image and we can start applying slim-down optimizations there.

This change is possible because the cilium-builder did not actually require most of what the cilium-runtime image adds on top of its ubuntu base. The only additional needed components is the `clang` binary that is transferred from the pre-built LLVM image.

With this PR, the cilium-builder image no longer contains the following components:
* iptables
* iproute2
* ipset
* kmod
* gops
* the CNI loopback plugin
* the iptables-wrapper
* libatomic1
* bash-completion
* llc

I combed through the various CI steps that use the builder image and local development make targets and I don't think any of those need any of the above.

Along with that change, the `extract-llvm.sh` script used in CI to extract the LLVM toolchain gets updated to directly get it out of the cilium-llvm image instead of going through the cilium-builder one as a proxy.