### PR TITLE
[v1.18] bpf: hostfw: tolerate unknown CT protocols and rely on policies

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -198,7 +198,10 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 #ifdef ENABLE_HOST_FIREWALL
 	if (from_host) {
 		if (ipv6_host_policy_egress_lookup(ctx, secctx, ipcache_srcid, ip6, &ct_buffer)) {
-			if (unlikely(ct_buffer.ret < 0))
+			/* Tolerate L4 protocol not supported by CT and defer the
+			 * decision to the egress policies if any and applicable.
+			 */
+			if (unlikely(ct_buffer.ret < 0) && ct_buffer.ret != DROP_CT_UNKNOWN_PROTO)
 				return ct_buffer.ret;
 			need_hostfw = true;
 			is_host_id = secctx == HOST_ID;
@@ -209,7 +212,10 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 			return DROP_INVALID;
 
 		if (ipv6_host_policy_ingress_lookup(ctx, ip6, &ct_buffer)) {
-			if (unlikely(ct_buffer.ret < 0))
+			/* Tolerate L4 protocol not supported by CT and defer the
+			 * decision to the ingress policies if any and applicable.
+			 */
+			if (unlikely(ct_buffer.ret < 0) && ct_buffer.ret != DROP_CT_UNKNOWN_PROTO)
 				return ct_buffer.ret;
 			need_hostfw = true;
 		}
@@ -627,7 +633,10 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 	if (from_host) {
 		/* We're on the egress path of cilium_host. */
 		if (ipv4_host_policy_egress_lookup(ctx, secctx, ipcache_srcid, ip4, &ct_buffer)) {
-			if (unlikely(ct_buffer.ret < 0))
+			/* Tolerate L4 protocol not supported by CT and defer the
+			 * decision to the egress policies if any and applicable.
+			 */
+			if (unlikely(ct_buffer.ret < 0) && ct_buffer.ret != DROP_CT_UNKNOWN_PROTO)
 				return ct_buffer.ret;
 			need_hostfw = true;
 			is_host_id = secctx == HOST_ID;
@@ -639,7 +648,10 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 
 		/* We're on the ingress path of the native device. */
 		if (ipv4_host_policy_ingress_lookup(ctx, ip4, &ct_buffer)) {
-			if (unlikely(ct_buffer.ret < 0))
+			/* Tolerate L4 protocol not supported by CT and defer the
+			 * decision to the ingress policies if any and applicable.
+			 */
+			if (unlikely(ct_buffer.ret < 0) && ct_buffer.ret != DROP_CT_UNKNOWN_PROTO)
 				return ct_buffer.ret;
 			need_hostfw = true;
 		}

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -570,6 +570,8 @@ ct_extract_ports6(struct __ctx_buff *ctx, struct ipv6hdr *ip6, fraginfo_t fragin
 		return ipv6_load_l4_ports(ctx, ip6, fraginfo, off,
 					  dir, &tuple->dport);
 	default:
+		tuple->sport = 0;
+		tuple->dport = 0;
 		/* Unsupported L4 protocol */
 		return DROP_CT_UNKNOWN_PROTO;
 	}
@@ -821,6 +823,8 @@ ct_extract_ports4(struct __ctx_buff *ctx, struct iphdr *ip4, fraginfo_t fraginfo
 		return ipv4_load_l4_ports(ctx, ip4, fraginfo, off,
 					  dir, &tuple->dport);
 	default:
+		tuple->sport = 0;
+		tuple->dport = 0;
 		/* Unsupported L4 protocol */
 		return DROP_CT_UNKNOWN_PROTO;
 	}

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -139,6 +139,20 @@ __ipv6_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 	return verdict;
 }
 
+/* Enforce HostFW egress policies. For the two following types of traffic, we
+ * create a CT entry to allow reply traffic:
+ *
+ * 1. Host-originated traffic carrying HOST_ID: for this traffic we also enforce
+ *    host egress policies.
+ * 2. Traffic with Node IP not necessarily Host-generated (i.e. UNKNOWN_ID but
+ *    matching HOST_ID in ipcache): for this traffic, we don't need to enforce
+ *    policies. Traffic can be SNATed pod traffic, or non-transparent proxy
+ *    connections. There exists an exception, that is unmarked kernel-generated
+ *    packets (https://github.com/cilium/cilium/issues/47223).
+ *
+ * For all L4 protocols not supported by CT, we tolerate the entry lookup
+ * failure, and defer the decision to the egress policy if any and applicable.
+ */
 static __always_inline int
 ipv6_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id,
 			__u32 ipcache_srcid, struct ipv6hdr *ip6,
@@ -148,7 +162,7 @@ ipv6_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id,
 
 	if (!ipv6_host_policy_egress_lookup(ctx, src_id, ipcache_srcid, ip6, &ct_buffer))
 		return CTX_ACT_OK;
-	if (ct_buffer.ret < 0)
+	if (ct_buffer.ret < 0 && ct_buffer.ret != DROP_CT_UNKNOWN_PROTO)
 		return ct_buffer.ret;
 
 	return __ipv6_host_policy_egress(ctx, src_id == HOST_ID,
@@ -424,6 +438,20 @@ __ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 	return verdict;
 }
 
+/* Enforce HostFW egress policies. For the two following types of traffic, we
+ * create a CT entry to allow reply traffic:
+ *
+ * 1. Host-originated traffic carrying HOST_ID: for this traffic we also enforce
+ *    host egress policies.
+ * 2. Traffic with Node IP not necessarily Host-generated (i.e. UNKNOWN_ID but
+ *    matching HOST_ID in ipcache): for this traffic, we don't need to enforce
+ *    policies. Traffic can be SNATed pod traffic, or non-transparent proxy
+ *    connections. There exists an exception, that is unmarked kernel-generated
+ *    packets (https://github.com/cilium/cilium/issues/47223).
+ *
+ * For all L4 protocols not supported by CT, we tolerate the entry lookup
+ * failure, and defer the decision to the egress policy if any and applicable.
+ */
 static __always_inline int
 ipv4_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id,
 			__u32 ipcache_srcid, struct iphdr *ip4,
@@ -433,7 +461,7 @@ ipv4_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id,
 
 	if (!ipv4_host_policy_egress_lookup(ctx, src_id, ipcache_srcid, ip4, &ct_buffer))
 		return CTX_ACT_OK;
-	if (ct_buffer.ret < 0)
+	if (ct_buffer.ret < 0 && ct_buffer.ret != DROP_CT_UNKNOWN_PROTO)
 		return ct_buffer.ret;
 
 	return __ipv4_host_policy_egress(ctx, src_id == HOST_ID, ip4, &ct_buffer, trace, ext_err);

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -291,6 +291,12 @@ out:
 	return verdict;
 }
 
+/* Enforce HostFW ingress policies. We skip policies on reply packets for which
+ * a CT entry exists.
+ *
+ * For all L4 protocols not supported by CT, we tolerate the entry lookup
+ * failure, and defer the decision to the ingress policy if any and applicable.
+ */
 static __always_inline int
 ipv6_host_policy_ingress(struct __ctx_buff *ctx, __u32 *src_sec_identity,
 			 struct trace_ctx *trace, __s8 *ext_err)
@@ -304,7 +310,7 @@ ipv6_host_policy_ingress(struct __ctx_buff *ctx, __u32 *src_sec_identity,
 
 	if (!ipv6_host_policy_ingress_lookup(ctx, ip6, &ct_buffer))
 		return CTX_ACT_OK;
-	if (ct_buffer.ret < 0)
+	if (ct_buffer.ret < 0 && ct_buffer.ret != DROP_CT_UNKNOWN_PROTO)
 		return ct_buffer.ret;
 
 	return __ipv6_host_policy_ingress(ctx, ip6, &ct_buffer, src_sec_identity, trace, ext_err);
@@ -582,6 +588,12 @@ out:
 	return verdict;
 }
 
+/* Enforce HostFW ingress policies. We skip policies on reply packets for which
+ * a CT entry exists.
+ *
+ * For all L4 protocols not supported by CT, we tolerate the entry lookup
+ * failure, and defer the decision to the ingress policy if any and applicable.
+ */
 static __always_inline int
 ipv4_host_policy_ingress(struct __ctx_buff *ctx, __u32 *src_sec_identity,
 			 struct trace_ctx *trace, __s8 *ext_err)
@@ -595,7 +607,7 @@ ipv4_host_policy_ingress(struct __ctx_buff *ctx, __u32 *src_sec_identity,
 
 	if (!ipv4_host_policy_ingress_lookup(ctx, ip4, &ct_buffer))
 		return CTX_ACT_OK;
-	if (ct_buffer.ret < 0)
+	if (ct_buffer.ret < 0 && ct_buffer.ret != DROP_CT_UNKNOWN_PROTO)
 		return ct_buffer.ret;
 
 	return __ipv4_host_policy_ingress(ctx, ip4, &ct_buffer, src_sec_identity, trace, ext_err);

--- a/bpf/tests/host_hostfw_igmp.c
+++ b/bpf/tests/host_hostfw_igmp.c
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "hostfw_igmp.h"

--- a/bpf/tests/hostfw_bpf_masq.c
+++ b/bpf/tests/hostfw_bpf_masq.c
@@ -80,6 +80,8 @@ int hostfw_ipv4_bpf_masq_proxy_01_setup(struct __ctx_buff *ctx)
 	ipcache_v4_add_entry(NODE_IP, 0, HOST_ID, 0, 0);
 	ipcache_v4_add_world_entry();
 
+	policy_add_egress_deny_all_entry();
+
 	set_identity_mark(ctx, POD_SEC_IDENTITY, MARK_MAGIC_PROXY_EGRESS);
 
 	/* Jump into the entrypoint */
@@ -122,6 +124,8 @@ int hostfw_ipv4_bpf_masq_proxy_01_check(const struct __ctx_buff *ctx)
 
 	assert(ct_entry->packets == 1);
 
+	policy_delete_egress_all_entry();
+
 	test_finish();
 }
 
@@ -150,6 +154,8 @@ int hostfw_ipv4_bpf_masq_proxy_02_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "hostfw_ipv4_bpf_masq_proxy_02")
 int hostfw_ipv4_bpf_masq_proxy_02_setup(struct __ctx_buff *ctx)
 {
+	policy_add_ingress_allow_all_entry();
+
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
 	/* Fail if we didn't jump */
@@ -189,6 +195,8 @@ int hostfw_ipv4_bpf_masq_proxy_02_check(const struct __ctx_buff *ctx)
 		test_fatal("no CT entry found");
 
 	assert(ct_entry->packets == 2);
+
+	policy_delete_ingress_all_entry();
 
 	test_finish();
 }

--- a/bpf/tests/hostfw_extended_protocols.c
+++ b/bpf/tests/hostfw_extended_protocols.c
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ENABLE_IPV4			1
+#define ENABLE_HOST_FIREWALL		1
+
+#define NODE_IP				v4_node_one
+#define NODE_IP2			v4_node_two
+
+#define DST_IP			v4_ext_one
+#define DST_IP2			v4_ext_two
+
+static volatile const __u8 *node_mac = mac_one;
+static volatile const __u8 *dst_mac = mac_two;
+
+#include "bpf_host.c"
+
+#include "lib/endpoint.h"
+#include "lib/ipcache.h"
+#include "lib/policy.h"
+
+#define FROM_NETDEV	0
+#define TO_NETDEV	1
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 2);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_NETDEV] = &cil_from_netdev,
+		[TO_NETDEV] = &cil_to_netdev,
+	},
+};
+
+/* Send an IGMP packet from host to IGMP destination (allow all egress policy).
+ *
+ */
+PKTGEN("tc", "hostfw_igmp_egress")
+int hostfw_igmp_egress_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct igmphdr *igmp;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	igmp = pktgen__push_ipv4_igmp_packet(&builder,
+					     (__u8 *)node_mac, (__u8 *)dst_mac,
+					     NODE_IP, DST_IP,
+					     IGMP_HOST_MEMBERSHIP_REPORT);
+	if (!igmp)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "hostfw_igmp_egress")
+int hostfw_igmp_egress_setup(struct __ctx_buff *ctx)
+{
+	policy_add_egress_allow_all_entry();
+	endpoint_v4_add_entry(NODE_IP, 0, 0, ENDPOINT_F_HOST, HOST_ID,
+			      0, (__u8 *)node_mac, (__u8 *)node_mac);
+	ipcache_v4_add_entry(NODE_IP, 0, HOST_ID, 0, 0);
+	set_identity_mark(ctx, 0, MARK_MAGIC_HOST);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "hostfw_igmp_egress")
+int hostfw_igmp_egress_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_DROP);
+
+	/* Check for egress CT entry */
+	struct ipv4_ct_tuple tuple = {
+		.daddr   = NODE_IP,
+		.saddr   = DST_IP,
+		.dport   = 0,
+		.sport   = 0,
+		.nexthdr = IPPROTO_IGMP,
+		.flags = TUPLE_F_OUT,
+	};
+	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+
+	if (ct_entry)
+		test_fatal("CT entry found when it shouldn't be");
+
+	policy_delete_egress_entry();
+
+	test_finish();
+}
+
+/* Send an IGMP packet from the IGMP destination to host.
+ *
+ */
+PKTGEN("tc", "hostfw_igmp_ingress")
+int hostfw_igmp_ingress_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct igmphdr *igmp;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	igmp = pktgen__push_ipv4_igmp_packet(&builder,
+					     (__u8 *)dst_mac, (__u8 *)node_mac,
+					     DST_IP, NODE_IP,
+					     IGMP_HOST_MEMBERSHIP_REPORT);
+	if (!igmp)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "hostfw_igmp_ingress")
+int hostfw_igmp_ingress_setup(struct __ctx_buff *ctx)
+{
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "hostfw_igmp_ingress")
+int hostfw_igmp_ingress_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_DROP);
+
+	/* Check whether this packet hits the existing egress entry */
+	struct ipv4_ct_tuple tuple = {
+		.daddr   = NODE_IP,
+		.saddr   = DST_IP,
+		.dport   = 0,
+		.sport   = 0,
+		.nexthdr = IPPROTO_IGMP,
+		.flags = TUPLE_F_OUT,
+	};
+	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+
+	if (ct_entry)
+		test_fatal("CT entry found when it shouldn't be");
+
+	test_finish();
+}

