### PR TITLE
gha/kubespray: run on schedule, rather than on every push

### DIFF
--- a/.github/workflows/conformance-kubespray.yaml
+++ b/.github/workflows/conformance-kubespray.yaml
@@ -20,11 +20,9 @@ on:
         description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
         required: false
         default: '{}'
-  push:
-    branches:
-      - main
+
   schedule:
-    - cron: '0 0 * * 0'
+    - cron: '0 4/12 * * *'
 
 permissions:
   # To read actions state with cilium/workflow-telemetry-action


### PR DESCRIPTION
Switch the Conformance Kubespray workflow to run on a scheduled basis, rather than every time a commit is merged into the main branch. This aligns it with the vast majority of the other workflows that are also run on schedule, and ensures a consistent interval across runs for better tracking of possible flakes.

AIL: 0