### PR TITLE
gha: pull sig-network e2e.test from v1.37.0-beta.0

### DIFF
--- a/.github/workflows/k8s-kind-network-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-e2e.yaml
@@ -294,7 +294,12 @@ jobs:
           # Run tests
           export KUBERNETES_CONFORMANCE_TEST='y'
           export E2E_REPORT_DIR=${PWD}/_artifacts
-          /usr/local/bin/ginkgo --nodes=25                \
+          # 25-way parallelism on the 4-vCPU runner starves endpoint
+          # regeneration, so pod CNI ADD takes an endpoint-create 429 and
+          # pods come up late or without an IP, flaking sig-network specs.
+          # Lower the parallelism to ease that pressure. Match the
+          # network-policies job at 10.
+          /usr/local/bin/ginkgo --nodes=10                \
             --focus="\[sig-network\]"     \
             --skip="${SKIP_FLAG}"   \
             /usr/local/bin/e2e.test                       \

--- a/.github/workflows/k8s-kind-network-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-e2e.yaml
@@ -96,8 +96,13 @@ jobs:
       - name: Set up environment (download Kubernetes dependencies)
         run: |
           TMP_DIR=$(mktemp -d)
-          # Test binaries
-          curl -fL --retry 5 --retry-all-errors --retry-delay 3 https://dl.k8s.io/${{ env.KIND_K8S_VERSION }}/kubernetes-test-linux-amd64.tar.gz -o ${TMP_DIR}/kubernetes-test-linux-amd64.tar.gz
+          # Test binaries. The e2e.test/ginkgo pair is pulled from
+          # v1.37.0-beta.0 rather than the cluster's KIND_K8S_VERSION
+          # (v1.36.0) to pick up upstream commit 108da50828f, which stops
+          # the UDP Conntrack client probe from crash-looping. The cluster
+          # (KIND_K8S_IMAGE) and kubectl stay on v1.36.0.
+          E2E_TEST_VERSION="v1.37.0-beta.0"
+          curl -fL --retry 5 --retry-all-errors --retry-delay 3 https://dl.k8s.io/${E2E_TEST_VERSION}/kubernetes-test-linux-amd64.tar.gz -o ${TMP_DIR}/kubernetes-test-linux-amd64.tar.gz
           tar -xvzf ${TMP_DIR}/kubernetes-test-linux-amd64.tar.gz \
             --directory ${TMP_DIR} \
             --strip-components=3 kubernetes/test/bin/ginkgo kubernetes/test/bin/e2e.test


### PR DESCRIPTION
The K8s Network E2E ("Installation and Conformance Test") job intermittently fails sig-network specs on the standard 4-vCPU ubuntu-24.04 runner. There are two distinct failure modes and this addresses both.

The first is the UDP Conntrack specs failing with "Failed to connect to backend N". This is a client-side artifact in the upstream Kubernetes test: the client probe runs a tight nc loop that finishes in seconds, the pod crash-loops, and its log is frozen during the one-minute assertion poll, so a backend that comes up a little late is missed. Upstream fixed this in commit 108da50828f by pacing the probe and keeping the client alive, but that landed only in v1.37.0-alpha.2 and later and was not backported to any v1.36.x. This pulls just the e2e.test and ginkgo binaries from v1.37.0-beta.0 while the KIND cluster and kubectl stay on the pinned v1.36.0, which is within the supported apiserver skew.

The second mode is the deeper cause. A 50-run soak with the fixed binary at the original --nodes=25 showed the Conntrack failures gone but surfaced other sig-network flakes, for example EndpointSlice "should create Endpoints and EndpointSlices for Pods matching a Service" timing out waiting for pods to get IPs. Those pods had taken an endpoint-create 429: 25 parallel test processes on a 4-vCPU host starve endpoint regeneration, so CNI ADD is rate limited whatever spec creates the pod. This lowers the ginkgo parallelism to 10, matching the sibling network-policies job on the same runner, to ease that pressure. A genuine slow-regeneration regression would still fail, so this does not mask real failures.

This PR was prepared with AIL:2.
