### PR TITLE
DO NOT MERGE: validate #47155 sysdump upload fix

### DIFF
--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -589,13 +589,15 @@ jobs:
           for filename in *.xml; do cp "${filename}" "../../cilium-junits/${junit_filename}"; done;
 
       - name: Upload artifacts
-        if: ${{ !success() }}
+        if: ${{ !success() && steps.provision-vh-vms.outcome == 'success' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: cilium-sysdumps-bugtool-${{ matrix.k8s-version }}-${{matrix.focus}}
-          path: |
-            bugtool-*.tar.gz
-            test_results-*.tar.gz
+          name: cilium-sysdumps-${{ matrix.k8s-version }}-${{matrix.focus}}
+          # The tarball is written under the host-mounted 'untrusted/' dir.
+          path: untrusted/test_results-*.tar.gz
+          # Fail loudly if the tarball is missing: a silent "No files found"
+          # warning is what hid this upload from being noticed for months.
+          if-no-files-found: error
 
       - name: Run common post steps
         if: ${{ always() }}

--- a/test/k8s/net_policies.go
+++ b/test/k8s/net_policies.go
@@ -736,6 +736,11 @@ var _ = SkipDescribeIf(func() bool {
 
 				err := kubectl.WaitforPods(helpers.DefaultNamespace, "", helpers.HelperTimeout)
 				Expect(err).Should(BeNil(), "connectivity-check pods are not ready after timeout")
+
+				// DO NOT MERGE - temporary forced failure to validate that the
+				// sysdump/test_results artifact is now uploaded on failure (#47155).
+				// Fails while Cilium is still up so AfterFailed gathers real logs.
+				Fail("DO NOT MERGE: forcing failure to validate #47155 sysdump upload")
 			})
 		})
 	})


### PR DESCRIPTION
DO NOT MERGE — throwaway validation PR for #47155.

This branch is the #47155 fix (correct the conformance-ginkgo sysdump
artifact upload path) plus a temporary commit that forces the
`f04-agent-policy-multi-node-1` race leg to fail, so the failure-only
"Upload artifacts" step actually runs.

Purpose: confirm that a failing `ci-conformance-race` run now uploads a
`cilium-sysdumps-*` artifact containing the sysdump / cilium-agent logs
(with the full DATA RACE stack), which the pre-fix workflow dropped.

Will be closed and the branch deleted once validated. The real fix is
tracked in #47187.
