### PR TITLE
Add zone locality info to envoy endpoints if service EndPointSlices have zone information.

### DIFF
--- a/pkg/ciliumenvoyconfig/computeloadassignments_test.go
+++ b/pkg/ciliumenvoyconfig/computeloadassignments_test.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumenvoyconfig
+
+import (
+	"iter"
+	"testing"
+
+	"github.com/cilium/statedb"
+	"github.com/stretchr/testify/require"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+)
+
+// makeBackend creates a test backend. Pass forZones to simulate topology hints
+// (trafficDistribution: PreferSameZone); omit them for a plain backend.
+func makeBackend(ip string, port uint16, zone string, forZones ...string) *loadbalancer.Backend {
+	be := &loadbalancer.Backend{
+		Address: loadbalancer.NewL3n4Addr(
+			loadbalancer.TCP,
+			cmtypes.MustParseAddrCluster(ip),
+			port,
+			loadbalancer.ScopeExternal,
+		),
+		State: loadbalancer.BackendStateActive,
+	}
+	if zone != "" {
+		be.Zone = &loadbalancer.BackendZone{Zone: zone, ForZones: forZones}
+	}
+	return be
+}
+
+func backendsSeq(bes []*loadbalancer.Backend) iter.Seq2[*loadbalancer.Backend, statedb.Revision] {
+	return func(yield func(*loadbalancer.Backend, statedb.Revision) bool) {
+		for _, be := range bes {
+			if !yield(be, 0) {
+				return
+			}
+		}
+	}
+}
+
+// allPorts returns a clusterReferences that matches all port names (anyPort).
+func allPorts() clusterReferences {
+	return clusterReferences{}
+}
+
+// --- Tests without topology hints (no ForZones): expect flat output ---
+
+func TestComputeLoadAssignments_NoZone(t *testing.T) {
+	svcName := loadbalancer.NewServiceName("test", "backend")
+	backends := []*loadbalancer.Backend{
+		makeBackend("10.0.0.1", 8080, ""),
+		makeBackend("10.0.0.2", 8080, ""),
+	}
+
+	assignments := computeLoadAssignments(svcName, allPorts(), nil, backendsSeq(backends))
+
+	require.Len(t, assignments, 2)
+	cla := assignments[1] // bare "test/backend" — what real CECs reference
+	require.Len(t, cla.Endpoints, 1)
+	require.Nil(t, cla.Endpoints[0].Locality, "expected no locality when zone is not set")
+	require.Len(t, cla.Endpoints[0].LbEndpoints, 2)
+}
+
+// Zone is set on backends but no ForZones hints (service has no PreferSameZone)
+// → flat output, no Locality grouping.
+func TestComputeLoadAssignments_ZoneWithoutHints_SingleZone(t *testing.T) {
+	svcName := loadbalancer.NewServiceName("test", "backend")
+	backends := []*loadbalancer.Backend{
+		makeBackend("10.0.0.1", 8080, "us-east-1a"),
+		makeBackend("10.0.0.2", 8080, "us-east-1a"),
+	}
+
+	assignments := computeLoadAssignments(svcName, allPorts(), nil, backendsSeq(backends))
+
+	require.Len(t, assignments, 2)
+	cla := assignments[1]
+	require.Len(t, cla.Endpoints, 1)
+	require.Nil(t, cla.Endpoints[0].Locality, "expected no locality without ForZones hints")
+	require.Len(t, cla.Endpoints[0].LbEndpoints, 2)
+}
+
+// Multiple zones set but no ForZones hints → single flat group.
+func TestComputeLoadAssignments_ZoneWithoutHints_MultiZone(t *testing.T) {
+	svcName := loadbalancer.NewServiceName("test", "backend")
+	backends := []*loadbalancer.Backend{
+		makeBackend("10.0.0.1", 8080, "us-east-1a"),
+		makeBackend("10.0.0.2", 8080, "us-east-1b"),
+		makeBackend("10.0.0.3", 8080, "us-east-1a"),
+	}
+
+	assignments := computeLoadAssignments(svcName, allPorts(), nil, backendsSeq(backends))
+
+	require.Len(t, assignments, 2)
+	cla := assignments[1]
+	require.Len(t, cla.Endpoints, 1)
+	require.Nil(t, cla.Endpoints[0].Locality, "expected no locality without ForZones hints")
+	require.Len(t, cla.Endpoints[0].LbEndpoints, 3)
+}
+
+// Mixed: some backends have zone, some don't, none have ForZones → flat output.
+func TestComputeLoadAssignments_ZoneWithoutHints_MixedZoneAndNoZone(t *testing.T) {
+	svcName := loadbalancer.NewServiceName("test", "backend")
+	backends := []*loadbalancer.Backend{
+		makeBackend("10.0.0.1", 8080, "us-east-1a"),
+		makeBackend("10.0.0.2", 8080, ""),
+	}
+
+	assignments := computeLoadAssignments(svcName, allPorts(), nil, backendsSeq(backends))
+
+	require.Len(t, assignments, 2)
+	cla := assignments[1]
+	require.Len(t, cla.Endpoints, 1)
+	require.Nil(t, cla.Endpoints[0].Locality, "expected no locality without ForZones hints")
+	require.Len(t, cla.Endpoints[0].LbEndpoints, 2)
+}
+
+// --- Tests with topology hints (ForZones set): expect zone-grouped output ---
+
+// Single zone with hints → one LocalityLbEndpoints group with Locality set.
+func TestComputeLoadAssignments_WithHints_SingleZone(t *testing.T) {
+	svcName := loadbalancer.NewServiceName("test", "backend")
+	backends := []*loadbalancer.Backend{
+		makeBackend("10.0.0.1", 8080, "us-east-1a", "us-east-1a"),
+		makeBackend("10.0.0.2", 8080, "us-east-1a", "us-east-1a"),
+	}
+
+	assignments := computeLoadAssignments(svcName, allPorts(), nil, backendsSeq(backends))
+
+	require.Len(t, assignments, 2)
+	cla := assignments[1]
+	require.Len(t, cla.Endpoints, 1)
+	require.NotNil(t, cla.Endpoints[0].Locality)
+	require.Equal(t, "us-east-1a", cla.Endpoints[0].Locality.Zone)
+	require.Len(t, cla.Endpoints[0].LbEndpoints, 2)
+	require.EqualValues(t, 2, cla.Endpoints[0].LoadBalancingWeight.GetValue())
+}
+
+// Multiple zones with hints → one group per zone, weight = endpoint count.
+func TestComputeLoadAssignments_WithHints_MultiZone(t *testing.T) {
+	svcName := loadbalancer.NewServiceName("test", "backend")
+	backends := []*loadbalancer.Backend{
+		makeBackend("10.0.0.1", 8080, "us-east-1a", "us-east-1a"),
+		makeBackend("10.0.0.2", 8080, "us-east-1b", "us-east-1b"),
+		makeBackend("10.0.0.3", 8080, "us-east-1a", "us-east-1a"),
+	}
+
+	assignments := computeLoadAssignments(svcName, allPorts(), nil, backendsSeq(backends))
+
+	require.Len(t, assignments, 2)
+	cla := assignments[1]
+	// Two zone groups sorted by name: us-east-1a (2 eps, weight=2), us-east-1b (1 ep, weight=1).
+	require.Len(t, cla.Endpoints, 2)
+
+	require.NotNil(t, cla.Endpoints[0].Locality)
+	require.Equal(t, "us-east-1a", cla.Endpoints[0].Locality.Zone)
+	require.Len(t, cla.Endpoints[0].LbEndpoints, 2)
+	require.EqualValues(t, 2, cla.Endpoints[0].LoadBalancingWeight.GetValue())
+
+	require.NotNil(t, cla.Endpoints[1].Locality)
+	require.Equal(t, "us-east-1b", cla.Endpoints[1].Locality.Zone)
+	require.Len(t, cla.Endpoints[1].LbEndpoints, 1)
+	require.EqualValues(t, 1, cla.Endpoints[1].LoadBalancingWeight.GetValue())
+}
+
+// Mixed: some backends have hints, some don't → zoned group for hinted backends,
+// flat group (nil Locality) for backends without hints.
+func TestComputeLoadAssignments_WithHints_MixedHintedAndUnhinted(t *testing.T) {
+	svcName := loadbalancer.NewServiceName("test", "backend")
+	backends := []*loadbalancer.Backend{
+		makeBackend("10.0.0.1", 8080, "us-east-1a", "us-east-1a"),
+		makeBackend("10.0.0.2", 8080, "us-east-1b"), // zone set, no ForZones
+	}
+
+	assignments := computeLoadAssignments(svcName, allPorts(), nil, backendsSeq(backends))
+
+	require.Len(t, assignments, 2)
+	cla := assignments[1]
+	// Two groups: "" (no hints, nil Locality) and "us-east-1a" (hinted).
+	require.Len(t, cla.Endpoints, 2)
+
+	// "" sorts before "us-east-1a".
+	require.Nil(t, cla.Endpoints[0].Locality, "unhinted backend should have nil Locality")
+	require.Len(t, cla.Endpoints[0].LbEndpoints, 1)
+	require.EqualValues(t, 1, cla.Endpoints[0].LoadBalancingWeight.GetValue())
+
+	require.NotNil(t, cla.Endpoints[1].Locality)
+	require.Equal(t, "us-east-1a", cla.Endpoints[1].Locality.Zone)
+	require.Len(t, cla.Endpoints[1].LbEndpoints, 1)
+	require.EqualValues(t, 1, cla.Endpoints[1].LoadBalancingWeight.GetValue())
+}

