### PR TITLE
endpoint: don't drop regenerations requested while waiting for identity

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2384,11 +2384,21 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context) (regenTriggered bo
 
 	if e.SecurityIdentity != nil && e.SecurityIdentity.Labels.Equals(newLabels) {
 		// Sets endpoint state to ready if was waiting for identity
+		var deferredRegen *regeneration.ExternalRegenerationMetadata
 		if e.getState() == StateWaitingForIdentity {
 			e.setState(StateReady, "Set identity for this endpoint")
+			// Regenerations requested while the endpoint was parked in
+			// waiting-for-identity were only buffered. No new identity is
+			// assigned here, so no regeneration is queued for us, flush the
+			// buffer instead of waiting for the periodic regeneration.
+			deferredRegen = e.consumeDeferredRegenerationLocked()
 		}
 		e.unlock()
 		scopedLog.Debug("Endpoint labels unchanged, skipping resolution of identity")
+		if deferredRegen != nil {
+			e.RegenerateIfAlive(deferredRegen)
+			return true, nil
+		}
 		return false, nil
 	}
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -763,10 +763,40 @@ func (e *Endpoint) setRegenerateStateLocked(regenMetadata *regeneration.External
 			e.skippedPolicyRevision = regenMetadata.PolicyRevisionToWaitFor
 		}
 		regen = false
+	case StateWaitingForIdentity:
+		// The state machine forbids waiting-for-identity -> waiting-to-regenerate,
+		// as policy cannot be computed before the endpoint has an identity. Buffer
+		// the request so whoever takes the endpoint out of this state picks it up,
+		// instead of dropping it until the next periodic regeneration.
+		if regenMetadata.RegenerationLevel > e.skippedRegenerationLevel {
+			e.skippedRegenerationLevel = regenMetadata.RegenerationLevel
+		}
+		if regenMetadata.PolicyRevisionToWaitFor > e.skippedPolicyRevision {
+			e.skippedPolicyRevision = regenMetadata.PolicyRevisionToWaitFor
+		}
+		e.logStatusLocked(Other, OK, fmt.Sprintf("Deferred endpoint regeneration until identity resolution completes due to %s", regenMetadata.GetRegenerationReason()))
+		regen = false
 	default:
 		regen = e.setState(StateWaitingToRegenerate, fmt.Sprintf("Triggering endpoint regeneration due to %s", regenMetadata.GetRegenerationReason()))
 	}
 	return regen
+}
+
+// consumeDeferredRegenerationLocked returns metadata for a regeneration that was
+// buffered while the endpoint was in StateWaitingForIdentity, or nil if there was
+// none. The buffered level and revision are left in place, regenerate() consumes
+// them.
+// Must be called with e.mutex held.
+func (e *Endpoint) consumeDeferredRegenerationLocked() *regeneration.ExternalRegenerationMetadata {
+	if e.skippedRegenerationLevel == regeneration.Invalid && e.skippedPolicyRevision == 0 {
+		return nil
+	}
+	return &regeneration.ExternalRegenerationMetadata{
+		Reason:                  regeneration.ReasonDeferredRegeneration,
+		Message:                 "regeneration deferred while waiting for identity",
+		RegenerationLevel:       max(e.skippedRegenerationLevel, regeneration.RegenerateWithoutDatapath),
+		PolicyRevisionToWaitFor: e.skippedPolicyRevision,
+	}
 }
 
 // consumeSkippedPolicyRevision transfers any buffered revision to ctx.

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -382,4 +382,37 @@ func TestSkippedPolicyRevision(t *testing.T) {
 		require.False(t, skip(ep, rev2))
 		require.Zero(t, ep.skippedPolicyRevision)
 	})
+
+	// waiting-for-identity cannot transition to waiting-to-regenerate, so the
+	// request must be buffered rather than dropped until the next periodic
+	// regeneration.
+	t.Run("waiting-for-identity buffers the regeneration", func(t *testing.T) {
+		ep := newEP()
+		ep.state = StateWaitingForIdentity
+
+		require.True(t, skip(ep, rev2))
+		require.Equal(t, uint64(rev2), ep.skippedPolicyRevision)
+		require.Equal(t, regeneration.RegenerateWithoutDatapath, ep.skippedRegenerationLevel)
+
+		// Leaving waiting-for-identity must surface the buffered request.
+		ep.unconditionalLock()
+		deferred := ep.consumeDeferredRegenerationLocked()
+		ep.unlock()
+		require.NotNil(t, deferred)
+		require.Equal(t, uint64(rev2), deferred.PolicyRevisionToWaitFor)
+		require.Equal(t, regeneration.RegenerateWithoutDatapath, deferred.RegenerationLevel)
+
+		// The buffered revision is still consumed by the regeneration itself.
+		ctx := &datapathRegenerationContext{}
+		consume(ep, ctx)
+		require.Equal(t, uint64(rev2), ctx.policyRevisionToWaitFor)
+	})
+
+	t.Run("no deferred regeneration when nothing was buffered", func(t *testing.T) {
+		ep := newEP()
+		ep.state = StateWaitingForIdentity
+		ep.unconditionalLock()
+		defer ep.unlock()
+		require.Nil(t, ep.consumeDeferredRegenerationLocked())
+	})
 }

--- a/pkg/endpoint/regeneration/regeneration_context.go
+++ b/pkg/endpoint/regeneration/regeneration_context.go
@@ -54,6 +54,7 @@ const (
 	ReasonPolicyUpdate               = "PolicyUpdate"
 	ReasonSelectorPolicyStale        = "SelectorPolicyStale"
 	ReasonRegenerationFailure        = "RegenerationFailure"
+	ReasonDeferredRegeneration       = "DeferredRegeneration"
 
 	// Custom Triggers for regeneration.
 	ReasonDaemonTrigger = "DeamonTrigger"


### PR DESCRIPTION
An endpoint parked in waiting-for-identity silently loses every regeneration request that arrives while it is in that state. setRegenerateStateLocked falls into its default branch, which, unlike the restoring branch right above it, buffers nothing, so the request is simply gone.

A pod relabel parks the endpoint there and defers the identity resolver by identity-max-jitter, 30s by default. A NetworkPolicy landing in that window is discarded, and when the resolver finds the labels unchanged it moves the endpoint to ready without queueing anything, so the policy is only realized by the next periodic regeneration two minutes later. Until then the endpoint enforces default deny with none of its allow rules. The identity change path is fine and untouched, it allocates an identity and queues its own regeneration, so this only bites when the relabel resolves to the same identity.

The fix buffers the skipped level and revision like the restoring branch does, and flushes them when the resolver leaves waiting-for-identity without assigning a new identity. It only ever adds back a regeneration that was already requested and wrongly discarded, so it cannot mask a failure.

Found while triaging four red Cyclonus Test jobs on main, where test 11 fails all eight probe retries of step 1 and then recovers, which is the shape this gap produces:

https://github.com/cilium/cilium/actions/runs/30524337994/job/90811693390
https://github.com/cilium/cilium/actions/runs/30517835160/job/90791519861
https://github.com/cilium/cilium/actions/runs/30488817231/job/90701233566
https://github.com/cilium/cilium/actions/runs/30484645335/job/90687153692

```release-note
Fix a NetworkPolicy update being ignored for up to two minutes when it arrived while an endpoint was waiting for its security identity to be resolved after a pod relabel.
```

This PR was prepared with AIL:3.

@cilium/sig-policy I've added the needs-backport/1.20 label but feel free to add more needs-backport label as you feel this PR would be important to backport. I think the bug is not that serious as the policy is "eventually" consistent.
