### PR TITLE
gateway-api: cleanup hardcoded Cilium GatewayClass controllerclass

### DIFF
--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -186,7 +186,7 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			builder.WithPredicates(predicates.GatewayClassOwnedByController(r.controllerName))).
 		// Watch related backend Service for status
 		// LB Services are handled by the Owns call later.
-		Watches(&corev1.Service{}, watchhandlers.EnqueueRequestForBackendService(r.Client, *r.logger)).
+		Watches(&corev1.Service{}, watchhandlers.EnqueueRequestForBackendService(r.Client, *r.logger, r.controllerName)).
 		// Watch HTTPRoute linked to Gateway
 		Watches(&gatewayv1.HTTPRoute{}, watchhandlers.EnqueueRequestForOwningHTTPRoute(r.Client, r.logger, r.controllerName)).
 		// Watch GRPCRoute linked to Gateway
@@ -203,10 +203,10 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Watch for changes to Reference Grants
 		Watches(&gatewayv1.ReferenceGrant{}, watchhandlers.EnqueueRequestForReferenceGrant(r.Client, r.logger)).
 		// Watch for changes to BackendTLSPolicy
-		Watches(&gatewayv1.BackendTLSPolicy{}, watchhandlers.EnqueueRequestForBackendTLSPolicy(r.Client, r.logger)).
-		Watches(&corev1.ConfigMap{}, watchhandlers.EnqueueRequestForBackendTLSPolicyConfigMap(r.Client, r.logger)).
+		Watches(&gatewayv1.BackendTLSPolicy{}, watchhandlers.EnqueueRequestForBackendTLSPolicy(r.Client, r.logger, r.controllerName)).
+		Watches(&corev1.ConfigMap{}, watchhandlers.EnqueueRequestForBackendTLSPolicyConfigMap(r.Client, r.logger, r.controllerName)).
 		// Watch for changes to node in order to populate gateway ip addresses if svc of type NodePort
-		Watches(&corev1.Node{}, watchhandlers.EnqueueRequestForNodes(r.Client, r.logger, owningGatewayLabel)).
+		Watches(&corev1.Node{}, watchhandlers.EnqueueRequestForNodes(r.Client, r.logger, owningGatewayLabel, r.controllerName)).
 		// Watch created and owned resources
 		Owns(&ciliumv2.CiliumEnvoyConfig{}).
 		Owns(&corev1.Service{}).
@@ -224,12 +224,12 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	if listenerSetEnabled {
 		// Watch ListenerSet linked to Gateway
-		gatewayBuilder = gatewayBuilder.Watches(&gatewayv1.ListenerSet{}, watchhandlers.EnqueueRequestForListenerSetOwner(r.Client, r.logger, defaultControllerName))
+		gatewayBuilder = gatewayBuilder.Watches(&gatewayv1.ListenerSet{}, watchhandlers.EnqueueRequestForListenerSetOwner(r.Client, r.logger, r.controllerName))
 	}
 
 	if serviceImportEnabled {
 		// Watch for changes to Backend Service Imports
-		gatewayBuilder = gatewayBuilder.Watches(&mcsapiv1beta1.ServiceImport{}, watchhandlers.EnqueueRequestForBackendServiceImport(r.Client, *r.logger))
+		gatewayBuilder = gatewayBuilder.Watches(&mcsapiv1beta1.ServiceImport{}, watchhandlers.EnqueueRequestForBackendServiceImport(r.Client, *r.logger, r.controllerName))
 	}
 
 	return gatewayBuilder.Complete(r)

