### PR TITLE
ipam: Wait for ENI netlink iface before configuring ingress routes

### DIFF
--- a/daemon/infraendpoints/infra_ip_allocation.go
+++ b/daemon/infraendpoints/infra_ip_allocation.go
@@ -292,12 +292,11 @@ func (r *infraIPAllocator) reallocateRouterIPs(ctx context.Context, family node.
 			return nil, fmt.Errorf("failed to create router info: %w", err)
 		}
 
-		// wait for ENI to be up and running before configuring routes and rules.
-		// This avoids spurious errors where netlink is not able to find
-		// the ifindex by its MAC because the ENI is not showing up yet.
-		if r.daemonConfig.IPAM == ipamOption.IPAMENI {
+		// Wait for the ENI to show up before configuring routes and rules, to
+		// avoid netlink failing to find the ifindex by its MAC.
+		if r.daemonConfig.IPAM == ipamOption.IPAMENI || r.daemonConfig.IPAM == ipamOption.IPAMAlibabaCloud {
 			if err := r.waitForENI(ctx, result.PrimaryMAC); err != nil {
-				r.logger.Warn("unable to find ENI netlink interface, this will likely lead to an error in configuring the router routes and rules",
+				r.logger.Error("Unable to find ENI netlink interface, this will likely lead to an error in configuring the router routes and rules",
 					logfields.MACAddr, result.PrimaryMAC,
 				)
 			}
@@ -425,7 +424,7 @@ func (r *infraIPAllocator) allocateHealthIPs(oldV4HealthIP netip.Addr, oldV6Heal
 	return nil
 }
 
-func (r *infraIPAllocator) allocateIngressIPs(oldV4IngressIP net.IP, oldV6IngressIP net.IP) error {
+func (r *infraIPAllocator) allocateIngressIPs(ctx context.Context, oldV4IngressIP net.IP, oldV6IngressIP net.IP) error {
 	if !r.daemonConfig.EnableEnvoyConfig {
 		return nil
 	}
@@ -475,6 +474,15 @@ func (r *infraIPAllocator) allocateIngressIPs(oldV4IngressIP net.IP, oldV6Ingres
 			if ingressRouting, err := r.parseRoutingInfo(result); err != nil {
 				r.logger.Warn("Unable to allocate ingress information for ENI", logfields.Error, err)
 			} else {
+				// The ingress IP may sit on a different ENI than the router IP, so
+				// wait for its ENI to show up before configuring routes and rules,
+				// to avoid netlink failing to find the ifindex by its MAC.
+				if err := r.waitForENI(ctx, result.PrimaryMAC); err != nil {
+					r.logger.Error("Unable to find ENI netlink interface, this will likely lead to an error in configuring the ingress routes and rules",
+						logfields.MACAddr, result.PrimaryMAC,
+					)
+				}
+
 				if err := ingressRouting.Configure(
 					result.IP,
 					r.mtuManager.GetDeviceMTU(),
@@ -553,7 +561,7 @@ func (r *infraIPAllocator) AllocateIPs(ctx context.Context) error {
 		return fmt.Errorf("failed to allocate service loopback IPs: %w", err)
 	}
 
-	if err := r.allocateIngressIPs(localNode.IPv4IngressIP, localNode.IPv6IngressIP); err != nil {
+	if err := r.allocateIngressIPs(ctx, localNode.IPv4IngressIP, localNode.IPv6IngressIP); err != nil {
 		return fmt.Errorf("failed to allocate ingress IPs: %w", err)
 	}
 


### PR DESCRIPTION
The ci-kpr EKS check-log-errors validator flags a cilium-agent warning from daemon/infraendpoints/infra_ip_allocation.go: "unable to find ifindex for interface MAC: interface with MAC ... not found". In ENI IPAM mode the operator creates ENIs asynchronously, so at agent startup a lookup of the ifindex by MAC can race the ENI's netlink interface appearing and fail.

The router path already guards against this: commit 60faea184e added a waitForENI call before it configures the router routes and rules. The ingress path never got the same guard, so allocateIngressIPs calls Configure without waiting, and it hits the race when the ingress IP lives on a different ENI than the router IP. The router and ingress IPs are separate allocations from the ENI pool, so on a multi-ENI node the ingress IP can sit on a secondary ENI that the router-path wait never covered.

This mirrors the router guard into the ingress path. allocateIngressIPs now takes a context and, before configuring the ingress routes and rules, waits for the ENI owning its own PrimaryMAC to show up. This is not masking: if the ENI genuinely never appears, waitForENI returns after the same bounded backoff, Configure still fails, and the warning still fires. Only the transient async-creation window is absorbed, which is exactly what commit 60faea184e was written to close.

While mirroring, two adjustments apply to both paths. Configure also runs in AlibabaCloud ENI mode and waitForENI only polls netlink for a MAC, so the wait is gated on ENI or AlibabaCloud rather than ENI alone. The "interface not found" message is raised from warn to error, since it precedes a route configuration that is about to fail.

The ingress code path is present on both main and v1.19, so this needs to reach v1.19 as well.

This PR was prepared with AIL:3.

```release-note
Fix a spurious "unable to find ifindex for interface MAC" agent warning on EKS ENI IPAM by waiting for the ENI netlink interface before configuring ingress routes and rules.
```
