### PR TITLE
ipam: Extend the ENI netlink interface wait to 150s

### DIFF
--- a/daemon/infraendpoints/infra_ip_allocation.go
+++ b/daemon/infraendpoints/infra_ip_allocation.go
@@ -221,13 +221,6 @@ func (r *infraIPAllocator) reallocateOldRouterIPs(fromK8s, fromFS net.IP) (resul
 }
 
 func (r *infraIPAllocator) waitForENI(ctx context.Context, macAddr string) error {
-	bo := wait.Backoff{
-		Duration: 250 * time.Millisecond,
-		Factor:   2,
-		Jitter:   0.2,
-		Steps:    5,
-	}
-
 	findENIByMAC := func(ctx context.Context) (bool, error) {
 		links, err := safenetlink.LinkList()
 		if err != nil {
@@ -246,7 +239,7 @@ func (r *infraIPAllocator) waitForENI(ctx context.Context, macAddr string) error
 		return false, nil
 	}
 
-	return wait.ExponentialBackoffWithContext(ctx, bo, findENIByMAC)
+	return wait.PollUntilContextTimeout(ctx, time.Second, 150*time.Second, true, findENIByMAC)
 }
 
 func (r *infraIPAllocator) reallocateRouterIPs(ctx context.Context, family node.AddressingFamily, fromK8s, fromFS net.IP) (routerIP net.IP, err error) {

--- a/daemon/infraendpoints/infra_ip_allocation_test.go
+++ b/daemon/infraendpoints/infra_ip_allocation_test.go
@@ -4,12 +4,14 @@
 package infraendpoints
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/netip"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/assert"
@@ -249,6 +251,75 @@ func createDevices(t *testing.T) {
 	_, ipnet, _ := net.ParseCIDR("192.0.2.1/32")
 	addr := &netlink.Addr{IPNet: ipnet}
 	assert.NoError(t, netlink.AddrAdd(ciliumHost, addr))
+}
+
+func TestPrivilegedWaitForENI(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	infraIPAllocator := &infraIPAllocator{
+		logger: hivetest.Logger(t),
+	}
+
+	cases := []struct {
+		name        string
+		ifaceDelay  time.Duration
+		ctxTimeout  time.Duration
+		expectError bool
+	}{
+		{
+			name:        "10s nominal delay",
+			ifaceDelay:  10 * time.Second,
+			ctxTimeout:  30 * time.Second,
+			expectError: false,
+		},
+		{
+			name:        "149s delay, just under the 150s cap",
+			ifaceDelay:  149 * time.Second,
+			ctxTimeout:  170 * time.Second,
+			expectError: false,
+		},
+		{
+			name:        "160s delay, past the 150s cap",
+			ifaceDelay:  160 * time.Second,
+			ctxTimeout:  170 * time.Second,
+			expectError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ns := netns.NewNetNS(t)
+
+			hwAddr, err := mac.GenerateRandMAC()
+			require.NoError(t, err)
+
+			done := make(chan error, 1)
+			go func() {
+				time.Sleep(tc.ifaceDelay)
+				done <- ns.Do(func() error {
+					return netlink.LinkAdd(&netlink.Dummy{
+						LinkAttrs: netlink.LinkAttrs{
+							Name:         "eni-test0",
+							HardwareAddr: net.HardwareAddr(hwAddr),
+						},
+					})
+				})
+			}()
+
+			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)
+			defer cancel()
+
+			err = ns.Do(func() error {
+				return infraIPAllocator.waitForENI(ctx, hwAddr.String())
+			})
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.NoError(t, <-done)
+		})
+	}
 }
 
 func Test_getCiliumHostIPsFromFile(t *testing.T) {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!


I've been reviewing some cases where the cilium-agent is failing to startup happliy and goes into CLB for a while on new nodes in AWS. It appears that there can be some significant latency from when the `cilium-operator` calls `AtachNetworkInterface` to when that ENI actually shows up on the node from it's kernel logs. The worst case I've found over the last 2 weeks was 149 seconds. 

The compounding issue is that with the current max of 3.75s + kubelet's exponetial backoff restarting the agent, where in one case the NIC was there within 129-ish seconds but, the agent wasn't able to get through this until 212-ish seconds. 

Okay so, with the pre-ample out of the way, this PR drops the exponential backoff and switches to using PollUntilContextTimeout instead. immediate is passed as `true` so it checks right away, so any case where the NIC is there shouldn't see any backoff. Then it'll check every second up to 150 seconds. This changes the current checking behavior from something like `0.000  0.285  0.840  1.865  3.904` (with jitter, then gives up)
to `0  1  2  3  4  5 ... 150` (fixed 1s, then gives up).

No chart change is required. 150s fits inside both remaining ceilings:

- cilium-agent `startupProbe: failureThreshold: 300` x `periodSeconds: 2` with
  `initialDelaySeconds: 5` ==  ~600s - https://github.com/cilium/cilium/blob/2efb257c8533af4a446af77813d9aaa9d8b127fc/install/kubernetes/cilium/values.yaml#L2428-L2433
- `defaults.HiveStartTimeout` = 300s - https://github.com/cilium/cilium/blob/main/pkg/defaults/defaults.go#L12-L13

```release-note
ipam: Wait up to 150s for attached ENI's to show up
```

Noting too that this is related to https://github.com/cilium/cilium/pull/47295 and the original PR https://github.com/cilium/cilium/pull/41954. I had happened to be looking at this error at the same time but in prod versus CI. 

This PR was prepared with AIL:3. I've personally confirmed the change and backing data is all accurate by hand. 
