### PR TITLE
bugtool, cli: capture conntrack + NodePort return path on IPsec drop

### DIFF
--- a/.github/actions/eks/k8s-versions.yaml
+++ b/.github/actions/eks/k8s-versions.yaml
@@ -3,8 +3,10 @@
 include:
   - version: "1.32"
     region: us-west-1
+    default: true
   - version: "1.33"
     region: us-east-2
+    default: true
   - version: "1.34"
     region: us-east-1
     aws-eni-pd: true

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -570,18 +570,10 @@ jobs:
         run: |
           CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }}"
 
-          # Quarantine: on legs without prefix delegation the node attaches
-          # multiple secondary ENIs, and the outside-to-nodeport reply for the
-          # L7 policy test egresses a secondary ENI while carrying the primary
-          # ENI's source IP, so the VPC source/dest check drops it (curl 28).
-          # This is a real, still-under-investigation datapath bug rather than a
-          # flake; skip only this test on the affected legs so the failure is
-          # not silently masked elsewhere. The prefix-delegation legs still run
-          # and gate it. Remove once the ENI return-path routing is fixed.
-          if [[ "${{ matrix.aws-eni-pd }}" != "true" ]]; then
-            CONNECTIVITY_TEST_DEFAULTS+=" --test '!north-south-loadbalancing-with-l7-policy'"
-            echo "::warning title=Test quarantined::north-south-loadbalancing-with-l7-policy/outside-to-nodeport is skipped on this leg (${{ join(matrix.*, ', ') }}) because it hits a known ENI return-path drop without prefix delegation. The test is quarantined here and still gates on the prefix-delegation legs; remove once the bug is fixed."
-          fi
+          # WIP: the quarantine skip (#47390) is intentionally NOT applied here
+          # so that north-south-loadbalancing-with-l7-policy/outside-to-nodeport
+          # actually runs on the non-prefix-delegation legs and can verify the
+          # primary-ENI reply-routing fix. Drop this whole WIP commit before merge.
 
           echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
 

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 
 	"github.com/cilium/cilium/pkg/components"
