### PR TITLE
docs: Fix chart --version flag

### DIFF
--- a/Documentation/_exts/cilium_helm_directive.py
+++ b/Documentation/_exts/cilium_helm_directive.py
@@ -138,10 +138,10 @@ class CiliumHelmInstallDirective(SphinxDirective):
         # For install/upgrade, format is "helm install name |CHART_RELEASE|"
         if command == 'template':
             helm_repo_base = f'helm {command} |CHART_RELEASE|'
-            oci_base = f'helm {command} oci://quay.io/cilium/charts/cilium |CHART_VERSION|'
+            oci_base = f'helm {command} oci://quay.io/cilium/charts/cilium --version |CHART_VERSION|'
         else:
             helm_repo_base = f'helm {command} {name} |CHART_RELEASE|'
-            oci_base = f'helm {command} {name} oci://quay.io/cilium/charts/cilium |CHART_VERSION|'
+            oci_base = f'helm {command} {name} oci://quay.io/cilium/charts/cilium --version |CHART_VERSION|'
 
         # Build formatted commands for each section
         helm_repo_cmd = self._format_command(

--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -254,7 +254,7 @@ You can install Cilium on any Kubernetes cluster. Pick one of the options below:
 
        .. parsed-literal::
 
-          cilium install |CHART_VERSION|
+          cilium install --version |CHART_VERSION|
 
     .. group-tab:: GKE
 
@@ -266,7 +266,7 @@ You can install Cilium on any Kubernetes cluster. Pick one of the options below:
 
        .. parsed-literal::
 
-           cilium install |CHART_VERSION|
+           cilium install --version |CHART_VERSION|
 
     .. group-tab:: AKS
        
@@ -278,7 +278,7 @@ You can install Cilium on any Kubernetes cluster. Pick one of the options below:
 
        .. parsed-literal::
 
-           cilium install |CHART_VERSION| --set azure.resourceGroup="${AZURE_RESOURCE_GROUP}"
+           cilium install --version |CHART_VERSION| --set azure.resourceGroup="${AZURE_RESOURCE_GROUP}"
            
     .. group-tab:: EKS
 
@@ -290,7 +290,7 @@ You can install Cilium on any Kubernetes cluster. Pick one of the options below:
 
        .. parsed-literal::
 
-           cilium install |CHART_VERSION|
+           cilium install --version |CHART_VERSION|
            cilium status --wait
 
        .. note::
@@ -320,7 +320,7 @@ You can install Cilium on any Kubernetes cluster. Pick one of the options below:
 
        .. parsed-literal::
 
-           cilium install |CHART_VERSION|
+           cilium install --version |CHART_VERSION|
 
     .. group-tab:: k3s
 
@@ -332,7 +332,7 @@ You can install Cilium on any Kubernetes cluster. Pick one of the options below:
 
        .. parsed-literal::
 
-           cilium install |CHART_VERSION|
+           cilium install --version |CHART_VERSION|
 
     .. group-tab:: Alibaba ACK
 

--- a/Documentation/installation/k0s.rst
+++ b/Documentation/installation/k0s.rst
@@ -103,7 +103,7 @@ Install Cilium by running:
 
 .. parsed-literal::
 
-    cilium install |CHART_VERSION|
+    cilium install --version |CHART_VERSION|
 
 Validate the Installation
 =========================

--- a/Documentation/installation/k3s.rst
+++ b/Documentation/installation/k3s.rst
@@ -79,7 +79,7 @@ Install Cilium by running:
 
 .. parsed-literal::
 
-    cilium install |CHART_VERSION| --set=ipam.operator.clusterPoolIPv4PodCIDRList="10.42.0.0/16"
+    cilium install --version |CHART_VERSION| --set=ipam.operator.clusterPoolIPv4PodCIDRList="10.42.0.0/16"
 
 Validate the Installation
 =========================

--- a/Documentation/installation/k8s-install-helm.rst
+++ b/Documentation/installation/k8s-install-helm.rst
@@ -51,7 +51,7 @@ several advantages:
    .. parsed-literal::
 
       helm install cilium oci://quay.io/cilium/charts/cilium \\
-        |CHART_VERSION| \\
+        --version |CHART_VERSION| \\
         --namespace kube-system
 
 .. only:: not stable
@@ -320,7 +320,7 @@ Using OCI Registry
    .. parsed-literal::
 
       helm upgrade cilium oci://quay.io/cilium/charts/cilium \\
-        |CHART_VERSION| \\
+        --version |CHART_VERSION| \\
         --namespace kube-system
 
 .. only:: not stable
@@ -342,7 +342,7 @@ switching to OCI is straightforward as the charts are identical:
    .. parsed-literal::
 
       helm upgrade cilium oci://quay.io/cilium/charts/cilium \\
-        |CHART_VERSION| \\
+        --version |CHART_VERSION| \\
         --namespace kube-system \\
         --reuse-values
 

--- a/Documentation/installation/k8s-install-migration.rst
+++ b/Documentation/installation/k8s-install-migration.rst
@@ -190,7 +190,7 @@ Preparation
 
     .. parsed-literal::
 
-        $ cilium install |CHART_VERSION| --values values-migration.yaml --dry-run-helm-values > values-initial.yaml
+        $ cilium install --version |CHART_VERSION| --values values-migration.yaml --dry-run-helm-values > values-initial.yaml
         $ cat values-initial.yaml
 
 
@@ -323,7 +323,7 @@ Perform these steps once the cluster is fully migrated.
 
     .. parsed-literal::
 
-      $ cilium install |CHART_VERSION| --values values-initial.yaml --dry-run-helm-values \\
+      $ cilium install --version |CHART_VERSION| --values values-initial.yaml --dry-run-helm-values \\
         --set operator.unmanagedPodWatcher.restart=true --set cni.customConf=false \\
         --set policyEnforcementMode=default \\
         --set bpf.hostLegacyRouting=false > values-final.yaml # optional, can cause brief interruptions

--- a/Documentation/installation/k8s-install-rke.rst
+++ b/Documentation/installation/k8s-install-rke.rst
@@ -83,7 +83,7 @@ Deploy Cilium
 
         .. parsed-literal::
 
-            cilium install |CHART_VERSION|
+            cilium install --version |CHART_VERSION|
 
 .. include:: k8s-install-validate.rst
 

--- a/Documentation/installation/rancher-desktop.rst
+++ b/Documentation/installation/rancher-desktop.rst
@@ -27,7 +27,7 @@ Install Cilium by running:
 
 .. parsed-literal::
 
-    cilium install |CHART_VERSION|
+    cilium install --version |CHART_VERSION|
 
 Validate the Installation
 =========================

--- a/Documentation/network/bgp-control-plane/bgp-control-plane.rst
+++ b/Documentation/network/bgp-control-plane/bgp-control-plane.rst
@@ -46,7 +46,7 @@ Installation
 
         .. parsed-literal::
 
-            $ cilium install |CHART_VERSION| --set bgpControlPlane.enabled=true
+            $ cilium install --version |CHART_VERSION| --set bgpControlPlane.enabled=true
 
 IPv4/IPv6 single-stack and dual-stack setup are supported. Note that the BGP
 Control Plane can only advertise the route of the address family that the

--- a/Documentation/network/clustermesh/aks-clustermesh-prep.rst
+++ b/Documentation/network/clustermesh/aks-clustermesh-prep.rst
@@ -87,7 +87,7 @@ Install cluster one
 
     .. parsed-literal::
 
-        cilium install |CHART_VERSION| \\
+        cilium install --version |CHART_VERSION| \\
             --set azure.resourceGroup="${AZURE_RESOURCE_GROUP}" \\
             --set cluster.id=1 \\
             --set ipam.operator.clusterPoolIPv4PodCIDRList='{10.10.0.0/16}'
@@ -174,7 +174,7 @@ arguments.
 
     .. parsed-literal::
 
-        cilium install |CHART_VERSION| \\
+        cilium install --version |CHART_VERSION| \\
             --set azure.resourceGroup="${AZURE_RESOURCE_GROUP}" \\
             --set cluster.id=2 \\
             --set ipam.operator.clusterPoolIPv4PodCIDRList='{10.20.0.0/16}'

--- a/Documentation/network/clustermesh/gke-clustermesh-prep.rst
+++ b/Documentation/network/clustermesh/gke-clustermesh-prep.rst
@@ -95,7 +95,7 @@ Deploy clusters
 
     .. parsed-literal::
 
-        cilium install |CHART_VERSION| \\
+        cilium install --version |CHART_VERSION| \\
             --set cluster.id=1 \\
             --set cluster.name=${CLUSTER}
 

--- a/Documentation/network/servicemesh/gateway-api/installation.rst
+++ b/Documentation/network/servicemesh/gateway-api/installation.rst
@@ -124,7 +124,7 @@ Once CRDs are installed, use Helm or Cilium CLI to enable Cilium Gateway API con
 
         .. parsed-literal::
 
-            $ cilium upgrade |CHART_VERSION| \\
+            $ cilium upgrade --version |CHART_VERSION| \\
                 --set kubeProxyReplacement=true \\
                 --set gatewayAPI.enabled=true
 

--- a/Documentation/network/servicemesh/installation.rst
+++ b/Documentation/network/servicemesh/installation.rst
@@ -55,7 +55,7 @@ Installation
 
         .. parsed-literal::
 
-            $ cilium install |CHART_VERSION| \\
+            $ cilium install --version |CHART_VERSION| \\
                 --set kubeProxyReplacement=true \\
                 --set ingressController.enabled=true \\
                 --set ingressController.loadbalancerMode=dedicated
@@ -69,7 +69,7 @@ Installation
 
         .. parsed-literal::
 
-            $ cilium install |CHART_VERSION| \\
+            $ cilium install --version |CHART_VERSION| \\
                 --set kubeProxyReplacement=true \\
                 --set envoyConfig.enabled=true
 
@@ -77,7 +77,7 @@ Installation
 
         .. parsed-literal::
 
-            $ cilium install |CHART_VERSION| \\
+            $ cilium install --version |CHART_VERSION| \\
                 --set kubeProxyReplacement=true \\
                 --set envoyConfig.enabled=true \\
                 --set loadBalancer.l7.backend=envoy

--- a/Documentation/network/servicemesh/tls-default-certificate.rst
+++ b/Documentation/network/servicemesh/tls-default-certificate.rst
@@ -45,7 +45,7 @@ Installation
 
         .. parsed-literal::
 
-            $ cilium install |CHART_VERSION| \\
+            $ cilium install --version |CHART_VERSION| \\
                 --set kubeProxyReplacement=true \\
                 --set ingressController.enabled=true \\
                 --set ingressController.defaultSecretNamespace=kube-system \\

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -407,7 +407,7 @@ For large clusters, consider disabling high-cardinality metrics like
 
       .. parsed-literal::
 
-         helm install cilium cilium/cilium |CHART_VERSION| \\
+         helm install cilium cilium/cilium --version |CHART_VERSION| \\
              --namespace kube-system \\
              --set prometheus.enabled=true \\
              --set prometheus.metrics="{-cilium_node_health_connectivity_status,-cilium_node_health_connectivity_latency_seconds}"

--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -374,7 +374,7 @@ To enable the iptables connection-tracking bypass:
 
        .. parsed-literal::
 
-          cilium install |CHART_VERSION| \\
+          cilium install --version |CHART_VERSION| \\
             --set installNoConntrackIptablesRules=true \\
             --set kubeProxyReplacement=true
 
@@ -443,7 +443,7 @@ increase the memory usage by up to five Megabytes.
 
        .. parsed-literal::
 
-           cilium install |CHART_VERSION| \\
+           cilium install --version |CHART_VERSION| \\
              --set hubble.eventQueueSize=32768
 
     .. group-tab:: Helm
@@ -506,7 +506,7 @@ The following will set the aggregation interval to 10 seconds.
 
        .. parsed-literal::
 
-           cilium install |CHART_VERSION| \\
+           cilium install --version |CHART_VERSION| \\
              --set bpf.events.monitorInterval="10s"
 
     .. group-tab:: Helm
@@ -545,7 +545,7 @@ To enable eBPF Event Rate Limiting with a rate limit of 10,000 and a burst limit
 
        .. parsed-literal::
 
-           cilium install |CHART_VERSION| \\
+           cilium install --version |CHART_VERSION| \\
              --set bpf.events.default.rateLimit=10000 \\
              --set bpf.events.default.burstLimit=50000
 

--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -118,7 +118,7 @@ Enable Encryption in Cilium
 
        .. parsed-literal::
 
-          cilium install |CHART_VERSION| \\
+          cilium install --version |CHART_VERSION| \\
              --set encryption.enabled=true \\
              --set encryption.type=ipsec
 
@@ -167,7 +167,7 @@ interface as follows:
 
        .. parsed-literal::
 
-          cilium install |CHART_VERSION| \\
+          cilium install --version |CHART_VERSION| \\
              --set encryption.enabled=true \\
              --set encryption.type=ipsec \\
              --set encryption.ipsec.interface=ethX

--- a/Documentation/security/network/encryption-wireguard.rst
+++ b/Documentation/security/network/encryption-wireguard.rst
@@ -61,7 +61,7 @@ on how to install the kernel module on your Linux distribution.
 
        .. parsed-literal::
 
-          cilium install |CHART_VERSION| \\
+          cilium install --version |CHART_VERSION| \\
              --set encryption.enabled=true \\
              --set encryption.type=wireguard
 
@@ -230,7 +230,7 @@ options:
 
        .. parsed-literal::
 
-          cilium install |CHART_VERSION| \\
+          cilium install --version |CHART_VERSION| \\
              --set encryption.enabled=true \\
              --set encryption.type=wireguard \\
              --set encryption.nodeEncryption=true

--- a/Documentation/security/network/encryption-ztunnel.rst
+++ b/Documentation/security/network/encryption-ztunnel.rst
@@ -62,7 +62,7 @@ Before you install Cilium with ztunnel enabled, ensure that:
 
        .. parsed-literal::
 
-          cilium install |CHART_VERSION| \\
+          cilium install --version |CHART_VERSION| \\
              --set encryption.enabled=true \\
              --set encryption.type=ztunnel
 


### PR DESCRIPTION
Commit 917034aaee53 ("docs: Remove not-stable installation instructions")
modified the chart version variable in the python script to strip the CLI
Helm '--version' flag. Unfortunately most of the docs were relying on this
script injecting the flag in order to properly render install
instructions. Fix it by updating all the relevant docs to explicitly
include the flag so that the variable can be a pure version number.

I considered a partial revert to put the '--version' flag back into the
variable, but it's counter-intuitive for a sphinx variable named
`|CHART_VERSION|` to include more content than just a version number.
To avoid a repeat of this issue in future I figured it's better to just
sed replace the existing usage of the variable to ensure that the docs
which refer to the version specify the Helm flag iff the flag is needed.

This only affects v1.21.0-pre.0, not older branches.

Fixes: 917034aaee53 ("docs: Remove not-stable installation instructions")
