### PR TITLE
gateway-api: prevent conflicted listener ingestion

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -742,9 +742,15 @@ func (r *gatewayReconciler) resolveAllowedListeners(
 	gw *gatewayv1.Gateway,
 ) ([]ingestion.ListenerWithContext, []gatewayv1.ListenerSet, error) {
 	gwSource := gatewayFQR(gw)
+	conflictedListeners := conflictedGatewayListeners(gw)
 
 	var merged []ingestion.ListenerWithContext
 	for _, l := range gw.Spec.Listeners {
+		// Conflicted listeners are rejected in Gateway status and must not be
+		// included in the model passed to the translation pipeline.
+		if _, conflicted := conflictedListeners[l.Name]; conflicted {
+			continue
+		}
 		merged = append(merged, ingestion.ListenerWithContext{
 			Listener: l,
 			Source:   gwSource,

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -124,11 +124,17 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 	}
 
-	mergedListeners, attachedListenerSets, err := r.resolveAllowedListeners(ctx, scopedLog, gw)
-	if err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to resolve allowed ListenerSet listeners", logfields.Error, err)
-		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+	var attachedListenerSets []gatewayv1.ListenerSet
+	if helpers.HasListenerSetSupport(r.Client.Scheme()) {
+		listenerSets, err := r.listenerSetsForGateway(ctx, gw)
+		if err != nil {
+			scopedLog.ErrorContext(ctx, "Unable to list ListenerSets", logfields.Error, err)
+			return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+		}
+		attachedListenerSets = r.filterAllowedListenerSets(ctx, scopedLog, gw, listenerSets)
 	}
+	mergedListeners := r.mergeListeners(ctx, scopedLog, gw, attachedListenerSets)
+	mergedListeners = filterConflictingListeners(gw, mergedListeners)
 
 	httpRouteList := &gatewayv1.HTTPRouteList{}
 	if err := r.Client.List(ctx, httpRouteList, &client.ListOptions{
@@ -736,43 +742,30 @@ func (r *gatewayReconciler) updateListenerSetStatus(ctx context.Context, origina
 	return r.Client.Status().Update(ctx, new)
 }
 
-func (r *gatewayReconciler) resolveAllowedListeners(
+func (r *gatewayReconciler) listenerSetsForGateway(
 	ctx context.Context,
-	scopedLog *slog.Logger,
 	gw *gatewayv1.Gateway,
-) ([]ingestion.ListenerWithContext, []gatewayv1.ListenerSet, error) {
-	gwSource := gatewayFQR(gw)
-	conflictedListeners := conflictedGatewayListeners(gw)
-
-	var merged []ingestion.ListenerWithContext
-	for _, l := range gw.Spec.Listeners {
-		// Conflicted listeners are rejected in Gateway status and must not be
-		// included in the model passed to the translation pipeline.
-		if _, conflicted := conflictedListeners[l.Name]; conflicted {
-			continue
-		}
-		merged = append(merged, ingestion.ListenerWithContext{
-			Listener: l,
-			Source:   gwSource,
-		})
-	}
-
-	if !helpers.HasListenerSetSupport(r.Client.Scheme()) {
-		return merged, nil, nil
-	}
-
+) ([]gatewayv1.ListenerSet, error) {
 	lsList := &gatewayv1.ListenerSetList{}
 	if err := r.Client.List(ctx, lsList, &client.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector(indexers.ListenerSetGatewayIndex, client.ObjectKeyFromObject(gw).String()),
 	}); err != nil {
-		return nil, nil, fmt.Errorf("failed to list ListenerSets: %w", err)
+		return nil, fmt.Errorf("failed to list ListenerSets: %w", err)
 	}
 
 	sortListenerSets(lsList.Items)
+	return lsList.Items, nil
+}
 
-	var attachedSets []gatewayv1.ListenerSet
-	for i := range lsList.Items {
-		ls := &lsList.Items[i]
+func (r *gatewayReconciler) filterAllowedListenerSets(
+	ctx context.Context,
+	scopedLog *slog.Logger,
+	gw *gatewayv1.Gateway,
+	listenerSets []gatewayv1.ListenerSet,
+) []gatewayv1.ListenerSet {
+	var allowed []gatewayv1.ListenerSet
+	for i := range listenerSets {
+		ls := &listenerSets[i]
 		if !isListenerSetAllowed(ctx, r.Client, gw, ls, scopedLog) {
 			original := ls.DeepCopy()
 			setListenerSetAccepted(ls, false, "ListenerSet is not allowed by the Gateway's allowedListeners policy", gatewayv1.ListenerSetReasonNotAllowed)
@@ -782,8 +775,29 @@ func (r *gatewayReconciler) resolveAllowedListeners(
 			}
 			continue
 		}
-		attachedSets = append(attachedSets, *ls)
+		allowed = append(allowed, *ls)
+	}
+	return allowed
+}
 
+func (r *gatewayReconciler) mergeListeners(
+	ctx context.Context,
+	scopedLog *slog.Logger,
+	gw *gatewayv1.Gateway,
+	listenerSets []gatewayv1.ListenerSet,
+) []ingestion.ListenerWithContext {
+	gwSource := gatewayFQR(gw)
+
+	var merged []ingestion.ListenerWithContext
+	for _, listener := range gw.Spec.Listeners {
+		merged = append(merged, ingestion.ListenerWithContext{
+			Listener: listener,
+			Source:   gwSource,
+		})
+	}
+
+	for i := range listenerSets {
+		ls := &listenerSets[i]
 		lsSource := listenerSetFQR(ls)
 		for _, entry := range ls.Spec.Listeners {
 			listener := helpers.ListenerEntryToListener(entry)
@@ -795,7 +809,29 @@ func (r *gatewayReconciler) resolveAllowedListeners(
 		}
 	}
 
-	return merged, attachedSets, nil
+	return merged
+}
+
+func filterConflictingListeners(
+	gw *gatewayv1.Gateway,
+	listeners []ingestion.ListenerWithContext,
+) []ingestion.ListenerWithContext {
+	conflictedGatewayListeners := conflictedGatewayListeners(gw)
+	accepted := &acceptedListeners{}
+	filtered := make([]ingestion.ListenerWithContext, 0, len(listeners))
+	for _, listener := range listeners {
+		if listener.Source.Kind == "Gateway" {
+			if _, conflicted := conflictedGatewayListeners[listener.Name]; conflicted {
+				continue
+			}
+		}
+		if accepted.checkConflict(listener.Listener) != "" {
+			continue
+		}
+		accepted.accept(listener.Listener)
+		filtered = append(filtered, listener)
+	}
+	return filtered
 }
 
 // resolveAllowedNamespaces resolves a listener's allowedRoutes.namespaces policy

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -799,7 +799,7 @@ func (r *gatewayReconciler) mergeListeners(
 	for i := range listenerSets {
 		ls := &listenerSets[i]
 		lsSource := listenerSetFQR(ls)
-		for _, entry := range ls.Spec.Listeners {
+		for _, entry := range sortedListenerEntries(ls.Spec.Listeners) {
 			listener := helpers.ListenerEntryToListener(entry)
 			merged = append(merged, ingestion.ListenerWithContext{
 				Listener:          listener,
@@ -1625,7 +1625,7 @@ func (r *gatewayReconciler) setListenerSetStatuses(
 		oneValidListener := false
 		var listenerStatuses []gatewayv1.ListenerEntryStatus
 
-		for _, entry := range ls.Spec.Listeners {
+		for _, entry := range sortedListenerEntries(ls.Spec.Listeners) {
 			l := helpers.ListenerEntryToListener(entry)
 			var conds []metav1.Condition
 

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -364,6 +364,9 @@ func Test_Conformance(t *testing.T) {
 		{name: "listenerset-hostname-conflict", skipCEC: true, gateway: []gwDetails{
 			{FullName: types.NamespacedName{Name: "hostname-conflict", Namespace: "gateway-conformance-infra"}},
 		}},
+		{name: "listenerset-tls-protocol-conflict", gateway: []gwDetails{
+			{FullName: types.NamespacedName{Name: "tls-protocol-conflict", Namespace: "gateway-conformance-infra"}},
+		}},
 		{name: "listenerset-cross-listenerset-hostname-conflict", skipCEC: true, gateway: []gwDetails{
 			{FullName: types.NamespacedName{Name: "cross-listenerset-hostname-conflict", Namespace: "gateway-conformance-infra"}},
 		}},

--- a/operator/pkg/gateway-api/helpers.go
+++ b/operator/pkg/gateway-api/helpers.go
@@ -262,6 +262,14 @@ func sortListenerSets(sets []gatewayv1.ListenerSet) {
 	})
 }
 
+func sortedListenerEntries(entries []gatewayv1.ListenerEntry) []gatewayv1.ListenerEntry {
+	sorted := append([]gatewayv1.ListenerEntry(nil), entries...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Name < sorted[j].Name
+	})
+	return sorted
+}
+
 func deduplicateHTTPRoutes(routes []gatewayv1.HTTPRoute) []gatewayv1.HTTPRoute {
 	seen := make(map[types.NamespacedName]struct{}, len(routes))
 	result := make([]gatewayv1.HTTPRoute, 0, len(routes))

--- a/operator/pkg/gateway-api/helpers_listenerset_test.go
+++ b/operator/pkg/gateway-api/helpers_listenerset_test.go
@@ -70,6 +70,18 @@ func Test_sortListenerSets(t *testing.T) {
 	}
 }
 
+func Test_sortedListenerEntries(t *testing.T) {
+	entries := []gatewayv1.ListenerEntry{
+		{Name: "zebra"},
+		{Name: "alpha"},
+	}
+
+	sorted := sortedListenerEntries(entries)
+	require.Equal(t, gatewayv1.SectionName("alpha"), sorted[0].Name)
+	require.Equal(t, gatewayv1.SectionName("zebra"), sorted[1].Name)
+	require.Equal(t, gatewayv1.SectionName("zebra"), entries[0].Name)
+}
+
 func Test_isListenerSetAllowed_noAllowedListeners(t *testing.T) {
 	gw := &gatewayv1.Gateway{
 		Spec: gatewayv1.GatewaySpec{},

--- a/operator/pkg/gateway-api/listener_conflict_test.go
+++ b/operator/pkg/gateway-api/listener_conflict_test.go
@@ -9,6 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/operator/pkg/model"
+	"github.com/cilium/cilium/operator/pkg/model/ingestion"
 )
 
 func muxedListener(
@@ -223,4 +226,23 @@ func Test_acceptedListeners(t *testing.T) {
 		reason := accepted.checkConflict(*muxedListener("second", gatewayv1.HTTPProtocolType, 80, "bar.example.com"))
 		assert.Empty(t, string(reason))
 	})
+}
+
+func Test_filterConflictingListeners(t *testing.T) {
+	gw := gatewayWithConflictListeners(
+		muxedListener("gateway-https", gatewayv1.HTTPSProtocolType, 443, "api.example.test"),
+		tlsPassthroughListener("gateway-tls", 443, "api.example.test"),
+	)
+	listeners := []ingestion.ListenerWithContext{
+		{Listener: gw.Spec.Listeners[0], Source: model.FullyQualifiedResource{Kind: "Gateway"}},
+		{Listener: gw.Spec.Listeners[1], Source: model.FullyQualifiedResource{Kind: "Gateway"}},
+		{Listener: *muxedListener("listenerset-https", gatewayv1.HTTPSProtocolType, 8443, "api.example.test"), Source: model.FullyQualifiedResource{Kind: "ListenerSet"}},
+		{Listener: *tlsPassthroughListener("listenerset-tls", 8443, "api.example.test"), Source: model.FullyQualifiedResource{Kind: "ListenerSet"}},
+		{Listener: *muxedListener("listenerset-http", gatewayv1.HTTPProtocolType, 80, "api.example.test"), Source: model.FullyQualifiedResource{Kind: "ListenerSet"}},
+	}
+
+	filtered := filterConflictingListeners(gw, listeners)
+	assert.Len(t, filtered, 2)
+	assert.Equal(t, gatewayv1.SectionName("listenerset-https"), filtered[0].Name)
+	assert.Equal(t, gatewayv1.SectionName("listenerset-http"), filtered[1].Name)
 }

--- a/operator/pkg/gateway-api/listener_conflict_test.go
+++ b/operator/pkg/gateway-api/listener_conflict_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/model"
 	"github.com/cilium/cilium/operator/pkg/model/ingestion"
 )
@@ -245,4 +246,38 @@ func Test_filterConflictingListeners(t *testing.T) {
 	assert.Len(t, filtered, 2)
 	assert.Equal(t, gatewayv1.SectionName("listenerset-https"), filtered[0].Name)
 	assert.Equal(t, gatewayv1.SectionName("listenerset-http"), filtered[1].Name)
+}
+
+func Test_filterConflictingListeners_listenerSetOrderIsStable(t *testing.T) {
+	listenerSetSource := model.FullyQualifiedResource{Kind: "ListenerSet"}
+	listenerEntries := []gatewayv1.ListenerEntry{
+		{
+			Name:     "z-tls",
+			Hostname: ptr.To(gatewayv1.Hostname("api.example.test")),
+			Port:     443,
+			Protocol: gatewayv1.TLSProtocolType,
+			TLS:      &gatewayv1.ListenerTLSConfig{Mode: ptr.To(gatewayv1.TLSModePassthrough)},
+		},
+		{
+			Name:     "a-https",
+			Hostname: ptr.To(gatewayv1.Hostname("api.example.test")),
+			Port:     443,
+			Protocol: gatewayv1.HTTPSProtocolType,
+			TLS:      &gatewayv1.ListenerTLSConfig{Mode: ptr.To(gatewayv1.TLSModeTerminate)},
+		},
+	}
+
+	for _, entries := range [][]gatewayv1.ListenerEntry{listenerEntries, {listenerEntries[1], listenerEntries[0]}} {
+		listeners := make([]ingestion.ListenerWithContext, 0, len(entries))
+		for _, entry := range sortedListenerEntries(entries) {
+			listeners = append(listeners, ingestion.ListenerWithContext{
+				Listener: helpers.ListenerEntryToListener(entry),
+				Source:   listenerSetSource,
+			})
+		}
+
+		filtered := filterConflictingListeners(&gatewayv1.Gateway{}, listeners)
+		assert.Len(t, filtered, 1)
+		assert.Equal(t, gatewayv1.SectionName("a-https"), filtered[0].Name)
+	}
 }

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-tls-protocol-conflict/input/listenerset-tls-protocol-conflict.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-tls-protocol-conflict/input/listenerset-tls-protocol-conflict.yaml
@@ -1,0 +1,59 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: tls-protocol-conflict
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  allowedListeners:
+    namespaces:
+      from: Same
+  listeners:
+    - name: https
+      hostname: tls.example.com
+      port: 443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: tls-checks-certificate
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: tls-protocol-conflict
+  namespace: gateway-conformance-infra
+spec:
+  parentRef:
+    name: tls-protocol-conflict
+  listeners:
+    - name: tls
+      hostname: tls.example.com
+      port: 443
+      protocol: TLS
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tls-protocol-conflict
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: tls-protocol-conflict
+      sectionName: tls
+  hostnames:
+    - tls.example.com
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-tls-protocol-conflict/output/cec-tls-protocol-conflict.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-tls-protocol-conflict/output/cec-tls-protocol-conflict.yaml
@@ -1,0 +1,115 @@
+metadata:
+  creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: tls-protocol-conflict
+  name: cilium-gateway-tls-protocol-conflict
+  namespace: gateway-conformance-infra
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      controller: true
+      kind: Gateway
+      name: tls-protocol-conflict
+      uid: ""
+  resourceVersion: "1"
+spec:
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            transportProtocol: raw_buffer
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-insecure
+                statPrefix: listener-insecure
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+        - filterChainMatch:
+            serverNames:
+              - tls.example.com
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-secure
+                statPrefix: listener-secure
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+          transportSocket:
+            name: envoy.transport_sockets.tls
+            typedConfig:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              commonTlsContext:
+                tlsCertificateSdsSecretConfigs:
+                  - name: cilium-secrets/cilium-sync-secret-500e3be49f49f792095ab868a790d52c93e9b87961de22ae3ff2c25a63d56845
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-insecure
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-secure
+  services:
+    - name: cilium-gateway-tls-protocol-conflict
+      namespace: gateway-conformance-infra
+      ports:
+        - 443

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-tls-protocol-conflict/output/listenerset-tls-protocol-conflict.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-tls-protocol-conflict/output/listenerset-tls-protocol-conflict.yaml
@@ -1,0 +1,56 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  creationTimestamp: null
+  name: tls-protocol-conflict
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  parentRef:
+    name: tls-protocol-conflict
+  listeners:
+    - name: tls
+      hostname: tls.example.com
+      port: 443
+      protocol: TLS
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: Same
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: No valid listeners
+      reason: ListenersNotValid
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: No valid listeners
+      reason: ListenersNotValid
+      status: "False"
+      type: Programmed
+  listeners:
+    - name: tls
+      attachedRoutes: 1
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener has a conflict
+          reason: ProtocolConflict
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener has a conflict
+          reason: ProtocolConflict
+          status: "False"
+          type: Programmed
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener has a conflict
+          reason: ProtocolConflict
+          status: "True"
+          type: Conflicted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-tls-protocol-conflict/output/tls-protocol-conflict.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-tls-protocol-conflict/output/tls-protocol-conflict.yaml
@@ -1,0 +1,60 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: tls-protocol-conflict
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  gatewayClassName: cilium
+  allowedListeners:
+    namespaces:
+      from: Same
+  listeners:
+    - name: https
+      hostname: tls.example.com
+      port: 443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: tls-checks-certificate
+      allowedRoutes:
+        namespaces:
+          from: Same
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+  listeners:
+    - name: https
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+      attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-tls-protocol-conflict/output/tlsroute-tls-protocol-conflict.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-tls-protocol-conflict/output/tlsroute-tls-protocol-conflict.yaml
@@ -1,0 +1,38 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: TLSRoute
+metadata:
+  creationTimestamp: null
+  name: tls-protocol-conflict
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: tls-protocol-conflict
+      sectionName: tls
+  hostnames:
+    - tls.example.com
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443
+status:
+  parents:
+    - parentRef:
+        group: gateway.networking.k8s.io
+        kind: ListenerSet
+        name: tls-protocol-conflict
+        sectionName: tls
+      controllerName: io.cilium/gateway-controller
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Accepted TLSRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs

--- a/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/output/cec-gateway-tlsroute-mixed.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/tlsroute-mixed-protocol-listeners/output/cec-gateway-tlsroute-mixed.yaml
@@ -14,11 +14,6 @@ metadata:
       uid: ""
   resourceVersion: "1"
 spec:
-  backendServices:
-    - name: tls-backend
-      namespace: gateway-conformance-infra
-      number:
-        - "443"
   resources:
     - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
       filterChains:
@@ -50,51 +45,6 @@ spec:
                 upgradeConfigs:
                   - upgradeType: websocket
                 useRemoteAddress: true
-        - filterChainMatch:
-            transportProtocol: tls
-          filters:
-            - name: envoy.filters.network.http_connection_manager
-              typedConfig:
-                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                commonHttpProtocolOptions:
-                  maxStreamDuration: 0s
-                httpFilters:
-                  - name: envoy.filters.http.grpc_web
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
-                  - name: envoy.filters.http.grpc_stats
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
-                      emitFilterState: true
-                      enableUpstreamStats: true
-                  - name: envoy.filters.http.router
-                    typedConfig:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-                internalAddressConfig: {}
-                rds:
-                  routeConfigName: listener-secure
-                statPrefix: listener-secure
-                streamIdleTimeout: 300s
-                upgradeConfigs:
-                  - upgradeType: websocket
-                useRemoteAddress: true
-          transportSocket:
-            name: envoy.transport_sockets.tls
-            typedConfig:
-              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
-              commonTlsContext:
-                tlsCertificateSdsSecretConfigs:
-                  - name: cilium-secrets/cilium-sync-secret-500e3be49f49f792095ab868a790d52c93e9b87961de22ae3ff2c25a63d56845
-        - filterChainMatch:
-            serverNames:
-              - tls.example.com
-            transportProtocol: tls
-          filters:
-            - name: envoy.filters.network.tcp_proxy
-              typedConfig:
-                "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-                cluster: gateway-conformance-infra:tls-backend:443
-                statPrefix: tls-passthrough:tls.example.com
       listenerFilters:
         - name: envoy.filters.listener.tls_inspector
           typedConfig:
@@ -119,18 +69,8 @@ spec:
           name: "6"
     - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
       name: listener-insecure
-    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
-      name: listener-secure
-    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
-      edsClusterConfig:
-        serviceName: gateway-conformance-infra/tls-backend:443
-      name: gateway-conformance-infra:tls-backend:443
-      outlierDetection:
-        splitExternalLocalOriginErrors: true
-      type: EDS
   services:
     - name: cilium-gateway-gateway-tlsroute-mixed
       namespace: gateway-conformance-infra
       ports:
         - 80
-        - 443


### PR DESCRIPTION
Refactor the initial listener aggregation functions to prevent
conflicted listeners from reaching ingestion.

Extends a previous attempt to fix this bug to also apply to ListenerSet
listeners using the existing acceptedListeners.checkConflict method.

According the the spec, Gateway-direct listeners that conflict must be
mutually rejected, while ListenerSet listeners that conflict must allow
a conflicting Gateway listener to persist.

Therefore, it is unclear if the first conflicting listener within a
single ListenerSet should also be allowed to win the conflict.
Currently, we do allow it to win the conflict. Otherwise, we would have
to allow only Gateway direct listeners to win, which appears to be an
implementation choice.

In this case, it was previously possible for a flip-flop of the winning
ListenerSet listener based on the order in which the listeners were
iterated. This change sorts those listeners so that there is always a
clear winner.

```release-note
gateway-api: prevent conflicted listeners from reaching ingestion
```

AIL: 2
