### PR TITLE
bpf: stop dropping MLD and router solicitation sent from pods

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1103,6 +1103,9 @@ static __always_inline int __tail_handle_ipv6(struct __ctx_buff *ctx,
 	if (unlikely(is_icmp6_ndp(ctx, ip6, ETH_HLEN)))
 		return icmp6_ndp_handle(ctx, ETH_HLEN, METRIC_EGRESS, ext_err);
 
+	if (unlikely(is_icmp6_link_local_ctrl(ctx, ip6, ETH_HLEN)))
+		return CTX_ACT_OK;
+
 #ifdef ENABLE_L7_LB
 	from_l7lb = ctx_load_meta(ctx, CB_FROM_HOST) == FROM_HOST_L7_LB;
 #endif

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1101,6 +1101,9 @@ static __always_inline int __tail_handle_ipv6(struct __ctx_buff *ctx,
 	if (unlikely(is_icmp6_ndp(ctx, ip6, ETH_HLEN)))
 		return icmp6_ndp_handle(ctx, ETH_HLEN, METRIC_EGRESS, ext_err);
 
+	if (unlikely(is_icmp6_link_local_ctrl(ctx, ip6, ETH_HLEN)))
+		return CTX_ACT_OK;
+
 #ifdef ENABLE_L7_LB
 	from_l7lb = ctx_load_meta(ctx, CB_FROM_HOST) == FROM_HOST_L7_LB;
 #endif

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -17,10 +17,16 @@
 #define ICMP6_ND_OPTS (sizeof(struct ipv6hdr) + sizeof(struct icmp6hdr) + sizeof(struct in6_addr))
 #define ICMP6_ND_OPT_LEN 8
 
+#define ICMP6_MLD_QUERY_MSG_TYPE	130
+#define ICMP6_MLD_REPORT_MSG_TYPE	131
+#define ICMP6_MLD_DONE_MSG_TYPE		132
+#define ICMP6_RS_MSG_TYPE		133
+#define ICMP6_RA_MSG_TYPE		134
 #define ICMP6_NS_MSG_TYPE		135
 #define ICMP6_NA_MSG_TYPE		136
 #define ICMP6_RR_MSG_TYPE		138
 #define ICMP6_INV_NS_MSG_TYPE		141
+#define ICMP6_MLD2_REPORT_MSG_TYPE	143
 #define ICMP6_SEND_NS_MSG_TYPE		148
 #define ICMP6_SEND_NA_MSG_TYPE		149
 #define ICMP6_MULT_RT_MSG_TYPE		153
@@ -442,6 +448,56 @@ is_icmp6_ndp(struct __ctx_buff *ctx, const struct ipv6hdr *ip6, int nh_off)
 		return false;
 
 	return (type == ICMP6_NS_MSG_TYPE || type == ICMP6_NA_MSG_TYPE);
+}
+
+static __always_inline bool
+is_icmp6_link_local_ctrl(struct __ctx_buff *ctx, const struct ipv6hdr *ip6,
+			 int nh_off)
+{
+	const union v6addr ll_net = { .addr = { 0xfe, 0x80 } };
+	const union v6addr ll_mask = { .addr = { 0xff, 0xc0 } };
+	const union v6addr mc_net = { .addr = { 0xff, 0x02 } };
+	const union v6addr mc_mask = { .addr = { 0xff, 0xff } };
+	const union v6addr *saddr = (const union v6addr *)&ip6->saddr;
+	const union v6addr *daddr = (const union v6addr *)&ip6->daddr;
+	int l4_off = nh_off + sizeof(struct ipv6hdr);
+	__u8 nexthdr = ip6->nexthdr;
+	__u8 type;
+
+	if (nexthdr == NEXTHDR_HOP) {
+		struct ipv6_opt_hdr opt __align_stack_8;
+
+		if (ctx_load_bytes(ctx, l4_off, &opt, sizeof(opt)) < 0)
+			return false;
+
+		nexthdr = opt.nexthdr;
+		l4_off += ipv6_optlen(&opt);
+	}
+
+	if (nexthdr != IPPROTO_ICMPV6)
+		return false;
+
+	if (icmp6_load_type(ctx, l4_off, &type) < 0)
+		return false;
+
+	switch (type) {
+	case ICMP6_MLD_QUERY_MSG_TYPE:
+	case ICMP6_MLD_REPORT_MSG_TYPE:
+	case ICMP6_MLD_DONE_MSG_TYPE:
+	case ICMP6_RS_MSG_TYPE:
+	case ICMP6_MLD2_REPORT_MSG_TYPE:
+		break;
+	default:
+		return false;
+	}
+
+	if (!ipv6_addr_in_net(daddr, &mc_net, &mc_mask))
+		return false;
+
+	if (!(saddr->d1 | saddr->d2))
+		return true;
+
+	return ipv6_addr_in_net(saddr, &ll_net, &ll_mask);
 }
 
 static __always_inline int icmp6_ndp_handle(struct __ctx_buff *ctx, int nh_off,

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -17,10 +17,16 @@
 #define ICMP6_ND_OPTS (sizeof(struct ipv6hdr) + sizeof(struct icmp6hdr) + sizeof(struct in6_addr))
 #define ICMP6_ND_OPT_LEN 8
 
+#define ICMP6_MLD_QUERY_MSG_TYPE	130
+#define ICMP6_MLD_REPORT_MSG_TYPE	131
+#define ICMP6_MLD_DONE_MSG_TYPE		132
+#define ICMP6_RS_MSG_TYPE		133
+#define ICMP6_RA_MSG_TYPE		134
 #define ICMP6_NS_MSG_TYPE		135
 #define ICMP6_NA_MSG_TYPE		136
 #define ICMP6_RR_MSG_TYPE		138
 #define ICMP6_INV_NS_MSG_TYPE		141
+#define ICMP6_MLD2_REPORT_MSG_TYPE	143
 #define ICMP6_SEND_NS_MSG_TYPE		148
 #define ICMP6_SEND_NA_MSG_TYPE		149
 #define ICMP6_MULT_RT_MSG_TYPE		153
@@ -442,6 +448,44 @@ is_icmp6_ndp(struct __ctx_buff *ctx, const struct ipv6hdr *ip6, int nh_off)
 		return false;
 
 	return (type == ICMP6_NS_MSG_TYPE || type == ICMP6_NA_MSG_TYPE);
+}
+
+static __always_inline bool
+is_icmp6_link_local_ctrl(struct __ctx_buff *ctx, const struct ipv6hdr *ip6,
+			 int nh_off)
+{
+	const union v6addr ll_net = { .addr = { 0xfe, 0x80 } };
+	const union v6addr ll_mask = { .addr = { 0xff, 0xc0 } };
+	const union v6addr mc_net = { .addr = { 0xff, 0x02 } };
+	const union v6addr mc_mask = { .addr = { 0xff, 0xff } };
+	const union v6addr *saddr = (const union v6addr *)&ip6->saddr;
+	const union v6addr *daddr = (const union v6addr *)&ip6->daddr;
+	__u8 type;
+
+	if (ip6->nexthdr != IPPROTO_ICMPV6)
+		return false;
+
+	if (icmp6_load_type(ctx, nh_off + sizeof(struct ipv6hdr), &type) < 0)
+		return false;
+
+	switch (type) {
+	case ICMP6_MLD_QUERY_MSG_TYPE:
+	case ICMP6_MLD_REPORT_MSG_TYPE:
+	case ICMP6_MLD_DONE_MSG_TYPE:
+	case ICMP6_RS_MSG_TYPE:
+	case ICMP6_MLD2_REPORT_MSG_TYPE:
+		break;
+	default:
+		return false;
+	}
+
+	if (!ipv6_addr_in_net(daddr, &mc_net, &mc_mask))
+		return false;
+
+	if (!(saddr->d1 | saddr->d2))
+		return true;
+
+	return ipv6_addr_in_net(saddr, &ll_net, &ll_mask);
 }
 
 static __always_inline int icmp6_ndp_handle(struct __ctx_buff *ctx, int nh_off,

--- a/bpf/tests/lxc_icmp6_link_local.c
+++ b/bpf/tests/lxc_icmp6_link_local.c
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ENABLE_IPV6
+#define ENABLE_SIP_VERIFICATION
+
+#define CLIENT_IP		v6_pod_one_addr
+/* Link-local address the kernel assigns to the pod interface. */
+#define CLIENT_LL_IP		{0xfe, 0x80, 0, 0, 0, 0, 0, 0, \
+				 0x1c, 0x05, 0xa0, 0xff, 0xfe, 0xe1, 0xf9, 0xa6}
+#define SERVER_IP		v6_pod_two_addr
+#define ALL_ROUTERS_IP		{0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x02}
+#define ALL_MLDV2_ROUTERS_IP	{0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x16}
+
+static volatile const __u8 *client_mac = mac_one;
+static volatile const __u8 *gw_mac = mac_two;
+
+#include "lib/bpf_lxc.h"
+
+ASSIGN_CONFIG(union v6addr, endpoint_ipv6, { .addr = CLIENT_IP })
+
+#include "lib/endpoint.h"
+#include "lib/ipcache.h"
+#include "lib/policy.h"
+
+static __always_inline int
+build_icmp6(struct __ctx_buff *ctx, __u8 *saddr, __u8 *daddr, __u8 type)
+{
+	struct pktgen builder;
+	struct icmp6hdr *l4;
+
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv6_icmp6_packet(&builder,
+					    (__u8 *)client_mac, (__u8 *)gw_mac,
+					    saddr, daddr, type);
+	if (!l4)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+/* Give the pod everything it needs to have its traffic forwarded, so that a
+ * packet only gets dropped if it fails the source IP check.
+ */
+static __always_inline int
+send_from_pod(struct __ctx_buff *ctx)
+{
+	union v6addr client_ip = { .addr = CLIENT_IP };
+
+	policy_add_egress_allow_all_entry();
+	endpoint_v6_add_entry(&client_ip, 0, LXC_ID, 0, 0,
+			      (__u8 *)client_mac, (__u8 *)client_mac);
+	ipcache_v6_add_entry(&client_ip, 0, LXC_ID, 0, 0);
+	ipcache_v6_add_world_entry();
+
+	set_identity_mark(ctx, LXC_ID, MARK_MAGIC_IDENTITY);
+
+	return pod_send_packet(ctx);
+}
+
+static __always_inline int
+read_status_code(const struct __ctx_buff *ctx, __u32 *status_code)
+{
+	void *data = (void *)(long)ctx_data(ctx);
+	void *data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		return -1;
+
+	*status_code = *(__u32 *)data;
+
+	return 0;
+}
+
+static __always_inline void
+clean_up(void)
+{
+	union v6addr client_ip = { .addr = CLIENT_IP };
+
+	endpoint_v6_del_entry(&client_ip);
+	policy_delete_egress_all_entry();
+}
+
+/* Router solicitation from the link-local address to ff02::2. */
+PKTGEN("tc", "lxc_icmp6_ll_router_solicitation")
+int lxc_icmp6_ll_router_solicitation_pktgen(struct __ctx_buff *ctx)
+{
+	__u8 saddr[] = CLIENT_LL_IP;
+	__u8 daddr[] = ALL_ROUTERS_IP;
+
+	return build_icmp6(ctx, saddr, daddr, ICMP6_RS_MSG_TYPE);
+}
+
+SETUP("tc", "lxc_icmp6_ll_router_solicitation")
+int lxc_icmp6_ll_router_solicitation_setup(struct __ctx_buff *ctx)
+{
+	return send_from_pod(ctx);
+}
+
+CHECK("tc", "lxc_icmp6_ll_router_solicitation")
+int lxc_icmp6_ll_router_solicitation_check(const struct __ctx_buff *ctx)
+{
+	__u32 status_code;
+
+	test_init();
+
+	if (read_status_code(ctx, &status_code))
+		test_fatal("status code out of bounds");
+
+	assert(status_code == CTX_ACT_OK);
+
+	clean_up();
+
+	test_finish();
+}
+
+/* MLDv2 report from the link-local address, which the kernel sends on its
+ * own every few seconds.
+ */
+PKTGEN("tc", "lxc_icmp6_ll_mld_report")
+int lxc_icmp6_ll_mld_report_pktgen(struct __ctx_buff *ctx)
+{
+	__u8 saddr[] = CLIENT_LL_IP;
+	__u8 daddr[] = ALL_MLDV2_ROUTERS_IP;
+
+	return build_icmp6(ctx, saddr, daddr, ICMP6_MLD2_REPORT_MSG_TYPE);
+}
+
+SETUP("tc", "lxc_icmp6_ll_mld_report")
+int lxc_icmp6_ll_mld_report_setup(struct __ctx_buff *ctx)
+{
+	return send_from_pod(ctx);
+}
+
+CHECK("tc", "lxc_icmp6_ll_mld_report")
+int lxc_icmp6_ll_mld_report_check(const struct __ctx_buff *ctx)
+{
+	__u32 status_code;
+
+	test_init();
+
+	if (read_status_code(ctx, &status_code))
+		test_fatal("status code out of bounds");
+
+	assert(status_code == CTX_ACT_OK);
+
+	clean_up();
+
+	test_finish();
+}
+
+/* Same report, sent while the link-local address is still tentative. */
+PKTGEN("tc", "lxc_icmp6_unspec_mld_report")
+int lxc_icmp6_unspec_mld_report_pktgen(struct __ctx_buff *ctx)
+{
+	__u8 saddr[] = v6_all_addr;
+	__u8 daddr[] = ALL_MLDV2_ROUTERS_IP;
+
+	return build_icmp6(ctx, saddr, daddr, ICMP6_MLD2_REPORT_MSG_TYPE);
+}
+
+SETUP("tc", "lxc_icmp6_unspec_mld_report")
+int lxc_icmp6_unspec_mld_report_setup(struct __ctx_buff *ctx)
+{
+	return send_from_pod(ctx);
+}
+
+CHECK("tc", "lxc_icmp6_unspec_mld_report")
+int lxc_icmp6_unspec_mld_report_check(const struct __ctx_buff *ctx)
+{
+	__u32 status_code;
+
+	test_init();
+
+	if (read_status_code(ctx, &status_code))
+		test_fatal("status code out of bounds");
+
+	assert(status_code == CTX_ACT_OK);
+
+	clean_up();
+
+	test_finish();
+}
+
+/* An echo request gets no exemption, even from the link-local address. */
+PKTGEN("tc", "lxc_icmp6_ll_echo_request")
+int lxc_icmp6_ll_echo_request_pktgen(struct __ctx_buff *ctx)
+{
+	__u8 saddr[] = CLIENT_LL_IP;
+	__u8 daddr[] = ALL_ROUTERS_IP;
+
+	return build_icmp6(ctx, saddr, daddr, ICMPV6_ECHO_REQUEST);
+}
+
+SETUP("tc", "lxc_icmp6_ll_echo_request")
+int lxc_icmp6_ll_echo_request_setup(struct __ctx_buff *ctx)
+{
+	return send_from_pod(ctx);
+}
+
+CHECK("tc", "lxc_icmp6_ll_echo_request")
+int lxc_icmp6_ll_echo_request_check(const struct __ctx_buff *ctx)
+{
+	__u32 status_code;
+
+	test_init();
+
+	if (read_status_code(ctx, &status_code))
+		test_fatal("status code out of bounds");
+
+	assert(status_code == CTX_ACT_DROP);
+
+	clean_up();
+
+	test_finish();
+}
+
+/* Neither does a router solicitation aimed at a pod address. */
+PKTGEN("tc", "lxc_icmp6_ll_unicast_router_solicitation")
+int lxc_icmp6_ll_unicast_router_solicitation_pktgen(struct __ctx_buff *ctx)
+{
+	__u8 saddr[] = CLIENT_LL_IP;
+	__u8 daddr[] = SERVER_IP;
+
+	return build_icmp6(ctx, saddr, daddr, ICMP6_RS_MSG_TYPE);
+}
+
+SETUP("tc", "lxc_icmp6_ll_unicast_router_solicitation")
+int lxc_icmp6_ll_unicast_router_solicitation_setup(struct __ctx_buff *ctx)
+{
+	return send_from_pod(ctx);
+}
+
+CHECK("tc", "lxc_icmp6_ll_unicast_router_solicitation")
+int lxc_icmp6_ll_unicast_router_solicitation_check(const struct __ctx_buff *ctx)
+{
+	__u32 status_code;
+
+	test_init();
+
+	if (read_status_code(ctx, &status_code))
+		test_fatal("status code out of bounds");
+
+	assert(status_code == CTX_ACT_DROP);
+
+	clean_up();
+
+	test_finish();
+}
+
+/* A pod sending a router advertisement is pretending to be a router, so the
+ * packet stays dropped.
+ */
+PKTGEN("tc", "lxc_icmp6_ll_router_advertisement")
+int lxc_icmp6_ll_router_advertisement_pktgen(struct __ctx_buff *ctx)
+{
+	__u8 saddr[] = CLIENT_LL_IP;
+	__u8 daddr[] = ALL_ROUTERS_IP;
+
+	return build_icmp6(ctx, saddr, daddr, ICMP6_RA_MSG_TYPE);
+}
+
+SETUP("tc", "lxc_icmp6_ll_router_advertisement")
+int lxc_icmp6_ll_router_advertisement_setup(struct __ctx_buff *ctx)
+{
+	return send_from_pod(ctx);
+}
+
+CHECK("tc", "lxc_icmp6_ll_router_advertisement")
+int lxc_icmp6_ll_router_advertisement_check(const struct __ctx_buff *ctx)
+{
+	__u32 status_code;
+
+	test_init();
+
+	if (read_status_code(ctx, &status_code))
+		test_fatal("status code out of bounds");
+
+	assert(status_code == CTX_ACT_DROP);
+
+	clean_up();
+
+	test_finish();
+}

--- a/bpf/tests/lxc_icmp6_link_local.c
+++ b/bpf/tests/lxc_icmp6_link_local.c
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include <bpf/ctx/skb.h>
+#include "common.h"
+#include "pktgen.h"
+
+/* Enable code paths under test */
+#define ENABLE_IPV6
+#define ENABLE_SIP_VERIFICATION
+
+#define CLIENT_IP		v6_pod_one_addr
+/* Link-local address the kernel assigns to the pod interface. */
+#define CLIENT_LL_IP		{0xfe, 0x80, 0, 0, 0, 0, 0, 0, \
+				 0x1c, 0x05, 0xa0, 0xff, 0xfe, 0xe1, 0xf9, 0xa6}
+#define SERVER_IP		v6_pod_two_addr
+#define ALL_ROUTERS_IP		{0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x02}
+#define ALL_MLDV2_ROUTERS_IP	{0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x16}
+
+static volatile const __u8 *client_mac = mac_one;
+static volatile const __u8 *gw_mac = mac_two;
+
+#include "lib/bpf_lxc.h"
+
+ASSIGN_CONFIG(union v6addr, endpoint_ipv6, { .addr = CLIENT_IP })
+
+#include "lib/endpoint.h"
+#include "lib/ipcache.h"
+#include "lib/policy.h"
+
+/* The kernel sends MLD messages with a hop by hop options header that carries
+ * the router alert option, so the ICMPv6 header does not directly follow the
+ * IPv6 header. Build that layout when with_router_alert is set.
+ */
+static __always_inline int
+build_icmp6(struct __ctx_buff *ctx, __u8 *saddr, __u8 *daddr, __u8 type,
+	    bool with_router_alert)
+{
+	struct pktgen builder;
+	struct icmp6hdr *l4;
+
+	pktgen__init(&builder, ctx);
+
+	if (!pktgen__push_ipv6_packet(&builder,
+				      (__u8 *)client_mac, (__u8 *)gw_mac,
+				      saddr, daddr))
+		return TEST_ERROR;
+
+	if (with_router_alert &&
+	    !pktgen__append_ipv6_extension_header(&builder, NEXTHDR_HOP, 0))
+		return TEST_ERROR;
+
+	l4 = pktgen__push_icmp6hdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->icmp6_type = type;
+	l4->icmp6_code = 0;
+	l4->icmp6_cksum = 0;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+/* Give the pod everything it needs to have its traffic forwarded, so that a
+ * packet only gets dropped if it fails the source IP check.
+ */
+static __always_inline int
+send_from_pod(struct __ctx_buff *ctx)
+{
+	union v6addr client_ip = { .addr = CLIENT_IP };
+
+	policy_add_egress_allow_all_entry();
+	endpoint_v6_add_entry(&client_ip, 0, LXC_ID, 0, 0,
+			      (__u8 *)client_mac, (__u8 *)client_mac);
+	ipcache_v6_add_entry(&client_ip, 0, LXC_ID, 0, 0);
+	ipcache_v6_add_world_entry();
+
+	set_identity_mark(ctx, LXC_ID, MARK_MAGIC_IDENTITY);
+
+	return pod_send_packet(ctx);
+}
+
+static __always_inline int
+read_status_code(const struct __ctx_buff *ctx, __u32 *status_code)
+{
+	void *data = (void *)(long)ctx_data(ctx);
+	void *data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		return -1;
+
+	*status_code = *(__u32 *)data;
+
+	return 0;
+}
+
+static __always_inline void
+clean_up(void)
+{
+	union v6addr client_ip = { .addr = CLIENT_IP };
+
+	endpoint_v6_del_entry(&client_ip);
+	policy_delete_egress_all_entry();
+}
+
+/* Router solicitation from the link-local address to ff02::2. */
+PKTGEN("tc", "lxc_icmp6_ll_router_solicitation")
+int lxc_icmp6_ll_router_solicitation_pktgen(struct __ctx_buff *ctx)
+{
+	__u8 saddr[] = CLIENT_LL_IP;
+	__u8 daddr[] = ALL_ROUTERS_IP;
+
+	return build_icmp6(ctx, saddr, daddr, ICMP6_RS_MSG_TYPE, false);
+}
+
+SETUP("tc", "lxc_icmp6_ll_router_solicitation")
+int lxc_icmp6_ll_router_solicitation_setup(struct __ctx_buff *ctx)
+{
+	return send_from_pod(ctx);
+}
+
+CHECK("tc", "lxc_icmp6_ll_router_solicitation")
+int lxc_icmp6_ll_router_solicitation_check(const struct __ctx_buff *ctx)
+{
+	__u32 status_code;
+
+	test_init();
+
+	if (read_status_code(ctx, &status_code))
+		test_fatal("status code out of bounds");
+
+	assert(status_code == CTX_ACT_OK);
+
+	clean_up();
+
+	test_finish();
+}
+
+/* MLDv2 report from the link-local address, which the kernel sends on its
+ * own every few seconds. It carries a router alert hop by hop header.
+ */
+PKTGEN("tc", "lxc_icmp6_ll_mld_report")
+int lxc_icmp6_ll_mld_report_pktgen(struct __ctx_buff *ctx)
+{
+	__u8 saddr[] = CLIENT_LL_IP;
+	__u8 daddr[] = ALL_MLDV2_ROUTERS_IP;
+
+	return build_icmp6(ctx, saddr, daddr, ICMP6_MLD2_REPORT_MSG_TYPE, true);
+}
+
+SETUP("tc", "lxc_icmp6_ll_mld_report")
+int lxc_icmp6_ll_mld_report_setup(struct __ctx_buff *ctx)
+{
+	return send_from_pod(ctx);
+}
+
+CHECK("tc", "lxc_icmp6_ll_mld_report")
+int lxc_icmp6_ll_mld_report_check(const struct __ctx_buff *ctx)
+{
+	__u32 status_code;
+
+	test_init();
+
+	if (read_status_code(ctx, &status_code))
+		test_fatal("status code out of bounds");
+
+	assert(status_code == CTX_ACT_OK);
+
+	clean_up();
+
+	test_finish();
+}
+
+/* Same report, sent while the link-local address is still tentative. */
+PKTGEN("tc", "lxc_icmp6_unspec_mld_report")
+int lxc_icmp6_unspec_mld_report_pktgen(struct __ctx_buff *ctx)
+{
+	__u8 saddr[] = v6_all_addr;
+	__u8 daddr[] = ALL_MLDV2_ROUTERS_IP;
+
+	return build_icmp6(ctx, saddr, daddr, ICMP6_MLD2_REPORT_MSG_TYPE, true);
+}
+
+SETUP("tc", "lxc_icmp6_unspec_mld_report")
+int lxc_icmp6_unspec_mld_report_setup(struct __ctx_buff *ctx)
+{
+	return send_from_pod(ctx);
+}
+
+CHECK("tc", "lxc_icmp6_unspec_mld_report")
+int lxc_icmp6_unspec_mld_report_check(const struct __ctx_buff *ctx)
+{
+	__u32 status_code;
+
+	test_init();
+
+	if (read_status_code(ctx, &status_code))
+		test_fatal("status code out of bounds");
+
+	assert(status_code == CTX_ACT_OK);
+
+	clean_up();
+
+	test_finish();
+}
+
+/* An echo request gets no exemption, even from the link-local address. */
+PKTGEN("tc", "lxc_icmp6_ll_echo_request")
+int lxc_icmp6_ll_echo_request_pktgen(struct __ctx_buff *ctx)
+{
+	__u8 saddr[] = CLIENT_LL_IP;
+	__u8 daddr[] = ALL_ROUTERS_IP;
+
+	return build_icmp6(ctx, saddr, daddr, ICMPV6_ECHO_REQUEST, false);
+}
+
+SETUP("tc", "lxc_icmp6_ll_echo_request")
+int lxc_icmp6_ll_echo_request_setup(struct __ctx_buff *ctx)
+{
+	return send_from_pod(ctx);
+}
+
+CHECK("tc", "lxc_icmp6_ll_echo_request")
+int lxc_icmp6_ll_echo_request_check(const struct __ctx_buff *ctx)
+{
+	__u32 status_code;
+
+	test_init();
+
+	if (read_status_code(ctx, &status_code))
+		test_fatal("status code out of bounds");
+
+	assert(status_code == CTX_ACT_DROP);
+
+	clean_up();
+
+	test_finish();
+}
+
+/* Neither does a router solicitation aimed at a pod address. */
+PKTGEN("tc", "lxc_icmp6_ll_unicast_router_solicitation")
+int lxc_icmp6_ll_unicast_router_solicitation_pktgen(struct __ctx_buff *ctx)
+{
+	__u8 saddr[] = CLIENT_LL_IP;
+	__u8 daddr[] = SERVER_IP;
+
+	return build_icmp6(ctx, saddr, daddr, ICMP6_RS_MSG_TYPE, false);
+}
+
+SETUP("tc", "lxc_icmp6_ll_unicast_router_solicitation")
+int lxc_icmp6_ll_unicast_router_solicitation_setup(struct __ctx_buff *ctx)
+{
+	return send_from_pod(ctx);
+}
+
+CHECK("tc", "lxc_icmp6_ll_unicast_router_solicitation")
+int lxc_icmp6_ll_unicast_router_solicitation_check(const struct __ctx_buff *ctx)
+{
+	__u32 status_code;
+
+	test_init();
+
+	if (read_status_code(ctx, &status_code))
+		test_fatal("status code out of bounds");
+
+	assert(status_code == CTX_ACT_DROP);
+
+	clean_up();
+
+	test_finish();
+}
+
+/* A pod sending a router advertisement is pretending to be a router, so the
+ * packet stays dropped.
+ */
+PKTGEN("tc", "lxc_icmp6_ll_router_advertisement")
+int lxc_icmp6_ll_router_advertisement_pktgen(struct __ctx_buff *ctx)
+{
+	__u8 saddr[] = CLIENT_LL_IP;
+	__u8 daddr[] = ALL_ROUTERS_IP;
+
+	return build_icmp6(ctx, saddr, daddr, ICMP6_RA_MSG_TYPE, false);
+}
+
+SETUP("tc", "lxc_icmp6_ll_router_advertisement")
+int lxc_icmp6_ll_router_advertisement_setup(struct __ctx_buff *ctx)
+{
+	return send_from_pod(ctx);
+}
+
+CHECK("tc", "lxc_icmp6_ll_router_advertisement")
+int lxc_icmp6_ll_router_advertisement_check(const struct __ctx_buff *ctx)
+{
+	__u32 status_code;
+
+	test_init();
+
+	if (read_status_code(ctx, &status_code))
+		test_fatal("status code out of bounds");
+
+	assert(status_code == CTX_ACT_DROP);
+
+	clean_up();
+
+	test_finish();
+}


### PR DESCRIPTION
Pods keep showing up in Hubble as dropping their own ICMPv6 traffic with "Invalid source ip". The source is always the link local address that the kernel gives the pod interface, and the messages are the MLD reports and router solicitations that the kernel sends on its own.

The from container path lets neighbour solicitation and neighbour advertisement past the source IP check and nothing else, so all of this gets treated as spoofed. The packets are link scoped and cannot reach anything anyway, so nothing is actually broken, but the drop counters and flow logs make it look like the pod is misbehaving.

This change lets MLD and router solicitation through when the source is a link local or unspecified address and the destination is a link local scope multicast group. Those packets go to the stack instead of being routed anywhere. Router advertisement and redirect are deliberately left out, since a pod has no reason to send either one and both are useful to an attacker.

There is a new BPF unit test with six cases, three that should now pass and three that must stay dropped. I checked it works both ways by reverting each half of the change and watching only the matching tests fail.

Fixes: #47645

```release-note
Stop dropping MLD and router solicitation messages that pods send from their kernel assigned link local address when source IP verification is enabled
```

This PR was prepared with AIL:4. I reviewed the datapath change, and ran the BPF unit tests and checkpatch locally.
