### PR TITLE
bugtool: collect snmp6 and dev_snmp6 for IPv6 host packet drops

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -172,6 +172,7 @@ func defaultCommands(confDir string, cmdDir string) []string {
 		"cat -u /proc/net/softnet_stat",
 		"cat -u /proc/net/snmp",
 		"cat -u /proc/net/netstat",
+		"cat -u /proc/net/snmp6",
 	)
 
 	return commands
@@ -191,10 +192,17 @@ func miscSystemCommands() []string {
 		// column 3 is time_squeeze (softirq ran out of budget, i.e. the CPU
 		// could not keep up). snmp and netstat add the IP/TCP layer drop
 		// counters (e.g. ListenDrops, ListenOverflows, TCPBacklogDrop) that tell
-		// a socket accept-queue drop apart from a backlog drop.
+		// a socket accept-queue drop apart from a backlog drop. snmp6 and
+		// dev_snmp6 are the IPv6 counterparts: they carry Ip6InDiscards,
+		// Ip6InAddrErrors, Ip6InNoRoutes, Ip6InHdrErrors, Ip6InTruncatedPkts,
+		// Ip6InUnknownProtos and the Tcp6/Udp6 error counters, i.e. the one
+		// place an IPv6 packet dropped in the host IP stack is recorded. The
+		// dev_snmp6 glob is expanded by bash -c into the per-interface files.
 		"cat /proc/net/softnet_stat",
 		"cat /proc/net/snmp",
 		"cat /proc/net/netstat",
+		"cat /proc/net/snmp6",
+		"cat -v -A /proc/net/dev_snmp6/*",
 		// Host and misc
 		"ps auxfw",
 		"hostname",


### PR DESCRIPTION
We already collect `/proc/net/snmp` and `/proc/net/netstat` at the start and end of a bugtool run, so the IPv4 IP and TCP layer drop counters can be diffed over the collection window. There is no IPv6 equivalent, which leaves a blind spot: when an IPv6 SYN-ACK goes missing on the return path in a connectivity test, we cannot tell whether the client host IP stack discarded it or it was lost below the stack, because nothing records `Ip6InDiscards` and its siblings.

I hit exactly this triaging a ci-e2e-upgrade `curl (28)` timeout: the BPF conntrack showed the server had emitted and retransmitted the SYN-ACK while the client saw nothing, so the packet was lost on the return path, but with only the IPv4 counters collected there was no way to place the drop in the client's IPv6 host stack.

Add `/proc/net/snmp6` (aggregate) and `/proc/net/dev_snmp6/*` (per interface) to the misc system commands, right after the existing snmp and netstat, and the matching end-of-run `cat -u /proc/net/snmp6` so the delta over the window is visible, mirroring the snmp/netstat pattern. snmp6 carries `Ip6InDiscards`, `Ip6InAddrErrors`, `Ip6InNoRoutes`, `Ip6InHdrErrors`, `Ip6InTruncatedPkts`, `Ip6InUnknownProtos` and the Tcp6/Udp6 error counters, which are the IPv6 counterparts of the IPv4 `Ip:`/`IpExt:` fields and the one place an IPv6 packet dropped in the host stack lands.

This PR was prepared with AIL:3.
