### PR TITLE
gateway-api: requeue L4/TLS routes on ServiceImport updates

### DIFF
--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -86,6 +86,19 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.GRPCRoute{}, indexers.BackendServiceImportGRPCRouteIndex, indexers.IndexGRPCRouteByBackendServiceImport); err != nil {
 			return fmt.Errorf("failed to setup field indexer %q: %w", indexers.BackendServiceImportGRPCRouteIndex, err)
 		}
+		if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.TLSRoute{}, indexers.BackendServiceImportTLSRouteIndex, indexers.IndexTLSRouteByBackendServiceImport); err != nil {
+			return fmt.Errorf("failed to setup field indexer %q: %w", indexers.BackendServiceImportTLSRouteIndex, err)
+		}
+		if tcpRouteEnabled {
+			if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.TCPRoute{}, indexers.BackendServiceImportTCPRouteIndex, indexers.IndexTCPRouteByBackendServiceImport); err != nil {
+				return fmt.Errorf("failed to setup field indexer %q: %w", indexers.BackendServiceImportTCPRouteIndex, err)
+			}
+		}
+		if udpRouteEnabled {
+			if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayv1.UDPRoute{}, indexers.BackendServiceImportUDPRouteIndex, indexers.IndexUDPRouteByBackendServiceImport); err != nil {
+				return fmt.Errorf("failed to setup field indexer %q: %w", indexers.BackendServiceImportUDPRouteIndex, err)
+			}
+		}
 	}
 
 	// Index Gateways by implementation (ie `cilium`)

