### PR TITLE
bpf: dsr: also send DSR info on first non-SYN packet towards new backend

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -51,8 +51,9 @@ struct ct_state {
 	      from_l7lb:1,	/* Connection is originated from an L7 LB proxy */
 	      reserved1:1,	/* Was auth_required, not used in production anywhere */
 	      from_tunnel:1,	/* Connection is from tunnel */
-		  closing:1,
-	      reserved:7;
+	      closing:1,
+	      new_backend:1,	/* Service connection was assigned a new backend */
+	      reserved:6;
 	__u32 src_sec_id;
 	__u32 backend_id;	/* Backend ID in lb4_backends */
 };

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1441,6 +1441,8 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 			backend = lb6_lookup_backend(ctx, backend_id);
 			if (backend == NULL)
 				goto no_service;
+
+			state->new_backend = true;
 		}
 
 		state->backend_id = backend_id;
@@ -1488,6 +1490,7 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 			if (!backend)
 				goto no_service;
 
+			state->new_backend = true;
 			state->rev_nat_index = svc->rev_nat_index;
 			ct_update_svc_entry(map, tuple, backend_id, svc->rev_nat_index);
 		}
@@ -2268,6 +2271,8 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 			backend = lb4_lookup_backend(ctx, backend_id);
 			if (backend == NULL)
 				goto no_service;
+
+			state->new_backend = true;
 		}
 
 		state->backend_id = backend_id;
@@ -2315,6 +2320,7 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 			if (!backend)
 				goto no_service;
 
+			state->new_backend = true;
 			state->rev_nat_index = svc->rev_nat_index;
 			ct_update_svc_entry(map, tuple, backend_id, svc->rev_nat_index);
 		}

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -136,8 +136,13 @@ nodeport_need_dsr_info(__u8 nexthdr, const struct ct_state *ct_state)
 	/* We only need to embed the DSR info into the first packet of a connection
 	 * (since it will then be cached on the backend node).
 	 * Doing so for the TCP-SYN avoids MTU troubles.
+	 *
+	 * We also send DSR info for the first TCP packet towards a new backend,
+	 * so that it can at least RevDNAT its RST reply.
 	 */
-	return (nexthdr != IPPROTO_TCP) || ct_state->syn;
+	return (nexthdr != IPPROTO_TCP) ||
+	       ct_state->new_backend ||
+	       ct_state->syn;
 }
 
 #if defined(ENABLE_IPV4)
