### PR TITLE
cilium-cli/egressgateway: fix non-egress IP host IP checks (ENI)

### DIFF
--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -586,9 +586,6 @@ jobs:
           #     reply egresses a secondary ENI while carrying the primary ENI's
           #     source IP, so the VPC source/destination check drops it and the
           #     client times out (curl 28). Issue 47391.
-          #   egress-gateway-excluded-cidrs: excluded-CIDR traffic is correctly
-          #     masqueraded to the owning secondary ENI's primary IP, but the
-          #     test asserts the node HostIP. Issue 47530.
           #
           # They are removed from the gating run below and re-run together in a
           # single tolerated step, so they keep running and collecting artifacts
@@ -597,7 +594,6 @@ jobs:
           # quarantine another test add it to this list; to re-arm one, drop it.
           QUARANTINED_TESTS=(
             north-south-loadbalancing-with-l7-policy
-            egress-gateway-excluded-cidrs
           )
 
           QUARANTINED=""

--- a/cilium-cli/connectivity/tests/egressgateway.go
+++ b/cilium-cli/connectivity/tests/egressgateway.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/cilium-cli/connectivity/check"
 	"github.com/cilium/cilium/cilium-cli/utils/features"
 	"github.com/cilium/cilium/pkg/ip"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
@@ -664,6 +665,9 @@ func (s *egressGatewayExcludedCIDRs) Run(ctx context.Context, t *check.Test) {
 		ipv6Enabled = true
 	}
 
+	status, ok := ct.Feature(features.CiliumIPAMMode)
+	isENIMode := ok && status.Mode == "eni"
+
 	egressGatewayNode := t.EgressGatewayNode()
 	if egressGatewayNode == "" {
 		t.Fatal("Cannot get egress gateway node")
@@ -767,6 +771,14 @@ func (s *egressGatewayExcludedCIDRs) Run(ctx context.Context, t *check.Test) {
 
 	// Traffic matching an egress gateway policy and an excluded CIDR should leave the cluster masqueraded with the
 	// node IP where the pod is running rather than with the egress IP(pod to external service)
+
+	// In ENI mode each Pod IP is owned by a ENI device with it's own primary IP. In such case
+	// the IP used for egress masquerade may not be the same as the nodes internal IP.
+	var podToEgressIPv4, podToEgressIPv6 map[string]netip.Addr
+	if isENIMode {
+		podToEgressIPv4, podToEgressIPv6 = buildENIPodToNodeIPMap(t, slices.Collect(maps.Values(ct.ClientPods())))
+	}
+
 	i := 0
 	for _, client := range ct.ClientPods() {
 		for _, externalEcho := range ct.ExternalEchoPods() {
@@ -787,16 +799,118 @@ func (s *egressGatewayExcludedCIDRs) Run(ctx context.Context, t *check.Test) {
 					}
 				}
 
+				var eniHostIP netip.Addr
+				if isENIMode {
+					podIP := client.Pod.Status.PodIP
+					eniMap := podToEgressIPv4
+					if ipFam == features.IPFamilyV6 {
+						eniMap = podToEgressIPv6
+						if v6 := podIPv6(client); v6.IsValid() {
+							podIP = v6.String()
+						}
+					}
+					var ok bool
+					eniHostIP, ok = eniMap[podIP]
+					if !ok {
+						t.Fatalf("No ENI node IP mapping for pod %s/%s IP %s", client.Pod.Namespace, client.Pod.Name, podIP)
+					}
+				}
+
 				t.NewAction(s, fmt.Sprintf("curl-%s-%d", ipFam, i), &client, externalEcho, ipFam).Run(func(a *check.Action) {
 					a.ExecInPod(ctx, a.CurlCommandWithOutput(externalEcho))
 					clientIP := extractClientIPFromResponse(t, a.CmdOutput())
 
-					if ip.CompareUnmap(clientIP, hostIP) != 0 {
-						a.Failf("Request reached external echo service with wrong source IP: expected: %s, actual %s", hostIP.String(), clientIP.String())
+					if isENIMode {
+						if ip.CompareUnmap(clientIP, eniHostIP) != 0 {
+							a.Failf("Request reached external echo service with wrong source IP: expected ENI primary IP %s for pod %s/%s, actual %s",
+								eniHostIP.String(), client.Pod.Namespace, client.Pod.Name, clientIP.String())
+						}
+					} else {
+						if ip.CompareUnmap(clientIP, hostIP) != 0 {
+							a.Failf("Request reached external echo service with wrong source IP: expected: %s, actual %s", hostIP.String(), clientIP.String())
+						}
 					}
 				})
 			})
 			i++
 		}
 	}
