### PR TITLE
cilium-cli/status: support custom agent DaemonSet name / pod selector

### DIFF
--- a/cilium-cli/cli/status.go
+++ b/cilium-cli/cli/status.go
@@ -69,6 +69,8 @@ func newCmdStatus() *cobra.Command {
 	cmd.Flags().StringVarP(&params.Output, "output", "o", status.OutputSummary, "Output format. One of: json, summary")
 	cmd.Flags().BoolVar(&params.Interactive, "interactive", true, "Refresh the status summary output after each retry when --wait flag is specified")
 	cmd.Flags().BoolVar(&params.Verbose, "verbose", false, "Print more verbose error / log messages")
+	cmd.Flags().StringVar(&params.AgentDaemonSetName, "agent-daemonset-name", defaults.AgentDaemonSetName, "Name of cilium agent daemonset")
+	cmd.Flags().StringVar(&params.AgentPodSelector, "agent-pod-selector", defaults.AgentPodSelector, "Label on cilium-agent pods to select with")
 
 	return cmd
 }

--- a/cilium-cli/status/k8s.go
+++ b/cilium-cli/status/k8s.go
@@ -67,6 +67,13 @@ type K8sStatusParameters struct {
 	// Verbose increases the verbosity of certain output, such as Cilium
 	// error logs on failure.
 	Verbose bool
+
+	// AgentDaemonSetName is the name of the Cilium agent DaemonSet. Defaults
+	// to defaults.AgentDaemonSetName when empty.
+	AgentDaemonSetName string
+	// AgentPodSelector is the label selector used to find Cilium agent pods.
+	// Defaults to defaults.AgentPodSelector when empty.
+	AgentPodSelector string
 }
 
 type K8sStatusCollector struct {
@@ -87,6 +94,12 @@ type k8sImplementation interface {
 }
 
 func NewK8sStatusCollector(client k8sImplementation, params K8sStatusParameters) (*K8sStatusCollector, error) {
+	if params.AgentDaemonSetName == "" {
+		params.AgentDaemonSetName = defaults.AgentDaemonSetName
+	}
+	if params.AgentPodSelector == "" {
+		params.AgentPodSelector = defaults.AgentPodSelector
+	}
 	return &K8sStatusCollector{
 		client: client,
 		params: params,
@@ -473,16 +486,19 @@ func (k *K8sStatusCollector) logComponentTask(status *Status, namespace, deploym
 
 func (k *K8sStatusCollector) status(ctx context.Context, cancel context.CancelFunc) *Status {
 	status := newStatus()
+	agentDaemonSetName := k.params.AgentDaemonSetName
+	agentPodSelector := k.params.AgentPodSelector
+	status.AgentDaemonSetName = agentDaemonSetName
 	tasks := []statusTask{
 		{
-			name: defaults.AgentDaemonSetName,
+			name: agentDaemonSetName,
 			task: func(_ context.Context) error {
-				_, err := k.daemonSetStatus(ctx, status, defaults.AgentDaemonSetName)
+				_, err := k.daemonSetStatus(ctx, status, agentDaemonSetName)
 				status.mutex.Lock()
 				defer status.mutex.Unlock()
 
 				if err != nil {
-					status.AddAggregatedError(defaults.AgentDaemonSetName, defaults.AgentDaemonSetName, err)
+					status.AddAggregatedError(agentDaemonSetName, agentDaemonSetName, err)
 					status.CollectionError(err)
 				}
 
@@ -685,7 +701,7 @@ func (k *K8sStatusCollector) status(ctx context.Context, cancel context.CancelFu
 
 	// for the sake of sanity, don't get pod logs more than once
 	agentLogsOnce := sync.Once{}
-	err := k.podStatus(ctx, status, defaults.AgentDaemonSetName, defaults.AgentPodSelector, func(_ context.Context, status *Status, name string, pod *corev1.Pod) {
+	err := k.podStatus(ctx, status, agentDaemonSetName, agentPodSelector, func(_ context.Context, status *Status, name string, pod *corev1.Pod) {
 		if pod.Status.Phase == corev1.PodRunning {
 			// extract container status
 			var containerStatus *corev1.ContainerStatus
@@ -735,8 +751,8 @@ func (k *K8sStatusCollector) status(ctx context.Context, cancel context.CancelFu
 					status.mutex.Lock()
 					defer status.mutex.Unlock()
 
-					status.parseStatusResponse(defaults.AgentDaemonSetName, pod.Name, s, err)
-					status.parseEndpointsResponse(defaults.AgentDaemonSetName, pod.Name, eps, epserr)
+					status.parseStatusResponse(agentDaemonSetName, pod.Name, s, err)
+					status.parseEndpointsResponse(agentDaemonSetName, pod.Name, eps, epserr)
 					status.CiliumStatus[pod.Name] = s
 					status.CiliumEndpoints[pod.Name] = eps
 
@@ -749,7 +765,7 @@ func (k *K8sStatusCollector) status(ctx context.Context, cancel context.CancelFu
 				},
 			})
 			agentLogsOnce.Do(func() { // in a sync.Once so we don't waste time retrieving lots of logs
-				tasks = append(tasks, k.logComponentTask(status, pod.Namespace, defaults.AgentDaemonSetName, pod.Name, defaults.AgentContainerName, containerStatus))
+				tasks = append(tasks, k.logComponentTask(status, pod.Namespace, agentDaemonSetName, pod.Name, defaults.AgentContainerName, containerStatus))
 			})
 		}
 	})

--- a/cilium-cli/status/k8s_test.go
+++ b/cilium-cli/status/k8s_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"testing"
 	"time"
 
@@ -258,7 +259,7 @@ func TestStatusCustomAgentDaemonSetName(t *testing.T) {
 	assert.NotNil(t, client)
 
 	const (
-		customDSName     = "cilium-v1-16-0"
+		customDSName      = "cilium-v1-16-0"
 		customPodSelector = "k8s-app=cilium-v1-16-0"
 	)
 
@@ -284,4 +285,29 @@ func TestStatusCustomAgentDaemonSetName(t *testing.T) {
 	formatted := status.Format()
 	assert.Contains(t, formatted, "Cilium:")
 	assert.Contains(t, formatted, customDSName)
+
+	// Not-ready custom DaemonSet: Errors and Format()'s Cilium summary must key off the
+	// custom name (not defaults.AgentDaemonSetName), otherwise the banner would show OK.
+	client.reset()
+	client.setDaemonSet("kube-system", customDSName, customPodSelector, 3, 1, 1, 2, 3, 1, 1)
+	status, err = collector.Status(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, status)
+	assert.Contains(t, status.Errors, customDSName)
+	assert.NotContains(t, status.Errors, defaults.AgentDaemonSetName)
+	customSummary := status.statusSummary(customDSName)
+	assert.NotEqual(t, Green+"OK"+Reset, customSummary)
+	assert.Equal(t, Green+"OK"+Reset, status.statusSummary(defaults.AgentDaemonSetName))
+	formatted = status.Format()
+	assert.Regexp(t, `(?m)Cilium:\s+`+regexp.QuoteMeta(customSummary), formatted)
+}
+
+func TestFormatEmptyAgentDaemonSetNameFallsBack(t *testing.T) {
+	status := newStatus()
+	status.AddAggregatedError(defaults.AgentDaemonSetName, defaults.AgentDaemonSetName, errors.New("agent missing"))
+
+	summary := status.statusSummary(defaults.AgentDaemonSetName)
+	formatted := status.Format()
+	assert.Regexp(t, `(?m)Cilium:\s+`+regexp.QuoteMeta(summary), formatted)
+	assert.NotRegexp(t, `(?m)Cilium:\s+`+regexp.QuoteMeta(Green+"OK"+Reset), formatted)
 }

--- a/cilium-cli/status/k8s_test.go
+++ b/cilium-cli/status/k8s_test.go
@@ -252,3 +252,36 @@ func TestFormat(t *testing.T) {
 	buf = nilStatus.Format()
 	assert.Empty(t, buf)
 }
+
+func TestStatusCustomAgentDaemonSetName(t *testing.T) {
+	client := newK8sStatusMockClient()
+	assert.NotNil(t, client)
+
+	const (
+		customDSName     = "cilium-v1-16-0"
+		customPodSelector = "k8s-app=cilium-v1-16-0"
+	)
+
+	collector, err := NewK8sStatusCollector(client, K8sStatusParameters{
+		Namespace:          "kube-system",
+		AgentDaemonSetName: customDSName,
+		AgentPodSelector:   customPodSelector,
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, collector)
+
+	client.setDaemonSet("kube-system", customDSName, customPodSelector, 3, 3, 3, 0, 3, 1, 1)
+	status, err := collector.Status(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, status)
+	assert.Equal(t, customDSName, status.AgentDaemonSetName)
+	assert.Equal(t, 3, status.PodState[customDSName].Desired)
+	assert.Equal(t, 3, status.PodState[customDSName].Ready)
+	assert.Equal(t, 3, status.PhaseCount[customDSName][string(corev1.PodRunning)])
+	assert.Len(t, status.CiliumStatus, 3)
+	assert.NotContains(t, status.PodState, defaults.AgentDaemonSetName)
+
+	formatted := status.Format()
+	assert.Contains(t, formatted, "Cilium:")
+	assert.Contains(t, formatted, customDSName)
+}

--- a/cilium-cli/status/status.go
+++ b/cilium-cli/status/status.go
@@ -142,6 +142,10 @@ type Status struct {
 
 	ConfigErrors []string `json:"config_errors,omitempty"`
 
+	// AgentDaemonSetName is the Cilium agent DaemonSet name used when collecting
+	// status. It is the map key for agent entries in PodState/Errors/PhaseCount.
+	AgentDaemonSetName string `json:"agent_daemonset_name,omitempty"`
+
 	mutex *lock.Mutex
 }
 
@@ -382,8 +386,13 @@ func (s *Status) Format() string {
 	var buf bytes.Buffer
 	w := tabwriter.NewWriter(&buf, 0, 0, 4, ' ', 0)
 
+	agentDaemonSetName := s.AgentDaemonSetName
+	if agentDaemonSetName == "" {
+		agentDaemonSetName = defaults.AgentDaemonSetName
+	}
+
 	fmt.Fprint(w, Yellow+"    /¯¯\\\n")
-	fmt.Fprint(w, Cyan+" /¯¯"+Yellow+"\\__/"+Green+"¯¯\\"+Reset+"\tCilium:\t"+s.statusSummary(defaults.AgentDaemonSetName)+"\n")
+	fmt.Fprint(w, Cyan+" /¯¯"+Yellow+"\\__/"+Green+"¯¯\\"+Reset+"\tCilium:\t"+s.statusSummary(agentDaemonSetName)+"\n")
 	fmt.Fprint(w, Cyan+" \\__"+Red+"/¯¯\\"+Green+"__/"+Reset+"\tOperator:\t"+s.statusSummary(defaults.OperatorDeploymentName)+"\n")
 	fmt.Fprint(w, Green+" /¯¯"+Red+"\\__/"+Magenta+"¯¯\\"+Reset+"\tEnvoy DaemonSet:\t"+envoyStatusSummary(s.statusSummary(defaults.EnvoyDaemonSetName))+"\n")
 	fmt.Fprint(w, Green+" \\__"+Blue+"/¯¯\\"+Magenta+"__/"+Reset+"\tHubble Relay:\t"+s.statusSummary(defaults.RelayDeploymentName)+"\n")


### PR DESCRIPTION
## Summary

`cilium status` currently hardcodes the agent DaemonSet name (`cilium`) and pod selector (`k8s-app=cilium`). Users who rename the agent DaemonSet for dual-version / Mode-3 upgrades (e.g. `cilium-<image-tag>` with matching `k8s-app`) get:

```
daemonsets.apps "cilium" not found
```

`cilium connectivity test` already supports `--agent-daemonset-name` and `--agent-pod-selector`. This PR mirrors those flags on `cilium status`.

Fixes #47299

Related: connectivity flags in `cilium-cli/cli/connectivity.go`; historical sysdump custom DaemonSet support in cilium/cilium-cli#653.

## Changes

- Add `--agent-daemonset-name` and `--agent-pod-selector` to `cilium status` (same defaults/help as connectivity)
- Wire through `status.K8sStatusParameters` instead of hardcoding defaults in `status/k8s.go`
- Record the configured name on `Status` so summary formatting looks up the correct PodState/Errors key
- Keep defaults `cilium` / `k8s-app=cilium` for backward compatibility
- Add unit test for a custom agent DaemonSet name

Auto-discovery (e.g. via `app.kubernetes.io/name=cilium-agent`) is intentionally left as a follow-up; flags are the MVP matching connectivity.

## Test plan

- [x] `go test ./cilium-cli/status/ -count=1`
- [ ] Manual: deploy Cilium with renamed agent DS + matching `k8s-app`, confirm:
  - `cilium status` without flags still fails as today when DS is not named `cilium`
  - `cilium status --agent-daemonset-name <name> --agent-pod-selector k8s-app=<name>` succeeds
  - Default install (`cilium` / `k8s-app=cilium`) unchanged without flags


Made with [Cursor](https://cursor.com)

```release-note
cilium-cli: add --agent-daemonset-name and --agent-pod-selector to `cilium status`
```