--- a/bpf/tests/hostfw_extended_protocols.c
+++ b/bpf/tests/hostfw_extended_protocols.c
@@ -111,7 +111,7 @@ int hostfw_igmp_egress_check(const struct __ctx_buff *ctx)
 	if (ct_entry)
 		test_fatal("CT entry found when it shouldn't be");
 
-	policy_delete_egress_entry();
+	policy_delete_egress_all_entry();
 
 	test_finish();
 }

--- a/bpf/tests/hostfw_host_iptables.c
+++ b/bpf/tests/hostfw_host_iptables.c
@@ -81,6 +81,8 @@ int hostfw_iptables_host_ipv4_01_pod_setup(struct __ctx_buff *ctx)
 	ipcache_v4_add_entry(NODE_IP, 0, HOST_ID, 0, 0);
 	ipcache_v4_add_world_entry();
 
+	policy_add_egress_deny_all_entry();
+
 	set_identity_mark(ctx, POD_SEC_IDENTITY, MARK_MAGIC_IDENTITY);
 
 	/* Jump into the entrypoint */
@@ -123,6 +125,8 @@ int hostfw_iptables_host_ipv4_01_pod_check(const struct __ctx_buff *ctx)
 
 	assert(ct_entry->packets == 1);
 
+	policy_delete_egress_all_entry();
+
 	test_finish();
 }
 
