### PR TITLE
kvstore/debug: convert etcd debug dialer to netip.Addr

### DIFF
--- a/cilium-dbg/cmd/troubleshoot/troubleshoot.go
+++ b/cilium-dbg/cmd/troubleshoot/troubleshoot.go
@@ -77,21 +77,21 @@ func (td *troubleshootDialer) DialContext(ctx context.Context, addr string) (con
 	return td.dial(ctx, addr)
 }
 
-func (td *troubleshootDialer) LookupIP(ctx context.Context, hostname string) ([]net.IP, error) {
+func (td *troubleshootDialer) LookupIP(ctx context.Context, hostname string) ([]netip.Addr, error) {
 	// Let's mimic the same behavior of the dialer returned by k8s.CreateCustomDialer,
 	// that is try to first resolve the hostname as a service, and then fallback to
 	// the system resolver.
 	addr := td.resolve(ctx, hostname)
 	if addr == hostname {
-		return net.DefaultResolver.LookupIP(ctx, "ip", hostname)
+		return net.DefaultResolver.LookupNetIP(ctx, "ip", hostname)
 	}
 
-	parsed := net.ParseIP(addr)
-	if parsed == nil {
-		return net.DefaultResolver.LookupIP(ctx, "ip", hostname)
+	parsed, err := netip.ParseAddr(addr)
+	if err != nil {
+		return net.DefaultResolver.LookupNetIP(ctx, "ip", hostname)
 	}
 
-	return []net.IP{parsed}, nil
+	return []netip.Addr{parsed}, nil
 }
 
 func (td *troubleshootDialer) Resolve(ctx context.Context, host, port string) (string, string) {

--- a/cilium-dbg/cmd/troubleshoot/troubleshoot_clustermesh.go
+++ b/cilium-dbg/cmd/troubleshoot/troubleshoot_clustermesh.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/dial"
 	"github.com/cilium/cilium/pkg/kvstore"
-	cslices "github.com/cilium/cilium/pkg/slices"
 )
 
 // DisableLocalNameLookup allows to disable the lookup of the local cluster
@@ -162,15 +161,15 @@ var _ kvstore.EtcdDbgDialer = (*staticEtcdDbgDialerWithFallback)(nil)
 // but with a kvstore.EtcdDbgDialer interface. It also wraps an existing
 // kvstore.EtcdDbgDialer as fallback if the specified hostname does not match.
 type staticEtcdDbgDialerWithFallback struct {
-	hostAliases           map[string][]net.IP
+	hostAliases           map[string][]netip.Addr
 	fallbackEtcdDbgDialer kvstore.EtcdDbgDialer
 	dialer                func(ctx context.Context, addr string) (net.Conn, error)
 }
 
 func newStaticEtcdDbgDialerWithFallback(configHostAliases []common.HostAlias, dialer kvstore.EtcdDbgDialer) *staticEtcdDbgDialerWithFallback {
-	hostAliases := make(map[string][]net.IP, len(configHostAliases))
+	hostAliases := make(map[string][]netip.Addr, len(configHostAliases))
 	for _, hostAlias := range configHostAliases {
-		hostAliases[hostAlias.Hostname] = cslices.Map(hostAlias.IPs, func(in netip.Addr) net.IP { return in.AsSlice() })
+		hostAliases[hostAlias.Hostname] = hostAlias.IPs
 	}
 	return &staticEtcdDbgDialerWithFallback{
 		hostAliases:           hostAliases,
@@ -181,7 +180,7 @@ func newStaticEtcdDbgDialerWithFallback(configHostAliases []common.HostAlias, di
 	}
 }
 
-func (sd *staticEtcdDbgDialerWithFallback) LookupIP(ctx context.Context, hostname string) ([]net.IP, error) {
+func (sd *staticEtcdDbgDialerWithFallback) LookupIP(ctx context.Context, hostname string) ([]netip.Addr, error) {
 	if ips, ok := sd.hostAliases[hostname]; ok {
 		return ips, nil
 	}

--- a/pkg/kvstore/etcd_debug.go
+++ b/pkg/kvstore/etcd_debug.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/netip"
 	"net/url"
 	"os"
 	"regexp"
@@ -37,15 +38,15 @@ var etcdVersionRegexp = regexp.MustCompile(`"etcdserver":"(?P<version>.*?)"`)
 // e.g., to support service name to IP address resolution when CoreDNS is not
 // the configured DNS server --- for pods running in the host network namespace.
 type EtcdDbgDialer interface {
-	LookupIP(ctx context.Context, hostname string) ([]net.IP, error)
+	LookupIP(ctx context.Context, hostname string) ([]netip.Addr, error)
 	DialContext(ctx context.Context, addr string) (net.Conn, error)
 }
 
 // DefaultEtcdDbgDialer provides a default implementation of the EtcdDbgDialer interface.
 type DefaultEtcdDbgDialer struct{}
 
-func (DefaultEtcdDbgDialer) LookupIP(ctx context.Context, hostname string) ([]net.IP, error) {
-	return net.DefaultResolver.LookupIP(ctx, "ip", hostname)
+func (DefaultEtcdDbgDialer) LookupIP(ctx context.Context, hostname string) ([]netip.Addr, error) {
+	return net.DefaultResolver.LookupNetIP(ctx, "ip", hostname)
 }
 
 func (DefaultEtcdDbgDialer) DialContext(ctx context.Context, addr string) (net.Conn, error) {
@@ -125,7 +126,7 @@ func etcdDbgEndpoint(ctx context.Context, ep string, tlscfg *tls.Config, dialer 
 
 	// Hostname resolution
 	hostname := u.Hostname()
-	if net.ParseIP(hostname) == nil {
+	if _, err := netip.ParseAddr(hostname); err != nil {
 		ips, err := dialer.LookupIP(ctx, hostname)
 		if err != nil {
 			iw.Println("❌ Cannot resolve hostname: %s", err)
@@ -380,7 +381,7 @@ func etcdDbgParseDN(der []byte) string {
 	return name.String()
 }
 
-func etcdDbgOutputIPs(ips []net.IP) string {
+func etcdDbgOutputIPs(ips []netip.Addr) string {
 	var buf bytes.Buffer
 	for i, ip := range ips {
 		if i > 0 {
@@ -391,8 +392,7 @@ func etcdDbgOutputIPs(ips []net.IP) string {
 			buf.WriteString("...")
 			break
 		}
-
-		buf.WriteString(ip.String())
+		buf.WriteString(ip.Unmap().String())
 	}
 	return buf.String()
 }

--- a/pkg/kvstore/etcd_debug_test.go
+++ b/pkg/kvstore/etcd_debug_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package kvstore
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEtcdDbgOutputIPs(t *testing.T) {
+	tests := []struct {
+		name string
+		ips  []netip.Addr
+		want string
+	}{
+		{name: "empty", ips: nil, want: ""},
+		{name: "single IPv4", ips: []netip.Addr{netip.MustParseAddr("10.0.0.1")}, want: "10.0.0.1"},
+		{name: "single IPv6", ips: []netip.Addr{netip.MustParseAddr("fe80::1")}, want: "fe80::1"},
+		{name: "IPv4-in-IPv6 is unmapped", ips: []netip.Addr{netip.MustParseAddr("::ffff:10.0.0.1")}, want: "10.0.0.1"},
+		{
+			name: "multiple addresses",
+			ips:  []netip.Addr{netip.MustParseAddr("10.0.0.1"), netip.MustParseAddr("10.0.0.2")},
+			want: "10.0.0.1, 10.0.0.2",
+		},
+		{
+			name: "truncated after four",
+			ips: []netip.Addr{
+				netip.MustParseAddr("10.0.0.1"),
+				netip.MustParseAddr("10.0.0.2"),
+				netip.MustParseAddr("10.0.0.3"),
+				netip.MustParseAddr("10.0.0.4"),
+				netip.MustParseAddr("10.0.0.5"),
+			},
+			want: "10.0.0.1, 10.0.0.2, 10.0.0.3, 10.0.0.4, ...",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, etcdDbgOutputIPs(tt.ips))
+		})
+	}
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

## Description

Converts the etcd debug dialer (`kvstore.EtcdDbgDialer`) IP-resolution path from `[]net.IP` to `[]netip.Addr`. Part of #24246.

`net.IP` is a `[]byte` slice — heap-allocated, not comparable, and unusable as a map key. `netip.Addr` is a fixed, comparable value type. Beyond swapping the type, this change *removes* conversions rather than adding them:

- `DefaultEtcdDbgDialer` now uses `net.DefaultResolver.LookupNetIP`, which returns `[]netip.Addr` natively.
- `staticEtcdDbgDialerWithFallback` drops its `cslices.Map(hostAlias.IPs, func(in netip.Addr) net.IP { return in.AsSlice() })`
  conversion, because `HostAlias.IPs` is already `[]netip.Addr` (the now-unused `cslices` import is removed).
- `etcdDbgOutputIPs` calls `.Unmap()` before `.String()`, so IPv4-in-IPv6 results still print as dotted IPv4 (`10.0.0.1`, not `::ffff:10.0.0.1`), preserving the existing troubleshoot output.

**Files**
- `pkg/kvstore/etcd_debug.go` — interface, `DefaultEtcdDbgDialer`, `etcdDbgOutputIPs`
- `cilium-dbg/cmd/troubleshoot/troubleshoot.go` — `troubleshootDialer`; `net.ParseIP`+nil-check → `netip.ParseAddr`+error-check
- `cilium-dbg/cmd/troubleshoot/troubleshoot_clustermesh.go` — `staticEtcdDbgDialerWithFallback`; conversion + `cslices` import removed
- `pkg/kvstore/etcd_debug_test.go` — new table-driven test for `etcdDbgOutputIPs`

**Testing**

```
$ go build ./pkg/kvstore/... ./cilium-dbg/...
$ go test ./pkg/kvstore/ -run TestEtcdDbgOutputIPs -v
--- PASS: TestEtcdDbgOutputIPs (0.00s)   # all subtests PASS
$ golangci-lint run ./pkg/kvstore/... ./cilium-dbg/cmd/troubleshoot/...
0 issues.
```

The `IPv4-in-IPv6 is unmapped` test case fails with `::ffff:10.0.0.1` if `.Unmap()` is removed, confirming it guards the behavior.

This PR was prepared with AIL:0.

Related: #24246

```release-note
Convert the etcd debug (troubleshoot) dialer from net.IP to netip.Addr.
```


[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
