### PR TITLE
docs(masquerade): add uRPF caution for cloud providers enforcing source IP validation

### DIFF
--- a/Documentation/network/concepts/masquerading.rst
+++ b/Documentation/network/concepts/masquerading.rst
@@ -40,6 +40,29 @@ Setting the routable CIDR
   within the same VPC (e.g., virtual machines) will be routed directly without
   masquerading the source IP address.
 
+  .. caution::
+
+     Some cloud providers enforce unicast reverse path forwarding (uRPF) at
+     their virtual network gateway. The gateway validates each packet's source
+     IP against the prefixes registered to the originating instance. Pod IPs
+     are not registered instance prefixes, so the gateway silently drops any
+     pod-sourced packet that passes through it—no ICMP unreachable is returned,
+     only a connection timeout.
+
+     When ``ipv4-native-routing-cidr`` is set to the full VPC or
+     private-network CIDR, Cilium does not masquerade pod traffic to
+     non-cluster hosts within that range, exposing pod IPs to the gateway and
+     triggering uRPF drops. Set ``ipv4-native-routing-cidr`` to the pod CIDR
+     only (e.g. ``10.42.0.0/16``) so that traffic to non-cluster destinations
+     is masqueraded to the node's registered IP.
+
+     This failure is easily missed during testing: ``auto-direct-node-routes``
+     installs direct host routes for intra-cluster pod CIDRs, bypassing the
+     gateway for pod-to-pod traffic. Only traffic from pods to non-cluster
+     hosts is affected.
+
+     See the :ref:`k8s_install_hetzner` guide for a concrete example of this
+     issue and the recommended configuration.
 
 Setting the masquerading interface
   See :ref:`masq_modes` for configuring the masquerading interfaces.

--- a/Documentation/network/concepts/masquerading.rst
+++ b/Documentation/network/concepts/masquerading.rst
@@ -43,18 +43,19 @@ Setting the routable CIDR
   .. caution::
 
      On some cloud platforms the virtual network gateway enforces unicast
-     reverse path forwarding (uRPF): it drops any packet whose source IP is
-     not a prefix assigned to the sending instance. Pod IPs fall into this
-     category. If ``ipv4-native-routing-cidr`` covers the full VPC range,
-     Cilium will not masquerade pod traffic to other VPC hosts, and those
-     packets will be dropped at the gateway with no ICMP response.
+     reverse path forwarding (uRPF), dropping any packet whose source IP is
+     not a prefix assigned to the sending instance. Because pod IPs are not
+     registered instance prefixes, setting ``ipv4-native-routing-cidr`` to
+     the full VPC CIDR causes Cilium to skip masquerade for pod traffic to
+     non-cluster hosts, and the gateway drops those packets silently without
+     returning an ICMP unreachable.
 
      To avoid this, set ``ipv4-native-routing-cidr`` to the pod CIDR only
-     (e.g. ``10.42.0.0/16``). Cilium will then masquerade pod traffic to
-     non-cluster destinations through the node IP, which the gateway accepts.
-     Be aware that ``auto-direct-node-routes`` can hide this problem during
-     testing—it installs direct routes between nodes for pod CIDRs, so
-     pod-to-pod traffic never reaches the gateway and appears to work fine.
+     (e.g., ``10.42.0.0/16``), so that traffic to non-cluster destinations
+     is masqueraded to the node IP before reaching the gateway. Note that
+     when ``auto-direct-node-routes`` is enabled, pod-to-pod cross-node
+     traffic uses direct host routes and bypasses the gateway entirely, which
+     can mask this misconfiguration during testing.
 
      See the :ref:`k8s_install_hetzner` guide for a concrete example.
 

--- a/Documentation/network/concepts/masquerading.rst
+++ b/Documentation/network/concepts/masquerading.rst
@@ -42,19 +42,19 @@ Setting the routable CIDR
 
   .. caution::
 
-     Some cloud providers enforce unicast reverse path forwarding (uRPF) at
-     their virtual network gateway: the gateway drops packets whose source IP
-     is not a prefix registered to the sending instance. Pod IPs are not
-     registered, so setting ``ipv4-native-routing-cidr`` to the full VPC CIDR
-     causes pod traffic to non-cluster hosts to bypass masquerade and be
-     dropped silently at the gateway—no ICMP unreachable, only a timeout.
+     On some cloud platforms the virtual network gateway enforces unicast
+     reverse path forwarding (uRPF): it drops any packet whose source IP is
+     not a prefix assigned to the sending instance. Pod IPs fall into this
+     category. If ``ipv4-native-routing-cidr`` covers the full VPC range,
+     Cilium will not masquerade pod traffic to other VPC hosts, and those
+     packets will be dropped at the gateway with no ICMP response.
 
-     Set ``ipv4-native-routing-cidr`` to the pod CIDR only (e.g.
-     ``10.42.0.0/16``). Traffic to non-cluster destinations is then
-     masqueraded to the node IP, which passes uRPF. Note that
-     ``auto-direct-node-routes`` installs direct host routes for peer pod
-     CIDRs, so pod-to-pod cross-node traffic bypasses the gateway—this can
-     mask the misconfiguration during testing.
+     To avoid this, set ``ipv4-native-routing-cidr`` to the pod CIDR only
+     (e.g. ``10.42.0.0/16``). Cilium will then masquerade pod traffic to
+     non-cluster destinations through the node IP, which the gateway accepts.
+     Be aware that ``auto-direct-node-routes`` can hide this problem during
+     testing—it installs direct routes between nodes for pod CIDRs, so
+     pod-to-pod traffic never reaches the gateway and appears to work fine.
 
      See the :ref:`k8s_install_hetzner` guide for a concrete example.
 

