### PR TITLE
gha: authenticate Image CI to quay.io with OIDC

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -51,6 +51,12 @@ jobs:
     timeout-minutes: 45
     name: Build and Push Images
     runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
+    # Pins the OIDC token subject to
+    # repo:cilium/cilium:environment:publish-ci-images, which is the identity
+    # federated with the Quay robot account.
+    environment:
+      name: publish-ci-images
+      deployment: false
     # GH-46482: Lint checks action is broken, skip dependency for now.
     #needs: wait-for-base-images
     outputs:
@@ -148,12 +154,36 @@ jobs:
             [worker.oci]
              gc=false
 
+      # Quay's registry endpoint only accepts credentials or a JWT signed by
+      # Quay itself, so the GitHub OIDC token cannot be used as the registry
+      # password directly. Trade it for a short lived robot token first.
+      - name: Get a quay.io robot token via OIDC
+        id: registry-token
+        env:
+          ROBOT: ${{ secrets.QUAY_USERNAME_CI }}
+        run: |
+          oidc_token="$(curl -sSf --retry 3 --retry-all-errors \
+            -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=quay.io" \
+            | jq -er '.value')"
+          echo "::add-mask::${oidc_token}"
+
+          # Pass the credentials on stdin so that the OIDC token is not visible
+          # in the process list of the runner.
+          robot_token="$(printf 'user = "%s:%s"\n' "${ROBOT}" "${oidc_token}" \
+            | curl -sSf --retry 3 --retry-all-errors -K - \
+              "https://quay.io/oauth2/federation/robot/token" \
+            | jq -er '.token')"
+          echo "::add-mask::${robot_token}"
+
+          echo "token=${robot_token}" >> "$GITHUB_OUTPUT"
+
       - name: Login to ${{ env.REGISTRY_DEV }} for CI
         uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
         with:
           registry: ${{ env.REGISTRY_DEV }}
           username: ${{ secrets.QUAY_USERNAME_CI }}
-          password: ${{ secrets.QUAY_PASSWORD_CI }}
+          password: ${{ steps.registry-token.outputs.token }}
 
       - name: Getting image tag
         id: tag


### PR DESCRIPTION
Use OIDC to authenticate Image CI to quay.io, instead of the static robot
password. The GitHub token cannot be used as the registry password directly, so
it is traded for a short lived robot token before the login.

Tested with a temporary commit that added this branch to the push trigger, which
built and pushed every image with the OIDC login:
https://github.com/cilium/cilium/actions/runs/30919974637

This PR was prepared with AIL:3.
