### PR TITLE
operator: Fix nil-pointer panic in CiliumNode GC

### DIFF
--- a/operator/watchers/cilium_node_gc.go
+++ b/operator/watchers/cilium_node_gc.go
@@ -106,10 +106,17 @@ func shouldGCNode(ctx context.Context, nodeName string, ciliumNodeStore resource
 		return false, err
 	}
 
-	cn, _, err := ciliumNodeStore.GetByKey(resource.Key{Name: nodeName})
+	cn, exists, err := ciliumNodeStore.GetByKey(resource.Key{Name: nodeName})
 	if err != nil {
 		scopedLog.ErrorContext(ctx, "Unable to fetch CiliumNode from store", logfields.Error, err)
 		return false, err
+	}
+	if !exists {
+		// Raced with a store delete between IterKeys() and GetByKey(), nothing
+		// to GC. Drop any stale candidate entry, since this key will not be
+		// yielded by IterKeys() again once the delete propagates.
+		candidateStore.Delete(nodeName)
+		return false, nil
 	}
 
 	// if there is owner references, let k8s handle garbage collection

--- a/operator/watchers/cilium_node_gc_test.go
+++ b/operator/watchers/cilium_node_gc_test.go
@@ -86,6 +86,40 @@ func Test_performCiliumNodeGC(t *testing.T) {
 	assert.False(t, exists)
 }
 
+// Test_shouldGCNode_notInStore ensures that when a CiliumNode key is yielded
+// by the CiliumNode store's IterKeys() but the object has already been removed
+// from that store by the time GetByKey() runs (a race between IterKeys and
+// GetByKey), shouldGCNode does not dereference the nil *CiliumNode and instead
+// skips GC gracefully.
+func Test_shouldGCNode_notInStore(t *testing.T) {
+	_, cs := k8sClient.NewFakeClientset(hivetest.Logger(t))
+
+	ciliumNodes, err := operatorK8s.CiliumNodeResource(hivetest.Lifecycle(t), cs, nil)
+	assert.NoError(t, err)
+
+	store, err := ciliumNodes.Store(t.Context())
+	assert.NoError(t, err)
+
+	// The k8s node is gone (NotFound), so GC proceeds to look up the
+	// CiliumNode, which is absent from the store: GetByKey returns
+	// (nil, false, nil).
+	fng := &fakeNodeGetter{
+		OnGetK8sSlimNode: func(nodeName string) (*slim_corev1.Node, error) {
+			return nil, k8serrors.NewNotFound(schema.GroupResource{}, nodeName)
+		},
+	}
+
+	// Seed a stale candidate entry for the node so we can verify it gets
+	// reclaimed when the node is found to be absent from the store.
+	candidateStore := newCiliumNodeGCCandidate()
+	candidateStore.Add("ghost-node")
+
+	shouldGC, err := shouldGCNode(t.Context(), "ghost-node", store, fng, time.Nanosecond, candidateStore, hivetest.Logger(t))
+	assert.NoError(t, err)
+	assert.False(t, shouldGC)
+	assert.Empty(t, candidateStore.nodesToRemove)
+}
+
 func Test_performCiliumNodeGC_oneOff(t *testing.T) {
 	// save global config and restore at the end of the test
 	prevCiliumNode := option.Config.EnableCiliumNodeCRD


### PR DESCRIPTION
`shouldGCNode` discarded the `exists` return of `resource.Store.GetByKey` and only checked `err`. When a CiliumNode is deleted from the store between `IterKeys()` snapshotting the key and the `GetByKey()` lookup, `GetByKey` returns `(nil, false, nil)`, so the subsequent `cn.GetOwnerReferences()` dereferenced a nil *CiliumNode and crashed the operator with SIGSEGV.

This PR adds a guard on `exists` and skips GC for the vanished node.

It also drops any stale garbage-collector candidate entry when the CiliumNode has vanished from the store. Candidate entries were previously reclaimed only on a successful GC delete, so a node marked as a candidate that then disappeared before the interval elapsed would leak its entry in `candidateStore.nodesToRemove` indefinitely (its key is no longer yielded by `IterKeys()`, so `shouldGCNode` is never called for it again).

Fixes these panics:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xc8 pc=0x200bb24]
goroutine 468 [running]:
github.com/cilium/cilium/operator/watchers.shouldGCNode({0x4fedc70, 0x4020bff950}, {0x401d2e5100, 0x1c}, {0x500b7a0, 0x4003294ff0}, {0x4faf028?, 0x8313720?}, 0x45d964b800, 0x400fb4ac00, ...)
	/go/src/github.com/cilium/cilium/operator/watchers/cilium_node_gc.go:179 +0x194
github.com/cilium/cilium/operator/watchers.performCiliumNodeGC({0x4fedc70, 0x4020bff950}, {0x501b460, 0x404280f2b0}, {0x500b7a0, 0x4003294ff0}, {0x4faf028, 0x8313720}, 0x45d964b800, 0x400fb4ac00, ...)
	/go/src/github.com/cilium/cilium/operator/watchers/cilium_node_gc.go:134 +0x130
github.com/cilium/cilium/operator/watchers.RunCiliumNodeGC.func1({0x4fedc70, 0x4020bff950})
	/go/src/github.com/cilium/cilium/operator/watchers/cilium_node_gc.go:109 +0x9c
github.com/cilium/cilium/pkg/controller.(*controller).runController(0x4000afa9a0)
	/go/src/github.com/cilium/cilium/pkg/controller/controller.go:333 +0x1d0
created by github.com/cilium/cilium/pkg/controller.(*Manager).createControllerLocked in goroutine 226
	/go/src/github.com/cilium/cilium/pkg/controller/manager.go:131 +0x380
```