### PR TITLE
bpf: hostfw: tolerate unknown CT protocols and rely on policies

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -227,7 +227,10 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 
 	if (from_host) {
 		if (ipv6_host_policy_egress_lookup(ctx, secctx, ipcache_srcid, ip6, ct_buffer)) {
-			if (unlikely(ct_buffer->ret < 0))
+			/* Tolerate L4 protocol not supported by CT and defer the
+			 * decision to the egress policies if any and applicable.
+			 */
+			if (unlikely(ct_buffer->ret < 0) && ct_buffer->ret != DROP_CT_UNKNOWN_PROTO)
 				return ct_buffer->ret;
 			need_hostfw = true;
 			is_host_id = secctx == HOST_ID;
@@ -238,7 +241,10 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 			return DROP_INVALID;
 
 		if (ipv6_host_policy_ingress_lookup(ctx, ip6, ct_buffer)) {
-			if (unlikely(ct_buffer->ret < 0))
+			/* Tolerate L4 protocol not supported by CT and defer the
+			 * decision to the ingress policies if any and applicable.
+			 */
+			if (unlikely(ct_buffer->ret < 0) && ct_buffer->ret != DROP_CT_UNKNOWN_PROTO)
 				return ct_buffer->ret;
 			need_hostfw = true;
 		}
@@ -675,7 +681,10 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 	if (from_host) {
 		/* We're on the egress path of cilium_host. */
 		if (ipv4_host_policy_egress_lookup(ctx, secctx, ipcache_srcid, ip4, ct_buffer)) {
-			if (unlikely(ct_buffer->ret < 0))
+			/* Tolerate L4 protocol not supported by CT and defer the
+			 * decision to the egress policies if any and applicable.
+			 */
+			if (unlikely(ct_buffer->ret < 0) && ct_buffer->ret != DROP_CT_UNKNOWN_PROTO)
 				return ct_buffer->ret;
 			need_hostfw = true;
 			is_host_id = secctx == HOST_ID;
@@ -687,7 +696,10 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 
 		/* We're on the ingress path of the native device. */
 		if (ipv4_host_policy_ingress_lookup(ctx, ip4, ct_buffer)) {
-			if (unlikely(ct_buffer->ret < 0))
+			/* Tolerate L4 protocol not supported by CT and defer the
+			 * decision to the ingress policies if any and applicable.
+			 */
+			if (unlikely(ct_buffer->ret < 0) && ct_buffer->ret != DROP_CT_UNKNOWN_PROTO)
 				return ct_buffer->ret;
 			need_hostfw = true;
 		}

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -646,10 +646,10 @@ ct_extract_ports6(const struct __ctx_buff *ctx, const struct ipv6hdr *ip6, fragi
 		return ipv6_load_l4_ports(ctx, ip6, fraginfo, off,
 					  dir, &tuple->dport);
 	default:
+		tuple->sport = 0;
+		tuple->dport = 0;
 		/* See comment in ct_extract_ports4. */
 		if (CONFIG(enable_extended_ip_protocols)) {
-			tuple->sport = 0;
-			tuple->dport = 0;
 			break;
 		}
 		/* Unsupported L4 protocol */
@@ -908,10 +908,10 @@ ct_extract_ports4(const struct __ctx_buff *ctx, const struct iphdr *ip4, fraginf
 		return ipv4_load_l4_ports(ctx, ip4, fraginfo, off,
 					  dir, &tuple->dport);
 	default:
+		tuple->sport = 0;
+		tuple->dport = 0;
 		/* Traffic is allowed/dropped based on user-defined policies. */
 		if (CONFIG(enable_extended_ip_protocols)) {
-			tuple->sport = 0;
-			tuple->dport = 0;
 			break;
 		}
 		/* Unsupported L4 protocol */

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -320,6 +320,12 @@ out:
 	return verdict;
 }
 
+/* Enforce HostFW ingress policies. We skip policies on reply packets for which
+ * a CT entry exists.
+ *
+ * For all L4 protocols not supported by CT, we tolerate the entry lookup
+ * failure, and defer the decision to the ingress policy if any and applicable.
+ */
 static __always_inline int
 ipv6_host_policy_ingress(struct __ctx_buff *ctx, __u32 *src_sec_identity,
 			 struct trace_ctx *trace, __s8 *ext_err)
@@ -333,7 +339,7 @@ ipv6_host_policy_ingress(struct __ctx_buff *ctx, __u32 *src_sec_identity,
 
 	if (!ipv6_host_policy_ingress_lookup(ctx, ip6, &ct_buffer))
 		return CTX_ACT_OK;
-	if (ct_buffer.ret < 0)
+	if (ct_buffer.ret < 0 && ct_buffer.ret != DROP_CT_UNKNOWN_PROTO)
 		return ct_buffer.ret;
 
 	return __ipv6_host_policy_ingress(ctx, ip6, &ct_buffer, src_sec_identity, trace, ext_err);
@@ -601,6 +607,12 @@ out:
 	return verdict;
 }
 
+/* Enforce HostFW ingress policies. We skip policies on reply packets for which
+ * a CT entry exists.
+ *
+ * For all L4 protocols not supported by CT, we tolerate the entry lookup
+ * failure, and defer the decision to the ingress policy if any and applicable.
+ */
 static __always_inline int
 ipv4_host_policy_ingress(struct __ctx_buff *ctx, __u32 *src_sec_identity,
 			 struct trace_ctx *trace, __s8 *ext_err)
@@ -614,7 +626,7 @@ ipv4_host_policy_ingress(struct __ctx_buff *ctx, __u32 *src_sec_identity,
 
 	if (!ipv4_host_policy_ingress_lookup(ctx, ip4, &ct_buffer))
 		return CTX_ACT_OK;
-	if (ct_buffer.ret < 0)
+	if (ct_buffer.ret < 0 && ct_buffer.ret != DROP_CT_UNKNOWN_PROTO)
 		return ct_buffer.ret;
 
 	return __ipv4_host_policy_ingress(ctx, ip4, &ct_buffer, src_sec_identity, trace, ext_err);

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -168,6 +168,20 @@ __ipv6_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id, bool is_from_
 	return verdict;
 }
 
+/* Enforce HostFW egress policies. For the two following types of traffic, we
+ * create a CT entry to allow reply traffic:
+ *
+ * 1. Host-originated traffic carrying HOST_ID: for this traffic we also enforce
+ *    host egress policies.
+ * 2. Traffic with Node IP not necessarily Host-generated (i.e. UNKNOWN_ID but
+ *    matching HOST_ID in ipcache): for this traffic, we don't need to enforce
+ *    policies. Traffic can be SNATed pod traffic, or non-transparent proxy
+ *    connections. There exists an exception, that is unmarked kernel-generated
+ *    packets (https://github.com/cilium/cilium/issues/47223).
+ *
+ * For all L4 protocols not supported by CT, we tolerate the entry lookup
+ * failure, and defer the decision to the egress policy if any and applicable.
+ */
 static __always_inline int
 ipv6_host_policy_egress(struct __ctx_buff *ctx,  bool is_from_proxy, __u32 src_id,
 			__u32 ipcache_srcid, const struct ipv6hdr *ip6,
@@ -177,7 +191,7 @@ ipv6_host_policy_egress(struct __ctx_buff *ctx,  bool is_from_proxy, __u32 src_i
 
 	if (!ipv6_host_policy_egress_lookup(ctx, src_id, ipcache_srcid, ip6, &ct_buffer))
 		return CTX_ACT_OK;
-	if (ct_buffer.ret < 0)
+	if (ct_buffer.ret < 0 && ct_buffer.ret != DROP_CT_UNKNOWN_PROTO)
 		return ct_buffer.ret;
 
 	return __ipv6_host_policy_egress(ctx, src_id == HOST_ID, is_from_proxy,
@@ -440,6 +454,20 @@ __ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id, bool is_from_
 	return verdict;
 }
 
+/* Enforce HostFW egress policies. For the two following types of traffic, we
+ * create a CT entry to allow reply traffic:
+ *
+ * 1. Host-originated traffic carrying HOST_ID: for this traffic we also enforce
+ *    host egress policies.
+ * 2. Traffic with Node IP not necessarily Host-generated (i.e. UNKNOWN_ID but
+ *    matching HOST_ID in ipcache): for this traffic, we don't need to enforce
+ *    policies. Traffic can be SNATed pod traffic, or non-transparent proxy
+ *    connections. There exists an exception, that is unmarked kernel-generated
+ *    packets (https://github.com/cilium/cilium/issues/47223).
+ *
+ * For all L4 protocols not supported by CT, we tolerate the entry lookup
+ * failure, and defer the decision to the egress policy if any and applicable.
+ */
 static __always_inline int
 ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_from_proxy, __u32 src_id,
 			__u32 ipcache_srcid, const struct iphdr *ip4,
@@ -449,7 +477,7 @@ ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_from_proxy, __u32 src_id
 
 	if (!ipv4_host_policy_egress_lookup(ctx, src_id, ipcache_srcid, ip4, &ct_buffer))
 		return CTX_ACT_OK;
-	if (ct_buffer.ret < 0)
+	if (ct_buffer.ret < 0 && ct_buffer.ret != DROP_CT_UNKNOWN_PROTO)
 		return ct_buffer.ret;
 
 	return __ipv4_host_policy_egress(ctx, src_id == HOST_ID, is_from_proxy,

--- a/bpf/tests/hostfw_bpf_masq.c
+++ b/bpf/tests/hostfw_bpf_masq.c
@@ -67,6 +67,8 @@ int hostfw_ipv4_bpf_masq_proxy_01_setup(struct __ctx_buff *ctx)
 	ipcache_v4_add_entry(NODE_IP, 0, HOST_ID, 0, 0);
 	ipcache_v4_add_world_entry();
 
+	policy_add_egress_deny_all_entry();
+
 	set_identity_mark(ctx, POD_SEC_IDENTITY, MARK_MAGIC_PROXY_EGRESS);
 
 	return netdev_send_packet(ctx);
@@ -108,6 +110,8 @@ int hostfw_ipv4_bpf_masq_proxy_01_check(const struct __ctx_buff *ctx)
 
 	assert(ct_entry->packets == 1);
 
+	policy_delete_egress_all_entry();
+
 	test_finish();
 }
 
@@ -136,6 +140,8 @@ int hostfw_ipv4_bpf_masq_proxy_02_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "hostfw_ipv4_bpf_masq_proxy_02")
 int hostfw_ipv4_bpf_masq_proxy_02_setup(struct __ctx_buff *ctx)
 {
+	policy_add_ingress_allow_all_entry();
+
 	return netdev_receive_packet(ctx);
 }
 
@@ -172,6 +178,8 @@ int hostfw_ipv4_bpf_masq_proxy_02_check(const struct __ctx_buff *ctx)
 		test_fatal("no CT entry found");
 
 	assert(ct_entry->packets == 2);
+
+	policy_delete_ingress_all_entry();
 
 	test_finish();
 }

--- a/bpf/tests/hostfw_host_iptables.c
+++ b/bpf/tests/hostfw_host_iptables.c
@@ -68,6 +68,8 @@ int hostfw_iptables_host_ipv4_01_pod_setup(struct __ctx_buff *ctx)
 	ipcache_v4_add_entry(NODE_IP, 0, HOST_ID, 0, 0);
 	ipcache_v4_add_world_entry();
 
+	policy_add_egress_deny_all_entry();
+
 	set_identity_mark(ctx, POD_SEC_IDENTITY, MARK_MAGIC_IDENTITY);
 
 	return netdev_send_packet(ctx);
@@ -109,6 +111,8 @@ int hostfw_iptables_host_ipv4_01_pod_check(const struct __ctx_buff *ctx)
 
 	assert(ct_entry->packets == 1);
 
+	policy_delete_egress_all_entry();
+
 	test_finish();
 }
 
@@ -137,6 +141,8 @@ int hostfw_iptables_host_ipv4_02_pod_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "hostfw_iptables_host_ipv4_02_pod")
 int hostfw_iptables_host_ipv4_02_pod_setup(struct __ctx_buff *ctx)
 {
+	policy_add_ingress_deny_all_entry();
+
 	return netdev_receive_packet(ctx);
 }
 
@@ -174,6 +180,8 @@ int hostfw_iptables_host_ipv4_02_pod_check(const struct __ctx_buff *ctx)
 
 	assert(ct_entry->packets == 2);
 
+	policy_delete_ingress_all_entry();
+
 	test_finish();
 }
 
@@ -206,6 +214,8 @@ int hostfw_iptables_host_ipv4_03_host_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "hostfw_iptables_host_ipv4_03_host")
 int hostfw_iptables_host_ipv4_03_host_setup(struct __ctx_buff *ctx)
 {
+	policy_add_egress_deny_all_entry();
+
 	set_identity_mark(ctx, 0, MARK_MAGIC_HOST);
 
 	return netdev_send_packet(ctx);
@@ -228,6 +238,8 @@ int hostfw_iptables_host_ipv4_03_host_check(const struct __ctx_buff *ctx)
 	status_code = data;
 
 	assert(*status_code == CTX_ACT_DROP);
+
+	policy_delete_egress_all_entry();
 
 	test_finish();
 }
@@ -303,6 +315,8 @@ int hostfw_iptables_host_ipv4_04_host_check(const struct __ctx_buff *ctx)
 
 	assert(ct_entry->packets == 1);
 
+	policy_delete_egress_all_entry();
+
 	test_finish();
 }
 
