### PR TITLE
datapath: split world-sourced orphan-fragment drops into new reason

### DIFF
--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -518,6 +518,11 @@ jobs:
           if [[ "${{ matrix.config.kpr }}" == "true" ]]; then
             CONNECTIVITY_TEST_DEFAULTS+=" --test '!pod-to-host'"
           fi
+          # GKE nodes have public IPs and receive stray internet fragments
+          # whose first fragment never reaches the node, which the datapath
+          # correctly drops as world-sourced. Tolerate only that variant here;
+          # in-cluster fragment drops keep the strict reason. See cilium#44131.
+          CONNECTIVITY_TEST_DEFAULTS+=" --expected-drop-reasons='+First logical datagram fragment not found from world'"
 
           echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
 

--- a/api/v1/flow/README.md
+++ b/api/v1/flow/README.md
@@ -1181,6 +1181,7 @@ here.
 | DROP_EP_NOT_READY | 203 | A BPF program wants to tail call some endpoint&#39;s policy program in cilium_call_policy, but the program is not available. |
 | DROP_NO_EGRESS_IP | 204 | An Egress Gateway node matched a packet against an Egress Gateway policy that didn&#39;t select a valid Egress IP. |
 | DROP_PUNT_PROXY | 205 | Punt packet to a user space proxy. |
+| DROP_FRAG_NOT_FOUND_WORLD | 207 | A non-first IP fragment from the world was dropped because its first fragment (carrying the L4 ports) was never seen, so host policy cannot be evaluated. Split from DROP_FRAG_NOT_FOUND to distinguish ambient external fragments from in-cluster fragment-tracking bugs. |
 
 
 

--- a/api/v1/flow/flow.pb.go
+++ b/api/v1/flow/flow.pb.go
@@ -652,6 +652,11 @@ const (
 	DropReason_DROP_NO_EGRESS_IP DropReason = 204
 	// Punt packet to a user space proxy.
 	DropReason_DROP_PUNT_PROXY DropReason = 205
+	// A non-first IP fragment from the world was dropped because its first
+	// fragment (carrying the L4 ports) was never seen, so host policy cannot
+	// be evaluated. Split from DROP_FRAG_NOT_FOUND to distinguish ambient
+	// external fragments from in-cluster fragment-tracking bugs.
+	DropReason_DROP_FRAG_NOT_FOUND_WORLD DropReason = 207
 )
 
 // Enum value maps for DropReason.
@@ -733,6 +738,7 @@ var (
 		203: "DROP_EP_NOT_READY",
 		204: "DROP_NO_EGRESS_IP",
 		205: "DROP_PUNT_PROXY",
+		207: "DROP_FRAG_NOT_FOUND_WORLD",
 	}
 	DropReason_value = map[string]int32{
 		"DROP_REASON_UNKNOWN":                                   0,
@@ -811,6 +817,7 @@ var (
 		"DROP_EP_NOT_READY":                                     203,
 		"DROP_NO_EGRESS_IP":                                     204,
 		"DROP_PUNT_PROXY":                                       205,
+		"DROP_FRAG_NOT_FOUND_WORLD":                             207,
 	}
 )
 
@@ -5916,7 +5923,7 @@ const file_flow_flow_proto_rawDesc = "" +
 	"\n" +
 	"\x06TRACED\x10\x06\x12\x0e\n" +
 	"\n" +
-	"TRANSLATED\x10\a*\xc5\x11\n" +
+	"TRANSLATED\x10\a*\xe5\x11\n" +
 	"\n" +
 	"DropReason\x12\x17\n" +
 	"\x13DROP_REASON_UNKNOWN\x10\x00\x12\x1b\n" +
@@ -5997,7 +6004,8 @@ const file_flow_flow_proto_rawDesc = "" +
 	"\x13DROP_HOST_NOT_READY\x10\xca\x01\x12\x16\n" +
 	"\x11DROP_EP_NOT_READY\x10\xcb\x01\x12\x16\n" +
 	"\x11DROP_NO_EGRESS_IP\x10\xcc\x01\x12\x14\n" +
