### PR TITLE
[v1.19] ariane: remove reference to the non-existing lint-ariane-config workflow

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -8,7 +8,6 @@ triggers:
     - tests-smoke-conformance.yaml
     - tests-smoke-ipv6.yaml
     - tests-cifuzz.yaml
-    - lint-ariane-config.yaml
     - conformance-kubespray.yaml
     - k8s-kind-network-e2e.yaml
     - lint-images-base.yaml


### PR DESCRIPTION
The Ariane Config linter is currently only present in the v1.20 and main branches. Hence, let's remove it from the set of workflows controlled by the default trigger in 1.19.
