### PR TITLE
gh: Add Delta xDS test run

### DIFF
--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -81,10 +81,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - name: default (ads)
-          extra-helm-set: ""
+        - name: ads
+          extra-helm-set: "--helm-set=envoy.xdsMode=ads"
         - name: split
           extra-helm-set: "--helm-set=envoy.xdsMode=split"
+        - name: delta-split
+          extra-helm-set: "--helm-set=envoy.xdsMode=delta-split"
     env:
       job_name: "Installation and Connectivity Test (${{ matrix.name }})"
       ENABLE_CLUSTERNETWORKPOLICY: "true"


### PR DESCRIPTION
Add delta-split (Delta xDS) run to conformance-kind-proxy-embedded and make the ADS run explicit rather than relying it being the default, as the default can change in future releases (e.g., to delta ADS).