@@ -331,6 +345,8 @@ int hostfw_iptables_host_ipv4_05_host_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "hostfw_iptables_host_ipv4_05_host")
 int hostfw_iptables_host_ipv4_05_host_setup(struct __ctx_buff *ctx)
 {
+	policy_add_ingress_deny_all_entry();
+
 	return netdev_receive_packet(ctx);
 }
 
@@ -368,7 +384,7 @@ int hostfw_iptables_host_ipv4_05_host_check(const struct __ctx_buff *ctx)
 
 	assert(ct_entry->packets == 2);
 
-	policy_delete_egress_all_entry();
+	policy_delete_ingress_all_entry();
 
 	test_finish();
 }

--- a/bpf/tests/hostfw_igmp.h
+++ b/bpf/tests/hostfw_igmp.h
@@ -88,6 +88,8 @@ int hostfw_igmp_egress_check(const struct __ctx_buff *ctx)
 
 	status_code = data;
 
+	assert(*status_code == CTX_ACT_OK);
+
 	/* Check for egress CT entry */
 	struct ipv4_ct_tuple tuple = {
 		.daddr   = NODE_IP,
@@ -100,15 +102,11 @@ int hostfw_igmp_egress_check(const struct __ctx_buff *ctx)
 	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
 
 #ifdef TEST_EXTENDED_PROTOCOLS
-	assert(*status_code == CTX_ACT_OK);
-
 	if (!ct_entry)
 		test_fatal("no CT entry found");
 
 	assert(ct_entry->packets == 1);
 #else
-	assert(*status_code == CTX_ACT_DROP);
-
 	if (ct_entry)
 		test_fatal("CT entry found");
 
@@ -116,7 +114,7 @@ int hostfw_igmp_egress_check(const struct __ctx_buff *ctx)
 		.reason = (__u8)-DROP_CT_UNKNOWN_PROTO,
 		.dir = METRIC_EGRESS,
 	};
