### PR TITLE
bugtool: write empty archive entry when a file cannot be opened

### DIFF
--- a/bugtool/cmd/helper.go
+++ b/bugtool/cmd/helper.go
@@ -37,6 +37,38 @@ func newWalker(baseDir, dbgDir string, output tarWriter, logger io.Writer) *walk
 	}
 }
 
+func (w *walker) tarEntryName(path string) string {
+	if w.baseDir != "" {
+		return filepath.Join(w.baseDir, strings.TrimPrefix(path, w.dbgDir))
+	}
+	return path
+}
+
+// writeEmptyFile writes a zero-length regular-file archive entry so the dump
+// still shows that the path existed even though its contents could not be collected.
+// If the collection failed, the original error is recorded in PAX headers so the
+// placeholder entry can be distinguished from a genuinely empty file.
+func (w *walker) writeEmptyFile(path string, info os.FileInfo, openErr error) {
+	header, err := tar.FileInfoHeader(info, "")
+	if err != nil {
+		fmt.Fprintf(w.log, "Failed to prepare empty file header for %s: %s\n", path, err)
+		return
+	}
+	header.Name = w.tarEntryName(path)
+	header.Typeflag = tar.TypeReg
+	header.Linkname = ""
+	header.Size = 0
+	if openErr != nil {
+		header.Format = tar.FormatPAX
+		header.PAXRecords = map[string]string{
+			"CILIUM.collection_error": openErr.Error(),
+		}
+	}
+	if err := w.output.WriteHeader(header); err != nil {
+		fmt.Fprintf(w.log, "Failed to write empty file header for %s: %s\n", path, err)
+	}
+}
+
 func (w *walker) walkPath(path string, info os.FileInfo, err error) error {
 	if err != nil {
 		fmt.Fprintf(w.log, "Error while walking path %s: %s", path, err)
@@ -50,8 +82,9 @@ func (w *walker) walkPath(path string, info os.FileInfo, err error) error {
 	file, err := os.Open(path)
 	if err != nil {
 		fmt.Fprintf(w.log, "Failed to open %s: %s\n", path, err)
-		// TODO: Write an empty file here, just to hint that this file
-		// existed by there was some problem attempting to add it.
+		if !info.IsDir() {
+			w.writeEmptyFile(path, info, err)
+		}
 		return nil
 	}
 	defer file.Close()
@@ -78,9 +111,7 @@ func (w *walker) walkPath(path string, info os.FileInfo, err error) error {
 		return nil
 	}
 
-	if w.baseDir != "" {
-		header.Name = filepath.Join(w.baseDir, strings.TrimPrefix(path, w.dbgDir))
-	}
+	header.Name = w.tarEntryName(path)
 
 	if err := w.output.WriteHeader(header); err != nil {
 		fmt.Fprintf(w.log, "Failed to write header: %s\n", err)

--- a/bugtool/cmd/helper_test.go
+++ b/bugtool/cmd/helper_test.go
@@ -30,6 +30,22 @@ func (t *dummyTarWriter) WriteHeader(h *tar.Header) error {
 	return nil
 }
 
+type capturingTarWriter struct {
+	headers []*tar.Header
+	content []byte
+}
+
+func (t *capturingTarWriter) Write(p []byte) (n int, err error) {
+	t.content = append(t.content, p...)
+	return len(p), nil
+}
+
+func (t *capturingTarWriter) WriteHeader(h *tar.Header) error {
+	copied := *h
+	t.headers = append(t.headers, &copied)
+	return nil
+}
+
 type logWrapper struct {
 	logf func(format string, args ...any)
 }
@@ -69,6 +85,7 @@ func TestWalkPath(t *testing.T) {
 	// With real file
 	realFile, err := os.CreateTemp(baseDir, "test")
 	require.NoError(t, err)
+	require.NoError(t, realFile.Close())
 	info, err = os.Stat(realFile.Name())
 	require.NoError(t, err)
 	err = w.walkPath(realFile.Name(), info, nil)
@@ -90,6 +107,30 @@ func TestWalkPath(t *testing.T) {
 	require.NoError(t, err)
 	err = w.walkPath(nestedDir, info, nil)
 	require.NoError(t, err)
+}
+
+func TestWalkPathOpenFailureWritesEmptyFile(t *testing.T) {
+	baseDir, tmpDir := t.TempDir(), t.TempDir()
+
+	// Broken symlink: Lstat succeeds so the path appears in the walk, but Open fails.
+	brokenLink := filepath.Join(baseDir, "broken_link")
+	require.NoError(t, os.Symlink("doesnotexist", brokenLink))
+	info, err := os.Lstat(brokenLink)
+	require.NoError(t, err)
+
+	capture := &capturingTarWriter{}
+	w := newWalker(baseDir, tmpDir, capture, &logWrapper{t.Logf})
+	require.NoError(t, w.walkPath(brokenLink, info, nil))
+
+	require.Len(t, capture.headers, 1)
+	require.Equal(t, w.tarEntryName(brokenLink), capture.headers[0].Name)
+	require.Equal(t, byte(tar.TypeReg), capture.headers[0].Typeflag)
+	require.Empty(t, capture.headers[0].Linkname)
+	require.Equal(t, int64(0), capture.headers[0].Size)
+	require.Equal(t, tar.FormatPAX, capture.headers[0].Format)
+	require.Contains(t, capture.headers[0].PAXRecords, "CILIUM.collection_error")
+	require.NotEmpty(t, capture.headers[0].PAXRecords["CILIUM.collection_error"])
+	require.Empty(t, capture.content)
 }
 
 // TestHashEncryptionKeys tests proper hashing of keys. Lines in which `auth` or


### PR DESCRIPTION
- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
- [x] Thanks for contributing!

previously, when `cilium-bugtool` fails to open a file while walking the dump directory, it previously only logged the error and omitted the path from the archive. THIS made it harder to tell that the file existed but could not be collected.

now,
This change writes a zero-length regular-file entry for that path (including dangling symlinks that fail `Open`) so the archive will still records the path. Directories are unchanged and remain skipped.

#### Related earlier codes:
there was earlier this TODO: 
`// TODO: Write an empty file here, just to hint that this file
// existed by there was some problem attempting to add it.`
