### PR TITLE
clustermesh: MCS-API endpoint slice mirror simplification 

### DIFF
--- a/pkg/clustermesh/mcsapi/endpointslice_mirror_controller.go
+++ b/pkg/clustermesh/mcsapi/endpointslice_mirror_controller.go
@@ -18,15 +18,11 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 
 	controllerruntime "github.com/cilium/cilium/operator/pkg/controller-runtime"
@@ -41,7 +37,16 @@ const (
 	// the component managing an EndpointSlice.
 	endpointSliceLocalMCSAPIControllerName = "endpointslice-local-mcsapi-controller.cilium.io"
 	localEndpointSliceLabel                = annotation.ServicePrefix + "/local-endpointslice"
+	malformedDerivedEndpointSlicePrefix    = "@malformed-derived|"
 )
+
+func malformedDerivedEndpointSliceRequest(name string) string {
+	return malformedDerivedEndpointSlicePrefix + name
+}
+
+func parseMalformedDerivedEndpointSliceRequest(name string) (string, bool) {
+	return strings.CutPrefix(name, malformedDerivedEndpointSlicePrefix)
+}
 
 // mcsAPIEndpointSliceMirrorReconciler is a controller that mirrors local
 // EndpointSlice from a local Service with a ServiceExport to its derived Service.
@@ -72,47 +77,73 @@ func getLocalEndpointSliceKey(derivedEpSlice *discoveryv1.EndpointSlice) *types.
 	}
 }
 
