### PR TITLE
api: Migrate the IPAM address response IP/gateway/CIDRs to netip

### DIFF
--- a/api/v1/models/ip_a_m_address_response.go
+++ b/api/v1/models/ip_a_m_address_response.go
@@ -8,8 +8,12 @@ package models
 import (
 	"context"
 
+	iputil "github.com/cilium/cilium/pkg/ip"
+
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag/jsonutils"
+	"github.com/go-openapi/swag/typeutils"
 )
 
 // IPAMAddressResponse IPAM configuration of an individual address family
@@ -18,7 +22,7 @@ import (
 type IPAMAddressResponse struct {
 
 	// List of CIDRs out of which IPs are allocated
-	Cidrs []string `json:"cidrs"`
+	Cidrs []iputil.Prefix `json:"cidrs"`
 
 	// The UUID for the expiration timer. Set when expiration has been
 	// enabled while allocating.
@@ -26,14 +30,14 @@ type IPAMAddressResponse struct {
 	ExpirationUUID string `json:"expiration-uuid,omitempty"`
 
 	// IP of gateway
-	Gateway string `json:"gateway,omitempty"`
+	Gateway iputil.Addr `json:"gateway,omitzero"`
 
 	// InterfaceNumber is a field for generically identifying an interface. This is only useful in ENI mode.
 	//
 	InterfaceNumber string `json:"interface-number,omitempty"`
 
 	// Allocated IP for endpoint
-	IP string `json:"ip,omitempty"`
+	IP iputil.Addr `json:"ip,omitzero"`
 
 	// MAC of master interface if address is a slave/secondary of a master interface
 	MasterMac string `json:"master-mac,omitempty"`
@@ -45,6 +49,23 @@ type IPAMAddressResponse struct {
 
 // Validate validates this IP a m address response
 func (m *IPAMAddressResponse) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.validateCidrs(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *IPAMAddressResponse) validateCidrs(formats strfmt.Registry) error {
+	if typeutils.IsZero(m.Cidrs) { // not required
+		return nil
+	}
+
 	return nil
 }
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1656,15 +1656,15 @@ definitions:
     properties:
       ip:
         description: Allocated IP for endpoint
-        type: string
+        "$ref": "#/definitions/Address"
       gateway:
         description: IP of gateway
-        type: string
+        "$ref": "#/definitions/Address"
       cidrs:
         description: List of CIDRs out of which IPs are allocated
         type: array
         items:
-          type: string
+          "$ref": "#/definitions/CIDR"
       master-mac:
         type: string
         description: MAC of master interface if address is a slave/secondary of a master interface

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -3243,7 +3243,7 @@ func init() {
           "description": "List of CIDRs out of which IPs are allocated",
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/CIDR"
           }
         },
         "expiration-uuid": {
@@ -3252,7 +3252,7 @@ func init() {
         },
         "gateway": {
           "description": "IP of gateway",
-          "type": "string"
+          "$ref": "#/definitions/Address"
         },
         "interface-number": {
           "description": "InterfaceNumber is a field for generically identifying an interface. This is only useful in ENI mode.\n",
@@ -3260,7 +3260,7 @@ func init() {
         },
         "ip": {
           "description": "Allocated IP for endpoint",
-          "type": "string"
+          "$ref": "#/definitions/Address"
         },
         "master-mac": {
           "description": "MAC of master interface if address is a slave/secondary of a master interface",
@@ -8712,7 +8712,7 @@ func init() {
           "description": "List of CIDRs out of which IPs are allocated",
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/CIDR"
           }
         },
         "expiration-uuid": {
@@ -8721,7 +8721,7 @@ func init() {
         },
         "gateway": {
           "description": "IP of gateway",
-          "type": "string"
+          "$ref": "#/definitions/Address"
         },
         "interface-number": {
           "description": "InterfaceNumber is a field for generically identifying an interface. This is only useful in ENI mode.\n",
@@ -8729,7 +8729,7 @@ func init() {
         },
         "ip": {
           "description": "Allocated IP for endpoint",
-          "type": "string"
+          "$ref": "#/definitions/Address"
         },
         "master-mac": {
           "description": "MAC of master interface if address is a slave/secondary of a master interface",

--- a/pkg/ipam/api/ipam_api_handler.go
+++ b/pkg/ipam/api/ipam_api_handler.go
@@ -19,23 +19,13 @@ import (
 	"github.com/cilium/cilium/pkg/api"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpointmanager"
+	iputil "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	cslices "github.com/cilium/cilium/pkg/slices"
 	"github.com/cilium/cilium/pkg/time"
 )
-
-func prefixesToStrings(prefixes []netip.Prefix) []string {
-	return cslices.Map(prefixes, func(p netip.Prefix) string { return p.String() })
-}
-
-func gatewayString(addr netip.Addr) string {
-	if !addr.IsValid() {
-		return ""
-	}
-	return addr.String()
-}
 
 type IpamDeleteIpamIPHandler struct {
 	IPAM            *ipam.IPAM
@@ -80,10 +70,10 @@ func (r *IpamPostIpamHandler) Handle(params ipamapi.PostIpamParams) middleware.R
 		resp.Address.IPv4 = ipv4Result.IP.String()
 		resp.Address.IPv4PoolName = ipv4Result.IPPoolName.String()
 		resp.IPv4 = &models.IPAMAddressResponse{
-			Cidrs:           prefixesToStrings(ipv4Result.CIDRs),
-			IP:              ipv4Result.IP.String(),
+			Cidrs:           cslices.Map(ipv4Result.CIDRs, iputil.PrefixFrom),
+			IP:              iputil.AddrFrom(ipv4Result.IP),
 			MasterMac:       ipv4Result.PrimaryMAC,
-			Gateway:         gatewayString(ipv4Result.GatewayIP),
+			Gateway:         iputil.AddrFrom(ipv4Result.GatewayIP),
 			ExpirationUUID:  ipv4Result.ExpirationUUID,
 			InterfaceNumber: ipv4Result.InterfaceNumber,
 			SkipMasquerade:  ipv4Result.SkipMasquerade,
@@ -94,10 +84,10 @@ func (r *IpamPostIpamHandler) Handle(params ipamapi.PostIpamParams) middleware.R
 		resp.Address.IPv6 = ipv6Result.IP.String()
 		resp.Address.IPv6PoolName = ipv6Result.IPPoolName.String()
 		resp.IPv6 = &models.IPAMAddressResponse{
-			Cidrs:           prefixesToStrings(ipv6Result.CIDRs),
-			IP:              ipv6Result.IP.String(),
+			Cidrs:           cslices.Map(ipv6Result.CIDRs, iputil.PrefixFrom),
+			IP:              iputil.AddrFrom(ipv6Result.IP),
 			MasterMac:       ipv6Result.PrimaryMAC,
-			Gateway:         gatewayString(ipv6Result.GatewayIP),
+			Gateway:         iputil.AddrFrom(ipv6Result.GatewayIP),
 			ExpirationUUID:  ipv6Result.ExpirationUUID,
 			InterfaceNumber: ipv6Result.InterfaceNumber,
 			SkipMasquerade:  ipv6Result.SkipMasquerade,

--- a/plugins/cilium-cni/cmd/cmd.go
+++ b/plugins/cilium-cni/cmd/cmd.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	endpointtypes "github.com/cilium/cilium/pkg/endpoint/types"
+	iputil "github.com/cilium/cilium/pkg/ip"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/hooks"
@@ -254,8 +255,8 @@ func allocateIPsWithDelegatedPlugin(
 			if conf.Addressing.IPv4 != nil {
 				ipam.Address.IPv4 = ipNet.String()
 				ipam.IPv4 = &models.IPAMAddressResponse{
-					IP:              ipNet.IP.String(),
-					Gateway:         ipConfig.Gateway.String(),
+					IP:              iputil.AddrFrom(iputil.AddrFromIP(ipNet.IP)),
+					Gateway:         iputil.AddrFrom(iputil.AddrFromIP(ipConfig.Gateway)),
 					MasterMac:       masterMac,
 					InterfaceNumber: "0",
 				}
@@ -264,8 +265,8 @@ func allocateIPsWithDelegatedPlugin(
 			if conf.Addressing.IPv6 != nil {
 				ipam.Address.IPv6 = ipNet.String()
 				ipam.IPv6 = &models.IPAMAddressResponse{
-					IP:              ipNet.IP.String(),
-					Gateway:         ipConfig.Gateway.String(),
+					IP:              iputil.AddrFrom(iputil.AddrFromIP(ipNet.IP)),
+					Gateway:         iputil.AddrFrom(iputil.AddrFromIP(ipConfig.Gateway)),
 					MasterMac:       masterMac,
 					InterfaceNumber: "0",
 				}

--- a/plugins/cilium-cni/cmd/interface.go
+++ b/plugins/cilium-cni/cmd/interface.go
@@ -9,6 +9,7 @@ import (
 	"net"
 
 	current "github.com/containernetworking/cni/pkg/types/100"
+	"go4.org/netipx"
 
 	"github.com/cilium/cilium/api/v1/models"
 	linuxrouting "github.com/cilium/cilium/pkg/datapath/linux/routing"
@@ -20,18 +21,19 @@ func interfaceAdd(logger *slog.Logger, ipConfig *current.IPConfig, ipam *models.
 		return fmt.Errorf("missing IPAM configuration")
 	}
 	// If the gateway IP is not available, it is already set up
-	if ipam.Gateway == "" {
+	if !ipam.Gateway.IsValid() {
 		return nil
 	}
 
 	var allCIDRs []*net.IPNet
 
-	for _, cidrString := range ipam.Cidrs {
-		_, cidr, err := net.ParseCIDR(cidrString)
-		if err != nil {
-			return fmt.Errorf("invalid CIDR '%s': %w", cidrString, err)
+	for _, cidr := range ipam.Cidrs {
+		if !cidr.IsValid() {
+			return fmt.Errorf("invalid CIDR '%s'", cidr)
 		}
-		allCIDRs = append(allCIDRs, cidr)
+		// Mask explicitly: net.ParseCIDR, which this loop replaces, returned
+		// the masked network, and ip.CoalesceCIDRs below expects that shape.
+		allCIDRs = append(allCIDRs, netipx.PrefixIPNet(cidr.Masked()))
 	}
 
 	// Coalesce CIDRs into minimum set needed for route rules
@@ -57,7 +59,7 @@ func interfaceAdd(logger *slog.Logger, ipConfig *current.IPConfig, ipam *models.
 
 	routingInfo, err := linuxrouting.NewRoutingInfo(
 		logger,
-		ipam.Gateway,
+		ipam.Gateway.String(),
 		coalescedCIDRs,
 		ipam.MasterMac,
 		ipam.InterfaceNumber,


### PR DESCRIPTION
Migrates the `ip`, `gateway` and `cidrs` fields of the `IPAMAddressResponse` openAPI model from `string` to `netip` types, via `pkg/ip.Addr` / `pkg/ip.Prefix` and the openAPI `Address` / `CIDR` definitions (see 99d9d398fc).

The producer side is a net deletion: `ipam.AllocationResult` already stores `netip.Addr` / `[]netip.Prefix`, so both conversion helpers in the handler go away. In particular `gatewayString`, which mapped an invalid address to "" so that go-swagger's `omitempty` would drop it, is now redundant: `omitzero` on `ip.Addr` does exactly that.

On the CNI plugin side the `net.ParseCIDR` loop in `interfaceAdd` is replaced by a direct conversion. `ip.CoalesceCIDRs` and `linuxrouting.NewRoutingInfo` still take `[]*net.IPNet` and strings respectively, so the conversion moves to those boundaries rather than disappearing. The conversion masks explicitly, since `net.ParseCIDR` returned the masked network but `netipx.PrefixIPNet` does not.

Relates to #24246