### PR TITLE
bpf,datapath: move RSS source prefixes to runtime config

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -33,6 +33,17 @@ DECLARE_CONFIG(bool, enable_no_service_endpoints_routable,
 	       "Enable routes when service has 0 endpoints")
 DECLARE_CONFIG(__u16, device_mtu, "MTU of the device the bpf program is attached to")
 
+#ifdef IS_BPF_XDP
+DECLARE_CONFIG(union v4addr, ipv4_rss_prefix,
+	       "IPv4 source prefix used for DSR IPIP RSS")
+DECLARE_CONFIG(__u8, ipv4_rss_prefix_bits,
+	       "Prefix length of the IPv4 DSR IPIP RSS source prefix")
+DECLARE_CONFIG(union v6addr, ipv6_rss_prefix,
+	       "IPv6 source prefix used for DSR IPIP RSS")
+DECLARE_CONFIG(__u8, ipv6_rss_prefix_bits,
+	       "Prefix length of the IPv6 DSR IPIP RSS source prefix")
+#endif
+
 /* Evaluate the input values for detecting compilation errors.
  * Just blindly substituting this macro with the CTX_ACT_OK
  * kills the C compile-time check against the input values
@@ -271,13 +282,14 @@ dsr_set_ipip6_dev(struct __ctx_buff *ctx, const union v6addr *tunnel_ep,
 	return 0;
 }
 
+#ifdef IS_BPF_XDP
 static __always_inline void rss_gen_src6(union v6addr *src,
 					 const union v6addr *client,
 					 __be32 l4_hint)
 {
-	__u32 bits = 128 - IPV6_RSS_PREFIX_BITS;
+	__u32 bits = 128 - CONFIG(ipv6_rss_prefix_bits);
 
-	*src = (union v6addr)IPV6_RSS_PREFIX;
+	*src = CONFIG(ipv6_rss_prefix);
 	if (bits) {
 		__u32 todo;
 
@@ -299,6 +311,7 @@ static __always_inline void rss_gen_src6(union v6addr *src,
 		src->p4 |= bpf_htonl(hash_32(client->p4 ^ l4_hint, bits));
 	}
 }
+#endif /* IS_BPF_XDP */
 
 static __always_inline int dsr_set_ipip6(struct __ctx_buff *ctx,
 					 const struct ipv6hdr *ip6 __maybe_unused,
@@ -1678,15 +1691,17 @@ dsr_set_ipip4_dev(struct __ctx_buff *ctx, __u32 tunnel_ep, __u32 seclabel)
 	return 0;
 }
 
+#ifdef IS_BPF_XDP
 static __always_inline __be32 rss_gen_src4(__be32 client, __be32 l4_hint)
 {
-	const __u32 bits = 32 - IPV4_RSS_PREFIX_BITS;
-	__be32 src = IPV4_RSS_PREFIX;
+	const __u32 bits = 32 - CONFIG(ipv4_rss_prefix_bits);
+	__be32 src = CONFIG(ipv4_rss_prefix).be32;
 
 	if (bits)
 		src |= bpf_htonl(hash_32(client ^ l4_hint, bits));
 	return src;
 }
