### PR TITLE
clarify k8s-common.sh ownership and document helpers

### DIFF
--- a/contrib/backporting/k8s-common.sh
+++ b/contrib/backporting/k8s-common.sh
@@ -24,9 +24,9 @@ export PROG
 
 set -o errtrace
 
-# TODO:
-# - Figure out a way to share common bits with other Kubernetes sub repos
-# - cleanup / function headers
+# NOTE: This file is adapted from upstream Kubernetes release tooling. Cilium-
+# specific helpers live in contrib/backporting/common.sh and gitlib.sh rather
+# than sharing this library with other Kubernetes sub-projects.
 
 ##############################################################################
 # COMMON CONSTANTS
@@ -307,7 +307,10 @@ common::timestamp () {
   esac
 }
 
-# Write our own trap to capture signal
+###############################################################################
+# common::trap() Register trap handlers for signals.
+# @param func - handler function name
+# @param sig... - one or more signal names
 common::trap () {
   local func="$1"
   shift
@@ -318,6 +321,9 @@ common::trap () {
   done
 }
 
+###############################################################################
+# common::trapclean() Handle trapped signals and print a traceback before exit.
+# @param sig - trapped signal name
 common::trapclean () {
   local sig=$1
   local frame=0
@@ -390,7 +396,10 @@ common::askyorn () {
   [[ $yorn == [yY] ]]
 }
 
-# Save a specified number of backups to a file
+###############################################################################
+# common::rotatelog() Rotate a log file, keeping up to num backups.
+# @param file - log file path
+# @param num - number of rotated backups to keep
 common::rotatelog () {
   local file=$1
   local num=$2


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

This PR replaces an outdated(stale todo) TODO in `contrib/backporting/k8s-common.sh` with a short note that this file is adapted from upstream Kubernetes release tooling and that Cilium-specific helpers live in `common.sh` / `gitlib.sh`. Also adds missing function headers for `common::trap`, `common::trapclean`, and `common::rotatelog`.

This is comment-only; no runtime behavior change.

```release-note
k8s-common.sh: Clarify ownership and document helpers
```