### PR TITLE
contrib: fix lock-check pattern matching

### DIFF
--- a/contrib/scripts/lock-check.sh
+++ b/contrib/scripts/lock-check.sh
@@ -4,13 +4,13 @@
 
 # Used to cause failure when pkg/lock is not used
 for l in sync.Mutex sync.RWMutex; do
-  if grep -r --exclude-dir={.git,_build,vendor,externalversions,lock,contrib} -i --include \*.go "$l" .; then
+  if grep -rwF --exclude-dir={.git,_build,vendor,externalversions,lock,contrib} --include \*.go "$l" .; then
     echo "Found $l usage. Please use pkg/lock instead to improve deadlock detection";
     exit 1
   fi
 done
 
-if grep -r --exclude-dir={.git,_build,vendor,externalversions,lock,contrib} -i --include \*.go "sync.Map" .; then
+if grep -rwF --exclude-dir={.git,_build,vendor,externalversions,lock,contrib} --include \*.go "sync.Map" .; then
   echo "Found sync.Map usages. Please use the generic pkg/lock.Map wrapper instead";
   exit 1
 fi


### PR DESCRIPTION
Grepping for `sync.Map` with a single `-i` flag causes false positives on patterns like:
```
Sync(map[int]bool)
```

This happens because case-insensitivity is enabled and unescaped `.` acts as a regex wildcard matching `(`. Same goes for `sync.Mutex` and `sync.RWMutex`.

This change replaces `-i` with `-F` and `-w` to disable regex parsing and require exact word matches.