### PR TITLE
test/helpers: allowlist renamed leader-election lease-lock retrieval error

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -136,6 +136,7 @@ const (
 	failedToUpdateLock                = "Failed to update lock"
 	failedToReleaseLock               = "Failed to release lock:"
 	errorCreatingInitialLeader        = "error initially creating leader election record:"
+	failedToRetrieveLock              = "Error retrieving lease lock"                                           // cf. https://github.com/cilium/cilium/issues/45426 ; client-go v1.35+ renamed "error retrieving resource lock".
 	cantEnableJIT                     = "bpf_jit_enable: no such file or directory"                             // Because we run tests in Kind.
 	podCIDRUnavailable                = " PodCIDR not available"                                                // cf. https://github.com/cilium/cilium/issues/29680
 	unableGetNode                     = "Unable to get node resource"                                           // cf. https://github.com/cilium/cilium/issues/29710
@@ -193,7 +194,8 @@ var badLogMessages = map[string][]string{
 	// error cannot be fixed in Cilium or in the test.
 	logutils.ErrorLogs: {opCantBeFulfilled, initLeaderElection, globalDataSupport,
 		failedToListCRDs, retrieveResLock, failedToRelLockEmptyName, failedToUpdateLock,
-		failedToReleaseLock, errorCreatingInitialLeader, errorCreatingInitialLeaderGEK8s35},
+		failedToReleaseLock, errorCreatingInitialLeader, errorCreatingInitialLeaderGEK8s35,
+		failedToRetrieveLock},
 	logutils.WarningLogs: {cantEnableJIT, podCIDRUnavailable, unableGetNode,
 		objectHasBeenModified, etcdTimeout, endpointRestoreFailed,
 		cantFindIdentityInCache, keyAllocFailedFoundMaster, cantRecreateMasterKey,


### PR DESCRIPTION
The Ginkgo post-test operator-log validation flags a benign, self-correcting leader-election blip as a failure. The operator's leader-election HTTP client Timeout is `max(1s, RenewDeadline/2) = 5s`, so a transient KIND apiserver hiccup cancels the renew-path lock GET at 5s. client-go then logs `level=error msg="Error retrieving lease lock"`, retries on the RetryPeriod and recovers, with the operator Deployment staying 1/1 Ready and never restarting. The failing job here was `E2E Test (1.33, f10-agent-hubble-bandwidth)` / K8sAgentHubbleTest, which tripped on `Found 1 io.cilium/app=operator logs matching list of errors that must be investigated`.

The `badLogMessages` allowlist in `test/helpers/cons.go` already tolerates this exact leader-election class (`retrieveResLock`, `failedToUpdateLock`, `failedToReleaseLock`), but client-go v1.35+ renamed the renew-path message from `error retrieving resource lock` to `Error retrieving lease lock`, so the stale substring no longer matches. PR #47023 added this same matcher to the cilium-cli allowlist (`cilium-cli/connectivity/tests/errors.go`) but never touched the Ginkgo helper, leaving ci-ginkgo runs exposed. This mirrors that fix into the Ginkgo allowlist.

This does not mask a genuine failure: a persistent lock-retrieval failure means leadership loss, which surfaces separately as operator crashes/restarts that are validated independently. `cons.go` uses plain substring matching, so only the string form is added; the read-body counterpart from #47023 is intentionally not mirrored to avoid an over-broad substring.

This PR was prepared with AIL:3.