@@ -1792,8 +1797,17 @@ static __always_inline int dsr_set_opt4(struct __ctx_buff *ctx,
 
 	opt.type = DSR_IPV4_OPT_TYPE;
 	opt.len = sizeof(opt);
+#ifdef TEST_DSR_OPT_NETWORK_BYTE_ORDER
+	/* We're annoyingly sending out the IPv4 option in host byte-order,
+	 * and this is baked into the wire-format now.
+	 * For easier testing with scapy, fix this up.
+	 */
+	opt.port = svc_port;
+	opt.addr = svc_addr;
+#else
 	opt.port = bpf_htons(svc_port);
 	opt.addr = bpf_htonl(svc_addr);
+#endif
 
 	sum = csum_diff(&iph_old, 4, &iph_new, 4, 0);
 	sum = csum_diff(NULL, 0, &opt, sizeof(opt), sum);
@@ -1940,8 +1954,13 @@ nodeport_extract_dsr_v4(struct __ctx_buff *ctx,
 
 		if (opt.type == DSR_IPV4_OPT_TYPE && opt.len == sizeof(opt)) {
 			*dsr = true;
+#ifdef TEST_DSR_OPT_NETWORK_BYTE_ORDER
+			*addr = opt.addr;
+			*port = opt.port;
+#else
 			*addr = bpf_ntohl(opt.addr);
 			*port = bpf_ntohs(opt.port);
+#endif
 			return 0;
 		}
 	}

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -537,23 +537,6 @@ nodeport_extract_dsr_v6(struct __ctx_buff *ctx,
 			const struct ipv6_ct_tuple *tuple, int l4_off,
 			union v6addr *addr, __be16 *port, bool *dsr)
 {
-	struct ipv6_ct_tuple tmp = *tuple;
-
-	if (tuple->nexthdr == IPPROTO_TCP) {
-		union tcp_flags tcp_flags = {};
-
-		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
-			return DROP_CT_INVALID_HDR;
-
-		ipv6_ct_tuple_reverse(&tmp);
-
-		if (!(tcp_flags.value & TCP_FLAG_SYN)) {
-			*dsr = ct_has_dsr_egress_entry6(get_ct_map6(&tmp), &tmp);
-			*port = 0;
-			return 0;
-		}
-	}
-
 #if defined(IS_BPF_OVERLAY)
 	{
 		struct geneve_dsr_opt6 gopt;
@@ -587,11 +570,26 @@ nodeport_extract_dsr_v6(struct __ctx_buff *ctx,
 	}
 #endif
 
-	/* SYN for a new connection that's not / no longer DSR.
-	 * If it's reopened, avoid sending subsequent traffic down the DSR path.
-	 */
-	if (tuple->nexthdr == IPPROTO_TCP)
-		ct_update_dsr(get_ct_map6(&tmp), &tmp, false);
+	if (tuple->nexthdr == IPPROTO_TCP) {
+		struct ipv6_ct_tuple tmp = *tuple;
+		union tcp_flags tcp_flags = {};
+
+		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
+			return DROP_CT_INVALID_HDR;
+
+		ipv6_ct_tuple_reverse(&tmp);
+
+		if (tcp_flags.value & TCP_FLAG_SYN) {
+			/* SYN for a new connection that's not / no longer DSR.
+			 * If it's reopened, avoid sending subsequent traffic down the DSR path.
+			 */
+			ct_update_dsr(get_ct_map6(&tmp), &tmp, false);
+		} else {
+			*dsr = ct_has_dsr_egress_entry6(get_ct_map6(&tmp), &tmp);
+			*port = 0;
+			return 0;
+		}
+	}
 
 	return 0;
 }
@@ -1896,33 +1894,9 @@ nodeport_extract_dsr_v4(struct __ctx_buff *ctx,
 			const struct ipv4_ct_tuple *tuple, int l4_off,
 			__be32 *addr, __be16 *port, bool *dsr)
 {
-	struct ipv4_ct_tuple tmp = *tuple;
-
 	/* Parse DSR info from the packet, to get the addr/port of the
 	 * addressed service. We need this for RevDNATing the backend's replies.
-	 *
-	 * TCP connections have the DSR Option only in their SYN packet.
-	 * To identify that a non-SYN packet belongs to a DSR connection,
-	 * we need to check whether a corresponding CT entry with .dsr flag exists.
 	 */
-	if (tuple->nexthdr == IPPROTO_TCP) {
-		union tcp_flags tcp_flags = {};
-
-		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
-			return DROP_CT_INVALID_HDR;
-
-		ipv4_ct_tuple_reverse(&tmp);
-
-		if (!(tcp_flags.value & TCP_FLAG_SYN)) {
-			/* If the packet belongs to a tracked DSR connection,
-			 * trigger a CT update.
-			 * We don't have any DSR info to report back, and that's ok.
-			 */
-			*dsr = ct_has_dsr_egress_entry4(get_ct_map4(&tmp), &tmp);
-			*port = 0;
-			return 0;
-		}
-	}
 
 #if defined(IS_BPF_OVERLAY)
 	{
@@ -1966,11 +1940,34 @@ nodeport_extract_dsr_v4(struct __ctx_buff *ctx,
 	}
 #endif
 
-	/* SYN for a new connection that's not / no longer DSR.
-	 * If it's reopened, avoid sending subsequent traffic down the DSR path.
+	/* TCP connections typically have the DSR info only in their SYN packet.
+	 * To identify that a packet without DSR info belongs to a DSR connection,
+	 * we need to check whether a corresponding CT entry with .dsr flag exists.
 	 */
-	if (tuple->nexthdr == IPPROTO_TCP)
-		ct_update_dsr(get_ct_map4(&tmp), &tmp, false);
+	if (tuple->nexthdr == IPPROTO_TCP) {
+		struct ipv4_ct_tuple tmp = *tuple;
+		union tcp_flags tcp_flags = {};
+
+		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
+			return DROP_CT_INVALID_HDR;
+
+		ipv4_ct_tuple_reverse(&tmp);
+
+		if (tcp_flags.value & TCP_FLAG_SYN) {
+			/* SYN for a new connection that's not / no longer DSR.
+			 * If it's reopened, avoid sending subsequent traffic down the DSR path.
+			 */
+			ct_update_dsr(get_ct_map4(&tmp), &tmp, false);
+		} else {
+			/* If the packet belongs to a tracked DSR connection,
+			 * trigger a CT update.
+			 * We don't have any DSR info to report back, and that's ok.
+			 */
+			*dsr = ct_has_dsr_egress_entry4(get_ct_map4(&tmp), &tmp);
+			*port = 0;
+			return 0;
+		}
+	}
 
 	return 0;
 }

--- a/bpf/tests/host_kpr_dsr_geneve_lb.c
+++ b/bpf/tests/host_kpr_dsr_geneve_lb.c
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#define ENABLE_IPV4		1
+#define ENABLE_IPV6		1
+#define ENABLE_NODEPORT		1
+#define ENABLE_DSR		1
+#define DSR_ENCAP_IPIP		2
+#define DSR_ENCAP_GENEVE        3
+#define DSR_ENCAP_MODE		DSR_ENCAP_GENEVE
+#define ENCAP_IFINDEX		42
+
+#include "kpr_dsr_lb.h"

--- a/bpf/tests/host_kpr_dsr_option_lb.c
+++ b/bpf/tests/host_kpr_dsr_option_lb.c
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#define ENABLE_IPV4		1
+#define ENABLE_IPV6		1
+#define ENABLE_NODEPORT		1
+#define ENABLE_DSR		1
+#define DSR_ENCAP_GENEVE        3
+
+#define TEST_DSR_OPT_NETWORK_BYTE_ORDER
+
+#include "kpr_dsr_lb.h"

--- a/bpf/tests/host_kpr_dsr_option_remote_node.c
+++ b/bpf/tests/host_kpr_dsr_option_remote_node.c
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#define ENABLE_IPV4		1
+#define ENABLE_IPV6		1
+#define ENABLE_NODEPORT		1
+#define ENABLE_DSR		1
+#define DSR_ENCAP_GENEVE        3
+
+#define TEST_DSR_OPT_NETWORK_BYTE_ORDER
+
+#include "kpr_dsr_remote_node.h"

--- a/bpf/tests/kpr_dsr_lb.h
+++ b/bpf/tests/kpr_dsr_lb.h
@@ -1,0 +1,1047 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#ifdef ATTACHMENT_XDP
+# define ATTACH "xdp"
+# include <bpf/ctx/xdp.h>
+#else
+# define ATTACH "tc"
+# include <bpf/ctx/skb.h>
+#endif
+
+#include "common.h"
+
+#include "pktgen.h"
+#include "scapy.h"
+
+#define IPV4_DIRECT_ROUTING		v4_node_one
+
+#define fib_lookup mock_fib_lookup
+long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
+		     __maybe_unused int plen, __maybe_unused __u32 flags)
+{
+	params->ifindex = 22;
+
+	__bpf_memcpy_builtin(params->smac, (__u8 *)mac_one, ETH_ALEN);
+	__bpf_memcpy_builtin(params->dmac, (__u8 *)mac_two, ETH_ALEN);
+
+	return 0;
+}
+
+bool tunnel_key_set;
+bool tunnel_opt_set;
+
+#ifdef ATTACHMENT_XDP
+# include "lib/bpf_xdp.h"
+# define netdev_receive_packet  xdp_receive_packet
+#else
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(value_size, sizeof(struct bpf_tunnel_key));
+	__uint(max_entries, 1);
+} tunnel_key_map __section_maps_btf;
+
+# define skb_set_tunnel_key mock_skb_set_tunnel_key
+int mock_skb_set_tunnel_key(__maybe_unused struct __sk_buff *skb,
+			    __maybe_unused const struct bpf_tunnel_key *from,
+			    __maybe_unused __u32 size,
+			    __maybe_unused __u32 flags)
+{
+	__u32 map_key = 0;
+	struct bpf_tunnel_key *mock_key = map_lookup_elem(&tunnel_key_map, &map_key);
+
+	if (mock_key) {
+		memcpy(mock_key, from, sizeof(*from));
+		tunnel_key_set = true;
+	}
+
+	return 0;
+}
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(value_size, sizeof(struct geneve_dsr_opt6));
+	__uint(max_entries, 1);
+} tunnel_opt_map __section_maps_btf;
+
+# define skb_set_tunnel_opt mock_skb_set_tunnel_opt
+int mock_skb_set_tunnel_opt(__maybe_unused struct __sk_buff *skb,
+			    __maybe_unused const void *opt,
+			    __maybe_unused __u32 opt_len)
+{
+	__u32 map_key = 0;
+	void *data = map_lookup_elem(&tunnel_opt_map, &map_key);
+
+	if (!data)
+		return -1;
+
+	switch (opt_len) {
+	case sizeof(struct geneve_dsr_opt4):
+		memcpy(data, opt, sizeof(struct geneve_dsr_opt4));
+		tunnel_opt_set = true;
+		return 0;
+	case sizeof(struct geneve_dsr_opt6):
+		memcpy(data, opt, sizeof(struct geneve_dsr_opt6));
+		tunnel_opt_set = true;
+		return 0;
+	default:
+		return -1;
+	}
+}
+
+# include "lib/bpf_host.h"
+#endif /* ATTACHMENT_XDP */
+
+#if DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+ASSIGN_CONFIG(__u8, tunnel_protocol, TUNNEL_PROTOCOL_GENEVE)
+ASSIGN_CONFIG(__u16, tunnel_port, 6081)
+#endif
+
+ASSIGN_CONFIG(__u32, hash_init4_seed, 0xcafe)
+ASSIGN_CONFIG(__u32, hash_init6_seed, 0xeb9f)
+
+#include "lib/ipcache.h"
+#include "lib/lb.h"
+
+const __u8 kpr_v4_dsr_lb1_syn[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb1_syn)
+};
+
+const __u8 kpr_v4_dsr_lb1_syn_post_option[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb1_syn_post_option)
+};
+
+const __u8 kpr_v4_dsr_lb1_syn_post_option_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb1_syn_post_option_xdp)
+};
+
+const __u8 kpr_v4_dsr_lb1_syn_post_geneve[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb1_syn_post_geneve)
+};
+
+const __u8 kpr_v4_dsr_lb1_syn_post_geneve_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb1_syn_post_geneve_xdp)
+};
+
+const __u8 kpr_v4_dsr_lb1_synack[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb1_synack)
+};
+
+const __u8 kpr_v4_dsr_lb1_synack_post_option[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb1_synack_post_option)
+};
+
+const __u8 kpr_v4_dsr_lb1_synack_post_option_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb1_synack_post_option_xdp)
+};
+
+const __u8 kpr_v4_dsr_lb1_synack_post_geneve[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb1_synack_post_geneve)
+};
+
+const __u8 kpr_v4_dsr_lb1_synack_post_geneve_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb1_synack_post_geneve_xdp)
+};
+
+const __u8 kpr_v4_dsr_lb2_data[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb2_data)
+};
+
+const __u8 kpr_v4_dsr_lb2_data_post_option[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb2_data_post_option)
+};
+
+const __u8 kpr_v4_dsr_lb2_data_post_option_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb2_data_post_option_xdp)
+};
+
+const __u8 kpr_v4_dsr_lb2_data_post_geneve[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb2_data_post_geneve)
+};
+
+const __u8 kpr_v4_dsr_lb2_data_post_geneve_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb2_data_post_geneve_xdp)
+};
+
+const __u8 kpr_v4_dsr_lb2_data2_post_option[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb2_data2_post_option)
+};
+
+const __u8 kpr_v4_dsr_lb2_data2_post_option_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb2_data2_post_option_xdp)
+};
+
+const __u8 kpr_v4_dsr_lb2_data2_post_geneve_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb2_data2_post_geneve_xdp)
+};
+
+const __u8 kpr_v6_dsr_lb1_syn[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb1_syn)
+};
+
+const __u8 kpr_v6_dsr_lb1_syn_post_option[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb1_syn_post_option)
+};
+
+const __u8 kpr_v6_dsr_lb1_syn_post_option_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb1_syn_post_option_xdp)
+};
+
+const __u8 kpr_v6_dsr_lb1_syn_post_geneve[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb1_syn_post_geneve)
+};
+
+const __u8 kpr_v6_dsr_lb1_syn_post_geneve_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb1_syn_post_geneve_xdp)
+};
+
+const __u8 kpr_v6_dsr_lb1_synack[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb1_synack)
+};
+
+const __u8 kpr_v6_dsr_lb1_synack_post_option[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb1_synack_post_option)
+};
+
+const __u8 kpr_v6_dsr_lb1_synack_post_option_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb1_synack_post_option_xdp)
+};
+
+const __u8 kpr_v6_dsr_lb1_synack_post_geneve[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb1_synack_post_geneve)
+};
+
+const __u8 kpr_v6_dsr_lb1_synack_post_geneve_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb1_synack_post_geneve_xdp)
+};
+
+const __u8 kpr_v6_dsr_lb2_data[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb2_data)
+};
+
+const __u8 kpr_v6_dsr_lb2_data_post_option[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb2_data_post_option)
+};
+
+const __u8 kpr_v6_dsr_lb2_data_post_option_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb2_data_post_option_xdp)
+};
+
+const __u8 kpr_v6_dsr_lb2_data_post_geneve[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb2_data_post_geneve)
+};
+
+const __u8 kpr_v6_dsr_lb2_data_post_geneve_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb2_data_post_geneve_xdp)
+};
+
+const __u8 kpr_v6_dsr_lb2_data2_post_option[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb2_data2_post_option)
+};
+
+const __u8 kpr_v6_dsr_lb2_data2_post_option_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb2_data2_post_option_xdp)
+};
+
+const __u8 kpr_v6_dsr_lb2_data2_post_geneve_xdp[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb2_data2_post_geneve_xdp)
+};
+
+#ifdef ENABLE_IPV4
+/* Client accesses a DSR service with remote backend.
+ * We expect the SYN to carry DSR-info, but the SYN-ACK to be forwarded
+ * without DSR-info.
+ */
+PKTGEN(ATTACH, "kpr_v4_dsr_lb1_syn")
+int kpr_v4_dsr_lb1_syn_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v4_dsr_lb1_syn,
+			sizeof(kpr_v4_dsr_lb1_syn));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v4_dsr_lb1_syn")
+int kpr_v4_dsr_lb1_syn_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 1;
+
+	lb_v4_add_service(v4_svc_one, tcp_svc_one, IPPROTO_TCP, 1, revnat_id);
+	lb_v4_add_backend(v4_svc_one, tcp_svc_one, 1, 124,
+			  v4_pod_one, tcp_dst_one, IPPROTO_TCP, 0);
+
+	ipcache_v4_add_entry(v4_pod_one, 0, 112233, v4_node_two, 0);
+
+	tunnel_key_set = false;
+	tunnel_opt_set = false;
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v4_dsr_lb1_syn")
+int kpr_v4_dsr_lb1_syn_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+#if DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb1_syn_post_geneve_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb1_syn_post_geneve_xdp,
+			   sizeof(kpr_v4_dsr_lb1_syn_post_geneve_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb1_syn_post_geneve",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb1_syn_post_geneve,
+			   sizeof(kpr_v4_dsr_lb1_syn_post_geneve));
+
+	struct bpf_tunnel_key *tunnel_key;
+	struct geneve_dsr_opt4 *dsr_opt;
+	__u32 key = 0;
+
+	if (!tunnel_key_set)
+		test_fatal("no tunnel key set")
+	tunnel_key = map_lookup_elem(&tunnel_key_map, &key);
+	if (!tunnel_key)
+		test_fatal("no tunnel key");
+	if (tunnel_key->remote_ipv4 != bpf_ntohl(v4_node_two))
+		test_fatal("tunnel remote IP is not correct");
+	if (tunnel_key->tunnel_id != WORLD_ID)
+		test_fatal("tunnel id is not correct");
+
+	if (!tunnel_opt_set)
+		test_fatal("no DSR opt set");
+	dsr_opt = map_lookup_elem(&tunnel_opt_map, &key);
+	if (!dsr_opt)
+		test_fatal("no DSR opt");
+	if (dsr_opt->hdr.opt_class != bpf_htons(DSR_GENEVE_OPT_CLASS))
+		test_fatal("DSR opt class is not correct");
+	if (dsr_opt->hdr.type != DSR_GENEVE_OPT_TYPE)
+		test_fatal("DSR opt type is not correct");
+	if (dsr_opt->hdr.length != DSR_IPV4_GENEVE_OPT_LEN)
+		test_fatal("DSR opt length is not correct");
+	if (dsr_opt->addr != v4_svc_one)
+		test_fatal("DSR addr is not correct");
+	if (dsr_opt->port != tcp_svc_one)
+		test_fatal("DSR port is not correct");
+# endif
+#else
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb1_syn_post_option_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb1_syn_post_option_xdp,
+			   sizeof(kpr_v4_dsr_lb1_syn_post_option_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb1_syn_post_option",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb1_syn_post_option,
+			   sizeof(kpr_v4_dsr_lb1_syn_post_option));
+# endif
+#endif
+
+	test_finish();
+}
+
+PKTGEN(ATTACH, "kpr_v4_dsr_lb1_synack")
+int kpr_v4_dsr_lb1_synack_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v4_dsr_lb1_synack,
+			sizeof(kpr_v4_dsr_lb1_synack));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v4_dsr_lb1_synack")
+int kpr_v4_dsr_lb1_synack_setup(struct __ctx_buff *ctx)
+{
+	tunnel_key_set = false;
+	tunnel_opt_set = false;
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v4_dsr_lb1_synack")
+int kpr_v4_dsr_lb1_synack_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+#if DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+ # ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb1_synack_post_geneve_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb1_synack_post_geneve_xdp,
+			   sizeof(kpr_v4_dsr_lb1_synack_post_geneve_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb1_synack_post_geneve",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb1_synack_post_geneve,
+			   sizeof(kpr_v4_dsr_lb1_synack_post_geneve));
+
+	struct bpf_tunnel_key *tunnel_key;
+	__u32 key = 0;
+
+	if (!tunnel_key_set)
+		test_fatal("no tunnel key set")
+	tunnel_key = map_lookup_elem(&tunnel_key_map, &key);
+	if (!tunnel_key)
+		test_fatal("no tunnel key");
+	if (tunnel_key->remote_ipv4 != bpf_ntohl(v4_node_two))
+		test_fatal("tunnel remote IP is not correct");
+	if (tunnel_key->tunnel_id != WORLD_ID)
+		test_fatal("tunnel id is not correct");
+
+	if (tunnel_opt_set)
+		test_fatal("DSR opt set");
+# endif
+#else
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb1_synack_post_option_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb1_synack_post_option_xdp,
+			   sizeof(kpr_v4_dsr_lb1_synack_post_option_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb1_synack_post_option",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb1_synack_post_option,
+			   sizeof(kpr_v4_dsr_lb1_synack_post_option));
+# endif
+#endif
+
+	test_finish();
+}
+
+/* Client's TCP connection is interrupted, and switches to a different LB node.
+ * We expect the first data packet to carry DSR-info, but the second data packet
+ * to be forwarded without DSR-info.
+ */
+PKTGEN(ATTACH, "kpr_v4_dsr_lb2_data")
+int kpr_v4_dsr_lb2_data_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v4_dsr_lb2_data,
+			sizeof(kpr_v4_dsr_lb2_data));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v4_dsr_lb2_data")
+int kpr_v4_dsr_lb2_data_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 2;
+
+	lb_v4_add_service(v4_svc_one, tcp_svc_two, IPPROTO_TCP, 1, revnat_id);
+	lb_v4_add_backend(v4_svc_one, tcp_svc_two, 1, 124,
+			  v4_pod_one, tcp_dst_two, IPPROTO_TCP, 0);
+
+	tunnel_key_set = false;
+	tunnel_opt_set = false;
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v4_dsr_lb2_data")
+int kpr_v4_dsr_lb2_data_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+#if DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb2_data_post_geneve_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb2_data_post_geneve_xdp,
+			   sizeof(kpr_v4_dsr_lb2_data_post_geneve_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb2_data_post_geneve",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb2_data_post_geneve,
+			   sizeof(kpr_v4_dsr_lb2_data_post_geneve));
+
+	struct bpf_tunnel_key *tunnel_key;
+	struct geneve_dsr_opt4 *dsr_opt;
+	__u32 key = 0;
+
+	if (!tunnel_key_set)
+		test_fatal("no tunnel key set")
+	tunnel_key = map_lookup_elem(&tunnel_key_map, &key);
+	if (!tunnel_key)
+		test_fatal("no tunnel key");
+	if (tunnel_key->remote_ipv4 != bpf_ntohl(v4_node_two))
+		test_fatal("tunnel remote IP is not correct");
+	if (tunnel_key->tunnel_id != WORLD_ID)
+		test_fatal("tunnel id is not correct");
+
+	if (!tunnel_opt_set)
+		test_fatal("no DSR opt set");
+	dsr_opt = map_lookup_elem(&tunnel_opt_map, &key);
+	if (!dsr_opt)
+		test_fatal("no DSR opt");
+	if (dsr_opt->hdr.opt_class != bpf_htons(DSR_GENEVE_OPT_CLASS))
+		test_fatal("DSR opt class is not correct");
+	if (dsr_opt->hdr.type != DSR_GENEVE_OPT_TYPE)
+		test_fatal("DSR opt type is not correct");
+	if (dsr_opt->hdr.length != DSR_IPV4_GENEVE_OPT_LEN)
+		test_fatal("DSR opt length is not correct");
+	if (dsr_opt->addr != v4_svc_one)
+		test_fatal("DSR addr is not correct");
+	if (dsr_opt->port != tcp_svc_two)
+		test_fatal("DSR port is not correct");
+# endif
+#else
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb2_data_post_option_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb2_data_post_option_xdp,
+			   sizeof(kpr_v4_dsr_lb2_data_post_option_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb2_data_post_option",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb2_data_post_option,
+			   sizeof(kpr_v4_dsr_lb2_data_post_option));
+# endif
+#endif
+
+	test_finish();
+}
+
+PKTGEN(ATTACH, "kpr_v4_dsr_lb2_data2")
+int kpr_v4_dsr_lb2_data2_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v4_dsr_lb2_data,
+			sizeof(kpr_v4_dsr_lb2_data));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v4_dsr_lb2_data2")
+int kpr_v4_dsr_lb2_data2_setup(struct __ctx_buff *ctx)
+{
+	tunnel_key_set = false;
+	tunnel_opt_set = false;
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v4_dsr_lb2_data2")
+int kpr_v4_dsr_lb2_data2_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+#if DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb2_data2_post_geneve_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb2_data2_post_geneve_xdp,
+			   sizeof(kpr_v4_dsr_lb2_data2_post_geneve_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb2_data2_post_geneve",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb2_data_post_geneve,
+			   sizeof(kpr_v4_dsr_lb2_data_post_geneve));
+
+	struct bpf_tunnel_key *tunnel_key;
+	__u32 key = 0;
+
+	if (!tunnel_key_set)
+		test_fatal("no tunnel key set")
+	tunnel_key = map_lookup_elem(&tunnel_key_map, &key);
+	if (!tunnel_key)
+		test_fatal("no tunnel key");
+	if (tunnel_key->remote_ipv4 != bpf_ntohl(v4_node_two))
+		test_fatal("tunnel remote IP is not correct");
+	if (tunnel_key->tunnel_id != WORLD_ID)
+		test_fatal("tunnel id is not correct");
+
+	if (tunnel_opt_set)
+		test_fatal("DSR opt set");
+# endif
+#else
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb2_data2_post_option_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb2_data2_post_option_xdp,
+			   sizeof(kpr_v4_dsr_lb2_data2_post_option_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_lb2_data2_post_option",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_lb2_data2_post_option,
+			   sizeof(kpr_v4_dsr_lb2_data2_post_option));
+# endif
+#endif
+
+	test_finish();
+}
+#endif /* ENABLE_IPV4 */
+
+#ifdef ENABLE_IPV6
+PKTGEN(ATTACH, "kpr_v6_dsr_lb1_syn")
+int kpr_v6_dsr_lb1_syn_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v6_dsr_lb1_syn,
+			sizeof(kpr_v6_dsr_lb1_syn));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v6_dsr_lb1_syn")
+int kpr_v6_dsr_lb1_syn_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 1;
+	union v6addr frontend_ip = { v6_svc_one_addr };
+	union v6addr backend_ip = { v6_pod_one_addr };
+
+	lb_v6_add_service(&frontend_ip, tcp_svc_one, IPPROTO_TCP, 1, revnat_id);
+	lb_v6_add_backend(&frontend_ip, tcp_svc_one, 1, 124,
+			  &backend_ip, tcp_dst_one, IPPROTO_TCP, 0);
+
+	ipcache_v6_add_entry(&backend_ip, 0, 112233, v4_node_two, 0);
+
+	tunnel_key_set = false;
+	tunnel_opt_set = false;
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v6_dsr_lb1_syn")
+int kpr_v6_dsr_lb1_syn_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+#if DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb1_syn_post_geneve_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb1_syn_post_geneve_xdp,
+			   sizeof(kpr_v6_dsr_lb1_syn_post_geneve_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb1_syn_post_geneve",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb1_syn_post_geneve,
+			   sizeof(kpr_v6_dsr_lb1_syn_post_geneve));
+
+	union v6addr frontend_ip = { v6_svc_one_addr };
+	struct bpf_tunnel_key *tunnel_key;
+	struct geneve_dsr_opt6 *dsr_opt;
+	__u32 key = 0;
+
+	if (!tunnel_key_set)
+		test_fatal("no tunnel key set")
+	tunnel_key = map_lookup_elem(&tunnel_key_map, &key);
+	if (!tunnel_key)
+		test_fatal("no tunnel key");
+	if (tunnel_key->remote_ipv4 != bpf_ntohl(v4_node_two))
+		test_fatal("tunnel remote IP is not correct");
+	if (tunnel_key->tunnel_id != WORLD_ID)
+		test_fatal("tunnel id is not correct");
+
+	if (!tunnel_opt_set)
+		test_fatal("no DSR opt set");
+	dsr_opt = map_lookup_elem(&tunnel_opt_map, &key);
+	if (!dsr_opt)
+		test_fatal("no DSR opt");
+	if (dsr_opt->hdr.opt_class != bpf_htons(DSR_GENEVE_OPT_CLASS))
+		test_fatal("DSR opt class is not correct");
+	if (dsr_opt->hdr.type != DSR_GENEVE_OPT_TYPE)
+		test_fatal("DSR opt type is not correct");
+	if (dsr_opt->hdr.length != DSR_IPV6_GENEVE_OPT_LEN)
+		test_fatal("DSR opt length is not correct");
+	if (!ipv6_addr_equals((union v6addr *)&dsr_opt->addr, &frontend_ip))
+		test_fatal("DSR addr is not correct");
+	if (dsr_opt->port != tcp_svc_one)
+		test_fatal("DSR port is not correct");
+# endif
+#else
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb1_syn_post_option_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb1_syn_post_option_xdp,
+			   sizeof(kpr_v6_dsr_lb1_syn_post_option_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb1_syn_post_option",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb1_syn_post_option,
+			   sizeof(kpr_v6_dsr_lb1_syn_post_option));
+# endif
+#endif
+	test_finish();
+}
+
+PKTGEN(ATTACH, "kpr_v6_dsr_lb1_synack")
+int kpr_v6_dsr_lb1_synack_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v6_dsr_lb1_synack,
+			sizeof(kpr_v6_dsr_lb1_synack));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v6_dsr_lb1_synack")
+int kpr_v6_dsr_lb1_synack_setup(struct __ctx_buff *ctx)
+{
+	tunnel_key_set = false;
+	tunnel_opt_set = false;
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v6_dsr_lb1_synack")
+int kpr_v6_dsr_lb1_synack_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+#if DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb1_synack_post_geneve_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb1_synack_post_geneve_xdp,
+			   sizeof(kpr_v6_dsr_lb1_synack_post_geneve_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb1_synack_post_geneve",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb1_synack_post_geneve,
+			   sizeof(kpr_v6_dsr_lb1_synack_post_geneve));
+
+	struct bpf_tunnel_key *tunnel_key;
+	__u32 key = 0;
+
+	if (!tunnel_key_set)
+		test_fatal("no tunnel key set")
+	tunnel_key = map_lookup_elem(&tunnel_key_map, &key);
+	if (!tunnel_key)
+		test_fatal("no tunnel key");
+	if (tunnel_key->remote_ipv4 != bpf_ntohl(v4_node_two))
+		test_fatal("tunnel remote IP is not correct");
+	if (tunnel_key->tunnel_id != WORLD_ID)
+		test_fatal("tunnel id is not correct");
+
+	if (tunnel_opt_set)
+		test_fatal("DSR opt set");
+# endif
+#else
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb1_synack_post_option_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb1_synack_post_option_xdp,
+			   sizeof(kpr_v6_dsr_lb1_synack_post_option_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb1_synack_post_option",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb1_synack_post_option,
+			   sizeof(kpr_v6_dsr_lb1_synack_post_option));
+# endif
+#endif
+
+	test_finish();
+}
+
+PKTGEN(ATTACH, "kpr_v6_dsr_lb2_data")
+int kpr_v6_dsr_lb2_data_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v6_dsr_lb2_data,
+			sizeof(kpr_v6_dsr_lb2_data));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v6_dsr_lb2_data")
+int kpr_v6_dsr_lb2_data_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 2;
+	union v6addr frontend_ip = { v6_svc_one_addr };
+	union v6addr backend_ip = { v6_pod_one_addr };
+
+	lb_v6_add_service(&frontend_ip, tcp_svc_two, IPPROTO_TCP, 1, revnat_id);
+	lb_v6_add_backend(&frontend_ip, tcp_svc_two, 1, 124,
+			  &backend_ip, tcp_dst_two, IPPROTO_TCP, 0);
+
+	tunnel_key_set = false;
+	tunnel_opt_set = false;
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v6_dsr_lb2_data")
+int kpr_v6_dsr_lb2_data_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+#if DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb2_data_post_geneve_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb2_data_post_geneve_xdp,
+			   sizeof(kpr_v6_dsr_lb2_data_post_geneve_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb2_data_post_geneve",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb2_data_post_geneve,
+			   sizeof(kpr_v6_dsr_lb2_data_post_geneve));
+
+	union v6addr frontend_ip = { v6_svc_one_addr };
+	struct bpf_tunnel_key *tunnel_key;
+	struct geneve_dsr_opt6 *dsr_opt;
+	__u32 key = 0;
+
+	if (!tunnel_key_set)
+		test_fatal("no tunnel key set")
+	tunnel_key = map_lookup_elem(&tunnel_key_map, &key);
+	if (!tunnel_key)
+		test_fatal("no tunnel key");
+	if (tunnel_key->remote_ipv4 != bpf_ntohl(v4_node_two))
+		test_fatal("tunnel remote IP is not correct");
+	if (tunnel_key->tunnel_id != WORLD_ID)
+		test_fatal("tunnel id is not correct");
+
+	if (!tunnel_opt_set)
+		test_fatal("no DSR opt set");
+	dsr_opt = map_lookup_elem(&tunnel_opt_map, &key);
+	if (!dsr_opt)
+		test_fatal("no DSR opt");
+	if (dsr_opt->hdr.opt_class != bpf_htons(DSR_GENEVE_OPT_CLASS))
+		test_fatal("DSR opt class is not correct");
+	if (dsr_opt->hdr.type != DSR_GENEVE_OPT_TYPE)
+		test_fatal("DSR opt type is not correct");
+	if (dsr_opt->hdr.length != DSR_IPV6_GENEVE_OPT_LEN)
+		test_fatal("DSR opt length is not correct");
+	if (!ipv6_addr_equals((union v6addr *)&dsr_opt->addr, &frontend_ip))
+		test_fatal("DSR addr is not correct");
+	if (dsr_opt->port != tcp_svc_two)
+		test_fatal("DSR port is not correct");
+# endif
+#else
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb2_data_post_option_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb2_data_post_option_xdp,
+			   sizeof(kpr_v6_dsr_lb2_data_post_option_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb2_data_post_option",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb2_data_post_option,
+			   sizeof(kpr_v6_dsr_lb2_data_post_option));
+# endif
+#endif
+
+	test_finish();
+}
+
+PKTGEN(ATTACH, "kpr_v6_dsr_lb2_data2")
+int kpr_v6_dsr_lb2_data2_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v6_dsr_lb2_data,
+			sizeof(kpr_v6_dsr_lb2_data));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v6_dsr_lb2_data2")
+int kpr_v6_dsr_lb2_data2_setup(struct __ctx_buff *ctx)
+{
+	tunnel_key_set = false;
+	tunnel_opt_set = false;
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v6_dsr_lb2_data2")
+int kpr_v6_dsr_lb2_data2_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+#if DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb2_data2_post_geneve_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb2_data2_post_geneve_xdp,
+			   sizeof(kpr_v6_dsr_lb2_data2_post_geneve_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb2_data2_post_geneve",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb2_data_post_geneve,
+			   sizeof(kpr_v6_dsr_lb2_data_post_geneve));
+
+	struct bpf_tunnel_key *tunnel_key;
+	__u32 key = 0;
+
+	if (!tunnel_key_set)
+		test_fatal("no tunnel key set")
+	tunnel_key = map_lookup_elem(&tunnel_key_map, &key);
+	if (!tunnel_key)
+		test_fatal("no tunnel key");
+	if (tunnel_key->remote_ipv4 != bpf_ntohl(v4_node_two))
+		test_fatal("tunnel remote IP is not correct");
+	if (tunnel_key->tunnel_id != WORLD_ID)
+		test_fatal("tunnel id is not correct");
+
+	if (tunnel_opt_set)
+		test_fatal("DSR opt set");
+# endif
+#else
+# ifdef ATTACHMENT_XDP
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb2_data2_post_option_xdp",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb2_data2_post_option_xdp,
+			   sizeof(kpr_v6_dsr_lb2_data2_post_option_xdp));
+# else
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_lb2_data2_post_option",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_lb2_data2_post_option,
+			   sizeof(kpr_v6_dsr_lb2_data2_post_option));
+# endif
+#endif
+
+	test_finish();
+}
+#endif /* ENABLE_IPV6 */

