### PR TITLE
gateway-api: fix gatewayclassconfig-nodeport test

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -885,11 +885,16 @@ func (r *gatewayReconciler) getGatewayClassConfig(ctx context.Context, gwc *gate
 		return nil
 	}
 
-	res := &v2alpha1.CiliumGatewayClassConfig{}
-	if err := r.Client.Get(ctx, client.ObjectKey{
+	key := client.ObjectKey{
 		Namespace: string(*gwc.Spec.ParametersRef.Namespace),
 		Name:      gwc.Spec.ParametersRef.Name,
-	}, res); err != nil {
+	}
+
+	res := &v2alpha1.CiliumGatewayClassConfig{}
+	if err := r.Client.Get(ctx, key, res); err != nil {
+		r.logger.ErrorContext(ctx, "Failed to get CiliumGatewayClassConfig",
+			logfields.Resource, key,
+			logfields.Error, err)
 		return nil
 	}
 	return res

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -90,14 +90,6 @@ func Test_Conformance(t *testing.T) {
 			UseRemoteAddress: true,
 		},
 	})
-	gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator, translation.Config{
-		ServiceConfig: translation.ServiceConfig{
-			ExternalTrafficPolicy: string(corev1.ServiceExternalTrafficPolicyCluster),
-		},
-		OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
-			UseRemoteAddress: true,
-		},
-	})
 
 	type gwDetails struct {
 		FullName types.NamespacedName
@@ -342,9 +334,9 @@ func Test_Conformance(t *testing.T) {
 		{name: "gateway-cross-protocol-same-hostname", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "cross-protocol-same-hostname", Namespace: "gateway-conformance-infra"}}}},
 		{name: "gateway-cross-protocol-same-port-same-hostname", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "cross-protocol-same-port-same-hostname", Namespace: "gateway-conformance-infra"}, wantErr: true}}},
 		{name: "gateway-ns-restricted-same-hostname", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "ns-restricted-same-hostname", Namespace: "gateway-conformance-infra"}}}},
+		{name: "gatewayclassconfig-nodeport", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "nodeport-gateway", Namespace: "gateway-conformance-infra"}}}},
 		{name: "hostNetwork-enabled-valid", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "hostnetwork-enabled", Namespace: "gateway-conformance-infra"}}}, hostNetwork: true},
 		{name: "hostNetwork-enabled-exceed-max-address", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "hostnetwork-enabled", Namespace: "gateway-conformance-infra"}}}, hostNetwork: true},
-		{name: "gatewayclassconfig-nodeport", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "nodeport-gateway", Namespace: "gateway-conformance-infra"}}}},
 		// ListenerSet tests
 		{name: "listenerset-default-not-allowed", gateway: []gwDetails{
 			{FullName: types.NamespacedName{Name: "default-not-allowed", Namespace: "gateway-conformance-infra"}},
@@ -440,19 +432,18 @@ func Test_Conformance(t *testing.T) {
 			clientBuilder.WithIndex(&gatewayv1.TLSRoute{}, indexers.TLSRouteListenerSetIndex, indexers.IndexTLSRouteByListenerSet)
 
 			c := clientBuilder.Build()
-			if tt.hostNetwork {
-				gatewayAPITranslator = gatewayApiTranslation.NewTranslator(cecTranslator, translation.Config{
-					ServiceConfig: translation.ServiceConfig{
-						ExternalTrafficPolicy: string(corev1.ServiceExternalTrafficPolicyCluster),
-					},
-					OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
-						UseRemoteAddress: true,
-					},
-					HostNetworkConfig: translation.HostNetworkConfig{
-						Enabled: true,
-					},
-				})
-			}
+			gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator, translation.Config{
+				ServiceConfig: translation.ServiceConfig{
+					ExternalTrafficPolicy: string(corev1.ServiceExternalTrafficPolicyCluster),
+				},
+				OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
+					UseRemoteAddress: true,
+				},
+				HostNetworkConfig: translation.HostNetworkConfig{
+					Enabled: tt.hostNetwork,
+				},
+			})
+
 			r := &gatewayReconciler{
 				Client:         c,
 				translator:     gatewayAPITranslator,

--- a/operator/pkg/gateway-api/helper_test.go
+++ b/operator/pkg/gateway-api/helper_test.go
@@ -16,6 +16,8 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 	k8syaml "sigs.k8s.io/yaml"
+
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 )
 
 func fromYaml(t *testing.T, yamlText string, obj any) {
@@ -116,6 +118,10 @@ func readInput(t *testing.T, file string) []client.Object {
 			res = append(res, obj)
 		case "GatewayClass":
 			obj := &gatewayv1.GatewayClass{}
+			fromYaml(t, o, obj)
+			res = append(res, obj)
+		case "CiliumGatewayClassConfig":
+			obj := &v2alpha1.CiliumGatewayClassConfig{}
 			fromYaml(t, o, obj)
 			res = append(res, obj)
 		case "ReferenceGrant":


### PR DESCRIPTION
While rebasing #46826, the order of the gateway conformance tests shifted and I noticed that gatewayclassconfig-nodeport was no longer passing.

When a test case with hostNetwork=true is run, the shared `gatewayAPITranslator` is being updated, so all following tests run with HostNetworkConfig.Enabled=true even without hostNetwork=true set. This caused a false positive for this test case.

In isolation the test was failing because the input `CiliumGatewayClassConfig` was never loaded to the fake client. CiliumGatewayClassConfig needs to be handled in `readInput`.