### PR TITLE
gateway-api: index request mirror backends for HTTPRoute and GRPCRoute

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -1315,6 +1315,22 @@ func fakeIndexHTTPRouteByBackendService(rawObj client.Object) []string {
 				}.String(),
 			)
 		}
+		for _, f := range rule.Filters {
+			if f.Type != gatewayv1.HTTPRouteFilterRequestMirror || f.RequestMirror == nil {
+				continue
+			}
+			if !helpers.IsService(f.RequestMirror.BackendRef) {
+				continue
+			}
+			namespace := helpers.NamespaceDerefOr(f.RequestMirror.BackendRef.Namespace, route.Namespace)
+			backendServices = append(
+				backendServices,
+				types.NamespacedName{
+					Namespace: namespace,
+					Name:      string(f.RequestMirror.BackendRef.Name),
+				}.String(),
+			)
+		}
 	}
 	return backendServices
 }

--- a/operator/pkg/gateway-api/indexers/grpcroute.go
+++ b/operator/pkg/gateway-api/indexers/grpcroute.go
@@ -101,6 +101,26 @@ func GenerateIndexerGRPCRoutebyBackendService(c client.Client, logger *slog.Logg
 					}.String(),
 				)
 			}
+			for _, f := range rule.Filters {
+				if f.Type != gatewayv1.GRPCRouteFilterRequestMirror || f.RequestMirror == nil {
+					continue
+				}
+				namespace := helpers.NamespaceDerefOr(f.RequestMirror.BackendRef.Namespace, route.Namespace)
+				backendServiceName, err := helpers.GetBackendServiceName(c, namespace, f.RequestMirror.BackendRef)
+				if err != nil {
+					logger.Error("Failed to get request mirror backend service name",
+						logfields.LogSubsys, logfields.GRPCRoute,
+						logfields.Resource, client.ObjectKeyFromObject(rawObj),
+						logfields.Error, err)
+					continue
+				}
+				backendServices = append(backendServices,
+					types.NamespacedName{
+						Namespace: namespace,
+						Name:      backendServiceName,
+					}.String(),
+				)
+			}
 		}
 
 		return backendServices

