### PR TITLE
Fix panic in CT map CG on agent shutdown

### DIFF
--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -1186,6 +1186,16 @@ func (m *Map) Dump(hash map[string][]string) error {
 // BatchLookup returns the count of elements in the map by dumping the map
 // using batch lookup.
 func (m *Map) BatchLookup(cursor *ebpf.MapBatchCursor, keysOut, valuesOut any, opts *ebpf.BatchOptions) (int, error) {
+	// Hold the read lock for the duration of the batch lookup so that a
+	// concurrent Close() (which takes the write lock and sets m.m to nil)
+	// cannot yank the underlying map out from under us mid-iteration.
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	if m.m == nil {
+		return 0, fmt.Errorf("%s: %w", m.name, ErrMapNotOpened)
+	}
+
 	return m.m.BatchLookup(cursor, keysOut, valuesOut, opts)
 }
 

--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -12,6 +12,7 @@ import (
 	"net/netip"
 	"os"
 	"slices"
+	"sync"
 	stdtime "time"
 
 	"github.com/cilium/ebpf"
@@ -116,6 +117,13 @@ type GC struct {
 	observable6 stream.Observable[ctmap.GCEvent]
 	next6       func(ctmap.GCEvent)
 	complete6   func(error)
+
+	// stopGC is closed by the OnStop hook to signal the GC goroutine started
+	// by Enable() to stop. gcWG tracks that goroutine so that OnStop can wait
+	// for any in-flight GC pass to drain before the ct-map cell closes the
+	// global CT maps out from under it.
+	stopGC chan struct{}
+	gcWG   sync.WaitGroup
 }
 
 func newGC(params parameters) *GC {
@@ -141,6 +149,8 @@ func newGC(params parameters) *GC {
 				return mapsFunc == nil
 			},
 		),
+
+		stopGC: make(chan struct{}),
 	}
 
 	gc.observable4, gc.next4, gc.complete4 = stream.Multicast[ctmap.GCEvent]()
@@ -148,7 +158,25 @@ func newGC(params parameters) *GC {
 
 	params.Lifecycle.Append(cell.Hook{
 		// OnStart not yet defined pending further modularization of CT map GC.
-		OnStop: func(cell.HookContext) error {
+		OnStop: func(ctx cell.HookContext) error {
+			// Signal the GC goroutine (if started by Enable) to stop and wait
+			// for any in-flight GC pass to finish. This GC module depends on
+			// ctmap.CTMaps, so hive runs this OnStop before the ct-map cell
+			// closes the global CT maps; draining here guarantees no BatchLookup
+			// races that close and dereferences a nil map. See the goroutine in
+			// enableWithConfig.
+			close(gc.stopGC)
+			drained := make(chan struct{})
+			go func() {
+				gc.gcWG.Wait()
+				close(drained)
+			}()
+			select {
+			case <-drained:
+			case <-ctx.Done():
+				gc.logger.Warn("Timed out waiting for connection tracking garbage collector to stop")
+			}
+
 			gc.controllerManager.RemoveAllAndWait()
 			gc.complete4(nil)
 			gc.complete6(nil)
@@ -214,7 +242,7 @@ func (gc *GC) enableWithConfig(
 		mapPressureSignalCh = make(chan struct{})
 	}
 
-	go func() {
+	gc.gcWG.Go(func() {
 		ipv4 := gc.ipv4
 		ipv6 := gc.ipv6
 		triggeredBySignal := false
@@ -330,12 +358,18 @@ func (gc *GC) enableWithConfig(
 			}
 
 			ipv4, ipv6, triggeredBySignal = gc.waitForGCTrigger(ctx, mapPressureSignalCh, interval)
+			select {
+			case <-gc.stopGC:
+				gc.logger.Info("Stopping conntrack garbage collector")
+				return
+			default:
+			}
 			if ctx.Err() != nil {
 				gc.logger.Info("GC job context failed", logfields.Error, ctx.Err())
 				return
 			}
 		}
-	}()
+	})
 
 	// Start a background go routine that waits to see if either the initial scan completes before
 	// our expected time of 30 seconds.
@@ -590,6 +624,8 @@ func (gc *GC) waitForGCTrigger(ctx context.Context, mapPressureSignalCh <-chan s
 				logfields.NextRunIn, interval,
 			)
 		case <-ctx.Done():
+			return
+		case <-gc.stopGC:
 			return
 		}
 	}


### PR DESCRIPTION
This PR addresses the following panics that can happen in the CT map GC on agent shutdown:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x25319c]
goroutine 2787 [running]:
github.com/cilium/ebpf.(*Map).batchLookup(0x0, 0x18, 0x40154d8980, {0x3272780?, 0x4013d8b4b8?}, {0x32727c0?, 0x4013d8b4d0?}, 0x0)
	/go/src/github.com/cilium/cilium/vendor/github.com/cilium/ebpf/map.go:1273 +0x3c
github.com/cilium/ebpf.(*Map).BatchLookup(0x4001ae6000?, 0x400?, {0x3272780?, 0x4013d8b4b8?}, {0x32727c0?, 0x4013d8b4d0?}, 0x38000006001dfc01?)
	/go/src/github.com/cilium/cilium/vendor/github.com/cilium/ebpf/map.go:1235 +0x48
github.com/cilium/cilium/pkg/bpf.(*Map).BatchLookup(...)
	/go/src/github.com/cilium/cilium/pkg/bpf/map_linux.go:1163
github.com/cilium/cilium/pkg/bpf.(*BatchIterator[...]).IterateAll.func2()
	/go/src/github.com/cilium/cilium/pkg/bpf/map_linux.go:1095 +0x1d4
github.com/cilium/cilium/pkg/maps/ctmap.iterate[...](0x4002486b40, 0x4015d66a00, 0x4018d84280)
	/go/src/github.com/cilium/cilium/pkg/maps/ctmap/ctmap.go:389 +0x110
github.com/cilium/cilium/pkg/maps/ctmap.(*Map).doGCForFamily(0x4002486b40, {0x48?, 0x0?, 0x0?, 0x4014503b60?}, 0x400016efc0, 0x400016f080, 0x0)
	/go/src/github.com/cilium/cilium/pkg/maps/ctmap/ctmap.go:357 +0x5dc
github.com/cilium/cilium/pkg/maps/ctmap.(*Map).doGC(0x400279f9b8?, {0x1c?, 0x0?, 0x0?, 0x4014503b60?}, 0x400279f9e8?, 0x2e9f4ec?)
	/go/src/github.com/cilium/cilium/pkg/maps/ctmap/ctmap.go:477 +0x48
github.com/cilium/cilium/pkg/maps/ctmap.(*Map).GC(0x4002486b40?, {0x5b?, 0x0?, 0x0?, 0x4014503b60?}, 0x400016efc0?, 0x400016f080?)
	/go/src/github.com/cilium/cilium/pkg/maps/ctmap/ctmap.go:489 +0xa8
github.com/cilium/cilium/pkg/maps/ctmap/gc.(*GC).runGC(0x4001cad740, 0x1?, 0x0?, 0x0, {0x0?, 0x0?, 0x0?, 0x4014503b60?})
	/go/src/github.com/cilium/cilium/pkg/maps/ctmap/gc/gc.go:435 +0x4fc
github.com/cilium/cilium/pkg/maps/ctmap/gc.(*GC).enableWithConfig.func1()
	/go/src/github.com/cilium/cilium/pkg/maps/ctmap/gc/gc.go:255 +0x28c
created by github.com/cilium/cilium/pkg/maps/ctmap/gc.(*GC).enableWithConfig in goroutine 613
	/go/src/github.com/cilium/cilium/pkg/maps/ctmap/gc/gc.go:191 +0xf4
```

This PR includes complementary fixes at two different levels (see individual commit messages for details):
* Add a nil guard to `BatchLookup`, fixing the assymetry with other similar functions (`Lookup`, `Type`, `MaxEntries`, ...)
* Fix the root lifecycle bug by tying the GC goroutine to the cell's `OnStop` context