-	__u64 count = 1;
+	__u64 count = 0;
 
 	assert_metrics_count(key, count);
 #endif
@@ -155,6 +153,8 @@ int hostfw_igmp_ingress_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "hostfw_igmp_2_ingress")
 int hostfw_igmp_ingress_setup(struct __ctx_buff *ctx)
 {
+	policy_add_ingress_allow_all_entry();
+
 	return netdev_receive_packet(ctx);
 }
 
@@ -206,6 +206,8 @@ int hostfw_igmp_ingress_check(const struct __ctx_buff *ctx)
 
 	assert_metrics_count(key, count);
 #endif
+
+	policy_delete_ingress_all_entry();
 
 	test_finish();
 }
@@ -267,6 +269,8 @@ int hostfw_igmp_egress_policy_check(const struct __ctx_buff *ctx)
 
 	status_code = data;
 
+	assert(*status_code == CTX_ACT_OK);
+
 	/* Check for egress CT entry */
 	struct ipv4_ct_tuple tuple = {
 		.daddr   = NODE_IP2,
@@ -279,13 +283,9 @@ int hostfw_igmp_egress_policy_check(const struct __ctx_buff *ctx)
 	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
 
 #ifdef TEST_EXTENDED_PROTOCOLS
-	assert(*status_code == CTX_ACT_OK);
-
 	if (!ct_entry)
 		test_fatal("no CT entry found");
 #else
-	assert(*status_code == CTX_ACT_DROP);
-
 	if (ct_entry)
 		test_fatal("CT entry found");
 
@@ -293,7 +293,7 @@ int hostfw_igmp_egress_policy_check(const struct __ctx_buff *ctx)
 		.reason = (__u8)-DROP_CT_UNKNOWN_PROTO,
 		.dir = METRIC_EGRESS,
 	};
