### PR TITLE
test: allowlist the leader election read timeout in ginkgo log check

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -137,6 +137,7 @@ const (
 	failedToReleaseLock               = "Failed to release lock:"
 	errorCreatingInitialLeader        = "error initially creating leader election record:"
 	failedToRetrieveLock              = "Error retrieving lease lock"                                           // cf. https://github.com/cilium/cilium/issues/45426 ; client-go v1.35+ renamed "error retrieving resource lock".
+	leaderElectionReadTimeout         = "(Client.Timeout or context cancellation while reading body)"           // cf. https://github.com/cilium/cilium/issues/45426 ; sibling of failedToRetrieveLock, matched on the cause so genuine read failures still fail.
 	cantEnableJIT                     = "bpf_jit_enable: no such file or directory"                             // Because we run tests in Kind.
 	podCIDRUnavailable                = " PodCIDR not available"                                                // cf. https://github.com/cilium/cilium/issues/29680
 	unableGetNode                     = "Unable to get node resource"                                           // cf. https://github.com/cilium/cilium/issues/29710
@@ -195,7 +196,7 @@ var badLogMessages = map[string][]string{
 	logutils.ErrorLogs: {opCantBeFulfilled, initLeaderElection, globalDataSupport,
 		failedToListCRDs, retrieveResLock, failedToRelLockEmptyName, failedToUpdateLock,
 		failedToReleaseLock, errorCreatingInitialLeader, errorCreatingInitialLeaderGEK8s35,
-		failedToRetrieveLock},
+		failedToRetrieveLock, leaderElectionReadTimeout},
 	logutils.WarningLogs: {cantEnableJIT, podCIDRUnavailable, unableGetNode,
 		objectHasBeenModified, etcdTimeout, endpointRestoreFailed,
 		cantFindIdentityInCache, keyAllocFailedFoundMaster, cantRecreateMasterKey,


### PR DESCRIPTION
When a transient apiserver blip cancels one of the operator's leader election lock reads, the operator emits two klog level=error lines from that single event. The lock line, "Error retrieving lease lock", is already tolerated by the Ginkgo log check. Its sibling is not: client-go logs "Unexpected error when reading response body" carrying "request canceled (Client.Timeout or context cancellation while reading body)", and that one still fails an otherwise passing spec in the AfterEach.

This is benign. The operator's leader election HTTP timeout is deliberately short, max(1s, RenewDeadline/2), so a slow apiserver read gets cancelled, the leader election loop retries on the next retry period and recovers. The Deployment stays 1/1 Ready and the test body itself passes; only the post-test log scan fails.

I hit this on E2E Test (1.35, f18-datapath-lrp), where K8sDatapathLRPTests "LRP connectivity" passed and then the AfterEach failed with a single matching operator log line.

The same pair was already tolerated on the cilium-cli side in commit cce18c04d3, which could use a regex narrowed to the read-body message. The Ginkgo allowlist only does plain substring matching on single lines, so a bare "Unexpected error when reading response body" entry would be far broader and would hide real read failures. Matching on the cause instead keeps it tight: a genuine EOF, an unmarshal error or a connection reset while reading a body all still fail the check, and so does a Client.Timeout in any other phase such as awaiting headers.

This is the twin of the fix that went into cilium-cli. Both allowlists validate the same operator logs, so an entry added to one generally needs mirroring in the other.
