### PR TITLE
docs: warn that Ingress TLS termination does not support ALPN for gRPC

### DIFF
--- a/Documentation/network/servicemesh/tls-termination.rst
+++ b/Documentation/network/servicemesh/tls-termination.rst
@@ -10,8 +10,15 @@
 Ingress Example with TLS Termination
 ************************************
 
-This example builds on the HTTP and gRPC ingress examples, adding TLS
-termination.
+This example builds on the HTTP ingress example, adding TLS termination.
+
+.. Note::
+
+    Ingress TLS termination does not support ALPN negotiation, so gRPC
+    clients that enforce ALPN (as required by the gRPC spec) will fail to
+    connect. If you need to terminate TLS for gRPC traffic, use the
+    :ref:`gs_gateway_grpc` instead, which supports ALPN via the
+    ``gatewayAPI.enableAlpn`` Helm flag.
 
 .. literalinclude:: ../../../examples/kubernetes/servicemesh/tls-ingress.yaml
      :language: yaml
@@ -100,29 +107,11 @@ Make HTTPS Requests
         Specifying -v on the curl request, you can see that the TLS handshake took
         place successfully.
 
-        Similarly you can specify the CA on a gRPC request like this:
-
-        .. code-block:: shell-session
-
-            # Download demo.proto file if you have not done before
-            $ curl -o demo.proto https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/main/protos/demo.proto
-            $ grpcurl -proto ./demo.proto -cacert minica.pem hipstershop.cilium.rocks:443 hipstershop.ProductCatalogService/ListProducts
-
     .. group-tab:: cert-manager
 
         .. code-block:: shell-session
 
             $ curl https://bookinfo.cilium.rocks/details/1
-
-        Similarly you can specify the CA on a gRPC request like this:
-
-        .. code-block:: shell-session
-
-            grpcurl -proto ./demo.proto -cacert minica.pem hipstershop.cilium.rocks:443 hipstershop.ProductCatalogService/ListProducts
-
-.. Note::
-
-    See the gRPC Ingress example if you don't already have the ``demo.proto`` file downloaded.
 
 You can also visit https://bookinfo.cilium.rocks in your browser. The browser
 might warn you that the certificate authority is unknown but if you proceed past

--- a/Documentation/network/servicemesh/tls-termination.rst
+++ b/Documentation/network/servicemesh/tls-termination.rst
@@ -10,7 +10,8 @@
 Ingress Example with TLS Termination
 ************************************
 
-This example builds on the HTTP ingress example, adding TLS termination.
+This example builds on the HTTP and gRPC ingress examples, adding TLS
+termination.
 
 .. Note::
 


### PR DESCRIPTION
Motivation:

The Ingress TLS termination example does not configure ALPN protocol
negotiation in the generated Envoy CiliumEnvoyConfig. gRPC requires
ALPN to select the h2 protocol during the TLS handshake, so gRPC
clients that correctly enforce ALPN (per the gRPC spec) fail to
connect through a TLS-terminating Ingress with errors such as
"missing selected ALPN property". The example previously worked only
with `grpcurl`, which happened to mask the problem due to a
grpc-go/grpc-core regression that has since been fixed upstream.

A maintainer confirmed on the issue that Ingress support is being
kept mostly as-is and that gRPC-over-TLS-termination should instead
be documented as a Gateway API use case, since Cilium's Gateway API
implementation already supports ALPN via `gatewayAPI.enableAlpn`
(added in #32486). Adding equivalent ALPN support to the Ingress
controller was explicitly declined for this issue.

Approach:

Update the Ingress TLS termination doc page to:
- Note that ALPN negotiation is not supported for Ingress TLS
  termination, and link to the Gateway API gRPC example instead.
- Remove the `grpcurl` gRPC-over-TLS-termination example snippets,
  since they only appeared to work due to the now-fixed grpc client
  bug and no longer represent a supported pattern.

This is a documentation-only change; no user-visible runtime
behavior changes, since Ingress TLS termination never negotiated
ALPN in the first place. The change only prevents users from being
misled by an example that appeared to work by accident.

Validation:

Manually reviewed the rendered RST for syntax consistency with other
`.. Note::` blocks in Documentation/network/servicemesh/*.rst, and
confirmed the `:ref:`gs_gateway_grpc`` target resolves to the label
in Documentation/network/servicemesh/gateway-api/grpc.rst. Sphinx
tooling (rstcheck/sphinx-build) was not available in this
environment to run Documentation/check-build.sh directly.

Fixes: #47206

```release-note
docs: Clarify that Ingress TLS termination does not support ALPN
negotiation for gRPC, and point users to the Gateway API gRPC
example instead.
```

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

This PR was prepared with AIL:4 (AI-assisted drafting; human-directed and human-reviewed). I personally read the full rendered diff, verified the ALPN limitation described here matches the maintainer guidance in #47206 (keep Ingress as-is; point gRPC TLS-termination use cases at Gateway API), and confirmed the gs_gateway_grpc cross-reference target exists.