### PR TITLE
gateway-api(deps): bump upstream dependencies to v1.6.1 (non-fork test)

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -199,9 +199,8 @@ jobs:
         run: |
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT
 
-          SKIPPED_TESTS="TCPRouteWeightedRouting,UDPRouteWeightedRouting"
           if [ "${{ matrix.conformance-profile }}" == "true" ]; then
-            SKIPPED_TESTS+=",MeshConsumerRoute,HTTPRouteListenerPortMatching"
+            SKIPPED_TESTS+="MeshConsumerRoute,HTTPRouteListenerPortMatching"
           fi
 
           # The conformance-profile jobs consume SKIPPED_TESTS through the
@@ -215,7 +214,9 @@ jobs:
           # flows through make's $(GATEWAY_TEST_FLAGS), where a trailing '$'
           # breaks shell quoting; none of the skipped names is a prefix of
           # another conformance test, so the alternation cannot over-match.
-          SKIPPED_TESTS_REGEX="TestConformance/(${SKIPPED_TESTS//,/|})"
+          if [ -n "${SKIPPED_TESTS}" ]; then
+            SKIPPED_TESTS_REGEX="TestConformance/(${SKIPPED_TESTS//,/|})"
+          fi
 
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --helm-set=kubeProxyReplacement=true \

--- a/Documentation/network/servicemesh/gateway-api/gateway-api.rst
+++ b/Documentation/network/servicemesh/gateway-api/gateway-api.rst
@@ -23,7 +23,7 @@ See the `Gateway API site <https://gateway-api.sigs.k8s.io/>`__ for more details
 Cilium Gateway API Support
 ##########################
 
-Cilium supports Gateway API v1.6.0 for below resources, all the Core conformance
+Cilium supports Gateway API v1.6.1 for below resources, all the Core conformance
 tests are passed.
 
 - `GatewayClass <https://gateway-api.sigs.k8s.io/reference/api-types/gatewayclass/>`_
@@ -77,7 +77,7 @@ Cilium's Gateway API features:
    access-logs
    listenerset
 
-More examples can be found in the `upstream repository <https://github.com/kubernetes-sigs/gateway-api/tree/v1.3.0/examples/standard>`_.
+More examples can be found in the `upstream repository <https://github.com/kubernetes-sigs/gateway-api/tree/v1.6.1/examples/standard>`_.
 
 Troubleshooting
 ###############

--- a/Documentation/network/servicemesh/gateway-api/installation.rst
+++ b/Documentation/network/servicemesh/gateway-api/installation.rst
@@ -6,7 +6,7 @@ Prerequisites
   replacement <kubeproxy-free>`.
 * Cilium must be configured with the L7 proxy enabled using ``l7Proxy=true``
   (enabled by default).
-* The below CRDs from Gateway API v1.6.0 ``must`` be pre-installed.
+* The below CRDs from Gateway API v1.6.1 ``must`` be pre-installed.
   Please refer to these `docs <https://gateway-api.sigs.k8s.io/guides/getting-started/introduction/#installing-gateway-api>`_
   for installation steps. Alternatively, the below snippet could be used.
 
@@ -22,13 +22,13 @@ Prerequisites
 
     .. code-block:: shell-session
 
-        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.0/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
-        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.0/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
-        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.0/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
-        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.0/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
-        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.0/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
-        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.0/config/crd/standard/gateway.networking.k8s.io_backendtlspolicies.yaml
-        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.0/config/crd/standard/gateway.networking.k8s.io_tlsroutes.yaml
+        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.1/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
+        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.1/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.1/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.1/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
+        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.1/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
+        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.1/config/crd/standard/gateway.networking.k8s.io_backendtlspolicies.yaml
+        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.1/config/crd/standard/gateway.networking.k8s.io_tlsroutes.yaml
 
   If you wish to use the ListenerSet, TCPRoute, or UDPRoute functionality, you
   also need to install the related CRDs. For each CRD that is not installed,
@@ -44,19 +44,19 @@ Prerequisites
 
     .. code-block:: shell-session
 