-	__u64 count = 2;
+	__u64 count = 0;
 
 	assert_metrics_count(key, count);
 #endif
@@ -333,6 +333,7 @@ SETUP("tc", "hostfw_igmp_4_ingress_policy")
 int hostfw_igmp_ingress_policy_setup(struct __ctx_buff *ctx)
 {
 	policy_add_ingress_deny_l4_entry(IPPROTO_IGMP, 0, 0);
+	policy_add_ingress_allow_all_entry();
 
 	return netdev_receive_packet(ctx);
 }
@@ -368,6 +369,8 @@ int hostfw_igmp_ingress_policy_check(const struct __ctx_buff *ctx)
 #endif
 
 	assert_metrics_count(key, count);
+
+	policy_delete_ingress_all_entry();
 
 	test_finish();
 }

--- a/bpf/tests/hostfw_igmp.h
+++ b/bpf/tests/hostfw_igmp.h
@@ -88,9 +88,6 @@ int hostfw_igmp_egress_check(const struct __ctx_buff *ctx)
 
 	status_code = data;
 
-#ifdef TEST_EXTENDED_PROTOCOLS
-	assert(*status_code == CTX_ACT_OK);
-
 	/* Check for egress CT entry */
 	struct ipv4_ct_tuple tuple = {
 		.daddr   = NODE_IP,
@@ -102,12 +99,26 @@ int hostfw_igmp_egress_check(const struct __ctx_buff *ctx)
 	};
 	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
 
