### PR TITLE
node: garbage collect stale entries from BPF node map

### DIFF
--- a/pkg/datapath/linux/node_ids.go
+++ b/pkg/datapath/linux/node_ids.go
@@ -351,6 +351,59 @@ func (n *linuxNodeHandler) RestoreNodeIDs() {
 		logfields.Count, len(nodeValues))
 }
 
+// NodeMapGarbageCollect removes stale entries from the BPF node map that do not
+// correspond to any currently known node IP.
+func (n *linuxNodeHandler) NodeMapGarbageCollect() {
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
+
+	validNodeIPs := make(map[string]struct{})
+	for _, node := range n.nodes {
+		for _, addr := range node.IPAddresses {
+			validNodeIPs[addr.IP.String()] = struct{}{}
+		}
+	}
+
+	staleIPsByID := make(map[uint16][]string)
+	for ip, nodeID := range n.nodeIDsByIPs {
+		if _, ok := validNodeIPs[ip]; ok {
+			continue
+		}
+		staleIPsByID[nodeID] = append(staleIPsByID[nodeID], ip)
+	}
+
+	if len(staleIPsByID) == 0 {
+		n.log.Debug("No stale node ID mappings found")
+		return
+	}
+
+	var staleIPs int
+	for nodeID, ips := range staleIPsByID {
+		for _, ip := range ips {
+			if err := n.unmapNodeID(ip); err != nil {
+				n.log.Warn("Failed to remove stale node ID mapping",
+					logfields.Error, err,
+					logfields.NodeID, nodeID,
+					logfields.IPAddr, ip,
+				)
+			} else {
+				staleIPs++
+			}
+		}
+		if n.nodeIPsByIDs[nodeID].Len() == 0 {
+			if !n.nodeIDs.Insert(idpool.ID(nodeID)) {
+				n.log.Warn("Attempted to deallocate a node ID that wasn't allocated",
+					logfields.NodeID, nodeID,
+				)
+			}
+		}
+	}
+
+	n.log.Info("Garbage collected stale node ID mappings",
+		logfields.Count, staleIPs,
+	)
+}
+
 func (n *linuxNodeHandler) registerNodeIDAllocations(allocatedNodeIDs map[string]*nodemap.NodeValueV2) {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()

--- a/pkg/datapath/linux/node_ids_test.go
+++ b/pkg/datapath/linux/node_ids_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package linux
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	fakeipsec "github.com/cilium/cilium/pkg/datapath/linux/ipsec/fake"
+	"github.com/cilium/cilium/pkg/idpool"
+	"github.com/cilium/cilium/pkg/kpr"
+	nodemapfake "github.com/cilium/cilium/pkg/maps/nodemap/fake"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/node/addressing"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+)
+
+func TestNodeMapGarbageCollect(t *testing.T) {
+	nodeMap := nodemapfake.NewFakeNodeMapV2()
+	lnh := newNodeHandler(hivetest.Logger(t), DatapathConfiguration{}, nodeMap, kpr.KPRConfig{}, &fakeipsec.Agent{}, fakeipsec.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+
+	validIP := "10.0.0.1"
+	staleIP := "10.0.0.2"
+	nodeWithStaleIP := nodeTypes.Node{
+		Name: "node1",
+		IPAddresses: []nodeTypes.Address{
+			{
+				Type: addressing.NodeInternalIP,
+				IP:   net.ParseIP(validIP),
+			},
+			{
+				Type: addressing.NodeCiliumInternalIP,
+				IP:   net.ParseIP(staleIP),
+			},
+		},
+	}
+
+	lnh.mutex.Lock()
+	nodeID, err := lnh.allocateIDForNode(nil, &nodeWithStaleIP)
+	lnh.mutex.Unlock()
+	require.NoError(t, err)
+	require.NotZero(t, nodeID)
+
+	lnh.nodes[nodeWithStaleIP.Identity()] = &nodeTypes.Node{
+		Name: "node1",
+		IPAddresses: []nodeTypes.Address{
+			{
+				Type: addressing.NodeInternalIP,
+				IP:   net.ParseIP(validIP),
+			},
+		},
+	}
+	lnh.NodeMapGarbageCollect()
+
+	_, err = nodeMap.Lookup(netip.MustParseAddr(validIP))
+	require.NoError(t, err)
+	_, err = nodeMap.Lookup(netip.MustParseAddr(staleIP))
+	require.Error(t, err)
+	require.Equal(t, nodeID, lnh.nodeIDsByIPs[validIP])
+	require.NotContains(t, lnh.nodeIDsByIPs, staleIP)
+	require.Contains(t, lnh.nodeIPsByIDs[nodeID], validIP)
+	require.NotContains(t, lnh.nodeIPsByIDs[nodeID], staleIP)
+	require.False(t, lnh.nodeIDs.Remove(idpool.ID(nodeID)))
+
+	delete(lnh.nodes, nodeWithStaleIP.Identity())
+	lnh.NodeMapGarbageCollect()
+
+	_, err = nodeMap.Lookup(netip.MustParseAddr(validIP))
+	require.Error(t, err)
+	require.NotContains(t, lnh.nodeIDsByIPs, validIP)
+	require.NotContains(t, lnh.nodeIPsByIDs, nodeID)
+	require.True(t, lnh.nodeIDs.Remove(idpool.ID(nodeID)))
+}

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sync"
+	"sync/atomic"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
@@ -92,6 +93,10 @@ type IPSetFilterFn func(*nodeTypes.Node) bool
 
 var _ Notifier = (*manager)(nil)
 
+type nodeMapGarbageCollector interface {
+	NodeMapGarbageCollect()
+}
+
 // manager is the entity that manages a collection of nodes
 type manager struct {
 	logger *slog.Logger
@@ -161,6 +166,11 @@ type manager struct {
 
 	// Ensure the pruning is only attempted once.
 	nodePruneOnce sync.Once
+	// nodeMapGCSyncs counts the two distinct initial node syncs. The per-source
+	// guards ensure duplicate cluster or mesh sync notifications are ignored.
+	nodeMapGCSyncs           atomic.Int32
+	nodeMapGCClusterSyncOnce sync.Once
+	nodeMapGCMeshSyncOnce    sync.Once
 
 	// Reference to the StateDB
 	db *statedb.DB
@@ -1183,6 +1193,7 @@ func (m *manager) NodeSync() {
 	m.nodePruneOnce.Do(func() {
 		m.pruneClusterNodes()
 	})
+	m.nodeMapGCClusterSyncOnce.Do(m.nodeMapSyncDone)
 }
 
 // MeshNodeSync signals the manager that the initial nodes listing from
@@ -1190,6 +1201,7 @@ func (m *manager) NodeSync() {
 // deletion of possible stale meshed nodes.
 func (m *manager) MeshNodeSync() {
 	m.pruneMeshedNodes()
+	m.nodeMapGCMeshSyncOnce.Do(m.nodeMapSyncDone)
 }
 
 func (m *manager) pruneClusterNodes() {
@@ -1282,6 +1294,17 @@ func (m *manager) pruneMeshedNodes() {
 		m.NodeDeleted(*n)
 		delete(m.restoredNodes, n.Identity())
 	}
+}
+
+func (m *manager) nodeMapSyncDone() {
+	if m.nodeMapGCSyncs.Add(1) != 2 {
+		return
+	}
+	m.Iter(func(nh node.Handler) {
+		if gc, ok := nh.(nodeMapGarbageCollector); ok {
+			gc.NodeMapGarbageCollect()
+		}
+	})
 }
 
 // GetNodeIdentities returns a list of all node identities store in node

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -191,6 +191,9 @@ type signalNodeHandler struct {
 	NodeValidateImplementationEvent       chan nodeTypes.Node
 	NodeValidateImplementationEventError  error
 	EnableNodeValidateImplementationEvent bool
+	NodeMapGarbageCollectEvent            chan struct{}
+	EnableNodeMapGarbageCollectEvent      bool
+	OnNodeMapGarbageCollect               func()
 	Stop                                  chan struct{}
 }
 
@@ -200,6 +203,7 @@ func newSignalNodeHandler() *signalNodeHandler {
 		NodeUpdateEvent:                 make(chan nodeTypes.Node, 10),
 		NodeDeleteEvent:                 make(chan nodeTypes.Node, 10),
 		NodeValidateImplementationEvent: make(chan nodeTypes.Node, 4096),
+		NodeMapGarbageCollectEvent:      make(chan struct{}, 10),
 		Stop:                            make(chan struct{}, 10),
 	}
 }
@@ -240,6 +244,33 @@ func (n *signalNodeHandler) NodeValidateImplementation(node nodeTypes.Node) erro
 		}
 	}
 	return n.NodeValidateImplementationEventError
+}
+
+func (n *signalNodeHandler) NodeMapGarbageCollect() {
+	if n.OnNodeMapGarbageCollect != nil {
+		n.OnNodeMapGarbageCollect()
+	}
+	if n.EnableNodeMapGarbageCollectEvent {
+		n.NodeMapGarbageCollectEvent <- struct{}{}
+	}
+}
+
+func assertNoNodeMapGarbageCollect(t *testing.T, dp *signalNodeHandler) {
+	t.Helper()
+	select {
+	case <-dp.NodeMapGarbageCollectEvent:
+		t.Fatal("unexpected NodeMapGarbageCollect() call")
+	default:
+	}
+}
+
+func assertNodeMapGarbageCollect(t *testing.T, dp *signalNodeHandler) {
+	t.Helper()
+	select {
+	case <-dp.NodeMapGarbageCollectEvent:
+	default:
+		t.Fatal("expected NodeMapGarbageCollect() to be called")
+	}
 }
 
 func TestNodeLifecycle(t *testing.T) {
@@ -321,6 +352,50 @@ func TestNodeLifecycle(t *testing.T) {
 
 	err = mngr.Stop(context.TODO())
 	require.NoError(t, err)
+}
+
+func TestNodeMapGarbageCollectOnNodeSync(t *testing.T) {
+	logger := hivetest.Logger(t)
+
+	dp := newSignalNodeHandler()
+	dp.EnableNodeMapGarbageCollectEvent = true
+	ipcacheMock := newIPcacheMock()
+	h, _ := cell.NewSimpleHealth()
+	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+	require.NoError(t, err)
+	mngr.Subscribe(dp)
+	t.Cleanup(func() {
+		mngr.Stop(context.TODO())
+	})
+
+	n1 := nodeTypes.Node{
+		Name:    "node1",
+		Cluster: "c1",
+		IPAddresses: []nodeTypes.Address{
+			{
+				Type: addressing.NodeInternalIP,
+				IP:   net.ParseIP("10.0.0.1"),
+			},
+			{
+				Type: addressing.NodeCiliumInternalIP,
+				IP:   net.ParseIP("192.0.2.1"),
+			},
+		},
+		Source: source.CustomResource,
+	}
+	mngr.NodeUpdated(n1)
+
+	mngr.NodeSync()
+	assertNoNodeMapGarbageCollect(t, dp)
+	mngr.NodeSync()
+	assertNoNodeMapGarbageCollect(t, dp)
+
+	mngr.MeshNodeSync()
+	assertNodeMapGarbageCollect(t, dp)
+
+	mngr.NodeSync()
+	mngr.MeshNodeSync()
+	assertNoNodeMapGarbageCollect(t, dp)
 }
 
 func TestNodeLabels(t *testing.T) {
@@ -1494,6 +1569,7 @@ func TestNodesStartupPruning(t *testing.T) {
 		ipcacheMock := newIPcacheMock()
 		dp := newSignalNodeHandler()
 		dp.EnableNodeDeleteEvent = true
+		dp.EnableNodeMapGarbageCollectEvent = true
 		h, _ := cell.NewSimpleHealth()
 		mngr, err := New(logger, &option.DaemonConfig{
 			StateDir:    stateDir,
@@ -1548,6 +1624,8 @@ func TestNodesStartupPruning(t *testing.T) {
 		mngr.NodeUpdated(c1Node2)
 		mngr.NodeSync()
 
+		assertNoNodeMapGarbageCollect(t, dp)
+
 		select {
 		case dn := <-dp.NodeDeleteEvent:
 			expectedNode := c1StaleNode
@@ -1563,6 +1641,8 @@ func TestNodesStartupPruning(t *testing.T) {
 		// it's present in the file but not in our current view).
 		mngr.NodeUpdated(c2Node1)
 		mngr.MeshNodeSync()
+
+		assertNodeMapGarbageCollect(t, dp)
 
 		select {
 		case dn := <-dp.NodeDeleteEvent:
@@ -1591,6 +1671,8 @@ func TestNodesStartupPruning(t *testing.T) {
 		mngr.NodeUpdated(c2Node1)
 		mngr.MeshNodeSync()
 
+		assertNoNodeMapGarbageCollect(t, dp)
+
 		select {
 		case dn := <-dp.NodeDeleteEvent:
 			expectedNode := c2StaleNode
@@ -1610,6 +1692,8 @@ func TestNodesStartupPruning(t *testing.T) {
 		mngr.NodeUpdated(c1Node2)
 		mngr.NodeSync()
 
+		assertNodeMapGarbageCollect(t, dp)
+
 		select {
 		case dn := <-dp.NodeDeleteEvent:
 			expectedNode := c1StaleNode
@@ -1623,5 +1707,61 @@ func TestNodesStartupPruning(t *testing.T) {
 
 		assert.Equal(t, float64(2), mngr.metrics.EventsReceived.WithLabelValues("delete", string(source.Restored)).Get())
 		assert.Equal(t, float64(3), mngr.metrics.NumNodes.Get())
+	})
+
+	t.Run("no checkpoint waits for both syncs before GC", func(t *testing.T) {
+		stateDir := t.TempDir()
+		logger := hivetest.Logger(t)
+
+		ipcacheMock := newIPcacheMock()
+		dp := newSignalNodeHandler()
+		dp.EnableNodeMapGarbageCollectEvent = true
+		h, _ := cell.NewSimpleHealth()
+		mngr, err := New(logger, &option.DaemonConfig{
+			StateDir:    stateDir,
+			ClusterName: "c1",
+		}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			mngr.Stop(context.TODO())
+		})
+		mngr.Subscribe(dp)
+
+		mngr.NodeUpdated(c1Node1)
+		mngr.NodeSync()
+		assertNoNodeMapGarbageCollect(t, dp)
+
+		mngr.MeshNodeSync()
+		assertNodeMapGarbageCollect(t, dp)
+	})
+
+	t.Run("node map GC releases manager lock before handlers", func(t *testing.T) {
+		stateDir := t.TempDir()
+		logger := hivetest.Logger(t)
+
+		ipcacheMock := newIPcacheMock()
+		dp := newSignalNodeHandler()
+		dp.EnableNodeMapGarbageCollectEvent = true
+		h, _ := cell.NewSimpleHealth()
+		mngr, err := New(logger, &option.DaemonConfig{
+			StateDir:    stateDir,
+			ClusterName: "c1",
+		}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			mngr.Stop(context.TODO())
+		})
+		mngr.Subscribe(dp)
+
+		dp.OnNodeMapGarbageCollect = func() {
+			require.True(t, mngr.mutex.TryLock(), "manager lock must not be held while running node map GC handlers")
+			mngr.mutex.Unlock()
+		}
+
+		mngr.NodeUpdated(c1Node1)
+		mngr.NodeSync()
+		mngr.MeshNodeSync()
+
+		assertNodeMapGarbageCollect(t, dp)
 	})
 }


### PR DESCRIPTION
Remove restored node ID mappings that no longer correspond to known cluster or mesh nodes after both initial node syncs complete. Reclaim unused node IDs and cover stale-IP cleanup, duplicate sync notifications, and handler lock ordering with tests.


Fixes: #44520

```release-note
fix: Cilium now removes stale BPF node map entries after the initial cluster and ClusterMesh node synchronizations complete. 
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
