### PR TITLE
docs: Improve build process

### DIFF
--- a/Documentation/check-build.sh
+++ b/Documentation/check-build.sh
@@ -170,7 +170,7 @@ run_linter() {
         --ignore-roles "${CONF_PY_ROLES},spelling:ignore,spelling:word" \
         --ignore-substitutions "${CONF_PY_SUBSTITUTIONS}" \
        -r . ../README.rst 2>&1 | \
-       grep -v 'WARNING:rstcheck_core.checker:An `AttributeError` error occurred. This is most probably due to a code block directive (code/code-block/sourcecode) without a specified language.'
+       grep -v 'WARNING:rstcheck_core.checker:An `AttributeError` error .* This is most probably due to a code block directive (code/code-block/sourcecode) without a specified language.'
 }
 
 read_all_opt=""

--- a/Documentation/check-build.sh
+++ b/Documentation/check-build.sh
@@ -221,7 +221,7 @@ fi
 
 echo "Building documentation (${target})..."
 sphinx-build -M "${target}" "${script_dir}" "${build_dir}" $@ \
-    ${read_all_opt} -n --color -w "${warnings}" 2>/dev/null
+    ${read_all_opt} -n --color -w "${warnings}"
 
 # We can have warnings but no errors here, or sphinx-build would return non-0
 # and we would have exited because of "set -o errexit".

--- a/Documentation/check-build.sh
+++ b/Documentation/check-build.sh
@@ -219,7 +219,7 @@ fi
 
 echo "Building documentation (${target})..."
 sphinx-build -M "${target}" "${script_dir}" "${build_dir}" $@ \
-    ${read_all_opt} -n --color -w "${warnings}" 2>/dev/null
+    ${read_all_opt} -n --color -w "${warnings}"
 
 # We can have warnings but no errors here, or sphinx-build would return non-0
 # and we would have exited because of "set -o errexit".

--- a/Documentation/check-build.sh
+++ b/Documentation/check-build.sh
@@ -172,7 +172,7 @@ run_linter() {
         --ignore-roles "${CONF_PY_ROLES},spelling:ignore,spelling:word" \
         --ignore-substitutions "${CONF_PY_SUBSTITUTIONS}" \
        -r . ../README.rst 2>&1 | \
-       grep -v 'WARNING:rstcheck_core.checker:An `AttributeError` error occurred. This is most probably due to a code block directive (code/code-block/sourcecode) without a specified language.'
+       grep -v 'WARNING:rstcheck_core.checker:An `AttributeError` error .* This is most probably due to a code block directive (code/code-block/sourcecode) without a specified language.'
 }
 
 read_all_opt=""


### PR DESCRIPTION
While developing other fixes for the docs area, I noticed two small issues with
the build system for docs:

1. The build failed locally for me because I hadn't done a 'make clean' in my
   Documentation/ directory for a while. However, when the failure occurred,
   I had no idea why, because all stderr output was being sent to `/dev/null`.
2. There were many spurious `AttributeError` messages which _should_ have been
   filtered out, but a recent submission "fixed" a typo in the message filter
   which broke the filter.

This PR fixes these two issues.

Fixes: https://github.com/cilium/cilium/pull/42053