### PR TITLE
ci: wait for all AKS nodes to register before labeling nodes-without-cilium

### DIFF
--- a/.github/actions/nodes-without-cilium/action.yml
+++ b/.github/actions/nodes-without-cilium/action.yml
@@ -7,4 +7,8 @@ runs:
       shell: bash
       run: |
         mapfile -t nodes_without_cilium < <(kubectl get nodes -o name | head -n 2)
+        # Fail loudly at the labeling site if fewer than two nodes are present:
+        # generic-external-targets needs two labeled nodes and this step never
+        # re-labels, so a late error here beats a jsonpath out-of-bounds later.
+        [ "${#nodes_without_cilium[@]}" -ge 2 ] || { echo "::error::expected >=2 nodes to label, found ${#nodes_without_cilium[@]}"; kubectl get nodes -o wide; exit 1; }
         kubectl patch "${nodes_without_cilium[@]}" --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'

--- a/.github/actions/setup-aks-cluster/action.yml
+++ b/.github/actions/setup-aks-cluster/action.yml
@@ -84,6 +84,29 @@ runs:
           --resource-group ${{ inputs.cluster_name }} \
           --name ${{ inputs.cluster_name }}
 
+    - name: Wait for all nodes to register with the API server
+      shell: bash
+      run: |
+        # az aks get-credentials returns as soon as the control plane is
+        # reachable, but the VMSS instances boot kubelet and register with the
+        # API server on a stagger. The next step labels the first two nodes as
+        # nodes-without-cilium and never re-labels, so it has to run only once
+        # the full expected topology (node_count + 2) is present. Otherwise it
+        # labels a single early node and generic-external-targets later reads
+        # .items[1] off a one-element list and aborts with an out-of-bounds
+        # jsonpath error.
+        expected=$(( ${{ inputs.node_count }} + 2 ))
+        timeout=300; elapsed=0
+        until [ "$(kubectl get nodes --no-headers 2>/dev/null | wc -l)" -ge "$expected" ]; do
+          if [ "$elapsed" -ge "$timeout" ]; then
+            echo "::error::only $(kubectl get nodes --no-headers 2>/dev/null | wc -l)/$expected nodes registered after ${timeout}s"
+            kubectl get nodes -o wide
+            exit 1
+          fi
+          echo "waiting for nodes to register ($(kubectl get nodes --no-headers 2>/dev/null | wc -l)/$expected)..."
+          sleep 10; elapsed=$((elapsed + 10))
+        done
+
     - name: Patch nodes without Cilium
       uses: ./.github/actions/nodes-without-cilium
 


### PR DESCRIPTION
The AKS harness creates the cluster with node_count+2 nodes but labels the
nodes-without-cilium before all of the VMSS instances have registered with the
API server. az aks get-credentials returns as soon as the control plane is
reachable, and the very next step runs nodes-without-cilium, which does
kubectl get nodes | head -n 2 and patches cilium.io/no-schedule=true on those.
When the Azure VMSS boots on a stagger only one node is registered at that
point, so only one node gets labeled and nothing ever re-labels. The Ready gate
that follows only waits on the label selector, so it passes on that single node.
Later on generic-external-targets reads .items[1] off
kubectl get nodes -l cilium.io/no-schedule=true and dies with
"array index out of bounds: index 1, length 1".

Wait for the full expected topology to register before labeling. Between getting
the credentials and patching nodes-without-cilium we now block until node_count+2
nodes show up, with a five minute timeout. setup-aks-cluster is where the
expected count lives, so gating there leaves the shared nodes-without-cilium
action and GKE untouched. If the nodes genuinely never register the gate fails
loudly with kubectl get nodes -o wide, and since it only waits on node
registration it can't hide a datapath problem. I also made nodes-without-cilium
assert it found at least two nodes before patching, so a future case with fewer
than two becomes an early clear error instead of a late jsonpath out-of-bounds.

Seen in https://github.com/cilium/cilium/actions/runs/29515531299 (Conformance
AKS with KPR + IPsec, 1.34/eastus2).

This PR was prepared with AIL:3.
