### PR TITLE
ipam: wait for pool readiness on fresh multi-pool allocation

### DIFF
--- a/daemon/infraendpoints/infra_ip_allocation.go
+++ b/daemon/infraendpoints/infra_ip_allocation.go
@@ -86,6 +86,7 @@ type infraIPAllocator struct {
 type ipamAllocator interface {
 	AllocateIPWithoutSyncUpstream(ip netip.Addr, owner string, pool ipam.Pool) (*ipam.AllocationResult, error)
 	AllocateNextFamilyWithoutSyncUpstream(family ipam.Family, owner string, pool ipam.Pool) (result *ipam.AllocationResult, err error)
+	AllocateNextFamily(family ipam.Family, owner string, pool ipam.Pool) (result *ipam.AllocationResult, err error)
 	ExcludeIP(ip netip.Addr, owner string, pool ipam.Pool)
 	ReleaseIP(ip netip.Addr, pool ipam.Pool) error
 }
@@ -220,6 +221,53 @@ func (r *infraIPAllocator) reallocateOldRouterIPs(fromK8s, fromFS net.IP) (resul
 	return result
 }
 
+func (r *infraIPAllocator) allocateNextFromPool(ctx context.Context, family ipam.Family, owner string) (*ipam.AllocationResult, error) {
+	result, err := r.ipAllocator.AllocateNextFamilyWithoutSyncUpstream(family, owner, ipam.PoolDefault())
+	if err == nil {
+		return result, nil
+	}
+
+	var poolErr *ipam.ErrPoolNotReadyYet
+	if !errors.As(err, &poolErr) {
+		return nil, err
+	}
+
+	// The pool is not yet provisioned by the operator. Fall back to
+	// AllocateNextFamily which triggers an upstream K8s sync to request
+	// pool provisioning, then retry until the pool becomes available.
+	bo := wait.Backoff{
+		Duration: 500 * time.Millisecond,
+		Factor:   1.5,
+		Jitter:   0.1,
+		Steps:    20,
+	}
+
+	var lastErr error
+	err = wait.ExponentialBackoffWithContext(ctx, bo, func(ctx context.Context) (bool, error) {
+		var allocErr error
+		result, allocErr = r.ipAllocator.AllocateNextFamily(family, owner, ipam.PoolDefault())
+		if allocErr == nil {
+			return true, nil
+		}
+
+		var poolErr *ipam.ErrPoolNotReadyYet
+		if errors.As(allocErr, &poolErr) {
+			lastErr = allocErr
+			return false, nil
+		}
+
+		return true, allocErr
+	})
+
+	if err != nil {
+		if lastErr != nil {
+			return nil, fmt.Errorf("timed out allocating IP: %w", lastErr)
+		}
+		return nil, fmt.Errorf("unable to allocate next IP: %w", err)
+	}
+	return result, nil
+}
+
 func (r *infraIPAllocator) waitForENI(ctx context.Context, macAddr string) error {
 	bo := wait.Backoff{
 		Duration: 250 * time.Millisecond,
@@ -262,7 +310,7 @@ func (r *infraIPAllocator) reallocateRouterIPs(ctx context.Context, family node.
 	if result == nil {
 		primaryAddr, _ := netip.AddrFromSlice(family.PrimaryExternal())
 		family := ipam.DeriveFamily(primaryAddr.Unmap())
-		result, err = r.ipAllocator.AllocateNextFamilyWithoutSyncUpstream(family, "router", ipam.PoolDefault())
+		result, err = r.allocateNextFromPool(ctx, family, "router")
 		if err != nil {
 			return nil, fmt.Errorf("unable to allocate router IP for family %s: %w", family, err)
 		}
@@ -346,7 +394,7 @@ func (r *infraIPAllocator) reallocateRouterIPs(ctx context.Context, family node.
 	return net.IP(result.IP.AsSlice()).To16(), nil
 }
 
-func (r *infraIPAllocator) allocateHealthIPs(oldV4HealthIP netip.Addr, oldV6HealthIP netip.Addr) error {
+func (r *infraIPAllocator) allocateHealthIPs(ctx context.Context, oldV4HealthIP netip.Addr, oldV6HealthIP netip.Addr) error {
 	if !r.daemonConfig.EnableHealthChecking || !r.daemonConfig.EnableEndpointHealthChecking {
 		return nil
 	}
@@ -367,7 +415,7 @@ func (r *infraIPAllocator) allocateHealthIPs(oldV4HealthIP netip.Addr, oldV6Heal
 			}
 		}
 		if !healthIPv4.IsValid() {
-			result, err = r.ipAllocator.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv4, "health", ipam.PoolDefault())
+			result, err = r.allocateNextFromPool(ctx, ipam.IPv4, "health")
 			if err != nil {
 				return fmt.Errorf("unable to allocate health IPv4: %w, see https://cilium.link/ipam-range-full", err)
 			}
@@ -410,7 +458,7 @@ func (r *infraIPAllocator) allocateHealthIPs(oldV4HealthIP netip.Addr, oldV6Heal
 			}
 		}
 		if !healthIPv6.IsValid() {
-			result, err = r.ipAllocator.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv6, "health", ipam.PoolDefault())
+			result, err = r.allocateNextFromPool(ctx, ipam.IPv6, "health")
 			if err != nil {
 				if healthIPv4.IsValid() {
 					r.ipAllocator.ReleaseIP(healthIPv4, ipam.PoolDefault())
@@ -425,7 +473,7 @@ func (r *infraIPAllocator) allocateHealthIPs(oldV4HealthIP netip.Addr, oldV6Heal
 	return nil
 }
 
-func (r *infraIPAllocator) allocateIngressIPs(oldV4IngressIP net.IP, oldV6IngressIP net.IP) error {
+func (r *infraIPAllocator) allocateIngressIPs(ctx context.Context, oldV4IngressIP net.IP, oldV6IngressIP net.IP) error {
 	if !r.daemonConfig.EnableEnvoyConfig {
 		return nil
 	}
@@ -450,7 +498,7 @@ func (r *infraIPAllocator) allocateIngressIPs(oldV4IngressIP net.IP, oldV6Ingres
 		// Allocate a fresh IP if not restored, or the reallocation of the restored
 		// IP failed
 		if result == nil {
-			result, err = r.ipAllocator.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv4, "ingress", ipam.PoolDefault())
+			result, err = r.allocateNextFromPool(ctx, ipam.IPv4, "ingress")
 			if err != nil {
 				return fmt.Errorf("unable to allocate ingress IPs: %w, see https://cilium.link/ipam-range-full", err)
 			}
@@ -507,7 +555,7 @@ func (r *infraIPAllocator) allocateIngressIPs(oldV4IngressIP net.IP, oldV6Ingres
 		// Allocate a fresh IP if not restored, or the reallocation of the restored
 		// IP failed
 		if result == nil {
-			result, err = r.ipAllocator.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv6, "ingress", ipam.PoolDefault())
+			result, err = r.allocateNextFromPool(ctx, ipam.IPv6, "ingress")
 			if err != nil {
 				if ingressIPv4 != nil {
 					r.ipAllocator.ReleaseIP(iputil.AddrFromIP(ingressIPv4), ipam.PoolDefault())
@@ -553,11 +601,11 @@ func (r *infraIPAllocator) AllocateIPs(ctx context.Context) error {
 		return fmt.Errorf("failed to allocate service loopback IPs: %w", err)
 	}
 
-	if err := r.allocateIngressIPs(localNode.IPv4IngressIP, localNode.IPv6IngressIP); err != nil {
+	if err := r.allocateIngressIPs(ctx, localNode.IPv4IngressIP, localNode.IPv6IngressIP); err != nil {
 		return fmt.Errorf("failed to allocate ingress IPs: %w", err)
 	}
 
-	if err := r.allocateHealthIPs(localNode.IPv4HealthIP.Addr, localNode.IPv6HealthIP.Addr); err != nil {
+	if err := r.allocateHealthIPs(ctx, localNode.IPv4HealthIP.Addr, localNode.IPv6HealthIP.Addr); err != nil {
 		return fmt.Errorf("failed to allocate health IPs: %w", err)
 	}
 

--- a/daemon/infraendpoints/infra_ip_allocation_test.go
+++ b/daemon/infraendpoints/infra_ip_allocation_test.go
@@ -9,6 +9,7 @@ import (
 	"net/netip"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
@@ -20,7 +21,10 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/ipam"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/mac"
+	nodeaddressing "github.com/cilium/cilium/pkg/node/fake"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/testutils/netns"
 )
@@ -114,6 +118,10 @@ func (m *mockIPAllocator) AllocateNextFamilyWithoutSyncUpstream(family ipam.Fami
 	return nil, nil
 }
 
+func (m *mockIPAllocator) AllocateNextFamily(family ipam.Family, owner string, pool ipam.Pool) (result *ipam.AllocationResult, err error) {
+	return nil, nil
+}
+
 func (m *mockIPAllocator) ExcludeIP(ip netip.Addr, owner string, pool ipam.Pool) {}
 
 func (m *mockIPAllocator) ReleaseIP(ip netip.Addr, pool ipam.Pool) error {
@@ -121,6 +129,40 @@ func (m *mockIPAllocator) ReleaseIP(ip netip.Addr, pool ipam.Pool) error {
 }
 
 var _ ipamAllocator = &mockIPAllocator{}
+
+type retryMockAllocator struct {
+	failCount int32        // how many ErrPoolNotReadyYet to return before succeeding
+	attempts  atomic.Int32 // total allocation attempts made
+	resultIP  netip.Addr   // IP to return on success
+}
+
+func (m *retryMockAllocator) AllocateIPWithoutSyncUpstream(ip netip.Addr, owner string, pool ipam.Pool) (*ipam.AllocationResult, error) {
+	return &ipam.AllocationResult{IP: ip}, nil
+}
+
+func (m *retryMockAllocator) AllocateNextFamilyWithoutSyncUpstream(family ipam.Family, owner string, pool ipam.Pool) (*ipam.AllocationResult, error) {
+	n := m.attempts.Add(1)
+	if n <= m.failCount {
+		return nil, &ipam.ErrPoolNotReadyYet{}
+	}
+	return &ipam.AllocationResult{IP: m.resultIP}, nil
+}
+
+func (m *retryMockAllocator) AllocateNextFamily(family ipam.Family, owner string, pool ipam.Pool) (*ipam.AllocationResult, error) {
+	n := m.attempts.Add(1)
+	if n <= m.failCount {
+		return nil, &ipam.ErrPoolNotReadyYet{}
+	}
+	return &ipam.AllocationResult{IP: m.resultIP}, nil
+}
+
+func (m *retryMockAllocator) ExcludeIP(ip netip.Addr, owner string, pool ipam.Pool) {}
+
+func (m *retryMockAllocator) ReleaseIP(ip netip.Addr, pool ipam.Pool) error {
+	return nil
+}
+
+var _ ipamAllocator = &retryMockAllocator{}
 
 func TestDaemon_reallocateDatapathIPs(t *testing.T) {
 	infraIPAllocator := &infraIPAllocator{
@@ -170,6 +212,161 @@ func TestDaemon_reallocateDatapathIPs(t *testing.T) {
 	result = infraIPAllocator.reallocateOldRouterIPs(fromK8s, invalidFromFS)
 	assert.NotNil(t, result)
 	assert.Equal(t, result.IP, fromK8sAddr)
+}
+
+func TestDaemon_allocateNextFromPool_Retries(t *testing.T) {
+	resultIP := netip.MustParseAddr("10.0.0.5")
+
+	mock := &retryMockAllocator{
+		failCount: 3,
+		resultIP:  resultIP,
+	}
+
+	infra := &infraIPAllocator{
+		logger:      hivetest.Logger(t),
+		ipAllocator: mock,
+	}
+
+	ctx := t.Context()
+	result, err := infra.allocateNextFromPool(ctx, ipam.IPv4, "router")
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, resultIP, result.IP)
+
+	assert.Equal(t, int32(4), mock.attempts.Load())
+}
+
+func TestDaemon_allocateNextFromPool_NonPoolError_StopsImmediately(t *testing.T) {
+	nonPoolMock := &nonPoolErrAllocator{}
+	infra := &infraIPAllocator{
+		logger:      hivetest.Logger(t),
+		ipAllocator: nonPoolMock,
+	}
+
+	ctx := t.Context()
+	_, err := infra.allocateNextFromPool(ctx, ipam.IPv4, "router")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "something unrelated went wrong")
+	assert.Equal(t, int32(1), nonPoolMock.attempts.Load())
+}
+
+func TestDaemon_allocateNextFromPool_NonPoolErrorInBackoff_StopsImmediately(t *testing.T) {
+	mock := &nonPoolErrorAfterRetryAllocator{}
+	infra := &infraIPAllocator{
+		logger:      hivetest.Logger(t),
+		ipAllocator: mock,
+	}
+
+	ctx := t.Context()
+	_, err := infra.allocateNextFromPool(ctx, ipam.IPv4, "router")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "something unrelated went wrong")
+	assert.Equal(t, int32(1), mock.poolNotReady.Load())
+	assert.Equal(t, int32(1), mock.allocateCalls.Load())
+}
+
+func TestDaemon_reallocateRouterIPs_PoolNotReady(t *testing.T) {
+	resultIP := netip.MustParseAddr("10.0.0.5")
+
+	mock := &retryMockAllocator{
+		failCount: 2,
+		resultIP:  resultIP,
+	}
+
+	origDefaultPool := option.Config.IPAMDefaultIPPool
+	option.Config.IPAMDefaultIPPool = "default"
+	defer func() { option.Config.IPAMDefaultIPPool = origDefaultPool }()
+
+	infra := &infraIPAllocator{
+		logger:         hivetest.Logger(t),
+		ipAllocator:    mock,
+		daemonConfig:   &option.DaemonConfig{IPAM: ipamOption.IPAMMultiPool},
+		nodeAddressing: nodeaddressing.NewIPv4OnlyAddressing(),
+	}
+
+	ctx := t.Context()
+	family := nodeaddressing.NewIPv4OnlyAddressing().IPv4()
+
+	ip, err := infra.reallocateRouterIPs(ctx, family, nil, nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, ip)
+	assert.Equal(t, net.IP(resultIP.AsSlice()).To16(), ip)
+
+	assert.Equal(t, int32(3), mock.attempts.Load())
+}
+
+func TestDaemon_reallocateRouterIPs_NonPoolError_Fatal(t *testing.T) {
+	origDefaultPool := option.Config.IPAMDefaultIPPool
+	option.Config.IPAMDefaultIPPool = "default"
+	defer func() { option.Config.IPAMDefaultIPPool = origDefaultPool }()
+
+	infra := &infraIPAllocator{
+		logger:         hivetest.Logger(t),
+		ipAllocator:    &nonPoolErrAllocator{},
+		daemonConfig:   &option.DaemonConfig{IPAM: ipamOption.IPAMMultiPool},
+		nodeAddressing: nodeaddressing.NewIPv4OnlyAddressing(),
+	}
+
+	ctx := t.Context()
+	family := nodeaddressing.NewIPv4OnlyAddressing().IPv4()
+
+	_, err := infra.reallocateRouterIPs(ctx, family, nil, nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to allocate router IP")
+}
+
+type nonPoolErrAllocator struct {
+	attempts atomic.Int32
+}
+
+func (m *nonPoolErrAllocator) AllocateIPWithoutSyncUpstream(ip netip.Addr, owner string, pool ipam.Pool) (*ipam.AllocationResult, error) {
+	return &ipam.AllocationResult{IP: ip}, nil
+}
+
+func (m *nonPoolErrAllocator) AllocateNextFamilyWithoutSyncUpstream(family ipam.Family, owner string, pool ipam.Pool) (*ipam.AllocationResult, error) {
+	m.attempts.Add(1)
+	return nil, fmt.Errorf("something unrelated went wrong")
+}
+
+func (m *nonPoolErrAllocator) AllocateNextFamily(family ipam.Family, owner string, pool ipam.Pool) (*ipam.AllocationResult, error) {
+	m.attempts.Add(1)
+	return nil, fmt.Errorf("something unrelated went wrong")
+}
+
+func (m *nonPoolErrAllocator) ExcludeIP(ip netip.Addr, owner string, pool ipam.Pool) {}
+
+func (m *nonPoolErrAllocator) ReleaseIP(ip netip.Addr, pool ipam.Pool) error {
+	return nil
+}
+
+type nonPoolErrorAfterRetryAllocator struct {
+	poolNotReady  atomic.Int32
+	allocateCalls atomic.Int32
+}
+
+func (m *nonPoolErrorAfterRetryAllocator) AllocateIPWithoutSyncUpstream(ip netip.Addr, owner string, pool ipam.Pool) (*ipam.AllocationResult, error) {
+	return &ipam.AllocationResult{IP: ip}, nil
+}
+
+func (m *nonPoolErrorAfterRetryAllocator) AllocateNextFamilyWithoutSyncUpstream(family ipam.Family, owner string, pool ipam.Pool) (*ipam.AllocationResult, error) {
+	m.poolNotReady.Add(1)
+	return nil, &ipam.ErrPoolNotReadyYet{}
+}
+
+func (m *nonPoolErrorAfterRetryAllocator) AllocateNextFamily(family ipam.Family, owner string, pool ipam.Pool) (*ipam.AllocationResult, error) {
+	m.allocateCalls.Add(1)
+	return nil, fmt.Errorf("something unrelated went wrong")
+}
+
+func (m *nonPoolErrorAfterRetryAllocator) ExcludeIP(ip netip.Addr, owner string, pool ipam.Pool) {}
+
+func (m *nonPoolErrorAfterRetryAllocator) ReleaseIP(ip netip.Addr, pool ipam.Pool) error {
+	return nil
 }
 
 func TestPrivilegedRemoveOldRouterState(t *testing.T) {


### PR DESCRIPTION
Fixes: #47379

## Problem:

When pre-allocation is set to 0 for a pool, the agent may attempt to allocate a router IP before the operator has provisioned any CIDR blocks. The local pool is `nil` and `AllocateNextFamilyWithoutSyncUpstream` returns `ErrPoolNotReadyYet`. Prior to this change that error was fatal and the agent restarted in a loop.

## Solution:

Add a retry mechanism in `reallocateRouterIPs` that catches `ErrPoolNotReadyYet`, triggers an upstream sync so the operator sees the pending demand, and waits for the pool to become available via `waitForPoolIP` with exponential backoff.

Also expose `PoolName()`/`Family()` on `ErrPoolNotReadyYet`, add `TriggerUpstreamSync()` plumbing through the IPAM and `multiPoolAllocator` layers.

I've added unit tests to check the retry behaviour and it seems okay?

This PR was prepared with AIL:1. I used AI to help understand the components involved, but used my braincells and implemented the fix myself.

Please let me know if there are any problems with my approach!!