### PR TITLE
azure: stop redundant CiliumNode status writes on IPAM sync

### DIFF
--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -325,7 +325,7 @@ func parseInterface(logger *slog.Logger, iface *armnetwork.Interface, subnets ip
 	}
 
 	if iface.ID != nil {
-		i.SetID(*iface.ID)
+		i.ID = *iface.ID
 	}
 
 	if iface.Name != nil {

--- a/pkg/azure/api/api_test.go
+++ b/pkg/azure/api/api_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
-	// Required so SetID() resolves the Azure resource-ID parser.
-	_ "github.com/cilium/cilium/pkg/azure/types/azureid"
 	iputil "github.com/cilium/cilium/pkg/ip"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 )
@@ -156,6 +154,7 @@ func TestParseInterface(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, got := parseInterface(hivetest.Logger(t), tt.iface, tt.subnets, tt.usePrimary)
 			require.NotNil(t, got)
+			require.Equal(t, ifaceID, got.ID)
 			require.Equal(t, tt.expectedIP, got.IP)
 			require.Equal(t, tt.expectedSubnetID, got.Subnet.ID)
 			require.Equal(t, tt.expectedCIDR, got.Subnet.CIDR)

--- a/pkg/azure/api/mock/mock_test.go
+++ b/pkg/azure/api/mock/mock_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/azure/types"
-	// Register the Azure resource-ID parser so AzureInterface.SetID() can
-	// populate VMSS/VM/RG fields used by AssignPrivateIpAddressesVMSS lookup.
+	// Register the Azure resource-ID parser so AzureInterface.GetVMID()
+	// resolves, which the AssignPrivateIpAddressesVMSS lookup compares against.
 	_ "github.com/cilium/cilium/pkg/azure/types/azureid"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 )
@@ -36,7 +36,7 @@ func TestMock(t *testing.T) {
 	ifaceID := "/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm1/networkInterfaces/vmss11"
 	instances = ipamTypes.NewInstanceMap()
 	resource := &types.AzureInterface{Name: "eth0"}
-	resource.SetID(ifaceID)
+	resource.ID = ifaceID
 	instances.Update("vm1", resource.DeepCopy())
 	api.UpdateInstances(instances)
 	nics, err = api.ListAllNetworkInterfaces(t.Context())
@@ -68,7 +68,7 @@ func TestMock(t *testing.T) {
 	vmIfaceID := "/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Network/networkInterfaces/vm22-if"
 	vmInstances := ipamTypes.NewInstanceMap()
 	resource = &types.AzureInterface{Name: "eth0"}
-	resource.SetID(vmIfaceID)
+	resource.ID = vmIfaceID
 	vmInstances.Update("vm2", resource.DeepCopy())
 	require.NoError(t, err)
 	require.Equal(t, 1, vmInstances.NumInstances())

--- a/pkg/azure/ipam/instances.go
+++ b/pkg/azure/ipam/instances.go
@@ -16,9 +16,8 @@ import (
 	"github.com/cilium/cilium/operator/pkg/ipam/nodemanager"
 	"github.com/cilium/cilium/pkg/azure/types"
 
-	// Register the Azure resource-ID parser. This is the canonical place
-	// for Azure-IPAM-enabled binaries to wire in pkg/azure/types' parser
-	// so AzureInterface.SetID() can populate the VMSS/VM/RG fields.
+	// Registers the Azure resource-ID parser used by AzureInterface's VMSS/VM
+	// getters.
 	_ "github.com/cilium/cilium/pkg/azure/types/azureid"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"

--- a/pkg/azure/ipam/instances_test.go
+++ b/pkg/azure/ipam/instances_test.go
@@ -79,7 +79,7 @@ func iteration1(t *testing.T, api *apimock.API, mngr *InstancesManager) {
 		},
 		State: types.StateSucceeded,
 	}
-	resource.SetID("intf-1")
+	resource.ID = "intf-1"
 	instances.Update("i-1", resource.DeepCopy())
 
 	resource = &types.AzureInterface{
@@ -93,7 +93,7 @@ func iteration1(t *testing.T, api *apimock.API, mngr *InstancesManager) {
 		},
 		State: types.StateSucceeded,
 	}
-	resource.SetID("intf-3")
+	resource.ID = "intf-3"
 	instances.Update("i-2", resource.DeepCopy())
 
 	api.UpdateInstances(instances)
@@ -117,7 +117,7 @@ func iteration2(t *testing.T, api *apimock.API, mngr *InstancesManager) {
 		},
 		State: types.StateSucceeded,
 	}
-	resource.SetID("intf-1")
+	resource.ID = "intf-1"
 	instances.Update("i-1", resource.DeepCopy())
 
 	resource = &types.AzureInterface{
@@ -131,7 +131,7 @@ func iteration2(t *testing.T, api *apimock.API, mngr *InstancesManager) {
 		},
 		State: types.StateSucceeded,
 	}
-	resource.SetID("intf-2")
+	resource.ID = "intf-2"
 	instances.Update("i-1", resource.DeepCopy())
 
 	resource = &types.AzureInterface{
@@ -145,7 +145,7 @@ func iteration2(t *testing.T, api *apimock.API, mngr *InstancesManager) {
 		},
 		State: types.StateSucceeded,
 	}
-	resource.SetID("intf-3")
+	resource.ID = "intf-3"
 	instances.Update("i-2", resource.DeepCopy())
 
 	api.UpdateInstances(instances)
@@ -211,7 +211,7 @@ func TestResyncInstancePreservesOtherNodesSubnets(t *testing.T) {
 		},
 		State: types.StateSucceeded,
 	}
