### PR TITLE
helm: reflect Socket LB override for kubeProxyReplacement

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -862,7 +862,11 @@ data:
 
 {{- if $socketLB }}
 {{- if hasKey $socketLB "enabled" }}
+{{- if eq $kubeProxyReplacement "true" }}
+  bpf-lb-sock: "true"
+{{- else }}
   bpf-lb-sock: {{ $socketLB.enabled | quote }}
+{{- end }}
 {{- end }}
 {{- if or (hasKey $socketLB "hostNamespaceOnly") .Values.gatewayAPI.enabled }}
 # When Gateway API is enabled this is forced to "true" so per-backend weights


### PR DESCRIPTION
### Description

When `kubeProxyReplacement=true`, the runtime unconditionally enables Socket LB in `pkg/kpr/kpr.go`.

However, the Helm chart currently renders `bpf-lb-sock` directly from `socketLB.enabled`, which defaults to `false`. As a result, the generated `cilium-config` ConfigMap can report:

```yaml
bpf-lb-sock: "false"
```

even though Socket LB is enabled at runtime.

This change updates the Helm template so that `bpf-lb-sock` is rendered as `"true"` whenever `kubeProxyReplacement=true`, keeping the rendered ConfigMap consistent with the runtime behavior.

### Validation

Validated the rendered Helm templates locally.

**Default configuration**

```bash
helm template cilium ./install/kubernetes/cilium \
  | grep -E "bpf-lb-sock|kube-proxy-replacement"
```

Output:

```yaml
kube-proxy-replacement: "false"
bpf-lb-sock: "false"
```

**With `kubeProxyReplacement=true`**

```bash
helm template cilium ./install/kubernetes/cilium \
  --set kubeProxyReplacement=true \
  --set socketLB.hostNamespaceOnly=true \
  --set cni.exclusive=false \
  | grep -E "bpf-lb-sock|kube-proxy-replacement"
```

Output:

```yaml
kube-proxy-replacement: "true"
bpf-lb-sock: "true"
bpf-lb-sock-hostns-only: "true"
```

Fixes: #47417

```release-note
helm: render bpf-lb-sock as enabled when kubeProxyReplacement is enabled to match runtime behavior
```

AIL: 3. I used an LLM to help investigate the issue and review the proposed change. I manually inspected the relevant code, implemented the fix, and validated the rendered Helm templates locally.