### PR TITLE
.github: test the default ENI behaviour on the EKS pull request leg

### DIFF
--- a/.github/actions/eks/k8s-versions.yaml
+++ b/.github/actions/eks/k8s-versions.yaml
@@ -1,4 +1,11 @@
 # List of k8s version for EKS tests
+#
+# The "default" entry is the only one pull requests run, so it is kept without
+# prefix delegation: eni.awsEnablePrefixDelegation defaults to false, so that is
+# the ENI behaviour every user gets unless they opt in.
+#
+# When adding a new EKS version, mark it as the default and move aws-eni-pd to
+# the second to last version, so that only that one enables prefix delegation.
 ---
 include:
   - version: "1.33"
@@ -9,4 +16,3 @@ include:
   - version: "1.35"
     region: us-west-2
     default: true
-    aws-eni-pd: true


### PR DESCRIPTION
Pull requests run a single EKS entry, the one marked default, and that entry
enabled prefix delegation. Prefix delegation is not the default ENI behaviour:
eni.awsEnablePrefixDelegation defaults to false in the Helm chart, so an ENI
IPAM user gets it only by explicitly opting in. Every EKS cluster a pull request
tested was therefore running an opt-in configuration, and the one users get out
of the box was only exercised hours later by the scheduled full matrix.

The difference is not cosmetic. Prefix delegation raises a single ENI's capacity
sixteenfold, so at CI pod density every pod fits on the primary ENI. Without it
pods spread across secondary ENIs, which is what brings in the allocation and
datapath paths that depend on which ENI owns a pod IP, such as picking the
masquerade source address and the ENI return path. Two recent issues that only
reproduce without prefix delegation reached main because no pull request leg ran
that way.

Drop prefix delegation from the default entry so pull requests test the default
ENI behaviour. Prefix delegation stays covered by a non-default entry that the
scheduled and stable-branch full matrix runs, and the number of clusters per
pull request is unchanged.

This PR was prepared with AIL:3.
