### PR TITLE
cilium-cli: tolerate "out of interfaces" warns from a single node

### DIFF
--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -45,6 +45,53 @@ func (r regexMatcher) IsMatch(log string) bool {
 	return r.MatchString(log)
 }
 
+// thresholdException tolerates a bad log message while it affects no more than
+// maxDistinct distinct values of the distinguishingField log field, used to
+// tell otherwise-equal message lines apart, and fails beyond that. seen tracks
+// the distinct values observed so far within a single pod's log stream.
+type thresholdException struct {
+	matcher             logMatcher
+	distinguishingField string
+	maxDistinct         int
+	seen                map[string]struct{}
+}
+
+// thresholdExceptions is the set of threshold exceptions in effect, carrying
+// their per-pod state. Create a fresh copy per pod with newTracker.
+type thresholdExceptions []thresholdException
+
+// newTracker returns a copy of the exceptions with empty per-pod state, ready
+// to record the messages of a single pod's log stream.
+func (tes thresholdExceptions) newTracker() thresholdExceptions {
+	tracker := make(thresholdExceptions, len(tes))
+	for i, te := range tes {
+		te.seen = make(map[string]struct{})
+		tracker[i] = te
+	}
+	return tracker
+}
+
+// recordFailure records an occurrence of a bad log message and reports whether
+// it should count as a failure. A message not governed by any threshold
+// exception always counts; a governed one counts only once it has been seen for
+// more than maxDistinct distinct values of its field.
+func (tes thresholdExceptions) recordFailure(justMsg, line string) bool {
+	for i := range tes {
+		te := &tes[i]
+		if !te.matcher.IsMatch(line) {
+			continue
+		}
+		value := extractValueFromLog(line, te.distinguishingField)
+		if value == "" {
+			// Missing field: key on the whole line so it can't collapse into one.
+			value = line
+		}
+		te.seen[value] = struct{}{}
+		return len(te.seen) > te.maxDistinct
+	}
+	return true
+}
+
 // NoErrorsInLogs checks whether there are no error messages in cilium-agent
 // logs. The error messages are defined in badLogMsgsWithExceptions, which key
 // is an error message, while values is a list of ignored messages.
@@ -72,6 +119,12 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, extraExc
 		envoyExternalTargetTLSWarning, envoyExternalOtherTargetTLSWarning,
 		hubbleUIEnvVarFallback, k8sClientNetworkStatusError, bgpAlphaResourceDeprecation, ccgAlphaResourceDeprecation,
 		k8sEndpointDeprecatedWarn, proxylibDeprecatedWarn, certloaderInitialLoadWarn, localKeyAlreadyAllocated}