--- a/bpf/tests/kpr_dsr_remote_node.h
+++ b/bpf/tests/kpr_dsr_remote_node.h
@@ -1,0 +1,800 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#ifdef ATTACHMENT_XDP
+# define ATTACH "xdp"
+# include <bpf/ctx/xdp.h>
+#else
+# define ATTACH "tc"
+# include <bpf/ctx/skb.h>
+#endif
+
+#include "common.h"
+
+#include "pktgen.h"
+#include "scapy.h"
+
+#define BACKEND_EP_ID			127
+#define NATIVE_IFINDEX			22
+
+#define fib_lookup mock_fib_lookup
+long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
+		     __maybe_unused int plen, __maybe_unused __u32 flags)
+{
+	params->ifindex = NATIVE_IFINDEX;
+
+	return 0;
+}
+
+#ifdef ATTACHMENT_XDP
+# include "lib/bpf_xdp.h"
+# define netdev_receive_packet	xdp_receive_packet
+#else
+# define CHECK_REPLY	1
+# include "lib/bpf_host.h"
+#endif
+
+ASSIGN_CONFIG(__u32, interface_ifindex, NATIVE_IFINDEX);
+
+#include "lib/endpoint.h"
+
+const __u8 kpr_v4_dsr_remote_node_syn[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb1_syn_post_option_xdp)
+};
+
+const __u8 kpr_v4_dsr_remote_node_synack[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_lb1_synack_post_option_xdp)
+};
+
+const __u8 kpr_v4_dsr_remote_node_data_option[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_remote_node_data_option)
+};
+
+const __u8 kpr_v4_dsr_remote_node_reply[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_remote_node_reply)
+};
+
+const __u8 kpr_v4_dsr_remote_node_reply_post[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_remote_node_reply_post)
+};
+
+const __u8 kpr_v4_dsr_remote_node_reply2_post[] = {
+	SCAPY_BUF_BYTES(kpr_v4_dsr_remote_node_reply2_post)
+};
+
+const __u8 kpr_v6_dsr_remote_node_syn[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb1_syn_post_option_xdp)
+};
+
+const __u8 kpr_v6_dsr_remote_node_synack[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_lb1_synack_post_option_xdp)
+};
+
+const __u8 kpr_v6_dsr_remote_node_data_option[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_remote_node_data_option)
+};
+
+const __u8 kpr_v6_dsr_remote_node_reply[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_remote_node_reply)
+};
+
+const __u8 kpr_v6_dsr_remote_node_reply_post[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_remote_node_reply_post)
+};
+
+const __u8 kpr_v6_dsr_remote_node_reply2_post[] = {
+	SCAPY_BUF_BYTES(kpr_v6_dsr_remote_node_reply2_post)
+};
+
+#ifdef ENABLE_IPV4
+/* Backend node receives SYN with DSR-info. Reply can be RevDNATed.
+ * Then we receive a second packet without DSR-info. Replies can still be
+ * RevDNATed.
+ */
+PKTGEN(ATTACH, "kpr_v4_dsr_remote_node_1syn")
+int kpr_v4_dsr_remote_node_1syn_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v4_dsr_remote_node_syn,
+			sizeof(kpr_v4_dsr_remote_node_syn));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v4_dsr_remote_node_1syn")
+int kpr_v4_dsr_remote_node_1syn_setup(struct __ctx_buff *ctx)
+{
+	endpoint_v4_add_entry(v4_pod_one, 123, BACKEND_EP_ID, 0, 0, 0, NULL, NULL);
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v4_dsr_remote_node_1syn")
+int kpr_v4_dsr_remote_node_1syn_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	__u32 pkt_offset = sizeof(__u32);
+	void *data, *data_end;
+	__u32 *status_code;
+
+#ifdef ATTACHMENT_XDP
+	pkt_offset += sizeof(__u32);
+#endif
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_remote_node_syn",
+			   "Ether", ctx, pkt_offset,
+			   kpr_v4_dsr_remote_node_syn,
+			   sizeof(kpr_v4_dsr_remote_node_syn));
+
+	struct ipv4_ct_tuple tuple;
+	struct ct_entry *ct_entry;
+
+	tuple.flags = TUPLE_F_IN;
+	tuple.nexthdr = IPPROTO_TCP;
+	tuple.daddr = v4_pod_one;
+	tuple.saddr = v4_ext_one;
+	tuple.sport = tcp_dst_one;
+	tuple.dport = tcp_src_one;
+	ipv4_ct_tuple_reverse(&tuple);
+
+	ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+	if (!ct_entry)
+		test_fatal("no CT entry for DSR found");
+	if (!ct_entry->dsr_internal)
+		test_fatal("CT entry doesn't have the .dsr_internal flag set");
+	if (ct_entry->nat_addr.p4 != v4_svc_one)
+		test_fatal("CT entry doesn't have the RevDNAT addr set");
+	if (ct_entry->nat_port != tcp_svc_one)
+		test_fatal("CT entry doesn't have the RevDNAT port set");
+
+	test_finish();
+}
+
+#ifdef CHECK_REPLY
+PKTGEN(ATTACH, "kpr_v4_dsr_remote_node_2reply")
+int kpr_v4_dsr_remote_node_2reply_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v4_dsr_remote_node_reply,
+			sizeof(kpr_v4_dsr_remote_node_reply));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v4_dsr_remote_node_2reply")
+int kpr_v4_dsr_remote_node_2reply_setup(struct __ctx_buff *ctx)
+{
+	return netdev_send_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v4_dsr_remote_node_2reply")
+int kpr_v4_dsr_remote_node_2reply_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_remote_node_reply_post",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_remote_node_reply_post,
+			   sizeof(kpr_v4_dsr_remote_node_reply_post));
+
+	test_finish();
+}
+#endif
+
+PKTGEN(ATTACH, "kpr_v4_dsr_remote_node_3synack")
+int kpr_v4_dsr_remote_node_3synack_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v4_dsr_remote_node_synack,
+			sizeof(kpr_v4_dsr_remote_node_synack));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v4_dsr_remote_node_3synack")
+int kpr_v4_dsr_remote_node_3synack_setup(struct __ctx_buff *ctx)
+{
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v4_dsr_remote_node_3synack")
+int kpr_v4_dsr_remote_node_3synack_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	__u32 pkt_offset = sizeof(__u32);
+	void *data, *data_end;
+	__u32 *status_code;
+
+#ifdef ATTACHMENT_XDP
+	pkt_offset += sizeof(__u32);
+#endif
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_remote_node_synack",
+			   "Ether", ctx, pkt_offset,
+			   kpr_v4_dsr_remote_node_synack,
+			   sizeof(kpr_v4_dsr_remote_node_synack));
+
+	test_finish();
+}
+
+#ifdef CHECK_REPLY
+PKTGEN(ATTACH, "kpr_v4_dsr_remote_node_4reply")
+int kpr_v4_dsr_remote_node_4reply_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v4_dsr_remote_node_reply,
+			sizeof(kpr_v4_dsr_remote_node_reply));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v4_dsr_remote_node_4reply")
+int kpr_v4_dsr_remote_node_4reply_setup(struct __ctx_buff *ctx)
+{
+	return netdev_send_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v4_dsr_remote_node_4reply")
+int kpr_v4_dsr_remote_node_4reply_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_remote_node_reply_post",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_remote_node_reply_post,
+			   sizeof(kpr_v4_dsr_remote_node_reply_post));
+
+	test_finish();
+}
+#endif
+
+/* Now receive a non-SYN with different DSR-info.
+ * The RevDNAT follows accordingly.
+ */
+PKTGEN(ATTACH, "kpr_v4_dsr_remote_node_5data_dsr_info")
+int kpr_v4_dsr_remote_node_5data_dsr_info_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v4_dsr_remote_node_data_option,
+			sizeof(kpr_v4_dsr_remote_node_data_option));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v4_dsr_remote_node_5data_dsr_info")
+int kpr_v4_dsr_remote_node_5data_dsr_info_setup(struct __ctx_buff *ctx)
+{
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v4_dsr_remote_node_5data_dsr_info")
+int kpr_v4_dsr_remote_node_5data_dsr_info_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	__u32 pkt_offset = sizeof(__u32);
+	void *data, *data_end;
+	__u32 *status_code;
+
+#ifdef ATTACHMENT_XDP
+	pkt_offset += sizeof(__u32);
+#endif
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_remote_node_data_option",
+			   "Ether", ctx, pkt_offset,
+			   kpr_v4_dsr_remote_node_data_option,
+			   sizeof(kpr_v4_dsr_remote_node_data_option));
+
+	struct ipv4_ct_tuple tuple;
+	struct ct_entry *ct_entry;
+
+	tuple.flags = TUPLE_F_IN;
+	tuple.nexthdr = IPPROTO_TCP;
+	tuple.daddr = v4_pod_one;
+	tuple.saddr = v4_ext_one;
+	tuple.sport = tcp_dst_one;
+	tuple.dport = tcp_src_one;
+	ipv4_ct_tuple_reverse(&tuple);
+
+	ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+	if (!ct_entry)
+		test_fatal("no CT entry for DSR found");
+	if (!ct_entry->dsr_internal)
+		test_fatal("CT entry doesn't have the .dsr_internal flag set");
+	if (ct_entry->nat_addr.p4 != v4_svc_one)
+		test_fatal("CT entry doesn't have the RevDNAT addr set");
+	if (ct_entry->nat_port != tcp_svc_two)
+		test_fatal("CT entry doesn't have the RevDNAT port set");
+
+	test_finish();
+}
+
+#ifdef CHECK_REPLY
+PKTGEN(ATTACH, "kpr_v4_dsr_remote_node_6reply")
+int kpr_v4_dsr_remote_node_6reply_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v4_dsr_remote_node_reply,
+			sizeof(kpr_v4_dsr_remote_node_reply));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v4_dsr_remote_node_6reply")
+int kpr_v4_dsr_remote_node_6reply_setup(struct __ctx_buff *ctx)
+{
+	return netdev_send_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v4_dsr_remote_node_6reply")
+int kpr_v4_dsr_remote_node_6reply_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	ASSERT_CTX_BUF_OFF("kpr_v4_dsr_remote_node_reply2_post",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v4_dsr_remote_node_reply2_post,
+			   sizeof(kpr_v4_dsr_remote_node_reply2_post));
+
+	test_finish();
+}
+#endif
+#endif /* ENABLE_IPV4 */
+
+#ifdef ENABLE_IPV6
+PKTGEN(ATTACH, "kpr_v6_dsr_remote_node_1syn")
+int kpr_v6_dsr_remote_node_1syn_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v6_dsr_remote_node_syn,
+			sizeof(kpr_v6_dsr_remote_node_syn));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v6_dsr_remote_node_1syn")
+int kpr_v6_dsr_remote_node_1syn_setup(struct __ctx_buff *ctx)
+{
+	union v6addr backend_ip = { v6_pod_one_addr };
+
+	endpoint_v6_add_entry(&backend_ip, 123, BACKEND_EP_ID, 0, 0, NULL, NULL);
+
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v6_dsr_remote_node_1syn")
+int kpr_v6_dsr_remote_node_1syn_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	__u32 pkt_offset = sizeof(__u32);
+	void *data, *data_end;
+	__u32 *status_code;
+
+#ifdef ATTACHMENT_XDP
+	pkt_offset += sizeof(__u32);
+#endif
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_remote_node_syn",
+			   "Ether", ctx, pkt_offset,
+			   kpr_v6_dsr_remote_node_syn,
+			   sizeof(kpr_v6_dsr_remote_node_syn));
+
+	struct ipv6_ct_tuple tuple __align_stack_8;
+	struct ct_entry *ct_entry;
+	union v6addr frontend_ip = { v6_svc_one_addr };
+	union v6addr backend_ip = { v6_pod_one_addr };
+	union v6addr client_ip = { v6_ext_node_one_addr };
+
+	tuple.flags = TUPLE_F_IN;
+	tuple.nexthdr = IPPROTO_TCP;
+	ipv6_addr_copy(&tuple.daddr, &backend_ip);
+	ipv6_addr_copy(&tuple.saddr, &client_ip);
+	tuple.sport = tcp_dst_one;
+	tuple.dport = tcp_src_one;
+	ipv6_ct_tuple_reverse(&tuple);
+
+	ct_entry = map_lookup_elem(get_ct_map6(&tuple), &tuple);
+	if (!ct_entry)
+		test_fatal("no CT entry for DSR found");
+	if (!ct_entry->dsr_internal)
+		test_fatal("CT entry doesn't have the .dsr_internal flag set");
+	if (!ipv6_addr_equals(&ct_entry->nat_addr, &frontend_ip))
+		test_fatal("CT entry doesn't have the RevDNAT addr set");
+	if (ct_entry->nat_port != tcp_svc_one)
+		test_fatal("CT entry doesn't have the RevDNAT port set");
+
+	test_finish();
+}
+
+#ifdef CHECK_REPLY
+PKTGEN(ATTACH, "kpr_v6_dsr_remote_node_2reply")
+int kpr_v6_dsr_remote_node_2reply_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v6_dsr_remote_node_reply,
+			sizeof(kpr_v6_dsr_remote_node_reply));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v6_dsr_remote_node_2reply")
+int kpr_v6_dsr_remote_node_2reply_setup(struct __ctx_buff *ctx)
+{
+	return netdev_send_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v6_dsr_remote_node_2reply")
+int kpr_v6_dsr_remote_node_2reply_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_remote_node_reply_post",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_remote_node_reply_post,
+			   sizeof(kpr_v6_dsr_remote_node_reply_post));
+
+	test_finish();
+}
+#endif
+
+PKTGEN(ATTACH, "kpr_v6_dsr_remote_node_3synack")
+int kpr_v6_dsr_remote_node_3synack_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v6_dsr_remote_node_synack,
+			sizeof(kpr_v6_dsr_remote_node_synack));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v6_dsr_remote_node_3synack")
+int kpr_v6_dsr_remote_node_3synack_setup(struct __ctx_buff *ctx)
+{
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v6_dsr_remote_node_3synack")
+int kpr_v6_dsr_remote_node_3synack_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	__u32 pkt_offset = sizeof(__u32);
+	void *data, *data_end;
+	__u32 *status_code;
+
+#ifdef ATTACHMENT_XDP
+	pkt_offset += sizeof(__u32);
+#endif
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_remote_node_synack",
+			   "Ether", ctx, pkt_offset,
+			   kpr_v6_dsr_remote_node_synack,
+			   sizeof(kpr_v6_dsr_remote_node_synack));
+
+	test_finish();
+}
+
+#ifdef CHECK_REPLY
+PKTGEN(ATTACH, "kpr_v6_dsr_remote_node_4reply")
+int kpr_v6_dsr_remote_node_4reply_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v6_dsr_remote_node_reply,
+			sizeof(kpr_v6_dsr_remote_node_reply));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v6_dsr_remote_node_4reply")
+int kpr_v6_dsr_remote_node_4reply_setup(struct __ctx_buff *ctx)
+{
+	return netdev_send_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v6_dsr_remote_node_4reply")
+int kpr_v6_dsr_remote_node_4reply_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_remote_node_reply_post",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_remote_node_reply_post,
+			   sizeof(kpr_v6_dsr_remote_node_reply_post));
+
+	test_finish();
+}
+#endif
+
+PKTGEN(ATTACH, "kpr_v6_dsr_remote_node_5data_dsr_info")
+int kpr_v6_dsr_remote_node_5data_dsr_info_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v6_dsr_remote_node_data_option,
+			sizeof(kpr_v6_dsr_remote_node_data_option));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v6_dsr_remote_node_5data_dsr_info")
+int kpr_v6_dsr_remote_node_5data_dsr_info_setup(struct __ctx_buff *ctx)
+{
+	return netdev_receive_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v6_dsr_remote_node_5data_dsr_info")
+int kpr_v6_dsr_remote_node_5data_dsr_info_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	__u32 pkt_offset = sizeof(__u32);
+	void *data, *data_end;
+	__u32 *status_code;
+
+#ifdef ATTACHMENT_XDP
+	pkt_offset += sizeof(__u32);
+#endif
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_remote_node_data_option",
+			   "Ether", ctx, pkt_offset,
+			   kpr_v6_dsr_remote_node_data_option,
+			   sizeof(kpr_v6_dsr_remote_node_data_option));
+
+	struct ipv6_ct_tuple tuple __align_stack_8;
+	struct ct_entry *ct_entry;
+	union v6addr frontend_ip = { v6_svc_one_addr };
+	union v6addr backend_ip = { v6_pod_one_addr };
+	union v6addr client_ip = { v6_ext_node_one_addr };
+
+	tuple.flags = TUPLE_F_IN;
+	tuple.nexthdr = IPPROTO_TCP;
+	ipv6_addr_copy(&tuple.daddr, &backend_ip);
+	ipv6_addr_copy(&tuple.saddr, &client_ip);
+	tuple.sport = tcp_dst_one;
+	tuple.dport = tcp_src_one;
+	ipv6_ct_tuple_reverse(&tuple);
+
+	ct_entry = map_lookup_elem(get_ct_map6(&tuple), &tuple);
+	if (!ct_entry)
+		test_fatal("no CT entry for DSR found");
+	if (!ct_entry->dsr_internal)
+		test_fatal("CT entry doesn't have the .dsr_internal flag set");
+	if (!ipv6_addr_equals(&ct_entry->nat_addr, &frontend_ip))
+		test_fatal("CT entry doesn't have the RevDNAT addr set");
+	if (ct_entry->nat_port != tcp_svc_two)
+		test_fatal("CT entry doesn't have the RevDNAT port set");
+
+	test_finish();
+}
+
+#ifdef CHECK_REPLY
+PKTGEN(ATTACH, "kpr_v6_dsr_remote_node_6reply")
+int kpr_v6_dsr_remote_node_6reply_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+
+	pktgen__init(&builder, ctx);
+
+	scapy_push_data(&builder, kpr_v6_dsr_remote_node_reply,
+			sizeof(kpr_v6_dsr_remote_node_reply));
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP(ATTACH, "kpr_v6_dsr_remote_node_6reply")
+int kpr_v6_dsr_remote_node_6reply_setup(struct __ctx_buff *ctx)
+{
+	return netdev_send_packet(ctx);
+}
+
+CHECK(ATTACH, "kpr_v6_dsr_remote_node_6reply")
+int kpr_v6_dsr_remote_node_6reply_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_OK);
+
+	ASSERT_CTX_BUF_OFF("kpr_v6_dsr_remote_node_reply2_post",
+			   "Ether", ctx, sizeof(__u32),
+			   kpr_v6_dsr_remote_node_reply2_post,
+			   sizeof(kpr_v6_dsr_remote_node_reply2_post));
+
+	test_finish();
+}
+#endif
+#endif /* ENABLE_IPV6 */

