### PR TITLE
bpf: Add is_subnet_same_id helper

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -382,12 +382,10 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 	/* Check if the source and destination IP has same subnet ID. */
 	bool same_subnet_id = false;
 
-	if (CONFIG(hybrid_routing_enabled)) {
-		__u32 src_subnet_id = lookup_ip6_subnet_id((union v6addr *)&ip6->saddr);
-		__u32 dst_subnet_id = lookup_ip6_subnet_id((union v6addr *)&ip6->daddr);
+	if (CONFIG(hybrid_routing_enabled))
+		same_subnet_id = is_subnet_same_id6((union v6addr *)&ip6->saddr,
+						    (union v6addr *)&ip6->daddr);
 
-		same_subnet_id = (src_subnet_id == dst_subnet_id) && (src_subnet_id != 0);
-	}
 	if ((info && info->flag_skip_tunnel) || same_subnet_id)
 		goto skip_tunnel;
 
@@ -841,12 +839,9 @@ handle_ipv4_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 	/* Check if the source and destination IP has same subnet ID. */
 	bool same_subnet_id = false;
 	/* Lookup the subnet IDs for the source and destination IPs in hybrid routing mode. */
-	if (CONFIG(hybrid_routing_enabled)) {
-		__u32 src_subnet_id = lookup_ip4_subnet_id(ip4->saddr);
-		__u32 dst_subnet_id = lookup_ip4_subnet_id(ip4->daddr);
+	if (CONFIG(hybrid_routing_enabled))
+		same_subnet_id = is_subnet_same_id4(ip4->saddr, ip4->daddr);
 
-		same_subnet_id = (src_subnet_id == dst_subnet_id) && (src_subnet_id != 0);
-	}
 	if ((info && info->flag_skip_tunnel) || same_subnet_id)
 		goto skip_tunnel;
 

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -861,13 +861,9 @@ static __always_inline int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *d
 		const union v6addr *daddr = (union v6addr *)&ip6->daddr;
 		bool same_subnet_id = false;
 
-		if (CONFIG(hybrid_routing_enabled)) {
-			const union v6addr *saddr = (union v6addr *)&ip6->saddr;
-			__u32 src_subnet_id = lookup_ip6_subnet_id(saddr);
-			__u32 dst_subnet_id = lookup_ip6_subnet_id(daddr);
-
-			same_subnet_id = (src_subnet_id == dst_subnet_id) && (src_subnet_id != 0);
-		}
+		if (CONFIG(hybrid_routing_enabled))
+			same_subnet_id = is_subnet_same_id6((union v6addr *)&ip6->saddr,
+							    (union v6addr *)&ip6->daddr);
 
 		info = lookup_ip6_remote_endpoint(daddr, 0);
 		if (info) {
@@ -1446,12 +1442,8 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 
 	bool same_subnet_id = false;
 
-	if (CONFIG(hybrid_routing_enabled)) {
-		__u32 src_subnet_id = lookup_ip4_subnet_id(ip4->saddr);
-		__u32 dst_subnet_id = lookup_ip4_subnet_id(ip4->daddr);
-
-		same_subnet_id = (src_subnet_id == dst_subnet_id) && (src_subnet_id != 0);
-	}
+	if (CONFIG(hybrid_routing_enabled))
+		same_subnet_id = is_subnet_same_id4(ip4->saddr, ip4->daddr);
 
 	/* Determine the destination category for policy fallback. */
 	info = lookup_ip4_remote_endpoint(ip4->daddr, cluster_id);

--- a/bpf/lib/subnet.h
+++ b/bpf/lib/subnet.h
@@ -100,3 +100,33 @@ subnet_lookup4(const void *map, __be32 addr)
 	subnet_lookup6(&cilium_subnet_map, addr)
 #define lookup_ip4_subnet_id(addr) \
 	subnet_lookup4(&cilium_subnet_map, addr)
+
+/* is_subnet_same_id4 returns true if both addresses have the same ID and it's
+ * different than zero.
+ */
+static __always_inline __maybe_unused bool
+is_subnet_same_id4(__be32 saddr, __be32 daddr)
+{
+	__u32 sid, did;
+
+	sid = lookup_ip4_subnet_id(saddr);
+	if (sid == 0)
+		return false;
+	did = lookup_ip4_subnet_id(daddr);
+	return sid == did;
+}
+
+/* is_subnet_same_id6 returns true if both addresses have the same ID and it's
+ * different than zero.
+ */
+static __always_inline __maybe_unused bool
+is_subnet_same_id6(const union v6addr *saddr, const union v6addr *daddr)
+{
+	__u32 sid, did;
+
+	sid = lookup_ip6_subnet_id(saddr);
+	if (sid == 0)
+		return false;
+	did = lookup_ip6_subnet_id(daddr);
+	return sid == did;
+}


### PR DESCRIPTION
Add is_subnet_same_id{4,6} helpers to reduce code duplication and also to skip an unneeded lookup if the first one already returns a zero id.