### PR TITLE
.github: fix conformance-ginkgo features-tested artifact upload

### DIFF
--- a/.github/actions/ginkgo/main-focus.yaml
+++ b/.github/actions/ginkgo/main-focus.yaml
@@ -228,6 +228,9 @@ exclude:
     focus: "f05-agent-policy-multi-node-2"
 
   - k8s-version: "1.33"
+    focus: "f06-agent-policy-basic"
+
+  - k8s-version: "1.33"
     focus: "f11-datapath-service-ns-tc"
 
   - k8s-version: "1.33"

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -582,6 +582,19 @@ jobs:
             fi
             mv "$file" "./${new_filename}"
           done
+          # Collect any feature-status collection error logs so a failure that
+          # would otherwise only appear on the (ephemeral) VM console survives,
+          # even on a passing run.
+          mkdir -p feature-status-errors
+          find ./test -type f -iname 'feature-status-error-*.log' -exec cp {} feature-status-errors/ \; || true
+
+      - name: Upload feature status error logs
+        if: ${{ always() && steps.run-tests.outcome != 'skipped' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: feature-status-errors-${{ env.job_name }}
+          path: untrusted/feature-status-errors/*.log
+          if-no-files-found: ignore
 
       - name: Fetch JUnits
         if: ${{ always() && steps.run-tests.outcome != 'skipped' }}

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -567,6 +567,12 @@ jobs:
         run: |
           cd untrusted
           sudo chown $USER:$USER -R ./test
+          # The renamed reports must land in the workspace root, not here in
+          # untrusted/: the shared post-logic action uploads them with the glob
+          # './features-tested-*.json', which actions/upload-artifact resolves
+          # relative to $GITHUB_WORKSPACE. Moving them into untrusted/ (the '.'
+          # after this cd) leaves them outside that glob, so the upload found
+          # nothing and warned on every E2E job.
           find . -type f -iname 'feature-status-*.json' | while IFS= read -r file; do
             basename_file=$(basename "$file")
             suffix="${basename_file#feature-status-}"
@@ -576,11 +582,11 @@ jobs:
               new_filename="${new_filename:0:250}"
             fi
             # Check if file already exists and fail if it does
-            if [ -f "./${new_filename}" ]; then
-              echo "Error: File ./${new_filename} already exists. Aborting to prevent overwrite."
+            if [ -f "${GITHUB_WORKSPACE}/${new_filename}" ]; then
+              echo "Error: File ${GITHUB_WORKSPACE}/${new_filename} already exists. Aborting to prevent overwrite."
               exit 1
             fi
-            mv "$file" "./${new_filename}"
+            mv "$file" "${GITHUB_WORKSPACE}/${new_filename}"
           done
           # Collect any feature-status collection error logs so a failure that
           # would otherwise only appear on the (ephemeral) VM console survives,

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4189,24 +4189,53 @@ func serviceAddressKey(ip, port, proto, scope string) string {
 }
 
 func (kub *Kubectl) CollectFeatures() {
-	ctx, cancel := context.WithTimeout(context.Background(), MidCommandTimeout)
-	defer cancel()
-
 	testPath, err := CreateReportDirectory()
 	if err != nil {
 		log.WithError(err).Errorf("cannot create test result path '%s'", testPath)
 		return
 	}
 
+	// Collect each report format under its own MidCommandTimeout rather than a
+	// single shared one: the metrics fetch dominates the budget, so sharing one
+	// context between the two collections risks starving the second of time.
+	kub.collectFeatureStatus(testPath, "markdown", "md")
+	kub.collectFeatureStatus(testPath, "json", "json")
+}
+
+// collectFeatureStatus runs `cilium-cli features status` for a single output
+// format, writing the report next to the other test_results. It uses its own
+// MidCommandTimeout so each format gets the full budget.
+func (kub *Kubectl) collectFeatureStatus(testPath, format, ext string) {
+	ctx, cancel := context.WithTimeout(context.Background(), MidCommandTimeout)
+	defer cancel()
+
 	// We need to get into the root directory because the CLI doesn't yet
 	// support absolute path. Once https://github.com/cilium/cilium-cli/pull/1552
 	// is installed in test VM images, we can remove this.
-	res := kub.ExecContext(ctx, fmt.Sprintf("cilium-cli features status -o markdown --output-file='%s/feature-status-%s.md'", testPath, ginkgoext.GetTestName()))
+	//
+	// The output path is double-quoted, not single-quoted: some test names
+	// contain an apostrophe (e.g. "Checks the pod's mac address"), which
+	// GetTestName keeps. Under single quotes the apostrophe would terminate the
+	// quoted string and the shell would drop it, so cilium-cli would receive a
+	// path without the apostrophe while CreateReportDirectory created the
+	// directory with it, and the write would fail with "no such file or
+	// directory". Double quotes preserve the apostrophe and keep both in sync.
+	res := kub.ExecContext(ctx, fmt.Sprintf("cilium-cli features status -o %s --output-file=\"%s/feature-status-%s.%s\"", format, testPath, ginkgoext.GetTestName(), ext))
 	if !res.WasSuccessful() {
-		log.WithError(res.GetError()).Errorf("failed to collect feature status :%s", res.CombineOutput().String())
+		recordFeatureStatusError(testPath, format, res)
 	}
-	res = kub.ExecContext(ctx, fmt.Sprintf("cilium-cli features status -o json --output-file='%s/feature-status-%s.json'", testPath, ginkgoext.GetTestName()))
-	if !res.WasSuccessful() {
-		log.WithError(res.GetError()).Errorf("failed to collect feature status :%s", res.CombineOutput().String())
+}
+
+// recordFeatureStatusError logs a failed 'features status' collection and also
+// persists its combined output to a file under testPath. The command runs
+// inside the test VM and only ever logged to the (ephemeral) VM console, so on
+// a passing run the failure left no downloadable trace. Writing it next to the
+// other test_results artifacts makes the real error visible after the fact.
+func recordFeatureStatusError(testPath, format string, res *CmdRes) {
+	out := res.CombineOutput().String()
+	log.WithError(res.GetError()).Errorf("failed to collect feature status :%s", out)
+	errFile := filepath.Join(testPath, fmt.Sprintf("feature-status-error-%s-%s.log", ginkgoext.GetTestName(), format))
+	if writeErr := os.WriteFile(errFile, []byte(out), 0o644); writeErr != nil {
+		log.WithError(writeErr).Errorf("cannot write feature status error log '%s'", errFile)
 	}
 }


### PR DESCRIPTION
The scheduled conformance-ginkgo runs warned about a missing features-tested
artifact on every E2E job, and the run-level merge then found nothing to merge.
The warning had been read as "the json report is never produced", but that
turned out to be a measurement artifact: cilium-cli does write the json report
inside the test VM. The real problem is where the report ends up. The "Fetch
tested features" step does a cd into the untrusted checkout and then moves each
report to ./features-tested-..., so it lands under untrusted/. The shared
post-logic action uploads them with the glob ./features-tested-*.json, which
actions/upload-artifact resolves against the workspace root, one directory
above. The files never matched the upload glob, so every job warned and no
artifact was produced. This moves the renamed report to the workspace root
instead, matching where the upload looks, which is the same convention the
host-side feature-status action already uses.

While tracking this down a couple of long-standing rough edges in the in-VM
collection were also cleaned up: failures were only logged to the VM console,
which is not uploaded on a passing run, so a broken collection left no
downloadable trace while the run stayed green; the output path was single-quoted
and so broke for test names containing an apostrophe; and both report formats
shared a single command timeout. These are folded into one commit that makes the
collection robust and its failures observable, without changing any test
outcome.

Finally, f06-agent-policy-basic was still being scheduled on the 1.33 leg even
though the whole K8sAgentPolicyTest suite is skipped on the 5.4 kernel that leg
runs with. It ran zero specs, produced no feature status, and warned. Its
sibling policy focuses were already excluded there, so this just excludes
f06-agent-policy-basic too.

This PR was prepared with AIL:3.

```release-note
Fixed the conformance-ginkgo feature status report not being uploaded as an artifact.
```
