### PR TITLE
iptables: add cilium comment to node-local-dns NOTRACK rules

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1151,6 +1151,7 @@ func (m *manager) endpointNoTrackRules(prog runnable, cmd string, IP string, por
 		"-p", protocol,
 		"-d", IP,
 		"--dport", p,
+		"-m", "comment", "--comment", "cilium: NOTRACK for node-local-dns",
 		"-j", "CT",
 		"--notrack"}); err != nil {
 		m.logger.Warn("Failed to enforce endpoint notrack", logfields.Error, err)
@@ -1160,9 +1161,9 @@ func (m *manager) endpointNoTrackRules(prog runnable, cmd string, IP string, por
 		cmd, ciliumForwardChain,
 		"-p", protocol,
 		"-d", IP,
-		"--dport",
-		p, "-j",
-		"ACCEPT"}); err != nil {
+		"--dport", p,
+		"-m", "comment", "--comment", "cilium: ACCEPT for node-local-dns",
+		"-j", "ACCEPT"}); err != nil {
 		m.logger.Warn("Failed to enforce endpoint notrack", logfields.Error, err)
 	}
 
@@ -1174,6 +1175,7 @@ func (m *manager) endpointNoTrackRules(prog runnable, cmd string, IP string, por
 		"-p", protocol,
 		"-s", IP,
 		"--sport", p,
+		"-m", "comment", "--comment", "cilium: NOTRACK for node-local-dns",
 		"-j", "CT",
 		"--notrack"}); err != nil {
 		m.logger.Warn("Failed to enforce endpoint notrack", logfields.Error, err)
@@ -1183,9 +1185,9 @@ func (m *manager) endpointNoTrackRules(prog runnable, cmd string, IP string, por
 		cmd, ciliumForwardChain,
 		"-p", protocol,
 		"-s", IP,
-		"--sport",
-		p, "-j",
-		"ACCEPT"}); err != nil {
+		"--sport", p,
+		"-m", "comment", "--comment", "cilium: ACCEPT for node-local-dns",
+		"-j", "ACCEPT"}); err != nil {
 		m.logger.Warn("Failed to enforce endpoint notrack", logfields.Error, err)
 	}
 
@@ -1197,6 +1199,7 @@ func (m *manager) endpointNoTrackRules(prog runnable, cmd string, IP string, por
 		"-p", protocol,
 		"-d", IP,
 		"--dport", p,
+		"-m", "comment", "--comment", "cilium: NOTRACK for node-local-dns",
 		"-j", "CT",
 		"--notrack"}); err != nil {
 		m.logger.Warn("Failed to enforce endpoint notrack", logfields.Error, err)
@@ -1207,6 +1210,7 @@ func (m *manager) endpointNoTrackRules(prog runnable, cmd string, IP string, por
 		"-p", protocol,
 		"-d", IP,
 		"--dport", p,
+		"-m", "comment", "--comment", "cilium: ACCEPT for node-local-dns",
 		"-j", "ACCEPT"}); err != nil {
 		m.logger.Warn("Failed to enforce endpoint notrack", logfields.Error, err)
 	}
@@ -1218,9 +1222,9 @@ func (m *manager) endpointNoTrackRules(prog runnable, cmd string, IP string, por
 		cmd, ciliumInputChain,
 		"-p", protocol,
 		"-s", IP,
-		"--sport",
-		p, "-j",
-		"ACCEPT"}); err != nil {
+		"--sport", p,
+		"-m", "comment", "--comment", "cilium: ACCEPT for node-local-dns",
+		"-j", "ACCEPT"}); err != nil {
 		m.logger.Warn("Failed to enforce endpoint notrack", logfields.Error, err)
 	}
 
@@ -1233,6 +1237,7 @@ func (m *manager) endpointNoTrackRules(prog runnable, cmd string, IP string, por
 		"-p", protocol,
 		"-s", IP,
 		"--sport", p,
+		"-m", "comment", "--comment", "cilium: NOTRACK for node-local-dns",
 		"-j", "CT",
 		"--notrack"}); err != nil {
 		m.logger.Warn("Failed to enforce endpoint notrack", logfields.Error, err)
@@ -1243,6 +1248,7 @@ func (m *manager) endpointNoTrackRules(prog runnable, cmd string, IP string, por
 		"-p", protocol,
 		"-s", IP,
 		"--sport", p,
+		"-m", "comment", "--comment", "cilium: ACCEPT for node-local-dns",
 		"-j", "ACCEPT"}); err != nil {
 		m.logger.Warn("Failed to enforce endpoint notrack", logfields.Error, err)
 	}
@@ -1251,9 +1257,9 @@ func (m *manager) endpointNoTrackRules(prog runnable, cmd string, IP string, por
 		cmd, ciliumInputChain,
 		"-p", protocol,
 		"-d", IP,
-		"--dport",
-		p, "-j",
-		"ACCEPT"}); err != nil {
+		"--dport", p,
+		"-m", "comment", "--comment", "cilium: ACCEPT for node-local-dns",
+		"-j", "ACCEPT"}); err != nil {
 		m.logger.Warn("Failed to enforce endpoint notrack", logfields.Error, err)
 	}
 	return err


### PR DESCRIPTION
The per-endpoint NOTRACK/ACCEPT iptables rules installed by endpointNoTrackRules for node-local-dns (via the
policy.cilium.io/no-track-port annotation) were the only Cilium-managed rules that did not carry a "cilium:" comment. This made them hard to attribute to Cilium when inspecting iptables output on a node, since they looked like rules added by some other component.

Add a "cilium: NOTRACK for node-local-dns" / "cilium: ACCEPT for node-local-dns" comment to each of these rules so they are consistent with every other rule Cilium programs and clearly attributable to Cilium. No functional change: the match criteria and targets are unchanged, and add/remove stay symmetric since both paths go through endpointNoTrackRules.

```release-note
iptables: add cilium comment to node-local-dns NOTRACK rules
```
AIL: 3
