### PR TITLE
bpf: lb: reply to ICMP echo (ping) for service VIPs (opt-in)

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -186,6 +186,7 @@ cilium-agent [flags]
       --enable-sctp                                               Enable SCTP support (beta)
       --enable-service-topology                                   Enable support for service topology aware hints
       --enable-standalone-dns-proxy                               Enables standalone DNS proxy
+      --enable-svc-icmp-echo-responder                            Reply to ICMP echo (ping) requests addressed to service (LoadBalancer/ClusterIP) VIPs
       --enable-tcx                                                Attach endpoint programs using tcx if supported by the kernel (default true)
       --enable-tracing                                            Enable tracing while determining policy (debugging)
       --enable-unreachable-routes                                 Add unreachable routes on pod deletion

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -992,6 +992,36 @@ int tail_handle_ipv4_from_netdev(struct __ctx_buff *ctx)
 	return tail_handle_ipv4(ctx, 0, false);
 }
 
+#if defined(ENABLE_SVC_ICMP_ECHO_RESPONDER) && !defined(IS_BPF_XDP)
+/* Craft and reflect the reply to an ICMP echo-request addressed to a service
+ * VIP. nodeport_lb4()/lb6() detect the target with a reads-only probe and
+ * tail-call here, so all the packet writes stay out of the shared from-netdev
+ * path (which keeps its ip4/ip6 pointer valid for the verifier). */
+#ifdef ENABLE_IPV4
+__declare_tail(CILIUM_CALL_IPV4_SVC_ICMP_ECHO)
+int tail_svc_icmp_echo_reply_v4(struct __ctx_buff *ctx)
+{
+	int ret = svc_icmp_echo_send_reply_v4(ctx);
+
+	if (IS_ERR(ret))
+		return send_drop_notify_error(ctx, UNKNOWN_ID, ret, METRIC_INGRESS);
+	return ret;
+}
+#endif /* ENABLE_IPV4 */
+
+#ifdef ENABLE_IPV6
+__declare_tail(CILIUM_CALL_IPV6_SVC_ICMP_ECHO)
+int tail_svc_icmp_echo_reply_v6(struct __ctx_buff *ctx)
+{
+	int ret = svc_icmp_echo_send_reply_v6(ctx);
+
+	if (IS_ERR(ret))
+		return send_drop_notify_error(ctx, UNKNOWN_ID, ret, METRIC_INGRESS);
+	return ret;
+}
+#endif /* ENABLE_IPV6 */
+#endif /* ENABLE_SVC_ICMP_ECHO_RESPONDER && !IS_BPF_XDP */
+
 #ifdef ENABLE_HOST_FIREWALL
 static __always_inline int
 handle_to_netdev_ipv4(struct __ctx_buff *ctx, bool is_from_proxy, __u32 src_sec_identity,

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -28,6 +28,7 @@
 #include "proxy_hairpin.h"
 #include "fib.h"
 #include "srv6.h"
+#include "svc_echo.h"
 
 DECLARE_CONFIG(bool, enable_no_service_endpoints_routable,
 	       "Enable routes when service has 0 endpoints")
@@ -1604,6 +1605,27 @@ skip_service_lookup:
 #endif
 	ctx_set_xfer(ctx, XFER_PKT_NO_SVC);
 
+#if defined(ENABLE_SVC_ICMP_ECHO_RESPONDER) && !defined(IS_BPF_XDP)
+	/* Answer an ICMPv6 echo (ping) addressed to a service VIP; see the IPv4
+	 * path in nodeport_lb4 for the rationale. Detection is reads-only and the
+	 * reply runs in the CILIUM_CALL_IPV6_SVC_ICMP_ECHO tail-call. Re-validate
+	 * ip6 before dereferencing it here. */
+	if (!is_svc_proto && tuple.nexthdr == IPPROTO_ICMPV6) {
+		void *data, *data_end;
+
+		if (!revalidate_data(ctx, &data, &data_end, &ip6))
+			return DROP_INVALID;
+		ret = svc_icmp_echo_is_target_v6(ctx, ip6, l4_off);
+		if (IS_ERR(ret))
+			return ret;
+		if (ret)
+			return tail_call_internal(ctx,
+					CILIUM_CALL_IPV6_SVC_ICMP_ECHO,
+					ext_err);
+	}
+#endif /* ENABLE_SVC_ICMP_ECHO_RESPONDER && !IS_BPF_XDP */
+
+
 #ifdef ENABLE_DSR
 #if (defined(IS_BPF_OVERLAY) && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE) || \
     ((defined(IS_BPF_XDP) || defined(IS_BPF_HOST) || defined(IS_BPF_WIREGUARD)) && \
@@ -2970,6 +2992,35 @@ skip_service_lookup:
 	 * the reverse NAT.
 	 */
 	ctx_set_xfer(ctx, XFER_PKT_NO_SVC);
+
+#if defined(ENABLE_SVC_ICMP_ECHO_RESPONDER) && !defined(IS_BPF_XDP)
+	/* Answer an ICMP echo (ping) addressed to a service VIP directly, so the
+	 * VIP is pingable like it is under kube-proxy/IPVS. Stateless: any node
+	 * that receives the echo can reply. Only echo-requests to a known VIP are
+	 * handled; everything else falls through unchanged.
+	 *
+	 * Detection is reads-only (svc_icmp_echo_is_target_v4 never writes the
+	 * packet) and the reply -- which does write the packet -- runs in the
+	 * CILIUM_CALL_IPV4_SVC_ICMP_ECHO tail-call, so no packet writes happen on
+	 * this shared path. Re-validate ip4 before dereferencing it here.
+	 * TC/host only: the echo arrives on the TC netdev and the tail program
+	 * lives in that object. */
+	if (!is_svc_proto) {
+		void *data, *data_end;
+
+		if (!revalidate_data(ctx, &data, &data_end, &ip4))
+			return DROP_INVALID;
+		if (ip4->protocol == IPPROTO_ICMP) {
+			ret = svc_icmp_echo_is_target_v4(ctx, ip4, l4_off);
+			if (IS_ERR(ret))
+				return ret;
+			if (ret)
+				return tail_call_internal(ctx,
+						CILIUM_CALL_IPV4_SVC_ICMP_ECHO,
+						ext_err);
+		}
+	}
+#endif /* ENABLE_SVC_ICMP_ECHO_RESPONDER && !IS_BPF_XDP */
 
 #ifdef ENABLE_DSR
 #if (defined(IS_BPF_OVERLAY) && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE) || \

--- a/bpf/lib/ratelimit.h
+++ b/bpf/lib/ratelimit.h
@@ -9,6 +9,7 @@
 #define RATELIMIT_USAGE_ICMPV6 1
 #define RATELIMIT_USAGE_EVENTS_MAP 2
 #define RATELIMIT_USAGE_SOCKET_EVENTS_MAP 3
+#define RATELIMIT_USAGE_SVC_ICMP_ECHO 4
 
 struct ratelimit_key {
 	__u32 usage;
@@ -16,6 +17,9 @@ struct ratelimit_key {
 		struct {
 			__u32 netdev_idx;
 		} icmpv6;
+		struct {
+			__u32 vip;
+		} svc_icmp_echo;
 	} key;
 };
 

--- a/bpf/lib/svc_echo.h
+++ b/bpf/lib/svc_echo.h
@@ -1,0 +1,290 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+/*
+ * Reply to ICMP echo (ping) requests addressed to a service VIP.
+ *
+ * Cilium's eBPF load balancer never binds service VIPs to an interface, so an
+ * ICMP echo-request to a LoadBalancer/ClusterIP VIP is classified as a
+ * non-service protocol (lb4_extract_tuple -> DROP_UNSUPP_SERVICE_PROTO) and
+ * falls through to the stack, where nothing owns the VIP -- so the VIP never
+ * answers ping. kube-proxy/IPVS binds the VIP to a dummy device and therefore
+ * does answer, so this is a visible behaviour gap when migrating to Cilium.
+ *
+ * When ENABLE_SVC_ICMP_ECHO_RESPONDER is set, the datapath answers echo
+ * requests addressed to a known service VIP directly: it turns the request
+ * into a reply in place (swap L2/L3, flip the ICMP echo type) and reflects it
+ * back out the ingress interface. The reply is stateless, so any node that
+ * receives the request can answer it. It is opt-in and rate-limited per VIP.
+ *
+ * The work is split in two so the packet writes stay off the shared
+ * nodeport_lb4/lb6 code path: svc_icmp_echo_is_target_v{4,6}() is a reads-only
+ * probe run inline in nodeport_lb4/lb6 (so it never invalidates the caller's
+ * ip4/ip6 pointer for the verifier), and svc_icmp_echo_send_reply_v{4,6}() --
+ * which does all the packet writes and reflects the reply -- runs in a
+ * dedicated CILIUM_CALL_IPV{4,6}_SVC_ICMP_ECHO tail-call program, returning
+ * immediately after the writes.
+ */
+
+#pragma once
+
+#include "common.h"
+#include "eth.h"
+#include "ipv6.h"
+#include "lb.h"
+#include "ratelimit.h"
+#include "csum.h"
+
+#ifdef ENABLE_SVC_ICMP_ECHO_RESPONDER
+
+/* Rate-limit the echo responder per VIP: 100 replies/s, burstable to 1000. For
+ * IPv6 the caller folds the 128-bit VIP down to a 32-bit key (a collision only
+ * means two VIPs share a bucket, which is harmless for rate-limiting). */
+static __always_inline bool
+svc_icmp_echo_ratelimited(__u32 vip)
+{
+	struct ratelimit_key rkey = {
+		.usage = RATELIMIT_USAGE_SVC_ICMP_ECHO,
+	};
+	const struct ratelimit_settings settings = {
+		.bucket_size = 1000,
+		.tokens_per_topup = 100,
+		.topup_interval_ns = NSEC_PER_SEC,
+	};
+
+	rkey.key.svc_icmp_echo.vip = vip;
+	return !ratelimit_check_and_take(&rkey, &settings);
+}
+
+#ifdef ENABLE_IPV4
+/*
+ * svc_icmp_echo_is_target_v4 - is this an ICMPv4 echo-request to a service VIP?
+ *
+ * @l4_off: offset of the (outer) ICMP header.
+ *
+ * Reads only -- it never writes the packet, so the caller's ip4 pointer stays
+ * valid for the verifier on the fall-through path. Returns 1 when the packet
+ * is an echo-request addressed to a known service VIP (caller should hand it
+ * to the reply tail-call), 0 when it is not ours (caller keeps its default
+ * handling), or a negative DROP_* code on a malformed header.
+ */
+static __always_inline int
+svc_icmp_echo_is_target_v4(struct __ctx_buff *ctx, struct iphdr *ip4, int l4_off)
+{
+	struct icmphdr icmphdr __align_stack_8;
+	struct lb4_key key = {};
+
+	if (ip4->protocol != IPPROTO_ICMP)
+		return 0;
+
+	if (ctx_load_bytes(ctx, l4_off, &icmphdr, sizeof(icmphdr)) < 0)
+		return DROP_INVALID;
+	/* Only echo-request; leave every other ICMP type (incl. the errors the
+	 * PMTU relay handles) to the caller. */
+	if (icmphdr.type != ICMP_ECHO)
+		return 0;
+
+	/* Is the destination a service VIP? LoadBalancer/ClusterIP frontends
+	 * (external scope) parent a wildcard service entry keyed on the VIP
+	 * address with a wildcard port/proto, so a single lookup answers
+	 * "is this a VIP?" without needing an L4 port. */
+	key.address = ip4->daddr;
+	key.dport = LB_SVC_WILDCARD_DPORT;
+	key.proto = LB_SVC_WILDCARD_PROTO;
+	key.scope = LB_LOOKUP_SCOPE_EXT;
+	if (!__lb4_lookup_service(&key))
+		return 0;			/* not a service VIP */
+
+	return 1;
+}
+
+/*
+ * svc_icmp_echo_send_reply_v4 - craft and reflect the echo reply.
+ *
+ * Runs in the CILIUM_CALL_IPV4_SVC_ICMP_ECHO tail-call program, so it is
+ * self-contained: it re-validates its own ip4 pointer and recomputes l4_off.
+ * All the packet writes live here (never on the shared nodeport_lb4 path), and
+ * the function returns immediately after them, so the verifier tolerates the
+ * ip4 invalidation the writes cause.
+ *
+ * The caller (nodeport_lb4 via svc_icmp_echo_is_target_v4) has already
+ * confirmed this is an echo-request to a service VIP.
+ *
+ * Returns CTX_ACT_REDIRECT (reply sent back out the ingress iface) or a
+ * negative DROP_* code.
+ */
+static __always_inline int
+svc_icmp_echo_send_reply_v4(struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	struct iphdr *ip4;
+	struct icmphdr icmphdr __align_stack_8;
+	union macaddr smac, dmac;
+	__be32 saddr, daddr;
+	__be16 check_be;
+	__u32 new_check;
+	__u8 reply_type = ICMP_ECHOREPLY;
+	int l4_off;
+
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
+		return DROP_INVALID;
+
+	l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
+	if (ctx_load_bytes(ctx, l4_off, &icmphdr, sizeof(icmphdr)) < 0)
+		return DROP_INVALID;
+
+	/* Capture the addresses up front: the packet writes below go through
+	 * bpf_skb_store_bytes(), which invalidates the ip4 pointer for the
+	 * verifier, so ip4 must not be dereferenced afterwards. */
+	saddr = ip4->saddr;
+	daddr = ip4->daddr;
+
+	if (svc_icmp_echo_ratelimited(daddr))
+		return DROP_RATE_LIMITED;
+
+	/* Swap L2. */
+	if (eth_load_saddr(ctx, smac.addr, 0) < 0 ||
+	    eth_load_daddr(ctx, dmac.addr, 0) < 0)
+		return DROP_INVALID;
+	if (eth_store_daddr(ctx, smac.addr, 0) < 0 ||
+	    eth_store_saddr(ctx, dmac.addr, 0) < 0)
+		return DROP_WRITE_ERROR;
+
+	/* Swap L3. A symmetric saddr<->daddr swap leaves the IPv4 header
+	 * checksum unchanged (both are summed), so it need not be recomputed. */
+	if (ctx_store_bytes(ctx, ETH_HLEN + offsetof(struct iphdr, saddr),
+			    &daddr, 4, 0) < 0)
+		return DROP_WRITE_ERROR;
+	if (ctx_store_bytes(ctx, ETH_HLEN + offsetof(struct iphdr, daddr),
+			    &saddr, 4, 0) < 0)
+		return DROP_WRITE_ERROR;
+
+	/* Flip ICMP type 8 (echo) -> 0 (echo reply); code, id, seq and payload
+	 * are preserved. The type sits in the high byte of the first 16-bit
+	 * ICMP word, so that word drops by (8 << 8). The ICMPv4 checksum covers
+	 * only the ICMP message (no pseudo-header) and is the one's-complement
+	 * of the sum, so it rises by the same amount, with the end-around carry
+	 * folded back in. */
+	new_check = bpf_ntohs(icmphdr.checksum) + (ICMP_ECHO << 8);
+	new_check = (new_check & 0xffff) + (new_check >> 16);
+	check_be = bpf_htons((__u16)new_check);
+	if (ctx_store_bytes(ctx, l4_off + offsetof(struct icmphdr, type),
+			    &reply_type, sizeof(reply_type), 0) < 0)
+		return DROP_WRITE_ERROR;
+	if (ctx_store_bytes(ctx, l4_off + offsetof(struct icmphdr, checksum),
+			    &check_be, sizeof(check_be), 0) < 0)
+		return DROP_WRITE_ERROR;
+
+	/* Reflect the reply back out the interface it arrived on. */
+	return redirect_self(ctx);
+}
+#endif /* ENABLE_IPV4 */
+
+#ifdef ENABLE_IPV6
+/*
+ * svc_icmp_echo_is_target_v6 - is this an ICMPv6 echo-request to a service VIP?
+ *
+ * @l4_off: offset of the (outer) ICMPv6 header. The caller has already
+ * established that the L4 protocol is ICMPv6.
+ *
+ * Reads only; same contract as the v4 variant.
+ */
+static __always_inline int
+svc_icmp_echo_is_target_v6(struct __ctx_buff *ctx, struct ipv6hdr *ip6, int l4_off)
+{
+	struct icmp6hdr icmp6 __align_stack_8;
+	struct lb6_key key = {};
+
+	if (ctx_load_bytes(ctx, l4_off, &icmp6, sizeof(icmp6)) < 0)
+		return DROP_INVALID;
+	if (icmp6.icmp6_type != ICMPV6_ECHO_REQUEST)
+		return 0;
+
+	memcpy(&key.address, &ip6->daddr, sizeof(key.address));
+	key.dport = LB_SVC_WILDCARD_DPORT;
+	key.proto = LB_SVC_WILDCARD_PROTO;
+	key.scope = LB_LOOKUP_SCOPE_EXT;
+	if (!__lb6_lookup_service(&key))
+		return 0;			/* not a service VIP */
+
+	return 1;
+}
+
+/*
+ * svc_icmp_echo_send_reply_v6 - craft and reflect the ICMPv6 echo reply.
+ *
+ * Runs in the CILIUM_CALL_IPV6_SVC_ICMP_ECHO tail-call program; self-contained
+ * like the v4 variant. The caller has confirmed this is an ICMPv6 echo-request
+ * to a service VIP.
+ */
+static __always_inline int
+svc_icmp_echo_send_reply_v6(struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	struct ipv6hdr *ip6;
+	struct icmp6hdr icmp6 __align_stack_8;
+	union macaddr smac, dmac;
+	union v6addr saddr, daddr;
+	__u8 nexthdr, reply_type = ICMPV6_ECHO_REPLY;
+	__be16 check_be;
+	__u32 new_check;
+	int l4_off, hdrlen;
+
+	if (!revalidate_data(ctx, &data, &data_end, &ip6))
+		return DROP_INVALID;
+
+	nexthdr = ip6->nexthdr;
+	hdrlen = ipv6_hdrlen(ctx, &nexthdr);
+	if (hdrlen < 0)
+		return DROP_INVALID;
+	l4_off = ETH_HLEN + hdrlen;
+
+	if (ctx_load_bytes(ctx, l4_off, &icmp6, sizeof(icmp6)) < 0)
+		return DROP_INVALID;
+
+	/* Capture the addresses before the packet writes below invalidate ip6. */
+	memcpy(&saddr, &ip6->saddr, sizeof(saddr));
+	memcpy(&daddr, &ip6->daddr, sizeof(daddr));
+
+	if (svc_icmp_echo_ratelimited(daddr.p1 ^ daddr.p2 ^ daddr.p3 ^ daddr.p4))
+		return DROP_RATE_LIMITED;
+
+	/* Swap L2. */
+	if (eth_load_saddr(ctx, smac.addr, 0) < 0 ||
+	    eth_load_daddr(ctx, dmac.addr, 0) < 0)
+		return DROP_INVALID;
+	if (eth_store_daddr(ctx, smac.addr, 0) < 0 ||
+	    eth_store_saddr(ctx, dmac.addr, 0) < 0)
+		return DROP_WRITE_ERROR;
+
+	/* Swap L3. The ICMPv6 checksum includes a pseudo-header over the source
+	 * and destination addresses, but a symmetric swap leaves that sum
+	 * unchanged, so only the type flip below affects the checksum. */
+	if (ctx_store_bytes(ctx, ETH_HLEN + offsetof(struct ipv6hdr, saddr),
+			    &daddr, sizeof(daddr), 0) < 0)
+		return DROP_WRITE_ERROR;
+	if (ctx_store_bytes(ctx, ETH_HLEN + offsetof(struct ipv6hdr, daddr),
+			    &saddr, sizeof(saddr), 0) < 0)
+		return DROP_WRITE_ERROR;
+
+	/* Flip ICMPv6 type 128 (echo request) -> 129 (echo reply). The type is
+	 * the high byte of the first 16-bit word, so that word rises by (1 << 8);
+	 * the one's-complement checksum therefore drops by the same amount, added
+	 * here as its 16-bit complement with the end-around carry folded in. */
+	new_check = bpf_ntohs(icmp6.icmp6_cksum) + (__u16)~(1 << 8);
+	new_check = (new_check & 0xffff) + (new_check >> 16);
+	new_check = (new_check & 0xffff) + (new_check >> 16);
+	check_be = bpf_htons((__u16)new_check);
+	if (ctx_store_bytes(ctx, l4_off + offsetof(struct icmp6hdr, icmp6_type),
+			    &reply_type, sizeof(reply_type), 0) < 0)
+		return DROP_WRITE_ERROR;
+	if (ctx_store_bytes(ctx, l4_off + offsetof(struct icmp6hdr, icmp6_cksum),
+			    &check_be, sizeof(check_be), 0) < 0)
+		return DROP_WRITE_ERROR;
+
+	/* Reflect the reply back out the interface it arrived on. */
+	return redirect_self(ctx);
+}
+#endif /* ENABLE_IPV6 */
+
+#endif /* ENABLE_SVC_ICMP_ECHO_RESPONDER */

--- a/bpf/lib/tailcall.h
+++ b/bpf/lib/tailcall.h
@@ -99,7 +99,9 @@
 #define CILIUM_CALL_MULTICAST_EP_DELIVERY		47
 #define CILIUM_CALL_IPV4_POLICY_DENIED			48
 #define CILIUM_CALL_IPV6_POLICY_DENIED			49
-#define CILIUM_CALL_SIZE				50
+#define CILIUM_CALL_IPV4_SVC_ICMP_ECHO			50
+#define CILIUM_CALL_IPV6_SVC_ICMP_ECHO			51
+#define CILIUM_CALL_SIZE				52
 
 /* Private per-EP map for internal tail calls. Its bpffs pin is replaced every
  * time the BPF object is loaded. An existing pinned map is never reused.

--- a/bpf/tests/svc_icmp_echo_responder.c
+++ b/bpf/tests/svc_icmp_echo_responder.c
@@ -1,0 +1,552 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+/* Datapath test for the service VIP ICMP echo responder.
+ *
+ * The responder is split in two: svc_icmp_echo_is_target_v4() is a reads-only
+ * probe (run inline in nodeport_lb4) and svc_icmp_echo_send_reply_v4() does the
+ * packet writes (run in the CILIUM_CALL_IPV4_SVC_ICMP_ECHO tail-call). This test
+ * exercises both in sequence.
+ *
+ * An ICMPv4 echo-request (type 8) addressed to a service VIP must be turned
+ * into an echo-reply in place and reflected back to the client:
+ *   - the probe returns 1 (it is a VIP echo-request);
+ *   - the reply worker returns CTX_ACT_REDIRECT (reply sent via redirect_self);
+ *   - outer IP src/dst are swapped (reply is sourced from the VIP);
+ *   - the ICMP type becomes 0 (echo reply) while code, id, seq and payload
+ *     are preserved;
+ *   - the ICMP checksum is valid (folds to 0 over the message);
+ *   - the ethernet addresses are swapped.
+ *
+ * A negative case (echo to a non-VIP address) asserts the probe returns 0 and
+ * the packet is left untouched.
+ */
+
+#include <bpf/ctx/skb.h>
+#include <bpf/api.h>
+#include "common.h"
+#include "pktgen.h"
+
+#define ENABLE_IPV4
+#define ENABLE_IPV6
+#define ENABLE_NODEPORT
+#define ENABLE_SVC_ICMP_ECHO_RESPONDER
+#include <bpf/config/global.h>
+
+/* The responder does not select a backend, so use "first slot" selection to
+ * avoid needing the maglev maps. */
+#define LB_SELECTION	LB_SELECTION_FIRST
+
+#include "nodeport_defaults.h"
+
+#include <lib/dbg.h>
+#include <lib/eps.h>
+#include <lib/svc_echo.h>
+#include "lib/lb.h"
+
+#define CLIENT_IP	bpf_htonl(0x0a0000f0)	/* 10.0.0.240 (client) */
+#define VIP_ADDR	bpf_htonl(0x0a00000a)	/* 10.0.0.10  (service VIP) */
+#define NOT_A_VIP	bpf_htonl(0x0a00000b)	/* 10.0.0.11  (not a service) */
+#define REVNAT		1
+#define ECHO_ID		bpf_htons(0x1234)
+#define ECHO_SEQ	bpf_htons(0x0001)
+
+/* fd00::f0 client, fd00::a service VIP, fd00::b not-a-service. */
+static volatile const union v6addr client_ip6 = {
+	.addr = {0xfd, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xf0},
+};
+static volatile const union v6addr vip_addr6 = {
+	.addr = {0xfd, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x0a},
+};
+static volatile const union v6addr not_a_vip6 = {
+	.addr = {0xfd, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x0b},
+};
+
+static volatile const __u8 cmac[ETH_ALEN] = {0x02, 0, 0, 0, 0, 1};	/* client */
+static volatile const __u8 nmac[ETH_ALEN] = {0x02, 0, 0, 0, 0, 2};	/* node */
+
+/* IPv6 pseudo-header used to compute/verify the ICMPv6 checksum. */
+struct icmp6_pseudo {
+	union v6addr saddr;
+	union v6addr daddr;
+	__be32 len;
+	__u8 pad[3];
+	__u8 nexthdr;
+};
+
+/* 16-byte echo payload so we can assert it survives untouched. */
+static const __u8 echo_payload[16] = {
+	0xde, 0xad, 0xbe, 0xef, 0x01, 0x02, 0x03, 0x04,
+	0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+};
+
+static __always_inline int build_echo(struct __ctx_buff *ctx, __be32 dst)
+{
+	struct pktgen builder;
+	struct iphdr *ip4;
+	struct icmphdr *icmp;
+
+	pktgen__init(&builder, ctx);
+
+	ip4 = pktgen__push_ipv4_packet(&builder, (__u8 *)cmac, (__u8 *)nmac,
+				       CLIENT_IP, dst);
+	if (!ip4)
+		return TEST_ERROR;
+	ip4->protocol = IPPROTO_ICMP;
+
+	icmp = pktgen__push_icmphdr(&builder);
+	if (!icmp)
+		return TEST_ERROR;
+	icmp->type = ICMP_ECHO;
+	icmp->code = 0;
+	icmp->un.echo.id = ECHO_ID;
+	icmp->un.echo.sequence = ECHO_SEQ;
+
+	if (!pktgen__push_data(&builder, (void *)echo_payload, sizeof(echo_payload)))
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	/* pktgen leaves the ICMP checksum at 0; fill in a valid one so the input
+	 * looks like a real client's echo-request (the responder patches the
+	 * checksum incrementally, which is only correct for a valid input). */
+	{
+		void *data = (void *)(long)ctx->data;
+		void *data_end = (void *)(long)ctx->data_end;
+		struct iphdr *l3 = data + sizeof(struct ethhdr);
+		struct icmphdr *l4;
+		int icmp_len = sizeof(struct icmphdr) + sizeof(echo_payload);
+
+		if ((void *)l3 + sizeof(*l3) > data_end)
+			return TEST_ERROR;
+		l4 = (void *)l3 + sizeof(*l3);
+		if ((void *)l4 + icmp_len > data_end)
+			return TEST_ERROR;
+		l4->checksum = 0;
+		l4->checksum = csum_fold(csum_diff(NULL, 0, l4, icmp_len, 0));
+	}
+	return 0;
+}
+
+PKTGEN("tc", "svc_icmp_echo_vip")
+int svc_icmp_echo_vip_pktgen(struct __ctx_buff *ctx)
+{
+	return build_echo(ctx, VIP_ADDR);
+}
+
+SETUP("tc", "svc_icmp_echo_vip")
+int svc_icmp_echo_vip_setup(struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	struct iphdr *ip4;
+	int l4_off, ret;
+
+	/* A LoadBalancer/ClusterIP frontend parents a wildcard service entry
+	 * keyed on the VIP with a wildcard port/proto -- that is what the
+	 * responder looks up to recognise the VIP. */
+	lb_v4_add_service(VIP_ADDR, LB_SVC_WILDCARD_DPORT, LB_SVC_WILDCARD_PROTO,
+			  1, REVNAT);
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+	ip4 = data + sizeof(struct ethhdr);
+	if ((void *)ip4 + sizeof(*ip4) > data_end)
+		return TEST_ERROR;
+
+	l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
+
+	/* Detection (reads-only, runs inline in nodeport_lb4) recognises the VIP
+	 * echo-request. */
+	ret = svc_icmp_echo_is_target_v4(ctx, ip4, l4_off);
+	if (ret != 1)
+		return TEST_ERROR;
+
+	/* The reply worker (runs in the CILIUM_CALL_IPV4_SVC_ICMP_ECHO tail-call)
+	 * re-validates ip4 itself and crafts the reply. */
+	ret = svc_icmp_echo_send_reply_v4(ctx);
+	if (ret != CTX_ACT_REDIRECT)
+		return TEST_ERROR;
+
+	return TEST_PASS;
+}
+
+CHECK("tc", "svc_icmp_echo_vip")
+int svc_icmp_echo_vip_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct ethhdr *eth;
+	struct iphdr *ip4;
+	struct icmphdr *icmp;
+	__u8 *payload;
+	__u32 i;
+	__wsum sum;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+	status_code = data;
+	if (*status_code != TEST_PASS)
+		test_fatal("SETUP failed with status code: %d", *status_code);
+
+	eth = data + sizeof(*status_code);
+	if ((void *)eth + sizeof(*eth) > data_end)
+		test_fatal("eth out of bounds");
+	/* MACs swapped: reply goes back to the client. */
+	if (memcmp(eth->h_dest, (__u8 *)cmac, ETH_ALEN) != 0)
+		test_fatal("eth dst not swapped to the client MAC");
+	if (memcmp(eth->h_source, (__u8 *)nmac, ETH_ALEN) != 0)
+		test_fatal("eth src not swapped to the node MAC");
+
+	ip4 = (void *)eth + sizeof(*eth);
+	if ((void *)ip4 + sizeof(*ip4) > data_end)
+		test_fatal("ip out of bounds");
+	if (ip4->saddr != VIP_ADDR)
+		test_fatal("reply not sourced from the VIP");
+	if (ip4->daddr != CLIENT_IP)
+		test_fatal("reply not addressed to the client");
+
+	icmp = (void *)ip4 + sizeof(*ip4);
+	if ((void *)icmp + sizeof(*icmp) > data_end)
+		test_fatal("icmp out of bounds");
+	if (icmp->type != ICMP_ECHOREPLY)
+		test_fatal("icmp type not flipped to echo reply");
+	if (icmp->code != 0)
+		test_fatal("icmp code must be preserved");
+	if (icmp->un.echo.id != ECHO_ID)
+		test_fatal("echo id must be preserved");
+	if (icmp->un.echo.sequence != ECHO_SEQ)
+		test_fatal("echo sequence must be preserved");
+
+	payload = (void *)icmp + sizeof(*icmp);
+	if ((void *)payload + sizeof(echo_payload) > data_end)
+		test_fatal("echo payload out of bounds");
+	for (i = 0; i < sizeof(echo_payload); i++)
+		if (payload[i] != echo_payload[i])
+			test_fatal("echo payload byte %d changed", i);
+
+	/* The ICMP checksum must be valid: summing the whole message (header +
+	 * payload, checksum field included) folds to 0. */
+	sum = csum_diff(NULL, 0, icmp, sizeof(*icmp) + sizeof(echo_payload), 0);
+	if (csum_fold(sum) != 0)
+		test_fatal("icmp checksum invalid after type flip");
+
+	test_finish();
+}
+
+/* Negative: an echo to a non-service address is left untouched. */
+PKTGEN("tc", "svc_icmp_echo_non_vip")
+int svc_icmp_echo_non_vip_pktgen(struct __ctx_buff *ctx)
+{
+	return build_echo(ctx, NOT_A_VIP);
+}
+
+SETUP("tc", "svc_icmp_echo_non_vip")
+int svc_icmp_echo_non_vip_setup(struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	struct iphdr *ip4;
+	int l4_off, ret;
+
+	lb_v4_add_service(VIP_ADDR, LB_SVC_WILDCARD_DPORT, LB_SVC_WILDCARD_PROTO,
+			  1, REVNAT);
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+	ip4 = data + sizeof(struct ethhdr);
+	if ((void *)ip4 + sizeof(*ip4) > data_end)
+		return TEST_ERROR;
+
+	l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
+
+	/* Not a VIP -> detection returns 0 and the caller keeps its default
+	 * handling; the reply worker is never reached, so the packet is untouched. */
+	ret = svc_icmp_echo_is_target_v4(ctx, ip4, l4_off);
+	if (ret != 0)
+		return TEST_ERROR;
+
+	return TEST_PASS;
+}
+
+CHECK("tc", "svc_icmp_echo_non_vip")
+int svc_icmp_echo_non_vip_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct iphdr *ip4;
+	struct icmphdr *icmp;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+	status_code = data;
+	if (*status_code != TEST_PASS)
+		test_fatal("SETUP failed with status code: %d", *status_code);
+
+	ip4 = data + sizeof(*status_code) + sizeof(struct ethhdr);
+	if ((void *)ip4 + sizeof(*ip4) > data_end)
+		test_fatal("ip out of bounds");
+	/* Untouched: still client -> non-VIP. */
+	if (ip4->saddr != CLIENT_IP || ip4->daddr != NOT_A_VIP)
+		test_fatal("non-VIP echo must be left untouched");
+
+	icmp = (void *)ip4 + sizeof(*ip4);
+	if ((void *)icmp + sizeof(*icmp) > data_end)
+		test_fatal("icmp out of bounds");
+	if (icmp->type != ICMP_ECHO)
+		test_fatal("non-VIP echo type must stay echo-request");
+
+	test_finish();
+}
+
+/* ------------------------------- IPv6 ------------------------------------- */
+
+static __always_inline int build_echo6(struct __ctx_buff *ctx,
+				       const volatile union v6addr *dst)
+{
+	struct pktgen builder;
+	struct ipv6hdr *ip6;
+	struct icmp6hdr *icmp;
+
+	pktgen__init(&builder, ctx);
+
+	ip6 = pktgen__push_ipv6_packet(&builder, (__u8 *)cmac, (__u8 *)nmac,
+				       (__u8 *)client_ip6.addr, (__u8 *)dst->addr);
+	if (!ip6)
+		return TEST_ERROR;
+	ip6->nexthdr = IPPROTO_ICMPV6;
+
+	icmp = pktgen__push_icmp6hdr(&builder);
+	if (!icmp)
+		return TEST_ERROR;
+	icmp->icmp6_type = ICMPV6_ECHO_REQUEST;
+	icmp->icmp6_code = 0;
+	icmp->icmp6_identifier = ECHO_ID;
+	icmp->icmp6_sequence = ECHO_SEQ;
+
+	if (!pktgen__push_data(&builder, (void *)echo_payload, sizeof(echo_payload)))
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	/* Fill in a valid ICMPv6 checksum (over the pseudo-header + message), so
+	 * the input looks like a real echo-request; the responder patches it
+	 * incrementally, which is only correct for a valid input. */
+	{
+		void *data = (void *)(long)ctx->data;
+		void *data_end = (void *)(long)ctx->data_end;
+		struct ipv6hdr *l3 = data + sizeof(struct ethhdr);
+		struct icmp6hdr *l4;
+		int icmp_len = sizeof(struct icmp6hdr) + sizeof(echo_payload);
+		struct icmp6_pseudo pseudo = {};
+		__wsum sum;
+
+		if ((void *)l3 + sizeof(*l3) > data_end)
+			return TEST_ERROR;
+		l4 = (void *)l3 + sizeof(*l3);
+		if ((void *)l4 + icmp_len > data_end)
+			return TEST_ERROR;
+
+		memcpy(&pseudo.saddr, (void *)client_ip6.addr, sizeof(pseudo.saddr));
+		memcpy(&pseudo.daddr, (void *)dst->addr, sizeof(pseudo.daddr));
+		pseudo.len = bpf_htonl(icmp_len);
+		pseudo.nexthdr = IPPROTO_ICMPV6;
+
+		l4->icmp6_cksum = 0;
+		sum = csum_diff(NULL, 0, &pseudo, sizeof(pseudo), 0);
+		l4->icmp6_cksum = csum_fold(csum_diff(NULL, 0, l4, icmp_len, sum));
+	}
+	return 0;
+}
+
+PKTGEN("tc", "svc_icmp_echo_vip6")
+int svc_icmp_echo_vip6_pktgen(struct __ctx_buff *ctx)
+{
+	return build_echo6(ctx, &vip_addr6);
+}
+
+SETUP("tc", "svc_icmp_echo_vip6")
+int svc_icmp_echo_vip6_setup(struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	struct ipv6hdr *ip6;
+	int l4_off, ret;
+	__u8 nexthdr;
+
+	lb_v6_add_service((const union v6addr *)&vip_addr6, LB_SVC_WILDCARD_DPORT,
+			  LB_SVC_WILDCARD_PROTO, 1, REVNAT);
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+	ip6 = data + sizeof(struct ethhdr);
+	if ((void *)ip6 + sizeof(*ip6) > data_end)
+		return TEST_ERROR;
+
+	nexthdr = ip6->nexthdr;
+	l4_off = ETH_HLEN + ipv6_hdrlen(ctx, &nexthdr);
+
+	ret = svc_icmp_echo_is_target_v6(ctx, ip6, l4_off);
+	if (ret != 1)
+		return TEST_ERROR;
+
+	ret = svc_icmp_echo_send_reply_v6(ctx);
+	if (ret != CTX_ACT_REDIRECT)
+		return TEST_ERROR;
+
+	return TEST_PASS;
+}
+
+CHECK("tc", "svc_icmp_echo_vip6")
+int svc_icmp_echo_vip6_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct ethhdr *eth;
+	struct ipv6hdr *ip6;
+	struct icmp6hdr *icmp;
+	struct icmp6_pseudo pseudo = {};
+	__u8 *payload;
+	__u32 i;
+	__wsum sum;
+	int icmp_len;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+	status_code = data;
+	if (*status_code != TEST_PASS)
+		test_fatal("SETUP failed with status code: %d", *status_code);
+
+	eth = data + sizeof(*status_code);
+	if ((void *)eth + sizeof(*eth) > data_end)
+		test_fatal("eth out of bounds");
+	if (memcmp(eth->h_dest, (__u8 *)cmac, ETH_ALEN) != 0)
+		test_fatal("eth dst not swapped to the client MAC");
+	if (memcmp(eth->h_source, (__u8 *)nmac, ETH_ALEN) != 0)
+		test_fatal("eth src not swapped to the node MAC");
+
+	ip6 = (void *)eth + sizeof(*eth);
+	if ((void *)ip6 + sizeof(*ip6) > data_end)
+		test_fatal("ip6 out of bounds");
+	if (memcmp(&ip6->saddr, (void *)vip_addr6.addr, 16) != 0)
+		test_fatal("reply not sourced from the VIP");
+	if (memcmp(&ip6->daddr, (void *)client_ip6.addr, 16) != 0)
+		test_fatal("reply not addressed to the client");
+
+	icmp = (void *)ip6 + sizeof(*ip6);
+	if ((void *)icmp + sizeof(*icmp) > data_end)
+		test_fatal("icmp6 out of bounds");
+	if (icmp->icmp6_type != ICMPV6_ECHO_REPLY)
+		test_fatal("icmp6 type not flipped to echo reply");
+	if (icmp->icmp6_code != 0)
+		test_fatal("icmp6 code must be preserved");
+	if (icmp->icmp6_identifier != ECHO_ID)
+		test_fatal("echo id must be preserved");
+	if (icmp->icmp6_sequence != ECHO_SEQ)
+		test_fatal("echo sequence must be preserved");
+
+	payload = (void *)icmp + sizeof(*icmp);
+	if ((void *)payload + sizeof(echo_payload) > data_end)
+		test_fatal("echo payload out of bounds");
+	for (i = 0; i < sizeof(echo_payload); i++)
+		if (payload[i] != echo_payload[i])
+			test_fatal("echo payload byte %d changed", i);
+
+	/* The ICMPv6 checksum must be valid: summing the pseudo-header plus the
+	 * ICMPv6 message (checksum field included) folds to 0. */
+	icmp_len = sizeof(*icmp) + sizeof(echo_payload);
+	memcpy(&pseudo.saddr, &ip6->saddr, sizeof(pseudo.saddr));
+	memcpy(&pseudo.daddr, &ip6->daddr, sizeof(pseudo.daddr));
+	pseudo.len = bpf_htonl(icmp_len);
+	pseudo.nexthdr = IPPROTO_ICMPV6;
+	sum = csum_diff(NULL, 0, &pseudo, sizeof(pseudo), 0);
+	if (csum_fold(csum_diff(NULL, 0, icmp, icmp_len, sum)) != 0)
+		test_fatal("icmp6 checksum invalid after type flip");
+
+	test_finish();
+}
+
+/* Negative: an ICMPv6 echo to a non-service address is left untouched. */
+PKTGEN("tc", "svc_icmp_echo_non_vip6")
+int svc_icmp_echo_non_vip6_pktgen(struct __ctx_buff *ctx)
+{
+	return build_echo6(ctx, &not_a_vip6);
+}
+
+SETUP("tc", "svc_icmp_echo_non_vip6")
+int svc_icmp_echo_non_vip6_setup(struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	struct ipv6hdr *ip6;
+	int l4_off, ret;
+	__u8 nexthdr;
+
+	lb_v6_add_service((const union v6addr *)&vip_addr6, LB_SVC_WILDCARD_DPORT,
+			  LB_SVC_WILDCARD_PROTO, 1, REVNAT);
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+	ip6 = data + sizeof(struct ethhdr);
+	if ((void *)ip6 + sizeof(*ip6) > data_end)
+		return TEST_ERROR;
+
+	nexthdr = ip6->nexthdr;
+	l4_off = ETH_HLEN + ipv6_hdrlen(ctx, &nexthdr);
+
+	ret = svc_icmp_echo_is_target_v6(ctx, ip6, l4_off);
+	/* Not a VIP -> left for the caller's default handling. */
+	if (ret != 0)
+		return TEST_ERROR;
+
+	return TEST_PASS;
+}
+
+CHECK("tc", "svc_icmp_echo_non_vip6")
+int svc_icmp_echo_non_vip6_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct ipv6hdr *ip6;
+	struct icmp6hdr *icmp;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+	status_code = data;
+	if (*status_code != TEST_PASS)
+		test_fatal("SETUP failed with status code: %d", *status_code);
+
+	ip6 = data + sizeof(*status_code) + sizeof(struct ethhdr);
+	if ((void *)ip6 + sizeof(*ip6) > data_end)
+		test_fatal("ip6 out of bounds");
+	/* Untouched: still client -> non-VIP. */
+	if (memcmp(&ip6->saddr, (void *)client_ip6.addr, 16) != 0 ||
+	    memcmp(&ip6->daddr, (void *)not_a_vip6.addr, 16) != 0)
+		test_fatal("non-VIP echo must be left untouched");
+
+	icmp = (void *)ip6 + sizeof(*ip6);
+	if ((void *)icmp + sizeof(*icmp) > data_end)
+		test_fatal("icmp6 out of bounds");
+	if (icmp->icmp6_type != ICMPV6_ECHO_REQUEST)
+		test_fatal("non-VIP echo type must stay echo-request");
+
+	test_finish();
+}
+
+BPF_LICENSE("Dual BSD/GPL");

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -542,6 +542,9 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	flags.String(option.ServiceNoBackendResponse, defaults.ServiceNoBackendResponse, "Response to traffic for a service without backends")
 	option.BindEnv(vp, option.ServiceNoBackendResponse)
 
