### PR TITLE
datapath/linux: return orphaned node ID to pool on partial remap

### DIFF
--- a/pkg/datapath/linux/node_ids.go
+++ b/pkg/datapath/linux/node_ids.go
@@ -256,6 +256,17 @@ func (n *linuxNodeHandler) unmapNodeID(ip string) error {
 		n.nodeIPsByIDs[id].Delete(ip)
 		if n.nodeIPsByIDs[id].Len() == 0 {
 			delete(n.nodeIPsByIDs, id)
+
+			// No IP references this ID anymore: return it to the free pool.
+			// Without this, an ID orphaned by a partial remap (e.g. the
+			// inconsistent-mapping recovery path in allocateIDForNode) is
+			// never freed, since deallocateNodeIDLocked - which does return
+			// IDs to the pool - is only reached via full node deletion.
+			if n.nodeIDs.Insert(idpool.ID(id)) {
+				n.log.Debug("Returned now-unused node ID to the pool",
+					logfields.NodeID, id,
+				)
+			}
 		}
 	}
 

--- a/pkg/datapath/linux/node_ids_test.go
+++ b/pkg/datapath/linux/node_ids_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package linux
+
+import (
+	"net"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/cilium/cilium/pkg/idpool"
+	fakenodemap "github.com/cilium/cilium/pkg/maps/nodemap/fake"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+)
+
+func newTestNodeIDHandler(t *testing.T, minID, maxID idpool.ID) *linuxNodeHandler {
+	return &linuxNodeHandler{
+		log:          hivetest.Logger(t),
+		nodeMap:      fakenodemap.NewFakeNodeMapV2(),
+		nodeIDs:      idpool.NewIDPool(minID, maxID),
+		nodeIDsByIPs: map[string]uint16{},
+		nodeIPsByIDs: map[uint16]sets.Set[string]{},
+	}
+}
+
+func testNode(ips ...string) *nodeTypes.Node {
+	n := &nodeTypes.Node{Name: "test-node"}
+	for _, ip := range ips {
+		n.IPAddresses = append(n.IPAddresses, nodeTypes.Address{IP: net.ParseIP(ip)})
+	}
+	return n
+}
+
+// TestNodeIDLeakOnSharedRouterIP reproduces
+// https://github.com/cilium/cilium/issues/47563: when a node ID gets
+// orphaned by allocateIDForNode's inconsistent-mapping recovery path (which
+// can happen when a router IP is shared across nodes' IPAddresses, e.g. a
+// shared --local-router-ipv4), the ID must be returned to the free pool. If
+// it isn't, the pool is silently exhausted over time even though far fewer
+// node IDs are actually in use.
+func TestNodeIDLeakOnSharedRouterIP(t *testing.T) {
+	const routerIP = "169.254.2.1"
+
+	// Only 2 IDs available: this makes exhaustion trivially observable.
+	n := newTestNodeIDHandler(t, 1, 2)
+
+	// Node A gets a node ID for its own IP plus the shared router IP.
+	nodeA := testNode("10.0.0.1", routerIP)
+	idA, err := n.allocateIDForNode(nil, nodeA)
+	require.NoError(t, err)
+
+	// Node B's IP gets an ID first on its own (e.g. via the ipcache path
+	// mentioned in allocateIDForNode's doc comment, before the full Node
+	// object with the router IP is processed). This consumes the pool's
+	// last remaining ID.
+	nodeBPartial := testNode("10.0.0.2")
+	idB, err := n.allocateIDForNode(nil, nodeBPartial)
+	require.NoError(t, err)
+	require.NotEqual(t, idA, idB, "node A and B must not share an ID at this point")
+
+	// Now the full node B event arrives, including the shared router IP,
+	// which already has id A's ID. This is the inconsistent-mapping case:
+	// node B's own IP has idB, but the router IP resolves to idA.
+	nodeBFull := testNode("10.0.0.2", routerIP)
+	newIDB, err := n.allocateIDForNode(nil, nodeBFull)
+
+	// The recovery path unmaps node B's stale mapping and allocates a fresh
+	// ID for it. That must succeed - the pool must not have been silently
+	// exhausted by the now-orphaned original idB, even though there are
+	// only 2 IDs in the entire pool and node A is still using one of them.
+	require.NoError(t, err, "re-allocating node B's ID should succeed: the orphaned ID must have been freed")
+	require.NotEqual(t, uint16(0), newIDB)
+
+	// Sanity check: node A's mapping must be completely unaffected.
+	got, ok := n.nodeIDsByIPs["10.0.0.1"]
+	require.True(t, ok)
+	require.Equal(t, idA, got)
+}

