### PR TITLE
Fix 5-tuple collision in conformance kind proxy embedded

### DIFF
--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -157,12 +157,18 @@ jobs:
         run: |
           # Note: On Kind, we install Cilium with HostPort (portmap CNI chaining) enabled,
           # to ensure coverage of that feature in cilium connectivity test
+          # This test intentionally sends traffic with and without L7 LB in succession.
+          # Bound attempts on a stale pooled connection and close that socket immediately
+          # so Envoy can release a colliding 5-tuple and retry when the client reuses its
+          # source port for a direct connection.
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --helm-set=hubble.relay.enabled=true
             --helm-set=cni.chainingMode=portmap \
             --helm-set-string=kubeProxyReplacement=true \
             --helm-set=k8sClusterNetworkPolicy.enabled=${ENABLE_CLUSTERNETWORKPOLICY} \
             --helm-set=loadBalancer.l7.backend=envoy \
+            --helm-set=envoy.httpRetryTimeout=1 \
+            --helm-set=envoy.httpUpstreamLingerTimeout=0 \
             --helm-set=tls.readSecretsOnlyFromSecretsNamespace=true \
             --helm-set=tls.secretSync.enabled=true \
             --helm-set=envoy.enabled=false \

--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -159,12 +159,18 @@ jobs:
         run: |
           # Note: On Kind, we install Cilium with HostPort (portmap CNI chaining) enabled,
           # to ensure coverage of that feature in cilium connectivity test
+          # This test intentionally sends traffic with and without L7 LB in succession.
+          # Bound attempts on a stale pooled connection and close that socket immediately
+          # so Envoy can release a colliding 5-tuple and retry when the client reuses its
+          # source port for a direct connection.
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --helm-set=hubble.relay.enabled=true
             --helm-set=cni.chainingMode=portmap \
             --helm-set-string=kubeProxyReplacement=true \
             --helm-set=k8sClusterNetworkPolicy.enabled=${ENABLE_CLUSTERNETWORKPOLICY} \
             --helm-set=loadBalancer.l7.backend=envoy \