@@ -151,6 +155,8 @@ int hostfw_iptables_host_ipv4_02_pod_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "hostfw_iptables_host_ipv4_02_pod")
 int hostfw_iptables_host_ipv4_02_pod_setup(struct __ctx_buff *ctx)
 {
+	policy_add_ingress_deny_all_entry();
+
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
 	/* Fail if we didn't jump */
@@ -191,6 +197,8 @@ int hostfw_iptables_host_ipv4_02_pod_check(const struct __ctx_buff *ctx)
 
 	assert(ct_entry->packets == 2);
 
+	policy_delete_ingress_all_entry();
+
 	test_finish();
 }
 
@@ -223,6 +231,8 @@ int hostfw_iptables_host_ipv4_03_host_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "hostfw_iptables_host_ipv4_03_host")
 int hostfw_iptables_host_ipv4_03_host_setup(struct __ctx_buff *ctx)
 {
+	policy_add_egress_deny_all_entry();
+
 	set_identity_mark(ctx, 0, MARK_MAGIC_HOST);
 
 	/* Jump into the entrypoint */
@@ -248,6 +258,8 @@ int hostfw_iptables_host_ipv4_03_host_check(const struct __ctx_buff *ctx)
 	status_code = data;
 
 	assert(*status_code == CTX_ACT_DROP);
+
+	policy_delete_egress_all_entry();
 
 	test_finish();
 }
@@ -326,6 +338,8 @@ int hostfw_iptables_host_ipv4_04_host_check(const struct __ctx_buff *ctx)
 
 	assert(ct_entry->packets == 1);
 
