### PR TITLE
.github: Simplify permissions for image linter workflow

### DIFF
--- a/.github/workflows/lint-images-base.yaml
+++ b/.github/workflows/lint-images-base.yaml
@@ -29,20 +29,6 @@ on:
       - main
       - ft/main/**
 
-# By specifying the access of one of the scopes, all of those that are not
-# specified are set to 'none'.
-permissions:
-  # To read actions state with cilium/workflow-telemetry-action
-  actions: read
-  # To be able to access the repository with actions/checkout
-  contents: read
-  # To allow retrieving information from the PR API
-  pull-requests: read
-  # To be able to set commit status
-  statuses: write
-  # To be able to request the JWT from GitHub's OIDC provider
-  id-token: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.PR-number || github.event.after }}
   cancel-in-progress: true
@@ -51,6 +37,8 @@ jobs:
   commit-status-start:
     name: Commit Status Start
     runs-on: ubuntu-24.04
+    permissions:
+      statuses: write
     steps:
       - name: Set initial commit status
         uses: cilium/cilium/.github/actions/set-commit-status@main # main
@@ -60,6 +48,9 @@ jobs:
   lint:
     name: Lint image build logic
     runs-on: ubuntu-24.04
+    permissions:
+      # To be able to access the repository with actions/checkout
+      contents: read
     steps:
       - name: Checkout base or default branch (trusted)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -111,6 +102,10 @@ jobs:
     needs: lint
     uses: ./.github/workflows/common-post-jobs.yaml
     secrets: inherit
+    permissions:
+      actions: read
+      contents: read
+      statuses: write
     with:
       context-ref: ${{ inputs.context-ref || github.sha }}
       sha: ${{ inputs.SHA || github.sha }}


### PR DESCRIPTION
See commit messages for more details.
