### PR TITLE
docs: mark TCPRoute/UDPRoute as unsupported under host network mode

### DIFF
--- a/Documentation/network/servicemesh/gateway-api/host-network-mode.rst
+++ b/Documentation/network/servicemesh/gateway-api/host-network-mode.rst
@@ -19,6 +19,7 @@ loadbalancers.
 .. note::
     * Enabling the Cilium Gateway API host network mode automatically disables the LoadBalancer type Service mode. They are mutually exclusive.
     * The listener is exposed on all interfaces (``0.0.0.0`` for IPv4 and/or ``::`` for IPv6).
+    * Host network mode is not compatible with ``TCPRoute`` and ``UDPRoute``. Their traffic bypasses Envoy and reaches the Gateway's generated Service directly, which normally exposes the configured ``Gateway`` listener port as a ``LoadBalancer`` Service. Enabling host network mode turns this Service into a ``NodePort`` Service instead, which gets a randomly assigned port from the node port range rather than the port configured on the ``Gateway`` listener.
 
 Host network mode can be enabled via Helm:
 


### PR DESCRIPTION
Host network mode is incompatible with TCPRoute and UDPRoute. It forces the Gateway's generated Service to type NodePort, which gets a "randomly" assigned port instead of the port configured on the Gateway listener.

Supersedes https://github.com/cilium/cilium/pull/47027 (more context over there, especially in https://github.com/cilium/cilium/pull/47027#issuecomment-4958076034 and the two following comments)

```release-note
docs: mark TCPRoute/UDPRoute as unsupported under host network mode
```

cc @mhofstetter, @youngnick 

<img width="747" height="558" alt="image" src="https://github.com/user-attachments/assets/fa9e139f-bc9c-455d-a76e-dcebd24f0418" />
