### PR TITLE
fix: Prevent Installation Failures When Hubble TLS Uses External Certificate Volumes

### DIFF
--- a/install/kubernetes/cilium/templates/hubble/tls-provided/relay-client-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-provided/relay-client-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.hubble.enabled .Values.hubble.tls.enabled (not .Values.hubble.tls.auto.enabled) .Values.hubble.relay.enabled (not .Values.hubble.relay.tls.client.existingSecret) }}
+{{- if and .Values.hubble.enabled .Values.hubble.tls.enabled (not .Values.hubble.tls.auto.enabled) .Values.hubble.relay.enabled (not .Values.hubble.relay.tls.disableDefaultVolumes) (not .Values.hubble.relay.tls.client.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/install/kubernetes/cilium/templates/hubble/tls-provided/relay-server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-provided/relay-server-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.hubble.enabled .Values.hubble.tls.enabled (not .Values.hubble.tls.auto.enabled) .Values.hubble.relay.enabled .Values.hubble.relay.tls.server.enabled (not .Values.hubble.relay.tls.server.existingSecret) }}
+{{- if and .Values.hubble.enabled .Values.hubble.tls.enabled (not .Values.hubble.tls.auto.enabled) .Values.hubble.relay.enabled .Values.hubble.relay.tls.server.enabled (not .Values.hubble.relay.tls.disableDefaultVolumes) (not .Values.hubble.relay.tls.server.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/install/kubernetes/cilium/templates/hubble/tls-provided/server-secret.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-provided/server-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.agent .Values.hubble.enabled .Values.hubble.tls.enabled (not .Values.hubble.tls.auto.enabled) (not .Values.hubble.tls.server.existingSecret) }}
+{{- if and .Values.agent .Values.hubble.enabled .Values.hubble.tls.enabled (not .Values.hubble.tls.auto.enabled) (not .Values.hubble.tls.disableDefaultVolumes) (not .Values.hubble.tls.server.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/install/kubernetes/cilium/templates/hubble/tls-provided/ui-client-certs.yaml
+++ b/install/kubernetes/cilium/templates/hubble/tls-provided/ui-client-certs.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.hubble.enabled .Values.hubble.tls.enabled (not .Values.hubble.tls.auto.enabled) .Values.hubble.ui.enabled .Values.hubble.relay.enabled .Values.hubble.relay.tls.server.enabled (not .Values.hubble.ui.tls.client.existingSecret) }}
+{{- if and .Values.hubble.enabled .Values.hubble.tls.enabled (not .Values.hubble.tls.auto.enabled) .Values.hubble.ui.enabled .Values.hubble.relay.enabled .Values.hubble.relay.tls.server.enabled (not .Values.hubble.ui.tls.disableDefaultVolumes) (not .Values.hubble.ui.tls.client.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
PR #46688 introduces disableDefaultVolumes=true to let `extraVolumes/extraVolumeMounts` provide TLS certificates. 

Since Cilium’s built-in certificates are no longer used, administrators do not need to configure `.Values.hubble.relay.tls.client.cert` and `.Values.hubble.relay.tls.client.key`

Although these built-in secrets are no longer  mounted into pod, their templates still attempt to render them.
They still try to read empty `.Values.hubble.relay.tls.client.cert` and `.Values.hubble.relay.tls.client.key`, causing Secret rendering to fail:

```
  kind: Secret
  metadata:
    name: hubble-relay-client-certs
  ...
  data:
    ca.crt:  {{ .Values.tls.ca.cert }}
    tls.crt: {{ .Values.hubble.relay.tls.client.cert | required "missing hubble.relay.tls.client.cert" }}
    tls.key: {{ .Values.hubble.relay.tls.client.key  | required "missing hubble.relay.tls.client.key"  }}
```

Therefore, Secret generation should include a disableDefaultVolumes condition and skip these Secrets when external certificate volumes are enabled.


Fixes: #issue-number

```release-note
fix: Prevent Installation Failures When Hubble TLS Uses External Certificate Volumes
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
