### PR TITLE
fqdn: resolve DNS server identity once for access logging

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -52,6 +52,12 @@ const (
 	// ProxyBindRetryInterval is how long to wait between attempts to bind to the
 	// proxy address:port
 	ProxyBindRetryInterval = ProxyBindTimeout / 5
+
+	// serverIdentityLookupTimeout is the maximum time to wait when resolving the
+	// full security identity (labels included) of the DNS server. The identity
+	// is only used for access logging, so the lookup is best-effort and must not
+	// block the DNS request/response path for long.
+	serverIdentityLookupTimeout = 10 * time.Millisecond
 )
 
 // DNSProxy is a L7 proxy for DNS traffic. It keeps a list of allowed DNS
@@ -917,7 +923,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 				scopedLog.Error("Dropping DNS request due to too many DNS requests already in-flight", logfields.Error, err)
 			}
 			stat.Err = err
-			p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, 0, netip.AddrPort{}, &MsgDetails{}, protocol, false, &stat)
+			p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, nil, netip.AddrPort{}, &MsgDetails{}, protocol, false, &stat)
 			p.sendErrorResponse(scopedLog, w, request, false)
 			return
 		}
@@ -945,7 +951,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		scopedLog.Error("cannot extract endpoint IP from DNS request", logfields.Error, err)
 		stat.Err = fmt.Errorf("Cannot extract endpoint IP from DNS request: %w", err)
 		stat.ProcessingTime.End(false)
-		p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, 0, netip.AddrPort{}, &MsgDetails{}, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, nil, netip.AddrPort{}, &MsgDetails{}, protocol, false, &stat)
 		p.sendErrorResponse(scopedLog, w, request, false)
 		return
 	}
@@ -955,7 +961,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		scopedLog.Error("cannot extract endpoint ID from DNS request", logfields.Error, err)
 		stat.Err = fmt.Errorf("Cannot extract endpoint ID from DNS request: %w", err)
 		stat.ProcessingTime.End(false)
-		p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, 0, netip.AddrPort{}, &MsgDetails{}, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), nil, epIPPort, nil, netip.AddrPort{}, &MsgDetails{}, protocol, false, &stat)
 		p.sendErrorResponse(scopedLog, w, request, false)
 		return
 	}
@@ -970,7 +976,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		p.logger.Error("cannot extract destination IP:port from DNS request", logfields.Error, err)
 		stat.Err = fmt.Errorf("Cannot extract destination IP:port from DNS request: %w", err)
 		stat.ProcessingTime.End(false)
-		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, 0, targetServer, requestDetails, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, nil, targetServer, requestDetails, protocol, false, &stat)
 		p.sendErrorResponse(scopedLog, w, request, false)
 		return
 	}
@@ -992,6 +998,8 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		)
 	}
 
+	targetServerIdentity := &identity.Identity{ID: targetServerID}
+
 	// The allowed check is first because we don't want to use DNS responses that
 	// endpoints are not allowed to see.
 	// Note: The cache doesn't know about the source of the DNS data (yet) and so
@@ -1005,7 +1013,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		scopedLog.Error("Rejecting DNS query from endpoint due to error", logfields.Error, err)
 		stat.Err = fmt.Errorf("Rejecting DNS query from endpoint due to error: %w", err)
 		stat.ProcessingTime.End(false)
-		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServer, requestDetails, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerIdentity, targetServer, requestDetails, protocol, false, &stat)
 		p.sendErrorResponse(scopedLog, w, request, false)
 		return
 
@@ -1017,12 +1025,14 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		// information for metrics.
 		stat.Err = p.sendErrorResponse(scopedLog, w, request, true)
 		stat.ProcessingTime.End(true)
-		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServer, requestDetails, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerIdentity, targetServer, requestDetails, protocol, false, &stat)
 		return
 	}
 
+	targetServerIdentity = p.resolveServerIdentity(targetServerIdentity)
+
 	scopedLog.Debug("Forwarding DNS request for a name that is allowed")
