### PR TITLE
loadbalancer: format SkipLB addresses with netip

### DIFF
--- a/pkg/loadbalancer/redirectpolicy/skiplb.go
+++ b/pkg/loadbalancer/redirectpolicy/skiplb.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"iter"
 	"log/slog"
-	"net"
+	"net/netip"
 	"os"
 	"slices"
 	"sort"
@@ -418,7 +418,7 @@ func newSkipLBMapCommand(m lbmaps.SkipLBMap) hive.ScriptCmdsOut {
 				var out []string
 
 				for key := range m.AllLB4() {
-					addr := net.IP(key.Address[:])
+					addr := netip.AddrFrom4(key.Address)
 					out = append(out, fmt.Sprintf("COOKIE=%d IP=%s PORT=%d\n",
 						key.NetnsCookie,
 						addr,
@@ -426,7 +426,7 @@ func newSkipLBMapCommand(m lbmaps.SkipLBMap) hive.ScriptCmdsOut {
 					))
 				}
 				for key := range m.AllLB6() {
-					addr := net.IP(key.Address[:])
+					addr := netip.AddrFrom16(key.Address)
 					out = append(out, fmt.Sprintf("COOKIE=%d IP=%s PORT=%d\n",
 						key.NetnsCookie,
 						addr,


### PR DESCRIPTION
Replace the two SkipLB address formatting conversions with `netip.AddrFrom4` and `netip.AddrFrom16`. The command output remains unchanged.

Related: #24246

Test:
- `go test ./pkg/loadbalancer/redirectpolicy -run '^TestScript/(skiplb|skiplb-addr)\.txtar$' -count=1` in `golang:1.26.1-bookworm` as a non-root user

AI disclosure:
This PR was prepared with AIL:4. Codex identified and implemented this narrow mechanical refactor and ran the focused Linux test. I reviewed and approved the three-line code change and its test result.

- [x] I have read the contribution guide.
- [x] Existing IPv4 and IPv6 behavior is covered by focused tests.
- [x] The commit includes a description and issue reference.
- [x] The commit is signed off under the DCO.
- [x] The title is suitable for release notes.
- [x] AI use and influence level are disclosed.