### PR TITLE
gateway-api: propagate errors when resolving CiliumGatewayClassConfig

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -18,6 +18,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
@@ -88,8 +89,7 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		scopedLog.ErrorContext(ctx, "Unable to get GatewayClass",
 			gatewayClass, gw.Spec.GatewayClassName,
 			logfields.Error, err)
-		// Doing nothing till the GatewayClass is available and matching controller name
-		return controllerruntime.Success()
+		return controllerruntime.Fail(err)
 	}
 
 	if string(gwc.Spec.ControllerName) != r.controllerName {
@@ -110,18 +110,16 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return r.handleReconcileErrorWithStatus(ctx, errors.New("Invalid Gateway"), original, gw)
 	}
 
-	if ref := gwc.Spec.ParametersRef; ref != nil {
-		if !isParameterRefSupported(ref) {
-			setGatewayAccepted(gw, false, "Invalid GatewayClass parameters: spec.parametersRef.kind must be CiliumGatewayClassConfig", gatewayv1.GatewayReasonInvalidParameters)
-			setGatewayProgrammed(gw, metav1.ConditionUnknown, "Waiting for Accepted condition to be True", gatewayv1.GatewayReasonPending)
-			return r.handleReconcileErrorWithStatus(ctx, errors.New("Invalid GatewayClass"), original, gw)
-		}
+	// Ensure the GatewayClass has been accepted.
+	if cond := meta.FindStatusCondition(gwc.Status.Conditions, string(gatewayv1.GatewayClassConditionStatusAccepted)); cond != nil &&
+		cond.Status == metav1.ConditionFalse {
+		scopedLog.ErrorContext(ctx, "GatewayClass is not accepted",
+			gatewayClass, gw.Spec.GatewayClassName,
+			logfields.Reason, cond.Message)
 
-		if !hasNamespacedName(ref) {
-			setGatewayAccepted(gw, false, "Invalid GatewayClass parametersRef: both name and namespace are required", gatewayv1.GatewayReasonInvalidParameters)
-			setGatewayProgrammed(gw, metav1.ConditionUnknown, "Waiting for Accepted condition to be True", gatewayv1.GatewayReasonPending)
-			return r.handleReconcileErrorWithStatus(ctx, errors.New("Invalid GatewayClass"), original, gw)
-		}
+		setGatewayAccepted(gw, false, cond.Message, gatewayv1.GatewayReasonInvalidParameters)
+		setGatewayProgrammed(gw, metav1.ConditionUnknown, "Waiting for Accepted condition to be True", gatewayv1.GatewayReasonPending)
+		return r.successWithStatus(ctx, original, gw)
 	}
 
 	grants := &gatewayv1.ReferenceGrantList{}
@@ -349,9 +347,17 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return controllerruntime.Fail(err)
 	}
 
