### PR TITLE
.github: tolerate transient artifact upload resets in post-logic

### DIFF
--- a/.github/actions/post-logic/action.yaml
+++ b/.github/actions/post-logic/action.yaml
@@ -41,6 +41,10 @@ runs:
 
     - name: Upload artifacts
       if: ${{ always() && inputs.job_status != 'success' }}
+      # A transient reset while finalizing the upload (e.g. FinalizeArtifact
+      # ECONNRESET) must not fail a job whose tests already passed: these steps
+      # only ship diagnostics and the job verdict is set by earlier steps.
+      continue-on-error: true
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: "cilium-sysdumps-${{ inputs.artifacts_suffix }}"
@@ -48,6 +52,7 @@ runs:
 
     - name: Upload JUnits [junit]
       if: ${{ always() }}
+      continue-on-error: true
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: "cilium-junits-${{ inputs.artifacts_suffix }}"
@@ -58,6 +63,7 @@ runs:
       # as features might have been captured in a previous step outside of this
       # composite action.
       if: ${{ always() }}
+      continue-on-error: true
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: "features-tested-${{ inputs.artifacts_suffix }}"


### PR DESCRIPTION
The common post-logic composite uploads sysdumps, JUnit XML and the features-tested JSON at the end of a job. These steps run under if: always() and only ship diagnostics, but a transient reset while the upload is being finalized hard-fails the whole job even when every connectivity test already passed. actions/upload-artifact does not retry FinalizeArtifact on ECONNRESET (actions/upload-artifact#560), so one blip on a diagnostic upload turns a green run red. This is the failure mode tracked in GH-46080, and I hit it again on a ci-l7 leg where all the datapath tests passed and the only error was a FinalizeArtifact ECONNRESET.

This marks the three upload-artifact steps continue-on-error so a finalize reset degrades to a warning instead of failing the job. It cannot hide a real failure: the job verdict is decided by the earlier test steps, which are not continue-on-error, and propagated through needs.setup-and-test.result, and nothing downstream re-derives pass or fail from the uploaded files. I kept this scoped to the post-logic steps and deliberately left the inline upload sites that guard with if-no-files-found: error alone, since that guard is there on purpose to make a missing artifact loud.

This PR was prepared with AIL:4.