### PR TITLE
hubble: don't attempt to correlate a policy on default deny

### DIFF
--- a/pkg/policy/correlation/correlation.go
+++ b/pkg/policy/correlation/correlation.go
@@ -28,14 +28,12 @@ func CorrelatePolicy(logger *slog.Logger, endpointGetter getters.EndpointGetter,
 	}
 
 	// We are only interested in flows which are either allowed (i.e. the verdict is either
-	// FORWARDED or REDIRECTED), denied by policy (i.e. DROPPED with a policy deny reason),
-	// or audited (i.e. AUDIT, which represents traffic allowed due to audit mode that would
-	// have been denied otherwise).
+	// FORWARDED or REDIRECTED) or explicitly denied (i.e. DROPPED, and matched by a deny policy),
+	// since we cannot usefully annotate the verdict otherwise. (Put differently, which policy
+	// should be listed in {in|e}gress_denied_by for an unmatched flow?)
 	verdict := f.GetVerdict()
 	allowed := verdict == flowpb.Verdict_FORWARDED || verdict == flowpb.Verdict_REDIRECTED
-	dropReason := f.GetDropReasonDesc()
-	denied := verdict == flowpb.Verdict_DROPPED &&
-		(dropReason == flowpb.DropReason_POLICY_DENY || dropReason == flowpb.DropReason_POLICY_DENIED)
+	denied := verdict == flowpb.Verdict_DROPPED && f.GetDropReasonDesc() == flowpb.DropReason_POLICY_DENY
 	audited := verdict == flowpb.Verdict_AUDIT
 	if !(allowed || denied || audited) {
 		return

--- a/pkg/policy/correlation/correlation_test.go
+++ b/pkg/policy/correlation/correlation_test.go
@@ -703,20 +703,6 @@ func TestCorrelatePolicyImplicitDeny(t *testing.T) {
 	dstPort := uint32(443)
 
 	policyLabel := utils.GetPolicyLabels("foo-namespace", "web-policy", "1234-5678", utils.ResourceTypeCiliumNetworkPolicy)
-	expected := []*flowpb.Policy{
-		{
-			Name:      "web-policy",
-			Namespace: "foo-namespace",
-			Kind:      utils.ResourceTypeCiliumNetworkPolicy,
-			Labels: []string{
-				"k8s:io.cilium.k8s.policy.derived-from=CiliumNetworkPolicy",
-				"k8s:io.cilium.k8s.policy.name=web-policy",
-				"k8s:io.cilium.k8s.policy.namespace=foo-namespace",
-				"k8s:io.cilium.k8s.policy.uid=1234-5678",
-			},
-			Revision: 1,
-		},
-	}
 
 	// DropReason_POLICY_DENIED (implicit deny, code 133) at egress
 	policyKey := policy.EgressKey().WithIdentity(identity.NumericIdentity(remoteIdentity)).WithTCPPort(uint16(dstPort))
@@ -755,7 +741,8 @@ func TestCorrelatePolicyImplicitDeny(t *testing.T) {
 		L4: &flowpb.Layer4{
 			Protocol: &flowpb.Layer4_TCP{
 				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
+					// NOTE: not the allowed dstPort=443
+					DestinationPort: 8080,
 				},
 			},
 		},
@@ -767,16 +754,14 @@ func TestCorrelatePolicyImplicitDeny(t *testing.T) {
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
-		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
+		PolicyMatchType: monitorAPI.PolicyMatchNone,
 	}
 	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
 
 	require.Nil(t, flow.EgressAllowedBy)
 	require.Nil(t, flow.IngressAllowedBy)
 	require.Nil(t, flow.IngressDeniedBy)
-	if diff := cmp.Diff(expected, flow.EgressDeniedBy, protocmp.Transform()); diff != "" {
-		t.Fatalf("not equal (-want +got):\n%s", diff)
-	}
+	require.Nil(t, flow.EgressDeniedBy)
 
 	// DropReason_POLICY_DENIED at ingress
 	policyKey = policy.IngressKey().WithIdentity(identity.NumericIdentity(localIdentity)).WithTCPPort(uint16(dstPort))
@@ -815,7 +800,8 @@ func TestCorrelatePolicyImplicitDeny(t *testing.T) {
 		L4: &flowpb.Layer4{
 			Protocol: &flowpb.Layer4_TCP{
 				TCP: &flowpb.TCP{
-					DestinationPort: dstPort,
+					// NOTE: not the allowed dstPort=443
+					DestinationPort: 8080,
 				},
 			},
 		},
@@ -827,16 +813,14 @@ func TestCorrelatePolicyImplicitDeny(t *testing.T) {
 			ID:       remoteID,
 			Identity: remoteIdentity,
 		},
-		PolicyMatchType: monitorAPI.PolicyMatchL3L4,
+		PolicyMatchType: monitorAPI.PolicyMatchNone,
 	}
 	CorrelatePolicy(hivetest.Logger(t), endpointGetter, flow)
 
 	require.Nil(t, flow.EgressAllowedBy)
 	require.Nil(t, flow.IngressAllowedBy)
 	require.Nil(t, flow.EgressDeniedBy)
-	if diff := cmp.Diff(expected, flow.IngressDeniedBy, protocmp.Transform()); diff != "" {
-		t.Fatalf("not equal (-want +got):\n%s", diff)
-	}
+	require.Nil(t, flow.IngressDeniedBy)
 }
 
 func TestCorrelatePolicy_PortRange(t *testing.T) {


### PR DESCRIPTION
See https://github.com/cilium/cilium/pull/45373#issuecomment-5099998496 for context.

Revert part two of f966f5359d2f407e44542b26232bab6d30200cca ("hubble: correlate policy for audit verdicts and implicit denies") which attempted to do policy attribution for `POLICY_DENIED` flows (default deny).

Adapt `TestCorrelatePolicyImplicitDeny` avoiding setting a `PolicyMatchType` as datapath don't set it in the `POLICY_DENIED` case.