--- a/Documentation/network/concepts/masquerading.rst
+++ b/Documentation/network/concepts/masquerading.rst
@@ -43,26 +43,20 @@ Setting the routable CIDR
   .. caution::
 
      Some cloud providers enforce unicast reverse path forwarding (uRPF) at
-     their virtual network gateway. The gateway validates each packet's source
-     IP against the prefixes registered to the originating instance. Pod IPs
-     are not registered instance prefixes, so the gateway silently drops any
-     pod-sourced packet that passes through it—no ICMP unreachable is returned,
-     only a connection timeout.
+     their virtual network gateway: the gateway drops packets whose source IP
+     is not a prefix registered to the sending instance. Pod IPs are not
+     registered, so setting ``ipv4-native-routing-cidr`` to the full VPC CIDR
+     causes pod traffic to non-cluster hosts to bypass masquerade and be
+     dropped silently at the gateway—no ICMP unreachable, only a timeout.
 
-     When ``ipv4-native-routing-cidr`` is set to the full VPC or
-     private-network CIDR, Cilium does not masquerade pod traffic to
-     non-cluster hosts within that range, exposing pod IPs to the gateway and
-     triggering uRPF drops. Set ``ipv4-native-routing-cidr`` to the pod CIDR
-     only (e.g. ``10.42.0.0/16``) so that traffic to non-cluster destinations
-     is masqueraded to the node's registered IP.
+     Set ``ipv4-native-routing-cidr`` to the pod CIDR only (e.g.
+     ``10.42.0.0/16``). Traffic to non-cluster destinations is then
+     masqueraded to the node IP, which passes uRPF. Note that
+     ``auto-direct-node-routes`` installs direct host routes for peer pod
+     CIDRs, so pod-to-pod cross-node traffic bypasses the gateway—this can
+     mask the misconfiguration during testing.
 
-     This failure is easily missed during testing: ``auto-direct-node-routes``
-     installs direct host routes for intra-cluster pod CIDRs, bypassing the
-     gateway for pod-to-pod traffic. Only traffic from pods to non-cluster
-     hosts is affected.
-
-     See the :ref:`k8s_install_hetzner` guide for a concrete example of this
-     issue and the recommended configuration.
+     See the :ref:`k8s_install_hetzner` guide for a concrete example.
 
 Setting the masquerading interface
   See :ref:`masq_modes` for configuring the masquerading interfaces.

--- a/Documentation/network/concepts/masquerading.rst
+++ b/Documentation/network/concepts/masquerading.rst
@@ -40,6 +40,24 @@ Setting the routable CIDR
   within the same VPC (e.g., virtual machines) will be routed directly without
   masquerading the source IP address.
 
+  .. caution::
+
+     On some cloud platforms the virtual network gateway enforces unicast
+     reverse path forwarding (uRPF), dropping any packet whose source IP is
+     not a prefix assigned to the sending instance. Because pod IPs are not
+     registered instance prefixes, setting ``ipv4-native-routing-cidr`` to
+     the full VPC CIDR causes Cilium to skip masquerade for pod traffic to
+     non-cluster hosts, and the gateway drops those packets silently without
+     returning an ICMP unreachable.
+
+     To avoid this, set ``ipv4-native-routing-cidr`` to the pod CIDR only
+     (e.g., ``10.42.0.0/16``), so that traffic to non-cluster destinations
+     is masqueraded to the node IP before reaching the gateway. Note that
+     when ``auto-direct-node-routes`` is enabled, pod-to-pod cross-node
+     traffic uses direct host routes and bypasses the gateway entirely, which
+     can mask this misconfiguration during testing.
+
+     See the :ref:`k8s_install_hetzner` guide for a concrete example.
 
 Setting the masquerading interface
   See :ref:`masq_modes` for configuring the masquerading interfaces.


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request]
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:N. I personally checked X."
- [x] Thanks for contributing!

<!-- Description of change -->

AIL:3 — AI generated content, human fully directed and structured.

Follow-up to #48615 (Hetzner Cloud installation guide). That PR covers the
uRPF issue in a provider-specific guide; this PR adds a cloud-provider-agnostic
caution to the masquerading docs so users encounter the warning before they
reach a provider-specific guide.

## Problem

Some cloud providers (Hetzner Cloud is a documented example) enforce unicast
reverse path forwarding (uRPF) at their virtual network gateway. Setting
`ipv4-native-routing-cidr` to the full VPC CIDR causes Cilium to skip
masquerade for pod traffic to non-cluster hosts, and the gateway drops those
packets silently — no ICMP unreachable, only connection timeouts.

The failure is easily missed during testing because `auto-direct-node-routes`
installs direct host routes for intra-cluster pod CIDRs, bypassing the gateway
entirely.

## Fix

Add a `.. caution::` to the `ipv4-native-routing-cidr` section in the
masquerading docs explaining the failure mode, the fix (set to pod CIDR only),
and linking to the Hetzner guide for a concrete example.

```release-note
docs: add caution about uRPF source IP validation on cloud provider virtual network gateways when configuring ipv4-native-routing-cidr
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer's Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request