### PR TITLE
[old] bpf:hostfw: Fix regression in hostfw egress when masquerade enabled

### DIFF
--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -148,6 +148,10 @@ ipv6_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id,
 
 	if (!ipv6_host_policy_egress_lookup(ctx, src_id, ipcache_srcid, ip6, &ct_buffer))
 		return CTX_ACT_OK;
+	/* See https://github.com/cilium/cilium/issues/47223. */
+	if (is_defined(ENABLE_MASQUERADE_IPV4) &&
+	    ct_buffer.ret == DROP_CT_UNKNOWN_PROTO && src_id != HOST_ID)
+		return CTX_ACT_OK;
 	if (ct_buffer.ret < 0)
 		return ct_buffer.ret;
 
@@ -432,6 +436,10 @@ ipv4_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id,
 	struct ct_buffer4 ct_buffer = {};
 
 	if (!ipv4_host_policy_egress_lookup(ctx, src_id, ipcache_srcid, ip4, &ct_buffer))
+		return CTX_ACT_OK;
+	/* See https://github.com/cilium/cilium/issues/47223. */
+	if (is_defined(ENABLE_MASQUERADE_IPV4) &&
+	    ct_buffer.ret == DROP_CT_UNKNOWN_PROTO && src_id != HOST_ID)
 		return CTX_ACT_OK;
 	if (ct_buffer.ret < 0)
 		return ct_buffer.ret;

--- a/bpf/tests/hostfw_bpf_masq.c
+++ b/bpf/tests/hostfw_bpf_masq.c
@@ -192,3 +192,201 @@ int hostfw_ipv4_bpf_masq_proxy_02_check(const struct __ctx_buff *ctx)
 
 	test_finish();
 }
