### PR TITLE
.github: select a usable AZ for EKS us-west-1

### DIFF
--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -289,7 +289,18 @@ jobs:
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT
           # shellcheck disable=SC2046
           echo owner=${OWNER} >> $GITHUB_OUTPUT
-          echo eks_zone_1=${{ matrix.region }}b >> $GITHUB_OUTPUT
+
+          # us-west-1 only exposes two usable availability zones for subnet
+          # creation (us-west-1a and us-west-1c); us-west-1b rejects subnets.
+          case "${{ matrix.region }}" in
+          us-west-1)
+            ZONE_1=${{ matrix.region }}a
+            ;;
+          *)
+            ZONE_1=${{ matrix.region }}b
+            ;;
+          esac
+          echo eks_zone_1=${ZONE_1} >> $GITHUB_OUTPUT
           echo eks_zone_2=${{ matrix.region }}c >> $GITHUB_OUTPUT
 
       - name: Install kubectl

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -399,7 +399,18 @@ jobs:
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT
           echo owner=${OWNER} >> $GITHUB_OUTPUT
-          echo eks_zone_1=${{ matrix.region }}b >> $GITHUB_OUTPUT
+
+          # us-west-1 only exposes two usable availability zones for subnet
+          # creation (us-west-1a and us-west-1c); us-west-1b rejects subnets.
+          case "${{ matrix.region }}" in
+          us-west-1)
+            ZONE_1=${{ matrix.region }}a
+            ;;
+          *)
+            ZONE_1=${{ matrix.region }}b
+            ;;
+          esac
+          echo eks_zone_1=${ZONE_1} >> $GITHUB_OUTPUT
           echo eks_zone_2=${{ matrix.region }}c >> $GITHUB_OUTPUT
 
       - name: Install kubectl


### PR DESCRIPTION
The EKS and AWS-CNI workflows compute the cluster AZs as `eks_zone_1 = ${region}b` and `eks_zone_2 = ${region}c`. For us-west-1 this picks us-west-1b, which cannot host subnets on our account: eksctl's CloudFormation stack fails with `Value (us-west-1b) for parameter availabilityZone is invalid. Subnets can currently only be created in the following availability zones: us-west-1a, us-west-1c.` and the cluster is never created, failing the 1.32/us-west-1 leg before any test runs.

Only `eks_zone_1` needs to change: the error confirms us-west-1c (`eks_zone_2`) is valid, so it stays `${region}c` and `eks_zone_1` switches to us-west-1a for that region while keeping `${region}b` everywhere else. `eks_zone_1` also feeds the CIDR lookup and the external-target AZ, so this keeps those consistent with the subnets that actually get created.

AIL: 2
