### PR TITLE
gateway-api: include HTTPRoute filter refs in ServiceImport index

### DIFF
--- a/operator/pkg/gateway-api/indexers/httproute.go
+++ b/operator/pkg/gateway-api/indexers/httproute.go
@@ -151,6 +151,28 @@ func IndexHTTPRouteByBackendServiceImport(rawObj client.Object) []string {
 				}.String(),
 			)
 		}
+		for _, f := range rule.Filters {
+			var backendRef gatewayv1.BackendObjectReference
+
+			switch {
+			case f.Type == gatewayv1.HTTPRouteFilterRequestMirror && f.RequestMirror != nil:
+				backendRef = f.RequestMirror.BackendRef
+			case f.Type == gatewayv1.HTTPRouteFilterExternalAuth && f.ExternalAuth != nil:
+				backendRef = f.ExternalAuth.BackendRef
+			default:
+				continue
+			}
+
+			if !helpers.IsServiceImport(backendRef) {
+				continue
+			}
+			backendServiceImports = append(backendServiceImports,
+				types.NamespacedName{
+					Namespace: helpers.NamespaceDerefOr(backendRef.Namespace, hr.Namespace),
+					Name:      string(backendRef.Name),
+				}.String(),
+			)
+		}
 	}
 	return backendServiceImports
 }

--- a/operator/pkg/gateway-api/indexers/httproute_test.go
+++ b/operator/pkg/gateway-api/indexers/httproute_test.go
@@ -212,6 +212,48 @@ func TestIndexHTTPRouteByBackendServiceImport(t *testing.T) {
 			},
 			want: []string(nil),
 		},
+		{
+			name: "Has ServiceImport filter refs",
+			obj: &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "has-serviceimport-filters",
+					Namespace: "default",
+				},
+				Spec: gatewayv1.HTTPRouteSpec{
+					Rules: []gatewayv1.HTTPRouteRule{
+						{
+							Filters: []gatewayv1.HTTPRouteFilter{
+								{
+									Type: gatewayv1.HTTPRouteFilterRequestMirror,
+									RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+										BackendRef: gatewayv1.BackendObjectReference{
+											Group:     ptr.To[gatewayv1.Group](mcsapiv1beta1.GroupName),
+											Kind:      ptr.To[gatewayv1.Kind]("ServiceImport"),
+											Name:      "mirror-import",
+											Namespace: ptr.To[gatewayv1.Namespace]("mirror-ns"),
+										},
+									},
+								},
+								{
+									Type: gatewayv1.HTTPRouteFilterExternalAuth,
+									ExternalAuth: &gatewayv1.HTTPExternalAuthFilter{
+										BackendRef: gatewayv1.BackendObjectReference{
+											Group: ptr.To[gatewayv1.Group](mcsapiv1beta1.GroupName),
+											Kind:  ptr.To[gatewayv1.Kind]("ServiceImport"),
+											Name:  "auth-import",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []string{
+				"mirror-ns/mirror-import",
+				"default/auth-import",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This commit includes HTTPRoute ExternalAuth and RequestMirror filter refs in the ServiceImport index.

I will follow up and check on the implementation whether serviceimport is actually supported for these cases. but it's still better to index properly.