### PR TITLE
operator: fix CID controller warn log

### DIFF
--- a/operator/pkg/ciliumidentity/controller.go
+++ b/operator/pkg/ciliumidentity/controller.go
@@ -287,7 +287,7 @@ func (c *Controller) processNextItem() bool {
 		processingLatency := time.Since(processingStartTime).Seconds()
 		item.Meter(enqueuedLatency, processingLatency, err != nil, c.metrics)
 	} else {
-		c.logger.Warn("Enqueue time not found for queue item", logfields.Key, item.Key)
+		c.logger.Warn("Enqueue time not found for queue item", logfields.Key, item.Key())
 	}
 
 	c.resourceQueue.Forget(item)


### PR DESCRIPTION
Fix warn entry logged in CID controller, `item.Key` is method which needs to be called. Without it would be the output `"key":"!ERROR:json: unsupported type: func() resource.Key"`