### PR TITLE
Introduce metrics for loadbalancer BPF reconciler

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -503,6 +503,7 @@ Name                                           Labels                          D
 ``loadbalancer_id_allocations``                ``type``                        Enabled     Number of loadbalancer IDs currently allocated
 ``loadbalancer_id_allocation_attempts_total``  ``type``                        Enabled     Total number of loadbalancer ID allocation attempts
 ``loadbalancer_id_allocation_failures_total``  ``type``                        Enabled     Total number of loadbalancer ID allocation failures
+``loadbalancer_id_mappings_pending_restore``   ``type``                        Enabled     Number of loadbalancer address-to-ID mappings pending restoration
 ============================================== =============================== =========== ===================================================================
 
 Cluster health

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -493,6 +493,18 @@ Name                                       Labels                               
 ``service_implementation_delay``           ``action``                                         Enabled    Duration in seconds to propagate the data plane programming of a service, its network and endpoints from the time the service or the service pod was changed excluding the event queue latency
 ========================================== ================================================== ========== ========================================================
 
+Load-balancer
+~~~~~~~~~~~~~
+
+============================================== =============================== =========== ===================================================================
+Name                                           Labels                          Default     Description
+============================================== =============================== =========== ===================================================================
+``loadbalancer_id_capacity``                   ``type``                        Enabled     Number of loadbalancer IDs in the allocation range
+``loadbalancer_id_allocations``                ``type``                        Enabled     Number of loadbalancer IDs currently allocated
+``loadbalancer_id_allocation_attempts_total``  ``type``                        Enabled     Total number of loadbalancer ID allocation attempts
+``loadbalancer_id_allocation_failures_total``  ``type``                        Enabled     Total number of loadbalancer ID allocation failures
+============================================== =============================== =========== ===================================================================
+
 Cluster health
 ~~~~~~~~~~~~~~
 

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -239,12 +239,16 @@ func (ops *BPFOps) ResetAndRestore() (err error) {
 		newIDAllocatorMetrics(ops.metrics, idAllocTypeService),
 	)
 	ops.restoredServiceIDs = map[loadbalancer.L3n4Addr]loadbalancer.ServiceID{}
+	ops.metrics.setIDMappingsPendingRestore(idAllocTypeService, len(ops.restoredServiceIDs))
+
 	ops.backendIDAlloc = newIDAllocator(
 		firstFreeBackendID,
 		maxSetOfBackendID,
 		newIDAllocatorMetrics(ops.metrics, idAllocTypeBackend),
 	)
 	ops.restoredBackendIDs = map[loadbalancer.L3n4Addr]loadbalancer.BackendID{}
+	ops.metrics.setIDMappingsPendingRestore(idAllocTypeBackend, len(ops.restoredBackendIDs))
+
 	ops.backendStates = map[loadbalancer.L3n4Addr]backendState{}
 	ops.backendReferences = map[loadbalancer.L3n4Addr]sets.Set[loadbalancer.L3n4Addr]{}
 	ops.wildcardReferences = map[netip.Addr][]loadbalancer.ServiceID{}
@@ -270,6 +274,7 @@ func (ops *BPFOps) ResetAndRestore() (err error) {
 		}
 		ops.backendIDAlloc.nextID = max(ops.backendIDAlloc.nextID, key.GetID()+1)
 	})
+	ops.metrics.setIDMappingsPendingRestore(idAllocTypeBackend, len(ops.restoredBackendIDs))
 	if err != nil {
 		return fmt.Errorf("restore backend ids: %w", err)
 	}
@@ -331,6 +336,7 @@ func (ops *BPFOps) ResetAndRestore() (err error) {
 			}
 		}
 	}
+	ops.metrics.setIDMappingsPendingRestore(idAllocTypeService, len(ops.restoredServiceIDs))
 	return nil
 }
 
