### PR TITLE
gateway-api: simplify ingestion logic for allowed namespaces

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -357,7 +357,6 @@ func (r *gatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		GRPCRoutes:          grpcRoutes,
 		TCPRoutes:           tcpRoutes,
 		UDPRoutes:           udpRoutes,
-		Namespaces:          namespaces,
 		Services:            servicesList.Items,
 		ServiceImports:      serviceImportsList.Items,
 		ReferenceGrants:     grants.Items,
@@ -814,9 +813,10 @@ func (r *gatewayReconciler) mergeListeners(
 	var merged []ingestion.ListenerWithContext
 	for _, listener := range gw.Spec.Listeners {
 		merged = append(merged, ingestion.ListenerWithContext{
-			Listener:         listener,
-			Source:           gwSource,
-			SourceGeneration: gw.Generation,
+			Listener:          listener,
+			Source:            gwSource,
+			SourceGeneration:  gw.Generation,
+			AllowedNamespaces: resolveAllowedNamespaces(ctx, r.Client, gw.GetNamespace(), listener, scopedLog),
 		})
 	}
 

--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -141,7 +141,6 @@ type Input struct {
 	TCPRoutes           []gatewayv1.TCPRoute
 	UDPRoutes           []gatewayv1.UDPRoute
 	ReferenceGrants     []gatewayv1.ReferenceGrant
-	Namespaces          []corev1.Namespace
 	Services            []corev1.Service
 	ServiceImports      []mcsapiv1beta1.ServiceImport
 	BackendTLSPolicyMap helpers.BackendTLSPolicyServiceMap
@@ -177,26 +176,7 @@ func GatewayAPI(log *slog.Logger, input Input) *model.Model {
 		}
 	}
 
-	namespaceLabels := helpers.NewNamespaceLabelIndex(input.Namespaces)
 	listeners := input.MergedListeners
-	// When MergedListeners is not provided, build it from the direct
-	// Gateway-listeners
-	if listeners == nil {
-		gwSource := model.FullyQualifiedResource{
-			Name:      input.Gateway.GetName(),
-			Namespace: input.Gateway.GetNamespace(),
-			Group:     gatewayv1.GroupVersion.Group,
-			Version:   gatewayv1.GroupVersion.Version,
-			Kind:      "Gateway",
-			UID:       string(input.Gateway.GetUID()),
-		}
-		for _, l := range input.Gateway.Spec.Listeners {
-			listeners = append(listeners, ListenerWithContext{
-				Listener: l,
-				Source:   gwSource,
-			})
-		}
-	}
 
 	// Find all the listener host names, so that we can match them with the routes
 	// Gateway API spec guarantees that the hostnames are unique across all listeners
@@ -219,17 +199,8 @@ func GatewayAPI(log *slog.Logger, input Input) *model.Model {
 
 			var httpRoutes []model.HTTPRoute
 
-			// (ajs) Note well, we are using the existence of AllowedNamespace
-			// as a hint that this listener has already performed filtering for
-			// routes based on AllowedNamespaces. We need to refactor this type
-			// of assumption to not apply only to ListenerSets, and be a true
-			// invariant expected by this code path. That is, move all such
-			// validation out of the ingestion codepath and into a combined
-			// validate-and-record status phase of the reconcile pipeline.
-			namespacesPreFiltered := l.AllowedNamespaces != nil
-
-			httpRoutes = append(httpRoutes, toHTTPRoutes(log, l.Listener, l.Source.Namespace, namespaceLabels, namespacesPreFiltered, listenerHostnamesByProtocol, filteredHTTPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants, input.BackendTLSPolicyMap)...)
-			httpRoutes = append(httpRoutes, toGRPCRoutes(l.Listener, l.Source.Namespace, namespaceLabels, namespacesPreFiltered, listenerHostnamesByProtocol, filteredGRPCRoutes, input.Services, input.ServiceImports, input.ReferenceGrants)...)
+			httpRoutes = append(httpRoutes, toHTTPRoutes(log, l.Listener, listenerHostnamesByProtocol, filteredHTTPRoutes, input.Services, input.ServiceImports, input.ReferenceGrants, input.BackendTLSPolicyMap)...)
+			httpRoutes = append(httpRoutes, toGRPCRoutes(l.Listener, listenerHostnamesByProtocol, filteredGRPCRoutes, input.Services, input.ServiceImports, input.ReferenceGrants)...)
 			m.HTTP = append(m.HTTP, model.HTTPListener{
 				Name:                       string(l.Name),
 				Sources:                    []model.FullyQualifiedResource{l.Source},
@@ -248,32 +219,30 @@ func GatewayAPI(log *slog.Logger, input Input) *model.Model {
 					Sources:        []model.FullyQualifiedResource{l.Source},
 					Port:           uint32(l.Port),
 					Hostname:       toHostname(l.Hostname),
-					Routes:         toTLSRoutes(l.Listener, l.Source.Namespace, namespaceLabels, namespacesPreFiltered, listenerHostnamesByProtocol, l.FilterTLSRoutes(input.TLSRoutes), input.Services, input.ServiceImports, input.ReferenceGrants),
+					Routes:         toTLSRoutes(l.Listener, listenerHostnamesByProtocol, l.FilterTLSRoutes(input.TLSRoutes), input.Services, input.ServiceImports, input.ReferenceGrants),
 					Infrastructure: infra,
 					Service:        toServiceModel(input.GatewayClassConfig),
 				})
 			}
 
 		case gatewayv1.TCPProtocolType:
-			namespacesPreFiltered := l.AllowedNamespaces != nil
 			m.L4 = append(m.L4, model.L4Listener{
 				Name:           string(l.Name),
 				Sources:        []model.FullyQualifiedResource{l.Source},
 				Port:           uint32(l.Port),
 				Protocol:       model.L4ProtocolTCP,
-				Routes:         toTCPRoutes(l.Listener, l.Source.Namespace, namespaceLabels, namespacesPreFiltered, l.FilterTCPRoutes(input.TCPRoutes), input.Services, input.ServiceImports, input.ReferenceGrants),
+				Routes:         toTCPRoutes(l.Listener, l.FilterTCPRoutes(input.TCPRoutes), input.Services, input.ServiceImports, input.ReferenceGrants),
 				Infrastructure: infra,
 				Service:        toServiceModel(input.GatewayClassConfig),
 			})
 
 		case gatewayv1.UDPProtocolType:
-			namespacesPreFiltered := l.AllowedNamespaces != nil
 			m.L4 = append(m.L4, model.L4Listener{
 				Name:           string(l.Name),
 				Sources:        []model.FullyQualifiedResource{l.Source},
 				Port:           uint32(l.Port),
 				Protocol:       model.L4ProtocolUDP,
-				Routes:         toUDPRoutes(l.Listener, l.Source.Namespace, namespaceLabels, namespacesPreFiltered, l.FilterUDPRoutes(input.UDPRoutes), input.Services, input.ServiceImports, input.ReferenceGrants),
+				Routes:         toUDPRoutes(l.Listener, l.FilterUDPRoutes(input.UDPRoutes), input.Services, input.ServiceImports, input.ReferenceGrants),
 				Infrastructure: infra,
 				Service:        toServiceModel(input.GatewayClassConfig),
 			})
@@ -331,9 +300,6 @@ func getBackendServiceName(namespace string, services []corev1.Service, serviceI
 
 func toHTTPRoutes(log *slog.Logger,
 	listener gatewayv1.Listener,
-	gatewayNamespace string,
-	namespaceLabels helpers.NamespaceLabelIndex,
-	namespacesPreFiltered bool,
 	listenerHostnamesByProtocol map[gatewayv1.ProtocolType][]string,
 	input []gatewayv1.HTTPRoute,
 	services []corev1.Service,
@@ -344,10 +310,6 @@ func toHTTPRoutes(log *slog.Logger,
 	var httpRoutes []model.HTTPRoute
 	for _, r := range input {
 		if !parentRefsMatchListener(r.Spec.ParentRefs, listener) {
-			continue
-		}
-
-		if !namespacesPreFiltered && !helpers.IsListenerNamespaceAllowed(listener, r.GetNamespace(), gatewayNamespace, namespaceLabels) {
 			continue
 		}
 
@@ -757,9 +719,6 @@ func toHTTPRetry(retry *gatewayv1.HTTPRouteRetry) *model.HTTPRetry {
 }
 
 func toGRPCRoutes(listener gatewayv1beta1.Listener,
-	gatewayNamespace string,
-	namespaceLabels helpers.NamespaceLabelIndex,
-	namespacesPreFiltered bool,
 	listenerHostnamesByProtocol map[gatewayv1.ProtocolType][]string,
 	input []gatewayv1.GRPCRoute,
 	services []corev1.Service,
@@ -769,10 +728,6 @@ func toGRPCRoutes(listener gatewayv1beta1.Listener,
 	var grpcRoutes []model.HTTPRoute
 	for _, r := range input {
 		if !parentRefsMatchListener(r.Spec.ParentRefs, listener) {
-			continue
-		}
-
-		if !namespacesPreFiltered && !helpers.IsListenerNamespaceAllowed(listener, r.GetNamespace(), gatewayNamespace, namespaceLabels) {
 			continue
 		}
 
@@ -909,14 +864,10 @@ func extractGRPCRoutes(hostnames []string, grpcr gatewayv1.GRPCRoute, services [
 	return grpcRoutes
 }
 
-func toTLSRoutes(listener gatewayv1beta1.Listener, gatewayNamespace string, namespaceLabels helpers.NamespaceLabelIndex, namespacesPreFiltered bool, listenerHostnamesByProtocol map[gatewayv1.ProtocolType][]string, input []gatewayv1.TLSRoute, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1.ReferenceGrant) []model.TLSPassthroughRoute {
+func toTLSRoutes(listener gatewayv1beta1.Listener, listenerHostnamesByProtocol map[gatewayv1.ProtocolType][]string, input []gatewayv1.TLSRoute, services []corev1.Service, serviceImports []mcsapiv1beta1.ServiceImport, grants []gatewayv1.ReferenceGrant) []model.TLSPassthroughRoute {
 	var tlsRoutes []model.TLSPassthroughRoute
 	for _, r := range input {
 		if !parentRefsMatchListener(r.Spec.ParentRefs, listener) {
-			continue
-		}
-
-		if !namespacesPreFiltered && !helpers.IsListenerNamespaceAllowed(listener, r.GetNamespace(), gatewayNamespace, namespaceLabels) {
 			continue
 		}
 
@@ -997,9 +948,6 @@ func sortL4RoutesByAge[T any](routes []T, meta func(T) metav1.ObjectMeta) {
 }
 
 func toTCPRoutes(listener gatewayv1beta1.Listener,
-	gatewayNamespace string,
-	namespaceLabels helpers.NamespaceLabelIndex,
-	namespacesPreFiltered bool,
 	input []gatewayv1.TCPRoute,
 	services []corev1.Service,
 	serviceImports []mcsapiv1beta1.ServiceImport,
@@ -1013,9 +961,6 @@ func toTCPRoutes(listener gatewayv1beta1.Listener,
 	// Accepted=True (handled by the status reconciler) but route no traffic.
 	attached := make([]gatewayv1.TCPRoute, 0, len(input))
 	for _, r := range input {
-		if !namespacesPreFiltered && !helpers.IsListenerNamespaceAllowed(listener, r.GetNamespace(), gatewayNamespace, namespaceLabels) {
-			continue
-		}
 		if parentRefsMatchListener(r.Spec.ParentRefs, listener) {
 			attached = append(attached, r)
 		}
@@ -1061,9 +1006,6 @@ func toTCPRoutes(listener gatewayv1beta1.Listener,
 }
 
 func toUDPRoutes(listener gatewayv1beta1.Listener,
-	gatewayNamespace string,
-	namespaceLabels helpers.NamespaceLabelIndex,
-	namespacesPreFiltered bool,
 	input []gatewayv1.UDPRoute,
 	services []corev1.Service,
 	serviceImports []mcsapiv1beta1.ServiceImport,
@@ -1072,9 +1014,6 @@ func toUDPRoutes(listener gatewayv1beta1.Listener,
 	// Keep only the oldest attaching UDPRoute. See toTCPRoutes for the rationale.
 	attached := make([]gatewayv1.UDPRoute, 0, len(input))
 	for _, r := range input {
-		if !namespacesPreFiltered && !helpers.IsListenerNamespaceAllowed(listener, r.GetNamespace(), gatewayNamespace, namespaceLabels) {
-			continue
-		}
 		if parentRefsMatchListener(r.Spec.ParentRefs, listener) {
 			attached = append(attached, r)
 		}

--- a/operator/pkg/model/ingestion/gateway_test.go
+++ b/operator/pkg/model/ingestion/gateway_test.go
@@ -14,10 +14,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 
+	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
 	"github.com/cilium/cilium/operator/pkg/model"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 )
@@ -25,6 +27,48 @@ import (
 const (
 	basedGatewayTestdataDir = "testdata/gateway"
 )
+
+func setTestMergedListeners(input *Input, namespaces []corev1.Namespace) {
+	source := model.FullyQualifiedResource{
+		Name:      input.Gateway.GetName(),
+		Namespace: input.Gateway.GetNamespace(),
+		Group:     gatewayv1.GroupVersion.Group,
+		Version:   gatewayv1.GroupVersion.Version,
+		Kind:      "Gateway",
+		UID:       string(input.Gateway.GetUID()),
+	}
+
+	namespaceLabels := helpers.NewNamespaceLabelIndex(namespaces)
+
+	candidateNamespaces := sets.New[string](source.Namespace)
+	for _, namespace := range namespaces {
+		candidateNamespaces.Insert(namespace.GetName())
+	}
+
+	for _, listener := range input.Gateway.Spec.Listeners {
+		var allowedNamespaces map[string]struct{}
+		allowedRoutes := listener.AllowedRoutes
+
+		if allowedRoutes == nil || allowedRoutes.Namespaces == nil ||
+			allowedRoutes.Namespaces.From == nil ||
+			*allowedRoutes.Namespaces.From != gatewayv1.NamespacesFromAll {
+
+			allowedNamespaces = make(map[string]struct{})
+			for namespace := range candidateNamespaces {
+				if helpers.IsListenerNamespaceAllowed(listener, namespace, source.Namespace, namespaceLabels) {
+					allowedNamespaces[namespace] = struct{}{}
+				}
+			}
+
+		}
+
+		input.MergedListeners = append(input.MergedListeners, ListenerWithContext{
+			Listener:          listener,
+			Source:            source,
+			AllowedNamespaces: allowedNamespaces,
+		})
+	}
+}
 
 func TestHTTPGatewayAPI(t *testing.T) {
 	tests := map[string]struct{}{
@@ -120,8 +164,16 @@ func TestExtractRoutesSetsHTTPRouteRuleSource(t *testing.T) {
 func TestHTTPGatewayAPIFiltersSelectorNamespacesPerListener(t *testing.T) {
 	selector := gatewayv1.NamespacesFromSelector
 	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
+	namespaces := []corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "backend-a",
+				Labels: map[string]string{"expose": "true"},
+			},
+		},
+	}
 
-	m := GatewayAPI(logger, Input{
+	input := Input{
 		Gateway: gatewayv1.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "selector-listener-conflict-gateway",
@@ -194,14 +246,6 @@ func TestHTTPGatewayAPIFiltersSelectorNamespacesPerListener(t *testing.T) {
 				},
 			},
 		},
-		Namespaces: []corev1.Namespace{
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "backend-a",
-					Labels: map[string]string{"expose": "true"},
-				},
-			},
-		},
 		Services: []corev1.Service{
 			{
 				ObjectMeta: metav1.ObjectMeta{
@@ -213,7 +257,9 @@ func TestHTTPGatewayAPIFiltersSelectorNamespacesPerListener(t *testing.T) {
 				},
 			},
 		},
-	})
+	}
+	setTestMergedListeners(&input, namespaces)
+	m := GatewayAPI(logger, input)
 
 	require.Len(t, m.HTTP, 2)
 	require.Equal(t, "http-selected", m.HTTP[0].Name)
@@ -233,7 +279,7 @@ func TestHTTPAndGRPCGatewayAPIFiltersRoutesByListenerAllowedNamespaces(t *testin
 	grpcMethod := "Get"
 	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
 
-	m := GatewayAPI(logger, Input{
+	input := Input{
 		Gateway: gatewayv1.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "platform",
@@ -392,7 +438,9 @@ func TestHTTPAndGRPCGatewayAPIFiltersRoutesByListenerAllowedNamespaces(t *testin
 				},
 			},
 		},
-	})
+	}
+	setTestMergedListeners(&input, nil)
+	m := GatewayAPI(logger, input)
 
 	require.Len(t, m.HTTP, 2)
 	require.Equal(t, "http", m.HTTP[0].Name)
@@ -416,7 +464,7 @@ func TestTLSGatewayAPIFiltersRoutesByListenerAllowedNamespaces(t *testing.T) {
 	allNamespaces := gatewayv1.NamespacesFromAll
 	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
 
-	m := GatewayAPI(logger, Input{
+	input := Input{
 		Gateway: gatewayv1.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "platform",
@@ -495,7 +543,9 @@ func TestTLSGatewayAPIFiltersRoutesByListenerAllowedNamespaces(t *testing.T) {
 				},
 			},
 		},
-	})
+	}
+	setTestMergedListeners(&input, nil)
+	m := GatewayAPI(logger, input)
 
 	require.Len(t, m.TLSPassthrough, 2)
 	require.Equal(t, "tls-same", m.TLSPassthrough[0].Name)
@@ -683,7 +733,7 @@ func TestL4GatewayAPIFiltersRoutesByListenerAllowedNamespaces(t *testing.T) {
 	allNamespaces := gatewayv1.NamespacesFromAll
 	logger := hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug))
 
-	m := GatewayAPI(logger, Input{
+	input := Input{
 		Gateway: gatewayv1.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "platform",
@@ -874,7 +924,9 @@ func TestL4GatewayAPIFiltersRoutesByListenerAllowedNamespaces(t *testing.T) {
 				},
 			},
 		},
-	})
+	}
+	setTestMergedListeners(&input, nil)
+	m := GatewayAPI(logger, input)
 
 	require.Len(t, m.L4, 4)
 	require.Equal(t, "tcp-same", m.L4[0].Name)
@@ -1472,7 +1524,7 @@ func TestGatewayAPI_GatewayClassConfig(t *testing.T) {
 		}, m.Telemetry)
 	})
 	t.Run("sets server header transformation from GatewayClassConfig envoy config", func(t *testing.T) {
-		m := GatewayAPI(logger, Input{
+		input := Input{
 			Gateway: gatewayv1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
@@ -1495,7 +1547,9 @@ func TestGatewayAPI_GatewayClassConfig(t *testing.T) {
 					},
 				},
 			},
-		})
+		}
+		setTestMergedListeners(&input, nil)
+		m := GatewayAPI(logger, input)
 
 		require.Len(t, m.HTTP, 1)
 		assert.Equal(t, model.ServerHeaderTransformationPassThrough, m.HTTP[0].ServerHeaderTransformation)
@@ -1692,11 +1746,14 @@ func readGatewayInput(t *testing.T, testName string) Input {
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-httproute.yaml"), &input.HTTPRoutes)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-tlsroute.yaml"), &input.TLSRoutes)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-grpcroute.yaml"), &input.GRPCRoutes)
-	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-namespace.yaml"), &input.Namespaces)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-tcproute.yaml"), &input.TCPRoutes)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-udproute.yaml"), &input.UDPRoutes)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-service.yaml"), &input.Services)
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-serviceimport.yaml"), &input.ServiceImports)
+
+	// namespaces are used to construct mergedListeners
+	var namespaces []corev1.Namespace
+	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-namespace.yaml"), &namespaces)
 
 	btlspMapFixture := &BackendTLSPolicyMapFixture{}
 	readInput(t, fmt.Sprintf("%s/%s/%s", basedGatewayTestdataDir, rewriteTestName(testName), "input-backendtlspolicy.yaml"), btlspMapFixture)
@@ -1705,6 +1762,7 @@ func readGatewayInput(t *testing.T, testName string) Input {
 		t.Fatal("Failed reading a BackendTLSPolicy fixture", err)
 	}
 	input.BackendTLSPolicyMap = btlspMap
+	setTestMergedListeners(&input, namespaces)
 
 	return input
 }


### PR DESCRIPTION
Move all listener-related namespace logic into the building of ListenerWithContext, regardless of listener source.

This allows us to remove the special casing in each of the ingestion codepaths that deal with different types of routes.

This also allows us to remove the fallback construction of MergedListeners within the ingestion codepath.

This sets up a future refactor where the related route filtering functions are methods of the ListenerWithContext type.

Fixes: https://github.com/cilium/cilium/issues/47684

```release-note
gateway-api: remove pre-filtered namespaces concept
```

AIL:2
