### PR TITLE
Deprecate WireGuard Node Encryption

### DIFF
--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -34,9 +34,6 @@ inputs:
   encryption:
     description: '"ipsec", "wireguard" or empty'
     default: ''
-  encryption-node:
-    description: 'Enable node-to-node encryption (WireGuard only)'
-    default: 'false'
   encryption-strict-egress:
     description: 'Enable strict mode egress encryption'
     default: ''
@@ -197,9 +194,6 @@ runs:
           ENCRYPT=""
           if [ "${{ inputs.encryption }}" != "" ]; then
             ENCRYPT="--helm-set=encryption.enabled=true --helm-set=encryption.type=${{ inputs.encryption }}"
-            if [ "${{ inputs.encryption-node }}" != "" ]; then
-              ENCRYPT+=" --helm-set=encryption.nodeEncryption=${{ inputs.encryption-node }}"
-            fi
             if [ "${{ inputs.encryption-strict-egress }}" != "" ]; then
               ENCRYPT+=" --helm-set=encryption.strictMode.egress.enabled=${{ inputs.encryption-strict-egress }}"
               ENCRYPT+=" --helm-set=encryption.strictMode.egress.cidr=10.244.0.0/16"

--- a/.github/actions/e2e/kube-proxy.yaml
+++ b/.github/actions/e2e/kube-proxy.yaml
@@ -42,7 +42,6 @@
   kpr: 'false'
   tunnel: 'disabled'
   encryption: 'wireguard'
-  encryption-node: 'false'
   encryption-strict-mode: 'true'
   misc: 'socketLB.enabled=true'
   local-redirect-policy: 'true'

--- a/.github/actions/e2e/wireguard.yaml
+++ b/.github/actions/e2e/wireguard.yaml
@@ -6,7 +6,6 @@
   secondary-network: 'true'
   tunnel: 'vxlan'
   encryption: 'wireguard'
-  encryption-node: 'false'
   lb-mode: 'snat'
   endpoint-routes: 'true'
   egress-gateway: 'true'
@@ -21,7 +20,6 @@
   secondary-network: 'true'
   tunnel: 'vxlan'
   encryption: 'wireguard'
-  encryption-node: 'true'
   lb-mode: 'snat'
   egress-gateway: 'true'
   ingress-controller: 'true'
@@ -38,7 +36,6 @@
   secondary-network: 'true'
   tunnel: 'disabled'
   encryption: 'wireguard'
-  encryption-node: 'true'
   encryption-strict-egress: 'true'
   lb-mode: 'snat'
   egress-gateway: 'true'
@@ -55,7 +52,6 @@
   tunnel: 'geneve'
   lb-mode: 'snat'
   encryption: 'wireguard'
-  encryption-node: 'false'
   host-fw: 'true'
   ciliumendpointslice: 'true'
   ingress-controller: 'true'
@@ -82,7 +78,6 @@
   secondary-network: 'true'
   tunnel: 'vxlan'
   encryption: 'wireguard'
-  encryption-node: 'false'
   encryption-strict-ingress: 'true'
   # Without strict egress encryption we observed unencrytped host-to-pod packets arriving at cil_from_overlay
   # during startup. This only seems to happen while the agent is still setting up the datapath, so possibly a
@@ -99,7 +94,6 @@
   secondary-network: 'true'
   tunnel: 'disabled'
   encryption: 'wireguard'
-  encryption-node: 'false'
   encryption-strict-ingress: 'true'
   encryption-strict-egress: 'true'
   # Strict ingress encryption in native routing mode is new in this release, so

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -200,7 +200,6 @@ jobs:
           lb-mode: ${{ matrix.lb-mode }}
           lb-acceleration: ${{ matrix.lb-acceleration }}
           encryption: 'ipsec'
-          encryption-node: ${{ matrix.encryption-node }}
           egress-gateway: ${{ matrix.egress-gateway }}
           host-fw: ${{ matrix.host-fw }}
           ingress-controller: ${{ matrix.ingress-controller }}

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -348,7 +348,6 @@ jobs:
           lb-mode: ${{ matrix.lb-mode }}
           lb-acceleration: ${{ matrix.lb-acceleration }}
           encryption: ${{ matrix.encryption }}
-          encryption-node: ${{ matrix.encryption-node }}
           encryption-strict-egress: ${{ matrix.encryption-strict-egress }}
           encryption-strict-ingress: ${{ matrix.encryption-strict-ingress }}
           egress-gateway: ${{ matrix.egress-gateway }}
