### PR TITLE
gateway-api: move ServerHeaderTransformation logic into ingestion

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -339,27 +339,22 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		scopedLog.ErrorContext(ctx, "Unable to update BackendTLSPolicy Status", logfields.Error, err)
 		return controllerruntime.Fail(err)
 	}
-	gatewayClassConfig := r.getGatewayClassConfig(ctx, gwc)
-	var serverHeaderTransformation model.ServerHeaderTransformation
-	if gatewayClassConfig != nil && gatewayClassConfig.Spec.Envoy != nil && gatewayClassConfig.Spec.Envoy.ServerHeaderTransformation != nil {
-		serverHeaderTransformation = model.ServerHeaderTransformation(*gatewayClassConfig.Spec.Envoy.ServerHeaderTransformation)
-	}
+
 	m := ingestion.GatewayAPI(scopedLog, ingestion.Input{
-		GatewayClass:               *gwc,
-		GatewayClassConfig:         gatewayClassConfig,
-		ServerHeaderTransformation: serverHeaderTransformation,
-		Gateway:                    *gw,
-		HTTPRoutes:                 httpRoutes,
-		TLSRoutes:                  tlsRoutes,
-		GRPCRoutes:                 grpcRoutes,
-		TCPRoutes:                  tcpRoutes,
-		UDPRoutes:                  udpRoutes,
-		Namespaces:                 namespaces,
-		Services:                   servicesList.Items,
-		ServiceImports:             serviceImportsList.Items,
-		ReferenceGrants:            grants.Items,
-		BackendTLSPolicyMap:        btlspMap,
-		MergedListeners:            mergedListeners,
+		GatewayClass:        *gwc,
+		GatewayClassConfig:  r.getGatewayClassConfig(ctx, gwc),
+		Gateway:             *gw,
+		HTTPRoutes:          httpRoutes,
+		TLSRoutes:           tlsRoutes,
+		GRPCRoutes:          grpcRoutes,
+		TCPRoutes:           tcpRoutes,
+		UDPRoutes:           udpRoutes,
+		Namespaces:          namespaces,
+		Services:            servicesList.Items,
+		ServiceImports:      serviceImportsList.Items,
+		ReferenceGrants:     grants.Items,
+		BackendTLSPolicyMap: btlspMap,
+		MergedListeners:     mergedListeners,
 	})
 
 	listenersStatus, err := r.setListenerStatus(ctx, gw, httpRouteList, tlsRouteList, grpcRouteList, tcpRouteList, udpRouteList, namespaceLabels)