-	"\x0fDROP_PUNT_PROXY\x10\xcd\x01*J\n" +
+	"\x0fDROP_PUNT_PROXY\x10\xcd\x01\x12\x1e\n" +
+	"\x19DROP_FRAG_NOT_FOUND_WORLD\x10\xcf\x01*J\n" +
 	"\x10TrafficDirection\x12\x1d\n" +
 	"\x19TRAFFIC_DIRECTION_UNKNOWN\x10\x00\x12\v\n" +
 	"\aINGRESS\x10\x01\x12\n" +

--- a/api/v1/flow/flow.proto
+++ b/api/v1/flow/flow.proto
@@ -524,6 +524,11 @@ enum DropReason {
     DROP_NO_EGRESS_IP = 204;
     // Punt packet to a user space proxy.
     DROP_PUNT_PROXY = 205;
+    // A non-first IP fragment from the world was dropped because its first
+    // fragment (carrying the L4 ports) was never seen, so host policy cannot
+    // be evaluated. Split from DROP_FRAG_NOT_FOUND to distinguish ambient
+    // external fragments from in-cluster fragment-tracking bugs.
+    DROP_FRAG_NOT_FOUND_WORLD = 207;
 }
 
 enum TrafficDirection {

--- a/api/v1/observer/observer.pb.go
+++ b/api/v1/observer/observer.pb.go
@@ -211,6 +211,7 @@ const DropReason_DROP_HOST_NOT_READY = flow.DropReason_DROP_HOST_NOT_READY
 const DropReason_DROP_EP_NOT_READY = flow.DropReason_DROP_EP_NOT_READY
 const DropReason_DROP_NO_EGRESS_IP = flow.DropReason_DROP_NO_EGRESS_IP
 const DropReason_DROP_PUNT_PROXY = flow.DropReason_DROP_PUNT_PROXY
+const DropReason_DROP_FRAG_NOT_FOUND_WORLD = flow.DropReason_DROP_FRAG_NOT_FOUND_WORLD
 
 var DropReason_name = flow.DropReason_name
 var DropReason_value = flow.DropReason_value

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -457,9 +457,11 @@ int tail_handle_ipv6_cont_from_netdev(struct __ctx_buff *ctx)
 
 	ret = tail_handle_ipv6_cont(ctx, src_sec_identity, false, &ext_err);
 
-	if (IS_ERR(ret))
+	if (IS_ERR(ret)) {
+		ret = frag_not_found_world(ret, src_sec_identity);
 		return send_drop_notify_error_ext(ctx, src_sec_identity, ret, ext_err,
 						  METRIC_INGRESS);
+	}
 
 	return ret;
 }
@@ -496,9 +498,11 @@ tail_handle_ipv6(struct __ctx_buff *ctx, __u32 ipcache_srcid, const bool from_ho
 	}
 
 	/* Catch errors from both handle_ipv6 and tail_call_internal here. */
-	if (IS_ERR(ret))
+	if (IS_ERR(ret)) {
+		ret = frag_not_found_world(ret, src_sec_identity);
 		return send_drop_notify_error_ext(ctx, src_sec_identity, ret, ext_err,
 						  METRIC_INGRESS);
+	}
 
 	return ret;
 }
@@ -932,9 +936,11 @@ int tail_handle_ipv4_cont_from_netdev(struct __ctx_buff *ctx)
 
 	ret = tail_handle_ipv4_cont(ctx, src_sec_identity, false, &ext_err);
 
-	if (IS_ERR(ret))
+	if (IS_ERR(ret)) {
+		ret = frag_not_found_world(ret, src_sec_identity);
 		return send_drop_notify_error_ext(ctx, src_sec_identity, ret, ext_err,
 						  METRIC_INGRESS);
+	}
 
 	return ret;
 }
