### PR TITLE
[v1.19] bpf: encap: move & use DSR-GENEVE helpers

### DIFF
--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -193,30 +193,6 @@ __encap_with_nodeid_opt6(struct __ctx_buff *ctx,
 
 	return ctx_set_encap_info6(ctx, tunnel_endpoint, seclabel, opt, opt_len);
 }
-
-static __always_inline void
-set_geneve_dsr_opt4(__be16 port, __be32 addr, struct geneve_dsr_opt4 *gopt)
-{
-	memset(gopt, 0, sizeof(*gopt));
-	gopt->hdr.opt_class = bpf_htons(DSR_GENEVE_OPT_CLASS);
-	gopt->hdr.type = DSR_GENEVE_OPT_TYPE;
-	gopt->hdr.length = DSR_IPV4_GENEVE_OPT_LEN;
-	gopt->addr = addr;
-	gopt->port = port;
-}
-
-static __always_inline void
-set_geneve_dsr_opt6(__be16 port, const union v6addr *addr,
-		    struct geneve_dsr_opt6 *gopt)
-{
-	memset(gopt, 0, sizeof(*gopt));
-	gopt->hdr.opt_class = bpf_htons(DSR_GENEVE_OPT_CLASS);
-	gopt->hdr.type = DSR_GENEVE_OPT_TYPE;
-	gopt->hdr.length = DSR_IPV6_GENEVE_OPT_LEN;
-	ipv6_addr_copy_unaligned((union v6addr *)&gopt->addr, addr);
-
-	gopt->port = port;
-}
 #endif
 
 # if defined(ENABLE_IPV4) || defined(ENABLE_IPV6)

--- a/bpf/lib/ipv6.h
+++ b/bpf/lib/ipv6.h
@@ -171,27 +171,6 @@ static __always_inline int ipv6_hdrlen(struct __ctx_buff *ctx, __u8 *nexthdr)
 	return ipv6_hdrlen_offset(ctx, ETH_HLEN, nexthdr, NULL);
 }
 