--- a/operator/pkg/gateway-api/indexers/gateway.go
+++ b/operator/pkg/gateway-api/indexers/gateway.go
@@ -11,8 +11,9 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-// indexGatewayByImplementation adds a value of `cilium` to the indexers.ImplementationGatewayIndex if
-// the Gateway has a GatewayClass that has the Cilium `controllerName`.
+// indexGatewayByImplementation adds the controller name to
+// indexers.ImplementationGatewayIndex if the Gateway has a GatewayClass with
+// that controller name.
 func GenerateIndexerGatewayByImplementation(c client.Client, controllerName gatewayv1.GatewayController) client.IndexerFunc {
 	return func(rawObj client.Object) []string {
 		gw := rawObj.(*gatewayv1.Gateway)
@@ -24,7 +25,7 @@ func GenerateIndexerGatewayByImplementation(c client.Client, controllerName gate
 		}
 
 		if gwc.Spec.ControllerName == controllerName {
-			return []string{"cilium"}
+			return []string{string(controllerName)}
 		}
 
 		return []string{}

--- a/operator/pkg/gateway-api/watch-handlers/backendtlspolicy.go
+++ b/operator/pkg/gateway-api/watch-handlers/backendtlspolicy.go
@@ -23,9 +23,9 @@ import (
 )
 
 // EnqueueRequestForBackendTLSPolicy returns an event handler that, when passed a BackendTLSPolicy, returns reconcile.Requests
-// for all Cilium-relevant Gateways where that BackendTLSPolicy references a Service that is used as a backend for a
+// for all controller-relevant Gateways where that BackendTLSPolicy references a Service that is used as a backend for a
 // Route that is attached to that Gateway.
-func EnqueueRequestForBackendTLSPolicy(c client.Client, logger *slog.Logger) handler.EventHandler {
+func EnqueueRequestForBackendTLSPolicy(c client.Client, logger *slog.Logger, controllerName string) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
 		scopedLog := logger.With(logfields.LogSubsys, "queue-gw-from-backendtlspolicy")
 
@@ -35,16 +35,16 @@ func EnqueueRequestForBackendTLSPolicy(c client.Client, logger *slog.Logger) han
 			return nil
 		}
 
-		// Build a set of all Cilium Gateway full names.
+		// Build a set of all matching Gateway full names.
 		// This makes sure we only add a reconcile.Request once for each Gateway.
-		allCiliumGatewaysSet, err := getAllCiliumGatewaysSet(ctx, c)
+		allGatewaysSet, err := getAllGatewaysSetForController(ctx, c, controllerName)
 		if err != nil {
-			scopedLog.ErrorContext(ctx, "Failed to get Cilium Gateways", logfields.Error, err)
+			scopedLog.ErrorContext(ctx, "Failed to get controller Gateways", logfields.Error, err)
 			return []reconcile.Request{}
 		}
 
 		ns := o.GetNamespace()
-		updateReconcileRequestsForBackendTLSPolicy(ctx, c, scopedLog, allCiliumGatewaysSet, reconcileRequests, btlsp, ns)
+		updateReconcileRequestsForBackendTLSPolicy(ctx, c, scopedLog, allGatewaysSet, reconcileRequests, btlsp, ns)
 
 		recs := slices.Collect(maps.Keys(reconcileRequests))
 		if len(recs) > 0 {
@@ -56,7 +56,7 @@ func EnqueueRequestForBackendTLSPolicy(c client.Client, logger *slog.Logger) han
 	})
 }
 
