### PR TITLE
v1.19: gateway-api backports 2026-07-24

### DIFF
--- a/operator/pkg/gateway-api/gamma_reconcile.go
+++ b/operator/pkg/gateway-api/gamma_reconcile.go
@@ -182,6 +182,8 @@ func (r *gammaReconciler) setHTTPRouteStatuses(gammaLogger *slog.Logger, ctx con
 			HTTPRoute: hr,
 		}
 
+		badRegexCond, hasBadRegex := i.ValidateMatchRegexps()
+
 		// Route validators
 		for _, parent := range hr.Spec.ParentRefs {
 
@@ -231,6 +233,10 @@ func (r *gammaReconciler) setHTTPRouteStatuses(gammaLogger *slog.Logger, ctx con
 				if !continueCheck {
 					break
 				}
+			}
+
+			if hasBadRegex {
+				i.SetParentCondition(parent, badRegexCond)
 			}
 
 			// Update the cached copy with the same status changes to prevent re-fetching from client cache.
@@ -285,6 +291,8 @@ func (r *gammaReconciler) setGRPCRouteStatuses(gammaLogger *slog.Logger, ctx con
 			GRPCRoute: grpc,
 		}
 
+		badRegexCond, hasBadRegex := i.ValidateMatchRegexps()
+
 		// Route validators
 		for _, parent := range grpc.Spec.ParentRefs {
 
@@ -334,6 +342,10 @@ func (r *gammaReconciler) setGRPCRouteStatuses(gammaLogger *slog.Logger, ctx con
 				if !continueCheck {
 					break
 				}
+			}
+
+			if hasBadRegex {
+				i.SetParentCondition(parent, badRegexCond)
 			}
 
 			// Update the cached copy with the same status changes to prevent re-fetching from client cache.

--- a/operator/pkg/gateway-api/gamma_reconcile.go
+++ b/operator/pkg/gateway-api/gamma_reconcile.go
@@ -123,10 +123,13 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return controllerruntime.Fail(err)
 	}
 
+	httpRoutes := r.filterHTTPRoutesByService(ctx, originalSvc, httpRouteList.Items)
+	grpcRoutes := r.filterGRPCRoutesByService(ctx, originalSvc, grpcRouteList.Items)
+
 	// TODO(youngnick): GammaHTTPRoutes needs to be updated now that we have a source Service.
 	httpListeners := ingestion.GammaHTTPRoutes(r.logger, ingestion.GammaInput{
-		HTTPRoutes: httpRouteList.Items,
-		GRPCRoutes: grpcRouteList.Items,
+		HTTPRoutes: httpRoutes,
+		GRPCRoutes: grpcRoutes,
 		Services:   servicesList.Items,
 
 		ReferenceGrants: grants.Items,
@@ -161,7 +164,7 @@ func (r *gammaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 func (r *gammaReconciler) setHTTPRouteStatuses(gammaLogger *slog.Logger, ctx context.Context, gammaService *corev1.Service, httpRoutes *gatewayv1.HTTPRouteList, grants *gatewayv1beta1.ReferenceGrantList) error {
 	gammaLogger.DebugContext(ctx, "Updating HTTPRoute statuses for GAMMA Service", numRoutes, len(httpRoutes.Items))
-	for _, original := range httpRoutes.Items {
+	for httpRouteIndex, original := range httpRoutes.Items {
 
 		hr := original.DeepCopy()
 		hr.Status.Parents = pruneRouteParentStatuses(hr.Status.Parents, hr.Spec.ParentRefs)
@@ -230,6 +233,8 @@ func (r *gammaReconciler) setHTTPRouteStatuses(gammaLogger *slog.Logger, ctx con
 				}
 			}
 
+			// Update the cached copy with the same status changes to prevent re-fetching from client cache.
+			httpRoutes.Items[httpRouteIndex].Status = hr.Status
 		}
 
 		if err := r.updateHTTPRouteStatus(ctx, &original, hr); err != nil {
@@ -240,9 +245,29 @@ func (r *gammaReconciler) setHTTPRouteStatuses(gammaLogger *slog.Logger, ctx con
 	return nil
 }
 
+func (r *gammaReconciler) filterHTTPRoutesByService(ctx context.Context, gammaService *corev1.Service, routes []gatewayv1.HTTPRoute) []gatewayv1.HTTPRoute {
+	var filtered []gatewayv1.HTTPRoute
+	for _, route := range routes {
+		if helpers.IsParentAttachable(ctx, gammaService, &route, route.Status.Parents) {
+			filtered = append(filtered, route)
+		}
+	}
+	return filtered
+}
+
+func (r *gammaReconciler) filterGRPCRoutesByService(ctx context.Context, gammaService *corev1.Service, routes []gatewayv1.GRPCRoute) []gatewayv1.GRPCRoute {
+	var filtered []gatewayv1.GRPCRoute
+	for _, route := range routes {
+		if helpers.IsParentAttachable(ctx, gammaService, &route, route.Status.Parents) {
+			filtered = append(filtered, route)
+		}
+	}
+	return filtered
+}
+
 func (r *gammaReconciler) setGRPCRouteStatuses(gammaLogger *slog.Logger, ctx context.Context, gammaService *corev1.Service, grpcRoutes *gatewayv1.GRPCRouteList, grants *gatewayv1beta1.ReferenceGrantList) error {
 	gammaLogger.DebugContext(ctx, "Updating GRPCRoute statuses for GAMMA Service", numRoutes, len(grpcRoutes.Items))
-	for _, original := range grpcRoutes.Items {
+	for grpcRouteIndex, original := range grpcRoutes.Items {
 
 		grpc := original.DeepCopy()
 		grpc.Status.Parents = pruneRouteParentStatuses(grpc.Status.Parents, grpc.Spec.ParentRefs)
@@ -310,6 +335,9 @@ func (r *gammaReconciler) setGRPCRouteStatuses(gammaLogger *slog.Logger, ctx con
 					break
 				}
 			}
+
+			// Update the cached copy with the same status changes to prevent re-fetching from client cache.
+			grpcRoutes.Items[grpcRouteIndex].Status = grpc.Status
 
 		}
 

--- a/operator/pkg/gateway-api/gamma_reconcile_test.go
+++ b/operator/pkg/gateway-api/gamma_reconcile_test.go
@@ -119,7 +119,7 @@ func Test_gammaReconciler_Reconcile(t *testing.T) {
 
 					t.Logf("Test %s, HTTPRoutes: %d, GRPCRoutes: %d", tt.name, len(filterHTTPRouteList), len(filterGRPCRouteList))
 					result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: serviceKey})
-					require.Equal(t, tt.wantErr, err != nil, "Error mismatch")
+					require.Equal(t, tt.wantErr, err != nil, "Error mismatch, error was %s", err)
 					require.Equal(t, ctrl.Result{}, result)
 
 					// Checking the output for Service

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -396,11 +396,16 @@ func (r *gatewayReconciler) getGatewayClassConfig(ctx context.Context, gwc *gate
 		return nil
 	}
 
-	res := &v2alpha1.CiliumGatewayClassConfig{}
-	if err := r.Client.Get(ctx, client.ObjectKey{
+	key := client.ObjectKey{
 		Namespace: string(*gwc.Spec.ParametersRef.Namespace),
 		Name:      gwc.Spec.ParametersRef.Name,
-	}, res); err != nil {
+	}
+
+	res := &v2alpha1.CiliumGatewayClassConfig{}
+	if err := r.Client.Get(ctx, key, res); err != nil {
+		r.logger.ErrorContext(ctx, "Failed to get CiliumGatewayClassConfig",
+			logfields.Resource, key,
+			logfields.Error, err)
 		return nil
 	}
 	return res

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -973,6 +973,12 @@ func (r *gatewayReconciler) setHTTPRouteStatuses(scopedLog *slog.Logger, ctx con
 			return r.handleHTTPRouteReconcileErrorWithStatus(ctx, scopedLog, err, &original, hr)
 		}
 
+		if cond, invalid := i.ValidateMatchRegexps(); invalid {
+			for _, parent := range hr.Status.Parents {
+				i.SetParentCondition(parent.ParentRef, cond)
+			}
+		}
+
 		// Checks finished, apply the status to the actual objects.
 		if err := r.updateHTTPRouteStatus(ctx, scopedLog, &original, hr); err != nil {
 			return fmt.Errorf("failed to update HTTPRoute status: %w", err)
@@ -1041,7 +1047,11 @@ func (r *gatewayReconciler) setGRPCRouteStatuses(scopedLog *slog.Logger, ctx con
 			return r.handleGRPCRouteReconcileErrorWithStatus(ctx, scopedLog, err, grpcr, &original)
 		}
 
-		// Route-specific checks will go in here separately if required.
+		if cond, invalid := i.ValidateMatchRegexps(); invalid {
+			for _, parent := range grpcr.Status.Parents {
+				i.SetParentCondition(parent.ParentRef, cond)
+			}
+		}
 
 		// Checks finished, apply the status to the actual objects.
 		if err := r.updateGRPCRouteStatus(ctx, scopedLog, &original, grpcr); err != nil {

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -342,7 +342,7 @@ func (r *gatewayReconciler) filterHTTPRoutesByGateway(ctx context.Context, gw *g
 	var filtered []gatewayv1.HTTPRoute
 	allListenerHostNames := routechecks.GetAllListenerHostNames(gw.Spec.Listeners)
 	for _, route := range routes {
-		if isAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(gw, &route, namespaceLabels) && len(computeHosts(gw, route.Spec.Hostnames, allListenerHostNames)) > 0 {
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(gw, &route, namespaceLabels) && len(computeHosts(gw, route.Spec.Hostnames, allListenerHostNames)) > 0 {
 			filtered = append(filtered, route)
 		}
 	}
@@ -354,7 +354,7 @@ func (r *gatewayReconciler) filterGRPCRoutesByGateway(ctx context.Context, gw *g
 	allListenerHostNames := routechecks.GetAllListenerHostNames(gw.Spec.Listeners)
 
 	for _, route := range routes {
-		if isAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(gw, &route, namespaceLabels) && len(computeHosts(gw, route.Spec.Hostnames, allListenerHostNames)) > 0 {
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(gw, &route, namespaceLabels) && len(computeHosts(gw, route.Spec.Hostnames, allListenerHostNames)) > 0 {
 			filtered = append(filtered, route)
 		}
 	}
@@ -364,7 +364,7 @@ func (r *gatewayReconciler) filterGRPCRoutesByGateway(ctx context.Context, gw *g
 func (r *gatewayReconciler) filterHTTPRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1.HTTPRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1.HTTPRoute {
 	var filtered []gatewayv1.HTTPRoute
 	for _, route := range routes {
-		if isAttachable(ctx, gw, &route, route.Status.Parents) &&
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) &&
 			listenerisAllowed(gw, listener, &route, namespaceLabels) &&
 			len(computeHostsForListener(listener, route.Spec.Hostnames, nil)) > 0 &&
 			parentRefMatched(gw, listener, route.GetNamespace(), route.Spec.ParentRefs) {
@@ -377,7 +377,7 @@ func (r *gatewayReconciler) filterHTTPRoutesByListener(ctx context.Context, gw *
 func (r *gatewayReconciler) filterGRPCRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1.GRPCRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1.GRPCRoute {
 	var filtered []gatewayv1.GRPCRoute
 	for _, route := range routes {
-		if isAttachable(ctx, gw, &route, route.Status.Parents) &&
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) &&
 			listenerisAllowed(gw, listener, &route, namespaceLabels) &&
 			len(computeHostsForListener(listener, route.Spec.Hostnames, nil)) > 0 &&
 			parentRefMatched(gw, listener, route.GetNamespace(), route.Spec.ParentRefs) {
@@ -430,7 +430,7 @@ func parentRefMatched(gw *gatewayv1.Gateway, listener *gatewayv1.Listener, route
 func (r *gatewayReconciler) filterTLSRoutesByGateway(ctx context.Context, gw *gatewayv1.Gateway, routes []gatewayv1alpha2.TLSRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1alpha2.TLSRoute {
 	var filtered []gatewayv1alpha2.TLSRoute
 	for _, route := range routes {
-		if isAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(gw, &route, namespaceLabels) &&
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) && isAllowed(gw, &route, namespaceLabels) &&
 			len(computeHosts(gw, route.Spec.Hostnames, nil)) > 0 {
 			filtered = append(filtered, route)
 		}
@@ -441,7 +441,7 @@ func (r *gatewayReconciler) filterTLSRoutesByGateway(ctx context.Context, gw *ga
 func (r *gatewayReconciler) filterTLSRoutesByListener(ctx context.Context, gw *gatewayv1.Gateway, listener *gatewayv1.Listener, routes []gatewayv1alpha2.TLSRoute, namespaceLabels helpers.NamespaceLabelIndex) []gatewayv1alpha2.TLSRoute {
 	var filtered []gatewayv1alpha2.TLSRoute
 	for _, route := range routes {
-		if isAttachable(ctx, gw, &route, route.Status.Parents) &&
+		if helpers.IsParentAttachable(ctx, gw, &route, route.Status.Parents) &&
 			listenerisAllowed(gw, listener, &route, namespaceLabels) &&
 			len(computeHostsForListener(listener, route.Spec.Hostnames, nil)) > 0 &&
 			parentRefMatched(gw, listener, route.GetNamespace(), route.Spec.ParentRefs) {
@@ -449,26 +449,6 @@ func (r *gatewayReconciler) filterTLSRoutesByListener(ctx context.Context, gw *g
 		}
 	}
 	return filtered
-}
-
-func isAttachable(_ context.Context, gw *gatewayv1.Gateway, route metav1.Object, parents []gatewayv1.RouteParentStatus) bool {
-	for _, rps := range parents {
-		if helpers.NamespaceDerefOr(rps.ParentRef.Namespace, route.GetNamespace()) != gw.GetNamespace() ||
-			string(rps.ParentRef.Name) != gw.GetName() {
-			continue
-		}
-
-		for _, cond := range rps.Conditions {
-			if cond.Type == string(gatewayv1.RouteConditionAccepted) && cond.Status == metav1.ConditionTrue {
-				return true
-			}
-
-			if cond.Type == string(gatewayv1.RouteConditionResolvedRefs) && cond.Status == metav1.ConditionFalse {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func (r *gatewayReconciler) setAddressStatus(ctx context.Context, gw *gatewayv1.Gateway) error {

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -65,11 +65,6 @@ func Test_Conformance(t *testing.T) {
 			IdleTimeoutSeconds: 60,
 		},
 	})
-	gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator, translation.Config{
-		ServiceConfig: translation.ServiceConfig{
-			ExternalTrafficPolicy: string(corev1.ServiceExternalTrafficPolicyCluster),
-		},
-	})
 
 	type gwDetails struct {
 		FullName types.NamespacedName
@@ -270,9 +265,9 @@ func Test_Conformance(t *testing.T) {
 		{name: "gateway-cross-protocol-same-hostname", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "cross-protocol-same-hostname", Namespace: "gateway-conformance-infra"}}}},
 		{name: "gateway-cross-protocol-same-port-same-hostname", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "cross-protocol-same-port-same-hostname", Namespace: "gateway-conformance-infra"}, wantErr: true}}},
 		{name: "gateway-ns-restricted-same-hostname", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "ns-restricted-same-hostname", Namespace: "gateway-conformance-infra"}}}},
+		{name: "gatewayclassconfig-nodeport", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "nodeport-gateway", Namespace: "gateway-conformance-infra"}}}},
 		{name: "hostNetwork-enabled-valid", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "hostnetwork-enabled", Namespace: "gateway-conformance-infra"}}}, hostNetwork: true},
 		{name: "hostNetwork-enabled-exceed-max-address", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "hostnetwork-enabled", Namespace: "gateway-conformance-infra"}}}, hostNetwork: true},
-		{name: "gatewayclassconfig-nodeport", gateway: []gwDetails{{FullName: types.NamespacedName{Name: "nodeport-gateway", Namespace: "gateway-conformance-infra"}}}},
 	}
 
 	for _, tt := range tests {
@@ -303,20 +298,19 @@ func Test_Conformance(t *testing.T) {
 					clientBuilder.WithIndex(&gatewayv1.HTTPRoute{}, gatewayHTTPRouteIndex, indexers.IndexHTTPRouteByGateway)
 					clientBuilder.WithIndex(&gatewayv1.GRPCRoute{}, gatewayGRPCRouteIndex, indexers.IndexGRPCRouteByGateway)
 					clientBuilder.WithIndex(&gatewayv1alpha2.TLSRoute{}, gatewayTLSRouteIndex, indexers.IndexTLSRouteByGateway)
-					if tt.hostNetwork {
-						gatewayAPITranslator = gatewayApiTranslation.NewTranslator(cecTranslator, translation.Config{
-							ServiceConfig: translation.ServiceConfig{
-								ExternalTrafficPolicy: string(corev1.ServiceExternalTrafficPolicyCluster),
-							},
-							OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
-								UseRemoteAddress: true,
-							},
-							HostNetworkConfig: translation.HostNetworkConfig{
-								Enabled: true,
-							},
-						})
-					}
+
 					c := clientBuilder.Build()
+					gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator, translation.Config{
+						ServiceConfig: translation.ServiceConfig{
+							ExternalTrafficPolicy: string(corev1.ServiceExternalTrafficPolicyCluster),
+						},
+						OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
+							UseRemoteAddress: true,
+						},
+						HostNetworkConfig: translation.HostNetworkConfig{
+							Enabled: tt.hostNetwork,
+						},
+					})
 
 					r := &gatewayReconciler{
 						Client:     c,

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/indexers"
 	"github.com/cilium/cilium/operator/pkg/model/translation"
@@ -767,4 +768,199 @@ func Test_sectionNameMatched(t *testing.T) {
 			assert.Equalf(t, tt.want, parentRefMatched(gw, tt.args.listener, "default", tt.args.refs), "parentRefMatched(%v, %v, %v, %v)", gw, tt.args.listener, tt.args.routeNamespace, tt.args.refs)
 		})
 	}
+}
+
+func testReconciler(t *testing.T, obj ...client.Object) (*gatewayReconciler, client.WithWatch) {
+	t.Helper()
+
+	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(obj...).
+		WithStatusSubresource(&gatewayv1.HTTPRoute{}, &gatewayv1.GRPCRoute{}).
+		Build()
+
+	reconciler := &gatewayReconciler{
+		Client: fakeClient,
+		logger: logger,
+	}
+
+	return reconciler, fakeClient
+}
+
+func findRouteAcceptedCondition(conds []metav1.Condition) *metav1.Condition {
+	for _, cond := range conds {
+		if cond.Type == string(gatewayv1.RouteConditionAccepted) {
+			return &cond
+		}
+	}
+	return nil
+}
+
+func TestGatewayReconciler_statuses(t *testing.T) {
+	controllerName := "io.cilium/gateway-controller"
+
+	ciliumGWClass := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "cilium"},
+		Spec:       gatewayv1.GatewayClassSpec{ControllerName: gatewayv1.GatewayController(controllerName)},
+	}
+	otherGWClass := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "other"},
+		Spec:       gatewayv1.GatewayClassSpec{ControllerName: "example.com/other-controller"},
+	}
+
+	listener := gatewayv1.Listener{
+		Name:     "http",
+		Port:     80,
+		Protocol: gatewayv1.HTTPProtocolType,
+		AllowedRoutes: &gatewayv1.AllowedRoutes{
+			Namespaces: &gatewayv1.RouteNamespaces{From: ptr.To(gatewayv1.NamespacesFromAll)},
+		},
+	}
+
+	ciliumGW := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "cilium-gw", Namespace: "default"},
+		Spec:       gatewayv1.GatewaySpec{GatewayClassName: "cilium", Listeners: []gatewayv1.Listener{listener}},
+	}
+	otherGW := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-gw", Namespace: "default"},
+		Spec:       gatewayv1.GatewaySpec{GatewayClassName: "other", Listeners: []gatewayv1.Listener{listener}},
+	}
+
+	t.Run("setHTTPRouteStatuses sets related parent statuses", func(t *testing.T) {
+		ctx := t.Context()
+
+		validRoute := &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "route", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{Name: gatewayv1.ObjectName(ciliumGW.Name)},
+						{Name: gatewayv1.ObjectName(otherGW.Name)},
+					},
+				},
+				Rules: []gatewayv1.HTTPRouteRule{{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  ptr.To(gatewayv1.PathMatchRegularExpression),
+							Value: ptr.To("^/api/v1$"),
+						},
+					}},
+				}},
+			},
+		}
+
+		invalidRoute := &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "invalid-route", Namespace: "default"},
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{Name: gatewayv1.ObjectName(ciliumGW.Name)},
+						{Name: gatewayv1.ObjectName(otherGW.Name)},
+					},
+				},
+				Rules: []gatewayv1.HTTPRouteRule{{
+					Matches: []gatewayv1.HTTPRouteMatch{{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  ptr.To(gatewayv1.PathMatchRegularExpression),
+							Value: ptr.To("[invalid"),
+						},
+					}},
+				}},
+			},
+		}
+
+		r, c := testReconciler(t, ciliumGWClass, ciliumGW, otherGWClass, otherGW, validRoute, invalidRoute)
+
+		hrList := &gatewayv1.HTTPRouteList{}
+		require.NoError(t, c.List(ctx, hrList))
+		require.NoError(t, r.setHTTPRouteStatuses(r.logger, ctx, hrList, &gatewayv1beta1.ReferenceGrantList{}))
+
+		var updatedValidRoute, updatedInvalidRoute gatewayv1.HTTPRoute
+		require.NoError(t, c.Get(ctx, types.NamespacedName{Name: validRoute.Name, Namespace: validRoute.Namespace}, &updatedValidRoute))
+		require.NoError(t, c.Get(ctx, types.NamespacedName{Name: invalidRoute.Name, Namespace: invalidRoute.Namespace}, &updatedInvalidRoute))
+
+		require.Len(t, updatedValidRoute.Status.Parents, 1, "Should not set status of unrelated parent")
+		assert.EqualValues(t, controllerName, updatedValidRoute.Status.Parents[0].ControllerName)
+
+		validAcceptedCond := findRouteAcceptedCondition(updatedValidRoute.Status.Parents[0].Conditions)
+		assert.NotNil(t, validAcceptedCond)
+		assert.Equal(t, metav1.ConditionTrue, validAcceptedCond.Status)
+
+		require.Len(t, updatedInvalidRoute.Status.Parents, 1, "Should not set status of unrelated parent")
+		assert.EqualValues(t, controllerName, updatedInvalidRoute.Status.Parents[0].ControllerName)
+
+		invalidAcceptedCond := findRouteAcceptedCondition(updatedInvalidRoute.Status.Parents[0].Conditions)
+		assert.NotNil(t, invalidAcceptedCond)
+		assert.Equal(t, metav1.ConditionFalse, invalidAcceptedCond.Status)
+	})
+
+	t.Run("setGRPCRouteStatuses sets related parent statuses", func(t *testing.T) {
+		ctx := t.Context()
+
+		validRoute := &gatewayv1.GRPCRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "route", Namespace: "default"},
+			Spec: gatewayv1.GRPCRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{Name: gatewayv1.ObjectName(ciliumGW.Name)},
+						{Name: gatewayv1.ObjectName(otherGW.Name)},
+					},
+				},
+				Rules: []gatewayv1.GRPCRouteRule{{
+					Matches: []gatewayv1.GRPCRouteMatch{{
+						Method: &gatewayv1.GRPCMethodMatch{
+							Type:    ptr.To(gatewayv1.GRPCMethodMatchRegularExpression),
+							Service: ptr.To("^ordersV[12]$"),
+						},
+					}},
+				}},
+			},
+		}
+
+		invalidRoute := &gatewayv1.GRPCRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "invalid-route", Namespace: "default"},
+			Spec: gatewayv1.GRPCRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
+						{Name: gatewayv1.ObjectName(ciliumGW.Name)},
+						{Name: gatewayv1.ObjectName(otherGW.Name)},
+					},
+				},
+				Rules: []gatewayv1.GRPCRouteRule{{
+					Matches: []gatewayv1.GRPCRouteMatch{{
+						Method: &gatewayv1.GRPCMethodMatch{
+							Type:    ptr.To(gatewayv1.GRPCMethodMatchRegularExpression),
+							Service: ptr.To("(unclosed"),
+						},
+					}},
+				}},
+			},
+		}
+
+		r, c := testReconciler(t, ciliumGWClass, ciliumGW, otherGWClass, otherGW, validRoute, invalidRoute)
+
+		hrList := &gatewayv1.GRPCRouteList{}
+		require.NoError(t, c.List(ctx, hrList))
+		require.NoError(t, r.setGRPCRouteStatuses(r.logger, ctx, hrList, &gatewayv1beta1.ReferenceGrantList{}))
+
+		var updatedValidRoute, updatedInvalidRoute gatewayv1.GRPCRoute
+		require.NoError(t, c.Get(ctx, types.NamespacedName{Name: validRoute.Name, Namespace: validRoute.Namespace}, &updatedValidRoute))
+		require.NoError(t, c.Get(ctx, types.NamespacedName{Name: invalidRoute.Name, Namespace: invalidRoute.Namespace}, &updatedInvalidRoute))
+
+		require.Len(t, updatedValidRoute.Status.Parents, 1, "Should not set status of unrelated parent")
+		assert.EqualValues(t, controllerName, updatedValidRoute.Status.Parents[0].ControllerName)
+
+		validAcceptedCond := findRouteAcceptedCondition(updatedValidRoute.Status.Parents[0].Conditions)
+		assert.NotNil(t, validAcceptedCond)
+		assert.Equal(t, metav1.ConditionTrue, validAcceptedCond.Status)
+
+		require.Len(t, updatedInvalidRoute.Status.Parents, 1, "Should not set status of unrelated parent")
+		assert.EqualValues(t, controllerName, updatedInvalidRoute.Status.Parents[0].ControllerName)
+
+		invalidAcceptedCond := findRouteAcceptedCondition(updatedInvalidRoute.Status.Parents[0].Conditions)
+		assert.NotNil(t, invalidAcceptedCond)
+		assert.Equal(t, metav1.ConditionFalse, invalidAcceptedCond.Status)
+	})
 }

