### PR TITLE
ipam: Exclude hostNetwork pods from pending surge allocation

### DIFF
--- a/operator/pkg/ipam/nodemanager/node.go
+++ b/operator/pkg/ipam/nodemanager/node.go
@@ -379,7 +379,7 @@ func getPendingPodCount(nodeName string) (int, error) {
 	}
 	for _, pod := range values {
 		p := pod.(*v1.Pod)
-		if p.Status.Phase == v1.PodPending {
+		if p.Status.Phase == v1.PodPending && !p.Spec.HostNetwork {
 			pendingPods++
 		}
 	}


### PR DESCRIPTION
The HostNetwork pods briefly enter Pending Phase but do not consume IPs.Counting them inflated surgeAllocate and caused unnecessary IP pre-allocation.

```release-note
Fix abnormal ip allocation caused by hostnetwork pod
```