### PR TITLE
fqdn-proxy: stop unnecessary identity resolution in NotifyOnDNSMsg

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -917,7 +917,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 				scopedLog.Error("Dropping DNS request due to too many DNS requests already in-flight", logfields.Error, err)
 			}
 			stat.Err = err
-			p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, 0, netip.AddrPort{}, &MsgDetails{}, protocol, false, &stat)
+			p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, nil, netip.AddrPort{}, &MsgDetails{}, protocol, false, &stat)
 			p.sendErrorResponse(scopedLog, w, request, false)
 			return
 		}
@@ -945,7 +945,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		scopedLog.Error("cannot extract endpoint IP from DNS request", logfields.Error, err)
 		stat.Err = fmt.Errorf("Cannot extract endpoint IP from DNS request: %w", err)
 		stat.ProcessingTime.End(false)
-		p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, 0, netip.AddrPort{}, &MsgDetails{}, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, nil, netip.AddrPort{}, &MsgDetails{}, protocol, false, &stat)
 		p.sendErrorResponse(scopedLog, w, request, false)
 		return
 	}
@@ -955,7 +955,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		scopedLog.Error("cannot extract endpoint ID from DNS request", logfields.Error, err)
 		stat.Err = fmt.Errorf("Cannot extract endpoint ID from DNS request: %w", err)
 		stat.ProcessingTime.End(false)
-		p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, 0, netip.AddrPort{}, &MsgDetails{}, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, nil, netip.AddrPort{}, &MsgDetails{}, protocol, false, &stat)
 		p.sendErrorResponse(scopedLog, w, request, false)
 		return
 	}
@@ -970,7 +970,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		p.logger.Error("cannot extract destination IP:port from DNS request", logfields.Error, err)
 		stat.Err = fmt.Errorf("Cannot extract destination IP:port from DNS request: %w", err)
 		stat.ProcessingTime.End(false)
-		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, 0, targetServer, requestDetails, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, nil, targetServer, requestDetails, protocol, false, &stat)
 		p.sendErrorResponse(scopedLog, w, request, false)
 		return
 	}
@@ -978,6 +978,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 
 	// Ignore invalid IP - getter will handle invalid value.
 	targetServerID := identity.GetWorldIdentityFromIP(targetServer.Addr())
+	var targetServerSecID *identity.Identity
 	if serverSecID, exists := p.proxyLookupHandler.LookupSecIDByIP(targetServer.Addr()); !exists {
 		scopedLog.Debug(
 			"cannot find server ip in ipcache, defaulting to WORLD",
@@ -985,6 +986,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		)
 	} else {
 		targetServerID = serverSecID.ID
+		targetServerSecID = p.proxyLookupHandler.LookupIdentityByIP(targetServer.Addr())
 		scopedLog.Debug(
 			"Found target server to of DNS request secID",
 			logfields.SecID, serverSecID,
@@ -1005,7 +1007,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		scopedLog.Error("Rejecting DNS query from endpoint due to error", logfields.Error, err)
 		stat.Err = fmt.Errorf("Rejecting DNS query from endpoint due to error: %w", err)
 		stat.ProcessingTime.End(false)
-		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServer, requestDetails, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerSecID, targetServer, requestDetails, protocol, false, &stat)
 		p.sendErrorResponse(scopedLog, w, request, false)
 		return
 
@@ -1017,12 +1019,12 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		// information for metrics.
 		stat.Err = p.sendErrorResponse(scopedLog, w, request, true)
 		stat.ProcessingTime.End(true)
-		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServer, requestDetails, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerSecID, targetServer, requestDetails, protocol, false, &stat)
 		return
 	}
 
 	scopedLog.Debug("Forwarding DNS request for a name that is allowed")
-	if err := p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServer, requestDetails, protocol, true, &stat); err != nil {
+	if err := p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerSecID, targetServer, requestDetails, protocol, true, &stat); err != nil {
 		scopedLog.Error("Failed to process DNS query", logfields.Error, err)
 		p.sendErrorResponse(scopedLog, w, request, false)
 		return
@@ -1037,7 +1039,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		scopedLog.Error("Cannot parse DNS proxy client network to select forward client")
 		stat.Err = fmt.Errorf("Cannot parse DNS proxy client network to select forward client: %w", err)
 		stat.ProcessingTime.End(false)
-		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServer, requestDetails, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerSecID, targetServer, requestDetails, protocol, false, &stat)
 		p.sendErrorResponse(scopedLog, w, request, false)
 		return
 	}
