### PR TITLE
[v1.19] bpf: egressgw: don't use bpf_redirect_neigh() for L3 packets

### DIFF
--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -87,8 +87,13 @@ int egress_gw_fib_lookup_and_redirect(struct __ctx_buff *ctx, __be32 egress_ip, 
 	/* Immediate redirect to egress_ifindex requires L2 resolution.
 	 * Fall back to FIB lookup on older kernels.
 	 */
-	if (egress_ifindex && neigh_resolver_without_nh_available())
-		return redirect_neigh(egress_ifindex, NULL, 0, 0);
+	if (egress_ifindex && neigh_resolver_without_nh_available()) {
+		/* Can't use redirect_neigh() when
+		 * - packet has no L2 header
+		 */
+		if (!THIS_IS_L3_DEV)
+			return redirect_neigh(egress_ifindex, NULL, 0, 0);
+	}
 
 	ret = (__s8)fib_lookup_v4(ctx, &fib_params, egress_ip, daddr, 0);
 
@@ -401,8 +406,13 @@ int egress_gw_fib_lookup_and_redirect_v6(struct __ctx_buff *ctx,
 	struct bpf_fib_lookup_padded *fib_params;
 	int ret, zero = 0;
 
-	if (egress_ifindex && neigh_resolver_without_nh_available())
-		return redirect_neigh(egress_ifindex, NULL, 0, 0);
+	if (egress_ifindex && neigh_resolver_without_nh_available()) {
+		/* Can't use redirect_neigh() when
+		 * - packet has no L2 header
+		 */
+		if (!THIS_IS_L3_DEV)
+			return redirect_neigh(egress_ifindex, NULL, 0, 0);
+	}
 
 	fib_params = map_lookup_elem(&fib_params_storage, &zero);
 	if (!fib_params)


### PR DESCRIPTION
Backport
* [ ] #45703

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 45703
```