### PR TITLE
lbmap: display proxy port for L7 services

### DIFF
--- a/pkg/loadbalancer/maps/types.go
+++ b/pkg/loadbalancer/maps/types.go
@@ -216,6 +216,10 @@ func (s *Service4Value) New() bpf.MapValue { return &Service4Value{} }
 
 func (s *Service4Value) String() string {
 	sHost := s.ToHost().(*Service4Value)
+	if loadbalancer.ServiceFlags(sHost.GetFlags()).IsL7LB() {
+		return fmt.Sprintf("%d %d[%d] (%d) [0x%x 0x%x]",
+			sHost.GetL7LBProxyPort(), sHost.Count, sHost.QCount, sHost.RevNat, sHost.Flags, sHost.Flags2)
+	}
 	return fmt.Sprintf("%d %d[%d] (%d) [0x%x 0x%x]", sHost.BackendID, sHost.Count, sHost.QCount, sHost.RevNat, sHost.Flags, sHost.Flags2)
 }
 
@@ -263,7 +267,7 @@ func (s *Service4Value) SetL7LBProxyPort(port uint16) {
 }
 
 func (s *Service4Value) GetL7LBProxyPort() uint16 {
-	return byteorder.HostToNetwork16(uint16(s.BackendID))
+	return byteorder.NetworkToHost16(uint16(s.BackendID))
 }
 
 func (s *Service4Value) SetBackendID(id loadbalancer.BackendID) {


### PR DESCRIPTION
## Summary

When dumping entries from `cilium_lb4_services_v2`, L7 service entries are
currently displayed using the `BackendID` field.

For L7 services, however, this field does not represent a backend ID. It
stores the Envoy proxy port in network byte order. Since
`Service4Value.String()` prints the raw field directly, the displayed value
is byte-swapped on little-endian systems, making the output misleading.

This PR detects L7 service entries via the `L7LB` service flag and displays
the decoded proxy port instead, so that the output reflects the actual
forwarding destination.

## Reproducer

Create a Gateway API service backed by the Cilium L7 proxy.

```console
$ kubectl get svc -n horizon-system cilium-gateway-horizon-gateway

NAME                             TYPE           CLUSTER-IP    EXTERNAL-IP   PORT(S)
cilium-gateway-horizon-gateway   LoadBalancer   10.43.2.169   10.251.8.82   80:32201/TCP
```

The Envoy proxy allocated for this Gateway is listening on port `18036`:

```console
$ netstat -anp | grep cilium-envoy | grep LISTEN

tcp  0  0 127.0.0.1:18036  0.0.0.0:*  LISTEN  2472775/cilium-envoy
```

The allocated proxy port is also recorded in Cilium's proxy state:

```console
$ cat /var/run/cilium/state/proxy_ports_state.json

{
  "horizon-system/cilium-gateway-horizon-gateway/listener": {
    "type": "crd",
    "ingress": false,
    "port": 18036
  }
}
```

However, dumping the service map shows:

```console
$ cilium map get cilium_lb4_services_v2 | grep 10.251.8.82

10.251.8.82:80/TCP (0)    29766 0[0] (204) [0x60 0x4]
```

The value `29766` is not the actual proxy port. It is the raw network-byte-order
representation of `18036` interpreted as a host-order integer.

As a result, the output can be confusing when troubleshooting L7 load balancer
entries.

## Root Cause

For L7 service entries, the value stored in `BackendID` is actually the Envoy
proxy port encoded in network byte order.

`Service4Value.String()` always prints the raw `BackendID` field, so the proxy
port is displayed incorrectly on little-endian architectures.

## Fix

This PR updates `Service4Value.String()` to detect L7 service entries using the
`L7LB` service flag.

Instead of printing the raw `BackendID` field, it uses `GetL7LBProxyPort()` to
decode the stored value into host byte order before formatting the output.

### Before

```console
10.251.8.82:80/TCP (0)    29766 0[0] (204) [0x60 0x4]
```

### After

```console
10.251.8.82:80/TCP (0)    18036 0[0] (204) [0x60 0x4]
```

This change only affects the string representation used when dumping service map
entries. It does not modify datapath behavior or the contents of the BPF maps.