### PR TITLE
[v1.18] CI flake backports 2026-07-27

### DIFF
--- a/.github/actions/ginkgo/main-focus.yaml
+++ b/.github/actions/ginkgo/main-focus.yaml
@@ -285,6 +285,9 @@ exclude:
   - k8s-version: "1.30"
     focus: "f05-agent-policy-multi-node-2"
 
+  - k8s-version: "1.30"
+    focus: "f06-agent-policy-basic"
+
   # These tests require an external node which is only available on
   # "net-next". So there's no point on running them.
   - k8s-version: "1.30"

--- a/.github/workflows/common-post-jobs.yaml
+++ b/.github/workflows/common-post-jobs.yaml
@@ -27,28 +27,22 @@ jobs:
       contents: read
       actions: read
     steps:
-      - name: Checkout context ref (trusted)
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ inputs.context-ref }}
-          persist-credentials: false
-
       - name: Merge Sysdumps
-        uses: ./.github/actions/merge-artifacts
+        uses: cilium/cilium/.github/actions/merge-artifacts@main # main
         with:
           name: cilium-sysdumps
           pattern: cilium-sysdumps-*
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Merge JUnits
-        uses: ./.github/actions/merge-artifacts
+        uses: cilium/cilium/.github/actions/merge-artifacts@main # main
         with:
           name: cilium-junits
           pattern: cilium-junits-*
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Merge Features tested
-        uses: ./.github/actions/merge-artifacts
+        uses: cilium/cilium/.github/actions/merge-artifacts@main # main
         with:
           name: features-tested
           pattern: features-tested-*

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -479,6 +479,19 @@ jobs:
             fi
             mv "$file" "./${new_filename}"
           done
+          # Collect any feature-status collection error logs so a failure that
+          # would otherwise only appear on the (ephemeral) VM console survives,
+          # even on a passing run.
+          mkdir -p feature-status-errors
+          find ./test -type f -iname 'feature-status-error-*.log' -exec cp {} feature-status-errors/ \; || true
+
+      - name: Upload feature status error logs
+        if: ${{ always() && steps.run-tests.outcome != 'skipped' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: feature-status-errors-${{ env.job_name }}
+          path: feature-status-errors/*.log
+          if-no-files-found: ignore
 
       - name: Fetch JUnits
         if: ${{ always() && steps.run-tests.outcome != 'skipped' }}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4377,24 +4377,53 @@ func serviceAddressKey(ip, port, proto, scope string) string {
 }
 
 func (kub *Kubectl) CollectFeatures() {
-	ctx, cancel := context.WithTimeout(context.Background(), MidCommandTimeout)
-	defer cancel()
-
 	testPath, err := CreateReportDirectory()
 	if err != nil {
 		log.WithError(err).Errorf("cannot create test result path '%s'", testPath)
 		return
 	}
 
+	// Collect each report format under its own MidCommandTimeout rather than a
+	// single shared one: the metrics fetch dominates the budget, so sharing one
+	// context between the two collections risks starving the second of time.
+	kub.collectFeatureStatus(testPath, "markdown", "md")
+	kub.collectFeatureStatus(testPath, "json", "json")
+}
+
+// collectFeatureStatus runs `cilium-cli features status` for a single output
+// format, writing the report next to the other test_results. It uses its own
+// MidCommandTimeout so each format gets the full budget.
+func (kub *Kubectl) collectFeatureStatus(testPath, format, ext string) {
+	ctx, cancel := context.WithTimeout(context.Background(), MidCommandTimeout)
+	defer cancel()
+
 	// We need to get into the root directory because the CLI doesn't yet
 	// support absolute path. Once https://github.com/cilium/cilium-cli/pull/1552
 	// is installed in test VM images, we can remove this.
-	res := kub.ExecContext(ctx, fmt.Sprintf("cilium-cli features status -o markdown --output-file='%s/feature-status-%s.md'", testPath, ginkgoext.GetTestName()))
+	//
+	// The output path is double-quoted, not single-quoted: some test names
+	// contain an apostrophe (e.g. "Checks the pod's mac address"), which
+	// GetTestName keeps. Under single quotes the apostrophe would terminate the
+	// quoted string and the shell would drop it, so cilium-cli would receive a
+	// path without the apostrophe while CreateReportDirectory created the
+	// directory with it, and the write would fail with "no such file or
+	// directory". Double quotes preserve the apostrophe and keep both in sync.
+	res := kub.ExecContext(ctx, fmt.Sprintf("cilium-cli features status -o %s --output-file=\"%s/feature-status-%s.%s\"", format, testPath, ginkgoext.GetTestName(), ext))
 	if !res.WasSuccessful() {
-		log.WithError(res.GetError()).Errorf("failed to collect feature status :%s", res.CombineOutput().String())
+		recordFeatureStatusError(testPath, format, res)
 	}
-	res = kub.ExecContext(ctx, fmt.Sprintf("cilium-cli features status -o json --output-file='%s/feature-status-%s.json'", testPath, ginkgoext.GetTestName()))
-	if !res.WasSuccessful() {
-		log.WithError(res.GetError()).Errorf("failed to collect feature status :%s", res.CombineOutput().String())
+}
+
+// recordFeatureStatusError logs a failed 'features status' collection and also
+// persists its combined output to a file under testPath. The command runs
+// inside the test VM and only ever logged to the (ephemeral) VM console, so on
+// a passing run the failure left no downloadable trace. Writing it next to the
+// other test_results artifacts makes the real error visible after the fact.
+func recordFeatureStatusError(testPath, format string, res *CmdRes) {
+	out := res.CombineOutput().String()
+	log.WithError(res.GetError()).Errorf("failed to collect feature status :%s", out)
+	errFile := filepath.Join(testPath, fmt.Sprintf("feature-status-error-%s-%s.log", ginkgoext.GetTestName(), format))
+	if writeErr := os.WriteFile(errFile, []byte(out), 0o644); writeErr != nil {
+		log.WithError(writeErr).Errorf("cannot write feature status error log '%s'", errFile)
 	}
 }

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4274,7 +4274,11 @@ func (kub *Kubectl) ensureKubectlVersion() error {
 		rcVersion = fmt.Sprintf("v%s.0", GetCurrentK8SEnv())
 	}
 	res = kub.Exec(
-		fmt.Sprintf("curl -sSLo %s https://dl.k8s.io/release/%s/bin/linux/amd64/kubectl && chmod +x %s",
+		// --retry-all-errors is required because a transient TLS/SSL connect
+		// failure to dl.k8s.io surfaces as curl exit 35, which is not part of
+		// curl's default --retry set. Mirrors the download retry convention
+		// applied to the .github/ workflows and composite actions in #47167.
+		fmt.Sprintf("curl -sSfLo %s --retry 5 --retry-all-errors --retry-delay 3 https://dl.k8s.io/release/%s/bin/linux/amd64/kubectl && chmod +x %s",
 			path, rcVersion, path))
 	if !res.WasSuccessful() {
 		return fmt.Errorf("failed to download kubectl")


### PR DESCRIPTION
 * [x] #47174 (@aanm)
 * [x] #47357 (@aanm)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 47174 47357
```
