### PR TITLE
node: Migrate `IPv{4,6}IngressIP` to netip

### DIFF
--- a/daemon/infraendpoints/infra_ip_allocation.go
+++ b/daemon/infraendpoints/infra_ip_allocation.go
@@ -425,7 +425,7 @@ func (r *infraIPAllocator) allocateHealthIPs(oldV4HealthIP netip.Addr, oldV6Heal
 	return nil
 }
 
-func (r *infraIPAllocator) allocateIngressIPs(oldV4IngressIP net.IP, oldV6IngressIP net.IP) error {
+func (r *infraIPAllocator) allocateIngressIPs(oldV4IngressIP netip.Addr, oldV6IngressIP netip.Addr) error {
 	if !r.daemonConfig.EnableEnvoyConfig {
 		return nil
 	}
@@ -436,8 +436,8 @@ func (r *infraIPAllocator) allocateIngressIPs(oldV4IngressIP net.IP, oldV6Ingres
 		var err error
 
 		// Reallocate the same address as before, if possible
-		if ingressIPv4 != nil {
-			result, err = r.ipAllocator.AllocateIPWithoutSyncUpstream(iputil.AddrFromIP(ingressIPv4), "ingress", ipam.PoolDefault())
+		if ingressIPv4.IsValid() {
+			result, err = r.ipAllocator.AllocateIPWithoutSyncUpstream(ingressIPv4, "ingress", ipam.PoolDefault())
 			if err != nil {
 				r.logger.Warn("unable to re-allocate ingress IPv4.",
 					logfields.Error, err,
@@ -464,8 +464,8 @@ func (r *infraIPAllocator) allocateIngressIPs(oldV4IngressIP net.IP, oldV6Ingres
 			result.CIDRs = r.coalesceCIDRs(result.CIDRs)
 		}
 
-		ingressIPv4 = net.IP(result.IP.AsSlice()).To16()
-		r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv4IngressIP = net.IP(result.IP.AsSlice()).To16() })
+		ingressIPv4 = result.IP
+		r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv4IngressIP = iputil.AddrFrom(result.IP) })
 		r.logger.Debug("Allocated IPv4 Ingress address", logfields.IPAddr, result.IP)
 
 		// In ENI and AlibabaCloud ENI mode, we require the gateway, CIDRs, and the
@@ -493,8 +493,8 @@ func (r *infraIPAllocator) allocateIngressIPs(oldV4IngressIP net.IP, oldV6Ingres
 
 		// Reallocate the same address as before, if possible
 		ingressIPv6 := oldV6IngressIP
-		if ingressIPv6 != nil {
-			result, err = r.ipAllocator.AllocateIPWithoutSyncUpstream(iputil.AddrFromIP(ingressIPv6), "ingress", ipam.PoolDefault())
+		if ingressIPv6.IsValid() {
+			result, err = r.ipAllocator.AllocateIPWithoutSyncUpstream(ingressIPv6, "ingress", ipam.PoolDefault())
 			if err != nil {
 				r.logger.Warn("unable to re-allocate ingress IPv6.",
 					logfields.Error, err,
@@ -509,9 +509,9 @@ func (r *infraIPAllocator) allocateIngressIPs(oldV4IngressIP net.IP, oldV6Ingres
 		if result == nil {
 			result, err = r.ipAllocator.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv6, "ingress", ipam.PoolDefault())
 			if err != nil {
-				if ingressIPv4 != nil {
-					r.ipAllocator.ReleaseIP(iputil.AddrFromIP(ingressIPv4), ipam.PoolDefault())
-					r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv4IngressIP = nil })
+				if ingressIPv4.IsValid() {
+					r.ipAllocator.ReleaseIP(ingressIPv4, ipam.PoolDefault())
+					r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv4IngressIP = iputil.Addr{} })
 				}
 				return fmt.Errorf("unable to allocate ingress IPs: %w, see https://cilium.link/ipam-range-full", err)
 			}
@@ -525,7 +525,7 @@ func (r *infraIPAllocator) allocateIngressIPs(oldV4IngressIP net.IP, oldV6Ingres
 			result.CIDRs = r.coalesceCIDRs(result.CIDRs)
 		}
 
-		r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv6IngressIP = net.IP(result.IP.AsSlice()).To16() })
+		r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv6IngressIP = iputil.AddrFrom(result.IP) })
 		r.logger.Debug("Allocated IPv6 Ingress address", logfields.IPAddr, result.IP)
 	}
 
@@ -553,7 +553,7 @@ func (r *infraIPAllocator) AllocateIPs(ctx context.Context) error {
 		return fmt.Errorf("failed to allocate service loopback IPs: %w", err)
 	}
 
-	if err := r.allocateIngressIPs(localNode.IPv4IngressIP, localNode.IPv6IngressIP); err != nil {
+	if err := r.allocateIngressIPs(localNode.IPv4IngressIP.Addr, localNode.IPv6IngressIP.Addr); err != nil {
 		return fmt.Errorf("failed to allocate ingress IPs: %w", err)
 	}
 

--- a/daemon/infraendpoints/infra_ip_allocation.go
+++ b/daemon/infraendpoints/infra_ip_allocation.go
@@ -472,7 +472,7 @@ func (r *infraIPAllocator) allocateHealthIPs(ctx context.Context, oldV4HealthIP 
 	return nil
 }
 
-func (r *infraIPAllocator) allocateIngressIPs(ctx context.Context, oldV4IngressIP net.IP, oldV6IngressIP net.IP) error {
+func (r *infraIPAllocator) allocateIngressIPs(ctx context.Context, oldV4IngressIP netip.Addr, oldV6IngressIP netip.Addr) error {
 	if !r.daemonConfig.EnableEnvoyConfig {
 		return nil
 	}
@@ -483,8 +483,8 @@ func (r *infraIPAllocator) allocateIngressIPs(ctx context.Context, oldV4IngressI
 		var err error
 
 		// Reallocate the same address as before, if possible
-		if ingressIPv4 != nil {
-			result, err = r.ipAllocator.AllocateIPWithoutSyncUpstream(iputil.AddrFromIP(ingressIPv4), "ingress", ipam.PoolDefault())
+		if ingressIPv4.IsValid() {
+			result, err = r.ipAllocator.AllocateIPWithoutSyncUpstream(ingressIPv4, "ingress", ipam.PoolDefault())
 			if err != nil {
 				r.logger.Warn("unable to re-allocate ingress IPv4.",
 					logfields.Error, err,
@@ -511,8 +511,8 @@ func (r *infraIPAllocator) allocateIngressIPs(ctx context.Context, oldV4IngressI
 			result.CIDRs = r.coalesceCIDRs(result.CIDRs)
 		}
 
-		ingressIPv4 = net.IP(result.IP.AsSlice()).To16()
-		r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv4IngressIP = net.IP(result.IP.AsSlice()).To16() })
+		ingressIPv4 = result.IP
+		r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv4IngressIP = iputil.AddrFrom(result.IP) })
 		r.logger.Debug("Allocated IPv4 Ingress address", logfields.IPAddr, result.IP)
 
 		// In ENI and AlibabaCloud ENI mode, we require the gateway, CIDRs, and the
@@ -549,8 +549,8 @@ func (r *infraIPAllocator) allocateIngressIPs(ctx context.Context, oldV4IngressI
 
 		// Reallocate the same address as before, if possible
 		ingressIPv6 := oldV6IngressIP
-		if ingressIPv6 != nil {
-			result, err = r.ipAllocator.AllocateIPWithoutSyncUpstream(iputil.AddrFromIP(ingressIPv6), "ingress", ipam.PoolDefault())
+		if ingressIPv6.IsValid() {
+			result, err = r.ipAllocator.AllocateIPWithoutSyncUpstream(ingressIPv6, "ingress", ipam.PoolDefault())
 			if err != nil {
 				r.logger.Warn("unable to re-allocate ingress IPv6.",
 					logfields.Error, err,
@@ -565,9 +565,9 @@ func (r *infraIPAllocator) allocateIngressIPs(ctx context.Context, oldV4IngressI
 		if result == nil {
 			result, err = r.allocateNextFromPool(ctx, ipam.IPv6, "ingress")
 			if err != nil {
-				if ingressIPv4 != nil {
-					r.ipAllocator.ReleaseIP(iputil.AddrFromIP(ingressIPv4), ipam.PoolDefault())
-					r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv4IngressIP = nil })
+				if ingressIPv4.IsValid() {
+					r.ipAllocator.ReleaseIP(ingressIPv4, ipam.PoolDefault())
+					r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv4IngressIP = iputil.Addr{} })
 				}
 				return fmt.Errorf("unable to allocate ingress IPs: %w, see https://cilium.link/ipam-range-full", err)
 			}
@@ -581,7 +581,7 @@ func (r *infraIPAllocator) allocateIngressIPs(ctx context.Context, oldV4IngressI
 			result.CIDRs = r.coalesceCIDRs(result.CIDRs)
 		}
 
-		r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv6IngressIP = net.IP(result.IP.AsSlice()).To16() })
+		r.localNodeStore.Update(func(n *node.LocalNode) { n.IPv6IngressIP = iputil.AddrFrom(result.IP) })
 		r.logger.Debug("Allocated IPv6 Ingress address", logfields.IPAddr, result.IP)
 	}
 
@@ -609,7 +609,7 @@ func (r *infraIPAllocator) AllocateIPs(ctx context.Context) error {
 		return fmt.Errorf("failed to allocate service loopback IPs: %w", err)
 	}
 
-	if err := r.allocateIngressIPs(ctx, localNode.IPv4IngressIP, localNode.IPv6IngressIP); err != nil {
+	if err := r.allocateIngressIPs(ctx, localNode.IPv4IngressIP.Addr, localNode.IPv6IngressIP.Addr); err != nil {
 		return fmt.Errorf("failed to allocate ingress IPs: %w", err)
 	}
 

--- a/daemon/infraendpoints/ingress_endpoint.go
+++ b/daemon/infraendpoints/ingress_endpoint.go
@@ -87,8 +87,8 @@ func (c *ingressEndpointCreator) createIngressEndpoint(ctx context.Context, heal
 		return fmt.Errorf("failed to get local node: %w", err)
 	}
 
-	if (c.ipv4Enabled && len(ln.IPv4IngressIP) == 0) ||
-		(c.ipv6Enabled && len(ln.IPv6IngressIP) == 0) {
+	if (c.ipv4Enabled && !ln.IPv4IngressIP.IsValid()) ||
+		(c.ipv6Enabled && !ln.IPv6IngressIP.IsValid()) {
 		msg := "Ingress IPs are not available, skipping creation of the Ingress Endpoint: Policy enforcement on Cilium Ingress will not work as expected."
 		c.logger.Warn(msg)
 		health.Degraded(msg, nil)

--- a/pkg/ciliumenvoyconfig/cec_resource_parser.go
+++ b/pkg/ciliumenvoyconfig/cec_resource_parser.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net"
 	"strconv"
 
 	"github.com/cilium/hive/cell"
@@ -36,6 +35,7 @@ import (
 	envoyCfg "github.com/cilium/cilium/pkg/envoy/config"
 	util "github.com/cilium/cilium/pkg/envoy/util"
 	"github.com/cilium/cilium/pkg/envoy/xds"
+	iputil "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -63,8 +63,8 @@ type CECResourceParser struct {
 	logger        *slog.Logger
 	portAllocator PortAllocator
 
-	ingressIPv4 net.IP
-	ingressIPv6 net.IP
+	ingressIPv4 iputil.Addr
+	ingressIPv6 iputil.Addr
 
 	defaultMaxConcurrentRetries uint32
 	defaultMaxConnections       uint32
@@ -626,12 +626,12 @@ func (r *CECResourceParser) getBPFMetadataListenerFilter(useOriginalSourceAddr b
 	// One solution to this dilemma would be to never configure these addresses if
 	// useOriginalSourceAddr is true and let such traffic fail.
 	if l7lb {
-		if r.ingressIPv4 != nil {
+		if r.ingressIPv4.IsValid() {
 			conf.Ipv4SourceAddress = r.ingressIPv4.String()
 			// Enforce ingress policy for Ingress
 			conf.EnforcePolicyOnL7Lb = true
 		}
-		if r.ingressIPv6 != nil {
+		if r.ingressIPv6.IsValid() {
 			conf.Ipv6SourceAddress = r.ingressIPv6.String()
 			// Enforce ingress policy for Ingress
 			conf.EnforcePolicyOnL7Lb = true

--- a/pkg/ciliumenvoyconfig/cec_resource_parser.go
+++ b/pkg/ciliumenvoyconfig/cec_resource_parser.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net"
 	"strconv"
 
 	"github.com/cilium/hive/cell"
@@ -36,6 +35,7 @@ import (
 	envoyCfg "github.com/cilium/cilium/pkg/envoy/config"
 	util "github.com/cilium/cilium/pkg/envoy/util"
 	"github.com/cilium/cilium/pkg/envoy/xds"
+	iputil "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -63,8 +63,8 @@ type CECResourceParser struct {
 	logger        *slog.Logger
 	portAllocator PortAllocator
 
-	ingressIPv4 net.IP
-	ingressIPv6 net.IP
+	ingressIPv4 iputil.Addr
+	ingressIPv6 iputil.Addr
 
 	defaultMaxConcurrentRetries uint32
 	defaultMaxConnections       uint32
@@ -652,12 +652,12 @@ func (r *CECResourceParser) getBPFMetadataListenerFilter(useOriginalSourceAddr b
 	// One solution to this dilemma would be to never configure these addresses if
 	// useOriginalSourceAddr is true and let such traffic fail.
 	if l7lb {
-		if r.ingressIPv4 != nil {
+		if r.ingressIPv4.IsValid() {
 			conf.Ipv4SourceAddress = r.ingressIPv4.String()
 			// Enforce ingress policy for Ingress
 			conf.EnforcePolicyOnL7Lb = true
 		}
-		if r.ingressIPv6 != nil {
+		if r.ingressIPv6.IsValid() {
 			conf.Ipv6SourceAddress = r.ingressIPv6.String()
 			// Enforce ingress policy for Ingress
 			conf.EnforcePolicyOnL7Lb = true

--- a/pkg/endpoint/creator/creator.go
+++ b/pkg/endpoint/creator/creator.go
@@ -6,7 +6,6 @@ package creator
 import (
 	"context"
 	"fmt"
-	"net/netip"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -14,7 +13,6 @@ import (
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/lumberjack/v2"
-	"go4.org/netipx"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/endpoint"
@@ -114,18 +112,13 @@ func (c *endpointCreator) AddIngressEndpoint(ctx context.Context) error {
 		return fmt.Errorf("failed to get local node: %w", err)
 	}
 
-	// Node.IPv4IngressIP has been parsed with net.ParseIP() and may be in IPv4 mapped IPv6
-	// address format. Use netipx.FromStdIP() to make sure we get a plain IPv4 address.
-	ingressIPv4, _ := netipx.FromStdIP(ln.IPv4IngressIP)
-	ingressIPv6, _ := netip.AddrFromSlice(ln.IPv6IngressIP)
-
 	ep, err := endpoint.CreateIngressEndpoint(
 		c.epParams,
 		c.params.DNSRulesService,
 		c.params.Proxy,
 		c.policyLogger(),
-		ingressIPv4,
-		ingressIPv6,
+		ln.IPv4IngressIP.Addr,
+		ln.IPv6IngressIP.Addr,
 	)
 	if err != nil {
 		return err

--- a/pkg/ipcache/restore/local_identity_restorer.go
+++ b/pkg/ipcache/restore/local_identity_restorer.go
@@ -15,6 +15,7 @@ import (
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/identity"
 	identitycell "github.com/cilium/cilium/pkg/identity/cache/cell"
+	iputil "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
@@ -196,9 +197,9 @@ func (d *LocalIdentityRestorer) restoreIPCache(ipCache *ipcache.IPCache, localPr
 			d.params.NodeLocalStore.Update(func(n *node.LocalNode) {
 				addr := prefix.Addr()
 				if addr.Is4() {
-					n.IPv4IngressIP = addr.AsSlice()
+					n.IPv4IngressIP = iputil.AddrFrom(addr)
 				} else {
-					n.IPv6IngressIP = addr.AsSlice()
+					n.IPv6IngressIP = iputil.AddrFrom(addr)
 				}
 			})
 			d.params.Logger.Info("Restored ingress IP", logfields.Ingress, prefix)

--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -279,33 +279,35 @@ func ParseNode(logger *slog.Logger, k8sNode *slim_corev1.Node, source source.Sou
 		}
 	}
 
-	if newNode.IPv4IngressIP == nil {
+	if !newNode.IPv4IngressIP.IsValid() {
 		if ingressIP, ok := annotation.Get(k8sNode, annotation.V4IngressName, annotation.V4IngressNameAlias); !ok || ingressIP == "" {
 			scopedLog.Debug(
 				"Empty IPv4 Ingress annotation in node",
 			)
-		} else if ip := net.ParseIP(ingressIP); ip == nil {
+		} else if addr, err := netip.ParseAddr(ingressIP); err != nil {
 			scopedLog.Error(
 				"BUG, invalid IPv4 Ingress annotation in node",
 				logfields.V4IngressIP, ingressIP,
+				logfields.Error, err,
 			)
 		} else {
-			newNode.IPv4IngressIP = ip
+			newNode.IPv4IngressIP = iputil.AddrFrom(addr)
 		}
 	}
 
-	if newNode.IPv6IngressIP == nil {
+	if !newNode.IPv6IngressIP.IsValid() {
 		if ingressIP, ok := annotation.Get(k8sNode, annotation.V6IngressName, annotation.V6IngressNameAlias); !ok || ingressIP == "" {
 			scopedLog.Debug(
 				"Empty IPv6 Ingress annotation in node",
 			)
-		} else if ip := net.ParseIP(ingressIP); ip == nil {
+		} else if addr, err := netip.ParseAddr(ingressIP); err != nil {
 			scopedLog.Error(
 				"BUG, invalid IPv6 Ingress annotation in node",
 				logfields.V6IngressIP, ingressIP,
+				logfields.Error, err,
 			)
 		} else {
-			newNode.IPv6IngressIP = ip
+			newNode.IPv6IngressIP = iputil.AddrFrom(addr)
 		}
 	}
 
@@ -365,8 +367,10 @@ func ParseCiliumNode(n *ciliumv2.CiliumNode) (node nodeTypes.Node) {
 	node.IPv4HealthIP = iputil.AddrFrom(v4HealthIP)
 	node.IPv6HealthIP = iputil.AddrFrom(v6HealthIP)
 
-	node.IPv4IngressIP = net.ParseIP(n.Spec.IngressAddressing.IPV4)
-	node.IPv6IngressIP = net.ParseIP(n.Spec.IngressAddressing.IPV6)
+	v4IngressIP, _ := netip.ParseAddr(n.Spec.IngressAddressing.IPV4)
+	v6IngressIP, _ := netip.ParseAddr(n.Spec.IngressAddressing.IPV6)
+	node.IPv4IngressIP = iputil.AddrFrom(v4IngressIP)
+	node.IPv6IngressIP = iputil.AddrFrom(v6IngressIP)
 
 	for _, address := range n.Spec.Addresses {
 		if ip := net.ParseIP(address.IP); ip != nil {

--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -276,33 +276,35 @@ func ParseNode(logger *slog.Logger, k8sNode *slim_corev1.Node, source source.Sou
 		}
 	}
 
-	if newNode.IPv4IngressIP == nil {
+	if !newNode.IPv4IngressIP.IsValid() {
 		if ingressIP, ok := annotation.Get(k8sNode, annotation.V4IngressName, annotation.V4IngressNameAlias); !ok || ingressIP == "" {
 			scopedLog.Debug(
 				"Empty IPv4 Ingress annotation in node",
 			)
-		} else if ip := net.ParseIP(ingressIP); ip == nil {
+		} else if addr, err := netip.ParseAddr(ingressIP); err != nil {
 			scopedLog.Error(
 				"BUG, invalid IPv4 Ingress annotation in node",
 				logfields.V4IngressIP, ingressIP,
+				logfields.Error, err,
 			)
 		} else {
-			newNode.IPv4IngressIP = ip
+			newNode.IPv4IngressIP = iputil.AddrFrom(addr)
 		}
 	}
 
-	if newNode.IPv6IngressIP == nil {
+	if !newNode.IPv6IngressIP.IsValid() {
 		if ingressIP, ok := annotation.Get(k8sNode, annotation.V6IngressName, annotation.V6IngressNameAlias); !ok || ingressIP == "" {
 			scopedLog.Debug(
 				"Empty IPv6 Ingress annotation in node",
 			)
-		} else if ip := net.ParseIP(ingressIP); ip == nil {
+		} else if addr, err := netip.ParseAddr(ingressIP); err != nil {
 			scopedLog.Error(
 				"BUG, invalid IPv6 Ingress annotation in node",
 				logfields.V6IngressIP, ingressIP,
+				logfields.Error, err,
 			)
 		} else {
-			newNode.IPv6IngressIP = ip
+			newNode.IPv6IngressIP = iputil.AddrFrom(addr)
 		}
 	}
 
@@ -363,8 +365,10 @@ func ParseCiliumNode(n *ciliumv2.CiliumNode) (node nodeTypes.Node) {
 	node.IPv4HealthIP = iputil.AddrFrom(v4HealthIP)
 	node.IPv6HealthIP = iputil.AddrFrom(v6HealthIP)
 
-	node.IPv4IngressIP = net.ParseIP(n.Spec.IngressAddressing.IPV4)
-	node.IPv6IngressIP = net.ParseIP(n.Spec.IngressAddressing.IPV6)
+	v4IngressIP, _ := netip.ParseAddr(n.Spec.IngressAddressing.IPV4)
+	v6IngressIP, _ := netip.ParseAddr(n.Spec.IngressAddressing.IPV6)
+	node.IPv4IngressIP = iputil.AddrFrom(v4IngressIP)
+	node.IPv6IngressIP = iputil.AddrFrom(v6IngressIP)
 
 	for _, address := range n.Spec.Addresses {
 		if ip := net.ParseIP(address.IP); ip != nil {

--- a/pkg/k8s/node_test.go
+++ b/pkg/k8s/node_test.go
@@ -443,7 +443,7 @@ func TestParseCiliumNode(t *testing.T) {
 		IPv6SecondaryAllocCIDRs: []*cidr.CIDR{cidr.MustParseCIDR("c0fe::/96")},
 		IPv4HealthIP:            iputil.AddrFrom(netip.MustParseAddr("1.1.1.1")),
 		IPv6HealthIP:            iputil.AddrFrom(netip.MustParseAddr("c0de::1")),
-		IPv4IngressIP:           net.ParseIP("1.1.1.2"),
-		IPv6IngressIP:           net.ParseIP("c0de::2"),
+		IPv4IngressIP:           iputil.AddrFrom(netip.MustParseAddr("1.1.1.2")),
+		IPv6IngressIP:           iputil.AddrFrom(netip.MustParseAddr("c0de::2")),
 	}, n)
 }

--- a/pkg/k8s/node_test.go
+++ b/pkg/k8s/node_test.go
@@ -442,7 +442,7 @@ func TestParseCiliumNode(t *testing.T) {
 		IPv6SecondaryAllocCIDRs: []nodeTypes.Prefix{nodeTypes.PrefixFrom(netip.MustParsePrefix("c0fe::/96"))},
 		IPv4HealthIP:            iputil.AddrFrom(netip.MustParseAddr("1.1.1.1")),
 		IPv6HealthIP:            iputil.AddrFrom(netip.MustParseAddr("c0de::1")),
-		IPv4IngressIP:           net.ParseIP("1.1.1.2"),
-		IPv6IngressIP:           net.ParseIP("c0de::2"),
+		IPv4IngressIP:           iputil.AddrFrom(netip.MustParseAddr("1.1.1.2")),
+		IPv6IngressIP:           iputil.AddrFrom(netip.MustParseAddr("c0de::2")),
 	}, n)
 }

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -811,8 +811,8 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 		healthIPsAdded = append(healthIPsAdded, prefixCluster.AsPrefix())
 	}
 
-	for _, address := range []net.IP{n.IPv4IngressIP, n.IPv6IngressIP} {
-		prefix := ip.IPToNetPrefix(address)
+	for _, address := range []netip.Addr{n.IPv4IngressIP.Addr, n.IPv6IngressIP.Addr} {
+		prefix := netip.PrefixFrom(address, address.BitLen())
 		if !prefix.IsValid() {
 			continue
 		}
@@ -1055,8 +1055,8 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 	}
 
 	// Delete the old ingress IP addresses if they have changed in this node.
-	for _, address := range []net.IP{oldNode.IPv4IngressIP, oldNode.IPv6IngressIP} {
-		prefix := ip.IPToNetPrefix(address)
+	for _, address := range []netip.Addr{oldNode.IPv4IngressIP.Addr, oldNode.IPv6IngressIP.Addr} {
+		prefix := netip.PrefixFrom(address, address.BitLen())
 		if !prefix.IsValid() || slices.Contains(ingressIPsAdded, prefix) {
 			continue
 		}

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -810,8 +810,8 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 		healthIPsAdded = append(healthIPsAdded, prefixCluster.AsPrefix())
 	}
 
-	for _, address := range []net.IP{n.IPv4IngressIP, n.IPv6IngressIP} {
-		prefix := ip.IPToNetPrefix(address)
+	for _, address := range []netip.Addr{n.IPv4IngressIP.Addr, n.IPv6IngressIP.Addr} {
+		prefix := netip.PrefixFrom(address, address.BitLen())
 		if !prefix.IsValid() {
 			continue
 		}
@@ -1054,8 +1054,8 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 	}
 
 	// Delete the old ingress IP addresses if they have changed in this node.
-	for _, address := range []net.IP{oldNode.IPv4IngressIP, oldNode.IPv6IngressIP} {
-		prefix := ip.IPToNetPrefix(address)
+	for _, address := range []netip.Addr{oldNode.IPv4IngressIP.Addr, oldNode.IPv6IngressIP.Addr} {
+		prefix := netip.PrefixFrom(address, address.BitLen())
 		if !prefix.IsValid() || slices.Contains(ingressIPsAdded, prefix) {
 			continue
 		}

--- a/pkg/node/store/store_test.go
+++ b/pkg/node/store/store_test.go
@@ -57,6 +57,16 @@ func TestValidatingNode(t *testing.T) {
 			errstr:    "name does not match key: got qux, expected fred",
 		},
 		{
+			name: "ingress IPs round-trip",
+			node: types.Node{
+				Cluster:       "foo",
+				Name:          "qux",
+				IPv4IngressIP: iputil.AddrFrom(netip.MustParseAddr("10.0.0.5")),
+				IPv6IngressIP: iputil.AddrFrom(netip.MustParseAddr("f00d::5")),
+			},
+			validator: ClusterNameValidator("foo"),
+		},
+		{
 			name:      "valid cluster ID",
 			node:      types.Node{Cluster: "foo", Name: "qux", ClusterID: 10},
 			validator: ClusterIDValidator(ptr.To[uint32](10)),

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -70,13 +70,13 @@ type Node struct {
 	// cilium-health endpoint located on the node.
 	IPv6HealthIP iputil.Addr
 
-	// IPv4IngressIP if not nil, this is the IPv4 address of the
+	// IPv4IngressIP if set, this is the IPv4 address of the
 	// Ingress listener on the node.
-	IPv4IngressIP net.IP
+	IPv4IngressIP iputil.Addr
 
-	// IPv6IngressIP if not nil, this is the IPv6 address of the
+	// IPv6IngressIP if set, this is the IPv6 address of the
 	// Ingress listener located on the node.
-	IPv6IngressIP net.IP
+	IPv6IngressIP iputil.Addr
 
 	// ClusterID is the unique identifier of the cluster
 	ClusterID uint32
@@ -385,15 +385,15 @@ func (n *Node) getHealthAddresses() *models.NodeAddressing {
 }
 
 func (n *Node) getIngressAddresses() *models.NodeAddressing {
-	if n.IPv4IngressIP == nil && n.IPv6IngressIP == nil {
+	if !n.IPv4IngressIP.IsValid() && !n.IPv6IngressIP.IsValid() {
 		return nil
 	}
 
 	var v4Str, v6Str string
-	if n.IPv4IngressIP != nil {
+	if n.IPv4IngressIP.IsValid() {
 		v4Str = n.IPv4IngressIP.String()
 	}
-	if n.IPv6IngressIP != nil {
+	if n.IPv6IngressIP.IsValid() {
 		v6Str = n.IPv6IngressIP.String()
 	}
 

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -69,13 +69,13 @@ type Node struct {
 	// cilium-health endpoint located on the node.
 	IPv6HealthIP iputil.Addr
 
-	// IPv4IngressIP if not nil, this is the IPv4 address of the
+	// IPv4IngressIP if set, this is the IPv4 address of the
 	// Ingress listener on the node.
-	IPv4IngressIP net.IP
+	IPv4IngressIP iputil.Addr
 
-	// IPv6IngressIP if not nil, this is the IPv6 address of the
+	// IPv6IngressIP if set, this is the IPv6 address of the
 	// Ingress listener located on the node.
-	IPv6IngressIP net.IP
+	IPv6IngressIP iputil.Addr
 
 	// ClusterID is the unique identifier of the cluster
 	ClusterID uint32
@@ -384,15 +384,15 @@ func (n *Node) getHealthAddresses() *models.NodeAddressing {
 }
 
 func (n *Node) getIngressAddresses() *models.NodeAddressing {
-	if n.IPv4IngressIP == nil && n.IPv6IngressIP == nil {
+	if !n.IPv4IngressIP.IsValid() && !n.IPv6IngressIP.IsValid() {
 		return nil
 	}
 
 	var v4Str, v6Str string
-	if n.IPv4IngressIP != nil {
+	if n.IPv4IngressIP.IsValid() {
 		v4Str = n.IPv4IngressIP.String()
 	}
-	if n.IPv6IngressIP != nil {
+	if n.IPv6IngressIP.IsValid() {
 		v6Str = n.IPv6IngressIP.String()
 	}
 

--- a/pkg/node/types/zz_generated.deepcopy.go
+++ b/pkg/node/types/zz_generated.deepcopy.go
@@ -75,16 +75,8 @@ func (in *Node) DeepCopyInto(out *Node) {
 	}
 	in.IPv4HealthIP.DeepCopyInto(&out.IPv4HealthIP)
 	in.IPv6HealthIP.DeepCopyInto(&out.IPv6HealthIP)
-	if in.IPv4IngressIP != nil {
-		in, out := &in.IPv4IngressIP, &out.IPv4IngressIP
-		*out = make(net.IP, len(*in))
-		copy(*out, *in)
-	}
-	if in.IPv6IngressIP != nil {
-		in, out := &in.IPv6IngressIP, &out.IPv6IngressIP
-		*out = make(net.IP, len(*in))
-		copy(*out, *in)
-	}
+	in.IPv4IngressIP.DeepCopyInto(&out.IPv4IngressIP)
+	in.IPv6IngressIP.DeepCopyInto(&out.IPv6IngressIP)
 	if in.Labels != nil {
 		in, out := &in.Labels, &out.Labels
 		*out = make(map[string]string, len(*in))

--- a/pkg/node/types/zz_generated.deepcopy.go
+++ b/pkg/node/types/zz_generated.deepcopy.go
@@ -61,16 +61,8 @@ func (in *Node) DeepCopyInto(out *Node) {
 	}
 	in.IPv4HealthIP.DeepCopyInto(&out.IPv4HealthIP)
 	in.IPv6HealthIP.DeepCopyInto(&out.IPv6HealthIP)
-	if in.IPv4IngressIP != nil {
-		in, out := &in.IPv4IngressIP, &out.IPv4IngressIP
-		*out = make(net.IP, len(*in))
-		copy(*out, *in)
-	}
-	if in.IPv6IngressIP != nil {
-		in, out := &in.IPv6IngressIP, &out.IPv6IngressIP
-		*out = make(net.IP, len(*in))
-		copy(*out, *in)
-	}
+	in.IPv4IngressIP.DeepCopyInto(&out.IPv4IngressIP)
+	in.IPv6IngressIP.DeepCopyInto(&out.IPv6IngressIP)
 	if in.Labels != nil {
 		in, out := &in.Labels, &out.Labels
 		*out = make(map[string]string, len(*in))

--- a/pkg/node/types/zz_generated.deepequal.go
+++ b/pkg/node/types/zz_generated.deepequal.go
@@ -96,38 +96,12 @@ func (in *Node) DeepEqual(other *Node) bool {
 		return false
 	}
 
-	if ((in.IPv4IngressIP != nil) && (other.IPv4IngressIP != nil)) || ((in.IPv4IngressIP == nil) != (other.IPv4IngressIP == nil)) {
-		in, other := &in.IPv4IngressIP, &other.IPv4IngressIP
-		if other == nil {
-			return false
-		}
-
-		if len(*in) != len(*other) {
-			return false
-		} else {
-			for i, inElement := range *in {
-				if inElement != (*other)[i] {
-					return false
-				}
-			}
-		}
+	if !in.IPv4IngressIP.DeepEqual(&other.IPv4IngressIP) {
+		return false
 	}
 
-	if ((in.IPv6IngressIP != nil) && (other.IPv6IngressIP != nil)) || ((in.IPv6IngressIP == nil) != (other.IPv6IngressIP == nil)) {
-		in, other := &in.IPv6IngressIP, &other.IPv6IngressIP
-		if other == nil {
-			return false
-		}
-
-		if len(*in) != len(*other) {
-			return false
-		} else {
-			for i, inElement := range *in {
-				if inElement != (*other)[i] {
-					return false
-				}
-			}
-		}
+	if !in.IPv6IngressIP.DeepEqual(&other.IPv6IngressIP) {
+		return false
 	}
 
 	if in.ClusterID != other.ClusterID {

--- a/pkg/node/types/zz_generated.deepequal.go
+++ b/pkg/node/types/zz_generated.deepequal.go
@@ -88,38 +88,12 @@ func (in *Node) DeepEqual(other *Node) bool {
 		return false
 	}
 
-	if ((in.IPv4IngressIP != nil) && (other.IPv4IngressIP != nil)) || ((in.IPv4IngressIP == nil) != (other.IPv4IngressIP == nil)) {
-		in, other := &in.IPv4IngressIP, &other.IPv4IngressIP
-		if other == nil {
-			return false
-		}
-
-		if len(*in) != len(*other) {
-			return false
-		} else {
-			for i, inElement := range *in {
-				if inElement != (*other)[i] {
-					return false
-				}
-			}
-		}
+	if !in.IPv4IngressIP.DeepEqual(&other.IPv4IngressIP) {
+		return false
 	}
 
-	if ((in.IPv6IngressIP != nil) && (other.IPv6IngressIP != nil)) || ((in.IPv6IngressIP == nil) != (other.IPv6IngressIP == nil)) {
-		in, other := &in.IPv6IngressIP, &other.IPv6IngressIP
-		if other == nil {
-			return false
-		}
-
-		if len(*in) != len(*other) {
-			return false
-		} else {
-			for i, inElement := range *in {
-				if inElement != (*other)[i] {
-					return false
-				}
-			}
-		}
+	if !in.IPv6IngressIP.DeepEqual(&other.IPv6IngressIP) {
+		return false
 	}
 
 	if in.ClusterID != other.ClusterID {

--- a/pkg/nodediscovery/k8s_node_annotate.go
+++ b/pkg/nodediscovery/k8s_node_annotate.go
@@ -28,8 +28,6 @@ func (n *NodeDiscovery) prepareNodeAnnotations(localNode nodeTypes.Node) nodeAnn
 	annotationMap := map[string]fmt.Stringer{
 		annotation.V4CIDRName:     localNode.IPv4AllocCIDR,
 		annotation.V6CIDRName:     localNode.IPv6AllocCIDR,
-		annotation.V4IngressName:  localNode.IPv4IngressIP,
-		annotation.V6IngressName:  localNode.IPv6IngressIP,
 		annotation.CiliumHostIP:   localNode.GetCiliumInternalIP(false),
 		annotation.CiliumHostIPv6: localNode.GetCiliumInternalIP(true),
 	}
@@ -45,6 +43,12 @@ func (n *NodeDiscovery) prepareNodeAnnotations(localNode nodeTypes.Node) nodeAnn
 	}
 	if localNode.IPv6HealthIP.IsValid() {
 		annotations[annotation.V6HealthName] = localNode.IPv6HealthIP.String()
+	}
+	if localNode.IPv4IngressIP.IsValid() {
+		annotations[annotation.V4IngressName] = localNode.IPv4IngressIP.String()
+	}
+	if localNode.IPv6IngressIP.IsValid() {
+		annotations[annotation.V6IngressName] = localNode.IPv6IngressIP.String()
 	}
 	if localNode.EncryptionKey != 0 {
 		annotations[annotation.CiliumEncryptionKey] = strconv.FormatUint(uint64(localNode.EncryptionKey), 10)

--- a/pkg/nodediscovery/k8s_node_annotate.go
+++ b/pkg/nodediscovery/k8s_node_annotate.go
@@ -26,8 +26,6 @@ var nodeAnnotationControllerGroup = controller.NewGroup("update-k8s-node-annotat
 
 func (n *NodeDiscovery) prepareNodeAnnotations(localNode nodeTypes.Node) nodeAnnotation {
 	annotationMap := map[string]fmt.Stringer{
-		annotation.V4IngressName:  localNode.IPv4IngressIP,
-		annotation.V6IngressName:  localNode.IPv6IngressIP,
 		annotation.CiliumHostIP:   localNode.GetCiliumInternalIP(false),
 		annotation.CiliumHostIPv6: localNode.GetCiliumInternalIP(true),
 	}
@@ -49,6 +47,12 @@ func (n *NodeDiscovery) prepareNodeAnnotations(localNode nodeTypes.Node) nodeAnn
 	}
 	if localNode.IPv6HealthIP.IsValid() {
 		annotations[annotation.V6HealthName] = localNode.IPv6HealthIP.String()
+	}
+	if localNode.IPv4IngressIP.IsValid() {
+		annotations[annotation.V4IngressName] = localNode.IPv4IngressIP.String()
+	}
+	if localNode.IPv6IngressIP.IsValid() {
+		annotations[annotation.V6IngressName] = localNode.IPv6IngressIP.String()
 	}
 	if localNode.EncryptionKey != 0 {
 		annotations[annotation.CiliumEncryptionKey] = strconv.FormatUint(uint64(localNode.EncryptionKey), 10)

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -373,12 +373,12 @@ func (n *NodeDiscovery) mutateNodeResource(ctx context.Context, nodeResource *ci
 	}
 
 	nodeResource.Spec.IngressAddressing.IPV4 = ""
-	if ip := ln.IPv4IngressIP; ip != nil {
+	if ip := ln.IPv4IngressIP; ip.IsValid() {
 		nodeResource.Spec.IngressAddressing.IPV4 = ip.String()
 	}
 
 	nodeResource.Spec.IngressAddressing.IPV6 = ""
-	if ip := ln.IPv6IngressIP; ip != nil {
+	if ip := ln.IPv6IngressIP; ip.IsValid() {
 		nodeResource.Spec.IngressAddressing.IPV6 = ip.String()
 	}
 

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -368,12 +368,12 @@ func (n *NodeDiscovery) mutateNodeResource(ctx context.Context, nodeResource *ci
 	}
 
 	nodeResource.Spec.IngressAddressing.IPV4 = ""
-	if ip := ln.IPv4IngressIP; ip != nil {
+	if ip := ln.IPv4IngressIP; ip.IsValid() {
 		nodeResource.Spec.IngressAddressing.IPV4 = ip.String()
 	}
 
 	nodeResource.Spec.IngressAddressing.IPV6 = ""
-	if ip := ln.IPv6IngressIP; ip != nil {
+	if ip := ln.IPv6IngressIP; ip.IsValid() {
 		nodeResource.Spec.IngressAddressing.IPV6 = ip.String()
 	}
 


### PR DESCRIPTION
This PR migrates `Node.IPv4IngressIP` and `Node.IPv6IngressIP` from `net.IP` to `ip.Addr`, following the same approach as the health IPs migration (#47001). We use the `ip.Addr` wrapper over the plain `netip.Addr` type because the `Node` struct needs generated deepcopy/deepequal methods (see #46047).

Relates to:
* #46924
* #24246