### PR TITLE
egressgateway: react to local device/address changes

### DIFF
--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
 	"log/slog"
 	"net/netip"
 	"slices"
@@ -68,6 +69,7 @@ const (
 	eventDeleteEndpoint
 	eventUpdateNode
 	eventDeleteNode
+	eventUpdateDevices
 )
 
 type Config struct {
@@ -265,6 +267,9 @@ func newEgressGatewayManager(p Params) (*Manager, error) {
 			wg.Go(func() {
 				manager.processEvents(ctx)
 			})
+			wg.Go(func() {
+				manager.processDeviceEvents(ctx)
+			})
 
 			return nil
 		},
@@ -398,6 +403,61 @@ func (manager *Manager) handlePolicyEvent(event resource.Event[*Policy]) {
 	case resource.Delete:
 		manager.onDeleteEgressPolicy(event.Object)
 		event.Done(nil)
+	}
+}
+
+// processDeviceEvents watches the device statedb table and triggers a
+// reconciliation whenever a local interface or one of its addresses is
+// added, modified or removed. This is what allows a CEGP to heal
+// automatically when its egress IP appears, disappears, or moves between
+// interfaces without requiring any CEGP / CiliumNode update to occur.
+//
+// The reconciliationTrigger already coalesces bursts via
+// reconciliationTriggerInterval, so a flurry of address add/del events will
+// not cause reconcile storms.
+func (manager *Manager) processDeviceEvents(ctx context.Context) {
+	if manager.db == nil || manager.deviceTable == nil {
+		return
+	}
+
+	wtxn := manager.db.WriteTxn(manager.deviceTable)
+	changeIter, err := manager.deviceTable.Changes(wtxn)
+	wtxn.Commit()
+	if err != nil {
+		manager.logger.Error(
+			"Failed to subscribe to device table changes; egress gateway will not react to local interface or address changes",
+			logfields.Error, err,
+		)
+		return
+	}
+
+	// Drain the initial snapshot without triggering reconciles: the initial
+	// reconciliation is already driven by k8s sync. After this loop, the
+	// watch channel will only fire on subsequent changes.
+	_, watch := changeIter.Next(manager.db.ReadTxn())
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-watch:
+		}
+
+		var changed bool
+		var changes iter.Seq2[statedb.Change[*tables.Device], statedb.Revision]
+		changes, watch = changeIter.Next(manager.db.ReadTxn())
+		for range changes {
+			changed = true
+		}
+
+		if !changed {
+			continue
+		}
+
+		manager.Lock()
+		manager.setEventBitmap(eventUpdateDevices)
+		manager.Unlock()
+		manager.reconciliationTrigger.TriggerWithReason("devices updated")
 	}
 }
 
@@ -810,7 +870,7 @@ func (manager *Manager) reconcileLocked() {
 		manager.updatePoliciesMatchedEndpointIDs()
 	}
 
