### PR TITLE
fix: Set the resource version when updating CiliumCIDRGroup

### DIFF
--- a/operator/pkg/networkpolicy/external-groups/cidrgroup.go
+++ b/operator/pkg/networkpolicy/external-groups/cidrgroup.go
@@ -181,6 +181,7 @@ func (gm *externalGroupManager) upsertCCG(ctx context.Context, row *ExternalGrou
 		newCCG, err = gm.createCCG(ctx, newCCG)
 	} else {
 		newCCG.Name = row.CCG.Name
+		newCCG.SetResourceVersion(row.CCG.GetResourceVersion())
 		newCCG, err = gm.updateCCG(ctx, newCCG)
 	}
 	if err != nil {


### PR DESCRIPTION
When updating a CiliumCIDRGroup, set the resource version to the existing value otherwise the update is rejected.

Fixes: #47711

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #47711

This PR was prepared with AIL:0.

```release-note
Set the resource version when updating CiliumCIDRGroup.
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
