### PR TITLE
pkg/gops: if no home user dir is set then default to random tmp dir.

### DIFF
--- a/pkg/gops/cell.go
+++ b/pkg/gops/cell.go
@@ -6,6 +6,8 @@ package gops
 import (
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 
 	"github.com/cilium/hive/cell"
 	gopsAgent "github.com/google/gops/agent"
@@ -37,6 +39,23 @@ func (def GopsConfig) Flags(flags *pflag.FlagSet) {
 	flags.Bool(option.EnableGops, def.EnableGops, "Enable gops server")
 }
 
+// gopsConfigDir returns a writable directory for the gops config.
+// By default, gops derives the config directory via os.UserConfigDir():
+// In any environment where $HOME is set to / (ex. containers running as a
+// randomly assigned UID with no /etc/passwd entry, as is common on OpenShift),
+// os.UserConfigDir() resolves to /. The portfile path then becomes /<PID>, which
+// is not writable. In such case fall back to os.TempDir().
+func gopsConfigDir(log *slog.Logger) string {
+	dir, err := os.UserConfigDir()
+	if err != nil || filepath.Clean(dir) == "/" {
+		p := filepath.Join(os.TempDir(), "gops")
+		log.Debug("os.UserConfigDir() was empty, will use tmp dir instead",
+			logfields.Directory, p)
+		return p
+	}
+	return filepath.Join(dir, "gops")
+}
+
 func registerGopsHooks(lc cell.Lifecycle, log *slog.Logger, cfg GopsConfig) {
 	if !cfg.EnableGops {
 		return
@@ -47,6 +66,7 @@ func registerGopsHooks(lc cell.Lifecycle, log *slog.Logger, cfg GopsConfig) {
 		OnStart: func(cell.HookContext) error {
 			scopedLog.Info("Started gops server")
 			return gopsAgent.Listen(gopsAgent.Options{
+				ConfigDir:              gopsConfigDir(log),
 				Addr:                   addr,
 				ReuseSocketAddrAndPort: true,
 			})


### PR DESCRIPTION
gopsConfigDir returns a writable directory for the gops config. By default, gops derives the config directory via os.UserConfigDir(): In any environment where $HOME is set to / (ex. containers running as a randomly assigned UID with no /etc/passwd entry, as is common on OpenShift), os.UserConfigDir() resolves to /. The portfile path then becomes /<PID>, which is not writable. In such case fall back to os.TempDir().

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request]
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here or remove this release-note section from your PR description. Do NOT put an "empty" release note here -->
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
