### PR TITLE
cilium-cli/utils/features: use netip.ParseAddr in GetIPFamily

### DIFF
--- a/cilium-cli/utils/features/utils.go
+++ b/cilium-cli/utils/features/utils.go
@@ -4,7 +4,6 @@
 package features
 
 import (
-	"net"
 	"net/netip"
 
 	"github.com/cilium/cilium/pkg/subnet/topology"
@@ -54,17 +53,16 @@ func NewIPFamily(s string) IPFamily {
 }
 
 func GetIPFamily(addr string) IPFamily {
-	ip := net.ParseIP(addr)
+	ip, err := netip.ParseAddr(addr)
+	if err != nil {
+		return IPFamilyAny
+	}
 
-	if ip.To4() != nil {
+	if ip.Unmap().Is4() {
 		return IPFamilyV4
 	}
 
-	if ip.To16() != nil {
-		return IPFamilyV6
-	}
-
-	return IPFamilyAny
+	return IPFamilyV6
 }
 
 // ComputeFailureExceptions computes a list of failure exceptions for various


### PR DESCRIPTION
## Description

`GetIPFamily` classified an address string using `net.ParseIP` followed by `To4()`/`To16()`. This converts it to `netip.ParseAddr` as part of the `net.IP` -> `netip.Addr` migration.

`ip.Unmap().Is4()` preserves the previous behaviour for v4-mapped v6 addresses (classified as v4), and an unparseable input still returns `IPFamilyAny` (previously `nil.To4()/To16()` both returned nil). `net` was only imported for this function, so the import is dropped. The signature is unchanged, so no callers are affected.

Related: #24246

```release-note
None
```