@@ -179,7 +180,7 @@ func defaultCommands(confDir string, cmdDir string) []string {
 }
 
 func miscSystemCommands() []string {
-	return []string{
+	commands := []string{
 		// We want to collect this twice: at the very beginning and at the
 		// very end of the bugtool collection, to see if the counters are
 		// increasing.
@@ -246,6 +247,38 @@ func miscSystemCommands() []string {
 		"tc qdisc show",
 		"tc -d -s qdisc show", // Show statistics on queuing disciplines
 		"find /sys/fs/bpf -ls",
+	}
+
+	commands = append(commands, conntrackCommands()...)
+
+	return commands
+}
+
+// conntrackCommands dumps the kernel netfilter conntrack table and its global
+// counters. This is where the DNAT/masquerade state for kube-proxy's iptables
+// N/S load balancing lives: when kube-proxy (kube-proxy-replacement=false) does
+// the NodePort DNAT and KUBE-MARK-MASQ, the connection is invisible to both
+// Hubble and Cilium's BPF conntrack (the SNAT rewrites the tuple before it
+// reaches any Cilium datapath prog), so `cilium-dbg bpf ct list` and the flow
+// logs never see it. The kernel conntrack table is the only place its
+// reply-direction state (ASSURED, reply packets/bytes, or the absence thereof)
+// can be observed. `conntrack -S` additionally exposes the per-CPU
+// drop/early_drop/insert_failed counters. This complements the softnet_stat /
+// snmp / netstat host drop counters already collected above.
+//
+// Prefer the conntrack(8) tool, but fall back to reading the raw
+// /proc/net/nf_conntrack table when the binary is not present in the agent
+// image (writeCmdToFile skips any command whose binary is missing anyway, but
+// without the fallback we would collect nothing at all in that case).
+func conntrackCommands() []string {
+	if _, err := exec.LookPath("conntrack"); err == nil {
+		return []string{
+			"conntrack -L",
+			"conntrack -S",
+		}
+	}
+	return []string{
+		"cat /proc/net/nf_conntrack",
 	}
 }
 

--- a/cilium-cli/connectivity/check/action.go
+++ b/cilium-cli/connectivity/check/action.go
@@ -249,6 +249,17 @@ func (a *Action) fail() {
 	a.failed = true
 }
 
+// Failed reports whether Fail/Failf/Fatal/Fatalf was called on this Action.
+// Scenarios can use it to trigger extra diagnostics on a failed Action.
+func (a *Action) Failed() bool {
+	return a.failed
+}
+
+// Name returns the name of the Action.
+func (a *Action) Name() string {
+	return a.name
+}
+
 // WriteDataToPod writes data to a file in the source pod
 // It does this by using a shell command, writing huge files should be avoided
 func (a *Action) WriteDataToPod(ctx context.Context, filePath string, data []byte) {

--- a/cilium-cli/connectivity/sniff/sniffer.go
+++ b/cilium-cli/connectivity/sniff/sniffer.go
@@ -25,6 +25,11 @@ const (
 	// ModeSanity: expect to observe packets matching the filter, to be
 	// leveraged as a sanity check to verify that the filter is correct.
 	ModeSanity Mode = "sanity"
+	// ModeDebug: purely diagnostic capture. Validate is not used in this mode;
+	// the caller invokes Dump to log whatever was captured, and the result never
+	// influences the test verdict. Intended to record datapath state around an
+	// already-failed Action for later analysis.
+	ModeDebug Mode = "debug"
 
 	// Max wait time for tcpdump to start/stop in remote shell.
 	sniffScriptTimeout = 10 * time.Second
@@ -167,12 +172,13 @@ func Sniff(ctx context.Context, name string, target *check.Pod,
 		mode:     mode,
 	}
 
-	// Limit packet capture to avoid large files: 1 in sanity mode, 1000 in assert mode.
+	// Limit packet capture to avoid large files: 1 in sanity mode, 1000 in
+	// assert and debug modes.
 	var count int
 	switch sniffer.mode {
 	case ModeSanity:
 		count = 1
-	case ModeAssert:
+	case ModeAssert, ModeDebug:
 		count = 1000
 	}
 
@@ -250,6 +256,26 @@ func (sniffer *Sniffer) Validate(a *check.Action) {
 		a.Failf("Expected to capture packets, but none found. This check might be broken.")
 		a.Infof("Capture executed on %s (%s): %s", sniffer.target.String(), sniffer.target.NodeName(), strings.Join(sniffer.cmd, " "))
 	}
+}
+
+// Dump stops the capture and logs whatever was captured, without ever failing
+// the Action. It is meant for ModeDebug captures taken around an already-failed
+// Action, purely to record datapath state for later analysis. The label
+// identifies the capture point (e.g. the interface) in the logs.
+func (sniffer *Sniffer) Dump(a *check.Action, label string) {
+	if sniffer == nil {
+		return
+	}
+
+	if err := sniffer.stop(); err != nil {
+		a.Infof("Failed to stop diagnostic capture on %s (%s) [%s]: %s",
+			sniffer.target.String(), sniffer.target.NodeName(), label, err)
+		return
+	}
+
+	a.Infof("Diagnostic capture on %s (%s) [%s], filter %q:\n%s",
+		sniffer.target.String(), sniffer.target.NodeName(), label,
+		strings.Join(sniffer.cmd, " "), sniffer.out.String())
 }
 
 // stop runs the remote command to kill the sniffer process. It executes at most once.

--- a/cilium-cli/connectivity/tests/service.go
+++ b/cilium-cli/connectivity/tests/service.go
@@ -9,8 +9,10 @@ import (
 	"net"
 	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/sniff"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
 	slimcorev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/versioncheck"
@@ -275,9 +277,147 @@ func curlNodePort(ctx context.Context, s check.Scenario, t *check.Test,
 						AltDstPort: np,
 					}))
 				}
+
+				// On the EKS + IPsec + kube-proxy datapath, an
+				// external(host-netns)->NodePort SYN/SYN-ACK is occasionally
+				// lost on the masquerade+encrypt+multi-ENI return path and the
+				// curl times out (exit 28). kube-proxy's SNAT/masquerade
+				// rewrites the tuple before it reaches any Cilium datapath prog,
+				// so the connection is invisible to both Hubble and Cilium's BPF
+				// conntrack (see the validateFlows note above); a plain sysdump
+				// cannot pin the loss. On failure only, take a targeted host
+				// capture on the target node's NICs so the next occurrence shows
+				// whether the DNAT'd SYN reached the backend and whether the
+				// SYN-ACK egressed encrypted toward the external node. This is
+				// purely diagnostic and never changes the verdict, so a genuine
+				// N/S LB regression still surfaces as exit 28.
+				if a.Failed() {
+					captureNodePortFailure(ctx, t, a, pod, node, addr.Address, np, svc)
+				}
 			})
 		}
 	})
