### PR TITLE
clustermesh: start migrating from legacy daemon config to ClusterInfo

### DIFF
--- a/cilium-dbg/cmd/preflight_identity_crd_migrate.go
+++ b/cilium-dbg/cmd/preflight_identity_crd_migrate.go
@@ -15,6 +15,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/cilium/cilium/pkg/allocator"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
@@ -228,9 +229,9 @@ func initK8s(ctx context.Context, clientset k8sClient.Clientset) (crdBackend all
 	// pkg/allocator/cache
 	//
 	// FIXME: add options to handle clustermesh with this constructor parameter:
-	//    allocator.WithPrefixMask(idpool.ID(option.Config.ClusterID<<identity.ClusterIDShift)))
-	minID := idpool.ID(identity.GetMinimalAllocationIdentity(option.Config.ClusterID))
-	maxID := idpool.ID(identity.GetMaximumAllocationIdentity(option.Config.ClusterID))
+	//    allocator.WithPrefixMask(idpool.ID(clusterID<<identity.ClusterIDShift)))
+	minID := idpool.ID(identity.GetMinimalAllocationIdentity(cmtypes.DefaultClusterInfo.ID))
+	maxID := idpool.ID(identity.GetMaximumAllocationIdentity(cmtypes.DefaultClusterInfo.ID))
 	crdAllocator, err = allocator.NewAllocator(log, &cacheKey.GlobalIdentity{}, crdBackend, allocator.WithMax(maxID), allocator.WithMin(minID))
 	if err != nil {
 		logging.Fatal(log, "Unable to initialize Identity Allocator with CRD backend to allocate identities with already allocated IDs", logfields.Error, err)

--- a/operator/pkg/ipam/allocator/aws/aws.go
+++ b/operator/pkg/ipam/allocator/aws/aws.go
@@ -17,9 +17,9 @@ import (
 	"github.com/cilium/cilium/pkg/aws/api"
 	"github.com/cilium/cilium/pkg/aws/ipam"
 	"github.com/cilium/cilium/pkg/aws/metadata"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -27,6 +27,7 @@ var subsysLogAttr = []any{logfields.LogSubsys, "ipam-allocator-aws"}
 
 // AllocatorAWS is an implementation of IPAM allocator interface for AWS ENI
 type AllocatorAWS struct {
+	ClusterInfo                  cmtypes.ClusterInfo
 	AWSReleaseExcessIPs          bool
 	ExcessIPReleaseDelay         int
 	AWSEnablePrefixDelegation    bool
@@ -61,7 +62,7 @@ func (a *AllocatorAWS) initENIGarbageCollectionTags(ctx context.Context, cfg aws
 	}
 
 	// Use cilium cluster name if available
-	if clusterName := option.Config.ClusterName; clusterName != defaults.ClusterName {
+	if clusterName := a.ClusterInfo.Name; clusterName != defaults.ClusterName {
 		eniTags[defaults.ENIGarbageCollectionTagClusterName] = clusterName
 		return eniTags
 	}

--- a/operator/pkg/ipam/aws.go
+++ b/operator/pkg/ipam/aws.go
@@ -15,6 +15,7 @@ import (
 	allocatorTypes "github.com/cilium/cilium/operator/pkg/ipam/allocator"
 	"github.com/cilium/cilium/operator/pkg/ipam/allocator/aws"
 	ipamMetrics "github.com/cilium/cilium/operator/pkg/ipam/metrics"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -88,6 +89,7 @@ type awsParams struct {
 	Clientset          k8sClient.Clientset
 	AWSMetrics         *aws.Metrics
 	IPAMMetrics        *ipamMetrics.Metrics
+	ClusterInfo        cmtypes.ClusterInfo
 	DaemonCfg          *option.DaemonConfig
 	NodeWatcherFactory allocatorTypes.NodeWatcherJobFactory
 
@@ -97,6 +99,7 @@ type awsParams struct {
 
 func startAWSAllocator(p awsParams) {
 	alloc := &aws.AllocatorAWS{
+		ClusterInfo:                  p.ClusterInfo,
 		AWSReleaseExcessIPs:          p.AwsCfg.AWSReleaseExcessIPs,
 		ExcessIPReleaseDelay:         p.AwsCfg.ExcessIPReleaseDelay,
 		AWSEnablePrefixDelegation:    p.AwsCfg.AWSEnablePrefixDelegation,

--- a/pkg/datapath/config/config.go
+++ b/pkg/datapath/config/config.go
@@ -34,6 +34,9 @@ type ChangeHandler interface {
 // +deepequal-gen=true
 // +deepequal-gen:private-method=true
 type Config struct {
+	// ClusterID is the immutable identifier of the local cluster.
+	ClusterID uint32
+
 	// NodeIPv4 is the primary IPv4 address of this node.
 	// Mutable at runtime.
 	// +deepequal-gen=false

--- a/pkg/datapath/config/node.go
+++ b/pkg/datapath/config/node.go
@@ -31,7 +31,7 @@ func NodeConfig(lnc *Config) Node {
 		node.RouterIPv6.Addr = lnc.CiliumInternalIPv6.As16()
 	}
 
-	node.ClusterID = option.Config.ClusterID
+	node.ClusterID = lnc.ClusterID
 	node.MonitorAggregation = uint8(option.Config.Opts.GetValue(option.MonitorAggregation))
 	node.TracePayloadLen = uint32(option.Config.TracePayloadlen)
 	node.TracePayloadLenOverlay = uint32(option.Config.TracePayloadlenOverlay)

--- a/pkg/datapath/config/zz_generated.deepequal.go
+++ b/pkg/datapath/config/zz_generated.deepequal.go
@@ -15,6 +15,9 @@ func (in *Config) deepEqual(other *Config) bool {
 		return false
 	}
 
+	if in.ClusterID != other.ClusterID {
+		return false
+	}
 	if in.CiliumHostIfIndex != other.CiliumHostIfIndex {
 		return false
 	}

--- a/pkg/datapath/orchestrator/localnodeconfig.go
+++ b/pkg/datapath/orchestrator/localnodeconfig.go
@@ -169,6 +169,7 @@ func newLocalNodeConfig(
 	}
 
 	return config.Config{
+		ClusterID:                    localNode.ClusterID,
 		NodeIPv4:                     ip.AddrFromIP(localNode.GetNodeIP(false)),
 		NodeIPv6:                     ip.AddrFromIP(localNode.GetNodeIP(true)),
 		CiliumInternalIPv4:           ip.AddrFromIP(localNode.GetCiliumInternalIP(false)),

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -228,7 +228,7 @@ func serveDNS(w dns.ResponseWriter, r *dns.Msg) {
 // Setup identities, ports and endpoint IDs we will need
 var (
 	// slogloggercheck: the default logger is enough for tests.
-	cacheAllocator = cache.NewCachingIdentityAllocator(logging.DefaultSlogLogger, &testidentity.IdentityAllocatorOwnerMock{}, cache.AllocatorConfig{})
+	cacheAllocator = cache.NewCachingIdentityAllocator(logging.DefaultSlogLogger, &testidentity.IdentityAllocatorOwnerMock{}, cache.NewTestAllocatorConfig())
 	// slogloggercheck: the default logger is enough for tests.
 	testSelectorCache       = policy.NewSelectorCache(logging.DefaultSlogLogger, cacheAllocator.GetIdentityCache())
 	dummySelectorCacheUser  = &testpolicy.DummySelectorCacheUser{}

--- a/pkg/fqdn/messagehandler/message_handler_test.go
+++ b/pkg/fqdn/messagehandler/message_handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/fqdn"
@@ -122,7 +123,7 @@ func BenchmarkNotifyOnDNSMsg(b *testing.B) {
 			ID:   uint16(i),
 			IPv4: netip.MustParseAddr(fmt.Sprintf("10.96.%d.%d", i/256, i%256)),
 			SecurityIdentity: &identity.Identity{
-				ID: identity.NumericIdentity(i % int(identity.GetMaximumAllocationIdentity(option.Config.ClusterID))),
+				ID: identity.NumericIdentity(i % int(identity.GetMaximumAllocationIdentity(cmtypes.DefaultClusterInfo.ID))),
 			},
 			DNSZombies: &fqdn.DNSZombieMappings{
 				Mutex: lock.Mutex{},

--- a/pkg/fqdn/namemanager/manager_test.go
+++ b/pkg/fqdn/namemanager/manager_test.go
@@ -240,7 +240,7 @@ func TestNameManagerGCConsistency(t *testing.T) {
 		eps:    make(sets.Set[*endpoint.Endpoint]),
 	}
 	ep := &endpoint.Endpoint{ID: uint16(1), IPv4: netip.MustParseAddr("10.96.0.1"), SecurityIdentity: &identity.Identity{
-		ID: identity.NumericIdentity(int(identity.GetMaximumAllocationIdentity(option.Config.ClusterID))),
+		ID: identity.NumericIdentity(int(identity.GetMaximumAllocationIdentity(cmtypes.DefaultClusterInfo.ID))),
 	},
 		DNSZombies: fqdn.NewDNSZombieMappings(logger, 10000, 10000),
 		DNSHistory: fqdn.NewDNSCache(1),

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -47,6 +47,7 @@ var (
 
 func testAllocatorConfig(enableOperatorManageCIDs bool, maxAttempts int) AllocatorConfig {
 	return AllocatorConfig{
+		ClusterInfo:              cmtypes.DefaultClusterInfo,
 		EnableOperatorManageCIDs: enableOperatorManageCIDs,
 		Timeout:                  5 * time.Second,
 		SyncInterval:             1 * time.Hour,

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -20,6 +20,7 @@ import (
 	jsoniter "github.com/json-iterator/go"
 
 	"github.com/cilium/cilium/pkg/allocator"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/key"
@@ -58,6 +59,7 @@ type CachingIdentityAllocator struct {
 	// IdentityAllocator is an allocator for security identities from the
 	// kvstore.
 	IdentityAllocator *allocator.Allocator
+	clusterInfo       cmtypes.ClusterInfo
 
 	// globalIdentityAllocatorInitialized is closed whenever the global identity
 	// allocator is initialized.
@@ -108,6 +110,7 @@ type CachingIdentityAllocator struct {
 }
 
 type AllocatorConfig struct {
+	ClusterInfo              cmtypes.ClusterInfo
 	EnableOperatorManageCIDs bool
 	Timeout                  time.Duration
 	SyncInterval             time.Duration
@@ -117,6 +120,7 @@ type AllocatorConfig struct {
 // NewTestAllocatorConfig returns an AllocatorConfig initialized for testing purposes.
 func NewTestAllocatorConfig() AllocatorConfig {
 	return AllocatorConfig{
+		ClusterInfo:              cmtypes.DefaultClusterInfo,
 		EnableOperatorManageCIDs: false,
 		Timeout:                  5 * time.Second,
 		SyncInterval:             1 * time.Hour,
@@ -217,14 +221,14 @@ func (m *CachingIdentityAllocator) InitIdentityAllocator(client clientset.Interf
 
 	m.logger.Info("Initializing identity allocator")
 
-	minID := idpool.ID(identity.GetMinimalAllocationIdentity(option.Config.ClusterID))
-	maxID := idpool.ID(identity.GetMaximumAllocationIdentity(option.Config.ClusterID))
+	minID := idpool.ID(identity.GetMinimalAllocationIdentity(m.clusterInfo.ID))
+	maxID := idpool.ID(identity.GetMaximumAllocationIdentity(m.clusterInfo.ID))
 
 	m.logger.Info(
 		"Allocating identities between range",
 		logfields.Min, minID,
 		logfields.Max, maxID,
-		logfields.ClusterID, option.Config.ClusterID,
+		logfields.ClusterID, m.clusterInfo.ID,
 	)
 
 	// In the case of the allocator being closed, we need to create a new events channel
@@ -305,7 +309,7 @@ func (m *CachingIdentityAllocator) InitIdentityAllocator(client clientset.Interf
 		allocOptions := []allocator.AllocatorOption{
 			allocator.WithMax(maxID), allocator.WithMin(minID),
 			allocator.WithEvents(events), allocator.WithSyncInterval(m.syncInterval),
-			allocator.WithPrefixMask(idpool.ID(option.Config.ClusterID << identity.GetClusterIDShift())),
+			allocator.WithPrefixMask(idpool.ID(m.clusterInfo.ID << identity.GetClusterIDShift())),
 		}
 		if m.operatorIDManagement {
 			allocOptions = append(allocOptions, allocator.WithOperatorIDManagement())
@@ -382,6 +386,7 @@ func NewCachingIdentityAllocator(logger *slog.Logger, owner IdentityAllocatorOwn
 
 	m := &CachingIdentityAllocator{
 		logger:                             logger,
+		clusterInfo:                        config.ClusterInfo,
 		globalIdentityAllocatorInitialized: make(chan struct{}),
 		owner:                              owner,
 		identitiesPath:                     IdentitiesPath,

--- a/pkg/identity/cache/cell/cell.go
+++ b/pkg/identity/cache/cell/cell.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/clustermesh"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
@@ -72,7 +73,8 @@ type identityAllocatorParams struct {
 
 	IdentityHandlers []identity.UpdateIdentities `group:"identity-handlers"`
 
-	Config config
+	ClusterInfo cmtypes.ClusterInfo
+	Config      config
 }
 
 type identityAllocatorOut struct {
@@ -120,6 +122,7 @@ func newIdentityAllocator(params identityAllocatorParams) identityAllocatorOut {
 		)
 
 		allocatorConfig := cache.AllocatorConfig{
+			ClusterInfo:              params.ClusterInfo,
 			EnableOperatorManageCIDs: isOperatorManageCIDsEnabled,
 			Timeout:                  params.Config.IdentityAllocationTimeout,
 			SyncInterval:             params.Config.IdentityAllocationSyncInterval,

--- a/pkg/kvstore/store/syncstore_test.go
+++ b/pkg/kvstore/store/syncstore_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/metrics"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 // Configure a generous timeout to prevent flakes when running in a noisy CI environment.
@@ -364,9 +363,6 @@ func TestWorkqueueSyncStoreSynced(t *testing.T) {
 }
 
 func TestWorkqueueSyncStoreMetrics(t *testing.T) {
-	defer func(name string) {
-		option.Config.ClusterName = name
-	}(option.Config.ClusterName)
 	st, me := GetFactory(t)
 	require.True(t, me.KVStoreSyncQueueSize.IsEnabled())
 	require.True(t, me.KVStoreInitialSyncCompleted.IsEnabled())

--- a/pkg/loadbalancer/frontend.go
+++ b/pkg/loadbalancer/frontend.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -167,15 +166,12 @@ func (fe *Frontend) ToModel() *models.Service {
 			HealthCheckNodePort: svc.HealthCheckNodePort,
 			Name:                svc.Name.Name(),
 			Namespace:           svc.Name.Namespace(),
+			Cluster:             svc.Name.Cluster(),
 		},
 	}
 
 	if fe.RedirectTo != nil {
 		spec.Flags.Type = string(SVCTypeLocalRedirect)
-	}
-
-	if svc.Name.Cluster() != option.Config.ClusterName {
-		spec.Flags.Cluster = svc.Name.Cluster()
 	}
 
 	backendModel := func(be *Backend) *models.BackendAddress {

--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/stream"
 	"github.com/spf13/pflag"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -68,6 +69,7 @@ type parameters struct {
 	JobGroup                job.Group
 	Logger                  *slog.Logger
 	Config                  config
+	ClusterInfo             cmtypes.ClusterInfo
 	DB                      *statedb.DB
 	NodeAddrs               statedb.Table[tables.NodeAddress]
 	DaemonConfig            *option.DaemonConfig
@@ -93,8 +95,9 @@ func (r config) Flags(flags *pflag.FlagSet) {
 }
 
 type GC struct {
-	logger *slog.Logger
-	config config
+	logger      *slog.Logger
+	config      config
+	clusterInfo cmtypes.ClusterInfo
 
 	ipv4 bool
 	ipv6 bool
@@ -128,8 +131,9 @@ type GC struct {
 
 func newGC(params parameters) *GC {
 	gc := &GC{
-		logger: params.Logger,
-		config: params.Config,
+		logger:      params.Logger,
+		config:      params.Config,
+		clusterInfo: params.ClusterInfo,
 
 		ipv4: params.DaemonConfig.EnableIPv4,
 		ipv6: params.DaemonConfig.EnableIPv6,
@@ -508,7 +512,7 @@ func (gc *GC) runGC(ipv4, ipv6, triggeredBySignal bool, filter ctmap.GCFilter) (
 					logfields.IngressAlive, stats.IngressAlive,
 					logfields.EgressAlive, stats.EgressAlive,
 					logfields.Family, stats.Family,
-					logfields.ClusterID, cmp.Or(stats.ClusterID, option.Config.ClusterID),
+					logfields.ClusterID, cmp.Or(stats.ClusterID, gc.clusterInfo.ID),
 					logfields.Duration, time.Since(startTime),
 				)
 			}

--- a/pkg/node/manager/cell.go
+++ b/pkg/node/manager/cell.go
@@ -85,6 +85,7 @@ type NodeManager interface {
 func newAllNodeManager(in struct {
 	cell.In
 	Logger         *slog.Logger
+	ClusterInfo    cmtypes.ClusterInfo
 	TunnelConf     tunnel.Config
 	Lifecycle      cell.Lifecycle
 	IPCache        *ipcache.IPCache
@@ -99,7 +100,7 @@ func newAllNodeManager(in struct {
 	LocalNodeStore *node.LocalNodeStore
 },
 ) (NodeManager, error) {
-	mngr, err := New(in.Logger, option.Config, in.TunnelConf, in.IPCache, in.IPSetMgr, in.IPSetFilter, in.NodeMetrics, in.Health, in.JobGroup, in.DB, in.Devices, in.WGConfig, in.LocalNodeStore)
+	mngr, err := New(in.Logger, option.Config, in.ClusterInfo, in.TunnelConf, in.IPCache, in.IPSetMgr, in.IPSetFilter, in.NodeMetrics, in.Health, in.JobGroup, in.DB, in.Devices, in.WGConfig, in.LocalNodeStore)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -136,6 +136,9 @@ type manager struct {
 	// conf is the configuration of the caller passed in via NewManager.
 	// This field is immutable after NewManager()
 	conf *option.DaemonConfig
+	// clusterInfo is the local cluster information passed in via NewManager.
+	// This field is immutable after NewManager()
+	clusterInfo cmtypes.ClusterInfo
 
 	underlay tunnel.UnderlayProtocol
 
@@ -260,6 +263,7 @@ func NewNodeMetrics() *nodeMetrics {
 func New(
 	logger *slog.Logger,
 	c *option.DaemonConfig,
+	clusterInfo cmtypes.ClusterInfo,
 	tunnelConf tunnel.Config,
 	ipCache IPCache,
 	ipsetMgr ipset.Manager,
@@ -281,6 +285,7 @@ func New(
 		nodes:                  map[nodeTypes.Identity]*nodeEntry{},
 		restoredNodes:          map[nodeTypes.Identity]*nodeTypes.Node{},
 		conf:                   c,
+		clusterInfo:            clusterInfo,
 		underlay:               tunnelConf.UnderlayProtocol(),
 		controllerManager:      controller.NewManager(),
 		nodeHandlers:           map[node.Handler]struct{}{},
@@ -720,7 +725,7 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 		}
 
 		endpointFlags := ipcacheTypes.EndpointFlags{}
-		if n.Cluster != m.conf.ClusterName {
+		if n.Cluster != m.clusterInfo.Name {
 			endpointFlags.SetRemoteCluster(true)
 		}
 
@@ -1003,7 +1008,7 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 		}
 
 		oldEndpointFlags := ipcacheTypes.EndpointFlags{}
-		if oldNode.Cluster != m.conf.ClusterName {
+		if oldNode.Cluster != m.clusterInfo.Name {
 			oldEndpointFlags.SetRemoteCluster(true)
 		}
 
@@ -1204,7 +1209,7 @@ func (m *manager) pruneClusterNodes() {
 
 	toDelete := make([]*nodeTypes.Node, 0, len(m.restoredNodes))
 	for _, n := range m.restoredNodes {
-		if n.Cluster == m.conf.ClusterName {
+		if n.Cluster == m.clusterInfo.Name {
 			toDelete = append(toDelete, n)
 		}
 	}
@@ -1250,7 +1255,7 @@ func (m *manager) pruneMeshedNodes() {
 
 	toDelete := make([]*nodeTypes.Node, 0, len(m.restoredNodes))
 	for _, n := range m.restoredNodes {
-		if n.Cluster != m.conf.ClusterName {
+		if n.Cluster != m.clusterInfo.Name {
 			toDelete = append(toDelete, n)
 		}
 	}

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -251,7 +251,7 @@ func TestNodeLifecycle(t *testing.T) {
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
 	mngr.Subscribe(dp)
 	require.NoError(t, err)
 
@@ -348,7 +348,7 @@ func TestNodeLabels(t *testing.T) {
 		Source:  source.Unspec,
 	}
 
-	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{Node: nLocal}))
+	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{Node: nLocal}))
 	mngr.Subscribe(dp)
 	require.NoError(t, err)
 	mngr.NodeUpdated(nRemote)
@@ -418,7 +418,7 @@ func TestNodeLabels(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require.NoError(t, labelsfilter.ParseLabelPrefixCfg(logger, nil, tt.nodeLabelPrefixes, ""))
 			option.Config.EnableNodeSelectorLabels = tt.nodeSelectorLabels
-			option.Config.ClusterName = "default"
+			option.Config.ClusterName = cmtypes.DefaultClusterInfo.Name
 			got := mngr.nodeIdentityLabels(tt.node)
 			want := tt.setupWanted()
 			assert.True(t, want.Equals(got), "Mismatched labels: want=%v got=%v", want, got)
@@ -435,7 +435,7 @@ func TestMultipleSources(t *testing.T) {
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -519,7 +519,7 @@ func BenchmarkUpdateAndDeleteCycle(b *testing.B) {
 	dp := fakenode.NewHandler()
 	h, _ := cell.NewSimpleHealth()
 	logger := hivetest.Logger(b)
-	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
 	require.NoError(b, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -542,7 +542,7 @@ func TestClusterSizeDependantInterval(t *testing.T) {
 	ipcacheMock := newIPcacheMock()
 	dp := fakenode.NewHandler()
 	h, _ := cell.NewSimpleHealth()
-	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -568,7 +568,7 @@ func TestBackgroundSync(t *testing.T) {
 	ipcacheMock := newIPcacheMock()
 	h, _ := cell.NewSimpleHealth()
 	logger := hivetest.Logger(t)
-	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
 	mngr.Subscribe(signalNodeHandler)
 	require.NoError(t, err)
 	defer mngr.Stop(context.TODO())
@@ -638,7 +638,7 @@ func TestIpcache(t *testing.T) {
 	dp := newSignalNodeHandler()
 	h, _ := cell.NewSimpleHealth()
 	logger := hivetest.Logger(t)
-	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -783,7 +783,7 @@ func TestIpcacheHealthIP(t *testing.T) {
 	dp := newSignalNodeHandler()
 	h, _ := cell.NewSimpleHealth()
 	logger := hivetest.Logger(t)
-	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -830,7 +830,7 @@ func TestNodeEncryption(t *testing.T) {
 	h, _ := cell.NewSimpleHealth()
 	mngr, err := New(logger, &option.DaemonConfig{
 		EncryptNode: true,
-	}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+	}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -954,7 +954,7 @@ func TestNode(t *testing.T) {
 	dp.EnableNodeDeleteEvent = true
 	h, _ := cell.NewSimpleHealth()
 	logger := hivetest.Logger(t)
-	mngr, err := New(logger, &option.DaemonConfig{}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+	mngr, err := New(logger, &option.DaemonConfig{}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -1094,7 +1094,7 @@ func TestNodeManagerEmitStatus(t *testing.T) {
 		cell.Provide(statedb.RWTable[*tables.Device].ToTable), // Provide statedb.Table[*tables.Device] from RW table
 		cell.Module("node_manager", "Node Manager", cell.Provide(New)),
 		node.LocalNodeStoreTestCell,
-		cell.Provide(func() cmtypes.ClusterInfo { return cmtypes.ClusterInfo{} }),
+		cell.Provide(func() cmtypes.ClusterInfo { return cmtypes.DefaultClusterInfo }),
 		cell.Invoke(fn),
 	)
 	l := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
@@ -1216,7 +1216,7 @@ func TestNodeWithSameInternalIP(t *testing.T) {
 	h, _ := cell.NewSimpleHealth()
 	mngr, err := New(logger, &option.DaemonConfig{
 		LocalRouterIPv4: "169.254.4.6",
-	}, tunnel.Config{}, ipcache, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+	}, cmtypes.DefaultClusterInfo, tunnel.Config{}, ipcache, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
 	require.NoError(t, err)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -1317,7 +1317,7 @@ func TestNodeIpset(t *testing.T) {
 	mngr, err := New(logger, &option.DaemonConfig{
 		RoutingMode:          option.RoutingModeNative,
 		EnableIPv4Masquerade: true,
-	}, tunnel.Config{}, newIPcacheMock(), newIPSetMock(), filter, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+	}, cmtypes.DefaultClusterInfo, tunnel.Config{}, newIPcacheMock(), newIPSetMock(), filter, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
 	mngr.Subscribe(dp)
 	require.NoError(t, err)
 	defer mngr.Stop(context.TODO())
@@ -1496,9 +1496,8 @@ func TestNodesStartupPruning(t *testing.T) {
 		dp.EnableNodeDeleteEvent = true
 		h, _ := cell.NewSimpleHealth()
 		mngr, err := New(logger, &option.DaemonConfig{
-			StateDir:    stateDir,
-			ClusterName: "c1",
-		}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+			StateDir: stateDir,
+		}, cmtypes.ClusterInfo{Name: "c1"}, tunnel.Config{}, ipcacheMock, newIPSetMock(), nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			mngr.Stop(context.TODO())

--- a/pkg/node/manager/rest_api_test.go
+++ b/pkg/node/manager/rest_api_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	fakeipset "github.com/cilium/cilium/pkg/datapath/iptables/ipset/fake"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
 	"github.com/cilium/cilium/pkg/node"
@@ -37,7 +38,7 @@ func setupGetNodesSuite(tb testing.TB) *GetNodesSuite {
 	option.Config.IPv6ServiceRange = "auto"
 
 	h, _ := cell.NewSimpleHealth()
-	nm, err := New(logger, fakeConfig, tunnel.Config{}, nil, &fakeipset.IPSet{}, nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
+	nm, err := New(logger, fakeConfig, cmtypes.DefaultClusterInfo, tunnel.Config{}, nil, &fakeipset.IPSet{}, nil, NewNodeMetrics(), h, nil, nil, nil, fakewireguard.Config{}, node.NewTestLocalNodeStore(node.LocalNode{}))
 	require.NoError(tb, err)
 
 	g := &GetNodesSuite{


### PR DESCRIPTION
The goal of this PR is to start migrating the existing clustermesh related fields from the daemon legacy config to ClusterInfo/cell style. It's mostly addressing low hanging fruit for now ~.

Used AIL-2 here