### PR TITLE
gateway-api: filter CEC controls from infrastructure metadata

### DIFF
--- a/Documentation/operations/upgrade-next.inc
+++ b/Documentation/operations/upgrade-next.inc
@@ -15,7 +15,12 @@ notes carefully below to understand what to do during upgrade.
 Informational Notes
 ~~~~~~~~~~~~~~~~~~~
 
-* TODO
+* Annotations in the ``cec.cilium.io/*`` namespace supplied through Gateway or
+  GAMMA infrastructure metadata are no longer propagated to internally
+  generated ``CiliumEnvoyConfig`` resources. They remain on generated Services,
+  where they have no effect, to preserve Gateway API infrastructure metadata
+  propagation. This prevents user-controlled infrastructure metadata from
+  changing proxy and policy behavior.
 
 Changes to Features
 ~~~~~~~~~~~~~~~~~~~

--- a/operator/pkg/model/translation/gateway-api/translator.go
+++ b/operator/pkg/model/translation/gateway-api/translator.go
@@ -486,7 +486,16 @@ func decorateCEC(cec *ciliumv2.CiliumEnvoyConfig, resource *model.FullyQualified
 	}
 	cec.Labels = mergeMap(cec.Labels, labels)
 	cec.Labels[gatewayNameLabel] = shortener.ShortenK8sResourceName(resource.Name)
-	cec.Annotations = mergeMap(cec.Annotations, annotations)
+
+	// Listener infrastructure annotations originate from user-controlled Gateway
+	// or Service metadata. Do not let them set CEC controls that can change proxy
+	// and policy behavior. Clone the map because it is also used for the generated
+	// Service.
+	cecAnnotations := maps.Clone(annotations)
+	maps.DeleteFunc(cecAnnotations, func(key, _ string) bool {
+		return strings.HasPrefix(key, annotation.CECPrefix+"/")
+	})
+	cec.Annotations = mergeMap(cec.Annotations, cecAnnotations)
 
 	return nil
 }

--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -5,6 +5,7 @@ package gateway_api
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"strings"
 	"testing"
@@ -398,6 +399,43 @@ func Test_translator_Translate_L4MaglevWeightAnnotation(t *testing.T) {
 	require.NotNil(t, svc)
 	_, ok := svc.Annotations[lbAlgorithmAnnotation]
 	assert.False(t, ok, "unweighted L4 backend must not set maglev annotation")
+}
+
+func Test_decorateCECDoesNotPropagateCECAnnotations(t *testing.T) {
+	const (
+		ordinaryAnnotation  = "example.com/annotation"
+		futureCECAnnotation = annotation.CECPrefix + "/future-control"
+	)
+
+	cec := &ciliumv2.CiliumEnvoyConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				annotation.CECUseOriginalSourceAddress: "false",
+			},
+		},
+	}
+	infrastructureAnnotations := map[string]string{
+		ordinaryAnnotation:                     "preserved",
+		annotation.CECInjectCiliumFilters:      "false",
+		annotation.CECIsL7LB:                   "false",
+		annotation.CECUseOriginalSourceAddress: "true",
+		futureCECAnnotation:                    "false",
+	}
+	originalInfrastructureAnnotations := maps.Clone(infrastructureAnnotations)
+
+	err := decorateCEC(cec, &model.FullyQualifiedResource{
+		Name: "gateway",
+		Kind: "Gateway",
+	}, nil, infrastructureAnnotations)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		ordinaryAnnotation:                     "preserved",
+		annotation.CECUseOriginalSourceAddress: "false",
+	}, cec.Annotations)
+
+	// Infrastructure annotations are also used to decorate the generated Service.
+	// Filtering CEC annotations must not mutate the source map.
+	require.Equal(t, originalInfrastructureAnnotations, infrastructureAnnotations)
 }
 
 func Test_translator_toServicePorts_MixedProtocolsSamePort(t *testing.T) {


### PR DESCRIPTION
Gateway and GAMMA infrastructure annotations originate from user-controlled resources and are propagated to generated CiliumEnvoyConfig metadata. This allowed those resources to set reserved cec.cilium.io controls that affect proxy and policy behavior.

Filter the complete CEC annotation namespace while decorating generated CECs. Preserve internally generated CEC annotations and leave the source map unchanged for the generated Service.

Fixes: #issue-number

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
