### PR TITLE
Fix: Prune Removed ParentRefs During L4 Route Status Reconciliation

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -2204,6 +2204,7 @@ func (r *gatewayReconciler) setTCPRouteStatuses(scopedLog *slog.Logger, ctx cont
 	for tcpRouteIndex, original := range tcpRoutes.Items {
 
 		tcpr := original.DeepCopy()
+		tcpr.Status.Parents = pruneRouteParentStatuses(tcpr.Status.Parents, tcpr.Spec.ParentRefs, r.controllerName)
 
 		i := &routechecks.TCPRouteInput{
 			Ctx:            ctx,
@@ -2235,6 +2236,7 @@ func (r *gatewayReconciler) setUDPRouteStatuses(scopedLog *slog.Logger, ctx cont
 	for udpRouteIndex, original := range udpRoutes.Items {
 
 		udpr := original.DeepCopy()
+		udpr.Status.Parents = pruneRouteParentStatuses(udpr.Status.Parents, udpr.Spec.ParentRefs, r.controllerName)
 
 		i := &routechecks.UDPRouteInput{
 			Ctx:            ctx,

--- a/operator/pkg/gateway-api/status_route_test.go
+++ b/operator/pkg/gateway-api/status_route_test.go
@@ -4,13 +4,17 @@
 package gateway_api
 
 import (
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/routechecks"
 )
 
@@ -108,4 +112,52 @@ func TestPruneRouteParentStatuses(t *testing.T) {
 	require.Equal(t, gatewayv1.GatewayController("example.com/other-gateway-controller"), route.Status.Parents[0].ControllerName, "prune removes only the detached Cilium-owned status")
 	require.Equal(t, currentParentStatus, route.Status.Parents[1].ParentRef, "prune removes only the detached Cilium-owned status")
 	require.Equal(t, gatewayv1.GatewayController(defaultControllerName), route.Status.Parents[1].ControllerName, "prune removes only the detached Cilium-owned status")
+}
+
+func TestSetTCPRouteStatusesPrunesDetachedParents(t *testing.T) {
+	route := &gatewayv1.TCPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "route", Namespace: "default"},
+		Status: gatewayv1.TCPRouteStatus{RouteStatus: gatewayv1.RouteStatus{Parents: []gatewayv1.RouteParentStatus{{
+			ParentRef:      gatewayv1.ParentReference{Name: "detached-gateway"},
+			ControllerName: gatewayv1.GatewayController(defaultControllerName),
+		}}}},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+		WithStatusSubresource(&gatewayv1.TCPRoute{}).
+		WithObjects(route).
+		Build()
+	routes := &gatewayv1.TCPRouteList{}
+	require.NoError(t, c.List(t.Context(), routes))
+
+	r := &gatewayReconciler{Client: c, controllerName: defaultControllerName}
+	require.NoError(t, r.setTCPRouteStatuses(slog.Default(), t.Context(), routes, &gatewayv1.ReferenceGrantList{}))
+
+	updated := &gatewayv1.TCPRoute{}
+	require.NoError(t, c.Get(t.Context(), client.ObjectKeyFromObject(route), updated))
+	require.Empty(t, updated.Status.Parents)
+}
+
+func TestSetUDPRouteStatusesPrunesDetachedParents(t *testing.T) {
+	route := &gatewayv1.UDPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "route", Namespace: "default"},
+		Status: gatewayv1.UDPRouteStatus{RouteStatus: gatewayv1.RouteStatus{Parents: []gatewayv1.RouteParentStatus{{
+			ParentRef:      gatewayv1.ParentReference{Name: "detached-gateway"},
+			ControllerName: gatewayv1.GatewayController(defaultControllerName),
+		}}}},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+		WithStatusSubresource(&gatewayv1.UDPRoute{}).
+		WithObjects(route).
+		Build()
+	routes := &gatewayv1.UDPRouteList{}
+	require.NoError(t, c.List(t.Context(), routes))
+
+	r := &gatewayReconciler{Client: c, controllerName: defaultControllerName}
+	require.NoError(t, r.setUDPRouteStatuses(slog.Default(), t.Context(), routes, &gatewayv1.ReferenceGrantList{}))
+
+	updated := &gatewayv1.UDPRoute{}
+	require.NoError(t, c.Get(t.Context(), client.ObjectKeyFromObject(route), updated))
+	require.Empty(t, updated.Status.Parents)
 }


### PR DESCRIPTION
The TCPRoute and UDPRoute status reconciliation paths deep-copy each Route object and recalculate conditions for the current spec.parentRefs, but they do not remove Cilium-managed status.parents entries whose ParentRefs were removed from the spec.
  
As a reference, `setHTTPRouteStatuses()` and `setTLSRouteStatuses()` call `pruneRouteParentStatuses()` before recalculating status. `setTCPRouteStatuses()` and `setUDPRouteStatuses()` were missing this call.

As a result, after a user removes or changes a TCPRoute or UDPRoute ParentRef, Cilium can retain an obsolete parent status entry. Users may observe a deleted listener attachment still reported as Accepted=True in status.parents.

```
  apiVersion: gateway.networking.k8s.io/v1
  kind: TCPRoute
  metadata:
    name: tcp-app-1
  spec:
    parentRefs:
      - name: my-tcp-gateway
        sectionName: bar           # Current ParentRef
  status:
    parents:
      - controllerName: io.cilium/gateway-controller
        parentRef:
          name: my-tcp-gateway
          sectionName: foo        # Removed ParentRef, but stale status remains
        conditions:
          - type: Accepted
            status: "True"
            reason: Accepted

```


<!-- Description of change -->

Fixes: https://github.com/cilium/cilium/pull/46184

```release-note
Fix: Prune Removed ParentRefs During L4 Route Status Reconciliation
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
