### PR TITLE
ztunnel: use node state marker to cleanup in-pod rules when feature is disabled

### DIFF
--- a/pkg/ztunnel/cell.go
+++ b/pkg/ztunnel/cell.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cilium/hive/cell"
 
 	"github.com/cilium/cilium/pkg/clustermesh"
+	"github.com/cilium/cilium/pkg/ztunnel/cleanup"
 	"github.com/cilium/cilium/pkg/ztunnel/config"
 	"github.com/cilium/cilium/pkg/ztunnel/reconciler"
 	"github.com/cilium/cilium/pkg/ztunnel/xds"
@@ -28,6 +29,9 @@ var Cell = cell.Module(
 	// ZDS server for ztunnel
 	zds.Cell,
 	reconciler.Cell,
+
+	// Cleanup in-pod rules when ztunnel is disabled
+	cleanup.Cell,
 )
 
 type ztunnelParams struct {

--- a/pkg/ztunnel/cleanup/cleanup.go
+++ b/pkg/ztunnel/cleanup/cleanup.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cleanup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
+
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/endpointstate"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/netns"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/promise"
+	"github.com/cilium/cilium/pkg/ztunnel/config"
+	"github.com/cilium/cilium/pkg/ztunnel/iptables"
+)
+
+// ztunnelStateFile is a marker file written to StateDir when ztunnel is
+// enabled. Its presence on a subsequent agent start with enable-ztunnel=false
+// triggers cleanup of in-pod redirect rules left in previously-enrolled pods.
+const ztunnelStateFile = "ztunnel_enabled"
+
+// Cell provides cleanup of ztunnel in-pod rules when ztunnel is disabled.
+var Cell = cell.Module(
+	"cleanup",
+	"Cleanup of ztunnel in-pod rules",
+	cell.ProvidePrivate(newCleanupConfig),
+	cell.Invoke(registerCleanup),
+)
+
+type cleanupConfig struct {
+	stateDir   string
+	enableIPv4 bool
+	enableIPv6 bool
+}
+
+func newCleanupConfig(dcfg *option.DaemonConfig) cleanupConfig {
+	return cleanupConfig{
+		stateDir:   dcfg.StateDir,
+		enableIPv4: dcfg.EnableIPv4,
+		enableIPv6: dcfg.EnableIPv6,
+	}
+}
+
+type cleanupParams struct {
+	cell.In
+
+	Lifecycle       cell.Lifecycle
+	Logger          *slog.Logger
+	JobGroup        job.Group
+	Config          config.Config
+	CleanupConfig   cleanupConfig
+	EndpointManager endpointmanager.EndpointManager
+	RestorerPromise promise.Promise[endpointstate.Restorer]
+}
+
+// registerCleanup handles two cases:
+//
+//  1. ztunnel enabled: write a marker file so a future disable knows cleanup
+//     is needed.
+//  2. ztunnel disabled + marker present: register a one-shot job that removes
+//     in-pod redirect rules from all restored endpoints, then removes the
+//     marker.
+func registerCleanup(p cleanupParams) error {
+	markerPath := filepath.Join(p.CleanupConfig.stateDir, ztunnelStateFile)
+
+	if p.Config.EnableZTunnel {
+		// Persist a marker so that a subsequent run with enable-ztunnel=false
+		// knows that cleanup is required.
+		p.Lifecycle.Append(cell.Hook{
+			OnStart: func(cell.HookContext) error {
+				return os.WriteFile(markerPath, nil, 0600)
+			},
+		})
+		return nil
+	}
+
+	// ztunnel is disabled. Only run cleanup if a previous agent run had it
+	// enabled (marker file exists).
+	if _, err := os.Stat(markerPath); errors.Is(err, os.ErrNotExist) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("stat ztunnel state marker %q: %w", markerPath, err)
+	}
+
+	p.JobGroup.Add(job.OneShot("ztunnel-inpod-cleanup", func(ctx context.Context, _ cell.Health) error {
+		return runCleanup(ctx, p.Logger, p.RestorerPromise, p.EndpointManager, p.CleanupConfig)
+	}))
+	return nil
+}
+
+func runCleanup(ctx context.Context, logger *slog.Logger, restorerPromise promise.Promise[endpointstate.Restorer], epMgr endpointmanager.EndpointManager, cfg cleanupConfig) error {
+	restorer, err := restorerPromise.Await(ctx)
+	if err != nil {
+		return fmt.Errorf("await endpoint restorer: %w", err)
+	}
+	if err := restorer.WaitForEndpointRestoreWithoutRegeneration(ctx); err != nil {
+		return fmt.Errorf("wait for endpoint restore: %w", err)
+	}
+
+	logger.Info("Starting ztunnel in-pod rules cleanup")
+
+	var cleanupErr error
+	var cleaned int
+	for _, ep := range epMgr.GetEndpoints() {
+		netnsPath := ep.GetContainerNetnsPath()
+		if netnsPath == "" {
+			continue
+		}
+
+		ns, err := netns.OpenPinned(netnsPath)
+		if err != nil {
+			// Pod netns no longer exists (container exited); rules are
+			// already gone with it.
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			logger.Warn("Failed to open pod netns for ztunnel cleanup",
+				logfields.EndpointID, ep.GetID16(),
+				logfields.Error, err,
+			)
+			cleanupErr = errors.Join(cleanupErr, err)
+			continue
+		}
+
+		if err := ns.Do(func() error {
+			return iptables.DeleteInPodRules(logger, cfg.enableIPv4, cfg.enableIPv6)
+		}); err != nil {
+			ns.Close()
+			logger.Warn("Failed to delete ztunnel in-pod rules",
+				logfields.EndpointID, ep.GetID16(),
+				logfields.Error, err,
+			)
+			cleanupErr = errors.Join(cleanupErr, err)
+			continue
+		}
+		ns.Close()
+		cleaned++
+	}
+
+	logger.Info("Finished ztunnel in-pod rules cleanup",
+		"cleaned", cleaned,
+	)
+
+	if cleanupErr != nil {
+		// Keep the marker so the next restart retries.
+		return cleanupErr
+	}
+
+	// All endpoints cleaned successfully; remove the marker.
+	markerPath := filepath.Join(cfg.stateDir, ztunnelStateFile)
+	if err := os.Remove(markerPath); err != nil && !os.IsNotExist(err) {
+		logger.Warn("Failed to remove ztunnel state marker",
+			logfields.Path, markerPath,
+			logfields.Error, err,
+		)
+	}
+	return nil
+}

