### PR TITLE
test/cyclonus: log the JUnit XML instead of copying it from a dead pod

### DIFF
--- a/test/k8s/manifests/netpol-cyclonus/install-cyclonus.yml
+++ b/test/k8s/manifests/netpol-cyclonus/install-cyclonus.yml
@@ -9,19 +9,32 @@ spec:
     spec:
       restartPolicy: Never
       containers:
+        # The JUnit file lives on an emptyDir that is only reachable through an
+        # exec into the container, and exec is rejected once the pod has
+        # terminated, so print the file between two sentinels and let the
+        # harness cut it back out of the log. exit $rc keeps the container exit
+        # code intact so a crash or a panic stays visible.
         - command:
-            - ./cyclonus
-            - generate
-            - --exclude=
-            - --include=upstream-e2e
-            - --perturbation-wait-seconds=20
-            - --retries=7
-            - --noisy=true
-            - --ignore-loopback=true
-            - --cleanup-namespaces=false
-            - --server-port=80
-            - --server-protocol=tcp
-            - --junit-results-file=/results/cyclonus-results.xml
+            - /bin/sh
+            - -c
+            - |
+              ./cyclonus generate \
+                --exclude= \
+                --include=upstream-e2e \
+                --perturbation-wait-seconds=20 \
+                --retries=7 \
+                --noisy=true \
+                --ignore-loopback=true \
+                --cleanup-namespaces=false \
+                --server-port=80 \
+                --server-protocol=tcp \
+                --junit-results-file=/results/cyclonus-results.xml
+              rc=$?
+              echo "===== BEGIN CYCLONUS JUNIT XML ====="
+              cat /results/cyclonus-results.xml 2>/dev/null || echo "(cyclonus produced no JUnit results file)"
+              echo
+              echo "===== END CYCLONUS JUNIT XML ====="
+              exit $rc
           name: cyclonus
           imagePullPolicy: IfNotPresent
           image: docker.io/mfenwick100/cyclonus:v0.5.6@sha256:f8da1d12837a85ada5d039725c89634f89ac30630e30f50ef17d745150294d26

--- a/test/k8s/manifests/netpol-cyclonus/test-cyclonus.sh
+++ b/test/k8s/manifests/netpol-cyclonus/test-cyclonus.sh
@@ -26,39 +26,54 @@ for pod in $(kubectl get pods -n kube-system -l job-name=cyclonus -o jsonpath='{
     kubectl logs -n kube-system "$pod" --previous 2>/dev/null || true
 done
 
-# grab the job logs used for the pass/fail check below
-LOG_FILE=$(mktemp)
-kubectl logs -n kube-system job.batch/cyclonus > "$LOG_FILE"
-cat "$LOG_FILE"
+# grab the job logs
+RAW_LOG_FILE=$(mktemp)
+kubectl logs -n kube-system job.batch/cyclonus > "$RAW_LOG_FILE"
+cat "$RAW_LOG_FILE"
 
-# retrieve the JUnit results file from the pod
+# The cyclonus container prints its JUnit file between these two sentinels, see
+# install-cyclonus.yml. Reading it out of the log is the only way to get it: the
+# file sits on an emptyDir, kubectl cp implements copy-from-pod by exec'ing tar
+# inside the container, and exec is refused on a pod that already reached
+# Succeeded or Failed, which is exactly the state the job is in by the time we
+# get here. So there is no window in which a copy could have worked.
+BEGIN_MARKER="===== BEGIN CYCLONUS JUNIT XML ====="
+END_MARKER="===== END CYCLONUS JUNIT XML ====="
+
+# Keep the XML out of the log used for the pass/fail check below, so that no
+# amount of XML text can ever look like a tag summary row.
+LOG_FILE=$(mktemp)
+awk -v b="$BEGIN_MARKER" '$0 == b { exit } { print }' "$RAW_LOG_FILE" > "$LOG_FILE"
+
+# retrieve the JUnit results file out of the pod logs
 RESULTS_DIR="cyclonus-results"
 mkdir -p "$RESULTS_DIR"
+RESULTS_FILE="$RESULTS_DIR/cyclonus-results.xml"
 
 # Get all pod names for the completed job
 POD_NAMES=$(kubectl get pods -n kube-system -l job-name=cyclonus -o jsonpath='{.items[*].metadata.name}')
 
 if [ -n "$POD_NAMES" ]; then
-    RESULTS_COPIED=false
     for POD_NAME in $POD_NAMES; do
-        echo "Attempting to retrieve JUnit results from pod: $POD_NAME"
-        if kubectl cp -n kube-system "$POD_NAME":/results/cyclonus-results.xml "$RESULTS_DIR/cyclonus-results.xml" 2>/dev/null; then
-            RESULTS_COPIED=true
-            echo "Successfully copied results from pod: $POD_NAME"
+        echo "Extracting JUnit results from the log of pod: $POD_NAME"
+        kubectl logs -n kube-system "$POD_NAME" |
+            awk -v b="$BEGIN_MARKER" -v e="$END_MARKER" \
+                '$0 == b { flag = 1; next } $0 == e { flag = 0 } flag' > "$RESULTS_FILE"
+        # A pod that crashed before writing the file leaves us an empty or a
+        # truncated block, so fall through to the pod that replaced it.
+        if grep -q '</testsuite>' "$RESULTS_FILE"; then
+            echo "JUnit results file retrieved successfully from pod: $POD_NAME"
+            ls -la "$RESULTS_FILE"
+            echo "Contents preview:"
+            head -20 "$RESULTS_FILE"
             break
-        else
-            echo "Failed to copy JUnit results from pod: $POD_NAME"
         fi
+        echo "No usable JUnit results in the log of pod: $POD_NAME"
+        rm -f "$RESULTS_FILE"
     done
 
-    # Check if the file was successfully copied and display its contents
-    if [ "$RESULTS_COPIED" = true ] && [ -f "$RESULTS_DIR/cyclonus-results.xml" ]; then
-        echo "JUnit results file retrieved successfully:"
-        ls -la "$RESULTS_DIR/cyclonus-results.xml"
-        echo "Contents preview:"
-        head -20 "$RESULTS_DIR/cyclonus-results.xml"
-    else
-        echo "Warning: JUnit results file not found or could not be retrieved from any pod"
+    if [ ! -f "$RESULTS_FILE" ]; then
+        echo "Warning: no pod backing the job logged a usable JUnit results file"
     fi
 else
     echo "Warning: Could not find cyclonus pod to retrieve results"


### PR DESCRIPTION
The cyclonus JUnit artifact has never been retrievable. The harness runs kubectl cp only after the job completes, so the pod has terminated by then, and kubectl cp works by exec'ing tar inside the container, which exec refuses on a terminated pod. There is no timing window in which the copy could have worked.

Let the pod print the XML between two sentinels instead, and cut it back out of the log, which kubectl logs can still read after the container is gone.

Verified with a temporary pull_request trigger, since this workflow only runs on push to main. The file came out for the first time, a 1546 byte artifact with 13 testcases:

https://github.com/cilium/cilium/actions/runs/30896929107/job/91951935566

This PR was prepared with AIL:3.
