### PR TITLE
gha/lvh-kind: respect Kind image version also when config is provided

### DIFF
--- a/.github/actions/lvh-kind/action.yaml
+++ b/.github/actions/lvh-kind/action.yaml
@@ -92,7 +92,7 @@ runs:
           export KIND_EXPERIMENTAL_DOCKER_NETWORK=${KIND_EXPERIMENTAL_DOCKER_NETWORK@Q}
 
           if [ "${{ inputs.kind-config }}" != "" ]; then
-            kind create cluster --config ${{ inputs.kind-config }}
+            kind create cluster --config ${{ inputs.kind-config }} --image ${{ inputs.kind-image }}
           else
             ./contrib/scripts/kind.sh ${{ inputs.kind-params }} 0.0.0.0 6443
           fi


### PR DESCRIPTION
Currently, the LVH kind action only respects the provided Kind image when a Kind configuration is not provided. Let's fix it to always respect the provided image parameter, which is also marked as required, to prevent surprises due to changes in the default image upon LVH image upgrades.

AIL: 0