### PR TITLE
iptables: Fix OutsideToNodePort reply coming from a secondary ENI on EKS

### DIFF
--- a/.github/actions/eks/k8s-versions.yaml
+++ b/.github/actions/eks/k8s-versions.yaml
@@ -8,11 +8,24 @@
 # the second to last version, so that only that one enables prefix delegation.
 ---
 include:
+  - version: "1.32"
+    region: us-west-1
+    default: true
+  - version: "1.32"
+    region: us-west-1
+    default: true
+    aws-eni-pd: true
   - version: "1.33"
     region: us-east-2
+    default: true
   - version: "1.34"
     region: us-east-1
+    default: true
     aws-eni-pd: true
   - version: "1.35"
     region: us-west-2
     default: true
+  - version: "1.35"
+    region: us-west-2
+    default: true
+    aws-eni-pd: true

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -596,7 +596,6 @@ jobs:
           # IPs on the primary ENI, so they run and gate on them as usual. To
           # quarantine another test add it to this list; to re-arm one, drop it.
           QUARANTINED_TESTS=(
-            north-south-loadbalancing-with-l7-policy
             egress-gateway-excluded-cidrs
           )
 

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -2145,6 +2145,22 @@ func (m *manager) addCiliumENIRules() error {
 			"-j", "CONNMARK", "--restore-mark", "--nfmask", nfmask, "--ctmask", ctmask}); err != nil {
 			return err
 		}
+		// Restore the primary-ENI mark for L7 proxy return traffic that
+		// loops back via the loopback interface. When a NodePort SYN
+		// arrives on the primary ENI the CONNMARK is set to 0x80 above.
+		// The L7 hairpin path (cil_to_container → cilium_host TPROXY →
+		// Envoy) sends the response through loopback, bypassing the lxc+
+		// restore rule. Restoring the mark on lo ensures the priority-109
+		// ip rule forces routing through the main table (primary ENI) so
+		// the VPC source/destination check passes.
+		if err := m.ip4tables.runProg([]string{
+			"-t", "mangle",
+			"-A", ciliumPreMangleChain,
+			"-i", "lo",
+			"-m", "comment", "--comment", "cilium: primary ENI",
+			"-j", "CONNMARK", "--restore-mark", "--nfmask", nfmask, "--ctmask", ctmask}); err != nil {
+			return err
+		}
 	}
 
 	if m.sharedCfg.EnableIPv6 {
@@ -2166,6 +2182,14 @@ func (m *manager) addCiliumENIRules() error {
 			"-t", "mangle",
 			"-A", ciliumPreMangleChain,
 			"-i", "lxc+",
+			"-m", "comment", "--comment", "cilium: primary ENI",
+			"-j", "CONNMARK", "--restore-mark", "--nfmask", nfmask, "--ctmask", ctmask}); err != nil {
+			return err
+		}
+		if err := m.ip6tables.runProg([]string{
+			"-t", "mangle",
+			"-A", ciliumPreMangleChain,
+			"-i", "lo",
 			"-m", "comment", "--comment", "cilium: primary ENI",
 			"-j", "CONNMARK", "--restore-mark", "--nfmask", nfmask, "--ctmask", ctmask}); err != nil {
 			return err


### PR DESCRIPTION
The issue occurs on EKS with kube-proxy and no prefix delegation. In non-PD ENI mode a node has several secondary ENIs. Cilium installs per-ENI IP rules (from pod_IP lookup tableID) that route pod egress through the ENI that owns that pod's IP. These rules fire on responses from Envoy too, because Envoy uses the original pod destination IP as the socket's source address (via IP_TRANSPARENT).

The packet flow for outside-to-nodeport with L7 policy and kube-proxy:

1. SYN arrives on eth0 (primary ENI). addCiliumENIRules fires: CONNMARK --set-xmark 0x80/0x80 stores the mark in the conntrack entry.
2. kube-proxy DNAT + MASQUERADE -> packet reaches cil_to_container -> L7 policy -> hairpin via cilium_host -> iptables TPROXY -> Envoy.
3. Envoy writes its SYN-ACK to the socket (src=pod_IP, dst=node_IP_masqueraded). Because dst=node_IP is a local address, the kernel sends it through loopback, not via lxc+.
4. On loopback PREROUTING, conntrack un-MASQUERADEs the destination (-> ext_IP) and re-routes. But the CONNMARK restore rule only covers -i lxc+ (loopback is missed) so the 0x80 mark is never restored.
5. Without the 0x80 mark the priority-109 ip rule (fwmark 0x80 -> main table) doesn't match. The per-ENI egress rule at priority 110/111 (from pod_IP -> tableID) wins instead, and the SYN-ACK exits via a secondary ENI.
6. After POSTROUTING SNAT (conntrack un-DNAT: pod_IP -> node_IP), the packet is on the secondary ENI with the primary ENI's source IP. The AWS VPC source/destination check drops it. TCP SYN never gets a reply -> curl timeout (exit 28).

Add CONNMARK --restore-mark for -i lo in addition to -l lxc+. This restores the 0x80 mark for Envoy's loopback-routed response, which lets the priority-109 rule force routing through the main table -> primary ENI -> correct source IP for the VPC check.

AIL:4

Fixes: https://github.com/cilium/cilium/issues/47391

```release-note
Fix outside-to-nodeport on EKS with kube-proxy and L7 policy, without prefix delegation.
```