### PR TITLE
datapath: relax strict ingress to allow hostport

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -154,6 +154,7 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 	int ret, zero __maybe_unused = 0;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
+	const struct endpoint_info *ep;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
@@ -185,6 +186,15 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 				return ret;
 			}
 		}
+	}
+
+	/* See IPv4 path for comments. */
+	if (is_defined(ENABLE_WIREGUARD) && CONFIG(encryption_strict_ingress) &&
+	    !from_host && identity_is_cluster(secctx) &&
+	    !identity_is_remote_node(secctx)) {
+		ep = lookup_ip6_endpoint(ip6);
+		if (ep && !(ep->flags & ENDPOINT_MASK_HOST_DELIVERY))
+			return DROP_UNENCRYPTED_TRAFFIC;
 	}
 
 #ifdef ENABLE_NODEPORT
@@ -329,24 +339,12 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 	}
 #endif /* ENABLE_SRV6 */
 
-	/* Lookup IPv6 address in list of local endpoints */
-	ep = lookup_ip6_endpoint(ip6);
-
-	/* Strict ingress encryption enforcement: drop cluster-internal pod
-	 * traffic that would reach a local pod from a netdev. Legitimate
-	 * decrypted traffic is delivered directly from cil_from_wireguard
-	 * via a bpf redirect or the stack.
-	 */
-	if (is_defined(ENABLE_WIREGUARD) && CONFIG(encryption_strict_ingress) &&
-	    !from_host && identity_is_cluster(secctx) &&
-	    !identity_is_remote_node(secctx) &&
-	    ep && !(ep->flags & ENDPOINT_MASK_HOST_DELIVERY))
-		return DROP_UNENCRYPTED_TRAFFIC;
-
 	/* See the equivalent v4 path for comments */
 	if (!from_host && !CONFIG(enable_bpf_host_routing))
 		return CTX_ACT_OK;
 
+	/* Lookup IPv6 address in list of local endpoints */
+	ep = lookup_ip6_endpoint(ip6);
 	if (ep) {
 		/* Let through packets to the node-ip so they are
 		 * processed by the local ip stack.
@@ -610,6 +608,7 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 	bool __maybe_unused is_host_id = false;
 	void *data, *data_end;
 	struct iphdr *ip4;
+	const struct endpoint_info *ep;
 	int zero __maybe_unused = 0;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
@@ -623,6 +622,23 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 
 		if (ipfrag_is_fragment(fraginfo))
 			return DROP_FRAG_NOSUPPORT;
+	}
+
+	/* Strict ingress encryption enforcement: drop cluster-internal pod
+	 * traffic that would reach a local pod from a netdev. Legitimate
+	 * decrypted traffic is delivered directly from cil_from_wireguard
+	 * via a bpf redirect or the stack.
+	 *
+	 * This must run before NodePort/HostPort DNAT, otherwise HostPort
+	 * traffic addressed to a node IP will be judged against the post-DNAT
+	 * pod backend address and dropped.
+	 */
+	if (is_defined(ENABLE_WIREGUARD) && CONFIG(encryption_strict_ingress) &&
+	    !from_host && identity_is_cluster(secctx) &&
+	    !identity_is_remote_node(secctx)) {
+		ep = lookup_ip4_endpoint(ip4);
+		if (ep && !(ep->flags & ENDPOINT_MASK_HOST_DELIVERY))
+			return DROP_UNENCRYPTED_TRAFFIC;
 	}
 
 #ifdef ENABLE_NODEPORT
@@ -744,20 +760,6 @@ handle_ipv4_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 	}
 #endif /* ENABLE_HOST_FIREWALL */
 
