### PR TITLE
bpf: extract L3/L4 rewrite+checksum helpers for sharing codebase

### DIFF
--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -52,6 +52,27 @@ ipv4_csum_update_by_diff(struct __ctx_buff *ctx, int l3_off, __u64 diff)
 			       0, (__u32)diff, 0);
 }
 
+/**
+ * Rewrite the L3 address at addr_off and amend the L3 checksum accordingly.
+ * @arg sum: set to the checksum diff of the change, for the caller to fold
+ *      into any paired L4 pseudo-header checksum update.
+ *
+ * Return 0 on success or a negative DROP_* reason
+ */
+static __always_inline int
+ipv4_l3_rewrite_addr(struct __ctx_buff *ctx, int l3_off, __u16 addr_off,
+		     __be32 old_addr, __be32 new_addr, __wsum *sum)
+{
+	*sum = csum_diff(&old_addr, 4, &new_addr, 4, 0);
+	if (ctx_store_bytes(ctx, l3_off + addr_off, &new_addr, 4, 0) < 0)
+		return DROP_WRITE_ERROR;
+
+	if (ipv4_csum_update_by_diff(ctx, l3_off, *sum) < 0)
+		return DROP_CSUM_L3;
+
+	return 0;
+}
+
 static __always_inline int ipv4_load_daddr(const struct __ctx_buff *ctx, int off,
 					   __u32 *dst)
 {

--- a/bpf/lib/ipv6.h
+++ b/bpf/lib/ipv6.h
@@ -305,6 +305,25 @@ ipv6_store_daddr(struct __ctx_buff *ctx, const __u8 *addr, int off)
 	return ctx_store_bytes(ctx, off + offsetof(struct ipv6hdr, daddr), addr, 16, 0);
 }
 
