### PR TITLE
bpf: ipv6: convert all ipv6_hdrlen*() into global func

### DIFF
--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -539,31 +539,33 @@ icmp6_host_handle(struct __ctx_buff *ctx, int l4_off, __s8 *ext_err, bool handle
 }
 
 static __always_inline
-bool icmp6_ndisc_validate(struct __ctx_buff *ctx, const struct ipv6hdr *ip6,
+bool icmp6_ndisc_validate(struct __ctx_buff *ctx, __u8 nexthdr,
 			  const union macaddr *iface_mac, union v6addr *tip)
 {
-	__u8 nexthdr = ip6->nexthdr;
-	struct icmp6hdr *icmp;
-	int l4_off = ipv6_hdrlen(ctx, &nexthdr);
+	int hdrlen = ipv6_hdrlen(ctx, &nexthdr);
 	struct ethhdr *eth = ctx_data(ctx);
+	int icmp_off, tip_off;
 	union macaddr *dmac;
+	__u8 icmp6_type;
 
 	if ((void *)eth + ETH_HLEN > ctx_data_end(ctx))
 		return false;
 
 	dmac = (union macaddr *)&eth->h_dest;
 
-	if (l4_off < 0 || nexthdr != NEXTHDR_ICMP)
+	if (hdrlen < 0 || nexthdr != NEXTHDR_ICMP)
 		return false;
 
-	icmp = (struct icmp6hdr *)((__u8 *)ip6 + l4_off);
-	if ((void *)icmp + sizeof(*icmp) + sizeof(*tip) > ctx_data_end(ctx))
+	icmp_off = ETH_HLEN + hdrlen;
+	if (icmp6_load_type(ctx, icmp_off, &icmp6_type))
+		return DROP_INVALID;
+
+	if (icmp6_type != ICMP6_NS_MSG_TYPE)
 		return false;
 
-	if (icmp->icmp6_type != ICMP6_NS_MSG_TYPE)
-		return false;
-
-	*tip = *(union v6addr *)(icmp + 1);
+	tip_off = icmp_off + offsetof(struct icmp6hdr, icmp6_dataun) + sizeof(__u32);
+	if (ctx_load_bytes(ctx, tip_off, tip, sizeof(*tip)))
+		return DROP_INVALID;
 
 	if (!ipv6_is_sol_mc_mac(tip, dmac) && eth_addrcmp(dmac, iface_mac) != 0)
 		return false;

--- a/bpf/lib/ipv6.h
+++ b/bpf/lib/ipv6.h
@@ -118,8 +118,8 @@ static __always_inline int ipv6_skip_exthdr(const struct __ctx_buff *ctx, __u8 *
 	}
 }
 
-static __always_inline int ipv6_hdrlen_offset(const struct __ctx_buff *ctx, int l3_off,
-					      __u8 *nexthdr, fraginfo_t *fraginfo)
+static __always_inline int ipv6_walk_exthdrs(const struct __ctx_buff *ctx, int l3_off,
+					     __u8 *nexthdr, fraginfo_t *fraginfo)
 {
 	int i, len = sizeof(struct ipv6hdr);
 	__u8 nh = *nexthdr;
@@ -171,15 +171,16 @@ struct ipv6_hdrlen_arg {
 DEFINE_AUX(struct ipv6_hdrlen_arg, ipv6_hdrlen_arg);
 
 __noinline __weak
-int ipv6_hdrlen_with_fraginfo_weak(const struct __ctx_buff *ctx)
+int ipv6_walk_exthdrs_weak(const struct __ctx_buff *ctx, int l3_off)
 {
 	struct ipv6_hdrlen_arg *arg = AUX(ipv6_hdrlen_arg);
 
-	return ipv6_hdrlen_offset(ctx, ETH_HLEN, &arg->nexthdr, &arg->fraginfo);
+	return ipv6_walk_exthdrs(ctx, l3_off, &arg->nexthdr, &arg->fraginfo);
 }
 
 static __always_inline
-int ipv6_hdrlen_with_fraginfo(const struct __ctx_buff *ctx, __u8 *nexthdr, fraginfo_t *fraginfo)
+int ipv6_hdrlen_offset(const struct __ctx_buff *ctx, int l3_off, __u8 *nexthdr,
+		       fraginfo_t *fraginfo)
 {
 	struct ipv6_hdrlen_arg *arg = AUX(ipv6_hdrlen_arg);
 	int ret;
@@ -190,11 +191,18 @@ int ipv6_hdrlen_with_fraginfo(const struct __ctx_buff *ctx, __u8 *nexthdr, fragi
 	arg->fraginfo = 0;
 	arg->nexthdr = *nexthdr;
 
-	ret = ipv6_hdrlen_with_fraginfo_weak(ctx);
+	ret = ipv6_walk_exthdrs_weak(ctx, l3_off);
 	*nexthdr = arg->nexthdr;
-	*fraginfo = arg->fraginfo;
+	if (fraginfo)
+		*fraginfo = arg->fraginfo;
 
 	return ret;
+}
+
+static __always_inline
+int ipv6_hdrlen_with_fraginfo(const struct __ctx_buff *ctx, __u8 *nexthdr, fraginfo_t *fraginfo)
+{
+	return ipv6_hdrlen_offset(ctx, ETH_HLEN, nexthdr, fraginfo);
 }
 
 static __always_inline int ipv6_hdrlen(const struct __ctx_buff *ctx, __u8 *nexthdr)

--- a/bpf/lib/ipv6.h
+++ b/bpf/lib/ipv6.h
@@ -208,7 +208,9 @@ void ipv6_sol_mc_mac_set(const union v6addr *addr, union macaddr *mac)
 	mac->addr[0] = 0x33;
 	mac->addr[1] = 0x33;
 	mac->addr[2] = 0xFF;
-	memcpy((__u8 *)mac + 3, (__u8 *)addr + 13, 3);
+	mac->addr[3] = addr->addr[13];
+	mac->addr[4] = addr->addr[14];
+	mac->addr[5] = addr->addr[15];
 }
 
 static __always_inline

--- a/bpf/lib/ipv6.h
+++ b/bpf/lib/ipv6.h
@@ -117,8 +117,9 @@ static __always_inline int ipv6_skip_exthdr(const struct __ctx_buff *ctx, __u8 *
 	}
 }
 
-static __always_inline int ipv6_hdrlen_offset(const struct __ctx_buff *ctx, int l3_off,
-					      __u8 *nexthdr, fraginfo_t *fraginfo)
+static __always_inline int
+ipv6_walk_exthdrs(const struct __ctx_buff *ctx, int l3_off, __u8 *nexthdr,
+		  fraginfo_t *fraginfo)
 {
 	int i, len = sizeof(struct ipv6hdr);
 	__u8 nh = *nexthdr;
@@ -168,12 +169,26 @@ int ipv6_hdrlen_with_fraginfo(const struct __ctx_buff *ctx, __u8 *nexthdr, fragi
 	if (!nexthdr)
 		return DROP_INVALID;
 
-	return ipv6_hdrlen_offset(ctx, ETH_HLEN, nexthdr, fraginfo);
+	return ipv6_walk_exthdrs(ctx, ETH_HLEN, nexthdr, fraginfo);
 }
 
-static __always_inline int ipv6_hdrlen(const struct __ctx_buff *ctx, __u8 *nexthdr)
+__noinline __weak
+int ipv6_hdrlen_offset(const struct __ctx_buff *ctx, int l3_off,
+		       __u8 *nexthdr, fraginfo_t *fraginfo)
 {
-	return ipv6_hdrlen_offset(ctx, ETH_HLEN, nexthdr, NULL);
+	if (!nexthdr)
+		return DROP_INVALID;
+
+	return ipv6_walk_exthdrs(ctx, l3_off, nexthdr, fraginfo);
+}
+
+__noinline __weak
+int ipv6_hdrlen(const struct __ctx_buff *ctx, __u8 *nexthdr)
+{
+	if (!nexthdr)
+		return DROP_INVALID;
+
+	return ipv6_walk_exthdrs(ctx, ETH_HLEN, nexthdr, NULL);
 }
 
 static __always_inline

--- a/bpf/lib/l2_responder.h
+++ b/bpf/lib/l2_responder.h
@@ -47,11 +47,11 @@ DECLARE_CONFIG(__u64, l2_announcements_max_liveness,
 static __always_inline
 int handle_l2_announcement(struct __ctx_buff *ctx, struct ipv6hdr *ip6)
 {
+	union v6addr __maybe_unused tip6 __align_stack_8;
 	union macaddr mac = CONFIG(interface_mac);
 	union macaddr smac;
 	__be32 __maybe_unused sip;
 	__be32 __maybe_unused tip;
-	union v6addr __maybe_unused tip6;
 	struct l2_responder_stats *stats;
 	int ret;
 	__u64 time;
@@ -89,7 +89,7 @@ int handle_l2_announcement(struct __ctx_buff *ctx, struct ipv6hdr *ip6)
 		struct l2_responder_v6_key key6;
 		int l3_off;
 
-		if (!icmp6_ndisc_validate(ctx, ip6, &mac, &tip6))
+		if (!icmp6_ndisc_validate(ctx, ip6->nexthdr, &mac, &tip6))
 			return CTX_ACT_OK;
 
 		key6.ip6 = tip6;


### PR DESCRIPTION
e9cd917197d6 ("bpf: Make ipv6_hdrlen_with_fraginfo into global func") already converted one helper. Now also do the others.