### PR TITLE
docs: Remove "not stable" installation instructions

### DIFF
--- a/Documentation/_exts/cilium_helm_directive.py
+++ b/Documentation/_exts/cilium_helm_directive.py
@@ -83,7 +83,13 @@ class CiliumHelmInstallDirective(SphinxDirective):
         opts.extend(f'--set {opt}' for opt in set_options)
         return opts
 
-    def _format_command(self, base_cmd, opts, indent, post_helm_commands='', post_commands=''):
+    def _format_command(
+            self,
+            base_cmd,
+            opts,
+            indent,
+            post_helm_commands='',
+            post_commands=''):
         """Format a helm command with proper line continuation."""
         # Parse post_helm_commands (these get line continuation like helm args)
         post_helm_lines = []
@@ -113,7 +119,8 @@ class CiliumHelmInstallDirective(SphinxDirective):
             suffix = '' if is_last else ' \\\\'
             lines.append(f'{indent}   {opt}{suffix}')
 
-        # Add post_helm_commands - no line continuation, just aligned with other args
+        # Add post_helm_commands - no line continuation, just aligned with
+        # other args
         for line in post_helm_lines:
             lines.append(f'{indent}   {line}')
 

--- a/Documentation/_exts/cilium_helm_directive.py
+++ b/Documentation/_exts/cilium_helm_directive.py
@@ -22,27 +22,20 @@ from textwrap import dedent
 
 
 RST_TEMPLATE = """\
-.. only:: stable
+.. tabs::
 
-   .. tabs::
+   .. group-tab:: Helm Repository
 
-      .. group-tab:: Helm Repository
-
-         .. parsed-literal::
+      .. parsed-literal::
 
 {helm_repo_cmd}
 
-      .. group-tab:: OCI Registry
+   .. group-tab:: OCI Registry
 
-         .. parsed-literal::
+      .. parsed-literal::
 
 {oci_cmd}
 
-.. only:: not stable
-
-   .. parsed-literal::
-
-{not_stable_cmd}
 """
 
 
@@ -159,16 +152,11 @@ class CiliumHelmInstallDirective(SphinxDirective):
             oci_base,
             opts_list, '            ', post_helm_commands, post_commands
         )
-        not_stable_cmd = self._format_command(
-            helm_repo_base,
-            opts_list, '      ', post_helm_commands, post_commands
-        )
 
         # Generate RST from template
         rst_content = RST_TEMPLATE.format(
             helm_repo_cmd=helm_repo_cmd,
             oci_cmd=oci_cmd,
-            not_stable_cmd=not_stable_cmd,
         )
 
         # Parse and return nodes

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -114,20 +114,15 @@ else:
 branch = os.environ.get('READTHEDOCS_VERSION')
 if not branch or branch == 'latest':
     branch = 'HEAD'
-    archive_name = 'main'
-    chart_release = './cilium'
-    chart_version = "--chart-directory ./install/kubernetes/cilium"
+    chart_version = prev_release
 elif branch == 'stable':
     branch = release
-    archive_name = release
-    chart_version = '--version ' + release
-    chart_release = 'cilium/cilium ' + chart_version
+    chart_version = release
     tags.add('stable')
 else:
-    archive_name = branch
-    chart_version = '--version ' + release
-    chart_release = 'cilium/cilium ' + chart_version
+    chart_version = release
     tags.add('stable')
+chart_release = 'cilium/cilium --version ' + chart_version
 
 if relinfo.prerelease == 'dev':
     # There's no dev snapshot yet. Use the last release.
@@ -138,9 +133,6 @@ else:
 githubusercontent = 'https://raw.githubusercontent.com/cilium/cilium/'
 scm_web = githubusercontent + branch
 github_repo = 'https://github.com/cilium/cilium/'
-archive_filename = archive_name + '.tar.gz'
-archive_link = github_repo + 'archive/' + archive_filename
-archive_name = 'cilium-' + archive_name.strip('v')
 backport_format = github_repo + \
     'pulls?q=is:open+is:pr+-label:backport/author+label:%s/' + current_release
 
