### PR TITLE
k8s/testutils: Validate CRDs on k8s/add and k8s/update by default

### DIFF
--- a/operator/pkg/kvstore/nodesgc/testdata/disabled.txtar
+++ b/operator/pkg/kvstore/nodesgc/testdata/disabled.txtar
@@ -34,6 +34,7 @@ apiVersion: cilium.io/v2
 kind: CiliumNode
 metadata:
   name: node-1
+spec: {}
 
 
 -- keys.expected --

--- a/operator/pkg/kvstore/nodesgc/testdata/enabled.txtar
+++ b/operator/pkg/kvstore/nodesgc/testdata/enabled.txtar
@@ -102,18 +102,21 @@ apiVersion: cilium.io/v2
 kind: CiliumNode
 metadata:
   name: node-1
+spec: {}
 
 -- cilium-node-2.yaml --
 apiVersion: cilium.io/v2
 kind: CiliumNode
 metadata:
   name: node-2
+spec: {}
 
 -- cilium-node-4.yaml --
 apiVersion: cilium.io/v2
 kind: CiliumNode
 metadata:
   name: node-4
+spec: {}
 
 -- pod-node-1a.yaml --
 apiVersion: v1

--- a/pkg/ciliumenvoyconfig/testdata/shared_cluster.txtar
+++ b/pkg/ciliumenvoyconfig/testdata/shared_cluster.txtar
@@ -107,7 +107,7 @@ spec:
   services:
     - name: echo
       namespace: test
-      cec: listener
+      listener: listener
       ports:
       - 80
   resources:

--- a/pkg/k8s/client/testutils/fake.go
+++ b/pkg/k8s/client/testutils/fake.go
@@ -343,6 +343,16 @@ func FakeClientCommands(fc *FakeClientset) map[string]script.Cmd {
 		return b, nil
 	}
 
