### PR TITLE
gateway-api: watch ServiceImport refs from GRPCRoutes

### DIFF
--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -77,11 +77,13 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			return fmt.Errorf("failed to setup field indexer %q: %w", indexName, err)
 		}
 	}
-
-	// Only index HTTPRoute by ServiceImport if ServiceImport is enabled
+	// Only index HTTPRoute and GRPCRoute by ServiceImport if ServiceImport is enabled
 	if serviceImportEnabled {
 		if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.HTTPRoute{}, indexers.BackendServiceImportHTTPRouteIndex, indexers.IndexHTTPRouteByBackendServiceImport); err != nil {
 			return fmt.Errorf("failed to setup field indexer %q: %w", indexers.BackendServiceImportHTTPRouteIndex, err)
+		}
+		if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.GRPCRoute{}, indexers.BackendServiceImportGRPCRouteIndex, indexers.IndexGRPCRouteByBackendServiceImport); err != nil {
+			return fmt.Errorf("failed to setup field indexer %q: %w", indexers.BackendServiceImportGRPCRouteIndex, err)
 		}
 	}
 

--- a/operator/pkg/gateway-api/indexers/grpcroute.go
+++ b/operator/pkg/gateway-api/indexers/grpcroute.go
@@ -106,3 +106,39 @@ func GenerateIndexerGRPCRoutebyBackendService(c client.Client, logger *slog.Logg
 		return backendServices
 	}
 }
+
+// IndexGRPCRouteByBackendServiceImport is a client.IndexerFunc that takes a single GRPCRoute and
+// returns all referenced backend ServiceImport full names (`namespace/name`) to add to the relevant index.
+func IndexGRPCRouteByBackendServiceImport(rawObj client.Object) []string {
+	route, ok := rawObj.(*gatewayv1.GRPCRoute)
+	if !ok {
+		return nil
+	}
+	var backendServiceImports []string
+
+	for _, rule := range route.Spec.Rules {
+		for _, backend := range rule.BackendRefs {
+			if !helpers.IsServiceImport(backend.BackendObjectReference) {
+				continue
+			}
+			backendServiceImports = append(backendServiceImports,
+				types.NamespacedName{
+					Namespace: helpers.NamespaceDerefOr(backend.Namespace, route.Namespace),
+					Name:      string(backend.Name),
+				}.String(),
+			)
+		}
+		for _, f := range rule.Filters {
+			if f.Type != gatewayv1.GRPCRouteFilterRequestMirror || f.RequestMirror == nil || !helpers.IsServiceImport(f.RequestMirror.BackendRef) {
+				continue
+			}
+			backendServiceImports = append(backendServiceImports,
+				types.NamespacedName{
+					Namespace: helpers.NamespaceDerefOr(f.RequestMirror.BackendRef.Namespace, route.Namespace),
+					Name:      string(f.RequestMirror.BackendRef.Name),
+				}.String(),
+			)
+		}
+	}
+	return backendServiceImports
+}

