### PR TITLE
docs: fix broken hive/cell pkg.go.dev link

### DIFF
--- a/Documentation/contributing/development/hive.rst
+++ b/Documentation/contributing/development/hive.rst
@@ -186,7 +186,7 @@ The ``hive.Hive`` type can be thought of as an application container, composed f
     // Hive also provides a sub-command for inspecting it:
     cmd.AddCommand(hive.Command())
 
-`hive/cell <https://pkg.go.dev/github.com/hive/cell>`_ defines the Cell interface that 
+`hive/cell <https://pkg.go.dev/github.com/cilium/hive/cell>`_ defines the Cell interface that
 ``hive.New()`` consumes and the following functions for creating cells:
 
 - :ref:`api_module`: A named set of cells.


### PR DESCRIPTION
The Hive development guide links `hive/cell` to `https://pkg.go.dev/github.com/hive/cell`, which returns HTTP 404. The package actually lives under the Cilium module, so the correct godoc URL is `https://pkg.go.dev/github.com/cilium/hive/cell` (returns HTTP 200). Docs-only fix.
