### PR TITLE
gateway-api: Add upgrade warnings and callouts for Gateway API v1.6

### DIFF
--- a/Documentation/network/servicemesh/gateway-api/installation.rst
+++ b/Documentation/network/servicemesh/gateway-api/installation.rst
@@ -30,6 +30,22 @@ Prerequisites
         $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.1/config/crd/standard/gateway.networking.k8s.io_backendtlspolicies.yaml
         $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.1/config/crd/standard/gateway.networking.k8s.io_tlsroutes.yaml
 
+
+    .. warning::
+
+      If you have used the ``TLSRoute`` resource in releases before Cilium v1.20, you should install the Experimental version of the TLSRoute resource instead.
+
+      If you install the Standard version, *all your TLSRoutes will not be readable*.
+
+      The Standard version of the ``TLSRoute`` resource in Gateway API v1.6 does *not* include the ``v1alpha2`` version that TLSRoute previously used, which
+      means that the apiserver cannot read the records in etcd.
+
+      Install the experimental version with:
+
+      .. code-block:: shell-session
+
+        $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.1/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+
   If you wish to use the ListenerSet, TCPRoute, or UDPRoute functionality, you
   also need to install the related CRDs. For each CRD that is not installed,
   Cilium will disable support for the feature.

--- a/Documentation/operations/upgrade-current.inc
+++ b/Documentation/operations/upgrade-current.inc
@@ -26,6 +26,21 @@ notes carefully below to understand what to do during upgrade.
 * Cilium updated to use CNI standard ``v1.0.0`` by default. If you use custom
   CNI configuration, consider updating the version requested in your CNI
   config to version ``1.0.0``.
+* Cilium's Gateway API support now requires Gateway API v1.6.1 at a minimum to work correctly.
+
+  This is because the ``TLSRoute`` resource has been upgraded from ``v1alpha2`` to ``v1``
+  support in Gateway API v1.6.1, and your cluster must support the ``v1`` version at all times.
+
+  As a result, if you were previously using ``TLSRoute``, you *must* install the Experimental
+  version of the ``TLSRoute`` resource from Gateway API v1.6.1, which still includes the ``v1alpha2``
+  version of the CRD.
+  
+  If you install the v1.6 Standard version of the ``TLSRoute`` resource,
+  any existing ``TLSRoute`` objects *will not be able to be read by the apiserver from etcd*,
+  and will effectively *disappear* from your cluster.
+  
+  Please backup your ``TLSRoute`` resources and ensure that Gateway API is upgraded to v1.6.1 before
+  upgrading Cilium to v1.20. See :ref:`gs_gateway_api` for installation instructions.
 
 Informational Notes
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This commit adds an upgrade warning and a install documentation callout for the process of upgrading to Gateway API v1.6, especially important for TLSRoute users.

AIL: 0