+	gwcConfig, err := r.getGatewayClassConfig(ctx, gwc)
+	if err != nil {
+		scopedLog.ErrorContext(ctx, "Unable to get CiliumGatewayClassConfig referenced by GatewayClass",
+			gatewayClass, gwc.GetName(),
+			logfields.Error, err)
+		return r.handleReconcileErrorWithStatus(ctx, err, original, gw)
+	}
+
 	m := ingestion.GatewayAPI(scopedLog, ingestion.Input{
 		GatewayClass:        *gwc,
-		GatewayClassConfig:  r.getGatewayClassConfig(ctx, gwc),
+		GatewayClassConfig:  gwcConfig,
 		Gateway:             *gw,
 		HTTPRoutes:          httpRoutes,
 		TLSRoutes:           tlsRoutes,
@@ -959,12 +965,11 @@ func (r *gatewayReconciler) filterGRPCRoutesByListener(ctx context.Context, gw *
 }
 
 // getGatewayClassConfig returns the CiliumGatewayClassConfig referenced by the GatewayClass.
-// If the GatewayClass does not reference a CiliumGatewayClassConfig, it returns nil.
-func (r *gatewayReconciler) getGatewayClassConfig(ctx context.Context, gwc *gatewayv1.GatewayClass) *v2alpha1.CiliumGatewayClassConfig {
-	if gwc.Spec.ParametersRef == nil ||
-		gwc.Spec.ParametersRef.Group != v2alpha1.CustomResourceDefinitionGroup ||
-		gwc.Spec.ParametersRef.Kind != v2alpha1.CGCCKindDefinition {
-		return nil
+// If the GatewayClass does not reference a CiliumGatewayClassConfig, it returns a nil config
+// and a nil error.
+func (r *gatewayReconciler) getGatewayClassConfig(ctx context.Context, gwc *gatewayv1.GatewayClass) (*v2alpha1.CiliumGatewayClassConfig, error) {
+	if !hasNamespacedName(gwc.Spec.ParametersRef) {
+		return nil, nil
 	}
 
 	key := client.ObjectKey{
@@ -974,12 +979,9 @@ func (r *gatewayReconciler) getGatewayClassConfig(ctx context.Context, gwc *gate
 
 	res := &v2alpha1.CiliumGatewayClassConfig{}
 	if err := r.Client.Get(ctx, key, res); err != nil {
-		r.logger.ErrorContext(ctx, "Failed to get CiliumGatewayClassConfig",
-			logfields.Resource, key,
-			logfields.Error, err)
-		return nil
+		return nil, fmt.Errorf("failed to get CiliumGatewayClassConfig %s: %w", key, err)
 	}
-	return res
+	return res, nil
 }
 
 func parentRefMatched(gw *gatewayv1.Gateway, listener *gatewayv1.Listener, listenerSource *model.FullyQualifiedResource, routeNamespace string, refs []gatewayv1.ParentReference) bool {
@@ -1547,6 +1549,13 @@ func (r *gatewayReconciler) handleReconcileErrorWithStatus(ctx context.Context, 
 	}
 
 	return controllerruntime.Fail(reconcileErr)
+}
+
+func (r *gatewayReconciler) successWithStatus(ctx context.Context, original *gatewayv1.Gateway, modified *gatewayv1.Gateway) (ctrl.Result, error) {
+	if err := r.updateStatus(ctx, original, modified); err != nil {
+		return controllerruntime.Fail(fmt.Errorf("failed to update Gateway status: %w", err))
+	}
+	return controllerruntime.Success()
 }
 
 func (r *gatewayReconciler) verifyGatewayStaticAddresses(gw *gatewayv1.Gateway) error {

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -608,6 +609,91 @@ func Test_Conformance(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGatewayReconciler_GatewayClassStatus(t *testing.T) {
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gateway", Namespace: "default"},
+		Spec:       gatewayv1.GatewaySpec{GatewayClassName: "gateway-class"},
+	}
+	ownerRef := *metav1.NewControllerRef(gw, schema.GroupVersionKind{
+		Group:   gatewayv1.GroupVersion.Group,
+		Version: gatewayv1.GroupVersion.Version,
+		Kind:    "Gateway",
+	})
+	resourceName := shortener.ShortenK8sResourceName(gatewayApiTranslation.CiliumGatewayPrefix + gw.Name)
+	ownedResources := []client.Object{
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{
+			Name: resourceName, Namespace: gw.Namespace, OwnerReferences: []metav1.OwnerReference{ownerRef},
+		}},
+		&discoveryv1.EndpointSlice{ObjectMeta: metav1.ObjectMeta{
+			Name: resourceName, Namespace: gw.Namespace, OwnerReferences: []metav1.OwnerReference{ownerRef},
+			Labels: map[string]string{gatewayApiTranslation.EndpointSliceServiceNameLabel: resourceName},
+		}},
+		&ciliumv2.CiliumEnvoyConfig{ObjectMeta: metav1.ObjectMeta{
+			Name: resourceName, Namespace: gw.Namespace, OwnerReferences: []metav1.OwnerReference{ownerRef},
+		}},
+	}
+
+	t.Run("accepted GatewayClass becomes rejected", func(t *testing.T) {
+		gwc := &gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{Name: "gateway-class"},
+			Spec:       gatewayv1.GatewayClassSpec{ControllerName: defaultControllerName},
+			Status: gatewayv1.GatewayClassStatus{Conditions: []metav1.Condition{{
+				Type:    string(gatewayv1.GatewayClassConditionStatusAccepted),
+				Status:  metav1.ConditionFalse,
+				Reason:  string(gatewayv1.GatewayClassReasonInvalidParameters),
+				Message: "Referenced CiliumGatewayClassConfig does not exist",
+			}}},
+		}
+
+		objects := append([]client.Object{gw, gwc}, ownedResources...)
+		r, c := testReconciler(t, objects...)
+
+		result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(gw)})
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result)
+
+		for _, resource := range ownedResources {
+			actual := resource.DeepCopyObject().(client.Object)
+			require.NoError(t, c.Get(t.Context(), client.ObjectKeyFromObject(resource), actual), "%T should be retained", resource)
+		}
+
+		updatedGW := &gatewayv1.Gateway{}
+		require.NoError(t, c.Get(t.Context(), client.ObjectKeyFromObject(gw), updatedGW))
+
+		accepted := meta.FindStatusCondition(updatedGW.Status.Conditions, string(gatewayv1.GatewayConditionAccepted))
+		require.NotNil(t, accepted)
+		assert.Equal(t, metav1.ConditionFalse, accepted.Status)
+		assert.Equal(t, string(gatewayv1.GatewayReasonInvalidParameters), accepted.Reason)
+		assert.Equal(t, "Referenced CiliumGatewayClassConfig does not exist", accepted.Message)
+
+		programmed := meta.FindStatusCondition(updatedGW.Status.Conditions, string(gatewayv1.GatewayConditionProgrammed))
+		require.NotNil(t, programmed)
+		assert.Equal(t, metav1.ConditionUnknown, programmed.Status)
+		assert.Equal(t, string(gatewayv1.GatewayReasonPending), programmed.Reason)
+		assert.Equal(t, "Waiting for Accepted condition to be True", programmed.Message)
+	})
+
+	t.Run("GatewayClass no longer managed by cilium", func(t *testing.T) {
+		gwc := &gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{Name: "gateway-class"},
+			Spec:       gatewayv1.GatewayClassSpec{ControllerName: "example.com/other-gateway-controller"},
+		}
+
+		objects := append([]client.Object{gw, gwc}, ownedResources...)
+		r, c := testReconciler(t, objects...)
+
+		result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(gw)})
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result)
+
+		for _, resource := range ownedResources {
+			res := resource.DeepCopyObject().(client.Object)
+			require.True(t, k8serrors.IsNotFound(c.Get(t.Context(), client.ObjectKeyFromObject(resource), res)), "%T should be deleted", resource)
+		}
+	})
+
 }
 
 func Test_grpcWebTranslationEnabled(t *testing.T) {
@@ -1349,7 +1435,7 @@ func testReconciler(t *testing.T, obj ...client.Object) (*gatewayReconciler, cli
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
 		WithObjects(obj...).
-		WithStatusSubresource(&gatewayv1.HTTPRoute{}, &gatewayv1.GRPCRoute{}).
+		WithStatusSubresource(&gatewayv1.Gateway{}, &gatewayv1.HTTPRoute{}, &gatewayv1.GRPCRoute{}).
 		Build()
 
 	reconciler := &gatewayReconciler{

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -128,6 +128,12 @@ func Test_Conformance(t *testing.T) {
 			},
 		},
 		{
+			name: "gateway-rejected-gatewayclass",
+			gateway: []gwDetails{
+				{FullName: types.NamespacedName{Name: "gateway-rejected-gatewayclass", Namespace: "gateway-conformance-infra"}, skipCEC: true},
+			},
+		},
+		{
 			name: "gateway-invalid-route-kind",
 			gateway: []gwDetails{
 				{FullName: types.NamespacedName{Name: "gateway-only-invalid-route-kind", Namespace: "gateway-conformance-infra"}, wantErr: true},

--- a/operator/pkg/gateway-api/gatewayclass_reconcile.go
+++ b/operator/pkg/gateway-api/gatewayclass_reconcile.go
@@ -48,6 +48,9 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if original.GetDeletionTimestamp() != nil {
 		return controllerruntime.Success()
 	}
+	if string(original.Spec.ControllerName) != r.controllerName {
+		return controllerruntime.Success()
+	}
 
 	gwc := original.DeepCopy()
 

--- a/operator/pkg/gateway-api/gatewayclass_reconcile.go
+++ b/operator/pkg/gateway-api/gatewayclass_reconcile.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -51,19 +52,10 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	gwc := original.DeepCopy()
 
 	if ref := gwc.Spec.ParametersRef; ref != nil {
-		if !isParameterRefSupported(ref) {
-			scopedLog.ErrorContext(ctx, "Only CiliumGatewayClassConfig is supported for ParametersRef")
-			setGatewayClassAccepted(gwc, false)
-			if err := r.ensureStatus(ctx, gwc, original); err != nil {
-				scopedLog.ErrorContext(ctx, "Failed to update GatewayClass status", logfields.Error, err)
-				return controllerruntime.Fail(err)
-			}
-			return controllerruntime.Fail(nil)
-		}
-
-		if !hasNamespacedName(ref) {
-			scopedLog.ErrorContext(ctx, "ParametersRef must specify namespace and name")
-			setGatewayClassAccepted(gwc, false)
+		if reason, msg, ok := r.validateParametersRef(gwc); !ok {
+			scopedLog.ErrorContext(ctx, "Invalid ParametersRef",
+				logfields.Resource, req.NamespacedName)
+			setGatewayClassAccepted(gwc, false, reason, msg)
 			if err := r.ensureStatus(ctx, gwc, original); err != nil {
 				scopedLog.ErrorContext(ctx, "Failed to update GatewayClass status", logfields.Error, err)
 				return controllerruntime.Fail(err)
@@ -76,13 +68,24 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			Namespace: string(*ref.Namespace),
 			Name:      ref.Name,
 		}
+
 		if err := r.Client.Get(ctx, key, cgcc); err != nil {
-			setGatewayClassAccepted(gwc, false)
+			if !k8serrors.IsNotFound(err) {
+				scopedLog.ErrorContext(ctx, "Failed to get CiliumGatewayClassConfig",
+					logfields.Resource, key,
+					logfields.Error, err)
+				return controllerruntime.Fail(err)
+			}
+
+			scopedLog.ErrorContext(ctx, "Referenced CiliumGatewayClassConfig does not exist",
+				logfields.Resource, key)
+			setGatewayClassAccepted(gwc, false, gatewayv1.GatewayClassReasonInvalidParameters, "Referenced CiliumGatewayClassConfig does not exist")
 			if err := r.ensureStatus(ctx, gwc, original); err != nil {
 				scopedLog.ErrorContext(ctx, "Failed to update GatewayClass status", logfields.Error, err)
 				return controllerruntime.Fail(err)
 			}
-			return controllerruntime.Fail(err)
+
+			return controllerruntime.Fail(nil)
 		}
 
 		if gwc.Annotations == nil {
@@ -96,7 +99,7 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 	}
 
-	setGatewayClassAccepted(gwc, true)
+	setGatewayClassAccepted(gwc, true, gatewayv1.GatewayClassReasonAccepted, gatewayClassAcceptedMessage)
 	setGatewayClassSupportedFeatures(gwc)
 	if err := r.ensureStatus(ctx, gwc, original); err != nil {
 		scopedLog.ErrorContext(ctx, "Failed to update GatewayClass status", logfields.Error, err)
@@ -113,6 +116,26 @@ func (r *gatewayClassReconciler) ensureStatus(ctx context.Context, gwc *gatewayv
 
 func (r *gatewayClassReconciler) ensureResource(ctx context.Context, gwc *gatewayv1.GatewayClass, original *gatewayv1.GatewayClass) error {
 	return r.Client.Patch(ctx, gwc, client.MergeFrom(original))
+}
+
+func (r *gatewayClassReconciler) validateParametersRef(gwc *gatewayv1.GatewayClass) (reason gatewayv1.GatewayClassConditionReason, msg string, ok bool) {
+	switch {
+	case !isParameterRefSupported(gwc.Spec.ParametersRef):
+		reason = gatewayv1.GatewayClassReasonInvalidParameters
+		msg = fmt.Sprintf("Unsupported ParametersRef resource; Must be %s",
+			v2alpha1.CGCCName)
+
+	case ptr.Deref(gwc.Spec.ParametersRef.Namespace, "") == "":
+		reason = gatewayv1.GatewayClassReasonInvalidParameters
+		msg = "ParametersRef namespace must be specified"
+
+	case gwc.Spec.ParametersRef.Name == "":
+		reason = gatewayv1.GatewayClassReasonInvalidParameters
+		msg = "ParametersRef name must be specified"
+	}
+
+	ok = reason == ""
+	return
 }
 
 // checksum returns a sha256 checksum of CiliumGatewayClassConfig.spec.

--- a/operator/pkg/gateway-api/gatewayclass_reconcile_test.go
+++ b/operator/pkg/gateway-api/gatewayclass_reconcile_test.go
@@ -8,7 +8,9 @@ import (
 	"time"
 
 	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -45,7 +47,7 @@ var (
 		},
 		&gatewayv1.GatewayClass{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "dummy-gw-class-with-unsupported-parameters-ref",
+				Name: "dummy-gw-class-with-unsupported-parameters-ref-resource",
 			},
 			Spec: gatewayv1.GatewayClassSpec{
 				ControllerName: "io.cilium/gateway-controller",
@@ -67,6 +69,45 @@ var (
 					Group:     "cilium.io",
 					Kind:      "CiliumGatewayClassConfig",
 					Name:      "dummy-gateway-class-config",
+					Namespace: ptr.To(gatewayv1.Namespace("default")),
+				},
+			},
+		},
+		&gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "dummy-gw-class-with-unnamespaced-parameters-ref",
+			},
+			Spec: gatewayv1.GatewayClassSpec{
+				ControllerName: "io.cilium/gateway-controller",
+				ParametersRef: &gatewayv1.ParametersReference{
+					Group: "cilium.io",
+					Kind:  "CiliumGatewayClassConfig",
+				},
+			},
+		},
+		&gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "dummy-gw-class-with-unnamed-parameters-ref",
+			},
+			Spec: gatewayv1.GatewayClassSpec{
+				ControllerName: "io.cilium/gateway-controller",
+				ParametersRef: &gatewayv1.ParametersReference{
+					Group:     "cilium.io",
+					Kind:      "CiliumGatewayClassConfig",
+					Namespace: ptr.To(gatewayv1.Namespace("default")),
+				},
+			},
+		},
+		&gatewayv1.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "dummy-gw-class-with-parameters-ref-not-found",
+			},
+			Spec: gatewayv1.GatewayClassSpec{
+				ControllerName: "io.cilium/gateway-controller",
+				ParametersRef: &gatewayv1.ParametersReference{
+					Group:     "cilium.io",
+					Kind:      "CiliumGatewayClassConfig",
+					Name:      "does-not-exist",
 					Namespace: ptr.To(gatewayv1.Namespace("default")),
 				},
 			},
@@ -144,14 +185,57 @@ func Test_gatewayClassReconciler_Reconcile(t *testing.T) {
 	t.Run("gateway class exists with unsupported parameter ref", func(t *testing.T) {
 		result, err := r.Reconcile(t.Context(), ctrl.Request{
 			NamespacedName: types.NamespacedName{
-				Name: "dummy-gw-class-with-unsupported-parameters-ref",
+				Name: "dummy-gw-class-with-unsupported-parameters-ref-resource",
 			},
 		})
 
 		require.NoError(t, err, "Successfully reconciling gateway class")
 		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
 
-		gwconformance.GWCMustHaveAcceptedConditionAny(t, c, gwconformanceconfig.DefaultTimeoutConfig(), "dummy-gw-class-with-unsupported-parameters-ref")
+		assertGatewayClassRejected(t, c, "dummy-gw-class-with-unsupported-parameters-ref-resource",
+			"Unsupported ParametersRef resource; Must be "+v2alpha1.CGCCName)
+	})
+
+	t.Run("gateway class exists with unnamespaced parameters ref", func(t *testing.T) {
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
+			NamespacedName: client.ObjectKey{
+				Name: "dummy-gw-class-with-unnamespaced-parameters-ref",
+			},
+		})
+
+		require.NoError(t, err, "Successfully reconciling gateway class")
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		assertGatewayClassRejected(t, c, "dummy-gw-class-with-unnamespaced-parameters-ref",
+			"ParametersRef namespace must be specified")
+	})
+
+	t.Run("gateway class exists with unnamed parameters ref", func(t *testing.T) {
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
+			NamespacedName: client.ObjectKey{
+				Name: "dummy-gw-class-with-unnamed-parameters-ref",
+			},
+		})
+
+		require.NoError(t, err, "Successfully reconciling gateway class")
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		assertGatewayClassRejected(t, c, "dummy-gw-class-with-unnamed-parameters-ref",
+			"ParametersRef name must be specified")
+	})
+
+	t.Run("gateway class exists with parameters ref not found", func(t *testing.T) {
+		result, err := r.Reconcile(t.Context(), ctrl.Request{
+			NamespacedName: client.ObjectKey{
+				Name: "dummy-gw-class-with-parameters-ref-not-found",
+			},
+		})
+
+		require.NoError(t, err, "Missing CiliumGatewayClassConfig should not be retried")
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		assertGatewayClassRejected(t, c, "dummy-gw-class-with-parameters-ref-not-found",
+			"Referenced CiliumGatewayClassConfig does not exist")
 	})
 
 	t.Run("gateway class exists with valid parameter ref", func(t *testing.T) {
@@ -221,4 +305,19 @@ func Test_hasNamespacedName(t *testing.T) {
 		}
 		require.True(t, hasNamespacedName(ref))
 	})
+}
+
+// requireGatewayClassRejected asserts that the GatewayClass carries an Accepted
+// condition reporting the given message as invalid parameters.
+func assertGatewayClassRejected(t *testing.T, c client.Client, name string, msg string) {
+	t.Helper()
+
+	gwc := &gatewayv1.GatewayClass{}
+	require.NoError(t, c.Get(t.Context(), client.ObjectKey{Name: name}, gwc), "Error getting gateway class")
+
+	cond := meta.FindStatusCondition(gwc.Status.Conditions, string(gatewayv1.GatewayClassConditionStatusAccepted))
+	require.NotNil(t, cond, "GatewayClass should have an Accepted condition")
+	assert.Equal(t, metav1.ConditionFalse, cond.Status, "GatewayClass should not be accepted")
+	assert.Equal(t, string(gatewayv1.GatewayClassReasonInvalidParameters), cond.Reason)
+	assert.Equal(t, msg, cond.Message)
 }

