### PR TITLE
chore: use GH_RUNNER_CILIUM_BASE_AMD64/ARM64 vars for integration-test runners

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -65,7 +65,7 @@ jobs:
   echo-inputs:
     if: ${{ github.event_name == 'workflow_dispatch' }}
     name: Echo Workflow Dispatch Inputs
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.UBUNTU_2404_AMD64_4CPU_16GB }}
     steps:
       - name: Echo Workflow Dispatch Inputs
         run: |
@@ -73,7 +73,7 @@ jobs:
 
   commit-status-start:
     name: Commit Status Start
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.UBUNTU_2404_AMD64_4CPU_16GB }}
     steps:
       - name: Set initial commit status
         uses: cilium/cilium/.github/actions/set-commit-status@main # main
@@ -89,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ["${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}", ubuntu-24.04-arm64]
+        arch: ["${{ vars.UBUNTU_2404_AMD64_4CPU_16GB }}", "${{ vars.UBUNTU_2404_ARM64_4CPU_16GB }}"]
     runs-on: ${{ matrix.arch }}
     timeout-minutes: 45
     steps:
@@ -249,7 +249,7 @@ jobs:
   merge-upload:
     if: ${{ always() }}
     name: Merge and Upload Artifacts
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.UBUNTU_2404_AMD64_4CPU_16GB }}
     needs: integration-test
     steps:
       - name: Checkout context ref (trusted)
@@ -268,7 +268,7 @@ jobs:
     if: ${{ always() }}
     name: Commit Status Final
     needs: integration-test
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.UBUNTU_2404_AMD64_4CPU_16GB }}
     steps:
       - name: Set final commit status
         uses: cilium/cilium/.github/actions/set-commit-status@main # main


### PR DESCRIPTION
This PR changes the runner labels used in integration-test.yaml from hardcoded ubuntu-24.04 / ubuntu-24.04-arm64 strings to the vars.GH_RUNNER_CILIUM_BASE_AMD64 and vars.GH_RUNNER_CILIUM_BASE_ARM64 GitHub Actions repository/organization variables.

This allows the actual runner type (e.g. self-hosted vs. GitHub-hosted, or a specific sized runner) to be controlled centrally via repo/org variables for OSS/Enterprise versions instead of being pinned in the workflow file, making it easier to change runners without editing workflow YAML.

Jobs updated:

echo-inputs
commit-status-start
integration-test (matrix arch for both AMD64 and ARM64)
merge-upload
commit-status-final