### PR TITLE
.github: fail smoke IPv6 closed when the test job does not succeed

### DIFF
--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -223,7 +223,7 @@ jobs:
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}
-      success: ${{ needs.conformance-test-ipv6.result != 'failure' }}
+      success: ${{ needs.conformance-test-ipv6.result == 'success' }}
       # This job runs a kubectl-based connectivity check rather than cilium
       # connectivity test, so it produces no JUnit report. Skip the junit merge
       # to avoid a spurious "No matching cilium-junits-* artifacts found" warning.


### PR DESCRIPTION
The IPv6 smoke workflow computes its final commit status from needs.conformance-test-ipv6.result != 'failure', which is fed to common-post-jobs and is the only place the status is set. That job is the workflow's sole test job and runs a real connectivity check (kubectl apply of the connectivity-check manifest plus kubectl wait for the deployments), so it is the thing the whole workflow exists to verify.

The problem is that != 'failure' also treats 'cancelled' and 'skipped' as a pass. The test job has no timeout-minutes so it inherits GitHub's 6h default, and cilium install / cilium status --wait have no bounding timeout, so a hang is eventually killed and the job ends 'cancelled'. The workflow also sets concurrency.cancel-in-progress, so a superseded run ends 'cancelled' as well. In either case 'cancelled' != 'failure' is true, and the head SHA is given a green commit status for a run that never finished its connectivity check.

This switches the gate to == 'success', so anything other than a genuine pass fails closed. The sibling tests-smoke-conformance.yaml already gates on == 'success', so this only brings the IPv6 variant in line. Ordinary test-logic failures were already caught because the bounded 5m kubectl wait yields 'failure'; only the cancellation path was leaking, which is why this is a small but real correctness fix rather than a behavior change for passing runs.

The != 'failure' gate was introduced when the IPv6 conformance smoke test was split out into its own common-post-jobs-gated workflow.

Fixes: 29c832727dad ("ci: handle pull_request workflows by ariane")

The common-post-jobs gate that makes this expression load-bearing exists on main, v1.20 and v1.19, so this wants backporting down to v1.19. On v1.19 the same change arrived via backport commit 1ba703c1e623. On v1.18 and v1.17 the IPv6 smoke workflow still fails natively (no success: boolean), so they are not affected.

This PR was prepared with AIL:3.
