### PR TITLE
ci: fix filtering out md files in bpf checks

### DIFF
--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -41,18 +41,16 @@ jobs:
           base: ${{ github.ref }}
           filters: |
             bpf-tree:
-              - 'bpf/**'
-              - 'images/**'
+              - '!(**/*.md)bpf/**'
+              - '!(**/*.md)images/**'
               - 'Makefile*'
               - 'contrib/scripts/builder.sh'
-              - '!**/*.md'
 
             coccinelle:
               - 'contrib/coccinelle/**'
             bpf-tests-runner:
-              - 'bpf/tests/bpftest/**'
-              - 'pkg/bpf/**'
-              - '!**/*.md'
+              - '!(**/*.md)bpf/tests/bpftest/**'
+              - '!(**/*.md)pkg/bpf/**'
             workflow-description:
               - '.github/workflows/lint-bpf-checks.yaml'
 


### PR DESCRIPTION
This change fixes the way we are filtering out markdown files when checking for file changes in lint-bpf-checks.

Previously, `!**/*.md` matched all files anywhere in the repo, which caused unnecessary runs on PRs with changes that had nothing to do with our bpf code.

We might revisit this when https://github.com/dorny/paths-filter/issues/260 is fixed.

The change was tested with following node code (picomatch is the library that dorny/paths-filter uses for matching):
```
const pm = require('picomatch');

filenames = [
'.github/workflows/enterprise-repush-stable-images-staging.yaml',
'bpf/trololo',
'bpf/trololo.md',
'images/image',
'images/image.md',
'bpf/tests/bpftest/trololo',
'bpf/tests/bpftest/trololo.md',
'pkg/bpf/trolo',
'pkg/bpf/trolo.md',
]

matchers = [
    '!(**/*.md)bpf/**', 
    '!(**/*.md)images/**',
    'Makefile*',
    'contrib/scripts/builder.sh',

    '!(**/*.md)bpf/tests/bpftest/**',
    '!(**/*.md)pkg/bpf/**',
]

for ( element of matchers ) {
        for (filename of filenames) {
                if (pm(element)(filename)) {
                        console.log(element+" matches "+filename)
                }
        }
}

```

output of the above code on my machine is following:

```
!(**/*.md)bpf/** matches bpf/trololo
!(**/*.md)bpf/** matches bpf/tests/bpftest/trololo
!(**/*.md)bpf/** matches pkg/bpf/trolo
!(**/*.md)images/** matches images/image
!(**/*.md)bpf/tests/bpftest/** matches bpf/tests/bpftest/trololo
!(**/*.md)pkg/bpf/** matches pkg/bpf/trolo
``` 
It seems to work fine.


AI influence level: 0