-func EnqueueRequestForBackendTLSPolicyConfigMap(c client.Client, logger *slog.Logger) handler.EventHandler {
+func EnqueueRequestForBackendTLSPolicyConfigMap(c client.Client, logger *slog.Logger, controllerName string) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
 		scopedLog := logger.With(logfields.LogSubsys, "queue-gw-from-backendtlspolicy-configmap")
 
@@ -84,11 +84,11 @@ func EnqueueRequestForBackendTLSPolicyConfigMap(c client.Client, logger *slog.Lo
 			return []reconcile.Request{}
 		}
 
-		// Build a set of all Cilium Gateway full names.
+		// Build a set of all matching Gateway full names.
 		// This makes sure we only add a reconcile.Request once for each Gateway.
-		allCiliumGatewaysSet, err := getAllCiliumGatewaysSet(ctx, c)
+		allGatewaysSet, err := getAllGatewaysSetForController(ctx, c, controllerName)
 		if err != nil {
-			scopedLog.ErrorContext(ctx, "Failed to get Cilium Gateways", logfields.Error, err)
+			scopedLog.ErrorContext(ctx, "Failed to get controller Gateways", logfields.Error, err)
 			return []reconcile.Request{}
 		}
 
@@ -117,8 +117,8 @@ func EnqueueRequestForBackendTLSPolicyConfigMap(c client.Client, logger *slog.Lo
 			}
 
 			// This BackendTLSPolicy references the ConfigMap being enqueued, check to see if it's in the
-			// ownership chain any Cilium-relevant Gateways.
-			updateReconcileRequestsForBackendTLSPolicy(ctx, c, scopedLog, allCiliumGatewaysSet, reconcileRequests, &btlsp, cfgMap.GetNamespace())
+			// ownership chain any matching Gateways.
+			updateReconcileRequestsForBackendTLSPolicy(ctx, c, scopedLog, allGatewaysSet, reconcileRequests, &btlsp, cfgMap.GetNamespace())
 
 		}
 		recs := slices.Collect(maps.Keys(reconcileRequests))

--- a/operator/pkg/gateway-api/watch-handlers/helpers.go
+++ b/operator/pkg/gateway-api/watch-handlers/helpers.go
@@ -123,25 +123,26 @@ func getGatewayReconcileRequestsForRoute(ctx context.Context, c client.Client, o
 	return reqs
 }
 
