### PR TITLE
.github: add external nodegroup to pooled EKS clusters

### DIFF
--- a/.github/workflows/eks-cluster-pool-manager.yaml
+++ b/.github/workflows/eks-cluster-pool-manager.yaml
@@ -290,13 +290,17 @@ jobs:
               (.aws_cni.include[] | . + {
                 "addons": "coredns kube-proxy vpc-cni",
                 "addons_name": "all-addons",
-                "zones": (. | zones)
+                "zones": (. | zones),
+                "az_cluster": (if .region == "us-west-1" then .region + "a" else .region + "b" end),
+                "az_external": (.region + "c")
               }),
               # coredns-kubeproxy configuration from eks versions
               (.eks.include[] | . + {
                 "addons": "coredns kube-proxy",
                 "addons_name": "coredns-kubeproxy",
-                "zones": (. | zones)
+                "zones": (. | zones),
+                "az_cluster": (if .region == "us-west-1" then .region + "a" else .region + "b" end),
+                "az_external": (.region + "c")
               })
             ]
           }
@@ -523,6 +527,9 @@ jobs:
           owner: "eks-cluster-pool-manager"
           version: ${{ matrix.version }}
           spot: false
+          nodes_without_cilium: 2
+          az_cluster: ${{ matrix.az_cluster }}
+          az_external: ${{ matrix.az_external }}
 
       - name: Upload kubeconfig to S3 pool
         if: ${{ steps.check-pool.outputs.should_create == 'true' }}


### PR DESCRIPTION
The aws-cni (and eks) conformance jobs run an "Add external targets to the cluster" step that picks the first node labeled cilium.io/no-schedule=true. That node lives in the ng-amd64-external nodegroup, which setup-eks-nodegroup creates only when it is given nodes_without_cilium plus the cluster and external availability zones. The consumer workflow passes those, but only creates nodegroups when it mints a fresh cluster (new_cluster_created == 'true'). The pool manager, which is what actually creates the clusters that PR jobs claim, was calling setup-eks-nodegroup without any of those inputs, so a pool-minted vpc-cni cluster was born with ng-amd64-external at desiredCapacity 0.

This stayed hidden until #47357 fixed the pool key mismatch and PR jobs started actually claiming pooled clusters instead of falling back to creating fresh ones. A claimed cluster then had zero cilium.io/no-schedule=true nodes, and the step indexed items[0] on an empty list, failing with "array index out of bounds: index 0, length 0". The same SHA passed the scheduled run (fresh cluster) and failed the dispatched runs (pool claim), which is what pointed at the provisioning path rather than any code under test.

The fix passes nodes_without_cilium and the cluster and external availability zones from the pool manager too, so a pooled vpc-cni cluster is born with the same external nodegroup a freshly created one gets. The zones use the same region logic the consumers use for eks_zone_1 and eks_zone_2, and they are not part of the pool key (the sha256 of "<addons> <zones>"), so this cannot change which pool a cluster lands in.

The change is on main and v1.20 only, where the external-nodes feature lives, so it needs a v1.20 backport.

This PR was prepared with AIL:3.