### PR TITLE
bugtool, cli: instrument plain-ENI EKS outside-to-nodeport drop

### DIFF
--- a/.github/actions/eks/k8s-versions.yaml
+++ b/.github/actions/eks/k8s-versions.yaml
@@ -5,6 +5,7 @@ include:
     region: us-west-1
   - version: "1.33"
     region: us-east-2
+    default: true
   - version: "1.34"
     region: us-east-1
     aws-eni-pd: true

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 
 	"github.com/cilium/cilium/pkg/components"
@@ -178,7 +179,7 @@ func defaultCommands(confDir string, cmdDir string) []string {
 }
 
 func miscSystemCommands() []string {
-	return []string{
+	commands := []string{
 		// We want to collect this twice: at the very beginning and at the
 		// very end of the bugtool collection, to see if the counters are
 		// increasing.
@@ -238,6 +239,35 @@ func miscSystemCommands() []string {
 		"tc qdisc show",
 		"tc -d -s qdisc show", // Show statistics on queuing disciplines
 		"find /sys/fs/bpf -ls",
+	}
+
+	commands = append(commands, conntrackCommands()...)
+
+	return commands
+}
+
+// conntrackCommands dumps the kernel netfilter conntrack table and its global
+// counters. On the plain-ENI EKS datapath with kube-proxy-replacement=false,
+// kube-proxy does the NodePort DNAT and KUBE-MARK-MASQ in iptables before the
+// packet reaches any Cilium datapath BPF prog, so the connection is invisible
+// to both Hubble and Cilium's BPF conntrack (`cilium-dbg bpf ct list`). The
+// kernel conntrack table is the only place its reply-direction state (ASSURED,
+// reply packets/bytes, or the absence thereof) can be observed, and
+// `conntrack -S` exposes the per-CPU drop/early_drop/insert_failed counters.
+// This complements the softnet_stat / snmp / netstat host drop counters above.
+//
+// Prefer conntrack(8), but fall back to reading /proc/net/nf_conntrack when the
+// binary is not present in the agent image (writeCmdToFile skips a command
+// whose binary is missing, so without the fallback we would collect nothing).
+func conntrackCommands() []string {
+	if _, err := exec.LookPath("conntrack"); err == nil {
+		return []string{
+			"conntrack -L",
+			"conntrack -S",
+		}
+	}
+	return []string{
+		"cat /proc/net/nf_conntrack",
 	}
 }
 

--- a/cilium-cli/connectivity/check/action.go
+++ b/cilium-cli/connectivity/check/action.go
@@ -249,6 +249,17 @@ func (a *Action) fail() {
 	a.failed = true
 }
 
+// Failed reports whether Fail/Failf/Fatal/Fatalf was called on this Action.
+// Scenarios can use it to trigger extra diagnostics on a failed Action.
+func (a *Action) Failed() bool {
+	return a.failed
+}
+
+// Name returns the name of the Action.
+func (a *Action) Name() string {
+	return a.name
+}
+
 // WriteDataToPod writes data to a file in the source pod
 // It does this by using a shell command, writing huge files should be avoided
 func (a *Action) WriteDataToPod(ctx context.Context, filePath string, data []byte) {

--- a/cilium-cli/connectivity/sniff/sniffer.go
+++ b/cilium-cli/connectivity/sniff/sniffer.go
@@ -25,6 +25,11 @@ const (
 	// ModeSanity: expect to observe packets matching the filter, to be
 	// leveraged as a sanity check to verify that the filter is correct.
 	ModeSanity Mode = "sanity"
+	// ModeDebug: purely diagnostic capture. Validate is not used in this mode;
+	// the caller invokes Dump to log whatever was captured, and the result never
+	// influences the test verdict. Intended to record datapath state around an
+	// already-failed Action for later analysis.
+	ModeDebug Mode = "debug"
 
 	// Max wait time for tcpdump to start/stop in remote shell.
 	sniffScriptTimeout = 10 * time.Second
@@ -167,12 +172,13 @@ func Sniff(ctx context.Context, name string, target *check.Pod,
 		mode:     mode,
 	}
 
-	// Limit packet capture to avoid large files: 1 in sanity mode, 1000 in assert mode.
+	// Limit packet capture to avoid large files: 1 in sanity mode, 1000 in
+	// assert and debug modes.
 	var count int
 	switch sniffer.mode {
 	case ModeSanity:
 		count = 1
-	case ModeAssert:
+	case ModeAssert, ModeDebug:
 		count = 1000
 	}
 
@@ -250,6 +256,26 @@ func (sniffer *Sniffer) Validate(a *check.Action) {
 		a.Failf("Expected to capture packets, but none found. This check might be broken.")
 		a.Infof("Capture executed on %s (%s): %s", sniffer.target.String(), sniffer.target.NodeName(), strings.Join(sniffer.cmd, " "))
 	}
+}
+
+// Dump stops the capture and logs whatever was captured, without ever failing
+// the Action. It is meant for ModeDebug captures taken around an already-failed
+// Action, purely to record datapath state for later analysis. The label
+// identifies the capture point (e.g. the interface) in the logs.
+func (sniffer *Sniffer) Dump(a *check.Action, label string) {
+	if sniffer == nil {
+		return
+	}
+
+	if err := sniffer.stop(); err != nil {
+		a.Infof("Failed to stop diagnostic capture on %s (%s) [%s]: %s",
+			sniffer.target.String(), sniffer.target.NodeName(), label, err)
+		return
+	}
+
+	a.Infof("Diagnostic capture on %s (%s) [%s], filter %q:\n%s",
+		sniffer.target.String(), sniffer.target.NodeName(), label,
+		strings.Join(sniffer.cmd, " "), sniffer.out.String())
 }
 
 // stop runs the remote command to kill the sniffer process. It executes at most once.

--- a/cilium-cli/connectivity/tests/service.go
+++ b/cilium-cli/connectivity/tests/service.go
@@ -9,8 +9,10 @@ import (
 	"net"
 	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
+	"github.com/cilium/cilium/cilium-cli/connectivity/sniff"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
 	slimcorev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/versioncheck"
@@ -275,9 +277,154 @@ func curlNodePort(ctx context.Context, s check.Scenario, t *check.Test,
 						AltDstPort: np,
 					}))
 				}
+
+				// On plain-ENI EKS the external(host-netns)->NodePort curl times
+				// out (exit 28) while the aws-eni-pd legs pass, and kube-proxy
+				// masquerades the NodePort tuple before it reaches any Cilium
+				// datapath prog, so the loss is invisible to both Hubble and
+				// Cilium's BPF conntrack. On failure only, take a targeted host
+				// capture on the client and target nodes to show whether the SYN
+				// reached the backend node and whether a SYN-ACK made it back.
+				// Purely diagnostic: it never touches the verdict, so a genuine
+				// N/S LB regression still surfaces as exit 28.
+				if a.Failed() && s.Name() == "outside-to-nodeport" {
+					captureOutsideNodePortFailure(ctx, t, a, pod, node, addr.Address, np, svc)
+				}
 			})
 		}
 	})