--- a/bpf/tests/scapy/kpr_dsr_pkt_defs.py
+++ b/bpf/tests/scapy/kpr_dsr_pkt_defs.py
@@ -1,0 +1,342 @@
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+from scapy.all import *
+from pkt_defs_common import *
+from scapy.contrib.geneve import GENEVE, GeneveOptions
+
+class IPOption_DSR(IPOption):
+    name = "DSR IPv4 Option"
+
+    fields_desc = [
+        ByteField("option", 0x9a),
+        ByteField("length", 8),
+        ShortField("port", 0),
+        IPField("addr", "0.0.0.0"),
+    ]
+
+    # Suppress trailing layer warnings when packed in IP option arrays
+    def extract_padding(self, p):
+        return b"", p
+
+class IPv6Ext_DSR(Packet):
+    name = "DSR IPv6 Ext Header"
+    nh = 60
+
+    fields_desc = [
+        ByteField("nh", 6),
+        ByteField("len", 2),
+
+        ByteField("opt_type", 0x1b),
+        ByteField("opt_len", 20),
+        IP6Field("addr", "::"),
+        ShortField("port", 0),
+        ShortField("pad", 0)
+    ]
+
+bind_layers(IPv6, IPv6Ext_DSR, nh=60)
+bind_layers(IPv6Ext_DSR, TCP, nh=6)
+
+class Geneve_DSR_Opt4(GeneveOptions):
+    name = "GENEVE DSR IPv4 Option"
+
+    fields_desc = [
+        ShortField("classid", 0x014b),
+        ByteField("type", 0x81),
+        BitField("reserved", 0, 3),
+        BitField("length", 2, 5),
+
+        IPField("addr", "0.0.0.0"),
+        ShortField("port", 0),
+        ShortField("pad", 0)
+    ]
+
+class Geneve_DSR_Opt6(GeneveOptions):
+    name = "GENEVE DSR IPv6 Option"
+
+    fields_desc = [
+        ShortField("classid", 0x014b),
+        ByteField("type", 0x81),
+        BitField("reserved", 0, 3),
+        BitField("length", 5, 5),
+
+        IP6Field("addr", "::"),
+        ShortField("port", 0),
+        ShortField("pad", 0)
+    ]
+
+kpr_v4_dsr_lb1_syn = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_svc_one) /
+    TCP(sport=tcp_src_one, dport=tcp_svc_one, flags="S")
+)
+
+kpr_v4_dsr_lb1_syn_post_option = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_pod_one, ttl=63,
+       options=[bytes(IPOption_DSR(port=tcp_svc_one, addr=v4_svc_one))]) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="S")
+)
+
+kpr_v4_dsr_lb1_syn_post_option_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_pod_one, ttl=63,
+       options=[bytes(IPOption_DSR(port=tcp_svc_one, addr=v4_svc_one))]) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="S")
+)
+
+kpr_v4_dsr_lb1_syn_post_geneve = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="S")
+)
+
+kpr_v4_dsr_lb1_syn_post_geneve_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_node_one, dst=v4_node_two, id=0, ttl=63) /
+    UDP(sport=56602,dport=6081, chksum=0) /
+    GENEVE(vni=2,proto=0x6558,
+           options=[Geneve_DSR_Opt4(addr=v4_svc_one, port=tcp_svc_one)]) /
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="S")
+)
+
+kpr_v4_dsr_lb1_synack = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_svc_one) /
+    TCP(sport=tcp_src_one, dport=tcp_svc_one, flags="SA")
+)
+
+kpr_v4_dsr_lb1_synack_post_option = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_pod_one, ttl=63) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA")
+)
+
+kpr_v4_dsr_lb1_synack_post_option_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_pod_one, ttl=63) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA")
+)
+
+kpr_v4_dsr_lb1_synack_post_geneve = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA")
+)
+
+kpr_v4_dsr_lb1_synack_post_geneve_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_node_one, dst=v4_node_two, id=0, ttl=63) /
+    UDP(sport=56602, dport=6081, chksum=0) /
+    GENEVE(vni=2,proto=0x6558) /
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA")
+)
+
+kpr_v4_dsr_lb2_data = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_svc_one) /
+    TCP(sport=tcp_src_one, dport=tcp_svc_two, flags="") /
+    b"foobar"
+)
+
+kpr_v4_dsr_lb2_data_post_option = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_pod_one, ttl=63,
+       options=[bytes(IPOption_DSR(port=tcp_svc_two, addr=v4_svc_one))]) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="") /
+    b"foobar"
+)
+
+kpr_v4_dsr_lb2_data_post_option_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_pod_one, ttl=63,
+       options=[bytes(IPOption_DSR(port=tcp_svc_two, addr=v4_svc_one))]) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="") /
+    b"foobar"
+)
+
+kpr_v4_dsr_lb2_data_post_geneve = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="") /
+    b"foobar"
+)
+
+kpr_v4_dsr_lb2_data_post_geneve_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_node_one, dst=v4_node_two, id=0, ttl=63) /
+    UDP(sport=24364,dport=6081, chksum=0) /
+    GENEVE(vni=2,proto=0x6558,
+           options=[Geneve_DSR_Opt4(addr=v4_svc_one, port=tcp_svc_two)]) /
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="") /
+    b"foobar"
+)
+
+kpr_v4_dsr_lb2_data2_post_option = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_pod_one, ttl=63) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="") /
+    b"foobar"
+)
+
+kpr_v4_dsr_lb2_data2_post_option_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_pod_one, ttl=63) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="") /
+    b"foobar"
+)
+
+kpr_v4_dsr_lb2_data2_post_geneve_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_node_one, dst=v4_node_two, id=0, ttl=63) /
+    UDP(sport=24364,dport=6081, chksum=0) /
+    GENEVE(vni=2,proto=0x6558) /
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IP(src=v4_ext_one, dst=v4_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="") /
+    b"foobar"
+)
+
+kpr_v6_dsr_lb1_syn = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_svc_one) /
+    TCP(sport=tcp_src_one, dport=tcp_svc_one, flags="S")
+)
+
+kpr_v6_dsr_lb1_syn_post_option = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one, nh=60) /
+    IPv6Ext_DSR(addr=v6_svc_one, port=tcp_svc_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="S", chksum=50277)
+)
+
+kpr_v6_dsr_lb1_syn_post_option_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one, nh=60) /
+    IPv6Ext_DSR(addr=v6_svc_one, port=tcp_svc_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="S", chksum=50277)
+)
+
+kpr_v6_dsr_lb1_syn_post_geneve = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="S")
+)
+
+kpr_v6_dsr_lb1_syn_post_geneve_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_node_one, dst=v4_node_two, id=0) /
+    UDP(sport=52625,dport=6081, chksum=0) /
+    GENEVE(vni=2,proto=0x6558,
+           options=[Geneve_DSR_Opt6(addr=v6_svc_one, port=tcp_svc_one)]) /
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="S")
+)
+
+kpr_v6_dsr_lb1_synack = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_svc_one) /
+    TCP(sport=tcp_src_one, dport=tcp_svc_one, flags="SA")
+)
+
+kpr_v6_dsr_lb1_synack_post_option = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA")
+)
+
+kpr_v6_dsr_lb1_synack_post_option_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA")
+)
+
+kpr_v6_dsr_lb1_synack_post_geneve = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA")
+)
+
+kpr_v6_dsr_lb1_synack_post_geneve_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_node_one, dst=v4_node_two, id=0) /
+    UDP(sport=52625, dport=6081, chksum=0) /
+    GENEVE(vni=2,proto=0x6558) /
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA")
+)
+
+kpr_v6_dsr_lb2_data = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_svc_one) /
+    TCP(sport=tcp_src_one, dport=tcp_svc_two, flags="") /
+    b"foobar"
+)
+
+kpr_v6_dsr_lb2_data_post_option = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one, nh=60) /
+    IPv6Ext_DSR(addr=v6_svc_one, port=tcp_svc_two) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="", chksum=25015) /
+    b"foobar"
+)
+
+kpr_v6_dsr_lb2_data_post_option_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one, nh=60) /
+    IPv6Ext_DSR(addr=v6_svc_one, port=tcp_svc_two) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="", chksum=25015) /
+    b"foobar"
+)
+
+kpr_v6_dsr_lb2_data_post_geneve = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="") /
+    b"foobar"
+)
+
+kpr_v6_dsr_lb2_data_post_geneve_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_node_one, dst=v4_node_two, id=0) /
+    UDP(sport=18056,dport=6081, chksum=0) /
+    GENEVE(vni=2,proto=0x6558,
+           options=[Geneve_DSR_Opt6(addr=v6_svc_one, port=tcp_svc_two)]) /
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="") /
+    b"foobar"
+)
+
+kpr_v6_dsr_lb2_data2_post_option = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="") /
+    b"foobar"
+)
+
+kpr_v6_dsr_lb2_data2_post_option_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="") /
+    b"foobar"
+)
+
+kpr_v6_dsr_lb2_data2_post_geneve_xdp = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_node_one, dst=v4_node_two, id=0) /
+    UDP(sport=18056,dport=6081, chksum=0) /
+    GENEVE(vni=2,proto=0x6558) /
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="") /
+    b"foobar"
+)

