### PR TITLE
.github: make the CL2 policy-implementation-delay median self-diagnosing

### DIFF
--- a/.github/actions/cl2-modules/cilium-metrics.yaml
+++ b/.github/actions/cl2-modules/cilium-metrics.yaml
@@ -20,6 +20,9 @@ steps:
         metricVersion: v1
         unit: s
         enableViolations: true
+        # source: one report sample per source, not "too many samples".
+        dimensions:
+        - source
         queries:
         # Gate on the median, not the tail: histogram p99 is interpolated
         # within the top populated bucket and is too noisy to hard-fail on,
@@ -32,6 +35,32 @@ steps:
         - name: Perc50
           query: histogram_quantile(0.50, sum(rate(cilium_policy_implementation_delay_bucket[%v])) by (le))
           threshold: {{$NETPOL_LATENCY_THRESHOLD}}
+        # Reported-only diagnostics (no threshold) for the next p50 breach.
+        - name: SampleCount
+          query: sum(increase(cilium_policy_implementation_delay_count[%v]))
+        - name: SampleCountBySource
+          query: sum(increase(cilium_policy_implementation_delay_count[%v])) by (source)
+        # Interpolation-free SLO: fraction of realizations under 100ms.
+        - name: FracUnder100ms
+          query: sum(rate(cilium_policy_implementation_delay_bucket{le="0.1"}[%v])) / sum(rate(cilium_policy_implementation_delay_count[%v]))
+    # Reported-only: attribute a real slowdown to its regeneration stage.
+    - Identifier: EndpointRegenerationTime
+      Method: GenericPrometheusQuery
+      Params:
+        action: {{$action}}
+        metricName: Endpoint Regeneration Time
+        metricVersion: v1
+        unit: s
+        enableViolations: true
+        dimensions:
+        - scope
+        queries:
+        - name: RegenTotalP50
+          query: histogram_quantile(0.5, sum(rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{scope="total"}[%v])) by (le))
+        - name: RegenTotalP99
+          query: histogram_quantile(0.99, sum(rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{scope="total"}[%v])) by (le))
+        - name: RegenP99ByScope
+          query: histogram_quantile(0.99, sum(rate(cilium_endpoint_regeneration_time_stats_seconds_bucket[%v])) by (le, scope))
     # For debugging cardinality of metrics, fetch prometheus snapshot and use
     # following query to get the cardinality of metrics:
     # topk(10, count by (__name__)({__name__=~"cilium_.+"}))

--- a/.github/actions/cl2-modules/netpol/modules/metrics.yaml
+++ b/.github/actions/cl2-modules/netpol/modules/metrics.yaml
@@ -16,6 +16,9 @@ steps:
         metricVersion: v1
         unit: s
         enableViolations: {{$ENABLE_VIOLATIONS}}
+        # source: one report sample per source, not "too many samples".
+        dimensions:
+        - source
         queries:
         # Gate on the median, not the tail: histogram p99 is interpolated
         # within the top populated bucket and is too noisy to hard-fail on,
@@ -28,6 +31,33 @@ steps:
         - name: Perc50
           query: histogram_quantile(0.50, sum(rate(cilium_policy_implementation_delay_bucket[%v])) by (le))
           threshold: {{$NETPOL_LATENCY_THRESHOLD}}
+        # Reported-only diagnostics (no threshold) for the next p50 breach.
+        - name: SampleCount
+          query: sum(increase(cilium_policy_implementation_delay_count[%v]))
+        - name: SampleCountBySource
+          query: sum(increase(cilium_policy_implementation_delay_count[%v])) by (source)
+        # Interpolation-free SLO: fraction of realizations under 100ms.
+        - name: FracUnder100ms
+          query: sum(rate(cilium_policy_implementation_delay_bucket{le="0.1"}[%v])) / sum(rate(cilium_policy_implementation_delay_count[%v]))
+
+    # Reported-only: attribute a real slowdown to its regeneration stage.
+    - Identifier: EndpointRegenerationTime
+      Method: GenericPrometheusQuery
+      Params:
+        action: {{$action}}
+        metricName: NetPol Endpoint Regeneration Time
+        metricVersion: v1
+        unit: s
+        enableViolations: {{$ENABLE_VIOLATIONS}}
+        dimensions:
+        - scope
+        queries:
+        - name: RegenTotalP50
+          query: histogram_quantile(0.5, sum(rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{scope="total"}[%v])) by (le))
+        - name: RegenTotalP99
+          query: histogram_quantile(0.99, sum(rate(cilium_endpoint_regeneration_time_stats_seconds_bucket{scope="total"}[%v])) by (le))
+        - name: RegenP99ByScope
+          query: histogram_quantile(0.99, sum(rate(cilium_endpoint_regeneration_time_stats_seconds_bucket[%v])) by (le, scope))
 
     - Identifier: CiliumCPUUsage
       Method: GenericPrometheusQuery


### PR DESCRIPTION
The scale-5 CL2 run keeps tripping the PolicyImplementationDelay median gate even though steady-state p50 is around 0.01s. cilium_policy_implementation_delay is one histogram sample per policy object, and each sample equals the full endpoint-regeneration fan-out. A scale test only creates a handful of NetworkPolicy objects, so the distribution is low-sample and strongly bimodal: a fast mode of no-op revision bumps and a slow mode of real BPF regenerations. A healthy run confirms the regime, only about seven samples, so one realization landing in the 0.1 to 0.25 bucket is enough to drag the interpolated median across 0.1 with no real slowdown. That is the same interpolation fragility #47170 already tamed for p99, now surfacing at the median.

Bumping the 0.1 threshold would mask a genuine median-realization regression, and the aggregate median the gate prints cannot on its own tell a stray-sample interpolation blip apart from a real transient slowdown. So instead of a speculative behavioural change I add reported-only diagnostics with no threshold, so they cannot mask anything, the same pattern we kept for p90 and p99, to both cilium-metrics.yaml and its netpol twin.

Inside the existing PolicyImplementationDelay measurement I add SampleCount and a per-source split to expose the low-sample regime and how much source=k8s contributes, and FracUnder100ms, the interpolation-free fraction of realizations at or under 100ms. A new EndpointRegenerationTime measurement decomposes the already-scraped cilium_endpoint_regeneration_time_stats_seconds by stage. The source and scope grouping labels are declared in dimensions so clusterloader reports one sample per label value instead of failing with "too many samples".

The discriminator on the next breach is not FracUnder100ms on its own: with 0.1 being an exact bucket edge, a median above 0.1 already means fewer than half the samples are under 100ms, so the two always move together. The tell for a stray-sample interpolation blip is instead that p90 and p99 stay at their baseline, around 1.9 and 2.4, while FracUnder100ms only dips a little below its healthy 0.75 (one sample out of seven), against a low SampleCount. A real slowdown looks different: FracUnder100ms falls hard, p90 and p99 climb, and EndpointRegenerationTime attributes the time to a stage.

I triggered a scale-5 run on this branch to confirm the diagnostics emit, https://github.com/cilium/cilium/actions/runs/29728978113 passed and reported p50 0.006, p90 1.9, p99 2.44, SampleCount about 7, FracUnder100ms 0.75. So the durable follow-up, once a breach confirms the blip, is to gate on the stable tail or on FracUnder100ms with a threshold well below 0.5 that a single stray sample cannot trip. There is no Go change and no threshold change here, only the two CI YAML files.

This PR was prepared with AIL:3.
