### PR TITLE
test(bpf): parallelize eBPF test execution

### DIFF
--- a/bpf/tests/bpftest/bpf_test.go
+++ b/bpf/tests/bpftest/bpf_test.go
@@ -22,6 +22,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -55,6 +56,17 @@ var (
 	dumpCtx = flag.Bool("dump-ctx", false, "If set, the program context will be dumped after a CHECK and SETUP run.")
 )
 
+type syncWriter struct {
+	mu *sync.Mutex
+	w  io.Writer
+}
+
+func (s *syncWriter) Write(p []byte) (n int, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.w.Write(p)
+}
+
 type testLogWriter struct {
 	t *testing.T
 }
@@ -81,17 +93,21 @@ func TestBPF(t *testing.T) {
 		t.Fatal("os readdir: ", err)
 	}
 
-	var instrLog io.Writer
+	var (
+		instrLogMu sync.Mutex
+		instrLog   io.Writer
+		profileMu  sync.Mutex
+	)
 	if *testInstrumentationLog != "" {
 		instrLogFile, err := os.Create(*testInstrumentationLog)
 		if err != nil {
 			t.Fatal("os create instrumentation log: ", err)
 		}
-		defer instrLogFile.Close()
+		t.Cleanup(func() { instrLogFile.Close() })
 
 		buf := bufio.NewWriter(instrLogFile)
-		instrLog = buf
-		defer buf.Flush()
+		instrLog = &syncWriter{w: buf, mu: &instrLogMu}
+		t.Cleanup(func() { buf.Flush() })
 	}
 
 	mergedProfiles := make([]*cover.Profile, 0)
