### PR TITLE
gha/e2e: cover etcd behind a service

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -484,11 +484,10 @@ jobs:
         run: |
           make kind-kvstore-start KVSTORE_POD_NAME=kvstore KVSTORE_POD_PORT=2378
 
-          IP=$(kubectl --namespace kube-system get pod kvstore -o jsonpath='{.status.hostIP}')
           echo "config= \
             --set=etcd.enabled=true \
             --set=identityAllocationMode=kvstore \
-            --set=etcd.endpoints[0]=http://${IP}:2378 \
+            --set=etcd.endpoints[0]=http://kvstore.kube-system.svc:2378 \
           " >> $GITHUB_OUTPUT
 
       - name: Install Cilium CLI


### PR DESCRIPTION
Following the fixes for the regressions preventing Cilium from starting when configured in kvstore mode \[1,2], if etcd is behind a service, let's extend the E2E tests to cover this scenario as well, to simplify catching possible problems in the future. Specifically, we convert all kvstore matrix entries of the E2E upgrade tests to point to the service, and leave the other workflows to still directly point to the etcd IP.

\[1]: f37f912615f8 ("pkg/dial/resolver: Fix KVStore service resolution on initialisation")
\[2]: 1ae34766202b ("kvstore: introduce circuit breaker to [kvstore.Client] start hook")

AIL: 0