### PR TITLE
.github: flag PRs with unvalidated CI workflow changes

### DIFF
--- a/.github/workflows/auto-labeler.yaml
+++ b/.github/workflows/auto-labeler.yaml
@@ -89,3 +89,134 @@ jobs:
     steps:
     - name: Label The PR
       uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6.2.0
+
+  ci-validation:
+    name: CI Validation Notice
+    # This job runs only on 'opened'/'reopened' (inherited from the workflow
+    # trigger), matching the auto-labeler job: the label is a manual merge gate
+    # that a reviewer clears once, so it must not be re-applied on every push.
+    # Consequently, CI changes added mid-review are not flagged automatically.
+    #
+    # Renovate and Dependabot open their pull requests from trusted branches
+    # within cilium/cilium, where the full CI (including 'pull_request'
+    # workflows) already runs against their changes, so they do not need this
+    # notice. actions/labeler cannot condition on the pull request author, which
+    # is why this is a dedicated job rather than an entry in labeler.yml.
+    if: |
+      (
+        (github.event.pull_request.user.login != 'cilium-renovate[bot]') &&
+        (github.event.pull_request.user.login != 'renovate[bot]') &&
+        (github.event.pull_request.user.login != 'dependabot[bot]')
+      )
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Label pull requests with unvalidated CI changes
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const { execFileSync } = require('child_process');
+
+            const { owner, repo } = context.repo;
+            const number = context.issue.number;
+            const headSha = context.payload.pull_request.head.sha;
+
+            // Matches the workflow definitions GitHub actually loads: files
+            // directly under .github/workflows/ with a .yml/.yaml extension.
+            const isWorkflow = path => /^\.github\/workflows\/[^/]+\.ya?ml$/.test(path);
+
+            // 'true' iff the workflow is triggered on 'pull_request', covering
+            // the mapping (on: {pull_request: ...}), sequence (on: [..., pull_request])
+            // and scalar (on: pull_request) forms.
+            const triggerExpr =
+              '((.on | tag == "!!str") and (.on == "pull_request")) or ' +
+              '((.on | tag == "!!seq") and ([.on[] == "pull_request"] | any)) or ' +
+              '((.on | tag == "!!map") and (.on | has("pull_request")))';
+
+            // Classify the pull request's OWN (head) version of a workflow, not
+            // the base branch: GitHub evaluates 'pull_request' workflows from the
+            // merge ref, so a workflow triggered on 'pull_request' in the head is
+            // validated by this pull request's CI regardless of the base branch.
+            const tmp = `${process.env.RUNNER_TEMP}/ci-validation-workflow.yaml`;
+            async function testedOnPullRequest(path) {
+              try {
+                const res = await github.rest.repos.getContent({ owner, repo, path, ref: headSha });
+                fs.writeFileSync(tmp, Buffer.from(res.data.content, 'base64').toString('utf8'));
+                return execFileSync('yq', [triggerExpr, tmp], { encoding: 'utf8' }).trim() === 'true';
+              } catch (err) {
+                // If the workflow cannot be fetched or parsed, err on the side of
+                // flagging it (treat it as not validated).
+                console.log(`Could not classify ${path}, flagging it: ${err}`);
+                return false;
+              }
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number: number,
+            });
+            const changed = files
+              .filter(file => file.status !== 'removed')
+              .map(file => file.filename);
+
+            // A change is not validated by the pull request's own CI when it
+            // touches a workflow that is not triggered on 'pull_request', a
+            // composite action, or the Ariane configuration, since those are
+            // loaded from the trusted base branch rather than from the pull
+            // request.
+            const unvalidated = [];
+            for (const path of changed) {
+              if (path.startsWith('.github/actions/') || path === '.github/ariane-config.yaml') {
+                unvalidated.push(path);
+              } else if (isWorkflow(path) && !(await testedOnPullRequest(path))) {
+                unvalidated.push(path);
+              }
+            }
+
+            if (unvalidated.length === 0) {
+              console.log('No unvalidated CI changes detected.');
+              return;
+            }
+            console.log('Unvalidated CI changes:\n' + unvalidated.join('\n'));
+
+            await github.rest.issues.addLabels({
+              owner, repo, issue_number: number,
+              labels: ['dont-merge/needs-ci-validation'],
+            });
+
+            // Post the explanatory comment only once. Require the marker to be in
+            // a comment authored by a bot so that a pull request author cannot
+            // pre-seed it to suppress the notice.
+            const marker = '<!-- ci-validation-notice -->';
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: number,
+            });
+            const alreadyPosted = comments.some(comment =>
+              comment.body && comment.body.includes(marker) &&
+              comment.user && comment.user.type === 'Bot');
+            if (alreadyPosted) {
+              return;
+            }
+
+            // Render the paths inside a fenced code block with backticks and
+            // newlines stripped, so that pull-request-controlled file names
+            // cannot break out to inject markdown links or notifications.
+            const list = unvalidated.map(path => path.replace(/[`\r\n]/g, '')).join('\n');
+            const body = [
+              marker,
+              "This pull request modifies GitHub Actions workflows that are **not** triggered on `pull_request` (or composite actions / the Ariane configuration that they use). For those triggers, the CI running on this pull request uses the trusted version from the base branch rather than the version in this pull request, so the following changes are **not automatically validated** before merge:",
+              "",
+              "```",
+              list,
+              "```",
+              "",
+              "To validate them, a reviewer should first confirm the changes are safe, then push them to a branch in `cilium/cilium` with a temporary `pull_request` trigger added to the affected workflow, and link the successful run here.",
+              "",
+              "See [Testing CI workflow changes](https://docs.cilium.io/en/latest/contributing/testing/ci/#testing-ci-workflow-changes) for the full process. Once the changes are validated, a reviewer can remove the `dont-merge/needs-ci-validation` label.",
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: number, body,
+            });

--- a/.github/workflows/ci-validation.yaml
+++ b/.github/workflows/ci-validation.yaml
@@ -1,0 +1,79 @@
+name: CI Validation Notice
+
+# Flags pull requests whose CI changes are not exercised by their own CI, so
+# that a reviewer validates them manually before merge. See the "Testing CI
+# workflow changes" section of Documentation/contributing/testing/ci.rst.
+#
+# The logic lives in tools/ci-validation so that it is covered by Go unit tests,
+# which do exercise the code a pull request proposes because /test checks out
+# the branch under test. That is not true of this workflow definition, so the
+# wiring below is deliberately thin: it is the part this job cannot validate.
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      # CI changes are routinely added after a pull request is opened, so
+      # flagging only on 'opened' would miss them. The tool reports a path only
+      # once, which keeps the label a gate a reviewer clears once rather than
+      # one that comes back on every push.
+      - synchronize
+    # Listed positively rather than as a 'branches-ignore' of the stable
+    # branches. 'pull_request_target' loads this file from the base branch, so
+    # the copy that a future stable branch inherits would otherwise start
+    # gating that branch's pull requests until someone added it to the ignore
+    # list. Naming the branches it applies to keeps that a no-op.
+    branches:
+      - main
+      - ft/main/**
+
+permissions: read-all
+
+# Serialize per pull request, so that two pushes in quick succession cannot both
+# observe that no notice has been posted yet and comment twice.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  ci-validation:
+    name: CI Validation Notice
+    # Renovate and Dependabot open their pull requests from trusted branches
+    # within cilium/cilium, where the full CI (including 'pull_request'
+    # workflows) already runs against their changes, so they do not need this
+    # notice.
+    if: |
+      (
+        (github.event.pull_request.user.login != 'cilium-renovate[bot]') &&
+        (github.event.pull_request.user.login != 'renovate[bot]') &&
+        (github.event.pull_request.user.login != 'dependabot[bot]')
+      )
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      # For 'pull_request_target', GitHub checks out the base branch by
+      # default, which is exactly what must run here: the tool is trusted code
+      # that inspects the pull request through the API, and the pull request
+      # head is never checked out or executed.
+      - name: Checkout base branch (TRUSTED)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache-dependency-path: "*.sum"
+          # renovate: datasource=golang-version depName=go
+          go-version: 1.26.6
+
+      - name: Label pull requests with unvalidated CI changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: go run ./tools/ci-validation

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -748,6 +748,7 @@ Makefile* @cilium/build
 /test/k8s/config.go @cilium/sig-k8s
 /test/k8s/pod_mac_address.go @cilium/sig-k8s
 /tools/ @cilium/contributing
+/tools/ci-validation @cilium/github-sec @cilium/ci-structure
 /tools/complexity-diff @cilium/loader
 /tools/dpgen @cilium/loader
 /tools/envoy-bootstrap-locality @cilium/envoy

--- a/Documentation/contributing/development/reviewers_committers/review_process.rst
+++ b/Documentation/contributing/development/reviewers_committers/review_process.rst
@@ -42,13 +42,16 @@ Review process
 #. Set the labels accordingly. A bot called maintainer's little helper might
    automatically help you with this.
 
-   +--------------------------------+---------------------------------------------------------------------------+
-   | Labels                         | When to set                                                               |
-   +================================+===========================================================================+
-   | ``dont-merge/needs-sign-off``  | Some commits are not signed off                                           |
-   +--------------------------------+---------------------------------------------------------------------------+
-   | ``dont-merge/needs-rebase``    | PR is outdated and needs to be rebased                                    |
-   +--------------------------------+---------------------------------------------------------------------------+
+   +-----------------------------------+------------------------------------------------------------------------+
+   | Labels                            | When to set                                                            |
+   +===================================+========================================================================+
+   | ``dont-merge/needs-sign-off``     | Some commits are not signed off                                        |
+   +-----------------------------------+------------------------------------------------------------------------+
+   | ``dont-merge/needs-rebase``       | PR is outdated and needs to be rebased                                 |
+   +-----------------------------------+------------------------------------------------------------------------+
+   | ``dont-merge/needs-ci-validation``| PR changes CI workflows not tested by the PR (set automatically); see  |
+   |                                   | :ref:`testing_ci_workflow_changes` before removing it                  |
+   +-----------------------------------+------------------------------------------------------------------------+
 
 #. Validate that bugfixes are marked with ``kind/bug`` and validate whether the
    assessment of backport requirements as requested by the submitter conforms

--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -229,6 +229,125 @@ always be found in the `Cilium CI matrix`_.
 
 .. _Cilium CI matrix: https://docs.google.com/spreadsheets/d/1TThkqvVZxaqLR-Ela4ZrcJ0lrTJByCqrbdCjnI32_X0
 
+.. _testing_ci_workflow_changes:
+
+Testing CI workflow changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TL;DR — what a reviewer needs to do, depending on what a pull request changes:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 22 50
+
+   * - Change
+     - Run by this pull request's CI?
+     - What to do before merge
+   * - A workflow triggered on ``pull_request`` (for example ``lint-go.yaml``,
+       ``tests-smoke.yaml``)
+     - Yes, the pull request's version runs (secrets are withheld on forks)
+     - Nothing extra; the change is already validated, and it is not labelled.
+   * - A workflow triggered on ``pull_request_target``
+     - No, GitHub loads it from the base branch
+     - Push to a branch in ``cilium/cilium``, temporarily add a ``pull_request``
+       trigger to the workflow, open a test pull request, and link the
+       successful run.
+   * - A workflow run via ``/test`` (``workflow_dispatch``), ``schedule`` or
+       ``push``
+     - No, the proposed version does not run on the pull request
+     - Same as above. Watch for inputs only Ariane provides (for example
+       ``SHA``, ``context-ref``) and any workflow-specific tweaks.
+   * - A composite action under ``.github/actions/``
+     - Only via ``/test`` from a ``cilium/cilium`` branch (not a fork)
+     - Open the pull request from a branch in ``cilium/cilium`` and run
+       ``/test``; link the successful run.
+   * - ``.github/ariane-config.yaml``
+     - No, it takes effect only after merge
+     - Review carefully (owned by ``ci-structure`` / ``github-sec``); it cannot
+       be exercised before merge.
+
+When CI runs on a pull request, only workflows triggered on ``pull_request``
+use the version of the workflow file proposed in that pull request: GitHub
+loads them from the pull request's merge ref. This holds whether the pull
+request is opened from a fork or from a branch in ``cilium/cilium``, so the
+proposed workflow is exercised in both cases. The difference is that, for a
+pull request opened from a fork, GitHub withholds repository secrets and only
+grants a read-only token, and workflows may not run at all until a maintainer
+approves the run for a first-time contributor. So a ``pull_request`` workflow
+change is tested either way, but steps that depend on secrets behave
+differently on a fork.
+
+The other triggers used in this repository do not run the proposed version at
+all, for different reasons:
+
+- ``pull_request_target`` workflows are loaded by GitHub from the base branch,
+  by design, so that untrusted pull request code cannot alter a workflow that
+  runs with elevated permissions.
+- ``workflow_dispatch`` workflows (those Ariane runs via ``/test``) are loaded
+  from the trusted ref Ariane dispatches against, not from the pull request's
+  head.
+- ``schedule`` and ``push`` workflows do not run on the pull request at all:
+  they run on ``main`` (on a schedule, or once the change is merged).
+
+In each of these cases the change to the workflow is only exercised after it is
+merged. Composite actions under ``.github/actions/`` and
+``.github/ariane-config.yaml`` may be subject to the same limitation, because
+the workflows that consume them run from a trusted ref (though, for a pull
+request opened from a branch in ``cilium/cilium`` rather than a fork, ``/test``
+does check out the branch under test; see below).
+
+This limitation is independent of whether the pull request is opened from a
+fork or from a branch in ``cilium/cilium``: it stems from the workflow trigger,
+not from where the pull request's branch lives. Whether the pull request comes
+from a fork only affects *how* the change can be validated, since the CI has
+access to secrets and checks out the branch under test only for pull requests
+opened from a branch in ``cilium/cilium``.
+
+To make this visible, the ``dont-merge/needs-ci-validation`` label is applied
+automatically when a pull request is opened or reopened with changes to such
+files, together with a comment listing the affected paths. The label is a
+manual merge gate that a reviewer clears once the changes are validated, so it
+is not re-evaluated on subsequent pushes; keep this in mind when CI changes are
+added later during review. Renovate and Dependabot are excluded, as they open
+pull requests from trusted branches within ``cilium/cilium`` where the full CI
+already runs against their changes.
+
+When a pull request carries this label, the changes should be validated
+manually before merge:
+
+#. A reviewer confirms that the workflow changes are safe to run and will not
+   compromise the repository or leak secrets.
+#. The changes are pushed to a branch in ``cilium/cilium`` (not a fork, so that
+   the CI has access to secrets and, for non-fork branches, workflows and
+   actions are picked up from the branch under test). If the contributor is a
+   reviewer, they are responsible for this step; otherwise the reviewer
+   performs it on the contributor's behalf. How to exercise the change depends
+   on what was modified:
+
+   - For a change to a workflow triggered by the ``/test`` comment (or any
+     other non-``pull_request`` trigger), GitHub loads the workflow definition
+     from the base branch, so the change is not run by simply commenting
+     ``/test``. Temporarily add a ``pull_request`` trigger to the affected
+     workflow's ``on`` section and open a test pull request so that GitHub runs
+     the branch's version. Note that some workflows expect inputs that are only
+     provided by Ariane (for example ``SHA`` or ``context-ref``); check that
+     the workflow falls back sensibly under a ``pull_request`` event, and apply
+     any additional tweaks the workflow documents (see, e.g., the
+     :ref:`bisect process <ci_gha>` for ``conformance-ginkgo.yaml``).
+   - For a change to a composite action under ``.github/actions/`` used by a
+     ``/test``-dispatched workflow, opening the pull request from a branch in
+     ``cilium/cilium`` (not a fork) and commenting ``/test`` is usually enough,
+     since those workflows check out the branch under test.
+
+#. If the test run does not pass, iterate on the change until it does,
+   coordinating with the contributor as needed.
+#. Once the test run passes, link the successful run on the original pull
+   request as a record of the validation.
+#. When the changes are validated, a reviewer removes the
+   ``dont-merge/needs-ci-validation`` label so that the pull request can be
+   merged. Any temporary ``pull_request`` trigger added for testing must be
+   reverted, and a separate test pull request can then be closed.
+
 .. _ci_failure_triage:
 
 CI Failure Triage

--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -229,6 +229,237 @@ always be found in the `Cilium CI matrix`_.
 
 .. _Cilium CI matrix: https://docs.google.com/spreadsheets/d/1TThkqvVZxaqLR-Ela4ZrcJ0lrTJByCqrbdCjnI32_X0
 
+.. _testing_ci_workflow_changes:
+
+Testing CI workflow changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There are six routes to running a CI change, from doing nothing to opening a
+separate test pull request. The notice posted alongside the
+``dont-merge/needs-ci-validation`` label works out the smallest set of actions
+that covers the files it flags, and tags each one with the route it uses, so the
+identifiers below are what a reviewer reads there.
+
+.. list-table:: Validation routes
+   :header-rows: 1
+   :widths: 10 90
+
+   * - Route
+     - What to do
+   * - M0
+     - Nothing. GitHub loads the workflow from the merge ref, so this pull
+       request already runs the version it proposes. These files are not
+       flagged. On a fork, secrets are still withheld, so a step that needs one
+       is not fully exercised.
+   * - M1
+     - Comment ``/test``, or the relevant ``/ci-*`` trigger. This exercises the
+       code under test but not the CI configuration, because for a fork Ariane
+       dispatches the base branch and points ``context-ref`` at the target
+       branch.
+   * - M2
+     - Comment the specific ``/ci-*`` trigger for each changed workflow. From a
+       branch in ``cilium/cilium`` Ariane dispatches that branch, so both the
+       workflow definition and ``context-ref`` come from the pull request.
+       Remember that ``/test`` does not cover every workflow.
+   * - M3
+     - Dispatch each consuming workflow by hand, keeping the definition trusted
+       and overriding ``context-ref`` to the pull request's head SHA. See the
+       command under step 2 below.
+   * - M4
+     - Mirror the branch to ``cilium/cilium`` and dispatch against it with
+       ``gh workflow run <workflow> --ref <branch>``, so that the branch's own
+       definition runs. No pull request is needed for this, only the branch:
+       push it, dispatch, read the run and delete it again. Nothing else reacts
+       to the push, because every ``push`` trigger in this repository is
+       restricted to ``main``, ``ft/main/**``, ``renovate/main-**`` or tags.
+   * - M5
+     - Mirror the branch under ``ft/main/``, then open a test pull request whose
+       *base* is that branch. A ``pull_request_target`` workflow is loaded from
+       the base branch, so pointing the base at the mirror is what makes the
+       proposed definition run, under the real trigger and with no temporary
+       edit to revert. A ``push`` only workflow needs no pull request at all,
+       just the push; a ``workflow_call`` only one runs when any workflow that
+       calls it is dispatched against the mirror, since a local
+       ``./.github/workflows/…`` reference resolves at the caller's commit. Only
+       a ``schedule`` only workflow has no native route, and there a temporary
+       trigger is the fallback; revert it before merge.
+   * - M6
+     - Add the workflow's own path to its ``pull_request`` ``paths`` filter, as
+       ``tests-cifuzz.yaml`` does, or include a file the filter does match in a
+       test pull request. Needed when a workflow is triggered on
+       ``pull_request`` but its filter excludes the workflow file itself, so a
+       change to it looks validated while nothing actually runs.
+
+Which route applies depends on what changed and, just as much, on whether the
+pull request comes from a fork:
+
+.. list-table:: Which route applies
+   :header-rows: 1
+   :widths: 52 24 24
+
+   * - What the pull request changes
+     - From a fork
+     - From a ``cilium/cilium`` branch
+   * - A workflow triggered on ``pull_request`` (``lint-go.yaml``,
+       ``tests-smoke.yaml``, …)
+     - M0
+     - M0
+   * - The same, but its ``paths`` filter excludes the workflow file itself
+     - M6
+     - M6
+   * - Product code (Go, bpf, ``cilium-cli``)
+     - M1
+     - M1
+   * - A composite action or config under ``.github/actions/``
+     - M3
+     - M2
+   * - A workflow body, where the workflow has ``workflow_dispatch``
+     - M4
+     - M2
+   * - A workflow body, where it does not (``pull_request_target``,
+       ``schedule``, ``push``)
+     - M5
+     - M5
+   * - A workflow's ``on:`` block, or a whole new workflow
+     - M5
+     - M5
+   * - ``.github/ariane-config.yaml``
+     - review only
+     - M2
+
+A change to an ``on:`` block is only partly covered, because GitHub evaluates
+triggers and the ``types``, ``branches`` and ``paths`` filters when the real
+event fires, and no route reproduces a cron. A whole new workflow is a special
+case of its own: it is not dispatchable until GitHub has a record for the file,
+which the first run of it on any branch creates, so a push or a test pull request
+has to register it before ``gh workflow run`` will accept it.
+
+Two exceptions are worth knowing. ``common-post-jobs.yaml`` consumes
+``cilium/cilium/.github/actions/merge-artifacts@main``, pinned to ``main``, so a
+change to that action is never exercised before merge even from a branch here.
+And for a pull request from a fork the ``/default`` workflows are not dispatched
+automatically at all, so nothing runs until a reviewer triggers it.
+
+When CI runs on a pull request, only workflows triggered on ``pull_request``
+use the version of the workflow file proposed in that pull request: GitHub
+loads them from the pull request's merge ref. This holds whether the pull
+request is opened from a fork or from a branch in ``cilium/cilium``, so the
+proposed workflow is exercised in both cases. The difference is that, for a
+pull request opened from a fork, GitHub withholds repository secrets and only
+grants a read-only token, and workflows may not run at all until a maintainer
+approves the run for a first-time contributor. So a ``pull_request`` workflow
+change is tested either way, but steps that depend on secrets behave
+differently on a fork.
+
+The other triggers used in this repository do not run the proposed version at
+all, for different reasons:
+
+- ``pull_request_target`` workflows are loaded by GitHub from the base branch,
+  by design, so that untrusted pull request code cannot alter a workflow that
+  runs with elevated permissions.
+- ``workflow_dispatch`` workflows, the ones Ariane runs for ``/test`` and the
+  ``/ci-*`` comments, are loaded from the ref Ariane dispatches against. For a
+  pull request opened from a branch in ``cilium/cilium`` that is the pull
+  request's own branch, so the proposed definition does run, but only for those
+  workflows somebody actually dispatches. For a pull request from a fork the
+  branch does not exist in this repository, so Ariane dispatches the base
+  branch and the proposed definition never runs.
+- ``schedule`` and ``push`` workflows do not run on the pull request at all:
+  they run on ``main`` (on a schedule, or once the change is merged).
+
+Composite actions and configuration under ``.github/actions/`` follow the same
+split, because the consuming workflow checks them out from ``context-ref``,
+which is the pull request's branch when it is not a fork and the target branch
+when it is. ``.github/ariane-config.yaml`` follows the same split, because Ariane
+reads its own configuration at the very ref it dispatches: commenting ``/test``
+on a pull request from a branch here uses the configuration that pull request
+proposes, while for a fork it uses the target branch's.
+
+So whether the pull request comes from a fork matters a great deal here. From a
+branch in ``cilium/cilium``, most changes are exercised as soon as the right
+workflow is dispatched, and the gap is only in remembering to dispatch it. From
+a fork, nothing under ``.github/`` other than a ``pull_request`` workflow is
+exercised, and validating it takes the deliberate steps below.
+
+To make this visible, the ``dont-merge/needs-ci-validation`` label is applied
+automatically when a pull request is opened, reopened or pushed to with changes
+to such files, together with a comment listing the affected paths. The label is
+a manual merge gate that a reviewer clears once the changes are validated, and
+clearing it sticks: each comment records the paths it reported, and the label is
+only applied again when a push adds a CI file that has not been reported yet.
+So a reviewer does not have to clear the label repeatedly, but CI changes added
+later during review still re-arm the gate. Renovate and Dependabot are
+excluded, as they open pull requests from trusted branches within
+``cilium/cilium`` where the full CI already runs against their changes. The
+check itself lives in ``tools/ci-validation``, run from the ``ci-validation``
+workflow; it inspects the pull request through the API and never checks out or
+executes its head.
+
+When a pull request carries this label, the changes should be validated
+manually before merge:
+
+#. A reviewer confirms that the workflow changes are safe to run and will not
+   compromise the repository or leak secrets.
+#. The changes are mirrored to a branch in ``cilium/cilium``, rather than left
+   on a fork, so that the CI has access to secrets and the branch can be
+   dispatched against directly. If the contributor is a reviewer, they are
+   responsible for this step; otherwise the reviewer performs it on the
+   contributor's behalf, which is why the previous step comes first. How to
+   exercise the change depends on what was modified:
+
+   - For a change to a ``workflow_dispatch`` workflow, the kind Ariane runs for
+     ``/test`` or a ``/ci-*`` comment, the mirrored branch is all that is
+     needed: Ariane dispatches against the pull request's branch whenever that
+     branch is in ``cilium/cilium``, so the proposed definition is what runs.
+     What is easy to miss is that only the workflows actually dispatched are
+     covered, and ``/test`` does not cover all of them, so comment the specific
+     ``/ci-*`` trigger for each changed workflow. To dispatch by hand instead,
+     use ``gh workflow run <workflow> --ref <branch>``, since
+     ``workflow_dispatch`` loads the definition from the ref it is dispatched
+     against, passing the inputs Ariane would provide, ``SHA`` and
+     ``context-ref``, as full 40 character SHAs. Apply any additional tweaks the
+     workflow documents (see, e.g., the :ref:`bisect process <ci_gha>` for
+     ``conformance-ginkgo.yaml``).
+   - For a change to a ``pull_request_target``, ``schedule`` or ``push``
+     workflow, there is no dispatch to hijack. Temporarily add a
+     ``pull_request`` trigger to the affected workflow's ``on`` section and open
+     a test pull request from the mirrored branch, so that GitHub runs the
+     branch's version.
+   - For a change to a composite action or config under ``.github/actions/``,
+     the consuming workflows read it from whatever ``context-ref`` points at.
+     For a pull request from a fork Ariane sets that to the target branch, so
+     commenting ``/test`` exercises the base version of the file and says
+     nothing about the change. Mirroring is not needed here: dispatch each
+     consuming workflow yourself, keeping ``--ref`` on the base branch so that a
+     trusted definition runs, and pass ``context-ref`` as the pull request's
+     head SHA so that its version of the file is used::
+
+         gh workflow run tests-e2e-upgrade.yaml --ref main \
+             -f PR-number=<number> \
+             -f SHA=<head SHA> \
+             -f base-SHA=<base SHA> \
+             -f context-ref=<head SHA>
+
+     Identify every workflow that consumes the changed file and dispatch each
+     one: not all of them are in ``/test``, and one behind its own trigger is
+     easy to forget. For example ``.github/actions/e2e/lb.yaml`` is consumed by
+     ``tests-e2e-upgrade.yaml``, which only runs for ``/ci-e2e-upgrade``.
+
+     Note that overriding ``context-ref`` deliberately crosses a security
+     boundary: the files under ``.github/actions/`` become steps that run with
+     the repository's secrets, which is exactly why Ariane does not do this for
+     forks. Only do it once the diff has been reviewed, as the first step
+     above requires.
+
+#. If the test run does not pass, iterate on the change until it does,
+   coordinating with the contributor as needed.
+#. Once the test run passes, link the successful run on the original pull
+   request as a record of the validation.
+#. When the changes are validated, a reviewer removes the
+   ``dont-merge/needs-ci-validation`` label so that the pull request can be
+   merged. Any temporary ``pull_request`` trigger added for testing must be
+   reverted, and a separate test pull request can then be closed.
+
 .. _ci_failure_triage:
 
 CI Failure Triage

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -31,6 +31,7 @@ Dangaard
 Datadog
 Dataplane
 Deconfigure
+Dependabot
 Dinan
 Disenroll
 Dockerfile
@@ -521,6 +522,7 @@ kubespray
 kvstore
 kvstoremesh
 kvstores
+labelled
 lan
 latencies
 lbipam

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -32,6 +32,7 @@ Dangaard
 Datadog
 Dataplane
 Deconfigure
+Dependabot
 Dinan
 Disenroll
 Dockerfile
@@ -287,6 +288,7 @@ cqlsh
 crd
 createtopic
 crio
+cron
 cronJob
 crt
 crypto
@@ -324,6 +326,7 @@ detections
 dev
 disenroll
 disjunct
+dispatchable
 distro
 distros
 dmesg
@@ -527,6 +530,7 @@ kubespray
 kvstore
 kvstoremesh
 kvstores
+labelled
 lan
 latencies
 lbipam

--- a/tools/ci-validation/main.go
+++ b/tools/ci-validation/main.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// ci-validation flags pull requests whose CI changes are not exercised by the
+// pull request's own CI, so that a reviewer validates them manually before
+// merge. See Documentation/contributing/testing/ci.rst for the process.
+//
+// It is meant to be run from the ci-validation workflow, and never checks out
+// or executes the pull request's head: the workflows it classifies are fetched
+// through the API as data.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/google/go-github/v90/github"
+)
+
+type config struct {
+	owner   string
+	repo    string
+	number  int
+	headSHA string
+	token   string
+	dryRun  bool
+}
+
+func loadConfig() (*config, error) {
+	cfg := &config{
+		headSHA: os.Getenv("HEAD_SHA"),
+		token:   os.Getenv("GITHUB_TOKEN"),
+	}
+	flag.BoolVar(&cfg.dryRun, "dry-run", false,
+		"report what would be done without labelling or commenting")
+	flag.Parse()
+
+	repository := os.Getenv("GITHUB_REPOSITORY")
+	owner, repo, ok := strings.Cut(repository, "/")
+	if !ok {
+		return nil, fmt.Errorf("GITHUB_REPOSITORY is not in owner/repo form: %q", repository)
+	}
+	cfg.owner, cfg.repo = owner, repo
+
+	number, err := strconv.Atoi(os.Getenv("PR_NUMBER"))
+	if err != nil {
+		return nil, fmt.Errorf("parsing PR_NUMBER: %w", err)
+	}
+	cfg.number = number
+
+	if cfg.headSHA == "" {
+		return nil, fmt.Errorf("HEAD_SHA is not set")
+	}
+	if cfg.token == "" {
+		return nil, fmt.Errorf("GITHUB_TOKEN is not set")
+	}
+	return cfg, nil
+}
+
+func main() {
+	log.SetFlags(0)
+
+	cfg, err := loadConfig()
+	if err != nil {
+		log.Fatalf("Invalid configuration: %v", err)
+	}
+	if err := run(context.Background(), cfg); err != nil {
+		log.Fatalf("Failed to check for unvalidated CI changes: %v", err)
+	}
+}
+
+func run(ctx context.Context, cfg *config) error {
+	client, err := github.NewClient(github.WithAuthToken(cfg.token))
+	if err != nil {
+		return fmt.Errorf("creating GitHub client: %w", err)
+	}
+
+	// Page at the maximum size: this runs on every push to every pull request,
+	// and the default of 30 costs a request per 30 files or comments.
+	listOpts := github.ListOptions{PerPage: 100}
+
+	var changed []string
+	for file, err := range client.PullRequests.ListFilesIter(ctx, cfg.owner, cfg.repo, cfg.number, &listOpts) {
+		if err != nil {
+			return fmt.Errorf("listing pull request files: %w", err)
+		}
+		if file.GetStatus() != "removed" {
+			changed = append(changed, file.GetFilename())
+		}
+	}
+
+	fetch := func(path string) ([]byte, error) {
+		content, _, _, err := client.Repositories.GetContents(ctx, cfg.owner, cfg.repo, path,
+			&github.RepositoryContentGetOptions{Ref: cfg.headSHA})
+		if err != nil {
+			return nil, err
+		}
+		if content == nil {
+			return nil, fmt.Errorf("%s is not a file", path)
+		}
+		decoded, err := content.GetContent()
+		if err != nil {
+			return nil, err
+		}
+		return []byte(decoded), nil
+	}
+
+	unvalidated := unvalidatedPaths(changed, fetch, log.Printf)
+	if len(unvalidated) == 0 {
+		log.Print("No unvalidated CI changes detected.")
+		return nil
+	}
+	log.Printf("Unvalidated CI changes: %s", strings.Join(paths(unvalidated), ", "))
+
+	// Whether the pull request comes from a fork decides how its CI changes can
+	// be validated, because Ariane dispatches, and checks out, the pull
+	// request's own branch only when that branch is in this repository.
+	pr, _, err := client.PullRequests.Get(ctx, cfg.owner, cfg.repo, cfg.number)
+	if err != nil {
+		return fmt.Errorf("getting the pull request: %w", err)
+	}
+	prCtx := prContext{
+		number:     cfg.number,
+		headSHA:    cfg.headSHA,
+		baseSHA:    pr.GetBase().GetSHA(),
+		baseBranch: pr.GetBase().GetRef(),
+	}
+	fromFork := pr.GetHead().GetRepo().GetFullName() != cfg.owner+"/"+cfg.repo
+	log.Printf("Pull request head is %s (fork: %t), base %s",
+		pr.GetHead().GetRepo().GetFullName(), fromFork, prCtx.baseBranch)
+
+	// Read from the checkout, which is the base branch and so trusted, to work
+	// out which workflows consume the changed files and what dispatches them.
+	workflows, err := loadWorkflows(workflowsDir)
+	if err != nil {
+		return err
+	}
+	arianeConfig, err := os.ReadFile(arianeConfigFile)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", arianeConfigFile, err)
+	}
+	triggers, err := arianeTriggers(arianeConfig)
+	if err != nil {
+		return err
+	}
+
+	var comments []comment
+	for c, err := range client.Issues.ListCommentsIter(ctx, cfg.owner, cfg.repo, cfg.number,
+		&github.IssueListCommentsOptions{ListOptions: listOpts}) {
+		if err != nil {
+			return fmt.Errorf("listing comments: %w", err)
+		}
+		comments = append(comments, comment{
+			body:  c.GetBody(),
+			isBot: c.GetUser().GetType() == "Bot",
+		})
+	}
+
+	reported := reportedPaths(comments, log.Printf)
+	fresh := freshFindings(unvalidated, reported)
+	if len(fresh) == 0 {
+		log.Print("All unvalidated CI changes have already been reported.")
+		return nil
+	}
+	log.Printf("Newly reported CI changes: %s", strings.Join(paths(fresh), ", "))
+
+	steps := plan(fresh, workflows, triggers, fromFork)
+	body := renderNotice(steps, paths(unvalidated), len(reported) > 0, prCtx)
+	if cfg.dryRun {
+		log.Printf("Dry run, would apply %q and post this comment:", validationLabel)
+		log.Print(body)
+		return nil
+	}
+
+	if _, _, err := client.Issues.AddLabelsToIssue(ctx, cfg.owner, cfg.repo, cfg.number,
+		[]string{validationLabel}); err != nil {
+		return fmt.Errorf("applying the %s label: %w", validationLabel, err)
+	}
+	if _, _, err := client.Issues.CreateComment(ctx, cfg.owner, cfg.repo, cfg.number,
+		&github.IssueComment{Body: github.Ptr(body)}); err != nil {
+		return fmt.Errorf("posting the notice: %w", err)
+	}
+	return nil
+}

--- a/tools/ci-validation/plan.go
+++ b/tools/ci-validation/plan.go
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+)
+
+// The workflows and the Ariane configuration are read from the checkout rather
+// than through the API. That checkout is the base branch, so this is trusted
+// content: it says which workflows consume a file and which comment dispatches
+// them, neither of which the pull request gets to influence.
+const (
+	workflowsDir      = ".github/workflows"
+	arianeConfigFile  = ".github/ariane-config.yaml"
+	arianeTriggerName = `^/[A-Za-z0-9][A-Za-z0-9-]*`
+)
+
+var arianeTrigger = regexp.MustCompile(arianeTriggerName)
+
+// loadWorkflows reads every workflow definition in dir, keyed by file name.
+func loadWorkflows(dir string) (map[string][]byte, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", dir, err)
+	}
+	workflows := make(map[string][]byte, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !workflowPath.MatchString(workflowsDir+"/"+name) {
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", name, err)
+		}
+		workflows[name] = content
+	}
+	return workflows, nil
+}
+
+// consumersOf returns the workflows that read a path under .github/actions/.
+//
+// A workflow refers to those files either by directory, as in
+// 'uses: ./.github/actions/lvh-kind' for a composite action or
+// 'work_dir=".github/actions/e2e"' for a directory of configs, or by the exact
+// path. Searching for the path and for each of its ancestors under
+// .github/actions/ covers both, and a directory match is not over-reporting:
+// the workflows that name a directory merge everything in it.
+func consumersOf(target string, workflows map[string][]byte) []string {
+	// The exact path, then each ancestor directory. A directory reference has
+	// to stop there: a workflow that names one file must not be taken to
+	// consume its siblings.
+	type candidate struct {
+		text  string
+		isDir bool
+	}
+	candidates := []candidate{{target, false}}
+	for p := path.Dir(target); strings.HasPrefix(p, actionsPrefix); p = path.Dir(p) {
+		candidates = append(candidates, candidate{p, true})
+	}
+
+	var consumers []string
+	for name, content := range workflows {
+		text := string(content)
+		if slices.ContainsFunc(candidates, func(c candidate) bool {
+			return mentions(text, c.text, c.isDir)
+		}) {
+			consumers = append(consumers, name)
+		}
+	}
+	sort.Strings(consumers)
+	return consumers
+}
+
+// mentions reports whether text refers to ref. When ref is a directory, an
+// occurrence that continues with '/' is a reference to something inside it, not
+// to the directory as a whole, so it does not count.
+func mentions(text, ref string, isDir bool) bool {
+	for i := 0; i <= len(text)-len(ref); {
+		j := strings.Index(text[i:], ref)
+		if j < 0 {
+			return false
+		}
+		end := i + j + len(ref)
+		if !isDir || end >= len(text) || text[end] != '/' {
+			return true
+		}
+		i = end
+	}
+	return false
+}
+
+// arianeTriggers maps a workflow file name to the comments that dispatch it.
+func arianeTriggers(content []byte) (map[string][]string, error) {
+	var config struct {
+		Triggers map[string]struct {
+			Workflows []string `yaml:"workflows"`
+		} `yaml:"triggers"`
+	}
+	if err := yaml.Unmarshal(content, &config); err != nil {
+		return nil, fmt.Errorf("parsing the Ariane configuration: %w", err)
+	}
+
+	triggers := map[string][]string{}
+	for trigger, spec := range config.Triggers {
+		// Trigger keys are regular expressions, for example '/test\s*'.
+		name := arianeTrigger.FindString(trigger)
+		if name == "" {
+			continue
+		}
+		for _, workflow := range spec.Workflows {
+			triggers[workflow] = append(triggers[workflow], name)
+		}
+	}
+	for workflow := range triggers {
+		sort.Strings(triggers[workflow])
+	}
+	return triggers, nil
+}
+
+// step is one thing a reviewer has to do, and the flagged paths it validates.
+type step struct {
+	// workflow is the workflow to run, empty when none can be named.
+	workflow string
+	// heading overrides the display heading when there is no workflow to name.
+	heading string
+	// triggers are the Ariane comments that dispatch it, if any.
+	triggers []string
+	method   method
+	covers   []string
+}
+
+// routeFor picks the validation route for running one workflow. Whether the
+// pull request comes from a fork decides more than the trigger does, because
+// Ariane dispatches, and checks out, the pull request's own branch only when
+// that branch is in this repository.
+//
+// definitionChanged distinguishes a change to the workflow itself, which needs
+// the definition to come from the pull request, from a change to a file the
+// workflow merely reads.
+func routeFor(definitionChanged, dispatchable, fromFork bool) method {
+	switch {
+	case !dispatchable:
+		// No dispatch to redirect: 'pull_request_target', 'schedule' and
+		// 'push' workflows are only ever loaded from the base branch.
+		return methodTempTrigger
+	case definitionChanged && fromFork:
+		return methodMirror
+	case definitionChanged:
+		return methodDispatch
+	case fromFork:
+		return methodContextRef
+	default:
+		return methodDispatch
+	}
+}
+
+// plan reduces the findings to the smallest set of actions that validates all of
+// them.
+//
+// Running one workflow exercises every flagged file it reads, so the candidates
+// are workflows and this is a set cover over the flagged paths. A workflow whose
+// own definition changed has to be run, because nothing else exercises that
+// definition; the rest are added only while paths remain uncovered. That is what
+// keeps a pull request changing both a workflow and a config it consumes down to
+// a single action, instead of one per consuming workflow.
+func plan(findings []finding, workflows map[string][]byte, triggers map[string][]string, fromFork bool) []step {
+	type candidate struct {
+		definitionChanged bool
+		dispatchable      bool
+		covers            []string
+	}
+	byWorkflow := map[string]*candidate{}
+	get := func(name string) *candidate {
+		if byWorkflow[name] == nil {
+			byWorkflow[name] = &candidate{}
+		}
+		return byWorkflow[name]
+	}
+
+	var reviewOnly, orphans, arianeConfig, pathFiltered []string
+	uncovered := map[string]struct{}{}
+	for _, f := range findings {
+		switch {
+		case f.path == arianeConfigPath:
+			// Ariane reads its configuration at the same ref it dispatches, so
+			// for a pull request from a branch in this repository the proposed
+			// configuration is what /test uses. For a fork it reads the target
+			// branch instead, and the change cannot be exercised at all.
+			if fromFork {
+				reviewOnly = append(reviewOnly, f.path)
+			} else {
+				arianeConfig = append(arianeConfig, f.path)
+			}
+		case f.prExcluded && !f.dispatchable:
+			pathFiltered = append(pathFiltered, f.path)
+		case strings.HasPrefix(f.path, actionsPrefix):
+			consumers := consumersOf(f.path, workflows)
+			if len(consumers) == 0 {
+				orphans = append(orphans, f.path)
+				continue
+			}
+			uncovered[f.path] = struct{}{}
+			for _, name := range consumers {
+				c := get(name)
+				c.covers = append(c.covers, f.path)
+				if declared, err := workflowTriggers(workflows[name]); err == nil {
+					c.dispatchable = declared[dispatchTrigger]
+				}
+			}
+		default:
+			uncovered[f.path] = struct{}{}
+			c := get(path.Base(f.path))
+			c.definitionChanged = true
+			c.dispatchable = f.dispatchable
+			c.covers = append(c.covers, f.path)
+		}
+	}
+
+	names := make([]string, 0, len(byWorkflow))
+	for name := range byWorkflow {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	// A changed definition can only be exercised by running that workflow.
+	var chosen []string
+	take := func(name string) {
+		chosen = append(chosen, name)
+		for _, p := range byWorkflow[name].covers {
+			delete(uncovered, p)
+		}
+	}
+	for _, name := range names {
+		if byWorkflow[name].definitionChanged {
+			take(name)
+		}
+	}
+
+	// Then cover whatever is left, most-covering workflow first, preferring the
+	// earlier name on a tie so that the result is deterministic.
+	for len(uncovered) > 0 {
+		best, bestCount := "", 0
+		for _, name := range names {
+			if slices.Contains(chosen, name) {
+				continue
+			}
+			count := 0
+			for _, p := range byWorkflow[name].covers {
+				if _, ok := uncovered[p]; ok {
+					count++
+				}
+			}
+			if count > bestCount {
+				best, bestCount = name, count
+			}
+		}
+		if bestCount == 0 {
+			break
+		}
+		take(best)
+	}
+	sort.Strings(chosen)
+
+	steps := make([]step, 0, len(chosen)+2)
+	for _, name := range chosen {
+		c := byWorkflow[name]
+		steps = append(steps, step{
+			workflow: name,
+			triggers: triggers[name],
+			method:   routeFor(c.definitionChanged, c.dispatchable, fromFork),
+			covers:   c.covers,
+		})
+	}
+	if len(orphans) > 0 {
+		steps = append(steps, step{
+			heading: "(no workflow found that consumes these)",
+			method:  routeFor(false, true, fromFork),
+			covers:  orphans,
+		})
+	}
+	if len(arianeConfig) > 0 {
+		steps = append(steps, step{
+			heading:  "(the Ariane configuration)",
+			method:   methodDispatch,
+			triggers: []string{"/test"},
+			covers:   arianeConfig,
+		})
+	}
+	for _, p := range pathFiltered {
+		steps = append(steps, step{
+			workflow: path.Base(p),
+			method:   methodPathFilter,
+			covers:   []string{p},
+		})
+	}
+	if len(reviewOnly) > 0 {
+		steps = append(steps, step{
+			heading: "(cannot be exercised before merge)",
+			method:  methodReviewOnly,
+			covers:  reviewOnly,
+		})
+	}
+	return steps
+}

--- a/tools/ci-validation/plan_test.go
+++ b/tools/ci-validation/plan_test.go
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsumersOf(t *testing.T) {
+	workflows := map[string][]byte{
+		// Reads a whole directory of configs, as the e2e workflows do.
+		"reads-dir.yaml": []byte("jobs:\n  a:\n    steps:\n      - run: |\n          work_dir=\".github/actions/e2e\"\n"),
+		// Uses a composite action by directory.
+		"uses-action.yaml": []byte("jobs:\n  a:\n    steps:\n      - uses: ./.github/actions/lvh-kind\n"),
+		// Names one config file exactly.
+		"reads-file.yaml": []byte("jobs:\n  a:\n    steps:\n      - run: cat .github/actions/e2e/ipsec.yaml\n"),
+		// Consumes nothing under .github/actions/.
+		"unrelated.yaml": []byte("jobs:\n  a:\n    steps:\n      - run: make\n"),
+	}
+
+	for _, tc := range []struct {
+		name string
+		path string
+		want []string
+	}{
+		{
+			name: "a config in a directory that is merged wholesale",
+			path: ".github/actions/e2e/lb.yaml",
+			want: []string{"reads-dir.yaml"},
+		},
+		{
+			name: "a config that is also named exactly",
+			path: ".github/actions/e2e/ipsec.yaml",
+			want: []string{"reads-dir.yaml", "reads-file.yaml"},
+		},
+		{
+			name: "a composite action referenced by its directory",
+			path: ".github/actions/lvh-kind/action.yaml",
+			want: []string{"uses-action.yaml"},
+		},
+		{
+			name: "an action nothing consumes",
+			path: ".github/actions/orphan/action.yaml",
+			want: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, consumersOf(tc.path, workflows))
+		})
+	}
+}
+
+// TestConsumersOfAgainstRepository checks the discovery against the real
+// workflows, using the file whose change had to be reverted from main.
+func TestConsumersOfAgainstRepository(t *testing.T) {
+	workflows, err := loadWorkflows(repoWorkflows)
+	require.NoError(t, err)
+	require.NotEmpty(t, workflows)
+
+	// Both of these merge every config in the directory with
+	// 'cat ${work_dir}/*.yaml', so both really do read lb.yaml.
+	consumers := consumersOf(".github/actions/e2e/lb.yaml", workflows)
+	assert.Contains(t, consumers, "tests-e2e-upgrade.yaml")
+	assert.Contains(t, consumers, "conformance-ipsec-e2e.yaml")
+
+	// A composite action, referenced as 'uses: ./.github/actions/lvh-kind'.
+	assert.Contains(t, consumersOf(".github/actions/lvh-kind/action.yaml", workflows),
+		"tests-e2e-upgrade.yaml")
+
+	// Nothing consumes a workflow, so this must not match everything.
+	assert.NotContains(t, consumersOf(".github/actions/e2e/lb.yaml", workflows),
+		"lint-go.yaml")
+}
+
+func TestArianeTriggers(t *testing.T) {
+	config := []byte(`
+triggers:
+  /default:
+    workflows:
+    - tests-smoke-conformance.yaml
+  /test\s*:
+    workflows:
+    - conformance-l7.yaml
+    - integration-test.yaml
+  /ci-e2e-upgrade:
+    workflows:
+    - tests-e2e-upgrade.yaml
+`)
+	triggers, err := arianeTriggers(config)
+	require.NoError(t, err)
+
+	// The trigger keys are regular expressions; the name has to be cleaned up.
+	assert.Equal(t, []string{"/test"}, triggers["conformance-l7.yaml"])
+	assert.Equal(t, []string{"/ci-e2e-upgrade"}, triggers["tests-e2e-upgrade.yaml"])
+	assert.Equal(t, []string{"/default"}, triggers["tests-smoke-conformance.yaml"])
+	assert.Empty(t, triggers["not-registered.yaml"])
+}
+
+// TestArianeTriggersAgainstRepository pins the fact that made #48192 escape:
+// tests-e2e-upgrade.yaml is not reached by /test.
+func TestArianeTriggersAgainstRepository(t *testing.T) {
+	config, err := os.ReadFile("../../" + arianeConfigFile)
+	require.NoError(t, err)
+	triggers, err := arianeTriggers(config)
+	require.NoError(t, err)
+
+	assert.Contains(t, triggers["tests-e2e-upgrade.yaml"], "/ci-e2e-upgrade")
+	assert.NotContains(t, triggers["tests-e2e-upgrade.yaml"], "/test")
+	assert.Contains(t, triggers["integration-test.yaml"], "/test")
+}
+
+func TestRouteFor(t *testing.T) {
+	for _, tc := range []struct {
+		name                                      string
+		definitionChanged, dispatchable, fromFork bool
+		want                                      method
+	}{
+		{
+			name:         "only a consumed file changed, from a branch",
+			dispatchable: true, want: methodDispatch,
+		},
+		{
+			// The #48192 case: for a fork Ariane points context-ref at the
+			// target branch, so it has to be overridden by hand.
+			name:         "only a consumed file changed, from a fork",
+			dispatchable: true, fromFork: true, want: methodContextRef,
+		},
+		{
+			name:              "the definition changed, from a branch",
+			definitionChanged: true, dispatchable: true, want: methodDispatch,
+		},
+		{
+			name:              "the definition changed, from a fork",
+			definitionChanged: true, dispatchable: true, fromFork: true, want: methodMirror,
+		},
+		{
+			name:              "not dispatchable, so nothing to redirect",
+			definitionChanged: true, want: methodTempTrigger,
+		},
+		{
+			name:     "not dispatchable, consumed file only",
+			fromFork: true, want: methodTempTrigger,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want,
+				routeFor(tc.definitionChanged, tc.dispatchable, tc.fromFork))
+		})
+	}
+}
+
+func TestPlan(t *testing.T) {
+	workflows := map[string][]byte{
+		"tests-e2e-upgrade.yaml": []byte("on:\n  workflow_dispatch: {}\njobs:\n  a:\n" +
+			"    steps:\n      - run: work_dir=\".github/actions/e2e\"\n" +
+			"      - uses: ./.github/actions/lvh-kind\n"),
+		"conformance-ipsec-e2e.yaml": []byte("on:\n  workflow_dispatch: {}\njobs:\n  a:\n" +
+			"    steps:\n      - run: work_dir=\".github/actions/e2e\"\n"),
+		"auto-labeler.yaml": []byte("on:\n  pull_request_target: {}\n"),
+	}
+	triggers := map[string][]string{
+		"tests-e2e-upgrade.yaml":     {"/ci-e2e-upgrade"},
+		"conformance-ipsec-e2e.yaml": {"/ci-ipsec-e2e"},
+	}
+
+	t.Run("the #48192 change set collapses to a single action", func(t *testing.T) {
+		findings := []finding{
+			{path: ".github/actions/e2e/lb.yaml"},
+			{path: ".github/actions/lvh-kind/action.yaml"},
+			{path: ".github/workflows/tests-e2e-upgrade.yaml", dispatchable: true},
+		}
+		steps := plan(findings, workflows, triggers, true)
+
+		// tests-e2e-upgrade.yaml has to be run because its own definition
+		// changed, and that one run also reads lb.yaml and lvh-kind. Dispatching
+		// the other consumers would add nothing, so it is not asked for.
+		require.Len(t, steps, 1)
+		assert.Equal(t, "tests-e2e-upgrade.yaml", steps[0].workflow)
+		assert.Equal(t, methodMirror, steps[0].method, "its own definition changed")
+		assert.ElementsMatch(t, []string{
+			".github/actions/e2e/lb.yaml",
+			".github/actions/lvh-kind/action.yaml",
+			".github/workflows/tests-e2e-upgrade.yaml",
+		}, steps[0].covers)
+		assert.Equal(t, []string{"/ci-e2e-upgrade"}, steps[0].triggers)
+	})
+
+	t.Run("from a branch the same set is one comment", func(t *testing.T) {
+		findings := []finding{
+			{path: ".github/actions/e2e/lb.yaml"},
+			{path: ".github/workflows/tests-e2e-upgrade.yaml", dispatchable: true},
+		}
+		steps := plan(findings, workflows, triggers, false)
+		require.Len(t, steps, 1)
+		assert.Equal(t, methodDispatch, steps[0].method)
+		assert.Equal(t, []string{"/ci-e2e-upgrade"}, steps[0].triggers)
+	})
+
+	t.Run("a consumed file alone picks one covering workflow, not all", func(t *testing.T) {
+		// lvh-kind is read by both workflows; covering it once is enough.
+		steps := plan([]finding{{path: ".github/actions/lvh-kind/action.yaml"}},
+			workflows, triggers, true)
+		require.Len(t, steps, 1)
+		assert.Equal(t, "tests-e2e-upgrade.yaml", steps[0].workflow)
+		assert.Equal(t, methodContextRef, steps[0].method, "its definition did not change")
+	})
+
+	t.Run("two files needing different workflows both get an action", func(t *testing.T) {
+		// Only ipsec-e2e reads ipsec.yaml here, so it cannot be covered by the
+		// workflow that covers lvh-kind.
+		withIpsec := map[string][]byte{
+			"tests-e2e-upgrade.yaml": []byte("on:\n  workflow_dispatch: {}\njobs:\n  a:\n" +
+				"    steps:\n      - uses: ./.github/actions/lvh-kind\n"),
+			"conformance-ipsec-e2e.yaml": []byte("on:\n  workflow_dispatch: {}\njobs:\n  a:\n" +
+				"    steps:\n      - run: cat .github/actions/e2e/ipsec.yaml\n"),
+		}
+		steps := plan([]finding{
+			{path: ".github/actions/lvh-kind/action.yaml"},
+			{path: ".github/actions/e2e/ipsec.yaml"},
+		}, withIpsec, triggers, true)
+		require.Len(t, steps, 2)
+		assert.Equal(t, "conformance-ipsec-e2e.yaml", steps[0].workflow)
+		assert.Equal(t, "tests-e2e-upgrade.yaml", steps[1].workflow)
+	})
+
+	t.Run("a pull_request_target workflow needs a temporary trigger", func(t *testing.T) {
+		steps := plan([]finding{{path: ".github/workflows/auto-labeler.yaml"}},
+			workflows, triggers, false)
+		require.Len(t, steps, 1)
+		assert.Equal(t, "auto-labeler.yaml", steps[0].workflow)
+		assert.Equal(t, methodTempTrigger, steps[0].method)
+	})
+
+	// Ariane reads its configuration at the ref it dispatches, so the fork
+	// qualifier decides here as it does everywhere else under .github/. PR #48267
+	// changed only ariane-config.yaml from a cilium/cilium branch and ci-structure
+	// confirmed that /test picked the change up.
+	t.Run("ariane config from a branch is validated by /test", func(t *testing.T) {
+		steps := plan([]finding{{path: arianeConfigPath}}, workflows, triggers, false)
+		require.Len(t, steps, 1)
+		assert.Empty(t, steps[0].workflow)
+		assert.Equal(t, methodDispatch, steps[0].method)
+		assert.Equal(t, []string{"/test"}, steps[0].triggers)
+		assert.Equal(t, []string{arianeConfigPath}, steps[0].covers)
+	})
+
+	t.Run("ariane config from a fork cannot be exercised", func(t *testing.T) {
+		steps := plan([]finding{{path: arianeConfigPath}}, workflows, triggers, true)
+		require.Len(t, steps, 1)
+		assert.Empty(t, steps[0].workflow)
+		assert.Equal(t, methodReviewOnly, steps[0].method)
+		assert.Equal(t, []string{arianeConfigPath}, steps[0].covers)
+	})
+
+	// A workflow triggered on 'pull_request' whose paths filter excludes itself
+	// looks validated but never runs. renovate-config-validator.yaml is the live
+	// case: PR #48145 changed it and no renovate.json5, and it did not run.
+	t.Run("a self-excluding paths filter gets its own route", func(t *testing.T) {
+		steps := plan([]finding{{
+			path:       ".github/workflows/renovate-config-validator.yaml",
+			prExcluded: true,
+		}}, workflows, triggers, false)
+		require.Len(t, steps, 1)
+		assert.Equal(t, "renovate-config-validator.yaml", steps[0].workflow)
+		assert.Equal(t, methodPathFilter, steps[0].method)
+	})
+
+	t.Run("a self-excluding filter is moot when it is also dispatchable", func(t *testing.T) {
+		steps := plan([]finding{{
+			path:         ".github/workflows/tests-e2e-upgrade.yaml",
+			dispatchable: true,
+			prExcluded:   true,
+		}}, workflows, triggers, false)
+		require.Len(t, steps, 1)
+		assert.Equal(t, methodDispatch, steps[0].method, "the dispatch route still works")
+	})
+
+	t.Run("an action with no consumer still gets reported", func(t *testing.T) {
+		steps := plan([]finding{{path: ".github/actions/orphan/action.yaml"}},
+			workflows, triggers, true)
+		require.Len(t, steps, 1)
+		assert.Empty(t, steps[0].workflow)
+		assert.Equal(t, methodContextRef, steps[0].method)
+		assert.Equal(t, []string{".github/actions/orphan/action.yaml"}, steps[0].covers)
+	})
+}

--- a/tools/ci-validation/validation.go
+++ b/tools/ci-validation/validation.go
@@ -1,0 +1,399 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+)
+
+const (
+	// validationLabel blocks merging via maintainers-little-helper, which
+	// treats any 'dont-merge/*' label as a merge blocker.
+	validationLabel = "dont-merge/needs-ci-validation"
+
+	// pullRequestTrigger is the trigger for which GitHub loads the workflow
+	// definition from the pull request itself.
+	pullRequestTrigger = "pull_request"
+
+	// dispatchTrigger is the trigger Ariane uses for '/test' and the '/ci-*'
+	// comments. It is dispatched against the pull request's own branch when that
+	// branch is in this repository, so the proposed definition does run then.
+	dispatchTrigger = "workflow_dispatch"
+
+	actionsPrefix    = ".github/actions/"
+	arianeConfigPath = arianeConfigFile
+
+	docsURL = "https://docs.cilium.io/en/latest/contributing/testing/ci/#testing-ci-workflow-changes"
+)
+
+// workflowPath matches the workflow definitions GitHub actually loads: files
+// directly under .github/workflows/ with a .yml or .yaml extension.
+var workflowPath = regexp.MustCompile(`^\.github/workflows/[^/]+\.ya?ml$`)
+
+// method is one of the validation routes documented in the CI testing guide.
+// The identifiers are the ones that guide's table uses, so that a reviewer can
+// look up the full procedure.
+type method struct {
+	id   string
+	help string
+}
+
+var (
+	methodDispatch = method{"M2",
+		"Ariane dispatches this pull request's own branch, so its version is what runs"}
+	methodContextRef = method{"M3",
+		"the definition stays trusted while `context-ref` supplies the pull request's files"}
+	methodMirror = method{"M4",
+		"dispatching the mirrored branch is what makes the proposed definition run"}
+	methodTempTrigger = method{"M5",
+		"there is no dispatch to redirect, so the workflow has to be made to run on a pull request"}
+	methodPathFilter = method{"M6",
+		"the workflow is triggered on `pull_request` but its paths filter excludes itself, " +
+			"so nothing runs for this change"}
+	methodReviewOnly = method{"review only",
+		"Ariane reads this from the base branch for a fork, so it cannot be exercised beforehand"}
+)
+
+// finding is a path whose CI is not exercised by the pull request proposing it.
+type finding struct {
+	path string
+	// dispatchable records whether a changed workflow declares
+	// 'workflow_dispatch'. It is false for anything that is not a workflow.
+	dispatchable bool
+	// prExcluded records a workflow that is triggered on 'pull_request' but
+	// whose paths filter excludes the workflow file itself.
+	prExcluded bool
+}
+
+// workflowTriggers returns the set of triggers a workflow declares, covering the
+// mapping (on: {pull_request: ...}), sequence (on: [..., pull_request]) and
+// scalar (on: pull_request) forms.
+//
+// Note that the parser does not apply the YAML 1.1 boolean aliases, so the 'on'
+// key is read as the string "on" rather than as 'true'.
+func workflowTriggers(content []byte) (map[string]bool, error) {
+	var workflow struct {
+		On any `yaml:"on"`
+	}
+	if err := yaml.Unmarshal(content, &workflow); err != nil {
+		return nil, fmt.Errorf("parsing workflow: %w", err)
+	}
+
+	triggers := map[string]bool{}
+	switch on := workflow.On.(type) {
+	case string:
+		triggers[on] = true
+	case []any:
+		for _, trigger := range on {
+			if name, ok := trigger.(string); ok {
+				triggers[name] = true
+			}
+		}
+	case map[string]any:
+		for name := range on {
+			triggers[name] = true
+		}
+	case nil:
+		return nil, fmt.Errorf("workflow has no 'on' key")
+	default:
+		return nil, fmt.Errorf("unexpected type %T for the 'on' key", workflow.On)
+	}
+	return triggers, nil
+}
+
+// pullRequestExcludes reports whether a 'paths' or 'paths-ignore' filter on the
+// 'pull_request' trigger means that a change to the workflow file itself does not
+// fire the event. Such a workflow looks validated because it is triggered on
+// 'pull_request', while in fact nothing runs.
+//
+// The comparison is literal: a 'paths' filter counts as excluding the file unless
+// it names it outright, the way tests-cifuzz.yaml lists its own path. That errs
+// towards flagging, since GitHub's glob syntax is not reproduced here.
+func pullRequestExcludes(content []byte, workflow string) bool {
+	var parsed struct {
+		On map[string]any `yaml:"on"`
+	}
+	if err := yaml.Unmarshal(content, &parsed); err != nil {
+		return false
+	}
+	trigger, ok := parsed.On[pullRequestTrigger].(map[string]any)
+	if !ok {
+		// The scalar and sequence forms of 'on' carry no filters, and
+		// 'pull_request:' with no body fires for every change.
+		return false
+	}
+	if paths, ok := trigger["paths"]; ok {
+		return !listsPath(paths, workflow)
+	}
+	if ignored, ok := trigger["paths-ignore"]; ok {
+		return listsPath(ignored, workflow)
+	}
+	return false
+}
+
+// listsPath reports whether a YAML sequence names path exactly.
+func listsPath(filter any, path string) bool {
+	entries, ok := filter.([]any)
+	if !ok {
+		return false
+	}
+	for _, entry := range entries {
+		if name, ok := entry.(string); ok && name == path {
+			return true
+		}
+	}
+	return false
+}
+
+// fetchFunc returns the content of a path at the pull request's head.
+type fetchFunc func(path string) ([]byte, error)
+
+// unvalidatedPaths returns the changed paths whose CI is not exercised by the
+// pull request proposing them.
+//
+// A workflow is classified from the pull request's OWN (head) version, not from
+// the base branch: GitHub evaluates 'pull_request' workflows from the merge ref,
+// so a workflow triggered on 'pull_request' in the head is validated by this pull
+// request's CI regardless of what the base branch says.
+func unvalidatedPaths(changed []string, fetch fetchFunc, logf func(string, ...any)) []finding {
+	var unvalidated []finding
+	for _, p := range changed {
+		switch {
+		case p == arianeConfigPath || strings.HasPrefix(p, actionsPrefix):
+			unvalidated = append(unvalidated, finding{path: p})
+		case workflowPath.MatchString(p):
+			content, err := fetch(p)
+			var triggers map[string]bool
+			var excluded bool
+			if err == nil {
+				triggers, err = workflowTriggers(content)
+				if err == nil && triggers[pullRequestTrigger] {
+					excluded = pullRequestExcludes(content, p)
+					if !excluded {
+						// GitHub loads it from the merge ref, so this
+						// pull request runs the proposed version.
+						continue
+					}
+					logf("%s is triggered on pull_request but its paths filter "+
+						"excludes itself, so nothing runs for this change", p)
+				}
+			}
+			if err != nil {
+				// If the workflow cannot be fetched or parsed, err on the
+				// side of flagging it, treating it as not validated.
+				logf("Could not classify %s, flagging it: %v", p, err)
+			}
+			unvalidated = append(unvalidated, finding{
+				path:         p,
+				dispatchable: triggers[dispatchTrigger],
+				prExcluded:   excluded,
+			})
+		}
+	}
+	return unvalidated
+}
+
+// paths returns just the paths of a set of findings.
+func paths(findings []finding) []string {
+	out := make([]string, 0, len(findings))
+	for _, f := range findings {
+		out = append(out, f.path)
+	}
+	return out
+}
+
+// marker matches the record a notice comment keeps of the paths it reported.
+var marker = regexp.MustCompile(`<!-- ci-validation-notice v1 ([A-Za-z0-9+/=]*) -->`)
+
+// encodeMarker records paths in a form that can be recovered from a comment
+// body. The paths are base64-encoded because they are pull-request-controlled
+// and could otherwise close the HTML comment or break the parse.
+func encodeMarker(recorded []string) string {
+	encoded, err := json.Marshal(recorded)
+	if err != nil {
+		// Cannot happen for a []string.
+		panic(err)
+	}
+	return fmt.Sprintf("<!-- ci-validation-notice v1 %s -->",
+		base64.StdEncoding.EncodeToString(encoded))
+}
+
+// comment is the part of a GitHub comment this tool needs, kept free of API
+// types so that the reporting logic can be tested directly.
+type comment struct {
+	body  string
+	isBot bool
+}
+
+// reportedPaths returns the union of the paths recorded by every notice already
+// posted. Only comments authored by a bot are considered, so that a pull request
+// author cannot pre-seed a marker to suppress the notice.
+func reportedPaths(comments []comment, logf func(string, ...any)) map[string]struct{} {
+	reported := make(map[string]struct{})
+	for _, c := range comments {
+		if !c.isBot {
+			continue
+		}
+		match := marker.FindStringSubmatch(c.body)
+		if match == nil {
+			continue
+		}
+		decoded, err := base64.StdEncoding.DecodeString(match[1])
+		if err != nil {
+			logf("Ignoring unparseable notice marker: %v", err)
+			continue
+		}
+		var recorded []string
+		if err := json.Unmarshal(decoded, &recorded); err != nil {
+			logf("Ignoring unparseable notice marker: %v", err)
+			continue
+		}
+		for _, p := range recorded {
+			reported[p] = struct{}{}
+		}
+	}
+	return reported
+}
+
+// freshFindings returns the findings no notice has reported yet. Keeping the
+// label to those makes clearing it stick: re-running on an unchanged set is a
+// no-op, while a newly added CI file re-arms the gate.
+func freshFindings(unvalidated []finding, reported map[string]struct{}) []finding {
+	var fresh []finding
+	for _, f := range unvalidated {
+		if _, ok := reported[f.path]; !ok {
+			fresh = append(fresh, f)
+		}
+	}
+	return fresh
+}
+
+// prContext is what the notice needs in order to spell out runnable commands.
+type prContext struct {
+	number     int
+	headSHA    string
+	baseSHA    string
+	baseBranch string
+}
+
+// sanitize strips the characters with which a pull-request-controlled file name
+// could break out of the rendered block.
+var sanitize = strings.NewReplacer("`", "", "\r", "", "\n", "")
+
+// dispatchCommand renders the invocation for one workflow against a given ref.
+func (c prContext) dispatchCommand(workflow, ref, contextRef string) []string {
+	return []string{
+		fmt.Sprintf("     gh workflow run %s --ref %s \\", sanitize.Replace(workflow), ref),
+		fmt.Sprintf("         -f PR-number=%d -f SHA=%s \\", c.number, c.headSHA),
+		fmt.Sprintf("         -f base-SHA=%s -f context-ref=%s", c.baseSHA, contextRef),
+	}
+}
+
+// instructions renders what a reviewer has to do for one step.
+func (s step) instructions(c prContext) []string {
+	workflow := sanitize.Replace(s.workflow)
+	switch s.method.id {
+	case methodDispatch.id:
+		if len(s.triggers) > 0 {
+			return []string{fmt.Sprintf("     comment %s", strings.Join(s.triggers, " or "))}
+		}
+		return append([]string{"     dispatch it against this pull request's branch:"},
+			c.dispatchCommand(workflow, s.workflow, c.headSHA)...)
+	case methodContextRef.id:
+		return append([]string{"     dispatch it with the pull request's files as the context:"},
+			c.dispatchCommand(workflow, c.baseBranch, c.headSHA)...)
+	case methodMirror.id:
+		return append([]string{"     mirror this branch to cilium/cilium as <branch>, then:"},
+			c.dispatchCommand(workflow, "<branch>", c.headSHA)...)
+	case methodTempTrigger.id:
+		return []string{
+			"     mirror this branch to cilium/cilium under ft/main/, then open a",
+			"     test pull request whose BASE is that branch: a pull_request_target",
+			fmt.Sprintf("     workflow loads %s from the base, so", workflow),
+			"     the proposed definition runs under the real trigger. A schedule",
+			"     or push only workflow instead runs by pushing that branch",
+		}
+	case methodPathFilter.id:
+		return []string{
+			fmt.Sprintf("     add %s to its own 'paths' filter,", workflow),
+			"     the way tests-cifuzz.yaml does, or include a file the filter",
+			"     does match in a test pull request so that the workflow runs",
+		}
+	default:
+		return []string{"     review it closely; it cannot be exercised before merge"}
+	}
+}
+
+// renderNotice builds the comment body. It records the full current set rather
+// than only the newly reported paths, so that the most recent notice alone is
+// enough to reconstruct it.
+func renderNotice(steps []step, unvalidated []string, rearm bool, c prContext) string {
+	intro := "This pull request changes CI files that its own CI does not exercise, so " +
+		"they are **not automatically validated** before merge. This is the smallest set " +
+		"of actions that validates all of them:"
+	if rearm {
+		intro = "This pull request now changes further CI files that its own CI does not " +
+			"exercise, so the `" + validationLabel + "` label has been applied again. " +
+			"To validate what was added since the previous notice:"
+	}
+
+	// Everything below is rendered inside a fenced block, with backticks and
+	// newlines stripped, so that pull-request-controlled file names cannot break
+	// out to inject markdown links or notifications.
+	var block []string
+	for i, s := range steps {
+		name := sanitize.Replace(s.workflow)
+		if name == "" {
+			name = s.heading
+		}
+		heading := fmt.Sprintf("%2d. %s", i+1, name)
+		block = append(block, fmt.Sprintf("%s  [%s]", heading, s.method.id))
+		block = append(block, s.instructions(c)...)
+		for j, p := range s.covers {
+			label := "     covers "
+			if j > 0 {
+				label = "            "
+			}
+			block = append(block, label+sanitize.Replace(p))
+		}
+		if i < len(steps)-1 {
+			block = append(block, "")
+		}
+	}
+
+	// Explain only the routes that actually apply, in the order they appear.
+	var legend []string
+	seen := map[string]bool{}
+	for _, s := range steps {
+		if seen[s.method.id] {
+			continue
+		}
+		seen[s.method.id] = true
+		legend = append(legend, fmt.Sprintf("- **%s**: %s.", s.method.id, s.method.help))
+	}
+
+	return strings.Join([]string{
+		encodeMarker(unvalidated),
+		intro,
+		"",
+		"```",
+		strings.Join(block, "\n"),
+		"```",
+		"",
+		strings.Join(legend, "\n"),
+		"",
+		"A reviewer should confirm the changes are safe before running any of this, then " +
+			"link the successful runs here.",
+		"",
+		fmt.Sprintf("See [Testing CI workflow changes](%s) for what each route means. Once "+
+			"the changes are validated, a reviewer can remove the `%s` label.",
+			docsURL, validationLabel),
+	}, "\n")
+}

--- a/tools/ci-validation/validation_test.go
+++ b/tools/ci-validation/validation_test.go
@@ -1,0 +1,563 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// repoWorkflows is the real workflow directory, used to check the classification
+// against every workflow in the repository.
+const repoWorkflows = "../../" + workflowsDir
+
+func TestWorkflowTriggers(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		content string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:    "mapping form",
+			content: "on:\n  pull_request: {}\n",
+			want:    []string{"pull_request"},
+		},
+		{
+			name:    "mapping form with options",
+			content: "on:\n  pull_request:\n    branches:\n      - main\n",
+			want:    []string{"pull_request"},
+		},
+		{
+			name:    "mapping form with several triggers",
+			content: "on:\n  push:\n    branches: [main]\n  pull_request: {}\n",
+			want:    []string{"pull_request", "push"},
+		},
+		{
+			name:    "scalar form",
+			content: "on: pull_request\n",
+			want:    []string{"pull_request"},
+		},
+		{
+			name:    "sequence form",
+			content: "on: [push, pull_request]\n",
+			want:    []string{"pull_request", "push"},
+		},
+		{
+			name:    "quoted on key",
+			content: "\"on\":\n  pull_request: {}\n",
+			want:    []string{"pull_request"},
+		},
+		{
+			// pull_request_target contains 'pull_request' as a substring, but
+			// GitHub loads those workflows from the base branch.
+			name:    "pull_request_target is not pull_request",
+			content: "on:\n  pull_request_target:\n    types: [opened]\n",
+			want:    []string{"pull_request_target"},
+		},
+		{
+			name:    "workflow_dispatch",
+			content: "on:\n  workflow_dispatch:\n    inputs:\n      SHA: {}\n",
+			want:    []string{"workflow_dispatch"},
+		},
+		{
+			name:    "schedule only",
+			content: "on:\n  schedule:\n    - cron: \"0 0 * * *\"\n",
+			want:    []string{"schedule"},
+		},
+		{
+			name:    "missing on key",
+			content: "name: no triggers\njobs: {}\n",
+			wantErr: true,
+		},
+		{
+			name:    "malformed yaml",
+			content: "on: [unterminated\n",
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := workflowTriggers([]byte(tc.content))
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			names := make([]string, 0, len(got))
+			for name := range got {
+				names = append(names, name)
+			}
+			slices.Sort(names)
+			assert.Equal(t, tc.want, names)
+		})
+	}
+}
+
+// TestWorkflowTriggersAgainstRepository classifies every workflow in the
+// repository. It guards against a workflow using an 'on' form the parser does
+// not understand, which would silently flag it as unvalidated.
+func TestWorkflowTriggersAgainstRepository(t *testing.T) {
+	entries, err := os.ReadDir(repoWorkflows)
+	require.NoError(t, err)
+	require.NotEmpty(t, entries)
+
+	// A workflow known to be triggered on 'pull_request', and one known not to
+	// be, so that the test fails if the classification inverts.
+	const (
+		testedWorkflow   = "lint-workflows.yaml"
+		untestedWorkflow = "auto-labeler.yaml"
+	)
+	seen := map[string]bool{}
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !workflowPath.MatchString(".github/workflows/"+name) {
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(repoWorkflows, name))
+		require.NoError(t, err)
+
+		triggers, err := workflowTriggers(content)
+		require.NoError(t, err, "%s could not be classified", name)
+		seen[name] = triggers[pullRequestTrigger]
+	}
+
+	require.Contains(t, seen, testedWorkflow)
+	assert.True(t, seen[testedWorkflow], "%s is triggered on pull_request", testedWorkflow)
+	require.Contains(t, seen, untestedWorkflow)
+	assert.False(t, seen[untestedWorkflow], "%s is a pull_request_target workflow", untestedWorkflow)
+}
+
+func TestPullRequestExcludes(t *testing.T) {
+	const self = ".github/workflows/w.yaml"
+	for _, tc := range []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name:    "no filters at all",
+			content: "on:\n  pull_request: {}\n",
+		},
+		{
+			name:    "empty trigger body",
+			content: "on:\n  pull_request:\n",
+		},
+		{
+			name:    "scalar form has no filters",
+			content: "on: pull_request\n",
+		},
+		{
+			name:    "branches only is not a path filter",
+			content: "on:\n  pull_request:\n    branches: [main]\n",
+		},
+		{
+			// The renovate-config-validator.yaml case: the filter cannot match
+			// the workflow file, so a change to it runs nothing.
+			name:    "paths filter that excludes the workflow itself",
+			content: "on:\n  pull_request:\n    paths: ['**renovate.json5']\n",
+			want:    true,
+		},
+		{
+			// The tests-cifuzz.yaml workaround: name your own path.
+			name:    "paths filter that names the workflow itself",
+			content: "on:\n  pull_request:\n    paths:\n      - " + self + "\n      - '**/fuzz_test.go'\n",
+		},
+		{
+			name:    "paths-ignore that does not cover the workflow",
+			content: "on:\n  pull_request:\n    paths-ignore: ['Documentation/**', 'test/**']\n",
+		},
+		{
+			name:    "paths-ignore that names the workflow itself",
+			content: "on:\n  pull_request:\n    paths-ignore:\n      - " + self + "\n",
+			want:    true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, pullRequestExcludes([]byte(tc.content), self))
+		})
+	}
+}
+
+// TestPullRequestExcludesAgainstRepository pins the behaviour against the three
+// real workflows that carry a pull_request path filter.
+func TestPullRequestExcludesAgainstRepository(t *testing.T) {
+	for name, want := range map[string]bool{
+		// paths: ['**renovate.json5'] — a change to the workflow runs nothing.
+		"renovate-config-validator.yaml": true,
+		// paths: lists its own path.
+		"tests-cifuzz.yaml": false,
+		// paths-ignore: Documentation and test only.
+		"cilium-cli.yaml": false,
+		// No filter whatsoever.
+		"lint-go.yaml": false,
+	} {
+		t.Run(name, func(t *testing.T) {
+			content, err := os.ReadFile(filepath.Join(repoWorkflows, name))
+			require.NoError(t, err)
+			assert.Equal(t, want, pullRequestExcludes(content, workflowsDir+"/"+name))
+		})
+	}
+}
+
+func TestWorkflowPath(t *testing.T) {
+	for path, want := range map[string]bool{
+		".github/workflows/tests-e2e-upgrade.yaml": true,
+		".github/workflows/reusable-greetings.yml": true,
+		".github/workflows/sub/dir/notes.yaml":     false,
+		".github/workflows/notes.txt":              false,
+		".github/workflows":                        false,
+		".github/actions/e2e/lb.yaml":              false,
+		"cilium-cli/connectivity/tests/lrp.go":     false,
+	} {
+		assert.Equal(t, want, workflowPath.MatchString(path), path)
+	}
+}
+
+// fetcher serves workflow content for unvalidatedPaths.
+func fetcher(contents map[string]string) fetchFunc {
+	return func(path string) ([]byte, error) {
+		content, ok := contents[path]
+		if !ok {
+			return nil, fmt.Errorf("404 not found")
+		}
+		return []byte(content), nil
+	}
+}
+
+const (
+	prWorkflow       = "on:\n  pull_request: {}\njobs: {}\n"
+	dispatchWorkflow = "on:\n  workflow_dispatch: {}\njobs: {}\n"
+	targetWorkflow   = "on:\n  pull_request_target: {}\njobs: {}\n"
+)
+
+// files48192 is the change set of #48192, whose unvalidated .github/ change was
+// reverted from main. Its CI files must all be flagged, and the cilium-cli file
+// must not be.
+var files48192 = []string{
+	"cilium-cli/connectivity/tests/lrp.go",
+	".github/actions/e2e/lb.yaml",
+	".github/actions/lvh-kind/action.yaml",
+	".github/workflows/tests-e2e-upgrade.yaml",
+}
+
+func TestUnvalidatedPaths(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		changed  []string
+		contents map[string]string
+		want     []finding
+	}{
+		{
+			name:    "no CI changes",
+			changed: []string{"cilium-cli/connectivity/tests/lrp.go", "pkg/policy/rules.go"},
+			want:    nil,
+		},
+		{
+			name:     "pull_request workflow is validated",
+			changed:  []string{".github/workflows/lint-go.yaml"},
+			contents: map[string]string{".github/workflows/lint-go.yaml": prWorkflow},
+			want:     nil,
+		},
+		{
+			name:     "a dispatchable workflow is flagged and recorded as such",
+			changed:  []string{".github/workflows/tests-e2e-upgrade.yaml"},
+			contents: map[string]string{".github/workflows/tests-e2e-upgrade.yaml": dispatchWorkflow},
+			want:     []finding{{path: ".github/workflows/tests-e2e-upgrade.yaml", dispatchable: true}},
+		},
+		{
+			name:     "a pull_request_target workflow is not dispatchable",
+			changed:  []string{".github/workflows/auto-labeler.yaml"},
+			contents: map[string]string{".github/workflows/auto-labeler.yaml": targetWorkflow},
+			want:     []finding{{path: ".github/workflows/auto-labeler.yaml", dispatchable: false}},
+		},
+		{
+			name:    "composite actions and ariane config need no fetch",
+			changed: []string{".github/actions/e2e/lb.yaml", arianeConfigPath},
+			want: []finding{
+				{path: ".github/actions/e2e/lb.yaml"},
+				{path: arianeConfigPath},
+			},
+		},
+		{
+			name:     "the #48192 change set",
+			changed:  files48192,
+			contents: map[string]string{".github/workflows/tests-e2e-upgrade.yaml": dispatchWorkflow},
+			want: []finding{
+				{path: ".github/actions/e2e/lb.yaml"},
+				{path: ".github/actions/lvh-kind/action.yaml"},
+				{path: ".github/workflows/tests-e2e-upgrade.yaml", dispatchable: true},
+			},
+		},
+		{
+			// Removing a 'pull_request' trigger in the head must re-arm the
+			// gate, since the head version is what would run after merge.
+			name:     "trigger removed in the head is flagged",
+			changed:  []string{".github/workflows/lint-go.yaml"},
+			contents: map[string]string{".github/workflows/lint-go.yaml": dispatchWorkflow},
+			want:     []finding{{path: ".github/workflows/lint-go.yaml", dispatchable: true}},
+		},
+		{
+			name:     "unfetchable workflow errs towards flagging",
+			changed:  []string{".github/workflows/gone.yaml"},
+			contents: nil,
+			want:     []finding{{path: ".github/workflows/gone.yaml"}},
+		},
+		{
+			name:     "unparseable workflow errs towards flagging",
+			changed:  []string{".github/workflows/broken.yaml"},
+			contents: map[string]string{".github/workflows/broken.yaml": "on: [unterminated\n"},
+			want:     []finding{{path: ".github/workflows/broken.yaml"}},
+		},
+		{
+			name:    "nested file under workflows is not a workflow",
+			changed: []string{".github/workflows/sub/dir/notes.yaml"},
+			want:    nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := unvalidatedPaths(tc.changed, fetcher(tc.contents), func(string, ...any) {})
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestMarkerRoundTrip(t *testing.T) {
+	recorded := []string{
+		".github/actions/e2e/lb.yaml",
+		// A hostile file name must not be able to close the HTML comment, fake
+		// a second marker, or inject a notification.
+		".github/actions/x-->`\n@cilium/team <!-- ci-validation-notice v1 -->/action.yaml",
+	}
+	body := encodeMarker(recorded)
+	reported := reportedPaths([]comment{{body: body, isBot: true}}, func(string, ...any) {})
+	assert.Len(t, reported, len(recorded))
+	for _, path := range recorded {
+		assert.Contains(t, reported, path)
+	}
+}
+
+func TestReportedPaths(t *testing.T) {
+	recorded := encodeMarker([]string{".github/actions/e2e/lb.yaml"})
+
+	t.Run("author authored marker is ignored", func(t *testing.T) {
+		reported := reportedPaths([]comment{{body: recorded, isBot: false}}, func(string, ...any) {})
+		assert.Empty(t, reported)
+	})
+
+	t.Run("union across notices", func(t *testing.T) {
+		other := encodeMarker([]string{arianeConfigPath})
+		reported := reportedPaths([]comment{
+			{body: recorded, isBot: true},
+			{body: "a plain review comment", isBot: false},
+			{body: other, isBot: true},
+		}, func(string, ...any) {})
+		assert.Len(t, reported, 2)
+		assert.Contains(t, reported, ".github/actions/e2e/lb.yaml")
+		assert.Contains(t, reported, arianeConfigPath)
+	})
+
+	t.Run("unparseable markers are skipped", func(t *testing.T) {
+		var logged int
+		reported := reportedPaths([]comment{
+			{body: "<!-- ci-validation-notice v1 notbase64 -->", isBot: true},
+			{body: "<!-- ci-validation-notice v1 " +
+				base64.StdEncoding.EncodeToString([]byte("not json")) + " -->", isBot: true},
+			{body: recorded, isBot: true},
+		}, func(string, ...any) { logged++ })
+		assert.Equal(t, 2, logged)
+		assert.Len(t, reported, 1)
+	})
+
+	t.Run("no marker at all", func(t *testing.T) {
+		reported := reportedPaths([]comment{{body: "LGTM", isBot: true}}, func(string, ...any) {})
+		assert.Empty(t, reported)
+	})
+}
+
+func TestFreshFindings(t *testing.T) {
+	unvalidated := []finding{
+		{path: ".github/actions/e2e/lb.yaml"},
+		{path: ".github/actions/lvh-kind/action.yaml"},
+		{path: ".github/workflows/tests-e2e-upgrade.yaml", dispatchable: true},
+	}
+	nolog := func(string, ...any) {}
+	recorded := func(f []finding) []comment {
+		return []comment{{body: encodeMarker(paths(f)), isBot: true}}
+	}
+
+	t.Run("nothing reported yet", func(t *testing.T) {
+		assert.Equal(t, unvalidated, freshFindings(unvalidated, nil))
+	})
+
+	t.Run("unchanged set is a no-op so clearing the label sticks", func(t *testing.T) {
+		reported := reportedPaths(recorded(unvalidated), nolog)
+		assert.Empty(t, freshFindings(unvalidated, reported))
+	})
+
+	t.Run("a strict subset does not re-arm", func(t *testing.T) {
+		reported := reportedPaths(recorded(unvalidated), nolog)
+		assert.Empty(t, freshFindings(unvalidated[:1], reported))
+	})
+
+	t.Run("a newly added CI file re-arms", func(t *testing.T) {
+		reported := reportedPaths(recorded(unvalidated), nolog)
+		added := append(slices.Clone(unvalidated), finding{path: arianeConfigPath})
+		assert.Equal(t, []finding{{path: arianeConfigPath}}, freshFindings(added, reported))
+	})
+}
+
+// testPR is the pull request context the rendered commands are built from.
+var testPR = prContext{
+	number:     48192,
+	headSHA:    "75b08d7540be271a1cfd561293ece85f678a379e",
+	baseSHA:    "0d2f8e4d67aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	baseBranch: "main",
+}
+
+// TestNoticeConverges walks the sequence a pull request goes through: an initial
+// notice, a no-op re-run, a re-arm when a CI file is added, and a no-op again.
+func TestNoticeConverges(t *testing.T) {
+	nolog := func(string, ...any) {}
+	workflows := map[string][]byte{
+		"tests-e2e-upgrade.yaml": []byte("on:\n  workflow_dispatch: {}\njobs:\n  a:\n" +
+			"    steps:\n      - run: work_dir=\".github/actions/e2e\"\n"),
+	}
+	triggers := map[string][]string{"tests-e2e-upgrade.yaml": {"/ci-e2e-upgrade"}}
+	unvalidated := []finding{{path: ".github/actions/e2e/lb.yaml"}}
+
+	// First push: nothing reported, so the notice is posted.
+	reported := reportedPaths(nil, nolog)
+	fresh := freshFindings(unvalidated, reported)
+	require.Equal(t, unvalidated, fresh)
+	first := renderNotice(plan(fresh, workflows, triggers, true), paths(unvalidated),
+		len(reported) > 0, testPR)
+	assert.Contains(t, first, "smallest set")
+	assert.NotContains(t, first, "now changes further CI files")
+
+	posted := []comment{{body: first, isBot: true}}
+
+	// Second push, same set: no notice, so a cleared label stays cleared.
+	reported = reportedPaths(posted, nolog)
+	assert.Empty(t, freshFindings(unvalidated, reported))
+
+	// Third push adds the workflow itself: the gate re-arms, reporting only it.
+	added := append(slices.Clone(unvalidated),
+		finding{path: ".github/workflows/tests-e2e-upgrade.yaml", dispatchable: true})
+	fresh = freshFindings(added, reported)
+	require.Len(t, fresh, 1)
+	second := renderNotice(plan(fresh, workflows, triggers, true), paths(added),
+		len(reported) > 0, testPR)
+	assert.Contains(t, second, "now changes further CI files")
+	assert.Contains(t, second, "tests-e2e-upgrade.yaml")
+
+	// Fourth push, same set: converged, no third notice.
+	posted = append(posted, comment{body: second, isBot: true})
+	reported = reportedPaths(posted, nolog)
+	assert.Empty(t, freshFindings(added, reported))
+}
+
+// codeBlock returns the contents of the fenced block listing the actions.
+func codeBlock(t *testing.T, body string) string {
+	t.Helper()
+	_, rest, ok := strings.Cut(body, "```\n")
+	require.True(t, ok)
+	block, _, ok := strings.Cut(rest, "\n```")
+	require.True(t, ok)
+	return block
+}
+
+// TestRenderNoticeSpellsOutCommands checks that a reviewer gets a runnable
+// command rather than being told to work out which trigger applies.
+func TestRenderNoticeSpellsOutCommands(t *testing.T) {
+	steps := []step{
+		{
+			workflow: "tests-e2e-upgrade.yaml",
+			triggers: []string{"/ci-e2e-upgrade"},
+			method:   methodMirror,
+			covers:   []string{".github/workflows/tests-e2e-upgrade.yaml"},
+		},
+		{
+			workflow: "conformance-ipsec-e2e.yaml",
+			method:   methodContextRef,
+			covers:   []string{".github/actions/e2e/lb.yaml"},
+		},
+	}
+	body := renderNotice(steps, []string{".github/actions/e2e/lb.yaml"}, false, testPR)
+	block := codeBlock(t, body)
+
+	// Both workflows are named, numbered, and tagged with their route.
+	assert.Contains(t, block, "1. tests-e2e-upgrade.yaml  [M4]")
+	assert.Contains(t, block, "2. conformance-ipsec-e2e.yaml  [M3]")
+
+	// The commands are concrete: the real SHAs and the base branch, not
+	// placeholders the reviewer has to resolve.
+	assert.Contains(t, block, "gh workflow run tests-e2e-upgrade.yaml --ref <branch>")
+	assert.Contains(t, block, "gh workflow run conformance-ipsec-e2e.yaml --ref main")
+	assert.Contains(t, block, "-f PR-number=48192")
+	assert.Contains(t, block, "-f SHA="+testPR.headSHA)
+	assert.Contains(t, block, "-f base-SHA="+testPR.baseSHA)
+	assert.Contains(t, block, "-f context-ref="+testPR.headSHA)
+
+	// Only the routes in play are explained.
+	assert.Equal(t, 1, strings.Count(body, "**"+methodMirror.id+"**"))
+	assert.Equal(t, 1, strings.Count(body, "**"+methodContextRef.id+"**"))
+	assert.NotContains(t, body, "**"+methodTempTrigger.id+"**")
+}
+
+// TestRenderNoticeUsesTriggerWhenDispatchable prefers a one-line comment over a
+// command when Ariane can do the dispatch.
+func TestRenderNoticeUsesTriggerWhenDispatchable(t *testing.T) {
+	steps := []step{{
+		workflow: "tests-e2e-upgrade.yaml",
+		triggers: []string{"/ci-e2e-upgrade"},
+		method:   methodDispatch,
+		covers:   []string{".github/actions/e2e/lb.yaml"},
+	}}
+	block := codeBlock(t, renderNotice(steps, nil, false, testPR))
+	assert.Contains(t, block, "comment /ci-e2e-upgrade")
+	assert.NotContains(t, block, "gh workflow run")
+}
+
+func TestRenderNoticeSanitizesPaths(t *testing.T) {
+	nasty := ".github/actions/x`code`\r\n@cilium/team/action.yaml"
+	steps := []step{{workflow: "w.yaml", method: methodContextRef, covers: []string{nasty}}}
+	body := renderNotice(steps, []string{nasty}, false, testPR)
+
+	block := codeBlock(t, body)
+	assert.NotContains(t, block, "`")
+	assert.Contains(t, block, ".github/actions/xcode@cilium/team/action.yaml")
+
+	// The raw path is still recorded, so the comparison on the next push is
+	// made against what actually changed.
+	reported := reportedPaths([]comment{{body: body, isBot: true}}, func(string, ...any) {})
+	assert.Contains(t, reported, nasty)
+}
+
+func TestRenderNoticeRecordsFullSet(t *testing.T) {
+	steps := []step{{method: methodReviewOnly, covers: []string{arianeConfigPath}}}
+	all := []string{".github/actions/e2e/lb.yaml", arianeConfigPath}
+	body := renderNotice(steps, all, true, testPR)
+
+	match := marker.FindStringSubmatch(body)
+	require.NotNil(t, match)
+	decoded, err := base64.StdEncoding.DecodeString(match[1])
+	require.NoError(t, err)
+	var recorded []string
+	require.NoError(t, json.Unmarshal(decoded, &recorded))
+	assert.Equal(t, all, recorded, "the notice records the full current set, not just the new paths")
+
+	assert.Contains(t, body, validationLabel)
+	assert.Contains(t, body, docsURL)
+}


### PR DESCRIPTION
Most CI changes are not run by the pull request that proposes them, so they have to be validated by hand before merge. This applies the existing `dont-merge/needs-ci-validation` label and posts the smallest set of actions that covers the flagged files, each tagged with one of the methods below and with a runnable command. MLH blocks merge on any `dont-merge/*` label, so the gate is enforced.

|     | Method |
|-----|--------|
| M0  | Nothing; the pull request's own CI already runs it (secrets are withheld on forks) |
| M1  | `/test` or `/ci-*` comment — PR from a fork |
| M2  | `/test` or `/ci-*` comment — PR from a `cilium/cilium` branch |
| M3  | `gh workflow run <wf> --ref <base> -f context-ref=<head SHA> -f SHA=<head SHA>` — no mirror |
| M4  | Mirror branch to `cilium/cilium` + `gh workflow run <wf> --ref <mirror>` |
| M5  | Mirror under `ft/main/` + test PR whose *base* is that branch (or just the push, for a `push` workflow) |
| M6  | Add the workflow's own path to its `pull_request` `paths` filter, as `tests-cifuzz.yaml` does |

| What changed | M0 | M1 | M2 | M3 | M4 | M5 | M6 |
|---|---|---|---|---|---|---|---|
| Product code (Go, bpf, `cilium-cli`) | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
| A composite action or config under `.github/actions/` | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | — |
| Workflow body, has `workflow_dispatch` | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | — |
| Workflow body, no `workflow_dispatch` | ❌ | ❌ | ❌ | n/a | n/a | ✅ | — |
| Workflow `on:` block (`types`, `branches`, `paths`, cron) | ❌ | ❌ | ❌ | ❌ | ❌ | ⚠️ | — |
| Brand-new workflow, non-`pull_request` trigger | ❌ | ❌ | ❌ | ⚠️ | ⚠️ | ✅ | — |
| `.github/ariane-config.yaml` | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | — |
| A `pull_request` workflow, any change | ✅ | ✅ | ✅ | — | — | — | — |
| The same, but its `paths` filter excludes the workflow itself | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |

Whether the pull request comes from a fork decides more than the trigger does, and it is one mechanism rather than three: Ariane resolves a single context ref per pull request, the head branch when that branch is in this repository and the target branch when it is not, and then uses it both as the dispatch ref and as the `context-ref` input. That is why the same fork boundary governs dispatched workflow definitions, everything under `.github/actions/`, and `ariane-config.yaml`, which Ariane reads at that very ref. M3 exists to cross that boundary deliberately for a fork, by keeping the definition trusted while pointing `context-ref` at the pull request's head.

M3 fails for a workflow body because `--ref <base>` makes GitHub read the definition from the base branch, and only M4 relocates it. `n/a` means `gh workflow run` cannot be issued: the workflow declares no `workflow_dispatch`. A brand-new workflow is ⚠️ for the dispatch routes because GitHub only accepts a dispatch once it holds a record for the file, which the first run of it on any branch creates, so something has to register it first. M5 only partly covers an `on:` change, since GitHub evaluates triggers and the `types`, `branches` and `paths` filters when the real event fires, and nothing reproduces a cron.

Two exceptions are worth knowing. `common-post-jobs.yaml` consumes `cilium/cilium/.github/actions/merge-artifacts@main`, pinned to `main`, so a change to that action is never exercised before merge even from a branch here. And for a pull request from a fork the `/default` workflows are not dispatched automatically, so nothing runs until a reviewer triggers it.

A reviewer first confirms the changes are safe to run, since they execute with the repository's secrets and, for a fork, this is the point at which untrusted CI configuration becomes trusted. Then they carry out each action in the posted comment, which already names the workflow, the method and the command, so there is nothing left to work out. The successful runs are linked on the pull request as the record of validation, and the label is removed. Clearing it sticks: the label only returns if a later push adds a CI file that has not been reported yet.

This does not need backporting. It targets the main development flow, and the docs are process docs maintained on main. If the same guard is wanted for stable-branch pull requests, that is better done as a deliberate follow-up than as a backport.

Fixes: #43939

This PR was prepared with AIL:3.