-	if err := p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServer, requestDetails, protocol, true, &stat); err != nil {
+	if err := p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerIdentity, targetServer, requestDetails, protocol, true, &stat); err != nil {
 		scopedLog.Error("Failed to process DNS query", logfields.Error, err)
 		p.sendErrorResponse(scopedLog, w, request, false)
 		return
@@ -1037,7 +1047,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		scopedLog.Error("Cannot parse DNS proxy client network to select forward client")
 		stat.Err = fmt.Errorf("Cannot parse DNS proxy client network to select forward client: %w", err)
 		stat.ProcessingTime.End(false)
-		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServer, requestDetails, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerIdentity, targetServer, requestDetails, protocol, false, &stat)
 		p.sendErrorResponse(scopedLog, w, request, false)
 		return
 	}
@@ -1091,12 +1101,12 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		stat.Err = err
 		if stat.IsTimeout() {
 			scopedLog.Warn("Timeout waiting for response to forwarded proxied DNS lookup", logfields.Error, err)
-			p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServer, requestDetails, protocol, false, &stat)
+			p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerIdentity, targetServer, requestDetails, protocol, false, &stat)
 			return
 		}
 		scopedLog.Error("Cannot forward proxied DNS lookup", logfields.Error, err)
 		stat.Err = fmt.Errorf("cannot forward proxied DNS lookup: %w", err)
-		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServer, requestDetails, protocol, false, &stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerIdentity, targetServer, requestDetails, protocol, false, &stat)
 		p.sendErrorResponse(scopedLog, w, request, false)
 		return
 	}
@@ -1118,7 +1128,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	stat.ProcessingTime.End(true)
 
 	scopedLog.Debug("Notifying with DNS response to original DNS query")
-	if err := p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServer, responseDetails, protocol, true, &stat); err != nil {
+	if err := p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerIdentity, targetServer, responseDetails, protocol, true, &stat); err != nil {
 		scopedLog.Error(
 			"Failed to process DNS response",
 			logfields.Error, err,
@@ -1136,7 +1146,7 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 	if err != nil {
 		scopedLog.Error("Cannot forward proxied DNS response", logfields.Error, err)
 		stat.Err = fmt.Errorf("Cannot forward proxied DNS response: %w", err)
-		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerID, targetServer, responseDetails, protocol, true, &stat)
+		p.NotifyOnDNSMsg(time.Now(), ep, epIPPort, targetServerIdentity, targetServer, responseDetails, protocol, true, &stat)
 	} else {
 		p.Lock()
 		// Add the server to the set of used DNS servers. This set is never GCd, but is limited by set
@@ -1144,6 +1154,22 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		p.usedServers[targetServer.Addr()] = struct{}{}
 		p.Unlock()
 	}
+}
+
+// resolveServerIdentity upgrades a numeric-only server identity into the full
+// security identity (labels included) of the DNS server. The lookup is
+// best-effort and bounded by serverIdentityLookupTimeout, since the identity is
+// only used for access logging and must not delay the DNS request/response
+// path. If the full identity cannot be resolved, the numeric-only identity is
+// returned unchanged so the access-log path can still fall back to resolving
+// the labels itself.
+func (p *DNSProxy) resolveServerIdentity(numericID *identity.Identity) *identity.Identity {
+	ctx, cancel := context.WithTimeout(context.Background(), serverIdentityLookupTimeout)
+	defer cancel()
+	if id := p.proxyLookupHandler.LookupIdentityByID(ctx, numericID.ID); id != nil {
+		return id
+	}
+	return numericID
 }
 
 func (p *DNSProxy) enforceConcurrencyLimit(ctx context.Context) error {

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -101,7 +101,7 @@ func setupDNSProxyTestSuite(tb testing.TB) *DNSProxyTestSuite {
 	}
 	proxy := NewDNSProxy(dnsProxyConfig,
 		s,
-		func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID identity.NumericIdentity, dstAddr netip.AddrPort, details *MsgDetails, protocol string, allowed bool, stat *ProxyRequestContext) error {
+		func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID *identity.Identity, dstAddr netip.AddrPort, details *MsgDetails, protocol string, allowed bool, stat *ProxyRequestContext) error {
 			return nil
 		},
 	)
