### PR TITLE
fix: allow setting endpointPolicyUpdateTimeoutDuration in helm

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1515,7 +1515,7 @@
    * - :spelling:ignore:`endpointPolicyUpdateTimeoutDuration`
      - Max duration to wait for envoy to respond to configuration changes. Default "10s".
      - string
-     - ``nil``
+     - ``""``
    * - :spelling:ignore:`endpointRoutes.enabled`
      - Enable use of per endpoint routes instead of routing via the cilium_host interface.
      - bool

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -428,7 +428,7 @@ contributors across the globe, there is almost always someone available to help.
 | encryption.ztunnel.updateStrategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0},"type":"RollingUpdate"}` | ztunnel update strategy. |
 | endpointHealthChecking.enabled | bool | `true` | Enable connectivity health checking between virtual endpoints. |
 | endpointLockdownOnMapOverflow | bool | `false` | Enable endpoint lockdown on policy map overflow. |
-| endpointPolicyUpdateTimeoutDuration | string | `nil` | Max duration to wait for envoy to respond to configuration changes. Default "10s". |
+| endpointPolicyUpdateTimeoutDuration | string | `""` | Max duration to wait for envoy to respond to configuration changes. Default "10s". |
 | endpointRoutes.enabled | bool | `false` | Enable use of per endpoint routes instead of routing via the cilium_host interface. |
 | eni.awsEnablePrefixDelegation | bool | `false` | Enable ENI prefix delegation |
 | eni.awsReleaseExcessIPs | bool | `false` | Release IPs not used from the ENI |

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -2204,7 +2204,7 @@
       "type": "boolean"
     },
     "endpointPolicyUpdateTimeoutDuration": {
-      "type": "null"
+      "type": "string"
     },
     "endpointRoutes": {
       "properties": {

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1280,7 +1280,7 @@ endpointHealthChecking:
   # -- Enable connectivity health checking between virtual endpoints.
   enabled: true
 # -- Max duration to wait for envoy to respond to configuration changes. Default "10s".
-endpointPolicyUpdateTimeoutDuration: null
+endpointPolicyUpdateTimeoutDuration: ""
 endpointRoutes:
   # @schema
   # type: [boolean, string]

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1292,7 +1292,7 @@ endpointHealthChecking:
   # -- Enable connectivity health checking between virtual endpoints.
   enabled: true
 # -- Max duration to wait for envoy to respond to configuration changes. Default "10s".
-endpointPolicyUpdateTimeoutDuration: null
+endpointPolicyUpdateTimeoutDuration: ""
 endpointRoutes:
   # @schema
   # type: [boolean, string]


### PR DESCRIPTION
In helm, `endpointPolicyUpdateTimeoutDuration`  defaulted to  null , so the generated  values.schema.json  typed it as  "null"  only. 

Helm validates  --set /values input against this schema before rendering, so any real duration string (e.g.  "30s" ) was rejected on install/upgrade. 

so,  widen the schema to  string  so an explicit duration reaches the ConfigMap template.


<!-- Description of change -->


```release-note
fix: allow setting endpointPolicyUpdateTimeoutDuration in helm
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
