### PR TITLE
selectorcache: remove global lastSelectorId variable

### DIFF
--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -273,6 +273,9 @@ type SelectorCache struct {
 
 	// userHandlerDone is initialized only in tests to allow termination of the handler
 	userHandlerDone chan struct{}
+
+	// lastSelectorId contains the last used selector cache id and is protected by the selector cache mutex
+	lastSelectorId types.SelectorId
 }
 
 // GetSelectorSnapshot returns a read-only state of the current selectors in the selector cache.

--- a/pkg/policy/selectorcache_selector.go
+++ b/pkg/policy/selectorcache_selector.go
@@ -68,14 +68,12 @@ type identitySelector struct {
 	cachedSelections map[identity.NumericIdentity]struct{}
 }
 
-var lastSelectorId types.SelectorId
-
 func newIdentitySelector(sc *SelectorCache, key string, source Selector) *identitySelector {
-	lastSelectorId++
+	sc.lastSelectorId++
 	return &identitySelector{
 		selectorCache:    sc,
 		key:              key,
-		id:               lastSelectorId,
+		id:               sc.lastSelectorId,
 		users:            make(map[CachedSelectionUser]struct{}),
 		cachedSelections: make(map[identity.NumericIdentity]struct{}),
 		source:           source,


### PR DESCRIPTION
This removes the global variable in order to avoid a data race between the two distrinct selector caches we have. The chance is tiny (or even impossible - have not really tried reproing it), and reusing the same counter is fine - but the data race is not great.

This was global var was introduced d7b4d5f1
("Reapply "policy: Replace versioned with part.Map"") and the change in 161a51b7 ("policy: split selectorCache in two") started using this in actual code rather than just test code.

These were both introduced in v1.19 so I'm adding backport required to both since its a data race, and the patch is very small and simple. Feel free to disagree. 

```release-note
Fix rare data race in selector cache that could lead to agent panic
```

AIL: 1

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