@@ -110,12 +126,17 @@ func TestBPF(t *testing.T) {
 		}
 
 		t.Run(entry.Name(), func(t *testing.T) {
+			t.Parallel()
 			testNetNS := netns.NewNetNS(t)
 			profiles := loadAndRunSpec(t, entry, instrLog, testNetNS)
-			for _, profile := range profiles {
-				if len(profile.Blocks) > 0 {
-					mergedProfiles = addProfile(mergedProfiles, profile)
+			if len(profiles) > 0 {
+				profileMu.Lock()
+				for _, profile := range profiles {
+					if len(profile.Blocks) > 0 {
+						mergedProfiles = addProfile(mergedProfiles, profile)
+					}
 				}
+				profileMu.Unlock()
 			}
 			if err := testNetNS.Close(); err != nil {
 				t.Fatal("netns close: ", err)
@@ -130,22 +151,24 @@ func TestBPF(t *testing.T) {
 	}
 
 	if *testCoverageReport != "" {
-		coverReport, err := os.Create(*testCoverageReport)
-		if err != nil {
-			t.Fatalf("create coverage report: %s", err.Error())
-		}
-		defer coverReport.Close()
-
-		switch *testCoverageFormat {
-		case "html":
-			if err = coverbee.HTMLOutput(mergedProfiles, coverReport); err != nil {
-				t.Fatalf("create HTML coverage report: %s", err.Error())
+		t.Cleanup(func() {
+			coverReport, err := os.Create(*testCoverageReport)
+			if err != nil {
+				t.Fatalf("create coverage report: %s", err.Error())
 			}
-		case "go-cover", "cover":
-			coverbee.ProfilesToGoCover(mergedProfiles, coverReport, "count")
-		default:
-			t.Fatal("unknown output format")
-		}
+			defer coverReport.Close()
+
+			switch *testCoverageFormat {
+			case "html":
+				if err = coverbee.HTMLOutput(mergedProfiles, coverReport); err != nil {
+					t.Fatalf("create HTML coverage report: %s", err.Error())
+				}
+			case "go-cover", "cover":
+				coverbee.ProfilesToGoCover(mergedProfiles, coverReport, "count")
+			default:
+				t.Fatal("unknown output format")
+			}
+		})
 	}
 }
 
@@ -153,8 +176,10 @@ func loadAndRunSpec(t *testing.T, entry fs.DirEntry, instrLog io.Writer, testNet
 	logger := hivetest.Logger(t)
 	elfPath := path.Join(*testPath, entry.Name())
 
+	// Buffer instrumentation logs per subtest to prevent interleaved output when running tests in parallel.
+	localBuf := new(bytes.Buffer)
 	if instrLog != nil {
-		fmt.Fprintln(instrLog, "===", elfPath, "===")
+		fmt.Fprintln(localBuf, "===", elfPath, "===")
 	}
 
 	spec := loadAndPrepSpec(t, elfPath)
@@ -186,7 +211,11 @@ func loadAndRunSpec(t *testing.T, entry fs.DirEntry, instrLog io.Writer, testNet
 	if !collectCoverage {
 		coll, _, err = bpf.LoadCollection(logger, spec, nil)
 	} else {
-		coll, cfg, err = coverbee.InstrumentAndLoadCollection(spec, ebpf.CollectionOptions{}, instrLog)
+		coll, cfg, err = coverbee.InstrumentAndLoadCollection(spec, ebpf.CollectionOptions{}, localBuf)
+	}
+
+	if instrLog != nil && localBuf.Len() > 0 {
+		instrLog.Write(localBuf.Bytes())
 	}
 
 	var ve *ebpf.VerifierError

--- a/bpf/tests/bpftest/bpf_test.go
+++ b/bpf/tests/bpftest/bpf_test.go
@@ -22,6 +22,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -37,6 +38,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath/link"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/maps/eventsmap"
 	"github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/monitor/format"
@@ -54,6 +56,17 @@ var (
 
 	dumpCtx = flag.Bool("dump-ctx", false, "If set, the program context will be dumped after a CHECK and SETUP run.")
 )
+
+type syncWriter struct {
+	mu *lock.Mutex
+	w  io.Writer
+}
+
+func (s *syncWriter) Write(p []byte) (n int, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.w.Write(p)
+}
 
 type testLogWriter struct {
 	t *testing.T
@@ -81,17 +94,21 @@ func TestBPF(t *testing.T) {
 		t.Fatal("os readdir: ", err)
 	}
 
-	var instrLog io.Writer
+	var (
+		instrLogMu lock.Mutex
+		instrLog   io.Writer
+		profileMu  lock.Mutex
+	)
 	if *testInstrumentationLog != "" {
 		instrLogFile, err := os.Create(*testInstrumentationLog)
 		if err != nil {
 			t.Fatal("os create instrumentation log: ", err)
 		}
-		defer instrLogFile.Close()
+		t.Cleanup(func() { instrLogFile.Close() })
 
 		buf := bufio.NewWriter(instrLogFile)
-		instrLog = buf
-		defer buf.Flush()
+		instrLog = &syncWriter{w: buf, mu: &instrLogMu}
+		t.Cleanup(func() { buf.Flush() })
 	}
 
 	mergedProfiles := make([]*cover.Profile, 0)
@@ -110,12 +127,17 @@ func TestBPF(t *testing.T) {
 		}
 
 		t.Run(entry.Name(), func(t *testing.T) {
+			t.Parallel()
 			testNetNS := netns.NewNetNS(t)
 			profiles := loadAndRunSpec(t, entry, instrLog, testNetNS)
-			for _, profile := range profiles {
-				if len(profile.Blocks) > 0 {
-					mergedProfiles = addProfile(mergedProfiles, profile)
+			if len(profiles) > 0 {
+				profileMu.Lock()
+				for _, profile := range profiles {
+					if len(profile.Blocks) > 0 {
+						mergedProfiles = addProfile(mergedProfiles, profile)
+					}
 				}
+				profileMu.Unlock()
 			}
 			if err := testNetNS.Close(); err != nil {
 				t.Fatal("netns close: ", err)
@@ -130,22 +152,24 @@ func TestBPF(t *testing.T) {
 	}
 
 	if *testCoverageReport != "" {
-		coverReport, err := os.Create(*testCoverageReport)
-		if err != nil {
-			t.Fatalf("create coverage report: %s", err.Error())
-		}
-		defer coverReport.Close()
-
-		switch *testCoverageFormat {
-		case "html":
-			if err = coverbee.HTMLOutput(mergedProfiles, coverReport); err != nil {
-				t.Fatalf("create HTML coverage report: %s", err.Error())
+		t.Cleanup(func() {
+			coverReport, err := os.Create(*testCoverageReport)
+			if err != nil {
+				t.Fatalf("create coverage report: %s", err.Error())
 			}
-		case "go-cover", "cover":
-			coverbee.ProfilesToGoCover(mergedProfiles, coverReport, "count")
-		default:
-			t.Fatal("unknown output format")
-		}
+			defer coverReport.Close()
+
+			switch *testCoverageFormat {
+			case "html":
+				if err = coverbee.HTMLOutput(mergedProfiles, coverReport); err != nil {
+					t.Fatalf("create HTML coverage report: %s", err.Error())
+				}
+			case "go-cover", "cover":
+				coverbee.ProfilesToGoCover(mergedProfiles, coverReport, "count")
+			default:
+				t.Fatal("unknown output format")
+			}
+		})
 	}
 }
 
@@ -153,8 +177,10 @@ func loadAndRunSpec(t *testing.T, entry fs.DirEntry, instrLog io.Writer, testNet
 	logger := hivetest.Logger(t)
 	elfPath := path.Join(*testPath, entry.Name())
 
+	// Buffer instrumentation logs per subtest to prevent interleaved output when running tests in parallel.
+	localBuf := new(bytes.Buffer)
 	if instrLog != nil {
-		fmt.Fprintln(instrLog, "===", elfPath, "===")
+		fmt.Fprintln(localBuf, "===", elfPath, "===")
 	}
 
 	spec := loadAndPrepSpec(t, elfPath)
@@ -186,7 +212,11 @@ func loadAndRunSpec(t *testing.T, entry fs.DirEntry, instrLog io.Writer, testNet
 	if !collectCoverage {
 		coll, _, err = bpf.LoadCollection(logger, spec, nil)
 	} else {
-		coll, cfg, err = coverbee.InstrumentAndLoadCollection(spec, ebpf.CollectionOptions{}, instrLog)
+		coll, cfg, err = coverbee.InstrumentAndLoadCollection(spec, ebpf.CollectionOptions{}, localBuf)
+	}
+
+	if instrLog != nil && localBuf.Len() > 0 {
+		instrLog.Write(localBuf.Bytes())
 	}
 
 	var ve *ebpf.VerifierError
@@ -244,16 +274,22 @@ func loadAndRunSpec(t *testing.T, entry fs.DirEntry, instrLog io.Writer, testNet
 	}
 
 	// Collect debug events and add them as logs of the main test
-	var globalLogReader *perf.Reader
+	var (
+		globalLogReader *perf.Reader
+		readerWg        sync.WaitGroup
+	)
 	if m := coll.Maps[eventsmap.MapName]; m != nil {
 		globalLogReader, err = perf.NewReader(m, os.Getpagesize()*16)
 		if err != nil {
 			t.Fatalf("new global log reader: %s", err.Error())
 		}
-		defer globalLogReader.Close()
+		defer func() {
+			globalLogReader.Close()
+			readerWg.Wait()
+		}()
 
 		formatter := format.NewMonitorFormatter(api.DEBUG, link.NewLinkCache(), &testLogWriter{t: t})
-		go func() {
+		readerWg.Go(func() {
 			for {
 				rec, err := globalLogReader.Read()
 				if err != nil {
@@ -261,7 +297,7 @@ func loadAndRunSpec(t *testing.T, entry fs.DirEntry, instrLog io.Writer, testNet
 				}
 				formatter.FormatSample(rec.RawSample, rec.CPU)
 			}
-		}()
+		})
 	}
 
 	// Make sure sub-tests are executed in alphabetic order, to make test results repeatable if programs rely on


### PR DESCRIPTION
This PR contains some enhancements to the eBPF execution step to help improve the eBPF test suite speed discussed in #45133.

Currently the eBPF tests are executed serially when running `make run_bpf_tests`. Each eBPF test file (.o) is loaded independently and does not share any state across the file boundary. So the test runner can be updated to load/execute these test targets in parallel to speed up the overall eBPF test suite runtime.

These changes allow the tests to safely run in parallel, ensuring the test output and coverbee output do not get mixed up across goroutines.

There was around an **11x improvement** in just the `go test` execution time (75 seconds vs 6 seconds).

Here are some small numbers from my larger workstation (128 cpus).

Commands Run:
```
# test targets were not re-built

time make run_bpf_tests 
```

| Strategy | Tests Execution Time (no compile) |
| :--- | :--- |
| Original | 1m25.520s |
| Parallel Execution | 0m16.374s |


The larger workstation that I am using makes these numbers look good but most workstations would see some speed up in execution time.

Here is an example I created locally to show that the test debug output is not interleaved due to tests running in parallel.

```
--- FAIL: TestBPF (0.00s)
    --- FAIL: TestBPF/skip_lb_xlate_socket_lb.o (0.42s)
        bpf_test.go:354: Skipping program 'cil_sock6_sendmsg' of type 'CGroupSockAddr': BPF_PROG_RUN not supported on program type
        bpf_test.go:354: Skipping program 'cil_sock6_connect' of type 'CGroupSockAddr': BPF_PROG_RUN not supported on program type
        bpf_test.go:354: Skipping program 'cil_sock_release' of type 'CGroupSock': BPF_PROG_RUN not supported on program type
        bpf_test.go:354: Skipping program 'cil_sock4_recvmsg' of type 'CGroupSockAddr': BPF_PROG_RUN not supported on program type
        bpf_test.go:354: Skipping program 'cil_sock4_sendmsg' of type 'CGroupSockAddr': BPF_PROG_RUN not supported on program type
        bpf_test.go:354: Skipping program 'cil_sock6_recvmsg' of type 'CGroupSockAddr': BPF_PROG_RUN not supported on program type
        bpf_test.go:354: Skipping program 'cil_sock4_connect' of type 'CGroupSockAddr': BPF_PROG_RUN not supported on program type
        --- FAIL: TestBPF/skip_lb_xlate_socket_lb.o/sock4_xlate_fwd (0.01s)
            bpf_test.go:605: skip_lb_xlate_socket_lb.c:92: ret: -6
            bpf_test.go:605: skip_lb_xlate_socket_lb.c:93: pod_one [0100a8c0] -> svc_one [010a10ac]
            bpf_test.go:605: skip_lb_xlate_socket_lb.c:96: assert failed at skip_lb_xlate_socket_lb.c:96
    --- FAIL: TestBPF/host_only_socket_lb_test.o (0.22s)
        bpf_test.go:354: Skipping program 'cil_sock4_recvmsg' of type 'CGroupSockAddr': BPF_PROG_RUN not supported on program type
        bpf_test.go:354: Skipping program 'cil_sock4_sendmsg' of type 'CGroupSockAddr': BPF_PROG_RUN not supported on program type
        bpf_test.go:354: Skipping program 'cil_sock6_connect' of type 'CGroupSockAddr': BPF_PROG_RUN not supported on program type
        bpf_test.go:354: Skipping program 'cil_sock6_sendmsg' of type 'CGroupSockAddr': BPF_PROG_RUN not supported on program type
        bpf_test.go:354: Skipping program 'cil_sock4_connect' of type 'CGroupSockAddr': BPF_PROG_RUN not supported on program type
        bpf_test.go:354: Skipping program 'cil_sock6_recvmsg' of type 'CGroupSockAddr': BPF_PROG_RUN not supported on program type
        bpf_test.go:354: Skipping program 'cil_sock_release' of type 'CGroupSock': BPF_PROG_RUN not supported on program type
        --- FAIL: TestBPF/host_only_socket_lb_test.o/sock4_xlate_fwd_test (0.01s)
            bpf_test.go:605: host_only_socket_lb_test.c:102: xlate_fwd: 0
            bpf_test.go:605: host_only_socket_lb_test.c:103: ip 0100a8c0
            bpf_test.go:605: host_only_socket_lb_test.c:104: port 7000
            bpf_test.go:605: host_only_socket_lb_test.c:105: ret: 0
            bpf_test.go:605: host_only_socket_lb_test.c:106: assert failed at host_only_socket_lb_test.c:106
FAIL
FAIL    github.com/cilium/cilium/bpf/tests/bpftest      6.062s
FAIL
```

AI Level: 1
Fixes: nobug