--- a/bpf/tests/scapy/kpr_dsr_pkt_defs.py
+++ b/bpf/tests/scapy/kpr_dsr_pkt_defs.py
@@ -203,6 +203,32 @@ kpr_v4_dsr_lb2_data2_post_geneve_xdp = (
     b"foobar"
 )
 
+kpr_v4_dsr_remote_node_reply = (
+    Ether(src=mac_two, dst=mac_one) /
+    IP(src=v4_pod_one, dst=v4_ext_one) /
+    TCP(sport=tcp_dst_one, dport=tcp_src_one, flags="R")
+)
+
+kpr_v4_dsr_remote_node_reply_post = (
+    Ether(src=mac_two, dst=mac_one) /
+    IP(src=v4_svc_one, dst=v4_ext_one) /
+    TCP(sport=tcp_svc_one, dport=tcp_src_one, flags="R")
+)
+
+kpr_v4_dsr_remote_node_data_option = (
+    Ether(src=mac_one, dst=mac_two) /
+    IP(src=v4_ext_one, dst=v4_pod_one, ttl=63,
+       options=[bytes(IPOption_DSR(port=tcp_svc_two, addr=v4_svc_one))]) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="") /
+    b"foobar"
+)
+
+kpr_v4_dsr_remote_node_reply2_post = (
+    Ether(src=mac_two, dst=mac_one) /
+    IP(src=v4_svc_one, dst=v4_ext_one) /
+    TCP(sport=tcp_svc_two, dport=tcp_src_one, flags="R")
+)
+
 kpr_v6_dsr_lb1_syn = (
     Ether(src=host_mac_addr, dst=mac_one) /
     IPv6(src=v6_ext_node_one, dst=v6_svc_one) /
@@ -339,4 +365,30 @@ kpr_v6_dsr_lb2_data2_post_geneve_xdp = (
     IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
     TCP(sport=tcp_src_one, dport=tcp_dst_two, flags="") /
     b"foobar"
+)
+
+kpr_v6_dsr_remote_node_reply = (
+    Ether(src=mac_two, dst=mac_one) /
+    IPv6(src=v6_pod_one, dst=v6_ext_node_one) /
+    TCP(sport=tcp_dst_one, dport=tcp_src_one, flags="R")
+)
+
+kpr_v6_dsr_remote_node_reply_post = (
+    Ether(src=mac_two, dst=mac_one) /
+    IPv6(src=v6_svc_one, dst=v6_ext_node_one) /
+    TCP(sport=tcp_svc_one, dport=tcp_src_one, flags="R")
+)
+
+kpr_v6_dsr_remote_node_data_option = (
+    Ether(src=host_mac_addr, dst=mac_one) /
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one, nh=60) /
+    IPv6Ext_DSR(addr=v6_svc_one, port=tcp_svc_two) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="", chksum=25015) /
+    b"foobar"
+)
+
+kpr_v6_dsr_remote_node_reply2_post = (
+    Ether(src=mac_two, dst=mac_one) /
+    IPv6(src=v6_svc_one, dst=v6_ext_node_one) /
+    TCP(sport=tcp_svc_two, dport=tcp_src_one, flags="R")
 )

