### PR TITLE
.github: quarantine outside-to-nodeport L7 test on non-PD EKS legs

### DIFF
--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -570,6 +570,19 @@ jobs:
         run: |
           CONNECTIVITY_TEST_DEFAULTS="${{ steps.e2e_config.outputs.test_flags }}"
 
+          # Quarantine: on legs without prefix delegation the node attaches
+          # multiple secondary ENIs, and the outside-to-nodeport reply for the
+          # L7 policy test egresses a secondary ENI while carrying the primary
+          # ENI's source IP, so the VPC source/dest check drops it (curl 28).
+          # This is a real, still-under-investigation datapath bug rather than a
+          # flake; skip only this test on the affected legs so the failure is
+          # not silently masked elsewhere. The prefix-delegation legs still run
+          # and gate it. Remove once the ENI return-path routing is fixed.
+          if [[ "${{ matrix.aws-eni-pd }}" != "true" ]]; then
+            CONNECTIVITY_TEST_DEFAULTS+=" --test '!north-south-loadbalancing-with-l7-policy'"
+            echo "::warning title=Test quarantined::north-south-loadbalancing-with-l7-policy/outside-to-nodeport is skipped on this leg (${{ join(matrix.*, ', ') }}) because it hits a known ENI return-path drop without prefix delegation. The test is quarantined here and still gates on the prefix-delegation legs; remove once the bug is fixed."
+          fi
+
           echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
 
       - name: Check that AWS leftover iptables chains have been removed


### PR DESCRIPTION
The north-south-loadbalancing-with-l7-policy outside-to-nodeport test fails with curl exit 28 on the EKS legs that run without prefix delegation (1.32/us-west-1 and 1.33/us-east-2), turning the Conformance EKS runs red. On those legs the node attaches several secondary ENIs, and the reply to the external client egresses a secondary ENI while still carrying the source IP owned by the primary ENI, so the VPC source/destination check drops it and the client never completes the handshake. That is a real datapath bug on the ENI return path, currently under investigation, not a flake.

This skips only that test, and only on the legs without prefix delegation, so the run stops going red while the bug is worked. The change lives in the connectivity test flag setup and is conditional on the matrix leg not using prefix delegation, mirroring the existing per-test skips in the GKE workflow. A warning annotation is emitted on the affected legs so the skip stays visible in the run summary rather than silently disappearing, in the same spirit as the quarantined netkit job. The prefix-delegation legs keep running the test and gating on it, and every other test keeps gating on every leg, so nothing else is masked.

This is meant to be removed once the ENI return-path routing is fixed; the diagnostics that proved the drop live in a separate change (#47285).

This PR was prepared with AIL:3.