### PR TITLE
datapath/sockets: convert SocketFilter.DestIp to netip.Addr

### DIFF
--- a/pkg/datapath/loader/sock.go
+++ b/pkg/datapath/loader/sock.go
@@ -6,7 +6,7 @@ package loader
 import (
 	"fmt"
 	"log/slog"
-	"net"
+	"net/netip"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	bpfgen "github.com/cilium/cilium/pkg/datapath/bpf"
@@ -23,7 +23,7 @@ const (
 	filterVarName = "cilium_sock_term_filter"
 )
 
-type FilterSetter func(af uint8, addr net.IP, port uint16) error
+type FilterSetter func(af uint8, addr netip.Addr, port uint16) error
 
 // LoadSockTerm loads the cil_sock_udp_destroy_v4, cil_sock_tcp_destroy_v4,
 // cil_sock_tcp_destroy_v6, and cil_sock_udp_destroy_v6 programs. It returns a
@@ -82,11 +82,12 @@ func LoadSockTerm(l *slog.Logger, sockRevNat4, sockRevNat6 *bpf.Map) (*bpfgen.So
 			CilSockTcpDestroyV4: coll.Programs[v4TCPProgName],
 			CilSockUdpDestroyV6: coll.Programs[v6UDPProgName],
 			CilSockTcpDestroyV6: coll.Programs[v6TCPProgName],
-		}, func(af uint8, addr net.IP, port uint16) error {
+		}, func(af uint8, addr netip.Addr, port uint16) error {
 			var value bpfgen.SockTermSockTermFilter
 			value.AddressFamily = af
 			value.Port = port
-			copy(value.Address.Addr6.Addr[:], addr.To16())
+			a16 := addr.As16()
+			copy(value.Address.Addr6.Addr[:], a16[:])
 
 			return coll.Variables[filterVarName].Set(&value)
 		}, nil

--- a/pkg/datapath/sockets/sockets.go
+++ b/pkg/datapath/sockets/sockets.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"net/netip"
 	"syscall"
 
 	"github.com/vishvananda/netlink"
@@ -115,7 +116,7 @@ type SocketDestroyer interface {
 }
 
 type SocketFilter struct {
-	DestIp   net.IP
+	DestIp   netip.Addr
 	DestPort uint16
 	Family   uint8
 	Protocol uint8
@@ -175,8 +176,9 @@ func (d *netlinkSocketDestroyer) Destroy(logger *slog.Logger, filter SocketFilte
 		// Note that socketlb placed the revnat entry into the IPv4-related
 		// map (not the IPv6 one!). The DestroyCB looks up the right revnat
 		// BPF map based on the filter.DestIp which in our case is an IPv4
-		// address. The filter.DestIp stores the IPv4 address internally
-		// as IPv4-mapped IPv6 form as per net.IP.
+		// address. So the filter must remain an IPv4 address even while
+		// matching IPv6 sockets. MatchSocket unmaps both sides so the
+		// v4-in-v6 form compares equal.
 		if family == syscall.AF_INET {
 			family = syscall.AF_INET6
 			goto redo
@@ -198,7 +200,11 @@ func (d *netlinkSocketDestroyer) Destroy(logger *slog.Logger, filter SocketFilte
 }
 
 func (f *SocketFilter) MatchSocket(socket netlink.SocketID) bool {
-	if socket.Destination.Equal(f.DestIp) && socket.DestinationPort == f.DestPort {
+	socketAddr, ok := netip.AddrFromSlice(socket.Destination)
+	if !ok {
+		return false
+	}
+	if socketAddr.Unmap() == f.DestIp.Unmap() && socket.DestinationPort == f.DestPort {
 		if f.DestroyCB == nil || f.DestroyCB(socket) {
 			return true
 		}

--- a/pkg/datapath/sockets/sockets_test.go
+++ b/pkg/datapath/sockets/sockets_test.go
@@ -492,7 +492,7 @@ func TestPrivilegedSocketDestroyers(t *testing.T) {
 	}{
 		"close 127.0.0.1:8888 (UDP)": {
 			filter: SocketFilter{
-				DestIp:   net.IP{127, 0, 0, 1},
+				DestIp:   netip.MustParseAddr("127.0.0.1"),
 				DestPort: 8888,
 				Family:   unix.AF_INET,
 				Protocol: unix.IPPROTO_UDP,
@@ -504,7 +504,7 @@ func TestPrivilegedSocketDestroyers(t *testing.T) {
 		},
 		"close 127.0.0.1:8888 (TCP)": {
 			filter: SocketFilter{
-				DestIp:   net.IP{127, 0, 0, 1},
+				DestIp:   netip.MustParseAddr("127.0.0.1"),
 				DestPort: 8888,
 				Family:   unix.AF_INET,
 				Protocol: unix.IPPROTO_TCP,
@@ -516,7 +516,7 @@ func TestPrivilegedSocketDestroyers(t *testing.T) {
 		},
 		"close [::1]:8888 (UDP)": {
 			filter: SocketFilter{
-				DestIp:   net.IPv6loopback,
+				DestIp:   netip.IPv6Loopback(),
 				DestPort: 8888,
 				Family:   unix.AF_INET6,
 				Protocol: unix.IPPROTO_UDP,
@@ -528,7 +528,7 @@ func TestPrivilegedSocketDestroyers(t *testing.T) {
 		},
 		"close [::1]:8888 (TCP)": {
 			filter: SocketFilter{
-				DestIp:   net.IPv6loopback,
+				DestIp:   netip.IPv6Loopback(),
 				DestPort: 8888,
 				Family:   unix.AF_INET6,
 				Protocol: unix.IPPROTO_TCP,
@@ -540,7 +540,7 @@ func TestPrivilegedSocketDestroyers(t *testing.T) {
 		},
 		"close [::ffff:127.0.0.1]:8890 (UDP)": {
 			filter: SocketFilter{
-				DestIp:   net.IP{127, 0, 0, 1},
+				DestIp:   netip.MustParseAddr("127.0.0.1"),
 				DestPort: 8890,
 				Family:   unix.AF_INET,
 				Protocol: unix.IPPROTO_UDP,
@@ -552,7 +552,7 @@ func TestPrivilegedSocketDestroyers(t *testing.T) {
 		},
 		"close [::ffff:127.0.0.1]:8890 (TCP)": {
 			filter: SocketFilter{
-				DestIp:   net.IP{127, 0, 0, 1},
+				DestIp:   netip.MustParseAddr("127.0.0.1"),
 				DestPort: 8890,
 				Family:   unix.AF_INET,
 				Protocol: unix.IPPROTO_TCP,
@@ -632,7 +632,7 @@ func BenchmarkDestroyers(b *testing.B) {
 				defer conn.Close()
 
 				require.NoError(b, sockDestroyer.Destroy(log, SocketFilter{
-					DestIp:   net.IPv4(127, 0, 0, 1),
+					DestIp:   netip.MustParseAddr("127.0.0.1"),
 					DestPort: 8888,
 					Family:   unix.AF_INET,
 					Protocol: unix.IPPROTO_UDP,

--- a/pkg/loadbalancer/reconciler/termination.go
+++ b/pkg/loadbalancer/reconciler/termination.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"iter"
 	"log/slog"
-	"net"
 	"syscall"
 
 	"github.com/vishvananda/netlink"
@@ -200,7 +199,6 @@ func terminateConnectionsToBackend(p socketTerminationParams, sd sockets.SocketD
 		protocol uint8
 		states   uint32
 	)
-	ip := net.IP(l3n4Addr.Addr().AsSlice())
 
 	switch l3n4Addr.Protocol() {
 	case lb.UDP:
@@ -246,7 +244,7 @@ func terminateConnectionsToBackend(p socketTerminationParams, sd sockets.SocketD
 				Family:    family,
 				Protocol:  protocol,
 				States:    states,
-				DestIp:    ip,
+				DestIp:    l3n4Addr.Addr(),
 				DestPort:  l3n4Addr.Port(),
 				DestroyCB: checkSockInRevNat,
 			})

--- a/pkg/loadbalancer/reconciler/termination_test.go
+++ b/pkg/loadbalancer/reconciler/termination_test.go
@@ -159,12 +159,12 @@ func testSocketTermination(t *testing.T, hostOnly bool) {
 	// We should see two deletions: one for host ns (if enabled) and one for the mocked
 	// "foo" one.
 	filter := <-mock.requests
-	require.True(t, beAddr.AddrCluster().AsNetIP().Equal(filter.DestIp), "IP matches")
+	require.Equal(t, beAddr.Addr(), filter.DestIp, "IP matches")
 	require.Equal(t, beAddr.Port(), filter.DestPort, "Port matches")
 
 	if !hostOnly {
 		filter = <-mock.requests
-		require.True(t, beAddr.AddrCluster().AsNetIP().Equal(filter.DestIp), "IP matches")
+		require.Equal(t, beAddr.Addr(), filter.DestIp, "IP matches")
 		require.Equal(t, beAddr.Port(), filter.DestPort, "Port matches")
 		require.ElementsMatch(t, visitedNamespaces, []*netns.NetNS{hostNS, fooNS})
 	} else {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

<!-- Description of change -->

Converts `sockets.SocketFilter.DestIp` from `net.IP` to `netip.Addr`, propagating the type through `loader.FilterSetter` and its caller in `loadbalancer/reconciler`.

The motivation is that the value is *already* a `netip.Addr` at its source `terminateConnectionsToBackend` was doing `net.IP(l3n4Addr.Addr().AsSlice())`. That conversion is now gone.

Two things needed care, both preserved deliberately:

- **`MatchSocket` comparison.** 

- **BPF filter setter.** 

`netlink.SocketID` fields, `serializeAddr` and `Deserialize` keep `net.IP` those are vendored/wire-format boundaries and out of scope.

Related: #24246

## How this was tested

- `go build ./...`
- `go vet ./pkg/datapath/sockets/ ./pkg/datapath/loader/ ./pkg/loadbalancer/reconciler/ ./pkg/testutils/sockets/`
- `go test ./pkg/datapath/sockets/... ./pkg/datapath/loader/... ./pkg/loadbalancer/reconciler/...`
- `golangci-lint run` on the three changed packages

This PR was prepared with AIL:0. 
```release-note
Convert SocketFilter.DestIp to netip.Addr
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
