### PR TITLE
ci: migrate GitHub Actions dependencies to Node.js 24

### DIFF
--- a/.github/actions/get-runner-ip/action.yml
+++ b/.github/actions/get-runner-ip/action.yml
@@ -26,7 +26,7 @@ runs:
   steps:
     - name: Get runner public IP
       id: get-ip
-      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           const source = `${{ inputs.source }}`.trim();

--- a/.github/actions/install-llvm/action.yml
+++ b/.github/actions/install-llvm/action.yml
@@ -1,0 +1,48 @@
+name: Install LLVM and Clang
+description: Download and configure an official LLVM release without a JavaScript action runtime.
+
+inputs:
+  version:
+    description: LLVM release version to install.
+    required: true
+  directory:
+    description: Directory where LLVM will be installed.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Download and install LLVM and Clang
+      shell: bash
+      env:
+        LLVM_VERSION: ${{ inputs.version }}
+        LLVM_INSTALL_PATH: ${{ inputs.directory }}
+      run: |
+        set -euo pipefail
+
+        case "${RUNNER_ARCH}" in
+          X64)
+            asset="LLVM-${LLVM_VERSION}-Linux-X64.tar.xz"
+            ;;
+          ARM64)
+            asset="clang%2Bllvm-${LLVM_VERSION}-aarch64-linux-gnu.tar.xz"
+            ;;
+          *)
+            echo "Unsupported runner architecture: ${RUNNER_ARCH}" >&2
+            exit 1
+            ;;
+        esac
+
+        archive="${RUNNER_TEMP}/llvm-${LLVM_VERSION}.tar.xz"
+        curl --fail --location --retry 3 --retry-all-errors \
+          --output "${archive}" \
+          "https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/${asset}"
+        mkdir -p "${LLVM_INSTALL_PATH}"
+        tar --extract --xz --file "${archive}" --strip-components=1 --directory "${LLVM_INSTALL_PATH}"
+
+        echo "${LLVM_INSTALL_PATH}/bin" >> "${GITHUB_PATH}"
+        {
+          echo "LLVM_PATH=${LLVM_INSTALL_PATH}"
+          echo "LD_LIBRARY_PATH=${LLVM_INSTALL_PATH}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+        } >> "${GITHUB_ENV}"
+        "${LLVM_INSTALL_PATH}/bin/clang" --version

--- a/.github/workflows/build-images-ci-v1.17.yaml
+++ b/.github/workflows/build-images-ci-v1.17.yaml
@@ -450,7 +450,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
-          app-id: ${{ secrets.AUTO_COMMENT_BOT_APP_ID }}
+          client-id: ${{ secrets.AUTO_COMMENT_BOT_APP_ID }}
           private-key: ${{ secrets.AUTO_COMMENT_BOT_PEM }}
       - name: Post /test comment
         env:

--- a/.github/workflows/build-images-ci-v1.18.yaml
+++ b/.github/workflows/build-images-ci-v1.18.yaml
@@ -480,7 +480,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
-          app-id: ${{ secrets.AUTO_COMMENT_BOT_APP_ID }}
+          client-id: ${{ secrets.AUTO_COMMENT_BOT_APP_ID }}
           private-key: ${{ secrets.AUTO_COMMENT_BOT_PEM }}
       - name: Post /test comment
         env:

--- a/.github/workflows/build-images-ci-v1.19.yaml
+++ b/.github/workflows/build-images-ci-v1.19.yaml
@@ -457,7 +457,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
-          app-id: ${{ secrets.AUTO_COMMENT_BOT_APP_ID }}
+          client-id: ${{ secrets.AUTO_COMMENT_BOT_APP_ID }}
           private-key: ${{ secrets.AUTO_COMMENT_BOT_PEM }}
       - name: Post /test comment
         env:

--- a/.github/workflows/build-images-ci-v1.20.yaml
+++ b/.github/workflows/build-images-ci-v1.20.yaml
@@ -447,7 +447,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
-          app-id: ${{ secrets.AUTO_COMMENT_BOT_APP_ID }}
+          client-id: ${{ secrets.AUTO_COMMENT_BOT_APP_ID }}
           private-key: ${{ secrets.AUTO_COMMENT_BOT_PEM }}
       - name: Post /test comment
         env:

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -462,7 +462,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
-          app-id: ${{ secrets.AUTO_COMMENT_BOT_APP_ID }}
+          client-id: ${{ secrets.AUTO_COMMENT_BOT_APP_ID }}
           private-key: ${{ secrets.AUTO_COMMENT_BOT_PEM }}
       - name: Post /test comment
         env:

--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -401,7 +401,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends libtinfo6
 
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@ebc0426251bc40c7cd31162802432c68818ab8f0 # v2.0.9
+        uses: ./.github/actions/install-llvm
         with:
           version: "19.1.7"
           directory: ${{ steps.set_clang_dir.outputs.clang_dir }}

--- a/.github/workflows/needs-more-info.yaml
+++ b/.github/workflows/needs-more-info.yaml
@@ -13,8 +13,36 @@ jobs:
       issues: write
     steps:
       - name: Apply Needs Attention Label
-        uses: hramos/needs-attention@d0eaa7f961c04d4da86466b1176b56e0d4089022 # v2.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-            repo-token: ${{ secrets.GITHUB_TOKEN }}
-            response-required-label: 'need-more-info'
-            needs-attention-label: 'info-completed'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue = context.payload.issue;
+            const comment = context.payload.comment;
+            if (!issue || !comment) {
+              core.setOutput('result', 'Event does not contain an issue and comment');
+              return;
+            }
+
+            const responseRequiredLabel = 'need-more-info';
+            const needsAttentionLabel = 'info-completed';
+            const labels = issue.labels.map((label) =>
+              typeof label === 'string' ? label : label.name
+            );
+
+            if (!labels.includes(responseRequiredLabel) || issue.user.login !== comment.user.login) {
+              core.setOutput('result', `${context.repo.owner}/${context.repo.repo}#${issue.number} does not need attention`);
+              return;
+            }
+
+            await github.rest.issues.removeLabel({
+              ...context.repo,
+              issue_number: issue.number,
+              name: responseRequiredLabel,
+            });
+            await github.rest.issues.addLabels({
+              ...context.repo,
+              issue_number: issue.number,
+              labels: [needsAttentionLabel],
+            });
+            core.setOutput('result', `${context.repo.owner}/${context.repo.repo}#${issue.number} marked as needing attention`);


### PR DESCRIPTION
Replace dependencies that require manual workflow implementations while preserving existing behavior.

Manual replacements:
- Replace KyleMayes/install-llvm-action with a local Bash composite action.
- Preserve LLVM 19.1.7, X64 and ARM64 support, environment exports, and clang verification.
- Replace hramos/needs-attention with actions/github-script logic that preserves the existing issue-author and label transitions.

Compatibility changes:
- Change five create-github-app-token inputs from deprecated app-id to client-id while retaining the existing AUTO_COMMENT_BOT_APP_ID secret references.
- Use the audited actions/github-script release where JavaScript execution remains necessary.
- Keep external action references pinned to immutable commit SHAs.

Renovate ownership:
- Leave docker/login-action, github/codeql-action, azure/login, and renovatebot/github-action version updates to Renovate.
- Avoid duplicating normal dependency-update PRs in this manual migration.

Validation:
- All nine changed workflow and composite-action YAML files parse successfully.
- No staged version change remains for the four Renovate-managed dependencies listed above.
- git diff --check passes.