### PR TITLE
operator: continue identity GC after update races

### DIFF
--- a/operator/identitygc/crd_gc.go
+++ b/operator/identitygc/crd_gc.go
@@ -134,6 +134,17 @@ func (igc *GC) gc(ctx context.Context) error {
 
 				identity.Annotations[identitybackend.HeartBeatAnnotation] = timeNow.Format(time.RFC3339Nano)
 				if err := igc.updateIdentity(ctx, identity); err != nil {
+					if isIdentityUpdateRace(err) {
+						// The identity was updated, deleted, or replaced after
+						// it was read from the local store. Defer it to the
+						// next run instead of aborting this GC pass.
+						igc.logger.WarnContext(ctx,
+							"Could not mark CRD identity for later deletion due to concurrent update",
+							logfields.Identity, identity.Name,
+							logfields.K8sUID, identity.UID)
+						continue
+					}
+
 					igc.logger.ErrorContext(ctx,
 						"Marking CRD identity for later deletion",
 						logfields.Identity, identity,
@@ -193,6 +204,10 @@ func (igc *GC) gc(ctx context.Context) error {
 	igc.heartbeatStore.gc()
 
 	return nil
+}
+
+func isIdentityUpdateRace(err error) bool {
+	return k8serrors.IsConflict(err) || k8serrors.IsNotFound(err)
 }
 
 // deleteIdentity deletes an identity. It includes the resource version and

--- a/operator/identitygc/crd_gc_test.go
+++ b/operator/identitygc/crd_gc_test.go
@@ -4,13 +4,16 @@
 package identitygc
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
 	"github.com/google/go-cmp/cmp"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/cilium/cilium/operator/k8s"
 	tu "github.com/cilium/cilium/operator/pkg/ciliumendpointslice/testutils"
@@ -20,6 +23,43 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/testutils"
 )
+
+func TestIsIdentityUpdateRace(t *testing.T) {
+	resource := schema.GroupResource{
+		Group:    "cilium.io",
+		Resource: "ciliumidentities",
+	}
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "conflict",
+			err:  k8serrors.NewConflict(resource, "1234", errors.New("identity was replaced")),
+			want: true,
+		},
+		{
+			name: "not found",
+			err:  k8serrors.NewNotFound(resource, "1234"),
+			want: true,
+		},
+		{
+			name: "other API error",
+			err:  k8serrors.NewInternalError(errors.New("API unavailable")),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isIdentityUpdateRace(tt.err); got != tt.want {
+				t.Fatalf("isIdentityUpdateRace() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestUsedIdentitiesInCESs(t *testing.T) {
 	var fakeClient *k8sClient.FakeClientset


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Write a short paragraph that states whether you used machine learning models
      (including LLMs and other generative AI), and indicate the rating using
      [AI Influence Level](https://danielmiessler.com/blog/ai-influence-level-ail).
- [x] Thanks for contributing!

CRD identity GC first annotates an unused identity, then deletes it on a later pass. If that identity is updated, deleted, or replaced after it is read from the local store, the annotation update can return a conflict or not-found error. The current code aborts the entire GC pass, so frequent identity churn can prevent unrelated stale identities later in the scan from progressing toward deletion.

This change treats those two recoverable races like the existing delete-conflict path: it logs a warning and defers only the raced identity to the next pass. Other API errors still fail the GC run, preserving the signal for systemic control-plane failures.

Validation:

- `go test ./operator/identitygc`
- `gofmt` and `git diff --check`

This PR was prepared with AIL:4. The resulting diff was reviewed against the existing GC conflict handling and validated with the focused unit test before submission.

```release-note
Prevent concurrent CRD identity updates from aborting an entire identity garbage-collection pass.
```
