### PR TITLE
envoy: restore http-idle-timeout as the route idle timeout source

### DIFF
--- a/pkg/envoy/cell.go
+++ b/pkg/envoy/cell.go
@@ -102,7 +102,7 @@ func newEnvoyXDSServer(params xdsServerParams) (XDSServer, error) {
 		envoySocketDir:                util.GetSocketDir(option.Config.RunDir),
 		proxyGID:                      int(params.EnvoyProxyConfig.ProxyGID),
 		httpRequestTimeout:            int(params.EnvoyProxyConfig.HTTPRequestTimeout),
-		httpIdleTimeout:               params.EnvoyProxyConfig.ProxyIdleTimeoutSeconds,
+		httpIdleTimeout:               int(params.EnvoyProxyConfig.HTTPIdleTimeout),
 		httpMaxGRPCTimeout:            int(params.EnvoyProxyConfig.HTTPMaxGRPCTimeout),
 		httpRetryCount:                int(params.EnvoyProxyConfig.HTTPRetryCount),
 		httpRetryTimeout:              int(params.EnvoyProxyConfig.HTTPRetryTimeout),


### PR DESCRIPTION
The route level `idle_timeout` on the L7 policy HTTP connection manager is built from `xdsServerConfig.httpIdleTimeout`, and `pkg/envoy/cell.go` was filling that from `ProxyIdleTimeoutSeconds` instead of `HTTPIdleTimeout`. Every other field in that struct literal pairs with its same named config value, and `HTTPIdleTimeout` was left declared at `pkg/envoy/config/config.go:113` and read nowhere.

Before c4bd58d18c the route `idle_timeout` came from `option.Config.HTTPIdleTimeout`, whose `--http-idle-timeout` flag defaults to 0, so the timeout was disabled unless someone asked for it. That commit moved the Envoy config into the hive cell and swapped the source to `--proxy-idle-timeout-seconds`, which defaults to 60, so the effective default silently became 60s.

The two flags do not mean the same thing:

    --proxy-idle-timeout-seconds  Set Envoy upstream HTTP idle connection timeout in
                                  seconds. Does not apply to connections with pending
                                  requests. (default 60)

That description is accurate for the bootstrap cluster `commonHttpProtocolOptions.idleTimeout`, which this flag still feeds and which this PR does not touch. Envoy enforces it there: `CodecClient::newStream()` calls `disableIdleTimer()`, and the timer is only re-armed once the connection has no active requests, so a cluster idle reap cannot interrupt an in flight request.

It is not accurate for a route level `idle_timeout`. That one bounds a request that is waiting for a response, and `ConnectionManagerImpl::ActiveStream::refreshIdleTimeout()` lets the route value overwrite the connection manager `stream_idle_timeout`. When it expires on a fully received request, Envoy answers 504 with a `stream timeout` body. So lowering `--proxy-idle-timeout-seconds` to reap idle upstream connections also caps how long any single L7 proxied request may take, which is the opposite of what the flag advertises.

I ran into this while triaging an e2e-upgrade failure where the L7 conn-disrupt clients got 504s: the served Envoy config had `routes[1].idle_timeout=3s` against `stream_idle_timeout=300s` and `routes[1].timeout=3600s`, and `envoy_http_downstream_rq_idle_timeout{envoy_http_conn_manager_prefix="proxy"}` counted the firings. The 504 rather than the 408 the proto comments mention is expected: `Utility::maybeRequestTimeoutCode()` returns `GatewayTimeout` once the request is fully received, gated by a runtime feature that defaults to true.

The fix points `httpIdleTimeout` back at `HTTPIdleTimeout`. This revives the documented `--http-idle-timeout` knob, restores the disabled by default behaviour, and leaves `--proxy-idle-timeout-seconds` doing only what it claims to. The operator side is already correct and is untouched: its `IdleTimeoutSeconds` goes to `operator/pkg/model/translation/envoy_cluster.go`, an upstream cluster idle timeout.

Worth reviewer attention, since this is a behaviour change on a user facing flag: anyone who has come to depend on the 60s route idle timeout that has been in place since c4bd58d18c needs to set `--http-idle-timeout` explicitly. I marked it `kind/regression` and requested backports on that basis, but the release note wording and how far back to carry it are a sig call.

This PR was prepared with AIL:3.
