### PR TITLE
.github: quarantine egress-gateway-excluded-cidrs on non-PD EKS legs

### DIFF
--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -591,6 +591,13 @@ jobs:
             echo "::warning title=Test quarantined::north-south-loadbalancing-with-l7-policy/outside-to-nodeport is skipped on this leg (${{ join(matrix.*, ', ') }}) because it hits a known ENI return-path drop without prefix delegation. The test is quarantined here and still gates on the prefix-delegation legs; remove once the bug is fixed."
           fi
 
+          # Quarantine egress-gateway-excluded-cidrs on non-PD legs (issue
+          # 47530): remove it from the gating run here and run it tolerated
+          # below. The PD legs run it inline and gate on it.
+          if [[ "${{ matrix.aws-eni-pd }}" != "true" ]]; then
+            CONNECTIVITY_TEST_DEFAULTS+=" --test '!egress-gateway-excluded-cidrs'"
+          fi
+
           echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
 
       - name: Check that AWS leftover iptables chains have been removed
@@ -615,6 +622,25 @@ jobs:
           --test-concurrency=${{ env.test_concurrency }} \
           --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - 1.xml" \
           --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
+
+      # Tolerated re-run of the quarantined egress-gateway-excluded-cidrs test
+      # on non-PD legs (issue 47530): it still runs and uploads a JUnit report,
+      # but its failure does not fail the workflow.
+      - name: Run quarantined test egress-gateway-excluded-cidrs (${{ join(matrix.*, ', ') }})
+        id: run-tests-quarantined
+        if: ${{ matrix.aws-eni-pd != true }}
+        continue-on-error: true
+        run: |
+          cilium connectivity test ${{ steps.e2e_config.outputs.test_flags }} \
+          --test 'egress-gateway-excluded-cidrs' \
+          --test-concurrency=${{ env.test_concurrency }} \
+          --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}) - quarantined.xml" \
+          --junit-property github_job_step="Run quarantined test egress-gateway-excluded-cidrs (${{ join(matrix.*, ', ') }})"
+
+      - name: Warn on quarantined egress-gateway-excluded-cidrs failure (${{ join(matrix.*, ', ') }})
+        if: ${{ always() && steps.run-tests-quarantined.outcome == 'failure' }}
+        run: |
+          echo "::warning title=Test quarantined::egress-gateway-excluded-cidrs failed on this leg (${{ join(matrix.*, ', ') }}) but is quarantined, so it did not fail the workflow. Without prefix delegation a client pod may be masqueraded to a secondary ENI's primary IP rather than the node HostIP the test asserts. Investigate the failure above; remove the quarantine once the test oracle is fixed."
 
       - name: Features tested
         if: ${{ always() && steps.install-cilium.outcome == 'success' }}


### PR DESCRIPTION
The egress-gateway-excluded-cidrs test asserts that excluded-CIDR egress
reaches the external echo with a source IP equal to the client pod's node
HostIP. On EKS ENI IPAM that only holds when the client pod's IP is owned by
the node's primary ENI. Without prefix delegation the node spreads pod IPs
across several ENIs, so a client pod can land on a secondary ENI and be
masqueraded to that ENI's primary IP, which is correct on ENI IPAM but differs
from HostIP, and the test fails with a wrong source IP. This is deterministic
on the 1.32/us-west-1 and 1.33/us-east-2 legs and is a test-oracle limitation,
not a datapath bug. Tracked in issue 47530.

Rather than lose all signal on those legs, this excludes the test from the
gating connectivity run and executes it on its own in a tolerated
continue-on-error step, so it still runs and uploads its JUnit report while its
failure does not fail the workflow, mirroring how the netkit jobs are
quarantined. A warning annotation keeps the failure visible in the run summary.
The prefix-delegation legs keep running the test inline and gating on it, and
every other test keeps gating everywhere, so nothing else is masked.

Verified on a run that forced the full EKS matrix so the non-PD legs actually
ran: https://github.com/cilium/cilium/actions/runs/30267206775 went green while
the quarantined egress-gateway-excluded-cidrs test failed inside its tolerated
step on the non-PD legs and emitted the warning annotation. The commit that
forced the full matrix on PRs has been dropped from this branch; on a normal PR
only the prefix-delegation default leg runs and gates on the test inline.

This PR was prepared with AIL:3.