--- a/operator/pkg/gateway-api/gatewayclass_reconcile_test.go
+++ b/operator/pkg/gateway-api/gatewayclass_reconcile_test.go
@@ -124,9 +124,7 @@ var (
 		},
 		&gatewayv1.GatewayClass{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:              "non-matching-gw-class",
-				DeletionTimestamp: &metav1.Time{Time: time.Now()},
-				Finalizers:        []string{gwcFinalizer},
+				Name: "non-matching-gw-class",
 			},
 			Spec: gatewayv1.GatewayClassSpec{
 				ControllerName: "not-cilium-controller-name",
@@ -142,7 +140,7 @@ func Test_gatewayClassReconciler_Reconcile(t *testing.T) {
 		WithObjects(cgwccFixture...).
 		WithStatusSubresource(&gatewayv1.GatewayClass{}).
 		Build()
-	r := &gatewayClassReconciler{Client: c, logger: hivetest.Logger(t)}
+	r := &gatewayClassReconciler{Client: c, logger: hivetest.Logger(t), controllerName: defaultControllerName}
 
 	t.Run("no gateway class", func(t *testing.T) {
 		result, err := r.Reconcile(t.Context(), ctrl.Request{

--- a/operator/pkg/gateway-api/gatewayclass_status.go
+++ b/operator/pkg/gateway-api/gatewayclass_status.go
@@ -6,7 +6,6 @@ package gateway_api
 import (
 	"cmp"
 	"slices"
-	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -14,8 +13,7 @@ import (
 )
 
 const (
-	gatewayClassAcceptedMessage    = "Valid GatewayClass"
-	gatewayClassNotAcceptedMessage = "Invalid GatewayClass"
+	gatewayClassAcceptedMessage = "Valid GatewayClass"
 )
 
 var supportedFeatures = features.AllFeatures
@@ -52,8 +50,8 @@ func getSupportedFeatures() []gatewayv1.SupportedFeature {
 
 // setGatewayClassAccepted inserts or updates the Accepted condition
 // for the provided GatewayClass.
-func setGatewayClassAccepted(gwc *gatewayv1.GatewayClass, accepted bool) *gatewayv1.GatewayClass {
-	gwc.Status.Conditions = merge(gwc.Status.Conditions, gatewayClassAcceptedCondition(gwc, accepted))
+func setGatewayClassAccepted(gwc *gatewayv1.GatewayClass, accepted bool, reason gatewayv1.GatewayClassConditionReason, msg string) *gatewayv1.GatewayClass {
+	gwc.Status.Conditions = merge(gwc.Status.Conditions, gatewayClassAcceptedCondition(gwc, accepted, reason, msg))
 	return gwc
 }
 
@@ -64,25 +62,18 @@ func setGatewayClassSupportedFeatures(gwc *gatewayv1.GatewayClass) *gatewayv1.Ga
 }
 
 // gatewayClassAcceptedCondition returns the GatewayClass with Accepted status condition.
-func gatewayClassAcceptedCondition(gwc *gatewayv1.GatewayClass, accepted bool) metav1.Condition {
-	switch accepted {
-	case true:
-		return metav1.Condition{
-			Type:               string(gatewayv1.GatewayClassConditionStatusAccepted),
-			Status:             metav1.ConditionTrue,
-			Reason:             string(gatewayv1.GatewayClassReasonAccepted),
-			Message:            gatewayClassAcceptedMessage,
-			ObservedGeneration: gwc.Generation,
-			LastTransitionTime: metav1.NewTime(time.Now()),
-		}
-	default:
-		return metav1.Condition{
-			Type:               string(gatewayv1.GatewayClassConditionStatusAccepted),
-			Status:             metav1.ConditionFalse,
-			Reason:             string(gatewayv1.GatewayClassReasonInvalidParameters),
-			Message:            gatewayClassNotAcceptedMessage,
-			ObservedGeneration: gwc.Generation,
-			LastTransitionTime: metav1.NewTime(time.Now()),
-		}
+func gatewayClassAcceptedCondition(gwc *gatewayv1.GatewayClass, accepted bool, reason gatewayv1.GatewayClassConditionReason, msg string) metav1.Condition {
+	status := metav1.ConditionTrue
+	if !accepted {
+		status = metav1.ConditionFalse
+	}
+
+	return metav1.Condition{
+		Type:               string(gatewayv1.GatewayClassConditionStatusAccepted),
+		Status:             status,
+		Reason:             string(reason),
+		Message:            msg,
+		ObservedGeneration: gwc.Generation,
+		LastTransitionTime: metav1.Now(),
 	}
 }

--- a/operator/pkg/gateway-api/gatewayclass_status_test.go
+++ b/operator/pkg/gateway-api/gatewayclass_status_test.go
@@ -17,6 +17,8 @@ func Test_gatewayClassAcceptedCondition(t *testing.T) {
 	type args struct {
 		gwc      *gatewayv1.GatewayClass
 		accepted bool
+		msg      string
+		reason   gatewayv1.GatewayClassConditionReason
 	}
 	tests := []struct {
 		name string
@@ -31,7 +33,9 @@ func Test_gatewayClassAcceptedCondition(t *testing.T) {
 						Generation: 100,
 					},
 				},
+				reason:   gatewayv1.GatewayClassReasonAccepted,
 				accepted: true,
+				msg:      "Valid GatewayClass",
 			},
 			want: metav1.Condition{
 				Type:               "Accepted",
@@ -49,7 +53,9 @@ func Test_gatewayClassAcceptedCondition(t *testing.T) {
 						Generation: 100,
 					},
 				},
+				reason:   gatewayv1.GatewayClassReasonInvalidParameters,
 				accepted: false,
+				msg:      "Invalid GatewayClass",
 			},
 			want: metav1.Condition{
 				Type:               "Accepted",
@@ -62,7 +68,7 @@ func Test_gatewayClassAcceptedCondition(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := gatewayClassAcceptedCondition(tt.args.gwc, tt.args.accepted)
+			got := gatewayClassAcceptedCondition(tt.args.gwc, tt.args.accepted, tt.args.reason, tt.args.msg)
 			assert.True(t, cmp.Equal(got, tt.want, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")), "httpRouteAcceptedCondition() = %v, want %v", got, tt.want)
 		})
 	}

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-rejected-gatewayclass/input/gateway-rejected-gatewayclass.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-rejected-gatewayclass/input/gateway-rejected-gatewayclass.yaml
@@ -1,0 +1,32 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: rejected
+spec:
+  controllerName: io.cilium/gateway-controller
+  description: A GatewayClass rejected by the GatewayClass reconciler
+  parametersRef:
+    group: cilium.io
+    kind: CiliumGatewayClassConfig
+    name: does-not-exist
+    namespace: gateway-conformance-infra
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T05:06:15Z"
+      message: Referenced CiliumGatewayClassConfig does not exist
+      observedGeneration: 0
+      reason: InvalidParameters
+      status: "False"
+      type: Accepted
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-rejected-gatewayclass
+  namespace: gateway-conformance-infra
+spec:
+  gatewayClassName: rejected
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP

--- a/operator/pkg/gateway-api/testdata/gateway/gateway-rejected-gatewayclass/output/gateway-rejected-gatewayclass.yaml
+++ b/operator/pkg/gateway-api/testdata/gateway/gateway-rejected-gatewayclass/output/gateway-rejected-gatewayclass.yaml
@@ -1,0 +1,25 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  creationTimestamp: null
+  name: gateway-rejected-gatewayclass
+  namespace: gateway-conformance-infra
+  resourceVersion: "1000"
+spec:
+  gatewayClassName: "rejected"
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+status:
+  conditions:
+    - lastTransitionTime: "2025-07-01T05:06:15Z"
+      message: "Referenced CiliumGatewayClassConfig does not exist"
+      reason: InvalidParameters
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: "2025-07-01T05:06:15Z"
+      message: "Waiting for Accepted condition to be True"
+      reason: Pending
+      status: "Unknown"
+      type: Programmed


### PR DESCRIPTION
Follow up to: https://github.com/cilium/cilium/pull/47255#discussion_r3597316606

This PR improves the status reporting in GatewayClass reconcile by adding more descriptive messages and only requeueing on transient errors. And handles GatewayClass Accepted=False in Gateway reconcile in place of existing duplicate validation. 

/cc @mhofstetter 

```release-note
GatewayClass and Gateway status now propagate errors from resolving the referenced CiliumGatewayClassConfig
```