### PR TITLE
.github: don't drop ciliumbot's approval when pruning reviewers

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -66,7 +66,7 @@ jobs:
           for reviewer in $reviewers; do
             if [ "$reviewer" != "ciliumbot" ]; then
               echo "Removing reviewer $reviewer"
-              gh -R ${GITHUB_REPOSITORY} pr edit ${PULL_REQUEST_NUMBER} --remove-reviewer "$reviewer"
+              gh api --method DELETE "/repos/${GITHUB_REPOSITORY}/pulls/${PULL_REQUEST_NUMBER}/requested_reviewers" -f "reviewers[]=${reviewer}"
             fi
           done
         else


### PR DESCRIPTION
The auto-approve workflow approves a Renovate PR as ciliumbot and then
prunes the other human reviewers to reduce noise. It did this with
gh pr edit --remove-reviewer, which does not remove a single reviewer:
it recomputes the desired reviewer set and re-submits it through the
requestReviews GraphQL mutation. Re-requesting a reviewer who has already
approved moves that approval out of latestReviews, so ciliumbot ends up
back in the pending review-request list and its own approval no longer
counts towards the review decision. The PR then shows as unapproved even
though ciliumbot approved it.

Remove reviewers with the DELETE requested_reviewers REST endpoint
instead. It only drops the named reviewer and leaves every existing
review, including ciliumbot's approval, untouched.

AIL:3
Signed-off-by: André Martins <andre@cilium.io>