### PR TITLE
envoy/xds: use netip.ParseAddr to validate the node IP

### DIFF
--- a/pkg/envoy/xds/node.go
+++ b/pkg/envoy/xds/node.go
@@ -6,7 +6,7 @@ package xds
 import (
 	"errors"
 	"fmt"
-	"net"
+	"net/netip"
 	"strings"
 )
 
@@ -35,7 +35,7 @@ func EnvoyNodeIdToIP(nodeId string) (string, error) {
 
 	ip := parts[1]
 
-	if net.ParseIP(ip) == nil {
+	if _, err := netip.ParseAddr(ip); err != nil {
 		return "", fmt.Errorf("nodeId contains an invalid node IP address: %s", nodeId)
 	}
 


### PR DESCRIPTION
## Description

`EnvoyNodeIdToIP` validated the node IP extracted from an Envoy node identifier with `net.ParseIP(ip) == nil`. This switches it to `netip.ParseAddr` - the stricter, allocation-free check - as part of the ongoing `net.IP` -> `netip.Addr` migration.

The check is self-contained: the parsed value is only used for the validity test, not stored or returned, so no callers change. Existing `TestEnvoyNodeToIP` still passes.

Related: #24246