### PR TITLE
ci: drop EOL k8s 1.32 from the EKS test matrix

### DIFF
--- a/.github/actions/eks/k8s-versions.yaml
+++ b/.github/actions/eks/k8s-versions.yaml
@@ -1,8 +1,6 @@
 # List of k8s version for EKS tests
 ---
 include:
-  - version: "1.32"
-    region: us-west-1
   - version: "1.33"
     region: us-east-2
   - version: "1.34"


### PR DESCRIPTION
The reusable conformance-eks workflow applies the netkit / netkit-l2 datapath to every matrix entry when a bpf-datapath is requested. One of those entries was EKS 1.32 in us-west-1, whose AmazonLinux2023 AMI ships kernel 6.1. netkit needs kernel 6.7+ and CONFIG_NETKIT, so on that node image cilium-agent fails hard with "netkit device probe failed, requires kernel 6.7.0+ and CONFIG_NETKIT" and never comes up. The Cilium nodegroups never turn Ready and eksctl's managed-nodegroup CloudFormation stacks never reach CREATE_COMPLETE, so "Create EKS nodegroups" dies after ~24 minutes on the StackCreateComplete waiter, while the non-Cilium external nodegroup in the same AZ comes up in ~1.5 minutes.

Kubernetes 1.32 is EOL, so rather than special-case it by kernel just drop it from the EKS version matrix. The remaining versions (1.33, 1.34, 1.35) ship a 6.12 kernel and run netkit fine.

This PR was prepared with AIL:3.