-	iface1.SetID("intf-vm-1")
+	iface1.ID = "intf-vm-1"
 	instances.Update("vm-1", iface1.DeepCopy())
 
 	iface2 := &types.AzureInterface{
@@ -225,7 +225,7 @@ func TestResyncInstancePreservesOtherNodesSubnets(t *testing.T) {
 		},
 		State: types.StateSucceeded,
 	}
-	iface2.SetID("intf-vm-2")
+	iface2.ID = "intf-vm-2"
 	instances.Update("vm-2", iface2.DeepCopy())
 
 	api.UpdateInstances(instances)
@@ -278,7 +278,7 @@ func TestExtractSubnetIDs(t *testing.T) {
 				},
 			},
 		}
-		resource.SetID(interfaceID)
+		resource.ID = interfaceID
 
 		instances.Update(instanceID, resource.DeepCopy())
 	}

--- a/pkg/azure/ipam/ipam_test.go
+++ b/pkg/azure/ipam/ipam_test.go
@@ -161,7 +161,7 @@ func TestIpamPreAllocate8(t *testing.T) {
 		},
 		State: types.StateSucceeded,
 	}
-	resource.SetID("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm1/networkInterfaces/vmss11")
+	resource.ID = "/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm1/networkInterfaces/vmss11"
 	vm1ID := "/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm1"
 	m.Update(vm1ID, resource.DeepCopy())
 	api.UpdateInstances(m)
@@ -223,7 +223,7 @@ func TestIpamMinAllocate10(t *testing.T) {
 		},
 		State: types.StateSucceeded,
 	}
-	resource.SetID("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm1/networkInterfaces/vmss11")
+	resource.ID = "/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm1/networkInterfaces/vmss11"
 	vm1ID := "/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm1"
 	m.Update(vm1ID, resource.DeepCopy())
 	api.UpdateInstances(m)
@@ -315,7 +315,7 @@ func TestIpamManyNodes(t *testing.T) {
 					},
 					State: types.StateSucceeded,
 				}
-				resource.SetID(fmt.Sprintf("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm%d/networkInterfaces/vmss11", i))
+				resource.ID = fmt.Sprintf("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm%d/networkInterfaces/vmss11", i)
 				allInstances.Update(fmt.Sprintf("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm%d", i), resource.DeepCopy())
 			}
 