@@ -380,7 +379,6 @@ jobs:
           lb-mode: ${{ matrix.lb-mode }}
           lb-acceleration: ${{ matrix.lb-acceleration }}
           encryption: ${{ matrix.encryption }}
-          encryption-node: ${{ matrix.encryption-node }}
           encryption-strict-egress: ${{ matrix.encryption-strict-egress }}
           encryption-strict-ingress: ${{ matrix.encryption-strict-ingress }}
           egress-gateway: ${{ matrix.egress-gateway }}

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -195,7 +195,6 @@ cilium-agent [flags]
       --enable-xdp-prefilter                                      Enable XDP prefiltering
       --enable-xt-socket-fallback                                 Enable fallback for missing xt_socket module (default true)
       --enable-ztunnel                                            Use zTunnel as Cilium's encryption infrastructure
-      --encrypt-node                                              Enables encrypting traffic from non-Cilium pods and host networking (only supported with WireGuard, beta)
       --encryption-strict-egress-allow-remote-node-identities     Allows unencrypted traffic from pods to remote node identities within the strict mode CIDR. This is required when tunneling is used or direct routing is used and the node CIDR and pod CIDR overlap.
       --encryption-strict-egress-cidr string                      In strict-mode-egress encryption, all unencrypted traffic coming from this CIDR and going to this same CIDR will be dropped.
       --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
@@ -371,7 +370,6 @@ cilium-agent [flags]
       --multicast-enabled                                         Enables multicast in Cilium
       --nat-map-stats-entries int                                 Number k top stats entries to store locally in statedb (default 32)
       --nat-map-stats-interval duration                           Interval upon which nat maps are iterated for stats (default 30s)
-      --node-encryption-opt-out-labels string                     Label selector for nodes which will opt-out of node-to-node encryption (default "node-role.kubernetes.io/control-plane")
       --node-labels strings                                       List of label prefixes used to determine identity of a node (used only when enable-node-selector-labels is enabled)
       --node-port-bind-protection                                 Reject application bind(2) requests to service ports in the NodePort range (default true)
       --node-port-range strings                                   Set the min/max NodePort port range (default [30000,32767])

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -227,7 +227,6 @@ cilium-agent hive [flags]
       --multicast-enabled                                         Enables multicast in Cilium
       --nat-map-stats-entries int                                 Number k top stats entries to store locally in statedb (default 32)
       --nat-map-stats-interval duration                           Interval upon which nat maps are iterated for stats (default 30s)
-      --node-encryption-opt-out-labels string                     Label selector for nodes which will opt-out of node-to-node encryption (default "node-role.kubernetes.io/control-plane")
       --node-port-range strings                                   Set the min/max NodePort port range (default [30000,32767])
       --nodeport-addresses strings                                A whitelist of CIDRs to limit which IPs are used for NodePort. If not set, primary IPv4 and/or IPv6 address of each native device is used.
       --only-masquerade-default-pool                              When using multi-pool IPAM, only masquerade flows from the default IP pool. This will preserve source IPs for pods from non-default IP pools. Useful when combining multi-pool IPAM with BGP control plane. This option must be combined with enable-bpf-masquerade.

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -232,7 +232,6 @@ cilium-agent hive dot-graph [flags]
       --multicast-enabled                                         Enables multicast in Cilium
       --nat-map-stats-entries int                                 Number k top stats entries to store locally in statedb (default 32)
       --nat-map-stats-interval duration                           Interval upon which nat maps are iterated for stats (default 30s)
-      --node-encryption-opt-out-labels string                     Label selector for nodes which will opt-out of node-to-node encryption (default "node-role.kubernetes.io/control-plane")
       --node-port-range strings                                   Set the min/max NodePort port range (default [30000,32767])
       --nodeport-addresses strings                                A whitelist of CIDRs to limit which IPs are used for NodePort. If not set, primary IPv4 and/or IPv6 address of each native device is used.
       --only-masquerade-default-pool                              When using multi-pool IPAM, only masquerade flows from the default IP pool. This will preserve source IPs for pods from non-default IP pools. Useful when combining multi-pool IPAM with BGP control plane. This option must be combined with enable-bpf-masquerade.

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1377,7 +1377,7 @@
      - string
      - ``"cilium-ipsec-keys"``
    * - :spelling:ignore:`encryption.nodeEncryption`
-     - Enable encryption for pure node to node traffic. This option is only effective when encryption.type is set to "wireguard".
+     - Enable encryption for pure node to node traffic. This option is only effective when encryption.type is set to "wireguard". Deprecated: will be removed in v1.22.
      - bool
      - ``false``
    * - :spelling:ignore:`encryption.strictMode`

