### PR TITLE
v1.19: gateway-api: fix sds secrets in golden tests

### DIFF
--- a/operator/pkg/gateway-api/testdata/gateway/gateway-cross-protocol-same-hostname/output/cec-cross-protocol-same-hostname.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-cross-protocol-same-hostname/output/cec-cross-protocol-same-hostname.yaml
@@ -94,7 +94,7 @@ spec:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
               commonTlsContext:
                 tlsCertificateSdsSecretConfigs:
-                  - name: /gateway-conformance-infra-cross-protocol-tls
+                  - name: gateway-conformance-infra/cross-protocol-tls
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https-with-multi-port-tls-passthrough/output/cec-multi-port-https-with-multi-port-tls-passthrough.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https-with-multi-port-tls-passthrough/output/cec-multi-port-https-with-multi-port-tls-passthrough.yaml
@@ -64,7 +64,7 @@ spec:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
               commonTlsContext:
                 tlsCertificateSdsSecretConfigs:
-                  - name: /gateway-conformance-infra-multi-port-https-tls
+                  - name: gateway-conformance-infra/multi-port-https-tls
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:
@@ -125,7 +125,7 @@ spec:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
               commonTlsContext:
                 tlsCertificateSdsSecretConfigs:
-                  - name: /gateway-conformance-infra-multi-port-https-tls
+                  - name: gateway-conformance-infra/multi-port-https-tls
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https/output/cec-multi-port-https.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-multi-port-https/output/cec-multi-port-https.yaml
@@ -61,7 +61,7 @@ spec:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
               commonTlsContext:
                 tlsCertificateSdsSecretConfigs:
-                  - name: /gateway-conformance-infra-multi-port-https-tls
+                  - name: gateway-conformance-infra/multi-port-https-tls
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:
@@ -122,7 +122,7 @@ spec:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
               commonTlsContext:
                 tlsCertificateSdsSecretConfigs:
-                  - name: /gateway-conformance-infra-multi-port-https-tls
+                  - name: gateway-conformance-infra/multi-port-https-tls
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-ns-restricted-same-hostname/output/cec-ns-restricted-same-hostname.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-ns-restricted-same-hostname/output/cec-ns-restricted-same-hostname.yaml
@@ -56,7 +56,7 @@ spec:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
               commonTlsContext:
                 tlsCertificateSdsSecretConfigs:
-                  - name: /gateway-conformance-infra-ns-restricted-tls
+                  - name: gateway-conformance-infra/ns-restricted-tls
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:
@@ -117,7 +117,7 @@ spec:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
               commonTlsContext:
                 tlsCertificateSdsSecretConfigs:
-                  - name: /gateway-conformance-infra-ns-restricted-tls
+                  - name: gateway-conformance-infra/ns-restricted-tls
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:

--- a/operator/pkg/gateway-api/testdata/gateway/httproute-allowed-kind-by-section-name/output/cec-kind-restricted-multi-listener.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/httproute-allowed-kind-by-section-name/output/cec-kind-restricted-multi-listener.yaml
@@ -58,7 +58,7 @@ spec:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
               commonTlsContext:
                 tlsCertificateSdsSecretConfigs:
-                  - name: /gateway-conformance-infra-tls-checks-certificate
+                  - name: gateway-conformance-infra/tls-checks-certificate
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:
@@ -117,7 +117,7 @@ spec:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
               commonTlsContext:
                 tlsCertificateSdsSecretConfigs:
-                  - name: /gateway-conformance-infra-tls-checks-certificate
+                  - name: gateway-conformance-infra/tls-checks-certificate
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:

--- a/operator/pkg/model/translation/gateway-api/testdata/basic_https_multi_port_listener/cec-output.yaml
+++ b/operator/pkg/model/translation/gateway-api/testdata/basic_https_multi_port_listener/cec-output.yaml
@@ -135,7 +135,7 @@ spec:
           '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
           commonTlsContext:
             tlsCertificateSdsSecretConfigs:
-            - name: cilium-secrets/default-example-tls
+            - name: cilium-secrets/cilium-sync-secret-a5ba1128989878da9227e0a9811f15bf3089558812daadeaa5ec10f45caa5479
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:
@@ -207,7 +207,7 @@ spec:
           '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
           commonTlsContext:
             tlsCertificateSdsSecretConfigs:
-            - name: cilium-secrets/default-example-tls
+            - name: cilium-secrets/cilium-sync-secret-a5ba1128989878da9227e0a9811f15bf3089558812daadeaa5ec10f45caa5479
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:


### PR DESCRIPTION
Relates to bf03ce5a89095ae1767a94ecf79260d31b53c568. 

This patch is a continuation of the secret cleanup for newly added gateway-api golden tests after the merge of #46826 (which was rebased just before bf03ce5a).