--- a/pkg/ciliumenvoyconfig/controller.go
+++ b/pkg/ciliumenvoyconfig/controller.go
@@ -19,6 +19,7 @@ import (
 	envoy_config_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -489,7 +490,11 @@ func computeLoadAssignments(
 	for _, port := range slices.Sorted(maps.Keys(backendMap)) {
 		bes := backendMap[port]
 
-		var lbEndpoints []*envoy_config_endpoint.LbEndpoint
+		// Group endpoints by zone only when topology hints (ForZones) are set, which
+		// happens when the service has trafficDistribution: PreferSameZone. Without
+		// hints every endpoint falls into the "" bucket producing a single flat
+		// LocalityLbEndpoints with no Locality, preserving prior behaviour.
+		zoneMap := map[string][]*envoy_config_endpoint.LbEndpoint{}
 		for _, addr := range slices.Sorted(maps.Keys(bes)) {
 			be := bes[addr]
 			if numActive != 0 && be.State == loadbalancer.BackendStateTerminating {
@@ -504,7 +509,7 @@ func computeLoadAssignments(
 				continue
 			}
 
-			lbEndpoints = append(lbEndpoints, &envoy_config_endpoint.LbEndpoint{
+			ep := &envoy_config_endpoint.LbEndpoint{
 				HostIdentifier: &envoy_config_endpoint.LbEndpoint_Endpoint{
 					Endpoint: &envoy_config_endpoint.Endpoint{
 						Address: &envoy_config_core.Address{
@@ -519,10 +524,29 @@ func computeLoadAssignments(
 						},
 					},
 				},
-			})
+			}
+			zone := ""
+			if be.Zone != nil && len(be.Zone.ForZones) > 0 {
+				zone = be.Zone.Zone
+			}
+			zoneMap[zone] = append(zoneMap[zone], ep)
 		}
 
-		endpoints := []*envoy_config_endpoint.LocalityLbEndpoints{{LbEndpoints: lbEndpoints}}
+		var endpoints []*envoy_config_endpoint.LocalityLbEndpoints
+		for _, zone := range slices.Sorted(maps.Keys(zoneMap)) {
+			eps := zoneMap[zone]
+			lle := &envoy_config_endpoint.LocalityLbEndpoints{
+				LbEndpoints: eps,
+				// Weight proportional to endpoint count so locality-weighted LB
+				// distributes traffic correctly. A nil weight means "no load" per
+				// the Envoy proto docs, which would cause panic-mode fallback.
+				LoadBalancingWeight: wrapperspb.UInt32(uint32(len(eps))),
+			}
+			if zone != "" {
+				lle.Locality = &envoy_config_core.Locality{Zone: zone}
+			}
+			endpoints = append(endpoints, lle)
+		}
 		assignments = append(assignments,
 			&envoy_config_endpoint.ClusterLoadAssignment{
 				ClusterName: fmt.Sprintf("%s:%s", serviceName.String(), port),

--- a/pkg/ciliumenvoyconfig/controller.go
+++ b/pkg/ciliumenvoyconfig/controller.go
@@ -495,6 +495,7 @@ func computeLoadAssignments(
 		// hints every endpoint falls into the "" bucket producing a single flat
 		// LocalityLbEndpoints with no Locality, preserving prior behaviour.
 		zoneMap := map[string][]*envoy_config_endpoint.LbEndpoint{}
+		hasZoneHints := false
 		for _, addr := range slices.Sorted(maps.Keys(bes)) {
 			be := bes[addr]
 			if numActive != 0 && be.State == loadbalancer.BackendStateTerminating {
@@ -528,6 +529,7 @@ func computeLoadAssignments(
 			zone := ""
 			if be.Zone != nil && len(be.Zone.ForZones) > 0 {
 				zone = be.Zone.Zone
+				hasZoneHints = true
 			}
 			zoneMap[zone] = append(zoneMap[zone], ep)
 		}
@@ -537,13 +539,16 @@ func computeLoadAssignments(
 			eps := zoneMap[zone]
 			lle := &envoy_config_endpoint.LocalityLbEndpoints{
 				LbEndpoints: eps,
-				// Weight proportional to endpoint count so locality-weighted LB
-				// distributes traffic correctly. A nil weight means "no load" per
-				// the Envoy proto docs, which would cause panic-mode fallback.
-				LoadBalancingWeight: wrapperspb.UInt32(uint32(len(eps))),
 			}
 			if zone != "" {
 				lle.Locality = &envoy_config_core.Locality{Zone: zone}
+			}
+			if hasZoneHints {
+				// Weight proportional to endpoint count so locality-weighted LB
+				// distributes traffic correctly across localities. Only set once
+				// zone hints are actually in play; otherwise leave unset to
+				// preserve prior (flat) behaviour.
+				lle.LoadBalancingWeight = wrapperspb.UInt32(uint32(len(eps)))
 			}
 			endpoints = append(endpoints, lle)
 		}


### PR DESCRIPTION

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

<!-- Description of change -->

This patch adds support to cilium agent to push zone aware endpoints to the envoy configuration. It is a required step to achieve strict local zone routing with cross zone failover.

Having a backend service defined as:
```
  apiVersion: v1
  kind: Service
  metadata:
    name: zone-consumer
    namespace: cilium-zone-test
  spec:
    trafficDistribution: PreferSameZone
    selector:
      app: zone-consumer
    ports:
    - port: 8080
      targetPort: 8080
      name: http
```
A simple CEC using this feature is the following

```
 apiVersion: cilium.io/v2
  kind: CiliumEnvoyConfig
  metadata:
    name: zone-locality-test
    namespace: cilium-zone-test
  spec:
    backendServices:
    - name: zone-consumer
      namespace: cilium-zone-test
    resources:
    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
      name: cilium-zone-test/zone-consumer
      type: EDS
      connect_timeout: 5s
      common_lb_config:
        zone_aware_lb_config:
          min_cluster_size: 2
      eds_cluster_config:
        eds_config:
          resource_api_version: V3
          api_config_source:
            api_type: GRPC
            transport_api_version: V3
            grpc_services:
            - envoy_grpc:
                cluster_name: xds-grpc-cilium
```
The important part is the use of zone_aware_lb_config. Without this the zone info is added to EDS but cilium does not use it. The min_cluster_size is set to 2 so that even with a single instance zone awareness works

The main part of the patch was is AIL2 but the testing is AIL3 
[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