-        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.0/config/crd/standard/gateway.networking.k8s.io_listenersets.yaml
+        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.1/config/crd/standard/gateway.networking.k8s.io_listenersets.yaml
 
   TCPRoute:
 
     .. code-block:: shell-session
 
-        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.0/config/crd/standard/gateway.networking.k8s.io_tcproutes.yaml
+        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.1/config/crd/standard/gateway.networking.k8s.io_tcproutes.yaml
 
   UDPRoute:
 
     .. code-block:: shell-session
 
-        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.0/config/crd/standard/gateway.networking.k8s.io_udproutes.yaml
+        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.1/config/crd/standard/gateway.networking.k8s.io_udproutes.yaml
 
 * By default, the Gateway API controller creates a service of LoadBalancer type,
   so your environment will need to support this. Alternatively, since Cilium 1.16+,

--- a/go.mod
+++ b/go.mod
@@ -137,8 +137,8 @@ require (
 	k8s.io/metrics v0.36.2
 	k8s.io/utils v0.0.0-20260617174310-a95e086a2553
 	sigs.k8s.io/controller-runtime v0.24.1
-	sigs.k8s.io/gateway-api v1.6.0
-	sigs.k8s.io/gateway-api/conformance v1.6.0
+	sigs.k8s.io/gateway-api v1.6.1
+	sigs.k8s.io/gateway-api/conformance v1.6.1
 	sigs.k8s.io/mcs-api v0.5.2
 	sigs.k8s.io/mcs-api/conformance v0.5.2
 	sigs.k8s.io/mcs-api/controllers v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -1049,10 +1049,10 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 h1:hSfpvjjTQXQY2
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.24.1 h1:miPEwrmirImAvgME1L9qebGHrOnGJoVmVdtOU9fRfo4=
 sigs.k8s.io/controller-runtime v0.24.1/go.mod h1:vFkfY5fGt5xAC/sKb8IBFKgWPNKG9OUG29dR8Y2wImw=
-sigs.k8s.io/gateway-api v1.6.0 h1:735YBRj5NXFrOGX0GoSjwzUIzbz8kiEOfADsqHFmHgE=
-sigs.k8s.io/gateway-api v1.6.0/go.mod h1:FVfx3t389ybeXOqvDghLbdvJdSCfI/PReqCUI3lu3mY=
-sigs.k8s.io/gateway-api/conformance v1.6.0 h1:jyH7Jtx46hEeBQnmSErn2cbp0k4OmT3FLRBnu77c4Ko=
-sigs.k8s.io/gateway-api/conformance v1.6.0/go.mod h1:JD6CHFrpzVyvgivIzhu0My27sOk3I3IphxJe4CIjGb4=
+sigs.k8s.io/gateway-api v1.6.1 h1:mock6phZbI6rvZerwrVNk7hVNymQgHo+6sJ81Ia7ftY=
+sigs.k8s.io/gateway-api v1.6.1/go.mod h1:FVfx3t389ybeXOqvDghLbdvJdSCfI/PReqCUI3lu3mY=
+sigs.k8s.io/gateway-api/conformance v1.6.1 h1:hjJJBYhGlLLDAkpbiL8wYP2JmTbc5D6t/DromATFXbI=
+sigs.k8s.io/gateway-api/conformance v1.6.1/go.mod h1:JD6CHFrpzVyvgivIzhu0My27sOk3I3IphxJe4CIjGb4=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/kind v0.23.0 h1:8fyDGWbWTeCcCTwA04v4Nfr45KKxbSPH1WO9K+jVrBg=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2849,7 +2849,7 @@ sigs.k8s.io/controller-tools/pkg/schemapatcher
 sigs.k8s.io/controller-tools/pkg/schemapatcher/internal/yaml
 sigs.k8s.io/controller-tools/pkg/version
 sigs.k8s.io/controller-tools/pkg/webhook
-# sigs.k8s.io/gateway-api v1.6.0
+# sigs.k8s.io/gateway-api v1.6.1
 ## explicit; go 1.26.0
 sigs.k8s.io/gateway-api/apis/v1
 sigs.k8s.io/gateway-api/apis/v1alpha2
@@ -2858,7 +2858,7 @@ sigs.k8s.io/gateway-api/apis/v1beta1
 sigs.k8s.io/gateway-api/apisx/v1alpha1
 sigs.k8s.io/gateway-api/pkg/consts
 sigs.k8s.io/gateway-api/pkg/features
-# sigs.k8s.io/gateway-api/conformance v1.6.0
+# sigs.k8s.io/gateway-api/conformance v1.6.1
 ## explicit; go 1.26.0
 sigs.k8s.io/gateway-api/conformance
 sigs.k8s.io/gateway-api/conformance/apis/v1

--- a/vendor/sigs.k8s.io/gateway-api/conformance/tests/backendtlspolicy.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/tests/backendtlspolicy.go
@@ -219,7 +219,7 @@ var BackendTLSPolicy = confsuite.ConformanceTest{
 
 			kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, testPolicyNN, gwNN, invalidAcceptedCond)
 			kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, testPolicyNN, gwNN, invalidResolvedRefsCond)
