### PR TITLE
kvstore: drop unused [IPIdentityPair.Mask]

### DIFF
--- a/clustermesh-apiserver/clustermesh/testdata/ciliumendpoints.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/ciliumendpoints.txtar
@@ -224,7 +224,6 @@ status:
 # cilium/state/ip/v1/default/10.244.1.79
 {
   "IP": "10.244.1.79",
-  "Mask": null,
   "HostIP": "172.18.0.3",
   "ID": 199472,
   "Key": 0,
@@ -236,7 +235,6 @@ status:
 # cilium/state/ip/v1/default/10.244.2.74
 {
   "IP": "10.244.2.74",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199475,
   "Key": 5,
@@ -260,7 +258,6 @@ status:
 # cilium/state/ip/v1/default/fd00:10:244:1::d643
 {
   "IP": "fd00:10:244:1::d643",
-  "Mask": null,
   "HostIP": "172.18.0.3",
   "ID": 199472,
   "Key": 0,
@@ -272,7 +269,6 @@ status:
 # cilium/state/ip/v1/default/fd00:10:244:2::e024
 {
   "IP": "fd00:10:244:2::e024",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199475,
   "Key": 5,
@@ -297,7 +293,6 @@ status:
 # cilium/state/ip/v1/default/10.244.1.80
 {
   "IP": "10.244.1.80",
-  "Mask": null,
   "HostIP": "172.18.0.3",
   "ID": 199472,
   "Key": 0,
@@ -309,7 +304,6 @@ status:
 # cilium/state/ip/v1/default/10.244.2.74
 {
   "IP": "10.244.2.74",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199475,
   "Key": 5,
@@ -333,7 +327,6 @@ status:
 # cilium/state/ip/v1/default/fd00:10:244:2::e024
 {
   "IP": "fd00:10:244:2::e024",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199475,
   "Key": 5,
@@ -358,7 +351,6 @@ status:
 # cilium/state/ip/v1/default/10.244.1.80
 {
   "IP": "10.244.1.80",
-  "Mask": null,
   "HostIP": "172.18.0.3",
   "ID": 199472,
   "Key": 0,
@@ -370,7 +362,6 @@ status:
 # cilium/state/ip/v1/default/10.244.2.74
 {
   "IP": "10.244.2.74",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199475,
   "Key": 5,
@@ -394,7 +385,6 @@ status:
 # cilium/state/ip/v1/default/10.244.2.91
 {
   "IP": "10.244.2.91",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199472,
   "Key": 0,
@@ -406,7 +396,6 @@ status:
 # cilium/state/ip/v1/default/fd00:10:244:2::e024
 {
   "IP": "fd00:10:244:2::e024",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199475,
   "Key": 5,
@@ -430,7 +419,6 @@ status:
 # cilium/state/ip/v1/default/fd00:10:244:2::e4b4
 {
   "IP": "fd00:10:244:2::e4b4",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199472,
   "Key": 0,
@@ -443,7 +431,6 @@ status:
 # cilium/state/ip/v1/default/10.244.1.80
 {
   "IP": "10.244.1.80",
-  "Mask": null,
   "HostIP": "172.18.0.3",
   "ID": 199472,
   "Key": 0,
@@ -455,7 +442,6 @@ status:
 # cilium/state/ip/v1/default/10.244.2.91
 {
   "IP": "10.244.2.91",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199472,
   "Key": 0,
@@ -467,7 +453,6 @@ status:
 # cilium/state/ip/v1/default/fd00:10:244:2::e4b4
 {
   "IP": "fd00:10:244:2::e4b4",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199472,
   "Key": 0,
@@ -480,7 +465,6 @@ status:
 # cilium/state/ip/v1/default/10.244.1.80
 {
   "IP": "10.244.1.80",
-  "Mask": null,
   "HostIP": "172.18.0.3",
   "ID": 199472,
   "Key": 0,
@@ -492,7 +476,6 @@ status:
 # cilium/state/ip/v1/default/10.244.2.91
 {
   "IP": "10.244.2.91",
-  "Mask": null,
   "HostIP": "172.18.0.3",
   "ID": 199479,
   "Key": 0,
@@ -504,7 +487,6 @@ status:
 # cilium/state/ip/v1/default/fd00:10:244:2::e4b4
 {
   "IP": "fd00:10:244:2::e4b4",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199472,
   "Key": 0,
@@ -516,7 +498,6 @@ status:
 # cilium/state/ip/v1/default/fd00:10:244:2::e4b5
 {
   "IP": "fd00:10:244:2::e4b5",
-  "Mask": null,
   "HostIP": "172.18.0.3",
   "ID": 199479,
   "Key": 0,
@@ -529,7 +510,6 @@ status:
 # cilium/state/ip/v1/default/10.244.1.80
 {
   "IP": "10.244.1.80",
-  "Mask": null,
   "HostIP": "172.18.0.3",
   "ID": 199472,
   "Key": 0,
@@ -541,7 +521,6 @@ status:
 # cilium/state/ip/v1/default/10.244.2.91
 {
   "IP": "10.244.2.91",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199472,
   "Key": 0,
@@ -553,7 +532,6 @@ status:
 # cilium/state/ip/v1/default/fd00:10:244:2::e4b4
 {
   "IP": "fd00:10:244:2::e4b4",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199472,
   "Key": 0,
@@ -565,7 +543,6 @@ status:
 # cilium/state/ip/v1/default/fd00:10:244:2::e4b5
 {
   "IP": "fd00:10:244:2::e4b5",
-  "Mask": null,
   "HostIP": "172.18.0.3",
   "ID": 199479,
   "Key": 0,
@@ -578,7 +555,6 @@ status:
 # cilium/state/ip/v1/default/10.244.1.80
 {
   "IP": "10.244.1.80",
-  "Mask": null,
   "HostIP": "172.18.0.3",
   "ID": 199472,
   "Key": 0,
@@ -590,7 +566,6 @@ status:
 # cilium/state/ip/v1/default/10.244.2.91
 {
   "IP": "10.244.2.91",
-  "Mask": null,
   "HostIP": "172.18.0.3",
   "ID": 199479,
   "Key": 0,
@@ -602,7 +577,6 @@ status:
 # cilium/state/ip/v1/default/fd00:10:244:2::e4b5
 {
   "IP": "fd00:10:244:2::e4b5",
-  "Mask": null,
   "HostIP": "172.18.0.3",
   "ID": 199479,
   "Key": 0,
@@ -615,7 +589,6 @@ status:
 # cilium/state/ip/v1/default/10.244.1.80
 {
   "IP": "10.244.1.80",
-  "Mask": null,
   "HostIP": "172.18.0.3",
   "ID": 199472,
   "Key": 0,

--- a/clustermesh-apiserver/clustermesh/testdata/ciliumendpointslices.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/ciliumendpointslices.txtar
@@ -198,7 +198,6 @@ namespace: fred
 # cilium/state/ip/v1/default/10.244.1.79
 {
   "IP": "10.244.1.79",
-  "Mask": null,
   "HostIP": "172.18.0.3",
   "ID": 199472,
   "Key": 0,
@@ -210,7 +209,6 @@ namespace: fred
 # cilium/state/ip/v1/default/10.244.2.74
 {
   "IP": "10.244.2.74",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199475,
   "Key": 5,
@@ -222,7 +220,6 @@ namespace: fred
 # cilium/state/ip/v1/default/10.244.2.78
 {
   "IP": "10.244.2.78",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199494,
   "Key": 0,
@@ -246,7 +243,6 @@ namespace: fred
 # cilium/state/ip/v1/default/10.244.2.91
 {
   "IP": "10.244.2.91",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199475,
   "Key": 0,
@@ -258,7 +254,6 @@ namespace: fred
 # cilium/state/ip/v1/default/fd00:10:244:1::d643
 {
   "IP": "fd00:10:244:1::d643",
-  "Mask": null,
   "HostIP": "172.18.0.3",
   "ID": 199472,
   "Key": 0,
@@ -270,7 +265,6 @@ namespace: fred
 # cilium/state/ip/v1/default/fd00:10:244:2::9182
 {
   "IP": "fd00:10:244:2::9182",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199494,
   "Key": 0,
@@ -294,7 +288,6 @@ namespace: fred
 # cilium/state/ip/v1/default/fd00:10:244:2::e024
 {
   "IP": "fd00:10:244:2::e024",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199475,
   "Key": 5,
@@ -306,7 +299,6 @@ namespace: fred
 # cilium/state/ip/v1/default/fd00:10:244:2::e4b4
 {
   "IP": "fd00:10:244:2::e4b4",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199475,
   "Key": 0,
@@ -319,7 +311,6 @@ namespace: fred
 # cilium/state/ip/v1/default/10.244.2.15
 {
   "IP": "10.244.2.15",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199477,
   "Key": 0,
@@ -331,7 +322,6 @@ namespace: fred
 # cilium/state/ip/v1/default/10.244.2.78
 {
   "IP": "10.244.2.78",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199494,
   "Key": 0,
@@ -355,7 +345,6 @@ namespace: fred
 # cilium/state/ip/v1/default/10.244.2.91
 {
   "IP": "10.244.2.91",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199481,
   "Key": 0,
@@ -367,7 +356,6 @@ namespace: fred
 # cilium/state/ip/v1/default/fd00:10:244:2::9182
 {
   "IP": "fd00:10:244:2::9182",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199494,
   "Key": 0,
@@ -391,7 +379,6 @@ namespace: fred
 # cilium/state/ip/v1/default/fd00:10:244:2::d615
 {
   "IP": "fd00:10:244:2::d615",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199477,
   "Key": 0,
@@ -403,7 +390,6 @@ namespace: fred
 # cilium/state/ip/v1/default/fd00:10:244:2::e4b3
 {
   "IP": "fd00:10:244:2::e4b3",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199481,
   "Key": 0,
@@ -416,7 +402,6 @@ namespace: fred
 # cilium/state/ip/v1/default/10.244.2.120
 {
   "IP": "10.244.2.120",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199494,
   "Key": 0,
@@ -428,7 +413,6 @@ namespace: fred
 # cilium/state/ip/v1/default/10.244.2.15
 {
   "IP": "10.244.2.15",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199477,
   "Key": 0,
@@ -440,7 +424,6 @@ namespace: fred
 # cilium/state/ip/v1/default/10.244.2.78
 {
   "IP": "10.244.2.78",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199494,
   "Key": 0,
@@ -464,7 +447,6 @@ namespace: fred
 # cilium/state/ip/v1/default/10.244.2.91
 {
   "IP": "10.244.2.91",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199481,
   "Key": 0,
@@ -476,7 +458,6 @@ namespace: fred
 # cilium/state/ip/v1/default/fd00:10:244:2::5e16
 {
   "IP": "fd00:10:244:2::5e16",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199494,
   "Key": 0,
@@ -488,7 +469,6 @@ namespace: fred
 # cilium/state/ip/v1/default/fd00:10:244:2::9182
 {
   "IP": "fd00:10:244:2::9182",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199494,
   "Key": 0,
@@ -512,7 +492,6 @@ namespace: fred
 # cilium/state/ip/v1/default/fd00:10:244:2::d615
 {
   "IP": "fd00:10:244:2::d615",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199477,
   "Key": 0,
@@ -524,7 +503,6 @@ namespace: fred
 # cilium/state/ip/v1/default/fd00:10:244:2::e4b3
 {
   "IP": "fd00:10:244:2::e4b3",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199481,
   "Key": 0,
@@ -537,7 +515,6 @@ namespace: fred
 # cilium/state/ip/v1/default/10.244.2.120
 {
   "IP": "10.244.2.120",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199494,
   "Key": 0,
@@ -549,7 +526,6 @@ namespace: fred
 # cilium/state/ip/v1/default/10.244.2.15
 {
   "IP": "10.244.2.15",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199477,
   "Key": 0,
@@ -561,7 +537,6 @@ namespace: fred
 # cilium/state/ip/v1/default/10.244.2.91
 {
   "IP": "10.244.2.91",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199481,
   "Key": 0,
@@ -573,7 +548,6 @@ namespace: fred
 # cilium/state/ip/v1/default/fd00:10:244:2::5e16
 {
   "IP": "fd00:10:244:2::5e16",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199494,
   "Key": 0,
@@ -585,7 +559,6 @@ namespace: fred
 # cilium/state/ip/v1/default/fd00:10:244:2::d615
 {
   "IP": "fd00:10:244:2::d615",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199477,
   "Key": 0,
@@ -597,7 +570,6 @@ namespace: fred
 # cilium/state/ip/v1/default/fd00:10:244:2::e4b3
 {
   "IP": "fd00:10:244:2::e4b3",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199481,
   "Key": 0,
@@ -610,7 +582,6 @@ namespace: fred
 # cilium/state/ip/v1/default/10.244.2.120
 {
   "IP": "10.244.2.120",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199494,
   "Key": 0,
@@ -622,7 +593,6 @@ namespace: fred
 # cilium/state/ip/v1/default/fd00:10:244:2::5e16
 {
   "IP": "fd00:10:244:2::5e16",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199494,
   "Key": 0,
@@ -635,7 +605,6 @@ namespace: fred
 # cilium/state/ip/v1/default/10.244.2.15
 {
   "IP": "10.244.2.15",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199477,
   "Key": 0,
@@ -647,7 +616,6 @@ namespace: fred
 # cilium/state/ip/v1/default/10.244.2.91
 {
   "IP": "10.244.2.91",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199481,
   "Key": 0,
@@ -659,7 +627,6 @@ namespace: fred
 # cilium/state/ip/v1/default/fd00:10:244:2::d615
 {
   "IP": "fd00:10:244:2::d615",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199477,
   "Key": 0,
@@ -671,7 +638,6 @@ namespace: fred
 # cilium/state/ip/v1/default/fd00:10:244:2::e4b3
 {
   "IP": "fd00:10:244:2::e4b3",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199481,
   "Key": 0,

--- a/clustermesh-apiserver/clustermesh/testdata/globalnamespace.txtar
+++ b/clustermesh-apiserver/clustermesh/testdata/globalnamespace.txtar
@@ -109,7 +109,6 @@ status:
 # cilium/state/ip/v1/default/10.244.1.79
 {
   "IP": "10.244.1.79",
-  "Mask": null,
   "HostIP": "172.18.0.3",
   "ID": 199472,
   "Key": 0,
@@ -121,7 +120,6 @@ status:
 # cilium/state/ip/v1/default/fd00:10:244:1::d643
 {
   "IP": "fd00:10:244:1::d643",
-  "Mask": null,
   "HostIP": "172.18.0.3",
   "ID": 199472,
   "Key": 0,
@@ -134,7 +132,6 @@ status:
 # cilium/state/ip/v1/default/10.244.1.79
 {
   "IP": "10.244.1.79",
-  "Mask": null,
   "HostIP": "172.18.0.3",
   "ID": 199472,
   "Key": 0,
@@ -146,7 +143,6 @@ status:
 # cilium/state/ip/v1/default/10.244.2.74
 {
   "IP": "10.244.2.74",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199475,
   "Key": 5,
@@ -158,7 +154,6 @@ status:
 # cilium/state/ip/v1/default/fd00:10:244:1::d643
 {
   "IP": "fd00:10:244:1::d643",
-  "Mask": null,
   "HostIP": "172.18.0.3",
   "ID": 199472,
   "Key": 0,
@@ -170,7 +165,6 @@ status:
 # cilium/state/ip/v1/default/fd00:10:244:2::e024
 {
   "IP": "fd00:10:244:2::e024",
-  "Mask": null,
   "HostIP": "172.18.0.2",
   "ID": 199475,
   "Key": 5,

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"strconv"
 	"sync"
 
 	"github.com/cilium/cilium/pkg/labels"
@@ -40,15 +39,13 @@ type Identity struct {
 }
 
 // IPIdentityPair is a pairing of an IP and the security identity to which that
-// IP corresponds. May include an optional Mask which, if present, denotes that
-// the IP represents a CIDR with the specified Mask.
+// IP corresponds.
 //
 // WARNING - STABLE API
 // This structure is written as JSON to the key-value store. Do NOT modify this
 // structure in ways which are not JSON forward compatible.
 type IPIdentityPair struct {
 	IP                net.IP          `json:"IP"`
-	Mask              net.IPMask      `json:"Mask"`
 	HostIP            net.IP          `json:"HostIP"`
 	ID                NumericIdentity `json:"ID"`
 	Key               uint8           `json:"Key"`
@@ -62,7 +59,7 @@ type IPIdentityPair struct {
 type IdentityMap map[NumericIdentity]labels.LabelArray
 
 // GetKeyName returns the kvstore key to be used for the IPIdentityPair
-func (pair *IPIdentityPair) GetKeyName() string { return pair.PrefixString() }
+func (pair *IPIdentityPair) GetKeyName() string { return pair.IP.String() }
 
 // Marshal returns the IPIdentityPair object as JSON byte slice
 func (pair *IPIdentityPair) Marshal() ([]byte, error) { return json.Marshal(pair) }
@@ -144,26 +141,6 @@ func NewIdentity(id NumericIdentity, lbls labels.Labels) *Identity {
 		lblArray = lbls.LabelArray()
 	}
 	return &Identity{ID: id, Labels: lbls, LabelArray: lblArray}
-}
-
-// IsHost determines whether the IP in the pair represents a host (true) or a
-// CIDR prefix (false)
-func (pair *IPIdentityPair) IsHost() bool {
-	return pair.Mask == nil
-}
-
-// PrefixString returns the IPIdentityPair's IP as either a host IP in the
-// format w.x.y.z if 'host' is true, or as a prefix in the format the w.x.y.z/N
-// if 'host' is false.
-func (pair *IPIdentityPair) PrefixString() string {
-	ipstr := pair.IP.String()
-
-	if pair.IsHost() {
-		return ipstr
-	}
-
-	ones, _ := pair.Mask.Size()
-	return ipstr + "/" + strconv.Itoa(ones)
 }
 
 // ScopeForLabels returns the identity scope to be used for the label set.

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -4,7 +4,6 @@
 package identity
 
 import (
-	"net"
 	"net/netip"
 	"testing"
 
@@ -326,126 +325,6 @@ func TestLookupReservedIdentityByLabels(t *testing.T) {
 			assert.NotNil(t, id)
 			assert.Equal(t, tt.want.id, id.ID)
 			assert.Equal(t, tt.want.labels, id.Labels)
-		})
-	}
-}
-
-func TestIPIdentityPair_PrefixString(t *testing.T) {
-	ipv6Mask := make(net.IPMask, net.IPv6len)
-	for i := range ipv6Mask {
-		ipv6Mask[i] = 255
-	}
-
-	tests := []struct {
-		name     string
-		expected string
-		pair     *IPIdentityPair
-	}{
-		{
-			name:     "IPv4 with mask",
-			expected: "10.1.128.15/32",
-			pair: &IPIdentityPair{
-				IP:           net.ParseIP("10.1.128.15"),
-				Mask:         net.IPv4Mask(255, 255, 255, 255),
-				HostIP:       net.ParseIP("10.1.128.15"),
-				ID:           1,
-				Key:          3,
-				Metadata:     "metadata",
-				K8sNamespace: "kube-system",
-				K8sPodName:   "pod-name",
-				NamedPorts: []NamedPort{
-					{Name: "port", Port: 8080, Protocol: "TCP"},
-				},
-			},
-		},
-		{
-			name:     "IPv4 without mask",
-			expected: "10.1.128.15",
-			pair: &IPIdentityPair{
-				IP:           net.ParseIP("10.1.128.15"),
-				HostIP:       net.ParseIP("10.1.128.15"),
-				ID:           1,
-				Key:          3,
-				Metadata:     "metadata",
-				K8sNamespace: "kube-system",
-				K8sPodName:   "pod-name",
-				NamedPorts: []NamedPort{
-					{Name: "port", Port: 8080, Protocol: "TCP"},
-				},
-			},
-		},
-		{
-			name:     "IPv4 encoded as IPv6 with mask",
-			expected: "10.1.128.15/128",
-			pair: &IPIdentityPair{
-				IP:           net.ParseIP("::ffff:a01:800f"),
-				Mask:         ipv6Mask,
-				HostIP:       net.ParseIP("::ffff:a01:800f"),
-				ID:           1,
-				Key:          3,
-				Metadata:     "metadata",
-				K8sNamespace: "kube-system",
-				K8sPodName:   "pod-name",
-				NamedPorts: []NamedPort{
-					{Name: "port", Port: 8080, Protocol: "TCP"},
-				},
-			},
-		},
-		{
-			name:     "IPv4 encoded as IPv6 without mask",
-			expected: "10.1.128.15",
-			pair: &IPIdentityPair{
-				IP:           net.ParseIP("::ffff:a01:800f"),
-				HostIP:       net.ParseIP("::ffff:a01:800f"),
-				ID:           1,
-				Key:          3,
-				Metadata:     "metadata",
-				K8sNamespace: "kube-system",
-				K8sPodName:   "pod-name",
-				NamedPorts: []NamedPort{
-					{Name: "port", Port: 8080, Protocol: "TCP"},
-				},
-			},
-		},
-		{
-			name:     "IPv6 local with mask",
-			expected: "fd12:3456:789a:1::1/128",
-			pair: &IPIdentityPair{
-				IP:           net.ParseIP("fd12:3456:789a:1::1"),
-				Mask:         ipv6Mask,
-				HostIP:       net.ParseIP("fd12:3456:789a:1::1"),
-				ID:           1,
-				Key:          3,
-				Metadata:     "metadata",
-				K8sNamespace: "kube-system",
-				K8sPodName:   "pod-name",
-				NamedPorts: []NamedPort{
-					{Name: "port", Port: 8080, Protocol: "TCP"},
-				},
-			},
-		},
-		{
-			name:     "IPv6 local without mask",
-			expected: "fd12:3456:789a:1::1",
-			pair: &IPIdentityPair{
-				IP:           net.ParseIP("fd12:3456:789a:1::1"),
-				HostIP:       net.ParseIP("fd12:3456:789a:1::1"),
-				ID:           1,
-				Key:          3,
-				Metadata:     "metadata",
-				K8sNamespace: "kube-system",
-				K8sPodName:   "pod-name",
-				NamedPorts: []NamedPort{
-					{Name: "port", Port: 8080, Protocol: "TCP"},
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			prefix := tt.pair.PrefixString()
-			assert.Len(t, prefix, len(tt.expected))
-			assert.Equal(t, tt.expected, prefix)
 		})
 	}
 }

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -373,21 +373,10 @@ func (iw *IPIdentityWatcher) WaitForSync(ctx context.Context) error {
 // OnUpdate is triggered when a new upsertion event is observed, and
 // synchronizes local caching of endpoint IP to ipIDPair mapping with
 // the operation the key-value store has informed us about.
-//
-// To resolve conflicts between hosts and full CIDR prefixes:
-//   - Insert hosts into the cache as ".../w.x.y.z"
-//   - Insert CIDRS into the cache as ".../w.x.y.z/N"
-//   - If a host entry created, notify the listeners.
-//   - If a CIDR is created and there's no overlapping host
-//     entry, ie it is a less than fully masked CIDR, OR
-//     it is a fully masked CIDR and there is no corresponding
-//     host entry, then:
-//   - Notify the listeners.
-//   - Otherwise, do not notify listeners.
 func (iw *IPIdentityWatcher) OnUpdate(k storepkg.Key) {
 	ipIDPair := k.(*identity.IPIdentityPair)
 
-	ip := ipIDPair.PrefixString()
+	ip := ipIDPair.IP.String()
 	if ip == "<nil>" {
 		iw.log.Warn("Ignoring entry with nil IP")
 		return
@@ -460,16 +449,9 @@ func (iw *IPIdentityWatcher) OnUpdate(k storepkg.Key) {
 // OnDelete is triggered when a new deletion event is observed, and
 // synchronizes local caching of endpoint IP to ipIDPair mapping with
 // the operation the key-value store has informed us about.
-//
-// To resolve conflicts between hosts and full CIDR prefixes:
-//   - If a host is removed, check for an overlapping CIDR
-//     and if it exists, notify the listeners with an upsert
-//     for the CIDR's identity
-//   - If any other deletion case, notify listeners of
-//     the deletion event.
 func (iw *IPIdentityWatcher) OnDelete(k storepkg.NamedKey) {
 	ipIDPair := k.(*identity.IPIdentityPair)
-	ip := ipIDPair.PrefixString()
+	ip := ipIDPair.IP.String()
 
 	iw.log.Debug(
 		"Observed deletion event",

--- a/pkg/ipcache/kvstore_test.go
+++ b/pkg/ipcache/kvstore_test.go
@@ -62,12 +62,12 @@ func (fb *fakeBackend) ListAndWatch(ctx context.Context, prefix string) kvstore.
 
 	pair = identity.IPIdentityPair{IP: net.ParseIP("10.0.0.1"), ID: id(10, 200)}
 	ch <- kvstore.KeyValueEvent{Typ: kvstore.EventTypeCreate, Key: pair.GetKeyName(), Value: marshal(pair)}
-	pair = identity.IPIdentityPair{IP: net.ParseIP("10.0.1.0"), Mask: net.CIDRMask(24, 32), ID: id(10, 201)}
+	pair = identity.IPIdentityPair{IP: net.ParseIP("10.0.1.2"), ID: id(10, 201)}
 	ch <- kvstore.KeyValueEvent{Typ: kvstore.EventTypeCreate, Key: pair.GetKeyName(), Value: marshal(pair)}
-	pair = identity.IPIdentityPair{IP: net.ParseIP("10.0.1.0"), Mask: net.CIDRMask(24, 32)}
+
 	ch <- kvstore.KeyValueEvent{Typ: kvstore.EventTypeListDone}
 
-	pair = identity.IPIdentityPair{IP: net.ParseIP("10.0.1.0"), Mask: net.CIDRMask(24, 32)}
+	pair = identity.IPIdentityPair{IP: net.ParseIP("10.0.1.2")}
 	ch <- kvstore.KeyValueEvent{Typ: kvstore.EventTypeDelete, Key: pair.GetKeyName()}
 	pair = identity.IPIdentityPair{IP: net.ParseIP("10.0.0.1")}
 	ch <- kvstore.KeyValueEvent{Typ: kvstore.EventTypeDelete, Key: pair.GetKeyName()}
@@ -130,8 +130,8 @@ func TestIPIdentityWatcher(t *testing.T) {
 
 	t.Run("without cluster ID", runnable(func(t *testing.T, ipcache *fakeIPCache) {
 		require.Equal(t, NewEvent("upsert", "10.0.0.1", src), eventually(ipcache.events))
-		require.Equal(t, NewEvent("upsert", "10.0.1.0/24", src), eventually(ipcache.events))
-		require.Equal(t, NewEvent("delete", "10.0.1.0/24", src), eventually(ipcache.events))
+		require.Equal(t, NewEvent("upsert", "10.0.1.2", src), eventually(ipcache.events))
+		require.Equal(t, NewEvent("delete", "10.0.1.2", src), eventually(ipcache.events))
 		require.Equal(t, NewEvent("delete", "10.0.0.1", src), eventually(ipcache.events))
 		require.Equal(t, NewEvent("upsert", "f00d::a00:0:0:c164", src), eventually(ipcache.events))
 		require.Equal(t, NewEvent("upsert", "10.0.0.2", src), eventually(ipcache.events))
@@ -140,8 +140,8 @@ func TestIPIdentityWatcher(t *testing.T) {
 
 	t.Run("with cluster ID", runnable(func(t *testing.T, ipcache *fakeIPCache) {
 		require.Equal(t, NewEvent("upsert", "10.0.0.1@10", src), eventually(ipcache.events))
-		require.Equal(t, NewEvent("upsert", "10.0.1.0/24@10", src), eventually(ipcache.events))
-		require.Equal(t, NewEvent("delete", "10.0.1.0/24@10", src), eventually(ipcache.events))
+		require.Equal(t, NewEvent("upsert", "10.0.1.2@10", src), eventually(ipcache.events))
+		require.Equal(t, NewEvent("delete", "10.0.1.2@10", src), eventually(ipcache.events))
 		require.Equal(t, NewEvent("delete", "10.0.0.1@10", src), eventually(ipcache.events))
 		require.Equal(t, NewEvent("upsert", "f00d::a00:0:0:c164@10", src), eventually(ipcache.events))
 		require.Equal(t, NewEvent("upsert", "10.0.0.2@10", src), eventually(ipcache.events))
@@ -150,8 +150,8 @@ func TestIPIdentityWatcher(t *testing.T) {
 
 	t.Run("with cached prefix", runnable(func(t *testing.T, ipcache *fakeIPCache) {
 		require.Equal(t, NewEvent("upsert", "10.0.0.1", src), eventually(ipcache.events))
-		require.Equal(t, NewEvent("upsert", "10.0.1.0/24", src), eventually(ipcache.events))
-		require.Equal(t, NewEvent("delete", "10.0.1.0/24", src), eventually(ipcache.events))
+		require.Equal(t, NewEvent("upsert", "10.0.1.2", src), eventually(ipcache.events))
+		require.Equal(t, NewEvent("delete", "10.0.1.2", src), eventually(ipcache.events))
 		require.Equal(t, NewEvent("delete", "10.0.0.1", src), eventually(ipcache.events))
 		require.Equal(t, NewEvent("upsert", "f00d::a00:0:0:c164", src), eventually(ipcache.events))
 		require.Equal(t, NewEvent("upsert", "10.0.0.2", src), eventually(ipcache.events))
@@ -160,8 +160,8 @@ func TestIPIdentityWatcher(t *testing.T) {
 
 	t.Run("with identity validation", runnable(func(t *testing.T, ipcache *fakeIPCache) {
 		require.Equal(t, NewEvent("upsert", "10.0.0.1", src), eventually(ipcache.events))
-		require.Equal(t, NewEvent("upsert", "10.0.1.0/24", src), eventually(ipcache.events))
-		require.Equal(t, NewEvent("delete", "10.0.1.0/24", src), eventually(ipcache.events))
+		require.Equal(t, NewEvent("upsert", "10.0.1.2", src), eventually(ipcache.events))
+		require.Equal(t, NewEvent("delete", "10.0.1.2", src), eventually(ipcache.events))
 		require.Equal(t, NewEvent("delete", "10.0.0.1", src), eventually(ipcache.events))
 		require.Equal(t, NewEvent("upsert", "f00d::a00:0:0:c164", src), eventually(ipcache.events))
 		require.True(t, synced, "The on-sync callback should have been executed")


### PR DESCRIPTION
The Mask field of the [IPIdentityPair] type, which represents an endpoint entry stored in etcd, is currently never directly populated, nor expected to be populated during unmarshaling of any legitimate entry. Hence, let's remove it, to simplify the surrounding logic, and remove a possible source of confusion. While being there, let's also remove stale references to host and CIDR conflict resolution in the [IPIdentityWatcher] comments.

This change does not introduce backwards compatibility concerns, as any nil mask value part of the JSON representation is simply ignored during unmarshaling. It does change the etcd key representation in case the mask value were set, in turn triggering an error during validation, which acts as a sanity check rejecting any non-legitimate entry, that should never be present in any well-behaving cluster anyways.

AIL:0