### PR TITLE
loadbalancer: limit service map entries when kpr=false

### DIFF
--- a/pkg/loadbalancer/frontend.go
+++ b/pkg/loadbalancer/frontend.go
@@ -62,10 +62,10 @@ type Frontend struct {
 	// HealthCheckBackends associated with the frontend that includes the ones that should be health checked.
 	HealthCheckBackends BackendsSeq2
 
-	// ID is the identifier allocated to this frontend. Used as the key
-	// in the services BPF map. This field is populated by the reconciler
-	// and is initially set to zero. It can be considered valid only when
-	// [Status] is set to done.
+	// ID is the identifier allocated to this frontend and used as the key in
+	// the services BPF map. It can be considered valid only when [Status] is
+	// set to done. When valid, a zero ID means the frontend is not a candidate
+	// for reconciliation; a non-zero ID identifies its datapath entry.
 	ID ServiceID
 
 	// RedirectTo if set selects the backends from this service name instead

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -731,17 +731,30 @@ func (ops *BPFOps) Update(_ context.Context, txn statedb.ReadTxn, _ statedb.Revi
 		return nil
 	}
 
-	isLocalAddr := func(addr netip.Addr) bool {
-		k := tables.NodeAddressKey{Addr: addr}
-		for range ops.nodeAddrs.Prefix(txn, tables.NodeAddressIndex.Query(k)) {
-			return true
+	isDatapathCandidate := ops.isDatapathCandidate(fe)
+	if isDatapathCandidate {
+		isLocalAddr := func(addr netip.Addr) bool {
+			k := tables.NodeAddressKey{Addr: addr}
+			for range ops.nodeAddrs.Prefix(txn, tables.NodeAddressIndex.Query(k)) {
+				return true
+			}
+			return false
 		}
-		return false
-	}
 
-	if err := ops.updateFrontend(fe, isLocalAddr); err != nil {
-		ops.log.Warn("Updating frontend failed", logfields.Error, err)
-		return err
+		if err := ops.updateFrontend(fe, isLocalAddr); err != nil {
+			ops.log.Warn("Updating frontend failed", logfields.Error, err)
+			return err
+		}
+	} else {
+		if err := ops.deleteFrontend(fe); err != nil {
+			ops.log.Warn("Deleting non-candidate frontend failed", logfields.Error, err)
+			return err
+		}
+
+		// Unlike Delete(), this Frontend will remain in StateDB. deleteFrontend()
+		// releases its service ID, so clear the debugging field to avoid exposing
+		// an ID that may subsequently be allocated to another Frontend.
+		fe.ID = 0
 	}
 
 	isExpansion := fe.Type == loadbalancer.SVCTypeNodePort ||
@@ -754,23 +767,27 @@ func (ops *BPFOps) Update(_ context.Context, txn statedb.ReadTxn, _ statedb.Revi
 		key := nodePortAddrKey{family: fe.Address.IsIPv6(), port: fe.Address.Port(), protocol: proto}
 		old := sets.New(ops.nodePortAddrByPort[key]...)
 
-		// Collect matching node addresses, skipping those owned by a primary frontend. See #44730.
+		// Collect matching node addresses for datapath candidates, skipping those
+		// owned by a primary frontend. See #44730. For non-candidates this remains
+		// empty so any previously expanded frontends are withdrawn below.
 		var nodePortAddrs []netip.Addr
-		for na := range ops.nodeAddrs.List(txn, tables.NodeAddressNodePortIndex.Query(true)) {
-			if na.Addr.Is6() != fe.Address.IsIPv6() {
-				continue
+		if isDatapathCandidate {
+			for na := range ops.nodeAddrs.List(txn, tables.NodeAddressNodePortIndex.Query(true)) {
+				if na.Addr.Is6() != fe.Address.IsIPv6() {
+					continue
+				}
+				feAddr := loadbalancer.NewL3n4Addr(
+					fe.Address.Protocol(),
+					cmtypes.AddrClusterFrom(na.Addr, 0),
+					fe.Address.Port(),
+					fe.Address.Scope(),
+				)
+				if ops.isPrimaryFrontend(txn, feAddr) {
+					old.Delete(na.Addr)
+					continue
+				}
+				nodePortAddrs = append(nodePortAddrs, na.Addr)
 			}
-			feAddr := loadbalancer.NewL3n4Addr(
-				fe.Address.Protocol(),
-				cmtypes.AddrClusterFrom(na.Addr, 0),
-				fe.Address.Port(),
-				fe.Address.Scope(),
-			)
-			if ops.isPrimaryFrontend(txn, feAddr) {
-				old.Delete(na.Addr)
-				continue
-			}
-			nodePortAddrs = append(nodePortAddrs, na.Addr)
 		}
 
 		// Create the NodePort/HostPort frontends with the node addresses.
@@ -812,7 +829,11 @@ func (ops *BPFOps) Update(_ context.Context, txn statedb.ReadTxn, _ statedb.Revi
 				return err
 			}
 		}
-		ops.nodePortAddrByPort[key] = nodePortAddrs
+		if len(nodePortAddrs) == 0 {
+			delete(ops.nodePortAddrByPort, key)
+		} else {
+			ops.nodePortAddrByPort[key] = nodePortAddrs
+		}
 	}
 
 	return nil
@@ -1196,6 +1217,26 @@ func (ops *BPFOps) isWildcardClass(svc *loadbalancer.Service) bool {
 	// programming wildcard entries for IP addresses we don't manage.
 	return *lbClass == cilium_api_v2alpha1.BGPLoadBalancerClass ||
 		*lbClass == cilium_api_v2alpha1.L2AnnounceLoadBalancerClass
+}
+
+// isDatapathCandidate() returns true if a Frontend should be present in the datapath
+// service map, false otherwise.
+func (ops *BPFOps) isDatapathCandidate(fe *loadbalancer.Frontend) bool {
+	// If KPR is on, everything is a candidate.
+	if ops.extCfg.KubeProxyReplacement {
+		return true
+	}
+
+	// If KPR is off, it depends on the Frontend type.
+	switch fe.Type {
+	case loadbalancer.SVCTypeClusterIP, loadbalancer.SVCTypeLocalRedirect,
+		loadbalancer.SVCTypeExternalIPs:
+		// We should always program ClusterIP and LocalRedirect, as well as
+		// ExternalIP for pod-to-pod scenarios.
+		return true
+	}
+
+	return false
 }
 
 func (ops *BPFOps) upsertService(svcKey maps.ServiceKey, svcVal maps.ServiceValue) error {

--- a/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
@@ -148,6 +148,10 @@ type testCase struct {
 
 	delete bool
 
+	// kubeProxyReplacement overrides the default enabled setting for this case.
+	kubeProxyReplacement *bool
+	expectIDCleared      bool
+
 	// expectErr when true causes UpdateService to fail on backend slots
 	// and expects Update to return an error.
 	expectErr bool
@@ -158,10 +162,11 @@ type testCase struct {
 	maps, maglev []maps.MapDump
 }
 
-// faultyLBMaps wraps an LBMaps and can inject errors on UpdateService.
+// faultyLBMaps wraps an LBMaps and can inject errors on map operations.
 type faultyLBMaps struct {
 	maps.LBMaps
-	fail bool
+	fail              bool
+	failDeleteService bool
 }
 
 func (m *faultyLBMaps) UpdateService(key maps.ServiceKey, value maps.ServiceValue) error {
@@ -169,6 +174,13 @@ func (m *faultyLBMaps) UpdateService(key maps.ServiceKey, value maps.ServiceValu
 		return errors.New("update service failed")
 	}
 	return m.LBMaps.UpdateService(key, value)
+}
+
+func (m *faultyLBMaps) DeleteService(key maps.ServiceKey) error {
+	if m.failDeleteService {
+		return errors.New("delete service failed")
+	}
+	return m.LBMaps.DeleteService(key)
 }
 
 var testServiceName = loadbalancer.NewServiceName("test", "test")
@@ -243,6 +255,17 @@ func newTestCase(name string, mod func(*loadbalancer.Service, *loadbalancer.Fron
 		maps:      maps,
 		maglev:    maglev,
 	}
+}
+
+func withKubeProxyReplacement(enabled bool, tc testCase) testCase {
+	tc.kubeProxyReplacement = &enabled
+	return tc
+}
+
+func withStaleFrontendID(tc testCase) testCase {
+	tc.frontend.ID = 123
+	tc.expectIDCleared = true
+	return tc
 }
 
 func deleteFrontend(addr loadbalancer.L3n4Addr, typ loadbalancer.SVCType) func(*loadbalancer.Service, *loadbalancer.Frontend) (bool, []loadbalancer.Backend) {
@@ -517,13 +540,17 @@ var nodePortTestCases = []testCase{
 		false,
 	),
 
-	newTestCase(
-		"NodePort_cleanup",
-		deleteFrontend(zeroAddr, NodePort),
+	withStaleFrontendID(withKubeProxyReplacement(false, newTestCase(
+		"NodePort_non_candidate_cleanup",
+		func(svc *loadbalancer.Service, fe *loadbalancer.Frontend) (delete bool, bes []loadbalancer.Backend) {
+			fe.Type = NodePort
+			fe.Address = zeroAddr
+			return false, nil
+		},
 		[]maps.MapDump{},
 		nil,
 		false,
-	),
+	))),
 }
 
 var hostPortTestCases = []testCase{
@@ -552,13 +579,17 @@ var hostPortTestCases = []testCase{
 		false,
 	),
 
-	newTestCase(
-		"HostPort_zero_cleanup",
-		deleteFrontend(zeroAddr, HostPort),
+	withKubeProxyReplacement(false, newTestCase(
+		"HostPort_zero_non_candidate_cleanup",
+		func(svc *loadbalancer.Service, fe *loadbalancer.Frontend) (delete bool, bes []loadbalancer.Backend) {
+			fe.Type = HostPort
+			fe.Address = zeroAddr
+			return false, nil
+		},
 		[]maps.MapDump{},
 		nil,
 		false,
-	),
+	)),
 
 	// HostPort with fixed address.
 	newTestCase(
@@ -581,13 +612,17 @@ var hostPortTestCases = []testCase{
 		false,
 	),
 
-	newTestCase(
-		"HostPort_fixed_cleanup",
-		deleteFrontend(autoAddr, HostPort),
+	withKubeProxyReplacement(false, newTestCase(
+		"HostPort_fixed_non_candidate_cleanup",
+		func(svc *loadbalancer.Service, fe *loadbalancer.Frontend) (delete bool, bes []loadbalancer.Backend) {
+			fe.Type = HostPort
+			fe.Address = autoAddr
+			return false, nil
+		},
 		[]maps.MapDump{},
 		nil,
 		false,
-	),
+	)),
 }
 
 var proxyTestCases = []testCase{
@@ -889,7 +924,7 @@ var externalIPTestCases = []testCase{
 
 var localRedirectTestCases = []testCase{
 	// If a frontend has a redirect set to another service it will have the "LocalRedirect" flag.
-	newTestCase(
+	withKubeProxyReplacement(false, newTestCase(
 		"LocalRedirect",
 		func(svc *loadbalancer.Service, fe *loadbalancer.Frontend) (delete bool, bes []loadbalancer.Backend) {
 			fe.Type = LocalRedirect
@@ -904,7 +939,7 @@ var localRedirectTestCases = []testCase{
 		},
 		nil,
 		false,
-	),
+	)),
 
 	newTestCase(
 		"LocalRedirect_cleanup",
@@ -1351,9 +1386,68 @@ func TestBPFOps(t *testing.T) {
 
 	faultMaps := &faultyLBMaps{LBMaps: lbmaps}
 
+	t.Run("Update_withdraws_non_candidate_without_prune", func(t *testing.T) {
+		// The table-driven cases below invoke Prune before validating the maps,
+		// which could hide an incomplete deletion in Update. This test checks the
+		// maps and BPFOps bookkeeping immediately after a frontend becomes a
+		// non-candidate, without giving Prune an opportunity to clean up for it.
+		external := extCfg
+		localCfg := cfg
+		localCfg.LBAlgorithm = loadbalancer.LBAlgorithmRandom
+		ops := newBPFOps(bpfOpsParams{
+			Lifecycle:      lc,
+			Log:            log,
+			Config:         localCfg,
+			ExternalConfig: external,
+			LBMaps:         faultMaps,
+			Maglev:         maglev,
+			DB:             db,
+			NodeAddresses:  nodeAddrs,
+			Frontends:      frontends,
+		})
+
+		svc := baseService
+		frontend := baseFrontend
+		frontend.Type = LoadBalancer
+		frontend.Address = extraFrontend
+		frontend.Service = &svc
+		frontend.Backends = concatBe(frontend.Backends, baseBackend, 1)
+
+		require.NoError(t, ops.Update(context.TODO(), db.ReadTxn(), 0, &frontend))
+		require.NotZero(t, frontend.ID, "programmed Frontend ID")
+		require.False(t, lbmaps.IsEmpty(), "programmed BPF maps")
+
+		ops.extCfg.KubeProxyReplacement = false
+		// Withdrawing a frontend performs multiple map operations. A failed
+		// operation must leave the ID intact so the reconciler can retry the
+		// partially completed deletion.
+		faultMaps.failDeleteService = true
+		err := ops.Update(context.TODO(), db.ReadTxn(), 0, &frontend)
+		faultMaps.failDeleteService = false
+		require.Error(t, err)
+		require.NotZero(t, frontend.ID, "Frontend ID after failed withdrawal")
+		require.Equal(t, frontend.Address, ops.serviceIDAlloc.idToAddr[frontend.ID],
+			"Frontend ID allocation after failed withdrawal")
+
+		require.NoError(t, ops.Update(context.TODO(), db.ReadTxn(), 0, &frontend))
+
+		require.Zero(t, frontend.ID, "withdrawn Frontend ID")
+		require.True(t, lbmaps.IsEmpty(), "BPF maps after Update")
+		require.Empty(t, ops.serviceIDAlloc.idToAddr, "Frontend ID allocations remain")
+		require.Empty(t, ops.backendIDAlloc.idToAddr, "Backend ID allocations remain")
+		require.Empty(t, ops.backendStates, "Backend state remains")
+		require.Empty(t, ops.backendReferences, "Backend references remain")
+		require.Empty(t, ops.wildcardReferences, "Wildcard references remain")
+	})
+
 	runTests := func(ops *BPFOps, testCaseSet []testCase, algo string, addr loadbalancer.L3n4Addr, validateMaglev bool) {
 		for _, testCase := range testCaseSet {
 			t.Run(fmt.Sprintf("%s/%s/ipv6:%v", testCase.name, algo, addr.IsIPv6()), func(t *testing.T) {
+				ops.extCfg.KubeProxyReplacement = true
+				if testCase.kubeProxyReplacement != nil {
+					ops.extCfg.KubeProxyReplacement = *testCase.kubeProxyReplacement
+				}
+
 				frontend := testCase.frontend
 
 				switch frontend.Address.String() {
@@ -1393,6 +1487,9 @@ func TestBPFOps(t *testing.T) {
 						require.Error(t, err, "Update")
 					} else {
 						require.NoError(t, err, "Update")
+					}
+					if testCase.expectIDCleared {
+						require.Zero(t, frontend.ID, "non-candidate Frontend ID")
 					}
 
 					// Invariant: every backendStates entry must have a non-zero addr.

--- a/pkg/loadbalancer/tests/script_test.go
+++ b/pkg/loadbalancer/tests/script_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	envoyCfg "github.com/cilium/cilium/pkg/envoy/config"
 	"github.com/cilium/cilium/pkg/hive"
+	k8sclient "github.com/cilium/cilium/pkg/k8s/client"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client/testutils"
 	k8sTables "github.com/cilium/cilium/pkg/k8s/tables"
 	k8sTestutils "github.com/cilium/cilium/pkg/k8s/testutils"
@@ -38,6 +39,7 @@ import (
 	"github.com/cilium/cilium/pkg/lbipamconfig"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	lbcell "github.com/cilium/cilium/pkg/loadbalancer/cell"
+	lbmaps "github.com/cilium/cilium/pkg/loadbalancer/maps"
 	lbreconciler "github.com/cilium/cilium/pkg/loadbalancer/reconciler"
 	"github.com/cilium/cilium/pkg/loadbalancer/writer"
 	"github.com/cilium/cilium/pkg/logging"
@@ -95,86 +97,184 @@ func testScript(t *testing.T) {
 				logging.SetLogLevel(slog.LevelDebug)
 			}
 			log := hivetest.Logger(t, opts...)
-
-			h := hive.New(
-				k8sClient.FakeClientCell(),
-				daemonk8s.ResourcesCell,
-				k8sTables.TablesCell,
-				cell.Config(envoyCfg.SecretSyncConfig{}),
-
-				cell.Config(loadbalancer.TestConfig{
-					// By default 10% of the time the LBMap operations fail
-					TestFaultProbability: 0.1,
-				}),
-				metrics.Cell,
-				maglev.Cell,
-				lbipamconfig.Cell,
-				nodeipamconfig.Cell,
-				node.LocalNodeStoreTestCell,
-				cell.Provide(
-					func() cmtypes.ClusterInfo { return cmtypes.ClusterInfo{} },
-					func(cfg loadbalancer.TestConfig) *loadbalancer.TestConfig { return &cfg },
-					tables.NewNodeAddressTable,
-					statedb.RWTable[tables.NodeAddress].ToTable,
-					source.NewSources,
-					func(cfg loadbalancer.TestConfig) *option.DaemonConfig {
-						return &option.DaemonConfig{
-							EnableIPv4: true,
-							EnableIPv6: true,
-						}
-					},
-					func() kpr.KPRConfig {
-						return kpr.KPRConfig{
-							KubeProxyReplacement: true,
-						}
-					},
-					func(ops *lbreconciler.BPFOps, lns *node.LocalNodeStore, w *writer.Writer, waitFn loadbalancer.InitWaitFunc) uhive.ScriptCmdsOut {
-						return uhive.NewScriptCmds(testCommands{w, lns, ops, waitFn}.cmds())
-					},
-				),
-
-				lbcell.Cell,
-			)
-
-			flags := pflag.NewFlagSet("", pflag.ContinueOnError)
-			h.RegisterFlags(flags)
-
-			// Set some defaults
-			flags.Set("lb-retry-backoff-min", "10ms") // as we're doing fault injection we want
-			flags.Set("lb-retry-backoff-max", "10ms") // tiny backoffs
-			flags.Set("bpf-lb-maglev-table-size", "1021")
-
-			// Expand $WORK in args. Used by testdata/file.txtar.
-			// This works by creating a new temporary directory for this test (e.g. /tmp/<tempdir/002)
-			// and replacing the directory with /001 which is the temp directory that scripttest created.
-			tempDir := filepath.Join(filepath.Dir(t.TempDir()), "001")
-			for i := range args {
-				args[i] = strings.ReplaceAll(args[i], "$WORK", tempDir)
-			}
-
-			// Parse the shebang arguments in the script.
-			require.NoError(t, flags.Parse(args), "flags.Parse")
-
-			t.Cleanup(func() {
-				assert.NoError(t, h.Stop(log, context.TODO()))
-			})
-			cmds, err := h.ScriptCommands(log)
-			require.NoError(t, err, "ScriptCommands")
-			maps.Insert(cmds, maps.All(script.DefaultCmds()))
-
 			conds := map[string]script.Cond{
 				"privileged": script.BoolCondition("testutils.IsPrivileged", testutils.IsPrivileged()),
 			}
-			return &script.Engine{
-				Cmds:             cmds,
+			rt := &scriptRuntime{
+				t:        t,
+				log:      log,
+				baseArgs: append([]string(nil), args...),
+				workDir:  filepath.Join(filepath.Dir(t.TempDir()), "001"),
+			}
+			rt.engine = &script.Engine{
 				Conds:            conds,
 				RetryInterval:    20 * time.Millisecond,
 				MaxRetryInterval: 500 * time.Millisecond,
 			}
+			require.NoError(t, rt.recreate(), "create initial hive")
+			return rt.engine
 		},
 		[]string{
 			/* empty environment */
 		}, "testdata/*.txtar")
+}
+
+// scriptRuntime owns the application instance used by a single script. Recreating
+// the Hive models restarting the Cilium agent: its in-memory StateDB is rebuilt,
+// while the Kubernetes API and pinned BPF maps continue to exist outside the
+// process. The fake client and fake LB maps model those two persistent stores.
+type scriptRuntime struct {
+	t        testing.TB
+	log      *slog.Logger
+	engine   *script.Engine
+	baseArgs []string
+	workDir  string
+
+	client *k8sClient.FakeClientset
+	lbMaps lbmaps.LBMaps
+}
+
+func (rt *scriptRuntime) newHive(extraArgs []string) (*hive.Hive, map[string]script.Cmd, error) {
+	var (
+		client *k8sClient.FakeClientset
+		lbMaps lbmaps.LBMaps
+	)
+
+	app := cell.Group(
+		k8sClient.FakeClientCell(),
+		daemonk8s.ResourcesCell,
+		k8sTables.TablesCell,
+		cell.Config(envoyCfg.SecretSyncConfig{}),
+		kpr.Cell,
+
+		cell.Config(loadbalancer.TestConfig{
+			// By default 10% of the time the LBMap operations fail.
+			TestFaultProbability: 0.1,
+		}),
+		metrics.Cell,
+		maglev.Cell,
+		lbipamconfig.Cell,
+		nodeipamconfig.Cell,
+		node.LocalNodeStoreTestCell,
+		cell.Provide(
+			func() cmtypes.ClusterInfo { return cmtypes.ClusterInfo{} },
+			func(cfg loadbalancer.TestConfig) *loadbalancer.TestConfig { return &cfg },
+			tables.NewNodeAddressTable,
+			statedb.RWTable[tables.NodeAddress].ToTable,
+			source.NewSources,
+			func(cfg loadbalancer.TestConfig) *option.DaemonConfig {
+				return &option.DaemonConfig{
+					EnableIPv4: true,
+					EnableIPv6: true,
+				}
+			},
+			func(ops *lbreconciler.BPFOps, lns *node.LocalNodeStore, w *writer.Writer, waitFn loadbalancer.InitWaitFunc) uhive.ScriptCmdsOut {
+				return uhive.NewScriptCmds(testCommands{w, lns, ops, waitFn}.cmds())
+			},
+		),
+		cell.Invoke(func(c *k8sClient.FakeClientset, m lbmaps.LBMaps) {
+			client = c
+			lbMaps = m
+		}),
+
+		lbcell.Cell,
+	)
+
+	// A new FakeClientCell and LB maps implementation would normally be constructed
+	// with every Hive. Decorate them on recreation so Kubernetes objects created by
+	// the script and datapath state programmed by the previous agent remain visible
+	// to the new agent. StateDB is not decorated and is therefore always fresh.
+	if rt.client != nil {
+		app = cell.Decorate(
+			func(k8sclient.Clientset) k8sclient.Clientset { return rt.client },
+			app,
+		)
+	}
+	if rt.lbMaps != nil {
+		app = cell.Decorate(
+			func(lbmaps.LBMaps) lbmaps.LBMaps { return rt.lbMaps },
+			app,
+		)
+	}
+
+	h := hive.New(app)
+	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+	h.RegisterFlags(flags)
+
+	// Preserve the defaults used by the existing script suite. The shebang and
+	// hive/recreate arguments may override these values.
+	for name, value := range map[string]string{
+		"kube-proxy-replacement":   "true",
+		"lb-retry-backoff-min":     "10ms",
+		"lb-retry-backoff-max":     "10ms",
+		"bpf-lb-maglev-table-size": "1021",
+	} {
+		if err := flags.Set(name, value); err != nil {
+			return nil, nil, fmt.Errorf("setting default --%s: %w", name, err)
+		}
+	}
+
+	// Treat the shebang as the base agent configuration and flags passed to
+	// hive/recreate as overrides for the replacement agent.
+	args := append([]string(nil), rt.baseArgs...)
+	args = append(args, extraArgs...)
+	for i := range args {
+		args[i] = strings.ReplaceAll(args[i], "$WORK", rt.workDir)
+	}
+	if err := flags.Parse(args); err != nil {
+		return nil, nil, fmt.Errorf("parsing hive arguments: %w", err)
+	}
+
+	rt.t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		assert.NoError(rt.t, h.Stop(rt.log, ctx))
+	})
+	cmds, err := h.ScriptCommands(rt.log)
+	if err != nil {
+		return nil, nil, fmt.Errorf("getting script commands: %w", err)
+	}
+
+	if rt.client == nil {
+		rt.client = client
+	}
+	if rt.lbMaps == nil {
+		rt.lbMaps = lbMaps
+	}
+
+	// Always direct Kubernetes commands to the client retained across Hive
+	// instances rather than the per-Hive client hidden by the decorator.
+	maps.Insert(cmds, maps.All(k8sClient.FakeClientCommands(rt.client)))
+	maps.Insert(cmds, maps.All(script.DefaultCmds()))
+	cmds["hive/recreate"] = script.Command(
+		script.CmdUsage{
+			Summary: "recreate the test Hive while retaining Kubernetes and BPF map state",
+			Args:    "[flags...]",
+			Detail: []string{
+				"The current Hive must be stopped before it is recreated.",
+				"The new Hive has a fresh StateDB, while the fake Kubernetes API and LB maps are retained to model an agent restart.",
+				"Flags override values from the script shebang for the replacement Hive.",
+			},
+		},
+		func(_ *script.State, args ...string) (script.WaitFunc, error) {
+			return nil, rt.recreate(args...)
+		},
+	)
+	return h, cmds, nil
+}
+
+func (rt *scriptRuntime) recreate(extraArgs ...string) error {
+	_, cmds, err := rt.newHive(extraArgs)
+	if err != nil {
+		return err
+	}
+	if rt.engine.Cmds == nil {
+		rt.engine.Cmds = cmds
+	} else {
+		clear(rt.engine.Cmds)
+		maps.Copy(rt.engine.Cmds, cmds)
+	}
+	return nil
 }
 
 type testCommands struct {

--- a/pkg/loadbalancer/tests/testdata/kpr-transition-to-disabled.txtar
+++ b/pkg/loadbalancer/tests/testdata/kpr-transition-to-disabled.txtar
@@ -1,0 +1,198 @@
+#! --kube-proxy-replacement=true --lb-test-fault-probability=0.0
+
+# Privileged mode uses real BPF maps, which are attached to the hive lifecycle.
+# Stop this test in privileged mode because we can't simulate the agent restarting
+# against BPF state that is not retained.
+[privileged] stop
+
+# Exercise both the zero-address and per-node forms of NodePort programming.
+db/insert node-addresses node-address.yaml
+hive/start
+k8s/add endpointslice.yaml service.yaml
+test/init-wait
+
+# With KPR enabled, all frontends derived from this Service are programmed,
+# with one shared wildcard for the two ClusterIP frontends and one for the two
+# LoadBalancer frontends.
+db/cmp frontends enabled-frontends.table
+lb/maps-dump enabled.actual
+* cmp enabled.expected enabled.actual
+
+hive/stop
+hive/recreate --kube-proxy-replacement=false
+
+# The replacement Hive has a fresh StateDB but sees the retained maps before
+# startup reconciliation removes frontends that are no longer candidates.
+db/empty services frontends backends
+lb/maps-dump retained.actual
+cmp enabled.expected retained.actual
+
+db/insert node-addresses node-address.yaml
+hive/start
+test/init-wait
+
+# LoadBalancer and ExternalIP remain desired StateDB state even though they are
+# no longer BPF datapath candidates. NodePort is not reflected with KPR disabled.
+db/cmp frontends disabled-frontends.table
+
+# Wait for startup reconciliation and pruning to withdraw non-candidates while
+# retaining the ClusterIP and its backends.
+lb/maps-dump disabled.actual
+* cmp disabled.expected disabled.actual
+
+hive/stop
+
+#####
+
+-- node-address.yaml --
+addr: 1.1.1.1
+nodeport: true
+primary: true
+devicename: test
+-- enabled-frontends.table --
+Address               Type           ServiceName   PortName   Status  Backends
+0.0.0.0:30781/TCP     NodePort       test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+0.0.0.0:30782/TCP     NodePort       test/echo     https      Done    10.244.1.1:443/TCP, 10.244.1.2:443/TCP
+10.96.50.104:80/TCP   ClusterIP      test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+10.96.50.104:443/TCP  ClusterIP      test/echo     https      Done    10.244.1.1:443/TCP, 10.244.1.2:443/TCP
+172.16.1.1:80/TCP     LoadBalancer   test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+172.16.1.1:443/TCP    LoadBalancer   test/echo     https      Done    10.244.1.1:443/TCP, 10.244.1.2:443/TCP
+192.0.2.10:80/TCP     ExternalIPs    test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+192.0.2.10:443/TCP    ExternalIPs    test/echo     https      Done    10.244.1.1:443/TCP, 10.244.1.2:443/TCP
+-- enabled.expected --
+BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
+BE: ID=2 ADDR=10.244.1.2:80/TCP STATE=active
+BE: ID=3 ADDR=10.244.1.1:443/TCP STATE=active
+BE: ID=4 ADDR=10.244.1.2:443/TCP STATE=active
+REV: ID=1 ADDR=0.0.0.0:30781
+REV: ID=10 ADDR=192.0.2.10:443
+REV: ID=2 ADDR=1.1.1.1:30781
+REV: ID=3 ADDR=0.0.0.0:30782
+REV: ID=4 ADDR=1.1.1.1:30782
+REV: ID=5 ADDR=10.96.50.104:80
+REV: ID=6 ADDR=10.96.50.104:443
+REV: ID=7 ADDR=172.16.1.1:80
+REV: ID=8 ADDR=172.16.1.1:443
+REV: ID=9 ADDR=192.0.2.10:80
+SVC: ID=0 ADDR=10.96.50.104:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=172.16.1.1:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+non-routable
+SVC: ID=1 ADDR=0.0.0.0:30781/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=1 ADDR=0.0.0.0:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=1 ADDR=0.0.0.0:30781/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=10 ADDR=192.0.2.10:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ExternalIPs
+SVC: ID=10 ADDR=192.0.2.10:443/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ExternalIPs
+SVC: ID=10 ADDR=192.0.2.10:443/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ExternalIPs
+SVC: ID=2 ADDR=1.1.1.1:30781/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort
+SVC: ID=2 ADDR=1.1.1.1:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=2 ADDR=1.1.1.1:30781/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=3 ADDR=0.0.0.0:30782/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=3 ADDR=0.0.0.0:30782/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=3 ADDR=0.0.0.0:30782/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=4 ADDR=1.1.1.1:30782/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort
+SVC: ID=4 ADDR=1.1.1.1:30782/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=4 ADDR=1.1.1.1:30782/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=5 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=10.96.50.104:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=10.96.50.104:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=10.96.50.104:443/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=10.96.50.104:443/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=7 ADDR=172.16.1.1:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=7 ADDR=172.16.1.1:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=7 ADDR=172.16.1.1:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=8 ADDR=172.16.1.1:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=8 ADDR=172.16.1.1:443/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=8 ADDR=172.16.1.1:443/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=9 ADDR=192.0.2.10:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ExternalIPs
+SVC: ID=9 ADDR=192.0.2.10:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ExternalIPs
+SVC: ID=9 ADDR=192.0.2.10:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ExternalIPs
+-- disabled.expected --
+BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
+BE: ID=2 ADDR=10.244.1.2:80/TCP STATE=active
+BE: ID=3 ADDR=10.244.1.1:443/TCP STATE=active
+BE: ID=4 ADDR=10.244.1.2:443/TCP STATE=active
+REV: ID=10 ADDR=192.0.2.10:443
+REV: ID=5 ADDR=10.96.50.104:80
+REV: ID=6 ADDR=10.96.50.104:443
+REV: ID=9 ADDR=192.0.2.10:80
+SVC: ID=0 ADDR=10.96.50.104:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=10 ADDR=192.0.2.10:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ExternalIPs
+SVC: ID=10 ADDR=192.0.2.10:443/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ExternalIPs
+SVC: ID=10 ADDR=192.0.2.10:443/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ExternalIPs
+SVC: ID=5 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=10.96.50.104:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=10.96.50.104:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=10.96.50.104:443/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=10.96.50.104:443/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=9 ADDR=192.0.2.10:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ExternalIPs
+SVC: ID=9 ADDR=192.0.2.10:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ExternalIPs
+SVC: ID=9 ADDR=192.0.2.10:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ExternalIPs
+-- disabled-frontends.table --
+Address               Type           ServiceName   PortName   Status  Backends
+10.96.50.104:80/TCP   ClusterIP      test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+10.96.50.104:443/TCP  ClusterIP      test/echo     https      Done    10.244.1.1:443/TCP, 10.244.1.2:443/TCP
+172.16.1.1:80/TCP     LoadBalancer   test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+172.16.1.1:443/TCP    LoadBalancer   test/echo     https      Done    10.244.1.1:443/TCP, 10.244.1.2:443/TCP
+192.0.2.10:80/TCP     ExternalIPs    test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+192.0.2.10:443/TCP    ExternalIPs    test/echo     https      Done    10.244.1.1:443/TCP, 10.244.1.2:443/TCP
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  externalIPs:
+  - 192.0.2.10
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    nodePort: 30781
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  - name: https
+    nodePort: 30782
+    port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    name: echo
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+    - ip: 172.16.1.1
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-kvlm2
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  nodeName: nodeport-worker
+- addresses:
+  - 10.244.1.2
+  nodeName: nodeport-worker2
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+- name: https
+  port: 443
+  protocol: TCP

--- a/pkg/loadbalancer/tests/testdata/kpr-transition-to-enabled.txtar
+++ b/pkg/loadbalancer/tests/testdata/kpr-transition-to-enabled.txtar
@@ -1,0 +1,194 @@
+#! --kube-proxy-replacement=false --lb-test-fault-probability=0.0
+
+# Privileged mode uses real BPF maps, which are attached to the hive lifecycle.
+# Stop this test in privileged mode because we can't simulate the agent restarting
+# against BPF state that is not retained.
+[privileged] stop
+
+# Exercise both the zero-address and per-node forms of NodePort programming.
+db/insert node-addresses node-address.yaml
+hive/start
+k8s/add endpointslice.yaml service.yaml
+test/init-wait
+
+# With KPR disabled, only this Service's ClusterIP frontends are programmed.
+# Both ports share one ClusterIP wildcard entry.
+db/cmp frontends disabled-frontends.table
+lb/maps-dump disabled.actual
+* cmp disabled.expected disabled.actual
+
+hive/stop
+hive/recreate --kube-proxy-replacement=true
+
+# The replacement Hive has a fresh StateDB but sees the retained maps before
+# startup reconciliation adds the frontends that become datapath candidates.
+db/empty services frontends backends
+lb/maps-dump retained.actual
+cmp disabled.expected retained.actual
+
+db/insert node-addresses node-address.yaml
+hive/start
+test/init-wait
+
+# The replacement agent reflects the retained Kubernetes state and adds the
+# frontends that become datapath candidates when KPR is enabled. Both
+# LoadBalancer frontends share one LoadBalancer wildcard entry.
+db/cmp frontends enabled-frontends.table
+lb/maps-dump enabled.actual
+* cmp enabled.expected enabled.actual
+
+hive/stop
+
+#####
+
+-- node-address.yaml --
+addr: 1.1.1.1
+nodeport: true
+primary: true
+devicename: test
+-- disabled-frontends.table --
+Address               Type           ServiceName   PortName   Status  Backends
+10.96.50.104:80/TCP   ClusterIP      test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+10.96.50.104:443/TCP  ClusterIP      test/echo     https      Done    10.244.1.1:443/TCP, 10.244.1.2:443/TCP
+172.16.1.1:80/TCP     LoadBalancer   test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+172.16.1.1:443/TCP    LoadBalancer   test/echo     https      Done    10.244.1.1:443/TCP, 10.244.1.2:443/TCP
+192.0.2.10:80/TCP     ExternalIPs    test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+192.0.2.10:443/TCP    ExternalIPs    test/echo     https      Done    10.244.1.1:443/TCP, 10.244.1.2:443/TCP
+-- enabled-frontends.table --
+Address               Type           ServiceName   PortName   Status  Backends
+0.0.0.0:30781/TCP     NodePort       test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+0.0.0.0:30782/TCP     NodePort       test/echo     https      Done    10.244.1.1:443/TCP, 10.244.1.2:443/TCP
+10.96.50.104:80/TCP   ClusterIP      test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+10.96.50.104:443/TCP  ClusterIP      test/echo     https      Done    10.244.1.1:443/TCP, 10.244.1.2:443/TCP
+172.16.1.1:80/TCP     LoadBalancer   test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+172.16.1.1:443/TCP    LoadBalancer   test/echo     https      Done    10.244.1.1:443/TCP, 10.244.1.2:443/TCP
+192.0.2.10:80/TCP     ExternalIPs    test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+192.0.2.10:443/TCP    ExternalIPs    test/echo     https      Done    10.244.1.1:443/TCP, 10.244.1.2:443/TCP
+-- disabled.expected --
+BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
+BE: ID=2 ADDR=10.244.1.2:80/TCP STATE=active
+BE: ID=3 ADDR=10.244.1.1:443/TCP STATE=active
+BE: ID=4 ADDR=10.244.1.2:443/TCP STATE=active
+REV: ID=1 ADDR=10.96.50.104:80
+REV: ID=2 ADDR=10.96.50.104:443
+REV: ID=3 ADDR=192.0.2.10:80
+REV: ID=4 ADDR=192.0.2.10:443
+SVC: ID=0 ADDR=10.96.50.104:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=10.96.50.104:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=10.96.50.104:443/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=10.96.50.104:443/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=192.0.2.10:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ExternalIPs
+SVC: ID=3 ADDR=192.0.2.10:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ExternalIPs
+SVC: ID=3 ADDR=192.0.2.10:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ExternalIPs
+SVC: ID=4 ADDR=192.0.2.10:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ExternalIPs
+SVC: ID=4 ADDR=192.0.2.10:443/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ExternalIPs
+SVC: ID=4 ADDR=192.0.2.10:443/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ExternalIPs
+-- enabled.expected --
+BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
+BE: ID=2 ADDR=10.244.1.2:80/TCP STATE=active
+BE: ID=3 ADDR=10.244.1.1:443/TCP STATE=active
+BE: ID=4 ADDR=10.244.1.2:443/TCP STATE=active
+REV: ID=1 ADDR=10.96.50.104:80
+REV: ID=10 ADDR=172.16.1.1:443
+REV: ID=2 ADDR=10.96.50.104:443
+REV: ID=3 ADDR=192.0.2.10:80
+REV: ID=4 ADDR=192.0.2.10:443
+REV: ID=5 ADDR=0.0.0.0:30781
+REV: ID=6 ADDR=1.1.1.1:30781
+REV: ID=7 ADDR=0.0.0.0:30782
+REV: ID=8 ADDR=1.1.1.1:30782
+REV: ID=9 ADDR=172.16.1.1:80
+SVC: ID=0 ADDR=10.96.50.104:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=172.16.1.1:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=1 ADDR=10.96.50.104:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=10 ADDR=172.16.1.1:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=10 ADDR=172.16.1.1:443/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=10 ADDR=172.16.1.1:443/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=2 ADDR=10.96.50.104:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=10.96.50.104:443/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=2 ADDR=10.96.50.104:443/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=3 ADDR=192.0.2.10:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ExternalIPs
+SVC: ID=3 ADDR=192.0.2.10:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ExternalIPs
+SVC: ID=3 ADDR=192.0.2.10:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ExternalIPs
+SVC: ID=4 ADDR=192.0.2.10:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ExternalIPs
+SVC: ID=4 ADDR=192.0.2.10:443/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ExternalIPs
+SVC: ID=4 ADDR=192.0.2.10:443/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ExternalIPs
+SVC: ID=5 ADDR=0.0.0.0:30781/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=5 ADDR=0.0.0.0:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=5 ADDR=0.0.0.0:30781/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=6 ADDR=1.1.1.1:30781/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort
+SVC: ID=6 ADDR=1.1.1.1:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=6 ADDR=1.1.1.1:30781/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=7 ADDR=0.0.0.0:30782/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=7 ADDR=0.0.0.0:30782/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=7 ADDR=0.0.0.0:30782/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=8 ADDR=1.1.1.1:30782/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort
+SVC: ID=8 ADDR=1.1.1.1:30782/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=8 ADDR=1.1.1.1:30782/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=9 ADDR=172.16.1.1:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=9 ADDR=172.16.1.1:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=9 ADDR=172.16.1.1:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  externalIPs:
+  - 192.0.2.10
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    nodePort: 30781
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  - name: https
+    nodePort: 30782
+    port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    name: echo
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+    - ip: 172.16.1.1
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-kvlm2
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  nodeName: nodeport-worker
+- addresses:
+  - 10.244.1.2
+  nodeName: nodeport-worker2
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+- name: https
+  port: 443
+  protocol: TCP

--- a/pkg/loadbalancer/tests/testdata/prune-deleted-on-restart.txtar
+++ b/pkg/loadbalancer/tests/testdata/prune-deleted-on-restart.txtar
@@ -1,0 +1,181 @@
+#! --lb-test-fault-probability=0.0
+
+# Privileged mode uses real BPF maps, which are attached to the hive lifecycle.
+# Stop this test in privileged mode because we can't simulate the agent restarting
+# against BPF state that is not retained.
+[privileged] stop
+
+# Ensure startup pruning covers an expanded per-node NodePort entry.
+db/insert node-addresses node-address.yaml
+hive/start
+k8s/add endpointslice.yaml service.yaml
+test/init-wait
+
+# Confirm that the old agent programmed state which must survive until the
+# replacement agent has reconstructed its desired state.
+db/cmp services services.table
+db/cmp frontends frontends.table
+db/cmp backends backends.table
+lb/maps-dump before.actual
+* cmp before.expected before.actual
+
+hive/stop
+
+# Kubernetes changes while the agent is stopped. The EndpointSlice is left
+# behind deliberately, since the absence of the Service must still be enough
+# to withdraw all associated datapath state.
+k8s/delete service.yaml
+
+hive/recreate
+
+# The replacement Hive has a fresh StateDB but sees the retained maps before
+# startup reconciliation gets an opportunity to prune them.
+db/empty services frontends backends
+lb/maps-dump retained.actual
+cmp before.expected retained.actual
+
+db/insert node-addresses node-address.yaml
+hive/start
+test/init-wait
+
+# The fresh StateDB has no Service or frontend deletion event to replay. Startup
+# pruning must remove the BPF state restored from the previous agent. Backends
+# remain in StateDB because the EndpointSlice still exists.
+* db/empty services frontends
+db/cmp backends backends.table
+* lb/maps-empty
+
+hive/stop
+
+#####
+
+-- node-address.yaml --
+addr: 1.1.1.1
+nodeport: true
+primary: true
+devicename: test
+-- services.table --
+Name        Source   PortNames            TrafficPolicy   Flags
+test/echo   k8s      http=80, https=443   Cluster
+-- frontends.table --
+Address               Type           ServiceName   PortName   Status  Backends
+0.0.0.0:30781/TCP     NodePort       test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+0.0.0.0:30782/TCP     NodePort       test/echo     https      Done    10.244.1.1:443/TCP, 10.244.1.2:443/TCP
+10.96.50.104:80/TCP   ClusterIP      test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+10.96.50.104:443/TCP  ClusterIP      test/echo     https      Done    10.244.1.1:443/TCP, 10.244.1.2:443/TCP
+172.16.1.1:80/TCP     LoadBalancer   test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+172.16.1.1:443/TCP    LoadBalancer   test/echo     https      Done    10.244.1.1:443/TCP, 10.244.1.2:443/TCP
+192.0.2.10:80/TCP     ExternalIPs    test/echo     http       Done    10.244.1.1:80/TCP, 10.244.1.2:80/TCP
+192.0.2.10:443/TCP    ExternalIPs    test/echo     https      Done    10.244.1.1:443/TCP, 10.244.1.2:443/TCP
+-- backends.table --
+Service     Address              Source   Priority   State    PortNames   NodeName
+test/echo   10.244.1.1:80/TCP    k8s      4          active   http        nodeport-worker
+test/echo   10.244.1.1:443/TCP   k8s      4          active   https       nodeport-worker
+test/echo   10.244.1.2:80/TCP    k8s      4          active   http        nodeport-worker2
+test/echo   10.244.1.2:443/TCP   k8s      4          active   https       nodeport-worker2
+-- before.expected --
+BE: ID=1 ADDR=10.244.1.1:80/TCP STATE=active
+BE: ID=2 ADDR=10.244.1.2:80/TCP STATE=active
+BE: ID=3 ADDR=10.244.1.1:443/TCP STATE=active
+BE: ID=4 ADDR=10.244.1.2:443/TCP STATE=active
+REV: ID=1 ADDR=0.0.0.0:30781
+REV: ID=10 ADDR=192.0.2.10:443
+REV: ID=2 ADDR=1.1.1.1:30781
+REV: ID=3 ADDR=0.0.0.0:30782
+REV: ID=4 ADDR=1.1.1.1:30782
+REV: ID=5 ADDR=10.96.50.104:80
+REV: ID=6 ADDR=10.96.50.104:443
+REV: ID=7 ADDR=172.16.1.1:80
+REV: ID=8 ADDR=172.16.1.1:443
+REV: ID=9 ADDR=192.0.2.10:80
+SVC: ID=0 ADDR=10.96.50.104:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=0 ADDR=172.16.1.1:0/ANY SLOT=0 LBALG=undef AFFTimeout=0 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer+non-routable
+SVC: ID=1 ADDR=0.0.0.0:30781/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=1 ADDR=0.0.0.0:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=1 ADDR=0.0.0.0:30781/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=10 ADDR=192.0.2.10:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ExternalIPs
+SVC: ID=10 ADDR=192.0.2.10:443/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ExternalIPs
+SVC: ID=10 ADDR=192.0.2.10:443/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ExternalIPs
+SVC: ID=2 ADDR=1.1.1.1:30781/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort
+SVC: ID=2 ADDR=1.1.1.1:30781/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=2 ADDR=1.1.1.1:30781/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=3 ADDR=0.0.0.0:30782/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=3 ADDR=0.0.0.0:30782/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=3 ADDR=0.0.0.0:30782/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=NodePort+non-routable
+SVC: ID=4 ADDR=1.1.1.1:30782/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=NodePort
+SVC: ID=4 ADDR=1.1.1.1:30782/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=4 ADDR=1.1.1.1:30782/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=NodePort
+SVC: ID=5 ADDR=10.96.50.104:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=10.96.50.104:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=5 ADDR=10.96.50.104:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=10.96.50.104:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=10.96.50.104:443/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=6 ADDR=10.96.50.104:443/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=ClusterIP+non-routable
+SVC: ID=7 ADDR=172.16.1.1:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=7 ADDR=172.16.1.1:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=7 ADDR=172.16.1.1:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=8 ADDR=172.16.1.1:443/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=8 ADDR=172.16.1.1:443/TCP SLOT=1 BEID=3 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=8 ADDR=172.16.1.1:443/TCP SLOT=2 BEID=4 COUNT=0 QCOUNT=0 FLAGS=LoadBalancer
+SVC: ID=9 ADDR=192.0.2.10:80/TCP SLOT=0 LBALG=undef AFFTimeout=0 COUNT=2 QCOUNT=0 FLAGS=ExternalIPs
+SVC: ID=9 ADDR=192.0.2.10:80/TCP SLOT=1 BEID=1 COUNT=0 QCOUNT=0 FLAGS=ExternalIPs
+SVC: ID=9 ADDR=192.0.2.10:80/TCP SLOT=2 BEID=2 COUNT=0 QCOUNT=0 FLAGS=ExternalIPs
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 10.96.50.104
+  clusterIPs:
+  - 10.96.50.104
+  externalIPs:
+  - 192.0.2.10
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: http
+    nodePort: 30781
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  - name: https
+    nodePort: 30782
+    port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:
+    name: echo
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+    - ip: 172.16.1.1
+
+-- endpointslice.yaml --
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  labels:
+    kubernetes.io/service-name: echo
+  name: echo-kvlm2
+  namespace: test
+addressType: IPv4
+endpoints:
+- addresses:
+  - 10.244.1.1
+  nodeName: nodeport-worker
+- addresses:
+  - 10.244.1.2
+  nodeName: nodeport-worker2
+ports:
+- name: http
+  port: 80
+  protocol: TCP
+- name: https
+  port: 443
+  protocol: TCP


### PR DESCRIPTION
Previously, the LB reflection logic would skip LoadBalancer VIPs if KPR was off. This condition was removed to facilitate BGP and L2 reachability announcements.

As a consequence the datapath is now unintentionally intercepting traffic that should be delegated to kube-proxy and the linux network stack. This means traffic towards a LoadBalancer VIP configured with `iTP=Cluster` and `eTP=Local` will drop if the traffic originates from inside the cluster and no backend pods exist on the local node.

Commit 1 is preparatory, to allow testing (or, more specifically, simulation) of load balancer reconciliation of BPF map state across agent restarts.

Commit 2 introduces the necessary logic to intentionally ignore certain frontends when reconciling the datapath when KPR is disabled, and associated testing.

This PR was prepared with AIL:2.

Fixes: #45252

```release-note
Fix bug causing Cilium to intercept traffic towards LoadBalancer VIPs when KPR is disabled, when the traffic should be delegated to kube-proxy.
```

**Reviewer Notes**
Please can this be tagged for backport to `v1.20` and `v1.19`.