### PR TITLE
gateway-api: watch backend Service changes for tcp&udp routes

### DIFF
--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -186,7 +186,7 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			builder.WithPredicates(predicates.GatewayClassOwnedByController(r.controllerName))).
 		// Watch related backend Service for status
 		// LB Services are handled by the Owns call later.
-		Watches(&corev1.Service{}, watchhandlers.EnqueueRequestForBackendService(r.Client, *r.logger, r.controllerName)).
+		Watches(&corev1.Service{}, watchhandlers.EnqueueRequestForBackendService(r.Client, r.Scheme, *r.logger, r.controllerName)).
 		// Watch HTTPRoute linked to Gateway
 		Watches(&gatewayv1.HTTPRoute{}, watchhandlers.EnqueueRequestForOwningHTTPRoute(r.Client, r.logger, r.controllerName)).
 		// Watch GRPCRoute linked to Gateway

--- a/operator/pkg/gateway-api/watch-handlers/service.go
+++ b/operator/pkg/gateway-api/watch-handlers/service.go
@@ -11,12 +11,14 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
@@ -24,7 +26,7 @@ import (
 // EnqueueRequestForBackendService returns an event handler that, when passed a
 // Service, returns reconcile.Requests for all relevant Gateways where that
 // Service is used as a backend for a Route attached to that Gateway.
-func EnqueueRequestForBackendService(c client.Client, logger slog.Logger, controllerName string) handler.EventHandler {
+func EnqueueRequestForBackendService(c client.Client, scheme *runtime.Scheme, logger slog.Logger, controllerName string) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
 		_, ok := o.(*corev1.Service)
 		if !ok {
@@ -56,12 +58,37 @@ func EnqueueRequestForBackendService(c client.Client, logger slog.Logger, contro
 			return []reconcile.Request{}
 		}
 
+		// Then, fetch all GRPCRoutes that reference this service, using the backendServiceIndex
 		grpcRouteList := &gatewayv1.GRPCRouteList{}
 		if err := c.List(ctx, grpcRouteList, &client.ListOptions{
 			FieldSelector: fields.OneTermEqualSelector(indexers.BackendServiceGRPCRouteIndex, client.ObjectKeyFromObject(o).String()),
 		}); err != nil {
 			scopedLog.ErrorContext(ctx, "Unable to list GRPCRoutes", logfields.Error, err)
 			return []reconcile.Request{}
+		}
+
+		tcpRouteEnabled := helpers.HasTCPRouteSupport(scheme)
+		tcpRouteList := &gatewayv1.TCPRouteList{}
+		if tcpRouteEnabled {
+			// Then, fetch all TCPRoutes that reference this service, using the backendServiceIndex
+			if err := c.List(ctx, tcpRouteList, &client.ListOptions{
+				FieldSelector: fields.OneTermEqualSelector(indexers.BackendServiceTCPRouteIndex, client.ObjectKeyFromObject(o).String()),
+			}); err != nil {
+				scopedLog.ErrorContext(ctx, "Unable to list TCPRoutes", logfields.Error, err)
+				return []reconcile.Request{}
+			}
+		}
+
+		udpRouteEnabled := helpers.HasUDPRouteSupport(scheme)
+		udpRouteList := &gatewayv1.UDPRouteList{}
+		if udpRouteEnabled {
+			// Then, fetch all UDPRoutes that reference this service, using the backendServiceIndex
+			if err := c.List(ctx, udpRouteList, &client.ListOptions{
+				FieldSelector: fields.OneTermEqualSelector(indexers.BackendServiceUDPRouteIndex, client.ObjectKeyFromObject(o).String()),
+			}); err != nil {
+				scopedLog.ErrorContext(ctx, "Unable to list UDPRoutes", logfields.Error, err)
+				return []reconcile.Request{}
+			}
 		}
 
 		allGatewaysSet, err := getAllGatewaysSetForController(ctx, c, controllerName)
@@ -80,9 +107,23 @@ func EnqueueRequestForBackendService(c client.Client, logger slog.Logger, contro
 			updateReconcileRequestsForParentRefs(ctx, c, tlsr.Spec.ParentRefs, tlsr.Namespace, allGatewaysSet, reconcileRequests)
 		}
 
-		// iterate through the TLSRoutes, update reconcileRequests for each Gateway that is relevant.
+		// iterate through the GRPCRoutes, update reconcileRequests for each Gateway that is relevant.
 		for _, grpcr := range grpcRouteList.Items {
 			updateReconcileRequestsForParentRefs(ctx, c, grpcr.Spec.ParentRefs, grpcr.Namespace, allGatewaysSet, reconcileRequests)
+		}
+
+		if tcpRouteEnabled {
+			// iterate through the TCPRoutes, update reconcileRequests for each Gateway that is relevant.
+			for _, tcpr := range tcpRouteList.Items {
+				updateReconcileRequestsForParentRefs(ctx, c, tcpr.Spec.ParentRefs, tcpr.Namespace, allGatewaysSet, reconcileRequests)
+			}
+		}
+
+		if udpRouteEnabled {
+			// iterate through the UDPRoutes, update reconcileRequests for each Gateway that is relevant.
+			for _, udpr := range udpRouteList.Items {
+				updateReconcileRequestsForParentRefs(ctx, c, udpr.Spec.ParentRefs, udpr.Namespace, allGatewaysSet, reconcileRequests)
+			}
 		}
 
 		// return the keys of the set, since that's the actual reconcile.Requests.

--- a/operator/pkg/gateway-api/watch-handlers/service_test.go
+++ b/operator/pkg/gateway-api/watch-handlers/service_test.go
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchhandlers
+
+import (
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
+)
+
+const testGatewayControllerName = "io.cilium/gateway-controller"
+
+func TestEnqueueRequestForBackendServiceIncludesGRPCTCPAndUDP(t *testing.T) {
+	scheme := helpers.TestScheme(helpers.AllOptionalKinds)
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "backend-svc",
+			Namespace: "default",
+		},
+	}
+
+	gatewayClass := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cilium",
+		},
+		Spec: gatewayv1.GatewayClassSpec{
+			ControllerName: gatewayv1.GatewayController(testGatewayControllerName),
+		},
+	}
+
+	grpcGateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "grpc-gateway",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cilium",
+		},
+	}
+
+	tcpGateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tcp-gateway",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cilium",
+		},
+	}
+
+	udpGateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "udp-gateway",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cilium",
+		},
+	}
+
+	grpcRoute := &gatewayv1.GRPCRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "grpc-route",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.GRPCRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "grpc-gateway"}},
+			},
+			Rules: []gatewayv1.GRPCRouteRule{{
+				BackendRefs: []gatewayv1.GRPCBackendRef{{
+					BackendRef: gatewayv1.BackendRef{
+						BackendObjectReference: gatewayv1.BackendObjectReference{Name: "backend-svc"},
+					},
+				}},
+			}},
+		},
+	}
+
+	tcpRoute := &gatewayv1.TCPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tcp-route",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.TCPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "tcp-gateway"}},
+			},
+			Rules: []gatewayv1.TCPRouteRule{{
+				BackendRefs: []gatewayv1.BackendRef{{
+					BackendObjectReference: gatewayv1.BackendObjectReference{Name: "backend-svc"},
+				}},
+			}},
+		},
+	}
+
+	udpRoute := &gatewayv1.UDPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "udp-route",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.UDPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "udp-gateway"}},
+			},
+			Rules: []gatewayv1.UDPRouteRule{{
+				BackendRefs: []gatewayv1.BackendRef{{
+					BackendObjectReference: gatewayv1.BackendObjectReference{Name: "backend-svc"},
+				}},
+			}},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(service, gatewayClass, grpcGateway, tcpGateway, udpGateway, grpcRoute, tcpRoute, udpRoute).
+		WithIndex(&gatewayv1.Gateway{}, indexers.ImplementationGatewayIndex, func(rawObj client.Object) []string {
+			return []string{testGatewayControllerName}
+		}).
+		WithIndex(&gatewayv1.HTTPRoute{}, indexers.BackendServiceHTTPRouteIndex, func(rawObj client.Object) []string {
+			return nil
+		}).
+		WithIndex(&gatewayv1.TLSRoute{}, indexers.BackendServiceTLSRouteIndex, func(rawObj client.Object) []string {
+			return nil
+		}).
+		WithIndex(&gatewayv1.GRPCRoute{}, indexers.BackendServiceGRPCRouteIndex, func(rawObj client.Object) []string {
+			route := rawObj.(*gatewayv1.GRPCRoute)
+			return []string{types.NamespacedName{
+				Namespace: route.Namespace,
+				Name:      "backend-svc",
+			}.String()}
+		}).
+		WithIndex(&gatewayv1.TCPRoute{}, indexers.BackendServiceTCPRouteIndex, func(rawObj client.Object) []string {
+			route := rawObj.(*gatewayv1.TCPRoute)
+			return []string{types.NamespacedName{
+				Namespace: route.Namespace,
+				Name:      "backend-svc",
+			}.String()}
+		}).
+		WithIndex(&gatewayv1.UDPRoute{}, indexers.BackendServiceUDPRouteIndex, func(rawObj client.Object) []string {
+			route := rawObj.(*gatewayv1.UDPRoute)
+			return []string{types.NamespacedName{
+				Namespace: route.Namespace,
+				Name:      "backend-svc",
+			}.String()}
+		}).
+		Build()
+
+	handler := EnqueueRequestForBackendService(fakeClient, scheme, *hivetest.Logger(t), testGatewayControllerName)
+	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+	defer queue.ShutDown()
+
+	handler.Create(t.Context(), event.TypedCreateEvent[client.Object]{Object: service}, queue)
+
+	var got []types.NamespacedName
+	for queue.Len() > 0 {
+		item, shutdown := queue.Get()
+		require.False(t, shutdown)
+		got = append(got, item.NamespacedName)
+		queue.Done(item)
+	}
+
+	require.ElementsMatch(t, []types.NamespacedName{
+		{Namespace: "default", Name: "grpc-gateway"},
+		{Namespace: "default", Name: "tcp-gateway"},
+		{Namespace: "default", Name: "udp-gateway"},
+	}, got)
+}


### PR DESCRIPTION
Extend the Gateway backend Service watch handler to enqueue affected Gateways for TCPRoute, and UDPRoute backends in addition to the existing HTTPRoute, GRPCRoute and TLSRoute handling.

Without this, a Service change could be missed when that Service is only referenced by one of those route types, so the affected Gateway would not be requeued through the Service -> Route -> Gateway watch path.

Note: It's needed to pass the controller scheme into the handler so TCPRoute and UDPRoute lookups can be gated on CRD support.

Fixes: https://github.com/cilium/cilium/pull/46184