### PR TITLE
ariane: move kind-proxy-embedded and kubespray workflows to /test

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -4,12 +4,10 @@ allowed-teams:
 triggers:
   /default:
     workflows:
-    - conformance-kind-proxy-embedded.yaml
     - tests-smoke-conformance.yaml
     - tests-smoke-ipv6.yaml
     - tests-cifuzz.yaml
     - lint-ariane-config.yaml
-    - conformance-kubespray.yaml
     - lint-images-base.yaml
   # This trigger needs to be kept in sync with ariane-scheduled.yaml workflow
   /test\s*:
@@ -26,9 +24,11 @@ triggers:
     - conformance-ingress.yaml
     - conformance-l3-l4.yaml
     - conformance-l7.yaml
+    - conformance-kind-proxy-embedded.yaml
     - conformance-kpr-aks.yaml
     - conformance-kpr-eks.yaml
     - conformance-kpr-gke.yaml
+    - conformance-kubespray.yaml
     - conformance-multi-pool.yaml
     - conformance-race.yaml
     - conformance-runtime.yaml


### PR DESCRIPTION
Move these conformance workflows to the /test trigger, as they shouldn't be automatically triggered once a PR is opened. Having them part of /test has also the desired side-effect that they are automatically run on schedule on stable branches as well through the ariane-scheduled workflow.

AIL: 0