### PR TITLE
gateway-api: handle TCPRoute/UDPRoute in Envoy host network mode

### DIFF
--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -291,6 +291,7 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 		params.Logger,
 		defaultControllerName,
 		installedOptionalKinds,
+		cfg.HostNetworkConfig.Enabled,
 	); err != nil {
 		return fmt.Errorf("failed to create gateway controller: %w", err)
 	}
@@ -406,12 +407,19 @@ func checkCRDs(ctx context.Context, clientset k8sClient.Clientset, logger *slog.
 
 // registerReconcilers registers Gateway API reconcilers to the controller-runtime library manager.
 // optionalKinds are previously autodetected based on what CRDs are present in the cluster.
-func registerReconcilers(mgr ctrlRuntime.Manager, translator translation.Translator, logger *slog.Logger, controllerName string, installedOptionalCRDs []schema.GroupVersionKind) error {
+func registerReconcilers(
+	mgr ctrlRuntime.Manager,
+	translator translation.Translator,
+	logger *slog.Logger,
+	controllerName string,
+	installedOptionalCRDs []schema.GroupVersionKind,
+	hostNetworkEnabled bool,
+) error {
 	requiredReconcilers := []interface {
 		SetupWithManager(mgr ctrlRuntime.Manager) error
 	}{
 		newGatewayClassReconciler(mgr, logger, controllerName),
-		newGatewayReconciler(mgr, translator, logger, controllerName),
+		newGatewayReconciler(mgr, translator, logger, controllerName, hostNetworkEnabled),
 		newGammaReconciler(mgr, translator, logger, controllerName),
 		newGatewayClassConfigReconciler(mgr, logger),
 		newEndpointSliceReconciler(mgr, logger),

--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -40,19 +40,21 @@ type gatewayReconciler struct {
 	Scheme     *runtime.Scheme
 	translator translation.Translator
 
-	logger         *slog.Logger
-	controllerName string
+	logger             *slog.Logger
+	controllerName     string
+	hostNetworkEnabled bool
 }
 
-func newGatewayReconciler(mgr ctrl.Manager, translator translation.Translator, logger *slog.Logger, controllerName string) *gatewayReconciler {
+func newGatewayReconciler(mgr ctrl.Manager, translator translation.Translator, logger *slog.Logger, controllerName string, hostNetworkEnabled bool) *gatewayReconciler {
 	scopedLog := logger.With(logfields.Controller, gateway)
 
 	return &gatewayReconciler{
-		Client:         mgr.GetClient(),
-		Scheme:         mgr.GetScheme(),
-		translator:     translator,
-		logger:         scopedLog,
-		controllerName: controllerName,
+		Client:             mgr.GetClient(),
+		Scheme:             mgr.GetScheme(),
+		translator:         translator,
+		logger:             scopedLog,
+		controllerName:     controllerName,
+		hostNetworkEnabled: hostNetworkEnabled,
 	}
 }
 

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -751,10 +751,12 @@ func (r *gatewayReconciler) resolveAllowedListeners(
 		if _, conflicted := conflictedListeners[l.Name]; conflicted {
 			continue
 		}
-		merged = append(merged, ingestion.ListenerWithContext{
-			Listener: l,
-			Source:   gwSource,
-		})
+		if r.listenerSupportedForIngestion(l) {
+			merged = append(merged, ingestion.ListenerWithContext{
+				Listener: l,
+				Source:   gwSource,
+			})
+		}
 	}
 
 	if !helpers.HasListenerSetSupport(r.Client.Scheme()) {
@@ -787,11 +789,13 @@ func (r *gatewayReconciler) resolveAllowedListeners(
 		lsSource := listenerSetFQR(ls)
 		for _, entry := range ls.Spec.Listeners {
 			listener := helpers.ListenerEntryToListener(entry)
-			merged = append(merged, ingestion.ListenerWithContext{
-				Listener:          listener,
-				Source:            lsSource,
-				AllowedNamespaces: resolveAllowedNamespaces(ctx, r.Client, ls.GetNamespace(), listener, scopedLog),
-			})
+			if r.listenerSupportedForIngestion(listener) {
+				merged = append(merged, ingestion.ListenerWithContext{
+					Listener:          listener,
+					Source:            lsSource,
+					AllowedNamespaces: resolveAllowedNamespaces(ctx, r.Client, ls.GetNamespace(), listener, scopedLog),
+				})
+			}
 		}
 	}
 
@@ -1453,6 +1457,14 @@ func (r *gatewayReconciler) validateListener(ctx context.Context, l gatewayv1.Li
 		res.isValid = false
 	}
 
+	if r.hostNetworkEnabled && isL4Protocol(l.Protocol) {
+		res.invalidMessages = append(res.invalidMessages,
+			fmt.Sprintf("%s listeners are not supported when Gateway API Host Network mode is enabled", l.Protocol))
+		res.invalidReason = gatewayv1.ListenerReasonUnsupportedProtocol
+		res.isValid = false
+		return res
+	}
+
 	if l.AllowedRoutes != nil && len(l.AllowedRoutes.Kinds) > 0 {
 		res.supportedKinds = []gatewayv1.RouteGroupKind{}
 		for _, supported := range allSupported {
@@ -1715,6 +1727,30 @@ func (r *gatewayReconciler) runCommonRouteChecks(ctx context.Context, input rout
 	return nil
 }
 
+// checkRouteSupported returns false when route validation should stop for this input.
+func (r *gatewayReconciler) checkRouteSupported(input routechecks.Input, parent gatewayv1.ParentReference) bool {
+	switch k := input.GetGVK().Kind; k {
+	case kindTCPRoute, kindUDPRoute:
+		if r.hostNetworkEnabled {
+			input.SetParentCondition(parent, metav1.Condition{
+				Type:    string(gatewayv1.RouteConditionAccepted),
+				Status:  metav1.ConditionFalse,
+				Reason:  string(gatewayv1.RouteReasonUnsupportedValue),
+				Message: fmt.Sprintf("%s is not supported when Gateway API Host Network mode is enabled", k),
+			})
+			input.SetParentCondition(parent, metav1.Condition{
+				Type:    string(gatewayv1.RouteConditionResolvedRefs),
+				Status:  metav1.ConditionUnknown,
+				Reason:  string(gatewayv1.RouteReasonPending),
+				Message: "Backend references were not evaluated because this route type is not supported in Gateway API Host Network mode",
+			})
+			return false
+		}
+	}
+
+	return true
+}
+
 var gatewayCheckFuncs = []routechecks.CheckWithParentFunc{
 	routechecks.CheckGatewayMatchingProtocol,
 	routechecks.CheckGatewayRouteKindAllowed,
@@ -1764,6 +1800,10 @@ func (r *gatewayReconciler) runGatewayRouteChecks(ctx context.Context, input rou
 		return nil
 	}
 
+	if !r.checkRouteSupported(input, parent) {
+		return nil
+	}
+
 	setInitialRouteConditions(input, parent)
 
 	if err := runCheckFuncs(input, parent, gatewayCheckFuncs, "Gateway"); err != nil {
@@ -1790,6 +1830,10 @@ func (r *gatewayReconciler) runListenerSetRouteChecks(ctx context.Context, input
 
 	hasMatchingControllerFn := helpers.GatewayHasMatchingControllerFn(ctx, r.Client, r.controllerName, r.logger)
 	if !hasMatchingControllerFn(gw) {
+		return nil
+	}
+
+	if !r.checkRouteSupported(input, parent) {
 		return nil
 	}
 
@@ -2373,6 +2417,19 @@ func (r *gatewayReconciler) updateBackendTLSPolicyStatus(ctx context.Context, sc
 	}
 	scopedLog.Debug("BackendTLSPolicy status", backendTLSPolicy, types.NamespacedName{Name: original.Name, Namespace: original.Namespace})
 	return r.Client.Status().Update(ctx, new)
+}
+
+func (r *gatewayReconciler) listenerSupportedForIngestion(listener gatewayv1.Listener) bool {
+	// TCPRoute and UDPRoute rely on NodePort Services, which are incompatible
+	// with Envoy running in host networking mode.
+	if !r.hostNetworkEnabled {
+		return true
+	}
+	if isL4Protocol(listener.Protocol) {
+		return false
+	}
+
+	return true
 }
 
 func listenerOwnerNamespace(gw *gatewayv1.Gateway, listenerSource *model.FullyQualifiedResource) string {

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -337,6 +337,10 @@ func Test_Conformance(t *testing.T) {
 		{name: "gatewayclassconfig-nodeport", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "nodeport-gateway", Namespace: "gateway-conformance-infra"}}}},
 		{name: "hostNetwork-enabled-valid", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "hostnetwork-enabled", Namespace: "gateway-conformance-infra"}}}, hostNetwork: true},
 		{name: "hostNetwork-enabled-exceed-max-address", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "hostnetwork-enabled", Namespace: "gateway-conformance-infra"}}}, hostNetwork: true},
+		{name: "hostNetwork-enabled-no-l4-listeners", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "host-networking", Namespace: "gateway-conformance-infra"}}}, hostNetwork: true},
+		{name: "hostNetwork-enabled-mixed-routes", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "host-networking", Namespace: "gateway-conformance-infra"}}}, hostNetwork: true},
+		{name: "hostNetwork-enabled-tcp-route", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "host-networking", Namespace: "gateway-conformance-infra"}, wantErr: true, skipCEC: true}}, hostNetwork: true},
+		{name: "hostNetwork-enabled-udp-route", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "host-networking", Namespace: "gateway-conformance-infra"}, wantErr: true, skipCEC: true}}, hostNetwork: true},
 		// ListenerSet tests
 		{name: "listenerset-default-not-allowed", gateway: []gwDetails{
 			{FullName: types.NamespacedName{Name: "default-not-allowed", Namespace: "gateway-conformance-infra"}},
@@ -445,10 +449,11 @@ func Test_Conformance(t *testing.T) {
 			})
 
 			r := &gatewayReconciler{
-				Client:         c,
-				translator:     gatewayAPITranslator,
-				logger:         logger,
-				controllerName: defaultControllerName,
+				Client:             c,
+				translator:         gatewayAPITranslator,
+				logger:             logger,
+				controllerName:     defaultControllerName,
+				hostNetworkEnabled: tt.hostNetwork,
 			}
 
 			// Reconcile all related HTTPRoute objects

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-mixed-routes/input/gateway.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-mixed-routes/input/gateway.yaml
@@ -1,0 +1,70 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: UDPRoute
+metadata:
+  name: udp-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: host-networking
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: udp-backend-host-networking
+          port: 53
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: TCPRoute
+metadata:
+  name: tcp-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: host-networking
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: tcp-backend-host-networking
+          port: 53
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: http-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: host-networking
+      namespace: gateway-conformance-infra
+  hostnames:
+    - example.org
+  rules:
+    - backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: host-networking
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: udp
+      port: 53
+      protocol: UDP
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: tcp
+      port: 53
+      protocol: TCP
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-mixed-routes/output/cec-host-networking.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-mixed-routes/output/cec-host-networking.yaml
@@ -1,0 +1,108 @@
+metadata:
+  creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: host-networking
+  name: cilium-gateway-host-networking
+  namespace: gateway-conformance-infra
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      controller: true
+      kind: Gateway
+      name: host-networking
+      uid: ""
+  resourceVersion: "1"
+spec:
+  backendServices:
+    - name: infra-backend-v1
+      namespace: gateway-conformance-infra
+      number:
+        - "8080"
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            transportProtocol: raw_buffer
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-insecure
+                statPrefix: listener-insecure
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-insecure
+      virtualHosts:
+        - domains:
+            - "example.org"
+            - "example.org:*"
+          name: "example.org"
+          routes:
+            - match:
+                prefix: /
+              route:
+                cluster: gateway-conformance-infra:infra-backend-v1:8080
+                maxStreamDuration:
+                  maxStreamDuration: 0s
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/infra-backend-v1:8080
+      name: gateway-conformance-infra:infra-backend-v1:8080
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 60s
+          useDownstreamProtocolConfig:
+            http2ProtocolOptions: {}
+  services:
+    - listener: ""
+      name: cilium-gateway-host-networking
+      namespace: gateway-conformance-infra
+      ports:
+        - 80

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-mixed-routes/output/host-networking.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-mixed-routes/output/host-networking.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: host-networking
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: udp
+      port: 53
+      protocol: UDP
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: tcp
+      port: 53
+      protocol: TCP
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+status:
+  conditions:
+    - message: Gateway has unsupported listeners
+      reason: ListenersNotValid
+      status: "True"
+      type: Accepted
+      lastTransitionTime: "2026-02-28T00:00:00Z"
+    - message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+      lastTransitionTime: "2026-02-28T00:00:00Z"
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - message: Listener not valid. UDP listeners are not supported when Gateway API Host Network mode is enabled
+          reason: UnsupportedProtocol
+          status: "False"
+          type: Accepted
+          lastTransitionTime: "2026-02-28T00:00:00Z"
+        - message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+          lastTransitionTime: "2026-02-28T00:00:00Z"
+      name: udp
+    - attachedRoutes: 0
+      conditions:
+        - message: Listener not valid. TCP listeners are not supported when Gateway API Host Network mode is enabled
+          reason: UnsupportedProtocol
+          status: "False"
+          type: Accepted
+          lastTransitionTime: "2026-02-28T00:00:00Z"
+        - message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+          lastTransitionTime: "2026-02-28T00:00:00Z"
+      name: tcp
+    - attachedRoutes: 1
+      conditions:
+        - lastTransitionTime: "2025-07-01T05:06:15Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T14:19:43Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T14:29:32Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+      name: http
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-mixed-routes/output/httproute-http-route.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-mixed-routes/output/httproute-http-route.yaml
@@ -1,0 +1,34 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  creationTimestamp: null
+  name: http-route
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  hostnames:
+  - example.org
+  parentRefs:
+    - name: host-networking
+      namespace: gateway-conformance-infra
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: "2025-07-01T14:19:43Z"
+      message: Accepted HTTPRoute
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T14:19:43Z"
+      message: Service reference is valid
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: io.cilium/gateway-controller
+    parentRef:
+      name: host-networking
+      namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-mixed-routes/output/tcproute-tcp-route.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-mixed-routes/output/tcproute-tcp-route.yaml
@@ -1,0 +1,30 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: TCPRoute
+metadata:
+  name: tcp-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: host-networking
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: tcp-backend-host-networking
+          port: 53
+status:
+  parents:
+    - conditions:
+        - message: TCPRoute is not supported when Gateway API Host Network mode is enabled
+          reason: UnsupportedValue
+          status: "False"
+          type: Accepted
+          lastTransitionTime: "2026-02-28T00:00:00Z"
+        - message: Backend references were not evaluated because this route type is not supported in Gateway API Host Network mode
+          reason: Pending
+          status: "Unknown"
+          type: ResolvedRefs
+          lastTransitionTime: "2026-02-28T00:00:00Z"
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: host-networking
+        namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-mixed-routes/output/udproute-udp-route.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-mixed-routes/output/udproute-udp-route.yaml
@@ -1,0 +1,30 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: UDPRoute
+metadata:
+  name: udp-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: host-networking
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: udp-backend-host-networking
+          port: 53
+status:
+  parents:
+    - conditions:
+        - message: UDPRoute is not supported when Gateway API Host Network mode is enabled
+          reason: UnsupportedValue
+          status: "False"
+          type: Accepted
+          lastTransitionTime: "2026-02-28T00:00:00Z"
+        - message: Backend references were not evaluated because this route type is not supported in Gateway API Host Network mode
+          reason: Pending
+          status: "Unknown"
+          type: ResolvedRefs
+          lastTransitionTime: "2026-02-28T00:00:00Z"
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: host-networking
+        namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-no-l4-listeners/input/gateway.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-no-l4-listeners/input/gateway.yaml
@@ -1,0 +1,58 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: UDPRoute
+metadata:
+  name: udp-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: host-networking
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: udp-backend-host-networking
+          port: 53
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: TCPRoute
+metadata:
+  name: tcp-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: host-networking
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: tcp-backend-host-networking
+          port: 53
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: http-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: host-networking
+      namespace: gateway-conformance-infra
+  hostnames:
+    - example.org
+  rules:
+    - backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: host-networking
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-no-l4-listeners/output/cec-host-networking.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-no-l4-listeners/output/cec-host-networking.yaml
@@ -1,0 +1,108 @@
+metadata:
+  creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: host-networking
+  name: cilium-gateway-host-networking
+  namespace: gateway-conformance-infra
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      controller: true
+      kind: Gateway
+      name: host-networking
+      uid: ""
+  resourceVersion: "1"
+spec:
+  backendServices:
+    - name: infra-backend-v1
+      namespace: gateway-conformance-infra
+      number:
+        - "8080"
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            transportProtocol: raw_buffer
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-insecure
+                statPrefix: listener-insecure
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-insecure
+      virtualHosts:
+        - domains:
+            - "example.org"
+            - "example.org:*"
+          name: "example.org"
+          routes:
+            - match:
+                prefix: /
+              route:
+                cluster: gateway-conformance-infra:infra-backend-v1:8080
+                maxStreamDuration:
+                  maxStreamDuration: 0s
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/infra-backend-v1:8080
+      name: gateway-conformance-infra:infra-backend-v1:8080
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 60s
+          useDownstreamProtocolConfig:
+            http2ProtocolOptions: {}
+  services:
+    - listener: ""
+      name: cilium-gateway-host-networking
+      namespace: gateway-conformance-infra
+      ports:
+        - 80

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-no-l4-listeners/output/host-networking.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-no-l4-listeners/output/host-networking.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: host-networking
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+status:
+  conditions:
+    - message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+      lastTransitionTime: "2026-02-25T00:00:00Z"
+    - message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+      lastTransitionTime: "2026-02-25T00:00:00Z"
+  listeners:
+    - attachedRoutes: 1
+      conditions:
+        - message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+      name: http
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-no-l4-listeners/output/httproute-http-route.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-no-l4-listeners/output/httproute-http-route.yaml
@@ -1,0 +1,34 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  creationTimestamp: null
+  name: http-route
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  hostnames:
+  - example.org
+  parentRefs:
+    - name: host-networking
+      namespace: gateway-conformance-infra
+  rules:
+  - backendRefs:
+    - name: infra-backend-v1
+      port: 8080
+status:
+  parents:
+  - conditions:
+    - lastTransitionTime: "2025-07-01T14:19:43Z"
+      message: Accepted HTTPRoute
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T14:19:43Z"
+      message: Service reference is valid
+      reason: ResolvedRefs
+      status: "True"
+      type: ResolvedRefs
+    controllerName: io.cilium/gateway-controller
+    parentRef:
+      name: host-networking
+      namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-no-l4-listeners/output/tcproute-tcp-route.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-no-l4-listeners/output/tcproute-tcp-route.yaml
@@ -1,0 +1,30 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: TCPRoute
+metadata:
+  name: tcp-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: host-networking
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: tcp-backend-host-networking
+          port: 53
+status:
+  parents:
+    - conditions:
+        - message: TCPRoute is not supported when Gateway API Host Network mode is enabled
+          reason: UnsupportedValue
+          status: "False"
+          type: Accepted
+          lastTransitionTime: "2026-02-28T00:00:00Z"
+        - message: Backend references were not evaluated because this route type is not supported in Gateway API Host Network mode
+          reason: Pending
+          status: "Unknown"
+          type: ResolvedRefs
+          lastTransitionTime: "2026-02-28T00:00:00Z"
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: host-networking
+        namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-no-l4-listeners/output/udproute-udp-route.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-no-l4-listeners/output/udproute-udp-route.yaml
@@ -1,0 +1,30 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: UDPRoute
+metadata:
+  name: udp-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: host-networking
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: udp-backend-host-networking
+          port: 53
+status:
+  parents:
+    - conditions:
+        - message: "UDPRoute is not supported when Gateway API Host Network mode is enabled"
+          reason: UnsupportedValue
+          status: "False"
+          type: Accepted
+          lastTransitionTime: "2026-02-25T00:00:00Z"
+        - message: Backend references were not evaluated because this route type is not supported in Gateway API Host Network mode
+          reason: Pending
+          status: "Unknown"
+          type: ResolvedRefs
+          lastTransitionTime: "2026-02-28T00:00:00Z"
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: host-networking
+        namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-tcp-route/input/gateway.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-tcp-route/input/gateway.yaml
@@ -1,0 +1,25 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: TCPRoute
+metadata:
+  name: tcp-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: host-networking
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: tcp-backend-host-networking
+          port: 22
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: host-networking
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: tcp
+      port: 22
+      protocol: TCP

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-tcp-route/output/host-networking.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-tcp-route/output/host-networking.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: host-networking
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: tcp
+      port: 22
+      protocol: TCP
+status:
+  conditions:
+    - message: No Accepted Listeners
+      reason: ListenersNotValid
+      status: "False"
+      type: Accepted
+      lastTransitionTime: "2026-02-28T00:00:00Z"
+    - message: No Accepted Listeners
+      reason: ListenersNotValid
+      status: "False"
+      type: Programmed
+      lastTransitionTime: "2026-02-28T00:00:00Z"
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - message: Listener not valid. TCP listeners are not supported when Gateway API Host Network mode is enabled
+          reason: UnsupportedProtocol
+          status: "False"
+          type: Accepted
+          lastTransitionTime: "2026-02-28T00:00:00Z"
+        - message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+          lastTransitionTime: "2026-02-28T00:00:00Z"
+      name: tcp

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-tcp-route/output/tcproute-tcp-route.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-tcp-route/output/tcproute-tcp-route.yaml
@@ -1,0 +1,30 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: TCPRoute
+metadata:
+  name: tcp-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: host-networking
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: tcp-backend-host-networking
+          port: 22
+status:
+  parents:
+    - conditions:
+        - message: TCPRoute is not supported when Gateway API Host Network mode is enabled
+          reason: UnsupportedValue
+          status: "False"
+          type: Accepted
+          lastTransitionTime: "2026-02-28T00:00:00Z"
+        - message: Backend references were not evaluated because this route type is not supported in Gateway API Host Network mode
+          reason: Pending
+          status: "Unknown"
+          type: ResolvedRefs
+          lastTransitionTime: "2026-02-28T00:00:00Z"
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: host-networking
+        namespace: gateway-conformance-infra

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-udp-route/input/gateway.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-udp-route/input/gateway.yaml
@@ -1,0 +1,25 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: UDPRoute
+metadata:
+  name: udp-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: host-networking
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: udp-backend-host-networking
+          port: 22
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: host-networking
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: udp
+      port: 22
+      protocol: UDP

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-udp-route/output/host-networking.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-udp-route/output/host-networking.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: host-networking
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: udp
+      port: 22
+      protocol: UDP
+status:
+  conditions:
+    - message: No Accepted Listeners
+      reason: ListenersNotValid
+      status: "False"
+      type: Accepted
+      lastTransitionTime: "2026-02-28T00:00:00Z"
+    - message: No Accepted Listeners
+      reason: ListenersNotValid
+      status: "False"
+      type: Programmed
+      lastTransitionTime: "2026-02-28T00:00:00Z"
+  listeners:
+    - attachedRoutes: 0
+      conditions:
+        - message: Listener not valid. UDP listeners are not supported when Gateway API Host Network mode is enabled
+          reason: UnsupportedProtocol
+          status: "False"
+          type: Accepted
+          lastTransitionTime: "2026-02-28T00:00:00Z"
+        - message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed
+          lastTransitionTime: "2026-02-28T00:00:00Z"
+      name: udp

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-udp-route/output/udproute-udp-route.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-udp-route/output/udproute-udp-route.yaml
@@ -1,0 +1,30 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: UDPRoute
+metadata:
+  name: udp-route
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: host-networking
+      namespace: gateway-conformance-infra
+  rules:
+    - backendRefs:
+        - name: udp-backend-host-networking
+          port: 22
+status:
+  parents:
+    - conditions:
+        - message: UDPRoute is not supported when Gateway API Host Network mode is enabled
+          reason: UnsupportedValue
+          status: "False"
+          type: Accepted
+          lastTransitionTime: "2026-02-28T00:00:00Z"
+        - message: Backend references were not evaluated because this route type is not supported in Gateway API Host Network mode
+          reason: Pending
+          status: "Unknown"
+          type: ResolvedRefs
+          lastTransitionTime: "2026-02-28T00:00:00Z"
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: host-networking
+        namespace: gateway-conformance-infra


### PR DESCRIPTION
This commit correctly handles TCPRoute and UDPRoute when Envoy runs in host network mode by rejecting unsupported routes, since the current NodePort-based implementation does not work correctly in this mode.

- Reject TCP/UDP listeners in host network mode and update Gateway listener status for unsupported L4 listeners.
- Reject TCPRoute and UDPRoute objects in host network mode and set unsupported status on route objects.
- Rejecting TCP/UDP listeners and/or routes doesn't stop the reconciliation of mixed scenarios.

Related to #47234.

```release-note
gateway-api: Correctly handle TCPRoute and UDPRoute in host network mode by rejecting unsupported L4 configurations and updating Gateway/Route statuses.
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
