### PR TITLE
policy: track how far forward a computed policy stays current

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -228,7 +228,10 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 			fmt.Errorf("failed waiting for policy computation result: %w", err))
 	} else if pcr != nil {
 		selectorPolicy = pcr.NewPolicy
-		result.policyRevision = pcr.Revision
+		// The realized revision is how far forward this policy is known to be
+		// correct, which is what waiters (e.g. the policy-revision wait in the
+		// connectivity tests) compare against.
+		result.policyRevision = pcr.CurrentAtRevision
 		err = pcr.Err
 	}
 	// Release the hold taken in waitForPolicyComputationResult. On success
@@ -289,11 +292,15 @@ func (e *Endpoint) waitForPolicyComputationResult(
 
 	for {
 		computeResult, _, watch, found := e.policyFetcher.GetIdentityPolicyByIdentity(securityIdentity)
-		if found && computeResult.Revision >= wantedRevision {
+		// CurrentAtRevision, not Revision: a policy computed at an older
+		// revision is still the right one to use if no later update selected
+		// this identity.
+		if found && computeResult.CurrentAtRevision >= wantedRevision {
 			if computeResult.NewPolicy.AddHold() {
 				e.getLogger().Debug(
 					"Retrieved identity policy from statedb",
 					logfields.PolicyRevision, computeResult.Revision,
+					logfields.PolicyRevisionCurrentAt, computeResult.CurrentAtRevision,
 				)
 				return &computeResult, nil
 			}
@@ -309,6 +316,7 @@ func (e *Endpoint) waitForPolicyComputationResult(
 				"Policy computation result has stale revision, waiting for update",
 				logfields.Identity, securityIdentity.ID,
 				logfields.PolicyRevision, computeResult.Revision,
+				logfields.PolicyRevisionCurrentAt, computeResult.CurrentAtRevision,
 				logfields.PolicyRevisionNext, wantedRevision,
 			)
 		} else {
@@ -325,12 +333,17 @@ func (e *Endpoint) waitForPolicyComputationResult(
 			continue
 		case <-timeout.C:
 			if found {
-				return nil, fmt.Errorf("%w: got rev=%d, want rev=%d",
+				return nil, fmt.Errorf("%w: identity=%d got rev=%d currentAt=%d, want rev=%d",
 					errPolicyComputationStaleRevision,
+					securityIdentity.ID,
 					computeResult.Revision,
+					computeResult.CurrentAtRevision,
 					wantedRevision)
 			}
-			return nil, errPolicyComputationNotFound
+			return nil, fmt.Errorf("%w: identity=%d, want rev=%d",
+				errPolicyComputationNotFound,
+				securityIdentity.ID,
+				wantedRevision)
 		}
 	}
 }

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -228,7 +228,10 @@ func (e *Endpoint) regeneratePolicy(stats *regenerationStatistics, datapathRegen
 			fmt.Errorf("failed waiting for policy computation result: %w", err))
 	} else if pcr != nil {
 		selectorPolicy = pcr.NewPolicy
-		result.policyRevision = pcr.Revision
+		// The realized revision is how far forward this policy is known to be
+		// correct, which is what waiters (e.g. the policy-revision wait in the
+		// connectivity tests) compare against.
+		result.policyRevision = pcr.CurrentAtRevision
 		err = pcr.Err
 	}
 	// Release the hold taken in waitForPolicyComputationResult. On success
@@ -289,11 +292,15 @@ func (e *Endpoint) waitForPolicyComputationResult(
 
 	for {
 		computeResult, _, watch, found := e.policyFetcher.GetIdentityPolicyByIdentity(securityIdentity)
-		if found && computeResult.Revision >= wantedRevision {
+		// CurrentAtRevision, not Revision: a policy computed at an older
+		// revision is still the right one to use if no later update selected
+		// this identity.
+		if found && computeResult.CurrentAtRevision >= wantedRevision {
 			if computeResult.NewPolicy.AddHold() {
 				e.getLogger().Debug(
 					"Retrieved identity policy from statedb",
 					logfields.PolicyRevision, computeResult.Revision,
+					logfields.PolicyRevisionCurrentAt, computeResult.CurrentAtRevision,
 				)
 				return &computeResult, nil
 			}
@@ -309,6 +316,7 @@ func (e *Endpoint) waitForPolicyComputationResult(
 				"Policy computation result has stale revision, waiting for update",
 				logfields.Identity, securityIdentity.ID,
 				logfields.PolicyRevision, computeResult.Revision,
+				logfields.PolicyRevisionCurrentAt, computeResult.CurrentAtRevision,
 				logfields.PolicyRevisionNext, wantedRevision,
 			)
 		} else {
@@ -327,7 +335,7 @@ func (e *Endpoint) waitForPolicyComputationResult(
 			if found {
 				return nil, fmt.Errorf("%w: got rev=%d, want rev=%d",
 					errPolicyComputationStaleRevision,
-					computeResult.Revision,
+					computeResult.CurrentAtRevision,
 					wantedRevision)
 			}
 			return nil, errPolicyComputationNotFound

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -297,8 +297,8 @@ func TestWaitSkipsSupersededPolicy(t *testing.T) {
 	fetcher := &supersedeFetcher{
 		PolicyRecomputer: f.polComputer,
 		results: []compute.Result{
-			{NewPolicy: detached, Revision: rev},
-			{NewPolicy: live, Revision: rev},
+			{NewPolicy: detached, Revision: rev, CurrentAtRevision: rev},
+			{NewPolicy: live, Revision: rev, CurrentAtRevision: rev},
 		},
 		watch: make(chan struct{}),
 	}

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -313,8 +313,8 @@ func TestWaitSkipsSupersededPolicy(t *testing.T) {
 	fetcher := &supersedeFetcher{
 		PolicyRecomputer: f.polComputer,
 		results: []compute.Result{
-			{NewPolicy: detached, Revision: rev},
-			{NewPolicy: live, Revision: rev},
+			{NewPolicy: detached, Revision: rev, CurrentAtRevision: rev},
+			{NewPolicy: live, Revision: rev, CurrentAtRevision: rev},
 		},
 		watch: make(chan struct{}),
 	}

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -1701,6 +1701,10 @@ const (
 
 	PolicyRevisionRepo = "policyRevisionRepo"
 
+	// PolicyRevisionCurrentAt is the highest repository revision a computed
+	// policy is known to be correct for.
+	PolicyRevisionCurrentAt = "policyRevisionCurrentAt"
+
 	PolicyChanged = "policyChanged"
 
 	CEPUIDOld = "old-" + CEPUID

--- a/pkg/policy/cell/policy_importer.go
+++ b/pkg/policy/cell/policy_importer.go
@@ -263,6 +263,8 @@ func (i *Importer) processUpdates(ctx context.Context, updates []*policytypes.Po
 	idsToRegen := &set.Set[identity.NumericIdentity]{}
 	startRevision := i.repo.GetRevision()
 	endRevision := startRevision
+	// Number of revisions this import produced, one per ReplaceByResource.
+	var ownRevs uint64
 	for _, upd := range updates {
 		if upd.Resource == "" {
 			i.log.Error("BUG: Policy supplied with empty resource!")
@@ -271,6 +273,7 @@ func (i *Importer) processUpdates(ctx context.Context, updates []*policytypes.Po
 
 		regen, er, oldRuleCnt := i.repo.ReplaceByResource(upd.Rules, upd.Resource)
 		endRevision = er
+		ownRevs++
 		idsToRegen.Merge(*regen)
 
 		if len(upd.Rules) == 0 {
@@ -321,7 +324,20 @@ func (i *Importer) processUpdates(ctx context.Context, updates []*policytypes.Po
 	// Unaffected endpoints can merely have their policy revision set.
 	i.log.Debug("Policy repository updates complete, triggering endpoint updates",
 		logfields.PolicyRevision, endRevision)
-	i.computer.UpdatePolicy(*idsToRegen, startRevision, endRevision)
+	// The importer must not rely on revisions advanced by code paths other than
+	// itself. If the repo advanced by more than ownRevs, another path bumped it
+	// during this import, so collapse the advance range and leave those
+	// identities to that path. Only the compute path reads fromRev.
+	//
+	// Without this, an identity's revision could be advanced past a change the
+	// importer did not make, and an endpoint could install a policy whose
+	// contents do not match the revision it claims to have realized.
+	revDiff := endRevision - startRevision
+	advanceFrom := startRevision
+	if revDiff != ownRevs {
+		advanceFrom = endRevision
+	}
+	i.computer.UpdatePolicy(*idsToRegen, advanceFrom, endRevision)
 	if i.epm != nil {
 		i.epm.UpdatePolicy(idsToRegen, startRevision, endRevision)
 	}

--- a/pkg/policy/cell/policy_importer_test.go
+++ b/pkg/policy/cell/policy_importer_test.go
@@ -5,6 +5,7 @@ package policycell
 
 import (
 	"context"
+	"fmt"
 	"net/netip"
 	"sync"
 	"testing"
@@ -22,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy"
 	policyapi "github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/policy/compute"
 	policytypes "github.com/cilium/cilium/pkg/policy/types"
 	policyutils "github.com/cilium/cilium/pkg/policy/utils"
 	testcompute "github.com/cilium/cilium/pkg/testutils/compute"
@@ -243,4 +245,78 @@ func TestAddReplaceRemoveRule(t *testing.T) {
 	require.False(t, found)
 	require.Equal(t, rev, epm.toRev)
 
+}
+
+// fakeComputer records the revision range the importer hands to UpdatePolicy.
+type fakeComputer struct {
+	compute.PolicyRecomputer
+	fromRev, toRev uint64
+}
+
+func (c *fakeComputer) UpdatePolicy(_ set.Set[identity.NumericIdentity], fromRev, toRev uint64) {
+	c.fromRev, c.toRev = fromRev, toRev
+}
+
+// fakeRepo advances the revision by bumpPerReplace on each ReplaceByResource. A
+// value above one models the repository advancing by more revisions than the
+// import produced, as a BumpRevision from another code path would.
+type fakeRepo struct {
+	policy.PolicyRepository
+	rev            uint64
+	bumpPerReplace uint64
+}
+
+func (r *fakeRepo) GetRevision() uint64 { return r.rev }
+
+func (r *fakeRepo) ReplaceByResource(policytypes.PolicyEntries, ipcachetypes.ResourceID) (*set.Set[identity.NumericIdentity], uint64, int) {
+	r.rev += r.bumpPerReplace
+	return &set.Set[identity.NumericIdentity]{}, r.rev, 0
+}
+
+// TestImporterCollapsesAdvanceOnOutsideBump checks that the importer advances
+// revisions it produced, and when another source bumped the revision during
+// the import, collapses the advance range instead of carrying identities
+// across a change it did not make.
+func TestImporterCollapsesAdvanceOnOutsideBump(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		numUpdates     int
+		bumpPerReplace uint64
+		wantCollapsed  bool
+	}{
+		{"no outside bump", 1, 1, false},
+		{"outside bump", 1, 2, true},
+		// A batched import produces more than one revision, so the check must
+		// compare against the count it produced, not a hardcoded one.
+		{"batched import, no outside bump", 2, 1, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			const startRev = 1
+			repo := &fakeRepo{rev: startRev, bumpPerReplace: tc.bumpPerReplace}
+			comp := &fakeComputer{}
+			pi := &Importer{
+				log:                hivetest.Logger(t),
+				repo:               repo,
+				computer:           comp,
+				epm:                &fakeEPM{},
+				ipc:                &fakeipcache{},
+				q:                  make(chan *policytypes.PolicyUpdate, 10),
+				prefixesByResource: map[ipcachetypes.ResourceID][]netip.Prefix{},
+			}
+
+			updates := make([]*policytypes.PolicyUpdate, tc.numUpdates)
+			for i := range updates {
+				updates[i] = &policytypes.PolicyUpdate{Resource: ipcachetypes.ResourceID(fmt.Sprintf("res-%d", i))}
+			}
+			pi.processUpdates(context.Background(), updates)
+
+			endRev := uint64(startRev) + tc.bumpPerReplace*uint64(tc.numUpdates)
+			require.Equal(t, endRev, comp.toRev)
+			if tc.wantCollapsed {
+				require.Equal(t, comp.toRev, comp.fromRev, "advance range should collapse to a no-op")
+			} else {
+				require.Equal(t, uint64(startRev), comp.fromRev, "advance range should start at the pre-import revision")
+			}
+		})
+	}
 }

--- a/pkg/policy/compute/cell.go
+++ b/pkg/policy/compute/cell.go
@@ -66,9 +66,10 @@ type IdentityPolicyComputer struct {
 	repo      policy.PolicyRepository
 	idmanager identitymanager.IDManager
 
-	reqsMu  lock.Mutex
-	reqs    []computeRequest
-	trigger chan struct{}
+	reqsMu   lock.Mutex
+	reqs     []computeRequest
+	advances []advanceRequest
+	trigger  chan struct{}
 }
 
 type Params struct {

--- a/pkg/policy/compute/compute.go
+++ b/pkg/policy/compute/compute.go
@@ -31,8 +31,17 @@ type PolicyRecomputer interface {
 type Result struct {
 	Identity             identity.NumericIdentity
 	NewPolicy, OldPolicy policy.SelectorPolicy
-	Revision             uint64
-	Err                  error
+	// Revision is the repository revision this policy was computed at. It is
+	// how processRequests tells whether a requested computation has already
+	// run, so it must only ever be set by an actual computation. Use
+	// CurrentAtRevision to ask how far forward the policy is still valid.
+	Revision uint64
+	// CurrentAtRevision is the highest repository revision this policy is
+	// known to be correct for. It starts equal to Revision and is advanced,
+	// without recomputing, by policy updates that do not select this identity.
+	// Always >= Revision.
+	CurrentAtRevision uint64
+	Err               error
 }
 
 type computeRequest struct {
@@ -41,7 +50,14 @@ type computeRequest struct {
 	done     chan struct{}
 }
 
-func (r *IdentityPolicyComputer) UpdatePolicy(idsToRegen set.Set[identity.NumericIdentity], _, toRev uint64) {
+// advanceRequest carries a policy update's revision range for the identities it
+// did not select. See applyAdvances.
+type advanceRequest struct {
+	unaffectedBy   set.Set[identity.NumericIdentity]
+	fromRev, toRev uint64
+}
+
+func (r *IdentityPolicyComputer) UpdatePolicy(idsToRegen set.Set[identity.NumericIdentity], fromRev, toRev uint64) {
 	// The lock order is IdentityManager.mutex before reqsMu, since the
 	// IdentityManager observer takes reqsMu. Resolve identities, which takes
 	// IdentityManager.mutex, before locking reqsMu.
@@ -58,8 +74,58 @@ func (r *IdentityPolicyComputer) UpdatePolicy(idsToRegen set.Set[identity.Numeri
 	for _, idd := range ids {
 		r.enqueueLocked(idd, toRev)
 	}
+	// Identities this update did not select keep their committed policy, but
+	// still need their revision advanced. The computation loop owns the table,
+	// so hand the work to it rather than writing here.
+	r.advances = append(r.advances, advanceRequest{
+		unaffectedBy: idsToRegen,
+		fromRev:      fromRev,
+		toRev:        toRev,
+	})
 	r.reqsMu.Unlock()
 	r.notifyTrigger()
+}
+
+// applyAdvances raises CurrentAtRevision for every committed policy that an
+// update did not select.
+//
+// An identity absent from an update's idsToRegen is not selected by any of the
+// rules that changed, so its already-committed policy is still correct at toRev
+// and needs no recomputation. Recording that fact mirrors what the importer
+// does for endpoints that are already exposed, which have their revision bumped
+// without a regeneration. Without it, an endpoint exposed after the importer
+// snapshotted the endpoint list has no way to learn that its policy is already
+// current, and adopts the pre-import revision as its realized one.
+//
+// A policy is only carried forward if it was already current at the revision
+// this update started from. That keeps the claim inductive: an identity whose
+// policy is still awaiting (or has failed) a computation for an earlier
+// revision is never marked current for a later one.
+//
+// Must be called from processRequests with wtxn open, so that these writes
+// cannot invalidate a CompareAndSwap performed by a concurrent recomputation.
+func (r *IdentityPolicyComputer) applyAdvances(wtxn statedb.WriteTxn, advances []advanceRequest) {
+	for _, adv := range advances {
+		var advanced []Result
+		for obj := range r.tbl.All(wtxn) {
+			if obj.CurrentAtRevision < adv.fromRev || obj.CurrentAtRevision >= adv.toRev {
+				continue
+			}
+			if adv.unaffectedBy.Has(obj.Identity) {
+				continue
+			}
+			obj.CurrentAtRevision = adv.toRev
+			advanced = append(advanced, obj)
+		}
+		for _, obj := range advanced {
+			if _, _, err := r.tbl.Insert(wtxn, obj); err != nil {
+				r.logger.Error("Failed to advance policy computation revision",
+					logfields.Identity, obj.Identity,
+					logfields.PolicyRevisionCurrentAt, adv.toRev,
+					logfields.Error, err)
+			}
+		}
+	}
 }
 
 // enqueueLocked appends or coalesces a request and returns the done channel.
@@ -161,8 +227,10 @@ func (r *IdentityPolicyComputer) processRequests(ctx context.Context) error {
 		r.reqsMu.Lock()
 		batch := r.reqs
 		r.reqs = nil
+		advances := r.advances
+		r.advances = nil
 		r.reqsMu.Unlock()
-		if len(batch) == 0 {
+		if len(batch) == 0 && len(advances) == 0 {
 			continue
 		}
 
@@ -173,6 +241,8 @@ func (r *IdentityPolicyComputer) processRequests(ctx context.Context) error {
 		var work []pending
 		for _, req := range batch {
 			obj, rev, found := r.tbl.Get(rtxn, PolicyComputationByIdentity(req.identity.ID))
+			// Revision, not CurrentAtRevision: only a computation that actually
+			// ran can satisfy a request. See applyAdvances.
 			if found && obj.Revision >= req.toRev {
 				close(req.done)
 				continue
@@ -182,6 +252,11 @@ func (r *IdentityPolicyComputer) processRequests(ctx context.Context) error {
 			work = append(work, pending{computeRequest: req, rev: rev, oldPolicy: obj.NewPolicy})
 		}
 		if len(work) == 0 {
+			if len(advances) > 0 {
+				wtxn := r.db.WriteTxn(r.tbl)
+				r.applyAdvances(wtxn, advances)
+				wtxn.Commit()
+			}
 			continue
 		}
 
@@ -198,6 +273,9 @@ func (r *IdentityPolicyComputer) processRequests(ctx context.Context) error {
 				results[i].res.Identity = w.identity.ID
 				results[i].res.OldPolicy = w.oldPolicy
 				results[i].res.NewPolicy, results[i].res.Revision, results[i].res.Err = r.repo.ComputeSelectorPolicy(w.identity)
+				// A freshly computed policy is current as of the revision it
+				// was computed at.
+				results[i].res.CurrentAtRevision = results[i].res.Revision
 				outcome := metrics.LabelValueOutcomeSuccess
 				if results[i].res.Err != nil {
 					outcome = metrics.LabelValueOutcomeFailure
@@ -247,6 +325,9 @@ func (r *IdentityPolicyComputer) processRequests(ctx context.Context) error {
 				results[i].res = Result{}
 			}
 		}
+		// After the CompareAndSwaps above, so that advancing a revision cannot
+		// invalidate a recomputation's expected statedb revision.
+		r.applyAdvances(wtxn, advances)
 		wtxn.Commit()
 
 		if len(retry) > 0 {

--- a/pkg/policy/compute/compute.go
+++ b/pkg/policy/compute/compute.go
@@ -31,8 +31,17 @@ type PolicyRecomputer interface {
 type Result struct {
 	Identity             identity.NumericIdentity
 	NewPolicy, OldPolicy policy.SelectorPolicy
-	Revision             uint64
-	Err                  error
+	// Revision is the repository revision this policy was computed at. It is
+	// how processRequests tells whether a requested computation has already
+	// run, so it must only ever be set by an actual computation. Use
+	// CurrentAtRevision to ask how far forward the policy is still valid.
+	Revision uint64
+	// CurrentAtRevision is the highest repository revision this policy is
+	// known to be correct for. It starts equal to Revision and is advanced,
+	// without recomputing, by policy updates that do not select this identity.
+	// Always >= Revision.
+	CurrentAtRevision uint64
+	Err               error
 }
 
 type computeRequest struct {
@@ -41,7 +50,14 @@ type computeRequest struct {
 	done     chan struct{}
 }
 
-func (r *IdentityPolicyComputer) UpdatePolicy(idsToRegen set.Set[identity.NumericIdentity], _, toRev uint64) {
+// advanceRequest carries a policy update's revision range. idsToRegen holds the
+// identities it selected, which an advance must skip. See applyAdvances.
+type advanceRequest struct {
+	idsToRegen     set.Set[identity.NumericIdentity]
+	fromRev, toRev uint64
+}
+
+func (r *IdentityPolicyComputer) UpdatePolicy(idsToRegen set.Set[identity.NumericIdentity], fromRev, toRev uint64) {
 	// The lock order is IdentityManager.mutex before reqsMu, since the
 	// IdentityManager observer takes reqsMu. Resolve identities, which takes
 	// IdentityManager.mutex, before locking reqsMu.
@@ -58,8 +74,68 @@ func (r *IdentityPolicyComputer) UpdatePolicy(idsToRegen set.Set[identity.Numeri
 	for _, idd := range ids {
 		r.enqueueLocked(idd, toRev)
 	}
+	// Identities this update did not select keep their committed policy, but
+	// still need their revision advanced. The computation loop owns the table,
+	// so hand the work to it rather than writing here.
+	r.advances = append(r.advances, advanceRequest{
+		idsToRegen: idsToRegen,
+		fromRev:    fromRev,
+		toRev:      toRev,
+	})
 	r.reqsMu.Unlock()
 	r.notifyTrigger()
+}
+
+// applyAdvances raises CurrentAtRevision for every committed policy that an
+// update did not select.
+//
+// An identity absent from an update's idsToRegen is not selected by any of the
+// rules that changed, so its already-committed policy is still correct at toRev
+// and needs no recomputation. Recording that fact mirrors what the importer
+// does for endpoints that are already exposed, which have their revision bumped
+// without a regeneration. Without it, an endpoint exposed after the importer
+// snapshotted the endpoint list has no way to learn that its policy is already
+// current, and adopts the pre-import revision as its realized one.
+//
+// A policy is only carried forward if it was already current at the revision
+// this update started from. That keeps the claim inductive: an identity whose
+// policy is still awaiting (or has failed) a computation for an earlier
+// revision is never marked current for a later one.
+//
+// Must be called from processRequests with wtxn open, so that these writes
+// cannot invalidate a CompareAndSwap performed by a concurrent recomputation.
+func (r *IdentityPolicyComputer) applyAdvances(wtxn statedb.WriteTxn, advances []advanceRequest) {
+	if len(advances) == 0 {
+		return
+	}
+	for obj := range r.tbl.All(wtxn) {
+		target := revisionAfterAdvances(advances, obj.Identity, obj.CurrentAtRevision)
+		if target == obj.CurrentAtRevision {
+			continue
+		}
+		obj.CurrentAtRevision = target
+		if _, _, err := r.tbl.Insert(wtxn, obj); err != nil {
+			r.logger.Error("Failed to advance policy computation revision",
+				logfields.Identity, obj.Identity,
+				logfields.PolicyRevisionCurrentAt, target,
+				logfields.Error, err)
+		}
+	}
+}
+
+// revisionAfterAdvances returns the revision the identity's policy is current at
+// once the given updates have been applied in order.
+func revisionAfterAdvances(advances []advanceRequest, id identity.NumericIdentity, current uint64) uint64 {
+	for _, adv := range advances {
+		if current < adv.fromRev || current >= adv.toRev {
+			continue
+		}
+		if adv.idsToRegen.Has(id) {
+			continue
+		}
+		current = adv.toRev
+	}
+	return current
 }
 
 // enqueueLocked appends or coalesces a request and returns the done channel.
@@ -161,8 +237,10 @@ func (r *IdentityPolicyComputer) processRequests(ctx context.Context) error {
 		r.reqsMu.Lock()
 		batch := r.reqs
 		r.reqs = nil
+		advances := r.advances
+		r.advances = nil
 		r.reqsMu.Unlock()
-		if len(batch) == 0 {
+		if len(batch) == 0 && len(advances) == 0 {
 			continue
 		}
 
@@ -173,6 +251,8 @@ func (r *IdentityPolicyComputer) processRequests(ctx context.Context) error {
 		var work []pending
 		for _, req := range batch {
 			obj, rev, found := r.tbl.Get(rtxn, PolicyComputationByIdentity(req.identity.ID))
+			// Revision, not CurrentAtRevision: only a computation that actually
+			// ran can satisfy a request. See applyAdvances.
 			if found && obj.Revision >= req.toRev {
 				close(req.done)
 				continue
@@ -182,6 +262,11 @@ func (r *IdentityPolicyComputer) processRequests(ctx context.Context) error {
 			work = append(work, pending{computeRequest: req, rev: rev, oldPolicy: obj.NewPolicy})
 		}
 		if len(work) == 0 {
+			if len(advances) > 0 {
+				wtxn := r.db.WriteTxn(r.tbl)
+				r.applyAdvances(wtxn, advances)
+				wtxn.Commit()
+			}
 			continue
 		}
 
@@ -198,6 +283,9 @@ func (r *IdentityPolicyComputer) processRequests(ctx context.Context) error {
 				results[i].res.Identity = w.identity.ID
 				results[i].res.OldPolicy = w.oldPolicy
 				results[i].res.NewPolicy, results[i].res.Revision, results[i].res.Err = r.repo.ComputeSelectorPolicy(w.identity)
+				// A freshly computed policy is current as of the revision it
+				// was computed at.
+				results[i].res.CurrentAtRevision = results[i].res.Revision
 				outcome := metrics.LabelValueOutcomeSuccess
 				if results[i].res.Err != nil {
 					outcome = metrics.LabelValueOutcomeFailure
@@ -247,6 +335,9 @@ func (r *IdentityPolicyComputer) processRequests(ctx context.Context) error {
 				results[i].res = Result{}
 			}
 		}
+		// After the CompareAndSwaps above, so that advancing a revision cannot
+		// invalidate a recomputation's expected statedb revision.
+		r.applyAdvances(wtxn, advances)
 		wtxn.Commit()
 
 		if len(retry) > 0 {

--- a/pkg/policy/compute/compute_test.go
+++ b/pkg/policy/compute/compute_test.go
@@ -216,6 +216,126 @@ func TestBulkRecompute(t *testing.T) {
 	require.NotNil(t, ws)
 }
 
+// An identity that a policy update does not select keeps its committed policy,
+// but must still have its revision advanced to the update's revision. Otherwise
+// an endpoint exposed after the importer snapshotted the endpoint list has no
+// way to tell that its policy is already current, and realizes a pre-import
+// revision until the next unrelated update or periodic regeneration.
+func TestUpdatePolicyAdvancesUnaffectedIdentities(t *testing.T) {
+	testutils.GoleakVerifyNone(t, testutils.GoleakIgnoreCurrent())
+
+	_, _, computer, idmgr := fixture(t)
+
+	affected := computeFor(t, computer, idmgr, identity.NumericIdentity(51))
+	unaffected := computeFor(t, computer, idmgr, identity.NumericIdentity(52))
+
+	// The importer passes the repository revision the update started from,
+	// which is the revision the committed policies are current at.
+	before, _, _, found := computer.GetIdentityPolicyByIdentity(unaffected)
+	require.True(t, found)
+	fromRev := before.CurrentAtRevision
+	toRev := fromRev + 1
+
+	computer.UpdatePolicy(set.NewSet(affected.ID), fromRev, toRev)
+
+	// The unaffected identity is not recomputed, so only the advance can mark
+	// it current at toRev.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		obj, _, _, found := computer.GetIdentityPolicyByIdentity(unaffected)
+		assert.True(c, found)
+		assert.GreaterOrEqual(c, obj.CurrentAtRevision, toRev)
+	}, time.Second, time.Millisecond, "unaffected identity never became current at revision %d", toRev)
+
+	// It must be marked current without being recomputed: the committed policy
+	// is still the very same object.
+	obj, _, _, found := computer.GetIdentityPolicyByIdentity(unaffected)
+	require.True(t, found)
+	require.NotNil(t, obj.NewPolicy)
+	require.Same(t, before.NewPolicy, obj.NewPolicy,
+		"unaffected identity was recomputed, not just advanced")
+	// An advance must leave the revision it was computed at alone.
+	require.Equal(t, before.Revision, obj.Revision)
+}
+
+// Carrying a policy forward must never satisfy a request to recompute it.
+//
+// Revision (computed-at) is what processRequests uses to decide whether a
+// requested computation has already run. CurrentAtRevision is only a statement
+// about the committed policy still being valid, so deciding on it instead would
+// close a request that no computation ever served, leaving the policy stale with
+// nothing left to re-trigger it.
+func TestAdvanceDoesNotSatisfyRecompute(t *testing.T) {
+	testutils.GoleakVerifyNone(t, testutils.GoleakIgnoreCurrent())
+
+	_, _, computer, idmgr := fixture(t)
+
+	carried := computeFor(t, computer, idmgr, identity.NumericIdentity(71))
+	other := computeFor(t, computer, idmgr, identity.NumericIdentity(72))
+
+	before, _, _, found := computer.GetIdentityPolicyByIdentity(carried)
+	require.True(t, found)
+	base := before.CurrentAtRevision
+
+	// Carry `carried` forward without recomputing it.
+	toRev := base + 1
+	computer.UpdatePolicy(set.NewSet(other.ID), base, toRev)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		obj, _, _, found := computer.GetIdentityPolicyByIdentity(carried)
+		assert.True(c, found)
+		assert.Equal(c, toRev, obj.CurrentAtRevision)
+	}, time.Second, time.Millisecond)
+
+	// Now ask for a recomputation at the revision it was carried forward to. A
+	// computation must actually run, even though CurrentAtRevision already
+	// reports that revision.
+	done, err := computer.RecomputeIdentityPolicy(carried, toRev)
+	require.NoError(t, err)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("recomputation request never completed")
+	}
+
+	// OldPolicy is only set when a computation ran and replaced a committed
+	// policy, so it is the oracle for "this was recomputed, not carried".
+	obj, _, _, found := computer.GetIdentityPolicyByIdentity(carried)
+	require.True(t, found)
+	require.NotNil(t, obj.OldPolicy,
+		"requested recomputation was skipped because the policy had been carried forward")
+	require.GreaterOrEqual(t, obj.Revision, before.Revision)
+}
+
+// A late-delivered update for an older revision range must not drag an
+// identity's revision backwards.
+func TestUpdatePolicyAdvanceDoesNotRegress(t *testing.T) {
+	testutils.GoleakVerifyNone(t, testutils.GoleakIgnoreCurrent())
+
+	_, _, computer, idmgr := fixture(t)
+
+	other := computeFor(t, computer, idmgr, identity.NumericIdentity(61))
+	ahead := computeFor(t, computer, idmgr, identity.NumericIdentity(62))
+
+	before, _, _, found := computer.GetIdentityPolicyByIdentity(ahead)
+	require.True(t, found)
+	base := before.CurrentAtRevision
+
+	// Carry `ahead` forward twice, then replay the first update.
+	computer.UpdatePolicy(set.NewSet(other.ID), base, base+1)
+	computer.UpdatePolicy(set.NewSet(other.ID), base+1, base+2)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		obj, _, _, found := computer.GetIdentityPolicyByIdentity(ahead)
+		assert.True(c, found)
+		assert.Equal(c, base+2, obj.CurrentAtRevision)
+	}, time.Second, time.Millisecond)
+
+	computer.UpdatePolicy(set.NewSet(other.ID), base, base+1)
+
+	require.Never(t, func() bool {
+		obj, _, _, found := computer.GetIdentityPolicyByIdentity(ahead)
+		return found && obj.CurrentAtRevision < base+2
+	}, 100*time.Millisecond, 10*time.Millisecond, "revision regressed below %d", base+2)
+}
+
 func fixture(t *testing.T) (*statedb.DB, statedb.RWTable[Result], PolicyRecomputer, identitymanager.IDManager) {
 	t.Helper()
 

--- a/pkg/policy/compute/compute_test.go
+++ b/pkg/policy/compute/compute_test.go
@@ -215,6 +215,124 @@ func TestBulkRecompute(t *testing.T) {
 	require.NotNil(t, ws)
 }
 
+// An identity that a policy update does not select keeps its committed policy,
+// but must still have its revision advanced to the update's revision. Otherwise
+// an endpoint exposed after the importer snapshotted the endpoint list has no
+// way to tell that its policy is already current, and realizes a pre-import
+// revision until the next unrelated update or periodic regeneration.
+func TestUpdatePolicyAdvancesUnaffectedIdentities(t *testing.T) {
+	testutils.GoleakVerifyNone(t, testutils.GoleakIgnoreCurrent())
+
+	_, _, computer, idmgr := fixture(t)
+
+	affected := computeFor(t, computer, idmgr, identity.NumericIdentity(51))
+	unaffected := computeFor(t, computer, idmgr, identity.NumericIdentity(52))
+
+	// The importer passes the repository revision the update started from,
+	// which is the revision the committed policies are current at.
+	before, _, _, found := computer.GetIdentityPolicyByIdentity(unaffected)
+	require.True(t, found)
+	fromRev := before.CurrentAtRevision
+	toRev := fromRev + 1
+
+	computer.UpdatePolicy(set.NewSet(affected.ID), fromRev, toRev)
+
+	// The unaffected identity is not recomputed, so only the advance can mark
+	// it current at toRev.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		obj, _, _, found := computer.GetIdentityPolicyByIdentity(unaffected)
+		assert.True(c, found)
+		assert.GreaterOrEqual(c, obj.CurrentAtRevision, toRev)
+	}, time.Second, time.Millisecond, "unaffected identity never became current at revision %d", toRev)
+
+	// It must be marked current without being recomputed: the revision it was
+	// computed at is unchanged, and its committed policy is the original one.
+	obj, _, _, found := computer.GetIdentityPolicyByIdentity(unaffected)
+	require.True(t, found)
+	require.Equal(t, before.Revision, obj.Revision, "unaffected identity was recomputed, not just advanced")
+	require.NotNil(t, obj.NewPolicy)
+	require.Nil(t, obj.OldPolicy, "unaffected identity was recomputed, not just advanced")
+}
+
+// Carrying a policy forward must never satisfy a request to recompute it.
+//
+// Revision (computed-at) is what processRequests uses to decide whether a
+// requested computation has already run. CurrentAtRevision is only a statement
+// about the committed policy still being valid, so deciding on it instead would
+// close a request that no computation ever served, leaving the policy stale with
+// nothing left to re-trigger it.
+func TestAdvanceDoesNotSatisfyRecompute(t *testing.T) {
+	testutils.GoleakVerifyNone(t, testutils.GoleakIgnoreCurrent())
+
+	_, _, computer, idmgr := fixture(t)
+
+	carried := computeFor(t, computer, idmgr, identity.NumericIdentity(71))
+	other := computeFor(t, computer, idmgr, identity.NumericIdentity(72))
+
+	before, _, _, found := computer.GetIdentityPolicyByIdentity(carried)
+	require.True(t, found)
+	base := before.CurrentAtRevision
+
+	// Carry `carried` forward without recomputing it.
+	toRev := base + 1
+	computer.UpdatePolicy(set.NewSet(other.ID), base, toRev)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		obj, _, _, found := computer.GetIdentityPolicyByIdentity(carried)
+		assert.True(c, found)
+		assert.Equal(c, toRev, obj.CurrentAtRevision)
+	}, time.Second, time.Millisecond)
+
+	// Now ask for a recomputation at the revision it was carried forward to. A
+	// computation must actually run, even though CurrentAtRevision already
+	// reports that revision.
+	done, err := computer.RecomputeIdentityPolicy(carried, toRev)
+	require.NoError(t, err)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("recomputation request never completed")
+	}
+
+	// OldPolicy is only set when a computation ran and replaced a committed
+	// policy, so it is the oracle for "this was recomputed, not carried".
+	obj, _, _, found := computer.GetIdentityPolicyByIdentity(carried)
+	require.True(t, found)
+	require.NotNil(t, obj.OldPolicy,
+		"requested recomputation was skipped because the policy had been carried forward")
+	require.GreaterOrEqual(t, obj.Revision, before.Revision)
+}
+
+// A late-delivered update for an older revision range must not drag an
+// identity's revision backwards.
+func TestUpdatePolicyAdvanceDoesNotRegress(t *testing.T) {
+	testutils.GoleakVerifyNone(t, testutils.GoleakIgnoreCurrent())
+
+	_, _, computer, idmgr := fixture(t)
+
+	other := computeFor(t, computer, idmgr, identity.NumericIdentity(61))
+	ahead := computeFor(t, computer, idmgr, identity.NumericIdentity(62))
+
+	before, _, _, found := computer.GetIdentityPolicyByIdentity(ahead)
+	require.True(t, found)
+	base := before.CurrentAtRevision
+
+	// Carry `ahead` forward twice, then replay the first update.
+	computer.UpdatePolicy(set.NewSet(other.ID), base, base+1)
+	computer.UpdatePolicy(set.NewSet(other.ID), base+1, base+2)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		obj, _, _, found := computer.GetIdentityPolicyByIdentity(ahead)
+		assert.True(c, found)
+		assert.Equal(c, base+2, obj.CurrentAtRevision)
+	}, time.Second, time.Millisecond)
+
+	computer.UpdatePolicy(set.NewSet(other.ID), base, base+1)
+
+	require.Never(t, func() bool {
+		obj, _, _, found := computer.GetIdentityPolicyByIdentity(ahead)
+		return found && obj.CurrentAtRevision < base+2
+	}, 100*time.Millisecond, 10*time.Millisecond, "revision regressed below %d", base+2)
+}
+
 func fixture(t *testing.T) (*statedb.DB, statedb.RWTable[Result], PolicyRecomputer, identitymanager.IDManager) {
 	t.Helper()
 

--- a/pkg/policy/compute/table.go
+++ b/pkg/policy/compute/table.go
@@ -36,7 +36,7 @@ var (
 )
 
 func (Result) TableHeader() []string {
-	return []string{"Identity", "NewPolicy", "OldPolicy", "Revision", "Err"}
+	return []string{"Identity", "NewPolicy", "OldPolicy", "Revision", "CurrentAtRevision", "Err"}
 }
 
 func (r Result) TableRow() []string {
@@ -57,6 +57,7 @@ func (r Result) TableRow() []string {
 		strconv.FormatUint(newRev, 10),
 		strconv.FormatUint(oldRev, 10),
 		strconv.FormatUint(r.Revision, 10),
+		strconv.FormatUint(r.CurrentAtRevision, 10),
 		serr,
 	}
 }

--- a/pkg/policy/test/testdata/test.txtar
+++ b/pkg/policy/test/testdata/test.txtar
@@ -46,6 +46,20 @@ stdout health.+1
 stdout ${id1}.+3
 stdout ${id2}.+3
 
+# An endpoint created now reuses ${id1}, which another live endpoint already
+# holds, so the identity manager notifies no observer and nothing schedules a
+# computation for it. It must still realize revision 4.
+endpoint/create ${id1} ${id1_labels}
+endpoint/wait-for-policy-revision 4
+
+# It got there without being recomputed: Revision is unchanged above, while
+# CurrentAtRevision carried it to the new repo revision.
+db/show --columns Identity,CurrentAtRevision policy-computations
+stdout host.+4
+stdout health.+4
+stdout ${id1}.+4
+stdout ${id2}.+4
+
 -- policy.yaml --
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy

--- a/pkg/policy/test/testdata/test.txtar
+++ b/pkg/policy/test/testdata/test.txtar
@@ -46,6 +46,15 @@ stdout health.+1
 stdout ${id1}.+3
 stdout ${id2}.+3
 
+# Those policies were not recomputed, but they are known to be correct at the
+# new repo revision 4. An endpoint created from here on must be able to realize
+# revision 4 without waiting for a recomputation that will never come.
+db/show --columns Identity,CurrentAtRevision policy-computations
+stdout host.+4
+stdout health.+4
+stdout ${id1}.+4
+stdout ${id2}.+4
+
 -- policy.yaml --
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy


### PR DESCRIPTION
An endpoint added just after a policy import can report a policy revision
older than the repository's, and keep reporting it for up to two minutes
(the periodic regeneration interval). The connectivity tests wait on that
revision, so they fail during setup with "N endpoints have not yet
realized policy revision R".

On import, the endpoints whose identity the new rules select are
regenerated, and the rest have their revision bumped without a
regeneration, since their policy has not changed. Both work from a single
snapshot of the endpoint list. An endpoint added after that snapshot is in
neither group: its first regeneration reuses the policy already computed
for its identity and takes that policy's revision as its own, which leaves
it behind until the next import or periodic regeneration.

That policy is correct, since the import did not select the endpoint's
identity; only the revision is wrong. A committed policy records the
revision it was computed at, which does not say how far forward it stays
valid, that is, up to which later revision recomputing it would give the
same policy. Record that separately as CurrentAtRevision, advanced for the
identities an update does not select, without recomputing them. A
regenerating endpoint then waits on that value, and reports it as the
revision it has realized.

Reusing Revision for this would not work, because the computation loop
decides on it whether a request has already been served. Advancing it
without computing anything would make the loop skip work it was asked to
do, and nothing retries it. The endpoint would then keep a policy that
really is out of date.

ef5d47de14 fixed the same symptom for an endpoint that is in the list but
still at revision zero. That path runs in Endpoint.UpdatePolicy, which
never sees an endpoint added after the list was taken, so this case
remained.

```release-note
Fix a pod created immediately after a network policy change reporting a stale policy revision for up to two minutes.
```

This PR was prepared with AIL:3.