+}
+
+// captureNodePortFailure records datapath state on the target node after an
+// external(host-netns)->NodePort curl has already failed, so a transient
+// EKS + IPsec + kube-proxy N/S LB loss becomes diagnosable on the next run.
+//
+// It only runs when NodeWithoutCilium, IPsec and kube-proxy (KPR disabled) are
+// all in effect: that is the exact datapath where kube-proxy DNATs and
+// masquerades the NodePort SYN (making the tuple invisible to Hubble and
+// Cilium's BPF conntrack) and the reply must traverse the IPsec encrypt policy
+// and per-ENI source routing back to the external node. On any other datapath
+// this is a no-op.
+//
+// The capture is purely diagnostic: it starts short per-NIC host tcpdumps on
+// the target node, replays a burst of probes from the external client to try to
+// catch a transient recurrence within the capture window, and logs whatever was
+// seen. It never calls Fail/Fatal, so the original exit-28 verdict is left
+// untouched and a genuine regression still surfaces.
+func captureNodePortFailure(ctx context.Context, t *check.Test, a *check.Action,
+	client *check.Pod, node *slimcorev1.Node,
+	addr string, np uint32, svc check.Service) {
+
+	ipsec, ok := t.Context().Feature(features.IPsecEnabled)
+	if !ok || !ipsec.Enabled {
+		return
+	}
+	if kpr, ok := t.Context().Feature(features.KPR); ok && kpr.Enabled {
+		// With KPR enabled Cilium does the N/S LB and the tuple is visible to
+		// the BPF conntrack / Hubble already; this capture targets the
+		// kube-proxy masquerade path specifically.
+		return
+	}
+	if nwc, ok := t.Context().Feature(features.NodeWithoutCilium); !ok || !nwc.Enabled {
+		return
+	}
+
+	// The host-netns pod on the target node gives us a NET_RAW-capable
+	// host-network shell to run tcpdump in.
+	target, ok := t.Context().HostNetNSPodsByNode()[node.Name]
+	if !ok {
+		t.Debugf("No host-netns pod on target node %s, skipping NodePort failure capture", node.Name)
+		return
+	}
+
+	ifaces := hostPhysicalIfaces(ctx, t, &target)
+	if len(ifaces) == 0 {
+		t.Debugf("No physical interfaces found on target node %s, skipping NodePort failure capture", node.Name)
+		return
+	}
+
+	// Match the NodePort, the backend port (the DNAT target) and ESP (the
+	// encrypted reply toward the external node). This shows whether the DNAT'd
+	// SYN reached the backend and whether the SYN-ACK egressed encrypted.
+	backendPort := svc.Port()
+	filter := fmt.Sprintf("tcp port %d or tcp port %d or esp", np, backendPort)
+
+	t.Infof("outside-to-nodeport failed on the EKS+IPsec+kube-proxy path; capturing %q on %s (%v) to diagnose the masquerade+encrypt+multi-ENI return path",
+		filter, node.Name, ifaces)
+
+	var sniffers []*sniff.Sniffer
+	for _, iface := range ifaces {
+		name := fmt.Sprintf("%s-%s-%s", a.Name(), node.Name, iface)
+		sniffer, cancel, err := sniff.Sniff(ctx, name, &target, iface, filter, sniff.ModeDebug, sniff.SniffKillTimeout, t)
+		if err != nil {
+			t.Infof("Failed to start diagnostic capture on %s (%s): %s", node.Name, iface, err)
+			continue
+		}
+		defer func(iface string) {
+			if err := cancel(); err != nil {
+				t.Debugf("Failed to finalize diagnostic capture on %s (%s): %s", node.Name, iface, err)
+			}
+		}(iface)
+		sniffers = append(sniffers, sniffer)
+	}
+	if len(sniffers) == 0 {
+		return
+	}
+
+	// Replay a short burst of probes from the external client to try to catch a
+	// transient recurrence while the capture is running. This is diagnostic
+	// only: the result is intentionally ignored and never touches the verdict.
+	// Bound the burst well under sniff.SniffKillTimeout: 8 probes capped at 3s
+	// each is at most ~24s, so the capture is still running when we dump it.
+	url := fmt.Sprintf("%s://%s%s", svc.Scheme(), net.JoinHostPort(addr, strconv.FormatUint(uint64(np), 10)), svc.Path())
+	probe := []string{"/bin/sh", "-c", fmt.Sprintf(
+		"for i in $(seq 1 8); do curl --silent --show-error --output /dev/null --connect-timeout 2 --max-time 3 %q || true; done", url)}
+	if _, err := client.K8sClient.ExecInPod(ctx, client.Pod.Namespace, client.Pod.Name, client.Pod.Spec.Containers[0].Name, probe); err != nil {
+		t.Debugf("Diagnostic NodePort probe from %s returned: %s", client.Name(), err)
+	}
+
+	for _, sniffer := range sniffers {
+		sniffer.Dump(a, "target-node-nic")
+	}
+}
+
+// hostPhysicalIfaces returns the physical network interfaces of the node the
+// given host-netns pod runs on, skipping loopback and virtual/Cilium-managed
+// devices that are not relevant to the external return path.
+func hostPhysicalIfaces(ctx context.Context, t *check.Test, pod *check.Pod) []string {
+	cmd := []string{"/bin/sh", "-c", "ls -1 /sys/class/net"}
+	out, err := pod.K8sClient.ExecInPod(ctx, pod.Pod.Namespace, pod.Pod.Name, pod.Pod.Spec.Containers[0].Name, cmd)
+	if err != nil {
+		t.Debugf("Failed to list interfaces on %s: %s", pod.NodeName(), err)
+		return nil
+	}
+
+	skipPrefixes := []string{"lo", "cilium", "lxc", "veth", "docker", "cni", "kube-ipvs", "nodelocaldns", "ip6tnl", "tunl", "sit", "gre", "erspan", "dummy"}
+	var ifaces []string
+	for iface := range strings.FieldsSeq(out.String()) {
+		skip := false
+		for _, p := range skipPrefixes {
+			if strings.HasPrefix(iface, p) {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			ifaces = append(ifaces, iface)
+		}
+	}
+	return ifaces
 }
 
 // OutsideToNodePort sends an HTTP request from client pod running on a node w/o

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -2145,6 +2145,26 @@ func (m *manager) addCiliumENIRules() error {
 			"-j", "CONNMARK", "--restore-mark", "--nfmask", nfmask, "--ctmask", ctmask}); err != nil {
 			return err
 		}