+/**
+ * Rewrite the L3 address at addr_off (IPv6 has no L3 checksum to amend).
+ * @arg sum: set to the checksum diff of the change, for the caller to fold
+ *      into any paired L4 pseudo-header checksum update.
+ *
+ * Return 0 on success or a negative DROP_* reason
+ */
+static __always_inline int
+ipv6_l3_rewrite_addr(struct __ctx_buff *ctx, int l3_off, __u16 addr_off,
+		     const union v6addr *old_addr, const union v6addr *new_addr,
+		     __wsum *sum)
+{
+	*sum = csum_diff(old_addr, 16, new_addr, 16, 0);
+	if (ctx_store_bytes(ctx, l3_off + addr_off, new_addr, 16, 0) < 0)
+		return DROP_WRITE_ERROR;
+
+	return 0;
+}
+
 static __always_inline int ipv6_load_nexthdr(const struct __ctx_buff *ctx, int off,
 					     __u8 *nexthdr)
 {

--- a/bpf/lib/l4.h
+++ b/bpf/lib/l4.h
@@ -5,6 +5,7 @@
 
 #include <linux/tcp.h>
 #include <linux/udp.h>
+#include <linux/icmp.h>
 #include "common.h"
 #include "dbg.h"
 #include "csum.h"
@@ -67,6 +68,79 @@ static __always_inline int l4_modify_port(struct __ctx_buff *ctx, int l4_off,
 
 	if (csum_l4_replace(ctx, l4_off, csum_off, old_port, port, sizeof(port)) < 0)
 		return DROP_CSUM_L4;
+
+	return 0;
+}
+
+/**
+ * Rewrite the L4 port (if changed) and amend the L4 checksum for both the
+ * port change and a paired L3 address change already applied by the caller,
+ * folding in an extra checksum diff for the embedded packet of an ICMP error.
+ * @arg ctx:      packet
+ * @arg nexthdr:  L4 protocol
+ * @arg l4_off:   offset to L4 header
+ * @arg port_off: offset from L4 header to source or destination port
+ * @arg old_port: old port value (for checksum correction), 0 if unused
+ * @arg new_port: new port value, equal to old_port if unused
+ * @arg l3_sum:   checksum diff of the paired L3 address change, 0 if none
+ * @arg l4_csum_diff_from_inner: extra L4 checksum diff to apply (for ICMP
+ *      error messages), 0 if none
+ *
+ * Return 0 on success or a negative DROP_* reason
+ */
+static __always_inline int
+l4_rewrite_port_and_csum(struct __ctx_buff *ctx, __u8 nexthdr, int l4_off, int port_off,
+			 __be16 old_port, __be16 new_port, __wsum l3_sum,
+			 __wsum l4_csum_diff_from_inner)
+{
+	struct csum_offset csum = {};
+	int err;
+
+	csum_l4_offset_and_flags(nexthdr, &csum);
+
+	if (old_port != new_port) {
+		switch (nexthdr) {
+		case IPPROTO_TCP:
+		case IPPROTO_UDP:
+		case IPPROTO_ICMPV6:
+			break;
+#ifdef ENABLE_SCTP
+		case IPPROTO_SCTP:
+			return DROP_CSUM_L4;
+#endif  /* ENABLE_SCTP */
+		case IPPROTO_ICMP:
+			/* Not initialized by csum_l4_offset_and_flags(), because ICMPv4
+			 * doesn't use a pseudo-header, and the change in IP addresses is
+			 * not supposed to change the L4 checksum.
+			 * Set it temporarily to amend the checksum after changing ports.
+			 */
+			csum.offset = offsetof(struct icmphdr, checksum);
+			break;
+		default:
+			return DROP_UNKNOWN_L4;
+		}
+
+		/* Amend the L4 checksum due to changing the ports. */
+		err = l4_modify_port(ctx, l4_off, port_off, &csum, new_port, old_port);
+		if (err < 0)
+			return err;
+
+		/* Restore the original offset. */
+		if (nexthdr == IPPROTO_ICMP)
+			csum.offset = 0;
+	}
+
+	/* Amend the L4 checksum due to changing the addresses. */
+	if (csum.offset &&
+	    csum_l4_replace(ctx, l4_off, &csum, 0, l3_sum, BPF_F_PSEUDO_HDR) < 0)
+		return DROP_CSUM_L4;
+
+	/* Apply additional L4 checksum diff if provided (for ICMP error messages). */
+	if (l4_csum_diff_from_inner && !csum.offset) {
+		csum.offset = offsetof(struct icmphdr, checksum);
+		if (csum_l4_replace(ctx, l4_off, &csum, 0, l4_csum_diff_from_inner, 0) < 0)
+			return DROP_CSUM_L4;
+	}
 
 	return 0;
 }

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -529,13 +529,9 @@ snat_v4_rewrite_headers(struct __ctx_buff *ctx, __u8 nexthdr, int l3_off,
 	if (old_addr == new_addr && old_port == new_port && !l4_csum_diff_from_inner)
 		return 0;
 
-	sum = csum_diff(&old_addr, 4, &new_addr, 4, 0);
-	if (ctx_store_bytes(ctx, l3_off + addr_off, &new_addr, 4, 0) < 0)
-		return DROP_WRITE_ERROR;
-
-	/* Amend the L3 checksum due to changing the addresses. */
-	if (ipv4_csum_update_by_diff(ctx, l3_off, sum) < 0)
-		return DROP_CSUM_L3;
+	err = ipv4_l3_rewrite_addr(ctx, l3_off, addr_off, old_addr, new_addr, &sum);
+	if (err < 0)
+		return err;
 
 	if (has_l4_header) {
 		struct csum_offset csum = {};
@@ -1681,14 +1677,15 @@ snat_v6_rewrite_headers(struct __ctx_buff *ctx, __u8 nexthdr, int l3_off,
 {
 	struct csum_offset csum = {};
 	__wsum sum;
+	int err;
 
 	/* No change needed: */
 	if (ipv6_addr_equals(old_addr, new_addr) && old_port == new_port)
 		return 0;
 
-	sum = csum_diff(old_addr, 16, new_addr, 16, 0);
-	if (ctx_store_bytes(ctx, l3_off + addr_off, new_addr, 16, 0) < 0)
-		return DROP_WRITE_ERROR;
+	err = ipv6_l3_rewrite_addr(ctx, l3_off, addr_off, old_addr, new_addr, &sum);
+	if (err < 0)
+		return err;
 
 	if (!has_l4_header)
 		return 0;
@@ -1696,8 +1693,6 @@ snat_v6_rewrite_headers(struct __ctx_buff *ctx, __u8 nexthdr, int l3_off,
 	csum_l4_offset_and_flags(nexthdr, &csum);
 
 	if (old_port != new_port) {
-		int err;
-
 		switch (nexthdr) {
 		case IPPROTO_TCP:
 		case IPPROTO_UDP:

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -533,54 +533,10 @@ snat_v4_rewrite_headers(struct __ctx_buff *ctx, __u8 nexthdr, int l3_off,
 	if (err < 0)
 		return err;
 
-	if (has_l4_header) {
-		struct csum_offset csum = {};
-
-		csum_l4_offset_and_flags(nexthdr, &csum);
-
-		if (old_port != new_port) {
-			switch (nexthdr) {
-			case IPPROTO_TCP:
-			case IPPROTO_UDP:
-				break;
-#ifdef ENABLE_SCTP
-			case IPPROTO_SCTP:
-				return DROP_CSUM_L4;
-#endif  /* ENABLE_SCTP */
-			case IPPROTO_ICMP:
-				/* Not initialized by csum_l4_offset_and_flags(), because ICMPv4
-				 * doesn't use a pseudo-header, and the change in IP addresses is
-				 * not supposed to change the L4 checksum.
-				 * Set it temporarily to amend the checksum after changing ports.
-				 */
-				csum.offset = offsetof(struct icmphdr, checksum);
-				break;
-			default:
-				return DROP_UNKNOWN_L4;
-			}
-
-			/* Amend the L4 checksum due to changing the ports. */
-			err = l4_modify_port(ctx, l4_off, port_off, &csum, new_port, old_port);
-			if (err < 0)
-				return err;
-
-			/* Restore the original offset. */
-			if (nexthdr == IPPROTO_ICMP)
-				csum.offset = 0;
-		}
-
-		/* Amend the L4 checksum due to changing the addresses. */
-		if (csum.offset &&
-		    csum_l4_replace(ctx, l4_off, &csum, 0, sum, BPF_F_PSEUDO_HDR) < 0)
-			return DROP_CSUM_L4;
-
-		/* Apply additional L4 checksum diff if provided (for ICMP error messages). */
-		if (l4_csum_diff_from_inner && !csum.offset) {
-			csum.offset = offsetof(struct icmphdr, checksum);
-			if (csum_l4_replace(ctx, l4_off, &csum, 0, l4_csum_diff_from_inner, 0) < 0)
-				return DROP_CSUM_L4;
-		}
-	}
+	if (has_l4_header)
+		return l4_rewrite_port_and_csum(ctx, nexthdr, l4_off, port_off,
+						old_port, new_port, sum,
+						l4_csum_diff_from_inner);
 
 	return 0;
 }
@@ -1675,7 +1631,6 @@ snat_v6_rewrite_headers(struct __ctx_buff *ctx, __u8 nexthdr, int l3_off,
 			const union v6addr *new_addr, __u16 addr_off,
 			__be16 old_port, __be16 new_port, __u16 port_off)
 {
-	struct csum_offset csum = {};
 	__wsum sum;
 	int err;
 
@@ -1687,34 +1642,9 @@ snat_v6_rewrite_headers(struct __ctx_buff *ctx, __u8 nexthdr, int l3_off,
 	if (err < 0)
 		return err;
 
-	if (!has_l4_header)
-		return 0;
-
-	csum_l4_offset_and_flags(nexthdr, &csum);
-
-	if (old_port != new_port) {
-		switch (nexthdr) {
-		case IPPROTO_TCP:
-		case IPPROTO_UDP:
-		case IPPROTO_ICMPV6:
-			break;
-#ifdef ENABLE_SCTP
-		case IPPROTO_SCTP:
-			return DROP_CSUM_L4;
-#endif  /* ENABLE_SCTP */
-		default:
-			return DROP_UNKNOWN_L4;
-		}
-
-		/* Amend the L4 checksum due to changing the ports. */
-		err = l4_modify_port(ctx, l4_off, port_off, &csum, new_port, old_port);
-		if (err < 0)
-			return err;
-	}
-
-	if (csum.offset &&
-	    csum_l4_replace(ctx, l4_off, &csum, 0, sum, BPF_F_PSEUDO_HDR) < 0)
-		return DROP_CSUM_L4;
+	if (has_l4_header)
+		return l4_rewrite_port_and_csum(ctx, nexthdr, l4_off, port_off,
+						old_port, new_port, sum, 0);
 
 	return 0;
 }


### PR DESCRIPTION
Extract the address+checksum and port+checksum rewrite logic out of `snat_v4/v6_rewrite_headers()` so the upcoming RevDNAT-of-ICMP-Error work can reuse it instead of duplicating it. 
https://github.com/cilium/cilium/issues/32029
https://github.com/cilium/cilium/pull/46939

**No functional change**.

