### PR TITLE
fix(policy): add cluster-mesh to the Entity enum validation

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -391,7 +391,7 @@ spec:
                       description: |-
                         ToEntities is a list of special entities to which the endpoint subject
                         to the rule is allowed to initiate connections. Supported entities are
-                        `world`, `cluster`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
+                        `world`, `cluster`, `cluster-mesh`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
                         `health`, `unmanaged`, `none` and `all`.
                       items:
                         description: |-
@@ -402,6 +402,7 @@ spec:
                         - all
                         - world
                         - cluster
+                        - cluster-mesh
                         - host
                         - init
                         - ingress
@@ -1390,7 +1391,7 @@ spec:
                       description: |-
                         ToEntities is a list of special entities to which the endpoint subject
                         to the rule is allowed to initiate connections. Supported entities are
-                        `world`, `cluster`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
+                        `world`, `cluster`, `cluster-mesh`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
                         `health`, `unmanaged`, `none` and `all`.
                       items:
                         description: |-
@@ -1401,6 +1402,7 @@ spec:
                         - all
                         - world
                         - cluster
+                        - cluster-mesh
                         - host
                         - init
                         - ingress
@@ -2023,7 +2025,7 @@ spec:
                       description: |-
                         FromEntities is a list of special entities which the endpoint subject
                         to the rule is allowed to receive connections from. Supported entities are
-                        `world`, `cluster`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
+                        `world`, `cluster`, `cluster-mesh`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
                         `health`, `unmanaged`, `none` and `all`.
                       items:
                         description: |-
@@ -2034,6 +2036,7 @@ spec:
                         - all
                         - world
                         - cluster
+                        - cluster-mesh
                         - host
                         - init
                         - ingress
@@ -2877,7 +2880,7 @@ spec:
                       description: |-
                         FromEntities is a list of special entities which the endpoint subject
                         to the rule is allowed to receive connections from. Supported entities are
-                        `world`, `cluster`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
+                        `world`, `cluster`, `cluster-mesh`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
                         `health`, `unmanaged`, `none` and `all`.
                       items:
                         description: |-
@@ -2888,6 +2891,7 @@ spec:
                         - all
                         - world
                         - cluster
+                        - cluster-mesh
                         - host
                         - init
                         - ingress
@@ -3594,7 +3598,7 @@ spec:
                         description: |-
                           ToEntities is a list of special entities to which the endpoint subject
                           to the rule is allowed to initiate connections. Supported entities are
-                          `world`, `cluster`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
+                          `world`, `cluster`, `cluster-mesh`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
                           `health`, `unmanaged`, `none` and `all`.
                         items:
                           description: |-
@@ -3605,6 +3609,7 @@ spec:
                           - all
                           - world
                           - cluster
+                          - cluster-mesh
                           - host
                           - init
                           - ingress
@@ -4594,7 +4599,7 @@ spec:
                         description: |-
                           ToEntities is a list of special entities to which the endpoint subject
                           to the rule is allowed to initiate connections. Supported entities are
-                          `world`, `cluster`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
+                          `world`, `cluster`, `cluster-mesh`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
                           `health`, `unmanaged`, `none` and `all`.
                         items:
                           description: |-
@@ -4605,6 +4610,7 @@ spec:
                           - all
                           - world
                           - cluster
+                          - cluster-mesh
                           - host
                           - init
                           - ingress
@@ -5227,7 +5233,7 @@ spec:
                         description: |-
                           FromEntities is a list of special entities which the endpoint subject
                           to the rule is allowed to receive connections from. Supported entities are
-                          `world`, `cluster`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
+                          `world`, `cluster`, `cluster-mesh`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
                           `health`, `unmanaged`, `none` and `all`.
                         items:
                           description: |-
@@ -5238,6 +5244,7 @@ spec:
                           - all
                           - world
                           - cluster
+                          - cluster-mesh
                           - host
                           - init
                           - ingress
@@ -6082,7 +6089,7 @@ spec:
                         description: |-
                           FromEntities is a list of special entities which the endpoint subject
                           to the rule is allowed to receive connections from. Supported entities are
-                          `world`, `cluster`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
+                          `world`, `cluster`, `cluster-mesh`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
                           `health`, `unmanaged`, `none` and `all`.
                         items:
                           description: |-
@@ -6093,6 +6100,7 @@ spec:
                           - all
                           - world
                           - cluster
+                          - cluster-mesh
                           - host
                           - init
                           - ingress

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -394,7 +394,7 @@ spec:
                       description: |-
                         ToEntities is a list of special entities to which the endpoint subject
                         to the rule is allowed to initiate connections. Supported entities are
-                        `world`, `cluster`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
+                        `world`, `cluster`, `cluster-mesh`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
                         `health`, `unmanaged`, `none` and `all`.
                       items:
                         description: |-
@@ -405,6 +405,7 @@ spec:
                         - all
                         - world
                         - cluster
+                        - cluster-mesh
                         - host
                         - init
                         - ingress
@@ -1393,7 +1394,7 @@ spec:
                       description: |-
                         ToEntities is a list of special entities to which the endpoint subject
                         to the rule is allowed to initiate connections. Supported entities are
-                        `world`, `cluster`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
+                        `world`, `cluster`, `cluster-mesh`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
                         `health`, `unmanaged`, `none` and `all`.
                       items:
                         description: |-
@@ -1404,6 +1405,7 @@ spec:
                         - all
                         - world
                         - cluster
