### PR TITLE
[v1.20] docs: Fix proxylib deprecation version number

### DIFF
--- a/Documentation/operations/upgrade-current.inc
+++ b/Documentation/operations/upgrade-current.inc
@@ -14,7 +14,7 @@ notes carefully below to understand what to do during upgrade.
   in a future version. Consider using :ref:`encryption_ztunnel` instead, and
   please provide feedback on whether this alternative feature addresses your
   use cases.
-* Envoy Go Extensions (proxylib) was removed after deprecation in Cilium 1.16.
+* Envoy Go Extensions (proxylib) was removed after deprecation in Cilium 1.18.
   If you have ``CiliumNetworkPolicy`` or ``CiliumClusterwideNetworkPolicy``
   network policies with the section ``.spec.ingress[].toPorts[].rules`` or
   ``.spec.egress[].toPorts[].rules``, with the sub-field ``kafka``, ``l7`` or


### PR DESCRIPTION
I must have picked up the wrong number from somewhere, clearly commit
5a1010a42f28 ("proxy: Add deprecated warning for proxylib") is only
present from v1.18 onwards.