-	/* Lookup IPv4 address in list of local endpoints and host IPs */
-	ep = lookup_ip4_endpoint(ip4);
-
-	/* Strict ingress encryption enforcement: drop cluster-internal pod
-	 * traffic that would reach a local pod from a netdev. Legitimate
-	 * decrypted traffic is delivered directly from cil_from_wireguard
-	 * via a bpf redirect or the stack.
-	 */
-	if (is_defined(ENABLE_WIREGUARD) && CONFIG(encryption_strict_ingress) &&
-	    !from_host && identity_is_cluster(secctx) &&
-	    !identity_is_remote_node(secctx) &&
-	    ep && !(ep->flags & ENDPOINT_MASK_HOST_DELIVERY))
-		return DROP_UNENCRYPTED_TRAFFIC;
-
 	/* Without bpf_redirect_neigh() helper, we cannot redirect a
 	 * packet to a local endpoint in the direct routing mode, as
 	 * the redirect bypasses nf_conntrack table. This makes a
@@ -770,6 +772,8 @@ handle_ipv4_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 	if (!from_host && !CONFIG(enable_bpf_host_routing))
 		return CTX_ACT_OK;
 
+	/* Lookup IPv4 address in list of local endpoints and host IPs */
+	ep = lookup_ip4_endpoint(ip4);
 	if (ep) {
 		int l3_off = ETH_HLEN;
 

--- a/bpf/tests/decrypt_host_wireguard_strict.c
+++ b/bpf/tests/decrypt_host_wireguard_strict.c
@@ -8,9 +8,13 @@
 
 #define ENABLE_IPV4
 #define ENABLE_IPV6
+#define ENABLE_NODEPORT		1
 #define ENABLE_WIREGUARD	1
 
 #define DEST_LXC_ID	0
+#define HOSTPORT_PORT	__bpf_htons(8080)
+#define BACKEND_PORT	__bpf_htons(80)
+#define BACKEND_ID	125
 
 #include <bpf/ctx/skb.h>
 #include "common.h"
@@ -44,6 +48,8 @@ mock_tail_call_dynamic(struct __ctx_buff *ctx __maybe_unused,
 #include "lib/bpf_host.h"
 #include "lib/ipcache.h"
 #include "lib/endpoint.h"
+#include "lib/lb.h"
+#include "nodeport_defaults.h"
 
 ASSIGN_CONFIG(bool, encryption_strict_ingress, true)
 
@@ -102,7 +108,7 @@ setup(struct __ctx_buff *ctx, bool ipv4)
 }
 
 static __always_inline int
-check(const struct __ctx_buff *ctx)
+check(const struct __ctx_buff *ctx, __u32 expected_status)
 {
 	void *data;
 	void *data_end;
@@ -118,8 +124,7 @@ check(const struct __ctx_buff *ctx)
 
 	status_code = data;
 
-	/* Cleartext pod-to-pod traffic must be dropped under strict mode. */
-	assert(*status_code == CTX_ACT_DROP);
+	assert(*status_code == expected_status);
 
 	test_finish();
 }
@@ -139,7 +144,7 @@ int ipv4_strict_ingress_from_netdev_setup(struct __ctx_buff *ctx)
 CHECK("tc", "ipv4_strict_ingress_from_netdev")
 int ipv4_strict_ingress_from_netdev_check(const struct __ctx_buff *ctx)
 {
-	return check(ctx);
+	return check(ctx, CTX_ACT_DROP);
 }
 
 PKTGEN("tc", "ipv6_strict_ingress_from_netdev")
@@ -157,5 +162,57 @@ int ipv6_strict_ingress_from_netdev_setup(struct __ctx_buff *ctx)
 CHECK("tc", "ipv6_strict_ingress_from_netdev")
 int ipv6_strict_ingress_from_netdev_check(const struct __ctx_buff *ctx)
 {
-	return check(ctx);
+	return check(ctx, CTX_ACT_DROP);
+}
+
+PKTGEN("tc", "ipv4_strict_ingress_hostport_from_netdev")
+int ipv4_strict_ingress_hostport_from_netdev_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)mac_one, (__u8 *)mac_two,
+					  v4_pod_one, v4_node_one,
+					  bpf_htons(12345), HOSTPORT_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "ipv4_strict_ingress_hostport_from_netdev")
+int ipv4_strict_ingress_hostport_from_netdev_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 1;
+
+	/* The source is cluster-internal, so the strict-ingress predicate would
+	 * match if it were evaluated after HostPort DNAT.
+	 */
+	ipcache_v4_add_entry(v4_pod_one, 0, SRC_POD_SEC_IDENTITY, 0, 0);
+
+	/* The original destination is a host endpoint. Strict ingress mode must
+	 * evaluate this pre-DNAT destination and allow HostPort handling.
+	 */
+	endpoint_v4_add_entry(v4_node_one, 0, 0, ENDPOINT_F_HOST, HOST_ID, 0,
+			      (__u8 *)mac_two, (__u8 *)mac_one);
+
+	lb_v4_add_hostport_service(v4_node_one, HOSTPORT_PORT, IPPROTO_TCP, 1,
+				   revnat_id, 0);
+	lb_v4_add_backend(v4_node_one, HOSTPORT_PORT, 1, BACKEND_ID,
+			  v4_pod_two, BACKEND_PORT, IPPROTO_TCP, 0);
+
+	endpoint_v4_add_entry(v4_pod_two, 0, DEST_LXC_ID, 0, 0, 0,
+			      (__u8 *)mac_two, (__u8 *)mac_one);
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK("tc", "ipv4_strict_ingress_hostport_from_netdev")
+int ipv4_strict_ingress_hostport_from_netdev_check(const struct __ctx_buff *ctx)
+{
+	return check(ctx, CTX_ACT_OK);
 }


### PR DESCRIPTION
HostPort traffic is resolved by the destination node, meaning HostPort traffic doesn't get encrypted by pod to pod WireGuard encryption (or IPsec for that matter) because the source node doesn't know that this traffic is eventually ending at a pod. Strict ingress encryption was placed after the HostPort resolution, meaning we started dropping such connections.

This commit moves the strict ingress encryption check before the HostPort resolution, so that we continue to allow unencrypted HostPort traffic even if strict ingress encryption is enabled.

Fixes: #47147

AIL:1