### PR TITLE
cilium-cli/clustermesh: log enable messages via Parameters.Writer

### DIFF
--- a/cilium-cli/clustermesh/clustermesh.go
+++ b/cilium-cli/clustermesh/clustermesh.go
@@ -984,12 +984,11 @@ func (k *K8sClusterMesh) outputConnectivityStatus(agents, kvstoremesh *Connectiv
 	}
 }
 
-func log(format string, a ...any) {
-	// TODO (ajs): make logger configurable
-	fmt.Fprintf(os.Stdout, format+"\n", a...)
-}
-
 func generateEnableHelmValues(params Parameters, flavor k8s.Flavor) (map[string]any, error) {
+	log := func(format string, a ...any) {
+		fmt.Fprintf(params.Writer, format+"\n", a...)
+	}
+
 	helmVals := map[string]any{
 		"clustermesh": map[string]any{
 			"useAPIServer": true,


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
- [x] Thanks for contributing!

#### Related cODE:
there was a TODO: `// TODO (ajs): make logger configurable`

#### changes done:
`generateEnableHelmValues` used a package-level helper that always wrote to `os.Stdout`. The rest of cilium-cli clustermesh logging already goes through `Parameters.Writer` (and `K.Log`).

This change routes those enable-time status messages through `params.Writer`so callers can redirect output (for example in tests). The CLI still sets `Writer: os.Stdout` for `cilium clustermesh enable`, so default user-facing behavior is unchanged.