### PR TITLE
operator/endpointslice: context-related fixes

### DIFF
--- a/operator/pkg/ciliumendpointslice/controller.go
+++ b/operator/pkg/ciliumendpointslice/controller.go
@@ -4,7 +4,6 @@
 package ciliumendpointslice
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -53,9 +52,7 @@ type params struct {
 }
 
 type Controller struct {
-	logger        *slog.Logger
-	context       context.Context
-	contextCancel context.CancelFunc
+	logger *slog.Logger
 
 	// Cilium kubernetes clients to access V2 and V2alpha1 resources
 	clientset           k8sClient.Clientset

--- a/operator/pkg/ciliumendpointslice/endpointslice.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
@@ -164,22 +164,29 @@ func (c *DefaultController) Start(ctx cell.HookContext) error {
 	// if the error has not appeared or the maximum number of retries has been reached, the element is forgotten.
 
 	c.logger.InfoContext(ctx, "Bootstrap ces controller")
-	c.context, c.contextCancel = context.WithCancel(context.Background())
 	defer utilruntime.HandleCrash()
 
 	c.manager = newDefaultManager(c.maxCEPsInCES, c.logger)
 
-	c.reconciler = newDefaultReconciler(c.context, c.clientset.CiliumV2alpha1(), c.manager, c.logger, c.ciliumEndpoint, c.ciliumEndpointSlice, c.metrics)
+	cepStore, _ := c.ciliumEndpoint.Store(ctx)
+	cesStore, _ := c.ciliumEndpointSlice.Store(ctx)
+	c.reconciler = newDefaultReconciler(c.clientset.CiliumV2alpha1(), c.manager, c.logger, cepStore, cesStore, c.metrics)
 	c.doReconciler = c.reconciler
 
 	c.initializeQueue()
 
+	workerCtx, workerCancel := context.WithCancel(context.Background())
+	// ensure the worker context is canceled if the Start context is canceled, to ensure it returns quickly.
+	stop := context.AfterFunc(ctx, workerCancel)
+	defer stop()
+
 	// Subscribe before draining to avoid missing events between subscription
 	// and drain (see syncCESsInLocalCache).
-	ciliumEndpointEvents := c.ciliumEndpoint.Events(c.context)
-	ciliumEndpointSliceEvents := c.ciliumEndpointSlice.Events(c.context)
+	ciliumEndpointEvents := c.ciliumEndpoint.Events(workerCtx)
+	ciliumEndpointSliceEvents := c.ciliumEndpointSlice.Events(workerCtx)
 
 	if err := c.syncCESsInLocalCache(ciliumEndpointEvents, ciliumEndpointSliceEvents); err != nil {
+		workerCancel()
 		return err
 	}
 
@@ -199,15 +206,16 @@ func (c *DefaultController) Start(ctx cell.HookContext) error {
 	c.wp.Submit("cilium-nodes-updater", c.runCiliumNodesUpdater)
 
 	c.logger.InfoContext(ctx, "Starting CES controller reconciler.")
+
 	c.Job.Add(
-		job.OneShot("proc-queues", func(ctx context.Context, health cell.Health) error {
-			c.worker()
+		job.OneShot("proc-queues", func(_ context.Context, health cell.Health) error {
+			c.worker(workerCtx)
 			return nil
 		}),
 		// Add the shutdown job last so it stops first.
 		job.OneShot("shutdown", func(ctx context.Context, health cell.Health) error {
 			<-ctx.Done()
-			c.contextCancel()
+			workerCancel()
 			c.wp.Close()
 			c.fastQueue.ShutDown()
 			c.standardQueue.ShutDown()
@@ -227,20 +235,30 @@ func (c *SlimController) Start(ctx cell.HookContext) error {
 	// Processing queues handled as with DefaultController.
 
 	c.logger.InfoContext(ctx, "Bootstrap ces controller")
-	c.context, c.contextCancel = context.WithCancel(context.Background())
 	defer utilruntime.HandleCrash()
 
 	c.manager = newSlimManager(c.maxCEPsInCES, c.logger)
 
-	c.reconciler = newSlimReconciler(c.context, c.clientset.CiliumV2alpha1(), c.manager, c.logger, c.ciliumEndpointSlice, c.pods, c.ciliumIdentity, c.ciliumNodes, c.namespace, c.metrics, c.ipsecEnabled, c.wgEnabled)
+	cesStore, _ := c.ciliumEndpointSlice.Store(ctx)
+	podStore, _ := c.pods.Store(ctx)
+	ciStore, _ := c.ciliumIdentity.Store(ctx)
+	cnodeStore, _ := c.ciliumNodes.Store(ctx)
+	namespaceStore, _ := c.namespace.Store(ctx)
+	c.reconciler = newSlimReconciler(c.clientset.CiliumV2alpha1(), c.manager, c.logger, cesStore, podStore, ciStore, cnodeStore, namespaceStore, c.metrics, c.ipsecEnabled, c.wgEnabled)
 	c.doReconciler = c.reconciler
 
 	c.initializeQueue()
 
+	workerCtx, workerCancel := context.WithCancel(context.Background())
+	// ensure the worker context is canceled if the Start context is canceled, to ensure it returns quickly.
+	stop := context.AfterFunc(ctx, workerCancel)
+	defer stop()
+
 	// starts the events loop before syncCESsInLocalCache() to be sure we don't miss any event
-	ciliumEndpointSliceEvents := c.ciliumEndpointSlice.Events(c.context)
+	ciliumEndpointSliceEvents := c.ciliumEndpointSlice.Events(workerCtx)
 
 	if err := c.syncCESsInLocalCache(ctx); err != nil {
+		workerCancel()
 		return err
 	}
 
@@ -260,8 +278,8 @@ func (c *SlimController) Start(ctx cell.HookContext) error {
 		job.OneShot("proc-ciliumidentities-events", func(ctx context.Context, health cell.Health) error {
 			return c.runCiliumIdentitiesUpdater(ctx)
 		}),
-		job.OneShot("proc-queues", func(ctx context.Context, health cell.Health) error {
-			c.worker()
+		job.OneShot("proc-queues", func(_ context.Context, health cell.Health) error {
+			c.worker(workerCtx)
 			return nil
 		}),
 		// Add the shutdown job last so it stops first.
@@ -269,7 +287,7 @@ func (c *SlimController) Start(ctx cell.HookContext) error {
 			<-ctx.Done()
 			c.fastQueue.ShutDown()
 			c.standardQueue.ShutDown()
-			c.contextCancel()
+			workerCancel()
 			return nil
 		}),
 	)
@@ -622,15 +640,15 @@ func (c *SlimController) syncCESsInLocalCache(ctx context.Context) error {
 
 // worker runs a worker thread that just dequeues items, processes them, and
 // marks them done.
-func (c *Controller) worker() {
-	for c.processNextWorkItem() {
+func (c *Controller) worker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
 	}
 }
 
-func (c *Controller) rateLimitProcessing() {
+func (c *Controller) rateLimitProcessing(ctx context.Context) {
 	delay := c.rateLimit.getDelay()
 	select {
-	case <-c.context.Done():
+	case <-ctx.Done():
 	case <-time.After(delay):
 	}
 }
@@ -650,8 +668,8 @@ func (c *Controller) getQueue() workqueue.TypedRateLimitingInterface[CESKey] {
 	}
 }
 
-func (c *Controller) processNextWorkItem() bool {
-	c.rateLimitProcessing()
+func (c *Controller) processNextWorkItem(ctx context.Context) bool {
+	c.rateLimitProcessing(ctx)
 	queue := c.getQueue()
 	key, quit := queue.Get()
 	if quit {
@@ -662,7 +680,7 @@ func (c *Controller) processNextWorkItem() bool {
 	c.logger.Debug("Processing CES", logfields.CESName, key.string())
 
 	queueDelay := c.getAndResetCESProcessingDelay(key)
-	err := c.doReconciler.reconcileCES(CESName(key.Name))
+	err := c.doReconciler.reconcileCES(ctx, CESName(key.Name))
 	if queue == c.fastQueue {
 		c.metrics.CiliumEndpointSliceQueueDelay.WithLabelValues(LabelQueueFast).Observe(queueDelay)
 	} else {

--- a/operator/pkg/ciliumendpointslice/endpointslice_test.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice_test.go
@@ -4,7 +4,6 @@
 package ciliumendpointslice
 
 import (
-	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -57,9 +56,9 @@ func TestFCFSModeSyncCESsInLocalCacheDefault(t *testing.T) {
 		}),
 	)
 	hive.Start(log, t.Context())
-	r = newDefaultReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
 	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
 	cepStore, _ := ciliumEndpoint.Store(t.Context())
+	r = newDefaultReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, cepStore, cesStore, cesMetrics)
 	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
 	assert.NoError(t, err)
 	cesController := &DefaultController{
@@ -152,7 +151,9 @@ func TestDifferentSpeedQueuesDefault(t *testing.T) {
 	)
 	hive.Start(log, t.Context())
 
-	r = newDefaultReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
+	cepStore, _ := ciliumEndpoint.Store(t.Context())
+	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
+	r = newDefaultReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, cepStore, cesStore, cesMetrics)
 
 	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
 	assert.NoError(t, err)
@@ -173,7 +174,6 @@ func TestDifferentSpeedQueuesDefault(t *testing.T) {
 		reconciler:     r,
 		ciliumEndpoint: ciliumEndpoint,
 	}
-	cesController.context, cesController.contextCancel = context.WithCancel(t.Context())
 	cesController.priorityNamespaces["FastNamespace"] = struct{}{}
 	cesController.initializeQueue()
 	var ns = "NotSoImportant"
@@ -207,7 +207,7 @@ func TestDifferentSpeedQueuesDefault(t *testing.T) {
 	}
 
 	for i := range 10 {
-		cesController.processNextWorkItem()
+		cesController.processNextWorkItem(t.Context())
 		if i < 4 {
 			standardQueueLen = 6
 			fastQueueLen = 3 - i
@@ -256,7 +256,9 @@ func TestCESManagementDefault(t *testing.T) {
 	)
 	hive.Start(log, t.Context())
 
-	r = newDefaultReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
+	cepStore, _ := ciliumEndpoint.Store(t.Context())
+	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
+	r = newDefaultReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, cepStore, cesStore, cesMetrics)
 
 	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
 	assert.NoError(t, err)
@@ -277,7 +279,6 @@ func TestCESManagementDefault(t *testing.T) {
 		reconciler:     r,
 		ciliumEndpoint: ciliumEndpoint,
 	}
-	cesController.context, cesController.contextCancel = context.WithCancel(t.Context())
 	cesController.initializeQueue()
 	var ns = "ns"
 
@@ -288,7 +289,7 @@ func TestCESManagementDefault(t *testing.T) {
 	}, time.Second); err != nil {
 		assert.Equal(t, 1, cesController.standardQueue.Len())
 	}
-	cesController.processNextWorkItem()
+	cesController.processNextWorkItem(t.Context())
 	//A CEP is enqueued and processed. Then, the same CEP (and CES) is enqueued
 	//to test if the CESStore works properly and if the associated CES can be found in the store
 	cesController.onEndpointUpdate(cep1)
@@ -347,12 +348,12 @@ func TestFCFSModeSyncCESsInLocalCache(t *testing.T) {
 	tlog := hivetest.Logger(t)
 	hive.Start(tlog, t.Context())
 	labelsfilter.ParseLabelPrefixCfg(tlog, nil, nil, "")
-	r = newSlimReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpointSlice, pods, ciliumIdentity, ciliumNode, namespace, cesMetrics, false, false)
 	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
 	nodeStore, _ := ciliumNode.Store(t.Context())
 	cidStore, _ := ciliumIdentity.Store(t.Context())
 	podStore, _ := pods.Store(t.Context())
 	nsStore, _ := namespace.Store(t.Context())
+	r = newSlimReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, cesStore, podStore, cidStore, nodeStore, nsStore, cesMetrics, false, false)
 	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
 	assert.NoError(t, err)
 	cesController := &SlimController{
@@ -475,7 +476,12 @@ func TestDifferentSpeedQueues(t *testing.T) {
 	hive.Start(tlog, t.Context())
 	labelsfilter.ParseLabelPrefixCfg(tlog, nil, nil, "")
 
-	r = newSlimReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpointSlice, pods, ciliumIdentity, ciliumNode, namespace, cesMetrics, false, false)
+	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
+	nodeStore, _ := ciliumNode.Store(t.Context())
+	cidStore, _ := ciliumIdentity.Store(t.Context())
+	podStore, _ := pods.Store(t.Context())
+	nsStore, _ := namespace.Store(t.Context())
+	r = newSlimReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, cesStore, podStore, cidStore, nodeStore, nsStore, cesMetrics, false, false)
 
 	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
 	assert.NoError(t, err)
@@ -500,7 +506,6 @@ func TestDifferentSpeedQueues(t *testing.T) {
 		pods:           pods,
 		ciliumIdentity: ciliumIdentity,
 	}
-	cesController.context, cesController.contextCancel = context.WithCancel(t.Context())
 	cesController.priorityNamespaces["FastNamespace"] = struct{}{}
 	cesController.initializeQueue()
 	var ns = "NotSoImportant"
@@ -534,7 +539,7 @@ func TestDifferentSpeedQueues(t *testing.T) {
 	}
 
 	for i := range 10 {
-		cesController.processNextWorkItem()
+		cesController.processNextWorkItem(t.Context())
 		if i < 4 {
 			standardQueueLen = 6
 			fastQueueLen = 3 - i
@@ -596,10 +601,12 @@ func TestCESManagement(t *testing.T) {
 	hive.Start(tlog, t.Context())
 	labelsfilter.ParseLabelPrefixCfg(tlog, nil, nil, "")
 
-	r = newSlimReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpointSlice, pods, ciliumIdentity, ciliumNode, namespace, cesMetrics, false, false)
+	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
+	podStore, _ := pods.Store(t.Context())
 	nodeStore, _ := ciliumNode.Store(t.Context())
 	cidStore, _ := ciliumIdentity.Store(t.Context())
 	nsStore, _ := namespace.Store(t.Context())
+	r = newSlimReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, cesStore, podStore, cidStore, nodeStore, nsStore, cesMetrics, false, false)
 
 	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
 	assert.NoError(t, err)
@@ -624,7 +631,6 @@ func TestCESManagement(t *testing.T) {
 		pods:           pods,
 		ciliumIdentity: ciliumIdentity,
 	}
-	cesController.context, cesController.contextCancel = context.WithCancel(t.Context())
 	cesController.initializeQueue()
 	var ns = "ns"
 
@@ -648,7 +654,7 @@ func TestCESManagement(t *testing.T) {
 	}, time.Second); err != nil {
 		assert.Equal(t, 1, cesController.standardQueue.Len())
 	}
-	cesController.processNextWorkItem()
+	cesController.processNextWorkItem(t.Context())
 	//A CEP is enqueued and processed. Then, the same CEP (and CES) is enqueued
 	//to test if the CESStore works properly and if the associated CES can be found in the store
 	cesController.onPodUpdate(pod1)
@@ -708,12 +714,12 @@ func TestSyncCESsInLocalCacheDeletedCID(t *testing.T) {
 	tlog := hivetest.Logger(t)
 	hive.Start(tlog, t.Context())
 	labelsfilter.ParseLabelPrefixCfg(tlog, nil, nil, "")
-	r = newSlimReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpointSlice, pods, ciliumIdentity, ciliumNode, namespace, cesMetrics, false, false)
 	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
 	nodeStore, _ := ciliumNode.Store(t.Context())
 	cidStore, _ := ciliumIdentity.Store(t.Context())
 	podStore, _ := pods.Store(t.Context())
 	nsStore, _ := namespace.Store(t.Context())
+	r = newSlimReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, cesStore, podStore, cidStore, nodeStore, nsStore, cesMetrics, false, false)
 	rateLimitConfig, err := getRateLimitConfig(params{Cfg: defaultConfig})
 	assert.NoError(t, err)
 	cesController := &SlimController{

--- a/operator/pkg/ciliumendpointslice/reconciler.go
+++ b/operator/pkg/ciliumendpointslice/reconciler.go
@@ -27,7 +27,7 @@ import (
 )
 
 type doReconciler interface {
-	reconcileCES(cesName CESName) error
+	reconcileCES(ctx context.Context, cesName CESName) error
 }
 
 type endpointGetter interface {
@@ -39,7 +39,6 @@ type endpointGetter interface {
 type reconciler struct {
 	logger   *slog.Logger
 	client   clientset.CiliumV2alpha1Interface
-	context  context.Context
 	cesStore resource.Store[*cilium_v2a1.CiliumEndpointSlice]
 	metrics  *Metrics
 
@@ -71,19 +70,15 @@ type slimReconciler struct {
 
 // newDefaultReconciler creates and initializes a new defaultReconciler.
 func newDefaultReconciler(
-	ctx context.Context,
 	client clientset.CiliumV2alpha1Interface,
 	cesMgr *defaultManager,
 	logger *slog.Logger,
-	ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint],
-	ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice],
+	cepStore resource.Store[*cilium_v2.CiliumEndpoint],
+	cesStore resource.Store[*cilium_v2a1.CiliumEndpointSlice],
 	metrics *Metrics,
 ) *defaultReconciler {
-	cepStore, _ := ciliumEndpoint.Store(ctx)
-	cesStore, _ := ciliumEndpointSlice.Store(ctx)
 	dReconciler := defaultReconciler{
 		reconciler: reconciler{
-			context:    ctx,
 			logger:     logger,
 			client:     client,
 			cesManager: cesMgr,
@@ -99,27 +94,20 @@ func newDefaultReconciler(
 
 // newSlimReconciler creates and initializes a new slimReconciler.
 func newSlimReconciler(
-	ctx context.Context,
 	client clientset.CiliumV2alpha1Interface,
 	cesMgr *slimManager,
 	logger *slog.Logger,
-	ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice],
-	pod resource.Resource[*slim_corev1.Pod],
-	ciliumIdentity resource.Resource[*cilium_v2.CiliumIdentity],
-	ciliumNode resource.Resource[*cilium_v2.CiliumNode],
-	namespace resource.Resource[*slim_corev1.Namespace],
+	cesStore resource.Store[*cilium_v2a1.CiliumEndpointSlice],
+	podStore resource.Store[*slim_corev1.Pod],
+	cidStore resource.Store[*cilium_v2.CiliumIdentity],
+	ciliumNodeStore resource.Store[*cilium_v2.CiliumNode],
+	namespaceStore resource.Store[*slim_corev1.Namespace],
 	metrics *Metrics,
 	ipsecEnabled bool,
 	wgEnabled bool,
 ) *slimReconciler {
-	cesStore, _ := ciliumEndpointSlice.Store(ctx)
-	podStore, _ := pod.Store(ctx)
-	cidStore, _ := ciliumIdentity.Store(ctx)
-	ciliumNodeStore, _ := ciliumNode.Store(ctx)
-	namespaceStore, _ := namespace.Store(ctx)
 	sReconciler := slimReconciler{
 		reconciler: reconciler{
-			context:    ctx,
 			logger:     logger,
 			client:     client,
 			cesManager: cesMgr,
@@ -138,7 +126,7 @@ func newSlimReconciler(
 	return &sReconciler
 }
 
-func (r *reconciler) reconcileCES(cesName CESName) (err error) {
+func (r *reconciler) reconcileCES(ctx context.Context, cesName CESName) (err error) {
 	desiredCEPsNumber := r.cesManager.getCEPCountInCES(cesName)
 	r.metrics.CiliumEndpointSliceDensity.Observe(float64(desiredCEPsNumber))
 	// Check the CES exists is in cesStore i.e. in api-server copy of CESs, if exist update or delete the CES.
@@ -147,19 +135,19 @@ func (r *reconciler) reconcileCES(cesName CESName) (err error) {
 		return
 	}
 	if !exists && desiredCEPsNumber > 0 {
-		return r.reconcileCESCreate(cesName)
+		return r.reconcileCESCreate(ctx, cesName)
 	} else if exists && desiredCEPsNumber > 0 {
-		return r.reconcileCESUpdate(cesName, cesObj)
+		return r.reconcileCESUpdate(ctx, cesName, cesObj)
 	} else if exists && desiredCEPsNumber == 0 {
-		return r.reconcileCESDelete(cesObj)
+		return r.reconcileCESDelete(ctx, cesObj)
 	} else { // !exist && desiredCEPsNumber == 0 => no op
 		return nil
 	}
 }
 
 // Create a new CES in api-server.
-func (r *reconciler) reconcileCESCreate(cesName CESName) (err error) {
-	r.logger.DebugContext(r.context, "Reconciling CES Create", logfields.CESName, cesName.string())
+func (r *reconciler) reconcileCESCreate(ctx context.Context, cesName CESName) (err error) {
+	r.logger.DebugContext(ctx, "Reconciling CES Create", logfields.CESName, cesName.string())
 	ceps := r.cesManager.getCEPinCES(cesName)
 	r.metrics.CiliumEndpointsChangeCount.WithLabelValues(LabelValueCEPInsert).Observe(float64(len(ceps)))
 	newCES := &cilium_v2a1.CiliumEndpointSlice{
@@ -177,7 +165,7 @@ func (r *reconciler) reconcileCESCreate(cesName CESName) (err error) {
 
 	for _, cepName := range ceps {
 		ccep := r.endpointGetter.getCoreEndpointFromStore(cepName)
-		r.logger.DebugContext(r.context,
+		r.logger.DebugContext(ctx,
 			fmt.Sprintf("Adding CEP to new CES (exist %v)", ccep != nil),
 			logfields.CESName, cesName.string(),
 			logfields.CEPName, cepName.string())
@@ -188,8 +176,8 @@ func (r *reconciler) reconcileCESCreate(cesName CESName) (err error) {
 
 	// Call the client API, to Create CES
 	if _, err = r.client.CiliumEndpointSlices().Create(
-		r.context, newCES, meta_v1.CreateOptions{}); err != nil && !errors.Is(err, context.Canceled) {
-		r.logger.InfoContext(r.context,
+		ctx, newCES, meta_v1.CreateOptions{}); err != nil && !errors.Is(err, context.Canceled) {
+		r.logger.InfoContext(ctx,
 			"Unable to create CiliumEndpointSlice in k8s-apiserver",
 			logfields.CESName, newCES.Name,
 			logfields.Error, err)
@@ -198,8 +186,8 @@ func (r *reconciler) reconcileCESCreate(cesName CESName) (err error) {
 }
 
 // Update an existing CES
-func (r *reconciler) reconcileCESUpdate(cesName CESName, cesObj *cilium_v2a1.CiliumEndpointSlice) (err error) {
-	r.logger.DebugContext(r.context, "Reconciling CES Update", logfields.CESName, cesName.string())
+func (r *reconciler) reconcileCESUpdate(ctx context.Context, cesName CESName, cesObj *cilium_v2a1.CiliumEndpointSlice) (err error) {
+	r.logger.DebugContext(ctx, "Reconciling CES Update", logfields.CESName, cesName.string())
 	updatedCES := cesObj.DeepCopy()
 	cepInserted := 0
 	cepRemoved := 0
@@ -213,7 +201,7 @@ func (r *reconciler) reconcileCESUpdate(cesName CESName, cesObj *cilium_v2a1.Cil
 	// Get the CEPs objects from the CEP Store and map the names to them
 	for _, cepName := range cepsAssignedToCES {
 		ccep := r.endpointGetter.getCoreEndpointFromStore(cepName)
-		r.logger.DebugContext(r.context,
+		r.logger.DebugContext(ctx,
 			fmt.Sprintf("Adding CEP to existing CES (exist %v)", ccep != nil),
 			logfields.CESName, cesName.string(),
 			logfields.CEPName, cepName.string())
@@ -237,7 +225,7 @@ func (r *reconciler) reconcileCESUpdate(cesName CESName, cesObj *cilium_v2a1.Cil
 		}
 	}
 	updatedCES.Endpoints = updatedEndpoints
-	r.logger.DebugContext(r.context,
+	r.logger.DebugContext(ctx,
 		fmt.Sprintf("Inserted %d endpoints, updated %d endpoints, removed %d endpoints",
 			cepInserted,
 			cepUpdated,
@@ -256,28 +244,28 @@ func (r *reconciler) reconcileCESUpdate(cesName CESName, cesObj *cilium_v2a1.Cil
 	r.metrics.CiliumEndpointsChangeCount.WithLabelValues(LabelValueCEPRemove).Observe(float64(cepRemoved))
 
 	if !cesEqual {
-		r.logger.DebugContext(r.context, "CES changed, updating", logfields.CESName, cesName.string())
+		r.logger.DebugContext(ctx, "CES changed, updating", logfields.CESName, cesName.string())
 		// Call the client API, to Create CESs
 		if _, err = r.client.CiliumEndpointSlices().Update(
-			r.context, updatedCES, meta_v1.UpdateOptions{}); err != nil && !errors.Is(err, context.Canceled) {
-			r.logger.InfoContext(r.context,
+			ctx, updatedCES, meta_v1.UpdateOptions{}); err != nil && !errors.Is(err, context.Canceled) {
+			r.logger.InfoContext(ctx,
 				"Unable to update CiliumEndpointSlice in k8s-apiserver",
 				logfields.CESName, updatedCES.Name,
 				logfields.Error, err)
 		}
 	} else {
-		r.logger.DebugContext(r.context, "CES up to date, skipping update", logfields.CESName, cesName.string())
+		r.logger.DebugContext(ctx, "CES up to date, skipping update", logfields.CESName, cesName.string())
 	}
 	return
 }
 
 // Delete the CES.
-func (r *reconciler) reconcileCESDelete(ces *cilium_v2a1.CiliumEndpointSlice) (err error) {
-	r.logger.DebugContext(r.context, "Reconciling CES Delete", logfields.CESName, ces.Name)
+func (r *reconciler) reconcileCESDelete(ctx context.Context, ces *cilium_v2a1.CiliumEndpointSlice) (err error) {
+	r.logger.DebugContext(ctx, "Reconciling CES Delete", logfields.CESName, ces.Name)
 	r.metrics.CiliumEndpointsChangeCount.WithLabelValues(LabelValueCEPRemove).Observe(float64(len(ces.Endpoints)))
 	if err = r.client.CiliumEndpointSlices().Delete(
-		r.context, ces.Name, meta_v1.DeleteOptions{}); err != nil && !errors.Is(err, context.Canceled) {
-		r.logger.InfoContext(r.context,
+		ctx, ces.Name, meta_v1.DeleteOptions{}); err != nil && !errors.Is(err, context.Canceled) {
+		r.logger.InfoContext(ctx,
 			"Unable to delete CiliumEndpointSlice in k8s-apiserver",
 			logfields.CESName, ces.Name,
 			logfields.Error, err)
@@ -291,7 +279,7 @@ func (r *defaultReconciler) getCoreEndpointFromStore(cepName CEPName) *cilium_v2
 	if err == nil && exists {
 		return k8s.ConvertCEPToCoreCEP(cepObj)
 	}
-	r.logger.DebugContext(r.context,
+	r.logger.Debug(
 		fmt.Sprintf("Couldn't get CEP from Store (err=%v, exists=%v)", err, exists),
 		logfields.CEPName, cepName.string(),
 	)
@@ -303,7 +291,7 @@ func (r *slimReconciler) getCoreEndpointFromStore(cepName CEPName) *cilium_v2a1.
 	if err == nil && exists {
 		return r.convertPodToCoreCEP(podObj)
 	}
-	r.logger.DebugContext(r.context,
+	r.logger.Debug(
 		"Couldn't get Pod from Store",
 		logfields.Error, err,
 		logfields.Exists, exists,
@@ -322,7 +310,7 @@ func (r *slimReconciler) getCoreEndpointFromStore(cepName CEPName) *cilium_v2a1.
 func (r *slimReconciler) convertPodToCoreCEP(pod *slim_corev1.Pod) *cilium_v2a1.CoreCiliumEndpoint {
 	identityId, err := r.getPodIdentityIDFromCache(pod)
 	if err != nil {
-		r.logger.DebugContext(r.context, "Could not get pod identity ID",
+		r.logger.Debug("Could not get pod identity ID",
 			logfields.K8sPodName, pod.GetName(),
 			logfields.K8sNamespace, pod.Namespace,
 			logfields.Error, err,
@@ -332,7 +320,7 @@ func (r *slimReconciler) convertPodToCoreCEP(pod *slim_corev1.Pod) *cilium_v2a1.
 
 	networking, err := GetPodEndpointNetworking(pod)
 	if err != nil {
-		r.logger.DebugContext(r.context, "Could not get pod's endpoint networking",
+		r.logger.Debug("Could not get pod's endpoint networking",
 			logfields.K8sPodName, pod.GetName(),
 			logfields.K8sNamespace, pod.Namespace,
 			logfields.Error, err,
@@ -342,7 +330,7 @@ func (r *slimReconciler) convertPodToCoreCEP(pod *slim_corev1.Pod) *cilium_v2a1.
 
 	encryptionKey, err := r.getEndpointEncryptionKey(pod)
 	if err != nil {
-		r.logger.DebugContext(r.context, "Could not get pod's endpoint encryption key",
+		r.logger.Debug("Could not get pod's endpoint encryption key",
 			logfields.K8sPodName, pod.GetName(),
 			logfields.K8sNamespace, pod.Namespace,
 			logfields.Error, err,

--- a/operator/pkg/ciliumendpointslice/reconciler_test.go
+++ b/operator/pkg/ciliumendpointslice/reconciler_test.go
@@ -51,8 +51,9 @@ func TestReconcileCreateDefault(t *testing.T) {
 	)
 	tlog := hivetest.Logger(t)
 	hive.Start(tlog, t.Context())
-	r = newDefaultReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
 	cepStore, _ := ciliumEndpoint.Store(t.Context())
+	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
+	r = newDefaultReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), cepStore, cesStore, cesMetrics)
 
 	var createdSlice *cilium_v2a1.CiliumEndpointSlice
 	fakeClient.CiliumFakeClientset.PrependReactor("create", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
@@ -72,7 +73,7 @@ func TestReconcileCreateDefault(t *testing.T) {
 	m.mapping.insertCEP(NewCEPName("cep1", "ns"), CESName("ces1"))
 	m.mapping.insertCEP(NewCEPName("cep2", "ns"), CESName("ces1"))
 	m.mapping.insertCEP(NewCEPName("cep3", "ns"), CESName("ces2"))
-	r.reconcileCES(CESName("ces1"))
+	r.reconcileCES(t.Context(), CESName("ces1"))
 
 	assert.Equal(t, "ces1", createdSlice.Name)
 	assert.Len(t, createdSlice.Endpoints, 2)
@@ -111,9 +112,9 @@ func TestReconcileUpdateDefault(t *testing.T) {
 
 	tlog := hivetest.Logger(t)
 	hive.Start(tlog, t.Context())
-	r = newDefaultReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
 	cepStore, _ := ciliumEndpoint.Store(t.Context())
 	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
+	r = newDefaultReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), cepStore, cesStore, cesMetrics)
 
 	var updatedSlice *cilium_v2a1.CiliumEndpointSlice
 	fakeClient.CiliumFakeClientset.PrependReactor("update", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
@@ -137,7 +138,7 @@ func TestReconcileUpdateDefault(t *testing.T) {
 	m.mapping.insertCEP(NewCEPName("cep3", "ns"), CESName("ces2"))
 	// ces1 contains cep1 and cep3, but it's mapped to cep1 and cep2
 	// so it's expected that after update it would contain cep1 and cep2
-	r.reconcileCES(CESName("ces1"))
+	r.reconcileCES(t.Context(), CESName("ces1"))
 
 	assert.Equal(t, "ces1", updatedSlice.Name)
 	assert.Len(t, updatedSlice.Endpoints, 2)
@@ -176,9 +177,9 @@ func TestReconcileDeleteDefault(t *testing.T) {
 
 	tlog := hivetest.Logger(t)
 	hive.Start(tlog, t.Context())
-	r = newDefaultReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
 	cepStore, _ := ciliumEndpoint.Store(t.Context())
 	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
+	r = newDefaultReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), cepStore, cesStore, cesMetrics)
 
 	var deletedSlice string
 	fakeClient.CiliumFakeClientset.PrependReactor("delete", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
@@ -201,7 +202,7 @@ func TestReconcileDeleteDefault(t *testing.T) {
 	m.mapping.insertCEP(NewCEPName("cep2", "ns"), CESName("ces2"))
 	m.mapping.insertCEP(NewCEPName("cep3", "ns"), CESName("ces2"))
 	// ces1 contains cep1 and cep3, but it's mapped to nothing so it should be deleted
-	r.reconcileCES(CESName("ces1"))
+	r.reconcileCES(t.Context(), CESName("ces1"))
 
 	assert.Equal(t, "ces1", deletedSlice)
 
@@ -238,8 +239,9 @@ func TestReconcileNoopDefault(t *testing.T) {
 	)
 	tlog := hivetest.Logger(t)
 	hive.Start(tlog, t.Context())
-	r = newDefaultReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
 	cepStore, _ := ciliumEndpoint.Store(t.Context())
+	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
+	r = newDefaultReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), cepStore, cesStore, cesMetrics)
 
 	noRequest := true
 	fakeClient.CiliumFakeClientset.PrependReactor("*", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
@@ -259,7 +261,7 @@ func TestReconcileNoopDefault(t *testing.T) {
 	m.mapping.insertCEP(NewCEPName("cep2", "ns"), CESName("ces2"))
 	m.mapping.insertCEP(NewCEPName("cep3", "ns"), CESName("ces2"))
 	// ces1 contains cep1 and cep3, but it's mapped to nothing so it should be deleted
-	r.reconcileCES(CESName("ces1"))
+	r.reconcileCES(t.Context(), CESName("ces1"))
 
 	assert.True(t, noRequest)
 
@@ -303,10 +305,12 @@ func TestReconcileCreate(t *testing.T) {
 	hive.Start(tlog, t.Context())
 	labelsfilter.ParseLabelPrefixCfg(tlog, nil, nil, "")
 
-	r = newSlimReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpointSlice, pods, ciliumIdentity, ciliumNode, namespace, cesMetrics, false, false)
+	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
 	podStore, _ := pods.Store(t.Context())
-	nsStore, _ := namespace.Store(t.Context())
 	cidStore, _ := ciliumIdentity.Store(t.Context())
+	nodeStore, _ := ciliumNode.Store(t.Context())
+	nsStore, _ := namespace.Store(t.Context())
+	r = newSlimReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), cesStore, podStore, cidStore, nodeStore, nsStore, cesMetrics, false, false)
 	ciliumNodeStore, _ := ciliumNode.Store(t.Context())
 
 	var createdSlice *cilium_v2a1.CiliumEndpointSlice
@@ -351,7 +355,7 @@ func TestReconcileCreate(t *testing.T) {
 	m.mapping.addCEP(NewCEPName("pod2", "ns"), CESName("ces1"), "node1", gidB)
 	m.mapping.addCEP(NewCEPName("pod3", "ns"), CESName("ces2"), "node1", gidC)
 
-	r.reconcileCES(CESName("ces1"))
+	r.reconcileCES(t.Context(), CESName("ces1"))
 
 	assert.Equal(t, "ces1", createdSlice.Name)
 	assert.Len(t, createdSlice.Endpoints, 2)
@@ -399,11 +403,12 @@ func TestReconcileUpdate(t *testing.T) {
 
 	tlog := hivetest.Logger(t)
 	hive.Start(tlog, t.Context())
-	r = newSlimReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpointSlice, pods, ciliumIdentity, ciliumNode, namespace, cesMetrics, false, false)
-	podStore, _ := pods.Store(t.Context())
 	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
-	nsStore, _ := namespace.Store(t.Context())
+	podStore, _ := pods.Store(t.Context())
 	cidStore, _ := ciliumIdentity.Store(t.Context())
+	nodeStore, _ := ciliumNode.Store(t.Context())
+	nsStore, _ := namespace.Store(t.Context())
+	r = newSlimReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), cesStore, podStore, cidStore, nodeStore, nsStore, cesMetrics, false, false)
 	ciliumNodeStore, _ := ciliumNode.Store(t.Context())
 
 	var updatedSlice *cilium_v2a1.CiliumEndpointSlice
@@ -448,7 +453,7 @@ func TestReconcileUpdate(t *testing.T) {
 
 	// ces1 contains cep1 and cep3, but it's mapped to cep1 and cep2
 	// so it's expected that after update it would contain cep1 and cep2
-	r.reconcileCES(CESName("ces1"))
+	r.reconcileCES(t.Context(), CESName("ces1"))
 
 	assert.Equal(t, "ces1", updatedSlice.Name)
 	assert.Len(t, updatedSlice.Endpoints, 2)
@@ -496,11 +501,12 @@ func TestReconcileDelete(t *testing.T) {
 
 	tlog := hivetest.Logger(t)
 	hive.Start(tlog, t.Context())
-	r = newSlimReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpointSlice, pods, ciliumIdentity, ciliumNode, namespace, cesMetrics, false, false)
-	podStore, _ := pods.Store(t.Context())
 	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
-	nsStore, _ := namespace.Store(t.Context())
+	podStore, _ := pods.Store(t.Context())
 	cidStore, _ := ciliumIdentity.Store(t.Context())
+	nodeStore, _ := ciliumNode.Store(t.Context())
+	nsStore, _ := namespace.Store(t.Context())
+	r = newSlimReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), cesStore, podStore, cidStore, nodeStore, nsStore, cesMetrics, false, false)
 	ciliumNodeStore, _ := ciliumNode.Store(t.Context())
 
 	var deletedSlice string
@@ -542,7 +548,7 @@ func TestReconcileDelete(t *testing.T) {
 	m.mapping.addCEP(NewCEPName("pod3", "ns"), CESName("ces2"), "node1", gidB)
 
 	// ces1 contains cep1 and cep3, but it's mapped to nothing so it should be deleted
-	r.reconcileCES(CESName("ces1"))
+	r.reconcileCES(t.Context(), CESName("ces1"))
 
 	assert.Equal(t, "ces1", deletedSlice)
 
@@ -585,10 +591,12 @@ func TestReconcileNoop(t *testing.T) {
 
 	tlog := hivetest.Logger(t)
 	hive.Start(tlog, t.Context())
-	r = newSlimReconciler(t.Context(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), ciliumEndpointSlice, pods, ciliumIdentity, ciliumNode, namespace, cesMetrics, false, false)
+	cesStore, _ := ciliumEndpointSlice.Store(t.Context())
 	podStore, _ := pods.Store(t.Context())
-	nsStore, _ := namespace.Store(t.Context())
 	cidStore, _ := ciliumIdentity.Store(t.Context())
+	nodeStore, _ := ciliumNode.Store(t.Context())
+	nsStore, _ := namespace.Store(t.Context())
+	r = newSlimReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, hivetest.Logger(t), cesStore, podStore, cidStore, nodeStore, nsStore, cesMetrics, false, false)
 	ciliumNodeStore, _ := ciliumNode.Store(t.Context())
 
 	noRequest := true
@@ -625,7 +633,7 @@ func TestReconcileNoop(t *testing.T) {
 	m.mapping.addCEP(NewCEPName("pod3", "ns"), CESName("ces2"), "node1", gidB)
 
 	// ces1 is mapped to nothing so it won't be reconciled
-	r.reconcileCES(CESName("ces1"))
+	r.reconcileCES(t.Context(), CESName("ces1"))
 
 	assert.True(t, noRequest)
 


### PR DESCRIPTION
Some fixes around the context handling:

1. Don't store context on structure:

The [official Go documentation](https://pkg.go.dev/context) suggests:

> Do not store Contexts inside a struct type; instead, pass a Context
> explicitly to each function that needs it. This is discussed further
> in https://go.dev/blog/context-and-structs. The Context should be the
> first parameter, typically named ctx:

This commit updates the controllers and reconciler not to store the
context on the struct.

2. Avoid Start() being blocked by cancelling the context at the right time:
http://github.com/cilium/cilium/pull/38388#discussion_r2631157254.


--- 

AIL: 3.

I  told claude what to do instead of manually editing the files myself.