--- a/bpf/tests/scapy/pkt_defs.py
+++ b/bpf/tests/scapy/pkt_defs.py
@@ -19,3 +19,4 @@ from tc_redirect_pkt_defs import *
 from xdp_nodeport_lb4_nat_lb_tun_dynamic_pkt_defs import *
 from tc_nodeport_lb4_nat_lb_dynamic_pkt_defs import *
 from tc_nodeport_lb6_nat_lb_dynamic_pkt_defs import *
+from kpr_dsr_pkt_defs import *

--- a/bpf/tests/xdp_kpr_dsr_geneve_lb.c
+++ b/bpf/tests/xdp_kpr_dsr_geneve_lb.c
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#define ATTACHMENT_XDP
+
+#define ENABLE_IPV4			1
+#define ENABLE_IPV6			1
+#define ENABLE_NODEPORT			1
+#define ENABLE_DSR			1
+#define DSR_ENCAP_IPIP			2
+#define DSR_ENCAP_GENEVE		3
+#define DSR_ENCAP_MODE			DSR_ENCAP_GENEVE
+#define ENCAP_IFINDEX			42
+
+#define ENABLE_NODEPORT_ACCELERATION	1
+
+#include "kpr_dsr_lb.h"

--- a/bpf/tests/xdp_kpr_dsr_option_lb.c
+++ b/bpf/tests/xdp_kpr_dsr_option_lb.c
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#define ATTACHMENT_XDP
+
+#define ENABLE_IPV4			1
+#define ENABLE_IPV6			1
+#define ENABLE_NODEPORT			1
+#define ENABLE_DSR			1
+#define DSR_ENCAP_GENEVE		3
+
+#define ENABLE_NODEPORT_ACCELERATION	1
+
+#define TEST_DSR_OPT_NETWORK_BYTE_ORDER
+
+#include "kpr_dsr_lb.h"

