### PR TITLE
images ci: free preinstalled toolchains on tight runners before building

### DIFF
--- a/.github/actions/disk-cleanup/action.yaml
+++ b/.github/actions/disk-cleanup/action.yaml
@@ -1,5 +1,10 @@
 name: Disk cleanup
 description: "Cleanup disk space"
+inputs:
+  min-free-gb:
+    description: "Only clean up when the root filesystem has less than this many GB free. Unset cleans up unconditionally."
+    required: false
+    default: ""
 runs:
   using: composite
   steps:
@@ -17,7 +22,28 @@ runs:
                 --dereference \
                 --threshold 50m \
                 -- /var/lib/docker/volumes/
+    - name: Decide whether cleanup is needed
+      id: decide
+      shell: bash
+      env:
+        MIN_FREE_GB: ${{ inputs.min-free-gb }}
+      run: |
+        if [ -z "${MIN_FREE_GB}" ]; then
+          echo "No min-free-gb threshold set; cleaning up unconditionally."
+          echo "needed=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        avail=$(df --block-size=G --output=avail / | tail -1 | tr -dc '0-9')
+        echo "Root filesystem has ${avail}G free; threshold is ${MIN_FREE_GB}G."
+        if [ "${avail}" -lt "${MIN_FREE_GB}" ]; then
+          echo "Below threshold; cleaning up."
+          echo "needed=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "Enough free space; skipping cleanup."
+          echo "needed=false" >> "$GITHUB_OUTPUT"
+        fi
     - name: Free up disk space
+      if: steps.decide.outputs.needed == 'true'
       shell: bash
       run: |
         echo "Removing unnecessary files to free up disk space..."
@@ -59,6 +85,7 @@ runs:
 
         echo "Disk cleanup completed with maximum parallelism"
     - name: Assess disk usage after cleanup
+      if: steps.decide.outputs.needed == 'true'
       shell: bash
       run: |
         echo "# Overview"

--- a/.github/workflows/build-images-ci-v1.17.yaml
+++ b/.github/workflows/build-images-ci-v1.17.yaml
@@ -113,6 +113,12 @@ jobs:
           echo "# Removing all contents of /mnt except /mnt/swapfile"
           sudo find /mnt -mindepth 1 ! -path /mnt/swapfile -exec rm -rf {} + || true
 
+      - name: Free up disk space on runner root filesystem
+        # The golang-cache import needs at least 40G free to not run out of space.
+        uses: ./.github/actions/disk-cleanup
+        with:
+          min-free-gb: 40
+
       - name: Setup docker volumes into /mnt
         # This allows us to make use of all available disk.
         shell: bash

--- a/.github/workflows/build-images-ci-v1.18.yaml
+++ b/.github/workflows/build-images-ci-v1.18.yaml
@@ -120,6 +120,12 @@ jobs:
           echo "# Removing all contents of /mnt except /mnt/swapfile"
           sudo find /mnt -mindepth 1 ! -path /mnt/swapfile -exec rm -rf {} + || true
 
+      - name: Free up disk space on runner root filesystem
+        # The golang-cache import needs at least 40G free to not run out of space.
+        uses: ./.github/actions/disk-cleanup
+        with:
+          min-free-gb: 40
+
       - name: Setup docker volumes into /mnt
         # This allows us to make use of all available disk.
         shell: bash

--- a/.github/workflows/build-images-ci-v1.19.yaml
+++ b/.github/workflows/build-images-ci-v1.19.yaml
@@ -120,6 +120,12 @@ jobs:
           echo "# Removing all contents of /mnt except /mnt/swapfile"
           sudo find /mnt -mindepth 1 ! -path /mnt/swapfile -exec rm -rf {} + || true
 
+      - name: Free up disk space on runner root filesystem
+        # The golang-cache import needs at least 40G free to not run out of space.
+        uses: ./.github/actions/disk-cleanup
+        with:
+          min-free-gb: 40
+
       - name: Setup docker volumes into /mnt
         # This allows us to make use of all available disk.
         shell: bash

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -124,6 +124,12 @@ jobs:
           echo "# Removing all contents of /mnt except /mnt/swapfile"
           sudo find /mnt -mindepth 1 ! -path /mnt/swapfile -exec rm -rf {} + || true
 
+      - name: Free up disk space on runner root filesystem
+        # The golang-cache import needs at least 40G free to not run out of space.
+        uses: ./.github/actions/disk-cleanup
+        with:
+          min-free-gb: 40
+
       - name: Setup docker volumes into /mnt
         # This allows us to make use of all available disk.
         shell: bash


### PR DESCRIPTION
The Image CI Build draws runners from a heterogeneous pool. Most have a 145G root filesystem, but some are provisioned with only 72G. The GitHub-hosted image ships around 57G used regardless, so a 145G runner starts at 88G free while a 72G runner starts at just 16G free.

Nothing on this workflow reclaims that space. The only disk step clears /mnt (which is empty) and moves the docker volumes onto /mnt, which adds no capacity since /mnt is not a separate mount on the ubuntu-24.04 runner. On a 72G runner the golang-cache import then tips over: the cache restore brings the disk down to 7.5G free, then images/cache/Dockerfile loads the ~7.9G build context and cp -r's it inside buildkit, and the copy dies with "No space left on device". The same full disk takes down the runner Worker as it flushes its own diagnostic log, which is why the failing job uploads no log at all. The 145G siblings in the very same run build the byte-identical image and peak below 60% used, so this only bites the jobs unlucky enough to draw a small runner.

Every other build-images-* workflow already frees the ~26G of unused preinstalled toolchains through the shared disk-cleanup action, and the CI image build is the only one that does not. This wires it in for build-images-ci and its release variants, but skips the cleanup on the 145G tier that does not need it so most jobs do not pay the extra time. Rather than duplicating the free-space check across the four workflows, disk-cleanup gains an optional min-free-gb input: when set it cleans only if the root filesystem has less than that many GB free, and when left unset it cleans unconditionally as before, so the other callers are untouched. The build-images-ci workflows pass 40, which sits cleanly between the 16G and 88G tiers. Because the release-branch workflows resolve the action from their own branch, the input and its consumers have to land together, so the backports carry the action change alongside the workflow change.

This PR was prepared with AIL:3. I reviewed the root cause against the failing run and its siblings and confirmed the threshold logic and the unchanged default for existing callers.
