### PR TITLE
ci: build race images on push events so conformance-race works on stable branches

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -188,9 +188,13 @@ jobs:
             normal_tag="${normal_tag},${floating_normal_tag}"
           fi
 
-          if [[ "${{ github.event_name }}" == 'merge_group' || "${{ github.event_name }}" == 'push' ]]; then
-            # Don't build race and unstripped images for merge_group or push events.
+          if [[ "${{ github.event_name }}" == 'merge_group' ]]; then
+            # Don't build race images for merge_group events.
             race_tag=""
+          fi
+
+          if [[ "${{ github.event_name }}" == 'merge_group' || "${{ github.event_name }}" == 'push' ]]; then
+            # Don't build unstripped images for merge_group or push events.
             unstripped_tag=""
           fi
 

--- a/.github/workflows/conformance-race.yaml
+++ b/.github/workflows/conformance-race.yaml
@@ -87,6 +87,11 @@ jobs:
         id: merge
         run: |
           ARGS='${{ inputs.extra-args }}'
+          # Empty on schedule events, where jq would emit nothing and thus
+          # silently drop "detect-race".
+          if [ -z "${ARGS}" ]; then
+            ARGS='{}'
+          fi
           echo "extra-args=$(echo "${ARGS}" | jq -c '. + {"detect-race": true}')" >> "$GITHUB_OUTPUT"
 
   conformance-ginkgo-race:


### PR DESCRIPTION
conformance-race has never been green on a stable branch, and on main it has been green for the wrong reason. There are two independent bugs and they point in opposite directions, which is why this went unnoticed for so long.

The first one is why v1.19 and v1.20 are red. Commit 7329f8f829 stopped building the race images for merge_group and push events, back when the only consumer was a manual /ci-conformance-race trigger on a pull request. That is no longer true: ariane-scheduled.yaml dispatches conformance-race hourly against the branch tip of v1.19 and v1.20, and a branch tip gets its images from the push event. So cilium-ci:<sha>-race simply never exists, conformance-ginkgo's wait-for-images polls for it until it hits its 30 minute timeout, the job ends up cancelled, every E2E leg is skipped and the status gate reports failure. I verified this against quay: pull request heads targeting v1.20 have the -race tag for cilium-ci, operator-generic-ci and hubble-relay-ci, while the branch tips only have the plain tag.

The second one is worse, because it is a false green. prepare-extra-args in conformance-race.yaml pipes inputs.extra-args into jq, but on schedule events that input is unset, so jq reads an empty stdin, emits nothing at all, and the job output becomes the empty string instead of {"detect-race":true}. conformance-ginkgo then computes detect-race as false, appends no -race suffix and runs the plain images. The nightly run on main has been passing while quietly testing without the race detector. Run 30503093093 shows it plainly: -cilium.tag= carries no -race suffix.

That asymmetry is what hid both bugs. On main the nightly comes from conformance-race.yaml's own cron, so the second bug masks the first one by making the workflow wait for plain images, which do exist. The stable branches are dispatched by ariane as workflow_dispatch with real extra-args, so detect-race really is true there and they run head first into the missing images.

So the fix is to build race images on push while keeping them out of the merge queue, where nothing consumes them and the cost would be paid on every single merge, and to default the jq input to an empty object. The unstripped images stay disabled for both events since no workflow consumes them at all.

Both fixes are proven by two runs on this branch. Neither of them can be reproduced through a pull request, because for pull_request_target GitHub reads the workflow definition from the base branch, so the push path has to be exercised on a branch that actually receives a push. I did that with two temporary commits that added this branch to the push triggers, and have since dropped them.

Run 30541045892 proves both bugs are fixed. prepare-extra-args emitted extra-args: {"detect-race":true} with no inputs at all, which is exactly the empty extra-args path the nightly schedule takes and which previously produced the empty string. Setup Vars then consumed it and set the -race image tag suffix. Wait for images completed successfully, which is the very job that burns its full 30 minute timeout on every stable branch dispatch today, and the E2E legs went on to run against the race images. Run 30541045451 is the corresponding Image CI Build, where the CI race detection Build steps ran instead of being skipped and published cilium-ci, operator-generic-ci, hubble-relay-ci and cilium-cli-ci with the -race tag from a push event.

Run 30542016821 then ran the full matrix rather than the single focus that detect-race normally restricts it to, so that we would know whether race detection is actually clean before this reaches main. 24 of 25 legs passed with no data races reported anywhere. The one failure, E2E Test (1.35, f18-datapath-lrp), is unrelated to race detection: the spec body passed and the AfterEach log check tripped over a benign leader election read timeout in the operator, which the same focus on 1.36 did not hit. That is fixed separately in #47612.

Worth flagging for whoever reviews this: fixing the second bug turns the nightly on main into a real race detection run for the first time. The full matrix came back clean here, but it is now a check that can genuinely fail.

On cost, the race build adds roughly two to six minutes per matrix leg, with the cilium image itself at 371 seconds. Push runs of Image CI currently finish in about ten minutes against a 45 minute job timeout, so there is plenty of headroom.

v1.17 and v1.18 do not need this. Neither branch ships conformance-race.yaml nor references it from ariane-config.yaml, so there is no consumer of the race images there.

This PR was prepared with AIL:3.
