### PR TITLE
ipcache: fix CIDR reference counter to use canonical prefixes

### DIFF
--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -572,7 +572,7 @@ func (ipc *IPCache) UpsertMetadataBatch(updates ...MU) (revision uint64) {
 	prefixes := make([]cmtypes.PrefixCluster, 0, len(updates))
 	ipc.metadata.Lock()
 	for _, upd := range updates {
-		if !upd.IsCIDR || ipc.metadata.prefixRefCounter.Add(upd.Prefix) {
+		if !upd.IsCIDR || ipc.metadata.prefixRefCounter.Add(canonicalPrefix(upd.Prefix)) {
 			resource := upd.Resource
 			if upd.IsCIDR {
 				resource = cidrResourceID
@@ -607,7 +607,7 @@ func (ipc *IPCache) RemoveMetadataBatch(updates ...MU) (revision uint64) {
 	prefixes := make([]cmtypes.PrefixCluster, 0, len(updates))
 	ipc.metadata.Lock()
 	for _, upd := range updates {
-		if !upd.IsCIDR || ipc.metadata.prefixRefCounter.Delete(upd.Prefix) {
+		if !upd.IsCIDR || ipc.metadata.prefixRefCounter.Delete(canonicalPrefix(upd.Prefix)) {
 			resource := upd.Resource
 			if upd.IsCIDR {
 				resource = cidrResourceID

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -1541,6 +1541,79 @@ func TestIPCacheCIDRResourceConsolidation(t *testing.T) {
 	assert.Nil(t, s.IPIdentityCache.metadata.get(cidr))
 }
 
+// TestIPCacheCIDRResourceConsolidationNonCanonical is a test for CIDR reference
+// counting with non-canonical prefixes. Ensures deleting a policy for 10.0.0.1/24
+// does not release the shared canonical identity for 10.0.0.0/24.
+func TestIPCacheCIDRResourceConsolidationNonCanonical(t *testing.T) {
+	s := setupIPCacheTestSuite(t)
+
+	// ns-A expresses the network with host bits set; ns-B uses the canonical
+	// (masked) form. Both collapse onto the same canonical prefix 10.0.0.0/24.
+	nsAPrefix := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("10.0.0.1/24"))
+	nsBPrefix := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("10.0.0.0/24"))
+	canonical := canonicalPrefix(nsAPrefix)
+	assert.Equal(t, canonical, canonicalPrefix(nsBPrefix))
+
+	nsAResource := types.NewResourceID(types.ResourceKindCNP, "ns-a", "policy-a")
+	nsBResource := types.NewResourceID(types.ResourceKindCNP, "ns-b", "policy-b")
+
+	// ns-A adds 10.0.0.1/24.
+	assert.NoError(t, s.IPIdentityCache.WaitForRevision(
+		context.TODO(), s.IPIdentityCache.UpsertMetadataBatch(MU{
+			Prefix:   nsAPrefix,
+			Source:   source.Generated,
+			Resource: nsAResource,
+			Metadata: []IPMetadata{labels.GetCIDRLabels(nsAPrefix.AsPrefix())},
+			IsCIDR:   true,
+		}),
+	))
+	// ns-B adds 10.0.0.0/24 (same canonical network, different raw prefix).
+	assert.NoError(t, s.IPIdentityCache.WaitForRevision(
+		context.TODO(), s.IPIdentityCache.UpsertMetadataBatch(MU{
+			Prefix:   nsBPrefix,
+			Source:   source.Generated,
+			Resource: nsBResource,
+			Metadata: []IPMetadata{labels.GetCIDRLabels(nsBPrefix.AsPrefix())},
+			IsCIDR:   true,
+		}),
+	))
+
+	// Both references must collapse onto one canonical counter key (count 2)
+	// with a single consolidated metadata entry.
+	assert.Equal(t, 2, s.IPIdentityCache.metadata.prefixRefCounter[canonical])
+	assert.NotNil(t, s.IPIdentityCache.metadata.get(canonical))
+
+	// ns-A's policy is deleted. Before the fix, the counter was keyed by the
+	// raw prefix 10.0.0.1/24, so this dropped that key to 0, tore down the
+	// shared canonical entry, and released the identity still used by ns-B.
+	assert.NoError(t, s.IPIdentityCache.WaitForRevision(
+		context.TODO(), s.IPIdentityCache.RemoveMetadataBatch(MU{
+			Prefix:   nsAPrefix,
+			Source:   source.Generated,
+			Resource: nsAResource,
+			Metadata: []IPMetadata{labels.Labels{}},
+			IsCIDR:   true,
+		}),
+	))
+	// ns-B must be unaffected: the entry survives with a refcount of 1.
+	assert.Equal(t, 1, s.IPIdentityCache.metadata.prefixRefCounter[canonical])
+	assert.NotNil(t, s.IPIdentityCache.metadata.get(canonical),
+		"deleting ns-A's CIDR policy must not release the identity still used by ns-B")
+
+	// ns-B's policy is deleted; only now is the shared entry truly removed.
+	assert.NoError(t, s.IPIdentityCache.WaitForRevision(
+		context.TODO(), s.IPIdentityCache.RemoveMetadataBatch(MU{
+			Prefix:   nsBPrefix,
+			Source:   source.Generated,
+			Resource: nsBResource,
+			Metadata: []IPMetadata{labels.Labels{}},
+			IsCIDR:   true,
+		}),
+	))
+	assert.Zero(t, s.IPIdentityCache.metadata.prefixRefCounter[canonical])
+	assert.Nil(t, s.IPIdentityCache.metadata.get(canonical))
+}
+
 func BenchmarkManyResources(b *testing.B) {
 	logger := hivetest.Logger(b)
 	m := newMetadata(logger)


### PR DESCRIPTION
Policy CIDR identities are shared across namespaces via a single consolidated ipcache metadata entry, guarded only by `prefixRefCounter`. The counter was keyed by the *raw* prefix from the update, while the metadata store keys entries by the *canonical* (masked, unmapped) prefix. This mismatch lets one namespace's policy deletion release a CIDR identity that another namespace still uses.

## Reproduction

- namespace-A: CiliumNetworkPolicy with `toCIDR: 10.0.0.1/24`
- namespace-B: CiliumNetworkPolicy with `toCIDR: 10.0.0.0/24`  (same network range, just different prefix)

Counter holds `{10.0.0.1/24: 1, 10.0.0.0/24: 1}` but there is a single `10.0.0.0/24` metadata entry / identity. Deleting ns-A's policy drops its raw key to 0, tears down the shared entry, and releases the identity ns-B still references — ns-B loses traffic to `10.0.0.0/24`. The stale ns-B count also prevents recovery until an agent restart. 

This leads to silent traffic drops in production environments when overlapping CIDRs are deleted across namespaces.

## Changes

- Key `prefixRefCounter` by `canonicalPrefix(upd.Prefix)` in both `UpsertMetadataBatch` and `RemoveMetadataBatch`, aligning it with the metadata store's existing canonical keying.
- Add `TestIPCacheCIDRResourceConsolidationNonCanonical`, which fails without the fix (shared entry released after deleting one of two namespaces).

## Note

This bug is introduced in this commit: 50d7f4530e
first affected releases: v1.19.0, and v1.18.5