### PR TITLE
gateway-api: sync ListenerSet TLS secrets on ListenerSet events

### DIFF
--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -323,14 +323,22 @@ func registerSecretSync(params secretSyncParams) secretsync.SecretSyncRegistrati
 	}
 
 	handler := NewSecretSyncHandler(params.CtrlRuntimeManager.GetClient(), params.Logger, defaultControllerName)
+	secretSyncRegistration := &secretsync.SecretSyncRegistration{
+		RefObject:            &gatewayv1.Gateway{},
+		RefObjectEnqueueFunc: handler.EnqueueTLSSecrets(),
+		RefObjectCheckFunc:   handler.IsReferencedByGateway,
+		SecretsNamespace:     params.GatewayApiConfig.GatewayAPISecretsNamespace,
+	}
+
+	if helpers.HasListenerSetSupport(params.CtrlRuntimeManager.GetScheme()) {
+		secretSyncRegistration.AdditionalWatches = append(secretSyncRegistration.AdditionalWatches, secretsync.AdditionalWatch{
+			RefObject:            &gatewayv1.ListenerSet{},
+			RefObjectEnqueueFunc: handler.EnqueueListenerSetTLSSecrets(),
+		})
+	}
 
 	return secretsync.SecretSyncRegistrationOut{
-		SecretSyncRegistration: &secretsync.SecretSyncRegistration{
-			RefObject:            &gatewayv1.Gateway{},
-			RefObjectEnqueueFunc: handler.EnqueueTLSSecrets(),
-			RefObjectCheckFunc:   handler.IsReferencedByGateway,
-			SecretsNamespace:     params.GatewayApiConfig.GatewayAPISecretsNamespace,
-		},
+		SecretSyncRegistration: secretSyncRegistration,
 		ConfigMapSyncRegistration: &secretsync.ConfigMapSyncRegistration{
 			RefObject:            &gatewayv1.BackendTLSPolicy{},
 			RefObjectEnqueueFunc: handler.EnqueueBackendTLSPolicyConfigMaps(),

--- a/operator/pkg/gateway-api/secretsync.go
+++ b/operator/pkg/gateway-api/secretsync.go
@@ -71,6 +71,50 @@ func (h *SecretSyncHandler) EnqueueTLSSecrets() handler.EventHandler {
 	})
 }
 
+func (h *SecretSyncHandler) EnqueueListenerSetTLSSecrets() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+		scopedLog := h.logger.With(
+			logfields.Resource, obj.GetName(),
+		)
+
+		ls, ok := obj.(*gatewayv1.ListenerSet)
+		if !ok {
+			return nil
+		}
+
+		gw := &gatewayv1.Gateway{}
+		gwNN := helpers.ListenerSetParentGateway(ls)
+		if err := h.client.Get(ctx, *gwNN, gw); err != nil {
+			scopedLog.DebugContext(ctx, "Unable to get parent gateway for listenerset", logfields.Error, err)
+			return nil
+		}
+
+		// Check whether parent Gateway is managed by Cilium
+		if !helpers.GatewayHasMatchingControllerFn(ctx, h.client, h.controllerName, h.logger)(gw) {
+			return nil
+		}
+
+		var reqs []reconcile.Request
+		for _, l := range ls.Spec.Listeners {
+			if l.TLS == nil {
+				continue
+			}
+			for _, cert := range l.TLS.CertificateRefs {
+				if !helpers.IsSecret(cert) {
+					continue
+				}
+				s := types.NamespacedName{
+					Namespace: helpers.NamespaceDerefOr(cert.Namespace, ls.Namespace),
+					Name:      string(cert.Name),
+				}
+				reqs = append(reqs, reconcile.Request{NamespacedName: s})
+				scopedLog.DebugContext(ctx, "Enqueued secret for listenerset", logfields.Secret, s)
+			}
+		}
+		return reqs
+	})
+}
+
 func (h *SecretSyncHandler) IsReferencedByGateway(ctx context.Context, _ client.Client, _ *slog.Logger, obj *corev1.Secret) bool {
 	return len(helpers.GetGatewaysForSecret(ctx, h.client, obj, h.controllerName, h.logger)) > 0
 }

--- a/operator/pkg/gateway-api/secretsync_test.go
+++ b/operator/pkg/gateway-api/secretsync_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gateway_api
+
+import (
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+)
+
+const testGatewayControllerName = "io.cilium/gateway-controller"
+
+func TestSecretSyncHandlerEnqueueListenerSetTLSSecretsIncludingCrossNamespaceRefs(t *testing.T) {
+	gatewayClass := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "cilium"},
+		Spec: gatewayv1.GatewayClassSpec{
+			ControllerName: gatewayv1.GatewayController(testGatewayControllerName),
+		},
+	}
+
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "parent-gateway",
+			Namespace: "gw-ns",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cilium",
+		},
+	}
+
+	listenerSet := &gatewayv1.ListenerSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app-listeners",
+			Namespace: "ls-secret-ns",
+		},
+		Spec: gatewayv1.ListenerSetSpec{
+			ParentRef: gatewayv1.ParentGatewayReference{
+				Name:      gatewayv1.ObjectName(gateway.Name),
+				Namespace: ptr.To[gatewayv1.Namespace](gatewayv1.Namespace(gateway.Namespace)),
+			},
+			Listeners: []gatewayv1.ListenerEntry{
+				{
+					Name:     "https",
+					Port:     443,
+					Protocol: gatewayv1.HTTPSProtocolType,
+					TLS: &gatewayv1.ListenerTLSConfig{
+						CertificateRefs: []gatewayv1.SecretObjectReference{
+							{
+								Name: "default-secret",
+							},
+							{
+								Name:      "cross-ns-secret",
+								Namespace: ptr.To[gatewayv1.Namespace]("cross-secret-ns"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+		WithObjects(gatewayClass, gateway, listenerSet).
+		Build()
+
+	handler := NewSecretSyncHandler(fakeClient, hivetest.Logger(t), testGatewayControllerName)
+	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+	defer queue.ShutDown()
+
+	handler.EnqueueListenerSetTLSSecrets().Create(t.Context(), event.TypedCreateEvent[client.Object]{Object: listenerSet}, queue)
+
+	var got []types.NamespacedName
+	for queue.Len() > 0 {
+		item, shutdown := queue.Get()
+		require.False(t, shutdown)
+		got = append(got, item.NamespacedName)
+		queue.Done(item)
+	}
+
+	require.ElementsMatch(t, []types.NamespacedName{
+		{Namespace: "ls-secret-ns", Name: "default-secret"},
+		{Namespace: "cross-secret-ns", Name: "cross-ns-secret"},
+	}, got)
+}


### PR DESCRIPTION
Gateway API secret sync only registered Gateway objects as reference triggers. That meant TLS Secrets referenced exclusively from ListenerSets were only reconciled when the Secret itself changed or when the operator restarted and replayed the initial Secret watch.

Therefore, this commit adds the missing secret sync watch.

Fixes: #47622