+}
+
+// captureOutsideNodePortFailure records datapath state around an
+// external(host-netns)->NodePort curl that has already failed with exit 28, so
+// the plain-ENI EKS N/S LB loss becomes diagnosable on the next run.
+//
+// It only runs when NodeWithoutCilium is in effect and kube-proxy-replacement
+// is disabled: that is the exact datapath where kube-proxy DNATs and
+// masquerades the NodePort SYN (making the tuple invisible to Hubble and
+// Cilium's BPF conntrack) and the reply must traverse per-ENI source routing
+// back to the external node. On any other datapath this is a no-op.
+//
+// The capture is purely diagnostic: it starts short per-NIC host tcpdumps on
+// both the external client node and the target (Cilium) node, replays a burst
+// of probes from the external client to try to catch a recurrence within the
+// capture window, and logs whatever was seen on each side. Capturing on both
+// ends localizes the loss: whether the SYN left the client node, reached the
+// target node, was DNAT'd to the backend, and whether a SYN-ACK egressed back
+// toward the external node. It never calls Fail/Fatal, so the original exit-28
+// verdict is left untouched and a genuine regression still surfaces.
+func captureOutsideNodePortFailure(ctx context.Context, t *check.Test, a *check.Action,
+	client *check.Pod, node *slimcorev1.Node,
+	addr string, np uint32, svc check.Service) {
+
+	if nwc, ok := t.Context().Feature(features.NodeWithoutCilium); !ok || !nwc.Enabled {
+		return
+	}
+	if kpr, ok := t.Context().Feature(features.KPR); ok && kpr.Enabled {
+		// With KPR enabled Cilium does the N/S LB and the tuple is visible to
+		// the BPF conntrack / Hubble already; this capture targets the
+		// kube-proxy masquerade path specifically.
+		return
+	}
+
+	// Capture on both ends of the path: the external client node (where the
+	// host-netns curl originates) and the target Cilium node (where the
+	// NodePort is DNAT'd to a backend). Comparing the two shows where the
+	// SYN/SYN-ACK is lost.
+	type capNode struct {
+		name string
+		node string
+	}
+	targets := []capNode{{name: "target-node", node: node.Name}}
+	if client.NodeName() != "" && client.NodeName() != node.Name {
+		targets = append(targets, capNode{name: "client-node", node: client.NodeName()})
+	}
+
+	// Match the NodePort and the backend port (the DNAT target) on both ends.
+	backendPort := svc.Port()
+	filter := fmt.Sprintf("tcp port %d or tcp port %d", np, backendPort)
+
+	t.Infof("outside-to-nodeport failed on the plain-ENI EKS + kube-proxy path; capturing %q on the client and target nodes to localize the loss (client=%s target=%s dst=%s:%d backend-port=%d)",
+		filter, client.NodeName(), node.Name, addr, np, backendPort)
+
+	var sniffers []*sniff.Sniffer
+	for _, cn := range targets {
+		hostPod, ok := t.Context().HostNetNSPodsByNode()[cn.node]
+		if !ok {
+			t.Debugf("No host-netns pod on %s (%s), skipping capture there", cn.name, cn.node)
+			continue
+		}
+		ifaces := hostPhysicalIfaces(ctx, t, &hostPod)
+		if len(ifaces) == 0 {
+			t.Debugf("No physical interfaces found on %s (%s), skipping capture there", cn.name, cn.node)
+			continue
+		}
+		for _, iface := range ifaces {
+			name := fmt.Sprintf("%s-%s-%s-%s", a.Name(), cn.name, cn.node, iface)
+			sniffer, cancel, err := sniff.Sniff(ctx, name, &hostPod, iface, filter, sniff.ModeDebug, sniff.SniffKillTimeout, t)
+			if err != nil {
+				t.Infof("Failed to start diagnostic capture on %s (%s): %s", cn.node, iface, err)
+				continue
+			}
+			defer func() {
+				if err := cancel(); err != nil {
+					t.Debugf("Failed to finalize diagnostic capture on %s (%s): %s", cn.node, iface, err)
+				}
+			}()
+			sniffers = append(sniffers, sniffer)
+		}
+	}
+	if len(sniffers) == 0 {
+		return
+	}
+
+	// Replay a short burst of probes from the external client to catch a
+	// recurrence while the capture is running. This is diagnostic only: the
+	// result is intentionally ignored and never touches the verdict. Bound the
+	// burst well under sniff.SniffKillTimeout: 8 probes capped at 3s each is at
+	// most ~24s, so the capture is still running when we dump it.
+	url := fmt.Sprintf("%s://%s%s", svc.Scheme(), net.JoinHostPort(addr, strconv.FormatUint(uint64(np), 10)), svc.Path())
+	probe := []string{"/bin/sh", "-c", fmt.Sprintf(
+		"for i in $(seq 1 8); do curl --silent --show-error --output /dev/null --connect-timeout 2 --max-time 3 %q || true; done", url)}
+	if _, err := client.K8sClient.ExecInPod(ctx, client.Pod.Namespace, client.Pod.Name, client.Pod.Spec.Containers[0].Name, probe); err != nil {
+		t.Debugf("Diagnostic NodePort probe from %s returned: %s", client.Name(), err)
+	}
+
+	for _, sniffer := range sniffers {
+		sniffer.Dump(a, "nodeport-return-path")
+	}
+}
+
+// hostPhysicalIfaces returns the physical network interfaces of the node the
+// given host-netns pod runs on, skipping loopback and virtual/Cilium-managed
+// devices that are not relevant to the external return path.
+func hostPhysicalIfaces(ctx context.Context, t *check.Test, pod *check.Pod) []string {
+	cmd := []string{"/bin/sh", "-c", "ls -1 /sys/class/net"}
+	out, err := pod.K8sClient.ExecInPod(ctx, pod.Pod.Namespace, pod.Pod.Name, pod.Pod.Spec.Containers[0].Name, cmd)
+	if err != nil {
+		t.Debugf("Failed to list interfaces on %s: %s", pod.NodeName(), err)
+		return nil
+	}
+
+	skipPrefixes := []string{"lo", "cilium", "lxc", "veth", "docker", "cni", "kube-ipvs", "nodelocaldns", "ip6tnl", "tunl", "sit", "gre", "erspan", "dummy"}
+	var ifaces []string
+	for _, line := range strings.Fields(out.String()) {
+		iface := strings.TrimSpace(line)
+		if iface == "" {
+			continue
+		}
+		skip := false
+		for _, p := range skipPrefixes {
+			if strings.HasPrefix(iface, p) {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			ifaces = append(ifaces, iface)
+		}
+	}
+	return ifaces
 }
 
 // OutsideToNodePort sends an HTTP request from client pod running on a node w/o


### PR DESCRIPTION
PR #45246 added node-without-cilium external targets to the EKS workflows, which un-skipped the outside-to-nodeport test. That test now times out (curl exit 28) from the host-netns client to the NodePort, but only on the plain-ENI legs (1.32/us-west-1, 1.33/us-east-2); the aws-eni-pd legs (1.34, 1.35) pass the exact same test with the same agent binary. The drop is config-specific and pre-existing, not a code regression, since #45246 only un-skipped the test without touching the datapath.

With kube-proxy-replacement disabled, kube-proxy DNATs and masquerades the NodePort tuple before it reaches any Cilium datapath prog, so the loss is invisible to both Hubble and Cilium's BPF conntrack and a plain sysdump cannot localize it. This adds the state needed to root-cause it without masking the failure.

bugtool now dumps the kernel conntrack table and its per-CPU counters (conntrack -L/-S, falling back to /proc/net/nf_conntrack), which is the only place kube-proxy's DNAT and masquerade reply-direction state can be seen. On an already-failed outside-to-nodeport action, the connectivity test starts short per-NIC tcpdumps on both the external client node and the target Cilium node, replays a bounded probe burst to catch a recurrence within the capture window, and logs both captures so we can tell where the SYN or SYN-ACK is lost. The capture is gated on node-without-cilium enabled and kube-proxy-replacement disabled, and it never touches the verdict, so it is a no-op on every other datapath and a genuine N/S LB regression still surfaces as exit 28.

The last commit marks the 1.33/us-east-2 plain-ENI leg as default so this PR reproduces the drop and exercises the capture, with 1.35 kept as the passing aws-eni-pd control, and it is dropped before merge. I left out 1.32/us-west-1 because it dies at cluster-create on a separate hardcoded us-west-1b AZ bug before reaching the test.

This PR was prepared with AIL:3.