@@ -1091,12 +1093,12 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		stat.Err = err
 		if stat.IsTimeout() {
 			scopedLog.Warn("Timeout waiting for response to forwarded proxied DNS lookup", logfields.Error, err)
-			p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServer, requestDetails, protocol, false, &stat)
+			p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerSecID, targetServer, requestDetails, protocol, false, &stat)
 			return
 		}
 		scopedLog.Error("Cannot forward proxied DNS lookup", logfields.Error, err)
 		stat.Err = fmt.Errorf("cannot forward proxied DNS lookup: %w", err)
-		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServer, requestDetails, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerSecID, targetServer, requestDetails, protocol, false, &stat)
 		p.sendErrorResponse(scopedLog, w, request, false)
 		return
 	}
@@ -1118,7 +1120,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	stat.ProcessingTime.End(true)
 
 	scopedLog.Debug("Notifying with DNS response to original DNS query")
-	if err := p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServer, responseDetails, protocol, true, &stat); err != nil {
+	if err := p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerSecID, targetServer, responseDetails, protocol, true, &stat); err != nil {
 		scopedLog.Error(
 			"Failed to process DNS response",
 			logfields.Error, err,
@@ -1136,7 +1138,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	if err != nil {
 		scopedLog.Error("Cannot forward proxied DNS response", logfields.Error, err)
 		stat.Err = fmt.Errorf("Cannot forward proxied DNS response: %w", err)
-		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServer, responseDetails, protocol, true, &stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerSecID, targetServer, responseDetails, protocol, true, &stat)
 	} else {
 		p.Lock()
 		// Add the server to the set of used DNS servers. This set is never GCd, but is limited by set

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -158,6 +158,16 @@ func (s *DNSProxyTestSuite) LookupSecIDByIP(ip netip.Addr) (secID ipcache.Identi
 	}
 }
 
+func (s *DNSProxyTestSuite) LookupIdentityByIP(ip netip.Addr) *identity.Identity {
+	secID, exists := s.LookupSecIDByIP(ip)
+	if !exists {
+		return nil
+	}
+	return &identity.Identity{
+		ID: secID.ID,
+	}
+}
+
 func (s *DNSProxyTestSuite) LookupByIdentity(nid identity.NumericIdentity) []string {
 	DNSServerListenerAddr := (s.dnsServer.Listener.Addr()).(*net.TCPAddr)
 	switch nid {

--- a/pkg/fqdn/dnsproxy/types.go
+++ b/pkg/fqdn/dnsproxy/types.go
@@ -22,7 +22,7 @@ type LookupEndpointIDByIPFunc func(ip netip.Addr) (endpoint *endpoint.Endpoint, 
 
 // NotifyOnDNSMsgFunc handles propagating DNS response data
 // See DNSProxy.LookupEndpointIDByIP for usage.
-type NotifyOnDNSMsgFunc func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID identity.NumericIdentity, serverAddr netip.AddrPort, details *MsgDetails, protocol string, allowed bool, stat *ProxyRequestContext) error
+type NotifyOnDNSMsgFunc func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverSecID *identity.Identity, serverAddr netip.AddrPort, details *MsgDetails, protocol string, allowed bool, stat *ProxyRequestContext) error
 
 // ErrFailedAcquireSemaphore is an error representing the DNS proxy's
 // failure to acquire the semaphore. This is error is treated like a timeout.

--- a/pkg/fqdn/lookup/endpoint.go
+++ b/pkg/fqdn/lookup/endpoint.go
@@ -21,6 +21,9 @@ type ProxyLookupHandler interface {
 	// from the ipcache.
 	LookupSecIDByIP(ip netip.Addr) (secID ipcache.Identity, exists bool)
 
+	// LookupIdentityByIP looks up the full identity for a given IP address.
+	LookupIdentityByIP(ip netip.Addr) *identity.Identity
+
 	// LookupByIdentity is a provided callback that returns the IPs of a given security ID.
 	LookupByIdentity(nid identity.NumericIdentity) []string
 
@@ -61,6 +64,14 @@ func (p *proxyLookupHandler) LookupRegisteredEndpoint(endpointAddr netip.Addr) (
 
 func (p *proxyLookupHandler) LookupSecIDByIP(ip netip.Addr) (secID ipcache.Identity, exists bool) {
 	return p.ipCache.LookupSecIDByIP(ip)
+}
+
+func (p *proxyLookupHandler) LookupIdentityByIP(ip netip.Addr) *identity.Identity {
+	secID, exists := p.ipCache.LookupSecIDByIP(ip)
+	if !exists {
+		return nil
+	}
+	return p.ipCache.IdentityAllocator.LookupIdentityByID(context.Background(), secID.ID)
 }
 
 func (p *proxyLookupHandler) LookupByIdentity(nid identity.NumericIdentity) []string {

--- a/pkg/fqdn/messagehandler/message_handler.go
+++ b/pkg/fqdn/messagehandler/message_handler.go
@@ -52,7 +52,7 @@ type DNSMessageHandler interface {
 	NotifyOnDNSMsg(lookupTime time.Time,
 		ep *endpoint.Endpoint,
 		epIPPort string,
-		serverID identity.NumericIdentity,
+		serverSecID *identity.Identity,
 		serverAddrPort netip.AddrPort,
 		details *dnsproxy.MsgDetails,
 		protocol string,
@@ -120,12 +120,12 @@ func (h *dnsMessageHandler) SetBindPort(port uint16) {
 
 // epIPPort and serverAddrPort should match the original request, where epAddr is
 // the source for egress (the only case current).
-// serverID is the destination server security identity at the time of the DNS event.
+// serverSecID is the destination server security identity at the time of the DNS event.
 func (h *dnsMessageHandler) NotifyOnDNSMsg(
 	lookupTime time.Time,
 	ep *endpoint.Endpoint,
 	epIPPort string,
-	serverID identity.NumericIdentity,
+	serverSecID *identity.Identity,
 	serverAddrPort netip.AddrPort,
 	dnsMsgDetails *dnsproxy.MsgDetails,
 	protocol string,
@@ -210,7 +210,12 @@ func (h *dnsMessageHandler) NotifyOnDNSMsg(
 		// is going away.
 		flow.addrInfo.DstSecIdentity, _ = ep.GetSecurityIdentity()
 		flow.addrInfo.SrcIPPort = serverAddrPortStr
-		flow.addrInfo.SrcIdentity = serverID
+		flow.addrInfo.SrcSecIdentity = serverSecID
+		if serverSecID != nil {
+			flow.addrInfo.SrcIdentity = serverSecID.ID
+		} else {
+			flow.addrInfo.SrcIdentity = identity.GetWorldIdentityFromIP(serverAddrPort.Addr())
+		}
 	} else {
 		flow.flowType = accesslog.TypeRequest
 		flow.addrInfo.SrcIPPort = epIPPort
@@ -218,7 +223,12 @@ func (h *dnsMessageHandler) NotifyOnDNSMsg(
 		// ignore error; same reason as above.
 		flow.addrInfo.SrcSecIdentity, _ = ep.GetSecurityIdentity()
 		flow.addrInfo.DstIPPort = serverAddrPortStr
-		flow.addrInfo.DstIdentity = serverID
+		flow.addrInfo.DstSecIdentity = serverSecID
+		if serverSecID != nil {
+			flow.addrInfo.DstIdentity = serverSecID.ID
+		} else {
+			flow.addrInfo.DstIdentity = identity.GetWorldIdentityFromIP(serverAddrPort.Addr())
+		}
 	}
 
 	if dnsMsgDetails.Response && dnsMsgDetails.RCode == dns.RcodeSuccess && len(dnsMsgDetails.ResponseIPs) > 0 {

--- a/pkg/fqdn/messagehandler/message_handler_test.go
+++ b/pkg/fqdn/messagehandler/message_handler_test.go
@@ -144,8 +144,8 @@ func BenchmarkNotifyOnDNSMsg(b *testing.B) {
 				// parameter is only used in logging. Not using the endpoint's IP
 				// so we don't spend any time in the benchmark on converting from
 				// net.IP to string.
-				require.NoError(b, handler.NotifyOnDNSMsg(time.Now(), ep, "10.96.64.8:12345", 0, srvAddr, ciliumMsgDetails, "udp", true, emptyPRCtx))
-				require.NoError(b, handler.NotifyOnDNSMsg(time.Now(), ep, "10.96.64.4:54321", 0, srvAddr, ebpfMsgDetails, "udp", true, emptyPRCtx))
+				require.NoError(b, handler.NotifyOnDNSMsg(time.Now(), ep, "10.96.64.8:12345", nil, srvAddr, ciliumMsgDetails, "udp", true, emptyPRCtx))
+				require.NoError(b, handler.NotifyOnDNSMsg(time.Now(), ep, "10.96.64.4:54321", nil, srvAddr, ebpfMsgDetails, "udp", true, emptyPRCtx))
 			})
 		}
 		wg.Wait()

--- a/pkg/fqdn/service/service.go
+++ b/pkg/fqdn/service/service.go
@@ -693,9 +693,9 @@ func (s *FQDNDataServer) UpdateMappingRequest(ctx context.Context, mappings *pb.
 		}
 	}
 
-	msgDetails, serverAddrPort, epIPPort, serverID, protocol, allowed := s.reconstructNotifyArgs(mappings, sourceIP)
+	msgDetails, serverAddrPort, epIPPort, serverSecID, protocol, allowed := s.reconstructNotifyArgs(mappings, sourceIP)
 
-	if err := s.updateOnDNSMsg.NotifyOnDNSMsg(now, ep, epIPPort, serverID, serverAddrPort, msgDetails, protocol, allowed, &stat); err != nil {
+	if err := s.updateOnDNSMsg.NotifyOnDNSMsg(now, ep, epIPPort, serverSecID, serverAddrPort, msgDetails, protocol, allowed, &stat); err != nil {
 		s.log.Error("Failed to process DNS message",
 			logfields.Error, err,
 			logfields.DNSName, mappings.GetFqdn(),
@@ -722,7 +722,7 @@ func (s *FQDNDataServer) reconstructNotifyArgs(mappings *pb.FQDNMapping, sourceI
 	msgDetails *dnsproxy.MsgDetails,
 	serverAddrPort netip.AddrPort,
 	epIPPort string,
-	serverID identity.NumericIdentity,
+	serverSecID *identity.Identity,
 	protocol string,
 	allowed bool,
 ) {
@@ -782,7 +782,11 @@ func (s *FQDNDataServer) reconstructNotifyArgs(mappings *pb.FQDNMapping, sourceI
 		epIPPort = fmt.Sprintf("%s:%d", string(sourceIP), md.GetSourcePort())
 	}
 
-	serverID = identity.NumericIdentity(md.GetServerIdentity())
+	if md.GetServerIdentity() != 0 {
+		serverSecID = &identity.Identity{
+			ID: identity.NumericIdentity(md.GetServerIdentity()),
+		}
+	}
 	protocol = md.GetProtocol()
 	allowed = md.GetAllowed()
 	return

--- a/standalone-dns-proxy/pkg/lookup/lookup.go
+++ b/standalone-dns-proxy/pkg/lookup/lookup.go
@@ -81,6 +81,16 @@ func (r *rulesClient) LookupSecIDByIP(ip netip.Addr) (secID ipcache.Identity, ex
 	return ipcache.Identity{}, false
 }
 
+func (r *rulesClient) LookupIdentityByIP(ip netip.Addr) *identity.Identity {
+	secID, exists := r.LookupSecIDByIP(ip)
+	if !exists {
+		return nil
+	}
+	return &identity.Identity{
+		ID: secID.ID,
+	}
+}
+
 func (r *rulesClient) lookupPrefix(txn statedb.ReadTxn, prefix netip.Prefix) (identity ipcache.Identity, exists bool) {
 	if _, cidr, err := net.ParseCIDR(prefix.String()); err == nil {
 		ones, bits := cidr.Mask.Size()

--- a/standalone-dns-proxy/pkg/messagehandler/messagehandler.go
+++ b/standalone-dns-proxy/pkg/messagehandler/messagehandler.go
@@ -31,7 +31,7 @@ type messageHandler struct {
 // This method always sends the gRPC message to the agent, even in error cases
 // (e.g. ep == nil, timeout, proxy errors), so that the agent can emit the
 // corresponding proxy metrics for every DNS event.
-func (m *messageHandler) NotifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID identity.NumericIdentity, serverAddrPort netip.AddrPort, details *dnsproxy.MsgDetails, protocol string, allowed bool, stat *dnsproxy.ProxyRequestContext) error {
+func (m *messageHandler) NotifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverSecID *identity.Identity, serverAddrPort netip.AddrPort, details *dnsproxy.MsgDetails, protocol string, allowed bool, stat *dnsproxy.ProxyRequestContext) error {
 	var ips [][]byte
 	for _, i := range details.ResponseIPs {
 		ips = append(ips, []byte(i.String()))
@@ -41,6 +41,11 @@ func (m *messageHandler) NotifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpo
 	sourceIdentity := m.getSourceIdentity(ep)
 
 	errorType, errorMessage := classifyProxyError(stat)
+
+	var serverID uint32
+	if serverSecID != nil {
+		serverID = serverSecID.ID.Uint32()
+	}
 
 	message := &pb.FQDNMapping{
 		Fqdn:           details.QName,
@@ -65,7 +70,7 @@ func (m *messageHandler) NotifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpo
 			},
 			SourcePort:     sourcePort,
 			ServerAddr:     serverAddrPort.String(),
-			ServerIdentity: serverID.Uint32(),
+			ServerIdentity: serverID,
 			Protocol:       protocol,
 			Allowed:        allowed,
 			ErrorMessage:   errorMessage,

--- a/standalone-dns-proxy/pkg/messagehandler/messagehandler_test.go
+++ b/standalone-dns-proxy/pkg/messagehandler/messagehandler_test.go
@@ -97,7 +97,7 @@ func TestNotifyOnDNSMsg(t *testing.T) {
 		details   *dnsproxy.MsgDetails
 		epIPPort  string
 		server    string
-		serverID  identity.NumericIdentity
+		serverSecID *identity.Identity
 		protocol  string
 		allowed   bool
 		stat      *dnsproxy.ProxyRequestContext
@@ -112,7 +112,7 @@ func TestNotifyOnDNSMsg(t *testing.T) {
 			details:  buildResponseDetails(),
 			epIPPort: "10.1.1.10:5353",
 			server:   "8.8.8.8:53",
-			serverID: identity.NumericIdentity(42),
+			serverSecID: &identity.Identity{ID: identity.NumericIdentity(42)},
 			protocol: "tcp",
 			allowed:  false,
 			stat:     buildStatWithTimings(),
@@ -262,7 +262,7 @@ func TestNotifyOnDNSMsg(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			h, mc, ep := newTestHandler(t, tc.nilEp)
 			serverAP := netip.MustParseAddrPort(tc.server)
-			err := h.NotifyOnDNSMsg(time.Now(), ep, tc.epIPPort, tc.serverID, serverAP, tc.details, tc.protocol, tc.allowed, tc.stat)
+			err := h.NotifyOnDNSMsg(time.Now(), ep, tc.epIPPort, tc.serverSecID, serverAP, tc.details, tc.protocol, tc.allowed, tc.stat)
 			if tc.expectErr {
 				require.Error(t, err)
 				return


### PR DESCRIPTION
Fixes #47279

In `messagehandler.go`, we determine the source and destination security identity for use in generating access logs. This winds up being quite CPU and alloc-expensive, as the labels are duplicated and we even need to lock the allocator.

Since we already know the security identity in `pkg/fqdn/dnsproxy/proxy.go`, we modify `NotifyOnDNSMsg` and the helper interfaces to accept the full security identity (`*identity.Identity`) directly. This allows us to populate `addrInfo.SrcSecIdentity` and `addrInfo.DstSecIdentity` directly and avoid the unnecessary and expensive allocator lookup/locking on the hot path.

---
### AI-Usage Disclosure
This pull request was prepared with the assistance of Generative AI (Claude).
- **Influence Level:** Level 2 (Refactored existing logic and function signatures to pass the resolved identity directly).
- **Tooling Used:** Claude Code.
- **Human Involvement:** A human developer (`emre155`) reviewed the entire change, verified the performance improvement, and locally validated the implementation.