@@ -386,7 +386,7 @@ func benchmarkAllocWorker(b *testing.B, workers int64, delay time.Duration, rate
 			Addresses:     []types.AzureAddress{},
 			State:         types.StateSucceeded,
 		}
-		resource.SetID(fmt.Sprintf("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm%d/networkInterfaces/vmss11", i))
+		resource.ID = fmt.Sprintf("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm%d/networkInterfaces/vmss11", i)
 		allInstances.Update(fmt.Sprintf("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm%d", i), resource.DeepCopy())
 	}
 

--- a/pkg/azure/ipam/node.go
+++ b/pkg/azure/ipam/node.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net/netip"
+	"slices"
+	"strings"
 
 	"github.com/cilium/cilium/operator/pkg/ipam/nodemanager"
 	"github.com/cilium/cilium/operator/pkg/ipam/stats"
@@ -43,19 +45,39 @@ func (n *Node) UpdatedNode(obj *v2.CiliumNode) {
 }
 
 // PopulateStatusFields fills in the status field of the CiliumNode custom
-// resource with Azure specific information
+// resource with Azure specific information.
+//
+// ForeachInterface iterates a map and Azure does not document an order for an
+// interface's IP configurations, so both levels are sorted: an unchanged node
+// then compares equal in ciliumNodeUpdateImplementation.UpdateStatus and the
+// /status write is skipped. ID and IP are each unique within their scope, so
+// sorting on them alone is deterministic.
 func (n *Node) PopulateStatusFields(k8sObj *v2.CiliumNode) {
-	k8sObj.Status.Azure.Interfaces = []types.AzureInterface{}
+	interfaces := []types.AzureInterface{}
 
 	n.manager.mutex.RLock()
 	defer n.manager.mutex.RUnlock()
 	n.manager.instances.ForeachInterface(n.node.InstanceID(), func(instanceID, interfaceID string, interfaceObj ipamTypes.Interface) error {
 		iface, ok := interfaceObj.(*types.AzureInterface)
-		if ok {
-			k8sObj.Status.Azure.Interfaces = append(k8sObj.Status.Azure.Interfaces, *(iface.DeepCopy()))
+		if !ok {
+			return nil
 		}
+		// Copied because the sorts below mutate in place and the instance
+		// cache is only read locked.
+		interfaces = append(interfaces, *iface.DeepCopy())
 		return nil
 	})
+
+	// ID alone is a total order: it is the instance's interface map key.
+	slices.SortFunc(interfaces, func(a, b types.AzureInterface) int {
+		return strings.Compare(a.ID, b.ID)
+	})
+	for i := range interfaces {
+		slices.SortFunc(interfaces[i].Addresses, func(a, b types.AzureAddress) int {
+			return a.IP.Addr.Compare(b.IP.Addr)
+		})
+	}
+	k8sObj.Status.Azure.Interfaces = interfaces
 }
 
 // PrepareIPRelease prepares the release of IPs

--- a/pkg/azure/ipam/node.go
+++ b/pkg/azure/ipam/node.go
@@ -156,10 +156,11 @@ func (n *Node) AllocateIPs(ctx context.Context, a *nodemanager.AllocationAction)
 		return fmt.Errorf("invalid interface object")
 	}
 
-	if iface.GetVMScaleSetName() == "" {
+	vmss := iface.GetVMScaleSetName()
+	if vmss == "" {
 		return n.manager.api.AssignPrivateIpAddressesVM(ctx, string(a.PoolID), iface.Name, a.IPv4.AvailableForAllocation)
 	} else {
-		return n.manager.api.AssignPrivateIpAddressesVMSS(ctx, iface.GetVMID(), iface.GetVMScaleSetName(), string(a.PoolID), iface.Name, a.IPv4.AvailableForAllocation)
+		return n.manager.api.AssignPrivateIpAddressesVMSS(ctx, iface.GetVMID(), vmss, string(a.PoolID), iface.Name, a.IPv4.AvailableForAllocation)
 	}
 }
 