+	flags.Bool(option.EnableSvcICMPEchoResponder, false, "Reply to ICMP echo (ping) requests addressed to service (LoadBalancer/ClusterIP) VIPs")
+	option.BindEnv(vp, option.EnableSvcICMPEchoResponder)
+
 	flags.Int(option.TracePayloadlen, defaults.TracePayloadLen, "Length of payload to capture when tracing native packets.")
 
 	flags.String(option.PolicyDenyResponse, defaults.PolicyDenyResponse, "How to handle pod egress traffic dropped by network policy: either drop the packet (\"none\") or reject with an ICMP Destination Unreachable (\"icmp\")")

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -587,6 +587,10 @@ data:
   service-no-backend-response: "{{ .Values.serviceNoBackendResponse }}"
 {{- end}}
 
+{{- if .Values.enableSvcICMPEchoResponder }}
+  enable-svc-icmp-echo-responder: "true"
+{{- end}}
+
 {{- if .Values.policyDenyResponse }}
   policy-deny-response: "{{ .Values.policyDenyResponse }}"
 {{- end}}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3202,6 +3202,10 @@ tunnelSourcePortRange: 0-0
 #  - reject (default)
 #  - drop
 serviceNoBackendResponse: reject
+# -- Reply to ICMP echo (ping) requests addressed to a service (LoadBalancer/
+# ClusterIP) VIP, so the VIP is pingable like it is under kube-proxy/IPVS.
+# Opt-in; the reply is stateless and rate-limited per VIP. IPv4 and IPv6.
+enableSvcICMPEchoResponder: false
 # -- Configure what the response should be to pod egress traffic denied by network policy.
 # Possible values:
 #  - none (default)

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -218,6 +218,13 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *config.Config) erro
 		cDefinesMap["SERVICE_NO_BACKEND_RESPONSE"] = "1"
 	}
 
