### PR TITLE
cilium-cli: Replace `reflect.DeepEqual` with `assert.Equal` in tests

### DIFF
--- a/cilium-cli/connectivity/check/test_test.go
+++ b/cilium-cli/connectivity/check/test_test.go
@@ -4,7 +4,6 @@
 package check
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,9 +47,8 @@ func TestWithFeatureRequirements(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			test := Test{requirements: tc.requirements}
-			if got := test.WithFeatureRequirements(tc.in...); !reflect.DeepEqual(got.requirements, tc.want) {
-				t.Errorf("WithFeatureRequirements() = %v, want %v", got.requirements, tc.want)
-			}
+			got := test.WithFeatureRequirements(tc.in...)
+			assert.Equal(t, tc.want, got.requirements)
 		})
 	}
 }

--- a/cilium-cli/internal/helm/helm_test.go
+++ b/cilium-cli/internal/helm/helm_test.go
@@ -4,7 +4,6 @@
 package helm
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/blang/semver/v4"
@@ -59,9 +58,7 @@ func TestResolveHelmChartVersion(t *testing.T) {
 				t.Errorf("ResolveHelmChartVersion() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ResolveHelmChartVersion() got = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -130,9 +127,7 @@ func TestParseVals(t *testing.T) {
 				t.Errorf("ParseVals() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ParseVals() got = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/cilium-cli/utils/features/utils_test.go
+++ b/cilium-cli/utils/features/utils_test.go
@@ -5,9 +5,10 @@ package features
 
 import (
 	"fmt"
-	"reflect"
 	"slices"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestComputeFailureExceptions(t *testing.T) {
@@ -50,9 +51,7 @@ func TestComputeFailureExceptions(t *testing.T) {
 			// computeFailureExceptions doesn't guarantee the order of the
 			// returned slice so we have to sort both slices.
 			slices.Sort(result)
-			if !reflect.DeepEqual(result, test.expectedExceptions) {
-				t.Errorf("Expected exceptions to be %v, but got: %v", test.expectedExceptions, result)
-			}
+			assert.Equal(t, test.expectedExceptions, result)
 		})
 	}
 }


### PR DESCRIPTION
`reflect.DeepEqual` produces unhelpful output on failure: it reports only that two values differ, not which fields. This PR replaces it with testify's `assert.Equal`, which prints a field-level diff.

Part of #40562