### PR TITLE
[v1.18] ci: build race images on push events

### DIFF
--- a/.github/workflows/build-images-ci-v1.18.yaml
+++ b/.github/workflows/build-images-ci-v1.18.yaml
@@ -180,9 +180,13 @@ jobs:
             normal_tag="${normal_tag},${floating_normal_tag}"
           fi
 
-          if [[ "${{ github.event_name }}" == 'merge_group' || "${{ github.event_name }}" == 'push' ]]; then
-            # Don't build race and unstripped images for merge_group or push events.
+          if [[ "${{ github.event_name }}" == 'merge_group' ]]; then
+            # Don't build race images for merge_group events.
             race_tag=""
+          fi
+
+          if [[ "${{ github.event_name }}" == 'merge_group' || "${{ github.event_name }}" == 'push' ]]; then
+            # Don't build unstripped images for merge_group or push events.
             unstripped_tag=""
           fi
 


### PR DESCRIPTION
 * [x] #47616 (@aanm)

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 47616
```
