### PR TITLE
clustermesh: remove legacy labels/annotations fields

### DIFF
--- a/clustermesh-apiserver/clustermesh/testdata/serviceexports.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/serviceexports.txtar
@@ -150,12 +150,6 @@ metadata:
   "labels": {
     "my-label": "test"
   },
-  "Labels": {
-    "my-label": "test"
-  },
-  "Annotations": {
-    "my-annotation": "foo"
-  },
   "exportCreationTimestamp": "2026-01-01T00:00:00Z",
   "ports": [
     {
@@ -199,12 +193,6 @@ metadata:
   },
   "labels": {
     "my-label": "test"
-  },
-  "Labels": {
-    "my-label": "test"
-  },
-  "Annotations": {
-    "my-annotation": "bar"
   },
   "exportCreationTimestamp": "2026-01-01T00:00:00Z",
   "ports": [

--- a/pkg/clustermesh/mcsapi/types/mcsapiservicespec.go
+++ b/pkg/clustermesh/mcsapi/types/mcsapiservicespec.go
@@ -59,14 +59,6 @@ type MCSAPIServiceSpec struct {
 	// Labels contains the exported labels
 	Labels map[string]string `json:"labels,omitempty"`
 
-	// LegacyLabels contains the exported labels.
-	// Deprecated: Use Labels instead, this is kept for backward compatibility
-	LegacyLabels map[string]string `json:"Labels,omitempty"`
-
-	// LegacyAnnotations contains the exported annotations.
-	// Deprecated: Use Annotations instead, this is kept for backward compatibility
-	LegacyAnnotations map[string]string `json:"Annotations,omitempty"`
-
 	// ExportCreationTimestamp is the timestamp representing when the
 	// ServiceExport object was created. It is used for conflict resolution.
 	ExportCreationTimestamp metav1.Time `json:"exportCreationTimestamp"`
@@ -123,9 +115,6 @@ func (s *MCSAPIServiceSpec) NamespacedName() types.NamespacedName {
 
 // Marshal returns the MCS-API Service Spec object as JSON byte slice
 func (s *MCSAPIServiceSpec) Marshal() ([]byte, error) {
-	// Populate legacy fields for forward compatibility
-	s.LegacyAnnotations = s.Annotations
-	s.LegacyLabels = s.Labels
 	return json.Marshal(s)
 }
 
@@ -136,16 +125,6 @@ func (s *MCSAPIServiceSpec) Unmarshal(_ string, data []byte) error {
 	if err := json.Unmarshal(data, &newMCSAPIServiceSpec); err != nil {
 		return err
 	}
-
-	// Handle backward compatibility of old annotations/labels fields
-	if len(newMCSAPIServiceSpec.Annotations) == 0 {
-		newMCSAPIServiceSpec.Annotations = newMCSAPIServiceSpec.LegacyAnnotations
-	}
-	if len(newMCSAPIServiceSpec.Labels) == 0 {
-		newMCSAPIServiceSpec.Labels = newMCSAPIServiceSpec.LegacyLabels
-	}
-	newMCSAPIServiceSpec.LegacyAnnotations = nil
-	newMCSAPIServiceSpec.LegacyLabels = nil
 
 	if err := newMCSAPIServiceSpec.validate(); err != nil {
 		return err


### PR DESCRIPTION
This fields were fixed/"un-capitalized" in commit
2f0ebbab46657143e62018db645220fc053e7a34 that was first part of Cilium 1.19. Now that we are in the 1.21 development cycle we can safely remove them!

I used AIL-3