### PR TITLE
resource: fix possible goroutine leak in filtered resource

### DIFF
--- a/pkg/k8s/resource/filtered_resource.go
+++ b/pkg/k8s/resource/filtered_resource.go
@@ -38,15 +38,23 @@ func (r *filteringResource[T]) Events(ctx context.Context, opts ...EventsOpt) <-
 	parentEvents := r.parent.Events(ctx, opts...)
 
 	go func() {
+		var send = func(ev Event[T]) {
+			select {
+			case out <- ev:
+			case <-ctx.Done():
+				ev.Done(nil)
+			}
+		}
+
 		defer close(out)
 		for ev := range parentEvents {
 			if ev.Kind == Sync {
-				out <- ev
+				send(ev)
 				continue
 			}
 
 			if r.filter(ev.Object) {
-				out <- ev
+				send(ev)
 			} else {
 				ev.Done(nil)
 			}

--- a/pkg/k8s/resource/filtered_resource_test.go
+++ b/pkg/k8s/resource/filtered_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/cilium/hive/cell"
@@ -254,6 +255,26 @@ func TestFilteringResource_Events(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFilteringResource_Events_Drain(t *testing.T) {
+	// Validate that no goroutine is leaked even if we don't drain the events
+	// channel. We leverage synctest to obtain a better failure, as it fails
+	// if any goroutine in the bubble deadlocks.
+	synctest.Test(t, func(t *testing.T) {
+		var (
+			store = &fakeStore[*testObject]{}
+			fake  = &fakeResource[*testObject]{
+				events: make(chan resource.Event[*testObject]),
+				store:  store,
+			}
+		)
+
+		_ = resource.NewFilteringResource(fake, func(obj *testObject) bool { return true }).Events(t.Context())
+
+		fake.events <- resource.Event[*testObject]{Kind: resource.Sync, Done: func(err error) {}}
+		close(fake.events)
+	})
 }
 
 func TestFilteringResource_Observe(t *testing.T) {

--- a/pkg/k8s/resource/filtered_resource_test.go
+++ b/pkg/k8s/resource/filtered_resource_test.go
@@ -353,6 +353,11 @@ func TestFilteringResource_Observe_context_cancel(t *testing.T) {
 
 	// We don't push events to blockingEvents, so Observe only returns if ctx is Done
 	wg.Wait()
+
+	// Mimic what the actual implementation would do when the context is canceled,
+	// and close the upstream events channel. This ensures that the goroutine can
+	// terminate, as otherwise flagged by goleak.
+	close(fake.events)
 }
 
 func TestFilteredResource_WithFakeClient(t *testing.T) {

--- a/pkg/k8s/resource/resource_test.go
+++ b/pkg/k8s/resource/resource_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand/v2"
+	"os"
 	"runtime"
 	"strconv"
 	"sync"
@@ -42,6 +43,7 @@ func TestMain(m *testing.M) {
 		// Force garbage-collection to force finalizers to run and catch
 		// missing Event.Done() calls.
 		runtime.GC()
+		os.Exit(exitCode)
 	}
 	testutils.GoleakVerifyTestMain(m,
 		testutils.GoleakCleanup(cleanup),


### PR DESCRIPTION
The [FilteredResource.Events] method starts a goroutine relaying events from the upstream to the downstream channel, according to the configured filter. While the context is propagated to the upstream resource, the goroutine can deadlock if the downstream channel is not explicitly drained after canceling the context, as it happens for instance when leveraging the observable interface. For instance, this is highlighted by goleak:

```
[Goroutine 79 in state chan send, with github.com/cilium/cilium/pkg/k8s/resource.(*filteringResource[...]).Events.func1 on top of the stack:
github.com/cilium/cilium/pkg/k8s/resource.(*filteringResource[...]).Events.func1()
        .../pkg/k8s/resource/filtered_resource.go:44 +0x10c
created by github.com/cilium/cilium/pkg/k8s/resource.(*filteringResource[...]).Events in goroutine 1582
        .../pkg/k8s/resource/filtered_resource.go:40 +0xf2
]
```

Let's get this fixed by short-circuiting the send to the channel when the context is canceled, and marking the event as done.