### PR TITLE
test/cyclonus: drop --fail-fast so a policy failure can't crash the run

### DIFF
--- a/test/k8s/manifests/netpol-cyclonus/install-cyclonus.yml
+++ b/test/k8s/manifests/netpol-cyclonus/install-cyclonus.yml
@@ -12,7 +12,6 @@ spec:
         - command:
             - ./cyclonus
             - generate
-            - --fail-fast=true
             - --exclude=
             - --include=upstream-e2e
             - --perturbation-wait-seconds=20


### PR DESCRIPTION
The Cyclonus Network Policy job runs the upstream-e2e suite with `--fail-fast=true`. When a step does not pass, cyclonus `ExecuteTestCase` appends that one step result and then breaks out of the per-step loop, so the test case ends up with fewer result steps than declared steps. `PrintTestCaseResult` then trips its `len(TestCase.Steps) != len(result.Steps)` guard and panics with `found 2 test steps, but 1 result steps` (printer.go:204).

The panic is specific to the fail-fast break: the error path sets `result.Err` and the printer returns before the count check, so this is not a datapath problem. But the panic takes down the runner pod, and with `restartPolicy: Never` the Job controller starts a replacement that re-runs the whole ~20 minute suite from scratch. That can't finish inside the residual `kubectl wait --timeout=20m` budget, so the step fails with `timed out waiting for the condition on jobs/cyclonus` even though every evaluated case reported zero wrong probes.

It reproduced three times on the "should work with Ingress, Egress specified together" case in runs 29478023454, 29485865500 and 29563066267.

Dropping `--fail-fast` lets the suite run to completion and print its summary table. Correctness stays gated by `test-cyclonus.sh`, which fails the step if any summary row is below 100%, so we lose nothing but the crash. A full green run already completes in about 16 minutes, well inside the 20 minute wait.

I ran the workflow against this change on a throwaway `ft/main` ref, since it only triggers on push to `main`/`ft/main/**` and not on pull requests: https://github.com/cilium/cilium/actions/runs/29572555020 passed. The suite ran to completion in 15m17s and printed its summary table, which only happens when the binary does not panic. All 13 cases passed, including case #11 "should work with Ingress, Egress specified together" (the one that panicked in the three failing runs above), with 0 wrong on every probe round.

The flag is present on v1.19 and v1.20, so this will need backports there; it is absent on v1.17/v1.18.

This PR was prepared with AIL:3.