--- a/Documentation/operations/upgrade-next.inc
+++ b/Documentation/operations/upgrade-next.inc
@@ -42,7 +42,9 @@ The following options have been deprecated in this version of Cilium. A future
 version of Cilium will remove these options, so if you use these options then
 you may need to take action to migrate to an alternative.
 
-* TODO
+* Node encryption, enabled with ``encryption.nodeEncryption`` and only
+  compatible with WireGuard, is deprecated and will be removed in v1.22. Please
+  reach out if you are interested to maintain this feature.
 
 Removed Options
 ###############

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -239,6 +239,7 @@ func InitGlobalFlags(logger *slog.Logger, cmd *cobra.Command, vp *viper.Viper) {
 	option.BindEnv(vp, option.IPv6MCastDevice)
 
 	flags.Bool(option.EncryptNode, defaults.EncryptNode, "Enables encrypting traffic from non-Cilium pods and host networking (only supported with WireGuard, beta)")
+	flags.MarkDeprecated(option.EncryptNode, "This option is obsolete and will be removed in v1.22")
 	option.BindEnv(vp, option.EncryptNode)
 
 	flags.StringSlice(option.IPv4PodSubnets, []string{}, "List of IPv4 pod subnets to preconfigure for encryption")

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -394,7 +394,7 @@ contributors across the globe, there is almost always someone available to help.
 | encryption.ipsec.keyWatcher | bool | `true` | Enable the key watcher. If disabled, a restart of the agent will be necessary on key rotations. |
 | encryption.ipsec.mountPath | string | `"/etc/ipsec"` | Path to mount the secret inside the Cilium pod. |
 | encryption.ipsec.secretName | string | `"cilium-ipsec-keys"` | Name of the Kubernetes secret containing the encryption keys. |
-| encryption.nodeEncryption | bool | `false` | Enable encryption for pure node to node traffic. This option is only effective when encryption.type is set to "wireguard". |
+| encryption.nodeEncryption | bool | `false` | Enable encryption for pure node to node traffic. This option is only effective when encryption.type is set to "wireguard". Deprecated: will be removed in v1.22. |
 | encryption.strictMode | object | `{"egress":{"allowRemoteNodeIdentities":false,"cidr":"","enabled":false},"ingress":{"enabled":false}}` | Configure the Encryption Pod2Pod strict mode. |
 | encryption.strictMode.egress.allowRemoteNodeIdentities | bool | `false` | Allow dynamic lookup of remote node identities. This is required when tunneling is used or direct routing is used and the node CIDR and pod CIDR overlap. |
 | encryption.strictMode.egress.cidr | string | `""` | CIDR for the Encryption Pod2Pod strict egress mode. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1154,7 +1154,7 @@ encryption:
   # -- Encryption method. Can be one of ipsec, wireguard or ztunnel.
   type: ipsec
   # -- Enable encryption for pure node to node traffic.
-  # This option is only effective when encryption.type is set to "wireguard".
+  # This option is only effective when encryption.type is set to "wireguard". Deprecated: will be removed in v1.22.
   nodeEncryption: false
   # -- Configure the Encryption Pod2Pod strict mode.
   strictMode:

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1166,7 +1166,7 @@ encryption:
   # -- Encryption method. Can be one of ipsec, wireguard or ztunnel.
   type: ipsec
   # -- Enable encryption for pure node to node traffic.
-  # This option is only effective when encryption.type is set to "wireguard".
+  # This option is only effective when encryption.type is set to "wireguard". Deprecated: will be removed in v1.22.
   nodeEncryption: false
   # -- Configure the Encryption Pod2Pod strict mode.
   strictMode:

--- a/pkg/wireguard/agent/cell.go
+++ b/pkg/wireguard/agent/cell.go
@@ -84,6 +84,7 @@ func (def UserConfig) Flags(flags *pflag.FlagSet) {
 	flags.Bool(types.WireguardTrackAllIPsFallback, def.WireguardTrackAllIPsFallback, "Force WireGuard to track all IPs")
 	flags.MarkHidden(types.WireguardTrackAllIPsFallback)
 	flags.String(types.NodeEncryptionOptOutLabels, def.NodeEncryptionOptOutLabels, "Label selector for nodes which will opt-out of node-to-node encryption")
+	flags.MarkDeprecated(types.NodeEncryptionOptOutLabels, "This option is obsolete and will be removed in v1.22")
 }
 
 // Final config of the WireGuard agent.


### PR DESCRIPTION
See commits for details. First commit deprecates and documents, subsequent commits remove it from the CI.