### PR TITLE
bpf: tests: use PROG_TYPE

### DIFF
--- a/bpf/tests/_scapy_selftest.c
+++ b/bpf/tests/_scapy_selftest.c
@@ -87,7 +87,7 @@ int force_assert_fail_ctx_smaller_exp(struct __ctx_buff *ctx)
 	return TEST_PASS;
 }
 
-PKTGEN("tc", "1_basic_test")
+PKTGEN(PROG_TYPE, "1_basic_test")
 int pktgen_scapy_basic_test(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -101,7 +101,7 @@ int pktgen_scapy_basic_test(struct __ctx_buff *ctx)
 	return 0;
 }
 
-CHECK("tc", "1_basic_test")
+CHECK(PROG_TYPE, "1_basic_test")
 int check_scapy_basic_test(struct __ctx_buff *ctx)
 {
 	int rc, id;
@@ -184,7 +184,7 @@ int check_scapy_basic_test(struct __ctx_buff *ctx)
 	return 0;
 }
 
-PKTGEN("tc", "1_test_large_pkts")
+PKTGEN(PROG_TYPE, "1_test_large_pkts")
 int pktgen_scapy_large_pkts(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -198,7 +198,7 @@ int pktgen_scapy_large_pkts(struct __ctx_buff *ctx)
 	return 0;
 }
 
-CHECK("tc", "1_test_large_pkts")
+CHECK(PROG_TYPE, "1_test_large_pkts")
 int check_scapy_large_pkts(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -211,7 +211,7 @@ int check_scapy_large_pkts(struct __ctx_buff *ctx)
 	return 0;
 }
 
-PKTGEN("tc", "2_test_xlarge_pkts")
+PKTGEN(PROG_TYPE, "2_test_xlarge_pkts")
 int pktgen_scapy_xlarge_pkts(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -225,7 +225,7 @@ int pktgen_scapy_xlarge_pkts(struct __ctx_buff *ctx)
 	return 0;
 }
 
-CHECK("tc", "2_test_xlarge_pkts")
+CHECK(PROG_TYPE, "2_test_xlarge_pkts")
 int check_scapy_xlarge_pkts(struct __ctx_buff *ctx)
 {
 	test_init();

--- a/bpf/tests/bpf_ct_tests.c
+++ b/bpf/tests/bpf_ct_tests.c
@@ -79,7 +79,7 @@ __always_inline int mkpkt(void *dst, bool first)
 
 static char pkt[100];
 
-CHECK("tc", "ct4")
+CHECK(PROG_TYPE, "ct4")
 int test_ct4_rst1_check(__maybe_unused struct __ctx_buff *ctx)
 {
 	test_init();

--- a/bpf/tests/bpf_nat_icmp6.h
+++ b/bpf/tests/bpf_nat_icmp6.h
@@ -207,7 +207,7 @@ int do_icmp6_pkt_too_big_check(const struct __ctx_buff *ctx)
 	return 0;
 }
 
-PKTGEN("tc", "snat_v6_tcp_pmtu")
+PKTGEN(PROG_TYPE, "snat_v6_tcp_pmtu")
 int snat_v6_pmtu_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -218,7 +218,7 @@ int snat_v6_pmtu_pktgen(struct __ctx_buff *ctx)
 	return TEST_PASS;
 }
 
-SETUP("tc", "snat_v6_tcp_pmtu")
+SETUP(PROG_TYPE, "snat_v6_tcp_pmtu")
 int snat_v6_pmtu_setup(struct __ctx_buff *ctx)
 {
 	int ret;
@@ -230,7 +230,7 @@ int snat_v6_pmtu_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "snat_v6_tcp_pmtu")
+CHECK(PROG_TYPE, "snat_v6_tcp_pmtu")
 int snat_v6_pmtu_check(const struct __ctx_buff *ctx)
 {
 	test_init();
@@ -240,7 +240,7 @@ int snat_v6_pmtu_check(const struct __ctx_buff *ctx)
 	return 0;
 }
 
-PKTGEN("tc", "snat_v6_udp_pmtu")
+PKTGEN(PROG_TYPE, "snat_v6_udp_pmtu")
 int snat_v6_pmtu_udp_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -251,7 +251,7 @@ int snat_v6_pmtu_udp_pktgen(struct __ctx_buff *ctx)
 	return TEST_PASS;
 }
 
-SETUP("tc", "snat_v6_udp_pmtu")
+SETUP(PROG_TYPE, "snat_v6_udp_pmtu")
 int snat_v6_pmtu_udp_setup(struct __ctx_buff *ctx)
 {
 	int ret;
@@ -263,7 +263,7 @@ int snat_v6_pmtu_udp_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "snat_v6_udp_pmtu")
+CHECK(PROG_TYPE, "snat_v6_udp_pmtu")
 int snat_v6_pmtu_udp_check(const struct __ctx_buff *ctx)
 {
 	test_init();

--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -169,7 +169,7 @@ __always_inline int mk_icmp4_error_pkt(void *dst, __u8 error_hdr, bool egress, b
 	return (int)(dst - orig);
 }
 
-CHECK("tc", "nat4_icmp_error_tcp")
+CHECK(PROG_TYPE, "nat4_icmp_error_tcp")
 int test_nat4_icmp_error_tcp(__maybe_unused struct __ctx_buff *ctx)
 {
 	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_TCP, false, true);
@@ -283,7 +283,7 @@ int test_nat4_icmp_error_tcp(__maybe_unused struct __ctx_buff *ctx)
 	test_finish();
 }
 
-CHECK("tc", "nat4_icmp_error_tcp_rfc1191")
+CHECK(PROG_TYPE, "nat4_icmp_error_tcp_rfc1191")
 int test_nat4_icmp_error_tcp_rfc1191(__maybe_unused struct __ctx_buff *ctx)
 {
 	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_TCP, false, false);
@@ -407,7 +407,7 @@ int test_nat4_icmp_error_tcp_rfc1191(__maybe_unused struct __ctx_buff *ctx)
 	test_finish();
 }
 
-CHECK("tc", "nat4_icmp_error_udp")
+CHECK(PROG_TYPE, "nat4_icmp_error_udp")
 int test_nat4_icmp_error_udp(__maybe_unused struct __ctx_buff *ctx)
 {
 	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_UDP, false, true);
@@ -521,7 +521,7 @@ int test_nat4_icmp_error_udp(__maybe_unused struct __ctx_buff *ctx)
 	test_finish();
 }
 
-CHECK("tc", "nat4_icmp_error_icmp")
+CHECK(PROG_TYPE, "nat4_icmp_error_icmp")
 int test_nat4_icmp_error_icmp(__maybe_unused struct __ctx_buff *ctx)
 {
 	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_ICMP, false, true);
@@ -630,7 +630,7 @@ int test_nat4_icmp_error_icmp(__maybe_unused struct __ctx_buff *ctx)
 	test_finish();
 }
 
-CHECK("tc", "nat4_icmp_error_sctp")
+CHECK(PROG_TYPE, "nat4_icmp_error_sctp")
 int test_nat4_icmp_error_sctp(__maybe_unused struct __ctx_buff *ctx)
 {
 	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_SCTP, false, true);
@@ -688,7 +688,7 @@ int test_nat4_icmp_error_sctp(__maybe_unused struct __ctx_buff *ctx)
 	test_finish();
 }
 
-CHECK("tc", "nat4_icmp_error_tcp_egress")
+CHECK(PROG_TYPE, "nat4_icmp_error_tcp_egress")
 int test_nat4_icmp_error_tcp_egress(__maybe_unused struct __ctx_buff *ctx)
 {
 	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_TCP, true, true);
@@ -807,7 +807,7 @@ int test_nat4_icmp_error_tcp_egress(__maybe_unused struct __ctx_buff *ctx)
 	test_finish();
 }
 
-CHECK("tc", "nat4_icmp_error_tcp_egress_rfc1191")
+CHECK(PROG_TYPE, "nat4_icmp_error_tcp_egress_rfc1191")
 int test_nat4_icmp_error_tcp_egress_rfc1191(__maybe_unused struct __ctx_buff *ctx)
 {
 	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_TCP, true, false);
@@ -936,7 +936,7 @@ int test_nat4_icmp_error_tcp_egress_rfc1191(__maybe_unused struct __ctx_buff *ct
 	test_finish();
 }
 
-CHECK("tc", "nat4_icmp_error_udp_egress")
+CHECK(PROG_TYPE, "nat4_icmp_error_udp_egress")
 int test_nat4_icmp_error_udp_egress(__maybe_unused struct __ctx_buff *ctx)
 {
 	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_UDP, true, true);
@@ -1055,7 +1055,7 @@ int test_nat4_icmp_error_udp_egress(__maybe_unused struct __ctx_buff *ctx)
 	test_finish();
 }
 
-CHECK("tc", "nat4_icmp_error_icmp_egress")
+CHECK(PROG_TYPE, "nat4_icmp_error_icmp_egress")
 int test_nat4_icmp_error_icmp_egress(__maybe_unused struct __ctx_buff *ctx)
 {
 	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_ICMP, true, true);
@@ -1169,7 +1169,7 @@ int test_nat4_icmp_error_icmp_egress(__maybe_unused struct __ctx_buff *ctx)
 	test_finish();
 }
 
-CHECK("tc", "nat4_icmp_error_sctp_egress")
+CHECK(PROG_TYPE, "nat4_icmp_error_sctp_egress")
 int test_nat4_icmp_error_sctp_egress(__maybe_unused struct __ctx_buff *ctx)
 {
 	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_SCTP, true, true);
@@ -1403,7 +1403,7 @@ static long snat_callback_tcp(__u32 i, struct snat_callback_ctx *ctx)
 	return ctx->err != 0;
 }
 
-CHECK("tc", "nat4_port_allocation_tcp")
+CHECK(PROG_TYPE, "nat4_port_allocation_tcp")
 int test_nat4_port_allocation_tcp_check(struct __ctx_buff *ctx)
 {
 	struct snat_callback_ctx cb_ctx = {
@@ -1530,7 +1530,7 @@ static long snat_callback_udp(__u32 i, struct snat_callback_ctx *ctx)
 	return ctx->err != 0;
 }
 
-CHECK("tc", "nat4_port_allocation_udp")
+CHECK(PROG_TYPE, "nat4_port_allocation_udp")
 int test_nat4_port_allocation_udp_check(struct __ctx_buff *ctx)
 {
 	struct snat_callback_ctx cb_ctx = {

--- a/bpf/tests/bpf_skb_255_tests.c
+++ b/bpf/tests/bpf_skb_255_tests.c
@@ -11,7 +11,7 @@
 #define TEST_CLUSTER_ID 0xFFu
 #define IDENTITY (0x00000000u | (TEST_CLUSTER_ID << IDENTITY_LOCAL_BITS) | CLUSTER_LOCAL_IDENTITY)
 
-CHECK("tc", "set_and_get_identity")
+CHECK(PROG_TYPE, "set_and_get_identity")
 int check_get_identity(struct __ctx_buff *ctx)
 {
 	__u32 identity;
@@ -31,7 +31,7 @@ int check_get_identity(struct __ctx_buff *ctx)
 	test_finish();
 }
 
-CHECK("tc", "set_identity_mark_bits")
+CHECK(PROG_TYPE, "set_identity_mark_bits")
 int set_identity_mark_bits(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -53,7 +53,7 @@ int set_identity_mark_bits(struct __ctx_buff *ctx)
 	test_finish();
 }
 
-CHECK("tc", "set_and_get_cluster_id")
+CHECK(PROG_TYPE, "set_and_get_cluster_id")
 int check_ctx_get_cluster_id_mark(struct __ctx_buff *ctx)
 {
 	__u32 cluster_id;

--- a/bpf/tests/bpf_skb_511_tests.c
+++ b/bpf/tests/bpf_skb_511_tests.c
@@ -13,7 +13,7 @@
 #define TEST_CLUSTER_ID 0x1FFu
 #define IDENTITY (0x00000000u | (TEST_CLUSTER_ID << IDENTITY_LOCAL_BITS) | CLUSTER_LOCAL_IDENTITY)
 
-CHECK("tc", "set_and_get_identity")
+CHECK(PROG_TYPE, "set_and_get_identity")
 int check_get_identity(struct __ctx_buff *ctx)
 {
 	__u32 identity;
@@ -33,7 +33,7 @@ int check_get_identity(struct __ctx_buff *ctx)
 	test_finish();
 }
 
-CHECK("tc", "set_and_get_cluster_id")
+CHECK(PROG_TYPE, "set_and_get_cluster_id")
 int check_ctx_get_cluster_id_mark(struct __ctx_buff *ctx)
 {
 	__u32 cluster_id;

--- a/bpf/tests/builtins.c
+++ b/bpf/tests/builtins.c
@@ -7,7 +7,7 @@
 
 #include "builtin_test.h"
 
-CHECK("tc", "builtin_memzero")
+CHECK(PROG_TYPE, "builtin_memzero")
 int test_builtin_memzero(__maybe_unused struct __ctx_buff *ctx)
 {
 	test_init();
@@ -18,7 +18,7 @@ int test_builtin_memzero(__maybe_unused struct __ctx_buff *ctx)
 	test_finish();
 }
 
-CHECK("tc", "builtin_memcpy")
+CHECK(PROG_TYPE, "builtin_memcpy")
 int test_builtin_memcpy(__maybe_unused struct __ctx_buff *ctx)
 {
 	test_init();
@@ -29,7 +29,7 @@ int test_builtin_memcpy(__maybe_unused struct __ctx_buff *ctx)
 	test_finish();
 }
 
-CHECK("tc", "builtin_memcmp")
+CHECK(PROG_TYPE, "builtin_memcmp")
 int test_builtin_memcmp(__maybe_unused struct __ctx_buff *ctx)
 {
 	test_init();
@@ -49,7 +49,7 @@ int test_builtin_memcmp(__maybe_unused struct __ctx_buff *ctx)
  * bug (possibly out of jump labels), see commit history and
  * PR#41017 for more details.
  */
-CHECK("tc", "builtin_memmove")
+CHECK(PROG_TYPE, "builtin_memmove")
 int test_builtin_memmove(__maybe_unused struct __ctx_buff *ctx)
 {
 	test_init();
@@ -62,7 +62,7 @@ int test_builtin_memmove(__maybe_unused struct __ctx_buff *ctx)
 	test_finish();
 }
 
-CHECK("tc", "builtin_memmove2")
+CHECK(PROG_TYPE, "builtin_memmove2")
 int test_builtin_memmove2(__maybe_unused struct __ctx_buff *ctx)
 {
 	test_init();

--- a/bpf/tests/classifiers_common.h
+++ b/bpf/tests/classifiers_common.h
@@ -162,37 +162,37 @@ check(struct __ctx_buff *ctx, bool is_ipv4)
 	test_finish();
 }
 
-PKTGEN("tc", "ctx_classify4")
+PKTGEN(PROG_TYPE, "ctx_classify4")
 static __always_inline int
 ctx_classify4_pktgen(struct __ctx_buff *ctx) {
 	return pktgen(ctx, true);
 }
 
-CHECK("tc", "ctx_classify4")
+CHECK(PROG_TYPE, "ctx_classify4")
 int ctx_classify4_check(struct __ctx_buff *ctx)
 {
 	return check(ctx, true);
 }
 
-PKTGEN("tc", "ctx_classify6")
+PKTGEN(PROG_TYPE, "ctx_classify6")
 static __always_inline int
 ctx_classify6_pktgen(struct __ctx_buff *ctx) {
 	return pktgen(ctx, false);
 }
 
-CHECK("tc", "ctx_classify6")
+CHECK(PROG_TYPE, "ctx_classify6")
 int ctx_classify6_check(struct __ctx_buff *ctx)
 {
 	return check(ctx, false);
 }
 
-PKTGEN("tc", "compute_capture_len")
+PKTGEN(PROG_TYPE, "compute_capture_len")
 static __always_inline int
 compute_capture_len_pktgen(struct __ctx_buff *ctx) {
 	return pktgen(ctx, true);
 }
 
-CHECK("tc", "compute_capture_len")
+CHECK(PROG_TYPE, "compute_capture_len")
 int compute_capture_len_check(struct __ctx_buff *ctx)
 {
 	test_init();

--- a/bpf/tests/conntrack_test.c
+++ b/bpf/tests/conntrack_test.c
@@ -39,7 +39,7 @@ bool timeout_in(const struct ct_entry *entry, int seconds)
 	return entry->lifetime == __now + seconds;
 }
 
-CHECK("tc", "conntrack")
+CHECK(PROG_TYPE, "conntrack")
 int bpf_test(__maybe_unused struct __sk_buff *sctx)
 {
 	test_init();
@@ -210,7 +210,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 	test_finish();
 }
 
-CHECK("tc", "conntrack_svc")
+CHECK(PROG_TYPE, "conntrack_svc")
 int svc_test(__maybe_unused struct __sk_buff *sctx)
 {
 	test_init();

--- a/bpf/tests/decrypt_host.h
+++ b/bpf/tests/decrypt_host.h
@@ -138,37 +138,37 @@ int check(const struct __ctx_buff *ctx, bool ipv4)
  * For both WireGuard and IPSec, we expect the packet to not be modified,
  * and to be passed up the stack with the MARK_MAGIC_DECRYPT mark set.
  */
-PKTGEN("tc", "encrypted_v4")
+PKTGEN(PROG_TYPE, "encrypted_v4")
 int encrypted_v4_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen(ctx, true);
 }
 
-SETUP("tc", "encrypted_v4")
+SETUP(PROG_TYPE, "encrypted_v4")
 int encrypted_v4_setup(struct __ctx_buff *ctx)
 {
 	return setup(ctx, true);
 }
 
-CHECK("tc", "encrypted_v4")
+CHECK(PROG_TYPE, "encrypted_v4")
 int encrypted_v4_check(const struct __ctx_buff *ctx)
 {
 	return check(ctx, true);
 }
 
-PKTGEN("tc", "encrypted_v6")
+PKTGEN(PROG_TYPE, "encrypted_v6")
 int encrypted_v6_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen(ctx, false);
 }
 
-SETUP("tc", "encrypted_v6")
+SETUP(PROG_TYPE, "encrypted_v6")
 int encrypted_v6_setup(struct __ctx_buff *ctx)
 {
 	return setup(ctx, false);
 }
 
-CHECK("tc", "encrypted_v6")
+CHECK(PROG_TYPE, "encrypted_v6")
 int encrypted_v6_check(const struct __ctx_buff *ctx)
 {
 	return check(ctx, false);

--- a/bpf/tests/decrypt_host_wireguard_strict.c
+++ b/bpf/tests/decrypt_host_wireguard_strict.c
@@ -129,43 +129,43 @@ check(const struct __ctx_buff *ctx, __u32 expected_status)
 	test_finish();
 }
 
-PKTGEN("tc", "ipv4_strict_ingress_from_netdev")
+PKTGEN(PROG_TYPE, "ipv4_strict_ingress_from_netdev")
 int ipv4_strict_ingress_from_netdev_pktgen(struct __ctx_buff *ctx)
 {
 	return build_packet(ctx, true);
 }
 
-SETUP("tc", "ipv4_strict_ingress_from_netdev")
+SETUP(PROG_TYPE, "ipv4_strict_ingress_from_netdev")
 int ipv4_strict_ingress_from_netdev_setup(struct __ctx_buff *ctx)
 {
 	return setup(ctx, true);
 }
 
-CHECK("tc", "ipv4_strict_ingress_from_netdev")
+CHECK(PROG_TYPE, "ipv4_strict_ingress_from_netdev")
 int ipv4_strict_ingress_from_netdev_check(const struct __ctx_buff *ctx)
 {
 	return check(ctx, CTX_ACT_DROP);
 }
 
-PKTGEN("tc", "ipv6_strict_ingress_from_netdev")
+PKTGEN(PROG_TYPE, "ipv6_strict_ingress_from_netdev")
 int ipv6_strict_ingress_from_netdev_pktgen(struct __ctx_buff *ctx)
 {
 	return build_packet(ctx, false);
 }
 
-SETUP("tc", "ipv6_strict_ingress_from_netdev")
+SETUP(PROG_TYPE, "ipv6_strict_ingress_from_netdev")
 int ipv6_strict_ingress_from_netdev_setup(struct __ctx_buff *ctx)
 {
 	return setup(ctx, false);
 }
 
-CHECK("tc", "ipv6_strict_ingress_from_netdev")
+CHECK(PROG_TYPE, "ipv6_strict_ingress_from_netdev")
 int ipv6_strict_ingress_from_netdev_check(const struct __ctx_buff *ctx)
 {
 	return check(ctx, CTX_ACT_DROP);
 }
 
-PKTGEN("tc", "ipv4_strict_ingress_hostport_from_netdev")
+PKTGEN(PROG_TYPE, "ipv4_strict_ingress_hostport_from_netdev")
 int ipv4_strict_ingress_hostport_from_netdev_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -184,7 +184,7 @@ int ipv4_strict_ingress_hostport_from_netdev_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "ipv4_strict_ingress_hostport_from_netdev")
+SETUP(PROG_TYPE, "ipv4_strict_ingress_hostport_from_netdev")
 int ipv4_strict_ingress_hostport_from_netdev_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -211,7 +211,7 @@ int ipv4_strict_ingress_hostport_from_netdev_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "ipv4_strict_ingress_hostport_from_netdev")
+CHECK(PROG_TYPE, "ipv4_strict_ingress_hostport_from_netdev")
 int ipv4_strict_ingress_hostport_from_netdev_check(const struct __ctx_buff *ctx)
 {
 	return check(ctx, CTX_ACT_OK);

--- a/bpf/tests/decrypt_overlay_wireguard.c
+++ b/bpf/tests/decrypt_overlay_wireguard.c
@@ -79,7 +79,7 @@ const __u8 v4_overlay_tcp_packet_rewritten[] = {
 	SCAPY_BUF_BYTES(v4_overlay_tcp_packet_rewritten)
 };
 
-PKTGEN("tc", "ipv4_wireguard_no_mark_from_overlay")
+PKTGEN(PROG_TYPE, "ipv4_wireguard_no_mark_from_overlay")
 int ipv4_wireguard_no_mark_from_overlay_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -92,13 +92,13 @@ int ipv4_wireguard_no_mark_from_overlay_pktgen(struct __ctx_buff *ctx)
 	return TEST_PASS;
 }
 
-SETUP("tc", "ipv4_wireguard_no_mark_from_overlay")
+SETUP(PROG_TYPE, "ipv4_wireguard_no_mark_from_overlay")
 int ipv4_wireguard_no_mark_from_overlay_setup(struct __ctx_buff *ctx)
 {
 	return overlay_receive_packet(ctx);
 }
 
-CHECK("tc", "ipv4_wireguard_no_mark_from_overlay")
+CHECK(PROG_TYPE, "ipv4_wireguard_no_mark_from_overlay")
 int ipv4_wireguard_no_mark_from_overlay_check(const struct __ctx_buff *ctx)
 {
 	void *data;
@@ -128,7 +128,7 @@ int ipv4_wireguard_no_mark_from_overlay_check(const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "ipv4_wireguard_mark_from_overlay")
+PKTGEN(PROG_TYPE, "ipv4_wireguard_mark_from_overlay")
 int ipv4_wireguard_mark_from_overlay_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -141,7 +141,7 @@ int ipv4_wireguard_mark_from_overlay_pktgen(struct __ctx_buff *ctx)
 	return TEST_PASS;
 }
 
-SETUP("tc", "ipv4_wireguard_mark_from_overlay")
+SETUP(PROG_TYPE, "ipv4_wireguard_mark_from_overlay")
 int ipv4_wireguard_mark_from_overlay_setup(struct __ctx_buff *ctx)
 {
 	/* Set the correct mark so that from-overlay doesn't drop the packet */
@@ -153,7 +153,7 @@ int ipv4_wireguard_mark_from_overlay_setup(struct __ctx_buff *ctx)
 	return overlay_receive_packet(ctx);
 }
 
-CHECK("tc", "ipv4_wireguard_mark_from_overlay")
+CHECK(PROG_TYPE, "ipv4_wireguard_mark_from_overlay")
 int ipv4_wireguard_mark_from_overlay_check(const struct __ctx_buff *ctx)
 {
 	void *data;

--- a/bpf/tests/drop_notify_test.c
+++ b/bpf/tests/drop_notify_test.c
@@ -55,7 +55,7 @@ int mock_tail_call(void *ctx, __maybe_unused const void *map, __maybe_unused __u
 
 /* A sample test for function send_drop_notify */
 /* It is a demo to show how we handle tailcalls. */
-CHECK("tc", "send_drop_notify")
+CHECK(PROG_TYPE, "send_drop_notify")
 int test_send_drop_notify(struct __ctx_buff ctx)
 {
 	test_init();

--- a/bpf/tests/encrypt_host.h
+++ b/bpf/tests/encrypt_host.h
@@ -132,13 +132,13 @@ int v4_build_packet(struct __ctx_buff *ctx)
  * its ipcache entry is missing), then the corresponding PodCIDR entry
  * is still sufficient to apply encryption for a pod-to-pod packet.
  */
-PKTGEN("tc", "encrypt_v4_1_missing_dst")
+PKTGEN(PROG_TYPE, "encrypt_v4_1_missing_dst")
 int encrypt_v4_1_missing_dst_pktgen(struct __ctx_buff *ctx)
 {
 	return v4_build_packet(ctx);
 }
 
-SETUP("tc", "encrypt_v4_1_missing_dst")
+SETUP(PROG_TYPE, "encrypt_v4_1_missing_dst")
 int encrypt_v4_1_missing_dst_setup(struct __ctx_buff *ctx)
 {
 	ipcache_v4_add_entry_with_mask_size(DST_POD_CIDR_V4, 0, WORLD_ID,
@@ -155,7 +155,7 @@ int encrypt_v4_1_missing_dst_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "encrypt_v4_1_missing_dst")
+CHECK(PROG_TYPE, "encrypt_v4_1_missing_dst")
 int encrypt_v4_1_missing_dst_check(const struct __ctx_buff *ctx)
 {
 	return check(ctx, CTX_ACT_REDIRECT);
@@ -167,13 +167,13 @@ int encrypt_v4_1_missing_dst_check(const struct __ctx_buff *ctx)
  * sufficient to trigger encryption, even if the endpoint's ipcache entry
  * is not available.
  */
-PKTGEN("tc", "encrypt_v4_2_src_mark")
+PKTGEN(PROG_TYPE, "encrypt_v4_2_src_mark")
 int encrypt_v4_2_src_mark_pktgen(struct __ctx_buff *ctx)
 {
 	return v4_build_packet(ctx);
 }
 
-SETUP("tc", "encrypt_v4_2_src_mark")
+SETUP(PROG_TYPE, "encrypt_v4_2_src_mark")
 int encrypt_v4_2_src_mark_setup(struct __ctx_buff *ctx)
 {
 	ipcache_v4_add_entry(DST_POD_V4, 0, DST_POD_SEC_IDENTITY,
@@ -184,7 +184,7 @@ int encrypt_v4_2_src_mark_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "encrypt_v4_2_src_mark")
+CHECK(PROG_TYPE, "encrypt_v4_2_src_mark")
 int encrypt_v4_2_src_mark_check(const struct __ctx_buff *ctx)
 {
 	return check(ctx, CTX_ACT_REDIRECT);
@@ -193,19 +193,19 @@ int encrypt_v4_2_src_mark_check(const struct __ctx_buff *ctx)
 /* Now test *without* the identity in the mark. This should *not* trigger
  * encryption. Strict-Mode should capture the packet.
  */
-PKTGEN("tc", "encrypt_v4_3_no_src_mark")
+PKTGEN(PROG_TYPE, "encrypt_v4_3_no_src_mark")
 int encrypt_v4_3_no_src_mark_pktgen(struct __ctx_buff *ctx)
 {
 	return v4_build_packet(ctx);
 }
 
-SETUP("tc", "encrypt_v4_3_no_src_mark")
+SETUP(PROG_TYPE, "encrypt_v4_3_no_src_mark")
 int encrypt_v4_3_no_src_mark_setup(struct __ctx_buff *ctx)
 {
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "encrypt_v4_3_no_src_mark")
+CHECK(PROG_TYPE, "encrypt_v4_3_no_src_mark")
 int encrypt_v4_3_no_src_mark_check(const struct __ctx_buff *ctx)
 {
 #ifdef ENCRYPTION_STRICT_MODE_EGRESS
@@ -216,13 +216,13 @@ int encrypt_v4_3_no_src_mark_check(const struct __ctx_buff *ctx)
 }
 
 /* Finally test without the mark, but with the endpoint's ipcache entry: */
-PKTGEN("tc", "encrypt_v4_4_no_src_mark_with_src_entry")
+PKTGEN(PROG_TYPE, "encrypt_v4_4_no_src_mark_with_src_entry")
 int encrypt_v4_4_no_src_mark_with_src_entry_pktgen(struct __ctx_buff *ctx)
 {
 	return v4_build_packet(ctx);
 }
 
-SETUP("tc", "encrypt_v4_4_no_src_mark_with_src_entry")
+SETUP(PROG_TYPE, "encrypt_v4_4_no_src_mark_with_src_entry")
 int encrypt_v4_4_no_src_mark_with_src_entry_setup(struct __ctx_buff *ctx)
 {
 	ipcache_v4_add_entry(SRC_POD_V4, 0, SRC_POD_SEC_IDENTITY,
@@ -231,7 +231,7 @@ int encrypt_v4_4_no_src_mark_with_src_entry_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "encrypt_v4_4_no_src_mark_with_src_entry")
+CHECK(PROG_TYPE, "encrypt_v4_4_no_src_mark_with_src_entry")
 int encrypt_v4_4_no_src_mark_with_src_entry_check(const struct __ctx_buff *ctx)
 {
 	return check(ctx, CTX_ACT_REDIRECT);
@@ -256,13 +256,13 @@ int v6_build_packet(struct __ctx_buff *ctx)
 	return 0;
 }
 
-PKTGEN("tc", "encrypt_v6_1_missing_dst")
+PKTGEN(PROG_TYPE, "encrypt_v6_1_missing_dst")
 int encrypt_v6_1_missing_dst_pktgen(struct __ctx_buff *ctx)
 {
 	return v6_build_packet(ctx);
 }
 
-SETUP("tc", "encrypt_v6_1_missing_dst")
+SETUP(PROG_TYPE, "encrypt_v6_1_missing_dst")
 int encrypt_v6_1_missing_dst_setup(struct __ctx_buff *ctx)
 {
 	ipcache_v6_add_entry_with_mask_size_ipv6_underlay(DST_POD_CIDR_V6, 0, WORLD_ID,
@@ -279,19 +279,19 @@ int encrypt_v6_1_missing_dst_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "encrypt_v6_1_missing_dst")
+CHECK(PROG_TYPE, "encrypt_v6_1_missing_dst")
 int encrypt_v6_1_missing_dst_check(const struct __ctx_buff *ctx)
 {
 	return check(ctx, CTX_ACT_REDIRECT);
 }
 
-PKTGEN("tc", "encrypt_v6_2_src_mark")
+PKTGEN(PROG_TYPE, "encrypt_v6_2_src_mark")
 int encrypt_v6_2_src_mark_pktgen(struct __ctx_buff *ctx)
 {
 	return v6_build_packet(ctx);
 }
 
-SETUP("tc", "encrypt_v6_2_src_mark")
+SETUP(PROG_TYPE, "encrypt_v6_2_src_mark")
 int encrypt_v6_2_src_mark_setup(struct __ctx_buff *ctx)
 {
 	ipcache_v6_add_entry_ipv6_underlay(DST_POD_V6, 0, DST_POD_SEC_IDENTITY,
@@ -302,37 +302,37 @@ int encrypt_v6_2_src_mark_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "encrypt_v6_2_src_mark")
+CHECK(PROG_TYPE, "encrypt_v6_2_src_mark")
 int encrypt_v6_2_src_mark_check(const struct __ctx_buff *ctx)
 {
 	return check(ctx, CTX_ACT_REDIRECT);
 }
 
-PKTGEN("tc", "encrypt_v6_3_no_src_mark")
+PKTGEN(PROG_TYPE, "encrypt_v6_3_no_src_mark")
 int encrypt_v6_3_no_src_mark_pktgen(struct __ctx_buff *ctx)
 {
 	return v6_build_packet(ctx);
 }
 
-SETUP("tc", "encrypt_v6_3_no_src_mark")
+SETUP(PROG_TYPE, "encrypt_v6_3_no_src_mark")
 int encrypt_v6_3_no_src_mark_setup(struct __ctx_buff *ctx)
 {
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "encrypt_v6_3_no_src_mark")
+CHECK(PROG_TYPE, "encrypt_v6_3_no_src_mark")
 int encrypt_v6_3_no_src_mark_check(const struct __ctx_buff *ctx)
 {
 	return check(ctx, CTX_ACT_OK);
 }
 
-PKTGEN("tc", "encrypt_v6_4_no_src_mark_with_src_entry")
+PKTGEN(PROG_TYPE, "encrypt_v6_4_no_src_mark_with_src_entry")
 int encrypt_v6_4_no_src_mark_with_src_entry_pktgen(struct __ctx_buff *ctx)
 {
 	return v6_build_packet(ctx);
 }
 
-SETUP("tc", "encrypt_v6_4_no_src_mark_with_src_entry")
+SETUP(PROG_TYPE, "encrypt_v6_4_no_src_mark_with_src_entry")
 int encrypt_v6_4_no_src_mark_with_src_entry_setup(struct __ctx_buff *ctx)
 {
 	ipcache_v6_add_entry(SRC_POD_V6, 0, SRC_POD_SEC_IDENTITY,
@@ -341,14 +341,14 @@ int encrypt_v6_4_no_src_mark_with_src_entry_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "encrypt_v6_4_no_src_mark_with_src_entry")
+CHECK(PROG_TYPE, "encrypt_v6_4_no_src_mark_with_src_entry")
 int encrypt_v6_4_no_src_mark_with_src_entry_check(const struct __ctx_buff *ctx)
 {
 	return check(ctx, CTX_ACT_REDIRECT);
 }
 
 #ifdef TUNNEL_MODE
-PKTGEN("tc", "encrypt_v4_vxlan")
+PKTGEN(PROG_TYPE, "encrypt_v4_vxlan")
 int encrypt_v4_vxlan_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -372,7 +372,7 @@ int encrypt_v4_vxlan_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "encrypt_v4_vxlan")
+SETUP(PROG_TYPE, "encrypt_v4_vxlan")
 int encrypt_v4_vxlan_setup(struct __ctx_buff *ctx)
 {
 	set_identity_mark(ctx, SRC_POD_SEC_IDENTITY, MARK_MAGIC_OVERLAY);
@@ -380,13 +380,13 @@ int encrypt_v4_vxlan_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "encrypt_v4_vxlan")
+CHECK(PROG_TYPE, "encrypt_v4_vxlan")
 int encrypt_v4_vxlan_check(const struct __ctx_buff *ctx)
 {
 	return check(ctx, CTX_ACT_REDIRECT);
 }
 
-PKTGEN("tc", "encrypt_v6_vxlan")
+PKTGEN(PROG_TYPE, "encrypt_v6_vxlan")
 int encrypt_v6_vxlan_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -410,7 +410,7 @@ int encrypt_v6_vxlan_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "encrypt_v6_vxlan")
+SETUP(PROG_TYPE, "encrypt_v6_vxlan")
 int encrypt_v6_vxlan_setup(struct __ctx_buff *ctx)
 {
 	set_identity_mark(ctx, SRC_POD_SEC_IDENTITY, MARK_MAGIC_OVERLAY);
@@ -418,7 +418,7 @@ int encrypt_v6_vxlan_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "encrypt_v6_vxlan")
+CHECK(PROG_TYPE, "encrypt_v6_vxlan")
 int encrypt_v6_vxlan_check(const struct __ctx_buff *ctx)
 {
 	return check(ctx, CTX_ACT_REDIRECT);

--- a/bpf/tests/encryption_helpers_ipsec.c
+++ b/bpf/tests/encryption_helpers_ipsec.c
@@ -89,33 +89,33 @@ int check(struct __ctx_buff *ctx, bool ipv4)
 	test_finish();
 }
 
-PKTGEN("tc", "do_decrypt4")
+PKTGEN(PROG_TYPE, "do_decrypt4")
 static __always_inline int
 do_decrypt4_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen(ctx, true);
 }
 
-CHECK("tc", "do_decrypt4")
+CHECK(PROG_TYPE, "do_decrypt4")
 int do_decrypt4_check(struct __ctx_buff *ctx)
 {
 	return check(ctx, true);
 }
 
-PKTGEN("tc", "do_decrypt6")
+PKTGEN(PROG_TYPE, "do_decrypt6")
 static __always_inline int
 do_decrypt6_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen(ctx, false);
 }
 
-CHECK("tc", "do_decrypt6")
+CHECK(PROG_TYPE, "do_decrypt6")
 int do_decrypt6_check(struct __ctx_buff *ctx)
 {
 	return check(ctx, false);
 }
 
-CHECK("tc", "ctx_is_encrypt_success")
+CHECK(PROG_TYPE, "ctx_is_encrypt_success")
 int check2(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -129,7 +129,7 @@ int check2(struct __ctx_buff *ctx)
 	test_finish();
 }
 
-CHECK("tc", "ctx_is_decrypt_success")
+CHECK(PROG_TYPE, "ctx_is_decrypt_success")
 int check3(struct __ctx_buff *ctx)
 {
 	test_init();

--- a/bpf/tests/encryption_helpers_ipsec_native.c
+++ b/bpf/tests/encryption_helpers_ipsec_native.c
@@ -148,73 +148,73 @@ int bad_identities_check(struct __ctx_buff *ctx, bool is_ipv4)
 	test_finish();
 }
 
-PKTGEN("tc", "ipsec_redirect4")
+PKTGEN(PROG_TYPE, "ipsec_redirect4")
 int ipsec_redirect4_pktgen(struct __ctx_buff *ctx)
 {
 	return generate_native_packet(ctx, true);
 }
 
-CHECK("tc", "ipsec_redirect4")
+CHECK(PROG_TYPE, "ipsec_redirect4")
 int ipsec_redirect4_check(struct __ctx_buff *ctx)
 {
 	return ipsec_redirect_checks(ctx, true, true);
 }
 
-PKTGEN("tc", "ipsec_redirect4_over6")
+PKTGEN(PROG_TYPE, "ipsec_redirect4_over6")
 int ipsec_redirect4_over6_pktgen(struct __ctx_buff *ctx)
 {
 	return generate_native_packet(ctx, true);
 }
 
-CHECK("tc", "ipsec_redirect4_over6")
+CHECK(PROG_TYPE, "ipsec_redirect4_over6")
 int ipsec_redirect4_over6_check(struct __ctx_buff *ctx)
 {
 	return ipsec_redirect_checks(ctx, true, false);
 }
 
-PKTGEN("tc", "ipsec_redirect6")
+PKTGEN(PROG_TYPE, "ipsec_redirect6")
 int ipsec_redirect6_pktgen(struct __ctx_buff *ctx)
 {
 	return generate_native_packet(ctx, false);
 }
 
-CHECK("tc", "ipsec_redirect6")
+CHECK(PROG_TYPE, "ipsec_redirect6")
 int ipsec_redirect6_check(struct __ctx_buff *ctx)
 {
 	return ipsec_redirect_checks(ctx, false, true);
 }
 
-PKTGEN("tc", "ipsec_redirect6_over6")
+PKTGEN(PROG_TYPE, "ipsec_redirect6_over6")
 int ipsec_redirect6_over6_pktgen(struct __ctx_buff *ctx)
 {
 	return generate_native_packet(ctx, false);
 }
 
-CHECK("tc", "ipsec_redirect6_over6")
+CHECK(PROG_TYPE, "ipsec_redirect6_over6")
 int ipsec_redirect6_over6_check(struct __ctx_buff *ctx)
 {
 	return ipsec_redirect_checks(ctx, false, false);
 }
 
-PKTGEN("tc", "ipsec_redirect_bad_identities4")
+PKTGEN(PROG_TYPE, "ipsec_redirect_bad_identities4")
 int ipsec_redirect_bad_identities4_pktgen(struct __ctx_buff *ctx)
 {
 	return generate_native_packet(ctx, true);
 }
 
-CHECK("tc", "ipsec_redirect_bad_identities4")
+CHECK(PROG_TYPE, "ipsec_redirect_bad_identities4")
 int ipsec_redirect_bad_identities4_check(struct __ctx_buff *ctx)
 {
 	return bad_identities_check(ctx, true);
 }
 
-PKTGEN("tc", "ipsec_redirect_bad_identities6")
+PKTGEN(PROG_TYPE, "ipsec_redirect_bad_identities6")
 int ipsec_redirect_bad_identities6_pktgen(struct __ctx_buff *ctx)
 {
 	return generate_native_packet(ctx, false);
 }
 
-CHECK("tc", "ipsec_redirect_bad_identities6")
+CHECK(PROG_TYPE, "ipsec_redirect_bad_identities6")
 int ipsec_redirect_bad_identities6_check(struct __ctx_buff *ctx)
 {
 	return bad_identities_check(ctx, false);

--- a/bpf/tests/encryption_helpers_ipsec_tunnel.c
+++ b/bpf/tests/encryption_helpers_ipsec_tunnel.c
@@ -51,49 +51,49 @@ int ipsec_redirect_checks(__maybe_unused struct __ctx_buff *ctx, bool outer_ipv4
 	test_finish();
 }
 
-PKTGEN("tc", "ipsec_redirect_tunnel4_v4")
+PKTGEN(PROG_TYPE, "ipsec_redirect_tunnel4_v4")
 int ipsec_redirect_tunnel4_v4_pktgen(struct __ctx_buff *ctx)
 {
 	return generate_vxlan_packet(ctx, true, true);
 }
 
-CHECK("tc", "ipsec_redirect_tunnel4_v4")
+CHECK(PROG_TYPE, "ipsec_redirect_tunnel4_v4")
 int ipsec_redirect_tunnel4_v4_check(__maybe_unused struct __ctx_buff *ctx)
 {
 	return ipsec_redirect_checks(ctx, true);
 }
 
-PKTGEN("tc", "ipsec_redirect_tunnel4_v6")
+PKTGEN(PROG_TYPE, "ipsec_redirect_tunnel4_v6")
 int ipsec_redirect_tunnel4_v6_pktgen(struct __ctx_buff *ctx)
 {
 	return generate_vxlan_packet(ctx, true, false);
 }
 
-CHECK("tc", "ipsec_redirect_tunnel4_v6")
+CHECK(PROG_TYPE, "ipsec_redirect_tunnel4_v6")
 int ipsec_redirect_tunnel4_v6_check(__maybe_unused struct __ctx_buff *ctx)
 {
 	return ipsec_redirect_checks(ctx, true);
 }
 
-PKTGEN("tc", "ipsec_redirect_tunnel6_v4")
+PKTGEN(PROG_TYPE, "ipsec_redirect_tunnel6_v4")
 int ipsec_redirect_tunnel6_v4_pktgen(struct __ctx_buff *ctx)
 {
 	return generate_vxlan_packet(ctx, false, true);
 }
 
-CHECK("tc", "ipsec_redirect_tunnel6_v4")
+CHECK(PROG_TYPE, "ipsec_redirect_tunnel6_v4")
 int ipsec_redirect_tunnel6_v4_check(__maybe_unused struct __ctx_buff *ctx)
 {
 	return ipsec_redirect_checks(ctx, false);
 }
 
-PKTGEN("tc", "ipsec_redirect_tunnel6_v6")
+PKTGEN(PROG_TYPE, "ipsec_redirect_tunnel6_v6")
 int ipsec_redirect_tunnel6_v6_pktgen(struct __ctx_buff *ctx)
 {
 	return generate_vxlan_packet(ctx, false, true);
 }
 
-CHECK("tc", "ipsec_redirect_tunnel6_v6")
+CHECK(PROG_TYPE, "ipsec_redirect_tunnel6_v6")
 int ipsec_redirect_tunnel6_v6_check(__maybe_unused struct __ctx_buff *ctx)
 {
 	return ipsec_redirect_checks(ctx, false);

--- a/bpf/tests/encryption_helpers_wireguard.c
+++ b/bpf/tests/encryption_helpers_wireguard.c
@@ -23,7 +23,7 @@
 ASSIGN_CONFIG(__u32, wg_ifindex, 42)
 ASSIGN_CONFIG(__u16, wg_port, 51871)
 
-PKTGEN("tc", "ctx_is_wireguard_success")
+PKTGEN(PROG_TYPE, "ctx_is_wireguard_success")
 static __always_inline int
 pktgen_wireguard_mock_check1(struct __ctx_buff *ctx) {
 	struct pktgen builder;
@@ -46,7 +46,7 @@ pktgen_wireguard_mock_check1(struct __ctx_buff *ctx) {
 	return 0;
 }
 
-CHECK("tc", "ctx_is_wireguard_success")
+CHECK(PROG_TYPE, "ctx_is_wireguard_success")
 int check1(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -86,7 +86,7 @@ int check1(struct __ctx_buff *ctx)
 	test_finish();
 }
 
-CHECK("tc", "ctx_is_encrypt_success")
+CHECK(PROG_TYPE, "ctx_is_encrypt_success")
 int check2(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -100,7 +100,7 @@ int check2(struct __ctx_buff *ctx)
 	test_finish();
 }
 
-CHECK("tc", "ctx_is_decrypt_success")
+CHECK(PROG_TYPE, "ctx_is_decrypt_success")
 int check3(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -114,7 +114,7 @@ int check3(struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "wireguard_icmpv6_na_skip")
+PKTGEN(PROG_TYPE, "wireguard_icmpv6_na_skip")
 int wireguard_icmpv6_na_skip_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -136,7 +136,7 @@ int wireguard_icmpv6_na_skip_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-CHECK("tc", "wireguard_icmpv6_na_skip")
+CHECK(PROG_TYPE, "wireguard_icmpv6_na_skip")
 int wireguard_icmpv6_na_skip_check(struct __ctx_buff *ctx)
 {
 	int ret_val;

--- a/bpf/tests/eni_nlb_symetric_routing_host.c
+++ b/bpf/tests/eni_nlb_symetric_routing_host.c
@@ -79,7 +79,7 @@ ASSIGN_CONFIG(__u32, interface_ifindex, PRIMARY_IFACE)
  */
 
 /* Create a boring TCP packet */
-PKTGEN("tc", "eni_nlb_symetric_routing_egress_v4_setup")
+PKTGEN(PROG_TYPE, "eni_nlb_symetric_routing_egress_v4_setup")
 int eni_nlb_symetric_routing_egress_v4_setup_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -107,7 +107,7 @@ int eni_nlb_symetric_routing_egress_v4_setup_pktgen(struct __ctx_buff *ctx)
 }
 
 /* Setup IPCache / Endpoint map / CT state according to the scenario */
-SETUP("tc", "eni_nlb_symetric_routing_egress_v4_setup")
+SETUP(PROG_TYPE, "eni_nlb_symetric_routing_egress_v4_setup")
 int eni_nlb_symetric_routing_egress_v4_setup_setup(struct __ctx_buff *ctx)
 {
 	struct ipv4_ct_tuple ct = {
@@ -132,7 +132,7 @@ int eni_nlb_symetric_routing_egress_v4_setup_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "eni_nlb_symetric_routing_egress_v4_setup")
+CHECK(PROG_TYPE, "eni_nlb_symetric_routing_egress_v4_setup")
 int eni_nlb_symetric_routing_egress_v4_setup_check(const struct __ctx_buff *ctx)
 {
 	void *data;
@@ -192,7 +192,7 @@ int eni_nlb_symetric_routing_egress_v4_setup_check(const struct __ctx_buff *ctx)
 }
 
 /* The same test, but for ICMP */
-PKTGEN("tc", "eni_nlb_symetric_routing_egress_v4_setup_icmp")
+PKTGEN(PROG_TYPE, "eni_nlb_symetric_routing_egress_v4_setup_icmp")
 int eni_nlb_symetric_routing_egress_v4_setup_icmp_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -220,7 +220,7 @@ int eni_nlb_symetric_routing_egress_v4_setup_icmp_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "eni_nlb_symetric_routing_egress_v4_setup_icmp")
+SETUP(PROG_TYPE, "eni_nlb_symetric_routing_egress_v4_setup_icmp")
 int eni_nlb_symetric_routing_egress_v4_setup_icmp_setup(struct __ctx_buff *ctx)
 {
 	struct ipv4_ct_tuple ct = {
@@ -245,7 +245,7 @@ int eni_nlb_symetric_routing_egress_v4_setup_icmp_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "eni_nlb_symetric_routing_egress_v4_setup_icmp")
+CHECK(PROG_TYPE, "eni_nlb_symetric_routing_egress_v4_setup_icmp")
 int eni_nlb_symetric_routing_egress_v4_setup_icmp_check(const struct __ctx_buff *ctx)
 {
 	void *data;

--- a/bpf/tests/fib_tests.c
+++ b/bpf/tests/fib_tests.c
@@ -64,7 +64,7 @@ long mock_fib_lookup(void *ctx __maybe_unused,
 
 ASSIGN_CONFIG(bool, supports_fib_lookup_skip_neigh, true)
 
-CHECK("tc", "fib_do_redirect_happy_path")
+CHECK(PROG_TYPE, "fib_do_redirect_happy_path")
 int test1_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -178,7 +178,7 @@ int test1_check(struct __ctx_buff *ctx)
 	test_finish();
 }
 
-CHECK("tc", "fib_redirect*_fib_lookup_flags")
+CHECK(PROG_TYPE, "fib_redirect*_fib_lookup_flags")
 int test2_check(struct __ctx_buff *ctx)
 {
 	test_init();

--- a/bpf/tests/hairpin_sctp_flow.c
+++ b/bpf/tests/hairpin_sctp_flow.c
@@ -41,7 +41,7 @@ ASSIGN_CONFIG(bool, enable_endpoint_routes, true)
 /* Test that sending a packet from a pod to its own service gets source nat-ed
  * and that it is forwarded to the correct veth.
  */
-SETUP("tc", "hairpin_sctp_flow_1_forward_v4")
+SETUP(PROG_TYPE, "hairpin_sctp_flow_1_forward_v4")
 int hairpin_flow_forward_setup(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -85,7 +85,7 @@ int hairpin_flow_forward_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "hairpin_sctp_flow_1_forward_v4")
+CHECK(PROG_TYPE, "hairpin_sctp_flow_1_forward_v4")
 int hairpin_flow_forward_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data;
@@ -137,7 +137,7 @@ int hairpin_flow_forward_check(__maybe_unused const struct __ctx_buff *ctx)
 }
 
 /* Let backend's ingress path create its CT own entry: */
-PKTGEN("tc", "hairpin_sctp_flow_2_forward_ingress_v4")
+PKTGEN(PROG_TYPE, "hairpin_sctp_flow_2_forward_ingress_v4")
 int hairpin_flow_forward_ingress_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -169,13 +169,13 @@ int hairpin_flow_forward_ingress_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "hairpin_sctp_flow_2_forward_ingress_v4")
+SETUP(PROG_TYPE, "hairpin_sctp_flow_2_forward_ingress_v4")
 int hairpin_flow_forward_ingress_setup(struct __ctx_buff *ctx)
 {
 	return pod_receive_packet(ctx);
 }
 
-CHECK("tc", "hairpin_sctp_flow_2_forward_ingress_v4")
+CHECK(PROG_TYPE, "hairpin_sctp_flow_2_forward_ingress_v4")
 int hairpin_flow_forward_ingress_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data;
@@ -225,7 +225,7 @@ int hairpin_flow_forward_ingress_check(__maybe_unused const struct __ctx_buff *c
 }
 
 /* Test that a packet in the reverse direction gets translated back. */
-SETUP("tc", "hairpin_sctp_flow_3_reverse_v4")
+SETUP(PROG_TYPE, "hairpin_sctp_flow_3_reverse_v4")
 int hairpin_flow_rev_setup(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -259,7 +259,7 @@ int hairpin_flow_rev_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "hairpin_sctp_flow_3_reverse_v4")
+CHECK(PROG_TYPE, "hairpin_sctp_flow_3_reverse_v4")
 int hairpin_flow_rev_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data;
@@ -307,7 +307,7 @@ int hairpin_flow_rev_check(__maybe_unused const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "hairpin_sctp_flow_4_reverse_ingress_v4")
+PKTGEN(PROG_TYPE, "hairpin_sctp_flow_4_reverse_ingress_v4")
 int hairpin_sctp_flow_4_reverse_ingress_v4_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -339,13 +339,13 @@ int hairpin_sctp_flow_4_reverse_ingress_v4_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "hairpin_sctp_flow_4_reverse_ingress_v4")
+SETUP(PROG_TYPE, "hairpin_sctp_flow_4_reverse_ingress_v4")
 int hairpin_sctp_flow_4_reverse_ingress_v4_setup(struct __ctx_buff *ctx)
 {
 	return pod_receive_packet(ctx);
 }
 
-CHECK("tc", "hairpin_sctp_flow_4_reverse_ingress_v4")
+CHECK(PROG_TYPE, "hairpin_sctp_flow_4_reverse_ingress_v4")
 int hairpin_sctp_flow_4_reverse_ingress_v4_check(const struct __ctx_buff *ctx)
 {
 	void *data;

--- a/bpf/tests/host_bpf_masq.h
+++ b/bpf/tests/host_bpf_masq.h
@@ -39,7 +39,7 @@ ASSIGN_CONFIG(bool, enable_conntrack_accounting, true)
 #include "lib/ipcache.h"
 
 /* Host-originating UDP should be tracked by BPF Masq. */
-PKTGEN("tc", "host_bpf_masq_v4_1_udp")
+PKTGEN(PROG_TYPE, "host_bpf_masq_v4_1_udp")
 int host_bpf_masq_v4_1_udp_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -61,7 +61,7 @@ int host_bpf_masq_v4_1_udp_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "host_bpf_masq_v4_1_udp")
+SETUP(PROG_TYPE, "host_bpf_masq_v4_1_udp")
 int host_bpf_masq_v4_1_udp_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v4_add_entry(NODE_IP, 0, 0, ENDPOINT_F_HOST, HOST_ID,
@@ -74,7 +74,7 @@ int host_bpf_masq_v4_1_udp_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "host_bpf_masq_v4_1_udp")
+CHECK(PROG_TYPE, "host_bpf_masq_v4_1_udp")
 int host_bpf_masq_v4_1_udp_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -113,7 +113,7 @@ int host_bpf_masq_v4_1_udp_check(const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "host_bpf_masq_v6_1_udp")
+PKTGEN(PROG_TYPE, "host_bpf_masq_v6_1_udp")
 int host_bpf_masq_v6_1_udp_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -135,7 +135,7 @@ int host_bpf_masq_v6_1_udp_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "host_bpf_masq_v6_1_udp")
+SETUP(PROG_TYPE, "host_bpf_masq_v6_1_udp")
 int host_bpf_masq_v6_1_udp_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v6_add_entry((union v6addr *)NODE_IP_V6, 0, 0, ENDPOINT_F_HOST, HOST_ID,
@@ -148,7 +148,7 @@ int host_bpf_masq_v6_1_udp_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "host_bpf_masq_v6_1_udp")
+CHECK(PROG_TYPE, "host_bpf_masq_v6_1_udp")
 int host_bpf_masq_v6_1_udp_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -189,7 +189,7 @@ int host_bpf_masq_v6_1_udp_check(const struct __ctx_buff *ctx)
 }
 
 /* Host-originating IPIP should be skipped by BPF Masq. */
-PKTGEN("tc", "host_bpf_masq_v4_2_ipip")
+PKTGEN(PROG_TYPE, "host_bpf_masq_v4_2_ipip")
 int host_bpf_masq_v4_2_ipip_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -212,7 +212,7 @@ int host_bpf_masq_v4_2_ipip_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "host_bpf_masq_v4_2_ipip")
+SETUP(PROG_TYPE, "host_bpf_masq_v4_2_ipip")
 int host_bpf_masq_v4_2_ipip_setup(struct __ctx_buff *ctx)
 {
 	set_identity_mark(ctx, 0, MARK_MAGIC_HOST);
@@ -220,7 +220,7 @@ int host_bpf_masq_v4_2_ipip_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "host_bpf_masq_v4_2_ipip")
+CHECK(PROG_TYPE, "host_bpf_masq_v4_2_ipip")
 int host_bpf_masq_v4_2_ipip_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -241,7 +241,7 @@ int host_bpf_masq_v4_2_ipip_check(const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "host_bpf_masq_v6_2_ipip")
+PKTGEN(PROG_TYPE, "host_bpf_masq_v6_2_ipip")
 int host_bpf_masq_v6_2_ipip_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -264,7 +264,7 @@ int host_bpf_masq_v6_2_ipip_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "host_bpf_masq_v6_2_ipip")
+SETUP(PROG_TYPE, "host_bpf_masq_v6_2_ipip")
 int host_bpf_masq_v6_2_ipip_setup(struct __ctx_buff *ctx)
 {
 	set_identity_mark(ctx, 0, MARK_MAGIC_HOST);
@@ -272,7 +272,7 @@ int host_bpf_masq_v6_2_ipip_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "host_bpf_masq_v6_2_ipip")
+CHECK(PROG_TYPE, "host_bpf_masq_v6_2_ipip")
 int host_bpf_masq_v6_2_ipip_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -294,7 +294,7 @@ int host_bpf_masq_v6_2_ipip_check(const struct __ctx_buff *ctx)
 }
 
 /* Host-originating unhandled ICMP should be dropped by BPF Masq. */
-PKTGEN("tc", "host_bpf_masq_v4_3_icmp_unhandled")
+PKTGEN(PROG_TYPE, "host_bpf_masq_v4_3_icmp_unhandled")
 int host_bpf_masq_v4_3_icmp_unhandled_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -316,7 +316,7 @@ int host_bpf_masq_v4_3_icmp_unhandled_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "host_bpf_masq_v4_3_icmp_unhandled")
+SETUP(PROG_TYPE, "host_bpf_masq_v4_3_icmp_unhandled")
 int host_bpf_masq_v4_3_icmp_unhandledp_setup(struct __ctx_buff *ctx)
 {
 	set_identity_mark(ctx, 0, MARK_MAGIC_HOST);
@@ -324,7 +324,7 @@ int host_bpf_masq_v4_3_icmp_unhandledp_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "host_bpf_masq_v4_3_icmp_unhandled")
+CHECK(PROG_TYPE, "host_bpf_masq_v4_3_icmp_unhandled")
 int host_bpf_masq_v4_3_icmp_timestamp_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -345,7 +345,7 @@ int host_bpf_masq_v4_3_icmp_timestamp_check(const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "host_bpf_masq_v6_3_icmp_unhandled")
+PKTGEN(PROG_TYPE, "host_bpf_masq_v6_3_icmp_unhandled")
 int host_bpf_masq_v6_3_icmp_unhandled_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -367,7 +367,7 @@ int host_bpf_masq_v6_3_icmp_unhandled_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "host_bpf_masq_v6_3_icmp_unhandled")
+SETUP(PROG_TYPE, "host_bpf_masq_v6_3_icmp_unhandled")
 int host_bpf_masq_v6_3_icmp_unhandled_setup(struct __ctx_buff *ctx)
 {
 	set_identity_mark(ctx, 0, MARK_MAGIC_HOST);
@@ -375,7 +375,7 @@ int host_bpf_masq_v6_3_icmp_unhandled_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "host_bpf_masq_v6_3_icmp_unhandled")
+CHECK(PROG_TYPE, "host_bpf_masq_v6_3_icmp_unhandled")
 int host_bpf_masq_v6_3_icmp_unhandled_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -397,7 +397,7 @@ int host_bpf_masq_v6_3_icmp_unhandled_check(const struct __ctx_buff *ctx)
 }
 
 /* Host-originating ICMP ECHO should be tracked by BPF Masq. */
-PKTGEN("tc", "host_bpf_masq_v4_4_icmp_echo")
+PKTGEN(PROG_TYPE, "host_bpf_masq_v4_4_icmp_echo")
 int host_bpf_masq_v4_4_icmp_echo_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -421,7 +421,7 @@ int host_bpf_masq_v4_4_icmp_echo_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "host_bpf_masq_v4_4_icmp_echo")
+SETUP(PROG_TYPE, "host_bpf_masq_v4_4_icmp_echo")
 int host_bpf_masq_v4_4_icmp_echo_setup(struct __ctx_buff *ctx)
 {
 	set_identity_mark(ctx, 0, MARK_MAGIC_HOST);
@@ -429,7 +429,7 @@ int host_bpf_masq_v4_4_icmp_echo_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "host_bpf_masq_v4_4_icmp_echo")
+CHECK(PROG_TYPE, "host_bpf_masq_v4_4_icmp_echo")
 int host_bpf_masq_v4_4_icmp_echo_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -466,7 +466,7 @@ int host_bpf_masq_v4_4_icmp_echo_check(const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "host_bpf_masq_v6_4_icmp_echo")
+PKTGEN(PROG_TYPE, "host_bpf_masq_v6_4_icmp_echo")
 int host_bpf_masq_v6_4_icmp_echo_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -490,7 +490,7 @@ int host_bpf_masq_v6_4_icmp_echo_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "host_bpf_masq_v6_4_icmp_echo")
+SETUP(PROG_TYPE, "host_bpf_masq_v6_4_icmp_echo")
 int host_bpf_masq_v6_4_icmp_echo_setup(struct __ctx_buff *ctx)
 {
 	set_identity_mark(ctx, 0, MARK_MAGIC_HOST);
@@ -498,7 +498,7 @@ int host_bpf_masq_v6_4_icmp_echo_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "host_bpf_masq_v6_4_icmp_echo")
+CHECK(PROG_TYPE, "host_bpf_masq_v6_4_icmp_echo")
 int host_bpf_masq_v6_4_icmp_echo_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -537,7 +537,7 @@ int host_bpf_masq_v6_4_icmp_echo_check(const struct __ctx_buff *ctx)
 }
 
 /* NO_SNAT endpoints should not be masqueraded */
-PKTGEN("tc", "host_bpf_masq_v4_5_no_snat_ep_udp")
+PKTGEN(PROG_TYPE, "host_bpf_masq_v4_5_no_snat_ep_udp")
 int host_bpf_masq_v4_5_no_snat_ep_udp_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -557,7 +557,7 @@ int host_bpf_masq_v4_5_no_snat_ep_udp_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "host_bpf_masq_v4_5_no_snat_ep_udp")
+SETUP(PROG_TYPE, "host_bpf_masq_v4_5_no_snat_ep_udp")
 int host_bpf_masq_v4_5_no_snat_ep_udp_setup(struct __ctx_buff *ctx)
 {
 	/* mark the source IP as a local endpoint with NO_SNAT flag */
@@ -566,7 +566,7 @@ int host_bpf_masq_v4_5_no_snat_ep_udp_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "host_bpf_masq_v4_5_no_snat_ep_udp")
+CHECK(PROG_TYPE, "host_bpf_masq_v4_5_no_snat_ep_udp")
 int host_bpf_masq_v4_5_no_snat_ep_udp_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -596,7 +596,7 @@ int host_bpf_masq_v4_5_no_snat_ep_udp_check(const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "host_bpf_masq_v6_5_no_snat_ep_udp")
+PKTGEN(PROG_TYPE, "host_bpf_masq_v6_5_no_snat_ep_udp")
 int host_bpf_masq_v6_5_no_snat_ep_udp_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -616,7 +616,7 @@ int host_bpf_masq_v6_5_no_snat_ep_udp_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "host_bpf_masq_v6_5_no_snat_ep_udp")
+SETUP(PROG_TYPE, "host_bpf_masq_v6_5_no_snat_ep_udp")
 int host_bpf_masq_v6_5_no_snat_ep_udp_setup(struct __ctx_buff *ctx)
 {
 	/* mark the source IP as a local endpoint with NO_SNAT flag */
@@ -631,7 +631,7 @@ int host_bpf_masq_v6_5_no_snat_ep_udp_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "host_bpf_masq_v6_5_no_snat_ep_udp")
+CHECK(PROG_TYPE, "host_bpf_masq_v6_5_no_snat_ep_udp")
 int host_bpf_masq_v6_5_no_snat_ep_udp_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -666,7 +666,7 @@ int host_bpf_masq_v6_5_no_snat_ep_udp_check(const struct __ctx_buff *ctx)
 }
 
 /* Regular endpoints (without NO_SNAT) should be masqueraded */
-PKTGEN("tc", "host_bpf_masq_v4_6_snat_ep_udp")
+PKTGEN(PROG_TYPE, "host_bpf_masq_v4_6_snat_ep_udp")
 int host_bpf_masq_v4_6_snat_ep_udp_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -686,7 +686,7 @@ int host_bpf_masq_v4_6_snat_ep_udp_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "host_bpf_masq_v4_6_snat_ep_udp")
+SETUP(PROG_TYPE, "host_bpf_masq_v4_6_snat_ep_udp")
 int host_bpf_masq_v4_6_snat_ep_udp_setup(struct __ctx_buff *ctx)
 {
 	/* mark the source IP as a local endpoint without NO_SNAT flag */
@@ -695,7 +695,7 @@ int host_bpf_masq_v4_6_snat_ep_udp_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "host_bpf_masq_v4_6_snat_ep_udp")
+CHECK(PROG_TYPE, "host_bpf_masq_v4_6_snat_ep_udp")
 int host_bpf_masq_v4_6_snat_ep_udp_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -724,7 +724,7 @@ int host_bpf_masq_v4_6_snat_ep_udp_check(const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "host_bpf_masq_v6_6_snat_ep_udp")
+PKTGEN(PROG_TYPE, "host_bpf_masq_v6_6_snat_ep_udp")
 int host_bpf_masq_v6_6_snat_ep_udp_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -744,7 +744,7 @@ int host_bpf_masq_v6_6_snat_ep_udp_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "host_bpf_masq_v6_6_snat_ep_udp")
+SETUP(PROG_TYPE, "host_bpf_masq_v6_6_snat_ep_udp")
 int host_bpf_masq_v6_6_snat_ep_udp_setup(struct __ctx_buff *ctx)
 {
 	/* mark the source IP as a local endpoint without NO_SNAT flag */
@@ -753,7 +753,7 @@ int host_bpf_masq_v6_6_snat_ep_udp_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "host_bpf_masq_v6_6_snat_ep_udp")
+CHECK(PROG_TYPE, "host_bpf_masq_v6_6_snat_ep_udp")
 int host_bpf_masq_v6_6_snat_ep_udp_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/host_proxy.c
+++ b/bpf/tests/host_proxy.c
@@ -56,13 +56,13 @@ pktgen(struct __ctx_buff *ctx, __be16 node_port, bool to_pod)
 /* Validate that a host-to-world packet matching a `proxy` policy entry
  * is actually redirected to the proxy.
  */
-PKTGEN("tc", "proxy_v4_1_host_to_world")
+PKTGEN(PROG_TYPE, "proxy_v4_1_host_to_world")
 int proxy_v4_1_host_to_world_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen(ctx, NODE_PORT, false);
 }
 
-SETUP("tc", "proxy_v4_1_host_to_world")
+SETUP(PROG_TYPE, "proxy_v4_1_host_to_world")
 int proxy_v4_1_host_to_world_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v4_add_entry(NODE_IP, 0, 0, ENDPOINT_F_HOST, HOST_ID,
@@ -114,7 +114,7 @@ check_redirect(struct __ctx_buff *ctx, bool to_pod)
 	test_finish();
 }
 
-CHECK("tc", "proxy_v4_1_host_to_world")
+CHECK(PROG_TYPE, "proxy_v4_1_host_to_world")
 int proxy_v4_1_host_to_world_check(struct __ctx_buff *ctx)
 {
 	return check_redirect(ctx, false);
@@ -122,13 +122,13 @@ int proxy_v4_1_host_to_world_check(struct __ctx_buff *ctx)
 
 /* Validate that a proxy-to-world packet is not redirected back to the proxy.
  */
-PKTGEN("tc", "proxy_v4_2_proxy_to_world")
+PKTGEN(PROG_TYPE, "proxy_v4_2_proxy_to_world")
 int proxy_v4_2_proxy_to_world_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen(ctx, NODE_PROXY_PORT, false);
 }
 
-SETUP("tc", "proxy_v4_2_proxy_to_world")
+SETUP(PROG_TYPE, "proxy_v4_2_proxy_to_world")
 int proxy_v4_2_proxy_to_world_setup(struct __ctx_buff *ctx)
 {
 	set_identity_mark(ctx, HOST_ID, MARK_MAGIC_PROXY_EGRESS);
@@ -183,7 +183,7 @@ check_passthrough(const struct __ctx_buff *ctx, bool to_pod)
 	test_finish();
 }
 
-CHECK("tc", "proxy_v4_2_proxy_to_world")
+CHECK(PROG_TYPE, "proxy_v4_2_proxy_to_world")
 int proxy_v4_2_proxy_to_world_check(const struct __ctx_buff *ctx)
 {
 	return check_passthrough(ctx, false);
@@ -192,13 +192,13 @@ int proxy_v4_2_proxy_to_world_check(const struct __ctx_buff *ctx)
 /* Validate that a host-to-pod packet matching a `proxy` policy entry
  * is actually redirected to the proxy.
  */
-PKTGEN("tc", "proxy_v4_3_host_to_pod")
+PKTGEN(PROG_TYPE, "proxy_v4_3_host_to_pod")
 int proxy_v4_3_host_to_pod_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen(ctx, NODE_PORT, true);
 }
 
-SETUP("tc", "proxy_v4_3_host_to_pod")
+SETUP(PROG_TYPE, "proxy_v4_3_host_to_pod")
 int proxy_v4_3_host_to_pod_setup(struct __ctx_buff *ctx)
 {
 	ipcache_v4_add_entry(POD_IP, 0, POD_SECURITY_ID, 0, 0);
@@ -208,7 +208,7 @@ int proxy_v4_3_host_to_pod_setup(struct __ctx_buff *ctx)
 	return host_send_packet(ctx);
 }
 
-CHECK("tc", "proxy_v4_3_host_to_pod")
+CHECK(PROG_TYPE, "proxy_v4_3_host_to_pod")
 int proxy_v4_3_host_to_pod_check(struct __ctx_buff *ctx)
 {
 	return check_redirect(ctx, true);
@@ -216,13 +216,13 @@ int proxy_v4_3_host_to_pod_check(struct __ctx_buff *ctx)
 
 /* Validate that a proxy-to-pod packet is not redirected back to the proxy.
  */
-PKTGEN("tc", "proxy_v4_4_proxy_to_pod")
+PKTGEN(PROG_TYPE, "proxy_v4_4_proxy_to_pod")
 int proxy_v4_4_proxy_to_pod_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen(ctx, NODE_PROXY_PORT, true);
 }
 
-SETUP("tc", "proxy_v4_4_proxy_to_pod")
+SETUP(PROG_TYPE, "proxy_v4_4_proxy_to_pod")
 int proxy_v4_4_proxy_to_pod_setup(struct __ctx_buff *ctx)
 {
 	set_identity_mark(ctx, HOST_ID, MARK_MAGIC_PROXY_EGRESS);
@@ -230,7 +230,7 @@ int proxy_v4_4_proxy_to_pod_setup(struct __ctx_buff *ctx)
 	return host_send_packet(ctx);
 }
 
-CHECK("tc", "proxy_v4_4_proxy_to_pod")
+CHECK(PROG_TYPE, "proxy_v4_4_proxy_to_pod")
 int proxy_v4_4_proxy_to_pod_check(const struct __ctx_buff *ctx)
 {
 	return check_passthrough(ctx, true);

--- a/bpf/tests/hostfw_bpf_masq.c
+++ b/bpf/tests/hostfw_bpf_masq.c
@@ -37,7 +37,7 @@ ASSIGN_CONFIG(bool, enable_conntrack_accounting, true)
  * The egress path should create a CT entry, but apply no egress network policy.
  * The ingress path should apply no ingress network policy.
  */
-PKTGEN("tc", "hostfw_ipv4_bpf_masq_proxy_01")
+PKTGEN(PROG_TYPE, "hostfw_ipv4_bpf_masq_proxy_01")
 int hostfw_ipv4_bpf_masq_proxy_01_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -59,7 +59,7 @@ int hostfw_ipv4_bpf_masq_proxy_01_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "hostfw_ipv4_bpf_masq_proxy_01")
+SETUP(PROG_TYPE, "hostfw_ipv4_bpf_masq_proxy_01")
 int hostfw_ipv4_bpf_masq_proxy_01_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v4_add_entry(NODE_IP, 0, 0, ENDPOINT_F_HOST, HOST_ID,
@@ -74,7 +74,7 @@ int hostfw_ipv4_bpf_masq_proxy_01_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "hostfw_ipv4_bpf_masq_proxy_01")
+CHECK(PROG_TYPE, "hostfw_ipv4_bpf_masq_proxy_01")
 int hostfw_ipv4_bpf_masq_proxy_01_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -115,7 +115,7 @@ int hostfw_ipv4_bpf_masq_proxy_01_check(const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "hostfw_ipv4_bpf_masq_proxy_02")
+PKTGEN(PROG_TYPE, "hostfw_ipv4_bpf_masq_proxy_02")
 int hostfw_ipv4_bpf_masq_proxy_02_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -137,7 +137,7 @@ int hostfw_ipv4_bpf_masq_proxy_02_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "hostfw_ipv4_bpf_masq_proxy_02")
+SETUP(PROG_TYPE, "hostfw_ipv4_bpf_masq_proxy_02")
 int hostfw_ipv4_bpf_masq_proxy_02_setup(struct __ctx_buff *ctx)
 {
 	policy_add_ingress_allow_all_entry();
@@ -145,7 +145,7 @@ int hostfw_ipv4_bpf_masq_proxy_02_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "hostfw_ipv4_bpf_masq_proxy_02")
+CHECK(PROG_TYPE, "hostfw_ipv4_bpf_masq_proxy_02")
 int hostfw_ipv4_bpf_masq_proxy_02_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/hostfw_host_iptables.c
+++ b/bpf/tests/hostfw_host_iptables.c
@@ -38,7 +38,7 @@ ASSIGN_CONFIG(bool, enable_conntrack_accounting, true)
  * The egress path should create a CT entry, but apply no egress network policy.
  * The ingress path should apply no ingress network policy.
  */
-PKTGEN("tc", "hostfw_iptables_host_ipv4_01_pod")
+PKTGEN(PROG_TYPE, "hostfw_iptables_host_ipv4_01_pod")
 int hostfw_iptables_host_ipv4_01_pod_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -60,7 +60,7 @@ int hostfw_iptables_host_ipv4_01_pod_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "hostfw_iptables_host_ipv4_01_pod")
+SETUP(PROG_TYPE, "hostfw_iptables_host_ipv4_01_pod")
 int hostfw_iptables_host_ipv4_01_pod_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v4_add_entry(NODE_IP, 0, 0, ENDPOINT_F_HOST, HOST_ID,
@@ -75,7 +75,7 @@ int hostfw_iptables_host_ipv4_01_pod_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "hostfw_iptables_host_ipv4_01_pod")
+CHECK(PROG_TYPE, "hostfw_iptables_host_ipv4_01_pod")
 int hostfw_iptables_host_ipv4_01_pod_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -116,7 +116,7 @@ int hostfw_iptables_host_ipv4_01_pod_check(const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "hostfw_iptables_host_ipv4_02_pod")
+PKTGEN(PROG_TYPE, "hostfw_iptables_host_ipv4_02_pod")
 int hostfw_iptables_host_ipv4_02_pod_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -138,7 +138,7 @@ int hostfw_iptables_host_ipv4_02_pod_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "hostfw_iptables_host_ipv4_02_pod")
+SETUP(PROG_TYPE, "hostfw_iptables_host_ipv4_02_pod")
 int hostfw_iptables_host_ipv4_02_pod_setup(struct __ctx_buff *ctx)
 {
 	policy_add_ingress_deny_all_entry();
@@ -146,7 +146,7 @@ int hostfw_iptables_host_ipv4_02_pod_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "hostfw_iptables_host_ipv4_02_pod")
+CHECK(PROG_TYPE, "hostfw_iptables_host_ipv4_02_pod")
 int hostfw_iptables_host_ipv4_02_pod_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -189,7 +189,7 @@ int hostfw_iptables_host_ipv4_02_pod_check(const struct __ctx_buff *ctx)
  *
  * The egress path should apply egress network policy and drop the packet.
  */
-PKTGEN("tc", "hostfw_iptables_host_ipv4_03_host")
+PKTGEN(PROG_TYPE, "hostfw_iptables_host_ipv4_03_host")
 int hostfw_iptables_host_ipv4_03_host_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -211,7 +211,7 @@ int hostfw_iptables_host_ipv4_03_host_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "hostfw_iptables_host_ipv4_03_host")
+SETUP(PROG_TYPE, "hostfw_iptables_host_ipv4_03_host")
 int hostfw_iptables_host_ipv4_03_host_setup(struct __ctx_buff *ctx)
 {
 	policy_add_egress_deny_all_entry();
@@ -221,7 +221,7 @@ int hostfw_iptables_host_ipv4_03_host_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "hostfw_iptables_host_ipv4_03_host")
+CHECK(PROG_TYPE, "hostfw_iptables_host_ipv4_03_host")
 int hostfw_iptables_host_ipv4_03_host_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -249,7 +249,7 @@ int hostfw_iptables_host_ipv4_03_host_check(const struct __ctx_buff *ctx)
  * The egress path should apply egress network policy, and let the packet pass.
  * The ingress path should skip ingress network policy.
  */
-PKTGEN("tc", "hostfw_iptables_host_ipv4_04_host")
+PKTGEN(PROG_TYPE, "hostfw_iptables_host_ipv4_04_host")
 int hostfw_iptables_host_ipv4_04_host_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -271,7 +271,7 @@ int hostfw_iptables_host_ipv4_04_host_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "hostfw_iptables_host_ipv4_04_host")
+SETUP(PROG_TYPE, "hostfw_iptables_host_ipv4_04_host")
 int hostfw_iptables_host_ipv4_04_host_setup(struct __ctx_buff *ctx)
 {
 	set_identity_mark(ctx, 0, MARK_MAGIC_HOST);
@@ -281,7 +281,7 @@ int hostfw_iptables_host_ipv4_04_host_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "hostfw_iptables_host_ipv4_04_host")
+CHECK(PROG_TYPE, "hostfw_iptables_host_ipv4_04_host")
 int hostfw_iptables_host_ipv4_04_host_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -320,7 +320,7 @@ int hostfw_iptables_host_ipv4_04_host_check(const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "hostfw_iptables_host_ipv4_05_host")
+PKTGEN(PROG_TYPE, "hostfw_iptables_host_ipv4_05_host")
 int hostfw_iptables_host_ipv4_05_host_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -342,7 +342,7 @@ int hostfw_iptables_host_ipv4_05_host_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "hostfw_iptables_host_ipv4_05_host")
+SETUP(PROG_TYPE, "hostfw_iptables_host_ipv4_05_host")
 int hostfw_iptables_host_ipv4_05_host_setup(struct __ctx_buff *ctx)
 {
 	policy_add_ingress_deny_all_entry();
@@ -350,7 +350,7 @@ int hostfw_iptables_host_ipv4_05_host_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "hostfw_iptables_host_ipv4_05_host")
+CHECK(PROG_TYPE, "hostfw_iptables_host_ipv4_05_host")
 int hostfw_iptables_host_ipv4_05_host_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/hostfw_igmp.h
+++ b/bpf/tests/hostfw_igmp.h
@@ -34,7 +34,7 @@ ASSIGN_CONFIG(bool, enable_conntrack_accounting, true)
 /* Send an IGMP packet from host to IGMP destination (allow all egress policy).
  *
  */
-PKTGEN("tc", "hostfw_igmp_1_egress")
+PKTGEN(PROG_TYPE, "hostfw_igmp_1_egress")
 int hostfw_igmp_egress_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -56,7 +56,7 @@ int hostfw_igmp_egress_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "hostfw_igmp_1_egress")
+SETUP(PROG_TYPE, "hostfw_igmp_1_egress")
 int hostfw_igmp_egress_setup(struct __ctx_buff *ctx)
 {
 	policy_add_egress_allow_all_entry();
@@ -70,7 +70,7 @@ int hostfw_igmp_egress_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "hostfw_igmp_1_egress")
+CHECK(PROG_TYPE, "hostfw_igmp_1_egress")
 int hostfw_igmp_egress_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -128,7 +128,7 @@ int hostfw_igmp_egress_check(const struct __ctx_buff *ctx)
  * conntrack entry (no ingress policy).
  *
  */
-PKTGEN("tc", "hostfw_igmp_2_ingress")
+PKTGEN(PROG_TYPE, "hostfw_igmp_2_ingress")
 int hostfw_igmp_ingress_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -150,7 +150,7 @@ int hostfw_igmp_ingress_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "hostfw_igmp_2_ingress")
+SETUP(PROG_TYPE, "hostfw_igmp_2_ingress")
 int hostfw_igmp_ingress_setup(struct __ctx_buff *ctx)
 {
 	policy_add_ingress_allow_all_entry();
@@ -158,7 +158,7 @@ int hostfw_igmp_ingress_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "hostfw_igmp_2_ingress")
+CHECK(PROG_TYPE, "hostfw_igmp_2_ingress")
 int hostfw_igmp_ingress_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -214,7 +214,7 @@ int hostfw_igmp_ingress_check(const struct __ctx_buff *ctx)
  *
  * The packet is allowed by the egress policy.
  */
-PKTGEN("tc", "hostfw_igmp_3_egress_policy")
+PKTGEN(PROG_TYPE, "hostfw_igmp_3_egress_policy")
 int hostfw_igmp_egress_policy_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -236,7 +236,7 @@ int hostfw_igmp_egress_policy_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "hostfw_igmp_3_egress_policy")
+SETUP(PROG_TYPE, "hostfw_igmp_3_egress_policy")
 int hostfw_igmp_egress_policy_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v4_add_entry(NODE_IP2, 0, 0, ENDPOINT_F_HOST, HOST_ID,
@@ -249,7 +249,7 @@ int hostfw_igmp_egress_policy_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "hostfw_igmp_3_egress_policy")
+CHECK(PROG_TYPE, "hostfw_igmp_3_egress_policy")
 int hostfw_igmp_egress_policy_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -305,7 +305,7 @@ int hostfw_igmp_egress_policy_check(const struct __ctx_buff *ctx)
  *
  * The packet is dropped by the ingress policy.
  */
-PKTGEN("tc", "hostfw_igmp_4_ingress_policy")
+PKTGEN(PROG_TYPE, "hostfw_igmp_4_ingress_policy")
 int hostfw_igmp_ingress_policy_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -327,7 +327,7 @@ int hostfw_igmp_ingress_policy_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "hostfw_igmp_4_ingress_policy")
+SETUP(PROG_TYPE, "hostfw_igmp_4_ingress_policy")
 int hostfw_igmp_ingress_policy_setup(struct __ctx_buff *ctx)
 {
 	policy_add_ingress_deny_l4_entry(IPPROTO_IGMP, 0, 0);
@@ -336,7 +336,7 @@ int hostfw_igmp_ingress_policy_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "hostfw_igmp_4_ingress_policy")
+CHECK(PROG_TYPE, "hostfw_igmp_4_ingress_policy")
 int hostfw_igmp_ingress_policy_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/icmp_error_revnat.c
+++ b/bpf/tests/icmp_error_revnat.c
@@ -54,7 +54,7 @@ const __u8 icmp4_err_frag_needed_after_revnat[] = {
  * 4. Result: ICMP error should be addressed to endpoint (10.0.10.1)
  *            with embedded packet showing original src (10.0.10.1:3030)
  */
-PKTGEN("tc", "nat4_icmp_error_tcp_snat_revnat")
+PKTGEN(PROG_TYPE, "nat4_icmp_error_tcp_snat_revnat")
 int nat4_icmp_error_tcp_snat_revnat_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -70,7 +70,7 @@ int nat4_icmp_error_tcp_snat_revnat_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "nat4_icmp_error_tcp_snat_revnat")
+SETUP(PROG_TYPE, "nat4_icmp_error_tcp_snat_revnat")
 int nat4_icmp_error_tcp_snat_revnat_setup(struct __ctx_buff *ctx)
 {
 	/* Set up NAT mapping to simulate prior outgoing connection.
@@ -121,7 +121,7 @@ int nat4_icmp_error_tcp_snat_revnat_setup(struct __ctx_buff *ctx)
 	return TEST_PASS;
 }
 
-CHECK("tc", "nat4_icmp_error_tcp_snat_revnat")
+CHECK(PROG_TYPE, "nat4_icmp_error_tcp_snat_revnat")
 int nat4_icmp_error_tcp_snat_revnat_check(const struct __ctx_buff *ctx)
 {
 	void *data;

--- a/bpf/tests/inter_cluster_snat_clusterip_backend_lxc.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_backend_lxc.c
@@ -123,13 +123,13 @@ pktgen_from_lxc(struct __ctx_buff *ctx, bool syn, bool ack)
 	return 0;
 }
 
-PKTGEN("tc", "01_overlay_to_lxc_syn")
+PKTGEN(PROG_TYPE, "01_overlay_to_lxc_syn")
 int overlay_to_lxc_syn_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_to_lxc(ctx, true, false);
 }
 
-SETUP("tc", "01_overlay_to_lxc_syn")
+SETUP(PROG_TYPE, "01_overlay_to_lxc_syn")
 int overlay_to_lxc_syn_setup(struct __ctx_buff *ctx)
 {
 	/*
@@ -145,7 +145,7 @@ int overlay_to_lxc_syn_setup(struct __ctx_buff *ctx)
 	return pod_receive_packet_by_tailcall(ctx);
 }
 
-CHECK("tc", "01_overlay_to_lxc_syn")
+CHECK(PROG_TYPE, "01_overlay_to_lxc_syn")
 int overlay_to_lxc_syn_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -226,13 +226,13 @@ int overlay_to_lxc_syn_check(struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "02_lxc_to_overlay_synack")
+PKTGEN(PROG_TYPE, "02_lxc_to_overlay_synack")
 int lxc_to_overlay_synack_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_lxc(ctx, true, true);
 }
 
-SETUP("tc", "02_lxc_to_overlay_synack")
+SETUP(PROG_TYPE, "02_lxc_to_overlay_synack")
 int lxc_to_overlay_synack_setup(struct __ctx_buff *ctx)
 {
 	ipcache_v4_add_entry_with_flags(CLIENT_NODE_IP, 0, REMOTE_NODE_ID,
@@ -241,7 +241,7 @@ int lxc_to_overlay_synack_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "02_lxc_to_overlay_synack")
+CHECK(PROG_TYPE, "02_lxc_to_overlay_synack")
 int lxc_to_overlay_ack_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -319,13 +319,13 @@ int lxc_to_overlay_ack_check(struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "03_overlay_to_lxc_ack")
+PKTGEN(PROG_TYPE, "03_overlay_to_lxc_ack")
 int overlay_to_lxc_ack_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_to_lxc(ctx, false, true);
 }
 
-SETUP("tc", "03_overlay_to_lxc_ack")
+SETUP(PROG_TYPE, "03_overlay_to_lxc_ack")
 int overlay_to_lxc_ack_setup(struct __ctx_buff *ctx)
 {
 	/* Emulate metadata filled by ipv4_local_delivery on bpf_overlay */
@@ -334,7 +334,7 @@ int overlay_to_lxc_ack_setup(struct __ctx_buff *ctx)
 	return pod_receive_packet_by_tailcall(ctx);
 }
 
-CHECK("tc", "03_overlay_to_lxc_ack")
+CHECK(PROG_TYPE, "03_overlay_to_lxc_ack")
 int overlay_to_lxc_ack_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/inter_cluster_snat_clusterip_backend_overlay.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_backend_overlay.c
@@ -155,7 +155,7 @@ pktgen_from_overlay(struct __ctx_buff *ctx, bool syn, bool ack)
 	return 0;
 }
 
-PKTGEN("tc", "01_from_overlay_syn")
+PKTGEN(PROG_TYPE, "01_from_overlay_syn")
 int from_overlay_syn_pktgen(struct __ctx_buff *ctx)
 {
 	/* Emulate input from bpf_lxc */
@@ -164,7 +164,7 @@ int from_overlay_syn_pktgen(struct __ctx_buff *ctx)
 	return pktgen_from_overlay(ctx, true, false);
 }
 
-SETUP("tc", "01_from_overlay_syn")
+SETUP(PROG_TYPE, "01_from_overlay_syn")
 int from_overlay_syn_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v4_add_entry(BACKEND_IP, BACKEND_IFINDEX, 0, 0, 0, 0,
@@ -174,7 +174,7 @@ int from_overlay_syn_setup(struct __ctx_buff *ctx)
 	return TEST_ERROR;
 }
 
-CHECK("tc", "01_from_overlay_syn")
+CHECK(PROG_TYPE, "01_from_overlay_syn")
 int from_overlay_syn_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -257,19 +257,19 @@ int from_overlay_syn_check(struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "02_to_overlay_synack")
+PKTGEN(PROG_TYPE, "02_to_overlay_synack")
 int to_overlay_synack_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_to_overlay(ctx, true, true);
 }
 
-SETUP("tc", "02_to_overlay_synack")
+SETUP(PROG_TYPE, "02_to_overlay_synack")
 int to_overlay_synack_setup(struct __ctx_buff *ctx)
 {
 	return overlay_send_packet(ctx);
 }
 
-CHECK("tc", "02_to_overlay_synack")
+CHECK(PROG_TYPE, "02_to_overlay_synack")
 int to_overlay_synack_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -330,13 +330,13 @@ int to_overlay_synack_check(struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "03_from_overlay_ack")
+PKTGEN(PROG_TYPE, "03_from_overlay_ack")
 int from_overlay_ack_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_overlay(ctx, false, true);
 }
 
-SETUP("tc", "03_from_overlay_ack")
+SETUP(PROG_TYPE, "03_from_overlay_ack")
 int from_overlay_ack_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v4_add_entry(BACKEND_IP, BACKEND_IFINDEX, 0, 0, 0, 0,
@@ -345,7 +345,7 @@ int from_overlay_ack_setup(struct __ctx_buff *ctx)
 	return overlay_receive_packet(ctx);
 }
 
-CHECK("tc", "03_from_overlay_ack")
+CHECK(PROG_TYPE, "03_from_overlay_ack")
 int from_overlay_ack_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/inter_cluster_snat_clusterip_client_lxc.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_client_lxc.c
@@ -127,13 +127,13 @@ pktgen_to_lxc(struct __ctx_buff *ctx, bool syn, bool ack)
 	return 0;
 }
 
-PKTGEN("tc", "01_lxc_to_overlay_syn")
+PKTGEN(PROG_TYPE, "01_lxc_to_overlay_syn")
 int lxc_to_overlay_syn_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_lxc(ctx, true, false);
 }
 
-SETUP("tc", "01_lxc_to_overlay_syn")
+SETUP(PROG_TYPE, "01_lxc_to_overlay_syn")
 int lxc_to_overlay_syn_setup(struct __ctx_buff *ctx)
 {
 
@@ -151,7 +151,7 @@ int lxc_to_overlay_syn_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "01_lxc_to_overlay_syn")
+CHECK(PROG_TYPE, "01_lxc_to_overlay_syn")
 int lxc_to_overlay_syn_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -244,13 +244,13 @@ int lxc_to_overlay_syn_check(struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "02_overlay_to_lxc_synack")
+PKTGEN(PROG_TYPE, "02_overlay_to_lxc_synack")
 int overlay_to_lxc_synack_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_to_lxc(ctx, true, true);
 }
 
-SETUP("tc", "02_overlay_to_lxc_synack")
+SETUP(PROG_TYPE, "02_overlay_to_lxc_synack")
 int overlay_to_lxc_synack_setup(struct __ctx_buff *ctx)
 {
 	/* Emulate metadata filled by ipv4_local_delivery on bpf_overlay */
@@ -259,7 +259,7 @@ int overlay_to_lxc_synack_setup(struct __ctx_buff *ctx)
 	return pod_receive_packet_by_tailcall(ctx);
 }
 
-CHECK("tc", "02_overlay_to_lxc_synack")
+CHECK(PROG_TYPE, "02_overlay_to_lxc_synack")
 int overlay_to_lxc_synack_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -337,19 +337,19 @@ int overlay_to_lxc_synack_check(struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "03_lxc_to_overlay_ack")
+PKTGEN(PROG_TYPE, "03_lxc_to_overlay_ack")
 int lxc_to_overlay_ack_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_lxc(ctx, false, true);
 }
 
-SETUP("tc", "03_lxc_to_overlay_ack")
+SETUP(PROG_TYPE, "03_lxc_to_overlay_ack")
 int lxc_to_overlay_ack_setup(struct __ctx_buff *ctx)
 {
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "03_lxc_to_overlay_ack")
+CHECK(PROG_TYPE, "03_lxc_to_overlay_ack")
 int lxc_to_overlay_ack_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/inter_cluster_snat_clusterip_client_overlay.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_client_overlay.c
@@ -157,13 +157,13 @@ pktgen_from_overlay(struct __ctx_buff *ctx, bool syn, bool ack)
 	return 0;
 }
 
-PKTGEN("tc", "01_to_overlay_syn")
+PKTGEN(PROG_TYPE, "01_to_overlay_syn")
 int to_overlay_syn_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_to_overlay(ctx, true, false);
 }
 
-SETUP("tc", "01_to_overlay_syn")
+SETUP(PROG_TYPE, "01_to_overlay_syn")
 int to_overlay_syn_setup(struct __ctx_buff *ctx)
 {
 	/* Emulate input from bpf_lxc */
@@ -172,7 +172,7 @@ int to_overlay_syn_setup(struct __ctx_buff *ctx)
 	return overlay_send_packet(ctx);
 }
 
-CHECK("tc", "01_to_overlay_syn")
+CHECK(PROG_TYPE, "01_to_overlay_syn")
 int to_overlay_syn_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -257,13 +257,13 @@ int to_overlay_syn_check(struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "02_from_overlay_synack")
+PKTGEN(PROG_TYPE, "02_from_overlay_synack")
 int from_overlay_synack_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_overlay(ctx, true, true);
 }
 
-SETUP("tc", "02_from_overlay_synack")
+SETUP(PROG_TYPE, "02_from_overlay_synack")
 int from_overlay_synack_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v4_add_entry(CLIENT_IP, CLIENT_IFINDEX, 0, 0, 0, 0,
@@ -272,7 +272,7 @@ int from_overlay_synack_setup(struct __ctx_buff *ctx)
 	return overlay_receive_packet(ctx);
 }
 
-CHECK("tc", "02_from_overlay_synack")
+CHECK(PROG_TYPE, "02_from_overlay_synack")
 int from_overlay_synack_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -356,13 +356,13 @@ int from_overlay_synack_check(struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "03_to_overlay_ack")
+PKTGEN(PROG_TYPE, "03_to_overlay_ack")
 int to_overlay_ack_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_to_overlay(ctx, false, true);
 }
 
-SETUP("tc", "03_to_overlay_ack")
+SETUP(PROG_TYPE, "03_to_overlay_ack")
 int to_overlay_ack_setup(struct __ctx_buff *ctx)
 {
 	/* Emulate input from bpf_lxc */
@@ -371,7 +371,7 @@ int to_overlay_ack_setup(struct __ctx_buff *ctx)
 	return overlay_send_packet(ctx);
 }
 
-CHECK("tc", "03_to_overlay_ack")
+CHECK(PROG_TYPE, "03_to_overlay_ack")
 int to_overlay_ack_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/ip_options_trace_id.c
+++ b/bpf/tests/ip_options_trace_id.c
@@ -77,7 +77,7 @@ gen_packet_with_options(struct __sk_buff *ctx,
  */
 
 /* Test packet with no l3 header should return TRACE_ID_ERROR. */
-PKTGEN("tc", "extract_trace_id_with_no_l3_header_error")
+PKTGEN(PROG_TYPE, "extract_trace_id_with_no_l3_header_error")
 int test_extract_trace_id_with_no_l3_header_error_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -91,7 +91,7 @@ int test_extract_trace_id_with_no_l3_header_error_pktgen(struct __ctx_buff *ctx)
 	return TEST_PASS;
 }
 
-CHECK("tc", "extract_trace_id_with_no_l3_header_error")
+CHECK(PROG_TYPE, "extract_trace_id_with_no_l3_header_error")
 int test_extract_trace_id_with_no_l3_header_error_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -109,7 +109,7 @@ int test_extract_trace_id_with_no_l3_header_error_check(struct __ctx_buff *ctx)
 }
 
 /* Test packet with no eth header should return TRACE_ID_NO_FAMILY. */
-PKTGEN("tc", "extract_trace_id_with_no_eth_header_no_family")
+PKTGEN(PROG_TYPE, "extract_trace_id_with_no_eth_header_no_family")
 int test_extract_trace_id_with_no_eth_header_no_family_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -121,7 +121,7 @@ int test_extract_trace_id_with_no_eth_header_no_family_pktgen(struct __ctx_buff 
 	return TEST_PASS;
 }
 
-CHECK("tc", "extract_trace_id_with_no_eth_header_no_family")
+CHECK(PROG_TYPE, "extract_trace_id_with_no_eth_header_no_family")
 int test_extract_trace_id_with_no_eth_header_no_family_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -139,7 +139,7 @@ int test_extract_trace_id_with_no_eth_header_no_family_check(struct __ctx_buff *
 }
 
 /* Test packet with IPv6 header should return TRACE_ID_SKIP_IPV6. */
-PKTGEN("tc", "extract_trace_id_no_ipv6_options")
+PKTGEN(PROG_TYPE, "extract_trace_id_no_ipv6_options")
 int test_extract_trace_id_no_ipv6_options_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -156,7 +156,7 @@ int test_extract_trace_id_no_ipv6_options_pktgen(struct __ctx_buff *ctx)
 	return TEST_PASS;
 }
 
-CHECK("tc", "extract_trace_id_no_ipv6_options")
+CHECK(PROG_TYPE, "extract_trace_id_no_ipv6_options")
 int test_extract_trace_id_no_ipv6_options_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -174,7 +174,7 @@ int test_extract_trace_id_no_ipv6_options_check(struct __ctx_buff *ctx)
 }
 
 /* Test a single option specifying the trace ID with no special cases. */
-PKTGEN("tc", "extract_trace_id_solo")
+PKTGEN(PROG_TYPE, "extract_trace_id_solo")
 int test_extract_trace_id_solo_pktgen(struct __ctx_buff *ctx)
 {
 	struct ipopthdr opts[] = {
@@ -188,7 +188,7 @@ int test_extract_trace_id_solo_pktgen(struct __ctx_buff *ctx)
 	return gen_packet_with_options(ctx, opts, 1, 4);
 }
 
-CHECK("tc", "extract_trace_id_solo")
+CHECK(PROG_TYPE, "extract_trace_id_solo")
 int test_extract_trace_id_solo_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -206,7 +206,7 @@ int test_extract_trace_id_solo_check(struct __ctx_buff *ctx)
 }
 
 /* Test packet with IPv4 header should return TRACE_ID_NOT_FOUND. */
-PKTGEN("tc", "extract_trace_id_no_ipv4_options")
+PKTGEN(PROG_TYPE, "extract_trace_id_no_ipv4_options")
 int test_extract_trace_id_no_options_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -223,7 +223,7 @@ int test_extract_trace_id_no_options_pktgen(struct __ctx_buff *ctx)
 	return TEST_PASS;
 }
 
-CHECK("tc", "extract_trace_id_no_ipv4_options")
+CHECK(PROG_TYPE, "extract_trace_id_no_ipv4_options")
 int test_extract_trace_id_no_options_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -241,7 +241,7 @@ int test_extract_trace_id_no_options_check(struct __ctx_buff *ctx)
 }
 
 /* Test trace ID after END should return TRACE_ID_NOT_FOUND. */
-PKTGEN("tc", "extract_trace_id_after_ipopt_end_not_found")
+PKTGEN(PROG_TYPE, "extract_trace_id_after_ipopt_end_not_found")
 int test_extract_trace_id_after_ipopt_end_not_found_pktgen(struct __ctx_buff *ctx)
 {
 	struct ipopthdr opts[] = {
@@ -276,7 +276,7 @@ int test_extract_trace_id_after_ipopt_end_not_found_pktgen(struct __ctx_buff *ct
 	return gen_packet_with_options(ctx, opts, 5, 8);
 }
 
-CHECK("tc", "extract_trace_id_after_ipopt_end_not_found")
+CHECK(PROG_TYPE, "extract_trace_id_after_ipopt_end_not_found")
 int test_extract_trace_id_after_ipopt_end_not_found_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -294,7 +294,7 @@ int test_extract_trace_id_after_ipopt_end_not_found_check(struct __ctx_buff *ctx
 }
 
 /* Test trace ID comes after loop limit should return TRACE_ID_NOT_FOUND. */
-PKTGEN("tc", "extract_trace_id_after_loop_limit_not_found")
+PKTGEN(PROG_TYPE, "extract_trace_id_after_loop_limit_not_found")
 int test_extract_trace_id_after_loop_limit_not_found_pktgen(struct __ctx_buff *ctx)
 {
 	struct ipopthdr opts[] = {
@@ -329,7 +329,7 @@ int test_extract_trace_id_after_loop_limit_not_found_pktgen(struct __ctx_buff *c
 	return gen_packet_with_options(ctx, opts, 5, 8);
 }
 
-CHECK("tc", "extract_trace_id_after_loop_limit_not_found")
+CHECK(PROG_TYPE, "extract_trace_id_after_loop_limit_not_found")
 int test_extract_trace_id_after_loop_limit_not_found_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -347,7 +347,7 @@ int test_extract_trace_id_after_loop_limit_not_found_check(struct __ctx_buff *ct
 }
 
 /* Test three options with the trace ID option being first. */
-PKTGEN("tc", "extract_trace_id_first_of_three")
+PKTGEN(PROG_TYPE, "extract_trace_id_first_of_three")
 int test_extract_trace_id_first_of_three_pktgen(struct __ctx_buff *ctx)
 {
 	struct ipopthdr opts[] = {
@@ -373,7 +373,7 @@ int test_extract_trace_id_first_of_three_pktgen(struct __ctx_buff *ctx)
 	return gen_packet_with_options(ctx, opts, 3, 12);
 }
 
-CHECK("tc", "extract_trace_id_first_of_three")
+CHECK(PROG_TYPE, "extract_trace_id_first_of_three")
 int test_extract_trace_id_first_of_three_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -391,7 +391,7 @@ int test_extract_trace_id_first_of_three_check(struct __ctx_buff *ctx)
 }
 
 /* Test three options with the trace ID option being between the other two. */
-PKTGEN("tc", "extract_trace_id_middle_of_three")
+PKTGEN(PROG_TYPE, "extract_trace_id_middle_of_three")
 int test_extract_trace_id_middle_of_three_pktgen(struct __ctx_buff *ctx)
 {
 	struct ipopthdr opts[] = {
@@ -417,7 +417,7 @@ int test_extract_trace_id_middle_of_three_pktgen(struct __ctx_buff *ctx)
 	return gen_packet_with_options(ctx, opts, 3, 12);
 }
 
-CHECK("tc", "extract_trace_id_middle_of_three")
+CHECK(PROG_TYPE, "extract_trace_id_middle_of_three")
 int test_extract_trace_id_middle_of_three_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -435,7 +435,7 @@ int test_extract_trace_id_middle_of_three_check(struct __ctx_buff *ctx)
 }
 
 /* Test three options with the trace ID option being last of the three. */
-PKTGEN("tc", "extract_trace_id_last_of_three")
+PKTGEN(PROG_TYPE, "extract_trace_id_last_of_three")
 int test_extract_trace_id_last_of_three_pktgen(struct __ctx_buff *ctx)
 {
 	struct ipopthdr opts[] = {
@@ -462,7 +462,7 @@ int test_extract_trace_id_last_of_three_pktgen(struct __ctx_buff *ctx)
 	return gen_packet_with_options(ctx, opts, 3, 12);
 }
 
-CHECK("tc", "extract_trace_id_last_of_three")
+CHECK(PROG_TYPE, "extract_trace_id_last_of_three")
 int test_extract_trace_id_last_of_three_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -480,7 +480,7 @@ int test_extract_trace_id_last_of_three_check(struct __ctx_buff *ctx)
 }
 
 /* Test multiple options with the trace ID coming after a NOOP option. */
-PKTGEN("tc", "extract_trace_id_after_ipopt_noop")
+PKTGEN(PROG_TYPE, "extract_trace_id_after_ipopt_noop")
 int test_extract_trace_id_after_ipopt_noop_pktgen(struct __ctx_buff *ctx)
 {
 	struct ipopthdr opts[] = {
@@ -514,7 +514,7 @@ int test_extract_trace_id_after_ipopt_noop_pktgen(struct __ctx_buff *ctx)
 	return gen_packet_with_options(ctx, opts, 5, 8);
 }
 
-CHECK("tc", "extract_trace_id_after_ipopt_noop")
+CHECK(PROG_TYPE, "extract_trace_id_after_ipopt_noop")
 int test_extract_trace_id_after_ipopt_noop_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -532,7 +532,7 @@ int test_extract_trace_id_after_ipopt_noop_check(struct __ctx_buff *ctx)
 }
 
 /* Test multiple options with the trace ID not present should return TRACE_ID_NOT_FOUND. */
-PKTGEN("tc", "extract_trace_id_not_found_with_other_options")
+PKTGEN(PROG_TYPE, "extract_trace_id_not_found_with_other_options")
 int test_extract_trace_id__not_found_with_other_options_pktgen(struct __ctx_buff *ctx)
 {
 	struct ipopthdr opts[] = {
@@ -553,7 +553,7 @@ int test_extract_trace_id__not_found_with_other_options_pktgen(struct __ctx_buff
 	return gen_packet_with_options(ctx, opts, 2, 8);
 }
 
-CHECK("tc", "extract_trace_id_not_found_with_other_options")
+CHECK(PROG_TYPE, "extract_trace_id_not_found_with_other_options")
 int test_extract_trace_id_not_found_with_other_options_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -571,7 +571,7 @@ int test_extract_trace_id_not_found_with_other_options_check(struct __ctx_buff *
 }
 
 /* Test trace ID with incorrect length field should return INVALID. */
-PKTGEN("tc", "extract_trace_id_wrong_len_invalid")
+PKTGEN(PROG_TYPE, "extract_trace_id_wrong_len_invalid")
 int test_extract_trace_id_wrong_len_invalid_pktgen(struct __ctx_buff *ctx)
 {
 	struct ipopthdr opts[] = {
@@ -586,7 +586,7 @@ int test_extract_trace_id_wrong_len_invalid_pktgen(struct __ctx_buff *ctx)
 	return gen_packet_with_options(ctx, opts, 1, 4);
 }
 
-CHECK("tc", "extract_trace_id_wrong_len_invalid")
+CHECK(PROG_TYPE, "extract_trace_id_wrong_len_invalid")
 int test_extract_trace_id_wrong_len_invalid_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -604,7 +604,7 @@ int test_extract_trace_id_wrong_len_invalid_check(struct __ctx_buff *ctx)
 }
 
 /* Test trace ID with negative value should return TRACE_ID_INVALID. */
-PKTGEN("tc", "extract_trace_id_negative")
+PKTGEN(PROG_TYPE, "extract_trace_id_negative")
 int test_extract_trace_id_negative_invalid_pktgen(struct __ctx_buff *ctx)
 {
 	struct ipopthdr opts[] = {
@@ -619,7 +619,7 @@ int test_extract_trace_id_negative_invalid_pktgen(struct __ctx_buff *ctx)
 	return gen_packet_with_options(ctx, opts, 1, 4);
 }
 
-CHECK("tc", "extract_trace_id_negative")
+CHECK(PROG_TYPE, "extract_trace_id_negative")
 int test_extract_trace_id_negative_invalid_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -638,7 +638,7 @@ int test_extract_trace_id_negative_invalid_check(struct __ctx_buff *ctx)
 }
 
 /* Store and read trace ID to different option than stream ID with 2 bytes of data. */
-PKTGEN("tc", "extract_trace_id_different_option_type")
+PKTGEN(PROG_TYPE, "extract_trace_id_different_option_type")
 int test_extract_trace_id_different_option_type_pktgen(struct __ctx_buff *ctx)
 {
 	struct ipopthdr opts[] = {
@@ -653,7 +653,7 @@ int test_extract_trace_id_different_option_type_pktgen(struct __ctx_buff *ctx)
 	return gen_packet_with_options(ctx, opts, 1, 4);
 }
 
-CHECK("tc", "extract_trace_id_different_option_type")
+CHECK(PROG_TYPE, "extract_trace_id_different_option_type")
 int test_extract_trace_id_different_option_type_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -671,7 +671,7 @@ int test_extract_trace_id_different_option_type_check(struct __ctx_buff *ctx)
 }
 
 /* Read trace ID from wrong IP option. */
-PKTGEN("tc", "extract_read_trace_id_wrong_option_type")
+PKTGEN(PROG_TYPE, "extract_read_trace_id_wrong_option_type")
 int test_extract_read_trace_id_wrong_option_type_pktgen(struct __ctx_buff *ctx)
 {
 	struct ipopthdr opts[] = {
@@ -686,7 +686,7 @@ int test_extract_read_trace_id_wrong_option_type_pktgen(struct __ctx_buff *ctx)
 	return gen_packet_with_options(ctx, opts, 1, 4);
 }
 
-CHECK("tc", "extract_read_trace_id_wrong_option_type")
+CHECK(PROG_TYPE, "extract_read_trace_id_wrong_option_type")
 int test_extract_read_trace_id_wrong_option_type_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -704,7 +704,7 @@ int test_extract_read_trace_id_wrong_option_type_check(struct __ctx_buff *ctx)
 }
 
 /* Test a valid 4-byte trace ID. */
-PKTGEN("tc", "extract_trace_id_4_bytes_valid")
+PKTGEN(PROG_TYPE, "extract_trace_id_4_bytes_valid")
 int test_extract_trace_id_4_bytes_valid_pktgen(struct __ctx_buff *ctx)
 {
 	struct ipopthdr opts[] = {
@@ -719,7 +719,7 @@ int test_extract_trace_id_4_bytes_valid_pktgen(struct __ctx_buff *ctx)
 	return gen_packet_with_options(ctx, opts, 1, 8);
 }
 
-CHECK("tc", "extract_trace_id_4_bytes_valid")
+CHECK(PROG_TYPE, "extract_trace_id_4_bytes_valid")
 int test_extract_trace_id_4_bytes_valid_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -737,7 +737,7 @@ int test_extract_trace_id_4_bytes_valid_check(struct __ctx_buff *ctx)
 }
 
 /* Test negative trace id should return valid. */
-PKTGEN("tc", "extract_trace_id_negative_4_bytes")
+PKTGEN(PROG_TYPE, "extract_trace_id_negative_4_bytes")
 int test_extract_trace_id_negative_4_bytes_pktgen(struct __ctx_buff *ctx)
 {
 	struct ipopthdr opts[] = {
@@ -752,7 +752,7 @@ int test_extract_trace_id_negative_4_bytes_pktgen(struct __ctx_buff *ctx)
 	return gen_packet_with_options(ctx, opts, 1, 8);
 }
 
-CHECK("tc", "extract_trace_id_negative_4_bytes")
+CHECK(PROG_TYPE, "extract_trace_id_negative_4_bytes")
 int test_extract_trace_id_negative_4_bytes_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -770,7 +770,7 @@ int test_extract_trace_id_negative_4_bytes_check(struct __ctx_buff *ctx)
 }
 
 /* Test a 4-byte trace ID with incorrect length. */
-PKTGEN("tc", "extract_trace_id_4_bytes_wrong_length")
+PKTGEN(PROG_TYPE, "extract_trace_id_4_bytes_wrong_length")
 int test_extract_trace_id_4_bytes_wrong_length_pktgen(struct __ctx_buff *ctx)
 {
 	struct ipopthdr opts[] = {
@@ -784,7 +784,7 @@ int test_extract_trace_id_4_bytes_wrong_length_pktgen(struct __ctx_buff *ctx)
 	return gen_packet_with_options(ctx, opts, 1, 8);
 }
 
-CHECK("tc", "extract_trace_id_4_bytes_wrong_length")
+CHECK(PROG_TYPE, "extract_trace_id_4_bytes_wrong_length")
 int test_extract_trace_id_4_bytes_wrong_length_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -802,7 +802,7 @@ int test_extract_trace_id_4_bytes_wrong_length_check(struct __ctx_buff *ctx)
 }
 
 /* Test a 4-byte trace ID before the end of option list. */
-PKTGEN("tc", "extract_trace_id_4_bytes_before_end")
+PKTGEN(PROG_TYPE, "extract_trace_id_4_bytes_before_end")
 int test_extract_trace_id_4_bytes_before_end_pktgen(struct __ctx_buff *ctx)
 {
 	struct ipopthdr opts[] = {
@@ -821,7 +821,7 @@ int test_extract_trace_id_4_bytes_before_end_pktgen(struct __ctx_buff *ctx)
 	return gen_packet_with_options(ctx, opts, 2, 8);
 }
 
-CHECK("tc", "extract_trace_id_4_bytes_before_end")
+CHECK(PROG_TYPE, "extract_trace_id_4_bytes_before_end")
 int test_extract_trace_id_4_bytes_before_end_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -839,7 +839,7 @@ int test_extract_trace_id_4_bytes_before_end_check(struct __ctx_buff *ctx)
 }
 
 /* Test a valid 8-byte trace ID should return TRACE_ID_ERROR. */
-PKTGEN("tc", "extract_trace_id_8_bytes_valid")
+PKTGEN(PROG_TYPE, "extract_trace_id_8_bytes_valid")
 int test_extract_trace_id_8_bytes_valid_pktgen(struct __ctx_buff *ctx)
 {
 	struct ipopthdr opts[] = {
@@ -853,7 +853,7 @@ int test_extract_trace_id_8_bytes_valid_pktgen(struct __ctx_buff *ctx)
 	return gen_packet_with_options(ctx, opts, 1, 12);
 }
 
-CHECK("tc", "extract_trace_id_8_bytes_valid")
+CHECK(PROG_TYPE, "extract_trace_id_8_bytes_valid")
 int test_extract_trace_id_8_bytes_valid_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -871,7 +871,7 @@ int test_extract_trace_id_8_bytes_valid_check(struct __ctx_buff *ctx)
 }
 
 /* Test an 8-byte trace ID followed by padding. */
-PKTGEN("tc", "extract_trace_id_8_bytes_with_padding")
+PKTGEN(PROG_TYPE, "extract_trace_id_8_bytes_with_padding")
 int test_extract_trace_id_8_bytes_with_padding_pktgen(struct __ctx_buff *ctx)
 {
 	struct ipopthdr opts[] = {
@@ -891,7 +891,7 @@ int test_extract_trace_id_8_bytes_with_padding_pktgen(struct __ctx_buff *ctx)
 	return gen_packet_with_options(ctx, opts, 2, 12);
 }
 
-CHECK("tc", "extract_trace_id_8_bytes_with_padding")
+CHECK(PROG_TYPE, "extract_trace_id_8_bytes_with_padding")
 int test_extract_trace_id_8_bytes_with_padding_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -909,7 +909,7 @@ int test_extract_trace_id_8_bytes_with_padding_check(struct __ctx_buff *ctx)
 }
 
 /* Test an 8-byte trace ID that represents a negative value. */
-PKTGEN("tc", "extract_trace_id_8_bytes_negative")
+PKTGEN(PROG_TYPE, "extract_trace_id_8_bytes_negative")
 int test_extract_trace_id_8_bytes_negative_pktgen(struct __ctx_buff *ctx)
 {
 	struct ipopthdr opts[] = {
@@ -924,7 +924,7 @@ int test_extract_trace_id_8_bytes_negative_pktgen(struct __ctx_buff *ctx)
 	return gen_packet_with_options(ctx, opts, 1, 12);
 }
 
-CHECK("tc", "extract_trace_id_8_bytes_negative")
+CHECK(PROG_TYPE, "extract_trace_id_8_bytes_negative")
 int test_extract_trace_id_8_bytes_negative_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -943,7 +943,7 @@ int test_extract_trace_id_8_bytes_negative_check(struct __ctx_buff *ctx)
 }
 
 /* Test an 8-byte trace ID with an invalid option length. */
-PKTGEN("tc", "extract_trace_id_8_bytes_invalid_length")
+PKTGEN(PROG_TYPE, "extract_trace_id_8_bytes_invalid_length")
 int test_extract_trace_id_8_bytes_invalid_length_pktgen(struct __ctx_buff *ctx)
 {
 	struct ipopthdr opts[] = {
@@ -957,7 +957,7 @@ int test_extract_trace_id_8_bytes_invalid_length_pktgen(struct __ctx_buff *ctx)
 	return gen_packet_with_options(ctx, opts, 1, 12);
 }
 
-CHECK("tc", "extract_trace_id_8_bytes_invalid_length")
+CHECK(PROG_TYPE, "extract_trace_id_8_bytes_invalid_length")
 int test_extract_trace_id_8_bytes_invalid_length_check(struct __ctx_buff *ctx)
 {
 	test_init();

--- a/bpf/tests/ipfrag.c
+++ b/bpf/tests/ipfrag.c
@@ -9,7 +9,7 @@
 #include <lib/ipfrag.h>
 #include <lib/ipv6.h>
 
-PKTGEN("tc", "ipfrag_helpers_ipv4")
+PKTGEN(PROG_TYPE, "ipfrag_helpers_ipv4")
 int test_ipfrag_helpers_ipv4_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -35,7 +35,7 @@ int test_ipfrag_helpers_ipv4_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-CHECK("tc", "ipfrag_helpers_ipv4")
+CHECK(PROG_TYPE, "ipfrag_helpers_ipv4")
 int test_ipfrag_helpers_ipv4_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -91,7 +91,7 @@ int test_ipfrag_helpers_ipv4_check(struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "ipfrag_helpers_ipv6_nofrag")
+PKTGEN(PROG_TYPE, "ipfrag_helpers_ipv6_nofrag")
 int test_ipfrag_helpers_ipv6_nofrag_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -117,7 +117,7 @@ int test_ipfrag_helpers_ipv6_nofrag_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-CHECK("tc", "ipfrag_helpers_ipv6_nofrag")
+CHECK(PROG_TYPE, "ipfrag_helpers_ipv6_nofrag")
 int test_ipfrag_helpers_ipv6_nofrag_check(struct __ctx_buff *ctx __maybe_unused)
 {
 	void *data, *data_end;
@@ -155,7 +155,7 @@ int test_ipfrag_helpers_ipv6_nofrag_check(struct __ctx_buff *ctx __maybe_unused)
 	test_finish();
 }
 
-PKTGEN("tc", "ipfrag_helpers_ipv6")
+PKTGEN(PROG_TYPE, "ipfrag_helpers_ipv6")
 int test_ipfrag_helpers_ipv6_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -197,7 +197,7 @@ int test_ipfrag_helpers_ipv6_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-CHECK("tc", "ipfrag_helpers_ipv6")
+CHECK(PROG_TYPE, "ipfrag_helpers_ipv6")
 int test_ipfrag_helpers_ipv6_check(struct __ctx_buff *ctx __maybe_unused)
 {
 	void *data, *data_end;

--- a/bpf/tests/ipv6_ndp_from_netdev_test.c
+++ b/bpf/tests/ipv6_ndp_from_netdev_test.c
@@ -115,7 +115,7 @@ int __ipv6_from_netdev_ns_pod_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-PKTGEN("tc", "011_ipv6_from_netdev_ns_pod")
+PKTGEN(PROG_TYPE, "011_ipv6_from_netdev_ns_pod")
 int ipv6_from_netdev_ns_pod_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -128,13 +128,13 @@ int ipv6_from_netdev_ns_pod_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "011_ipv6_from_netdev_ns_pod")
+SETUP(PROG_TYPE, "011_ipv6_from_netdev_ns_pod")
 int ipv6_from_netdev_ns_pod_setup(struct __ctx_buff *ctx)
 {
 	return __ipv6_from_netdev_ns_pod_setup(ctx);
 }
 
-CHECK("tc", "011_ipv6_from_netdev_ns_pod")
+CHECK(PROG_TYPE, "011_ipv6_from_netdev_ns_pod")
 int ipv6_from_netdev_ns_pod_check(const struct __ctx_buff *ctx)
 {
 	test_init();
@@ -151,7 +151,7 @@ int ipv6_from_netdev_ns_pod_check(const struct __ctx_buff *ctx)
 	return 0;
 }
 
-PKTGEN("tc", "011_ipv6_from_netdev_ns_pod_noopt")
+PKTGEN(PROG_TYPE, "011_ipv6_from_netdev_ns_pod_noopt")
 int ipv6_from_netdev_ns_pod_pktgen_noopt(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -165,13 +165,13 @@ int ipv6_from_netdev_ns_pod_pktgen_noopt(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "011_ipv6_from_netdev_ns_pod_noopt")
+SETUP(PROG_TYPE, "011_ipv6_from_netdev_ns_pod_noopt")
 int ipv6_from_netdev_ns_pod_setup_noopt(struct __ctx_buff *ctx)
 {
 	return __ipv6_from_netdev_ns_pod_setup(ctx);
 }
 
-CHECK("tc", "011_ipv6_from_netdev_ns_pod_noopt")
+CHECK(PROG_TYPE, "011_ipv6_from_netdev_ns_pod_noopt")
 int ipv6_from_netdev_ns_pod_check_noopt(const struct __ctx_buff *ctx)
 {
 	test_init();
@@ -200,7 +200,7 @@ int __ipv6_from_netdev_ns_pod_setup_mcast(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-PKTGEN("tc", "012_ipv6_from_netdev_ns_pod_mcast")
+PKTGEN(PROG_TYPE, "012_ipv6_from_netdev_ns_pod_mcast")
 int ipv6_from_netdev_ns_pod_pktgen_mcast(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -215,13 +215,13 @@ int ipv6_from_netdev_ns_pod_pktgen_mcast(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "012_ipv6_from_netdev_ns_pod_mcast")
+SETUP(PROG_TYPE, "012_ipv6_from_netdev_ns_pod_mcast")
 int ipv6_from_netdev_ns_pod_setup_mcast(struct __ctx_buff *ctx)
 {
 	return __ipv6_from_netdev_ns_pod_setup_mcast(ctx);
 }
 
-CHECK("tc", "012_ipv6_from_netdev_ns_pod_mcast")
+CHECK(PROG_TYPE, "012_ipv6_from_netdev_ns_pod_mcast")
 int ipv6_from_netdev_ns_pod_check_mcast(const struct __ctx_buff *ctx)
 {
 	test_init();
@@ -239,7 +239,7 @@ int ipv6_from_netdev_ns_pod_check_mcast(const struct __ctx_buff *ctx)
 	return 0;
 }
 
-PKTGEN("tc", "012_ipv6_from_netdev_ns_pod_mcast_noopt")
+PKTGEN(PROG_TYPE, "012_ipv6_from_netdev_ns_pod_mcast_noopt")
 int ipv6_from_netdev_ns_pod_pktgen_mcast_noopt(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -253,13 +253,13 @@ int ipv6_from_netdev_ns_pod_pktgen_mcast_noopt(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "012_ipv6_from_netdev_ns_pod_mcast_noopt")
+SETUP(PROG_TYPE, "012_ipv6_from_netdev_ns_pod_mcast_noopt")
 int ipv6_from_netdev_ns_pod_setup_mcast_noopt(struct __ctx_buff *ctx)
 {
 	return __ipv6_from_netdev_ns_pod_setup_mcast(ctx);
 }
 
-CHECK("tc", "012_ipv6_from_netdev_ns_pod_mcast_noopt")
+CHECK(PROG_TYPE, "012_ipv6_from_netdev_ns_pod_mcast_noopt")
 int ipv6_from_netdev_ns_pod_check_mcast_noopt(const struct __ctx_buff *ctx)
 {
 	test_init();
@@ -294,7 +294,7 @@ int __ipv6_from_netdev_ns_node_ip_setup(struct __ctx_buff *ctx)
 }
 
 /* With LL SRC option */
-PKTGEN("tc", "0211_ipv6_from_netdev_ns_node_ip")
+PKTGEN(PROG_TYPE, "0211_ipv6_from_netdev_ns_node_ip")
 int ipv6_from_netdev_ns_node_ip_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -308,13 +308,13 @@ int ipv6_from_netdev_ns_node_ip_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "0211_ipv6_from_netdev_ns_node_ip")
+SETUP(PROG_TYPE, "0211_ipv6_from_netdev_ns_node_ip")
 int ipv6_from_netdev_ns_node_ip_setup(struct __ctx_buff *ctx)
 {
 	return __ipv6_from_netdev_ns_node_ip_setup(ctx);
 }
 
-CHECK("tc", "0211_ipv6_from_netdev_ns_node_ip")
+CHECK(PROG_TYPE, "0211_ipv6_from_netdev_ns_node_ip")
 int ipv6_from_netdev_ns_node_ip_check(const struct __ctx_buff *ctx)
 {
 	test_init();
@@ -334,7 +334,7 @@ int ipv6_from_netdev_ns_node_ip_check(const struct __ctx_buff *ctx)
 }
 
 /* Without LL SRC option */
-PKTGEN("tc", "0212_ipv6_from_netdev_ns_node_ip_noopt")
+PKTGEN(PROG_TYPE, "0212_ipv6_from_netdev_ns_node_ip_noopt")
 int ipv6_from_netdev_ns_node_ip_pktgen_noopt(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -348,13 +348,13 @@ int ipv6_from_netdev_ns_node_ip_pktgen_noopt(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "0212_ipv6_from_netdev_ns_node_ip_noopt")
+SETUP(PROG_TYPE, "0212_ipv6_from_netdev_ns_node_ip_noopt")
 int ipv6_from_netdev_ns_node_ip_setup_noopt(struct __ctx_buff *ctx)
 {
 	return __ipv6_from_netdev_ns_node_ip_setup(ctx);
 }
 
-CHECK("tc", "0212_ipv6_from_netdev_ns_node_ip_noopt")
+CHECK(PROG_TYPE, "0212_ipv6_from_netdev_ns_node_ip_noopt")
 int ipv6_from_netdev_ns_node_ip_check_noopt(const struct __ctx_buff *ctx)
 {
 	test_init();
@@ -383,7 +383,7 @@ int __ipv6_from_netdev_ns_node_ip_setup_mcast(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-PKTGEN("tc", "022_ipv6_from_netdev_ns_node_ip_mcast")
+PKTGEN(PROG_TYPE, "022_ipv6_from_netdev_ns_node_ip_mcast")
 int ipv6_from_netdev_ns_node_ip_pktgen_mcast(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -398,13 +398,13 @@ int ipv6_from_netdev_ns_node_ip_pktgen_mcast(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "022_ipv6_from_netdev_ns_node_ip_mcast")
+SETUP(PROG_TYPE, "022_ipv6_from_netdev_ns_node_ip_mcast")
 int ipv6_from_netdev_ns_node_ip_setup_mcast(struct __ctx_buff *ctx)
 {
 	return __ipv6_from_netdev_ns_node_ip_setup_mcast(ctx);
 }
 
-CHECK("tc", "022_ipv6_from_netdev_ns_node_ip_mcast")
+CHECK(PROG_TYPE, "022_ipv6_from_netdev_ns_node_ip_mcast")
 int ipv6_from_netdev_ns_node_ip_check_mcast(const struct __ctx_buff *ctx)
 {
 	test_init();
@@ -423,7 +423,7 @@ int ipv6_from_netdev_ns_node_ip_check_mcast(const struct __ctx_buff *ctx)
 	return 0;
 }
 
-PKTGEN("tc", "022_ipv6_from_netdev_ns_node_ip_mcast_noopt")
+PKTGEN(PROG_TYPE, "022_ipv6_from_netdev_ns_node_ip_mcast_noopt")
 int ipv6_from_netdev_ns_node_ip_pktgen_mcast_noopt(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -437,13 +437,13 @@ int ipv6_from_netdev_ns_node_ip_pktgen_mcast_noopt(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "022_ipv6_from_netdev_ns_node_ip_mcast_noopt")
+SETUP(PROG_TYPE, "022_ipv6_from_netdev_ns_node_ip_mcast_noopt")
 int ipv6_from_netdev_ns_node_ip_setup_mcast_noopt(struct __ctx_buff *ctx)
 {
 	return __ipv6_from_netdev_ns_node_ip_setup_mcast(ctx);
 }
 
-CHECK("tc", "022_ipv6_from_netdev_ns_node_ip_mcast_noopt")
+CHECK(PROG_TYPE, "022_ipv6_from_netdev_ns_node_ip_mcast_noopt")
 int ipv6_from_netdev_ns_node_ip_check_mcast_noopt(const struct __ctx_buff *ctx)
 {
 	test_init();

--- a/bpf/tests/ipv6_test.c
+++ b/bpf/tests/ipv6_test.c
@@ -9,7 +9,7 @@
 #include "lib/common.h"
 #include "lib/ipv6.h"
 
-PKTGEN("xdp", "ipv6_without_extension_header")
+PKTGEN(PROG_TYPE, "ipv6_without_extension_header")
 int ipv6_without_extension_header_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -29,13 +29,13 @@ int ipv6_without_extension_header_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("xdp", "ipv6_without_extension_header")
+SETUP(PROG_TYPE, "ipv6_without_extension_header")
 int ipv6_without_extension_header_setup(__maybe_unused struct __ctx_buff *ctx)
 {
 	return 123;
 }
 
-CHECK("xdp", "ipv6_without_extension_header")
+CHECK(PROG_TYPE, "ipv6_without_extension_header")
 int ipv6_without_extension_header_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -85,7 +85,7 @@ struct ipv6_authhdr {
 	char icv[];
 };
 
-PKTGEN("xdp", "ipv6_with_auth_hop_tcp")
+PKTGEN(PROG_TYPE, "ipv6_with_auth_hop_tcp")
 int ipv6_with_hop_auth_tcp_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -128,13 +128,13 @@ int ipv6_with_hop_auth_tcp_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("xdp", "ipv6_with_auth_hop_tcp")
+SETUP(PROG_TYPE, "ipv6_with_auth_hop_tcp")
 int ipv6_with_hop_auth_tcp_setup(__maybe_unused struct __ctx_buff *ctx)
 {
 	return 1234;
 }
 
-CHECK("xdp", "ipv6_with_auth_hop_tcp")
+CHECK(PROG_TYPE, "ipv6_with_auth_hop_tcp")
 int ipv6_with_hop_auth_tcp_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -176,7 +176,7 @@ int ipv6_with_hop_auth_tcp_check(struct __ctx_buff *ctx)
 	test_finish();
 }
 
-CHECK("xdp", "ipv6")
+CHECK(PROG_TYPE, "ipv6")
 int bpf_test(__maybe_unused struct xdp_md *ctx)
 {
 	test_init();

--- a/bpf/tests/jhash_test.c
+++ b/bpf/tests/jhash_test.c
@@ -5,7 +5,7 @@
 #include "common.h"
 #include <lib/jhash.h>
 
-CHECK("xdp", "jhash")
+CHECK(PROG_TYPE, "jhash")
 int bpf_test(__maybe_unused struct xdp_md *ctx)
 {
 	test_init();

--- a/bpf/tests/kpr_dsr_lb.h
+++ b/bpf/tests/kpr_dsr_lb.h
@@ -2,10 +2,8 @@
 /* Copyright Authors of Cilium */
 
 #ifdef ATTACHMENT_XDP
-# define ATTACH "xdp"
 # include <bpf/ctx/xdp.h>
 #else
-# define ATTACH "tc"
 # include <bpf/ctx/skb.h>
 #endif
 
@@ -254,7 +252,7 @@ const __u8 kpr_v6_dsr_lb2_data2_post_geneve_xdp[] = {
  * We expect the SYN to carry DSR-info, but the SYN-ACK to be forwarded
  * without DSR-info.
  */
-PKTGEN(ATTACH, "kpr_v4_dsr_lb1_syn")
+PKTGEN(PROG_TYPE, "kpr_v4_dsr_lb1_syn")
 int kpr_v4_dsr_lb1_syn_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -269,7 +267,7 @@ int kpr_v4_dsr_lb1_syn_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP(ATTACH, "kpr_v4_dsr_lb1_syn")
+SETUP(PROG_TYPE, "kpr_v4_dsr_lb1_syn")
 int kpr_v4_dsr_lb1_syn_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -286,7 +284,7 @@ int kpr_v4_dsr_lb1_syn_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK(ATTACH, "kpr_v4_dsr_lb1_syn")
+CHECK(PROG_TYPE, "kpr_v4_dsr_lb1_syn")
 int kpr_v4_dsr_lb1_syn_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -363,7 +361,7 @@ int kpr_v4_dsr_lb1_syn_check(__maybe_unused const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN(ATTACH, "kpr_v4_dsr_lb1_synack")
+PKTGEN(PROG_TYPE, "kpr_v4_dsr_lb1_synack")
 int kpr_v4_dsr_lb1_synack_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -378,7 +376,7 @@ int kpr_v4_dsr_lb1_synack_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP(ATTACH, "kpr_v4_dsr_lb1_synack")
+SETUP(PROG_TYPE, "kpr_v4_dsr_lb1_synack")
 int kpr_v4_dsr_lb1_synack_setup(struct __ctx_buff *ctx)
 {
 	tunnel_key_set = false;
@@ -387,7 +385,7 @@ int kpr_v4_dsr_lb1_synack_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK(ATTACH, "kpr_v4_dsr_lb1_synack")
+CHECK(PROG_TYPE, "kpr_v4_dsr_lb1_synack")
 int kpr_v4_dsr_lb1_synack_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -454,7 +452,7 @@ int kpr_v4_dsr_lb1_synack_check(__maybe_unused const struct __ctx_buff *ctx)
  * We expect the first data packet to carry DSR-info, but the second data packet
  * to be forwarded without DSR-info.
  */
-PKTGEN(ATTACH, "kpr_v4_dsr_lb2_data")
+PKTGEN(PROG_TYPE, "kpr_v4_dsr_lb2_data")
 int kpr_v4_dsr_lb2_data_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -469,7 +467,7 @@ int kpr_v4_dsr_lb2_data_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP(ATTACH, "kpr_v4_dsr_lb2_data")
+SETUP(PROG_TYPE, "kpr_v4_dsr_lb2_data")
 int kpr_v4_dsr_lb2_data_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 2;
@@ -484,7 +482,7 @@ int kpr_v4_dsr_lb2_data_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK(ATTACH, "kpr_v4_dsr_lb2_data")
+CHECK(PROG_TYPE, "kpr_v4_dsr_lb2_data")
 int kpr_v4_dsr_lb2_data_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -561,7 +559,7 @@ int kpr_v4_dsr_lb2_data_check(__maybe_unused const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN(ATTACH, "kpr_v4_dsr_lb2_data2")
+PKTGEN(PROG_TYPE, "kpr_v4_dsr_lb2_data2")
 int kpr_v4_dsr_lb2_data2_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -576,7 +574,7 @@ int kpr_v4_dsr_lb2_data2_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP(ATTACH, "kpr_v4_dsr_lb2_data2")
+SETUP(PROG_TYPE, "kpr_v4_dsr_lb2_data2")
 int kpr_v4_dsr_lb2_data2_setup(struct __ctx_buff *ctx)
 {
 	tunnel_key_set = false;
@@ -585,7 +583,7 @@ int kpr_v4_dsr_lb2_data2_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK(ATTACH, "kpr_v4_dsr_lb2_data2")
+CHECK(PROG_TYPE, "kpr_v4_dsr_lb2_data2")
 int kpr_v4_dsr_lb2_data2_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -650,7 +648,7 @@ int kpr_v4_dsr_lb2_data2_check(__maybe_unused const struct __ctx_buff *ctx)
 #endif /* ENABLE_IPV4 */
 
 #ifdef ENABLE_IPV6
-PKTGEN(ATTACH, "kpr_v6_dsr_lb1_syn")
+PKTGEN(PROG_TYPE, "kpr_v6_dsr_lb1_syn")
 int kpr_v6_dsr_lb1_syn_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -665,7 +663,7 @@ int kpr_v6_dsr_lb1_syn_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP(ATTACH, "kpr_v6_dsr_lb1_syn")
+SETUP(PROG_TYPE, "kpr_v6_dsr_lb1_syn")
 int kpr_v6_dsr_lb1_syn_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -684,7 +682,7 @@ int kpr_v6_dsr_lb1_syn_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK(ATTACH, "kpr_v6_dsr_lb1_syn")
+CHECK(PROG_TYPE, "kpr_v6_dsr_lb1_syn")
 int kpr_v6_dsr_lb1_syn_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -761,7 +759,7 @@ int kpr_v6_dsr_lb1_syn_check(__maybe_unused const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN(ATTACH, "kpr_v6_dsr_lb1_synack")
+PKTGEN(PROG_TYPE, "kpr_v6_dsr_lb1_synack")
 int kpr_v6_dsr_lb1_synack_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -776,7 +774,7 @@ int kpr_v6_dsr_lb1_synack_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP(ATTACH, "kpr_v6_dsr_lb1_synack")
+SETUP(PROG_TYPE, "kpr_v6_dsr_lb1_synack")
 int kpr_v6_dsr_lb1_synack_setup(struct __ctx_buff *ctx)
 {
 	tunnel_key_set = false;
@@ -785,7 +783,7 @@ int kpr_v6_dsr_lb1_synack_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK(ATTACH, "kpr_v6_dsr_lb1_synack")
+CHECK(PROG_TYPE, "kpr_v6_dsr_lb1_synack")
 int kpr_v6_dsr_lb1_synack_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -848,7 +846,7 @@ int kpr_v6_dsr_lb1_synack_check(__maybe_unused const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN(ATTACH, "kpr_v6_dsr_lb2_data")
+PKTGEN(PROG_TYPE, "kpr_v6_dsr_lb2_data")
 int kpr_v6_dsr_lb2_data_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -863,7 +861,7 @@ int kpr_v6_dsr_lb2_data_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP(ATTACH, "kpr_v6_dsr_lb2_data")
+SETUP(PROG_TYPE, "kpr_v6_dsr_lb2_data")
 int kpr_v6_dsr_lb2_data_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 2;
@@ -880,7 +878,7 @@ int kpr_v6_dsr_lb2_data_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK(ATTACH, "kpr_v6_dsr_lb2_data")
+CHECK(PROG_TYPE, "kpr_v6_dsr_lb2_data")
 int kpr_v6_dsr_lb2_data_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -958,7 +956,7 @@ int kpr_v6_dsr_lb2_data_check(__maybe_unused const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN(ATTACH, "kpr_v6_dsr_lb2_data2")
+PKTGEN(PROG_TYPE, "kpr_v6_dsr_lb2_data2")
 int kpr_v6_dsr_lb2_data2_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -973,7 +971,7 @@ int kpr_v6_dsr_lb2_data2_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP(ATTACH, "kpr_v6_dsr_lb2_data2")
+SETUP(PROG_TYPE, "kpr_v6_dsr_lb2_data2")
 int kpr_v6_dsr_lb2_data2_setup(struct __ctx_buff *ctx)
 {
 	tunnel_key_set = false;
@@ -982,7 +980,7 @@ int kpr_v6_dsr_lb2_data2_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK(ATTACH, "kpr_v6_dsr_lb2_data2")
+CHECK(PROG_TYPE, "kpr_v6_dsr_lb2_data2")
 int kpr_v6_dsr_lb2_data2_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/kpr_dsr_remote_node.h
+++ b/bpf/tests/kpr_dsr_remote_node.h
@@ -2,10 +2,8 @@
 /* Copyright Authors of Cilium */
 
 #ifdef ATTACHMENT_XDP
-# define ATTACH "xdp"
 # include <bpf/ctx/xdp.h>
 #else
-# define ATTACH "tc"
 # include <bpf/ctx/skb.h>
 #endif
 
@@ -91,7 +89,7 @@ const __u8 kpr_v6_dsr_remote_node_reply2_post[] = {
  * Then we receive a second packet without DSR-info. Replies can still be
  * RevDNATed.
  */
-PKTGEN(ATTACH, "kpr_v4_dsr_remote_node_1syn")
+PKTGEN(PROG_TYPE, "kpr_v4_dsr_remote_node_1syn")
 int kpr_v4_dsr_remote_node_1syn_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -106,7 +104,7 @@ int kpr_v4_dsr_remote_node_1syn_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP(ATTACH, "kpr_v4_dsr_remote_node_1syn")
+SETUP(PROG_TYPE, "kpr_v4_dsr_remote_node_1syn")
 int kpr_v4_dsr_remote_node_1syn_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v4_add_entry(v4_pod_one, 123, BACKEND_EP_ID, 0, 0, 0, NULL, NULL);
@@ -114,7 +112,7 @@ int kpr_v4_dsr_remote_node_1syn_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK(ATTACH, "kpr_v4_dsr_remote_node_1syn")
+CHECK(PROG_TYPE, "kpr_v4_dsr_remote_node_1syn")
 int kpr_v4_dsr_remote_node_1syn_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	__u32 pkt_offset = sizeof(__u32);
@@ -167,7 +165,7 @@ int kpr_v4_dsr_remote_node_1syn_check(__maybe_unused const struct __ctx_buff *ct
 }
 
 #ifdef CHECK_REPLY
-PKTGEN(ATTACH, "kpr_v4_dsr_remote_node_2reply")
+PKTGEN(PROG_TYPE, "kpr_v4_dsr_remote_node_2reply")
 int kpr_v4_dsr_remote_node_2reply_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -182,13 +180,13 @@ int kpr_v4_dsr_remote_node_2reply_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP(ATTACH, "kpr_v4_dsr_remote_node_2reply")
+SETUP(PROG_TYPE, "kpr_v4_dsr_remote_node_2reply")
 int kpr_v4_dsr_remote_node_2reply_setup(struct __ctx_buff *ctx)
 {
 	return netdev_send_packet(ctx);
 }
 
-CHECK(ATTACH, "kpr_v4_dsr_remote_node_2reply")
+CHECK(PROG_TYPE, "kpr_v4_dsr_remote_node_2reply")
 int kpr_v4_dsr_remote_node_2reply_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -215,7 +213,7 @@ int kpr_v4_dsr_remote_node_2reply_check(__maybe_unused const struct __ctx_buff *
 }
 #endif
 
-PKTGEN(ATTACH, "kpr_v4_dsr_remote_node_3synack")
+PKTGEN(PROG_TYPE, "kpr_v4_dsr_remote_node_3synack")
 int kpr_v4_dsr_remote_node_3synack_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -230,13 +228,13 @@ int kpr_v4_dsr_remote_node_3synack_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP(ATTACH, "kpr_v4_dsr_remote_node_3synack")
+SETUP(PROG_TYPE, "kpr_v4_dsr_remote_node_3synack")
 int kpr_v4_dsr_remote_node_3synack_setup(struct __ctx_buff *ctx)
 {
 	return netdev_receive_packet(ctx);
 }
 
-CHECK(ATTACH, "kpr_v4_dsr_remote_node_3synack")
+CHECK(PROG_TYPE, "kpr_v4_dsr_remote_node_3synack")
 int kpr_v4_dsr_remote_node_3synack_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	__u32 pkt_offset = sizeof(__u32);
@@ -268,7 +266,7 @@ int kpr_v4_dsr_remote_node_3synack_check(__maybe_unused const struct __ctx_buff 
 }
 
 #ifdef CHECK_REPLY
-PKTGEN(ATTACH, "kpr_v4_dsr_remote_node_4reply")
+PKTGEN(PROG_TYPE, "kpr_v4_dsr_remote_node_4reply")
 int kpr_v4_dsr_remote_node_4reply_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -283,13 +281,13 @@ int kpr_v4_dsr_remote_node_4reply_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP(ATTACH, "kpr_v4_dsr_remote_node_4reply")
+SETUP(PROG_TYPE, "kpr_v4_dsr_remote_node_4reply")
 int kpr_v4_dsr_remote_node_4reply_setup(struct __ctx_buff *ctx)
 {
 	return netdev_send_packet(ctx);
 }
 
-CHECK(ATTACH, "kpr_v4_dsr_remote_node_4reply")
+CHECK(PROG_TYPE, "kpr_v4_dsr_remote_node_4reply")
 int kpr_v4_dsr_remote_node_4reply_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -319,7 +317,7 @@ int kpr_v4_dsr_remote_node_4reply_check(__maybe_unused const struct __ctx_buff *
 /* Now receive a non-SYN with different DSR-info.
  * The RevDNAT follows accordingly.
  */
-PKTGEN(ATTACH, "kpr_v4_dsr_remote_node_5data_dsr_info")
+PKTGEN(PROG_TYPE, "kpr_v4_dsr_remote_node_5data_dsr_info")
 int kpr_v4_dsr_remote_node_5data_dsr_info_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -334,13 +332,13 @@ int kpr_v4_dsr_remote_node_5data_dsr_info_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP(ATTACH, "kpr_v4_dsr_remote_node_5data_dsr_info")
+SETUP(PROG_TYPE, "kpr_v4_dsr_remote_node_5data_dsr_info")
 int kpr_v4_dsr_remote_node_5data_dsr_info_setup(struct __ctx_buff *ctx)
 {
 	return netdev_receive_packet(ctx);
 }
 
-CHECK(ATTACH, "kpr_v4_dsr_remote_node_5data_dsr_info")
+CHECK(PROG_TYPE, "kpr_v4_dsr_remote_node_5data_dsr_info")
 int kpr_v4_dsr_remote_node_5data_dsr_info_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	__u32 pkt_offset = sizeof(__u32);
@@ -393,7 +391,7 @@ int kpr_v4_dsr_remote_node_5data_dsr_info_check(__maybe_unused const struct __ct
 }
 
 #ifdef CHECK_REPLY
-PKTGEN(ATTACH, "kpr_v4_dsr_remote_node_6reply")
+PKTGEN(PROG_TYPE, "kpr_v4_dsr_remote_node_6reply")
 int kpr_v4_dsr_remote_node_6reply_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -408,13 +406,13 @@ int kpr_v4_dsr_remote_node_6reply_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP(ATTACH, "kpr_v4_dsr_remote_node_6reply")
+SETUP(PROG_TYPE, "kpr_v4_dsr_remote_node_6reply")
 int kpr_v4_dsr_remote_node_6reply_setup(struct __ctx_buff *ctx)
 {
 	return netdev_send_packet(ctx);
 }
 
-CHECK(ATTACH, "kpr_v4_dsr_remote_node_6reply")
+CHECK(PROG_TYPE, "kpr_v4_dsr_remote_node_6reply")
 int kpr_v4_dsr_remote_node_6reply_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -443,7 +441,7 @@ int kpr_v4_dsr_remote_node_6reply_check(__maybe_unused const struct __ctx_buff *
 #endif /* ENABLE_IPV4 */
 
 #ifdef ENABLE_IPV6
-PKTGEN(ATTACH, "kpr_v6_dsr_remote_node_1syn")
+PKTGEN(PROG_TYPE, "kpr_v6_dsr_remote_node_1syn")
 int kpr_v6_dsr_remote_node_1syn_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -458,7 +456,7 @@ int kpr_v6_dsr_remote_node_1syn_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP(ATTACH, "kpr_v6_dsr_remote_node_1syn")
+SETUP(PROG_TYPE, "kpr_v6_dsr_remote_node_1syn")
 int kpr_v6_dsr_remote_node_1syn_setup(struct __ctx_buff *ctx)
 {
 	union v6addr backend_ip = { v6_pod_one_addr };
@@ -468,7 +466,7 @@ int kpr_v6_dsr_remote_node_1syn_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK(ATTACH, "kpr_v6_dsr_remote_node_1syn")
+CHECK(PROG_TYPE, "kpr_v6_dsr_remote_node_1syn")
 int kpr_v6_dsr_remote_node_1syn_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	__u32 pkt_offset = sizeof(__u32);
@@ -524,7 +522,7 @@ int kpr_v6_dsr_remote_node_1syn_check(__maybe_unused const struct __ctx_buff *ct
 }
 
 #ifdef CHECK_REPLY
-PKTGEN(ATTACH, "kpr_v6_dsr_remote_node_2reply")
+PKTGEN(PROG_TYPE, "kpr_v6_dsr_remote_node_2reply")
 int kpr_v6_dsr_remote_node_2reply_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -539,13 +537,13 @@ int kpr_v6_dsr_remote_node_2reply_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP(ATTACH, "kpr_v6_dsr_remote_node_2reply")
+SETUP(PROG_TYPE, "kpr_v6_dsr_remote_node_2reply")
 int kpr_v6_dsr_remote_node_2reply_setup(struct __ctx_buff *ctx)
 {
 	return netdev_send_packet(ctx);
 }
 
-CHECK(ATTACH, "kpr_v6_dsr_remote_node_2reply")
+CHECK(PROG_TYPE, "kpr_v6_dsr_remote_node_2reply")
 int kpr_v6_dsr_remote_node_2reply_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -572,7 +570,7 @@ int kpr_v6_dsr_remote_node_2reply_check(__maybe_unused const struct __ctx_buff *
 }
 #endif
 
-PKTGEN(ATTACH, "kpr_v6_dsr_remote_node_3synack")
+PKTGEN(PROG_TYPE, "kpr_v6_dsr_remote_node_3synack")
 int kpr_v6_dsr_remote_node_3synack_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -587,13 +585,13 @@ int kpr_v6_dsr_remote_node_3synack_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP(ATTACH, "kpr_v6_dsr_remote_node_3synack")
+SETUP(PROG_TYPE, "kpr_v6_dsr_remote_node_3synack")
 int kpr_v6_dsr_remote_node_3synack_setup(struct __ctx_buff *ctx)
 {
 	return netdev_receive_packet(ctx);
 }
 
-CHECK(ATTACH, "kpr_v6_dsr_remote_node_3synack")
+CHECK(PROG_TYPE, "kpr_v6_dsr_remote_node_3synack")
 int kpr_v6_dsr_remote_node_3synack_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	__u32 pkt_offset = sizeof(__u32);
@@ -625,7 +623,7 @@ int kpr_v6_dsr_remote_node_3synack_check(__maybe_unused const struct __ctx_buff 
 }
 
 #ifdef CHECK_REPLY
-PKTGEN(ATTACH, "kpr_v6_dsr_remote_node_4reply")
+PKTGEN(PROG_TYPE, "kpr_v6_dsr_remote_node_4reply")
 int kpr_v6_dsr_remote_node_4reply_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -640,13 +638,13 @@ int kpr_v6_dsr_remote_node_4reply_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP(ATTACH, "kpr_v6_dsr_remote_node_4reply")
+SETUP(PROG_TYPE, "kpr_v6_dsr_remote_node_4reply")
 int kpr_v6_dsr_remote_node_4reply_setup(struct __ctx_buff *ctx)
 {
 	return netdev_send_packet(ctx);
 }
 
-CHECK(ATTACH, "kpr_v6_dsr_remote_node_4reply")
+CHECK(PROG_TYPE, "kpr_v6_dsr_remote_node_4reply")
 int kpr_v6_dsr_remote_node_4reply_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -673,7 +671,7 @@ int kpr_v6_dsr_remote_node_4reply_check(__maybe_unused const struct __ctx_buff *
 }
 #endif
 
-PKTGEN(ATTACH, "kpr_v6_dsr_remote_node_5data_dsr_info")
+PKTGEN(PROG_TYPE, "kpr_v6_dsr_remote_node_5data_dsr_info")
 int kpr_v6_dsr_remote_node_5data_dsr_info_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -688,13 +686,13 @@ int kpr_v6_dsr_remote_node_5data_dsr_info_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP(ATTACH, "kpr_v6_dsr_remote_node_5data_dsr_info")
+SETUP(PROG_TYPE, "kpr_v6_dsr_remote_node_5data_dsr_info")
 int kpr_v6_dsr_remote_node_5data_dsr_info_setup(struct __ctx_buff *ctx)
 {
 	return netdev_receive_packet(ctx);
 }
 
-CHECK(ATTACH, "kpr_v6_dsr_remote_node_5data_dsr_info")
+CHECK(PROG_TYPE, "kpr_v6_dsr_remote_node_5data_dsr_info")
 int kpr_v6_dsr_remote_node_5data_dsr_info_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	__u32 pkt_offset = sizeof(__u32);
@@ -750,7 +748,7 @@ int kpr_v6_dsr_remote_node_5data_dsr_info_check(__maybe_unused const struct __ct
 }
 
 #ifdef CHECK_REPLY
-PKTGEN(ATTACH, "kpr_v6_dsr_remote_node_6reply")
+PKTGEN(PROG_TYPE, "kpr_v6_dsr_remote_node_6reply")
 int kpr_v6_dsr_remote_node_6reply_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -765,13 +763,13 @@ int kpr_v6_dsr_remote_node_6reply_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP(ATTACH, "kpr_v6_dsr_remote_node_6reply")
+SETUP(PROG_TYPE, "kpr_v6_dsr_remote_node_6reply")
 int kpr_v6_dsr_remote_node_6reply_setup(struct __ctx_buff *ctx)
 {
 	return netdev_send_packet(ctx);
 }
 
-CHECK(ATTACH, "kpr_v6_dsr_remote_node_6reply")
+CHECK(PROG_TYPE, "kpr_v6_dsr_remote_node_6reply")
 int kpr_v6_dsr_remote_node_6reply_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/l4lb_ipip_health_check_host.c
+++ b/bpf/tests/l4lb_ipip_health_check_host.c
@@ -71,7 +71,7 @@ int mock_skb_set_tunnel_key(__maybe_unused struct __sk_buff *skb,
 #include "lib/bpf_host.h"
 
 /* Test that a health-check request to a remote backend is IPIP-encapsulated. */
-PKTGEN("tc", "l4lb_health_check_host")
+PKTGEN(PROG_TYPE, "l4lb_health_check_host")
 int l4lb_health_check_host_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -98,7 +98,7 @@ int l4lb_health_check_host_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "l4lb_health_check_host")
+SETUP(PROG_TYPE, "l4lb_health_check_host")
 int l4lb_health_check_host_setup(struct __ctx_buff *ctx)
 {
 	__sock_cookie key = SOCKET_COOKIE;
@@ -113,7 +113,7 @@ int l4lb_health_check_host_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "l4lb_health_check_host")
+CHECK(PROG_TYPE, "l4lb_health_check_host")
 int l4lb_health_check_host_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/l7_lb_hairpin_netdev.c
+++ b/bpf/tests/l7_lb_hairpin_netdev.c
@@ -68,7 +68,7 @@ ASSIGN_CONFIG(__u32, cilium_net_ifindex, CILIUM_NET_IFINDEX)
 ASSIGN_CONFIG(bool, proxy_redirect_via_cilium_net, true)
 
 /* Test 1: IPv4 L7 LB on bridge device. Ensure packets is hairpinned via cilium_net. */
-PKTGEN("tc", "l7_lb_hairpin_v4")
+PKTGEN(PROG_TYPE, "l7_lb_hairpin_v4")
 int l7_lb_hairpin_v4_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -87,7 +87,7 @@ int l7_lb_hairpin_v4_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "l7_lb_hairpin_v4")
+SETUP(PROG_TYPE, "l7_lb_hairpin_v4")
 int l7_lb_hairpin_v4_setup(struct __ctx_buff *ctx)
 {
 	clear_map(&cilium_lb4_services_v2);
@@ -102,7 +102,7 @@ int l7_lb_hairpin_v4_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "l7_lb_hairpin_v4")
+CHECK(PROG_TYPE, "l7_lb_hairpin_v4")
 int l7_lb_hairpin_v4_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -128,7 +128,7 @@ int l7_lb_hairpin_v4_check(const struct __ctx_buff *ctx)
 }
 
 /* Test 1: IPv6 L7 LB on bridge device. Ensure packets is hairpinned via cilium_net. */
-PKTGEN("tc", "l7_lb_hairpin_v6")
+PKTGEN(PROG_TYPE, "l7_lb_hairpin_v6")
 int l7_lb_hairpin_v6_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -148,7 +148,7 @@ int l7_lb_hairpin_v6_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "l7_lb_hairpin_v6")
+SETUP(PROG_TYPE, "l7_lb_hairpin_v6")
 int l7_lb_hairpin_v6_setup(struct __ctx_buff *ctx)
 {
 	clear_map(&cilium_lb6_services_v2);
@@ -164,7 +164,7 @@ int l7_lb_hairpin_v6_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "l7_lb_hairpin_v6")
+CHECK(PROG_TYPE, "l7_lb_hairpin_v6")
 int l7_lb_hairpin_v6_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/l7_lb_local_backend.h
+++ b/bpf/tests/l7_lb_local_backend.h
@@ -89,7 +89,7 @@ ASSIGN_CONFIG(__u32, interface_ifindex, 12)
  * Given we cannot import both bpf_host and bpf_lxc, in our SETUP functions
  * we will simulate hitting the `tail_call_egress_policy(ctx, lxc_id)` codepath.
  */
-PKTGEN("tc", "l7_lb_local_backend_v4")
+PKTGEN(PROG_TYPE, "l7_lb_local_backend_v4")
 int l7_lb_local_backend_v4_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -108,7 +108,7 @@ int l7_lb_local_backend_v4_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "l7_lb_local_backend_v4")
+SETUP(PROG_TYPE, "l7_lb_local_backend_v4")
 int l7_lb_local_backend_v4_setup(struct __ctx_buff *ctx)
 {
 	/* We need this to allow the packet proceeding. */
@@ -118,7 +118,7 @@ int l7_lb_local_backend_v4_setup(struct __ctx_buff *ctx)
 	return tail_call_egress_policy(ctx, CLIENT_EP_ID);
 }
 
-CHECK("tc", "l7_lb_local_backend_v4")
+CHECK(PROG_TYPE, "l7_lb_local_backend_v4")
 int l7_lb_local_backend_v4_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -146,7 +146,7 @@ int l7_lb_local_backend_v4_check(const struct __ctx_buff *ctx)
 }
 
 /* See IPv4 test for comments. */
-PKTGEN("tc", "l7_lb_local_backend_v6")
+PKTGEN(PROG_TYPE, "l7_lb_local_backend_v6")
 int l7_lb_local_backend_v6_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -165,7 +165,7 @@ int l7_lb_local_backend_v6_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "l7_lb_local_backend_v6")
+SETUP(PROG_TYPE, "l7_lb_local_backend_v6")
 int l7_lb_local_backend_v6_setup(struct __ctx_buff *ctx)
 {
 	/* We need this to allow the packet proceeding. */
@@ -175,7 +175,7 @@ int l7_lb_local_backend_v6_setup(struct __ctx_buff *ctx)
 	return tail_call_egress_policy(ctx, CLIENT_EP_ID);
 }
 
-CHECK("tc", "l7_lb_local_backend_v6")
+CHECK(PROG_TYPE, "l7_lb_local_backend_v6")
 int l7_lb_local_backend_v6_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/lb_tests.c
+++ b/bpf/tests/lb_tests.c
@@ -20,7 +20,7 @@
 #include "lib/lb.h"
 
 /* TCP Service, single-scope */
-CHECK("tc", "lb4_tcp_single_scope")
+CHECK(PROG_TYPE, "lb4_tcp_single_scope")
 int test_lb4_tcp_single_scope(__maybe_unused struct __ctx_buff *ctx)
 {
 	const struct lb4_service *service;
@@ -47,7 +47,7 @@ int test_lb4_tcp_single_scope(__maybe_unused struct __ctx_buff *ctx)
 }
 
 /* TCP Service, dual-scope */
-CHECK("tc", "lb4_tcp_dual_scope")
+CHECK(PROG_TYPE, "lb4_tcp_dual_scope")
 int test_lb4_tcp_dual_scope(__maybe_unused struct __ctx_buff *ctx)
 {
 	const struct lb4_service *service;
@@ -75,7 +75,7 @@ int test_lb4_tcp_dual_scope(__maybe_unused struct __ctx_buff *ctx)
 }
 
 /* UDP Service, single-scope */
-CHECK("tc", "lb4_udp_single_scope")
+CHECK(PROG_TYPE, "lb4_udp_single_scope")
 int test_lb4_udp_single_scope(__maybe_unused struct __ctx_buff *ctx)
 {
 	const struct lb4_service *service;
@@ -102,7 +102,7 @@ int test_lb4_udp_single_scope(__maybe_unused struct __ctx_buff *ctx)
 }
 
 /* UDP Service, dual-scope */
-CHECK("tc", "lb4_udp_dual_scope")
+CHECK(PROG_TYPE, "lb4_udp_dual_scope")
 int test_lb4_udp_dual_scope(__maybe_unused struct __ctx_buff *ctx)
 {
 	const struct lb4_service *service;
@@ -129,7 +129,7 @@ int test_lb4_udp_dual_scope(__maybe_unused struct __ctx_buff *ctx)
 }
 
 /* Protocol mismatch, no wildcard, single scope */
-CHECK("tc", "lb4_proto_mismatch_nowild_single_scope")
+CHECK(PROG_TYPE, "lb4_proto_mismatch_nowild_single_scope")
 int test_lb4_proto_mismatch_nowild_single_scope(__maybe_unused struct __ctx_buff *ctx)
 {
 	const struct lb4_service *service;
@@ -156,7 +156,7 @@ int test_lb4_proto_mismatch_nowild_single_scope(__maybe_unused struct __ctx_buff
 }
 
 /* Protocol mismatch, no wildcard, dual scope */
-CHECK("tc", "lb4_proto_mismatch_nowild_dual_scope")
+CHECK(PROG_TYPE, "lb4_proto_mismatch_nowild_dual_scope")
 int test_lb4_proto_mismatch_nowild_dual_scope(__maybe_unused struct __ctx_buff *ctx)
 {
 	const struct lb4_service *service;
@@ -183,7 +183,7 @@ int test_lb4_proto_mismatch_nowild_dual_scope(__maybe_unused struct __ctx_buff *
 }
 
 /* Protocol mismatch, with wildcard, single scope */
-CHECK("tc", "lb4_proto_mismatch_wild_single_scope")
+CHECK(PROG_TYPE, "lb4_proto_mismatch_wild_single_scope")
 int test_lb4_proto_mismatch_wild_single_scope(__maybe_unused struct __ctx_buff *ctx)
 {
 	const struct lb4_service *service;
@@ -222,7 +222,7 @@ int test_lb4_proto_mismatch_wild_single_scope(__maybe_unused struct __ctx_buff *
 }
 
 /* Protocol mismatch, with wildcard, dual scope */
-CHECK("tc", "lb4_proto_mismatch_wild_dual_scope")
+CHECK(PROG_TYPE, "lb4_proto_mismatch_wild_dual_scope")
 int test_lb4_proto_mismatch_wild_dual_scope(__maybe_unused struct __ctx_buff *ctx)
 {
 	const struct lb4_service *service;

--- a/bpf/tests/lxc_extended_protocols.c
+++ b/bpf/tests/lxc_extended_protocols.c
@@ -57,7 +57,7 @@ pod_send_packet(struct __ctx_buff *ctx)
 /* Send an IGMP packet from pod to IGMP destination (allow all egress policy).
  *
  */
-PKTGEN("tc", "lxc_igmp_egress")
+PKTGEN(PROG_TYPE, "lxc_igmp_egress")
 int lxc_igmp_egress_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -79,7 +79,7 @@ int lxc_igmp_egress_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "lxc_igmp_egress")
+SETUP(PROG_TYPE, "lxc_igmp_egress")
 int lxc_igmp_egress_setup(struct __ctx_buff *ctx)
 {
 	policy_add_egress_allow_all_entry();
@@ -95,7 +95,7 @@ int lxc_igmp_egress_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "lxc_igmp_egress")
+CHECK(PROG_TYPE, "lxc_igmp_egress")
 int lxc_igmp_egress_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -140,7 +140,7 @@ int lxc_igmp_egress_check(const struct __ctx_buff *ctx)
  *
  * The packet is allowed by the egress policy.
  */
-PKTGEN("tc", "lxc_igmp_egress_policy")
+PKTGEN(PROG_TYPE, "lxc_igmp_egress_policy")
 int lxc_igmp_egress_policy_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -162,7 +162,7 @@ int lxc_igmp_egress_policy_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "lxc_igmp_egress_policy")
+SETUP(PROG_TYPE, "lxc_igmp_egress_policy")
 int lxc_igmp_egress_policy_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v4_add_entry(CLIENT_IP, 0, 0, ENDPOINT_F_HOST, LXC_ID,
@@ -178,7 +178,7 @@ int lxc_igmp_egress_policy_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "lxc_igmp_egress_policy")
+CHECK(PROG_TYPE, "lxc_igmp_egress_policy")
 int lxc_igmp_egress_policy_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -221,7 +221,7 @@ int lxc_igmp_egress_policy_check(const struct __ctx_buff *ctx)
  *
  * The packet is denied by the egress policy.
  */
-PKTGEN("tc", "lxc_igmp_egress_policy_deny")
+PKTGEN(PROG_TYPE, "lxc_igmp_egress_policy_deny")
 int lxc_igmp_egress_policy_deny_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -243,7 +243,7 @@ int lxc_igmp_egress_policy_deny_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "lxc_igmp_egress_policy_deny")
+SETUP(PROG_TYPE, "lxc_igmp_egress_policy_deny")
 int lxc_igmp_egress_policy_deny_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v4_add_entry(CLIENT_IP, 0, 0, ENDPOINT_F_HOST, LXC_ID,
@@ -259,7 +259,7 @@ int lxc_igmp_egress_policy_deny_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "lxc_igmp_egress_policy_deny")
+CHECK(PROG_TYPE, "lxc_igmp_egress_policy_deny")
 int lxc_igmp_egress_policy_deny_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/mcast_tests.c
+++ b/bpf/tests/mcast_tests.c
@@ -70,7 +70,7 @@ static __always_inline int igmpv3_join_packet(struct __ctx_buff *ctx)
 	return 0;
 }
 
-CHECK("tc", "mcast_tests")
+CHECK(PROG_TYPE, "mcast_tests")
 int test1_check(struct __ctx_buff *ctx)
 {
 	test_init();

--- a/bpf/tests/mock_skb_metadata.c
+++ b/bpf/tests/mock_skb_metadata.c
@@ -7,7 +7,7 @@
 
 #include "mock_skb_metadata.h"
 
-PKTGEN("tc", "01_mock_skb_metadata")
+PKTGEN(PROG_TYPE, "01_mock_skb_metadata")
 int mock_skb_metadata_pktgen(__maybe_unused struct __ctx_buff *ctx)
 {
 	ctx_store_meta(ctx, 0, 1);
@@ -18,7 +18,7 @@ int mock_skb_metadata_pktgen(__maybe_unused struct __ctx_buff *ctx)
 	return 0;
 }
 
-CHECK("tc", "01_mock_skb_metadata")
+CHECK(PROG_TYPE, "01_mock_skb_metadata")
 int mock_skb_metadata_check1(__maybe_unused struct __ctx_buff *ctx)
 {
 	__u32 data;
@@ -43,7 +43,7 @@ int mock_skb_metadata_check1(__maybe_unused struct __ctx_buff *ctx)
 	test_finish();
 }
 
-CHECK("tc", "02_mock_skb_metadata")
+CHECK(PROG_TYPE, "02_mock_skb_metadata")
 int mock_skb_metadata_check2(__maybe_unused struct __ctx_buff *ctx)
 {
 	__u32 data;

--- a/bpf/tests/network_policy.c
+++ b/bpf/tests/network_policy.c
@@ -32,7 +32,7 @@ check_egress_policy(struct __ctx_buff *ctx, __u32 dst_id, __u8 proto, __be16 dpo
 				 &cookie);
 }
 
-CHECK("tc", "network_policy_egress_allow")
+CHECK(PROG_TYPE, "network_policy_egress_allow")
 int network_policy_egress_allow_check(struct __ctx_buff *ctx)
 {
 	test_init();

--- a/bpf/tests/nodeport_geneve_dsr_lb_xdp.c
+++ b/bpf/tests/nodeport_geneve_dsr_lb_xdp.c
@@ -87,7 +87,7 @@ ASSIGN_CONFIG(__u8, tunnel_protocol, TUNNEL_PROTOCOL_GENEVE)
  * - gets DNATed (but not SNATed)
  * - gets passed up from XDP to TC
  */
-PKTGEN("xdp", "nodeport_geneve_dsr_lb_xdp1_local_backend")
+PKTGEN(PROG_TYPE, "nodeport_geneve_dsr_lb_xdp1_local_backend")
 int nodeport_geneve_dsr_lb_xdp1_local_backend_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -114,7 +114,7 @@ int nodeport_geneve_dsr_lb_xdp1_local_backend_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("xdp", "nodeport_geneve_dsr_lb_xdp1_local_backend")
+SETUP(PROG_TYPE, "nodeport_geneve_dsr_lb_xdp1_local_backend")
 int nodeport_geneve_dsr_lb_xdp1_local_backend_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -132,7 +132,7 @@ int nodeport_geneve_dsr_lb_xdp1_local_backend_setup(struct __ctx_buff *ctx)
 	return xdp_receive_packet(ctx);
 }
 
-CHECK("xdp", "nodeport_geneve_dsr_lb_xdp1_local_backend")
+CHECK(PROG_TYPE, "nodeport_geneve_dsr_lb_xdp1_local_backend")
 int nodeport_geneve_dsr_lb_xdp1_local_backend_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -204,7 +204,7 @@ int nodeport_geneve_dsr_lb_xdp1_local_backend_check(const struct __ctx_buff *ctx
  * - has tunnel encapsulation header added,
  * - has DSR option inserted
  */
-PKTGEN("xdp", "nodeport_geneve_dsr_lb_xdp2_fwd")
+PKTGEN(PROG_TYPE, "nodeport_geneve_dsr_lb_xdp2_fwd")
 int nodeport_geneve_dsr_lb_xdp2_fwd_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -231,7 +231,7 @@ int nodeport_geneve_dsr_lb_xdp2_fwd_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("xdp", "nodeport_geneve_dsr_lb_xdp2_fwd")
+SETUP(PROG_TYPE, "nodeport_geneve_dsr_lb_xdp2_fwd")
 int nodeport_geneve_dsr_lb_xdp2_fwd_setup(struct __ctx_buff *ctx)
 {
 	__u32 backend_id = 125;
@@ -246,7 +246,7 @@ int nodeport_geneve_dsr_lb_xdp2_fwd_setup(struct __ctx_buff *ctx)
 	return xdp_receive_packet(ctx);
 }
 
-CHECK("xdp", "nodeport_geneve_dsr_lb_xdp2_fwd")
+CHECK(PROG_TYPE, "nodeport_geneve_dsr_lb_xdp2_fwd")
 int nodeport_geneve_dsr_lb_xdp_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	struct geneve_dsr_opt4 *dsr_opt;

--- a/bpf/tests/nodeport_hybrid_dsr_test.c
+++ b/bpf/tests/nodeport_hybrid_dsr_test.c
@@ -19,7 +19,7 @@
 
 ASSIGN_CONFIG(bool, enable_endpoint_routes, true)
 
-CHECK("tc", "test_nodeport_uses_dsr_ipv4_with_flag")
+CHECK(PROG_TYPE, "test_nodeport_uses_dsr_ipv4_with_flag")
 int test_nodeport_uses_dsr_ipv4_with_flag(__maybe_unused struct __ctx_buff *ctx)
 {
 	test_init();
@@ -60,7 +60,7 @@ int test_nodeport_uses_dsr_ipv4_with_flag(__maybe_unused struct __ctx_buff *ctx)
 	test_finish();
 }
 
-CHECK("tc", "test_nodeport_uses_dsr_ipv6_with_flag")
+CHECK(PROG_TYPE, "test_nodeport_uses_dsr_ipv6_with_flag")
 int test_nodeport_uses_dsr_ipv6_with_flag(__maybe_unused struct __ctx_buff *ctx)
 {
 	test_init();

--- a/bpf/tests/nodeport_overlay_nat_lb.c
+++ b/bpf/tests/nodeport_overlay_nat_lb.c
@@ -106,7 +106,7 @@ ASSIGN_CONFIG(__u8, tunnel_protocol, TUNNEL_PROTOCOL_VXLAN)
  * and flows back out on the overlay interface to a remote backend
  * (with WORLD_ID security identity).
  */
-PKTGEN("tc", "nodeport_overlay_nat_1_fwd")
+PKTGEN(PROG_TYPE, "nodeport_overlay_nat_1_fwd")
 int nodeport_overlay_nat_1_fwd_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -133,7 +133,7 @@ int nodeport_overlay_nat_1_fwd_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "nodeport_overlay_nat_1_fwd")
+SETUP(PROG_TYPE, "nodeport_overlay_nat_1_fwd")
 int nodeport_overlay_nat_1_fwd_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -148,7 +148,7 @@ int nodeport_overlay_nat_1_fwd_setup(struct __ctx_buff *ctx)
 	return overlay_receive_packet(ctx);
 }
 
-CHECK("tc", "nodeport_overlay_nat_1_fwd")
+CHECK(PROG_TYPE, "nodeport_overlay_nat_1_fwd")
 int nodeport_overlay_nat_1_fwd_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -210,7 +210,7 @@ int nodeport_overlay_nat_1_fwd_check(const struct __ctx_buff *ctx)
  * and flows back out on the overlay interface to the client
  * (preserving the backend's security identity).
  */
-PKTGEN("tc", "nodeport_overlay_nat_2_reply")
+PKTGEN(PROG_TYPE, "nodeport_overlay_nat_2_reply")
 int nodeport_overlay_nat_2_reply_pktgen(struct __ctx_buff *ctx)
 {
 	__be16 nat_source_port = 0;
@@ -244,7 +244,7 @@ int nodeport_overlay_nat_2_reply_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "nodeport_overlay_nat_2_reply")
+SETUP(PROG_TYPE, "nodeport_overlay_nat_2_reply")
 int nodeport_overlay_nat_2_reply_setup(struct __ctx_buff *ctx)
 {
 	ipcache_v4_add_entry(CLIENT_IP, 0, CLIENT_SEC_IDENTITY,
@@ -253,7 +253,7 @@ int nodeport_overlay_nat_2_reply_setup(struct __ctx_buff *ctx)
 	return overlay_receive_packet(ctx);
 }
 
-CHECK("tc", "nodeport_overlay_nat_2_reply")
+CHECK(PROG_TYPE, "nodeport_overlay_nat_2_reply")
 int nodeport_overlay_nat_2_reply_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/overlay.c
+++ b/bpf/tests/overlay.c
@@ -6,7 +6,7 @@
 
 #include "bpf_overlay.c"
 
-CHECK("tc", "overlay_neigh_resolver")
+CHECK(PROG_TYPE, "overlay_neigh_resolver")
 int overlay_neigh_resolver(__maybe_unused struct __sk_buff *ctx)
 {
 	test_init();

--- a/bpf/tests/ratelimit.c
+++ b/bpf/tests/ratelimit.c
@@ -16,7 +16,7 @@ static __u64 mock_ktime_get_ns(void)
 
 #include "lib/ratelimit.h"
 
-CHECK("xdp", "ratelimit") int test_ratelimit(void)
+CHECK(PROG_TYPE, "ratelimit") int test_ratelimit(void)
 {
 	struct ratelimit_settings settings = {
 		.bucket_size = 1000,

--- a/bpf/tests/remote_node_masquerade_skip_test.c
+++ b/bpf/tests/remote_node_masquerade_skip_test.c
@@ -42,7 +42,7 @@ ASSIGN_CONFIG(bool, enable_extended_ip_protocols, false)
 
 #include "lib/ipcache.h"
 
-CHECK("tc", "nat4_remote_node_masquerade_skipped_test")
+CHECK(PROG_TYPE, "nat4_remote_node_masquerade_skipped_test")
 int test_nat4_remote_node_masquerade_skipped(__maybe_unused struct __ctx_buff *ctx)
 {
     struct snat_v4_args *args = AUX(snat_v4_args);

--- a/bpf/tests/remote_node_masquerade_test.c
+++ b/bpf/tests/remote_node_masquerade_test.c
@@ -42,7 +42,7 @@ ASSIGN_CONFIG(bool, enable_extended_ip_protocols, false)
 
 #include "lib/ipcache.h"
 
-CHECK("tc", "nat4_remote_node_masquerade_enabled_test")
+CHECK(PROG_TYPE, "nat4_remote_node_masquerade_enabled_test")
 int test_nat4_remote_node_masquerade_enabled(__maybe_unused struct __ctx_buff *ctx)
 {
     struct snat_v4_args *args = AUX(snat_v4_args);

--- a/bpf/tests/session_affinity_maglev_test.c
+++ b/bpf/tests/session_affinity_maglev_test.c
@@ -263,13 +263,13 @@ check_packet(const struct __ctx_buff *ctx, int backend_id)
 
 /* ------------------------------------------------------------------------------ */
 
-PKTGEN("xdp", "session_affinity_maglev_client_1_port_1")
+PKTGEN(PROG_TYPE, "session_affinity_maglev_client_1_port_1")
 int generate_packet_1_1(struct __ctx_buff *ctx)
 {
 	return generate_packet(ctx, CLIENT_ID1, CLIENT_PORT1);
 }
 
-SETUP("xdp", "session_affinity_maglev_client_1_port_1")
+SETUP(PROG_TYPE, "session_affinity_maglev_client_1_port_1")
 int setup_1_1(struct __ctx_buff *ctx)
 {
 	setup_test();
@@ -277,7 +277,7 @@ int setup_1_1(struct __ctx_buff *ctx)
 	return xdp_receive_packet(ctx);
 }
 
-CHECK("xdp", "session_affinity_maglev_client_1_port_1")
+CHECK(PROG_TYPE, "session_affinity_maglev_client_1_port_1")
 int test_1_1(__maybe_unused const struct __ctx_buff *ctx)
 {
 	/* Client 1 always maps to the backend 13 */
@@ -286,13 +286,13 @@ int test_1_1(__maybe_unused const struct __ctx_buff *ctx)
 
 /* ------------------------------------------------------------------------------ */
 
-PKTGEN("xdp", "session_affinity_maglev_client_1_port_2")
+PKTGEN(PROG_TYPE, "session_affinity_maglev_client_1_port_2")
 int generate_packet_1_2(struct __ctx_buff *ctx)
 {
 	return generate_packet(ctx, CLIENT_ID1, CLIENT_PORT2);
 }
 
-SETUP("xdp", "session_affinity_maglev_client_1_port_2")
+SETUP(PROG_TYPE, "session_affinity_maglev_client_1_port_2")
 int setup_1_2(struct __ctx_buff *ctx)
 {
 	setup_test();
@@ -300,7 +300,7 @@ int setup_1_2(struct __ctx_buff *ctx)
 	return xdp_receive_packet(ctx);
 }
 
-CHECK("xdp", "session_affinity_maglev_client_1_port_2")
+CHECK(PROG_TYPE, "session_affinity_maglev_client_1_port_2")
 int test_1_2(__maybe_unused const struct __ctx_buff *ctx)
 {
 	/* Client 1 always maps to the backend 13 */
@@ -309,13 +309,13 @@ int test_1_2(__maybe_unused const struct __ctx_buff *ctx)
 
 /* ------------------------------------------------------------------------------ */
 
-PKTGEN("xdp", "session_affinity_maglev_client_1_port_3")
+PKTGEN(PROG_TYPE, "session_affinity_maglev_client_1_port_3")
 int generate_packet_1_3(struct __ctx_buff *ctx)
 {
 	return generate_packet(ctx, CLIENT_ID1, CLIENT_PORT3);
 }
 
-SETUP("xdp", "session_affinity_maglev_client_1_port_3")
+SETUP(PROG_TYPE, "session_affinity_maglev_client_1_port_3")
 int setup_1_3(struct __ctx_buff *ctx)
 {
 	setup_test();
@@ -323,7 +323,7 @@ int setup_1_3(struct __ctx_buff *ctx)
 	return xdp_receive_packet(ctx);
 }
 
-CHECK("xdp", "session_affinity_maglev_client_1_port_3")
+CHECK(PROG_TYPE, "session_affinity_maglev_client_1_port_3")
 int test_1_3(__maybe_unused const struct __ctx_buff *ctx)
 {
 	/* Client 1 always maps to the backend 13 */
@@ -332,13 +332,13 @@ int test_1_3(__maybe_unused const struct __ctx_buff *ctx)
 
 /* ------------------------------------------------------------------------------ */
 
-PKTGEN("xdp", "session_affinity_maglev_client_2_port_1")
+PKTGEN(PROG_TYPE, "session_affinity_maglev_client_2_port_1")
 int generate_packet_2_1(struct __ctx_buff *ctx)
 {
 	return generate_packet(ctx, CLIENT_ID2, CLIENT_PORT1);
 }
 
-SETUP("xdp", "session_affinity_maglev_client_2_port_1")
+SETUP(PROG_TYPE, "session_affinity_maglev_client_2_port_1")
 int setup_2_1(struct __ctx_buff *ctx)
 {
 	setup_test();
@@ -346,7 +346,7 @@ int setup_2_1(struct __ctx_buff *ctx)
 	return xdp_receive_packet(ctx);
 }
 
-CHECK("xdp", "session_affinity_maglev_client_2_port_1")
+CHECK(PROG_TYPE, "session_affinity_maglev_client_2_port_1")
 int test_2_1(__maybe_unused const struct __ctx_buff *ctx)
 {
 	/* Client 2 always maps to the backend 14 */
@@ -355,13 +355,13 @@ int test_2_1(__maybe_unused const struct __ctx_buff *ctx)
 
 /* ------------------------------------------------------------------------------ */
 
-PKTGEN("xdp", "session_affinity_maglev_client_2_port_2")
+PKTGEN(PROG_TYPE, "session_affinity_maglev_client_2_port_2")
 int generate_packet_2_2(struct __ctx_buff *ctx)
 {
 	return generate_packet(ctx, CLIENT_ID2, CLIENT_PORT2);
 }
 
-SETUP("xdp", "session_affinity_maglev_client_2_port_2")
+SETUP(PROG_TYPE, "session_affinity_maglev_client_2_port_2")
 int setup_2_2(struct __ctx_buff *ctx)
 {
 	setup_test();
@@ -369,7 +369,7 @@ int setup_2_2(struct __ctx_buff *ctx)
 	return xdp_receive_packet(ctx);
 }
 
-CHECK("xdp", "session_affinity_maglev_client_2_port_2")
+CHECK(PROG_TYPE, "session_affinity_maglev_client_2_port_2")
 int test_2_2(__maybe_unused const struct __ctx_buff *ctx)
 {
 	/* Client 2 always maps to the backend 14 */
@@ -378,13 +378,13 @@ int test_2_2(__maybe_unused const struct __ctx_buff *ctx)
 
 /* ------------------------------------------------------------------------------ */
 
-PKTGEN("xdp", "session_affinity_maglev_client_2_port_3")
+PKTGEN(PROG_TYPE, "session_affinity_maglev_client_2_port_3")
 int generate_packet_2_3(struct __ctx_buff *ctx)
 {
 	return generate_packet(ctx, CLIENT_ID2, CLIENT_PORT3);
 }
 
-SETUP("xdp", "session_affinity_maglev_client_2_port_3")
+SETUP(PROG_TYPE, "session_affinity_maglev_client_2_port_3")
 int setup_2_3(struct __ctx_buff *ctx)
 {
 	setup_test();
@@ -392,7 +392,7 @@ int setup_2_3(struct __ctx_buff *ctx)
 	return xdp_receive_packet(ctx);
 }
 
-CHECK("xdp", "session_affinity_maglev_client_2_port_3")
+CHECK(PROG_TYPE, "session_affinity_maglev_client_2_port_3")
 int test_2_3(__maybe_unused const struct __ctx_buff *ctx)
 {
 	/* Client 2 always maps to the backend 14 */

--- a/bpf/tests/session_affinity_test.c
+++ b/bpf/tests/session_affinity_test.c
@@ -102,7 +102,7 @@ static __always_inline int craft_packet(struct __ctx_buff *ctx)
 			  .proto = SERVICE_PROTO },\
 	}
 
-SETUP("xdp", "session_affinity")
+SETUP(PROG_TYPE, "session_affinity")
 int test1_setup(struct __ctx_buff *ctx)
 {
 	struct {
@@ -161,7 +161,7 @@ int test1_setup(struct __ctx_buff *ctx)
 	return xdp_receive_packet(ctx);
 }
 
-CHECK("xdp", "session_affinity")
+CHECK(PROG_TYPE, "session_affinity")
 int test1_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	test_init();

--- a/bpf/tests/skip_lb_xlate_lrp_per_packet_lb.c
+++ b/bpf/tests/skip_lb_xlate_lrp_per_packet_lb.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
 /* Copyright Authors of Cilium */
 
-#include <bpf/ctx/unspec.h>
+#include <bpf/ctx/skb.h>
 #include "common.h"
 #include "pktgen.h"
 

--- a/bpf/tests/skip_lb_xlate_lrp_per_packet_lb.c
+++ b/bpf/tests/skip_lb_xlate_lrp_per_packet_lb.c
@@ -28,7 +28,7 @@ ASSIGN_CONFIG(__u64, endpoint_netns_cookie, NETNS_COOKIE)
 #define V6_SERVICE_IP		v6_pod_one
 #define V6_BACKEND_IP		v6_pod_two
 
-PKTGEN("tc", "v4_local_redirect")
+PKTGEN(PROG_TYPE, "v4_local_redirect")
 int  v4_local_backend_to_service_packetgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -51,7 +51,7 @@ int  v4_local_backend_to_service_packetgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "v4_local_redirect")
+SETUP(PROG_TYPE, "v4_local_redirect")
 int v4_local_backend_to_service_setup(struct __ctx_buff *ctx)
 {
 	lb_v4_add_service_with_flags(V4_SERVICE_IP, SERVICE_PORT, IPPROTO_TCP, 1, 1,
@@ -78,7 +78,7 @@ int v4_local_backend_to_service_setup(struct __ctx_buff *ctx)
 /* Test that sending a packet from a backend pod to its own service does not
  * get sent back to the backend due to local redirect policy
  */
-CHECK("tc", "v4_local_redirect")
+CHECK(PROG_TYPE, "v4_local_redirect")
 int v4_local_backend_to_service_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data;
@@ -120,7 +120,7 @@ int v4_local_backend_to_service_check(__maybe_unused const struct __ctx_buff *ct
 	test_finish();
 }
 
-PKTGEN("tc", "v6_local_redirect")
+PKTGEN(PROG_TYPE, "v6_local_redirect")
 int  v6_local_backend_to_service_packetgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -143,7 +143,7 @@ int  v6_local_backend_to_service_packetgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "v6_local_redirect")
+SETUP(PROG_TYPE, "v6_local_redirect")
 int v6_local_backend_to_service_setup(struct __ctx_buff *ctx)
 {
 	union v6addr service_ip __align_stack_8 = {};
@@ -174,7 +174,7 @@ int v6_local_backend_to_service_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "v6_local_redirect")
+CHECK(PROG_TYPE, "v6_local_redirect")
 int v6_local_backend_to_service_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data;

--- a/bpf/tests/skip_tunnel_from_host.c
+++ b/bpf/tests/skip_tunnel_from_host.c
@@ -261,225 +261,225 @@ check_ctx(const struct __ctx_buff *ctx, __u32 expected_result, bool v4)
 	test_finish();
 }
 
-PKTGEN("tc", "01_ipv4_from_host_no_flags")
+PKTGEN(PROG_TYPE, "01_ipv4_from_host_no_flags")
 int ipv4_from_host_no_flags_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_host(ctx, true);
 }
 
-SETUP("tc", "01_ipv4_from_host_no_flags")
+SETUP(PROG_TYPE, "01_ipv4_from_host_no_flags")
 int ipv4_from_host_no_flags_setup(struct __ctx_buff *ctx)
 {
 	return setup(ctx, false, true);
 }
 
-CHECK("tc", "01_ipv4_from_host_no_flags")
+CHECK(PROG_TYPE, "01_ipv4_from_host_no_flags")
 int ipv4_from_host_no_flags_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, CTX_ACT_REDIRECT, true);
 }
 
-PKTGEN("tc", "02_ipv4_from_host_skip_tunnel")
+PKTGEN(PROG_TYPE, "02_ipv4_from_host_skip_tunnel")
 int ipv4_from_host_skip_tunnel_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_host(ctx, true);
 }
 
-SETUP("tc", "02_ipv4_from_host_skip_tunnel")
+SETUP(PROG_TYPE, "02_ipv4_from_host_skip_tunnel")
 int ipv4_from_host_skip_tunnel_setup(struct __ctx_buff *ctx)
 {
 	return setup(ctx, true, true);
 }
 
-CHECK("tc", "02_ipv4_from_host_skip_tunnel")
+CHECK(PROG_TYPE, "02_ipv4_from_host_skip_tunnel")
 int ipv4_from_host_skip_tunnel_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, CTX_ACT_OK, true);
 }
 
-PKTGEN("tc", "03_ipv6_from_host_no_flags")
+PKTGEN(PROG_TYPE, "03_ipv6_from_host_no_flags")
 int ipv6_from_host_no_flags_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_host(ctx, false);
 }
 
-SETUP("tc", "03_ipv6_from_host_no_flags")
+SETUP(PROG_TYPE, "03_ipv6_from_host_no_flags")
 int ipv6_from_host_no_flags_setup(struct __ctx_buff *ctx)
 {
 	return setup(ctx, false, false);
 }
 
-CHECK("tc", "03_ipv6_from_host_no_flags")
+CHECK(PROG_TYPE, "03_ipv6_from_host_no_flags")
 int ipv6_from_host_no_flags_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, CTX_ACT_REDIRECT, false);
 }
 
-PKTGEN("tc", "04_ipv6_from_host_skip_tunnel")
+PKTGEN(PROG_TYPE, "04_ipv6_from_host_skip_tunnel")
 int ipv6_from_host_skip_tunnel_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_host(ctx, false);
 }
 
-SETUP("tc", "04_ipv6_from_host_skip_tunnel")
+SETUP(PROG_TYPE, "04_ipv6_from_host_skip_tunnel")
 int ipv6_from_host_skip_tunnel_setup(struct __ctx_buff *ctx)
 {
 	return setup(ctx, true, false);
 }
 
-CHECK("tc", "04_ipv6_from_host_skip_tunnel")
+CHECK(PROG_TYPE, "04_ipv6_from_host_skip_tunnel")
 int ipv6_from_host_skip_tunnel_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, CTX_ACT_OK, false);
 }
 
-PKTGEN("tc", "05_ipv4_from_host_no_flags_same_subnet")
+PKTGEN(PROG_TYPE, "05_ipv4_from_host_no_flags_same_subnet")
 int ipv4_from_host_no_flags_same_subnet_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_host(ctx, true);
 }
 
-SETUP("tc", "05_ipv4_from_host_no_flags_same_subnet")
+SETUP(PROG_TYPE, "05_ipv4_from_host_no_flags_same_subnet")
 int ipv4_from_host_no_flags_same_subnet_setup(struct __ctx_buff *ctx)
 {
 	setup_subnet_table_v4(100, 100);
 	return setup(ctx, false, true);
 }
 
-CHECK("tc", "05_ipv4_from_host_no_flags_same_subnet")
+CHECK(PROG_TYPE, "05_ipv4_from_host_no_flags_same_subnet")
 int ipv4_from_host_no_flags_same_subnet_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, CTX_ACT_OK, true);
 }
 
-PKTGEN("tc", "06_ipv4_from_host_skip_tunnel_same_subnet")
+PKTGEN(PROG_TYPE, "06_ipv4_from_host_skip_tunnel_same_subnet")
 int ipv4_from_host_skip_tunnel_same_subnet_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_host(ctx, true);
 }
 
-SETUP("tc", "06_ipv4_from_host_skip_tunnel_same_subnet")
+SETUP(PROG_TYPE, "06_ipv4_from_host_skip_tunnel_same_subnet")
 int ipv4_from_host_skip_tunnel_same_subnet_setup(struct __ctx_buff *ctx)
 {
 	setup_subnet_table_v4(100, 100);
 	return setup(ctx, true, true);
 }
 
-CHECK("tc", "06_ipv4_from_host_skip_tunnel_same_subnet")
+CHECK(PROG_TYPE, "06_ipv4_from_host_skip_tunnel_same_subnet")
 int ipv4_from_host_skip_tunnel_same_subnet_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, CTX_ACT_OK, true);
 }
 
-PKTGEN("tc", "07_ipv4_from_host_no_flags_different_subnet")
+PKTGEN(PROG_TYPE, "07_ipv4_from_host_no_flags_different_subnet")
 int ipv4_from_host_no_flags_different_subnet_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_host(ctx, true);
 }
 
-SETUP("tc", "07_ipv4_from_host_no_flags_different_subnet")
+SETUP(PROG_TYPE, "07_ipv4_from_host_no_flags_different_subnet")
 int ipv4_from_host_no_flags_different_subnet_setup(struct __ctx_buff *ctx)
 {
 	setup_subnet_table_v4(100, 101);
 	return setup(ctx, false, true);
 }
 
-CHECK("tc", "07_ipv4_from_host_no_flags_different_subnet")
+CHECK(PROG_TYPE, "07_ipv4_from_host_no_flags_different_subnet")
 int ipv4_from_host_no_flags_different_subnet_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, CTX_ACT_REDIRECT, true);
 }
 
-PKTGEN("tc", "08_ipv4_from_host_skip_tunnel_different_subnet")
+PKTGEN(PROG_TYPE, "08_ipv4_from_host_skip_tunnel_different_subnet")
 int ipv4_from_host_skip_tunnel_different_subnet_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_host(ctx, true);
 }
 
-SETUP("tc", "08_ipv4_from_host_skip_tunnel_different_subnet")
+SETUP(PROG_TYPE, "08_ipv4_from_host_skip_tunnel_different_subnet")
 int ipv4_from_host_skip_tunnel_different_subnet_setup(struct __ctx_buff *ctx)
 {
 	setup_subnet_table_v4(100, 101);
 	return setup(ctx, true, true);
 }
 
-CHECK("tc", "08_ipv4_from_host_skip_tunnel_different_subnet")
+CHECK(PROG_TYPE, "08_ipv4_from_host_skip_tunnel_different_subnet")
 int ipv4_from_host_skip_tunnel_different_subnet_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, CTX_ACT_OK, true);
 }
 
-PKTGEN("tc", "09_ipv6_from_host_no_flags_same_subnet")
+PKTGEN(PROG_TYPE, "09_ipv6_from_host_no_flags_same_subnet")
 int ipv6_from_host_no_flags_same_subnet_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_host(ctx, false);
 }
 
-SETUP("tc", "09_ipv6_from_host_no_flags_same_subnet")
+SETUP(PROG_TYPE, "09_ipv6_from_host_no_flags_same_subnet")
 int ipv6_from_host_no_flags_same_subnet_setup(struct __ctx_buff *ctx)
 {
 	setup_subnet_table_v6(100, 100);
 	return setup(ctx, false, false);
 }
 
-CHECK("tc", "09_ipv6_from_host_no_flags_same_subnet")
+CHECK(PROG_TYPE, "09_ipv6_from_host_no_flags_same_subnet")
 int ipv6_from_host_no_flags_same_subnet_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, CTX_ACT_OK, false);
 }
 
-PKTGEN("tc", "10_ipv6_from_host_no_flags_different_subnet")
+PKTGEN(PROG_TYPE, "10_ipv6_from_host_no_flags_different_subnet")
 int ipv6_from_host_no_flags_different_subnet_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_host(ctx, false);
 }
 
-SETUP("tc", "10_ipv6_from_host_no_flags_different_subnet")
+SETUP(PROG_TYPE, "10_ipv6_from_host_no_flags_different_subnet")
 int ipv6_from_host_no_flags_different_subnet_setup(struct __ctx_buff *ctx)
 {
 	setup_subnet_table_v6(100, 101);
 	return setup(ctx, false, false);
 }
 
-CHECK("tc", "10_ipv6_from_host_no_flags_different_subnet")
+CHECK(PROG_TYPE, "10_ipv6_from_host_no_flags_different_subnet")
 int ipv6_from_host_no_flags_different_subnet_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, CTX_ACT_REDIRECT, false);
 }
 
-PKTGEN("tc", "11_ipv6_from_host_skip_tunnel_same_subnet")
+PKTGEN(PROG_TYPE, "11_ipv6_from_host_skip_tunnel_same_subnet")
 int ipv6_from_host_same_subnet_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_host(ctx, false);
 }
 
-SETUP("tc", "11_ipv6_from_host_skip_tunnel_same_subnet")
+SETUP(PROG_TYPE, "11_ipv6_from_host_skip_tunnel_same_subnet")
 int ipv6_from_host_same_subnet_setup(struct __ctx_buff *ctx)
 {
 	setup_subnet_table_v6(100, 100);
 	return setup(ctx, true, false);
 }
 
-CHECK("tc", "11_ipv6_from_host_skip_tunnel_same_subnet")
+CHECK(PROG_TYPE, "11_ipv6_from_host_skip_tunnel_same_subnet")
 int ipv6_from_host_same_subnet_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, CTX_ACT_OK, false);
 }
 
-PKTGEN("tc", "12_ipv6_from_host_skip_tunnel_different_subnet")
+PKTGEN(PROG_TYPE, "12_ipv6_from_host_skip_tunnel_different_subnet")
 int ipv6_from_host_skip_tunnel_different_subnet_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_host(ctx, false);
 }
 
-SETUP("tc", "12_ipv6_from_host_skip_tunnel_different_subnet")
+SETUP(PROG_TYPE, "12_ipv6_from_host_skip_tunnel_different_subnet")
 int ipv6_from_host_skip_tunnel_different_subnet_setup(struct __ctx_buff *ctx)
 {
 	setup_subnet_table_v6(100, 101);
 	return setup(ctx, true, false);
 }
 
-CHECK("tc", "12_ipv6_from_host_skip_tunnel_different_subnet")
+CHECK(PROG_TYPE, "12_ipv6_from_host_skip_tunnel_different_subnet")
 int ipv6_from_host_skip_tunnel_different_subnet_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, CTX_ACT_OK, false);

--- a/bpf/tests/skip_tunnel_from_lxc.c
+++ b/bpf/tests/skip_tunnel_from_lxc.c
@@ -244,225 +244,225 @@ check_ctx(const struct __ctx_buff *ctx, __u32 expected_result, bool v4)
  * - When no subnet entries exist: follow skip_tunnel flag behavior
  */
 
-PKTGEN("tc", "01_ipv4_from_lxc_no_flags_no_subnet_entries")
+PKTGEN(PROG_TYPE, "01_ipv4_from_lxc_no_flags_no_subnet_entries")
 int ipv4_from_lxc_no_flags_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_lxc(ctx, true);
 }
 
-SETUP("tc", "01_ipv4_from_lxc_no_flags_no_subnet_entries")
+SETUP(PROG_TYPE, "01_ipv4_from_lxc_no_flags_no_subnet_entries")
 int ipv4_from_lxc_no_flags_setup(struct __ctx_buff *ctx)
 {
 	return setup(ctx, false, true);
 }
 
-CHECK("tc", "01_ipv4_from_lxc_no_flags_no_subnet_entries")
+CHECK(PROG_TYPE, "01_ipv4_from_lxc_no_flags_no_subnet_entries")
 int ipv4_from_lxc_no_flags_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, CTX_ACT_REDIRECT, true);
 }
 
-PKTGEN("tc", "02_ipv4_from_lxc_skip_tunnel_no_subnet_entries")
+PKTGEN(PROG_TYPE, "02_ipv4_from_lxc_skip_tunnel_no_subnet_entries")
 int ipv4_from_lxc_skip_tunnel_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_lxc(ctx, true);
 }
 
-SETUP("tc", "02_ipv4_from_lxc_skip_tunnel_no_subnet_entries")
+SETUP(PROG_TYPE, "02_ipv4_from_lxc_skip_tunnel_no_subnet_entries")
 int ipv4_from_lxc_skip_tunnel_setup(struct __ctx_buff *ctx)
 {
 	return setup(ctx, true, true);
 }
 
-CHECK("tc", "02_ipv4_from_lxc_skip_tunnel_no_subnet_entries")
+CHECK(PROG_TYPE, "02_ipv4_from_lxc_skip_tunnel_no_subnet_entries")
 int ipv4_from_lxc_skip_tunnel_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, CTX_ACT_OK, true);
 }
 
-PKTGEN("tc", "03_ipv6_from_lxc_no_flags_no_subnet_entries")
+PKTGEN(PROG_TYPE, "03_ipv6_from_lxc_no_flags_no_subnet_entries")
 int ipv6_from_lxc_no_flags_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_lxc(ctx, false);
 }
 
-SETUP("tc", "03_ipv6_from_lxc_no_flags_no_subnet_entries")
+SETUP(PROG_TYPE, "03_ipv6_from_lxc_no_flags_no_subnet_entries")
 int ipv6_from_lxc_no_flags_setup(struct __ctx_buff *ctx)
 {
 	return setup(ctx, false, false);
 }
 
-CHECK("tc", "03_ipv6_from_lxc_no_flags_no_subnet_entries")
+CHECK(PROG_TYPE, "03_ipv6_from_lxc_no_flags_no_subnet_entries")
 int ipv6_from_lxc_no_flags_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, CTX_ACT_REDIRECT, false);
 }
 
-PKTGEN("tc", "04_ipv6_from_lxc_skip_tunnel_no_subnet_entries")
+PKTGEN(PROG_TYPE, "04_ipv6_from_lxc_skip_tunnel_no_subnet_entries")
 int ipv6_from_lxc_skip_tunnel_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_lxc(ctx, false);
 }
 
-SETUP("tc", "04_ipv6_from_lxc_skip_tunnel_no_subnet_entries")
+SETUP(PROG_TYPE, "04_ipv6_from_lxc_skip_tunnel_no_subnet_entries")
 int ipv6_from_lxc_skip_tunnel_setup(struct __ctx_buff *ctx)
 {
 	return setup(ctx, true, false);
 }
 
-CHECK("tc", "04_ipv6_from_lxc_skip_tunnel_no_subnet_entries")
+CHECK(PROG_TYPE, "04_ipv6_from_lxc_skip_tunnel_no_subnet_entries")
 int ipv6_from_lxc_skip_tunnel_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, CTX_ACT_OK, false);
 }
 
-PKTGEN("tc", "05_ipv4_from_lxc_no_flags_same_subnet")
+PKTGEN(PROG_TYPE, "05_ipv4_from_lxc_no_flags_same_subnet")
 int ipv4_from_lxc_no_flags_same_subnet_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_lxc(ctx, true);
 }
 
-SETUP("tc", "05_ipv4_from_lxc_no_flags_same_subnet")
+SETUP(PROG_TYPE, "05_ipv4_from_lxc_no_flags_same_subnet")
 int ipv4_from_lxc_no_flags_same_subnet_setup(struct __ctx_buff *ctx)
 {
 	setup_subnet_table(true, 100, 100);
 	return setup(ctx, false, true);
 }
 
-CHECK("tc", "05_ipv4_from_lxc_no_flags_same_subnet")
+CHECK(PROG_TYPE, "05_ipv4_from_lxc_no_flags_same_subnet")
 int ipv4_from_lxc_no_flags_same_subnet_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, CTX_ACT_OK, true);
 }
 
-PKTGEN("tc", "06_ipv4_from_lxc_no_flags_different_subnet")
+PKTGEN(PROG_TYPE, "06_ipv4_from_lxc_no_flags_different_subnet")
 int ipv4_from_lxc_no_flags_different_subnet_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_lxc(ctx, true);
 }
 
-SETUP("tc", "06_ipv4_from_lxc_no_flags_different_subnet")
+SETUP(PROG_TYPE, "06_ipv4_from_lxc_no_flags_different_subnet")
 int ipv4_from_lxc_no_flags_different_subnet_setup(struct __ctx_buff *ctx)
 {
 	setup_subnet_table(true, 100, 101);
 	return setup(ctx, false, true);
 }
 
-CHECK("tc", "06_ipv4_from_lxc_no_flags_different_subnet")
+CHECK(PROG_TYPE, "06_ipv4_from_lxc_no_flags_different_subnet")
 int ipv4_from_lxc_no_flags_different_subnet_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, CTX_ACT_REDIRECT, true);
 }
 
-PKTGEN("tc", "07_ipv4_from_lxc_skip_tunnel_same_subnet")
+PKTGEN(PROG_TYPE, "07_ipv4_from_lxc_skip_tunnel_same_subnet")
 int ipv4_from_lxc_skip_tunnel_same_subnet_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_lxc(ctx, true);
 }
 
-SETUP("tc", "07_ipv4_from_lxc_skip_tunnel_same_subnet")
+SETUP(PROG_TYPE, "07_ipv4_from_lxc_skip_tunnel_same_subnet")
 int ipv4_from_lxc_skip_tunnel_same_subnet_setup(struct __ctx_buff *ctx)
 {
 	setup_subnet_table(true, 100, 100);
 	return setup(ctx, true, true);
 }
 
-CHECK("tc", "07_ipv4_from_lxc_skip_tunnel_same_subnet")
+CHECK(PROG_TYPE, "07_ipv4_from_lxc_skip_tunnel_same_subnet")
 int ipv4_from_lxc_skip_tunnel_same_subnet_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, CTX_ACT_OK, true);
 }
 
-PKTGEN("tc", "08_ipv4_from_lxc_skip_tunnel_different_subnet")
+PKTGEN(PROG_TYPE, "08_ipv4_from_lxc_skip_tunnel_different_subnet")
 int ipv4_from_lxc_skip_tunnel_different_subnet_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_lxc(ctx, true);
 }
 
-SETUP("tc", "08_ipv4_from_lxc_skip_tunnel_different_subnet")
+SETUP(PROG_TYPE, "08_ipv4_from_lxc_skip_tunnel_different_subnet")
 int ipv4_from_lxc_skip_tunnel_different_subnet_setup(struct __ctx_buff *ctx)
 {
 	setup_subnet_table(true, 100, 101);
 	return setup(ctx, true, true);
 }
 
-CHECK("tc", "08_ipv4_from_lxc_skip_tunnel_different_subnet")
+CHECK(PROG_TYPE, "08_ipv4_from_lxc_skip_tunnel_different_subnet")
 int ipv4_from_lxc_skip_tunnel_different_subnet_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, CTX_ACT_OK, true);
 }
 
-PKTGEN("tc", "09_ipv6_from_lxc_no_flags_same_subnet")
+PKTGEN(PROG_TYPE, "09_ipv6_from_lxc_no_flags_same_subnet")
 int ipv6_from_lxc_no_flags_same_subnet_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_lxc(ctx, false);
 }
 
-SETUP("tc", "09_ipv6_from_lxc_no_flags_same_subnet")
+SETUP(PROG_TYPE, "09_ipv6_from_lxc_no_flags_same_subnet")
 int ipv6_from_lxc_no_flags_same_subnet_setup(struct __ctx_buff *ctx)
 {
 	setup_subnet_table(false, 100, 100);
 	return setup(ctx, false, false);
 }
 
-CHECK("tc", "09_ipv6_from_lxc_no_flags_same_subnet")
+CHECK(PROG_TYPE, "09_ipv6_from_lxc_no_flags_same_subnet")
 int ipv6_from_lxc_no_flags_same_subnet_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, CTX_ACT_OK, false);
 }
 
-PKTGEN("tc", "10_ipv6_from_lxc_no_flags_different_subnet")
+PKTGEN(PROG_TYPE, "10_ipv6_from_lxc_no_flags_different_subnet")
 int ipv6_from_lxc_no_flags_different_subnet_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_lxc(ctx, false);
 }
 
-SETUP("tc", "10_ipv6_from_lxc_no_flags_different_subnet")
+SETUP(PROG_TYPE, "10_ipv6_from_lxc_no_flags_different_subnet")
 int ipv6_from_lxc_no_flags_different_subnet_setup(struct __ctx_buff *ctx)
 {
 	setup_subnet_table(false, 100, 101);
 	return setup(ctx, false, false);
 }
 
-CHECK("tc", "10_ipv6_from_lxc_no_flags_different_subnet")
+CHECK(PROG_TYPE, "10_ipv6_from_lxc_no_flags_different_subnet")
 int ipv6_from_lxc_no_flags_different_subnet_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, CTX_ACT_REDIRECT, false);
 }
 
-PKTGEN("tc", "11_ipv6_from_lxc_skip_tunnel_same_subnet")
+PKTGEN(PROG_TYPE, "11_ipv6_from_lxc_skip_tunnel_same_subnet")
 int ipv6_from_lxc_skip_tunnel_same_subnet_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_lxc(ctx, false);
 }
 
-SETUP("tc", "11_ipv6_from_lxc_skip_tunnel_same_subnet")
+SETUP(PROG_TYPE, "11_ipv6_from_lxc_skip_tunnel_same_subnet")
 int ipv6_from_lxc_skip_tunnel_same_subnet_setup(struct __ctx_buff *ctx)
 {
 	setup_subnet_table(false, 100, 100);
 	return setup(ctx, true, false);
 }
 
-CHECK("tc", "11_ipv6_from_lxc_skip_tunnel_same_subnet")
+CHECK(PROG_TYPE, "11_ipv6_from_lxc_skip_tunnel_same_subnet")
 int ipv6_from_lxc_skip_tunnel_same_subnet_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, CTX_ACT_OK, false);
 }
 
-PKTGEN("tc", "12_ipv6_from_lxc_skip_tunnel_different_subnet")
+PKTGEN(PROG_TYPE, "12_ipv6_from_lxc_skip_tunnel_different_subnet")
 int ipv6_from_lxc_skip_tunnel_different_subnet_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_from_lxc(ctx, false);
 }
 
-SETUP("tc", "12_ipv6_from_lxc_skip_tunnel_different_subnet")
+SETUP(PROG_TYPE, "12_ipv6_from_lxc_skip_tunnel_different_subnet")
 int ipv6_from_lxc_skip_tunnel_different_subnet_setup(struct __ctx_buff *ctx)
 {
 	setup_subnet_table(false, 100, 101);
 	return setup(ctx, true, false);
 }
 
-CHECK("tc", "12_ipv6_from_lxc_skip_tunnel_different_subnet")
+CHECK(PROG_TYPE, "12_ipv6_from_lxc_skip_tunnel_different_subnet")
 int ipv6_from_lxc_skip_tunnel_different_subnet_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, CTX_ACT_OK, false);

--- a/bpf/tests/skip_tunnel_nodeport_masq.c
+++ b/bpf/tests/skip_tunnel_nodeport_masq.c
@@ -249,73 +249,73 @@ check_ctx(const struct __ctx_buff *ctx, bool v4, bool snat)
 	test_finish();
 }
 
-PKTGEN("tc", "01_ipv4_nodeport_ingress_no_flags")
+PKTGEN(PROG_TYPE, "01_ipv4_nodeport_ingress_no_flags")
 int ipv4_nodeport_ingress_no_flags_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen(ctx, true);
 }
 
-SETUP("tc", "01_ipv4_nodeport_ingress_no_flags")
+SETUP(PROG_TYPE, "01_ipv4_nodeport_ingress_no_flags")
 int ipv4_nodeport_ingress_no_flags_setup(struct __ctx_buff *ctx)
 {
 	return setup(ctx, true, false);
 }
 
-CHECK("tc", "01_ipv4_nodeport_ingress_no_flags")
+CHECK(PROG_TYPE, "01_ipv4_nodeport_ingress_no_flags")
 int ipv4_nodeport_ingress_no_flags_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, true, true);
 }
 
-PKTGEN("tc", "02_ipv4_nodeport_ingress_skip_tunnel")
+PKTGEN(PROG_TYPE, "02_ipv4_nodeport_ingress_skip_tunnel")
 int ipv4_nodeport_ingress_skip_tunnel_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen(ctx, true);
 }
 
-SETUP("tc", "02_ipv4_nodeport_ingress_skip_tunnel")
+SETUP(PROG_TYPE, "02_ipv4_nodeport_ingress_skip_tunnel")
 int ipv4_nodeport_ingress_skip_tunnel_setup(struct __ctx_buff *ctx)
 {
 	return setup(ctx, true, true);
 }
 
-CHECK("tc", "02_ipv4_nodeport_ingress_skip_tunnel")
+CHECK(PROG_TYPE, "02_ipv4_nodeport_ingress_skip_tunnel")
 int ipv4_nodeport_ingress_skip_tunnel_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, true, false);
 }
 
-PKTGEN("tc", "03_ipv6_nodeport_ingress_no_flags")
+PKTGEN(PROG_TYPE, "03_ipv6_nodeport_ingress_no_flags")
 int ipv6_nodeport_ingress_no_flags_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen(ctx, false);
 }
 
-SETUP("tc", "03_ipv6_nodeport_ingress_no_flags")
+SETUP(PROG_TYPE, "03_ipv6_nodeport_ingress_no_flags")
 int ipv6_nodeport_ingress_no_flags_setup(struct __ctx_buff *ctx)
 {
 	return setup(ctx, false, false);
 }
 
-CHECK("tc", "03_ipv6_nodeport_ingress_no_flags")
+CHECK(PROG_TYPE, "03_ipv6_nodeport_ingress_no_flags")
 int ipv6_nodeport_ingress_no_flags_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, false, true);
 }
 
-PKTGEN("tc", "04_ipv6_nodeport_ingress_skip_tunnel")
+PKTGEN(PROG_TYPE, "04_ipv6_nodeport_ingress_skip_tunnel")
 int ipv6_nodeport_ingress_skip_tunnel_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen(ctx, false);
 }
 
-SETUP("tc", "04_ipv6_nodeport_ingress_skip_tunnel")
+SETUP(PROG_TYPE, "04_ipv6_nodeport_ingress_skip_tunnel")
 int ipv6_nodeport_ingress_skip_tunnel_setup(struct __ctx_buff *ctx)
 {
 	return setup(ctx, false, true);
 }
 
-CHECK("tc", "04_ipv6_nodeport_ingress_skip_tunnel")
+CHECK(PROG_TYPE, "04_ipv6_nodeport_ingress_skip_tunnel")
 int ipv6_nodeport_ingress_skip_tunnel_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, false, false);

--- a/bpf/tests/skip_tunnel_nodeport_nat.c
+++ b/bpf/tests/skip_tunnel_nodeport_nat.c
@@ -322,73 +322,73 @@ check_ctx(const struct __ctx_buff *ctx, bool v4, __u32 expected_result)
 	test_finish();
 }
 
-PKTGEN("tc", "01_ipv4_nodeport_egress_no_flags")
+PKTGEN(PROG_TYPE, "01_ipv4_nodeport_egress_no_flags")
 int ipv4_nodeport_egress_no_flags_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen(ctx, true);
 }
 
-SETUP("tc", "01_ipv4_nodeport_egress_no_flags")
+SETUP(PROG_TYPE, "01_ipv4_nodeport_egress_no_flags")
 int ipv4_nodeport_egress_no_flags_setup(struct __ctx_buff *ctx)
 {
 	return setup(ctx, true, false);
 }
 
-CHECK("tc", "01_ipv4_nodeport_egress_no_flags")
+CHECK(PROG_TYPE, "01_ipv4_nodeport_egress_no_flags")
 int ipv4_nodeport_egress_no_flags_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, true, CTX_ACT_REDIRECT);
 }
 
-PKTGEN("tc", "02_ipv4_nodeport_egress_skip_tunnel")
+PKTGEN(PROG_TYPE, "02_ipv4_nodeport_egress_skip_tunnel")
 int ipv4_nodeport_egress_skip_tunnel_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen(ctx, true);
 }
 
-SETUP("tc", "02_ipv4_nodeport_egress_skip_tunnel")
+SETUP(PROG_TYPE, "02_ipv4_nodeport_egress_skip_tunnel")
 int ipv4_nodeport_egress_skip_tunnel_setup(struct __ctx_buff *ctx)
 {
 	return setup(ctx, true, true);
 }
 
-CHECK("tc", "02_ipv4_nodeport_egress_skip_tunnel")
+CHECK(PROG_TYPE, "02_ipv4_nodeport_egress_skip_tunnel")
 int ipv4_nodeport_egress_skip_tunnel_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, true, CTX_ACT_DROP);
 }
 
-PKTGEN("tc", "03_ipv6_nodeport_egress_no_flags")
+PKTGEN(PROG_TYPE, "03_ipv6_nodeport_egress_no_flags")
 int ipv6_nodeport_egress_no_flags_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen(ctx, false);
 }
 
-SETUP("tc", "03_ipv6_nodeport_egress_no_flags")
+SETUP(PROG_TYPE, "03_ipv6_nodeport_egress_no_flags")
 int ipv6_nodeport_egress_no_flags_setup(struct __ctx_buff *ctx)
 {
 	return setup(ctx, false, false);
 }
 
-CHECK("tc", "03_ipv6_nodeport_egress_no_flags")
+CHECK(PROG_TYPE, "03_ipv6_nodeport_egress_no_flags")
 int ipv6_nodeport_egress_no_flags_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, false, CTX_ACT_REDIRECT);
 }
 
-PKTGEN("tc", "04_ipv6_nodeport_egress_skip_tunnel")
+PKTGEN(PROG_TYPE, "04_ipv6_nodeport_egress_skip_tunnel")
 int ipv6_nodeport_egress_skip_tunnel_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen(ctx, false);
 }
 
-SETUP("tc", "04_ipv6_nodeport_egress_skip_tunnel")
+SETUP(PROG_TYPE, "04_ipv6_nodeport_egress_skip_tunnel")
 int ipv6_nodeport_egress_skip_tunnel_setup(struct __ctx_buff *ctx)
 {
 	return setup(ctx, false, true);
 }
 
-CHECK("tc", "04_ipv6_nodeport_egress_skip_tunnel")
+CHECK(PROG_TYPE, "04_ipv6_nodeport_egress_skip_tunnel")
 int ipv6_nodeport_egress_skip_tunnel_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, false, CTX_ACT_DROP);

--- a/bpf/tests/skip_tunnel_nodeport_revnat.c
+++ b/bpf/tests/skip_tunnel_nodeport_revnat.c
@@ -369,73 +369,73 @@ check_ctx(const struct __ctx_buff *ctx, bool v4, __u32 expected_result)
 	test_finish();
 }
 
-PKTGEN("tc", "01_ipv4_nodeport_ingress_no_flags")
+PKTGEN(PROG_TYPE, "01_ipv4_nodeport_ingress_no_flags")
 int ipv4_nodeport_ingress_no_flags_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen(ctx, true);
 }
 
-SETUP("tc", "01_ipv4_nodeport_ingress_no_flags")
+SETUP(PROG_TYPE, "01_ipv4_nodeport_ingress_no_flags")
 int ipv4_nodeport_ingress_no_flags_setup(struct __ctx_buff *ctx)
 {
 	return setup(ctx, true, false);
 }
 
-CHECK("tc", "01_ipv4_nodeport_ingress_no_flags")
+CHECK(PROG_TYPE, "01_ipv4_nodeport_ingress_no_flags")
 int ipv4_nodeport_ingress_no_flags_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, true, CTX_ACT_REDIRECT);
 }
 
-PKTGEN("tc", "02_ipv4_nodeport_ingress_skip_tunnel")
+PKTGEN(PROG_TYPE, "02_ipv4_nodeport_ingress_skip_tunnel")
 int ipv4_nodeport_ingress_skip_tunnel_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen(ctx, true);
 }
 
-SETUP("tc", "02_ipv4_nodeport_ingress_skip_tunnel")
+SETUP(PROG_TYPE, "02_ipv4_nodeport_ingress_skip_tunnel")
 int ipv4_nodeport_ingress_skip_tunnel_setup(struct __ctx_buff *ctx)
 {
 	return setup(ctx, true, true);
 }
 
-CHECK("tc", "02_ipv4_nodeport_ingress_skip_tunnel")
+CHECK(PROG_TYPE, "02_ipv4_nodeport_ingress_skip_tunnel")
 int ipv4_nodeport_ingress_skip_tunnel_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, true, CTX_ACT_DROP);
 }
 
-PKTGEN("tc", "03_ipv6_nodeport_ingress_no_flags")
+PKTGEN(PROG_TYPE, "03_ipv6_nodeport_ingress_no_flags")
 int ipv6_nodeport_ingress_no_flags_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen(ctx, false);
 }
 
-SETUP("tc", "03_ipv6_nodeport_ingress_no_flags")
+SETUP(PROG_TYPE, "03_ipv6_nodeport_ingress_no_flags")
 int ipv6_nodeport_ingress_no_flags_setup(struct __ctx_buff *ctx)
 {
 	return setup(ctx, false, false);
 }
 
-CHECK("tc", "03_ipv6_nodeport_ingress_no_flags")
+CHECK(PROG_TYPE, "03_ipv6_nodeport_ingress_no_flags")
 int ipv6_nodeport_ingress_no_flags_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, false, CTX_ACT_REDIRECT);
 }
 
-PKTGEN("tc", "04_ipv6_nodeport_ingress_skip_tunnel")
+PKTGEN(PROG_TYPE, "04_ipv6_nodeport_ingress_skip_tunnel")
 int ipv6_nodeport_ingress_skip_tunnel_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen(ctx, false);
 }
 
-SETUP("tc", "04_ipv6_nodeport_ingress_skip_tunnel")
+SETUP(PROG_TYPE, "04_ipv6_nodeport_ingress_skip_tunnel")
 int ipv6_nodeport_ingress_skip_tunnel_setup(struct __ctx_buff *ctx)
 {
 	return setup(ctx, false, true);
 }
 
-CHECK("tc", "04_ipv6_nodeport_ingress_skip_tunnel")
+CHECK(PROG_TYPE, "04_ipv6_nodeport_ingress_skip_tunnel")
 int ipv6_nodeport_ingress_skip_tunnel_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_ctx(ctx, false, CTX_ACT_DROP);

--- a/bpf/tests/tc_egressgw_redirect_from_host.c
+++ b/bpf/tests/tc_egressgw_redirect_from_host.c
@@ -78,7 +78,7 @@ mock_fib_lookup(void *ctx __maybe_unused,
 /* Test that a packet matching an egress gateway policy on the to-netdev
  * program egresses locally.
  */
-PKTGEN("tc", "tc_egressgw_egress1")
+PKTGEN(PROG_TYPE, "tc_egressgw_egress1")
 int egressgw_egress1_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
@@ -86,7 +86,7 @@ int egressgw_egress1_pktgen(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_egress1")
+SETUP(PROG_TYPE, "tc_egressgw_egress1")
 int egressgw_egress1_setup(struct __ctx_buff *ctx)
 {
 	__u32 key = 0;
@@ -113,7 +113,7 @@ int egressgw_egress1_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_egress1")
+CHECK(PROG_TYPE, "tc_egressgw_egress1")
 int egressgw_egress1_check(const struct __ctx_buff *ctx)
 {
 	__u32 key = 0;
@@ -132,7 +132,7 @@ int egressgw_egress1_check(const struct __ctx_buff *ctx)
 /* Test that a packet matching an egress gateway policy on the to-netdev
  * program egresses locally. Using the ifindex in the policy.
  */
-PKTGEN("tc", "tc_egressgw_egress2_ifindex")
+PKTGEN(PROG_TYPE, "tc_egressgw_egress2_ifindex")
 int egressgw_egress2_ifindex_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
@@ -140,7 +140,7 @@ int egressgw_egress2_ifindex_pktgen(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_egress2_ifindex")
+SETUP(PROG_TYPE, "tc_egressgw_egress2_ifindex")
 int egressgw_egress2_ifindex_setup(struct __ctx_buff *ctx)
 {
 	__u32 key = 0;
@@ -157,7 +157,7 @@ int egressgw_egress2_ifindex_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_egress2_ifindex")
+CHECK(PROG_TYPE, "tc_egressgw_egress2_ifindex")
 int egressgw_egress2_ifindex_check(const struct __ctx_buff *ctx)
 {
 	__u32 key = 0;
@@ -176,7 +176,7 @@ int egressgw_egress2_ifindex_check(const struct __ctx_buff *ctx)
 /* Test that a packet matching an egress gateway policy on the to-netdev
  * program egresses locally, using the endpoint's rt_info.
  */
-PKTGEN("tc", "tc_egressgw_egress3_rt_info")
+PKTGEN(PROG_TYPE, "tc_egressgw_egress3_rt_info")
 int egressgw_egress3_rt_info_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
@@ -184,7 +184,7 @@ int egressgw_egress3_rt_info_pktgen(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_egress3_rt_info")
+SETUP(PROG_TYPE, "tc_egressgw_egress3_rt_info")
 int egressgw_egress3_rt_info_setup(struct __ctx_buff *ctx)
 {
 	__u32 key = 0;
@@ -205,7 +205,7 @@ int egressgw_egress3_rt_info_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_egress3_rt_info")
+CHECK(PROG_TYPE, "tc_egressgw_egress3_rt_info")
 int egressgw_egress3_rt_info_check(const struct __ctx_buff *ctx)
 {
 	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
@@ -232,7 +232,7 @@ int egressgw_egress3_rt_info_check(const struct __ctx_buff *ctx)
 /* Test that a packet matching an egress gateway policy on the to-netdev
  * program gets redirected to the gateway node.
  */
-PKTGEN("tc", "tc_egressgw_redirect")
+PKTGEN(PROG_TYPE, "tc_egressgw_redirect")
 int egressgw_redirect_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
@@ -240,7 +240,7 @@ int egressgw_redirect_pktgen(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_redirect")
+SETUP(PROG_TYPE, "tc_egressgw_redirect")
 int egressgw_redirect_setup(struct __ctx_buff *ctx)
 {
 	ipcache_v4_add_world_entry();
@@ -252,7 +252,7 @@ int egressgw_redirect_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_redirect")
+CHECK(PROG_TYPE, "tc_egressgw_redirect")
 int egressgw_redirect_check(const struct __ctx_buff *ctx)
 {
 	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
@@ -267,7 +267,7 @@ int egressgw_redirect_check(const struct __ctx_buff *ctx)
 /* Test that a packet matching an excluded CIDR egress gateway policy on the
  * to-netdev program does not get redirected to the gateway node.
  */
-PKTGEN("tc", "tc_egressgw_skip_excluded_cidr_redirect")
+PKTGEN(PROG_TYPE, "tc_egressgw_skip_excluded_cidr_redirect")
 int egressgw_skip_excluded_cidr_redirect_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
@@ -275,7 +275,7 @@ int egressgw_skip_excluded_cidr_redirect_pktgen(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_skip_excluded_cidr_redirect")
+SETUP(PROG_TYPE, "tc_egressgw_skip_excluded_cidr_redirect")
 int egressgw_skip_excluded_cidr_redirect_setup(struct __ctx_buff *ctx)
 {
 	ipcache_v4_add_world_entry();
@@ -289,7 +289,7 @@ int egressgw_skip_excluded_cidr_redirect_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_skip_excluded_cidr_redirect")
+CHECK(PROG_TYPE, "tc_egressgw_skip_excluded_cidr_redirect")
 int egressgw_skip_excluded_cidr_redirect_check(const struct __ctx_buff *ctx)
 {
 	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
@@ -305,7 +305,7 @@ int egressgw_skip_excluded_cidr_redirect_check(const struct __ctx_buff *ctx)
 /* Test that a packet matching an egress gateway policy without a gateway on the
  * to-netdev program does not get redirected to the gateway node.
  */
-PKTGEN("tc", "tc_egressgw_skip_no_gateway_redirect")
+PKTGEN(PROG_TYPE, "tc_egressgw_skip_no_gateway_redirect")
 int egressgw_skip_no_gateway_redirect_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
@@ -313,7 +313,7 @@ int egressgw_skip_no_gateway_redirect_pktgen(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_skip_no_gateway_redirect")
+SETUP(PROG_TYPE, "tc_egressgw_skip_no_gateway_redirect")
 int egressgw_skip_no_gateway_redirect_setup(struct __ctx_buff *ctx)
 {
 	metrics_del_entry((__u8)-DROP_NO_EGRESS_GATEWAY, METRIC_EGRESS);
@@ -325,7 +325,7 @@ int egressgw_skip_no_gateway_redirect_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_skip_no_gateway_redirect")
+CHECK(PROG_TYPE, "tc_egressgw_skip_no_gateway_redirect")
 int egressgw_skip_no_gateway_redirect_check(const struct __ctx_buff *ctx)
 {
 	struct metrics_value *entry = NULL;
@@ -357,7 +357,7 @@ int egressgw_skip_no_gateway_redirect_check(const struct __ctx_buff *ctx)
 /* Test that a packet matching an egress gateway policy without an egressIP on the
  * to-netdev program gets dropped.
  */
-PKTGEN("tc", "tc_egressgw_drop_no_egress_ip")
+PKTGEN(PROG_TYPE, "tc_egressgw_drop_no_egress_ip")
 int egressgw_drop_no_egress_ip_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
@@ -365,7 +365,7 @@ int egressgw_drop_no_egress_ip_pktgen(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_drop_no_egress_ip")
+SETUP(PROG_TYPE, "tc_egressgw_drop_no_egress_ip")
 int egressgw_drop_no_egress_ip_setup(struct __ctx_buff *ctx)
 {
 	metrics_del_entry((__u8)-DROP_NO_EGRESS_IP, METRIC_EGRESS);
@@ -379,7 +379,7 @@ int egressgw_drop_no_egress_ip_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_drop_no_egress_ip")
+CHECK(PROG_TYPE, "tc_egressgw_drop_no_egress_ip")
 int egressgw_drop_no_egress_ip_check(const struct __ctx_buff *ctx)
 {
 	struct metrics_value *entry = NULL;
@@ -412,7 +412,7 @@ int egressgw_drop_no_egress_ip_check(const struct __ctx_buff *ctx)
 /* Test that a packet matching an egress gateway policy on the to-netdev
  * program egresses locally.
  */
-PKTGEN("tc", "tc_egressgw_v6_egress1")
+PKTGEN(PROG_TYPE, "tc_egressgw_v6_egress1")
 int egressgw_v6_egress1_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
@@ -420,7 +420,7 @@ int egressgw_v6_egress1_pktgen(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_v6_egress1")
+SETUP(PROG_TYPE, "tc_egressgw_v6_egress1")
 int egressgw_v6_egress1_setup(struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -451,7 +451,7 @@ int egressgw_v6_egress1_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_v6_egress1")
+CHECK(PROG_TYPE, "tc_egressgw_v6_egress1")
 int egressgw_v6_egress1_check(const struct __ctx_buff *ctx)
 {
 	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
@@ -470,7 +470,7 @@ int egressgw_v6_egress1_check(const struct __ctx_buff *ctx)
 /* Test that a packet matching an egress gateway policy on the to-netdev
  * program egresses locally. Using the ifindex in the policy.
  */
-PKTGEN("tc", "tc_egressgw_v6_egress2_ifindex")
+PKTGEN(PROG_TYPE, "tc_egressgw_v6_egress2_ifindex")
 int egressgw_v6_egress2_ifindex_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
@@ -478,7 +478,7 @@ int egressgw_v6_egress2_ifindex_pktgen(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_v6_egress2_ifindex")
+SETUP(PROG_TYPE, "tc_egressgw_v6_egress2_ifindex")
 int egressgw_v6_egress2_ifindex_setup(struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -498,7 +498,7 @@ int egressgw_v6_egress2_ifindex_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_v6_egress2_ifindex")
+CHECK(PROG_TYPE, "tc_egressgw_v6_egress2_ifindex")
 int egressgw_v6_egress2_ifindex_check(const struct __ctx_buff *ctx)
 {
 	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
@@ -517,7 +517,7 @@ int egressgw_v6_egress2_ifindex_check(const struct __ctx_buff *ctx)
 /* Test that a packet matching an egress gateway policy on the to-netdev
  * program egresses locally, using the endpoint's rt_info.
  */
-PKTGEN("tc", "tc_egressgw_v6_egress3_rt_info")
+PKTGEN(PROG_TYPE, "tc_egressgw_v6_egress3_rt_info")
 int egressgw_v6_egress3_rt_info_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
@@ -525,7 +525,7 @@ int egressgw_v6_egress3_rt_info_pktgen(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_v6_egress3_rt_info")
+SETUP(PROG_TYPE, "tc_egressgw_v6_egress3_rt_info")
 int egressgw_v6_egress3_rt_info_setup(struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -549,7 +549,7 @@ int egressgw_v6_egress3_rt_info_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_v6_egress3_rt_info")
+CHECK(PROG_TYPE, "tc_egressgw_v6_egress3_rt_info")
 int egressgw_v6_egress3_rt_info_check(const struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -579,7 +579,7 @@ int egressgw_v6_egress3_rt_info_check(const struct __ctx_buff *ctx)
 /* Test that a packet matching an egress gateway policy on the to-netdev
  * program gets redirected to the gateway node (IPv6).
  */
-PKTGEN("tc", "tc_egressgw_redirect_v6")
+PKTGEN(PROG_TYPE, "tc_egressgw_redirect_v6")
 int egressgw_redirect_pktgen_v6(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
@@ -587,7 +587,7 @@ int egressgw_redirect_pktgen_v6(struct __ctx_buff *ctx)
 	});
 }
 
-SETUP("tc", "tc_egressgw_redirect_v6")
+SETUP(PROG_TYPE, "tc_egressgw_redirect_v6")
 int egressgw_redirect_setup_v6(struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -603,7 +603,7 @@ int egressgw_redirect_setup_v6(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_redirect_v6")
+CHECK(PROG_TYPE, "tc_egressgw_redirect_v6")
 int egressgw_redirect_check_v6(const struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -621,7 +621,7 @@ int egressgw_redirect_check_v6(const struct __ctx_buff *ctx)
 /* Test that a packet matching an excluded CIDR egress gateway policy on the
  * to-netdev program does not get redirected to the gateway node (IPv6).
  */
-PKTGEN("tc", "tc_egressgw_skip_excluded_cidr_redirect_v6")
+PKTGEN(PROG_TYPE, "tc_egressgw_skip_excluded_cidr_redirect_v6")
 int egressgw_skip_excluded_cidr_redirect_pktgen_v6(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
@@ -629,7 +629,7 @@ int egressgw_skip_excluded_cidr_redirect_pktgen_v6(struct __ctx_buff *ctx)
 	});
 }
 
-SETUP("tc", "tc_egressgw_skip_excluded_cidr_redirect_v6")
+SETUP(PROG_TYPE, "tc_egressgw_skip_excluded_cidr_redirect_v6")
 int egressgw_skip_excluded_cidr_redirect_setup_v6(struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -647,7 +647,7 @@ int egressgw_skip_excluded_cidr_redirect_setup_v6(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_skip_excluded_cidr_redirect_v6")
+CHECK(PROG_TYPE, "tc_egressgw_skip_excluded_cidr_redirect_v6")
 int egressgw_skip_excluded_cidr_redirect_check_v6(const struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -666,7 +666,7 @@ int egressgw_skip_excluded_cidr_redirect_check_v6(const struct __ctx_buff *ctx)
 /* Test that a packet matching an egress gateway policy without a gateway on the
  * to-netdev program does not get redirected to the gateway node (IPv6).
  */
-PKTGEN("tc", "tc_egressgw_skip_no_gateway_redirect_v6")
+PKTGEN(PROG_TYPE, "tc_egressgw_skip_no_gateway_redirect_v6")
 int egressgw_skip_no_gateway_redirect_pktgen_v6(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
@@ -674,7 +674,7 @@ int egressgw_skip_no_gateway_redirect_pktgen_v6(struct __ctx_buff *ctx)
 	});
 }
 
-SETUP("tc", "tc_egressgw_skip_no_gateway_redirect_v6")
+SETUP(PROG_TYPE, "tc_egressgw_skip_no_gateway_redirect_v6")
 int egressgw_skip_no_gateway_redirect_setup_v6(struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -691,7 +691,7 @@ int egressgw_skip_no_gateway_redirect_setup_v6(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_skip_no_gateway_redirect_v6")
+CHECK(PROG_TYPE, "tc_egressgw_skip_no_gateway_redirect_v6")
 int egressgw_skip_no_gateway_redirect_check_v6(const struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -725,7 +725,7 @@ int egressgw_skip_no_gateway_redirect_check_v6(const struct __ctx_buff *ctx)
 /* Test that a packet matching an egress gateway policy without an egressIP on the
  * to-netdev program gets dropped (IPv6).
  */
-PKTGEN("tc", "tc_egressgw_drop_no_egress_ip_v6")
+PKTGEN(PROG_TYPE, "tc_egressgw_drop_no_egress_ip_v6")
 int egressgw_drop_no_egress_ip_pktgen_v6(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
@@ -733,7 +733,7 @@ int egressgw_drop_no_egress_ip_pktgen_v6(struct __ctx_buff *ctx)
 	});
 }
 
-SETUP("tc", "tc_egressgw_drop_no_egress_ip_v6")
+SETUP(PROG_TYPE, "tc_egressgw_drop_no_egress_ip_v6")
 int egressgw_drop_no_egress_ip_setup_v6(struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -750,7 +750,7 @@ int egressgw_drop_no_egress_ip_setup_v6(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_drop_no_egress_ip_v6")
+CHECK(PROG_TYPE, "tc_egressgw_drop_no_egress_ip_v6")
 int egressgw_drop_no_egress_ip_check_v6(const struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;

--- a/bpf/tests/tc_egressgw_redirect_from_overlay.c
+++ b/bpf/tests/tc_egressgw_redirect_from_overlay.c
@@ -63,7 +63,7 @@ mock_fib_lookup(void *ctx __maybe_unused, struct bpf_fib_lookup *params __maybe_
 /* Test that a packet matching an egress gateway policy on the from-overlay program
  * gets correctly redirected to the target netdev.
  */
-PKTGEN("tc", "tc_egressgw_redirect_from_overlay")
+PKTGEN(PROG_TYPE, "tc_egressgw_redirect_from_overlay")
 int egressgw_redirect_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
@@ -72,7 +72,7 @@ int egressgw_redirect_pktgen(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_redirect_from_overlay")
+SETUP(PROG_TYPE, "tc_egressgw_redirect_from_overlay")
 int egressgw_redirect_setup(struct __ctx_buff *ctx)
 {
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, GATEWAY_NODE_IP,
@@ -81,7 +81,7 @@ int egressgw_redirect_setup(struct __ctx_buff *ctx)
 	return overlay_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_redirect_from_overlay")
+CHECK(PROG_TYPE, "tc_egressgw_redirect_from_overlay")
 int egressgw_redirect_check(const struct __ctx_buff *ctx)
 {
 	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
@@ -96,7 +96,7 @@ int egressgw_redirect_check(const struct __ctx_buff *ctx)
 /* Test that a packet matching an egress gateway policy on the from-overlay program
  * gets correctly redirected to the target netdev, using the ifindex from the policy.
  */
-PKTGEN("tc", "tc_egressgw_redirect_from_overlay_with_ifindex")
+PKTGEN(PROG_TYPE, "tc_egressgw_redirect_from_overlay_with_ifindex")
 int egressgw_redirect_with_ifindex_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
@@ -105,7 +105,7 @@ int egressgw_redirect_with_ifindex_pktgen(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_redirect_from_overlay_with_ifindex")
+SETUP(PROG_TYPE, "tc_egressgw_redirect_from_overlay_with_ifindex")
 int egressgw_redirect_with_ifindex_setup(struct __ctx_buff *ctx)
 {
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, GATEWAY_NODE_IP,
@@ -114,7 +114,7 @@ int egressgw_redirect_with_ifindex_setup(struct __ctx_buff *ctx)
 	return overlay_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_redirect_from_overlay_with_ifindex")
+CHECK(PROG_TYPE, "tc_egressgw_redirect_from_overlay_with_ifindex")
 int egressgw_redirect_with_ifindex_check(const struct __ctx_buff *ctx)
 {
 	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
@@ -129,7 +129,7 @@ int egressgw_redirect_with_ifindex_check(const struct __ctx_buff *ctx)
 /* Test that a packet matching an excluded CIDR egress gateway policy on the
  * from-overlay program does not get redirected to the target netdev.
  */
-PKTGEN("tc", "tc_egressgw_skip_excluded_cidr_redirect_from_overlay")
+PKTGEN(PROG_TYPE, "tc_egressgw_skip_excluded_cidr_redirect_from_overlay")
 int egressgw_skip_excluded_cidr_redirect_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
@@ -137,7 +137,7 @@ int egressgw_skip_excluded_cidr_redirect_pktgen(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_skip_excluded_cidr_redirect_from_overlay")
+SETUP(PROG_TYPE, "tc_egressgw_skip_excluded_cidr_redirect_from_overlay")
 int egressgw_skip_excluded_cidr_redirect_setup(struct __ctx_buff *ctx)
 {
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, GATEWAY_NODE_IP,
@@ -148,7 +148,7 @@ int egressgw_skip_excluded_cidr_redirect_setup(struct __ctx_buff *ctx)
 	return overlay_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_skip_excluded_cidr_redirect_from_overlay")
+CHECK(PROG_TYPE, "tc_egressgw_skip_excluded_cidr_redirect_from_overlay")
 int egressgw_skip_excluded_cidr_redirect_check(const struct __ctx_buff *ctx)
 {
 	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
@@ -164,7 +164,7 @@ int egressgw_skip_excluded_cidr_redirect_check(const struct __ctx_buff *ctx)
 /* Test that a packet matching an egress gateway policy without a gateway on the
  * from-overlay program does not get redirected to the target netdev.
  */
-PKTGEN("tc", "tc_egressgw_skip_no_gateway_redirect_from_overlay")
+PKTGEN(PROG_TYPE, "tc_egressgw_skip_no_gateway_redirect_from_overlay")
 int egressgw_skip_no_gateway_redirect_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
@@ -172,7 +172,7 @@ int egressgw_skip_no_gateway_redirect_pktgen(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_skip_no_gateway_redirect_from_overlay")
+SETUP(PROG_TYPE, "tc_egressgw_skip_no_gateway_redirect_from_overlay")
 int egressgw_skip_no_gateway_redirect_setup(struct __ctx_buff *ctx)
 {
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32, EGRESS_GATEWAY_NO_GATEWAY,
@@ -181,7 +181,7 @@ int egressgw_skip_no_gateway_redirect_setup(struct __ctx_buff *ctx)
 	return overlay_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_skip_no_gateway_redirect_from_overlay")
+CHECK(PROG_TYPE, "tc_egressgw_skip_no_gateway_redirect_from_overlay")
 int egressgw_skip_no_gateway_redirect_check(const struct __ctx_buff *ctx)
 {
 	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
@@ -196,7 +196,7 @@ int egressgw_skip_no_gateway_redirect_check(const struct __ctx_buff *ctx)
 /* Test that a packet matching an egress gateway policy without an egressIP on the
  * from-overlay program gets dropped.
  */
-PKTGEN("tc", "tc_egressgw_drop_no_egress_ip_from_overlay")
+PKTGEN(PROG_TYPE, "tc_egressgw_drop_no_egress_ip_from_overlay")
 int egressgw_drop_no_egress_ip_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
@@ -204,7 +204,7 @@ int egressgw_drop_no_egress_ip_pktgen(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_drop_no_egress_ip_from_overlay")
+SETUP(PROG_TYPE, "tc_egressgw_drop_no_egress_ip_from_overlay")
 int egressgw_drop_no_egress_ip_setup(struct __ctx_buff *ctx)
 {
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32, GATEWAY_NODE_IP,
@@ -213,7 +213,7 @@ int egressgw_drop_no_egress_ip_setup(struct __ctx_buff *ctx)
 	return overlay_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_drop_no_egress_ip_from_overlay")
+CHECK(PROG_TYPE, "tc_egressgw_drop_no_egress_ip_from_overlay")
 int egressgw_drop_no_egress_ip_check(const struct __ctx_buff *ctx)
 {
 	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
@@ -228,7 +228,7 @@ int egressgw_drop_no_egress_ip_check(const struct __ctx_buff *ctx)
 /* Test that a packet matching an egress gateway policy on the from-overlay program
  * gets correctly redirected to the target netdev for IPv6.
  */
-PKTGEN("tc", "tc_egressgw_v6_redirect_from_overlay")
+PKTGEN(PROG_TYPE, "tc_egressgw_v6_redirect_from_overlay")
 int egressgw_v6_redirect_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
@@ -237,7 +237,7 @@ int egressgw_v6_redirect_pktgen(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_v6_redirect_from_overlay")
+SETUP(PROG_TYPE, "tc_egressgw_v6_redirect_from_overlay")
 int egressgw_v6_redirect_setup(struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -250,7 +250,7 @@ int egressgw_v6_redirect_setup(struct __ctx_buff *ctx)
 	return overlay_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_v6_redirect_from_overlay")
+CHECK(PROG_TYPE, "tc_egressgw_v6_redirect_from_overlay")
 int egressgw_v6_redirect_check(const struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -268,7 +268,7 @@ int egressgw_v6_redirect_check(const struct __ctx_buff *ctx)
 /* Test that a packet matching an egress gateway policy on the from-overlay program
  * gets correctly redirected to the target netdev for IPv6, using the ifindex from the policy.
  */
-PKTGEN("tc", "tc_egressgw_v6_redirect_from_overlay_with_ifindex")
+PKTGEN(PROG_TYPE, "tc_egressgw_v6_redirect_from_overlay_with_ifindex")
 int egressgw_v6_redirect_with_ifindex_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
@@ -277,7 +277,7 @@ int egressgw_v6_redirect_with_ifindex_pktgen(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_v6_redirect_from_overlay_with_ifindex")
+SETUP(PROG_TYPE, "tc_egressgw_v6_redirect_from_overlay_with_ifindex")
 int egressgw_v6_redirect_with_ifindex_setup(struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -290,7 +290,7 @@ int egressgw_v6_redirect_with_ifindex_setup(struct __ctx_buff *ctx)
 	return overlay_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_v6_redirect_from_overlay_with_ifindex")
+CHECK(PROG_TYPE, "tc_egressgw_v6_redirect_from_overlay_with_ifindex")
 int egressgw_v6_redirect_check_with_ifindex(const struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -308,7 +308,7 @@ int egressgw_v6_redirect_check_with_ifindex(const struct __ctx_buff *ctx)
 /* Test that a packet matching an excluded CIDR egress gateway policy on the
  * from-overlay program does not get redirected to the target netdev.
  */
-PKTGEN("tc", "tc_egressgw_skip_excluded_cidr_redirect_from_overlay_v6")
+PKTGEN(PROG_TYPE, "tc_egressgw_skip_excluded_cidr_redirect_from_overlay_v6")
 int egressgw_skip_excluded_cidr_redirect_pktgen_v6(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
@@ -316,7 +316,7 @@ int egressgw_skip_excluded_cidr_redirect_pktgen_v6(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_skip_excluded_cidr_redirect_from_overlay_v6")
+SETUP(PROG_TYPE, "tc_egressgw_skip_excluded_cidr_redirect_from_overlay_v6")
 int egressgw_skip_excluded_cidr_redirect_setup_v6(struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -331,7 +331,7 @@ int egressgw_skip_excluded_cidr_redirect_setup_v6(struct __ctx_buff *ctx)
 	return overlay_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_skip_excluded_cidr_redirect_from_overlay_v6")
+CHECK(PROG_TYPE, "tc_egressgw_skip_excluded_cidr_redirect_from_overlay_v6")
 int egressgw_skip_excluded_cidr_redirect_check_v6(const struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -350,7 +350,7 @@ int egressgw_skip_excluded_cidr_redirect_check_v6(const struct __ctx_buff *ctx)
 /* Test that a packet matching an egress gateway policy without a gateway on the
  * from-overlay program does not get redirected to the target netdev.
  */
-PKTGEN("tc", "tc_egressgw_skip_no_gateway_redirect_from_overlay_v6")
+PKTGEN(PROG_TYPE, "tc_egressgw_skip_no_gateway_redirect_from_overlay_v6")
 int egressgw_skip_no_gateway_redirect_pktgen_v6(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
@@ -358,7 +358,7 @@ int egressgw_skip_no_gateway_redirect_pktgen_v6(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_skip_no_gateway_redirect_from_overlay_v6")
+SETUP(PROG_TYPE, "tc_egressgw_skip_no_gateway_redirect_from_overlay_v6")
 int egressgw_skip_no_gateway_redirect_setup_v6(struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -371,7 +371,7 @@ int egressgw_skip_no_gateway_redirect_setup_v6(struct __ctx_buff *ctx)
 	return overlay_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_skip_no_gateway_redirect_from_overlay_v6")
+CHECK(PROG_TYPE, "tc_egressgw_skip_no_gateway_redirect_from_overlay_v6")
 int egressgw_skip_no_gateway_redirect_check_v6(const struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -389,7 +389,7 @@ int egressgw_skip_no_gateway_redirect_check_v6(const struct __ctx_buff *ctx)
 /* Test that a packet matching an egress gateway policy without an egressIP on the
  * from-overlay program gets dropped.
  */
-PKTGEN("tc", "tc_egressgw_drop_no_egress_ip_from_overlay_v6")
+PKTGEN(PROG_TYPE, "tc_egressgw_drop_no_egress_ip_from_overlay_v6")
 int egressgw_drop_no_egress_ip_pktgen_v6(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
@@ -397,7 +397,7 @@ int egressgw_drop_no_egress_ip_pktgen_v6(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_drop_no_egress_ip_from_overlay_v6")
+SETUP(PROG_TYPE, "tc_egressgw_drop_no_egress_ip_from_overlay_v6")
 int egressgw_drop_no_egress_ip_setup_v6(struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -410,7 +410,7 @@ int egressgw_drop_no_egress_ip_setup_v6(struct __ctx_buff *ctx)
 	return overlay_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_drop_no_egress_ip_from_overlay_v6")
+CHECK(PROG_TYPE, "tc_egressgw_drop_no_egress_ip_from_overlay_v6")
 int egressgw_drop_no_egress_ip_check_v6(const struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;

--- a/bpf/tests/tc_egressgw_redirect_from_overlay_with_rt_info.c
+++ b/bpf/tests/tc_egressgw_redirect_from_overlay_with_rt_info.c
@@ -83,7 +83,7 @@ mock_fib_lookup(void *ctx __maybe_unused, struct bpf_fib_lookup *params __maybe_
 /* Test that a packet matching an egress gateway policy on the from-overlay program
  * gets correctly redirected to the target netdev.
  */
-PKTGEN("tc", "tc_egressgw_redirect_from_overlay_with_rt_info")
+PKTGEN(PROG_TYPE, "tc_egressgw_redirect_from_overlay_with_rt_info")
 int egressgw_redirect_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
@@ -92,7 +92,7 @@ int egressgw_redirect_pktgen(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_redirect_from_overlay_with_rt_info")
+SETUP(PROG_TYPE, "tc_egressgw_redirect_from_overlay_with_rt_info")
 int egressgw_redirect_setup(struct __ctx_buff *ctx)
 {
 	__u32 key = 0;
@@ -109,7 +109,7 @@ int egressgw_redirect_setup(struct __ctx_buff *ctx)
 	return overlay_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_redirect_from_overlay_with_rt_info")
+CHECK(PROG_TYPE, "tc_egressgw_redirect_from_overlay_with_rt_info")
 int egressgw_redirect_check(const struct __ctx_buff *ctx)
 {
 	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
@@ -130,7 +130,7 @@ int egressgw_redirect_check(const struct __ctx_buff *ctx)
 /* Test that a packet matching an egress gateway policy on the from-overlay program
  * gets correctly redirected to the target netdev for IPv6.
  */
-PKTGEN("tc", "tc_egressgw_redirect_from_overlay_with_rt_info_v6")
+PKTGEN(PROG_TYPE, "tc_egressgw_redirect_from_overlay_with_rt_info_v6")
 int egressgw_redirect_pktgen_v6(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
@@ -139,7 +139,7 @@ int egressgw_redirect_pktgen_v6(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_redirect_from_overlay_with_rt_info_v6")
+SETUP(PROG_TYPE, "tc_egressgw_redirect_from_overlay_with_rt_info_v6")
 int egressgw_redirect_setup_v6(struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -160,7 +160,7 @@ int egressgw_redirect_setup_v6(struct __ctx_buff *ctx)
 	return overlay_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_redirect_from_overlay_with_rt_info_v6")
+CHECK(PROG_TYPE, "tc_egressgw_redirect_from_overlay_with_rt_info_v6")
 int egressgw_redirect_check_v6(const struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -76,7 +76,7 @@ mock_fib_lookup(void *ctx __maybe_unused, const struct bpf_fib_lookup *params __
 /* Test that a packet matching an egress gateway policy on the to-netdev program
  * gets correctly SNATed with the egress IP of the policy.
  */
-PKTGEN("tc", "tc_egressgw_snat1")
+PKTGEN(PROG_TYPE, "tc_egressgw_snat1")
 int egressgw_snat1_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
@@ -84,7 +84,7 @@ int egressgw_snat1_pktgen(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_snat1")
+SETUP(PROG_TYPE, "tc_egressgw_snat1")
 int egressgw_snat1_setup(struct __ctx_buff *ctx)
 {
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24,
@@ -96,7 +96,7 @@ int egressgw_snat1_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_snat1")
+CHECK(PROG_TYPE, "tc_egressgw_snat1")
 int egressgw_snat1_check(const struct __ctx_buff *ctx)
 {
 	return egressgw_snat_check(ctx, (struct egressgw_test_ctx) {
@@ -109,7 +109,7 @@ int egressgw_snat1_check(const struct __ctx_buff *ctx)
 /* Test that a packet matching an egress gateway policy on the from-netdev program
  * gets correctly revSNATed and connection tracked.
  */
-PKTGEN("tc", "tc_egressgw_snat1_2_reply")
+PKTGEN(PROG_TYPE, "tc_egressgw_snat1_2_reply")
 int egressgw_snat1_2_reply_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
@@ -118,7 +118,7 @@ int egressgw_snat1_2_reply_pktgen(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_snat1_2_reply")
+SETUP(PROG_TYPE, "tc_egressgw_snat1_2_reply")
 int egressgw_snat1_2_reply_setup(struct __ctx_buff *ctx)
 {
 	/* install ipcache entry for the CLIENT_IP: */
@@ -127,7 +127,7 @@ int egressgw_snat1_2_reply_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_snat1_2_reply")
+CHECK(PROG_TYPE, "tc_egressgw_snat1_2_reply")
 int egressgw_snat1_2_reply_check(const struct __ctx_buff *ctx)
 {
 	return egressgw_snat_check(ctx, (struct egressgw_test_ctx) {
@@ -138,7 +138,7 @@ int egressgw_snat1_2_reply_check(const struct __ctx_buff *ctx)
 		});
 }
 
-PKTGEN("tc", "tc_egressgw_snat2")
+PKTGEN(PROG_TYPE, "tc_egressgw_snat2")
 int egressgw_snat2_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
@@ -146,7 +146,7 @@ int egressgw_snat2_pktgen(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_snat2")
+SETUP(PROG_TYPE, "tc_egressgw_snat2")
 int egressgw_snat2_setup(struct __ctx_buff *ctx)
 {
 	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
@@ -154,7 +154,7 @@ int egressgw_snat2_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_snat2")
+CHECK(PROG_TYPE, "tc_egressgw_snat2")
 int egressgw_snat2_check(struct __ctx_buff *ctx)
 {
 	int ret = egressgw_snat_check(ctx, (struct egressgw_test_ctx) {
@@ -172,7 +172,7 @@ int egressgw_snat2_check(struct __ctx_buff *ctx)
  * gets correctly SNATed with the desired egress IP of the policy, event if the
  * packet hits a stale NAT entry.
  */
-PKTGEN("tc", "tc_egressgw_tuple_collision1")
+PKTGEN(PROG_TYPE, "tc_egressgw_tuple_collision1")
 int egressgw_tuple_collision1_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
@@ -180,7 +180,7 @@ int egressgw_tuple_collision1_pktgen(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_tuple_collision1")
+SETUP(PROG_TYPE, "tc_egressgw_tuple_collision1")
 int egressgw_tuple_collision1_setup(struct __ctx_buff *ctx)
 {
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24,
@@ -192,7 +192,7 @@ int egressgw_tuple_collision1_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_tuple_collision1")
+CHECK(PROG_TYPE, "tc_egressgw_tuple_collision1")
 int egressgw_tuple_collision1_check(const struct __ctx_buff *ctx)
 {
 	int ret = egressgw_snat_check(ctx, (struct egressgw_test_ctx) {
@@ -206,7 +206,7 @@ int egressgw_tuple_collision1_check(const struct __ctx_buff *ctx)
 	return ret;
 }
 
-PKTGEN("tc", "tc_egressgw_tuple_collision2")
+PKTGEN(PROG_TYPE, "tc_egressgw_tuple_collision2")
 int egressgw_tuple_collision2_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
@@ -214,7 +214,7 @@ int egressgw_tuple_collision2_pktgen(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_tuple_collision2")
+SETUP(PROG_TYPE, "tc_egressgw_tuple_collision2")
 int egressgw_tuple_collision2_setup(struct __ctx_buff *ctx)
 {
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24,
@@ -226,7 +226,7 @@ int egressgw_tuple_collision2_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_tuple_collision2")
+CHECK(PROG_TYPE, "tc_egressgw_tuple_collision2")
 int egressgw_tuple_collision2_check(const struct __ctx_buff *ctx)
 {
 	return egressgw_snat_check(ctx, (struct egressgw_test_ctx) {
@@ -241,7 +241,7 @@ int egressgw_tuple_collision2_check(const struct __ctx_buff *ctx)
  * gets correctly revSNATed and connection tracked, even if the packet hits a
  * stale NAT entry.
  */
-PKTGEN("tc", "tc_egressgw_tuple_collision2_reply")
+PKTGEN(PROG_TYPE, "tc_egressgw_tuple_collision2_reply")
 int egressgw_tuple_collision2_reply_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
@@ -251,7 +251,7 @@ int egressgw_tuple_collision2_reply_pktgen(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_tuple_collision2_reply")
+SETUP(PROG_TYPE, "tc_egressgw_tuple_collision2_reply")
 int egressgw_tuple_collision2_reply_setup(struct __ctx_buff *ctx)
 {
 	/* install ipcache entry for the CLIENT_IP: */
@@ -260,7 +260,7 @@ int egressgw_tuple_collision2_reply_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_tuple_collision2_reply")
+CHECK(PROG_TYPE, "tc_egressgw_tuple_collision2_reply")
 int egressgw_tuple_collision2_reply_check(const struct __ctx_buff *ctx)
 {
 	int ret = egressgw_snat_check(ctx, (struct egressgw_test_ctx) {
@@ -278,7 +278,7 @@ int egressgw_tuple_collision2_reply_check(const struct __ctx_buff *ctx)
 /* Test that a packet matching an excluded CIDR egress gateway policy on the
  * to-netdev program does not get SNATed with the egress IP of the policy.
  */
-PKTGEN("tc", "tc_egressgw_skip_excluded_cidr_snat")
+PKTGEN(PROG_TYPE, "tc_egressgw_skip_excluded_cidr_snat")
 int egressgw_skip_excluded_cidr_snat_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
@@ -286,7 +286,7 @@ int egressgw_skip_excluded_cidr_snat_pktgen(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_egressgw_skip_excluded_cidr_snat")
+SETUP(PROG_TYPE, "tc_egressgw_skip_excluded_cidr_snat")
 int egressgw_skip_excluded_cidr_snat_setup(struct __ctx_buff *ctx)
 {
 
@@ -300,7 +300,7 @@ int egressgw_skip_excluded_cidr_snat_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_egressgw_skip_excluded_cidr_snat")
+CHECK(PROG_TYPE, "tc_egressgw_skip_excluded_cidr_snat")
 int egressgw_skip_excluded_cidr_snat_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -361,7 +361,7 @@ int egressgw_skip_excluded_cidr_snat_check(const struct __ctx_buff *ctx)
 /* Test that a packet matching an egress gateway policy on the to-netdev program
  * gets correctly SNATed with the egress IP of the policy (IPv6).
  */
-PKTGEN("tc", "tc_v6_egressgw_snat1")
+PKTGEN(PROG_TYPE, "tc_v6_egressgw_snat1")
 int egressgw_snat1_pktgen_v6(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
@@ -369,7 +369,7 @@ int egressgw_snat1_pktgen_v6(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_v6_egressgw_snat1")
+SETUP(PROG_TYPE, "tc_v6_egressgw_snat1")
 int egressgw_snat1_setup_v6(struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -385,7 +385,7 @@ int egressgw_snat1_setup_v6(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_v6_egressgw_snat1")
+CHECK(PROG_TYPE, "tc_v6_egressgw_snat1")
 int egressgw_snat1_check_v6(const struct __ctx_buff *ctx)
 {
 	return egressgw_snat_check_v6(ctx, (struct egressgw_test_ctx) {
@@ -398,7 +398,7 @@ int egressgw_snat1_check_v6(const struct __ctx_buff *ctx)
 /* Test that a packet matching an egress gateway policy on the from-netdev program
  * gets correctly revSNATed and connection tracked (IPv6).
  */
-PKTGEN("tc", "tc_v6_egressgw_snat1_2_reply")
+PKTGEN(PROG_TYPE, "tc_v6_egressgw_snat1_2_reply")
 int egressgw_snat1_2_reply_pktgen_v6(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
@@ -407,7 +407,7 @@ int egressgw_snat1_2_reply_pktgen_v6(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_v6_egressgw_snat1_2_reply")
+SETUP(PROG_TYPE, "tc_v6_egressgw_snat1_2_reply")
 int egressgw_snat1_2_reply_setup_v6(struct __ctx_buff *ctx)
 {
 	union v6addr client_ip = CLIENT_IP_V6;
@@ -418,7 +418,7 @@ int egressgw_snat1_2_reply_setup_v6(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_v6_egressgw_snat1_2_reply")
+CHECK(PROG_TYPE, "tc_v6_egressgw_snat1_2_reply")
 int egressgw_snat1_2_reply_check_v6(const struct __ctx_buff *ctx)
 {
 	return egressgw_snat_check_v6(ctx, (struct egressgw_test_ctx) {
@@ -429,7 +429,7 @@ int egressgw_snat1_2_reply_check_v6(const struct __ctx_buff *ctx)
 		});
 }
 
-PKTGEN("tc", "tc_v6_egressgw_snat2")
+PKTGEN(PROG_TYPE, "tc_v6_egressgw_snat2")
 int egressgw_snat2_pktgen_v6(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
@@ -437,7 +437,7 @@ int egressgw_snat2_pktgen_v6(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_v6_egressgw_snat2")
+SETUP(PROG_TYPE, "tc_v6_egressgw_snat2")
 int egressgw_snat2_setup_v6(struct __ctx_buff *ctx)
 {
 	set_identity_mark(ctx, CLIENT_IDENTITY, MARK_MAGIC_EGW_DONE);
@@ -445,7 +445,7 @@ int egressgw_snat2_setup_v6(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_v6_egressgw_snat2")
+CHECK(PROG_TYPE, "tc_v6_egressgw_snat2")
 int egressgw_snat2_check_v6(struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -466,7 +466,7 @@ int egressgw_snat2_check_v6(struct __ctx_buff *ctx)
  * gets correctly SNATed with the desired egress IP of the policy, even if the
  * packet hits a stale NAT entry (IPv6).
  */
-PKTGEN("tc", "tc_v6_egressgw_tuple_collision1")
+PKTGEN(PROG_TYPE, "tc_v6_egressgw_tuple_collision1")
 int egressgw_tuple_collision1_pktgen_v6(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
@@ -474,7 +474,7 @@ int egressgw_tuple_collision1_pktgen_v6(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_v6_egressgw_tuple_collision1")
+SETUP(PROG_TYPE, "tc_v6_egressgw_tuple_collision1")
 int egressgw_tuple_collision1_setup_v6(struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -490,7 +490,7 @@ int egressgw_tuple_collision1_setup_v6(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_v6_egressgw_tuple_collision1")
+CHECK(PROG_TYPE, "tc_v6_egressgw_tuple_collision1")
 int egressgw_tuple_collision1_check_v6(const struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -507,7 +507,7 @@ int egressgw_tuple_collision1_check_v6(const struct __ctx_buff *ctx)
 	return ret;
 }
 
-PKTGEN("tc", "tc_v6_egressgw_tuple_collision2")
+PKTGEN(PROG_TYPE, "tc_v6_egressgw_tuple_collision2")
 int egressgw_tuple_collision2_pktgen_v6(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
@@ -515,7 +515,7 @@ int egressgw_tuple_collision2_pktgen_v6(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_v6_egressgw_tuple_collision2")
+SETUP(PROG_TYPE, "tc_v6_egressgw_tuple_collision2")
 int egressgw_tuple_collision2_setup_v6(struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -531,7 +531,7 @@ int egressgw_tuple_collision2_setup_v6(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_v6_egressgw_tuple_collision2")
+CHECK(PROG_TYPE, "tc_v6_egressgw_tuple_collision2")
 int egressgw_tuple_collision2_check_v6(const struct __ctx_buff *ctx)
 {
 	return egressgw_snat_check_v6(ctx, (struct egressgw_test_ctx) {
@@ -546,7 +546,7 @@ int egressgw_tuple_collision2_check_v6(const struct __ctx_buff *ctx)
  * gets correctly revSNATed and connection tracked, even if the packet hits a
  * stale NAT entry (IPv6).
  */
-PKTGEN("tc", "tc_v6_egressgw_tuple_collision2_reply")
+PKTGEN(PROG_TYPE, "tc_v6_egressgw_tuple_collision2_reply")
 int egressgw_tuple_collision2_reply_pktgen_v6(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
@@ -556,7 +556,7 @@ int egressgw_tuple_collision2_reply_pktgen_v6(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_v6_egressgw_tuple_collision2_reply")
+SETUP(PROG_TYPE, "tc_v6_egressgw_tuple_collision2_reply")
 int egressgw_tuple_collision2_reply_setup_v6(struct __ctx_buff *ctx)
 {
 	union v6addr client_ip = CLIENT_IP_V6;
@@ -567,7 +567,7 @@ int egressgw_tuple_collision2_reply_setup_v6(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_v6_egressgw_tuple_collision2_reply")
+CHECK(PROG_TYPE, "tc_v6_egressgw_tuple_collision2_reply")
 int egressgw_tuple_collision2_reply_check_v6(const struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -588,7 +588,7 @@ int egressgw_tuple_collision2_reply_check_v6(const struct __ctx_buff *ctx)
 /* Test that a packet matching an excluded CIDR egress gateway policy on the
  * to-netdev program does not get SNATed with the egress IP of the policy (IPv6).
  */
-PKTGEN("tc", "tc_v6_egressgw_skip_excluded_cidr_snat")
+PKTGEN(PROG_TYPE, "tc_v6_egressgw_skip_excluded_cidr_snat")
 int egressgw_skip_excluded_cidr_snat_pktgen_v6(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen_v6(ctx, (struct egressgw_test_ctx) {
@@ -596,7 +596,7 @@ int egressgw_skip_excluded_cidr_snat_pktgen_v6(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("tc", "tc_v6_egressgw_skip_excluded_cidr_snat")
+SETUP(PROG_TYPE, "tc_v6_egressgw_skip_excluded_cidr_snat")
 int egressgw_skip_excluded_cidr_snat_setup_v6(struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -612,7 +612,7 @@ int egressgw_skip_excluded_cidr_snat_setup_v6(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_v6_egressgw_skip_excluded_cidr_snat")
+CHECK(PROG_TYPE, "tc_v6_egressgw_skip_excluded_cidr_snat")
 int egressgw_skip_excluded_cidr_snat_check_v6(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/tc_geneve_dsr_legacy.c
+++ b/bpf/tests/tc_geneve_dsr_legacy.c
@@ -75,7 +75,7 @@ int mock_skb_get_tunnel_key(__maybe_unused struct __sk_buff *skb,
 	return 0;
 }
 
-PKTGEN("tc", "tc_geneve_dsr_v4_legacy")
+PKTGEN(PROG_TYPE, "tc_geneve_dsr_v4_legacy")
 int tc_geneve_dsr_v4_legacy_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -102,7 +102,7 @@ int tc_geneve_dsr_v4_legacy_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_geneve_dsr_v4_legacy")
+SETUP(PROG_TYPE, "tc_geneve_dsr_v4_legacy")
 int tc_geneve_dsr_v4_legacy_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v4_add_entry(BACKEND_IP, 0, 0, 0, 0, 0, NULL, NULL);
@@ -111,7 +111,7 @@ int tc_geneve_dsr_v4_legacy_setup(struct __ctx_buff *ctx)
 	return overlay_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_geneve_dsr_v4_legacy")
+CHECK(PROG_TYPE, "tc_geneve_dsr_v4_legacy")
 int tc_geneve_dsr_v4_legacy_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -153,7 +153,7 @@ int tc_geneve_dsr_v4_legacy_check(struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "tc_geneve_dsr_v6_legacy")
+PKTGEN(PROG_TYPE, "tc_geneve_dsr_v6_legacy")
 int tc_geneve_dsr_v6_legacy_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -182,7 +182,7 @@ int tc_geneve_dsr_v6_legacy_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_geneve_dsr_v6_legacy")
+SETUP(PROG_TYPE, "tc_geneve_dsr_v6_legacy")
 int tc_geneve_dsr_v6_legacy_setup(struct __ctx_buff *ctx)
 {
 	union v6addr backend_ip = BACKEND_IPV6;
@@ -194,7 +194,7 @@ int tc_geneve_dsr_v6_legacy_setup(struct __ctx_buff *ctx)
 	return overlay_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_geneve_dsr_v6_legacy")
+CHECK(PROG_TYPE, "tc_geneve_dsr_v6_legacy")
 int tc_geneve_dsr_v6_legacy_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/tc_l2_announcement.c
+++ b/bpf/tests/tc_l2_announcement.c
@@ -53,7 +53,7 @@ static __always_inline int build_packet(struct __ctx_buff *ctx)
 	return 0;
 }
 
-PKTGEN("tc", "0_no_entry")
+PKTGEN(PROG_TYPE, "0_no_entry")
 int l2_announcement_arp_no_entry_pktgen(struct __ctx_buff *ctx)
 {
 	return build_packet(ctx);
@@ -61,13 +61,13 @@ int l2_announcement_arp_no_entry_pktgen(struct __ctx_buff *ctx)
 
 /* Test that sending a ARP broadcast request without entries in the map.
  */
-SETUP("tc", "0_no_entry")
+SETUP(PROG_TYPE, "0_no_entry")
 int l2_announcement_arp_no_entry_setup(struct __ctx_buff *ctx)
 {
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "0_no_entry")
+CHECK(PROG_TYPE, "0_no_entry")
 int l2_announcement_arp_no_entry_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data;
@@ -93,7 +93,7 @@ int l2_announcement_arp_no_entry_check(__maybe_unused const struct __ctx_buff *c
 
 }
 
-PKTGEN("tc", "1_happy_path")
+PKTGEN(PROG_TYPE, "1_happy_path")
 int l2_announcement_arp_happy_path_pktgen(struct __ctx_buff *ctx)
 {
 	return build_packet(ctx);
@@ -102,7 +102,7 @@ int l2_announcement_arp_happy_path_pktgen(struct __ctx_buff *ctx)
 /* Test that sending a ARP broadcast request matching an entry in
  * cilium_l2_responder_v4 results in a valid ARP reply.
  */
-SETUP("tc", "1_happy_path")
+SETUP(PROG_TYPE, "1_happy_path")
 int l2_announcement_arp_happy_path_setup(struct __ctx_buff *ctx)
 {
 	struct l2_responder_v4_key key;
@@ -117,7 +117,7 @@ int l2_announcement_arp_happy_path_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "1_happy_path")
+CHECK(PROG_TYPE, "1_happy_path")
 int l2_announcement_arp_happy_path_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data;

--- a/bpf/tests/tc_l2_announcement6.c
+++ b/bpf/tests/tc_l2_announcement6.c
@@ -75,19 +75,19 @@ static __always_inline int build_packet(struct __ctx_buff *ctx, bool targeted)
 	return 0;
 }
 
-PKTGEN("tc", "0_no_entry")
+PKTGEN(PROG_TYPE, "0_no_entry")
 int l2_announcement_nd_no_entry_pktgen(struct __ctx_buff *ctx)
 {
 	return build_packet(ctx, false);
 }
 
-SETUP("tc", "0_no_entry")
+SETUP(PROG_TYPE, "0_no_entry")
 int l2_announcement_nd_no_entry_setup(struct __ctx_buff *ctx)
 {
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "0_no_entry")
+CHECK(PROG_TYPE, "0_no_entry")
 int l2_announcement_nd_no_entry_check(const struct __ctx_buff *ctx)
 {
 	void *data;
@@ -114,19 +114,19 @@ int l2_announcement_nd_no_entry_check(const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "0_no_entry_targeted")
+PKTGEN(PROG_TYPE, "0_no_entry_targeted")
 int l2_announcement_nd_no_entry_tar_pktgen(struct __ctx_buff *ctx)
 {
 	return build_packet(ctx, true);
 }
 
-SETUP("tc", "0_no_entry_targeted")
+SETUP(PROG_TYPE, "0_no_entry_targeted")
 int l2_announcement_nd_no_entry_tar_setup(struct __ctx_buff *ctx)
 {
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "0_no_entry_targeted")
+CHECK(PROG_TYPE, "0_no_entry_targeted")
 int l2_announcement_nd_no_entry_tar_check(const struct __ctx_buff *ctx)
 {
 	void *data;
@@ -153,7 +153,7 @@ int l2_announcement_nd_no_entry_tar_check(const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "1_ok")
+PKTGEN(PROG_TYPE, "1_ok")
 int l2_announcement_nd_ok_pktgen(struct __ctx_buff *ctx)
 {
 	return build_packet(ctx, false);
@@ -174,13 +174,13 @@ int __l2_announcement_nd_ok_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-SETUP("tc", "1_ok")
+SETUP(PROG_TYPE, "1_ok")
 int l2_announcement_nd_ok_setup(struct __ctx_buff *ctx)
 {
 	return __l2_announcement_nd_ok_setup(ctx);
 }
 
-CHECK("tc", "1_ok")
+CHECK(PROG_TYPE, "1_ok")
 int l2_announcement_nd_ok_check(const struct __ctx_buff *ctx)
 {
 	void *data;
@@ -207,19 +207,19 @@ int l2_announcement_nd_ok_check(const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "1_ok_targeted")
+PKTGEN(PROG_TYPE, "1_ok_targeted")
 int l2_announcement_nd_ok_tar_pktgen(struct __ctx_buff *ctx)
 {
 	return build_packet(ctx, true);
 }
 
-SETUP("tc", "1_ok_targeted")
+SETUP(PROG_TYPE, "1_ok_targeted")
 int l2_announcement_nd_ok_tar_setup(struct __ctx_buff *ctx)
 {
 	return __l2_announcement_nd_ok_setup(ctx);
 }
 
-CHECK("tc", "1_ok_targeted")
+CHECK(PROG_TYPE, "1_ok_targeted")
 int l2_announcement_nd_ok_tar_check(const struct __ctx_buff *ctx)
 {
 	void *data;

--- a/bpf/tests/tc_lb_clusterip.c
+++ b/bpf/tests/tc_lb_clusterip.c
@@ -62,7 +62,7 @@ const __u8 lb6_clusterip_post_dnat[] = {
  * leading to the datapath dropping the packet with the reason code
  * DROP_IS_CLUSTER_IP, and the respective BPF metric updated accordingly.
  */
-PKTGEN("tc", "tc_lb4_nonroutable_clusterip")
+PKTGEN(PROG_TYPE, "tc_lb4_nonroutable_clusterip")
 int lb4_nonroutable_clusterip_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -76,7 +76,7 @@ int lb4_nonroutable_clusterip_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lb4_nonroutable_clusterip")
+SETUP(PROG_TYPE, "tc_lb4_nonroutable_clusterip")
 int lb4_nonroutable_clusterip_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v4_add_entry(BACKEND_IP, BACKEND_IFINDEX, 0, 0, 0, 0,
@@ -90,7 +90,7 @@ int lb4_nonroutable_clusterip_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_lb4_nonroutable_clusterip")
+CHECK(PROG_TYPE, "tc_lb4_nonroutable_clusterip")
 int lb4_nonroutable_clusterip_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -127,7 +127,7 @@ int lb4_nonroutable_clusterip_check(__maybe_unused const struct __ctx_buff *ctx)
  * is allowed. The reason is due to the SVC being created with the SVC_FLAG_ROUTABLE
  * flag set, leading to the datapath correctly accepting and DNAT the packet.
  */
-PKTGEN("tc", "tc_lb4_routable_clusterip")
+PKTGEN(PROG_TYPE, "tc_lb4_routable_clusterip")
 int lb4_routable_clusterip_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -141,7 +141,7 @@ int lb4_routable_clusterip_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lb4_routable_clusterip")
+SETUP(PROG_TYPE, "tc_lb4_routable_clusterip")
 int lb4_routable_clusterip_setup(struct __ctx_buff *ctx)
 {
 	/* Endpoint and backend added in previous setup, simply change SVC flags. */
@@ -152,7 +152,7 @@ int lb4_routable_clusterip_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_lb4_routable_clusterip")
+CHECK(PROG_TYPE, "tc_lb4_routable_clusterip")
 int lb4_routable_clusterip_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -195,7 +195,7 @@ int lb4_routable_clusterip_check(__maybe_unused const struct __ctx_buff *ctx)
  * leading to the datapath dropping the packet with the reason code
  * DROP_IS_CLUSTER_IP, and the respective BPF metric updated accordingly.
  */
-PKTGEN("tc", "tc_lb6_nonroutable_clusterip")
+PKTGEN(PROG_TYPE, "tc_lb6_nonroutable_clusterip")
 int lb6_nonroutable_clusterip_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -209,7 +209,7 @@ int lb6_nonroutable_clusterip_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lb6_nonroutable_clusterip")
+SETUP(PROG_TYPE, "tc_lb6_nonroutable_clusterip")
 int lb6_nonroutable_clusterip_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v6_add_entry((union v6addr *)BACKEND_IPV6, BACKEND_IFINDEX, 0, 0, 0,
@@ -223,7 +223,7 @@ int lb6_nonroutable_clusterip_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_lb6_nonroutable_clusterip")
+CHECK(PROG_TYPE, "tc_lb6_nonroutable_clusterip")
 int lb6_nonroutable_clusterip_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -260,7 +260,7 @@ int lb6_nonroutable_clusterip_check(__maybe_unused const struct __ctx_buff *ctx)
  * is allowed. The reason is due to the SVC being created with the SVC_FLAG_ROUTABLE
  * flag set, leading to the datapath correctly accepting and DNAT the packet.
  */
-PKTGEN("tc", "tc_lb6_routable_clusterip")
+PKTGEN(PROG_TYPE, "tc_lb6_routable_clusterip")
 int lb6_routable_clusterip_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -274,7 +274,7 @@ int lb6_routable_clusterip_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lb6_routable_clusterip")
+SETUP(PROG_TYPE, "tc_lb6_routable_clusterip")
 int lb6_routable_clusterip_setup(struct __ctx_buff *ctx)
 {
 	/* Endpoint and backend added in previous setup, simply change SVC flags. */
@@ -285,7 +285,7 @@ int lb6_routable_clusterip_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_lb6_routable_clusterip")
+CHECK(PROG_TYPE, "tc_lb6_routable_clusterip")
 int lb6_routable_clusterip_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/tc_lb_external_ips.h
+++ b/bpf/tests/tc_lb_external_ips.h
@@ -105,7 +105,7 @@ const __u8 lb6_ew_external_ip[] = {
  * - For East-West traffic, the packet should be dropped and no conntrack entry
  *   should be created for the connection.
  */
-PKTGEN("tc", "tc_lb4_external_ips")
+PKTGEN(PROG_TYPE, "tc_lb4_external_ips")
 int lb4_external_ips_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -123,7 +123,7 @@ int lb4_external_ips_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lb4_external_ips")
+SETUP(PROG_TYPE, "tc_lb4_external_ips")
 int lb4_external_ips_setup(struct __ctx_buff *ctx)
 {
 	policy_add_egress_allow_all_entry();
@@ -140,7 +140,7 @@ int lb4_external_ips_setup(struct __ctx_buff *ctx)
 	return HOOK(ctx);
 }
 
-CHECK("tc", "tc_lb4_external_ips")
+CHECK(PROG_TYPE, "tc_lb4_external_ips")
 int lb4_external_ips_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -200,7 +200,7 @@ int lb4_external_ips_check(__maybe_unused const struct __ctx_buff *ctx)
  * - For East-West traffic, the packet should be dropped and no conntrack entry
  *   should be created for the connection.
  */
-PKTGEN("tc", "tc_lb6_external_ips")
+PKTGEN(PROG_TYPE, "tc_lb6_external_ips")
 int lb6_external_ips_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -218,7 +218,7 @@ int lb6_external_ips_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lb6_external_ips")
+SETUP(PROG_TYPE, "tc_lb6_external_ips")
 int lb6_external_ips_setup(struct __ctx_buff *ctx)
 {
 	policy_add_egress_allow_all_entry();
@@ -235,7 +235,7 @@ int lb6_external_ips_setup(struct __ctx_buff *ctx)
 	return HOOK(ctx);
 }
 
-CHECK("tc", "tc_lb6_external_ips")
+CHECK(PROG_TYPE, "tc_lb6_external_ips")
 int lb6_external_ips_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/tc_lb_no_backend_nonroutable.c
+++ b/bpf/tests/tc_lb_no_backend_nonroutable.c
@@ -63,7 +63,7 @@ static __always_inline int build_packet(struct __ctx_buff *ctx,
 }
 
 /* Test that a packet for a SVC without any backend does not get dropped (enable_no_endpoints_routable=false). */
-SETUP("tc", "tc_lb_no_backend_nonroutable")
+SETUP(PROG_TYPE, "tc_lb_no_backend_nonroutable")
 int tc_lb_no_backend_nonroutable_setup(struct __ctx_buff *ctx)
 {
 	int ret;
@@ -81,7 +81,7 @@ int tc_lb_no_backend_nonroutable_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "tc_lb_no_backend_nonroutable")
+CHECK(PROG_TYPE, "tc_lb_no_backend_nonroutable")
 int tc_lb_no_backend_nonroutable_check(const struct __ctx_buff *ctx)
 {
 	__u32 expected_status = TC_ACT_OK;
@@ -106,7 +106,7 @@ int tc_lb_no_backend_nonroutable_check(const struct __ctx_buff *ctx)
 }
 
 /* Test that a packet for a SVC without any backend with eTP=Local gets dropped. */
-SETUP("tc", "tc_lb_no_backend_nonroutable_etp")
+SETUP(PROG_TYPE, "tc_lb_no_backend_nonroutable_etp")
 int tc_lb_no_backend_nonroutable_etp_setup(struct __ctx_buff *ctx)
 {
 	int ret;
@@ -124,7 +124,7 @@ int tc_lb_no_backend_nonroutable_etp_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "tc_lb_no_backend_nonroutable_etp")
+CHECK(PROG_TYPE, "tc_lb_no_backend_nonroutable_etp")
 int tc_lb_no_backend_nonroutable_etp_check(const struct __ctx_buff *ctx)
 {
 	__u32 expected_status = TC_ACT_SHOT;

--- a/bpf/tests/tc_lxc_lb_hostport.c
+++ b/bpf/tests/tc_lxc_lb_hostport.c
@@ -78,7 +78,7 @@ ASSIGN_CONFIG(union v6addr, endpoint_ipv6, { .addr = v6_pod_one_addr })
  * - Port is outside NodePort range so NodePort wildcard lookup misses
  * - HostPort wildcard lookup should match and perform DNAT
  */
-PKTGEN("tc", "tc_lxc_v4_host_hostport_local_backend")
+PKTGEN(PROG_TYPE, "tc_lxc_v4_host_hostport_local_backend")
 int lxc_v4_host_hostport_local_backend_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -103,7 +103,7 @@ int lxc_v4_host_hostport_local_backend_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lxc_v4_host_hostport_local_backend")
+SETUP(PROG_TYPE, "tc_lxc_v4_host_hostport_local_backend")
 int lxc_v4_host_hostport_local_backend_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -123,7 +123,7 @@ int lxc_v4_host_hostport_local_backend_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "tc_lxc_v4_host_hostport_local_backend")
+CHECK(PROG_TYPE, "tc_lxc_v4_host_hostport_local_backend")
 int lxc_v4_host_hostport_local_backend_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -197,7 +197,7 @@ int lxc_v4_host_hostport_local_backend_check(const struct __ctx_buff *ctx)
  * - HostPort wildcard lookup should NOT match (port in NodePort range is rejected)
  * - Packet should pass through without DNAT
  */
-PKTGEN("tc", "tc_lxc_v4_hostport_nodeport_range_no_match")
+PKTGEN(PROG_TYPE, "tc_lxc_v4_hostport_nodeport_range_no_match")
 int lxc_v4_hostport_nodeport_range_no_match_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -223,7 +223,7 @@ int lxc_v4_hostport_nodeport_range_no_match_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lxc_v4_hostport_nodeport_range_no_match")
+SETUP(PROG_TYPE, "tc_lxc_v4_hostport_nodeport_range_no_match")
 int lxc_v4_hostport_nodeport_range_no_match_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 2;
@@ -246,7 +246,7 @@ int lxc_v4_hostport_nodeport_range_no_match_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "tc_lxc_v4_hostport_nodeport_range_no_match")
+CHECK(PROG_TYPE, "tc_lxc_v4_hostport_nodeport_range_no_match")
 int lxc_v4_hostport_nodeport_range_no_match_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -298,7 +298,7 @@ int lxc_v4_hostport_nodeport_range_no_match_check(const struct __ctx_buff *ctx)
  * - Port is outside NodePort range so NodePort wildcard lookup misses
  * - HostPort wildcard lookup should match and perform DNAT
  */
-PKTGEN("tc", "tc_lxc_v6_host_hostport_local_backend")
+PKTGEN(PROG_TYPE, "tc_lxc_v6_host_hostport_local_backend")
 int lxc_v6_host_hostport_local_backend_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -323,7 +323,7 @@ int lxc_v6_host_hostport_local_backend_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lxc_v6_host_hostport_local_backend")
+SETUP(PROG_TYPE, "tc_lxc_v6_host_hostport_local_backend")
 int lxc_v6_host_hostport_local_backend_setup(struct __ctx_buff *ctx)
 {
 	union v6addr host_node_ip = {};
@@ -349,7 +349,7 @@ int lxc_v6_host_hostport_local_backend_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "tc_lxc_v6_host_hostport_local_backend")
+CHECK(PROG_TYPE, "tc_lxc_v6_host_hostport_local_backend")
 int lxc_v6_host_hostport_local_backend_check(const struct __ctx_buff *ctx)
 {
 	union v6addr host_node_ip = {};
@@ -430,7 +430,7 @@ int lxc_v6_host_hostport_local_backend_check(const struct __ctx_buff *ctx)
  * - HostPort wildcard lookup should NOT match (port in NodePort range is rejected)
  * - Packet should pass through without DNAT
  */
-PKTGEN("tc", "tc_lxc_v6_hostport_nodeport_range_no_match")
+PKTGEN(PROG_TYPE, "tc_lxc_v6_hostport_nodeport_range_no_match")
 int lxc_v6_hostport_nodeport_range_no_match_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -456,7 +456,7 @@ int lxc_v6_hostport_nodeport_range_no_match_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lxc_v6_hostport_nodeport_range_no_match")
+SETUP(PROG_TYPE, "tc_lxc_v6_hostport_nodeport_range_no_match")
 int lxc_v6_hostport_nodeport_range_no_match_setup(struct __ctx_buff *ctx)
 {
 	union v6addr host_node_ip = {};
@@ -485,7 +485,7 @@ int lxc_v6_hostport_nodeport_range_no_match_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "tc_lxc_v6_hostport_nodeport_range_no_match")
+CHECK(PROG_TYPE, "tc_lxc_v6_hostport_nodeport_range_no_match")
 int lxc_v6_hostport_nodeport_range_no_match_check(const struct __ctx_buff *ctx)
 {
 	union v6addr host_node_ip = {};

--- a/bpf/tests/tc_lxc_lb_no_backend.c
+++ b/bpf/tests/tc_lxc_lb_no_backend.c
@@ -33,7 +33,7 @@ ASSIGN_CONFIG(bool, enable_no_service_endpoints_routable, true)
 #include "lib/lb.h"
 
 /* Test that a SVC without backends returns a TCP RST or ICMP error */
-PKTGEN("tc", "tc_lxc4_no_backend")
+PKTGEN(PROG_TYPE, "tc_lxc4_no_backend")
 int lxc4_no_backend_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -60,7 +60,7 @@ int lxc4_no_backend_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lxc4_no_backend")
+SETUP(PROG_TYPE, "tc_lxc4_no_backend")
 int lxc4_no_backend_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -72,7 +72,7 @@ int lxc4_no_backend_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "tc_lxc4_no_backend")
+CHECK(PROG_TYPE, "tc_lxc4_no_backend")
 int lxc4_no_backend_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -132,7 +132,7 @@ int lxc4_no_backend_check(__maybe_unused const struct __ctx_buff *ctx)
 }
 
 /* Test that a SVC without backends returns a TCP RST or ICMP error */
-PKTGEN("tc", "tc_lxc6_no_backend")
+PKTGEN(PROG_TYPE, "tc_lxc6_no_backend")
 int lxc6_no_backend_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -160,7 +160,7 @@ int lxc6_no_backend_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lxc6_no_backend")
+SETUP(PROG_TYPE, "tc_lxc6_no_backend")
 int lxc6_no_backend_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 2;
@@ -180,7 +180,7 @@ int lxc6_no_backend_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "tc_lxc6_no_backend")
+CHECK(PROG_TYPE, "tc_lxc6_no_backend")
 int lxc6_no_backend_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/tc_lxc_lb_nodeport.c
+++ b/bpf/tests/tc_lxc_lb_nodeport.c
@@ -86,7 +86,7 @@ ASSIGN_CONFIG(union v6addr, endpoint_ipv6, { .addr = v6_pod_one_addr })
  * - Connection tracking entry should be created with
  * - nat_addr = REMOTE_NODE_IP and nat_port = NODEPORT_PORT
  */
-PKTGEN("tc", "tc_lxc_v4_remote_nodeport_local_backend")
+PKTGEN(PROG_TYPE, "tc_lxc_v4_remote_nodeport_local_backend")
 int lxc_v4_remote_nodeport_local_backend_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -111,7 +111,7 @@ int lxc_v4_remote_nodeport_local_backend_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lxc_v4_remote_nodeport_local_backend")
+SETUP(PROG_TYPE, "tc_lxc_v4_remote_nodeport_local_backend")
 int lxc_v4_remote_nodeport_local_backend_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -131,7 +131,7 @@ int lxc_v4_remote_nodeport_local_backend_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "tc_lxc_v4_remote_nodeport_local_backend")
+CHECK(PROG_TYPE, "tc_lxc_v4_remote_nodeport_local_backend")
 int lxc_v4_remote_nodeport_local_backend_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -207,7 +207,7 @@ int lxc_v4_remote_nodeport_local_backend_check(const struct __ctx_buff *ctx)
  * - Client pod's cil_to_container receives it
  * - RevNAT applied: src IP/port changed to REMOTE_NODE_IP:NODEPORT_PORT
  */
-PKTGEN("tc", "tc_lxc_v4_remote_nodeport_local_backend_reply")
+PKTGEN(PROG_TYPE, "tc_lxc_v4_remote_nodeport_local_backend_reply")
 int lxc_v4_remote_nodeport_local_backend_reply_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -232,7 +232,7 @@ int lxc_v4_remote_nodeport_local_backend_reply_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lxc_v4_remote_nodeport_local_backend_reply")
+SETUP(PROG_TYPE, "tc_lxc_v4_remote_nodeport_local_backend_reply")
 int lxc_v4_remote_nodeport_local_backend_reply_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v4_add_entry(CLIENT_IP, BACKEND_IFACE, BACKEND_EP_ID, 0, 0, 0,
@@ -241,7 +241,7 @@ int lxc_v4_remote_nodeport_local_backend_reply_setup(struct __ctx_buff *ctx)
 	return pod_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_lxc_v4_remote_nodeport_local_backend_reply")
+CHECK(PROG_TYPE, "tc_lxc_v4_remote_nodeport_local_backend_reply")
 int lxc_v4_remote_nodeport_local_backend_reply_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -299,7 +299,7 @@ int lxc_v4_remote_nodeport_local_backend_reply_check(const struct __ctx_buff *ct
  * - Connection tracking entry should be created with
  * - nat_addr = REMOTE_NODE_IP and nat_port = NODEPORT_PORT_DSR
  */
-PKTGEN("tc", "tc_lxc_v4_remote_nodeport_dsr_local_backend")
+PKTGEN(PROG_TYPE, "tc_lxc_v4_remote_nodeport_dsr_local_backend")
 int lxc_v4_remote_nodeport_dsr_local_backend_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -324,7 +324,7 @@ int lxc_v4_remote_nodeport_dsr_local_backend_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lxc_v4_remote_nodeport_dsr_local_backend")
+SETUP(PROG_TYPE, "tc_lxc_v4_remote_nodeport_dsr_local_backend")
 int lxc_v4_remote_nodeport_dsr_local_backend_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 2;
@@ -345,7 +345,7 @@ int lxc_v4_remote_nodeport_dsr_local_backend_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "tc_lxc_v4_remote_nodeport_dsr_local_backend")
+CHECK(PROG_TYPE, "tc_lxc_v4_remote_nodeport_dsr_local_backend")
 int lxc_v4_remote_nodeport_dsr_local_backend_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -421,7 +421,7 @@ int lxc_v4_remote_nodeport_dsr_local_backend_check(const struct __ctx_buff *ctx)
  * - Client pod's cil_to_container receives it
  * - RevNAT applied: src IP/port changed to REMOTE_NODE_IP:NODEPORT_PORT_DSR
  */
-PKTGEN("tc", "tc_lxc_v4_remote_nodeport_dsr_local_backend_reply")
+PKTGEN(PROG_TYPE, "tc_lxc_v4_remote_nodeport_dsr_local_backend_reply")
 int lxc_v4_remote_nodeport_dsr_local_backend_reply_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -446,7 +446,7 @@ int lxc_v4_remote_nodeport_dsr_local_backend_reply_pktgen(struct __ctx_buff *ctx
 	return 0;
 }
 
-SETUP("tc", "tc_lxc_v4_remote_nodeport_dsr_local_backend_reply")
+SETUP(PROG_TYPE, "tc_lxc_v4_remote_nodeport_dsr_local_backend_reply")
 int lxc_v4_remote_nodeport_dsr_local_backend_reply_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v4_add_entry(CLIENT_IP, BACKEND_IFACE, BACKEND_EP_ID, 0, 0, 0,
@@ -455,7 +455,7 @@ int lxc_v4_remote_nodeport_dsr_local_backend_reply_setup(struct __ctx_buff *ctx)
 	return pod_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_lxc_v4_remote_nodeport_dsr_local_backend_reply")
+CHECK(PROG_TYPE, "tc_lxc_v4_remote_nodeport_dsr_local_backend_reply")
 int lxc_v4_remote_nodeport_dsr_local_backend_reply_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -512,7 +512,7 @@ int lxc_v4_remote_nodeport_dsr_local_backend_reply_check(const struct __ctx_buff
  * - Packet should be DNATed to CLIENT_IP:BACKEND_PORT
  * - Source should be SNATed to loopback IP to avoid routing issues
  */
-PKTGEN("tc", "tc_lxc_v4_remote_nodeport_hairpin")
+PKTGEN(PROG_TYPE, "tc_lxc_v4_remote_nodeport_hairpin")
 int lxc_v4_remote_nodeport_hairpin_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -537,7 +537,7 @@ int lxc_v4_remote_nodeport_hairpin_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lxc_v4_remote_nodeport_hairpin")
+SETUP(PROG_TYPE, "tc_lxc_v4_remote_nodeport_hairpin")
 int lxc_v4_remote_nodeport_hairpin_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 3;
@@ -557,7 +557,7 @@ int lxc_v4_remote_nodeport_hairpin_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "tc_lxc_v4_remote_nodeport_hairpin")
+CHECK(PROG_TYPE, "tc_lxc_v4_remote_nodeport_hairpin")
 int lxc_v4_remote_nodeport_hairpin_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -629,7 +629,7 @@ int lxc_v4_remote_nodeport_hairpin_check(const struct __ctx_buff *ctx)
  * - After hairpin, the pod replies to loopback IP
  * - RevNAT applied: src IP/port changed to REMOTE_NODE_IP:NODEPORT_PORT_HAIRPIN
  */
-PKTGEN("tc", "tc_lxc_v4_remote_nodeport_hairpin_reply")
+PKTGEN(PROG_TYPE, "tc_lxc_v4_remote_nodeport_hairpin_reply")
 int lxc_v4_remote_nodeport_hairpin_reply_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -655,7 +655,7 @@ int lxc_v4_remote_nodeport_hairpin_reply_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lxc_v4_remote_nodeport_hairpin_reply")
+SETUP(PROG_TYPE, "tc_lxc_v4_remote_nodeport_hairpin_reply")
 int lxc_v4_remote_nodeport_hairpin_reply_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v4_add_entry(CLIENT_IP, BACKEND_IFACE, BACKEND_EP_ID, 0, 0, 0,
@@ -664,7 +664,7 @@ int lxc_v4_remote_nodeport_hairpin_reply_setup(struct __ctx_buff *ctx)
 	return pod_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_lxc_v4_remote_nodeport_hairpin_reply")
+CHECK(PROG_TYPE, "tc_lxc_v4_remote_nodeport_hairpin_reply")
 int lxc_v4_remote_nodeport_hairpin_reply_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -721,7 +721,7 @@ int lxc_v4_remote_nodeport_hairpin_reply_check(const struct __ctx_buff *ctx)
  * - Packet should NOT be DNATed (goes to remote node directly)
  * - CT entry is created for this connection
  */
-PKTGEN("tc", "tc_lxc_v4_existing_conn_udp_first")
+PKTGEN(PROG_TYPE, "tc_lxc_v4_existing_conn_udp_first")
 int lxc_v4_existing_conn_udp_first_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -746,7 +746,7 @@ int lxc_v4_existing_conn_udp_first_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lxc_v4_existing_conn_udp_first")
+SETUP(PROG_TYPE, "tc_lxc_v4_existing_conn_udp_first")
 int lxc_v4_existing_conn_udp_first_setup(struct __ctx_buff *ctx)
 {
 	ipcache_v4_add_entry(REMOTE_NODE_IP, 0, REMOTE_NODE_ID, 0, 0);
@@ -756,7 +756,7 @@ int lxc_v4_existing_conn_udp_first_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "tc_lxc_v4_existing_conn_udp_first")
+CHECK(PROG_TYPE, "tc_lxc_v4_existing_conn_udp_first")
 int lxc_v4_existing_conn_udp_first_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -826,7 +826,7 @@ int lxc_v4_existing_conn_udp_first_check(const struct __ctx_buff *ctx)
  * - Packet should still NOT be DNATed because CT entry already exists
  * - This verifies the CT check prevents wildcard lookup for existing connections
  */
-PKTGEN("tc", "tc_lxc_v4_existing_conn_udp_second")
+PKTGEN(PROG_TYPE, "tc_lxc_v4_existing_conn_udp_second")
 int lxc_v4_existing_conn_udp_second_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -852,7 +852,7 @@ int lxc_v4_existing_conn_udp_second_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lxc_v4_existing_conn_udp_second")
+SETUP(PROG_TYPE, "tc_lxc_v4_existing_conn_udp_second")
 int lxc_v4_existing_conn_udp_second_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 10;
@@ -867,7 +867,7 @@ int lxc_v4_existing_conn_udp_second_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "tc_lxc_v4_existing_conn_udp_second")
+CHECK(PROG_TYPE, "tc_lxc_v4_existing_conn_udp_second")
 int lxc_v4_existing_conn_udp_second_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -928,7 +928,7 @@ int lxc_v4_existing_conn_udp_second_check(const struct __ctx_buff *ctx)
  * - Wildcard NodePort lookup should match HOST_ID and perform DNAT
  * - Packet should be DNATed to local backend IP and port
  */
-PKTGEN("tc", "tc_lxc_v4_host_nodeport_local_backend")
+PKTGEN(PROG_TYPE, "tc_lxc_v4_host_nodeport_local_backend")
 int lxc_v4_host_nodeport_local_backend_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -953,7 +953,7 @@ int lxc_v4_host_nodeport_local_backend_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lxc_v4_host_nodeport_local_backend")
+SETUP(PROG_TYPE, "tc_lxc_v4_host_nodeport_local_backend")
 int lxc_v4_host_nodeport_local_backend_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 11;
@@ -973,7 +973,7 @@ int lxc_v4_host_nodeport_local_backend_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "tc_lxc_v4_host_nodeport_local_backend")
+CHECK(PROG_TYPE, "tc_lxc_v4_host_nodeport_local_backend")
 int lxc_v4_host_nodeport_local_backend_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -1051,7 +1051,7 @@ int lxc_v4_host_nodeport_local_backend_check(const struct __ctx_buff *ctx)
  * - Connection tracking entry should be created with
  * - nat_addr = REMOTE_NODE_IP and nat_port = NODEPORT_PORT
  */
-PKTGEN("tc", "tc_lxc_v6_remote_nodeport_local_backend")
+PKTGEN(PROG_TYPE, "tc_lxc_v6_remote_nodeport_local_backend")
 int lxc_v6_remote_nodeport_local_backend_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -1076,7 +1076,7 @@ int lxc_v6_remote_nodeport_local_backend_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lxc_v6_remote_nodeport_local_backend")
+SETUP(PROG_TYPE, "tc_lxc_v6_remote_nodeport_local_backend")
 int lxc_v6_remote_nodeport_local_backend_setup(struct __ctx_buff *ctx)
 {
 	union v6addr remote_node_ip = {};
@@ -1102,7 +1102,7 @@ int lxc_v6_remote_nodeport_local_backend_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "tc_lxc_v6_remote_nodeport_local_backend")
+CHECK(PROG_TYPE, "tc_lxc_v6_remote_nodeport_local_backend")
 int lxc_v6_remote_nodeport_local_backend_check(const struct __ctx_buff *ctx)
 {
 	union v6addr remote_node_ip = {};
@@ -1183,7 +1183,7 @@ int lxc_v6_remote_nodeport_local_backend_check(const struct __ctx_buff *ctx)
  * - Client pod's cil_to_container receives it
  * - RevNAT applied: src IP/port changed to REMOTE_NODE_IP:NODEPORT_PORT
  */
-PKTGEN("tc", "tc_lxc_v6_remote_nodeport_local_backend_reply")
+PKTGEN(PROG_TYPE, "tc_lxc_v6_remote_nodeport_local_backend_reply")
 int lxc_v6_remote_nodeport_local_backend_reply_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -1208,7 +1208,7 @@ int lxc_v6_remote_nodeport_local_backend_reply_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lxc_v6_remote_nodeport_local_backend_reply")
+SETUP(PROG_TYPE, "tc_lxc_v6_remote_nodeport_local_backend_reply")
 int lxc_v6_remote_nodeport_local_backend_reply_setup(struct __ctx_buff *ctx)
 {
 	union v6addr client_ip = {};
@@ -1221,7 +1221,7 @@ int lxc_v6_remote_nodeport_local_backend_reply_setup(struct __ctx_buff *ctx)
 	return pod_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_lxc_v6_remote_nodeport_local_backend_reply")
+CHECK(PROG_TYPE, "tc_lxc_v6_remote_nodeport_local_backend_reply")
 int lxc_v6_remote_nodeport_local_backend_reply_check(const struct __ctx_buff *ctx)
 {
 	union v6addr remote_node_ip = {};
@@ -1282,7 +1282,7 @@ int lxc_v6_remote_nodeport_local_backend_reply_check(const struct __ctx_buff *ct
  * - Connection tracking entry should be created with
  * - nat_addr = REMOTE_NODE_IP and nat_port = NODEPORT_PORT_DSR
  */
-PKTGEN("tc", "tc_lxc_v6_remote_nodeport_dsr_local_backend")
+PKTGEN(PROG_TYPE, "tc_lxc_v6_remote_nodeport_dsr_local_backend")
 int lxc_v6_remote_nodeport_dsr_local_backend_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -1307,7 +1307,7 @@ int lxc_v6_remote_nodeport_dsr_local_backend_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lxc_v6_remote_nodeport_dsr_local_backend")
+SETUP(PROG_TYPE, "tc_lxc_v6_remote_nodeport_dsr_local_backend")
 int lxc_v6_remote_nodeport_dsr_local_backend_setup(struct __ctx_buff *ctx)
 {
 	union v6addr remote_node_ip = {};
@@ -1334,7 +1334,7 @@ int lxc_v6_remote_nodeport_dsr_local_backend_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "tc_lxc_v6_remote_nodeport_dsr_local_backend")
+CHECK(PROG_TYPE, "tc_lxc_v6_remote_nodeport_dsr_local_backend")
 int lxc_v6_remote_nodeport_dsr_local_backend_check(const struct __ctx_buff *ctx)
 {
 	union v6addr remote_node_ip = {};
@@ -1415,7 +1415,7 @@ int lxc_v6_remote_nodeport_dsr_local_backend_check(const struct __ctx_buff *ctx)
  * - Client pod's cil_to_container receives it
  * - RevNAT applied: src IP/port changed to REMOTE_NODE_IP:NODEPORT_PORT_DSR
  */
-PKTGEN("tc", "tc_lxc_v6_remote_nodeport_dsr_local_backend_reply")
+PKTGEN(PROG_TYPE, "tc_lxc_v6_remote_nodeport_dsr_local_backend_reply")
 int lxc_v6_remote_nodeport_dsr_local_backend_reply_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -1440,7 +1440,7 @@ int lxc_v6_remote_nodeport_dsr_local_backend_reply_pktgen(struct __ctx_buff *ctx
 	return 0;
 }
 
-SETUP("tc", "tc_lxc_v6_remote_nodeport_dsr_local_backend_reply")
+SETUP(PROG_TYPE, "tc_lxc_v6_remote_nodeport_dsr_local_backend_reply")
 int lxc_v6_remote_nodeport_dsr_local_backend_reply_setup(struct __ctx_buff *ctx)
 {
 	union v6addr client_ip = {};
@@ -1453,7 +1453,7 @@ int lxc_v6_remote_nodeport_dsr_local_backend_reply_setup(struct __ctx_buff *ctx)
 	return pod_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_lxc_v6_remote_nodeport_dsr_local_backend_reply")
+CHECK(PROG_TYPE, "tc_lxc_v6_remote_nodeport_dsr_local_backend_reply")
 int lxc_v6_remote_nodeport_dsr_local_backend_reply_check(const struct __ctx_buff *ctx)
 {
 	union v6addr remote_node_ip = {};
@@ -1513,7 +1513,7 @@ int lxc_v6_remote_nodeport_dsr_local_backend_reply_check(const struct __ctx_buff
  * - Packet should be DNATed to CLIENT_IP:BACKEND_PORT
  * - Source should be SNATed to loopback IP to avoid routing issues
  */
-PKTGEN("tc", "tc_lxc_v6_remote_nodeport_hairpin")
+PKTGEN(PROG_TYPE, "tc_lxc_v6_remote_nodeport_hairpin")
 int lxc_v6_remote_nodeport_hairpin_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -1538,7 +1538,7 @@ int lxc_v6_remote_nodeport_hairpin_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lxc_v6_remote_nodeport_hairpin")
+SETUP(PROG_TYPE, "tc_lxc_v6_remote_nodeport_hairpin")
 int lxc_v6_remote_nodeport_hairpin_setup(struct __ctx_buff *ctx)
 {
 	union v6addr remote_node_ip = {};
@@ -1564,7 +1564,7 @@ int lxc_v6_remote_nodeport_hairpin_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "tc_lxc_v6_remote_nodeport_hairpin")
+CHECK(PROG_TYPE, "tc_lxc_v6_remote_nodeport_hairpin")
 int lxc_v6_remote_nodeport_hairpin_check(const struct __ctx_buff *ctx)
 {
 	union v6addr client_ip = {};
@@ -1642,7 +1642,7 @@ int lxc_v6_remote_nodeport_hairpin_check(const struct __ctx_buff *ctx)
  * - After hairpin, the pod replies to loopback IP
  * - RevNAT applied: src IP/port changed to REMOTE_NODE_IP:NODEPORT_PORT_HAIRPIN
  */
-PKTGEN("tc", "tc_lxc_v6_remote_nodeport_hairpin_reply")
+PKTGEN(PROG_TYPE, "tc_lxc_v6_remote_nodeport_hairpin_reply")
 int lxc_v6_remote_nodeport_hairpin_reply_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -1669,7 +1669,7 @@ int lxc_v6_remote_nodeport_hairpin_reply_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lxc_v6_remote_nodeport_hairpin_reply")
+SETUP(PROG_TYPE, "tc_lxc_v6_remote_nodeport_hairpin_reply")
 int lxc_v6_remote_nodeport_hairpin_reply_setup(struct __ctx_buff *ctx)
 {
 	union v6addr client_ip = {};
@@ -1682,7 +1682,7 @@ int lxc_v6_remote_nodeport_hairpin_reply_setup(struct __ctx_buff *ctx)
 	return pod_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_lxc_v6_remote_nodeport_hairpin_reply")
+CHECK(PROG_TYPE, "tc_lxc_v6_remote_nodeport_hairpin_reply")
 int lxc_v6_remote_nodeport_hairpin_reply_check(const struct __ctx_buff *ctx)
 {
 	union v6addr remote_node_ip = {};
@@ -1742,7 +1742,7 @@ int lxc_v6_remote_nodeport_hairpin_reply_check(const struct __ctx_buff *ctx)
  * - Packet should NOT be DNATed (goes to remote node directly)
  * - CT entry is created for this connection
  */
-PKTGEN("tc", "tc_lxc_v6_existing_conn_udp_first")
+PKTGEN(PROG_TYPE, "tc_lxc_v6_existing_conn_udp_first")
 int lxc_v6_existing_conn_udp_first_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -1767,7 +1767,7 @@ int lxc_v6_existing_conn_udp_first_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lxc_v6_existing_conn_udp_first")
+SETUP(PROG_TYPE, "tc_lxc_v6_existing_conn_udp_first")
 int lxc_v6_existing_conn_udp_first_setup(struct __ctx_buff *ctx)
 {
 	/* Add ipcache entry for remote node, but NO NodePort service */
@@ -1778,7 +1778,7 @@ int lxc_v6_existing_conn_udp_first_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "tc_lxc_v6_existing_conn_udp_first")
+CHECK(PROG_TYPE, "tc_lxc_v6_existing_conn_udp_first")
 int lxc_v6_existing_conn_udp_first_check(const struct __ctx_buff *ctx)
 {
 	union v6addr remote_node_ip = {};
@@ -1854,7 +1854,7 @@ int lxc_v6_existing_conn_udp_first_check(const struct __ctx_buff *ctx)
  * - Packet should still NOT be DNATed because CT entry already exists
  * - This verifies the CT check prevents wildcard lookup for existing connections
  */
-PKTGEN("tc", "tc_lxc_v6_existing_conn_udp_second")
+PKTGEN(PROG_TYPE, "tc_lxc_v6_existing_conn_udp_second")
 int lxc_v6_existing_conn_udp_second_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -1880,7 +1880,7 @@ int lxc_v6_existing_conn_udp_second_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lxc_v6_existing_conn_udp_second")
+SETUP(PROG_TYPE, "tc_lxc_v6_existing_conn_udp_second")
 int lxc_v6_existing_conn_udp_second_setup(struct __ctx_buff *ctx)
 {
 	union v6addr zero_addr = {};
@@ -1897,7 +1897,7 @@ int lxc_v6_existing_conn_udp_second_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "tc_lxc_v6_existing_conn_udp_second")
+CHECK(PROG_TYPE, "tc_lxc_v6_existing_conn_udp_second")
 int lxc_v6_existing_conn_udp_second_check(const struct __ctx_buff *ctx)
 {
 	union v6addr remote_node_ip = {};
@@ -1961,7 +1961,7 @@ int lxc_v6_existing_conn_udp_second_check(const struct __ctx_buff *ctx)
  * - Wildcard NodePort lookup should match HOST_ID and perform DNAT
  * - Packet should be DNATed to local backend IP and port
  */
-PKTGEN("tc", "tc_lxc_v6_host_nodeport_local_backend")
+PKTGEN(PROG_TYPE, "tc_lxc_v6_host_nodeport_local_backend")
 int lxc_v6_host_nodeport_local_backend_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -1986,7 +1986,7 @@ int lxc_v6_host_nodeport_local_backend_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_lxc_v6_host_nodeport_local_backend")
+SETUP(PROG_TYPE, "tc_lxc_v6_host_nodeport_local_backend")
 int lxc_v6_host_nodeport_local_backend_setup(struct __ctx_buff *ctx)
 {
 	union v6addr host_node_ip = {};
@@ -2012,7 +2012,7 @@ int lxc_v6_host_nodeport_local_backend_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "tc_lxc_v6_host_nodeport_local_backend")
+CHECK(PROG_TYPE, "tc_lxc_v6_host_nodeport_local_backend")
 int lxc_v6_host_nodeport_local_backend_check(const struct __ctx_buff *ctx)
 {
 	union v6addr host_node_ip = {};

--- a/bpf/tests/tc_lxc_policy_drop.c
+++ b/bpf/tests/tc_lxc_policy_drop.c
@@ -27,7 +27,7 @@ ASSIGN_CONFIG(union v4addr, endpoint_ipv4, { .be32 = v4_pod_one})
 
 /* Test that a packet drop results in BPF metric counters increament.
  */
-PKTGEN("tc", "tc_lxc_policy_drop")
+PKTGEN(PROG_TYPE, "tc_lxc_policy_drop")
 int tc_lxc_policy_drop_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -56,7 +56,7 @@ int tc_lxc_policy_drop_pktgen(struct __ctx_buff *ctx)
 
 __u64 drop_count;
 
-SETUP("tc", "tc_lxc_policy_drop")
+SETUP(PROG_TYPE, "tc_lxc_policy_drop")
 int tc_lxc_policy_drop__setup(struct __ctx_buff *ctx)
 {
 	policy_add_egress_deny_all_entry();
@@ -64,7 +64,7 @@ int tc_lxc_policy_drop__setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "tc_lxc_policy_drop")
+CHECK(PROG_TYPE, "tc_lxc_policy_drop")
 int tc_lxc_policy_drop_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/tc_nodeport_icmp4_snat.h
+++ b/bpf/tests/tc_nodeport_icmp4_snat.h
@@ -150,7 +150,7 @@ __always_inline int check_pmtu_snat(const struct __ctx_buff *ctx)
 	return 0;
 }
 
-PKTGEN("tc", "nodeport_revsnat_icmp4_pmtu")
+PKTGEN(PROG_TYPE, "nodeport_revsnat_icmp4_pmtu")
 int nodeport_revsnat_icmp4_pmtu_pktgen(struct __ctx_buff *ctx)
 {
 	int ret;
@@ -162,7 +162,7 @@ int nodeport_revsnat_icmp4_pmtu_pktgen(struct __ctx_buff *ctx)
 	return ret;
 }
 
-SETUP("tc", "nodeport_revsnat_icmp4_pmtu")
+SETUP(PROG_TYPE, "nodeport_revsnat_icmp4_pmtu")
 int nodeport_revsnat_icmp4_pmtu_setup(struct __ctx_buff *ctx)
 {
 	snat_v4_insert_ct_nat(IPPROTO_TCP);
@@ -170,7 +170,7 @@ int nodeport_revsnat_icmp4_pmtu_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "nodeport_revsnat_icmp4_pmtu")
+CHECK(PROG_TYPE, "nodeport_revsnat_icmp4_pmtu")
 int nodeport_revsnat_icmp4_pmtu_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	test_init();
@@ -179,7 +179,7 @@ int nodeport_revsnat_icmp4_pmtu_check(__maybe_unused const struct __ctx_buff *ct
 	test_finish();
 }
 
-PKTGEN("tc", "nodeport_revsnat_icmp4_pmtu_udp")
+PKTGEN(PROG_TYPE, "nodeport_revsnat_icmp4_pmtu_udp")
 int nodeport_revsnat_icmp4_pmtu_udp_pktgen(struct __ctx_buff *ctx)
 {
 	int ret;
@@ -191,7 +191,7 @@ int nodeport_revsnat_icmp4_pmtu_udp_pktgen(struct __ctx_buff *ctx)
 	return ret;
 }
 
-SETUP("tc", "nodeport_revsnat_icmp4_pmtu_udp")
+SETUP(PROG_TYPE, "nodeport_revsnat_icmp4_pmtu_udp")
 int nodeport_revsnat_icmp4_pmtu_udp_setup(struct __ctx_buff *ctx)
 {
 	snat_v4_insert_ct_nat(IPPROTO_UDP);
@@ -199,7 +199,7 @@ int nodeport_revsnat_icmp4_pmtu_udp_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "nodeport_revsnat_icmp4_pmtu_udp")
+CHECK(PROG_TYPE, "nodeport_revsnat_icmp4_pmtu_udp")
 int nodeport_revsnat_icmp4_pmtu_udp_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	test_init();

--- a/bpf/tests/tc_nodeport_l3_dev.h
+++ b/bpf/tests/tc_nodeport_l3_dev.h
@@ -511,145 +511,145 @@ egress_l3_to_l2_fast_redirect_check(__maybe_unused const struct __ctx_buff *ctx,
 	test_finish();
 }
 
-PKTGEN("tc", "ingress_ipv4_l3_to_l2_fast_redirect_pod")
+PKTGEN(PROG_TYPE, "ingress_ipv4_l3_to_l2_fast_redirect_pod")
 int ingress_ipv4_l3_to_l2_fast_redirect_pod_pktgen(struct __ctx_buff *ctx)
 {
 	return l3_to_l2_fast_redirect_pktgen(ctx, true, true, false);
 }
 
-SETUP("tc", "ingress_ipv4_l3_to_l2_fast_redirect_pod")
+SETUP(PROG_TYPE, "ingress_ipv4_l3_to_l2_fast_redirect_pod")
 int ingress_ipv4_l3_to_l2_fast_redirect_pod_setup(struct __ctx_buff *ctx)
 {
 	return l3_to_l2_fast_redirect_setup(ctx, true, true, false);
 }
 
-CHECK("tc", "ingress_ipv4_l3_to_l2_fast_redirect_pod")
+CHECK(PROG_TYPE, "ingress_ipv4_l3_to_l2_fast_redirect_pod")
 int ingress_ipv4_l3_to_l2_fast_redirect_pod_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return ingress_l3_to_l2_fast_redirect_check(ctx, true, false);
 }
 
-PKTGEN("tc", "ingress_ipv6_l3_to_l2_fast_redirect_pod")
+PKTGEN(PROG_TYPE, "ingress_ipv6_l3_to_l2_fast_redirect_pod")
 int ingress_ipv6_l3_to_l2_fast_redirect_pktgen(struct __ctx_buff *ctx)
 {
 	return l3_to_l2_fast_redirect_pktgen(ctx, true, false, false);
 }
 
-SETUP("tc", "ingress_ipv6_l3_to_l2_fast_redirect_pod")
+SETUP(PROG_TYPE, "ingress_ipv6_l3_to_l2_fast_redirect_pod")
 int ingress_ipv6_l3_to_l2_fast_redirect_pod_setup(struct __ctx_buff *ctx)
 {
 	return l3_to_l2_fast_redirect_setup(ctx, true, false, false);
 }
 
-CHECK("tc", "ingress_ipv6_l3_to_l2_fast_redirect_pod")
+CHECK(PROG_TYPE, "ingress_ipv6_l3_to_l2_fast_redirect_pod")
 int ingress_ipv6_l3_to_l2_fast_redirect_pod_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return ingress_l3_to_l2_fast_redirect_check(ctx, false, false);
 }
 
-PKTGEN("tc", "egress_ipv4_l3_to_l2_fast_redirect_pod")
+PKTGEN(PROG_TYPE, "egress_ipv4_l3_to_l2_fast_redirect_pod")
 int egress_ipv4_l3_to_l2_fast_redirect_pod_pktgen(struct __ctx_buff *ctx)
 {
 	return l3_to_l2_fast_redirect_pktgen(ctx, false, true, false);
 }
 
-SETUP("tc", "egress_ipv4_l3_to_l2_fast_redirect_pod")
+SETUP(PROG_TYPE, "egress_ipv4_l3_to_l2_fast_redirect_pod")
 int egress_ipv4_l3_to_l2_fast_redirect_pod_setup(struct __ctx_buff *ctx)
 {
 	return l3_to_l2_fast_redirect_setup(ctx, false, true, false);
 }
 
-CHECK("tc", "egress_ipv4_l3_to_l2_fast_redirect_pod")
+CHECK(PROG_TYPE, "egress_ipv4_l3_to_l2_fast_redirect_pod")
 int egress_ipv4_l3_to_l2_fast_redirect_pod_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return egress_l3_to_l2_fast_redirect_check(ctx, true, false);
 }
 
-PKTGEN("tc", "egress_ipv6_l3_to_l2_fast_redirect_pod")
+PKTGEN(PROG_TYPE, "egress_ipv6_l3_to_l2_fast_redirect_pod")
 int egress_ipv6_l3_to_l2_fast_redirect_pod_pktgen(struct __ctx_buff *ctx)
 {
 	return l3_to_l2_fast_redirect_pktgen(ctx, false, false, false);
 }
 
-SETUP("tc", "egress_ipv6_l3_to_l2_fast_redirect_pod")
+SETUP(PROG_TYPE, "egress_ipv6_l3_to_l2_fast_redirect_pod")
 int egress_ipv6_l3_to_l2_fast_redirect_pod_setup(struct __ctx_buff *ctx)
 {
 	return l3_to_l2_fast_redirect_setup(ctx, false, false, false);
 }
 
-CHECK("tc", "egress_ipv6_l3_to_l2_fast_redirect_pod")
+CHECK(PROG_TYPE, "egress_ipv6_l3_to_l2_fast_redirect_pod")
 int egress_ipv6_l3_to_l2_fast_redirect_pod_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return egress_l3_to_l2_fast_redirect_check(ctx, false, false);
 }
 
-PKTGEN("tc", "ingress_ipv4_l3_to_l2_fast_redirect_host")
+PKTGEN(PROG_TYPE, "ingress_ipv4_l3_to_l2_fast_redirect_host")
 int ingress_ipv4_l3_to_l2_fast_redirect_host_pktgen(struct __ctx_buff *ctx)
 {
 	return l3_to_l2_fast_redirect_pktgen(ctx, true, true, true);
 }
 
-SETUP("tc", "ingress_ipv4_l3_to_l2_fast_redirect_host")
+SETUP(PROG_TYPE, "ingress_ipv4_l3_to_l2_fast_redirect_host")
 int ingress_ipv4_l3_to_l2_fast_redirect_host_setup(struct __ctx_buff *ctx)
 {
 	return l3_to_l2_fast_redirect_setup(ctx, true, true, true);
 }
 
-CHECK("tc", "ingress_ipv4_l3_to_l2_fast_redirect_host")
+CHECK(PROG_TYPE, "ingress_ipv4_l3_to_l2_fast_redirect_host")
 int ingress_ipv4_l3_to_l2_fast_redirect_host_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return ingress_l3_to_l2_fast_redirect_check(ctx, true, true);
 }
 
-PKTGEN("tc", "ingress_ipv6_l3_to_l2_fast_redirect_host")
+PKTGEN(PROG_TYPE, "ingress_ipv6_l3_to_l2_fast_redirect_host")
 int ingress_ipv6_l3_to_l2_fast_redirect_host_pktgen(struct __ctx_buff *ctx)
 {
 	return l3_to_l2_fast_redirect_pktgen(ctx, true, false, true);
 }
 
-SETUP("tc", "ingress_ipv6_l3_to_l2_fast_redirect_host")
+SETUP(PROG_TYPE, "ingress_ipv6_l3_to_l2_fast_redirect_host")
 int ingress_ipv6_l3_to_l2_fast_redirect_host_setup(struct __ctx_buff *ctx)
 {
 	return l3_to_l2_fast_redirect_setup(ctx, true, false, true);
 }
 
-CHECK("tc", "ingress_ipv6_l3_to_l2_fast_redirect_host")
+CHECK(PROG_TYPE, "ingress_ipv6_l3_to_l2_fast_redirect_host")
 int ingress_ipv6_l3_to_l2_fast_redirect_host_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return ingress_l3_to_l2_fast_redirect_check(ctx, false, true);
 }
 
-PKTGEN("tc", "egress_ipv4_l3_to_l2_fast_redirect_host")
+PKTGEN(PROG_TYPE, "egress_ipv4_l3_to_l2_fast_redirect_host")
 int egress_ipv4_l3_to_l2_fast_redirect_host_pktgen(struct __ctx_buff *ctx)
 {
 	return l3_to_l2_fast_redirect_pktgen(ctx, false, true, true);
 }
 
-SETUP("tc", "egress_ipv4_l3_to_l2_fast_redirect_host")
+SETUP(PROG_TYPE, "egress_ipv4_l3_to_l2_fast_redirect_host")
 int egress_ipv4_l3_to_l2_fast_redirect_host_setup(struct __ctx_buff *ctx)
 {
 	return l3_to_l2_fast_redirect_setup(ctx, false, true, true);
 }
 
-CHECK("tc", "egress_ipv4_l3_to_l2_fast_redirect_host")
+CHECK(PROG_TYPE, "egress_ipv4_l3_to_l2_fast_redirect_host")
 int egress_ipv4_l3_to_l2_fast_redirect_host_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return egress_l3_to_l2_fast_redirect_check(ctx, true, true);
 }
 
-PKTGEN("tc", "egress_ipv6_l3_to_l2_fast_redirect_host")
+PKTGEN(PROG_TYPE, "egress_ipv6_l3_to_l2_fast_redirect_host")
 int egress_ipv6_l3_to_l2_fast_redirect_host_pktgen(struct __ctx_buff *ctx)
 {
 	return l3_to_l2_fast_redirect_pktgen(ctx, false, false, true);
 }
 
-SETUP("tc", "egress_ipv6_l3_to_l2_fast_redirect_host")
+SETUP(PROG_TYPE, "egress_ipv6_l3_to_l2_fast_redirect_host")
 int egress_ipv6_l3_to_l2_fast_redirect_host_setup(struct __ctx_buff *ctx)
 {
 	return l3_to_l2_fast_redirect_setup(ctx, false, false, true);
 }
 
-CHECK("tc", "egress_ipv6_l3_to_l2_fast_redirect_host")
+CHECK(PROG_TYPE, "egress_ipv6_l3_to_l2_fast_redirect_host")
 int egress_ipv6_l3_to_l2_fast_redirect_host_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return egress_l3_to_l2_fast_redirect_check(ctx, false, true);

--- a/bpf/tests/tc_nodeport_l3_dev_lb_dsr_geneve_lb.c
+++ b/bpf/tests/tc_nodeport_l3_dev_lb_dsr_geneve_lb.c
@@ -55,7 +55,7 @@ mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
  * - has IP Option inserted,
  * - gets redirected back out by TC
  */
-PKTGEN("tc", "ipv4_tc_nodeport_l3_dev_dsr_geneve_fwd")
+PKTGEN(PROG_TYPE, "ipv4_tc_nodeport_l3_dev_dsr_geneve_fwd")
 int ipv4_tc_nodeport_l3_dev_dsr_geneve_fwd_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -82,7 +82,7 @@ int ipv4_tc_nodeport_l3_dev_dsr_geneve_fwd_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "ipv4_tc_nodeport_l3_dev_dsr_geneve_fwd")
+SETUP(PROG_TYPE, "ipv4_tc_nodeport_l3_dev_dsr_geneve_fwd")
 int ipv4_tc_nodeport_l3_dev_dsr_geneve_fwd_setup(struct __ctx_buff *ctx)
 {
 	void *data = (void *)(long)ctx->data;
@@ -105,7 +105,7 @@ int ipv4_tc_nodeport_l3_dev_dsr_geneve_fwd_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "ipv4_tc_nodeport_l3_dev_dsr_geneve_fwd")
+CHECK(PROG_TYPE, "ipv4_tc_nodeport_l3_dev_dsr_geneve_fwd")
 int ipv4_tc_nodeport_l3_dev_dsr_geneve_fwd_check(__maybe_unused struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -158,7 +158,7 @@ int ipv4_tc_nodeport_l3_dev_dsr_geneve_fwd_check(__maybe_unused struct __ctx_buf
  * - has IPv6 Extension inserted,
  * - gets redirected back out by TC
  */
-PKTGEN("tc", "ipv6_tc_nodeport_l3_dev_dsr_geneve_fwd")
+PKTGEN(PROG_TYPE, "ipv6_tc_nodeport_l3_dev_dsr_geneve_fwd")
 int ipv6_tc_nodeport_l3_dev_dsr_geneve_fwd_pktgen(struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip = FRONTEND_IPV6;
@@ -187,7 +187,7 @@ int ipv6_tc_nodeport_l3_dev_dsr_geneve_fwd_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "ipv6_tc_nodeport_l3_dev_dsr_geneve_fwd")
+SETUP(PROG_TYPE, "ipv6_tc_nodeport_l3_dev_dsr_geneve_fwd")
 int ipv6_tc_nodeport_l3_dev_dsr_geneve_fwd_setup(struct __ctx_buff *ctx)
 {
 	void *data = (void *)(long)ctx->data;
@@ -212,7 +212,7 @@ int ipv6_tc_nodeport_l3_dev_dsr_geneve_fwd_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "ipv6_tc_nodeport_l3_dev_dsr_geneve_fwd")
+CHECK(PROG_TYPE, "ipv6_tc_nodeport_l3_dev_dsr_geneve_fwd")
 int ipv6_tc_nodeport_l3_dev_dsr_geneve_fwd_check(__maybe_unused struct __ctx_buff *ctx)
 {
 	union v6addr backend_ip = BACKEND_IPV6;

--- a/bpf/tests/tc_nodeport_l3_dev_to_tunnel.c
+++ b/bpf/tests/tc_nodeport_l3_dev_to_tunnel.c
@@ -35,7 +35,7 @@
 
 static volatile const __u8 *node_mac = mac_two;
 
-PKTGEN("tc", "ipv4_tc_nodeport_l3_to_remote_backend_via_tunnel")
+PKTGEN(PROG_TYPE, "ipv4_tc_nodeport_l3_to_remote_backend_via_tunnel")
 int ipv4_tc_nodeport_l3_to_remote_backend_via_tunnel(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -70,7 +70,7 @@ int ipv4_tc_nodeport_l3_to_remote_backend_via_tunnel(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "ipv4_tc_nodeport_l3_to_remote_backend_via_tunnel")
+SETUP(PROG_TYPE, "ipv4_tc_nodeport_l3_to_remote_backend_via_tunnel")
 int ipv4_tc_nodeport_l3_to_remote_backend_via_tunnel_setup(struct __ctx_buff *ctx)
 {
 	void *data = (void *)(long)ctx->data;
@@ -96,7 +96,7 @@ int ipv4_tc_nodeport_l3_to_remote_backend_via_tunnel_setup(struct __ctx_buff *ct
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "ipv4_tc_nodeport_l3_to_remote_backend_via_tunnel")
+CHECK(PROG_TYPE, "ipv4_tc_nodeport_l3_to_remote_backend_via_tunnel")
 int ipv4_tc_nodeport_l3_to_remote_backend_via_tunnel_check(__maybe_unused
 							   const struct __ctx_buff *ctx)
 {
@@ -130,7 +130,7 @@ int ipv4_tc_nodeport_l3_to_remote_backend_via_tunnel_check(__maybe_unused
 	test_finish();
 }
 
-PKTGEN("tc", "ipv6_tc_nodeport_l3_to_remote_backend_via_tunnel")
+PKTGEN(PROG_TYPE, "ipv6_tc_nodeport_l3_to_remote_backend_via_tunnel")
 int ipv6_tc_nodeport_l3_to_remote_backend_via_tunnel(struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip = FRONTEND_IPV6;
@@ -167,7 +167,7 @@ int ipv6_tc_nodeport_l3_to_remote_backend_via_tunnel(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "ipv6_tc_nodeport_l3_to_remote_backend_via_tunnel")
+SETUP(PROG_TYPE, "ipv6_tc_nodeport_l3_to_remote_backend_via_tunnel")
 int ipv6_tc_nodeport_l3_to_remote_backend_via_tunnel_setup(struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip = FRONTEND_IPV6;
@@ -195,7 +195,7 @@ int ipv6_tc_nodeport_l3_to_remote_backend_via_tunnel_setup(struct __ctx_buff *ct
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "ipv6_tc_nodeport_l3_to_remote_backend_via_tunnel")
+CHECK(PROG_TYPE, "ipv6_tc_nodeport_l3_to_remote_backend_via_tunnel")
 int ipv6_tc_nodeport_l3_to_remote_backend_via_tunnel_check(__maybe_unused
 							   const struct __ctx_buff *ctx)
 {

--- a/bpf/tests/tc_nodeport_lb4_dsr_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_dsr_backend.c
@@ -112,7 +112,7 @@ ASSIGN_CONFIG(__u32, interface_ifindex, DEFAULT_IFACE)
  * - redirects it to the pod (as BPF Host Routing is enabled)
  * - creates a matching CT entry, and SNAT entry from the DSR info
  */
-PKTGEN("tc", "tc_nodeport_dsr_backend")
+PKTGEN(PROG_TYPE, "tc_nodeport_dsr_backend")
 int nodeport_dsr_backend_pktgen(struct __ctx_buff *ctx)
 {
 	struct dsr_opt_v4 *opt;
@@ -164,7 +164,7 @@ int nodeport_dsr_backend_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_dsr_backend")
+SETUP(PROG_TYPE, "tc_nodeport_dsr_backend")
 int nodeport_dsr_backend_setup(struct __ctx_buff *ctx)
 {
 	/* add local backend */
@@ -176,7 +176,7 @@ int nodeport_dsr_backend_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_dsr_backend")
+CHECK(PROG_TYPE, "tc_nodeport_dsr_backend")
 int nodeport_dsr_backend_check(struct __ctx_buff *ctx)
 {
 	struct dsr_opt_v4 *opt;
@@ -361,19 +361,19 @@ static __always_inline int check_reply(const struct __ctx_buff *ctx)
 /* Test that the backend node revDNATs a reply from the
  * DSR backend, and sends the reply back to the client.
  */
-PKTGEN("tc", "tc_nodeport_dsr_backend_reply")
+PKTGEN(PROG_TYPE, "tc_nodeport_dsr_backend_reply")
 int nodeport_dsr_backend_reply_pktgen(struct __ctx_buff *ctx)
 {
 	return build_reply(ctx);
 }
 
-SETUP("tc", "tc_nodeport_dsr_backend_reply")
+SETUP(PROG_TYPE, "tc_nodeport_dsr_backend_reply")
 int nodeport_dsr_backend_reply_setup(struct __ctx_buff *ctx)
 {
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_dsr_backend_reply")
+CHECK(PROG_TYPE, "tc_nodeport_dsr_backend_reply")
 int nodeport_dsr_backend_reply_check(const struct __ctx_buff *ctx)
 {
 	return check_reply(ctx);
@@ -382,7 +382,7 @@ int nodeport_dsr_backend_reply_check(const struct __ctx_buff *ctx)
 /* Same scenario as above, but for a different CLIENT_IP_2. Here replies
  * should leave via a non-default interface.
  */
-PKTGEN("tc", "tc_nodeport_dsr_backend_redirect")
+PKTGEN(PROG_TYPE, "tc_nodeport_dsr_backend_redirect")
 int nodeport_dsr_backend_redirect_pktgen(struct __ctx_buff *ctx)
 {
 	struct dsr_opt_v4 *opt;
@@ -434,7 +434,7 @@ int nodeport_dsr_backend_redirect_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_dsr_backend_redirect")
+SETUP(PROG_TYPE, "tc_nodeport_dsr_backend_redirect")
 int nodeport_dsr_backend_redirect_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v4_add_entry(BACKEND_IP, BACKEND_IFACE, BACKEND_EP_ID, 0, 0, 0,
@@ -443,7 +443,7 @@ int nodeport_dsr_backend_redirect_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_dsr_backend_redirect")
+CHECK(PROG_TYPE, "tc_nodeport_dsr_backend_redirect")
 int nodeport_dsr_backend_redirect_check(struct __ctx_buff *ctx)
 {
 	struct dsr_opt_v4 *opt;
@@ -537,7 +537,7 @@ int nodeport_dsr_backend_redirect_check(struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "tc_nodeport_dsr_backend_redirect_reply")
+PKTGEN(PROG_TYPE, "tc_nodeport_dsr_backend_redirect_reply")
 int nodeport_dsr_backend_redirect_reply_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -564,7 +564,7 @@ int nodeport_dsr_backend_redirect_reply_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_dsr_backend_redirect_reply")
+SETUP(PROG_TYPE, "tc_nodeport_dsr_backend_redirect_reply")
 int nodeport_dsr_backend_redirect_reply_setup(struct __ctx_buff *ctx)
 {
 	return netdev_send_packet(ctx);
@@ -573,7 +573,7 @@ int nodeport_dsr_backend_redirect_reply_setup(struct __ctx_buff *ctx)
 /* Test that to-netdev respects the routing needed for CLIENT_IP_2,
  * and redirects the packet to the correct egress interface.
  */
-CHECK("tc", "tc_nodeport_dsr_backend_redirect_reply")
+CHECK(PROG_TYPE, "tc_nodeport_dsr_backend_redirect_reply")
 int nodeport_dsr_backend_redirect_reply_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/tc_nodeport_lb4_dsr_ipip_local.c
+++ b/bpf/tests/tc_nodeport_lb4_dsr_ipip_local.c
@@ -211,13 +211,13 @@ pktgen_client_to_svc(struct __ctx_buff *ctx, __be32 svc_addr, __be16 svc_port)
 /* Pod netns (netkit). No IPIP encap happens.                                 */
 /* -------------------------------------------------------------------------- */
 
-PKTGEN("tc", "tc_nodeport_dsr_ipip_lb_local_pod")
+PKTGEN(PROG_TYPE, "tc_nodeport_dsr_ipip_lb_local_pod")
 int nodeport_dsr_ipip_lb_local_pod_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_client_to_svc(ctx, FRONTEND_IP, FRONTEND_PORT);
 }
 
-SETUP("tc", "tc_nodeport_dsr_ipip_lb_local_pod")
+SETUP(PROG_TYPE, "tc_nodeport_dsr_ipip_lb_local_pod")
 int nodeport_dsr_ipip_lb_local_pod_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -239,7 +239,7 @@ int nodeport_dsr_ipip_lb_local_pod_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_dsr_ipip_lb_local_pod")
+CHECK(PROG_TYPE, "tc_nodeport_dsr_ipip_lb_local_pod")
 int nodeport_dsr_ipip_lb_local_pod_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -319,13 +319,13 @@ int nodeport_dsr_ipip_lb_local_pod_check(struct __ctx_buff *ctx)
 /* no encap, no redirect.                                                     */
 /* -------------------------------------------------------------------------- */
 
-PKTGEN("tc", "tc_nodeport_dsr_ipip_lb_local_l7punt")
+PKTGEN(PROG_TYPE, "tc_nodeport_dsr_ipip_lb_local_l7punt")
 int nodeport_dsr_ipip_lb_local_l7punt_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_client_to_svc(ctx, L7_FRONTEND_IP, FRONTEND_PORT);
 }
 
-SETUP("tc", "tc_nodeport_dsr_ipip_lb_local_l7punt")
+SETUP(PROG_TYPE, "tc_nodeport_dsr_ipip_lb_local_l7punt")
 int nodeport_dsr_ipip_lb_local_l7punt_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 2;
@@ -349,7 +349,7 @@ int nodeport_dsr_ipip_lb_local_l7punt_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_dsr_ipip_lb_local_l7punt")
+CHECK(PROG_TYPE, "tc_nodeport_dsr_ipip_lb_local_l7punt")
 int nodeport_dsr_ipip_lb_local_l7punt_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/tc_nodeport_lb4_ipip_termination.c
+++ b/bpf/tests/tc_nodeport_lb4_ipip_termination.c
@@ -281,13 +281,13 @@ pktgen_ipip_v4(struct __ctx_buff *ctx, __be32 outer_dst, __be32 inner_dst)
 /* Test 1: outer dst is a local Pod IP. Expect strip + DNAT + redirect_peer.  */
 /* -------------------------------------------------------------------------- */
 
-PKTGEN("tc", "tc_nodeport_ipip_term_v4_local_pod")
+PKTGEN(PROG_TYPE, "tc_nodeport_ipip_term_v4_local_pod")
 int ipip_term_v4_local_pod_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_ipip_v4(ctx, BACKEND_IP, FRONTEND_IP);
 }
 
-SETUP("tc", "tc_nodeport_ipip_term_v4_local_pod")
+SETUP(PROG_TYPE, "tc_nodeport_ipip_term_v4_local_pod")
 int ipip_term_v4_local_pod_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -316,7 +316,7 @@ int ipip_term_v4_local_pod_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_ipip_term_v4_local_pod")
+CHECK(PROG_TYPE, "tc_nodeport_ipip_term_v4_local_pod")
 int ipip_term_v4_local_pod_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -397,14 +397,14 @@ int ipip_term_v4_local_pod_check(struct __ctx_buff *ctx)
 /* decapped inner reaches the host stack unchanged for Envoy to intercept.    */
 /* -------------------------------------------------------------------------- */
 
-PKTGEN("tc", "tc_nodeport_ipip_term_v4_l7_punt_proxy")
+PKTGEN(PROG_TYPE, "tc_nodeport_ipip_term_v4_l7_punt_proxy")
 int ipip_term_v4_l7_punt_proxy_pktgen(struct __ctx_buff *ctx)
 {
 	/* Outer dst = local host IP; inner dst = the L7-delegate svc VIP. */
 	return pktgen_ipip_v4(ctx, L7_HOST_BACKEND_IP, L7_FRONTEND_IP);
 }
 
-SETUP("tc", "tc_nodeport_ipip_term_v4_l7_punt_proxy")
+SETUP(PROG_TYPE, "tc_nodeport_ipip_term_v4_l7_punt_proxy")
 int ipip_term_v4_l7_punt_proxy_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 2;
@@ -437,7 +437,7 @@ int ipip_term_v4_l7_punt_proxy_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_ipip_term_v4_l7_punt_proxy")
+CHECK(PROG_TYPE, "tc_nodeport_ipip_term_v4_l7_punt_proxy")
 int ipip_term_v4_l7_punt_proxy_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -502,13 +502,13 @@ int ipip_term_v4_l7_punt_proxy_check(struct __ctx_buff *ctx)
 /* runs - otherwise the inner falls through with daddr == LB VIP.            */
 /* -------------------------------------------------------------------------- */
 
-PKTGEN("tc", "tc_nodeport_ipip_term_v4_xdp_handoff")
+PKTGEN(PROG_TYPE, "tc_nodeport_ipip_term_v4_xdp_handoff")
 int ipip_term_v4_xdp_handoff_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_ipip_v4(ctx, BACKEND_IP, FRONTEND_IP);
 }
 
-SETUP("tc", "tc_nodeport_ipip_term_v4_xdp_handoff")
+SETUP(PROG_TYPE, "tc_nodeport_ipip_term_v4_xdp_handoff")
 int ipip_term_v4_xdp_handoff_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -536,7 +536,7 @@ int ipip_term_v4_xdp_handoff_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_ipip_term_v4_xdp_handoff")
+CHECK(PROG_TYPE, "tc_nodeport_ipip_term_v4_xdp_handoff")
 int ipip_term_v4_xdp_handoff_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/tc_nodeport_lb4_nat_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_backend.c
@@ -63,7 +63,7 @@ ASSIGN_CONFIG(bool, enable_bpf_host_routing, true)
  * - doesn't touch a NATed request,
  * - redirects it to the pod (as BPF Host Routing is enabled)
  */
-PKTGEN("tc", "tc_nodeport_nat_backend")
+PKTGEN(PROG_TYPE, "tc_nodeport_nat_backend")
 int nodeport_nat_backend_pktgen(struct __ctx_buff *ctx)
 {
 	volatile const __u8 *src = mac_one;
@@ -92,7 +92,7 @@ int nodeport_nat_backend_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_nat_backend")
+SETUP(PROG_TYPE, "tc_nodeport_nat_backend")
 int nodeport_nat_backend_setup(struct __ctx_buff *ctx)
 {
 	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP, 1, 1);
@@ -107,7 +107,7 @@ int nodeport_nat_backend_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_nat_backend")
+CHECK(PROG_TYPE, "tc_nodeport_nat_backend")
 int nodeport_nat_backend_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/tc_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_lb.c
@@ -162,7 +162,7 @@ ASSIGN_CONFIG(__u32, interface_ifindex, DEFAULT_IFACE)
  * - gets DNATed (but not SNATed)
  * - gets redirected by TC (as BPF Host Routing is enabled)
  */
-PKTGEN("tc", "tc_nodeport_local_backend")
+PKTGEN(PROG_TYPE, "tc_nodeport_local_backend")
 int nodeport_local_backend_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -189,7 +189,7 @@ int nodeport_local_backend_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_local_backend")
+SETUP(PROG_TYPE, "tc_nodeport_local_backend")
 int nodeport_local_backend_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -207,7 +207,7 @@ int nodeport_local_backend_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_local_backend")
+CHECK(PROG_TYPE, "tc_nodeport_local_backend")
 int nodeport_local_backend_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -269,7 +269,7 @@ int nodeport_local_backend_check(const struct __ctx_buff *ctx)
 }
 
 /* Test that a reply by the local backend gets revDNATed at to-netdev. */
-PKTGEN("tc", "tc_nodeport_local_backend_reply")
+PKTGEN(PROG_TYPE, "tc_nodeport_local_backend_reply")
 int nodeport_local_backend_reply_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -296,13 +296,13 @@ int nodeport_local_backend_reply_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_local_backend_reply")
+SETUP(PROG_TYPE, "tc_nodeport_local_backend_reply")
 int nodeport_local_backend_reply_setup(struct __ctx_buff *ctx)
 {
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_local_backend_reply")
+CHECK(PROG_TYPE, "tc_nodeport_local_backend_reply")
 int nodeport_local_backend_reply_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -364,7 +364,7 @@ int nodeport_local_backend_reply_check(const struct __ctx_buff *ctx)
 /* Same scenario as above, but for a different CLIENT_IP_2. Here replies
  * should leave via a non-default interface.
  */
-PKTGEN("tc", "tc_nodeport_local_backend_redirect")
+PKTGEN(PROG_TYPE, "tc_nodeport_local_backend_redirect")
 int nodeport_local_backend_redirect_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -391,7 +391,7 @@ int nodeport_local_backend_redirect_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_local_backend_redirect")
+SETUP(PROG_TYPE, "tc_nodeport_local_backend_redirect")
 int nodeport_local_backend_redirect_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v4_add_entry(BACKEND_IP_LOCAL, BACKEND_IFACE, BACKEND_EP_ID, 0, 0, 0,
@@ -400,7 +400,7 @@ int nodeport_local_backend_redirect_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_local_backend_redirect")
+CHECK(PROG_TYPE, "tc_nodeport_local_backend_redirect")
 int nodeport_local_backend_redirect_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -464,7 +464,7 @@ int nodeport_local_backend_redirect_check(const struct __ctx_buff *ctx)
 /* Test that to-netdev respects the routing needed for CLIENT_IP_2,
  * and redirects the packet to the correct egress interface.
  */
-PKTGEN("tc", "tc_nodeport_local_backend_redirect_reply")
+PKTGEN(PROG_TYPE, "tc_nodeport_local_backend_redirect_reply")
 int nodeport_local_backend_redirect_reply_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -491,13 +491,13 @@ int nodeport_local_backend_redirect_reply_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_local_backend_redirect_reply")
+SETUP(PROG_TYPE, "tc_nodeport_local_backend_redirect_reply")
 int nodeport_local_backend_redirect_reply_setup(struct __ctx_buff *ctx)
 {
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_local_backend_redirect_reply")
+CHECK(PROG_TYPE, "tc_nodeport_local_backend_redirect_reply")
 int nodeport_local_backend_redirect_reply_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -560,7 +560,7 @@ int nodeport_local_backend_redirect_reply_check(const struct __ctx_buff *ctx)
  * - gets DNATed (but not SNATed)
  * - gets redirected by TC (as BPF Host Routing is enabled)
  */
-PKTGEN("tc", "tc_nodeport_udp_local_backend")
+PKTGEN(PROG_TYPE, "tc_nodeport_udp_local_backend")
 int nodeport_udp_local_backend_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -587,7 +587,7 @@ int nodeport_udp_local_backend_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_udp_local_backend")
+SETUP(PROG_TYPE, "tc_nodeport_udp_local_backend")
 int nodeport_udp_local_backend_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 2;
@@ -602,7 +602,7 @@ int nodeport_udp_local_backend_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_udp_local_backend")
+CHECK(PROG_TYPE, "tc_nodeport_udp_local_backend")
 int nodeport_udp_local_backend_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -667,7 +667,7 @@ int nodeport_udp_local_backend_check(const struct __ctx_buff *ctx)
  * - gets DNATed and SNATed,
  * - gets redirected back out by TC
  */
-PKTGEN("tc", "tc_nodeport_nat_fwd")
+PKTGEN(PROG_TYPE, "tc_nodeport_nat_fwd")
 int nodeport_nat_fwd_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -694,7 +694,7 @@ int nodeport_nat_fwd_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_nat_fwd")
+SETUP(PROG_TYPE, "tc_nodeport_nat_fwd")
 int nodeport_nat_fwd_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -708,7 +708,7 @@ int nodeport_nat_fwd_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_nat_fwd")
+CHECK(PROG_TYPE, "tc_nodeport_nat_fwd")
 int nodeport_nat_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -841,19 +841,19 @@ static __always_inline int check_reply(const struct __ctx_buff *ctx)
 /* Test that the LB RevDNATs and RevSNATs a reply from the
  * NAT remote backend, and sends it back to the client.
  */
-PKTGEN("tc", "tc_nodeport_nat_fwd_reply")
+PKTGEN(PROG_TYPE, "tc_nodeport_nat_fwd_reply")
 int nodeport_nat_fwd_reply_pktgen(struct __ctx_buff *ctx)
 {
 	return build_reply(ctx);
 }
 
-SETUP("tc", "tc_nodeport_nat_fwd_reply")
+SETUP(PROG_TYPE, "tc_nodeport_nat_fwd_reply")
 int nodeport_nat_fwd_reply_setup(struct __ctx_buff *ctx)
 {
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_nat_fwd_reply")
+CHECK(PROG_TYPE, "tc_nodeport_nat_fwd_reply")
 int nodeport_nat_fwd_reply_check(const struct __ctx_buff *ctx)
 {
 	return check_reply(ctx);
@@ -863,13 +863,13 @@ int nodeport_nat_fwd_reply_check(const struct __ctx_buff *ctx)
  * NAT remote backend, and sends it back to the client.
  * Even if the FIB lookup fails.
  */
-PKTGEN("tc", "tc_nodeport_nat_fwd_reply_no_fib")
+PKTGEN(PROG_TYPE, "tc_nodeport_nat_fwd_reply_no_fib")
 int nodepoirt_nat_fwd_reply_no_fib_pktgen(struct __ctx_buff *ctx)
 {
 	return build_reply(ctx);
 }
 
-SETUP("tc", "tc_nodeport_nat_fwd_reply_no_fib")
+SETUP(PROG_TYPE, "tc_nodeport_nat_fwd_reply_no_fib")
 int nodeport_nat_fwd_reply_no_fib_setup(struct __ctx_buff *ctx)
 {
 	__u32 key = 0;
@@ -881,7 +881,7 @@ int nodeport_nat_fwd_reply_no_fib_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_nat_fwd_reply_no_fib")
+CHECK(PROG_TYPE, "tc_nodeport_nat_fwd_reply_no_fib")
 int nodeport_nat_fwd_reply_no_fib_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_reply(ctx);
@@ -897,13 +897,13 @@ int nodeport_nat_fwd_reply_no_fib_check(__maybe_unused const struct __ctx_buff *
  * Test that the LB fails to RevDNAT and RevSNAT a reply from the
  * NAT remote backend when its Rev NAT entry gets deleted
  */
-PKTGEN("tc", "tc_nodeport_nat_fwd_reply_punt")
+PKTGEN(PROG_TYPE, "tc_nodeport_nat_fwd_reply_punt")
 int nodeport_nat_fwd_reply_punt_pktgen(struct __ctx_buff *ctx)
 {
 	return build_reply(ctx);
 }
 
-SETUP("tc", "tc_nodeport_nat_fwd_reply_punt")
+SETUP(PROG_TYPE, "tc_nodeport_nat_fwd_reply_punt")
 int nodeport_nat_fwd_reply_punt_setup(struct __ctx_buff *ctx)
 {
 	/* Delete the Rev NAT */
@@ -929,7 +929,7 @@ int nodeport_nat_fwd_reply_punt_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_nat_fwd_reply_punt")
+CHECK(PROG_TYPE, "tc_nodeport_nat_fwd_reply_punt")
 int nodeport_nat_fwd_reply_punt_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -955,7 +955,7 @@ int nodeport_nat_fwd_reply_punt_check(const struct __ctx_buff *ctx)
  * - gets DNATed and SNATed,
  * - gets redirected back out by TC
  */
-PKTGEN("tc", "tc_nodeport_nat_fwd_restore")
+PKTGEN(PROG_TYPE, "tc_nodeport_nat_fwd_restore")
 int nodeport_nat_fwd_restore_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -982,7 +982,7 @@ int nodeport_nat_fwd_restore_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_nat_fwd_restore")
+SETUP(PROG_TYPE, "tc_nodeport_nat_fwd_restore")
 int nodeport_nat_fwd_restore_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 3;
@@ -1004,7 +1004,7 @@ int nodeport_nat_fwd_restore_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_nat_fwd_restore")
+CHECK(PROG_TYPE, "tc_nodeport_nat_fwd_restore")
 int nodeport_nat_fwd_restore_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -1059,19 +1059,19 @@ int nodeport_nat_fwd_restore_check(__maybe_unused const struct __ctx_buff *ctx)
 /* Test that the restored LB RevDNATs and RevSNATs a reply from the
  * NAT remote backend, and sends it back to the client.
  */
-PKTGEN("tc", "tc_nodeport_nat_fwd_restore_reply")
+PKTGEN(PROG_TYPE, "tc_nodeport_nat_fwd_restore_reply")
 int nodeport_nat_fwd_restore_reply_pktgen(struct __ctx_buff *ctx)
 {
 	return build_reply(ctx);
 }
 
-SETUP("tc", "tc_nodeport_nat_fwd_restore_reply")
+SETUP(PROG_TYPE, "tc_nodeport_nat_fwd_restore_reply")
 int nodeport_nat_fwd_restore_reply_setup(struct __ctx_buff *ctx)
 {
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_nat_fwd_restore_reply")
+CHECK(PROG_TYPE, "tc_nodeport_nat_fwd_restore_reply")
 int nodeport_nat_fwd_restore_reply_check(const struct __ctx_buff *ctx)
 {
 	return check_reply(ctx);
@@ -1085,7 +1085,7 @@ int nodeport_nat_fwd_restore_reply_check(const struct __ctx_buff *ctx)
   *
   * Test that source port is changed when the Original NAT entry is deleted.(ReSNATed)
   */
-PKTGEN("tc", "tc_nodeport_nat_fwd_original_renated")
+PKTGEN(PROG_TYPE, "tc_nodeport_nat_fwd_original_renated")
 int nodeport_nat_fwd_original_renated_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -1112,7 +1112,7 @@ int nodeport_nat_fwd_original_renated_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_nat_fwd_original_renated")
+SETUP(PROG_TYPE, "tc_nodeport_nat_fwd_original_renated")
 int nodeport_nat_fwd_original_renated_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 4;
@@ -1138,7 +1138,7 @@ int nodeport_nat_fwd_original_renated_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_nat_fwd_original_renated")
+CHECK(PROG_TYPE, "tc_nodeport_nat_fwd_original_renated")
 int nodeport_nat_fwd_original_renated_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -1201,13 +1201,13 @@ int nodeport_nat_fwd_original_renated_check(const struct __ctx_buff *ctx)
  * NAT remote backend, and sends it back to the client. And expects
  * the Original NAT entry to be restored.
  */
-PKTGEN("tc", "tc_nodeport_nat_fwd_restore_original_entry")
+PKTGEN(PROG_TYPE, "tc_nodeport_nat_fwd_restore_original_entry")
 int nodeport_nat_fwd_restore_original_entry_pktgen(struct __ctx_buff *ctx)
 {
 	return build_reply(ctx);
 }
 
-SETUP("tc", "tc_nodeport_nat_fwd_restore_original_entry")
+SETUP(PROG_TYPE, "tc_nodeport_nat_fwd_restore_original_entry")
 int nodeport_nat_fwd_restore_original_entry_setup(struct __ctx_buff *ctx)
 {
 	struct ipv4_ct_tuple otuple = {};
@@ -1226,7 +1226,7 @@ int nodeport_nat_fwd_restore_original_entry_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_nat_fwd_restore_original_entry")
+CHECK(PROG_TYPE, "tc_nodeport_nat_fwd_restore_original_entry")
 int nodeport_nat_fwd_restore_original_entry_check(struct __ctx_buff *ctx)
 {
 	return check_reply(ctx);
@@ -1237,7 +1237,7 @@ int nodeport_nat_fwd_restore_original_entry_check(struct __ctx_buff *ctx)
  * - gets redirected back out by TC
  * - verifies that the Original NAT entry is restored.
  */
-PKTGEN("tc", "tc_nodeport_nat_fwd_verify_restored_original_entry")
+PKTGEN(PROG_TYPE, "tc_nodeport_nat_fwd_verify_restored_original_entry")
 int nodeport_nat_fwd_verify_restored_original_entry_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -1264,7 +1264,7 @@ int nodeport_nat_fwd_verify_restored_original_entry_pktgen(struct __ctx_buff *ct
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_nat_fwd_verify_restored_original_entry")
+SETUP(PROG_TYPE, "tc_nodeport_nat_fwd_verify_restored_original_entry")
 int nodeport_nat_fwd_verify_restored_original_entry_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 5;
@@ -1277,7 +1277,7 @@ int nodeport_nat_fwd_verify_restored_original_entry_setup(struct __ctx_buff *ctx
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_nat_fwd_verify_restored_original_entry")
+CHECK(PROG_TYPE, "tc_nodeport_nat_fwd_verify_restored_original_entry")
 int nodeport_nat_fwd_verify_restored_original_entry_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -1342,7 +1342,7 @@ int nodeport_nat_fwd_verify_restored_original_entry_check(struct __ctx_buff *ctx
 /* Test that a request to svc2 (FRONTEND_IP_REMOTE_2), which shares the same
  * backend as svc1, is correctly forwarded.
  */
-PKTGEN("tc", "tc_nodeport_nat_shared_backend_fwd")
+PKTGEN(PROG_TYPE, "tc_nodeport_nat_shared_backend_fwd")
 int tc_nodeport_nat_shared_backend_fwd_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -1366,7 +1366,7 @@ int tc_nodeport_nat_shared_backend_fwd_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_nat_shared_backend_fwd")
+SETUP(PROG_TYPE, "tc_nodeport_nat_shared_backend_fwd")
 int tc_nodeport_nat_shared_backend_fwd_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 6;
@@ -1381,7 +1381,7 @@ int tc_nodeport_nat_shared_backend_fwd_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_nat_shared_backend_fwd")
+CHECK(PROG_TYPE, "tc_nodeport_nat_shared_backend_fwd")
 int tc_nodeport_nat_shared_backend_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -1429,19 +1429,19 @@ int tc_nodeport_nat_shared_backend_fwd_check(__maybe_unused const struct __ctx_b
 /* Test that the reply from the shared backend is rev-NATed to svc2
  * (FRONTEND_IP_REMOTE_2), not svc1.
  */
-PKTGEN("tc", "tc_nodeport_nat_shared_backend_reply")
+PKTGEN(PROG_TYPE, "tc_nodeport_nat_shared_backend_reply")
 int tc_nodeport_nat_shared_backend_reply_pktgen(struct __ctx_buff *ctx)
 {
 	return build_reply(ctx);
 }
 
-SETUP("tc", "tc_nodeport_nat_shared_backend_reply")
+SETUP(PROG_TYPE, "tc_nodeport_nat_shared_backend_reply")
 int tc_nodeport_nat_shared_backend_reply_setup(struct __ctx_buff *ctx)
 {
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_nat_shared_backend_reply")
+CHECK(PROG_TYPE, "tc_nodeport_nat_shared_backend_reply")
 int tc_nodeport_nat_shared_backend_reply_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/tc_nodeport_lb6_dsr_backend.c
+++ b/bpf/tests/tc_nodeport_lb6_dsr_backend.c
@@ -95,7 +95,7 @@ mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
  * - redirects it to the pod (as BPF Host Routing is enabled)
  * - creates a matching CT entry, and SNAT entry from the DSR info
  */
-PKTGEN("tc", "tc_nodeport_dsr_backend")
+PKTGEN(PROG_TYPE, "tc_nodeport_dsr_backend")
 int nodeport_dsr_backend_pktgen(struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip = FRONTEND_IP;
@@ -147,7 +147,7 @@ int nodeport_dsr_backend_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_dsr_backend")
+SETUP(PROG_TYPE, "tc_nodeport_dsr_backend")
 int nodeport_dsr_backend_setup(struct __ctx_buff *ctx)
 {
 	union v6addr backend_ip = BACKEND_IP;
@@ -161,7 +161,7 @@ int nodeport_dsr_backend_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_dsr_backend")
+CHECK(PROG_TYPE, "tc_nodeport_dsr_backend")
 int nodeport_dsr_backend_check(struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip = FRONTEND_IP;
@@ -359,19 +359,19 @@ int check_reply(const struct __ctx_buff *ctx)
 /* Test that the backend node revDNATs a reply from the
  * DSR backend, and sends the reply back to the client.
  */
-PKTGEN("tc", "tc_nodeport_dsr_backend_reply")
+PKTGEN(PROG_TYPE, "tc_nodeport_dsr_backend_reply")
 int nodeport_dsr_backend_reply_pktgen(struct __ctx_buff *ctx)
 {
 	return build_reply(ctx);
 }
 
-SETUP("tc", "tc_nodeport_dsr_backend_reply")
+SETUP(PROG_TYPE, "tc_nodeport_dsr_backend_reply")
 int nodeport_dsr_backend_reply_reply_setup(struct __ctx_buff *ctx)
 {
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_dsr_backend_reply")
+CHECK(PROG_TYPE, "tc_nodeport_dsr_backend_reply")
 int nodeport_dsr_backend_reply_reply_check(const struct __ctx_buff *ctx)
 {
 	return check_reply(ctx);

--- a/bpf/tests/tc_nodeport_lb6_dsr_ipip_local.c
+++ b/bpf/tests/tc_nodeport_lb6_dsr_ipip_local.c
@@ -180,13 +180,13 @@ pktgen_client_to_svc_v6(struct __ctx_buff *ctx, const void *svc_addr,
 /* run (post-fd483bd2cd contract), delivery via ctx_redirect_peer, no encap.  */
 /* -------------------------------------------------------------------------- */
 
-PKTGEN("tc", "tc_nodeport_dsr_ipip_lb_local_pod_v6")
+PKTGEN(PROG_TYPE, "tc_nodeport_dsr_ipip_lb_local_pod_v6")
 int nodeport_dsr_ipip_lb_local_pod_v6_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_client_to_svc_v6(ctx, (void *)v6_pod_three, FRONTEND_PORT);
 }
 
-SETUP("tc", "tc_nodeport_dsr_ipip_lb_local_pod_v6")
+SETUP(PROG_TYPE, "tc_nodeport_dsr_ipip_lb_local_pod_v6")
 int nodeport_dsr_ipip_lb_local_pod_v6_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -211,7 +211,7 @@ int nodeport_dsr_ipip_lb_local_pod_v6_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_dsr_ipip_lb_local_pod_v6")
+CHECK(PROG_TYPE, "tc_nodeport_dsr_ipip_lb_local_pod_v6")
 int nodeport_dsr_ipip_lb_local_pod_v6_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -283,13 +283,13 @@ int nodeport_dsr_ipip_lb_local_pod_v6_check(struct __ctx_buff *ctx)
 /* host-ns). Punt to stack; no DNAT, no encap, no redirect.                   */
 /* -------------------------------------------------------------------------- */
 
-PKTGEN("tc", "tc_nodeport_dsr_ipip_lb_local_l7punt_v6")
+PKTGEN(PROG_TYPE, "tc_nodeport_dsr_ipip_lb_local_l7punt_v6")
 int nodeport_dsr_ipip_lb_local_l7punt_v6_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_client_to_svc_v6(ctx, (void *)v6_pod_three, FRONTEND_PORT);
 }
 
-SETUP("tc", "tc_nodeport_dsr_ipip_lb_local_l7punt_v6")
+SETUP(PROG_TYPE, "tc_nodeport_dsr_ipip_lb_local_l7punt_v6")
 int nodeport_dsr_ipip_lb_local_l7punt_v6_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 2;
@@ -315,7 +315,7 @@ int nodeport_dsr_ipip_lb_local_l7punt_v6_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_dsr_ipip_lb_local_l7punt_v6")
+CHECK(PROG_TYPE, "tc_nodeport_dsr_ipip_lb_local_l7punt_v6")
 int nodeport_dsr_ipip_lb_local_l7punt_v6_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/tc_nodeport_lb6_ipip_termination.c
+++ b/bpf/tests/tc_nodeport_lb6_ipip_termination.c
@@ -235,13 +235,13 @@ pktgen_ipip_v6(struct __ctx_buff *ctx, const void *outer_dst,
 /* Test 1: outer dst is a local Pod IP. Strip + DNAT + redirect_peer.         */
 /* -------------------------------------------------------------------------- */
 
-PKTGEN("tc", "tc_nodeport_ipip_term_v6_local_pod")
+PKTGEN(PROG_TYPE, "tc_nodeport_ipip_term_v6_local_pod")
 int ipip_term_v6_local_pod_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_ipip_v6(ctx, (void *)v6_pod_two, (void *)v6_pod_three);
 }
 
-SETUP("tc", "tc_nodeport_ipip_term_v6_local_pod")
+SETUP(PROG_TYPE, "tc_nodeport_ipip_term_v6_local_pod")
 int ipip_term_v6_local_pod_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -272,7 +272,7 @@ int ipip_term_v6_local_pod_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_ipip_term_v6_local_pod")
+CHECK(PROG_TYPE, "tc_nodeport_ipip_term_v6_local_pod")
 int ipip_term_v6_local_pod_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -344,14 +344,14 @@ int ipip_term_v6_local_pod_check(struct __ctx_buff *ctx)
 /* without running the forced-backend DNAT so Envoy sees the inner unchanged. */
 /* -------------------------------------------------------------------------- */
 
-PKTGEN("tc", "tc_nodeport_ipip_term_v6_l7_punt_proxy")
+PKTGEN(PROG_TYPE, "tc_nodeport_ipip_term_v6_l7_punt_proxy")
 int ipip_term_v6_l7_punt_proxy_pktgen(struct __ctx_buff *ctx)
 {
 	/* outer dst = local host IP (v6_node_one), inner dst = L7 svc VIP. */
 	return pktgen_ipip_v6(ctx, (void *)v6_node_one, (void *)v6_pod_three);
 }
 
-SETUP("tc", "tc_nodeport_ipip_term_v6_l7_punt_proxy")
+SETUP(PROG_TYPE, "tc_nodeport_ipip_term_v6_l7_punt_proxy")
 int ipip_term_v6_l7_punt_proxy_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 2;
@@ -379,7 +379,7 @@ int ipip_term_v6_l7_punt_proxy_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_ipip_term_v6_l7_punt_proxy")
+CHECK(PROG_TYPE, "tc_nodeport_ipip_term_v6_l7_punt_proxy")
 int ipip_term_v6_l7_punt_proxy_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -438,13 +438,13 @@ int ipip_term_v6_l7_punt_proxy_check(struct __ctx_buff *ctx)
 /* rationale and the full contract being pinned.                              */
 /* -------------------------------------------------------------------------- */
 
-PKTGEN("tc", "tc_nodeport_ipip_term_v6_xdp_handoff")
+PKTGEN(PROG_TYPE, "tc_nodeport_ipip_term_v6_xdp_handoff")
 int ipip_term_v6_xdp_handoff_pktgen(struct __ctx_buff *ctx)
 {
 	return pktgen_ipip_v6(ctx, (void *)v6_pod_two, (void *)v6_pod_three);
 }
 
-SETUP("tc", "tc_nodeport_ipip_term_v6_xdp_handoff")
+SETUP(PROG_TYPE, "tc_nodeport_ipip_term_v6_xdp_handoff")
 int ipip_term_v6_xdp_handoff_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -469,7 +469,7 @@ int ipip_term_v6_xdp_handoff_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_ipip_term_v6_xdp_handoff")
+CHECK(PROG_TYPE, "tc_nodeport_ipip_term_v6_xdp_handoff")
 int ipip_term_v6_xdp_handoff_check(struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/tc_nodeport_lb6_nat_lb.c
+++ b/bpf/tests/tc_nodeport_lb6_nat_lb.c
@@ -170,7 +170,7 @@ ASSIGN_CONFIG(__u32, interface_ifindex, DEFAULT_IFACE)
  * - gets DNATed (but not SNATed)
  * - gets redirected by TC (as BPF Host Routing is enabled)
  */
-PKTGEN("tc", "tc_nodeport_local_backend")
+PKTGEN(PROG_TYPE, "tc_nodeport_local_backend")
 int nodeport_local_backend_pktgen(struct __ctx_buff *ctx)
 {
 	union v6addr client_ip = CLIENT_IP;
@@ -196,7 +196,7 @@ int nodeport_local_backend_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_local_backend")
+SETUP(PROG_TYPE, "tc_nodeport_local_backend")
 int nodeport_local_backend_setup(struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip_local = FRONTEND_IP_LOCAL;
@@ -215,7 +215,7 @@ int nodeport_local_backend_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_local_backend")
+CHECK(PROG_TYPE, "tc_nodeport_local_backend")
 int nodeport_local_backend_check(const struct __ctx_buff *ctx)
 {
 	union v6addr client_ip = CLIENT_IP;
@@ -275,7 +275,7 @@ int nodeport_local_backend_check(const struct __ctx_buff *ctx)
 }
 
 /* Test that a reply by the local backend gets revDNATed at to-netdev. */
-PKTGEN("tc", "tc_nodeport_local_backend_reply")
+PKTGEN(PROG_TYPE, "tc_nodeport_local_backend_reply")
 int nodeport_local_backend_reply_pktgen(struct __ctx_buff *ctx)
 {
 	union v6addr backend_ip_local = BACKEND_IP_LOCAL;
@@ -301,13 +301,13 @@ int nodeport_local_backend_reply_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_local_backend_reply")
+SETUP(PROG_TYPE, "tc_nodeport_local_backend_reply")
 int nodeport_local_backend_reply_setup(struct __ctx_buff *ctx)
 {
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_local_backend_reply")
+CHECK(PROG_TYPE, "tc_nodeport_local_backend_reply")
 int nodeport_local_backend_reply_check(const struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip_local = FRONTEND_IP_LOCAL;
@@ -367,7 +367,7 @@ int nodeport_local_backend_reply_check(const struct __ctx_buff *ctx)
 /* Same scenario as above, but for a different CLIENT_IP_2. Here replies
  * should leave via a non-default interface.
  */
-PKTGEN("tc", "tc_nodeport_local_backend_redirect")
+PKTGEN(PROG_TYPE, "tc_nodeport_local_backend_redirect")
 int nodeport_local_backend_redirect_pktgen(struct __ctx_buff *ctx)
 {
 	union v6addr client_ip_2 = CLIENT_IP_2;
@@ -393,7 +393,7 @@ int nodeport_local_backend_redirect_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_local_backend_redirect")
+SETUP(PROG_TYPE, "tc_nodeport_local_backend_redirect")
 int nodeport_local_backend_redirect_setup(struct __ctx_buff *ctx)
 {
 	union v6addr backend_ip_local = BACKEND_IP_LOCAL;
@@ -404,7 +404,7 @@ int nodeport_local_backend_redirect_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_local_backend_redirect")
+CHECK(PROG_TYPE, "tc_nodeport_local_backend_redirect")
 int nodeport_local_backend_redirect_check(const struct __ctx_buff *ctx)
 {
 	union v6addr client_ip_2 = CLIENT_IP_2;
@@ -466,7 +466,7 @@ int nodeport_local_backend_redirect_check(const struct __ctx_buff *ctx)
 /* Test that to-netdev respects the routing needed for CLIENT_IP_2,
  * and redirects the packet to the correct egress interface.
  */
-PKTGEN("tc", "tc_nodeport_local_backend_redirect_reply")
+PKTGEN(PROG_TYPE, "tc_nodeport_local_backend_redirect_reply")
 int nodeport_local_backend_redirect_reply_pktgen(struct __ctx_buff *ctx)
 {
 	union v6addr backend_ip_local = BACKEND_IP_LOCAL;
@@ -492,13 +492,13 @@ int nodeport_local_backend_redirect_reply_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_local_backend_redirect_reply")
+SETUP(PROG_TYPE, "tc_nodeport_local_backend_redirect_reply")
 int nodeport_local_backend_redirect_reply_setup(struct __ctx_buff *ctx)
 {
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_local_backend_redirect_reply")
+CHECK(PROG_TYPE, "tc_nodeport_local_backend_redirect_reply")
 int nodeport_local_backend_redirect_reply_check(const struct __ctx_buff *ctx)
 {
 	union v6addr backend_ip_local = BACKEND_IP_LOCAL;
@@ -559,7 +559,7 @@ int nodeport_local_backend_redirect_reply_check(const struct __ctx_buff *ctx)
  * - gets DNATed (but not SNATed)
  * - gets redirected by TC (as BPF Host Routing is enabled)
  */
-PKTGEN("tc", "tc_nodeport_udp_local_backend")
+PKTGEN(PROG_TYPE, "tc_nodeport_udp_local_backend")
 int nodeport_udp_local_backend_pktgen(struct __ctx_buff *ctx)
 {
 	union v6addr client_ip = CLIENT_IP;
@@ -585,7 +585,7 @@ int nodeport_udp_local_backend_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_udp_local_backend")
+SETUP(PROG_TYPE, "tc_nodeport_udp_local_backend")
 int nodeport_udp_local_backend_setup(struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip_local = FRONTEND_IP_LOCAL;
@@ -602,7 +602,7 @@ int nodeport_udp_local_backend_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_udp_local_backend")
+CHECK(PROG_TYPE, "tc_nodeport_udp_local_backend")
 int nodeport_udp_local_backend_check(const struct __ctx_buff *ctx)
 {
 	union v6addr client_ip = CLIENT_IP;
@@ -665,7 +665,7 @@ int nodeport_udp_local_backend_check(const struct __ctx_buff *ctx)
  * - gets DNATed and SNATed,
  * - gets redirected back out by TC
  */
-PKTGEN("tc", "tc_nodeport_nat_fwd")
+PKTGEN(PROG_TYPE, "tc_nodeport_nat_fwd")
 int nodeport_nat_fwd_pktgen(struct __ctx_buff *ctx)
 {
 	union v6addr client_ip = CLIENT_IP;
@@ -691,7 +691,7 @@ int nodeport_nat_fwd_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_nat_fwd")
+SETUP(PROG_TYPE, "tc_nodeport_nat_fwd")
 int nodeport_nat_fwd_setup(struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip_remote = FRONTEND_IP_REMOTE;
@@ -707,7 +707,7 @@ int nodeport_nat_fwd_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_nat_fwd")
+CHECK(PROG_TYPE, "tc_nodeport_nat_fwd")
 int nodeport_nat_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	union v6addr lb_ip = LB_IP;
@@ -838,19 +838,19 @@ static __always_inline int check_reply(const struct __ctx_buff *ctx)
 /* Test that the LB RevDNATs and RevSNATs a reply from the
  * NAT remote backend, and sends it back to the client.
  */
-PKTGEN("tc", "tc_nodeport_nat_fwd_reply")
+PKTGEN(PROG_TYPE, "tc_nodeport_nat_fwd_reply")
 int nodeport_nat_fwd_reply_pktgen(struct __ctx_buff *ctx)
 {
 	return build_reply(ctx);
 }
 
-SETUP("tc", "tc_nodeport_nat_fwd_reply")
+SETUP(PROG_TYPE, "tc_nodeport_nat_fwd_reply")
 int nodeport_nat_fwd_reply_setup(struct __ctx_buff *ctx)
 {
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_nat_fwd_reply")
+CHECK(PROG_TYPE, "tc_nodeport_nat_fwd_reply")
 int nodeport_nat_fwd_reply_check(const struct __ctx_buff *ctx)
 {
 	return check_reply(ctx);
@@ -860,13 +860,13 @@ int nodeport_nat_fwd_reply_check(const struct __ctx_buff *ctx)
  * NAT remote backend, and sends it back to the client.
  * Even if the FIB lookup fails.
  */
-PKTGEN("tc", "tc_nodeport_nat_fwd_reply_no_fib")
+PKTGEN(PROG_TYPE, "tc_nodeport_nat_fwd_reply_no_fib")
 int nodeport_nat_fwd_reply_no_fib_pktgen(struct __ctx_buff *ctx)
 {
 	return build_reply(ctx);
 }
 
-SETUP("tc", "tc_nodeport_nat_fwd_reply_no_fib")
+SETUP(PROG_TYPE, "tc_nodeport_nat_fwd_reply_no_fib")
 int nodeport_nat_fwd_reply_no_fib_setup(struct __ctx_buff *ctx)
 {
 	__u32 key = 0;
@@ -878,7 +878,7 @@ int nodeport_nat_fwd_reply_no_fib_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_nat_fwd_reply_no_fib")
+CHECK(PROG_TYPE, "tc_nodeport_nat_fwd_reply_no_fib")
 int nodeport_nat_fwd_reply_no_fib_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return check_reply(ctx);
@@ -894,13 +894,13 @@ int nodeport_nat_fwd_reply_no_fib_check(__maybe_unused const struct __ctx_buff *
  * Test that the LB fails to RevDNAT and RevSNAT a reply from the
  * NAT remote backend when its Rev NAT entry gets deleted
  */
-PKTGEN("tc", "tc_nodeport_nat_fwd_reply_punt")
+PKTGEN(PROG_TYPE, "tc_nodeport_nat_fwd_reply_punt")
 int nodeport_nat_fwd_reply_punt_pktgen(struct __ctx_buff *ctx)
 {
 	return build_reply(ctx);
 }
 
-SETUP("tc", "tc_nodeport_nat_fwd_reply_punt")
+SETUP(PROG_TYPE, "tc_nodeport_nat_fwd_reply_punt")
 int nodeport_nat_fwd_reply_punt_setup(struct __ctx_buff *ctx)
 {
 	union v6addr backend_ip_remote = BACKEND_IP_REMOTE;
@@ -931,7 +931,7 @@ int nodeport_nat_fwd_reply_punt_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_nat_fwd_reply_punt")
+CHECK(PROG_TYPE, "tc_nodeport_nat_fwd_reply_punt")
 int nodeport_nat_fwd_reply_punt_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -957,7 +957,7 @@ int nodeport_nat_fwd_reply_punt_check(const struct __ctx_buff *ctx)
  * - gets DNATed and SNATed,
  * - gets redirected back out by TC
  */
-PKTGEN("tc", "tc_nodeport_nat_fwd_restore")
+PKTGEN(PROG_TYPE, "tc_nodeport_nat_fwd_restore")
 int nodeport_nat_fwd_restore_pktgen(struct __ctx_buff *ctx)
 {
 	union v6addr client_ip = CLIENT_IP;
@@ -983,7 +983,7 @@ int nodeport_nat_fwd_restore_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_nat_fwd_restore")
+SETUP(PROG_TYPE, "tc_nodeport_nat_fwd_restore")
 int nodeport_nat_fwd_restore_setup(struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip_remote = FRONTEND_IP_REMOTE;
@@ -999,7 +999,7 @@ int nodeport_nat_fwd_restore_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_nat_fwd_restore")
+CHECK(PROG_TYPE, "tc_nodeport_nat_fwd_restore")
 int nodeport_nat_fwd_restore_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	union v6addr lb_ip = LB_IP;
@@ -1052,19 +1052,19 @@ int nodeport_nat_fwd_restore_check(__maybe_unused const struct __ctx_buff *ctx)
 /* Test that the restored LB RevDNATs and RevSNATs a reply from the
  * NAT remote backend, and sends it back to the client.
  */
-PKTGEN("tc", "tc_nodeport_nat_fwd_restore_reply")
+PKTGEN(PROG_TYPE, "tc_nodeport_nat_fwd_restore_reply")
 int nodeport_nat_fwd_restore_reply_pktgen(struct __ctx_buff *ctx)
 {
 	return build_reply(ctx);
 }
 
-SETUP("tc", "tc_nodeport_nat_fwd_restore_reply")
+SETUP(PROG_TYPE, "tc_nodeport_nat_fwd_restore_reply")
 int nodeport_nat_fwd_restore_reply_setup(struct __ctx_buff *ctx)
 {
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_nat_fwd_restore_reply")
+CHECK(PROG_TYPE, "tc_nodeport_nat_fwd_restore_reply")
 int nodeport_nat_fwd_restore_reply_check(const struct __ctx_buff *ctx)
 {
 	return check_reply(ctx);
@@ -1081,7 +1081,7 @@ int nodeport_nat_fwd_restore_reply_check(const struct __ctx_buff *ctx)
  * Test that source port is changed when the Original NAT entry is deleted.
  * (ReSNATed)
  */
-PKTGEN("tc", "tc_nodeport_nat_fwd_original_renated")
+PKTGEN(PROG_TYPE, "tc_nodeport_nat_fwd_original_renated")
 int nodeport_nat_fwd_original_renated_pktgen(struct __ctx_buff *ctx)
 {
 	union v6addr client_ip = CLIENT_IP;
@@ -1107,7 +1107,7 @@ int nodeport_nat_fwd_original_renated_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_nat_fwd_original_renated")
+SETUP(PROG_TYPE, "tc_nodeport_nat_fwd_original_renated")
 int nodeport_nat_fwd_original_renated_setup(struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip_remote = FRONTEND_IP_REMOTE;
@@ -1136,7 +1136,7 @@ int nodeport_nat_fwd_original_renated_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_nat_fwd_original_renated")
+CHECK(PROG_TYPE, "tc_nodeport_nat_fwd_original_renated")
 int nodeport_nat_fwd_original_renated_check(const struct __ctx_buff *ctx)
 {
 	union v6addr lb_ip = LB_IP;
@@ -1197,13 +1197,13 @@ int nodeport_nat_fwd_original_renated_check(const struct __ctx_buff *ctx)
  * NAT remote backend, and sends it back to the client. And expects
  * the Original NAT entry to be restored.
  */
-PKTGEN("tc", "tc_nodeport_nat_fwd_restore_original_entry")
+PKTGEN(PROG_TYPE, "tc_nodeport_nat_fwd_restore_original_entry")
 int nodeport_nat_fwd_restore_original_entry_pktgen(struct __ctx_buff *ctx)
 {
 	return build_reply(ctx);
 }
 
-SETUP("tc", "tc_nodeport_nat_fwd_restore_original_entry")
+SETUP(PROG_TYPE, "tc_nodeport_nat_fwd_restore_original_entry")
 int nodeport_nat_fwd_restore_original_entry_setup(struct __ctx_buff *ctx)
 {
 	union v6addr backend_ip_remote = BACKEND_IP_REMOTE;
@@ -1224,7 +1224,7 @@ int nodeport_nat_fwd_restore_original_entry_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_nat_fwd_restore_original_entry")
+CHECK(PROG_TYPE, "tc_nodeport_nat_fwd_restore_original_entry")
 int nodeport_nat_fwd_restore_original_entry_check(struct __ctx_buff *ctx)
 {
 	return check_reply(ctx);
@@ -1235,7 +1235,7 @@ int nodeport_nat_fwd_restore_original_entry_check(struct __ctx_buff *ctx)
  * - gets redirected back out by TC
  * - verifies that the Original NAT entry is restored.
  */
-PKTGEN("tc", "tc_nodeport_nat_fwd_verify_restored_original_entry")
+PKTGEN(PROG_TYPE, "tc_nodeport_nat_fwd_verify_restored_original_entry")
 int nodeport_nat_fwd_verify_restored_original_entry_pktgen(struct __ctx_buff *ctx)
 {
 	union v6addr client_ip = CLIENT_IP;
@@ -1261,7 +1261,7 @@ int nodeport_nat_fwd_verify_restored_original_entry_pktgen(struct __ctx_buff *ct
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_nat_fwd_verify_restored_original_entry")
+SETUP(PROG_TYPE, "tc_nodeport_nat_fwd_verify_restored_original_entry")
 int nodeport_nat_fwd_verify_restored_original_entry_setup(struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip_remote = FRONTEND_IP_REMOTE;
@@ -1276,7 +1276,7 @@ int nodeport_nat_fwd_verify_restored_original_entry_setup(struct __ctx_buff *ctx
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_nat_fwd_verify_restored_original_entry")
+CHECK(PROG_TYPE, "tc_nodeport_nat_fwd_verify_restored_original_entry")
 int nodeport_nat_fwd_verify_restored_original_entry_check(struct __ctx_buff *ctx)
 {
 	union v6addr lb_ip = LB_IP;
@@ -1339,7 +1339,7 @@ int nodeport_nat_fwd_verify_restored_original_entry_check(struct __ctx_buff *ctx
 /* Test that a request to svc2 (FRONTEND_IP_REMOTE_2), which shares the same
  * backend as svc1, is correctly forwarded.
  */
-PKTGEN("tc", "tc_nodeport_nat_shared_backend_fwd")
+PKTGEN(PROG_TYPE, "tc_nodeport_nat_shared_backend_fwd")
 int gh10983_svc2_fwd_pktgen(struct __ctx_buff *ctx)
 {
 	union v6addr client_ip = CLIENT_IP;
@@ -1365,7 +1365,7 @@ int gh10983_svc2_fwd_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_nat_shared_backend_fwd")
+SETUP(PROG_TYPE, "tc_nodeport_nat_shared_backend_fwd")
 int gh10983_svc2_fwd_setup(struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip_remote_2 = FRONTEND_IP_REMOTE_2;
@@ -1382,7 +1382,7 @@ int gh10983_svc2_fwd_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_nat_shared_backend_fwd")
+CHECK(PROG_TYPE, "tc_nodeport_nat_shared_backend_fwd")
 int gh10983_svc2_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	union v6addr lb_ip = LB_IP;
@@ -1432,19 +1432,19 @@ int gh10983_svc2_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 /* Test that the reply from the shared backend is rev-NATed to svc2
  * (FRONTEND_IP_REMOTE_2), not svc1.
  */
-PKTGEN("tc", "tc_nodeport_nat_shared_backend_reply")
+PKTGEN(PROG_TYPE, "tc_nodeport_nat_shared_backend_reply")
 int gh10983_svc2_reply_pktgen(struct __ctx_buff *ctx)
 {
 	return build_reply(ctx);
 }
 
-SETUP("tc", "tc_nodeport_nat_shared_backend_reply")
+SETUP(PROG_TYPE, "tc_nodeport_nat_shared_backend_reply")
 int gh10983_svc2_reply_setup(struct __ctx_buff *ctx)
 {
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_nat_shared_backend_reply")
+CHECK(PROG_TYPE, "tc_nodeport_nat_shared_backend_reply")
 int gh10983_svc2_reply_check(const struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip_remote_2 = FRONTEND_IP_REMOTE_2;

--- a/bpf/tests/tc_nodeport_lb_dsr_ipip.c
+++ b/bpf/tests/tc_nodeport_lb_dsr_ipip.c
@@ -122,7 +122,7 @@ long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
  * - keeps the inner destination as the service IP,
  * - gets redirected back out by TC
  */
-PKTGEN("tc", "tc_nodeport_dsr_ipip4_fwd")
+PKTGEN(PROG_TYPE, "tc_nodeport_dsr_ipip4_fwd")
 int nodeport_dsr_ipip4_fwd_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -149,7 +149,7 @@ int nodeport_dsr_ipip4_fwd_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_dsr_ipip4_fwd")
+SETUP(PROG_TYPE, "tc_nodeport_dsr_ipip4_fwd")
 int nodeport_dsr_ipip4_fwd_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -163,7 +163,7 @@ int nodeport_dsr_ipip4_fwd_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_dsr_ipip4_fwd")
+CHECK(PROG_TYPE, "tc_nodeport_dsr_ipip4_fwd")
 int nodeport_dsr_ipip4_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -231,7 +231,7 @@ int nodeport_dsr_ipip4_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
  * - keeps the inner destination as the service IP,
  * - gets redirected back out by TC
  */
-PKTGEN("tc", "tc_nodeport_dsr_ipip6_fwd")
+PKTGEN(PROG_TYPE, "tc_nodeport_dsr_ipip6_fwd")
 int nodeport_dsr_ipip6_fwd_pktgen(struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip = FRONTEND_IPV6;
@@ -260,7 +260,7 @@ int nodeport_dsr_ipip6_fwd_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_dsr_ipip6_fwd")
+SETUP(PROG_TYPE, "tc_nodeport_dsr_ipip6_fwd")
 int nodeport_dsr_ipip6_fwd_setup(struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip = FRONTEND_IPV6;
@@ -276,7 +276,7 @@ int nodeport_dsr_ipip6_fwd_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_dsr_ipip6_fwd")
+CHECK(PROG_TYPE, "tc_nodeport_dsr_ipip6_fwd")
 int nodeport_dsr_ipip6_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip = FRONTEND_IPV6;

--- a/bpf/tests/tc_nodeport_lb_dsr_lb.c
+++ b/bpf/tests/tc_nodeport_lb_dsr_lb.c
@@ -78,7 +78,7 @@ long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
  * - has IP Option inserted,
  * - gets redirected back out by TC
  */
-PKTGEN("tc", "tc_nodeport_dsr_fwd4")
+PKTGEN(PROG_TYPE, "tc_nodeport_dsr_fwd4")
 int nodeport_dsr_fwd4_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -105,7 +105,7 @@ int nodeport_dsr_fwd4_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_dsr_fwd4")
+SETUP(PROG_TYPE, "tc_nodeport_dsr_fwd4")
 int nodeport_dsr_fwd4_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -119,7 +119,7 @@ int nodeport_dsr_fwd4_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_dsr_fwd4")
+CHECK(PROG_TYPE, "tc_nodeport_dsr_fwd4")
 int nodeport_dsr_fwd4_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	struct dsr_opt_v4 *opt;
@@ -187,7 +187,7 @@ int nodeport_dsr_fwd4_check(__maybe_unused const struct __ctx_buff *ctx)
  * - has IPv6 Extension inserted,
  * - gets redirected back out by TC
  */
-PKTGEN("tc", "tc_nodeport_dsr_fwd6")
+PKTGEN(PROG_TYPE, "tc_nodeport_dsr_fwd6")
 int nodeport_dsr_fwd6_pktgen(struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip = FRONTEND_IPV6;
@@ -216,7 +216,7 @@ int nodeport_dsr_fwd6_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_dsr_fwd6")
+SETUP(PROG_TYPE, "tc_nodeport_dsr_fwd6")
 int nodeport_dsr_fwd6_setup(struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip = FRONTEND_IPV6;
@@ -232,7 +232,7 @@ int nodeport_dsr_fwd6_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_dsr_fwd6")
+CHECK(PROG_TYPE, "tc_nodeport_dsr_fwd6")
 int nodeport_dsr_fwd6_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip = FRONTEND_IPV6;

--- a/bpf/tests/tc_nodeport_lb_fragments.h
+++ b/bpf/tests/tc_nodeport_lb_fragments.h
@@ -171,7 +171,7 @@ const __u8 lb6_ew_nodeport_fragment2_post_dnat[] = {
 };
 
 /* Test that the 1st fragment of an external-to-nodeport request is handled correctly */
-PKTGEN("tc", "tc_nodeport_lb4_fragments_1")
+PKTGEN(PROG_TYPE, "tc_nodeport_lb4_fragments_1")
 int nodeport_lb4_fragments_1_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -189,7 +189,7 @@ int nodeport_lb4_fragments_1_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_lb4_fragments_1")
+SETUP(PROG_TYPE, "tc_nodeport_lb4_fragments_1")
 int nodeport_lb4_fragments_1_setup(struct __ctx_buff *ctx)
 {
 	policy_add_egress_allow_all_entry();
@@ -204,7 +204,7 @@ int nodeport_lb4_fragments_1_setup(struct __ctx_buff *ctx)
 	return HOOK(ctx);
 }
 
-CHECK("tc", "tc_nodeport_lb4_fragments_1")
+CHECK(PROG_TYPE, "tc_nodeport_lb4_fragments_1")
 int nodeport_lb4_fragments_1_check(struct __ctx_buff *ctx)
 {
 	__u32 *status_code;
@@ -262,7 +262,7 @@ int nodeport_lb4_fragments_1_check(struct __ctx_buff *ctx)
 }
 
 /* Test that the 2nd fragment is handled correctly */
-PKTGEN("tc", "tc_nodeport_lb4_fragments_2")
+PKTGEN(PROG_TYPE, "tc_nodeport_lb4_fragments_2")
 int nodeport_lb4_fragments_2_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -280,7 +280,7 @@ int nodeport_lb4_fragments_2_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_lb4_fragments_2")
+SETUP(PROG_TYPE, "tc_nodeport_lb4_fragments_2")
 int nodeport_lb4_fragments_2_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v4_add_entry(BACKEND_IP, BACKEND_IFINDEX, 0, 0, 0, 0,
@@ -289,7 +289,7 @@ int nodeport_lb4_fragments_2_setup(struct __ctx_buff *ctx)
 	return HOOK(ctx);
 }
 
-CHECK("tc", "tc_nodeport_lb4_fragments_2")
+CHECK(PROG_TYPE, "tc_nodeport_lb4_fragments_2")
 int nodeport_lb4_fragments_2_check(struct __ctx_buff *ctx)
 {
 	__u32 *status_code;
@@ -341,7 +341,7 @@ int nodeport_lb4_fragments_2_check(struct __ctx_buff *ctx)
 }
 
 /* Test that the 1st fragment is handled correctly */
-PKTGEN("tc", "tc_nodeport_lb6_fragment1")
+PKTGEN(PROG_TYPE, "tc_nodeport_lb6_fragment1")
 int nodeport_lb6_fragment1_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -359,7 +359,7 @@ int nodeport_lb6_fragment1_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_lb6_fragment1")
+SETUP(PROG_TYPE, "tc_nodeport_lb6_fragment1")
 int nodeport_lb6_fragment1_setup(struct __ctx_buff *ctx)
 {
 	policy_add_egress_allow_all_entry();
@@ -375,7 +375,7 @@ int nodeport_lb6_fragment1_setup(struct __ctx_buff *ctx)
 	return HOOK(ctx);
 }
 
-CHECK("tc", "tc_nodeport_lb6_fragment1")
+CHECK(PROG_TYPE, "tc_nodeport_lb6_fragment1")
 int nodeport_lb6_fragment1_check(struct __ctx_buff *ctx)
 {
 	__u32 *status_code;
@@ -432,7 +432,7 @@ int nodeport_lb6_fragment1_check(struct __ctx_buff *ctx)
 }
 
 /* Test that the 2nd fragment is handled correctly */
-PKTGEN("tc", "tc_nodeport_lb6_fragment2")
+PKTGEN(PROG_TYPE, "tc_nodeport_lb6_fragment2")
 int nodeport_lb6_fragment2_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -450,13 +450,13 @@ int nodeport_lb6_fragment2_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_lb6_fragment2")
+SETUP(PROG_TYPE, "tc_nodeport_lb6_fragment2")
 int nodeport_lb6_fragment2_setup(struct __ctx_buff *ctx)
 {
 	return HOOK(ctx);
 }
 
-CHECK("tc", "tc_nodeport_lb6_fragment2")
+CHECK(PROG_TYPE, "tc_nodeport_lb6_fragment2")
 int nodeport_lb6_fragment2_check(struct __ctx_buff *ctx)
 {
 	__u32 *status_code;

--- a/bpf/tests/tc_nodeport_lb_nat_lb_dynamic.c
+++ b/bpf/tests/tc_nodeport_lb_nat_lb_dynamic.c
@@ -125,7 +125,7 @@ const __u8 tc_nodeport_lb6_nat_lb_dynamic_post[] = {
  * - gets DNATed and SNATed,
  * - gets redirected back out by TC
  */
-PKTGEN("tc", "tc_nodeport_lb4_nat_lb_dynamic")
+PKTGEN(PROG_TYPE, "tc_nodeport_lb4_nat_lb_dynamic")
 int tc_nodeport_lb4_nat_lb_dynamic_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -140,7 +140,7 @@ int tc_nodeport_lb4_nat_lb_dynamic_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_lb4_nat_lb_dynamic")
+SETUP(PROG_TYPE, "tc_nodeport_lb4_nat_lb_dynamic")
 int tc_nodeport_lb4_nat_lb_dynamic_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -154,7 +154,7 @@ int tc_nodeport_lb4_nat_lb_dynamic_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_lb4_nat_lb_dynamic")
+CHECK(PROG_TYPE, "tc_nodeport_lb4_nat_lb_dynamic")
 int tc_nodeport_lb4_nat_lb_dynamic_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -184,7 +184,7 @@ int tc_nodeport_lb4_nat_lb_dynamic_check(const struct __ctx_buff *ctx)
  * - gets DNATed and SNATed,
  * - gets redirected back out by TC
  */
-PKTGEN("tc", "tc_nodeport_lb6_nat_lb_dynamic")
+PKTGEN(PROG_TYPE, "tc_nodeport_lb6_nat_lb_dynamic")
 int tc_nodeport_lb6_nat_lb_dynamic_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -199,7 +199,7 @@ int tc_nodeport_lb6_nat_lb_dynamic_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_lb6_nat_lb_dynamic")
+SETUP(PROG_TYPE, "tc_nodeport_lb6_nat_lb_dynamic")
 int tc_nodeport_lb6_nat_lb_dynamic_setup(struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip = FRONTEND_IPV6;
@@ -215,7 +215,7 @@ int tc_nodeport_lb6_nat_lb_dynamic_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_lb6_nat_lb_dynamic")
+CHECK(PROG_TYPE, "tc_nodeport_lb6_nat_lb_dynamic")
 int tc_nodeport_lb6_nat_lb_dynamic_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/tc_nodeport_lb_no_backend.c
+++ b/bpf/tests/tc_nodeport_lb_no_backend.c
@@ -38,7 +38,7 @@ ASSIGN_CONFIG(bool, enable_no_service_endpoints_routable, true)
 #include "lib/lb.h"
 
 /* Test that a SVC without backends returns a TCP RST or ICMP error */
-PKTGEN("tc", "tc_nodeport_no_backend4")
+PKTGEN(PROG_TYPE, "tc_nodeport_no_backend4")
 int nodeport_no_backend4_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -65,7 +65,7 @@ int nodeport_no_backend4_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_no_backend4")
+SETUP(PROG_TYPE, "tc_nodeport_no_backend4")
 int nodeport_no_backend4_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -140,21 +140,21 @@ validate_icmp_reply(const struct __ctx_buff *ctx, __u32 retval)
 	test_finish();
 }
 
-CHECK("tc", "tc_nodeport_no_backend4")
+CHECK(PROG_TYPE, "tc_nodeport_no_backend4")
 int nodeport_no_backend4_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return validate_icmp_reply(ctx, CTX_ACT_REDIRECT);
 }
 
 /* Test that the ICMP error message leaves the node */
-PKTGEN("tc", "tc_nodeport_no_backend4_2_reply")
+PKTGEN(PROG_TYPE, "tc_nodeport_no_backend4_2_reply")
 int nodeport_no_backend4_2_reply_pktgen(struct __ctx_buff *ctx)
 {
 	/* Start with the initial request, and let SETUP() below rebuild it. */
 	return nodeport_no_backend4_pktgen(ctx);
 }
 
-SETUP("tc", "tc_nodeport_no_backend4_2_reply")
+SETUP(PROG_TYPE, "tc_nodeport_no_backend4_2_reply")
 int nodeport_no_backend4_2_reply_setup(struct __ctx_buff *ctx)
 {
 	if (tail_no_service_ipv4(ctx) != CTX_ACT_REDIRECT)
@@ -163,14 +163,14 @@ int nodeport_no_backend4_2_reply_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_no_backend4_2_reply")
+CHECK(PROG_TYPE, "tc_nodeport_no_backend4_2_reply")
 int nodeport_no_backend4_2_reply_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return validate_icmp_reply(ctx, CTX_ACT_OK);
 }
 
 /* Test that a SVC without backends returns a TCP RST or ICMP error */
-PKTGEN("tc", "tc_nodeport_no_backend6")
+PKTGEN(PROG_TYPE, "tc_nodeport_no_backend6")
 int nodeport_no_backend6_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -198,7 +198,7 @@ int nodeport_no_backend6_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_no_backend6")
+SETUP(PROG_TYPE, "tc_nodeport_no_backend6")
 int nodeport_no_backend6_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 2;
@@ -235,21 +235,21 @@ validate_icmpv6_reply_return(const struct __ctx_buff *ctx, __u32 retval) {
 	return validate_icmpv6_reply(&args);
 }
 
-CHECK("tc", "tc_nodeport_no_backend6")
+CHECK(PROG_TYPE, "tc_nodeport_no_backend6")
 int nodeport_no_backend6_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return validate_icmpv6_reply_return(ctx, CTX_ACT_REDIRECT);
 }
 
 /* Test that the ICMP error message leaves the node */
-PKTGEN("tc", "tc_nodeport_no_backend6_2_reply")
+PKTGEN(PROG_TYPE, "tc_nodeport_no_backend6_2_reply")
 int nodeport_no_backend6_2_reply_pktgen(struct __ctx_buff *ctx)
 {
 	/* Start with the initial request, and let SETUP() below rebuild it. */
 	return nodeport_no_backend6_pktgen(ctx);
 }
 
-SETUP("tc", "tc_nodeport_no_backend6_2_reply")
+SETUP(PROG_TYPE, "tc_nodeport_no_backend6_2_reply")
 int nodeport_no_backend6_2_reply_setup(struct __ctx_buff *ctx)
 {
 	if (generate_icmp6_reply(ctx, ICMPV6_DEST_UNREACH, ICMPV6_PORT_UNREACH))
@@ -258,7 +258,7 @@ int nodeport_no_backend6_2_reply_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_no_backend6_2_reply")
+CHECK(PROG_TYPE, "tc_nodeport_no_backend6_2_reply")
 int nodeport_no_backend6_2_reply_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return validate_icmpv6_reply_return(ctx, CTX_ACT_OK);

--- a/bpf/tests/tc_nodeport_lb_terminating_backend.c
+++ b/bpf/tests/tc_nodeport_lb_terminating_backend.c
@@ -92,7 +92,7 @@ ASSIGN_CONFIG(__u32, interface_ifindex, DEFAULT_IFACE)
  * - gets DNATed (but not SNATed)
  * - gets redirected by TC (as BPF Host Routing is enabled)
  */
-PKTGEN("tc", "tc_nodeport_lb_terminating_backend_0")
+PKTGEN(PROG_TYPE, "tc_nodeport_lb_terminating_backend_0")
 int tc_nodeport_lb_terminating_backend_0_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -119,7 +119,7 @@ int tc_nodeport_lb_terminating_backend_0_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_lb_terminating_backend_0")
+SETUP(PROG_TYPE, "tc_nodeport_lb_terminating_backend_0")
 int tc_nodeport_lb_terminating_backend_0_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = SVC_REV_NAT_ID;
@@ -137,7 +137,7 @@ int tc_nodeport_lb_terminating_backend_0_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_lb_terminating_backend_0")
+CHECK(PROG_TYPE, "tc_nodeport_lb_terminating_backend_0")
 int tc_nodeport_lb_terminating_backend_0_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -201,7 +201,7 @@ int tc_nodeport_lb_terminating_backend_0_check(const struct __ctx_buff *ctx)
 /* Test that a second request gets LBed to a terminating backend,
  * even when the service has no active backends remaining.
  */
-PKTGEN("tc", "tc_nodeport_lb_terminating_backend_1")
+PKTGEN(PROG_TYPE, "tc_nodeport_lb_terminating_backend_1")
 int tc_nodeport_lb_terminating_backend_1_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -228,7 +228,7 @@ int tc_nodeport_lb_terminating_backend_1_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_lb_terminating_backend_1")
+SETUP(PROG_TYPE, "tc_nodeport_lb_terminating_backend_1")
 int tc_nodeport_lb_terminating_backend_1_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = SVC_REV_NAT_ID;
@@ -246,7 +246,7 @@ int tc_nodeport_lb_terminating_backend_1_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_lb_terminating_backend_1")
+CHECK(PROG_TYPE, "tc_nodeport_lb_terminating_backend_1")
 int tc_nodeport_lb_terminating_backend_1_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/tc_nodeport_lb_wildcard_drop.c
+++ b/bpf/tests/tc_nodeport_lb_wildcard_drop.c
@@ -203,14 +203,14 @@ static __always_inline int validate_packet(const struct __ctx_buff *ctx,
 
 /* Test wildcard drop for unknown destination port on TCP */
 
-PKTGEN("tc", "tc_nodeport_lb4_wildcard_drop_unknown_dport")
+PKTGEN(PROG_TYPE, "tc_nodeport_lb4_wildcard_drop_unknown_dport")
 int tc_nodeport_lb4_wildcard_drop_unknown_dport_pktgen(struct __ctx_buff *ctx)
 {
 	/* Generate a packet to the Frontend IP, but to an unknown TCP dest port. */
 	return build_packet(ctx, UNKNOWN_PORT, IPPROTO_TCP);
 }
 
-SETUP("tc", "tc_nodeport_lb4_wildcard_drop_unknown_dport")
+SETUP(PROG_TYPE, "tc_nodeport_lb4_wildcard_drop_unknown_dport")
 int tc_nodeport_lb4_wildcard_drop_unknown_dport_setup(struct __ctx_buff *ctx)
 {
 	setup_services(ctx);
@@ -218,7 +218,7 @@ int tc_nodeport_lb4_wildcard_drop_unknown_dport_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_lb4_wildcard_drop_unknown_dport")
+CHECK(PROG_TYPE, "tc_nodeport_lb4_wildcard_drop_unknown_dport")
 int tc_nodeport_lb4_wildcard_drop_unknown_dport_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return validate_packet(ctx, (__u8 *)client_mac, (__u8 *)lb_mac, CLIENT_IP, FRONTEND_IP,
@@ -227,14 +227,14 @@ int tc_nodeport_lb4_wildcard_drop_unknown_dport_check(__maybe_unused const struc
 
 /* Test wildcard drop for unknown protocol on a valid destination port */
 
-PKTGEN("tc", "tc_nodeport_lb4_wildcard_drop_unknown_proto")
+PKTGEN(PROG_TYPE, "tc_nodeport_lb4_wildcard_drop_unknown_proto")
 int tc_nodeport_lb4_wildcard_drop_unknown_proto_pktgen(struct __ctx_buff *ctx)
 {
 	/* Generate a packet to the Frontend IP and port, but on an unknown protocol */
 	return build_packet(ctx, FRONTEND_PORT, IPPROTO_UDP);
 }
 
-SETUP("tc", "tc_nodeport_lb4_wildcard_drop_unknown_proto")
+SETUP(PROG_TYPE, "tc_nodeport_lb4_wildcard_drop_unknown_proto")
 int tc_nodeport_lb4_wildcard_drop_unknown_proto_setup(struct __ctx_buff *ctx)
 {
 	setup_services(ctx);
@@ -242,7 +242,7 @@ int tc_nodeport_lb4_wildcard_drop_unknown_proto_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_lb4_wildcard_drop_unknown_proto")
+CHECK(PROG_TYPE, "tc_nodeport_lb4_wildcard_drop_unknown_proto")
 int tc_nodeport_lb4_wildcard_drop_unknown_proto_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return validate_packet(ctx,
@@ -256,14 +256,14 @@ int tc_nodeport_lb4_wildcard_drop_unknown_proto_check(__maybe_unused const struc
  * per lbXX_no_backend testing.
  */
 
-PKTGEN("tc", "tc_nodeport_lb4_wildcard_drop_not_unknown")
+PKTGEN(PROG_TYPE, "tc_nodeport_lb4_wildcard_drop_not_unknown")
 int tc_nodeport_lb4_wildcard_drop_not_unknown_pktgen(struct __ctx_buff *ctx)
 {
 	/* Generate a packet to the Frontend IP and port, on TCP */
 	return build_packet(ctx, FRONTEND_PORT, IPPROTO_TCP);
 }
 
-SETUP("tc", "tc_nodeport_lb4_wildcard_drop_not_unknown")
+SETUP(PROG_TYPE, "tc_nodeport_lb4_wildcard_drop_not_unknown")
 int tc_nodeport_lb4_wildcard_drop_not_unknown_setup(struct __ctx_buff *ctx)
 {
 	setup_services(ctx);
@@ -271,7 +271,7 @@ int tc_nodeport_lb4_wildcard_drop_not_unknown_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_lb4_wildcard_drop_not_unknown")
+CHECK(PROG_TYPE, "tc_nodeport_lb4_wildcard_drop_not_unknown")
 int tc_nodeport_lb4_wildcard_drop_not_unknown_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	/* We should receive an ICMP Unreachable */
@@ -279,14 +279,14 @@ int tc_nodeport_lb4_wildcard_drop_not_unknown_check(__maybe_unused const struct 
 			       FRONTEND_PORT, IPPROTO_ICMP, CTX_ACT_REDIRECT);
 }
 
-PKTGEN("tc", "tc_nodeport_lb4_wildcard_drop_not_unknown2")
+PKTGEN(PROG_TYPE, "tc_nodeport_lb4_wildcard_drop_not_unknown2")
 int tc_nodeport_lb4_wildcard_drop_not_unknown2_pktgen(struct __ctx_buff *ctx)
 {
 	/* Generate a packet to the Frontend IP and port, on TCP */
 	return build_packet(ctx, FRONTEND_PORT, IPPROTO_TCP);
 }
 
-SETUP("tc", "tc_nodeport_lb4_wildcard_drop_not_unknown2")
+SETUP(PROG_TYPE, "tc_nodeport_lb4_wildcard_drop_not_unknown2")
 int tc_nodeport_lb4_wildcard_drop_not_unknown2_setup(struct __ctx_buff *ctx)
 {
 	if (tail_no_service_ipv4(ctx) != CTX_ACT_REDIRECT)
@@ -297,7 +297,7 @@ int tc_nodeport_lb4_wildcard_drop_not_unknown2_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_lb4_wildcard_drop_not_unknown2")
+CHECK(PROG_TYPE, "tc_nodeport_lb4_wildcard_drop_not_unknown2")
 int tc_nodeport_lb4_wildcard_drop_not_unknown2_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	/* We should receive an ICMP Unreachable */
@@ -472,14 +472,14 @@ static __always_inline int validate_packet6(const struct __ctx_buff *ctx,
 
 /* Test wildcard drop for unknown destination port on TCP */
 
-PKTGEN("tc", "tc_nodeport_lb6_wildcard_drop_unknown_dport")
+PKTGEN(PROG_TYPE, "tc_nodeport_lb6_wildcard_drop_unknown_dport")
 int tc_nodeport_lb6_wildcard_drop_unknown_dport_pktgen(struct __ctx_buff *ctx)
 {
 	/* Generate a packet to the Frontend IP, but to an unknown TCP dest port. */
 	return build_packet6(ctx, UNKNOWN_PORT, IPPROTO_TCP);
 }
 
-SETUP("tc", "tc_nodeport_lb6_wildcard_drop_unknown_dport")
+SETUP(PROG_TYPE, "tc_nodeport_lb6_wildcard_drop_unknown_dport")
 int tc_nodeport_lb6_wildcard_drop_unknown_dport_setup(struct __ctx_buff *ctx)
 {
 	setup_services6(ctx);
@@ -487,7 +487,7 @@ int tc_nodeport_lb6_wildcard_drop_unknown_dport_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_lb6_wildcard_drop_unknown_dport")
+CHECK(PROG_TYPE, "tc_nodeport_lb6_wildcard_drop_unknown_dport")
 int tc_nodeport_lb6_wildcard_drop_unknown_dport_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return validate_packet6(ctx, (__u8 *)client_mac, (__u8 *)lb_mac, client_ip6.addr,
@@ -496,14 +496,14 @@ int tc_nodeport_lb6_wildcard_drop_unknown_dport_check(__maybe_unused const struc
 
 /* Test wildcard drop for unknown protocol on a valid destination port */
 
-PKTGEN("tc", "tc_nodeport_lb6_wildcard_drop_unknown_proto")
+PKTGEN(PROG_TYPE, "tc_nodeport_lb6_wildcard_drop_unknown_proto")
 int tc_nodeport_lb6_wildcard_drop_unknown_proto_pktgen(struct __ctx_buff *ctx)
 {
 	/* Generate a packet to the Frontend IP and port, but on an unknown protocol */
 	return build_packet6(ctx, FRONTEND_PORT, IPPROTO_UDP);
 }
 
-SETUP("tc", "tc_nodeport_lb6_wildcard_drop_unknown_proto")
+SETUP(PROG_TYPE, "tc_nodeport_lb6_wildcard_drop_unknown_proto")
 int tc_nodeport_lb6_wildcard_drop_unknown_proto_setup(struct __ctx_buff *ctx)
 {
 	setup_services6(ctx);
@@ -511,7 +511,7 @@ int tc_nodeport_lb6_wildcard_drop_unknown_proto_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_lb6_wildcard_drop_unknown_proto")
+CHECK(PROG_TYPE, "tc_nodeport_lb6_wildcard_drop_unknown_proto")
 int tc_nodeport_lb6_wildcard_drop_unknown_proto_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	return validate_packet6(ctx, (__u8 *)client_mac, (__u8 *)lb_mac, client_ip6.addr,
@@ -523,14 +523,14 @@ int tc_nodeport_lb6_wildcard_drop_unknown_proto_check(__maybe_unused const struc
  * per lbXX_no_backend testing.
  */
 
-PKTGEN("tc", "tc_nodeport_lb6_wildcard_drop_not_unknown")
+PKTGEN(PROG_TYPE, "tc_nodeport_lb6_wildcard_drop_not_unknown")
 int tc_nodeport_lb6_wildcard_drop_not_unknown_pktgen(struct __ctx_buff *ctx)
 {
 	/* Generate a packet to the Frontend IP and port, on TCP */
 	return build_packet6(ctx, FRONTEND_PORT, IPPROTO_TCP);
 }
 
-SETUP("tc", "tc_nodeport_lb6_wildcard_drop_not_unknown")
+SETUP(PROG_TYPE, "tc_nodeport_lb6_wildcard_drop_not_unknown")
 int tc_nodeport_lb6_wildcard_drop_not_unknown_setup(struct __ctx_buff *ctx)
 {
 	setup_services6(ctx);
@@ -538,7 +538,7 @@ int tc_nodeport_lb6_wildcard_drop_not_unknown_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_lb6_wildcard_drop_not_unknown")
+CHECK(PROG_TYPE, "tc_nodeport_lb6_wildcard_drop_not_unknown")
 int tc_nodeport_lb6_wildcard_drop_not_unknown_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	/* We should receive an ICMP Unreachable */
@@ -546,14 +546,14 @@ int tc_nodeport_lb6_wildcard_drop_not_unknown_check(__maybe_unused const struct 
 				client_ip6.addr, FRONTEND_PORT, IPPROTO_ICMPV6, CTX_ACT_REDIRECT);
 }
 
-PKTGEN("tc", "tc_nodeport_lb6_wildcard_drop_not_unknown2")
+PKTGEN(PROG_TYPE, "tc_nodeport_lb6_wildcard_drop_not_unknown2")
 int tc_nodeport_lb6_wildcard_drop_not_unknown2_pktgen(struct __ctx_buff *ctx)
 {
 	/* Generate a packet to the Frontend IP and port, on TCP */
 	return build_packet6(ctx, FRONTEND_PORT, IPPROTO_TCP);
 }
 
-SETUP("tc", "tc_nodeport_lb6_wildcard_drop_not_unknown2")
+SETUP(PROG_TYPE, "tc_nodeport_lb6_wildcard_drop_not_unknown2")
 int tc_nodeport_lb6_wildcard_drop_not_unknown2_setup(struct __ctx_buff *ctx)
 {
 	if (generate_icmp6_reply(ctx, ICMPV6_DEST_UNREACH, ICMPV6_PORT_UNREACH))
@@ -564,7 +564,7 @@ int tc_nodeport_lb6_wildcard_drop_not_unknown2_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_lb6_wildcard_drop_not_unknown2")
+CHECK(PROG_TYPE, "tc_nodeport_lb6_wildcard_drop_not_unknown2")
 int tc_nodeport_lb6_wildcard_drop_not_unknown2_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	/* We should receive an ICMP Unreachable */

--- a/bpf/tests/tc_nodeport_snat_conflict.c
+++ b/bpf/tests/tc_nodeport_snat_conflict.c
@@ -108,7 +108,7 @@ static __always_inline int tc_nodeport_snat_conflict_assert_ipv6(void)
  * within the endpoint map to an external host, subjecting it to the nat fwd
  * path.
  */
-PKTGEN("tc", "tc_nodeport_snat_conflict_host_ipv4")
+PKTGEN(PROG_TYPE, "tc_nodeport_snat_conflict_host_ipv4")
 int tc_nodeport_snat_conflict_host_ipv4_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -132,7 +132,7 @@ int tc_nodeport_snat_conflict_host_ipv4_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_snat_conflict_host_ipv4")
+SETUP(PROG_TYPE, "tc_nodeport_snat_conflict_host_ipv4")
 int tc_nodeport_snat_conflict_host_ipv4_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v4_add_entry(NODE_IP, 0, 0, ENDPOINT_F_HOST, HOST_ID,
@@ -143,7 +143,7 @@ int tc_nodeport_snat_conflict_host_ipv4_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_snat_conflict_host_ipv4")
+CHECK(PROG_TYPE, "tc_nodeport_snat_conflict_host_ipv4")
 int tc_nodeport_snat_conflict_host_ipv4_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -159,7 +159,7 @@ int tc_nodeport_snat_conflict_host_ipv4_check(struct __ctx_buff *ctx)
  * IPv6: Create a request from a host process or host-networked pod from a host IP
  * within the endpoint map to an external host, subjecting it to the nat fwd path.
  */
-PKTGEN("tc", "tc_nodeport_snat_conflict_host_ipv6")
+PKTGEN(PROG_TYPE, "tc_nodeport_snat_conflict_host_ipv6")
 int tc_nodeport_snat_conflict_host_ipv6_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -183,7 +183,7 @@ int tc_nodeport_snat_conflict_host_ipv6_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_snat_conflict_host_ipv6")
+SETUP(PROG_TYPE, "tc_nodeport_snat_conflict_host_ipv6")
 int tc_nodeport_snat_conflict_host_ipv6_setup(struct __ctx_buff *ctx)
 {
 	union v6addr node_ip6 = NODE_IP6_ADDR;
@@ -196,7 +196,7 @@ int tc_nodeport_snat_conflict_host_ipv6_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_snat_conflict_host_ipv6")
+CHECK(PROG_TYPE, "tc_nodeport_snat_conflict_host_ipv6")
 int tc_nodeport_snat_conflict_host_ipv6_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -209,7 +209,7 @@ int tc_nodeport_snat_conflict_host_ipv6_check(struct __ctx_buff *ctx)
  * Create a non-transparent request from the egress proxy sourced from a node
  * IP, subjecting it to the nat fwd path.
  */
-PKTGEN("tc", "tc_nodeport_snat_conflict_egressproxy_ipv4")
+PKTGEN(PROG_TYPE, "tc_nodeport_snat_conflict_egressproxy_ipv4")
 int tc_nodeport_snat_conflict_egressproxy_ipv4_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -233,7 +233,7 @@ int tc_nodeport_snat_conflict_egressproxy_ipv4_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_snat_conflict_egressproxy_ipv4")
+SETUP(PROG_TYPE, "tc_nodeport_snat_conflict_egressproxy_ipv4")
 int tc_nodeport_snat_conflict_egressproxy_ipv4_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v4_add_entry(NODE_IP, 0, 0, ENDPOINT_F_HOST, HOST_ID,
@@ -244,7 +244,7 @@ int tc_nodeport_snat_conflict_egressproxy_ipv4_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_snat_conflict_egressproxy_ipv4")
+CHECK(PROG_TYPE, "tc_nodeport_snat_conflict_egressproxy_ipv4")
 int tc_nodeport_snat_conflict_egressproxy_ipv4_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -260,7 +260,7 @@ int tc_nodeport_snat_conflict_egressproxy_ipv4_check(struct __ctx_buff *ctx)
  * IPv6: Create a non-transparent request from the egress proxy sourced from a
  * node IP, subjecting it to the nat fwd path.
  */
-PKTGEN("tc", "tc_nodeport_snat_conflict_egressproxy_ipv6")
+PKTGEN(PROG_TYPE, "tc_nodeport_snat_conflict_egressproxy_ipv6")
 int tc_nodeport_snat_conflict_egressproxy_ipv6_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -284,7 +284,7 @@ int tc_nodeport_snat_conflict_egressproxy_ipv6_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_snat_conflict_egressproxy_ipv6")
+SETUP(PROG_TYPE, "tc_nodeport_snat_conflict_egressproxy_ipv6")
 int tc_nodeport_snat_conflict_egressproxy_ipv6_setup(struct __ctx_buff *ctx)
 {
 	union v6addr node_ip6 = NODE_IP6_ADDR;
@@ -297,7 +297,7 @@ int tc_nodeport_snat_conflict_egressproxy_ipv6_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_snat_conflict_egressproxy_ipv6")
+CHECK(PROG_TYPE, "tc_nodeport_snat_conflict_egressproxy_ipv6")
 int tc_nodeport_snat_conflict_egressproxy_ipv6_check(struct __ctx_buff *ctx)
 {
 	test_init();
@@ -312,7 +312,7 @@ int tc_nodeport_snat_conflict_egressproxy_ipv6_check(struct __ctx_buff *ctx)
  *
  * We expect no conntrack to be created in this scenario.
  */
-PKTGEN("tc", "tc_nodeport_snat_conflict_pod_ipv4")
+PKTGEN(PROG_TYPE, "tc_nodeport_snat_conflict_pod_ipv4")
 int tc_nodeport_snat_conflict_pod_ipv4_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -336,7 +336,7 @@ int tc_nodeport_snat_conflict_pod_ipv4_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_snat_conflict_pod_ipv4")
+SETUP(PROG_TYPE, "tc_nodeport_snat_conflict_pod_ipv4")
 int tc_nodeport_snat_conflict_pod_ipv4_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v4_add_entry(POD_IP, 0, 0, 0, POD_SEC_IDENTITY,
@@ -347,7 +347,7 @@ int tc_nodeport_snat_conflict_pod_ipv4_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_snat_conflict_pod_ipv4")
+CHECK(PROG_TYPE, "tc_nodeport_snat_conflict_pod_ipv4")
 int tc_nodeport_snat_conflict_pod_ipv4_check(struct __ctx_buff *ctx)
 {
 	struct ipv4_ct_tuple tuple = {
@@ -379,7 +379,7 @@ int tc_nodeport_snat_conflict_pod_ipv4_check(struct __ctx_buff *ctx)
  *
  * We expect no conntrack to be created in this scenario.
  */
-PKTGEN("tc", "tc_nodeport_snat_conflict_pod_ipv6")
+PKTGEN(PROG_TYPE, "tc_nodeport_snat_conflict_pod_ipv6")
 int tc_nodeport_snat_conflict_pod_ipv6_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -403,7 +403,7 @@ int tc_nodeport_snat_conflict_pod_ipv6_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_nodeport_snat_conflict_pod_ipv6")
+SETUP(PROG_TYPE, "tc_nodeport_snat_conflict_pod_ipv6")
 int tc_nodeport_snat_conflict_pod_ipv6_setup(struct __ctx_buff *ctx)
 {
 	union v6addr pod_ip6 = POD_IP6_ADDR;
@@ -416,7 +416,7 @@ int tc_nodeport_snat_conflict_pod_ipv6_setup(struct __ctx_buff *ctx)
 	return netdev_send_packet(ctx);
 }
 
-CHECK("tc", "tc_nodeport_snat_conflict_pod_ipv6")
+CHECK(PROG_TYPE, "tc_nodeport_snat_conflict_pod_ipv6")
 int tc_nodeport_snat_conflict_pod_ipv6_check(struct __ctx_buff *ctx)
 {
 	struct ipv6_ct_tuple tuple = {

--- a/bpf/tests/tc_nodeport_test.c
+++ b/bpf/tests/tc_nodeport_test.c
@@ -68,7 +68,7 @@ static __always_inline int build_packet(struct __ctx_buff *ctx,
 	return 0;
 }
 
-PKTGEN("tc", "hairpin_flow_1_forward_v4")
+PKTGEN(PROG_TYPE, "hairpin_flow_1_forward_v4")
 int hairpin_flow_forward_pktgen(struct __ctx_buff *ctx)
 {
 	return build_packet(ctx, tcp_src_one);
@@ -77,7 +77,7 @@ int hairpin_flow_forward_pktgen(struct __ctx_buff *ctx)
 /* Test that sending a packet from a pod to its own service gets source nat-ed
  * and that it is forwarded to the correct veth.
  */
-SETUP("tc", "hairpin_flow_1_forward_v4")
+SETUP(PROG_TYPE, "hairpin_flow_1_forward_v4")
 int hairpin_flow_forward_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -98,7 +98,7 @@ int hairpin_flow_forward_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "hairpin_flow_1_forward_v4")
+CHECK(PROG_TYPE, "hairpin_flow_1_forward_v4")
 int hairpin_flow_forward_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data;
@@ -188,7 +188,7 @@ int hairpin_flow_forward_check(__maybe_unused const struct __ctx_buff *ctx)
 }
 
 /* Let backend's ingress path create its own CT entry: */
-PKTGEN("tc", "hairpin_flow_2_forward_ingress_v4")
+PKTGEN(PROG_TYPE, "hairpin_flow_2_forward_ingress_v4")
 int hairpin_flow_forward_ingress_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -219,13 +219,13 @@ int hairpin_flow_forward_ingress_pktgen(struct __ctx_buff *ctx)
 }
 
 /* Test that a packet in the forward direction is good. */
-SETUP("tc", "hairpin_flow_2_forward_ingress_v4")
+SETUP(PROG_TYPE, "hairpin_flow_2_forward_ingress_v4")
 int hairpin_flow_forward_ingress_setup(struct __ctx_buff *ctx)
 {
 	return pod_receive_packet(ctx);
 }
 
-CHECK("tc", "hairpin_flow_2_forward_ingress_v4")
+CHECK(PROG_TYPE, "hairpin_flow_2_forward_ingress_v4")
 int hairpin_flow_forward_ingress_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data;
@@ -297,7 +297,7 @@ int hairpin_flow_forward_ingress_check(__maybe_unused const struct __ctx_buff *c
 	test_finish();
 }
 
-PKTGEN("tc", "hairpin_flow_3_reverse_v4")
+PKTGEN(PROG_TYPE, "hairpin_flow_3_reverse_v4")
 int hairpin_flow_reverse_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -330,7 +330,7 @@ int hairpin_flow_reverse_pktgen(struct __ctx_buff *ctx)
 }
 
 /* Test that a packet in the reverse direction gets translated back. */
-SETUP("tc", "hairpin_flow_3_reverse_v4")
+SETUP(PROG_TYPE, "hairpin_flow_3_reverse_v4")
 int hairpin_flow_rev_setup(struct __ctx_buff *ctx)
 {
 	endpoint_v4_add_entry(v4_pod_one, 0, 0, 0, 0, 0, NULL, NULL);
@@ -338,7 +338,7 @@ int hairpin_flow_rev_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "hairpin_flow_3_reverse_v4")
+CHECK(PROG_TYPE, "hairpin_flow_3_reverse_v4")
 int hairpin_flow_rev_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data;
@@ -389,7 +389,7 @@ int hairpin_flow_rev_check(__maybe_unused const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "hairpin_flow_4_reverse_ingress_v4")
+PKTGEN(PROG_TYPE, "hairpin_flow_4_reverse_ingress_v4")
 int hairpin_flow_reverse_ingress_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -421,13 +421,13 @@ int hairpin_flow_reverse_ingress_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "hairpin_flow_4_reverse_ingress_v4")
+SETUP(PROG_TYPE, "hairpin_flow_4_reverse_ingress_v4")
 int hairpin_flow_reverse_ingress_setup(struct __ctx_buff *ctx)
 {
 	return pod_receive_packet(ctx);
 }
 
-CHECK("tc", "hairpin_flow_4_reverse_ingress_v4")
+CHECK(PROG_TYPE, "hairpin_flow_4_reverse_ingress_v4")
 int hairpin_flow_reverse_ingress_check(const struct __ctx_buff *ctx)
 {
 	void *data;
@@ -480,7 +480,7 @@ int hairpin_flow_reverse_ingress_check(const struct __ctx_buff *ctx)
 }
 
 /* Test that a packet for a SVC without any backend gets dropped. */
-SETUP("tc", "tc_drop_no_backend")
+SETUP(PROG_TYPE, "tc_drop_no_backend")
 int tc_drop_no_backend_setup(struct __ctx_buff *ctx)
 {
 	int ret;
@@ -497,7 +497,7 @@ int tc_drop_no_backend_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "tc_drop_no_backend")
+CHECK(PROG_TYPE, "tc_drop_no_backend")
 int tc_drop_no_backend_check(const struct __ctx_buff *ctx)
 {
 	__u32 expected_status = TC_ACT_SHOT;
@@ -546,13 +546,13 @@ static __always_inline int build_packet_v6(struct __ctx_buff *ctx, __be16 sport)
 	return 0;
 }
 
-PKTGEN("tc", "hairpin_flow_1_forward_v6")
+PKTGEN(PROG_TYPE, "hairpin_flow_1_forward_v6")
 int hairpin_flow_forward_pktgen_v6(struct __ctx_buff *ctx)
 {
 	return build_packet_v6(ctx, tcp_src_one);
 }
 
-SETUP("tc", "hairpin_flow_1_forward_v6")
+SETUP(PROG_TYPE, "hairpin_flow_1_forward_v6")
 int hairpin_flow_forward_setup_v6(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -572,7 +572,7 @@ int hairpin_flow_forward_setup_v6(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "hairpin_flow_1_forward_v6")
+CHECK(PROG_TYPE, "hairpin_flow_1_forward_v6")
 int hairpin_flow_forward_check_v6(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data;
@@ -653,7 +653,7 @@ int hairpin_flow_forward_check_v6(__maybe_unused const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "hairpin_flow_2_forward_ingress_v6")
+PKTGEN(PROG_TYPE, "hairpin_flow_2_forward_ingress_v6")
 int hairpin_flow_forward_ingress_pktgen_v6(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -679,13 +679,13 @@ int hairpin_flow_forward_ingress_pktgen_v6(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "hairpin_flow_2_forward_ingress_v6")
+SETUP(PROG_TYPE, "hairpin_flow_2_forward_ingress_v6")
 int hairpin_flow_forward_ingress_setup_v6(struct __ctx_buff *ctx)
 {
 	return pod_receive_packet(ctx);
 }
 
-CHECK("tc", "hairpin_flow_2_forward_ingress_v6")
+CHECK(PROG_TYPE, "hairpin_flow_2_forward_ingress_v6")
 int hairpin_flow_forward_ingress_check_v6(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data;
@@ -753,7 +753,7 @@ int hairpin_flow_forward_ingress_check_v6(__maybe_unused const struct __ctx_buff
 	test_finish();
 }
 
-PKTGEN("tc", "hairpin_flow_3_reverse_v6")
+PKTGEN(PROG_TYPE, "hairpin_flow_3_reverse_v6")
 int hairpin_flow_reverse_pktgen_v6(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -782,13 +782,13 @@ int hairpin_flow_reverse_pktgen_v6(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "hairpin_flow_3_reverse_v6")
+SETUP(PROG_TYPE, "hairpin_flow_3_reverse_v6")
 int hairpin_flow_rev_setup_v6(struct __ctx_buff *ctx)
 {
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "hairpin_flow_3_reverse_v6")
+CHECK(PROG_TYPE, "hairpin_flow_3_reverse_v6")
 int hairpin_flow_rev_check_v6(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data;
@@ -838,7 +838,7 @@ int hairpin_flow_rev_check_v6(__maybe_unused const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-PKTGEN("tc", "hairpin_flow_4_reverse_ingress_v6")
+PKTGEN(PROG_TYPE, "hairpin_flow_4_reverse_ingress_v6")
 int hairpin_flow_reverse_ingress_pktgen_v6(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -867,13 +867,13 @@ int hairpin_flow_reverse_ingress_pktgen_v6(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "hairpin_flow_4_reverse_ingress_v6")
+SETUP(PROG_TYPE, "hairpin_flow_4_reverse_ingress_v6")
 int hairpin_flow_reverse_ingress_setup_v6(struct __ctx_buff *ctx)
 {
 	return pod_receive_packet(ctx);
 }
 
-CHECK("tc", "hairpin_flow_4_reverse_ingress_v6")
+CHECK(PROG_TYPE, "hairpin_flow_4_reverse_ingress_v6")
 int hairpin_flow_reverse_ingress_check_v6(const struct __ctx_buff *ctx)
 {
 	void *data;
@@ -922,7 +922,7 @@ int hairpin_flow_reverse_ingress_check_v6(const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-SETUP("tc", "tc_drop_no_backend_v6")
+SETUP(PROG_TYPE, "tc_drop_no_backend_v6")
 int tc_drop_no_backend_setup_v6(struct __ctx_buff *ctx)
 {
 	int ret;
@@ -939,7 +939,7 @@ int tc_drop_no_backend_setup_v6(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "tc_drop_no_backend_v6")
+CHECK(PROG_TYPE, "tc_drop_no_backend_v6")
 int tc_drop_no_backend_check_v6(const struct __ctx_buff *ctx)
 {
 	__u32 expected_status = TC_ACT_SHOT;

--- a/bpf/tests/tc_policy_reject_response_test.c
+++ b/bpf/tests/tc_policy_reject_response_test.c
@@ -21,7 +21,7 @@ ASSIGN_CONFIG(bool, policy_deny_response_enabled, true)
 #define CLIENT_IP v4_pod_one
 #define TARGET_IP v4_ext_one
 
-PKTGEN("tc", "policy_reject_response_v4")
+PKTGEN(PROG_TYPE, "policy_reject_response_v4")
 int policy_reject_response_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -48,7 +48,7 @@ int policy_reject_response_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "policy_reject_response_v4")
+SETUP(PROG_TYPE, "policy_reject_response_v4")
 int policy_reject_response_setup(struct __ctx_buff *ctx)
 {
 	/* Add endpoint for source */
@@ -64,7 +64,7 @@ int policy_reject_response_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "policy_reject_response_v4")
+CHECK(PROG_TYPE, "policy_reject_response_v4")
 int policy_reject_response_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -142,7 +142,7 @@ validate_icmpv6_reply_return(const struct __ctx_buff *ctx, __u32 retval)
 	return validate_icmpv6_reply(&args);
 }
 
-PKTGEN("tc", "policy_reject_response_v6")
+PKTGEN(PROG_TYPE, "policy_reject_response_v6")
 int policy_reject_response_v6_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -170,7 +170,7 @@ int policy_reject_response_v6_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "policy_reject_response_v6")
+SETUP(PROG_TYPE, "policy_reject_response_v6")
 int policy_reject_response_v6_setup(struct __ctx_buff *ctx)
 {
 	/* Add endpoint for source */
@@ -186,7 +186,7 @@ int policy_reject_response_v6_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "policy_reject_response_v6")
+CHECK(PROG_TYPE, "policy_reject_response_v6")
 int policy_reject_response_v6_check(const struct __ctx_buff *ctx)
 {
 	/* we should have a redirect of the packet on the same interface. */
@@ -196,14 +196,14 @@ int policy_reject_response_v6_check(const struct __ctx_buff *ctx)
 /*
  * Test that the ICMP error message goes back into the pod
  */
-PKTGEN("tc", "policy_reject_response_v6_ingress")
+PKTGEN(PROG_TYPE, "policy_reject_response_v6_ingress")
 int policy_reject_response_v6_ingress_pktgen(struct __ctx_buff *ctx)
 {
 	/* Start with the initial request, and let SETUP() below rebuild it. */
 	return policy_reject_response_v6_pktgen(ctx);
 }
 
-SETUP("tc", "policy_reject_response_v6_ingress")
+SETUP(PROG_TYPE, "policy_reject_response_v6_ingress")
 int policy_reject_response_v6_ingress_setup(struct __ctx_buff *ctx)
 {
 	if (generate_icmp6_reply(ctx, ICMPV6_DEST_UNREACH, ICMPV6_ADM_PROHIBITED))
@@ -212,7 +212,7 @@ int policy_reject_response_v6_ingress_setup(struct __ctx_buff *ctx)
 	return pod_receive_packet(ctx);
 }
 
-CHECK("tc", "policy_reject_response_v6_ingress")
+CHECK(PROG_TYPE, "policy_reject_response_v6_ingress")
 int policy_reject_response_v6_ingress_check(const struct __ctx_buff *ctx)
 {
 	return validate_icmpv6_reply_return(ctx, TC_ACT_SHOT);

--- a/bpf/tests/tc_redirect_host.h
+++ b/bpf/tests/tc_redirect_host.h
@@ -189,7 +189,7 @@ const __u8 tc_redirect_host_ipv4_post[] = {
  * | v4_ext_one:high-port   | -> | v4_pod_one:tcp_svc_one |
  * +------------------------+    +------------------------+
  */
-PKTGEN("tc", "tc_redirect_host_ipv4")
+PKTGEN(PROG_TYPE, "tc_redirect_host_ipv4")
 int tc_redirect_host_ipv4_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -207,7 +207,7 @@ int tc_redirect_host_ipv4_pktgen(struct __ctx_buff *ctx)
 /* Test that sending a packet from the host into a Pod is correctly forwarded via
  * the appropriate bpf redirect helper.
  */
-SETUP("tc", "tc_redirect_host_ipv4")
+SETUP(PROG_TYPE, "tc_redirect_host_ipv4")
 int tc_redirect_host_ipv4_setup(struct __ctx_buff *ctx)
 {
 	/* Add an IPCache entry for pod 1 */
@@ -224,7 +224,7 @@ int tc_redirect_host_ipv4_setup(struct __ctx_buff *ctx)
 	return host_send_packet(ctx);
 }
 
-CHECK("tc", "tc_redirect_host_ipv4")
+CHECK(PROG_TYPE, "tc_redirect_host_ipv4")
 int tc_redirect_host_ipv4_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 #ifdef __CONFIG_ENABLE_ENDPOINT_ROUTES
@@ -301,7 +301,7 @@ const __u8 tc_redirect_host_ipv6_post[] = {
  * | v6_ext_one:high-port   | -> | v6_pod_one:tcp_svc_one |
  * +------------------------+    +------------------------+
  */
-PKTGEN("tc", "tc_redirect_host_ipv6")
+PKTGEN(PROG_TYPE, "tc_redirect_host_ipv6")
 int tc_redirect_host_ipv6_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -319,7 +319,7 @@ int tc_redirect_host_ipv6_pktgen(struct __ctx_buff *ctx)
 /* Test that sending a packet from the host into a Pod is correctly forwarded via
  * the appropriate bpf redirect helper.
  */
-SETUP("tc", "tc_redirect_host_ipv6")
+SETUP(PROG_TYPE, "tc_redirect_host_ipv6")
 int tc_redirect_host_ipv6_setup(struct __ctx_buff *ctx)
 {
 	const union v6addr pod_ip = { .addr = v6_pod_one_addr };
@@ -339,7 +339,7 @@ int tc_redirect_host_ipv6_setup(struct __ctx_buff *ctx)
 	return host_send_packet(ctx);
 }
 
-CHECK("tc", "tc_redirect_host_ipv6")
+CHECK(PROG_TYPE, "tc_redirect_host_ipv6")
 int tc_redirect_host_ipv6_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 #ifdef __CONFIG_ENABLE_ENDPOINT_ROUTES

--- a/bpf/tests/tc_redirect_lxc.h
+++ b/bpf/tests/tc_redirect_lxc.h
@@ -166,7 +166,7 @@ const __u8 tc_redirect_lxc_ipv4_post[] = {
  *            ^                            |
  *            \---------------------------/
  */
-PKTGEN("tc", "tc_redirect_lxc_ipv4")
+PKTGEN(PROG_TYPE, "tc_redirect_lxc_ipv4")
 int tc_redirect_lxc_ipv4_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -184,7 +184,7 @@ int tc_redirect_lxc_ipv4_pktgen(struct __ctx_buff *ctx)
 /* Test that sending a packet from a pod to its own service gets source nat-ed
  * and that it is forwarded via the correct BPF redirect helper.
  */
-SETUP("tc", "tc_redirect_lxc_ipv4")
+SETUP(PROG_TYPE, "tc_redirect_lxc_ipv4")
 int tc_redirect_lxc_ipv4_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -205,7 +205,7 @@ int tc_redirect_lxc_ipv4_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "tc_redirect_lxc_ipv4")
+CHECK(PROG_TYPE, "tc_redirect_lxc_ipv4")
 int tc_redirect_lxc_ipv4_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 #ifdef __CONFIG_ENABLE_NETKIT
@@ -274,7 +274,7 @@ const __u8 tc_redirect_lxc_ipv6_post[] = {
  *            ^                            |
  *            \---------------------------/
  */
-PKTGEN("tc", "tc_redirect_lxc_ipv6")
+PKTGEN(PROG_TYPE, "tc_redirect_lxc_ipv6")
 int tc_redirect_lxc_ipv6_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -292,7 +292,7 @@ int tc_redirect_lxc_ipv6_pktgen(struct __ctx_buff *ctx)
 /* Test that sending a packet from a pod to its own service gets source nat-ed
  * and that it is forwarded via the correct BPF redirect helper.
  */
-SETUP("tc", "tc_redirect_lxc_ipv6")
+SETUP(PROG_TYPE, "tc_redirect_lxc_ipv6")
 int tc_redirect_lxc_ipv6_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -315,7 +315,7 @@ int tc_redirect_lxc_ipv6_setup(struct __ctx_buff *ctx)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "tc_redirect_lxc_ipv6")
+CHECK(PROG_TYPE, "tc_redirect_lxc_ipv6")
 int tc_redirect_lxc_ipv6_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 #ifdef __CONFIG_ENABLE_NETKIT

--- a/bpf/tests/tc_redirect_netdev.h
+++ b/bpf/tests/tc_redirect_netdev.h
@@ -189,7 +189,7 @@ const __u8 tc_redirect_netdev_ipv4_post[] = {
  * and netkit - that's the behavior the runtime arm of should_redirect_peer
  * encodes (and what 210b5866e0 inadvertently broke for netkit).
  */
-PKTGEN("tc", "tc_redirect_netdev_ipv4")
+PKTGEN(PROG_TYPE, "tc_redirect_netdev_ipv4")
 int tc_redirect_netdev_ipv4_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -204,7 +204,7 @@ int tc_redirect_netdev_ipv4_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_redirect_netdev_ipv4")
+SETUP(PROG_TYPE, "tc_redirect_netdev_ipv4")
 int tc_redirect_netdev_ipv4_setup(struct __ctx_buff *ctx)
 {
 	/* phys-netdev TC ingress: kernel sets ingress_ifindex */
@@ -221,7 +221,7 @@ int tc_redirect_netdev_ipv4_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_redirect_netdev_ipv4")
+CHECK(PROG_TYPE, "tc_redirect_netdev_ipv4")
 int tc_redirect_netdev_ipv4_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	/* Both veth and netkit must take the redirect_peer() path here:
@@ -273,7 +273,7 @@ int tc_redirect_netdev_ipv4_check(__maybe_unused const struct __ctx_buff *ctx)
  * is the right answer (and matches the existing tc_redirect_lxc_veth_*
  * expectations).
  */
-PKTGEN("tc", "tc_redirect_pod_egress_ipv4")
+PKTGEN(PROG_TYPE, "tc_redirect_pod_egress_ipv4")
 int tc_redirect_pod_egress_ipv4_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -288,7 +288,7 @@ int tc_redirect_pod_egress_ipv4_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_redirect_pod_egress_ipv4")
+SETUP(PROG_TYPE, "tc_redirect_pod_egress_ipv4")
 int tc_redirect_pod_egress_ipv4_setup(struct __ctx_buff *ctx)
 {
 	/* Pod-egress on netkit: ns crossing scrubs ingress_ifindex to 0 */
@@ -302,7 +302,7 @@ int tc_redirect_pod_egress_ipv4_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_redirect_pod_egress_ipv4")
+CHECK(PROG_TYPE, "tc_redirect_pod_egress_ipv4")
 int tc_redirect_pod_egress_ipv4_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 #ifdef __CONFIG_ENABLE_NETKIT
@@ -363,7 +363,7 @@ const __u8 tc_redirect_netdev_ipv6_post[] = {
 	SCAPY_BUF_BYTES(tc_redirect_host_ipv6_post)
 };
 
-PKTGEN("tc", "tc_redirect_netdev_ipv6")
+PKTGEN(PROG_TYPE, "tc_redirect_netdev_ipv6")
 int tc_redirect_netdev_ipv6_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -378,7 +378,7 @@ int tc_redirect_netdev_ipv6_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_redirect_netdev_ipv6")
+SETUP(PROG_TYPE, "tc_redirect_netdev_ipv6")
 int tc_redirect_netdev_ipv6_setup(struct __ctx_buff *ctx)
 {
 	const union v6addr pod_ip = { .addr = v6_pod_one_addr };
@@ -394,7 +394,7 @@ int tc_redirect_netdev_ipv6_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_redirect_netdev_ipv6")
+CHECK(PROG_TYPE, "tc_redirect_netdev_ipv6")
 int tc_redirect_netdev_ipv6_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	const unsigned int expected[RECORD__MAX] = {1, 0, 1};
@@ -432,7 +432,7 @@ int tc_redirect_netdev_ipv6_check(__maybe_unused const struct __ctx_buff *ctx)
 }
 
 /* See the IPv4 sibling for the rationale of this scenario. */
-PKTGEN("tc", "tc_redirect_pod_egress_ipv6")
+PKTGEN(PROG_TYPE, "tc_redirect_pod_egress_ipv6")
 int tc_redirect_pod_egress_ipv6_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -447,7 +447,7 @@ int tc_redirect_pod_egress_ipv6_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("tc", "tc_redirect_pod_egress_ipv6")
+SETUP(PROG_TYPE, "tc_redirect_pod_egress_ipv6")
 int tc_redirect_pod_egress_ipv6_setup(struct __ctx_buff *ctx)
 {
 	const union v6addr pod_ip = { .addr = v6_pod_one_addr };
@@ -462,7 +462,7 @@ int tc_redirect_pod_egress_ipv6_setup(struct __ctx_buff *ctx)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_redirect_pod_egress_ipv6")
+CHECK(PROG_TYPE, "tc_redirect_pod_egress_ipv6")
 int tc_redirect_pod_egress_ipv6_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 #ifdef __CONFIG_ENABLE_NETKIT

--- a/bpf/tests/tc_srv6_decap.c
+++ b/bpf/tests/tc_srv6_decap.c
@@ -37,7 +37,7 @@ ASSIGN_CONFIG(bool, enable_bpf_host_routing, true)
 #define CLIENT_PORT __bpf_htons(12345)
 #define SERVICE_PORT __bpf_htons(80)
 
-PKTGEN("tc", "tc_srv6_decap_to_pod_ipv4")
+PKTGEN(PROG_TYPE, "tc_srv6_decap_to_pod_ipv4")
 int srv6_decap_to_pod_ipv4_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -101,7 +101,7 @@ int srv6_decap_to_pod_ipv4_pktgen(struct __ctx_buff *ctx)
 	return TEST_PASS;
 }
 
-SETUP("tc", "tc_srv6_decap_to_pod_ipv4")
+SETUP(PROG_TYPE, "tc_srv6_decap_to_pod_ipv4")
 int srv6_decap_to_pod_ipv4_setup(struct __ctx_buff *ctx __maybe_unused)
 {
 	union v6addr sid __align_stack_8;
@@ -117,7 +117,7 @@ int srv6_decap_to_pod_ipv4_setup(struct __ctx_buff *ctx __maybe_unused)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_srv6_decap_to_pod_ipv4")
+CHECK(PROG_TYPE, "tc_srv6_decap_to_pod_ipv4")
 int srv6_decap_to_pod_ipv4_check(const struct __ctx_buff *ctx __maybe_unused)
 {
 	void *data;
@@ -175,7 +175,7 @@ int srv6_decap_to_pod_ipv4_check(const struct __ctx_buff *ctx __maybe_unused)
 	return TEST_PASS;
 }
 
-PKTGEN("tc", "tc_srv6_decap_to_pod_ipv6")
+PKTGEN(PROG_TYPE, "tc_srv6_decap_to_pod_ipv6")
 int srv6_decap_to_pod_ipv6_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -239,7 +239,7 @@ int srv6_decap_to_pod_ipv6_pktgen(struct __ctx_buff *ctx)
 	return TEST_PASS;
 }
 
-SETUP("tc", "tc_srv6_decap_to_pod_ipv6")
+SETUP(PROG_TYPE, "tc_srv6_decap_to_pod_ipv6")
 int srv6_decap_to_pod_ipv6_setup(struct __ctx_buff *ctx __maybe_unused)
 {
 	union v6addr sid;
@@ -255,7 +255,7 @@ int srv6_decap_to_pod_ipv6_setup(struct __ctx_buff *ctx __maybe_unused)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_srv6_decap_to_pod_ipv6")
+CHECK(PROG_TYPE, "tc_srv6_decap_to_pod_ipv6")
 int srv6_decap_to_pod_ipv6_check(const struct __ctx_buff *ctx __maybe_unused)
 {
 	void *data;
@@ -313,7 +313,7 @@ int srv6_decap_to_pod_ipv6_check(const struct __ctx_buff *ctx __maybe_unused)
 	return TEST_PASS;
 }
 
-PKTGEN("tc", "tc_srv6_decap_to_service_ipv4")
+PKTGEN(PROG_TYPE, "tc_srv6_decap_to_service_ipv4")
 int srv6_decap_to_service_ipv4_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -378,7 +378,7 @@ int srv6_decap_to_service_ipv4_pktgen(struct __ctx_buff *ctx)
 	return TEST_PASS;
 }
 
-SETUP("tc", "tc_srv6_decap_to_service_ipv4")
+SETUP(PROG_TYPE, "tc_srv6_decap_to_service_ipv4")
 int srv6_decap_to_service_ipv4_setup(struct __ctx_buff *ctx __maybe_unused)
 {
 	union v6addr sid __align_stack_8;
@@ -398,7 +398,7 @@ int srv6_decap_to_service_ipv4_setup(struct __ctx_buff *ctx __maybe_unused)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_srv6_decap_to_service_ipv4")
+CHECK(PROG_TYPE, "tc_srv6_decap_to_service_ipv4")
 int srv6_decap_to_service_ipv4_check(const struct __ctx_buff *ctx __maybe_unused)
 {
 	void *data;
@@ -456,7 +456,7 @@ int srv6_decap_to_service_ipv4_check(const struct __ctx_buff *ctx __maybe_unused
 	return TEST_PASS;
 }
 
-PKTGEN("tc", "tc_srv6_decap_to_service_ipv6")
+PKTGEN(PROG_TYPE, "tc_srv6_decap_to_service_ipv6")
 int srv6_decap_to_service_ipv6_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -521,7 +521,7 @@ int srv6_decap_to_service_ipv6_pktgen(struct __ctx_buff *ctx)
 	return TEST_PASS;
 }
 
-SETUP("tc", "tc_srv6_decap_to_service_ipv6")
+SETUP(PROG_TYPE, "tc_srv6_decap_to_service_ipv6")
 int srv6_decap_to_service_ipv6_setup(struct __ctx_buff *ctx __maybe_unused)
 {
 	union v6addr sid;
@@ -541,7 +541,7 @@ int srv6_decap_to_service_ipv6_setup(struct __ctx_buff *ctx __maybe_unused)
 	return netdev_receive_packet(ctx);
 }
 
-CHECK("tc", "tc_srv6_decap_to_service_ipv6")
+CHECK(PROG_TYPE, "tc_srv6_decap_to_service_ipv6")
 int srv6_decap_to_service_ipv6_check(const struct __ctx_buff *ctx __maybe_unused)
 {
 	void *data;

--- a/bpf/tests/tc_srv6_encap.c
+++ b/bpf/tests/tc_srv6_encap.c
@@ -26,7 +26,7 @@
 #define EXT_IPV6 v6_node_one
 #define SID v6_node_two
 
-PKTGEN("tc", "tc_srv6_encap_from_pod_ipv4")
+PKTGEN(PROG_TYPE, "tc_srv6_encap_from_pod_ipv4")
 int srv6_encap_from_pod_ipv4_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -65,7 +65,7 @@ int srv6_encap_from_pod_ipv4_pktgen(struct __ctx_buff *ctx)
 	return TEST_PASS;
 }
 
-SETUP("tc", "tc_srv6_encap_from_pod_ipv4")
+SETUP(PROG_TYPE, "tc_srv6_encap_from_pod_ipv4")
 int srv6_encap_from_pod_ipv4_setup(struct __ctx_buff *ctx __maybe_unused)
 {
 	struct srv6_vrf_key4 vrf_key = {
@@ -91,7 +91,7 @@ int srv6_encap_from_pod_ipv4_setup(struct __ctx_buff *ctx __maybe_unused)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "tc_srv6_encap_from_pod_ipv4")
+CHECK(PROG_TYPE, "tc_srv6_encap_from_pod_ipv4")
 int srv6_encap_from_pod_ipv4_check(const struct __ctx_buff *ctx __maybe_unused)
 {
 	void *data;
@@ -177,7 +177,7 @@ int srv6_encap_from_pod_ipv4_check(const struct __ctx_buff *ctx __maybe_unused)
 	return TEST_PASS;
 }
 
-PKTGEN("tc", "tc_srv6_encap_from_pod_ipv6")
+PKTGEN(PROG_TYPE, "tc_srv6_encap_from_pod_ipv6")
 int srv6_encap_from_pod_ipv6_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -216,7 +216,7 @@ int srv6_encap_from_pod_ipv6_pktgen(struct __ctx_buff *ctx)
 	return TEST_PASS;
 }
 
-SETUP("tc", "tc_srv6_encap_from_pod_ipv6")
+SETUP(PROG_TYPE, "tc_srv6_encap_from_pod_ipv6")
 int srv6_encap_from_pod_ipv6_setup(struct __ctx_buff *ctx __maybe_unused)
 {
 	struct srv6_vrf_key6 vrf_key = {
@@ -243,7 +243,7 @@ int srv6_encap_from_pod_ipv6_setup(struct __ctx_buff *ctx __maybe_unused)
 	return pod_send_packet(ctx);
 }
 
-CHECK("tc", "tc_srv6_encap_from_pod_ipv6")
+CHECK(PROG_TYPE, "tc_srv6_encap_from_pod_ipv6")
 int srv6_encap_from_pod_ipv6_check(const struct __ctx_buff *ctx __maybe_unused)
 {
 	void *data;

--- a/bpf/tests/xdp_egressgw_reply.c
+++ b/bpf/tests/xdp_egressgw_reply.c
@@ -71,7 +71,7 @@ mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
 /* Test that a EgressGW reply gets RevSNATed, and forwarded to the
  * worker node via tunnel.
  */
-PKTGEN("xdp", "xdp_egressgw_reply")
+PKTGEN(PROG_TYPE, "xdp_egressgw_reply")
 int egressgw_reply_pktgen(struct __ctx_buff *ctx)
 {
 	/* Add a new NAT entry so that pktgen can figure out the correct destination port */
@@ -96,7 +96,7 @@ int egressgw_reply_pktgen(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("xdp", "xdp_egressgw_reply")
+SETUP(PROG_TYPE, "xdp_egressgw_reply")
 int egressgw_reply_setup(struct __ctx_buff *ctx)
 {
 	/* install EgressGW policy for the connection: */
@@ -125,7 +125,7 @@ int egressgw_reply_setup(struct __ctx_buff *ctx)
 	return xdp_receive_packet(ctx);
 }
 
-CHECK("xdp", "xdp_egressgw_reply")
+CHECK(PROG_TYPE, "xdp_egressgw_reply")
 int egressgw_reply_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -228,7 +228,7 @@ int egressgw_reply_check(__maybe_unused const struct __ctx_buff *ctx)
 /* Test that a EgressGW reply gets RevSNATed, and forwarded to the
  * worker node via tunnel (IPv6).
  */
-PKTGEN("xdp", "xdp_egressgw_reply_v6")
+PKTGEN(PROG_TYPE, "xdp_egressgw_reply_v6")
 int egressgw_reply_pktgen_v6(struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -257,7 +257,7 @@ int egressgw_reply_pktgen_v6(struct __ctx_buff *ctx)
 		});
 }
 
-SETUP("xdp", "xdp_egressgw_reply_v6")
+SETUP(PROG_TYPE, "xdp_egressgw_reply_v6")
 int egressgw_reply_setup_v6(struct __ctx_buff *ctx)
 {
 	union v6addr ext_svc_ip = EXTERNAL_SVC_IP_V6;
@@ -291,7 +291,7 @@ int egressgw_reply_setup_v6(struct __ctx_buff *ctx)
 	return xdp_receive_packet(ctx);
 }
 
-CHECK("xdp", "xdp_egressgw_reply_v6")
+CHECK(PROG_TYPE, "xdp_egressgw_reply_v6")
 int egressgw_reply_check_v6(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/xdp_nodeport_lb4_nat_backend.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_backend.c
@@ -37,7 +37,7 @@ static volatile const __u8 *lb_mac = mac_two;
  * - doesn't touch a NATed request,
  * - passes it up from XDP to TC
  */
-PKTGEN("xdp", "xdp_nodeport_nat_backend")
+PKTGEN(PROG_TYPE, "xdp_nodeport_nat_backend")
 int nodeport_nat_backend_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -64,7 +64,7 @@ int nodeport_nat_backend_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("xdp", "xdp_nodeport_nat_backend")
+SETUP(PROG_TYPE, "xdp_nodeport_nat_backend")
 int nodeport_nat_backend_setup(struct __ctx_buff *ctx)
 {
 	lb_v4_add_service(FRONTEND_IP, FRONTEND_PORT, IPPROTO_TCP, 1, 1);
@@ -79,7 +79,7 @@ int nodeport_nat_backend_setup(struct __ctx_buff *ctx)
 	return xdp_receive_packet(ctx);
 }
 
-CHECK("xdp", "xdp_nodeport_nat_backend")
+CHECK(PROG_TYPE, "xdp_nodeport_nat_backend")
 int nodeport_nat_backend_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/xdp_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_lb.c
@@ -94,7 +94,7 @@ ASSIGN_CONFIG(bool, enable_endpoint_routes, true)
  * - gets DNATed (but not SNATed)
  * - gets passed up from XDP to TC
  */
-PKTGEN("xdp", "xdp_nodeport_local_backend")
+PKTGEN(PROG_TYPE, "xdp_nodeport_local_backend")
 int nodeport_local_backend_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -121,7 +121,7 @@ int nodeport_local_backend_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("xdp", "xdp_nodeport_local_backend")
+SETUP(PROG_TYPE, "xdp_nodeport_local_backend")
 int nodeport_local_backend_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -138,7 +138,7 @@ int nodeport_local_backend_setup(struct __ctx_buff *ctx)
 	return xdp_receive_packet(ctx);
 }
 
-CHECK("xdp", "xdp_nodeport_local_backend")
+CHECK(PROG_TYPE, "xdp_nodeport_local_backend")
 int nodeport_local_backend_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -210,7 +210,7 @@ int nodeport_local_backend_check(const struct __ctx_buff *ctx)
  * - doesn't have the XFER_PKT_NO_SVC flag set, so that the TC layer applies
  *   another round of SVC processing
  */
-PKTGEN("xdp", "xdp_nodeport_etp_local")
+PKTGEN(PROG_TYPE, "xdp_nodeport_etp_local")
 int nodeport_etp_local_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -237,7 +237,7 @@ int nodeport_etp_local_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("xdp", "xdp_nodeport_etp_local")
+SETUP(PROG_TYPE, "xdp_nodeport_etp_local")
 int nodeport_etp_local_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 2;
@@ -252,7 +252,7 @@ int nodeport_etp_local_setup(struct __ctx_buff *ctx)
 	return xdp_receive_packet(ctx);
 }
 
-CHECK("xdp", "xdp_nodeport_etp_local")
+CHECK(PROG_TYPE, "xdp_nodeport_etp_local")
 int nodeport_etp_local_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -310,7 +310,7 @@ int nodeport_etp_local_check(const struct __ctx_buff *ctx)
  * - gets DNATed and SNATed,
  * - gets redirected back out by XDP
  */
-PKTGEN("xdp", "xdp_nodeport_nat_fwd")
+PKTGEN(PROG_TYPE, "xdp_nodeport_nat_fwd")
 int nodeport_nat_fwd_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -337,7 +337,7 @@ int nodeport_nat_fwd_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("xdp", "xdp_nodeport_nat_fwd")
+SETUP(PROG_TYPE, "xdp_nodeport_nat_fwd")
 int nodeport_nat_fwd_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -351,7 +351,7 @@ int nodeport_nat_fwd_setup(struct __ctx_buff *ctx)
 	return xdp_receive_packet(ctx);
 }
 
-CHECK("xdp", "xdp_nodeport_nat_fwd")
+CHECK(PROG_TYPE, "xdp_nodeport_nat_fwd")
 int nodeport_nat_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -507,19 +507,19 @@ static __always_inline int check_reply(const struct __ctx_buff *ctx)
 /* Test that the LB RevDNATs and RevSNATs a reply from the
  * NAT remote backend, and sends it back to the client.
  */
-PKTGEN("xdp", "xdp_nodeport_nat_fwd_reply")
+PKTGEN(PROG_TYPE, "xdp_nodeport_nat_fwd_reply")
 int nodeport_nat_fwd_reply_pktgen(struct __ctx_buff *ctx)
 {
 	return build_reply(ctx);
 }
 
-SETUP("xdp", "xdp_nodeport_nat_fwd_reply")
+SETUP(PROG_TYPE, "xdp_nodeport_nat_fwd_reply")
 int nodeport_nat_fwd_reply_setup(struct __ctx_buff *ctx)
 {
 	return xdp_receive_packet(ctx);
 }
 
-CHECK("xdp", "xdp_nodeport_nat_fwd_reply")
+CHECK(PROG_TYPE, "xdp_nodeport_nat_fwd_reply")
 int nodeport_nat_fwd_reply_check(const struct __ctx_buff *ctx)
 {
 	return check_reply(ctx);
@@ -529,13 +529,13 @@ int nodeport_nat_fwd_reply_check(const struct __ctx_buff *ctx)
  * NAT remote backend, and sends it back to the client.
  * Even if the FIB lookup fails.
  */
-PKTGEN("xdp", "xdp_nodeport_nat_fwd_reply_no_fib")
+PKTGEN(PROG_TYPE, "xdp_nodeport_nat_fwd_reply_no_fib")
 int nodepoirt_nat_fwd_reply_no_fib_pktgen(struct __ctx_buff *ctx)
 {
 	return build_reply(ctx);
 }
 
-SETUP("xdp", "xdp_nodeport_nat_fwd_reply_no_fib")
+SETUP(PROG_TYPE, "xdp_nodeport_nat_fwd_reply_no_fib")
 int nodeport_nat_fwd_reply_no_fib_setup(struct __ctx_buff *ctx)
 {
 	__u32 key = 0;
@@ -549,7 +549,7 @@ int nodeport_nat_fwd_reply_no_fib_setup(struct __ctx_buff *ctx)
 	return xdp_receive_packet(ctx);
 }
 
-CHECK("xdp", "xdp_nodeport_nat_fwd_reply_no_fib")
+CHECK(PROG_TYPE, "xdp_nodeport_nat_fwd_reply_no_fib")
 int nodeport_nat_fwd_reply_no_fib_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	cilium_device_del_entry(DEFAULT_IFACE);
@@ -562,7 +562,7 @@ int nodeport_nat_fwd_reply_no_fib_check(__maybe_unused const struct __ctx_buff *
  * - does have XFER_PKT_NO_SVC flag set so that TC does not process it again
  * if the backend is a /local/ backend
  */
-PKTGEN("xdp", "xdp_nodeport_l7delegate_local")
+PKTGEN(PROG_TYPE, "xdp_nodeport_l7delegate_local")
 int nodeport_l7delegate_local_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -586,7 +586,7 @@ int nodeport_l7delegate_local_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("xdp", "xdp_nodeport_l7delegate_local")
+SETUP(PROG_TYPE, "xdp_nodeport_l7delegate_local")
 int nodeport_l7delegate_local_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 2;
@@ -605,7 +605,7 @@ int nodeport_l7delegate_local_setup(struct __ctx_buff *ctx)
 	return xdp_receive_packet(ctx);
 }
 
-CHECK("xdp", "xdp_nodeport_l7delegate_local")
+CHECK(PROG_TYPE, "xdp_nodeport_l7delegate_local")
 int nodeport_l7delegate_local_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -673,7 +673,7 @@ int nodeport_l7delegate_local_check(const struct __ctx_buff *ctx)
  * xdp_nodeport_l7delegate_local just that the backend is not
  * part of the endpoint map.
  */
-PKTGEN("xdp", "xdp_nodeport_l7delegate_remote")
+PKTGEN(PROG_TYPE, "xdp_nodeport_l7delegate_remote")
 int nodeport_l7delegate_remote_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -697,7 +697,7 @@ int nodeport_l7delegate_remote_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("xdp", "xdp_nodeport_l7delegate_remote")
+SETUP(PROG_TYPE, "xdp_nodeport_l7delegate_remote")
 int nodeport_l7delegate_remote_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 2;
@@ -715,7 +715,7 @@ int nodeport_l7delegate_remote_setup(struct __ctx_buff *ctx)
 	return xdp_receive_packet(ctx);
 }
 
-CHECK("xdp", "xdp_nodeport_l7delegate_remote")
+CHECK(PROG_TYPE, "xdp_nodeport_l7delegate_remote")
 int nodeport_l7delegate_remote_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/xdp_nodeport_lb4_nat_lb_tun_dynamic.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_lb_tun_dynamic.c
@@ -76,7 +76,7 @@ const __u8 xdp_nodeport_lb4_nat_lb_tun_dynamic_post[] = {
 /* Test that an XDP nodeport load balanced packet has its outer source
  * ip dynamically resolved.
  */
-PKTGEN("xdp", "xdp_nodeport_lb4_nat_lb_tun_dynamic")
+PKTGEN(PROG_TYPE, "xdp_nodeport_lb4_nat_lb_tun_dynamic")
 int xdp_nodeport_lb4_nat_lb_tun_dynamic_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -91,7 +91,7 @@ int xdp_nodeport_lb4_nat_lb_tun_dynamic_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("xdp", "xdp_nodeport_lb4_nat_lb_tun_dynamic")
+SETUP(PROG_TYPE, "xdp_nodeport_lb4_nat_lb_tun_dynamic")
 int xdp_nodeport_lb4_nat_lb_tun_dynamic_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -105,7 +105,7 @@ int xdp_nodeport_lb4_nat_lb_tun_dynamic_setup(struct __ctx_buff *ctx)
 	return xdp_receive_packet(ctx);
 }
 
-CHECK("xdp", "xdp_nodeport_lb4_nat_lb_tun_dynamic")
+CHECK(PROG_TYPE, "xdp_nodeport_lb4_nat_lb_tun_dynamic")
 int xdp_nodeport_lb4_nat_lb_tun_dynamic_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;

--- a/bpf/tests/xdp_nodeport_lb4_test.c
+++ b/bpf/tests/xdp_nodeport_lb4_test.c
@@ -107,7 +107,7 @@ static __always_inline int build_packet(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("xdp", "xdp_lb4_forward_to_other_node")
+SETUP(PROG_TYPE, "xdp_lb4_forward_to_other_node")
 int test1_setup(struct __ctx_buff *ctx)
 {
 	int ret;
@@ -123,7 +123,7 @@ int test1_setup(struct __ctx_buff *ctx)
 	return xdp_receive_packet(ctx);
 }
 
-CHECK("xdp", "xdp_lb4_forward_to_other_node")
+CHECK(PROG_TYPE, "xdp_lb4_forward_to_other_node")
 int test1_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	test_init();
@@ -190,7 +190,7 @@ int test1_check(__maybe_unused const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-SETUP("xdp", "xdp_lb4_drop_no_backend")
+SETUP(PROG_TYPE, "xdp_lb4_drop_no_backend")
 int test2_setup(struct __ctx_buff *ctx)
 {
 	int ret;
@@ -204,7 +204,7 @@ int test2_setup(struct __ctx_buff *ctx)
 	return xdp_receive_packet(ctx);
 }
 
-CHECK("xdp", "xdp_lb4_drop_no_backend")
+CHECK(PROG_TYPE, "xdp_lb4_drop_no_backend")
 int test2_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data_end = (void *)(long)ctx->data_end;

--- a/bpf/tests/xdp_nodeport_lb_dsr_ipip.c
+++ b/bpf/tests/xdp_nodeport_lb_dsr_ipip.c
@@ -89,7 +89,7 @@ long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
  * - keeps the inner destination as the service IP,
  * - gets redirected back out by XDP
  */
-PKTGEN("xdp", "xdp_nodeport_dsr_ipip4_fwd")
+PKTGEN(PROG_TYPE, "xdp_nodeport_dsr_ipip4_fwd")
 int nodeport_dsr_ipip4_fwd_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -116,7 +116,7 @@ int nodeport_dsr_ipip4_fwd_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("xdp", "xdp_nodeport_dsr_ipip4_fwd")
+SETUP(PROG_TYPE, "xdp_nodeport_dsr_ipip4_fwd")
 int nodeport_dsr_ipip4_fwd_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -130,7 +130,7 @@ int nodeport_dsr_ipip4_fwd_setup(struct __ctx_buff *ctx)
 	return xdp_receive_packet(ctx);
 }
 
-CHECK("xdp", "xdp_nodeport_dsr_ipip4_fwd")
+CHECK(PROG_TYPE, "xdp_nodeport_dsr_ipip4_fwd")
 int nodeport_dsr_ipip4_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
@@ -215,7 +215,7 @@ int nodeport_dsr_ipip4_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
  * - keeps the inner destination as the service IP,
  * - gets redirected back out by XDP
  */
-PKTGEN("xdp", "xdp_nodeport_dsr_ipip6_fwd")
+PKTGEN(PROG_TYPE, "xdp_nodeport_dsr_ipip6_fwd")
 int nodeport_dsr_ipip6_fwd_pktgen(struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip = FRONTEND_IPV6;
@@ -244,7 +244,7 @@ int nodeport_dsr_ipip6_fwd_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("xdp", "xdp_nodeport_dsr_ipip6_fwd")
+SETUP(PROG_TYPE, "xdp_nodeport_dsr_ipip6_fwd")
 int nodeport_dsr_ipip6_fwd_setup(struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip = FRONTEND_IPV6;
@@ -260,7 +260,7 @@ int nodeport_dsr_ipip6_fwd_setup(struct __ctx_buff *ctx)
 	return xdp_receive_packet(ctx);
 }
 
-CHECK("xdp", "xdp_nodeport_dsr_ipip6_fwd")
+CHECK(PROG_TYPE, "xdp_nodeport_dsr_ipip6_fwd")
 int nodeport_dsr_ipip6_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip = FRONTEND_IPV6;

--- a/bpf/tests/xdp_nodeport_lb_dsr_lb.c
+++ b/bpf/tests/xdp_nodeport_lb_dsr_lb.c
@@ -79,7 +79,7 @@ mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
  * - has IP Option inserted,
  * - gets redirected back out by XDP
  */
-PKTGEN("xdp", "xdp_nodeport_dsr_fwd4")
+PKTGEN(PROG_TYPE, "xdp_nodeport_dsr_fwd4")
 int nodeport_dsr_fwd4_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -106,7 +106,7 @@ int nodeport_dsr_fwd4_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("xdp", "xdp_nodeport_dsr_fwd4")
+SETUP(PROG_TYPE, "xdp_nodeport_dsr_fwd4")
 int nodeport_dsr_fwd4_setup(struct __ctx_buff *ctx)
 {
 	__u16 revnat_id = 1;
@@ -120,7 +120,7 @@ int nodeport_dsr_fwd4_setup(struct __ctx_buff *ctx)
 	return xdp_receive_packet(ctx);
 }
 
-CHECK("xdp", "xdp_nodeport_dsr_fwd4")
+CHECK(PROG_TYPE, "xdp_nodeport_dsr_fwd4")
 int nodeport_dsr_fwd4_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	struct dsr_opt_v4 *opt;
@@ -198,7 +198,7 @@ int nodeport_dsr_fwd4_check(__maybe_unused const struct __ctx_buff *ctx)
  * - has IPv6 Extension inserted,
  * - gets redirected back out by XDP
  */
-PKTGEN("xdp", "xdp_nodeport_dsr_fwd6")
+PKTGEN(PROG_TYPE, "xdp_nodeport_dsr_fwd6")
 int nodeport_dsr_fwd6_pktgen(struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip = FRONTEND_IPV6;
@@ -227,7 +227,7 @@ int nodeport_dsr_fwd6_pktgen(struct __ctx_buff *ctx)
 	return 0;
 }
 
-SETUP("xdp", "xdp_nodeport_dsr_fwd6")
+SETUP(PROG_TYPE, "xdp_nodeport_dsr_fwd6")
 int nodeport_dsr_fwd6_setup(struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip = FRONTEND_IPV6;
@@ -243,7 +243,7 @@ int nodeport_dsr_fwd6_setup(struct __ctx_buff *ctx)
 	return xdp_receive_packet(ctx);
 }
 
-CHECK("xdp", "xdp_nodeport_dsr_fwd6")
+CHECK(PROG_TYPE, "xdp_nodeport_dsr_fwd6")
 int nodeport_dsr_fwd6_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	union v6addr frontend_ip = FRONTEND_IPV6;


### PR DESCRIPTION
Instead of hard-coding the program type of each sub-test stage, use the `PROG_TYPE` macro that's provided by the `ctx` header.