### PR TITLE
bpf: neigh: avoid IP header revalidation

### DIFF
--- a/bpf/lib/neigh.h
+++ b/bpf/lib/neigh.h
@@ -19,20 +19,17 @@ struct {
 } cilium_nodeport_neigh6 __section_maps_btf;
 
 #if defined(ENABLE_NODEPORT) && defined(ENABLE_IPV6)
-static __always_inline int neigh_record_ip6(struct __ctx_buff *ctx)
+static __always_inline int
+neigh_record_ip6(struct __ctx_buff *ctx, union v6addr *saddr)
 {
 	union macaddr smac = {}, *mac;
-	void *data, *data_end;
-	struct ipv6hdr *ip6;
 
-	if (!revalidate_data(ctx, &data, &data_end, &ip6))
-		return DROP_INVALID;
 	if (eth_load_saddr(ctx, smac.addr, 0) < 0)
 		return DROP_INVALID;
 
-	mac = map_lookup_elem(&cilium_nodeport_neigh6, &ip6->saddr);
+	mac = map_lookup_elem(&cilium_nodeport_neigh6, saddr);
 	if (!mac || eth_addrcmp(mac, &smac)) {
-		int ret = map_update_elem(&cilium_nodeport_neigh6, &ip6->saddr,
+		int ret = map_update_elem(&cilium_nodeport_neigh6, saddr,
 					  &smac, 0);
 		if (ret < 0)
 			return ret;
@@ -64,20 +61,17 @@ struct {
 } cilium_nodeport_neigh4 __section_maps_btf;
 
 #if defined(ENABLE_NODEPORT) && defined(ENABLE_IPV4)
-static __always_inline int neigh_record_ip4(struct __ctx_buff *ctx)
+static __always_inline int
+neigh_record_ip4(struct __ctx_buff *ctx, __be32 saddr)
 {
 	union macaddr smac = {}, *mac;
-	void *data, *data_end;
-	struct iphdr *ip4;
 
-	if (!revalidate_data(ctx, &data, &data_end, &ip4))
-		return DROP_INVALID;
 	if (eth_load_saddr(ctx, smac.addr, 0) < 0)
 		return DROP_INVALID;
 
-	mac = map_lookup_elem(&cilium_nodeport_neigh4, &ip4->saddr);
+	mac = map_lookup_elem(&cilium_nodeport_neigh4, &saddr);
 	if (!mac || eth_addrcmp(mac, &smac)) {
-		int ret = map_update_elem(&cilium_nodeport_neigh4, &ip4->saddr,
+		int ret = map_update_elem(&cilium_nodeport_neigh4, &saddr,
 					  &smac, 0);
 		if (ret < 0)
 			return ret;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1517,7 +1517,8 @@ static __always_inline int nodeport_svc_lb6(struct __ctx_buff *ctx,
 			return CTX_ACT_OK;
 		}
 
-		ret = neigh_record_ip6(ctx);
+		/* tuple was reversed earlier, this gives us the ip6->saddr: */
+		ret = neigh_record_ip6(ctx, &tuple->daddr);
 		if (ret < 0)
 			return ret;
 	}
@@ -1601,7 +1602,7 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 skip_service_lookup:
 #ifdef ENABLE_NAT_46X64_GATEWAY
 	if (is_v4_in_v6_rfc6052((union v6addr *)&ip6->daddr)) {
-		ret = neigh_record_ip6(ctx);
+		ret = neigh_record_ip6(ctx, &tuple.saddr);
 		if (ret < 0)
 			return ret;
 		if (is_v4_in_v6_rfc6052((union v6addr *)&ip6->saddr))
@@ -2891,7 +2892,8 @@ static __always_inline int nodeport_svc_lb4(struct __ctx_buff *ctx,
 			return CTX_ACT_OK;
 		}
 
-		ret = neigh_record_ip4(ctx);
+		/* tuple was reversed earlier, this gives us the ip4->saddr: */
+		ret = neigh_record_ip4(ctx, tuple->daddr);
 		if (ret < 0)
 			return ret;
 	}

--- a/bpf/tests/tc_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_lb.c
@@ -752,6 +752,11 @@ int nodeport_nat_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 	if (l4->dest != BACKEND_PORT)
 		test_fatal("dst port hasn't been NATed to backend port");
 
+	__be32 client_ip = CLIENT_IP;
+
+	if (!neigh_lookup_ip4(&client_ip))
+		test_fatal("client is missing from neighbour table")
+
 	struct mock_settings *settings = map_lookup_elem(&settings_map, &key);
 
 	if (settings)

--- a/bpf/tests/tc_nodeport_lb6_nat_lb.c
+++ b/bpf/tests/tc_nodeport_lb6_nat_lb.c
@@ -749,6 +749,11 @@ int nodeport_nat_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 	if (l4->dest != BACKEND_PORT)
 		test_fatal("dst port hasn't been NATed to backend port");
 
+	union v6addr client_ip = CLIENT_IP;
+
+	if (!neigh_lookup_ip6(&client_ip))
+		test_fatal("client is missing from neighbour table")
+
 	struct mock_settings *settings = map_lookup_elem(&settings_map, &key);
 
 	if (settings)


### PR DESCRIPTION
Let the caller pass the source IP instead.