### PR TITLE
gha: fix features-tested warnings for l7-perf and mcs-api

### DIFF
--- a/.github/workflows/common-post-jobs.yaml
+++ b/.github/workflows/common-post-jobs.yaml
@@ -22,6 +22,11 @@ on:
         required: false
         type: boolean
         default: true
+      merge-features:
+        description: "Whether to merge and upload features-tested-* artifacts. Set to false for workflows that do not collect feature status and therefore produce no such artifact (e.g. perf tests)."
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -52,6 +57,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Merge Features tested
+        if: ${{ inputs.merge-features }}
         uses: ./.github/actions/merge-artifacts
         with:
           name: features-tested

--- a/.github/workflows/conformance-mcs-api.yaml
+++ b/.github/workflows/conformance-mcs-api.yaml
@@ -343,6 +343,20 @@ jobs:
           retention-days: 5
           if-no-files-found: ignore
 
+      - name: Features tested on cluster 1
+        uses: ./.github/actions/feature-status
+        with:
+          cilium-cli: "cilium --context ${{ env.contextName1 }}"
+          title: "Summary of all features tested on cluster 1"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - cluster 1"
+
+      - name: Features tested on cluster 2
+        uses: ./.github/actions/feature-status
+        with:
+          cilium-cli: "cilium --context ${{ env.contextName2 }}"
+          title: "Summary of all features tested on cluster 2"
+          json-filename: "${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - cluster 2"
+
       - name: Run common post steps
         if: ${{ always() && steps.install-cilium.outcome != 'skipped' }}
         uses: ./.github/actions/post-logic

--- a/.github/workflows/l7-perf.yaml
+++ b/.github/workflows/l7-perf.yaml
@@ -550,3 +550,7 @@ jobs:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
       success: ${{ needs.install-and-perftest.result == 'success' }}
+      # This perf test does not collect feature status (capture_features_tested
+      # is false), so it produces no features-tested artifact. Skip that merge
+      # to avoid a spurious "No matching features-tested-* artifacts found" warning.
+      merge-features: false


### PR DESCRIPTION
Follow-up to the scheduled-run warning cleanup. Two more workflows still warned
about a missing features-tested artifact.

The l7 perf job never collects feature status, so it now skips that merge via a
new merge-features input on the common post jobs workflow (mirroring the
existing merge-junits input). The MCS API job runs two clusters and now
captures the feature status per cluster with explicit feature-status steps, the
same way conformance-clustermesh does it.

conformance-ginkgo (and conformance-race, which reuses it) still warn about
features-tested; that collection fails inside the test VM and is being
investigated separately in #47174.
