### PR TITLE
policy: Reject bare IP addresses in CIDR policy fields

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/types_test.go
@@ -56,7 +56,7 @@ var (
 				},
 			}, {
 				EgressCommonRule: api.EgressCommonRule{
-					ToCIDR: []api.CIDR{"10.0.0.1"},
+					ToCIDR: []api.CIDR{"10.0.0.1/32"},
 				},
 			}, {
 				EgressCommonRule: api.EgressCommonRule{
@@ -97,7 +97,7 @@ var (
 				},
 			}, {
 				EgressCommonRule: api.EgressCommonRule{
-					ToCIDR: []api.CIDR{"10.0.0.1"},
+					ToCIDR: []api.CIDR{"10.0.0.1/32"},
 				},
 			}, {
 				EgressCommonRule: api.EgressCommonRule{
@@ -141,7 +141,7 @@ var (
 			},
 			{
 				EgressCommonRule: api.EgressCommonRule{
-					ToCIDR: []api.CIDR{"10.0.0.1"},
+					ToCIDR: []api.CIDR{"10.0.0.1/32"},
 				},
 			}, {
 				EgressCommonRule: api.EgressCommonRule{
@@ -222,7 +222,7 @@ var (
                 ]
             },{
                 "toCIDR": [
-                    "10.0.0.1"
+                    "10.0.0.1/32"
                 ]
             },{
                 "toCIDRSet": [
@@ -489,7 +489,7 @@ func TestParseWithNodeSelector(t *testing.T) {
 				},
 			}, {
 				EgressCommonRule: api.EgressCommonRule{
-					ToCIDR: []api.CIDR{"10.0.0.1"},
+					ToCIDR: []api.CIDR{"10.0.0.1/32"},
 				},
 			}, {
 				EgressCommonRule: api.EgressCommonRule{

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -659,11 +659,7 @@ func (c CIDR) sanitize() error {
 
 	prefix, err := netip.ParsePrefix(strCIDR)
 	if err != nil {
-		_, err := netip.ParseAddr(strCIDR)
-		if err != nil {
-			return fmt.Errorf("unable to parse CIDR: %w", err)
-		}
-		return nil
+		return fmt.Errorf("unable to parse CIDR: %w", err)
 	}
 	prefixLength := prefix.Bits()
 	if prefixLength < 0 {

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -93,7 +93,7 @@ func newTestData(tb testing.TB, logger *slog.Logger) *testData {
 	td.cachedSelectorCIDR = func(cidr api.CIDR) CachedSelector {
 		css, _ := td.sc.AddSelectors(dummySelectorCacheUser, types.ToSelector(cidr))
 		return css[0]
-	}(api.CIDR("10.1.1.1"))
+	}(api.CIDR("10.1.1.1/32"))
 
 	td.cachedSelectorCIDR0 = func(cidr api.CIDR) CachedSelector {
 		css, _ := td.sc.AddSelectors(dummySelectorCacheUser, types.ToSelector(cidr))

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -320,7 +320,7 @@ func TestEgressCIDRTCPPort(t *testing.T) {
 		Egress: []api.EgressRule{
 			{
 				EgressCommonRule: api.EgressCommonRule{
-					ToCIDR: []api.CIDR{"10.1.1.1"},
+					ToCIDR: []api.CIDR{"10.1.1.1/32"},
 				},
 				ToPorts: []api.PortRule{{
 					Ports: []api.PortProtocol{

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -509,10 +509,10 @@ func TestRuleWithNoEndpointSelector(t *testing.T) {
 				IngressCommonRule: api.IngressCommonRule{
 					FromCIDR: []api.CIDR{
 						"10.0.1.0/24",
-						"192.168.2.0",
-						"10.0.3.1",
+						"192.168.2.0/32",
+						"10.0.3.1/32",
 						"2001:db8::1/48",
-						"2001:db9::",
+						"2001:db9::/128",
 					},
 				},
 			},
@@ -546,10 +546,10 @@ func TestL3Policy(t *testing.T) {
 				IngressCommonRule: api.IngressCommonRule{
 					FromCIDR: []api.CIDR{
 						"10.0.1.0/24",
-						"192.168.2.0",
-						"10.0.3.1",
+						"192.168.2.0/32",
+						"10.0.3.1/32",
 						"2001:db8::1/48",
-						"2001:db9::",
+						"2001:db9::/128",
 					},
 				},
 			},

--- a/pkg/policy/types/selector.go
+++ b/pkg/policy/types/selector.go
@@ -454,15 +454,6 @@ func newCIDRSelectorFromRequirements(key string, reqs Requirements, except []api
 }
 
 func NewCIDRSelector(key string, cidr api.CIDR, except []api.CIDR) *CIDRSelector {
-	i := strings.LastIndexByte(string(cidr), '/')
-	if i < 0 {
-		parsedIP, err := netip.ParseAddr(string(cidr))
-		if err != nil {
-			// input is sanitized, so this panic should never fire
-			panic(fmt.Errorf("%q is not an IP address: %w", cidr, err))
-		}
-		cidr += api.CIDR(fmt.Sprintf("/%d", parsedIP.BitLen()))
-	}
 	lbl, err := labels.IPStringToLabel(string(cidr))
 	if err != nil {
 		// input is sanitized, so this panic should never fire


### PR DESCRIPTION
The CIDR type used in `fromCIDR`/`toCIDR`/`CIDRRule` accepted bare IP addresses (e.g. `192.0.2.3`) in addition to prefix notation (`192.0.2.3/32`). `CIDR.sanitize()` fell back to `netip.ParseAddr` when `netip.ParsePrefix` failed, and `NewCIDRSelector` normalized a slash-less value by appending `/BitLen`.

This notation has been rejected at admission time by the Kubernetes API server since the fields gained `format: cidr` in v1.16 (see https://github.com/cilium/cilium/pull/32814) and before that via a validation regex. So the bare-IP codepaths are effectively deadcode. This PR drops them so the agent-side contract matches admission and CIDR becomes effectively an IP prefix only with no bare IP fallback.