+	policy_delete_egress_all_entry();
+
 	test_finish();
 }
 
@@ -354,6 +368,8 @@ int hostfw_iptables_host_ipv4_05_host_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "hostfw_iptables_host_ipv4_05_host")
 int hostfw_iptables_host_ipv4_05_host_setup(struct __ctx_buff *ctx)
 {
+	policy_add_ingress_deny_all_entry();
+
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
 	/* Fail if we didn't jump */
@@ -394,7 +410,7 @@ int hostfw_iptables_host_ipv4_05_host_check(const struct __ctx_buff *ctx)
 
 	assert(ct_entry->packets == 2);
 
-	policy_delete_egress_all_entry();
+	policy_delete_ingress_all_entry();
 
 	test_finish();
 }

--- a/bpf/tests/hostfw_host_iptables.c
+++ b/bpf/tests/hostfw_host_iptables.c
@@ -394,7 +394,7 @@ int hostfw_iptables_host_ipv4_05_host_check(const struct __ctx_buff *ctx)
 
 	assert(ct_entry->packets == 2);
 
-	policy_delete_egress_entry();
+	policy_delete_egress_all_entry();
 
 	test_finish();
 }

--- a/bpf/tests/hostfw_igmp.h
+++ b/bpf/tests/hostfw_igmp.h
@@ -97,6 +97,8 @@ int hostfw_igmp_egress_check(const struct __ctx_buff *ctx)
 
 	status_code = data;
 
+	assert(*status_code == CTX_ACT_OK);
+
 	/* Check for egress CT entry */
 	struct ipv4_ct_tuple tuple = {
 		.daddr   = NODE_IP,
@@ -109,15 +111,11 @@ int hostfw_igmp_egress_check(const struct __ctx_buff *ctx)
 	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
 
 #ifdef TEST_EXTENDED_PROTOCOLS
-	assert(*status_code == CTX_ACT_OK);
-
 	if (!ct_entry)
 		test_fatal("no CT entry found");
 
 	assert(ct_entry->packets == 1);
 #else
-	assert(*status_code == CTX_ACT_DROP);
-
 	if (ct_entry)
 		test_fatal("CT entry found");
 
@@ -125,7 +123,7 @@ int hostfw_igmp_egress_check(const struct __ctx_buff *ctx)
 		.reason = (__u8)-DROP_CT_UNKNOWN_PROTO,
 		.dir = METRIC_EGRESS,
 	};
-	__u64 count = 1;
+	__u64 count = 0;
 
 	assert_metrics_count(key, count);
 #endif
@@ -135,7 +133,7 @@ int hostfw_igmp_egress_check(const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-/* Send an IGMP packet from the IGMP destination to host.
+/* Send an IGMP packet from the IGMP destination to host  (allow all ingress policy).
  *
  */
 PKTGEN("tc", "hostfw_igmp_2_ingress")
@@ -163,6 +161,8 @@ int hostfw_igmp_ingress_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "hostfw_igmp_2_ingress")
 int hostfw_igmp_ingress_setup(struct __ctx_buff *ctx)
 {
+	policy_add_ingress_allow_all_entry();
+
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, entry_call_map, FROM_NETDEV);
 	/* Fail if we didn't jump */
@@ -217,6 +217,8 @@ int hostfw_igmp_ingress_check(const struct __ctx_buff *ctx)
 
 	assert_metrics_count(key, count);
 #endif
+
+	policy_delete_ingress_all_entry();
 
 	test_finish();
 }

--- a/bpf/tests/hostfw_igmp.h
+++ b/bpf/tests/hostfw_igmp.h
@@ -42,7 +42,7 @@ struct {
 /* Send an IGMP packet from host to IGMP destination (allow all egress policy).
  *
  */
-PKTGEN("tc", "hostfw_igmp_egress")
+PKTGEN("tc", "hostfw_igmp_1_egress")
 int hostfw_igmp_egress_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -64,13 +64,15 @@ int hostfw_igmp_egress_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "hostfw_igmp_egress")
+SETUP("tc", "hostfw_igmp_1_egress")
 int hostfw_igmp_egress_setup(struct __ctx_buff *ctx)
 {
 	policy_add_egress_allow_all_entry();
 	endpoint_v4_add_entry(NODE_IP, 0, 0, ENDPOINT_F_HOST, HOST_ID,
 			      0, (__u8 *)node_mac, (__u8 *)node_mac);
 	ipcache_v4_add_entry(NODE_IP, 0, HOST_ID, 0, 0);
+	ipcache_v4_add_world_entry();
+
 	set_identity_mark(ctx, 0, MARK_MAGIC_HOST);
 
 	/* Jump into the entrypoint */
@@ -79,7 +81,7 @@ int hostfw_igmp_egress_setup(struct __ctx_buff *ctx)
 	return TEST_ERROR;
 }
 
-CHECK("tc", "hostfw_igmp_egress")
+CHECK("tc", "hostfw_igmp_1_egress")
 int hostfw_igmp_egress_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -125,7 +127,7 @@ int hostfw_igmp_egress_check(const struct __ctx_buff *ctx)
 /* Send an IGMP packet from the IGMP destination to host.
  *
  */
-PKTGEN("tc", "hostfw_igmp_ingress")
+PKTGEN("tc", "hostfw_igmp_2_ingress")
 int hostfw_igmp_ingress_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -147,7 +149,7 @@ int hostfw_igmp_ingress_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "hostfw_igmp_ingress")
+SETUP("tc", "hostfw_igmp_2_ingress")
 int hostfw_igmp_ingress_setup(struct __ctx_buff *ctx)
 {
 	/* Jump into the entrypoint */
@@ -156,7 +158,7 @@ int hostfw_igmp_ingress_setup(struct __ctx_buff *ctx)
 	return TEST_ERROR;
 }
 
