### PR TITLE
fix: Print port numbers correctly for map cilium_lb*_reverse_sk 

### DIFF
--- a/pkg/loadbalancer/maps/test_utils.go
+++ b/pkg/loadbalancer/maps/test_utils.go
@@ -4,6 +4,8 @@
 package maps
 
 import (
+	"encoding"
+	"encoding/binary"
 	"fmt"
 	"slices"
 	"sort"
@@ -188,4 +190,35 @@ func DumpLBMaps(lbmaps LBMaps, sanitizeIDs bool, customizeAddr func(types.AddrCl
 
 	sort.Strings(out)
 	return
+}
+
+// unmarshalFromBpfMapBytes unmarshals ebpf map bytes to golang value
+// It is trimmed from from github.com/cilium/ebpf/internal/sysenc.Unmarshal
+// The original one is internal and it limits client writing unit test
+
+func unmarshalFromBpfMapBytes(data any, buf []byte) error {
+	switch value := data.(type) {
+	case encoding.BinaryUnmarshaler:
+		return value.UnmarshalBinary(buf)
+
+	case *string:
+		*value = string(buf)
+		return nil
+
+	case *[]byte:
+		// Backwards compat: unmarshaling into a slice replaces the whole slice.
+		*value = slices.Clone(buf)
+		return nil
+
+	default:
+		n, err := binary.Decode(buf, binary.NativeEndian, value)
+		if err != nil {
+			return err
+		}
+		if n != len(buf) {
+			return fmt.Errorf("unmarshaling %T doesn't consume all data", data)
+		}
+
+		return nil
+	}
 }

--- a/pkg/loadbalancer/maps/types.go
+++ b/pkg/loadbalancer/maps/types.go
@@ -989,24 +989,27 @@ const (
 
 // SockRevNat4Key is the tuple with address, port and cookie used as key in
 // the reverse NAT sock map.
+// SockRevNat4Key  must match 'struct ipv4_revnat_tuple' in "bpf/lib/sock.h".
 type SockRevNat4Key struct {
 	Cookie  uint64     `align:"cookie"`
 	Address types.IPv4 `align:"address"`
-	Port    int16      `align:"port"`
-	_       int16
+	// port is Network Byte Order, it is simply binary unmarshalled from ebpf map
+	Port uint16 `align:"port"`
+	_    int16
 }
 
 // SockRevNat4Value is an entry in the reverse NAT sock map.
 type SockRevNat4Value struct {
-	Address     types.IPv4 `align:"address"`
-	Port        int16      `align:"port"`
-	RevNatIndex uint16     `align:"rev_nat_index"`
+	Address types.IPv4 `align:"address"`
+	// port is Network Byte Order, it is simply binary unmarshalled from ebpf map
+	Port        uint16 `align:"port"`
+	RevNatIndex uint16 `align:"rev_nat_index"`
 }
 
 func NewSockRevNat4Key(cookie uint64, addr net.IP, port uint16) *SockRevNat4Key {
 	var key SockRevNat4Key
 	key.Cookie = cookie
-	key.Port = int16(byteorder.NetworkToHost16(port))
+	key.Port = byteorder.HostToNetwork16(port)
 	copy(key.Address[:], addr.To4())
 
 	return &key
@@ -1014,25 +1017,27 @@ func NewSockRevNat4Key(cookie uint64, addr net.IP, port uint16) *SockRevNat4Key 
 
 // String converts the key into a human readable string format.
 func (k *SockRevNat4Key) String() string {
-	return fmt.Sprintf("[%s]:%d, %d", k.Address, k.Port, k.Cookie)
+	return fmt.Sprintf("[%s]:%d, %d", k.Address, byteorder.NetworkToHost16(k.Port), k.Cookie)
 }
 
 func (k *SockRevNat4Key) New() bpf.MapKey { return &SockRevNat4Key{} }
 
 // String converts the value into a human readable string format.
 func (v *SockRevNat4Value) String() string {
-	return fmt.Sprintf("[%s]:%d, %d", v.Address, v.Port, v.RevNatIndex)
+	return fmt.Sprintf("[%s]:%d, %d", v.Address, byteorder.NetworkToHost16(v.Port), v.RevNatIndex)
 }
 
 func (v *SockRevNat4Value) New() bpf.MapValue { return &SockRevNat4Value{} }
 
 // SockRevNat6Key is the tuple with address, port and cookie used as key in
 // the reverse NAT sock map.
+// SockRevNat6Key  must match 'struct ipv6_revnat_tuple' in "bpf/lib/sock.h".
 type SockRevNat6Key struct {
 	Cookie  uint64     `align:"cookie"`
 	Address types.IPv6 `align:"address"`
-	Port    int16      `align:"port"`
-	_       [6]byte
+	// port is Network Byte Order, it is simply binary unmarshalled from ebpf map
+	Port uint16 `align:"port"`
+	_    [6]byte
 }
 
 // SizeofSockRevNat6Key is the size of type SockRevNat6Key.
@@ -1040,9 +1045,10 @@ const SizeofSockRevNat6Key = int(unsafe.Sizeof(SockRevNat6Key{}))
 
 // SockRevNat6Value is an entry in the reverse NAT sock map.
 type SockRevNat6Value struct {
-	Address     types.IPv6 `align:"address"`
-	Port        int16      `align:"port"`
-	RevNatIndex uint16     `align:"rev_nat_index"`
+	Address types.IPv6 `align:"address"`
+	// port is Network Byte Order, it is simply binary unmarshalled from ebpf map
+	Port        uint16 `align:"port"`
+	RevNatIndex uint16 `align:"rev_nat_index"`
 }
 
 // SizeofSockRevNat6Value is the size of type SockRevNat6Value.
@@ -1052,7 +1058,7 @@ func NewSockRevNat6Key(cookie uint64, addr net.IP, port uint16) *SockRevNat6Key 
 	var key SockRevNat6Key
 
 	key.Cookie = cookie
-	key.Port = int16(byteorder.NetworkToHost16(port))
+	key.Port = byteorder.HostToNetwork16(port)
 	ipv6Array := addr.To16()
 	copy(key.Address[:], ipv6Array[:])
 
@@ -1061,14 +1067,14 @@ func NewSockRevNat6Key(cookie uint64, addr net.IP, port uint16) *SockRevNat6Key 
 
 // String converts the key into a human readable string format.
 func (k *SockRevNat6Key) String() string {
-	return fmt.Sprintf("[%s]:%d, %d", k.Address, k.Port, k.Cookie)
+	return fmt.Sprintf("[%s]:%d, %d", k.Address, byteorder.NetworkToHost16(k.Port), k.Cookie)
 }
 
 func (k *SockRevNat6Key) New() bpf.MapKey { return &SockRevNat6Key{} }
 
 // String converts the value into a human readable string format.
 func (v *SockRevNat6Value) String() string {
-	return fmt.Sprintf("[%s]:%d, %d", v.Address, v.Port, v.RevNatIndex)
+	return fmt.Sprintf("[%s]:%d, %d", v.Address, byteorder.NetworkToHost16(v.Port), v.RevNatIndex)
 }
 
 func (v *SockRevNat6Value) New() bpf.MapValue { return &SockRevNat6Value{} }

--- a/pkg/loadbalancer/maps/types_test.go
+++ b/pkg/loadbalancer/maps/types_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package maps
+
+import (
+	"encoding/binary"
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/byteorder"
+	"github.com/cilium/cilium/pkg/types"
+)
+
+func TestUnmarshalSockRevNat4Key(t *testing.T) {
+	bpfMapBytes := [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0x0a, 0x61, 0x02, 0x66, 0x01, 0xbb, 0, 0}
+	binary.NativeEndian.PutUint64(bpfMapBytes[:8], 16977)
+	expected := *NewSockRevNat4Key(16977, net.ParseIP("10.97.2.102"), 443)
+	var got SockRevNat4Key
+	var out bpf.MapKey = &got
+	err := unmarshalFromBpfMapBytes(out, bpfMapBytes[:])
+	require.NoError(t, err)
+	require.Equal(t, expected, got)
+}
+
+func TestUnmarshalSockRevNat4Value(t *testing.T) {
+	bpfMapBytes := [8]byte{0x0a, 0x60, 0x01, 0x03, 0x01, 0xbb, 0, 0}
+	binary.NativeEndian.PutUint16(bpfMapBytes[6:8], 15612)
+	var addr types.IPv4
+	addr.FromAddr(netip.MustParseAddr("10.96.1.3"))
+	var expected = SockRevNat4Value{
+		Address:     addr,
+		Port:        byteorder.HostToNetwork16(443),
+		RevNatIndex: 15612,
+	}
+	var got SockRevNat4Value
+	var out bpf.MapValue = &got
+	err := unmarshalFromBpfMapBytes(out, bpfMapBytes[:])
+	require.NoError(t, err)
+	require.Equal(t, expected, got)
+}
+
+func TestUnmarshalSockRevNat6Key(t *testing.T) {
+	bpfMapBytes := [32]byte{0, 0, 0, 0, 0, 0, 0, 0, 0xfd, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x0a, 0x61, 0x02, 0x66, 0x01, 0xbb, 0, 0, 0, 0, 0, 0}
+	binary.NativeEndian.PutUint64(bpfMapBytes[:8], 16977)
+	expected := *NewSockRevNat6Key(16977, net.ParseIP("fd00::10.97.2.102"), 443)
+	var got SockRevNat6Key
+	var out bpf.MapKey = &got
+	err := unmarshalFromBpfMapBytes(out, bpfMapBytes[:])
+	require.NoError(t, err)
+	require.Equal(t, expected, got)
+}
+
+func TestUnmarshalSockRevNat6Value(t *testing.T) {
+	bpfMapBytes := [20]byte{0xfd, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x0a, 0x60, 0x01, 0x03, 0x01, 0xbb, 0, 0}
+	binary.NativeEndian.PutUint16(bpfMapBytes[18:], 15612)
+	var addr types.IPv6
+	addr.FromAddr(netip.MustParseAddr("fd00::10.96.1.3"))
+	var expected = SockRevNat6Value{
+		Address:     addr,
+		Port:        byteorder.HostToNetwork16(443),
+		RevNatIndex: 15612,
+	}
+	var got SockRevNat6Value
+	var out bpf.MapValue = &got
+	err := unmarshalFromBpfMapBytes(out, bpfMapBytes[:])
+	require.NoError(t, err)
+	require.Equal(t, expected, got)
+}


### PR DESCRIPTION
struct SockRevNat* is simply binary unmarshalled from ebpf map and seems to be read-only in agent, so I just keep Port network byte order

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #47131

```release-note
cilium-dbg: Print port numbers correctly for map cilium_lb*_reverse_sk
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
