### PR TITLE
conformance-aws-cni: skip l7 and fqdn tests by name on chaining mode

### DIFF
--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -270,7 +270,6 @@ jobs:
             --helm-set=cni.chainingMode=aws-cni \
             --helm-set=eni.enabled=false \
             --helm-set=ipam.mode=cluster-pool \
-            --helm-set=enable-l7-proxy=false \
             --helm-set=routingMode=native \
             --helm-set=bandwidthManager.enabled=false \
             --helm-set=extraArgs={--enable-identity-mark=false} \
@@ -447,6 +446,7 @@ jobs:
           external-target-fake-dns: true
           hubble: false
           test-concurrency: 3
+          tests: '!fqdn,!l7' # L7 policies are not supported in chaining mode.
 
       - name: Set up job variables for connectivity tests
         id: vars-conn


### PR DESCRIPTION
AWS-CNI chaining mode does not support L7 policies. The agent rejects any L7 CiliumNetworkPolicy with `L7 policy is not supported since L7 proxy is not enabled`, so the L7 tests must not run on this config.

56864b4a29 tried to stop them from running by disabling the L7 proxy with a helm flag, instead of the cilium-cli test filter `--test '!fqdn,!l7'` it removed. That does not work. The L7 tests gate on `features.L7Proxy`, and cilium-cli sets that from the agent status (`st.Proxy != nil`), which is still true when the proxy is disabled. So the tests keep running, apply their policies, get rejected by the agent, and the run hangs on `policies were not applied on all Cilium nodes in time` until the job is cancelled. That is worse than the NodePort `curl (28)` timeout it was meant to fix.

This was seen on the `/ci-awscni` run of the first version of this PR ([run 29571617001](https://github.com/cilium/cilium/actions/runs/29571617001)): `client-egress-l7-method`, `north-south-loadbalancing-with-l7-policy` and the other L7 tests all ran and stalled.

Put the filter back. The `cli-test-config` action turns the `tests` input into `--test '!fqdn,!l7'`. cilium-cli compiles each entry into a skip regexp that is matched unanchored against the test name, so every l7 and fqdn test is skipped before it applies any policy. Drop the helm flag, it never did anything here other than take the filter away.

This does not mask a real datapath regression. L7 policy is unsupported in aws-cni chaining mode by design, so these tests must not run here.

This PR was prepared with AIL:3.
