### PR TITLE
gha: fix checkout of trusted branch in smoke and k8s-kind workflows

### DIFF
--- a/.github/workflows/k8s-kind-network-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-e2e.yaml
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          ref: ${{ inputs.context-ref || github.event.repository.default_branch }}
+          ref: ${{ inputs.context-ref || github.sha }}
 
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables

--- a/.github/workflows/k8s-kind-network-policies-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-policies-e2e.yaml
@@ -89,7 +89,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          ref: ${{ inputs.context-ref || github.event.repository.default_branch }}
+          ref: ${{ inputs.context-ref || github.sha }}
 
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables

--- a/.github/workflows/tests-smoke-conformance.yaml
+++ b/.github/workflows/tests-smoke-conformance.yaml
@@ -88,7 +88,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          ref: ${{ inputs.context-ref || github.event.repository.default_branch }}
+          ref: ${{ inputs.context-ref || github.sha }}
 
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          ref: ${{ inputs.context-ref || github.event.repository.default_branch }}
+          ref: ${{ inputs.context-ref || github.sha }}
 
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables


### PR DESCRIPTION
The blamed commit modified the trusted checkout step in the smoke and k8s-kind workflows. However, the reference is configured differently from the other already existing workflows, and in particular defaults to that of the default branch when the workflow is not triggered through Ariane. While this is not a problem on the default branch itself, it breaks stable branches, because they then retrieve the subsequent actions (for instance, set-env-variables) from the main branch, rather than the actual target branch, upon push events. In turn, this causes the workflow to fail, as for instance the Cilium CLI environment variable ends up not being correct. Let's get this fixed by matching the same pattern already used by all other workflows.

Fixes: 29c832727dad ("ci: handle pull_request workflows by ariane")

AIL: 0