### PR TITLE
gateway-api: allow local path for conformance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -619,10 +619,28 @@ KIND_NET_CIDR ?= $(shell docker network inspect kind-cilium -f '{{json .IPAM.Con
 GATEWAY_API_CONFORMANCE_USABLE_NETWORK_ADDRESSES?=$(shell echo ${KIND_NET_CIDR} | sed "s@0.0/16@255.206@")
 GATEWAY_API_CONFORMANCE_UNUSABLE_NETWORK_ADDRESSES?=$(shell echo ${KIND_NET_CIDR} | sed "s@0.0/16@255.216@")
 GATEWAY_API_CONFORMANCE_TEST_NAME ?= TestConformance
+GATEWAY_API_DIR ?=
 gateway-api-conformance: ## Run Gateway API conformance tests.
 	@$(ECHO_CHECK) running Gateway API conformance tests...
+	$(QUIET)set -e; \
+	modfile_flags=; \
+	if [ -n "$(GATEWAY_API_DIR)" ]; then \
+		if [ ! -f "$(GATEWAY_API_DIR)/go.mod" ] || [ ! -f "$(GATEWAY_API_DIR)/conformance/go.mod" ]; then \
+			echo "GATEWAY_API_DIR must contain go.mod and conformance/go.mod" >&2; \
+			exit 1; \
+		fi; \
+		gateway_api_dir="$$(cd "$(GATEWAY_API_DIR)" && pwd)"; \
+		tmpdir="$$(mktemp -d)"; \
+		trap 'rm -rf "$$tmpdir"' EXIT; \
+		cp "$(CURDIR)/go.mod" "$$tmpdir/cilium.mod"; \
+		cp "$(CURDIR)/go.sum" "$$tmpdir/cilium.sum"; \
+		$(GO) mod edit -modfile="$$tmpdir/cilium.mod" \
+			-replace=sigs.k8s.io/gateway-api="$$gateway_api_dir" \
+			-replace=sigs.k8s.io/gateway-api/conformance="$$gateway_api_dir/conformance"; \
+		modfile_flags="-mod=mod -modfile=$$tmpdir/cilium.mod"; \
+	fi; \
 	GATEWAY_API_CONFORMANCE_TESTS=1 \
-	$(GO_TEST) $(GO_TEST_FLAGS) -p 4 -v ./operator/pkg/gateway-api \
+	$(GO_TEST) $(GO_TEST_FLAGS) $$modfile_flags -p 4 -v ./operator/pkg/gateway-api \
 		$(GATEWAY_TEST_FLAGS) \
 		-test.run $(GATEWAY_API_CONFORMANCE_TEST_NAME) \
 		-test.timeout=29m \


### PR DESCRIPTION
Add an environment variable GATEWAY_API_DIR which allows specifying a local checkout of the gateway-api sources when running conformance tests using the gateway-api-conformance target.

This allows for easier local development of Gateway API conformance tests.

Example usage:

```
GATEWAY_API_DIR="../../gateway-api" make gateway-api-conformance
```

In this case, modifications to the conformance tests can be made in the local checkout at `../../gateway-api/conformance/`

```release-note
gateway-api: allow local path for conformance tests
```

AIL:2