-			suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{testCM}, suite.Cleanup)
+			suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{testCM}, suite.CleanupTestResources)
 			kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, testPolicyNN, gwNN, acceptedCond)
 			kubernetes.BackendTLSPolicyMustHaveCondition(t, suite.Client, suite.TimeoutConfig, testPolicyNN, gwNN, resolvedRefsCond)
 

--- a/vendor/sigs.k8s.io/gateway-api/conformance/tests/gateway-infrastructure.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/tests/gateway-infrastructure.go
@@ -21,8 +21,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	v1core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
@@ -72,6 +74,7 @@ var GatewayInfrastructure = suite.ConformanceTest{
 		})
 
 		t.Logf("verifying that generated resources for Gateway %s/%s have the proper gateway name label", gwNN.Namespace, gwNN.Name)
+		// Accepted=True does not guarantee generated infrastructure is visible yet.
 		// Don't check services because implementations may have special filtering logic (e.g. for LB annotations)
 		// Instead, check service accounts for the gateway-name label first and then
 		// fallback to Pod if that fails
@@ -85,33 +88,42 @@ var GatewayInfrastructure = suite.ConformanceTest{
 		for k, v := range currentGW.Spec.Infrastructure.Labels {
 			labels[string(k)] = string(v)
 		}
-		var foundResource bool
 		listOptions := metav1.ListOptions{LabelSelector: v1.GatewayNameLabelKey + "=" + gwNN.Name}
-		saList, err := s.Clientset.CoreV1().ServiceAccounts(ns).List(ctx, listOptions)
-		require.NoError(t, err, "error listing ServiceAccounts")
-		podList, err := s.Clientset.CoreV1().Pods(ns).List(ctx, listOptions)
-		require.NoError(t, err, "error listing Pods")
-		serviceList, err := s.Clientset.CoreV1().Services(ns).List(ctx, listOptions)
-		require.NoError(t, err, "error listing Services")
+		var saList *v1core.ServiceAccountList
+		var podList *v1core.PodList
+		var serviceList *v1core.ServiceList
+
+		waitErr := wait.PollUntilContextTimeout(t.Context(), s.TimeoutConfig.DefaultPollInterval, s.TimeoutConfig.DefaultTestTimeout, true, func(ctx context.Context) (bool, error) {
+			saList, err = s.Clientset.CoreV1().ServiceAccounts(ns).List(ctx, listOptions)
+			if err != nil {
+				return false, err
+			}
+			podList, err = s.Clientset.CoreV1().Pods(ns).List(ctx, listOptions)
+			if err != nil {
+				return false, err
+			}
+			serviceList, err = s.Clientset.CoreV1().Services(ns).List(ctx, listOptions)
+			if err != nil {
+				return false, err
+			}
+
+			return len(saList.Items) > 0 || len(podList.Items) > 0 || len(serviceList.Items) > 0, nil
+		})
+		require.NoError(t, waitErr, "expected to find a ServiceAccount, Pod, or Service with the gateway-name label")
 		if len(saList.Items) > 0 {
-			foundResource = true
 			sa := saList.Items[0]
 			require.Subsetf(t, sa.Labels, labels, "expected Pod label set %v to contain all Gateway infrastructure labels %v", sa.Labels, labels)
 			require.Subsetf(t, sa.Annotations, annotations, "expected Pod annotation set %v to contain all Gateway infrastructure annotations %v", sa.Annotations, annotations)
 		}
 		if len(podList.Items) > 0 {
-			foundResource = true
 			pod := podList.Items[0]
 			require.Subsetf(t, pod.Labels, labels, "expected Pod label set %v to contain all Gateway infrastructure labels %v", pod.Labels, labels)
 			require.Subsetf(t, pod.Annotations, annotations, "expected Pod annotation set %v to contain all Gateway infrastructure annotations %v", pod.Annotations, annotations)
 		}
 		if len(serviceList.Items) > 0 {
-			foundResource = true
 			service := serviceList.Items[0]
 			require.Subsetf(t, service.Labels, labels, "expected Pod label set %v to contain all Gateway infrastructure labels %v", service.Labels, labels)
 			require.Subsetf(t, service.Annotations, annotations, "expected Pod annotation set %v to contain all Gateway infrastructure annotations %v", service.Annotations, annotations)
 		}
-
-		require.True(t, foundResource, "expected to find a ServiceAccount, Pod, or Service with the gateway-name label")
 	},
 }

