### PR TITLE
doublewrite: Don't run CRD backend with real handler when reading from KVStore

### DIFF
--- a/pkg/kvstore/allocator/doublewrite/backend.go
+++ b/pkg/kvstore/allocator/doublewrite/backend.go
@@ -312,6 +312,12 @@ func (d *doubleWriteBackend) ListAndWatch(ctx context.Context, handler allocator
 		// Since we don't need to use the results of the list operation, we can use a no-op handler
 		go d.crdBackend.ListAndWatch(ctx, NoOpHandler{})
 		d.kvstoreBackend.ListAndWatch(ctx, handler)
+		// Return here: the real handler is driven exclusively by the KVStore
+		// backend in this mode. Falling through to run the CRD backend with the
+		// same handler would deliver a second OnListDone (and thus a duplicate
+		// Sync event) whenever the KVStore watch terminates with a live context,
+		// closing the allocator's listDone channel twice.
+		return
 	}
 	d.crdBackend.ListAndWatch(ctx, handler)
 }

--- a/pkg/kvstore/allocator/doublewrite/backend_test.go
+++ b/pkg/kvstore/allocator/doublewrite/backend_test.go
@@ -58,6 +58,59 @@ func setup(tb testing.TB) (string, *k8sClient.FakeClientset, kvstore.BackendOper
 	return kvstorePrefix, kubeClient, kvstoreClient, backend
 }
 
+// fakeBackend embeds allocator.Backend so that only the methods exercised by a
+// test need to be implemented; every other method is nil and must not be called.
+type fakeBackend struct {
+	allocator.Backend
+	listAndWatch func(ctx context.Context, handler allocator.CacheMutations)
+}
+
+func (f *fakeBackend) ListAndWatch(ctx context.Context, handler allocator.CacheMutations) {
+	f.listAndWatch(ctx, handler)
+}
+
+// countingHandler records how many times OnListDone is invoked on it.
+type countingHandler struct {
+	NoOpHandler
+	onListDone atomic.Int32
+}
+
+func (h *countingHandler) OnListDone() { h.onListDone.Add(1) }
+
+// TestListAndWatchReadFromKVStoreSingleOnListDone is a regression test for a
+// double-close of the allocator's listDone channel. In read-from-KVStore mode
+// the real handler must be driven only by the KVStore backend. Previously a
+// missing return caused the CRD backend to also run with the real handler once
+// the KVStore watch returned, delivering a second OnListDone/Sync event and
+// panicking with "close of closed channel" in the identity watcher.
+func TestListAndWatchReadFromKVStoreSingleOnListDone(t *testing.T) {
+	handler := &countingHandler{}
+
+	// The KVStore backend receives the real handler, signals sync completion,
+	// then returns while the context is still live (mimicking a transient
+	// etcd/watch disconnect rather than a shutdown).
+	kvstoreBackend := &fakeBackend{listAndWatch: func(ctx context.Context, h allocator.CacheMutations) {
+		h.OnListDone()
+	}}
+	// The CRD backend forwards OnListDone to whatever handler it is given, so a
+	// duplicate only reaches the real handler if it is (incorrectly) wired to it.
+	crdBackend := &fakeBackend{listAndWatch: func(ctx context.Context, h allocator.CacheMutations) {
+		h.OnListDone()
+	}}
+
+	backend := &doubleWriteBackend{
+		logger:          hivetest.Logger(t),
+		crdBackend:      crdBackend,
+		kvstoreBackend:  kvstoreBackend,
+		readFromKVStore: true,
+	}
+
+	backend.ListAndWatch(context.Background(), handler)
+
+	require.Equal(t, int32(1), handler.onListDone.Load(),
+		"real handler must receive exactly one OnListDone in read-from-KVStore mode")
+}
+
 func TestAllocateID(t *testing.T) {
 	kvstorePrefix, kubeClient, kvstoreClient, backend := setup(t)
 


### PR DESCRIPTION
In read-from-KVStore mode, `ListAndWatch` ran the `KVStore` backend with the real handler and then fell through to run the CRD backend with the same handler due to a missing return. When the KVStore watch terminated with a live context (e.g. a transient etcd disconnect), the CRD backend delivered a second `OnListDone`, emitting a duplicate `AllocatorChangeSync` event. The identity watcher then closed the allocator's `listDone` channel twice, panicking with "close of closed channel".

Return after the KVStore backend so the real handler is driven exclusively by the KVStore in this mode. The CRD backend keeps running only with the `NoOpHandler` to initialize its store.

Fixes those panics:
```
panic: close of closed channel
goroutine 238 [running]:
github.com/cilium/cilium/pkg/identity/cache.(*identityWatcher).watch.func1()
	/go/src/github.com/cilium/cilium/pkg/identity/cache/cache.go:197 +0x198
created by github.com/cilium/cilium/pkg/identity/cache.(*identityWatcher).watch in goroutine 1
	/go/src/github.com/cilium/cilium/pkg/identity/cache/cache.go:153 +0x68
```