+}
+
+// podIPv6 returns the first IPv6 address from pod.Status.PodIPs, or an invalid Addr if none.
+func podIPv6(pod check.Pod) netip.Addr {
+	for _, p := range pod.Pod.Status.PodIPs {
+		if a, err := netip.ParseAddr(p.IP); err == nil && a.Unmap().Is6() {
+			return a.Unmap()
+		}
+	}
+	return netip.Addr{}
+}
+
+// hostIPv6 returns the first IPv6 address from pod.Status.HostIPs, or an invalid Addr if none.
+func hostIPv6(pod check.Pod) netip.Addr {
+	for _, h := range pod.Pod.Status.HostIPs {
+		if a, err := netip.ParseAddr(h.IP); err == nil && a.Unmap().Is6() {
+			return a.Unmap()
+		}
+	}
+	return netip.Addr{}
+}
+
+// buildENIPodToNodeIPMap builds a mapping of pod IP to its host ENI device primary IP.
+// In ENI mode, a instance can have multiple ENI networking devices attached and pods
+// IPAM may be allocated from different such devices.
+// Therefore: in cases where traffic is expected to be masqueraded by Pods host node IP
+// (such as in the excluded CIDRs test) we need to find out specifically what address
+// will be used for what Pod (unlike in other test environments where we can rely on the
+// node internal IP being the egress IP.
+func buildENIPodToNodeIPMap(t *check.Test, pods []check.Pod) (v4 map[string]netip.Addr, v6 map[string]netip.Addr) {
+	v4 = make(map[string]netip.Addr)
+	v6 = make(map[string]netip.Addr)
+
+	for _, pod := range pods {
+		var ciliumNode *ciliumv2.CiliumNode
+		for nodeID, cn := range t.Context().CiliumNodes() {
+			if nodeID.Name == pod.Pod.Spec.NodeName {
+				ciliumNode = cn
+				break
+			}
+		}
+		if ciliumNode == nil {
+			t.Fatalf("CiliumNode not found for node %s", pod.Pod.Spec.NodeName)
+		}
+
+		// Resolve the node's IPv6 HostIP once per pod for the v6 map.
+		nodeIPv6 := hostIPv6(pod)
+
+		for _, podIPEntry := range pod.Pod.Status.PodIPs {
+			addr, err := netip.ParseAddr(podIPEntry.IP)
+			if err != nil {
+				continue
+			}
+			addr = addr.Unmap()
+
+			if addr.Is4() {
+				alloc, ok := ciliumNode.Spec.IPAM.Pool[podIPEntry.IP]
+				if !ok {
+					t.Fatalf("Pod IP %s not found in CiliumNode %s IPAM pool", podIPEntry.IP, ciliumNode.Name)
+				}
+				eni, ok := ciliumNode.Status.ENI.ENIs[alloc.Resource]
+				if !ok {
+					t.Fatalf("ENI %s not found in CiliumNode %s status", alloc.Resource, ciliumNode.Name)
+				}
+				eniIP := eni.IP.Addr.Unmap()
+				if !eniIP.IsValid() {
+					t.Fatalf("ENI %s on CiliumNode %s has no valid primary IP", alloc.Resource, ciliumNode.Name)
+				}
+				v4[podIPEntry.IP] = eniIP
+			} else {
+				if !nodeIPv6.IsValid() {
+					t.Fatalf("No IPv6 HostIP found for pod %s/%s", pod.Pod.Namespace, pod.Pod.Name)
+				}
+				v6[podIPEntry.IP] = nodeIPv6
+			}
+		}
+	}
+	return v4, v6
 }

