### PR TITLE
plugins, examples: Remove extra whitespace from example files

### DIFF
--- a/examples/datapath-plugin/bpf/common.h
+++ b/examples/datapath-plugin/bpf/common.h
@@ -16,5 +16,3 @@ char attachment_context[256];
 			trace_printk(____fmt, sizeof(____fmt),	\
 				     ##__VA_ARGS__);		\
 		})
-
-

--- a/examples/datapath-plugin/bpf/sock.c
+++ b/examples/datapath-plugin/bpf/sock.c
@@ -21,4 +21,3 @@ int after(struct bpf_sock *ctx __maybe_unused, int ret)
 }
 
 BPF_LICENSE("Dual BSD/GPL");
-

--- a/examples/datapath-plugin/bpf/sock_addr.c
+++ b/examples/datapath-plugin/bpf/sock_addr.c
@@ -21,4 +21,3 @@ int after(struct bpf_sock_addr *ctx __maybe_unused, int ret)
 }
 
 BPF_LICENSE("Dual BSD/GPL");
-

--- a/examples/datapath-plugin/bpf/xdp.c
+++ b/examples/datapath-plugin/bpf/xdp.c
@@ -21,4 +21,3 @@ int after(struct __ctx_buff *ctx __maybe_unused, int ret)
 }
 
 BPF_LICENSE("Dual BSD/GPL");
-


### PR DESCRIPTION
@joestringer noted [here](https://github.com/cilium/cilium/pull/46872#discussion_r3624298748) that `common.h` had some extra whitespace. Let's fix this up along with other instances of excess newlines.