### PR TITLE
operator: Replace `reflect.DeepEqual` with `assert.Equal` in tests

### DIFF
--- a/operator/api/metrics_test.go
+++ b/operator/api/metrics_test.go
@@ -11,11 +11,11 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"maps"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"reflect"
 	"testing"
 	"time"
 
@@ -293,7 +293,7 @@ func testMetric(metrics []models.Metric, name string, value float64, labels map[
 			if metric.Value != value {
 				return fmt.Errorf("expected value %f for %q, got %f", value, name, metric.Value)
 			}
-			if !reflect.DeepEqual(metric.Labels, labels) {
+			if !maps.Equal(metric.Labels, labels) {
 				return fmt.Errorf("expected labels map %v for %q, got %v", labels, name, metric.Labels)
 			}
 			return nil

--- a/operator/auth/spire/client_test.go
+++ b/operator/auth/spire/client_test.go
@@ -6,12 +6,12 @@ package spire
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
 	entryv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/server/entry/v1"
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -522,13 +522,11 @@ func Test_resolvedK8sService(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := resolvedK8sService(t.Context(), tt.args.client, tt.args.address)
-			if tt.wantedErr != nil && (err == nil || !reflect.DeepEqual(err.Error(), tt.wantedErr.Error())) {
+			if tt.wantedErr != nil && (err == nil || err.Error() != tt.wantedErr.Error()) {
 				t.Errorf("resolvedK8sService() error = %v, wantErr %v", err, tt.wantedErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("resolvedK8sService() got = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/operator/pkg/ciliumidentity/cache_test.go
+++ b/operator/pkg/ciliumidentity/cache_test.go
@@ -4,10 +4,8 @@
 package ciliumidentity
 
 import (
-	"fmt"
 	"log/slog"
 	"os"
-	"reflect"
 	"sync"
 	"testing"
 
@@ -55,7 +53,7 @@ func TestCIDState(t *testing.T) {
 			},
 		}
 
-		assert.NoError(t, validateCIDState(state, expectedState), "cid 1 added")
+		validateCIDState(t, state, expectedState, "cid 1 added")
 
 		state.Upsert("2", k2)
 		expectedState = &CIDState{
@@ -72,7 +70,7 @@ func TestCIDState(t *testing.T) {
 			},
 		}
 
-		assert.NoError(t, validateCIDState(state, expectedState), "cid 2 added")
+		validateCIDState(t, state, expectedState, "cid 2 added")
 
 		state.Upsert("3", k3)
 		expectedState = &CIDState{
@@ -89,7 +87,7 @@ func TestCIDState(t *testing.T) {
 			},
 		}
 
-		assert.NoError(t, validateCIDState(state, expectedState), "cid 3 added - duplicate")
+		validateCIDState(t, state, expectedState, "cid 3 added - duplicate")
 	})
 
 	t.Run("Lookup CID state", func(t *testing.T) {
@@ -124,7 +122,7 @@ func TestCIDState(t *testing.T) {
 			},
 		}
 
-		assert.NoError(t, validateCIDState(state, expectedState), "cid 2 removed")
+		validateCIDState(t, state, expectedState, "cid 2 removed")
 
 		_, exists := state.LookupByID("2")
 		assert.False(t, exists, "cid 2 LookupByID - not found")
@@ -139,7 +137,7 @@ func TestCIDState(t *testing.T) {
 				},
 			},
 		}
-		assert.NoError(t, validateCIDState(state, expectedState), "cid 3 removed")
+		validateCIDState(t, state, expectedState, "cid 3 removed")
 	})
 }
 
@@ -175,16 +173,10 @@ func TestCIDStateThreadSafety(t *testing.T) {
 	wg.Wait()
 }
 
-func validateCIDState(state, expectedState *CIDState) error {
-	if !reflect.DeepEqual(state.idToLabels, expectedState.idToLabels) {
-		return fmt.Errorf("failed to validate the state, expected idToLabels %v, got %v", expectedState.idToLabels, state.idToLabels)
-	}
-
-	if !reflect.DeepEqual(state.labelsToID, expectedState.labelsToID) {
-		return fmt.Errorf("failed to validate the state, expected labelsToID %v, got %v", expectedState.labelsToID, state.labelsToID)
-	}
-
-	return nil
+func validateCIDState(t *testing.T, state, expectedState *CIDState, msg string) {
+	t.Helper()
+	assert.Equal(t, expectedState.idToLabels, state.idToLabels, msg)
+	assert.Equal(t, expectedState.labelsToID, state.labelsToID, msg)
 }
 
 func TestCIDUsageInPods(t *testing.T) {

--- a/operator/pkg/ciliumidentity/namespace_test.go
+++ b/operator/pkg/ciliumidentity/namespace_test.go
@@ -4,8 +4,9 @@
 package ciliumidentity
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	ciliumio "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	slimcorev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -64,9 +65,7 @@ func TestGetNamespaceLabels(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			result := getNamespaceLabels(tc.namespace)
 
-			if !reflect.DeepEqual(result, tc.expected) {
-				t.Errorf("Expected %v, but got %v", tc.expected, result)
-			}
+			assert.Equal(t, tc.expected, result)
 		})
 	}
 }

--- a/operator/pkg/ciliumidentity/reconciler_test.go
+++ b/operator/pkg/ciliumidentity/reconciler_test.go
@@ -6,13 +6,13 @@ package ciliumidentity
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -232,12 +232,8 @@ func TestReconcileCID(t *testing.T) {
 				t.Errorf("Unexpected error during reconciliation: %v", err)
 			}
 
