### PR TITLE
ci: fix three renovate-PR CI flakes (kubectl download retry, merge-upload ref, EKS pool zones)

### DIFF
--- a/.github/workflows/common-post-jobs.yaml
+++ b/.github/workflows/common-post-jobs.yaml
@@ -42,15 +42,9 @@ jobs:
       contents: read
       actions: read
     steps:
-      - name: Checkout context ref (trusted)
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ inputs.context-ref }}
-          persist-credentials: false
-
       - name: Merge JUnits
         if: ${{ inputs.merge-junits }}
-        uses: ./.github/actions/merge-artifacts
+        uses: cilium/cilium/.github/actions/merge-artifacts@main # main
         with:
           name: cilium-junits
           pattern: cilium-junits-*
@@ -58,7 +52,7 @@ jobs:
 
       - name: Merge Features tested
         if: ${{ inputs.merge-features }}
-        uses: ./.github/actions/merge-artifacts
+        uses: cilium/cilium/.github/actions/merge-artifacts@main # main
         with:
           name: features-tested
           pattern: features-tested-*

--- a/.github/workflows/eks-cluster-pool-manager.yaml
+++ b/.github/workflows/eks-cluster-pool-manager.yaml
@@ -271,19 +271,32 @@ jobs:
           jq '{ "include": [ .include[] | select(.default) ] }' eks.json > /tmp/eks-defaults.json
           jq '{ "include": [ .include[] | select(.default) ] }' aws-cni.json > /tmp/aws-cni-defaults.json
 
-          # Expand matrix with different addon configurations
+          # Expand matrix with different addon configurations.
+          #
+          # The "zones" field MUST match what the conformance-eks.yaml /
+          # conformance-aws-cni.yaml consumers compute from the region, because
+          # setup-eks-cluster hashes "<addons> <zones>" into the pool key. If
+          # the pool clusters are created with a different zone set than the PR
+          # jobs search for, the pool key never matches, every PR leg creates a
+          # brand-new (NAT-gateway-consuming) cluster instead of claiming a
+          # pooled one, and the region eventually hits its NAT gateway quota.
+          # Consumer derivation (keep in sync): ZONE_1 = <region>a for us-west-1
+          # (us-west-1b rejects subnets), else <region>b; ZONE_2 = <region>c.
           cat > /tmp/expand-addons.jq << 'EOF'
+          def zones: (if .region == "us-west-1" then .region + "a" else .region + "b" end) + " " + .region + "c";
           {
             "include": [
               # all-addons configuration from aws-cni versions
               (.aws_cni.include[] | . + {
                 "addons": "coredns kube-proxy vpc-cni",
-                "addons_name": "all-addons"
+                "addons_name": "all-addons",
+                "zones": (. | zones)
               }),
               # coredns-kubeproxy configuration from eks versions
               (.eks.include[] | . + {
                 "addons": "coredns kube-proxy",
-                "addons_name": "coredns-kubeproxy"
+                "addons_name": "coredns-kubeproxy",
+                "zones": (. | zones)
               })
             ]
           }

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4110,7 +4110,11 @@ func (kub *Kubectl) ensureKubectlVersion() error {
 		rcVersion = fmt.Sprintf("v%s.0", GetCurrentK8SEnv())
 	}
 	res = kub.Exec(
-		fmt.Sprintf("curl -sSLo %s https://dl.k8s.io/release/%s/bin/linux/amd64/kubectl && chmod +x %s",
+		// --retry-all-errors is required because a transient TLS/SSL connect
+		// failure to dl.k8s.io surfaces as curl exit 35, which is not part of
+		// curl's default --retry set. Mirrors the download retry convention
+		// applied to the .github/ workflows and composite actions in #47167.
+		fmt.Sprintf("curl -sSfLo %s --retry 5 --retry-all-errors --retry-delay 3 https://dl.k8s.io/release/%s/bin/linux/amd64/kubectl && chmod +x %s",
 			path, rcVersion, path))
 	if !res.WasSuccessful() {
 		return fmt.Errorf("failed to download kubectl")


### PR DESCRIPTION
Three independent CI flake and infra fixes came out of triaging failing renovate-PR runs on main. They are unrelated, so I kept them as separate commits for independent review and backporting.

The first retries the kubectl download in the ginkgo E2E harness. ensureKubectlVersion downloads a version-matched kubectl from dl.k8s.io with a bare curl and no retry, and a transient TLS connect glitch surfaces as curl exit 35, which curl's default --retry does not cover. A single glitch then fails the download, turns into a suite BeforeAll failure, and cascades across every spec. I added --retry 5 --retry-all-errors --retry-delay 3 (and -f), the same convention already applied to the .github downloads in #47167; --retry-all-errors is the part that matters, because plain --retry ignores exit 35. It still returns non-zero if every attempt fails, so it cannot hide a genuine outage.

The second stops the merge-upload job in common-post-jobs.yaml from checking out a mutable ref. It checked out inputs.context-ref, which for renovate PRs is the head branch name; once the PR merges and GitHub deletes that branch, actions/checkout's glob fetch matches zero refs and fails on every retry, so the job goes red even though every test passed. The job only merges and uploads artifacts through the GitHub API and needs no working tree, so I dropped the checkout and reference the internal action as cilium/cilium/.github/actions/merge-artifacts@main, the same way the sibling commit-status-final job already runs set-commit-status@main.

The third fixes the EKS cluster-pool key so PR jobs actually claim pooled clusters. setup-eks-cluster derives the pool key from a hash of the addons and zones, and the conformance-eks and conformance-aws-cni consumers pass zones derived from the region. The pool-manager built its create matrix without any zones field, so it created pool clusters under the hash of an empty zones string and the keys never matched. Every PR leg then reported no cluster in the pool and created a fresh cluster, VPC and NAT gateway of its own, which eventually exhausted the us-west-2 NAT gateway quota. The zones component was added to the consumer in c0cb5bb615 but never mirrored into the pool-manager, so I replicated the same derivation in the matrix jq. For us-west-2 the pool now produces zones us-west-2b us-west-2c and the keys match what the consumers search for.

On backports: the first commit applies to 1.17 through 1.20. The second applies to 1.18 through 1.20, since common-post-jobs.yaml does not exist on 1.17. The third only applies to 1.20; 1.17 and 1.18 have no pool-manager, and although 1.19 has one, c0cb5bb615 is not on 1.19 so its consumer also passes empty zones and the keys already match there.

This PR was prepared with AIL:3.