--- a/vendor/sigs.k8s.io/gateway-api/conformance/tests/gateway-static-addresses.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/tests/gateway-static-addresses.go
@@ -134,7 +134,13 @@ var GatewayStaticAddresses = suite.ConformanceTest{
 			Reason: string(v1.GatewayReasonProgrammed),
 		})
 		kubernetes.GatewayStatusMustHaveListeners(t, s.Client, s.TimeoutConfig, gwNN, finalExpectedListenerState)
-		require.Len(t, currentGW.Spec.Addresses, 1, "expected only 1 address left specified on Gateway")
+		require.Eventually(t, func() bool {
+			err = s.Client.Get(ctx, gwNN, currentGW)
+			if err != nil {
+				return false
+			}
+			return len(currentGW.Status.Addresses) == 1
+		}, s.TimeoutConfig.GatewayMustHaveAddress, s.TimeoutConfig.DefaultPollInterval, "expected only 1 status address on Gateway")
 		statusAddresses := extractStatusAddresses(currentGW.Status.Addresses)
 		require.NotContains(t, statusAddresses, unusableAddress.Value, "should not contain the unusable address")
 		require.NotContains(t, statusAddresses, invalidAddress.Value, "should not contain the invalid address")

--- a/vendor/sigs.k8s.io/gateway-api/conformance/tests/tcproute-multiple-routes-attachment.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/tests/tcproute-multiple-routes-attachment.go
@@ -85,7 +85,7 @@ var TCPRouteMultipleRoutesAttachment = confsuite.ConformanceTest{
 				}},
 			},
 		}
-		suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{newerRoute}, suite.Cleanup)
+		suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{newerRoute}, suite.CleanupTestResources)
 
 		acceptedCond := metav1.Condition{
 			Type:   string(gatewayv1.RouteConditionAccepted),

--- a/vendor/sigs.k8s.io/gateway-api/conformance/tests/tcproute-multiple-routes-attachment.yaml
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/tests/tcproute-multiple-routes-attachment.yaml
@@ -122,7 +122,7 @@ spec:
   listeners:
     - name: tcp
       protocol: TCP
-      port: 9091
+      port: 9310
       allowedRoutes:
         kinds:
           - kind: TCPRoute

--- a/vendor/sigs.k8s.io/gateway-api/conformance/tests/tcproute-weighted-routing.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/tests/tcproute-weighted-routing.go
@@ -61,6 +61,8 @@ var TCPRouteWeightedRouting = confsuite.ConformanceTest{
 				"tcp-backend-v3": 0.0,
 			}
 
+			tcp.ExpectAddressBeAvailable(t, suite.TimeoutConfig.DefaultPollInterval, suite.TimeoutConfig.MaxTimeToConsistency, gwAddr)
+
 			sender := weight.NewFunctionBasedSender(func() (string, error) {
 				return tcp.EchoSendOnce(t.Context(), gwAddr, suite.TimeoutConfig.RequestTimeout)
 			})

--- a/vendor/sigs.k8s.io/gateway-api/conformance/tests/udproute-multiple-routes-attachment.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/tests/udproute-multiple-routes-attachment.go
@@ -88,7 +88,7 @@ var UDPRouteMultipleRoutesAttachment = confsuite.ConformanceTest{
 				}},
 			},
 		}
