### PR TITLE
docs: fix CURRENT_RELEASE detection

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -123,7 +123,7 @@ else:
     tags.add('stable')
 relinfo = semver.parse_version_info(release)
 prev_release = '%d.%d' % (relinfo.major, relinfo.minor - 1)
-if relinfo.prerelease != '':
+if relinfo.prerelease:
     next_release = '%d.%d' % (relinfo.major, relinfo.minor)
     current_release = prev_release
 else:


### PR DESCRIPTION
semver returns None (not '') for VersionInfo.prerelease when a version has no prerelease component, so `relinfo.prerelease != ''` was always true and CURRENT_RELEASE always resolved to the previous minor release instead of the actual one.

Fixes: #47595

```release-note
docs: Fix a bug that caused all versions to be treated as pre-release and rendering previous releases in the upgrade guide.
```
