### PR TITLE
docs: wireguard: update Pod-to-remote-backend encryption requirements

### DIFF
--- a/Documentation/security/network/encryption-wireguard.rst
+++ b/Documentation/security/network/encryption-wireguard.rst
@@ -313,7 +313,7 @@ table are not subject to encryption with WireGuard and therefore assumed to be u
 | Pod            | remote Pod via    | any                  | default         |
 |                | ClusterIP Service |                      |                 |
 +----------------+-------------------+----------------------+-----------------+
-| Pod            | remote Pod via    | Socket LB            | default         |
+| Pod            | remote Pod via    | KPR                  | default         |
 |                | non ClusterIP     |                      |                 |
 |                | Service (e.g.,    |                      |                 |
 |                | NodePort)         |                      |                 |


### PR DESCRIPTION
With https://github.com/cilium/cilium/pull/44507 this case should no longer require SocketLB, any KPR configuration will do (so that the service access is translated at the source node).