### PR TITLE
l2announcer: re-evaluate services on frontend changes

### DIFF
--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -145,6 +145,13 @@ func (l2a *L2Announcer) run(ctx context.Context, health cell.Health) error {
 	if err != nil {
 		return err
 	}
+
+	wtxn = l2a.params.StateDB.WriteTxn(l2a.params.Frontends)
+	frontendChangeIter, err := l2a.params.Frontends.Changes(wtxn)
+	wtxn.Commit()
+	if err != nil {
+		return err
+	}
 	// Wait for services to initialize
 	_, servicesInitialized := l2a.params.Services.Initialized(l2a.params.StateDB.ReadTxn())
 	select {
@@ -196,11 +203,22 @@ loop:
 			}
 		}
 
+		frontendChanges, frontendWatch := frontendChangeIter.Next(l2a.params.StateDB.ReadTxn())
+		for event := range frontendChanges {
+			if err := l2a.processFrontendEvent(event); err != nil {
+				l2a.params.Logger.Warn("Error processing frontend event",
+					logfields.Error, err,
+				)
+			}
+		}
+
 		select {
 		case <-ctx.Done():
 			break loop
 
 		case <-svcWatch:
+
+		case <-frontendWatch:
 
 		case event, more := <-policyChan:
 			// resource closed, shutting down
@@ -440,6 +458,16 @@ func (l2a *L2Announcer) processSvcEvent(event statedb.Change[*loadbalancer.Servi
 	}
 
 	return err
+}
+
+func (l2a *L2Announcer) processFrontendEvent(event statedb.Change[*loadbalancer.Frontend]) error {
+	name := event.Object.ServiceName
+	txn := l2a.params.StateDB.ReadTxn()
+	svc, _, found := l2a.params.Services.Get(txn, loadbalancer.ServiceByName(name))
+	if found {
+		return l2a.upsertSvc(svc)
+	}
+	return l2a.delSvc(types.NamespacedName{Namespace: name.Namespace(), Name: name.Name()})
 }
 
 func policyKey(policy *cilium_api_v2alpha1.CiliumL2AnnouncementPolicy) types.NamespacedName {

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -194,18 +194,20 @@ func (l2a *L2Announcer) run(ctx context.Context, health cell.Health) error {
 
 loop:
 	for {
-		svcChanges, svcWatch := svcChangeIter.Next(l2a.params.StateDB.ReadTxn())
+		rtxn := l2a.params.StateDB.ReadTxn()
+
+		svcChanges, svcWatch := svcChangeIter.Next(rtxn)
 		for event := range svcChanges {
-			if err := l2a.processSvcEvent(event); err != nil {
+			if err := l2a.processSvcEvent(rtxn, event); err != nil {
 				l2a.params.Logger.Warn("Error processing service event",
 					logfields.Error, err,
 				)
 			}
 		}
 
-		frontendChanges, frontendWatch := frontendChangeIter.Next(l2a.params.StateDB.ReadTxn())
+		frontendChanges, frontendWatch := frontendChangeIter.Next(rtxn)
 		for event := range frontendChanges {
-			if err := l2a.processFrontendEvent(event); err != nil {
+			if err := l2a.processFrontendEvent(rtxn, event); err != nil {
 				l2a.params.Logger.Warn("Error processing frontend event",
 					logfields.Error, err,
 				)
@@ -252,7 +254,7 @@ loop:
 			}
 
 		case <-watchDevices:
-			devices, watchDevices = tables.SelectedDevices(l2a.params.Devices, l2a.params.StateDB.ReadTxn())
+			devices, watchDevices = tables.SelectedDevices(l2a.params.Devices, rtxn)
 			deviceNames := tables.DeviceNames(devices)
 
 			if slices.Equal(l2a.devices, deviceNames) {
@@ -341,11 +343,9 @@ func (l2a *L2Announcer) processPolicyEvent(ctx context.Context, event resource.E
 	return err
 }
 
-func (l2a *L2Announcer) upsertSvc(svc *loadbalancer.Service) error {
-	txn := l2a.params.StateDB.ReadTxn()
-
+func (l2a *L2Announcer) upsertSvc(rtxn statedb.ReadTxn, svc *loadbalancer.Service) error {
 	// Lookup associated frontends
-	fes := l2a.params.Frontends.List(txn, loadbalancer.FrontendByServiceName(svc.Name))
+	fes := l2a.params.Frontends.List(rtxn, loadbalancer.FrontendByServiceName(svc.Name))
 	var lbAddresses, externalAddresses []netip.Addr
 	for fe := range fes {
 		if fe.Type == loadbalancer.SVCTypeExternalIPs {
@@ -443,10 +443,10 @@ func (l2a *L2Announcer) delSvc(key types.NamespacedName) error {
 	return nil
 }
 
-func (l2a *L2Announcer) processSvcEvent(event statedb.Change[*loadbalancer.Service]) error {
+func (l2a *L2Announcer) processSvcEvent(rtxn statedb.ReadTxn, event statedb.Change[*loadbalancer.Service]) error {
 	var err error
 	if !event.Deleted {
-		err = l2a.upsertSvc(event.Object)
+		err = l2a.upsertSvc(rtxn, event.Object)
 		if err != nil {
 			err = fmt.Errorf("upsert service: %w", err)
 		}
@@ -460,12 +460,11 @@ func (l2a *L2Announcer) processSvcEvent(event statedb.Change[*loadbalancer.Servi
 	return err
 }
 
-func (l2a *L2Announcer) processFrontendEvent(event statedb.Change[*loadbalancer.Frontend]) error {
+func (l2a *L2Announcer) processFrontendEvent(rtxn statedb.ReadTxn, event statedb.Change[*loadbalancer.Frontend]) error {
 	name := event.Object.ServiceName
-	txn := l2a.params.StateDB.ReadTxn()
-	svc, _, found := l2a.params.Services.Get(txn, loadbalancer.ServiceByName(name))
+	svc, _, found := l2a.params.Services.Get(rtxn, loadbalancer.ServiceByName(name))
 	if found {
-		return l2a.upsertSvc(svc)
+		return l2a.upsertSvc(rtxn, svc)
 	}
 	return l2a.delSvc(types.NamespacedName{Namespace: name.Namespace(), Name: name.Name()})
 }

--- a/pkg/l2announcer/l2announcer_test.go
+++ b/pkg/l2announcer/l2announcer_test.go
@@ -849,6 +849,59 @@ func TestPolicySelection(t *testing.T) {
 	})
 }
 
+func TestFrontendUpdateSelectsPreviouslyIgnoredService(t *testing.T) {
+	fix := newFixture(t)
+
+	policy := bluePolicy()
+	policy.Spec.LoadBalancerIPs = true
+	policy.Spec.ExternalIPs = false
+	fix.fakePolicyStore.slice = []*v2alpha1.CiliumL2AnnouncementPolicy{policy}
+
+	node := blueNode()
+	err := fix.announcer.processLocalNodeEvent(context.Background(), resource.Event[*v2.CiliumNode]{
+		Kind:   resource.Upsert,
+		Key:    resource.NewKey(node),
+		Object: node,
+		Done:   func(error) {},
+	})
+	require.NoError(t, err)
+
+	err = fix.announcer.processPolicyEvent(context.Background(), resource.Event[*v2alpha1.CiliumL2AnnouncementPolicy]{
+		Kind:   resource.Upsert,
+		Key:    resource.NewKey(policy),
+		Object: policy,
+		Done:   func(error) {},
+	})
+	require.NoError(t, err)
+
+	svc, fe := blueService()
+	fe.Type = loadbalancer.SVCTypeLoadBalancer
+
+	wtxn := fix.stateDB.WriteTxn(fix.svcs)
+	fix.svcs.Insert(wtxn, svc)
+	wtxn.Commit()
+
+	err = fix.announcer.processSvcEvent(statedb.Change[*loadbalancer.Service]{
+		Deleted: false,
+		Object:  svc,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, fix.announcer.selectedServices)
+
+	wtxn = fix.stateDB.WriteTxn(fix.fes)
+	fix.fes.Insert(wtxn, fe)
+	wtxn.Commit()
+
+	err = fix.announcer.processFrontendEvent(statedb.Change[*loadbalancer.Frontend]{
+		Deleted: false,
+		Object:  fe,
+	})
+	require.NoError(t, err)
+
+	assert.Len(t, fix.announcer.selectedServices, 1)
+	assert.Contains(t, fix.announcer.selectedServices, serviceKey(svc))
+}
+
 // Test that when the selected IP types in the policy changes, that proxy neighbor table is updated properly.
 func TestUpdatePolicy_ChangeIPType(t *testing.T) {
 	fix := baseUpdateSetup(t)

--- a/pkg/l2announcer/l2announcer_test.go
+++ b/pkg/l2announcer/l2announcer_test.go
@@ -254,7 +254,7 @@ func TestHappyPath(t *testing.T) {
 
 	svc, fe := blueService()
 	fix.insertService(svc, fe)
-	err = fix.announcer.processSvcEvent(statedb.Change[*loadbalancer.Service]{
+	err = fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
 		Object:  svc,
 	})
@@ -311,7 +311,7 @@ func TestHappyPathPermutations(t *testing.T) {
 	addService := func(fix *fixture, tt *testing.T) {
 		svc, fe := blueService()
 		fix.insertService(svc, fe)
-		err := fix.announcer.processSvcEvent(statedb.Change[*loadbalancer.Service]{
+		err := fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 			Deleted: false,
 			Object:  svc,
 		})
@@ -434,7 +434,7 @@ func TestPolicyRedundancy(t *testing.T) {
 	// Add service policy
 	svc, fe := blueService()
 	fix.insertService(svc, fe)
-	err = fix.announcer.processSvcEvent(statedb.Change[*loadbalancer.Service]{
+	err = fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
 		Object:  svc,
 	})
@@ -528,7 +528,7 @@ func baseUpdateSetup(t *testing.T) *fixture {
 
 	svc, fe := blueService()
 	fix.insertService(svc, fe)
-	err = fix.announcer.processSvcEvent(statedb.Change[*loadbalancer.Service]{
+	err = fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
 		Object:  svc,
 	})
@@ -614,7 +614,7 @@ func TestUpdateHostLabels_AdditionalMatch(t *testing.T) {
 	fe.ServiceName = svc.Name
 	require.NoError(t, fe.Address.ParseFromString("192.168.2.2:80/TCP"))
 	fix.insertService(svc, fe)
-	err = fix.announcer.processSvcEvent(statedb.Change[*loadbalancer.Service]{
+	err = fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
 		Object:  svc,
 	})
@@ -701,7 +701,7 @@ func TestUpdatePolicy_AdditionalMatch(t *testing.T) {
 	}, "k8s")
 	require.NoError(t, fe.Address.ParseFromString("192.168.2.2:80/TCP"))
 	fix.insertService(svc, fe)
-	err := fix.announcer.processSvcEvent(statedb.Change[*loadbalancer.Service]{
+	err := fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
 		Object:  svc,
 	})
@@ -761,7 +761,7 @@ func TestPolicySelection(t *testing.T) {
 	svc, fe := blueService()
 	fe.Type = loadbalancer.SVCTypeClusterIP
 	fix.insertService(svc, fe)
-	err = fix.announcer.processSvcEvent(statedb.Change[*loadbalancer.Service]{
+	err = fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
 		Object:  svc,
 	})
@@ -791,7 +791,7 @@ func TestPolicySelection(t *testing.T) {
 	fe.Type = loadbalancer.SVCTypeExternalIPs
 	require.NoError(t, fe.Address.ParseFromString("192.168.2.2:80/TCP"))
 	fix.insertService(svc, fe)
-	err = fix.announcer.processSvcEvent(statedb.Change[*loadbalancer.Service]{
+	err = fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
 		Object:  svc,
 	})
@@ -807,7 +807,7 @@ func TestPolicySelection(t *testing.T) {
 	require.NoError(t, fe.Address.ParseFromString("192.168.2.7:80/TCP"))
 	fix.insertService(svc, fe)
 
-	err = fix.announcer.processSvcEvent(statedb.Change[*loadbalancer.Service]{
+	err = fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
 		Object:  svc,
 	})
@@ -881,7 +881,7 @@ func TestFrontendUpdateSelectsPreviouslyIgnoredService(t *testing.T) {
 	fix.svcs.Insert(wtxn, svc)
 	wtxn.Commit()
 
-	err = fix.announcer.processSvcEvent(statedb.Change[*loadbalancer.Service]{
+	err = fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
 		Object:  svc,
 	})
@@ -892,7 +892,7 @@ func TestFrontendUpdateSelectsPreviouslyIgnoredService(t *testing.T) {
 	fix.fes.Insert(wtxn, fe)
 	wtxn.Commit()
 
-	err = fix.announcer.processFrontendEvent(statedb.Change[*loadbalancer.Frontend]{
+	err = fix.announcer.processFrontendEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Frontend]{
 		Deleted: false,
 		Object:  fe,
 	})
@@ -932,7 +932,7 @@ func TestUpdatePolicy_ChangeIPType(t *testing.T) {
 	fe.Type = loadbalancer.SVCTypeLoadBalancer
 	assert.NoError(t, fe.Address.ParseFromString("192.168.2.3:80/TCP"))
 	fix.insertService(svc, fe)
-	err = fix.announcer.processSvcEvent(statedb.Change[*loadbalancer.Service]{
+	err = fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
 		Object:  svc,
 	})
@@ -964,7 +964,7 @@ func TestUpdatePolicy_ChangeIPType(t *testing.T) {
 	fe = fe.Clone()
 	fe.Type = loadbalancer.SVCTypeClusterIP
 	fix.insertService(svc, fe)
-	err = fix.announcer.processSvcEvent(statedb.Change[*loadbalancer.Service]{
+	err = fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
 		Object:  svc,
 	})
@@ -1026,7 +1026,7 @@ func TestUpdateService_DelIP(t *testing.T) {
 	fix.fes.Delete(wtxn, fe)
 	wtxn.Commit()
 
-	err := fix.announcer.processSvcEvent(statedb.Change[*loadbalancer.Service]{
+	err := fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
 		Object:  svc,
 	})
@@ -1051,7 +1051,7 @@ func TestUpdateService_AddIP(t *testing.T) {
 	assert.NoError(t, fe2.Address.ParseFromString("192.168.2.2:80/TCP"))
 	fix.insertService(svc, fe1, fe2)
 
-	err := fix.announcer.processSvcEvent(statedb.Change[*loadbalancer.Service]{
+	err := fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
 		Object:  svc,
 	})
@@ -1072,7 +1072,7 @@ func TestUpdateService_NoMatch(t *testing.T) {
 	svc.Labels["color"] = labels.NewLabel("color", "red", "k8s")
 	fix.insertService(svc, fe)
 
-	err := fix.announcer.processSvcEvent(statedb.Change[*loadbalancer.Service]{
+	err := fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
 		Object:  svc,
 	})
@@ -1094,7 +1094,7 @@ func TestUpdateService_LoadBalancerClassMatch(t *testing.T) {
 	svc.LoadBalancerClass = ptr.To[string](v2alpha1.L2AnnounceLoadBalancerClass)
 	fix.insertService(svc, fe)
 
-	err := fix.announcer.processSvcEvent(statedb.Change[*loadbalancer.Service]{
+	err := fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
 		Object:  svc,
 	})
@@ -1116,7 +1116,7 @@ func TestUpdateService_LoadBalancerClassNotMatch(t *testing.T) {
 	svc.LoadBalancerClass = ptr.To[string]("unsupported.io/lb-class")
 	fix.insertService(svc, fe)
 
-	err := fix.announcer.processSvcEvent(statedb.Change[*loadbalancer.Service]{
+	err := fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: false,
 		Object:  svc,
 	})
@@ -1139,7 +1139,7 @@ func TestDelService(t *testing.T) {
 	wtxn.Commit()
 	svc, _ := blueService()
 
-	err := fix.announcer.processSvcEvent(statedb.Change[*loadbalancer.Service]{
+	err := fix.announcer.processSvcEvent(fix.stateDB.ReadTxn(), statedb.Change[*loadbalancer.Service]{
 		Deleted: true,
 		Object:  svc,
 	})


### PR DESCRIPTION
The L2 announcer decides whether a Service should participate in L2 announcement based on both the Service object and its associated frontend entries. In particular, LoadBalancer and ExternalIP announcement depends on the presence of the corresponding frontends.

Before this change, the announcer only reacted to Service table changes. If a Service was observed before its LoadBalancer frontend had been written, it was ignored and never reconsidered. This could leave the service present in the load-balancer maps but missing from L2 announcement.

Fix this by watching frontend changes as well and re-running service selection for the owning Service whenever a frontend is added, updated, or removed.