@@ -148,9 +140,6 @@ backport_format = github_repo + \
 rst_epilog = """
 .. |SCM_WEB| replace:: \\{s}
 .. |SCM_BRANCH| replace:: \\{b}
-.. |SCM_ARCHIVE_NAME| replace:: \\{a}
-.. |SCM_ARCHIVE_FILENAME| replace:: \\{f}
-.. |SCM_ARCHIVE_LINK| replace:: \\{l}
 .. |CURRENT_RELEASE| replace:: \\{c}
 .. |NEXT_RELEASE| replace:: \\{n}
 .. |CHART_RELEASE| replace:: \\{h}
@@ -162,9 +151,6 @@ rst_epilog = """
 """.format(
     s=scm_web,
     b=branch,
-    a=archive_name,
-    f=archive_filename,
-    l=archive_link,
     c=current_release,
     n=next_release,
     h=chart_release,

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -101,6 +101,15 @@ gateway_api_raw_base_url = (
     gateway_api_version
 )
 
+relinfo = semver.parse_version_info(release)
+prev_branch = '%d.%d' % (relinfo.major, relinfo.minor - 1)
+if relinfo.prerelease:
+    next_release = '%d.%d' % (relinfo.major, relinfo.minor)
+    current_release = prev_branch
+else:
+    next_release = '%d.%d' % (relinfo.major, relinfo.minor + 1)
+    current_release = '%d.%d' % (relinfo.major, relinfo.minor)
+
 # Fetch the docs version from an environment variable.
 # Map latest -> main.
 # Map stable -> current version number.
@@ -121,14 +130,6 @@ else:
     chart_version = '--version ' + release
     chart_release = 'cilium/cilium ' + chart_version
     tags.add('stable')
-relinfo = semver.parse_version_info(release)
-prev_release = '%d.%d' % (relinfo.major, relinfo.minor - 1)
-if relinfo.prerelease:
-    next_release = '%d.%d' % (relinfo.major, relinfo.minor)
-    current_release = prev_release
-else:
-    next_release = '%d.%d' % (relinfo.major, relinfo.minor + 1)
-    current_release = '%d.%d' % (relinfo.major, relinfo.minor)
 githubusercontent = 'https://raw.githubusercontent.com/cilium/cilium/'
 scm_web = githubusercontent + branch
 github_repo = 'https://github.com/cilium/cilium/'
@@ -185,7 +186,7 @@ extlinks = {
     'git-tree': (scm_web + "/%s", None),
     'github-backport': (backport_format, None),
     'gh-issue': (github_repo + 'issues/%s', 'GitHub issue %s'),
-    'prev-docs': (versionwarning_api_url + language + '/v' + prev_release + '/%s', None),
+    'prev-docs': (versionwarning_api_url + language + '/v' + prev_branch + '/%s', None),
 }
 
 # List of patterns, relative to source directory, that match files and

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -48,7 +48,7 @@ extensions = ['myst_parser',
               'versionwarning.extension',
               "sphinxext.rediraffe",
               'cilium_helm_directive',
-]
+              ]
 
 rediraffe_redirects = 'redirects.txt'
 # rediraffe_branch is the base for which rediraffe compares the current HEAD to
@@ -153,7 +153,20 @@ rst_epilog = """
 .. |IMAGE_TAG| replace:: \\{i}
 .. |GATEWAY_API_VERSION| replace:: \\{gav}
 .. |GATEWAY_API_RAW_BASE_URL| replace:: \\{grbu}
