### PR TITLE
Revert "bpf: conntrack: don't report SYN-ACK as 'observed SYN'"

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -46,7 +46,7 @@ struct ct_state {
 	__u16 loopback:1,
 	      node_port:1,
 	      dsr_internal:1,   /* DSR is k8s service related, cluster internal */
-	      syn:1,		/* Is a TCP SYN */
+	      syn:1,
 	      proxy_redirect:1,	/* Connection is redirected to a proxy */
 	      from_l7lb:1,	/* Connection is originated from an L7 LB proxy */
 	      reserved1:1,	/* Was auth_required, not used in production anywhere */
@@ -681,8 +681,7 @@ __ct_lookup6(const void *map, struct ipv6_ct_tuple *tuple, const struct __ctx_bu
 
 		action = ct_tcp_select_action(tcp_flags);
 
-		if (ct_state && dir == CT_SERVICE &&
-		    (tcp_flags.value & TCP_FLAG_SYN) && !(tcp_flags.value & TCP_FLAG_ACK))
+		if (ct_state && dir == CT_SERVICE && (tcp_flags.value & TCP_FLAG_SYN))
 			ct_state->syn = true;
 	} else {
 		action = ACTION_UNSPEC;
@@ -943,8 +942,7 @@ __ct_lookup4(const void *map, struct ipv4_ct_tuple *tuple, const struct __ctx_bu
 
 		action = ct_tcp_select_action(tcp_flags);
 
-		if (ct_state && dir == CT_SERVICE &&
-		    (tcp_flags.value & TCP_FLAG_SYN) && !(tcp_flags.value & TCP_FLAG_ACK))
+		if (ct_state && dir == CT_SERVICE && (tcp_flags.value & TCP_FLAG_SYN))
 			ct_state->syn = true;
 	} else {
 		action = ACTION_UNSPEC;

--- a/bpf/tests/kpr_dsr_lb.h
+++ b/bpf/tests/kpr_dsr_lb.h
@@ -430,8 +430,8 @@ int kpr_v4_dsr_lb1_synack_check(__maybe_unused const struct __ctx_buff *ctx)
 	if (tunnel_key->tunnel_id != WORLD_ID)
 		test_fatal("tunnel id is not correct");
 
-	if (tunnel_opt_set)
-		test_fatal("DSR opt set");
+	if (!tunnel_opt_set)
+		test_fatal("expected DSR opt");
 # endif
 #else
 # ifdef ATTACHMENT_XDP
@@ -828,8 +828,8 @@ int kpr_v6_dsr_lb1_synack_check(__maybe_unused const struct __ctx_buff *ctx)
 	if (tunnel_key->tunnel_id != WORLD_ID)
 		test_fatal("tunnel id is not correct");
 
-	if (tunnel_opt_set)
-		test_fatal("DSR opt set");
+	if (!tunnel_opt_set)
+		test_fatal("expected DSR opt");
 # endif
 #else
 # ifdef ATTACHMENT_XDP

--- a/bpf/tests/scapy/kpr_dsr_pkt_defs.py
+++ b/bpf/tests/scapy/kpr_dsr_pkt_defs.py
@@ -110,13 +110,15 @@ kpr_v4_dsr_lb1_synack = (
 
 kpr_v4_dsr_lb1_synack_post_option = (
     Ether(src=host_mac_addr, dst=mac_one) /
-    IP(src=v4_ext_one, dst=v4_pod_one, ttl=63) /
+    IP(src=v4_ext_one, dst=v4_pod_one, ttl=63,
+       options=[bytes(IPOption_DSR(port=tcp_svc_one, addr=v4_svc_one))]) /
     TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA")
 )
 
 kpr_v4_dsr_lb1_synack_post_option_xdp = (
     Ether(src=mac_one, dst=mac_two) /
-    IP(src=v4_ext_one, dst=v4_pod_one, ttl=63) /
+    IP(src=v4_ext_one, dst=v4_pod_one, ttl=63,
+       options=[bytes(IPOption_DSR(port=tcp_svc_one, addr=v4_svc_one))]) /
     TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA")
 )
 
@@ -130,7 +132,8 @@ kpr_v4_dsr_lb1_synack_post_geneve_xdp = (
     Ether(src=mac_one, dst=mac_two) /
     IP(src=v4_node_one, dst=v4_node_two, id=0, ttl=63) /
     UDP(sport=56602, dport=6081, chksum=0) /
-    GENEVE(vni=2,proto=0x6558) /
+    GENEVE(vni=2,proto=0x6558,
+           options=[Geneve_DSR_Opt4(addr=v4_svc_one, port=tcp_svc_one)]) /
     Ether(src=host_mac_addr, dst=mac_one) /
     IP(src=v4_ext_one, dst=v4_pod_one) /
     TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA")
@@ -274,14 +277,16 @@ kpr_v6_dsr_lb1_synack = (
 
 kpr_v6_dsr_lb1_synack_post_option = (
     Ether(src=host_mac_addr, dst=mac_one) /
-    IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
-    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA")
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one, nh=60) /
+    IPv6Ext_DSR(addr=v6_svc_one, port=tcp_svc_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA", chksum=50261)
 )
 
 kpr_v6_dsr_lb1_synack_post_option_xdp = (
     Ether(src=mac_one, dst=mac_two) /
-    IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
-    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA")
+    IPv6(src=v6_ext_node_one, dst=v6_pod_one, nh=60) /
+    IPv6Ext_DSR(addr=v6_svc_one, port=tcp_svc_one) /
+    TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA", chksum=50261)
 )
 
 kpr_v6_dsr_lb1_synack_post_geneve = (
@@ -294,7 +299,8 @@ kpr_v6_dsr_lb1_synack_post_geneve_xdp = (
     Ether(src=mac_one, dst=mac_two) /
     IP(src=v4_node_one, dst=v4_node_two, id=0) /
     UDP(sport=52625, dport=6081, chksum=0) /
-    GENEVE(vni=2,proto=0x6558) /
+    GENEVE(vni=2,proto=0x6558,
+           options=[Geneve_DSR_Opt6(addr=v6_svc_one, port=tcp_svc_one)]) /
     Ether(src=host_mac_addr, dst=mac_one) /
     IPv6(src=v6_ext_node_one, dst=v6_pod_one) /
     TCP(sport=tcp_src_one, dport=tcp_dst_one, flags="SA")


### PR DESCRIPTION
This reverts commit 82d2d5125a7da6a802cc607f96d7dc5ffa660b1b.

The change itself is correct. But it also needs a fix in the ingress path on the remote node, so that
nodeport_extract_dsr_v*() doesn't expect DSR-info in the SYN-ACK packet. This will need to go out first for upgrade compatibility reasons.

Also update the generated SYN-ACK packet in a few tests that have been added in the meantime.