### PR TITLE
conn-disrupt: surface benign-vs-real discriminator on restart failure

### DIFF
--- a/.github/actions/conn-disrupt-test-check/action.yaml
+++ b/.github/actions/conn-disrupt-test-check/action.yaml
@@ -72,3 +72,28 @@ runs:
           --test-concurrency=${{ inputs.test-concurrency }} \
           --expected-xfrm-errors "+inbound_no_state" \
           ${EXTRA_ARG}
+
+    # A conn-disrupt restart is often not a datapath drop but the test client
+    # being starved off-CPU (BPF recompiles during a rollout on a small KIND
+    # host) until its socket deadline fires. Surface that saturation signal in
+    # the job log so the benign case can be told apart from a real drop without
+    # a manual sysdump dive. Best-effort: never fails the job.
+    - name: Capture host saturation signals on conn-disrupt failure
+      if: ${{ failure() }}
+      shell: bash {0}
+      run: |
+        echo "=== node CPU/memory (best-effort, needs metrics-server) ==="
+        kubectl top nodes || true
+        echo "=== per-node load average ==="
+        for node in $(kubectl get nodes -o name); do
+          echo "--- ${node#node/} ---"
+          docker exec "${node#node/}" cat /proc/loadavg 2>/dev/null || true
+          docker exec "${node#node/}" cat /proc/pressure/cpu 2>/dev/null || true
+        done
+        echo "=== recent BPF compile / regeneration durations per agent ==="
+        for pod in $(kubectl get -n kube-system pods -l k8s-app=cilium -o name); do
+          echo "--- ${pod#pod/} ---"
+          kubectl logs -n kube-system "$pod" -c cilium-agent --since=15m 2>/dev/null \
+            | grep -E 'BPFCompilationTime|eventHandlingDuration|Completed endpoint regeneration' \
+            | tail -20 || true
+        done

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -209,6 +209,13 @@ func miscSystemCommands() []string {
 		"uname -a",
 		"top -b -n 1",
 		"uptime",
+		// CPU/IO/memory pressure over a short window, to tell sustained host
+		// saturation (which can starve workloads until their socket deadlines
+		// fire) apart from a point-in-time top snapshot.
+		"cat /proc/pressure/cpu",
+		"cat /proc/pressure/io",
+		"cat /proc/pressure/memory",
+		"vmstat 1 5",
 		"dmesg --time-format=iso",
 		"sysctl -a",
 		"bpftool map show",

--- a/cilium-cli/connectivity/tests/upgrade.go
+++ b/cilium-cli/connectivity/tests/upgrade.go
@@ -14,10 +14,13 @@ import (
 	"strings"
 	"time"
 
+	"google.golang.org/protobuf/types/known/timestamppb"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
+	"github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/api/v1/observer"
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/k8s"
 )
@@ -172,11 +175,15 @@ func (n *noInterruptedConnections) Run(ctx context.Context, t *check.Test) {
 
 // restartReason returns a human-readable, best-effort explanation of why the
 // container of the given conn-disrupt client/server pod restarted. It reports
-// the last termination state (exit code, signal, reason) and the tail of the
-// previous container's logs. It is only used to enrich the failure message so
-// that a benign environmental restart can be told apart from a genuine
-// connection disruption; it never changes the pass/fail outcome and swallows
-// its own errors, returning an empty string when nothing can be collected.
+// the last termination state (exit code, signal, reason), the tail of the
+// previous container's logs, and whether Cilium dropped any flow to or from the
+// pod during its downtime. It is only used to enrich the failure message so
+// that a benign environmental restart (e.g. host CPU saturation starving the
+// test client until its socket deadline fires, with the connection never
+// dropped) can be told apart from a genuine datapath disruption (a burst of
+// DROPPED flows on the pod's IP); it never changes the pass/fail outcome and
+// swallows its own errors, returning an empty string when nothing can be
+// collected.
 func restartReason(ctx context.Context, ct *check.ConnectivityTest, client *k8s.Client, podName string) string {
 	if client == nil {
 		return ""
@@ -193,6 +200,15 @@ func restartReason(ctx context.Context, ct *check.ConnectivityTest, client *k8s.
 		fmt.Fprintf(&sb, "; last termination: exitCode=%d signal=%d reason=%q message=%q startedAt=%s finishedAt=%s",
 			term.ExitCode, term.Signal, term.Reason, term.Message,
 			term.StartedAt.Format(time.RFC3339), term.FinishedAt.Format(time.RFC3339))
+
+		// The single most useful benign-vs-real discriminator: did Cilium
+		// actually drop any flow to/from this pod while it was down? A clean
+		// window (no drops) points at host saturation; a POLICY_DENIED burst
+		// points at a real datapath regression.
+		if drops := hubbleDropSummary(ctx, ct, pod.Status.PodIP,
+			term.StartedAt.Time, term.FinishedAt.Time); drops != "" {
+			sb.WriteString(drops)
+		}
 	}
 
 	var logs bytes.Buffer
@@ -205,4 +221,57 @@ func restartReason(ctx context.Context, ct *check.ConnectivityTest, client *k8s.
 	}
 
 	return sb.String()
+}
+
+// hubbleDropSummary asks Hubble for DROPPED flows involving podIP within the
+// pod's downtime window and returns a short summary suitable for appending to
+// the failure message. It returns a "0 dropped flows" note when the window was
+// clean, a per-reason breakdown when drops are found, and an empty string when
+// Hubble is unavailable or the query fails (best-effort, never fatal).
+func hubbleDropSummary(ctx context.Context, ct *check.ConnectivityTest, podIP string, since, until time.Time) string {
+	hubbleClient := ct.HubbleClient()
+	if hubbleClient == nil || podIP == "" || since.IsZero() || until.IsZero() {
+		return ""
+	}
+
+	// Bound the query so a hung Relay can never stall the failure path.
+	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	// Pad the window slightly: container start/finish timestamps and flow
+	// timestamps are not perfectly aligned.
+	req := &observer.GetFlowsRequest{
+		Since: timestamppb.New(since.Add(-5 * time.Second)),
+		Until: timestamppb.New(until.Add(5 * time.Second)),
+		Whitelist: []*flow.FlowFilter{
+			{SourceIp: []string{podIP}, Verdict: []flow.Verdict{flow.Verdict_DROPPED}},
+			{DestinationIp: []string{podIP}, Verdict: []flow.Verdict{flow.Verdict_DROPPED}},
+		},
+	}
+
+	b, err := hubbleClient.GetFlows(queryCtx, req)
+	if err != nil {
+		return ""
+	}
+
+	reasons := make(map[string]int)
+	total := 0
+	for {
+		res, err := b.Recv()
+		if err != nil {
+			break
+		}
+		f := res.GetFlow()
+		if f == nil {
+			continue
+		}
+		total++
+		reason := fmt.Sprintf("%s/%s", f.GetDropReasonDesc(), f.GetTrafficDirection())
+		reasons[reason]++
+	}
+
+	if total == 0 {
+		return fmt.Sprintf("; hubble: 0 dropped flows on %s during downtime (points at benign host saturation, not a datapath drop)", podIP)
+	}
+	return fmt.Sprintf("; hubble: %d dropped flows on %s during downtime %v (points at a real datapath drop, not benign saturation)", total, podIP, reasons)
 }


### PR DESCRIPTION
When the no-interrupted-connections conn-disrupt test fails with a restart-count mismatch, the failure message looks the same whether the test client was simply starved off-CPU until its socket deadline fired (a benign flake, common when BPF templates get recompiled during an upgrade or downgrade rollout on a small KIND host) or whether the datapath actually dropped its traffic during an endpoint reload (a real regression). Telling the two apart today means downloading the precheck sysdump and correlating Hubble flows, agent BPF-compile times and host load average by hand.

This makes that discrimination automatic without touching the pass/fail outcome. restartReason, which already prints on the failing assertion, now asks Hubble whether any flow to or from the restarted pod was dropped during its downtime window and appends a one-line verdict: zero drops points at benign host saturation, a burst of dropped flows points at a real datapath drop. The query is bounded and best-effort, so it never stalls the failure path or changes the result. The conn-disrupt check action also captures per-node load average, /proc/pressure/cpu and each agent's recent BPF-compile and regeneration durations into the job log on failure, and bugtool now collects PSI and a short vmstat sample so every sysdump shows the saturation time series across the rollout window instead of only a point-in-time top snapshot.

The restart assertion itself is unchanged: a genuine datapath drop still fails the test.

This PR was prepared with AIL:3.

```release-note
cilium-bugtool now captures CPU/IO/memory pressure (PSI) and a short vmstat sample to help diagnose host saturation.
```
