### PR TITLE
ci: draft renovate PRs until ciliumbot auto-approval

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -218,8 +218,10 @@
         "quay.io/lvh-images/{/,}**", // LVH images
         "sigs.k8s.io/{/,}**" // Kubernetes official SIG repo
       ],
-      "automerge": true,
-      "automergeType": "pr",
+      // Open as draft so CODEOWNERS are only requested once ciliumbot has
+      // been added and the auto-approve workflow can mark the PR ready.
+      // GitHub auto-merge is also enabled by the auto-approve workflow.
+      "draftPR": true,
       "groupName": "auto-merge-trusted-deps",
       // Replace the list of reviewers with just ciliumbot
       "reviewers": [
@@ -257,8 +259,10 @@
       ],
       "groupName": "goswagger",
       "separateMajorMinor": true,
-      "automerge": true,
-      "automergeType": "pr",
+      // Open as draft so CODEOWNERS are only requested once ciliumbot has
+      // been added and the auto-approve workflow can mark the PR ready.
+      // GitHub auto-merge is also enabled by the auto-approve workflow.
+      "draftPR": true,
       // Replace the list of reviewers with just ciliumbot
       "reviewers":[
         "ciliumbot",

--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types:
     - review_requested
+    - synchronize
 
 jobs:
   pre-approve:
@@ -60,6 +61,12 @@ jobs:
         ciliumbot_requested_by_renovate=$(gh api "/repos/${GITHUB_REPOSITORY}/issues/${PULL_REQUEST_NUMBER}/events" --paginate --jq '[.[] | select(.event == "review_requested" and .requested_reviewer.login == "ciliumbot" and .actor.login == "cilium-renovate[bot]")] | length > 0')
 
         if [ "$ciliumbot_requested_by_renovate" == "true" ]; then
+          if [ "${GITHUB_ACTOR}" = "auto-committer[bot]" ]; then
+            # Follow-up image updates re-draft the PR before pushing. Re-request
+            # review from ciliumbot before undrafting so GitHub can resolve
+            # CODEOWNERS against a pending bot review again.
+            gh -R ${GITHUB_REPOSITORY} pr edit ${PULL_REQUEST_NUMBER} --add-reviewer ciliumbot
+          fi
           echo "ciliumbot was requested by cilium-renovate[bot], marking the PR ready"
           # Renovate is configured to open these PRs as drafts so ciliumbot is
           # attached before GitHub requests CODEOWNERS on ready-for-review.

--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -54,21 +54,24 @@ jobs:
         PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
       run: |
         echo ${TOKEN} | gh auth login --with-token
-        gh -R ${GITHUB_REPOSITORY} pr review ${PULL_REQUEST_NUMBER} --approve
 
         # Check if ciliumbot was requested by cilium-renovate[bot] from the events list
         echo "Checking if ciliumbot was requested by cilium-renovate[bot]..."
         ciliumbot_requested_by_renovate=$(gh api "/repos/${GITHUB_REPOSITORY}/issues/${PULL_REQUEST_NUMBER}/events" --paginate --jq '[.[] | select(.event == "review_requested" and .requested_reviewer.login == "ciliumbot" and .actor.login == "cilium-renovate[bot]")] | length > 0')
 
         if [ "$ciliumbot_requested_by_renovate" == "true" ]; then
-          echo "ciliumbot was requested by cilium-renovate[bot], removing other reviewers to avoid noise"
-          reviewers=$(gh -R ${GITHUB_REPOSITORY} pr view ${PULL_REQUEST_NUMBER} --json reviewRequests --jq '.reviewRequests[] | select(."__typename"=="User") | .login')
-          for reviewer in $reviewers; do
-            if [ "$reviewer" != "ciliumbot" ]; then
-              echo "Removing reviewer $reviewer"
-              gh api --method DELETE "/repos/${GITHUB_REPOSITORY}/pulls/${PULL_REQUEST_NUMBER}/requested_reviewers" -f "reviewers[]=${reviewer}"
-            fi
-          done
-        else
-          echo "ciliumbot was not requested by cilium-renovate[bot], keeping all reviewers"
+          echo "ciliumbot was requested by cilium-renovate[bot], marking the PR ready"
+          # Renovate is configured to open these PRs as drafts so ciliumbot is
+          # attached before GitHub requests CODEOWNERS on ready-for-review.
+          # Undrafting after ciliumbot is assigned should only request missing
+          # reviews from groups that are not already covered by ciliumbot.
+          # Safe to call unconditionally: gh pr ready succeeds even if the PR
+          # is already ready for review.
+          gh -R ${GITHUB_REPOSITORY} pr ready ${PULL_REQUEST_NUMBER}
+          # Enable GitHub auto-merge here instead of having Renovate do it when
+          # the PR is created as a draft (not possible to have draft and automerge
+          # enabled at the same time).
+          gh -R ${GITHUB_REPOSITORY} pr merge ${PULL_REQUEST_NUMBER} --auto --rebase
         fi
+
+        gh -R ${GITHUB_REPOSITORY} pr review ${PULL_REQUEST_NUMBER} --approve

--- a/.github/workflows/build-images-base-v1.17.yaml
+++ b/.github/workflows/build-images-base-v1.17.yaml
@@ -331,9 +331,22 @@ jobs:
       - name: Push changes into PR
         if: ${{ steps.update-runtime-image.outputs.committed == 'true' || steps.update-builder-image.outputs.committed == 'true' }}
         env:
+          GH_TOKEN: ${{ steps.get_token.outputs.app_token }}
+          pr_number: ${{ github.event.pull_request.number }}
+          pr_author: ${{ github.event.pull_request.user.login }}
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           repository:  ${{ github.event.pull_request.head.repo.full_name || github.repository }}
         run: |
+          if [ -n "${pr_number}" ] && [ "${pr_author}" = "cilium-renovate[bot]" ]; then
+            is_draft=$(gh -R ${repository} pr view ${pr_number} --json isDraft --jq .isDraft)
+            if [ "${is_draft}" = "false" ]; then
+              # Follow-up image updates should not trigger CODEOWNERS while the
+              # regenerated commit is being pushed. The auto-approve workflow
+              # will re-request review from ciliumbot, undraft the PR again,
+              # and only then approve and enable auto-merge.
+              gh -R ${repository} pr ready ${pr_number} --undo
+            fi
+          fi
           git diff HEAD^
           git push https://x-access-token:${{ steps.get_token.outputs.app_token }}@github.com/${{ env.repository }}.git HEAD:$ref
 

--- a/.github/workflows/build-images-base-v1.18.yaml
+++ b/.github/workflows/build-images-base-v1.18.yaml
@@ -303,9 +303,22 @@ jobs:
       - name: Push changes into PR
         if: ${{ steps.update-runtime-image.outputs.committed == 'true' || steps.update-builder-image.outputs.committed == 'true' }}
         env:
+          GH_TOKEN: ${{ steps.get_token.outputs.app_token }}
+          pr_number: ${{ github.event.pull_request.number }}
+          pr_author: ${{ github.event.pull_request.user.login }}
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           repository:  ${{ github.event.pull_request.head.repo.full_name || github.repository }}
         run: |
+          if [ -n "${pr_number}" ] && [ "${pr_author}" = "cilium-renovate[bot]" ]; then
+            is_draft=$(gh -R ${repository} pr view ${pr_number} --json isDraft --jq .isDraft)
+            if [ "${is_draft}" = "false" ]; then
+              # Follow-up image updates should not trigger CODEOWNERS while the
+              # regenerated commit is being pushed. The auto-approve workflow
+              # will re-request review from ciliumbot, undraft the PR again,
+              # and only then approve and enable auto-merge.
+              gh -R ${repository} pr ready ${pr_number} --undo
+            fi
+          fi
           git diff HEAD^
           git push https://x-access-token:${{ steps.get_token.outputs.app_token }}@github.com/${{ env.repository }}.git HEAD:$ref
 

--- a/.github/workflows/build-images-base-v1.19.yaml
+++ b/.github/workflows/build-images-base-v1.19.yaml
@@ -281,9 +281,22 @@ jobs:
       - name: Push changes into PR
         if: ${{ steps.update-runtime-image.outputs.committed == 'true' || steps.update-builder-image.outputs.committed == 'true' }}
         env:
+          GH_TOKEN: ${{ steps.get_token.outputs.app_token }}
+          pr_number: ${{ github.event.pull_request.number }}
+          pr_author: ${{ github.event.pull_request.user.login }}
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           repository:  ${{ github.event.pull_request.head.repo.full_name || github.repository }}
         run: |
+          if [ -n "${pr_number}" ] && [ "${pr_author}" = "cilium-renovate[bot]" ]; then
+            is_draft=$(gh -R ${repository} pr view ${pr_number} --json isDraft --jq .isDraft)
+            if [ "${is_draft}" = "false" ]; then
+              # Follow-up image updates should not trigger CODEOWNERS while the
+              # regenerated commit is being pushed. The auto-approve workflow
+              # will re-request review from ciliumbot, undraft the PR again,
+              # and only then approve and enable auto-merge.
+              gh -R ${repository} pr ready ${pr_number} --undo
+            fi
+          fi
           git diff HEAD^
           git push https://x-access-token:${{ steps.get_token.outputs.app_token }}@github.com/${{ env.repository }}.git HEAD:$ref
 

--- a/.github/workflows/build-images-base-v1.20.yaml
+++ b/.github/workflows/build-images-base-v1.20.yaml
@@ -281,9 +281,22 @@ jobs:
       - name: Push changes into PR
         if: ${{ steps.update-runtime-image.outputs.committed == 'true' || steps.update-builder-image.outputs.committed == 'true' }}
         env:
+          GH_TOKEN: ${{ steps.get_token.outputs.app_token }}
+          pr_number: ${{ github.event.pull_request.number }}
+          pr_author: ${{ github.event.pull_request.user.login }}
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           repository:  ${{ github.event.pull_request.head.repo.full_name || github.repository }}
         run: |
+          if [ -n "${pr_number}" ] && [ "${pr_author}" = "cilium-renovate[bot]" ]; then
+            is_draft=$(gh -R ${repository} pr view ${pr_number} --json isDraft --jq .isDraft)
+            if [ "${is_draft}" = "false" ]; then
+              # Follow-up image updates should not trigger CODEOWNERS while the
+              # regenerated commit is being pushed. The auto-approve workflow
+              # will re-request review from ciliumbot, undraft the PR again,
+              # and only then approve and enable auto-merge.
+              gh -R ${repository} pr ready ${pr_number} --undo
+            fi
+          fi
           git diff HEAD^
           git push https://x-access-token:${{ steps.get_token.outputs.app_token }}@github.com/${{ env.repository }}.git HEAD:$ref
 

--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -297,9 +297,22 @@ jobs:
       - name: Push changes into PR
         if: ${{ steps.update-runtime-image.outputs.committed == 'true' || steps.update-builder-image.outputs.committed == 'true' }}
         env:
+          GH_TOKEN: ${{ steps.get_token.outputs.app_token }}
+          pr_number: ${{ github.event.pull_request.number }}
+          pr_author: ${{ github.event.pull_request.user.login }}
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           repository:  ${{ github.event.pull_request.head.repo.full_name || github.repository }}
         run: |
+          if [ -n "${pr_number}" ] && [ "${pr_author}" = "cilium-renovate[bot]" ]; then
+            is_draft=$(gh -R ${repository} pr view ${pr_number} --json isDraft --jq .isDraft)
+            if [ "${is_draft}" = "false" ]; then
+              # Follow-up image updates should not trigger CODEOWNERS while the
+              # regenerated commit is being pushed. The auto-approve workflow
+              # will re-request review from ciliumbot, undraft the PR again,
+              # and only then approve and enable auto-merge.
+              gh -R ${repository} pr ready ${pr_number} --undo
+            fi
+          fi
           git diff HEAD^
           git push https://x-access-token:${{ steps.get_token.outputs.app_token }}@github.com/${{ env.repository }}.git HEAD:$ref
 


### PR DESCRIPTION
Configure the renovate rules that route review through `ciliumbot` to open their PRs as drafts. This avoids requesting CODEOWNERS immediately when the PR is created, which otherwise always triggers unnecessary reviewer notifications before `ciliumbot` can take over.

The auto-approve workflow is responsible to mark the PR as ready for review before auto-approving it.

Flow: 
1. renovate opens PR as draft and adds `ciliumbot` as reviewer
2. github adds codeowners - but doesn't assign users from the respective review groups because the PR is in draft
3. auto-approve workflow will still be triggered and and will undraft the PR if necessary. this will trigger github reviewer assignment - but it will only assign (and notify (incl. subscription)) users for groups that aren't already covered by `ciliumbot` user. (Note: That's why it's no longer required to remove unnecessary reviewers)
4. auto-approve workflow enables github auto-merge on the PR (responsibility moved because renovate is not allowed to configure github automerge on a draft PR) 
5. auto-approve workflow will auto-approve the PR on behalf of ciliumbot user (needs to happen after undrafting so that the review counts for the review groups).

:pray: :crossed_fingers:  :innocent: 
