### PR TITLE
linux/node: deallocate all IDs for deleted nodes

### DIFF
--- a/pkg/datapath/linux/node_ids.go
+++ b/pkg/datapath/linux/node_ids.go
@@ -161,33 +161,63 @@ func (n *linuxNodeHandler) allocateIDForNode(oldNode *nodeTypes.Node, node *node
 // deallocateIDForNode deallocates the node ID for the given node, if it was allocated.
 func (n *linuxNodeHandler) deallocateIDForNode(oldNode *nodeTypes.Node) error {
 	var errs error
-	nodeIPs := make(map[string]bool)
-	nodeID := n.getNodeIDForNode(oldNode)
+	nodeIPs := sets.New[string]()
+	nodeIPsInUse := sets.New[string]()
+	nodeIDs := sets.New[uint16]()
 
-	// Check that all node IDs of the node had the same node ID.
-	for _, addr := range oldNode.IPAddresses {
-		nodeIPs[addr.IP.String()] = true
-		id := n.nodeIDsByIPs[addr.IP.String()]
-		if nodeID != id {
-			n.log.Error("Found two node IDs for the same node",
-				logfields.First, id,
-				logfields.Second, nodeID,
-				logfields.NodeName, oldNode.Name,
-				logfields.IPAddr, addr.IP,
-			)
-			errs = errors.Join(errs, fmt.Errorf("found two node IDs (%d and %d) for the same node", id, nodeID))
+	for _, node := range n.nodes {
+		for _, addr := range node.IPAddresses {
+			nodeIPsInUse.Insert(addr.IP.String())
 		}
 	}
 
-	errs = errors.Join(n.deallocateNodeIDLocked(nodeID, nodeIPs, oldNode.Name))
+	// Check that all node IDs of the node had the same node ID.
+	var expectedNodeID uint16
+	for _, addr := range oldNode.IPAddresses {
+		ip := addr.IP.String()
+		// A stale delete event may contain an IP that has since been reused.
+		if nodeIPsInUse.Has(ip) {
+			continue
+		}
+
+		nodeIPs.Insert(ip)
+		id := n.nodeIDsByIPs[ip]
+		if id == uint16(idpool.NoID) {
+			continue
+		}
+		if expectedNodeID == uint16(idpool.NoID) {
+			expectedNodeID = id
+		} else if expectedNodeID != id {
+			n.log.Error("Found two node IDs for the same node",
+				logfields.First, id,
+				logfields.Second, expectedNodeID,
+				logfields.NodeName, oldNode.Name,
+				logfields.IPAddr, addr.IP,
+			)
+		}
+		nodeIDs.Insert(id)
+	}
+
+	for nodeID := range nodeIDs {
+		errs = errors.Join(errs, n.deallocateNodeIDLocked(nodeID, nodeIPs, nodeIPsInUse, oldNode.Name))
+	}
 	return errs
 }
 
-func (n *linuxNodeHandler) deallocateNodeIDLocked(nodeID uint16, nodeIPs map[string]bool, nodeName string) error {
+func (n *linuxNodeHandler) deallocateNodeIDLocked(
+	nodeID uint16,
+	nodeIPs sets.Set[string],
+	nodeIPsInUse sets.Set[string],
+	nodeName string,
+) error {
 	var errs error
 	for ip := range n.nodeIPsByIDs[nodeID] {
+		if nodeIPsInUse.Has(ip) {
+			continue
+		}
+
 		// Check that only IPs of this node had this node ID.
-		if _, isIPOfOldNode := nodeIPs[ip]; !isIPOfOldNode {
+		if !nodeIPs.Has(ip) {
 			n.log.Error("Found a foreign IP address with the ID of the current node",
 				logfields.NodeName, nodeName,
 				logfields.IPAddr, ip,
@@ -201,7 +231,12 @@ func (n *linuxNodeHandler) deallocateNodeIDLocked(nodeID uint16, nodeIPs map[str
 				logfields.NodeID, nodeID,
 				logfields.IPAddr, ip,
 			)
+			errs = errors.Join(errs, fmt.Errorf("failed to unmap node IP %s from node ID %d: %w", ip, nodeID, err))
 		}
+	}
+
+	if n.nodeIPsByIDs[nodeID].Len() != 0 {
+		return errs
 	}
 
 	if !n.nodeIDs.Insert(idpool.ID(nodeID)) {

--- a/pkg/datapath/linux/node_ids_deallocation_test.go
+++ b/pkg/datapath/linux/node_ids_deallocation_test.go
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package linux
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	fakeipsec "github.com/cilium/cilium/pkg/datapath/linux/ipsec/fake"
+	"github.com/cilium/cilium/pkg/idpool"
+	"github.com/cilium/cilium/pkg/kpr"
+	"github.com/cilium/cilium/pkg/maps/nodemap"
+	nodemapfake "github.com/cilium/cilium/pkg/maps/nodemap/fake"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/node/addressing"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+)
+
+func TestDeallocateIDsForNode(t *testing.T) {
+	t.Run("no allocated ID", func(t *testing.T) {
+		nodeMap := nodemapfake.NewFakeNodeMapV2()
+		handler := newNodeIDTestHandler(t, nodeMap)
+		node := nodeIDTestNode("node", "10.0.0.1")
+
+		require.NoError(t, deallocateNodeIDForTest(handler, &node))
+		require.False(t, handler.nodeIDs.Remove(idpool.NoID))
+	})
+
+	t.Run("single node ID", func(t *testing.T) {
+		nodeMap := nodemapfake.NewFakeNodeMapV2()
+		handler := newNodeIDTestHandler(t, nodeMap)
+		node := nodeIDTestNode("node", "10.0.0.1", "10.0.0.2")
+		nodeID := allocateNodeIDForTest(t, handler, &node)
+
+		require.NoError(t, deallocateNodeIDForTest(handler, &node))
+		requireNodeIDRemoved(t, handler, nodeMap, nodeID, "10.0.0.1", "10.0.0.2")
+	})
+
+	t.Run("multiple node IDs", func(t *testing.T) {
+		nodeMap := nodemapfake.NewFakeNodeMapV2()
+		handler, logs := newBufferedNodeIDTestHandler(t, nodeMap)
+		nodeIP1 := nodeIDTestNode("node-1", "10.0.0.1")
+		nodeIP2 := nodeIDTestNode("node-2", "10.0.0.2")
+		nodeID1 := allocateNodeIDForTest(t, handler, &nodeIP1)
+		nodeID2 := allocateNodeIDForTest(t, handler, &nodeIP2)
+		require.NotEqual(t, nodeID1, nodeID2)
+
+		node := nodeIDTestNode("node", "10.0.0.1", "10.0.0.2")
+		require.NoError(t, deallocateNodeIDForTest(handler, &node))
+		require.Contains(t, logs.String(), "Found two node IDs for the same node")
+		requireNodeIDRemoved(t, handler, nodeMap, nodeID1, "10.0.0.1")
+		requireNodeIDRemoved(t, handler, nodeMap, nodeID2, "10.0.0.2")
+	})
+
+	t.Run("mapped and unmapped IPs", func(t *testing.T) {
+		nodeMap := nodemapfake.NewFakeNodeMapV2()
+		handler, logs := newBufferedNodeIDTestHandler(t, nodeMap)
+		mappedNode := nodeIDTestNode("node", "10.0.0.2")
+		nodeID := allocateNodeIDForTest(t, handler, &mappedNode)
+
+		node := nodeIDTestNode("node", "10.0.0.1", "10.0.0.2")
+		require.NoError(t, deallocateNodeIDForTest(handler, &node))
+		require.NotContains(t, logs.String(), "Found two node IDs for the same node")
+		requireNodeIDRemoved(t, handler, nodeMap, nodeID, "10.0.0.2")
+	})
+
+	t.Run("stale foreign IP", func(t *testing.T) {
+		nodeMap := nodemapfake.NewFakeNodeMapV2()
+		handler := newNodeIDTestHandler(t, nodeMap)
+		node := nodeIDTestNode("node", "10.0.0.1")
+		nodeID := allocateNodeIDForTest(t, handler, &node)
+		mapNodeIDForTest(t, handler, "10.0.0.2", nodeID)
+
+		require.NoError(t, deallocateNodeIDForTest(handler, &node))
+		requireNodeIDRemoved(t, handler, nodeMap, nodeID, "10.0.0.1", "10.0.0.2")
+	})
+
+	t.Run("IP reused by live node", func(t *testing.T) {
+		nodeMap := nodemapfake.NewFakeNodeMapV2()
+		handler := newNodeIDTestHandler(t, nodeMap)
+		staleNode := nodeIDTestNode("stale-node", "10.0.0.1")
+		liveNode := nodeIDTestNode("live-node", "10.0.0.2")
+		staleNodeID := allocateNodeIDForTest(t, handler, &staleNode)
+		liveNodeID := allocateNodeIDForTest(t, handler, &liveNode)
+		addLiveNodeForTest(handler, &liveNode)
+
+		deletedNode := nodeIDTestNode("stale-node", "10.0.0.1", "10.0.0.2")
+		require.NoError(t, deallocateNodeIDForTest(handler, &deletedNode))
+		requireNodeIDRemoved(t, handler, nodeMap, staleNodeID, "10.0.0.1")
+		requireNodeIDPresent(t, handler, nodeMap, liveNodeID, "10.0.0.2")
+	})
+
+	t.Run("node ID shared with live node", func(t *testing.T) {
+		nodeMap := nodemapfake.NewFakeNodeMapV2()
+		handler := newNodeIDTestHandler(t, nodeMap)
+		staleNode := nodeIDTestNode("stale-node", "10.0.0.1")
+		liveNode := nodeIDTestNode("live-node", "10.0.0.2")
+		nodeID := allocateNodeIDForTest(t, handler, &staleNode)
+		mapNodeIDForTest(t, handler, "10.0.0.2", nodeID)
+		addLiveNodeForTest(handler, &liveNode)
+
+		require.NoError(t, deallocateNodeIDForTest(handler, &staleNode))
+		requireNodeIDMappingMissing(t, handler, nodeMap, "10.0.0.1")
+		requireNodeIDPresent(t, handler, nodeMap, nodeID, "10.0.0.2")
+	})
+
+	t.Run("BPF map delete failure", func(t *testing.T) {
+		nodeMap := nodemapfake.NewFakeNodeMapV2()
+		ip := netip.MustParseAddr("10.0.0.1")
+		handler := newNodeIDTestHandler(t, &deleteFailingNodeMap{
+			MapV2:  nodeMap,
+			failIP: ip,
+		})
+		node := nodeIDTestNode("node", ip.String())
+		nodeID := allocateNodeIDForTest(t, handler, &node)
+
+		err := deallocateNodeIDForTest(handler, &node)
+		require.ErrorContains(t, err, "failed to unmap node IP")
+		requireNodeIDPresent(t, handler, nodeMap, nodeID, ip.String())
+	})
+}
+
+type deleteFailingNodeMap struct {
+	nodemap.MapV2
+	failIP netip.Addr
+}
+
+type nodeMapLookup interface {
+	Lookup(netip.Addr) (*nodemap.NodeValueV2, error)
+}
+
+func (m *deleteFailingNodeMap) Delete(ip netip.Addr) error {
+	if ip == m.failIP {
+		return errors.New("test node map delete failure")
+	}
+	return m.MapV2.Delete(ip)
+}
+
+func newNodeIDTestHandler(t *testing.T, nodeMap nodemap.MapV2) *linuxNodeHandler {
+	t.Helper()
+	return newNodeIDTestHandlerWithLogger(t, hivetest.Logger(t), nodeMap)
+}
+
+func newBufferedNodeIDTestHandler(t *testing.T, nodeMap nodemap.MapV2) (*linuxNodeHandler, *bytes.Buffer) {
+	t.Helper()
+	logs := new(bytes.Buffer)
+	logger := slog.New(slog.NewTextHandler(logs, nil))
+	return newNodeIDTestHandlerWithLogger(t, logger, nodeMap), logs
+}
+
+func newNodeIDTestHandlerWithLogger(
+	t *testing.T,
+	logger *slog.Logger,
+	nodeMap nodemap.MapV2,
+) *linuxNodeHandler {
+	t.Helper()
+	return newNodeHandler(
+		logger,
+		DatapathConfiguration{},
+		nodeMap,
+		kpr.KPRConfig{},
+		&fakeipsec.Agent{},
+		fakeipsec.Config{},
+		node.NewTestLocalNodeStore(node.LocalNode{}),
+	)
+}
+
+func nodeIDTestNode(name string, ips ...string) nodeTypes.Node {
+	addresses := make([]nodeTypes.Address, 0, len(ips))
+	for _, ip := range ips {
+		addresses = append(addresses, nodeTypes.Address{
+			Type: addressing.NodeInternalIP,
+			IP:   netip.MustParseAddr(ip).AsSlice(),
+		})
+	}
+	return nodeTypes.Node{
+		Name:        name,
+		IPAddresses: addresses,
+	}
+}
+
+func allocateNodeIDForTest(t *testing.T, handler *linuxNodeHandler, node *nodeTypes.Node) uint16 {
+	t.Helper()
+	handler.mutex.Lock()
+	defer handler.mutex.Unlock()
+
+	nodeID, err := handler.allocateIDForNode(nil, node)
+	require.NoError(t, err)
+	require.NotZero(t, nodeID)
+	return nodeID
+}
+
+func mapNodeIDForTest(t *testing.T, handler *linuxNodeHandler, ip string, nodeID uint16) {
+	t.Helper()
+	handler.mutex.Lock()
+	defer handler.mutex.Unlock()
+	require.NoError(t, handler.mapNodeID(ip, nodeID, 0))
+}
+
+func deallocateNodeIDForTest(handler *linuxNodeHandler, node *nodeTypes.Node) error {
+	handler.mutex.Lock()
+	defer handler.mutex.Unlock()
+	return handler.deallocateIDForNode(node)
+}
+
+func addLiveNodeForTest(handler *linuxNodeHandler, node *nodeTypes.Node) {
+	handler.mutex.Lock()
+	defer handler.mutex.Unlock()
+	handler.nodes[node.Identity()] = node
+}
+
+func requireNodeIDRemoved(
+	t *testing.T,
+	handler *linuxNodeHandler,
+	nodeMap nodeMapLookup,
+	nodeID uint16,
+	ips ...string,
+) {
+	t.Helper()
+	for _, ip := range ips {
+		requireNodeIDMappingMissing(t, handler, nodeMap, ip)
+	}
+	require.NotContains(t, handler.nodeIPsByIDs, nodeID)
+	require.True(t, handler.nodeIDs.Remove(idpool.ID(nodeID)))
+}
+
+func requireNodeIDMappingMissing(
+	t *testing.T,
+	handler *linuxNodeHandler,
+	nodeMap nodeMapLookup,
+	ip string,
+) {
+	t.Helper()
+	require.NotContains(t, handler.nodeIDsByIPs, ip)
+	_, err := nodeMap.Lookup(netip.MustParseAddr(ip))
+	require.Error(t, err)
+}
+
+func requireNodeIDPresent(
+	t *testing.T,
+	handler *linuxNodeHandler,
+	nodeMap nodeMapLookup,
+	nodeID uint16,
+	ip string,
+) {
+	t.Helper()
+	require.Equal(t, nodeID, handler.nodeIDsByIPs[ip])
+	require.Contains(t, handler.nodeIPsByIDs[nodeID], ip)
+	value, err := nodeMap.Lookup(netip.MustParseAddr(ip))
+	require.NoError(t, err)
+	require.Equal(t, nodeID, value.NodeID)
+	require.False(t, handler.nodeIDs.Remove(idpool.ID(nodeID)))
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
- [x] Thanks for contributing!

## Description

Inconsistent restored node-map state can associate one node's IPs with multiple IDs. During node deletion, `deallocateIDForNode` selected one matching ID and deallocated only that ID. Secondary forward/reverse mappings, BPF node-map entries, and the corresponding IDs could remain.

The deletion path now collects every distinct nonzero ID from deleted-node IPs that have not been reused by another live node, then deallocates each ID exactly once. An ID returns to the pool only after its reverse set is empty, so it remains allocated if a live mapping or a BPF deletion failure remains. A multi-ID mismatch stays diagnostic-only when repair succeeds; actual cleanup failures are still returned.

The related allocation/update conflict path can independently leave old IDs unreclaimed. That behavior is known and intentionally out of scope for a focused follow-up.

## Testing

```text
go test ./pkg/datapath/linux -run '^TestDeallocateIDsForNode$' -count=1
go test ./pkg/datapath/linux -run '^TestDeallocateIDsForNode$' -count=100
go test ./pkg/datapath/linux -count=1
```

This PR was prepared with AIL:3. GitHub Copilot assisted with source analysis, implementation, and test drafting. The final patch was independently reviewed, and all listed checks were run against the exact commit.

Related: #36052

```release-note
Fix cleanup of inconsistent node ID mappings when nodes are deleted.
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request