### PR TITLE
hubble: ignore DNS names for IPs with many names

### DIFF
--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -525,6 +525,17 @@ func (c *DNSCache) LookupIP(ip netip.Addr) (names []string) {
 	return c.lookupIPByTime(c.lastCleanup, ip)
 }
 
+// CountNamesForIP returns the number of DNS names which include that IP (as in, the length of the
+// slice that LookupIP would return). This is useful for hubble, where displaying many domain names
+// for a single IP is useless, but memory-intensive.
+func (c *DNSCache) CountNamesForIP(ip netip.Addr) int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	cacheEntries := c.reverse[ip]
+	return len(cacheEntries)
+}
+
 // lookupIPByTime takes a timestamp for expiration comparisons, and is
 // only intended for testing.
 func (c *DNSCache) lookupIPByTime(now time.Time, ip netip.Addr) (names []string) {

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -227,6 +227,20 @@ func TestReverseUpdateLookup(t *testing.T) {
 	require.Empty(t, lookupNames, "Returned names for IP not in cache")
 }
 
+func TestCountNamesForIP(t *testing.T) {
+	cache := NewDNSCache(0)
+	sharedIP := netip.MustParseAddr("1.1.1.1")
+	otherIP := netip.MustParseAddr("2.2.2.2")
+
+	require.Zero(t, cache.CountNamesForIP(sharedIP))
+
+	cache.Update(time.Now(), "one.example.", []netip.Addr{sharedIP}, 60)
+	cache.Update(time.Now(), "two.example.", []netip.Addr{sharedIP, otherIP}, 60)
+
+	require.Equal(t, 2, cache.CountNamesForIP(sharedIP))
+	require.Equal(t, 1, cache.CountNamesForIP(otherIP))
+}
+
 func TestJSONMarshal(t *testing.T) {
 	names := map[string]netip.Addr{
 		"test1.com": netip.MustParseAddr("2.2.2.1"),

--- a/pkg/hubble/parser/cell/cell.go
+++ b/pkg/hubble/parser/cell/cell.go
@@ -151,8 +151,18 @@ func (h *payloadGetters) GetNamesOf(sourceEpID uint32, ip netip.Addr) []string {
 	if !ip.IsValid() {
 		return nil
 	}
-	names := ep.DNSHistory.LookupIP(ip)
-
+	var names []string
+	// The reverse lookup of DNS names by IP to store in a flow is only useful
+	// if a small number of domains maps to that IP. We don't want to allocate
+	// potentially large slices of domain names which are then retained due to
+	// the ringbuffer, see cilium/cilium#47128.
+	//
+	// Note that this is TOCTOU racy - there's no guarantee that we don't get
+	// more than 9 domain names back, as concurrent processing may introduce a
+	// new mapping including this IP. That's fine, though.
+	if ep.DNSHistory.CountNamesForIP(ip) < 10 {
+		names = ep.DNSHistory.LookupIP(ip)
+	}
 	for i := range names {
 		names[i] = strings.TrimSuffix(names[i], ".")
 	}


### PR DESCRIPTION
Hubble flows can be enriched with DNS names via a reverse lookup IP -> DNS names. The DNS names are stored as a slice of strings directly in the hubble flow. In the egde case of thousands of DNS subdomains mapping to a single IP, this means allocating large slices of string for each flow. Since these flows are also retained in the hubble event ringbuffer, they baloon the memory usage of the agent.

I argue that storing more than 9 DNS names in a flow is not useful - we can't know which of the domains the flow actually goes to/comes from, hence the signal to noise ratio is not good even for a small number of domains. Hence, when the FQDN subsystem reports more DNS names for that IP, just don't report any.

This PR was prepared with AIL:1, I've had it review the code after writing it.

Fixes: #47128

```release-note
When toFQDN policies are used, Hubble flows involving an IP which is mapped to from many different domains would lead to excessive agent memory usage. These domains are no longer reported if there are more than ten mapping to an IP.  
```