+	// Kinds outside the Kubernetes scheme decode to a nil object, any other
+	// error is a real one.
+	decodeKubernetesObject := func(b []byte) (runtime.Object, error) {
+		kobj, _, err := testutils.DecodeKubernetesObject(b)
+		if err != nil && !runtime.IsNotRegisteredError(err) {
+			return nil, fmt.Errorf("decode: %w", err)
+		}
+		return kobj, nil
+	}
+
 	decodeTrackerObjects := func(s *script.State, file string) ([]object, schema.GroupVersionResource, error) {
 		b, err := readInputFile(s, file)
 		if err != nil {
@@ -353,7 +363,10 @@ func FakeClientCommands(fc *FakeClientset) map[string]script.Cmd {
 		if err != nil {
 			return nil, schema.GroupVersionResource{}, fmt.Errorf("decode: %w", err)
 		}
-		kobj, _, _ := testutils.DecodeKubernetesObject(b)
+		kobj, err := decodeKubernetesObject(b)
+		if err != nil {
+			return nil, schema.GroupVersionResource{}, err
+		}
 		gvr, _ := meta.UnsafeGuessKindToResource(*gvk)
 
 		toObject := func(domain string, obj runtime.Object) (object, error) {
@@ -409,7 +422,10 @@ func FakeClientCommands(fc *FakeClientset) map[string]script.Cmd {
 			if err != nil {
 				return fmt.Errorf("decode: %w", err)
 			}
-			kobj, _, _ := testutils.DecodeKubernetesObject(b)
+			kobj, err := decodeKubernetesObject(b)
+			if err != nil {
+				return err
+			}
 			gvr, _ := meta.UnsafeGuessKindToResource(*gvk)
 			objMeta, err := meta.Accessor(obj)
 			if err != nil {

--- a/pkg/k8s/client/testutils/fake.go
+++ b/pkg/k8s/client/testutils/fake.go
@@ -387,11 +387,21 @@ func FakeClientCommands(fc *FakeClientset) map[string]script.Cmd {
 	}
 
 	addUpdateOrDelete := func(s *script.State, action string, files []string) error {
+		validate, _ := s.Flags.GetBool("validate")
 		for _, file := range files {
 			b, err := readInputFile(s, file)
 			if err != nil {
 				return err
 			}
+
+			// Validate the raw bytes, not the typed object below, which would
+			// drop the unknown fields we want to catch.
+			if validate && action != "delete" {
+				if _, err := testutils.ValidateCRD(fc.ot.log, b); err != nil {
+					return fmt.Errorf("validate %s: %w", file, err)
+				}
+			}
+
 			obj, gvk, err := testutils.DecodeObjectGVK(b)
 			if err != nil {
 				return fmt.Errorf("decode: %w", err)
@@ -462,6 +472,10 @@ func FakeClientCommands(fc *FakeClientset) map[string]script.Cmd {
 					"'kubectl get -o yaml'",
 				},
 				Args: "files...",
+				Flags: func(fs *pflag.FlagSet) {
+					fs.Bool("validate", true,
+						"Validate objects against their CRD OpenAPI schema (and reject unknown fields) the way the kube-apiserver would, before adding. Kinds without a known CRD schema are accepted as-is. Pass --validate=false to accept objects the apiserver would reject.")
+				},
 			},
 			func(s *script.State, args ...string) (script.WaitFunc, error) {
 				if len(args) == 0 {
@@ -479,6 +493,8 @@ func FakeClientCommands(fc *FakeClientset) map[string]script.Cmd {
 				Flags: func(fs *pflag.FlagSet) {
 					fs.Bool("strict", false,
 						"Enable strict optimistic concurrency control")
+					fs.Bool("validate", true,
+						"Validate objects against their CRD OpenAPI schema (and reject unknown fields) the way the kube-apiserver would, before updating. Kinds without a known CRD schema are accepted as-is. Pass --validate=false to accept objects the apiserver would reject.")
 				},
 			},
 			func(s *script.State, args ...string) (script.WaitFunc, error) {

--- a/pkg/k8s/client/testutils/fake.go
+++ b/pkg/k8s/client/testutils/fake.go
@@ -392,6 +392,19 @@ func FakeClientCommands(fc *FakeClientset) map[string]script.Cmd {
 			if err != nil {
 				return err
 			}
+
+			if action != "delete" {
+				schemaValidation, err := s.Flags.GetBool("validate-schema")
+				if err != nil {
+					return err
+				}
+				// Validate the raw bytes and not the typed object below,
+				// since the decode drops the unknown fields.
+				if err := testutils.ValidateCRD(fc.ot.log, b, schemaValidation); err != nil {
+					return fmt.Errorf("validate %s: %w", file, err)
+				}
+			}
+
 			obj, gvk, err := testutils.DecodeObjectGVK(b)
 			if err != nil {
 				return fmt.Errorf("decode: %w", err)
@@ -453,6 +466,11 @@ func FakeClientCommands(fc *FakeClientset) map[string]script.Cmd {
 		return nil
 	}
 
+	validateFlag := func(fs *pflag.FlagSet) {
+		fs.Bool("validate-schema", true,
+			"Validate objects against their CRD OpenAPI schema, as the kube-apiserver would. Kinds without a known CRD schema are accepted as-is. Pass --validate-schema=false for objects that are deliberately incomplete, e.g. to leave out required fields the test does not care about. Unknown fields are rejected either way.")
+	}
+
 	return map[string]script.Cmd{
 		"k8s/add": script.Command(
 			script.CmdUsage{
@@ -461,13 +479,13 @@ func FakeClientCommands(fc *FakeClientset) map[string]script.Cmd {
 					"The files should be YAML, e.g. in the format produced by",
 					"'kubectl get -o yaml'",
 				},
-				Args: "files...",
+				Args:  "files...",
+				Flags: validateFlag,
 			},
 			func(s *script.State, args ...string) (script.WaitFunc, error) {
 				if len(args) == 0 {
 					return nil, script.ErrUsage
 				}
-
 				return nil, addUpdateOrDelete(s, "add", args)
 			},
 		),
@@ -479,6 +497,7 @@ func FakeClientCommands(fc *FakeClientset) map[string]script.Cmd {
 				Flags: func(fs *pflag.FlagSet) {
 					fs.Bool("strict", false,
 						"Enable strict optimistic concurrency control")
+					validateFlag(fs)
 				},
 			},
 			func(s *script.State, args ...string) (script.WaitFunc, error) {

--- a/pkg/k8s/client/testutils/testdata/fake.txtar
+++ b/pkg/k8s/client/testutils/testdata/fake.txtar
@@ -145,6 +145,9 @@ metadata:
 spec:
   backendServices:
   - name: foo
+  resources:
+  - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+    name: listener
 
 -- apiext_crd.yaml --
 apiVersion: apiextensions.k8s.io/v1

--- a/pkg/k8s/client/testutils/testdata/validate.txtar
+++ b/pkg/k8s/client/testutils/testdata/validate.txtar
@@ -1,0 +1,115 @@
+# Tests for CRD validation on k8s/add and k8s/update. By default the fake
+# clientset rejects objects the kube-apiserver would reject, validating them
+# against their CRD OpenAPI schema (plus unknown-field detection). Kinds without
+# a known CRD schema (core objects, non-Cilium CRDs) are accepted as-is.
+# Validation can be disabled per command with --validate=false.
+
+hive/start
+
+# A well-formed CNP passes validation on both add and update.
+k8s/add good-cnp.yaml
+k8s/update good-cnp.yaml
+
+# A CNP with an unknown/misspelled spec field is rejected the way the
+# kube-apiserver would. The typed decoder silently drops unknown fields, so
+# this only fails because validation runs on the raw YAML.
+! k8s/add unknown-field-cnp.yaml
+! k8s/update unknown-field-cnp.yaml
+
+# An invalid L4 protocol enum is rejected against the CRD OpenAPI schema.
+! k8s/add bad-proto-cnp.yaml
+
+# Validation is generic across Cilium CRDs, not just policies: a well-formed
+# CiliumEnvoyConfig passes, and one with an unknown field is rejected.
+k8s/add good-cec.yaml
+! k8s/add unknown-field-cec.yaml
+
+# A kind without a known CRD schema (a core Service) is accepted: validation
+# only rejects objects whose kind has a schema.
+k8s/add service.yaml
+
+# With --validate=false, the same bogus CNP is accepted (the unknown field is
+# silently dropped by the typed decode). This is the opt-out that lets a test
+# deliberately feed an object the apiserver would reject.
+k8s/add --validate=false unknown-field-cnp.yaml
+
+-- good-cnp.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: good
+  namespace: default
+spec:
+  endpointSelector:
+    matchLabels:
+      app: foo
+  egress:
+  - toEndpoints:
+    - matchLabels:
+        app: bar
+
+-- unknown-field-cnp.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: unknown-field
+  namespace: default
+spec:
+  endpointSelector:
+    matchLabels:
+      app: foo
+  totallyBogusUnknownField: true
+  egress:
+  - toEndpoints:
+    - matchLabels:
+        app: bar
+
+-- bad-proto-cnp.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: bad-proto
+  namespace: default
+spec:
+  endpointSelector: {}
+  egress:
+  - toPorts:
+    - ports:
+      - port: "80"
+        protocol: NOTAPROTOCOL
+
+-- good-cec.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumEnvoyConfig
+metadata:
+  name: cec
+  namespace: default
+spec:
+  services:
+  - name: foo
+  resources:
+  - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+    name: listener
+
+-- unknown-field-cec.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumEnvoyConfig
+metadata:
+  name: cec
+  namespace: default
+spec:
+  bogusUnknownFieldHere: true
+  services:
+  - name: foo
+  resources:
+  - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+    name: listener
+
+-- service.yaml --
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 10.96.50.104

--- a/pkg/k8s/client/testutils/testdata/validate.txtar
+++ b/pkg/k8s/client/testutils/testdata/validate.txtar
@@ -1,0 +1,63 @@
+# Tests for CRD validation on k8s/add and k8s/update.
+#
+# This checks that schema validation is on by default and can be turned off with
+# --validate-schema=false, and that unknown fields are rejected either way. The
+# validation itself is tested by TestValidateCRD in pkg/k8s/testutils.
+
+hive/start
+
+# A well-formed CNP is accepted on both add and update.
+k8s/add good-cnp.yaml
+k8s/update good-cnp.yaml
+
+# An object missing a field the CRD marks as required is rejected, and accepted
+# with --validate-schema=false.
+! k8s/add no-spec-cn.yaml
+k8s/add --validate-schema=false no-spec-cn.yaml
+
+# A CNP with an unknown field is rejected regardless of --validate-schema, since
+# the typed decode would silently drop the field.
+! k8s/add unknown-field-cnp.yaml
+! k8s/update unknown-field-cnp.yaml
+! k8s/add --validate-schema=false unknown-field-cnp.yaml
+
+# Deletes are not validated, so the object added above without a spec can be
+# deleted again.
+k8s/delete no-spec-cn.yaml
+
+-- good-cnp.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: good
+  namespace: default
+spec:
+  endpointSelector:
+    matchLabels:
+      app: foo
+  egress:
+  - toEndpoints:
+    - matchLabels:
+        app: bar
+
+-- unknown-field-cnp.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: unknown-field
+  namespace: default
+spec:
+  endpointSelector:
+    matchLabels:
+      app: foo
+  totallyBogusUnknownField: true
+  egress:
+  - toEndpoints:
+    - matchLabels:
+        app: bar
+
+-- no-spec-cn.yaml --
+apiVersion: cilium.io/v2
+kind: CiliumNode
+metadata:
+  name: no-spec

--- a/pkg/k8s/testutils/crd_validation.go
+++ b/pkg/k8s/testutils/crd_validation.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package testutils
+
+import (
+	"fmt"
+	"log/slog"
+	"sync"
+
+	apiextensionsinternal "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sYaml "sigs.k8s.io/yaml"
+
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/client"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+var (
+	crdSchemas []func(logger *slog.Logger) []apiextensionsv1.CustomResourceDefinition
+
+	crdSchemaValidatorsOnce sync.Once
+	crdSchemaValidators     map[schema.GroupVersionKind]validation.SchemaCreateValidator
+)
+
+func init() {
+	RegisterCRDSchemas(ciliumCRDs)
+}
+
+func ciliumCRDs(logger *slog.Logger) []apiextensionsv1.CustomResourceDefinition {
+	list := client.CustomResourceDefinitionList()
+	crds := make([]apiextensionsv1.CustomResourceDefinition, 0, len(list))
+	for _, crdList := range list {
+		crds = append(crds, client.GetPregeneratedCRD(logger, crdList.Name))
+	}
+	return crds
+}
+
+// RegisterCRDSchemas adds CRDs for [ValidateCRD] to validate against. Call it
+// from an init(), as the CRDs are read on the first validation. Their kinds
+// have to be in [Scheme] too, since the validation decodes them.
+func RegisterCRDSchemas(crds func(logger *slog.Logger) []apiextensionsv1.CustomResourceDefinition) {
+	crdSchemas = append(crdSchemas, crds)
+}
+
+func getCRDSchemaValidators(logger *slog.Logger) map[schema.GroupVersionKind]validation.SchemaCreateValidator {
+	crdSchemaValidatorsOnce.Do(func() {
+		crdSchemaValidators = make(map[schema.GroupVersionKind]validation.SchemaCreateValidator)
+		for _, crds := range crdSchemas {
+			for _, crd := range crds(logger) {
+				for _, version := range crd.Spec.Versions {
+					if version.Schema == nil || version.Schema.OpenAPIV3Schema == nil {
+						continue
+					}
+					v, err := schemaValidatorFor(version.Schema)
+					if err != nil {
+						// Skip this schema so the other CRDs can still be
+						// validated.
+						logger.Warn("Skipping CRD schema validator",
+							logfields.CRDName, crd.Name,
+							logfields.Version, version.Name,
+							logfields.Error, err)
+						continue
+					}
+					gvk := schema.GroupVersionKind{
+						Group:   crd.Spec.Group,
+						Version: version.Name,
+						Kind:    crd.Spec.Names.Kind,
+					}
+					crdSchemaValidators[gvk] = v
+				}
+			}
+		}
+	})
+	return crdSchemaValidators
+}
+
+func schemaValidatorFor(crv *apiextensionsv1.CustomResourceValidation) (validation.SchemaCreateValidator, error) {
+	var crvInternal apiextensionsinternal.CustomResourceValidation
+	if err := apiextensionsv1.Convert_v1_CustomResourceValidation_To_apiextensions_CustomResourceValidation(
+		crv, &crvInternal, nil,
+	); err != nil {
+		return nil, err
+	}
+
+	v, _, err := validation.NewSchemaValidator(crvInternal.OpenAPIV3Schema)
+	return v, err
+}
+
+// ValidateCRD validates a raw CRD YAML document against the embedded CRD
+// schemas, like the kube-apiserver does. Kinds without a known CRD schema are
+// accepted as-is.
+//
+// With schemaValidation the document is validated against the CRD OpenAPI
+// schema. Unknown fields are rejected either way, as a typo is never
+// intentional.
+//
+// The input must be the raw YAML and not a decoded object, since the typed
+// decode drops the unknown fields we want to catch.
+func ValidateCRD(logger *slog.Logger, rawYAML []byte, schemaValidation bool) error {
+	var us unstructured.Unstructured
+	if err := k8sYaml.Unmarshal(rawYAML, &us); err != nil {
+		return fmt.Errorf("decoding into unstructured: %w", err)
+	}
+
+	validator, ok := getCRDSchemaValidators(logger)[us.GroupVersionKind()]
+	if !ok {
+		return nil
+	}
+
+	// Reject unknown fields before the schema check, as a typo otherwise
+	// shows up as the correct field missing.
+	//
+	// This is stricter than the apiserver, which prunes unknown fields
+	// instead of rejecting them. We want to catch typos.
+	if _, _, err := StrictDecoder().Decode(rawYAML, nil, nil); err != nil {
+		return fmt.Errorf("strict decode: %w", err)
+	}
+
+	if schemaValidation {
+		if errs := validation.ValidateCustomResource(nil, &us, validator); len(errs) > 0 {
+			return errs.ToAggregate()
+		}
+	}
+
+	return nil
+}

--- a/pkg/k8s/testutils/crd_validation.go
+++ b/pkg/k8s/testutils/crd_validation.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package testutils
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	apiextensionsinternal "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	k8sYaml "sigs.k8s.io/yaml"
+
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/client"
+)
+
+var (
+	crdSchemaValidatorsOnce sync.Once
+	crdSchemaValidators     map[schema.GroupVersionKind]validation.SchemaCreateValidator
+
+	strictDecoderOnce sync.Once
+	strictDecoder     runtime.Decoder
+)
+
+func getCRDSchemaValidators(logger *slog.Logger) map[schema.GroupVersionKind]validation.SchemaCreateValidator {
+	crdSchemaValidatorsOnce.Do(func() {
+		crdSchemaValidators = make(map[schema.GroupVersionKind]validation.SchemaCreateValidator)
+		for _, crdList := range client.CustomResourceDefinitionList() {
+			crd := client.GetPregeneratedCRD(logger, crdList.Name)
+			for _, version := range crd.Spec.Versions {
+				if version.Schema == nil || version.Schema.OpenAPIV3Schema == nil {
+					continue
+				}
+				v, err := schemaValidatorFor(version.Schema)
+				if err != nil {
+					// A bad embedded schema is a build-time bug, not test input;
+					// skip it rather than poisoning the whole map.
+					logger.Warn("skipping CRD schema validator",
+						"crd", crdList.Name, "version", version.Name, "error", err)
+					continue
+				}
+				gvk := schema.GroupVersionKind{
+					Group:   crd.Spec.Group,
+					Version: version.Name,
+					Kind:    crd.Spec.Names.Kind,
+				}
+				crdSchemaValidators[gvk] = v
+			}
+		}
+	})
+	return crdSchemaValidators
+}
+
+func schemaValidatorFor(crv *apiextensionsv1.CustomResourceValidation) (validation.SchemaCreateValidator, error) {
+	// Round-trip through JSON to apply the schema's defaults, as the apiserver does.
+	crvJSON, err := json.Marshal(crv)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling CRD validation: %w", err)
+	}
+	var crvV1 apiextensionsv1.CustomResourceValidation
+	if err := json.Unmarshal(crvJSON, &crvV1); err != nil {
+		return nil, fmt.Errorf("unmarshalling CRD validation: %w", err)
+	}
+
+	var crvInternal apiextensionsinternal.CustomResourceValidation
+	if err := apiextensionsv1.Convert_v1_CustomResourceValidation_To_apiextensions_CustomResourceValidation(
+		&crvV1, &crvInternal, nil,
+	); err != nil {
+		return nil, err
+	}
+
+	v, _, err := validation.NewSchemaValidator(crvInternal.OpenAPIV3Schema)
+	return v, err
+}
+
+func getStrictDecoder() runtime.Decoder {
+	strictDecoderOnce.Do(func() {
+		strictDecoder = serializer.NewCodecFactory(Scheme, serializer.EnableStrict).UniversalDeserializer()
+	})
+	return strictDecoder
+}
+
+// ValidateCRD validates a raw CRD YAML document against the embedded CRD
+// schemas, as the kube-apiserver would: OpenAPI schema validation plus a strict
+// decode to reject unknown fields.
+//
+// supported reports whether the document's kind is a Cilium CRD with a known
+// schema; callers feeding arbitrary objects should skip validation when it is
+// false rather than treating it as an error. Malformed input returns an error
+// with supported=false.
+//
+// Callers must pass raw YAML, not a decoded object: a typed decode silently
+// drops unknown fields, defeating the typo detection.
+func ValidateCRD(logger *slog.Logger, rawYAML []byte) (supported bool, err error) {
+	jsonBytes, err := k8sYaml.YAMLToJSON(rawYAML)
+	if err != nil {
+		return false, fmt.Errorf("converting YAML to JSON: %w", err)
+	}
+
+	var us unstructured.Unstructured
+	if err := json.Unmarshal(jsonBytes, &us); err != nil {
+		return false, fmt.Errorf("decoding into unstructured: %w", err)
+	}
+
+	validator, ok := getCRDSchemaValidators(logger)[us.GroupVersionKind()]
+	if !ok {
+		return false, nil
+	}
+
+	if errs := validation.ValidateCustomResource(nil, &us, validator); len(errs) > 0 {
+		return true, errs.ToAggregate()
+	}
+
+	// Stricter than the apiserver, which prunes unknown fields rather than
+	// rejecting them; surfaces typos that would otherwise be silently dropped.
+	if _, _, err := getStrictDecoder().Decode(jsonBytes, nil, nil); err != nil {
+		return true, fmt.Errorf("strict decode: %w", err)
+	}
+
+	return true, nil
+}

--- a/pkg/k8s/testutils/crd_validation_test.go
+++ b/pkg/k8s/testutils/crd_validation_test.go
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package testutils
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestValidateCRD(t *testing.T) {
+	tests := []struct {
+		name    string
+		object  string
+		wantErr bool
+		// wantErrNoSchema is the expectation with schema validation off.
+		wantErrNoSchema bool
+	}{
+		{
+			name: "valid CNP",
+			object: `apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: valid-cnp
+  namespace: default
+spec:
+  endpointSelector:
+    matchLabels:
+      app: foo
+  egress:
+  - toEndpoints:
+    - matchLabels:
+        app: bar
+`,
+			wantErr: false,
+		},
+		{
+			name: "CNP with unknown field is rejected",
+			object: `apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: bogus-field
+  namespace: default
+spec:
+  endpointSelector:
+    matchLabels:
+      app: foo
+  totallyBogusUnknownField: true
+`,
+			wantErr:         true,
+			wantErrNoSchema: true,
+		},
+		{
+			name: "CNP with misspelled selector is rejected",
+			object: `apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: typo
+  namespace: default
+spec:
+  endpointSelectr:
+    matchLabels:
+      app: foo
+`,
+			wantErr:         true,
+			wantErrNoSchema: true,
+		},
+		{
+			name: "CNP with bad L4 protocol enum is rejected",
+			object: `apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: bad-proto
+  namespace: default
+spec:
+  endpointSelector: {}
+  egress:
+  - toPorts:
+    - ports:
+      - port: "80"
+        protocol: NOTAPROTOCOL
+`,
+			wantErr: true,
+		},
+		{
+			name: "validation is generic: valid CiliumEnvoyConfig",
+			object: `apiVersion: cilium.io/v2
+kind: CiliumEnvoyConfig
+metadata:
+  name: cec
+  namespace: default
+spec:
+  services:
+  - name: foo
+  resources:
+  - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+    name: listener
+`,
+			wantErr: false,
+		},
+		{
+			name: "validation is generic: CiliumEnvoyConfig with unknown field is rejected",
+			object: `apiVersion: cilium.io/v2
+kind: CiliumEnvoyConfig
+metadata:
+  name: cec
+  namespace: default
+spec:
+  bogusUnknownFieldHere: true
+  services:
+  - name: foo
+  resources:
+  - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+    name: listener
+`,
+			wantErr:         true,
+			wantErrNoSchema: true,
+		},
+		{
+			name: "validation is generic: CiliumEnvoyConfig missing required resources is rejected",
+			object: `apiVersion: cilium.io/v2
+kind: CiliumEnvoyConfig
+metadata:
+  name: cec
+  namespace: default
+spec:
+  services:
+  - name: foo
+`,
+			wantErr: true,
+		},
+		{
+			name: "core kind without a CRD schema is skipped",
+			object: `apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 10.96.50.104
+`,
+			wantErr: false,
+		},
+		{
+			name:            "malformed YAML is rejected",
+			object:          "this: is: not: valid: yaml:\n\t- ][",
+			wantErr:         true,
+			wantErrNoSchema: true,
+		},
+	}
+
+	log := hivetest.Logger(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, schemaValidation := range []bool{true, false} {
+				err := ValidateCRD(log, []byte(tt.object), schemaValidation)
+				wantErr := tt.wantErr
+				if !schemaValidation {
+					wantErr = tt.wantErrNoSchema
+				}
+				if wantErr {
+					require.Error(t, err, "schemaValidation=%v", schemaValidation)
+				} else {
+					require.NoError(t, err, "schemaValidation=%v", schemaValidation)
+				}
+			}
+		})
+	}
+}
+
+func init() {
+	RegisterCRDSchemas(func(*slog.Logger) []apiextensionsv1.CustomResourceDefinition {
+		return []apiextensionsv1.CustomResourceDefinition{testCRD}
+	})
+}
+
+var testCRD = apiextensionsv1.CustomResourceDefinition{
+	Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+		Group: "example.com",
+		Names: apiextensionsv1.CustomResourceDefinitionNames{Kind: "Example"},
+		Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+			{
+				Name: "v1",
+				Schema: &apiextensionsv1.CustomResourceValidation{
+					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{Type: "object"},
+				},
+			},
+		},
+	},
+}
+
+func TestRegisterCRDSchemas(t *testing.T) {
+	validators := getCRDSchemaValidators(hivetest.Logger(t))
+
+	// The registered CRDs are validated alongside the pregenerated ones.
+	require.Contains(t, validators, schema.GroupVersionKind{
+		Group: "example.com", Version: "v1", Kind: "Example",
+	})
+	require.Contains(t, validators, schema.GroupVersionKind{
+		Group: "cilium.io", Version: "v2", Kind: "CiliumNetworkPolicy",
+	})
+}

--- a/pkg/k8s/testutils/crd_validation_test.go
+++ b/pkg/k8s/testutils/crd_validation_test.go
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package testutils
+
+import (
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateCRD(t *testing.T) {
+	tests := []struct {
+		name          string
+		object        string
+		wantSupported bool
+		wantErr       bool
+	}{
+		{
+			name: "valid CNP",
+			object: `apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: valid-cnp
+  namespace: default
+spec:
+  endpointSelector:
+    matchLabels:
+      app: foo
+  egress:
+  - toEndpoints:
+    - matchLabels:
+        app: bar
+`,
+			wantSupported: true,
+			wantErr:       false,
+		},
+		{
+			name: "CNP with unknown field is rejected",
+			object: `apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: bogus-field
+  namespace: default
+spec:
+  endpointSelector:
+    matchLabels:
+      app: foo
+  totallyBogusUnknownField: true
+`,
+			wantSupported: true,
+			wantErr:       true,
+		},
+		{
+			name: "CNP with misspelled selector is rejected",
+			object: `apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: typo
+  namespace: default
+spec:
+  endpointSelectr:
+    matchLabels:
+      app: foo
+`,
+			wantSupported: true,
+			wantErr:       true,
+		},
+		{
+			name: "CNP with bad L4 protocol enum is rejected",
+			object: `apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: bad-proto
+  namespace: default
+spec:
+  endpointSelector: {}
+  egress:
+  - toPorts:
+    - ports:
+      - port: "80"
+        protocol: NOTAPROTOCOL
+`,
+			wantSupported: true,
+			wantErr:       true,
+		},
+		{
+			name: "validation is generic: valid CiliumEnvoyConfig",
+			object: `apiVersion: cilium.io/v2
+kind: CiliumEnvoyConfig
+metadata:
+  name: cec
+  namespace: default
+spec:
+  services:
+  - name: foo
+  resources:
+  - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+    name: listener
+`,
+			wantSupported: true,
+			wantErr:       false,
+		},
+		{
+			name: "validation is generic: CiliumEnvoyConfig with unknown field is rejected",
+			object: `apiVersion: cilium.io/v2
+kind: CiliumEnvoyConfig
+metadata:
+  name: cec
+  namespace: default
+spec:
+  bogusUnknownFieldHere: true
+  services:
+  - name: foo
+  resources:
+  - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+    name: listener
+`,
+			wantSupported: true,
+			wantErr:       true,
+		},
+		{
+			name: "validation is generic: CiliumEnvoyConfig missing required resources is rejected",
+			object: `apiVersion: cilium.io/v2
+kind: CiliumEnvoyConfig
+metadata:
+  name: cec
+  namespace: default
+spec:
+  services:
+  - name: foo
+`,
+			wantSupported: true,
+			wantErr:       true,
+		},
+		{
+			name: "core kind without a CRD schema is skipped",
+			object: `apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  namespace: test
+spec:
+  clusterIP: 10.96.50.104
+`,
+			wantSupported: false,
+			wantErr:       false,
+		},
+		{
+			name: "non-Cilium object is skipped",
+			object: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm
+  namespace: default
+data:
+  foo: bar
+`,
+			wantSupported: false,
+			wantErr:       false,
+		},
+		{
+			name:          "malformed YAML is rejected",
+			object:        "this: is: not: valid: yaml:\n\t- ][",
+			wantSupported: false,
+			wantErr:       true,
+		},
+	}
+
+	log := hivetest.Logger(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			supported, err := ValidateCRD(log, []byte(tt.object))
+			require.Equal(t, tt.wantSupported, supported)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/k8s/testutils/decoder.go
+++ b/pkg/k8s/testutils/decoder.go
@@ -45,6 +45,9 @@ var (
 // Decoder returns an object decoder for Cilium and Slim objects.
 // The [DecodeObject] and [DecodeFile] functions are provided as
 // shorthands for decoding from bytes and files respectively.
+//
+// Not strict, as the slim types leave out fields that are valid in the full
+// Kubernetes ones. See [StrictDecoder].
 func Decoder() runtime.Decoder {
 	decoderOnce.Do(func() {
 		decoder = serializer.NewCodecFactory(Scheme).UniversalDeserializer()
@@ -52,9 +55,12 @@ func Decoder() runtime.Decoder {
 	return decoder
 }
 
+// KubernetesDecoder returns a decoder for the core Kubernetes objects. Unlike
+// [Decoder] it rejects unknown fields, which the full types can afford as they
+// are not trimmed the way the slim ones are.
 func KubernetesDecoder() runtime.Decoder {
 	kubernetesDecoderOnce.Do(func() {
-		kubernetesDecoder = serializer.NewCodecFactory(KubernetesScheme).UniversalDeserializer()
+		kubernetesDecoder = serializer.NewCodecFactory(KubernetesScheme, serializer.EnableStrict).UniversalDeserializer()
 	})
 	return kubernetesDecoder
 }

--- a/pkg/k8s/testutils/decoder.go
+++ b/pkg/k8s/testutils/decoder.go
@@ -37,6 +37,9 @@ var (
 
 	kubernetesDecoderOnce sync.Once
 	kubernetesDecoder     runtime.Decoder
+
+	strictDecoderOnce sync.Once
+	strictDecoder     runtime.Decoder
 )
 
 // Decoder returns an object decoder for Cilium and Slim objects.
@@ -54,6 +57,15 @@ func KubernetesDecoder() runtime.Decoder {
 		kubernetesDecoder = serializer.NewCodecFactory(KubernetesScheme).UniversalDeserializer()
 	})
 	return kubernetesDecoder
+}
+
+// StrictDecoder is like [Decoder], but rejects unknown fields instead of
+// dropping them.
+func StrictDecoder() runtime.Decoder {
+	strictDecoderOnce.Do(func() {
+		strictDecoder = serializer.NewCodecFactory(Scheme, serializer.EnableStrict).UniversalDeserializer()
+	})
+	return strictDecoder
 }
 
 func init() {

--- a/pkg/loadbalancer/tests/testdata/topology-aware-terminating.txtar
+++ b/pkg/loadbalancer/tests/testdata/topology-aware-terminating.txtar
@@ -32,7 +32,7 @@ db/cmp frontends frontends-both.table
 cp endpointslice2.yaml endpointslice2-terminating.yaml
 sed 'ready: true' 'ready: false' endpointslice2-terminating.yaml
 sed 'terminating: false' 'terminating: true' endpointslice2-terminating.yaml
-sed 'forZones:' 'notForZones:' endpointslice2-terminating.yaml
+sed '- name: foo' '' endpointslice2-terminating.yaml
 k8s/update endpointslice2-terminating.yaml
 db/cmp backends backends-one-terminating.table
 db/cmp frontends frontends-only-eps1.table
@@ -44,7 +44,7 @@ db/cmp frontends frontends-only-eps1.table
 cp endpointslice1.yaml endpointslice1-terminating.yaml
 sed 'ready: true' 'ready: false' endpointslice1-terminating.yaml
 sed 'terminating: false' 'terminating: true' endpointslice1-terminating.yaml
-sed 'forZones:' 'notForZones:' endpointslice1-terminating.yaml
+sed '- name: foo' '' endpointslice1-terminating.yaml
 k8s/update endpointslice1-terminating.yaml
 db/cmp backends backends-both-terminating.table
 db/cmp frontends frontends-both-terminating.table

--- a/pkg/loadbalancer/tests/testdata/topology-aware.txtar
+++ b/pkg/loadbalancer/tests/testdata/topology-aware.txtar
@@ -35,7 +35,7 @@ db/cmp frontends frontends-foo.table
 # fall back to selecting all backends.
 # (safeguard #4 at https://kubernetes.io/docs/concepts/services-networking/topology-aware-routing/#safeguards)
 cp endpointslice2.yaml endpointslice2-no-hints.yaml
-sed 'forZones:' 'notForZones:' endpointslice2-no-hints.yaml
+sed '- name: quux' '' endpointslice2-no-hints.yaml
 k8s/update endpointslice2-no-hints.yaml
 db/cmp frontends frontends-all.table
 


### PR DESCRIPTION
Validate CRDs against their embedded schemas on k8s/add and k8s/update in script tests, enabled by default and opt-out with --validate=false, so tests fail on CRD YAML the apiserver would reject.

Fix existing fixtures that this surfaced.

---

Inspired by: https://github.com/cilium/cilium/pull/47225
