### PR TITLE
cilium-cli/connectivity: use netip.ParseAddr for the dstIP check

### DIFF
--- a/cilium-cli/connectivity/check/action.go
+++ b/cilium-cli/connectivity/check/action.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"net"
+	"net/netip"
 	"regexp"
 	"strconv"
 	"strings"
@@ -642,7 +642,7 @@ func (a *Action) matchFlowRequirements(flows flowsSet, req *filters.FlowSetRequi
 func (a *Action) GetEgressRequirements(p FlowParameters) (reqs []filters.FlowSetRequirement) {
 	srcIP := a.src.Address(a.ipFam)
 	dstIP := a.dst.Address(a.ipFam)
-	if dstIP != "" && net.ParseIP(dstIP) == nil {
+	if _, err := netip.ParseAddr(dstIP); dstIP != "" && err != nil {
 		// dstIP is not an IP address, assume it is a domain name
 		dstIP = ""
 	}
@@ -806,7 +806,7 @@ func (a *Action) GetIngressRequirements(p FlowParameters) []filters.FlowSetRequi
 
 	srcIP := a.src.Address(a.ipFam)
 	dstIP := a.dst.Address(a.ipFam)
-	if dstIP != "" && net.ParseIP(dstIP) == nil {
+	if _, err := netip.ParseAddr(dstIP); dstIP != "" && err != nil {
 		// dstIP is not an IP address, assume it is a domain name
 		dstIP = ""
 	}


### PR DESCRIPTION
## Description

`GetEgressRequirements` and `GetIngressRequirements` decide whether `dstIP` is an IP address or a domain name using `net.ParseIP(dstIP) == nil`. This switches both to `netip.ParseAddr` as part of the `net.IP` -> `netip.Addr` migration.

The parsed value is only used for the validity test — it is never stored or returned — so no callers change, and `net` was only imported for these two checks.

Related: #24246

```release-note
None
```