--- a/operator/pkg/gateway-api/helper_test.go
+++ b/operator/pkg/gateway-api/helper_test.go
@@ -18,6 +18,8 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	mcsapiv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 	k8syaml "sigs.k8s.io/yaml"
+
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 )
 
 func fromYaml(t *testing.T, yamlText string, obj any) {
@@ -106,6 +108,10 @@ func readInput(t *testing.T, file string) []client.Object {
 			res = append(res, obj)
 		case "GatewayClass":
 			obj := &gatewayv1.GatewayClass{}
+			fromYaml(t, o, obj)
+			res = append(res, obj)
+		case "CiliumGatewayClassConfig":
+			obj := &v2alpha1.CiliumGatewayClassConfig{}
 			fromYaml(t, o, obj)
 			res = append(res, obj)
 		case "ReferenceGrant":

--- a/operator/pkg/gateway-api/helpers/routes.go
+++ b/operator/pkg/gateway-api/helpers/routes.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package helpers
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func IsParentAttachable(_ context.Context, reconcileParent metav1.Object, route metav1.Object, parents []gatewayv1.RouteParentStatus) bool {
+	for _, rps := range parents {
+		if NamespaceDerefOr(rps.ParentRef.Namespace, route.GetNamespace()) != reconcileParent.GetNamespace() ||
+			string(rps.ParentRef.Name) != reconcileParent.GetName() {
+			continue
+		}
+
+		acceptedValid := false
+		for _, cond := range rps.Conditions {
+			if cond.Type == string(gatewayv1.RouteConditionAccepted) && cond.Status == metav1.ConditionTrue {
+				acceptedValid = true
+			}
+		}
+		if acceptedValid {
+			return true
+		}
+	}
+	return false
+}

--- a/operator/pkg/gateway-api/helpers/routes_test.go
+++ b/operator/pkg/gateway-api/helpers/routes_test.go
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package helpers
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestIsParentAttachable(t *testing.T) {
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		reconcileParent metav1.Object
+		route           metav1.Object
+		parents         []gatewayv1.RouteParentStatus
+		want            bool
+	}{
+		{
+			name: "Gateway parent, all okay",
+			reconcileParent: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gateway",
+					Namespace: "testns",
+				},
+			},
+			route: httpRouteWithParentAndStatus("gammaRoute",
+				"testns",
+				"gateway",
+				nil),
+			parents: parentStatus("gateway",
+				nil,
+				true),
+			want: true,
+		},
+		{
+			name: "Gateway parent, Not Accepted",
+			reconcileParent: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gateway",
+					Namespace: "testns",
+				},
+			},
+			route: httpRouteWithParentAndStatus("gammaRoute",
+				"testns",
+				"gateway",
+				nil),
+			parents: parentStatus("gateway",
+				nil,
+				false),
+			want: false,
+		},
+		{
+			name: "Gateway parent, Accepted but namespace mismatch",
+			reconcileParent: &gatewayv1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gateway",
+					Namespace: "testns",
+				},
+			},
+			route: httpRouteWithParentAndStatus("gammaRoute",
+				"testns",
+				"gateway",
+				ptr.To("otherns")),
+			parents: parentStatus("gateway",
+				ptr.To("otherns"),
+				true),
+			want: false,
+		},
+
+		{
+			name: "GAMMA Service parent, same namespace",
+			reconcileParent: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gammaParent",
+					Namespace: "testns",
+				},
+			},
+			route: httpRouteWithParentAndStatus("gammaRoute",
+				"testns",
+				"gammaParent",
+				nil),
+			parents: parentStatus("gammaParent",
+				nil,
+				true),
+
+			want: true,
+		},
+		{
+			name: "GAMMA Service parent, diff namespace",
+			reconcileParent: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gammaParent",
+					Namespace: "otherns",
+				},
+			},
+			route: httpRouteWithParentAndStatus("gammaRoute",
+				"testns",
+				"",
+				ptr.To("otherns")),
+			parents: parentStatus("gateway",
+				ptr.To("otherns"),
+				false),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsParentAttachable(context.Background(), tt.reconcileParent, tt.route, tt.parents)
+			// TODO: update the condition below to compare got with tt.want.
+			if tt.want != got {
+				t.Errorf("IsParentAttachable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func httpRouteWithParentAndStatus(name, ns, parentName string, parentNS *string) *gatewayv1.HTTPRoute {
+	gwParentName := gatewayv1.ObjectName(parentName)
+	var gwParentNS *gatewayv1.Namespace
+	if parentNS != nil {
+		tempNS := gatewayv1.Namespace(*parentNS)
+		gwParentNS = &tempNS
+	} else {
+		gwParentNS = nil
+	}
+
+	parentRef := gatewayv1.ParentReference{
+		Name:      gwParentName,
+		Namespace: gwParentNS,
+	}
+	return &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					parentRef,
+				},
+			},
+		},
+	}
+}
+
+func parentStatus(parentName string, parentNS *string, status bool) []gatewayv1.RouteParentStatus {
+	gwParentName := gatewayv1.ObjectName(parentName)
+	var gwParentNS *gatewayv1.Namespace
+	if parentNS != nil {
+		tempNS := gatewayv1.Namespace(*parentNS)
+		gwParentNS = &tempNS
+	} else {
+		gwParentNS = nil
+	}
+
+	parentRef := gatewayv1.ParentReference{
+		Name:      gwParentName,
+		Namespace: gwParentNS,
+	}
+	var condStatus metav1.ConditionStatus
+
+	if status {
+		condStatus = metav1.ConditionTrue
+	} else {
+		condStatus = metav1.ConditionFalse
+	}
+
+	return []gatewayv1.RouteParentStatus{
+		{
+			ParentRef: parentRef,
+			Conditions: []metav1.Condition{
+				{
+					Type:   "Accepted",
+					Status: condStatus,
+				},
+				{
+					Type:   "ResolvedRefs",
+					Status: condStatus,
+				},
+			},
+		},
+	}
+}

