### PR TITLE
.github: allow fork PR checkout in v1.20 build-images workflows

### DIFF
--- a/.github/workflows/build-images-base-v1.20.yaml
+++ b/.github/workflows/build-images-base-v1.20.yaml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout base or default branch (trusted)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # This workflow is supposed to run only on pull_request_target context, but in case workflow call is made from a push context we still keep the default to default_branch
           ref: ${{ github.base_ref || github.event.repository.default_branch }}
@@ -76,9 +76,11 @@ jobs:
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.
       - name: Checkout pull request branch (NOT TRUSTED)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          # Required by checkout v7+ to fetch fork PR code; see the NOT TRUSTED warning above.
+          allow-unsafe-pr-checkout: true
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set-up git

--- a/.github/workflows/build-images-ci-v1.20.yaml
+++ b/.github/workflows/build-images-ci-v1.20.yaml
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: Checkout base or default branch (trusted)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # We first check if base_ref exist, meaning we're in pull_request_target context, and if not we just use default_branch
           ref: ${{ github.base_ref || github.event.repository.default_branch }}
@@ -187,9 +187,11 @@ jobs:
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.
       - name: Checkout pull request branch (NOT TRUSTED)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          # Required by checkout v7+ to fetch fork PR code; see the NOT TRUSTED warning above.
+          allow-unsafe-pr-checkout: true
           ref: ${{ steps.tag.outputs.sha }}
 
       - name: Check for disk usage

--- a/.github/workflows/build-images-docs-builder-v1.20.yaml
+++ b/.github/workflows/build-images-docs-builder-v1.20.yaml
@@ -35,7 +35,7 @@ jobs:
       digest: ${{ steps.docker-build-docs-builder.outputs.digest }}
     steps:
       - name: Checkout base branch (trusted)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.base_ref }}
           persist-credentials: false
@@ -52,9 +52,11 @@ jobs:
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.
       - name: Checkout pull request branch (NOT TRUSTED)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          # Required by checkout v7+ to fetch fork PR code; see the NOT TRUSTED warning above.
+          allow-unsafe-pr-checkout: true
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Generate image tag for docs-builder
@@ -106,7 +108,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout base branch (trusted)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.base_ref }}
           persist-credentials: false
@@ -117,9 +119,11 @@ jobs:
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.
       - name: Checkout pull request branch (NOT TRUSTED)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          # Required by checkout v7+ to fetch fork PR code; see the NOT TRUSTED warning above.
+          allow-unsafe-pr-checkout: true
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up git
@@ -159,9 +163,11 @@ jobs:
       deployment: false
     steps:
       - name: Checkout pull request branch (NOT TRUSTED)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          # Required by checkout v7+ to fetch fork PR code; see the NOT TRUSTED warning above.
+          allow-unsafe-pr-checkout: true
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up git
@@ -200,7 +206,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout base branch (trusted)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.base_ref }}
           persist-credentials: false


### PR DESCRIPTION
Follow-up to #47133, which added `allow-unsafe-pr-checkout` to the
build-images `pull_request_target` workflows but missed the v1.20
variants. It covered `build-images-base.yaml` and the v1.17/v1.18/v1.19
suffixed files, but not `build-images-{base,ci,docs-builder}-v1.20`.

These are the `pull_request_target` entry workflows for v1.20 PRs. They
live on `main`, since `pull_request_target` always reads the workflow
from the default branch. Without the flag, checkout v7 refuses to fetch
fork PR head code, so the image builds break for PRs opened from forks
against v1.20.

This sets `allow-unsafe-pr-checkout: true` on the NOT TRUSTED checkouts
and bumps the checkout pin to v7.0.0, matching the rest of #47133.

This PR was prepared with AIL:3.
