### PR TITLE
gha: dump nodegroup CloudFormation failure events on create failure

### DIFF
--- a/.github/actions/setup-eks-nodegroup/action.yml
+++ b/.github/actions/setup-eks-nodegroup/action.yml
@@ -168,3 +168,30 @@ runs:
         fi
 
         eksctl create nodegroup -f ./eks-nodegroups.yaml ${TIMEOUT_ARG}
+
+    - name: Dump nodegroup CloudFormation failure events
+      if: failure()
+      shell: bash
+      run: |
+        # When a managed nodegroup fails to create, eksctl only prints
+        # "waiter state transitioned to Failure" and exits, so the actual
+        # cause (capacity, subnet, IAM, bootstrap) never reaches the logs.
+        # Dump the failed CloudFormation resource events, which carry the
+        # ResourceStatusReason, so the next occurrence is diagnosable.
+        STACKS=$(aws cloudformation list-stacks \
+          --region ${{ inputs.region }} \
+          --query "StackSummaries[?starts_with(StackName, 'eksctl-${{ inputs.cluster_name }}-nodegroup-')].StackName" \
+          --output text 2>/dev/null || true)
+        if [ -z "$STACKS" ]; then
+          echo "No eksctl nodegroup stacks found for cluster ${{ inputs.cluster_name }}."
+          exit 0
+        fi
+        for stack in $STACKS; do
+          echo "::group::CloudFormation failure events for $stack"
+          aws cloudformation describe-stack-events \
+            --region ${{ inputs.region }} \
+            --stack-name "$stack" \
+            --query "StackEvents[?contains(ResourceStatus, 'FAILED')].{Time:Timestamp,Resource:LogicalResourceId,Type:ResourceType,Status:ResourceStatus,Reason:ResourceStatusReason}" \
+            --output table 2>&1 || true
+          echo "::endgroup::"
+        done


### PR DESCRIPTION
When a managed EKS nodegroup fails to create, eksctl prints only "waiter state transitioned to Failure" and exits non-zero, so the real cause of the failure, whether insufficient capacity, subnet exhaustion, an IAM problem or a bootstrap error, never reaches the CI logs. The ci-kpr EKS jobs hit this on the ng-arm64 nodegroup in us-west-2 and there was nothing in the logs to tell whether it was an AWS capacity event or a configuration problem.

This adds a failure-only step to the setup-eks-nodegroup action that, when the create step fails, lists the eksctl nodegroup CloudFormation stacks for the cluster and dumps their FAILED resource events, including the ResourceStatusReason that carries the actual cause. The step runs only on failure and only reads state, so it does not change the success path and cannot mask a real failure; it just makes the next occurrence diagnosable.

It should reach v1.19, where these nodegroup-create failures have been recurring.

This commit was prepared with AIL:3.

