### PR TITLE
docs: Update Gateway API installation guide

### DIFF
--- a/Documentation/network/servicemesh/gateway-api/installation.rst
+++ b/Documentation/network/servicemesh/gateway-api/installation.rst
@@ -6,89 +6,100 @@ Prerequisites
   replacement <kubeproxy-free>`.
 * Cilium must be configured with the L7 proxy enabled using ``l7Proxy=true``
   (enabled by default).
-* The below CRDs from Gateway API |GATEWAY_API_VERSION| ``must`` be pre-installed.
-  Please refer to these `docs <https://gateway-api.sigs.k8s.io/guides/getting-started/introduction/#installing-gateway-api>`_
-  for installation steps. Alternatively, the below snippet could be used.
-
-    - `GatewayClass <https://gateway-api.sigs.k8s.io/reference/api-types/gatewayclass/>`_
-    - `Gateway <https://gateway-api.sigs.k8s.io/reference/api-types/gateway/>`_
-    - `HTTPRoute <https://gateway-api.sigs.k8s.io/reference/api-types/httproute/>`_
-    - `GRPCRoute <https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute/>`_
-    - `BackendTLSPolicy <https://gateway-api.sigs.k8s.io/reference/api-types/policy/backendtlspolicy/>`__
-    - `ReferenceGrant <https://gateway-api.sigs.k8s.io/reference/api-types/referencegrant/>`_
-    - `TLSRoute <https://gateway-api.sigs.k8s.io/reference/api-types/tlsroute/>`_
-
-  You can install the set of required CRDs like this:
-
-    .. parsed-literal::
-
-        kubectl apply -f |GATEWAY_API_RAW_BASE_URL|/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
-        kubectl apply -f |GATEWAY_API_RAW_BASE_URL|/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
-        kubectl apply -f |GATEWAY_API_RAW_BASE_URL|/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
-        kubectl apply -f |GATEWAY_API_RAW_BASE_URL|/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
-        kubectl apply -f |GATEWAY_API_RAW_BASE_URL|/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
-        kubectl apply -f |GATEWAY_API_RAW_BASE_URL|/config/crd/standard/gateway.networking.k8s.io_backendtlspolicies.yaml
-        kubectl apply -f |GATEWAY_API_RAW_BASE_URL|/config/crd/standard/gateway.networking.k8s.io_tlsroutes.yaml
-
-
-    .. warning::
-
-      If you have used the ``TLSRoute`` resource in releases before Cilium v1.20, you should install the Experimental version of the TLSRoute resource instead.
-
-      If you install the Standard version, *all your TLSRoutes will not be readable*.
-
-      The Standard version of the ``TLSRoute`` resource in Gateway API v1.6 does *not* include the ``v1alpha2`` version that TLSRoute previously used, which
-      means that the apiserver cannot read the records in etcd.
-
-      Install the experimental version with:
-
-      .. parsed-literal::
-
-        kubectl apply -f |GATEWAY_API_RAW_BASE_URL|/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
-
-  If you wish to use the ListenerSet, TCPRoute, or UDPRoute functionality, you
-  also need to install the related CRDs. For each CRD that is not installed,
-  Cilium will disable support for the feature.
-
-    - `ListenerSet <https://gateway-api.sigs.k8s.io/reference/api-types/listenerset/>`__
-    - `TCPRoute <https://gateway-api.sigs.k8s.io/reference/api-types/tcproute/>`__
-    - `UDPRoute <https://gateway-api.sigs.k8s.io/reference/api-types/udproute/>`__
-
-  Each optional CRD can be installed with these respective commands.
-
-  ListenerSet:
-
-    .. parsed-literal::
-
-        kubectl apply -f |GATEWAY_API_RAW_BASE_URL|/config/crd/standard/gateway.networking.k8s.io_listenersets.yaml
-
-  TCPRoute:
-
-    .. parsed-literal::
-
-        kubectl apply -f |GATEWAY_API_RAW_BASE_URL|/config/crd/standard/gateway.networking.k8s.io_tcproutes.yaml
-
-  UDPRoute:
-
-    .. parsed-literal::
-
-        kubectl apply -f |GATEWAY_API_RAW_BASE_URL|/config/crd/standard/gateway.networking.k8s.io_udproutes.yaml
-
-* By default, the Gateway API controller creates a service of LoadBalancer type,
-  so your environment will need to support this. Alternatively, since Cilium 1.16+,
+* By default, the Cilium Gateway API controller creates a service of LoadBalancer type,
+  so your environment will need to support this. Alternatively, since Cilium 1.16,
   you can directly expose the Cilium L7 proxy on the :ref:`host network <gs_gateway_host_network_mode>`.
 
 Installation
 ############
 