+
+/* HostFw conntrack lookup fails for non-TCP/UDP protocols with HOST_ID. */
+PKTGEN("tc", "hostfw_ipv4_bpf_masq_extended_protocol")
+int hostfw_ipv4_bpf_masq_extended_protocol_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct iphdr *l3;
+
+	pktgen__init(&builder, ctx);
+
+	l3 = pktgen__push_ipv4_packet(&builder,
+				      (__u8 *)node_mac, (__u8 *)server_mac,
+				      NODE_IP, SERVER_IP);
+
+	if (!l3)
+		return TEST_ERROR;
+
+	l3->protocol = IPPROTO_IGMP;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "hostfw_ipv4_bpf_masq_extended_protocol")
+int hostfw_ipv4_bpf_masq_extended_protocol_setup(struct __ctx_buff *ctx)
+{
+	endpoint_v4_add_entry(NODE_IP, 0, 0, ENDPOINT_F_HOST, HOST_ID,
+			      0, (__u8 *)node_mac, (__u8 *)node_mac);
+	ipcache_v4_add_entry(NODE_IP, 0, HOST_ID, 0, 0);
+	ipcache_v4_add_world_entry();
+
+	set_identity_mark(ctx, 0, MARK_MAGIC_HOST);
+
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+	return TEST_ERROR;
+}
+
+CHECK("tc", "hostfw_ipv4_bpf_masq_extended_protocol")
+int hostfw_ipv4_bpf_masq_extended_protocol_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_DROP);
+
+	test_finish();
+}
+
+/* HostFW is enforced for TCP/UDP packets with UNKNOWN_ID */
+PKTGEN("tc", "hostfw_ipv4_bpf_masq_unknown_id")
+int hostfw_ipv4_bpf_masq_unknown_id_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct udphdr *udp;
+
+	pktgen__init(&builder, ctx);
+
+	udp = pktgen__push_ipv4_udp_packet(&builder,
+					   (__u8 *)server_mac, (__u8 *)node_mac,
+					   NODE_IP, SERVER_IP,
+					   NODE_PORT, SERVER_PORT);
+	if (!udp)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "hostfw_ipv4_bpf_masq_unknown_id")
+int hostfw_ipv4_bpf_masq_unknown_id_setup(struct __ctx_buff *ctx)
+{
+	endpoint_v4_add_entry(NODE_IP, 0, 0, ENDPOINT_F_HOST, HOST_ID,
+			      0, (__u8 *)node_mac, (__u8 *)node_mac);
+	ipcache_v4_add_entry(NODE_IP, 0, HOST_ID, 0, 0);
+	ipcache_v4_add_world_entry();
+
+	ctx->mark = 0;
+
+	/* Cleanup conntrack from previous hostfw_ipv4_bpf_masq_proxy tests */
+	struct ipv4_ct_tuple tuple = {
+		.daddr   = NODE_IP,
+		.saddr   = SERVER_IP,
+		.dport   = SERVER_PORT,
+		.sport   = NODE_PORT,
+		.nexthdr = IPPROTO_UDP,
+		.flags = TUPLE_F_OUT,
+	};
+	map_delete_elem(get_ct_map4(&tuple), &tuple);
+
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+	return TEST_ERROR;
+}
+
+CHECK("tc", "hostfw_ipv4_bpf_masq_unknown_id")
+int hostfw_ipv4_bpf_masq_unknown_id_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	/* Check that HostFW updated the CT entry */
+	struct ipv4_ct_tuple tuple = {
+		.daddr   = NODE_IP,
+		.saddr   = SERVER_IP,
+		.dport   = SERVER_PORT,
+		.sport   = NODE_PORT,
+		.nexthdr = IPPROTO_UDP,
+		.flags = TUPLE_F_OUT,
+	};
+	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+
+	if (!ct_entry)
+		test_fatal("no CT entry found");
+
+	assert(ct_entry->packets == 1);
+
+	test_finish();
+}
+
+/* HostFw is not enforced for non-TCP/UDP protocols with UNKNOWN_ID. */
+PKTGEN("tc", "hostfw_ipv4_bpf_masq_unknown_id_extended_protocol")
+int hostfw_ipv4_bpf_masq_unknown_id_extended_protocol_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct iphdr *l3;
+
+	pktgen__init(&builder, ctx);
+
+	l3 = pktgen__push_ipv4_packet(&builder,
+				      (__u8 *)server_mac, (__u8 *)node_mac,
+				      NODE_IP, SERVER_IP);
+	if (!l3)
+		return TEST_ERROR;
+
+	l3->protocol = IPPROTO_IGMP;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "hostfw_ipv4_bpf_masq_unknown_id_extended_protocol")
+int hostfw_ipv4_bpf_masq_unknown_id_extended_protocol_setup(struct __ctx_buff *ctx)
+{
+	endpoint_v4_add_entry(NODE_IP, 0, 0, ENDPOINT_F_HOST, HOST_ID,
+			      0, (__u8 *)node_mac, (__u8 *)node_mac);
+	ipcache_v4_add_entry(NODE_IP, 0, HOST_ID, 0, 0);
+	ipcache_v4_add_world_entry();
+
+	ctx->mark = 0;
+
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+	return TEST_ERROR;
+}
+
+CHECK("tc", "hostfw_ipv4_bpf_masq_unknown_id_extended_protocol")
+int hostfw_ipv4_bpf_masq_unknown_id_extended_protocol_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	test_finish();
+}


### PR DESCRIPTION
As described in the linked issue below, we're hitting regression in the
HostFirewall egress path in upgrades from v1.17 to v1.18 when masquerade
is enabled. In case of packets with `src_sec_id=UNKNOWN_ID` such as for
non-transparent proxy, we do not enforce policies but still perform the
conntrack lookup so that we don't enforce policies either on replies in
the ingress hook. Those packets from proxy are either TCP/UDP, thus the
lookup will likely always succeed. However, for kernel-generated packets
with the node IP as source, the packet reaches this hook with `src_sec_id=UNKNOWN_ID`,
so we try to perform the lookup in conntrack. For non-TCP/UDP packets,
this results in drop with DROP_CT_UNKNOWN_PROTOCOL, while in v1.17 we were
simply skipping the conntrack lookup and allowing the packet to pass through.
   
This patch fixes the regression by skipping the conntrack lookup for packets with
`src_sec_id=UNKNOWN_ID`, node IP as source, and getting the DROP_CT_UNKNOWN_PROTOCOL
error from the lookup.

Fixes: https://github.com/cilium/cilium/issues/47223.
