### PR TITLE
[41867][Part7] Hybrid Routing Delegated IPAM

### DIFF
--- a/pkg/node/sync/local_node_sync_wait.go
+++ b/pkg/node/sync/local_node_sync_wait.go
@@ -33,7 +33,14 @@ func (ini *localNodeSynchronizer) retrieveNodeInformation(ctx context.Context) *
 	}
 
 	if option.Config.IPAM == ipamOption.IPAMClusterPool ||
-		option.Config.IPAM == ipamOption.IPAMMultiPool {
+		option.Config.IPAM == ipamOption.IPAMMultiPool ||
+		option.Config.IPAM == ipamOption.IPAMDelegatedPlugin {
+		// For delegated-plugin mode (e.g. AKS with Azure CNS), the
+		// authoritative pod CIDRs are written to CiliumNode by the
+		// out-of-tree IPAM plugin, not to k8s Node.spec.podCIDR (which
+		// on AKS reflects kubelet's --pod-cidr and is unrelated to the
+		// pod subnet actually used). Read from CiliumNode like the
+		// in-tree pool modes do.
 		for event := range ini.K8sCiliumLocalNode.Events(ctx) {
 			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 				ini.Logger.Error("Timeout while waiting for CiliumNode resource: API server connection issue", logfields.NodeName, nodeTypes.GetName())


### PR DESCRIPTION
While testing I saw in IPAMDelegatedPlugin mode, GetIPv4AllocCIDRs() returned Cilium's internal CIDR instead of the Azure-assigned pod CIDR, causing downstream consumers (route installation, masquerade decisions, etc.) to work with the wrong CIDR.

This is because LocalNodeSynchronizer.retrieveNodeInformation pulls from k8s Node.spec.podCIDR which is unrelated to pod subnet assigned by IPAM plugin.

The fix: to extend ciliumNode podCIDRs for ipamOption.IPAMDelegatedPlugin

Result: IPAM users get the correct podCIDRs from ciliumNode

Validated on AKS with Azure CNS: GetIPv4AllocCIDRs() now returns the Azure-assigned pod CIDR rather than Cilium's internal CIDR.
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request]
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here or remove this release-note section from your PR description. Do NOT put an "empty" release note here -->
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
