### PR TITLE
azure: remove deprecated CIDR and Subnet status fields

### DIFF
--- a/pkg/azure/api/api.go
+++ b/pkg/azure/api/api.go
@@ -352,7 +352,6 @@ func parseInterface(logger *slog.Logger, iface *armnetwork.Interface, subnets ip
 				if subnet, ok := subnets[i.Subnet.ID]; ok {
 					if subnet.CIDR.IsValid() {
 						i.Subnet.CIDR = iputil.PrefixFrom(subnet.CIDR)
-						i.CIDR = i.Subnet.CIDR //nolint:staticcheck // transitional, see https://github.com/cilium/cilium/issues/46074
 					}
 					i.Gateway = deriveGatewayIP(subnet.CIDR.Addr())
 				}
@@ -379,9 +378,6 @@ func parseInterface(logger *slog.Logger, iface *armnetwork.Interface, subnets ip
 			addr := types.AzureAddress{
 				IP:    iputil.AddrFrom(parsedIP),
 				State: strings.ToLower(string(*ip.Properties.ProvisioningState)),
-			}
-			if ip.Properties.Subnet != nil {
-				addr.Subnet = *ip.Properties.Subnet.ID //nolint:staticcheck // transitional, see https://github.com/cilium/cilium/issues/46074
 			}
 			i.Addresses = append(i.Addresses, addr)
 		}

--- a/pkg/azure/api/api_test.go
+++ b/pkg/azure/api/api_test.go
@@ -159,13 +159,11 @@ func TestParseInterface(t *testing.T) {
 			require.Equal(t, tt.expectedIP, got.IP)
 			require.Equal(t, tt.expectedSubnetID, got.Subnet.ID)
 			require.Equal(t, tt.expectedCIDR, got.Subnet.CIDR)
-			require.Equal(t, tt.expectedCIDR, got.CIDR) //nolint:staticcheck // verifies the deprecated mirror still tracks Subnet.CIDR
 			require.Equal(t, tt.expectedGateway, got.Gateway)
 
 			gotAddrs := make([]iputil.Addr, 0, len(got.Addresses))
 			for _, a := range got.Addresses {
 				gotAddrs = append(gotAddrs, a.IP)
-				require.Equal(t, tt.expectedSubnetID, a.Subnet) //nolint:staticcheck // exercises the deprecated mirror
 			}
 			if tt.expectedAddrs == nil {
 				require.Empty(t, gotAddrs)

--- a/pkg/azure/api/mock/mock.go
+++ b/pkg/azure/api/mock/mock.go
@@ -192,9 +192,8 @@ func (a *API) AssignPrivateIpAddressesVMSS(ctx context.Context, vmName, vmssName
 				panic("Unable to allocate IP from allocator")
 			}
 			intf.Addresses = append(intf.Addresses, types.AzureAddress{
-				IP:     iputil.AddrFrom(ip),
-				Subnet: subnetID, //nolint:staticcheck // deprecated mirror; matches parseInterface, see https://github.com/cilium/cilium/issues/46074
-				State:  types.StateSucceeded,
+				IP:    iputil.AddrFrom(ip),
+				State: types.StateSucceeded,
 			})
 		}
 

--- a/pkg/azure/types/types.go
+++ b/pkg/azure/types/types.go
@@ -55,13 +55,6 @@ type AzureAddress struct {
 	// +optional
 	IP iputil.Addr `json:"ip,omitzero"`
 
-	// Subnet is the subnet the address belongs to.
-	//
-	// Deprecated: use AzureInterface.Subnet.ID. Populated as a mirror for one
-	// release so external consumers of CiliumNode.Status.Azure can migrate.
-	// TODO(https://github.com/cilium/cilium/issues/46074): remove once the migration window closes.
-	Subnet string `json:"subnet,omitempty"`
-
 	// State is the provisioning state of the address
 	State string `json:"state,omitempty"`
 }
@@ -128,15 +121,6 @@ type AzureInterface struct {
 	//
 	// +optional
 	Gateway iputil.Addr `json:"gateway"`
-
-	// CIDR is the range that the interface belongs to.
-	//
-	// Deprecated: use Subnet.CIDR. Retained for one release so agent/operator
-	// rolling upgrades work in either order.
-	// TODO(https://github.com/cilium/cilium/issues/46074): remove once the migration window closes.
-	//
-	// +optional
-	CIDR iputil.Prefix `json:"cidr,omitzero"`
 
 	// vmssName is the name of the virtual machine scale set. This field is
 	// set by extractIDs()

--- a/pkg/azure/types/zz_generated.deepcopy.go
+++ b/pkg/azure/types/zz_generated.deepcopy.go
@@ -38,7 +38,6 @@ func (in *AzureInterface) DeepCopyInto(out *AzureInterface) {
 	}
 	in.Subnet.DeepCopyInto(&out.Subnet)
 	in.Gateway.DeepCopyInto(&out.Gateway)
-	in.CIDR.DeepCopyInto(&out.CIDR)
 	return
 }
 

--- a/pkg/azure/types/zz_generated.deepequal.go
+++ b/pkg/azure/types/zz_generated.deepequal.go
@@ -19,9 +19,6 @@ func (in *AzureAddress) DeepEqual(other *AzureAddress) bool {
 		return false
 	}
 
-	if in.Subnet != other.Subnet {
-		return false
-	}
 	if in.State != other.State {
 		return false
 	}
@@ -77,10 +74,6 @@ func (in *AzureInterface) DeepEqual(other *AzureInterface) bool {
 	}
 
 	if !in.Gateway.DeepEqual(&other.Gateway) {
-		return false
-	}
-
-	if !in.CIDR.DeepEqual(&other.CIDR) {
 		return false
 	}
 

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	alibabaCloudTypes "github.com/cilium/cilium/pkg/alibabacloud/types"
-	azureTypes "github.com/cilium/cilium/pkg/azure/types"
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/ip"
@@ -252,7 +251,7 @@ func deriveVpcCIDRs(node *ciliumv2.CiliumNode) (primaryCIDR *cidr.CIDR, secondar
 		}
 	}
 	for _, azif := range node.Status.Azure.Interfaces {
-		if p := azureInterfaceCIDR(azif); p.IsValid() {
+		if p := azif.Subnet.CIDR.Prefix; p.IsValid() {
 			primaryCIDR = cidr.NewCIDR(netipx.PrefixIPNet(p.Masked()))
 			return
 		}
@@ -722,7 +721,7 @@ func (a *crdAllocator) buildAllocationResult(addr netip.Addr, ipInfo *ipamTypes.
 				if iface.Gateway.IsValid() {
 					result.GatewayIP = iface.Gateway.Addr
 				}
-				if p := azureInterfaceCIDR(iface); p.IsValid() {
+				if p := iface.Subnet.CIDR.Prefix; p.IsValid() {
 					result.CIDRs = append(result.CIDRs, p)
 				}
 				// Add manually configured Native Routing CIDR
@@ -968,17 +967,4 @@ func (e *ErrIPNotAvailableInPool) Is(target error) bool {
 		return false
 	}
 	return t.addr == e.addr
-}
-
-// azureInterfaceCIDR returns Subnet.CIDR, falling back to the deprecated
-// AzureInterface.CIDR for CiliumNodes written by operators predating the
-// Subnet.CIDR migration.
-//
-// TODO(https://github.com/cilium/cilium/issues/46074): remove once
-// AzureInterface.CIDR is deleted.
-func azureInterfaceCIDR(iface azureTypes.AzureInterface) netip.Prefix {
-	if iface.Subnet.CIDR.IsValid() {
-		return iface.Subnet.CIDR.Prefix
-	}
-	return iface.CIDR.Prefix //nolint:staticcheck // fallback for operators predating the Subnet.CIDR migration
 }

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -28,48 +28,6 @@ import (
 	"github.com/cilium/cilium/pkg/trigger"
 )
 
-func TestAzureInterfaceCIDR(t *testing.T) {
-	tests := []struct {
-		name  string
-		iface azureTypes.AzureInterface
-		want  netip.Prefix
-	}{
-		{
-			name: "new operator: Subnet.CIDR populated, flat CIDR mirrored",
-			iface: azureTypes.AzureInterface{
-				Subnet: azureTypes.AzureSubnet{CIDR: iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.0/24"))},
-				CIDR:   iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.0/24")), //nolint:staticcheck // exercises the dual-write path
-			},
-			want: netip.MustParsePrefix("10.0.0.0/24"),
-		},
-		{
-			name: "old operator: only flat CIDR set, fallback used",
-			iface: azureTypes.AzureInterface{
-				CIDR: iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.0/24")), //nolint:staticcheck // exercises the legacy-only path
-			},
-			want: netip.MustParsePrefix("10.0.0.0/24"),
-		},
-		{
-			name: "Subnet.CIDR wins when fields disagree",
-			iface: azureTypes.AzureInterface{
-				Subnet: azureTypes.AzureSubnet{CIDR: iputil.PrefixFrom(netip.MustParsePrefix("10.0.1.0/24"))},
-				CIDR:   iputil.PrefixFrom(netip.MustParsePrefix("10.0.0.0/24")), //nolint:staticcheck // exercises preference order
-			},
-			want: netip.MustParsePrefix("10.0.1.0/24"),
-		},
-		{
-			name:  "neither field set: zero Prefix",
-			iface: azureTypes.AzureInterface{},
-			want:  netip.Prefix{},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, azureInterfaceCIDR(tt.iface))
-		})
-	}
-}
-
 func TestIPNotAvailableInPoolError(t *testing.T) {
 	err := NewIPNotAvailableInPoolError(netip.MustParseAddr("1.1.1.1"))
 	err2 := NewIPNotAvailableInPoolError(netip.MustParseAddr("1.1.1.1"))

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
@@ -556,23 +556,8 @@ spec:
                                 description: State is the provisioning state of the
                                   address
                                 type: string
-                              subnet:
-                                description: |-
-                                  Subnet is the subnet the address belongs to.
-
-                                  Deprecated: use AzureInterface.Subnet.ID. Populated as a mirror for one
-                                  release so external consumers of CiliumNode.Status.Azure can migrate.
-                                type: string
                             type: object
                           type: array
-                        cidr:
-                          description: |-
-                            CIDR is the range that the interface belongs to.
-
-                            Deprecated: use Subnet.CIDR. Retained for one release so agent/operator
-                            rolling upgrades work in either order.
-                          format: cidr
-                          type: string
                         gateway:
                           description: Gateway is the interface's subnet's default
                             route


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

The `AzureInterface.CIDR` and `AzureAddress.Subnet` fields on
`CiliumNode.Status.Azure` were deprecated in #45985 in favor of the shared
`AzureInterface.Subnet` object (`Subnet.ID` and `Subnet.CIDR`). They were
retained for one release (1.20) as populated mirrors so that agent/operator
rolling upgrades work in either order and external consumers could migrate.

Now that 1.20 is branched, this removes the deprecated fields
and migrates the remaining reader (`pkg/ipam` VPC CIDR derivation) to read
`Subnet.CIDR` directly. The transitional dual-write in `parseInterface`, the
mock, and the `azureInterfaceCIDR` fallback helper are dropped, and the
generated deepcopy/deepequal code and the CiliumNode CRD manifest are
regenerated to match.

This PR was prepared with AIL:3. I used Claude Code to review issue #46074 and
implement the change; I directed the scope and reviewed the entire result.

Fixes: #46074

```release-note
Removed the deprecated `cidr` field from `CiliumNode.Status.Azure` interfaces and the deprecated `subnet` field from their addresses; use `interfaces[].subnet.{id,cidr}` instead.
```
