### PR TITLE
gateway-api: migrate net.IP usage to net/netip

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -4,13 +4,12 @@
 package gateway_api
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"log/slog"
-	"net"
-	"sort"
+	"net/netip"
+	"slices"
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
@@ -1039,19 +1038,23 @@ func (r *gatewayReconciler) setAddressStatus(ctx context.Context, gw *gatewayv1.
 			return fmt.Errorf("unable to list nodes")
 		}
 
-		ips := make([]net.IP, 0)
+		ips := make([]netip.Addr, 0)
 		for _, node := range nodes.Items {
 			if len(node.Status.Addresses) == 0 {
 				continue
 			}
 			nodeAddress := node.Status.Addresses[0]
-			ips = append(ips, net.ParseIP(nodeAddress.Address))
+			ip, err := netip.ParseAddr(nodeAddress.Address)
+			if err != nil {
+				// the first address is not an IP address (e.g. a hostname),
+				// skip the node instead of reporting an invalid address.
+				continue
+			}
+			ips = append(ips, ip.Unmap())
 		}
 
 		// sort the addresses for consistent ip addresses assigned
-		sort.Slice(ips, func(i, j int) bool {
-			return bytes.Compare(ips[i], ips[j]) < 0
-		})
+		slices.SortFunc(ips, netip.Addr.Compare)
 
 		// allows for only a max of 16 addresses
 		if len(ips) > 16 {
@@ -1420,8 +1423,7 @@ func (r *gatewayReconciler) verifyGatewayStaticAddresses(gw *gatewayv1.Gateway) 
 		if address.Value == "" {
 			return fmt.Errorf("address value is not set")
 		}
-		ip := net.ParseIP(address.Value)
-		if ip == nil {
+		if _, err := netip.ParseAddr(address.Value); err != nil {
 			return fmt.Errorf("invalid ip address")
 		}
 	}

--- a/operator/pkg/gateway-api/testdata/gateway/gatewayclassconfig-nodeport/input/nodeport-gateway.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gatewayclassconfig-nodeport/input/nodeport-gateway.yaml
@@ -84,3 +84,17 @@ status:
     type: InternalIP
   - address: kind-worker
     type: Hostname
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: kind-worker3
+spec:
+  podCIDR: 10.244.2.0/24
+  podCIDRs:
+  - 10.244.2.0/24
+  - fd00:10:244:2::/64
+status:
+  addresses:
+  - address: kind-worker3
+    type: Hostname


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy](https://github.com/cilium/community/blob/main/AI-POLICY.md), and indicate the rating using
      [AI Influence Level](https://danielmiessler.com/blog/ai-influence-level-ail).
- [x] Thanks for contributing!

Convert the remaining `net.IP` usage in the Gateway API operator to `net/netip`, as a small slice of the tree-wide migration tracked in #24246.

- `setAddressStatus` (NodePort branch): node addresses are now parsed with `netip.ParseAddr` and sorted with `netip.Addr.Compare`. A node whose first status address is not an IP literal (e.g. a `Hostname` entry) is now skipped instead of being appended as a nil `net.IP`, which previously rendered as a bogus `<nil>` address in the Gateway status. Parsed addresses are `Unmap()`-ed so IPv4-mapped IPv6 inputs keep rendering in dotted-quad form as before. With mixed address families the sort now places IPv4 before IPv6 instead of interleaving the IPv4-mapped form inside the IPv6 space; the sort only exists to keep the reported addresses deterministic, which is preserved.
- `verifyGatewayStaticAddresses`: `netip.ParseAddr` replaces the `net.ParseIP` nil check. Semantics are unchanged for valid IPv4/IPv6 literals; zoned IPv6 literals are additionally accepted.
- The nodeport testdata gains a node whose only status address is a `Hostname` entry, locking in the skip behavior through the existing `Test_Conformance`/`gatewayclassconfig-nodeport` case (the previous code turns it into a leading `<nil>` status address and fails the case). The `hostNetwork-enabled-exceed-max-address` case keeps covering sorting and the 16-address cap.

Verified locally with `GOOS=linux go build`, `go vet` and `go test -c` on `operator/pkg/gateway-api` (a darwin host cannot link the linux-only test dependencies, so I could not execute the suite locally — CI should exercise it).

This PR was prepared with AIL:3. I personally reviewed every line of the submission and validated the behavioral notes above against the previous implementation.

Related: #24246

```release-note
Gateway API: the Gateway address status no longer reports a bogus "<nil>" address when a Node's first status address is not an IP literal (e.g. a Hostname entry).
```
