### PR TITLE
ipam: Accept native routing CIDR that is a subnet of the VPC CIDR

### DIFF
--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -236,15 +236,15 @@ func newNodeStore(logger *slog.Logger, nodeName string, conf *option.DaemonConfi
 	return store
 }
 
-func deriveVpcCIDRs(node *ciliumv2.CiliumNode) (primaryCIDR *cidr.CIDR, secondaryCIDRs []*cidr.CIDR) {
+func deriveVpcCIDRs(node *ciliumv2.CiliumNode) (primaryCIDR netip.Prefix, secondaryCIDRs []netip.Prefix) {
 	// A node belongs to a single VPC so we can pick the first ENI
 	// in the list and derive the VPC CIDR from it.
 	for _, eni := range node.Status.ENI.ENIs {
 		if p := eni.VPC.PrimaryCIDR; p.IsValid() {
-			primaryCIDR = cidr.NewCIDR(netipx.PrefixIPNet(p.Masked()))
+			primaryCIDR = p.Masked()
 			for _, sc := range eni.VPC.CIDRs {
 				if sc.IsValid() {
-					secondaryCIDRs = append(secondaryCIDRs, cidr.NewCIDR(netipx.PrefixIPNet(sc.Masked())))
+					secondaryCIDRs = append(secondaryCIDRs, sc.Masked())
 				}
 			}
 			return
@@ -252,19 +252,19 @@ func deriveVpcCIDRs(node *ciliumv2.CiliumNode) (primaryCIDR *cidr.CIDR, secondar
 	}
 	for _, azif := range node.Status.Azure.Interfaces {
 		if p := azif.Subnet.CIDR.Prefix; p.IsValid() {
-			primaryCIDR = cidr.NewCIDR(netipx.PrefixIPNet(p.Masked()))
+			primaryCIDR = p.Masked()
 			return
 		}
 	}
 	// return AlibabaCloud vpc CIDR
 	if len(node.Status.AlibabaCloud.ENIs) > 0 {
 		if p := node.Spec.AlibabaCloud.CIDRBlock; p.IsValid() {
-			primaryCIDR = cidr.NewCIDR(netipx.PrefixIPNet(p.Masked()))
+			primaryCIDR = p.Masked()
 		}
 		for _, eni := range node.Status.AlibabaCloud.ENIs {
 			for _, sc := range eni.VPC.SecondaryCIDRs {
 				if sc.IsValid() {
-					secondaryCIDRs = append(secondaryCIDRs, cidr.NewCIDR(netipx.PrefixIPNet(sc.Masked())))
+					secondaryCIDRs = append(secondaryCIDRs, sc.Masked())
 				}
 			}
 			return
@@ -274,18 +274,17 @@ func deriveVpcCIDRs(node *ciliumv2.CiliumNode) (primaryCIDR *cidr.CIDR, secondar
 }
 
 func (n *nodeStore) autoDetectIPv4NativeRoutingCIDR(localNodeStore *node.LocalNodeStore) bool {
-	if primaryCIDR, secondaryCIDRs := deriveVpcCIDRs(n.ownNode); primaryCIDR != nil {
-		allCIDRs := append([]*cidr.CIDR{primaryCIDR}, secondaryCIDRs...)
+	if primaryCIDR, secondaryCIDRs := deriveVpcCIDRs(n.ownNode); primaryCIDR.IsValid() {
+		allCIDRs := append([]netip.Prefix{primaryCIDR}, secondaryCIDRs...)
 		if nativeCIDR := n.conf.IPv4NativeRoutingCIDR; nativeCIDR != nil {
 			native, ok := netipx.FromStdIPNet(nativeCIDR.IPNet)
 			found := false
 			for _, vpcCIDR := range allCIDRs {
-				vpc, vpcOK := netipx.FromStdIPNet(vpcCIDR.IPNet)
 				// Accept the configured native routing CIDR as long as it
 				// overlaps one of the VPC CIDRs, i.e. it is a VPC CIDR, a
 				// subnet of one (e.g. a single availability-zone subnet, used
 				// to masquerade cross-subnet traffic), or a supernet of one.
-				if !ok || !vpcOK || !ip.LaminarCIDRsOverlap(native, vpc) {
+				if !ok || !ip.LaminarCIDRsOverlap(native, vpcCIDR) {
 					n.logger.Info(
 						"Native routing CIDR does not overlap VPC CIDR, trying next",
 						logfields.VPCCIDR, vpcCIDR,
@@ -310,7 +309,7 @@ func (n *nodeStore) autoDetectIPv4NativeRoutingCIDR(localNodeStore *node.LocalNo
 				logfields.VPCCIDR, primaryCIDR,
 			)
 			localNodeStore.Update(func(n *node.LocalNode) {
-				n.Local.IPv4NativeRoutingCIDR = primaryCIDR
+				n.Local.IPv4NativeRoutingCIDR = cidr.NewCIDR(netipx.PrefixIPNet(primaryCIDR))
 			})
 		}
 		return true

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -277,19 +277,24 @@ func (n *nodeStore) autoDetectIPv4NativeRoutingCIDR(localNodeStore *node.LocalNo
 	if primaryCIDR, secondaryCIDRs := deriveVpcCIDRs(n.ownNode); primaryCIDR != nil {
 		allCIDRs := append([]*cidr.CIDR{primaryCIDR}, secondaryCIDRs...)
 		if nativeCIDR := n.conf.IPv4NativeRoutingCIDR; nativeCIDR != nil {
+			native, ok := netipx.FromStdIPNet(nativeCIDR.IPNet)
 			found := false
 			for _, vpcCIDR := range allCIDRs {
-				ranges4, _ := ip.CoalesceCIDRs([]*net.IPNet{nativeCIDR.IPNet, vpcCIDR.IPNet})
-				if len(ranges4) != 1 {
+				vpc, vpcOK := netipx.FromStdIPNet(vpcCIDR.IPNet)
+				// Accept the configured native routing CIDR as long as it
+				// overlaps one of the VPC CIDRs, i.e. it is a VPC CIDR, a
+				// subnet of one (e.g. a single availability-zone subnet, used
+				// to masquerade cross-subnet traffic), or a supernet of one.
+				if !ok || !vpcOK || !ip.LaminarCIDRsOverlap(native, vpc) {
 					n.logger.Info(
-						"Native routing CIDR does not contain VPC CIDR, trying next",
+						"Native routing CIDR does not overlap VPC CIDR, trying next",
 						logfields.VPCCIDR, vpcCIDR,
 						option.IPv4NativeRoutingCIDR, nativeCIDR,
 					)
 				} else {
 					found = true
 					n.logger.Info(
-						"Native routing CIDR contains VPC CIDR, ignoring autodetected VPC CIDRs.",
+						"Native routing CIDR overlaps VPC CIDR, ignoring autodetected VPC CIDRs.",
 						logfields.VPCCIDR, vpcCIDR,
 						option.IPv4NativeRoutingCIDR, nativeCIDR,
 					)
@@ -297,7 +302,7 @@ func (n *nodeStore) autoDetectIPv4NativeRoutingCIDR(localNodeStore *node.LocalNo
 				}
 			}
 			if !found {
-				logging.Fatal(n.logger, "None of the VPC CIDRs contains the specified native routing CIDR")
+				logging.Fatal(n.logger, "None of the VPC CIDRs overlaps the specified native routing CIDR")
 			}
 		} else {
 			n.logger.Info(

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	azureTypes "github.com/cilium/cilium/pkg/azure/types"
+	"github.com/cilium/cilium/pkg/cidr"
 	iputil "github.com/cilium/cilium/pkg/ip"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
@@ -273,4 +274,61 @@ func TestAzureIPMasq(t *testing.T) {
 	)
 
 	ipMasqAgent.Stop()
+}
+
+func TestAutoDetectIPv4NativeRoutingCIDR(t *testing.T) {
+	newStore := func(t *testing.T, nativeCIDR string) *nodeStore {
+		return &nodeStore{
+			logger: hivetest.Logger(t),
+			conf: &option.DaemonConfig{
+				IPv4NativeRoutingCIDR: cidr.MustParseCIDR(nativeCIDR),
+			},
+			ownNode: &ciliumv2.CiliumNode{
+				Status: ciliumv2.NodeStatus{
+					Azure: azureTypes.AzureStatus{
+						Interfaces: []azureTypes.AzureInterface{
+							{
+								ID:   "azure-interface-1",
+								Name: "eth0",
+								Subnet: azureTypes.AzureSubnet{
+									ID:   "subnet-1",
+									CIDR: iputil.PrefixFrom(netip.MustParsePrefix("10.10.0.0/16")),
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("accepts a native routing CIDR that is a subnet of the VNet CIDR", func(t *testing.T) {
+		localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
+		require.True(t, newStore(t, "10.10.64.0/19").autoDetectIPv4NativeRoutingCIDR(localNodeStore))
+
+		localNode, err := localNodeStore.Get(t.Context())
+		require.NoError(t, err)
+		// Should NOT have been written since the config already has a value.
+		require.Nil(t, localNode.Local.IPv4NativeRoutingCIDR)
+	})
+
+	t.Run("accepts a native routing CIDR that is a supernet of the VNet CIDR", func(t *testing.T) {
+		localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
+		require.True(t, newStore(t, "10.0.0.0/8").autoDetectIPv4NativeRoutingCIDR(localNodeStore))
+
+		localNode, err := localNodeStore.Get(t.Context())
+		require.NoError(t, err)
+		require.Nil(t, localNode.Local.IPv4NativeRoutingCIDR)
+	})
+
+	t.Run("uses the autodetected primary CIDR when unset", func(t *testing.T) {
+		localNodeStore := node.NewTestLocalNodeStore(node.LocalNode{})
+		n := newStore(t, "10.10.0.0/16")
+		n.conf.IPv4NativeRoutingCIDR = nil
+		require.True(t, n.autoDetectIPv4NativeRoutingCIDR(localNodeStore))
+
+		localNode, err := localNodeStore.Get(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, "10.10.0.0/16", localNode.Local.IPv4NativeRoutingCIDR.String())
+	})
 }


### PR DESCRIPTION
Commit https://github.com/cilium/cilium/commit/1c44d9de95b908e1edf47bfb67655151d11f0e76 ("ipam: accept native routing CIDR that is a subnet of the VPC CIDR") fixed `autoDetectENINativeRoutingCIDR` used by multi-pool backed ENI IPAM mode. But other cloud provider IPAM modes (Azure and Alibabacloud) that still use the CRD allocator did not benefit from that fix.

This commit updates the `autoDetectIPv4NativeRoutingCIDR` CRD allocator function in a similar way to unify the underlying behavior for all cloud provider, regardless of their IPAM backend (multipool/CRD).

Related: https://github.com/cilium/cilium/pull/46649

While at it, I also updated the signature of the `deriveVpcCIDRs` helper to remove unneeded round-trip conversions between `netip.Prefix` and `cidr.CIDR`.