### PR TITLE
docs: Update NetworkPolicy and ClusterNetworkPolicy documentation

### DIFF
--- a/Documentation/network/kubernetes/policy.rst
+++ b/Documentation/network/kubernetes/policy.rst
@@ -13,11 +13,14 @@ Network Policy
 If you are running Cilium on Kubernetes, you can benefit from Kubernetes
 distributing policies for you. In this mode, Kubernetes is responsible for
 distributing the policies across all nodes and Cilium will automatically apply
-the policies. Three formats are available to configure network policies natively
+the policies. Multiple formats are available to configure network policies natively
 with Kubernetes:
 
 - The standard `NetworkPolicy` resource which supports L3 and L4 policies
   at ingress or egress of the Pod.
+
+- The `ClusterNetworkPolicy` format (v1alpha2) which supports
+  cluster-scoped policies.
 
 - The extended `CiliumNetworkPolicy` format which is available as a
   :term:`CustomResourceDefinition` which supports specification of policies
@@ -46,6 +49,37 @@ For more information, see the official `NetworkPolicy documentation
 .. note::
 
     By default, ``ipBlock`` rules in NetworkPolicy do not match intra-cluster IPs (such as Pod or Node IPs). Setting the :ref:`--policy-cidr-match-mode <cidr_select_nodes>` option (or equivalent Helm value ``policyCIDRMatchMode``) to ``pods`` or ``nodes`` allows ``ipBlock`` rules to match intra-cluster IPs.
+
+.. _ClusterNetworkPolicy:
+
+Kubernetes ClusterNetworkPolicy
+===============================
+
+Support for the Kubernetes ClusterNetworkPolicy (KCNP) is available starting with Cilium 1.20.
+For more information, see the official `ClusterNetworkPolicy documentation
+<https://network-policy-api.sigs.k8s.io/api-overview/>`_.
+
+Enabling KCNP
+-------------
+
+Support must be enabled by setting the ``--enable-k8s-cluster-network-policy`` flag to ``true`` (or equivalent Helm value ``k8sClusterNetworkPolicy.enabled=true``). You also must install the Custom Resource Definition (CRD) from `sigs.k8s.io/network-policy-api <https://sigs.k8s.io/network-policy-api>`_:
+
+.. code-block:: shell-session
+
+    $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/network-policy-api/release-0.2/config/crd/standard/policy.networking.k8s.io_clusternetworkpolicies.yaml
+
+The KCNP API specifies that CIDR rules must also match pod and node IPs. For full conformance, set the :ref:`--policy-cidr-match-mode <cidr_select_nodes>` flag to ``pods,nodes``.
+
+Tiers
+-----
+
+The KCNP API uses tiers as top-level groupings for policy evaluation. Policy rules are evaluated in the following order:
+
+1. **Admin tier**: High-priority security rules set by cluster administrators.
+2. **NetworkPolicy tier**: Workload and cluster rules, including standard `NetworkPolicy`, `CiliumNetworkPolicy`, and `CiliumClusterwideNetworkPolicy`.
+3. **Baseline tier**: Default guardrails set by cluster administrators.
+
+A Kubernetes ClusterNetworkPolicy can be assigned to either the Admin or Baseline tier. Rules in the Admin tier take precedence over all policies at the NetworkPolicy tier level, including CiliumClusterwideNetworkPolicy, CiliumNetworkPolicy, and standard NetworkPolicy resources and cannot be overridden by them. Keep this in mind when migrating from CiliumClusterwideNetworkPolicy to Kubernetes ClusterNetworkPolicy.
 
 .. _CiliumNetworkPolicy:
 

--- a/Documentation/network/kubernetes/policy.rst
+++ b/Documentation/network/kubernetes/policy.rst
@@ -43,13 +43,9 @@ NetworkPolicy
 For more information, see the official `NetworkPolicy documentation
 <https://kubernetes.io/docs/concepts/services-networking/network-policies/>`_.
 
-Known missing features for Kubernetes Network Policy:
+.. note::
 
-+-------------------------------+-------------------+
-| Feature                       | Tracking Issue    |
-+===============================+===================+
-| ``ipBlock`` set with a pod IP | :gh-issue:`9209`  |
-+-------------------------------+-------------------+
+    By default, ``ipBlock`` rules in NetworkPolicy do not match intra-cluster IPs (such as Pod or Node IPs). Setting the :ref:`--policy-cidr-match-mode <cidr_select_nodes>` option (or equivalent Helm value ``policyCIDRMatchMode``) to ``pods`` or ``nodes`` allows ``ipBlock`` rules to match intra-cluster IPs.
 
 .. _CiliumNetworkPolicy:
 

--- a/Documentation/security/policy/layer3.rst
+++ b/Documentation/security/policy/layer3.rst
@@ -458,16 +458,22 @@ use a :ref:`CiliumCIDRGroup` to reduce identity usage.
 
 .. _cidr_select_nodes:
 
-Selecting nodes with CIDR / ipBlock
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Selecting pods or nodes with CIDR / ipBlock
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: ../../beta.rst
 
 By default, CIDR-based selectors do not match in-cluster entities (pods or nodes).
-Optionally, you can direct the policy engine to select nodes by CIDR / ipBlock.
-This requires you to configure Cilium with ``--policy-cidr-match-mode=nodes`` or
-the equivalent Helm value ``policyCIDRMatchMode: nodes``. It is safe to toggle this
-option on a running cluster, and toggling the option affects neither upgrades nor downgrades.
+Optionally, you can direct the policy engine to select pods or nodes by CIDR / ipBlock.
+This requires you to configure Cilium with ``--policy-cidr-match-mode=pods`` or ``--policy-cidr-match-mode=nodes`` (or the equivalent Helm values ``policyCIDRMatchMode: pods`` or ``policyCIDRMatchMode: nodes``).
+
+.. caution::
+
+   Leaving ``--policy-cidr-match-mode`` disabled (the default) is recommended for most deployments.
+
+   Enabling ``--policy-cidr-match-mode=pods`` allocates additional :ref:`security identities <arch_id_security>` for every pod matching a CIDR selector. In environments with large numbers of pods, high pod churn, or extensive CIDR rule sets, this significantly increases identity consumption and risks exhausting available Cilium security identities.
+
+   Only enable or modify this setting if you specifically require CIDR rules to match intra-cluster pod IPs, understand your cluster's security identity allocation limits, and are prepared to monitor identity usage and revert the setting if needed.
 
 When ``--policy-cidr-match-mode=nodes`` is specified, every agent allocates a
 distinct local :ref:`security identity <arch_id_security>` for all other nodes.


### PR DESCRIPTION
Adds documentation for ClusterNetworkPolicy, including links to upstream documentation, CRD installation steps, and details on Network Policy API tier evaluation order and priorities.

Updates NetworkPolicy and Layer 3 policy documentation to replace the tracked issue 9209 table with a note on using --policy-cidr-match-mode to match intra-cluster IPs (pods or nodes) and detail security identity allocations.
