### PR TITLE
gha: capture per-pod diagnostics for sig-network conntrack UDP NodePort failures

### DIFF
--- a/.github/workflows/k8s-kind-network-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-e2e.yaml
@@ -296,7 +296,8 @@ jobs:
             --provider=local                              \
             --dump-logs-on-failure=true                   \
             --report-dir=${E2E_REPORT_DIR}                \
-            --disable-log-dump=true
+            --disable-log-dump=true                       \
+            --delete-namespace-on-failure=false
 
       # Sequentially kill kube-apiserver pods to verify cilium agent pods fail over to an active instance.
       - name: Test kube-apiserver high availability
@@ -349,6 +350,38 @@ jobs:
         if: ${{ !success() && steps.install-cilium.outcome != 'skipped' }}
         run: |
           mkdir -p ./_artifacts/logs
+
+          # The sig-network run keeps failed specs' namespaces alive
+          # (--delete-namespace-on-failure=false), so capture per-pod state
+          # before the kind export tears the cluster down. This is where the
+          # sig-network Conntrack UDP NodePort failure lives: the client probe
+          # pod (pod-client) has been observed crash-looping during the
+          # backend poll window, and namespace teardown plus --disable-log-dump
+          # previously destroyed the evidence (lastState.terminated exit code
+          # /reason and the --previous container stdout that shows whether the
+          # nc loop ran to completion) needed to tell a client-pod crash apart
+          # from a real datapath regression.
+          kubectl get pods -A -o wide > ./_artifacts/logs/pods-wide.txt 2>&1
+          kubectl get pods -A -o yaml > ./_artifacts/logs/pods.yaml 2>&1
+          kubectl get events -A --sort-by=.lastTimestamp > ./_artifacts/logs/events.txt 2>&1
+
+          # For every pod left behind in a sig-network test namespace, dump the
+          # describe output, current logs and previous-container logs so a
+          # future occurrence is fully diagnosable.
+          for ns in $(kubectl get ns -o jsonpath='{.items[*].metadata.name}'); do
+            case "$ns" in
+              conntrack-*|services-*|nettest-*|network-*)
+                nsdir="./_artifacts/logs/${ns}"
+                mkdir -p "$nsdir"
+                for pod in $(kubectl -n "$ns" get pods -o jsonpath='{.items[*].metadata.name}'); do
+                  kubectl -n "$ns" describe pod "$pod" > "${nsdir}/${pod}.describe.txt" 2>&1
+                  kubectl -n "$ns" logs "$pod" --all-containers=true > "${nsdir}/${pod}.log" 2>&1
+                  kubectl -n "$ns" logs "$pod" --all-containers=true --previous > "${nsdir}/${pod}.previous.log" 2>&1
+                done
+                ;;
+            esac
+          done
+
           /usr/local/bin/kind export logs --name  ${{ env.cluster_name }} --verbosity=3 ./_artifacts/logs
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 


### PR DESCRIPTION
The sig-network Conntrack "should be able to preserve UDP traffic when server pod cycles for a NodePort service" spec fails intermittently at conntrack.go:214 with "Failed to connect to backend 2", most recently in run 29198289299 on a v1.19.5 fresh install.

That run points at the client probe pod rather than Cilium's datapath. The backend-1 check passed (no "Failed to connect to backend 1" in the log), so Cilium forwarded and replied to the UDP NodePort flow correctly. What actually went wrong is that pod-client was in CrashLoopBackOff during the one-minute backend-2 poll window, so its logs froze and the substring poll timed out deterministically. The likely trigger is the nc -u -w 5 loop returning immediately instead of blocking (the log shows 20 tries in a single second), so the 3000-iteration loop finishes in seconds, the container exits, and RestartPolicy=Always drives it into BackOff.

I could not prove this from CI, because the evidence was already gone by the time logs were collected. The run passes --disable-log-dump=true and the test namespace is torn down in AfterEach, so pod-client's lastState.terminated exit code and reason, and the previous-container stdout that would show whether the nc loop ran to completion, no longer existed.

This adds instrumentation rather than a behavioural change, because a genuine backend-2 datapath regression would surface at the same line and masking it is unacceptable. It passes --delete-namespace-on-failure=false to the sig-network ginkgo run so only failed specs' namespaces survive past AfterEach, and in the post-test gathering step, before the kind export, it captures pods -o wide and -o yaml, sorted events, and for every pod left in a conntrack, services, nettest or network namespace a describe plus current and --previous logs. The next occurrence will show pod-client's exit code and whether the loop completed, which is what tells a client-pod crash apart from a datapath fault. Once that is confirmed the durable fix is upstream, either making the probe robust or setting the probe pod's RestartPolicy, not a change in Cilium.

It is a draft because it only produces new output when the flake recurs on a failing run; there is nothing to observe on a green run. I want to keep it open until a recurrence is captured with the new artifacts.
