### PR TITLE
gitattributes: Restore rST syntax highlighting for upgrade notes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 /install/kubernetes/cilium/values.yaml linguist-generated
 /install/kubernetes/cilium/README.md linguist-generated
 go.sum linguist-generated
+vendor/modules.txt linguist-generated
 examples/kubernetes/connectivity-check/connectivity-*.yaml linguist-generated
 pkg/k8s/apis/cilium.io/v2/client/crds/*.yaml linguist-generated
 test/controlplane/**/v1.[0-9][0-9]/*.yaml linguist-generated
@@ -19,6 +20,8 @@ pkg/k8s/client/informers/** linguist-generated
 pkg/k8s/client/listers/** linguist-generated
 *.bt linguist-language=D
 pkg/datapath/config/*_config.go linguist-generated
+Documentation/**/*.inc linguist-language=reStructuredText
+Documentation/**/*.rst.tmpl linguist-language=reStructuredText
 
 # Merge driver configuration for specific paths
 # To set up these merge drivers locally, run:


### PR DESCRIPTION
The upgrade notes fragments cannot carry an `.rst` extension: Sphinx would then build them as standalone documents and fail on duplicate labels with the file that '.. include::'s them. This PR manually configures their Linguist language via `.gitattributes` which GitHub uses for syntax highlighting. This allows both keeping the current file names and restoring syntax highlighting.

While at it, I also marked `vendor/modules.txt` as generated so that it gets collapsed like `go.sum` in PR diffs.

Fixes: #47218
