### PR TITLE
cli: ignore ENI IPv6 beta warning and detect IPv6 EKS server URL

### DIFF
--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -118,7 +118,7 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, extraExc
 		failedCreategRPCClient, unableReallocateIngressIP, fqdnMaxIPPerHostname, failedGetMetricsAPI,
 		envoyExternalTargetTLSWarning, envoyExternalOtherTargetTLSWarning,
 		hubbleUIEnvVarFallback, k8sClientNetworkStatusError, bgpAlphaResourceDeprecation, ccgAlphaResourceDeprecation,
-		k8sEndpointDeprecatedWarn, proxylibDeprecatedWarn, certloaderInitialLoadWarn, localKeyAlreadyAllocated}
+		k8sEndpointDeprecatedWarn, proxylibDeprecatedWarn, certloaderInitialLoadWarn, localKeyAlreadyAllocated, eniIPv6BetaWarn}
 
 	warningThresholdExceptions := thresholdExceptions{
 		// Benign for one node at ENI capacity, a real IP-starvation signal for
@@ -557,6 +557,7 @@ const (
 	hubbleUIEnvVarFallback           stringMatcher = "using fallback value for env var"                                      // cf. https://github.com/cilium/hubble-ui/pull/940
 	k8sClientNetworkStatusError      stringMatcher = "Network status error received, restarting client connections"          // cf. https://github.com/cilium/cilium/issues/37712
 	localKeyAlreadyAllocated         stringMatcher = "local key already allocated with different value"                      // cf. https://github.com/cilium/cilium/issues/41280
+	eniIPv6BetaWarn                  stringMatcher = "(ipam.mode=eni, ipv6.enabled=true) is a beta feature"                  // Expected when running with IPv6 enabled in ENI IPAM mode.
 
 	k8sEndpointDeprecatedWarn stringMatcher = "v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice" // cf. https://github.com/cilium/cilium/issues/39105
 	proxylibDeprecatedWarn    stringMatcher = "The support for Envoy Go Extensions (proxylib) has been deprecated"          // cf. https://github.com/cilium/cilium/issues/38224

--- a/cilium-cli/connectivity/tests/errors.go
+++ b/cilium-cli/connectivity/tests/errors.go
@@ -119,7 +119,7 @@ func NoErrorsInLogs(ciliumVersion semver.Version, checkLevels []string, extraExc
 		envoyExternalTargetTLSWarning, envoyExternalOtherTargetTLSWarning,
 		hubbleUIEnvVarFallback, k8sClientNetworkStatusError, bgpAlphaResourceDeprecation, ccgAlphaResourceDeprecation,
 		k8sEndpointDeprecatedWarn, proxylibDeprecatedWarn, certloaderInitialLoadWarn, localKeyAlreadyAllocated,
-		getSecurityGroupsForVpcUnauthorized}
+		getSecurityGroupsForVpcUnauthorized, eniIPv6BetaWarn}
 
 	warningThresholdExceptions := thresholdExceptions{
 		// Benign for one node at ENI capacity, a real IP-starvation signal for
@@ -558,6 +558,7 @@ const (
 	hubbleUIEnvVarFallback           stringMatcher = "using fallback value for env var"                                      // cf. https://github.com/cilium/hubble-ui/pull/940
 	k8sClientNetworkStatusError      stringMatcher = "Network status error received, restarting client connections"          // cf. https://github.com/cilium/cilium/issues/37712
 	localKeyAlreadyAllocated         stringMatcher = "local key already allocated with different value"                      // cf. https://github.com/cilium/cilium/issues/41280
+	eniIPv6BetaWarn                  stringMatcher = "(ipam.mode=eni, ipv6.enabled=true) is a beta feature"                  // Expected when running with IPv6 enabled in ENI IPAM mode.
 
 	k8sEndpointDeprecatedWarn stringMatcher = "v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice" // cf. https://github.com/cilium/cilium/issues/39105
 	proxylibDeprecatedWarn    stringMatcher = "The support for Envoy Go Extensions (proxylib) has been deprecated"          // cf. https://github.com/cilium/cilium/issues/38224

--- a/cilium-cli/k8s/client.go
+++ b/cilium-cli/k8s/client.go
@@ -682,7 +682,7 @@ func (c *Client) AutodetectFlavor(ctx context.Context) Flavor {
 
 	if context, ok := c.RawConfig.Contexts[c.ContextName()]; ok {
 		if cluster, ok := c.RawConfig.Clusters[context.Cluster]; ok {
-			if strings.HasSuffix(cluster.Server, "eks.amazonaws.com") {
+			if strings.Contains(cluster.Server, ".eks-cluster.") || strings.Contains(cluster.Server, ".eks.") {
 				f.Kind = KindEKS
 				return f
 			} else if strings.HasSuffix(cluster.Server, "azmk8s.io:443") {

--- a/cilium-cli/k8s/client_test.go
+++ b/cilium-cli/k8s/client_test.go
@@ -60,3 +60,66 @@ func TestAutodetectFlavorGKE(t *testing.T) {
 		assert.Equal(t, KindGKE, flavor.Kind, "Should detect GKE via node label")
 	})
 }
+
+func TestAutodetectFlavorEKS(t *testing.T) {
+	t.Run("by-cluster-name", func(t *testing.T) {
+		c := &Client{
+			Clientset: fake.NewSimpleClientset(),
+			RawConfig: clientcmdapi.Config{
+				Contexts: map[string]*clientcmdapi.Context{
+					"foo.us-west-2.eksctl.io": {
+						Cluster: "foo.us-west-2.eksctl.io",
+					},
+				},
+				CurrentContext: "foo.us-west-2.eksctl.io",
+			},
+			contextName: "foo.us-west-2.eksctl.io",
+		}
+		flavor := c.AutodetectFlavor(context.Background())
+		assert.Equal(t, KindEKS, flavor.Kind)
+	})
+
+	t.Run("by-cluster-server", func(t *testing.T) {
+		c := &Client{
+			Clientset: fake.NewSimpleClientset(),
+			RawConfig: clientcmdapi.Config{
+				Contexts: map[string]*clientcmdapi.Context{
+					"my-cluster": {
+						Cluster: "my-cluster",
+					},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"my-cluster": {
+						Server: "https://ABCDEF1234567890.gr7.us-west-2.eks.amazonaws.com",
+					},
+				},
+				CurrentContext: "my-cluster",
+			},
+			contextName: "my-cluster",
+		}
+		flavor := c.AutodetectFlavor(context.Background())
+		assert.Equal(t, KindEKS, flavor.Kind, "Should detect EKS via cluster server URL")
+	})
+
+	t.Run("by-cluster-server-ipv6", func(t *testing.T) {
+		c := &Client{
+			Clientset: fake.NewSimpleClientset(),
+			RawConfig: clientcmdapi.Config{
+				Contexts: map[string]*clientcmdapi.Context{
+					"my-cluster": {
+						Cluster: "my-cluster",
+					},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"my-cluster": {
+						Server: "https://ABCDEF1234567890.gr7.eks-cluster.us-west-2.api.aws",
+					},
+				},
+				CurrentContext: "my-cluster",
+			},
+			contextName: "my-cluster",
+		}
+		flavor := c.AutodetectFlavor(context.Background())
+		assert.Equal(t, KindEKS, flavor.Kind, "Should detect EKS via IPv6 cluster server URL")
+	})
+}


### PR DESCRIPTION
# Ignoring the beta warning

The ENI IPv6 implementation is in beta for the v1.20 release of Cilium. This adds the beta warning log to the list of expected warnings in the CLI. Otherwise, the error check test fails when running connectivity tests with ENI+IPv6 enabled.

Example test error:
```
.  ❌ Found 1 logs in [...]/my-ipv6-cluster/kube-system/cilium-operator-b8c85f56b-txldk (cilium-operator) matching list of errors that must be investigated:
time=2026-07-27T15:48:15.96359495Z level=warn msg="IPv6 support in the ENI IPAM mode (ipam.mode=eni, ipv6.enabled=true) is a beta feature. Please use it with caution and report any issues you encounter: https://github.com/cilium/cilium/issues/new?template=bug_report.yaml" subsys=cilium-operator-aws (1 occurrences)
```

The error no longer appears after this change.

# Detecting EKS IPv6 server URL

For IPv6 EKS clusters, the format of the server URL is different than that of IPv4 clusters. For IPv6, the URL is suffixed with eks-cluster.\<region\>.api.aws (See https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html#cluster-endpoint-ipv6).

This change relaxes detection of EKS flavor by server endpoint URL. The new condition should match all types of EKS clusters (Commercial, GovCloud, China) (IPv4, IPv6). However, I did note some inconsistencies in the AWS docs as in IPv4 I get this pattern `https://ABCDEF1234567890.gr7.us-west-2.eks.amazonaws.com` while on IPv6 I get the `eks-cluster` substring `https://ABCDEF1234567890.gr7.eks-cluster.us-west-2.api.aws`. I'm not sure if we get either the `.eks-cluster.` or `.eks.` substrings in China and I can't test it myself.

```release-note
cli: the CLI now considers the ENI IPv6 beta warning log as expected and detects EKS flavor for IPv6 EKS clusters.
```
