### PR TITLE
bpf: hostfw: use tailcall buffer for ipv{4,6}_host_policy_{e,in}gress

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -26,6 +26,20 @@
 
 #define	NODEPORT_USE_NAT_46x64		1
 
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__type(key, __u32);
+	__type(value, struct ct_buffer6);
+	__uint(max_entries, 1);
+} cilium_tail_call_buffer6 __section_maps_btf;
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__type(key, __u32);
+	__type(value, struct ct_buffer4);
+	__uint(max_entries, 1);
+} cilium_tail_call_buffer4 __section_maps_btf;
+
 #include "lib/common.h"
 #include "lib/config_map.h"
 #include "lib/edt.h"
@@ -75,20 +89,6 @@
 static __always_inline bool allow_vlan(__u32 __maybe_unused ifindex, __u32 __maybe_unused vlan_id) {
 	VLAN_FILTER(ifindex, vlan_id);
 }
-
-struct {
-	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-	__type(key, __u32);
-	__type(value, struct ct_buffer6);
-	__uint(max_entries, 1);
-} cilium_tail_call_buffer6 __section_maps_btf;
-
-struct {
-	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-	__type(key, __u32);
-	__type(value, struct ct_buffer4);
-	__uint(max_entries, 1);
-} cilium_tail_call_buffer4 __section_maps_btf;
 
 #if defined(ENABLE_IPV4) || defined(ENABLE_IPV6)
 static __always_inline int rewrite_dmac_to_host(struct __ctx_buff *ctx)

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -334,19 +334,23 @@ static __always_inline int
 ipv6_host_policy_ingress(struct __ctx_buff *ctx, __u32 *src_sec_identity,
 			 struct trace_ctx *trace, __s8 *ext_err)
 {
-	struct ct_buffer6 ct_buffer = {};
+	struct ct_buffer6 *ct_buffer;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
+	__u32 zero = 0;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
-	if (!ipv6_host_policy_ingress_lookup(ctx, ip6, &ct_buffer))
+	ct_buffer = map_lookup_elem(&cilium_tail_call_buffer6, &zero);
+	if (!ct_buffer)
+		return DROP_INVALID_TC_BUFFER;
+	if (!ipv6_host_policy_ingress_lookup(ctx, ip6, ct_buffer))
 		return CTX_ACT_OK;
-	if (ct_buffer.ret < 0 && ct_buffer.ret != DROP_CT_UNKNOWN_PROTO)
-		return ct_buffer.ret;
+	if (ct_buffer->ret < 0 && ct_buffer->ret != DROP_CT_UNKNOWN_PROTO)
+		return ct_buffer->ret;
 
-	return __ipv6_host_policy_ingress(ctx, ip6, &ct_buffer, src_sec_identity, trace, ext_err);
+	return __ipv6_host_policy_ingress(ctx, ip6, ct_buffer, src_sec_identity, trace, ext_err);
 }
 # endif /* ENABLE_IPV6 */
 
@@ -625,19 +629,23 @@ static __always_inline int
 ipv4_host_policy_ingress(struct __ctx_buff *ctx, __u32 *src_sec_identity,
 			 struct trace_ctx *trace, __s8 *ext_err)
 {
-	struct ct_buffer4 ct_buffer = {};
+	struct ct_buffer4 *ct_buffer;
 	void *data, *data_end;
 	struct iphdr *ip4;
+	__u32 zero = 0;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
-	if (!ipv4_host_policy_ingress_lookup(ctx, ip4, &ct_buffer))
+	ct_buffer = map_lookup_elem(&cilium_tail_call_buffer4, &zero);
+	if (!ct_buffer)
+		return DROP_INVALID_TC_BUFFER;
+	if (!ipv4_host_policy_ingress_lookup(ctx, ip4, ct_buffer))
 		return CTX_ACT_OK;
-	if (ct_buffer.ret < 0 && ct_buffer.ret != DROP_CT_UNKNOWN_PROTO)
-		return ct_buffer.ret;
+	if (ct_buffer->ret < 0 && ct_buffer->ret != DROP_CT_UNKNOWN_PROTO)
+		return ct_buffer->ret;
 
-	return __ipv4_host_policy_ingress(ctx, ip4, &ct_buffer, src_sec_identity, trace, ext_err);
+	return __ipv4_host_policy_ingress(ctx, ip4, ct_buffer, src_sec_identity, trace, ext_err);
 }
 #  endif /* ENABLE_IPV4 */
 # endif /* ENABLE_HOST_FIREWALL */

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -187,15 +187,19 @@ ipv6_host_policy_egress(struct __ctx_buff *ctx,  bool is_from_proxy, __u32 src_i
 			__u32 ipcache_srcid, const struct ipv6hdr *ip6,
 			struct trace_ctx *trace, __s8 *ext_err)
 {
-	struct ct_buffer6 ct_buffer = {};
+	struct ct_buffer6 *ct_buffer;
+	__u32 zero = 0;
 
-	if (!ipv6_host_policy_egress_lookup(ctx, src_id, ipcache_srcid, ip6, &ct_buffer))
+	ct_buffer = map_lookup_elem(&cilium_tail_call_buffer6, &zero);
+	if (!ct_buffer)
+		return DROP_INVALID_TC_BUFFER;
+	if (!ipv6_host_policy_egress_lookup(ctx, src_id, ipcache_srcid, ip6, ct_buffer))
 		return CTX_ACT_OK;
-	if (ct_buffer.ret < 0 && ct_buffer.ret != DROP_CT_UNKNOWN_PROTO)
-		return ct_buffer.ret;
+	if (ct_buffer->ret < 0 && ct_buffer->ret != DROP_CT_UNKNOWN_PROTO)
+		return ct_buffer->ret;
 
 	return __ipv6_host_policy_egress(ctx, src_id == HOST_ID, is_from_proxy,
-					ip6, &ct_buffer, trace, ext_err);
+					ip6, ct_buffer, trace, ext_err);
 }
 
 static __always_inline bool
@@ -479,15 +483,19 @@ ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_from_proxy, __u32 src_id
 			__u32 ipcache_srcid, const struct iphdr *ip4,
 			struct trace_ctx *trace, __s8 *ext_err)
 {
-	struct ct_buffer4 ct_buffer = {};
+	struct ct_buffer4 *ct_buffer;
+	__u32 zero = 0;
 
-	if (!ipv4_host_policy_egress_lookup(ctx, src_id, ipcache_srcid, ip4, &ct_buffer))
+	ct_buffer = map_lookup_elem(&cilium_tail_call_buffer4, &zero);
+	if (!ct_buffer)
+		return DROP_INVALID_TC_BUFFER;
+	if (!ipv4_host_policy_egress_lookup(ctx, src_id, ipcache_srcid, ip4, ct_buffer))
 		return CTX_ACT_OK;
-	if (ct_buffer.ret < 0 && ct_buffer.ret != DROP_CT_UNKNOWN_PROTO)
-		return ct_buffer.ret;
+	if (ct_buffer->ret < 0 && ct_buffer->ret != DROP_CT_UNKNOWN_PROTO)
+		return ct_buffer->ret;
 
 	return __ipv4_host_policy_egress(ctx, src_id == HOST_ID, is_from_proxy,
-					ip4, &ct_buffer, trace, ext_err);
+					ip4, ct_buffer, trace, ext_err);
 }
 
 static __always_inline bool


### PR DESCRIPTION
This pull request performs a similar change as done in https://github.com/cilium/cilium/pull/45589, to reduce stack usage and complexity. See commits for details. This will help fix a complexity issue on one of the stable branches.