@@ -156,6 +156,10 @@ func (s *DNSProxyTestSuite) LookupSecIDByIP(ip netip.Addr) (secID ipcache.Identi
 		}
 		return ident, true
 	}
+}
+
+func (s *DNSProxyTestSuite) LookupIdentityByID(ctx context.Context, nid identity.NumericIdentity) *identity.Identity {
+	return &identity.Identity{ID: nid}
 }
 
 func (s *DNSProxyTestSuite) LookupByIdentity(nid identity.NumericIdentity) []string {

--- a/pkg/fqdn/dnsproxy/types.go
+++ b/pkg/fqdn/dnsproxy/types.go
@@ -22,7 +22,7 @@ type LookupEndpointIDByIPFunc func(ip netip.Addr) (endpoint *endpoint.Endpoint, 
 
 // NotifyOnDNSMsgFunc handles propagating DNS response data
 // See DNSProxy.LookupEndpointIDByIP for usage.
-type NotifyOnDNSMsgFunc func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID identity.NumericIdentity, serverAddr netip.AddrPort, details *MsgDetails, protocol string, allowed bool, stat *ProxyRequestContext) error
+type NotifyOnDNSMsgFunc func(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID *identity.Identity, serverAddr netip.AddrPort, details *MsgDetails, protocol string, allowed bool, stat *ProxyRequestContext) error
 
 // ErrFailedAcquireSemaphore is an error representing the DNS proxy's
 // failure to acquire the semaphore. This is error is treated like a timeout.

--- a/pkg/fqdn/lookup/cell.go
+++ b/pkg/fqdn/lookup/cell.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cilium/hive/cell"
 
 	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/node"
 )
