### PR TITLE
gha: capture EKS node forensics on mid-test worker termination

### DIFF
--- a/.github/actions/eks-node-forensics/action.sh
+++ b/.github/actions/eks-node-forensics/action.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Capture forensic data about the EKS worker nodes and their backing EC2
+# instances after a test failure. Every probe is best-effort: we deliberately do
+# NOT set -e, so a single failing command (e.g. the node is already gone) never
+# aborts the rest of the collection. The point is to answer, for the next
+# occurrence, "who terminated these instances?" without having to guess.
+
+set -u -o pipefail
+
+ARTIFACTS_SUFFIX="${1:?artifacts_suffix argument is required}"
+
+OUTDIR="$(mktemp -d)"
+echo "Collecting EKS node forensics into ${OUTDIR}"
+
+# Kubernetes view: which nodes still exist, and the recent events (cordon,
+# NotReady, DeletingNode "because it does not exist in the cloud provider", ...).
+kubectl get nodes -o wide > "${OUTDIR}/nodes.txt" 2>&1
+kubectl get nodes -o json > "${OUTDIR}/nodes.json" 2>&1
+kubectl get events -A --sort-by=.lastTimestamp > "${OUTDIR}/events.txt" 2>&1
+
+# Map every node to its backing EC2 instance via the providerID
+# (aws:///<az>/<instance-id>) and interrogate AWS about each instance.
+PROVIDER_IDS=$(kubectl get nodes -o jsonpath='{range .items[*]}{.spec.providerID}{"\n"}{end}' 2>/dev/null)
+
+if [ -z "${PROVIDER_IDS}" ]; then
+  echo "No node providerIDs found (all nodes may already be gone)." | tee "${OUTDIR}/no-nodes.txt"
+fi
+
+echo "${PROVIDER_IDS}" | while read -r provider_id; do
+  [ -z "${provider_id}" ] && continue
+
+  # providerID looks like aws:///us-west-2b/i-0123456789abcdef0
+  instance_id="${provider_id##*/}"
+  case "${instance_id}" in
+    i-*) ;;
+    *)
+      echo "Skipping unexpected providerID: ${provider_id}"
+      continue
+      ;;
+  esac
+
+  echo "=== Forensics for instance ${instance_id} (${provider_id}) ==="
+
+  # EC2 instance state and, most importantly, the state-transition reason which
+  # for a fleet-wide event reads e.g. "Server.InsufficientInstanceCapacity" or a
+  # user/service-initiated shutdown.
+  aws ec2 describe-instances --instance-ids "${instance_id}" \
+    --query 'Reservations[].Instances[].{state:State.Name,reason:StateTransitionReason,stateReason:StateReason}' \
+    > "${OUTDIR}/ec2-describe-${instance_id}.json" 2>&1
+
+  # ASG scaling activities mentioning this instance tell us whether the
+  # Auto Scaling Group itself scaled the instance in.
+  aws autoscaling describe-scaling-activities \
+    --query "Activities[?contains(Description, '${instance_id}')]" \
+    > "${OUTDIR}/asg-activities-${instance_id}.json" 2>&1
+
+  # CloudTrail is the decisive probe: it names the principal behind the
+  # TerminateInstances call, distinguishing an AWS-side region-scoped event from
+  # our own pool-manager / eksctl teardown.
+  aws cloudtrail lookup-events \
+    --lookup-attributes "AttributeKey=ResourceName,AttributeValue=${instance_id}" \
+    > "${OUTDIR}/cloudtrail-${instance_id}.json" 2>&1
+done
+
+TARBALL="eks-node-forensics-${ARTIFACTS_SUFFIX}.tar.gz"
+tar -czf "${TARBALL}" -C "${OUTDIR}" .
+echo "Wrote ${TARBALL}"

