### PR TITLE
gateway-api: report invalid HTTPRoute header modifiers in status

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -2015,15 +2015,14 @@ func (r *gatewayReconciler) setHTTPRouteStatuses(scopedLog *slog.Logger, ctx con
 
 		// Route-specific checks will go in here separately if required.
 
-		if cond, invalid := i.ValidateHeaderModifier(); invalid {
-			for _, parent := range hr.Status.Parents {
-				i.SetParentCondition(parent.ParentRef, cond)
-			}
-		}
-
-		if cond, invalid := i.ValidateMatchRegexps(); invalid {
-			for _, parent := range hr.Status.Parents {
-				i.SetParentCondition(parent.ParentRef, cond)
+		for _, validate := range []func() (metav1.Condition, bool){
+			i.ValidateHeaderModifier,
+			i.ValidateMatchRegexps,
+		} {
+			if cond, invalid := validate(); invalid {
+				for _, parent := range hr.Status.Parents {
+					i.SetParentCondition(parent.ParentRef, cond)
+				}
 			}
 		}
 

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -2015,9 +2015,10 @@ func (r *gatewayReconciler) setHTTPRouteStatuses(scopedLog *slog.Logger, ctx con
 
 		// Route-specific checks will go in here separately if required.
 
-		// Validate the HTTPRoute header name
-		if err := i.ValidateHeaderModifier(); err != nil {
-			return r.handleHTTPRouteReconcileErrorWithStatus(ctx, scopedLog, err, &original, hr)
+		if cond, invalid := i.ValidateHeaderModifier(); invalid {
+			for _, parent := range hr.Status.Parents {
+				i.SetParentCondition(parent.ParentRef, cond)
+			}
 		}
 
 		if cond, invalid := i.ValidateMatchRegexps(); invalid {

--- a/operator/pkg/gateway-api/routechecks/httproute.go
+++ b/operator/pkg/gateway-api/routechecks/httproute.go
@@ -174,20 +174,29 @@ func (t *HTTPRouteRule) GetBackendRefs() []gatewayv1.BackendRef {
 	return refs
 }
 
-// Validates the HTTPRoute header
-func (r *HTTPRouteInput) ValidateHeaderModifier() error {
+func invalidHeaderModifierCondition(headerName gatewayv1.HTTPHeaderName) metav1.Condition {
+	return metav1.Condition{
+		Type:    string(gatewayv1.RouteConditionAccepted),
+		Status:  metav1.ConditionFalse,
+		Reason:  string(gatewayv1.RouteReasonUnsupportedValue),
+		Message: fmt.Sprintf("Invalid HTTPRoute header modifier: %q header is not supported; use URLRewrite.hostname instead", headerName),
+	}
+}
+
+// Validates the HTTPRoute header modifiers.
+func (r *HTTPRouteInput) ValidateHeaderModifier() (metav1.Condition, bool) {
 	for _, backendref := range r.HTTPRoute.Spec.Rules {
 		for _, f := range backendref.Filters {
 			if f.Type == gatewayv1.HTTPRouteFilterRequestHeaderModifier {
 				for _, set := range f.RequestHeaderModifier.Set {
 					if set.Name == "Host" {
-						return fmt.Errorf("Invalid HTTPRoute header: %q", set.Name)
+						return invalidHeaderModifierCondition(set.Name), true
 					}
 				}
 			}
 		}
 	}
-	return nil
+	return metav1.Condition{}, false
 }
 
 func invalidRegexCondition(field string, err error) metav1.Condition {

--- a/operator/pkg/gateway-api/routechecks/httproute_test.go
+++ b/operator/pkg/gateway-api/routechecks/httproute_test.go
@@ -12,6 +12,66 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
+func TestHTTPRouteValidateHeaderModifier(t *testing.T) {
+	tests := []struct {
+		name    string
+		filters []gatewayv1.HTTPRouteFilter
+		invalid bool
+	}{
+		{
+			name: "valid request header modifier",
+			filters: []gatewayv1.HTTPRouteFilter{{
+				Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Set: []gatewayv1.HTTPHeader{{
+						Name:  "X-Forwarded-Host",
+						Value: "example.com",
+					}},
+				},
+			}},
+		},
+		{
+			name: "invalid host request header modifier",
+			filters: []gatewayv1.HTTPRouteFilter{{
+				Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Set: []gatewayv1.HTTPHeader{{
+						Name:  "Host",
+						Value: "example.com",
+					}},
+				},
+			}},
+			invalid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := &HTTPRouteInput{
+				ControllerName: "io.cilium/gateway-controller",
+				HTTPRoute: &gatewayv1.HTTPRoute{
+					Spec: gatewayv1.HTTPRouteSpec{
+						CommonRouteSpec: gatewayv1.CommonRouteSpec{
+							ParentRefs: []gatewayv1.ParentReference{{Name: "my-gw"}},
+						},
+						Rules: []gatewayv1.HTTPRouteRule{{Filters: tt.filters}},
+					},
+				},
+			}
+
+			cond, invalid := input.ValidateHeaderModifier()
+
+			assert.Equal(t, tt.invalid, invalid)
+			if invalid {
+				assert.Equal(t, string(gatewayv1.RouteConditionAccepted), cond.Type)
+				assert.Equal(t, metav1.ConditionFalse, cond.Status)
+				assert.Equal(t, string(gatewayv1.RouteReasonUnsupportedValue), cond.Reason)
+				assert.Equal(t, `Invalid HTTPRoute header modifier: "Host" header is not supported; use URLRewrite.hostname instead`, cond.Message)
+			}
+		})
+	}
+}
+
 func TestHTTPRouteValidateMatchRegexps(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
Make HTTPRoute header modifier validation return a Route condition
instead of a reconcile error.

When a RequestHeaderModifier tries to set the Host header, mark the
route as Accepted=False with reason UnsupportedValue and persist that
status through the normal HTTPRoute status update path. This aligns
header modifier validation with the existing regex validation flow and
surfaces the problem to users on the Route object rather than only in
controller errors.

```
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
...
spec:
...
  rules:
  - ...
    filters:
    - requestHeaderModifier:
        set:
        - name: Host
          value: example.com
      type: RequestHeaderModifier
...
status:
  parents:
  - conditions:
    - lastTransitionTime: "2026-07-31T12:36:07Z"
      message: 'Invalid HTTPRoute header modifier: "Host" header is not supported;
        use URLRewrite.hostname instead'
      observedGeneration: 1
      reason: UnsupportedValue
      status: "False"
      type: Accepted
...
```

Note: A follow up PR will add the same validation (& changes) to the GRPCRoute.

cc @xtineskim 

Fixes: https://github.com/cilium/cilium/pull/42504
Fixes: https://github.com/cilium/cilium/issues/47633
