### PR TITLE
helm: finish removing encryption.ipsec.interface

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1356,10 +1356,6 @@
      - Enable transparent network encryption.
      - bool
      - ``false``
-   * - :spelling:ignore:`encryption.ipsec.interface`
-     - The interface to use for encrypted traffic.
-     - string
-     - ``""``
    * - :spelling:ignore:`encryption.ipsec.keyFile`
      - Name of the key file inside the Kubernetes secret configured via secretName.
      - string

--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -155,11 +155,10 @@ DNS proxy operates in transparent mode (``--dnsproxy-enable-transparent-mode=tru
 Encryption interface
 --------------------
 
-An additional argument can be used to identify the network-facing interface.
 If direct routing is used and no interface is specified, the default route
 link is chosen by inspecting the routing tables. This will work in many cases,
-but depending on routing rules, users may need to specify the encryption
-interface as follows:
+but depending on routing rules, users may need to name the network-facing
+interface explicitly with ``devices``:
 
 .. tabs::
 
@@ -170,13 +169,13 @@ interface as follows:
           cilium install |CHART_VERSION| \\
              --set encryption.enabled=true \\
              --set encryption.type=ipsec \\
-             --set encryption.ipsec.interface=ethX
+             --set devices=ethX
 
     .. group-tab:: Helm
 
        .. code-block:: shell-session
 
-           --set encryption.ipsec.interface=ethX
+           --set devices=ethX
 
 Validate the Setup
 ==================
@@ -298,9 +297,8 @@ Troubleshooting
 
  * Check for ``level=warning`` and ``level=error`` messages in the Cilium log files
 
-   * If there is a warning message similar to ``Device eth0 does not exist``,
-     use ``--set encryption.ipsec.interface=ethX`` to set the encryption
-     interface.
+   * If a warning names a device Cilium could not find, use ``--set devices=ethX``
+     to name the network-facing interface explicitly.
 
  * Run ``cilium-dbg encrypt status`` in the Cilium Pod:
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -389,7 +389,6 @@ contributors across the globe, there is almost always someone available to help.
 | enableNonDefaultDenyPolicies | bool | `true` | Enable Non-Default-Deny policies |
 | enableXTSocketFallback | bool | `true` | Enables the fallback compatibility solution for when the xt_socket kernel module is missing and it is needed for the datapath L7 redirection to work properly. See documentation for details on when this can be disabled: https://docs.cilium.io/en/stable/operations/system_requirements/#linux-kernel. |
 | encryption.enabled | bool | `false` | Enable transparent network encryption. |
-| encryption.ipsec.interface | string | `""` | The interface to use for encrypted traffic. |
 | encryption.ipsec.keyFile | string | `"keys"` | Name of the key file inside the Kubernetes secret configured via secretName. |
 | encryption.ipsec.keyRotationDuration | string | `"5m"` | Maximum duration of the IPsec key rotation. The previous key will be removed after that delay. |
 | encryption.ipsec.keyWatcher | bool | `true` | Enable the key watcher. If disabled, a restart of the agent will be necessary on key rotations. |

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -17,6 +17,11 @@
 }}
   {{ fail "encryption.{keyFile,mountPath,secretName,interface} were deprecated in v1.14 and has been removed in v1.16. For details please refer to https://docs.cilium.io/en/v1.16/operations/upgrade/#helm-options" }}
 {{- end }}
+
+{{/* Options removed in v1.21 */}}
+{{- if dig "encryption" "ipsec" "interface" "" .Values.AsMap }}
+  {{ fail "encryption.ipsec.interface (the --encrypt-interface agent flag) was a no-op since v1.18 and has been removed. Use devices to select the network-facing interface." }}
+{{- end }}
 {{- if or
   ((dig "proxy" "prometheus" "enabled" "" .Values.AsMap) | toString)
   (dig "proxy" "prometheus" "port" "" .Values.AsMap)

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -1938,9 +1938,6 @@
         },
         "ipsec": {
           "properties": {
-            "interface": {
-              "type": "string"
-            },
             "keyFile": {
               "type": "string"
             },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1178,8 +1178,6 @@ encryption:
     mountPath: /etc/ipsec
     # -- Name of the Kubernetes secret containing the encryption keys.
     secretName: cilium-ipsec-keys
-    # -- The interface to use for encrypted traffic.
-    interface: ""
     # -- Enable the key watcher. If disabled, a restart of the agent will be
     # necessary on key rotations.
     keyWatcher: true

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1190,8 +1190,6 @@ encryption:
     mountPath: /etc/ipsec
     # -- Name of the Kubernetes secret containing the encryption keys.
     secretName: cilium-ipsec-keys
-    # -- The interface to use for encrypted traffic.
-    interface: ""
     # -- Enable the key watcher. If disabled, a restart of the agent will be
     # necessary on key rotations.
     keyWatcher: true


### PR DESCRIPTION
Please review this on a per commit basis. The commits are grouped by the set of reviewers they belong to rather than by a single change, so each one stands alone with its own analysis, its own reproduction and its own `Fixes:` trailer.

This PR was prepared with AIL:3.
