### PR TITLE
gateway-api: Add TCP and UDP gateway conformance profiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -639,7 +639,7 @@ gateway-api-conformance-report: ## Run Gateway API conformance tests with a conf
 		--url github.com/cilium/cilium \
 		--version $(CILIUM_VERSION) \
 		--contact https://github.com/cilium/community/blob/main/roles/Maintainers.md \
-		--conformance-profiles GATEWAY-HTTP,GATEWAY-TLS,GATEWAY-GRPC,MESH-HTTP,MESH-GRPC \
+		--conformance-profiles GATEWAY-HTTP,GATEWAY-TLS,GATEWAY-GRPC,GATEWAY-TCP,GATEWAY-UDP,MESH-HTTP,MESH-GRPC \
 		--report-output=$(CURDIR)/gateway-api-conformance-report.yaml \
 	| $(GOTEST_FORMATTER)
 


### PR DESCRIPTION
Add GATEWAY-TCP and GATEWAY-UDP conformance profiles to the `gateway-api-conformance-report` target in Makefile.

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