--- a/pkg/azure/ipam/node_stats_test.go
+++ b/pkg/azure/ipam/node_stats_test.go
@@ -54,7 +54,7 @@ func newCapacityTestInterface(name, id, primaryIP string, secondaryIPs ...string
 		Addresses:     addrs,
 		State:         types.StateSucceeded,
 	}
-	iface.SetID(id)
+	iface.ID = id
 	return iface
 }
 

--- a/pkg/azure/ipam/node_test.go
+++ b/pkg/azure/ipam/node_test.go
@@ -4,14 +4,96 @@
 package ipam
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/azure/types"
+	iputil "github.com/cilium/cilium/pkg/ip"
+	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 )
 
 func TestGetMaximumAllocatableIPv4(t *testing.T) {
 	n := &Node{}
 	require.Equal(t, types.InterfaceAddressLimit, n.GetMaximumAllocatableIPv4())
+}
+
+const statusTestIDFormat = "/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/%s"
+
+// SecurityGroup collates inversely to ID, so sorting by the wrong field shows up.
+func newStatusTestInterfaces() []*types.AzureInterface {
+	names := []string{"nic-c", "nic-a", "nic-b"}
+	var ifaces []*types.AzureInterface
+	for i, name := range names {
+		ifaces = append(ifaces, &types.AzureInterface{
+			ID:            fmt.Sprintf(statusTestIDFormat, name),
+			SecurityGroup: fmt.Sprintf("sg-%d", len(names)-i),
+			Addresses: []types.AzureAddress{
+				{IP: iputil.AddrFrom(netip.MustParseAddr("10.0.0.2")), State: types.StateSucceeded},
+				{IP: iputil.AddrFrom(netip.MustParseAddr("10.0.0.1")), State: types.StateSucceeded},
+				{IP: iputil.AddrFrom(netip.MustParseAddr("10.0.0.3")), State: types.StateSucceeded},
+			},
+		})
+	}
+	return ifaces
+}
+
+// Repeated calls must produce an identical status, and it must match the copy
+// the operator reads back from the apiserver, or
+// ciliumNodeUpdateImplementation.UpdateStatus writes /status on every sync.
+func TestPopulateStatusFieldsDeterministicOrder(t *testing.T) {
+	node := newCapacityTestNode(t, newStatusTestInterfaces(), false)
+
+	wantIDs := make([]string, 0, 3)
+	for _, name := range []string{"nic-a", "nic-b", "nic-c"} {
+		wantIDs = append(wantIDs, fmt.Sprintf(statusTestIDFormat, name))
+	}
+
+	// The sorts run in place, so they must operate on copies: the instance
+	// cache is shared between nodes and only read locked.
+	cached := map[string]*types.AzureInterface{}
+	node.manager.instances.ForeachInterface("vm1", func(_, id string, obj ipamTypes.Interface) error {
+		cached[id] = obj.(*types.AzureInterface).DeepCopy()
+		return nil
+	})
+	require.Len(t, cached, 3)
+
+	fromAPIServer := &v2.CiliumNode{}
+	node.PopulateStatusFields(fromAPIServer)
+	marshalled, err := json.Marshal(fromAPIServer)
+	require.NoError(t, err)
+	fromAPIServer = &v2.CiliumNode{}
+	require.NoError(t, json.Unmarshal(marshalled, fromAPIServer))
+
+	// ForeachInterface's map iteration order is randomized per call.
+	for i := range 10 {
+		k8sObj := &v2.CiliumNode{}
+		node.PopulateStatusFields(k8sObj)
+
+		got := k8sObj.Status.Azure.Interfaces
+		ids := make([]string, 0, len(got))
+		for _, iface := range got {
+			ids = append(ids, iface.ID)
+
+			addrs := make([]string, 0, len(iface.Addresses))
+			for _, addr := range iface.Addresses {
+				addrs = append(addrs, addr.IP.String())
+			}
+			require.Equal(t, []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}, addrs, "iteration %d", i)
+		}
+		require.Equal(t, wantIDs, ids, "iteration %d", i)
+
+		require.True(t, fromAPIServer.Status.DeepEqual(&k8sObj.Status),
+			"iteration %d: no-op sync differs from the apiserver copy, forcing a /status write", i)
+	}
+
+	node.manager.instances.ForeachInterface("vm1", func(_, id string, obj ipamTypes.Interface) error {
+		require.True(t, cached[id].DeepEqual(obj.(*types.AzureInterface)),
+			"cached interface %s mutated by PopulateStatusFields", id)
+		return nil
+	})
 }

