### PR TITLE
pkg/mtu: Add fallback to MTU of 1500 and identify the primary ENI by device index

### DIFF
--- a/pkg/mtu/manager.go
+++ b/pkg/mtu/manager.go
@@ -56,10 +56,20 @@ func (m *MTUManager) Updater(ctx context.Context, health cell.Health) error {
 			baseMTU = min(baseMTU, dev.MTU)
 			deviceNames = append(deviceNames, dev.Name)
 		}
-		m.Log.Debug("Detected base MTU from devices",
-			logfields.Devices, deviceNames,
-			logfields.MTU, baseMTU,
-		)
+		if len(consideredDevices) == 0 {
+			// Without any device to detect the MTU from we would keep MaxMTU, which no
+			// real NIC can carry. Fall back to the safe Ethernet default instead, the MTU
+			// is re-evaluated whenever the devices or the local node change.
+			baseMTU = EthernetMTU
+			m.Log.Warn("No devices to detect the MTU from, falling back to the default MTU",
+				logfields.MTU, baseMTU,
+			)
+		} else {
+			m.Log.Debug("Detected base MTU from devices",
+				logfields.Devices, deviceNames,
+				logfields.MTU, baseMTU,
+			)
+		}
 
 		routeMTU := m.Config.Calculate(baseMTU)
 

--- a/pkg/mtu/manager.go
+++ b/pkg/mtu/manager.go
@@ -17,7 +17,6 @@ import (
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/node/addressing"
 
 	"github.com/cilium/hive/cell"
 )
@@ -57,10 +56,20 @@ func (m *MTUManager) Updater(ctx context.Context, health cell.Health) error {
 			baseMTU = min(baseMTU, dev.MTU)
 			deviceNames = append(deviceNames, dev.Name)
 		}
-		m.Log.Debug("Detected base MTU from devices",
-			logfields.Devices, deviceNames,
-			logfields.MTU, baseMTU,
-		)
+		if len(consideredDevices) == 0 {
+			// Without any device to detect the MTU from we would keep MaxMTU, which no
+			// real NIC can carry. Fall back to the safe Ethernet default instead, the MTU
+			// is re-evaluated whenever the devices or the local node change.
+			baseMTU = EthernetMTU
+			m.Log.Warn("No devices to detect the MTU from, falling back to the default MTU",
+				logfields.MTU, baseMTU,
+			)
+		} else {
+			m.Log.Debug("Detected base MTU from devices",
+				logfields.Devices, deviceNames,
+				logfields.MTU, baseMTU,
+			)
+		}
 
 		routeMTU := m.Config.Calculate(baseMTU)
 
@@ -117,16 +126,9 @@ func (m *MTUManager) observeLocalCiliumNode(ctx context.Context, event resource.
 		return nil
 	}
 
