### PR TITLE
bpf/tests: remove stale make run references

### DIFF
--- a/bpf/tests/Makefile
+++ b/bpf/tests/Makefile
@@ -27,7 +27,7 @@ SCAPY_CORE := $(wildcard $(ROOT_DIR)/bpf/tests/scapy/*.py)
 SCAPY_HDR := $(ROOT_DIR)/bpf/tests/output/scapy_bytes.h
 
 
-.PHONY: all clean run
+.PHONY: all clean
 
 ALL_TEST_OBJECTS = $(patsubst %.c, %.o, $(wildcard *.c))
 

--- a/bpf/tests/scapy/README.md
+++ b/bpf/tests/scapy/README.md
@@ -68,10 +68,21 @@ index 3f9303e46e..6193bf9200 100644
 
 </details>
 
-Do a run `make run` and recover the trace:
+Start monitoring the `trace_pipe`:
 
 ```
-~/dev/cilium/bpf/tests$ cat output/trace_pipe.log | grep test
+sudo cat /sys/kernel/tracing/trace_pipe | grep test
+```
+
+From the repository root, run the BPF test in another terminal:
+
+```
+make run_bpf_tests BPF_TEST=tc_l2_announcement6
+```
+
+Recover the packet trace:
+
+```
 [...]
            <...>-2084557 [003] b..11 146984.634298: bpf_trace_printk: tc_l2_announcement6.c:98 test: pkt_hex Ether[3333ff000001deadbeefdeef86dd6000000000203a4020010000000000000000000000000001fd1000000000000000000000000000018700000040000000fd1000000000000000000000000000010101deadbeefdeef]
 ```


### PR DESCRIPTION
Commit '768b61c' removed the option to invoke BPF unit tests from bpf/tests folder itself (`make run`). Cleanup remaning references.

cc @gentoo-root 