### PR TITLE
docs: improve clustermesh setup page

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -168,7 +168,14 @@ extlinks = {
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = [
+    '_build',
+    'Thumbs.db',
+    '.DS_Store',
+    # Already included as a fragment from another page, including it in source
+    # processing would process the labels twice
+    'operations/troubleshooting_clustermesh.rst'
+]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'

--- a/Documentation/network/clustermesh/index.rst
+++ b/Documentation/network/clustermesh/index.rst
@@ -20,6 +20,3 @@ Multi-cluster Networking
    load-balancing
    policy
    affinity
-   aks-clustermesh-prep
-   eks-clustermesh-prep
-   gke-clustermesh-prep

--- a/Documentation/network/clustermesh/setup.rst
+++ b/Documentation/network/clustermesh/setup.rst
@@ -27,6 +27,10 @@ Cluster Addressing Requirements
   may default to :ref:`arch_overlay` or :ref:`native_routing` mode depending on
   the specific cloud environment.
 
+* The Cilium versions of all clusters must differ by no more than one minor
+  release. For example, Cilium ``1.18.x`` can connect to clusters running
+  Cilium ``1.17.x`` or ``1.19.x``, but not ``1.16.x``.
+
 * PodCIDR ranges in all clusters and all nodes must be non-conflicting and
   unique IP addresses.
 

--- a/Documentation/network/clustermesh/setup.rst
+++ b/Documentation/network/clustermesh/setup.rst
@@ -110,17 +110,6 @@ Scaling Limitations
   changed for existing clusters. Changing this option on a live cluster may result in connection
   disruption and possible incorrect enforcement of network policies
 
-Install the Cilium CLI
-======================
-
-.. include:: ../../installation/cli-download.rst
-
-.. warning::
-
-  Don't use the Cilium CLI *helm* mode to enable Cluster Mesh or connect clusters
-  configured using the Cilium CLI operating in *classic* mode, as the two modes are
-  not compatible with each other.
-
 Prepare the Clusters
 ####################
 
@@ -141,20 +130,17 @@ cluster ID (1-255). The cluster name must respect the following constraints:
 * It must begin and end with a lower case alphanumeric character;
 * It may contain lower case alphanumeric characters and dashes between.
 
-It is best to assign both the cluster name and the cluster ID at installation time:
+It is best to assign both the cluster name and the cluster ID at installation time.
+Set the following Helm values for each cluster:
 
- * ConfigMap options ``cluster-name`` and ``cluster-id``
- * Helm options ``cluster.name`` and ``cluster.id``
- * Cilium CLI install options ``--set cluster.name`` and ``--set cluster.id``
+.. code-block:: yaml
 
-Review :ref:`k8s_install_quick` for more details and use cases.
+   cluster:
+     name: cluster1
+     id: 1
 
-Example install using the Cilium CLI:
-
-.. code-block:: shell-session
-
-  cilium install --set cluster.name=$CLUSTER1 --set cluster.id=1 --context $CLUSTER1
-  cilium install --set cluster.name=$CLUSTER2 --set cluster.id=2 --context $CLUSTER2
+Use a different name and ID in each cluster. Review :ref:`k8s_install_quick` for
+more details and use cases.
 
 .. important::
 
@@ -162,6 +148,8 @@ Example install using the Cilium CLI:
    workloads, you will need to restart all workloads. The cluster ID is used to
    generate the security identity and it will need to be re-created in order to
    establish access across clusters.
+
+.. _clustermesh_setup_tls:
 
 Configure TLS certificates
 ==========================
@@ -377,10 +365,222 @@ a common root CA, or configure ``tls.caBundle`` with every trusted CA certificat
 
 For TLS troubleshooting, see :ref:`troubleshooting_clustermesh_tls`.
 
-.. _enable_clustermesh:
+Configure Cluster Mesh with Helm
+================================
 
-Enable Cluster Mesh
-===================
+The following example values files configure ``cluster1`` and ``cluster2`` as a
+Cluster Mesh. Adapt them to your environment. They assume that the Cluster Mesh
+API servers are reachable through a LoadBalancer exposed with a
+``clusterX.example.com`` DNS name, and use certgen with a shared CA for
+simplicity. Choose a different certificate method if appropriate, as described
+in :ref:`clustermesh_setup_tls`.
+
+Create the following values files:
+
+.. tabs::
+
+    .. group-tab:: cluster1.yaml
+
+        .. code-block:: yaml
+
+            cluster:
+              name: cluster1
+              id: 1
+
+            clustermesh:
+              useAPIServer: true
+
+              config:
+                enabled: true
+
+              apiserver:
+                service:
+                  type: LoadBalancer
+                  annotations: {}
+                  # The following annotations are examples. Adapt them to your
+                  # environment and context.
+                  #
+                  # Optional: Have ExternalDNS create the DNS records to
+                  # reach this API server. Otherwise, create the same record
+                  # through your usual DNS management workflow.
+                  # annotations:
+                  #   external-dns.alpha.kubernetes.io/hostname: cluster1.example.com
+                  #
+                  # AKS:
+                  # annotations:
+                  #   service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+                  #
+                  # EKS:
+                  # annotations:
+                  #   service.beta.kubernetes.io/aws-load-balancer-scheme: internal
+                  #
+                  # GKE:
+                  # annotations:
+                  #   networking.gke.io/load-balancer-type: Internal
+                  #   networking.gke.io/internal-load-balancer-allow-global-access: "true"
+                tls:
+                  auto:
+                    enabled: true
+                    method: cronJob
+                    server:
+                      extraDnsNames:
+                        - cluster1.example.com
+
+              # Optional Cluster Mesh features that you may find useful:
+              # enableEndpointSliceSynchronization: true
+              # mcsapi:
+              #   enabled: true
+              #   corednsAutoConfigure:
+              #     enabled: true
+
+    .. group-tab:: cluster2.yaml
+
+        .. code-block:: yaml
+
+            cluster:
+              name: cluster2
+              id: 2
+
+            clustermesh:
+              useAPIServer: true
+
+              config:
+                enabled: true
+
+              apiserver:
+                service:
+                  type: LoadBalancer
+                  annotations: {}
+                  # The following annotations are examples. Adapt them to your
+                  # environment and context.
+                  #
+                  # Optional: Have ExternalDNS create the DNS records to
+                  # reach this API server. Otherwise, create the same record
+                  # through your usual DNS management workflow.
+                  # annotations:
+                  #   external-dns.alpha.kubernetes.io/hostname: cluster2.example.com
+                  #
+                  # AKS:
+                  # annotations:
+                  #   service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+                  #
+                  # EKS:
+                  # annotations:
+                  #   service.beta.kubernetes.io/aws-load-balancer-scheme: internal
+                  #
+                  # GKE:
+                  # annotations:
+                  #   networking.gke.io/load-balancer-type: Internal
+                  #   networking.gke.io/internal-load-balancer-allow-global-access: "true"
+                tls:
+                  auto:
+                    enabled: true
+                    method: cronJob
+                    server:
+                      extraDnsNames:
+                        - cluster2.example.com
+
+              # Optional Cluster Mesh features that you may find useful:
+              # enableEndpointSliceSynchronization: true
+              # mcsapi:
+              #   enabled: true
+              #   corednsAutoConfigure:
+              #     enabled: true
+
+    .. group-tab:: clusters.yaml
+
+        .. code-block:: yaml
+
+            clustermesh:
+              config:
+                clusters:
+                  cluster1:
+                    address: cluster1.example.com
+                    port: 2379
+                  cluster2:
+                    address: cluster2.example.com
+                    port: 2379
+
+The ``clusters.yaml`` file contains all the remote clusters so that you don't
+have to repeat the same information in every cluster's values file. Note that
+this is possible since Cilium ignores the local cluster from the list of remote
+clusters.
+
+.. important::
+
+    All the possible values for ``clustermesh.apiserver.service.type`` are:
+
+    LoadBalancer:
+        A Kubernetes service of type LoadBalancer is used to expose the control
+        plane. This uses a stable LoadBalancer IP and is typically the best option. 
+
+    NodePort:
+        A Kubernetes service of type NodePort is used to expose the control plane.
+        This requires stable Node IPs. If a node disappears, the Cluster Mesh may
+        have to reconnect to a different node. If all nodes have become
+        unavailable, you may have to re-connect the clusters to extract new node
+        IPs.
+
+    ClusterIP:
+        A Kubernetes service of type ClusterIP is used to expose the control
+        plane. This requires the ClusterIPs are routable between clusters. This is
+        typically only available via the helm chart installation method.
+
+.. cilium-helm-upgrade::
+    :namespace: kube-system
+    :extra-args: --kube-context $CLUSTER1 --reuse-values -f clusters.yaml -f cluster1.yaml
+
+Copy the Cilium CA to ``cluster2`` before enabling Cluster Mesh there, so both
+clusters generate certificates signed by the same CA:
+
+.. code-block:: shell-session
+
+    $ kubectl --context $CLUSTER1 get secret -n kube-system cilium-ca -o yaml | \
+        kubectl --context $CLUSTER2 create -f -
+
+.. cilium-helm-upgrade::
+    :namespace: kube-system
+    :extra-args: --kube-context $CLUSTER2 --reuse-values -f clusters.yaml -f cluster2.yaml
+
+Adapt these files to your configuration-management model as needed. For
+example, you can use a common values file for all the shared settings or split
+the cluster map into group files to apply only the groups that each cluster
+should join and build a "partial mesh" instead of connecting every cluster to
+every other cluster.
+
+Cluster Mesh supports many other configuration scenarios such as using a
+standalone etcd with the KVStore mode, generating your own certificates and/or
+etcd client config, or configuring a partial mesh where not all clusters are
+connected to all others. Don't hesitate to explore the Helm values to discover
+all the available options.
+
+Install the Cilium CLI
+======================
+
+The remaining validation steps use the Cilium CLI. It is also required if you
+use the alternative Cilium CLI setup.
+
+.. include:: ../../installation/cli-download.rst
+
+Alternative: configure with the Cilium CLI
+==========================================
+
+The Cilium CLI can also enable and configure Cluster Mesh across clusters. It
+is a wrapper around Helm and may be used alongside Helm when applicable.
+This can be convenient if you are already using the Cilium CLI to configure
+Cilium or to do a quick setup such as in a lab environment or for a demo.
+
+This alternative still requires a unique ``cluster.name`` and ``cluster.id``
+to be configured in every cluster.
+
+Example install using the Cilium CLI:
+
+.. code-block:: shell-session
+
+    $ cilium install --set cluster.name=$CLUSTER1 --set cluster.id=1 --context $CLUSTER1
+    $ cilium install --set cluster.name=$CLUSTER2 --set cluster.id=2 --context $CLUSTER2
+
+Review :ref:`k8s_install_quick` for more details and use cases.
 
 Enable all required components by running ``cilium clustermesh enable`` in the
 context of both clusters. This will deploy the ``clustermesh-apiserver`` into
@@ -391,29 +591,18 @@ clusters.
 
 .. code-block:: shell-session
 
-   cilium clustermesh enable --context $CLUSTER1
-   cilium clustermesh enable --context $CLUSTER2
+    $ cilium clustermesh enable --context $CLUSTER1
+    $ cilium clustermesh enable --context $CLUSTER2
 
-.. important::
+Finally, connect the clusters. This step only needs to be done in one
+direction. The connection will automatically be established in both directions:
 
-   In some cases, the service type cannot be automatically detected and you need to specify it manually. This
-   can be done with the option ``--service-type``. The possible values are:
+.. code-block:: shell-session
 
-   LoadBalancer:
-     A Kubernetes service of type LoadBalancer is used to expose the control
-     plane. This uses a stable LoadBalancer IP and is typically the best option. 
+    $ cilium clustermesh connect --context $CLUSTER1 --destination-context $CLUSTER2
 
-   NodePort:
-     A Kubernetes service of type NodePort is used to expose the control plane.
-     This requires stable Node IPs. If a node disappears, the Cluster Mesh may
-     have to reconnect to a different node. If all nodes have become
-     unavailable, you may have to re-connect the clusters to extract new node
-     IPs.
-
-   ClusterIP:
-     A Kubernetes service of type ClusterIP is used to expose the control
-     plane. This requires the ClusterIPs are routable between clusters. This is
-     typically only available via the helm chart installation method.
+Validate Cluster Mesh
+=====================
 
 Wait for the Cluster Mesh components to come up by invoking ``cilium
 clustermesh status --wait``. If you are using a service of type LoadBalancer
@@ -421,33 +610,8 @@ then this will also wait for the LoadBalancer to be assigned an IP.
 
 .. code-block:: shell-session
 
-   cilium clustermesh status --context $CLUSTER1 --wait
-   cilium clustermesh status --context $CLUSTER2 --wait
-
-.. code-block:: shell-session
-
-    ✅ Cluster access information is available:
-      - 10.168.0.89:2379
-    ✅ Service "clustermesh-apiserver" of type "LoadBalancer" found
-    🔌 Cluster Connections:
-
-
-Connect Clusters
-================
-
-Finally, connect the clusters. This step only needs to be done in one
-direction. The connection will automatically be established in both directions:
-
-.. code-block:: shell-session
-
-    cilium clustermesh connect --context $CLUSTER1 --destination-context $CLUSTER2
-
-It may take a bit for the clusters to be connected. You can run ``cilium
-clustermesh status --wait`` to wait for the connection to be successful:
-
-.. code-block:: shell-session
-
-   cilium clustermesh status --context $CLUSTER1 --wait
+    $ cilium clustermesh status --context $CLUSTER1 --wait
+    $ cilium clustermesh status --context $CLUSTER2 --wait
 
 The output will look something like this:
 
@@ -466,8 +630,8 @@ The output will look something like this:
     🔌 Cluster Connections:
     - cilium-cli-ci-multicluster-2-168: 2/2 configured, 2/2 connected
 
-If this step does not complete successfully, proceed to the troubleshooting
-section.
+If this step does not complete successfully, proceed to the
+:ref:`clustermesh_setup_troubleshooting` section.
 
 Test Pod Connectivity Between Clusters
 ======================================
@@ -478,7 +642,7 @@ mode:
 
 .. code-block:: shell-session
 
-   cilium connectivity test --context $CLUSTER1 --multi-cluster $CLUSTER2
+    $ cilium connectivity test --context $CLUSTER1 --multi-cluster $CLUSTER2
 
 Next Steps
 ==========
@@ -487,6 +651,8 @@ Logical next steps to explore from here are:
 
  * :ref:`gs_clustermesh_load_balancing`
  * :ref:`gs_clustermesh_network_policy`
+
+.. _clustermesh_setup_troubleshooting:
 
 Troubleshooting
 ###############
@@ -497,15 +663,15 @@ Use the following list of steps to troubleshoot issues with ClusterMesh:
 
     .. code-block:: shell-session
 
-       cilium status --context $CLUSTER1
-       cilium status --context $CLUSTER2
+        $ cilium status --context $CLUSTER1
+        $ cilium status --context $CLUSTER2
 
  #. Validate that Cluster Mesh is enabled and operational:
 
     .. code-block:: shell-session
 
-       cilium clustermesh status --context $CLUSTER1
-       cilium clustermesh status --context $CLUSTER2
+        $ cilium clustermesh status --context $CLUSTER1
+        $ cilium clustermesh status --context $CLUSTER2
 
 If you cannot resolve the issue with the above commands, see the
 :ref:`troubleshooting_clustermesh` for a more detailed troubleshooting guide.

--- a/Documentation/network/clustermesh/setup.rst
+++ b/Documentation/network/clustermesh/setup.rst
@@ -159,38 +159,219 @@ Example install using the Cilium CLI:
    generate the security identity and it will need to be re-created in order to
    establish access across clusters.
 
-Shared Certificate Authority
-============================
+Configure TLS certificates
+==========================
 
-If you are planning to run Hubble Relay across clusters, it is best to share a
-certificate authority (CA) between the clusters as it will enable mTLS across
-clusters to just work.
+Cluster Mesh uses mTLS to secure control plane connections within and between
+clusters. TLS certificates can be generated automatically or manually provided.
 
-You can propagate the CA copying the Kubernetes secret containing the CA
-from one cluster to another:
+The following options are available to configure TLS certificates
+automatically:
 
-.. code-block:: shell-session
+* cilium's `certgen <https://github.com/cilium/certgen>`__ (using a Kubernetes ``CronJob``)
+* `cert-manager <https://cert-manager.io/>`__
+* `Helm <https://helm.sh/docs/chart_template_guide/function_list/#gensignedcert>`__
 
-  kubectl --context=$CLUSTER1 get secret -n kube-system cilium-ca -o yaml | \
-    kubectl --context $CLUSTER2 create -f -
+Every cluster must trust the certificates presented by the other clusters. Use
+a common root CA, or configure ``tls.caBundle`` with every trusted CA certificate.
 
-.. _clustermesh_external_tls:
+.. tabs::
 
-Custom Per-Pod Certificates
-===========================
+    .. group-tab:: CronJob (certgen)
 
-You can inject custom certificates for Cluster Mesh components by
-configuring the following Helm settings:
+        When using certgen, TLS certificates are generated at installation time
+        and a Kubernetes ``CronJob`` is scheduled to renew them (regardless of
+        their expiration date). The certgen method is easier to implement than
+        cert-manager but less flexible.
 
-- Set ``disableDefaultVolumes=true``
-- Inject your own certificate agent via ``extraInitContainers``
-- Specify ``extraVolumes``/``extraVolumeMounts`` to share the certificate
-  mount with the init container
+        The following Helm values configure certgen:
 
-This is useful when you want to provide certificates directly to each pod
-rather than through Kubernetes Secrets (e.g., per-pod certificates issued
-at runtime by HashiCorp Vault, the cert-manager CSI driver, or SPIFFE).
-See :ref:`hubble_enable_tls` for the general pattern.
+        .. code-block:: yaml
+
+          clustermesh:
+            apiserver:
+              tls:
+                auto:
+                  # enable automatic TLS certificate generation
+                  enabled: true
+                  # auto generate certificates using cronJob method
+                  method: cronJob
+                  # certificates validity duration in days (default 1 year)
+                  certValidityDuration: 365
+                  # schedule for certificate re-generation (crontab syntax)
+                  schedule: "0 0 1 */4 *"
+
+    .. group-tab:: cert-manager
+
+        This method relies on `cert-manager <https://cert-manager.io/>`__ to generate
+        the TLS certificates. cert-manager is the de facto way to manage TLS certificates
+        on Kubernetes, and it has the following advantages compared to the other
+        documented methods:
+
+        * Support for multiple issuers (e.g. a custom CA,
+          `Vault <https://www.vaultproject.io/>`__,
+          `Let's Encrypt <https://letsencrypt.org/>`__,
+          `Google's Certificate Authority Service <https://cloud.google.com/certificate-authority-service>`__,
+          and more) allowing to choose the issuer fitting your organization's
+          requirements.
+        * Manages certificates via a
+          `CRD <https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/>`__
+          which is easier to inspect with Kubernetes tools than PEM files.
+
+        **Installation steps:**
+
+        #. First, install `cert-manager <https://cert-manager.io/docs/installation/>`__
+           and setup an `issuer <https://cert-manager.io/docs/configuration/>`_.
+           Please make sure that your issuer can create certificates for the
+           configured Cluster Mesh API server names.
+        #. Install or upgrade Cilium with the following Helm values:
+
+        .. code-block:: yaml
+
+          clustermesh:
+            apiserver:
+              tls:
+                auto:
+                  # enable automatic TLS certificate generation
+                  enabled: true
+                  # auto generate certificates using cert-manager
+                  method: certmanager
+                  # certificates validity duration in days (default 1 year)
+                  certValidityDuration: 365
+                  certManagerIssuerRef:
+                    # Reference to cert-manager's issuer
+                    group: cert-manager.io
+                    kind: ClusterIssuer
+                    name: ca-issuer
+
+        During the first Cilium installation, cert-manager's webhook might not
+        yet be available when Cilium creates its ``Certificate`` resources. See
+        :ref:`troubleshooting_clustermesh_tls` if that occurs.
+
+    .. group-tab:: Helm
+
+        When using Helm, TLS certificates are (re-)generated every time Helm is used
+        to install or upgrade Cilium.
+
+        The following Helm values configure Helm certificate generation:
+
+        .. code-block:: yaml
+
+          clustermesh:
+            apiserver:
+              tls:
+                auto:
+                  # enable automatic TLS certificate generation
+                  enabled: true
+                  # auto generate certificates using helm method
+                  method: helm
+                  # certificates validity duration in days (default 1 year)
+                  certValidityDuration: 365
+
+        The downside of the Helm method is that while certificates are automatically
+        generated, they are not automatically renewed.  Consequently, running
+        ``helm upgrade`` is required when certificates are about to expire (i.e. before
+        the configured ``clustermesh.apiserver.tls.auto.certValidityDuration``).
+
+    .. group-tab:: User Provided Certificates
+
+        In order to provide your own TLS certificates,
+        ``clustermesh.apiserver.tls.auto.enabled`` must be set to ``false``,
+        and the following fixed-name Secrets must be created in the
+        namespace where Cilium is installed, which is typically ``kube-system``.
+
+        The **Common Name (CN)** and **Subject Alternative Name (SAN)** of the
+        certificates must be set as follows:
+
+        * Server: CN ``clustermesh-apiserver.<namespace>.svc``. SANs must
+          include ``clustermesh-apiserver.<namespace>.svc``,
+          ``*.mesh.cilium.io``, ``127.0.0.1``, ``::1``, and every DNS name
+          through which remote clusters reach the Cluster Mesh API Service
+        * Admin: CN ``admin-<cluster-name>``
+        * Remote: CN ``remote`` with the default ``migration`` authentication
+          mode
+        * Local: CN ``local-<cluster-name>``
+
+        Once the certificates have been issued, create the following Secrets in
+        the target namespace:
+
+        * ``clustermesh-apiserver-server-cert``
+        * ``clustermesh-apiserver-admin-cert``
+        * ``clustermesh-apiserver-remote-cert``
+        * ``clustermesh-apiserver-local-cert``
+
+        Each Secret must contain the following keys:
+
+        * ``tls.crt``: The certificate file
+        * ``tls.key``: The private key file
+        * ``ca.crt``: The CA certificate file
+
+        After creating the Secrets, install or upgrade Cilium with automatic
+        certificate generation disabled using the following Helm values:
+
+        .. code-block:: yaml
+
+           clustermesh:
+             apiserver:
+               tls:
+                 auto:
+                   enabled: false
+
+    .. group-tab:: Custom Per-Pod Certificates
+
+        If you want to provide TLS certificates directly to each pod rather than
+        through Kubernetes Secrets, for example with HashiCorp Vault, the
+        cert-manager CSI driver, or SPIFFE, configure a certificate agent and
+        mount its output into the components.
+
+        The external certificate agent is responsible for generating valid
+        certificates. It must generate certificates with the same CN and SAN
+        requirements as user-provided certificates.
+
+        The following Helm values disable automatic certificate generation and
+        the default Cluster Mesh certificate volumes:
+
+        .. code-block:: yaml
+
+          clustermesh:
+            apiserver:
+              tls:
+                auto:
+                  enabled: false
+                disableDefaultVolumes: true
+
+        You can then configure your certificate init containers using the
+        following extension points:
+
+        .. code-block:: yaml
+
+          # Cilium agent
+          extraInitContainers: []
+          extraVolumes: []
+          extraVolumeMounts: []
+
+          operator:
+            extraInitContainers: []
+            extraVolumes: []
+            extraVolumeMounts: []
+
+          clustermesh:
+            apiserver:
+              extraInitContainers: []
+              extraVolumes: []
+              extraVolumeMounts: []
+              kvstoremesh:
+                extraVolumeMounts: []
+
+        Disabling the default Cluster Mesh volumes also removes the peer
+        configuration mounts.
+
+        You need to mount ``cilium-clustermesh`` for the Cilium agent and operator,
+        and ``cilium-kvstoremesh`` for KVStoreMesh, or provide equivalent peer
+        configuration from your own integration. The exact values depend on your
+        certificate management system and are out of scope for this guide.
+
+For TLS troubleshooting, see :ref:`troubleshooting_clustermesh_tls`.
 
 .. _enable_clustermesh:
 

--- a/Documentation/observability/hubble/configuration/tls.rst
+++ b/Documentation/observability/hubble/configuration/tls.rst
@@ -109,12 +109,14 @@ restart Hubble server or Hubble Relay.
         set to ``false``, secrets containing the certificates must be created in the
         ``kube-system`` namespace, and the secret names must be provided to Helm.
 
-        Provided files must be **base64 encoded** PEM certificates.
+        The **Common Name (CN)** and **Subject Alternative Name (SAN)** of the
+        certificates must be set as follows. ``<cluster-name>`` refers to the
+        cluster name defined by ``cluster.name`` (defaults to ``default``):
 
-        In addition, the **Common Name (CN)** and **Subject Alternative Name (SAN)**
-        of the certificate for Hubble server MUST be set to
-        ``*.{cluster-name}.hubble-grpc.cilium.io`` where ``{cluster-name}`` is the
-        cluster name defined by ``cluster.name`` (defaults to ``default``).
+        - Hubble server: ``*.<cluster-name>.hubble-grpc.cilium.io``
+        - Hubble Relay: ``*.hubble-relay.cilium.io``
+        - Hubble UI: ``*.hubble-ui.cilium.io``
+        - Hubble metrics: ``<cluster-name>.hubble-metrics.cilium.io``
 
         Once the certificates have been issued, the secrets must be created in the ``kube-system`` namespace.
 
@@ -175,60 +177,59 @@ restart Hubble server or Hubble Relay.
         If you want to provide TLS certificates directly to each pod rather
         than through Kubernetes Secrets (e.g., per-pod certificates issued at
         runtime by HashiCorp Vault, the cert-manager CSI driver, or SPIFFE),
-        you can disable the default TLS certificate volumes by setting
-        ``disableDefaultVolumes=true`` and provide your own via
-        ``extraVolumes``/``extraVolumeMounts``, and inject a
-        certificate-fetching sidecar via ``extraInitContainers``.
-
-        **Certificate requirements:**
+        configure a certificate agent and mount its output into the component.
 
         The external certificate agent is responsible for generating valid
-        certificates. The Common Name (CN) and Subject Alternative Name
-        (SAN) requirements are the same as for user-provided certificates:
+        certificates. It must generate certificates with the same CN and
+        SAN requirements as user-provided certificates, and write these files:
 
-        - Hubble server: ``*.{cluster-name}.hubble-grpc.cilium.io`` where
-          ``{cluster-name}`` is the cluster name defined by ``cluster.name``
-          (defaults to ``default``)
-        - Hubble Relay: ``*.hubble-relay.cilium.io``
-        - Hubble UI: ``*.hubble-ui.cilium.io``
+        - Hubble server: ``server.crt``, ``server.key``, and
+          ``client-ca.crt`` in ``/var/lib/cilium/tls/hubble``
+        - Hubble Relay: ``client.crt``, ``client.key``, and
+          ``hubble-server-ca.crt`` in ``/var/lib/hubble-relay/tls``. If Relay
+          TLS server is enabled, you also need ``server.crt`` and ``server.key``
+          in the same directory
+        - Hubble UI: ``client.crt``, ``client.key``, and
+          ``hubble-relay-ca.crt`` in ``/var/lib/hubble-ui/certs``
 
-        The certificate agent must write files matching the names expected
-        by each component:
+        The following Helm values disable the default certificate volumes:
 
-        - Hubble server: ``server.crt``, ``server.key``, ``client-ca.crt``
-        - Hubble Relay: ``client.crt``, ``client.key``,
-          ``hubble-server-ca.crt``, and if relay TLS server is enabled:
-          ``server.crt``, ``server.key``
-        - Hubble UI: ``client.crt``, ``client.key``, ``hubble-relay-ca.crt``
+        .. code-block:: yaml
 
-        **Configuration:**
+            hubble:
+              tls:
+                disableDefaultVolumes: true
 
-        For each component, disable its default TLS volume, provide your own
-        via ``extraVolumes``/``extraVolumeMounts``, and configure the
-        certificate agent under ``extraInitContainers``. Hubble Relay and
-        Hubble UI are optional; only set the values for the components you
-        deploy.
+              relay:
+                tls:
+                  disableDefaultVolumes: true
 
-        ::
+              ui:
+                tls:
+                  disableDefaultVolumes: true
+
+        Configure the certificate agent using the following extension points:
+
+        .. code-block:: yaml
 
             # Hubble server (on the cilium-agent DaemonSet)
-            --set hubble.tls.disableDefaultVolumes=true
-            # configure the certificate agent under the top-level extraInitContainers
+            extraInitContainers: []
+            extraVolumes: []
+            extraVolumeMounts: []
 
-            # Hubble Relay
-            --set hubble.relay.tls.disableDefaultVolumes=true
-            # configure the certificate agent under hubble.relay.extraInitContainers
+            hubble:
+              relay:
+                extraInitContainers: []
+                extraVolumes: []
+                extraVolumeMounts: []
 
-            # Hubble UI
-            --set hubble.ui.tls.disableDefaultVolumes=true
-            # configure the certificate agent under hubble.ui.extraInitContainers
+              ui:
+                extraInitContainers: []
+                backend:
+                  extraVolumes: []
+                  extraVolumeMounts: []
 
-        Each component can be configured independently.
-
-        You will need to determine the valid contents of the ``extraVolumes``,
-        ``extraVolumeMounts``, and ``extraInitContainers`` settings based on
-        your own approach to certificate management. The values of these
-        settings are out of scope for this guide.
+        Their exact contents are out of scope for this guide.
 
 .. _hubble_enable_tls_troubleshooting:
 

--- a/Documentation/observability/hubble/configuration/tls.rst
+++ b/Documentation/observability/hubble/configuration/tls.rst
@@ -46,18 +46,27 @@ restart Hubble server or Hubble Relay.
         their expiration date). The certgen method is easier to implement than
         cert-manager but less flexible.
 
