### PR TITLE
ipcache/fake: use netip.Addr for node events

### DIFF
--- a/pkg/ipcache/fake/ipcache.go
+++ b/pkg/ipcache/fake/ipcache.go
@@ -5,6 +5,7 @@ package fake
 
 import (
 	"net"
+	"net/netip"
 
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/source"
@@ -17,7 +18,7 @@ const (
 
 type NodeEvent struct {
 	event string
-	ip    net.IP
+	ip    netip.Addr
 }
 
 type IPCache struct {
@@ -33,11 +34,13 @@ func NewIPCache(events bool) *IPCache {
 }
 
 func (i *IPCache) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) (bool, error) {
-	i.Events <- NodeEvent{EventUpsert, net.ParseIP(ip)}
+	addr, _ := netip.ParseAddr(ip)
+	i.Events <- NodeEvent{EventUpsert, addr}
 	return false, nil
 }
 
 func (i *IPCache) Delete(IP string, source source.Source) bool {
-	i.Events <- NodeEvent{EventDelete, net.ParseIP(IP)}
+	addr, _ := netip.ParseAddr(IP)
+	i.Events <- NodeEvent{EventDelete, addr}
 	return false
 }

--- a/pkg/ipcache/fake/ipcache_test.go
+++ b/pkg/ipcache/fake/ipcache_test.go
@@ -5,6 +5,7 @@ package fake
 
 import (
 	"net"
+	"net/netip"
 	"testing"
 	"time"
 
@@ -20,7 +21,7 @@ func TestFakeIPCache(t *testing.T) {
 	ipcacheMock.Upsert("1.1.1.1", net.ParseIP("2.2.2.2"), 0, nil, ipcache.Identity{ID: 1, Source: source.Local})
 	select {
 	case event := <-ipcacheMock.Events:
-		require.Equal(t, NodeEvent{EventUpsert, net.ParseIP("1.1.1.1")}, event)
+		require.Equal(t, NodeEvent{EventUpsert, netip.MustParseAddr("1.1.1.1")}, event)
 	case <-time.After(5 * time.Second):
 		t.Errorf("timeout while waiting for ipcache upsert for IP 1.1.1.1")
 	}
@@ -29,7 +30,7 @@ func TestFakeIPCache(t *testing.T) {
 
 	select {
 	case event := <-ipcacheMock.Events:
-		require.Equal(t, NodeEvent{EventDelete, net.ParseIP("1.1.1.1")}, event)
+		require.Equal(t, NodeEvent{EventDelete, netip.MustParseAddr("1.1.1.1")}, event)
 	case <-time.After(5 * time.Second):
 		t.Errorf("timeout while waiting for ipcache delete for IP 1.1.1.1")
 	}


### PR DESCRIPTION
## Summary

- Store fake IPCache node event addresses as `netip.Addr`.
- Parse the event address with `netip.ParseAddr` while retaining the existing `net.IP` IPCache interface boundary.

## Rationale

This is a small, non-overlapping migration slice for the ongoing `net.IP` to `netip.Addr` conversion.

Related: #24246

## Testing

- `go test ./pkg/ipcache/...`

```release-note
ipcache/fake: migrate fake IPCache node event addresses to netip.Addr
```
