### PR TITLE
Revert restore-path policy map changes (#46927, #47062, #47075)

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -552,27 +552,7 @@ func (e *Endpoint) policyMapSync(policyMapDump policy.MapStateMap, stats *regene
 	// Nothing to do if the desired policy is already fully realized.
 	if e.realizedPolicy != e.desiredPolicy {
 		if len(policyMapDump) > 0 {
-			// A non-empty dump only happens on the first regeneration after an
-			// agent restart, when the BPF policy map still holds the entries
-			// that were enforced before the restart but no policy has been
-			// realized yet (see the caller in runPreCompilationSteps). Those
-			// entries represent the last known good policy, so preserve them:
-			// add the desired keys but do not delete the restored ones against a
-			// desired policy that may not have finished resolving its selectors
-			// yet. Deleting them here breaks established L3/L4 connections until
-			// the desired policy is complete (a POLICY_DENIED black-hole during
-			// upgrade/downgrade).
-			//
-			// The preserved entries that end up not being part of the desired
-			// policy (e.g. entries keyed on identities that were reallocated
-			// across the restart) are left in the map. They are not tracked by
-			// realizedPolicy once regeneration completes, so normal syncs do not
-			// remove them; the periodic full reconciliation (syncPolicyMapWithDump)
-			// removes them once the desired policy is fully realized. Mark the
-			// endpoint so that first reconciliation is treated as expected
-			// convergence rather than a policy-map bug.
-			_, _, err = e.syncPolicyMapWith(policyMapDump, false, true)
-			e.preservedRestoredPolicyEntries = true
+			_, _, err = e.syncPolicyMapWith(policyMapDump, false)
 		} else {
 			err = e.syncPolicyMap()
 		}
@@ -1404,16 +1384,7 @@ func (e *Endpoint) syncPolicyMap() error {
 // syncPolicyMapWith updates the bpf policy map state based on the
 // difference between a realized MapStateMap from a recent policy map dump
 // and desired policy state.
-//
-// When skipDeletes is true, entries present in the realized map but missing
-// from the desired policy are left in place instead of being deleted. This is
-// used on the first regeneration after an agent restart, where the realized map
-// is the pre-restart map and the desired policy may not have finished resolving
-// its selectors yet: deleting then would tear down entries that still enforce
-// established L3/L4 connections. The stale entries are cleaned up once the
-// desired policy is fully realized, by a subsequent regeneration and by the
-// periodic full reconciliation (syncPolicyMapWithDump).
-func (e *Endpoint) syncPolicyMapWith(realized policy.MapStateMap, withDiffs bool, skipDeletes bool) (diffCount int, diffs []policy.MapChange, err error) {
+func (e *Endpoint) syncPolicyMapWith(realized policy.MapStateMap, withDiffs bool) (diffCount int, diffs []policy.MapChange, err error) {
 	addErrors, deleteErrors := 0, 0
 
 	e.updatePolicyMapPressureMetric(e.desiredPolicy.Len())
@@ -1451,19 +1422,17 @@ func (e *Endpoint) syncPolicyMapWith(realized policy.MapStateMap, withDiffs bool
 	}
 
 	// Delete policy keys present in the realized state, but not present in the desired state
-	if !skipDeletes {
-		for k, v := range e.desiredPolicy.MissingMap(realized) {
-			if !e.deletePolicyKey(k) {
-				deleteErrors++
-				continue
-			}
-			diffCount++
-			if withDiffs {
-				diffs = append(diffs, policy.MapChange{
-					Key:   k,
-					Value: v,
-				})
-			}
+	for k, v := range e.desiredPolicy.MissingMap(realized) {
+		if !e.deletePolicyKey(k) {
+			deleteErrors++
+			continue
+		}
+		diffCount++
+		if withDiffs {
+			diffs = append(diffs, policy.MapChange{
+				Key:   k,
+				Value: v,
+			})
 		}
 	}
 
@@ -1546,38 +1515,12 @@ func (e *Endpoint) syncPolicyMapWithDump() error {
 	e.PolicyDebug("syncPolicyMapWithDump", logfields.DumpedPolicyMap, currentMap)
 	// Diffs between the maps indicate an error in the policy map update logic.
 	// Collect and log diffs if policy logging is enabled.
-	//
-	// Always collect diffs (withDiffs=true) so that a restart-preserved cleanup
-	// can be told apart from a genuine bug: on the first reconciliation after a
-	// restart that preserved policy map entries, we expect only deletions of the
-	// leftover entries and no additions. That case is expected convergence, not a
-	// bug, so log it at a lower severity and clear the marker. Any addition, or
-	// any discrepancy once the marker is cleared, still indicates a real policy
-	// map update bug and is logged as a warning (which CI treats as an error).
-	diffCount, diffs, err := e.syncPolicyMapWith(currentMap, true, false)
+	diffCount, diffs, err := e.syncPolicyMapWith(currentMap, e.getLogger() != nil)
 
 	if diffCount > 0 {
-		onlyDeletes := true
-		for _, d := range diffs {
-			if d.Add {
-				onlyDeletes = false
-				break
-			}
-		}
-		if e.preservedRestoredPolicyEntries && onlyDeletes {
-			e.getLogger().Info(
-				"Removed policy map entries preserved across agent restart now that the desired policy is realized",
-				logfields.Count, diffCount,
-			)
-		} else {
-			e.getLogger().Warn("Policy map sync fixed errors, consider running with debug verbose = policy to get detailed dumps", logfields.Count, diffCount)
-		}
+		e.getLogger().Warn("Policy map sync fixed errors, consider running with debug verbose = policy to get detailed dumps", logfields.Count, diffCount)
 		e.PolicyDebug("syncPolicyMapWithDump", logfields.DumpedDiffs, diffs)
 	}
-
-	// The reconciliation has converged the map to the desired policy, so any
-	// entries preserved across the restart have now been dealt with.
-	e.preservedRestoredPolicyEntries = false
 
 	return err
 }

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -787,19 +787,43 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext) (pr
 			return newRegenerationErrorf(regenerationFailureReasonPolicyBPFError, "policymap dump failed: %w", err)
 		}
 
-		// Sync the desired policy into the map before bpf compilation, so
-		// upgrades and downgrades between versions that key the policy map
-		// differently have the correctly-keyed entries in place before the
-		// program is loaded. On the first regeneration after an agent restart
-		// the dump may be non-empty while no policy has been realized yet;
-		// policyMapSync then adds the desired keys without deleting the restored
-		// ones, so established connections are not black-holed during the
-		// reload->realization window (GH-37724, GH-38998).
-		e.realizedPolicy.CopyMapStateFrom(datapathRegenCtxt.policyMapDump)
-		if err = e.policyMapSync(datapathRegenCtxt.policyMapDump, stats); err != nil {
-			return newRegenerationErrorf(regenerationFailureReasonPolicyBPFError, "policymap synchronization failed: %w", err)
+		// Sync policy map before bpf compilation if the bpf policymap is empty.
+		// This allows for upgrades and downgrades from versions using a different policy map
+		if len(datapathRegenCtxt.policyMapDump) == 0 {
+			err = e.policyMapSync(nil, stats)
+			if err != nil {
+				return newRegenerationErrorf(regenerationFailureReasonPolicyBPFError, "policymap synchronization failed: %w", err)
+			}
+			datapathRegenCtxt.policyMapSyncDone = true
+		} else {
+			// There is an edge case where on startup, the policy map for an endpoint
+			// is not empty (policyMapDump > 0) but no policy has been realized yet (realizedPolicy is empty).
+			// Default policy may exist in map to allow all ingress/egress traffic, something like this:
+			// --------------------------------------------------------------------------------------------------------------------------
+			// POLICY   DIRECTION   LABELS (source:key[=value])   PORT/PROTO   PROXY PORT   AUTH TYPE   BYTES   PACKETS   PREFIX
+			// Allow    Ingress     ANY                           ANY          NONE         disabled    2426    29        0
+			// Allow    Ingress     reserved:host                 ANY          NONE         disabled    0       0         0
+			// Allow    Egress      ANY                           ANY          NONE         disabled    30639   165       0
+			// ----------------------------------------------------------------------------------------------------------------------------
+			// If the code has reached here, it means:
+			// 1. The endpoint has a policy map that is not empty (default policy exists)
+			// 2. No policies has been realized (realized policy is empty)
+			// 3. New policies need to be applied for this endpoint (hence desiredPolicy != realizedPolicy)
+			// GH-37724: https://github.com/cilium/cilium/issues/37724
+			e.getLogger().Debug(
+				"Policy map is not empty, but no policy has been realized yet, setting policyMapSyncDone to false",
+			)
+			// Ensure that e.realizedPolicy actually represents the
+			// current policy map state in case rollback is
+			// necessary, so we don't try to "roll back" to an empty
+			// map and delete all the entries, even momentarily.
+			// This may be the case if the agent just restarted,
+			// for example. See GH-38998.
+			e.realizedPolicy.CopyMapStateFrom(datapathRegenCtxt.policyMapDump)
+			// Not strictly required to set as false, but it is a good idea to absolutely
+			// ensure that the policy map is in sync with the desired policy.
+			datapathRegenCtxt.policyMapSyncDone = false
 		}
-		datapathRegenCtxt.policyMapSyncDone = true
 	}
 
 	// sync policy map for fake endpoints, bpf compilation will be skipped for them.

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1582,12 +1582,6 @@ func (e *Endpoint) syncPolicyMapWithDump() error {
 	return err
 }
 
-// syncPolicyMapControllerName is shared by the controller's creation and its
-// callers so the name cannot drift apart.
-func (e *Endpoint) syncPolicyMapControllerName() string {
-	return fmt.Sprintf("sync-policymap-%d", e.ID)
-}
-
 // startSyncPolicyMapController starts the policymap sync controller. Must be called with the endpoint mutex held.
 func (e *Endpoint) startSyncPolicyMapController() {
 	// Skip the controller if the endpoint has no policy map
@@ -1595,7 +1589,7 @@ func (e *Endpoint) startSyncPolicyMapController() {
 		return
 	}
 
-	ctrlName := e.syncPolicyMapControllerName()
+	ctrlName := fmt.Sprintf("sync-policymap-%d", e.ID)
 	e.controllers.CreateController(ctrlName,
 		controller.ControllerParams{
 			Group:  syncPolicymapControllerGroup,

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -392,17 +392,6 @@ type Endpoint struct {
 	// ep.mutex must be held.
 	realizedPolicy *policy.EndpointPolicy
 
-	// preservedRestoredPolicyEntries is set on the first regeneration after an
-	// agent restart when the pre-restart policy map entries were preserved
-	// (added to, but not deleted from) while the desired policy was still being
-	// resolved, to avoid dropping established L3/L4 connections. It records that
-	// the BPF policy map may legitimately still hold stale entries that are not
-	// part of realizedPolicy. The first full reconciliation
-	// (syncPolicyMapWithDump) that removes those leftovers is therefore expected
-	// rather than a symptom of a policy-map bug, and clears this flag.
-	// ep.mutex must be held.
-	preservedRestoredPolicyEntries bool
-
 	eventQueue *eventqueue.EventQueue
 
 	// skippedRegenerationLevel is the DatapathRegenerationLevel of the regeneration event that

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -557,17 +557,8 @@ func (e *Endpoint) regenerate(ctx *regenerationContext) (retErr error) {
 		// State will remain as waiting-to-regenerate if further
 		// changes are needed. There should be an another regenerate
 		// queued for taking care of it.
-		ready := e.BuilderSetStateLocked(StateReady, "Completed endpoint regeneration with no pending regeneration requests")
-
-		// Reap the restart-preserved leftovers now that the endpoint is ready,
-		// instead of waiting up to 15m for the next periodic reconciliation
-		// (GH-47012).
-		reapPreserved := ready && e.preservedRestoredPolicyEntries
+		e.BuilderSetStateLocked(StateReady, "Completed endpoint regeneration with no pending regeneration requests")
 		e.unlock()
-
-		if reapPreserved {
-			e.controllers.TriggerController(e.syncPolicyMapControllerName())
-		}
 	}()
 
 	revision, err = e.regenerateBPF(ctx)

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -421,7 +421,7 @@ func (e *Endpoint) setDesiredPolicy(datapathRegenCtxt *datapathRegenerationConte
 					return fmt.Errorf("unable to dump PolicyMap when trying to revert failed endpoint regeneration: %w", err)
 				}
 
-				_, _, err = e.syncPolicyMapWith(currentMap, false, false)
+				_, _, err = e.syncPolicyMapWith(currentMap, false)
 				if err != nil {
 					e.getLogger().Error("failed to sync PolicyMap when reverting to last known good policy", logfields.Error, err)
 				}


### PR DESCRIPTION
Reverts #46927, #47062 and #47075 on main.

These three all exist to work around the 1.20 to 1.19 identity-aggregation
downgrade, where 1.20 aggregates world/world-ipv4/world-ipv6 into a single
reserved:world entry and 1.19, sharing the same policy map, inherits an entry it
keys differently and can't match. That was the only failure any of them was
actually reproduced against (#47014, #47025). #46927 kept the pre-restart
entries around instead of deleting them while the desired policy was still
incomplete, #47062 reaped those leftovers once the endpoint was ready, and
#47075 seeded the correctly-keyed entries before the reload as extra insurance.

Jarno's #47080 renames the policy map to cilium_policy_v3_ for 1.20, so the two
versions no longer share a map and neither picks up the other's entries on
upgrade or downgrade. That removes the incompatibility at the source, which is
what all three of these were papering over, so I'd rather drop them than carry
the extra restore-path complexity into 1.20. This just puts the restore path
back to how it behaved before #46927.

Companion reverts: #47201 (v1.20) and one for v1.19.

I validated this on the main <-> v1.20 upgrade/downgrade leg before opening it
up: pinning the downgrade side to a v1.20 build carrying the same three reverts,
so the run installed v1.20 with the reverts, upgraded to main with the reverts,
and downgraded back. L3/L4 and L7 both came back green, so dropping these does
not bring the downgrade drops back now that #47080 is in.

AIL: 2