--- a/bpf/tests/xdp_kpr_dsr_option_remote_node.c
+++ b/bpf/tests/xdp_kpr_dsr_option_remote_node.c
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#define ATTACHMENT_XDP
+
+#define ENABLE_IPV4			1
+#define ENABLE_IPV6			1
+#define ENABLE_NODEPORT			1
+#define ENABLE_DSR			1
+#define DSR_ENCAP_GENEVE		3
+
+#define ENABLE_NODEPORT_ACCELERATION	1
+
+#define TEST_DSR_OPT_NETWORK_BYTE_ORDER
+
+#include "kpr_dsr_remote_node.h"


### PR DESCRIPTION
Consider scenarios where an established TCP connection switches to (a) [different backend](https://github.com/cilium/cilium/blob/d376efb53dd51c8355851ca8ddbec399bc5205f9/bpf/lib/lb.h#L2303), or (b) gets ECMP-routed through a different LB node. As we currently only send the DSR-info on the TCP-SYN packet, the newly selected backend has no way of replying with a correctly RevDNATed TCP RST. The connection therefore stalls until it times out / the client terminates it.

Improve the recovery time by also sending the DSR info on a non-SYN packet, when it's going towards a newly selected backend. This is best-effort - if the DSR-info doesn't fit, we send an ICMP `FRAG_NEEDED` msg back to the client instead.

```release-note
Speed up recovery time for disrupted TCP connections that access a DSR-enabled Service.
```