--- a/operator/pkg/gateway-api/indexers/indexnames.go
+++ b/operator/pkg/gateway-api/indexers/indexnames.go
@@ -19,6 +19,9 @@ const (
 	// Indexes TLSRoutes by all the backend Services referenced in the object.
 	BackendServiceTLSRouteIndex = "backendServiceTLSRouteIndex"
 
+	// Indexes TLSRoutes by all the backend ServiceImports referenced in the object.
+	BackendServiceImportTLSRouteIndex = "backendServiceImportTLSRouteIndex"
+
 	// Indexes TLSRoutes by all the Gateway parents referenced in the object.
 	GatewayTLSRouteIndex = "gatewayTLSRouteIndex"
 
@@ -50,11 +53,17 @@ const (
 	// Indexes TCPRoutes by all the backend Services referenced in the object.
 	BackendServiceTCPRouteIndex = "backendServiceTCPRouteIndex"
 
+	// Indexes TCPRoutes by all the backend ServiceImports referenced in the object.
+	BackendServiceImportTCPRouteIndex = "backendServiceImportTCPRouteIndex"
+
 	// Indexes TCPRoutes by all the Gateway parents referenced in the object.
 	GatewayTCPRouteIndex = "gatewayTCPRouteIndex"
 
 	// Indexes UDPRoutes by all the backend Services referenced in the object.
 	BackendServiceUDPRouteIndex = "backendServiceUDPRouteIndex"
+
+	// Indexes UDPRoutes by all the backend ServiceImports referenced in the object.
+	BackendServiceImportUDPRouteIndex = "backendServiceImportUDPRouteIndex"
 
 	// Indexes UDPRoutes by all the Gateway parents referenced in the object.
 	GatewayUDPRouteIndex = "gatewayUDPRouteIndex"

--- a/operator/pkg/gateway-api/indexers/tcproute.go
+++ b/operator/pkg/gateway-api/indexers/tcproute.go
@@ -45,6 +45,32 @@ func GenerateIndexerTCPRoutebyBackendService(c client.Client, logger *slog.Logge
 	}
 }
 
+// IndexTCPRouteByBackendServiceImport is a client.IndexerFunc that takes a single TCPRoute and
+// returns all referenced backend ServiceImport full names (`namespace/name`) to add to the relevant index.
+func IndexTCPRouteByBackendServiceImport(rawObj client.Object) []string {
+	route, ok := rawObj.(*gatewayv1.TCPRoute)
+	if !ok {
+		return nil
+	}
+	var backendServiceImports []string
+
+	for _, rule := range route.Spec.Rules {
+		for _, backend := range rule.BackendRefs {
+			if !helpers.IsServiceImport(backend.BackendObjectReference) {
+				continue
+			}
+			backendServiceImports = append(backendServiceImports,
+				types.NamespacedName{
+					Namespace: helpers.NamespaceDerefOr(backend.Namespace, route.Namespace),
+					Name:      string(backend.Name),
+				}.String(),
+			)
+		}
+	}
+
+	return backendServiceImports
+}
+
 // IndexTCPRouteByGateway takes a single TCPRoute and returns all referenced Gateway object
 // full names (`namespace/name`) to add to the relevant index.
 //

--- a/operator/pkg/gateway-api/indexers/tcproute_test.go
+++ b/operator/pkg/gateway-api/indexers/tcproute_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 )
 
 func TestIndexTCPRouteByGateway(t *testing.T) {
@@ -133,6 +134,77 @@ func TestIndexTCPRouteByGateway(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := IndexTCPRouteByGateway(tt.obj); !slices.Equal(got, tt.want) {
 				t.Errorf("IndexTCPRouteByGateway() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIndexTCPRouteByBackendServiceImport(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  client.Object
+		want []string
+	}{
+		{
+			name: "has ServiceImport backend refs",
+			obj: &gatewayv1.TCPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "has-serviceimport",
+					Namespace: "default",
+				},
+				Spec: gatewayv1.TCPRouteSpec{
+					Rules: []gatewayv1.TCPRouteRule{
+						{
+							BackendRefs: []gatewayv1.BackendRef{
+								{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Group:     ptr.To[gatewayv1.Group](mcsapiv1beta1.GroupName),
+										Kind:      ptr.To[gatewayv1.Kind]("ServiceImport"),
+										Name:      "backend-import",
+										Namespace: ptr.To[gatewayv1.Namespace]("backend-ns"),
+									},
+								},
+								{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Name: "backend-svc",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []string{"backend-ns/backend-import"},
+		},
+		{
+			name: "has no ServiceImport refs",
+			obj: &gatewayv1.TCPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "no-serviceimport",
+					Namespace: "default",
+				},
+				Spec: gatewayv1.TCPRouteSpec{
+					Rules: []gatewayv1.TCPRouteRule{
+						{
+							BackendRefs: []gatewayv1.BackendRef{
+								{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Name: "backend-svc",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IndexTCPRouteByBackendServiceImport(tt.obj); !slices.Equal(got, tt.want) {
+				t.Errorf("IndexTCPRouteByBackendServiceImport() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/operator/pkg/gateway-api/indexers/tlsroute.go
+++ b/operator/pkg/gateway-api/indexers/tlsroute.go
@@ -45,6 +45,32 @@ func GenerateIndexerTLSRoutebyBackendService(c client.Client, logger *slog.Logge
 	}
 }
 
+// IndexTLSRouteByBackendServiceImport is a client.IndexerFunc that takes a single TLSRoute and
+// returns all referenced backend ServiceImport full names (`namespace/name`) to add to the relevant index.
+func IndexTLSRouteByBackendServiceImport(rawObj client.Object) []string {
+	route, ok := rawObj.(*gatewayv1.TLSRoute)
+	if !ok {
+		return nil
+	}
+	var backendServiceImports []string
+
+	for _, rule := range route.Spec.Rules {
+		for _, backend := range rule.BackendRefs {
+			if !helpers.IsServiceImport(backend.BackendObjectReference) {
+				continue
+			}
+			backendServiceImports = append(backendServiceImports,
+				types.NamespacedName{
+					Namespace: helpers.NamespaceDerefOr(backend.Namespace, route.Namespace),
+					Name:      string(backend.Name),
+				}.String(),
+			)
+		}
+	}
+
+	return backendServiceImports
+}
+
 // IndexTLSRouteByGateway takes a single TLSRoute and returns all referenced Gateway object full names (`namespace/name`)
 // to add to the relevant index.
 //

--- a/operator/pkg/gateway-api/indexers/tlsroute_test.go
+++ b/operator/pkg/gateway-api/indexers/tlsroute_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 )
 
 func TestIndexTLSRouteByGateway(t *testing.T) {
@@ -89,6 +90,77 @@ func TestIndexTLSRouteByGateway(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := IndexTLSRouteByGateway(tt.obj); !slices.Equal(got, tt.want) {
 				t.Errorf("IndexTLSRouteByGateway() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIndexTLSRouteByBackendServiceImport(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  client.Object
+		want []string
+	}{
+		{
+			name: "has ServiceImport backend refs",
+			obj: &gatewayv1.TLSRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "has-serviceimport",
+					Namespace: "default",
+				},
+				Spec: gatewayv1.TLSRouteSpec{
+					Rules: []gatewayv1.TLSRouteRule{
+						{
+							BackendRefs: []gatewayv1.BackendRef{
+								{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Group:     ptr.To[gatewayv1.Group](mcsapiv1beta1.GroupName),
+										Kind:      ptr.To[gatewayv1.Kind]("ServiceImport"),
+										Name:      "backend-import",
+										Namespace: ptr.To[gatewayv1.Namespace]("backend-ns"),
+									},
+								},
+								{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Name: "backend-svc",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []string{"backend-ns/backend-import"},
+		},
+		{
+			name: "has no ServiceImport refs",
+			obj: &gatewayv1.TLSRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "no-serviceimport",
+					Namespace: "default",
+				},
+				Spec: gatewayv1.TLSRouteSpec{
+					Rules: []gatewayv1.TLSRouteRule{
+						{
+							BackendRefs: []gatewayv1.BackendRef{
+								{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Name: "backend-svc",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IndexTLSRouteByBackendServiceImport(tt.obj); !slices.Equal(got, tt.want) {
+				t.Errorf("IndexTLSRouteByBackendServiceImport() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/operator/pkg/gateway-api/indexers/udproute.go
+++ b/operator/pkg/gateway-api/indexers/udproute.go
@@ -45,6 +45,32 @@ func GenerateIndexerUDPRoutebyBackendService(c client.Client, logger *slog.Logge
 	}
 }
 
+// IndexUDPRouteByBackendServiceImport is a client.IndexerFunc that takes a single UDPRoute and
+// returns all referenced backend ServiceImport full names (`namespace/name`) to add to the relevant index.
+func IndexUDPRouteByBackendServiceImport(rawObj client.Object) []string {
+	route, ok := rawObj.(*gatewayv1.UDPRoute)
+	if !ok {
+		return nil
+	}
+	var backendServiceImports []string
+
+	for _, rule := range route.Spec.Rules {
+		for _, backend := range rule.BackendRefs {
+			if !helpers.IsServiceImport(backend.BackendObjectReference) {
+				continue
+			}
+			backendServiceImports = append(backendServiceImports,
+				types.NamespacedName{
+					Namespace: helpers.NamespaceDerefOr(backend.Namespace, route.Namespace),
+					Name:      string(backend.Name),
+				}.String(),
+			)
+		}
+	}
+
+	return backendServiceImports
+}
+
 // IndexUDPRouteByGateway takes a single UDPRoute and returns all referenced Gateway object
 // full names (`namespace/name`) to add to the relevant index.
 //

--- a/operator/pkg/gateway-api/indexers/udproute_test.go
+++ b/operator/pkg/gateway-api/indexers/udproute_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	mcsapiv1beta1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 )
 
 func TestIndexUDPRouteByGateway(t *testing.T) {
@@ -133,6 +134,77 @@ func TestIndexUDPRouteByGateway(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := IndexUDPRouteByGateway(tt.obj); !slices.Equal(got, tt.want) {
 				t.Errorf("IndexUDPRouteByGateway() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIndexUDPRouteByBackendServiceImport(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  client.Object
+		want []string
+	}{
+		{
+			name: "has ServiceImport backend refs",
+			obj: &gatewayv1.UDPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "has-serviceimport",
+					Namespace: "default",
+				},
+				Spec: gatewayv1.UDPRouteSpec{
+					Rules: []gatewayv1.UDPRouteRule{
+						{
+							BackendRefs: []gatewayv1.BackendRef{
+								{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Group:     ptr.To[gatewayv1.Group](mcsapiv1beta1.GroupName),
+										Kind:      ptr.To[gatewayv1.Kind]("ServiceImport"),
+										Name:      "backend-import",
+										Namespace: ptr.To[gatewayv1.Namespace]("backend-ns"),
+									},
+								},
+								{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Name: "backend-svc",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []string{"backend-ns/backend-import"},
+		},
+		{
+			name: "has no ServiceImport refs",
+			obj: &gatewayv1.UDPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "no-serviceimport",
+					Namespace: "default",
+				},
+				Spec: gatewayv1.UDPRouteSpec{
+					Rules: []gatewayv1.UDPRouteRule{
+						{
+							BackendRefs: []gatewayv1.BackendRef{
+								{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Name: "backend-svc",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IndexUDPRouteByBackendServiceImport(tt.obj); !slices.Equal(got, tt.want) {
+				t.Errorf("IndexUDPRouteByBackendServiceImport() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/operator/pkg/gateway-api/watch-handlers/service.go
+++ b/operator/pkg/gateway-api/watch-handlers/service.go
@@ -132,7 +132,7 @@ func EnqueueRequestForBackendService(c client.Client, scheme *runtime.Scheme, lo
 }
 
 // EnqueueRequestForBackendServiceImport makes sure that Gateways are reconciled
-// if a relevant HTTPRoute or GRPCRoute backend ServiceImport is updated.
+// if a relevant route backend ServiceImport is updated.
 func EnqueueRequestForBackendServiceImport(c client.Client, logger slog.Logger, controllerName string) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
 		_, ok := o.(*mcsapiv1beta1.ServiceImport)
@@ -145,7 +145,7 @@ func EnqueueRequestForBackendServiceImport(c client.Client, logger slog.Logger, 
 		// make a set to hold all reconcile requests
 		reconcileRequests := make(map[reconcile.Request]struct{})
 
-		// Fetch all HTTPRoutes and GRPCRoutes that reference this ServiceImport.
+		// Fetch all routes that reference this ServiceImport.
 		hrList := &gatewayv1.HTTPRouteList{}
 
 		if err := c.List(ctx, hrList, &client.ListOptions{
@@ -164,6 +164,35 @@ func EnqueueRequestForBackendServiceImport(c client.Client, logger slog.Logger, 
 			return []reconcile.Request{}
 		}
 
+		tlsRouteList := &gatewayv1.TLSRouteList{}
+
+		if err := c.List(ctx, tlsRouteList, &client.ListOptions{
+			FieldSelector: fields.OneTermEqualSelector(indexers.BackendServiceImportTLSRouteIndex, client.ObjectKeyFromObject(o).String()),
+		}); err != nil {
+			scopedLog.ErrorContext(ctx, "Failed to get related TLSRoutes", logfields.Error, err)
+			return []reconcile.Request{}
+		}
+
+		tcpRouteList := &gatewayv1.TCPRouteList{}
+		if helpers.HasTCPRouteSupport(c.Scheme()) {
+			if err := c.List(ctx, tcpRouteList, &client.ListOptions{
+				FieldSelector: fields.OneTermEqualSelector(indexers.BackendServiceImportTCPRouteIndex, client.ObjectKeyFromObject(o).String()),
+			}); err != nil {
+				scopedLog.ErrorContext(ctx, "Failed to get related TCPRoutes", logfields.Error, err)
+				return []reconcile.Request{}
+			}
+		}
+
+		udpRouteList := &gatewayv1.UDPRouteList{}
+		if helpers.HasUDPRouteSupport(c.Scheme()) {
+			if err := c.List(ctx, udpRouteList, &client.ListOptions{
+				FieldSelector: fields.OneTermEqualSelector(indexers.BackendServiceImportUDPRouteIndex, client.ObjectKeyFromObject(o).String()),
+			}); err != nil {
+				scopedLog.ErrorContext(ctx, "Failed to get related UDPRoutes", logfields.Error, err)
+				return []reconcile.Request{}
+			}
+		}
+
 		allGatewaysSet, err := getAllGatewaysSetForController(ctx, c, controllerName)
 		if err != nil {
 			scopedLog.ErrorContext(ctx, "Failed to get controller Gateways", logfields.Error, err)
@@ -176,6 +205,15 @@ func EnqueueRequestForBackendServiceImport(c client.Client, logger slog.Logger, 
 		}
 		for _, grpcr := range grpcRouteList.Items {
 			updateReconcileRequestsForParentRefs(ctx, c, grpcr.Spec.ParentRefs, grpcr.Namespace, allGatewaysSet, reconcileRequests)
+		}
+		for _, tlsr := range tlsRouteList.Items {
+			updateReconcileRequestsForParentRefs(ctx, c, tlsr.Spec.ParentRefs, tlsr.Namespace, allGatewaysSet, reconcileRequests)
+		}
+		for _, tcpr := range tcpRouteList.Items {
+			updateReconcileRequestsForParentRefs(ctx, c, tcpr.Spec.ParentRefs, tcpr.Namespace, allGatewaysSet, reconcileRequests)
+		}
+		for _, udpr := range udpRouteList.Items {
+			updateReconcileRequestsForParentRefs(ctx, c, udpr.Spec.ParentRefs, udpr.Namespace, allGatewaysSet, reconcileRequests)
 		}
 
 		// return the keys of the set.


### PR DESCRIPTION
Extend BackendServiceImport handling beyond HTTPRoute and GRPCRoute.

Add ServiceImport field indexes for TLSRoute, TCPRoute, and UDPRoute, register them during Gateway API controller setup, and include those route types in EnqueueRequestForBackendServiceImport. This ensures Gateway reconciliation is triggered when a ServiceImport used by L4/TLS routes changes.