+#ifdef TEST_EXTENDED_PROTOCOLS
+	assert(*status_code == CTX_ACT_OK);
+
 	if (!ct_entry)
 		test_fatal("no CT entry found");
 
 	assert(ct_entry->packets == 1);
 #else
 	assert(*status_code == CTX_ACT_DROP);
+
+	if (ct_entry)
+		test_fatal("CT entry found");
+
+	struct metrics_key key = {
+		.reason = (__u8)-DROP_CT_UNKNOWN_PROTO,
+		.dir = METRIC_EGRESS,
+	};
+	__u64 count = 1;
+
+	assert_metrics_count(key, count);
 #endif
 
 	policy_delete_egress_all_entry();
@@ -163,9 +174,6 @@ int hostfw_igmp_ingress_check(const struct __ctx_buff *ctx)
 
 	status_code = data;
 
-#ifdef TEST_EXTENDED_PROTOCOLS
-	assert(*status_code == CTX_ACT_OK);
-
 	/* Check whether this packet hits the existing egress entry */
 	struct ipv4_ct_tuple tuple = {
 		.daddr   = NODE_IP,
@@ -177,12 +185,26 @@ int hostfw_igmp_ingress_check(const struct __ctx_buff *ctx)
 	};
 	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
 
+#ifdef TEST_EXTENDED_PROTOCOLS
+	assert(*status_code == CTX_ACT_OK);
+
 	if (!ct_entry)
 		test_fatal("no CT entry found");
 
 	assert(ct_entry->packets == 2);
 #else
 	assert(*status_code == CTX_ACT_DROP);
+
+	if (ct_entry)
+		test_fatal("CT entry found");
+
+	struct metrics_key key = {
+		.reason = (__u8)-DROP_CT_UNKNOWN_PROTO,
+		.dir = METRIC_INGRESS,
+	};
+	__u64 count = 1;
+
+	assert_metrics_count(key, count);
 #endif
 
 	test_finish();
@@ -245,9 +267,6 @@ int hostfw_igmp_egress_policy_check(const struct __ctx_buff *ctx)
 
 	status_code = data;
 
-#ifdef TEST_EXTENDED_PROTOCOLS
-	assert(*status_code == CTX_ACT_OK);
-
 	/* Check for egress CT entry */
 	struct ipv4_ct_tuple tuple = {
 		.daddr   = NODE_IP2,
@@ -259,10 +278,24 @@ int hostfw_igmp_egress_policy_check(const struct __ctx_buff *ctx)
 	};
 	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
 
+#ifdef TEST_EXTENDED_PROTOCOLS
+	assert(*status_code == CTX_ACT_OK);
+
 	if (!ct_entry)
 		test_fatal("no CT entry found");
 #else
 	assert(*status_code == CTX_ACT_DROP);