@@ -971,9 +977,11 @@ tail_handle_ipv4(struct __ctx_buff *ctx, __u32 ipcache_srcid, const bool from_ho
 	}
 
 	/* Catch errors from both handle_ipv4 and tail_call_internal here. */
-	if (IS_ERR(ret))
+	if (IS_ERR(ret)) {
+		ret = frag_not_found_world(ret, src_sec_identity);
 		return send_drop_notify_error_ext(ctx, src_sec_identity, ret, ext_err,
 						  METRIC_INGRESS);
+	}
 
 	return ret;
 }

--- a/bpf/bpf_xdp.c
+++ b/bpf/bpf_xdp.c
@@ -92,6 +92,38 @@ bpf_xdp_exit(struct __ctx_buff *ctx, const int verdict)
 	return verdict;
 }
 
+/* XDP has no resolved source identity at the drop epilogue, so resolve it from
+ * the ipcache here to reclassify a world-sourced orphan fragment drop. See
+ * frag_not_found_world() in l4.h for the rationale.
+ */
+#if defined(ENABLE_IPV4) && defined(ENABLE_NODEPORT_ACCELERATION)
+static __always_inline int
+xdp_frag_not_found_world_v4(int ret, const struct iphdr *ip4)
+{
+	const struct remote_endpoint_info *info;
+
+	if (ret != DROP_FRAG_NOT_FOUND)
+		return ret;
+
+	info = lookup_ip4_remote_endpoint(ip4->saddr, 0);
+	return frag_not_found_world(ret, info ? info->sec_identity : WORLD_IPV4_ID);
+}
+#endif /* ENABLE_IPV4 && ENABLE_NODEPORT_ACCELERATION */
+
+#if defined(ENABLE_IPV6) && defined(ENABLE_NODEPORT_ACCELERATION)
+static __always_inline int
+xdp_frag_not_found_world_v6(int ret, const struct ipv6hdr *ip6)
+{
+	const struct remote_endpoint_info *info;
+
+	if (ret != DROP_FRAG_NOT_FOUND)
+		return ret;
+
+	info = lookup_ip6_remote_endpoint((const union v6addr *)&ip6->saddr, 0);
+	return frag_not_found_world(ret, info ? info->sec_identity : WORLD_IPV6_ID);
+}
+#endif /* ENABLE_IPV6 */
+
 #ifdef ENABLE_IPV4
 #ifdef ENABLE_NODEPORT_ACCELERATION
 __declare_tail(CILIUM_CALL_IPV4_FROM_NETDEV)
@@ -113,6 +145,8 @@ int tail_lb_ipv4(struct __ctx_buff *ctx)
 
 		ret = nodeport_lb4(ctx, ip4, UNKNOWN_ID, &punt_to_stack,
 				   &ext_err, &is_dsr);
+		if (IS_ERR(ret))
+			ret = xdp_frag_not_found_world_v4(ret, ip4);
 	}
 
 out:
@@ -185,8 +219,10 @@ int tail_lb_ipv6(struct __ctx_buff *ctx)
 		}
 
 		ret = nodeport_lb6(ctx, ip6, UNKNOWN_ID, &punt_to_stack, &ext_err, &is_dsr);
-		if (IS_ERR(ret))
+		if (IS_ERR(ret)) {
+			ret = xdp_frag_not_found_world_v6(ret, ip6);
 			goto drop_err;
+		}
 	}
 
 	return bpf_xdp_exit(ctx, ret);

--- a/bpf/lib/drop_reasons.h
+++ b/bpf/lib/drop_reasons.h
@@ -86,3 +86,5 @@
 #define DROP_EP_NOT_READY	-203
 #define DROP_NO_EGRESS_IP	-204
 #define DROP_PUNT_PROXY		-205 /* Mapped as drop code, though drop not necessary. */
+/* -206 (DROP_NO_DEVICE) was retired and never released; do not reuse. */
+#define DROP_FRAG_NOT_FOUND_WORLD	-207

