### PR TITLE
Use k8s API constants instead of string literals

### DIFF
--- a/cilium-cli/connectivity/check/context.go
+++ b/cilium-cli/connectivity/check/context.go
@@ -925,9 +925,9 @@ func (ct *ConnectivityTest) detectSingleNode(ctx context.Context) error {
 	for _, n := range nodes.Items {
 		for _, t := range n.Spec.Taints {
 			switch {
-			case (t.Key == "node-role.kubernetes.io/master" && t.Effect == "NoSchedule"):
+			case (t.Key == "node-role.kubernetes.io/master" && t.Effect == slimcorev1.TaintEffectNoSchedule):
 				numWorkerNodes--
-			case (t.Key == "node-role.kubernetes.io/control-plane" && t.Effect == "NoSchedule"):
+			case (t.Key == "node-role.kubernetes.io/control-plane" && t.Effect == slimcorev1.TaintEffectNoSchedule):
 				numWorkerNodes--
 			}
 		}

--- a/cilium-cli/sysdump/k8sutils.go
+++ b/cilium-cli/sysdump/k8sutils.go
@@ -148,7 +148,7 @@ func (c *Collector) ensureExecTarget(ctx context.Context, pod *corev1.Pod, conta
 			return false, err
 		}
 		for _, condition := range targetPod.Status.Conditions {
-			if condition.Type == corev1.ContainersReady && condition.Status == "True" {
+			if condition.Type == corev1.ContainersReady && condition.Status == corev1.ConditionTrue {
 				return true, nil
 			}
 		}

--- a/cilium-cli/sysdump/sysdump.go
+++ b/cilium-cli/sysdump/sysdump.go
@@ -1563,7 +1563,7 @@ func (c *Collector) Run() error {
 					return fmt.Errorf("could not find Cilium Agent Pod to run kvstore get, Cilium Pod list was empty")
 				}
 				for _, pod := range c.CiliumPods {
-					if pod.Status.Phase == "Running" {
+					if pod.Status.Phase == corev1.PodRunning {
 						return c.submitKVStoreTasks(ctx, pod.DeepCopy())
 					}
 				}

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -1030,8 +1030,8 @@ func (r *gatewayReconciler) setAddressStatus(ctx context.Context, gw *gatewayv1.
 
 	var addresses []gatewayv1.GatewayStatusAddress
 	// Check the svc type
-	switch svcType := svc.Spec.Type; svcType {
-	case "NodePort":
+	switch svc.Spec.Type {
+	case corev1.ServiceTypeNodePort:
 		// NodePort service gets as many Node
 		// IP addresses as we can fit into Status
 		nodes := &corev1.NodeList{}
@@ -1063,7 +1063,7 @@ func (r *gatewayReconciler) setAddressStatus(ctx context.Context, gw *gatewayv1.
 				Value: ipAddress.String(),
 			})
 		}
-	case "LoadBalancer":
+	case corev1.ServiceTypeLoadBalancer:
 		if len(svc.Status.LoadBalancer.Ingress) == 0 {
 			// Potential loadbalancer service isn't ready yet. No need to report as an error, because
 			// reconciliation should be triggered when the loadbalancer services gets updated.
@@ -1992,7 +1992,7 @@ func (r *gatewayReconciler) setBackendTLSPolicyStatuses(scopedLog *slog.Logger,
 	scopedLog.Debug("Updating BackendTLSPolicy statuses for Gateway", policies, len(btlspMap))
 
 	currentGatewayRef := gatewayv1.ParentReference{
-		Group:     ptr.To[gatewayv1.Group]("gateway.networking.k8s.io"),
+		Group:     ptr.To[gatewayv1.Group](gatewayv1.GroupName),
 		Kind:      ptr.To[gatewayv1.Kind]("Gateway"),
 		Namespace: (*gatewayv1.Namespace)(&gatewayName.Namespace),
 		Name:      gatewayv1.ObjectName(gatewayName.Name),

--- a/operator/pkg/gateway-api/watch-handlers/node.go
+++ b/operator/pkg/gateway-api/watch-handlers/node.go
@@ -53,7 +53,7 @@ func EnqueueRequestForNodes(c client.Client, logger *slog.Logger, owningGatewayL
 			}
 			// if the service owned by the gateway is a nodeport, add to map of UID
 			for _, svc := range svcList.Items {
-				if svc.Spec.Type == "NodePort" {
+				if svc.Spec.Type == corev1.ServiceTypeNodePort {
 					svcMap[string(svc.GetOwnerReferences()[0].UID)] = struct{}{}
 				}
 			}

--- a/operator/pkg/model/ingestion/gamma.go
+++ b/operator/pkg/model/ingestion/gamma.go
@@ -145,7 +145,7 @@ func toGammaHTTPRoutes(
 			} else {
 				// Otherwise, we find ones where appProtocol is http
 				for _, port := range parentSvc.Spec.Ports {
-					if port.Protocol == "" || port.Protocol == "TCP" {
+					if port.Protocol == "" || port.Protocol == corev1.ProtocolTCP {
 						// This is a little suspect, but we should only be using ones where AppProtocol is http
 						// _apparently_
 						if (port.AppProtocol == nil) || (port.AppProtocol != nil && *port.AppProtocol != "http") {
@@ -289,7 +289,7 @@ func toGammaGRPCRoutes(
 			} else {
 				// Otherwise, we find ones where appProtocol is grpc
 				for _, port := range parentSvc.Spec.Ports {
-					if port.Protocol == "" || port.Protocol == "TCP" {
+					if port.Protocol == "" || port.Protocol == corev1.ProtocolTCP {
 						// This is a little suspect, but we should only be using ones where AppProtocol is grpc
 						// _apparently_
 						if (port.AppProtocol == nil) || (port.AppProtocol != nil && *port.AppProtocol != "grpc") {

--- a/operator/pkg/model/translation/ingress/dedicated_ingress.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress.go
@@ -93,7 +93,7 @@ func (d *dedicatedIngressTranslator) getService(resource model.FullyQualifiedRes
 		ports = []corev1.ServicePort{
 			{
 				Name:     "https",
-				Protocol: "TCP",
+				Protocol: corev1.ProtocolTCP,
 				Port:     443,
 			},
 		}
@@ -101,12 +101,12 @@ func (d *dedicatedIngressTranslator) getService(resource model.FullyQualifiedRes
 		ports = []corev1.ServicePort{
 			{
 				Name:     "http",
-				Protocol: "TCP",
+				Protocol: corev1.ProtocolTCP,
 				Port:     80,
 			},
 			{
 				Name:     "https",
-				Protocol: "TCP",
+				Protocol: corev1.ProtocolTCP,
 				Port:     443,
 			},
 		}


### PR DESCRIPTION
Several comparisons and assignments to typed Kubernetes API fields used bare string literals, which compile via untyped constant conversion but give up compile-time checking: a typo would silently become a value that never matches.

This PR replaces them with the corresponding constants from `corev1` and `gatewayv1` as appropriate.