### PR TITLE
hubble: add source and destination node labels to flows

### DIFF
--- a/api/v1/flow/README.md
+++ b/api/v1/flow/README.md
@@ -328,6 +328,8 @@ EventTypeFilter is a filter describing a particular event type.
 | time | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
 | uuid | [string](#string) |  | uuid is a universally unique identifier for this flow. |
 | emitter | [Emitter](#flow-Emitter) |  | emitter identifies the source that emitted the flow. |
+| source_node_labels | [string](#string) | repeated | source_node_labels are the labels of the node hosting the source endpoint, formatted as &#34;key=value&#34;. |
+| destination_node_labels | [string](#string) | repeated | destination_node_labels are the labels of the node hosting the destination endpoint, formatted as &#34;key=value&#34;. |
 | verdict | [Verdict](#flow-Verdict) |  |  |
 | drop_reason | [uint32](#uint32) |  | **Deprecated.** only applicable to Verdict = DROPPED. deprecated in favor of drop_reason_desc. |
 | auth_type | [AuthType](#flow-AuthType) |  | auth_type is the authentication type specified for the flow in Cilium Network Policy. Only set on policy verdict events. |
@@ -421,6 +423,8 @@ multiple fields are set, then all fields must match for the filter to match.
 | tcp_flags | [TCPFlags](#flow-TCPFlags) | repeated | tcp_flags filters flows based on TCP header flags |
 | node_name | [string](#string) | repeated | node_name is a list of patterns to filter on the node name, e.g. &#34;k8s*&#34;, &#34;test-cluster/*.domain.com&#34;, &#34;cluster-name/&#34; etc. |
 | node_labels | [string](#string) | repeated | node_labels filters on a list of node label selectors. Selectors support the full Kubernetes label selector syntax. |
+| source_node_labels | [string](#string) | repeated | source_node_labels filters on source node label selectors. |
+| destination_node_labels | [string](#string) | repeated | destination_node_labels filters on destination node label selectors. |
 | ip_version | [IPVersion](#flow-IPVersion) | repeated | filter based on IP version (ipv4 or ipv6) |
 | trace_id | [string](#string) | repeated | trace_id filters flows by trace ID |
 | ip_trace_id | [uint64](#uint64) | repeated | ip_trace_id filters flows by IPTraceID |

--- a/api/v1/flow/flow.pb.go
+++ b/api/v1/flow/flow.pb.go
@@ -1510,7 +1510,13 @@ type Flow struct {
 	Uuid string `protobuf:"bytes,34,opt,name=uuid,proto3" json:"uuid,omitempty"`
 	// emitter identifies the source that emitted the flow.
 	Emitter *Emitter `protobuf:"bytes,41,opt,name=emitter,proto3" json:"emitter,omitempty"`
-	Verdict Verdict  `protobuf:"varint,2,opt,name=verdict,proto3,enum=flow.Verdict" json:"verdict,omitempty"`
+	// source_node_labels are the labels of the node hosting the source endpoint,
+	// formatted as "key=value".
+	SourceNodeLabels []string `protobuf:"bytes,42,rep,name=source_node_labels,json=sourceNodeLabels,proto3" json:"source_node_labels,omitempty"`
+	// destination_node_labels are the labels of the node hosting the destination
+	// endpoint, formatted as "key=value".
+	DestinationNodeLabels []string `protobuf:"bytes,43,rep,name=destination_node_labels,json=destinationNodeLabels,proto3" json:"destination_node_labels,omitempty"`
+	Verdict               Verdict  `protobuf:"varint,2,opt,name=verdict,proto3,enum=flow.Verdict" json:"verdict,omitempty"`
 	// only applicable to Verdict = DROPPED.
 	// deprecated in favor of drop_reason_desc.
 	//
@@ -1666,6 +1672,20 @@ func (x *Flow) GetUuid() string {
 func (x *Flow) GetEmitter() *Emitter {
 	if x != nil {
 		return x.Emitter
+	}
+	return nil
+}
+
+func (x *Flow) GetSourceNodeLabels() []string {
+	if x != nil {
+		return x.SourceNodeLabels
+	}
+	return nil
+}
+
+func (x *Flow) GetDestinationNodeLabels() []string {
+	if x != nil {
+		return x.DestinationNodeLabels
 	}
 	return nil
 }
@@ -3592,6 +3612,10 @@ type FlowFilter struct {
 	// node_labels filters on a list of node label selectors. Selectors support
 	// the full Kubernetes label selector syntax.
 	NodeLabels []string `protobuf:"bytes,36,rep,name=node_labels,json=nodeLabels,proto3" json:"node_labels,omitempty"`
+	// source_node_labels filters on source node label selectors.
+	SourceNodeLabels []string `protobuf:"bytes,41,rep,name=source_node_labels,json=sourceNodeLabels,proto3" json:"source_node_labels,omitempty"`
+	// destination_node_labels filters on destination node label selectors.
+	DestinationNodeLabels []string `protobuf:"bytes,42,rep,name=destination_node_labels,json=destinationNodeLabels,proto3" json:"destination_node_labels,omitempty"`
 	// filter based on IP version (ipv4 or ipv6)
 	IpVersion []IPVersion `protobuf:"varint,25,rep,packed,name=ip_version,json=ipVersion,proto3,enum=flow.IPVersion" json:"ip_version,omitempty"`
 	// trace_id filters flows by trace ID
@@ -3887,6 +3911,20 @@ func (x *FlowFilter) GetNodeName() []string {
 func (x *FlowFilter) GetNodeLabels() []string {
 	if x != nil {
 		return x.NodeLabels
+	}
+	return nil
+}
+
+func (x *FlowFilter) GetSourceNodeLabels() []string {
+	if x != nil {
+		return x.SourceNodeLabels
+	}
+	return nil
+}
+
+func (x *FlowFilter) GetDestinationNodeLabels() []string {
+	if x != nil {
+		return x.DestinationNodeLabels
 	}
 	return nil
 }
@@ -5508,11 +5546,13 @@ var File_flow_flow_proto protoreflect.FileDescriptor
 
 const file_flow_flow_proto_rawDesc = "" +
 	"\n" +
-	"\x0fflow/flow.proto\x12\x04flow\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xbf\x10\n" +
+	"\x0fflow/flow.proto\x12\x04flow\x1a\x19google/protobuf/any.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xa5\x11\n" +
 	"\x04Flow\x12.\n" +
 	"\x04time\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x04time\x12\x12\n" +
 	"\x04uuid\x18\" \x01(\tR\x04uuid\x12'\n" +
-	"\aemitter\x18) \x01(\v2\r.flow.EmitterR\aemitter\x12'\n" +
+	"\aemitter\x18) \x01(\v2\r.flow.EmitterR\aemitter\x12,\n" +
+	"\x12source_node_labels\x18* \x03(\tR\x10sourceNodeLabels\x126\n" +
+	"\x17destination_node_labels\x18+ \x03(\tR\x15destinationNodeLabels\x12'\n" +
 	"\averdict\x18\x02 \x01(\x0e2\r.flow.VerdictR\averdict\x12#\n" +
 	"\vdrop_reason\x18\x03 \x01(\rB\x02\x18\x01R\n" +
 	"dropReason\x12+\n" +
@@ -5675,7 +5715,7 @@ const file_flow_flow_proto_rawDesc = "" +
 	"\bsub_type\x18\x03 \x01(\x05R\asubType\"@\n" +
 	"\x0fCiliumEventType\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\x05R\x04type\x12\x19\n" +
-	"\bsub_type\x18\x02 \x01(\x05R\asubType\"\xe2\r\n" +
+	"\bsub_type\x18\x02 \x01(\x05R\asubType\"\xc8\x0e\n" +
 	"\n" +
 	"FlowFilter\x12\x12\n" +
 	"\x04uuid\x18\x1d \x03(\tR\x04uuid\x12\x1b\n" +
@@ -5721,7 +5761,9 @@ const file_flow_flow_proto_rawDesc = "" +
 	"\ttcp_flags\x18\x17 \x03(\v2\x0e.flow.TCPFlagsR\btcpFlags\x12\x1b\n" +
 	"\tnode_name\x18\x18 \x03(\tR\bnodeName\x12\x1f\n" +
 	"\vnode_labels\x18$ \x03(\tR\n" +
-	"nodeLabels\x12.\n" +
+	"nodeLabels\x12,\n" +
+	"\x12source_node_labels\x18) \x03(\tR\x10sourceNodeLabels\x126\n" +
+	"\x17destination_node_labels\x18* \x03(\tR\x15destinationNodeLabels\x12.\n" +
 	"\n" +
 	"ip_version\x18\x19 \x03(\x0e2\x0f.flow.IPVersionR\tipVersion\x12\x19\n" +
 	"\btrace_id\x18\x1c \x03(\tR\atraceId\x12\x1e\n" +

--- a/api/v1/flow/flow.proto
+++ b/api/v1/flow/flow.proto
@@ -20,6 +20,13 @@ message Flow {
     // emitter identifies the source that emitted the flow.
     Emitter emitter = 41;
 
+    // source_node_labels are the labels of the node hosting the source endpoint,
+    // formatted as "key=value".
+    repeated string source_node_labels = 42;
+    // destination_node_labels are the labels of the node hosting the destination
+    // endpoint, formatted as "key=value".
+    repeated string destination_node_labels = 43;
+
     Verdict verdict = 2;
     // only applicable to Verdict = DROPPED.
     // deprecated in favor of drop_reason_desc.
@@ -680,6 +687,10 @@ message FlowFilter {
     // node_labels filters on a list of node label selectors. Selectors support
     // the full Kubernetes label selector syntax.
     repeated string node_labels = 36;
+    // source_node_labels filters on source node label selectors.
+    repeated string source_node_labels = 41;
+    // destination_node_labels filters on destination node label selectors.
+    repeated string destination_node_labels = 42;
 
     // filter based on IP version (ipv4 or ipv6)
     repeated IPVersion ip_version = 25;

--- a/hubble/cmd/observe/flows.go
+++ b/hubble/cmd/observe/flows.go
@@ -358,6 +358,12 @@ func newFlowsCmdHelper(usage cmdUsage, vp *viper.Viper, ofilter *flowFilter) *co
 		"node-label", ofilter,
 		`Show only flows observed on nodes matching the given label filter (e.g. "key1=value1", "io.cilium/egress-gateway")`))
 	filterFlags.Var(filterVar(
+		"from-node-labels", ofilter,
+		"Show only flows whose source node matches the given label selector"))
+	filterFlags.Var(filterVar(
+		"to-node-labels", ofilter,
+		"Show only flows whose destination node matches the given label selector"))
+	filterFlags.Var(filterVar(
 		"from-cluster", ofilter,
 		"Show all flows originating from endpoints known to be in the given cluster name"))
 	filterFlags.Var(filterVar(

--- a/hubble/cmd/observe/flows_filter.go
+++ b/hubble/cmd/observe/flows_filter.go
@@ -697,6 +697,14 @@ func (of *flowFilter) set(f *filterTracker, name, val string, track bool) error 
 		f.apply(func(f *flowpb.FlowFilter) {
 			f.NodeLabels = append(f.GetNodeLabels(), val)
 		})
+	case "from-node-labels":
+		f.apply(func(f *flowpb.FlowFilter) {
+			f.SourceNodeLabels = append(f.GetSourceNodeLabels(), val)
+		})
+	case "to-node-labels":
+		f.apply(func(f *flowpb.FlowFilter) {
+			f.DestinationNodeLabels = append(f.GetDestinationNodeLabels(), val)
+		})
 
 	// cluster name filters
 	case "cluster":

--- a/hubble/cmd/observe/flows_filter_test.go
+++ b/hubble/cmd/observe/flows_filter_test.go
@@ -4,6 +4,7 @@
 package observe
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"strconv"
@@ -494,6 +495,120 @@ func TestLabels(t *testing.T) {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 	assert.Nil(t, f.blacklist)
+}
+
+func TestDirectionalNodeLabels(t *testing.T) {
+	tests := []struct {
+		name  string
+		flags []string
+		want  []*flowpb.FlowFilter
+	}{
+		{
+			name:  "from single",
+			flags: []string{"--from-node-labels", "topology.kubernetes.io/zone=zone-a"},
+			want: []*flowpb.FlowFilter{
+				{SourceNodeLabels: []string{"topology.kubernetes.io/zone=zone-a"}},
+			},
+		},
+		{
+			name:  "to single",
+			flags: []string{"--to-node-labels", "topology.kubernetes.io/zone=zone-b"},
+			want: []*flowpb.FlowFilter{
+				{DestinationNodeLabels: []string{"topology.kubernetes.io/zone=zone-b"}},
+			},
+		},
+		{
+			name: "repeated from and to preserve argument order",
+			flags: []string{
+				"--from-node-labels", "source-first=one",
+				"--to-node-labels", "destination-first=one",
+				"--from-node-labels", "source-second=two",
+				"--to-node-labels", "destination-second=two",
+			},
+			want: []*flowpb.FlowFilter{
+				{
+					SourceNodeLabels:      []string{"source-first=one", "source-second=two"},
+					DestinationNodeLabels: []string{"destination-first=one", "destination-second=two"},
+				},
+			},
+		},
+		{
+			name: "both directional fields in one filter",
+			flags: []string{
+				"--from-node-labels", "topology.kubernetes.io/zone=zone-a",
+				"--to-node-labels", "topology.kubernetes.io/zone=zone-b",
+			},
+			want: []*flowpb.FlowFilter{
+				{
+					SourceNodeLabels:      []string{"topology.kubernetes.io/zone=zone-a"},
+					DestinationNodeLabels: []string{"topology.kubernetes.io/zone=zone-b"},
+				},
+			},
+		},
+		{
+			name: "observing and directional node labels combine in one filter",
+			flags: []string{
+				"--node-label", "observing-node=true",
+				"--from-node-labels", "source-node=true",
+				"--to-node-labels", "destination-node=true",
+			},
+			want: []*flowpb.FlowFilter{
+				{
+					NodeLabels:            []string{"observing-node=true"},
+					SourceNodeLabels:      []string{"source-node=true"},
+					DestinationNodeLabels: []string{"destination-node=true"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newFlowFilter()
+			cmd := newFlowsCmdWithFilter(viper.New(), f)
+
+			require.NoError(t, cmd.Flags().Parse(tt.flags))
+			if diff := cmp.Diff(
+				tt.want,
+				f.whitelist.flowFilters(),
+				cmpopts.IgnoreUnexported(flowpb.FlowFilter{}),
+			); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+			assert.Nil(t, f.blacklist)
+		})
+	}
+}
+
+func TestDirectionalNodeLabelsBlacklistDispatch(t *testing.T) {
+	f := newFlowFilter()
+	cmd := newFlowsCmdWithFilter(viper.New(), f)
+
+	require.NoError(t, cmd.Flags().Parse([]string{
+		"--not", "--from-node-labels", "topology.kubernetes.io/zone=zone-a",
+	}))
+	assert.Nil(t, f.whitelist, "blacklisted directional filter must not leak into allowlist")
+	if diff := cmp.Diff(
+		[]*flowpb.FlowFilter{
+			{SourceNodeLabels: []string{"topology.kubernetes.io/zone=zone-a"}},
+		},
+		f.blacklist.flowFilters(),
+		cmpopts.IgnoreUnexported(flowpb.FlowFilter{}),
+	); diff != "" {
+		t.Errorf("blacklist mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestDirectionalNodeLabelsHelp(t *testing.T) {
+	cmd := newFlowsCmdWithFilter(viper.New(), newFlowFilter())
+	var help bytes.Buffer
+	cmd.SetOut(&help)
+
+	require.NoError(t, cmd.Help())
+	assert.Contains(t, help.String(), "--from-node-labels")
+	assert.Contains(t, help.String(), "Show only flows whose source node matches the given label selector")
+	assert.Contains(t, help.String(), "--to-node-labels")
+	assert.Contains(t, help.String(), "Show only flows whose destination node matches the given label selector")
 }
 
 func TestFromToWorkloadCombined(t *testing.T) {

--- a/pkg/clustermesh/script_test.go
+++ b/pkg/clustermesh/script_test.go
@@ -253,9 +253,17 @@ func (d dummyNodeManager) Subscribe(node.Handler) {
 	panic("unimplemented")
 }
 
+// SubscribeNodeState implements manager.NodeManager.
+func (d dummyNodeManager) SubscribeNodeState(nodemanager.NodeStateObserver) {
+}
+
 // Unsubscribe implements manager.NodeManager.
 func (d dummyNodeManager) Unsubscribe(node.Handler) {
 	panic("unimplemented")
+}
+
+// UnsubscribeNodeState implements manager.NodeManager.
+func (d dummyNodeManager) UnsubscribeNodeState(nodemanager.NodeStateObserver) {
 }
 
 // SetPrefixClusterMutatorFn implements manager.NodeManager

--- a/pkg/hubble/cell/cell.go
+++ b/pkg/hubble/cell/cell.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	"github.com/cilium/cilium/pkg/hubble/parser"
 	parsercell "github.com/cilium/cilium/pkg/hubble/parser/cell"
+	"github.com/cilium/cilium/pkg/hubble/parser/nodes"
 	"github.com/cilium/cilium/pkg/hubble/peer"
 	peercell "github.com/cilium/cilium/pkg/hubble/peer/cell"
 	identitycell "github.com/cilium/cilium/pkg/identity/cache/cell"
@@ -97,8 +98,9 @@ type hubbleParams struct {
 
 	DropEventEmitter dropeventemitter.FlowProcessor
 
-	PayloadParser    parser.Decoder
-	NamespaceManager namespace.Manager
+	PayloadParser         parser.Decoder
+	DirectionalNodeLabels nodes.DirectionalNodeLabelsLifecycle
+	NamespaceManager      namespace.Manager
 
 	GRPCMetrics          *grpc_prometheus.ServerMetrics
 	MetricsFlowProcessor metrics.FlowProcessor
@@ -127,6 +129,7 @@ func newHubbleIntegration(params hubbleParams) (HubbleIntegration, error) {
 		params.ExporterBuilders,
 		params.DropEventEmitter,
 		params.PayloadParser,
+		params.DirectionalNodeLabels,
 		params.NamespaceManager,
 		params.GRPCMetrics,
 		params.MetricsFlowProcessor,

--- a/pkg/hubble/cell/hubbleintegration.go
+++ b/pkg/hubble/cell/hubbleintegration.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/observer/namespace"
 	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	"github.com/cilium/cilium/pkg/hubble/parser"
+	"github.com/cilium/cilium/pkg/hubble/parser/nodes"
 	"github.com/cilium/cilium/pkg/hubble/peer"
 	"github.com/cilium/cilium/pkg/hubble/server"
 	"github.com/cilium/cilium/pkg/hubble/server/serveroption"
@@ -72,7 +73,8 @@ type hubbleIntegration struct {
 	dropEventEmitter dropeventemitter.FlowProcessor
 
 	// payloadParser is used to decode monitor events into Hubble events.
-	payloadParser parser.Decoder
+	payloadParser         parser.Decoder
+	directionalNodeLabels nodes.DirectionalNodeLabelsLifecycle
 	// nsManager is used to monitor the namespaces seen in Hubble flows.
 	nsManager namespace.Manager
 
@@ -99,6 +101,7 @@ func createHubbleIntegration(
 	exporterBuilders []*exportercell.FlowLogExporterBuilder,
 	dropEventEmitter dropeventemitter.FlowProcessor,
 	payloadParser parser.Decoder,
+	directionalNodeLabels nodes.DirectionalNodeLabelsLifecycle,
 	nsManager namespace.Manager,
 	grpcMetrics *grpc_prometheus.ServerMetrics,
 	metricsFlowProcessor metrics.FlowProcessor,
@@ -118,24 +121,25 @@ func createHubbleIntegration(
 	}
 
 	hi := &hubbleIntegration{
-		identityAllocator:    identityAllocator,
-		endpointManager:      endpointManager,
-		ipcache:              ipcache,
-		cgroupManager:        cgroupManager,
-		nodeManager:          nodeManager,
-		nodeLocalStore:       nodeLocalStore,
-		monitorAgent:         monitorAgent,
-		tlsConfigPromise:     tlsConfigPromise,
-		observerOptions:      observerOptions,
-		exporters:            exporters,
-		dropEventEmitter:     dropEventEmitter,
-		payloadParser:        payloadParser,
-		nsManager:            nsManager,
-		grpcMetrics:          grpcMetrics,
-		metricsFlowProcessor: metricsFlowProcessor,
-		peerService:          peerService,
-		config:               config,
-		log:                  log,
+		identityAllocator:     identityAllocator,
+		endpointManager:       endpointManager,
+		ipcache:               ipcache,
+		cgroupManager:         cgroupManager,
+		nodeManager:           nodeManager,
+		nodeLocalStore:        nodeLocalStore,
+		monitorAgent:          monitorAgent,
+		tlsConfigPromise:      tlsConfigPromise,
+		observerOptions:       observerOptions,
+		exporters:             exporters,
+		dropEventEmitter:      dropEventEmitter,
+		payloadParser:         payloadParser,
+		directionalNodeLabels: directionalNodeLabels,
+		nsManager:             nsManager,
+		grpcMetrics:           grpcMetrics,
+		metricsFlowProcessor:  metricsFlowProcessor,
+		peerService:           peerService,
+		config:                config,
+		log:                   log,
 	}
 
 	return hi, nil
@@ -206,6 +210,16 @@ func (h *hubbleIntegration) Status(ctx context.Context) *models.HubbleStatus {
 }
 
 func (h *hubbleIntegration) launch(ctx context.Context) (*observer.LocalObserverServer, error) {
+	if err := h.directionalNodeLabels.Start(); err != nil {
+		return nil, fmt.Errorf("failed to start directional node labels resolver: %w", err)
+	}
+	launchComplete := false
+	defer func() {
+		if !launchComplete {
+			h.directionalNodeLabels.Stop()
+		}
+	}()
+
 	var (
 		observerOpts []observeroption.Option
 		localSrvOpts []serveroption.Option
@@ -373,6 +387,7 @@ func (h *hubbleIntegration) launch(ctx context.Context) (*observer.LocalObserver
 		}()
 	}
 
+	launchComplete = true
 	return hubbleObserver, nil
 }
 

--- a/pkg/hubble/cell/hubbleintegration_test.go
+++ b/pkg/hubble/cell/hubbleintegration_test.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package hubblecell
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
+	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
+	"github.com/cilium/cilium/pkg/monitor/agent/consumer"
+	"github.com/cilium/cilium/pkg/node"
+)
+
+type orderedCalls struct {
+	mu    sync.Mutex
+	calls []string
+}
+
+func (o *orderedCalls) add(call string) {
+	o.mu.Lock()
+	o.calls = append(o.calls, call)
+	o.mu.Unlock()
+}
+
+func (o *orderedCalls) snapshot() []string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]string(nil), o.calls...)
+}
+
+type recordingNodeLabelsLifecycle struct {
+	calls    *orderedCalls
+	startErr error
+	stops    int
+}
+
+func (l *recordingNodeLabelsLifecycle) Start() error {
+	l.calls.add("start")
+	return l.startErr
+}
+
+func (l *recordingNodeLabelsLifecycle) Stop() {
+	l.calls.add("stop")
+	l.stops++
+}
+
+type recordingMonitorAgent struct {
+	monitorAgent.Agent
+	calls *orderedCalls
+}
+
+func (a *recordingMonitorAgent) RegisterNewConsumer(consumer.MonitorConsumer) {
+	a.calls.add("monitor")
+}
+
+func TestNodeLabelsDisabledHubbleDoesNotStartLifecycle(t *testing.T) {
+	calls := &orderedCalls{}
+	h := &hubbleIntegration{
+		log:                   hivetest.Logger(t),
+		directionalNodeLabels: &recordingNodeLabelsLifecycle{calls: calls},
+		config:                config{EnableHubble: false},
+	}
+
+	require.NoError(t, h.Launch(context.Background()))
+	require.Empty(t, calls.snapshot())
+}
+
+func TestNodeLabelsEnabledLaunchStartsBeforeObserverAndMonitor(t *testing.T) {
+	calls := &orderedCalls{}
+	lifecycle := &recordingNodeLabelsLifecycle{calls: calls}
+	h := newNodeLabelsLaunchTestIntegration(t, lifecycle, calls,
+		observeroption.WithOnServerInitFunc(func(observeroption.Server) error {
+			calls.add("observer")
+			return nil
+		}),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, h.Launch(ctx))
+	require.Equal(t, []string{"start", "observer", "monitor"}, calls.snapshot())
+	require.Zero(t, lifecycle.stops, "successful launch leaves cleanup to Hive OnStop")
+
+	observer := h.observer.Load()
+	require.NotNil(t, observer)
+	close(observer.GetEventsChannel())
+	<-observer.GetStopped()
+	cancel()
+}
+
+func TestNodeLabelsLaunchStartErrorReturnsImmediately(t *testing.T) {
+	calls := &orderedCalls{}
+	startErr := errors.New("start failed")
+	h := &hubbleIntegration{
+		log: hivetest.Logger(t),
+		directionalNodeLabels: &recordingNodeLabelsLifecycle{
+			calls: calls, startErr: startErr,
+		},
+		config: config{EnableHubble: true},
+	}
+
+	require.ErrorIs(t, h.Launch(context.Background()), startErr)
+	require.Equal(t, []string{"start"}, calls.snapshot())
+}
+
+func TestNodeLabelsLaterLaunchErrorStopsLifecycle(t *testing.T) {
+	calls := &orderedCalls{}
+	lifecycle := &recordingNodeLabelsLifecycle{calls: calls}
+	observerErr := errors.New("observer failed")
+	h := newNodeLabelsLaunchTestIntegration(t, lifecycle, calls,
+		observeroption.WithOnServerInitFunc(func(observeroption.Server) error {
+			calls.add("observer")
+			return observerErr
+		}),
+	)
+
+	require.ErrorIs(t, h.Launch(context.Background()), observerErr)
+	require.Equal(t, []string{"start", "observer", "stop"}, calls.snapshot())
+	require.Equal(t, 1, lifecycle.stops)
+}
+
+func newNodeLabelsLaunchTestIntegration(
+	t *testing.T,
+	lifecycle *recordingNodeLabelsLifecycle,
+	calls *orderedCalls,
+	observerOptions ...observeroption.Option,
+) *hubbleIntegration {
+	t.Helper()
+	cfg := defaultConfig
+	cfg.EnableHubble = true
+	cfg.SocketPath = filepath.Join(t.TempDir(), "hubble.sock")
+
+	return &hubbleIntegration{
+		log:                   hivetest.Logger(t),
+		directionalNodeLabels: lifecycle,
+		nodeLocalStore:        node.NewTestLocalNodeStore(node.LocalNode{}),
+		monitorAgent:          &recordingMonitorAgent{calls: calls},
+		observerOptions:       observerOptions,
+		grpcMetrics:           grpc_prometheus.NewServerMetrics(),
+		config:                cfg,
+	}
+}

--- a/pkg/hubble/filters/labels.go
+++ b/pkg/hubble/filters/labels.go
@@ -29,6 +29,16 @@ func nodeLabels(ev *v1.Event) k8sLabels.Labels {
 	return ciliumLabels.ParseK8sLabelArrayFromArray(labels)
 }
 
+func sourceNodeLabels(ev *v1.Event) k8sLabels.Labels {
+	labels := ev.GetFlow().GetSourceNodeLabels()
+	return ciliumLabels.ParseK8sLabelArrayFromArray(labels)
+}
+
+func destinationNodeLabels(ev *v1.Event) k8sLabels.Labels {
+	labels := ev.GetFlow().GetDestinationNodeLabels()
+	return ciliumLabels.ParseK8sLabelArrayFromArray(labels)
+}
+
 func parseSelector(selector string) (k8sLabels.Selector, error) {
 	// ciliumLabels.LabelArray extends the k8sLabels.Selector logic with
 	// support for Cilium source prefixes such as "k8s:foo" or "any:bar".
@@ -99,6 +109,22 @@ func (l *LabelsFilter) OnBuildFilter(ctx context.Context, ff *flowpb.FlowFilter)
 			return nil, fmt.Errorf("invalid node label filter: %w", err)
 		}
 		fs = append(fs, nlf)
+	}
+
+	if len(ff.GetSourceNodeLabels()) > 0 {
+		snlf, err := FilterByLabelSelectors(ff.GetSourceNodeLabels(), sourceNodeLabels)
+		if err != nil {
+			return nil, fmt.Errorf("invalid source node label filter: %w", err)
+		}
+		fs = append(fs, snlf)
+	}
+
+	if len(ff.GetDestinationNodeLabels()) > 0 {
+		dnlf, err := FilterByLabelSelectors(ff.GetDestinationNodeLabels(), destinationNodeLabels)
+		if err != nil {
+			return nil, fmt.Errorf("invalid destination node label filter: %w", err)
+		}
+		fs = append(fs, dnlf)
 	}
 
 	return fs, nil

--- a/pkg/hubble/filters/labels_test.go
+++ b/pkg/hubble/filters/labels_test.go
@@ -4,6 +4,7 @@
 package filters
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,7 +13,7 @@ import (
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 )
 
-func TestLabelSelectorFilter(t *testing.T) {
+func TestLabelsFilter(t *testing.T) {
 	type args struct {
 		f  []*flowpb.FlowFilter
 		ev []*v1.Event
@@ -20,7 +21,7 @@ func TestLabelSelectorFilter(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		wantErr bool
+		wantErr string
 		want    []bool
 	}{
 		{
@@ -224,6 +225,207 @@ func TestLabelSelectorFilter(t *testing.T) {
 				false,
 				false,
 			},
+		},
+		{
+			name: "source node label filter",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{
+						SourceNodeLabels: []string{"topology.kubernetes.io/zone=source-zone"},
+					},
+				},
+				ev: []*v1.Event{
+					{
+						Event: &flowpb.Flow{
+							SourceNodeLabels: []string{"topology.kubernetes.io/zone=source-zone"},
+						},
+					},
+					{
+						Event: &flowpb.Flow{
+							DestinationNodeLabels: []string{"topology.kubernetes.io/zone=source-zone"},
+							NodeLabels:            []string{"topology.kubernetes.io/zone=source-zone"},
+						},
+					},
+					{Event: &flowpb.Flow{}},
+					{},
+					nil,
+				},
+			},
+			want: []bool{
+				true,
+				false,
+				false,
+				false,
+				false,
+			},
+		},
+		{
+			name: "destination node label filter",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{
+						DestinationNodeLabels: []string{"topology.kubernetes.io/zone=destination-zone"},
+					},
+				},
+				ev: []*v1.Event{
+					{
+						Event: &flowpb.Flow{
+							DestinationNodeLabels: []string{"topology.kubernetes.io/zone=destination-zone"},
+						},
+					},
+					{
+						Event: &flowpb.Flow{
+							SourceNodeLabels: []string{"topology.kubernetes.io/zone=destination-zone"},
+							NodeLabels:       []string{"topology.kubernetes.io/zone=destination-zone"},
+						},
+					},
+					{Event: &flowpb.Flow{}},
+					{},
+					nil,
+				},
+			},
+			want: []bool{
+				true,
+				false,
+				false,
+				false,
+				false,
+			},
+		},
+		{
+			name: "source node label selectors use OR",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{
+						SourceNodeLabels: []string{"role=source-first", "role=source-second"},
+					},
+				},
+				ev: []*v1.Event{
+					{Event: &flowpb.Flow{SourceNodeLabels: []string{"role=source-first"}}},
+					{Event: &flowpb.Flow{SourceNodeLabels: []string{"role=source-second"}}},
+					{Event: &flowpb.Flow{SourceNodeLabels: []string{"role=other"}}},
+				},
+			},
+			want: []bool{true, true, false},
+		},
+		{
+			name: "destination node label selectors use OR",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{
+						DestinationNodeLabels: []string{"role=destination-first", "role=destination-second"},
+					},
+				},
+				ev: []*v1.Event{
+					{Event: &flowpb.Flow{DestinationNodeLabels: []string{"role=destination-first"}}},
+					{Event: &flowpb.Flow{DestinationNodeLabels: []string{"role=destination-second"}}},
+					{Event: &flowpb.Flow{DestinationNodeLabels: []string{"role=other"}}},
+				},
+			},
+			want: []bool{true, true, false},
+		},
+		{
+			name: "source and destination node label filters use AND",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{
+						SourceNodeLabels:      []string{"topology.kubernetes.io/zone=source-zone"},
+						DestinationNodeLabels: []string{"topology.kubernetes.io/zone=destination-zone"},
+					},
+				},
+				ev: []*v1.Event{
+					{
+						Event: &flowpb.Flow{
+							SourceNodeLabels:      []string{"topology.kubernetes.io/zone=source-zone"},
+							DestinationNodeLabels: []string{"topology.kubernetes.io/zone=destination-zone"},
+						},
+					},
+					{
+						Event: &flowpb.Flow{
+							SourceNodeLabels:      []string{"topology.kubernetes.io/zone=other-zone"},
+							DestinationNodeLabels: []string{"topology.kubernetes.io/zone=destination-zone"},
+						},
+					},
+					{
+						Event: &flowpb.Flow{
+							SourceNodeLabels:      []string{"topology.kubernetes.io/zone=source-zone"},
+							DestinationNodeLabels: []string{"topology.kubernetes.io/zone=other-zone"},
+						},
+					},
+				},
+			},
+			want: []bool{true, false, false},
+		},
+		{
+			name: "observing and directional node labels do not cross-match",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{
+						NodeLabels:            []string{"node=observer"},
+						SourceNodeLabels:      []string{"node=source"},
+						DestinationNodeLabels: []string{"node=destination"},
+					},
+				},
+				ev: []*v1.Event{
+					{
+						Event: &flowpb.Flow{
+							NodeLabels:            []string{"node=observer"},
+							SourceNodeLabels:      []string{"node=source"},
+							DestinationNodeLabels: []string{"node=destination"},
+						},
+					},
+					{
+						Event: &flowpb.Flow{
+							NodeLabels:            []string{"node=source"},
+							SourceNodeLabels:      []string{"node=destination"},
+							DestinationNodeLabels: []string{"node=observer"},
+						},
+					},
+				},
+			},
+			want: []bool{true, false},
+		},
+		{
+			name: "observing node label selectors retain OR",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{
+						NodeLabels: []string{"role=observer-first", "role=observer-second"},
+					},
+				},
+				ev: []*v1.Event{
+					{Event: &flowpb.Flow{NodeLabels: []string{"role=observer-first"}}},
+					{Event: &flowpb.Flow{NodeLabels: []string{"role=observer-second"}}},
+					{
+						Event: &flowpb.Flow{
+							SourceNodeLabels:      []string{"role=observer-first"},
+							DestinationNodeLabels: []string{"role=observer-second"},
+						},
+					},
+				},
+			},
+			want: []bool{true, true, false},
+		},
+		{
+			name: "empty directional node label filters add no matcher",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{
+						SourceNodeLabels:      []string{},
+						DestinationNodeLabels: []string{},
+					},
+				},
+				ev: []*v1.Event{nil},
+			},
+			want: []bool{true},
+		},
+		{
+			name: "unset directional node label filters add no matcher",
+			args: args{
+				f:  []*flowpb.FlowFilter{{}},
+				ev: []*v1.Event{nil},
+			},
+			want: []bool{true},
 		},
 		{
 			name: "source and destination label filter",
@@ -550,7 +752,7 @@ func TestLabelSelectorFilter(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true,
+			wantErr: "invalid source label filter",
 		},
 		{
 			name: "invalid destination filter",
@@ -561,7 +763,7 @@ func TestLabelSelectorFilter(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true,
+			wantErr: "invalid destination label filter",
 		},
 		{
 			name: "invalid node filter",
@@ -572,17 +774,41 @@ func TestLabelSelectorFilter(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true,
+			wantErr: "invalid node label filter",
+		},
+		{
+			name: "invalid source node label filter",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{
+						SourceNodeLabels: []string{"()"},
+					},
+				},
+			},
+			wantErr: "invalid source node label filter",
+		},
+		{
+			name: "invalid destination node label filter",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{
+						DestinationNodeLabels: []string{"="},
+					},
+				},
+			},
+			wantErr: "invalid destination node label filter",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fl, err := BuildFilterList(t.Context(), tt.args.f, []OnBuildFilter{&LabelsFilter{}})
-			if (err != nil) != tt.wantErr {
-				t.Errorf("\"%s\" error = %v, wantErr %v", tt.name, err, tt.wantErr)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				assert.Error(t, errors.Unwrap(err))
 				return
 			}
 			if err != nil {
+				t.Errorf("\"%s\" unexpected error = %v", tt.name, err)
 				return
 			}
 			for i, ev := range tt.args.ev {

--- a/pkg/hubble/parser/cell/cell.go
+++ b/pkg/hubble/parser/cell/cell.go
@@ -20,20 +20,55 @@ import (
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/hubble/parser"
 	hubbleGetters "github.com/cilium/cilium/pkg/hubble/parser/getters"
+	"github.com/cilium/cilium/pkg/hubble/parser/nodes"
 	parserOptions "github.com/cilium/cilium/pkg/hubble/parser/options"
 	"github.com/cilium/cilium/pkg/identity"
 	identitycell "github.com/cilium/cilium/pkg/identity/cache/cell"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	nodeManager "github.com/cilium/cilium/pkg/node/manager"
 )
 
 var Cell = cell.Module(
 	"payload-parser",
 	"Provides a payload parser for Hubble",
 
-	cell.Provide(newPayloadParser),
+	cell.Provide(
+		newPayloadParser,
+		newDirectionalNodeLabelsResolver,
+	),
 	cell.Config(defaultConfig),
 )
+
+type directionalNodeLabelsParams struct {
+	cell.In
+
+	Lifecycle   cell.Lifecycle
+	IPCache     *ipcache.IPCache
+	NodeManager nodeManager.NodeManager
+	ClusterInfo cmtypes.ClusterInfo
+}
+
+type directionalNodeLabelsOut struct {
+	cell.Out
+
+	ParserOption parserOptions.Option `group:"hubble-parser-options"`
+	Lifecycle    nodes.DirectionalNodeLabelsLifecycle
+}
+
+func newDirectionalNodeLabelsResolver(params directionalNodeLabelsParams) directionalNodeLabelsOut {
+	resolver := nodes.NewResolver(params.IPCache, params.ClusterInfo, params.NodeManager)
+	params.Lifecycle.Append(cell.Hook{
+		OnStop: func(cell.HookContext) error {
+			resolver.Stop()
+			return nil
+		},
+	})
+	return directionalNodeLabelsOut{
+		ParserOption: parserOptions.WithNodeLabelsGetter(resolver),
+		Lifecycle:    resolver,
+	}
+}
 
 func newPayloadParser(params payloadParserParams) (parser.Decoder, error) {
 	if err := params.Config.validate(); err != nil {

--- a/pkg/hubble/parser/cell/cell_test.go
+++ b/pkg/hubble/parser/cell/cell_test.go
@@ -4,16 +4,106 @@
 package cell
 
 import (
+	"context"
 	"math/rand/v2"
 	"net/netip"
 	"runtime"
+	"sync"
 	"testing"
 
+	hivecell "github.com/cilium/hive/cell"
+	"github.com/cilium/hive/hivetest"
 	"github.com/cilium/statedb"
 	"github.com/stretchr/testify/require"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hubble/parser/nodes"
+	parserOptions "github.com/cilium/cilium/pkg/hubble/parser/options"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/node/manager"
 )
+
+type fakeNodeManagerForNodeLabels struct {
+	manager.NodeManager
+
+	mu               sync.Mutex
+	subscribeCalls   int
+	unsubscribeCalls int
+}
+
+func (f *fakeNodeManagerForNodeLabels) SubscribeNodeState(manager.NodeStateObserver) {
+	f.mu.Lock()
+	f.subscribeCalls++
+	f.mu.Unlock()
+}
+
+func (f *fakeNodeManagerForNodeLabels) UnsubscribeNodeState(manager.NodeStateObserver) {
+	f.mu.Lock()
+	f.unsubscribeCalls++
+	f.mu.Unlock()
+}
+
+func (f *fakeNodeManagerForNodeLabels) calls() (subscribe, unsubscribe int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.subscribeCalls, f.unsubscribeCalls
+}
+
+func TestNodeLabelsResolverProviderSharesGetterAndLifecycle(t *testing.T) {
+	ipc := ipcache.NewIPCache(&ipcache.Configuration{
+		Context: context.Background(),
+		Logger:  hivetest.Logger(t),
+	})
+	t.Cleanup(func() { require.NoError(t, ipc.Shutdown()) })
+	nodeManager := &fakeNodeManagerForNodeLabels{}
+
+	var (
+		parserOpts []parserOptions.Option
+		lifecycle  nodes.DirectionalNodeLabelsLifecycle
+	)
+	h := hive.New(
+		hivecell.Provide(
+			newDirectionalNodeLabelsResolver,
+			func() *ipcache.IPCache { return ipc },
+			func() manager.NodeManager { return nodeManager },
+			func() cmtypes.ClusterInfo {
+				return cmtypes.ClusterInfo{ID: 10, Name: "local"}
+			},
+		),
+		hivecell.Invoke(func(in struct {
+			hivecell.In
+
+			ParserOptions []parserOptions.Option `group:"hubble-parser-options"`
+			Lifecycle     nodes.DirectionalNodeLabelsLifecycle
+		}) {
+			parserOpts = in.ParserOptions
+			lifecycle = in.Lifecycle
+		}),
+	)
+
+	log := hivetest.Logger(t)
+	require.NoError(t, h.Start(log, context.Background()))
+	subscribe, unsubscribe := nodeManager.calls()
+	require.Zero(t, subscribe, "construction and Hive start must not subscribe")
+	require.Zero(t, unsubscribe)
+	require.Len(t, parserOpts, 1)
+	require.NotNil(t, lifecycle)
+
+	var opts parserOptions.Options
+	parserOpts[0](&opts)
+	require.Same(t, opts.NodeLabelsGetter, lifecycle,
+		"the grouped getter and lifecycle must expose the same resolver")
+
+	require.NoError(t, lifecycle.Start())
+	lifecycle.Stop()                                      // launch-error cleanup
+	require.NoError(t, h.Stop(log, context.Background())) // normal OnStop cleanup
+	subscribe, unsubscribe = nodeManager.calls()
+	require.Equal(t, 1, subscribe)
+	require.Equal(t, 1, unsubscribe,
+		"launch-error cleanup followed by Hive OnStop must be idempotent")
+}
 
 func TestPayloadGetters_GetServiceByAddr(t *testing.T) {
 	db := statedb.New()

--- a/pkg/hubble/parser/getters/getters.go
+++ b/pkg/hubble/parser/getters/getters.go
@@ -46,6 +46,19 @@ type IPGetter interface {
 	LookupSecIDByIP(ip netip.Addr) (ipcache.Identity, bool)
 }
 
+// NodeClusterHint carries only cluster provenance established by the original
+// event. IdentityKnown must not be set for identities filled by a later lookup.
+type NodeClusterHint struct {
+	Identity      identity.NumericIdentity
+	IdentityKnown bool
+	LocalEndpoint bool
+}
+
+// NodeLabelsGetter resolves the labels of the node owning an endpoint IP.
+type NodeLabelsGetter interface {
+	GetNodeLabels(netip.Addr, NodeClusterHint) []string
+}
+
 // ServiceGetter fetches service metadata.
 type ServiceGetter interface {
 	GetServiceByAddr(ip netip.Addr, port uint16) *flowpb.Service

--- a/pkg/hubble/parser/nodes/resolver.go
+++ b/pkg/hubble/parser/nodes/resolver.go
@@ -5,9 +5,11 @@
 package nodes
 
 import (
+	"errors"
 	"net"
 	"net/netip"
 	"slices"
+	"sync"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
@@ -16,6 +18,28 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/node/manager"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+)
+
+// DirectionalNodeLabelsLifecycle controls the resolver's NodeManager state
+// subscription and its synchronous initial replay.
+type DirectionalNodeLabelsLifecycle interface {
+	Start() error
+	Stop()
+}
+
+type resolverLifecycleState uint8
+
+const (
+	resolverLifecycleInert resolverLifecycleState = iota
+	resolverLifecycleStarting
+	resolverLifecycleStarted
+	resolverLifecycleStopping
+	resolverLifecycleStopped
+)
+
+var (
+	errNilNodeStateNotifier = errors.New("directional node labels notifier is nil")
+	errResolverStopped      = errors.New("directional node labels resolver is stopped")
 )
 
 type nodeSnapshot struct {
@@ -32,6 +56,10 @@ type Resolver struct {
 	clusterInfo cmtypes.ClusterInfo
 	notifier    manager.NodeStateNotifier
 
+	lifecycleMu         sync.Mutex
+	lifecycleState      resolverLifecycleState
+	lifecycleTransition chan struct{}
+
 	mu         lock.RWMutex
 	byIdentity map[nodeTypes.Identity]nodeSnapshot
 	byAddress  map[netip.Addr]map[nodeTypes.Identity]struct{}
@@ -39,6 +67,7 @@ type Resolver struct {
 
 var _ getters.NodeLabelsGetter = (*Resolver)(nil)
 var _ manager.NodeStateObserver = (*Resolver)(nil)
+var _ DirectionalNodeLabelsLifecycle = (*Resolver)(nil)
 
 // NewResolver constructs an inert resolver. Subscription is explicit and is
 // not performed during construction.
@@ -49,6 +78,84 @@ func NewResolver(ipc *ipcache.IPCache, clusterInfo cmtypes.ClusterInfo, notifier
 		notifier:    notifier,
 		byIdentity:  make(map[nodeTypes.Identity]nodeSnapshot),
 		byAddress:   make(map[netip.Addr]map[nodeTypes.Identity]struct{}),
+	}
+}
+
+// Start subscribes the resolver exactly once. SubscribeNodeState performs its
+// replay synchronously, so the resolver is ready when Start returns.
+func (r *Resolver) Start() error {
+	for {
+		r.lifecycleMu.Lock()
+		switch r.lifecycleState {
+		case resolverLifecycleInert:
+			if r.notifier == nil {
+				r.lifecycleMu.Unlock()
+				return errNilNodeStateNotifier
+			}
+			r.lifecycleState = resolverLifecycleStarting
+			done := make(chan struct{})
+			r.lifecycleTransition = done
+			notifier := r.notifier
+			r.lifecycleMu.Unlock()
+
+			// NodeManager replays through callbacks here. Do not hold the
+			// lifecycle mutex across this external call: callbacks take the
+			// resolver index lock and must not participate in lock inversion.
+			notifier.SubscribeNodeState(r)
+
+			r.lifecycleMu.Lock()
+			r.lifecycleState = resolverLifecycleStarted
+			close(done)
+			r.lifecycleTransition = nil
+			r.lifecycleMu.Unlock()
+			return nil
+		case resolverLifecycleStarting, resolverLifecycleStopping:
+			done := r.lifecycleTransition
+			r.lifecycleMu.Unlock()
+			<-done
+		case resolverLifecycleStarted:
+			r.lifecycleMu.Unlock()
+			return nil
+		case resolverLifecycleStopped:
+			r.lifecycleMu.Unlock()
+			return errResolverStopped
+		}
+	}
+}
+
+// Stop unsubscribes a successfully started resolver exactly once. A stopped
+// resolver cannot be restarted.
+func (r *Resolver) Stop() {
+	for {
+		r.lifecycleMu.Lock()
+		switch r.lifecycleState {
+		case resolverLifecycleInert:
+			r.lifecycleState = resolverLifecycleStopped
+			r.lifecycleMu.Unlock()
+			return
+		case resolverLifecycleStarting, resolverLifecycleStopping:
+			done := r.lifecycleTransition
+			r.lifecycleMu.Unlock()
+			<-done
+		case resolverLifecycleStarted:
+			r.lifecycleState = resolverLifecycleStopping
+			done := make(chan struct{})
+			r.lifecycleTransition = done
+			notifier := r.notifier
+			r.lifecycleMu.Unlock()
+
+			notifier.UnsubscribeNodeState(r)
+
+			r.lifecycleMu.Lock()
+			r.lifecycleState = resolverLifecycleStopped
+			close(done)
+			r.lifecycleTransition = nil
+			r.lifecycleMu.Unlock()
+			return
+		case resolverLifecycleStopped:
+			r.lifecycleMu.Unlock()
+			return
+		}
 	}
 }
 

--- a/pkg/hubble/parser/nodes/resolver.go
+++ b/pkg/hubble/parser/nodes/resolver.go
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+// Package nodes resolves endpoint addresses to immutable node-label snapshots.
+package nodes
+
+import (
+	"net"
+	"net/netip"
+	"slices"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/hubble/parser/getters"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/node/manager"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+)
+
+type nodeSnapshot struct {
+	clusterID uint32
+	labels    []string
+	addresses []netip.Addr
+}
+
+// Resolver maintains an exact, cluster-aware reverse index of node-owned
+// addresses. The notifier is retained for explicit lifecycle ownership;
+// creating a Resolver deliberately has no subscription side effect.
+type Resolver struct {
+	ipcache     *ipcache.IPCache
+	clusterInfo cmtypes.ClusterInfo
+	notifier    manager.NodeStateNotifier
+
+	mu         lock.RWMutex
+	byIdentity map[nodeTypes.Identity]nodeSnapshot
+	byAddress  map[netip.Addr]map[nodeTypes.Identity]struct{}
+}
+
+var _ getters.NodeLabelsGetter = (*Resolver)(nil)
+var _ manager.NodeStateObserver = (*Resolver)(nil)
+
+// NewResolver constructs an inert resolver. Subscription is explicit and is
+// not performed during construction.
+func NewResolver(ipc *ipcache.IPCache, clusterInfo cmtypes.ClusterInfo, notifier manager.NodeStateNotifier) *Resolver {
+	return &Resolver{
+		ipcache:     ipc,
+		clusterInfo: clusterInfo,
+		notifier:    notifier,
+		byIdentity:  make(map[nodeTypes.Identity]nodeSnapshot),
+		byAddress:   make(map[netip.Addr]map[nodeTypes.Identity]struct{}),
+	}
+}
+
+// NodeUpsert atomically replaces the complete immutable snapshot for a node.
+// Even an excluded update removes the node's previously accepted state.
+func (r *Resolver) NodeUpsert(n nodeTypes.Node) {
+	identity := nodeTypes.Identity{Name: n.Name, Cluster: n.Cluster}
+	clusterID, accepted := r.classifyOwner(n)
+	var snapshot nodeSnapshot
+	if accepted {
+		snapshot = nodeSnapshot{
+			clusterID: clusterID,
+			labels:    sortedLabels(n.Labels),
+			addresses: nodeAddresses(n),
+		}
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.removeIdentityLocked(identity)
+	if !accepted {
+		return
+	}
+
+	r.byIdentity[identity] = snapshot
+	for _, address := range snapshot.addresses {
+		owners := r.byAddress[address]
+		if owners == nil {
+			owners = make(map[nodeTypes.Identity]struct{})
+			r.byAddress[address] = owners
+		}
+		owners[identity] = struct{}{}
+	}
+}
+
+// NodeDelete removes addresses from the stored snapshot, never from the
+// potentially stale or incomplete delete payload.
+func (r *Resolver) NodeDelete(n nodeTypes.Node) {
+	identity := nodeTypes.Identity{Name: n.Name, Cluster: n.Cluster}
+	r.mu.Lock()
+	r.removeIdentityLocked(identity)
+	r.mu.Unlock()
+}
+
+func (r *Resolver) removeIdentityLocked(identity nodeTypes.Identity) {
+	old, exists := r.byIdentity[identity]
+	if !exists {
+		return
+	}
+	for _, address := range old.addresses {
+		owners := r.byAddress[address]
+		delete(owners, identity)
+		if len(owners) == 0 {
+			delete(r.byAddress, address)
+		}
+	}
+	delete(r.byIdentity, identity)
+}
+
+func (r *Resolver) classifyOwner(n nodeTypes.Node) (uint32, bool) {
+	if n.Cluster == r.clusterInfo.Name {
+		if n.ClusterID == 0 || n.ClusterID == r.clusterInfo.ID {
+			return r.clusterInfo.ID, true
+		}
+		return 0, false
+	}
+
+	if n.Cluster == "" || n.ClusterID == 0 || n.ClusterID == r.clusterInfo.ID {
+		return 0, false
+	}
+	return n.ClusterID, true
+}
+
+func sortedLabels(source map[string]string) []string {
+	labels := make([]string, 0, len(source))
+	for key, value := range source {
+		labels = append(labels, key+"="+value)
+	}
+	slices.Sort(labels)
+	return labels
+}
+
+func nodeAddresses(n nodeTypes.Node) []netip.Addr {
+	addresses := make([]netip.Addr, 0, len(n.IPAddresses)+4)
+	seen := make(map[netip.Addr]struct{}, len(n.IPAddresses)+4)
+	appendAddress := func(address netip.Addr) {
+		if !address.IsValid() {
+			return
+		}
+		address = address.Unmap()
+		if _, exists := seen[address]; exists {
+			return
+		}
+		seen[address] = struct{}{}
+		addresses = append(addresses, address)
+	}
+	appendIP := func(ip net.IP) {
+		address, ok := netip.AddrFromSlice(ip)
+		if ok {
+			appendAddress(address)
+		}
+	}
+
+	for _, address := range n.IPAddresses {
+		appendIP(address.IP)
+	}
+	appendAddress(n.IPv4HealthIP.Addr)
+	appendAddress(n.IPv6HealthIP.Addr)
+	appendIP(n.IPv4IngressIP)
+	appendIP(n.IPv6IngressIP)
+	return addresses
+}
+
+// GetNodeLabels resolves only from event-established cluster provenance.
+// Endpoint cluster names and userspace-filled identities are intentionally not
+// inputs because neither is trustworthy when ClusterMesh address space overlaps.
+func (r *Resolver) GetNodeLabels(ip netip.Addr, hint getters.NodeClusterHint) []string {
+	if !ip.IsValid() {
+		return nil
+	}
+	ip = ip.Unmap()
+
+	ipcacheScope, expectedCluster, ok := r.resolveScope(hint)
+	if !ok {
+		return nil
+	}
+
+	if r.ipcache == nil {
+		return nil
+	}
+	hostIP, found := r.ipcache.GetHostIP(cmtypes.AddrClusterFrom(ip, ipcacheScope))
+	if found {
+		return r.labelsForAddress(hostIP, expectedCluster)
+	}
+
+	// Direct-node fallback is permitted only after an exact scoped IPCache miss
+	// and retains the already authenticated expected ClusterID.
+	return r.labelsForAddress(ip, expectedCluster)
+}
+
+func (r *Resolver) resolveScope(hint getters.NodeClusterHint) (ipcacheScope, expectedCluster uint32, ok bool) {
+	if hint.LocalEndpoint {
+		if !hint.IdentityKnown || hint.Identity == identity.IdentityUnknown || isLocalOnlyReserved(hint.Identity) {
+			return 0, r.clusterInfo.ID, true
+		}
+		clusterID, allocated := allocatedClusterID(hint.Identity)
+		if allocated && clusterID == r.clusterInfo.ID {
+			return 0, r.clusterInfo.ID, true
+		}
+		return 0, 0, false
+	}
+
+	if !hint.IdentityKnown {
+		return 0, 0, false
+	}
+	if hint.Identity == identity.ReservedIdentityHost {
+		return 0, r.clusterInfo.ID, true
+	}
+
+	clusterID, allocated := allocatedClusterID(hint.Identity)
+	if !allocated {
+		return 0, 0, false
+	}
+	if clusterID == r.clusterInfo.ID {
+		return 0, r.clusterInfo.ID, true
+	}
+	if clusterID == 0 {
+		return 0, 0, false
+	}
+	return clusterID, clusterID, true
+}
+
+func isLocalOnlyReserved(id identity.NumericIdentity) bool {
+	switch id {
+	case identity.ReservedIdentityHost, identity.ReservedIdentityHealth, identity.ReservedIdentityIngress:
+		return true
+	default:
+		return false
+	}
+}
+
+// allocatedClusterID validates the allocation scope and authoritative numeric
+// bounds before interpreting the identity's embedded ClusterID.
+func allocatedClusterID(id identity.NumericIdentity) (uint32, bool) {
+	if id.HasLocalScope() || id.HasRemoteNodeScope() || id.Scope() != identity.IdentityScopeGlobal ||
+		id.IsReservedIdentity() || identity.IsUserReservedIdentity(id) {
+		return 0, false
+	}
+
+	clusterID := id.ClusterID()
+	if id < identity.GetMinimalAllocationIdentity(clusterID) || id > identity.GetMaximumAllocationIdentity(clusterID) {
+		return 0, false
+	}
+	return clusterID, true
+}
+
+func (r *Resolver) labelsForAddress(address netip.Addr, expectedCluster uint32) []string {
+	if !address.IsValid() {
+		return nil
+	}
+	address = address.Unmap()
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var labels []string
+	matches := 0
+	for identity := range r.byAddress[address] {
+		snapshot, exists := r.byIdentity[identity]
+		if !exists || snapshot.clusterID != expectedCluster {
+			continue
+		}
+		matches++
+		if matches > 1 {
+			return nil
+		}
+		labels = snapshot.labels
+	}
+	if matches != 1 {
+		return nil
+	}
+	return labels
+}

--- a/pkg/hubble/parser/nodes/resolver.go
+++ b/pkg/hubble/parser/nodes/resolver.go
@@ -180,14 +180,19 @@ func (r *Resolver) GetNodeLabels(ip netip.Addr, hint getters.NodeClusterHint) []
 	if r.ipcache == nil {
 		return nil
 	}
-	hostIP, found := r.ipcache.GetHostIP(cmtypes.AddrClusterFrom(ip, ipcacheScope))
-	if found {
+	hostIP, status := r.ipcache.LookupHostIP(cmtypes.AddrClusterFrom(ip, ipcacheScope))
+	switch status {
+	case ipcache.HostIPLookupResolved:
 		return r.labelsForAddress(hostIP, expectedCluster)
+	case ipcache.HostIPLookupAbsent:
+		// Direct-node fallback is permitted only after a true exact scoped
+		// IPCache absence and retains the authenticated expected ClusterID.
+		return r.labelsForAddress(ip, expectedCluster)
+	case ipcache.HostIPLookupInvalid:
+		return nil
+	default:
+		return nil
 	}
-
-	// Direct-node fallback is permitted only after an exact scoped IPCache miss
-	// and retains the already authenticated expected ClusterID.
-	return r.labelsForAddress(ip, expectedCluster)
 }
 
 func (r *Resolver) resolveScope(hint getters.NodeClusterHint) (ipcacheScope, expectedCluster uint32, ok bool) {

--- a/pkg/hubble/parser/nodes/resolver_benchmark_test.go
+++ b/pkg/hubble/parser/nodes/resolver_benchmark_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package nodes
+
+import (
+	"net/netip"
+	"testing"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/hubble/parser/getters"
+	"github.com/cilium/cilium/pkg/identity"
+)
+
+var benchmarkLabels []string
+
+func benchmarkResolver(b *testing.B, withIPCache bool) *Resolver {
+	b.Helper()
+	ipc := newTestIPCache(b)
+	r := NewResolver(ipc, cmtypes.ClusterInfo{ID: localClusterID, Name: localCluster}, nil)
+	r.NodeUpsert(nodeWithAddresses(localCluster, "node-a", localClusterID,
+		map[string]string{
+			"kubernetes.io/hostname":        "node-a",
+			"topology.kubernetes.io/region": "region-a",
+			"topology.kubernetes.io/zone":   "zone-a",
+		}, "192.0.2.10"))
+	if withIPCache {
+		upsertHost(b, ipc, "10.0.0.1", "192.0.2.10")
+		upsertHost(b, ipc, "10.0.0.2", "192.0.2.10")
+	}
+	return r
+}
+
+func BenchmarkResolverCacheHitBothDirections(b *testing.B) {
+	r := benchmarkResolver(b, true)
+	src := netip.MustParseAddr("10.0.0.1")
+	dst := netip.MustParseAddr("10.0.0.2")
+	hint := allocatedHint(localClusterID)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		benchmarkLabels = r.GetNodeLabels(src, hint)
+		benchmarkLabels = r.GetNodeLabels(dst, hint)
+	}
+}
+
+func BenchmarkResolverIPCacheMiss(b *testing.B) {
+	r := benchmarkResolver(b, false)
+	ip := netip.MustParseAddr("10.0.0.1")
+	hint := allocatedHint(localClusterID)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		benchmarkLabels = r.GetNodeLabels(ip, hint)
+	}
+}
+
+func BenchmarkResolverDirectNodeHit(b *testing.B) {
+	r := benchmarkResolver(b, false)
+	ip := netip.MustParseAddr("192.0.2.10")
+	hint := allocatedHint(localClusterID)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		benchmarkLabels = r.GetNodeLabels(ip, hint)
+	}
+}
+
+func BenchmarkResolverUnknownProvenanceMiss(b *testing.B) {
+	r := benchmarkResolver(b, true)
+	ip := netip.MustParseAddr("10.0.0.1")
+	hint := getters.NodeClusterHint{Identity: identity.GetMinimalAllocationIdentity(localClusterID)}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		benchmarkLabels = r.GetNodeLabels(ip, hint)
+	}
+}

--- a/pkg/hubble/parser/nodes/resolver_test.go
+++ b/pkg/hubble/parser/nodes/resolver_test.go
@@ -1,0 +1,453 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package nodes
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"sync"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/cidr"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/hubble/parser/getters"
+	"github.com/cilium/cilium/pkg/identity"
+	iputil "github.com/cilium/cilium/pkg/ip"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/node/addressing"
+	"github.com/cilium/cilium/pkg/node/manager"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/source"
+)
+
+const (
+	localClusterID  = uint32(10)
+	remoteClusterID = uint32(42)
+	localCluster    = "local"
+	remoteCluster   = "remote"
+)
+
+type fakeNodeStateNotifier struct {
+	initial          []nodeTypes.Node
+	observer         manager.NodeStateObserver
+	subscribeCalls   int
+	unsubscribeCalls int
+}
+
+func (f *fakeNodeStateNotifier) SubscribeNodeState(observer manager.NodeStateObserver) {
+	f.subscribeCalls++
+	f.observer = observer
+	for _, n := range f.initial {
+		observer.NodeUpsert(n)
+	}
+}
+
+func (f *fakeNodeStateNotifier) UnsubscribeNodeState(observer manager.NodeStateObserver) {
+	f.unsubscribeCalls++
+	if f.observer == observer {
+		f.observer = nil
+	}
+}
+
+func newTestIPCache(t testing.TB) *ipcache.IPCache {
+	t.Helper()
+	ipc := ipcache.NewIPCache(&ipcache.Configuration{
+		Context: context.Background(),
+		Logger:  hivetest.Logger(t),
+	})
+	t.Cleanup(func() { require.NoError(t, ipc.Shutdown()) })
+	return ipc
+}
+
+func upsertHost(t testing.TB, ipc *ipcache.IPCache, endpoint, host string) {
+	t.Helper()
+	_, err := ipc.Upsert(endpoint, net.ParseIP(host), 0, nil, ipcache.Identity{
+		ID:     identity.GetMinimalAllocationIdentity(0),
+		Source: source.KVStore,
+	})
+	require.NoError(t, err)
+}
+
+func nodeWithAddresses(cluster, name string, clusterID uint32, nodeLabels map[string]string, addresses ...string) nodeTypes.Node {
+	n := nodeTypes.Node{
+		Name:      name,
+		Cluster:   cluster,
+		ClusterID: clusterID,
+		Labels:    nodeLabels,
+	}
+	for _, address := range addresses {
+		n.IPAddresses = append(n.IPAddresses, nodeTypes.Address{
+			Type: addressing.NodeInternalIP,
+			IP:   net.ParseIP(address),
+		})
+	}
+	return n
+}
+
+func allocatedHint(clusterID uint32) getters.NodeClusterHint {
+	return getters.NodeClusterHint{
+		Identity:      identity.GetMinimalAllocationIdentity(clusterID),
+		IdentityKnown: true,
+	}
+}
+
+func requireLabels(t testing.TB, want []string, got []string, msgAndArgs ...any) {
+	t.Helper()
+	require.Equal(t, want, got, msgAndArgs...)
+}
+
+func TestResolverConstructionHasNoSubscriptionAndInitialReplayIsSynchronous(t *testing.T) {
+	ipc := newTestIPCache(t)
+	notifier := &fakeNodeStateNotifier{initial: []nodeTypes.Node{
+		nodeWithAddresses(localCluster, "node-a", localClusterID,
+			map[string]string{"z": "last", "a": "first"}, "192.0.2.10"),
+	}}
+	r := NewResolver(ipc, cmtypes.ClusterInfo{ID: localClusterID, Name: localCluster}, notifier)
+
+	require.Zero(t, notifier.subscribeCalls, "construction must not own lifecycle subscription")
+	require.Empty(t, r.GetNodeLabels(netip.MustParseAddr("192.0.2.10"), allocatedHint(localClusterID)))
+
+	notifier.SubscribeNodeState(r)
+	require.Equal(t, 1, notifier.subscribeCalls)
+	requireLabels(t, []string{"a=first", "z=last"},
+		r.GetNodeLabels(netip.MustParseAddr("192.0.2.10"), allocatedHint(localClusterID)))
+
+	// Replayed duplicate state is idempotent.
+	r.NodeUpsert(notifier.initial[0])
+	requireLabels(t, []string{"a=first", "z=last"},
+		r.GetNodeLabels(netip.MustParseAddr("192.0.2.10"), allocatedHint(localClusterID)))
+}
+
+func TestResolverSelectsAuthoritativeIdentityScope(t *testing.T) {
+	ipc := newTestIPCache(t)
+	r := NewResolver(ipc, cmtypes.ClusterInfo{ID: localClusterID, Name: localCluster}, nil)
+	r.NodeUpsert(nodeWithAddresses(localCluster, "local-node", localClusterID,
+		map[string]string{"cluster": localCluster}, "192.0.2.10"))
+	r.NodeUpsert(nodeWithAddresses(remoteCluster, "remote-node", remoteClusterID,
+		map[string]string{"cluster": remoteCluster}, "192.0.2.42"))
+
+	// The endpoint IP overlaps, so only exact IPCache scope can distinguish it.
+	upsertHost(t, ipc, "10.0.0.1", "192.0.2.10")
+	upsertHost(t, ipc, "10.0.0.1@42", "192.0.2.42")
+
+	for _, id := range []identity.NumericIdentity{
+		identity.GetMinimalAllocationIdentity(localClusterID),
+		identity.GetMaximumAllocationIdentity(localClusterID),
+	} {
+		requireLabels(t, []string{"cluster=local"}, r.GetNodeLabels(
+			netip.MustParseAddr("10.0.0.1"),
+			getters.NodeClusterHint{Identity: id, IdentityKnown: true},
+		))
+	}
+	for _, id := range []identity.NumericIdentity{
+		identity.GetMinimalAllocationIdentity(remoteClusterID),
+		identity.GetMaximumAllocationIdentity(remoteClusterID),
+	} {
+		requireLabels(t, []string{"cluster=remote"}, r.GetNodeLabels(
+			netip.MustParseAddr("10.0.0.1"),
+			getters.NodeClusterHint{Identity: id, IdentityKnown: true},
+		))
+	}
+
+	requireLabels(t, []string{"cluster=local"}, r.GetNodeLabels(
+		netip.MustParseAddr("10.0.0.1"),
+		getters.NodeClusterHint{Identity: identity.ReservedIdentityHost, IdentityKnown: true},
+	))
+	require.Empty(t, r.GetNodeLabels(netip.MustParseAddr("10.0.0.1"), getters.NodeClusterHint{
+		Identity: identity.GetMinimalAllocationIdentity(remoteClusterID), IdentityKnown: false,
+	}))
+	require.Empty(t, r.GetNodeLabels(netip.Addr{}, allocatedHint(localClusterID)))
+}
+
+func TestResolverExplicitLocalHint(t *testing.T) {
+	ipc := newTestIPCache(t)
+	r := NewResolver(ipc, cmtypes.ClusterInfo{ID: localClusterID, Name: localCluster}, nil)
+	r.NodeUpsert(nodeWithAddresses(localCluster, "local-node", localClusterID,
+		map[string]string{"scope": "local"}, "192.0.2.10"))
+	upsertHost(t, ipc, "10.0.0.1", "192.0.2.10")
+
+	requireLabels(t, []string{"scope=local"}, r.GetNodeLabels(
+		netip.MustParseAddr("10.0.0.1"),
+		getters.NodeClusterHint{LocalEndpoint: true},
+	))
+	requireLabels(t, []string{"scope=local"}, r.GetNodeLabels(
+		netip.MustParseAddr("10.0.0.1"),
+		getters.NodeClusterHint{
+			Identity: identity.GetMinimalAllocationIdentity(localClusterID), IdentityKnown: true, LocalEndpoint: true,
+		},
+	))
+	requireLabels(t, []string{"scope=local"}, r.GetNodeLabels(
+		netip.MustParseAddr("10.0.0.1"),
+		getters.NodeClusterHint{Identity: identity.ReservedIdentityHealth, IdentityKnown: true, LocalEndpoint: true},
+	))
+
+	// Event-established locality and an authoritative remote identity contradict.
+	require.Empty(t, r.GetNodeLabels(netip.MustParseAddr("10.0.0.1"), getters.NodeClusterHint{
+		Identity: identity.GetMinimalAllocationIdentity(remoteClusterID), IdentityKnown: true, LocalEndpoint: true,
+	}))
+}
+
+func TestResolverRejectsUntrustedIdentityScopes(t *testing.T) {
+	ipc := newTestIPCache(t)
+	r := NewResolver(ipc, cmtypes.ClusterInfo{ID: localClusterID, Name: localCluster}, nil)
+	r.NodeUpsert(nodeWithAddresses(localCluster, "local-node", localClusterID,
+		map[string]string{"scope": "local"}, "192.0.2.10"))
+	upsertHost(t, ipc, "10.0.0.1", "192.0.2.10")
+
+	maxGlobal := identity.GetMaximumAllocationIdentity(cmtypes.ClusterIDMax)
+	cases := map[string]identity.NumericIdentity{
+		"unknown":                   identity.IdentityUnknown,
+		"world":                     identity.ReservedIdentityWorld,
+		"user reserved":             identity.UserReservedNumericIdentity,
+		"below allocation range":    identity.GetMinimalAllocationIdentity(0) - 1,
+		"above allocation range":    maxGlobal + 1,
+		"local scope":               identity.MinLocalIdentity,
+		"health":                    identity.ReservedIdentityHealth,
+		"ingress":                   identity.ReservedIdentityIngress,
+		"remote node":               identity.ReservedIdentityRemoteNode,
+		"kube apiserver":            identity.ReservedIdentityKubeAPIServer,
+		"dynamic remote-node scope": identity.IdentityScopeRemoteNode | identity.GetMinimalAllocationIdentity(remoteClusterID),
+	}
+	for name, id := range cases {
+		t.Run(name, func(t *testing.T) {
+			require.Empty(t, r.GetNodeLabels(netip.MustParseAddr("10.0.0.1"), getters.NodeClusterHint{
+				Identity: id, IdentityKnown: true,
+			}))
+		})
+	}
+
+	// A userspace-filled identity is not authoritative, regardless of its value.
+	require.Empty(t, r.GetNodeLabels(netip.MustParseAddr("10.0.0.1"), getters.NodeClusterHint{
+		Identity: identity.GetMinimalAllocationIdentity(localClusterID),
+	}))
+}
+
+func TestResolverIPv4IPv6AndSameNodeBothDirections(t *testing.T) {
+	ipc := newTestIPCache(t)
+	r := NewResolver(ipc, cmtypes.ClusterInfo{ID: localClusterID, Name: localCluster}, nil)
+	r.NodeUpsert(nodeWithAddresses(localCluster, "dual-stack", localClusterID,
+		map[string]string{"node": "dual-stack"}, "192.0.2.10", "2001:db8::10"))
+	upsertHost(t, ipc, "10.0.0.1", "192.0.2.10")
+	upsertHost(t, ipc, "fd00::1", "2001:db8::10")
+
+	sourceLabels := r.GetNodeLabels(netip.MustParseAddr("10.0.0.1"), allocatedHint(localClusterID))
+	destinationLabels := r.GetNodeLabels(netip.MustParseAddr("fd00::1"), allocatedHint(localClusterID))
+	requireLabels(t, []string{"node=dual-stack"}, sourceLabels)
+	requireLabels(t, sourceLabels, destinationLabels)
+}
+
+func TestResolverDirectNodeFallbackIsScopedAndUnambiguous(t *testing.T) {
+	t.Run("missing IPCache fails closed", func(t *testing.T) {
+		r := NewResolver(nil, cmtypes.ClusterInfo{ID: localClusterID, Name: localCluster}, nil)
+		r.NodeUpsert(nodeWithAddresses(localCluster, "local-node", localClusterID,
+			map[string]string{"node": "local"}, "192.0.2.10"))
+
+		require.Empty(t, r.GetNodeLabels(
+			netip.MustParseAddr("192.0.2.10"), allocatedHint(localClusterID)))
+	})
+
+	t.Run("local and remote direct node addresses use expected ClusterID", func(t *testing.T) {
+		ipc := newTestIPCache(t)
+		r := NewResolver(ipc, cmtypes.ClusterInfo{ID: localClusterID, Name: localCluster}, nil)
+		r.NodeUpsert(nodeWithAddresses(localCluster, "local-node", localClusterID,
+			map[string]string{"node": "local"}, "192.0.2.10"))
+		r.NodeUpsert(nodeWithAddresses(remoteCluster, "remote-node", remoteClusterID,
+			map[string]string{"node": "remote"}, "192.0.2.42"))
+
+		requireLabels(t, []string{"node=local"}, r.GetNodeLabels(
+			netip.MustParseAddr("192.0.2.10"), allocatedHint(localClusterID)))
+		requireLabels(t, []string{"node=remote"}, r.GetNodeLabels(
+			netip.MustParseAddr("192.0.2.42"), allocatedHint(remoteClusterID)))
+		require.Empty(t, r.GetNodeLabels(
+			netip.MustParseAddr("192.0.2.10"), allocatedHint(remoteClusterID)))
+	})
+
+	t.Run("owners from other clusters do not make an expected cluster ambiguous", func(t *testing.T) {
+		ipc := newTestIPCache(t)
+		r := NewResolver(ipc, cmtypes.ClusterInfo{ID: localClusterID, Name: localCluster}, nil)
+		r.NodeUpsert(nodeWithAddresses(localCluster, "local-node", localClusterID,
+			map[string]string{"node": "local"}, "192.0.2.50"))
+		r.NodeUpsert(nodeWithAddresses(remoteCluster, "remote-node", remoteClusterID,
+			map[string]string{"node": "remote"}, "192.0.2.50"))
+
+		requireLabels(t, []string{"node=local"}, r.GetNodeLabels(
+			netip.MustParseAddr("192.0.2.50"), allocatedHint(localClusterID)))
+		requireLabels(t, []string{"node=remote"}, r.GetNodeLabels(
+			netip.MustParseAddr("192.0.2.50"), allocatedHint(remoteClusterID)))
+	})
+
+	t.Run("two matching owners are ambiguous", func(t *testing.T) {
+		ipc := newTestIPCache(t)
+		r := NewResolver(ipc, cmtypes.ClusterInfo{ID: localClusterID, Name: localCluster}, nil)
+		r.NodeUpsert(nodeWithAddresses(localCluster, "node-a", localClusterID,
+			map[string]string{"node": "a"}, "192.0.2.10"))
+		r.NodeUpsert(nodeWithAddresses(localCluster, "node-b", localClusterID,
+			map[string]string{"node": "b"}, "192.0.2.10"))
+
+		require.Empty(t, r.GetNodeLabels(
+			netip.MustParseAddr("192.0.2.10"), allocatedHint(localClusterID)))
+	})
+
+	t.Run("IPCache owner miss does not fall back to endpoint", func(t *testing.T) {
+		ipc := newTestIPCache(t)
+		r := NewResolver(ipc, cmtypes.ClusterInfo{ID: localClusterID, Name: localCluster}, nil)
+		r.NodeUpsert(nodeWithAddresses(localCluster, "node-a", localClusterID,
+			map[string]string{"node": "a"}, "10.0.0.1"))
+		upsertHost(t, ipc, "10.0.0.1", "192.0.2.99")
+
+		require.Empty(t, r.GetNodeLabels(
+			netip.MustParseAddr("10.0.0.1"), allocatedHint(localClusterID)))
+	})
+}
+
+func TestResolverOwnerClassificationFailsClosed(t *testing.T) {
+	t.Run("configured local ClusterID zero excludes differently named zero", func(t *testing.T) {
+		ipc := newTestIPCache(t)
+		r := NewResolver(ipc, cmtypes.ClusterInfo{ID: 0, Name: localCluster}, nil)
+		r.NodeUpsert(nodeWithAddresses(localCluster, "local", 0,
+			map[string]string{"node": "local"}, "192.0.2.10"))
+		r.NodeUpsert(nodeWithAddresses(remoteCluster, "remote", 0,
+			map[string]string{"node": "remote"}, "192.0.2.10"))
+
+		requireLabels(t, []string{"node=local"}, r.GetNodeLabels(
+			netip.MustParseAddr("192.0.2.10"), getters.NodeClusterHint{LocalEndpoint: true}))
+	})
+
+	t.Run("remote cluster colliding with local ClusterID is excluded", func(t *testing.T) {
+		ipc := newTestIPCache(t)
+		r := NewResolver(ipc, cmtypes.ClusterInfo{ID: localClusterID, Name: localCluster}, nil)
+		r.NodeUpsert(nodeWithAddresses(remoteCluster, "collision", localClusterID,
+			map[string]string{"node": "collision"}, "192.0.2.10"))
+		require.Empty(t, r.GetNodeLabels(
+			netip.MustParseAddr("192.0.2.10"), allocatedHint(localClusterID)))
+	})
+
+	t.Run("local name with contradictory ClusterID is excluded", func(t *testing.T) {
+		ipc := newTestIPCache(t)
+		r := NewResolver(ipc, cmtypes.ClusterInfo{ID: localClusterID, Name: localCluster}, nil)
+		r.NodeUpsert(nodeWithAddresses(localCluster, "contradiction", remoteClusterID,
+			map[string]string{"node": "contradiction"}, "192.0.2.42"))
+		require.Empty(t, r.GetNodeLabels(
+			netip.MustParseAddr("192.0.2.42"), allocatedHint(remoteClusterID)))
+	})
+
+	t.Run("empty remote cluster name is excluded", func(t *testing.T) {
+		ipc := newTestIPCache(t)
+		r := NewResolver(ipc, cmtypes.ClusterInfo{ID: localClusterID, Name: localCluster}, nil)
+		r.NodeUpsert(nodeWithAddresses("", "remote", remoteClusterID,
+			map[string]string{"node": "remote"}, "192.0.2.42"))
+		require.Empty(t, r.GetNodeLabels(
+			netip.MustParseAddr("192.0.2.42"), allocatedHint(remoteClusterID)))
+	})
+}
+
+func TestResolverUpsertDeleteAndImmutableSnapshots(t *testing.T) {
+	ipc := newTestIPCache(t)
+	r := NewResolver(ipc, cmtypes.ClusterInfo{ID: localClusterID, Name: localCluster}, nil)
+
+	original := nodeWithAddresses(localCluster, "node-a", 0,
+		map[string]string{"version": "one", "a": "first"}, "192.0.2.10", "192.0.2.10")
+	original.IPAddresses = append(original.IPAddresses, nodeTypes.Address{
+		Type: addressing.NodeExternalIP,
+		IP:   net.IP{1, 2, 3}, // invalid and therefore not indexed
+	})
+	original.IPv4HealthIP = iputil.AddrFrom(netip.MustParseAddr("192.0.2.11"))
+	original.IPv6HealthIP = iputil.AddrFrom(netip.MustParseAddr("2001:db8::11"))
+	original.IPv4IngressIP = net.ParseIP("192.0.2.12")
+	original.IPv6IngressIP = net.ParseIP("2001:db8::12")
+	original.IPv4AllocCIDR = cidr.MustParseCIDR("10.244.0.0/24")
+	r.NodeUpsert(original)
+	original.Labels["version"] = "mutated"
+	original.Labels["later"] = "input-map-change"
+
+	oldLabels := r.GetNodeLabels(netip.MustParseAddr("192.0.2.10"), allocatedHint(localClusterID))
+	requireLabels(t, []string{"a=first", "version=one"}, oldLabels)
+	repeatedLabels := r.GetNodeLabels(netip.MustParseAddr("192.0.2.10"), allocatedHint(localClusterID))
+	require.True(t, &oldLabels[0] == &repeatedLabels[0], "cache hits must share the immutable published slice")
+	for _, address := range []string{"192.0.2.11", "2001:db8::11", "192.0.2.12", "2001:db8::12"} {
+		requireLabels(t, oldLabels, r.GetNodeLabels(netip.MustParseAddr(address), allocatedHint(localClusterID)))
+	}
+	require.Empty(t, r.GetNodeLabels(netip.MustParseAddr("10.244.0.1"), allocatedHint(localClusterID)),
+		"pod allocation CIDRs are not node-owned direct addresses")
+
+	replacement := nodeWithAddresses(localCluster, "node-a", localClusterID,
+		map[string]string{"version": "two"}, "192.0.2.20")
+	r.NodeUpsert(replacement)
+	r.NodeUpsert(replacement) // duplicate accepted updates remain idempotent
+
+	for _, stale := range []string{"192.0.2.10", "192.0.2.11", "2001:db8::11", "192.0.2.12", "2001:db8::12"} {
+		require.Empty(t, r.GetNodeLabels(netip.MustParseAddr(stale), allocatedHint(localClusterID)))
+	}
+	requireLabels(t, []string{"version=two"},
+		r.GetNodeLabels(netip.MustParseAddr("192.0.2.20"), allocatedHint(localClusterID)))
+	requireLabels(t, []string{"a=first", "version=one"}, oldLabels,
+		"published label snapshots must not be mutated by later updates")
+
+	// An excluded upsert removes the complete previously accepted snapshot.
+	replacement.ClusterID = remoteClusterID
+	r.NodeUpsert(replacement)
+	require.Empty(t, r.GetNodeLabels(netip.MustParseAddr("192.0.2.20"), allocatedHint(localClusterID)))
+
+	// Delete is keyed by identity and ignores the event's missing addresses.
+	replacement.ClusterID = localClusterID
+	r.NodeUpsert(replacement)
+	r.NodeDelete(nodeTypes.Node{Name: replacement.Name, Cluster: replacement.Cluster})
+	require.Empty(t, r.GetNodeLabels(netip.MustParseAddr("192.0.2.20"), allocatedHint(localClusterID)))
+}
+
+func TestResolverSharedAddressDeletePreservesOtherOwner(t *testing.T) {
+	ipc := newTestIPCache(t)
+	r := NewResolver(ipc, cmtypes.ClusterInfo{ID: localClusterID, Name: localCluster}, nil)
+	nodeA := nodeWithAddresses(localCluster, "node-a", localClusterID,
+		map[string]string{"node": "a"}, "192.0.2.10")
+	nodeB := nodeWithAddresses(localCluster, "node-b", localClusterID,
+		map[string]string{"node": "b"}, "192.0.2.10")
+	r.NodeUpsert(nodeA)
+	r.NodeUpsert(nodeB)
+	require.Empty(t, r.GetNodeLabels(netip.MustParseAddr("192.0.2.10"), allocatedHint(localClusterID)))
+
+	r.NodeDelete(nodeTypes.Node{Name: nodeA.Name, Cluster: nodeA.Cluster})
+	requireLabels(t, []string{"node=b"},
+		r.GetNodeLabels(netip.MustParseAddr("192.0.2.10"), allocatedHint(localClusterID)))
+}
+
+func TestResolverConcurrentUpdatesAndLookups(t *testing.T) {
+	ipc := newTestIPCache(t)
+	r := NewResolver(ipc, cmtypes.ClusterInfo{ID: localClusterID, Name: localCluster}, nil)
+	node := nodeWithAddresses(localCluster, "node-a", localClusterID,
+		map[string]string{"node": "a"}, "192.0.2.10")
+	r.NodeUpsert(node)
+	upsertHost(t, ipc, "10.0.0.1", "192.0.2.10")
+
+	const iterations = 500
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			r.NodeUpsert(node)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			r.NodeDelete(nodeTypes.Node{Name: node.Name, Cluster: node.Cluster})
+			r.NodeUpsert(node)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			labels := r.GetNodeLabels(netip.MustParseAddr("10.0.0.1"), allocatedHint(localClusterID))
+			if len(labels) != 0 && (len(labels) != 1 || labels[0] != "node=a") {
+				t.Errorf("lookup observed a partial snapshot: %v", labels)
+			}
+		}
+	}()
+	wg.Wait()
+}

--- a/pkg/hubble/parser/nodes/resolver_test.go
+++ b/pkg/hubble/parser/nodes/resolver_test.go
@@ -512,7 +512,7 @@ func TestResolverUpsertDeleteAndImmutableSnapshots(t *testing.T) {
 	oldLabels := r.GetNodeLabels(netip.MustParseAddr("192.0.2.10"), allocatedHint(localClusterID))
 	requireLabels(t, []string{"a=first", "version=one"}, oldLabels)
 	repeatedLabels := r.GetNodeLabels(netip.MustParseAddr("192.0.2.10"), allocatedHint(localClusterID))
-	require.True(t, &oldLabels[0] == &repeatedLabels[0], "cache hits must share the immutable published slice")
+	require.Same(t, &oldLabels[0], &repeatedLabels[0], "cache hits must share the immutable published slice")
 	for _, address := range []string{"192.0.2.11", "2001:db8::11", "192.0.2.12", "2001:db8::12"} {
 		requireLabels(t, oldLabels, r.GetNodeLabels(netip.MustParseAddr(address), allocatedHint(localClusterID)))
 	}

--- a/pkg/hubble/parser/nodes/resolver_test.go
+++ b/pkg/hubble/parser/nodes/resolver_test.go
@@ -199,12 +199,30 @@ func TestResolverRejectsUntrustedIdentityScopes(t *testing.T) {
 		map[string]string{"scope": "local"}, "192.0.2.10"))
 	upsertHost(t, ipc, "10.0.0.1", "192.0.2.10")
 
+	malformedGlobal := identity.UserReservedNumericIdentity - 1
+	require.Less(t, malformedGlobal, identity.GetMinimalAllocationIdentity(0))
+	require.False(t, malformedGlobal.IsReservedIdentity())
+	require.False(t, identity.IsUserReservedIdentity(malformedGlobal))
+	require.Equal(t, identity.IdentityScopeGlobal, malformedGlobal.Scope())
+	require.False(t, malformedGlobal.HasLocalScope())
+	require.False(t, malformedGlobal.HasRemoteNodeScope())
+	t.Run("below allocation range", func(t *testing.T) {
+		ipc := newTestIPCache(t)
+		r := NewResolver(ipc, cmtypes.ClusterInfo{ID: 0, Name: localCluster}, nil)
+		r.NodeUpsert(nodeWithAddresses(localCluster, "local-node", 0,
+			map[string]string{"scope": "local-zero"}, "192.0.2.127"))
+		upsertHost(t, ipc, "10.0.0.127", "192.0.2.127")
+
+		require.Empty(t, r.GetNodeLabels(netip.MustParseAddr("10.0.0.127"), getters.NodeClusterHint{
+			Identity: malformedGlobal, IdentityKnown: true,
+		}))
+	})
+
 	maxGlobal := identity.GetMaximumAllocationIdentity(cmtypes.ClusterIDMax)
 	cases := map[string]identity.NumericIdentity{
 		"unknown":                   identity.IdentityUnknown,
 		"world":                     identity.ReservedIdentityWorld,
 		"user reserved":             identity.UserReservedNumericIdentity,
-		"below allocation range":    identity.GetMinimalAllocationIdentity(0) - 1,
 		"above allocation range":    maxGlobal + 1,
 		"local scope":               identity.MinLocalIdentity,
 		"health":                    identity.ReservedIdentityHealth,
@@ -303,6 +321,48 @@ func TestResolverDirectNodeFallbackIsScopedAndUnambiguous(t *testing.T) {
 		require.Empty(t, r.GetNodeLabels(
 			netip.MustParseAddr("10.0.0.1"), allocatedHint(localClusterID)))
 	})
+
+	for _, tt := range []struct {
+		name    string
+		entries map[string]net.IP
+	}{
+		{
+			name: "conflicting exact IPCache representations",
+			entries: map[string]net.IP{
+				"10.0.0.1":    net.ParseIP("192.0.2.10"),
+				"10.0.0.1/32": net.ParseIP("192.0.2.11"),
+			},
+		},
+		{
+			name: "missing host metadata",
+			entries: map[string]net.IP{
+				"10.0.0.1": nil,
+			},
+		},
+		{
+			name: "invalid host bytes",
+			entries: map[string]net.IP{
+				"10.0.0.1": {1, 2, 3},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ipc := newTestIPCache(t)
+			r := NewResolver(ipc, cmtypes.ClusterInfo{ID: localClusterID, Name: localCluster}, nil)
+			r.NodeUpsert(nodeWithAddresses(localCluster, "endpoint-owner", localClusterID,
+				map[string]string{"node": "endpoint-owner"}, "10.0.0.1"))
+			for endpoint, hostIP := range tt.entries {
+				_, err := ipc.Upsert(endpoint, hostIP, 0, nil, ipcache.Identity{
+					ID:     identity.GetMinimalAllocationIdentity(0),
+					Source: source.KVStore,
+				})
+				require.NoError(t, err)
+			}
+
+			require.Empty(t, r.GetNodeLabels(
+				netip.MustParseAddr("10.0.0.1"), allocatedHint(localClusterID)))
+		})
+	}
 }
 
 func TestResolverOwnerClassificationFailsClosed(t *testing.T) {
@@ -334,6 +394,10 @@ func TestResolverOwnerClassificationFailsClosed(t *testing.T) {
 			map[string]string{"node": "contradiction"}, "192.0.2.42"))
 		require.Empty(t, r.GetNodeLabels(
 			netip.MustParseAddr("192.0.2.42"), allocatedHint(remoteClusterID)))
+		require.Empty(t, r.GetNodeLabels(
+			netip.MustParseAddr("192.0.2.42"), allocatedHint(localClusterID)))
+		require.Empty(t, r.GetNodeLabels(
+			netip.MustParseAddr("192.0.2.42"), getters.NodeClusterHint{LocalEndpoint: true}))
 	})
 
 	t.Run("empty remote cluster name is excluded", func(t *testing.T) {

--- a/pkg/hubble/parser/nodes/resolver_test.go
+++ b/pkg/hubble/parser/nodes/resolver_test.go
@@ -33,25 +33,49 @@ const (
 )
 
 type fakeNodeStateNotifier struct {
+	mu               sync.Mutex
 	initial          []nodeTypes.Node
 	observer         manager.NodeStateObserver
 	subscribeCalls   int
 	unsubscribeCalls int
 }
 
+type blockingNodeStateNotifier struct {
+	*fakeNodeStateNotifier
+	subscribeEntered chan struct{}
+	releaseSubscribe chan struct{}
+}
+
+func (f *blockingNodeStateNotifier) SubscribeNodeState(observer manager.NodeStateObserver) {
+	close(f.subscribeEntered)
+	<-f.releaseSubscribe
+	f.fakeNodeStateNotifier.SubscribeNodeState(observer)
+}
+
 func (f *fakeNodeStateNotifier) SubscribeNodeState(observer manager.NodeStateObserver) {
+	f.mu.Lock()
 	f.subscribeCalls++
 	f.observer = observer
-	for _, n := range f.initial {
+	initial := append([]nodeTypes.Node(nil), f.initial...)
+	f.mu.Unlock()
+	for _, n := range initial {
 		observer.NodeUpsert(n)
 	}
 }
 
 func (f *fakeNodeStateNotifier) UnsubscribeNodeState(observer manager.NodeStateObserver) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.unsubscribeCalls++
 	if f.observer == observer {
 		f.observer = nil
 	}
+}
+
+func (f *fakeNodeStateNotifier) calls() (subscribe, unsubscribe int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.subscribeCalls, f.unsubscribeCalls
 }
 
 func newTestIPCache(t testing.TB) *ipcache.IPCache {
@@ -101,7 +125,7 @@ func requireLabels(t testing.TB, want []string, got []string, msgAndArgs ...any)
 	require.Equal(t, want, got, msgAndArgs...)
 }
 
-func TestResolverConstructionHasNoSubscriptionAndInitialReplayIsSynchronous(t *testing.T) {
+func TestResolverLifecycleStartReplaysSynchronouslyAndIsIdempotent(t *testing.T) {
 	ipc := newTestIPCache(t)
 	notifier := &fakeNodeStateNotifier{initial: []nodeTypes.Node{
 		nodeWithAddresses(localCluster, "node-a", localClusterID,
@@ -109,18 +133,74 @@ func TestResolverConstructionHasNoSubscriptionAndInitialReplayIsSynchronous(t *t
 	}}
 	r := NewResolver(ipc, cmtypes.ClusterInfo{ID: localClusterID, Name: localCluster}, notifier)
 
-	require.Zero(t, notifier.subscribeCalls, "construction must not own lifecycle subscription")
+	subscribe, unsubscribe := notifier.calls()
+	require.Zero(t, subscribe, "construction must not own lifecycle subscription")
+	require.Zero(t, unsubscribe)
 	require.Empty(t, r.GetNodeLabels(netip.MustParseAddr("192.0.2.10"), allocatedHint(localClusterID)))
 
-	notifier.SubscribeNodeState(r)
-	require.Equal(t, 1, notifier.subscribeCalls)
+	require.NoError(t, r.Start())
+	subscribe, unsubscribe = notifier.calls()
+	require.Equal(t, 1, subscribe)
+	require.Zero(t, unsubscribe)
 	requireLabels(t, []string{"a=first", "z=last"},
-		r.GetNodeLabels(netip.MustParseAddr("192.0.2.10"), allocatedHint(localClusterID)))
+		r.GetNodeLabels(netip.MustParseAddr("192.0.2.10"), allocatedHint(localClusterID)),
+		"the notifier replay must complete before Start returns")
 
-	// Replayed duplicate state is idempotent.
-	r.NodeUpsert(notifier.initial[0])
-	requireLabels(t, []string{"a=first", "z=last"},
-		r.GetNodeLabels(netip.MustParseAddr("192.0.2.10"), allocatedHint(localClusterID)))
+	require.NoError(t, r.Start())
+	r.Stop()
+	r.Stop()
+	subscribe, unsubscribe = notifier.calls()
+	require.Equal(t, 1, subscribe, "repeated Start must not subscribe twice")
+	require.Equal(t, 1, unsubscribe, "repeated Stop must not unsubscribe twice")
+}
+
+func TestResolverLifecycleFailsClosedWithoutNotifierAndAfterStop(t *testing.T) {
+	r := NewResolver(nil, cmtypes.ClusterInfo{ID: localClusterID, Name: localCluster}, nil)
+	require.ErrorContains(t, r.Start(), "notifier")
+	r.Stop()
+	require.ErrorContains(t, r.Start(), "stopped")
+
+	notifier := &fakeNodeStateNotifier{}
+	r = NewResolver(nil, cmtypes.ClusterInfo{ID: localClusterID, Name: localCluster}, notifier)
+	require.NoError(t, r.Start())
+	r.Stop()
+	require.ErrorContains(t, r.Start(), "stopped")
+	subscribe, unsubscribe := notifier.calls()
+	require.Equal(t, 1, subscribe)
+	require.Equal(t, 1, unsubscribe)
+}
+
+func TestResolverLifecycleSerializesConcurrentStartAndStop(t *testing.T) {
+	notifier := &blockingNodeStateNotifier{
+		fakeNodeStateNotifier: &fakeNodeStateNotifier{},
+		subscribeEntered:      make(chan struct{}),
+		releaseSubscribe:      make(chan struct{}),
+	}
+	r := NewResolver(nil, cmtypes.ClusterInfo{ID: localClusterID, Name: localCluster}, notifier)
+
+	startResults := make(chan error, 2)
+	go func() { startResults <- r.Start() }()
+	<-notifier.subscribeEntered
+	go func() { startResults <- r.Start() }()
+	close(notifier.releaseSubscribe)
+	require.NoError(t, <-startResults)
+	require.NoError(t, <-startResults)
+
+	var stops sync.WaitGroup
+	stops.Add(2)
+	go func() {
+		defer stops.Done()
+		r.Stop()
+	}()
+	go func() {
+		defer stops.Done()
+		r.Stop()
+	}()
+	stops.Wait()
+
+	subscribe, unsubscribe := notifier.calls()
+	require.Equal(t, 1, subscribe)
+	require.Equal(t, 1, unsubscribe)
 }
 
 func TestResolverSelectsAuthoritativeIdentityScope(t *testing.T) {

--- a/pkg/hubble/parser/options/options.go
+++ b/pkg/hubble/parser/options/options.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	pb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	"github.com/cilium/cilium/pkg/monitor"
 )
 
@@ -20,6 +21,7 @@ type Options struct {
 	HubbleRedactSettings           HubbleRedactSettings
 	EnableNetworkPolicyCorrelation bool
 	SkipUnknownCGroupIDs           bool
+	NodeLabelsGetter               getters.NodeLabelsGetter
 
 	DropNotifyDecoder          DropNotifyDecoderFunc
 	DebugMsgDecoder            DebugMsgDecoderFunc
@@ -28,6 +30,14 @@ type Options struct {
 	PolicyVerdictNotifyDecoder PolicyVerdictNotifyDecoderFunc
 	TraceSockNotifyDecoder     TraceSockNotifyDecoderFunc
 	L34PacketDecoder           L34PacketDecoder
+}
+
+// WithNodeLabelsGetter configures directional node-label resolution. A nil
+// getter preserves the parser's existing behavior.
+func WithNodeLabelsGetter(g getters.NodeLabelsGetter) Option {
+	return func(opt *Options) {
+		opt.NodeLabelsGetter = g
+	}
 }
 
 // HubbleRedactSettings contains all hubble redact related options

--- a/pkg/hubble/parser/options/options_test.go
+++ b/pkg/hubble/parser/options/options_test.go
@@ -4,10 +4,32 @@
 package options
 
 import (
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 )
+
+type fakeNodeLabelsGetter struct{}
+
+func (*fakeNodeLabelsGetter) GetNodeLabels(netip.Addr, getters.NodeClusterHint) []string {
+	return nil
+}
+
+func TestWithNodeLabelsGetter(t *testing.T) {
+	var opts Options
+	require.Nil(t, opts.NodeLabelsGetter, "the zero value must preserve parser behavior")
+
+	getter := &fakeNodeLabelsGetter{}
+	WithNodeLabelsGetter(getter)(&opts)
+	require.Same(t, getter, opts.NodeLabelsGetter)
+
+	WithNodeLabelsGetter(nil)(&opts)
+	require.Nil(t, opts.NodeLabelsGetter)
+}
 
 func TestRedact(t *testing.T) {
 	opt := WithRedact(true, false, nil, nil)

--- a/pkg/hubble/parser/seven/parser.go
+++ b/pkg/hubble/parser/seven/parser.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/parser/errors"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	"github.com/cilium/cilium/pkg/hubble/parser/options"
+	"github.com/cilium/cilium/pkg/identity"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/k8s/utils"
 	ciliumLabels "github.com/cilium/cilium/pkg/labels"
@@ -36,6 +37,7 @@ type Parser struct {
 	ipGetter          getters.IPGetter
 	serviceGetter     getters.ServiceGetter
 	endpointGetter    getters.EndpointGetter
+	nodeLabelsGetter  getters.NodeLabelsGetter
 	opts              *options.Options
 }
 
@@ -83,6 +85,7 @@ func New(
 		ipGetter:          ipGetter,
 		serviceGetter:     serviceGetter,
 		endpointGetter:    endpointGetter,
+		nodeLabelsGetter:  args.NodeLabelsGetter,
 		opts:              args,
 	}, nil
 }
@@ -145,6 +148,18 @@ func (p *Parser) Decode(r *accesslog.LogRecord, decoded *flowpb.Flow) error {
 	decoded.L4 = l4
 	decoded.Source = srcEndpoint
 	decoded.Destination = dstEndpoint
+	decoded.SourceNodeLabels = nil
+	decoded.DestinationNodeLabels = nil
+	if p.nodeLabelsGetter != nil {
+		decoded.SourceNodeLabels = p.nodeLabelsGetter.GetNodeLabels(sourceIP, getters.NodeClusterHint{
+			Identity:      identity.NumericIdentity(r.SourceEndpoint.Identity),
+			IdentityKnown: r.SourceEndpoint.SecurityIdentityProvided,
+		})
+		decoded.DestinationNodeLabels = p.nodeLabelsGetter.GetNodeLabels(destinationIP, getters.NodeClusterHint{
+			Identity:      identity.NumericIdentity(r.DestinationEndpoint.Identity),
+			IdentityKnown: r.DestinationEndpoint.SecurityIdentityProvided,
+		})
+	}
 	decoded.Type = flowpb.FlowType_L7
 	decoded.SourceNames = sourceNames
 	decoded.DestinationNames = destinationNames

--- a/pkg/hubble/parser/seven/parser_test.go
+++ b/pkg/hubble/parser/seven/parser_test.go
@@ -4,7 +4,9 @@
 package seven
 
 import (
+	"context"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"testing"
 
@@ -13,11 +15,43 @@ import (
 	"github.com/stretchr/testify/require"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/parser/getters"
+	"github.com/cilium/cilium/pkg/hubble/parser/options"
 	"github.com/cilium/cilium/pkg/hubble/testutils"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
+
+type nodeLabelsCall struct {
+	ip   netip.Addr
+	hint getters.NodeClusterHint
+}
+
+type recordingNodeLabelsGetter struct {
+	calls   []nodeLabelsCall
+	results [][]string
+	onCall  func(netip.Addr, getters.NodeClusterHint) []string
+}
+
+func (g *recordingNodeLabelsGetter) GetNodeLabels(ip netip.Addr, hint getters.NodeClusterHint) []string {
+	callIndex := len(g.calls)
+	g.calls = append(g.calls, nodeLabelsCall{ip: ip, hint: hint})
+	if g.onCall != nil {
+		return g.onCall(ip, hint)
+	}
+	if callIndex < len(g.results) {
+		return g.results[callIndex]
+	}
+	return nil
+}
+
+type sevenEndpointInfoRegistryFunc func(*accesslog.EndpointInfo, netip.Addr)
+
+func (f sevenEndpointInfoRegistryFunc) FillEndpointInfo(_ context.Context, info *accesslog.EndpointInfo, addr netip.Addr) {
+	f(info, addr)
+}
 
 var (
 	fakeTimestamp = "2006-01-02T15:04:05.999999999Z"
@@ -125,4 +159,218 @@ func Test_decodeEndpoint(t *testing.T) {
 	}
 	ep := decodeEndpoint(epi, "kube-system", "hubble-ui")
 	assert.Equal(t, expected, ep)
+}
+
+func TestL7NodeLabelsUsesFinalIPOrientationAndIdentityProvenance(t *testing.T) {
+	tests := []struct {
+		name               string
+		sourceIP           netip.Addr
+		destinationIP      netip.Addr
+		addressing         accesslog.AddressingInfo
+		wantIPVersion      flowpb.IPVersion
+		wantSourceIdentity identity.NumericIdentity
+		wantDestIdentity   identity.NumericIdentity
+	}{
+		{
+			name:          "IPv4 security identity pointers",
+			sourceIP:      netip.MustParseAddr("192.0.2.10"),
+			destinationIP: netip.MustParseAddr("192.0.2.20"),
+			addressing: accesslog.AddressingInfo{
+				SrcSecIdentity: &identity.Identity{ID: 101},
+				SrcIdentity:    901,
+				DstSecIdentity: &identity.Identity{ID: 202},
+				DstIdentity:    902,
+			},
+			wantIPVersion:      flowpb.IPVersion_IPv4,
+			wantSourceIdentity: 101,
+			wantDestIdentity:   202,
+		},
+		{
+			name:          "IPv6 numeric identity fallbacks",
+			sourceIP:      netip.MustParseAddr("2001:db8::10"),
+			destinationIP: netip.MustParseAddr("2001:db8::20"),
+			addressing: accesslog.AddressingInfo{
+				SrcIdentity: 303,
+				DstIdentity: 404,
+			},
+			wantIPVersion:      flowpb.IPVersion_IPv6,
+			wantSourceIdentity: 303,
+			wantDestIdentity:   404,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			record := &accesslog.LogRecord{
+				Type:      accesslog.TypeSample,
+				Timestamp: fakeTimestamp,
+			}
+			addressing := tt.addressing
+			addressing.SrcIPPort = netip.AddrPortFrom(tt.sourceIP, 1234).String()
+			addressing.DstIPPort = netip.AddrPortFrom(tt.destinationIP, 4321).String()
+			registry := sevenEndpointInfoRegistryFunc(func(info *accesslog.EndpointInfo, addr netip.Addr) {
+				if addr.Is4() {
+					info.IPv4 = addr.String()
+				} else {
+					info.IPv6 = addr.String()
+				}
+			})
+			accesslog.LogTags.Addressing(t.Context(), addressing)(record, registry)
+
+			sourceLabels := []string{"node=source"}
+			destinationLabels := []string{"node=destination"}
+			getter := &recordingNodeLabelsGetter{results: [][]string{sourceLabels, destinationLabels}}
+			parser, err := New(
+				hivetest.Logger(t),
+				&testutils.NoopDNSGetter,
+				&testutils.NoopIPGetter,
+				&testutils.NoopServiceGetter,
+				&testutils.NoopEndpointGetter,
+				options.WithNodeLabelsGetter(getter),
+			)
+			require.NoError(t, err)
+
+			decoded := &flowpb.Flow{}
+			require.NoError(t, parser.Decode(record, decoded))
+
+			require.Equal(t, tt.wantIPVersion, decoded.GetIP().GetIpVersion())
+			require.Equal(t, []nodeLabelsCall{
+				{
+					ip: tt.sourceIP,
+					hint: getters.NodeClusterHint{
+						Identity:      tt.wantSourceIdentity,
+						IdentityKnown: true,
+					},
+				},
+				{
+					ip: tt.destinationIP,
+					hint: getters.NodeClusterHint{
+						Identity:      tt.wantDestIdentity,
+						IdentityKnown: true,
+					},
+				},
+			}, getter.calls)
+			require.Equal(t, sourceLabels, decoded.GetSourceNodeLabels())
+			require.Equal(t, destinationLabels, decoded.GetDestinationNodeLabels())
+			require.Same(t, &sourceLabels[0], &decoded.SourceNodeLabels[0], "source labels must be assigned without copying")
+			require.Same(t, &destinationLabels[0], &decoded.DestinationNodeLabels[0], "destination labels must be assigned without copying")
+		})
+	}
+}
+
+func TestL7IdentityProvenanceRejectsUserspaceFilledIdentity(t *testing.T) {
+	sourceIP := netip.MustParseAddr("192.0.2.30")
+	destinationIP := netip.MustParseAddr("192.0.2.40")
+	record := &accesslog.LogRecord{
+		Type:      accesslog.TypeSample,
+		Timestamp: fakeTimestamp,
+	}
+	addressing := accesslog.AddressingInfo{
+		SrcIPPort:      netip.AddrPortFrom(sourceIP, 1234).String(),
+		DstIPPort:      netip.AddrPortFrom(destinationIP, 4321).String(),
+		SrcSecIdentity: &identity.Identity{ID: identity.IdentityUnknown},
+		SrcIdentity:    505,
+		DstSecIdentity: &identity.Identity{ID: identity.IdentityUnknown},
+		DstIdentity:    606,
+	}
+	registry := sevenEndpointInfoRegistryFunc(func(info *accesslog.EndpointInfo, addr netip.Addr) {
+		info.IPv4 = addr.String()
+		info.Labels = labels.ParseLabelArray("k8s:io.cilium.k8s.policy.cluster=userspace-only")
+		switch addr {
+		case sourceIP:
+			require.Zero(t, info.Identity, "the unknown pointer must override the numeric source fallback")
+			info.Identity = 7001
+		case destinationIP:
+			require.Zero(t, info.Identity, "the unknown pointer must override the numeric destination fallback")
+			info.Identity = 7002
+		default:
+			t.Fatalf("unexpected endpoint address %s", addr)
+		}
+	})
+	accesslog.LogTags.Addressing(t.Context(), addressing)(record, registry)
+	require.Equal(t, uint64(7001), record.SourceEndpoint.Identity)
+	require.Equal(t, uint64(7002), record.DestinationEndpoint.Identity)
+	require.False(t, record.SourceEndpoint.SecurityIdentityProvided)
+	require.False(t, record.DestinationEndpoint.SecurityIdentityProvided)
+
+	getter := &recordingNodeLabelsGetter{
+		onCall: func(_ netip.Addr, hint getters.NodeClusterHint) []string {
+			if !hint.IdentityKnown {
+				return nil
+			}
+			return []string{"must-not-resolve=true"}
+		},
+	}
+	parser, err := New(
+		hivetest.Logger(t),
+		&testutils.NoopDNSGetter,
+		&testutils.NoopIPGetter,
+		&testutils.NoopServiceGetter,
+		&testutils.NoopEndpointGetter,
+		options.WithNodeLabelsGetter(getter),
+	)
+	require.NoError(t, err)
+
+	decoded := &flowpb.Flow{}
+	require.NoError(t, parser.Decode(record, decoded))
+
+	require.Equal(t, []nodeLabelsCall{
+		{ip: sourceIP, hint: getters.NodeClusterHint{Identity: 7001, IdentityKnown: false}},
+		{ip: destinationIP, hint: getters.NodeClusterHint{Identity: 7002, IdentityKnown: false}},
+	}, getter.calls)
+	require.Equal(t, "userspace-only", decoded.GetSource().GetClusterName(), "the fixture must expose tempting userspace cluster metadata")
+	require.Equal(t, "userspace-only", decoded.GetDestination().GetClusterName(), "the fixture must expose tempting userspace cluster metadata")
+	require.Empty(t, decoded.GetSourceNodeLabels())
+	require.Empty(t, decoded.GetDestinationNodeLabels())
+}
+
+func TestL7NodeLabelsNilGetterPreservesOutputAndClearsReuse(t *testing.T) {
+	sourceIP := netip.MustParseAddr("192.0.2.50")
+	destinationIP := netip.MustParseAddr("192.0.2.60")
+	record := &accesslog.LogRecord{
+		Type:      accesslog.TypeSample,
+		Timestamp: fakeTimestamp,
+	}
+	registry := sevenEndpointInfoRegistryFunc(func(info *accesslog.EndpointInfo, addr netip.Addr) {
+		info.IPv4 = addr.String()
+	})
+	accesslog.LogTags.Addressing(t.Context(), accesslog.AddressingInfo{
+		SrcIPPort:   netip.AddrPortFrom(sourceIP, 1234).String(),
+		DstIPPort:   netip.AddrPortFrom(destinationIP, 4321).String(),
+		SrcIdentity: 101,
+		DstIdentity: 202,
+	})(record, registry)
+
+	baselineParser, err := New(
+		hivetest.Logger(t),
+		&testutils.NoopDNSGetter,
+		&testutils.NoopIPGetter,
+		&testutils.NoopServiceGetter,
+		&testutils.NoopEndpointGetter,
+	)
+	require.NoError(t, err)
+	baseline := &flowpb.Flow{}
+	require.NoError(t, baselineParser.Decode(record, baseline))
+
+	recorder := &recordingNodeLabelsGetter{results: [][]string{{"must-not-be-called"}}}
+	nilParser, err := New(
+		hivetest.Logger(t),
+		&testutils.NoopDNSGetter,
+		&testutils.NoopIPGetter,
+		&testutils.NoopServiceGetter,
+		&testutils.NoopEndpointGetter,
+		options.WithNodeLabelsGetter(recorder),
+		options.WithNodeLabelsGetter(nil),
+	)
+	require.NoError(t, err)
+	reused := &flowpb.Flow{
+		SourceNodeLabels:      []string{"stale-source-label"},
+		DestinationNodeLabels: []string{"stale-destination-label"},
+	}
+	require.NoError(t, nilParser.Decode(record, reused))
+
+	require.Empty(t, recorder.calls, "a final nil option must disable the getter")
+	require.Empty(t, reused.GetSourceNodeLabels())
+	require.Empty(t, reused.GetDestinationNodeLabels())
+	require.Equal(t, baseline, reused, "nil getter output must match the existing parser behavior")
 }

--- a/pkg/hubble/parser/sock/parser.go
+++ b/pkg/hubble/parser/sock/parser.go
@@ -21,14 +21,15 @@ import (
 
 // Parser is a parser for SockTraceNotify payloads
 type Parser struct {
-	log            *slog.Logger
-	endpointGetter getters.EndpointGetter
-	identityGetter getters.IdentityGetter
-	dnsGetter      getters.DNSGetter
-	ipGetter       getters.IPGetter
-	serviceGetter  getters.ServiceGetter
-	cgroupGetter   getters.PodMetadataGetter
-	epResolver     *common.EndpointResolver
+	log              *slog.Logger
+	endpointGetter   getters.EndpointGetter
+	identityGetter   getters.IdentityGetter
+	dnsGetter        getters.DNSGetter
+	ipGetter         getters.IPGetter
+	serviceGetter    getters.ServiceGetter
+	cgroupGetter     getters.PodMetadataGetter
+	nodeLabelsGetter getters.NodeLabelsGetter
+	epResolver       *common.EndpointResolver
 
 	traceSockNotifyDecoder options.TraceSockNotifyDecoderFunc
 
@@ -65,6 +66,7 @@ func New(log *slog.Logger,
 		ipGetter:               ipGetter,
 		serviceGetter:          serviceGetter,
 		cgroupGetter:           cgroupGetter,
+		nodeLabelsGetter:       args.NodeLabelsGetter,
 		epResolver:             common.NewEndpointResolver(log, endpointGetter, identityGetter, ipGetter),
 		traceSockNotifyDecoder: args.TraceSockNotifyDecoder,
 		skipUnknownCGroupIDs:   args.SkipUnknownCGroupIDs,
@@ -110,6 +112,17 @@ func (p *Parser) Decode(data []byte, decoded *flowpb.Flow) error {
 	}
 	srcEndpoint := p.epResolver.ResolveEndpoint(srcIP, 0, datapathContext)
 	dstEndpoint := p.epResolver.ResolveEndpoint(dstIP, 0, datapathContext)
+	var srcNodeLabels, dstNodeLabels []string
+	if p.nodeLabelsGetter != nil {
+		srcNodeLabels = p.nodeLabelsGetter.GetNodeLabels(srcIP, getters.NodeClusterHint{
+			IdentityKnown: false,
+			LocalEndpoint: true,
+		})
+		dstNodeLabels = p.nodeLabelsGetter.GetNodeLabels(dstIP, getters.NodeClusterHint{
+			IdentityKnown: false,
+			LocalEndpoint: false,
+		})
+	}
 
 	// On the reverse path, source and destination IP of the packet are reversed
 	isRevNat := decodeRevNat(sock.XlatePoint)
@@ -117,8 +130,11 @@ func (p *Parser) Decode(data []byte, decoded *flowpb.Flow) error {
 		srcIP, dstIP = dstIP, srcIP
 		srcPort, dstPort = dstPort, srcPort
 		srcEndpoint, dstEndpoint = dstEndpoint, srcEndpoint
+		srcNodeLabels, dstNodeLabels = dstNodeLabels, srcNodeLabels
 	}
 
+	decoded.SourceNodeLabels = srcNodeLabels
+	decoded.DestinationNodeLabels = dstNodeLabels
 	decoded.Verdict = decodeVerdict(sock.XlatePoint)
 	decoded.IP = decodeL3(srcIP, dstIP, ipVersion)
 	decoded.L4 = decodeL4(sock.L4Proto, srcPort, dstPort)

--- a/pkg/hubble/parser/sock/parser_test.go
+++ b/pkg/hubble/parser/sock/parser_test.go
@@ -43,6 +43,25 @@ func mustParseIP(s string) (res types.IPv6) {
 	return res
 }
 
+type nodeLabelsCall struct {
+	ip   netip.Addr
+	hint getters.NodeClusterHint
+}
+
+type recordingNodeLabelsGetter struct {
+	calls   []nodeLabelsCall
+	results [][]string
+}
+
+func (g *recordingNodeLabelsGetter) GetNodeLabels(ip netip.Addr, hint getters.NodeClusterHint) []string {
+	callIndex := len(g.calls)
+	g.calls = append(g.calls, nodeLabelsCall{ip: ip, hint: hint})
+	if callIndex < len(g.results) {
+		return g.results[callIndex]
+	}
+	return nil
+}
+
 func TestDecodeSockEvent(t *testing.T) {
 	const (
 		xwingIPv4                 = "192.168.10.10"
@@ -464,4 +483,213 @@ func TestDecodeSockEvent(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDecodeNodeLabelsUsesLocalSourceProvenance(t *testing.T) {
+	const (
+		sourceIP = "192.0.2.10"
+		destIP   = "198.51.100.20"
+		cgroupID = 1010
+	)
+	localLabels := []string{"topology.kubernetes.io/zone=local-a"}
+	getter := &recordingNodeLabelsGetter{results: [][]string{localLabels, nil}}
+	cgroupGetter := &testutils.FakePodMetadataGetter{
+		OnGetPodMetadataForContainer: func(id uint64) *cgroupManager.PodMetadata {
+			require.Equal(t, uint64(cgroupID), id)
+			return &cgroupManager.PodMetadata{IPs: []string{sourceIP}}
+		},
+	}
+	parser, err := New(
+		hivetest.Logger(t), nil, nil, nil, nil, nil, cgroupGetter,
+		options.WithNodeLabelsGetter(getter),
+	)
+	require.NoError(t, err)
+
+	msg := monitor.TraceSockNotify{
+		Type:       monitorAPI.MessageTypeTraceSock,
+		XlatePoint: monitor.XlatePointPreDirectionFwd,
+		DstIP:      mustParseIP(destIP),
+		DstPort:    8080,
+		CgroupId:   cgroupID,
+		L4Proto:    monitor.L4ProtocolTCP,
+	}
+	buf := &bytes.Buffer{}
+	require.NoError(t, binary.Write(buf, binary.NativeEndian, &msg))
+	decoded := &flowpb.Flow{}
+	require.NoError(t, parser.Decode(buf.Bytes(), decoded))
+
+	require.Equal(t, []nodeLabelsCall{
+		{
+			ip: netip.MustParseAddr(sourceIP),
+			hint: getters.NodeClusterHint{
+				Identity:      identity.IdentityUnknown,
+				IdentityKnown: false,
+				LocalEndpoint: true,
+			},
+		},
+		{
+			ip: netip.MustParseAddr(destIP),
+			hint: getters.NodeClusterHint{
+				Identity:      identity.IdentityUnknown,
+				IdentityKnown: false,
+				LocalEndpoint: false,
+			},
+		},
+	}, getter.calls)
+	require.Equal(t, localLabels, decoded.GetSourceNodeLabels())
+	require.Empty(t, decoded.GetDestinationNodeLabels())
+	require.Same(t, &localLabels[0], &decoded.SourceNodeLabels[0], "getter results must be assigned without copying")
+}
+
+func TestDecodeReverseNATSwapsLabelsWithFlowOrientation(t *testing.T) {
+	const (
+		initialSourceIP = "192.0.2.10"
+		initialDestIP   = "198.51.100.20"
+		cgroupID        = 1010
+		initialSourceEP = 110
+		initialDestEP   = 220
+	)
+	localLabels := []string{"topology.kubernetes.io/zone=local-a"}
+	getter := &recordingNodeLabelsGetter{results: [][]string{localLabels, nil}}
+	cgroupGetter := &testutils.FakePodMetadataGetter{
+		OnGetPodMetadataForContainer: func(id uint64) *cgroupManager.PodMetadata {
+			require.Equal(t, uint64(cgroupID), id)
+			return &cgroupManager.PodMetadata{IPs: []string{initialSourceIP}}
+		},
+	}
+	endpointGetter := &testutils.FakeEndpointGetter{
+		OnGetEndpointInfo: func(ip netip.Addr) (getters.EndpointInfo, bool) {
+			switch ip.String() {
+			case initialSourceIP:
+				return &testutils.FakeEndpointInfo{ID: initialSourceEP, PodName: "initial-source"}, true
+			case initialDestIP:
+				return &testutils.FakeEndpointInfo{ID: initialDestEP, PodName: "initial-destination"}, true
+			default:
+				t.Fatalf("unexpected endpoint lookup for %s", ip)
+				return nil, false
+			}
+		},
+	}
+	dnsGetter := &testutils.FakeFQDNCache{
+		OnGetNamesOf: func(epID uint32, ip netip.Addr) []string {
+			switch {
+			case epID == initialSourceEP && ip.String() == initialDestIP:
+				return []string{"initial-destination.example"}
+			case epID == initialDestEP && ip.String() == initialSourceIP:
+				return []string{"initial-source.example"}
+			default:
+				t.Fatalf("unexpected DNS lookup from endpoint %d for %s", epID, ip)
+				return nil
+			}
+		},
+	}
+	serviceGetter := &testutils.FakeServiceGetter{
+		OnGetServiceByAddr: func(ip netip.Addr, port uint16) *flowpb.Service {
+			switch {
+			case ip.String() == initialDestIP && port == 8080:
+				return &flowpb.Service{Name: "initial-destination"}
+			case ip.String() == initialSourceIP && port == 0:
+				return &flowpb.Service{Name: "initial-source"}
+			default:
+				t.Fatalf("unexpected service lookup for %s:%d", ip, port)
+				return nil
+			}
+		},
+	}
+	parser, err := New(
+		hivetest.Logger(t), endpointGetter, nil, dnsGetter, nil, serviceGetter, cgroupGetter,
+		options.WithNodeLabelsGetter(getter),
+	)
+	require.NoError(t, err)
+
+	msg := monitor.TraceSockNotify{
+		Type:       monitorAPI.MessageTypeTraceSock,
+		XlatePoint: monitor.XlatePointPostDirectionRev,
+		DstIP:      mustParseIP(initialDestIP),
+		DstPort:    8080,
+		CgroupId:   cgroupID,
+		L4Proto:    monitor.L4ProtocolTCP,
+	}
+	buf := &bytes.Buffer{}
+	require.NoError(t, binary.Write(buf, binary.NativeEndian, &msg))
+	decoded := &flowpb.Flow{}
+	require.NoError(t, parser.Decode(buf.Bytes(), decoded))
+
+	require.Equal(t, initialDestIP, decoded.GetIP().GetSource())
+	require.Equal(t, initialSourceIP, decoded.GetIP().GetDestination())
+	require.Equal(t, uint32(initialDestEP), decoded.GetSource().GetID())
+	require.Equal(t, "initial-destination", decoded.GetSource().GetPodName())
+	require.Equal(t, uint32(initialSourceEP), decoded.GetDestination().GetID())
+	require.Equal(t, "initial-source", decoded.GetDestination().GetPodName())
+	require.Equal(t, "initial-destination", decoded.GetSourceService().GetName())
+	require.Equal(t, "initial-source", decoded.GetDestinationService().GetName())
+	require.Equal(t, []string{"initial-destination.example"}, decoded.GetSourceNames())
+	require.Equal(t, []string{"initial-source.example"}, decoded.GetDestinationNames())
+	require.Equal(t, []nodeLabelsCall{
+		{
+			ip: netip.MustParseAddr(initialSourceIP),
+			hint: getters.NodeClusterHint{
+				Identity:      identity.IdentityUnknown,
+				IdentityKnown: false,
+				LocalEndpoint: true,
+			},
+		},
+		{
+			ip: netip.MustParseAddr(initialDestIP),
+			hint: getters.NodeClusterHint{
+				Identity:      identity.IdentityUnknown,
+				IdentityKnown: false,
+				LocalEndpoint: false,
+			},
+		},
+	}, getter.calls)
+	require.Empty(t, decoded.GetSourceNodeLabels())
+	require.Equal(t, localLabels, decoded.GetDestinationNodeLabels())
+	require.Same(t, &localLabels[0], &decoded.DestinationNodeLabels[0], "swapped getter results must be assigned without copying")
+}
+
+func TestDecodeNodeLabelsNilGetterPreservesOutputAndClearsReuse(t *testing.T) {
+	const (
+		sourceIP = "192.0.2.10"
+		destIP   = "198.51.100.20"
+		cgroupID = 1010
+	)
+	cgroupGetter := &testutils.FakePodMetadataGetter{
+		OnGetPodMetadataForContainer: func(uint64) *cgroupManager.PodMetadata {
+			return &cgroupManager.PodMetadata{IPs: []string{sourceIP}}
+		},
+	}
+	msg := monitor.TraceSockNotify{
+		Type:       monitorAPI.MessageTypeTraceSock,
+		XlatePoint: monitor.XlatePointPreDirectionFwd,
+		DstIP:      mustParseIP(destIP),
+		DstPort:    8080,
+		CgroupId:   cgroupID,
+		L4Proto:    monitor.L4ProtocolTCP,
+	}
+	buf := &bytes.Buffer{}
+	require.NoError(t, binary.Write(buf, binary.NativeEndian, &msg))
+
+	baselineParser, err := New(hivetest.Logger(t), nil, nil, nil, nil, nil, cgroupGetter)
+	require.NoError(t, err)
+	baseline := &flowpb.Flow{}
+	require.NoError(t, baselineParser.Decode(buf.Bytes(), baseline))
+
+	recorder := &recordingNodeLabelsGetter{results: [][]string{{"must-not-be-called"}}}
+	nilGetterParser, err := New(
+		hivetest.Logger(t), nil, nil, nil, nil, nil, cgroupGetter,
+		options.WithNodeLabelsGetter(recorder),
+		options.WithNodeLabelsGetter(nil),
+	)
+	require.NoError(t, err)
+	reused := &flowpb.Flow{
+		SourceNodeLabels:      []string{"stale-source-label"},
+		DestinationNodeLabels: []string{"stale-destination-label"},
+	}
+	require.NoError(t, nilGetterParser.Decode(buf.Bytes(), reused))
+
+	require.Empty(t, recorder.calls, "a final nil option must disable the getter")
+	require.Empty(t, reused.GetSourceNodeLabels())
+	require.Empty(t, reused.GetDestinationNodeLabels())
+	require.Equal(t, baseline, reused, "nil getter output must match existing socket parser behavior")
 }

--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/parser/errors"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	"github.com/cilium/cilium/pkg/hubble/parser/options"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/monitor"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
@@ -29,13 +30,14 @@ import (
 
 // Parser is a parser for L3/L4 payloads
 type Parser struct {
-	log            *slog.Logger
-	endpointGetter getters.EndpointGetter
-	identityGetter getters.IdentityGetter
-	dnsGetter      getters.DNSGetter
-	ipGetter       getters.IPGetter
-	serviceGetter  getters.ServiceGetter
-	linkGetter     getters.LinkGetter
+	log              *slog.Logger
+	endpointGetter   getters.EndpointGetter
+	identityGetter   getters.IdentityGetter
+	dnsGetter        getters.DNSGetter
+	ipGetter         getters.IPGetter
+	serviceGetter    getters.ServiceGetter
+	linkGetter       getters.LinkGetter
+	nodeLabelsGetter getters.NodeLabelsGetter
 
 	dropNotifyDecoder          options.DropNotifyDecoderFunc
 	traceNotifyDecoder         options.TraceNotifyDecoderFunc
@@ -165,6 +167,7 @@ func New(
 		ipGetter:                   ipGetter,
 		serviceGetter:              serviceGetter,
 		linkGetter:                 linkGetter,
+		nodeLabelsGetter:           args.NodeLabelsGetter,
 		dropNotifyDecoder:          args.DropNotifyDecoder,
 		debugCaptureDecoder:        args.DebugCaptureDecoder,
 		traceNotifyDecoder:         args.TraceNotifyDecoder,
@@ -267,6 +270,18 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 	}
 
 	srcLabelID, dstLabelID := decodeSecurityIdentities(dn, tn, pvn)
+	decoded.SourceNodeLabels = nil
+	decoded.DestinationNodeLabels = nil
+	if p.nodeLabelsGetter != nil {
+		decoded.SourceNodeLabels = p.nodeLabelsGetter.GetNodeLabels(srcIP, getters.NodeClusterHint{
+			Identity:      identity.NumericIdentity(srcLabelID),
+			IdentityKnown: identity.NumericIdentity(srcLabelID) != identity.IdentityUnknown,
+		})
+		decoded.DestinationNodeLabels = p.nodeLabelsGetter.GetNodeLabels(dstIP, getters.NodeClusterHint{
+			Identity:      identity.NumericIdentity(dstLabelID),
+			IdentityKnown: identity.NumericIdentity(dstLabelID) != identity.IdentityUnknown,
+		})
+	}
 	datapathContext := common.DatapathContext{
 		SrcIP:                 srcIP,
 		SrcLabelID:            srcLabelID,

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -51,6 +51,24 @@ type ipTuple struct {
 	src, dst netip.Addr
 }
 
+type nodeLabelsCall struct {
+	ip   netip.Addr
+	hint getters.NodeClusterHint
+}
+
+type recordingNodeLabelsGetter struct {
+	calls           []nodeLabelsCall
+	onGetNodeLabels func(netip.Addr, getters.NodeClusterHint) []string
+}
+
+func (g *recordingNodeLabelsGetter) GetNodeLabels(ip netip.Addr, hint getters.NodeClusterHint) []string {
+	g.calls = append(g.calls, nodeLabelsCall{ip: ip, hint: hint})
+	if g.onGetNodeLabels != nil {
+		return g.onGetNodeLabels(ip, hint)
+	}
+	return nil
+}
+
 var (
 	localIP  = netip.MustParseAddr("1.2.3.4")
 	localEP  = uint16(1234)
@@ -1566,6 +1584,243 @@ func TestTraceNotifyOriginalIP(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "10.0.0.2", f.IP.Source)
 	assert.Empty(t, f.IP.SourceXlated)
+}
+
+func TestDecodeNodeLabelsUsesFinalNATOrientationAndRawIdentities(t *testing.T) {
+	packetSourceIP := netip.MustParseAddr("10.0.0.2")
+	finalSourceIP := netip.MustParseAddr("192.0.2.10")
+	destinationIP := netip.MustParseAddr("10.0.0.3")
+	sourceIdentity := identity.GetMinimalAllocationIdentity(7)
+	destinationIdentity := identity.GetMinimalAllocationIdentity(9)
+	sourceLabels := []string{"topology.kubernetes.io/zone=remote-a"}
+	destinationLabels := []string{"topology.kubernetes.io/zone=unknown"}
+
+	getter := &recordingNodeLabelsGetter{
+		onGetNodeLabels: func(ip netip.Addr, _ getters.NodeClusterHint) []string {
+			switch ip {
+			case finalSourceIP:
+				return sourceLabels
+			case destinationIP:
+				return destinationLabels
+			default:
+				t.Fatalf("unexpected node-label lookup for %s", ip)
+				return nil
+			}
+		},
+	}
+	parser, err := New(
+		hivetest.Logger(t),
+		&testutils.NoopEndpointGetter,
+		&testutils.NoopIdentityGetter,
+		&testutils.NoopDNSGetter,
+		&testutils.NoopIPGetter,
+		&testutils.NoopServiceGetter,
+		&testutils.NoopLinkGetter,
+		options.WithNodeLabelsGetter(getter),
+	)
+	require.NoError(t, err)
+
+	event := monitor.TraceNotify{
+		Type:     byte(monitorAPI.MessageTypeTrace),
+		Version:  monitor.TraceNotifyVersion1,
+		SrcLabel: sourceIdentity,
+		DstLabel: destinationIdentity,
+		OrigIP:   types.IPv6{192, 0, 2, 10},
+	}
+	data, err := testutils.CreateL3L4Payload(
+		event,
+		&layers.Ethernet{SrcMAC: srcMAC, DstMAC: dstMAC, EthernetType: layers.EthernetTypeIPv4},
+		&layers.IPv4{SrcIP: packetSourceIP.AsSlice(), DstIP: destinationIP.AsSlice()},
+	)
+	require.NoError(t, err)
+
+	flow := &flowpb.Flow{}
+	require.NoError(t, parser.Decode(data, flow))
+
+	require.Equal(t, finalSourceIP.String(), flow.GetIP().GetSource())
+	require.Equal(t, packetSourceIP.String(), flow.GetIP().GetSourceXlated())
+	require.Equal(t, []nodeLabelsCall{
+		{
+			ip: finalSourceIP,
+			hint: getters.NodeClusterHint{
+				Identity:      sourceIdentity,
+				IdentityKnown: true,
+			},
+		},
+		{
+			ip: destinationIP,
+			hint: getters.NodeClusterHint{
+				Identity:      destinationIdentity,
+				IdentityKnown: true,
+			},
+		},
+	}, getter.calls)
+	require.Equal(t, sourceLabels, flow.GetSourceNodeLabels())
+	require.Equal(t, destinationLabels, flow.GetDestinationNodeLabels())
+	require.Same(t, &sourceLabels[0], &flow.SourceNodeLabels[0])
+	require.Same(t, &destinationLabels[0], &flow.DestinationNodeLabels[0])
+}
+
+func TestDecodeNodeLabelsNilGetterPreservesExistingOutput(t *testing.T) {
+	sourceIP := netip.MustParseAddr("10.0.0.2")
+	destinationIP := netip.MustParseAddr("10.0.0.3")
+	event := monitor.TraceNotify{
+		Type:     byte(monitorAPI.MessageTypeTrace),
+		Version:  monitor.TraceNotifyVersion2,
+		SrcLabel: identity.GetMinimalAllocationIdentity(1),
+		DstLabel: identity.GetMinimalAllocationIdentity(2),
+	}
+	data, err := testutils.CreateL3L4Payload(
+		event,
+		&layers.Ethernet{SrcMAC: srcMAC, DstMAC: dstMAC, EthernetType: layers.EthernetTypeIPv4},
+		&layers.IPv4{SrcIP: sourceIP.AsSlice(), DstIP: destinationIP.AsSlice()},
+	)
+	require.NoError(t, err)
+
+	getter := &recordingNodeLabelsGetter{
+		onGetNodeLabels: func(ip netip.Addr, _ getters.NodeClusterHint) []string {
+			return []string{"node=" + ip.String()}
+		},
+	}
+	disabledGetter := &recordingNodeLabelsGetter{
+		onGetNodeLabels: func(netip.Addr, getters.NodeClusterHint) []string {
+			t.Fatal("nil node-label getter must not be called")
+			return nil
+		},
+	}
+	enrichedParser, err := New(hivetest.Logger(t), nil, nil, nil, nil, nil, nil, options.WithNodeLabelsGetter(getter))
+	require.NoError(t, err)
+	nilGetterParser, err := New(
+		hivetest.Logger(t), nil, nil, nil, nil, nil, nil,
+		options.WithNodeLabelsGetter(disabledGetter),
+		options.WithNodeLabelsGetter(nil),
+	)
+	require.NoError(t, err)
+
+	enriched := &flowpb.Flow{}
+	require.NoError(t, enrichedParser.Decode(data, enriched))
+	require.Len(t, getter.calls, 2)
+	require.NotEmpty(t, enriched.GetSourceNodeLabels())
+	require.NotEmpty(t, enriched.GetDestinationNodeLabels())
+
+	withoutGetter := &flowpb.Flow{
+		SourceNodeLabels:      []string{"stale-source-label"},
+		DestinationNodeLabels: []string{"stale-destination-label"},
+	}
+	require.NoError(t, nilGetterParser.Decode(data, withoutGetter))
+	require.Empty(t, disabledGetter.calls)
+	require.Empty(t, withoutGetter.GetSourceNodeLabels())
+	require.Empty(t, withoutGetter.GetDestinationNodeLabels())
+
+	enrichedWithoutNewFields := proto.Clone(enriched).(*flowpb.Flow)
+	enrichedWithoutNewFields.SourceNodeLabels = nil
+	enrichedWithoutNewFields.DestinationNodeLabels = nil
+	require.Empty(t, cmp.Diff(enrichedWithoutNewFields, withoutGetter, protocmp.Transform()))
+}
+
+func TestDecodeNodeLabelsClusterCollisionUsesOnlyRawIdentityProvenance(t *testing.T) {
+	collidingIP := netip.MustParseAddr("10.0.0.2")
+	destinationIP := netip.MustParseAddr("10.0.0.3")
+	localIdentity := identity.GetMinimalAllocationIdentity(1)
+	remoteIdentity := identity.GetMinimalAllocationIdentity(7)
+	remoteLabels := []string{"topology.kubernetes.io/zone=remote-a"}
+	endpointGetter := &testutils.FakeEndpointGetter{
+		OnGetEndpointInfo: func(ip netip.Addr) (getters.EndpointInfo, bool) {
+			if ip != collidingIP {
+				return nil, false
+			}
+			return &testutils.FakeEndpointInfo{
+				ID:           1234,
+				Identity:     localIdentity,
+				PodName:      "colliding-local-pod",
+				PodNamespace: "default",
+				Labels: []string{
+					"k8s:io.cilium.k8s.policy.cluster=local-cluster",
+				},
+			}, true
+		},
+	}
+
+	for _, tc := range []struct {
+		name              string
+		rawSourceIdentity identity.NumericIdentity
+		wantKnown         bool
+		wantLabels        []string
+	}{
+		{
+			name:              "remote raw identity ignores colliding local metadata",
+			rawSourceIdentity: remoteIdentity,
+			wantKnown:         true,
+			wantLabels:        remoteLabels,
+		},
+		{
+			name:              "raw unknown does not become local provenance",
+			rawSourceIdentity: identity.IdentityUnknown,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			getter := &recordingNodeLabelsGetter{
+				onGetNodeLabels: func(_ netip.Addr, hint getters.NodeClusterHint) []string {
+					if hint.IdentityKnown && hint.Identity == remoteIdentity {
+						return remoteLabels
+					}
+					return nil
+				},
+			}
+			parser, err := New(
+				hivetest.Logger(t),
+				endpointGetter,
+				&testutils.NoopIdentityGetter,
+				&testutils.NoopDNSGetter,
+				&testutils.NoopIPGetter,
+				&testutils.NoopServiceGetter,
+				&testutils.NoopLinkGetter,
+				options.WithNodeLabelsGetter(getter),
+			)
+			require.NoError(t, err)
+
+			event := monitor.TraceNotify{
+				Type:     byte(monitorAPI.MessageTypeTrace),
+				Version:  monitor.TraceNotifyVersion2,
+				SrcLabel: tc.rawSourceIdentity,
+			}
+			data, err := testutils.CreateL3L4Payload(
+				event,
+				&layers.Ethernet{SrcMAC: srcMAC, DstMAC: dstMAC, EthernetType: layers.EthernetTypeIPv4},
+				&layers.IPv4{SrcIP: collidingIP.AsSlice(), DstIP: destinationIP.AsSlice()},
+			)
+			require.NoError(t, err)
+
+			flow := &flowpb.Flow{}
+			require.NoError(t, parser.Decode(data, flow))
+
+			require.Equal(t, "colliding-local-pod", flow.GetSource().GetPodName())
+			require.Equal(t, "local-cluster", flow.GetSource().GetClusterName())
+			require.Equal(t, []nodeLabelsCall{
+				{
+					ip: collidingIP,
+					hint: getters.NodeClusterHint{
+						Identity:      tc.rawSourceIdentity,
+						IdentityKnown: tc.wantKnown,
+					},
+				},
+				{
+					ip: destinationIP,
+					hint: getters.NodeClusterHint{
+						Identity: identity.IdentityUnknown,
+					},
+				},
+			}, getter.calls)
+			require.Equal(t, tc.wantLabels, flow.GetSourceNodeLabels())
+			require.Empty(t, flow.GetDestinationNodeLabels())
+
+			if tc.rawSourceIdentity == identity.IdentityUnknown {
+				require.Equal(t, localIdentity.Uint32(), flow.GetSource().GetIdentity())
+			} else {
+				require.Equal(t, remoteIdentity.Uint32(), flow.GetSource().GetIdentity())
+			}
+		})
+	}
 }
 
 func TestICMP(t *testing.T) {

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -244,6 +244,51 @@ func (ipc *IPCache) getHostIPCacheRLocked(ip string) (net.IP, uint8) {
 	return ipKeyPair.IP, ipKeyPair.Key
 }
 
+// GetHostIP returns the host IP for the exact endpoint or single-host prefix
+// representation of addr in the same cluster scope.
+func (ipc *IPCache) GetHostIP(addr cmtypes.AddrCluster) (netip.Addr, bool) {
+	if !addr.Addr().IsValid() {
+		return netip.Addr{}, false
+	}
+
+	endpointKey := addr.String()
+	prefixKey := addr.AsPrefixCluster().String()
+
+	ipc.mutex.RLock()
+	defer ipc.mutex.RUnlock()
+
+	lookup := func(key string) (host netip.Addr, exists, valid bool) {
+		if _, exists = ipc.ipToIdentityCache[key]; !exists {
+			return netip.Addr{}, false, false
+		}
+
+		pair, found := ipc.ipToHostIPCache[key]
+		if !found {
+			return netip.Addr{}, true, false
+		}
+
+		host, valid = netip.AddrFromSlice(pair.IP)
+		return host.Unmap(), true, valid
+	}
+
+	endpointHost, endpointExists, endpointValid := lookup(endpointKey)
+	prefixHost, prefixExists, prefixValid := lookup(prefixKey)
+
+	if endpointExists && (!endpointValid || prefixExists && (!prefixValid || endpointHost != prefixHost)) {
+		return netip.Addr{}, false
+	}
+	if prefixExists && !prefixValid {
+		return netip.Addr{}, false
+	}
+	if endpointExists {
+		return endpointHost, true
+	}
+	if prefixExists {
+		return prefixHost, true
+	}
+	return netip.Addr{}, false
+}
+
 // GetK8sMetadata returns Kubernetes metadata for the given IP address.
 // The returned pointer should *never* be modified.
 func (ipc *IPCache) GetK8sMetadata(ip netip.Addr) *K8sMetadata {

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -244,11 +244,25 @@ func (ipc *IPCache) getHostIPCacheRLocked(ip string) (net.IP, uint8) {
 	return ipKeyPair.IP, ipKeyPair.Key
 }
 
-// GetHostIP returns the host IP for the exact endpoint or single-host prefix
-// representation of addr in the same cluster scope.
-func (ipc *IPCache) GetHostIP(addr cmtypes.AddrCluster) (netip.Addr, bool) {
+// HostIPLookupStatus describes the result of an exact host IP lookup.
+type HostIPLookupStatus uint8
+
+const (
+	// HostIPLookupAbsent means neither exact identity representation exists.
+	HostIPLookupAbsent HostIPLookupStatus = iota
+	// HostIPLookupResolved means every existing exact representation contains
+	// the same valid host IP.
+	HostIPLookupResolved
+	// HostIPLookupInvalid means the input is invalid or an exact representation
+	// is missing a valid host IP or conflicts with another representation.
+	HostIPLookupInvalid
+)
+
+// LookupHostIP returns the host IP and status for the exact endpoint and
+// single-host prefix representations of addr in the same cluster scope.
+func (ipc *IPCache) LookupHostIP(addr cmtypes.AddrCluster) (netip.Addr, HostIPLookupStatus) {
 	if !addr.Addr().IsValid() {
-		return netip.Addr{}, false
+		return netip.Addr{}, HostIPLookupInvalid
 	}
 
 	endpointKey := addr.String()
@@ -274,19 +288,25 @@ func (ipc *IPCache) GetHostIP(addr cmtypes.AddrCluster) (netip.Addr, bool) {
 	endpointHost, endpointExists, endpointValid := lookup(endpointKey)
 	prefixHost, prefixExists, prefixValid := lookup(prefixKey)
 
-	if endpointExists && (!endpointValid || prefixExists && (!prefixValid || endpointHost != prefixHost)) {
-		return netip.Addr{}, false
+	if !endpointExists && !prefixExists {
+		return netip.Addr{}, HostIPLookupAbsent
 	}
-	if prefixExists && !prefixValid {
-		return netip.Addr{}, false
+	if endpointExists && !endpointValid || prefixExists && !prefixValid ||
+		endpointExists && prefixExists && endpointHost != prefixHost {
+		return netip.Addr{}, HostIPLookupInvalid
 	}
 	if endpointExists {
-		return endpointHost, true
+		return endpointHost, HostIPLookupResolved
 	}
-	if prefixExists {
-		return prefixHost, true
-	}
-	return netip.Addr{}, false
+	return prefixHost, HostIPLookupResolved
+}
+
+// GetHostIP returns the host IP for the exact endpoint or single-host prefix
+// representation of addr in the same cluster scope. Invalid and ambiguous
+// mappings retain the compatibility behavior of returning ok=false.
+func (ipc *IPCache) GetHostIP(addr cmtypes.AddrCluster) (netip.Addr, bool) {
+	hostIP, status := ipc.LookupHostIP(addr)
+	return hostIP, status == HostIPLookupResolved
 }
 
 // GetK8sMetadata returns Kubernetes metadata for the given IP address.

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -71,18 +71,20 @@ func TestGetHostIP(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		entries []cacheEntry
-		addr    cmtypes.AddrCluster
-		want    netip.Addr
-		wantOK  bool
+		name       string
+		entries    []cacheEntry
+		addr       cmtypes.AddrCluster
+		want       netip.Addr
+		wantStatus HostIPLookupStatus
+		wantOK     bool
 	}{
 		{
-			name:    "local IPv4 endpoint",
-			entries: []cacheEntry{{key: "10.0.0.1", hostIP: net.ParseIP("192.0.2.1")}},
-			addr:    cmtypes.MustParseAddrCluster("10.0.0.1"),
-			want:    netip.MustParseAddr("192.0.2.1"),
-			wantOK:  true,
+			name:       "local IPv4 endpoint",
+			entries:    []cacheEntry{{key: "10.0.0.1", hostIP: net.ParseIP("192.0.2.1")}},
+			addr:       cmtypes.MustParseAddrCluster("10.0.0.1"),
+			want:       netip.MustParseAddr("192.0.2.1"),
+			wantStatus: HostIPLookupResolved,
+			wantOK:     true,
 		},
 		{
 			name: "remote IPv4 endpoint selects same ClusterID",
@@ -90,9 +92,10 @@ func TestGetHostIP(t *testing.T) {
 				{key: "10.0.0.1", hostIP: net.ParseIP("192.0.2.1")},
 				{key: "10.0.0.1@42", hostIP: net.ParseIP("192.0.2.42")},
 			},
-			addr:   cmtypes.MustParseAddrCluster("10.0.0.1@42"),
-			want:   netip.MustParseAddr("192.0.2.42"),
-			wantOK: true,
+			addr:       cmtypes.MustParseAddrCluster("10.0.0.1@42"),
+			want:       netip.MustParseAddr("192.0.2.42"),
+			wantStatus: HostIPLookupResolved,
+			wantOK:     true,
 		},
 		{
 			name: "local IPv4 endpoint does not select remote ClusterID",
@@ -100,21 +103,24 @@ func TestGetHostIP(t *testing.T) {
 				{key: "10.0.0.1", hostIP: net.ParseIP("192.0.2.1")},
 				{key: "10.0.0.1@42", hostIP: net.ParseIP("192.0.2.42")},
 			},
-			addr:   cmtypes.MustParseAddrCluster("10.0.0.1"),
-			want:   netip.MustParseAddr("192.0.2.1"),
-			wantOK: true,
+			addr:       cmtypes.MustParseAddrCluster("10.0.0.1"),
+			want:       netip.MustParseAddr("192.0.2.1"),
+			wantStatus: HostIPLookupResolved,
+			wantOK:     true,
 		},
 		{
-			name:    "remote IPv4 endpoint does not fall back to local scope",
-			entries: []cacheEntry{{key: "10.0.0.1", hostIP: net.ParseIP("192.0.2.1")}},
-			addr:    cmtypes.MustParseAddrCluster("10.0.0.1@42"),
+			name:       "remote IPv4 endpoint does not fall back to local scope",
+			entries:    []cacheEntry{{key: "10.0.0.1", hostIP: net.ParseIP("192.0.2.1")}},
+			addr:       cmtypes.MustParseAddrCluster("10.0.0.1@42"),
+			wantStatus: HostIPLookupAbsent,
 		},
 		{
-			name:    "exact IPv4 host prefix",
-			entries: []cacheEntry{{key: "10.0.0.2/32@42", hostIP: net.ParseIP("192.0.2.2")}},
-			addr:    cmtypes.MustParseAddrCluster("10.0.0.2@42"),
-			want:    netip.MustParseAddr("192.0.2.2"),
-			wantOK:  true,
+			name:       "exact IPv4 host prefix",
+			entries:    []cacheEntry{{key: "10.0.0.2/32@42", hostIP: net.ParseIP("192.0.2.2")}},
+			addr:       cmtypes.MustParseAddrCluster("10.0.0.2@42"),
+			want:       netip.MustParseAddr("192.0.2.2"),
+			wantStatus: HostIPLookupResolved,
+			wantOK:     true,
 		},
 		{
 			name: "matching IPv4 endpoint and host prefix",
@@ -122,23 +128,26 @@ func TestGetHostIP(t *testing.T) {
 				{key: "10.0.0.3@42", hostIP: net.ParseIP("192.0.2.3")},
 				{key: "10.0.0.3/32@42", hostIP: net.ParseIP("192.0.2.3")},
 			},
-			addr:   cmtypes.MustParseAddrCluster("10.0.0.3@42"),
-			want:   netip.MustParseAddr("192.0.2.3"),
-			wantOK: true,
+			addr:       cmtypes.MustParseAddrCluster("10.0.0.3@42"),
+			want:       netip.MustParseAddr("192.0.2.3"),
+			wantStatus: HostIPLookupResolved,
+			wantOK:     true,
 		},
 		{
-			name:    "IPv6 endpoint",
-			entries: []cacheEntry{{key: "fd00::1@42", hostIP: net.ParseIP("2001:db8::1")}},
-			addr:    cmtypes.MustParseAddrCluster("fd00::1@42"),
-			want:    netip.MustParseAddr("2001:db8::1"),
-			wantOK:  true,
+			name:       "IPv6 endpoint",
+			entries:    []cacheEntry{{key: "fd00::1@42", hostIP: net.ParseIP("2001:db8::1")}},
+			addr:       cmtypes.MustParseAddrCluster("fd00::1@42"),
+			want:       netip.MustParseAddr("2001:db8::1"),
+			wantStatus: HostIPLookupResolved,
+			wantOK:     true,
 		},
 		{
-			name:    "exact IPv6 host prefix",
-			entries: []cacheEntry{{key: "fd00::2/128@42", hostIP: net.ParseIP("2001:db8::2")}},
-			addr:    cmtypes.MustParseAddrCluster("fd00::2@42"),
-			want:    netip.MustParseAddr("2001:db8::2"),
-			wantOK:  true,
+			name:       "exact IPv6 host prefix",
+			entries:    []cacheEntry{{key: "fd00::2/128@42", hostIP: net.ParseIP("2001:db8::2")}},
+			addr:       cmtypes.MustParseAddrCluster("fd00::2@42"),
+			want:       netip.MustParseAddr("2001:db8::2"),
+			wantStatus: HostIPLookupResolved,
+			wantOK:     true,
 		},
 		{
 			name: "conflicting exact representations",
@@ -146,30 +155,54 @@ func TestGetHostIP(t *testing.T) {
 				{key: "10.0.0.4@42", hostIP: net.ParseIP("192.0.2.4")},
 				{key: "10.0.0.4/32@42", hostIP: net.ParseIP("192.0.2.44")},
 			},
-			addr: cmtypes.MustParseAddrCluster("10.0.0.4@42"),
+			addr:       cmtypes.MustParseAddrCluster("10.0.0.4@42"),
+			wantStatus: HostIPLookupInvalid,
 		},
 		{
-			name:    "broader prefix is not an exact host match",
-			entries: []cacheEntry{{key: "10.0.0.0/24@42", hostIP: net.ParseIP("192.0.2.5")}},
-			addr:    cmtypes.MustParseAddrCluster("10.0.0.5@42"),
+			name: "valid endpoint and missing host prefix",
+			entries: []cacheEntry{
+				{key: "10.0.0.5@42", hostIP: net.ParseIP("192.0.2.5")},
+				{key: "10.0.0.5/32@42"},
+			},
+			addr:       cmtypes.MustParseAddrCluster("10.0.0.5@42"),
+			wantStatus: HostIPLookupInvalid,
 		},
 		{
-			name:    "nil host IP",
-			entries: []cacheEntry{{key: "10.0.0.6@42"}},
-			addr:    cmtypes.MustParseAddrCluster("10.0.0.6@42"),
+			name: "missing endpoint host and valid prefix",
+			entries: []cacheEntry{
+				{key: "10.0.0.6@42"},
+				{key: "10.0.0.6/32@42", hostIP: net.ParseIP("192.0.2.6")},
+			},
+			addr:       cmtypes.MustParseAddrCluster("10.0.0.6@42"),
+			wantStatus: HostIPLookupInvalid,
 		},
 		{
-			name:    "invalid host IP",
-			entries: []cacheEntry{{key: "10.0.0.7@42", hostIP: net.IP{1, 2, 3}}},
-			addr:    cmtypes.MustParseAddrCluster("10.0.0.7@42"),
+			name:       "broader prefix is not an exact host match",
+			entries:    []cacheEntry{{key: "10.0.0.0/24@42", hostIP: net.ParseIP("192.0.2.5")}},
+			addr:       cmtypes.MustParseAddrCluster("10.0.0.6@42"),
+			wantStatus: HostIPLookupAbsent,
 		},
 		{
-			name: "invalid address",
-			addr: cmtypes.AddrCluster{},
+			name:       "nil host IP",
+			entries:    []cacheEntry{{key: "10.0.0.7@42"}},
+			addr:       cmtypes.MustParseAddrCluster("10.0.0.7@42"),
+			wantStatus: HostIPLookupInvalid,
 		},
 		{
-			name: "absent address",
-			addr: cmtypes.MustParseAddrCluster("10.0.0.8@42"),
+			name:       "invalid host IP",
+			entries:    []cacheEntry{{key: "10.0.0.8@42", hostIP: net.IP{1, 2, 3}}},
+			addr:       cmtypes.MustParseAddrCluster("10.0.0.8@42"),
+			wantStatus: HostIPLookupInvalid,
+		},
+		{
+			name:       "invalid address",
+			addr:       cmtypes.AddrCluster{},
+			wantStatus: HostIPLookupInvalid,
+		},
+		{
+			name:       "absent address",
+			addr:       cmtypes.MustParseAddrCluster("10.0.0.9@42"),
+			wantStatus: HostIPLookupAbsent,
 		},
 	}
 
@@ -183,6 +216,10 @@ func TestGetHostIP(t *testing.T) {
 				})
 				require.NoError(t, err)
 			}
+
+			got, status := s.IPIdentityCache.LookupHostIP(tt.addr)
+			require.Equal(t, tt.wantStatus, status)
+			require.Equal(t, tt.want, got)
 
 			got, ok := s.IPIdentityCache.GetHostIP(tt.addr)
 			require.Equal(t, tt.wantOK, ok)

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -62,6 +62,158 @@ func setupIPCacheTestSuite(tb testing.TB) *IPCacheTestSuite {
 	return s
 }
 
+func TestGetHostIP(t *testing.T) {
+	t.Parallel()
+
+	type cacheEntry struct {
+		key    string
+		hostIP net.IP
+	}
+
+	tests := []struct {
+		name    string
+		entries []cacheEntry
+		addr    cmtypes.AddrCluster
+		want    netip.Addr
+		wantOK  bool
+	}{
+		{
+			name:    "local IPv4 endpoint",
+			entries: []cacheEntry{{key: "10.0.0.1", hostIP: net.ParseIP("192.0.2.1")}},
+			addr:    cmtypes.MustParseAddrCluster("10.0.0.1"),
+			want:    netip.MustParseAddr("192.0.2.1"),
+			wantOK:  true,
+		},
+		{
+			name: "remote IPv4 endpoint selects same ClusterID",
+			entries: []cacheEntry{
+				{key: "10.0.0.1", hostIP: net.ParseIP("192.0.2.1")},
+				{key: "10.0.0.1@42", hostIP: net.ParseIP("192.0.2.42")},
+			},
+			addr:   cmtypes.MustParseAddrCluster("10.0.0.1@42"),
+			want:   netip.MustParseAddr("192.0.2.42"),
+			wantOK: true,
+		},
+		{
+			name: "local IPv4 endpoint does not select remote ClusterID",
+			entries: []cacheEntry{
+				{key: "10.0.0.1", hostIP: net.ParseIP("192.0.2.1")},
+				{key: "10.0.0.1@42", hostIP: net.ParseIP("192.0.2.42")},
+			},
+			addr:   cmtypes.MustParseAddrCluster("10.0.0.1"),
+			want:   netip.MustParseAddr("192.0.2.1"),
+			wantOK: true,
+		},
+		{
+			name:    "remote IPv4 endpoint does not fall back to local scope",
+			entries: []cacheEntry{{key: "10.0.0.1", hostIP: net.ParseIP("192.0.2.1")}},
+			addr:    cmtypes.MustParseAddrCluster("10.0.0.1@42"),
+		},
+		{
+			name:    "exact IPv4 host prefix",
+			entries: []cacheEntry{{key: "10.0.0.2/32@42", hostIP: net.ParseIP("192.0.2.2")}},
+			addr:    cmtypes.MustParseAddrCluster("10.0.0.2@42"),
+			want:    netip.MustParseAddr("192.0.2.2"),
+			wantOK:  true,
+		},
+		{
+			name: "matching IPv4 endpoint and host prefix",
+			entries: []cacheEntry{
+				{key: "10.0.0.3@42", hostIP: net.ParseIP("192.0.2.3")},
+				{key: "10.0.0.3/32@42", hostIP: net.ParseIP("192.0.2.3")},
+			},
+			addr:   cmtypes.MustParseAddrCluster("10.0.0.3@42"),
+			want:   netip.MustParseAddr("192.0.2.3"),
+			wantOK: true,
+		},
+		{
+			name:    "IPv6 endpoint",
+			entries: []cacheEntry{{key: "fd00::1@42", hostIP: net.ParseIP("2001:db8::1")}},
+			addr:    cmtypes.MustParseAddrCluster("fd00::1@42"),
+			want:    netip.MustParseAddr("2001:db8::1"),
+			wantOK:  true,
+		},
+		{
+			name:    "exact IPv6 host prefix",
+			entries: []cacheEntry{{key: "fd00::2/128@42", hostIP: net.ParseIP("2001:db8::2")}},
+			addr:    cmtypes.MustParseAddrCluster("fd00::2@42"),
+			want:    netip.MustParseAddr("2001:db8::2"),
+			wantOK:  true,
+		},
+		{
+			name: "conflicting exact representations",
+			entries: []cacheEntry{
+				{key: "10.0.0.4@42", hostIP: net.ParseIP("192.0.2.4")},
+				{key: "10.0.0.4/32@42", hostIP: net.ParseIP("192.0.2.44")},
+			},
+			addr: cmtypes.MustParseAddrCluster("10.0.0.4@42"),
+		},
+		{
+			name:    "broader prefix is not an exact host match",
+			entries: []cacheEntry{{key: "10.0.0.0/24@42", hostIP: net.ParseIP("192.0.2.5")}},
+			addr:    cmtypes.MustParseAddrCluster("10.0.0.5@42"),
+		},
+		{
+			name:    "nil host IP",
+			entries: []cacheEntry{{key: "10.0.0.6@42"}},
+			addr:    cmtypes.MustParseAddrCluster("10.0.0.6@42"),
+		},
+		{
+			name:    "invalid host IP",
+			entries: []cacheEntry{{key: "10.0.0.7@42", hostIP: net.IP{1, 2, 3}}},
+			addr:    cmtypes.MustParseAddrCluster("10.0.0.7@42"),
+		},
+		{
+			name: "invalid address",
+			addr: cmtypes.AddrCluster{},
+		},
+		{
+			name: "absent address",
+			addr: cmtypes.MustParseAddrCluster("10.0.0.8@42"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := setupIPCacheTestSuite(t)
+			for _, entry := range tt.entries {
+				_, err := s.IPIdentityCache.Upsert(entry.key, entry.hostIP, 0, nil, Identity{
+					ID:     1234,
+					Source: source.KVStore,
+				})
+				require.NoError(t, err)
+			}
+
+			got, ok := s.IPIdentityCache.GetHostIP(tt.addr)
+			require.Equal(t, tt.wantOK, ok)
+			require.Equal(t, tt.want, got)
+		})
+	}
+
+	t.Run("upsert update and delete", func(t *testing.T) {
+		s := setupIPCacheTestSuite(t)
+		addr := cmtypes.MustParseAddrCluster("10.0.0.9@42")
+		identity := Identity{ID: 1234, Source: source.KVStore}
+
+		_, err := s.IPIdentityCache.Upsert(addr.String(), net.ParseIP("192.0.2.9"), 0, nil, identity)
+		require.NoError(t, err)
+		got, ok := s.IPIdentityCache.GetHostIP(addr)
+		require.True(t, ok)
+		require.Equal(t, netip.MustParseAddr("192.0.2.9"), got)
+
+		_, err = s.IPIdentityCache.Upsert(addr.String(), net.ParseIP("192.0.2.99"), 0, nil, identity)
+		require.NoError(t, err)
+		got, ok = s.IPIdentityCache.GetHostIP(addr)
+		require.True(t, ok)
+		require.Equal(t, netip.MustParseAddr("192.0.2.99"), got)
+
+		s.IPIdentityCache.Delete(addr.String(), source.KVStore)
+		got, ok = s.IPIdentityCache.GetHostIP(addr)
+		require.False(t, ok)
+		require.Equal(t, netip.Addr{}, got)
+	})
+}
+
 func TestIPCache(t *testing.T) {
 	s := setupIPCacheTestSuite(t)
 	t.Parallel()

--- a/pkg/node/manager/cell.go
+++ b/pkg/node/manager/cell.go
@@ -48,8 +48,24 @@ type Notifier interface {
 	Unsubscribe(node.Handler)
 }
 
+// NodeStateObserver observes every accepted change to the NodeManager's stored
+// node state. Callbacks are synchronous and read-only; implementations must not
+// call back into NodeManager.
+type NodeStateObserver interface {
+	NodeUpsert(types.Node)
+	NodeDelete(types.Node)
+}
+
+// NodeStateNotifier provides a serialized stream of the NodeManager's stored
+// node state, including a complete replay when an observer subscribes.
+type NodeStateNotifier interface {
+	SubscribeNodeState(NodeStateObserver)
+	UnsubscribeNodeState(NodeStateObserver)
+}
+
 type NodeManager interface {
 	Notifier
+	NodeStateNotifier
 
 	// GetNodes returns a copy of all the nodes as a map from Identity to Node.
 	GetNodes() map[types.Identity]types.Node

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -91,24 +91,25 @@ type IPCache interface {
 type IPSetFilterFn func(*nodeTypes.Node) bool
 
 var _ Notifier = (*manager)(nil)
+var _ NodeStateNotifier = (*manager)(nil)
 
 // manager is the entity that manages a collection of nodes
 type manager struct {
 	logger *slog.Logger
-	// mutex is the lock protecting access to the nodes map. The mutex must
-	// be held for any access of the nodes map.
+	// mutex protects the nodes map and nodeStateObservers. It must be held for
+	// any access to either collection.
 	//
 	// The manager mutex works together with the entry mutex in the
-	// following way to minimize the duration the manager mutex is held:
+	// following way to serialize stored state changes before datapath work:
 	//
 	// 1. Acquire manager mutex to safely access nodes map and to retrieve
 	//    node entry.
 	// 2. Acquire mutex of the entry while the manager mutex is still held.
 	//    This guarantees that no change to the entry has happened.
-	// 3. Release of the manager mutex to unblock changes or reads to other
-	//    node entries.
-	// 4. Change of entry data or performing of datapath interactions
-	// 5. Release of the entry mutex
+	// 3. Change stored entry data and synchronously notify state observers.
+	// 4. Release the manager mutex to unblock other node state operations.
+	// 5. Perform datapath interactions.
+	// 6. Release the entry mutex.
 	//
 	// If both the nodeEntry.mutex and Manager.mutex must be held, then the
 	// Manager.mutex must *always* be acquired first.
@@ -116,6 +117,9 @@ type manager struct {
 
 	// nodes is the list of nodes. Access must be protected via mutex.
 	nodes map[nodeTypes.Identity]*nodeEntry
+	// nodeStateObservers is protected by mutex. Observer callbacks run while
+	// mutex is write locked to serialize them with stored node state changes.
+	nodeStateObservers map[NodeStateObserver]struct{}
 
 	// Upon agent startup, this is filled with nodes as read from disk. Used to
 	// synthesize node deletion events for nodes which disappeared while we were
@@ -205,6 +209,42 @@ func (m *manager) Unsubscribe(nh node.Handler) {
 	m.nodeHandlersMu.Unlock()
 }
 
+// SubscribeNodeState subscribes an observer and replays the complete current
+// node state before allowing another stored state change to proceed.
+func (m *manager) SubscribeNodeState(observer NodeStateObserver) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	m.nodeStateObservers[observer] = struct{}{}
+	for _, entry := range m.nodes {
+		entry.mutex.Lock()
+		observer.NodeUpsert(entry.node)
+		entry.mutex.Unlock()
+	}
+}
+
+// UnsubscribeNodeState removes an observer after any in-flight callback has
+// completed. Once this method returns, no later callback can start.
+func (m *manager) UnsubscribeNodeState(observer NodeStateObserver) {
+	m.mutex.Lock()
+	delete(m.nodeStateObservers, observer)
+	m.mutex.Unlock()
+}
+
+// notifyNodeStateUpsert notifies observers while m.mutex is write locked.
+func (m *manager) notifyNodeStateUpsert(n nodeTypes.Node) {
+	for observer := range m.nodeStateObservers {
+		observer.NodeUpsert(n)
+	}
+}
+
+// notifyNodeStateDelete notifies observers while m.mutex is write locked.
+func (m *manager) notifyNodeStateDelete(n nodeTypes.Node) {
+	for observer := range m.nodeStateObservers {
+		observer.NodeDelete(n)
+	}
+}
+
 // Iter executes the given function in all subscribed node handlers.
 func (m *manager) Iter(f func(nh node.Handler)) {
 	m.nodeHandlersMu.RLock()
@@ -280,6 +320,7 @@ func New(
 	m := &manager{
 		logger:                 logger,
 		nodes:                  map[nodeTypes.Identity]*nodeEntry{},
+		nodeStateObservers:     map[NodeStateObserver]struct{}{},
 		restoredNodes:          map[nodeTypes.Identity]*nodeTypes.Node{},
 		conf:                   c,
 		underlay:               tunnelConf.UnderlayProtocol(),
@@ -830,24 +871,40 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 		ingressIPsAdded = append(ingressIPsAdded, prefixCluster.AsPrefix())
 	}
 
+	m.updateNodeState(n, nodeIdentifier, dpUpdate, resource, ipsetEntries,
+		nodeIPsAdded, healthIPsAdded, ingressIPsAdded, podCIDRsAdded)
+}
+
+// updateNodeState replaces the stored node and publishes the accepted state
+// before running per-entry datapath work. Its first operation is the manager
+// lock, which is the serialization boundary shared with state subscriptions.
+func (m *manager) updateNodeState(
+	n nodeTypes.Node,
+	nodeIdentifier nodeTypes.Identity,
+	dpUpdate bool,
+	resource ipcacheTypes.ResourceID,
+	ipsetEntries, nodeIPsAdded, healthIPsAdded, ingressIPsAdded, podCIDRsAdded []netip.Prefix,
+) {
 	m.mutex.Lock()
 	entry, oldNodeExists := m.nodes[nodeIdentifier]
 	if oldNodeExists {
 		m.metrics.EventsReceived.WithLabelValues("update", string(n.Source)).Inc()
+		entry.mutex.Lock()
 
 		if !source.AllowOverwrite(entry.node.Source, n.Source) {
 			// Done; skip node-handler updates and label injection
 			// triggers below. Includes case where the local host
 			// was discovered locally and then is subsequently
 			// updated by the k8s watcher.
+			entry.mutex.Unlock()
 			m.mutex.Unlock()
 			return
 		}
 
-		entry.mutex.Lock()
-		m.mutex.Unlock()
 		oldNode := entry.node
 		entry.node = n
+		m.notifyNodeStateUpsert(entry.node)
+		m.mutex.Unlock()
 		if dpUpdate {
 			var errs error
 			m.Iter(func(nh node.Handler) {
@@ -880,6 +937,7 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 		entry = &nodeEntry{node: n}
 		entry.mutex.Lock()
 		m.nodes[nodeIdentifier] = entry
+		m.notifyNodeStateUpsert(entry.node)
 		m.mutex.Unlock()
 		var errs error
 		if dpUpdate {
@@ -1088,31 +1146,43 @@ func (m *manager) NodeDeleted(n nodeTypes.Node) {
 	m.metrics.EventsReceived.WithLabelValues("delete", string(n.Source)).Inc()
 
 	nodeIdentifier := n.Identity()
+	m.deleteNodeState(n, nodeIdentifier)
+}
+
+// deleteNodeState removes a node from stored state. Its first operation is the
+// manager lock, followed immediately by the live entry lock when one exists.
+func (m *manager) deleteNodeState(n nodeTypes.Node, nodeIdentifier nodeTypes.Identity) {
+	m.mutex.Lock()
 
 	var (
 		entry         *nodeEntry
 		oldNodeExists bool
+		currentNode   nodeTypes.Node
 	)
 
-	m.mutex.Lock()
 	// If the node is restored from disk, it doesn't exist in the bookkeeping,
 	// but we need to synthesize a deletion event for downstream.
 	if n.Source == source.Restored {
 		entry = &nodeEntry{
 			node: n,
 		}
+		entry.mutex.Lock()
+		currentNode = entry.node
 	} else {
 		entry, oldNodeExists = m.nodes[nodeIdentifier]
 		if !oldNodeExists {
 			m.mutex.Unlock()
 			return
 		}
+		entry.mutex.Lock()
+		currentNode = entry.node
 	}
 
 	// If the source is Kubernetes and the node is the node we are running on
 	// Kubernetes is giving us a hint it is about to delete our node. Close down
 	// the agent gracefully in this case.
-	if n.Source != entry.node.Source {
+	if n.Source != currentNode.Source {
+		entry.mutex.Unlock()
 		m.mutex.Unlock()
 		if n.IsLocal() && n.Source == source.Kubernetes {
 			m.logger.Debug(
@@ -1124,7 +1194,7 @@ func (m *manager) NodeDeleted(n nodeTypes.Node) {
 				"Ignoring delete event of node",
 				logfields.Name, n.Name,
 				logfields.Source, n.Source,
-				logfields.NodeOwner, entry.node.Source,
+				logfields.NodeOwner, currentNode.Source,
 			)
 		}
 		return
@@ -1132,15 +1202,16 @@ func (m *manager) NodeDeleted(n nodeTypes.Node) {
 
 	if n.Source != source.Restored {
 		// The ipcache is recreated from scratch on startup, no need to prune restored stale nodes.
-		resource := ipcacheTypes.NewResourceID(ipcacheTypes.ResourceKindNode, "", n.Name)
-		m.removeNodeFromIPCache(entry.node, resource, nil, nil, nil, nil, nil)
+		resource := ipcacheTypes.NewResourceID(ipcacheTypes.ResourceKindNode, "", currentNode.Name)
+		m.removeNodeFromIPCache(currentNode, resource, nil, nil, nil, nil, nil)
 
 		// We only need to decrement for nodes we've accounted for.
 		m.metrics.NumNodes.Dec()
+
+		delete(m.nodes, currentNode.Identity())
+		m.notifyNodeStateDelete(currentNode)
 	}
 
-	entry.mutex.Lock()
-	delete(m.nodes, nodeIdentifier)
 	if m.nodeCheckpointer != nil {
 		m.nodeCheckpointer.TriggerWithReason("NodeDeleted")
 	}

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -13,11 +13,9 @@ import (
 	"net/netip"
 	"os"
 	"path/filepath"
-	"runtime"
 	"slices"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -61,6 +59,7 @@ type nodeEvent struct {
 type ipcacheMock struct {
 	events         chan nodeEvent
 	metadataSource source.Source
+	onRemove       func()
 }
 
 func newIPcacheMock() *ipcacheMock {
@@ -111,6 +110,9 @@ func (i *ipcacheMock) UpsertMetadata(prefix cmtypes.PrefixCluster, src source.So
 }
 
 func (i *ipcacheMock) RemoveMetadata(prefix cmtypes.PrefixCluster, resource ipcacheTypes.ResourceID, aux ...ipcache.IPMetadata) {
+	if i.onRemove != nil {
+		i.onRemove()
+	}
 	i.Delete(prefix.String(), source.CustomResource, aux...)
 }
 
@@ -341,28 +343,62 @@ func waitForNodeStateTestOperation(t *testing.T, done <-chan struct{}, operation
 	}
 }
 
-// startNodeStateTestOperation advances operation to either completion or its
-// first blocking point. Running one P and yielding after the goroutine marks
-// itself active makes the concurrency assertions below independent of sleeps.
-func startNodeStateTestOperation(t *testing.T, operation func()) (<-chan struct{}, *atomic.Int32) {
+func requireNodeStateTestLockHeld(t *testing.T, tryLock func() bool, unlock func(), lockBoundary string) {
 	t.Helper()
 
-	oldProcs := runtime.GOMAXPROCS(1)
-	t.Cleanup(func() { runtime.GOMAXPROCS(oldProcs) })
+	if tryLock() {
+		unlock()
+		t.Fatalf("%s was not locked", lockBoundary)
+	}
+}
+
+// startNodeStateTestManagerLockContender proves that the goroutine has reached
+// the manager-lock boundary with a failed TryLock before it runs operation.
+func startNodeStateTestManagerLockContender(t *testing.T, mngr *manager, operation func()) <-chan struct{} {
+	t.Helper()
 
 	done := make(chan struct{})
-	started := make(chan struct{})
-	state := &atomic.Int32{}
+	managerLockContended := make(chan bool, 1)
 	go func() {
-		state.Store(1)
-		close(started)
+		if mngr.mutex.TryLock() {
+			mngr.mutex.Unlock()
+			managerLockContended <- false
+			close(done)
+			return
+		}
+		managerLockContended <- true
 		operation()
-		state.Store(2)
 		close(done)
 	}()
-	<-started
-	runtime.Gosched()
-	return done, state
+
+	select {
+	case contended := <-managerLockContended:
+		require.True(t, contended, "operation reached an unlocked manager-lock boundary")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for operation to contend on the manager lock")
+	}
+	return done
+}
+
+// waitForNodeStateTestLockHeld waits only for eventual progress. The failed
+// TryLock, rather than the timeout or scheduling, proves that the lock is held.
+func waitForNodeStateTestLockHeld(t *testing.T, tryLock func() bool, unlock func(), lockBoundary string) {
+	t.Helper()
+
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	for {
+		if !tryLock() {
+			return
+		}
+		unlock()
+
+		select {
+		case <-timer.C:
+			t.Fatalf("timed out waiting for %s to become locked", lockBoundary)
+		default:
+		}
+	}
 }
 
 func TestNodeStateSubscriptionReplaysCurrentNodes(t *testing.T) {
@@ -401,10 +437,11 @@ func TestNodeStateSubscriptionSerializesReplayBeforeUpdate(t *testing.T) {
 		close(subscribeDone)
 	}()
 	require.Equal(t, current, receiveNodeStateTestEvent(t, observer.entered).node)
+	requireNodeStateTestLockHeld(t, mngr.mutex.TryLock, mngr.mutex.Unlock, "manager lock during subscription replay")
 
 	updated := *current.DeepCopy()
 	updated.Labels["version"] = "new"
-	updateDone, updateState := startNodeStateTestOperation(t, func() {
+	updateDone := startNodeStateTestManagerLockContender(t, mngr, func() {
 		mngr.updateNodeState(
 			updated,
 			updated.Identity(),
@@ -413,12 +450,6 @@ func TestNodeStateSubscriptionSerializesReplayBeforeUpdate(t *testing.T) {
 			nil, nil, nil, nil, nil,
 		)
 	})
-	require.Equal(t, int32(1), updateState.Load(), "accepted update did not block behind replay")
-	select {
-	case event := <-observer.entered:
-		t.Fatalf("accepted update callback overtook initial replay: %+v", event)
-	default:
-	}
 	releaseReplayOnce.Do(func() { close(releaseReplay) })
 	waitForNodeStateTestOperation(t, subscribeDone, "subscription replay")
 	waitForNodeStateTestOperation(t, updateDone, "concurrent node update")
@@ -553,11 +584,11 @@ func TestNodeStateUnsubscribeWaitsForCallbackAndPreventsLaterCallbacks(t *testin
 		close(updateDone)
 	}()
 	require.Equal(t, first, receiveNodeStateTestEvent(t, observer.entered).node)
+	requireNodeStateTestLockHeld(t, mngr.mutex.TryLock, mngr.mutex.Unlock, "manager lock during observer callback")
 
-	unsubscribeDone, unsubscribeState := startNodeStateTestOperation(t, func() {
+	unsubscribeDone := startNodeStateTestManagerLockContender(t, mngr, func() {
 		mngr.UnsubscribeNodeState(observer)
 	})
-	require.Equal(t, int32(1), unsubscribeState.Load(), "unsubscribe returned while an observer callback was in flight")
 
 	releaseCallbackOnce.Do(func() { close(releaseCallback) })
 	waitForNodeStateTestOperation(t, updateDone, "blocked observer callback")
@@ -598,9 +629,9 @@ func TestNodeStateOrderingAndManagerEntryLockOrder(t *testing.T) {
 			<-ipcache.events
 		}
 
-		// The documented order is manager mutex then entry mutex. Holding the
-		// entry lock here forces delete to wait before cleanup while retaining
-		// the manager lock; releasing it must let the delete complete.
+		// Holding the entry lock forces deletion to retain the manager lock while
+		// it waits. Cleanup then pauses so both retained locks can be probed at
+		// the actual IPCache removal boundary.
 		mngr.mutex.Lock()
 		entry := mngr.nodes[current.Identity()]
 		entry.mutex.Lock()
@@ -608,17 +639,33 @@ func TestNodeStateOrderingAndManagerEntryLockOrder(t *testing.T) {
 		defer unlockEntryOnce.Do(entry.mutex.Unlock)
 		mngr.mutex.Unlock()
 
-		deleteDone, deleteState := startNodeStateTestOperation(t, func() {
-			mngr.deleteNodeState(current, current.Identity())
-		})
-		require.Equal(t, int32(1), deleteState.Load(), "delete did not block on the live entry lock")
-		select {
-		case event := <-ipcache.events:
-			t.Fatalf("IPCache cleanup ran before the live entry lock was acquired: %+v", event)
-		default:
+		cleanupEntered := make(chan struct{})
+		cleanupRelease := make(chan struct{})
+		var cleanupReleaseOnce sync.Once
+		defer cleanupReleaseOnce.Do(func() { close(cleanupRelease) })
+		var cleanupOnce sync.Once
+		ipcache.onRemove = func() {
+			cleanupOnce.Do(func() {
+				close(cleanupEntered)
+				<-cleanupRelease
+			})
 		}
 
+		deleteStarted := make(chan struct{})
+		deleteDone := make(chan struct{})
+		go func() {
+			close(deleteStarted)
+			mngr.deleteNodeState(current, current.Identity())
+			close(deleteDone)
+		}()
+		waitForNodeStateTestOperation(t, deleteStarted, "node deletion start")
+		waitForNodeStateTestLockHeld(t, mngr.mutex.TryLock, mngr.mutex.Unlock, "manager lock retained while delete waits for entry lock")
+
 		unlockEntryOnce.Do(entry.mutex.Unlock)
+		waitForNodeStateTestOperation(t, cleanupEntered, "IPCache cleanup boundary")
+		requireNodeStateTestLockHeld(t, mngr.mutex.TryLock, mngr.mutex.Unlock, "manager lock during IPCache cleanup")
+		requireNodeStateTestLockHeld(t, entry.mutex.TryLock, entry.mutex.Unlock, "entry lock during IPCache cleanup")
+		cleanupReleaseOnce.Do(func() { close(cleanupRelease) })
 		waitForNodeStateTestOperation(t, deleteDone, "node deletion after releasing entry lock")
 		require.NotContains(t, mngr.GetNodes(), current.Identity())
 	})

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -13,9 +13,11 @@ import (
 	"net/netip"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -57,7 +59,8 @@ type nodeEvent struct {
 }
 
 type ipcacheMock struct {
-	events chan nodeEvent
+	events         chan nodeEvent
+	metadataSource source.Source
 }
 
 func newIPcacheMock() *ipcacheMock {
@@ -100,7 +103,7 @@ func (i *ipcacheMock) Delete(ip string, source source.Source, aux ...ipcache.IPM
 }
 
 func (i *ipcacheMock) GetMetadataSourceByPrefix(prefix cmtypes.PrefixCluster) source.Source {
-	return source.Unspec
+	return i.metadataSource
 }
 
 func (i *ipcacheMock) UpsertMetadata(prefix cmtypes.PrefixCluster, src source.Source, resource ipcacheTypes.ResourceID, aux ...ipcache.IPMetadata) {
@@ -241,6 +244,384 @@ func (n *signalNodeHandler) NodeValidateImplementation(node nodeTypes.Node) erro
 		}
 	}
 	return n.NodeValidateImplementationEventError
+}
+
+type nodeStateTestEvent struct {
+	kind string
+	node nodeTypes.Node
+}
+
+type testNodeStateObserver struct {
+	mutex   sync.Mutex
+	events  []nodeStateTestEvent
+	entered chan nodeStateTestEvent
+	release <-chan struct{}
+}
+
+func (o *testNodeStateObserver) NodeUpsert(n nodeTypes.Node) {
+	o.record("upsert", n)
+}
+
+func (o *testNodeStateObserver) NodeDelete(n nodeTypes.Node) {
+	o.record("delete", n)
+}
+
+func (o *testNodeStateObserver) record(kind string, n nodeTypes.Node) {
+	event := nodeStateTestEvent{kind: kind, node: *n.DeepCopy()}
+	if o.entered != nil {
+		o.entered <- event
+	}
+	if o.release != nil {
+		<-o.release
+	}
+
+	o.mutex.Lock()
+	o.events = append(o.events, event)
+	o.mutex.Unlock()
+}
+
+func (o *testNodeStateObserver) recordedEvents() []nodeStateTestEvent {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+
+	events := make([]nodeStateTestEvent, len(o.events))
+	for i := range o.events {
+		events[i] = nodeStateTestEvent{
+			kind: o.events[i].kind,
+			node: *o.events[i].node.DeepCopy(),
+		}
+	}
+	return events
+}
+
+func newNodeStateTestManager(t *testing.T) (*manager, *ipcacheMock) {
+	t.Helper()
+
+	ipcache := newIPcacheMock()
+	health, _ := cell.NewSimpleHealth()
+	mngr, err := New(
+		hivetest.Logger(t),
+		&option.DaemonConfig{},
+		tunnel.Config{},
+		ipcache,
+		newIPSetMock(),
+		nil,
+		NewNodeMetrics(),
+		health,
+		nil,
+		nil,
+		nil,
+		fakewireguard.Config{},
+		node.NewTestLocalNodeStore(node.LocalNode{}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, mngr.Stop(context.Background()))
+	})
+	return mngr, ipcache
+}
+
+func receiveNodeStateTestEvent(t *testing.T, events <-chan nodeStateTestEvent) nodeStateTestEvent {
+	t.Helper()
+	select {
+	case event := <-events:
+		return event
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for node state observer callback")
+		return nodeStateTestEvent{}
+	}
+}
+
+func waitForNodeStateTestOperation(t *testing.T, done <-chan struct{}, operation string) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %s", operation)
+	}
+}
+
+// startNodeStateTestOperation advances operation to either completion or its
+// first blocking point. Running one P and yielding after the goroutine marks
+// itself active makes the concurrency assertions below independent of sleeps.
+func startNodeStateTestOperation(t *testing.T, operation func()) (<-chan struct{}, *atomic.Int32) {
+	t.Helper()
+
+	oldProcs := runtime.GOMAXPROCS(1)
+	t.Cleanup(func() { runtime.GOMAXPROCS(oldProcs) })
+
+	done := make(chan struct{})
+	started := make(chan struct{})
+	state := &atomic.Int32{}
+	go func() {
+		state.Store(1)
+		close(started)
+		operation()
+		state.Store(2)
+		close(done)
+	}()
+	<-started
+	runtime.Gosched()
+	return done, state
+}
+
+func TestNodeStateSubscriptionReplaysCurrentNodes(t *testing.T) {
+	mngr, _ := newNodeStateTestManager(t)
+	node1 := nodeTypes.Node{Name: "node-1", Cluster: "cluster-1", Source: source.Kubernetes}
+	node2 := nodeTypes.Node{Name: "node-2", Cluster: "cluster-1", Source: source.Kubernetes}
+	mngr.NodeUpdated(node1)
+	mngr.NodeUpdated(node2)
+
+	observer := &testNodeStateObserver{}
+	mngr.SubscribeNodeState(observer)
+
+	replayed := observer.recordedEvents()
+	require.Len(t, replayed, 2)
+	require.ElementsMatch(t, []nodeStateTestEvent{
+		{kind: "upsert", node: node1},
+		{kind: "upsert", node: node2},
+	}, replayed)
+}
+
+func TestNodeStateSubscriptionSerializesReplayBeforeUpdate(t *testing.T) {
+	mngr, _ := newNodeStateTestManager(t)
+	current := nodeTypes.Node{Name: "node-1", Cluster: "cluster-1", Source: source.Kubernetes, Labels: map[string]string{"version": "old"}}
+	mngr.NodeUpdated(current)
+
+	releaseReplay := make(chan struct{})
+	var releaseReplayOnce sync.Once
+	defer releaseReplayOnce.Do(func() { close(releaseReplay) })
+	observer := &testNodeStateObserver{
+		entered: make(chan nodeStateTestEvent, 2),
+		release: releaseReplay,
+	}
+	subscribeDone := make(chan struct{})
+	go func() {
+		mngr.SubscribeNodeState(observer)
+		close(subscribeDone)
+	}()
+	require.Equal(t, current, receiveNodeStateTestEvent(t, observer.entered).node)
+
+	updated := *current.DeepCopy()
+	updated.Labels["version"] = "new"
+	updateDone, updateState := startNodeStateTestOperation(t, func() {
+		mngr.updateNodeState(
+			updated,
+			updated.Identity(),
+			true,
+			ipcacheTypes.NewResourceID(ipcacheTypes.ResourceKindNode, "", updated.Name),
+			nil, nil, nil, nil, nil,
+		)
+	})
+	require.Equal(t, int32(1), updateState.Load(), "accepted update did not block behind replay")
+	select {
+	case event := <-observer.entered:
+		t.Fatalf("accepted update callback overtook initial replay: %+v", event)
+	default:
+	}
+	releaseReplayOnce.Do(func() { close(releaseReplay) })
+	waitForNodeStateTestOperation(t, subscribeDone, "subscription replay")
+	waitForNodeStateTestOperation(t, updateDone, "concurrent node update")
+
+	require.Equal(t, []nodeStateTestEvent{
+		{kind: "upsert", node: current},
+		{kind: "upsert", node: updated},
+	}, observer.recordedEvents())
+}
+
+func TestNodeStateAcceptedUpdatesIgnoreDatapathSuppression(t *testing.T) {
+	mngr, ipcache := newNodeStateTestManager(t)
+	ipcache.metadataSource = source.Local
+
+	dp := newSignalNodeHandler()
+	dp.EnableNodeAddEvent = true
+	dp.EnableNodeUpdateEvent = true
+	mngr.Subscribe(dp)
+	observer := &testNodeStateObserver{}
+	mngr.SubscribeNodeState(observer)
+
+	added := nodeTypes.Node{
+		Name: "node-1", Cluster: "cluster-1", Source: source.Kubernetes,
+		IPAddresses: []nodeTypes.Address{{Type: addressing.NodeInternalIP, IP: net.ParseIP("10.0.0.1")}},
+	}
+	mngr.NodeUpdated(added)
+	updated := *added.DeepCopy()
+	updated.Labels = map[string]string{"version": "new"}
+	mngr.NodeUpdated(updated)
+
+	require.Equal(t, []nodeStateTestEvent{
+		{kind: "upsert", node: added},
+		{kind: "upsert", node: updated},
+	}, observer.recordedEvents())
+	require.Zero(t, len(dp.NodeAddEvent))
+	require.Zero(t, len(dp.NodeUpdateEvent))
+}
+
+func TestNodeStateRejectedUpdateEmitsNothing(t *testing.T) {
+	mngr, _ := newNodeStateTestManager(t)
+	observer := &testNodeStateObserver{}
+	mngr.SubscribeNodeState(observer)
+
+	current := nodeTypes.Node{Name: "node-1", Cluster: "cluster-1", Source: source.Local}
+	mngr.NodeUpdated(current)
+	rejected := *current.DeepCopy()
+	rejected.Source = source.Kubernetes
+	rejected.Labels = map[string]string{"rejected": "true"}
+	mngr.NodeUpdated(rejected)
+
+	require.Equal(t, []nodeStateTestEvent{{kind: "upsert", node: current}}, observer.recordedEvents())
+	require.Equal(t, current, mngr.GetNodes()[current.Identity()])
+}
+
+func TestNodeStateDeleteUsesLatestStoredSnapshot(t *testing.T) {
+	mngr, ipcache := newNodeStateTestManager(t)
+	observer := &testNodeStateObserver{}
+	mngr.SubscribeNodeState(observer)
+
+	stale := nodeTypes.Node{
+		Name: "node-1", Cluster: "cluster-1", Source: source.Kubernetes,
+		IPAddresses: []nodeTypes.Address{{Type: addressing.NodeInternalIP, IP: net.ParseIP("10.0.0.1")}},
+		Labels:      map[string]string{"version": "old"},
+	}
+	mngr.NodeUpdated(stale)
+	latest := *stale.DeepCopy()
+	latest.IPAddresses[0].IP = net.ParseIP("10.0.0.2")
+	latest.Labels["version"] = "new"
+	mngr.NodeUpdated(latest)
+	for len(ipcache.events) > 0 {
+		<-ipcache.events
+	}
+
+	mngr.NodeDeleted(stale)
+
+	require.Equal(t, []nodeStateTestEvent{
+		{kind: "upsert", node: stale},
+		{kind: "upsert", node: latest},
+		{kind: "delete", node: latest},
+	}, observer.recordedEvents())
+	require.NotContains(t, mngr.GetNodes(), stale.Identity())
+	select {
+	case event := <-ipcache.events:
+		require.Equal(t, "delete", event.event)
+		require.Equal(t, netip.MustParsePrefix("10.0.0.2/32"), event.prefix)
+	default:
+		t.Fatal("latest stored node address was not removed from IPCache")
+	}
+	require.Zero(t, len(ipcache.events), "stale caller payload drove additional IPCache cleanup")
+}
+
+func TestNodeStateSourceMismatchedDeleteEmitsNothing(t *testing.T) {
+	mngr, _ := newNodeStateTestManager(t)
+	observer := &testNodeStateObserver{}
+	mngr.SubscribeNodeState(observer)
+
+	current := nodeTypes.Node{Name: "node-1", Cluster: "cluster-1", Source: source.Local}
+	mngr.NodeUpdated(current)
+	mismatched := current
+	mismatched.Source = source.Kubernetes
+	mngr.NodeDeleted(mismatched)
+
+	require.Equal(t, []nodeStateTestEvent{{kind: "upsert", node: current}}, observer.recordedEvents())
+	require.Equal(t, current, mngr.GetNodes()[current.Identity()])
+}
+
+func TestNodeStateSyntheticRestoredDeleteEmitsNothing(t *testing.T) {
+	mngr, _ := newNodeStateTestManager(t)
+	observer := &testNodeStateObserver{}
+	mngr.SubscribeNodeState(observer)
+
+	mngr.NodeDeleted(nodeTypes.Node{Name: "stale-node", Cluster: "cluster-1", Source: source.Restored})
+
+	require.Empty(t, observer.recordedEvents())
+}
+
+func TestNodeStateUnsubscribeWaitsForCallbackAndPreventsLaterCallbacks(t *testing.T) {
+	mngr, _ := newNodeStateTestManager(t)
+	releaseCallback := make(chan struct{})
+	var releaseCallbackOnce sync.Once
+	defer releaseCallbackOnce.Do(func() { close(releaseCallback) })
+	observer := &testNodeStateObserver{
+		entered: make(chan nodeStateTestEvent, 1),
+		release: releaseCallback,
+	}
+	mngr.SubscribeNodeState(observer)
+
+	first := nodeTypes.Node{Name: "node-1", Cluster: "cluster-1", Source: source.Kubernetes}
+	updateDone := make(chan struct{})
+	go func() {
+		mngr.NodeUpdated(first)
+		close(updateDone)
+	}()
+	require.Equal(t, first, receiveNodeStateTestEvent(t, observer.entered).node)
+
+	unsubscribeDone, unsubscribeState := startNodeStateTestOperation(t, func() {
+		mngr.UnsubscribeNodeState(observer)
+	})
+	require.Equal(t, int32(1), unsubscribeState.Load(), "unsubscribe returned while an observer callback was in flight")
+
+	releaseCallbackOnce.Do(func() { close(releaseCallback) })
+	waitForNodeStateTestOperation(t, updateDone, "blocked observer callback")
+	waitForNodeStateTestOperation(t, unsubscribeDone, "observer unsubscription")
+
+	mngr.NodeUpdated(nodeTypes.Node{Name: "node-2", Cluster: "cluster-1", Source: source.Kubernetes})
+	require.Equal(t, []nodeStateTestEvent{{kind: "upsert", node: first}}, observer.recordedEvents())
+}
+
+func TestNodeStateOrderingAndManagerEntryLockOrder(t *testing.T) {
+	t.Run("callbacks preserve add update delete ordering", func(t *testing.T) {
+		mngr, _ := newNodeStateTestManager(t)
+		observer := &testNodeStateObserver{}
+		mngr.SubscribeNodeState(observer)
+
+		added := nodeTypes.Node{Name: "node-1", Cluster: "cluster-1", Source: source.Kubernetes}
+		updated := added
+		updated.Labels = map[string]string{"version": "new"}
+		mngr.NodeUpdated(added)
+		mngr.NodeUpdated(updated)
+		mngr.NodeDeleted(updated)
+
+		require.Equal(t, []nodeStateTestEvent{
+			{kind: "upsert", node: added},
+			{kind: "upsert", node: updated},
+			{kind: "delete", node: updated},
+		}, observer.recordedEvents())
+	})
+
+	t.Run("delete follows manager then entry lock order without deadlock", func(t *testing.T) {
+		mngr, ipcache := newNodeStateTestManager(t)
+		current := nodeTypes.Node{
+			Name: "node-1", Cluster: "cluster-1", Source: source.Kubernetes,
+			IPAddresses: []nodeTypes.Address{{Type: addressing.NodeInternalIP, IP: net.ParseIP("10.0.0.1")}},
+		}
+		mngr.NodeUpdated(current)
+		for len(ipcache.events) > 0 {
+			<-ipcache.events
+		}
+
+		// The documented order is manager mutex then entry mutex. Holding the
+		// entry lock here forces delete to wait before cleanup while retaining
+		// the manager lock; releasing it must let the delete complete.
+		mngr.mutex.Lock()
+		entry := mngr.nodes[current.Identity()]
+		entry.mutex.Lock()
+		var unlockEntryOnce sync.Once
+		defer unlockEntryOnce.Do(entry.mutex.Unlock)
+		mngr.mutex.Unlock()
+
+		deleteDone, deleteState := startNodeStateTestOperation(t, func() {
+			mngr.deleteNodeState(current, current.Identity())
+		})
+		require.Equal(t, int32(1), deleteState.Load(), "delete did not block on the live entry lock")
+		select {
+		case event := <-ipcache.events:
+			t.Fatalf("IPCache cleanup ran before the live entry lock was acquired: %+v", event)
+		default:
+		}
+
+		unlockEntryOnce.Do(entry.mutex.Unlock)
+		waitForNodeStateTestOperation(t, deleteDone, "node deletion after releasing entry lock")
+		require.NotContains(t, mngr.GetNodes(), current.Identity())
+	})
 }
 
 func TestNodeLifecycle(t *testing.T) {

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -484,8 +484,8 @@ func TestNodeStateAcceptedUpdatesIgnoreDatapathSuppression(t *testing.T) {
 		{kind: "upsert", node: added},
 		{kind: "upsert", node: updated},
 	}, observer.recordedEvents())
-	require.Zero(t, len(dp.NodeAddEvent))
-	require.Zero(t, len(dp.NodeUpdateEvent))
+	require.Empty(t, dp.NodeAddEvent)
+	require.Empty(t, dp.NodeUpdateEvent)
 }
 
 func TestNodeStateRejectedUpdateEmitsNothing(t *testing.T) {
@@ -538,7 +538,7 @@ func TestNodeStateDeleteUsesLatestStoredSnapshot(t *testing.T) {
 	default:
 		t.Fatal("latest stored node address was not removed from IPCache")
 	}
-	require.Zero(t, len(ipcache.events), "stale caller payload drove additional IPCache cleanup")
+	require.Empty(t, ipcache.events, "stale caller payload drove additional IPCache cleanup")
 }
 
 func TestNodeStateSourceMismatchedDeleteEmitsNothing(t *testing.T) {

--- a/pkg/proxy/accesslog/record.go
+++ b/pkg/proxy/accesslog/record.go
@@ -84,6 +84,10 @@ type EndpointInfo struct {
 	// Identity is the security identity of the endpoint
 	Identity uint64
 
+	// SecurityIdentityProvided indicates whether Identity was provided by the
+	// original proxy event rather than filled later by a userspace lookup.
+	SecurityIdentityProvided bool `json:"-"`
+
 	// Labels is the list of security relevant labels of the endpoint.
 	// Shared, do not mutate!
 	Labels labels.LabelArray

--- a/pkg/proxy/accesslog/record_test.go
+++ b/pkg/proxy/accesslog/record_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package accesslog
+
+import (
+	"bytes"
+	"encoding/gob"
+	"encoding/json"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogRecordGobPreservesIdentityProvided(t *testing.T) {
+	want := LogRecord{
+		SourceEndpoint: EndpointInfo{
+			Identity:                 101,
+			SecurityIdentityProvided: true,
+		},
+		DestinationEndpoint: EndpointInfo{
+			Identity:                 202,
+			SecurityIdentityProvided: true,
+		},
+	}
+
+	var wire bytes.Buffer
+	require.NoError(t, gob.NewEncoder(&wire).Encode(want))
+
+	var got LogRecord
+	require.NoError(t, gob.NewDecoder(&wire).Decode(&got))
+	require.Equal(t, want, got)
+	require.True(t, got.SourceEndpoint.SecurityIdentityProvided)
+	require.True(t, got.DestinationEndpoint.SecurityIdentityProvided)
+}
+
+func TestLogRecordGobDecodesRecordsWithoutIdentityProvided(t *testing.T) {
+	type legacyEndpointInfo struct {
+		Identity uint64
+	}
+	type legacyLogRecord struct {
+		SourceEndpoint      legacyEndpointInfo
+		DestinationEndpoint legacyEndpointInfo
+	}
+
+	want := legacyLogRecord{
+		SourceEndpoint:      legacyEndpointInfo{Identity: 303},
+		DestinationEndpoint: legacyEndpointInfo{Identity: 404},
+	}
+	var wire bytes.Buffer
+	require.NoError(t, gob.NewEncoder(&wire).Encode(want))
+
+	var got LogRecord
+	require.NoError(t, gob.NewDecoder(&wire).Decode(&got))
+	require.Equal(t, want.SourceEndpoint.Identity, got.SourceEndpoint.Identity)
+	require.Equal(t, want.DestinationEndpoint.Identity, got.DestinationEndpoint.Identity)
+	require.False(t, got.SourceEndpoint.SecurityIdentityProvided)
+	require.False(t, got.DestinationEndpoint.SecurityIdentityProvided)
+}
+
+func TestEndpointInfoJSONHidesIdentityProvided(t *testing.T) {
+	assertJSONHidesIdentityProvided(t, EndpointInfo{
+		Identity:                 101,
+		SecurityIdentityProvided: true,
+	})
+}
+
+func TestLogRecordJSONHidesIdentityProvided(t *testing.T) {
+	assertJSONHidesIdentityProvided(t, LogRecord{
+		SourceEndpoint: EndpointInfo{
+			Identity:                 101,
+			SecurityIdentityProvided: true,
+		},
+		DestinationEndpoint: EndpointInfo{
+			Identity:                 202,
+			SecurityIdentityProvided: true,
+		},
+	})
+}
+
+func assertJSONHidesIdentityProvided(t *testing.T, value any) {
+	t.Helper()
+
+	data, err := json.Marshal(value)
+	require.NoError(t, err)
+
+	var decoded any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assertNoIdentityProvenanceKey(t, decoded)
+}
+
+func assertNoIdentityProvenanceKey(t *testing.T, value any) {
+	t.Helper()
+
+	switch value := value.(type) {
+	case map[string]any:
+		for key, nested := range value {
+			normalized := strings.Map(func(r rune) rune {
+				if unicode.IsLetter(r) {
+					return unicode.ToLower(r)
+				}
+				return -1
+			}, key)
+			require.NotContains(t, normalized, "identityprovided", "JSON exposed identity provenance as %q", key)
+			require.NotContains(t, normalized, "identityknown", "JSON exposed derived identity provenance as %q", key)
+			assertNoIdentityProvenanceKey(t, nested)
+		}
+	case []any:
+		for _, nested := range value {
+			assertNoIdentityProvenanceKey(t, nested)
+		}
+	}
+}

--- a/pkg/proxy/accesslog/tags.go
+++ b/pkg/proxy/accesslog/tags.go
@@ -68,12 +68,13 @@ type AddressingInfo struct {
 func (logTags) Addressing(ctx context.Context, i AddressingInfo) LogTag {
 	return func(lr *LogRecord, endpointInfoRegistry EndpointInfoRegistry) {
 		lr.SourceEndpoint.ID = i.SrcEPID
+		sourceIdentity := i.SrcIdentity
 		if i.SrcSecIdentity != nil {
-			lr.SourceEndpoint.Identity = uint64(i.SrcSecIdentity.ID)
+			sourceIdentity = i.SrcSecIdentity.ID
 			lr.SourceEndpoint.Labels = i.SrcSecIdentity.LabelArray
-		} else {
-			lr.SourceEndpoint.Identity = uint64(i.SrcIdentity)
 		}
+		lr.SourceEndpoint.Identity = uint64(sourceIdentity)
+		lr.SourceEndpoint.SecurityIdentityProvided = sourceIdentity != identity.IdentityUnknown
 
 		addrPort, err := netip.ParseAddrPort(i.SrcIPPort)
 		if err == nil {
@@ -86,12 +87,13 @@ func (logTags) Addressing(ctx context.Context, i AddressingInfo) LogTag {
 		}
 
 		lr.DestinationEndpoint.ID = i.DstEPID
+		destinationIdentity := i.DstIdentity
 		if i.DstSecIdentity != nil {
-			lr.DestinationEndpoint.Identity = uint64(i.DstSecIdentity.ID)
+			destinationIdentity = i.DstSecIdentity.ID
 			lr.DestinationEndpoint.Labels = i.DstSecIdentity.LabelArray
-		} else {
-			lr.DestinationEndpoint.Identity = uint64(i.DstIdentity)
 		}
+		lr.DestinationEndpoint.Identity = uint64(destinationIdentity)
+		lr.DestinationEndpoint.SecurityIdentityProvided = destinationIdentity != identity.IdentityUnknown
 
 		addrPort, err = netip.ParseAddrPort(i.DstIPPort)
 		if err == nil {

--- a/pkg/proxy/accesslog/tags_test.go
+++ b/pkg/proxy/accesslog/tags_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package accesslog
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/identity"
+)
+
+type endpointInfoRegistryFunc func(*EndpointInfo, netip.Addr)
+
+func (f endpointInfoRegistryFunc) FillEndpointInfo(_ context.Context, info *EndpointInfo, addr netip.Addr) {
+	f(info, addr)
+}
+
+func TestAddressingIdentityProvided(t *testing.T) {
+	sourceIP := netip.MustParseAddr("192.0.2.10")
+	destinationIP := netip.MustParseAddr("192.0.2.20")
+
+	tests := []struct {
+		name                    string
+		addressing              AddressingInfo
+		wantSourceIdentity      uint64
+		wantDestinationIdentity uint64
+		wantSourceProvided      bool
+		wantDestinationProvided bool
+		fillSourceIdentity      uint64
+		fillDestinationIdentity uint64
+	}{
+		{
+			name: "security identity pointers",
+			addressing: AddressingInfo{
+				SrcSecIdentity: &identity.Identity{ID: 101},
+				SrcIdentity:    901,
+				DstSecIdentity: &identity.Identity{ID: 202},
+				DstIdentity:    902,
+			},
+			wantSourceIdentity:      101,
+			wantDestinationIdentity: 202,
+			wantSourceProvided:      true,
+			wantDestinationProvided: true,
+		},
+		{
+			name: "numeric identity fallback",
+			addressing: AddressingInfo{
+				SrcIdentity: 303,
+				DstIdentity: 404,
+			},
+			wantSourceIdentity:      303,
+			wantDestinationIdentity: 404,
+			wantSourceProvided:      true,
+			wantDestinationProvided: true,
+		},
+		{
+			name: "unknown pointer overrides numeric fallback",
+			addressing: AddressingInfo{
+				SrcSecIdentity: &identity.Identity{ID: identity.IdentityUnknown},
+				SrcIdentity:    505,
+				DstSecIdentity: &identity.Identity{ID: identity.IdentityUnknown},
+				DstIdentity:    606,
+			},
+			wantSourceIdentity:      7001,
+			wantDestinationIdentity: 7002,
+			wantSourceProvided:      false,
+			wantDestinationProvided: false,
+			fillSourceIdentity:      7001,
+			fillDestinationIdentity: 7002,
+		},
+		{
+			name: "unknown numeric identity remains unprovided after userspace fill",
+			addressing: AddressingInfo{
+				SrcIdentity: identity.IdentityUnknown,
+				DstIdentity: identity.IdentityUnknown,
+			},
+			wantSourceIdentity:      8001,
+			wantDestinationIdentity: 8002,
+			wantSourceProvided:      false,
+			wantDestinationProvided: false,
+			fillSourceIdentity:      8001,
+			fillDestinationIdentity: 8002,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addressing := tt.addressing
+			addressing.SrcIPPort = netip.AddrPortFrom(sourceIP, 1234).String()
+			addressing.DstIPPort = netip.AddrPortFrom(destinationIP, 4321).String()
+
+			sourceFillCalled := false
+			destinationFillCalled := false
+			registry := endpointInfoRegistryFunc(func(info *EndpointInfo, addr netip.Addr) {
+				switch addr {
+				case sourceIP:
+					sourceFillCalled = true
+					require.Equal(t, tt.wantSourceProvided, info.SecurityIdentityProvided,
+						"source provenance must be set from the selected original identity before userspace fill")
+					if tt.fillSourceIdentity != 0 {
+						require.Zero(t, info.Identity, "an unknown pointer must override a numeric fallback")
+						info.Identity = tt.fillSourceIdentity
+					}
+				case destinationIP:
+					destinationFillCalled = true
+					require.Equal(t, tt.wantDestinationProvided, info.SecurityIdentityProvided,
+						"destination provenance must be set from the selected original identity before userspace fill")
+					if tt.fillDestinationIdentity != 0 {
+						require.Zero(t, info.Identity, "an unknown pointer must override a numeric fallback")
+						info.Identity = tt.fillDestinationIdentity
+					}
+				default:
+					t.Fatalf("unexpected endpoint address %s", addr)
+				}
+			})
+
+			record := LogRecord{
+				SourceEndpoint:      EndpointInfo{SecurityIdentityProvided: true},
+				DestinationEndpoint: EndpointInfo{SecurityIdentityProvided: true},
+			}
+			LogTags.Addressing(t.Context(), addressing)(&record, registry)
+
+			require.True(t, sourceFillCalled)
+			require.True(t, destinationFillCalled)
+			require.Equal(t, tt.wantSourceIdentity, record.SourceEndpoint.Identity)
+			require.Equal(t, tt.wantDestinationIdentity, record.DestinationEndpoint.Identity)
+			require.Equal(t, tt.wantSourceProvided, record.SourceEndpoint.SecurityIdentityProvided)
+			require.Equal(t, tt.wantDestinationProvided, record.DestinationEndpoint.SecurityIdentityProvided)
+		})
+	}
+}


### PR DESCRIPTION
This implements the flow-enrichment approach selected in [#34133](https://github.com/cilium/cilium/issues/34133#issuecomment-4961083198).

Hubble flows currently expose labels for the observing node. They do not preserve labels for the source and destination nodes, so a central Hubble consumer cannot filter flows by directional node labels without performing its own node lookup.

This change adds `source_node_labels` and `destination_node_labels` to `Flow` and fills them during parser enrichment. It covers L3/L4 flows, L7 access logs, and socket flows after their final NAT and direction handling. The existing observing-node `node_labels` field keeps its current meaning.

The resolver builds its index from serialized NodeManager replay, update, and delete callbacks. Cluster selection uses exact, cluster-scoped IPCache lookups and identity provenance from the datapath or access log. Missing, conflicting, or untrusted provenance produces no directional labels instead of risking labels from the wrong cluster.

`FlowFilter` has matching source and destination fields. The Hubble CLI exposes them through repeatable `--from-node-labels` and `--to-node-labels` flags. Selectors in one directional field use the existing OR behavior, while source, destination, and observing-node fields combine with AND.

## Compatibility

The protobuf additions use previously unused field numbers. Existing clients can ignore the new fields, and existing `node_labels` filters continue to target the observing node. Access-log identity provenance is carried over gob for internal parsing but remains absent from diagnostic JSON.

## Testing

Validation on the final commit included:

- canonical protobuf regeneration with no diff;
- affected package tests, including all 14 parser packages;
- race tests for NodeManager, the resolver, Hubble lifecycle, L7 parsing, and socket parsing;
- compile-only coverage for 76 Hubble packages and `go vet` coverage for 26 affected packages;
- the pinned `golangci-lint v2.12.2` and custom kube-api linter, both with zero issues;
- five resolver benchmark samples with stable allocation counts.

Linux-only package sets were run with Cilium's pinned Linux builder. The final commit also passed three independent reviews covering ClusterMesh provenance, lifecycle and locking, and protobuf/filter/CLI compatibility.

## AI use

This PR was prepared with [AIL:4](https://danielmiessler.com/blog/ai-influence-level-ail). Hermes Agent and Codex generated substantial parts of the implementation and tests from the issue requirements and a contributor-directed design. I reviewed the final diff and design decisions, checked the generated artifacts, and reran the tests and linters listed above. I take responsibility for the code, its correctness, and its licensing.

Fixes: #34133

```release-note
Hubble flows now include source and destination node labels and can be filtered with `--from-node-labels` and `--to-node-labels`.
```
