### PR TITLE
egressgw: use node-addresses table to resolve EgressIPs

### DIFF
--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -147,8 +147,9 @@ type Manager struct {
 
 	sysctl sysctl.Sysctl
 
-	db          *statedb.DB
-	deviceTable statedb.Table[*tables.Device]
+	db            *statedb.DB
+	deviceTable   statedb.Table[*tables.Device]
+	nodeAddrTable statedb.Table[tables.NodeAddress]
 }
 
 type Params struct {
@@ -168,8 +169,9 @@ type Params struct {
 	Endpoints         resource.Resource[*k8sTypes.CiliumEndpoint]
 	Sysctl            sysctl.Sysctl
 
-	DB          *statedb.DB
-	DeviceTable statedb.Table[*tables.Device]
+	DB            *statedb.DB
+	DeviceTable   statedb.Table[*tables.Device]
+	NodeAddrTable statedb.Table[tables.NodeAddress]
 
 	Lifecycle cell.Lifecycle
 }
@@ -236,6 +238,7 @@ func newEgressGatewayManager(p Params) (*Manager, error) {
 		sysctl:                        p.Sysctl,
 		db:                            p.DB,
 		deviceTable:                   p.DeviceTable,
+		nodeAddrTable:                 p.NodeAddrTable,
 		nodesAddresses2Labels:         make(map[string]map[string]string),
 	}
 

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -173,23 +173,23 @@ func (config *PolicyConfig) regenerateGatewayConfig(manager *Manager) {
 	}
 }
 
