### PR TITLE
api/v1/health: Remove dead `x-go-type` `hint` block

### DIFF
--- a/api/v1/health/openapi.yaml
+++ b/api/v1/health/openapi.yaml
@@ -71,9 +71,6 @@ definitions:
       import:
         package: "github.com/cilium/cilium/api/v1/models"
         alias: "ciliumModels"
-      hint:
-        kind: object
-        nullable: true
   HealthResponse:
     description: Health and status information of local node
     type: object

--- a/api/v1/health/server/embedded_spec.go
+++ b/api/v1/health/server/embedded_spec.go
@@ -259,10 +259,6 @@ func init() {
       "description": "Status of Cilium daemon",
       "type": "object",
       "x-go-type": {
-        "hint": {
-          "kind": "object",
-          "nullable": true
-        },
         "import": {
           "alias": "ciliumModels",
           "package": "github.com/cilium/cilium/api/v1/models"
@@ -517,10 +513,6 @@ func init() {
       "description": "Status of Cilium daemon",
       "type": "object",
       "x-go-type": {
-        "hint": {
-          "kind": "object",
-          "nullable": true
-        },
         "import": {
           "alias": "ciliumModels",
           "package": "github.com/cilium/cilium/api/v1/models"


### PR DESCRIPTION
The `hint:` key under `StatusResponse`'s `x-go-type` never had any effect. go-swagger decodes the `x-go-type` extension via mapstructure into a struct whose field is `Hints` (plural). The unknown singular `hint` key is silently dropped. This has held since the block was introduced (with the go-swagger 0.25.0 bump in #12673), so `kind: object` / `nullable: true` were never applied and `HealthResponse.Cilium` has always been generated as a value type, not the pointer the block implies.

Fixing this situation by renaming the broken `hint` to a working `hints` is not possible as that would be an API breaking change by switching the existing value type to be a pointer.

This PR removes the misleading dead config. Code regeneration leaves all generated Go code identical, the only changes are the embedded spec copy.