-func getAllCiliumGatewaysSet(ctx context.Context, c client.Client) (map[string]struct{}, error) {
-	// Fetch all the Cilium-relevant Gateways using the indexers.ImplementationGatewayIndex.
+func getAllGatewaysSetForController(ctx context.Context, c client.Client, controllerName string) (map[string]struct{}, error) {
+	// Fetch all Gateways for the target controller using the
+	// indexers.ImplementationGatewayIndex.
 	gwList := &gatewayv1.GatewayList{}
 	if err := c.List(ctx, gwList, &client.ListOptions{
-		FieldSelector: fields.OneTermEqualSelector(indexers.ImplementationGatewayIndex, "cilium"),
+		FieldSelector: fields.OneTermEqualSelector(indexers.ImplementationGatewayIndex, controllerName),
 	}); err != nil {
 		return nil, err
 	}
-	// Build a set of all Cilium Gateway full names.
+	// Build a set of all matching Gateway full names.
 	// This makes sure we only add a reconcile.Request once for each Gateway.
-	allCiliumGatewaysSet := make(map[string]struct{})
+	allGatewaysSet := make(map[string]struct{})
 
 	for _, gw := range gwList.Items {
 		gwFullName := types.NamespacedName{
 			Name:      gw.GetName(),
 			Namespace: gw.GetNamespace(),
 		}
-		allCiliumGatewaysSet[gwFullName.String()] = struct{}{}
+		allGatewaysSet[gwFullName.String()] = struct{}{}
 	}
 
-	return allCiliumGatewaysSet, nil
+	return allGatewaysSet, nil
 }

--- a/operator/pkg/gateway-api/watch-handlers/node.go
+++ b/operator/pkg/gateway-api/watch-handlers/node.go
@@ -19,8 +19,8 @@ import (
 )
 
 // EnqueueRequestForNodes returns an event handler for any changes to a node's IP address, returns reconcile.Requests
-// for all Cilium-relvant Gateways
-func EnqueueRequestForNodes(c client.Client, logger *slog.Logger, owningGatewayLabel string) handler.EventHandler {
+// for all controller-relevant Gateways.
+func EnqueueRequestForNodes(c client.Client, logger *slog.Logger, owningGatewayLabel, controllerName string) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, ns client.Object) []reconcile.Request {
 		scopedLog := logger.With(
 			logfields.K8sNamespace, ns.GetName(),
@@ -31,10 +31,10 @@ func EnqueueRequestForNodes(c client.Client, logger *slog.Logger, owningGatewayL
 			return nil
 		}
 
-		gateways, err := getAllCiliumGatewaysSet(ctx, c)
+		gateways, err := getAllGatewaysSetForController(ctx, c, controllerName)
 
 		if err != nil {
-			scopedLog.ErrorContext(ctx, "Failed to get Cilium Gateways", logfields.Error, err)
+			scopedLog.ErrorContext(ctx, "Failed to get controller Gateways", logfields.Error, err)
 			return []reconcile.Request{}
 		}
 
@@ -59,7 +59,7 @@ func EnqueueRequestForNodes(c client.Client, logger *slog.Logger, owningGatewayL
 			}
 		}
 
-		// queue up a request for every Cilium related gateway
+		// Queue up a request for every matching gateway.
 		for gw := range gateways {
 			gwSplit := strings.SplitN(gw, "/", 2)
 

--- a/operator/pkg/gateway-api/watch-handlers/service.go
+++ b/operator/pkg/gateway-api/watch-handlers/service.go
@@ -11,7 +11,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -22,9 +21,10 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
-// EnqueueRequestForBackendService returns an event handler that, when passed a Service, returns reconcile.Requests
-// for all Cilium-relevant Gateways where that Service is used as a backend for a HTTPRoute that is attached to that Gateway.
-func EnqueueRequestForBackendService(c client.Client, logger slog.Logger) handler.EventHandler {
+// EnqueueRequestForBackendService returns an event handler that, when passed a
+// Service, returns reconcile.Requests for all relevant Gateways where that
+// Service is used as a backend for a Route attached to that Gateway.
+func EnqueueRequestForBackendService(c client.Client, logger slog.Logger, controllerName string) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
 		_, ok := o.(*corev1.Service)
 		if !ok {
@@ -64,40 +64,25 @@ func EnqueueRequestForBackendService(c client.Client, logger slog.Logger) handle
 			return []reconcile.Request{}
 		}
 
-		// Fetch all the Cilium-relevant Gateways using the indexers.ImplementationGatewayIndex.
-		gwList := &gatewayv1.GatewayList{}
-		if err := c.List(ctx, gwList, &client.ListOptions{
-			FieldSelector: fields.OneTermEqualSelector(indexers.ImplementationGatewayIndex, "cilium"),
-		}); err != nil {
-			scopedLog.ErrorContext(ctx, "Failed to get Cilium Gateways", logfields.Error, err)
+		allGatewaysSet, err := getAllGatewaysSetForController(ctx, c, controllerName)
+		if err != nil {
+			scopedLog.ErrorContext(ctx, "Failed to get controller Gateways", logfields.Error, err)
 			return []reconcile.Request{}
-		}
-
-		// Build a set of all Cilium Gateway full names.
-		// This makes sure we only add a reconcile.Request once for each Gateway.
-		allCiliumGatewaysSet := make(map[string]struct{})
-
-		for _, gw := range gwList.Items {
-			gwFullName := types.NamespacedName{
-				Name:      gw.GetName(),
-				Namespace: gw.GetNamespace(),
-			}
-			allCiliumGatewaysSet[gwFullName.String()] = struct{}{}
 		}
 
 		// iterate through the HTTPRoutes, update reconcileRequests for each Gateway that is relevant.
 		for _, hr := range hrList.Items {
-			updateReconcileRequestsForParentRefs(ctx, c, hr.Spec.ParentRefs, hr.Namespace, allCiliumGatewaysSet, reconcileRequests)
+			updateReconcileRequestsForParentRefs(ctx, c, hr.Spec.ParentRefs, hr.Namespace, allGatewaysSet, reconcileRequests)
 		}
 
 		// iterate through the TLSRoutes, update reconcileRequests for each Gateway that is relevant.
 		for _, tlsr := range tlsrList.Items {
-			updateReconcileRequestsForParentRefs(ctx, c, tlsr.Spec.ParentRefs, tlsr.Namespace, allCiliumGatewaysSet, reconcileRequests)
+			updateReconcileRequestsForParentRefs(ctx, c, tlsr.Spec.ParentRefs, tlsr.Namespace, allGatewaysSet, reconcileRequests)
 		}
 
 		// iterate through the TLSRoutes, update reconcileRequests for each Gateway that is relevant.
 		for _, grpcr := range grpcRouteList.Items {
-			updateReconcileRequestsForParentRefs(ctx, c, grpcr.Spec.ParentRefs, grpcr.Namespace, allCiliumGatewaysSet, reconcileRequests)
+			updateReconcileRequestsForParentRefs(ctx, c, grpcr.Spec.ParentRefs, grpcr.Namespace, allGatewaysSet, reconcileRequests)
 		}
 
 		// return the keys of the set, since that's the actual reconcile.Requests.
@@ -107,7 +92,7 @@ func EnqueueRequestForBackendService(c client.Client, logger slog.Logger) handle
 
 // EnqueueRequestForBackendServiceImport makes sure that Gateways are reconciled
 // if a relevant HTTPRoute backend Service Imports are updated.
-func EnqueueRequestForBackendServiceImport(c client.Client, logger slog.Logger) handler.EventHandler {
+func EnqueueRequestForBackendServiceImport(c client.Client, logger slog.Logger, controllerName string) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
 		_, ok := o.(*mcsapiv1beta1.ServiceImport)
 		if !ok {
@@ -129,29 +114,15 @@ func EnqueueRequestForBackendServiceImport(c client.Client, logger slog.Logger) 
 			return []reconcile.Request{}
 		}
 
-		// Fetch all the Cilium-relevant Gateways using the indexers.ImplementationGatewayIndex.
-		gwList := &gatewayv1.GatewayList{}
-		if err := c.List(ctx, gwList, &client.ListOptions{
-			FieldSelector: fields.OneTermEqualSelector(indexers.ImplementationGatewayIndex, "cilium"),
-		}); err != nil {
-			scopedLog.ErrorContext(ctx, "Failed to get Cilium Gateways", logfields.Error, err)
+		allGatewaysSet, err := getAllGatewaysSetForController(ctx, c, controllerName)
+		if err != nil {
+			scopedLog.ErrorContext(ctx, "Failed to get controller Gateways", logfields.Error, err)
 			return []reconcile.Request{}
-		}
-
-		// Build a set of all Cilium Gateway full names.
-		// This makes sure we only add a reconcile.Request once for each Gateway.
-		allCiliumGatewaysSet := make(map[string]struct{})
-		for _, gw := range gwList.Items {
-			gwFullName := types.NamespacedName{
-				Name:      gw.GetName(),
-				Namespace: gw.GetNamespace(),
-			}
-			allCiliumGatewaysSet[gwFullName.String()] = struct{}{}
 		}
 
 		// iterate through the HTTPRoutes, return a reconcile.Request for each Gateway that is relevant.
 		for _, hr := range hrList.Items {
-			updateReconcileRequestsForParentRefs(ctx, c, hr.Spec.ParentRefs, hr.Namespace, allCiliumGatewaysSet, reconcileRequests)
+			updateReconcileRequestsForParentRefs(ctx, c, hr.Spec.ParentRefs, hr.Namespace, allGatewaysSet, reconcileRequests)
 		}
 
 		// return the keys of the set.


### PR DESCRIPTION
A previous commit cleaned up some hardcoded occurrences of the Cilium GatewayClass controllerName. This should only be defined in the controller struct and propagated to the various helpers.

This commit cleans up some more leftovers that have been re-introduced in the meantime.

Related to https://github.com/cilium/cilium/pull/46362