### PR TITLE
pkg/datapath/sockets/probe: fix inet diag probing.

### DIFF
--- a/pkg/datapath/sockets/cell.go
+++ b/pkg/datapath/sockets/cell.go
@@ -1,0 +1,12 @@
+package sockets
+
+import "github.com/cilium/hive/cell"
+
+// Cell provides a socket inet probe used for probing for nl
+// socket functionality. Results are memoized for subsequent
+// calls by other consumers.
+var Cell = cell.Module(
+	"sockets-inet-probe",
+	"Sockets Inet Probe",
+	cell.Provide(newSocketInetProbe),
+)

--- a/pkg/datapath/sockets/probe.go
+++ b/pkg/datapath/sockets/probe.go
@@ -153,13 +153,14 @@ func (p *SocketInetProbe) probeForSockDestroy(ctx context.Context, logger *slog.
 			logger.Debug("found probe socket, attempting destroy",
 				logfields.Port, probe.port,
 				logfields.Protocol, probe.proto)
-			destroyErr := DestroySocket(slog.Default(), *s, netlink.Proto(probe.proto), 0xff)
+			destroyErr := DestroySocket(logger, *s, netlink.Proto(probe.proto), 0xff)
 			if errors.Is(destroyErr, unix.ENOTSUP) {
 				// Note: Returning error stops iteration and passes err through to
 				// return value of Iterate.
 				return fmt.Errorf("%w: operation to destroy probe socket is unsupported. "+
 					"This likely means that kernel CONFIG_INET_DIAG_DESTROY must be set in order for this functionality to work",
 					probes.ErrNotSupported)
+
 			}
 			if destroyErr != nil {
 				return destroyErr

--- a/pkg/datapath/sockets/probe.go
+++ b/pkg/datapath/sockets/probe.go
@@ -25,7 +25,7 @@ import (
 // probe. We manage the lifecycle via the cell such that we can
 // memoize results.
 func newSocketInetProbe() *SocketInetProbe {
-	return &SocketInetProbe{}
+	return &SocketInetProbe{probeSocketFns: defaultProbeSocketFns}
 }
 
 type SocketInetProbe struct {
@@ -34,6 +34,8 @@ type SocketInetProbe struct {
 	udpProbed   bool
 	tcpProbeErr error
 	udpProbeErr error
+
+	probeSocketFns
 }
 
 type closer interface {
@@ -46,6 +48,16 @@ func parsePort(a string) (uint16, error) {
 		return 0, err
 	}
 	return ap.Port(), nil
+}
+
+// testProbeSocketFns abstracts the socket-creation and privileged netlink
+// inet_diag operations used while probing so that tests can substitute fakes
+// and exercise the probing logic without CAP_NET_ADMIN.
+type probeSocketFns struct {
+	createProbeTCPSocket func(ctx context.Context) (lis *net.TCPListener, conn net.Conn, port uint16, err error)
+	createProbeUDPSocket func() (closer, uint16, error)
+	iterate              func(proto uint8, family uint8, stateFilter uint32, fn func(*netlink.Socket, error) error) error
+	destroySocket        func(logger *slog.Logger, sock netlink.Socket, proto netlink.Proto, stateFilter uint32) error
 }
 
 func createProbeTCPSocket(ctx context.Context) (lis *net.TCPListener, conn net.Conn, port uint16, err error) {
@@ -100,6 +112,13 @@ func createProbeUDPSocket() (closer, uint16, error) {
 	return lis, port, nil
 }
 
+var defaultProbeSocketFns = probeSocketFns{
+	createProbeTCPSocket: createProbeTCPSocket,
+	createProbeUDPSocket: createProbeUDPSocket,
+	iterate:              Iterate,
+	destroySocket:        DestroySocket,
+}
+
 type inetProbe struct {
 	proto      int
 	filterMask uint32
@@ -116,7 +135,7 @@ func (p *SocketInetProbe) probeForSockDestroy(ctx context.Context, logger *slog.
 	var probe inetProbe
 
 	if udp {
-		udpSock, port, err := createProbeUDPSocket()
+		udpSock, port, err := p.createProbeUDPSocket()
 		if err != nil {
 			return err
 		}
@@ -128,12 +147,12 @@ func (p *SocketInetProbe) probeForSockDestroy(ctx context.Context, logger *slog.
 			port:       port,
 		}
 	} else {
-		lis, tcpSock, port, err := createProbeTCPSocket(ctx)
+		lis, tcpConn, port, err := p.createProbeTCPSocket(ctx)
 		if err != nil {
 			return err
 		}
 		defer lis.Close()
-		defer tcpSock.Close()
+		defer tcpConn.Close()
 
 		probe = inetProbe{
 			proto:      unix.IPPROTO_TCP,
@@ -150,23 +169,27 @@ func (p *SocketInetProbe) probeForSockDestroy(ctx context.Context, logger *slog.
 	ok := false
 	count := 0
 	lo := net.IP{127, 0, 0, 1}
-	if err := Iterate(uint8(probe.proto), unix.AF_INET, probe.filterMask, func(s *netlink.Socket, err error) error {
-		logger.Debug("found probe socket, attempting destroy",
-			logfields.Port, probe.port,
-			logfields.Protocol, probe.proto)
+	if err := p.iterate(uint8(probe.proto), unix.AF_INET, probe.filterMask, func(s *netlink.Socket, err error) error {
+		// Abort the dump promptly on cancellation.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		// A per-message error yields a nil socket; surface it and stop.
+		if err != nil {
+			return err
+		}
 		count++
-		if s.ID.SourcePort == uint16(probe.port) && s.ID.Source.Equal(lo) {
+		if s.ID.SourcePort == probe.port && s.ID.Source.Equal(lo) {
 			logger.Debug("found probe socket, attempting destroy",
 				logfields.Port, probe.port,
 				logfields.Protocol, probe.proto)
-			destroyErr := DestroySocket(logger, *s, netlink.Proto(probe.proto), 0xff)
+			destroyErr := p.destroySocket(logger, *s, netlink.Proto(probe.proto), 0xff)
 			if errors.Is(destroyErr, unix.ENOTSUP) {
 				// Note: Returning error stops iteration and passes err through to
 				// return value of Iterate.
 				return fmt.Errorf("%w: operation to destroy probe socket is unsupported. "+
 					"This likely means that kernel CONFIG_INET_DIAG_DESTROY must be set in order for this functionality to work",
 					probes.ErrNotSupported)
-
 			}
 			if destroyErr != nil {
 				return destroyErr
@@ -191,7 +214,6 @@ func (p *SocketInetProbe) probeForSockDestroy(ctx context.Context, logger *slog.
 				proto = "udp"
 				requiredConfig = "CONFIG_INET_UDP_DIAG"
 			}
-
 			return fmt.Errorf("%w: no netlink messages testing INET_DIAG listing for %s. "+
 				"This indicates that the kernel does not have the appropriate kernel config set (%s)",
 				probes.ErrNotSupported, proto, requiredConfig)

--- a/pkg/datapath/sockets/probe.go
+++ b/pkg/datapath/sockets/probe.go
@@ -20,7 +20,20 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var probeOnce sync.Once
+// newSocketInetProbe is a unexported function to construct a new
+// probe. We manage the lifecycle via the cell such that we can
+// memoize results.
+func newSocketInetProbe() *SocketInetProbe {
+	return &SocketInetProbe{}
+}
+
+type SocketInetProbe struct {
+	sync.Mutex
+	tcpProbed   bool
+	udpProbed   bool
+	tcpProbeErr error
+	udpProbeErr error
+}
 
 type closer interface {
 	Close() error
@@ -75,12 +88,16 @@ func createProbeUDPSocket() (closer, uint16, error) {
 		IP: net.IP{127, 0, 0, 1},
 	})
 	if err != nil {
-		return lis, 0, err
+		return nil, 0, err
 	}
 
 	port, err := parsePort(lis.LocalAddr().String())
+	if err != nil {
+		lis.Close()
+		return nil, 0, err
+	}
 
-	return lis, uint16(port), err
+	return lis, port, nil
 }
 
 type inetProbe struct {
@@ -90,13 +107,13 @@ type inetProbe struct {
 }
 
 // probeForSockDestroy probes supported socket termination protocols.
-// To do this reliably and portably, this creates sockets for udp/tcp
+// To do this reliably and portably, this creates a socket for udp/tcp
 // and attempts to both list and destroy sockets to probe for the full
 // suite of inet diag features; ensuring that the sockets.Destroy will
 // successfully find and terminate sockets.
 // This is sufficient for both ip4 and ip6.
-func probeForSockDestroy(ctx context.Context, logger *slog.Logger, tcp, udp bool) error {
-	protoProbes := []inetProbe{}
+func (p *SocketInetProbe) probeForSockDestroy(ctx context.Context, logger *slog.Logger, udp bool) error {
+	var probe inetProbe
 
 	if udp {
 		udpSock, port, err := createProbeUDPSocket()
@@ -105,92 +122,109 @@ func probeForSockDestroy(ctx context.Context, logger *slog.Logger, tcp, udp bool
 		}
 		defer udpSock.Close()
 
-		protoProbes = append(protoProbes, inetProbe{
+		probe = inetProbe{
 			proto:      unix.IPPROTO_UDP,
 			filterMask: StateFilterUDP,
 			port:       port,
-		})
-	}
-
-	if tcp {
+		}
+	} else {
 		tcpSock, port, err := createProbeTCPSocket(ctx)
 		if err != nil {
 			return err
 		}
 		defer tcpSock.Close()
 
-		protoProbes = append(protoProbes, inetProbe{
+		probe = inetProbe{
 			proto:      unix.IPPROTO_TCP,
 			filterMask: StateFilterTCP,
 			port:       port,
-		})
+		}
 	}
 
-	var errs error
-	for _, probe := range protoProbes {
-		ok := false
-		count := 0
-		lo := net.IP{127, 0, 0, 1}
-		if err := Iterate(uint8(probe.proto), unix.AF_INET, probe.filterMask, func(s *netlink.Socket, err error) error {
+	ok := false
+	count := 0
+	lo := net.IP{127, 0, 0, 1}
+	if err := Iterate(uint8(probe.proto), unix.AF_INET, probe.filterMask, func(s *netlink.Socket, err error) error {
+		logger.Debug("found probe socket, attempting destroy",
+			logfields.Port, probe.port,
+			logfields.Protocol, probe.proto)
+		count++
+		if s.ID.SourcePort == uint16(probe.port) && s.ID.Source.Equal(lo) {
 			logger.Debug("found probe socket, attempting destroy",
 				logfields.Port, probe.port,
 				logfields.Protocol, probe.proto)
-			count++
-			if s.ID.SourcePort == uint16(probe.port) && s.ID.Source.Equal(lo) {
-				logger.Debug("found probe socket, attempting destroy",
-					logfields.Port, probe.port,
-					logfields.Protocol, probe.proto)
-				destroyErr := DestroySocket(slog.Default(), *s, netlink.Proto(probe.proto), 0xff)
-				if errors.Is(destroyErr, unix.ENOTSUP) {
-					// Note: Returning error stops iteration and passes err through to
-					// return value of Iterate.
-					return fmt.Errorf("%w: operation to destroy probe socket is unsupported. "+
-						"This likely means that kernel CONFIG_INET_DIAG_DESTROY must be set in order for this functionality to work",
-						probes.ErrNotSupported)
-				}
-				if destroyErr != nil {
-					return destroyErr
-				}
-				ok = true
+			destroyErr := DestroySocket(slog.Default(), *s, netlink.Proto(probe.proto), 0xff)
+			if errors.Is(destroyErr, unix.ENOTSUP) {
+				// Note: Returning error stops iteration and passes err through to
+				// return value of Iterate.
+				return fmt.Errorf("%w: operation to destroy probe socket is unsupported. "+
+					"This likely means that kernel CONFIG_INET_DIAG_DESTROY must be set in order for this functionality to work",
+					probes.ErrNotSupported)
 			}
-			return nil
-		}); err != nil {
-			errs = errors.Join(errs, fmt.Errorf("failed while iterating sockets: %w", err))
-			continue
+			if destroyErr != nil {
+				return destroyErr
+			}
+			ok = true
 		}
-		if !ok {
-			// Unexpected: if we saw other sockets (which is very likely on host ns) then we should
-			// have found our test sockets.
-			// By not wrapping in the ErrNotSupported error, we indicate that this is an unexpected error
-			// not a legitimate probing error.
-			if count > 0 {
-				return fmt.Errorf("failed to find listener socket for inet diag destroy probe")
-			} else {
-				proto := "tcp"
-				requiredConfig := "CONFIG_INET_TCP_DIAG"
-				if probe.proto == unix.IPPROTO_UDP {
-					proto = "udp"
-					requiredConfig = "CONFIG_INET_UDP_DIAG"
-				}
-
-				errs = errors.Join(errs, fmt.Errorf("%w: no netlink messages testing INET_DIAG listing for %s. "+
-					"This indicates that the kernel does not have the appropriate kernel config set (%s)",
-					probes.ErrNotSupported, proto, requiredConfig))
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed while iterating sockets: %w", err)
+	}
+	if !ok {
+		// Unexpected: if we saw other sockets (which is very likely on host ns) then we should
+		// have found our test sockets.
+		// By not wrapping in the ErrNotSupported error, we indicate that this is an unexpected error
+		// not a legitimate probing error.
+		if count > 0 {
+			return fmt.Errorf("failed to find listener socket for inet diag destroy probe")
+		} else {
+			proto := "tcp"
+			requiredConfig := "CONFIG_INET_TCP_DIAG"
+			if probe.proto == unix.IPPROTO_UDP {
+				proto = "udp"
+				requiredConfig = "CONFIG_INET_UDP_DIAG"
 			}
+
+			return fmt.Errorf("%w: no netlink messages testing INET_DIAG listing for %s. "+
+				"This indicates that the kernel does not have the appropriate kernel config set (%s)",
+				probes.ErrNotSupported, proto, requiredConfig)
 		}
 	}
-	return errs
+	return nil
 }
 
-// InetDiagDestroyEnabled sets up a local listener socket on localhost
-// and attempts to terminate it to probe for functionality enabled by
-// CONFIG_INET_DIAG_DESTROY.
-func InetDiagDestroyEnabled(logger *slog.Logger, probeTCP, probeUDP bool) error {
-	var err error
+// resultIsCached reports whether a previous probe produced a definitive result
+// implying we can just return memoized results.
+func resultIsCached(isProbed bool, probeErr error) bool {
+	return isProbed && (probeErr == nil || errors.Is(probeErr, probes.ErrNotSupported))
+}
+
+// InetDiagDestroyTCPEnabled probes for CONFIG_INET_DIAG_DESTROY functionality for
+// TCP.
+func (p *SocketInetProbe) InetDiagDestroyTCPEnabled(logger *slog.Logger) error {
+	p.Lock()
+	defer p.Unlock()
+	if resultIsCached(p.tcpProbed, p.tcpProbeErr) {
+		return p.tcpProbeErr
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	probeOnce.Do(func() {
-		err = probeForSockDestroy(ctx, logger, probeTCP, probeUDP)
-	})
-	return err
+	p.tcpProbeErr = p.probeForSockDestroy(ctx, logger, false)
+	p.tcpProbed = true
+	return p.tcpProbeErr
+}
+
+// InetDiagDestroyUDPEnabled probes for CONFIG_INET_DIAG_DESTROY functionality for
+// UDP.
+func (p *SocketInetProbe) InetDiagDestroyUDPEnabled(logger *slog.Logger) error {
+	p.Lock()
+	defer p.Unlock()
+	if resultIsCached(p.udpProbed, p.udpProbeErr) {
+		return p.udpProbeErr
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	p.udpProbeErr = p.probeForSockDestroy(ctx, logger, true)
+	p.udpProbed = true
+	return p.udpProbeErr
 }

--- a/pkg/datapath/sockets/probe.go
+++ b/pkg/datapath/sockets/probe.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net"
 	"net/netip"
+	"strconv"
 	"sync"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
@@ -47,40 +48,39 @@ func parsePort(a string) (uint16, error) {
 	return ap.Port(), nil
 }
 
-func createProbeTCPSocket(ctx context.Context) (closer, uint16, error) {
-	lis, err := net.ListenTCP("tcp", &net.TCPAddr{
+func createProbeTCPSocket(ctx context.Context) (lis *net.TCPListener, conn net.Conn, port uint16, err error) {
+	lis, err = net.ListenTCP("tcp", &net.TCPAddr{
 		IP: net.IP{127, 0, 0, 1},
 	})
 	if err != nil {
-		return lis, 0, err
+		return nil, nil, 0, err
 	}
 
-	port, err := parsePort(lis.Addr().String())
+	port, err = parsePort(lis.Addr().String())
 	if err != nil {
 		lis.Close()
-		return lis, 0, err
+		return nil, nil, 0, err
 	}
 
+	dialer := net.Dialer{}
 	// According to the kernel; we cannot terminate tcp listener
 	// sockets in the LIST state.
 	// Therefore, we dial our listener to create a connection that
 	// we can use to probe on.
-	conn, err := net.DialTCP("tcp", nil, &net.TCPAddr{
-		IP:   net.IP{127, 0, 0, 1},
-		Port: int(port),
-	})
+	conn, err = dialer.DialContext(ctx, "tcp", "localhost:"+strconv.Itoa(int(port)))
 	if err != nil {
 		lis.Close()
-		return lis, 0, err
+		return nil, nil, 0, err
 	}
 
 	port, err = parsePort(conn.LocalAddr().String())
 	if err != nil {
 		lis.Close()
-		return nil, 0, err
+		conn.Close()
+		return nil, nil, 0, err
 	}
 
-	return lis, uint16(port), nil
+	return lis, conn, port, nil
 }
 
 func createProbeUDPSocket() (closer, uint16, error) {
@@ -128,10 +128,11 @@ func (p *SocketInetProbe) probeForSockDestroy(ctx context.Context, logger *slog.
 			port:       port,
 		}
 	} else {
-		tcpSock, port, err := createProbeTCPSocket(ctx)
+		lis, tcpSock, port, err := createProbeTCPSocket(ctx)
 		if err != nil {
 			return err
 		}
+		defer lis.Close()
 		defer tcpSock.Close()
 
 		probe = inetProbe{
@@ -139,6 +140,11 @@ func (p *SocketInetProbe) probeForSockDestroy(ctx context.Context, logger *slog.
 			filterMask: StateFilterTCP,
 			port:       port,
 		}
+	}
+
+	// Bail out early if the caller cancelled before we start iterating.
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("failed to complete probes: %w", err)
 	}
 
 	ok := false

--- a/pkg/datapath/sockets/probe_test.go
+++ b/pkg/datapath/sockets/probe_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestPrivilegedProbetInetDiagDestroyEnabled(t *testing.T) {
 	testutils.PrivilegedTest(t)
-	assert.NoError(t, InetDiagDestroyEnabled(hivetest.Logger(t), true, true))
-	assert.NoError(t, InetDiagDestroyEnabled(hivetest.Logger(t), false, false))
+	p := newSocketInetProbe()
+	assert.NoError(t, p.InetDiagDestroyTCPEnabled(hivetest.Logger(t)))
+	assert.NoError(t, p.InetDiagDestroyUDPEnabled(hivetest.Logger(t)))
 }

--- a/pkg/datapath/sockets/probe_test.go
+++ b/pkg/datapath/sockets/probe_test.go
@@ -4,18 +4,320 @@
 package sockets
 
 import (
+	"context"
+	"errors"
+	"log/slog"
+	"net"
 	"testing"
 
+	"github.com/cilium/cilium/pkg/datapath/linux/probes"
 	"github.com/cilium/cilium/pkg/testutils"
 
 	"github.com/cilium/hive/hivetest"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
+// TestPrivilegedProbetInetDiagDestroyEnabled is the end-to-end smoke test: with
+// real privileges it exercises the full netlink inet_diag list+destroy path and
+// asserts the kernel supports socket termination for both TCP and UDP. The
+// unprivileged tests below stub netlink to cover the surrounding logic.
 func TestPrivilegedProbetInetDiagDestroyEnabled(t *testing.T) {
 	testutils.PrivilegedTest(t)
 	p := newSocketInetProbe()
 	assert.NoError(t, p.InetDiagDestroyTCPEnabled(hivetest.Logger(t)))
 	assert.NoError(t, p.InetDiagDestroyUDPEnabled(hivetest.Logger(t)))
+}
+
+// fakeNetlink stubs the privileged netlink inet_diag operations (iterate /
+// destroySocket) so the probing logic can be tested without CAP_NET_ADMIN. It
+// records destroyed sockets and can inject list/destroy errors.
+type fakeNetlink struct {
+	// sockets returned by iterate for a given protocol.
+	sockets map[uint8][]netlink.Socket
+	// iterErr, if set, is passed to the callback (simulating a per-message error).
+	iterErr error
+	// destroyErr, if set, is returned from destroySocket.
+	destroyErr error
+
+	destroyed []netlink.Socket
+}
+
+func (f *fakeNetlink) iterate(proto uint8, family uint8, stateFilter uint32, fn func(*netlink.Socket, error) error) error {
+	if f.iterErr != nil {
+		// Mirror the openSubscribeHandle failure path, where Iterate returns
+		// the error directly rather than via the callback.
+		//
+		// TODO: the real iterateNetlinkSockets has a second error path we don't
+		// model here: per-message errors (short reads, NLMSG_ERROR, wrong sender
+		// PID) are delivered to the callback as fn(nil, err) while iteration
+		// continues, not returned directly. The probe callback guards this with
+		// its `if err != nil` check, but that path is currently only covered
+		// indirectly. Extend fakeNetlink to optionally inject a per-message
+		// error via the callback so we exercise that branch explicitly.
+		return f.iterErr
+	}
+	for i := range f.sockets[proto] {
+		s := f.sockets[proto][i]
+		if err := fn(&s, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *fakeNetlink) destroySocket(logger *slog.Logger, sock netlink.Socket, proto netlink.Proto, stateFilter uint32) error {
+	if f.destroyErr != nil {
+		return f.destroyErr
+	}
+	f.destroyed = append(f.destroyed, sock)
+	return nil
+}
+
+// captureFns wraps the real socket creators but records the ports handed out so
+// the fake netlink layer can return a matching socket.
+func captureFns(t *testing.T, fnl *fakeNetlink) probeSocketFns {
+	lo := net.IP{127, 0, 0, 1}
+	return probeSocketFns{
+		createProbeTCPSocket: func(ctx context.Context) (*net.TCPListener, net.Conn, uint16, error) {
+			lis, conn, port, err := createProbeTCPSocket(ctx)
+			if err != nil {
+				return nil, nil, 0, err
+			}
+			fnl.sockets[unix.IPPROTO_TCP] = append(fnl.sockets[unix.IPPROTO_TCP], netlink.Socket{
+				ID: netlink.SocketID{SourcePort: port, Source: lo},
+			})
+			return lis, conn, port, nil
+		},
+		createProbeUDPSocket: func() (closer, uint16, error) {
+			c, port, err := createProbeUDPSocket()
+			if err != nil {
+				return c, 0, err
+			}
+			fnl.sockets[unix.IPPROTO_UDP] = append(fnl.sockets[unix.IPPROTO_UDP], netlink.Socket{
+				ID: netlink.SocketID{SourcePort: port, Source: lo},
+			})
+			return c, port, nil
+		},
+		iterate:       fnl.iterate,
+		destroySocket: fnl.destroySocket,
+	}
+}
+
+func newFakeNetlink() *fakeNetlink {
+	return &fakeNetlink{sockets: map[uint8][]netlink.Socket{}}
+}
+
+// TestProbeForSockDestroy_Success covers the happy path: the single probe socket
+// that is created is found during iteration and successfully destroyed, and no
+// error is returned.
+func TestProbeForSockDestroy_Success(t *testing.T) {
+	// probe runs the probe for one protocol (udp=false means TCP) and asserts
+	// the created socket was found and destroyed.
+	probe := func(t *testing.T, udp bool) {
+		fnl := newFakeNetlink()
+		fns := captureFns(t, fnl)
+		p := &SocketInetProbe{probeSocketFns: fns}
+
+		require.NoError(t, p.probeForSockDestroy(t.Context(), hivetest.Logger(t), udp))
+		require.Len(t, fnl.destroyed, 1)
+	}
+
+	t.Run("tcp", func(t *testing.T) { probe(t, false) })
+	t.Run("udp", func(t *testing.T) { probe(t, true) })
+}
+
+// TestProbeForSockDestroy_DestroyUnsupported verifies that an ENOTSUP from the
+// destroy operation is surfaced as ErrNotSupported, hinting that the kernel is
+// missing CONFIG_INET_DIAG_DESTROY.
+func TestProbeForSockDestroy_DestroyUnsupported(t *testing.T) {
+	fnl := newFakeNetlink()
+	fnl.destroyErr = unix.ENOTSUP
+	fns := captureFns(t, fnl)
+	p := &SocketInetProbe{probeSocketFns: fns}
+
+	err := p.probeForSockDestroy(t.Context(), hivetest.Logger(t), false)
+	require.Error(t, err)
+	require.ErrorIs(t, err, probes.ErrNotSupported)
+}
+
+// TestProbeForSockDestroy_NoSocketsListed verifies that when iteration lists no
+// sockets at all (not even our own probe socket) the probe concludes the
+// *_DIAG listing config is missing and returns ErrNotSupported.
+func TestProbeForSockDestroy_NoSocketsListed(t *testing.T) {
+	fnl := newFakeNetlink()
+	fns := captureFns(t, fnl)
+	// Drop the socket the creator registered so iterate yields nothing.
+	fns.iterate = func(proto uint8, family uint8, stateFilter uint32, fn func(*netlink.Socket, error) error) error {
+		return nil
+	}
+	p := &SocketInetProbe{probeSocketFns: fns}
+
+	err := p.probeForSockDestroy(t.Context(), hivetest.Logger(t), false)
+	require.Error(t, err)
+	require.ErrorIs(t, err, probes.ErrNotSupported)
+}
+
+// TestProbeForSockDestroy_OtherSocketsButNotOurs checks the "unexpected" case
+// where we manage to list sockets but do not find a match.
+func TestProbeForSockDestroy_OtherSocketsButNotOurs(t *testing.T) {
+	fnl := newFakeNetlink()
+	fns := captureFns(t, fnl)
+	fns.iterate = func(proto uint8, family uint8, stateFilter uint32, fn func(*netlink.Socket, error) error) error {
+		// A socket that doesn't match (different port, non-loopback source).
+		return fn(&netlink.Socket{
+			ID: netlink.SocketID{SourcePort: 1, Source: net.IP{10, 0, 0, 1}},
+		}, nil)
+	}
+	p := &SocketInetProbe{probeSocketFns: fns}
+
+	err := p.probeForSockDestroy(t.Context(), hivetest.Logger(t), false)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, probes.ErrNotSupported)
+	require.Empty(t, fnl.destroyed)
+}
+
+// TestProbeForSockDestroy_IterateError verifies that a netlink-level error
+// returned directly from iterate (e.g. the socket subscribe handle fails) is
+// joined into the probe's returned error.
+func TestProbeForSockDestroy_IterateError(t *testing.T) {
+	fnl := newFakeNetlink()
+	fnl.iterErr = errors.New("boom")
+	fns := captureFns(t, fnl)
+	p := &SocketInetProbe{probeSocketFns: fns}
+
+	err := p.probeForSockDestroy(t.Context(), hivetest.Logger(t), true)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "boom")
+}
+
+// TestProbeForSockDestroy_ContextCancelledDuringIterate verifies that a context
+// cancel prior to the first destroy is respected.
+func TestProbeForSockDestroy_ContextCancelledDuringIterate(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	fnl := newFakeNetlink()
+	fns := captureFns(t, fnl)
+	fns.iterate = func(proto uint8, family uint8, stateFilter uint32, fn func(*netlink.Socket, error) error) error {
+		// Cancel just before delivering a matching socket; the callback's
+		// ctx.Err() check must fire before it attempts a destroy.
+		cancel()
+		return fn(&netlink.Socket{
+			ID: netlink.SocketID{SourcePort: 1234, Source: net.IP{127, 0, 0, 1}},
+		}, nil)
+	}
+	p := &SocketInetProbe{probeSocketFns: fns}
+
+	err := p.probeForSockDestroy(ctx, hivetest.Logger(t), false)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, fnl.destroyed)
+}
+
+// TestInetDiagDestroyEnabled_MemoizesResult verifies that the exported wrappers
+// run the underlying probe only once for a definitive (success) result and
+// return the memoized value on subsequent calls, per protocol.
+func TestInetDiagDestroyEnabled_MemoizesResult(t *testing.T) {
+	fnl := newFakeNetlink()
+	fns := captureFns(t, fnl)
+
+	tcpCreates := 0
+	realTCP := fns.createProbeTCPSocket
+	fns.createProbeTCPSocket = func(ctx context.Context) (*net.TCPListener, net.Conn, uint16, error) {
+		tcpCreates++
+		return realTCP(ctx)
+	}
+	udpCreates := 0
+	realUDP := fns.createProbeUDPSocket
+	fns.createProbeUDPSocket = func() (closer, uint16, error) {
+		udpCreates++
+		return realUDP()
+	}
+	p := &SocketInetProbe{probeSocketFns: fns}
+
+	logger := hivetest.Logger(t)
+	for range 3 {
+		require.NoError(t, p.InetDiagDestroyTCPEnabled(logger))
+		require.NoError(t, p.InetDiagDestroyUDPEnabled(logger))
+	}
+
+	// Despite three calls each, the probe (and thus socket creation) runs once
+	// per protocol.
+	require.Equal(t, 1, tcpCreates, "TCP probe should run exactly once")
+	require.Equal(t, 1, udpCreates, "UDP probe should run exactly once")
+}
+
+// TestInetDiagDestroyEnabled_TCPAndUDPStoredSeparately is a regression test for
+// the original memoization bug where a shared result pinned both protocols to
+// whichever ran first. Here UDP fails with ErrNotSupported while TCP succeeds;
+// each wrapper must report its own independent result, including on repeat calls.
+func TestInetDiagDestroyEnabled_TCPAndUDPStoredSeparately(t *testing.T) {
+	fnl := newFakeNetlink()
+	fns := captureFns(t, fnl)
+	// Make only UDP destroys fail; TCP must still report success.
+	fns.destroySocket = func(logger *slog.Logger, sock netlink.Socket, proto netlink.Proto, stateFilter uint32) error {
+		if proto == netlink.Proto(unix.IPPROTO_UDP) {
+			return unix.ENOTSUP
+		}
+		fnl.destroyed = append(fnl.destroyed, sock)
+		return nil
+	}
+	p := &SocketInetProbe{probeSocketFns: fns}
+
+	logger := hivetest.Logger(t)
+
+	// Drive UDP (failing) first to ensure its result doesn't bleed into TCP.
+	udpErr := p.InetDiagDestroyUDPEnabled(logger)
+	require.ErrorIs(t, udpErr, probes.ErrNotSupported)
+
+	tcpErr := p.InetDiagDestroyTCPEnabled(logger)
+	require.NoError(t, tcpErr, "TCP result must be independent of UDP's failure")
+
+	// And the memoized values stay distinct on repeat calls.
+	require.ErrorIs(t, p.InetDiagDestroyUDPEnabled(logger), probes.ErrNotSupported)
+	require.NoError(t, p.InetDiagDestroyTCPEnabled(logger))
+}
+
+// TestInetDiagDestroyEnabled_UnexpectedError verifies the "retry transient" half
+// of the memoization policy: an unexpected error (neither success nor
+// ErrNotSupported) is not cached, so a later call re-probes and can succeed -
+// after which the success is memoized.
+func TestInetDiagDestroyEnabled_UnexpectedError(t *testing.T) {
+	fnl := newFakeNetlink()
+	fns := captureFns(t, fnl)
+
+	fail := true
+	tcpCreates := 0
+	realTCP := fns.createProbeTCPSocket
+	fns.createProbeTCPSocket = func(ctx context.Context) (*net.TCPListener, net.Conn, uint16, error) {
+		tcpCreates++
+		if fail {
+			return nil, nil, 0, errors.New("transient boom")
+		}
+		return realTCP(ctx)
+	}
+	p := &SocketInetProbe{probeSocketFns: fns}
+
+	logger := hivetest.Logger(t)
+
+	// First call fails transiently.
+	err := p.InetDiagDestroyTCPEnabled(logger)
+	require.ErrorContains(t, err, "transient boom")
+	require.NotErrorIs(t, err, probes.ErrNotSupported)
+
+	// Recover, then a subsequent call must re-probe (not return the cached error).
+	fail = false
+	require.NoError(t, p.InetDiagDestroyTCPEnabled(logger))
+	require.Equal(t, 2, tcpCreates, "transient failure should be retried, not memoized")
+
+	// Now that it succeeded, the success is memoized.
+	require.NoError(t, p.InetDiagDestroyTCPEnabled(logger))
+	require.Equal(t, 2, tcpCreates, "success should be memoized")
+
+	fail = true
+	// Probes now should be memoized, so underlying failures shouldn't happen.
+	require.NoError(t, p.InetDiagDestroyTCPEnabled(logger))
+	require.Equal(t, 2, tcpCreates, "second success should be memoized")
 }

--- a/pkg/loadbalancer/cell/cell.go
+++ b/pkg/loadbalancer/cell/cell.go
@@ -6,6 +6,7 @@ package cell
 import (
 	"github.com/cilium/hive/cell"
 
+	"github.com/cilium/cilium/pkg/datapath/sockets"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/loadbalancer/healthserver"
 	"github.com/cilium/cilium/pkg/loadbalancer/maps"
@@ -31,6 +32,9 @@ var Cell = cell.Group(
 
 	// Reconciliation from tables to BPF maps.
 	reconciler.Cell,
+
+	// Inet probe for socket termination probing.
+	sockets.Cell,
 
 	// Control-plane for CiliumLocalRedirectPolicy
 	redirectpolicy.Cell,

--- a/pkg/loadbalancer/reconciler/termination.go
+++ b/pkg/loadbalancer/reconciler/termination.go
@@ -68,6 +68,7 @@ type socketTerminationParams struct {
 
 	MakeSocketDestroyer socketDestroyerFactory
 	NetNSOps            netnsOps
+	InetProbe           *sockets.SocketInetProbe
 
 	// TestSyncChan is used by the tests to synchronize with the job so it
 	// knows when to delete the backend.
@@ -107,19 +108,28 @@ func registerSocketTermination(p socketTerminationParams) error {
 		return nil
 	}
 
-	if err := sockets.InetDiagDestroyEnabled(p.Log, p.Config.LBSockTerminateAllProtos, true); err != nil {
-		if errors.Is(err, probes.ErrNotSupported) {
+	var probeErr error
+	if err := p.InetProbe.InetDiagDestroyUDPEnabled(p.Log); err != nil {
+		probeErr = errors.Join(probeErr, err)
+	}
+	if p.Config.LBSockTerminateAllProtos {
+		if err := p.InetProbe.InetDiagDestroyTCPEnabled(p.Log); err != nil {
+			probeErr = errors.Join(probeErr, err)
+		}
+	}
+	if probeErr != nil {
+		if errors.Is(probeErr, probes.ErrNotSupported) {
 			// The kernel doesn't support socket termination.
 			p.Log.Error("Forcefully terminating sockets connected to deleted service backends "+
-				"not supported by underlying kernel", logfields.Error, err)
-			p.Health.Degraded("service LV socket termination not supported by kernel", err)
+				"not supported by underlying kernel", logfields.Error, probeErr)
+			p.Health.Degraded("service LV socket termination not supported by kernel", probeErr)
 			return nil
 		}
 		p.Log.Error("Unexpected error while probing kernel socket termination support."+
 			"Will proceed with starting socket destroyer job but functionality may be degraded",
-			logfields.Error, err)
+			logfields.Error, probeErr)
 		p.Health.Degraded("Unexpected error while probing kernel socket termination support",
-			err)
+			probeErr)
 	}
 	p.JobGroup.Add(
 		job.OneShot(

--- a/pkg/loadbalancer/reconciler/termination_test.go
+++ b/pkg/loadbalancer/reconciler/termination_test.go
@@ -121,6 +121,7 @@ func testSocketTermination(t *testing.T, hostOnly bool) {
 				}
 			},
 		),
+		sockets.Cell,
 		cell.Invoke(registerSocketTermination),
 		cell.Invoke(func(db_ *statedb.DB, backends_ statedb.RWTable[*loadbalancer.Backend]) {
 			db = db_


### PR DESCRIPTION
Unfortunately, the old approach was flawed as it misused the sync once such that a) only the first call to the function produces a meaningful result (because err is not global scope) and b) we need to compute and store TCP and UDP separately lest we pin the result to whatever the first calls tcp/udp params were.

As it stands, this isn't a problem as there is only one caller but this may produce incorrect results if the probing is called from other places in the future.

Therefore, we split the TCP/UDP into seperate probe funcs for ergonomics and to allow us to store the results separately.

Also includes some minor fixes and improvements related to closing test socket listeners and logging.

[AI Influence Level]: AIL1: Claude Code was used to fix some tests and catch/fix some issues to my initial changes. Later it was used to refactor away from global vars into the SocketInetProbe and using that to write abstractions and more extensive test coverage for the probing and memoization functionality. 