### PR TITLE
cilium-cli/clustermesh: Fix bad type for service type

### DIFF
--- a/cilium-cli/clustermesh/clustermesh.go
+++ b/cilium-cli/clustermesh/clustermesh.go
@@ -1005,7 +1005,7 @@ func generateEnableHelmValues(params Parameters, flavor k8s.Flavor) (map[string]
 			log("🔮 Auto-exposing service within GCP VPC (networking.gke.io/load-balancer-type=Internal)")
 			helmVals["clustermesh"].(map[string]any)["apiserver"] = map[string]any{
 				"service": map[string]any{
-					"type": corev1.ServiceTypeLoadBalancer,
+					"type": string(corev1.ServiceTypeLoadBalancer),
 					"annotations": map[string]any{
 						"networking.gke.io/load-balancer-type": "Internal",
 						// Allows cross-region access
@@ -1017,7 +1017,7 @@ func generateEnableHelmValues(params Parameters, flavor k8s.Flavor) (map[string]
 			log("🔮 Auto-exposing service within Azure VPC (service.beta.kubernetes.io/azure-load-balancer-internal)")
 			helmVals["clustermesh"].(map[string]any)["apiserver"] = map[string]any{
 				"service": map[string]any{
-					"type": corev1.ServiceTypeLoadBalancer,
+					"type": string(corev1.ServiceTypeLoadBalancer),
 					"annotations": map[string]any{
 						"service.beta.kubernetes.io/azure-load-balancer-internal": "true",
 					},
@@ -1027,7 +1027,7 @@ func generateEnableHelmValues(params Parameters, flavor k8s.Flavor) (map[string]
 			log("🔮 Auto-exposing service within AWS VPC (service.beta.kubernetes.io/aws-load-balancer-scheme: internal")
 			helmVals["clustermesh"].(map[string]any)["apiserver"] = map[string]any{
 				"service": map[string]any{
-					"type": corev1.ServiceTypeLoadBalancer,
+					"type": string(corev1.ServiceTypeLoadBalancer),
 					"annotations": map[string]any{
 						"service.beta.kubernetes.io/aws-load-balancer-scheme": "internal",
 					},


### PR DESCRIPTION
Helm expects /clustermesh/apiserver/service/type to be a string according to [install/kubernetes/cilium/values.schema.json:1404,](https://github.com/cilium/cilium/blob/4d55bb2db33c429cfdf5734e1c95d0b5ec03565c/install/kubernetes/cilium/values.schema.json#L1404) but it was passed as a v1.ServiceType causing the following error:

```
cilium clustermesh enable --context cluster1
🔮 Auto-exposing service within Azure VPC (service.beta.kubernetes.io/azure-load-balancer-internal)

Error: Unable to enable ClusterMesh: values don't meet the specifications of the schema(s) in the following chart(s):
cilium:
- at '/clustermesh/apiserver/service/type': invalid jsonType v1.ServiceType
```

This is fixed by casting it to a string.

Fixes: 290612f39a Update module helm.sh/helm/v3 to v3.18.5 [SECURITY]

```release-note
cilium-cli: Fix clustermesh enable command on cloud providers
```

--- 

Notes for reviewers:
- Please double check it as I'm surprised nobody has reported it in 2 years
- Opening as draft because I reached the max open PR limit 