### PR TITLE
bpf: dsr: don't look for TCP header on fragmented packets

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -535,7 +535,8 @@ static __always_inline int
 nodeport_extract_dsr_v6(struct __ctx_buff *ctx,
 			struct ipv6hdr *ip6 __maybe_unused,
 			const struct ipv6_ct_tuple *tuple, int l4_off,
-			union v6addr *addr, __be16 *port, bool *dsr)
+			fraginfo_t fraginfo, union v6addr *addr, __be16 *port,
+			bool *dsr)
 {
 #if defined(IS_BPF_OVERLAY)
 	{
@@ -574,8 +575,10 @@ nodeport_extract_dsr_v6(struct __ctx_buff *ctx,
 		struct ipv6_ct_tuple tmp = *tuple;
 		union tcp_flags tcp_flags = {};
 
-		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
-			return DROP_CT_INVALID_HDR;
+		if (ipfrag_has_l4_header(fraginfo)) {
+			if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
+				return DROP_CT_INVALID_HDR;
+		}
 
 		tmp.flags = TUPLE_F_OUT;
 		__ipv6_ct_tuple_reverse(&tmp);
@@ -1620,7 +1623,7 @@ skip_service_lookup:
      (DSR_ENCAP_MODE == DSR_ENCAP_NONE))
 	if (is_svc_proto) {
 		ret = nodeport_extract_dsr_v6(ctx, ip6, &tuple, l4_off,
-					      &key.address,
+					      fraginfo, &key.address,
 					      &key.dport, dsr);
 		if (IS_ERR(ret))
 			return ret;
@@ -1893,7 +1896,8 @@ static __always_inline int
 nodeport_extract_dsr_v4(struct __ctx_buff *ctx,
 			const struct iphdr *ip4 __maybe_unused,
 			const struct ipv4_ct_tuple *tuple, int l4_off,
-			__be32 *addr, __be16 *port, bool *dsr)
+			fraginfo_t fraginfo,  __be32 *addr, __be16 *port,
+			bool *dsr)
 {
 	/* Parse DSR info from the packet, to get the addr/port of the
 	 * addressed service. We need this for RevDNATing the backend's replies.
@@ -1949,8 +1953,10 @@ nodeport_extract_dsr_v4(struct __ctx_buff *ctx,
 		struct ipv4_ct_tuple tmp = *tuple;
 		union tcp_flags tcp_flags = {};
 
-		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
-			return DROP_CT_INVALID_HDR;
+		if (ipfrag_has_l4_header(fraginfo)) {
+			if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
+				return DROP_CT_INVALID_HDR;
+		}
 
 		/* tuple direction only gets initialized on the first CT lookup */
 		tmp.flags = TUPLE_F_OUT;
@@ -2983,8 +2989,8 @@ skip_service_lookup:
 		/* Check if packet has embedded DSR info, or belongs to
 		 * an established DSR connection:
 		 */
-		ret = nodeport_extract_dsr_v4(ctx, ip4, &tuple,
-					      l4_off, &key.address,
+		ret = nodeport_extract_dsr_v4(ctx, ip4, &tuple, l4_off,
+					      fraginfo, &key.address,
 					      &key.dport, dsr);
 		if (IS_ERR(ret))
 			return ret;


### PR DESCRIPTION
Trying to parse TCP header flags from a fragmented packet will only return garbage.