### PR TITLE
gateway-api: prune stale TCP/UDPRoute parent statuses

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -2209,6 +2209,7 @@ func (r *gatewayReconciler) setTCPRouteStatuses(scopedLog *slog.Logger, ctx cont
 	for tcpRouteIndex, original := range tcpRoutes.Items {
 
 		tcpr := original.DeepCopy()
+		tcpr.Status.Parents = pruneRouteParentStatuses(tcpr.Status.Parents, tcpr.Spec.ParentRefs, r.controllerName)
 
 		i := &routechecks.TCPRouteInput{
 			Ctx:            ctx,
@@ -2240,6 +2241,7 @@ func (r *gatewayReconciler) setUDPRouteStatuses(scopedLog *slog.Logger, ctx cont
 	for udpRouteIndex, original := range udpRoutes.Items {
 
 		udpr := original.DeepCopy()
+		udpr.Status.Parents = pruneRouteParentStatuses(udpr.Status.Parents, udpr.Spec.ParentRefs, r.controllerName)
 
 		i := &routechecks.UDPRouteInput{
 			Ctx:            ctx,


### PR DESCRIPTION
Apply the existing route parent-status logic to TCPRoute and UDPRoute.

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