-func getLocalDerivedEndpointSliceKey(localEpSlice *discoveryv1.EndpointSlice) *types.NamespacedName {
-	suffix := getSuffix(localEpSlice)
-	derivedServiceName := getDerivedServiceName(localEpSlice)
-	if derivedServiceName == "" {
-		return nil
-	}
-	name := derivedServiceName + "-" + suffix
-	if suffix == "" {
-		name = derivedServiceName
-	}
-	return &types.NamespacedName{Name: name, Namespace: localEpSlice.Namespace}
+func getLocalDerivedEndpointSliceKey(localEpSlice *discoveryv1.EndpointSlice) types.NamespacedName {
+	name := strings.TrimRight(getDerivedServiceName(localEpSlice)+"-"+getSuffix(localEpSlice), "-")
+	return types.NamespacedName{Name: name, Namespace: localEpSlice.Namespace}
 }
 
-func (r *mcsAPIEndpointSliceMirrorReconciler) getLocalEndpointSlice(
-	ctx context.Context, derivedEpSlice *discoveryv1.EndpointSlice,
-) (*discoveryv1.EndpointSlice, error) {
-	localEpSliceKey := getLocalEndpointSliceKey(derivedEpSlice)
-	if localEpSliceKey == nil {
-		return nil, nil
-	}
-	var localEpSlice discoveryv1.EndpointSlice
-	if err := r.Client.Get(ctx, *localEpSliceKey, &localEpSlice); err != nil {
+func (r *mcsAPIEndpointSliceMirrorReconciler) getLocalEndpointSlice(ctx context.Context, key types.NamespacedName) (*discoveryv1.EndpointSlice, error) {
+	var epSlice discoveryv1.EndpointSlice
+	if err := r.Client.Get(ctx, key, &epSlice); err != nil {
 		return nil, client.IgnoreNotFound(err)
 	}
-	return &localEpSlice, nil
+
+	switch epSlice.Labels[discoveryv1.LabelManagedBy] {
+	case utils.EndpointSliceMeshControllerName, endpointSliceLocalMCSAPIControllerName:
+		return nil, nil
+	}
+
+	if epSlice.Labels[discoveryv1.LabelServiceName] == "" {
+		return nil, nil
+	}
+
+	return &epSlice, nil
+}
+
+func (r *mcsAPIEndpointSliceMirrorReconciler) getAndCleanupDerivedEndpointSlice(ctx context.Context, key types.NamespacedName, localEpSlice *discoveryv1.EndpointSlice) (*discoveryv1.EndpointSlice, error) {
+	serviceReq, _ := labels.NewRequirement(localEndpointSliceLabel, selection.Equals, []string{key.Name})
+	managedByReq, _ := labels.NewRequirement(discoveryv1.LabelManagedBy, selection.Equals, []string{endpointSliceLocalMCSAPIControllerName})
+	selector := labels.NewSelector()
+	selector = selector.Add(*serviceReq)
+	selector = selector.Add(*managedByReq)
+
+	var epSliceList discoveryv1.EndpointSliceList
+	if err := r.Client.List(ctx, &epSliceList, &client.ListOptions{Namespace: key.Namespace, LabelSelector: selector}); err != nil {
+		return nil, err
+	}
+
+	var derivedEpSlice *discoveryv1.EndpointSlice
+	var derivedEpSliceKey *types.NamespacedName
+	if localEpSlice != nil {
+		derivedEpSliceKey = new(getLocalDerivedEndpointSliceKey(localEpSlice))
+	}
+	for _, epSlice := range epSliceList.Items {
+		if derivedEpSliceKey != nil && epSlice.Name == derivedEpSliceKey.Name {
+			derivedEpSlice = &epSlice
+			continue
+		}
+		if err := r.Client.Delete(ctx, &epSlice); err != nil {
+			return nil, client.IgnoreNotFound(err)
+		}
+	}
+	return derivedEpSlice, nil
+}
+
+func (r *mcsAPIEndpointSliceMirrorReconciler) cleanupDerivedEndpointSlices(ctx context.Context, key types.NamespacedName) error {
+	_, err := r.getAndCleanupDerivedEndpointSlice(ctx, key, nil)
+	return err
 }
 
 func (r *mcsAPIEndpointSliceMirrorReconciler) shouldMirrorLocalEndpointSlice(
 	ctx context.Context, localEpSlice *discoveryv1.EndpointSlice, derivedService *corev1.Service,
 ) (bool, error) {
-	if localEpSlice == nil {
-		return false, nil
-	}
-	serviceName := localEpSlice.Labels[discoveryv1.LabelServiceName]
-	if serviceName == "" {
-		return false, nil
-	}
 	var svcExport mcsapiv1beta1.ServiceExport
 	if err := r.Client.Get(
 		ctx,
-		types.NamespacedName{Name: serviceName, Namespace: localEpSlice.Namespace},
+		types.NamespacedName{
+			Name:      localEpSlice.Labels[discoveryv1.LabelServiceName],
+			Namespace: localEpSlice.Namespace,
+		},
 		&svcExport,
 	); err != nil {
 		return false, client.IgnoreNotFound(err)
@@ -140,13 +171,8 @@ func (r *mcsAPIEndpointSliceMirrorReconciler) shouldMirrorLocalEndpointSlice(
 func (r *mcsAPIEndpointSliceMirrorReconciler) getFilteredPorts(
 	ctx context.Context, localEpSlice *discoveryv1.EndpointSlice, derivedService *corev1.Service,
 ) ([]discoveryv1.EndpointPort, error) {
-	if localEpSlice == nil {
-		return nil, nil
-	}
-
 	// Note that shouldMirrorLocalEndpointSlice already guarantee that a
-	// ServiceExport exist for a local EndpointSlice and that the
-	// local EndpointSlice has a service label name too
+	// ServiceExport exist for a local EndpointSlice
 	var localService corev1.Service
 	if err := r.Client.Get(ctx, types.NamespacedName{
 		Name:      localEpSlice.Labels[discoveryv1.LabelServiceName],
@@ -196,27 +222,9 @@ func (r *mcsAPIEndpointSliceMirrorReconciler) getFilteredPorts(
 }
 
 func getDerivedServiceName(localEpSlice *discoveryv1.EndpointSlice) string {
-	serviceName := localEpSlice.Labels[discoveryv1.LabelServiceName]
-	if serviceName == "" {
-		return ""
-	}
 	return derivedName(types.NamespacedName{
-		Name: serviceName, Namespace: localEpSlice.Namespace,
+		Name: localEpSlice.Labels[discoveryv1.LabelServiceName], Namespace: localEpSlice.Namespace,
 	})
-}
-
-func (r *mcsAPIEndpointSliceMirrorReconciler) getLocalDerivedEndpointSlice(
-	ctx context.Context, localEpSlice *discoveryv1.EndpointSlice,
-) (*discoveryv1.EndpointSlice, error) {
-	derivedEpSliceKey := getLocalDerivedEndpointSliceKey(localEpSlice)
-	if derivedEpSliceKey == nil {
-		return nil, nil
-	}
-	var derivedEpSlice discoveryv1.EndpointSlice
-	if err := r.Client.Get(ctx, *derivedEpSliceKey, &derivedEpSlice); err != nil {
-		return nil, client.IgnoreNotFound(err)
-	}
-	return &derivedEpSlice, nil
 }
 
 func (r *mcsAPIEndpointSliceMirrorReconciler) updateDerivedEndpointSlice(
@@ -250,9 +258,6 @@ func (r *mcsAPIEndpointSliceMirrorReconciler) newDerivedEndpointSlice(
 	localEpSlice *discoveryv1.EndpointSlice, derivedService *corev1.Service,
 	filteredPorts []discoveryv1.EndpointPort,
 ) *discoveryv1.EndpointSlice {
-	// Note that derivedEpsliceKey can not return nil here since it has already
-	// been checked by shouldMirrorLocalEndpointSlice that prevents the EndpointSlice
-	// to not have a service label name
 	derivedEpSliceKey := getLocalDerivedEndpointSliceKey(localEpSlice)
 	derivedEndpointSlice := discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
@@ -266,74 +271,26 @@ func (r *mcsAPIEndpointSliceMirrorReconciler) newDerivedEndpointSlice(
 }
 
 func (r *mcsAPIEndpointSliceMirrorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	var epSlice discoveryv1.EndpointSlice
-	if err := r.Client.Get(ctx, req.NamespacedName, &epSlice); err != nil {
-		return controllerruntime.Fail(client.IgnoreNotFound(err))
+	// Most reconcile requests should be from local endpoint slices except when
+	// we cannot map the derived object back when we receive events. In this case
+	// we use a specific prefix and handle it outside of the normal reconcile flow.
+	if name, ok := parseMalformedDerivedEndpointSliceRequest(req.Name); ok {
+		return r.reconcileMalformedDerivedEndpointSlice(ctx, types.NamespacedName{
+			Name:      name,
+			Namespace: req.Namespace,
+		})
 	}
 
-	var localEpSlice *discoveryv1.EndpointSlice
-	var derivedEpSlice *discoveryv1.EndpointSlice
-	var derivedServiceName string
-	var err error
-
-	if epSlice.Labels[discoveryv1.LabelManagedBy] == endpointSliceLocalMCSAPIControllerName {
-		derivedEpSlice = &epSlice
-		localEpSlice, err = r.getLocalEndpointSlice(ctx, derivedEpSlice)
-		if err != nil {
-			return controllerruntime.Fail(err)
-		}
-		derivedServiceName = derivedEpSlice.Labels[discoveryv1.LabelServiceName]
-		// We try to aggressively find the service name here to have a chance to fix the mirrored EndpointSlice
-		if derivedServiceName == "" {
-			derivedServiceName = getOwnerReferenceName(derivedEpSlice.GetOwnerReferences(), "v1", "Service")
-		}
-		if derivedServiceName == "" && localEpSlice != nil {
-			derivedServiceName = getDerivedServiceName(localEpSlice)
-		}
-	} else {
-		localEpSlice = &epSlice
-		derivedEpSlice, err = r.getLocalDerivedEndpointSlice(ctx, localEpSlice)
-		if err != nil {
-			return controllerruntime.Fail(err)
-		}
-		derivedServiceName = getDerivedServiceName(localEpSlice)
+	localEpSlice, err := r.getLocalEndpointSlice(ctx, req.NamespacedName)
+	if err != nil {
+		return controllerruntime.Fail(err)
+	} else if localEpSlice == nil {
+		return controllerruntime.Fail(r.cleanupDerivedEndpointSlices(ctx, req.NamespacedName))
 	}
 
-	// Not finding the derived service name essentially means that the user manually
-	// removed every mention of a link that we support between the EndpointSlice and its Service.
-	if derivedServiceName == "" {
-		if derivedEpSlice != nil {
-			r.Logger.Warn(
-				"Can not find a possible related derived Service name, "+
-					"derived mirrored EndpointSlice was likely tampered and will be deleted",
-				logfields.Request, req.NamespacedName,
-			)
-			if err := r.Client.Delete(ctx, derivedEpSlice); err != nil {
-				return controllerruntime.Fail(client.IgnoreNotFound(err))
-			}
-		} else if localEpSlice != nil {
-			// This will happen if the user has manually created an EndpointSlice and remove the label service name
-			// instead of deleting it. In that case we find the mirrored derived EndpointSlice from its label
-			// and remove it bypassing the general logic for this specific case.
-			if derivedEpSlice, err = r.getDerivedEndpointSliceByLabel(ctx, client.ObjectKeyFromObject(localEpSlice)); err != nil {
-				return controllerruntime.Fail(err)
-			}
-			if derivedEpSlice == nil {
-				r.Logger.Debug(
-					"Can not find a possible related derived Service name, reconciliation is aborted",
-					logfields.Request, req.NamespacedName,
-				)
-				return controllerruntime.Success()
-			}
-			if err := r.Client.Delete(ctx, derivedEpSlice); err != nil {
-				return controllerruntime.Fail(client.IgnoreNotFound(err))
-			}
-			return controllerruntime.Success()
-		}
-	}
 	var derivedService corev1.Service
 	if err := r.Client.Get(ctx, types.NamespacedName{
-		Name:      derivedServiceName,
+		Name:      getDerivedServiceName(localEpSlice),
 		Namespace: req.Namespace,
 	}, &derivedService); err != nil {
 		// If the derived service is not found, it probably isn't created yet
@@ -342,36 +299,34 @@ func (r *mcsAPIEndpointSliceMirrorReconciler) Reconcile(ctx context.Context, req
 		return controllerruntime.Fail(client.IgnoreNotFound(err))
 	}
 
-	var shouldMirror bool
-	if shouldMirror, err = r.shouldMirrorLocalEndpointSlice(ctx, localEpSlice, &derivedService); err != nil {
+	if shouldMirror, err := r.shouldMirrorLocalEndpointSlice(ctx, localEpSlice, &derivedService); err != nil {
+		return controllerruntime.Fail(err)
+	} else if !shouldMirror {
+		return controllerruntime.Fail(r.cleanupDerivedEndpointSlices(ctx, req.NamespacedName))
+	}
+
+	filteredPorts, err := r.getFilteredPorts(ctx, localEpSlice, &derivedService)
+	if err != nil {
 		return controllerruntime.Fail(err)
 	}
-	if !shouldMirror {
-		localEpSlice = nil
+	if len(filteredPorts) == 0 {
+		// If all ports are filtered out we should exclude this EndpointSlice
+		return controllerruntime.Fail(r.cleanupDerivedEndpointSlices(ctx, req.NamespacedName))
 	}
 
-	var filteredPorts []discoveryv1.EndpointPort
-	if localEpSlice != nil {
-		filteredPorts, err = r.getFilteredPorts(ctx, localEpSlice, &derivedService)
-		if err != nil {
-			return controllerruntime.Fail(err)
-		}
-		if len(filteredPorts) == 0 {
-			// If all ports are filtered out we should exclude this EndpointSlice
-			localEpSlice = nil
-		}
+	derivedEpSlice, err := r.getAndCleanupDerivedEndpointSlice(ctx, req.NamespacedName, localEpSlice)
+	if err != nil {
+		return controllerruntime.Fail(err)
 	}
 
-	if localEpSlice == nil && derivedEpSlice != nil {
-		err = r.Client.Delete(ctx, derivedEpSlice)
-	} else if localEpSlice != nil && derivedEpSlice == nil {
+	if derivedEpSlice == nil {
 		derivedEpSlice = r.newDerivedEndpointSlice(localEpSlice, &derivedService, filteredPorts)
 		err = r.Client.Create(ctx, derivedEpSlice)
 		if k8sApiErrors.IsForbidden(err) && k8sApiErrors.HasStatusCause(err, corev1.NamespaceTerminatingCause) {
 			r.Logger.InfoContext(ctx, "Aborting reconciliation because namespace is being terminated")
 			return controllerruntime.Success()
 		}
-	} else if localEpSlice != nil && r.needUpdate(localEpSlice, derivedEpSlice, &derivedService, filteredPorts) {
+	} else if r.needUpdate(localEpSlice, derivedEpSlice, &derivedService, filteredPorts) {
 		r.updateDerivedEndpointSlice(derivedEpSlice, localEpSlice, &derivedService, filteredPorts)
 		err = r.Client.Update(ctx, derivedEpSlice)
 	}
@@ -379,69 +334,62 @@ func (r *mcsAPIEndpointSliceMirrorReconciler) Reconcile(ctx context.Context, req
 	return controllerruntime.Fail(err)
 }
 
-// endpointSliceMirrorDeleteWatcher watch EndpointSlice and return the predicted
-// mirrored EndpointSlice. If a non derived EndpointSlice it will return a derived
-// EndpointSlice and the other way around. We have to do this because the very first
-// thing we do in the Reconcile method is to get the EndpointSlice requested so on
-// a delete we have to swap the EndpointSlice object essentially.
-type endpointSliceMirrorDeleteWatcher struct{}
+func (r *mcsAPIEndpointSliceMirrorReconciler) reconcileMalformedDerivedEndpointSlice(ctx context.Context, key types.NamespacedName) (ctrl.Result, error) {
+	var epSlice discoveryv1.EndpointSlice
+	if err := r.Client.Get(ctx, key, &epSlice); err != nil {
+		return controllerruntime.Fail(client.IgnoreNotFound(err))
+	}
 
-func (*endpointSliceMirrorDeleteWatcher) Delete(ctx context.Context, evt event.TypedDeleteEvent[client.Object], q workqueue.TypedRateLimitingInterface[ctrl.Request]) {
-	epSlice := evt.Object.(*discoveryv1.EndpointSlice)
+	if epSlice.Labels[discoveryv1.LabelManagedBy] != endpointSliceLocalMCSAPIControllerName ||
+		getLocalEndpointSliceKey(&epSlice) != nil {
+		// This endpoint slice is no longer malformed
+		return controllerruntime.Success()
+	}
+
+	r.Logger.Warn(
+		"This derived EndpointSlice was tampered and cannot be traced back to its source and will be deleted",
+		logfields.Request, key,
+	)
+	return controllerruntime.Fail(client.IgnoreNotFound(r.Client.Delete(
+		ctx, &epSlice,
+		client.Preconditions{UID: &epSlice.UID, ResourceVersion: &epSlice.ResourceVersion},
+	)))
+}
+
+func endpointSliceMirrorRequests(obj client.Object) []ctrl.Request {
+	epSlice := obj.(*discoveryv1.EndpointSlice)
 	switch epSlice.Labels[discoveryv1.LabelManagedBy] {
 	case utils.EndpointSliceMeshControllerName:
 		// We can explicitly ignore remote EndpointSlice
+		return nil
 	case endpointSliceLocalMCSAPIControllerName:
 		localEpSliceKey := getLocalEndpointSliceKey(epSlice)
 		if localEpSliceKey == nil {
-			return
+			return []ctrl.Request{{NamespacedName: types.NamespacedName{
+				Namespace: epSlice.Namespace,
+				Name:      malformedDerivedEndpointSliceRequest(epSlice.Name),
+			}}}
 		}
-		q.Add(ctrl.Request{NamespacedName: *localEpSliceKey})
+		return []ctrl.Request{{NamespacedName: *localEpSliceKey}}
 	default:
-		derivedEpSliceKey := getLocalDerivedEndpointSliceKey(epSlice)
-		if derivedEpSliceKey == nil {
-			return
-		}
-		q.Add(ctrl.Request{NamespacedName: *derivedEpSliceKey})
+		return []ctrl.Request{{NamespacedName: client.ObjectKeyFromObject(epSlice)}}
 	}
-}
-
-func (*endpointSliceMirrorDeleteWatcher) Create(context.Context, event.TypedCreateEvent[client.Object], workqueue.TypedRateLimitingInterface[ctrl.Request]) {
-}
-
-func (*endpointSliceMirrorDeleteWatcher) Update(context.Context, event.TypedUpdateEvent[client.Object], workqueue.TypedRateLimitingInterface[ctrl.Request]) {
-}
-
-func (*endpointSliceMirrorDeleteWatcher) Generic(context.Context, event.TypedGenericEvent[client.Object], workqueue.TypedRateLimitingInterface[ctrl.Request]) {
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *mcsAPIEndpointSliceMirrorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("EndpointSliceMirrorMCSAPI").
-		For(&discoveryv1.EndpointSlice{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
-			switch obj.GetLabels()[discoveryv1.LabelManagedBy] {
-			case utils.EndpointSliceMeshControllerName:
-				// We can explicitly ignore remote EndpointSlice
-			case endpointSliceLocalMCSAPIControllerName:
-				return true
-			default:
-				return true
-			}
-
-			return false
-		}))).
-
-		// Special watchers for EndpointSlice deletion
-		Watches(&discoveryv1.EndpointSlice{}, &endpointSliceMirrorDeleteWatcher{}).
+		Watches(&discoveryv1.EndpointSlice{}, handler.EnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []ctrl.Request {
+			return endpointSliceMirrorRequests(obj)
+		})).
 
 		// Watch for changes to Service to enqueue local EndpointSlice
 		Watches(&mcsapiv1beta1.ServiceExport{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
 			return r.getEndpointSliceFromServiceRequests(ctx, client.ObjectKeyFromObject(obj))
 		})).
-		// Watch for changes to derived Service to enqueue local EndpointSlices.
-		// We need to enqueue the "other" EndpointSlice to allow derived
-		// EndpointSlice initial creation.
+		// Watch for changes to derived Service to enqueue local EndpointSlices,
+		// allowing derived EndpointSlice initial creation.
 		// Also watch for changes to local Service to refresh port filtering
 		// if local Service ports where to change.
 		Watches(&corev1.Service{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []ctrl.Request {
@@ -466,7 +414,7 @@ func (r *mcsAPIEndpointSliceMirrorReconciler) getEndpointSliceFromServiceRequest
 
 	requests := make([]ctrl.Request, 0, len(epSliceList.Items))
 	for _, epSlice := range epSliceList.Items {
-		requests = append(requests, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(&epSlice)})
+		requests = append(requests, endpointSliceMirrorRequests(&epSlice)...)
 	}
 	return requests
 }
@@ -507,21 +455,4 @@ func (r *mcsAPIEndpointSliceMirrorReconciler) needUpdate(
 		return reflect.DeepEqual(a, b)
 	}
 	return !slices.EqualFunc(derivedEpSlice.Ports, desiredDerivedEndpointSlice.Ports, equalsEndpointPort)
-}
-
-func (r *mcsAPIEndpointSliceMirrorReconciler) getDerivedEndpointSliceByLabel(ctx context.Context, key types.NamespacedName) (*discoveryv1.EndpointSlice, error) {
-	serviceReq, _ := labels.NewRequirement(localEndpointSliceLabel, selection.Equals, []string{key.Name})
-	selector := labels.NewSelector()
-	selector = selector.Add(*serviceReq)
-
-	var epSliceList discoveryv1.EndpointSliceList
-	if err := r.Client.List(ctx, &epSliceList, &client.ListOptions{Namespace: key.Namespace, LabelSelector: selector}); err != nil {
-		return nil, err
-	}
-
-	if len(epSliceList.Items) != 1 {
-		return nil, nil
-	}
-
-	return &epSliceList.Items[0], nil
 }

--- a/pkg/clustermesh/mcsapi/endpointslice_mirror_controller.go
+++ b/pkg/clustermesh/mcsapi/endpointslice_mirror_controller.go
@@ -37,8 +37,22 @@ const (
 	// the component managing an EndpointSlice.
 	endpointSliceLocalMCSAPIControllerName = "endpointslice-local-mcsapi-controller.cilium.io"
 	localEndpointSliceLabel                = annotation.ServicePrefix + "/local-endpointslice"
+	derivedEndpointSliceByLocalNameIndex   = "mcs.cilium.io/derived-endpointslice-by-local-name"
 	malformedDerivedEndpointSlicePrefix    = "@malformed-derived|"
 )
+
+func derivedEndpointSliceByLocalNameIndexFunc(obj client.Object) []string {
+	epSlice := obj.(*discoveryv1.EndpointSlice)
+	if epSlice.Labels[discoveryv1.LabelManagedBy] != endpointSliceLocalMCSAPIControllerName {
+		return nil
+	}
+
+	localName := epSlice.Labels[localEndpointSliceLabel]
+	if localName == "" {
+		return nil
+	}
+	return []string{localName}
+}
 
 func malformedDerivedEndpointSliceRequest(name string) string {
 	return malformedDerivedEndpointSlicePrefix + name
@@ -101,14 +115,13 @@ func (r *mcsAPIEndpointSliceMirrorReconciler) getLocalEndpointSlice(ctx context.
 }
 
 func (r *mcsAPIEndpointSliceMirrorReconciler) getAndCleanupDerivedEndpointSlice(ctx context.Context, key types.NamespacedName, localEpSlice *discoveryv1.EndpointSlice) (*discoveryv1.EndpointSlice, error) {
-	serviceReq, _ := labels.NewRequirement(localEndpointSliceLabel, selection.Equals, []string{key.Name})
-	managedByReq, _ := labels.NewRequirement(discoveryv1.LabelManagedBy, selection.Equals, []string{endpointSliceLocalMCSAPIControllerName})
-	selector := labels.NewSelector()
-	selector = selector.Add(*serviceReq)
-	selector = selector.Add(*managedByReq)
-
 	var epSliceList discoveryv1.EndpointSliceList
-	if err := r.Client.List(ctx, &epSliceList, &client.ListOptions{Namespace: key.Namespace, LabelSelector: selector}); err != nil {
+	if err := r.Client.List(
+		ctx, &epSliceList,
+		client.InNamespace(key.Namespace),
+		client.MatchingFields{derivedEndpointSliceByLocalNameIndex: key.Name},
+		client.MatchingLabels{discoveryv1.LabelManagedBy: endpointSliceLocalMCSAPIControllerName},
+	); err != nil {
 		return nil, err
 	}
 
@@ -378,6 +391,15 @@ func endpointSliceMirrorRequests(obj client.Object) []ctrl.Request {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *mcsAPIEndpointSliceMirrorReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(),
+		&discoveryv1.EndpointSlice{},
+		derivedEndpointSliceByLocalNameIndex,
+		derivedEndpointSliceByLocalNameIndexFunc,
+	); err != nil {
+		return err
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("EndpointSliceMirrorMCSAPI").
 		Watches(&discoveryv1.EndpointSlice{}, handler.EnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []ctrl.Request {

--- a/pkg/clustermesh/mcsapi/endpointslice_mirror_controller_test.go
+++ b/pkg/clustermesh/mcsapi/endpointslice_mirror_controller_test.go
@@ -235,6 +235,18 @@ var (
 			Ports:       commonPorts,
 			AddressType: discoveryv1.AddressTypeIPv4,
 		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "full-duplicate-derived",
+				Namespace: "default",
+				Labels: map[string]string{
+					discoveryv1.LabelServiceName: "full",
+				},
+			},
+			Endpoints:   commonEndpoints,
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv4,
+		},
 
 		&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
@@ -406,6 +418,28 @@ var (
 			Ports:       commonPorts,
 			AddressType: discoveryv1.AddressTypeIPv4,
 		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            commonDerivedName + "-duplicate-derived",
+				Namespace:       "default",
+				Labels:          getExpectedDerivedLabels("full-duplicate-derived"),
+				OwnerReferences: commonOwnerReferences,
+			},
+			Endpoints:   commonEndpoints,
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv4,
+		},
+		&discoveryv1.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            commonDerivedName + "-duplicate-derived-extra",
+				Namespace:       "default",
+				Labels:          getExpectedDerivedLabels("full-duplicate-derived"),
+				OwnerReferences: commonOwnerReferences,
+			},
+			Endpoints:   commonEndpoints,
+			Ports:       commonPorts,
+			AddressType: discoveryv1.AddressTypeIPv4,
+		},
 
 		&mcsapiv1beta1.ServiceExport{
 			TypeMeta: typeMetaSvcExport,
@@ -475,38 +509,26 @@ func Test_mcsEndpointSliceMirror_Reconcile(t *testing.T) {
 		clusterName: "cluster1",
 	}
 
-	for _, tt := range []struct {
-		suffix                string
-		derivedReconciliation bool
-	}{
-		{suffix: "keep"},
-		{suffix: ""},
-		{suffix: "update-1"},
-		{suffix: "update-2"},
-		{suffix: "update-3"},
-		{suffix: "update-4"},
-		{suffix: "update-5"},
-		{
-			suffix:                "not-linked-service-2",
-			derivedReconciliation: true,
-		},
-		{
-			suffix:                "not-linked-service-3",
-			derivedReconciliation: true,
-		},
+	for _, suffix := range []string{
+		"keep",
+		"",
+		"update-1",
+		"update-2",
+		"update-3",
+		"update-4",
+		"update-5",
+		"not-linked-service-2",
+		"not-linked-service-3",
 	} {
-		t.Run(fmt.Sprintf("Check mirrored Endpoint %s", tt.suffix), func(t *testing.T) {
-			fullSuffix := "-" + tt.suffix
-			if tt.suffix == "" {
+		t.Run(fmt.Sprintf("Check mirrored Endpoint %s", suffix), func(t *testing.T) {
+			fullSuffix := "-" + suffix
+			if suffix == "" {
 				fullSuffix = ""
 			}
 
 			key := types.NamespacedName{
 				Name:      "full" + fullSuffix,
 				Namespace: "default",
-			}
-			if tt.derivedReconciliation {
-				key.Name = commonDerivedName + fullSuffix
 			}
 			result, err := r.Reconcile(t.Context(), ctrl.Request{
 				NamespacedName: key,
@@ -515,10 +537,10 @@ func Test_mcsEndpointSliceMirror_Reconcile(t *testing.T) {
 			require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
 			keyDerived := types.NamespacedName{
-				Name:      commonDerivedName + "-" + tt.suffix,
+				Name:      commonDerivedName + "-" + suffix,
 				Namespace: "default",
 			}
-			if tt.suffix == "" {
+			if suffix == "" {
 				keyDerived.Name = commonDerivedName
 			}
 			epSlice := &discoveryv1.EndpointSlice{}
@@ -554,27 +576,57 @@ func Test_mcsEndpointSliceMirror_Reconcile(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("Check duplicate derived Endpoint cleanup", func(t *testing.T) {
+		key := types.NamespacedName{
+			Name:      "full-duplicate-derived",
+			Namespace: "default",
+		}
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
+			NamespacedName: key,
+		})
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		keyDerived := types.NamespacedName{
+			Name:      commonDerivedName + "-duplicate-derived",
+			Namespace: "default",
+		}
+		epSlice := &discoveryv1.EndpointSlice{}
+		err = c.Get(t.Context(), keyDerived, epSlice)
+		require.NoError(t, err)
+
+		keyDuplicate := types.NamespacedName{
+			Name:      commonDerivedName + "-duplicate-derived-extra",
+			Namespace: "default",
+		}
+		err = c.Get(t.Context(), keyDuplicate, epSlice)
+		require.True(t, apierrors.IsNotFound(err), "duplicate EndpointSlice should be deleted")
+	})
+
 	for _, tt := range []struct {
-		suffix              string
-		localReconciliation bool
+		suffix           string
+		malformedCleanup bool
 	}{
 		{suffix: "delete"},
 		{suffix: "wrong-family-delete"},
 		{suffix: "wrong-family-ignore"},
+		{suffix: "not-linked-service-1"},
 		{
-			suffix:              "not-linked-service-1",
-			localReconciliation: true,
+			suffix:           "not-linked-service-4",
+			malformedCleanup: true,
 		},
-		{suffix: "not-linked-service-4"},
 	} {
 		t.Run(fmt.Sprintf("Check delete Endpoint %s", tt.suffix), func(t *testing.T) {
 			keyDerived := types.NamespacedName{
 				Name:      commonDerivedName + "-" + tt.suffix,
 				Namespace: "default",
 			}
-			keyReconcile := keyDerived
-			if tt.localReconciliation {
-				keyReconcile.Name = "full-" + tt.suffix
+			keyReconcile := types.NamespacedName{
+				Name:      "full-" + tt.suffix,
+				Namespace: "default",
+			}
+			if tt.malformedCleanup {
+				keyReconcile.Name = malformedDerivedEndpointSliceRequest(keyDerived.Name)
 			}
 			result, err := r.Reconcile(t.Context(), ctrl.Request{
 				NamespacedName: keyReconcile,

--- a/pkg/clustermesh/mcsapi/endpointslice_mirror_controller_test.go
+++ b/pkg/clustermesh/mcsapi/endpointslice_mirror_controller_test.go
@@ -502,6 +502,7 @@ func Test_mcsEndpointSliceMirror_Reconcile(t *testing.T) {
 	c := fake.NewClientBuilder().
 		WithObjects(endpointsliceMirrorFixtures...).
 		WithScheme(testScheme()).
+		WithIndex(&discoveryv1.EndpointSlice{}, derivedEndpointSliceByLocalNameIndex, derivedEndpointSliceByLocalNameIndexFunc).
 		Build()
 	r := &mcsAPIEndpointSliceMirrorReconciler{
 		Client:      c,


### PR DESCRIPTION
I made this while brainstorming about how I would do the mirroring for the new endpointslicesync logic with ClusterEndpointSlice and found that we could simplify the logic to not requeue both the source and the target (which would be even more relevant for ClusterEndpointSlice since the source and target would be stored in different places).

Used AIL-2 to help write this PR