### PR TITLE
fqdn/service: prune SDP identity->IP mapping on delete using newID

### DIFF
--- a/pkg/fqdn/service/service.go
+++ b/pkg/fqdn/service/service.go
@@ -469,12 +469,13 @@ func (s *FQDNDataServer) OnIPIdentityCacheChange(modType ipcache.CacheModificati
 			}
 			s.prefixLengths.Add([]netip.Prefix{prefix})
 		case ipcache.Delete:
-			if oldID != nil {
-				err := s.deleteFromIdentityToIPLocked(txn, oldID, prefix)
-				if err != nil {
-					s.log.Error("Failed to delete identity from identity to IP mapping", logfields.Error, err)
-					return
-				}
+			// On a delete the ipcache reports the removed identity in newID; oldID
+			// is nil for a plain delete. Prune newID's mapping so the prefix isn't
+			// left associated with a stale (garbage-collected) identity.
+			err := s.deleteFromIdentityToIPLocked(txn, &newID, prefix)
+			if err != nil {
+				s.log.Error("Failed to delete identity from identity to IP mapping", logfields.Error, err)
+				return
 			}
 		}
 	}

--- a/pkg/fqdn/service/service_test.go
+++ b/pkg/fqdn/service/service_test.go
@@ -606,7 +606,7 @@ func TestHandleIPUpsert(t *testing.T) {
 	// Expectation: currentIdentityToIP:{2: [1.2.3.4/32, 4.5.6.7/32]}
 	prefix4 := netip.MustParsePrefix("10.10.10.10/24")
 	validCIDR4 := types.NewPrefixCluster(prefix4, 0)
-	server.OnIPIdentityCacheChange(ipcache.Delete, validCIDR4, nil, nil, &dummyIdentity2, dummyIdentity2, 0, nil, 0)
+	server.OnIPIdentityCacheChange(ipcache.Delete, validCIDR4, nil, nil, nil, dummyIdentity2, 0, nil, 0)
 	identityToIP, _, found = server.identityToIPsTable.Get(server.db.ReadTxn(), idIndexIdentityToIP.Query(dummyIdentity2.ID))
 	require.True(t, found)
 	require.Equal(t, 3, identityToIP.IPs.Len())
@@ -615,7 +615,7 @@ func TestHandleIPUpsert(t *testing.T) {
 
 	// Call OnIPIdentityCacheChange with Delete for identity 2 and ip: 8.9.10.11/24.
 	// Expectation: currentIdentityToIP:{2: [1.2.3.4/32, 4.5.6.7/32]}
-	server.OnIPIdentityCacheChange(ipcache.Delete, validCIDR3, nil, nil, &dummyIdentity2, dummyIdentity2, 0, nil, 0)
+	server.OnIPIdentityCacheChange(ipcache.Delete, validCIDR3, nil, nil, nil, dummyIdentity2, 0, nil, 0)
 	identityToIP, _, found = server.identityToIPsTable.Get(server.db.ReadTxn(), idIndexIdentityToIP.Query(dummyIdentity2.ID))
 	require.True(t, found)
 	require.Equal(t, 2, identityToIP.IPs.Len())
@@ -624,7 +624,7 @@ func TestHandleIPUpsert(t *testing.T) {
 
 	// Call OnIPIdentityCacheChange with Delete for identity 2 and ip: 4.5.6.7/32.
 	// Expectation: currentIdentityToIP:{2: [1.2.3.4/32]}
-	server.OnIPIdentityCacheChange(ipcache.Delete, validCIDR2, nil, nil, &dummyIdentity2, dummyIdentity2, 0, nil, 0)
+	server.OnIPIdentityCacheChange(ipcache.Delete, validCIDR2, nil, nil, nil, dummyIdentity2, 0, nil, 0)
 	identityToIP, _, found = server.identityToIPsTable.Get(server.db.ReadTxn(), idIndexIdentityToIP.Query(dummyIdentity2.ID))
 	require.True(t, found)
 	require.Equal(t, 1, identityToIP.IPs.Len())
@@ -632,7 +632,7 @@ func TestHandleIPUpsert(t *testing.T) {
 
 	// Call again OnIPIdentityCacheChange with Delete for identity 2 and ip: 4.5.6.7/32.
 	// Expectation: currentIdentityToIP:{2: [1.2.3.4/32]}
-	server.OnIPIdentityCacheChange(ipcache.Delete, validCIDR2, nil, nil, &dummyIdentity2, dummyIdentity2, 0, nil, 0)
+	server.OnIPIdentityCacheChange(ipcache.Delete, validCIDR2, nil, nil, nil, dummyIdentity2, 0, nil, 0)
 	identityToIP, _, found = server.identityToIPsTable.Get(server.db.ReadTxn(), idIndexIdentityToIP.Query(dummyIdentity2.ID))
 	require.True(t, found)
 	require.Equal(t, 1, identityToIP.IPs.Len())
@@ -640,7 +640,7 @@ func TestHandleIPUpsert(t *testing.T) {
 
 	// Call again OnIPIdentityCacheChange with Delete for identity 2 and ip: 1.2.3.4/32.
 	// Expectation: currentIdentityToIP:{}
-	server.OnIPIdentityCacheChange(ipcache.Delete, validCIDR, nil, nil, &dummyIdentity2, dummyIdentity2, 0, nil, 0)
+	server.OnIPIdentityCacheChange(ipcache.Delete, validCIDR, nil, nil, nil, dummyIdentity2, 0, nil, 0)
 	identityToIP, _, found = server.identityToIPsTable.Get(server.db.ReadTxn(), idIndexIdentityToIP.Query(dummyIdentity2.ID))
 	require.False(t, found)
 


### PR DESCRIPTION
FQDNDataServer.OnIPIdentityCacheChange maintains the identity->IPs table that is streamed to the standalone DNS proxy (SDP). On an ipcache Delete it pruned the prefix from oldID, but the ipcache reports the removed identity in newID and passes oldID as nil for a plain delete (and for the delete-then-reuse of an IP). The `if oldID != nil` branch was therefore dead code: prefixes were never removed on delete and piled up under stale, garbage-collected identities. The SDP then resolved client/destination IPs to dead identities and rejected allowed DNS requests with REFUSED.

Prune newID on delete instead. The existing TestHandleIPUpsert already exercised the delete path but passed a non-nil oldID, which never happens in production and masked the bug; its delete calls now use oldID=nil to match the real ipcache contract, so the test fails without this fix.

AIL: 3

```release-note
fqdn/service: prune SDP identity->IP mapping on delete using newID 
```
