### PR TITLE
gateway-api: exclude conflicted listeners from translation

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -747,9 +747,15 @@ func (r *gatewayReconciler) resolveAllowedListeners(
 	gw *gatewayv1.Gateway,
 ) ([]ingestion.ListenerWithContext, []gatewayv1.ListenerSet, error) {
 	gwSource := gatewayFQR(gw)
+	conflictedListeners := conflictedGatewayListeners(gw)
 
 	var merged []ingestion.ListenerWithContext
 	for _, l := range gw.Spec.Listeners {
+		// Conflicted listeners are rejected in Gateway status and must not be
+		// included in the model passed to the translation pipeline.
+		if _, conflicted := conflictedListeners[l.Name]; conflicted {
+			continue
+		}
 		merged = append(merged, ingestion.ListenerWithContext{
 			Listener: l,
 			Source:   gwSource,

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/output/cec-gateway-tlsroute-mixed.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/output/cec-gateway-tlsroute-mixed.yaml
@@ -14,11 +14,6 @@ metadata:
       uid: ""
   resourceVersion: "1"
 spec:
-  backendServices:
-    - name: tls-backend
-      namespace: gateway-conformance-infra
-      number:
-        - "443"
   resources:
     - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
       filterChains:
@@ -50,51 +45,6 @@ spec:
                 upgradeConfigs:
                   - upgradeType: websocket
                 useRemoteAddress: true
-        - filterChainMatch:
-            transportProtocol: tls
-          filters:
-            - name: envoy.filters.network.http_connection_manager
-              typedConfig:
-                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                commonHttpProtocolOptions:
-                  maxStreamDuration: 0s
-                httpFilters:
-                  - name: envoy.filters.http.grpc_web
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
-                  - name: envoy.filters.http.grpc_stats
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
-                      emitFilterState: true
-                      enableUpstreamStats: true
-                  - name: envoy.filters.http.router
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-                internalAddressConfig: {}
-                rds:
-                  routeConfigName: listener-secure
-                statPrefix: listener-secure
-                streamIdleTimeout: 300s
-                upgradeConfigs:
-                  - upgradeType: websocket
-                useRemoteAddress: true
-          transportSocket:
-            name: envoy.transport_sockets.tls
-            typedConfig:
-              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
-              commonTlsContext:
-                tlsCertificateSdsSecretConfigs:
-                  - name: cilium-secrets/cilium-sync-secret-500e3be49f49f792095ab868a790d52c93e9b87961de22ae3ff2c25a63d56845
-        - filterChainMatch:
-            serverNames:
-              - tls.example.com
-            transportProtocol: tls
-          filters:
-            - name: envoy.filters.network.tcp_proxy
-              typedConfig:
-                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-                cluster: gateway-conformance-infra:tls-backend:443
-                statPrefix: tls-passthrough:tls.example.com
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:
@@ -119,18 +69,8 @@ spec:
           name: "6"
     - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
       name: listener-insecure
-    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
-      name: listener-secure
-    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
-      edsClusterConfig:
-        serviceName: gateway-conformance-infra/tls-backend:443
-      name: gateway-conformance-infra:tls-backend:443
-      outlierDetection:
-        splitExternalLocalOriginErrors: true
-      type: EDS
   services:
     - name: cilium-gateway-gateway-tlsroute-mixed
       namespace: gateway-conformance-infra
       ports:
         - 80
-        - 443


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

Gateway listener conflicts (e.g. two listeners sharing a port with
`ProtocolConflict`) are reflected correctly in Gateway status, but every
configured listener was still passed into the translation pipeline. As a
result, rejected/conflicted listeners could still be programmed into Envoy
and serve traffic, as long as the Gateway had at least one other accepted
listener keeping it `Programmed`.

This excludes conflicted direct Gateway listeners when building the merged
listener model in `resolveAllowedListeners`, so only listeners that are
actually accepted are handed to translation. The `tlsroute-mixed-protocol-listeners`
golden CEC fixture is updated to assert that port 443, its TLS filter
chains, route config, and backend are absent from the resulting Envoy
config, instead of asserting their presence.

Fixes: #46917

This PR was prepared with AIL:3. I personally checked that the conflicted
listener exclusion only applies to already-rejected listeners (Gateway
status `Accepted=False`/`Conflicted=ProtocolConflict`) and verified the
regenerated golden fixture no longer emits port 443 or its associated TLS
chains, route config, and backend.

```release-note
gateway-api: exclude conflicted listeners from Envoy programming
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