-CHECK("tc", "hostfw_igmp_ingress")
+CHECK("tc", "hostfw_igmp_2_ingress")
 int hostfw_igmp_ingress_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/hostfw_igmp.h
+++ b/bpf/tests/hostfw_igmp.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
 /* Copyright Authors of Cilium */
 
 #include <bpf/ctx/skb.h>

--- a/bpf/tests/hostfw_igmp.h
+++ b/bpf/tests/hostfw_igmp.h
@@ -97,9 +97,6 @@ int hostfw_igmp_egress_check(const struct __ctx_buff *ctx)
 
 	status_code = data;
 
-#ifdef TEST_EXTENDED_PROTOCOLS
-	assert(*status_code == CTX_ACT_OK);
-
 	/* Check for egress CT entry */
 	struct ipv4_ct_tuple tuple = {
 		.daddr   = NODE_IP,
@@ -111,12 +108,26 @@ int hostfw_igmp_egress_check(const struct __ctx_buff *ctx)
 	};
 	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
 
+#ifdef TEST_EXTENDED_PROTOCOLS
+	assert(*status_code == CTX_ACT_OK);
+
 	if (!ct_entry)
 		test_fatal("no CT entry found");
 
 	assert(ct_entry->packets == 1);
 #else
 	assert(*status_code == CTX_ACT_DROP);
+
+	if (ct_entry)
+		test_fatal("CT entry found");
+
+	struct metrics_key key = {
+		.reason = (__u8)-DROP_CT_UNKNOWN_PROTO,
+		.dir = METRIC_EGRESS,
+	};
+	__u64 count = 1;
+
+	assert_metrics_count(key, count);
 #endif
 
 	policy_delete_egress_all_entry();
@@ -174,9 +185,6 @@ int hostfw_igmp_ingress_check(const struct __ctx_buff *ctx)
 
 	status_code = data;
 
-#ifdef TEST_EXTENDED_PROTOCOLS
-	assert(*status_code == CTX_ACT_OK);
-
 	/* Check whether this packet hits the existing egress entry */
 	struct ipv4_ct_tuple tuple = {
 		.daddr   = NODE_IP,
@@ -188,12 +196,26 @@ int hostfw_igmp_ingress_check(const struct __ctx_buff *ctx)
 	};
 	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
 
+#ifdef TEST_EXTENDED_PROTOCOLS
+	assert(*status_code == CTX_ACT_OK);
+
 	if (!ct_entry)
 		test_fatal("no CT entry found");
 
 	assert(ct_entry->packets == 2);
 #else
 	assert(*status_code == CTX_ACT_DROP);
+
+	if (ct_entry)
+		test_fatal("CT entry found");
+
+	struct metrics_key key = {
+		.reason = (__u8)-DROP_CT_UNKNOWN_PROTO,
+		.dir = METRIC_INGRESS,
+	};
+	__u64 count = 1;
+
+	assert_metrics_count(key, count);
 #endif
 
 	test_finish();

--- a/bpf/tests/hostfw_igmp.h
+++ b/bpf/tests/hostfw_igmp.h
@@ -95,7 +95,8 @@ int hostfw_igmp_egress_check(const struct __ctx_buff *ctx)
 
 	status_code = data;
 
-	assert(*status_code == CTX_ACT_DROP);
+#ifdef TEST_EXTENDED_PROTOCOLS
+	assert(*status_code == CTX_ACT_OK);
 
 	/* Check for egress CT entry */
 	struct ipv4_ct_tuple tuple = {
@@ -108,8 +109,13 @@ int hostfw_igmp_egress_check(const struct __ctx_buff *ctx)
 	};
 	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
 
-	if (ct_entry)
-		test_fatal("CT entry found when it shouldn't be");
+	if (!ct_entry)
+		test_fatal("no CT entry found");
+
+	assert(ct_entry->packets == 1);
+#else
+	assert(*status_code == CTX_ACT_DROP);
+#endif
 
 	policy_delete_egress_all_entry();
 
@@ -166,7 +172,8 @@ int hostfw_igmp_ingress_check(const struct __ctx_buff *ctx)
 
 	status_code = data;
 
-	assert(*status_code == CTX_ACT_DROP);
+#ifdef TEST_EXTENDED_PROTOCOLS
+	assert(*status_code == CTX_ACT_OK);
 
 	/* Check whether this packet hits the existing egress entry */
 	struct ipv4_ct_tuple tuple = {
@@ -179,8 +186,13 @@ int hostfw_igmp_ingress_check(const struct __ctx_buff *ctx)
 	};
 	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
 
-	if (ct_entry)
-		test_fatal("CT entry found when it shouldn't be");
+	if (!ct_entry)
+		test_fatal("no CT entry found");
+
+	assert(ct_entry->packets == 2);
+#else
+	assert(*status_code == CTX_ACT_DROP);
+#endif
 
 	test_finish();
 }

--- a/bpf/tests/hostfw_igmp.h
+++ b/bpf/tests/hostfw_igmp.h
@@ -185,6 +185,8 @@ int hostfw_igmp_ingress_check(const struct __ctx_buff *ctx)
 
 	status_code = data;
 
+	assert(*status_code == CTX_ACT_OK);
+
 	/* Check whether this packet hits the existing egress entry */
 	struct ipv4_ct_tuple tuple = {
 		.daddr   = NODE_IP,
@@ -197,15 +199,11 @@ int hostfw_igmp_ingress_check(const struct __ctx_buff *ctx)
 	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
 
 #ifdef TEST_EXTENDED_PROTOCOLS
-	assert(*status_code == CTX_ACT_OK);
-
 	if (!ct_entry)
 		test_fatal("no CT entry found");
 
 	assert(ct_entry->packets == 2);
 #else
-	assert(*status_code == CTX_ACT_DROP);
-
 	if (ct_entry)
 		test_fatal("CT entry found");
 
@@ -213,7 +211,7 @@ int hostfw_igmp_ingress_check(const struct __ctx_buff *ctx)
 		.reason = (__u8)-DROP_CT_UNKNOWN_PROTO,
 		.dir = METRIC_INGRESS,
 	};
