### PR TITLE
cilium-cli: make encryption sniffer stop resilient and configurable

### DIFF
--- a/cilium-cli/cli/connectivity.go
+++ b/cilium-cli/cli/connectivity.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/cilium-cli/api"
 	"github.com/cilium/cilium/cilium-cli/connectivity"
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/sniff"
 	"github.com/cilium/cilium/cilium-cli/defaults"
 	"github.com/cilium/cilium/cilium-cli/sysdump"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
@@ -229,6 +230,8 @@ func newCmdConnectivityTest(hooks api.Hooks) *cobra.Command {
 	cmd.Flags().StringVar(&params.SecondaryNetworkIface, "secondary-network-iface", "", "Secondary network iface name (e.g., to test NodePort BPF on multiple networks)")
 
 	cmd.Flags().DurationVar(&params.Timeout, "timeout", defaults.ConnectivityTestSuiteTimeout, "Maximum time to allow the connectivity test suite to take")
+
+	cmd.Flags().DurationVar(&params.SniffKillTimeout, "sniff-kill-timeout", sniff.SniffKillTimeout, "Time allowed for the in-pod tcpdump sniffer to shut down during encryption tests (increase on slow or contended nodes)")
 
 	cmd.Flags().IntVar(&params.TestConcurrency, "test-concurrency", 1, "Count of namespaces to perform the connectivity tests in parallel (value <= 0 will be treated as 1)")
 	cmd.Flags().StringSliceVar(&params.IPFamilies, "ip-families", []string{features.IPFamilyV4.String(), features.IPFamilyV6.String()}, "Restrict test actions to specific IP families")

--- a/cilium-cli/connectivity/check/check.go
+++ b/cilium-cli/connectivity/check/check.go
@@ -150,6 +150,11 @@ type Parameters struct {
 	CurlInsecure   bool
 	CurlParallel   uint
 
+	// SniffKillTimeout is the time allowed for the in-pod tcpdump sniffer to
+	// shut down after being signalled during encryption tests. Slow or
+	// contended nodes may need a higher value.
+	SniffKillTimeout time.Duration
+
 	ExitZeroOnFailure       bool
 	CollectSysdumpOnFailure bool
 	SysdumpOptions          sysdump.Options

--- a/cilium-cli/connectivity/sniff/sniffer.go
+++ b/cilium-cli/connectivity/sniff/sniffer.go
@@ -116,23 +116,30 @@ const (
 		sleep 1
 	done
 
-	# Process still exists, exit with error.
+	# Process did not stop in time: force kill it. This is not an error on its
+	# own, as tcpdump may be slow to react to SIGINT on a contended node. Only
+	# fail if nothing was captured; otherwise report the packets and succeed.
 	kill -9 $pid 2>/dev/null
-	exit 197
+	if [ "$(tcpdump -r {{ .DumpPath }} --count 2>/dev/null)" = "0 packets" ]; then
+		exit 197
+	fi
+	report
+	exit 0
 }
 `
 )
 
 type Sniffer struct {
-	target   *check.Pod
-	dumpPath string
-	logPath  string
-	pidPath  string
-	out      bytes.Buffer
-	mode     Mode
-	cmd      []string
-	stopCmd  []string
-	once     sync.Once
+	target      *check.Pod
+	dumpPath    string
+	logPath     string
+	pidPath     string
+	out         bytes.Buffer
+	mode        Mode
+	cmd         []string
+	stopCmd     []string
+	killTimeout time.Duration
+	once        sync.Once
 }
 
 type sniffScriptParams struct {
@@ -150,6 +157,15 @@ type debugLogger interface {
 	Debugf(string, ...any)
 }
 
+// KillTimeout returns the configured sniffer kill timeout, falling back to the
+// default when the given value is unset (<= 0).
+func KillTimeout(configured time.Duration) time.Duration {
+	if configured <= 0 {
+		return SniffKillTimeout
+	}
+	return configured
+}
+
 // Start starts a tcpdump capture on the given pod, listening to the specified
 // interface. The mode configures whether Validate() will (not) expect any packet
 // to match the filter. The returned finalization/close function must be run
@@ -160,11 +176,12 @@ func Sniff(ctx context.Context, name string, target *check.Pod,
 	killTimeout time.Duration, dbg debugLogger,
 ) (*Sniffer, func() error, error) {
 	sniffer := &Sniffer{
-		target:   target,
-		dumpPath: fmt.Sprintf("/tmp/%s.pcap", name),
-		logPath:  fmt.Sprintf("/tmp/%s.log", name),
-		pidPath:  fmt.Sprintf("/tmp/%s.pid", name),
-		mode:     mode,
+		target:      target,
+		dumpPath:    fmt.Sprintf("/tmp/%s.pcap", name),
+		logPath:     fmt.Sprintf("/tmp/%s.log", name),
+		pidPath:     fmt.Sprintf("/tmp/%s.pid", name),
+		mode:        mode,
+		killTimeout: killTimeout,
 	}
 
 	// Limit packet capture to avoid large files: 1 in sanity mode, 1000 in assert mode.
@@ -259,6 +276,13 @@ func (sniffer *Sniffer) stop() (err error) {
 	}
 
 	sniffer.once.Do(func() {
+		// Time allowed for tcpdump to shut down after being signalled. Falls back
+		// to the default when the sniffer was created without an explicit timeout.
+		stopWait := sniffer.killTimeout
+		if stopWait <= 0 {
+			stopWait = sniffScriptTimeout
+		}
+
 		// Execute the template with only the needed params.
 		var buf bytes.Buffer
 		tmpl := template.Must(template.New("sniffStop").Parse(sniffScriptStopTmpl))
@@ -266,7 +290,7 @@ func (sniffer *Sniffer) stop() (err error) {
 		err = tmpl.Execute(&buf, sniffScriptParams{
 			PidPath:     sniffer.pidPath,
 			DumpPath:    sniffer.dumpPath,
-			WaitSeconds: int(sniffScriptTimeout.Seconds()),
+			WaitSeconds: int(stopWait.Seconds()),
 		})
 		if err != nil {
 			err = fmt.Errorf("template execution failed: %w", err)
@@ -276,9 +300,10 @@ func (sniffer *Sniffer) stop() (err error) {
 		// Finally wrap the resulting command.
 		sniffer.stopCmd = append([]string{"sh", "-c"}, buf.String())
 
-		// Context with timeout for stopping tcpdump.
+		// Context with timeout for stopping tcpdump. Must outlive the in-pod wait
+		// loop, so size it relative to stopWait rather than the fixed default.
 		// NOTE: Context is not passed anymore to this function to avoid premature cancellation.
-		ctx, cancel := context.WithTimeout(context.Background(), sniffConnectionTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), stopWait+5*time.Second)
 		defer cancel()
 
 		// Stop tcpdump and store output.

--- a/cilium-cli/connectivity/sniff/sniffer.go
+++ b/cilium-cli/connectivity/sniff/sniffer.go
@@ -30,6 +30,12 @@ const (
 	sniffScriptTimeout = 10 * time.Second
 	// Max timeout before aborting k8s connection in Start/Stop; must exceed sniffScriptTimeout.
 	sniffConnectionTimeout = sniffScriptTimeout + 5*time.Second
+	// Additional allowance on top of the in-pod stop wait to cover kubectl exec
+	// setup/teardown and API round-trip latency. The in-pod stop script always
+	// self-terminates within its wait loop (force-killing with `kill -9`), so the
+	// client context only needs to outlive that wait plus this transport overhead;
+	// it exists solely to trip on a genuinely wedged exec, not to bound tcpdump.
+	sniffStopExecOverhead = sniffConnectionTimeout
 	// Max remote sniffer runtime to prevent lingering processes in the pod.
 	// NOTE: too low may kill tcpdump while test is running.
 	SniffKillTimeout = sniffConnectionTimeout * 4
@@ -300,10 +306,12 @@ func (sniffer *Sniffer) stop() (err error) {
 		// Finally wrap the resulting command.
 		sniffer.stopCmd = append([]string{"sh", "-c"}, buf.String())
 
-		// Context with timeout for stopping tcpdump. Must outlive the in-pod wait
-		// loop, so size it relative to stopWait rather than the fixed default.
+		// Context with timeout for stopping tcpdump. The in-pod script always
+		// self-terminates within stopWait (it force-kills with `kill -9` after the
+		// wait loop), so the client context only needs to outlive that wait plus
+		// exec transport overhead; it guards solely against a wedged kubectl exec.
 		// NOTE: Context is not passed anymore to this function to avoid premature cancellation.
-		ctx, cancel := context.WithTimeout(context.Background(), stopWait+5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), stopWait+sniffStopExecOverhead)
 		defer cancel()
 
 		// Stop tcpdump and store output.

--- a/cilium-cli/connectivity/tests/encryption.go
+++ b/cilium-cli/connectivity/tests/encryption.go
@@ -298,7 +298,7 @@ func testNoTrafficLeak(ctx context.Context, t *check.Test, s check.Scenario,
 		snifferMode = sniff.ModeSanity
 	}
 
-	srcSniffer, cancel, err := sniff.Sniff(ctx, s.Name(), clientHost, srcIface, srcFilter, snifferMode, sniff.SniffKillTimeout, t)
+	srcSniffer, cancel, err := sniff.Sniff(ctx, s.Name(), clientHost, srcIface, srcFilter, snifferMode, sniff.KillTimeout(t.Context().Params().SniffKillTimeout), t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -309,7 +309,7 @@ func testNoTrafficLeak(ctx context.Context, t *check.Test, s check.Scenario,
 		dstFilter := getFilter(ctx, t, server, serverHost, client, clientHost, ipFam, reqType, wgEncap)
 		dstIface := getInterNodeIface(ctx, t, server, serverHost, client, clientHost, ipFam, wgEncap)
 
-		dstSniffer, cancel, err = sniff.Sniff(ctx, s.Name(), serverHost, dstIface, dstFilter, snifferMode, sniff.SniffKillTimeout, t)
+		dstSniffer, cancel, err = sniff.Sniff(ctx, s.Name(), serverHost, dstIface, dstFilter, snifferMode, sniff.KillTimeout(t.Context().Params().SniffKillTimeout), t)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cilium-cli/connectivity/tests/encryption_v2.go
+++ b/cilium-cli/connectivity/tests/encryption_v2.go
@@ -465,7 +465,7 @@ func (s *podToPodEncryptionV2) startSniffers(ctx context.Context, t *check.Test)
 	var cancel func() error
 
 	if s.ipv4Enabled.Enabled {
-		s.clientSniffer4, cancel, err = sniff.Sniff(ctx, s.Name(), s.clientHostNS, s.clientEgressDev, s.clientFilter4, mode, sniff.SniffKillTimeout, t)
+		s.clientSniffer4, cancel, err = sniff.Sniff(ctx, s.Name(), s.clientHostNS, s.clientEgressDev, s.clientFilter4, mode, sniff.KillTimeout(t.Context().Params().SniffKillTimeout), t)
 		if err != nil {
 			return fmt.Errorf("Failed to start sniffer on client: %w", err)
 		}
@@ -473,7 +473,7 @@ func (s *podToPodEncryptionV2) startSniffers(ctx context.Context, t *check.Test)
 		t.Debugf("started client tcpdump sniffer: [client: %s] [node: %s] [dev: %s] [filter: %s] [mode: %s]",
 			s.client.Pod.Name, s.client.Pod.Spec.NodeName, s.clientEgressDev, s.clientFilter4, mode)
 
-		s.serverSniffer4, cancel, err = sniff.Sniff(ctx, s.Name(), s.serverHostNS, s.serverEgressDev, s.serverFilter4, mode, sniff.SniffKillTimeout, t)
+		s.serverSniffer4, cancel, err = sniff.Sniff(ctx, s.Name(), s.serverHostNS, s.serverEgressDev, s.serverFilter4, mode, sniff.KillTimeout(t.Context().Params().SniffKillTimeout), t)
 		if err != nil {
 			return fmt.Errorf("Failed to start sniffer on server: %w", err)
 		}
@@ -505,7 +505,7 @@ func (s *podToPodEncryptionV2) startSniffers(ctx context.Context, t *check.Test)
 		// write to the same pcap file and this can break validation.
 		name := fmt.Sprintf("%s-ipv6", s.Name())
 
-		s.clientSniffer6, cancel, err = sniff.Sniff(ctx, name, s.clientHostNS, s.clientEgressDev, s.clientFilter6, mode, sniff.SniffKillTimeout, t)
+		s.clientSniffer6, cancel, err = sniff.Sniff(ctx, name, s.clientHostNS, s.clientEgressDev, s.clientFilter6, mode, sniff.KillTimeout(t.Context().Params().SniffKillTimeout), t)
 		if err != nil {
 			return fmt.Errorf("Failed to start sniffer on client for IPv6: %w", err)
 		}
@@ -513,7 +513,7 @@ func (s *podToPodEncryptionV2) startSniffers(ctx context.Context, t *check.Test)
 		t.Debugf("started client tcpdump sniffer for IPv6: [client: %s] [node: %s] [dev: %s] [filter: %s] [mode: %s]",
 			s.client.Pod.Name, s.client.Pod.Spec.NodeName, s.clientEgressDev, s.clientFilter6, mode)
 
-		s.serverSniffer6, cancel, err = sniff.Sniff(ctx, name, s.serverHostNS, s.serverEgressDev, s.serverFilter6, mode, sniff.SniffKillTimeout, t)
+		s.serverSniffer6, cancel, err = sniff.Sniff(ctx, name, s.serverHostNS, s.serverEgressDev, s.serverFilter6, mode, sniff.KillTimeout(t.Context().Params().SniffKillTimeout), t)
 		if err != nil {
 			return fmt.Errorf("Failed to start sniffer on server for IPv6: %w", err)
 		}


### PR DESCRIPTION
Make the encryption connectivity-test sniffer resilient when tcpdump is
slow to stop. Previously the stop script SIGKILLed tcpdump after a fixed
wait and exited 197, failing the test even when the capture had already
succeeded — common on slow or contended nodes.

Changes:
- Treat a forced kill as success when the capture contains packets.
- Honor the kill timeout passed to `Sniff()` in the stop wait instead of
  a hardcoded value, and expose it via a new `--sniff-kill-timeout` flag.

Fixes: #47142

```release-note
cilium-cli: make the encryption connectivity-test sniffer tolerate a slow
tcpdump shutdown and add a --sniff-kill-timeout flag
```