--- a/pkg/datapath/linux/node_ids_test.go
+++ b/pkg/datapath/linux/node_ids_test.go
@@ -45,17 +45,18 @@ func TestNodeIDLeakOnSharedRouterIP(t *testing.T) {
 	const routerIP = "169.254.2.1"
 	const nodeAIP = "10.0.0.1"
 	const nodeBIP = "10.0.0.2"
-	const firstNodeID = uint16(1) // first ID handed out by a pool starting at 1
-	const lastNodeID = uint16(2)  // the pool's only other ID (see newTestNodeIDHandler below)
 
 	// Only 2 IDs available: this makes exhaustion trivially observable.
+	// Note: idpool.idCache.allocateID() draws from a Go map (`for id := range
+	// c.ids`), so which of the 2 IDs comes out first is intentionally
+	// unspecified/non-deterministic across runs - assertions below must not
+	// assume either ID is specifically 1 or 2.
 	n := newTestNodeIDHandler(t, 1, 2)
 
 	// Node A gets a node ID for its own IP plus the shared router IP.
 	nodeA := testNode(nodeAIP, routerIP)
 	idA, err := n.allocateIDForNode(nil, nodeA)
 	require.NoError(t, err)
-	require.Equal(t, firstNodeID, idA)
 
 	// Node B's IP gets an ID first on its own (e.g. via the ipcache path
 	// mentioned in allocateIDForNode's doc comment, before the full Node
@@ -64,7 +65,7 @@ func TestNodeIDLeakOnSharedRouterIP(t *testing.T) {
 	nodeBPartial := testNode(nodeBIP)
 	idB, err := n.allocateIDForNode(nil, nodeBPartial)
 	require.NoError(t, err)
-	require.Equal(t, lastNodeID, idB, "node B's own IP should get the last available ID")
+	require.NotEqual(t, idA, idB, "node A and B must not share an ID at this point")
 
 	// Now the full node B event arrives, including the shared router IP,
 	// which already has id A's ID. This is the inconsistent-mapping case:
@@ -77,9 +78,13 @@ func TestNodeIDLeakOnSharedRouterIP(t *testing.T) {
 	// exhausted by the now-orphaned original idB, even though there are
 	// only 2 IDs in the entire pool and node A is still using one of them.
 	require.NoError(t, err, "re-allocating node B's ID should succeed: the orphaned ID must have been freed")
-	require.Equal(t, lastNodeID, newIDB)
+	// With only 2 IDs total and idA still held by node A, idB is the only ID
+	// the pool can possibly hand out here - so the recovered ID must be
+	// exactly the one that was just freed, not merely non-zero.
+	require.Equal(t, idB, newIDB, "the freed ID must be the one reallocated - it's the only one left in a 2-ID pool with idA still held")
 
-	// Sanity check: node A's mapping must be completely unaffected.
+	// Sanity check: node A's mapping must be completely unaffected, and node
+	// B's own IP must now resolve to its recovered ID.
 	require.Equal(t, idA, n.nodeIDsByIPs[nodeAIP])
-	require.Equal(t, idB, n.nodeIDsByIPs[nodeBIP])
+	require.Equal(t, newIDB, n.nodeIDsByIPs[nodeBIP])
 }

--- a/pkg/datapath/linux/node_ids_test.go
+++ b/pkg/datapath/linux/node_ids_test.go
@@ -43,28 +43,33 @@ func testNode(ips ...string) *nodeTypes.Node {
 // node IDs are actually in use.
 func TestNodeIDLeakOnSharedRouterIP(t *testing.T) {
 	const routerIP = "169.254.2.1"
+	const nodeAIP = "10.0.0.1"
+	const nodeBIP = "10.0.0.2"
+	const firstNodeID = uint16(1) // first ID handed out by a pool starting at 1
+	const lastNodeID = uint16(2)  // the pool's only other ID (see newTestNodeIDHandler below)
 
 	// Only 2 IDs available: this makes exhaustion trivially observable.
 	n := newTestNodeIDHandler(t, 1, 2)
 
 	// Node A gets a node ID for its own IP plus the shared router IP.
-	nodeA := testNode("10.0.0.1", routerIP)
+	nodeA := testNode(nodeAIP, routerIP)
 	idA, err := n.allocateIDForNode(nil, nodeA)
 	require.NoError(t, err)
+	require.Equal(t, firstNodeID, idA)
 
 	// Node B's IP gets an ID first on its own (e.g. via the ipcache path
 	// mentioned in allocateIDForNode's doc comment, before the full Node
 	// object with the router IP is processed). This consumes the pool's
 	// last remaining ID.
-	nodeBPartial := testNode("10.0.0.2")
+	nodeBPartial := testNode(nodeBIP)
 	idB, err := n.allocateIDForNode(nil, nodeBPartial)
 	require.NoError(t, err)
-	require.NotEqual(t, idA, idB, "node A and B must not share an ID at this point")
+	require.Equal(t, lastNodeID, idB, "node B's own IP should get the last available ID")
 
 	// Now the full node B event arrives, including the shared router IP,
 	// which already has id A's ID. This is the inconsistent-mapping case:
 	// node B's own IP has idB, but the router IP resolves to idA.
-	nodeBFull := testNode("10.0.0.2", routerIP)
+	nodeBFull := testNode(nodeBIP, routerIP)
 	newIDB, err := n.allocateIDForNode(nil, nodeBFull)
 
 	// The recovery path unmaps node B's stale mapping and allocates a fresh
@@ -72,10 +77,9 @@ func TestNodeIDLeakOnSharedRouterIP(t *testing.T) {
 	// exhausted by the now-orphaned original idB, even though there are
 	// only 2 IDs in the entire pool and node A is still using one of them.
 	require.NoError(t, err, "re-allocating node B's ID should succeed: the orphaned ID must have been freed")
-	require.NotEqual(t, uint16(0), newIDB)
+	require.Equal(t, lastNodeID, newIDB)
 
 	// Sanity check: node A's mapping must be completely unaffected.
-	got, ok := n.nodeIDsByIPs["10.0.0.1"]
-	require.True(t, ok)
-	require.Equal(t, idA, got)
+	require.Equal(t, idA, n.nodeIDsByIPs[nodeAIP])
+	require.Equal(t, idB, n.nodeIDsByIPs[nodeBIP])
 }


### PR DESCRIPTION
- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title, description and a `Fixes: #XXX` line if the commit addresses a particular GitHub issue.
- [x] All commits are signed off. See the section [Developer's Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#developer-s-certificate-of-origin)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI) in accordance with the [Cilium AI Policy](https://github.com/cilium/community/blob/main/AI-POLICY.md), and indicate the rating using [AI Influence Level](https://danielmiessler.com/blog/ai-influence-level-ail).

This PR was prepared with **AIL:3** (AI Created, Human Full Structure) — I directed the investigation and the fix approach, and reviewed the diff, root-cause analysis, and test before submission.

`allocateIDForNode`'s inconsistent-mapping recovery path unmaps all IPs of a node when it finds them pointing to different node IDs, then retries allocation. `unmapNodeID` removes the IP<>ID mappings but never returned the ID itself to the free pool once it had no IPs left, unlike `deallocateNodeIDLocked` (used only on full node deletion).

This can happen whenever a node's `IPAddresses` contain an IP shared across nodes (e.g. a shared `--local-router-ipv4`), since it lets a later node's addresses resolve to an earlier node's ID and trigger the recovery path. Each occurrence orphans one node ID, so the ID pool (65535 entries) is silently exhausted over time, well before the actual node count would justify it — eventually logging `"No more IDs available for nodes"`, as reported in #47563.

**Fix:** return the ID to the pool in `unmapNodeID` itself when it removes the last remaining IP for that ID. This covers the partial-remap path in addition to the existing full-deletion path (which already re-inserts the same ID again there, harmlessly, since `idpool.Insert` is a no-op on an ID that's already available).

**Testing:** added `TestNodeIDLeakOnSharedRouterIP`, which reproduces the leak with a 2-ID pool: without the fix it fails with the same `"no available node ID"` error as the reported bug; with the fix, the orphaned ID is correctly freed and reused. Verified this locally (reverted the fix, confirmed the test fails with that exact error; restored it, confirmed it passes) before submitting.

Fixes: #47563

```release-note
Fix a node ID leak that could exhaust the node ID pool over time when a node's IP addresses (e.g. a shared local router IP) caused the inconsistent-mapping recovery path in the node ID allocator to run.
```