### PR TITLE
endpoint/watchdog: Avoid warning about endpoints being deleted

### DIFF
--- a/pkg/endpoint/watchdog/ep-bpfprog-watchdog.go
+++ b/pkg/endpoint/watchdog/ep-bpfprog-watchdog.go
@@ -119,10 +119,12 @@ func (r *endpointBPFProgWatchdog) checkEndpointBPFPrograms(ctx context.Context) 
 			return fmt.Errorf("failed to assert if endpoint BPF programs need to be reloaded: %w", err)
 		}
 
-		// We've detected missing bpf progs for this endpoint.
-		// Trigger bpf progs reload - but first fetch all endpoints that
-		// don't have the programs loaded.
-		if !loaded {
+		// Collect all endpoints without the programs loaded before triggering
+		// the reload below. An Endpoint being deleted also detaches the programs
+		// while the host device still exists, so check if the Endpoint is still
+		// alive. Both the StateReady check above and loaded were fetched earlier.
+		// Otherwise, we will false warn of programs being unloaded.
+		if !loaded && ep.IsAlive() {
 			epsWithoutProgramsLoaded[ep.ID] = ep.GetK8sNamespaceAndCEPName()
 		}
 	}


### PR DESCRIPTION
The endpoint BPF program watchdog periodically walks the endpoints and,
for each one in StateReady, asks netlink whether its host device still
has Cilium's BPF programs attached. If any endpoint comes back without
them, the watchdog warns that another application removed the BPF
programs and reinitializes the datapath.

The state check and the probe are not atomic. GetState releases the
endpoint mutex on return and DeviceHasSKBProgramLoaded takes no endpoint
lock, so an endpoint that was StateReady when the loop began can be
deleted before it is probed. Endpoint deletion detaches the BPF programs
while the host device still exists, which the probe cannot tell apart
from another application removing them. This is what makes
check-log-errors flake in the conn-disrupt tests, where the fixture's
pods are torn down while the watchdog is running.

Check IsAlive before recording the endpoint. Delete holds the endpoint
mutex across both setState(StateDisconnecting) and the detach, so the
check either blocks until the deletion completes or observes
StateDisconnecting, neither of which can transition back to StateReady.
When another application is the one removing the BPF programs, the
endpoint stays alive and the watchdog still warns and reloads as before.

Fixes: #47564
Fixes: #44078