+	// Reply to ICMP echo (ping) requests addressed to a service VIP
+	// (LoadBalancer/ClusterIP). Opt-in; the datapath answers from the VIP so
+	// operators/monitoring can ping the VIP as they can with kube-proxy/IPVS.
+	if option.Config.EnableSvcICMPEchoResponder {
+		cDefinesMap["ENABLE_SVC_ICMP_ECHO_RESPONDER"] = "1"
+	}
+
 	if option.Config.EnableEncryptionStrictModeEgress {
 		cDefinesMap["ENCRYPTION_STRICT_MODE_EGRESS"] = "1"
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -434,6 +434,11 @@ const (
 	// without any backends
 	ServiceNoBackendResponseDrop = "drop"
 
+	// EnableSvcICMPEchoResponder is the name of the option that makes the
+	// datapath reply to ICMP echo (ping) requests addressed to a service
+	// (LoadBalancer/ClusterIP) VIP.
+	EnableSvcICMPEchoResponder = "enable-svc-icmp-echo-responder"
+
 	// PolicyDenyResponse is the name of the option to pick how to handle ipv4 egress traffic denied by policy
 	PolicyDenyResponse = "policy-deny-response"
 
@@ -1853,6 +1858,10 @@ type DaemonConfig struct {
 	// ServiceNoBackendResponse determines how we handle traffic to a service with no backends.
 	ServiceNoBackendResponse string
 
+	// EnableSvcICMPEchoResponder makes the datapath reply to ICMP echo (ping)
+	// requests addressed to a service (LoadBalancer/ClusterIP) VIP.
+	EnableSvcICMPEchoResponder bool
+
 	// PolicyDenyResponse determines how we handle pod egress traffic denied by network policy.
 	PolicyDenyResponse string
 
@@ -2557,6 +2566,7 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
 	default:
 		logging.Fatal(logger, "Invalid value for --%s: %s (must be 'reject' or 'drop')", ServiceNoBackendResponse, c.ServiceNoBackendResponse)
 	}
+	c.EnableSvcICMPEchoResponder = vp.GetBool(EnableSvcICMPEchoResponder)
 
 	c.populateLoadBalancerSettings(logger, vp)
 	c.PolicyDenyResponse = vp.GetString(PolicyDenyResponse)


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

<!-- Description of change -->

**AI disclosure (AIL:4):** the datapath implementation and tests were
AI-generated from my design and iterative direction. I reviewed all of the
code, and I validated the change on our own cluster.

## Motivation

**Why we built this.** Under kube-proxy/IPVS a service VIP is bound to a dummy
device on the node, so the VIP answers ping. Cilium's eBPF load balancer never
binds a VIP to an interface, so an ICMP echo-request to a LoadBalancer/ClusterIP
VIP is classified as a non-service protocol (`lb4_extract_tuple` ->
`DROP_UNSUPP_SERVICE_PROTO`), falls through `nodeport_lb4` to the local stack,
and nothing owns the VIP there, so nothing answers.

That is a visible behaviour gap when migrating to Cilium: reachability checks,
monitoring probes and operators that ping a service VIP to decide it is "up"
suddenly see 100% loss even though the service is perfectly healthy. There is no
way to make a Cilium-load-balanced VIP pingable today short of the workarounds
people used before kube-proxy replacement (a dummy device per VIP), which we do
not want to reintroduce.

**It is worse than "silently unanswered" in a BGP/anycast deployment.** We
advertise service VIPs over BGP from every node, so the VIP is anycast and the
fabric ECMPs traffic for it across the nodes. When an echo-request the node
cannot answer locally falls through to the stack, the host FIB routes it per the
BGP-learned route for the VIP -- which points back at the upstream router -- so
the packet is forwarded back into the fabric, ECMP'd to a node again, and
**loops between nodes and the router until its TTL expires**. A single `ping`
then produces a train of TTL-exceeded errors instead of a clean reply or a clean
drop. Concretely, with the responder disabled we see:

```
$ ping <service-VIP>
From <node> icmp_seq=1 Time to live exceeded
From <node> icmp_seq=2 Time to live exceeded
...
6 packets transmitted, 0 received, +6 errors, 100% packet loss
```

because the node's FIB has `<VIP> via <router> dev <uplink> proto bird` and no
local reject/blackhole for the advertised VIP. Under kube-proxy/IPVS the dummy
device that owns the VIP terminates the request, so it never loops.

**Current workaround (and why we would prefer a real fix).** To stop the storm
we changed our BIRD config to install a reject/blackhole route for the advertised
VIPs on each node, so an unanswered packet to a VIP is dropped locally instead of
being routed back into the fabric. That kills the loop, but it is a routing-layer
band-aid we maintain outside Cilium: it silently drops *all* non-service traffic
to the VIP (so the VIP still is not pingable), and it has to be kept in sync with
whatever Cilium advertises. We would much rather Cilium not leak VIP-destined
traffic it cannot serve to the host stack in the first place -- either by
answering it (this PR, for echo-requests) or, more generally, by dropping
unhandled traffic to a known VIP in the datapath rather than passing it through
to the stack where the anycast route loops it.

This change lets the datapath answer echo requests for a VIP directly, so a VIP
behaves like it did under kube-proxy/IPVS: it is pingable, and the request is
consumed on the first node it reaches instead of looping -- without needing the
BIRD reject-route workaround for the ping case.

## What this does

New helper `bpf/lib/svc_echo.h`, gated by `ENABLE_SVC_ICMP_ECHO_RESPONDER`
(opt-in, default off). When an ICMP echo-request (IPv4 `ICMP_ECHO` /
ICMPv6 echo request) is addressed to a **known service VIP**, the datapath turns
it into an echo-reply and reflects it back out the ingress interface, instead of
passing it to the stack.

The work is split in two so no packet writes happen on the shared
`nodeport_lb4`/`nodeport_lb6` path (inlined writes there would invalidate the
`ip4`/`ip6` pointer the from-netdev program relies on for the verifier):

- **`svc_icmp_echo_is_target_v{4,6}()`** is a reads-only probe run inline at
  `skip_service_lookup`: is this an echo-request whose destination is a service
  VIP (a LoadBalancer/ClusterIP frontend in the LB maps)? Every other ICMP type,
  and any non-VIP destination, falls through unchanged.
- On a hit it tail-calls **`CILIUM_CALL_IPV{4,6}_SVC_ICMP_ECHO`**, whose worker
  (`svc_icmp_echo_send_reply_v{4,6}()`) does all the packet writes: swap the L2
  and L3 addresses, flip the ICMP type from request to reply (with an
  incremental checksum fixup), and reflect the packet back out the ingress
  interface.

The reply is **stateless** -- any node that receives the request can answer it,
so it works regardless of forwarding mode and under BGP/ECMP -- and it is
**rate-limited per VIP** (`RATELIMIT_USAGE_SVC_ICMP_ECHO`, 100 replies/s
burstable to 1000). IPv4 and IPv6. Exposed as the `enableSvcICMPEchoResponder`
Helm value (`--enable-svc-icmp-echo-responder`).

## Scope

- **Implemented and tested:** IPv4 `ICMP_ECHO` and IPv6 echo-request to
  LoadBalancer/ClusterIP service VIPs. Only echo-requests to a known VIP are
  handled; all other ICMP (including errors) and all non-VIP traffic is
  untouched. TC/host datapath (the reply tail-call lives in that object).
- **Out of scope:** answering ping for anything other than a service VIP; XDP
  acceleration of the responder (unaffected -- it runs on the TC path). No new
  map is introduced; the responder reuses the existing service maps and the
  shared rate-limit map.

## Behaviour and limitations

These are deliberate, and all follow from reproducing kube-proxy/IPVS, where the
VIP is a dummy device on the host and the host kernel answers ping:

- **Policy-independent.** The responder answers at the VIP frontend and
  synthesizes the reply -- it never selects or reaches a backend pod, so there is
  no endpoint for a NetworkPolicy / CiliumNetworkPolicy to be evaluated against.
  It therefore answers regardless of any ingress policy, exactly as pinging a
  kube-proxy dummy device is not subject to NetworkPolicy. (Pod-IP ping, which
  *does* traverse an endpoint, remains governed by policy as usual -- this only
  concerns the service VIP.)
- **Ignores `loadBalancerSourceRanges`.** A ping to the VIP is answered from any
  source, even when the service restricts its L4 traffic to specific CIDRs
  (source ranges gate the service ports, not ICMP to the VIP). The VIP is thus
  pingable from sources that cannot use the service.
- **Answers even with no ready backends.** As long as the VIP is a known service
  frontend it is pingable, independent of backend health.
- **Rate-limited per VIP** (100 replies/s, burst 1000); echo-requests beyond that
  are dropped, not answered.

If a stricter posture is ever needed (e.g. gate the VIP's pingability on policy
or source ranges), it would be a follow-up: there is no single endpoint identity
at the frontend to police, so it would need an explicit mechanism rather than
existing NetworkPolicy.

## Testing

- pktgen datapath test (`bpf/tests/svc_icmp_echo_responder.c`) covers the IPv4
  and IPv6 responder: an echo-request to a VIP is turned into a correct reply
  (addresses swapped, type flipped, checksum valid) and reflected, while a
  request to a non-VIP and a non-echo ICMP fall through. Passes under
  `BPF_PROG_RUN`.
- `bpf_host` compiles with and without `ENABLE_SVC_ICMP_ECHO_RESPONDER`, for
  IPv4 and IPv6.
- Validated on a live cluster (kube-proxy replacement, BGP-advertised anycast
  VIPs): with the responder enabled, `ping <service-VIP>` from off-cluster
  succeeds (4/4, ~0.6 ms); with it disabled the same ping route-loops and
  returns 100% loss with TTL-exceeded from a node (see Motivation), confirming
  both the responder's effect and the underlying loop it resolves.

```release-note
Add an opt-in datapath responder that answers ICMP echo (ping) requests
addressed to a load-balanced service VIP, restoring the pingable-VIP behaviour
that kube-proxy/IPVS provides (disabled by default, enableSvcICMPEchoResponder).
```
