### PR TITLE
bgp: register route-policy statedb only when BGP control plane enabled

### DIFF
--- a/pkg/bgp/cell.go
+++ b/pkg/bgp/cell.go
@@ -82,7 +82,14 @@ var Cell = cell.Module(
 	cell.Provide(
 		tables.NewBGPReconcileErrorTable,
 		tables.NewDesiredRoutePoliciesTable,
-		statedb.RWTable[*tables.DesiredRoutePolicy].ToTable,
+		func(t statedb.RWTable[*tables.DesiredRoutePolicy], dc *option.DaemonConfig) statedb.Table[*tables.DesiredRoutePolicy] {
+			// Do not create this resource if BGP Control Plane is disabled.
+			if !dc.BGPControlPlaneEnabled() {
+				return nil
+			}
+
+			return statedb.RWTable[*tables.DesiredRoutePolicy].ToTable(t)
+		},
 	),
 
 	// provide privates for reconciler v2

--- a/pkg/bgp/manager/reconciler/interface_test.go
+++ b/pkg/bgp/manager/reconciler/interface_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/bgp/types"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 func Test_InterfaceAdvertisement(t *testing.T) {
@@ -422,7 +423,10 @@ func Test_InterfaceAdvertisement(t *testing.T) {
 	db := statedb.New()
 	deviceTable, err := tables.NewDeviceTable(db)
 	req.NoError(err)
-	desiredRoutePolicyTable, err := bgpTables.NewDesiredRoutePoliciesTable(db)
+	dc := &option.DaemonConfig{
+		EnableBGPControlPlane: true,
+	}
+	desiredRoutePolicyTable, err := bgpTables.NewDesiredRoutePoliciesTable(db, dc)
 	req.NoError(err)
 
 	// initialize reconciler

--- a/pkg/bgp/manager/reconciler/pod_cidr_test.go
+++ b/pkg/bgp/manager/reconciler/pod_cidr_test.go
@@ -449,7 +449,10 @@ func Test_PodCIDRAdvertisement(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := require.New(t)
 			db := statedb.New()
-			desiredRoutePolicyTable, err := bgpTables.NewDesiredRoutePoliciesTable(db)
+			dc := &option.DaemonConfig{
+				EnableBGPControlPlane: true,
+			}
+			desiredRoutePolicyTable, err := bgpTables.NewDesiredRoutePoliciesTable(db, dc)
 			req.NoError(err)
 
 			// initialize pod cidr reconciler

--- a/pkg/bgp/manager/reconciler/pod_ip_pool_test.go
+++ b/pkg/bgp/manager/reconciler/pod_ip_pool_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 var (
@@ -603,7 +604,10 @@ func Test_PodIPPoolAdvertisements(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := require.New(t)
 			db := statedb.New()
-			desiredRoutePolicyTable, err := bgpTables.NewDesiredRoutePoliciesTable(db)
+			dc := &option.DaemonConfig{
+				EnableBGPControlPlane: true,
+			}
+			desiredRoutePolicyTable, err := bgpTables.NewDesiredRoutePoliciesTable(db, dc)
 			req.NoError(err)
 
 			params := PodIPPoolReconcilerIn{

--- a/pkg/bgp/manager/reconciler/route_policy.go
+++ b/pkg/bgp/manager/reconciler/route_policy.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/bgp/manager/instance"
 	"github.com/cilium/cilium/pkg/bgp/manager/tables"
 	"github.com/cilium/cilium/pkg/bgp/types"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 type RoutePolicyReconcilerOut struct {
@@ -31,6 +32,7 @@ type RoutePolicyReconcilerIn struct {
 	Logger                  *slog.Logger
 	DB                      *statedb.DB
 	DesiredRoutePolicyTable statedb.Table[*tables.DesiredRoutePolicy]
+	DaemonConfig            *option.DaemonConfig
 }
 
 type RoutePolicyReconciler struct {
@@ -48,6 +50,11 @@ type RoutePolicyReconcilerMetadata struct {
 }
 
 func NewRoutePolicyReconciler(params RoutePolicyReconcilerIn) RoutePolicyReconcilerOut {
+	// Do not create this resource if BGP Control Plane is disabled.
+	if !params.DaemonConfig.BGPControlPlaneEnabled() {
+		return RoutePolicyReconcilerOut{}
+	}
+
 	return RoutePolicyReconcilerOut{
 		Reconciler: &RoutePolicyReconciler{
 			logger:                  params.Logger.With(types.ReconcilerLogField, RoutePolicyReconcilerName),

--- a/pkg/bgp/manager/reconciler/route_policy_test.go
+++ b/pkg/bgp/manager/reconciler/route_policy_test.go
@@ -20,6 +20,7 @@ import (
 	bgpTables "github.com/cilium/cilium/pkg/bgp/manager/tables"
 	bgpmock "github.com/cilium/cilium/pkg/bgp/mock"
 	ciliumhive "github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 type routePolicyTestFixture struct {
@@ -61,6 +62,11 @@ func newRoutePolicyTestFixture(t testing.TB) *routePolicyTestFixture {
 	}
 	f.hive = ciliumhive.New(
 		cell.Provide(
+			func() *option.DaemonConfig {
+				return &option.DaemonConfig{
+					EnableBGPControlPlane: true,
+				}
+			},
 			bgpTables.NewDesiredRoutePoliciesTable,
 			statedb.RWTable[*bgpTables.DesiredRoutePolicy].ToTable,
 

--- a/pkg/bgp/manager/reconciler/service_test.go
+++ b/pkg/bgp/manager/reconciler/service_test.go
@@ -2839,6 +2839,9 @@ func newServiceTestFixture(t *testing.T, config option.BGPConfig) *svcTestFixtur
 					Logger:                  p.Logger,
 					DB:                      f.svcReconciler.db,
 					DesiredRoutePolicyTable: f.svcReconciler.desiredRoutePolicyTable,
+					DaemonConfig: &ciliumoption.DaemonConfig{
+						EnableBGPControlPlane: true,
+					},
 				}).Reconciler.(*RoutePolicyReconciler)
 			}),
 		),

--- a/pkg/bgp/manager/tables/route_policies.go
+++ b/pkg/bgp/manager/tables/route_policies.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/bgp/types"
 	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 const (
@@ -229,7 +230,12 @@ func DesiredRoutePoliciesByInstanceOwnerResource(instance string, owner string, 
 	})
 }
 
-func NewDesiredRoutePoliciesTable(db *statedb.DB) (statedb.RWTable[*DesiredRoutePolicy], error) {
+func NewDesiredRoutePoliciesTable(db *statedb.DB, dc *option.DaemonConfig) (statedb.RWTable[*DesiredRoutePolicy], error) {
+	// Do not create this resource if BGP Control Plane is disabled.
+	if !dc.BGPControlPlaneEnabled() {
+		return nil, nil
+	}
+
 	return statedb.NewTable(
 		db,
 		"bgp-desired-route-policies",


### PR DESCRIPTION
Only register route-policy statedb table and reconciler when BGP control plane enabled.

```release-note
bgp: register route-policy statedb only when BGP control plane enabled
```
