### PR TITLE
.github: fix EKS native-routing CIDR lookup on pooled clusters

### DIFF
--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -499,9 +499,17 @@ jobs:
           # availability zone), to reflect the most common type of real deployments.
           NATIVE_CIDR=$(aws ec2 describe-subnets --region ${{ matrix.region }} \
             --filters Name=availability-zone,Values=${{ steps.vars.outputs.eks_zone_1 }} \
-                Name=tag:alpha.eksctl.io/cluster-name,Values=${{ steps.vars.outputs.cluster_name }} \
+                Name=tag:alpha.eksctl.io/cluster-name,Values=${{ steps.setup-cluster.outputs.cluster_name }} \
                 Name=map-public-ip-on-launch,Values=false \
             --query 'Subnets[*].CidrBlock' --output text)
+          # A pooled cluster is tagged with its real eksctl name, not the
+          # synthetic run name, so an empty result means the lookup missed and
+          # Cilium would silently fall back to the whole-VPC CIDR, disabling the
+          # masquerade this test relies on. Fail loudly instead.
+          if [ "$(echo "$NATIVE_CIDR" | wc -w)" -ne 1 ]; then
+            echo "::error::native routing CIDR lookup returned '$NATIVE_CIDR' (expected exactly one CIDR); masquerade would not engage"
+            exit 1
+          fi
           echo "ipv4_native_cidr=$NATIVE_CIDR" >> $GITHUB_OUTPUT
           echo "Native routing CIDR: $NATIVE_CIDR"
 


### PR DESCRIPTION
The egress-gateway-excluded-cidrs connectivity test asserts that traffic
matching an excluded CIDR reaches the external echo with the client node's
HostIP. That only holds when Cilium masquerades the pod's egress, and the EKS
workflow arranges that on purpose: the external echo runs on a node in a
second availability zone, and the "Determine the native routing CIDR" step
narrows ipv4NativeRoutingCIDR to the first zone's subnet so traffic to the
other zone falls outside the non-masquerade CIDR and is SNATed to HostIP.

The narrowing looked up the subnet by the alpha.eksctl.io/cluster-name tag
using the synthetic per-run name (steps.vars.outputs.cluster_name). On a
cluster taken from the pool the subnets are tagged with the real eksctl name
(steps.setup-cluster.outputs.cluster_name), so the filter matched nothing,
NATIVE_CIDR came back empty, and Cilium fell back to the whole VPC CIDR. With
the entire VPC excluded from masquerade, the in-VPC echo target is reached
with the raw pod IP and the test fails with a source IP that is neither
HostIP nor the egress gateway IP. This is a CI-config regression introduced
by #45246: the sibling nodegroup and external-target steps already use the
real cluster name, only this step was missed when the pool was introduced.

Use the real cluster name here too, and fail the step loudly if the lookup
does not return exactly one CIDR rather than silently disabling masquerade,
so a future mismatch surfaces as a red step instead of a connectivity flake.

The connectivity test itself is left untouched: once masquerade engages, the
existing clientIP == HostIP assertion is correct and still fails on a genuine
datapath regression (excluded traffic wrongly SNATed to the gateway IP, or
masquerade not happening at all).

This PR was prepared with AIL:3.
