### PR TITLE
gateway-api: filter conflicted and invalid listeners before ingestion

### DIFF
--- a/operator/pkg/gateway-api/gamma_reconcile_test.go
+++ b/operator/pkg/gateway-api/gamma_reconcile_test.go
@@ -37,10 +37,6 @@ var (
 	serviceKeyEcho   = types.NamespacedName{Namespace: "gateway-conformance-mesh", Name: "echo"}
 	serviceKeyEchoV1 = types.NamespacedName{Namespace: "gateway-conformance-mesh", Name: "echo-v1"}
 	serviceKeyEchoV2 = types.NamespacedName{Namespace: "gateway-conformance-mesh", Name: "echo-v2"}
-	serviceTypeMeta  = metav1.TypeMeta{
-		Kind:       "Service",
-		APIVersion: corev1.SchemeGroupVersion.Version,
-	}
 )
 
 func Test_gammaReconciler_Reconcile(t *testing.T) {
@@ -95,15 +91,17 @@ func Test_gammaReconciler_Reconcile(t *testing.T) {
 				t.Run(serviceKey.String(), func(t *testing.T) {
 					base := readInputDir(t, "testdata/gamma/base")
 					input := readInputDir(t, fmt.Sprintf("testdata/gamma/%s/input", tt.name))
+					scheme := helpers.TestScheme(helpers.AllOptionalKinds)
 
 					c := fake.NewClientBuilder().
-						WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+						WithScheme(scheme).
 						WithObjects(append(base, input...)...).
 						WithIndex(&gatewayv1.HTTPRoute{}, indexers.GammaHTTPRouteParentRefsIndex, indexers.IndexHTTPRouteByGammaService).
 						WithIndex(&gatewayv1.GRPCRoute{}, indexers.GammaGRPCRouteParentRefsIndex, indexers.IndexGRPCRouteByGammaService).
 						WithStatusSubresource(&corev1.Service{}).
 						WithStatusSubresource(&gatewayv1.HTTPRoute{}).
 						WithStatusSubresource(&gatewayv1.GRPCRoute{}).
+						WithInterceptorFuncs(typeMetaInterceptor(scheme)).
 						Build()
 
 					r := &gammaReconciler{
@@ -135,13 +133,11 @@ func Test_gammaReconciler_Reconcile(t *testing.T) {
 					readOutput(t, fmt.Sprintf("testdata/gamma/%s/output/service-%s.yaml", tt.name, serviceKey.Name), expectedService)
 					actualService := &corev1.Service{}
 					err = c.Get(t.Context(), serviceKey, actualService)
-					actualService.TypeMeta = serviceTypeMeta
 					require.NoError(t, err)
 
 					for _, hr := range filterHTTPRouteList {
 						actualHR := &gatewayv1.HTTPRoute{}
 						err = c.Get(t.Context(), client.ObjectKeyFromObject(&hr), actualHR)
-						actualHR.TypeMeta = httpRouteTypeMeta
 						require.NoError(t, err, "error getting HTTPRoute %s/%s: %v", hr.Namespace, hr.Name, err)
 						expectedHR := &gatewayv1.HTTPRoute{}
 						readOutput(t, fmt.Sprintf("testdata/gamma/%s/output/httproute-%s.yaml", tt.name, hr.Name), expectedHR)
@@ -151,7 +147,6 @@ func Test_gammaReconciler_Reconcile(t *testing.T) {
 					for _, grpcr := range filterGRPCRouteList {
 						actualGRPCR := &gatewayv1.GRPCRoute{}
 						err = c.Get(t.Context(), client.ObjectKeyFromObject(&grpcr), actualGRPCR)
-						actualGRPCR.TypeMeta = grpcRouteTypeMeta
 						require.NoError(t, err, "error getting GRPCRoute %s/%s: %v", grpcr.Namespace, grpcr.Name, err)
 						expectedGRPCR := &gatewayv1.GRPCRoute{}
 						readOutput(t, fmt.Sprintf("testdata/gamma/%s/output/grpcroute-%s.yaml", tt.name, grpcr.Name), expectedGRPCR)

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -366,7 +366,17 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		MergedListeners:     mergedListeners,
 	})
 
-	listenersStatus, err := r.setListenerStatus(ctx, gw, httpRouteList, tlsRouteList, grpcRouteList, tcpRouteList, udpRouteList, namespaceLabels)
+	listenersStatus, err := r.setListenerStatus(
+		ctx,
+		gw,
+		conflictedListeners,
+		httpRouteList,
+		tlsRouteList,
+		grpcRouteList,
+		tcpRouteList,
+		udpRouteList,
+		namespaceLabels,
+	)
 	if err != nil {
 		scopedLog.ErrorContext(ctx, "Unable to set listener status", logfields.Error, err)
 		setGatewayAccepted(gw, false, "Unable to set listener status", gatewayv1.GatewayReasonNoResources)
@@ -391,7 +401,18 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// Accepted and Programmed conditions. Those Gateway conditions reflect the
 	// Gateway's local configuration, so valid ListenerSets do not make an
 	// otherwise invalid Gateway accepted or programmed.
-	r.setListenerSetStatuses(ctx, gw, attachedListenerSets, httpRouteList, tlsRouteList, grpcRouteList, tcpRouteList, udpRouteList, namespaceLabels)
+	r.setListenerSetStatuses(
+		ctx,
+		gw,
+		attachedListenerSets,
+		conflictedListeners,
+		httpRouteList,
+		tlsRouteList,
+		grpcRouteList,
+		tcpRouteList,
+		udpRouteList,
+		namespaceLabels,
+	)
 
 	// Step 3: Translate the listeners into Cilium model
 	cec, svc, eps, err := r.translator.Translate(m)
@@ -1217,13 +1238,23 @@ const (
 	ListenersStatusAllValid                     ListenersStatus = "AllValid"
 )
 
-func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1.Gateway, httpRoutes *gatewayv1.HTTPRouteList, tlsRoutes *gatewayv1.TLSRouteList, grpcRoutes *gatewayv1.GRPCRouteList, tcpRoutes *gatewayv1.TCPRouteList, udpRoutes *gatewayv1.UDPRouteList, namespaceLabels helpers.NamespaceLabelIndex) (ListenersStatus, error) {
+func (r *gatewayReconciler) setListenerStatus(
+	ctx context.Context,
+	gw *gatewayv1.Gateway,
+	conflictedListeners listenerConflictsBySource,
+	httpRoutes *gatewayv1.HTTPRouteList,
+	tlsRoutes *gatewayv1.TLSRouteList,
+	grpcRoutes *gatewayv1.GRPCRouteList,
+	tcpRoutes *gatewayv1.TCPRouteList,
+	udpRoutes *gatewayv1.UDPRouteList,
+	namespaceLabels helpers.NamespaceLabelIndex,
+) (ListenersStatus, error) {
 	grants := &gatewayv1.ReferenceGrantList{}
 	if err := r.Client.List(ctx, grants); err != nil {
 		return "", fmt.Errorf("failed to retrieve reference grants: %w", err)
 	}
 
-	conflictedListeners := conflictedGatewayListeners(gw)
+	conflictedGatewayListeners := conflictedListeners[gatewayFQR(gw)]
 
 	validListeners := 0
 	unsupportedProtocolListeners := 0
@@ -1234,7 +1265,7 @@ func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1
 
 		var conds []metav1.Condition
 
-		if conflict, ok := conflictedListeners[l.Name]; ok {
+		if conflict, ok := conflictedGatewayListeners[l.Name]; ok {
 			conds = merge(conds, listenerConflictedCondition(gw.GetGeneration(), conflict.reason, conflict.message))
 			invalidMessages = append(invalidMessages, conflict.message)
 			isValid = false
@@ -1242,7 +1273,7 @@ func (r *gatewayReconciler) setListenerStatus(ctx context.Context, gw *gatewayv1
 
 		res := r.validateListener(ctx, l, listenerValidationParams{
 			ownerNamespace: gw.Namespace,
-			ownerKind:      "Gateway",
+			ownerKind:      gw.Kind,
 			generation:     gw.GetGeneration(),
 			grants:         grants.Items,
 			ownerRef:       client.ObjectKeyFromObject(gw).String(),
@@ -1337,10 +1368,6 @@ type listenerConflict struct {
 }
 
 type listenerConflictsBySource map[model.FullyQualifiedResource]map[gatewayv1.SectionName]listenerConflict
-
-func conflictedGatewayListeners(gw *gatewayv1.Gateway) map[gatewayv1.SectionName]listenerConflict {
-	return conflictsWithinSource(gw.Spec.Listeners)
-}
 
 func conflictsAcrossSources(listeners []ingestion.ListenerWithContext) listenerConflictsBySource {
 	listenersBySource := make(map[model.FullyQualifiedResource][]gatewayv1.Listener)
@@ -1689,6 +1716,7 @@ func (r *gatewayReconciler) setListenerSetStatuses(
 	ctx context.Context,
 	gw *gatewayv1.Gateway,
 	attachedListenerSets []gatewayv1.ListenerSet,
+	conflictedListeners listenerConflictsBySource,
 	httpRoutes *gatewayv1.HTTPRouteList,
 	tlsRoutes *gatewayv1.TLSRouteList,
 	grpcRoutes *gatewayv1.GRPCRouteList,
@@ -1704,15 +1732,11 @@ func (r *gatewayReconciler) setListenerSetStatuses(
 		return
 	}
 
-	accepted := &acceptedListeners{}
-	for _, listener := range gw.Spec.Listeners {
-		accepted.accept(listener)
-	}
-
 	var validAttachedCount int32
 	for i := range attachedListenerSets {
 		ls := &attachedListenerSets[i]
 		original := ls.DeepCopy()
+		lsSource := listenerSetFQR(ls)
 
 		oneValidListener := false
 		var listenerStatuses []gatewayv1.ListenerEntryStatus
@@ -1721,14 +1745,13 @@ func (r *gatewayReconciler) setListenerSetStatuses(
 			l := helpers.ListenerEntryToListener(entry)
 			var conds []metav1.Condition
 
-			conflictReason := accepted.checkConflict(l)
-			isConflicted := conflictReason != ""
+			conflict, isConflicted := conflictedListeners[lsSource][l.Name]
 
 			if isConflicted {
 				conds = merge(conds,
-					listenerAcceptedCondition(ls.GetGeneration(), false, conflictReason, "Listener has a conflict"),
-					listenerProgrammedCondition(ls.GetGeneration(), false, conflictReason, "Listener has a conflict"),
-					listenerConflictedCondition(ls.GetGeneration(), conflictReason, "Listener has a conflict"),
+					listenerAcceptedCondition(ls.GetGeneration(), false, conflict.reason, "Listener has a conflict"),
+					listenerProgrammedCondition(ls.GetGeneration(), false, conflict.reason, "Listener has a conflict"),
+					listenerConflictedCondition(ls.GetGeneration(), conflict.reason, "Listener has a conflict"),
 					metav1.Condition{
 						Type:               string(gatewayv1.ListenerConditionResolvedRefs),
 						Status:             metav1.ConditionTrue,
@@ -1760,7 +1783,6 @@ func (r *gatewayReconciler) setListenerSetStatuses(
 					)
 				} else {
 					oneValidListener = true
-					accepted.accept(l)
 
 					// If ResolvedRefs is not already present, add a successful one.
 					if !helpers.IsConditionPresent(conds, string(gatewayv1.ListenerConditionResolvedRefs)) {
@@ -1780,7 +1802,6 @@ func (r *gatewayReconciler) setListenerSetStatuses(
 				}
 			}
 
-			lsSource := listenerSetFQR(ls)
 			var attachedRoutes int32
 			attachedRoutes += int32(len(r.filterHTTPRoutesByListener(ctx, gw, &l, &lsSource, httpRoutes.Items, namespaceLabels, *ls)))
 			attachedRoutes += int32(len(r.filterGRPCRoutesByListener(ctx, gw, &l, &lsSource, grpcRoutes.Items, namespaceLabels, *ls)))

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -124,11 +124,25 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 	}
 
-	mergedListeners, attachedListenerSets, err := r.resolveAllowedListeners(ctx, scopedLog, gw)
-	if err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to resolve allowed ListenerSet listeners", logfields.Error, err)
+	grants := &gatewayv1.ReferenceGrantList{}
+	if err := r.Client.List(ctx, grants); err != nil {
+		scopedLog.ErrorContext(ctx, "Unable to list ReferenceGrants", logfields.Error, err)
 		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
 	}
+
+	var attachedListenerSets []gatewayv1.ListenerSet
+	if helpers.HasListenerSetSupport(r.Client.Scheme()) {
+		listenerSets, err := r.listenerSetsForGateway(ctx, gw)
+		if err != nil {
+			scopedLog.ErrorContext(ctx, "Unable to list ListenerSets", logfields.Error, err)
+			return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+		}
+		attachedListenerSets = r.filterToAllowedListenerSets(ctx, scopedLog, gw, listenerSets)
+	}
+	listenerContexts := r.mergeListeners(ctx, scopedLog, gw, attachedListenerSets)
+	conflictedListeners := conflictsAcrossSources(listenerContexts)
+	mergedListeners := filterOutConflictedListeners(listenerContexts, conflictedListeners)
+	mergedListeners = r.filterOutInvalidListeners(ctx, mergedListeners, grants.Items)
 
 	httpRouteList := &gatewayv1.HTTPRouteList{}
 	if err := r.Client.List(ctx, httpRouteList, &client.ListOptions{
@@ -282,11 +296,6 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 	}
 
-	grants := &gatewayv1.ReferenceGrantList{}
-	if err := r.Client.List(ctx, grants); err != nil {
-		scopedLog.ErrorContext(ctx, "Unable to list ReferenceGrants", logfields.Error, err)
-		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
-	}
 	if gw.Spec.Infrastructure != nil && gw.Spec.Infrastructure.Annotations[annotation.LBIPAMIPKeyAlias] != "" {
 		scopedLog.WarnContext(ctx, fmt.Sprintf("DEPRECATED: The Gateway <%s/%s> is setting an IP address using the infrastructure annotations <%s>."+
 			" These should be set using the spec.addresses field in Gateway objects instead."+
@@ -736,45 +745,30 @@ func (r *gatewayReconciler) updateListenerSetStatus(ctx context.Context, origina
 	return r.Client.Status().Update(ctx, new)
 }
 
-func (r *gatewayReconciler) resolveAllowedListeners(
+func (r *gatewayReconciler) listenerSetsForGateway(
 	ctx context.Context,
-	scopedLog *slog.Logger,
 	gw *gatewayv1.Gateway,
-) ([]ingestion.ListenerWithContext, []gatewayv1.ListenerSet, error) {
-	gwSource := gatewayFQR(gw)
-	conflictedListeners := conflictedGatewayListeners(gw)
-
-	var merged []ingestion.ListenerWithContext
-	for _, l := range gw.Spec.Listeners {
-		// Conflicted listeners are rejected in Gateway status and must not be
-		// included in the model passed to the translation pipeline.
-		if _, conflicted := conflictedListeners[l.Name]; conflicted {
-			continue
-		}
-		if r.listenerSupportedForIngestion(l) {
-			merged = append(merged, ingestion.ListenerWithContext{
-				Listener: l,
-				Source:   gwSource,
-			})
-		}
-	}
-
-	if !helpers.HasListenerSetSupport(r.Client.Scheme()) {
-		return merged, nil, nil
-	}
-
+) ([]gatewayv1.ListenerSet, error) {
 	lsList := &gatewayv1.ListenerSetList{}
 	if err := r.Client.List(ctx, lsList, &client.ListOptions{
 		FieldSelector: fields.OneTermEqualSelector(indexers.ListenerSetGatewayIndex, client.ObjectKeyFromObject(gw).String()),
 	}); err != nil {
-		return nil, nil, fmt.Errorf("failed to list ListenerSets: %w", err)
+		return nil, fmt.Errorf("failed to list ListenerSets: %w", err)
 	}
 
 	sortListenerSets(lsList.Items)
+	return lsList.Items, nil
+}
 
-	var attachedSets []gatewayv1.ListenerSet
-	for i := range lsList.Items {
-		ls := &lsList.Items[i]
+func (r *gatewayReconciler) filterToAllowedListenerSets(
+	ctx context.Context,
+	scopedLog *slog.Logger,
+	gw *gatewayv1.Gateway,
+	listenerSets []gatewayv1.ListenerSet,
+) []gatewayv1.ListenerSet {
+	var allowed []gatewayv1.ListenerSet
+	for i := range listenerSets {
+		ls := &listenerSets[i]
 		if !isListenerSetAllowed(ctx, r.Client, gw, ls, scopedLog) {
 			original := ls.DeepCopy()
 			setListenerSetAccepted(ls, false, "ListenerSet is not allowed by the Gateway's allowedListeners policy", gatewayv1.ListenerSetReasonNotAllowed)
@@ -784,22 +778,84 @@ func (r *gatewayReconciler) resolveAllowedListeners(
 			}
 			continue
 		}
-		attachedSets = append(attachedSets, *ls)
+		allowed = append(allowed, *ls)
+	}
+	return allowed
+}
 
+func (r *gatewayReconciler) mergeListeners(
+	ctx context.Context,
+	scopedLog *slog.Logger,
+	gw *gatewayv1.Gateway,
+	listenerSets []gatewayv1.ListenerSet,
+) []ingestion.ListenerWithContext {
+	gwSource := gatewayFQR(gw)
+
+	var merged []ingestion.ListenerWithContext
+	for _, listener := range gw.Spec.Listeners {
+		merged = append(merged, ingestion.ListenerWithContext{
+			Listener:         listener,
+			Source:           gwSource,
+			SourceGeneration: gw.Generation,
+		})
+	}
+
+	for i := range listenerSets {
+		ls := &listenerSets[i]
 		lsSource := listenerSetFQR(ls)
 		for _, entry := range ls.Spec.Listeners {
 			listener := helpers.ListenerEntryToListener(entry)
-			if r.listenerSupportedForIngestion(listener) {
-				merged = append(merged, ingestion.ListenerWithContext{
-					Listener:          listener,
-					Source:            lsSource,
-					AllowedNamespaces: resolveAllowedNamespaces(ctx, r.Client, ls.GetNamespace(), listener, scopedLog),
-				})
-			}
+			merged = append(merged, ingestion.ListenerWithContext{
+				Listener:          listener,
+				Source:            lsSource,
+				SourceGeneration:  ls.Generation,
+				AllowedNamespaces: resolveAllowedNamespaces(ctx, r.Client, ls.GetNamespace(), listener, scopedLog),
+			})
 		}
 	}
 
-	return merged, attachedSets, nil
+	return merged
+}
+
+func filterOutConflictedListeners(
+	listeners []ingestion.ListenerWithContext,
+	conflictedListeners listenerConflictsBySource,
+) []ingestion.ListenerWithContext {
+	filtered := make([]ingestion.ListenerWithContext, 0, len(listeners))
+	for _, listener := range listeners {
+		if _, conflicted := conflictedListeners[listener.Source][listener.Name]; conflicted {
+			continue
+		}
+		filtered = append(filtered, listener)
+	}
+	return filtered
+}
+
+func (r *gatewayReconciler) filterOutInvalidListeners(
+	ctx context.Context,
+	listeners []ingestion.ListenerWithContext,
+	grants []gatewayv1.ReferenceGrant,
+) []ingestion.ListenerWithContext {
+	filtered := make([]ingestion.ListenerWithContext, 0, len(listeners))
+	for _, listener := range listeners {
+		res := r.validateListener(ctx, listener.Listener, listenerValidationParams{
+			ownerNamespace: listener.Source.Namespace,
+			ownerKind:      listener.Source.Kind,
+			generation:     listener.SourceGeneration,
+			grants:         grants,
+			ownerRef: types.NamespacedName{
+				Name:      listener.Source.Name,
+				Namespace: listener.Source.Namespace,
+			}.String(),
+		})
+
+		if !res.isValid {
+			continue
+		}
+
+		filtered = append(filtered, listener)
+	}
+	return filtered
 }
 
 // resolveAllowedNamespaces resolves a listener's allowedRoutes.namespaces policy
@@ -1280,13 +1336,70 @@ type listenerConflict struct {
 	message string
 }
 
+type listenerConflictsBySource map[model.FullyQualifiedResource]map[gatewayv1.SectionName]listenerConflict
+
 func conflictedGatewayListeners(gw *gatewayv1.Gateway) map[gatewayv1.SectionName]listenerConflict {
+	return conflictsWithinSource(gw.Spec.Listeners)
+}
+
+func conflictsAcrossSources(listeners []ingestion.ListenerWithContext) listenerConflictsBySource {
+	listenersBySource := make(map[model.FullyQualifiedResource][]gatewayv1.Listener)
+	var sources []model.FullyQualifiedResource
+	for _, listener := range listeners {
+		if _, knownSource := listenersBySource[listener.Source]; !knownSource {
+			sources = append(sources, listener.Source)
+		}
+		listenersBySource[listener.Source] = append(listenersBySource[listener.Source], listener.Listener)
+	}
+
+	conflicts := make(listenerConflictsBySource)
+	accepted := &acceptedListeners{}
+	for _, source := range sources {
+		var eligible []gatewayv1.Listener
+
+		for _, listener := range listenersBySource[source] {
+
+			// Find conflicts with any earlier accepted listener.
+			//
+			// The earlier, higher precedence, listener which conflicts is
+			// already in the accepted set
+			if reason := accepted.checkConflict(listener); reason != "" {
+				if conflicts[source] == nil {
+					conflicts[source] = map[gatewayv1.SectionName]listenerConflict{}
+				}
+				conflicts[source][listener.Name] = listenerConflict{reason: reason}
+				continue
+			}
+
+			eligible = append(eligible, listener)
+		}
+
+		// Find conflicts within the source.
+		//
+		// Such conflicts never enter the accepted set
+		for name, conflict := range conflictsWithinSource(eligible) {
+			if conflicts[source] == nil {
+				conflicts[source] = map[gatewayv1.SectionName]listenerConflict{}
+			}
+			conflicts[source][name] = conflict
+		}
+
+		for _, listener := range eligible {
+			if _, conflicted := conflicts[source][listener.Name]; !conflicted {
+				accepted.accept(listener)
+			}
+		}
+	}
+	return conflicts
+}
+
+func conflictsWithinSource(listeners []gatewayv1.Listener) map[gatewayv1.SectionName]listenerConflict {
 	conflicts := map[gatewayv1.SectionName]listenerConflict{}
 
-	for i := range gw.Spec.Listeners {
-		for j := i + 1; j < len(gw.Spec.Listeners); j++ {
-			first := &gw.Spec.Listeners[i]
-			second := &gw.Spec.Listeners[j]
+	for i := range listeners {
+		for j := i + 1; j < len(listeners); j++ {
+			first := &listeners[i]
+			second := &listeners[j]
 			reason, ok := listenerPairConflict(first, second)
 			if !ok {
 				continue
@@ -1591,11 +1704,9 @@ func (r *gatewayReconciler) setListenerSetStatuses(
 		return
 	}
 
-	// Seed the accumulator with the direct Gateway listeners, which take
-	// precedence over any ListenerSet listener.
 	accepted := &acceptedListeners{}
-	for _, l := range gw.Spec.Listeners {
-		accepted.accept(l)
+	for _, listener := range gw.Spec.Listeners {
+		accepted.accept(listener)
 	}
 
 	var validAttachedCount int32
@@ -1633,7 +1744,7 @@ func (r *gatewayReconciler) setListenerSetStatuses(
 			if !isConflicted {
 				res := r.validateListener(ctx, l, listenerValidationParams{
 					ownerNamespace: ls.Namespace,
-					ownerKind:      "ListenerSet",
+					ownerKind:      ls.Kind,
 					generation:     ls.GetGeneration(),
 					grants:         grants.Items,
 					ownerRef:       client.ObjectKeyFromObject(ls).String(),
@@ -1649,7 +1760,6 @@ func (r *gatewayReconciler) setListenerSetStatuses(
 					)
 				} else {
 					oneValidListener = true
-					// Claim this slot for subsequent listeners
 					accepted.accept(l)
 
 					// If ResolvedRefs is not already present, add a successful one.
@@ -2417,19 +2527,6 @@ func (r *gatewayReconciler) updateBackendTLSPolicyStatus(ctx context.Context, sc
 	}
 	scopedLog.Debug("BackendTLSPolicy status", backendTLSPolicy, types.NamespacedName{Name: original.Name, Namespace: original.Namespace})
 	return r.Client.Status().Update(ctx, new)
-}
-
-func (r *gatewayReconciler) listenerSupportedForIngestion(listener gatewayv1.Listener) bool {
-	// TCPRoute and UDPRoute rely on NodePort Services, which are incompatible
-	// with Envoy running in host networking mode.
-	if !r.hostNetworkEnabled {
-		return true
-	}
-	if isL4Protocol(listener.Protocol) {
-		return false
-	}
-
-	return true
 }
 
 func listenerOwnerNamespace(gw *gatewayv1.Gateway, listenerSource *model.FullyQualifiedResource) string {

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -356,6 +356,9 @@ func Test_Conformance(t *testing.T) {
 		{name: "listenerset-hostname-conflict", skipCEC: true, gateway: []gwDetails{
 			{FullName: types.NamespacedName{Name: "hostname-conflict", Namespace: "gateway-conformance-infra"}},
 		}},
+		{name: "listenerset-tls-protocol-conflict", gateway: []gwDetails{
+			{FullName: types.NamespacedName{Name: "tls-protocol-conflict", Namespace: "gateway-conformance-infra"}},
+		}},
 		{name: "listenerset-cross-listenerset-hostname-conflict", skipCEC: true, gateway: []gwDetails{
 			{FullName: types.NamespacedName{Name: "cross-listenerset-hostname-conflict", Namespace: "gateway-conformance-infra"}},
 		}},
@@ -1044,7 +1047,6 @@ func Test_gatewayReconciler_setListenerStatus(t *testing.T) {
 					WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
 					Build(),
 			}
-
 			gotStatus, err := r.setListenerStatus(
 				t.Context(),
 				gw,

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
+	"github.com/cilium/cilium/operator/pkg/model/ingestion"
 	"github.com/cilium/cilium/operator/pkg/model/translation"
 	gatewayApiTranslation "github.com/cilium/cilium/operator/pkg/model/translation/gateway-api"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -1047,9 +1048,17 @@ func Test_gatewayReconciler_setListenerStatus(t *testing.T) {
 					WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
 					Build(),
 			}
+			listenerContexts := make([]ingestion.ListenerWithContext, 0, len(gw.Spec.Listeners))
+			for _, listener := range gw.Spec.Listeners {
+				listenerContexts = append(listenerContexts, ingestion.ListenerWithContext{
+					Listener: listener,
+					Source:   gatewayFQR(gw),
+				})
+			}
 			gotStatus, err := r.setListenerStatus(
 				t.Context(),
 				gw,
+				conflictsAcrossSources(listenerContexts),
 				&gatewayv1.HTTPRouteList{},
 				&gatewayv1.TLSRouteList{},
 				&gatewayv1.GRPCRouteList{},

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -4,6 +4,7 @@
 package gateway_api
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"testing"
@@ -15,13 +16,16 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
@@ -33,45 +37,37 @@ import (
 	"github.com/cilium/cilium/pkg/shortener"
 )
 
-var (
-	gatewayv1APIVersion = gatewayv1.GroupVersion.Group + "/" + gatewayv1.GroupVersion.Version
-	gatewayTypeMeta     = metav1.TypeMeta{
-		Kind:       "Gateway",
-		APIVersion: gatewayv1APIVersion,
+func typeMetaInterceptor(scheme *runtime.Scheme) interceptor.Funcs {
+	setTypeMeta := func(obj runtime.Object) error {
+		if _, isCEC := obj.(*ciliumv2.CiliumEnvoyConfig); isCEC {
+			return nil
+		}
+		gvks, _, err := scheme.ObjectKinds(obj)
+		if err != nil {
+			return err
+		}
+		obj.GetObjectKind().SetGroupVersionKind(gvks[0])
+		return nil
 	}
-	httpRouteTypeMeta = metav1.TypeMeta{
-		Kind:       "HTTPRoute",
-		APIVersion: gatewayv1APIVersion,
+
+	return interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if err := c.Get(ctx, key, obj, opts...); err != nil {
+				return err
+			}
+			return setTypeMeta(obj)
+		},
+		List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			if err := c.List(ctx, list, opts...); err != nil {
+				return err
+			}
+			if err := setTypeMeta(list); err != nil {
+				return err
+			}
+			return meta.EachListItem(list, setTypeMeta)
+		},
 	}
-	grpcRouteTypeMeta = metav1.TypeMeta{
-		Kind:       "GRPCRoute",
-		APIVersion: gatewayv1APIVersion,
-	}
-	tlsRouteTypeMeta = metav1.TypeMeta{
-		Kind:       "TLSRoute",
-		APIVersion: gatewayv1APIVersion,
-	}
-	backendTLSPolicyTypeMeta = metav1.TypeMeta{
-		Kind:       "BackendTLSPolicy",
-		APIVersion: gatewayv1APIVersion,
-	}
-	tcpRouteTypeMeta = metav1.TypeMeta{
-		Kind:       "TCPRoute",
-		APIVersion: gatewayv1APIVersion,
-	}
-	udpRouteTypeMeta = metav1.TypeMeta{
-		Kind:       "UDPRoute",
-		APIVersion: gatewayv1APIVersion,
-	}
-	listenerSetTypeMeta = metav1.TypeMeta{
-		Kind:       "ListenerSet",
-		APIVersion: gatewayv1APIVersion,
-	}
-	endpointSliceTypeMeta = metav1.TypeMeta{
-		Kind:       "EndpointSlice",
-		APIVersion: discoveryv1.SchemeGroupVersion.String(),
-	}
-)
+}
 
 func Test_Conformance(t *testing.T) {
 	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
@@ -387,18 +383,6 @@ func Test_Conformance(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			base := readInputDir(t, "testdata/gateway/base")
 			input := readInputDir(t, fmt.Sprintf("testdata/gateway/%s/input", tt.name))
-			clientBuilder := fake.NewClientBuilder().
-				WithObjects(append(base, input...)...).
-				WithStatusSubresource(&corev1.Service{}).
-				WithStatusSubresource(&corev1.Namespace{}).
-				WithStatusSubresource(&gatewayv1.GRPCRoute{}).
-				WithStatusSubresource(&gatewayv1.HTTPRoute{}).
-				WithStatusSubresource(&gatewayv1.TLSRoute{}).
-				WithStatusSubresource(&gatewayv1.Gateway{}).
-				WithStatusSubresource(&gatewayv1.GatewayClass{}).
-				WithStatusSubresource(&gatewayv1.BackendTLSPolicy{}).
-				WithStatusSubresource(&gatewayv1.ListenerSet{})
-
 			disabledKinds := map[string]bool{
 				helpers.ServiceImportKind: tt.disableServiceImport,
 				helpers.TCPRouteKind:      tt.disableTCPRoute,
@@ -411,7 +395,20 @@ func Test_Conformance(t *testing.T) {
 				}
 				optionalKinds = append(optionalKinds, k)
 			}
-			clientBuilder.WithScheme(helpers.TestScheme(optionalKinds))
+			scheme := helpers.TestScheme(optionalKinds)
+			clientBuilder := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(append(base, input...)...).
+				WithStatusSubresource(&corev1.Service{}).
+				WithStatusSubresource(&corev1.Namespace{}).
+				WithStatusSubresource(&gatewayv1.GRPCRoute{}).
+				WithStatusSubresource(&gatewayv1.HTTPRoute{}).
+				WithStatusSubresource(&gatewayv1.TLSRoute{}).
+				WithStatusSubresource(&gatewayv1.Gateway{}).
+				WithStatusSubresource(&gatewayv1.GatewayClass{}).
+				WithStatusSubresource(&gatewayv1.BackendTLSPolicy{}).
+				WithStatusSubresource(&gatewayv1.ListenerSet{}).
+				WithInterceptorFuncs(typeMetaInterceptor(scheme))
 
 			// Add any required indexes here
 			clientBuilder.WithIndex(&gatewayv1.HTTPRoute{}, indexers.GatewayHTTPRouteIndex, indexers.IndexHTTPRouteByGateway)
@@ -498,9 +495,6 @@ func Test_Conformance(t *testing.T) {
 				// Checking the output for Gateway
 				actualGateway := &gatewayv1.Gateway{}
 				err = c.Get(t.Context(), gwDetail.FullName, actualGateway)
-				// TODO(youngnick): controller-runtime has broken something with the fake client
-				// Bypass for now
-				actualGateway.TypeMeta = gatewayTypeMeta
 				require.NoError(t, err)
 				expectedGateway := &gatewayv1.Gateway{}
 				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/%s.yaml", tt.name, gwDetail.FullName.Name), expectedGateway)
@@ -530,7 +524,6 @@ func Test_Conformance(t *testing.T) {
 			for _, eps := range epsList.Items {
 				actualEPS := &discoveryv1.EndpointSlice{}
 				err = c.Get(t.Context(), client.ObjectKeyFromObject(&eps), actualEPS)
-				actualEPS.TypeMeta = endpointSliceTypeMeta
 				require.NoError(t, err, "error getting EndpointSlice %s/%s: %v", eps.Namespace, eps.Name, err)
 				expectedEPS := &discoveryv1.EndpointSlice{}
 				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/endpointslice-%s.yaml", tt.name, eps.Name), expectedEPS)
@@ -541,9 +534,6 @@ func Test_Conformance(t *testing.T) {
 			for _, hr := range hrList.Items {
 				actualHR := &gatewayv1.HTTPRoute{}
 				err = c.Get(t.Context(), client.ObjectKeyFromObject(&hr), actualHR)
-				// TODO(youngnick): controller-runtime has broken something with the fake client
-				// Bypass for now
-				actualHR.TypeMeta = httpRouteTypeMeta
 				require.NoError(t, err, "error getting HTTPRoute %s/%s: %v", hr.Namespace, hr.Name, err)
 				expectedHR := &gatewayv1.HTTPRoute{}
 				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/httproute-%s.yaml", tt.name, hr.Name), expectedHR)
@@ -553,7 +543,6 @@ func Test_Conformance(t *testing.T) {
 			for _, tlsr := range tlsrList.Items {
 				actualTLSR := &gatewayv1.TLSRoute{}
 				err = c.Get(t.Context(), client.ObjectKeyFromObject(&tlsr), actualTLSR)
-				actualTLSR.TypeMeta = tlsRouteTypeMeta
 				require.NoError(t, err, "error getting TLSRoute %s/%s: %v", tlsr.Namespace, tlsr.Name, err)
 				expectedTLSR := &gatewayv1.TLSRoute{}
 				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/tlsroute-%s.yaml", tt.name, tlsr.Name), expectedTLSR)
@@ -563,7 +552,6 @@ func Test_Conformance(t *testing.T) {
 			for _, grpcr := range grpcrList.Items {
 				actualGRPCR := &gatewayv1.GRPCRoute{}
 				err = c.Get(t.Context(), client.ObjectKeyFromObject(&grpcr), actualGRPCR)
-				actualGRPCR.TypeMeta = grpcRouteTypeMeta
 				require.NoError(t, err, "error getting GRPCRoute %s/%s: %v", grpcr.Namespace, grpcr.Name, err)
 				expectedGRPCR := &gatewayv1.GRPCRoute{}
 				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/grpcroute-%s.yaml", tt.name, grpcr.Name), expectedGRPCR)
@@ -573,7 +561,6 @@ func Test_Conformance(t *testing.T) {
 			for _, btlsp := range btlspList.Items {
 				actualBTLSP := &gatewayv1.BackendTLSPolicy{}
 				err = c.Get(t.Context(), client.ObjectKeyFromObject(&btlsp), actualBTLSP)
-				actualBTLSP.TypeMeta = backendTLSPolicyTypeMeta
 				require.NoError(t, err, "error getting BackendTLSPolicy %s/%s: %v", btlsp.Namespace, btlsp.Name, err)
 				expectedBTLSP := &gatewayv1.BackendTLSPolicy{}
 				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/backendtlspolicy-%s.yaml", tt.name, btlsp.Name), expectedBTLSP)
@@ -583,7 +570,6 @@ func Test_Conformance(t *testing.T) {
 			for _, tcpr := range tcprList.Items {
 				actualTCPR := &gatewayv1.TCPRoute{}
 				err = c.Get(t.Context(), client.ObjectKeyFromObject(&tcpr), actualTCPR)
-				actualTCPR.TypeMeta = tcpRouteTypeMeta
 				require.NoError(t, err, "error getting TCPRoute %s/%s: %v", tcpr.Namespace, tcpr.Name, err)
 				expectedTCPR := &gatewayv1.TCPRoute{}
 				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/tcproute-%s.yaml", tt.name, tcpr.Name), expectedTCPR)
@@ -593,7 +579,6 @@ func Test_Conformance(t *testing.T) {
 			for _, udpr := range udprList.Items {
 				actualUDPR := &gatewayv1.UDPRoute{}
 				err = c.Get(t.Context(), client.ObjectKeyFromObject(&udpr), actualUDPR)
-				actualUDPR.TypeMeta = udpRouteTypeMeta
 				require.NoError(t, err, "error getting UDPRoute %s/%s: %v", udpr.Namespace, udpr.Name, err)
 				expectedUDPR := &gatewayv1.UDPRoute{}
 				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/udproute-%s.yaml", tt.name, udpr.Name), expectedUDPR)
@@ -606,7 +591,6 @@ func Test_Conformance(t *testing.T) {
 			for _, ls := range lsList.Items {
 				actualLS := &gatewayv1.ListenerSet{}
 				err = c.Get(t.Context(), client.ObjectKeyFromObject(&ls), actualLS)
-				actualLS.TypeMeta = listenerSetTypeMeta
 				require.NoError(t, err, "error getting ListenerSet %s/%s: %v", ls.Namespace, ls.Name, err)
 				expectedLS := &gatewayv1.ListenerSet{}
 				readOutput(t, fmt.Sprintf("testdata/gateway/%s/output/listenerset-%s.yaml", tt.name, ls.Name), expectedLS)

--- a/operator/pkg/gateway-api/listener_conflict_test.go
+++ b/operator/pkg/gateway-api/listener_conflict_test.go
@@ -9,6 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/operator/pkg/model"
+	"github.com/cilium/cilium/operator/pkg/model/ingestion"
 )
 
 func muxedListener(
@@ -163,13 +166,13 @@ func gatewayWithConflictListeners(listeners ...*gatewayv1.Listener) *gatewayv1.G
 	return gw
 }
 
-func Test_conflictedGatewayListeners(t *testing.T) {
+func Test_conflictsWithinSource(t *testing.T) {
 	t.Run("non-conflicting listeners produce no entries", func(t *testing.T) {
 		gw := gatewayWithConflictListeners(
 			muxedListener("a", gatewayv1.HTTPProtocolType, 80, "foo.example.com"),
 			muxedListener("b", gatewayv1.HTTPProtocolType, 80, "bar.example.com"),
 		)
-		assert.Empty(t, conflictedGatewayListeners(gw))
+		assert.Empty(t, conflictsWithinSource(gw.Spec.Listeners))
 	})
 
 	t.Run("identical hostname duplicate marks both listeners", func(t *testing.T) {
@@ -177,7 +180,7 @@ func Test_conflictedGatewayListeners(t *testing.T) {
 			muxedListener("a", gatewayv1.HTTPSProtocolType, 443, "foo.example.com"),
 			muxedListener("b", gatewayv1.HTTPSProtocolType, 443, "foo.example.com"),
 		)
-		conflicts := conflictedGatewayListeners(gw)
+		conflicts := conflictsWithinSource(gw.Spec.Listeners)
 		assert.Equal(t, gatewayv1.ListenerReasonHostnameConflict, conflicts["a"].reason)
 		assert.Equal(t, gatewayv1.ListenerReasonHostnameConflict, conflicts["b"].reason)
 		assert.Contains(t, conflicts["a"].message, `listener "b"`)
@@ -189,7 +192,7 @@ func Test_conflictedGatewayListeners(t *testing.T) {
 			l4Listener("a", gatewayv1.TCPProtocolType, 80),
 			muxedListener("b", gatewayv1.HTTPProtocolType, 80, "foo.example.com"),
 		)
-		conflicts := conflictedGatewayListeners(gw)
+		conflicts := conflictsWithinSource(gw.Spec.Listeners)
 		assert.Equal(t, gatewayv1.ListenerReasonProtocolConflict, conflicts["a"].reason)
 		assert.Equal(t, gatewayv1.ListenerReasonProtocolConflict, conflicts["b"].reason)
 	})
@@ -199,7 +202,7 @@ func Test_conflictedGatewayListeners(t *testing.T) {
 			muxedListener("https", gatewayv1.HTTPSProtocolType, 443, "api.example.test"),
 			tlsPassthroughListener("tls-passthrough", 443, "api.example.test"),
 		)
-		conflicts := conflictedGatewayListeners(gw)
+		conflicts := conflictsWithinSource(gw.Spec.Listeners)
 		assert.Equal(t, gatewayv1.ListenerReasonProtocolConflict, conflicts["https"].reason)
 		assert.Equal(t,
 			`Listener conflicts with listener "tls-passthrough": same port 443 has overlapping HTTPS and TLS passthrough hostnames.`,
@@ -223,4 +226,52 @@ func Test_acceptedListeners(t *testing.T) {
 		reason := accepted.checkConflict(*muxedListener("second", gatewayv1.HTTPProtocolType, 80, "bar.example.com"))
 		assert.Empty(t, string(reason))
 	})
+}
+
+func Test_filterOutConflictedListeners_gatewayListeners(t *testing.T) {
+	listeners := []ingestion.ListenerWithContext{
+		{Listener: *muxedListener("https", gatewayv1.HTTPSProtocolType, 443, "api.example.test"), Source: model.FullyQualifiedResource{Kind: "Gateway"}},
+		{Listener: *tlsPassthroughListener("tls", 443, "api.example.test"), Source: model.FullyQualifiedResource{Kind: "Gateway"}},
+	}
+
+	filtered := filterOutConflictedListeners(listeners, conflictsAcrossSources(listeners))
+	assert.Empty(t, filtered)
+}
+
+func Test_filterOutConflictedListeners_listenerSetListeners(t *testing.T) {
+	listeners := []ingestion.ListenerWithContext{
+		{Listener: *muxedListener("https", gatewayv1.HTTPSProtocolType, 443, "api.example.test"), Source: model.FullyQualifiedResource{Kind: "ListenerSet", Name: "one"}},
+		{Listener: *tlsPassthroughListener("tls", 443, "api.example.test"), Source: model.FullyQualifiedResource{Kind: "ListenerSet", Name: "one"}},
+	}
+
+	filtered := filterOutConflictedListeners(listeners, conflictsAcrossSources(listeners))
+	assert.Empty(t, filtered)
+}
+
+func Test_filterOutConflictedListeners_gatewayPrecedence(t *testing.T) {
+	listeners := []ingestion.ListenerWithContext{
+		{Listener: *muxedListener("gateway", gatewayv1.HTTPSProtocolType, 443, "api.example.test"), Source: model.FullyQualifiedResource{Kind: "Gateway"}},
+		{Listener: *tlsPassthroughListener("listenerset", 443, "api.example.test"), Source: model.FullyQualifiedResource{Kind: "ListenerSet", Name: "one"}},
+	}
+
+	filtered := filterOutConflictedListeners(listeners, conflictsAcrossSources(listeners))
+	assert.Len(t, filtered, 1)
+	assert.Equal(t, gatewayv1.SectionName("gateway"), filtered[0].Name)
+}
+
+func Test_filterOutConflictedListeners_listenerSetPrecedence(t *testing.T) {
+	listeners := []ingestion.ListenerWithContext{
+		{
+			Listener: *muxedListener("older", gatewayv1.HTTPSProtocolType, 443, "api.example.test"),
+			Source:   model.FullyQualifiedResource{Kind: "ListenerSet", Name: "older"},
+		},
+		{
+			Listener: *tlsPassthroughListener("newer", 443, "api.example.test"),
+			Source:   model.FullyQualifiedResource{Kind: "ListenerSet", Name: "newer"},
+		},
+	}
+
+	filtered := filterOutConflictedListeners(listeners, conflictsAcrossSources(listeners))
+	assert.Len(t, filtered, 1)
+	assert.Equal(t, gatewayv1.SectionName("older"), filtered[0].Name)
 }

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-modify-listeners/output/cec-gateway-remove-listener.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-modify-listeners/output/cec-gateway-remove-listener.yaml
@@ -50,43 +50,6 @@ spec:
           upgradeConfigs:
           - upgradeType: websocket
           useRemoteAddress: true
-    - filterChainMatch:
-        serverNames:
-        - secure.test.com
-        transportProtocol: tls
-      filters:
-      - name: envoy.filters.network.http_connection_manager
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-          commonHttpProtocolOptions:
-            maxStreamDuration: 0s
-          httpFilters:
-          - name: envoy.filters.http.grpc_web
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
-          - name: envoy.filters.http.grpc_stats
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
-              emitFilterState: true
-              enableUpstreamStats: true
-          - name: envoy.filters.http.router
-            typedConfig:
-              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-          internalAddressConfig: {}
-          rds:
-            routeConfigName: listener-secure
-          statPrefix: listener-secure
-          streamIdleTimeout: 300s
-          upgradeConfigs:
-          - upgradeType: websocket
-          useRemoteAddress: true
-      transportSocket:
-        name: envoy.transport_sockets.tls
-        typedConfig:
-          '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
-          commonTlsContext:
-            tlsCertificateSdsSecretConfigs:
-            - name: cilium-secrets/cilium-sync-secret-261c3c0ed7182ef9200310151d846ebc492656fb3bcdf448223b3495dcc9016a
     listenerFilters:
     - name: envoy.filters.listener.tls_inspector
       typedConfig:
@@ -122,20 +85,6 @@ spec:
           cluster: gateway-conformance-infra:infra-backend-v1:8080
           maxStreamDuration:
             maxStreamDuration: 0s
-  - '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
-    name: listener-secure
-    virtualHosts:
-    - domains:
-      - secure.test.com
-      - secure.test.com:*
-      name: secure.test.com
-      routes:
-      - match:
-          prefix: /
-        route:
-          cluster: gateway-conformance-infra:infra-backend-v1:8080
-          maxStreamDuration:
-            maxStreamDuration: 0s
   - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
     edsClusterConfig:
       serviceName: gateway-conformance-infra/infra-backend-v1:8080
@@ -156,4 +105,3 @@ spec:
     namespace: gateway-conformance-infra
     ports:
     - 80
-    - 443

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-tls-protocol-conflict/input/listenerset-tls-protocol-conflict.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-tls-protocol-conflict/input/listenerset-tls-protocol-conflict.yaml
@@ -1,0 +1,59 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: tls-protocol-conflict
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  allowedListeners:
+    namespaces:
+      from: Same
+  listeners:
+    - name: https
+      hostname: tls.example.com
+      port: 443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: tls-checks-certificate
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: tls-protocol-conflict
+  namespace: gateway-conformance-infra
+spec:
+  parentRef:
+    name: tls-protocol-conflict
+  listeners:
+    - name: tls
+      hostname: tls.example.com
+      port: 443
+      protocol: TLS
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: tls-protocol-conflict
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: tls-protocol-conflict
+      sectionName: tls
+  hostnames:
+    - tls.example.com
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-tls-protocol-conflict/output/cec-tls-protocol-conflict.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-tls-protocol-conflict/output/cec-tls-protocol-conflict.yaml
@@ -1,0 +1,115 @@
+metadata:
+  creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: tls-protocol-conflict
+  name: cilium-gateway-tls-protocol-conflict
+  namespace: gateway-conformance-infra
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      controller: true
+      kind: Gateway
+      name: tls-protocol-conflict
+      uid: ""
+  resourceVersion: "1"
+spec:
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            transportProtocol: raw_buffer
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-insecure
+                statPrefix: listener-insecure
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+        - filterChainMatch:
+            serverNames:
+              - tls.example.com
+            transportProtocol: tls
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-secure
+                statPrefix: listener-secure
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+          transportSocket:
+            name: envoy.transport_sockets.tls
+            typedConfig:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              commonTlsContext:
+                tlsCertificateSdsSecretConfigs:
+                  - name: cilium-secrets/cilium-sync-secret-500e3be49f49f792095ab868a790d52c93e9b87961de22ae3ff2c25a63d56845
+      listenerFilters:
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-insecure
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-secure
+  services:
+    - name: cilium-gateway-tls-protocol-conflict
+      namespace: gateway-conformance-infra
+      ports:
+        - 443

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-tls-protocol-conflict/output/listenerset-tls-protocol-conflict.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-tls-protocol-conflict/output/listenerset-tls-protocol-conflict.yaml
@@ -1,0 +1,56 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  creationTimestamp: null
+  name: tls-protocol-conflict
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  parentRef:
+    name: tls-protocol-conflict
+  listeners:
+    - name: tls
+      hostname: tls.example.com
+      port: 443
+      protocol: TLS
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: Same
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: No valid listeners
+      reason: ListenersNotValid
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: No valid listeners
+      reason: ListenersNotValid
+      status: "False"
+      type: Programmed
+  listeners:
+    - name: tls
+      attachedRoutes: 1
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener has a conflict
+          reason: ProtocolConflict
+          status: "False"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener has a conflict
+          reason: ProtocolConflict
+          status: "False"
+          type: Programmed
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener has a conflict
+          reason: ProtocolConflict
+          status: "True"
+          type: Conflicted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-tls-protocol-conflict/output/tls-protocol-conflict.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-tls-protocol-conflict/output/tls-protocol-conflict.yaml
@@ -1,0 +1,60 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: tls-protocol-conflict
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  gatewayClassName: cilium
+  allowedListeners:
+    namespaces:
+      from: Same
+  listeners:
+    - name: https
+      hostname: tls.example.com
+      port: 443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: tls-checks-certificate
+      allowedRoutes:
+        namespaces:
+          from: Same
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T00:00:00Z"
+      message: Gateway waiting for address
+      reason: AddressNotAssigned
+      status: "False"
+      type: Programmed
+  listeners:
+    - name: https
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute
+      attachedRoutes: 0
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Address not ready yet
+          reason: Pending
+          status: "False"
+          type: Programmed

--- a/operator/pkg/gateway-api/testdata/gateway/listenerset-tls-protocol-conflict/output/tlsroute-tls-protocol-conflict.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/listenerset-tls-protocol-conflict/output/tlsroute-tls-protocol-conflict.yaml
@@ -1,0 +1,38 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: TLSRoute
+metadata:
+  creationTimestamp: null
+  name: tls-protocol-conflict
+  namespace: gateway-conformance-infra
+  resourceVersion: "999"
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: ListenerSet
+      name: tls-protocol-conflict
+      sectionName: tls
+  hostnames:
+    - tls.example.com
+  rules:
+    - backendRefs:
+        - name: tls-backend
+          port: 443
+status:
+  parents:
+    - parentRef:
+        group: gateway.networking.k8s.io
+        kind: ListenerSet
+        name: tls-protocol-conflict
+        sectionName: tls
+      controllerName: io.cilium/gateway-controller
+      conditions:
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Accepted TLSRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-07-01T00:00:00Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs

--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -34,7 +34,8 @@ const (
 type ListenerWithContext struct {
 	gatewayv1.Listener
 	// Source is where this listener appears: Gateway or ListenerSet
-	Source model.FullyQualifiedResource
+	Source           model.FullyQualifiedResource
+	SourceGeneration int64
 
 	// AllowedNamespaces is the set of namespaces allowed for Route attachment
 	AllowedNamespaces map[string]struct{}


### PR DESCRIPTION
### Filter invalid and conflicted listeners before ingestion

Refactor resolveAllowedListeners into a collection of smaller functions which perform the following operations

* Query for ListenerSets attached to a Gateway
* Filter to the allowed ListenerSets for the Gateway
* Merge a collection of direct and ListenerSet listeners
* Filter out conflicted listeners from a set of listeners
* Distinguish between same-source and cross-source conflicts
* Filter out invalid Listeners using the existing validateListener

This allows us to compose calls that prevent both Gateway-direct listeners and ListenerSet listeners which conflict with each other from reaching the ingestion phase.

This handles both "same source" conflicts, where both listeners should be rejected, and "cross source" conflicts, where only the less precedent listener should be rejected.

### Listener filtering using validateListener and test updates

Note that one of the most important things that this commit introduces is the use of r.validateListener to filter out invalid listeners before ingestion. This is a pre-existing validation function which was not yet used to prevent listeners from reaching ingestion. This filters out the following types of invalid listeners:

* Listeners with unsupported protocols
* Listeners with invalid route kinds
* Listeners with invalid certificates
* Listeners with invalid secret references

All of these cases previously had correct status-writing, but the listener objects were still allowed to reach the ingestion phase. This is no longer the case. The gateway-modify-listeners test case needed corrections after this more strict validation was implemented. The gateway-remove-listener Gateway correctly reported InvalidCertificateRef in status. However, the output CEC still contained the HTTPS filter chain. So, the CEC fixture was modified to remove the HTTPS filter chain.

A test case was added which confirms that both the resulting ListenerSet status and CEC correctly reflect a listener with a TLS/HTTPS protocol conflict.

### Reuse listener conflicts for status writing

Use the existing conflict detection listener aggregation to drive status writing. This helps to match listener liveness with reported status.

### Update fake client to always restore TypeMeta

Use an interceptor function to restore type meta for objects populated using the fake client. Do not populate type meta for CECs.

Remove all points in the Gateway API and GAMMA tests which manually restore the TypeMeta information for the fake client objects.

Fixes: https://github.com/cilium/cilium/issues/46917
Fixes: https://github.com/cilium/cilium/issues/47519

AIL:2

```release-note
gateway-api: prevent conflicted listeners from reaching ingestion
```