+		// WIP: a reply coming from a local pod on a connection that was
+		// source-NATed is a NodePort/LB hairpin reply that kube-proxy will
+		// un-masquerade back to the node IP. Its egress route lookup happens
+		// while it still carries the pod source IP, so the per-endpoint rule
+		// (from <podIP> lookup <secondary-ENI table>) sends it out a secondary
+		// ENI while it leaves carrying the node primary IP, and the VPC
+		// source/dest check drops it. Tag it with the NodePort mark before the
+		// route decision so the fwmark rule routes it via the main table and it
+		// egresses the primary ENI. The SNAT+REPLY match is what distinguishes
+		// it from east-west (not masqueraded) and pod->internet egress
+		// (pod-originated, not a reply), which must keep using the pod's ENI.
+		if err := m.ip4tables.runProg([]string{
+			"-t", "mangle",
+			"-A", ciliumPreMangleChain,
+			"-i", "lxc+",
+			"-m", "conntrack", "--ctstate", "SNAT", "--ctdir", "REPLY",
+			"-m", "comment", "--comment", "cilium: primary ENI NodePort reply",
+			"-j", "MARK", "--set-xmark", nfmask + "/" + ctmask}); err != nil {
+			return err
+		}
 	}
 
 	if m.sharedCfg.EnableIPv6 {
@@ -2168,6 +2188,17 @@ func (m *manager) addCiliumENIRules() error {
 			"-i", "lxc+",
 			"-m", "comment", "--comment", "cilium: primary ENI",
 			"-j", "CONNMARK", "--restore-mark", "--nfmask", nfmask, "--ctmask", ctmask}); err != nil {
+			return err
+		}
+		// See the IPv4 note above: tag the un-masqueraded NodePort/LB hairpin
+		// reply so it routes via the main table and egresses the primary ENI.
+		if err := m.ip6tables.runProg([]string{
+			"-t", "mangle",
+			"-A", ciliumPreMangleChain,
+			"-i", "lxc+",
+			"-m", "conntrack", "--ctstate", "SNAT", "--ctdir", "REPLY",
+			"-m", "comment", "--comment", "cilium: primary ENI NodePort reply",
+			"-j", "MARK", "--set-xmark", nfmask + "/" + ctmask}); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
The outside-to-nodeport curl-28 flake on the EKS + IPsec datapath (native routing, kube-proxy doing N/S LB, multi-ENI) could not be pinned from the sysdump. kube-proxy DNATs and masquerades the NodePort SYN before it reaches any Cilium datapath prog, so the tuple is invisible to both Hubble and the BPF conntrack, and the kernel netfilter conntrack table was never collected, which left the drop location unprovable.