--- a/pkg/azure/types/azureid/azureid.go
+++ b/pkg/azure/types/azureid/azureid.go
@@ -9,8 +9,8 @@
 // pkg/azure/types via CiliumNode's AzureSpec).
 //
 // On import, this package registers Parse with pkg/azure/types so that
-// AzureInterface.SetID() can extract the resource group, VMSS name, and VM ID
-// from a network interface resource ID.
+// AzureInterface's GetResourceGroup(), GetVMScaleSetName(), and GetVMID() can
+// derive their values from the network interface resource ID.
 package azureid
 
 import (

--- a/pkg/azure/types/extract_ids.go
+++ b/pkg/azure/types/extract_ids.go
@@ -8,7 +8,7 @@ package types
 // from pkg/azure/types/azureid (which uses the Azure SDK) so that pkg/azure/types
 // itself does not transitively pull the Azure SDK into every consumer of
 // CiliumNode (which embeds AzureSpec). Non-Azure binaries leave this stub in
-// place; they never call extractIDs() on real Azure resource IDs.
+// place.
 var resourceIDParser = func(_ string) (resourceGroup, vmssName, vmID string) {
 	return "", "", ""
 }

--- a/pkg/azure/types/types.go
+++ b/pkg/azure/types/types.go
@@ -74,6 +74,10 @@ type AzureSubnet struct {
 	CIDR iputil.Prefix `json:"cidr,omitzero"`
 }
 
+// Every field must be exported and JSON-serialized; see
+// TestAzureStatusHasNoUnserializedState. Kept out of the doc comment so it
+// stays out of the generated CRD description.
+
 // AzureInterface represents an Azure Interface
 type AzureInterface struct {
 	// ID is the identifier
@@ -121,27 +125,10 @@ type AzureInterface struct {
 	//
 	// +optional
 	Gateway iputil.Addr `json:"gateway"`
-
-	// vmssName is the name of the virtual machine scale set. This field is
-	// set by extractIDs()
-	vmssName string `json:"-"`
-
-	// vmID is the ID of the virtual machine
-	vmID string `json:"-"`
-
-	// resourceGroup is the resource group the interface belongs to
-	resourceGroup string `json:"-"`
 }
 
 func (a *AzureInterface) DeepCopyInterface() types.Interface {
 	return a.DeepCopy()
-}
-
-// SetID sets the Azure interface ID, as well as extracting other fields from
-// the ID itself.
-func (a *AzureInterface) SetID(id string) {
-	a.ID = id
-	a.extractIDs()
 }
 
 // InterfaceID returns the identifier of the interface
@@ -149,25 +136,20 @@ func (a *AzureInterface) InterfaceID() string {
 	return a.ID
 }
 
-// extractIDs extracts resource group name, VMSS name, and VM ID from the
-// network interface Azure resource ID. The actual implementation is build-tag
-// gated so the Azure SDK is only pulled in by builds that need it (see
-// extract_ids.go).
-func (a *AzureInterface) extractIDs() {
-	a.resourceGroup, a.vmssName, a.vmID = parseAzureResourceID(a.ID)
-}
-
 // GetResourceGroup returns the resource group the interface belongs to
 func (a *AzureInterface) GetResourceGroup() string {
-	return a.resourceGroup
+	resourceGroup, _, _ := parseAzureResourceID(a.ID)
+	return resourceGroup
 }
 
 // GetVMScaleSetName returns the VM scale set name the interface belongs to
 func (a *AzureInterface) GetVMScaleSetName() string {
-	return a.vmssName
+	_, vmssName, _ := parseAzureResourceID(a.ID)
+	return vmssName
 }
 
 // GetVMID returns the VM ID the interface belongs to
 func (a *AzureInterface) GetVMID() string {
-	return a.vmID
+	_, _, vmID := parseAzureResourceID(a.ID)
+	return vmID
 }

--- a/pkg/azure/types/types_test.go
+++ b/pkg/azure/types/types_test.go
@@ -4,15 +4,75 @@
 package types_test
 
 import (
+	"encoding/json"
+	"net/netip"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/azure/types"
-	// Register the Azure resource-ID parser so SetID()/extractIDs() populate
-	// the VMSS/VM/RG fields exercised by TestExtractIDs.
+	// Register the Azure resource-ID parser used by TestExtractIDs.
 	_ "github.com/cilium/cilium/pkg/azure/types/azureid"
+	iputil "github.com/cilium/cilium/pkg/ip"
 )
+
+// State that does not serialize forces a /status write on every IPAM sync.
+func TestAzureStatusHasNoUnserializedState(t *testing.T) {
+	status := reflect.TypeFor[types.AzureStatus]()
+
+	queue := []reflect.Type{status}
+	for len(queue) > 0 {
+		ty := queue[0]
+		queue = queue[1:]
+
+		for ty.Kind() == reflect.Pointer || ty.Kind() == reflect.Slice || ty.Kind() == reflect.Array || ty.Kind() == reflect.Map {
+			ty = ty.Elem()
+		}
+		// iputil's wrappers serialize through MarshalText, so the unexported
+		// state they keep is legitimate.
+		if ty.Kind() != reflect.Struct || ty.PkgPath() != status.PkgPath() {
+			continue
+		}
+		for field := range ty.Fields() {
+			require.True(t, field.IsExported(), "%s.%s is unexported", ty.Name(), field.Name)
+			require.NotEqual(t, "-", field.Tag.Get("json"), "%s.%s is excluded from JSON", ty.Name(), field.Name)
+			queue = append(queue, field.Type)
+		}
+	}
+}
+
+// A round trip must not perturb the interface, or the write-skip gate breaks.
+func TestAzureInterfaceJSONRoundTrip(t *testing.T) {
+	base := &types.AzureInterface{
+		ID:            "/subscriptions/xxx/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss1/virtualMachines/0/networkInterfaces/vmss1",
+		IP:            iputil.AddrFrom(netip.MustParseAddr("10.0.0.1")),
+		Name:          "eth0",
+		MAC:           "aa:bb:cc:dd:ee:ff",
+		State:         "succeeded",
+		SecurityGroup: "sg1",
+		Addresses: []types.AzureAddress{
+			{IP: iputil.AddrFrom(netip.MustParseAddr("10.0.0.2")), State: "succeeded"},
+			{IP: iputil.AddrFrom(netip.MustParseAddr("10.0.0.3")), State: "succeeded"},
+		},
+		Subnet:  types.AzureSubnet{ID: "s-1", CIDR: iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.0/24"))},
+		Gateway: iputil.AddrFrom(netip.MustParseAddr("10.0.0.1")),
+	}
+
+	marshalled, err := json.Marshal(base)
+	require.NoError(t, err)
+	var roundTripped types.AzureInterface
+	require.NoError(t, json.Unmarshal(marshalled, &roundTripped))
+
+	require.Equal(t, *base, roundTripped)
+	require.True(t, base.DeepEqual(&roundTripped))
+
+	// Reordering must be visible to DeepEqual, or sorting the addresses in
+	// PopulateStatusFields would be pointless.
+	reordered := roundTripped.DeepCopy()
+	reordered.Addresses[0], reordered.Addresses[1] = reordered.Addresses[1], reordered.Addresses[0]
+	require.False(t, base.DeepEqual(reordered))
+}
 
 func TestExtractIDs(t *testing.T) {
 	tests := []struct {
@@ -36,12 +96,18 @@ func TestExtractIDs(t *testing.T) {
 			expectedVMID:     "",
 			expectedVMSSName: "",
 		},
+		{
+			name:       "Unparseable resource ID",
+			resourceID: "intf-1",
+		},
+		{
+			name: "Empty resource ID",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			intf := types.AzureInterface{}
-			intf.SetID(tt.resourceID)
+			intf := types.AzureInterface{ID: tt.resourceID}
 
 			require.Equal(t, tt.expectedRG, intf.GetResourceGroup())
 			require.Equal(t, tt.expectedVMID, intf.GetVMID())

--- a/pkg/azure/types/zz_generated.deepequal.go
+++ b/pkg/azure/types/zz_generated.deepequal.go
@@ -77,16 +77,6 @@ func (in *AzureInterface) DeepEqual(other *AzureInterface) bool {
 		return false
 	}
 
-	if in.vmssName != other.vmssName {
-		return false
-	}
-	if in.vmID != other.vmID {
-		return false
-	}
-	if in.resourceGroup != other.resourceGroup {
-		return false
-	}
-
 	return true
 }
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

On the Azure IPAM path, the operator rewrote CiliumNode `/status` on every sync tick even when nothing had changed. The operator only writes when the status it builds differs from the copy it read back from the apiserver, and two independent things made an unchanged node look different every time:

1. **Nondeterministic ordering.** `PopulateStatusFields` builds `Status.Azure.Interfaces` by appending inside `ForeachInterface`, which iterates a Go map, so the interface order changed between syncs. The Azure API also documents no order for an interface's IP configurations. Both slices are compared element by element, so a reordered-but-identical set compares unequal.

2. **State that does not survive the apiserver.** `AzureInterface` cached the resource group, VMSS name and VM ID in unexported `json:"-"` fields populated from the interface ID. An interface freshly built from the Azure API carried them; the copy read back from the apiserver never could, so the two were never equal.

The first commit sorts the interfaces by ID and their addresses by IP and state. The second drops the three cached fields and derives those values from `ID` on demand — they are cheap to parse and are not read on a hot path — which also removes `SetID()`, since it then only assigned `ID`.

To test, I've built and deployed this to an Azure IPAM cluster. As shown below, we see a substantial drop in kube-apiserver writes as a result:


Kubernetes Audit events showing all update calls from the cilium-operator before and after this change:
<img width="2024" height="548" alt="% decrease — operator CiliumNode updates (diglet, vs previous day)" src="https://github.com/user-attachments/assets/7b805acf-2159-4faa-ba63-23ee216a9628" />
<img width="2024" height="548" alt="k8s_cluster_fqdn_diglet us3 staging dog @usr id__system_serviceaccount_diglet-k8s_cilium-operator_ @http method_update" src="https://github.com/user-attachments/assets/27736d32-2f07-4934-998d-4fe1ad03098d" />

Tracing showing difference before (light blue) and after (dark blue) of the cilium-operator PUT's to `cilium.io/v2/ciliumnodes/{name}/status` or `cilium.io/v2/ciliumnodes/{name}`  
<img width="2024" height="548" alt="Traces matching_ a   b, count__" src="https://github.com/user-attachments/assets/b9c182f5-2bf8-4110-8d75-409bdb70442e" />


```release-note
azure: Stop issuing redundant CiliumNode status updates on every IPAM sync when the node's Azure interfaces are unchanged.
```

### AI usage disclosure

This PR was prepared with AIL:3. I used Claude Code to investigate and identify the two root causes. I directed the scope and have reviewed the entire change. I've validated it on a live Azure cluster.

