### PR TITLE
ci: Bump Renovate to 43.288.0 to restore commit sign-off

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -45,7 +45,7 @@ jobs:
           LOG_LEVEL: ${{ github.event.inputs.renovate_log_level_debug == 'false' && 'INFO' || 'DEBUG' }}
         with:
           # renovate: datasource=github-releases depName=renovatebot/renovate
-          renovate-version: 43.285.3
+          renovate-version: 43.288.0
           docker-user: root
           docker-cmd-file: .github/actions/renovate/entrypoint.sh
           configurationFile: .github/renovate.json5


### PR DESCRIPTION
43.285.3 contains https://github.com/renovatebot/renovate/pull/44651, which migrated the `:gitSignOff` preset from `commitBody` to `commitTrailers` but only wired trailers into the local git commit path. Cilium authenticates Renovate with a GitHub App token, so `platformCommit` resolves from "auto" to "enabled" and commits go through the GitHub API, which dropped the trailer, leaving PRs such as #47682 without a Signed-off-by line.

https://github.com/renovatebot/renovate/pull/44918 fixes this for platform-native commits and first shipped in renovate 43.287.0.


PRs to rebase once this is merged:
* #47682 
* #47681
* #47679
* #47678
* #47676
* #47675
* #47674
* #47671
* #47670
* #47669
