### PR TITLE
docs: clarify GAMMA DROP_EP_NOT_READY events

### DIFF
--- a/Documentation/network/servicemesh/gateway-api/gamma.rst
+++ b/Documentation/network/servicemesh/gateway-api/gamma.rst
@@ -73,4 +73,17 @@ experimental as at Gateway API v1.0.0.
 Cilium currently does not support "consumer" HTTPRoutes, and so does not  
 support the ``MeshConsumerRoute`` feature of the Mesh conformance profile.  
 
+.. note::
+
+   During workload termination or rolling updates, Hubble may report
+   ``DROP_EP_NOT_READY`` events for GAMMA traffic. An Envoy upstream TCP
+   connection can outlive the source endpoint whose traffic created it. After
+   Cilium removes that endpoint's policy program, packets that close the
+   remaining connection can be dropped.
+
+   These events are generally harmless when they are limited to closing TCP
+   connections and application requests continue to succeed. Drops that affect
+   new connections or coincide with request failures should be separately
+   investigated.
+
 .. include:: installation.rst


### PR DESCRIPTION
During workload churn, Hubble may report `DROP_EP_NOT_READY` when Envoy upstream TCP connections outlive the source endpoint. The behavioral change submitted in https://github.com/cilium/cilium/pull/46508 would likely add too much complexity for a somewhat cosmetic issue. This PR instead adds a note to the GAMMA docs to mention this caveat.

Related to: #41970