-			if !reflect.DeepEqual(createCID, tc.expectedCreate) {
-				t.Errorf("Unexpected createCID result: got %v, want %v", createCID, tc.expectedCreate)
-			}
-			if !reflect.DeepEqual(updateCID, tc.expectedUpdate) {
-				t.Errorf("Unexpected updateCID result: got %v, want %v", updateCID, tc.expectedUpdate)
-			}
+			assert.Equal(t, tc.expectedCreate, createCID)
+			assert.Equal(t, tc.expectedUpdate, updateCID)
 			if deleteCIDName != tc.expectedDelete {
 				t.Errorf("Unexpected deleteCIDName result: got %v, want %v", deleteCIDName, tc.expectedDelete)
 			}

--- a/operator/pkg/gateway-api/indexers/grpcroute_test.go
+++ b/operator/pkg/gateway-api/indexers/grpcroute_test.go
@@ -5,10 +5,10 @@ package indexers
 
 import (
 	"log/slog"
-	"reflect"
 	"slices"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -355,9 +355,8 @@ func Test_IndexGRPCRouteByGammaService(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			parentIndexFunc := IndexGRPCRouteByGammaService
 
-			if got := parentIndexFunc(tt.args.obj); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("IndexGRPCRouteByGammaService() = %#v, want %#v", got, tt.want)
-			}
+			got := parentIndexFunc(tt.args.obj)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/operator/pkg/gateway-api/indexers/httproute_test.go
+++ b/operator/pkg/gateway-api/indexers/httproute_test.go
@@ -5,10 +5,10 @@ package indexers
 
 import (
 	"log/slog"
-	"reflect"
 	"slices"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -475,9 +475,8 @@ func Test_IndexHTTPRouteByGammaService(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			parentIndexFunc := IndexHTTPRouteByGammaService
 
-			if got := parentIndexFunc(tt.args.obj); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getGammaHTTPRouteParentIndexFunc() = %#v, want %#v", got, tt.want)
-			}
+			got := parentIndexFunc(tt.args.obj)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/operator/pkg/gateway-api/indexers/listenerset_test.go
+++ b/operator/pkg/gateway-api/indexers/listenerset_test.go
@@ -4,9 +4,9 @@
 package indexers
 
 import (
-	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -55,9 +55,7 @@ func TestIndexListenerSetByGateway(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := IndexListenerSetByGateway(tt.obj)
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("IndexListenerSetByGateway() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/operator/pkg/ingress/annotations/annotations_test.go
+++ b/operator/pkg/ingress/annotations/annotations_test.go
@@ -4,10 +4,10 @@
 package annotations
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -130,9 +130,7 @@ func TestGetAnnotationServiceExternalTrafficPolicy(t *testing.T) {
 				t.Errorf("GetAnnotationServiceExternalTrafficPolicy() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetAnnotationServiceExternalTrafficPolicy() got = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -192,9 +190,7 @@ func TestGetAnnotationRequestTimeout(t *testing.T) {
 				return
 			}
 
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetAnnotationRequestTimeout() got = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -252,9 +248,7 @@ func TestGetAnnotationSecureNodePort(t *testing.T) {
 				t.Errorf("GetAnnotationSecureNodePort() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetAnnotationSecureNodePort() got = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -311,9 +305,7 @@ func TestGetAnnotationInsecureNodePort(t *testing.T) {
 				t.Errorf("GetAnnotationSecureNodePort() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetAnnotationSecureNodePort() got = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -371,9 +363,7 @@ func TestGetAnnotationHostListenerPort(t *testing.T) {
 				t.Errorf("GetAnnotationHostListenerPort() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetAnnotationHostListenerPort() got = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -464,9 +454,7 @@ func TestGetAnnotationSSLPassthrough(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := GetAnnotationTLSPassthroughEnabled(tt.args.ingress)
 
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetAnnotationSecureNodePort() got = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -557,9 +545,7 @@ func TestGetAnnotationEnforceHTTPSEnabled(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := GetAnnotationForceHTTPSEnabled(tt.args.ingress)
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetAnnotationForceHTTPSEnabled() got = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/operator/pkg/kvstore/locksweeper/locksweeper_test.go
+++ b/operator/pkg/kvstore/locksweeper/locksweeper_test.go
@@ -4,8 +4,9 @@
 package locksweeper
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/cilium/cilium/pkg/kvstore"
 )
@@ -88,9 +89,8 @@ func Test_getOldestLeases(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getOldestLeases(tt.args.m); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getOldestLeases() = %v, want %v", got, tt.want)
-			}
+			got := getOldestLeases(tt.args.m)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/operator/pkg/model/model_test.go
+++ b/operator/pkg/model/model_test.go
@@ -4,7 +4,6 @@
 package model
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -96,9 +95,8 @@ func TestModel_GetListeners(t *testing.T) {
 				TLSPassthrough: tt.fields.TLS,
 				L4:             tt.fields.L4,
 			}
-			if got := m.GetListeners(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Model.GetListeners() = %v, want %v", got, tt.want)
-			}
+			got := m.GetListeners()
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
`reflect.DeepEqual` produces unhelpful output on failure: it reports only that two values differ, not which fields. This PR replaces it with testify's `assert.Equal` in operator test code, which prints a field-level diff.

Two cases that didn't map to `assert.Equal`:
* `operator/api/metrics_test.go`: `testMetric` is an error-returning helper comparing `map[string]string`, so I used the reflect-free `maps.Equal`.
* `operator/auth/spire/client_test.go`: one call compared error strings, so a plain != was enough.

Part of #40562