### PR TITLE
wireguard: Unsubscribe node handler on shutdown

### DIFF
--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -197,6 +197,15 @@ func (a *Agent) Stop(cell.HookContext) error {
 		return nil
 	}
 
+	// Unsubscribe from node events before tearing down the WireGuard client.
+	// Unsubscribe blocks until any in-flight backgroundSync iteration in the
+	// node manager completes and guarantees the handler is not invoked again,
+	// so NodeValidateImplementation (and the other node handler callbacks) can
+	// no longer call ConfigureDevice on the closed wgClient. This must run
+	// before acquiring a.RLock() to avoid deadlocking with an in-flight handler
+	// that takes a.Lock().
+	a.nodeManager.Unsubscribe(a)
+
 	a.RLock()
 	defer a.RUnlock()
 


### PR DESCRIPTION
The WireGuard Agent subscribes itself as a node handler in `Start` but `Stop` only closed the `wgctrl` client without unsubscribing. Because the agent depends on the node manager, it stops first. The node manager's backgroundSync can then still invoke the agent's `NodeValidateImplementation`, leading to a `wgClient.ConfigureDevice` after `Stop` has already closed the client, producing noisy netlink errors on a closed handle during shutdown.

This is exactly the same kind of bug and corresponding fix as PR #47197.

The fix is to `Unsubscribe` in the `Stop` hook.