### PR TITLE
bpf: tests: fix up prog type in ipv6_test

### DIFF
--- a/bpf/tests/ipv6_test.c
+++ b/bpf/tests/ipv6_test.c
@@ -223,7 +223,7 @@ int bpf_test(__maybe_unused struct xdp_md *ctx)
 	test_finish();
 }
 
-CHECK("tc", "test_ipv6_sol_mc_helpers")
+CHECK(PROG_TYPE, "test_ipv6_sol_mc_helpers")
 int test_ipv6_sol_mc_helpers(__maybe_unused struct __ctx_buff *ctx)
 {
 	union macaddr mac = {{0}};


### PR DESCRIPTION
This test file includes ctx/xdp.h, and in all other sub-tests used "xdp" as program type.

Assume that the single occurence of "tc" was just a typo, and fix it up by using the correct PROG_TYPE as provided by ctx/xdp.h