### PR TITLE
gateway-api: discover external-auth backend refs

### DIFF
--- a/operator/pkg/gateway-api/routechecks/httproute.go
+++ b/operator/pkg/gateway-api/routechecks/httproute.go
@@ -160,12 +160,20 @@ func (t *HTTPRouteRule) GetBackendRefs() []gatewayv1.BackendRef {
 		refs = append(refs, backend.BackendRef)
 	}
 	for _, f := range t.Rule.Filters {
-		if f.Type == gatewayv1.HTTPRouteFilterRequestMirror {
+		switch f.Type {
+		case gatewayv1.HTTPRouteFilterRequestMirror:
 			if f.RequestMirror == nil {
 				continue
 			}
 			refs = append(refs, gatewayv1.BackendRef{
 				BackendObjectReference: f.RequestMirror.BackendRef,
+			})
+		case gatewayv1.HTTPRouteFilterExternalAuth:
+			if f.ExternalAuth == nil {
+				continue
+			}
+			refs = append(refs, gatewayv1.BackendRef{
+				BackendObjectReference: f.ExternalAuth.BackendRef,
 			})
 		}
 	}

--- a/operator/pkg/gateway-api/routechecks/httproute_test.go
+++ b/operator/pkg/gateway-api/routechecks/httproute_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -90,6 +91,117 @@ func TestHTTPRouteValidateMatchRegexps(t *testing.T) {
 				assert.Equal(t, metav1.ConditionFalse, cond.Status)
 				assert.Equal(t, string(gatewayv1.RouteReasonUnsupportedValue), cond.Reason)
 			}
+		})
+	}
+}
+
+func TestHTTPRouteRuleGetBackendRefs(t *testing.T) {
+	svcPort := ptr.To[gatewayv1.PortNumber](8080)
+	authPort := ptr.To[gatewayv1.PortNumber](9001)
+	mirrorPort := ptr.To[gatewayv1.PortNumber](9002)
+
+	tests := []struct {
+		name      string
+		rule      gatewayv1.HTTPRouteRule
+		wantNames []gatewayv1.ObjectName
+	}{
+		{
+			name: "backendRefs only",
+			rule: gatewayv1.HTTPRouteRule{
+				BackendRefs: []gatewayv1.HTTPBackendRef{
+					{BackendRef: gatewayv1.BackendRef{
+						BackendObjectReference: gatewayv1.BackendObjectReference{Name: "my-service", Port: svcPort},
+					}},
+				},
+			},
+			wantNames: []gatewayv1.ObjectName{"my-service"},
+		},
+		{
+			name: "ExternalAuth filter includes its BackendRef",
+			rule: gatewayv1.HTTPRouteRule{
+				BackendRefs: []gatewayv1.HTTPBackendRef{
+					{BackendRef: gatewayv1.BackendRef{
+						BackendObjectReference: gatewayv1.BackendObjectReference{Name: "my-service", Port: svcPort},
+					}},
+				},
+				Filters: []gatewayv1.HTTPRouteFilter{
+					{
+						Type: gatewayv1.HTTPRouteFilterExternalAuth,
+						ExternalAuth: &gatewayv1.HTTPExternalAuthFilter{
+							ExternalAuthProtocol: gatewayv1.HTTPRouteExternalAuthGRPCProtocol,
+							BackendRef:           gatewayv1.BackendObjectReference{Name: "auth-service", Port: authPort},
+						},
+					},
+				},
+			},
+			wantNames: []gatewayv1.ObjectName{"my-service", "auth-service"},
+		},
+		{
+			name: "nil ExternalAuth filter is skipped",
+			rule: gatewayv1.HTTPRouteRule{
+				Filters: []gatewayv1.HTTPRouteFilter{
+					{Type: gatewayv1.HTTPRouteFilterExternalAuth, ExternalAuth: nil},
+				},
+			},
+			wantNames: nil,
+		},
+		{
+			name: "RequestMirror filter still included",
+			rule: gatewayv1.HTTPRouteRule{
+				BackendRefs: []gatewayv1.HTTPBackendRef{
+					{BackendRef: gatewayv1.BackendRef{
+						BackendObjectReference: gatewayv1.BackendObjectReference{Name: "my-service", Port: svcPort},
+					}},
+				},
+				Filters: []gatewayv1.HTTPRouteFilter{
+					{
+						Type: gatewayv1.HTTPRouteFilterRequestMirror,
+						RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+							BackendRef: gatewayv1.BackendObjectReference{Name: "mirror-service", Port: mirrorPort},
+						},
+					},
+				},
+			},
+			wantNames: []gatewayv1.ObjectName{"my-service", "mirror-service"},
+		},
+		{
+			name: "ExternalAuth and RequestMirror filters both included",
+			rule: gatewayv1.HTTPRouteRule{
+				BackendRefs: []gatewayv1.HTTPBackendRef{
+					{BackendRef: gatewayv1.BackendRef{
+						BackendObjectReference: gatewayv1.BackendObjectReference{Name: "my-service", Port: svcPort},
+					}},
+				},
+				Filters: []gatewayv1.HTTPRouteFilter{
+					{
+						Type: gatewayv1.HTTPRouteFilterExternalAuth,
+						ExternalAuth: &gatewayv1.HTTPExternalAuthFilter{
+							ExternalAuthProtocol: gatewayv1.HTTPRouteExternalAuthGRPCProtocol,
+							BackendRef:           gatewayv1.BackendObjectReference{Name: "auth-service", Port: authPort},
+						},
+					},
+					{
+						Type: gatewayv1.HTTPRouteFilterRequestMirror,
+						RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+							BackendRef: gatewayv1.BackendObjectReference{Name: "mirror-service", Port: mirrorPort},
+						},
+					},
+				},
+			},
+			wantNames: []gatewayv1.ObjectName{"my-service", "auth-service", "mirror-service"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := &HTTPRouteRule{Rule: tt.rule}
+			refs := rule.GetBackendRefs()
+
+			var gotNames []gatewayv1.ObjectName
+			for _, r := range refs {
+				gotNames = append(gotNames, r.Name)
+			}
+			assert.Equal(t, tt.wantNames, gotNames)
 		})
 	}
 }


### PR DESCRIPTION
<!-- Description of change -->

Because external-auth envoy config is generated "starting" from the backend that is expected to perform authz, the ExternalAuth filter need to be added to known backendrefs when checking HTTPRoute resources. Before this fix, ExternalAuth filters were effectively ignored. With this fix, cilium-operator will now:

1) set resolvedrefs to false when the auth backend is unknown, and
2) correctly create an envoy ExtAuthz resource.

Note that this means that the filter will still fail open, for example if the backend service does not exist. This is mildly dangerous and should probably be fixed, but that presumably requires changing existing behavior of all filter configuration. As far as I can tell, the Gateway API spec is not entirely clear on this subject.

AIL: 3 (Claude Sonnet 4.6).

Fixes: #47178 

```release-note
ExternalAuth filters are now detected properly.
```

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
