### PR TITLE
 operator/endpointslice: Fix races on defaultController

### DIFF
--- a/operator/pkg/ciliumendpointslice/endpointslice.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
@@ -5,6 +5,7 @@ package ciliumendpointslice
 
 import (
 	"context"
+	"slices"
 	"strconv"
 	"time"
 
@@ -68,8 +69,19 @@ func (c *Controller) initializeQueue() {
 		})
 }
 
+// isValidEndpoint reports whether a CiliumEndpoint has enough state to be
+// placed into a CES. Endpoints missing Networking/Identity are being
+// initialized by the agent and would produce invalid CoreCiliumEndpoint entries.
+func isValidEndpoint(cep *cilium_api_v2.CiliumEndpoint) bool {
+	return cep != nil &&
+		cep.Status.Networking != nil &&
+		cep.Status.Identity != nil &&
+		cep.GetName() != "" &&
+		cep.Namespace != ""
+}
+
 func (c *DefaultController) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
-	if cep.Status.Networking == nil || cep.Status.Identity == nil || cep.GetName() == "" || cep.Namespace == "" {
+	if !isValidEndpoint(cep) {
 		return
 	}
 	touchedCESs := c.manager.UpdateCEPMapping(k8s.ConvertCEPToCoreCEP(cep), cep.Namespace)
@@ -162,7 +174,12 @@ func (c *DefaultController) Start(ctx cell.HookContext) error {
 
 	c.initializeQueue()
 
-	if err := c.syncCESsInLocalCache(ctx); err != nil {
+	// Subscribe before draining to avoid missing events between subscription
+	// and drain (see syncCESsInLocalCache).
+	ciliumEndpointEvents := c.ciliumEndpoint.Events(c.context)
+	ciliumEndpointSliceEvents := c.ciliumEndpointSlice.Events(c.context)
+
+	if err := c.syncCESsInLocalCache(ciliumEndpointEvents, ciliumEndpointSliceEvents); err != nil {
 		return err
 	}
 
@@ -173,8 +190,12 @@ func (c *DefaultController) Start(ctx cell.HookContext) error {
 	)
 	// Start the work pools processing CEP events only after syncing CES in local cache.
 	c.wp = workerpool.New(3)
-	c.wp.Submit("cilium-endpoints-updater", c.runCiliumEndpointsUpdater)
-	c.wp.Submit("cilium-endpoint-slices-updater", c.runCiliumEndpointSliceUpdater)
+	c.wp.Submit("cilium-endpoints-updater", func(ctx context.Context) error {
+		return c.runCiliumEndpointsUpdater(ctx, ciliumEndpointEvents)
+	})
+	c.wp.Submit("cilium-endpoint-slices-updater", func(ctx context.Context) error {
+		return c.runCiliumEndpointSliceUpdater(ctx, ciliumEndpointSliceEvents)
+	})
 	c.wp.Submit("cilium-nodes-updater", c.runCiliumNodesUpdater)
 
 	c.logger.InfoContext(ctx, "Starting CES controller reconciler.")
@@ -186,10 +207,10 @@ func (c *DefaultController) Start(ctx cell.HookContext) error {
 		// Add the shutdown job last so it stops first.
 		job.OneShot("shutdown", func(ctx context.Context, health cell.Health) error {
 			<-ctx.Done()
+			c.contextCancel()
 			c.wp.Close()
 			c.fastQueue.ShutDown()
 			c.standardQueue.ShutDown()
-			c.contextCancel()
 			return nil
 		}),
 	)
@@ -216,6 +237,9 @@ func (c *SlimController) Start(ctx cell.HookContext) error {
 
 	c.initializeQueue()
 
+	// starts the events loop before syncCESsInLocalCache() to be sure we don't miss any event
+	ciliumEndpointSliceEvents := c.ciliumEndpointSlice.Events(c.context)
+
 	if err := c.syncCESsInLocalCache(ctx); err != nil {
 		return err
 	}
@@ -228,7 +252,7 @@ func (c *SlimController) Start(ctx cell.HookContext) error {
 			return c.runCiliumPodsUpdater(ctx)
 		}),
 		job.OneShot("proc-ces-events", func(ctx context.Context, health cell.Health) error {
-			return c.runCiliumEndpointSliceUpdater(ctx)
+			return c.runCiliumEndpointSliceUpdater(ctx, ciliumEndpointSliceEvents)
 		}),
 		job.OneShot("proc-ciliumnodes-events", func(ctx context.Context, health cell.Health) error {
 			return c.runCiliumNodesUpdater(ctx)
@@ -275,8 +299,8 @@ func (c *SlimController) Stop(ctx cell.HookContext) error {
 	return nil
 }
 
-func (c *DefaultController) runCiliumEndpointsUpdater(ctx context.Context) error {
-	for event := range c.ciliumEndpoint.Events(ctx) {
+func (c *DefaultController) runCiliumEndpointsUpdater(ctx context.Context, events <-chan resource.Event[*cilium_api_v2.CiliumEndpoint]) error {
+	for event := range events {
 		switch event.Kind {
 		case resource.Upsert:
 			c.logger.DebugContext(ctx, "Got Upsert Endpoint event", logfields.CEPName, event.Key)
@@ -308,8 +332,8 @@ func (c *SlimController) runCiliumPodsUpdater(ctx context.Context) error {
 	return nil
 }
 
-func (c *Controller) runCiliumEndpointSliceUpdater(ctx context.Context) error {
-	for event := range c.ciliumEndpointSlice.Events(ctx) {
+func (c *Controller) runCiliumEndpointSliceUpdater(ctx context.Context, events <-chan resource.Event[*capi_v2a1.CiliumEndpointSlice]) error {
+	for event := range events {
 		switch event.Kind {
 		case resource.Upsert:
 			c.logger.DebugContext(ctx, "Got Upsert Endpoint Slice event", logfields.CESName, event.Key)
@@ -465,21 +489,77 @@ func (c *SlimController) onPodDelete(pod *slim_corev1.Pod) {
 	c.enqueueCESReconciliation(touchedCES)
 }
 
-// Sync all CESs from cesStore to manager cache.
-// Note: CESs are synced locally before CES controller running and this is required.
-func (c *DefaultController) syncCESsInLocalCache(ctx context.Context) error {
-	store, err := c.ciliumEndpointSlice.Store(ctx)
-	if err != nil {
-		c.logger.WarnContext(ctx, "Error getting CES Store", logfields.Error, err)
-		return err
-	}
-	for _, ces := range store.List() {
-		cesName := c.manager.initializeMappingForCES(ces)
-		for _, cep := range ces.Endpoints {
-			c.manager.initializeMappingCEPtoCES(&cep, ces.Namespace, cesName)
+// syncCESsInLocalCache seeds the manager's CES↔CEP mapping from the CEP and
+// CES event replays.
+func (c *DefaultController) syncCESsInLocalCache(cepEvents <-chan resource.Event[*cilium_api_v2.CiliumEndpoint],
+	cesEvents <-chan resource.Event[*capi_v2a1.CiliumEndpointSlice]) error {
+	// Phase 1: snapshot live CEPs from the CEP replay.
+	livecep := map[resource.Key]*cilium_api_v2.CiliumEndpoint{}
+cepLoop:
+	for event := range cepEvents {
+		switch event.Kind {
+		case resource.Upsert:
+			if isValidEndpoint(event.Object) {
+				livecep[event.Key] = event.Object
+			}
+		case resource.Delete:
+			delete(livecep, event.Key)
+		case resource.Sync:
+			event.Done(nil)
+			break cepLoop
 		}
+		event.Done(nil)
 	}
-	c.logger.DebugContext(ctx, "Successfully synced all CESs locally")
+
+	// Phase 2: seed the CES cache, skipping CEPs not in the phase-1 snapshot.
+	var dirtyCESes []CESKey
+cesLoop:
+	for event := range cesEvents {
+		switch event.Kind {
+		case resource.Upsert:
+			ces := event.Object
+			cesName := c.manager.initializeMappingForCES(ces)
+			stale := false
+			for _, cep := range ces.Endpoints {
+				cepKey := NewCEPName(cep.Name, ces.Namespace).key()
+				if _, exists := livecep[cepKey]; exists {
+					c.manager.initializeMappingCEPtoCES(&cep, ces.Namespace, cesName)
+					delete(livecep, cepKey)
+				} else {
+					c.logger.Debug("Skipping stale CEP in CES during bootstrap",
+						logfields.CESName, ces.Name,
+						logfields.CEPName, cep.Name)
+					stale = true
+				}
+			}
+			if stale {
+				dirtyCESes = append(dirtyCESes, NewCESKey(ces.Name, ces.Namespace))
+			}
+		case resource.Delete:
+			// A CES we saw earlier in this replay has been deleted. Drop it
+			// from the mapping and from dirtyCESes.
+			cesName := CESName(event.Key.Name)
+			for _, cep := range c.manager.mapping.getCEPsInCES(cesName) {
+				c.manager.mapping.deleteCEP(cep)
+			}
+			c.manager.mapping.deleteCES(cesName)
+			dirtyCESes = slices.DeleteFunc(dirtyCESes, func(k CESKey) bool {
+				return k.Name == event.Key.Name && k.Namespace == event.Key.Namespace
+			})
+		case resource.Sync:
+			event.Done(nil)
+			break cesLoop
+		}
+		event.Done(nil)
+	}
+
+	// Phase 3: place orphan CEPs (no CES references them yet) into a CES.
+	for _, cep := range livecep {
+		c.onEndpointUpdate(cep)
+	}
+
+	c.enqueueCESReconciliation(dirtyCESes)
+	c.logger.Debug("Successfully synced all CESs locally")
 	return nil
 }
 

--- a/operator/pkg/ciliumendpointslice/endpointslice_test.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice_test.go
@@ -59,6 +59,7 @@ func TestFCFSModeSyncCESsInLocalCacheDefault(t *testing.T) {
 	hive.Start(log, t.Context())
 	r = newDefaultReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
 	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
+	cepStore, _ := ciliumEndpoint.Store(t.Context())
 	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
 	assert.NoError(t, err)
 	cesController := &DefaultController{
@@ -69,6 +70,7 @@ func TestFCFSModeSyncCESsInLocalCacheDefault(t *testing.T) {
 			rateLimit:           rateLimitConfig,
 			enqueuedAt:          make(map[CESKey]time.Time),
 			doReconciler:        r,
+			cond:                *sync.NewCond(&lock.Mutex{}),
 		},
 		manager:        m,
 		reconciler:     r,
@@ -80,21 +82,39 @@ func TestFCFSModeSyncCESsInLocalCacheDefault(t *testing.T) {
 	cep2 := tu.CreateManagerEndpoint("cep2", 1, "node2")
 	cep3 := tu.CreateManagerEndpoint("cep3", 2, "node3")
 	cep4 := tu.CreateManagerEndpoint("cep4", 2, "node2")
+	cepStore.CacheStore().Add(tu.CreateStoreEndpoint("cep1", "ns", 1))
+	cepStore.CacheStore().Add(tu.CreateStoreEndpoint("cep2", "ns", 1))
+	cepStore.CacheStore().Add(tu.CreateStoreEndpoint("cep3", "ns", 2))
+	cepStore.CacheStore().Add(tu.CreateStoreEndpoint("cep4", "ns", 2))
 	ces1 := tu.CreateStoreEndpointSlice("ces1", "ns", []cilium_v2a1.CoreCiliumEndpoint{cep1, cep2, cep3, cep4})
 	cesStore.CacheStore().Add(ces1)
+
 	cep5 := tu.CreateManagerEndpoint("cep5", 1, "node1")
 	cep6 := tu.CreateManagerEndpoint("cep6", 1, "node2")
 	cep7 := tu.CreateManagerEndpoint("cep7", 2, "node3")
+	cepStore.CacheStore().Add(tu.CreateStoreEndpoint("cep5", "ns", 1))
+	cepStore.CacheStore().Add(tu.CreateStoreEndpoint("cep6", "ns", 1))
+	// cep7 is intentionally NOT added to the CEP store, simulating a pod that
+	// was deleted while the operator was down. The bootstrap must drop it from
+	// the mapping.
 	ces2 := tu.CreateStoreEndpointSlice("ces2", "ns", []cilium_v2a1.CoreCiliumEndpoint{cep5, cep6, cep7})
 	cesStore.CacheStore().Add(ces2)
 
-	cesController.syncCESsInLocalCache(t.Context())
+	// Subscribe after seeding so the replay picks up the objects we injected.
+	cepEvents := ciliumEndpoint.Events(t.Context())
+	cesEvents := ciliumEndpointSlice.Events(t.Context())
+	cesController.syncCESsInLocalCache(cepEvents, cesEvents)
 
 	mapping := m.mapping
 
 	for _, ces := range []*cilium_v2a1.CiliumEndpointSlice{ces1, ces2} {
 		for _, cep := range ces.Endpoints {
 			cesN, _ := mapping.getCESName(NewCEPName(cep.Name, "ns"))
+			if cep.Name == "cep7" {
+				assert.Empty(t, cesN, "stale cep7 should not have a CES mapping")
+				continue
+			}
+
 			// ensure that the CEP is mapped to the correct CES
 			assert.Equal(t, cesN, CESName(ces.Name))
 		}

--- a/operator/pkg/ciliumendpointslice/endpointslice_test.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice_test.go
@@ -147,12 +147,12 @@ func TestDifferentSpeedQueuesDefault(t *testing.T) {
 			priorityNamespaces:  make(map[string]struct{}),
 			syncDelay:           0,
 			doReconciler:        r,
+			cond:                *sync.NewCond(&lock.Mutex{}),
 		},
 		manager:        m,
 		reconciler:     r,
 		ciliumEndpoint: ciliumEndpoint,
 	}
-	cesController.cond = *sync.NewCond(&lock.Mutex{})
 	cesController.context, cesController.contextCancel = context.WithCancel(t.Context())
 	cesController.priorityNamespaces["FastNamespace"] = struct{}{}
 	cesController.initializeQueue()
@@ -251,12 +251,12 @@ func TestCESManagementDefault(t *testing.T) {
 			priorityNamespaces:  make(map[string]struct{}),
 			syncDelay:           0,
 			doReconciler:        r,
+			cond:                *sync.NewCond(&lock.Mutex{}),
 		},
 		manager:        m,
 		reconciler:     r,
 		ciliumEndpoint: ciliumEndpoint,
 	}
-	cesController.cond = *sync.NewCond(&lock.Mutex{})
 	cesController.context, cesController.contextCancel = context.WithCancel(t.Context())
 	cesController.initializeQueue()
 	var ns = "ns"
@@ -347,6 +347,7 @@ func TestFCFSModeSyncCESsInLocalCache(t *testing.T) {
 			doReconciler:        r,
 			metrics:             cesMetrics,
 			priorityNamespaces:  make(map[string]struct{}),
+			cond:                *sync.NewCond(&lock.Mutex{}),
 		},
 		ipsecEnabled:   false,
 		wgEnabled:      false,
@@ -355,7 +356,6 @@ func TestFCFSModeSyncCESsInLocalCache(t *testing.T) {
 		pods:           pods,
 		ciliumIdentity: ciliumIdentity,
 	}
-	cesController.cond = *sync.NewCond(&lock.Mutex{})
 	cesController.initializeQueue()
 
 	node1 := tu.CreateStoreNode("node1")
@@ -471,6 +471,7 @@ func TestDifferentSpeedQueues(t *testing.T) {
 			doReconciler:        r,
 			metrics:             cesMetrics,
 			priorityNamespaces:  make(map[string]struct{}),
+			cond:                *sync.NewCond(&lock.Mutex{}),
 		},
 		ipsecEnabled:   false,
 		wgEnabled:      false,
@@ -479,7 +480,6 @@ func TestDifferentSpeedQueues(t *testing.T) {
 		pods:           pods,
 		ciliumIdentity: ciliumIdentity,
 	}
-	cesController.cond = *sync.NewCond(&lock.Mutex{})
 	cesController.context, cesController.contextCancel = context.WithCancel(t.Context())
 	cesController.priorityNamespaces["FastNamespace"] = struct{}{}
 	cesController.initializeQueue()
@@ -595,6 +595,7 @@ func TestCESManagement(t *testing.T) {
 			doReconciler:        r,
 			metrics:             cesMetrics,
 			priorityNamespaces:  make(map[string]struct{}),
+			cond:                *sync.NewCond(&lock.Mutex{}),
 		},
 		ipsecEnabled:   false,
 		wgEnabled:      false,
@@ -603,7 +604,6 @@ func TestCESManagement(t *testing.T) {
 		pods:           pods,
 		ciliumIdentity: ciliumIdentity,
 	}
-	cesController.cond = *sync.NewCond(&lock.Mutex{})
 	cesController.context, cesController.contextCancel = context.WithCancel(t.Context())
 	cesController.initializeQueue()
 	var ns = "ns"
@@ -708,6 +708,7 @@ func TestSyncCESsInLocalCacheDeletedCID(t *testing.T) {
 			doReconciler:        r,
 			metrics:             cesMetrics,
 			priorityNamespaces:  make(map[string]struct{}),
+			cond:                *sync.NewCond(&lock.Mutex{}),
 		},
 		ipsecEnabled:   false,
 		wgEnabled:      false,
@@ -716,7 +717,6 @@ func TestSyncCESsInLocalCacheDeletedCID(t *testing.T) {
 		pods:           pods,
 		ciliumIdentity: ciliumIdentity,
 	}
-	cesController.cond = *sync.NewCond(&lock.Mutex{})
 	cesController.initializeQueue()
 
 	node1 := tu.CreateStoreNode("node1")


### PR DESCRIPTION
This commit fixes multiple races on the default controller implementation:
   - Check that a CEP exists before adding it to the cache when starting the operator. It avoids to add stale CEPs that could make the cache misbehave when the operator is down and CEPs are removed from the kube-api server.
- Don't use Store() to avoid missing events

Ref https://github.com/cilium/cilium/pull/38388#discussion_r2631120349

```
operator/ces: fix default controller race causing stale CEP entries in cache after operator restart
```

---

## Reproducing (first issue)

When executing the following steps, be sure the previous one completes before going on, otherwise the results can be different.

0. Deploy cilium with CiliumEndpointSlice enabled

```yaml
# contrib/testing/kind-custom.yaml
ciliumEndpointSlice:
  enabled: true
```
1. Create a deployment with 100 pods:

```bash
kubectl create deployment test-deployment --image=nginx --replicas=100
```

A CES (`ces-9wg8bdkm8-mblh5`) with 100 endpoints is created:

```bash
$ kubectl get ces -o json | jq -r '.items[] | "\(.metadata.name)\t\(.endpoints|length)"'
ces-2jqxgjvhz-x552c     2
ces-8vqrc69xx-8fx9c     1
ces-9wg8bdkm8-mblh5     100
```

2. Now, disable the operator:

```bash
kubectl scale deployment cilium-operator --replicas=0 -n kube-system
```

3. Remove 95 of the created pods:

```bash
kubectl scale deployment test-deployment --replicas=5
```

4. Restart the cilium-operator:

```bash
kubectl scale deployment cilium-operator --replicas=1 -n kube-system
```

Check the CES again (it takes a bit for them to be updated wile the operator starts up)

```bash
$ kubectl get ces -o json | jq -r '.items[] | "\(.metadata.name)\t\(.endpoints|length)"'
ces-2jqxgjvhz-x552c     2
ces-8vqrc69xx-8fx9c     1
ces-9wg8bdkm8-mblh5     5
```

It's right that `ces-9wg8bdkm8-mblh5` now contains 5 entries.

5. Now, scale the deployment back up to 100 replicas:

```bash
kubectl scale deployment test-deployment --replicas=100
```

And check the CES again:

```bash
$ kubectl get ces -o json | jq -r '.items[] | "\(.metadata.name)\t\(.endpoints|length)"'
ces-25z7g4v8n-dlhrk     95
ces-2jqxgjvhz-x552c     2
ces-8vqrc69xx-8fx9c     1
ces-9wg8bdkm8-mblh5     5
```

Instead of putting the 100 endpoints into the original CES, a new CES `ces-25z7g4v8n-dlhrk` was created to hold the additional 95 endpoints. This happens because the DefaultController cache wrongly believes that there are  100 on the `mblh5` CES so it decides to create a new instead of filling up the existing one.

After this PR the existing CES is filled with 100 CEPs when scaling up the test deployment.
--- 

AIL: 2. 

I used claude to learn about the base code as I'm new to it, I discussed possible alternatives implementations for the issues. I write the implementation and it cleaned and improved it for me.

--- 

The slimController implementation still needs to be fixed, but I'll handle that in a follow up PR once this one is merged.