-static __always_inline void ipv6_addr_copy(union v6addr *dst,
-					   const union v6addr *src)
-{
-	memcpy(dst, src, sizeof(*dst));
-}
-
-static __always_inline void ipv6_addr_copy_unaligned(union v6addr *dst,
-						     const union v6addr *src)
-{
-	dst->d1 = src->d1;
-	dst->d2 = src->d2;
-}
-
-static __always_inline bool ipv6_addr_equals(const union v6addr *a,
-					     const union v6addr *b)
-{
-	if (a->d1 != b->d1)
-		return false;
-	return a->d2 == b->d2;
-}
-
 static __always_inline
 void ipv6_sol_mc_mac_set(const union v6addr *addr, union macaddr *mac)
 {

--- a/bpf/lib/ipv6_core.h
+++ b/bpf/lib/ipv6_core.h
@@ -22,3 +22,24 @@ union v6addr {
 #define d1 d.d1
 #define d2 d.d2
 } __packed;
+
+static __always_inline void ipv6_addr_copy(union v6addr *dst,
+					   const union v6addr *src)
+{
+	memcpy(dst, src, sizeof(*dst));
+}
+
+static __always_inline void ipv6_addr_copy_unaligned(union v6addr *dst,
+						     const union v6addr *src)
+{
+	dst->d1 = src->d1;
+	dst->d2 = src->d2;
+}
+
+static __always_inline bool ipv6_addr_equals(const union v6addr *a,
+					     const union v6addr *b)
+{
+	if (a->d1 != b->d1)
+		return false;
+	return a->d2 == b->d2;
+}

--- a/bpf/lib/tunnel.h
+++ b/bpf/lib/tunnel.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <linux/ipv6.h>
+#include <lib/ipv6_core.h>
 
 /* The high-order bit of the Geneve option type indicates that
  * this is a critical option.
@@ -36,6 +37,14 @@ struct geneve_opt_hdr {
 #endif
 };
 
+static __always_inline void
+set_geneve_dsr_opt_hdr(struct geneve_opt_hdr *hdr, __u8 length)
+{
+	hdr->opt_class = bpf_htons(DSR_GENEVE_OPT_CLASS);
+	hdr->type = DSR_GENEVE_OPT_TYPE;
+	hdr->length = length;
+}
+
 struct geneve_dsr_opt4 {
 	struct geneve_opt_hdr hdr;
 	__be32 addr;
@@ -43,12 +52,33 @@ struct geneve_dsr_opt4 {
 	__u16 pad;
 };
 
+static __always_inline void
+set_geneve_dsr_opt4(__be16 port, __be32 addr, struct geneve_dsr_opt4 *gopt)
+{
+	memset(gopt, 0, sizeof(*gopt));
+
+	set_geneve_dsr_opt_hdr(&gopt->hdr, DSR_IPV4_GENEVE_OPT_LEN);
+	gopt->addr = addr;
+	gopt->port = port;
+}
+
 struct geneve_dsr_opt6 {
 	struct geneve_opt_hdr hdr;
 	struct in6_addr addr;
 	__be16 port;
 	__u16 pad;
 };
+
+static __always_inline void
+set_geneve_dsr_opt6(__be16 port, const union v6addr *addr,
+		    struct geneve_dsr_opt6 *gopt)
+{
+	memset(gopt, 0, sizeof(*gopt));
+
+	set_geneve_dsr_opt_hdr(&gopt->hdr, DSR_IPV6_GENEVE_OPT_LEN);
+	ipv6_addr_copy_unaligned((union v6addr *)&gopt->addr, addr);
+	gopt->port = port;
+}
 
 struct genevehdr {
 #ifdef __LITTLE_ENDIAN_BITFIELD

--- a/bpf/tests/tc_geneve_dsr_v4_legacy.c
+++ b/bpf/tests/tc_geneve_dsr_v4_legacy.c
@@ -18,6 +18,8 @@
 #define ENCAP_IFINDEX 42
 #define TUNNEL_MODE
 
+#define FRONTEND_PORT		__bpf_htons(80)
+
 #define CLIENT_IP v4_pod_one
 #define CLIENT_PORT __bpf_htons(111)
 
@@ -44,8 +46,7 @@ int mock_skb_get_tunnel_opt(__maybe_unused struct __sk_buff *skb,
 {
 	struct geneve_dsr_opt4 *gopt = opt;
 
-	gopt->hdr.opt_class = bpf_htons(DSR_GENEVE_OPT_CLASS);
-	gopt->hdr.type = DSR_GENEVE_OPT_TYPE;
+	set_geneve_dsr_opt4(FRONTEND_PORT, 0, gopt);
 	return size;
 }
 

--- a/bpf/tests/tc_geneve_dsr_v6_legacy.c
+++ b/bpf/tests/tc_geneve_dsr_v6_legacy.c
@@ -18,6 +18,8 @@
 #define ENCAP_IFINDEX 42
 #define TUNNEL_MODE
 
+#define FRONTEND_PORT		__bpf_htons(80)
+
 #define CLIENT_IP { .addr = { 0x1, 0x0, 0x0, 0x0, 0x0, 0x0 } }
 #define CLIENT_PORT __bpf_htons(111)
 
@@ -43,9 +45,9 @@ int mock_skb_get_tunnel_opt(__maybe_unused struct __sk_buff *skb,
 			    void *opt, __u32 size)
 {
 	struct geneve_dsr_opt6 *gopt = opt;
+	union v6addr zero_addr = {};
 
-	gopt->hdr.opt_class = bpf_htons(DSR_GENEVE_OPT_CLASS);
-	gopt->hdr.type = DSR_GENEVE_OPT_TYPE;
+	set_geneve_dsr_opt6(FRONTEND_PORT, &zero_addr, gopt);
 	return size;
 }
 


### PR DESCRIPTION
Backport
* [ ] #45526

This actually fixed a subtle issue in the DSR-Geneve backend test (the caller doesn't initialize the `geneve_dsr_opt*` struct, and so we **must** set the `port` field - otherwise we rely on uninitialized stack behavior). I just spent way too much time chasing after this ...

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 45526
```