+
+	warningThresholdExceptions := thresholdExceptions{
+		// Benign for one node at ENI capacity, a real IP-starvation signal for
+		// several. cf. https://github.com/cilium/cilium/issues/42092
+		{matcher: instanceOutOfInterfaces, distinguishingField: "name", maxDistinct: 1},
+	}
 
 	if ciliumVersion.LT(semver.MustParse("1.18.0")) {
 		errorLogExceptions = append(errorLogExceptions, linkNotFound, removeInexistentID)
@@ -110,6 +163,7 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, extraExc
 	}
 	return &noErrorsInLogs{
 		errorMsgsWithExceptions: errorMsgsWithExceptions,
+		thresholdExceptions:     warningThresholdExceptions,
 		ScenarioBase:            check.NewScenarioBase(),
 		ciliumVersion:           ciliumVersion,
 		startTime:               startTime,
@@ -120,6 +174,7 @@ type noErrorsInLogs struct {
 	check.ScenarioBase
 
 	errorMsgsWithExceptions map[string][]logMatcher
+	thresholdExceptions     thresholdExceptions
 	ciliumVersion           semver.Version
 	mostCommonFailureLog    string
 	mostCommonFailureCount  int
@@ -343,6 +398,8 @@ func (n *noErrorsInLogs) podContainers(pod *corev1.Pod) podContainers {
 func (n *noErrorsInLogs) findUniqueFailures(logs []byte) (map[string]int, map[string]string) {
 	uniqueFailures := make(map[string]int)
 	exampleLogLine := make(map[string]string)
+	// Per-pod threshold state, reset for each pod's log stream.
+	thresholdExceptions := n.thresholdExceptions.newTracker()
 	for chunk := range bytes.SplitSeq(logs, []byte("\n")) {
 		msg := string(chunk)
 		for fail, ignoreMsgs := range n.errorMsgsWithExceptions {
@@ -360,8 +417,10 @@ func (n *noErrorsInLogs) findUniqueFailures(logs []byte) (map[string]int, map[st
 						// Matching didn't work, fallback to previous behaviour
 						justMsg = msg
 					}
-					count := uniqueFailures[justMsg]
-					uniqueFailures[justMsg] = count + 1
+					if !thresholdExceptions.recordFailure(justMsg, msg) {
+						continue
+					}
+					uniqueFailures[justMsg]++
 					exampleLogLine[justMsg] = msg
 				}
 			}
@@ -501,6 +560,7 @@ const (
 
 	k8sEndpointDeprecatedWarn stringMatcher = "v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice" // cf. https://github.com/cilium/cilium/issues/39105
 	proxylibDeprecatedWarn    stringMatcher = "The support for Envoy Go Extensions (proxylib) has been deprecated"          // cf. https://github.com/cilium/cilium/issues/38224
+	instanceOutOfInterfaces   stringMatcher = "Instance is out of interfaces"                                               // AWS ENI-at-capacity; benign for one node, fails if several nodes hit it. cf. https://github.com/cilium/cilium/issues/42092
 
 	certloaderInitialLoadWarn stringMatcher = certloader.InitialLoadWarn // Expected when certificates are not yet mounted.
 

--- a/cilium-cli/connectivity/tests/errors_test.go
+++ b/cilium-cli/connectivity/tests/errors_test.go
@@ -192,6 +192,62 @@ func TestLeaderElectionLeaseLockErrorMatcher(t *testing.T) {
 	}
 }
 
+func TestInstanceOutOfInterfacesThreshold(t *testing.T) {
+	line := func(node string) string {
+		return `time=2026-07-15T20:46:30Z level=warning msg="Instance is out of interfaces" subsys=ipam-allocator-aws name=` + node + ` instanceID=i-0abc`
+	}
+
+	for _, tt := range []struct {
+		name       string
+		lines      []string
+		wantFailed bool
+	}{
+		{
+			name:       "one node at capacity is tolerated",
+			lines:      []string{line("ip-1.compute.internal")},
+			wantFailed: false,
+		},
+		{
+			name: "one node logging repeatedly is still tolerated",
+			lines: []string{
+				line("ip-1.compute.internal"),
+				line("ip-1.compute.internal"),
+				line("ip-1.compute.internal"),
+			},
+			wantFailed: false,
+		},
+		{
+			name: "two distinct nodes at capacity is a failure",
+			lines: []string{
+				line("ip-1.compute.internal"),
+				line("ip-2.compute.internal"),
+			},
+			wantFailed: true,
+		},
+		{
+			name: "many distinct nodes at capacity is a failure",
+			lines: []string{
+				line("ip-1.compute.internal"),
+				line("ip-2.compute.internal"),
+				line("ip-3.compute.internal"),
+			},
+			wantFailed: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var zt time.Time
+			s := NoErrorsInLogs(semver.MustParse("1.19.0"), defaults.LogCheckLevels, nil, "one.one.one.one", "k8s.io", zt).(*noErrorsInLogs)
+			logs := strings.Join(tt.lines, "\n") + "\n"
+			fails, _ := s.findUniqueFailures([]byte(logs))
+			if tt.wantFailed {
+				assert.Contains(t, fails, "Instance is out of interfaces")
+			} else {
+				assert.NotContains(t, fails, "Instance is out of interfaces")
+			}
+		})
+	}
+}
+
 func TestExtractPathFromLog(t *testing.T) {
 	_, thisPath, _, _ := runtime.Caller(0)
 	repoDir, _ := filepath.Abs(filepath.Join(thisPath, "..", "..", "..", ".."))


### PR DESCRIPTION
On EKS with ENI IPAM, when a node reaches its ENI/interface budget the cilium-operator logs a warning "Instance is out of interfaces". The operator itself treats this as "not a failure scenario", but the check-log-errors step in the cilium-cli connectivity suite was failing the whole run on it even though every connectivity test passed. Issue 42092 tracked this exact signature and was auto-closed stale without a fix.

Rather than adding a blanket allowlist entry, which would also hide the case where several nodes run out of interfaces at once and point at genuine IP starvation, this adds a threshold-exception mechanism. Each occurrence of a governed bad log message is recorded, and it only counts as a failure once it has affected more than a bounded number of distinct values of a chosen log field. The operator log line carries the node in its "name" field, so "Instance is out of interfaces" is tolerated for one distinct node and fails the run for two or more.

Counting distinct nodes rather than log lines means a single node that logs the message several times is still treated as one node, so the check does not depend on how the operator throttles the message. The threshold state is per pod, created fresh for each pod's log stream, and the per-container checks run sequentially so no locking is needed. It does not account for an operator leader change mid-run, whose occurrences would be split across two pods' logs, but that is no worse than the blanket allowlist it replaces.

The mechanism lives in the cilium-cli tree vendored into main; on the stable branches the CLI is a separate repository, so this targets main only and is not backported.

This PR was prepared with AIL:3.