@@ -627,7 +633,9 @@ func (ops *BPFOps) pruneBackendMaps() error {
 
 func (ops *BPFOps) pruneRestoredIDs() error {
 	ops.restoredServiceIDs = nil
+	ops.metrics.setIDMappingsPendingRestore(idAllocTypeService, len(ops.restoredServiceIDs))
 	ops.restoredBackendIDs = nil
+	ops.metrics.setIDMappingsPendingRestore(idAllocTypeBackend, len(ops.restoredBackendIDs))
 	return nil
 }
 
@@ -873,6 +881,7 @@ func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend, isLocalAddr func(ne
 		feID = id
 		ops.serviceIDAlloc.addID(fe.Address, id)
 		delete(ops.restoredServiceIDs, fe.Address)
+		ops.metrics.setIDMappingsPendingRestore(idAllocTypeService, len(ops.restoredServiceIDs))
 	} else {
 		var err error
 		feID, err = ops.serviceIDAlloc.acquireLocalID(fe.Address)
@@ -966,6 +975,7 @@ func (ops *BPFOps) updateFrontend(fe *loadbalancer.Frontend, isLocalAddr func(ne
 				beID = id
 				ops.backendIDAlloc.addID(be.Address, id)
 				delete(ops.restoredBackendIDs, be.Address)
+				ops.metrics.setIDMappingsPendingRestore(idAllocTypeBackend, len(ops.restoredBackendIDs))
 			} else {
 				var err error
 				beID, err = ops.backendIDAlloc.acquireLocalID(be.Address)

--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
@@ -119,6 +119,7 @@ type BPFOps struct {
 	maglev        *maglev.Maglev
 	lastUpdatedAt atomic.Pointer[time.Time]
 	pruneCount    atomic.Int32
+	metrics       *reconcilerMetrics
 
 	// mu protects the state below. The reconciler itself is single-threaded, but we need
 	// to protect the state in order to be able to ResetAndRestore() in tests.
@@ -188,6 +189,7 @@ type bpfOpsParams struct {
 	DB             *statedb.DB
 	NodeAddresses  statedb.Table[tables.NodeAddress]
 	Frontends      statedb.Table[*loadbalancer.Frontend]
+	Metrics        *reconcilerMetrics
 }
 
 const (
@@ -206,6 +208,7 @@ func newBPFOps(p bpfOpsParams) *BPFOps {
 		db:        p.DB,
 		nodeAddrs: p.NodeAddresses,
 		frontends: p.Frontends,
+		metrics:   p.Metrics,
 	}
 	ops.setLastUpdatedAt()
 
@@ -230,9 +233,17 @@ func (ops *BPFOps) ResetAndRestore() (err error) {
 	ops.mu.Lock()
 	defer ops.mu.Unlock()
 
-	ops.serviceIDAlloc = newIDAllocator(firstFreeServiceID, maxSetOfServiceID)
+	ops.serviceIDAlloc = newIDAllocator(
+		firstFreeServiceID,
+		maxSetOfServiceID,
+		newIDAllocatorMetrics(ops.metrics, idAllocTypeService),
+	)
 	ops.restoredServiceIDs = map[loadbalancer.L3n4Addr]loadbalancer.ServiceID{}
-	ops.backendIDAlloc = newIDAllocator(firstFreeBackendID, maxSetOfBackendID)
+	ops.backendIDAlloc = newIDAllocator(
+		firstFreeBackendID,
+		maxSetOfBackendID,
+		newIDAllocatorMetrics(ops.metrics, idAllocTypeBackend),
+	)
 	ops.restoredBackendIDs = map[loadbalancer.L3n4Addr]loadbalancer.BackendID{}
 	ops.backendStates = map[loadbalancer.L3n4Addr]backendState{}
 	ops.backendReferences = map[loadbalancer.L3n4Addr]sets.Set[loadbalancer.L3n4Addr]{}

--- a/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
@@ -1623,6 +1623,29 @@ func TestBPFOps(t *testing.T) {
 	}
 }
 
+func TestIDMappingsPendingRestoreMetric(t *testing.T) {
+	metrics := newReconcilerMetrics()
+	ops := &BPFOps{
+		metrics: metrics,
+		restoredServiceIDs: map[loadbalancer.L3n4Addr]loadbalancer.ServiceID{
+			frontendAddrs[0]: 1,
+		},
+		restoredBackendIDs: map[loadbalancer.L3n4Addr]loadbalancer.BackendID{
+			backend1: 1,
+			backend2: 2,
+		},
+	}
+
+	metrics.setIDMappingsPendingRestore(idAllocTypeService, len(ops.restoredServiceIDs))
+	metrics.setIDMappingsPendingRestore(idAllocTypeBackend, len(ops.restoredBackendIDs))
+	require.Equal(t, float64(1), metrics.IDMappingsPendingRestore.WithLabelValues(idAllocTypeService).Get())
+	require.Equal(t, float64(2), metrics.IDMappingsPendingRestore.WithLabelValues(idAllocTypeBackend).Get())
+
+	require.NoError(t, ops.pruneRestoredIDs())
+	require.Zero(t, metrics.IDMappingsPendingRestore.WithLabelValues(idAllocTypeService).Get())
+	require.Zero(t, metrics.IDMappingsPendingRestore.WithLabelValues(idAllocTypeBackend).Get())
+}
+
 // showMaps formats the map dumps as the Go code expected in the test cases.
 func showMaps(m []maps.MapDump) string {
 	var w strings.Builder

--- a/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
+++ b/pkg/loadbalancer/reconciler/bpf_reconciler_test.go
@@ -1404,6 +1404,7 @@ func TestBPFOps(t *testing.T) {
 			DB:             db,
 			NodeAddresses:  nodeAddrs,
 			Frontends:      frontends,
+			Metrics:        newReconcilerMetrics(),
 		})
 
 		svc := baseService
@@ -1586,6 +1587,7 @@ func TestBPFOps(t *testing.T) {
 					DB:             db,
 					NodeAddresses:  nodeAddrs,
 					Frontends:      frontends,
+					Metrics:        newReconcilerMetrics(),
 				}
 
 				ops := newBPFOps(p)
@@ -1613,6 +1615,7 @@ func TestBPFOps(t *testing.T) {
 				DB:             db,
 				NodeAddresses:  nodeAddrs,
 				Frontends:      frontends,
+				Metrics:        newReconcilerMetrics(),
 			}
 			ops := newBPFOps(p)
 			runTests(ops, setWithAlgo.testCaseSet, setWithAlgo.algo, addr, true)

--- a/pkg/loadbalancer/reconciler/cell.go
+++ b/pkg/loadbalancer/reconciler/cell.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cilium/statedb/reconciler"
 
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/promise"
 )
 
@@ -17,6 +18,8 @@ import (
 var Cell = cell.Module(
 	"loadbalancer-reconciler",
 	"Load-balancing BPF map reconciliation",
+
+	metrics.Metric(newReconcilerMetrics),
 
 	cell.Provide(
 		// Provide [BPFOps] for reconciling a changed frontend.

--- a/pkg/loadbalancer/reconciler/id_allocator.go
+++ b/pkg/loadbalancer/reconciler/id_allocator.go
@@ -7,10 +7,18 @@ import (
 	"fmt"
 
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/metrics/metric"
 )
 
 type idConstraint interface {
 	loadbalancer.ServiceID | loadbalancer.BackendID
+}
+
+type idAllocatorMetrics struct {
+	capacity           metric.Gauge
+	allocations        metric.Gauge
+	allocationAttempts metric.Counter
+	allocationFailures metric.Counter
 }
 
 // idAllocator contains an internal state of the ID allocator.
@@ -32,6 +40,9 @@ type idAllocator[ID idConstraint] struct {
 
 	// initMaxID is the initial exclusive upper bound of the ID allocation range
 	initMaxID ID
+
+	// metrics are updated on mutation so scrapes do not need to read allocator state
+	metrics idAllocatorMetrics
 }
 
 const (
@@ -51,20 +62,28 @@ const (
 	maxSetOfBackendID = loadbalancer.BackendID(0xFFFFFFFF)
 )
 
-func newIDAllocator[ID idConstraint](nextID ID, maxID ID) idAllocator[ID] {
-	return idAllocator[ID]{
+func newIDAllocator[ID idConstraint](nextID ID, maxID ID, metrics idAllocatorMetrics) idAllocator[ID] {
+	alloc := idAllocator[ID]{
 		idToAddr:   map[ID]loadbalancer.L3n4Addr{},
 		addrToId:   map[loadbalancer.L3n4Addr]ID{},
 		nextID:     nextID,
 		maxID:      maxID,
 		initNextID: nextID,
 		initMaxID:  maxID,
+		metrics:    metrics,
 	}
+
+	// Initialise allocator metrics
+	alloc.metrics.capacity.Set(float64(uint64(maxID) - uint64(nextID)))
+	alloc.updateAllocationMetric()
+
+	return alloc
 }
 
 func (alloc *idAllocator[ID]) addID(addr loadbalancer.L3n4Addr, id ID) ID {
 	alloc.idToAddr[id] = addr
 	alloc.addrToId[addr] = id
+	alloc.updateAllocationMetric()
 	return id
 }
 
@@ -72,6 +91,8 @@ func (alloc *idAllocator[ID]) acquireLocalID(svc loadbalancer.L3n4Addr) (ID, err
 	if id, ok := alloc.addrToId[svc]; ok {
 		return id, nil
 	}
+
+	alloc.metrics.allocationAttempts.Inc()
 
 	startingID := alloc.nextID
 	rollover := false
@@ -92,6 +113,7 @@ func (alloc *idAllocator[ID]) acquireLocalID(svc loadbalancer.L3n4Addr) (ID, err
 		alloc.nextID++
 	}
 
+	alloc.metrics.allocationFailures.Inc()
 	return 0, fmt.Errorf("no ID available")
 }
 
@@ -99,7 +121,12 @@ func (alloc *idAllocator[ID]) deleteLocalID(id ID) {
 	if addr, ok := alloc.idToAddr[id]; ok {
 		delete(alloc.idToAddr, id)
 		delete(alloc.addrToId, addr)
+		alloc.updateAllocationMetric()
 	}
+}
+
+func (alloc *idAllocator[ID]) updateAllocationMetric() {
+	alloc.metrics.allocations.Set(float64(len(alloc.idToAddr)))
 }
 
 func (alloc *idAllocator[ID]) lookupLocalID(addr loadbalancer.L3n4Addr) (ID, error) {

--- a/pkg/loadbalancer/reconciler/id_allocator.go
+++ b/pkg/loadbalancer/reconciler/id_allocator.go
@@ -24,13 +24,13 @@ type idAllocator[ID idConstraint] struct {
 	// nextID is the next ID to attempt to allocate
 	nextID ID
 
-	// maxID is the maximum ID available for allocation
+	// maxID is the exclusive upper bound of the ID allocation range
 	maxID ID
 
 	// initNextID is the initial nextID
 	initNextID ID
 
-	// initMaxID is the initial maxID
+	// initMaxID is the initial exclusive upper bound of the ID allocation range
 	initMaxID ID
 }
 
@@ -38,16 +38,16 @@ const (
 	// firstFreeServiceID is the first ID for which the services should be assigned.
 	firstFreeServiceID = loadbalancer.ServiceID(1)
 
-	// maxSetOfServiceID is maximum number of set of service IDs that can be stored
-	// in the kvstore or the local ID allocator.
+	// maxSetOfServiceID is the exclusive upper bound of the service ID allocation
+	// range.
 	maxSetOfServiceID = loadbalancer.ServiceID(0xFFFF)
 
 	// firstFreeBackendID is the first ID for which the backend should be assigned.
 	// BPF datapath assumes that backend_id cannot be 0.
 	firstFreeBackendID = loadbalancer.BackendID(1)
 
-	// maxSetOfBackendID is maximum number of set of backendIDs IDs that can be
-	// stored in the local ID allocator.
+	// maxSetOfBackendID is the exclusive upper bound of the backend ID allocation
+	// range.
 	maxSetOfBackendID = loadbalancer.BackendID(0xFFFFFFFF)
 )
 

--- a/pkg/loadbalancer/reconciler/id_allocator_test.go
+++ b/pkg/loadbalancer/reconciler/id_allocator_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
 )
 
 func TestIDAllocatorMaxIDIsExclusive(t *testing.T) {
@@ -17,7 +19,12 @@ func TestIDAllocatorMaxIDIsExclusive(t *testing.T) {
 	lastID := loadbalancer.ServiceID(3)
 	maxID := lastID + 1
 
-	alloc := newIDAllocator(firstID, maxID)
+	alloc := newIDAllocator(firstID, maxID, idAllocatorMetrics{
+		capacity:           metrics.NoOpGauge,
+		allocations:        metrics.NoOpGauge,
+		allocationAttempts: metrics.NoOpCounter,
+		allocationFailures: metrics.NoOpCounter,
+	})
 
 	// Allocate every ID in the known range of firstID .. lastID.
 	for expectedID := firstID; expectedID <= lastID; expectedID++ {
@@ -44,4 +51,108 @@ func TestIDAllocatorMaxIDIsExclusive(t *testing.T) {
 	id, err := alloc.acquireLocalID(addr)
 	require.Zero(t, id)
 	require.Error(t, err)
+}
+
+func TestIDAllocatorMetrics(t *testing.T) {
+	allocations := metric.NewGauge(metric.GaugeOpts{})
+	capacity := metric.NewGauge(metric.GaugeOpts{})
+	allocationAttempts := metric.NewCounter(metric.CounterOpts{})
+	allocationFailures := metric.NewCounter(metric.CounterOpts{})
+	metrics := idAllocatorMetrics{
+		allocations:        allocations,
+		capacity:           capacity,
+		allocationAttempts: allocationAttempts,
+		allocationFailures: allocationFailures,
+	}
+
+	// Verify a new allocator reports its capacity and starts empty without any
+	// allocation attempts or failures.
+	alloc := newIDAllocator(loadbalancer.ServiceID(1), loadbalancer.ServiceID(4), metrics)
+	require.Zero(t, allocations.Get())
+	require.Equal(t, float64(3), capacity.Get())
+	require.Zero(t, allocationAttempts.Get())
+	require.Zero(t, allocationFailures.Get())
+
+	// Verify allocating an ID updates the gauge, while acquiring the same
+	// address again does not count it twice.
+	addr := loadbalancer.NewL3n4Addr(
+		loadbalancer.TCP,
+		types.MustParseAddrCluster("10.0.0.1"),
+		1,
+		loadbalancer.ScopeExternal,
+	)
+	firstAllocatedID, err := alloc.acquireLocalID(addr)
+	require.NoError(t, err)
+	require.Equal(t, float64(1), allocations.Get())
+	require.Equal(t, float64(1), allocationAttempts.Get())
+
+	_, err = alloc.acquireLocalID(addr)
+	require.NoError(t, err)
+	require.Equal(t, float64(1), allocations.Get())
+	require.Equal(t, float64(1), allocationAttempts.Get())
+
+	// Verify adding a restored ID updates the gauge, but restoring the same
+	// mapping again does not count it twice.
+	restoredAddr := loadbalancer.NewL3n4Addr(
+		loadbalancer.TCP,
+		types.MustParseAddrCluster("10.0.0.2"),
+		2,
+		loadbalancer.ScopeExternal,
+	)
+	restoredID := loadbalancer.ServiceID(2)
+
+	alloc.addID(restoredAddr, restoredID)
+	require.Equal(t, float64(2), allocations.Get())
+	require.Equal(t, float64(1), allocationAttempts.Get())
+
+	alloc.addID(restoredAddr, restoredID)
+	require.Equal(t, float64(2), allocations.Get())
+
+	// Fill the remaining allocation and verify all IDs are reported as used.
+	thirdAddr := loadbalancer.NewL3n4Addr(
+		loadbalancer.TCP,
+		types.MustParseAddrCluster("10.0.0.3"),
+		3,
+		loadbalancer.ScopeExternal,
+	)
+	thirdID, err := alloc.acquireLocalID(thirdAddr)
+	require.NoError(t, err)
+	require.Equal(t, float64(3), allocations.Get())
+	require.Equal(t, float64(2), allocationAttempts.Get())
+	require.Zero(t, allocationFailures.Get())
+
+	// Verify an exhausted allocator records the failure without changing the
+	// number of allocated IDs.
+	exhaustedAddr := loadbalancer.NewL3n4Addr(
+		loadbalancer.TCP,
+		types.MustParseAddrCluster("10.0.0.4"),
+		4,
+		loadbalancer.ScopeExternal,
+	)
+	failedID, err := alloc.acquireLocalID(exhaustedAddr)
+	require.Zero(t, failedID)
+	require.Error(t, err)
+	require.Equal(t, float64(3), allocations.Get())
+	require.Equal(t, float64(3), allocationAttempts.Get())
+	require.Equal(t, float64(1), allocationFailures.Get())
+
+	// Verify deleting IDs updates the gauge, while deleting an unknown ID doesn't.
+	alloc.deleteLocalID(firstAllocatedID)
+	require.Equal(t, float64(2), allocations.Get())
+
+	alloc.deleteLocalID(firstAllocatedID)
+	require.Equal(t, float64(2), allocations.Get())
+
+	alloc.deleteLocalID(restoredID)
+	require.Equal(t, float64(1), allocations.Get())
+
+	alloc.deleteLocalID(thirdID)
+	require.Zero(t, allocations.Get())
+
+	// Recreating an allocator resets its gauges, but not cumulative counters.
+	newIDAllocator(loadbalancer.ServiceID(1), loadbalancer.ServiceID(4), metrics)
+	require.Zero(t, allocations.Get())
+	require.Equal(t, float64(3), capacity.Get())
+	require.Equal(t, float64(3), allocationAttempts.Get())
+	require.Equal(t, float64(1), allocationFailures.Get())
 }

--- a/pkg/loadbalancer/reconciler/id_allocator_test.go
+++ b/pkg/loadbalancer/reconciler/id_allocator_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/loadbalancer"
+)
+
+func TestIDAllocatorMaxIDIsExclusive(t *testing.T) {
+	firstID := loadbalancer.ServiceID(1)
+	lastID := loadbalancer.ServiceID(3)
+	maxID := lastID + 1
+
+	alloc := newIDAllocator(firstID, maxID)
+
+	// Allocate every ID in the known range of firstID .. lastID.
+	for expectedID := firstID; expectedID <= lastID; expectedID++ {
+		addr := loadbalancer.NewL3n4Addr(
+			loadbalancer.TCP,
+			types.MustParseAddrCluster("10.0.0.1"),
+			uint16(expectedID),
+			loadbalancer.ScopeExternal,
+		)
+
+		id, err := alloc.acquireLocalID(addr)
+		require.NoError(t, err)
+		require.Equal(t, expectedID, id)
+	}
+
+	// Now verify we've exhausted the range. MaxID is the exclusive upper
+	// bound so should never be allocated.
+	addr := loadbalancer.NewL3n4Addr(
+		loadbalancer.TCP,
+		types.MustParseAddrCluster("10.0.0.1"),
+		uint16(maxID),
+		loadbalancer.ScopeExternal,
+	)
+	id, err := alloc.acquireLocalID(addr)
+	require.Zero(t, id)
+	require.Error(t, err)
+}

--- a/pkg/loadbalancer/reconciler/metrics.go
+++ b/pkg/loadbalancer/reconciler/metrics.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package reconciler
+
+import (
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+const (
+	subsystemName = "loadbalancer"
+
+	// idAllocator for unique loadbalancer.ServiceID
+	idAllocTypeService = "service"
+
+	// idAllocator for unique loadbalancer.BackendID
+	idAllocTypeBackend = "backend"
+)
+
+type reconcilerMetrics struct {
+	// IDAllocatorCapacity tracks the size of the numeric range of IDs available
+	// from an idAllocator.
+	IDAllocatorCapacity metric.Vec[metric.Gauge]
+
+	// IDAllocatorUsed tracks the number of used IDs within the capacity of an
+	// idAllocator.
+	IDAllocatorUsed metric.Vec[metric.Gauge]
+
+	// IDAllocatorAttempts tracks the number of attempts by an idAllocator to
+	// provide a new ID.
+	IDAllocatorAttempts metric.Vec[metric.Counter]
+
+	// IDAllocatorFailures tracks the number of times an idAllocator failed to
+	// provide an ID, e.g. if the allocator had consumed its entire range of IDs.
+	IDAllocatorFailures metric.Vec[metric.Counter]
+}
+
+// newReconcilerMetrics returns a pointer to reconcilerMetrics.
+func newReconcilerMetrics() *reconcilerMetrics {
+	idAllocTypeLabels := metric.Labels{
+		{Name: metrics.LabelType, Values: metric.NewValues(
+			idAllocTypeService,
+			idAllocTypeBackend,
+		)},
+	}
+
+	return &reconcilerMetrics{
+		IDAllocatorCapacity: metric.NewGaugeVecWithLabels(metric.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemName,
+			Name:      "id_capacity",
+			Help:      "Number of loadbalancer IDs in the allocation range",
+		}, idAllocTypeLabels),
+		IDAllocatorUsed: metric.NewGaugeVecWithLabels(metric.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemName,
+			Name:      "id_allocations",
+			Help:      "Number of loadbalancer IDs currently allocated",
+		}, idAllocTypeLabels),
+		IDAllocatorAttempts: metric.NewCounterVecWithLabels(metric.CounterOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemName,
+			Name:      "id_allocation_attempts_total",
+			Help:      "Total number of loadbalancer ID allocation attempts",
+		}, idAllocTypeLabels),
+		IDAllocatorFailures: metric.NewCounterVecWithLabels(metric.CounterOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemName,
+			Name:      "id_allocation_failures_total",
+			Help:      "Total number of loadbalancer ID allocation failures",
+		}, idAllocTypeLabels),
+	}
+}
+
+func newIDAllocatorMetrics(m *reconcilerMetrics, idType string) idAllocatorMetrics {
+	return idAllocatorMetrics{
+		capacity:           m.IDAllocatorCapacity.WithLabelValues(idType),
+		allocations:        m.IDAllocatorUsed.WithLabelValues(idType),
+		allocationAttempts: m.IDAllocatorAttempts.WithLabelValues(idType),
+		allocationFailures: m.IDAllocatorFailures.WithLabelValues(idType),
+	}
+}

--- a/pkg/loadbalancer/reconciler/metrics.go
+++ b/pkg/loadbalancer/reconciler/metrics.go
@@ -34,6 +34,10 @@ type reconcilerMetrics struct {
 	// IDAllocatorFailures tracks the number of times an idAllocator failed to
 	// provide an ID, e.g. if the allocator had consumed its entire range of IDs.
 	IDAllocatorFailures metric.Vec[metric.Counter]
+
+	// IDMappingsPendingRestore tracks address-to-ID mappings restored from BPF
+	// that have not yet been adopted or pruned by the reconciler.
+	IDMappingsPendingRestore metric.Vec[metric.Gauge]
 }
 
 // newReconcilerMetrics returns a pointer to reconcilerMetrics.
@@ -70,6 +74,12 @@ func newReconcilerMetrics() *reconcilerMetrics {
 			Name:      "id_allocation_failures_total",
 			Help:      "Total number of loadbalancer ID allocation failures",
 		}, idAllocTypeLabels),
+		IDMappingsPendingRestore: metric.NewGaugeVecWithLabels(metric.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: subsystemName,
+			Name:      "id_mappings_pending_restore",
+			Help:      "Number of loadbalancer address-to-ID mappings pending restoration",
+		}, idAllocTypeLabels),
 	}
 }
 
@@ -80,4 +90,8 @@ func newIDAllocatorMetrics(m *reconcilerMetrics, idType string) idAllocatorMetri
 		allocationAttempts: m.IDAllocatorAttempts.WithLabelValues(idType),
 		allocationFailures: m.IDAllocatorFailures.WithLabelValues(idType),
 	}
+}
+
+func (m *reconcilerMetrics) setIDMappingsPendingRestore(idType string, count int) {
+	m.IDMappingsPendingRestore.WithLabelValues(idType).Set(float64(count))
 }


### PR DESCRIPTION
Introduce metrics for the loadbalancer BPF reconciler, primarily around the `idAllocator` used to map `L3n4Addr` to `ServiceID` and `BackendID`.

For both `service` and `backend` IDs, we express:
* `cilium_loadbalancer_id_capacity` (Gauge)
* `cilium_loadbalancer_id_allocations` (Gauge)
* `cilium_loadbalancer_id_allocation_attempts_total` (Counter)
* `cilium_loadbalancer_id_allocation_failures_total` (Counter)
* `cilium_loadbalancer_id_mappings_pending_restore` (Gauge)

Example output from cilium-dbg with various resources loaded, unloaded and reloaded:

```
$ kubectl -n kube-system exec -it cilium-prz65 -- cilium metrics list | grep loadbalancer_id | grep service
cilium_loadbalancer_id_allocation_attempts_total                            type=service                                                                          330.000000
cilium_loadbalancer_id_allocation_failures_total                            type=service                                                                          0.000000
cilium_loadbalancer_id_allocations                                          type=service                                                                          120.000000
cilium_loadbalancer_id_capacity                                             type=service                                                                          65534.000000
cilium_loadbalancer_id_mappings_pending_restore                             type=service                                                                          0.000000

$ kubectl -n kube-system exec -it cilium-prz65 -- cilium metrics list | grep loadbalancer_id | grep backend
cilium_loadbalancer_id_allocation_attempts_total                            type=backend                                                                          77.000000
cilium_loadbalancer_id_allocation_failures_total                            type=backend                                                                          0.000000
cilium_loadbalancer_id_allocations                                          type=backend                                                                          33.000000
cilium_loadbalancer_id_capacity                                             type=backend                                                                          4294967294.000000
cilium_loadbalancer_id_mappings_pending_restore                             type=backend                                                                          0.000000
```

Fixes: #47729 

```release-note
loadbalancer: Add metrics that provide visibility into the capacity and utilisation of ID allocators within the loadbalancer control plane.
```

AIL:2