--- a/pkg/ztunnel/cleanup/cleanup_test.go
+++ b/pkg/ztunnel/cleanup/cleanup_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cleanup
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpointstate"
+	"github.com/cilium/cilium/pkg/promise"
+	testendpointmanager "github.com/cilium/cilium/pkg/testutils/endpointmanager"
+	"github.com/cilium/cilium/pkg/ztunnel/config"
+)
+
+type fakeRestorer struct{}
+
+func (*fakeRestorer) WaitForEndpointRestoreWithoutRegeneration(context.Context) error {
+	return nil
+}
+
+func (*fakeRestorer) WaitForEndpointRestore(context.Context) error {
+	return nil
+}
+
+func (*fakeRestorer) WaitForInitialPolicy(context.Context) error {
+	return nil
+}
+
+func TestRegisterCleanupEnabledCreatesMarker(t *testing.T) {
+	stateDir := t.TempDir()
+	markerPath := filepath.Join(stateDir, ztunnelStateFile)
+
+	require.NoError(t, registerCleanup(cleanupParams{
+		Lifecycle:     hivetest.Lifecycle(t),
+		Config:        config.Config{EnableZTunnel: true},
+		CleanupConfig: cleanupConfig{stateDir: stateDir},
+	}))
+
+	require.FileExists(t, markerPath)
+}
+
+func TestRegisterCleanupMarkerStatError(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "not-a-directory")
+	require.NoError(t, os.WriteFile(stateDir, nil, 0600))
+
+	err := registerCleanup(cleanupParams{
+		CleanupConfig: cleanupConfig{stateDir: stateDir},
+	})
+	require.ErrorContains(t, err, "stat ztunnel state marker")
+}
+
+func TestRunCleanupRemovesMarker(t *testing.T) {
+	stateDir := t.TempDir()
+	markerPath := filepath.Join(stateDir, ztunnelStateFile)
+	require.NoError(t, os.WriteFile(markerPath, nil, 0600))
+
+	resolver, restorerPromise := promise.New[endpointstate.Restorer]()
+	resolver.Resolve(&fakeRestorer{})
+
+	require.NoError(t, runCleanup(
+		t.Context(),
+		hivetest.Logger(t),
+		restorerPromise,
+		testendpointmanager.NewMockEndpointManager(),
+		cleanupConfig{stateDir: stateDir},
+	))
+	require.NoFileExists(t, markerPath)
+}
+
+func TestRunCleanupNetnsOpenErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		netnsPath  string
+		wantErr    bool
+		wantMarker bool
+	}{
+		{
+			name:      "missing netns is ignored",
+			netnsPath: filepath.Join(t.TempDir(), "does-not-exist"),
+		},
+		{
+			name:       "other open error is returned",
+			netnsPath:  "\x00",
+			wantErr:    true,
+			wantMarker: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stateDir := t.TempDir()
+			markerPath := filepath.Join(stateDir, ztunnelStateFile)
+			require.NoError(t, os.WriteFile(markerPath, nil, 0600))
+
+			resolver, restorerPromise := promise.New[endpointstate.Restorer]()
+			resolver.Resolve(&fakeRestorer{})
+
+			ep := &endpoint.Endpoint{ID: 123}
+			ep.SetContainerNetnsPath(tt.netnsPath)
+			epMgr := testendpointmanager.NewMockEndpointManager()
+			epMgr.Endpoints = []*endpoint.Endpoint{ep}
+
+			err := runCleanup(
+				t.Context(),
+				hivetest.Logger(t),
+				restorerPromise,
+				epMgr,
+				cleanupConfig{stateDir: stateDir},
+			)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tt.wantMarker {
+				require.FileExists(t, markerPath)
+			} else {
+				require.NoFileExists(t, markerPath)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->
When Cilium is restarted with `enable-ztunnel=false`, in-pod iptables redirect rules left in previously enrolled pods cause traffic blackholing.

To resolve this without mutating per-endpoint state serialization, this change introduces node-level state tracking via a `ztunnel_enabled` marker file persisted in `option.Config.StateDir`. When `enable-ztunnel=true`, a Hive `OnStart` lifecycle hook creates the marker file. When the agent starts with `enable-ztunnel=false`, `registerCleanup` checks for the marker: if absent, execution returns immediately as a zero-cost O(1) no-op; if present, it schedules a restore-gated one-shot job (`ztunnel-inpod-cleanup`) that awaits endpoint restoration (`WaitForEndpointRestore`), iterates restored endpoints to execute `iptables.DeleteInPodRules()` inside each pod's network namespace (gracefully skipping terminated pods via `os.ErrNotExist`), and unlinks the marker file upon full completion to guarantee retry idempotency across restarts.

Fixes: #46333

```release-note
Fix traffic blackholing when disabling ztunnel by introducing node-level state tracking to automatically strip in-pod redirect rules from restored endpoints.
```

[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