--- a/.github/actions/eks-node-forensics/action.yml
+++ b/.github/actions/eks-node-forensics/action.yml
@@ -1,0 +1,30 @@
+name: "EKS node forensics"
+description: |
+  On a test failure, capture forensic data about the EKS worker nodes and their
+  backing EC2 instances (Kubernetes node/event state, EC2 instance state and
+  state-transition reason, ASG scaling activities and, crucially, the CloudTrail
+  lookup that reveals the TerminateInstances principal). This lets a fleet-wide
+  or region-scoped AWS infrastructure termination be told apart from a Cilium
+  datapath regression during triage. Every probe is best-effort and never fails
+  the job.
+inputs:
+  artifacts_suffix:
+    description: "Suffix added to the forensics artifact name. Used to distinguish artifacts from parallel matrix legs."
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Capture EKS node forensics
+      shell: bash {0} # Disable default fail-fast so that every probe runs independently
+      env:
+        ARTIFACTS_SUFFIX: ${{ inputs.artifacts_suffix }}
+      run: |
+        bash .github/actions/eks-node-forensics/action.sh "${ARTIFACTS_SUFFIX}"
+
+    - name: Upload EKS node forensics
+      if: ${{ always() }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: "eks-node-forensics-${{ inputs.artifacts_suffix }}"
+        path: eks-node-forensics-*.tar.gz
+        if-no-files-found: ignore

--- a/.github/actions/post-logic/action.yaml
+++ b/.github/actions/post-logic/action.yaml
@@ -16,6 +16,9 @@ inputs:
   always_capture_sysdump:
     description: "Always capture sysdump, regardless of test status; the result is uploaded as artifact only in case of test failure"
     default: "false"
+  capture_eks_node_forensics:
+    description: "On an EKS failure, capture forensics about the worker nodes and their backing EC2 instances (EC2 state, ASG activities, CloudTrail TerminateInstances principal) to tell a fleet-wide AWS termination apart from a Cilium regression."
+    default: "false"
   junits-directory:
     description: "Directory where JUnit XML files are stored."
     default: cilium-junits
@@ -38,6 +41,15 @@ runs:
         kubectl get pods --all-namespaces -o wide
         cilium status
         cilium sysdump --output-filename "cilium-sysdump-${{ inputs.artifacts_suffix }}"
+
+    # Capture EKS node/EC2 forensics before the caller triggers cluster
+    # deletion, so a fleet-wide AWS termination (nodes vanish mid-test) is
+    # diagnosable rather than mis-triaged as a Cilium datapath regression.
+    - name: EKS node forensics
+      if: ${{ always() && inputs.job_status == 'failure' && inputs.capture_eks_node_forensics == 'true' }}
+      uses: ./.github/actions/eks-node-forensics
+      with:
+        artifacts_suffix: "${{ inputs.artifacts_suffix }}"
 
     - name: Upload artifacts
       if: ${{ always() && inputs.job_status != 'success' }}

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -531,6 +531,17 @@ jobs:
           cilium status --wait --interactive=false --wait-duration=10m
           kubectl get pods -n kube-system
 
+      # Snapshot the worker node count while the cluster is known-healthy. If the
+      # connectivity test later fails with fewer nodes than this, it points at a
+      # mid-test infrastructure node loss (e.g. a fleet-wide AWS EC2 termination)
+      # rather than a Cilium regression.
+      - name: Snapshot node count
+        id: node-count
+        run: |
+          NODE_COUNT=$(kubectl get nodes --no-headers 2>/dev/null | wc -l)
+          echo "expected=${NODE_COUNT}" >> $GITHUB_OUTPUT
+          echo "Snapshotted ${NODE_COUNT} nodes after Cilium became ready"
+
       - name: Add external targets to the cluster
         uses: ./.github/actions/generic-external-targets
         id: external_targets
@@ -621,6 +632,24 @@ jobs:
           test-concurrency: ${{ env.test_concurrency }}
           extra-connectivity-test-flags: ${{ steps.vars-conn.outputs.connectivity_test_defaults }}
 
+      # If the connectivity test failed and the cluster has fewer nodes than the
+      # snapshot taken while it was healthy, the failure is almost certainly a
+      # mid-test infrastructure node loss (e.g. a fleet-wide AWS EC2
+      # termination), not a Cilium regression. Emit a warning so triage isn't
+      # sent hunting a datapath bug; the eks-node-forensics artifact has the
+      # CloudTrail principal behind the terminate.
+      - name: Warn on mid-test node loss
+        if: ${{ always() && steps.run-tests.outcome == 'failure' }}
+        env:
+          EXPECTED_NODES: ${{ steps.node-count.outputs.expected }}
+        run: |
+          LIVE_NODES=$(kubectl get nodes --no-headers 2>/dev/null | wc -l)
+          echo "Expected ${EXPECTED_NODES:-unknown} nodes, currently see ${LIVE_NODES}"
+          if [ -n "${EXPECTED_NODES}" ] && [ "${LIVE_NODES}" -lt "${EXPECTED_NODES}" ]; then
+            LOST=$((EXPECTED_NODES - LIVE_NODES))
+            echo "::warning::EKS lost ${LOST} worker nodes mid-test (infra) — see eks-node-forensics artifact"
+          fi
+
       - name: Run common post steps
         if: ${{ always() && steps.install-cilium.outcome != 'skipped' }}
         uses: ./.github/actions/post-logic
@@ -628,6 +657,7 @@ jobs:
           artifacts_suffix: "eks-${{ join(matrix.*, '-') }}-${{ inputs.UID }}"
           job_status: "${{ job.status }}"
           capture_features_tested: false
+          capture_eks_node_forensics: true
 
       # Surface quarantined failures. continue-on-error makes the job (and thus
       # the workflow) succeed even when a step failed, so without this the


### PR DESCRIPTION
On 2026-07-16 a region-scoped AWS EC2 termination in us-west-2 killed the running EKS worker instances of every conformance cluster that had nodes at that instant. Three independent runs in three different VPCs lost their nodes at the same second, and the connectivity tests then failed with pods NotFound, ping exit 1, curl 137 and exec "unable to upgrade connection". The failure was mis-triaged as a Cilium datapath regression, because nothing in the logs pointed at the node loss and the actor behind the termination lives only in CloudTrail, which we never captured.

This adds forensics so the next occurrence is diagnosable rather than a guessing game. A new composite action eks-node-forensics dumps the Kubernetes node and event state and, for each node's backing EC2 instance resolved from its providerID, the EC2 state and state-transition reason, the ASG scaling activities that mention it, and the CloudTrail lookup that names the TerminateInstances principal. Every probe is best-effort and never fails the job; the result is tarred and uploaded as an artifact.

post-logic gains a capture_eks_node_forensics input, default false, and runs the action on an EKS failure before the caller triggers cluster deletion, so the instances are still queryable. conformance-eks opts in, snapshots the worker node count while the cluster is healthy, and if the connectivity test later fails with fewer live nodes emits a warning pointing triage at the infrastructure node loss and the forensics artifact instead of a datapath bug.

This does not change what any test does or fix the node loss itself; it only makes a fleet-wide AWS termination distinguishable from a Cilium regression. It should reach v1.19, where this class of failure has been recurring.

This commit was prepared with AIL:3.
