### PR TITLE
ci: build race images on push in the stable image builders

### DIFF
--- a/.github/workflows/build-images-ci-v1.18.yaml
+++ b/.github/workflows/build-images-ci-v1.18.yaml
@@ -183,9 +183,13 @@ jobs:
             normal_tag="${normal_tag},${floating_normal_tag}"
           fi
 
-          if [[ "${{ github.event_name }}" == 'merge_group' || "${{ github.event_name }}" == 'push' ]]; then
-            # Don't build race and unstripped images for merge_group or push events.
+          if [[ "${{ github.event_name }}" == 'merge_group' ]]; then
+            # Don't build race images for merge_group events.
             race_tag=""
+          fi
+
+          if [[ "${{ github.event_name }}" == 'merge_group' || "${{ github.event_name }}" == 'push' ]]; then
+            # Don't build unstripped images for merge_group or push events.
             unstripped_tag=""
           fi
 

--- a/.github/workflows/build-images-ci-v1.19.yaml
+++ b/.github/workflows/build-images-ci-v1.19.yaml
@@ -183,9 +183,13 @@ jobs:
             normal_tag="${normal_tag},${floating_normal_tag}"
           fi
 
-          if [[ "${{ github.event_name }}" == 'merge_group' || "${{ github.event_name }}" == 'push' ]]; then
-            # Don't build race and unstripped images for merge_group or push events.
+          if [[ "${{ github.event_name }}" == 'merge_group' ]]; then
+            # Don't build race images for merge_group events.
             race_tag=""
+          fi
+
+          if [[ "${{ github.event_name }}" == 'merge_group' || "${{ github.event_name }}" == 'push' ]]; then
+            # Don't build unstripped images for merge_group or push events.
             unstripped_tag=""
           fi
 

--- a/.github/workflows/build-images-ci-v1.20.yaml
+++ b/.github/workflows/build-images-ci-v1.20.yaml
@@ -173,9 +173,13 @@ jobs:
             normal_tag="${normal_tag},${floating_normal_tag}"
           fi
 
-          if [[ "${{ github.event_name }}" == 'merge_group' || "${{ github.event_name }}" == 'push' ]]; then
-            # Don't build race and unstripped images for merge_group or push events.
+          if [[ "${{ github.event_name }}" == 'merge_group' ]]; then
+            # Don't build race images for merge_group events.
             race_tag=""
+          fi
+
+          if [[ "${{ github.event_name }}" == 'merge_group' || "${{ github.event_name }}" == 'push' ]]; then
+            # Don't build unstripped images for merge_group or push events.
             unstripped_tag=""
           fi
 


### PR DESCRIPTION
Follow-up of #47608 as it missed the workflows for the stable branches.

This PR was prepared with AIL:3.
