### PR TITLE
endpointmanager: Do not hold manager lock when calling subscriber callbacks

### DIFF
--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -515,10 +515,13 @@ func (mgr *endpointManager) removeEndpoint(ep *endpoint.Endpoint, conf endpoint.
 	}
 
 	mgr.mutex.RLock()
-	for s := range mgr.subscribers {
+	// Invoke subscribers without holding the endpoint-manager lock. Deletion
+	// callbacks may use EndpointOwnsIP, which performs an endpoint lookup.
+	subscribers := maps.Clone(mgr.subscribers)
+	mgr.mutex.RUnlock()
+	for s := range subscribers {
 		s.EndpointDeleted(ep, conf)
 	}
-	mgr.mutex.RUnlock()
 
 	return result
 }

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -806,10 +806,11 @@ func (mgr *endpointManager) AddEndpoint(ep *endpoint.Endpoint) (err error) {
 	}
 
 	mgr.mutex.RLock()
-	for s := range mgr.subscribers {
+	subscribers := maps.Clone(mgr.subscribers)
+	mgr.mutex.RUnlock()
+	for s := range subscribers {
 		s.EndpointCreated(ep)
 	}
-	mgr.mutex.RUnlock()
 
 	return nil
 }

--- a/pkg/endpointmanager/subscribe.go
+++ b/pkg/endpointmanager/subscribe.go
@@ -22,8 +22,6 @@ type Subscriber interface {
 	// EndpointRestored is called at the end of endpoint restoration.
 	// Implementations must not attempt write operations on the
 	// EndpointManager from this callback.
-	// This function is being called inside a RLock, so it must not attempt
-	// to acquire a lock on the EndpointManager.
 	EndpointRestored(ep *endpoint.Endpoint)
 }
 

--- a/pkg/endpointmanager/subscribe.go
+++ b/pkg/endpointmanager/subscribe.go
@@ -10,8 +10,6 @@ type Subscriber interface {
 	// EndpointCreated is called at the end of endpoint creation.
 	// Implementations must not attempt write operations on the
 	// EndpointManager from this callback.
-	// This function is being called inside a RLock, so it must not attempt
-	// to acquire a lock on the EndpointManager.
 	EndpointCreated(ep *endpoint.Endpoint)
 
 	// EndpointDeleted is called at the end of endpoint deletion.

--- a/pkg/endpointmanager/subscribe.go
+++ b/pkg/endpointmanager/subscribe.go
@@ -17,8 +17,6 @@ type Subscriber interface {
 	// EndpointDeleted is called at the end of endpoint deletion.
 	// Implementations must not attempt write operations on the
 	// EndpointManager from this callback.
-	// This function is being called inside a RLock, so it must not attempt
-	// to acquire a lock on the EndpointManager.
 	EndpointDeleted(ep *endpoint.Endpoint, conf endpoint.DeleteConfig)
 
 	// EndpointRestored is called at the end of endpoint restoration.


### PR DESCRIPTION
Clone the endpoint manager subscribers map to avoid calling `EndpointCreated` or `EndpointDeleted` callbacks while holding the manager lock. For `EndpointDeleted` doing that also allows to safely call `DeleteConfig.EndpointOwnsIP` (that in turn calls `LookupIP`) from the callback itself.