### PR TITLE
bpf: dsr: fix CT update in remote note's ingress path

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -577,7 +577,8 @@ nodeport_extract_dsr_v6(struct __ctx_buff *ctx,
 		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
 			return DROP_CT_INVALID_HDR;
 
-		ipv6_ct_tuple_reverse(&tmp);
+		tmp.flags = TUPLE_F_OUT;
+		__ipv6_ct_tuple_reverse(&tmp);
 
 		if (tcp_flags.value & TCP_FLAG_SYN) {
 			/* SYN for a new connection that's not / no longer DSR.
@@ -1951,7 +1952,9 @@ nodeport_extract_dsr_v4(struct __ctx_buff *ctx,
 		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
 			return DROP_CT_INVALID_HDR;
 
-		ipv4_ct_tuple_reverse(&tmp);
+		/* tuple direction only gets initialized on the first CT lookup */
+		tmp.flags = TUPLE_F_OUT;
+		__ipv4_ct_tuple_reverse(&tmp);
 
 		if (tcp_flags.value & TCP_FLAG_SYN) {
 			/* SYN for a new connection that's not / no longer DSR.


### PR DESCRIPTION
When a DSR-enabled node receives a TCP packet with SYN flag but *without* DSR info, it updates the connection's DSR status to 'false'. This addresses scenarios where a connection is re-opened by the same client, but this time directly towards the backend (without a service inbetween).

But since we're using a CT tuple that hasn't been used for a CT lookup, its direction flag isn't set yet. And so the call to ct_update_dsr() is not effective, since it doesn't even find the expected CT entry.

Fix this by setting the TUPLE_F_OUT manually.

```release-note
Fix unintended RevDNAT for client-to-pod TCP connections, when an identical connection was previously established through a DSR Service.
```