-	__u64 count = 1;
+	__u64 count = 0;
 
 	assert_metrics_count(key, count);
 #endif

--- a/bpf/tests/lib/policy.h
+++ b/bpf/tests/lib/policy.h
@@ -2,7 +2,8 @@
 /* Copyright Authors of Cilium */
 
 static __always_inline void
-policy_add_entry(bool egress, __u32 sec_label, __u8 protocol, __u16 dport, bool deny)
+policy_add_entry(bool egress, __u32 sec_label, __u8 protocol, __u16 dport, bool deny,
+		 __u8 prefix_length)
 {
 	struct policy_key key = {
 		.sec_label = sec_label,
@@ -12,6 +13,7 @@ policy_add_entry(bool egress, __u32 sec_label, __u8 protocol, __u16 dport, bool 
 	};
 	struct policy_entry value = {
 		.deny = deny,
+		.lpm_prefix_length = prefix_length,
 	};
 
 	map_update_elem(&cilium_policy_v2, &key, &value, BPF_ANY);
@@ -20,29 +22,35 @@ policy_add_entry(bool egress, __u32 sec_label, __u8 protocol, __u16 dport, bool 
 static __always_inline void
 policy_add_ingress_allow_entry(__u32 sec_label, __u8 protocol, __u16 dport)
 {
-	policy_add_entry(false, sec_label, protocol, dport, false);
+	policy_add_entry(false, sec_label, protocol, dport, false, 0);
+}
+
+static __always_inline void
+policy_add_l4_ingress_deny_entry(__u32 sec_label, __u8 protocol, __u16 dport)
+{
+	policy_add_entry(false, sec_label, protocol, dport, true, LPM_PROTO_PREFIX_BITS);
 }
 
 static __always_inline void
 policy_add_ingress_deny_all_entry(void)
 {
-	policy_add_entry(false, 0, 0, 0, true);
+	policy_add_entry(false, 0, 0, 0, true, 0);
 }
 
 static __always_inline void
 policy_add_egress_allow_entry(__u32 sec_label, __u8 protocol, __u16 dport)
 {
-	policy_add_entry(true, sec_label, protocol, dport, false);
+	policy_add_entry(true, sec_label, protocol, dport, false, 0);
 }
 
 static __always_inline void policy_add_egress_allow_all_entry(void)
 {
-	policy_add_entry(true, 0, 0, 0, false);
+	policy_add_entry(true, 0, 0, 0, false, 0);
 }
 
 static __always_inline void policy_add_egress_deny_all_entry(void)
 {
-	policy_add_entry(true, 0, 0, 0, true);
+	policy_add_entry(true, 0, 0, 0, true, 0);
 }
 
 static __always_inline void policy_delete_egress_entry(void)

--- a/bpf/tests/lib/policy.h
+++ b/bpf/tests/lib/policy.h
@@ -1,11 +1,51 @@
 /* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
 /* Copyright Authors of Cilium */
 
-static __always_inline void
-policy_add_entry(bool egress, __u32 sec_label, __u8 protocol, __u16 dport, bool deny,
-		 __u8 prefix_length)
+static __always_inline __u8
+policy_calc_wildcard_bits(__u8 protocol, __u16 dport)
 {
+	__u8 wildcard_bits = 0;
+
+	/* Wildcard the port: */
+	if (!dport) {
+		wildcard_bits += 16;
+
+		/* Only wildcard protocol if port is also wildcarded: */
+		if (!protocol)
+			wildcard_bits += 8;
+	}
+
+	return wildcard_bits;
+}
+
+static __always_inline void
+policy_delete_entry(bool egress, __u32 sec_label, __u8 protocol, __u16 dport)
+{
+	__u8 wildcard_bits = policy_calc_wildcard_bits(protocol, dport);
+	/* Start with an exact L3/L4 policy, and wildcard it as determined above: */
+	__u32 key_prefix_len = POLICY_FULL_PREFIX - wildcard_bits;
+
 	struct policy_key key = {
+		.lpm_key = { key_prefix_len, {} },
+		.sec_label = sec_label,
+		.egress = egress,
+		.protocol = protocol,
+		.dport = dport,
+	};
+
+	map_delete_elem(&cilium_policy_v2, &key);
+}
+
+static __always_inline void
+policy_add_entry(bool egress, __u32 sec_label, __u8 protocol, __u16 dport, bool deny)
+{
+	__u8 wildcard_bits = policy_calc_wildcard_bits(protocol, dport);
+	/* Start with an exact L3/L4 policy, and wildcard it as determined above: */
+	__u32 key_prefix_len = POLICY_FULL_PREFIX - wildcard_bits;
+	__u8 value_prefix_len = LPM_FULL_PREFIX_BITS - wildcard_bits;
+
+	struct policy_key key = {
+		.lpm_key = { key_prefix_len, {} },
 		.sec_label = sec_label,
 		.egress = egress,
 		.protocol = protocol,
@@ -13,7 +53,7 @@ policy_add_entry(bool egress, __u32 sec_label, __u8 protocol, __u16 dport, bool 
 	};
 	struct policy_entry value = {
 		.deny = deny,
-		.lpm_prefix_length = prefix_length,
+		.lpm_prefix_length = value_prefix_len,
 	};
 
 	map_update_elem(&cilium_policy_v2, &key, &value, BPF_ANY);
@@ -22,42 +62,44 @@ policy_add_entry(bool egress, __u32 sec_label, __u8 protocol, __u16 dport, bool 
 static __always_inline void
 policy_add_ingress_allow_entry(__u32 sec_label, __u8 protocol, __u16 dport)
 {
-	policy_add_entry(false, sec_label, protocol, dport, false, 0);
+	policy_add_entry(false, sec_label, protocol, dport, false);
 }
 
 static __always_inline void
 policy_add_l4_ingress_deny_entry(__u32 sec_label, __u8 protocol, __u16 dport)
 {
-	policy_add_entry(false, sec_label, protocol, dport, true, LPM_PROTO_PREFIX_BITS);
+	policy_add_entry(false, sec_label, protocol, dport, true);
 }
 
 static __always_inline void
 policy_add_ingress_deny_all_entry(void)
 {
-	policy_add_entry(false, 0, 0, 0, true, 0);
+	policy_add_entry(false, 0, 0, 0, true);
 }
 
 static __always_inline void
 policy_add_egress_allow_entry(__u32 sec_label, __u8 protocol, __u16 dport)
 {
-	policy_add_entry(true, sec_label, protocol, dport, false, 0);
+	policy_add_entry(true, sec_label, protocol, dport, false);
 }
 
 static __always_inline void policy_add_egress_allow_all_entry(void)
 {
-	policy_add_entry(true, 0, 0, 0, false, 0);
+	policy_add_entry(true, 0, 0, 0, false);
 }
 
 static __always_inline void policy_add_egress_deny_all_entry(void)
 {
-	policy_add_entry(true, 0, 0, 0, true, 0);
+	policy_add_entry(true, 0, 0, 0, true);
 }
 
-static __always_inline void policy_delete_egress_entry(void)
+static __always_inline void
+policy_delete_egress_entry(__u32 sec_label, __u8 protocol, __u16 dport)
 {
-	struct policy_key key = {
-		.egress = 1,
-	};
+	policy_delete_entry(true, sec_label, protocol, dport);
+}
 
-	map_delete_elem(&cilium_policy_v2, &key);
+static __always_inline void policy_delete_egress_all_entry(void)
+{
+	policy_delete_egress_entry(0, 0, 0);
 }

--- a/bpf/tests/lib/policy.h
+++ b/bpf/tests/lib/policy.h
@@ -77,6 +77,16 @@ policy_add_ingress_deny_all_entry(void)
 	policy_add_entry(false, 0, 0, 0, true);
 }
 
+static __always_inline void policy_add_ingress_allow_all_entry(void)
+{
+	policy_add_entry(false, 0, 0, 0, false);
+}
+
+static __always_inline void policy_delete_ingress_all_entry(void)
+{
+	policy_delete_entry(false, 0, 0, 0);
+}
+
 static __always_inline void
 policy_add_egress_allow_entry(__u32 sec_label, __u8 protocol, __u16 dport)
 {

--- a/bpf/tests/network_policy.c
+++ b/bpf/tests/network_policy.c
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+#include <node_config.h>
+
+#include <lib/policy.h>
+
+#include "lib/policy.h"
+
+#define REMOTE_IDENTITY		112233
+
+static __always_inline int
+check_egress_policy(struct __ctx_buff *ctx, __u32 dst_id, __u8 proto, __be16 dport)
+{
+	__u8 match_type;
+	__u8 audited;
+	__s8 ext_err;
+	__u16 proxy_port;
+
+	return policy_can_egress(ctx, &cilium_policy_v2,
+				 0 /* ignored */, dst_id,
+				 0 /* ICMP only */,
+				 dport, proto, 0 /* ICMP only */,
+				 &match_type, &audited, &ext_err, &proxy_port);
+}
+
+CHECK("tc", "network_policy_egress_allow")
+int network_policy_egress_allow_check(struct __ctx_buff *ctx)
+{
+	test_init();
+
+	TEST("deny by default", {
+		int ret;
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_UDP,
+					  __bpf_htons(80));
+		assert(ret == DROP_POLICY);
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_TCP,
+					  __bpf_htons(80));
+		assert(ret == DROP_POLICY);
+	});
+
+	TEST("L3+L4 policy", {
+		int ret;
+
+		policy_add_egress_allow_entry(REMOTE_IDENTITY, IPPROTO_UDP,
+					      __bpf_htons(80));
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_UDP,
+					  __bpf_htons(80));
+		assert(ret == CTX_ACT_OK);
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_UDP,
+					  __bpf_htons(81));
+		assert(ret == DROP_POLICY);
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_TCP,
+					  __bpf_htons(80));
+		assert(ret == DROP_POLICY);
+
+		policy_delete_egress_entry(REMOTE_IDENTITY, IPPROTO_UDP,
+					   __bpf_htons(80));
+	});
+
+	TEST("wildcarded L4", {
+		int ret;
+
+		policy_add_egress_allow_entry(REMOTE_IDENTITY, IPPROTO_UDP, 0);
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_UDP,
+					  __bpf_htons(80));
+		assert(ret == CTX_ACT_OK);
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_TCP,
+					  __bpf_htons(80));
+		assert(ret == DROP_POLICY);
+
+		policy_delete_egress_entry(REMOTE_IDENTITY, IPPROTO_UDP, 0);
+	});
+
+	TEST("wildcarded L3+L4", {
+		int ret;
+
+		policy_add_egress_allow_entry(REMOTE_IDENTITY, 0, 0);
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_UDP,
+					  __bpf_htons(80));
+		assert(ret == CTX_ACT_OK);
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_TCP,
+					  __bpf_htons(80));
+		assert(ret == CTX_ACT_OK);
+
+		policy_delete_egress_entry(REMOTE_IDENTITY, 0, 0);
+	});
+
+	TEST("L3+L4 policy, any identity", {
+		int ret;
+
+		policy_add_egress_allow_entry(0, IPPROTO_UDP,
+					      __bpf_htons(80));
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_UDP,
+					  __bpf_htons(80));
+		assert(ret == CTX_ACT_OK);
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_UDP,
+					  __bpf_htons(81));
+		assert(ret == DROP_POLICY);
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_TCP,
+					  __bpf_htons(80));
+		assert(ret == DROP_POLICY);
+
+		policy_delete_egress_entry(0, IPPROTO_UDP,
+					   __bpf_htons(80));
+	});
+
+	TEST("wildcarded L4, any-identity", {
+		int ret;
+
+		policy_add_egress_allow_entry(0, IPPROTO_UDP, 0);
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_UDP,
+					  __bpf_htons(80));
+		assert(ret == CTX_ACT_OK);
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_TCP,
+					  __bpf_htons(80));
+		assert(ret == DROP_POLICY);
+
+		policy_delete_egress_entry(0, IPPROTO_UDP, 0);
+	});
+
+	TEST("wildcarded L3+L4, any identity [allow-all]", {
+		int ret;
+
+		policy_add_egress_allow_entry(0, 0, 0);
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_UDP,
+					  __bpf_htons(80));
+		assert(ret == CTX_ACT_OK);
+
+		ret = check_egress_policy(ctx, REMOTE_IDENTITY, IPPROTO_TCP,
+					  __bpf_htons(80));
+		assert(ret == CTX_ACT_OK);
+
+		policy_delete_egress_entry(0, 0, 0);
+	});
+
+	test_finish();
+}

