### PR TITLE
gh: Disable Envoy connection pooling in conformance-kind-proxy-embedded

### DIFF
--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -157,12 +157,18 @@ jobs:
         run: |
           # Note: On Kind, we install Cilium with HostPort (portmap CNI chaining) enabled,
           # to ensure coverage of that feature in cilium connectivity test
+          # This test intentionally sends traffic with and without L7 LB in succession.
+          # Disable upstream connection pooling and close each upstream socket immediately
+          # so client source port reuse cannot collide with an existing pool connection for
+          # the same 5-tuple and cause a test flake.
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --helm-set=hubble.relay.enabled=true
             --helm-set=cni.chainingMode=portmap \
             --helm-set-string=kubeProxyReplacement=true \
             --helm-set=k8sClusterNetworkPolicy.enabled=${ENABLE_CLUSTERNETWORKPOLICY} \
             --helm-set=loadBalancer.l7.backend=envoy \
+            --helm-set=envoy.maxRequestsPerConnection=1 \
+            --helm-set=envoy.httpUpstreamLingerTimeout=0 \
             --helm-set=tls.readSecretsOnlyFromSecretsNamespace=true \
             --helm-set=tls.secretSync.enabled=true \
             --helm-set=envoy.enabled=false \

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -142,6 +142,7 @@ cilium-operator-alibabacloud [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -127,6 +127,7 @@ cilium-operator-alibabacloud hive [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -132,6 +132,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -149,6 +149,7 @@ cilium-operator-aws [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -134,6 +134,7 @@ cilium-operator-aws hive [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -139,6 +139,7 @@ cilium-operator-aws hive dot-graph [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -144,6 +144,7 @@ cilium-operator-azure [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -129,6 +129,7 @@ cilium-operator-azure hive [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -134,6 +134,7 @@ cilium-operator-azure hive dot-graph [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -148,6 +148,7 @@ cilium-operator-generic [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -133,6 +133,7 @@ cilium-operator-generic hive [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -138,6 +138,7 @@ cilium-operator-generic hive dot-graph [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -163,6 +163,7 @@ cilium-operator [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -148,6 +148,7 @@ cilium-operator hive [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -153,6 +153,7 @@ cilium-operator hive dot-graph [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1512,7 +1512,7 @@ data:
   external-envoy-proxy: {{ include "envoyDaemonSetEnabled" . | quote }}
   envoy-base-id: {{ .Values.envoy.baseID | quote }}
 
-{{- if .Values.envoy.httpUpstreamLingerTimeout }}
+{{- if ne .Values.envoy.httpUpstreamLingerTimeout nil }}
   envoy-http-upstream-linger-timeout: {{ .Values.envoy.httpUpstreamLingerTimeout | quote }}
 {{- end }}
 

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -2500,7 +2500,10 @@
           "type": "integer"
         },
         "httpUpstreamLingerTimeout": {
-          "type": "null"
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "idleTimeoutDurationSeconds": {
           "type": "integer"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2835,6 +2835,9 @@ envoy:
   # @schema
   # -- Max duration to wait for endpoint policies to be restored on restart. Default "3m".
   policyRestoreTimeoutDuration: null
+  # @schema
+  # type: [null, integer]
+  # @schema
   # -- Time in seconds to block Envoy worker thread while an upstream HTTP connection is closing. If set to 0, the connection is closed immediately (with TCP RST). If set to -1, the connection is closed asynchronously in the background.
   httpUpstreamLingerTimeout: null
   # -- Static runtime bootstrap config for envoy.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2866,6 +2866,9 @@ envoy:
   # @schema
   # -- Max duration to wait for endpoint policies to be restored on restart. Default "3m".
   policyRestoreTimeoutDuration: null
+  # @schema
+  # type: [null, integer]
+  # @schema
   # -- Time in seconds to block Envoy worker thread while an upstream HTTP connection is closing. If set to 0, the connection is closed immediately (with TCP RST). If set to -1, the connection is closed asynchronously in the background.
   httpUpstreamLingerTimeout: null
   # -- Static runtime bootstrap config for envoy.

--- a/operator/pkg/ciliumenvoyconfig/cell.go
+++ b/operator/pkg/ciliumenvoyconfig/cell.go
@@ -24,28 +24,33 @@ var Cell = cell.Module(
 		LoadBalancerL7Ports:     []string{},
 		LoadBalancerL7Algorithm: "round_robin",
 	}),
-	cell.Config(defaultEnvoyProxyTimeouts),
+	cell.Config(defaultEnvoyProxyConfig),
 	cell.Invoke(registerL7LoadBalancingController),
 	cell.Provide(func(r l7LoadBalancerConfig) LoadBalancerConfig { return r }),
 )
 
-// EnvoyProxyTimeouts holds the upstream timeout values used by the operator
-// when translating Ingress and Gateway API resources into CiliumEnvoyConfig.
-type EnvoyProxyTimeouts struct {
+// EnvoyProxyConfig holds the upstream HTTP settings used by the operator
+// when translating services, Ingress, and Gateway API resources into
+// CiliumEnvoyConfig.
+type EnvoyProxyConfig struct {
 	ProxyIdleTimeoutSeconds       int
 	ProxyStreamIdleTimeoutSeconds int
+	ProxyMaxRequestsPerConnection int
 }
 
-var defaultEnvoyProxyTimeouts = EnvoyProxyTimeouts{
+var defaultEnvoyProxyConfig = EnvoyProxyConfig{
 	ProxyIdleTimeoutSeconds:       60,
 	ProxyStreamIdleTimeoutSeconds: 300,
+	ProxyMaxRequestsPerConnection: 0,
 }
 
-func (c EnvoyProxyTimeouts) Flags(flags *pflag.FlagSet) {
-	flags.Int("proxy-idle-timeout-seconds", defaultEnvoyProxyTimeouts.ProxyIdleTimeoutSeconds,
+func (c EnvoyProxyConfig) Flags(flags *pflag.FlagSet) {
+	flags.Int("proxy-idle-timeout-seconds", defaultEnvoyProxyConfig.ProxyIdleTimeoutSeconds,
 		"Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests.")
-	flags.Int("proxy-stream-idle-timeout-seconds", defaultEnvoyProxyTimeouts.ProxyStreamIdleTimeoutSeconds,
+	flags.Int("proxy-stream-idle-timeout-seconds", defaultEnvoyProxyConfig.ProxyStreamIdleTimeoutSeconds,
 		"Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity.")
+	flags.Int("proxy-max-requests-per-connection", defaultEnvoyProxyConfig.ProxyMaxRequestsPerConnection,
+		"Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)")
 }
 
 type l7LoadBalancerConfig struct {
@@ -74,7 +79,7 @@ type l7LoadbalancerParams struct {
 	Logger             *slog.Logger
 	CtrlRuntimeManager ctrlRuntime.Manager
 	Config             l7LoadBalancerConfig
-	ProxyTimeouts      EnvoyProxyTimeouts
+	ProxyConfig        EnvoyProxyConfig
 }
 
 func registerL7LoadBalancingController(params l7LoadbalancerParams) error {
@@ -90,8 +95,9 @@ func registerL7LoadBalancingController(params l7LoadbalancerParams) error {
 		params.Config.LoadBalancerL7Algorithm,
 		params.Config.LoadBalancerL7Ports,
 		10,
-		params.ProxyTimeouts.ProxyIdleTimeoutSeconds,
-		params.ProxyTimeouts.ProxyStreamIdleTimeoutSeconds,
+		params.ProxyConfig.ProxyIdleTimeoutSeconds,
+		params.ProxyConfig.ProxyStreamIdleTimeoutSeconds,
+		params.ProxyConfig.ProxyMaxRequestsPerConnection,
 		agentOption.Config.EnableIPv4,
 		agentOption.Config.EnableIPv6,
 	)

--- a/operator/pkg/ciliumenvoyconfig/ciliumenvoyconfig.go
+++ b/operator/pkg/ciliumenvoyconfig/ciliumenvoyconfig.go
@@ -23,12 +23,13 @@ type ciliumEnvoyConfigReconciler struct {
 	maxRetries               int
 	idleTimeoutSeconds       int
 	streamIdleTimeoutSeconds int
+	maxRequestsPerConnection int
 	enableIpv4               bool
 	enableIpv6               bool
 }
 
 func newCiliumEnvoyConfigReconciler(c client.Client, logger *slog.Logger, defaultAlgorithm string, ports []string,
-	maxRetries int, idleTimeoutSeconds int, streamIdleTimeoutSeconds int, enableIpv4 bool, enableIpv6 bool,
+	maxRetries int, idleTimeoutSeconds int, streamIdleTimeoutSeconds int, maxRequestsPerConnection int, enableIpv4 bool, enableIpv6 bool,
 ) *ciliumEnvoyConfigReconciler {
 	return &ciliumEnvoyConfigReconciler{
 		client: c,
@@ -39,6 +40,7 @@ func newCiliumEnvoyConfigReconciler(c client.Client, logger *slog.Logger, defaul
 		maxRetries:               maxRetries,
 		idleTimeoutSeconds:       idleTimeoutSeconds,
 		streamIdleTimeoutSeconds: streamIdleTimeoutSeconds,
+		maxRequestsPerConnection: maxRequestsPerConnection,
 		enableIpv4:               enableIpv4,
 		enableIpv6:               enableIpv6,
 	}

--- a/operator/pkg/ciliumenvoyconfig/envoy_config.go
+++ b/operator/pkg/ciliumenvoyconfig/envoy_config.go
@@ -80,15 +80,19 @@ func (r *ciliumEnvoyConfigReconciler) getClusterResources(svc *corev1.Service) (
 	if !ok {
 		lbPolicy = int32(envoy_config_cluster_v3.Cluster_ROUND_ROBIN)
 	}
+	commonHTTPProtocolOptions := &envoy_config_core_v3.HttpProtocolOptions{
+		IdleTimeout: &durationpb.Duration{Seconds: int64(r.idleTimeoutSeconds)},
+	}
+	if r.maxRequestsPerConnection > 0 {
+		commonHTTPProtocolOptions.MaxRequestsPerConnection = wrapperspb.UInt32(uint32(r.maxRequestsPerConnection))
+	}
 	cluster := &envoy_config_cluster_v3.Cluster{
 		Name:           getName(svc),
 		ConnectTimeout: &durationpb.Duration{Seconds: 5},
 		LbPolicy:       envoy_config_cluster_v3.Cluster_LbPolicy(lbPolicy),
 		TypedExtensionProtocolOptions: map[string]*anypb.Any{
 			"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": r.toAny(&envoy_config_upstream.HttpProtocolOptions{
-				CommonHttpProtocolOptions: &envoy_config_core_v3.HttpProtocolOptions{
-					IdleTimeout: &durationpb.Duration{Seconds: int64(r.idleTimeoutSeconds)},
-				},
+				CommonHttpProtocolOptions: commonHTTPProtocolOptions,
 				UpstreamProtocolOptions: &envoy_config_upstream.HttpProtocolOptions_UseDownstreamProtocolConfig{
 					UseDownstreamProtocolConfig: &envoy_config_upstream.HttpProtocolOptions_UseDownstreamHttpConfig{
 						Http2ProtocolOptions: &envoy_config_core_v3.Http2ProtocolOptions{},

--- a/operator/pkg/ciliumenvoyconfig/envoy_config_test.go
+++ b/operator/pkg/ciliumenvoyconfig/envoy_config_test.go
@@ -9,6 +9,7 @@ import (
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	envoy_config_upstream "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	corev1 "k8s.io/api/core/v1"
@@ -16,7 +17,10 @@ import (
 )
 
 func Test_getClusterResources(t *testing.T) {
-	r := &ciliumEnvoyConfigReconciler{}
+	r := &ciliumEnvoyConfigReconciler{
+		idleTimeoutSeconds:       60,
+		maxRequestsPerConnection: 1,
+	}
 	res, err := r.getClusterResources(&corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "dummy-service",
@@ -36,6 +40,11 @@ func Test_getClusterResources(t *testing.T) {
 	require.Equal(t, &envoy_config_cluster_v3.Cluster_Type{
 		Type: envoy_config_cluster_v3.Cluster_EDS,
 	}, cluster.ClusterDiscoveryType)
+
+	protocolOptions := &envoy_config_upstream.HttpProtocolOptions{}
+	require.NoError(t, cluster.TypedExtensionProtocolOptions["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"].UnmarshalTo(protocolOptions))
+	require.Equal(t, int64(60), protocolOptions.CommonHttpProtocolOptions.IdleTimeout.Seconds)
+	require.Equal(t, uint32(1), protocolOptions.CommonHttpProtocolOptions.MaxRequestsPerConnection.Value)
 }
 
 func Test_getRouteConfigurationResource(t *testing.T) {

--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -224,7 +224,7 @@ type gatewayAPIParams struct {
 	OperatorConfig   *operatorOption.OperatorConfig
 	MCSAPIConfig     mcsapitypes.MCSAPIConfig
 	GatewayApiConfig gatewayApiConfig
-	ProxyTimeouts    ciliumenvoyconfig.EnvoyProxyTimeouts
+	ProxyConfig      ciliumenvoyconfig.EnvoyProxyConfig
 
 	// Preconditions is injected from private provider
 	Preconditions *gatewayAPIPreconditions
@@ -267,11 +267,12 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 		ListenerConfig: translation.ListenerConfig{
 			UseProxyProtocol:         params.GatewayApiConfig.EnableGatewayAPIProxyProtocol,
 			UseAlpn:                  params.GatewayApiConfig.EnableGatewayAPIAlpn,
-			StreamIdleTimeoutSeconds: params.ProxyTimeouts.ProxyStreamIdleTimeoutSeconds,
+			StreamIdleTimeoutSeconds: params.ProxyConfig.ProxyStreamIdleTimeoutSeconds,
 		},
 		ClusterConfig: translation.ClusterConfig{
-			IdleTimeoutSeconds: params.ProxyTimeouts.ProxyIdleTimeoutSeconds,
-			UseAppProtocol:     params.GatewayApiConfig.EnableGatewayAPIAppProtocol,
+			IdleTimeoutSeconds:       params.ProxyConfig.ProxyIdleTimeoutSeconds,
+			MaxRequestsPerConnection: params.ProxyConfig.ProxyMaxRequestsPerConnection,
+			UseAppProtocol:           params.GatewayApiConfig.EnableGatewayAPIAppProtocol,
 		},
 		RouteConfig: translation.RouteConfig{
 			HostNameSuffixMatch: true,

--- a/operator/pkg/ingress/cell.go
+++ b/operator/pkg/ingress/cell.go
@@ -109,7 +109,7 @@ type ingressParams struct {
 	AgentConfig        *option.DaemonConfig
 	OperatorConfig     *operatorOption.OperatorConfig
 	IngressConfig      IngressConfig
-	ProxyTimeouts      ciliumenvoyconfig.EnvoyProxyTimeouts
+	ProxyConfig        ciliumenvoyconfig.EnvoyProxyConfig
 	PodCfg             ciliumpod.Config
 }
 
@@ -135,11 +135,12 @@ func registerReconciler(params ingressParams) error {
 		},
 		ListenerConfig: translation.ListenerConfig{
 			UseProxyProtocol:         params.IngressConfig.EnableIngressProxyProtocol,
-			StreamIdleTimeoutSeconds: params.ProxyTimeouts.ProxyStreamIdleTimeoutSeconds,
+			StreamIdleTimeoutSeconds: params.ProxyConfig.ProxyStreamIdleTimeoutSeconds,
 		},
 		ClusterConfig: translation.ClusterConfig{
-			IdleTimeoutSeconds: params.ProxyTimeouts.ProxyIdleTimeoutSeconds,
-			UseAppProtocol:     false,
+			IdleTimeoutSeconds:       params.ProxyConfig.ProxyIdleTimeoutSeconds,
+			MaxRequestsPerConnection: params.ProxyConfig.ProxyMaxRequestsPerConnection,
+			UseAppProtocol:           false,
 		},
 		RouteConfig: translation.RouteConfig{
 			HostNameSuffixMatch: false,

--- a/operator/pkg/model/translation/cec_translator.go
+++ b/operator/pkg/model/translation/cec_translator.go
@@ -50,8 +50,9 @@ type ListenerConfig struct {
 }
 
 type ClusterConfig struct {
-	IdleTimeoutSeconds int  `json:"idle_timeout_seconds,omitempty"`
-	UseAppProtocol     bool `json:"use_app_protocol,omitempty"`
+	IdleTimeoutSeconds       int  `json:"idle_timeout_seconds,omitempty"`
+	MaxRequestsPerConnection int  `json:"max_requests_per_connection,omitempty"`
+	UseAppProtocol           bool `json:"use_app_protocol,omitempty"`
 }
 
 type RouteConfig struct {

--- a/operator/pkg/model/translation/envoy_cluster.go
+++ b/operator/pkg/model/translation/envoy_cluster.go
@@ -34,6 +34,7 @@ const (
 func (i *cecTranslator) clusterMutators(grpcService bool, appProtocol string, tls *model.BackendTLSOrigination) []ClusterMutator {
 	res := []ClusterMutator{
 		withIdleTimeout(i.Config.ClusterConfig.IdleTimeoutSeconds),
+		withMaxRequestsPerConnection(i.Config.ClusterConfig.MaxRequestsPerConnection),
 		withClusterLbPolicy(int32(envoy_config_cluster_v3.Cluster_ROUND_ROBIN)),
 		withOutlierDetection(true),
 		withTLSOrigination(i.Config.SecretsNamespace, tls),

--- a/operator/pkg/model/translation/envoy_cluster_mutator.go
+++ b/operator/pkg/model/translation/envoy_cluster_mutator.go
@@ -11,6 +11,7 @@ import (
 	envoy_upstreams_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/cilium/cilium/operator/pkg/model"
@@ -69,6 +70,25 @@ func withIdleTimeout(seconds int) ClusterMutator {
 		opts.CommonHttpProtocolOptions = &envoy_config_core_v3.HttpProtocolOptions{
 			IdleTimeout: &durationpb.Duration{Seconds: int64(seconds)},
 		}
+		cluster.TypedExtensionProtocolOptions[httpProtocolOptionsType] = toAny(opts)
+		return cluster
+	}
+}
+
+func withMaxRequestsPerConnection(maxRequests int) ClusterMutator {
+	return func(cluster *envoy_config_cluster_v3.Cluster) *envoy_config_cluster_v3.Cluster {
+		if cluster == nil || maxRequests <= 0 {
+			return cluster
+		}
+		a := cluster.TypedExtensionProtocolOptions[httpProtocolOptionsType]
+		opts := &envoy_upstreams_http_v3.HttpProtocolOptions{}
+		if err := a.UnmarshalTo(opts); err != nil {
+			return cluster
+		}
+		if opts.CommonHttpProtocolOptions == nil {
+			opts.CommonHttpProtocolOptions = &envoy_config_core_v3.HttpProtocolOptions{}
+		}
+		opts.CommonHttpProtocolOptions.MaxRequestsPerConnection = wrapperspb.UInt32(uint32(maxRequests))
 		cluster.TypedExtensionProtocolOptions[httpProtocolOptionsType] = toAny(opts)
 		return cluster
 	}

--- a/operator/pkg/model/translation/envoy_cluster_test.go
+++ b/operator/pkg/model/translation/envoy_cluster_test.go
@@ -11,6 +11,7 @@ import (
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	envoy_upstreams_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
@@ -75,7 +76,10 @@ func Test_withConnectionTimeout(t *testing.T) {
 }
 
 func Test_httpCluster(t *testing.T) {
-	c := &cecTranslator{}
+	c := &cecTranslator{Config: Config{ClusterConfig: ClusterConfig{
+		IdleTimeoutSeconds:       60,
+		MaxRequestsPerConnection: 1,
+	}}}
 	res, err := c.httpCluster("dummy-name", "dummy-name", false, "", nil)
 	require.NoError(t, err)
 
@@ -87,6 +91,11 @@ func Test_httpCluster(t *testing.T) {
 	require.Equal(t, &envoy_config_cluster_v3.Cluster_Type{
 		Type: envoy_config_cluster_v3.Cluster_EDS,
 	}, cluster.ClusterDiscoveryType)
+
+	protocolOptions := &envoy_upstreams_http_v3.HttpProtocolOptions{}
+	require.NoError(t, cluster.TypedExtensionProtocolOptions[httpProtocolOptionsType].UnmarshalTo(protocolOptions))
+	require.Equal(t, int64(60), protocolOptions.CommonHttpProtocolOptions.IdleTimeout.Seconds)
+	require.Equal(t, uint32(1), protocolOptions.CommonHttpProtocolOptions.MaxRequestsPerConnection.Value)
 }
 
 func Test_httpClusterWithTLSOriginationAllowsTLS13(t *testing.T) {


### PR DESCRIPTION
Disable Envoy upstream connection pooling in Conformance Kind Envoy Embedded workflow by passing requests per connection as 1 and socket linger timeout as 0. This limits Envoy upstream connections to 1 request and clears up the TCP/IP stack state of the connection immediately on close. This allows test pods to re-use the same source port when targeting a service with and without L7 LB in fast succession. When Envoy connection pooling is enabled this scenario is a 5-tuple collision between Envoy and the source pod. Pod source port reuse like this is not likely to happen in production and even then the error condition is transitory and fails closed. Thus disabling Envoy upstream connection pooling is not advised in production settings as it can be costly, especially if the upstream is a TLS connection.

This fixes a CI flake where a pod is accessing a service backend first via l7-lb, with Envoy connection pooling enabled, and then in the next test tries accessing the same backend without l7-lb using the same source port, but fails due to the return packets being redirected to Envoy.

AIL: 2