+            --helm-set=envoy.httpRetryTimeout=1 \
+            --helm-set=envoy.httpUpstreamLingerTimeout=0 \
             --helm-set=tls.readSecretsOnlyFromSecretsNamespace=true \
             --helm-set=tls.secretSync.enabled=true \
             --helm-set=envoy.enabled=false \

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -69,6 +69,8 @@ cilium-operator-alibabacloud [flags]
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for cilium-operator-alibabacloud
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-allocation-mode string                            Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
@@ -142,6 +144,7 @@ cilium-operator-alibabacloud [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -75,6 +75,8 @@ cilium-operator-alibabacloud [flags]
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for cilium-operator-alibabacloud
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-allocation-mode string                            Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
@@ -146,6 +148,7 @@ cilium-operator-alibabacloud [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -60,6 +60,8 @@ cilium-operator-alibabacloud hive [flags]
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for hive
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
@@ -127,6 +129,7 @@ cilium-operator-alibabacloud hive [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -66,6 +66,8 @@ cilium-operator-alibabacloud hive [flags]
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for hive
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
@@ -131,6 +133,7 @@ cilium-operator-alibabacloud hive [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -65,6 +65,8 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --gateway-api-use-remote-address                             Use the immediate client's IP address as the origin client's IP address (default true)
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
@@ -132,6 +134,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -71,6 +71,8 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --gateway-api-use-remote-address                             Use the immediate client's IP address as the origin client's IP address (default true)
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
@@ -136,6 +138,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -76,6 +76,8 @@ cilium-operator-aws [flags]
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for cilium-operator-aws
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-allocation-mode string                            Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
@@ -149,6 +151,7 @@ cilium-operator-aws [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -81,6 +81,8 @@ cilium-operator-aws [flags]
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for cilium-operator-aws
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-allocation-mode string                            Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
@@ -152,6 +154,7 @@ cilium-operator-aws [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -67,6 +67,8 @@ cilium-operator-aws hive [flags]
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for hive
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
@@ -134,6 +136,7 @@ cilium-operator-aws hive [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -72,6 +72,8 @@ cilium-operator-aws hive [flags]
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for hive
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
@@ -137,6 +139,7 @@ cilium-operator-aws hive [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -72,6 +72,8 @@ cilium-operator-aws hive dot-graph [flags]
       --gateway-api-use-remote-address                             Use the immediate client's IP address as the origin client's IP address (default true)
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
@@ -139,6 +141,7 @@ cilium-operator-aws hive dot-graph [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -77,6 +77,8 @@ cilium-operator-aws hive dot-graph [flags]
       --gateway-api-use-remote-address                             Use the immediate client's IP address as the origin client's IP address (default true)
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
@@ -142,6 +144,7 @@ cilium-operator-aws hive dot-graph [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -71,6 +71,8 @@ cilium-operator-azure [flags]
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for cilium-operator-azure
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-allocation-mode string                            Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
@@ -144,6 +146,7 @@ cilium-operator-azure [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -77,6 +77,8 @@ cilium-operator-azure [flags]
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for cilium-operator-azure
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-allocation-mode string                            Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
@@ -148,6 +150,7 @@ cilium-operator-azure [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -62,6 +62,8 @@ cilium-operator-azure hive [flags]
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for hive
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
@@ -129,6 +131,7 @@ cilium-operator-azure hive [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -68,6 +68,8 @@ cilium-operator-azure hive [flags]
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for hive
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
@@ -133,6 +135,7 @@ cilium-operator-azure hive [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -67,6 +67,8 @@ cilium-operator-azure hive dot-graph [flags]
       --gateway-api-use-remote-address                             Use the immediate client's IP address as the origin client's IP address (default true)
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
@@ -134,6 +136,7 @@ cilium-operator-azure hive dot-graph [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -73,6 +73,8 @@ cilium-operator-azure hive dot-graph [flags]
       --gateway-api-use-remote-address                             Use the immediate client's IP address as the origin client's IP address (default true)
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
@@ -138,6 +140,7 @@ cilium-operator-azure hive dot-graph [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -73,6 +73,8 @@ cilium-operator-generic [flags]
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for cilium-operator-generic
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-allocation-mode string                            Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
@@ -148,6 +150,7 @@ cilium-operator-generic [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -79,6 +79,8 @@ cilium-operator-generic [flags]
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for cilium-operator-generic
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-allocation-mode string                            Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
@@ -152,6 +154,7 @@ cilium-operator-generic [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -64,6 +64,8 @@ cilium-operator-generic hive [flags]
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for hive
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
@@ -133,6 +135,7 @@ cilium-operator-generic hive [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -70,6 +70,8 @@ cilium-operator-generic hive [flags]
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for hive
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
@@ -137,6 +139,7 @@ cilium-operator-generic hive [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -69,6 +69,8 @@ cilium-operator-generic hive dot-graph [flags]
       --gateway-api-use-remote-address                             Use the immediate client's IP address as the origin client's IP address (default true)
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
@@ -138,6 +140,7 @@ cilium-operator-generic hive dot-graph [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -75,6 +75,8 @@ cilium-operator-generic hive dot-graph [flags]
       --gateway-api-use-remote-address                             Use the immediate client's IP address as the origin client's IP address (default true)
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
@@ -142,6 +144,7 @@ cilium-operator-generic hive dot-graph [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -88,6 +88,8 @@ cilium-operator [flags]
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for cilium-operator
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-allocation-mode string                            Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
@@ -163,6 +165,7 @@ cilium-operator [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -93,6 +93,8 @@ cilium-operator [flags]
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for cilium-operator
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-allocation-mode string                            Method to use for identity allocation (default "kvstore")
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
@@ -166,6 +168,7 @@ cilium-operator [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -79,6 +79,8 @@ cilium-operator hive [flags]
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for hive
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
@@ -148,6 +150,7 @@ cilium-operator hive [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -84,6 +84,8 @@ cilium-operator hive [flags]
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
   -h, --help                                                       help for hive
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
@@ -151,6 +153,7 @@ cilium-operator hive [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -84,6 +84,8 @@ cilium-operator hive dot-graph [flags]
       --gateway-api-use-remote-address                             Use the immediate client's IP address as the origin client's IP address (default true)
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
@@ -153,6 +155,7 @@ cilium-operator hive dot-graph [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -89,6 +89,8 @@ cilium-operator hive dot-graph [flags]
       --gateway-api-use-remote-address                             Use the immediate client's IP address as the origin client's IP address (default true)
       --gateway-api-xff-num-trusted-hops uint32                    The number of additional GatewayAPI proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --gops-port uint16                                           Port for gops server to listen on (default 9891)
+      --http-retry-count uint                                      Number of retries performed after a forwarded request attempt fails (default 3)
+      --http-retry-timeout uint                                    Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)
       --identity-gc-interval duration                              GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                         Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                                 Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
@@ -156,6 +158,7 @@ cilium-operator hive dot-graph [flags]
       --policy-external-group-sync-interval duration               Period between refreshing the CIDRs for a given policy external group. (default 10m0s)
       --policy-secrets-namespace string                            Namespace where secrets used in TLS Interception will be synced to. (default "cilium-secrets")
       --proxy-idle-timeout-seconds int                             Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests. (default 60)
+      --proxy-max-requests-per-connection int                      Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)
       --proxy-stream-idle-timeout-seconds int                      Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity. (default 300)
       --remove-cilium-node-taints                                  Remove node taint "node.cilium.io/agent-not-ready" from Kubernetes nodes once Cilium is up and running (default true)
       --set-cilium-is-up-condition                                 Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node (default true)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1680,6 +1680,10 @@
      - Maximum number of retries for each HTTP request
      - int
      - ``3``
+   * - :spelling:ignore:`envoy.httpRetryTimeout`
+     - Time in seconds after which a forwarded but uncompleted HTTP request is retried. Default 0 (never).
+     - int
+     - ``0``
    * - :spelling:ignore:`envoy.httpUpstreamLingerTimeout`
      - Time in seconds to block Envoy worker thread while an upstream HTTP connection is closing. If set to 0, the connection is closed immediately (with TCP RST). If set to -1, the connection is closed asynchronously in the background.
      - string

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1688,6 +1688,10 @@
      - Maximum number of retries for each HTTP request
      - int
      - ``3``
+   * - :spelling:ignore:`envoy.httpRetryTimeout`
+     - Time in seconds after which a forwarded but uncompleted HTTP request is retried. Default 0 (never).
+     - int
+     - ``0``
    * - :spelling:ignore:`envoy.httpUpstreamLingerTimeout`
      - Time in seconds to block Envoy worker thread while an upstream HTTP connection is closing. If set to 0, the connection is closed immediately (with TCP RST). If set to -1, the connection is closed asynchronously in the background.
      - string

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1024,7 +1024,10 @@ ct_recreate6:
 
 		/* See comment in handle_ipv4_from_lxc(). */
 		ct_state_new.proxy_redirect = proxy_port > 0;
-		if (unlikely(ct_state->proxy_redirect != ct_state_new.proxy_redirect))
+		ct_state_new.from_l7lb = from_l7lb;
+		if (unlikely(ct_state->proxy_redirect != ct_state_new.proxy_redirect ||
+			     (ct_state->syn &&
+			      ct_state->from_l7lb != ct_state_new.from_l7lb)))
 			goto ct_recreate6;
 		break;
 
@@ -1608,11 +1611,18 @@ ct_recreate4:
 		 * suddenly comes into the scope of an L7 policy. Recreating the entry
 		 * updates the proxy_redirect flag properly.
 		 *
+		 * A new SYN may reuse a tuple with different L7 LB provenance. Recreate
+		 * the entry so the new connection takes ownership of the tuple, but do
+		 * not allow later packets from the old connection to take it back.
+		 *
 		 * if the packet hits a closing stale entry, ct_lookup returns CT_NEW and
 		 * caller recreates the entry.
 		 */
 		ct_state_new.proxy_redirect = proxy_port > 0;
-		if (unlikely(ct_state->proxy_redirect != ct_state_new.proxy_redirect))
+		ct_state_new.from_l7lb = from_l7lb;
+		if (unlikely(ct_state->proxy_redirect != ct_state_new.proxy_redirect ||
+			     (ct_state->syn &&
+			      ct_state->from_l7lb != ct_state_new.from_l7lb)))
 			goto ct_recreate4;
 		break;
 

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -265,9 +265,9 @@ ct_lookup_fill_state(struct ct_state *state, const struct ct_entry *entry,
 		     enum ct_dir dir, bool syn)
 {
 	state->rev_nat_index = entry->rev_nat_index;
+	state->syn = syn;
 	if (dir == CT_SERVICE) {
 		state->backend_id = (__u32)entry->backend_id;
-		state->syn = syn;
 	} else if (dir == CT_INGRESS || dir == CT_EGRESS) {
 #ifdef USE_LOOPBACK_LB
 		state->loopback = entry->lb_loopback;

--- a/bpf/tests/l7_lb_local_backend.h
+++ b/bpf/tests/l7_lb_local_backend.h
@@ -16,6 +16,7 @@
 #define CLIENT_IP		v4_pod_one
 #define CLIENT_IP6		v6_pod_one
 #define CLIENT_PORT		tcp_src_one
+#define REUSED_CLIENT_PORT	tcp_src_two
 
 #define BACKEND_IP		v4_svc_one
 #define BACKEND_IP6		v6_svc_one
@@ -200,4 +201,200 @@ int l7_lb_local_backend_v6_check(const struct __ctx_buff *ctx)
 #endif
 
 	test_finish();
+}
+
+static __always_inline int
+l7_lb_ct_pktgen(struct __ctx_buff *ctx, bool ipv6, bool fin)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+
+	pktgen__init(&builder, ctx);
+
+	if (ipv6)
+		l4 = pktgen__push_ipv6_tcp_packet(&builder,
+						  (__u8 *)mac_one, (__u8 *)mac_host,
+						  (__u8 *)CLIENT_IP6, (__u8 *)BACKEND_IP6,
+						  REUSED_CLIENT_PORT, BACKEND_PORT);
+	else
+		l4 = pktgen__push_ipv4_tcp_packet(&builder,
+						  (__u8 *)mac_one, (__u8 *)mac_host,
+						  CLIENT_IP, BACKEND_IP,
+						  REUSED_CLIENT_PORT, BACKEND_PORT);
+	if (!l4)
+		return TEST_ERROR;
+
+	if (fin) {
+		l4->syn = 0;
+		l4->fin = 1;
+	}
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+static __always_inline int
+l7_lb_ct_check(void *map, const void *tuple, bool from_l7lb)
+{
+	struct ct_entry *entry;
+
+	test_init();
+
+	entry = map_lookup_elem(map, tuple);
+	if (!entry)
+		test_fatal("no CT entry found");
+
+	assert(entry->from_l7lb == from_l7lb);
+
+	test_finish();
+}
+
+static __always_inline int
+l7_lb_ct_v4_check(bool from_l7lb)
+{
+	struct ipv4_ct_tuple tuple = {
+		.daddr = CLIENT_IP,
+		.saddr = BACKEND_IP,
+		.dport = BACKEND_PORT,
+		.sport = REUSED_CLIENT_PORT,
+		.nexthdr = IPPROTO_TCP,
+		.flags = TUPLE_F_OUT,
+	};
+
+	return l7_lb_ct_check(get_ct_map4(&tuple), &tuple, from_l7lb);
+}
+
+static __always_inline int
+l7_lb_ct_v6_check(bool from_l7lb)
+{
+	struct ipv6_ct_tuple tuple = {
+		.daddr = *(union v6addr *)CLIENT_IP6,
+		.saddr = *(union v6addr *)BACKEND_IP6,
+		.dport = BACKEND_PORT,
+		.sport = REUSED_CLIENT_PORT,
+		.nexthdr = IPPROTO_TCP,
+		.flags = TUPLE_F_OUT,
+	};
+
+	return l7_lb_ct_check(get_ct_map6(&tuple), &tuple, from_l7lb);
+}
+
+static __always_inline int
+l7_lb_ct_setup(struct __ctx_buff *ctx, bool from_proxy)
+{
+	policy_add_egress_allow_all_entry();
+	if (from_proxy)
+		return tail_call_egress_policy(ctx, CLIENT_EP_ID);
+	return pod_send_packet(ctx);
+}
+
+/* A direct SYN reusing an Envoy upstream tuple must take ownership of its CT
+ * entry. Later packets from the old Envoy connection must not take it back.
+ */
+PKTGEN("tc", "l7_lb_ct_v4_1_proxy_syn")
+int l7_lb_ct_v4_1_proxy_syn_pktgen(struct __ctx_buff *ctx)
+{
+	return l7_lb_ct_pktgen(ctx, false, false);
+}
+
+SETUP("tc", "l7_lb_ct_v4_1_proxy_syn")
+int l7_lb_ct_v4_1_proxy_syn_setup(struct __ctx_buff *ctx)
+{
+	return l7_lb_ct_setup(ctx, true);
+}
+
+CHECK("tc", "l7_lb_ct_v4_1_proxy_syn")
+int l7_lb_ct_v4_1_proxy_syn_check(const struct __ctx_buff *ctx __maybe_unused)
+{
+	return l7_lb_ct_v4_check(true);
+}
+
+PKTGEN("tc", "l7_lb_ct_v4_2_direct_syn")
+int l7_lb_ct_v4_2_direct_syn_pktgen(struct __ctx_buff *ctx)
+{
+	return l7_lb_ct_pktgen(ctx, false, false);
+}
+
+SETUP("tc", "l7_lb_ct_v4_2_direct_syn")
+int l7_lb_ct_v4_2_direct_syn_setup(struct __ctx_buff *ctx)
+{
+	return l7_lb_ct_setup(ctx, false);
+}
+
+CHECK("tc", "l7_lb_ct_v4_2_direct_syn")
+int l7_lb_ct_v4_2_direct_syn_check(const struct __ctx_buff *ctx __maybe_unused)
+{
+	return l7_lb_ct_v4_check(false);
+}
+
+PKTGEN("tc", "l7_lb_ct_v4_3_proxy_fin")
+int l7_lb_ct_v4_3_proxy_fin_pktgen(struct __ctx_buff *ctx)
+{
+	return l7_lb_ct_pktgen(ctx, false, true);
+}
+
+SETUP("tc", "l7_lb_ct_v4_3_proxy_fin")
+int l7_lb_ct_v4_3_proxy_fin_setup(struct __ctx_buff *ctx)
+{
+	return l7_lb_ct_setup(ctx, true);
+}
+
+CHECK("tc", "l7_lb_ct_v4_3_proxy_fin")
+int l7_lb_ct_v4_3_proxy_fin_check(const struct __ctx_buff *ctx __maybe_unused)
+{
+	return l7_lb_ct_v4_check(false);
+}
+
+PKTGEN("tc", "l7_lb_ct_v6_1_proxy_syn")
+int l7_lb_ct_v6_1_proxy_syn_pktgen(struct __ctx_buff *ctx)
+{
+	return l7_lb_ct_pktgen(ctx, true, false);
+}
+
+SETUP("tc", "l7_lb_ct_v6_1_proxy_syn")
+int l7_lb_ct_v6_1_proxy_syn_setup(struct __ctx_buff *ctx)
+{
+	return l7_lb_ct_setup(ctx, true);
+}
+
+CHECK("tc", "l7_lb_ct_v6_1_proxy_syn")
+int l7_lb_ct_v6_1_proxy_syn_check(const struct __ctx_buff *ctx __maybe_unused)
+{
+	return l7_lb_ct_v6_check(true);
+}
+
+PKTGEN("tc", "l7_lb_ct_v6_2_direct_syn")
+int l7_lb_ct_v6_2_direct_syn_pktgen(struct __ctx_buff *ctx)
+{
+	return l7_lb_ct_pktgen(ctx, true, false);
+}
+
+SETUP("tc", "l7_lb_ct_v6_2_direct_syn")
+int l7_lb_ct_v6_2_direct_syn_setup(struct __ctx_buff *ctx)
+{
+	return l7_lb_ct_setup(ctx, false);
+}
+
+CHECK("tc", "l7_lb_ct_v6_2_direct_syn")
+int l7_lb_ct_v6_2_direct_syn_check(const struct __ctx_buff *ctx __maybe_unused)
+{
+	return l7_lb_ct_v6_check(false);
+}
+
+PKTGEN("tc", "l7_lb_ct_v6_3_proxy_fin")
+int l7_lb_ct_v6_3_proxy_fin_pktgen(struct __ctx_buff *ctx)
+{
+	return l7_lb_ct_pktgen(ctx, true, true);
+}
+
+SETUP("tc", "l7_lb_ct_v6_3_proxy_fin")
+int l7_lb_ct_v6_3_proxy_fin_setup(struct __ctx_buff *ctx)
+{
+	return l7_lb_ct_setup(ctx, true);
+}
+
+CHECK("tc", "l7_lb_ct_v6_3_proxy_fin")
+int l7_lb_ct_v6_3_proxy_fin_check(const struct __ctx_buff *ctx __maybe_unused)
+{
+	return l7_lb_ct_v6_check(false);
 }

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -470,6 +470,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.extraVolumes | list | `[]` | Additional envoy volumes. |
 | envoy.healthPort | int | `9878` | TCP port for the health API. |
 | envoy.httpRetryCount | int | `3` | Maximum number of retries for each HTTP request |
+| envoy.httpRetryTimeout | int | `0` | Time in seconds after which a forwarded but uncompleted HTTP request is retried. Default 0 (never). |
 | envoy.httpUpstreamLingerTimeout | string | `nil` | Time in seconds to block Envoy worker thread while an upstream HTTP connection is closing. If set to 0, the connection is closed immediately (with TCP RST). If set to -1, the connection is closed asynchronously in the background. |
 | envoy.idleTimeoutDurationSeconds | int | `60` | Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s |
 | envoy.image | object | `{"digest":"sha256:583057dd4f7d54cd41efff3c413aa0b148ac201f522e2c3336851fa89c78b039","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-envoy","tag":"v1.37.5-1782911245-7cffc778c923f68a77954a53b1a98d6b5353f004","useDigest":true}` | Envoy container image. |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -472,6 +472,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.extraVolumes | list | `[]` | Additional envoy volumes. |
 | envoy.healthPort | int | `9878` | TCP port for the health API. |
 | envoy.httpRetryCount | int | `3` | Maximum number of retries for each HTTP request |
+| envoy.httpRetryTimeout | int | `0` | Time in seconds after which a forwarded but uncompleted HTTP request is retried. Default 0 (never). |
 | envoy.httpUpstreamLingerTimeout | string | `nil` | Time in seconds to block Envoy worker thread while an upstream HTTP connection is closing. If set to 0, the connection is closed immediately (with TCP RST). If set to -1, the connection is closed asynchronously in the background. |
 | envoy.idleTimeoutDurationSeconds | int | `60` | Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s |
 | envoy.image | object | `{"digest":"sha256:1b958363b16328905d93371dd974cc57e8ff277f8e589b31de9ff8e805013b9f","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-envoy","tag":"v1.38.4-1788418248-230e609978a4f7e614671e0e7e00a1911b93406c","useDigest":true}` | Envoy container image. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1506,13 +1506,14 @@ data:
   proxy-cluster-max-pending-requests: {{ .Values.envoy.clusterMaxPendingRequests | quote }}
   proxy-cluster-max-requests: {{ .Values.envoy.clusterMaxRequests | quote }}
   http-retry-count: {{ .Values.envoy.httpRetryCount | quote }}
+  http-retry-timeout: {{ .Values.envoy.httpRetryTimeout | quote }}
   http-stream-idle-timeout: {{ .Values.envoy.streamIdleTimeoutDurationSeconds | quote }}
   envoy-node-locality-enabled: {{ .Values.envoy.nodeLocality.enabled | quote }}
 
   external-envoy-proxy: {{ include "envoyDaemonSetEnabled" . | quote }}
   envoy-base-id: {{ .Values.envoy.baseID | quote }}
 
-{{- if .Values.envoy.httpUpstreamLingerTimeout }}
+{{- if ne .Values.envoy.httpUpstreamLingerTimeout nil }}
   envoy-http-upstream-linger-timeout: {{ .Values.envoy.httpUpstreamLingerTimeout | quote }}
 {{- end }}
 

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1520,6 +1520,7 @@ data:
   proxy-cluster-max-pending-requests: {{ .Values.envoy.clusterMaxPendingRequests | quote }}
   proxy-cluster-max-requests: {{ .Values.envoy.clusterMaxRequests | quote }}
   http-retry-count: {{ .Values.envoy.httpRetryCount | quote }}
+  http-retry-timeout: {{ .Values.envoy.httpRetryTimeout | quote }}
   http-stream-idle-timeout: {{ .Values.envoy.streamIdleTimeoutDurationSeconds | quote }}
   envoy-node-locality-enabled: {{ .Values.envoy.nodeLocality.enabled | quote }}
 

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -2499,8 +2499,14 @@
         "httpRetryCount": {
           "type": "integer"
         },
+        "httpRetryTimeout": {
+          "type": "integer"
+        },
         "httpUpstreamLingerTimeout": {
-          "type": "null"
+          "type": [
+            "null",
+            "integer"
+          ]
         },
         "idleTimeoutDurationSeconds": {
           "type": "integer"

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -2513,6 +2513,9 @@
         "httpRetryCount": {
           "type": "integer"
         },
+        "httpRetryTimeout": {
+          "type": "integer"
+        },
         "httpUpstreamLingerTimeout": {
           "type": [
             "null",

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2813,6 +2813,8 @@ envoy:
   maxGlobalDownstreamConnections: 50000
   # -- Maximum number of retries for each HTTP request
   httpRetryCount: 3
+  # -- Time in seconds after which a forwarded but uncompleted HTTP request is retried. Default 0 (never).
+  httpRetryTimeout: 0
   # -- ProxyMaxRequestsPerConnection specifies the max_requests_per_connection setting for Envoy
   maxRequestsPerConnection: 0
   # -- Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable)
@@ -2835,6 +2837,9 @@ envoy:
   # @schema
   # -- Max duration to wait for endpoint policies to be restored on restart. Default "3m".
   policyRestoreTimeoutDuration: null
+  # @schema
+  # type: [null, integer]
+  # @schema
   # -- Time in seconds to block Envoy worker thread while an upstream HTTP connection is closing. If set to 0, the connection is closed immediately (with TCP RST). If set to -1, the connection is closed asynchronously in the background.
   httpUpstreamLingerTimeout: null
   # -- Static runtime bootstrap config for envoy.

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2838,6 +2838,8 @@ envoy:
   maxGlobalDownstreamConnections: 50000
   # -- Maximum number of retries for each HTTP request
   httpRetryCount: 3
+  # -- Time in seconds after which a forwarded but uncompleted HTTP request is retried. Default 0 (never).
+  httpRetryTimeout: 0
   # -- ProxyMaxRequestsPerConnection specifies the max_requests_per_connection setting for Envoy
   maxRequestsPerConnection: 0
   # -- Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable)

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2844,6 +2844,8 @@ envoy:
   maxGlobalDownstreamConnections: 50000
   # -- Maximum number of retries for each HTTP request
   httpRetryCount: 3
+  # -- Time in seconds after which a forwarded but uncompleted HTTP request is retried. Default 0 (never).
+  httpRetryTimeout: 0
   # -- ProxyMaxRequestsPerConnection specifies the max_requests_per_connection setting for Envoy
   maxRequestsPerConnection: 0
   # -- Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable)
@@ -2866,6 +2868,9 @@ envoy:
   # @schema
   # -- Max duration to wait for endpoint policies to be restored on restart. Default "3m".
   policyRestoreTimeoutDuration: null
+  # @schema
+  # type: [null, integer]
+  # @schema
   # -- Time in seconds to block Envoy worker thread while an upstream HTTP connection is closing. If set to 0, the connection is closed immediately (with TCP RST). If set to -1, the connection is closed asynchronously in the background.
   httpUpstreamLingerTimeout: null
   # -- Static runtime bootstrap config for envoy.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2869,6 +2869,8 @@ envoy:
   maxGlobalDownstreamConnections: 50000
   # -- Maximum number of retries for each HTTP request
   httpRetryCount: 3
+  # -- Time in seconds after which a forwarded but uncompleted HTTP request is retried. Default 0 (never).
+  httpRetryTimeout: 0
   # -- ProxyMaxRequestsPerConnection specifies the max_requests_per_connection setting for Envoy
   maxRequestsPerConnection: 0
   # -- Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable)

--- a/operator/pkg/ciliumenvoyconfig/cell.go
+++ b/operator/pkg/ciliumenvoyconfig/cell.go
@@ -24,28 +24,41 @@ var Cell = cell.Module(
 		LoadBalancerL7Ports:     []string{},
 		LoadBalancerL7Algorithm: "round_robin",
 	}),
-	cell.Config(defaultEnvoyProxyTimeouts),
+	cell.Config(defaultEnvoyProxyConfig),
 	cell.Invoke(registerL7LoadBalancingController),
 	cell.Provide(func(r l7LoadBalancerConfig) LoadBalancerConfig { return r }),
 )
 
-// EnvoyProxyTimeouts holds the upstream timeout values used by the operator
-// when translating Ingress and Gateway API resources into CiliumEnvoyConfig.
-type EnvoyProxyTimeouts struct {
+// EnvoyProxyConfig holds the upstream HTTP settings used by the operator
+// when translating services, Ingress, and Gateway API resources into
+// CiliumEnvoyConfig.
+type EnvoyProxyConfig struct {
 	ProxyIdleTimeoutSeconds       int
 	ProxyStreamIdleTimeoutSeconds int
+	ProxyMaxRequestsPerConnection int
+	HTTPRetryCount                uint
+	HTTPRetryTimeout              uint
 }
 
-var defaultEnvoyProxyTimeouts = EnvoyProxyTimeouts{
+var defaultEnvoyProxyConfig = EnvoyProxyConfig{
 	ProxyIdleTimeoutSeconds:       60,
 	ProxyStreamIdleTimeoutSeconds: 300,
+	ProxyMaxRequestsPerConnection: 0,
+	HTTPRetryCount:                3,
+	HTTPRetryTimeout:              0,
 }
 
-func (c EnvoyProxyTimeouts) Flags(flags *pflag.FlagSet) {
-	flags.Int("proxy-idle-timeout-seconds", defaultEnvoyProxyTimeouts.ProxyIdleTimeoutSeconds,
+func (c EnvoyProxyConfig) Flags(flags *pflag.FlagSet) {
+	flags.Int("proxy-idle-timeout-seconds", defaultEnvoyProxyConfig.ProxyIdleTimeoutSeconds,
 		"Set Envoy upstream HTTP idle connection timeout in seconds. Does not apply to connections with pending requests.")
-	flags.Int("proxy-stream-idle-timeout-seconds", defaultEnvoyProxyTimeouts.ProxyStreamIdleTimeoutSeconds,
+	flags.Int("proxy-stream-idle-timeout-seconds", defaultEnvoyProxyConfig.ProxyStreamIdleTimeoutSeconds,
 		"Set Envoy HTTP stream idle timeout in seconds. A stream is considered idle when there is no upstream or downstream activity.")
+	flags.Int("proxy-max-requests-per-connection", defaultEnvoyProxyConfig.ProxyMaxRequestsPerConnection,
+		"Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)")
+	flags.Uint("http-retry-count", defaultEnvoyProxyConfig.HTTPRetryCount,
+		"Number of retries performed after a forwarded request attempt fails")
+	flags.Uint("http-retry-timeout", defaultEnvoyProxyConfig.HTTPRetryTimeout,
+		"Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)")
 }
 
 type l7LoadBalancerConfig struct {
@@ -74,7 +87,7 @@ type l7LoadbalancerParams struct {
 	Logger             *slog.Logger
 	CtrlRuntimeManager ctrlRuntime.Manager
 	Config             l7LoadBalancerConfig
-	ProxyTimeouts      EnvoyProxyTimeouts
+	ProxyConfig        EnvoyProxyConfig
 }
 
 func registerL7LoadBalancingController(params l7LoadbalancerParams) error {
@@ -89,9 +102,11 @@ func registerL7LoadBalancingController(params l7LoadbalancerParams) error {
 		params.Logger,
 		params.Config.LoadBalancerL7Algorithm,
 		params.Config.LoadBalancerL7Ports,
-		10,
-		params.ProxyTimeouts.ProxyIdleTimeoutSeconds,
-		params.ProxyTimeouts.ProxyStreamIdleTimeoutSeconds,
+		params.ProxyConfig.ProxyIdleTimeoutSeconds,
+		params.ProxyConfig.ProxyStreamIdleTimeoutSeconds,
+		params.ProxyConfig.ProxyMaxRequestsPerConnection,
+		params.ProxyConfig.HTTPRetryCount,
+		params.ProxyConfig.HTTPRetryTimeout,
 		agentOption.Config.EnableIPv4,
 		agentOption.Config.EnableIPv6,
 	)

--- a/operator/pkg/ciliumenvoyconfig/ciliumenvoyconfig.go
+++ b/operator/pkg/ciliumenvoyconfig/ciliumenvoyconfig.go
@@ -20,15 +20,17 @@ type ciliumEnvoyConfigReconciler struct {
 
 	algorithm                string
 	ports                    []string
-	maxRetries               int
 	idleTimeoutSeconds       int
 	streamIdleTimeoutSeconds int
+	maxRequestsPerConnection int
+	httpRetryCount           uint
+	httpRetryTimeout         uint
 	enableIpv4               bool
 	enableIpv6               bool
 }
 
 func newCiliumEnvoyConfigReconciler(c client.Client, logger *slog.Logger, defaultAlgorithm string, ports []string,
-	maxRetries int, idleTimeoutSeconds int, streamIdleTimeoutSeconds int, enableIpv4 bool, enableIpv6 bool,
+	idleTimeoutSeconds int, streamIdleTimeoutSeconds int, maxRequestsPerConnection int, httpRetryCount uint, httpRetryTimeout uint, enableIpv4 bool, enableIpv6 bool,
 ) *ciliumEnvoyConfigReconciler {
 	return &ciliumEnvoyConfigReconciler{
 		client: c,
@@ -36,9 +38,11 @@ func newCiliumEnvoyConfigReconciler(c client.Client, logger *slog.Logger, defaul
 
 		algorithm:                defaultAlgorithm,
 		ports:                    ports,
-		maxRetries:               maxRetries,
 		idleTimeoutSeconds:       idleTimeoutSeconds,
 		streamIdleTimeoutSeconds: streamIdleTimeoutSeconds,
+		maxRequestsPerConnection: maxRequestsPerConnection,
+		httpRetryCount:           httpRetryCount,
+		httpRetryTimeout:         httpRetryTimeout,
 		enableIpv4:               enableIpv4,
 		enableIpv6:               enableIpv6,
 	}

--- a/operator/pkg/ciliumenvoyconfig/envoy_config.go
+++ b/operator/pkg/ciliumenvoyconfig/envoy_config.go
@@ -80,15 +80,19 @@ func (r *ciliumEnvoyConfigReconciler) getClusterResources(svc *corev1.Service) (
 	if !ok {
 		lbPolicy = int32(envoy_config_cluster_v3.Cluster_ROUND_ROBIN)
 	}
+	commonHTTPProtocolOptions := &envoy_config_core_v3.HttpProtocolOptions{
+		IdleTimeout: &durationpb.Duration{Seconds: int64(r.idleTimeoutSeconds)},
+	}
+	if r.maxRequestsPerConnection > 0 {
+		commonHTTPProtocolOptions.MaxRequestsPerConnection = wrapperspb.UInt32(uint32(r.maxRequestsPerConnection))
+	}
 	cluster := &envoy_config_cluster_v3.Cluster{
 		Name:           getName(svc),
 		ConnectTimeout: &durationpb.Duration{Seconds: 5},
 		LbPolicy:       envoy_config_cluster_v3.Cluster_LbPolicy(lbPolicy),
 		TypedExtensionProtocolOptions: map[string]*anypb.Any{
 			"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": r.toAny(&envoy_config_upstream.HttpProtocolOptions{
-				CommonHttpProtocolOptions: &envoy_config_core_v3.HttpProtocolOptions{
-					IdleTimeout: &durationpb.Duration{Seconds: int64(r.idleTimeoutSeconds)},
-				},
+				CommonHttpProtocolOptions: commonHTTPProtocolOptions,
 				UpstreamProtocolOptions: &envoy_config_upstream.HttpProtocolOptions_UseDownstreamProtocolConfig{
 					UseDownstreamProtocolConfig: &envoy_config_upstream.HttpProtocolOptions_UseDownstreamHttpConfig{
 						Http2ProtocolOptions: &envoy_config_core_v3.Http2ProtocolOptions{},
@@ -266,6 +270,7 @@ func (r *ciliumEnvoyConfigReconciler) getVirtualHost(svc *corev1.Service) *envoy
 						Seconds: 0,
 					},
 				},
+				RetryPolicy: envoy.GetHTTPRetryPolicy(r.httpRetryCount, r.httpRetryTimeout),
 			},
 		},
 	}

--- a/operator/pkg/ciliumenvoyconfig/envoy_config_test.go
+++ b/operator/pkg/ciliumenvoyconfig/envoy_config_test.go
@@ -9,6 +9,7 @@ import (
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	envoy_config_upstream "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	corev1 "k8s.io/api/core/v1"
@@ -16,7 +17,10 @@ import (
 )
 
 func Test_getClusterResources(t *testing.T) {
-	r := &ciliumEnvoyConfigReconciler{}
+	r := &ciliumEnvoyConfigReconciler{
+		idleTimeoutSeconds:       60,
+		maxRequestsPerConnection: 1,
+	}
 	res, err := r.getClusterResources(&corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "dummy-service",
@@ -36,10 +40,18 @@ func Test_getClusterResources(t *testing.T) {
 	require.Equal(t, &envoy_config_cluster_v3.Cluster_Type{
 		Type: envoy_config_cluster_v3.Cluster_EDS,
 	}, cluster.ClusterDiscoveryType)
+
+	protocolOptions := &envoy_config_upstream.HttpProtocolOptions{}
+	require.NoError(t, cluster.TypedExtensionProtocolOptions["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"].UnmarshalTo(protocolOptions))
+	require.Equal(t, int64(60), protocolOptions.CommonHttpProtocolOptions.IdleTimeout.Seconds)
+	require.Equal(t, uint32(1), protocolOptions.CommonHttpProtocolOptions.MaxRequestsPerConnection.Value)
 }
 
 func Test_getRouteConfigurationResource(t *testing.T) {
-	r := &ciliumEnvoyConfigReconciler{}
+	r := &ciliumEnvoyConfigReconciler{
+		httpRetryCount:   3,
+		httpRetryTimeout: 5,
+	}
 	res, err := r.getRouteConfigurationResource(&corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "dummy-service",
@@ -56,6 +68,11 @@ func Test_getRouteConfigurationResource(t *testing.T) {
 	require.Equal(t, "dummy-namespace/dummy-service", routeConfig.VirtualHosts[0].Name)
 	require.Equal(t, []string{"*"}, routeConfig.VirtualHosts[0].Domains)
 	require.Len(t, routeConfig.VirtualHosts[0].Routes, 1)
+	retryPolicy := routeConfig.VirtualHosts[0].Routes[0].GetRoute().GetRetryPolicy()
+	require.NotNil(t, retryPolicy)
+	require.Equal(t, "5xx", retryPolicy.GetRetryOn())
+	require.Equal(t, uint32(3), retryPolicy.GetNumRetries().GetValue())
+	require.Equal(t, int64(5), retryPolicy.GetPerTryTimeout().GetSeconds())
 }
 
 func Test_getListenerResource(t *testing.T) {

--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -224,7 +224,7 @@ type gatewayAPIParams struct {
 	OperatorConfig   *operatorOption.OperatorConfig
 	MCSAPIConfig     mcsapitypes.MCSAPIConfig
 	GatewayApiConfig gatewayApiConfig
-	ProxyTimeouts    ciliumenvoyconfig.EnvoyProxyTimeouts
+	ProxyConfig      ciliumenvoyconfig.EnvoyProxyConfig
 
 	// Preconditions is injected from private provider
 	Preconditions *gatewayAPIPreconditions
@@ -267,11 +267,12 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 		ListenerConfig: translation.ListenerConfig{
 			UseProxyProtocol:         params.GatewayApiConfig.EnableGatewayAPIProxyProtocol,
 			UseAlpn:                  params.GatewayApiConfig.EnableGatewayAPIAlpn,
-			StreamIdleTimeoutSeconds: params.ProxyTimeouts.ProxyStreamIdleTimeoutSeconds,
+			StreamIdleTimeoutSeconds: params.ProxyConfig.ProxyStreamIdleTimeoutSeconds,
 		},
 		ClusterConfig: translation.ClusterConfig{
-			IdleTimeoutSeconds: params.ProxyTimeouts.ProxyIdleTimeoutSeconds,
-			UseAppProtocol:     params.GatewayApiConfig.EnableGatewayAPIAppProtocol,
+			IdleTimeoutSeconds:       params.ProxyConfig.ProxyIdleTimeoutSeconds,
+			MaxRequestsPerConnection: params.ProxyConfig.ProxyMaxRequestsPerConnection,
+			UseAppProtocol:           params.GatewayApiConfig.EnableGatewayAPIAppProtocol,
 		},
 		RouteConfig: translation.RouteConfig{
 			HostNameSuffixMatch: true,

--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -225,7 +225,7 @@ type gatewayAPIParams struct {
 	OperatorConfig   *operatorOption.OperatorConfig
 	MCSAPIConfig     mcsapitypes.MCSAPIConfig
 	GatewayApiConfig gatewayApiConfig
-	ProxyTimeouts    ciliumenvoyconfig.EnvoyProxyTimeouts
+	ProxyConfig      ciliumenvoyconfig.EnvoyProxyConfig
 
 	// Preconditions is injected from private provider
 	Preconditions *gatewayAPIPreconditions
@@ -268,11 +268,12 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 		ListenerConfig: translation.ListenerConfig{
 			UseProxyProtocol:         params.GatewayApiConfig.EnableGatewayAPIProxyProtocol,
 			UseAlpn:                  params.GatewayApiConfig.EnableGatewayAPIAlpn,
-			StreamIdleTimeoutSeconds: params.ProxyTimeouts.ProxyStreamIdleTimeoutSeconds,
+			StreamIdleTimeoutSeconds: params.ProxyConfig.ProxyStreamIdleTimeoutSeconds,
 		},
 		ClusterConfig: translation.ClusterConfig{
-			IdleTimeoutSeconds: params.ProxyTimeouts.ProxyIdleTimeoutSeconds,
-			UseAppProtocol:     params.GatewayApiConfig.EnableGatewayAPIAppProtocol,
+			IdleTimeoutSeconds:       params.ProxyConfig.ProxyIdleTimeoutSeconds,
+			MaxRequestsPerConnection: params.ProxyConfig.ProxyMaxRequestsPerConnection,
+			UseAppProtocol:           params.GatewayApiConfig.EnableGatewayAPIAppProtocol,
 		},
 		RouteConfig: translation.RouteConfig{
 			HostNameSuffixMatch: true,

--- a/operator/pkg/ingress/cell.go
+++ b/operator/pkg/ingress/cell.go
@@ -109,7 +109,7 @@ type ingressParams struct {
 	AgentConfig        *option.DaemonConfig
 	OperatorConfig     *operatorOption.OperatorConfig
 	IngressConfig      IngressConfig
-	ProxyTimeouts      ciliumenvoyconfig.EnvoyProxyTimeouts
+	ProxyConfig        ciliumenvoyconfig.EnvoyProxyConfig
 	PodCfg             ciliumpod.Config
 }
 
@@ -135,11 +135,12 @@ func registerReconciler(params ingressParams) error {
 		},
 		ListenerConfig: translation.ListenerConfig{
 			UseProxyProtocol:         params.IngressConfig.EnableIngressProxyProtocol,
-			StreamIdleTimeoutSeconds: params.ProxyTimeouts.ProxyStreamIdleTimeoutSeconds,
+			StreamIdleTimeoutSeconds: params.ProxyConfig.ProxyStreamIdleTimeoutSeconds,
 		},
 		ClusterConfig: translation.ClusterConfig{
-			IdleTimeoutSeconds: params.ProxyTimeouts.ProxyIdleTimeoutSeconds,
-			UseAppProtocol:     false,
+			IdleTimeoutSeconds:       params.ProxyConfig.ProxyIdleTimeoutSeconds,
+			MaxRequestsPerConnection: params.ProxyConfig.ProxyMaxRequestsPerConnection,
+			UseAppProtocol:           false,
 		},
 		RouteConfig: translation.RouteConfig{
 			HostNameSuffixMatch: false,

--- a/operator/pkg/model/translation/cec_translator.go
+++ b/operator/pkg/model/translation/cec_translator.go
@@ -50,8 +50,9 @@ type ListenerConfig struct {
 }
 
 type ClusterConfig struct {
-	IdleTimeoutSeconds int  `json:"idle_timeout_seconds,omitempty"`
-	UseAppProtocol     bool `json:"use_app_protocol,omitempty"`
+	IdleTimeoutSeconds       int  `json:"idle_timeout_seconds,omitempty"`
+	MaxRequestsPerConnection int  `json:"max_requests_per_connection,omitempty"`
+	UseAppProtocol           bool `json:"use_app_protocol,omitempty"`
 }
 
 type RouteConfig struct {

--- a/operator/pkg/model/translation/envoy_cluster.go
+++ b/operator/pkg/model/translation/envoy_cluster.go
@@ -34,6 +34,7 @@ const (
 func (i *cecTranslator) clusterMutators(grpcService bool, appProtocol string, tls *model.BackendTLSOrigination) []ClusterMutator {
 	res := []ClusterMutator{
 		withIdleTimeout(i.Config.ClusterConfig.IdleTimeoutSeconds),
+		withMaxRequestsPerConnection(i.Config.ClusterConfig.MaxRequestsPerConnection),
 		withClusterLbPolicy(int32(envoy_config_cluster_v3.Cluster_ROUND_ROBIN)),
 		withOutlierDetection(true),
 		withTLSOrigination(i.Config.SecretsNamespace, tls),

--- a/operator/pkg/model/translation/envoy_cluster_mutator.go
+++ b/operator/pkg/model/translation/envoy_cluster_mutator.go
@@ -11,6 +11,7 @@ import (
 	envoy_upstreams_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/cilium/cilium/operator/pkg/model"
@@ -69,6 +70,25 @@ func withIdleTimeout(seconds int) ClusterMutator {
 		opts.CommonHttpProtocolOptions = &envoy_config_core_v3.HttpProtocolOptions{
 			IdleTimeout: &durationpb.Duration{Seconds: int64(seconds)},
 		}
+		cluster.TypedExtensionProtocolOptions[httpProtocolOptionsType] = toAny(opts)
+		return cluster
+	}
+}
+
+func withMaxRequestsPerConnection(maxRequests int) ClusterMutator {
+	return func(cluster *envoy_config_cluster_v3.Cluster) *envoy_config_cluster_v3.Cluster {
+		if cluster == nil || maxRequests <= 0 {
+			return cluster
+		}
+		a := cluster.TypedExtensionProtocolOptions[httpProtocolOptionsType]
+		opts := &envoy_upstreams_http_v3.HttpProtocolOptions{}
+		if err := a.UnmarshalTo(opts); err != nil {
+			return cluster
+		}
+		if opts.CommonHttpProtocolOptions == nil {
+			opts.CommonHttpProtocolOptions = &envoy_config_core_v3.HttpProtocolOptions{}
+		}
+		opts.CommonHttpProtocolOptions.MaxRequestsPerConnection = wrapperspb.UInt32(uint32(maxRequests))
 		cluster.TypedExtensionProtocolOptions[httpProtocolOptionsType] = toAny(opts)
 		return cluster
 	}

--- a/operator/pkg/model/translation/envoy_cluster_test.go
+++ b/operator/pkg/model/translation/envoy_cluster_test.go
@@ -11,6 +11,7 @@ import (
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	envoy_upstreams_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
@@ -75,7 +76,10 @@ func Test_withConnectionTimeout(t *testing.T) {
 }
 
 func Test_httpCluster(t *testing.T) {
-	c := &cecTranslator{}
+	c := &cecTranslator{Config: Config{ClusterConfig: ClusterConfig{
+		IdleTimeoutSeconds:       60,
+		MaxRequestsPerConnection: 1,
+	}}}
 	res, err := c.httpCluster("dummy-name", "dummy-name", false, "", nil)
 	require.NoError(t, err)
 
@@ -87,6 +91,11 @@ func Test_httpCluster(t *testing.T) {
 	require.Equal(t, &envoy_config_cluster_v3.Cluster_Type{
 		Type: envoy_config_cluster_v3.Cluster_EDS,
 	}, cluster.ClusterDiscoveryType)
+
+	protocolOptions := &envoy_upstreams_http_v3.HttpProtocolOptions{}
+	require.NoError(t, cluster.TypedExtensionProtocolOptions[httpProtocolOptionsType].UnmarshalTo(protocolOptions))
+	require.Equal(t, int64(60), protocolOptions.CommonHttpProtocolOptions.IdleTimeout.Seconds)
+	require.Equal(t, uint32(1), protocolOptions.CommonHttpProtocolOptions.MaxRequestsPerConnection.Value)
 }
 
 func Test_httpClusterWithTLSOriginationAllowsTLS13(t *testing.T) {

--- a/pkg/envoy/model.go
+++ b/pkg/envoy/model.go
@@ -973,13 +973,20 @@ func GetUpstreamCodecFilter() *envoy_config_http.HttpFilter {
 	}
 }
 
+// GetHTTPRetryPolicy returns the common HTTP retry policy using a timeout in seconds.
+func GetHTTPRetryPolicy(retryCount, retryTimeout uint) *envoy_config_route.RetryPolicy {
+	return &envoy_config_route.RetryPolicy{
+		RetryOn:       "5xx",
+		NumRetries:    wrapperspb.UInt32(uint32(retryCount)),
+		PerTryTimeout: &durationpb.Duration{Seconds: int64(retryTimeout)},
+	}
+}
+
 func GetHttpFilterChainProto(clusterName string, tls bool, isIngress bool, accessLogPath string, config xdsServerConfig) *envoy_config_listener.FilterChain {
 	requestTimeout := int64(config.httpRequestTimeout)       // seconds
 	idleTimeout := int64(config.httpIdleTimeout)             // seconds
 	maxGRPCTimeout := int64(config.httpMaxGRPCTimeout)       // seconds
 	streamIdleTimeout := int64(config.httpStreamIdleTimeout) // seconds
-	numRetries := uint32(config.httpRetryCount)
-	retryTimeout := int64(config.httpRetryTimeout) // seconds
 	xffNumTrustedHops := config.proxyXffNumTrustedHopsEgress
 	if isIngress {
 		xffNumTrustedHops = config.proxyXffNumTrustedHopsIngress
@@ -1026,11 +1033,7 @@ func GetHttpFilterChainProto(clusterName string, tls bool, isIngress bool, acces
 								MaxStreamDuration: &envoy_config_route.RouteAction_MaxStreamDuration{
 									GrpcTimeoutHeaderMax: &durationpb.Duration{Seconds: maxGRPCTimeout},
 								},
-								RetryPolicy: &envoy_config_route.RetryPolicy{
-									RetryOn:       "5xx",
-									NumRetries:    &wrapperspb.UInt32Value{Value: numRetries},
-									PerTryTimeout: &durationpb.Duration{Seconds: retryTimeout},
-								},
+								RetryPolicy: GetHTTPRetryPolicy(uint(config.httpRetryCount), uint(config.httpRetryTimeout)),
 							},
 						},
 					}, {
@@ -1044,11 +1047,7 @@ func GetHttpFilterChainProto(clusterName string, tls bool, isIngress bool, acces
 								},
 								Timeout: &durationpb.Duration{Seconds: requestTimeout},
 								// IdleTimeout: &durationpb.Duration{Seconds: idleTimeout},
-								RetryPolicy: &envoy_config_route.RetryPolicy{
-									RetryOn:       "5xx",
-									NumRetries:    &wrapperspb.UInt32Value{Value: numRetries},
-									PerTryTimeout: &durationpb.Duration{Seconds: retryTimeout},
-								},
+								RetryPolicy: GetHTTPRetryPolicy(uint(config.httpRetryCount), uint(config.httpRetryTimeout)),
 							},
 						},
 					}},

--- a/pkg/envoy/model.go
+++ b/pkg/envoy/model.go
@@ -973,13 +973,20 @@ func GetUpstreamCodecFilter() *envoy_config_http.HttpFilter {
 	}
 }
 
+// GetHTTPRetryPolicy returns the common HTTP retry policy using a timeout in seconds.
+func GetHTTPRetryPolicy(retryCount, retryTimeout uint) *envoy_config_route.RetryPolicy {
+	return &envoy_config_route.RetryPolicy{
+		RetryOn:       "5xx",
+		NumRetries:    wrapperspb.UInt32(uint32(retryCount)),
+		PerTryTimeout: &durationpb.Duration{Seconds: int64(retryTimeout)},
+	}
+}
+
 func GetHttpFilterChainProto(clusterName string, tls bool, isIngress bool, accessLogPath string, config xdsServerConfig) *envoy_config_listener.FilterChain {
 	requestTimeout := int64(config.httpRequestTimeout)       // seconds
 	idleTimeout := int64(config.httpIdleTimeout)             // seconds
 	maxGRPCTimeout := int64(config.httpMaxGRPCTimeout)       // seconds
 	streamIdleTimeout := int64(config.httpStreamIdleTimeout) // seconds
-	numRetries := uint32(config.httpRetryCount)
-	retryTimeout := int64(config.httpRetryTimeout) // seconds
 	xffNumTrustedHops := config.proxyXffNumTrustedHopsEgress
 	if isIngress {
 		xffNumTrustedHops = config.proxyXffNumTrustedHopsIngress
@@ -990,12 +997,8 @@ func GetHttpFilterChainProto(clusterName string, tls bool, isIngress bool, acces
 			ClusterSpecifier: &envoy_config_route.RouteAction_Cluster{
 				Cluster: clusterName,
 			},
-			Timeout: &durationpb.Duration{Seconds: requestTimeout},
-			RetryPolicy: &envoy_config_route.RetryPolicy{
-				RetryOn:       "5xx",
-				NumRetries:    &wrapperspb.UInt32Value{Value: numRetries},
-				PerTryTimeout: &durationpb.Duration{Seconds: retryTimeout},
-			},
+			Timeout:     &durationpb.Duration{Seconds: requestTimeout},
+			RetryPolicy: GetHTTPRetryPolicy(uint(config.httpRetryCount), uint(config.httpRetryTimeout)),
 		}
 		if idleTimeout > 0 {
 			action.IdleTimeout = &durationpb.Duration{Seconds: idleTimeout}
@@ -1055,11 +1058,7 @@ func GetHttpFilterChainProto(clusterName string, tls bool, isIngress bool, acces
 								MaxStreamDuration: &envoy_config_route.RouteAction_MaxStreamDuration{
 									GrpcTimeoutHeaderMax: &durationpb.Duration{Seconds: maxGRPCTimeout},
 								},
-								RetryPolicy: &envoy_config_route.RetryPolicy{
-									RetryOn:       "5xx",
-									NumRetries:    &wrapperspb.UInt32Value{Value: numRetries},
-									PerTryTimeout: &durationpb.Duration{Seconds: retryTimeout},
-								},
+								RetryPolicy: GetHTTPRetryPolicy(uint(config.httpRetryCount), uint(config.httpRetryTimeout)),
 							},
 						},
 					}, {

--- a/pkg/envoy/model_test.go
+++ b/pkg/envoy/model_test.go
@@ -39,3 +39,11 @@ func TestGetListenerFilterADSMode(t *testing.T) {
 		assert.Equal(t, envoy_config_core.ApiVersion_V3, meta.CiliumConfigSource.ResourceApiVersion)
 	})
 }
+
+func TestGetHTTPRetryPolicy(t *testing.T) {
+	policy := GetHTTPRetryPolicy(3, 5)
+
+	assert.Equal(t, "5xx", policy.RetryOn)
+	assert.Equal(t, uint32(3), policy.GetNumRetries().GetValue())
+	assert.Equal(t, int64(5), policy.GetPerTryTimeout().GetSeconds())
+}

--- a/pkg/envoy/model_test.go
+++ b/pkg/envoy/model_test.go
@@ -76,3 +76,11 @@ func TestGetListenerFilterADSMode(t *testing.T) {
 		assert.Equal(t, envoy_config_core.ApiVersion_V3, meta.CiliumConfigSource.ResourceApiVersion)
 	})
 }
+
+func TestGetHTTPRetryPolicy(t *testing.T) {
+	policy := GetHTTPRetryPolicy(3, 5)
+
+	assert.Equal(t, "5xx", policy.RetryOn)
+	assert.Equal(t, uint32(3), policy.GetNumRetries().GetValue())
+	assert.Equal(t, int64(5), policy.GetPerTryTimeout().GetSeconds())
+}


### PR DESCRIPTION
'l7-lb' CI workflow accesses the same backend through two distinct Service VIPs: an L7 Service through Envoy and a non-L7 Service through BPF Service translation. Although neither request directly targets the backend PodIP, both paths can produce the same backend-facing 5-tuple when the client reuses its source port. 

Make this collision less likely to occur by enabling retry timeouts and setting socket linger option to 0, causing the old upstream connection being closed synchronously after the timeout, so that retry connections can re-use the same 5-tuple and negotiate a new connection with the backend.

AIL: 3

```release-note
Set `envoy.httpRetryTimeout` to one second and `envoy.httpUpstreamLingerTimeout` to zero to recover from 5-tuple collisions between L7-LB and non-L7-LB traffic.
```