### PR TITLE
[gateway-api]: Enable extra redirect code support

### DIFF
--- a/operator/pkg/gateway-api/gatewayclass_status.go
+++ b/operator/pkg/gateway-api/gatewayclass_status.go
@@ -31,9 +31,6 @@ var exemptFeatures = []features.Feature{
 	features.TLSRouteModeTerminateFeature,
 	features.GatewayBackendClientCertificateFeature,
 	features.GatewayFrontendClientCertificateValidationFeature,
-	features.HTTPRoute303RedirectStatusCodeFeature,
-	features.HTTPRoute307RedirectStatusCodeFeature,
-	features.HTTPRoute308RedirectStatusCodeFeature,
 	features.GatewayHTTPSListenerDetectMisdirectedRequestsFeature,
 }
 


### PR DESCRIPTION
Gateway API has optional features for HTTP redirect codes 303, 307, and 308. At some point recently, our implementation has started to support these, but we were not listing them as supported in the `cilium` GatewayClass, which meant that we are not claiming conformance for them, even though we do have the support.

This commit enables those features so that conformance tests will now correctly test for them. The conformance tests pass as well.

AIL: 0

```release-note
gateway-api: Cilium now supports the additional redirect codes 303, 307, and 308 for HTTPRoute redirects.
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
