### PR TITLE
gateway-api: skip proxy_protocol filter for GAMMA CECs

### DIFF
--- a/operator/pkg/gateway-api/gamma_reconcile_test.go
+++ b/operator/pkg/gateway-api/gamma_reconcile_test.go
@@ -68,6 +68,30 @@ func Test_gammaReconciler_Reconcile(t *testing.T) {
 		},
 	})
 
+	cecTranslatorWithProxy := translation.NewCECTranslator(translation.Config{
+		RouteConfig: translation.RouteConfig{
+			HostNameSuffixMatch: true,
+		},
+		ListenerConfig: translation.ListenerConfig{
+			UseProxyProtocol:         true,
+			StreamIdleTimeoutSeconds: 300,
+		},
+		ClusterConfig: translation.ClusterConfig{
+			IdleTimeoutSeconds: 60,
+		},
+		OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
+			UseRemoteAddress: true,
+		},
+	})
+	proxyProtocolTranslator := gatewayApiTranslation.NewTranslator(cecTranslatorWithProxy, translation.Config{
+		ServiceConfig: translation.ServiceConfig{
+			ExternalTrafficPolicy: string(corev1.ServiceExternalTrafficPolicyCluster),
+		},
+		OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
+			UseRemoteAddress: true,
+		},
+	})
+
 	tests := []struct {
 		name       string
 		serviceKey []types.NamespacedName
@@ -173,4 +197,40 @@ func Test_gammaReconciler_Reconcile(t *testing.T) {
 			}
 		})
 	}
+
+	// Regression test for #47500.
+	t.Run("proxy-protocol-not-injected", func(t *testing.T) {
+		serviceKey := serviceKeyEcho
+
+		base := readInputDir(t, "testdata/gamma/base")
+		input := readInputDir(t, "testdata/gamma/mesh-basic/input")
+
+		c := fake.NewClientBuilder().
+			WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+			WithObjects(append(base, input...)...).
+			WithIndex(&gatewayv1.HTTPRoute{}, indexers.GammaHTTPRouteParentRefsIndex, indexers.IndexHTTPRouteByGammaService).
+			WithIndex(&gatewayv1.GRPCRoute{}, indexers.GammaGRPCRouteParentRefsIndex, indexers.IndexGRPCRouteByGammaService).
+			WithStatusSubresource(&corev1.Service{}).
+			WithStatusSubresource(&gatewayv1.HTTPRoute{}).
+			WithStatusSubresource(&gatewayv1.GRPCRoute{}).
+			Build()
+
+		r := &gammaReconciler{
+			Client:         c,
+			translator:     proxyProtocolTranslator,
+			logger:         logger,
+			controllerName: defaultControllerName,
+		}
+
+		result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: serviceKey})
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result)
+
+		actualCEC := &ciliumv2.CiliumEnvoyConfig{}
+		err = c.Get(t.Context(), serviceKey, actualCEC)
+		require.NoError(t, err)
+		expectedCEC := &ciliumv2.CiliumEnvoyConfig{}
+		readOutput(t, "testdata/gamma/mesh-basic/output/cec-echo.yaml", expectedCEC)
+		require.Empty(t, cmp.Diff(expectedCEC, actualCEC, protocmp.Transform()))
+	})
 }

--- a/operator/pkg/gateway-api/gamma_reconcile_test.go
+++ b/operator/pkg/gateway-api/gamma_reconcile_test.go
@@ -198,7 +198,6 @@ func Test_gammaReconciler_Reconcile(t *testing.T) {
 		})
 	}
 
-	// Regression test for #47500.
 	t.Run("proxy-protocol-not-injected", func(t *testing.T) {
 		serviceKey := serviceKeyEcho
 

--- a/operator/pkg/gateway-api/gamma_reconcile_test.go
+++ b/operator/pkg/gateway-api/gamma_reconcile_test.go
@@ -58,9 +58,16 @@ func Test_gammaReconciler_Reconcile(t *testing.T) {
 			UseRemoteAddress: true,
 		},
 	})
