### PR TITLE
signal: remove SignalCTFillUp

### DIFF
--- a/bpf/lib/signal.h
+++ b/bpf/lib/signal.h
@@ -15,7 +15,7 @@ struct {
 
 enum {
 	SIGNAL_NAT_FILL_UP = 0,
-	SIGNAL_CT_FILL_UP,
+	UNUSED,
 	SIGNAL_AUTH_REQUIRED,
 };
 
@@ -53,12 +53,6 @@ static __always_inline void send_signal_nat_fill_up(const struct __ctx_buff *ctx
 						    __u32 proto)
 {
 	SEND_SIGNAL(ctx, SIGNAL_NAT_FILL_UP, proto, proto);
-}
-
-static __always_inline void send_signal_ct_fill_up(const struct __ctx_buff *ctx,
-						   __u32 proto)
-{
-	SEND_SIGNAL(ctx, SIGNAL_CT_FILL_UP, proto, proto);
 }
 
 static __always_inline void send_signal_auth_required(const struct __ctx_buff *ctx,

--- a/pkg/maps/ctmap/gc/signals.go
+++ b/pkg/maps/ctmap/gc/signals.go
@@ -10,7 +10,7 @@ import (
 )
 
 // SignalData holds the IP address family type BPF program sent along with
-// the SignalNatFillUp and SignalCTFillUp signals.
+// the SignalNatFillUp signal.
 type SignalData uint32
 
 const (
@@ -45,7 +45,7 @@ func newSignalHandler(sm signal.SignalManager) (SignalHandler, error) {
 		manager: sm,
 	}
 
-	err := sm.RegisterHandler(signal.ChannelHandler(handler.signals), signal.SignalCTFillUp, signal.SignalNatFillUp)
+	err := sm.RegisterHandler(signal.ChannelHandler(handler.signals), signal.SignalNatFillUp)
 	if err != nil {
 		return SignalHandler{}, fmt.Errorf("failed to set up signal channel for CT & NAT fill-up events: %w", err)
 	}
@@ -58,9 +58,9 @@ func (sh *SignalHandler) Signals() <-chan SignalData {
 }
 
 func (sh *SignalHandler) MuteSignals() error {
-	return sh.manager.MuteSignals(signal.SignalCTFillUp, signal.SignalNatFillUp)
+	return sh.manager.MuteSignals(signal.SignalNatFillUp)
 }
 
 func (sh *SignalHandler) UnmuteSignals() error {
-	return sh.manager.UnmuteSignals(signal.SignalCTFillUp, signal.SignalNatFillUp)
+	return sh.manager.UnmuteSignals(signal.SignalNatFillUp)
 }

--- a/pkg/signal/signal.go
+++ b/pkg/signal/signal.go
@@ -26,8 +26,7 @@ type SignalType uint32
 const (
 	// SignalNatFillUp denotes potential congestion on the NAT table
 	SignalNatFillUp SignalType = iota
-	// SignalCTFillUp denotes potential congestion on the CT table
-	SignalCTFillUp
+	Unused
 	// SignalAuthRequired denotes a connection dropped due to missing authentication
 	SignalAuthRequired
 	SignalTypeMax
@@ -35,7 +34,7 @@ const (
 
 var signalName = [SignalTypeMax]string{
 	SignalNatFillUp:    "nat_fill_up",
-	SignalCTFillUp:     "ct_fill_up",
+	Unused:             "unused",
 	SignalAuthRequired: "auth_required",
 }
 

--- a/pkg/signal/signal_test.go
+++ b/pkg/signal/signal_test.go
@@ -60,7 +60,6 @@ func TestSignalSet(t *testing.T) {
 	sm := &signalManager{events: events}
 	require.True(t, sm.isMuted())
 	require.True(t, sm.isSignalMuted(SignalNatFillUp))
-	require.True(t, sm.isSignalMuted(SignalCTFillUp))
 	require.True(t, sm.isSignalMuted(SignalAuthRequired))
 
 	// invalid signal, nothing changes
@@ -69,73 +68,56 @@ func TestSignalSet(t *testing.T) {
 	require.ErrorContains(t, err, "signal number not supported: 16")
 	require.True(t, sm.isMuted())
 	require.True(t, sm.isSignalMuted(SignalNatFillUp))
-	require.True(t, sm.isSignalMuted(SignalCTFillUp))
 	require.True(t, sm.isSignalMuted(SignalAuthRequired))
 
-	// 2 active signals
-	err = sm.UnmuteSignals(SignalNatFillUp, SignalCTFillUp)
+	// 1 active signal
+	err = sm.UnmuteSignals(SignalNatFillUp)
 	require.NoError(t, err)
 	require.False(t, sm.isMuted())
 	require.False(t, sm.isSignalMuted(SignalNatFillUp))
-	require.False(t, sm.isSignalMuted(SignalCTFillUp))
 	require.True(t, sm.isSignalMuted(SignalAuthRequired))
 
 	require.False(t, events.paused)
 	require.False(t, events.closed)
 
-	// Mute one, one still active
+	// Mute it again
 	err = sm.MuteSignals(SignalNatFillUp)
-	require.NoError(t, err)
-	require.False(t, sm.isMuted())
-	require.True(t, sm.isSignalMuted(SignalNatFillUp))
-	require.False(t, sm.isSignalMuted(SignalCTFillUp))
-	require.True(t, sm.isSignalMuted(SignalAuthRequired))
-
-	require.False(t, events.paused)
-	require.False(t, events.closed)
-
-	// Nothing happens if the signal is already muted
-	err = sm.MuteSignals(SignalNatFillUp)
-	require.NoError(t, err)
-	require.False(t, sm.isMuted())
-	require.True(t, sm.isSignalMuted(SignalNatFillUp))
-	require.False(t, sm.isSignalMuted(SignalCTFillUp))
-	require.True(t, sm.isSignalMuted(SignalAuthRequired))
-
-	require.False(t, events.paused)
-	require.False(t, events.closed)
-
-	// Unmute one more
-	err = sm.UnmuteSignals(SignalAuthRequired)
-	require.NoError(t, err)
-	require.False(t, sm.isMuted())
-	require.True(t, sm.isSignalMuted(SignalNatFillUp))
-	require.False(t, sm.isSignalMuted(SignalCTFillUp))
-	require.False(t, sm.isSignalMuted(SignalAuthRequired))
-
-	require.False(t, events.paused)
-	require.False(t, events.closed)
-
-	// Last signala are muted
-	err = sm.MuteSignals(SignalCTFillUp, SignalAuthRequired)
 	require.NoError(t, err)
 	require.True(t, sm.isMuted())
 	require.True(t, sm.isSignalMuted(SignalNatFillUp))
-	require.True(t, sm.isSignalMuted(SignalCTFillUp))
 	require.True(t, sm.isSignalMuted(SignalAuthRequired))
 
 	require.True(t, events.paused)
 	require.False(t, events.closed)
 
-	// A signal is unmuted again
-	err = sm.UnmuteSignals(SignalCTFillUp)
+	// Nothing happens if the signal is already muted
+	err = sm.MuteSignals(SignalNatFillUp)
+	require.NoError(t, err)
+	require.True(t, sm.isMuted())
+	require.True(t, sm.isSignalMuted(SignalNatFillUp))
+	require.True(t, sm.isSignalMuted(SignalAuthRequired))
+
+	require.True(t, events.paused)
+	require.False(t, events.closed)
+
+	// Unmute one
+	err = sm.UnmuteSignals(SignalAuthRequired)
 	require.NoError(t, err)
 	require.False(t, sm.isMuted())
 	require.True(t, sm.isSignalMuted(SignalNatFillUp))
-	require.False(t, sm.isSignalMuted(SignalCTFillUp))
-	require.True(t, sm.isSignalMuted(SignalAuthRequired))
+	require.False(t, sm.isSignalMuted(SignalAuthRequired))
 
 	require.False(t, events.paused)
+	require.False(t, events.closed)
+
+	// Mute it again
+	err = sm.MuteSignals(SignalAuthRequired)
+	require.NoError(t, err)
+	require.True(t, sm.isMuted())
+	require.True(t, sm.isSignalMuted(SignalNatFillUp))
+	require.True(t, sm.isSignalMuted(SignalAuthRequired))
+
+	require.True(t, events.paused)
 	require.False(t, events.closed)
 }
 
@@ -168,7 +150,6 @@ func TestLifeCycle(t *testing.T) {
 	binary.Write(buf1, binary.NativeEndian, SignalProtoV4)
 
 	buf2 := new(bytes.Buffer)
-	binary.Write(buf2, binary.NativeEndian, SignalCTFillUp)
 	binary.Write(buf2, binary.NativeEndian, SignalProtoV4)
 
 	messages := [][]byte{buf1.Bytes(), buf2.Bytes()}
@@ -177,7 +158,7 @@ func TestLifeCycle(t *testing.T) {
 	require.True(t, sm.isMuted())
 
 	wakeup := make(chan SignalData, 1024)
-	err := sm.RegisterHandler(ChannelHandler(wakeup), SignalNatFillUp, SignalCTFillUp)
+	err := sm.RegisterHandler(ChannelHandler(wakeup), SignalNatFillUp)
 	require.NoError(t, err)
 	require.False(t, sm.isMuted())
 
@@ -186,7 +167,7 @@ func TestLifeCycle(t *testing.T) {
 
 	select {
 	case x := <-wakeup:
-		sm.MuteSignals(SignalNatFillUp, SignalCTFillUp)
+		sm.MuteSignals(SignalNatFillUp)
 		require.True(t, sm.isMuted())
 
 		ipv4 := false
@@ -211,7 +192,7 @@ func TestLifeCycle(t *testing.T) {
 		require.False(t, ipv6)
 
 	case <-time.After(5 * time.Second):
-		sm.MuteSignals(SignalNatFillUp, SignalCTFillUp)
+		sm.MuteSignals(SignalNatFillUp)
 		require.True(t, sm.isMuted())
 
 		t.Fatal("No signals received on time.")

--- a/pkg/signal/signal_test.go
+++ b/pkg/signal/signal_test.go
@@ -60,7 +60,6 @@ func TestSignalSet(t *testing.T) {
 	sm := &signalManager{events: events}
 	require.True(t, sm.isMuted())
 	require.True(t, sm.isSignalMuted(SignalNatFillUp))
-	require.True(t, sm.isSignalMuted(SignalCTFillUp))
 	require.True(t, sm.isSignalMuted(SignalAuthRequired))
 
 	// invalid signal, nothing changes
@@ -69,26 +68,23 @@ func TestSignalSet(t *testing.T) {
 	require.ErrorContains(t, err, "signal number not supported: 16")
 	require.True(t, sm.isMuted())
 	require.True(t, sm.isSignalMuted(SignalNatFillUp))
-	require.True(t, sm.isSignalMuted(SignalCTFillUp))
 	require.True(t, sm.isSignalMuted(SignalAuthRequired))
 
-	// 2 active signals
-	err = sm.UnmuteSignals(SignalNatFillUp, SignalCTFillUp)
+	// 1 active signal
+	err = sm.UnmuteSignals(SignalNatFillUp)
 	require.NoError(t, err)
 	require.False(t, sm.isMuted())
 	require.False(t, sm.isSignalMuted(SignalNatFillUp))
-	require.False(t, sm.isSignalMuted(SignalCTFillUp))
 	require.True(t, sm.isSignalMuted(SignalAuthRequired))
 
 	require.False(t, events.paused)
 	require.False(t, events.closed)
 
-	// Mute one, one still active
+	// Mute it again
 	err = sm.MuteSignals(SignalNatFillUp)
 	require.NoError(t, err)
 	require.False(t, sm.isMuted())
 	require.True(t, sm.isSignalMuted(SignalNatFillUp))
-	require.False(t, sm.isSignalMuted(SignalCTFillUp))
 	require.True(t, sm.isSignalMuted(SignalAuthRequired))
 
 	require.False(t, events.paused)
@@ -99,43 +95,29 @@ func TestSignalSet(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, sm.isMuted())
 	require.True(t, sm.isSignalMuted(SignalNatFillUp))
-	require.False(t, sm.isSignalMuted(SignalCTFillUp))
 	require.True(t, sm.isSignalMuted(SignalAuthRequired))
 
 	require.False(t, events.paused)
 	require.False(t, events.closed)
 
-	// Unmute one more
+	// Unmute one
 	err = sm.UnmuteSignals(SignalAuthRequired)
 	require.NoError(t, err)
 	require.False(t, sm.isMuted())
 	require.True(t, sm.isSignalMuted(SignalNatFillUp))
-	require.False(t, sm.isSignalMuted(SignalCTFillUp))
 	require.False(t, sm.isSignalMuted(SignalAuthRequired))
 
 	require.False(t, events.paused)
 	require.False(t, events.closed)
 
-	// Last signala are muted
-	err = sm.MuteSignals(SignalCTFillUp, SignalAuthRequired)
+	// Mute it again
+	err = sm.MuteSignals(SignalAuthRequired)
 	require.NoError(t, err)
 	require.True(t, sm.isMuted())
 	require.True(t, sm.isSignalMuted(SignalNatFillUp))
-	require.True(t, sm.isSignalMuted(SignalCTFillUp))
 	require.True(t, sm.isSignalMuted(SignalAuthRequired))
 
 	require.True(t, events.paused)
-	require.False(t, events.closed)
-
-	// A signal is unmuted again
-	err = sm.UnmuteSignals(SignalCTFillUp)
-	require.NoError(t, err)
-	require.False(t, sm.isMuted())
-	require.True(t, sm.isSignalMuted(SignalNatFillUp))
-	require.False(t, sm.isSignalMuted(SignalCTFillUp))
-	require.True(t, sm.isSignalMuted(SignalAuthRequired))
-
-	require.False(t, events.paused)
 	require.False(t, events.closed)
 }
 
@@ -168,7 +150,6 @@ func TestLifeCycle(t *testing.T) {
 	binary.Write(buf1, binary.NativeEndian, SignalProtoV4)
 
 	buf2 := new(bytes.Buffer)
-	binary.Write(buf2, binary.NativeEndian, SignalCTFillUp)
 	binary.Write(buf2, binary.NativeEndian, SignalProtoV4)
 
 	messages := [][]byte{buf1.Bytes(), buf2.Bytes()}
@@ -177,7 +158,7 @@ func TestLifeCycle(t *testing.T) {
 	require.True(t, sm.isMuted())
 
 	wakeup := make(chan SignalData, 1024)
-	err := sm.RegisterHandler(ChannelHandler(wakeup), SignalNatFillUp, SignalCTFillUp)
+	err := sm.RegisterHandler(ChannelHandler(wakeup), SignalNatFillUp)
 	require.NoError(t, err)
 	require.False(t, sm.isMuted())
 
@@ -186,7 +167,7 @@ func TestLifeCycle(t *testing.T) {
 
 	select {
 	case x := <-wakeup:
-		sm.MuteSignals(SignalNatFillUp, SignalCTFillUp)
+		sm.MuteSignals(SignalNatFillUp)
 		require.True(t, sm.isMuted())
 
 		ipv4 := false
@@ -211,7 +192,7 @@ func TestLifeCycle(t *testing.T) {
 		require.False(t, ipv6)
 
 	case <-time.After(5 * time.Second):
-		sm.MuteSignals(SignalNatFillUp, SignalCTFillUp)
+		sm.MuteSignals(SignalNatFillUp)
 		require.True(t, sm.isMuted())
 
 		t.Fatal("No signals received on time.")


### PR DESCRIPTION
The last user of this datapath signal was removed in v1.19. Let's clean up the leftovers, but keep the signal# reserved so to not cause confusion between datapath and controlplane.