### PR TITLE
cilium-cli: don't fail status --wait on superseded taint-rejected pods

### DIFF
--- a/cilium-cli/status/k8s.go
+++ b/cilium-cli/status/k8s.go
@@ -276,6 +276,21 @@ func (k *K8sStatusCollector) daemonSetStatus(ctx context.Context, status *Status
 	return false, nil
 }
 
+// isSupersededPodRejection reports whether a Failed pod reached its terminal
+// state by admission-rejection or eviction rather than by running and crashing.
+// Such pods (e.g. bound to a node still carrying node.cilium.io/agent-not-ready
+// :NoExecute) are already replaced by a healthy sibling from the controller, so
+// they must not fail `status --wait`. A container that ran and crashed has an
+// empty pod-level Status.Reason and is therefore still surfaced.
+func isSupersededPodRejection(reason string) bool {
+	switch reason {
+	case "TaintToleration", "NodeAffinity", "NodeLost", "Evicted",
+		"Shutdown", "Preempting", "UnexpectedAdmissionError":
+		return true
+	}
+	return false
+}
+
 type podStatusCallback func(ctx context.Context, status *Status, name string, pod *corev1.Pod)
 
 func (k *K8sStatusCollector) podStatus(ctx context.Context, status *Status, name, filter string, callback podStatusCallback) error {
@@ -298,6 +313,13 @@ func (k *K8sStatusCollector) podStatus(ctx context.Context, status *Status, name
 			status.AddAggregatedWarning(name, pod.Name, fmt.Errorf("pod is pending"))
 		case corev1.PodRunning, corev1.PodSucceeded:
 		case corev1.PodFailed:
+			// A pod rejected by admission or evicted before its workload ran
+			// is terminal and already superseded by a healthy replacement from
+			// the controller. The Deployment/DaemonSet gate remains authoritative
+			// for real availability, so don't fail the status on such leftovers.
+			if isSupersededPodRejection(pod.Status.Reason) {
+				break
+			}
 			status.AddAggregatedError(name, pod.Name, fmt.Errorf("pod has failed: %s - %s", pod.Status.Reason, pod.Status.Message))
 		}
 

--- a/cilium-cli/status/k8s_test.go
+++ b/cilium-cli/status/k8s_test.go
@@ -230,6 +230,51 @@ func TestStatus(t *testing.T) {
 	assert.Regexp(t, ".*is rolling out.*", status.Errors["cilium"]["cilium"].Errors[0].Error())
 }
 
+func TestPodStatusSkipsSupersededRejection(t *testing.T) {
+	client := newK8sStatusMockClient()
+	collector, err := NewK8sStatusCollector(client, fakeParameters)
+	assert.NoError(t, err)
+
+	const relaySelector = "k8s-app=hubble-relay"
+
+	// A leftover replica rejected by admission (TaintToleration) sits next to a
+	// healthy running sibling created by the ReplicaSet. The rejected pod must
+	// not be counted as an error.
+	client.addPod("kube-system", "hubble-relay-running", relaySelector,
+		[]corev1.Container{{Image: "hubble-relay:1.9"}},
+		corev1.PodStatus{Phase: corev1.PodRunning})
+	client.addPod("kube-system", "hubble-relay-rejected", relaySelector,
+		[]corev1.Container{{Image: "hubble-relay:1.9"}},
+		corev1.PodStatus{Phase: corev1.PodFailed, Reason: "TaintToleration", Message: "Pod was rejected"})
+
+	status := newStatus()
+	err = collector.podStatus(context.Background(), status, defaults.RelayDeploymentName, relaySelector, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, status.totalErrors())
+	assert.Equal(t, 1, status.PhaseCount[defaults.RelayDeploymentName][string(corev1.PodFailed)])
+
+	// A pod that actually ran and crashed carries an empty pod-level Reason and
+	// must still be surfaced as an error.
+	client.reset()
+	client.addPod("kube-system", "hubble-relay-crashed", relaySelector,
+		[]corev1.Container{{Image: "hubble-relay:1.9"}},
+		corev1.PodStatus{Phase: corev1.PodFailed})
+
+	status = newStatus()
+	err = collector.podStatus(context.Background(), status, defaults.RelayDeploymentName, relaySelector, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, status.totalErrors())
+}
+
+func TestIsSupersededPodRejection(t *testing.T) {
+	for _, reason := range []string{"TaintToleration", "NodeAffinity", "NodeLost", "Evicted", "Shutdown", "Preempting", "UnexpectedAdmissionError"} {
+		assert.True(t, isSupersededPodRejection(reason), reason)
+	}
+	for _, reason := range []string{"", "OOMKilled", "Error", "ContainerCannotRun"} {
+		assert.False(t, isSupersededPodRejection(reason), reason)
+	}
+}
+
 func TestFormat(t *testing.T) {
 	client := newK8sStatusMockClient()
 	assert.NotNil(t, client)


### PR DESCRIPTION
EKS nodegroups carry node.cilium.io/agent-not-ready=true:NoExecute until the node's cilium-agent clears it. During that window, coredns and hubble-relay pods bound to the node are rejected by admission and left in a terminal Failed phase with Status.Reason=TaintToleration. The ReplicaSet controller creates healthy replacements, so the Deployment reaches Ready 1/1 Available 1/1, but the leftover Failed pod is not garbage-collected for a while. podStatus() counted any Failed pod as a fatal error and statusIsReady() returned false while there was any error, so cilium status --wait spun to its deadline and exited 1 even though the workload's own Deployment/DaemonSet gate was green, producing a 10 minute CI timeout on the "Wait for Cilium to be ready" step (see #43872).

Pods that reached a terminal Failed state by admission-rejection or eviction before running their workload are now skipped, deferring the readiness verdict to the authoritative Deployment/DaemonSet gate. This cannot mask a genuine failure: a truly-unavailable workload keeps its Deployment Ready<Desired and deploymentStatus already raises an error, while a pod that ran and crashed (OOMKilled or a container error) has an empty pod-level Reason and is still surfaced. A unit test covers both cases.

This PR was prepared with AIL:3.
