### PR TITLE
Simplify cilium policy API types validation and parsing

### DIFF
--- a/operator/pkg/networkpolicy/validator.go
+++ b/operator/pkg/networkpolicy/validator.go
@@ -102,12 +102,12 @@ func (pv *policyValidator) handleCNPEvent(ctx context.Context, event resource.Ev
 
 	var errs error
 	if newPol.Spec != nil {
-		errs = errors.Join(errs, newPol.Spec.Sanitize())
+		errs = errors.Join(errs, newPol.Spec.Validate())
 		errs = errors.Join(errs, validateCNPEndpointSelectorNamespace(pol.Namespace, newPol.Spec))
 		errs = errors.Join(errs, pv.checkMutalAuthUsage(newPol.Spec))
 	}
 	for _, r := range newPol.Specs {
-		errs = errors.Join(errs, r.Sanitize())
+		errs = errors.Join(errs, r.Validate())
 		errs = errors.Join(errs, validateCNPEndpointSelectorNamespace(pol.Namespace, r))
 		errs = errors.Join(errs, pv.checkMutalAuthUsage(r))
 	}
@@ -157,11 +157,11 @@ func (pv *policyValidator) handleCCNPEvent(ctx context.Context, event resource.E
 
 	var errs error
 	if newPol.Spec != nil {
-		errs = errors.Join(errs, newPol.Spec.Sanitize())
+		errs = errors.Join(errs, newPol.Spec.Validate())
 		errs = errors.Join(errs, pv.checkMutalAuthUsage(newPol.Spec))
 	}
 	for _, r := range newPol.Specs {
-		errs = errors.Join(errs, r.Sanitize())
+		errs = errors.Join(errs, r.Validate())
 		errs = errors.Join(errs, pv.checkMutalAuthUsage(r))
 	}
 

--- a/operator/pkg/networkpolicy/validator.go
+++ b/operator/pkg/networkpolicy/validator.go
@@ -100,11 +100,11 @@ func (pv *policyValidator) handleCNPEvent(ctx context.Context, event resource.Ev
 
 	var errs error
 	if newPol.Spec != nil {
-		errs = errors.Join(errs, newPol.Spec.Sanitize())
+		errs = errors.Join(errs, newPol.Spec.Validate())
 		errs = errors.Join(errs, pv.checkMutalAuthUsage(newPol.Spec))
 	}
 	for _, r := range newPol.Specs {
-		errs = errors.Join(errs, r.Sanitize())
+		errs = errors.Join(errs, r.Validate())
 		errs = errors.Join(errs, pv.checkMutalAuthUsage(r))
 	}
 
@@ -153,11 +153,11 @@ func (pv *policyValidator) handleCCNPEvent(ctx context.Context, event resource.E
 
 	var errs error
 	if newPol.Spec != nil {
-		errs = errors.Join(errs, newPol.Spec.Sanitize())
+		errs = errors.Join(errs, newPol.Spec.Validate())
 		errs = errors.Join(errs, pv.checkMutalAuthUsage(newPol.Spec))
 	}
 	for _, r := range newPol.Specs {
-		errs = errors.Join(errs, r.Sanitize())
+		errs = errors.Join(errs, r.Validate())
 		errs = errors.Join(errs, pv.checkMutalAuthUsage(r))
 	}
 

--- a/operator/pkg/networkpolicy/validator_test.go
+++ b/operator/pkg/networkpolicy/validator_test.go
@@ -55,7 +55,7 @@ func TestValidateCNPEndpointSelectorNamespace(t *testing.T) {
 				},
 				Ingress: []api.IngressRule{{}},
 			}
-			require.NoError(t, spec.Sanitize())
+			require.NoError(t, spec.ValidateAndSanitize())
 
 			err := validateCNPEndpointSelectorNamespace(tc.namespace, spec)
 			if tc.wantErr {
@@ -95,7 +95,7 @@ func TestValidateCNPEndpointSelectorNamespace(t *testing.T) {
 			},
 			Ingress: []api.IngressRule{{}},
 		}
-		require.NoError(t, spec.Sanitize())
+		require.NoError(t, spec.ValidateAndSanitize())
 		require.Error(t, validateCNPEndpointSelectorNamespace("foo", spec))
 	})
 }

--- a/pkg/envoy/standalone_envoy_test.go
+++ b/pkg/envoy/standalone_envoy_test.go
@@ -737,7 +737,7 @@ func newStandaloneTestPolicyRepo(t *testing.T, logger *slog.Logger, secretManage
 			}},
 		}},
 	}
-	require.NoError(t, rule.Sanitize())
+	require.NoError(t, rule.ValidateAndSanitize())
 	repo.MustAddList(api.Rules{rule})
 
 	return repo, localIdentity

--- a/pkg/envoy/standalone_envoy_test.go
+++ b/pkg/envoy/standalone_envoy_test.go
@@ -693,7 +693,7 @@ func newStandaloneTestPolicyRepo(t *testing.T, logger *slog.Logger, secretManage
 			}},
 		}},
 	}
-	require.NoError(t, rule.Sanitize())
+	require.NoError(t, rule.ValidateAndSanitize())
 	repo.MustAddList(api.Rules{rule})
 
 	return repo, localIdentity

--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -1487,7 +1487,7 @@ func TestCNPWildcardPortListenerRedirectToEnvoy(t *testing.T) {
 			}},
 		}},
 	}
-	require.NoError(t, cnpRule.Sanitize())
+	require.NoError(t, cnpRule.ValidateAndSanitize())
 	repo.MustAddList(api.Rules{cnpRule})
 
 	selPolicy, _, err := repo.ComputeSelectorPolicy(localIdentity)
@@ -2603,7 +2603,7 @@ func newTestEndpointPolicy(t *testing.T, ep *listenerProxyUpdaterMock) (*policy.
 			},
 		}},
 	}
-	require.NoError(t, rule.Sanitize())
+	require.NoError(t, rule.ValidateAndSanitize())
 	repo.MustAddList(api.Rules{rule})
 
 	return repo, localIdentity, distillEndpointPolicy(t, repo, localIdentity, ep)

--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -1484,7 +1484,7 @@ func TestCNPWildcardPortListenerRedirectToEnvoy(t *testing.T) {
 			}},
 		}},
 	}
-	require.NoError(t, cnpRule.Sanitize())
+	require.NoError(t, cnpRule.ValidateAndSanitize())
 	repo.MustAddList(api.Rules{cnpRule})
 
 	selPolicy, _, err := repo.ComputeSelectorPolicy(localIdentity)
@@ -2599,7 +2599,7 @@ func newTestEndpointPolicy(t *testing.T, ep *listenerProxyUpdaterMock) (*policy.
 			},
 		}},
 	}
-	require.NoError(t, rule.Sanitize())
+	require.NoError(t, rule.ValidateAndSanitize())
 	repo.MustAddList(api.Rules{rule})
 
 	return repo, localIdentity, distillEndpointPolicy(t, repo, localIdentity, ep)

--- a/pkg/k8s/apis/cilium.io/v2/ccnp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/ccnp_types.go
@@ -82,38 +82,76 @@ type CiliumClusterwideNetworkPolicyList struct {
 	Items []CiliumClusterwideNetworkPolicy `json:"items"`
 }
 
