### PR TITLE
allocator: fix flake in TestWatchRemoteKVStore

### DIFF
--- a/pkg/allocator/allocator_test.go
+++ b/pkg/allocator/allocator_test.go
@@ -584,8 +584,11 @@ func TestWatchRemoteKVStore(t *testing.T) {
 		return global.remoteCaches["remote"] == rc
 	}, 1*time.Second, 10*time.Millisecond)
 
-	require.True(t, rc.Synced(), "The cache should now be synchronized")
-	require.True(t, synced.Load(), "The on-sync callback should have been executed")
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.True(c, rc.Synced(), "The cache should now be synchronized")
+		assert.True(c, synced.Load(), "The on-sync callback should have been executed")
+	}, 1*time.Second, 10*time.Millisecond)
+
 	stop(cancel)
 	require.False(t, rc.Synced(), "The cache should no longer be synchronized when stopped")
 


### PR DESCRIPTION
The TestWatchRemoteKVStore test is currently affected by a potential source of flakiness because it directly asserts that the cache is synchronized after validating that it has been registered. However, the two operations are performed independently, and the on-sync callback handler is invoked after having released the lock, which implies that it may not have been invoked at check time. Let's get this fixed by wrapping the check with Eventually.

Marked for backport to all versions given that it is a small test-only change, even though the likelihood of hitting this flake seems very low.

AIL: 0