-        ::
+        The following Helm values configure certgen:
 
-            --set hubble.tls.auto.enabled=true               # enable automatic TLS certificate generation
-            --set hubble.tls.auto.method=cronJob             # auto generate certificates using cronJob method
-            --set hubble.tls.auto.certValidityDuration=1095  # certificates validity duration in days (default 3 years)
-            --set hubble.tls.auto.schedule="0 0 1 */4 *"     # schedule for certificates re-generation (crontab syntax)
+        .. code-block:: yaml
+
+            hubble:
+              tls:
+                auto:
+                  # enable automatic TLS certificate generation
+                  enabled: true
+                  # auto generate certificates using cronJob method
+                  method: cronJob
+                  # certificates validity duration in days (default 3 years)
+                  certValidityDuration: 1095
+                  # schedule for certificates re-generation (crontab syntax)
+                  schedule: "0 0 1 */4 *"
 
     .. group-tab:: cert-manager
 
         This method relies on `cert-manager <https://cert-manager.io/>`__ to generate
-        the TLS certificates. cert-manager has becomes the de facto way to manage TLS on
-        Kubernetes, and it has the following advantages compared to the other
+        the TLS certificates. cert-manager is the de facto way to manage TLS certificates
+        on Kubernetes, and it has the following advantages compared to the other
         documented methods:
 
         * Support for multiple issuers (e.g. a custom CA,
@@ -76,27 +85,47 @@ restart Hubble server or Hubble Relay.
            and setup an `issuer <https://cert-manager.io/docs/configuration/>`_.
            Please make sure that your issuer is able to create certificates under the
            ``cilium.io`` domain name.
-        #. Install/upgrade Cilium including the following Helm flags:
+        #. Install or upgrade Cilium with the following Helm values:
 
-        ::
+        .. code-block:: yaml
 
-            --set hubble.tls.auto.enabled=true                                 # enable automatic TLS certificate generation
-            --set hubble.tls.auto.method=certmanager                           # auto generate certificates using cert-manager
-            --set hubble.tls.auto.certValidityDuration=1095                    # certificates validity duration in days (default 3 years)
-            --set hubble.tls.auto.certManagerIssuerRef.group="cert-manager.io" # Reference to cert-manager's issuer
-            --set hubble.tls.auto.certManagerIssuerRef.kind="ClusterIssuer"
-            --set hubble.tls.auto.certManagerIssuerRef.name="ca-issuer"
+            hubble:
+              tls:
+                auto:
+                  # enable automatic TLS certificate generation
+                  enabled: true
+                  # auto generate certificates using cert-manager
+                  method: certmanager
+                  # certificates validity duration in days (default 3 years)
+                  certValidityDuration: 1095
+                  certManagerIssuerRef:
+                    # Reference to cert-manager's issuer
+                    group: cert-manager.io
+                    kind: ClusterIssuer
+                    name: ca-issuer
+
+        During the first Cilium installation, cert-manager's webhook might not
+        yet be available when Cilium creates its ``Certificate`` resources. See
+        :ref:`hubble_enable_tls_troubleshooting` if that occurs.
 
     .. group-tab:: Helm
 
         When using Helm, TLS certificates are (re-)generated every time Helm is used
-        for install or upgrade.
+        to install or upgrade Cilium.
 
-        ::
+        The following Helm values configure Helm certificate generation:
 
-            --set hubble.tls.auto.enabled=true               # enable automatic TLS certificate generation
-            --set hubble.tls.auto.method=helm                # auto generate certificates using helm method
-            --set hubble.tls.auto.certValidityDuration=1095  # certificates validity duration in days (default 3 years)
+        .. code-block:: yaml
+
+            hubble:
+              tls:
+                auto:
+                  # enable automatic TLS certificate generation
+                  enabled: true
+                  # auto generate certificates using helm method
+                  method: helm
+                  # certificates validity duration in days (default 3 years)
+                  certValidityDuration: 1095
 
         The downside of the Helm method is that while certificates are automatically
         generated, they are not automatically renewed.  Consequently, running
@@ -107,7 +136,8 @@ restart Hubble server or Hubble Relay.
 
         In order to provide your own TLS certificates, ``hubble.tls.auto.enabled`` must be
         set to ``false``, secrets containing the certificates must be created in the
-        ``kube-system`` namespace, and the secret names must be provided to Helm.
+        namespace where Cilium is installed, which is typically ``kube-system``,
+        and the secret names must be provided to Helm.
 
         The **Common Name (CN)** and **Subject Alternative Name (SAN)** of the
         certificates must be set as follows. ``<cluster-name>`` refers to the
@@ -118,7 +148,8 @@ restart Hubble server or Hubble Relay.
         - Hubble UI: ``*.hubble-ui.cilium.io``
         - Hubble metrics: ``<cluster-name>.hubble-metrics.cilium.io``
 
-        Once the certificates have been issued, the secrets must be created in the ``kube-system`` namespace.
+        Once the certificates have been issued, create the secrets in the target
+        namespace.
 
         Each secret must contain the following keys:
 
@@ -153,18 +184,36 @@ restart Hubble server or Hubble Relay.
 
           $ kubectl -n kube-system create secret generic hubble-metrics-certs --from-file=hubble-metrics.crt --from-file=hubble-metrics.key --from-file=ca.crt
 
-        After the secrets have been created, the secret names must be provided to Helm and automatic certificate generation must be disabled:
+        After the secrets have been created, provide their names to Helm and
+        disable automatic certificate generation with the following Helm values:
 
-        ::
+        .. code-block:: yaml
 
-            --set hubble.tls.auto.enabled=false                                       # Disable automatic TLS certificate generation
-            --set hubble.tls.server.existingSecret="hubble-server-certs"
-            --set hubble.relay.tls.server.enabled=true                                # Enable TLS on Hubble Relay (optional)
-            --set hubble.relay.tls.server.existingSecret="hubble-relay-server-certs"
-            --set hubble.relay.tls.client.existingSecret="hubble-relay-client-certs"
-            --set hubble.ui.tls.client.existingSecret="hubble-ui-client-certs"
-            --set hubble.metrics.tls.enabled=true                                     # Enable TLS on the Hubble metrics API (optional)
-            --set hubble.metrics.tls.server.existingSecret="hubble-metrics-certs"
+            hubble:
+              tls:
+                auto:
+                  # Disable automatic TLS certificate generation.
+                  enabled: false
+                server:
+                  existingSecret: hubble-server-certs
+              relay:
+                tls:
+                  server:
+                    # Enable TLS on Hubble Relay (optional).
+                    enabled: true
+                    existingSecret: hubble-relay-server-certs
+                  client:
+                    existingSecret: hubble-relay-client-certs
+              ui:
+                tls:
+                  client:
+                    existingSecret: hubble-ui-client-certs
+              metrics:
+                tls:
+                  # Enable TLS on the Hubble metrics API (optional).
+                  enabled: true
+                  server:
+                    existingSecret: hubble-metrics-certs
 
         - ``hubble.relay.tls.server.existingSecret`` and ``hubble.ui.tls.client.existingSecret``
           only need to be provided when ``hubble.relay.tls.server.enabled=true`` (default ``false``).
@@ -243,9 +292,7 @@ If you encounter issues after enabling TLS, you can use the following instructio
     .. group-tab:: cert-manager
 
 
-        While installing Cilium or cert-manager you may get the following error:
-
-        ::
+        While installing Cilium or cert-manager you may get the following error::
 
             Error: Internal error occurred: failed calling webhook "webhook.cert-manager.io": Post "https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s": dial tcp x.x.x.x:443: connect: connection refused
 
@@ -299,7 +346,7 @@ If you encounter issues after enabling TLS, you can use the following instructio
 
                     $ helm install cert-manager jetstack/cert-manager \
                             --set webhook.hostNetwork=true \
-                            --set webhook.tolerations='["operator": "Exists"]'
+                            --set 'webhook.tolerations[0].operator=Exists'
 
                 Then configure an issuer and install Cilium.
 

--- a/Documentation/operations/troubleshooting_clustermesh.rst
+++ b/Documentation/operations/troubleshooting_clustermesh.rst
@@ -7,6 +7,8 @@ Install the Cilium CLI
 
 .. include:: /installation/cli-download.rst
 
+.. _troubleshooting_clustermesh_automatic_verification:
+
 Automatic Verification
 ----------------------
 
@@ -51,6 +53,8 @@ Automatic Verification
       command to run the checks only towards a subset of remote clusters.
 
 
+.. _troubleshooting_clustermesh_manual_verification:
+
 Manual Verification
 -------------------
 
@@ -87,25 +91,7 @@ you may perform the following steps to troubleshoot ClusterMesh issues.
       $ kubectl --context $CLUSTER1 exec -it -n kube-system deploy/clustermesh-apiserver \
           -c kvstoremesh -- clustermesh-apiserver kvstoremesh-dbg status --verbose
 
- #. Validate that the required TLS secrets are set up properly. By default, the
-    following TLS secrets must be available in the namespace in which Cilium is
-    installed:
-
-    * ``clustermesh-apiserver-server-cert``, which is used by the etcd container
-      in the clustermesh-apiserver deployment. Not applicable if an external etcd
-      cluster is used.
-
-    * ``clustermesh-apiserver-admin-cert``, which is used by the apiserver/kvstoremesh
-      containers in the clustermesh-apiserver deployment, to authenticate against the
-      sidecar etcd instance. Not applicable if an external etcd cluster is used.
-
-    * ``clustermesh-apiserver-remote-cert``, which is used by Cilium agents, or
-      the kvstoremesh container in the clustermesh-apiserver deployment when
-      KVStoreMesh is enabled, to authenticate against remote etcd instances.
-
-    * ``clustermesh-apiserver-local-cert``, which is used by Cilium agents to
-      authenticate against the local etcd instance. Only applicable if KVStoreMesh
-      is enabled.
+ #. For TLS-related manual checks, see :ref:`troubleshooting_clustermesh_tls`.
 
  #. Validate that the configuration for remote clusters is picked up correctly.
     For each remote cluster, an info log message ``New remote cluster
@@ -209,3 +195,141 @@ State Propagation
     backend IPs consist of pod IPs from all clusters running relevant backends.
     You can further validate the correct datapath plumbing by running
     ``cilium-dbg bpf lb list`` to inspect the state of the eBPF maps.
+
+.. _troubleshooting_clustermesh_tls:
+
+TLS Certificate Troubleshooting
+-------------------------------
+
+If you encounter issues after enabling Cluster Mesh TLS, use the following
+instructions to help diagnose the problem. First, refer to
+:ref:`troubleshooting_clustermesh_automatic_verification` and run the
+troubleshoot commands. They validate TLS authentication and display certificate
+information in a human-readable format.
+
+The following checks apply regardless of the certificate management method:
+
+* Verify that certificates have not expired and that their CN and SANs match
+  the expected values.
+* Verify that each client trusts the CA that signed the server certificate.
+* By default, the following TLS Secrets must be available in the namespace in
+  which Cilium is installed:
+
+   * ``clustermesh-apiserver-server-cert``, which is used by the etcd container
+     in the clustermesh-apiserver deployment. Not applicable if an external etcd
+     cluster is used.
+
+   * ``clustermesh-apiserver-admin-cert``, which is used by the apiserver/kvstoremesh
+     containers in the clustermesh-apiserver deployment, to authenticate against the
+     sidecar etcd instance. Not applicable if an external etcd cluster is used.
+
+   * ``clustermesh-apiserver-remote-cert``, which is used by Cilium agents, or
+     the kvstoremesh container in the clustermesh-apiserver deployment when
+     KVStoreMesh is enabled, to authenticate against remote etcd instances.
+
+   * ``clustermesh-apiserver-local-cert``, which is used by Cilium agents to
+     authenticate against the local etcd instance. Only applicable if KVStoreMesh
+     is enabled.
+
+The following checks depend on the specific method used to provision the
+certificates:
+
+.. tabs::
+
+    .. group-tab:: cert-manager
+
+        While installing Cilium or cert-manager you may get the following error::
+
+            Error: Internal error occurred: failed calling webhook "webhook.cert-manager.io": Post "https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s": dial tcp x.x.x.x:443: connect: connection refused
+
+        This happens when cert-manager's webhook (which is used to verify the
+        ``Certificate``'s CRD resources) is not available. There are several ways
+        to resolve this issue. Pick one of the following options:
+
+        .. tabs::
+
+            .. tab:: Install CRDs first
+
+                Install cert-manager CRDs before Cilium and cert-manager (see `cert-manager's documentation about installing CRDs with kubectl <https://cert-manager.io/docs/installation/helm/#option-1-installing-crds-with-kubectl>`__):
+
+                .. code-block:: shell-session
+
+                    $ kubectl create -f cert-manager.crds.yaml
+
+                Then install cert-manager, configure an issuer and install Cilium.
+
+            .. tab:: Upgrade Cilium
+
+                Install Cilium with Cluster Mesh disabled:
+
+                .. code-block:: shell-session
+
+                    $ helm install cilium cilium/cilium \
+                        --set clustermesh.useAPIServer=false \
+                        --set clustermesh.config.enabled=false \
+                        ...
+
+                Then install cert-manager, configure an issuer, and enable Cluster Mesh.
+
+            .. tab:: Disable webhook
+
+                Disable cert-manager validation (assuming Cilium is installed in
+                the ``kube-system`` namespace):
+
+                .. code-block:: shell-session
+
+                    $ kubectl label namespace kube-system cert-manager.io/disable-validation=true
+
+                Then install Cilium, cert-manager, and configure an issuer.
+
+            .. tab:: Host network webhook
+
+                Configure cert-manager to expose its webhook within the host
+                network namespace:
+
+                .. code-block:: shell-session
+
+                    $ helm install cert-manager jetstack/cert-manager \
+                        --set webhook.hostNetwork=true \
+                        --set 'webhook.tolerations[0].operator=Exists'
+
+                Then configure an issuer and install Cilium.
+
+    .. group-tab:: Helm
+
+        When using Helm certificates are not automatically renewed. If you
+        encounter issues with expired certificates, you can manually renew them
+        by running ``helm upgrade`` to renew the certificates.
+
+    .. group-tab:: User Provided Certificates
+
+        If you encounter issues with the certificates, you can check the
+        certificates and keys by decoding them:
+
+        .. code-block:: shell-session
+
+            $ kubectl -n kube-system get secret clustermesh-apiserver-server-cert -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -text -noout
+            $ kubectl -n kube-system get secret clustermesh-apiserver-server-cert -o jsonpath='{.data.tls\.key}' | base64 -d | openssl pkey -text -noout
+            $ kubectl -n kube-system get secret clustermesh-apiserver-server-cert -o jsonpath='{.data.ca\.crt}' | base64 -d | openssl x509 -text -noout
+
+        The same commands can be used for the other secrets as well.
+
+    .. group-tab:: Custom Per-Pod Certificates
+
+        **Pod stuck in init / CrashLoopBackOff:**
+
+        The certificate agent init container must write all expected certificate
+        and configuration files before the main container starts. Check its logs
+        and the pod's events:
+
+        .. code-block:: shell-session
+
+            $ kubectl -n kube-system logs <pod> -c <cert-agent>
+            $ kubectl -n kube-system describe pod <pod>
+
+        **Secrets still being generated:**
+
+        If the chart still generates TLS Secrets, verify that
+        ``clustermesh.apiserver.tls.auto.enabled`` is set to ``false``. Automatic
+        generation is controlled by this value, not by
+        ``clustermesh.apiserver.tls.disableDefaultVolumes``.


### PR DESCRIPTION
This is the last "big" doc change that I was planning to do for Cluster Mesh and it's addressing mainly the setup page of cluster mesh to be helm first. See the individual commits for more details

Marked it as backport but does not need to be a release blocker / necessarily merged before the 1.20.0 release ~.

Used AIL-2 to help write this

Fixes: #19057 (our oldest currently opened clustermesh issue, and fairly upvoted as well!)

```release-note
docs/clustermesh: overhaul Cluster Mesh documentation with a new introduction, improved load-balancing guidance, and Helm-first setup and certificate configuration instructions
```