--- a/operator/pkg/gateway-api/routechecks/grpcroute.go
+++ b/operator/pkg/gateway-api/routechecks/grpcroute.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"reflect"
+	"regexp"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -191,4 +192,34 @@ func (g *GRPCRouteInput) mergeStatusConditions(parentRef gatewayv1.ParentReferen
 		ControllerName: controllerName,
 		Conditions:     updates,
 	})
+}
+
+func (g *GRPCRouteInput) ValidateMatchRegexps() (metav1.Condition, bool) {
+	for _, rule := range g.GRPCRoute.Spec.Rules {
+		for _, match := range rule.Matches {
+			if methodMatch := match.Method; methodMatch != nil && methodMatch.Type != nil &&
+				*methodMatch.Type == gatewayv1.GRPCMethodMatchRegularExpression {
+				if methodMatch.Service != nil {
+					if _, err := regexp.Compile(*methodMatch.Service); err != nil {
+						return invalidRegexCondition("method.service", err), true
+					}
+				}
+
+				if methodMatch.Method != nil {
+					if _, err := regexp.Compile(*methodMatch.Method); err != nil {
+						return invalidRegexCondition("method.method", err), true
+					}
+				}
+			}
+
+			for _, headerMatch := range match.Headers {
+				if headerMatch.Type != nil && *headerMatch.Type == gatewayv1.GRPCHeaderMatchRegularExpression {
+					if _, err := regexp.Compile(headerMatch.Value); err != nil {
+						return invalidRegexCondition("header", err), true
+					}
+				}
+			}
+		}
+	}
+	return metav1.Condition{}, false
 }