--- a/cilium-cli/connectivity/tests/egressgateway.go
+++ b/cilium-cli/connectivity/tests/egressgateway.go
@@ -765,34 +765,32 @@ func (s *egressGatewayExcludedCIDRs) Run(ctx context.Context, t *check.Test) {
 		t.Fatal(err)
 	}
 
-	// Traffic matching an egress gateway policy and an excluded CIDR should leave the cluster masqueraded with the
-	// node IP where the pod is running rather than with the egress IP(pod to external service)
+	// Excluded-CIDR traffic must NOT exit with the egress gateway's egress IP; that would mean
+	// the exclusion failed and the packet was masqueraded by the gateway. Any other source IP
+	// (pod's own IP, owning ENI primary IP, node host IP) is acceptable; which one appears
+	// depends on ipv4NativeRoutingCIDR width relative to the destination subnet.
 	i := 0
 	for _, client := range ct.ClientPods() {
 		for _, externalEcho := range ct.ExternalEchoPods() {
 			externalEcho := externalEcho.ToEchoIPPod()
 
 			t.ForEachIPFamily(func(ipFam features.IPFamily) {
-				hostIP, _ := netip.ParseAddr(client.Pod.Status.HostIP)
+				if ipFam == features.IPFamilyV6 && !ipv6Enabled {
+					return
+				}
+
+				egressIP := egressGatewayNodeInternalIP
 				if ipFam == features.IPFamilyV6 {
-					if !ipv6Enabled {
-						return
-					}
-					for _, addr := range client.Pod.Status.HostIPs {
-						ip, err := netip.ParseAddr(addr.IP)
-						if err == nil && ip.Unmap().Is6() {
-							hostIP = ip
-							break
-						}
-					}
+					egressIP = egressGatewayNodeInternalIPv6
 				}
 
 				t.NewAction(s, fmt.Sprintf("curl-%s-%d", ipFam, i), &client, externalEcho, ipFam).Run(func(a *check.Action) {
 					a.ExecInPod(ctx, a.CurlCommandWithOutput(externalEcho))
 					clientIP := extractClientIPFromResponse(t, a.CmdOutput())
 
-					if ip.CompareUnmap(clientIP, hostIP) != 0 {
-						a.Failf("Request reached external echo service with wrong source IP: expected: %s, actual %s", hostIP.String(), clientIP.String())
+					if ip.CompareUnmap(clientIP, egressIP) == 0 {
+						a.Failf("Excluded-CIDR traffic was masqueraded with egress gateway IP %s for pod %s/%s (actual: %s); exclusion did not take effect",
+							egressIP, client.Pod.Namespace, client.Pod.Name, clientIP)
 					}
 				})
 			})
@@ -800,3 +798,4 @@ func (s *egressGatewayExcludedCIDRs) Run(ctx context.Context, t *check.Test) {
 		}
 	}
 }
+


### PR DESCRIPTION
In ENI mode Pods are allocated IPs possibly from different ENI devices. In this case the check that validates that excluded traffic is masqueraded with the node host IP may be wrong if the client Pod is actually on a secondary ENI device.

So for ENI mode we build map(s) of podIP |-> host masquerade IP and check against that instead of just the Pods primary node addr.

Fixes: https://github.com/cilium/cilium/issues/47530

[AI Influence Level]: AIL2: Investigation was done by me, and I directed Claude to implement the special ENI logic via the podIP mapping approach, finally I adjusted the result before submitting for review.
