### PR TITLE
chore: refresh expired dates in SECURITY-INSIGHTS.yml

### DIFF
--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -1,8 +1,8 @@
 header:
   schema-version: '1.0.0'
-  expiration-date: '2025-01-26T01:00:00.000Z'
-  last-updated: '2024-01-26'
-  last-reviewed: '2024-01-26'
+  expiration-date: '2027-07-14T01:00:00.000Z'
+  last-updated: '2026-07-14'
+  last-reviewed: '2026-07-14'
   project-url: https://github.com/cilium/cilium
   license: https://github.com/cilium/cilium/blob/main/LICENSE
 project-lifecycle:


### PR DESCRIPTION
## What
Refresh the date fields in `SECURITY-INSIGHTS.yml`:

```diff
-  expiration-date: '2025-01-26T01:00:00.000Z'
-  last-updated: '2024-01-26'
-  last-reviewed: '2024-01-26'
+  expiration-date: '2027-07-14T01:00:00.000Z'
+  last-updated: '2026-07-14'
+  last-reviewed: '2026-07-14'
```

## Why
The [OpenSSF Security Insights](https://github.com/ossf/security-insights-spec) manifest declared `expiration-date: 2025-01-26`, which has been in the past for ~18 months (the file's only commit is from 2024-01-29, so it was never refreshed). Consumers of the manifest — and OpenSSF tooling that ingests it — may treat an expired manifest as stale or untrusted, which quietly undercuts its purpose.

This bumps `expiration-date` one year out and refreshes `last-updated` / `last-reviewed`. I only changed the dates — please confirm the rest of the manifest still reflects Cilium's current security posture as part of merging (the merge re-attests it). Signed off per DCO.

I used AI assistance to spot this and prepare the change; I verified the dates and the spec myself.