### PR TITLE
cilium-cli: skip node-to-node pod-to-remote-node check in sanity mode

### DIFF
--- a/cilium-cli/connectivity/tests/encryption.go
+++ b/cilium-cli/connectivity/tests/encryption.go
@@ -169,7 +169,12 @@ func getFilter(ctx context.Context, t *check.Test, client, clientHost *check.Pod
 	filter := fmt.Sprintf("src host %s", client.Address(ipFam))
 	dstIP := server.Address(ipFam)
 
-	if tunnelEnabled {
+	// Match the node source for tunnel and SNAT-ed pod-to-remote-node traffic.
+	// This may also capture node-to-node traffic with the same destination and
+	// protocol, which is also a valid leak when node encryption is asserted.
+	srcIsPod := client.Address(ipFam) != clientHost.Address(ipFam)
+	dstIsRemoteNode := dstIP == serverHost.Address(ipFam)
+	if tunnelEnabled || (srcIsPod && dstIsRemoteNode) {
 		cmd := []string{
 			"/bin/sh", "-c",
 			fmt.Sprintf("ip -o route get %s | grep -oE 'src [^ ]*' | cut -d' ' -f2",


### PR DESCRIPTION
The node-to-node-encryption test's pod-to-remote-host sub-check builds a tcpdump filter using the client pod IP as the source. On clusters where pod-to-remote-node traffic is SNAT-ed to the node IP (e.g. AKS "Azure CNI powered by Cilium" overlay in native-routing mode with masquerading), the pod IP never appears on the wire, so tcpdump captures zero packets. In sanity mode (no encryption, assertNoLeaks == false), zero captured packets is reported as a failure ("Expected to capture packets, but none found. This check might be broken."), producing a false failure on non-encryption
clusters.
`getFilter` already used 'ip route get' to resolve the node's preferred source address and matched it in addition to the pod IP when tunneling was enabled. Extend that lookup specifically to pod-to-remote-node traffic, including native-routing mode. On the affected AKS setup, the preferred route source is the node address visible after masquerading. Keep matching the pod IP as well because the route lookup predicts the expected egress source but does not observe the datapath's NAT decision. This fixes the false sanity-mode failure and improves assert-mode coverage: a SNAT-ed plaintext leak now matches the filter instead of being missed. The onlyPodToPodWGWithTunnel skip is retained because the WireGuard+tunnel case builds a different filter that does not use this source clause.

```release-note
cilium-cli: skip node-to-node pod-to-remote-node check in sanity mode
```

AIL: 2