-// Parse parses a CiliumClusterwideNetworkPolicy and returns a list of cilium
-// policy rules.
-func (r *CiliumClusterwideNetworkPolicy) Parse(logger *slog.Logger, clusterName string) (api.Rules, error) {
+// Validate validates the CiliumClusterwideNetworkPolicy object
+func (r *CiliumClusterwideNetworkPolicy) Validate() error {
 	if r.ObjectMeta.Name == "" {
-		return nil, NewErrParse("CiliumClusterwideNetworkPolicy must have name")
+		return NewErrParse("CiliumClusterwideNetworkPolicy must have name")
 	}
 
+	if r.Spec == nil && r.Specs == nil {
+		return ErrEmptyCCNP
+	}
+
+	if r.Spec != nil {
+		if err := r.Spec.Validate(); err != nil {
+			return NewErrParse(fmt.Sprintf("Invalid CiliumClusterwideNetworkPolicy spec: %s", err))
+		}
+	}
+	if r.Specs != nil {
+		for _, rule := range r.Specs {
+			if err := rule.Validate(); err != nil {
+				return NewErrParse(fmt.Sprintf("Invalid CiliumClusterwideNetworkPolicy specs: %s", err))
+			}
+		}
+	}
+
+	return nil
+}
+
+// Sanitize sanitizes the CiliumClusterwideNetworkPolicy object modifying object in place
+// to make it ready for parsing.
+//
+// NOTE: This method assumes that the CCNP object is validated beforehand.
+func (r *CiliumClusterwideNetworkPolicy) Sanitize() {
+	if r.Spec != nil {
+		r.Spec.Sanitize()
+	}
+	if r.Specs != nil {
+		for i := range r.Specs {
+			r.Specs[i].Sanitize()
+		}
+	}
+}
+
+// ParseRules parses the CiliumClusterwideNetworkPolicy and returns a list of cilium policy
+// rules ready for processing by downstream subsystems.
+//
+// NOTE: This method assumes that the CCNP object is validated beforehand.
+func (r *CiliumClusterwideNetworkPolicy) ParseRules(logger *slog.Logger, clusterName string) api.Rules {
 	name := r.ObjectMeta.Name
 	uid := r.ObjectMeta.UID
 
 	retRules := api.Rules{}
 
-	if r.Spec == nil && r.Specs == nil {
-		return nil, ErrEmptyCCNP
-	}
-
 	if r.Spec != nil {
-		if err := r.Spec.Sanitize(); err != nil {
-			return nil, NewErrParse(fmt.Sprintf("Invalid CiliumClusterwideNetworkPolicy spec: %s", err))
-		}
 		cr := k8sCiliumUtils.ParseToCiliumRule(logger, clusterName, "", name, uid, r.Spec)
 		retRules = append(retRules, cr)
 	}
 	if r.Specs != nil {
 		for _, rule := range r.Specs {
-			if err := rule.Sanitize(); err != nil {
-				return nil, NewErrParse(fmt.Sprintf("Invalid CiliumClusterwideNetworkPolicy specs: %s", err))
-			}
 			cr := k8sCiliumUtils.ParseToCiliumRule(logger, clusterName, "", name, uid, rule)
 			retRules = append(retRules, cr)
 		}
 	}
 
-	return retRules, nil
+	return retRules
+}
+
+// Parse parses the CiliumClusterwideNetworkPolicy and returns a list of cilium policy rules.
+func (r *CiliumClusterwideNetworkPolicy) Parse(logger *slog.Logger, clusterName string) (api.Rules, error) {
+	if err := r.Validate(); err != nil {
+		return nil, err
+	}
+	r.Sanitize()
+	return r.ParseRules(logger, clusterName), nil
 }

--- a/pkg/k8s/apis/cilium.io/v2/cnp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2/cnp_types.go
@@ -162,11 +162,10 @@ func (r *CiliumNetworkPolicy) SetDerivedPolicyStatus(derivativePolicyName string
 	r.Status.DerivativePolicies[derivativePolicyName] = status
 }
 
-// Parse parses a CiliumNetworkPolicy and returns a list of cilium policy
-// rules.
-func (r *CiliumNetworkPolicy) Parse(logger *slog.Logger, clusterName string) (api.Rules, error) {
+// Validate validates the CiliumNetworkPolicy object.
+func (r *CiliumNetworkPolicy) Validate() error {
 	if r.ObjectMeta.Name == "" {
-		return nil, NewErrParse("CiliumNetworkPolicy must have name")
+		return NewErrParse("CiliumNetworkPolicy must have name")
 	}
 
 	namespace := k8sUtils.ExtractNamespace(&r.ObjectMeta)
@@ -181,41 +180,106 @@ func (r *CiliumNetworkPolicy) Parse(logger *slog.Logger, clusterName string) (ap
 			Specs:      r.Specs,
 			Status:     r.Status,
 		}
-		return ccnp.Parse(logger, clusterName)
+		return ccnp.Validate()
+	}
+
+	if r.Spec == nil && r.Specs == nil {
+		return ErrEmptyCNP
+	}
+	if r.Spec != nil {
+		if err := r.Spec.Validate(); err != nil {
+			return NewErrParse(fmt.Sprintf("Invalid CiliumNetworkPolicy spec: %s", err))
+		}
+		if r.Spec.NodeSelector.LabelSelector != nil {
+			return NewErrParse("Invalid CiliumNetworkPolicy spec: rule cannot have NodeSelector")
+		}
+	}
+	if r.Specs != nil {
+		for _, rule := range r.Specs {
+			if err := rule.Validate(); err != nil {
+				return NewErrParse(fmt.Sprintf("Invalid CiliumNetworkPolicy specs: %s", err))
+			}
+			if rule.NodeSelector.LabelSelector != nil {
+				return NewErrParse("Invalid CiliumNetworkPolicy spec: rule cannot have NodeSelector")
+			}
+		}
+	}
+	return nil
+}
+
+// Sanitize sanitizes the CiliumNetworkPolicy object modifying object in place to make it
+// ready for parsing.
+//
+// NOTE: This method assumes that the CiliumNetworkPolicy object is validated beforehand.
+func (r *CiliumNetworkPolicy) Sanitize() {
+	namespace := k8sUtils.ExtractNamespace(&r.ObjectMeta)
+	if namespace == "" {
+		ccnp := CiliumClusterwideNetworkPolicy{
+			TypeMeta:   r.TypeMeta,
+			ObjectMeta: r.ObjectMeta,
+			Spec:       r.Spec,
+			Specs:      r.Specs,
+			Status:     r.Status,
+		}
+		ccnp.Sanitize()
+		return
+	}
+
+	if r.Spec != nil {
+		r.Spec.Sanitize()
+	}
+	if r.Specs != nil {
+		for i := range r.Specs {
+			r.Specs[i].Sanitize()
+		}
+	}
+}
+
+// ParseRules parses the CiliumNetworkPolicy and returns a list of cilium policy rules ready
+// for processing by downstream subsystems.
+//
+// NOTE: This method assumes that the CiliumNetworkPolicy object is validated beforehand.
+func (r *CiliumNetworkPolicy) ParseRules(logger *slog.Logger, clusterName string) api.Rules {
+	namespace := k8sUtils.ExtractNamespace(&r.ObjectMeta)
+	// Temporary fix for CCNPs. See #12834.
+	// TL;DR. CCNPs are converted into SlimCNPs and end up here so we need to
+	// convert them back to CCNPs to allow proper parsing.
+	if namespace == "" {
+		ccnp := CiliumClusterwideNetworkPolicy{
+			TypeMeta:   r.TypeMeta,
+			ObjectMeta: r.ObjectMeta,
+			Spec:       r.Spec,
+			Specs:      r.Specs,
+			Status:     r.Status,
+		}
+		return ccnp.ParseRules(logger, clusterName)
 	}
 	name := r.ObjectMeta.Name
 	uid := r.ObjectMeta.UID
 
 	retRules := api.Rules{}
 
-	if r.Spec == nil && r.Specs == nil {
-		return nil, ErrEmptyCNP
-	}
-
 	if r.Spec != nil {
-		if err := r.Spec.Sanitize(); err != nil {
-			return nil, NewErrParse(fmt.Sprintf("Invalid CiliumNetworkPolicy spec: %s", err))
-		}
-		if r.Spec.NodeSelector.LabelSelector != nil {
-			return nil, NewErrParse("Invalid CiliumNetworkPolicy spec: rule cannot have NodeSelector")
-		}
 		cr := k8sCiliumUtils.ParseToCiliumRule(logger, clusterName, namespace, name, uid, r.Spec)
 		retRules = append(retRules, cr)
 	}
 	if r.Specs != nil {
 		for _, rule := range r.Specs {
-			if err := rule.Sanitize(); err != nil {
-				return nil, NewErrParse(fmt.Sprintf("Invalid CiliumNetworkPolicy specs: %s", err))
-			}
-			if rule.NodeSelector.LabelSelector != nil {
-				return nil, NewErrParse("Invalid CiliumNetworkPolicy spec: rule cannot have NodeSelector")
-			}
 			cr := k8sCiliumUtils.ParseToCiliumRule(logger, clusterName, namespace, name, uid, rule)
 			retRules = append(retRules, cr)
 		}
 	}
 
-	return retRules, nil
+	return retRules
+}
+
+// Parse parses the CiliumNetworkPolicy and returns a list of cilium policy rules.
+func (r *CiliumNetworkPolicy) Parse(logger *slog.Logger, clusterName string) (api.Rules, error) {
+	if err := r.Validate(); err != nil {
+		return nil, err
+	}
+	r.Sanitize()
+	return r.ParseRules(logger, clusterName), nil
 }
 
 // GetIdentityLabels returns all rule labels in the CiliumNetworkPolicy.

--- a/pkg/k8s/apis/cilium.io/v2/types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/types_test.go
@@ -263,14 +263,14 @@ var (
 
 func sanitizeCNPRules(cnp *CiliumNetworkPolicy) error {
 	if cnp.Spec != nil {
-		if err := cnp.Spec.Sanitize(); err != nil {
+		if err := cnp.Spec.ValidateAndSanitize(); err != nil {
 			return err
 		}
 	}
 
 	if cnp.Specs != nil {
 		for _, rule := range cnp.Specs {
-			if err := rule.Sanitize(); err != nil {
+			if err := rule.ValidateAndSanitize(); err != nil {
 				return err
 			}
 		}

--- a/pkg/k8s/cluster_network_policy.go
+++ b/pkg/k8s/cluster_network_policy.go
@@ -144,7 +144,7 @@ func kcnpParseFQDNSelectors(fqdns []policyv1alpha2.DomainName) (types.Selectors,
 			fqdnSelector.MatchName = string(fqdn)
 		}
 		dnsRule := api.PortRuleDNS(fqdnSelector)
-		if err := dnsRule.Sanitize(); err != nil {
+		if err := dnsRule.Validate(); err != nil {
 			return nil, nil, err
 		}
 		peerSelectors = append(peerSelectors, types.ToSelector(fqdnSelector))

--- a/pkg/policy/api/fqdn.go
+++ b/pkg/policy/api/fqdn.go
@@ -94,10 +94,10 @@ func (s *FQDNSelector) IdentityLabel() labels.Label {
 	return labels.NewLabel(match, "", labels.LabelSourceFQDN)
 }
 
-// sanitize for FQDNSelector is a little wonky. While we do more processing
+// Validate for FQDNSelector is a little wonky. While we do more processing
 // when using MatchName the basic requirement is that is a valid regexp. We
 // test that it can compile here.
-func (s *FQDNSelector) sanitize() error {
+func (s *FQDNSelector) Validate() error {
 	if len(s.MatchName) > 0 && len(s.MatchPattern) > 0 {
 		return fmt.Errorf("only one of MatchName or MatchPattern is allowed in an FQDNSelector")
 	}
@@ -133,9 +133,9 @@ type PortRuleDNS FQDNSelector
 // +deepequal-gen:unordered-array=true
 type PortRulesDNS []PortRuleDNS
 
-// Sanitize checks that the matchName in the portRule can be compiled as a
+// Validate checks that the matchName in the portRule can be compiled as a
 // regex. It does not check that a DNS name is a valid DNS name.
-func (r *PortRuleDNS) Sanitize() error {
+func (r *PortRuleDNS) Validate() error {
 	if len(r.MatchName) > 0 && !allowedMatchNameChars.MatchString(r.MatchName) {
 		return fmt.Errorf("Invalid characters in MatchName: \"%s\". Only 0-9, a-z, A-Z and . and - characters are allowed", r.MatchName)
 	}

--- a/pkg/policy/api/fqdn_test.go
+++ b/pkg/policy/api/fqdn_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestFQDNSelectorSanitize tests that the sanitizer correctly catches bad
+// TestFQDNSelectorValidation tests that the validator correctly catches bad
 // cases, and allows good ones.
-func TestFQDNSelectorSanitize(t *testing.T) {
+func TestFQDNSelectorValidation(t *testing.T) {
 	for _, accept := range []FQDNSelector{
 		{MatchName: "cilium.io."},
 		{MatchName: "get-cilium.io."},
@@ -23,7 +23,7 @@ func TestFQDNSelectorSanitize(t *testing.T) {
 		{MatchPattern: "*cilium.io"},
 		{MatchPattern: "cilium.io"},
 	} {
-		err := accept.sanitize()
+		err := accept.Validate()
 		require.NoError(t, err, "FQDNSelector %+v was rejected but it should be valid", accept)
 	}
 
@@ -32,14 +32,14 @@ func TestFQDNSelectorSanitize(t *testing.T) {
 		{MatchPattern: "[a-z]*.cilium.io."},
 		{MatchName: "cilium.io", MatchPattern: "*cilium.io"},
 	} {
-		err := reject.sanitize()
+		err := reject.Validate()
 		require.Error(t, err, "FQDNSelector %+v was accepted but it should be invalid", reject)
 	}
 }
 
-// TestPortRuleDNSSanitize tests that the sanitizer correctly catches bad
+// TestPortRuleDNSValidation tests that the validator correctly catches bad
 // cases, and allows good ones.
-func TestPortRuleDNSSanitize(t *testing.T) {
+func TestPortRuleDNSValidation(t *testing.T) {
 	for _, accept := range []PortRuleDNS{
 		{MatchName: "cilium.io."},
 		{MatchName: "get-cilium.io."},
@@ -51,7 +51,7 @@ func TestPortRuleDNSSanitize(t *testing.T) {
 		{MatchPattern: "*cilium.io"},
 		{MatchPattern: "cilium.io"},
 	} {
-		err := accept.Sanitize()
+		err := accept.Validate()
 		require.NoError(t, err, "PortRuleDNS %+v was rejected but it should be valid", accept)
 	}
 
@@ -60,7 +60,7 @@ func TestPortRuleDNSSanitize(t *testing.T) {
 		{MatchPattern: "[a-z]*.cilium.io."},
 		{MatchName: "a{1,2}.cilium.io.", MatchPattern: "[a-z]*.cilium.io."},
 	} {
-		err := reject.Sanitize()
+		err := reject.Validate()
 		require.Error(t, err, "PortRuleDNS %+v was accepted but it should be invalid", reject)
 	}
 }

--- a/pkg/policy/api/http.go
+++ b/pkg/policy/api/http.go
@@ -114,11 +114,11 @@ type PortRuleHTTP struct {
 // +deepequal-gen:unordered-array=true
 type PortRulesHTTP []PortRuleHTTP
 
-// Sanitize sanitizes HTTP rules. It ensures that the path and method fields
+// Validate validates HTTP rules. It ensures that the path and method fields
 // are valid regular expressions. Note that the proxy may support a wider-range
 // of regular expressions (e.g. that specified by ECMAScript), so this function
 // may return some false positives. If the rule is invalid, returns an error.
-func (h *PortRuleHTTP) Sanitize() error {
+func (h *PortRuleHTTP) Validate() error {
 	if h.Path != "" {
 		_, err := regexp.Compile(h.Path)
 		if err != nil {

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -30,20 +30,75 @@ var (
 	enableDefaultDenyDefault = true
 )
 
-// Sanitize validates and sanitizes a policy rule. Minor edits such as capitalization
-// of the protocol name are automatically fixed up.
-// As part of `EndpointSelector` sanitization we also convert the label keys to internal
-// representation prefixed with the source information. Check `EndpointSelector.sanitize()`
-// method for more details.
-// More fundamental violations will cause an error to be returned.
+// Validate validates a policy rule returning error if validation fails.
 //
-// Note: this function is called from both the operator and the agent;
-// make sure any configuration flags are bound in **both** binaries.
-func (r *Rule) Sanitize() error {
+// NOTE: This method is immutable and MUST not modify the Rule itself. Any edits
+// to the rule object should be done within Sanitize()
+func (r *Rule) Validate() error {
 	if len(r.Ingress) == 0 && len(r.IngressDeny) == 0 && len(r.Egress) == 0 && len(r.EgressDeny) == 0 {
 		return fmt.Errorf("rule must have at least one of Ingress, IngressDeny, Egress, EgressDeny")
 	}
 
+	if r.EndpointSelector.LabelSelector == nil && r.NodeSelector.LabelSelector == nil {
+		return errors.New("rule must have one of EndpointSelector or NodeSelector")
+	}
+	if r.EndpointSelector.LabelSelector != nil && r.NodeSelector.LabelSelector != nil {
+		return errors.New("rule cannot have both EndpointSelector and NodeSelector")
+	}
+
+	if r.EndpointSelector.LabelSelector != nil {
+		if err := r.EndpointSelector.Validate(); err != nil {
+			return err
+		}
+	}
+
+	var hostPolicy bool
+	if r.NodeSelector.LabelSelector != nil {
+		if err := r.NodeSelector.Validate(); err != nil {
+			return err
+		}
+		hostPolicy = true
+	}
+
+	for i := range r.Ingress {
+		if err := r.Ingress[i].Validate(hostPolicy); err != nil {
+			return err
+		}
+	}
+
+	for i := range r.IngressDeny {
+		if err := r.IngressDeny[i].Validate(); err != nil {
+			return err
+		}
+	}
+
+	for i := range r.Egress {
+		if err := r.Egress[i].Validate(hostPolicy); err != nil {
+			return err
+		}
+	}
+
+	for i := range r.EgressDeny {
+		if err := r.EgressDeny[i].Validate(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Sanitize sanitizes a policy rule. Minor edits such as capitalization of the protocol name
+// are automatically fixed up.
+// As part of `EndpointSelector` sanitization we also convert the label keys to internal
+// representation prefixed with the source information. Check `EndpointSelector.sanitize()`
+// method for more details.
+//
+// NOTE:
+//   - This function is called from both the operator and the agent;
+//     make sure any configuration flags are bound in **both** binaries.
+//   - This function assumes that the Rule is already validated with a prior
+//     call to Validate() method.
+func (r *Rule) Sanitize() {
 	if option.Config.EnableNonDefaultDenyPolicies {
 		// Fill in the default traffic posture of this Rule.
 		// Default posture is per-direction (ingress or egress),
@@ -63,51 +118,37 @@ func (r *Rule) Sanitize() error {
 		r.EnableDefaultDeny.Ingress = &enableDefaultDenyDefault
 	}
 
-	if r.EndpointSelector.LabelSelector == nil && r.NodeSelector.LabelSelector == nil {
-		return errors.New("rule must have one of EndpointSelector or NodeSelector")
-	}
-	if r.EndpointSelector.LabelSelector != nil && r.NodeSelector.LabelSelector != nil {
-		return errors.New("rule cannot have both EndpointSelector and NodeSelector")
-	}
-
 	if r.EndpointSelector.LabelSelector != nil {
-		if err := r.EndpointSelector.Sanitize(); err != nil {
-			return err
-		}
+		r.EndpointSelector.Sanitize()
 	}
 
-	var hostPolicy bool
 	if r.NodeSelector.LabelSelector != nil {
-		if err := r.NodeSelector.Sanitize(); err != nil {
-			return err
-		}
-		hostPolicy = true
+		r.NodeSelector.Sanitize()
 	}
 
 	for i := range r.Ingress {
-		if err := r.Ingress[i].sanitize(hostPolicy); err != nil {
-			return err
-		}
+		r.Ingress[i].Sanitize()
 	}
 
 	for i := range r.IngressDeny {
-		if err := r.IngressDeny[i].sanitize(); err != nil {
-			return err
-		}
+		r.IngressDeny[i].Sanitize()
 	}
 
 	for i := range r.Egress {
-		if err := r.Egress[i].sanitize(hostPolicy); err != nil {
-			return err
-		}
+		r.Egress[i].Sanitize()
 	}
 
 	for i := range r.EgressDeny {
-		if err := r.EgressDeny[i].sanitize(); err != nil {
-			return err
-		}
+		r.EgressDeny[i].Sanitize()
 	}
+}
 
+// ValidateAndSanitize first validates the rule and sanitizes the object if validation succeeds.
+func (r *Rule) ValidateAndSanitize() error {
+	if err := r.Validate(); err != nil {
+		return err
+	}
+	r.Sanitize()
 	return nil
 }
 
@@ -122,14 +163,14 @@ func countL7Rules(ports []PortRule) map[string]int {
 	return result
 }
 
-func (i *IngressRule) sanitize(hostPolicy bool) error {
+func (i *IngressRule) Validate(hostPolicy bool) error {
 	l7Members := countL7Rules(i.ToPorts)
 	l7IngressSupport := map[string]bool{
 		"DNS":  false,
 		"HTTP": true,
 	}
 
-	if err := i.IngressCommonRule.sanitize(); err != nil {
+	if err := i.IngressCommonRule.Validate(); err != nil {
 		return err
 	}
 
@@ -155,22 +196,29 @@ func (i *IngressRule) sanitize(hostPolicy bool) error {
 	}
 
 	for n := range i.ToPorts {
-		if err := i.ToPorts[n].sanitize(true); err != nil {
+		if err := i.ToPorts[n].Validate(true); err != nil {
 			return err
 		}
 	}
 
 	for n := range i.ICMPs {
-		if err := i.ICMPs[n].verify(); err != nil {
+		if err := i.ICMPs[n].Validate(); err != nil {
 			return err
 		}
 	}
-
 	return nil
 }
 
-func (i *IngressDenyRule) sanitize() error {
-	if err := i.IngressCommonRule.sanitize(); err != nil {
+func (i *IngressRule) Sanitize() {
+	i.IngressCommonRule.Sanitize()
+
+	for n := range i.ToPorts {
+		i.ToPorts[n].Sanitize()
+	}
+}
+
+func (i *IngressDenyRule) Validate() error {
+	if err := i.IngressCommonRule.Validate(); err != nil {
 		return err
 	}
 
@@ -183,13 +231,13 @@ func (i *IngressDenyRule) sanitize() error {
 	}
 
 	for n := range i.ToPorts {
-		if err := i.ToPorts[n].sanitize(); err != nil {
+		if err := i.ToPorts[n].Validate(); err != nil {
 			return err
 		}
 	}
 
 	for n := range i.ICMPs {
-		if err := i.ICMPs[n].verify(); err != nil {
+		if err := i.ICMPs[n].Validate(); err != nil {
 			return err
 		}
 	}
@@ -197,7 +245,15 @@ func (i *IngressDenyRule) sanitize() error {
 	return nil
 }
 
-func (i *IngressCommonRule) sanitize() error {
+func (i *IngressDenyRule) Sanitize() {
+	i.IngressCommonRule.Sanitize()
+
+	for n := range i.ToPorts {
+		i.ToPorts[n].Sanitize()
+	}
+}
+
+func (i *IngressCommonRule) Validate() error {
 	l3Members := map[string]int{
 		"FromEndpoints": len(i.FromEndpoints),
 		"FromCIDR":      len(i.FromCIDR),
@@ -222,25 +278,25 @@ func (i *IngressCommonRule) sanitize() error {
 	}
 
 	for n := range i.FromEndpoints {
-		if err := i.FromEndpoints[n].Sanitize(); err != nil {
+		if err := i.FromEndpoints[n].Validate(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
 
 	for n := range i.FromNodes {
-		if err := i.FromNodes[n].Sanitize(); err != nil {
+		if err := i.FromNodes[n].Validate(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
 
 	for n := range i.FromCIDR {
-		if err := i.FromCIDR[n].sanitize(); err != nil {
+		if err := i.FromCIDR[n].Validate(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
 
 	for n := range i.FromCIDRSet {
-		if err := i.FromCIDRSet[n].sanitize(); err != nil {
+		if err := i.FromCIDRSet[n].Validate(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
@@ -253,6 +309,20 @@ func (i *IngressCommonRule) sanitize() error {
 	}
 
 	return retErr
+}
+
+func (i *IngressCommonRule) Sanitize() {
+	for n := range i.FromEndpoints {
+		i.FromEndpoints[n].Sanitize()
+	}
+
+	for n := range i.FromNodes {
+		i.FromNodes[n].Sanitize()
+	}
+
+	for n := range i.FromCIDRSet {
+		i.FromCIDRSet[n].Sanitize()
+	}
 }
 
 // countNonGeneratedRules counts the number of CIDRRule items which are not
@@ -289,7 +359,7 @@ func countNonGeneratedEndpoints(s []EndpointSelector) int {
 	return n
 }
 
-func (e *EgressRule) sanitize(hostPolicy bool) error {
+func (e *EgressRule) Validate(hostPolicy bool) error {
 	l3Members := e.l3Members()
 	l3DependentL4Support := e.l3DependentL4Support()
 	l7Members := countL7Rules(e.ToPorts)
@@ -298,7 +368,7 @@ func (e *EgressRule) sanitize(hostPolicy bool) error {
 		"HTTP": !hostPolicy,
 	}
 
-	if err := e.EgressCommonRule.sanitize(l3Members); err != nil {
+	if err := e.EgressCommonRule.Validate(l3Members); err != nil {
 		return err
 	}
 
@@ -330,25 +400,32 @@ func (e *EgressRule) sanitize(hostPolicy bool) error {
 	}
 
 	for i := range e.ToPorts {
-		if err := e.ToPorts[i].sanitize(false); err != nil {
+		if err := e.ToPorts[i].Validate(false); err != nil {
 			return err
 		}
 	}
 
 	for n := range e.ICMPs {
-		if err := e.ICMPs[n].verify(); err != nil {
+		if err := e.ICMPs[n].Validate(); err != nil {
 			return err
 		}
 	}
 
 	for i := range e.ToFQDNs {
-		err := e.ToFQDNs[i].sanitize()
-		if err != nil {
+		if err := e.ToFQDNs[i].Validate(); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func (e *EgressRule) Sanitize() {
+	e.EgressCommonRule.Sanitize()
+
+	for i := range e.ToPorts {
+		e.ToPorts[i].Sanitize()
+	}
 }
 
 func (e *EgressRule) l3Members() map[string]int {
@@ -363,11 +440,11 @@ func (e *EgressRule) l3DependentL4Support() map[string]bool {
 	return l3DependentL4Support
 }
 
-func (e *EgressDenyRule) sanitize() error {
+func (e *EgressDenyRule) Validate() error {
 	l3Members := e.l3Members()
 	l3DependentL4Support := e.l3DependentL4Support()
 
-	if err := e.EgressCommonRule.sanitize(l3Members); err != nil {
+	if err := e.EgressCommonRule.Validate(l3Members); err != nil {
 		return err
 	}
 
@@ -386,18 +463,26 @@ func (e *EgressDenyRule) sanitize() error {
 	}
 
 	for i := range e.ToPorts {
-		if err := e.ToPorts[i].sanitize(); err != nil {
+		if err := e.ToPorts[i].Validate(); err != nil {
 			return err
 		}
 	}
 
 	for n := range e.ICMPs {
-		if err := e.ICMPs[n].verify(); err != nil {
+		if err := e.ICMPs[n].Validate(); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func (e *EgressDenyRule) Sanitize() {
+	e.EgressCommonRule.Sanitize()
+
+	for i := range e.ToPorts {
+		e.ToPorts[i].Sanitize()
+	}
 }
 
 func (e *EgressDenyRule) l3Members() map[string]int {
@@ -408,7 +493,7 @@ func (e *EgressDenyRule) l3DependentL4Support() map[string]bool {
 	return e.EgressCommonRule.l3DependentL4Support()
 }
 
-func (e *EgressCommonRule) sanitize(l3Members map[string]int) error {
+func (e *EgressCommonRule) Validate(l3Members map[string]int) error {
 	for m1 := range l3Members {
 		for m2 := range l3Members {
 			if m2 != m1 && l3Members[m1] > 0 && l3Members[m2] > 0 {
@@ -424,24 +509,24 @@ func (e *EgressCommonRule) sanitize(l3Members map[string]int) error {
 	}
 
 	for i := range e.ToEndpoints {
-		if err := e.ToEndpoints[i].Sanitize(); err != nil {
+		if err := e.ToEndpoints[i].Validate(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
 
 	for i := range e.ToNodes {
-		if err := e.ToNodes[i].Sanitize(); err != nil {
+		if err := e.ToNodes[i].Validate(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
 
 	for i := range e.ToCIDR {
-		if err := e.ToCIDR[i].sanitize(); err != nil {
+		if err := e.ToCIDR[i].Validate(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
 	for i := range e.ToCIDRSet {
-		if err := e.ToCIDRSet[i].sanitize(); err != nil {
+		if err := e.ToCIDRSet[i].Validate(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
@@ -454,6 +539,20 @@ func (e *EgressCommonRule) sanitize(l3Members map[string]int) error {
 	}
 
 	return retErr
+}
+
+func (e *EgressCommonRule) Sanitize() {
+	for i := range e.ToEndpoints {
+		e.ToEndpoints[i].Sanitize()
+	}
+
+	for i := range e.ToNodes {
+		e.ToNodes[i].Sanitize()
+	}
+
+	for i := range e.ToCIDRSet {
+		e.ToCIDRSet[i].Sanitize()
+	}
 }
 
 func (e *EgressCommonRule) l3Members() map[string]int {
@@ -480,13 +579,13 @@ func (e *EgressCommonRule) l3DependentL4Support() map[string]bool {
 	}
 }
 
-func (pr *L7Rules) sanitize(ports []PortProtocol) error {
+func (pr *L7Rules) Validate(ports []PortProtocol) error {
 	nTypes := 0
 
 	if pr.HTTP != nil {
 		nTypes++
 		for i := range pr.HTTP {
-			if err := pr.HTTP[i].Sanitize(); err != nil {
+			if err := pr.HTTP[i].Validate(); err != nil {
 				return err
 			}
 		}
@@ -501,7 +600,7 @@ func (pr *L7Rules) sanitize(ports []PortProtocol) error {
 
 		nTypes++
 		for i := range pr.DNS {
-			if err := pr.DNS[i].Sanitize(); err != nil {
+			if err := pr.DNS[i].Validate(); err != nil {
 				return err
 			}
 		}
@@ -517,7 +616,7 @@ func (pr *L7Rules) sanitize(ports []PortProtocol) error {
 // have some unit tests relying on this. So, allow overriding this check in the unit tests.
 var TestAllowIngressListener = false
 
-func (pr *PortRule) sanitize(ingress bool) error {
+func (pr *PortRule) Validate(ingress bool) error {
 	hasDNSRules := pr.Rules != nil && len(pr.Rules.DNS) > 0
 	if ingress && hasDNSRules {
 		return fmt.Errorf("DNS rules are not allowed on ingress")
@@ -537,7 +636,7 @@ func (pr *PortRule) sanitize(ingress bool) error {
 	for i := range pr.Ports {
 		var isZero bool
 		var err error
-		if isZero, err = pr.Ports[i].sanitize(hasDNSRules); err != nil {
+		if isZero, err = pr.Ports[i].Validate(hasDNSRules); err != nil {
 			return err
 		}
 		if isZero {
@@ -572,24 +671,36 @@ func (pr *PortRule) sanitize(ingress bool) error {
 			return errors.New("L7 rules can not be used when a port is 0")
 		}
 
-		if err := pr.Rules.sanitize(pr.Ports); err != nil {
+		if err := pr.Rules.Validate(pr.Ports); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (pr *PortDenyRule) sanitize() error {
+func (pr *PortRule) Sanitize() {
+	for i := range pr.Ports {
+		pr.Ports[i].Sanitize()
+	}
+}
+
+func (pr *PortDenyRule) Validate() error {
 	if len(pr.Ports) > maxPorts {
 		return fmt.Errorf("too many ports, the max is %d", maxPorts)
 	}
 	for i := range pr.Ports {
-		if _, err := pr.Ports[i].sanitize(false); err != nil {
+		if _, err := pr.Ports[i].Validate(false); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func (pr *PortDenyRule) Sanitize() {
+	for i := range pr.Ports {
+		pr.Ports[i].Sanitize()
+	}
 }
 
 // isExtendedIPProtocol returns true if the protocol is an extended IP protocol
@@ -604,19 +715,14 @@ func isExtendedIPProtocol(proto L4Proto) bool {
 	}
 }
 
-func (pp *PortProtocol) sanitize(hasDNSRules bool) (isZero bool, err error) {
+func (pp *PortProtocol) Validate(hasDNSRules bool) (isZero bool, err error) {
 	if pp.Port == "" {
 		if !option.Config.EnableExtendedIPProtocols {
 			return isZero, errors.New("port must be specified")
 		}
 	}
 
-	// Port names are formatted as IANA Service Names.  This means that
-	// some legal numeric literals are no longer considered numbers, e.g,
-	// 0x10 is now considered a name rather than number 16.
-	if iana.IsSvcName(pp.Port) {
-		pp.Port = strings.ToLower(pp.Port) // Normalize for case insensitive comparison
-	} else if pp.Port != "" {
+	if !iana.IsSvcName(pp.Port) && pp.Port != "" {
 		// Extended IP protocols and tunnel/encapsulation protocols do not have
 		// transport-layer ports. Require port to be empty or 0 for these protocols.
 		if pp.Port != "0" && isExtendedIPProtocol(pp.Protocol) {
@@ -632,11 +738,21 @@ func (pp *PortProtocol) sanitize(hasDNSRules bool) (isZero bool, err error) {
 		}
 	}
 
-	pp.Protocol, err = ParseL4Proto(string(pp.Protocol))
+	_, err = ParseL4Proto(string(pp.Protocol))
 	return isZero, err
 }
 
-func (ir *ICMPRule) verify() error {
+func (pp *PortProtocol) Sanitize() {
+	// Port names are formatted as IANA Service Names.  This means that
+	// some legal numeric literals are no longer considered numbers, e.g,
+	// 0x10 is now considered a name rather than number 16.
+	if iana.IsSvcName(pp.Port) {
+		pp.Port = strings.ToLower(pp.Port) // Normalize for case insensitive comparison
+	}
+	pp.Protocol, _ = ParseL4Proto(string(pp.Protocol))
+}
+
+func (ir *ICMPRule) Validate() error {
 	if len(ir.Fields) > maxICMPFields {
 		return fmt.Errorf("too many types, the max is %d", maxICMPFields)
 	}
@@ -650,8 +766,8 @@ func (ir *ICMPRule) verify() error {
 	return nil
 }
 
-// sanitize the given CIDR.
-func (c CIDR) sanitize() error {
+// Validate the given CIDR.
+func (c CIDR) Validate() error {
 	strCIDR := string(c)
 	if strCIDR == "" {
 		return fmt.Errorf("IP must be specified")
@@ -673,10 +789,10 @@ func (c CIDR) sanitize() error {
 	return nil
 }
 
-// sanitize validates a CIDRRule by checking that the CIDR prefix itself is
+// Validate validates a CIDRRule by checking that the CIDR prefix itself is
 // valid, and ensuring that all of the exception CIDR prefixes are contained
 // within the allowed CIDR prefix.
-func (c *CIDRRule) sanitize() error {
+func (c *CIDRRule) Validate() error {
 	// Exactly one of CIDR, CIDRGroupRef, or CIDRGroupSelector must be set
 	cnt := 0
 	if len(c.CIDRGroupRef) > 0 {
@@ -687,8 +803,8 @@ func (c *CIDRRule) sanitize() error {
 	}
 	if c.CIDRGroupSelector.LabelSelector != nil {
 		cnt++
-		c.CIDRGroupSelector = NewESFromK8sLabelSelector(labels.LabelSourceCIDRGroupKeyPrefix, c.CIDRGroupSelector.LabelSelector)
-		if err := c.CIDRGroupSelector.Sanitize(); err != nil {
+		cidrSelector := NewESFromK8sLabelSelector(labels.LabelSourceCIDRGroupKeyPrefix, c.CIDRGroupSelector.LabelSelector)
+		if err := cidrSelector.Validate(); err != nil {
 			return fmt.Errorf("failed to sanitize cidrGroupSelector %v: %w", c.CIDRGroupSelector.String(), err)
 		}
 	}
@@ -733,4 +849,11 @@ func (c *CIDRRule) sanitize() error {
 	}
 
 	return nil
+}
+
+func (c *CIDRRule) Sanitize() {
+	if c.CIDRGroupSelector.LabelSelector != nil {
+		c.CIDRGroupSelector = NewESFromK8sLabelSelector(labels.LabelSourceCIDRGroupKeyPrefix, c.CIDRGroupSelector.LabelSelector)
+		c.CIDRGroupSelector.Sanitize()
+	}
 }

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -30,20 +30,75 @@ var (
 	enableDefaultDenyDefault = true
 )
 
-// Sanitize validates and sanitizes a policy rule. Minor edits such as capitalization
-// of the protocol name are automatically fixed up.
-// As part of `EndpointSelector` sanitization we also convert the label keys to internal
-// representation prefixed with the source information. Check `EndpointSelector.sanitize()`
-// method for more details.
-// More fundamental violations will cause an error to be returned.
+// Validate validates a policy rule returning error if validation fails.
 //
-// Note: this function is called from both the operator and the agent;
-// make sure any configuration flags are bound in **both** binaries.
-func (r *Rule) Sanitize() error {
+// NOTE: This method is immutable and MUST not modify the Rule itself. Any edits
+// to the rule object should be done within Sanitize()
+func (r *Rule) Validate() error {
 	if len(r.Ingress) == 0 && len(r.IngressDeny) == 0 && len(r.Egress) == 0 && len(r.EgressDeny) == 0 {
 		return fmt.Errorf("rule must have at least one of Ingress, IngressDeny, Egress, EgressDeny")
 	}
 
+	if r.EndpointSelector.LabelSelector == nil && r.NodeSelector.LabelSelector == nil {
+		return errors.New("rule must have one of EndpointSelector or NodeSelector")
+	}
+	if r.EndpointSelector.LabelSelector != nil && r.NodeSelector.LabelSelector != nil {
+		return errors.New("rule cannot have both EndpointSelector and NodeSelector")
+	}
+
+	if r.EndpointSelector.LabelSelector != nil {
+		if err := r.EndpointSelector.Validate(); err != nil {
+			return err
+		}
+	}
+
+	var hostPolicy bool
+	if r.NodeSelector.LabelSelector != nil {
+		if err := r.NodeSelector.Validate(); err != nil {
+			return err
+		}
+		hostPolicy = true
+	}
+
+	for i := range r.Ingress {
+		if err := r.Ingress[i].Validate(hostPolicy); err != nil {
+			return err
+		}
+	}
+
+	for i := range r.IngressDeny {
+		if err := r.IngressDeny[i].Validate(); err != nil {
+			return err
+		}
+	}
+
+	for i := range r.Egress {
+		if err := r.Egress[i].Validate(hostPolicy); err != nil {
+			return err
+		}
+	}
+
+	for i := range r.EgressDeny {
+		if err := r.EgressDeny[i].Validate(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Sanitize sanitizes a policy rule. Minor edits such as capitalization of the protocol name
+// are automatically fixed up.
+// As part of `EndpointSelector` sanitization we also convert the label keys to internal
+// representation prefixed with the source information. Check `EndpointSelector.sanitize()`
+// method for more details.
+//
+// NOTE:
+//   - This function is called from both the operator and the agent;
+//     make sure any configuration flags are bound in **both** binaries.
+//   - This function assumes that the Rule is already validated with a prior
+//     call to Validate() method.
+func (r *Rule) Sanitize() {
 	if option.Config.EnableNonDefaultDenyPolicies {
 		// Fill in the default traffic posture of this Rule.
 		// Default posture is per-direction (ingress or egress),
@@ -63,51 +118,37 @@ func (r *Rule) Sanitize() error {
 		r.EnableDefaultDeny.Ingress = &enableDefaultDenyDefault
 	}
 
-	if r.EndpointSelector.LabelSelector == nil && r.NodeSelector.LabelSelector == nil {
-		return errors.New("rule must have one of EndpointSelector or NodeSelector")
-	}
-	if r.EndpointSelector.LabelSelector != nil && r.NodeSelector.LabelSelector != nil {
-		return errors.New("rule cannot have both EndpointSelector and NodeSelector")
-	}
-
 	if r.EndpointSelector.LabelSelector != nil {
-		if err := r.EndpointSelector.Sanitize(); err != nil {
-			return err
-		}
+		r.EndpointSelector.Sanitize()
 	}
 
-	var hostPolicy bool
 	if r.NodeSelector.LabelSelector != nil {
-		if err := r.NodeSelector.Sanitize(); err != nil {
-			return err
-		}
-		hostPolicy = true
+		r.NodeSelector.Sanitize()
 	}
 
 	for i := range r.Ingress {
-		if err := r.Ingress[i].sanitize(hostPolicy); err != nil {
-			return err
-		}
+		r.Ingress[i].Sanitize()
 	}
 
 	for i := range r.IngressDeny {
-		if err := r.IngressDeny[i].sanitize(); err != nil {
-			return err
-		}
+		r.IngressDeny[i].Sanitize()
 	}
 
 	for i := range r.Egress {
-		if err := r.Egress[i].sanitize(hostPolicy); err != nil {
-			return err
-		}
+		r.Egress[i].Sanitize()
 	}
 
 	for i := range r.EgressDeny {
-		if err := r.EgressDeny[i].sanitize(); err != nil {
-			return err
-		}
+		r.EgressDeny[i].Sanitize()
 	}
+}
 
+// ValidateAndSanitize first validates the rule and sanitizes the object if validation succeeds.
+func (r *Rule) ValidateAndSanitize() error {
+	if err := r.Validate(); err != nil {
+		return err
+	}
+	r.Sanitize()
 	return nil
 }
 
@@ -122,14 +163,14 @@ func countL7Rules(ports []PortRule) map[string]int {
 	return result
 }
 
-func (i *IngressRule) sanitize(hostPolicy bool) error {
+func (i *IngressRule) Validate(hostPolicy bool) error {
 	l7Members := countL7Rules(i.ToPorts)
 	l7IngressSupport := map[string]bool{
 		"DNS":  false,
 		"HTTP": true,
 	}
 
-	if err := i.IngressCommonRule.sanitize(); err != nil {
+	if err := i.IngressCommonRule.Validate(); err != nil {
 		return err
 	}
 
@@ -155,22 +196,29 @@ func (i *IngressRule) sanitize(hostPolicy bool) error {
 	}
 
 	for n := range i.ToPorts {
-		if err := i.ToPorts[n].sanitize(true); err != nil {
+		if err := i.ToPorts[n].Validate(true); err != nil {
 			return err
 		}
 	}
 
 	for n := range i.ICMPs {
-		if err := i.ICMPs[n].verify(); err != nil {
+		if err := i.ICMPs[n].Validate(); err != nil {
 			return err
 		}
 	}
-
 	return nil
 }
 
-func (i *IngressDenyRule) sanitize() error {
-	if err := i.IngressCommonRule.sanitize(); err != nil {
+func (i *IngressRule) Sanitize() {
+	i.IngressCommonRule.Sanitize()
+
+	for n := range i.ToPorts {
+		i.ToPorts[n].Sanitize()
+	}
+}
+
+func (i *IngressDenyRule) Validate() error {
+	if err := i.IngressCommonRule.Validate(); err != nil {
 		return err
 	}
 
@@ -183,13 +231,13 @@ func (i *IngressDenyRule) sanitize() error {
 	}
 
 	for n := range i.ToPorts {
-		if err := i.ToPorts[n].sanitize(); err != nil {
+		if err := i.ToPorts[n].Validate(); err != nil {
 			return err
 		}
 	}
 
 	for n := range i.ICMPs {
-		if err := i.ICMPs[n].verify(); err != nil {
+		if err := i.ICMPs[n].Validate(); err != nil {
 			return err
 		}
 	}
@@ -197,7 +245,15 @@ func (i *IngressDenyRule) sanitize() error {
 	return nil
 }
 
-func (i *IngressCommonRule) sanitize() error {
+func (i *IngressDenyRule) Sanitize() {
+	i.IngressCommonRule.Sanitize()
+
+	for n := range i.ToPorts {
+		i.ToPorts[n].Sanitize()
+	}
+}
+
+func (i *IngressCommonRule) Validate() error {
 	l3Members := map[string]int{
 		"FromEndpoints": len(i.FromEndpoints),
 		"FromCIDR":      len(i.FromCIDR),
@@ -222,25 +278,25 @@ func (i *IngressCommonRule) sanitize() error {
 	}
 
 	for n := range i.FromEndpoints {
-		if err := i.FromEndpoints[n].Sanitize(); err != nil {
+		if err := i.FromEndpoints[n].Validate(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
 
 	for n := range i.FromNodes {
-		if err := i.FromNodes[n].Sanitize(); err != nil {
+		if err := i.FromNodes[n].Validate(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
 
 	for n := range i.FromCIDR {
-		if err := i.FromCIDR[n].sanitize(); err != nil {
+		if err := i.FromCIDR[n].Validate(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
 
 	for n := range i.FromCIDRSet {
-		if err := i.FromCIDRSet[n].sanitize(); err != nil {
+		if err := i.FromCIDRSet[n].Validate(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
@@ -253,6 +309,20 @@ func (i *IngressCommonRule) sanitize() error {
 	}
 
 	return retErr
+}
+
+func (i *IngressCommonRule) Sanitize() {
+	for n := range i.FromEndpoints {
+		i.FromEndpoints[n].Sanitize()
+	}
+
+	for n := range i.FromNodes {
+		i.FromNodes[n].Sanitize()
+	}
+
+	for n := range i.FromCIDRSet {
+		i.FromCIDRSet[n].Sanitize()
+	}
 }
 
 // countNonGeneratedRules counts the number of CIDRRule items which are not
@@ -289,7 +359,7 @@ func countNonGeneratedEndpoints(s []EndpointSelector) int {
 	return n
 }
 
-func (e *EgressRule) sanitize(hostPolicy bool) error {
+func (e *EgressRule) Validate(hostPolicy bool) error {
 	l3Members := e.l3Members()
 	l3DependentL4Support := e.l3DependentL4Support()
 	l7Members := countL7Rules(e.ToPorts)
@@ -298,7 +368,7 @@ func (e *EgressRule) sanitize(hostPolicy bool) error {
 		"HTTP": !hostPolicy,
 	}
 
-	if err := e.EgressCommonRule.sanitize(l3Members); err != nil {
+	if err := e.EgressCommonRule.Validate(l3Members); err != nil {
 		return err
 	}
 
@@ -330,25 +400,32 @@ func (e *EgressRule) sanitize(hostPolicy bool) error {
 	}
 
 	for i := range e.ToPorts {
-		if err := e.ToPorts[i].sanitize(false); err != nil {
+		if err := e.ToPorts[i].Validate(false); err != nil {
 			return err
 		}
 	}
 
 	for n := range e.ICMPs {
-		if err := e.ICMPs[n].verify(); err != nil {
+		if err := e.ICMPs[n].Validate(); err != nil {
 			return err
 		}
 	}
 
 	for i := range e.ToFQDNs {
-		err := e.ToFQDNs[i].sanitize()
-		if err != nil {
+		if err := e.ToFQDNs[i].Validate(); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func (e *EgressRule) Sanitize() {
+	e.EgressCommonRule.Sanitize()
+
+	for i := range e.ToPorts {
+		e.ToPorts[i].Sanitize()
+	}
 }
 
 func (e *EgressRule) l3Members() map[string]int {
@@ -363,11 +440,11 @@ func (e *EgressRule) l3DependentL4Support() map[string]bool {
 	return l3DependentL4Support
 }
 
-func (e *EgressDenyRule) sanitize() error {
+func (e *EgressDenyRule) Validate() error {
 	l3Members := e.l3Members()
 	l3DependentL4Support := e.l3DependentL4Support()
 
-	if err := e.EgressCommonRule.sanitize(l3Members); err != nil {
+	if err := e.EgressCommonRule.Validate(l3Members); err != nil {
 		return err
 	}
 
@@ -386,18 +463,26 @@ func (e *EgressDenyRule) sanitize() error {
 	}
 
 	for i := range e.ToPorts {
-		if err := e.ToPorts[i].sanitize(); err != nil {
+		if err := e.ToPorts[i].Validate(); err != nil {
 			return err
 		}
 	}
 
 	for n := range e.ICMPs {
-		if err := e.ICMPs[n].verify(); err != nil {
+		if err := e.ICMPs[n].Validate(); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func (e *EgressDenyRule) Sanitize() {
+	e.EgressCommonRule.Sanitize()
+
+	for i := range e.ToPorts {
+		e.ToPorts[i].Sanitize()
+	}
 }
 
 func (e *EgressDenyRule) l3Members() map[string]int {
@@ -408,7 +493,7 @@ func (e *EgressDenyRule) l3DependentL4Support() map[string]bool {
 	return e.EgressCommonRule.l3DependentL4Support()
 }
 
-func (e *EgressCommonRule) sanitize(l3Members map[string]int) error {
+func (e *EgressCommonRule) Validate(l3Members map[string]int) error {
 	for m1 := range l3Members {
 		for m2 := range l3Members {
 			if m2 != m1 && l3Members[m1] > 0 && l3Members[m2] > 0 {
@@ -424,24 +509,24 @@ func (e *EgressCommonRule) sanitize(l3Members map[string]int) error {
 	}
 
 	for i := range e.ToEndpoints {
-		if err := e.ToEndpoints[i].Sanitize(); err != nil {
+		if err := e.ToEndpoints[i].Validate(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
 
 	for i := range e.ToNodes {
-		if err := e.ToNodes[i].Sanitize(); err != nil {
+		if err := e.ToNodes[i].Validate(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
 
 	for i := range e.ToCIDR {
-		if err := e.ToCIDR[i].sanitize(); err != nil {
+		if err := e.ToCIDR[i].Validate(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
 	for i := range e.ToCIDRSet {
-		if err := e.ToCIDRSet[i].sanitize(); err != nil {
+		if err := e.ToCIDRSet[i].Validate(); err != nil {
 			return errors.Join(err, retErr)
 		}
 	}
@@ -454,6 +539,20 @@ func (e *EgressCommonRule) sanitize(l3Members map[string]int) error {
 	}
 
 	return retErr
+}
+
+func (e *EgressCommonRule) Sanitize() {
+	for i := range e.ToEndpoints {
+		e.ToEndpoints[i].Sanitize()
+	}
+
+	for i := range e.ToNodes {
+		e.ToNodes[i].Sanitize()
+	}
+
+	for i := range e.ToCIDRSet {
+		e.ToCIDRSet[i].Sanitize()
+	}
 }
 
 func (e *EgressCommonRule) l3Members() map[string]int {
@@ -480,13 +579,13 @@ func (e *EgressCommonRule) l3DependentL4Support() map[string]bool {
 	}
 }
 
-func (pr *L7Rules) sanitize(ports []PortProtocol) error {
+func (pr *L7Rules) Validate(ports []PortProtocol) error {
 	nTypes := 0
 
 	if pr.HTTP != nil {
 		nTypes++
 		for i := range pr.HTTP {
-			if err := pr.HTTP[i].Sanitize(); err != nil {
+			if err := pr.HTTP[i].Validate(); err != nil {
 				return err
 			}
 		}
@@ -501,7 +600,7 @@ func (pr *L7Rules) sanitize(ports []PortProtocol) error {
 
 		nTypes++
 		for i := range pr.DNS {
-			if err := pr.DNS[i].Sanitize(); err != nil {
+			if err := pr.DNS[i].Validate(); err != nil {
 				return err
 			}
 		}
@@ -517,7 +616,7 @@ func (pr *L7Rules) sanitize(ports []PortProtocol) error {
 // have some unit tests relying on this. So, allow overriding this check in the unit tests.
 var TestAllowIngressListener = false
 
-func (pr *PortRule) sanitize(ingress bool) error {
+func (pr *PortRule) Validate(ingress bool) error {
 	hasDNSRules := pr.Rules != nil && len(pr.Rules.DNS) > 0
 	if ingress && hasDNSRules {
 		return fmt.Errorf("DNS rules are not allowed on ingress")
@@ -537,7 +636,7 @@ func (pr *PortRule) sanitize(ingress bool) error {
 	for i := range pr.Ports {
 		var isZero bool
 		var err error
-		if isZero, err = pr.Ports[i].sanitize(hasDNSRules); err != nil {
+		if isZero, err = pr.Ports[i].Validate(hasDNSRules); err != nil {
 			return err
 		}
 		if isZero {
@@ -572,24 +671,36 @@ func (pr *PortRule) sanitize(ingress bool) error {
 			return errors.New("L7 rules can not be used when a port is 0")
 		}
 
-		if err := pr.Rules.sanitize(pr.Ports); err != nil {
+		if err := pr.Rules.Validate(pr.Ports); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (pr *PortDenyRule) sanitize() error {
+func (pr *PortRule) Sanitize() {
+	for i := range pr.Ports {
+		pr.Ports[i].Sanitize()
+	}
+}
+
+func (pr *PortDenyRule) Validate() error {
 	if len(pr.Ports) > maxPorts {
 		return fmt.Errorf("too many ports, the max is %d", maxPorts)
 	}
 	for i := range pr.Ports {
-		if _, err := pr.Ports[i].sanitize(false); err != nil {
+		if _, err := pr.Ports[i].Validate(false); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func (pr *PortDenyRule) Sanitize() {
+	for i := range pr.Ports {
+		pr.Ports[i].Sanitize()
+	}
 }
 
 // isExtendedIPProtocol returns true if the protocol is an extended IP protocol
@@ -604,19 +715,14 @@ func isExtendedIPProtocol(proto L4Proto) bool {
 	}
 }
 
-func (pp *PortProtocol) sanitize(hasDNSRules bool) (isZero bool, err error) {
+func (pp *PortProtocol) Validate(hasDNSRules bool) (isZero bool, err error) {
 	if pp.Port == "" {
 		if !option.Config.EnableExtendedIPProtocols {
 			return isZero, errors.New("port must be specified")
 		}
 	}
 
-	// Port names are formatted as IANA Service Names.  This means that
-	// some legal numeric literals are no longer considered numbers, e.g,
-	// 0x10 is now considered a name rather than number 16.
-	if iana.IsSvcName(pp.Port) {
-		pp.Port = strings.ToLower(pp.Port) // Normalize for case insensitive comparison
-	} else if pp.Port != "" {
+	if !iana.IsSvcName(pp.Port) && pp.Port != "" {
 		// Extended IP protocols and tunnel/encapsulation protocols do not have
 		// transport-layer ports. Require port to be empty or 0 for these protocols.
 		if pp.Port != "0" && isExtendedIPProtocol(pp.Protocol) {
@@ -632,11 +738,21 @@ func (pp *PortProtocol) sanitize(hasDNSRules bool) (isZero bool, err error) {
 		}
 	}
 
-	pp.Protocol, err = ParseL4Proto(string(pp.Protocol))
+	_, err = ParseL4Proto(string(pp.Protocol))
 	return isZero, err
 }
 
-func (ir *ICMPRule) verify() error {
+func (pp *PortProtocol) Sanitize() {
+	// Port names are formatted as IANA Service Names.  This means that
+	// some legal numeric literals are no longer considered numbers, e.g,
+	// 0x10 is now considered a name rather than number 16.
+	if iana.IsSvcName(pp.Port) {
+		pp.Port = strings.ToLower(pp.Port) // Normalize for case insensitive comparison
+	}
+	pp.Protocol, _ = ParseL4Proto(string(pp.Protocol))
+}
+
+func (ir *ICMPRule) Validate() error {
 	if len(ir.Fields) > maxICMPFields {
 		return fmt.Errorf("too many types, the max is %d", maxICMPFields)
 	}
@@ -650,8 +766,8 @@ func (ir *ICMPRule) verify() error {
 	return nil
 }
 
-// sanitize the given CIDR.
-func (c CIDR) sanitize() error {
+// Validate the given CIDR.
+func (c CIDR) Validate() error {
 	strCIDR := string(c)
 	if strCIDR == "" {
 		return fmt.Errorf("IP must be specified")
@@ -669,10 +785,10 @@ func (c CIDR) sanitize() error {
 	return nil
 }
 
-// sanitize validates a CIDRRule by checking that the CIDR prefix itself is
+// Validate validates a CIDRRule by checking that the CIDR prefix itself is
 // valid, and ensuring that all of the exception CIDR prefixes are contained
 // within the allowed CIDR prefix.
-func (c *CIDRRule) sanitize() error {
+func (c *CIDRRule) Validate() error {
 	// Exactly one of CIDR, CIDRGroupRef, or CIDRGroupSelector must be set
 	cnt := 0
 	if len(c.CIDRGroupRef) > 0 {
@@ -683,8 +799,8 @@ func (c *CIDRRule) sanitize() error {
 	}
 	if c.CIDRGroupSelector.LabelSelector != nil {
 		cnt++
-		c.CIDRGroupSelector = NewESFromK8sLabelSelector(labels.LabelSourceCIDRGroupKeyPrefix, c.CIDRGroupSelector.LabelSelector)
-		if err := c.CIDRGroupSelector.Sanitize(); err != nil {
+		cidrSelector := NewESFromK8sLabelSelector(labels.LabelSourceCIDRGroupKeyPrefix, c.CIDRGroupSelector.LabelSelector)
+		if err := cidrSelector.Validate(); err != nil {
 			return fmt.Errorf("failed to sanitize cidrGroupSelector %v: %w", c.CIDRGroupSelector.String(), err)
 		}
 	}
@@ -729,4 +845,11 @@ func (c *CIDRRule) sanitize() error {
 	}
 
 	return nil
+}
+
+func (c *CIDRRule) Sanitize() {
+	if c.CIDRGroupSelector.LabelSelector != nil {
+		c.CIDRGroupSelector = NewESFromK8sLabelSelector(labels.LabelSourceCIDRGroupKeyPrefix, c.CIDRGroupSelector.LabelSelector)
+		c.CIDRGroupSelector.Sanitize()
+	}
 }

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -538,6 +538,12 @@ func (e *EgressCommonRule) Validate(l3Members map[string]int) error {
 		}
 	}
 
+	for i := range e.ToServices {
+		if err := e.ToServices[i].Validate(); err != nil {
+			return errors.Join(err, retErr)
+		}
+	}
+
 	return retErr
 }
 
@@ -552,6 +558,10 @@ func (e *EgressCommonRule) Sanitize() {
 
 	for i := range e.ToCIDRSet {
 		e.ToCIDRSet[i].Sanitize()
+	}
+
+	for i := range e.ToServices {
+		e.ToServices[i].Sanitize()
 	}
 }
 

--- a/pkg/policy/api/rule_validation_test.go
+++ b/pkg/policy/api/rule_validation_test.go
@@ -43,7 +43,7 @@ func TestL7RulesWithNonTCPProtocols(t *testing.T) {
 		},
 	}
 
-	err := validPortRule.Sanitize()
+	err := validPortRule.Validate()
 	require.NoError(t, err)
 
 	// Rule is invalid because no port is specified for DNS proxy rule.
@@ -65,7 +65,7 @@ func TestL7RulesWithNonTCPProtocols(t *testing.T) {
 		},
 	}
 
-	err = validPortRule.Sanitize()
+	err = validPortRule.Validate()
 	require.Error(t, err, "Port 53 must be specified for DNS rules")
 
 	// Rule is valid because all protocols are allowed for L7 rules with ToFQDNs.
@@ -91,7 +91,7 @@ func TestL7RulesWithNonTCPProtocols(t *testing.T) {
 		},
 	}
 
-	err = validPortRule.Sanitize()
+	err = validPortRule.Validate()
 	require.NoError(t, err, "Saw an error for a L7 rule with DNS rules. This should be allowed.")
 
 	validSCTPRule := Rule{
@@ -110,7 +110,7 @@ func TestL7RulesWithNonTCPProtocols(t *testing.T) {
 		},
 	}
 
-	err = validSCTPRule.Sanitize()
+	err = validSCTPRule.Validate()
 	require.NoError(t, err, "Saw an error for an SCTP rule.")
 
 	validSCTPDenyRule := Rule{
@@ -129,7 +129,7 @@ func TestL7RulesWithNonTCPProtocols(t *testing.T) {
 		},
 	}
 
-	err = validSCTPDenyRule.Sanitize()
+	err = validSCTPDenyRule.Validate()
 	require.NoError(t, err, "Saw an error for an SCTP deny rule.")
 
 	// Rule is invalid because only ProtoTCP is allowed for L7 rules (except with DNS, below).
@@ -154,7 +154,7 @@ func TestL7RulesWithNonTCPProtocols(t *testing.T) {
 		},
 	}
 
-	err = invalidPortRule.Sanitize()
+	err = invalidPortRule.Validate()
 	require.ErrorContains(t, err, "L7 rules can only apply to TCP (not UDP) except for DNS rules")
 
 	// Rule is invalid because DNS proxy rules are not allowed on ingress rules.
@@ -179,7 +179,7 @@ func TestL7RulesWithNonTCPProtocols(t *testing.T) {
 		},
 	}
 
-	err = invalidPortRule.Sanitize()
+	err = invalidPortRule.Validate()
 	require.Error(t, err, "DNS rule should not be allowed on ingress")
 
 	// Rule is invalid because only ProtoTCP is allowed for L7 rules (except with DNS, below).
@@ -204,7 +204,7 @@ func TestL7RulesWithNonTCPProtocols(t *testing.T) {
 		},
 	}
 
-	err = invalidPortRule.Sanitize()
+	err = invalidPortRule.Validate()
 	require.Error(t, err)
 	require.Equal(t, "L7 rules can only apply to TCP (not ANY) except for DNS rules", err.Error())
 
@@ -231,7 +231,7 @@ func TestL7RulesWithNonTCPProtocols(t *testing.T) {
 		},
 	}
 
-	err = invalidPortRule.Sanitize()
+	err = invalidPortRule.Validate()
 	require.Error(t, err)
 	require.Equal(t, "L7 rules can only apply to TCP (not UDP) except for DNS rules", err.Error())
 
@@ -258,7 +258,7 @@ func TestL7RulesWithNonTCPProtocols(t *testing.T) {
 		},
 	}
 
-	err = invalidPortRule.Sanitize()
+	err = invalidPortRule.Validate()
 	require.Error(t, err)
 	require.Equal(t, "L7 rules can only apply to TCP (not UDP) except for DNS rules", err.Error())
 
@@ -279,7 +279,7 @@ func TestL7RulesWithNonTCPProtocols(t *testing.T) {
 			},
 		},
 	}
-	err = validPortRule.Sanitize()
+	err = validPortRule.Validate()
 	require.NoError(t, err)
 
 	// Rule is invalid because empty ServerNames are not allowed
@@ -299,7 +299,7 @@ func TestL7RulesWithNonTCPProtocols(t *testing.T) {
 			},
 		},
 	}
-	err = invalidPortRule.Sanitize()
+	err = invalidPortRule.Validate()
 	require.ErrorIs(t, err, errEmptyServerName)
 
 	//  Rule is invalid because ServerNames with L7 rules are not allowed without TLS termination.
@@ -324,7 +324,7 @@ func TestL7RulesWithNonTCPProtocols(t *testing.T) {
 			},
 		},
 	}
-	err = invalidPortRule.Sanitize()
+	err = invalidPortRule.Validate()
 	require.Error(t, err)
 	require.Equal(t, "ServerNames are not allowed with L7 rules without TLS termination", err.Error())
 
@@ -355,7 +355,7 @@ func TestL7RulesWithNonTCPProtocols(t *testing.T) {
 			},
 		},
 	}
-	err = validPortRule.Sanitize()
+	err = validPortRule.Validate()
 	require.NoError(t, err)
 
 	// Rule is valid because Listener is allowed on egress, default Kind
@@ -380,7 +380,7 @@ func TestL7RulesWithNonTCPProtocols(t *testing.T) {
 			},
 		},
 	}
-	err = validPortRule.Sanitize()
+	err = validPortRule.Validate()
 	require.NoError(t, err)
 
 	// Rule is valid because Listener is allowed on egress, Kind CiliumClusterwideEnvoyConfig
@@ -406,7 +406,7 @@ func TestL7RulesWithNonTCPProtocols(t *testing.T) {
 			},
 		},
 	}
-	err = validPortRule.Sanitize()
+	err = validPortRule.Validate()
 	require.NoError(t, err)
 
 	// Rule is valid because Listener is allowed on egress, Kind CiliumEnvoyConfig
@@ -432,7 +432,7 @@ func TestL7RulesWithNonTCPProtocols(t *testing.T) {
 			},
 		},
 	}
-	err = validPortRule.Sanitize()
+	err = validPortRule.Validate()
 	require.NoError(t, err)
 
 	// Rule is invalid because Listener is not allowed on ingress (yet)
@@ -457,7 +457,7 @@ func TestL7RulesWithNonTCPProtocols(t *testing.T) {
 			},
 		},
 	}
-	err = invalidPortRule.Sanitize()
+	err = invalidPortRule.Validate()
 	require.Error(t, err)
 	require.Equal(t, "Listener is not allowed on ingress (myCustomListener)", err.Error())
 
@@ -488,7 +488,7 @@ func TestL7RulesWithNonTCPProtocols(t *testing.T) {
 			},
 		},
 	}
-	err = invalidPortRule.Sanitize()
+	err = invalidPortRule.Validate()
 	require.Error(t, err)
 	require.Equal(t, "Listener is not allowed with L7 rules (myCustomListener)", err.Error())
 }
@@ -516,7 +516,7 @@ func TestL7RuleRejectsEmptyPort(t *testing.T) {
 		},
 	}
 
-	err := invalidL7PortRule.Sanitize()
+	err := invalidL7PortRule.Validate()
 	require.Error(t, err)
 }
 
@@ -545,7 +545,7 @@ func TestHTTPRuleRegexes(t *testing.T) {
 		},
 	}
 
-	err := invalidHTTPRegexPathRule.Sanitize()
+	err := invalidHTTPRegexPathRule.Validate()
 	require.Error(t, err)
 
 	invalidHTTPRegexMethodRule := Rule{
@@ -570,61 +570,62 @@ func TestHTTPRuleRegexes(t *testing.T) {
 		},
 	}
 
-	err = invalidHTTPRegexMethodRule.Sanitize()
+	err = invalidHTTPRegexMethodRule.Validate()
 	require.Error(t, err)
 }
 
 // Test the validation of CIDR rule prefix definitions
-func TestCIDRsanitize(t *testing.T) {
+func TestCIDRValidation(t *testing.T) {
 	sel := EndpointSelector{LabelSelector: &slim_metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}}}
 	expectedSel := NewESFromK8sLabelSelector(labels.LabelSourceCIDRGroupKeyPrefix, sel.LabelSelector)
 
 	cidr := CIDRRule{}
-	err := cidr.sanitize()
+	err := cidr.Validate()
 	require.Error(t, err)
 
 	// IPv4
 	cidr = CIDRRule{Cidr: "0.0.0.0/0"}
-	err = cidr.sanitize()
+	err = cidr.Validate()
 	require.NoError(t, err)
 
 	cidr = CIDRRule{Cidr: "10.0.0.0/24"}
-	err = cidr.sanitize()
+	err = cidr.Validate()
 	require.NoError(t, err)
 
 	cidr = CIDRRule{Cidr: "192.0.2.3/32"}
-	err = cidr.sanitize()
+	err = cidr.Validate()
 	require.NoError(t, err)
 
 	// IPv6
 	cidr = CIDRRule{Cidr: "::/0"}
-	err = cidr.sanitize()
+	err = cidr.Validate()
 	require.NoError(t, err)
 
 	cidr = CIDRRule{Cidr: "ff02::/64"}
-	err = cidr.sanitize()
+	err = cidr.Validate()
 	require.NoError(t, err)
 
 	cidr = CIDRRule{Cidr: "", CIDRGroupRef: "cidrgroup"}
-	err = cidr.sanitize()
+	err = cidr.Validate()
 	require.NoError(t, err)
 
 	cidr = CIDRRule{Cidr: "", CIDRGroupSelector: sel}
-	err = cidr.sanitize()
+	err = cidr.Validate()
 	require.NoError(t, err)
+	cidr.Sanitize()
 	require.Equal(t, expectedSel, cidr.CIDRGroupSelector)
 
 	cidr = CIDRRule{Cidr: "", CIDRGroupRef: "foo", CIDRGroupSelector: sel}
-	err = cidr.sanitize()
+	err = cidr.Validate()
 	require.Error(t, err)
 
 	cidr = CIDRRule{Cidr: "2001:0db8:85a3:0000:0000:8a2e:0370:7334/128"}
-	err = cidr.sanitize()
+	err = cidr.Validate()
 	require.NoError(t, err)
 
 	// Non-contiguous mask.
 	cidr = CIDRRule{Cidr: "10.0.0.0/254.0.0.255"}
-	err = cidr.sanitize()
+	err = cidr.Validate()
 	require.Error(t, err)
 
 	// Valid ExceptCIDRs
@@ -632,7 +633,7 @@ func TestCIDRsanitize(t *testing.T) {
 		Cidr:        "10.0.0.0/24",
 		ExceptCIDRs: []CIDR{"10.0.0.1/32", "10.0.0.128/25"},
 	}
-	err = cidr.sanitize()
+	err = cidr.Validate()
 	require.NoError(t, err)
 
 	// Invalid ExceptCIDRs: Broader than main CIDR
@@ -640,7 +641,7 @@ func TestCIDRsanitize(t *testing.T) {
 		Cidr:        "10.0.0.0/24",
 		ExceptCIDRs: []CIDR{"10.0.0.0/16"},
 	}
-	err = cidr.sanitize()
+	err = cidr.Validate()
 	require.Error(t, err)
 
 	// Invalid ExceptCIDRs: Outside main CIDR
@@ -648,11 +649,11 @@ func TestCIDRsanitize(t *testing.T) {
 		Cidr:        "10.0.0.0/24",
 		ExceptCIDRs: []CIDR{"10.1.0.0/24"},
 	}
-	err = cidr.sanitize()
+	err = cidr.Validate()
 	require.Error(t, err)
 }
 
-func TestToServicesSanitize(t *testing.T) {
+func TestToServicesValidation(t *testing.T) {
 	svcLabels := map[string]string{
 		"app": "tested-service",
 	}
@@ -682,7 +683,7 @@ func TestToServicesSanitize(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, toServicesL3L4.Sanitize())
+	require.NoError(t, toServicesL3L4.Validate())
 
 	toServicesDenyL3L4 := Rule{
 		EndpointSelector: WildcardEndpointSelector,
@@ -708,7 +709,7 @@ func TestToServicesSanitize(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, toServicesDenyL3L4.Sanitize())
+	require.NoError(t, toServicesDenyL3L4.Validate())
 }
 
 // This test ensures that DNS rules do not accept port ranges
@@ -734,7 +735,7 @@ func TestPortRangesNotAllowedWithDNSRules(t *testing.T) {
 			},
 		},
 	}
-	err := invalidPortRule.Sanitize()
+	err := invalidPortRule.Validate()
 	require.Error(t, err)
 	require.Equal(t, "DNS rules do not support port ranges", err.Error())
 }
@@ -763,7 +764,7 @@ func TestL7RulesWithNodeSelector(t *testing.T) {
 			},
 		},
 	}
-	err := invalidL7RuleIngress.Sanitize()
+	err := invalidL7RuleIngress.Validate()
 	require.Equal(t, "L7 policy is not supported on host ingress yet", err.Error())
 
 	invalidL7RuleEgress := Rule{
@@ -778,7 +779,7 @@ func TestL7RulesWithNodeSelector(t *testing.T) {
 		},
 	}
 
-	err = invalidL7RuleEgress.Sanitize()
+	err = invalidL7RuleEgress.Validate()
 	require.Equal(t, "L7 protocol HTTP is not supported on host egress yet", err.Error())
 
 	validL7RuleEgress := Rule{
@@ -801,7 +802,7 @@ func TestL7RulesWithNodeSelector(t *testing.T) {
 			},
 		},
 	}
-	err = validL7RuleEgress.Sanitize()
+	err = validL7RuleEgress.Validate()
 	require.NoError(t, err)
 
 	validNodeRuleIngress := Rule{
@@ -814,7 +815,7 @@ func TestL7RulesWithNodeSelector(t *testing.T) {
 			},
 		},
 	}
-	err = validNodeRuleIngress.Sanitize()
+	err = validNodeRuleIngress.Validate()
 	require.NoError(t, err)
 
 	validNodeRuleIngressDeny := Rule{
@@ -827,7 +828,7 @@ func TestL7RulesWithNodeSelector(t *testing.T) {
 			},
 		},
 	}
-	err = validNodeRuleIngressDeny.Sanitize()
+	err = validNodeRuleIngressDeny.Validate()
 	require.NoError(t, err)
 }
 
@@ -853,7 +854,7 @@ func TestInvalidEndpointSelectors(t *testing.T) {
 		EndpointSelector: invalidSel,
 	}
 
-	err := invalidEpSelectorRule.Sanitize()
+	err := invalidEpSelectorRule.Validate()
 	require.Error(t, err)
 
 	invalidEpSelectorIngress := Rule{
@@ -867,7 +868,7 @@ func TestInvalidEndpointSelectors(t *testing.T) {
 		},
 	}
 
-	err = invalidEpSelectorIngress.Sanitize()
+	err = invalidEpSelectorIngress.Validate()
 	require.Error(t, err)
 
 	invalidEpSelectorIngressDeny := Rule{
@@ -881,7 +882,7 @@ func TestInvalidEndpointSelectors(t *testing.T) {
 		},
 	}
 
-	err = invalidEpSelectorIngressDeny.Sanitize()
+	err = invalidEpSelectorIngressDeny.Validate()
 	require.Error(t, err)
 
 	invalidEpSelectorEgress := Rule{
@@ -895,7 +896,7 @@ func TestInvalidEndpointSelectors(t *testing.T) {
 		},
 	}
 
-	err = invalidEpSelectorEgress.Sanitize()
+	err = invalidEpSelectorEgress.Validate()
 	require.Error(t, err)
 
 	invalidEpSelectorEgressDeny := Rule{
@@ -909,7 +910,7 @@ func TestInvalidEndpointSelectors(t *testing.T) {
 		},
 	}
 
-	err = invalidEpSelectorEgressDeny.Sanitize()
+	err = invalidEpSelectorEgressDeny.Validate()
 	require.Error(t, err)
 }
 
@@ -933,7 +934,7 @@ func TestPrivilegedNodeSelector(t *testing.T) {
 		NodeSelector: invalidSel,
 		Egress:       []EgressRule{{}},
 	}
-	err := invalidNodeSelectorRule.Sanitize()
+	err := invalidNodeSelectorRule.Validate()
 	require.EqualError(t, err, "invalid label selector: matchExpressions[0].operator: Invalid value: \"asdfasdfasdf\": not a valid selector operator")
 
 	invalidRuleBothSelectors := Rule{
@@ -941,13 +942,13 @@ func TestPrivilegedNodeSelector(t *testing.T) {
 		NodeSelector:     WildcardEndpointSelector,
 		Egress:           []EgressRule{{}},
 	}
-	err = invalidRuleBothSelectors.Sanitize()
+	err = invalidRuleBothSelectors.Validate()
 	require.Equal(t, "rule cannot have both EndpointSelector and NodeSelector", err.Error())
 
 	invalidRuleNoSelector := Rule{
 		Egress: []EgressRule{{}},
 	}
-	err = invalidRuleNoSelector.Sanitize()
+	err = invalidRuleNoSelector.Validate()
 	require.Equal(t, "rule must have one of EndpointSelector or NodeSelector", err.Error())
 }
 
@@ -974,7 +975,7 @@ func TestTooManyPortsRule(t *testing.T) {
 			},
 		},
 	}
-	err := tooManyPortsRule.Sanitize()
+	err := tooManyPortsRule.Validate()
 	require.Error(t, err)
 
 	tooManyDenyPortsRule := Rule{
@@ -990,7 +991,7 @@ func TestTooManyPortsRule(t *testing.T) {
 			},
 		},
 	}
-	err = tooManyDenyPortsRule.Sanitize()
+	err = tooManyDenyPortsRule.Validate()
 	require.Error(t, err)
 }
 
@@ -1013,7 +1014,7 @@ func TestInvalidIPProtocolRules(t *testing.T) {
 		},
 	}
 
-	err := nonZeroPortRule1.Sanitize()
+	err := nonZeroPortRule1.Validate()
 	require.Error(t, err)
 
 	nonZeroPortRule2 := Rule{
@@ -1034,7 +1035,7 @@ func TestInvalidIPProtocolRules(t *testing.T) {
 		},
 	}
 
-	err = nonZeroPortRule2.Sanitize()
+	err = nonZeroPortRule2.Validate()
 	require.Error(t, err)
 }
 
@@ -1061,7 +1062,7 @@ func TestTooManyICMPFields(t *testing.T) {
 			},
 		},
 	}
-	err := tooManyICMPRule.Sanitize()
+	err := tooManyICMPRule.Validate()
 	require.Error(t, err)
 
 	tooManyICMPDenyRule := Rule{
@@ -1077,7 +1078,7 @@ func TestTooManyICMPFields(t *testing.T) {
 			},
 		},
 	}
-	err = tooManyICMPDenyRule.Sanitize()
+	err = tooManyICMPDenyRule.Validate()
 	require.Error(t, err)
 }
 
@@ -1099,7 +1100,7 @@ func TestWrongICMPFieldFamily(t *testing.T) {
 			},
 		},
 	}
-	err := wrongFamilyICMPRule.Sanitize()
+	err := wrongFamilyICMPRule.Validate()
 	require.Error(t, err)
 
 	wrongFamilyICMPDenyRule := Rule{
@@ -1118,7 +1119,7 @@ func TestWrongICMPFieldFamily(t *testing.T) {
 			},
 		},
 	}
-	err = wrongFamilyICMPDenyRule.Sanitize()
+	err = wrongFamilyICMPDenyRule.Validate()
 	require.Error(t, err)
 }
 
@@ -1210,13 +1211,13 @@ func TestICMPRuleWithOtherRuleFailed(t *testing.T) {
 	}
 
 	option.Config.EnableICMPRules = true
-	err := ingressICMPWithPort.Sanitize()
+	err := ingressICMPWithPort.Validate()
 	require.ErrorIs(t, err, errUnsupportedICMPWithToPorts)
-	err = egressICMPWithPort.Sanitize()
+	err = egressICMPWithPort.Validate()
 	require.ErrorIs(t, err, errUnsupportedICMPWithToPorts)
-	err = ingressICMPDenyWithPort.Sanitize()
+	err = ingressICMPDenyWithPort.Validate()
 	require.ErrorIs(t, err, errUnsupportedICMPWithToPorts)
-	err = egressICMPDenyWithPort.Sanitize()
+	err = egressICMPDenyWithPort.Validate()
 	require.ErrorIs(t, err, errUnsupportedICMPWithToPorts)
 }
 
@@ -1227,14 +1228,17 @@ func BenchmarkCIDRSanitize(b *testing.B) {
 	b.ReportAllocs()
 
 	for b.Loop() {
-		err := cidr4.sanitize()
+		err := cidr4.Validate()
 		if err != nil {
 			b.Fatal(err)
 		}
-		err = cidr6.sanitize()
+		cidr4.Sanitize()
+
+		err = cidr6.Validate()
 		if err != nil {
 			b.Fatal(err)
 		}
+		cidr6.Sanitize()
 	}
 }
 
@@ -1298,7 +1302,7 @@ func TestSanitizeDefaultDeny(t *testing.T) {
 		b := tc.before
 		b.EndpointSelector = EndpointSelector{LabelSelector: &slim_metav1.LabelSelector{}}
 
-		err := b.Sanitize()
+		err := b.ValidateAndSanitize()
 		if tc.wantError {
 			assert.Error(t, err)
 			continue

--- a/pkg/policy/api/rule_validation_test.go
+++ b/pkg/policy/api/rule_validation_test.go
@@ -1316,3 +1316,87 @@ func TestSanitizeDefaultDeny(t *testing.T) {
 		assert.Equal(t, tc.wantIngress, *b.EnableDefaultDeny.Ingress, "Rule.EnableDefaultDeny.Ingress should match")
 	}
 }
+
+func TestSanitizeServiceSelector(t *testing.T) {
+	newServiceSelector := func(namespace string, labels map[string]string) Service {
+		return Service{
+			K8sServiceSelector: &K8sServiceSelectorNamespace{
+				Namespace: namespace,
+				Selector:  ServiceSelector(NewESFromMatchRequirements(labels, nil)),
+			},
+		}
+	}
+
+	for _, tc := range []struct {
+		name     string
+		svc      Service
+		expected Service
+		wantErr  bool
+	}{
+		{
+			name: "service selector with dot in name",
+			svc: Service{
+				K8sServiceSelector: &K8sServiceSelectorNamespace{
+					Selector: ServiceSelector{
+						LabelSelector: &slim_metav1.LabelSelector{
+							MatchLabels: map[string]slim_metav1.MatchLabelsValue{
+								"app.kubernetes.io/name": "test-app",
+							},
+						},
+					},
+				},
+			},
+			expected: newServiceSelector("", map[string]string{
+				"any:app.kubernetes.io/name": "test-app",
+			}),
+			wantErr: false,
+		},
+		{
+			name: "service selector with source prefix",
+			svc: Service{
+				K8sServiceSelector: &K8sServiceSelectorNamespace{
+					Selector: ServiceSelector{
+						LabelSelector: &slim_metav1.LabelSelector{
+							MatchLabels: map[string]slim_metav1.MatchLabelsValue{
+								"any:app.kubernetes.io/name": "test-app",
+								"k8s:app.environment":        "staging",
+							},
+						},
+					},
+				},
+			},
+			expected: newServiceSelector("", map[string]string{
+				"any:app.kubernetes.io/name": "test-app",
+				"k8s:app.environment":        "staging",
+			}),
+			wantErr: false,
+		},
+		{
+			name: "invalid label key",
+			svc: Service{
+				K8sServiceSelector: &K8sServiceSelectorNamespace{
+					Selector: ServiceSelector{
+						LabelSelector: &slim_metav1.LabelSelector{
+							MatchLabels: map[string]slim_metav1.MatchLabelsValue{
+								"any:app.kubernetes:io/name": "test-app",
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.svc.Validate()
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			tc.svc.Sanitize()
+			require.Equal(t, tc.expected, tc.svc)
+		})
+	}
+}

--- a/pkg/policy/api/rules_test.go
+++ b/pkg/policy/api/rules_test.go
@@ -266,7 +266,7 @@ func TestRuleMarshalling(t *testing.T) {
 			require.NoError(t, err)
 			require.Equalf(t, tt.inputJSON, string(ruleMarshalled), "Marshalled Rule")
 
-			err = rule.Sanitize()
+			err = rule.ValidateAndSanitize()
 			if tt.expectedErr == sanitizeError {
 				require.Error(t, err)
 				return

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -218,17 +218,22 @@ func (n *EndpointSelector) IsWildcard() bool {
 		len(n.LabelSelector.MatchLabels)+len(n.LabelSelector.MatchExpressions) == 0
 }
 
-func (n *EndpointSelector) Sanitize() error {
+// Validate validates the EndpointSelector object.
+func (n *EndpointSelector) Validate() error {
 	errList := labels.ValidateLabelSelector(n.LabelSelector, labels.LabelSelectorValidationOptions{AllowInvalidLabelValueInSelector: false}, nil)
 	if len(errList) > 0 {
 		return fmt.Errorf("invalid label selector: %w", errList.ToAggregate())
 	}
+	return nil
+}
 
+// Sanitize converts the label selector keys to internal representation prefixed with
+// source information. This method assumes that the EndpointSelector is validated
+// beforehand.
+func (n *EndpointSelector) Sanitize() {
 	es := NewESFromK8sLabelSelector(labels.LabelSourceAnyKeyPrefix, n.LabelSelector)
 	n.cachedLabelSelectorString = es.cachedLabelSelectorString
 	n.LabelSelector = es.LabelSelector
-
-	return nil
 }
 
 // EndpointSelectorSlice is a slice of EndpointSelectors that can be sorted.

--- a/pkg/policy/api/selector_test.go
+++ b/pkg/policy/api/selector_test.go
@@ -277,8 +277,9 @@ func TestEndpointSelectorMarshalling(t *testing.T) {
 				require.ErrorContains(t, err, "unexpected end of JSON input")
 				require.Equal(t, tt.expected, es)
 
-				err = es.Sanitize()
+				err = es.Validate()
 				require.NoError(t, err)
+				es.Sanitize()
 				require.Equal(t, tt.sanitizedExepected, es, "Sanitized EndpointSelector")
 
 				marshalledData, err := json.Marshal(es)
@@ -294,12 +295,14 @@ func TestEndpointSelectorMarshalling(t *testing.T) {
 			require.NoError(t, err)
 			require.Equalf(t, tt.inputJSON, string(esMarshalled), "Marshalled EndpointSelector")
 
-			err = es.Sanitize()
+			err = es.Validate()
 			require.NoError(t, err)
+			es.Sanitize()
 			require.Equal(t, tt.sanitizedExepected, es, "Sanitized EndpointSelector")
 
-			err = es.Sanitize()
+			err = es.Validate()
 			require.NoError(t, err)
+			es.Sanitize()
 			require.Equal(t, tt.sanitizedExepected, es, "Idempotent EndpointSelector sanitization")
 
 			esSanitizedMarshalled, err := json.Marshal(es)
@@ -309,8 +312,9 @@ func TestEndpointSelectorMarshalling(t *testing.T) {
 			sanitizedEs := EndpointSelector{}
 			err = json.Unmarshal(esSanitizedMarshalled, &sanitizedEs)
 			require.NoError(t, err)
-			err = sanitizedEs.Sanitize()
+			err = sanitizedEs.Validate()
 			require.NoError(t, err)
+			sanitizedEs.Sanitize()
 			require.Equal(t, tt.sanitizedExepected, sanitizedEs, "Idempotent EndpointSelector sanitization and marshalling")
 		})
 	}
@@ -375,13 +379,14 @@ func TestEndpointSelectorSanitize(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.input.Sanitize()
+			err := tt.input.Validate()
 			if tt.shouldFail {
 				require.ErrorContains(t, err, "invalid label selector")
 				return
 			}
 
 			require.NoError(t, err)
+			tt.input.Sanitize()
 			require.Equal(t, tt.expected, tt.input)
 		})
 	}

--- a/pkg/policy/api/service.go
+++ b/pkg/policy/api/service.go
@@ -6,6 +6,16 @@ package api
 // ServiceSelector is a label selector for k8s services
 type ServiceSelector EndpointSelector
 
+// Validate the underlying LabelSelector.
+func (s *ServiceSelector) Validate() error {
+	return (*EndpointSelector)(s).Validate()
+}
+
+// Sanitize the EndpointSelector.
+func (s *ServiceSelector) Sanitize() {
+	(*EndpointSelector)(s).Sanitize()
+}
+
 // Service selects policy targets that are bundled as part of a
 // logical load-balanced service.
 //
@@ -15,6 +25,21 @@ type Service struct {
 	K8sServiceSelector *K8sServiceSelectorNamespace `json:"k8sServiceSelector,omitempty"`
 	// K8sService selects service by name and namespace pair
 	K8sService *K8sServiceNamespace `json:"k8sService,omitempty"`
+}
+
+func (s *Service) Validate() error {
+	if s.K8sServiceSelector != nil {
+		if err := s.K8sServiceSelector.Selector.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Service) Sanitize() {
+	if s.K8sServiceSelector != nil {
+		s.K8sServiceSelector.Selector.Sanitize()
+	}
 }
 
 // K8sServiceNamespace selects services by name and, optionally, namespace.

--- a/pkg/policy/cell/policy_importer_test.go
+++ b/pkg/policy/cell/policy_importer_test.go
@@ -120,7 +120,7 @@ func TestAddReplaceRemoveRule(t *testing.T) {
 		t.Helper()
 
 		for _, r := range rules {
-			require.NoError(t, r.Sanitize())
+			require.NoError(t, r.ValidateAndSanitize())
 		}
 
 		dc := make(chan uint64, 1)

--- a/pkg/policy/cell/policy_importer_test.go
+++ b/pkg/policy/cell/policy_importer_test.go
@@ -121,7 +121,7 @@ func TestAddReplaceRemoveRule(t *testing.T) {
 		t.Helper()
 
 		for _, r := range rules {
-			require.NoError(t, r.Sanitize())
+			require.NoError(t, r.ValidateAndSanitize())
 		}
 
 		dc := make(chan uint64, 1)

--- a/pkg/policy/fuzz_test.go
+++ b/pkg/policy/fuzz_test.go
@@ -25,7 +25,7 @@ func FuzzResolvePolicy(f *testing.F) {
 			return
 		}
 		r.EndpointSelector = endpointSelectorA // force the endpoint selector to one that will select, so we definitely evaluate policy
-		err = r.Sanitize()
+		err = r.ValidateAndSanitize()
 		if err != nil {
 			return
 		}

--- a/pkg/policy/k8s/cilium_network_policy.go
+++ b/pkg/policy/k8s/cilium_network_policy.go
@@ -5,7 +5,6 @@ package k8s
 
 import (
 	"context"
-	"fmt"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
@@ -28,6 +27,11 @@ func (p *policyWatcher) onUpsert(
 	dc chan uint64,
 ) error {
 	initialRecvTime := time.Now()
+	scopedLog := p.log.With(
+		logfields.CiliumNetworkPolicyName, cnp.ObjectMeta.Name,
+		logfields.K8sAPIVersion, cnp.TypeMeta.APIVersion,
+		logfields.K8sNamespace, cnp.ObjectMeta.Namespace,
+	)
 
 	defer func() {
 		p.k8sResourceSynced.SetEventTimestamp(apiGroup)
@@ -43,15 +47,21 @@ func (p *policyWatcher) onUpsert(
 			return nil
 		}
 
-		p.log.Debug(
+		scopedLog.Debug(
 			"Modified CiliumNetworkPolicy",
-			logfields.K8sAPIVersion, cnp.TypeMeta.APIVersion,
-			logfields.CiliumNetworkPolicyName, cnp.ObjectMeta.Name,
-			logfields.K8sNamespace, cnp.ObjectMeta.Namespace,
 			logfields.AnnotationsOld, oldCNP.ObjectMeta.Annotations,
 			logfields.Annotations, cnp.ObjectMeta.Annotations,
 		)
 	}
+
+	// Do early validation for CNP object so we don't continue processing invalid objects.
+	if err := cnp.Validate(); err != nil {
+		scopedLog.Error("Invalid CiliumNetworkPolicy")
+		return err
+	}
+
+	// Cache the valid un-sanitized CNP for use when resolving external references.
+	p.cnpCache[key] = cnp
 
 	// check if this cnp was referencing or is now referencing at least one ToServices rule
 	if hasToServices(cnp) {
@@ -67,7 +77,8 @@ func (p *policyWatcher) onUpsert(
 		}
 	}
 
-	return p.resolveCiliumNetworkPolicyRefs(cnp, key, initialRecvTime, resourceID, dc)
+	p.upsertCiliumNetworkPolicyV2(cnp, key, initialRecvTime, resourceID, dc)
+	return nil
 }
 
 func (p *policyWatcher) onDelete(
@@ -90,46 +101,34 @@ func (p *policyWatcher) onDelete(
 	p.k8sResourceSynced.SetEventTimestamp(apiGroup)
 }
 
-// resolveCiliumNetworkPolicyRefs resolves all the references to external resources
-// (e.g. CiliumCIDRGroups) in a CNP/CCNP, inlines them into a "translated" CNP,
-// and then adds the translated CNP to the policy repository.
-// If the CNP was successfully imported, the raw (i.e. untranslated) CNP/CCNP
-// is also added to p.cnpCache.
-func (p *policyWatcher) resolveCiliumNetworkPolicyRefs(
-	cnp *types.SlimCNP,
+// upsertCiliumNetworkPolicyV2 resolves all references to external resources(eg. ToServices),
+// parses the rules and adds them to policy repository.
+//
+// NOTE: This method assumes that the provided CNP object is validated beforehand.
+func (p *policyWatcher) upsertCiliumNetworkPolicyV2(
+	cachedCNP *types.SlimCNP,
 	key resource.Key,
 	initialRecvTime time.Time,
 	resourceID ipcacheTypes.ResourceID,
 	dc chan uint64,
-) error {
-	// We need to deepcopy this structure because we are writing
-	// fields in cnp.Parse() in upsertCiliumNetworkPolicyV2.
-	// See https://github.com/cilium/cilium/blob/27fee207f5422c95479422162e9ea0d2f2b6c770/pkg/policy/api/ingress.go#L112-L134
-	translatedCNP := cnp.DeepCopy()
+) {
+	// DeepCopy the object as it will be mutated by Sanitize and later when resolving
+	// external(eg. toServices) references.
+	cnp := cachedCNP.DeepCopy()
+	cnp.Sanitize()
 
-	// Resolve ToService references
+	// Resolve ToService references if present.
 	if _, exists := p.toServicesPolicies[key]; exists {
-		p.resolveToServices(key, translatedCNP)
+		p.resolveToServices(key, cnp)
 	}
 
-	err := p.upsertCiliumNetworkPolicyV2(translatedCNP, initialRecvTime, resourceID, dc)
-	if err == nil {
-		p.cnpCache[key] = cnp
-	}
-
-	return err
-}
-
-func (p *policyWatcher) upsertCiliumNetworkPolicyV2(cnp *types.SlimCNP, initialRecvTime time.Time, resourceID ipcacheTypes.ResourceID, dc chan uint64) error {
 	scopedLog := p.log.With(
 		logfields.CiliumNetworkPolicyName, cnp.ObjectMeta.Name,
 		logfields.K8sAPIVersion, cnp.TypeMeta.APIVersion,
 		logfields.K8sNamespace, cnp.ObjectMeta.Namespace,
 	)
 
-	scopedLog.Debug(
-		"Adding CiliumNetworkPolicy",
-	)
+	scopedLog.Debug("Adding CiliumNetworkPolicy")
 	namespace := k8sUtils.ExtractNamespace(&cnp.ObjectMeta)
 	if namespace == "" {
 		p.metricsManager.AddCCNP(cnp.CiliumNetworkPolicy)
@@ -137,14 +136,7 @@ func (p *policyWatcher) upsertCiliumNetworkPolicyV2(cnp *types.SlimCNP, initialR
 		p.metricsManager.AddCNP(cnp.CiliumNetworkPolicy)
 	}
 
-	rules, err := cnp.Parse(scopedLog, cmtypes.LocalClusterNameForPolicies(p.clusterMeshPolicyConfig, p.config.ClusterName))
-	if err != nil {
-		scopedLog.Warn(
-			"Unable to add CiliumNetworkPolicy",
-			logfields.Error, err,
-		)
-		return fmt.Errorf("failed to parse CiliumNetworkPolicy %s/%s: %w", cnp.ObjectMeta.Namespace, cnp.ObjectMeta.Name, err)
-	}
+	rules := cnp.ParseRules(scopedLog, cmtypes.LocalClusterNameForPolicies(p.clusterMeshPolicyConfig, p.config.ClusterName))
 	if dc != nil {
 		if cnp.ObjectMeta.Namespace == "" {
 			p.ccnpSyncPending.Add(1)
@@ -159,10 +151,8 @@ func (p *policyWatcher) upsertCiliumNetworkPolicyV2(cnp *types.SlimCNP, initialR
 		Resource:            resourceID,
 		DoneChan:            dc,
 	})
-	scopedLog.Info(
-		"Imported CiliumNetworkPolicy",
-	)
-	return nil
+
+	scopedLog.Info("Imported CiliumNetworkPolicy")
 }
 
 func (p *policyWatcher) deleteCiliumNetworkPolicyV2(cnp *types.SlimCNP, resourceID ipcacheTypes.ResourceID, dc chan uint64) {

--- a/pkg/policy/k8s/cilium_network_policy.go
+++ b/pkg/policy/k8s/cilium_network_policy.go
@@ -5,7 +5,6 @@ package k8s
 
 import (
 	"context"
-	"fmt"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
@@ -28,6 +27,11 @@ func (p *policyWatcher) onUpsert(
 	dc chan uint64,
 ) error {
 	initialRecvTime := time.Now()
+	scopedLog := p.log.With(
+		logfields.CiliumNetworkPolicyName, cnp.ObjectMeta.Name,
+		logfields.K8sAPIVersion, cnp.TypeMeta.APIVersion,
+		logfields.K8sNamespace, cnp.ObjectMeta.Namespace,
+	)
 
 	defer func() {
 		p.k8sResourceSynced.SetEventTimestamp(apiGroup)
@@ -43,15 +47,21 @@ func (p *policyWatcher) onUpsert(
 			return nil
 		}
 
-		p.log.Debug(
+		scopedLog.Debug(
 			"Modified CiliumNetworkPolicy",
-			logfields.K8sAPIVersion, cnp.TypeMeta.APIVersion,
-			logfields.CiliumNetworkPolicyName, cnp.ObjectMeta.Name,
-			logfields.K8sNamespace, cnp.ObjectMeta.Namespace,
 			logfields.AnnotationsOld, oldCNP.ObjectMeta.Annotations,
 			logfields.Annotations, cnp.ObjectMeta.Annotations,
 		)
 	}
+
+	// Do early validation for CNP object so we don't continue processing invalid objects.
+	if err := cnp.Validate(); err != nil {
+		scopedLog.Error("Invalid CiliumNetworkPolicy")
+		return err
+	}
+
+	// Cache the valid un-sanitized CNP for use when resolving external references.
+	p.cnpCache[key] = cnp
 
 	// check if this cnp was referencing or is now referencing at least one ToServices rule
 	if hasToServices(cnp) {
@@ -67,7 +77,8 @@ func (p *policyWatcher) onUpsert(
 		}
 	}
 
-	return p.resolveCiliumNetworkPolicyRefs(cnp, key, initialRecvTime, resourceID, dc)
+	p.upsertCiliumNetworkPolicyV2(cnp, key, initialRecvTime, resourceID, dc)
+	return nil
 }
 
 func (p *policyWatcher) onDelete(
@@ -90,46 +101,34 @@ func (p *policyWatcher) onDelete(
 	p.k8sResourceSynced.SetEventTimestamp(apiGroup)
 }
 
-// resolveCiliumNetworkPolicyRefs resolves all the references to external resources
-// (e.g. CiliumCIDRGroups) in a CNP/CCNP, inlines them into a "translated" CNP,
-// and then adds the translated CNP to the policy repository.
-// If the CNP was successfully imported, the raw (i.e. untranslated) CNP/CCNP
-// is also added to p.cnpCache.
-func (p *policyWatcher) resolveCiliumNetworkPolicyRefs(
-	cnp *types.SlimCNP,
+// upsertCiliumNetworkPolicyV2 resolves all references to external resources(eg. ToServices),
+// parses the rules and adds them to policy repository.
+//
+// NOTE: This method assumes that the provided CNP object is validated beforehand.
+func (p *policyWatcher) upsertCiliumNetworkPolicyV2(
+	cachedCNP *types.SlimCNP,
 	key resource.Key,
 	initialRecvTime time.Time,
 	resourceID ipcacheTypes.ResourceID,
 	dc chan uint64,
-) error {
-	// We need to deepcopy this structure because we are writing
-	// fields in cnp.Parse() in upsertCiliumNetworkPolicyV2.
-	// See https://github.com/cilium/cilium/blob/27fee207f5422c95479422162e9ea0d2f2b6c770/pkg/policy/api/ingress.go#L112-L134
-	translatedCNP := cnp.DeepCopy()
+) {
+	// DeepCopy the object as it will be mutated by Sanitize and later when resolving
+	// external(eg. toServices) references.
+	cnp := cachedCNP.DeepCopy()
+	cnp.Sanitize()
 
-	// Resolve ToService references
+	// Resolve ToService references if present.
 	if _, exists := p.toServicesPolicies[key]; exists {
-		p.resolveToServices(key, translatedCNP)
+		p.resolveToServices(key, cnp)
 	}
 
-	err := p.upsertCiliumNetworkPolicyV2(translatedCNP, initialRecvTime, resourceID, dc)
-	if err == nil {
-		p.cnpCache[key] = cnp
-	}
-
-	return err
-}
-
-func (p *policyWatcher) upsertCiliumNetworkPolicyV2(cnp *types.SlimCNP, initialRecvTime time.Time, resourceID ipcacheTypes.ResourceID, dc chan uint64) error {
 	scopedLog := p.log.With(
 		logfields.CiliumNetworkPolicyName, cnp.ObjectMeta.Name,
 		logfields.K8sAPIVersion, cnp.TypeMeta.APIVersion,
 		logfields.K8sNamespace, cnp.ObjectMeta.Namespace,
 	)
 
-	scopedLog.Debug(
-		"Adding CiliumNetworkPolicy",
-	)
+	scopedLog.Debug("Adding CiliumNetworkPolicy")
 	namespace := k8sUtils.ExtractNamespace(&cnp.ObjectMeta)
 	if namespace == "" {
 		p.metricsManager.AddCCNP(cnp.CiliumNetworkPolicy)
@@ -137,14 +136,7 @@ func (p *policyWatcher) upsertCiliumNetworkPolicyV2(cnp *types.SlimCNP, initialR
 		p.metricsManager.AddCNP(cnp.CiliumNetworkPolicy)
 	}
 
-	rules, err := cnp.Parse(scopedLog, cmtypes.LocalClusterNameForPolicies(p.clusterMeshPolicyConfig, p.clusterInfo.Name))
-	if err != nil {
-		scopedLog.Warn(
-			"Unable to add CiliumNetworkPolicy",
-			logfields.Error, err,
-		)
-		return fmt.Errorf("failed to parse CiliumNetworkPolicy %s/%s: %w", cnp.ObjectMeta.Namespace, cnp.ObjectMeta.Name, err)
-	}
+	rules := cnp.ParseRules(scopedLog, cmtypes.LocalClusterNameForPolicies(p.clusterMeshPolicyConfig, p.clusterInfo.Name))
 	if dc != nil {
 		if cnp.ObjectMeta.Namespace == "" {
 			p.ccnpSyncPending.Add(1)
@@ -159,10 +151,8 @@ func (p *policyWatcher) upsertCiliumNetworkPolicyV2(cnp *types.SlimCNP, initialR
 		Resource:            resourceID,
 		DoneChan:            dc,
 	})
-	scopedLog.Info(
-		"Imported CiliumNetworkPolicy",
-	)
-	return nil
+
+	scopedLog.Info("Imported CiliumNetworkPolicy")
 }
 
 func (p *policyWatcher) deleteCiliumNetworkPolicyV2(cnp *types.SlimCNP, resourceID ipcacheTypes.ResourceID, dc chan uint64) {

--- a/pkg/policy/k8s/service.go
+++ b/pkg/policy/k8s/service.go
@@ -5,7 +5,6 @@ package k8s
 
 import (
 	"context"
-	"errors"
 	"maps"
 	"net/netip"
 	"slices"
@@ -166,23 +165,14 @@ func serviceEventStream(db *statedb.DB, services statedb.Table[*loadbalancer.Ser
 // onServiceEvent processes a ServiceNotification and (if necessary)
 // recalculates all policies affected by this change.
 func (p *policyWatcher) onServiceEvent(event serviceEvent) {
-	err := p.updateToServicesPolicies(event)
-	if err != nil {
-		p.log.Warn(
-			"Failed to recalculate CiliumNetworkPolicy rules after service event",
-			logfields.Error, err,
-			logfields.Event, event,
-		)
-	}
+	p.updateToServicesPolicies(event)
 }
 
 // updateToServicesPolicies is to be invoked when a service has changed (i.e. it was
 // added, removed, its endpoints have changed, or its labels have changed).
 // This function then checks if any of the known CNP/CCNPs are affected by this
 // change, and recomputes them by calling resolveCiliumNetworkPolicyRefs.
-func (p *policyWatcher) updateToServicesPolicies(ev serviceEvent) error {
-	var errs []error
-
+func (p *policyWatcher) updateToServicesPolicies(ev serviceEvent) {
 	// candidatePolicyKeys contains the set of policy names we need to process
 	// for this service update. By default, we consider all policies with
 	// a ToServices selector as candidates.
@@ -223,13 +213,13 @@ func (p *policyWatcher) updateToServicesPolicies(ev serviceEvent) error {
 				logfields.ServiceID, ev.name,
 			)
 		}
-		initialRecvTime := time.Now()
 
+		initialRecvTime := time.Now()
 		resourceID := resourceIDForCiliumNetworkPolicy(key, cnp)
 
-		errs = append(errs, p.resolveCiliumNetworkPolicyRefs(cnp, key, initialRecvTime, resourceID, nil))
+		// CNP retrieved from cnpCache is already validated.
+		p.upsertCiliumNetworkPolicyV2(cnp, key, initialRecvTime, resourceID, nil)
 	}
-	return errors.Join(errs...)
 }
 
 // resolveToServices translates all ToServices rules found in the provided CNP

--- a/pkg/policy/k8s/service.go
+++ b/pkg/policy/k8s/service.go
@@ -353,7 +353,9 @@ type serviceDetailer interface {
 }
 
 // serviceSelectorMatches returns true if the ToServices k8sServiceSelector
-// matches the labels of the provided service svc
+// matches the labels of the provided service svc.
+//
+// NOTE: This method assumes that the selector is validated beforehand.
 func serviceSelectorMatches(sel *api.K8sServiceSelectorNamespace, svc serviceDetailer) bool {
 	if !(sel.Namespace == svc.getNamespace() || sel.Namespace == "") {
 		return false
@@ -368,7 +370,10 @@ type labelsMatcher labels.Labels
 // Lookup implements labels.LabelMatcher
 func (l labelsMatcher) LookupLabel(label *labels.Label) (value string, exists bool) {
 	v, ok := l[label.Key]
-	return v.Value, ok
+	if ok && (label.IsAnySource() || v.Source == label.Source) {
+		return v.Value, true
+	}
+	return "", false
 }
 
 var _ labels.LabelMatcher = labelsMatcher{}

--- a/pkg/policy/k8s/service.go
+++ b/pkg/policy/k8s/service.go
@@ -365,18 +365,6 @@ func serviceSelectorMatches(sel *api.K8sServiceSelectorNamespace, svc serviceDet
 
 type labelsMatcher labels.Labels
 
-// Get implements labels.LabelMatcher; label source is ignored
-func (l labelsMatcher) GetLabel(label *labels.Label) (value string) {
-	v := l[label.Key]
-	return v.Value
-}
-
-// Has implements labels.LabelMatcher.
-func (l labelsMatcher) HasLabel(label *labels.Label) (exists bool) {
-	_, ok := l[label.Key]
-	return ok
-}
-
 // Lookup implements labels.LabelMatcher
 func (l labelsMatcher) LookupLabel(label *labels.Label) (value string, exists bool) {
 	v, ok := l[label.Key]

--- a/pkg/policy/k8s/service_test.go
+++ b/pkg/policy/k8s/service_test.go
@@ -283,8 +283,7 @@ func TestPolicyWatcher_updateToServicesPolicies(t *testing.T) {
 	// Add foo-svc, which is selected by svcByNameCNP twice
 	fooEv := servicesFixture.upsertService(fooSvcID, nil, nil, fooEps, nil)
 
-	err = p.updateToServicesPolicies(fooEv)
-	assert.NoError(t, err)
+	p.updateToServicesPolicies(fooEv)
 	rules = <-policyAdd
 	assert.Len(t, rules, 2)
 
@@ -311,8 +310,7 @@ func TestPolicyWatcher_updateToServicesPolicies(t *testing.T) {
 
 	// Add bar-svc, which is selected by both policies
 	barEv := servicesFixture.upsertService(barSvcID, barSvcLabels, nil, barEps, nil)
-	err = p.updateToServicesPolicies(barEv)
-	assert.NoError(t, err)
+	p.updateToServicesPolicies(barEv)
 
 	// Expect two policies to be updated (in any order)
 	var policies [2]policytypes.PolicyEntries
@@ -359,9 +357,8 @@ func TestPolicyWatcher_updateToServicesPolicies(t *testing.T) {
 
 	// Change foo-svc endpoints, which is selected by svcByNameCNP twice
 	fooEv = servicesFixture.upsertService(fooSvcID, nil, nil, fooEps[:1], &fooEv)
-	err = p.updateToServicesPolicies(fooEv)
+	p.updateToServicesPolicies(fooEv)
 
-	assert.NoError(t, err)
 	byNameRules = <-policyAdd
 	assert.Len(t, byNameRules, 2)
 
@@ -380,8 +377,7 @@ func TestPolicyWatcher_updateToServicesPolicies(t *testing.T) {
 
 	// Delete bar-svc labels. This should remove all CIDRs from svcByLabelCNP
 	barEv = servicesFixture.upsertService(barSvcID, nil, nil, barEps, &barEv)
-	err = p.updateToServicesPolicies(barEv)
-	assert.NoError(t, err)
+	p.updateToServicesPolicies(barEv)
 
 	// Expect two policies to be updated (in any order)
 	oldByNameRules := make(policytypes.PolicyEntries, 0)
@@ -421,8 +417,7 @@ func TestPolicyWatcher_updateToServicesPolicies(t *testing.T) {
 
 	// Add baz-svc, which is selected by svcByLabelCNP
 	bazEv := servicesFixture.upsertService(bazSvcID, barSvcLabels, bazSvcSelector, bazEps, nil)
-	err = p.updateToServicesPolicies(bazEv)
-	assert.NoError(t, err)
+	p.updateToServicesPolicies(bazEv)
 	rules = <-policyAdd
 	assert.Len(t, rules, 1)
 	// Check that Spec was translated
@@ -527,8 +522,7 @@ func TestPolicyWatcher_updateToServicesPoliciesTransformToEndpoint(t *testing.T)
 	}
 
 	fooEv := servicesFixture.upsertService(fooSvcID, nil, fooSvcSelector, nil, nil)
-	err = p.updateToServicesPolicies(fooEv)
-	assert.NoError(t, err)
+	p.updateToServicesPolicies(fooEv)
 	rules = <-policyAdd
 	assert.Len(t, rules, 1)
 
@@ -552,8 +546,7 @@ func TestPolicyWatcher_updateToServicesPoliciesTransformToEndpoint(t *testing.T)
 		"new": "label",
 	}
 	fooEv = servicesFixture.upsertService(fooSvcID, fooSvcLabels, fooSvcSelector, nil, &fooEv)
-	err = p.updateToServicesPolicies(fooEv)
-	assert.NoError(t, err)
+	p.updateToServicesPolicies(fooEv)
 	rules = <-policyAdd
 	assert.Len(t, rules, 1)
 	assert.Len(t, rules[0].L3, 1)
@@ -607,9 +600,8 @@ func TestPolicyWatcher_updateToServicesPoliciesTransformToEndpoint(t *testing.T)
 	assert.Empty(t, rules[0].L3)
 
 	barEv := servicesFixture.upsertService(barSvcID, barSvcLabels, barSvcLabels, nil, nil)
-	err = p.updateToServicesPolicies(barEv)
+	p.updateToServicesPolicies(barEv)
 
-	assert.NoError(t, err)
 	rules = <-policyAdd
 	assert.Len(t, rules, 1)
 	assert.Len(t, rules[0].L3, 1)
@@ -629,8 +621,7 @@ func TestPolicyWatcher_updateToServicesPoliciesTransformToEndpoint(t *testing.T)
 
 	// Delete bar-svc labels. This should remove all toEndpoints from svcByLabelCNP
 	barEv = servicesFixture.upsertService(barSvcID, nil, barSvcLabels, nil, &barEv)
-	err = p.updateToServicesPolicies(barEv)
-	assert.NoError(t, err)
+	p.updateToServicesPolicies(barEv)
 	rules = <-policyAdd
 	assert.Len(t, rules, 1)
 	assert.Empty(t, rules[0].L3)
@@ -653,9 +644,8 @@ func TestPolicyWatcher_updateToServicesPoliciesTransformToEndpoint(t *testing.T)
 
 	// Add foo-svc again, which should re-add the policy
 	fooEv.previous = nil // Bypass change checks
-	err = p.updateToServicesPolicies(fooEv)
+	p.updateToServicesPolicies(fooEv)
 	p.onUpsert(svcByNameCNP, svcByNameKey, k8sAPIGroupCiliumNetworkPolicyV2, svcByNameResourceID, nil)
-	assert.NoError(t, err)
 	rules = <-policyAdd
 	assert.Len(t, rules, 1)
 	assert.Len(t, rules[0].L3, 1)

--- a/pkg/policy/k8s/service_test.go
+++ b/pkg/policy/k8s/service_test.go
@@ -1041,3 +1041,151 @@ func TestServiceEventStream(t *testing.T) {
 		}
 	}
 }
+
+func TestServiceSelectorMatches(t *testing.T) {
+	testSvc := func(lbls map[string]string, source string) serviceDetailer {
+		return serviceEvent{
+			name:   loadbalancer.NewServiceName("test-ns", "test-svc"),
+			labels: labels.Map2Labels(lbls, source),
+		}
+	}
+
+	tests := []struct {
+		name       string
+		sel        *api.K8sServiceSelectorNamespace
+		matches    []serviceDetailer
+		notMatches []serviceDetailer
+	}{
+		{
+			name: "matchLabels",
+			sel: &api.K8sServiceSelectorNamespace{
+				Selector: api.ServiceSelector{
+					LabelSelector: &slim_metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "bar"},
+					},
+				},
+			},
+			matches: []serviceDetailer{
+				testSvc(map[string]string{"app": "bar"}, "k8s"),
+				testSvc(map[string]string{"app": "bar"}, "other"),
+			},
+			notMatches: []serviceDetailer{
+				testSvc(map[string]string{"app": "baz"}, "k8s"),
+				testSvc(map[string]string{"any.app": "bar"}, "k8s"),
+			},
+		},
+		{
+			name: "matchLabels - dotted key",
+			sel: &api.K8sServiceSelectorNamespace{
+				Selector: api.ServiceSelector{
+					LabelSelector: &slim_metav1.LabelSelector{
+						MatchLabels: map[string]string{"app.kubernetes.io/name": "my-app"},
+					},
+				},
+			},
+			matches: []serviceDetailer{
+				testSvc(map[string]string{"app.kubernetes.io/name": "my-app"}, "k8s"),
+				testSvc(map[string]string{"app.kubernetes.io/name": "my-app"}, "any"),
+			},
+			notMatches: []serviceDetailer{
+				testSvc(map[string]string{"app.kubernetes.io/name": "not-my-app"}, "k8s"),
+			},
+		},
+		{
+			name: "matchExpression",
+			sel: &api.K8sServiceSelectorNamespace{
+				Selector: api.ServiceSelector{
+					LabelSelector: &slim_metav1.LabelSelector{
+						MatchExpressions: []slim_metav1.LabelSelectorRequirement{
+							{Key: "app.kubernetes.io/name", Operator: slim_metav1.LabelSelectorOpExists},
+						},
+					},
+				},
+			},
+			matches: []serviceDetailer{
+				testSvc(map[string]string{"app.kubernetes.io/name": "my-app"}, "k8s"),
+				testSvc(map[string]string{"app.kubernetes.io/name": "my-app"}, "any"),
+			},
+			notMatches: []serviceDetailer{
+				testSvc(map[string]string{"apps.kubernetes.io/name": "not-my-app"}, "k8s"),
+			},
+		},
+		{
+			name: "matchLabels - k8s source prefix",
+			sel: &api.K8sServiceSelectorNamespace{
+				Selector: api.ServiceSelector{
+					LabelSelector: &slim_metav1.LabelSelector{
+						MatchLabels: map[string]string{"k8s:app": "my-app"},
+					},
+				},
+			},
+			matches: []serviceDetailer{
+				testSvc(map[string]string{"app": "my-app"}, "k8s"),
+			},
+			notMatches: []serviceDetailer{
+				testSvc(map[string]string{"app": "my-app"}, "other"),
+				testSvc(map[string]string{"app": "not-my-app"}, "k8s"),
+			},
+		},
+		{
+			name: "matchLabels - any source prefix",
+			sel: &api.K8sServiceSelectorNamespace{
+				Selector: api.ServiceSelector{
+					LabelSelector: &slim_metav1.LabelSelector{
+						MatchLabels: map[string]string{"any:app": "my-app"},
+					},
+				},
+			},
+			matches: []serviceDetailer{
+				testSvc(map[string]string{"app": "my-app"}, "k8s"),
+				testSvc(map[string]string{"app": "my-app"}, "other"),
+			},
+			notMatches: []serviceDetailer{
+				testSvc(map[string]string{"app": "not-my-app"}, "k8s"),
+			},
+		},
+		{
+			name: "matchLabels and matchExpressions",
+			sel: &api.K8sServiceSelectorNamespace{
+				Selector: api.ServiceSelector{
+					LabelSelector: &slim_metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "bar"},
+						MatchExpressions: []slim_metav1.LabelSelectorRequirement{
+							{Key: "app.kubernetes.io/name", Operator: slim_metav1.LabelSelectorOpIn, Values: []string{"my-app"}},
+							{Key: "k8s:env", Operator: slim_metav1.LabelSelectorOpExists},
+						},
+					},
+				},
+			},
+			matches: []serviceDetailer{
+				testSvc(map[string]string{
+					"app.kubernetes.io/name": "my-app",
+					"app":                    "bar",
+					"env":                    "prod",
+				}, "k8s"),
+			},
+			notMatches: []serviceDetailer{
+				testSvc(map[string]string{
+					"app.kubernetes.io/name": "my-app",
+					"env":                    "prod",
+				}, "k8s"),
+				testSvc(map[string]string{
+					"app.kubernetes.io/name": "my-app",
+					"app":                    "bar",
+					"env":                    "prod",
+				}, "other"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, svc := range tt.matches {
+				require.True(t, serviceSelectorMatches(tt.sel, svc))
+			}
+			for _, svc := range tt.notMatches {
+				require.False(t, serviceSelectorMatches(tt.sel, svc))
+			}
+		})
+	}
+}

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -369,7 +369,7 @@ func (td *testData) policyInvalid(t *testing.T, errStr string, rules ...*api.Rul
 		if r.EndpointSelector.LabelSelector == nil {
 			r.EndpointSelector = endpointSelectorA
 		}
-		require.NoError(t, r.Sanitize())
+		require.NoError(t, r.ValidateAndSanitize())
 	}
 	td.repo.ReplaceByResource(utils.RulesToPolicyEntries(rules), "dummy-resource")
 
@@ -386,7 +386,7 @@ func (td *testData) policyValid(t *testing.T, rules ...*api.Rule) {
 		if r.EndpointSelector.LabelSelector == nil {
 			r.EndpointSelector = endpointSelectorA
 		}
-		require.NoError(t, r.Sanitize())
+		require.NoError(t, r.ValidateAndSanitize())
 	}
 	td.repo.ReplaceByResource(utils.RulesToPolicyEntries(rules), "dummy-resource")
 

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -372,7 +372,7 @@ func (td *testData) policyInvalid(t *testing.T, errStr string, rules ...*api.Rul
 		if r.EndpointSelector.LabelSelector == nil {
 			r.EndpointSelector = endpointSelectorA
 		}
-		require.NoError(t, r.Sanitize())
+		require.NoError(t, r.ValidateAndSanitize())
 	}
 	td.repo.ReplaceByResource(utils.RulesToPolicyEntries(rules), "dummy-resource")
 
@@ -389,7 +389,7 @@ func (td *testData) policyValid(t *testing.T, rules ...*api.Rule) {
 		if r.EndpointSelector.LabelSelector == nil {
 			r.EndpointSelector = endpointSelectorA
 		}
-		require.NoError(t, r.Sanitize())
+		require.NoError(t, r.ValidateAndSanitize())
 	}
 	td.repo.ReplaceByResource(utils.RulesToPolicyEntries(rules), "dummy-resource")
 

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -258,8 +258,7 @@ func (p *Repository) releaseRule(r *rule) {
 // unit-testing purposes only. Panics if the rule is invalid
 func (p *Repository) MustAddList(rules api.Rules) (ruleSlice, uint64) {
 	for i := range rules {
-		err := rules[i].Sanitize()
-		if err != nil {
+		if err := rules[i].ValidateAndSanitize(); err != nil {
 			panic(err)
 		}
 	}

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -261,8 +261,7 @@ func (p *Repository) releaseRule(r *rule) {
 // unit-testing purposes only. Panics if the rule is invalid
 func (p *Repository) MustAddList(rules api.Rules) (ruleSlice, uint64) {
 	for i := range rules {
-		err := rules[i].Sanitize()
-		if err != nil {
+		if err := rules[i].ValidateAndSanitize(); err != nil {
 			panic(err)
 		}
 	}

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -77,7 +77,6 @@ func (epd *PerSelectorPolicy) appendL7WildcardRule(policyContext PolicyContext) 
 		// Wildcarding at L7 for DNS is specified via allowing all via
 		// MatchPattern!
 		rule := api.PortRuleDNS{MatchPattern: "*"}
-		rule.Sanitize()
 		if !rule.Exists(epd.L7Rules) {
 			policyContext.PolicyTrace("   Merging DNS wildcard rule: %+v\n", rule)
 			epd.L7Rules.DNS = append(epd.L7Rules.DNS, rule)

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -55,7 +55,7 @@ func TestL4Policy(t *testing.T) {
 	}
 
 	// Transform to PolicyEntries and set priority level to 0.5
-	require.NoError(t, rule1.Sanitize())
+	require.NoError(t, rule1.ValidateAndSanitize())
 	entries := utils.RulesToPolicyEntries(api.Rules{rule1})
 	require.Len(t, entries, 2)
 	for i := range entries {
@@ -533,7 +533,7 @@ func TestRuleWithNoEndpointSelector(t *testing.T) {
 		},
 	}
 
-	err := apiRule1.Sanitize()
+	err := apiRule1.ValidateAndSanitize()
 	require.Error(t, err)
 }
 
@@ -570,7 +570,7 @@ func TestL3Policy(t *testing.T) {
 		},
 	}
 
-	err := apiRule1.Sanitize()
+	err := apiRule1.ValidateAndSanitize()
 	require.NoError(t, err)
 
 	// Must be parsable, make sure Validate fails when not.
@@ -581,7 +581,7 @@ func TestL3Policy(t *testing.T) {
 				FromCIDR: []api.CIDR{"10.0.1..0/24"},
 			},
 		}},
-	}).Sanitize()
+	}).Validate()
 	require.Error(t, err)
 
 	// Test CIDRRule with no provided CIDR or ExceptionCIDR.
@@ -593,7 +593,7 @@ func TestL3Policy(t *testing.T) {
 				FromCIDRSet: []api.CIDRRule{{Cidr: "", ExceptCIDRs: nil}},
 			},
 		}},
-	}).Sanitize()
+	}).Validate()
 	require.Error(t, err)
 
 	// Test CIDRRule with only CIDR provided; should not fail, as ExceptionCIDR
@@ -605,7 +605,7 @@ func TestL3Policy(t *testing.T) {
 				FromCIDRSet: []api.CIDRRule{{Cidr: "10.0.1.0/24", ExceptCIDRs: nil}},
 			},
 		}},
-	}).Sanitize()
+	}).Validate()
 	require.NoError(t, err)
 
 	// Cannot provide just an IP to a CIDRRule; Cidr must be of format
@@ -617,7 +617,7 @@ func TestL3Policy(t *testing.T) {
 				FromCIDRSet: []api.CIDRRule{{Cidr: "10.0.1.32", ExceptCIDRs: nil}},
 			},
 		}},
-	}).Sanitize()
+	}).Validate()
 	require.Error(t, err)
 
 	// Cannot exclude a range that is not part of the CIDR.
@@ -628,7 +628,7 @@ func TestL3Policy(t *testing.T) {
 				FromCIDRSet: []api.CIDRRule{{Cidr: "10.0.0.0/10", ExceptCIDRs: []api.CIDR{"10.64.0.0/11"}}},
 			},
 		}},
-	}).Sanitize()
+	}).Validate()
 	require.Error(t, err)
 
 	// Must have a contiguous mask, make sure Validate fails when not.
@@ -639,7 +639,7 @@ func TestL3Policy(t *testing.T) {
 				FromCIDR: []api.CIDR{"10.0.1.0/128.0.0.128"},
 			},
 		}},
-	}).Sanitize()
+	}).Validate()
 	require.Error(t, err)
 
 	// Prefix length must be in range for the address, make sure
@@ -651,7 +651,7 @@ func TestL3Policy(t *testing.T) {
 				FromCIDR: []api.CIDR{"10.0.1.0/34"},
 			},
 		}},
-	}).Sanitize()
+	}).Validate()
 	require.Error(t, err)
 }
 
@@ -1023,7 +1023,7 @@ func TestEgressRuleRestrictions(t *testing.T) {
 		},
 	}
 
-	err := apiRule1.Sanitize()
+	err := apiRule1.Validate()
 	require.Error(t, err)
 }
 
@@ -1038,15 +1038,15 @@ func TestPolicyEntityValidationEgress(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, r.Sanitize())
+	require.NoError(t, r.ValidateAndSanitize())
 	require.Len(t, r.Egress[0].ToEntities, 1)
 
 	r.Egress[0].ToEntities = []api.Entity{api.EntityHost}
-	require.NoError(t, r.Sanitize())
+	require.NoError(t, r.ValidateAndSanitize())
 	require.Len(t, r.Egress[0].ToEntities, 1)
 
 	r.Egress[0].ToEntities = []api.Entity{"trololo"}
-	require.Error(t, r.Sanitize())
+	require.Error(t, r.ValidateAndSanitize())
 }
 
 func TestPolicyEntityValidationIngress(t *testing.T) {
@@ -1060,15 +1060,15 @@ func TestPolicyEntityValidationIngress(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, r.Sanitize())
+	require.NoError(t, r.ValidateAndSanitize())
 	require.Len(t, r.Ingress[0].FromEntities, 1)
 
 	r.Ingress[0].FromEntities = []api.Entity{api.EntityHost}
-	require.NoError(t, r.Sanitize())
+	require.NoError(t, r.ValidateAndSanitize())
 	require.Len(t, r.Ingress[0].FromEntities, 1)
 
 	r.Ingress[0].FromEntities = []api.Entity{"trololo"}
-	require.Error(t, r.Sanitize())
+	require.Error(t, r.ValidateAndSanitize())
 }
 
 func TestPolicyEntityValidationEntitySelectorsFill(t *testing.T) {
@@ -1089,7 +1089,7 @@ func TestPolicyEntityValidationEntitySelectorsFill(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, r.Sanitize())
+	require.NoError(t, r.ValidateAndSanitize())
 	require.Len(t, r.Ingress[0].FromEntities, 2)
 	require.Len(t, r.Egress[0].ToEntities, 2)
 }

--- a/pkg/policy/test/regenerate_retry_test.go
+++ b/pkg/policy/test/regenerate_retry_test.go
@@ -93,7 +93,7 @@ func TestRegenerateRetries(t *testing.T) {
 			labels.NewLabel(k8sConst.PolicyLabelName, "retryRule", labels.LabelSourceAny),
 		},
 	}
-	require.NoError(t, rule.Sanitize())
+	require.NoError(t, rule.ValidateAndSanitize())
 
 	done := make(chan uint64, 1)
 	f.importer.UpdatePolicy(&policytypes.PolicyUpdate{

--- a/pkg/policy/test/updatepolicy_bench_test.go
+++ b/pkg/policy/test/updatepolicy_bench_test.go
@@ -90,7 +90,7 @@ func runUpdatePolicyBench(b *testing.B, numEPs, numIDs int) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		rule := makeRuleSelectingAllIdentities(numIDs, i)
-		require.NoError(b, rule.Sanitize())
+		require.NoError(b, rule.ValidateAndSanitize())
 
 		done := make(chan uint64, 1)
 		start := time.Now()


### PR DESCRIPTION
See commit message for details.

While working on this PR I see that ToServices selectors are not resolved for [policy script commands](https://github.com/cilium/cilium/blob/b3d4b354ae780c846fd422d1f6f0ee071f48b068/pkg/policy/cell/script_cmds.go#L81-L97) and [directory watcher](https://github.com/cilium/cilium/blob/b3d4b354ae780c846fd422d1f6f0ee071f48b068/pkg/policy/directory/watcher.go#L199-L222) implementation. Will fix these code paths in a follow up PR.