### PR TITLE
WIP - capture CT-insertion drop errno in e2e-upgrade

### DIFF
--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -619,6 +619,22 @@ jobs:
           script: ./.github/actions/bpftrace/scripts/check-encryption-leaks.bt
           args: ${{ steps.bpftrace-params.outputs.params }} "${{ steps.vars.outputs.enable_proxy_check }}" "${{ matrix.encryption }}"
 
+      # WIP (do not merge): a "CT: Map insertion failed" INGRESS drop shows up in
+      # this concurrent phase (GH-35010). We suspect it is a transient kernel
+      # map_locked -EBUSY on <6.15 under concurrent CT GC/flush, not a full CT
+      # map. The errno that tells the two apart is only rendered by cilium
+      # monitor, so start a background drop monitor before the concurrent phase
+      # to capture it live; the no-unexpected-packet-drops metric only says a
+      # drop happened, not why.
+      - name: WIP start CT-insertion drop monitor
+        if: ${{ steps.vars.outputs.downgrade_version != '' && steps.cilium-stable-config.outputs.skip != 'true' && steps.cilium-newest-config.outputs.skip != 'true' }}
+        shell: bash {0} # keep going even if a single command fails
+        run: |
+          for pod in $(kubectl get -n kube-system pods -l k8s-app=cilium -o name); do
+            kubectl exec -n kube-system "${pod}" -c cilium-agent -- \
+              sh -c 'nohup cilium-dbg monitor --type drop -j > /var/run/cilium/wip-ct-drop.json 2>&1 & echo $! > /var/run/cilium/wip-ct-drop.pid'
+          done
+
       - name: Run concurrent Cilium tests
         if: ${{ steps.vars.outputs.downgrade_version != '' && steps.cilium-stable-config.outputs.skip != 'true' && steps.cilium-newest-config.outputs.skip != 'true' }}
         timeout-minutes: 50
@@ -638,6 +654,39 @@ jobs:
           tests: 'no-unexpected-packet-drops'
           conn-disrupt: 'false'
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
+
+      # WIP (do not merge): stop the drop monitor and snapshot CT fill + map
+      # pressure + GC runs. A near-empty CT map with GC-correlated drops points
+      # at -EBUSY contention; a near-full map would instead mean a real -ENOMEM
+      # CT-map-full regression. Runs on always() so we still get the data when
+      # the drop check above failed the job.
+      - name: WIP capture CT-insertion drop diagnostics
+        if: ${{ always() && steps.vars.outputs.downgrade_version != '' && steps.cilium-stable-config.outputs.skip != 'true' && steps.cilium-newest-config.outputs.skip != 'true' }}
+        shell: bash {0} # keep going even if a single command fails
+        run: |
+          out="cilium-ct-drop-diag-${{ matrix.name }}.txt"
+          for pod in $(kubectl get -n kube-system pods -l k8s-app=cilium -o name); do
+            echo "===== ${pod} =====" | tee -a "$out"
+            kubectl exec -n kube-system "${pod}" -c cilium-agent -- \
+              sh -c 'kill "$(cat /var/run/cilium/wip-ct-drop.pid)" 2>/dev/null; sleep 1; true'
+            echo "--- drop monitor events (CT: Map insertion failed carries the errno) ---" | tee -a "$out"
+            kubectl exec -n kube-system "${pod}" -c cilium-agent -- \
+              sh -c 'grep -F "Map insertion failed" /var/run/cilium/wip-ct-drop.json || cat /var/run/cilium/wip-ct-drop.json' 2>&1 | tee -a "$out"
+            echo "--- CT global entry count (fill level; LRU maps evict, do not fill) ---" | tee -a "$out"
+            kubectl exec -n kube-system "${pod}" -c cilium-agent -- \
+              sh -c 'cilium-dbg bpf ct list global | wc -l' 2>&1 | tee -a "$out"
+            echo "--- CT map pressure and conntrack GC runs ---" | tee -a "$out"
+            kubectl exec -n kube-system "${pod}" -c cilium-agent -- \
+              sh -c 'cilium-dbg metrics list -o json | grep -E "map_pressure|conntrack_gc_runs" || true' 2>&1 | tee -a "$out"
+          done
+
+      - name: WIP upload CT-insertion drop diagnostics
+        if: ${{ always() && steps.vars.outputs.downgrade_version != '' && steps.cilium-stable-config.outputs.skip != 'true' && steps.cilium-newest-config.outputs.skip != 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: "cilium-ct-drop-diag-${{ matrix.name }}-${{ matrix.mode }}-${{ inputs.UID }}"
+          path: cilium-ct-drop-diag-*.txt
+          if-no-files-found: warn
 
       - name: Assert that no unencrypted packets are leaked during connectivity tests after upgrade
         if: ${{ steps.vars.outputs.downgrade_version != '' && matrix.encryption != '' && steps.cilium-stable-config.outputs.skip != 'true' && steps.cilium-newest-config.outputs.skip != 'true' }}

--- a/.github/workflows/tests-e2e-upgrade.yaml
+++ b/.github/workflows/tests-e2e-upgrade.yaml
@@ -182,6 +182,14 @@ jobs:
             echo "::notice::Including only test-l7: false configurations (${CONFIG_COUNT} configs - L3/L4 testing only)"
             echo "timeout=90" >> $GITHUB_OUTPUT
           fi
+          # WIP (do not merge): fan the matrix out to 100 copies of the lb-1
+          # minor leg (kernel 5.15) to try to reproduce the rare
+          # "CT: Map insertion failed" INGRESS drop with the drop monitor live.
+          jq '[.[] | select(.name == "lb-1" and .mode == "minor")] | .[0] as $e
+              | [range(0;100) | $e + {name: ("lb-1-" + (100 + .|tostring)[1:])}]' \
+            /tmp/generated/e2e/matrix.json > /tmp/generated/e2e/matrix.fanout.json
+          mv /tmp/generated/e2e/matrix.fanout.json /tmp/generated/e2e/matrix.json
+
           echo "Generated matrix:"
           cat /tmp/generated/e2e/matrix.json
           echo "matrix=$(jq -c . < /tmp/generated/e2e/matrix.json)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The ci-l7 upgrade concurrent phase occasionally trips no-unexpected-packet-drops with a single INGRESS "CT: Map insertion failed" drop on kernel 5.15. GH-35010 describes the same symptom as a transient kernel map_locked -EBUSY under concurrent CT GC/flush on kernels before 6.15, not a genuinely full CT map, but the metric the test reads only tells us a drop happened, not why.

The errno that separates -EBUSY (benign contention) from -ENOMEM (a real CT-map-full regression) is decoded by the datapath and only rendered by cilium monitor, so a post-hoc snapshot cannot recover it. This starts a background drop monitor before the concurrent phase to capture the event live, and after the drop check it snapshots the CT global entry count, the cilium_bpf_map_pressure for the CT maps and the conntrack GC run count. A near-empty CT map with GC-correlated drops confirms contention; a near-full map would point at a real regression and justify a source fix instead of a kernel-version-gated tolerance.

This is instrumentation only. It does not change the pass or fail of any test and is not meant to merge; it is here to capture the discriminating data the next time the drop reproduces.

This PR was prepared with AIL:4.