-.. include:: ../../../installation/cli-download.rst
+The below CRDs from Gateway API |GATEWAY_API_VERSION| ``must`` be installed.
+
+- `GatewayClass <https://gateway-api.sigs.k8s.io/reference/api-types/gatewayclass/>`_
+- `Gateway <https://gateway-api.sigs.k8s.io/reference/api-types/gateway/>`_
+- `HTTPRoute <https://gateway-api.sigs.k8s.io/reference/api-types/httproute/>`_
+- `GRPCRoute <https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute/>`_
+- `BackendTLSPolicy <https://gateway-api.sigs.k8s.io/reference/api-types/policy/backendtlspolicy/>`__
+- `ReferenceGrant <https://gateway-api.sigs.k8s.io/reference/api-types/referencegrant/>`_
+- `TLSRoute <https://gateway-api.sigs.k8s.io/reference/api-types/tlsroute/>`_
+
+Please refer to these `docs <https://gateway-api.sigs.k8s.io/guides/getting-started/introduction/#installing-gateway-api>`__
+for installation steps. Alternatively, the below snippet could be used.
+
+Note that the **experimental** release channel includes everything in the **standard**
+release channel plus some experimental resources and fields. If you need
+a feature that is currently marked as *experimental* (for example, HTTPRoute Retry in the ``HTTPRoute`` resource),
+you must install the corresponding CRDs. Please refer to `the experimental GEP list <https://gateway-api.sigs.k8s.io/geps/by-state/experimental/>`__
+for a full list of experimental features.
+
+If you are updating your current installation, make sure to always check the :ref:`admin_upgrade`
+first to review any breaking changes, deprecated features, or important configuration updates needed for the new version.
+For Cilium 1.20 upgrades, review the Gateway API v1.6.1 and ``TLSRoute`` notes in the upgrade guide before updating Gateway API CRDs.
+
+You can install the set of required CRDs like this:
+
+.. tabs::
+
+  .. group-tab:: Standard
+
+    .. parsed-literal::
+
+      kubectl apply --server-side -f |GATEWAY_API_RAW_BASE_URL|/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
+      kubectl apply --server-side -f |GATEWAY_API_RAW_BASE_URL|/config/crd/standard/gateway.networking.k8s.io_gateways.yaml
+      kubectl apply --server-side -f |GATEWAY_API_RAW_BASE_URL|/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml
+      kubectl apply --server-side -f |GATEWAY_API_RAW_BASE_URL|/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml
+      kubectl apply --server-side -f |GATEWAY_API_RAW_BASE_URL|/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml
+      kubectl apply --server-side -f |GATEWAY_API_RAW_BASE_URL|/config/crd/standard/gateway.networking.k8s.io_backendtlspolicies.yaml
+      kubectl apply --server-side -f |GATEWAY_API_RAW_BASE_URL|/config/crd/standard/gateway.networking.k8s.io_tlsroutes.yaml
+
+  .. group-tab:: Experimental
+
+    .. parsed-literal::
+
+      kubectl apply --server-side -f |GATEWAY_API_RAW_BASE_URL|/config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
+      kubectl apply --server-side -f |GATEWAY_API_RAW_BASE_URL|/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
+      kubectl apply --server-side -f |GATEWAY_API_RAW_BASE_URL|/config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
+      kubectl apply --server-side -f |GATEWAY_API_RAW_BASE_URL|/config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
+      kubectl apply --server-side -f |GATEWAY_API_RAW_BASE_URL|/config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+      kubectl apply --server-side -f |GATEWAY_API_RAW_BASE_URL|/config/crd/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
+      kubectl apply --server-side -f |GATEWAY_API_RAW_BASE_URL|/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+
+The `TCPRoute <https://gateway-api.sigs.k8s.io/reference/api-types/tcproute/>`__,
+`UDPRoute <https://gateway-api.sigs.k8s.io/reference/api-types/udproute/>`__,
+or `ListenerSet <https://gateway-api.sigs.k8s.io/reference/api-types/listenerset/>`__
+CRDs are optional and to use this functionality, you must install the corresponding CRD resources.
+If they are not installed, Cilium will disable support for these features.
+
+You can install the set of optional CRDs like this:
+
+.. tabs::
+
+  .. group-tab:: Standard
+
+    .. parsed-literal::
+
+      kubectl apply --server-side -f |GATEWAY_API_RAW_BASE_URL|/config/crd/standard/gateway.networking.k8s.io_listenersets.yaml
+      kubectl apply --server-side -f |GATEWAY_API_RAW_BASE_URL|/config/crd/standard/gateway.networking.k8s.io_tcproutes.yaml
+      kubectl apply --server-side -f |GATEWAY_API_RAW_BASE_URL|/config/crd/standard/gateway.networking.k8s.io_udproutes.yaml
+
+  .. group-tab:: Experimental
+
+    .. parsed-literal::
+
+      kubectl apply --server-side -f |GATEWAY_API_RAW_BASE_URL|/config/crd/experimental/gateway.networking.k8s.io_listenersets.yaml
+      kubectl apply --server-side -f |GATEWAY_API_RAW_BASE_URL|/config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
+      kubectl apply --server-side -f |GATEWAY_API_RAW_BASE_URL|/config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
+
+Once CRDs are installed, use Helm or Cilium CLI to enable Cilium Gateway API controller.
 
 .. tabs::
 
     .. group-tab:: Helm
 
+        .. include:: ../../../installation/cli-download.rst
+
         Cilium Gateway API Controller can be enabled with helm flag ``gatewayAPI.enabled``
-        set as true. Please refer to :ref:`k8s_install_helm` for a fresh installation.
+        set as ``true``. Please refer to :ref:`k8s_install_helm` for a fresh installation.
 
         .. cilium-helm-upgrade::
            :namespace: kube-system
@@ -107,11 +118,13 @@ Installation
 
     .. group-tab:: Cilium CLI
 
-        Cilium Gateway API Controller can be enabled with the below command
+        .. include:: ../../../installation/cli-download.rst
+
+        Cilium Gateway API Controller can be enabled with the below command.
 
         .. parsed-literal::
 
-            $ cilium install |CHART_VERSION| \\
+            $ cilium upgrade |CHART_VERSION| \\
                 --set kubeProxyReplacement=true \\
                 --set gatewayAPI.enabled=true
 


### PR DESCRIPTION
This commit updates the Gateway API installation guide:

- Move CRDs installation steps from prerequisites to the installation section.
- Remove Gateway CRDs from prerequisites as they are covered below.
- Add --server-side option for CRDs installation.
- Move Cilium CLI installation under Helm and Cilium CLI tabs to align with other guides.
- Replace TLS Route warning with a reference to the upgrade guide.

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