+                        - cluster-mesh
                         - host
                         - init
                         - ingress
@@ -2026,7 +2028,7 @@ spec:
                       description: |-
                         FromEntities is a list of special entities which the endpoint subject
                         to the rule is allowed to receive connections from. Supported entities are
-                        `world`, `cluster`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
+                        `world`, `cluster`, `cluster-mesh`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
                         `health`, `unmanaged`, `none` and `all`.
                       items:
                         description: |-
@@ -2037,6 +2039,7 @@ spec:
                         - all
                         - world
                         - cluster
+                        - cluster-mesh
                         - host
                         - init
                         - ingress
@@ -2880,7 +2883,7 @@ spec:
                       description: |-
                         FromEntities is a list of special entities which the endpoint subject
                         to the rule is allowed to receive connections from. Supported entities are
-                        `world`, `cluster`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
+                        `world`, `cluster`, `cluster-mesh`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
                         `health`, `unmanaged`, `none` and `all`.
                       items:
                         description: |-
@@ -2891,6 +2894,7 @@ spec:
                         - all
                         - world
                         - cluster
+                        - cluster-mesh
                         - host
                         - init
                         - ingress
@@ -3597,7 +3601,7 @@ spec:
                         description: |-
                           ToEntities is a list of special entities to which the endpoint subject
                           to the rule is allowed to initiate connections. Supported entities are
-                          `world`, `cluster`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
+                          `world`, `cluster`, `cluster-mesh`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
                           `health`, `unmanaged`, `none` and `all`.
                         items:
                           description: |-
@@ -3608,6 +3612,7 @@ spec:
                           - all
                           - world
                           - cluster
+                          - cluster-mesh
                           - host
                           - init
                           - ingress
@@ -4597,7 +4602,7 @@ spec:
                         description: |-
                           ToEntities is a list of special entities to which the endpoint subject
                           to the rule is allowed to initiate connections. Supported entities are
-                          `world`, `cluster`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
+                          `world`, `cluster`, `cluster-mesh`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
                           `health`, `unmanaged`, `none` and `all`.
                         items:
                           description: |-
@@ -4608,6 +4613,7 @@ spec:
                           - all
                           - world
                           - cluster
+                          - cluster-mesh
                           - host
                           - init
                           - ingress
@@ -5230,7 +5236,7 @@ spec:
                         description: |-
                           FromEntities is a list of special entities which the endpoint subject
                           to the rule is allowed to receive connections from. Supported entities are
-                          `world`, `cluster`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
+                          `world`, `cluster`, `cluster-mesh`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
                           `health`, `unmanaged`, `none` and `all`.
                         items:
                           description: |-
@@ -5241,6 +5247,7 @@ spec:
                           - all
                           - world
                           - cluster
+                          - cluster-mesh
                           - host
                           - init
                           - ingress
@@ -6085,7 +6092,7 @@ spec:
                         description: |-
                           FromEntities is a list of special entities which the endpoint subject
                           to the rule is allowed to receive connections from. Supported entities are
-                          `world`, `cluster`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
+                          `world`, `cluster`, `cluster-mesh`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
                           `health`, `unmanaged`, `none` and `all`.
                         items:
                           description: |-
@@ -6096,6 +6103,7 @@ spec:
                           - all
                           - world
                           - cluster
+                          - cluster-mesh
                           - host
                           - init
                           - ingress

--- a/pkg/policy/api/egress.go
+++ b/pkg/policy/api/egress.go
@@ -66,7 +66,7 @@ type EgressCommonRule struct {
 
 	// ToEntities is a list of special entities to which the endpoint subject
 	// to the rule is allowed to initiate connections. Supported entities are
-	// `world`, `cluster`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
+	// `world`, `cluster`, `cluster-mesh`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
 	// `health`, `unmanaged`, `none` and `all`.
 	//
 	// +kubebuilder:validation:Optional

--- a/pkg/policy/api/entity.go
+++ b/pkg/policy/api/entity.go
@@ -13,7 +13,7 @@ import (
 // individual identities.  Entities are used to describe "outside of cluster",
 // "host", etc.
 //
-// +kubebuilder:validation:Enum=all;world;cluster;host;init;ingress;unmanaged;remote-node;health;none;kube-apiserver
+// +kubebuilder:validation:Enum=all;world;cluster;cluster-mesh;host;init;ingress;unmanaged;remote-node;health;none;kube-apiserver
 type Entity string
 
 const (

--- a/pkg/policy/api/ingress.go
+++ b/pkg/policy/api/ingress.go
@@ -67,7 +67,7 @@ type IngressCommonRule struct {
 
 	// FromEntities is a list of special entities which the endpoint subject
 	// to the rule is allowed to receive connections from. Supported entities are
-	// `world`, `cluster`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
+	// `world`, `cluster`, `cluster-mesh`, `host`, `remote-node`, `kube-apiserver`, `ingress`, `init`,
 	// `health`, `unmanaged`, `none` and `all`.
 	//
 	// +kubebuilder:validation:Optional


### PR DESCRIPTION
The cluster-mesh entity was already resolved at runtime via
`EntitySelectorMapping`, but was missing from the CRD schema's Entity enum,
so policies using it in toEntities/fromEntities were rejected by CRD
validation.

Regenerate the CNP/CCNP CRDs and add a validator test covering every
entity for egress and ingress.

Related: #46438


[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
