### PR TITLE
gateway-api: nodeSelector with hostNetwork enabled

### DIFF
--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -16,6 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrlRuntime "sigs.k8s.io/controller-runtime"
@@ -284,6 +285,10 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 	cecTranslator := translation.NewCECTranslator(cfg)
 
 	gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator, cfg)
+	var nodeLabelSelector v1.LabelSelector
+	if cfg.HostNetworkConfig.NodeLabelSelector != nil {
+		nodeLabelSelector = v1.LabelSelector{MatchLabels: cfg.HostNetworkConfig.NodeLabelSelector.MatchLabels}
+	}
 
 	if err := registerReconcilers(
 		params.CtrlRuntimeManager,
@@ -292,6 +297,7 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 		defaultControllerName,
 		installedOptionalKinds,
 		cfg.HostNetworkConfig.Enabled,
+		nodeLabelSelector,
 	); err != nil {
 		return fmt.Errorf("failed to create gateway controller: %w", err)
 	}
@@ -421,12 +427,13 @@ func registerReconcilers(
 	controllerName string,
 	installedOptionalCRDs []schema.GroupVersionKind,
 	hostNetworkEnabled bool,
+	hostNetworkLabel v1.LabelSelector,
 ) error {
 	requiredReconcilers := []interface {
 		SetupWithManager(mgr ctrlRuntime.Manager) error
 	}{
 		newGatewayClassReconciler(mgr, logger, controllerName),
-		newGatewayReconciler(mgr, translator, logger, controllerName, hostNetworkEnabled),
+		newGatewayReconciler(mgr, translator, logger, controllerName, hostNetworkEnabled, hostNetworkLabel),
 		newGammaReconciler(mgr, translator, logger, controllerName),
 		newGatewayClassConfigReconciler(mgr, logger),
 		newEndpointSliceReconciler(mgr, logger),

--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -9,6 +9,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -50,9 +51,11 @@ type gatewayReconciler struct {
 	controllerName                string
 	tcpUDPRouteSupport            bool
 	tcpUDPUnsupportedReason       string
+	hostNetworkEnabled            bool
+	hostNetworkLabel              metav1.LabelSelector
 }
 
-func newGatewayReconciler(mgr ctrl.Manager, translator translation.Translator, logger *slog.Logger, controllerName string, hostNetworkEnabled bool) *gatewayReconciler {
+func newGatewayReconciler(mgr ctrl.Manager, translator translation.Translator, logger *slog.Logger, controllerName string, hostNetworkEnabled bool, hostNetworkLabel metav1.LabelSelector) *gatewayReconciler {
 	scopedLog := logger.With(logfields.Controller, gateway)
 	includeTCPRoutes := helpers.HasTCPRouteSupport(mgr.GetScheme())
 	includeUDPRoutes := helpers.HasUDPRouteSupport(mgr.GetScheme())
@@ -68,7 +71,7 @@ func newGatewayReconciler(mgr ctrl.Manager, translator translation.Translator, l
 			IncludeServiceImports: helpers.HasServiceImportSupport(mgr.GetScheme()),
 			IncludeListenerSets:   helpers.HasListenerSetSupport(mgr.GetScheme()),
 		}),
-		gatewayAddressStatusManager: NewGatewayAddressStatusManager(mgr.GetClient(), scopedLog),
+		gatewayAddressStatusManager: NewGatewayAddressStatusManager(mgr.GetClient(), scopedLog, hostNetworkLabel),
 		listenerStatusManager: NewListenerStatusManager(
 			mgr.GetClient(),
 			scopedLog,
@@ -93,6 +96,8 @@ func newGatewayReconciler(mgr ctrl.Manager, translator translation.Translator, l
 		controllerName:                controllerName,
 		tcpUDPRouteSupport:            tcpUDPRouteSupport,
 		tcpUDPUnsupportedReason:       hostNetworkTCPUDPRouteUnsupportedReason,
+		hostNetworkEnabled:            hostNetworkEnabled,
+		hostNetworkLabel:              hostNetworkLabel,
 	}
 }
 

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -35,6 +35,7 @@ import (
 	gatewayApiTranslation "github.com/cilium/cilium/operator/pkg/model/translation/gateway-api"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	slim_meta_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/shortener"
 )
 
@@ -109,6 +110,7 @@ func Test_Conformance(t *testing.T) {
 		skipCEC              bool
 		wantErr              bool
 		hostNetwork          bool
+		nodeLabelSelector    metav1.LabelSelector
 	}{
 		{
 			name: "gateway-http-listener-isolation",
@@ -335,12 +337,18 @@ func Test_Conformance(t *testing.T) {
 		{name: "gateway-cross-protocol-same-port-same-hostname", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "cross-protocol-same-port-same-hostname", Namespace: "gateway-conformance-infra"}, wantErr: true}}},
 		{name: "gateway-ns-restricted-same-hostname", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "ns-restricted-same-hostname", Namespace: "gateway-conformance-infra"}}}},
 		{name: "gatewayclassconfig-nodeport", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "nodeport-gateway", Namespace: "gateway-conformance-infra"}}}},