-func deviceGetFirstAdresses(dev *tables.Device) (netip.Addr, netip.Addr) {
-	var firstIPv4, firstIPv6 netip.Addr
+func deviceGetPrimaryAddresses(manager *Manager, iface string) (netip.Addr, netip.Addr) {
+	var primaryIP4, primaryIP6 netip.Addr
 
-	for _, addr := range dev.Addrs {
-		if addr.Addr.Is4() && !firstIPv4.IsValid() {
-			firstIPv4 = addr.Addr
-		}
-		if addr.Addr.Is6() && !firstIPv6.IsValid() {
-			firstIPv6 = addr.Addr
+	addrs := manager.nodeAddrTable.List(manager.db.ReadTxn(), tables.NodeAddressDeviceNameIndex.Query(iface))
+	for addr := range addrs {
+		if !addr.Primary {
+			continue
 		}
 
-		if firstIPv4.IsValid() && firstIPv6.IsValid() {
-			break
+		if addr.Addr.Is4() {
+			primaryIP4 = addr.Addr
+		} else if addr.Addr.Is6() {
+			primaryIP6 = addr.Addr
 		}
 	}
 
-	return firstIPv4, firstIPv6
+	return primaryIP4, primaryIP6
 }
 
 func getDeviceWithAddress(manager *Manager, addr netip.Addr) *tables.Device {
@@ -222,7 +222,7 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(manager *Manager, gc *po
 		if found {
 			gwc.egressIfindex = uint32(dev.Index)
 
-			egressIP4, egressIP6 = deviceGetFirstAdresses(dev)
+			egressIP4, egressIP6 = deviceGetPrimaryAddresses(manager, dev.Name)
 			if v4Needed && !egressIP4.IsValid() {
 				return fmt.Errorf("failed to retrieve IPv4 address for egress interface")
 			}
@@ -263,7 +263,7 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(manager *Manager, gc *po
 				egressIP4 = gc.egressIP
 
 				if v6Needed {
-					_, egressIP6 = deviceGetFirstAdresses(dev)
+					_, egressIP6 = deviceGetPrimaryAddresses(manager, dev.Name)
 					if !egressIP6.IsValid() {
 						return fmt.Errorf("failed to retrieve IPv6 address for egress interface")
 					}
@@ -272,7 +272,7 @@ func (gwc *gatewayConfig) deriveFromPolicyGatewayConfig(manager *Manager, gc *po
 				egressIP6 = gc.egressIP
 
 				if v4Needed {
-					egressIP4, _ = deviceGetFirstAdresses(dev)
+					egressIP4, _ = deviceGetPrimaryAddresses(manager, dev.Name)
 					if !egressIP4.IsValid() {
 						return fmt.Errorf("failed to retrieve IPv4 address for egress interface")
 					}

--- a/pkg/egressgateway/script_test.go
+++ b/pkg/egressgateway/script_test.go
@@ -66,6 +66,7 @@ func TestPrivilegedScripts(t *testing.T) {
 
 				Cell,
 				sysctl.Cell,
+				tables.NodeAddressCell,
 
 				// Note: We use the default local node store, and setup the node obj
 				// using the mock node sync type.
@@ -122,7 +123,9 @@ func TestPrivilegedScripts(t *testing.T) {
 
 					tables.NewDeviceTable,
 					statedb.RWTable[*tables.Device].ToTable,
-					statedb.RWTable[tables.NodeAddress].ToTable,
+					// For NodeAddressCell
+					tables.NewRouteTable,
+					statedb.RWTable[*tables.Route].ToTable,
 
 					func() loadbalancer.Config {
 						return loadbalancer.DefaultConfig

--- a/pkg/egressgateway/testdata/test.txtar
+++ b/pkg/egressgateway/testdata/test.txtar
@@ -9,6 +9,8 @@ k8s/add ciliumendpoint1.yaml
 
 db/insert devices device-eth0.yaml device-eth1.yaml
 
+db/cmp --timeout=10s node-addresses nodeaddrs.expected
+
 # Check that manager realizes expected bpf map state.
  egress/policy-maps-dump policymap.actual
  * cmp policymap.actual policymap.expected.1
@@ -29,6 +31,14 @@ db/cmp --timeout=10s sysctl sysctl.expected.1
 db/show sysctl --columns Name,Value
 db/cmp --timeout=10s sysctl sysctl.expected.2
 
+-- nodeaddrs.expected --
+Address                   NodePort Primary DeviceName
+10.10.0.1                 false    true    *
+10.10.0.1                 true     true    eth0
+10.10.0.2                 true     true    eth1
+fd00::10:10:0:1           false    true    *
+fd00::10:10:0:1           true     true    eth0
+fd00::10:10:0:2           true     true    eth1
 -- policymap.expected.1 --
 source_ip=10.244.3.91 dest_cidr=0.0.0.0 egress_ip=10.10.0.1 egress_ifindex=1 gateway_ip=172.18.0.3
 source_ip=fd00:10:244:3::9c94 dest_cidr=:: egress_ip=fd00::10:10:0:1 egress_ifindex=1 gateway_ip=172.18.0.3
@@ -117,9 +127,11 @@ addrs:
   - addr: 10.10.0.1
   - addr: fd00::10:10:0:1
   - addr: fe80::42:bdff:ec52:ab12
+    scope: 0xfd
 type: veth
 flags: 1 # admin-up
 operstatus: up
+selected: true
 -- device-eth1.yaml --
 index: 2
 name: eth1
@@ -131,3 +143,4 @@ addrs:
 type: veth
 flags: 1 # admin-up
 operstatus: up
+selected: true

--- a/pkg/egressgateway/testdata/test_egressip.txtar
+++ b/pkg/egressgateway/testdata/test_egressip.txtar
@@ -9,6 +9,8 @@ k8s/add ciliumendpoint1.yaml
 
 db/insert devices device-eth0.yaml device-eth1.yaml
 
+db/cmp --timeout=10s node-addresses nodeaddrs.expected
+
 # Check that manager realizes expected bpf map state.
  egress/policy-maps-dump policymap.actual
  * cmp policymap.actual policymap.expected.1
@@ -28,6 +30,14 @@ db/cmp --timeout=10s sysctl sysctl.expected.1
 db/show sysctl --columns Name,Value
 db/cmp --timeout=10s sysctl sysctl.expected.2
 
+-- nodeaddrs.expected --
+Address                   NodePort Primary DeviceName
+10.10.0.1                 false    true    *
+10.10.0.1                 true     true    eth0
+10.10.0.2                 true     true    eth1
+fd00::10:10:0:1           false    true    *
+fd00::10:10:0:1           true     true    eth0
+fd00::10:10:0:2           true     true    eth1
 -- policymap.expected.1 --
 source_ip=10.244.3.91 dest_cidr=0.0.0.0 egress_ip=10.10.0.1 egress_ifindex=0 gateway_ip=172.18.0.3
 source_ip=fd00:10:244:3::9c94 dest_cidr=:: egress_ip=fd00::10:10:0:1 egress_ifindex=0 gateway_ip=172.18.0.3
@@ -116,9 +126,11 @@ addrs:
   - addr: 10.10.0.1
   - addr: fd00::10:10:0:1
   - addr: fe80::42:bdff:ec52:ab11
+    scope: 0xfd
 type: veth
 flags: 1 # admin-up
 operstatus: up
+selected: true
 -- device-eth1.yaml --
 index: 2
 name: eth1
@@ -126,6 +138,8 @@ addrs:
   - addr: 10.10.0.2
   - addr: fd00::10:10:0:2
   - addr: fe80::42:bdff:ec52:ab12
+    scope: 0xfd
 type: veth
 flags: 1 # admin-up
 operstatus: up
+selected: true


### PR DESCRIPTION
Make use of the existing logic, so that we end up selecting the same IPs as for regular BPF masquerading. And filter out link-local IPv6 addresses.