--- a/bpf/lib/l4.h
+++ b/bpf/lib/l4.h
@@ -8,6 +8,7 @@
 #include "common.h"
 #include "dbg.h"
 #include "csum.h"
+#include "identity.h"
 
 #define TCP_DPORT_OFF (offsetof(struct tcphdr, dest))
 #define TCP_SPORT_OFF (offsetof(struct tcphdr, source))
@@ -80,4 +81,18 @@ static __always_inline int l4_load_tcp_flags(const struct __ctx_buff *ctx, int l
 					     union tcp_flags *flags)
 {
 	return ctx_load_bytes(ctx, l4_off + 12, flags, 2);
+}
+
+/* A non-first fragment from the world whose first fragment (with the L4 ports)
+ * was never seen can't be matched against policy, so it's dropped. On public
+ * node IPs this is mostly ambient internet noise; report it under a distinct
+ * reason so it can be told apart from in-cluster fragment bugs. Caller must
+ * pass a resolved source identity.
+ */
+static __always_inline int
+frag_not_found_world(int ret, __u32 src_sec_identity)
+{
+	if (ret == DROP_FRAG_NOT_FOUND && identity_is_world(src_sec_identity))
+		return DROP_FRAG_NOT_FOUND_WORLD;
+	return ret;
 }

--- a/pkg/monitor/api/drop.go
+++ b/pkg/monitor/api/drop.go
@@ -106,6 +106,7 @@ var errors = map[uint8]string{
 	204: "No Egress IP configured",
 	205: "Punt to proxy",
 	206: "No device",
+	207: "First logical datagram fragment not found from world",
 }
 
 func extendedReason(extError int8) string {


### PR DESCRIPTION
On nodes with public IPs, the host datapath periodically receives non-first IPv4 fragments coming straight from the internet, whose first fragment (the one carrying the L4 header) never reached the node. With no first fragment we cannot recover the L4 ports, so the datagrams map lookup misses and the packet is dropped on ingress with DROP_FRAG_NOT_FOUND. That drop is correct: without ports there is no way to evaluate host policy.

The trouble is that the very same reason is emitted both for this benign external noise and for genuine in-cluster fragment-tracking bugs, and drop_count_total only carries the reason and direction labels, so nothing reading the metric can tell the two apart. On GKE conformance this shows up as a single unexpected packet drop that fails no-unexpected-packet-drops even though a stray internet fragment hitting the node's public IP is nothing Cilium did wrong.

The first commit splits the world-sourced case into its own reason. The source identity is already resolved at the ingress drop sites in bpf_host, so when the drop is DROP_FRAG_NOT_FOUND and the source is world we report it as DROP_FRAG_NOT_FOUND_WORLD instead. In-cluster sources keep the strict DROP_FRAG_NOT_FOUND, so a real regression on a remote-node or pod identity still surfaces. The default expected-drop-reasons list stays strict for both reasons, so this noise is still visible everywhere it occurs. Reason code -206 (DROP_NO_DEVICE) was retired before it ever shipped, so the new reason takes -207 to avoid reusing a released code point.

The second commit scopes the exception to where it is a known artifact: GKE conformance nodes have public IPs, so the connectivity test there tolerates the world-sourced reason via the +-diff form while keeping the rest of the defaults strict. Other environments keep both reasons strict, so if this noise ever appears elsewhere it is caught rather than silently tolerated.

Seen for example in https://github.com/cilium/cilium/actions/runs/29516084207 (KPR) and https://github.com/cilium/cilium/actions/runs/29473040374 (KPR + IPsec). Related to #44131.

This PR was prepared with AIL:3.

```release-note
Distinguish world-sourced orphan IPv4 fragment drops from in-cluster fragment drops with a dedicated DROP_FRAG_NOT_FOUND_WORLD reason.
```

Fixes https://github.com/cilium/cilium/issues/44131