+		// hostNetwork mode tests
 		{name: "hostNetwork-enabled-valid", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "hostnetwork-enabled", Namespace: "gateway-conformance-infra"}}}, hostNetwork: true},
 		{name: "hostNetwork-enabled-exceed-max-address", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "hostnetwork-enabled", Namespace: "gateway-conformance-infra"}}}, hostNetwork: true},
 		{name: "hostNetwork-enabled-no-l4-listeners", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "host-networking", Namespace: "gateway-conformance-infra"}}}, hostNetwork: true},
 		{name: "hostNetwork-enabled-mixed-routes", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "host-networking", Namespace: "gateway-conformance-infra"}}}, hostNetwork: true},
 		{name: "hostNetwork-enabled-tcp-route", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "host-networking", Namespace: "gateway-conformance-infra"}, wantErr: true, skipCEC: true}}, hostNetwork: true},
 		{name: "hostNetwork-enabled-udp-route", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "host-networking", Namespace: "gateway-conformance-infra"}, wantErr: true, skipCEC: true}}, hostNetwork: true},
+		{name: "hostNetwork-enabled-nodelabel", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "hostnetwork-enabled-nodeselector", Namespace: "gateway-conformance-infra"}, wantErr: false, skipCEC: true}}, hostNetwork: true,
+			nodeLabelSelector: metav1.LabelSelector{MatchLabels: map[string]string{
+				"role": "gateway",
+			}}},
+
 		// ListenerSet tests
 		{name: "listenerset-default-not-allowed", gateway: []gwDetails{
 			{FullName: types.NamespacedName{Name: "default-not-allowed", Namespace: "gateway-conformance-infra"}},
@@ -440,6 +448,7 @@ func Test_Conformance(t *testing.T) {
 			clientBuilder.WithIndex(&gatewayv1.TLSRoute{}, indexers.TLSRouteListenerSetIndex, indexers.IndexTLSRouteByListenerSet)
 
 			c := clientBuilder.Build()
+			nodeLabel := &slim_meta_v1.LabelSelector{MatchLabels: tt.nodeLabelSelector.MatchLabels}
 			gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator, translation.Config{
 				ServiceConfig: translation.ServiceConfig{
 					ExternalTrafficPolicy: string(corev1.ServiceExternalTrafficPolicyCluster),
@@ -448,7 +457,8 @@ func Test_Conformance(t *testing.T) {
 					UseRemoteAddress: true,
 				},
 				HostNetworkConfig: translation.HostNetworkConfig{
-					Enabled: tt.hostNetwork,
+					Enabled:           tt.hostNetwork,
+					NodeLabelSelector: nodeLabel,
 				},
 			})
 
@@ -462,7 +472,7 @@ func Test_Conformance(t *testing.T) {
 					IncludeServiceImports: helpers.HasServiceImportSupport(c.Scheme()),
 					IncludeListenerSets:   helpers.HasListenerSetSupport(c.Scheme()),
 				}),
-				gatewayAddressStatusManager: NewGatewayAddressStatusManager(c, logger),
+				gatewayAddressStatusManager: NewGatewayAddressStatusManager(c, logger, tt.nodeLabelSelector),
 				listenerStatusManager: NewListenerStatusManager(c, logger, ListenerStatusManagerConfig{
 					TCPUDPRouteSupport:      !tt.hostNetwork,
 					TCPUDPUnsupportedReason: hostNetworkTCPUDPRouteUnsupportedReason,
@@ -478,6 +488,8 @@ func Test_Conformance(t *testing.T) {
 				controllerName:                defaultControllerName,
 				tcpUDPRouteSupport:            !tt.hostNetwork,
 				tcpUDPUnsupportedReason:       hostNetworkTCPUDPRouteUnsupportedReason,
+				hostNetworkEnabled:            tt.hostNetwork,
+				hostNetworkLabel:              tt.nodeLabelSelector,
 			}
 
 			// Reconcile all related HTTPRoute objects

--- a/operator/pkg/gateway-api/status_gateway_address.go
+++ b/operator/pkg/gateway-api/status_gateway_address.go
@@ -21,14 +21,16 @@ import (
 )
 
 type GatewayAddressStatusManager struct {
-	client client.Client
-	logger *slog.Logger
+	client           client.Client
+	logger           *slog.Logger
+	hostNetworkLabel []metav1.LabelSelector
 }
 
-func NewGatewayAddressStatusManager(client client.Client, logger *slog.Logger) *GatewayAddressStatusManager {
+func NewGatewayAddressStatusManager(client client.Client, logger *slog.Logger, hostNetworkLabel ...metav1.LabelSelector) *GatewayAddressStatusManager {
 	return &GatewayAddressStatusManager{
-		client: client,
-		logger: logger,
+		client:           client,
+		logger:           logger,
+		hostNetworkLabel: hostNetworkLabel,
 	}
 }
 
@@ -88,28 +90,38 @@ func (m *GatewayAddressStatusManager) SetAddressStatus(ctx context.Context, gw *
 		// NodePort service gets as many Node
 		// IP addresses as we can fit into Status
 		nodes := &corev1.NodeList{}
-		if err := m.client.List(ctx, nodes); err != nil {
-			setGatewayProgrammed(gw, metav1.ConditionFalse, "Address is not ready, failed to load nodes", gatewayv1.GatewayReasonAddressNotAssigned)
-			return fmt.Errorf("failed to load nodes: %w", err)
-		}
 
 		ips := make([]netip.Addr, 0)
-		for _, node := range nodes.Items {
-			if len(node.Status.Addresses) == 0 {
-				continue
-			}
-			nodeAddress := node.Status.Addresses[0]
-			ip, err := netip.ParseAddr(nodeAddress.Address)
+		// for every label that is present, determine if there are any nodes with those labels and
+		// add them to the list of ips
+		for _, s := range m.hostNetworkLabel {
+			selector, err := metav1.LabelSelectorAsSelector(&s)
 			if err != nil {
-				// the first address is not an IP address (e.g. a hostname),
-				// skip the node instead of reporting an invalid address.
-				continue
+				return fmt.Errorf("unable to get node selector label")
 			}
-			ips = append(ips, ip.Unmap())
+			if err := m.client.List(ctx, nodes, &client.ListOptions{
+				LabelSelector: selector,
+			}); err != nil {
+				return fmt.Errorf("unable to list nodes")
+			}
+			for _, node := range nodes.Items {
+				if len(node.Status.Addresses) == 0 {
+					continue
+				}
+				nodeAddress := node.Status.Addresses[0]
+				ip, err := netip.ParseAddr(nodeAddress.Address)
+				if err != nil {
+					// the first address is not an IP address (e.g. a hostname),
+					// skip the node instead of reporting an invalid address.
+					continue
+				}
+				ips = append(ips, ip.Unmap())
+			}
 		}
 
 		// sort the addresses for consistent ip addresses assigned
 		slices.SortFunc(ips, netip.Addr.Compare)
+
 		// allows for only a max of 16 addresses
 		if len(ips) > 16 {
 			ips = ips[:16]

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-nodelabel/input/gateway.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-nodelabel/input/gateway.yaml
@@ -1,0 +1,84 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: hostnetwork-enabled-nodeselector
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cilium-gateway-hostnetwork-enabled-nodeselector
+  namespace: gateway-conformance-infra
+  labels:
+    gateway.networking.k8s.io/gateway-name: hostnetwork-enabled-nodeselector
+    io.cilium.gateway/owning-gateway: hostnetwork-enabled-nodeselector
+spec:
+  ports:
+    - port: 3000
+      targetPort: 80
+      nodePort: 30020
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.3
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker2
+  labels:
+    role: gateway
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.4
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker3
+spec:
+  podCIDR: 10.244.1.0/24
+  podCIDRs:
+  - 10.244.1.0/24
+  - fd00:10:244:1::/64
+status:
+  addresses:
+  - address: 172.18.0.5
+    type: InternalIP
+  - address: fc00:f853:ccd:e793::3
+    type: InternalIP
+  - address: kind-worker
+    type: Hostname

--- a/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-nodelabel/output/hostnetwork-enabled-nodeselector.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/hostNetwork-enabled-nodelabel/output/hostnetwork-enabled-nodeselector.yaml
@@ -1,0 +1,54 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: hostnetwork-enabled-nodeselector
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: Same
+status:
+  addresses:
+    - type: IPAddress
+      value: 172.18.0.4
+  conditions:
+    - lastTransitionTime: "2026-05-05T19:06:19Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2026-05-05T19:06:19Z"
+      message: Gateway Programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 0
+      name: "http"
+      conditions:
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2026-05-05T19:06:19Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/gateway-api/watch-handlers/node.go
+++ b/operator/pkg/gateway-api/watch-handlers/node.go
@@ -25,12 +25,7 @@ func EnqueueRequestForNodes(c client.Client, logger *slog.Logger, owningGatewayL
 		scopedLog := logger.With(
 			logfields.K8sNamespace, ns.GetName(),
 		)
-		nodeList := &corev1.NodeList{}
-		if err := c.List(ctx, nodeList); err != nil {
-			scopedLog.WarnContext(ctx, "Unable to list nodes", logfields.Error, err)
-			return nil
-		}
-
+		// get all the gateways with cilium controller name
 		gateways, err := getAllGatewaysSetForController(ctx, c, controllerName)
 
 		if err != nil {
@@ -40,7 +35,7 @@ func EnqueueRequestForNodes(c client.Client, logger *slog.Logger, owningGatewayL
 
 		reqs := make([]reconcile.Request, 0, len(gateways))
 		svcList := &corev1.ServiceList{}
-		svcMap := make(map[string]struct{})
+		svcMap := make(map[types.UID]struct{})
 
 		// for each gateway, filter for the services owned by the gateway
 		for gw := range gateways {
@@ -53,8 +48,8 @@ func EnqueueRequestForNodes(c client.Client, logger *slog.Logger, owningGatewayL
 			}
 			// if the service owned by the gateway is a nodeport, add to map of UID
 			for _, svc := range svcList.Items {
-				if svc.Spec.Type == corev1.ServiceTypeNodePort {
-					svcMap[string(svc.GetOwnerReferences()[0].UID)] = struct{}{}
+				if svc.Spec.Type == "NodePort" {
+					svcMap[svc.GetOwnerReferences()[0].UID] = struct{}{}
 				}
 			}
 		}
@@ -80,13 +75,13 @@ func EnqueueRequestForNodes(c client.Client, logger *slog.Logger, owningGatewayL
 			if err := c.Get(ctx, gatewayNamespaceName, gateway); err != nil {
 				scopedLog.WarnContext(ctx, "Unable to get gateway", logfields.Error, err)
 			}
-			if _, err := svcMap[string(gateway.GetUID())]; err {
-				// there is no nodeport svc for this gateway, no need to reconcile
-				continue
+
+			if _, exist := svcMap[gateway.GetUID()]; exist {
+				// gateway present in svcMap have a nodeport service and should be queued for reconcile
+				reqs = append(reqs, reconcile.Request{
+					NamespacedName: gatewayNamespaceName,
+				})
 			}
-			reqs = append(reqs, reconcile.Request{
-				NamespacedName: gatewayNamespaceName,
-			})
 		}
 		return reqs
 	})


### PR DESCRIPTION


<!-- Description of change -->
As noted in #47456, the node addresses all get added when hostNetwork is enabled. If a user enables Cilium + GWAPI with hostnetwork enabled and labels a node or nodes, then only those address should populate the gateway ip address.
Adding in test case to ensure functionality

Fixes: #47456

```release-note
gateway-api: node label selector for when hostNetwork is enabled
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
