### PR TITLE
loader/test: Add endpoint-routes to overlay/wg

### DIFF
--- a/pkg/datapath/loader/verifier_load_test.go
+++ b/pkg/datapath/loader/verifier_load_test.go
@@ -89,6 +89,7 @@ func baseOverlayPermutations() *loadPermutationBuilder {
 			t.Node.DebugLB = true
 			t.EnableConntrackAccounting = true
 		}),
+		Increment(func(t *config.BPFOverlay, v bool) { t.Node.EnableEndpointRoutes = v }),
 	)
 	return b
 }
@@ -123,6 +124,7 @@ func baseWireguardPermutations() *loadPermutationBuilder {
 			t.EnableIPv4Fragments = true
 			t.EnableIPv6Fragments = true
 		}),
+		Increment(func(t *config.BPFWireguard, v bool) { t.Node.EnableEndpointRoutes = v }),
 	)
 	return b
 }


### PR DESCRIPTION
As pointed by Julian, the endpoint-routes config affects the bpf_overlay and bpf_wireguard behavior (both via [local_delivery()]). The 69c82352f7 commit did not consider that.