--- a/bpf/tests/pktgen.h
+++ b/bpf/tests/pktgen.h
@@ -20,6 +20,7 @@
 #include <linux/udp.h>
 #include <linux/icmp.h>
 #include <linux/icmpv6.h>
+#include <linux/igmp.h>
 
 /* A collection of pre-defined Ethernet MAC addresses, so tests can reuse them
  * without having to come up with custom addresses.
@@ -189,6 +190,7 @@ enum pkt_layer {
 	PKT_LAYER_ICMPV6,
 	PKT_LAYER_SCTP,
 	PKT_LAYER_ESP,
+	PKT_LAYER_IGMP,
 
 	/* Tunnel layers */
 	PKT_LAYER_GENEVE,
@@ -472,6 +474,13 @@ __attribute__((warn_unused_result))
 struct icmp6hdr *pktgen__push_icmp6hdr(struct pktgen *builder)
 {
 	return pktgen__push_rawhdr(builder, sizeof(struct icmp6hdr), PKT_LAYER_ICMPV6);
+}
+
+static __always_inline
+__attribute__((warn_unused_result))
+struct igmphdr *pktgen__push_igmphdr(struct pktgen *builder)
+{
+	return pktgen__push_rawhdr(builder, sizeof(struct igmphdr), PKT_LAYER_IGMP);
 }
 
 /* Push an empty ESP header onto the packet */
