### PR TITLE
clustermesh: cleanup hostAliases

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -335,7 +335,6 @@ jobs:
             --helm-set=extraConfig.clustermesh-sync-timeout=5m \
             --helm-set=extraConfig.lb-init-wait-timeout=4m \
             --helm-set=clustermesh.defaultGlobalNamespace=${{ matrix.defaultGlobalNamespace }} \
-            --helm-set=clustermesh.disableKubernetesHostAliases=true \
             "
 
           CILIUM_INSTALL_TUNNEL=" \

--- a/Documentation/operations/troubleshooting_clustermesh.rst
+++ b/Documentation/operations/troubleshooting_clustermesh.rst
@@ -145,28 +145,30 @@ you may perform the following steps to troubleshoot ClusterMesh issues.
 
     If the connection fails, check the following:
 
-    * When KVStoreMesh is disabled, validate that the ``hostAliases`` section in the Cilium DaemonSet maps
-      each remote cluster to the IP of the LoadBalancer that makes the remote
-      control plane available; When KVStoreMesh is enabled,
-      validate the ``hostAliases`` section in the clustermesh-apiserver Deployment.
+    * When KVStoreMesh is disabled, validate that the ``cilium-host-aliases``
+      section in the ``cilium-clustermesh`` secret maps each remote cluster
+      to the IP of the LoadBalancer that makes the remote control plane
+      available; When KVStoreMesh is enabled, validate the
+      ``cilium-host-aliases`` section in the ``cilium-kvstoremesh`` secret.
 
-    * Validate that a local node in the source cluster can reach the IP
-      specified in the ``hostAliases`` section. When KVStoreMesh is disabled, the ``cilium-clustermesh``
-      secret contains a configuration file for each remote cluster, it will
-      point to a logical name representing the remote cluster;
-      When KVStoreMesh is enabled, it exists in the ``cilium-kvstoremesh`` secret.
+    * Validate that a local node in the source cluster can reach the IPs
+      specified in the ``cilium-host-aliases`` section. When KVStoreMesh
+      is disabled, those aliases are configured in the ``cilium-clustermesh``
+      secret. When KVStoreMesh is enabled, they are configured in the
+      ``cilium-kvstoremesh`` secret.
 
       .. code-block:: yaml
 
          endpoints:
          - https://cluster1.mesh.cilium.io:2379
+         cilium-host-aliases:
+         - hostname: cluster1.mesh.cilium.io
+           ips:
+           - 192.0.2.10
 
       The name will *NOT* be resolvable via DNS outside the Cilium agent pods.
-      The name is mapped to an IP using ``hostAliases``. Run ``kubectl -n
-      kube-system get daemonset cilium -o yaml`` when KVStoreMesh is disabled,
-      or run ``kubectl -n kube-system get deployment clustermesh-apiserver -o yaml`` when KVStoreMesh is enabled,
-      grep for the FQDN to retrieve the IP that is configured. Then use ``curl`` to validate that the port is
-      reachable.
+      Internally, the name is mapped to an IP using ``cilium-host-aliases``.
+      You can use ``curl`` to validate that those IPs and port are reachable.
 
     * A firewall between the local cluster and the remote cluster may drop the
       control plane connection. Ensure that port 2379/TCP is allowed.

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -857,16 +857,6 @@ spec:
       tolerations:
         {{- toYaml . | trim | nindent 8 }}
       {{- end }}
-      {{/* TODO: remove hostAliases for the v1.21 release as this is now handled via a static dialer to avoid pod restart */}}
-      {{- if and .Values.clustermesh.config.enabled (not (and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.kvstoremesh.enabled )) (not .Values.clustermesh.disableKubernetesHostAliases) }}
-      hostAliases:
-      {{- range $_, $cluster := (include "clustermesh-clusters" . | fromJson) }}
-      {{- range $ip := $cluster.ips }}
-      - ip: {{ $ip }}
-        hostnames: [ "{{ $cluster.name }}.{{ $.Values.clustermesh.config.domain }}" ]
-      {{- end }}
-      {{- end }}
-      {{- end }}
       volumes:
       {{- if $buildDaemonConfig }}
       # For sharing configuration between the "config" initContainer and the agent

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -314,16 +314,6 @@ spec:
       nodeSelector:
         {{- toYaml . | trim | nindent 8 }}
       {{- end }}
-      {{/* TODO: remove hostAliases for the v1.21 release as this is now handled via a static dialer to avoid pod restart */}}
-      {{- if and (or .Values.clustermesh.enableEndpointSliceSynchronization .Values.clustermesh.mcsapi.enabled) .Values.clustermesh.config.enabled (not (and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.kvstoremesh.enabled )) (not .Values.clustermesh.disableKubernetesHostAliases) }}
-      hostAliases:
-      {{- range $_, $cluster := (include "clustermesh-clusters" . | fromJson) }}
-      {{- range $ip := $cluster.ips }}
-      - ip: {{ $ip }}
-        hostnames: [ "{{ $cluster.name }}.{{ $.Values.clustermesh.config.domain }}" ]
-      {{- end }}
-      {{- end }}
-      {{- end }}
       {{- if or (.Values.operator.tolerations) (hasKey .Values "agentNotReadyTaintKey") }}
       tolerations:
       {{- with .Values.operator.tolerations }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -510,14 +510,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{/* TODO: remove hostAliases for the v1.21 release as this is now handled via a static dialer to avoid pod restart */}}
-      {{- if and .Values.clustermesh.config.enabled .Values.clustermesh.apiserver.kvstoremesh.enabled (not .Values.clustermesh.disableKubernetesHostAliases) }}
-      hostAliases:
-      {{- range $_, $cluster := (include "clustermesh-clusters" . | fromJson) }}
-      {{- range $ip := $cluster.ips }}
-      - ip: {{ $ip }}
-        hostnames: [ "{{ $cluster.name }}.{{ $.Values.clustermesh.config.domain }}" ]
-      {{- end }}
-      {{- end }}
-      {{- end }}
 {{- end }}


### PR DESCRIPTION
In commit 877da8147ed0d12898cbc28f800f4ec76c4c3da7 we introduced a new mechanism to pass remote cluster IPs through the etcd config instead of Kubernetes hostAliases. Now that we are in the 1.21 cycle let's actually remove hostAliases which will allow for changing remote cluster IPs without restarting most Cilium pods.

AIL-0

```release-note
clustermesh: no longer restart pods when changing remote clustermesh-apiserver IPs statically defined (without a DNS name)
```