### PR TITLE
ipam: restore ingress IPs from Kubernetes state

### DIFF
--- a/pkg/ipcache/restore/local_identity_restorer.go
+++ b/pkg/ipcache/restore/local_identity_restorer.go
@@ -154,8 +154,10 @@ func (d *LocalIdentityRestorer) dumpOldIPCache() (map[netip.Prefix]identity.Nume
 // identities. Specifically, if a prefix in the ipcache has a CIDR label, this re-creates
 // that metadata entry.
 //
-// For ingress IPs, it will add those to the ipcache and configure the local node
-// accordingly.
+// For ingress IPs, it adds them to the ipcache and overwrites any addresses
+// restored from Kubernetes on the local node. The BPF map reflects the
+// addresses used by the previous datapath and therefore has highest restoration
+// precedence.
 func (d *LocalIdentityRestorer) restoreIPCache(ipCache *ipcache.IPCache, localPrefixes map[netip.Prefix]identity.NumericIdentity, restoredIdentities map[identity.NumericIdentity]*identity.Identity) {
 	if len(localPrefixes) == 0 {
 		return
@@ -193,7 +195,8 @@ func (d *LocalIdentityRestorer) restoreIPCache(ipCache *ipcache.IPCache, localPr
 				Metadata: []ipcache.IPMetadata{labels.LabelIngress},
 			})
 
-			// Set any restored ingress IPs back on the LocalNode object
+			// BPF ipcache state takes precedence over the Kubernetes Node and
+			// CiliumNode fallbacks restored on the local node earlier.
 			d.params.NodeLocalStore.Update(func(n *node.LocalNode) {
 				addr := prefix.Addr()
 				if addr.Is4() {

--- a/pkg/ipcache/restore/local_identity_restorer.go
+++ b/pkg/ipcache/restore/local_identity_restorer.go
@@ -153,8 +153,10 @@ func (d *LocalIdentityRestorer) dumpOldIPCache() (map[netip.Prefix]identity.Nume
 // identities. Specifically, if a prefix in the ipcache has a CIDR label, this re-creates
 // that metadata entry.
 //
-// For ingress IPs, it will add those to the ipcache and configure the local node
-// accordingly.
+// For ingress IPs, it adds them to the ipcache and overwrites any addresses
+// restored from Kubernetes on the local node. The BPF map reflects the
+// addresses used by the previous datapath and therefore has highest restoration
+// precedence.
 func (d *LocalIdentityRestorer) restoreIPCache(ipCache *ipcache.IPCache, localPrefixes map[netip.Prefix]identity.NumericIdentity, restoredIdentities map[identity.NumericIdentity]*identity.Identity) {
 	if len(localPrefixes) == 0 {
 		return
@@ -192,7 +194,8 @@ func (d *LocalIdentityRestorer) restoreIPCache(ipCache *ipcache.IPCache, localPr
 				Metadata: []ipcache.IPMetadata{labels.LabelIngress},
 			})
 
-			// Set any restored ingress IPs back on the LocalNode object
+			// BPF ipcache state takes precedence over the Kubernetes Node and
+			// CiliumNode fallbacks restored on the local node earlier.
 			d.params.NodeLocalStore.Update(func(n *node.LocalNode) {
 				addr := prefix.Addr()
 				if addr.Is4() {

--- a/pkg/node/sync/local_node_sync.go
+++ b/pkg/node/sync/local_node_sync.go
@@ -213,7 +213,6 @@ func (ini *localNodeSynchronizer) initFromK8s(ctx context.Context, node *node.Lo
 	// The fields left uninitialized/unrestored here:
 	//   - Cilium internal IPs (restored from cilium_host or allocated by IPAM)
 	//   - Health IPs (allocated by IPAM)
-	//   - Ingress IPs (restored from ipcachemap or allocated)
 	//   - WireGuard key (set by WireGuard agent)
 	//   - IPsec key (set by IPsec)
 	//   - alloc CIDRs (depends on IPAM mode; restored from Node or CiliumNode)
@@ -223,6 +222,18 @@ func (ini *localNodeSynchronizer) initFromK8s(ctx context.Context, node *node.Lo
 			node.SetNodeInternalIP(addr.IP)
 		} else if addr.Type == addressing.NodeExternalIP {
 			node.SetNodeExternalIP(addr.IP)
+		}
+	}
+	// The Ingress IPs parsed from Kubernetes Node annotations are only a fallback.
+	// The local CiliumNode fetched immediately below overrides them when available.
+	// A later bootstrap stage gives addresses restored from the BPF ipcache map
+	// highest precedence; IPAM allocates new addresses only if none could be restored.
+	if ini.Config.EnableEnvoyConfig {
+		if ini.Config.EnableIPv4 {
+			node.IPv4IngressIP = parsedNode.IPv4IngressIP
+		}
+		if ini.Config.EnableIPv6 {
+			node.IPv6IngressIP = parsedNode.IPv6IngressIP
 		}
 	}
 	ini.syncFromK8s(node, parsedNode)
@@ -246,6 +257,23 @@ func (ini *localNodeSynchronizer) initFromK8s(ctx context.Context, node *node.Lo
 			if ini.Config.EnableIPv6 {
 				addr, _ := netip.ParseAddr(k8sCiliumNode.Spec.HealthAddressing.IPv6)
 				node.IPv6HealthIP = iputil.AddrFrom(addr)
+			}
+		}
+
+		// Prefer the durable local CiliumNode values over the Kubernetes Node
+		// annotation fallback. The BPF ipcache restoration runs later and may
+		// override these with the addresses used by the previous datapath.
+		if ini.Config.EnableEnvoyConfig {
+			if ini.Config.EnableIPv4 {
+				if ip := net.ParseIP(k8sCiliumNode.Spec.IngressAddressing.IPV4); ip != nil {
+					node.IPv4IngressIP = ip
+				}
+			}
+
+			if ini.Config.EnableIPv6 {
+				if ip := net.ParseIP(k8sCiliumNode.Spec.IngressAddressing.IPV6); ip != nil {
+					node.IPv6IngressIP = ip
+				}
 			}
 		}
 	} else {

--- a/pkg/node/sync/local_node_sync.go
+++ b/pkg/node/sync/local_node_sync.go
@@ -215,7 +215,6 @@ func (ini *localNodeSynchronizer) initFromK8s(ctx context.Context, node *node.Lo
 	// The fields left uninitialized/unrestored here:
 	//   - Cilium internal IPs (restored from cilium_host or allocated by IPAM)
 	//   - Health IPs (allocated by IPAM)
-	//   - Ingress IPs (restored from ipcachemap or allocated)
 	//   - WireGuard key (set by WireGuard agent)
 	//   - IPsec key (set by IPsec)
 	//   - alloc CIDRs (depends on IPAM mode; restored from Node or CiliumNode)
@@ -225,6 +224,18 @@ func (ini *localNodeSynchronizer) initFromK8s(ctx context.Context, node *node.Lo
 			node.SetNodeInternalIP(addr.IP)
 		} else if addr.Type == addressing.NodeExternalIP {
 			node.SetNodeExternalIP(addr.IP)
+		}
+	}
+	// The Ingress IPs parsed from Kubernetes Node annotations are only a fallback.
+	// The local CiliumNode fetched immediately below overrides them when available.
+	// A later bootstrap stage gives addresses restored from the BPF ipcache map
+	// highest precedence; IPAM allocates new addresses only if none could be restored.
+	if ini.Config.EnableEnvoyConfig {
+		if ini.Config.EnableIPv4 {
+			node.IPv4IngressIP = parsedNode.IPv4IngressIP
+		}
+		if ini.Config.EnableIPv6 {
+			node.IPv6IngressIP = parsedNode.IPv6IngressIP
 		}
 	}
 	ini.syncFromK8s(node, parsedNode)
@@ -248,6 +259,23 @@ func (ini *localNodeSynchronizer) initFromK8s(ctx context.Context, node *node.Lo
 			if ini.Config.EnableIPv6 {
 				addr, _ := netip.ParseAddr(k8sCiliumNode.Spec.HealthAddressing.IPv6)
 				node.IPv6HealthIP = iputil.AddrFrom(addr)
+			}
+		}
+
+		// Prefer the durable local CiliumNode values over the Kubernetes Node
+		// annotation fallback. The BPF ipcache restoration runs later and may
+		// override these with the addresses used by the previous datapath.
+		if ini.Config.EnableEnvoyConfig {
+			if ini.Config.EnableIPv4 {
+				if addr, err := netip.ParseAddr(k8sCiliumNode.Spec.IngressAddressing.IPV4); err == nil {
+					node.IPv4IngressIP = iputil.AddrFrom(addr)
+				}
+			}
+
+			if ini.Config.EnableIPv6 {
+				if addr, err := netip.ParseAddr(k8sCiliumNode.Spec.IngressAddressing.IPV6); err == nil {
+					node.IPv6IngressIP = iputil.AddrFrom(addr)
+				}
 			}
 		}
 	} else {

--- a/pkg/node/sync/local_node_sync_test.go
+++ b/pkg/node/sync/local_node_sync_test.go
@@ -17,6 +17,7 @@ import (
 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
+	"github.com/cilium/cilium/pkg/annotation"
 	fakeipsec "github.com/cilium/cilium/pkg/datapath/linux/ipsec/fake"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -178,6 +179,7 @@ func TestInitLocalNode_initFromK8s(t *testing.T) {
 				IPv6ClusterAllocCIDRBase:     "fd00::",
 				EnableIPv4:                   true,
 				EnableIPv6:                   true,
+				EnableEnvoyConfig:            true,
 				EnableHealthChecking:         true,
 				EnableEndpointHealthChecking: true,
 			},
@@ -226,6 +228,10 @@ func TestInitLocalNode_initFromK8s(t *testing.T) {
 									IPv4: "10.0.0.2",
 									IPv6: "fd00:10:244:1::aaa7",
 								},
+								IngressAddressing: v2.AddressPair{
+									IPV4: "10.0.0.3",
+									IPV6: "fd00:10:244:1::aaa8",
+								},
 							},
 						},
 						Done: func(err error) {},
@@ -246,7 +252,124 @@ func TestInitLocalNode_initFromK8s(t *testing.T) {
 	assert.Equal(t, "fd00:10:244:1::aaa6", n.GetCiliumInternalIP(true).String())
 	assert.Equal(t, "10.0.0.2", n.IPv4HealthIP.String())
 	assert.Equal(t, "fd00:10:244:1::aaa7", n.IPv6HealthIP.String())
+	assert.Equal(t, "10.0.0.3", n.IPv4IngressIP.String())
+	assert.Equal(t, "fd00:10:244:1::aaa8", n.IPv6IngressIP.String())
 	assert.Equal(t, "test-node", n.Name)
+}
+
+func TestInitLocalNode_initFromK8sIngress(t *testing.T) {
+	oldAnnotateK8sNode := option.Config.AnnotateK8sNode
+	option.Config.AnnotateK8sNode = true
+	t.Cleanup(func() {
+		option.Config.AnnotateK8sNode = oldAnnotateK8sNode
+	})
+
+	tests := []struct {
+		name           string
+		enableEnvoy    bool
+		ciliumNodeIPv4 string
+		ciliumNodeIPv6 string
+		expectedIPv4   string
+		expectedIPv6   string
+	}{
+		{
+			name:           "cilium node takes precedence",
+			enableEnvoy:    true,
+			ciliumNodeIPv4: "10.0.0.3",
+			ciliumNodeIPv6: "fd00:10:244:1::aaa8",
+			expectedIPv4:   "10.0.0.3",
+			expectedIPv6:   "fd00:10:244:1::aaa8",
+		},
+		{
+			name:         "kubernetes node annotation fallback",
+			enableEnvoy:  true,
+			expectedIPv4: "10.0.0.4",
+			expectedIPv6: "fd00:10:244:1::aaa9",
+		},
+		{
+			name:           "invalid cilium node address keeps annotation fallback",
+			enableEnvoy:    true,
+			ciliumNodeIPv4: "not-an-ip",
+			ciliumNodeIPv6: "also-not-an-ip",
+			expectedIPv4:   "10.0.0.4",
+			expectedIPv6:   "fd00:10:244:1::aaa9",
+		},
+		{
+			name:           "envoy disabled",
+			ciliumNodeIPv4: "10.0.0.3",
+			ciliumNodeIPv6: "fd00:10:244:1::aaa8",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lni := newLocalNodeSynchronizer(localNodeSynchronizerParams{
+				Logger: hivetest.Logger(t),
+				Config: &option.DaemonConfig{
+					IPv4NodeAddr:             "auto",
+					IPv6NodeAddr:             "auto",
+					IPv6ClusterAllocCIDRBase: "fd00::",
+					EnableIPv4:               true,
+					EnableIPv6:               true,
+					EnableEnvoyConfig:        tt.enableEnvoy,
+				},
+				K8sLocalNode: &mockResource[*slim_corev1.Node]{
+					items: []resource.Event[*slim_corev1.Node]{
+						{
+							Kind: resource.Upsert,
+							Object: &slim_corev1.Node{
+								ObjectMeta: slim_metav1.ObjectMeta{
+									Name: "test-node",
+									Annotations: map[string]string{
+										annotation.V4IngressName: "10.0.0.4",
+										annotation.V6IngressName: "fd00:10:244:1::aaa9",
+									},
+								},
+							},
+							Done: func(error) {},
+						},
+					},
+				},
+				K8sCiliumLocalNode: &mockResource[*v2.CiliumNode]{
+					items: []resource.Event[*v2.CiliumNode]{
+						{
+							Kind: resource.Upsert,
+							Object: &v2.CiliumNode{
+								Spec: v2.NodeSpec{
+									IngressAddressing: v2.AddressPair{
+										IPV4: tt.ciliumNodeIPv4,
+										IPV6: tt.ciliumNodeIPv6,
+									},
+								},
+							},
+							Done: func(error) {},
+						},
+					},
+				},
+				IPsecConfig: fakeipsec.Config{},
+			})
+
+			n := &node.LocalNode{
+				Node: types.Node{
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				Local: &node.LocalNodeInfo{},
+			}
+			require.NoError(t, lni.InitLocalNode(t.Context(), n))
+
+			if tt.expectedIPv4 == "" {
+				assert.Nil(t, n.IPv4IngressIP)
+			} else {
+				assert.Equal(t, tt.expectedIPv4, n.IPv4IngressIP.String())
+			}
+			if tt.expectedIPv6 == "" {
+				assert.Nil(t, n.IPv6IngressIP)
+			} else {
+				assert.Equal(t, tt.expectedIPv6, n.IPv6IngressIP.String())
+			}
+		})
+	}
 }
 
 func TestLocalNodeSync_NodeDeletion(t *testing.T) {

--- a/pkg/node/sync/local_node_sync_test.go
+++ b/pkg/node/sync/local_node_sync_test.go
@@ -17,6 +17,7 @@ import (
 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
+	"github.com/cilium/cilium/pkg/annotation"
 	fakeipsec "github.com/cilium/cilium/pkg/datapath/linux/ipsec/fake"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -178,6 +179,7 @@ func TestInitLocalNode_initFromK8s(t *testing.T) {
 				IPv6ClusterAllocCIDRBase:     "fd00::",
 				EnableIPv4:                   true,
 				EnableIPv6:                   true,
+				EnableEnvoyConfig:            true,
 				EnableHealthChecking:         true,
 				EnableEndpointHealthChecking: true,
 			},
@@ -226,6 +228,10 @@ func TestInitLocalNode_initFromK8s(t *testing.T) {
 									IPv4: "10.0.0.2",
 									IPv6: "fd00:10:244:1::aaa7",
 								},
+								IngressAddressing: v2.AddressPair{
+									IPV4: "10.0.0.3",
+									IPV6: "fd00:10:244:1::aaa8",
+								},
 							},
 						},
 						Done: func(err error) {},
@@ -246,7 +252,124 @@ func TestInitLocalNode_initFromK8s(t *testing.T) {
 	assert.Equal(t, "fd00:10:244:1::aaa6", n.GetCiliumInternalIP(true).String())
 	assert.Equal(t, "10.0.0.2", n.IPv4HealthIP.String())
 	assert.Equal(t, "fd00:10:244:1::aaa7", n.IPv6HealthIP.String())
+	assert.Equal(t, "10.0.0.3", n.IPv4IngressIP.String())
+	assert.Equal(t, "fd00:10:244:1::aaa8", n.IPv6IngressIP.String())
 	assert.Equal(t, "test-node", n.Name)
+}
+
+func TestInitLocalNode_initFromK8sIngress(t *testing.T) {
+	oldAnnotateK8sNode := option.Config.AnnotateK8sNode
+	option.Config.AnnotateK8sNode = true
+	t.Cleanup(func() {
+		option.Config.AnnotateK8sNode = oldAnnotateK8sNode
+	})
+
+	tests := []struct {
+		name           string
+		enableEnvoy    bool
+		ciliumNodeIPv4 string
+		ciliumNodeIPv6 string
+		expectedIPv4   string
+		expectedIPv6   string
+	}{
+		{
+			name:           "cilium node takes precedence",
+			enableEnvoy:    true,
+			ciliumNodeIPv4: "10.0.0.3",
+			ciliumNodeIPv6: "fd00:10:244:1::aaa8",
+			expectedIPv4:   "10.0.0.3",
+			expectedIPv6:   "fd00:10:244:1::aaa8",
+		},
+		{
+			name:         "kubernetes node annotation fallback",
+			enableEnvoy:  true,
+			expectedIPv4: "10.0.0.4",
+			expectedIPv6: "fd00:10:244:1::aaa9",
+		},
+		{
+			name:           "invalid cilium node address keeps annotation fallback",
+			enableEnvoy:    true,
+			ciliumNodeIPv4: "not-an-ip",
+			ciliumNodeIPv6: "also-not-an-ip",
+			expectedIPv4:   "10.0.0.4",
+			expectedIPv6:   "fd00:10:244:1::aaa9",
+		},
+		{
+			name:           "envoy disabled",
+			ciliumNodeIPv4: "10.0.0.3",
+			ciliumNodeIPv6: "fd00:10:244:1::aaa8",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lni := newLocalNodeSynchronizer(localNodeSynchronizerParams{
+				Logger: hivetest.Logger(t),
+				Config: &option.DaemonConfig{
+					IPv4NodeAddr:             "auto",
+					IPv6NodeAddr:             "auto",
+					IPv6ClusterAllocCIDRBase: "fd00::",
+					EnableIPv4:               true,
+					EnableIPv6:               true,
+					EnableEnvoyConfig:        tt.enableEnvoy,
+				},
+				K8sLocalNode: &mockResource[*slim_corev1.Node]{
+					items: []resource.Event[*slim_corev1.Node]{
+						{
+							Kind: resource.Upsert,
+							Object: &slim_corev1.Node{
+								ObjectMeta: slim_metav1.ObjectMeta{
+									Name: "test-node",
+									Annotations: map[string]string{
+										annotation.V4IngressName: "10.0.0.4",
+										annotation.V6IngressName: "fd00:10:244:1::aaa9",
+									},
+								},
+							},
+							Done: func(error) {},
+						},
+					},
+				},
+				K8sCiliumLocalNode: &mockResource[*v2.CiliumNode]{
+					items: []resource.Event[*v2.CiliumNode]{
+						{
+							Kind: resource.Upsert,
+							Object: &v2.CiliumNode{
+								Spec: v2.NodeSpec{
+									IngressAddressing: v2.AddressPair{
+										IPV4: tt.ciliumNodeIPv4,
+										IPV6: tt.ciliumNodeIPv6,
+									},
+								},
+							},
+							Done: func(error) {},
+						},
+					},
+				},
+				IPsecConfig: fakeipsec.Config{},
+			})
+
+			n := &node.LocalNode{
+				Node: types.Node{
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				Local: &node.LocalNodeInfo{},
+			}
+			require.NoError(t, lni.InitLocalNode(t.Context(), n))
+
+			if tt.expectedIPv4 == "" {
+				assert.False(t, n.IPv4IngressIP.IsValid())
+			} else {
+				assert.Equal(t, tt.expectedIPv4, n.IPv4IngressIP.String())
+			}
+			if tt.expectedIPv6 == "" {
+				assert.False(t, n.IPv6IngressIP.IsValid())
+			} else {
+				assert.Equal(t, tt.expectedIPv6, n.IPv6IngressIP.String())
+			}
+		})
+	}
 }
 
 func TestLocalNodeSync_NodeDeletion(t *testing.T) {


### PR DESCRIPTION
Ingress IPs were previously restored only from the old BPF ipcache. That runtime entry may be absent after a node reboot, BPF-state cleanup or map replacement, or incomplete ingress endpoint initialization. Make ingress IP restoration more robust by recovering them from CiliumNode, with Node annotations as fallback, before infrastructure IP allocation. Retain BPF ipcache as the highest-precedence source when available.

AIL: 3

```release-note
Restore ingress IPs from k8s / local node as a backup when they may be missing from the ipcache.
```