-	gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator, translation.Config{
-		ServiceConfig: translation.ServiceConfig{
-			ExternalTrafficPolicy: string(corev1.ServiceExternalTrafficPolicyCluster),
+	cecTranslatorWithProxy := translation.NewCECTranslator(translation.Config{
+		RouteConfig: translation.RouteConfig{
+			HostNameSuffixMatch: true,
+		},
+		ListenerConfig: translation.ListenerConfig{
+			UseProxyProtocol:         true,
+			StreamIdleTimeoutSeconds: 300,
+		},
+		ClusterConfig: translation.ClusterConfig{
+			IdleTimeoutSeconds: 60,
 		},
 		OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
 			UseRemoteAddress: true,
@@ -68,11 +75,13 @@ func Test_gammaReconciler_Reconcile(t *testing.T) {
 	})
 
 	tests := []struct {
-		name       string
-		serviceKey []types.NamespacedName
-		wantErr    bool
+		name          string
+		serviceKey    []types.NamespacedName
+		wantErr       bool
+		proxyProtocol bool
 	}{
 		{name: "mesh-basic", serviceKey: []types.NamespacedName{serviceKeyEcho}},
+		{name: "mesh-proxy-protocol", serviceKey: []types.NamespacedName{serviceKeyEcho}, proxyProtocol: true},
 		{name: "mesh-split", serviceKey: []types.NamespacedName{serviceKeyEcho}},
 		{name: "mesh-frontend", serviceKey: []types.NamespacedName{serviceKeyEchoV2}},
 		{name: "mesh-matching", serviceKey: []types.NamespacedName{serviceKeyEcho}},
@@ -106,6 +115,19 @@ func Test_gammaReconciler_Reconcile(t *testing.T) {
 						WithStatusSubresource(&gatewayv1.GRPCRoute{}).
 						WithInterceptorFuncs(typeMetaInterceptor(scheme)).
 						Build()
+
+					selectedCECTranslator := cecTranslator
+					if tt.proxyProtocol {
+						selectedCECTranslator = cecTranslatorWithProxy
+					}
+					gatewayAPITranslator := gatewayApiTranslation.NewTranslator(selectedCECTranslator, translation.Config{
+						ServiceConfig: translation.ServiceConfig{
+							ExternalTrafficPolicy: string(corev1.ServiceExternalTrafficPolicyCluster),
+						},
+						OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
+							UseRemoteAddress: true,
+						},
+					})
 
 					r := &gammaReconciler{
 						client:         c,

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -6,6 +6,7 @@ package gateway_api
 import (
 	"fmt"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
@@ -614,6 +615,98 @@ func Test_Conformance(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGatewayReconciler_ProxyProtocolInjected(t *testing.T) {
+	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+
+	cecTranslatorWithProxy := translation.NewCECTranslator(translation.Config{
+		SecretsNamespace: "cilium-secrets",
+		RouteConfig: translation.RouteConfig{
+			HostNameSuffixMatch: true,
+		},
+		ListenerConfig: translation.ListenerConfig{
+			UseProxyProtocol:         true,
+			StreamIdleTimeoutSeconds: 300,
+		},
+		ClusterConfig: translation.ClusterConfig{
+			IdleTimeoutSeconds: 60,
+		},
+		OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
+			UseRemoteAddress: true,
+		},
+	})
+
+	gatewayKey := types.NamespacedName{Name: "same-namespace", Namespace: "gateway-conformance-infra"}
+	cecKey := types.NamespacedName{Name: "cilium-gateway-same-namespace", Namespace: "gateway-conformance-infra"}
+
+	base := readInputDir(t, "testdata/gateway/base")
+	input := readInputDir(t, "testdata/gateway/httproute-simple-same-namespace/input")
+
+	c := fake.NewClientBuilder().
+		WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+		WithObjects(append(base, input...)...).
+		WithIndex(&gatewayv1.HTTPRoute{}, indexers.GatewayHTTPRouteIndex, indexers.IndexHTTPRouteByGateway).
+		WithIndex(&gatewayv1.HTTPRoute{}, indexers.BackendServiceHTTPRouteIndex, fakeIndexHTTPRouteByBackendService).
+		WithIndex(&gatewayv1.GRPCRoute{}, indexers.GatewayGRPCRouteIndex, indexers.IndexGRPCRouteByGateway).
+		WithIndex(&gatewayv1.TLSRoute{}, indexers.GatewayTLSRouteIndex, indexers.IndexTLSRouteByGateway).
+		WithIndex(&gatewayv1.TCPRoute{}, indexers.GatewayTCPRouteIndex, indexers.IndexTCPRouteByGateway).
+		WithIndex(&gatewayv1.UDPRoute{}, indexers.GatewayUDPRouteIndex, indexers.IndexUDPRouteByGateway).
+		WithIndex(&gatewayv1.ListenerSet{}, indexers.ListenerSetGatewayIndex, indexers.IndexListenerSetByGateway).
+		WithIndex(&gatewayv1.HTTPRoute{}, indexers.HTTPRouteListenerSetIndex, indexers.IndexHTTPRouteByListenerSet).
+		WithIndex(&gatewayv1.GRPCRoute{}, indexers.GRPCRouteListenerSetIndex, indexers.IndexGRPCRouteByListenerSet).
+		WithIndex(&gatewayv1.TLSRoute{}, indexers.TLSRouteListenerSetIndex, indexers.IndexTLSRouteByListenerSet).
+		WithIndex(&gatewayv1.TCPRoute{}, indexers.TCPRouteListenerSetIndex, indexers.IndexTCPRouteByListenerSet).
+		WithIndex(&gatewayv1.UDPRoute{}, indexers.UDPRouteListenerSetIndex, indexers.IndexUDPRouteByListenerSet).
+		WithStatusSubresource(&corev1.Service{}).
+		WithStatusSubresource(&corev1.Namespace{}).
+		WithStatusSubresource(&gatewayv1.Gateway{}).
+		WithStatusSubresource(&gatewayv1.GatewayClass{}).
+		WithStatusSubresource(&gatewayv1.HTTPRoute{}).
+		WithStatusSubresource(&gatewayv1.GRPCRoute{}).
+		WithStatusSubresource(&gatewayv1.TLSRoute{}).
+		WithStatusSubresource(&gatewayv1.TCPRoute{}).
+		WithStatusSubresource(&gatewayv1.UDPRoute{}).
+		WithStatusSubresource(&gatewayv1.ListenerSet{}).
+		Build()
+
+	gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslatorWithProxy, translation.Config{
+		ServiceConfig: translation.ServiceConfig{
+			ExternalTrafficPolicy: string(corev1.ServiceExternalTrafficPolicyCluster),
+		},
+		OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
+			UseRemoteAddress: true,
+		},
+	})
+
+	r := &gatewayReconciler{
+		Client:         c,
+		translator:     gatewayAPITranslator,
+		logger:         logger,
+		controllerName: defaultControllerName,
+	}
+
+	result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: gatewayKey})
+	require.NoError(t, err)
+	require.Equal(t, ctrl.Result{}, result)
+
+	actualCEC := &ciliumv2.CiliumEnvoyConfig{}
+	err = c.Get(t.Context(), cecKey, actualCEC)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, actualCEC.Spec.Resources)
+
+	var foundProxyProtocol bool
+	for _, res := range actualCEC.Spec.Resources {
+		if res.TypeUrl == "type.googleapis.com/envoy.config.listener.v3.Listener" {
+			if strings.Contains(string(res.Value), "envoy.filters.listener.proxy_protocol") {
+				foundProxyProtocol = true
+				break
+			}
+		}
+	}
+	require.True(t, foundProxyProtocol,
+		"Gateway CEC must contain proxy_protocol listener filter when UseProxyProtocol is enabled")
 }
 
 func Test_grpcWebTranslationEnabled(t *testing.T) {

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -88,6 +88,22 @@ func Test_Conformance(t *testing.T) {
 			UseRemoteAddress: true,
 		},
 	})