-	// Ignore update events if the node local IPs is not yet know, which might not happen
-	// in the first event.
-	hasInternalIP := false
-	for _, addr := range event.Object.Spec.Addresses {
-		if addr.Type == addressing.NodeInternalIP {
-			hasInternalIP = true
-			break
-		}
-	}
-	if !hasInternalIP {
+	// Ignore update events until the ENIs of the node are known, which might not be the
+	// case in the first event.
+	if len(event.Object.Status.ENI.ENIs) == 0 {
 		event.Done(nil)
 		return nil
 	}
@@ -166,22 +168,9 @@ func (m *MTUManager) consideredDevices(devs []*tables.Device) []*tables.Device {
 			break
 		}
 
-		var internalIP string
-		for _, addr := range localNode.Spec.Addresses {
-			if addr.Type == addressing.NodeInternalIP {
-				internalIP = addr.IP
-				break
-			}
-		}
-		// If we don't have the internal IP yet, we cannot exclude any devices
-		if internalIP == "" {
-			break
-		}
-
 		for _, eni := range localNode.Status.ENI.ENIs {
-			// Use the primary IP of the node to tell which ENI is the primary
-			isPrimary := eni.IP.String() == internalIP
-			if isPrimary {
+			// Skip primary ENI
+			if eni.Number == 0 {
 				continue
 			}
 

--- a/pkg/mtu/manager.go
+++ b/pkg/mtu/manager.go
@@ -17,7 +17,6 @@ import (
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/node/addressing"
 
 	"github.com/cilium/hive/cell"
 )
@@ -117,16 +116,9 @@ func (m *MTUManager) observeLocalCiliumNode(ctx context.Context, event resource.
 		return nil
 	}
 
-	// Ignore update events if the node local IPs is not yet know, which might not happen
-	// in the first event.
-	hasInternalIP := false
-	for _, addr := range event.Object.Spec.Addresses {
-		if addr.Type == addressing.NodeInternalIP {
-			hasInternalIP = true
-			break
-		}
-	}
-	if !hasInternalIP {
+	// Ignore update events until the ENIs of the node are known, which might not be the
+	// case in the first event.
+	if len(event.Object.Status.ENI.ENIs) == 0 {
 		event.Done(nil)
 		return nil
 	}
@@ -166,22 +158,9 @@ func (m *MTUManager) consideredDevices(devs []*tables.Device) []*tables.Device {
 			break
 		}
 
-		var internalIP string
-		for _, addr := range localNode.Spec.Addresses {
-			if addr.Type == addressing.NodeInternalIP {
-				internalIP = addr.IP
-				break
-			}
-		}
-		// If we don't have the internal IP yet, we cannot exclude any devices
-		if internalIP == "" {
-			break
-		}
-
 		for _, eni := range localNode.Status.ENI.ENIs {
-			// Use the primary IP of the node to tell which ENI is the primary
-			isPrimary := eni.IP.String() == internalIP
-			if isPrimary {
+			// Skip primary ENI
+			if eni.Number == 0 {
 				continue
 			}
 

--- a/pkg/mtu/manager_test.go
+++ b/pkg/mtu/manager_test.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package mtu
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	awsTypes "github.com/cilium/cilium/pkg/aws/types"
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/defaults"
+	iputil "github.com/cilium/cilium/pkg/ip"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/node/addressing"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+const (
+	primaryMAC   = "0a:00:00:00:00:01"
+	secondaryMAC = "0a:00:00:00:00:02"
+)
+
+func mustParseMAC(t *testing.T, s string) tables.HardwareAddr {
+	t.Helper()
+	mac, err := net.ParseMAC(s)
+	require.NoError(t, err)
+	return tables.HardwareAddr(mac)
+}
+
+func mustParseAddr(t *testing.T, s string) iputil.Addr {
+	t.Helper()
+	addr, err := netip.ParseAddr(s)
+	require.NoError(t, err)
+	return iputil.AddrFrom(addr)
+}
+
+func eniNode(t *testing.T) *v2.CiliumNode {
+	t.Helper()
+	return &v2.CiliumNode{
+		Spec: v2.NodeSpec{
+			Addresses: []v2.NodeAddress{
+				{Type: addressing.NodeInternalIP, IP: "fd00::1"},
+				{Type: addressing.NodeInternalIP, IP: "192.168.0.1"},
+			},
+		},
+		Status: v2.NodeStatus{
+			ENI: awsTypes.ENIStatus{
+				ENIs: map[string]awsTypes.ENI{
+					"eni-primary": {
+						ID:     "eni-primary",
+						Number: 0,
+						IP:     mustParseAddr(t, "192.168.0.1"),
+						MAC:    primaryMAC,
+					},
+					"eni-secondary": {
+						ID:     "eni-secondary",
+						Number: 1,
+						IP:     mustParseAddr(t, "192.168.0.2"),
+						MAC:    secondaryMAC,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestConsideredDevices(t *testing.T) {
+	tests := []struct {
+		name       string
+		ipam       string
+		localNode  func(*testing.T) *v2.CiliumNode
+		devices    func(*testing.T) []*tables.Device
+		wantDevice []string
+	}{
+		{
+			name:      "ENI mode excludes only secondary ENIs",
+			ipam:      ipamOption.IPAMENI,
+			localNode: eniNode,
+			devices: func(t *testing.T) []*tables.Device {
+				return []*tables.Device{
+					{Name: "eth0", MTU: 9001, HardwareAddr: mustParseMAC(t, primaryMAC)},
+					{Name: "eth1", MTU: 9001, HardwareAddr: mustParseMAC(t, secondaryMAC)},
+				}
+			},
+			wantDevice: []string{"eth0"},
+		},
+		{
+			name:      "ENI mode considers all devices while the local node is unknown",
+			ipam:      ipamOption.IPAMENI,
+			localNode: func(*testing.T) *v2.CiliumNode { return nil },
+			devices: func(t *testing.T) []*tables.Device {
+				return []*tables.Device{
+					{Name: "eth0", MTU: 9001, HardwareAddr: mustParseMAC(t, primaryMAC)},
+					{Name: "eth1", MTU: 9001, HardwareAddr: mustParseMAC(t, secondaryMAC)},
+				}
+			},
+			wantDevice: []string{"eth0", "eth1"},
+		},
+		{
+			name:      "ENI mode excludes Cilium managed and dummy devices",
+			ipam:      ipamOption.IPAMENI,
+			localNode: eniNode,
+			devices: func(t *testing.T) []*tables.Device {
+				return []*tables.Device{
+					{Name: "eth0", MTU: 9001, HardwareAddr: mustParseMAC(t, primaryMAC)},
+					{Name: defaults.VxlanDevice, MTU: 8951},
+					{Name: defaults.GeneveDevice, MTU: 8951},
+					{Name: defaults.IPIPv4Device, MTU: 8981},
+					{Name: defaults.IPIPv6Device, MTU: 8953},
+					{Name: "cilium_dummy", MTU: 65520, Type: "dummy"},
+				}
+			},
+			wantDevice: []string{"eth0"},
+		},
+		{
+			name:      "non-ENI mode keeps all non-excluded devices",
+			ipam:      ipamOption.IPAMKubernetes,
+			localNode: func(*testing.T) *v2.CiliumNode { return nil },
+			devices: func(t *testing.T) []*tables.Device {
+				return []*tables.Device{
+					{Name: "eth0", MTU: 9001, HardwareAddr: mustParseMAC(t, primaryMAC)},
+					{Name: "eth1", MTU: 1500, HardwareAddr: mustParseMAC(t, secondaryMAC)},
+					{Name: defaults.VxlanDevice, MTU: 8951},
+				}
+			},
+			wantDevice: []string{"eth0", "eth1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &MTUManager{
+				mtuParams: mtuParams{
+					Log:          hivetest.Logger(t),
+					DaemonConfig: &option.DaemonConfig{IPAM: tt.ipam},
+				},
+			}
+			if node := tt.localNode(t); node != nil {
+				m.localNode.Store(node)
+			}
+
+			considered := m.consideredDevices(tt.devices(t))
+
+			names := make([]string, 0, len(considered))
+			for _, dev := range considered {
+				names = append(names, dev.Name)
+			}
+			require.ElementsMatch(t, tt.wantDevice, names)
+		})
+	}
+}


### PR DESCRIPTION
In ENI IPAM mode the MTU auto detection excludes the secondary ENIs, which are managed by Cilium, and derives the base MTU from the primary ENI only. The primary ENI was told apart from the secondary ones by comparing ENI.IP with the first NodeInternalIP of the CiliumNode. ENI.IP is the primary private IPv4 address of the ENI, as reported by the EC2 API, so on a node whose first NodeInternalIP is an IPv6 address no ENI ever matched and every device was excluded, including the primary one. With no device left, the base MTU stayed at its MaxMTU initializer and Cilium tried to configure an MTU of 65520, which the ENA driver rejects.

Use the ENI device index instead, as the AWS IPAM code already does. It is address family agnostic and does not depend on the ordering of the node addresses.

This also adds a fallback to the default Ethernet MTU (1500 bytes) when no device is left to detect the MTU from, so that a filtering mistake cannot result in an unusable MTU again. **This part impacts all IPAM modes not just ENI IPAM.**

This PR was prepared with AIL:3.

```release-note
pkg/mtu: Added a fallback to an MTU of 1500 bytes if no network devices are selected for MTU detection. Fixed a bug where Cilium would fail to find the appropriate MTU to use when in IPAM ENI mode with IPv6 enabled. 
```