@@ -26,16 +27,18 @@ var Cell = cell.Module(
 type ProxyLookupParams struct {
 	cell.In
 
-	IPCache         *ipcache.IPCache
-	LocalNodeStore  *node.LocalNodeStore
-	EndpointManager endpointmanager.EndpointManager
+	IPCache           *ipcache.IPCache
+	LocalNodeStore    *node.LocalNodeStore
+	EndpointManager   endpointmanager.EndpointManager
+	IdentityAllocator cache.IdentityAllocator
 }
 
 func NewProxyLookupHandler(params ProxyLookupParams) ProxyLookupHandler {
 	handler := &proxyLookupHandler{
-		localNodeStore:  params.LocalNodeStore,
-		endpointManager: params.EndpointManager,
-		ipCache:         params.IPCache,
+		localNodeStore:    params.LocalNodeStore,
+		endpointManager:   params.EndpointManager,
+		ipCache:           params.IPCache,
+		identityAllocator: params.IdentityAllocator,
 	}
 
 	return handler

--- a/pkg/fqdn/lookup/endpoint.go
+++ b/pkg/fqdn/lookup/endpoint.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/node"
 )
@@ -20,6 +21,10 @@ type ProxyLookupHandler interface {
 	// LookupSecIDByIP looks up the security ID for a given IP address
 	// from the ipcache.
 	LookupSecIDByIP(ip netip.Addr) (secID ipcache.Identity, exists bool)
+
+	// LookupIdentityByID resolves the full security identity for the given
+	// numeric identity. It returns nil if the identity cannot be resolved.
+	LookupIdentityByID(ctx context.Context, nid identity.NumericIdentity) *identity.Identity
 
 	// LookupByIdentity is a provided callback that returns the IPs of a given security ID.
 	LookupByIdentity(nid identity.NumericIdentity) []string
@@ -31,9 +36,10 @@ type ProxyLookupHandler interface {
 }
 
 type proxyLookupHandler struct {
-	ipCache         *ipcache.IPCache
-	localNodeStore  *node.LocalNodeStore
-	endpointManager endpointmanager.EndpointManager
+	ipCache           *ipcache.IPCache
+	localNodeStore    *node.LocalNodeStore
+	endpointManager   endpointmanager.EndpointManager
+	identityAllocator cache.IdentityAllocator
 }
 
 var _ ProxyLookupHandler = &proxyLookupHandler{}
@@ -61,6 +67,10 @@ func (p *proxyLookupHandler) LookupRegisteredEndpoint(endpointAddr netip.Addr) (
 
 func (p *proxyLookupHandler) LookupSecIDByIP(ip netip.Addr) (secID ipcache.Identity, exists bool) {
 	return p.ipCache.LookupSecIDByIP(ip)
+}
+
+func (p *proxyLookupHandler) LookupIdentityByID(ctx context.Context, nid identity.NumericIdentity) *identity.Identity {
+	return p.identityAllocator.LookupIdentityByID(ctx, nid)
 }
 
 func (p *proxyLookupHandler) LookupByIdentity(nid identity.NumericIdentity) []string {

--- a/pkg/fqdn/messagehandler/message_handler.go
+++ b/pkg/fqdn/messagehandler/message_handler.go
@@ -52,7 +52,7 @@ type DNSMessageHandler interface {
 	NotifyOnDNSMsg(lookupTime time.Time,
 		ep *endpoint.Endpoint,
 		epIPPort string,
-		serverID identity.NumericIdentity,
+		serverID *identity.Identity,
 		serverAddrPort netip.AddrPort,
 		details *dnsproxy.MsgDetails,
 		protocol string,
@@ -121,11 +121,14 @@ func (h *dnsMessageHandler) SetBindPort(port uint16) {
 // epIPPort and serverAddrPort should match the original request, where epAddr is
 // the source for egress (the only case current).
 // serverID is the destination server security identity at the time of the DNS event.
+// It may be nil on early error paths, and may carry only
+// a numeric identity (no labels) when the full identity could not be resolved;
+// in either case the access-log path falls back to resolving the labels itself.
 func (h *dnsMessageHandler) NotifyOnDNSMsg(
 	lookupTime time.Time,
 	ep *endpoint.Endpoint,
 	epIPPort string,
-	serverID identity.NumericIdentity,
+	serverID *identity.Identity,
 	serverAddrPort netip.AddrPort,
 	dnsMsgDetails *dnsproxy.MsgDetails,
 	protocol string,
@@ -210,7 +213,10 @@ func (h *dnsMessageHandler) NotifyOnDNSMsg(
 		// is going away.
 		flow.addrInfo.DstSecIdentity, _ = ep.GetSecurityIdentity()
 		flow.addrInfo.SrcIPPort = serverAddrPortStr
-		flow.addrInfo.SrcIdentity = serverID
+		if serverID != nil {
+			flow.addrInfo.SrcIdentity = serverID.ID
+			flow.addrInfo.SrcSecIdentity = serverID
+		}
 	} else {
 		flow.flowType = accesslog.TypeRequest
 		flow.addrInfo.SrcIPPort = epIPPort
@@ -218,7 +224,10 @@ func (h *dnsMessageHandler) NotifyOnDNSMsg(
 		// ignore error; same reason as above.
 		flow.addrInfo.SrcSecIdentity, _ = ep.GetSecurityIdentity()
 		flow.addrInfo.DstIPPort = serverAddrPortStr
-		flow.addrInfo.DstIdentity = serverID
+		if serverID != nil {
+			flow.addrInfo.DstIdentity = serverID.ID
+			flow.addrInfo.DstSecIdentity = serverID
+		}
 	}
 
 	if dnsMsgDetails.Response && dnsMsgDetails.RCode == dns.RcodeSuccess && len(dnsMsgDetails.ResponseIPs) > 0 {

--- a/pkg/fqdn/messagehandler/message_handler_test.go
+++ b/pkg/fqdn/messagehandler/message_handler_test.go
@@ -144,8 +144,8 @@ func BenchmarkNotifyOnDNSMsg(b *testing.B) {
 				// parameter is only used in logging. Not using the endpoint's IP
 				// so we don't spend any time in the benchmark on converting from
 				// net.IP to string.
-				require.NoError(b, handler.NotifyOnDNSMsg(time.Now(), ep, "10.96.64.8:12345", 0, srvAddr, ciliumMsgDetails, "udp", true, emptyPRCtx))
-				require.NoError(b, handler.NotifyOnDNSMsg(time.Now(), ep, "10.96.64.4:54321", 0, srvAddr, ebpfMsgDetails, "udp", true, emptyPRCtx))
+				require.NoError(b, handler.NotifyOnDNSMsg(time.Now(), ep, "10.96.64.8:12345", nil, srvAddr, ciliumMsgDetails, "udp", true, emptyPRCtx))
+				require.NoError(b, handler.NotifyOnDNSMsg(time.Now(), ep, "10.96.64.4:54321", nil, srvAddr, ebpfMsgDetails, "udp", true, emptyPRCtx))
 			})
 		}
 		wg.Wait()

--- a/pkg/fqdn/service/service.go
+++ b/pkg/fqdn/service/service.go
@@ -696,7 +696,9 @@ func (s *FQDNDataServer) UpdateMappingRequest(ctx context.Context, mappings *pb.
 
 	msgDetails, serverAddrPort, epIPPort, serverID, protocol, allowed := s.reconstructNotifyArgs(mappings, sourceIP)
 
-	if err := s.updateOnDNSMsg.NotifyOnDNSMsg(now, ep, epIPPort, serverID, serverAddrPort, msgDetails, protocol, allowed, &stat); err != nil {
+	serverIdentity := &identity.Identity{ID: serverID}
+
+	if err := s.updateOnDNSMsg.NotifyOnDNSMsg(now, ep, epIPPort, serverIdentity, serverAddrPort, msgDetails, protocol, allowed, &stat); err != nil {
 		s.log.Error("Failed to process DNS message",
 			logfields.Error, err,
 			logfields.DNSName, mappings.GetFqdn(),

--- a/standalone-dns-proxy/pkg/lookup/lookup.go
+++ b/standalone-dns-proxy/pkg/lookup/lookup.go
@@ -37,6 +37,13 @@ func (r *rulesClient) LookupByIdentity(nid identity.NumericIdentity) []string {
 	return []string{}
 }
 
+// LookupIdentityByID returns a numeric-only identity for the given numeric identity. The standalone
+// DNS proxy does not have access to the identity allocator (and therefore to the labels), so the
+// numeric identity is propagated to the agent, which resolves the labels on its side.
+func (r *rulesClient) LookupIdentityByID(ctx context.Context, nid identity.NumericIdentity) *identity.Identity {
+	return &identity.Identity{ID: nid}
+}
+
 // Note: isHost is always false because the standalone DNS proxy does not handle host endpoints yet.
 func (r *rulesClient) LookupRegisteredEndpoint(endpointAddr netip.Addr) (endpt *endpoint.Endpoint, isHost bool, err error) {
 	info, _, found := r.ipToIdentityTable.Get(r.db.ReadTxn(), client.IdIPToEndpointIndex.Query(endpointAddr))

--- a/standalone-dns-proxy/pkg/messagehandler/messagehandler.go
+++ b/standalone-dns-proxy/pkg/messagehandler/messagehandler.go
@@ -31,7 +31,7 @@ type messageHandler struct {
 // This method always sends the gRPC message to the agent, even in error cases
 // (e.g. ep == nil, timeout, proxy errors), so that the agent can emit the
 // corresponding proxy metrics for every DNS event.
-func (m *messageHandler) NotifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID identity.NumericIdentity, serverAddrPort netip.AddrPort, details *dnsproxy.MsgDetails, protocol string, allowed bool, stat *dnsproxy.ProxyRequestContext) error {
+func (m *messageHandler) NotifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpoint, epIPPort string, serverID *identity.Identity, serverAddrPort netip.AddrPort, details *dnsproxy.MsgDetails, protocol string, allowed bool, stat *dnsproxy.ProxyRequestContext) error {
 	var ips [][]byte
 	for _, i := range details.ResponseIPs {
 		ips = append(ips, []byte(i.String()))
@@ -41,6 +41,11 @@ func (m *messageHandler) NotifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpo
 	sourceIdentity := m.getSourceIdentity(ep)
 
 	errorType, errorMessage := classifyProxyError(stat)
+
+	var serverNID identity.NumericIdentity
+	if serverID != nil {
+		serverNID = serverID.ID
+	}
 
 	message := &pb.FQDNMapping{
 		Fqdn:           details.QName,
@@ -65,7 +70,7 @@ func (m *messageHandler) NotifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpo
 			},
 			SourcePort:     sourcePort,
 			ServerAddr:     serverAddrPort.String(),
-			ServerIdentity: serverID.Uint32(),
+			ServerIdentity: serverNID.Uint32(),
 			Protocol:       protocol,
 			Allowed:        allowed,
 			ErrorMessage:   errorMessage,

--- a/standalone-dns-proxy/pkg/messagehandler/messagehandler_test.go
+++ b/standalone-dns-proxy/pkg/messagehandler/messagehandler_test.go
@@ -97,7 +97,7 @@ func TestNotifyOnDNSMsg(t *testing.T) {
 		details   *dnsproxy.MsgDetails
 		epIPPort  string
 		server    string
-		serverID  identity.NumericIdentity
+		serverID  *identity.Identity
 		protocol  string
 		allowed   bool
 		stat      *dnsproxy.ProxyRequestContext
@@ -112,7 +112,7 @@ func TestNotifyOnDNSMsg(t *testing.T) {
 			details:  buildResponseDetails(),
 			epIPPort: "10.1.1.10:5353",
 			server:   "8.8.8.8:53",
-			serverID: identity.NumericIdentity(42),
+			serverID: &identity.Identity{ID: 42},
 			protocol: "tcp",
 			allowed:  false,
 			stat:     buildStatWithTimings(),


### PR DESCRIPTION
The DNS proxy access-log path re-resolved the DNS server's security identity (labels) through the identity allocator on every DNS event, once when handling the request and once for the response. This lookup ran even for requests denied by policy, adding latency to the deny response.

Resolve the server's full identity once in the DNS proxy, after the request is allowed, and thread it through `NotifyOnDNSMsg` so the access-log path reuses the already-resolved labels instead of looking them up again. A numeric-only identity is constructed up front and reused for the deny and error paths, and upgraded in place to the full identity on the allowed path. Standalone DNS proxy traffic keeps resolving labels in the agent, since labels cannot be threaded across the gRPC boundary.

There are couple of things to note for the issue:
 - Source identity is not affected: The client (source) security identity is already resolved from the local endpoint lookup, so source labels are never resolved through the identity allocator. This change concerns only the destination (DNS server) identity, which was the one being resolved twice.
- Trade-off on lookup failure: On the happy path this reduces the destination label lookups from two to one. However, the single up-front resolution is best-effort: if it fails (cache miss or timeout), the access-log path still falls back to resolving the labels itself on each record. In that worst case we incur one extra lookup (three instead of two) that did not exist before i.e the cost of the fallback, in exchange for the common-case saving.

Fixes: #47279

AIL: 2

```release-note
fqdn: resolve DNS server identity once for access logging
```