+	cecTranslatorWithProxy := translation.NewCECTranslator(translation.Config{
+		SecretsNamespace: "cilium-secrets",
+		RouteConfig: translation.RouteConfig{
+			HostNameSuffixMatch: true,
+		},
+		ListenerConfig: translation.ListenerConfig{
+			UseProxyProtocol:         true,
+			StreamIdleTimeoutSeconds: 300,
+		},
+		ClusterConfig: translation.ClusterConfig{
+			IdleTimeoutSeconds: 60,
+		},
+		OriginalIPDetectionConfig: translation.OriginalIPDetectionConfig{
+			UseRemoteAddress: true,
+		},
+	})
 
 	type gwDetails struct {
 		FullName types.NamespacedName
@@ -111,6 +127,7 @@ func Test_Conformance(t *testing.T) {
 		wantErr              bool
 		hostNetwork          bool
 		nodeLabelSelector    metav1.LabelSelector
+		proxyProtocol        bool
 	}{
 		{
 			name: "gateway-http-listener-isolation",
@@ -392,6 +409,7 @@ func Test_Conformance(t *testing.T) {
 		{name: "listenerset-l4-namespace-isolation", skipCEC: true, gateway: []gwDetails{
 			{FullName: types.NamespacedName{Name: "l4-namespace-isolation", Namespace: "gateway-conformance-infra"}},
 		}},
+		{name: "proxy-protocol-enabled", proxyProtocol: true, gateway: []gwDetails{gatewaySameNamespace}},
 	}
 
 	for _, tt := range tests {
@@ -449,7 +467,11 @@ func Test_Conformance(t *testing.T) {
 
 			c := clientBuilder.Build()
 			nodeLabel := &slim_meta_v1.LabelSelector{MatchLabels: tt.nodeLabelSelector.MatchLabels}
-			gatewayAPITranslator := gatewayApiTranslation.NewTranslator(cecTranslator, translation.Config{
+			selectedCECTranslator := cecTranslator
+			if tt.proxyProtocol {
+				selectedCECTranslator = cecTranslatorWithProxy
+			}
+			gatewayAPITranslator := gatewayApiTranslation.NewTranslator(selectedCECTranslator, translation.Config{
 				ServiceConfig: translation.ServiceConfig{
 					ExternalTrafficPolicy: string(corev1.ServiceExternalTrafficPolicyCluster),
 				},

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-proxy-protocol/input/httproute-gateway-conformance-mesh-test.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-proxy-protocol/input/httproute-gateway-conformance-mesh-test.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: gateway-conformance-mesh-test
+  namespace: gateway-conformance-mesh
+spec:
+  parentRefs:
+  - group: ""
+    kind: Service
+    name: echo
+    port: 80
+  rules:
+  - backendRefs:
+    - name: echo-v1
+      port: 8080

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-proxy-protocol/output/cec-echo.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-proxy-protocol/output/cec-echo.yaml
@@ -1,0 +1,107 @@
+metadata:
+  creationTimestamp: null
+  annotations:
+    cec.cilium.io/use-original-source-address: "true"
+  labels:
+    gateway.networking.k8s.io/gateway-name: gateway-conformance-mesh-test
+  name: echo
+  namespace: gateway-conformance-mesh
+  ownerReferences:
+  - apiVersion: gateway.networking.k8s.io/v1
+    controller: true
+    kind: HTTPRoute
+    name: gateway-conformance-mesh-test
+    uid: ""
+  resourceVersion: "1"
+spec:
+  backendServices:
+  - name: echo-v1
+    namespace: gateway-conformance-mesh
+    number:
+    - "8080"
+  resources:
+  - '@type': type.googleapis.com/envoy.config.listener.v3.Listener
+    filterChains:
+    - filterChainMatch:
+        transportProtocol: raw_buffer
+      filters:
+      - name: envoy.filters.network.http_connection_manager
+        typedConfig:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          commonHttpProtocolOptions:
+            maxStreamDuration: 0s
+          httpFilters:
+          - name: envoy.filters.http.grpc_web
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+          - name: envoy.filters.http.grpc_stats
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+              emitFilterState: true
+              enableUpstreamStats: true
+          - name: envoy.filters.http.router
+            typedConfig:
+              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          internalAddressConfig: {}
+          rds:
+            routeConfigName: listener-insecure
+          statPrefix: listener-insecure
+          streamIdleTimeout: 300s
+          upgradeConfigs:
+          - upgradeType: websocket
+          useRemoteAddress: true
+    listenerFilters:
+    - name: envoy.filters.listener.tls_inspector
+      typedConfig:
+        '@type': type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+    name: listener
+    socketOptions:
+    - description: Enable TCP keep-alive (default to enabled)
+      intValue: "1"
+      level: "1"
+      name: "9"
+    - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+      intValue: "10"
+      level: "6"
+      name: "4"
+    - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+      intValue: "5"
+      level: "6"
+      name: "5"
+    - description: TCP keep-alive probe max failures.
+      intValue: "10"
+      level: "6"
+      name: "6"
+  - '@type': type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+    name: listener-insecure
+    virtualHosts:
+    - domains:
+      - '*'
+      name: '*'
+      routes:
+      - match:
+          prefix: /
+        route:
+          cluster: gateway-conformance-mesh:echo-v1:8080
+          maxStreamDuration:
+            maxStreamDuration: 0s
+  - '@type': type.googleapis.com/envoy.config.cluster.v3.Cluster
+    edsClusterConfig:
+      serviceName: gateway-conformance-mesh/echo-v1:8080
+    name: gateway-conformance-mesh:echo-v1:8080
+    outlierDetection:
+      splitExternalLocalOriginErrors: true
+    type: EDS
+    typedExtensionProtocolOptions:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        commonHttpProtocolOptions:
+          idleTimeout: 60s
+        useDownstreamProtocolConfig:
+          http2ProtocolOptions: {}
+  services:
+  - listener: ""
+    name: echo
+    namespace: gateway-conformance-mesh
+    ports:
+    - 80

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-proxy-protocol/output/httproute-gateway-conformance-mesh-test.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-proxy-protocol/output/httproute-gateway-conformance-mesh-test.yaml
@@ -1,0 +1,36 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  creationTimestamp: null
+  name: gateway-conformance-mesh-test
+  namespace: gateway-conformance-mesh
+  resourceVersion: "1000"
+spec:
+  parentRefs:
+    - group: ""
+      kind: Service
+      name: echo
+      port: 80
+  rules:
+    - backendRefs:
+        - name: echo-v1
+          port: 8080
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2025-06-19T03:48:45Z"
+          message: Accepted HTTPRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-06-19T03:48:45Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        group: ""
+        kind: Service
+        name: echo
+        port: 80

--- a/operator/pkg/gateway-api/testdata/gamma/mesh-proxy-protocol/output/service-echo.yaml
+++ b/operator/pkg/gateway-api/testdata/gamma/mesh-proxy-protocol/output/service-echo.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  name: echo
+  namespace: gateway-conformance-mesh
+  resourceVersion: "1000"
+spec:
+  ports:
+  - appProtocol: http
+    name: http
+    port: 80
+    targetPort: 80
+  - appProtocol: http
+    name: http-alt
+    port: 8080
+    targetPort: 8080
+  - name: https
+    port: 443
+    targetPort: 443
+  - name: tcp
+    port: 9090
+    targetPort: 0
+  - appProtocol: grpc
+    name: grpc
+    port: 7070
+    targetPort: 0
+  selector:
+    app: echo
+status:
+  conditions:
+  - lastTransitionTime: "2025-06-19T03:48:45Z"
+    message: Gamma Service has routes attached
+    reason: Accepted
+    status: "True"
+    type: gamma.cilium.io/GammaRoutesAttached
+  - lastTransitionTime: "2025-06-19T03:48:45Z"
+    message: Gamma Service has been programmed
+    reason: Programmed
+    status: "True"
+    type: gamma.cilium.io/GammaRoutesProgrammed
+  loadBalancer: {}

--- a/operator/pkg/gateway-api/testdata/gateway/proxy-protocol-enabled/input/proxy-protocol-enabled.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/proxy-protocol-enabled/input/proxy-protocol-enabled.yaml
@@ -1,0 +1,25 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: gateway-conformance-infra-test
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: same-namespace
+  rules:
+    - backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+spec:
+  type: LoadBalancer
+status:
+  loadBalancer:
+    ingress:
+      - ip: 172.18.255.196
+        ipMode: VIP

--- a/operator/pkg/gateway-api/testdata/gateway/proxy-protocol-enabled/output/cec-same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/proxy-protocol-enabled/output/cec-same-namespace.yaml
@@ -1,0 +1,108 @@
+metadata:
+  annotations:
+    cec.cilium.io/use-original-source-address: "false"
+  labels:
+    gateway.networking.k8s.io/gateway-name: same-namespace
+  name: cilium-gateway-same-namespace
+  namespace: gateway-conformance-infra
+  resourceVersion: 1
+  ownerReferences:
+    - apiVersion: gateway.networking.k8s.io/v1
+      controller: true
+      kind: Gateway
+      name: same-namespace
+spec:
+  backendServices:
+    - name: infra-backend-v1
+      namespace: gateway-conformance-infra
+      number:
+        - "8080"
+  resources:
+    - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+      filterChains:
+        - filterChainMatch:
+            transportProtocol: raw_buffer
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typedConfig:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                commonHttpProtocolOptions:
+                  maxStreamDuration: 0s
+                httpFilters:
+                  - name: envoy.filters.http.grpc_web
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.grpc_stats
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+                      emitFilterState: true
+                      enableUpstreamStats: true
+                  - name: envoy.filters.http.router
+                    typedConfig:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                internalAddressConfig: {}
+                rds:
+                  routeConfigName: listener-insecure
+                statPrefix: listener-insecure
+                streamIdleTimeout: 300s
+                upgradeConfigs:
+                  - upgradeType: websocket
+                useRemoteAddress: true
+      listenerFilters:
+        - name: envoy.filters.listener.proxy_protocol
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.proxy_protocol.v3.ProxyProtocol
+        - name: envoy.filters.listener.tls_inspector
+          typedConfig:
+            "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+      name: listener
+      socketOptions:
+        - description: Enable TCP keep-alive (default to enabled)
+          intValue: "1"
+          level: "1"
+          name: "9"
+        - description: TCP keep-alive idle time (in seconds) (defaults to 10s)
+          intValue: "10"
+          level: "6"
+          name: "4"
+        - description: TCP keep-alive probe intervals (in seconds) (defaults to 5s)
+          intValue: "5"
+          level: "6"
+          name: "5"
+        - description: TCP keep-alive probe max failures.
+          intValue: "10"
+          level: "6"
+          name: "6"
+    - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
+      name: listener-insecure
+      virtualHosts:
+        - domains:
+            - "*"
+          name: "*"
+          routes:
+            - match:
+                prefix: /
+              route:
+                cluster: gateway-conformance-infra:infra-backend-v1:8080
+                maxStreamDuration:
+                  maxStreamDuration: 0s
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      edsClusterConfig:
+        serviceName: gateway-conformance-infra/infra-backend-v1:8080
+      name: gateway-conformance-infra:infra-backend-v1:8080
+      outlierDetection:
+        splitExternalLocalOriginErrors: true
+      type: EDS
+      typedExtensionProtocolOptions:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          commonHttpProtocolOptions:
+            idleTimeout: 60s
+          useDownstreamProtocolConfig:
+            http2ProtocolOptions: {}
+  services:
+    - listener: ""
+      name: cilium-gateway-same-namespace
+      namespace: gateway-conformance-infra
+      ports:
+        - 80

--- a/operator/pkg/gateway-api/testdata/gateway/proxy-protocol-enabled/output/httproute-gateway-conformance-infra-test.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/proxy-protocol-enabled/output/httproute-gateway-conformance-infra-test.yaml
@@ -1,0 +1,28 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: gateway-conformance-infra-test
+  namespace: gateway-conformance-infra
+spec:
+  parentRefs:
+    - name: same-namespace
+  rules:
+    - backendRefs:
+        - name: infra-backend-v1
+          port: 8080
+status:
+  parents:
+    - conditions:
+        - lastTransitionTime: "2025-08-18T04:35:05Z"
+          message: Accepted HTTPRoute
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-08-18T04:35:05Z"
+          message: Service reference is valid
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+      controllerName: io.cilium/gateway-controller
+      parentRef:
+        name: same-namespace

--- a/operator/pkg/gateway-api/testdata/gateway/proxy-protocol-enabled/output/same-namespace.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/proxy-protocol-enabled/output/same-namespace.yaml
@@ -1,0 +1,54 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  annotations:
+  name: same-namespace
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - allowedRoutes:
+        namespaces:
+          from: Same
+      name: http
+      port: 80
+      protocol: HTTP
+status:
+  addresses:
+    - type: IPAddress
+      value: 172.18.255.196
+  conditions:
+    - lastTransitionTime: "2025-08-18T04:34:43Z"
+      message: Gateway successfully scheduled
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: "2025-08-18T04:35:05Z"
+      message: Gateway Programmed
+      reason: Programmed
+      status: "True"
+      type: Programmed
+  listeners:
+    - attachedRoutes: 1
+      conditions:
+        - lastTransitionTime: "2025-08-18T04:35:05Z"
+          message: Resolved Refs
+          reason: ResolvedRefs
+          status: "True"
+          type: ResolvedRefs
+        - lastTransitionTime: "2025-08-18T04:35:05Z"
+          message: Listener Accepted
+          reason: Accepted
+          status: "True"
+          type: Accepted
+        - lastTransitionTime: "2025-08-18T04:35:05Z"
+          message: Listener Programmed
+          reason: Programmed
+          status: "True"
+          type: Programmed
+      name: http
+      supportedKinds:
+        - group: gateway.networking.k8s.io
+          kind: HTTPRoute
+        - group: gateway.networking.k8s.io
+          kind: GRPCRoute

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -747,6 +747,15 @@ func (m *Model) IsEmpty() bool {
 	return len(m.HTTP) == 0 && len(m.TLSPassthrough) == 0 && len(m.L4) == 0
 }
 
+func (m *Model) IsGamma() bool {
+	for _, l := range m.HTTP {
+		if l.Gamma {
+			return true
+		}
+	}
+	return false
+}
+
 // IsHTTPListenerConfigured returns true if the model has any HTTP listeners.
 func (m *Model) IsHTTPListenerConfigured() bool {
 	return len(m.HTTP) > 0

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -824,6 +824,15 @@ func (m *Model) IsEmpty() bool {
 	return len(m.HTTP) == 0 && len(m.TLSPassthrough) == 0 && len(m.L4) == 0
 }
 
+func (m *Model) IsGamma() bool {
+	for _, l := range m.HTTP {
+		if l.Gamma {
+			return true
+		}
+	}
+	return false
+}
+
 // IsHTTPListenerConfigured returns true if the model has any HTTP listeners.
 func (m *Model) IsHTTPListenerConfigured() bool {
 	return len(m.HTTP) > 0

--- a/operator/pkg/model/translation/cec_translator.go
+++ b/operator/pkg/model/translation/cec_translator.go
@@ -292,13 +292,7 @@ func (i *cecTranslator) desiredResources(m *model.Model) ([]ciliumv2.XDSResource
 }
 
 func (i *cecTranslator) shouldUseOriginalSourceAddress(m *model.Model) bool {
-	for _, l := range m.HTTP {
-		if l.Gamma {
-			return true
-		}
-	}
-
-	return false
+	return m.IsGamma()
 }
 
 func (i *cecTranslator) desiredNodeSelector() *slim_metav1.LabelSelector {

--- a/operator/pkg/model/translation/cec_translator.go
+++ b/operator/pkg/model/translation/cec_translator.go
@@ -293,13 +293,7 @@ func (i *cecTranslator) desiredResources(m *model.Model) ([]ciliumv2.XDSResource
 }
 
 func (i *cecTranslator) shouldUseOriginalSourceAddress(m *model.Model) bool {
-	for _, l := range m.HTTP {
-		if l.Gamma {
-			return true
-		}
-	}
-
-	return false
+	return m.IsGamma()
 }
 
 func (i *cecTranslator) desiredNodeSelector() *slim_metav1.LabelSelector {

--- a/operator/pkg/model/translation/cec_translator_test.go
+++ b/operator/pkg/model/translation/cec_translator_test.go
@@ -376,10 +376,6 @@ func TestSharedIngressTranslator_getListenerProxy(t *testing.T) {
 	require.Equal(t, []string{proxyProtocolType, tlsInspectorType}, listenerNames)
 }
 
-// TestSharedIngressTranslator_getListenerProxy_GammaNotInjected verifies that when
-// UseProxyProtocol is true, GAMMA (Service-parented) listeners do not receive the
-// proxy_protocol listener filter. Pod-to-pod traffic never carries PROXY protocol
-// headers; injecting the filter causes Envoy to RST every connection.
 func TestSharedIngressTranslator_getListenerProxy_GammaNotInjected(t *testing.T) {
 	i := &cecTranslator{
 		Config: Config{

--- a/operator/pkg/model/translation/cec_translator_test.go
+++ b/operator/pkg/model/translation/cec_translator_test.go
@@ -376,6 +376,41 @@ func TestSharedIngressTranslator_getListenerProxy(t *testing.T) {
 	require.Equal(t, []string{proxyProtocolType, tlsInspectorType}, listenerNames)
 }
 
+// TestSharedIngressTranslator_getListenerProxy_GammaNotInjected verifies that when
+// UseProxyProtocol is true, GAMMA (Service-parented) listeners do not receive the
+// proxy_protocol listener filter. Pod-to-pod traffic never carries PROXY protocol
+// headers; injecting the filter causes Envoy to RST every connection.
+func TestSharedIngressTranslator_getListenerProxy_GammaNotInjected(t *testing.T) {
+	i := &cecTranslator{
+		Config: Config{
+			SecretsNamespace: "cilium-secrets",
+			ListenerConfig: ListenerConfig{
+				UseProxyProtocol: true,
+			},
+		},
+	}
+	res, err := i.desiredEnvoyListener(&model.Model{
+		HTTP: []model.HTTPListener{
+			{
+				Gamma: true,
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+
+	listener := &envoy_config_listener.Listener{}
+	err = proto.Unmarshal(res[0].GetValue(), listener)
+	require.NoError(t, err)
+
+	listenerNames := []string{}
+	for _, l := range listener.ListenerFilters {
+		listenerNames = append(listenerNames, l.Name)
+	}
+	require.NotContains(t, listenerNames, proxyProtocolType,
+		"GAMMA CEC must not contain proxy_protocol listener filter")
+}
+
 func TestSharedIngressTranslator_getListener(t *testing.T) {
 	i := &cecTranslator{
 		Config: Config{

--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -553,7 +553,7 @@ func (i *cecTranslator) listenerMutatorsForPorts(m *model.Model, ports []uint32)
 			defaultTCPKeepAliveProbeIntervalInSeconds,
 			defaultTCPKeepAliveMaxFailures),
 	}
-	if i.Config.ListenerConfig.UseProxyProtocol {
+	if i.Config.ListenerConfig.UseProxyProtocol && !m.IsGamma() {
 		res = append(res, withProxyProtocol())
 	}
 

--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -553,7 +553,12 @@ func (i *cecTranslator) listenerMutatorsForPorts(m *model.Model, ports []uint32)
 			defaultTCPKeepAliveProbeIntervalInSeconds,
 			defaultTCPKeepAliveMaxFailures),
 	}
-	if i.Config.ListenerConfig.UseProxyProtocol {
+	// PROXY protocol headers are injected by the load balancer on north-south Gateway paths.
+	// GAMMA (Service-parented) traffic is pod-to-pod and never carries them; applying the
+	// filter would cause Envoy to RST every connection. GAMMA and non-GAMMA listeners are
+	// never mixed in one model (separate reconcilers), so shouldUseOriginalSourceAddress is
+	// a safe proxy for the GAMMA check here.
+	if i.Config.ListenerConfig.UseProxyProtocol && !i.shouldUseOriginalSourceAddress(m) {
 		res = append(res, withProxyProtocol())
 	}
 

--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -553,12 +553,7 @@ func (i *cecTranslator) listenerMutatorsForPorts(m *model.Model, ports []uint32)
 			defaultTCPKeepAliveProbeIntervalInSeconds,
 			defaultTCPKeepAliveMaxFailures),
 	}
-	// PROXY protocol headers are injected by the load balancer on north-south Gateway paths.
-	// GAMMA (Service-parented) traffic is pod-to-pod and never carries them; applying the
-	// filter would cause Envoy to RST every connection. GAMMA and non-GAMMA listeners are
-	// never mixed in one model (separate reconcilers), so shouldUseOriginalSourceAddress is
-	// a safe proxy for the GAMMA check here.
-	if i.Config.ListenerConfig.UseProxyProtocol && !i.shouldUseOriginalSourceAddress(m) {
+	if i.Config.ListenerConfig.UseProxyProtocol && !m.IsGamma() {
 		res = append(res, withProxyProtocol())
 	}
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
- [x] Thanks for contributing!

---

## Summary

When `gatewayAPI.enableProxyProtocol=true` is set, the Gateway API controller unconditionally appends `envoy.filters.listener.proxy_protocol` to **every** generated `CiliumEnvoyConfig`, including those for GAMMA (east-west, Service-parented) routes.

Cilium's BPF datapath redirects packets to Envoy transparently at L3/L4. When Envoy's `proxy_protocol` listener filter reads the first bytes and finds no `PROXY v1/v2` signature, it immediately closes the connection with a TCP RST. This breaks all L7 east-west mesh traffic with no per-route workaround.

The fix gates `withProxyProtocol()` on `!m.IsGamma()` to avoid injecting PROXY protocol filters to GAMMA routes.

> [!NOTE]
> **AI Disclosure (AIL:3):** I identified, reproduced, and traced the root cause on a live EKS cluster. An LLM assisted with code authoring and test writing under my full review. Investigation notes and reproduction logs are available in the linked issue.

## Changes

- Add `Model.IsGamma()` predicate and gate `withProxyProtocol()` on `!m.IsGamma()` in `listenerMutatorsForPorts`
- Deduplicate the existing Gamma check in `shouldUseOriginalSourceAddress` to use the new predicate
- Added YAML testdata scenarios to gate against the issue (Gateway with `UseProxyProtocol` enabled, GAMMA with proxy protocol skipped).

Fixes: #47500

```release-note
Fix `proxy_protocol` listener filter incorrectly injected into GAMMA CiliumEnvoyConfigs when `gatewayAPI.enableProxyProtocol` is enabled
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer's Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