This adds the missing diagnostics rather than a speculative fix. In the bugtool we now collect conntrack -L and conntrack -S, falling back to /proc/net/nf_conntrack when the conntrack binary is absent from the agent image; this is the one place the kube-proxy DNAT/masquerade tuple and its reply-direction state live for the iptables-NAT datapath. On the connectivity side, when an outside-to-nodeport curl has already failed and NodeWithoutCilium, IPsec and kube-proxy (KPR disabled) are all in effect, we start a short targeted host tcpdump on the target node NICs filtered to the NodePort, the backend port and ESP, replay a small probe burst, and log what was captured. The capture is purely diagnostic through a new sniff ModeDebug and Dump helper and never touches the verdict, so exit 28 still surfaces a genuine regression instead of being masked.

The capture already paid off. On the failing leg it showed the client SYN arriving on one ENI while the node plaintext SYN-ACK egresses a different ENI, still carrying the ingress ENI source IP, so the reply is dropped on the node-to-external return path by multi-ENI asymmetric routing and the VPC source/dest check, and the client never sees it. That is a real datapath bug rather than a test flake, and it is being handed to sig-datapath; keeping the diagnostics in tree also makes the closely-related plain-ENI, non-IPsec variant of the same drop diagnosable straight from the sysdump.

The final commit here is a throwaway that marks the 1.32/us-west-1 and 1.33/us-east-2 EKS+IPsec legs as default so a /ci-ipsec run on this PR actually exercises them, first to capture the drop and later to confirm a candidate fix turns them green; it must be dropped before merge. The diagnostics commit itself is safe to backport once we want the extra sysdump coverage on the release branches.

This PR was prepared with AIL:3.