--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -130,9 +130,8 @@ func (l *ListenerWithContext) FilterUDPRoutes(routes []gatewayv1.UDPRoute) []gat
 
 // Input is the input for GatewayAPI.
 type Input struct {
-	GatewayClass               gatewayv1.GatewayClass
-	GatewayClassConfig         *v2alpha1.CiliumGatewayClassConfig
-	ServerHeaderTransformation model.ServerHeaderTransformation
+	GatewayClass       gatewayv1.GatewayClass
+	GatewayClassConfig *v2alpha1.CiliumGatewayClassConfig
 
 	Gateway             gatewayv1.Gateway
 	HTTPRoutes          []gatewayv1.HTTPRoute
@@ -150,9 +149,7 @@ type Input struct {
 
 // GatewayAPI translates Gateway API resources into a model.
 func GatewayAPI(log *slog.Logger, input Input) *model.Model {
-	var resHTTP []model.HTTPListener
-	var resTLSPassthrough []model.TLSPassthroughListener
-	var resL4 []model.L4Listener
+	m := &model.Model{}
 
 	labels := make(map[string]string)
 	annotations := make(map[string]string)
@@ -232,7 +229,7 @@ func GatewayAPI(log *slog.Logger, input Input) *model.Model {
 
 			httpRoutes = append(httpRoutes, toHTTPRoutes(log, l.Listener, l.Source.Namespace, namespaceLabels, namespacesPreFiltered, listenerHostnamesByProtocol, filteredHTTPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants, input.BackendTLSPolicyMap)...)
 			httpRoutes = append(httpRoutes, toGRPCRoutes(l.Listener, l.Source.Namespace, namespaceLabels, namespacesPreFiltered, listenerHostnamesByProtocol, filteredGRPCRoutes, input.Services, input.ServiceImports, input.ReferenceGrants)...)
-			resHTTP = append(resHTTP, model.HTTPListener{
+			m.HTTP = append(m.HTTP, model.HTTPListener{
 				Name:                       string(l.Name),
 				Sources:                    []model.FullyQualifiedResource{l.Source},
 				Port:                       uint32(l.Port),
@@ -241,11 +238,11 @@ func GatewayAPI(log *slog.Logger, input Input) *model.Model {
 				Routes:                     httpRoutes,
 				Infrastructure:             infra,
 				Service:                    toServiceModel(input.GatewayClassConfig),
-				ServerHeaderTransformation: input.ServerHeaderTransformation,
+				ServerHeaderTransformation: toServerHeaderTransformation(input.GatewayClassConfig),
 			})
 
 			if l.Protocol == gatewayv1.TLSProtocolType {
-				resTLSPassthrough = append(resTLSPassthrough, model.TLSPassthroughListener{
+				m.TLSPassthrough = append(m.TLSPassthrough, model.TLSPassthroughListener{
 					Name:           string(l.Name),
 					Sources:        []model.FullyQualifiedResource{l.Source},
 					Port:           uint32(l.Port),
@@ -258,7 +255,7 @@ func GatewayAPI(log *slog.Logger, input Input) *model.Model {
 
 		case gatewayv1.TCPProtocolType:
 			namespacesPreFiltered := l.AllowedNamespaces != nil
-			resL4 = append(resL4, model.L4Listener{
+			m.L4 = append(m.L4, model.L4Listener{
 				Name:           string(l.Name),
 				Sources:        []model.FullyQualifiedResource{l.Source},
 				Port:           uint32(l.Port),
@@ -270,7 +267,7 @@ func GatewayAPI(log *slog.Logger, input Input) *model.Model {
 
 		case gatewayv1.UDPProtocolType:
 			namespacesPreFiltered := l.AllowedNamespaces != nil
-			resL4 = append(resL4, model.L4Listener{
+			m.L4 = append(m.L4, model.L4Listener{
 				Name:           string(l.Name),
 				Sources:        []model.FullyQualifiedResource{l.Source},
 				Port:           uint32(l.Port),
@@ -282,27 +279,20 @@ func GatewayAPI(log *slog.Logger, input Input) *model.Model {
 		}
 	}
 
-	m := &model.Model{
-		HTTP:           resHTTP,
-		TLSPassthrough: resTLSPassthrough,
-		L4:             resL4,
-	}
-
-	if input.GatewayClassConfig != nil {
+	if gcc := input.GatewayClassConfig; gcc != nil {
 		// HTTP Options
 		m.HTTPOptions = &model.HTTPOptions{
 			GRPCWebTranslation: &model.GRPCWebTranslationConfig{
-				Enabled: input.GatewayClassConfig.GRPCWebTranslationEnabled(),
+				Enabled: gcc.GRPCWebTranslationEnabled(),
 			},
 		}
-
 		// Telemetry
-		if input.GatewayClassConfig.IsTelemetryConfigured() {
+		if gcc.IsTelemetryConfigured() {
 			nn := types.NamespacedName{
 				Namespace: input.Gateway.GetNamespace(),
 				Name:      input.Gateway.GetName(),
 			}
-			m.Telemetry = toTelemetryConfig(nn, input.GatewayClassConfig.Spec.Telemetry)
+			m.Telemetry = toTelemetryConfig(nn, gcc.Spec.Telemetry)
 		}
 	}
 

--- a/operator/pkg/model/ingestion/gateway_config.go
+++ b/operator/pkg/model/ingestion/gateway_config.go
@@ -99,3 +99,10 @@ func toTelemetryConfig(nn types.NamespacedName, telemetry *v2alpha1.Telemetry) *
 
 	return t
 }
+
+func toServerHeaderTransformation(gcc *v2alpha1.CiliumGatewayClassConfig) model.ServerHeaderTransformation {
+	if gcc == nil || gcc.Spec.Envoy == nil || gcc.Spec.Envoy.ServerHeaderTransformation == nil {
+		return ""
+	}
+	return model.ServerHeaderTransformation(*gcc.Spec.Envoy.ServerHeaderTransformation)
+}

--- a/operator/pkg/model/ingestion/gateway_test.go
+++ b/operator/pkg/model/ingestion/gateway_test.go
@@ -1210,6 +1210,35 @@ func TestGatewayAPI_GatewayClassConfig(t *testing.T) {
 			},
 		}, m.Telemetry)
 	})
+	t.Run("sets server header transformation from GatewayClassConfig envoy config", func(t *testing.T) {
+		m := GatewayAPI(logger, Input{
+			Gateway: gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "cilium",
+				},
+				Spec: gatewayv1.GatewaySpec{
+					Listeners: []gatewayv1.Listener{
+						{
+							Name:     "http",
+							Port:     80,
+							Protocol: gatewayv1.HTTPProtocolType,
+						},
+					},
+				},
+			},
+			GatewayClassConfig: &v2alpha1.CiliumGatewayClassConfig{
+				Spec: v2alpha1.CiliumGatewayClassConfigSpec{
+					Envoy: &v2alpha1.EnvoyConfig{
+						ServerHeaderTransformation: ptr.To(v2alpha1.ServerHeaderTransformationPassThrough),
+					},
+				},
+			},
+		})
+
+		require.Len(t, m.HTTP, 1)
+		assert.Equal(t, model.ServerHeaderTransformationPassThrough, m.HTTP[0].ServerHeaderTransformation)
+	})
 }
 
 func TestGatewayAPI_GatewayClassConfigTelemetry(t *testing.T) {


### PR DESCRIPTION
Move Server Header Transformation handling from the Gateway reconciler and centralize it within `ingestion.GatewayAPI`, where the rest of the `CiliumGatewayClassConfig` model transformation lives.

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
