### PR TITLE
egressgw: remove redundant rp_filter assertion from privileged test

### DIFF
--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -135,11 +135,6 @@ func (v *parsedEgressRule) String() string {
 		v.sourceIP.String(), v.destCIDR.String(), v.gatewayIP.String(), v.egressIP.String())
 }
 
-type rpFilterSetting struct {
-	iFaceName       string
-	rpFilterSetting string
-}
-
 type EgressGatewayTestSuite struct {
 	manager   *Manager
 	policies  fakeResource[*Policy]
@@ -505,10 +500,6 @@ func TestPrivilegedEgressGatewayManager(t *testing.T) {
 
 	addPolicyAndReconcile(t, egressGatewayManager, k.policies, &policy1)
 
-	assertRPFilter(t, k.sysctl, []rpFilterSetting{
-		{iFaceName: testInterface1, rpFilterSetting: "2"},
-		{iFaceName: testInterface2, rpFilterSetting: "1"},
-	})
 	assertEgressRules4(t, policyMap4, []egressRule{})
 
 	// Add a new endpoint & ID which matches policy-1
@@ -1345,25 +1336,6 @@ func tryAssertEgressRules6(policyMap egressmap.PolicyMap6, rules []egressRule) e
 
 	if untrackedRule {
 		return fmt.Errorf("Untracked egress policy")
-	}
-
-	return nil
-}
-
-func assertRPFilter(t *testing.T, sysctl sysctl.Sysctl, rpFilterSettings []rpFilterSetting) {
-	t.Helper()
-
-	err := tryAssertRPFilterSettings(sysctl, rpFilterSettings)
-	require.NoError(t, err)
-}
-
-func tryAssertRPFilterSettings(sysctl sysctl.Sysctl, rpFilterSettings []rpFilterSetting) error {
-	for _, setting := range rpFilterSettings {
-		if val, err := sysctl.Read([]string{"net", "ipv4", "conf", setting.iFaceName, "rp_filter"}); err != nil {
-			return fmt.Errorf("failed to read rp_filter")
-		} else if val != setting.rpFilterSetting {
-			return fmt.Errorf("mismatched rp_filter iface: %s rp_filter: %s", setting.iFaceName, val)
-		}
 	}
 
 	return nil


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
      
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
      (N/A — this PR fixes a GitHub issue, not a prior commit.)
      
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [] Provide a title or release-note blurb suitable for the release notes. NA
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      This PR was prepared after Cursor assisted with root-cause analysis for
      #43947, and also made some changes in `testdata/test_rpfilter.txtar`.
       I personally reviewed all changes, verified the diff matches the intended
      migration (script test + removal of the privileged `assertRPFilter` helpers),
      and ran the privileged script test successfully on Linux.
- [x] Thanks for contributing!

## Summary
Part of #45893.
Move the `rp_filter` assertion from `TestPrivilegedEgressGatewayManager` into a
new script test (`testdata/test_rpfilter.txtar`). The script test uses the real
`sysctl.Cell` reconciler and asserts sysctl state via `db/cmp sysctl`, avoiding
the timing flake seen in #43947.
Changes:
- Add `pkg/egressgateway/testdata/test_rpfilter.txtar` — policy selects `eth0`
  as the egress gateway interface; asserts only `net.ipv4.conf.eth0.rp_filter=2`
  is set while `eth1` (present in the device table but not selected) is left alone
- Remove the flaky `assertRPFilter` check and related helpers from
  `manager_privileged_test.go`

## Test plan

Ran on Linux (x86_64, Go 1.26.4):

```bash
cd /mnt1/aviral/cilium/pkg/egressgateway
export TMPDIR=/mnt1/aviral/tmp
export GOCACHE=/mnt1/aviral/go-cache

go test -c -o /mnt1/aviral/egressgateway.test ./pkg/egressgateway/

PRIVILEGED_TESTS=true /mnt1/aviral/egressgateway.test \
  -test.run 'TestPrivilegedScripts/test_rpfilter' \
  -test.v -test.count=1

Output:
=== RUN   TestPrivilegedScripts
=== RUN   TestPrivilegedScripts/test_rpfilter.txtar
=== PAUSE TestPrivilegedScripts/test_rpfilter.txtar
=== CONT  TestPrivilegedScripts/test_rpfilter.txtar
    scripttest.go:253: 2026-07-11T09:46:43Z
    scripttest.go:255: $WORK=/mnt1/aviral/tmp/TestPrivilegedScriptstest_rpfilter.txtar702852538/001
=== NAME  TestPrivilegedScripts/test_rpfilter.txtar
    scripttest.go:72: > hive start
        > db/initialized
        health initialized
        k8s-object-tracker initialized
        Waiting for k8s-namespaces to initialize ([daemon-k8s])...
        k8s-namespaces initialized
        local-node initialized
        sysctl initialized
        devices initialized
    scripttest.go:72: > k8s/add node1.yaml ciliumnode1.yaml
        > k8s/add policy1.yaml
        > db/insert devices device-eth0.yaml device-eth1.yaml
    scripttest.go:72: > db/show sysctl --columns Name,Value
        [stdout]
        Name   Value
        > db/cmp --timeout=10s sysctl sysctl.expected
--- PASS: TestPrivilegedScripts (0.00s)
    --- PASS: TestPrivilegedScripts/test_rpfilter.txtar (1.06s)
PASS