+
+	if (ct_entry)
+		test_fatal("CT entry found");
+
+	struct metrics_key key = {
+		.reason = (__u8)-DROP_CT_UNKNOWN_PROTO,
+		.dir = METRIC_EGRESS,
+	};
+	__u64 count = 2;
+
+	assert_metrics_count(key, count);
 #endif
 
 	policy_delete_egress_all_entry();
@@ -321,6 +354,20 @@ int hostfw_igmp_ingress_policy_check(const struct __ctx_buff *ctx)
 	status_code = data;
 
 	assert(*status_code == CTX_ACT_DROP);
+
+	struct metrics_key key = {
+		.reason = (__u8)-DROP_CT_UNKNOWN_PROTO,
+		.dir = METRIC_INGRESS,
+	};
+#ifdef TEST_EXTENDED_PROTOCOLS
+	/* Packet being dropped per-policy, counter not updated */
+	__u64 count = 0;
+#else
+	/* Packet being dropped per CT lookup, counter updated */
+	__u64 count = 2;
+#endif
+
+	assert_metrics_count(key, count);
 
 	test_finish();
 }

--- a/bpf/tests/hostfw_igmp.h
+++ b/bpf/tests/hostfw_igmp.h
@@ -174,6 +174,8 @@ int hostfw_igmp_ingress_check(const struct __ctx_buff *ctx)
 
 	status_code = data;
 
+	assert(*status_code == CTX_ACT_OK);
+
 	/* Check whether this packet hits the existing egress entry */
 	struct ipv4_ct_tuple tuple = {
 		.daddr   = NODE_IP,
@@ -186,15 +188,11 @@ int hostfw_igmp_ingress_check(const struct __ctx_buff *ctx)
 	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
 
 #ifdef TEST_EXTENDED_PROTOCOLS
-	assert(*status_code == CTX_ACT_OK);
-
 	if (!ct_entry)
 		test_fatal("no CT entry found");
 
 	assert(ct_entry->packets == 2);
 #else
-	assert(*status_code == CTX_ACT_DROP);
-
 	if (ct_entry)
 		test_fatal("CT entry found");
 
@@ -202,7 +200,7 @@ int hostfw_igmp_ingress_check(const struct __ctx_buff *ctx)
 		.reason = (__u8)-DROP_CT_UNKNOWN_PROTO,
 		.dir = METRIC_INGRESS,
 	};
-	__u64 count = 1;
+	__u64 count = 0;
 
 	assert_metrics_count(key, count);
 #endif
@@ -360,13 +358,8 @@ int hostfw_igmp_ingress_policy_check(const struct __ctx_buff *ctx)
 		.reason = (__u8)-DROP_CT_UNKNOWN_PROTO,
 		.dir = METRIC_INGRESS,
 	};
-#ifdef TEST_EXTENDED_PROTOCOLS
 	/* Packet being dropped per-policy, counter not updated */
 	__u64 count = 0;
-#else
-	/* Packet being dropped per CT lookup, counter updated */
-	__u64 count = 2;
-#endif
 
 	assert_metrics_count(key, count);
 

--- a/bpf/tests/lib/policy.h
+++ b/bpf/tests/lib/policy.h
@@ -84,6 +84,23 @@ policy_add_ingress_deny_all_entry(void)
 	policy_add_entry(false, 0, 0, 0, 0, true, 0);
 }
 
+static __always_inline void policy_add_ingress_allow_all_entry(void)
+{
+	policy_add_entry(false, 0, 0, 0, 0, false, 0);
+}
+
+static __always_inline void
+policy_delete_ingress_l3_l4_entry(__u32 sec_label, __u8 protocol, __be16 dport,
+				  __u8 port_range)
+{
+	policy_delete_entry(false, sec_label, protocol, dport, port_range);
+}
+
+static __always_inline void policy_delete_ingress_all_entry(void)
+{
+	policy_delete_ingress_l3_l4_entry(0, 0, 0, 0);
+}
+
 static __always_inline void
 policy_add_egress_allow_l3_l4_entry(__u32 sec_label, __u8 protocol, __be16 dport,
 				    __u8 port_range)


### PR DESCRIPTION
See commits for detailed explanation.

Fixes https://github.com/cilium/cilium/issues/47223.