-""".format(s=scm_web, b=branch, a=archive_name, f=archive_filename, l=archive_link, c=current_release, n=next_release, h=chart_release, g=go_release, i=image_tag, v=chart_version, gav=gateway_api_version, grbu=gateway_api_raw_base_url)
+""".format(
+    s=scm_web,
+    b=branch,
+    a=archive_name,
+    f=archive_filename,
+    l=archive_link,
+    c=current_release,
+    n=next_release,
+    h=chart_release,
+    g=go_release,
+    i=image_tag,
+    v=chart_version,
+    gav=gateway_api_version,
+    grbu=gateway_api_raw_base_url)
 
 # Make shared and constructed links globally available.
 rst_epilog += """

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -91,9 +91,6 @@ go_mod = open("../go.mod", "r").readlines()
 go_release = [line.rstrip()[len("go "):]
               for line in go_mod if line.startswith("go ")][0]
 
-# The image tag for Cilium docker images
-image_tag = 'v' + release
-
 # The upstream Gateway API version referenced across the documentation.
 gateway_api_version = 'v1.6.1'
 gateway_api_raw_base_url = (
@@ -103,6 +100,7 @@ gateway_api_raw_base_url = (
 
 relinfo = semver.parse_version_info(release)
 prev_branch = '%d.%d' % (relinfo.major, relinfo.minor - 1)
+prev_release = '%d.%d.%d' % (relinfo.major, relinfo.minor - 1, 0)
 if relinfo.prerelease:
     next_release = '%d.%d' % (relinfo.major, relinfo.minor)
     current_release = prev_branch
@@ -130,6 +128,13 @@ else:
     chart_version = '--version ' + release
     chart_release = 'cilium/cilium ' + chart_version
     tags.add('stable')
+
+if relinfo.prerelease == 'dev':
+    # There's no dev snapshot yet. Use the last release.
+    docker_tag = 'v' + prev_release
+else:
+    docker_tag = 'v' + release
+
 githubusercontent = 'https://raw.githubusercontent.com/cilium/cilium/'
 scm_web = githubusercontent + branch
 github_repo = 'https://github.com/cilium/cilium/'
@@ -164,7 +169,7 @@ rst_epilog = """
     n=next_release,
     h=chart_release,
     g=go_release,
-    i=image_tag,
+    i=docker_tag,
     v=chart_version,
     gav=gateway_api_version,
     grbu=gateway_api_raw_base_url)

--- a/Documentation/installation/k8s-install-download-release.rst
+++ b/Documentation/installation/k8s-install-download-release.rst
@@ -4,32 +4,20 @@
     Please use the official rendered version released here:
     https://docs.cilium.io
 
-.. only:: stable
+Setup Helm repository:
 
-   Setup Helm repository:
+.. tabs::
 
-   .. tabs::
+   .. group-tab:: Helm Repository
 
-      .. group-tab:: Helm Repository
+      .. code-block:: shell-session
 
-         .. code-block:: shell-session
+         helm repo add cilium https://helm.cilium.io/
 
-            helm repo add cilium https://helm.cilium.io/
+   .. group-tab:: OCI Registry
 
-      .. group-tab:: OCI Registry
+      Cilium charts are also available via OCI registries (Quay.io and Docker Hub).
+      No setup required - you can install directly using ``oci://`` URLs.
 
-         Cilium charts are also available via OCI registries (Quay.io and Docker Hub).
-         No setup required - you can install directly using ``oci://`` URLs.
-
-         See the :ref:`OCI Registry section <k8s_install_helm>` for more information,
-         including chart signing verification and digest-based installations.
-
-.. only:: not stable
-
-   Download the Cilium release tarball and change to the kubernetes install directory:
-
-   .. parsed-literal::
-
-      curl -LO |SCM_ARCHIVE_LINK|
-      tar xzf |SCM_ARCHIVE_FILENAME|
-      cd |SCM_ARCHIVE_NAME|/install/kubernetes
+      See the :ref:`OCI Registry section <k8s_install_helm>` for more information,
+      including chart signing verification and digest-based installations.


### PR DESCRIPTION
Developers don't use these, and they only cause confusion for users who
stumble on the `/latest` docs without realizing they're the latest
developer docs. Remove these special cases for installing the development
version directly from source. Developers can find the relevant
instructions under the development section of the docs.

It looks like the kind install instructions were broken on `/latest` /
`main` as long as we had the pre-pull instructions in the docs, five
years at least. Someone finally noticed. May as well fix it.

Fixes: https://github.com/cilium/cilium/issues/47611
