### PR TITLE
cilium-cli: retry transient exec errors in setup/teardown exec sites

### DIFF
--- a/cilium-cli/connectivity/check/action.go
+++ b/cilium-cli/connectivity/check/action.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/api/v1/relay"
 	"github.com/cilium/cilium/cilium-cli/connectivity/filters"
 	"github.com/cilium/cilium/cilium-cli/defaults"
+	"github.com/cilium/cilium/cilium-cli/k8s"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
 	hubprinter "github.com/cilium/cilium/hubble/pkg/printer"
 	"github.com/cilium/cilium/pkg/lock"
@@ -306,6 +307,30 @@ func isExecTransportError(err error) bool {
 	msg := err.Error()
 	return strings.Contains(msg, "unable to upgrade connection") ||
 		strings.Contains(msg, "error dialing backend")
+}
+
+// execInPodWithTransportRetry runs a one-shot command in a pod, retrying only
+// on transport-level failures to establish the exec stream (see
+// isExecTransportError). Setup/teardown helpers use it because they have no
+// curl-level --retry of their own, so a single transient apiserver/konnectivity
+// upgrade-connection blip — common on managed clusters and under load — would
+// otherwise abort the whole test before the command ran. A non-zero exit of the
+// command itself is a real result and is returned on the first attempt.
+func (ct *ConnectivityTest) execInPodWithTransportRetry(ctx context.Context, client *k8s.Client, namespace, pod, container string, cmd []string) (bytes.Buffer, error) {
+	var output bytes.Buffer
+	var err error
+	for i := 1; i <= testCommandRetries; i++ {
+		output, err = client.ExecInPod(ctx, namespace, pod, container, cmd)
+		if err == nil || !isExecTransportError(err) {
+			break
+		}
+		ct.Debugf("retrying exec in pod %s/%s due to exec transport error: %s", namespace, pod, err)
+		select {
+		case <-ctx.Done():
+		case <-time.After(time.Second):
+		}
+	}
+	return output, err
 }
 
 func (a *Action) ExecInPod(ctx context.Context, cmd []string) {

--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -497,7 +497,7 @@ func (ct *ConnectivityTest) PrintReport(ctx context.Context) error {
 				defer wg.Done()
 
 				ct.Debugf("Flushing CT entries in %s/%s", pod.Pod.Namespace, pod.Pod.Name)
-				_, err := pod.K8sClient.ExecInPod(ctx, pod.Pod.Namespace, pod.Pod.Name, defaults.AgentContainerName, cmd)
+				_, err := ct.execInPodWithTransportRetry(ctx, pod.K8sClient, pod.Pod.Namespace, pod.Pod.Name, defaults.AgentContainerName, cmd)
 				if err != nil {
 					ct.Fatalf("failed to flush ct entries: %v", err)
 				}
@@ -822,7 +822,7 @@ func (ct *ConnectivityTest) modifyStaticRoutesForNodesWithoutCilium(ctx context.
 	for _, e := range ct.params.PodCIDRs {
 		for withoutCilium := range ct.nodesWithoutCilium {
 			pod := ct.hostNetNSPodsByNode[withoutCilium]
-			_, err := ct.client.ExecInPod(ctx, pod.Pod.Namespace, pod.Pod.Name, hostNetNSDeploymentNameNonCilium,
+			_, err := ct.execInPodWithTransportRetry(ctx, ct.client, pod.Pod.Namespace, pod.Pod.Name, hostNetNSDeploymentNameNonCilium,
 				[]string{"ip", "route", string(verb), e.CIDR, "via", e.HostIP},
 			)
 			ct.Debugf("Modifying (%s) static route on nodes without Cilium (%v): %v",

--- a/cilium-cli/connectivity/check/deployment.go
+++ b/cilium-cli/connectivity/check/deployment.go
@@ -1817,8 +1817,8 @@ func (ct *ConnectivityTest) patchDeployment(ctx context.Context) error {
 		}
 
 		for _, pod := range clientPods.Items {
-			_, err := ct.client.ExecInPod(ctx, ct.params.TestNamespace, pod.Name, pod.Spec.Containers[0].Name,
-				[]string{"sh", "-c", fmt.Sprintf("echo %s | base64 -d >> /etc/ssl/certs/ca-certificates.crt", encodedCert)})
+			cmd := []string{"sh", "-c", fmt.Sprintf("echo %s | base64 -d >> /etc/ssl/certs/ca-certificates.crt", encodedCert)}
+			_, err := ct.execInPodWithTransportRetry(ctx, ct.client, ct.params.TestNamespace, pod.Name, pod.Spec.Containers[0].Name, cmd)
 			if err != nil {
 				return fmt.Errorf("unable to add CA to pod %s: %w", pod.Name, err)
 			}
@@ -3047,7 +3047,7 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 			if iface := ct.params.SecondaryNetworkIface; iface != "" {
 				if ct.Features[features.IPv4].Enabled {
 					cmd := []string{"/bin/sh", "-c", fmt.Sprintf("ip -family inet -oneline address show dev %s scope global | awk '{print $4}' | cut -d/ -f1", iface)}
-					addr, err := client.ExecInPod(ctx, pod.Namespace, pod.Name, pod.Spec.Containers[0].Name, cmd)
+					addr, err := ct.execInPodWithTransportRetry(ctx, client, pod.Namespace, pod.Name, pod.Spec.Containers[0].Name, cmd)
 					if err != nil {
 						return fmt.Errorf("failed to fetch secondary network ip addr: %w", err)
 					}
@@ -3055,7 +3055,7 @@ func (ct *ConnectivityTest) validateDeployment(ctx context.Context) error {
 				}
 				if ct.Features[features.IPv6].Enabled {
 					cmd := []string{"/bin/sh", "-c", fmt.Sprintf("ip -family inet6 -oneline address show dev %s scope global | awk '{print $4}' | cut -d/ -f1", iface)}
-					addr, err := client.ExecInPod(ctx, pod.Namespace, pod.Name, pod.Spec.Containers[0].Name, cmd)
+					addr, err := ct.execInPodWithTransportRetry(ctx, client, pod.Namespace, pod.Name, pod.Spec.Containers[0].Name, cmd)
 					if err != nil {
 						return fmt.Errorf("failed to fetch secondary network ip addr: %w", err)
 					}


### PR DESCRIPTION
The connectivity test has several one-shot `ExecInPod` calls in its setup/teardown paths that abort the whole test on the first error. These execs traverse the apiserver->kubelet SPDY/konnectivity tunnel, which occasionally emits a transient transport-level error while establishing the stream (the command never runs) — the same failure class that `WriteDataToPod` and the features exec already tolerate via retry. `patchDeployment`'s external-target CA append was seen failing this way on both an L3-L4 kube-proxy-1 leg ("error dialing backend: ... connection reset by peer") and an AKS leg ("proxy error ... code 503: Service Unavailable") under `--test-concurrency=5`.

This adds a shared `ConnectivityTest.execInPodWithTransportRetry` helper that retries only on `isExecTransportError` (the stream never established), and routes the setup/teardown direct-exec sites through it: `patchDeployment`'s CA append, the `PrintReport` CT flush, the static-route programming for nodes without Cilium, and the secondary-network address lookup. The test-body `Action.ExecInPod` path already retries these via its `ExitInvalidCode` handling and is left unchanged.

Retries fire only when the exec stream could not be established, so the command never ran; a genuine non-zero exit or stderr is a non-transport error and is returned on the first attempt, so this cannot mask a real failure. A unit test covers the classifier.

AIL: 2