-		suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{newerRoute}, suite.Cleanup)
+		suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{newerRoute}, suite.CleanupTestResources)
 
 		acceptedCond := metav1.Condition{
 			Type:   string(gatewayv1.RouteConditionAccepted),

--- a/vendor/sigs.k8s.io/gateway-api/conformance/tests/udproute-weighted-routing.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/tests/udproute-weighted-routing.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 	confsuite "sigs.k8s.io/gateway-api/conformance/utils/suite"
 	"sigs.k8s.io/gateway-api/conformance/utils/tlog"
+	"sigs.k8s.io/gateway-api/conformance/utils/udp"
 	"sigs.k8s.io/gateway-api/conformance/utils/weight"
 	"sigs.k8s.io/gateway-api/pkg/features"
 )
@@ -69,6 +70,8 @@ var UDPRouteWeightedRouting = confsuite.ConformanceTest{
 				"udp-backend-v2": 0.3,
 				"udp-backend-v3": 0.0,
 			}
+
+			udp.ExpectEchoResponse(t, suite.TimeoutConfig.MaxTimeToConsistency, gwAddr)
 
 			sender := weight.NewFunctionBasedSender(func() (string, error) {
 				return udpEchoSendOnce(t.Context(), gwAddr, 2*time.Second)

--- a/vendor/sigs.k8s.io/gateway-api/conformance/utils/config/timeout.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/utils/config/timeout.go
@@ -86,11 +86,11 @@ type TimeoutConfig struct {
 
 	// TCPRouteMustHaveCondition represents the maximum time for a TCPRoute to have the supplied Condition.
 	// Max value for conformant implementation: None
-	TCPRouteMustHaveCondition time.Duration
+	TCPRouteMustHaveCondition time.Duration `json:"tcpRouteMustHaveCondition"`
 
 	// UDPRouteMustHaveCondition represents the maximum time for a UDPRoute to have the supplied Condition.
 	// Max value for conformant implementation: None
-	UDPRouteMustHaveCondition time.Duration
+	UDPRouteMustHaveCondition time.Duration `json:"udpRouteMustHaveCondition"`
 
 	// RouteMustHaveParents represents the maximum time for an xRoute to have parents in status that match the expected parents.
 	// Max value for conformant implementation: None
@@ -307,6 +307,12 @@ func SetupTimeoutConfig(timeoutConfig *TimeoutConfig) {
 	if timeoutConfig.GatewayListenersMustHaveConditions == 0 {
 		timeoutConfig.GatewayListenersMustHaveConditions = defaultTimeoutConfig.GatewayListenersMustHaveConditions
 	}
+	if timeoutConfig.ListenerSetMustHaveCondition == 0 {
+		timeoutConfig.ListenerSetMustHaveCondition = defaultTimeoutConfig.ListenerSetMustHaveCondition
+	}
+	if timeoutConfig.ListenerSetListenersMustHaveConditions == 0 {
+		timeoutConfig.ListenerSetListenersMustHaveConditions = defaultTimeoutConfig.ListenerSetListenersMustHaveConditions
+	}
 	if timeoutConfig.GWCMustBeAccepted == 0 {
 		timeoutConfig.GWCMustBeAccepted = defaultTimeoutConfig.GWCMustBeAccepted
 	}
@@ -348,5 +354,8 @@ func SetupTimeoutConfig(timeoutConfig *TimeoutConfig) {
 	}
 	if timeoutConfig.DefaultPollInterval == 0 {
 		timeoutConfig.DefaultPollInterval = defaultTimeoutConfig.DefaultPollInterval
+	}
+	if timeoutConfig.RequiredConsecutiveSuccesses == 0 {
+		timeoutConfig.RequiredConsecutiveSuccesses = defaultTimeoutConfig.RequiredConsecutiveSuccesses
 	}
 }

--- a/vendor/sigs.k8s.io/gateway-api/conformance/utils/echo/pod.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/utils/echo/pod.go
@@ -100,7 +100,7 @@ func makeRequestWithCount(t *testing.T, exp *http.ExpectedResponse, count int) [
 
 	// if the deprecated field StatusCode is set, append it to StatusCodes for backwards compatibility
 	//nolint:staticcheck
-	if exp.Response.StatusCode != 0 {
+	if exp.Response.StatusCode != 0 && !slices.Contains(exp.Response.StatusCodes, exp.Response.StatusCode) {
 		exp.Response.StatusCodes = append(exp.Response.StatusCodes, exp.Response.StatusCode)
 	}
 

--- a/vendor/sigs.k8s.io/gateway-api/conformance/utils/tcp/tcp.go
+++ b/vendor/sigs.k8s.io/gateway-api/conformance/utils/tcp/tcp.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	tcpserver "sigs.k8s.io/gateway-api/conformance/echo-basic/tcpserver"
 	"sigs.k8s.io/gateway-api/conformance/utils/config"
@@ -204,4 +205,30 @@ func EchoSendOnce(ctx context.Context, gwAddr string, timeout time.Duration) (st
 		return "", fmt.Errorf("TCP echo response missing pod name: %q", line)
 	}
 	return resp.Pod, nil
+}
+
+// ExpectAddressBeAvailable polls until a TCP connection to the provided address
+// can be established, or fails the test if the timeout expires. It only verifies
+// that the address accepts TCP connections; it does not validate an echo response
+// or backend selection.
+func ExpectAddressBeAvailable(t *testing.T, interval, timeout time.Duration, address string) {
+	t.Helper()
+
+	tlog.Logf(t, "performing TCP connection probe on %s", address)
+	err := wait.PollUntilContextTimeout(t.Context(), interval, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			var dialer net.Dialer
+			conn, err := dialer.DialContext(ctx, "tcp", address)
+			if err != nil {
+				tlog.Logf(t, "failed to establish TCP connection to %s; retrying: %v", address, err)
+				return false, nil
+			}
+			tlog.Logf(t, "established TCP connection to %s", address)
+			if err := conn.Close(); err != nil {
+				tlog.Logf(t, "failed to close TCP probe connection to %s: %v", address, err)
+			}
+
+			return true, nil
+		})
+	require.NoError(t, err, "failed waiting for TCP connection to %s after %v", address, timeout)
 }

--- a/vendor/sigs.k8s.io/gateway-api/pkg/consts/consts.go
+++ b/vendor/sigs.k8s.io/gateway-api/pkg/consts/consts.go
@@ -27,7 +27,7 @@ const (
 
 	// BundleVersion is the value used for the "gateway.networking.k8s.io/bundle-version" annotation.
 	// These value must be updated during the release process.
-	BundleVersion = "v1.6.0"
+	BundleVersion = "v1.6.1"
 
 	// ApprovalLink is the value used for the "api-approved.kubernetes.io" annotation.
 	// These value must be updated during the release process.


### PR DESCRIPTION
Update sigs.k8s.io/gateway-api and sigs.k8s.io/gateway-api/conformance to v1.6.1, refresh the vendored conformance sources, and update the Gateway API docs to reference the new CRD bundle.

Stop skipping the TCPRouteWeightedRouting and UDPRouteWeightedRouting conformance tests now that the upstream tests include readiness probes.

Related PR: https://github.com/cilium/cilium/pull/47274