--- a/operator/pkg/gateway-api/indexers/grpcroute_test.go
+++ b/operator/pkg/gateway-api/indexers/grpcroute_test.go
@@ -4,6 +4,7 @@
 package indexers
 
 import (
+	"log/slog"
 	"reflect"
 	"slices"
 	"testing"
@@ -12,8 +13,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 )
 
 func TestIndexGRPCRouteByGateway(t *testing.T) {
@@ -179,6 +183,54 @@ func TestIndexGRPCRouteByBackendServiceImport(t *testing.T) {
 				t.Errorf("IndexGRPCRouteByBackendServiceImport() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestGenerateIndexerGRPCRoutebyBackendServiceIncludesRequestMirror(t *testing.T) {
+	indexer := GenerateIndexerGRPCRoutebyBackendService(
+		fake.NewClientBuilder().WithScheme(helpers.TestScheme(nil)).Build(),
+		slog.New(slog.DiscardHandler),
+	)
+
+	route := &gatewayv1.GRPCRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mirror-route",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.GRPCRouteSpec{
+			Rules: []gatewayv1.GRPCRouteRule{
+				{
+					BackendRefs: []gatewayv1.GRPCBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: "primary-svc",
+								},
+							},
+						},
+					},
+					Filters: []gatewayv1.GRPCRouteFilter{
+						{
+							Type: gatewayv1.GRPCRouteFilterRequestMirror,
+							RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+								BackendRef: gatewayv1.BackendObjectReference{
+									Name:      "mirror-svc",
+									Namespace: ptr.To[gatewayv1.Namespace]("other-ns"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	want := []string{
+		"default/primary-svc",
+		"other-ns/mirror-svc",
+	}
+	if got := indexer(route); !slices.Equal(got, want) {
+		t.Errorf("GenerateIndexerGRPCRoutebyBackendService() = %v, want %v", got, want)
 	}
 }
 

--- a/operator/pkg/gateway-api/indexers/httproute.go
+++ b/operator/pkg/gateway-api/indexers/httproute.go
@@ -105,19 +105,37 @@ func GenerateIndexerHTTPRouteByBackendService(c client.Client, logger *slog.Logg
 				)
 			}
 			for _, f := range rule.Filters {
-				if f.Type != gatewayv1.HTTPRouteFilterExternalAuth || f.ExternalAuth == nil {
+				var (
+					namespace          string
+					backendServiceName string
+					err                error
+				)
+
+				switch {
+				case f.Type == gatewayv1.HTTPRouteFilterRequestMirror && f.RequestMirror != nil:
+					namespace = helpers.NamespaceDerefOr(f.RequestMirror.BackendRef.Namespace, route.Namespace)
+					backendServiceName, err = helpers.GetBackendServiceName(c, namespace, f.RequestMirror.BackendRef)
+					if err != nil {
+						logger.Error("Failed to get request mirror backend service name",
+							logfields.LogSubsys, logfields.HTTPRoute,
+							logfields.HTTPRoute, client.ObjectKeyFromObject(rawObj),
+							logfields.Error, err)
+						continue
+					}
+				case f.Type == gatewayv1.HTTPRouteFilterExternalAuth && f.ExternalAuth != nil:
+					namespace = helpers.NamespaceDerefOr(f.ExternalAuth.BackendRef.Namespace, route.Namespace)
+					backendServiceName, err = helpers.GetBackendServiceName(c, namespace, f.ExternalAuth.BackendRef)
+					if err != nil {
+						logger.Error("Failed to get ext_auth backend service name",
+							logfields.LogSubsys, logfields.HTTPRoute,
+							logfields.HTTPRoute, client.ObjectKeyFromObject(rawObj),
+							logfields.Error, err)
+						continue
+					}
+				default:
 					continue
 				}
-				ea := f.ExternalAuth
-				namespace := helpers.NamespaceDerefOr(ea.BackendRef.Namespace, route.Namespace)
-				backendServiceName, err := helpers.GetBackendServiceName(c, namespace, ea.BackendRef)
-				if err != nil {
-					logger.Error("Failed to get ext_auth backend service name",
-						logfields.LogSubsys, logfields.HTTPRoute,
-						logfields.HTTPRoute, client.ObjectKeyFromObject(rawObj),
-						logfields.Error, err)
-					continue
-				}
+
 				backendServices = append(backendServices,
 					types.NamespacedName{
 						Namespace: namespace,

--- a/operator/pkg/gateway-api/indexers/httproute_test.go
+++ b/operator/pkg/gateway-api/indexers/httproute_test.go
@@ -4,6 +4,7 @@
 package indexers
 
 import (
+	"log/slog"
 	"reflect"
 	"slices"
 	"testing"
@@ -12,8 +13,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 )
 
 func TestIndexHTTPRouteByGateway(t *testing.T) {
@@ -261,6 +265,64 @@ func TestIndexHTTPRouteByBackendServiceImport(t *testing.T) {
 				t.Errorf("IndexHTTPRouteByBackendServiceImport() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestGenerateIndexerHTTPRouteByBackendServiceIncludesFilterBackends(t *testing.T) {
+	indexer := GenerateIndexerHTTPRouteByBackendService(
+		fake.NewClientBuilder().WithScheme(helpers.TestScheme(nil)).Build(),
+		slog.New(slog.DiscardHandler),
+	)
+
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mirror-route",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.HTTPRouteSpec{
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: "primary-svc",
+								},
+							},
+						},
+					},
+					Filters: []gatewayv1.HTTPRouteFilter{
+						{
+							Type: gatewayv1.HTTPRouteFilterRequestMirror,
+							RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+								BackendRef: gatewayv1.BackendObjectReference{
+									Name:      "mirror-svc",
+									Namespace: ptr.To[gatewayv1.Namespace]("other-ns"),
+								},
+							},
+						},
+						{
+							Type: gatewayv1.HTTPRouteFilterExternalAuth,
+							ExternalAuth: &gatewayv1.HTTPExternalAuthFilter{
+								BackendRef: gatewayv1.BackendObjectReference{
+									Name:      "auth-svc",
+									Namespace: ptr.To[gatewayv1.Namespace]("auth-ns"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	want := []string{
+		"default/primary-svc",
+		"other-ns/mirror-svc",
+		"auth-ns/auth-svc",
+	}
+	if got := indexer(route); !slices.Equal(got, want) {
+		t.Errorf("GenerateIndexerHTTPRouteByBackendService() = %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
Include RequestMirror backend references in the HTTPRoute and GRPCRoute backend-service indexers.

Without this, Services referenced only through RequestMirror are missed by the Service -> Route -> Gateway lookup path. That can prevent Gateway reconciliation when a mirrored backend Service changes.