### PR TITLE
[v1.20] Revert "routing: add hybrid routing mode support"

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1063,8 +1063,8 @@ func initEnv(logger *slog.Logger, vp *viper.Viper) {
 		logging.Fatal(logger, "Option "+option.EnableRemoteNodeMasquerade+" requires BPF masquerade to be enabled ("+option.EnableBPFMasquerade+")")
 	}
 
-	if !option.Config.RequiresNativeRouting() && option.Config.EnableAutoDirectRouting {
-		logging.Fatal(logger, fmt.Sprintf("%s requires native or hybrid routing mode.", option.EnableAutoDirectRoutingName))
+	if option.Config.TunnelingEnabled() && option.Config.EnableAutoDirectRouting {
+		logging.Fatal(logger, fmt.Sprintf("%s cannot be used with tunneling. Packets must be routed through the tunnel device.", option.EnableAutoDirectRoutingName))
 	}
 
 	initClockSourceOption(logger)
@@ -1088,9 +1088,8 @@ func initEnv(logger *slog.Logger, vp *viper.Viper) {
 	}
 
 	if option.Config.LocalRouterIPv4 != "" || option.Config.LocalRouterIPv6 != "" {
-		// TODO(weil0ng): add a proper check for ipam in PR# 15429.
-		if !option.Config.RequiresNativeRouting() {
-			logging.Fatal(logger, fmt.Sprintf("%s and %s require native or hybrid routing mode.", option.LocalRouterIPv4, option.LocalRouterIPv6))
+		if option.Config.TunnelingEnabled() {
+			logging.Fatal(logger, fmt.Sprintf("Cannot specify %s or %s in tunnel mode.", option.LocalRouterIPv4, option.LocalRouterIPv6))
 		}
 	}
 

--- a/pkg/datapath/config/config.go
+++ b/pkg/datapath/config/config.go
@@ -163,9 +163,6 @@ type Config struct {
 	// subsequent calls to NodeConfigurationChanged().
 	EnableEncapsulation bool
 
-	// RequiresNativeRouting returns true if the node requires native routing to setup.
-	RequiresNativeRouting bool
-
 	// TunnelProtocol is the datapath ID of the encapsulation protocol
 	// (0 if disabled, 1 for VXLAN, 2 for Geneve).
 	//

--- a/pkg/datapath/config/endpoint.go
+++ b/pkg/datapath/config/endpoint.go
@@ -68,7 +68,5 @@ func Endpoint(ep endpoint.Config, lnc *Config) any {
 	cfg.EnableIPv4Fragments = option.Config.EnableIPv4FragmentsTracking
 	cfg.EnableIPv6Fragments = option.Config.EnableIPv6FragmentsTracking
 
-	cfg.HybridRoutingEnabled = option.Config.RoutingMode == option.RoutingModeHybrid
-
 	return cfg
 }

--- a/pkg/datapath/config/host.go
+++ b/pkg/datapath/config/host.go
@@ -61,8 +61,6 @@ func CiliumHost(ep endpoint.Config, lnc *Config) any {
 	cfg.EnableIPv4Fragments = option.Config.EnableIPv4FragmentsTracking
 	cfg.EnableIPv6Fragments = option.Config.EnableIPv6FragmentsTracking
 
-	cfg.HybridRoutingEnabled = option.Config.RoutingMode == option.RoutingModeHybrid
-
 	return cfg
 }
 
@@ -109,8 +107,6 @@ func CiliumNet(ep endpoint.Config, lnc *Config, link netlink.Link) any {
 
 	cfg.EnableIPv4Fragments = option.Config.EnableIPv4FragmentsTracking
 	cfg.EnableIPv6Fragments = option.Config.EnableIPv6FragmentsTracking
-
-	cfg.HybridRoutingEnabled = option.Config.RoutingMode == option.RoutingModeHybrid
 
 	return cfg
 }
@@ -178,8 +174,6 @@ func Netdev(ep endpoint.Config, lnc *Config, link netlink.Link, masq4, masq6 net
 
 	cfg.EnableIPv4Fragments = option.Config.EnableIPv4FragmentsTracking
 	cfg.EnableIPv6Fragments = option.Config.EnableIPv6FragmentsTracking
-
-	cfg.HybridRoutingEnabled = option.Config.RoutingMode == option.RoutingModeHybrid
 
 	switch link.(type) {
 	case *netlink.Bridge:

--- a/pkg/datapath/config/zz_generated.deepequal.go
+++ b/pkg/datapath/config/zz_generated.deepequal.go
@@ -170,9 +170,6 @@ func (in *Config) deepEqual(other *Config) bool {
 	if in.EnableEncapsulation != other.EnableEncapsulation {
 		return false
 	}
-	if in.RequiresNativeRouting != other.RequiresNativeRouting {
-		return false
-	}
 	if in.TunnelProtocol != other.TunnelProtocol {
 		return false
 	}

--- a/pkg/datapath/orchestrator/localnodeconfig.go
+++ b/pkg/datapath/orchestrator/localnodeconfig.go
@@ -183,7 +183,6 @@ func newLocalNodeConfig(
 		EnableIPv4:                   daemon.EnableIPv4,
 		EnableIPv6:                   daemon.EnableIPv6,
 		EnableEncapsulation:          daemon.TunnelingEnabled(),
-		RequiresNativeRouting:        daemon.RequiresNativeRouting(),
 		TunnelProtocol:               tunnelCfg.EncapProtocol().ToDpID(),
 		TunnelPort:                   tunnelCfg.Port(),
 		EnableAutoDirectRouting:      daemon.EnableAutoDirectRouting,

--- a/pkg/maps/subnet/table.go
+++ b/pkg/maps/subnet/table.go
@@ -6,7 +6,6 @@ package subnet
 import (
 	"encoding"
 	"fmt"
-	"iter"
 	"net/netip"
 
 	"github.com/cilium/statedb"
@@ -18,18 +17,6 @@ import (
 )
 
 const TableName = "subnet-identities"
-
-var (
-	SubnetPrimaryIndex = statedb.Index[SubnetTableEntry, netip.Prefix]{
-		Name: "key",
-		FromObject: func(t SubnetTableEntry) index.KeySet {
-			return index.NewKeySet(index.NetIPPrefix(t.Key))
-		},
-		FromKey:    index.NetIPPrefix,
-		FromString: index.NetIPPrefixString,
-		Unique:     true,
-	}
-)
 
 type SubnetTableEntry struct {
 	Key netip.Prefix
@@ -79,26 +66,6 @@ func (s SubnetTableEntry) getStatus() reconciler.Status {
 	return s.Status
 }
 
-// SubnetLPMIndex is the secondary index for SubnetEntry
-// Primary index is exact prefix index and secondary is LPM.
-var SubnetLPMIndex = statedb.NetIPPrefixIndex[SubnetTableEntry]{
-	Name: "prefix",
-	FromObject: func(s SubnetTableEntry) iter.Seq[netip.Prefix] {
-		return statedb.Just(s.Key)
-	},
-	Unique: true,
-}
-
-// newSubnetEntryTable creates and registers the subnet entry table in stateDB.
-func newSubnetEntryTable(db *statedb.DB) (statedb.RWTable[SubnetTableEntry], error) {
-	return statedb.NewTable(
-		db,
-		TableName,
-		SubnetPrimaryIndex,
-		SubnetLPMIndex,
-	)
-}
-
 // BinaryKey returns the binary representation of the subnet prefix for the eBPF map key.
 func (s SubnetTableEntry) BinaryKey() encoding.BinaryMarshaler {
 	var ip types.IPv6
@@ -134,4 +101,24 @@ func (s SubnetTableEntry) BinaryValue() encoding.BinaryMarshaler {
 		Identity: s.Value,
 	}
 	return bpf.StructBinaryMarshaler{Target: &v}
+}
+
+// SubnetIndex is the primary index for SubnetEntry, indexing by Prefix.
+var SubnetIndex = statedb.Index[SubnetTableEntry, netip.Prefix]{
+	Name: "prefix",
+	FromObject: func(s SubnetTableEntry) index.KeySet {
+		return index.NewKeySet(index.NetIPPrefix(s.Key))
+	},
+	FromKey:    index.NetIPPrefix,
+	FromString: index.NetIPPrefixString,
+	Unique:     true,
+}
+
+// newSubnetEntryTable creates and registers the subnet entry table in stateDB.
+func newSubnetEntryTable(db *statedb.DB) (statedb.RWTable[SubnetTableEntry], error) {
+	return statedb.NewTable(
+		db,
+		TableName,
+		SubnetIndex,
+	)
 }

--- a/pkg/mtu/cell.go
+++ b/pkg/mtu/cell.go
@@ -131,7 +131,7 @@ func newForCell(lc cell.Lifecycle, p mtuParams, cc Config) (MTU, error) {
 	c := &Configuration{}
 	lc.Append(cell.Hook{
 		OnStart: func(ctx cell.HookContext) error {
-			tunnelOverIPv6 := option.Config.TunnelingEnabled() &&
+			tunnelOverIPv6 := option.Config.RoutingMode == option.RoutingModeTunnel &&
 				p.TunnelConfig.UnderlayProtocol() == tunnel.IPv6
 			*c = NewConfiguration(
 				p.IPsec.AuthKeySize(),

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2005,11 +2005,6 @@ func (c *DaemonConfig) TunnelingEnabled() bool {
 	return c.RoutingMode != RoutingModeNative
 }
 
-// RequiresNativeRouting returns true if the agent needs to use native routing to implement some features.
-func (c *DaemonConfig) RequiresNativeRouting() bool {
-	return c.RoutingMode == RoutingModeNative || c.RoutingMode == RoutingModeHybrid
-}
-
 // AreDevicesRequired returns true if the agent needs to attach to the native
 // devices to implement some features.
 func (c *DaemonConfig) AreDevicesRequired(kprCfg kpr.KPRConfig, wireguardEnabled, ipsecEnabled bool) bool {
@@ -2025,7 +2020,7 @@ func (c *DaemonConfig) NeedEgressOnWireGuardDevice(kprCfg kpr.KPRConfig, wiregua
 	}
 
 	// No need to handle rev-NAT xlations in wireguard with tunneling enabled.
-	if !c.RequiresNativeRouting() {
+	if c.TunnelingEnabled() {
 		return false
 	}
 
@@ -2241,10 +2236,10 @@ func (c *DaemonConfig) Validate(vp *viper.Viper) error {
 	}
 
 	switch c.RoutingMode {
-	case RoutingModeNative, RoutingModeTunnel, RoutingModeHybrid:
+	case RoutingModeNative, RoutingModeTunnel:
 	default:
-		return fmt.Errorf("invalid routing mode %q, valid modes = {%q, %q, %q}",
-			c.RoutingMode, RoutingModeTunnel, RoutingModeNative, RoutingModeHybrid)
+		return fmt.Errorf("invalid routing mode %q, valid modes = {%q, %q}",
+			c.RoutingMode, RoutingModeTunnel, RoutingModeNative)
 	}
 
 	cinfo := clustermeshTypes.ClusterInfo{
@@ -2988,7 +2983,7 @@ func (c *DaemonConfig) checkIPv4NativeRoutingCIDR() error {
 	if c.EnableIPMasqAgent {
 		return nil
 	}
-	if !c.RequiresNativeRouting() {
+	if c.TunnelingEnabled() {
 		return nil
 	}
 	if c.IPAMMode() == ipamOption.IPAMENI || c.IPAMMode() == ipamOption.IPAMAlibabaCloud {
@@ -3015,7 +3010,7 @@ func (c *DaemonConfig) checkIPv6NativeRoutingCIDR() error {
 	if c.EnableIPMasqAgent {
 		return nil
 	}
-	if !c.RequiresNativeRouting() {
+	if c.TunnelingEnabled() {
 		return nil
 	}
 	return fmt.Errorf(

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -249,42 +249,6 @@ func TestEnabledFunctions(t *testing.T) {
 	require.Equal(t, ipamOption.IPAMENI, d.IPAMMode())
 }
 
-func TestRoutingModeHelpers(t *testing.T) {
-	tests := []struct {
-		name           string
-		routingMode    string
-		expectedTunnel bool
-		expectedNative bool
-	}{
-		{
-			name:           "native mode - tunneling disabled and native routing required",
-			routingMode:    RoutingModeNative,
-			expectedTunnel: false,
-			expectedNative: true,
-		},
-		{
-			name:           "tunnel mode - tunneling enabled and native routing not required",
-			routingMode:    RoutingModeTunnel,
-			expectedTunnel: true,
-			expectedNative: false,
-		},
-		{
-			name:           "hybrid mode - tunneling enabled and native routing required",
-			routingMode:    RoutingModeHybrid,
-			expectedTunnel: true,
-			expectedNative: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			d := &DaemonConfig{RoutingMode: tt.routingMode}
-			assert.Equal(t, tt.expectedTunnel, d.TunnelingEnabled())
-			assert.Equal(t, tt.expectedNative, d.RequiresNativeRouting())
-		})
-	}
-}
-
 func TestLocalAddressExclusion(t *testing.T) {
 	d := &DaemonConfig{}
 	err := d.parseExcludedLocalAddresses([]string{"1.1.1.1/32", "3.3.3.0/24", "f00d::1/128"})
@@ -582,29 +546,6 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 			},
 			wantErr: false,
 		},
-		{
-			name: "hybrid mode with native routing cidr",
-			d: &DaemonConfig{
-				EnableIPv4Masquerade:  true,
-				EnableIPv6Masquerade:  true,
-				RoutingMode:           RoutingModeHybrid,
-				IPAM:                  ipamOption.IPAMAzure,
-				IPv4NativeRoutingCIDR: cidr.MustParseCIDR("10.127.64.0/18"),
-				EnableIPv4:            true,
-			},
-			wantErr: false,
-		},
-		{
-			name: "hybrid mode without native routing cidr requires cidr",
-			d: &DaemonConfig{
-				EnableIPv4Masquerade: true,
-				EnableIPv6Masquerade: true,
-				RoutingMode:          RoutingModeHybrid,
-				IPAM:                 ipamOption.IPAMAzure,
-				EnableIPv4:           true,
-			},
-			wantErr: true,
-		},
 	}
 
 	for _, tt := range tests {
@@ -677,27 +618,6 @@ func TestCheckIPv6NativeRoutingCIDR(t *testing.T) {
 				EnableIPMasqAgent:    true,
 			},
 			wantErr: false,
-		},
-		{
-			name: "hybrid mode with native routing cidr",
-			d: &DaemonConfig{
-				EnableIPv4Masquerade:  true,
-				EnableIPv6Masquerade:  true,
-				RoutingMode:           RoutingModeHybrid,
-				IPv6NativeRoutingCIDR: cidr.MustParseCIDR("fd00::/120"),
-				EnableIPv6:            true,
-			},
-			wantErr: false,
-		},
-		{
-			name: "hybrid mode without native routing cidr requires cidr",
-			d: &DaemonConfig{
-				EnableIPv4Masquerade: true,
-				EnableIPv6Masquerade: true,
-				RoutingMode:          RoutingModeHybrid,
-				EnableIPv6:           true,
-			},
-			wantErr: true,
 		},
 	}
 


### PR DESCRIPTION
This reverts commit e8bac7929b421a31cb974cb34b1e4d1237731981.

The feature is incomplete, so it doesn't make sense to expose it in
Cilium v1.20.

I didn't propose an equivalent change to `main` branch, because
there is ongoing active development there.

Related: https://github.com/cilium/cilium/pull/45001