+#endif /* IS_BPF_XDP */
 
 /*
  * Original packet: [clientIP:clientPort -> serviceIP:servicePort] } IP/L4

--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -98,15 +98,11 @@
 #  ifndef IPV4_DIRECT_ROUTING
 #   define IPV4_DIRECT_ROUTING 0
 #  endif
-#  define IPV4_RSS_PREFIX IPV4_DIRECT_ROUTING
-#  define IPV4_RSS_PREFIX_BITS 32
 # endif
 # ifdef ENABLE_IPV6
 #  ifndef IPV6_DIRECT_ROUTING
 #   define IPV6_DIRECT_ROUTING { .addr = { 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 } }
 #  endif
-#  define IPV6_RSS_PREFIX IPV6_DIRECT_ROUTING
-#  define IPV6_RSS_PREFIX_BITS 128
 # endif
 #endif
 

--- a/bpf/tests/xdp_nodeport_lb_dsr_ipip.c
+++ b/bpf/tests/xdp_nodeport_lb_dsr_ipip.c
@@ -45,6 +45,11 @@ mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
 
 ASSIGN_CONFIG(bool, enable_endpoint_routes, true)
 
+ASSIGN_CONFIG(union v4addr, ipv4_rss_prefix, { .be32 = IPV4_DIRECT_ROUTING })
+ASSIGN_CONFIG(__u8, ipv4_rss_prefix_bits, 32)
+ASSIGN_CONFIG(union v6addr, ipv6_rss_prefix, IPV6_DIRECT_ROUTING)
+ASSIGN_CONFIG(__u8, ipv6_rss_prefix_bits, 128)
+
 long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
 		     __maybe_unused int plen, __maybe_unused __u32 flags)
 {

--- a/pkg/datapath/config/xdp.go
+++ b/pkg/datapath/config/xdp.go
@@ -28,5 +28,43 @@ func XDP(lnc *Config, link netlink.Link) any {
 	cfg.EnableIPv4Fragments = option.Config.EnableIPv4FragmentsTracking
 	cfg.EnableIPv6Fragments = option.Config.EnableIPv6FragmentsTracking
 
+	if option.Config.EnableIPv4 {
+		if option.Config.LoadBalancerRSSv4CIDR != "" {
+			copy(cfg.IPv4RSSPrefix.Addr[:], option.Config.UnsafeDaemonConfigOption.LoadBalancerRSSv4.IP.To4())
+			ones, _ := option.Config.UnsafeDaemonConfigOption.LoadBalancerRSSv4.Mask.Size()
+			cfg.IPv4RSSPrefixBits = uint8(ones)
+		} else {
+			cfg.IPv4RSSPrefixBits = 32
+			if lnc.DirectRoutingDevice != nil {
+				for _, addr := range lnc.DirectRoutingDevice.Addrs {
+					if addr.Addr.Is4() {
+						cfg.IPv4RSSPrefix.Addr = addr.Addr.As4()
+						break
+					}
+				}
+			}
+		}
+	}
+
+	if option.Config.EnableIPv6 {
+		if option.Config.LoadBalancerRSSv6CIDR != "" {
+			copy(cfg.IPv6RSSPrefix.Addr[:], option.Config.UnsafeDaemonConfigOption.LoadBalancerRSSv6.IP.To16())
+			ones, _ := option.Config.UnsafeDaemonConfigOption.LoadBalancerRSSv6.Mask.Size()
+			cfg.IPv6RSSPrefixBits = uint8(ones)
+		} else {
+			cfg.IPv6RSSPrefixBits = 128
+			if lnc.DirectRoutingDevice != nil {
+				for _, addr := range lnc.DirectRoutingDevice.Addrs {
+					if addr.Addr.Is6() {
+						cfg.IPv6RSSPrefix.Addr = addr.Addr.As16()
+						if !addr.Addr.IsLinkLocalUnicast() {
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+
 	return cfg
 }

--- a/pkg/datapath/config/xdp_config.go
+++ b/pkg/datapath/config/xdp_config.go
@@ -28,6 +28,14 @@ type BPFXDP struct {
 	EnableXDPPrefilter bool `config:"enable_xdp_prefilter"`
 	// Ephemeral port range minimun.
 	EphemeralMin uint16 `config:"ephemeral_min"`
+	// IPv4 source prefix used for DSR IPIP RSS.
+	IPv4RSSPrefix types.V4Addr `config:"ipv4_rss_prefix"`
+	// Prefix length of the IPv4 DSR IPIP RSS source prefix.
+	IPv4RSSPrefixBits uint8 `config:"ipv4_rss_prefix_bits"`
+	// IPv6 source prefix used for DSR IPIP RSS.
+	IPv6RSSPrefix types.V6Addr `config:"ipv6_rss_prefix"`
+	// Prefix length of the IPv6 DSR IPIP RSS source prefix.
+	IPv6RSSPrefixBits uint8 `config:"ipv6_rss_prefix_bits"`
 	// Ifindex of the interface the bpf program is attached to.
 	InterfaceIfIndex uint32 `config:"interface_ifindex"`
 	// MAC address of the interface the bpf program is attached to.
@@ -47,7 +55,10 @@ type BPFXDP struct {
 }
 
 func NewBPFXDP(node Node) *BPFXDP {
-	return &BPFXDP{0x0, false, false, false, false, false, false, 0x0, 0x0,
+	return &BPFXDP{0x0, false, false, false, false, false, false, 0x0, cast[types.V4Addr]([]byte{0x0, 0x0, 0x0, 0x0}),
+		0x0,
+		cast[types.V6Addr]([]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}),
+		0x0, 0x0,
 		cast[types.MACAddr]([]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}),
 		cast[types.V4Addr]([]byte{0x0, 0x0, 0x0, 0x0}),
 		cast[types.V6Addr]([]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}),

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -323,29 +323,6 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *config.Config) erro
 		} else {
 			cDefinesMap["DSR_ENCAP_MODE"] = fmt.Sprintf("%d", dsrEncapInv)
 		}
-		if option.Config.EnableIPv4 {
-			if option.Config.LoadBalancerRSSv4CIDR != "" {
-				ipv4 := byteorder.NetIPv4ToHost32(option.Config.UnsafeDaemonConfigOption.LoadBalancerRSSv4.IP)
-				ones, _ := option.Config.UnsafeDaemonConfigOption.LoadBalancerRSSv4.Mask.Size()
-				cDefinesMap["IPV4_RSS_PREFIX"] = fmt.Sprintf("%d", ipv4)
-				cDefinesMap["IPV4_RSS_PREFIX_BITS"] = fmt.Sprintf("%d", ones)
-			} else {
-				cDefinesMap["IPV4_RSS_PREFIX"] = "IPV4_DIRECT_ROUTING"
-				cDefinesMap["IPV4_RSS_PREFIX_BITS"] = "32"
-			}
-		}
-		if option.Config.EnableIPv6 {
-			if option.Config.LoadBalancerRSSv6CIDR != "" {
-				ipv6 := option.Config.UnsafeDaemonConfigOption.LoadBalancerRSSv6.IP
-				ones, _ := option.Config.UnsafeDaemonConfigOption.LoadBalancerRSSv6.Mask.Size()
-				extraMacrosMap["IPV6_RSS_PREFIX"] = ipv6.String()
-				fw.WriteString(FmtDefineAddress("IPV6_RSS_PREFIX", ipv6))
-				cDefinesMap["IPV6_RSS_PREFIX_BITS"] = fmt.Sprintf("%d", ones)
-			} else {
-				cDefinesMap["IPV6_RSS_PREFIX"] = "IPV6_DIRECT_ROUTING"
-				cDefinesMap["IPV6_RSS_PREFIX_BITS"] = "128"
-			}
-		}
 
 		if option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled {
 			cDefinesMap["ENABLE_NODEPORT_ACCELERATION"] = "1"

--- a/tools/dpgen/acronyms.txt
+++ b/tools/dpgen/acronyms.txt
@@ -45,6 +45,7 @@ NAT
 NetNS
 PerCPU
 RevNAT
+RSS
 SAddr
 SNAT
 SPI


### PR DESCRIPTION
Replace the IPV4_RSS_PREFIX, IPV4_RSS_PREFIX_BITS, IPV6_RSS_PREFIX, and IPV6_RSS_PREFIX_BITS macros with XDP load-time configuration.

Scope the configuration to XDP, where DSR IPIP RSS source generation is used.

Related: https://github.com/cilium/cilium/issues/38370