### PR TITLE
gateway-api: validate gRPCRoute header modifiers in status

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -2098,9 +2098,14 @@ func (r *gatewayReconciler) setGRPCRouteStatuses(scopedLog *slog.Logger, ctx con
 			return r.handleGRPCRouteReconcileErrorWithStatus(ctx, scopedLog, err, grpcr, &original)
 		}
 
-		if cond, invalid := i.ValidateMatchRegexps(); invalid {
-			for _, parent := range grpcr.Status.Parents {
-				i.SetParentCondition(parent.ParentRef, cond)
+		for _, validate := range []func() (metav1.Condition, bool){
+			i.ValidateHeaderModifier,
+			i.ValidateMatchRegexps,
+		} {
+			if cond, invalid := validate(); invalid {
+				for _, parent := range grpcr.Status.Parents {
+					i.SetParentCondition(parent.ParentRef, cond)
+				}
 			}
 		}
 

--- a/operator/pkg/gateway-api/routechecks/grpcroute.go
+++ b/operator/pkg/gateway-api/routechecks/grpcroute.go
@@ -175,6 +175,22 @@ func (g *GRPCRouteInput) mergeStatusConditions(parentRef gatewayv1.ParentReferen
 	})
 }
 
+func (g *GRPCRouteInput) ValidateHeaderModifier() (metav1.Condition, bool) {
+	for _, rule := range g.GRPCRoute.Spec.Rules {
+		for _, f := range rule.Filters {
+			if f.Type == gatewayv1.GRPCRouteFilterRequestHeaderModifier {
+				for _, set := range f.RequestHeaderModifier.Set {
+					if set.Name == "Host" {
+						return invalidHeaderModifierCondition(set.Name), true
+					}
+				}
+			}
+		}
+	}
+
+	return metav1.Condition{}, false
+}
+
 func (g *GRPCRouteInput) ValidateMatchRegexps() (metav1.Condition, bool) {
 	for _, rule := range g.GRPCRoute.Spec.Rules {
 		for _, match := range rule.Matches {

--- a/operator/pkg/gateway-api/routechecks/grpcroute_test.go
+++ b/operator/pkg/gateway-api/routechecks/grpcroute_test.go
@@ -11,6 +11,66 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
+func TestGRPCRouteValidateHeaderModifier(t *testing.T) {
+	tests := []struct {
+		name    string
+		filters []gatewayv1.GRPCRouteFilter
+		invalid bool
+	}{
+		{
+			name: "valid request header modifier",
+			filters: []gatewayv1.GRPCRouteFilter{{
+				Type: gatewayv1.GRPCRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Set: []gatewayv1.HTTPHeader{{
+						Name:  "X-Forwarded-Host",
+						Value: "example.com",
+					}},
+				},
+			}},
+		},
+		{
+			name: "invalid host request header modifier",
+			filters: []gatewayv1.GRPCRouteFilter{{
+				Type: gatewayv1.GRPCRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Set: []gatewayv1.HTTPHeader{{
+						Name:  "Host",
+						Value: "example.com",
+					}},
+				},
+			}},
+			invalid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := &GRPCRouteInput{
+				ControllerName: "io.cilium/gateway-controller",
+				GRPCRoute: &gatewayv1.GRPCRoute{
+					Spec: gatewayv1.GRPCRouteSpec{
+						CommonRouteSpec: gatewayv1.CommonRouteSpec{
+							ParentRefs: []gatewayv1.ParentReference{{Name: "my-gw"}},
+						},
+						Rules: []gatewayv1.GRPCRouteRule{{Filters: tt.filters}},
+					},
+				},
+			}
+
+			cond, invalid := input.ValidateHeaderModifier()
+
+			assert.Equal(t, tt.invalid, invalid)
+			if invalid {
+				assert.Equal(t, string(gatewayv1.RouteConditionAccepted), cond.Type)
+				assert.Equal(t, metav1.ConditionFalse, cond.Status)
+				assert.Equal(t, string(gatewayv1.RouteReasonUnsupportedValue), cond.Reason)
+				assert.Equal(t, `Invalid header modifier: "Host" header is not supported`, cond.Message)
+			}
+		})
+	}
+}
+
 func TestGRPCRouteValidateMatchRegexps(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/operator/pkg/gateway-api/routechecks/httproute.go
+++ b/operator/pkg/gateway-api/routechecks/httproute.go
@@ -179,7 +179,7 @@ func invalidHeaderModifierCondition(headerName gatewayv1.HTTPHeaderName) metav1.
 		Type:    string(gatewayv1.RouteConditionAccepted),
 		Status:  metav1.ConditionFalse,
 		Reason:  string(gatewayv1.RouteReasonUnsupportedValue),
-		Message: fmt.Sprintf("Invalid HTTPRoute header modifier: %q header is not supported; use URLRewrite.hostname instead", headerName),
+		Message: fmt.Sprintf("Invalid header modifier: %q header is not supported", headerName),
 	}
 }
 

--- a/operator/pkg/gateway-api/routechecks/httproute_test.go
+++ b/operator/pkg/gateway-api/routechecks/httproute_test.go
@@ -66,7 +66,7 @@ func TestHTTPRouteValidateHeaderModifier(t *testing.T) {
 				assert.Equal(t, string(gatewayv1.RouteConditionAccepted), cond.Type)
 				assert.Equal(t, metav1.ConditionFalse, cond.Status)
 				assert.Equal(t, string(gatewayv1.RouteReasonUnsupportedValue), cond.Reason)
-				assert.Equal(t, `Invalid HTTPRoute header modifier: "Host" header is not supported; use URLRewrite.hostname instead`, cond.Message)
+				assert.Equal(t, `Invalid header modifier: "Host" header is not supported`, cond.Message)
 			}
 		})
 	}


### PR DESCRIPTION
Add gRPCRoute header modifier validation alongside the existing regex validation path.

Related PR: https://github.com/cilium/cilium/pull/42504