@@ -789,6 +798,40 @@ pktgen__push_ipv4_icmp_packet(struct pktgen *builder,
 	return l4;
 }
 
+static __always_inline struct igmphdr *
+pktgen__push_ipv4_igmp_packet(struct pktgen *builder,
+			      __u8 *smac, __u8 *dmac,
+			      __be32 saddr, __be32 daddr,
+			      __u8 igmp_type)
+{
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	struct igmphdr *l4;
+
+	l2 = pktgen__push_ethhdr(builder);
+	if (!l2)
+		return NULL;
+
+	ethhdr__set_macs(l2, smac, dmac);
+
+	l3 = pktgen__push_default_iphdr(builder);
+	if (!l3)
+		return NULL;
+
+	l3->saddr = saddr;
+	l3->daddr = daddr;
+
+	l4 = pktgen__push_igmphdr(builder);
+	if (!l4)
+		return NULL;
+
+	l4->type = igmp_type;
+	l4->code = 0;
+	l4->csum = 0;
+
+	return l4;
+}
+
 static __always_inline struct tcphdr *
 pktgen__push_ipv6_tcp_packet(struct pktgen *builder,
 			     __u8 *smac, __u8 *dmac,
@@ -945,6 +988,9 @@ static __always_inline void pktgen__finish_ipv4(const struct pktgen *builder, in
 		break;
 	case PKT_LAYER_ESP:
 		ipv4_layer->protocol = IPPROTO_ESP;
+		break;
+	case PKT_LAYER_IGMP:
+		ipv4_layer->protocol = IPPROTO_IGMP;
 		break;
 	default:
 		break;
@@ -1317,6 +1363,9 @@ void pktgen__finish(const struct pktgen *builder)
 			break;
 
 		case PKT_LAYER_VXLAN:
+			break;
+
+		case PKT_LAYER_IGMP:
 			break;
 
 		case PKT_LAYER_DATA:


### PR DESCRIPTION
TODO: fix upstream commit sha for https://github.com/cilium/cilium/pull/47648 once merged.

 * [x] https://github.com/cilium/cilium/pull/39872: (@aditighag) PARTIAL backport, taking only tests infra, see commit messages for changes and what has been dropped or adjusted. CONFLICT see backport messages
 * [x] https://github.com/cilium/cilium/pull/41906 (@julianwiedmann) CONFLICT see backport messages
 * [x] https://github.com/cilium/cilium/pull/43684 (@julianwiedmann) CONFLICT see backport messages
 * [x] https://github.com/cilium/cilium/pull/47343 (@smagnani96) CONFLICT see backport messages
 * [ ] ~~https://github.com/cilium/cilium/pull/45589 (@pchaigno) CONFLICT~~
 * [ ] ~~https://github.com/cilium/cilium/pull/47648 (@smagnani96) CONFLICT~~

Most of the conflicts are due either the non-backported `enable-extended-ip-protocol` feature or some middle infrastructural commit with a lot of consequential unrelated changes.

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 39872 41906 43684 47343
```