-	if manager.eventBitmapIsSet(eventK8sSyncDone, eventAddPolicy, eventDeletePolicy, eventUpdateNode, eventDeleteNode) {
+	if manager.eventBitmapIsSet(eventK8sSyncDone, eventAddPolicy, eventDeletePolicy, eventUpdateNode, eventDeleteNode, eventUpdateDevices) {
 		manager.regenerateGatewayConfigs()
 
 		// Sysctl updates are handled by a reconciler, with the initial update attempting to wait some time

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -16,6 +16,7 @@ import (
 	"sync/atomic"
 
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -173,6 +174,7 @@ type Params struct {
 	DeviceTable   statedb.Table[*tables.Device]
 	NodeAddrTable statedb.Table[tables.NodeAddress]
 
+	JobGroup  job.Group
 	Lifecycle cell.Lifecycle
 }
 
@@ -259,6 +261,17 @@ func newEgressGatewayManager(p Params) (*Manager, error) {
 
 	manager.reconciliationTrigger = t
 
+	// The device-table watcher runs as a job so that a failure to subscribe
+	// (or an unexpected exit) surfaces as module health via `cilium status`
+	// / `cilium-dbg status --all-health`, rather than only a log line. Retry
+	// forever with backoff: losing device reactivity degrades egress gateway
+	// but must not take down the agent, so we do not use job.WithShutdown.
+	p.JobGroup.Add(job.OneShot(
+		"egress-gateway-device-watcher",
+		manager.processDeviceEvents,
+		job.WithRetry(-1, &job.ExponentialBackoff{Min: time.Second, Max: time.Minute}),
+	))
+
 	var wg sync.WaitGroup
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -266,9 +279,6 @@ func newEgressGatewayManager(p Params) (*Manager, error) {
 		OnStart: func(hc cell.HookContext) error {
 			wg.Go(func() {
 				manager.processEvents(ctx)
-			})
-			wg.Go(func() {
-				manager.processDeviceEvents(ctx)
 			})
 
 			return nil
@@ -415,34 +425,41 @@ func (manager *Manager) handlePolicyEvent(event resource.Event[*Policy]) {
 // The reconciliationTrigger already coalesces bursts via
 // reconciliationTriggerInterval, so a flurry of address add/del events will
 // not cause reconcile storms.
-func (manager *Manager) processDeviceEvents(ctx context.Context) {
-	if manager.db == nil || manager.deviceTable == nil {
-		return
-	}
-
+//
+// Runs as a job.OneShot: a subscription failure is reported through the health
+// reporter (visible via `cilium status`) and retried, instead of silently
+// leaving egress gateway unable to react to device changes.
+func (manager *Manager) processDeviceEvents(ctx context.Context, health cell.Health) error {
 	wtxn := manager.db.WriteTxn(manager.deviceTable)
 	changeIter, err := manager.deviceTable.Changes(wtxn)
 	wtxn.Commit()
 	if err != nil {
-		manager.logger.Error(
-			"Failed to subscribe to device table changes; egress gateway will not react to local interface or address changes",
-			logfields.Error, err,
-		)
-		return
+		return fmt.Errorf("subscribe to device table changes: %w", err)
 	}
 
+	health.OK("Watching device table")
+
 	// Drain the initial snapshot without triggering reconciles: the initial
-	// reconciliation is already driven by k8s sync. After this loop, the
-	// watch channel will only fire on subsequent changes.
-	_, watch := changeIter.Next(manager.db.ReadTxn())
+	// reconciliation is already driven by k8s sync. The change sequence must
+	// be consumed in full (see the comment in the loop below); discarding it
+	// here would leave the initial devices to be replayed on the first
+	// iteration and fire a spurious "devices updated" trigger at startup.
+	initial, watch := changeIter.Next(manager.db.ReadTxn())
+	for range initial {
+	}
 
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 		case <-watch:
 		}
 
+		// The change sequence must be consumed in full: statedb only hands
+		// back a blocking watch channel once the iterator is fully drained
+		// (a partial read keeps returning a closed channel, which would busy
+		// -spin this loop), and draining is what advances the revision
+		// watermark. So we range the whole batch rather than breaking early.
 		var changed bool
 		var changes iter.Seq2[statedb.Change[*tables.Device], statedb.Revision]
 		changes, watch = changeIter.Next(manager.db.ReadTxn())

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -141,6 +141,8 @@ type EgressGatewayTestSuite struct {
 	nodes     fakeResource[*cilium_api_v2.CiliumNode]
 	endpoints fakeResource[*k8sTypes.CiliumEndpoint]
 	sysctl    sysctl.Sysctl
+	db        *statedb.DB
+	devicesRW statedb.RWTable[*tables.Device]
 }
 
 func setupEgressGatewayTestSuite(t *testing.T) *EgressGatewayTestSuite {
@@ -166,7 +168,7 @@ func setupEgressGatewayTestSuite(t *testing.T) *EgressGatewayTestSuite {
 
 	var (
 		db          *statedb.DB
-		deviceTable statedb.Table[*tables.Device]
+		deviceTable statedb.RWTable[*tables.Device]
 	)
 
 	// create a hive to provide statedb
@@ -187,6 +189,9 @@ func setupEgressGatewayTestSuite(t *testing.T) *EgressGatewayTestSuite {
 	t.Cleanup(func() {
 		require.NoError(t, h.Stop(logger, context.TODO()))
 	})
+
+	k.db = db
+	k.devicesRW = deviceTable
 
 	k.manager, err = newEgressGatewayManager(Params{
 		Logger:            logger,
@@ -1088,6 +1093,60 @@ func TestPrivilegedMultigatewayPolicy(t *testing.T) {
 	}
 	assertEgressRules4(t, policyMap4, assignEndpoints(eps, nodes[:1], ifIndex1, true))
 	assertEgressRules6(t, policyMap6, assignEndpoints(eps, nodes[:1], ifIndex1, false))
+}
+
+// TestPrivilegedDeviceTableTriggersReconcile verifies that mutations to the
+// statedb device table fire an egress gateway reconciliation. This is the
+// mechanism that allows a CEGP to heal when its egress IP appears,
+// disappears, or moves between interfaces, without requiring any CEGP or
+// CiliumNode update to occur.
+func TestPrivilegedDeviceTableTriggersReconcile(t *testing.T) {
+	k := setupEgressGatewayTestSuite(t)
+	egressGatewayManager := k.manager
+
+	// Drive the initial reconciliation so we have a stable baseline.
+	k.policies.sync(t)
+	k.nodes.sync(t)
+	k.endpoints.sync(t)
+	_ = waitForReconciliationRun(t, egressGatewayManager, egressGatewayManager.reconciliationEventsCount.Load())
+
+	// Insert a device into the table and assert the watcher fires a reconcile.
+	insertRun := egressGatewayManager.reconciliationEventsCount.Load()
+	wtxn := k.db.WriteTxn(k.devicesRW)
+	_, _, err := k.devicesRW.Insert(wtxn, &tables.Device{
+		Index: 4242,
+		Name:  "egw-test-dev0",
+		Addrs: []tables.DeviceAddress{
+			{Addr: netip.MustParseAddr(egressIP1)},
+		},
+	})
+	require.NoError(t, err)
+	wtxn.Commit()
+	_ = waitForReconciliationRun(t, egressGatewayManager, insertRun)
+
+	// Mutate the device's addresses (simulating the egress IP being moved
+	// off this interface) and assert the watcher fires another reconcile.
+	updateRun := egressGatewayManager.reconciliationEventsCount.Load()
+	wtxn = k.db.WriteTxn(k.devicesRW)
+	_, _, err = k.devicesRW.Insert(wtxn, &tables.Device{
+		Index: 4242,
+		Name:  "egw-test-dev0",
+		Addrs: nil,
+	})
+	require.NoError(t, err)
+	wtxn.Commit()
+	_ = waitForReconciliationRun(t, egressGatewayManager, updateRun)
+
+	// Delete the device entirely and assert the watcher fires a reconcile.
+	deleteRun := egressGatewayManager.reconciliationEventsCount.Load()
+	wtxn = k.db.WriteTxn(k.devicesRW)
+	_, _, err = k.devicesRW.Delete(wtxn, &tables.Device{
+		Index: 4242,
+		Name:  "egw-test-dev0",
+	})
+	require.NoError(t, err)
+	wtxn.Commit()
+	_ = waitForReconciliationRun(t, egressGatewayManager, deleteRun)
 }
 
 func TestCell(t *testing.T) {

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/hivetest"
+	"github.com/cilium/hive/job"
 	"github.com/cilium/statedb"
 	"github.com/google/uuid"
 	"github.com/spf13/afero"
@@ -169,19 +170,24 @@ func setupEgressGatewayTestSuite(t *testing.T) *EgressGatewayTestSuite {
 	var (
 		db          *statedb.DB
 		deviceTable statedb.RWTable[*tables.Device]
+		jobGroup    job.Group
 	)
 
 	// create a hive to provide statedb
 	h := hive.New(
-		cell.Provide(
-			tables.NewDeviceTable,
-		),
+		cell.Module("egressgateway-test-fixtures", "egress gateway test fixtures",
+			cell.Provide(
+				tables.NewDeviceTable,
+			),
 
-		cell.Invoke(func(db_ *statedb.DB,
-			dT statedb.RWTable[*tables.Device]) {
-			db = db_
-			deviceTable = dT
-		}),
+			cell.Invoke(func(db_ *statedb.DB,
+				dT statedb.RWTable[*tables.Device],
+				jg job.Group) {
+				db = db_
+				deviceTable = dT
+				jobGroup = jg
+			}),
+		),
 	)
 
 	require.NoError(t, h.Start(logger, context.TODO()))
@@ -207,6 +213,7 @@ func setupEgressGatewayTestSuite(t *testing.T) *EgressGatewayTestSuite {
 		Sysctl:            k.sysctl,
 		DB:                db,
 		DeviceTable:       deviceTable,
+		JobGroup:          jobGroup,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, k.manager)


### PR DESCRIPTION

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue. <!-- N/A: fixes a GitHub issue, not a commit -->
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
- [x] Thanks for contributing!

## Description of change

As per the [docs](https://docs.cilium.io/en/latest/network/egress-gateway/egress-gateway/):

> After Cilium has selected the network interface and Egress IP for an Egress Gateway policy (or failed to do so), it 
> does not automatically respond to a change in the gateway node’s network configuration (for example if an IP 
> address is added or deleted). You can force a fresh selection by re-applying the Egress Gateway policy.

Cilium does not react to changes of Node interfaces/IPs, the code for this reconciliation is already present but only triggers on updates to `CiliumEgressGatewayPolicy`, `CiliumNode` and `CiliumEndpoint` changes, plus the
initial k8s sync.

This PR simply adds another trigger to this already existing reconciliation logic, by subscribing the egress manager to changes in the statedb `Device` table. With this in place, my testing shows that IPs added/removed from nodes are near instantly picked up and acted upon. 


### Testing

AI generated and verified tests:

- `go build` / `go vet` on `pkg/egressgateway/` — clean.
- New privileged test `TestPrivilegedDeviceTableTriggersReconcile`.

AI generated but extensively human verified tests: 

- Validated on a live Talos cluster via A/B:  A CEGP is created, a corresponding IP is added to the matching node but the `bpf egress list` continues to show `Egress IP 0.0.0.0`. Once I switch to an image built based on this PR, the IP change is detected by Cilium and the `bpf egress list` is updated accordingly. This testing has mainly been done with: [This script](https://github.com/cilium/cilium/issues/47761#issuecomment-5189815765)


@joestringer says to `highlight any specific areas that you would like feedback from reviewers about`, this is a fairly small PR and I don't really have any such areas. Most important to me is that I want to deliver a PR that is as actionable and helpful to the dev team as possible. 


Fixes: #47761

```release-note
egressgateway: reconcile when a CiliumEgressGatewayPolicy's egress IP is added, removed, or moved between node interfaces,, so a CiliumEgressGatewayPolicy no longer stays black-holed until an unrelated event triggers a reconcile.
```

<!-- AI disclosure — EDIT to match your own attestation before submitting.
     AIL scale: https://danielmiessler.com/blog/ai-influence-level-ail -->
This PR was prepared with AIL:3. AI assistance was used to draft the
implementation and the privileged test; I personally reviewed
the code, confirmed it builds and vets, and validated the fix and its
reproduction on a live Talos cluster via A/B testing against stock vs patched
images and wrote this PR description. 

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
