### PR TITLE
bgp: Use GoBGP configuration directly in script test

### DIFF
--- a/pkg/bgp/test/commands/gobgp.go
+++ b/pkg/bgp/test/commands/gobgp.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"net/netip"
 	"sort"
-	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -17,6 +16,8 @@ import (
 	"github.com/cilium/hive/script"
 	gobgpapi "github.com/osrg/gobgp/v4/api"
 	"github.com/osrg/gobgp/v4/pkg/apiutil"
+	gobgpconfig "github.com/osrg/gobgp/v4/pkg/config"
+	"github.com/osrg/gobgp/v4/pkg/config/oc"
 	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
 	"github.com/osrg/gobgp/v4/pkg/server"
 	"github.com/spf13/pflag"
@@ -32,36 +33,35 @@ const (
 	serverNameFlag      = "server-name"
 	serverNameFlagShort = "s"
 
-	routerIDFlag      = "router-id"
-	routerIDFlagShort = "r"
-
 	timeoutFlag      = "timeout"
 	timeoutFlagShort = "t"
-
-	passwordFlag      = "password"
-	passwordFlagShort = "p"
-
-	familiesFlag      = "families"
-	familiesFlagShort = "f"
 
 	gobgpSessionStatePrefix = "SESSION_STATE_"
 )
 
+// gobgpServerState tracks a running GoBGP test server instance together with
+// the last GoBGP configuration successfully applied to it, so that
+// gobgp/reload-server can diff a new configuration against it.
+type gobgpServerState struct {
+	server *server.BgpServer
+	config *oc.BgpConfigSet
+}
+
 type GoBGPCmdContext struct {
-	servers map[string]*server.BgpServer
+	servers map[string]*gobgpServerState
 }
 
 func NewGoBGPCmdContext() *GoBGPCmdContext {
 	return &GoBGPCmdContext{
-		servers: make(map[string]*server.BgpServer),
+		servers: make(map[string]*gobgpServerState),
 	}
 }
 
-func (ctx *GoBGPCmdContext) AddServer(name string, srv *server.BgpServer) {
+func (ctx *GoBGPCmdContext) AddServer(name string, srv *server.BgpServer, config *oc.BgpConfigSet) {
 	if _, found := ctx.servers[name]; found {
 		panic("Server " + name + " already exists")
 	}
-	ctx.servers[name] = srv
+	ctx.servers[name] = &gobgpServerState{server: srv, config: config}
 }
 
 func (ctx *GoBGPCmdContext) DeleteServer(name string) {
@@ -79,20 +79,23 @@ func (ctx *GoBGPCmdContext) GetServer(name string) (*server.BgpServer, bool) {
 	if name == "" {
 		if ctx.NServers() > 0 {
 			// Return fierst server if no name is specified
-			for _, srv := range ctx.servers {
-				return srv, true
+			for _, state := range ctx.servers {
+				return state.server, true
 			}
 		} else {
 			return nil, false
 		}
 	}
-	srv, found := ctx.servers[name]
-	return srv, found
+	state, found := ctx.servers[name]
+	if !found {
+		return nil, false
+	}
+	return state.server, true
 }
 
 func (ctx *GoBGPCmdContext) Cleanup() {
-	for _, s := range ctx.servers {
-		s.Stop()
+	for _, state := range ctx.servers {
+		state.server.Stop()
 	}
 }
 
@@ -100,7 +103,7 @@ func GoBGPScriptCmds(ctx *GoBGPCmdContext) map[string]script.Cmd {
 	return map[string]script.Cmd{
 		"gobgp/add-server":      GoBGPAddServerCmd(ctx),
 		"gobgp/delete-server":   GoBGPDeleteServerCmd(ctx),
-		"gobgp/add-peer":        GoBGPAddPeerCmd(ctx),
+		"gobgp/reload-server":   GoBGPReloadServerCmd(ctx),
 		"gobgp/wait-state":      GoBGPWaitStateCmd(ctx),
 		"gobgp/peers":           GoBGPPeersCmd(ctx),
 		"gobgp/routes":          GoBGPRoutesCmd(ctx),
@@ -111,61 +114,43 @@ func GoBGPScriptCmds(ctx *GoBGPCmdContext) map[string]script.Cmd {
 func GoBGPAddServerCmd(cmdCtx *GoBGPCmdContext) script.Cmd {
 	return script.Command(
 		script.CmdUsage{
-			Summary: "Add a new GoBGP server instance",
-			Args:    "name asn ip port",
-			Flags: func(fs *pflag.FlagSet) {
-				fs.StringP(routerIDFlag, routerIDFlagShort, "", "router-id of the server. Defaults to server ip if not provided.")
-			},
+			Summary: "Add a new GoBGP server instance from a native GoBGP configuration file",
+			Args:    "name config-file",
 			Detail: []string{
-				"Add a new GoBGP server instance with the specified parameters.",
-				"The server will be stopped during the test cleanup, but can be also removed during the test with gobgp/delete-server command.",
+				"Add a new GoBGP server instance. The <config-file> argument specifies an initial",
+				"configuration file. The format is the same as the one of upstream gobgpd.",
 				"",
-				"'Name' is the name of the server.",
-				"'ASN' is the autonomous system number of this instance.",
-				"'ip' is the IP address on which the server listens for incoming connections.",
-				"'port' is the port number on which the server listens for incoming connections.",
+				"'name' is the name used to refer to this server instance in other gobgp/* commands.",
+				"'config-file' is a path to an initial configuration file. The format is the same as",
+				"the one of the upstream gobgpd consumes.",
 			},
 		},
 		func(s *script.State, args ...string) (script.WaitFunc, error) {
-			if len(args) < 4 {
-				return nil, fmt.Errorf("invalid command format, should be: 'gobgp/add-server name asn ip port'")
+			if len(args) < 2 {
+				return nil, fmt.Errorf("invalid command format, should be: 'gobgp/add-server name config-file'")
 			}
-			asn, err := strconv.Atoi(args[1])
+			path := s.Path(args[1])
+			configSet, err := gobgpconfig.ReadConfigFile(path, "")
 			if err != nil {
-				return nil, fmt.Errorf("could not parse asn: %w", err)
-			}
-			port, err := strconv.Atoi(args[3])
-			if err != nil {
-				return nil, fmt.Errorf("could not parse port: %w", err)
-			}
-			routerID, err := s.Flags.GetString(routerIDFlag)
-			if err != nil {
-				return nil, err
-			}
-			if routerID == "" {
-				routerID = args[2]
+				return nil, fmt.Errorf("could not read GoBGP config file %s: %w", args[1], err)
 			}
 
 			// start new GoBGP server
 			logger := slog.Default().With(
 				types.ComponentLogField, "gobgp-server",
-				types.LocalASNLogField, asn,
+				types.NameLogField, args[0],
 			)
 			gobgpServer := server.NewBgpServer(server.LoggerOption(logger, nil))
 			go gobgpServer.Serve()
-			err = gobgpServer.StartBgp(s.Context(), &gobgpapi.StartBgpRequest{Global: &gobgpapi.Global{
-				Asn:             uint32(asn),
-				RouterId:        routerID,
-				ListenAddresses: []string{args[2]},
-				ListenPort:      int32(port),
-			}})
+			appliedConfig, err := gobgpconfig.InitialConfig(s.Context(), gobgpServer, configSet, false)
 			if err != nil {
 				gobgpServer.Stop()
 				return nil, err
 			}
-			cmdCtx.AddServer(args[0], gobgpServer)
+			cmdCtx.AddServer(args[0], gobgpServer, appliedConfig)
 
-			s.Logf("Started GoBGP Server Name: %s, ASN: %d, ip: %s, port: %d\n", args[0], asn, args[2], port)
+			s.Logf("Started GoBGP Server %q\n", args[0])
+
 			return nil, nil
 		},
 	)
@@ -198,90 +183,49 @@ func GoBGPDeleteServerCmd(cmdCtx *GoBGPCmdContext) script.Cmd {
 	)
 }
 
-func GoBGPAddPeerCmd(cmdCtx *GoBGPCmdContext) script.Cmd {
+func GoBGPReloadServerCmd(cmdCtx *GoBGPCmdContext) script.Cmd {
 	return script.Command(
 		script.CmdUsage{
-			Summary: "Add a new peer the GoBGP server instance",
-			Args:    "ip remote-asn",
-			Flags: func(fs *pflag.FlagSet) {
-				fs.StringP(serverNameFlag, serverNameFlagShort, "", "Name of the GoBGP server instance. Can be omitted if only one instance is active.")
-				fs.StringP(passwordFlag, passwordFlagShort, "", "Authentication password used for the peer.")
-				fs.StringP(familiesFlag, familiesFlagShort, "ipv4/unicast,ipv6/unicast", "Comma-separated list of AFI/SAFIs enabled for the peer. If not specified, ipv4/unicast and ipv6/unicast are enabled.")
-			},
+			Summary: "Reload the configuration of a running GoBGP server instance",
+			Args:    "name config-file",
 			Detail: []string{
-				"Add a new peer with the given IP and remote ASN to the GoBGP server instance.",
+				"Apply a new GoBGP configuration file to an already-running server instance, the same way",
+				"gobgpd applies a config file change on SIGHUP: the new file is diffed against the last",
+				"configuration applied to this server, and peers/peer-groups/route-policies are added,",
+				"removed or updated to match.",
 				"",
-				"'ip' is IP address of the peer.",
-				"'remote-asn' is the remote ASN number of the peer.",
-				"If there are multiple server instances configured, the server-asn flag needs to be specified.",
+				"Global/listen parameters (ASN, listen address, port) in the new file are ignored - GoBGP",
+				"cannot change those on a running server. To change them, use gobgp/delete-server followed",
+				"by gobgp/add-server instead.",
+				"",
+				"Like gobgpd's own reload, per-item failures (e.g. a malformed peer) are only logged, not",
+				"returned as a command error - inspect gobgp/peers, gobgp/routes, etc. afterwards to confirm",
+				"the change actually applied.",
 			},
 		},
 		func(s *script.State, args ...string) (script.WaitFunc, error) {
 			if len(args) < 2 {
-				return nil, fmt.Errorf("invalid command format, should be: 'gobgp/ass-peer ip remote-asn'")
+				return nil, fmt.Errorf("invalid command format, should be: 'gobgp/reload-server name config-file'")
 			}
-			gobgpServer, err := getGoBGPServer(s, cmdCtx)
-			if err != nil {
-				return nil, err
-			}
-
-			peer := &gobgpapi.Peer{
-				Conf: &gobgpapi.PeerConf{
-					NeighborAddress: args[0],
-				},
-				Transport: &gobgpapi.Transport{
-					PassiveMode: true,
-				},
-				GracefulRestart: &gobgpapi.GracefulRestart{
-					Enabled: true,
-				},
-			}
-			_, err = fmt.Sscanf(args[1], "%d", &peer.Conf.PeerAsn)
-			if err != nil {
-				return nil, fmt.Errorf("could not parse remote-asn: %w", err)
+			state, found := cmdCtx.servers[args[0]]
+			if !found {
+				return nil, fmt.Errorf("GoBGP Server with name: %s not found", args[0])
 			}
 
-			families, err := s.Flags.GetString(familiesFlag)
+			path := s.Path(args[1])
+			newConfig, err := gobgpconfig.ReadConfigFile(path, "")
 			if err != nil {
-				return nil, err
-			}
-			if families == "" {
-				return nil, fmt.Errorf("families have to be specified for the peer")
-			}
-			afiSafis := strings.SplitSeq(families, ",")
-			for afiSafi := range afiSafis {
-				afiSafiArr := strings.Split(afiSafi, "/")
-				if len(afiSafiArr) != 2 {
-					return nil, fmt.Errorf("invalid afi/safi format: %s", afiSafi)
-				}
-				peer.AfiSafis = append(peer.AfiSafis, &gobgpapi.AfiSafi{
-					Config: &gobgpapi.AfiSafiConfig{
-						Family: &gobgpapi.Family{
-							Afi:  gobgpapi.Family_Afi(types.ParseAfi(afiSafiArr[0])),
-							Safi: gobgpapi.Family_Safi(types.ParseSafi(afiSafiArr[1])),
-						},
-					},
-					AddPaths: &gobgpapi.AddPaths{
-						Config: &gobgpapi.AddPathsConfig{
-							Receive: true,
-						},
-					},
-				})
+				return nil, fmt.Errorf("could not read GoBGP config file %s: %w", args[1], err)
 			}
 
-			password, err := s.Flags.GetString(passwordFlag)
+			appliedConfig, err := gobgpconfig.UpdateConfig(s.Context(), state.server, state.config, newConfig)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("error reloading GoBGP server %s: %w", args[0], err)
 			}
-			if password != "" {
-				peer.Conf.AuthPassword = password
-			}
+			state.config = appliedConfig
 
-			err = gobgpServer.AddPeer(s.Context(), &gobgpapi.AddPeerRequest{Peer: peer})
-			if err != nil {
-				return nil, fmt.Errorf("error by adding peer to server: %w", err)
-			}
-			s.Logf("Added peer to GoBGP Server: %+v\n", peer)
+			s.Logf("Reloaded GoBGP Server %q\n", args[0])
+
 			return nil, nil
 		},
 	)

--- a/pkg/bgp/test/testdata/README.md
+++ b/pkg/bgp/test/testdata/README.md
@@ -16,10 +16,12 @@ and observing BGP state on Cilium (`bgp/*`).
 For creating and observing GoBGP instances that can be used to peer with Cilium, use the `gobgp/*` commands:
 
 ```
-gobgp/add-peer [-s] [--server-asn=uint32] ip remote-asn
-	Add a new peer the GoBGP server instance
-gobgp/add-server [-r] [--router-id=string] asn ip port
-	Add a new GoBGP server instance
+gobgp/add-server name config-file
+	Add a new GoBGP server instance from a native GoBGP configuration file
+gobgp/delete-server name
+	Delete an existing GoBGP server instance
+gobgp/reload-server name config-file
+	Reload the configuration of a running GoBGP server instance
 gobgp/peers [-os] [--out=string] [--server-asn=uint32]
 	List peers on the GoBGP server
 gobgp/routes [-os] [--out=string] [--server-asn=uint32] [afi] [safi]
@@ -27,6 +29,22 @@ gobgp/routes [-os] [--out=string] [--server-asn=uint32] [afi] [safi]
 gobgp/wait-state [-st] [--server-asn=uint32] [--timeout=duration] peer state
 	Wait until the GoBGP peer is in the specified state
 ```
+
+`gobgp/add-server` and `gobgp/reload-server` take a `config-file` argument: a
+path (resolved relative to the test's working directory, typically an embedded
+`-- name.toml --` txtar section) to a GoBGP configuration file in the same
+schema `gobgpd` itself reads (TOML is used in this directory's tests, matching
+upstream GoBGP's own documentation, but YAML/JSON are also supported and
+auto-detected from the file extension).
+
+`gobgp/add-server` applies the whole file the same way `gobgpd` applies its
+config file at startup (via GoBGP's own `InitialConfig`); `gobgp/reload-server`
+applies a new file to an already-running server the same way `gobgpd` reloads on
+`SIGHUP` (via GoBGP's own `UpdateConfig`), diffing it against the last-applied
+configuration and adding, removing or updating peers/policies to match. Global
+parameters cannot be changed by `reload-server` (GoBGP cannot rebind those on a
+running server) - use `gobgp/delete-server` followed by `gobgp/add-server`
+instead.
 
 **Important**: Each test should use unique peering IPs, as the tests are executed in parallel.
 These should be passed to the test infra via the `test-peering-ips` arg in the shebang at the beginning of the test,

--- a/pkg/bgp/test/testdata/commands.txtar
+++ b/pkg/bgp/test/testdata/commands.txtar
@@ -4,16 +4,10 @@
 hive start
 
 # Configure GoBGP servers
-gobgp/add-server server0 65000 fd00:10:99:7::1 1790 --router-id 10.99.7.1
-gobgp/add-server server1 65000 fd00:10:99:7::2 1790 --router-id 10.99.7.2
-gobgp/add-server server2 65001 fd00:10:99:7::3 1790 --router-id 10.99.7.3
-gobgp/add-server server3 65001 fd00:10:99:7::4 1790 --router-id 10.99.7.4
-
-# Configure peers on GoBGP
-gobgp/add-peer -s server0 fd00:10:99:7::5 65000
-gobgp/add-peer -s server1 fd00:10:99:7::5 65000
-gobgp/add-peer -s server2 fd00:10:99:7::6 65001
-gobgp/add-peer -s server3 fd00:10:99:7::6 65001
+gobgp/add-server server0 server0.toml
+gobgp/add-server server1 server1.toml
+gobgp/add-server server2 server2.toml
+gobgp/add-server server3 server3.toml
 
 # Advertise routes on GoBGP
 gobgp/advertise-route -s server0 10.0.0.0/24
@@ -72,6 +66,104 @@ bgp/routes in ipv4 unicast --no-age -o bgp-routes-in-ipv4-unicast.actual
 bgp/routes in ipv6 unicast --no-age -o bgp-routes-in-ipv6-unicast.actual
 * cmp bgp-routes-in-ipv6-unicast.expected bgp-routes-in-ipv6-unicast.actual
 
+# Delete all peers from server0 (to test reload-server)
+gobgp/reload-server server0 server0-no-peer.toml
+
+# No peer should be present on server0
+gobgp/peers -s server0 -o bgp-peers.actual
+* cmp no-peer.expected bgp-peers.actual
+
+-- server0.toml --
+[global.config]
+  as = 65000
+  router-id = "10.99.7.1"
+  local-address-list = ["fd00:10:99:7::1"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "fd00:10:99:7::5"
+    peer-as = 65000
+  [neighbors.transport.config]
+    passive-mode = true
+  [neighbors.graceful-restart.config]
+    enabled = true
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-unicast"
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv6-unicast"
+-- server0-no-peer.toml --
+[global.config]
+  as = 65000
+  router-id = "10.99.7.1"
+  local-address-list = ["fd00:10:99:7::1"]
+  port = 1790
+
+-- server1.toml --
+[global.config]
+  as = 65000
+  router-id = "10.99.7.2"
+  local-address-list = ["fd00:10:99:7::2"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "fd00:10:99:7::5"
+    peer-as = 65000
+  [neighbors.transport.config]
+    passive-mode = true
+  [neighbors.graceful-restart.config]
+    enabled = true
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-unicast"
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv6-unicast"
+-- server2.toml --
+[global.config]
+  as = 65001
+  router-id = "10.99.7.3"
+  local-address-list = ["fd00:10:99:7::3"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "fd00:10:99:7::6"
+    peer-as = 65001
+  [neighbors.transport.config]
+    passive-mode = true
+  [neighbors.graceful-restart.config]
+    enabled = true
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-unicast"
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv6-unicast"
+-- server3.toml --
+[global.config]
+  as = 65001
+  router-id = "10.99.7.4"
+  local-address-list = ["fd00:10:99:7::4"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "fd00:10:99:7::6"
+    peer-as = 65001
+  [neighbors.transport.config]
+    passive-mode = true
+  [neighbors.graceful-restart.config]
+    enabled = true
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-unicast"
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv6-unicast"
 -- cilium-node.yaml --
 apiVersion: cilium.io/v2
 kind: CiliumNode
@@ -219,9 +311,6 @@ Instance: instance0
       extended-message
       graceful-restart
       4-octet-as
-      add-path:
-        ipv4-unicast: receive
-        ipv6-unicast: receive
       fqdn:
         name: <redacted>
         domain: 
@@ -278,9 +367,6 @@ Instance: instance0
       extended-message
       graceful-restart
       4-octet-as
-      add-path:
-        ipv4-unicast: receive
-        ipv6-unicast: receive
       fqdn:
         name: <redacted>
         domain: 
@@ -338,9 +424,6 @@ Instance: instance1
       extended-message
       graceful-restart
       4-octet-as
-      add-path:
-        ipv4-unicast: receive
-        ipv6-unicast: receive
       fqdn:
         name: <redacted>
         domain: 
@@ -397,9 +480,6 @@ Instance: instance1
       extended-message
       graceful-restart
       4-octet-as
-      add-path:
-        ipv4-unicast: receive
-        ipv6-unicast: receive
       fqdn:
         name: <redacted>
         domain: 
@@ -449,3 +529,5 @@ instance0   peer0   fd00:10::/64     fd00:10:99:7::1   -
             peer1   fd00:10::/64     fd00:10:99:7::2   -
 instance1   peer0   fd00:10:1::/64   fd00:10:99:7::3   -
             peer1   fd00:10:2::/64   fd00:10:99:7::4   -
+-- no-peer.expected --
+PeerAddress   RouterID   PeerASN   SessionState   KeepAlive   HoldTime   GracefulRestartTime

--- a/pkg/bgp/test/testdata/interface.txtar
+++ b/pkg/bgp/test/testdata/interface.txtar
@@ -6,12 +6,8 @@
 hive start
 
 # Configure GoBGP servers
-gobgp/add-server v4-only   65010 10.99.5.1        1790
-gobgp/add-server dualstack 65010 fd00::aa:bb:55:1 1790 --router-id 1.0.0.1
-
-# Configure peers on GoBGP
-gobgp/add-peer -s v4-only   10.99.5.2        65001
-gobgp/add-peer -s dualstack fd00::aa:bb:55:2 65001
+gobgp/add-server v4-only   v4-only.toml
+gobgp/add-server dualstack dualstack.toml
 
 # Configure BGP on Cilium
 k8s/add cilium-node.yaml bgp-node-config.yaml bgp-peer-config-v4.yaml bgp-peer-config-dualstack.yaml bgp-advertisement.yaml
@@ -94,6 +90,41 @@ gobgp/routes -s dualstack -o routes.actual ipv6 unicast
 
 #####
 
+-- v4-only.toml --
+[global.config]
+  as = 65010
+  router-id = "10.99.5.1"
+  local-address-list = ["10.99.5.1"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "10.99.5.2"
+    peer-as = 65001
+  [neighbors.transport.config]
+    passive-mode = true
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-unicast"
+-- dualstack.toml --
+[global.config]
+  as = 65010
+  router-id = "1.0.0.1"
+  local-address-list = ["fd00::aa:bb:55:1"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "fd00::aa:bb:55:2"
+    peer-as = 65001
+  [neighbors.transport.config]
+    passive-mode = true
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-unicast"
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv6-unicast"
 -- cilium-node.yaml --
 apiVersion: cilium.io/v2
 kind: CiliumNode

--- a/pkg/bgp/test/testdata/multi-peer-advertisements.txtar
+++ b/pkg/bgp/test/testdata/multi-peer-advertisements.txtar
@@ -7,12 +7,8 @@
 hive start
 
 # Configure gobgp servers
-gobgp/add-server peer1 65010 10.99.7.101 1790
-gobgp/add-server peer2 65011 10.99.7.102 1790
-
-# Configure peers on GoBGP
-gobgp/add-peer -s peer1 10.99.7.110 65001
-gobgp/add-peer -s peer2 10.99.7.110 65001
+gobgp/add-server peer1 peer1.toml
+gobgp/add-server peer2 peer2.toml
 
 # Add a k8s service
 k8s/add service.yaml
@@ -69,6 +65,32 @@ gobgp/routes -s peer2 -o routes.actual
 
 #####
 
+-- peer1.toml --
+[global.config]
+  as = 65010
+  router-id = "10.99.7.101"
+  local-address-list = ["10.99.7.101"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "10.99.7.110"
+    peer-as = 65001
+  [neighbors.transport.config]
+    passive-mode = true
+-- peer2.toml --
+[global.config]
+  as = 65011
+  router-id = "10.99.7.102"
+  local-address-list = ["10.99.7.102"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "10.99.7.110"
+    peer-as = 65001
+  [neighbors.transport.config]
+    passive-mode = true
 -- cilium-node.yaml --
 apiVersion: cilium.io/v2
 kind: CiliumNode

--- a/pkg/bgp/test/testdata/peering-auth.txtar
+++ b/pkg/bgp/test/testdata/peering-auth.txtar
@@ -6,8 +6,7 @@
 hive start
 
 # Configure gobgp server
-gobgp/add-server test --router-id=1.2.3.4 65001 fd00::aa:bb:cc:101 1790
-gobgp/add-peer --password=Cilium123 fd00::aa:bb:cc:102 65001
+gobgp/add-server test gobgp-server.toml
 
 # Configure BGP on Cilium
 k8s/add cilium-node.yaml bgp-node-config.yaml bgp-peer-config.yaml bgp-advertisement.yaml auth-secret.yaml
@@ -29,6 +28,26 @@ gobgp/routes -o routes.actual ipv6 unicast
 
 #####
 
+-- gobgp-server.toml --
+[global.config]
+  as = 65001
+  router-id = "1.2.3.4"
+  local-address-list = ["fd00::aa:bb:cc:101"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "fd00::aa:bb:cc:102"
+    peer-as = 65001
+    auth-password = "Cilium123"
+  [neighbors.transport.config]
+    passive-mode = true
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-unicast"
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv6-unicast"
 -- cilium-node.yaml --
 apiVersion: cilium.io/v2
 kind: CiliumNode

--- a/pkg/bgp/test/testdata/peering-changes.txtar
+++ b/pkg/bgp/test/testdata/peering-changes.txtar
@@ -9,8 +9,7 @@ hive start
 k8s/add service-lb.yaml
 
 # Configure GoBGP server
-gobgp/add-server test 65010 10.99.0.121 1790
-gobgp/add-peer 10.99.0.130 65001
+gobgp/add-server test gobgp-server-1.toml
 
 # Configure BGP on Cilium
 k8s/add cilium-node.yaml bgp-advertisement.yaml
@@ -29,8 +28,7 @@ gobgp/routes -o routes.actual
 
 # Re-configure GoBGP server with the new IP
 gobgp/delete-server test
-gobgp/add-server test 65010 10.99.0.122 1790
-gobgp/add-peer 10.99.0.130 65001
+gobgp/add-server test gobgp-server-2.toml
 
 # Update peer IP
 k8s/update bgp-node-config-2.yaml
@@ -61,6 +59,36 @@ gobgp/peers -o peers.actual
 
 #####
 
+-- gobgp-server-1.toml --
+[global.config]
+  as = 65010
+  router-id = "10.99.0.121"
+  local-address-list = ["10.99.0.121"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "10.99.0.130"
+    peer-as = 65001
+  [neighbors.transport.config]
+    passive-mode = true
+  [neighbors.graceful-restart.config]
+    enabled = true
+-- gobgp-server-2.toml --
+[global.config]
+  as = 65010
+  router-id = "10.99.0.122"
+  local-address-list = ["10.99.0.122"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "10.99.0.130"
+    peer-as = 65001
+  [neighbors.transport.config]
+    passive-mode = true
+  [neighbors.graceful-restart.config]
+    enabled = true
 -- cilium-node.yaml --
 apiVersion: cilium.io/v2
 kind: CiliumNode

--- a/pkg/bgp/test/testdata/peering-default-gateway.txtar
+++ b/pkg/bgp/test/testdata/peering-default-gateway.txtar
@@ -6,12 +6,10 @@
 hive start
 
 # Configure v4 GoBGP server
-gobgp/add-server v4 65010 10.99.0.135 1790
-gobgp/add-peer -s v4 10.99.0.136 65001
+gobgp/add-server v4 v4.toml
 
 # Configure v6 GoBGP server
-gobgp/add-server v6 --router-id=1.2.3.4 65011 fd00::aa:bb:cc:135 1790
-gobgp/add-peer -s v6 fd00::aa:bb:cc:136 65001
+gobgp/add-server v6 v6.toml
 
 # Configure BGP on Cilium
 k8s/add cilium-node.yaml bgp-advertisement.yaml
@@ -48,6 +46,35 @@ gobgp/routes -s v6 -o routes.actual
 
 #####
 
+-- v4.toml --
+[global.config]
+  as = 65010
+  router-id = "10.99.0.135"
+  local-address-list = ["10.99.0.135"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "10.99.0.136"
+    peer-as = 65001
+  [neighbors.transport.config]
+    passive-mode = true
+-- v6.toml --
+[global.config]
+  as = 65011
+  router-id = "1.2.3.4"
+  local-address-list = ["fd00::aa:bb:cc:135"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "fd00::aa:bb:cc:136"
+    peer-as = 65001
+  [neighbors.transport.config]
+    passive-mode = true
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-unicast"
 -- devices.yaml --
 index: 1
 name: test1

--- a/pkg/bgp/test/testdata/peering-ipv6.txtar
+++ b/pkg/bgp/test/testdata/peering-ipv6.txtar
@@ -6,8 +6,7 @@
 hive start
 
 # Configure gobgp server
-gobgp/add-server test --router-id=1.2.3.4 65001 fd00::aa:bb:cc:111 1790
-gobgp/add-peer fd00::aa:bb:cc:112 65001 --families=ipv6/unicast
+gobgp/add-server test gobgp-server.toml
 
 # Configure BGP on Cilium
 k8s/add cilium-node.yaml bgp-node-config.yaml bgp-peer-config.yaml bgp-advertisement.yaml
@@ -25,6 +24,22 @@ gobgp/routes -o routes.actual ipv6 unicast
 
 #####
 
+-- gobgp-server.toml --
+[global.config]
+  as = 65001
+  router-id = "1.2.3.4"
+  local-address-list = ["fd00::aa:bb:cc:111"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "fd00::aa:bb:cc:112"
+    peer-as = 65001
+  [neighbors.transport.config]
+    passive-mode = true
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv6-unicast"
 -- cilium-node.yaml --
 apiVersion: cilium.io/v2
 kind: CiliumNode

--- a/pkg/bgp/test/testdata/peering-multi-instance.txtar
+++ b/pkg/bgp/test/testdata/peering-multi-instance.txtar
@@ -6,14 +6,9 @@
 hive start
 
 # Configure gobgp servers
-gobgp/add-server test0 65010 10.99.0.101 1790
-gobgp/add-server test1 65011 10.99.0.102 1790
-gobgp/add-server test2 65012 10.99.0.103 1790
-
-# Configure peers on GoBGP
-gobgp/add-peer -s test0 10.99.0.110 65001
-gobgp/add-peer -s test1 10.99.0.110 65001
-gobgp/add-peer -s test2 10.99.0.110 65002
+gobgp/add-server test0 test0.toml
+gobgp/add-server test1 test1.toml
+gobgp/add-server test2 test2.toml
 
 # Configure BGP on Cilium - only first peer
 k8s/add cilium-node.yaml bgp-peer-config.yaml bgp-advertisement.yaml
@@ -95,6 +90,51 @@ gobgp/routes -s test0 -o routes.actual
 
 #####
 
+-- test0.toml --
+[global.config]
+  as = 65010
+  router-id = "10.99.0.101"
+  local-address-list = ["10.99.0.101"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "10.99.0.110"
+    peer-as = 65001
+  [neighbors.transport.config]
+    passive-mode = true
+  [neighbors.graceful-restart.config]
+    enabled = true
+-- test1.toml --
+[global.config]
+  as = 65011
+  router-id = "10.99.0.102"
+  local-address-list = ["10.99.0.102"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "10.99.0.110"
+    peer-as = 65001
+  [neighbors.transport.config]
+    passive-mode = true
+  [neighbors.graceful-restart.config]
+    enabled = true
+-- test2.toml --
+[global.config]
+  as = 65012
+  router-id = "10.99.0.103"
+  local-address-list = ["10.99.0.103"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "10.99.0.110"
+    peer-as = 65002
+  [neighbors.transport.config]
+    passive-mode = true
+  [neighbors.graceful-restart.config]
+    enabled = true
 -- cilium-node.yaml --
 apiVersion: cilium.io/v2
 kind: CiliumNode

--- a/pkg/bgp/test/testdata/pod-cidr.txtar
+++ b/pkg/bgp/test/testdata/pod-cidr.txtar
@@ -6,8 +6,7 @@
 hive start
 
 # Configure gobgp server
-gobgp/add-server test --router-id=1.2.3.4 65001 fd00::aa:bb:dd:101 1790
-gobgp/add-peer fd00::aa:bb:dd:102 65001
+gobgp/add-server test gobgp-server.toml
 
 # Configure BGP on Cilium
 k8s/add cilium-node.yaml bgp-node-config.yaml bgp-peer-config.yaml
@@ -54,6 +53,25 @@ gobgp/routes -o routes.actual ipv6 unicast
 
 #####
 
+-- gobgp-server.toml --
+[global.config]
+  as = 65001
+  router-id = "1.2.3.4"
+  local-address-list = ["fd00::aa:bb:dd:101"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "fd00::aa:bb:dd:102"
+    peer-as = 65001
+  [neighbors.transport.config]
+    passive-mode = true
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-unicast"
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv6-unicast"
 -- cilium-node.yaml --
 apiVersion: cilium.io/v2
 kind: CiliumNode

--- a/pkg/bgp/test/testdata/pod-ip-pool.txtar
+++ b/pkg/bgp/test/testdata/pod-ip-pool.txtar
@@ -6,8 +6,7 @@
 hive start
 
 # Configure GoBGP server
-gobgp/add-server test --router-id=10.99.2.1 65010 fd00::99:2:1 1790
-gobgp/add-peer fd00::99:2:2 65001
+gobgp/add-server test gobgp-server.toml
 
 # Configure BGP on Cilium
 k8s/add bgp-node-config.yaml bgp-peer-config.yaml
@@ -68,6 +67,25 @@ gobgp/routes -o routes.actual ipv6 unicast
 
 #####
 
+-- gobgp-server.toml --
+[global.config]
+  as = 65010
+  router-id = "10.99.2.1"
+  local-address-list = ["fd00::99:2:1"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "fd00::99:2:2"
+    peer-as = 65001
+  [neighbors.transport.config]
+    passive-mode = true
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-unicast"
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv6-unicast"
 -- cilium-node-partial.yaml --
 apiVersion: cilium.io/v2
 kind: CiliumNode

--- a/pkg/bgp/test/testdata/svc-adverts.txtar
+++ b/pkg/bgp/test/testdata/svc-adverts.txtar
@@ -7,12 +7,8 @@
 hive start
 
 # Configure gobgp server
-gobgp/add-server test0 --router-id=1.2.3.4 65010 fd00::bb:cc:dd:1 1790
-gobgp/add-server test1 --router-id=5.6.7.8 65011 fd00::bb:cc:dd:2 1790
-
-# Configure peers on GoBGP
-gobgp/add-peer -s test0 fd00::bb:cc:dd:10 65001
-gobgp/add-peer -s test1 fd00::bb:cc:dd:10 65001
+gobgp/add-server test0 test0.toml
+gobgp/add-server test1 test1.toml
 
 # Configure BGP on Cilium
 k8s/add cilium-node.yaml bgp-node-config.yaml
@@ -98,6 +94,44 @@ gobgp/routes -s test1 -o routes.actual ipv6 unicast
 
 #####
 
+-- test0.toml --
+[global.config]
+  as = 65010
+  router-id = "1.2.3.4"
+  local-address-list = ["fd00::bb:cc:dd:1"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "fd00::bb:cc:dd:10"
+    peer-as = 65001
+  [neighbors.transport.config]
+    passive-mode = true
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-unicast"
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv6-unicast"
+-- test1.toml --
+[global.config]
+  as = 65011
+  router-id = "5.6.7.8"
+  local-address-list = ["fd00::bb:cc:dd:2"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "fd00::bb:cc:dd:10"
+    peer-as = 65001
+  [neighbors.transport.config]
+    passive-mode = true
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-unicast"
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv6-unicast"
 -- cilium-node.yaml --
 apiVersion: cilium.io/v2
 kind: CiliumNode

--- a/pkg/bgp/test/testdata/svc-aggregation-priority.txtar
+++ b/pkg/bgp/test/testdata/svc-aggregation-priority.txtar
@@ -11,8 +11,7 @@ hive start
 k8s/add service-exact-and-aggregate.yaml service-aggregate-only.yaml
 
 # Configure an iBGP server so local preference is advertised
-gobgp/add-server test --router-id=10.99.4.221 65001 fd00::99:4:221 1790
-gobgp/add-peer fd00::99:4:222 65001
+gobgp/add-server test gobgp-server.toml
 
 # Configure BGP on Cilium
 k8s/add cilium-node.yaml bgp-node-config.yaml bgp-peer-config.yaml bgp-advertisement.yaml
@@ -36,6 +35,22 @@ gobgp/routes -o routes.actual ipv4 unicast
 
 #####
 
+-- gobgp-server.toml --
+[global.config]
+  as = 65001
+  router-id = "10.99.4.221"
+  local-address-list = ["fd00::99:4:221"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "fd00::99:4:222"
+    peer-as = 65001
+  [neighbors.transport.config]
+    passive-mode = true
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-unicast"
 -- cilium-node.yaml --
 apiVersion: cilium.io/v2
 kind: CiliumNode

--- a/pkg/bgp/test/testdata/svc-aggregation.txtar
+++ b/pkg/bgp/test/testdata/svc-aggregation.txtar
@@ -7,10 +7,7 @@
 hive start
 
 # Configure gobgp server
-gobgp/add-server test --router-id=10.99.4.211 65010 fd00::99:4:211 1790
-
-# Configure peers on GoBGP
-gobgp/add-peer fd00::99:4:212 65001
+gobgp/add-server test gobgp-server.toml
 
 # Add k8s services and endpoints
 k8s/add service-1.yaml service-2.yaml service-3.yaml endpoints-ipv4.yaml endpoints-ipv6.yaml
@@ -53,6 +50,25 @@ gobgp/routes -o routes.actual ipv6 unicast
 
 #####
 
+-- gobgp-server.toml --
+[global.config]
+  as = 65010
+  router-id = "10.99.4.211"
+  local-address-list = ["fd00::99:4:211"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "fd00::99:4:212"
+    peer-as = 65001
+  [neighbors.transport.config]
+    passive-mode = true
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-unicast"
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv6-unicast"
 -- cilium-node.yaml --
 apiVersion: cilium.io/v2
 kind: CiliumNode

--- a/pkg/bgp/test/testdata/svc-gateway-proxy-redirect.txtar
+++ b/pkg/bgp/test/testdata/svc-gateway-proxy-redirect.txtar
@@ -12,10 +12,7 @@
 hive start
 
 # Configure gobgp server
-gobgp/add-server test 65010 10.99.5.101 1790
-
-# Configure peers on GoBGP
-gobgp/add-peer 10.99.5.102 65001
+gobgp/add-server test gobgp-server.toml
 
 # Add Gateway service (without endpoints)
 k8s/add service-gateway.yaml
@@ -37,6 +34,22 @@ gobgp/routes -o routes.actual
 
 #####
 
+-- gobgp-server.toml --
+[global.config]
+  as = 65010
+  router-id = "10.99.5.101"
+  local-address-list = ["10.99.5.101"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "10.99.5.102"
+    peer-as = 65001
+  [neighbors.transport.config]
+    passive-mode = true
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-unicast"
 -- cilium-node.yaml --
 apiVersion: cilium.io/v2
 kind: CiliumNode

--- a/pkg/bgp/test/testdata/svc-kpr-disabled.txtar
+++ b/pkg/bgp/test/testdata/svc-kpr-disabled.txtar
@@ -6,10 +6,7 @@
 hive start
 
 # Configure gobgp server
-gobgp/add-server test 65010 10.99.6.101 1790
-
-# Configure peers on GoBGP
-gobgp/add-peer 10.99.6.102 65001
+gobgp/add-server test gobgp-server.toml
 
 # Add k8s services (LB service with eTP=Local)
 k8s/add service-clusterip.yaml service-lb-local.yaml
@@ -43,6 +40,19 @@ gobgp/routes -o routes.actual
 
 #####
 
+-- gobgp-server.toml --
+[global.config]
+  as = 65010
+  router-id = "10.99.6.101"
+  local-address-list = ["10.99.6.101"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "10.99.6.102"
+    peer-as = 65001
+  [neighbors.transport.config]
+    passive-mode = true
 -- cilium-node.yaml --
 apiVersion: cilium.io/v2
 kind: CiliumNode

--- a/pkg/bgp/test/testdata/svc-modifications.txtar
+++ b/pkg/bgp/test/testdata/svc-modifications.txtar
@@ -6,10 +6,7 @@
 hive start
 
 # Configure gobgp server
-gobgp/add-server test 65010 10.99.4.251 1790
-
-# Configure peers on GoBGP
-gobgp/add-peer 10.99.4.252 65001
+gobgp/add-server test gobgp-server.toml
 
 # Configure BGP on Cilium
 k8s/add cilium-node.yaml bgp-node-config.yaml bgp-peer-config.yaml bgp-advertisement.yaml
@@ -55,6 +52,22 @@ gobgp/routes -o routes.actual
 
 #####
 
+-- gobgp-server.toml --
+[global.config]
+  as = 65010
+  router-id = "10.99.4.251"
+  local-address-list = ["10.99.4.251"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "10.99.4.252"
+    peer-as = 65001
+  [neighbors.transport.config]
+    passive-mode = true
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-unicast"
 -- cilium-node.yaml --
 apiVersion: cilium.io/v2
 kind: CiliumNode

--- a/pkg/bgp/test/testdata/svc-no-endpoints.txtar
+++ b/pkg/bgp/test/testdata/svc-no-endpoints.txtar
@@ -7,10 +7,7 @@
 hive start
 
 # Configure gobgp server
-gobgp/add-server test 65010 10.99.4.111 1790
-
-# Configure peers on GoBGP
-gobgp/add-peer 10.99.4.112 65001
+gobgp/add-server test gobgp-server.toml
 
 # Add a k8s service
 k8s/add service.yaml
@@ -42,6 +39,22 @@ gobgp/routes -o routes.actual
 
 #####
 
+-- gobgp-server.toml --
+[global.config]
+  as = 65010
+  router-id = "10.99.4.111"
+  local-address-list = ["10.99.4.111"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "10.99.4.112"
+    peer-as = 65001
+  [neighbors.transport.config]
+    passive-mode = true
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-unicast"
 -- cilium-node.yaml --
 apiVersion: cilium.io/v2
 kind: CiliumNode

--- a/pkg/bgp/test/testdata/svc-path-attributes.txtar
+++ b/pkg/bgp/test/testdata/svc-path-attributes.txtar
@@ -8,8 +8,7 @@
 hive start
 
 # Configure gobgp server
-gobgp/add-server test --router-id=1.2.3.4 65001 fd00::bb:cc:dd:101 1790
-gobgp/add-peer fd00::bb:cc:dd:102 65001
+gobgp/add-server test gobgp-server.toml
 
 # Configure BGP on Cilium
 k8s/add cilium-node.yaml bgp-node-config.yaml bgp-peer-config.yaml
@@ -59,6 +58,25 @@ gobgp/routes -o routes.actual ipv6 unicast
 
 #####
 
+-- gobgp-server.toml --
+[global.config]
+  as = 65001
+  router-id = "1.2.3.4"
+  local-address-list = ["fd00::bb:cc:dd:101"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "fd00::bb:cc:dd:102"
+    peer-as = 65001
+  [neighbors.transport.config]
+    passive-mode = true
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-unicast"
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv6-unicast"
 -- cilium-node.yaml --
 apiVersion: cilium.io/v2
 kind: CiliumNode

--- a/pkg/bgp/test/testdata/svc-sharing.txtar
+++ b/pkg/bgp/test/testdata/svc-sharing.txtar
@@ -7,10 +7,7 @@
 hive start
 
 # Configure gobgp server
-gobgp/add-server test 65010 10.99.4.201 1790
-
-# Configure peers on GoBGP
-gobgp/add-peer 10.99.4.202 65001
+gobgp/add-server test gobgp-server.toml
 
 # Add k8s services
 k8s/add service-1.yaml service-2.yaml
@@ -42,6 +39,22 @@ gobgp/routes -o routes.actual
 
 #####
 
+-- gobgp-server.toml --
+[global.config]
+  as = 65010
+  router-id = "10.99.4.201"
+  local-address-list = ["10.99.4.201"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "10.99.4.202"
+    peer-as = 65001
+  [neighbors.transport.config]
+    passive-mode = true
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-unicast"
 -- cilium-node.yaml --
 apiVersion: cilium.io/v2
 kind: CiliumNode

--- a/pkg/bgp/test/testdata/svc-traffic-policy.txtar
+++ b/pkg/bgp/test/testdata/svc-traffic-policy.txtar
@@ -7,10 +7,7 @@
 hive start
 
 # Configure gobgp server
-gobgp/add-server test 65010 10.99.4.101 1790
-
-# Configure peers on GoBGP
-gobgp/add-peer 10.99.4.102 65001
+gobgp/add-server test gobgp-server.toml
 
 # Add k8s services
 k8s/add service-lb.yaml service-cluster.yaml
@@ -55,6 +52,22 @@ gobgp/routes -o routes.actual
 
 #####
 
+-- gobgp-server.toml --
+[global.config]
+  as = 65010
+  router-id = "10.99.4.101"
+  local-address-list = ["10.99.4.101"]
+  port = 1790
+
+[[neighbors]]
+  [neighbors.config]
+    neighbor-address = "10.99.4.102"
+    peer-as = 65001
+  [neighbors.transport.config]
+    passive-mode = true
+  [[neighbors.afi-safis]]
+    [neighbors.afi-safis.config]
+      afi-safi-name = "ipv4-unicast"
 -- cilium-node.yaml --
 apiVersion: cilium.io/v2
 kind: CiliumNode

--- a/vendor/github.com/osrg/gobgp/v4/pkg/config/config.go
+++ b/vendor/github.com/osrg/gobgp/v4/pkg/config/config.go
@@ -1,0 +1,451 @@
+package config
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/osrg/gobgp/v4/api"
+	"github.com/osrg/gobgp/v4/internal/pkg/table"
+	"github.com/osrg/gobgp/v4/pkg/apiutil"
+	"github.com/osrg/gobgp/v4/pkg/config/oc"
+	"github.com/osrg/gobgp/v4/pkg/packet/bgp"
+	"github.com/osrg/gobgp/v4/pkg/server"
+)
+
+// ReadConfigFile parses a config file into a BgpConfigSet which can be applied
+// using InitialConfig and UpdateConfig.
+func ReadConfigFile(configFile, configType string) (*oc.BgpConfigSet, error) {
+	return oc.ReadConfigfile(configFile, configType)
+}
+
+// WatchConfigFile calls the callback function anytime an update to the
+// config file is detected.
+func WatchConfigFile(configFile, configType string, callBack func()) {
+	oc.WatchConfigFile(configFile, configType, callBack)
+}
+
+func marshalRouteTargets(l []string) ([]*api.RouteTarget, error) {
+	rtList := make([]*api.RouteTarget, 0, len(l))
+	for _, rtString := range l {
+		rt, err := bgp.ParseRouteTarget(rtString)
+		if err != nil {
+			return nil, err
+		}
+		a, err := apiutil.MarshalRT(rt)
+		if err != nil {
+			return nil, err
+		}
+		rtList = append(rtList, a)
+	}
+	return rtList, nil
+}
+
+func assignGlobalpolicy(ctx context.Context, bgpServer *server.BgpServer, a *oc.ApplyPolicyConfig) {
+	toDefaultTable := func(r oc.DefaultPolicyType) table.RouteType {
+		var def table.RouteType
+		switch r {
+		case oc.DEFAULT_POLICY_TYPE_ACCEPT_ROUTE:
+			def = table.ROUTE_TYPE_ACCEPT
+		case oc.DEFAULT_POLICY_TYPE_REJECT_ROUTE:
+			def = table.ROUTE_TYPE_REJECT
+		}
+		return def
+	}
+	toPolicies := func(r []string) []*table.Policy {
+		p := make([]*table.Policy, 0, len(r))
+		for _, n := range r {
+			p = append(p, &table.Policy{
+				Name: n,
+			})
+		}
+		return p
+	}
+
+	def := toDefaultTable(a.DefaultImportPolicy)
+	ps := toPolicies(a.ImportPolicyList)
+	err := bgpServer.SetPolicyAssignment(ctx, &api.SetPolicyAssignmentRequest{
+		Assignment: table.NewAPIPolicyAssignmentFromTableStruct(&table.PolicyAssignment{
+			Name:     table.GLOBAL_RIB_NAME,
+			Type:     table.POLICY_DIRECTION_IMPORT,
+			Policies: ps,
+			Default:  def,
+		}),
+	})
+	if err != nil {
+		bgpServer.Log().Error("failed to set policy assignment",
+			slog.String("Topic", "config"),
+			slog.String("Direction", table.POLICY_DIRECTION_IMPORT.String()),
+			slog.Any("Error", err),
+		)
+	}
+
+	def = toDefaultTable(a.DefaultExportPolicy)
+	ps = toPolicies(a.ExportPolicyList)
+	err = bgpServer.SetPolicyAssignment(ctx, &api.SetPolicyAssignmentRequest{
+		Assignment: table.NewAPIPolicyAssignmentFromTableStruct(&table.PolicyAssignment{
+			Name:     table.GLOBAL_RIB_NAME,
+			Type:     table.POLICY_DIRECTION_EXPORT,
+			Policies: ps,
+			Default:  def,
+		}),
+	})
+	if err != nil {
+		bgpServer.Log().Warn("failed to set policy assignment",
+			slog.String("Topic", "config"),
+			slog.String("Direction", table.POLICY_DIRECTION_EXPORT.String()),
+			slog.Any("Error", err),
+		)
+	}
+}
+
+func addPeerGroups(ctx context.Context, bgpServer *server.BgpServer, addedPg []oc.PeerGroup) {
+	for _, pg := range addedPg {
+		bgpServer.Log().Info("Add PeerGroup",
+			slog.String("Topic", "config"),
+			slog.String("Key", pg.Config.PeerGroupName),
+		)
+
+		if err := bgpServer.AddPeerGroup(ctx, &api.AddPeerGroupRequest{
+			PeerGroup: oc.NewPeerGroupFromConfigStruct(&pg),
+		}); err != nil {
+			bgpServer.Log().Error("Failed to add PeerGroup",
+				slog.String("Topic", "config"),
+				slog.String("Key", pg.Config.PeerGroupName),
+				slog.Any("Error", err))
+		}
+	}
+}
+
+func deletePeerGroups(ctx context.Context, bgpServer *server.BgpServer, deletedPg []oc.PeerGroup) {
+	for _, pg := range deletedPg {
+		bgpServer.Log().Info("delete PeerGroup",
+			slog.String("Topic", "config"),
+			slog.String("Key", pg.Config.PeerGroupName),
+		)
+		if err := bgpServer.DeletePeerGroup(ctx, &api.DeletePeerGroupRequest{
+			Name: pg.Config.PeerGroupName,
+		}); err != nil {
+			bgpServer.Log().Error("Failed to delete PeerGroup",
+				slog.String("Topic", "config"),
+				slog.String("Key", pg.Config.PeerGroupName),
+				slog.Any("Error", err),
+			)
+		}
+	}
+}
+
+func updatePeerGroups(ctx context.Context, bgpServer *server.BgpServer, updatedPg []oc.PeerGroup) bool {
+	for _, pg := range updatedPg {
+		bgpServer.Log().Info("update PeerGroup",
+			slog.String("Topic", "config"),
+			slog.String("Key", pg.Config.PeerGroupName),
+		)
+		if u, err := bgpServer.UpdatePeerGroup(ctx, &api.UpdatePeerGroupRequest{
+			PeerGroup: oc.NewPeerGroupFromConfigStruct(&pg),
+		}); err != nil {
+			bgpServer.Log().Error("Failed to update PeerGroup",
+				slog.String("Topic", "config"),
+				slog.String("Key", pg.Config.PeerGroupName),
+				slog.Any("Error", err),
+			)
+		} else {
+			return u.NeedsSoftResetIn
+		}
+	}
+	return false
+}
+
+func addDynamicNeighbors(ctx context.Context, bgpServer *server.BgpServer, dynamicNeighbors []oc.DynamicNeighbor) {
+	for _, dn := range dynamicNeighbors {
+		bgpServer.Log().Info("Add Dynamic Neighbor to PeerGroup",
+			slog.String("Topic", "config"),
+			slog.String("Key", dn.Config.PeerGroup),
+			slog.String("Prefix", dn.Config.Prefix.String()),
+		)
+		if err := bgpServer.AddDynamicNeighbor(ctx, &api.AddDynamicNeighborRequest{
+			DynamicNeighbor: &api.DynamicNeighbor{
+				Prefix:    dn.Config.Prefix.String(),
+				PeerGroup: dn.Config.PeerGroup,
+			},
+		}); err != nil {
+			bgpServer.Log().Error("Failed to add Dynamic Neighbor to PeerGroup",
+				slog.String("Topic", "config"),
+				slog.String("Key", dn.Config.PeerGroup),
+				slog.String("Prefix", dn.Config.Prefix.String()),
+				slog.Any("Error", err),
+			)
+		}
+	}
+}
+
+func addNeighbors(ctx context.Context, bgpServer *server.BgpServer, added []oc.Neighbor) {
+	for _, p := range added {
+		bgpServer.Log().Info("Add Peer",
+			slog.String("Topic", "config"),
+			slog.String("Key", p.State.NeighborAddress.String()),
+		)
+		if err := bgpServer.AddPeer(ctx, &api.AddPeerRequest{
+			Peer: oc.NewPeerFromConfigStruct(&p),
+		}); err != nil {
+			bgpServer.Log().Error("Failed to add Peer",
+				slog.String("Topic", "config"),
+				slog.String("Key", p.State.NeighborAddress.String()),
+				slog.Any("Error", err))
+		}
+	}
+}
+
+func deleteNeighbors(ctx context.Context, bgpServer *server.BgpServer, deleted []oc.Neighbor) {
+	for _, p := range deleted {
+		bgpServer.Log().Info("Delete Peer",
+			slog.String("Topic", "config"),
+			slog.String("Key", p.State.NeighborAddress.String()),
+		)
+		if err := bgpServer.DeletePeer(ctx, &api.DeletePeerRequest{
+			Address: p.State.NeighborAddress.String(),
+		}); err != nil {
+			bgpServer.Log().Error("Failed to delete Peer",
+				slog.String("Topic", "config"),
+				slog.String("Key", p.State.NeighborAddress.String()),
+				slog.Any("Error", err),
+			)
+		}
+	}
+}
+
+func updateNeighbors(ctx context.Context, bgpServer *server.BgpServer, updated []oc.Neighbor) bool {
+	for _, p := range updated {
+		bgpServer.Log().Info("Update Peer",
+			slog.String("Topic", "config"), slog.String("Key", p.State.NeighborAddress.String()))
+		if u, err := bgpServer.UpdatePeer(ctx, &api.UpdatePeerRequest{
+			Peer: oc.NewPeerFromConfigStruct(&p),
+		}); err != nil {
+			bgpServer.Log().Error("Failed to update Peer",
+				slog.String("Topic", "config"),
+				slog.String("Key", p.State.NeighborAddress.String()),
+				slog.Any("Error", err),
+			)
+		} else {
+			return u.NeedsSoftResetIn
+		}
+	}
+	return false
+}
+
+// InitialConfig applies initial configuration to a pristine gobgp instance. It
+// can only be called once for an instance. Subsequent changes to the
+// configuration can be applied using UpdateConfig. The BgpConfigSet can be
+// obtained by calling ReadConfigFile. If graceful restart behavior is desired,
+// pass true for isGracefulRestart. Otherwise, pass false.
+func InitialConfig(ctx context.Context, bgpServer *server.BgpServer, newConfig *oc.BgpConfigSet, isGracefulRestart bool) (*oc.BgpConfigSet, error) {
+	if err := bgpServer.StartBgp(ctx, &api.StartBgpRequest{
+		Global: oc.NewGlobalFromConfigStruct(&newConfig.Global),
+	}); err != nil {
+		return nil, err
+	}
+
+	if newConfig.Zebra.Config.Enabled {
+		tps := newConfig.Zebra.Config.RedistributeRouteTypeList
+		l := make([]string, 0, len(tps))
+		l = append(l, tps...)
+		if err := bgpServer.EnableZebra(ctx, &api.EnableZebraRequest{
+			Url:                  newConfig.Zebra.Config.Url,
+			RouteTypes:           l,
+			Version:              uint32(newConfig.Zebra.Config.Version),
+			NexthopTriggerEnable: newConfig.Zebra.Config.NexthopTriggerEnable,
+			NexthopTriggerDelay:  uint32(newConfig.Zebra.Config.NexthopTriggerDelay),
+			MplsLabelRangeSize:   newConfig.Zebra.Config.MplsLabelRangeSize,
+			SoftwareName:         newConfig.Zebra.Config.SoftwareName,
+		}); err != nil {
+			bgpServer.Log().Error("failed to set zebra config",
+				slog.String("Topic", "config"), slog.Any("Error", err))
+		}
+	}
+
+	if len(newConfig.Collector.Config.Url) > 0 {
+		bgpServer.Log().Error("collector feature is not supported",
+			slog.String("Topic", "config"))
+	}
+
+	for _, c := range newConfig.RpkiServers {
+		if err := bgpServer.AddRpki(ctx, &api.AddRpkiRequest{
+			Address:  c.Config.Address.String(),
+			Port:     c.Config.Port,
+			Lifetime: c.Config.RecordLifetime,
+		}); err != nil {
+			bgpServer.Log().Error("failed to set rpki config",
+				slog.String("Topic", "config"), slog.Any("Error", err))
+		}
+	}
+	f := func(t oc.BmpRouteMonitoringPolicyType) api.AddBmpRequest_MonitoringPolicy {
+		switch t {
+		case oc.BMP_ROUTE_MONITORING_POLICY_TYPE_PRE_POLICY:
+			return api.AddBmpRequest_MONITORING_POLICY_PRE
+		case oc.BMP_ROUTE_MONITORING_POLICY_TYPE_POST_POLICY:
+			return api.AddBmpRequest_MONITORING_POLICY_POST
+		case oc.BMP_ROUTE_MONITORING_POLICY_TYPE_BOTH:
+			return api.AddBmpRequest_MONITORING_POLICY_BOTH
+		case oc.BMP_ROUTE_MONITORING_POLICY_TYPE_LOCAL_RIB:
+			return api.AddBmpRequest_MONITORING_POLICY_LOCAL
+		case oc.BMP_ROUTE_MONITORING_POLICY_TYPE_ALL:
+			return api.AddBmpRequest_MONITORING_POLICY_ALL
+		}
+		return api.AddBmpRequest_MONITORING_POLICY_UNSPECIFIED
+	}
+
+	for _, c := range newConfig.BmpServers {
+		if err := bgpServer.AddBmp(ctx, &api.AddBmpRequest{
+			Address:           c.Config.Address.String(),
+			Port:              c.Config.Port,
+			SysName:           c.Config.SysName,
+			SysDescr:          c.Config.SysDescr,
+			Policy:            f(c.Config.RouteMonitoringPolicy),
+			StatisticsTimeout: int32(c.Config.StatisticsTimeout),
+		}); err != nil {
+			bgpServer.Log().Error("failed to set bmp config",
+				slog.String("Topic", "config"), slog.Any("Error", err))
+		}
+	}
+	for _, vrf := range newConfig.Vrfs {
+		rd, err := bgp.ParseRouteDistinguisher(vrf.Config.Rd)
+		if err != nil {
+			bgpServer.Log().Error("failed to load vrf rd config",
+				slog.String("Topic", "config"), slog.Any("Error", err))
+		}
+
+		importRtList, err := marshalRouteTargets(vrf.Config.ImportRtList)
+		if err != nil {
+			bgpServer.Log().Error("failed to load vrf import rt config",
+				slog.String("Topic", "config"), slog.Any("Error", err))
+		}
+		exportRtList, err := marshalRouteTargets(vrf.Config.ExportRtList)
+		if err != nil {
+			bgpServer.Log().Error("failed to load vrf export rt config",
+				slog.String("Topic", "config"), slog.Any("Error", err))
+		}
+
+		a, err := apiutil.MarshalRD(rd)
+		if err != nil {
+			bgpServer.Log().Error("failed to set vrf config",
+				slog.String("Topic", "config"), slog.Any("Error", err))
+		}
+		if err := bgpServer.AddVrf(ctx, &api.AddVrfRequest{
+			Vrf: &api.Vrf{
+				Name:     vrf.Config.Name,
+				Rd:       a,
+				Id:       vrf.Config.Id,
+				ImportRt: importRtList,
+				ExportRt: exportRtList,
+			},
+		}); err != nil {
+			bgpServer.Log().Error("failed to set vrf config", slog.String("Topic", "config"), slog.Any("Error", err))
+		}
+	}
+	for _, c := range newConfig.MrtDump {
+		if len(c.Config.FileName) == 0 {
+			continue
+		}
+
+		dump_type := api.EnableMrtRequest_DUMP_TYPE_UNSPECIFIED
+		switch c.Config.DumpType {
+		case oc.MRT_TYPE_UPDATES:
+			dump_type = api.EnableMrtRequest_DUMP_TYPE_UPDATES
+		case oc.MRT_TYPE_TABLE:
+			dump_type = api.EnableMrtRequest_DUMP_TYPE_TABLE
+		}
+
+		if err := bgpServer.EnableMrt(ctx, &api.EnableMrtRequest{
+			DumpType:         dump_type,
+			Filename:         c.Config.FileName,
+			DumpInterval:     c.Config.DumpInterval,
+			RotationInterval: c.Config.RotationInterval,
+		}); err != nil {
+			bgpServer.Log().Error("failed to set mrt config",
+				slog.String("Topic", "config"), slog.Any("Error", err))
+		}
+	}
+	p := oc.ConfigSetToRoutingPolicy(newConfig)
+	rp, err := table.NewAPIRoutingPolicyFromConfigStruct(p)
+	if err != nil {
+		bgpServer.Log().Error("failed to update policy config",
+			slog.String("Topic", "config"), slog.Any("Error", err))
+	} else if err := bgpServer.SetPolicies(ctx, &api.SetPoliciesRequest{
+		DefinedSets: rp.DefinedSets,
+		Policies:    rp.Policies,
+	}); err != nil {
+		bgpServer.Log().Error("failed to set policies",
+			slog.String("Topic", "config"), slog.Any("Error", err))
+	}
+
+	assignGlobalpolicy(ctx, bgpServer, &newConfig.Global.ApplyPolicy.Config)
+
+	added := newConfig.Neighbors
+	addedPg := newConfig.PeerGroups
+	if isGracefulRestart {
+		for i, n := range added {
+			if n.GracefulRestart.Config.Enabled {
+				added[i].GracefulRestart.State.LocalRestarting = true
+			}
+		}
+	}
+
+	addPeerGroups(ctx, bgpServer, addedPg)
+	addDynamicNeighbors(ctx, bgpServer, newConfig.DynamicNeighbors)
+	addNeighbors(ctx, bgpServer, added)
+	return newConfig, nil
+}
+
+// UpdateConfig updates the configuration of a running gobgp instance.
+// InitialConfig must have been called once before this can be called for
+// subsequent changes to config. The differences are that this call 1) does not
+// hangle graceful restart and 2) requires a BgpConfigSet for the previous
+// configuration so that it can compute the delta between it and the new
+// config. The new BgpConfigSet can be obtained using ReadConfigFile.
+func UpdateConfig(ctx context.Context, bgpServer *server.BgpServer, c, newConfig *oc.BgpConfigSet) (*oc.BgpConfigSet, error) {
+	addedPg, deletedPg, updatedPg := oc.UpdatePeerGroupConfig(bgpServer.Log(), c, newConfig)
+	added, deleted, updated := oc.UpdateNeighborConfig(bgpServer.Log(), c, newConfig)
+	updatePolicy := oc.CheckPolicyDifference(bgpServer.Log(), oc.ConfigSetToRoutingPolicy(c), oc.ConfigSetToRoutingPolicy(newConfig))
+
+	if updatePolicy {
+		bgpServer.Log().Info("policy config is update", slog.String("Topic", "config"))
+		p := oc.ConfigSetToRoutingPolicy(newConfig)
+		rp, err := table.NewAPIRoutingPolicyFromConfigStruct(p)
+		if err != nil {
+			bgpServer.Log().Error("failed to update policy config",
+				slog.String("Topic", "config"), slog.Any("Error", err))
+		} else if err := bgpServer.SetPolicies(ctx, &api.SetPoliciesRequest{
+			DefinedSets: rp.DefinedSets,
+			Policies:    rp.Policies,
+		}); err != nil {
+			bgpServer.Log().Error("failed to set policies",
+				slog.String("Topic", "config"), slog.Any("Error", err))
+		}
+	}
+	// global policy update
+	if !newConfig.Global.ApplyPolicy.Config.Equal(&c.Global.ApplyPolicy.Config) {
+		assignGlobalpolicy(ctx, bgpServer, &newConfig.Global.ApplyPolicy.Config)
+		updatePolicy = true
+	}
+
+	addPeerGroups(ctx, bgpServer, addedPg)
+	deletePeerGroups(ctx, bgpServer, deletedPg)
+	needsSoftResetIn := updatePeerGroups(ctx, bgpServer, updatedPg)
+	updatePolicy = updatePolicy || needsSoftResetIn
+	addDynamicNeighbors(ctx, bgpServer, newConfig.DynamicNeighbors)
+	addNeighbors(ctx, bgpServer, added)
+	deleteNeighbors(ctx, bgpServer, deleted)
+	needsSoftResetIn = updateNeighbors(ctx, bgpServer, updated)
+	updatePolicy = updatePolicy || needsSoftResetIn
+
+	if updatePolicy {
+		if err := bgpServer.ResetPeer(ctx, &api.ResetPeerRequest{
+			Address:   "",
+			Direction: api.ResetPeerRequest_DIRECTION_IN,
+			Soft:      true,
+		}); err != nil {
+			bgpServer.Log().Error("failed to update policy config",
+				slog.String("Topic", "config"), slog.Any("Error", err))
+		}
+	}
+	return newConfig, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1336,6 +1336,7 @@ github.com/osrg/gobgp/v4/internal/pkg/netutils
 github.com/osrg/gobgp/v4/internal/pkg/table
 github.com/osrg/gobgp/v4/internal/pkg/version
 github.com/osrg/gobgp/v4/pkg/apiutil
+github.com/osrg/gobgp/v4/pkg/config
 github.com/osrg/gobgp/v4/pkg/config/oc
 github.com/osrg/gobgp/v4/pkg/packet/bfd
 github.com/osrg/gobgp/v4/pkg/packet/bgp


### PR DESCRIPTION
The current gobgp/add-server and gobgp/add-peer API expose a subnet of the configuration knobs that GoBGP provides. This requires us to extend the command every time we introduce a new configuration option.

This commit changes the gobgp/add-server to accept initial configuration (including peers) directly via configuration file. The schema and the format (TOML, YAML, etc) is identical to the one of upstream gobgpd and it uses the same initialization procedure as the gobgpd does. With a trade-off with configuration redundancy, we can now use the full feature of the GoBGP without any code changes.

We also introduced a gobgp/reload-server command which applies the new configuration to the server. This corresponds to the reload operation that update the configuration file and send SIGHUP to the gobgpd. We can express any state transition of gobgp server with this command.

Removing gobgp/add-peer command as it can be replaced by addr-server or add-server + reload-server.

Prepared with AIL 3 with full review from myself.

```release-note
bgp: Use GoBGP configuration directly in script test
```
