### PR TITLE
.github: add python3-scapy for BPF unit tests

### DIFF
--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -149,6 +149,10 @@ jobs:
         with:
           # renovate: datasource=golang-version depName=go
           go-version: 1.26.5
+      - name: Install Scapy (trace_diff_pkts.py)
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends python3-scapy
       - name: Install tparse and go-junit-report
         timeout-minutes: 15
         run: |


### PR DESCRIPTION
When BPF unit tests fail, `trace_diff_pkts.py` fails as it's
invoked by `go test` in the context of the Github runner, and the
runner doesn't have Scapy installed.

Install python3-scapy.

```release-note
```