### PR TITLE
datapath/linux: Unsubscribe node handler on shutdown

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -116,6 +116,10 @@ func NewNodeHandler(
 			handler.RestoreNodeIDs()
 			return nil
 		},
+		OnStop: func(_ cell.HookContext) error {
+			nodeManager.Unsubscribe(handler)
+			return nil
+		},
 	})
 
 	return handler, handler


### PR DESCRIPTION
`NewNodeHandler` subscribes the Linux node handler to the node manager but never unsubscribes it. During agent shutdown the node BPF map's file descriptor can be closed (`node-map` cell `OnStop`) before the manager's `backgroundSync` job is torn down, since there is no dependency edge ordering `node-manager` relative to `node-map`. An in-flight `backgroundSync` iteration then calls `NodeValidateImplementation` -> `allocateIDForNode` -> `mapNodeID` -> `nodeMap.Update` on the closed fd, failing with `EBADF` ("bad file descriptor") and logging spurious degraded-functionality errors:
```
Failed to apply node handler during background sync. Cilium may have degraded functionality. See error message for details.
err: failed to allocate ID for node ip-10-XX-YY-229.ec2.internal: failed to map IP 10.XX.YY.229 with node ID 26803: failed to update node map: update: bad file descriptor
failed to map IP 10.XX.YY.229 with node ID 26803: failed to update node map: update: bad file descriptor
```

This PR adds an `OnStop` hook that unsubscribes the handler from the node manager. `NewNodeHandler` depends on both the node manager and the node map, so this hook runs before either stops, ensuring `backgroundSync` can no longer invoke the handler once teardown begins.

Note: These shutdown lifecycle ordering issues can be observed on the logs attached here: https://github.com/cilium/cilium/pull/47144#issuecomment-4960157480