### PR TITLE
.github: fix conformance-ginkgo sysdump artifact upload path

### DIFF
--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -589,13 +589,15 @@ jobs:
           for filename in *.xml; do cp "${filename}" "../../cilium-junits/${junit_filename}"; done;
 
       - name: Upload artifacts
-        if: ${{ !success() }}
+        if: ${{ !success() && steps.provision-vh-vms.outcome == 'success' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: cilium-sysdumps-bugtool-${{ matrix.k8s-version }}-${{matrix.focus}}
-          path: |
-            bugtool-*.tar.gz
-            test_results-*.tar.gz
+          name: cilium-sysdumps-${{ matrix.k8s-version }}-${{matrix.focus}}
+          # The tarball is written under the host-mounted 'untrusted/' dir.
+          path: untrusted/test_results-*.tar.gz
+          # Fail loudly if the tarball is missing: a silent "No files found"
+          # warning is what hid this upload from being noticed for months.
+          if-no-files-found: error
 
       - name: Run common post steps
         if: ${{ always() }}


### PR DESCRIPTION
When a conformance-ginkgo job fails, the framework already gathers the cilium-agent logs and a sysdump into /host/test/test_results while Cilium is still running, and the "Fetch artifacts" step tars that into test_results-<job>.tar.gz. Since the LVH VM mounts the runner's untrusted/ directory at /host, the tarball lands at untrusted/test_results-<job>.tar.gz on the runner.

The "Upload artifacts" step, however, still globbed test_results-*.tar.gz from the workspace root, so upload-artifact found nothing and emitted only a warning. This regressed in 76de630b78, which moved the checkout under untrusted/ and updated the JUnit copy path but not the test_results path. As a result every conformance-ginkgo failure (including ci-conformance-race) uploaded only the JUnit XML, and the full data-race stack from test/helpers/utils.go was lost.

Point the upload at untrusted/test_results-*.tar.gz, drop the bugtool-*.tar.gz glob that no step produces, and set if-no-files-found: error so a future path or mount drift fails the step instead of hiding behind a warning. The upload if: is aligned with the Fetch step's provision guard to avoid a false alarm when provisioning itself failed.

Fixes: #47155