### PR TITLE
Fix: data race for unlocked map read in regeneration goroutine

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -694,7 +694,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 	// pre-existing connections using that IP are now invalid.
 	if !e.ctCleaned {
 		go func() {
-			if !e.isPropertyLocked(endpointtypes.PropertyFakeEndpoint) {
+			if !e.IsProperty(endpointtypes.PropertyFakeEndpoint) {
 				e.scrubIPsInConntrackTable()
 			}
 			close(datapathRegenCtxt.ctCleaned)

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -673,9 +673,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 	// pre-existing connections using that IP are now invalid.
 	if !e.ctCleaned {
 		go func() {
-			if !e.isPropertyLocked(endpointtypes.PropertyFakeEndpoint) {
-				e.scrubIPsInConntrackTable()
-			}
+			e.scrubIPsInConntrackTable()
 			close(datapathRegenCtxt.ctCleaned)
 		}()
 	} else {
@@ -904,6 +902,10 @@ func (e *Endpoint) deleteMaps() []error {
 
 // scrubIPsInConntrackTableLocked will run the CTMap garbagecollector with the endpoint IPs.
 func (e *Endpoint) scrubIPsInConntrackTableLocked() {
+	if e.isPropertyLocked(endpointtypes.PropertyFakeEndpoint) {
+		return
+	}
+
 	e.ctMapGC.Run(ctmap.GCFilter{
 		MatchIPs: map[ctmap.NetAddr]struct{}{
 			{Addr: e.IPv4}: {},

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1323,9 +1323,7 @@ func (e *Endpoint) leaveLocked(conf DeleteConfig) []error {
 	e.controllers.RemoveAll()
 	e.cleanPolicySignals()
 
-	if !e.isPropertyLocked(endpoint.PropertyFakeEndpoint) {
-		e.scrubIPsInConntrackTableLocked()
-	}
+	e.scrubIPsInConntrackTableLocked()
 
 	e.setState(StateDisconnected, "Endpoint removed")
 


### PR DESCRIPTION

<!-- Description of change -->

This is a Go map concurrent read data race bug.

The core issue is that a new goroutine is spawned to perform `e.isPropertyLocked()` instead of calling the API on the original goroutine

```
go func() {
    if !e.isPropertyLocked(endpointtypes.PropertyFakeEndpoint) {
        e.scrubIPsInConntrackTable()
    }
    close(datapathRegenCtxt.ctCleaned)
}()
```

e.isPropertyLocked() reads e.properties (a map[string]any) without holding any lock:

```
func (e *Endpoint) isPropertyLocked(propertyKey string) bool {
    if v, ok := e.properties[propertyKey]; ok {
        ...
    }
    return false
}
```

Go maps are not safe for concurrent access. If goroutine A writes e.properties while holding the lock, and this new goroutine reads e.properties without holding the lock, the Go runtime will panic with fatal error: concurrent map read and map write.

The fix replaces it with e.IsProperty(), which acquires a read lock first:

```
func (e *Endpoint) IsProperty(propertyKey string) bool {
    e.mutex.RWMutex.RLock()
    defer e.mutex.RWMutex.RUnlock()
    return e.isPropertyLocked(propertyKey)
}
```

This ensures all reads of e.properties are properly synchronized.


Fixes: #issue-number

```release-note
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
