### PR TITLE
ci: helm override failsafe in ginkgo workflow

### DIFF
--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -516,10 +516,14 @@ jobs:
               export RACE=1
               export LOCKDEBUG=1
             fi
+            HELM_OVERRIDES="${{ env.HELM_OVERRIDES }}"
             # Only pass the imagePullSecrets helm override when registry auth is required.
-            HELM_OVERRIDES=""
             if [[ "${{ vars.DOCKER_AUTH_REQUIRED }}" == "true" ]]; then
-              HELM_OVERRIDES="-cilium.install-helm-overrides=imagePullSecrets[0].name=cilium-registry"
+              if [[ -n "${HELM_OVERRIDES}" ]]; then
+                HELM_OVERRIDES="${HELM_OVERRIDES},imagePullSecrets[0].name=cilium-registry"
+              else
+                HELM_OVERRIDES="-cilium.install-helm-overrides=imagePullSecrets[0].name=cilium-registry"
+              fi
             fi
             echo "/root/go/bin/ginkgo \
              --focus=\"${{ matrix.cliFocus }}\" \


### PR DESCRIPTION
This commit checks whether HELM_OVERRIDES is already set before defining it. In case we want to add specific helm values from set-env-variable action.