### PR TITLE
datapath: fix five config knobs that never reach their sink

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -8,7 +8,6 @@
 {{- $defaultOperatorApiServeAddr := "localhost:9234" -}}
 {{- $defaultBpfCtTcpMax := 524288 -}}
 {{- $defaultBpfCtAnyMax := 262144 -}}
-{{- $enableIdentityMark := "true" -}}
 {{- $fragmentTracking := "true" -}}
 {{- $defaultKubeProxyReplacement := "false" -}}
 {{- $azureUsePrimaryAddress := "true" -}}
@@ -706,17 +705,16 @@ data:
   #  - portmap (Enables HostPort support for Cilium)
   cni-chaining-mode: {{ $cniChainingMode }}
 
-{{- if hasKey .Values "enableIdentityMark" }}
-  enable-identity-mark: {{ .Values.enableIdentityMark | quote }}
-{{- else if (ne $enableIdentityMark "true") }}
-  enable-identity-mark: "false"
-{{- end }}
 {{- if ne $cniChainingMode "portmap" }}
   # Disable the PodCIDR route to the cilium_host interface as it is not
   # required. While chaining, it is the responsibility of the underlying plugin
   # to enable routing.
   enable-local-node-route: "false"
 {{- end }}
+{{- end }}
+
+{{- if hasKey .Values "enableIdentityMark" }}
+  enable-identity-mark: {{ .Values.enableIdentityMark | quote }}
 {{- end }}
 
 {{- if (not (kindIs "invalid" .Values.enableIPv4Masquerade)) }}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -8,7 +8,6 @@
 {{- $defaultOperatorApiServeAddr := "localhost:9234" -}}
 {{- $defaultBpfCtTcpMax := 524288 -}}
 {{- $defaultBpfCtAnyMax := 262144 -}}
-{{- $fragmentTracking := "true" -}}
 {{- $defaultKubeProxyReplacement := "false" -}}
 {{- $azureUsePrimaryAddress := "true" -}}
 {{- $defaultK8sClientQPS := 5 -}}
@@ -828,8 +827,6 @@ data:
 
 {{- if hasKey .Values "fragmentTracking" }}
   enable-ipv4-fragment-tracking: {{ .Values.fragmentTracking | quote }}
-{{- else if (ne $fragmentTracking "true") }}
-  enable-ipv4-fragment-tracking: "false"
 {{- end }}
 
 {{- if .Values.nat46x64Gateway.enabled }}

--- a/pkg/datapath/iptables/cell.go
+++ b/pkg/datapath/iptables/cell.go
@@ -101,7 +101,6 @@ type SharedConfig struct {
 
 	EnableIPv4                  bool
 	EnableIPv6                  bool
-	EnableXTSocketFallback      bool
 	EnableBPFTProxy             bool
 	InstallNoConntrackIptRules  bool
 	EnableEndpointRoutes        bool

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -582,7 +582,7 @@ func (m *manager) Start(ctx cell.HookContext) error {
 			// We would not need the xt_socket at all if the datapath universally would
 			// set the "to proxy" skb mark bits on before the packet hits policy routing
 			// stage. Currently this is not true for endpoint routing modes.
-			if m.sharedCfg.EnableXTSocketFallback {
+			if m.cfg.EnableXTSocketFallback {
 				m.disableIPEarlyDemux()
 			}
 		}

--- a/pkg/datapath/vtep/cell.go
+++ b/pkg/datapath/vtep/cell.go
@@ -64,7 +64,7 @@ func newVTEPManager(params vtepManagerParams) error {
 	// use trigger to enforce first execution immediately when the timer job starts
 	tr := job.NewTrigger()
 	tr.Trigger()
-	params.JobGroup.Add(job.Timer("sync-vtep", mgr.syncVTEP, 1*time.Minute, job.WithTrigger(tr)))
+	params.JobGroup.Add(job.Timer("sync-vtep", mgr.syncVTEP, params.Config.VTEPSyncInterval, job.WithTrigger(tr)))
 
 	return nil
 }
@@ -85,6 +85,10 @@ func (r config) Flags(flags *pflag.FlagSet) {
 
 func (r config) validatedConfig() (*vtepManagerConfig, error) {
 	config := vtepManagerConfig{}
+
+	if r.VTEPSyncInterval <= 0 {
+		return nil, fmt.Errorf("VTEP sync interval must be positive (got %s)", r.VTEPSyncInterval)
+	}
 
 	if len(r.VTEPEndpoint) < 1 {
 		return nil, fmt.Errorf("If VTEP is enabled, at least one VTEP device must be configured")

--- a/pkg/loadbalancer/config.go
+++ b/pkg/loadbalancer/config.go
@@ -294,7 +294,7 @@ func (def UserConfig) Flags(flags *pflag.FlagSet) {
 	flags.Duration("lb-retry-backoff-min", def.RetryBackoffMin, "Minimum amount of time to wait before retrying LB operation")
 	flags.MarkHidden("lb-retry-backoff-min")
 
-	flags.Duration("lb-retry-backoff-max", def.RetryBackoffMin, "Maximum amount of time to wait before retrying LB operation")
+	flags.Duration("lb-retry-backoff-max", def.RetryBackoffMax, "Maximum amount of time to wait before retrying LB operation")
 	flags.MarkHidden("lb-retry-backoff-max")
 
 	flags.Int(LBMapEntriesName, def.LBMapEntries, "Maximum number of entries in Cilium BPF lbmap")

--- a/pkg/nodediscovery/eni/eni.go
+++ b/pkg/nodediscovery/eni/eni.go
@@ -100,7 +100,9 @@ func mutate(ctx context.Context, in nodediscovery.ENIMutateInputs, nodeResource 
 		if c.ENI.DisablePrefixDelegation != nil {
 			nodeResource.Spec.ENI.DisablePrefixDelegation = c.ENI.DisablePrefixDelegation
 		}
-		nodeResource.Spec.ENI.DeleteOnTermination = c.ENI.DeleteOnTermination
+		if c.ENI.DeleteOnTermination != nil {
+			nodeResource.Spec.ENI.DeleteOnTermination = c.ENI.DeleteOnTermination
+		}
 	}
 
 	nodeResource.Spec.InstanceID = info.InstanceID


### PR DESCRIPTION
Please review this on a per commit basis. The commits are grouped by the set of reviewers they belong to rather than by a single change, so each one stands alone with its own analysis, its own reproduction and its own `Fixes:` trailer.

This PR was prepared with AIL:3.

```release-note
Fixed five configuration options that were accepted but silently ignored: `vtep-sync-interval`, `enable-xt-socket-fallback`, `eni-delete-on-termination` with a custom CNI configuration, the `enableIdentityMark` Helm value outside CNI chaining mode, and `lb-retry-backoff-max`.
```
