### PR TITLE
envoy: demote stale ADS endpoint warning

### DIFF
--- a/pkg/envoy/standalone_envoy.go
+++ b/pkg/envoy/standalone_envoy.go
@@ -291,10 +291,12 @@ func isExpectedEnvoyWarning(logMsg string, adsMode bool) bool {
 		return true
 	}
 
-	// During ADS/SDS teardown Envoy may unsubscribe from Secret resources while
-	// an older Secret response is already queued on the ADS stream. Envoy drops
-	// that stale response and logs "Ignoring unwatched type URL".
-	return adsMode && strings.Contains(logMsg, "Ignoring unwatched type URL "+SecretTypeURL)
+	// During ADS resource teardown Envoy may unsubscribe while an older response
+	// is already queued on the ADS stream. Envoy drops that stale response and
+	// logs "Ignoring unwatched type URL".
+	return adsMode &&
+		(strings.Contains(logMsg, "Ignoring unwatched type URL "+SecretTypeURL) ||
+			strings.Contains(logMsg, "Ignoring unwatched type URL "+EndpointTypeURL))
 }
 
 // newEnvoyLogPiper creates a writer that parses and logs log messages written by Envoy.

--- a/pkg/envoy/standalone_envoy_test.go
+++ b/pkg/envoy/standalone_envoy_test.go
@@ -57,6 +57,48 @@ type EnvoySuite struct {
 	waitGroup *completion.WaitGroup
 }
 
+func TestIsExpectedEnvoyWarning(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+		adsMode bool
+		want    bool
+	}{
+		{
+			name:    "initial fetch timeout",
+			message: "[gRPC config: initial fetch timed out for type.googleapis.com/example",
+			want:    true,
+		},
+		{
+			name:    "ADS secret response after unsubscribe",
+			message: "[Ignoring unwatched type URL " + SecretTypeURL,
+			adsMode: true,
+			want:    true,
+		},
+		{
+			name:    "ADS endpoint response after unsubscribe",
+			message: "[Ignoring unwatched type URL " + EndpointTypeURL,
+			adsMode: true,
+			want:    true,
+		},
+		{
+			name:    "split endpoint response",
+			message: "[Ignoring unwatched type URL " + EndpointTypeURL,
+		},
+		{
+			name:    "unrelated ADS warning",
+			message: "[Ignoring unwatched type URL " + ListenerTypeURL,
+			adsMode: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isExpectedEnvoyWarning(tt.message, tt.adsMode))
+		})
+	}
+}
+
 func setupEnvoySuite(tb testing.TB) *EnvoySuite {
 	return &EnvoySuite{
 		tb: tb,


### PR DESCRIPTION
Demoting another ads related warn message until we bump version of control plane with generic fix: https://github.com/envoyproxy/go-control-plane/pull/1498