--- a/operator/pkg/gateway-api/indexers/grpcroute_test.go
+++ b/operator/pkg/gateway-api/indexers/grpcroute_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 )
 
 func TestIndexGRPCRouteByGateway(t *testing.T) {
@@ -91,6 +92,91 @@ func TestIndexGRPCRouteByGateway(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := IndexGRPCRouteByGateway(tt.obj); !slices.Equal(got, tt.want) {
 				t.Errorf("IndexGRPCRouteByGateway() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIndexGRPCRouteByBackendServiceImport(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  client.Object
+		want []string
+	}{
+		{
+			name: "Has ServiceImport backend and request mirror refs",
+			obj: &gatewayv1.GRPCRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "has-serviceimport",
+					Namespace: "default",
+				},
+				Spec: gatewayv1.GRPCRouteSpec{
+					Rules: []gatewayv1.GRPCRouteRule{
+						{
+							BackendRefs: []gatewayv1.GRPCBackendRef{
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Group:     ptr.To[gatewayv1.Group](mcsapiv1beta1.GroupName),
+											Kind:      ptr.To[gatewayv1.Kind]("ServiceImport"),
+											Name:      "backend-import",
+											Namespace: ptr.To[gatewayv1.Namespace]("backend-ns"),
+										},
+									},
+								},
+							},
+							Filters: []gatewayv1.GRPCRouteFilter{
+								{
+									Type: gatewayv1.GRPCRouteFilterRequestMirror,
+									RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+										BackendRef: gatewayv1.BackendObjectReference{
+											Group: ptr.To[gatewayv1.Group](mcsapiv1beta1.GroupName),
+											Kind:  ptr.To[gatewayv1.Kind]("ServiceImport"),
+											Name:  "mirror-import",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []string{
+				"backend-ns/backend-import",
+				"default/mirror-import",
+			},
+		},
+		{
+			name: "Has no ServiceImport refs",
+			obj: &gatewayv1.GRPCRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "no-serviceimport",
+					Namespace: "default",
+				},
+				Spec: gatewayv1.GRPCRouteSpec{
+					Rules: []gatewayv1.GRPCRouteRule{
+						{
+							BackendRefs: []gatewayv1.GRPCBackendRef{
+								{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
+											Name: "backend-svc",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IndexGRPCRouteByBackendServiceImport(tt.obj); !slices.Equal(got, tt.want) {
+				t.Errorf("IndexGRPCRouteByBackendServiceImport() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/operator/pkg/gateway-api/indexers/indexnames.go
+++ b/operator/pkg/gateway-api/indexers/indexnames.go
@@ -25,6 +25,9 @@ const (
 	// Indexes GRPCRoutes by all the backend Services referenced in the object.
 	BackendServiceGRPCRouteIndex = "backendServiceGRPCRouteIndex"
 
+	// Indexes GRPCRoutes by all the backend ServiceImports referenced in the object.
+	BackendServiceImportGRPCRouteIndex = "BackendServiceImportGRPCRouteIndex"
+
 	// Indexes GRPCRoutes by all the Gateway parents referenced in the object.
 	GatewayGRPCRouteIndex = "gatewayGRPCRouteIndex"
 

--- a/operator/pkg/gateway-api/watch-handlers/service.go
+++ b/operator/pkg/gateway-api/watch-handlers/service.go
@@ -91,7 +91,7 @@ func EnqueueRequestForBackendService(c client.Client, logger slog.Logger, contro
 }
 
 // EnqueueRequestForBackendServiceImport makes sure that Gateways are reconciled
-// if a relevant HTTPRoute backend Service Imports are updated.
+// if a relevant HTTPRoute or GRPCRoute backend ServiceImport is updated.
 func EnqueueRequestForBackendServiceImport(c client.Client, logger slog.Logger, controllerName string) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
 		_, ok := o.(*mcsapiv1beta1.ServiceImport)
@@ -104,7 +104,7 @@ func EnqueueRequestForBackendServiceImport(c client.Client, logger slog.Logger, 
 		// make a set to hold all reconcile requests
 		reconcileRequests := make(map[reconcile.Request]struct{})
 
-		// Then, fetch all HTTPRoutes that reference this service, using the backendServiceIndex
+		// Fetch all HTTPRoutes and GRPCRoutes that reference this ServiceImport.
 		hrList := &gatewayv1.HTTPRouteList{}
 
 		if err := c.List(ctx, hrList, &client.ListOptions{
@@ -114,15 +114,27 @@ func EnqueueRequestForBackendServiceImport(c client.Client, logger slog.Logger, 
 			return []reconcile.Request{}
 		}
 
+		grpcRouteList := &gatewayv1.GRPCRouteList{}
+
+		if err := c.List(ctx, grpcRouteList, &client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector(indexers.BackendServiceImportGRPCRouteIndex, client.ObjectKeyFromObject(o).String()),
+		}); err != nil {
+			scopedLog.ErrorContext(ctx, "Failed to get related GRPCRoutes", logfields.Error, err)
+			return []reconcile.Request{}
+		}
+
 		allGatewaysSet, err := getAllGatewaysSetForController(ctx, c, controllerName)
 		if err != nil {
 			scopedLog.ErrorContext(ctx, "Failed to get controller Gateways", logfields.Error, err)
 			return []reconcile.Request{}
 		}
 
-		// iterate through the HTTPRoutes, return a reconcile.Request for each Gateway that is relevant.
+		// Iterate through matching routes and return a reconcile.Request for each relevant Gateway.
 		for _, hr := range hrList.Items {
 			updateReconcileRequestsForParentRefs(ctx, c, hr.Spec.ParentRefs, hr.Namespace, allGatewaysSet, reconcileRequests)
+		}
+		for _, grpcr := range grpcRouteList.Items {
+			updateReconcileRequestsForParentRefs(ctx, c, grpcr.Spec.ParentRefs, grpcr.Namespace, allGatewaysSet, reconcileRequests)
 		}
 
 		// return the keys of the set.


### PR DESCRIPTION
Currently, ServiceImport-triggered Gateway reconciliation only covers HTTPRoutes, but not GRPCRoutes. The watch handler don't look up affected GRPCRoutes.

Therefore, this commit adds the missing GRPCRoute ServiceImport indexing and watch handling.