### PR TITLE
bpf: dsr: re-use TCP SYN flag from CT lookup in remote-backend path

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -262,12 +262,11 @@ static __always_inline __u32 ct_update_timeout(struct ct_entry *entry,
 
 static __always_inline void
 ct_lookup_fill_state(struct ct_state *state, const struct ct_entry *entry,
-		     enum ct_dir dir, bool syn)
+		     enum ct_dir dir)
 {
 	state->rev_nat_index = entry->rev_nat_index;
 	if (dir == CT_SERVICE) {
 		state->backend_id = (__u32)entry->backend_id;
-		state->syn = syn;
 	} else if (dir == CT_INGRESS || dir == CT_EGRESS) {
 #ifdef USE_LOOPBACK_LB
 		state->loopback = entry->lb_loopback;
@@ -434,7 +433,7 @@ __ct_lookup(const void *map, const struct __ctx_buff *ctx, const void *tuple,
 
 		/* Fill ct_state after all potential CT_NEW returns. */
 		if (ct_state)
-			ct_lookup_fill_state(ct_state, entry, dir, syn);
+			ct_lookup_fill_state(ct_state, entry, dir);
 
 		return CT_ESTABLISHED;
 	}
@@ -680,6 +679,9 @@ __ct_lookup6(const void *map, struct ipv6_ct_tuple *tuple, const struct __ctx_bu
 			return DROP_CT_INVALID_HDR;
 
 		action = ct_tcp_select_action(tcp_flags);
+
+		if (ct_state && dir == CT_SERVICE && (tcp_flags.value & TCP_FLAG_SYN))
+			ct_state->syn = true;
 	} else {
 		action = ACTION_UNSPEC;
 	}
@@ -938,6 +940,9 @@ __ct_lookup4(const void *map, struct ipv4_ct_tuple *tuple, const struct __ctx_bu
 			return DROP_CT_INVALID_HDR;
 
 		action = ct_tcp_select_action(tcp_flags);
+
+		if (ct_state && dir == CT_SERVICE && (tcp_flags.value & TCP_FLAG_SYN))
+			ct_state->syn = true;
 	} else {
 		action = ACTION_UNSPEC;
 	}

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -128,6 +128,18 @@ static __always_inline bool nodeport_uses_dsr(bool flip __maybe_unused)
 #endif
 }
 
+#define NEED_DSR_INFO	(1 << 16)
+
+static __always_inline bool
+nodeport_need_dsr_info(__u8 nexthdr, const struct ct_state *ct_state)
+{
+	/* We only need to embed the DSR info into the first packet of a connection
+	 * (since it will then be cached on the backend node).
+	 * Doing so for the TCP-SYN avoids MTU troubles.
+	 */
+	return (nexthdr != IPPROTO_TCP) || ct_state->syn;
+}
+
 #if defined(ENABLE_IPV4)
 static __always_inline struct ipv4_nat_entry *
 nodeport_dsr_lookup_v4_nat_entry(const struct ipv4_ct_tuple *nat_tuple)
@@ -365,31 +377,18 @@ static __always_inline int dsr_set_ipip6(struct __ctx_buff *ctx,
 static __always_inline int dsr_set_ext6(struct __ctx_buff *ctx,
 					struct ipv6hdr *ip6,
 					const union v6addr *svc_addr,
-					__be16 svc_port, int *ohead)
+					__be16 svc_port, bool need_dsr_info,
+					int *ohead)
 {
 	struct dsr_opt_v6 opt __align_stack_8 = {};
 	__u16 payload_len = bpf_ntohs(ip6->payload_len) + sizeof(opt);
 	__u16 total_len = bpf_ntohs(ip6->payload_len) + sizeof(struct ipv6hdr) + sizeof(opt);
-	__u8 nexthdr = ip6->nexthdr;
-	int hdrlen;
 
 	/* The IPv6 extension should be 8-bytes aligned */
 	build_bug_on((sizeof(struct dsr_opt_v6) % 8) != 0);
 
-	hdrlen = ipv6_hdrlen(ctx, &nexthdr);
-	if (hdrlen < 0)
-		return hdrlen;
-
-	/* See dsr_set_opt4(): */
-	if (nexthdr == IPPROTO_TCP) {
-		union tcp_flags tcp_flags = { .value = 0 };
-
-		if (l4_load_tcp_flags(ctx, ETH_HLEN + hdrlen, &tcp_flags) < 0)
-			return DROP_CT_INVALID_HDR;
-
-		if (!(tcp_flags.value & (TCP_FLAG_SYN)))
-			return 0;
-	}
+	if (!need_dsr_info)
+		return 0;
 
 	if (dsr_is_too_big(ctx, total_len)) {
 		*ohead = sizeof(opt);
@@ -419,13 +418,13 @@ static __always_inline int encap_geneve_dsr_opt6(struct __ctx_buff *ctx,
 						 struct ipv6hdr *ip6,
 						 const union v6addr *svc_addr,
 						 __be16 svc_port,
+						 bool need_opt,
 						 int *ifindex, int *ohead)
 {
 	const struct remote_endpoint_info *info;
 	struct ipv6_ct_tuple tuple __align_stack_8 = {};
 	struct geneve_dsr_opt6 gopt;
 	union v6addr *dst;
-	bool need_opt = true;
 	__u16 encap_len = sizeof(struct ipv6hdr) + sizeof(struct udphdr) +
 		sizeof(struct genevehdr) + ETH_HLEN;
 	__u16 payload_len = bpf_ntohs(ip6->payload_len) + sizeof(*ip6);
@@ -453,17 +452,6 @@ static __always_inline int encap_geneve_dsr_opt6(struct __ctx_buff *ctx,
 		return ret;
 
 	src_port = tunnel_gen_src_port_v6(&tuple);
-
-	/* See encap_geneve_dsr_opt4(): */
-	if (tuple.nexthdr == IPPROTO_TCP) {
-		union tcp_flags tcp_flags = { .value = 0 };
-
-		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
-			return DROP_CT_INVALID_HDR;
-
-		if (!(tcp_flags.value & (TCP_FLAG_SYN)))
-			need_opt = false;
-	}
 
 	if (need_opt) {
 		encap_len += sizeof(struct geneve_dsr_opt6);
@@ -717,12 +705,14 @@ int tail_nodeport_ipv6_dsr(struct __ctx_buff *ctx)
 			.ifindex	= ctx_get_ifindex(ctx),
 		},
 	};
+	__u32 tmp = ctx_load_meta(ctx, CB_PORT);
+	bool need_dsr_info __maybe_unused = tmp & NEED_DSR_INFO;
+	__be16 port = tmp & 0xffff;
 	int ret, oif = 0, ohead = 0;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	union v6addr addr __align_stack_8 = {};
 	__s8 ext_err = 0;
-	__be16 port;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6)) {
 		ret = DROP_INVALID;
@@ -731,15 +721,14 @@ int tail_nodeport_ipv6_dsr(struct __ctx_buff *ctx)
 
 	ctx_load_meta_ipv6(ctx, &addr, CB_ADDR_V6_1);
 
-	port = (__be16)ctx_load_meta(ctx, CB_PORT);
-
 #if DSR_ENCAP_MODE == DSR_ENCAP_IPIP
 	ret = dsr_set_ipip6(ctx, ip6, &addr,
 			    ctx_load_meta(ctx, CB_HINT), &oif, &ohead);
 #elif DSR_ENCAP_MODE == DSR_ENCAP_NONE
-	ret = dsr_set_ext6(ctx, ip6, &addr, port, &ohead);
+	ret = dsr_set_ext6(ctx, ip6, &addr, port, need_dsr_info, &ohead);
 #elif DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
-	ret = encap_geneve_dsr_opt6(ctx, ip6, &addr, port, &oif, &ohead);
+	ret = encap_geneve_dsr_opt6(ctx, ip6, &addr, port, need_dsr_info,
+				    &oif, &ohead);
 	if (!IS_ERR(ret))
 		fib_params.l.family = AF_INET;
 #else
@@ -1538,7 +1527,12 @@ static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
 			       ((__u32)tuple->sport << 16) | tuple->dport);
 		ctx_store_meta_ipv6(ctx, CB_ADDR_V6_1, &backend->address);
 #elif DSR_ENCAP_MODE == DSR_ENCAP_GENEVE || DSR_ENCAP_MODE == DSR_ENCAP_NONE
-		ctx_store_meta(ctx, CB_PORT, key->dport);
+		__u32 port = key->dport;
+
+		if (nodeport_need_dsr_info(tuple->nexthdr, &ct_state_svc))
+			port |= NEED_DSR_INFO;
+
+		ctx_store_meta(ctx, CB_PORT, port);
 		ctx_store_meta_ipv6(ctx, CB_ADDR_V6_1, &key->address);
 #endif /* DSR_ENCAP_MODE */
 		return tail_call_internal(ctx, CILIUM_CALL_IPV6_NODEPORT_DSR, ext_err);
@@ -1773,27 +1767,16 @@ static __always_inline int dsr_set_ipip4(struct __ctx_buff *ctx,
 # elif DSR_ENCAP_MODE == DSR_ENCAP_NONE
 static __always_inline int dsr_set_opt4(struct __ctx_buff *ctx,
 					struct iphdr *ip4, __be32 svc_addr,
-					__be16 svc_port, __be16 *ohead)
+					__be16 svc_port, bool need_dsr_info,
+					__be16 *ohead)
 {
 	__u32 iph_old, iph_new;
 	struct dsr_opt_v4 opt;
 	__u16 tot_len = bpf_ntohs(ip4->tot_len) + sizeof(opt);
 	__be32 sum;
 
-	if (ip4->protocol == IPPROTO_TCP) {
-		union tcp_flags tcp_flags = { .value = 0 };
-
-		if (l4_load_tcp_flags(ctx, ETH_HLEN + ipv4_hdrlen(ip4), &tcp_flags) < 0)
-			return DROP_CT_INVALID_HDR;
-
-		/* Setting the option is required only for the first packet
-		 * (SYN), in the case of TCP, as for further packets of the
-		 * same connection a remote node will use a NAT entry to
-		 * reverse xlate a reply.
-		 */
-		if (!(tcp_flags.value & (TCP_FLAG_SYN)))
-			return 0;
-	}
+	if (!need_dsr_info)
+		return 0;
 
 	if (ipv4_hdrlen(ip4) + sizeof(opt) > sizeof(struct iphdr) + MAX_IPOPTLEN)
 		return DROP_CT_INVALID_HDR;
@@ -1831,19 +1814,18 @@ static __always_inline int dsr_set_opt4(struct __ctx_buff *ctx,
 # elif DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
 static __always_inline int encap_geneve_dsr_opt4(struct __ctx_buff *ctx, struct iphdr *ip4,
 						 __be32 svc_addr, __be16 svc_port,
-						 int *ifindex, __be16 *ohead)
+						 bool need_opt, int *ifindex, __be16 *ohead)
 {
 	const struct remote_endpoint_info *info;
 	struct geneve_dsr_opt4 gopt __align_stack_8 = { };
-	bool need_opt = true;
 	__u16 encap_len = sizeof(struct iphdr) + sizeof(struct udphdr) +
 		sizeof(struct genevehdr) + ETH_HLEN;
 	__u16 total_len = bpf_ntohs(ip4->tot_len);
 	__u32 src_sec_identity = WORLD_IPV4_ID;
 	__be16 src_port = 0;
-	int l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
 #  if __ctx_is == __ctx_xdp
 	fraginfo_t fraginfo = ipfrag_encode_ipv4(ip4);
+	int l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
 	struct ipv4_ct_tuple tuple = {};
 	int ret;
 
@@ -1859,21 +1841,6 @@ static __always_inline int encap_geneve_dsr_opt4(struct __ctx_buff *ctx, struct 
 	info = lookup_ip4_remote_endpoint(ip4->daddr, 0);
 	if (!info || !info->flag_has_tunnel_ep)
 		return DROP_NO_TUNNEL_ENDPOINT;
-
-	if (ip4->protocol == IPPROTO_TCP) {
-		union tcp_flags tcp_flags = { .value = 0 };
-
-		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
-			return DROP_CT_INVALID_HDR;
-
-		/* The GENEVE option is required only for the first packet
-		 * (SYN), in the case of TCP, as for further packets of the
-		 * same connection a remote node will use a NAT entry to
-		 * reverse xlate a reply.
-		 */
-		if (!(tcp_flags.value & (TCP_FLAG_SYN)))
-			need_opt = false;
-	}
 
 	if (need_opt) {
 		encap_len += sizeof(struct geneve_dsr_opt4);
@@ -2109,31 +2076,31 @@ drop_err:
 __declare_tail(CILIUM_CALL_IPV4_NODEPORT_DSR)
 int tail_nodeport_ipv4_dsr(struct __ctx_buff *ctx)
 {
+	__u32 tmp = ctx_load_meta(ctx, CB_PORT);
+	bool need_dsr_info __maybe_unused = tmp & NEED_DSR_INFO;
+	__be16 port = tmp & 0xffff;
 	void *data, *data_end;
 	struct iphdr *ip4;
 	int ret, oif = 0;
 	__be16 ohead = 0;
 	__s8 ext_err = 0;
 	__be32 addr;
-	__be16 port;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4)) {
 		ret = DROP_INVALID;
 		goto drop_err;
 	}
 	addr = ctx_load_meta(ctx, CB_ADDR_V4);
-	port = (__be16)ctx_load_meta(ctx, CB_PORT);
 
 #if DSR_ENCAP_MODE == DSR_ENCAP_IPIP
 	ret = dsr_set_ipip4(ctx, ip4,
 			    addr,
 			    ctx_load_meta(ctx, CB_HINT), &oif, &ohead);
 #elif DSR_ENCAP_MODE == DSR_ENCAP_NONE
-	ret = dsr_set_opt4(ctx, ip4,
-			   addr,
-			   port, &ohead);
+	ret = dsr_set_opt4(ctx, ip4, addr, port, need_dsr_info, &ohead);
 #elif DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
-	ret = encap_geneve_dsr_opt4(ctx, ip4, addr, port, &oif, &ohead);
+	ret = encap_geneve_dsr_opt4(ctx, ip4, addr, port, need_dsr_info,
+				    &oif, &ohead);
 #else
 # error "Invalid load balancer DSR encapsulation mode!"
 #endif
@@ -2920,7 +2887,12 @@ static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,
 			       ((__u32)tuple->sport << 16) | tuple->dport);
 		ctx_store_meta(ctx, CB_ADDR_V4, backend->address);
 #elif DSR_ENCAP_MODE == DSR_ENCAP_GENEVE || DSR_ENCAP_MODE == DSR_ENCAP_NONE
-		ctx_store_meta(ctx, CB_PORT, key->dport);
+		__u32 port = key->dport;
+
+		if (nodeport_need_dsr_info(tuple->nexthdr, &ct_state_svc))
+			port |= NEED_DSR_INFO;
+
+		ctx_store_meta(ctx, CB_PORT, port);
 		ctx_store_meta(ctx, CB_ADDR_V4, key->address);
 #endif /* DSR_ENCAP_MODE */
 		return tail_call_internal(ctx, CILIUM_CALL_IPV4_NODEPORT_DSR, ext_err);


### PR DESCRIPTION
When forwarding a DSR request to a remote backend, each egress path
currently needs to have its own logic to extract the TCP flags and check
for the SYN flag.

But we already obtain the flag during the CT lookup. So let's just
forward a "need_dsr_info" indication over the tailcall boundary, mixing it
into the free part of the CB_PORT slot.