### PR TITLE
gha: don't install LLVM and Clang in integration tests workflow

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -103,32 +103,6 @@ jobs:
         with:
           comment_on_pr: false
 
-      - name: Setup additional repositories
-        if: ${{ startsWith(matrix.arch, 'ubuntu-latest') || startsWith(matrix.arch, 'ubuntu-24.04') }}
-        shell: bash
-        run: |
-          # This is required for libtinfo6
-          uri="http://security.ubuntu.com/ubuntu"
-          arch="amd64"
-          if [ ${{ runner.arch }} == "ARM64" ]; then
-            uri="http://ports.ubuntu.com/ubuntu-ports"
-            arch="arm64"
-          fi
-
-          sudo tee -a /etc/apt/sources.list.d/jammy-security.sources <<EOF
-          Types: deb
-          URIs: $uri
-          Suites: jammy-updates
-          Components: main universe restricted multiverse
-          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
-          Architectures: $arch
-          EOF
-
-      - name: Install Dependencies
-        shell: bash
-        run: |
-          sudo apt update && sudo apt install -y --no-install-recommends build-essential make libtinfo6
-
       - name: Checkout context ref (trusted)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -178,16 +152,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-integration-test-cache-${{ runner.arch }}-
 
-      - name: Set clang directory
-        id: set_clang_dir
-        run: echo "clang_dir=$HOME/.clang" >> $GITHUB_OUTPUT
-
-      - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@ebc0426251bc40c7cd31162802432c68818ab8f0 # v2.0.9
-        with:
-          version: "19.1.7"
-          directory: ${{ steps.set_clang_dir.outputs.clang_dir }}
-
       - name: Create cache directories if they don't exist
         if: ${{ steps.go-cache.outputs.cache-hit != 'true' }}
         env:
@@ -219,7 +183,6 @@ jobs:
         run: |
           export V=0
           export DOCKER_BUILD_FLAGS=--quiet
-          export CFLAGS="-Werror"
           make integration-tests LOG_CODEOWNERS=1 JUNIT_PATH="test/${{ env.job_name }}.xml"
 
       - name: Fetch JUnits


### PR DESCRIPTION
LLVM and Clang are not required to run the Go based integration tests. Hence, let's simplify the workflow and drop the corresponding steps; this allows to additionally drop the installation of the dependencies, which are also a bit tricky as they depend on the actual Ubuntu version.

Tentatively marking for backport to all stable versions, unless anything unexpected pops up there.

AIL:0