### PR TITLE
images/scripts: Validate Envoy image vars against sed injection

### DIFF
--- a/images/scripts/check-cilium-envoy-image.sh
+++ b/images/scripts/check-cilium-envoy-image.sh
@@ -17,8 +17,24 @@ image="$(sed -n -E 's/^export[[:space:]]+CILIUM_ENVOY_REPO[?]?=(.*)$/\1/p' "${MA
 image_tag="$(sed -n -E 's/^export[[:space:]]+CILIUM_ENVOY_VERSION[?]?=(.*)$/\1/p' "${MAKEFILEPATH}")"
 image_sha256="$(sed -n -E 's/^export[[:space:]]+CILIUM_ENVOY_DIGEST[?]?=(.*)$/\1/p' "${MAKEFILEPATH}")"
 
+if [[ ! "${image_tag}" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+    echo "Invalid image_tag format: ${image_tag}"
+    exit 1
+fi
+
+if [[ ! "${image_sha256}" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+    echo "Invalid image_sha256 format: ${image_sha256}"
+    exit 1
+fi
+
+if [[ ! "${image}" =~ ^[a-zA-Z0-9./:-]+$ ]]; then
+    echo "Invalid image format: ${image}"
+    exit 1
+fi
+
 # pre-check for sed, in case that this script may fail to detect change when the `sed` command fails to replace the string and return code 0
-image_regular="(ARG CILIUM_ENVOY_IMAGE=${image}:)(.*)(@sha256:[0-9a-z]*)"
+image_escaped="${image//./\\.}"
+image_regular="(ARG CILIUM_ENVOY_IMAGE=${image_escaped}:)(.*)(@sha256:[0-9a-z]*)"
 grep -E "${image_regular}" ./images/cilium/Dockerfile &>/dev/null || exit 1
 sed -i -E "s|${image_regular}|\1${image_tag}@${image_sha256}|" ./images/cilium/Dockerfile
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

When `check-cilium-envoy-image.sh` extracts Envoy image variables from `Makefile.values`, it didn't previously check if the variables had unexpected characters. This PR adds structure validation for `image_tag`, `image_sha256`, and `image` using bash regular expressions right after they are parsed. This ensures they conform to expected naming and hash patterns before they are used in sed operations further down the script.

This PR was prepared with AIL:3. I personally checked and verified the bash regex implementations.