--- a/operator/pkg/gateway-api/routechecks/grpcroute.go
+++ b/operator/pkg/gateway-api/routechecks/grpcroute.go
@@ -155,18 +155,6 @@ func (g *GRPCRouteInput) SetParentCondition(ref gatewayv1beta1.ParentReference, 
 	})
 }
 
-func (g *GRPCRouteInput) SetAllParentCondition(condition metav1.Condition) {
-	// fill in the condition
-	condition.LastTransitionTime = metav1.NewTime(time.Now())
-	condition.ObservedGeneration = g.GRPCRoute.GetGeneration()
-
-	for _, parent := range g.GRPCRoute.Spec.ParentRefs {
-		g.mergeStatusConditions(parent, []metav1.Condition{
-			condition,
-		})
-	}
-}
-
 func (g *GRPCRouteInput) Log() *slog.Logger {
 	return g.Logger
 }

--- a/operator/pkg/gateway-api/routechecks/grpcroute_test.go
+++ b/operator/pkg/gateway-api/routechecks/grpcroute_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package routechecks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestGRPCRouteValidateMatchRegexps(t *testing.T) {
+	tests := []struct {
+		name    string
+		match   gatewayv1.GRPCRouteMatch
+		invalid bool
+	}{
+		{
+			name: "valid method regex",
+			match: gatewayv1.GRPCRouteMatch{Method: &gatewayv1.GRPCMethodMatch{
+				Type:    new(gatewayv1.GRPCMethodMatchRegularExpression),
+				Service: new("^presence$"),
+				Method:  new("^(Hello|Goodbye)$"),
+			}},
+		},
+		{
+			name: "invalid method.service regex",
+			match: gatewayv1.GRPCRouteMatch{Method: &gatewayv1.GRPCMethodMatch{
+				Type:    new(gatewayv1.GRPCMethodMatchRegularExpression),
+				Service: new("^ordersV[12$"),
+			}},
+			invalid: true,
+		},
+		{
+			name: "invalid method.method regex",
+			match: gatewayv1.GRPCRouteMatch{Method: &gatewayv1.GRPCMethodMatch{
+				Type:   new(gatewayv1.GRPCMethodMatchRegularExpression),
+				Method: new(".(unclosed"),
+			}},
+			invalid: true,
+		},
+		{
+			name: "valid header regex",
+			match: gatewayv1.GRPCRouteMatch{Headers: []gatewayv1.GRPCHeaderMatch{{
+				Type:  new(gatewayv1.GRPCHeaderMatchRegularExpression),
+				Name:  "X-Device-Id",
+				Value: "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+			}}},
+		},
+		{
+			name: "invalid header regex",
+			match: gatewayv1.GRPCRouteMatch{Headers: []gatewayv1.GRPCHeaderMatch{{
+				Type:  new(gatewayv1.GRPCHeaderMatchRegularExpression),
+				Name:  "X-Device-Id",
+				Value: "****invalid",
+			}}},
+			invalid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := &GRPCRouteInput{
+				ControllerName: "io.cilium/gateway-controller",
+				GRPCRoute: &gatewayv1.GRPCRoute{
+					Spec: gatewayv1.GRPCRouteSpec{
+						CommonRouteSpec: gatewayv1.CommonRouteSpec{
+							ParentRefs: []gatewayv1.ParentReference{{Name: "my-gw"}},
+						},
+						Rules: []gatewayv1.GRPCRouteRule{{Matches: []gatewayv1.GRPCRouteMatch{tt.match}}},
+					},
+				},
+			}
+
+			cond, invalid := input.ValidateMatchRegexps()
+
+			assert.Equal(t, tt.invalid, invalid)
+			if invalid {
+				assert.Equal(t, string(gatewayv1.RouteConditionAccepted), cond.Type)
+				assert.Equal(t, metav1.ConditionFalse, cond.Status)
+				assert.Equal(t, string(gatewayv1.RouteReasonUnsupportedValue), cond.Reason)
+			}
+		})
+	}
+}

--- a/operator/pkg/gateway-api/routechecks/grpcroute_test.go
+++ b/operator/pkg/gateway-api/routechecks/grpcroute_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -20,31 +21,31 @@ func TestGRPCRouteValidateMatchRegexps(t *testing.T) {
 		{
 			name: "valid method regex",
 			match: gatewayv1.GRPCRouteMatch{Method: &gatewayv1.GRPCMethodMatch{
-				Type:    new(gatewayv1.GRPCMethodMatchRegularExpression),
-				Service: new("^presence$"),
-				Method:  new("^(Hello|Goodbye)$"),
+				Type:    ptr.To(gatewayv1.GRPCMethodMatchRegularExpression),
+				Service: ptr.To("^presence$"),
+				Method:  ptr.To("^(Hello|Goodbye)$"),
 			}},
 		},
 		{
 			name: "invalid method.service regex",
 			match: gatewayv1.GRPCRouteMatch{Method: &gatewayv1.GRPCMethodMatch{
-				Type:    new(gatewayv1.GRPCMethodMatchRegularExpression),
-				Service: new("^ordersV[12$"),
+				Type:    ptr.To(gatewayv1.GRPCMethodMatchRegularExpression),
+				Service: ptr.To("^ordersV[12$"),
 			}},
 			invalid: true,
 		},
 		{
 			name: "invalid method.method regex",
 			match: gatewayv1.GRPCRouteMatch{Method: &gatewayv1.GRPCMethodMatch{
-				Type:   new(gatewayv1.GRPCMethodMatchRegularExpression),
-				Method: new(".(unclosed"),
+				Type:   ptr.To(gatewayv1.GRPCMethodMatchRegularExpression),
+				Method: ptr.To(".(unclosed"),
 			}},
 			invalid: true,
 		},
 		{
 			name: "valid header regex",
 			match: gatewayv1.GRPCRouteMatch{Headers: []gatewayv1.GRPCHeaderMatch{{
-				Type:  new(gatewayv1.GRPCHeaderMatchRegularExpression),
+				Type:  ptr.To(gatewayv1.GRPCHeaderMatchRegularExpression),
 				Name:  "X-Device-Id",
 				Value: "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
 			}}},
@@ -52,7 +53,7 @@ func TestGRPCRouteValidateMatchRegexps(t *testing.T) {
 		{
 			name: "invalid header regex",
 			match: gatewayv1.GRPCRouteMatch{Headers: []gatewayv1.GRPCHeaderMatch{{
-				Type:  new(gatewayv1.GRPCHeaderMatchRegularExpression),
+				Type:  ptr.To(gatewayv1.GRPCHeaderMatchRegularExpression),
 				Name:  "X-Device-Id",
 				Value: "****invalid",
 			}}},
@@ -63,7 +64,6 @@ func TestGRPCRouteValidateMatchRegexps(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			input := &GRPCRouteInput{
-				ControllerName: "io.cilium/gateway-controller",
 				GRPCRoute: &gatewayv1.GRPCRoute{
 					Spec: gatewayv1.GRPCRouteSpec{
 						CommonRouteSpec: gatewayv1.CommonRouteSpec{

--- a/operator/pkg/gateway-api/routechecks/httproute.go
+++ b/operator/pkg/gateway-api/routechecks/httproute.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"reflect"
+	"regexp"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -206,4 +207,44 @@ func (r *HTTPRouteInput) ValidateHeaderModifier() error {
 		}
 	}
 	return nil
+}
+
+func invalidRegexCondition(field string, err error) metav1.Condition {
+	return metav1.Condition{
+		Type:    string(gatewayv1.RouteConditionAccepted),
+		Status:  metav1.ConditionFalse,
+		Reason:  string(gatewayv1.RouteReasonUnsupportedValue),
+		Message: fmt.Sprintf("Invalid regular expression in %s match: %v", field, err),
+	}
+}
+
+func (h *HTTPRouteInput) ValidateMatchRegexps() (metav1.Condition, bool) {
+	for _, rule := range h.HTTPRoute.Spec.Rules {
+		for _, match := range rule.Matches {
+			if pathMatch := match.Path; pathMatch != nil && pathMatch.Type != nil &&
+				*pathMatch.Type == gatewayv1.PathMatchRegularExpression && pathMatch.Value != nil {
+				if _, err := regexp.Compile(*pathMatch.Value); err != nil {
+					return invalidRegexCondition("path", err), true
+				}
+			}
+
+			for _, headerMatch := range match.Headers {
+				if headerMatch.Type != nil && *headerMatch.Type == gatewayv1.HeaderMatchRegularExpression {
+					if _, err := regexp.Compile(headerMatch.Value); err != nil {
+						return invalidRegexCondition("header", err), true
+					}
+				}
+			}
+
+			for _, queryMatch := range match.QueryParams {
+				if queryMatch.Type != nil && *queryMatch.Type == gatewayv1.QueryParamMatchRegularExpression {
+					if _, err := regexp.Compile(queryMatch.Value); err != nil {
+						return invalidRegexCondition("queryParam", err), true
+					}
+				}
+			}
+		}
+	}
+
+	return metav1.Condition{}, false
 }

--- a/operator/pkg/gateway-api/routechecks/httproute.go
+++ b/operator/pkg/gateway-api/routechecks/httproute.go
@@ -45,18 +45,6 @@ func (h *HTTPRouteInput) SetParentCondition(ref gatewayv1.ParentReference, condi
 	})
 }
 
-func (h *HTTPRouteInput) SetAllParentCondition(condition metav1.Condition) {
-	// fill in the condition
-	condition.LastTransitionTime = metav1.NewTime(time.Now())
-	condition.ObservedGeneration = h.HTTPRoute.GetGeneration()
-
-	for _, parent := range h.HTTPRoute.Spec.ParentRefs {
-		h.mergeStatusConditions(parent, []metav1.Condition{
-			condition,
-		})
-	}
-}
-
 func (h *HTTPRouteInput) mergeStatusConditions(parentRef gatewayv1alpha2.ParentReference, updates []metav1.Condition) {
 	index := -1
 	for i, parent := range h.HTTPRoute.Status.RouteStatus.Parents {

--- a/operator/pkg/gateway-api/routechecks/httproute_test.go
+++ b/operator/pkg/gateway-api/routechecks/httproute_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package routechecks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestHTTPRouteValidateMatchRegexps(t *testing.T) {
+	tests := []struct {
+		name    string
+		match   gatewayv1.HTTPRouteMatch
+		invalid bool
+	}{
+		{
+			name: "valid path regex",
+			match: gatewayv1.HTTPRouteMatch{Path: &gatewayv1.HTTPPathMatch{
+				Type:  new(gatewayv1.PathMatchRegularExpression),
+				Value: new("/api/v[0-9]/.+"),
+			}},
+		},
+		{
+			name: "invalid path regex",
+			match: gatewayv1.HTTPRouteMatch{Path: &gatewayv1.HTTPPathMatch{
+				Type:  new(gatewayv1.PathMatchRegularExpression),
+				Value: new("[unterminated"),
+			}},
+			invalid: true,
+		},
+		{
+			name: "valid header regex",
+			match: gatewayv1.HTTPRouteMatch{Headers: []gatewayv1.HTTPHeaderMatch{{
+				Type:  new(gatewayv1.HeaderMatchRegularExpression),
+				Name:  "X-Consumer-Key",
+				Value: "^[A-Za-z0-9]{16,32}$",
+			}}},
+		},
+		{
+			name: "invalid header regex",
+			match: gatewayv1.HTTPRouteMatch{Headers: []gatewayv1.HTTPHeaderMatch{{
+				Type:  new(gatewayv1.HeaderMatchRegularExpression),
+				Name:  "X-Consumer-Key",
+				Value: "(unclosed",
+			}}},
+			invalid: true,
+		},
+		{
+			name: "valid queryParam regex",
+			match: gatewayv1.HTTPRouteMatch{QueryParams: []gatewayv1.HTTPQueryParamMatch{{
+				Type:  new(gatewayv1.QueryParamMatchRegularExpression),
+				Name:  "ref",
+				Value: "^[a-z_]{8,16}[0-9]{1,5}$",
+			}}},
+		},
+		{
+			name: "invalid queryParam regex",
+			match: gatewayv1.HTTPRouteMatch{QueryParams: []gatewayv1.HTTPQueryParamMatch{{
+				Type:  new(gatewayv1.QueryParamMatchRegularExpression),
+				Name:  "ref",
+				Value: "(?invalidflag)",
+			}}},
+			invalid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := &HTTPRouteInput{
+				ControllerName: "io.cilium/gateway-controller",
+				HTTPRoute: &gatewayv1.HTTPRoute{
+					Spec: gatewayv1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayv1.CommonRouteSpec{
+							ParentRefs: []gatewayv1.ParentReference{{Name: "my-gw"}},
+						},
+						Rules: []gatewayv1.HTTPRouteRule{{Matches: []gatewayv1.HTTPRouteMatch{tt.match}}},
+					},
+				},
+			}
+
+			cond, invalid := input.ValidateMatchRegexps()
+
+			assert.Equal(t, tt.invalid, invalid)
+			if invalid {
+				assert.Equal(t, string(gatewayv1.RouteConditionAccepted), cond.Type)
+				assert.Equal(t, metav1.ConditionFalse, cond.Status)
+				assert.Equal(t, string(gatewayv1.RouteReasonUnsupportedValue), cond.Reason)
+			}
+		})
+	}
+}

--- a/operator/pkg/gateway-api/routechecks/httproute_test.go
+++ b/operator/pkg/gateway-api/routechecks/httproute_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -20,22 +21,22 @@ func TestHTTPRouteValidateMatchRegexps(t *testing.T) {
 		{
 			name: "valid path regex",
 			match: gatewayv1.HTTPRouteMatch{Path: &gatewayv1.HTTPPathMatch{
-				Type:  new(gatewayv1.PathMatchRegularExpression),
-				Value: new("/api/v[0-9]/.+"),
+				Type:  ptr.To(gatewayv1.PathMatchRegularExpression),
+				Value: ptr.To("/api/v[0-9]/.+"),
 			}},
 		},
 		{
 			name: "invalid path regex",
 			match: gatewayv1.HTTPRouteMatch{Path: &gatewayv1.HTTPPathMatch{
-				Type:  new(gatewayv1.PathMatchRegularExpression),
-				Value: new("[unterminated"),
+				Type:  ptr.To(gatewayv1.PathMatchRegularExpression),
+				Value: ptr.To("[unterminated"),
 			}},
 			invalid: true,
 		},
 		{
 			name: "valid header regex",
 			match: gatewayv1.HTTPRouteMatch{Headers: []gatewayv1.HTTPHeaderMatch{{
-				Type:  new(gatewayv1.HeaderMatchRegularExpression),
+				Type:  ptr.To(gatewayv1.HeaderMatchRegularExpression),
 				Name:  "X-Consumer-Key",
 				Value: "^[A-Za-z0-9]{16,32}$",
 			}}},
@@ -43,7 +44,7 @@ func TestHTTPRouteValidateMatchRegexps(t *testing.T) {
 		{
 			name: "invalid header regex",
 			match: gatewayv1.HTTPRouteMatch{Headers: []gatewayv1.HTTPHeaderMatch{{
-				Type:  new(gatewayv1.HeaderMatchRegularExpression),
+				Type:  ptr.To(gatewayv1.HeaderMatchRegularExpression),
 				Name:  "X-Consumer-Key",
 				Value: "(unclosed",
 			}}},
@@ -52,7 +53,7 @@ func TestHTTPRouteValidateMatchRegexps(t *testing.T) {
 		{
 			name: "valid queryParam regex",
 			match: gatewayv1.HTTPRouteMatch{QueryParams: []gatewayv1.HTTPQueryParamMatch{{
-				Type:  new(gatewayv1.QueryParamMatchRegularExpression),
+				Type:  ptr.To(gatewayv1.QueryParamMatchRegularExpression),
 				Name:  "ref",
 				Value: "^[a-z_]{8,16}[0-9]{1,5}$",
 			}}},
@@ -60,7 +61,7 @@ func TestHTTPRouteValidateMatchRegexps(t *testing.T) {
 		{
 			name: "invalid queryParam regex",
 			match: gatewayv1.HTTPRouteMatch{QueryParams: []gatewayv1.HTTPQueryParamMatch{{
-				Type:  new(gatewayv1.QueryParamMatchRegularExpression),
+				Type:  ptr.To(gatewayv1.QueryParamMatchRegularExpression),
 				Name:  "ref",
 				Value: "(?invalidflag)",
 			}}},
@@ -71,7 +72,6 @@ func TestHTTPRouteValidateMatchRegexps(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			input := &HTTPRouteInput{
-				ControllerName: "io.cilium/gateway-controller",
 				HTTPRoute: &gatewayv1.HTTPRoute{
 					Spec: gatewayv1.HTTPRouteSpec{
 						CommonRouteSpec: gatewayv1.CommonRouteSpec{

--- a/operator/pkg/gateway-api/routechecks/tlsroute.go
+++ b/operator/pkg/gateway-api/routechecks/tlsroute.go
@@ -43,18 +43,6 @@ func (t *TLSRouteInput) SetParentCondition(ref gatewayv1.ParentReference, condit
 	})
 }
 
-func (t *TLSRouteInput) SetAllParentCondition(condition metav1.Condition) {
-	// fill in the condition
-	condition.LastTransitionTime = metav1.NewTime(time.Now())
-	condition.ObservedGeneration = t.TLSRoute.GetGeneration()
-
-	for _, parent := range t.TLSRoute.Spec.ParentRefs {
-		t.mergeStatusConditions(parent, []metav1.Condition{
-			condition,
-		})
-	}
-}
-
 func (t *TLSRouteInput) mergeStatusConditions(parentRef gatewayv1alpha2.ParentReference, updates []metav1.Condition) {
 	index := -1
 	for i, parent := range t.TLSRoute.Status.RouteStatus.Parents {

--- a/operator/pkg/gateway-api/status_route_test.go
+++ b/operator/pkg/gateway-api/status_route_test.go
@@ -84,11 +84,17 @@ func TestPruneRouteParentStatuses(t *testing.T) {
 	require.Equal(t, otherControllerDetachedParent, route.Status.Parents[1].ParentRef)
 	require.Equal(t, currentParentStatus, route.Status.Parents[2].ParentRef)
 
-	input.SetAllParentCondition(metav1.Condition{
-		Type:   string(gatewayv1.RouteConditionAccepted),
-		Status: metav1.ConditionTrue,
-		Reason: string(gatewayv1.RouteReasonAccepted),
-	})
+	acceptedCond := metav1.Condition{
+		Type:               string(gatewayv1.RouteConditionAccepted),
+		Status:             metav1.ConditionTrue,
+		Reason:             string(gatewayv1.RouteReasonAccepted),
+		ObservedGeneration: input.HTTPRoute.GetGeneration(),
+		LastTransitionTime: metav1.Now(),
+	}
+
+	for _, parent := range input.HTTPRoute.Spec.ParentRefs {
+		input.SetParentCondition(parent, acceptedCond)
+	}
 
 	require.Len(t, route.Status.Parents, 3, "merge alone keeps both detached statuses")
 	require.Equal(t, ourDetachedParent, route.Status.Parents[0].ParentRef, "merge alone keeps both detached statuses")


### PR DESCRIPTION
Backports the following PRs to `v1.19`:

- [x] #45294 (@youngnick) :warning: resolved conflicts
- [x] #47005 (@0xch4z) :warning: resolved conflicts
- [x] #47086 (@0xch4z)
- [x] #47255 (@0xch4z) 

```upstream-prs
45294 47005 47086 47255
```