### PR TITLE
gateway-api: fix gateway address status listener and NodePort handling

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -1176,7 +1176,7 @@ func (r *gatewayReconciler) setAddressStatus(ctx context.Context, gw *gatewayv1.
 			accepted := false
 
 			for _, cond := range l.Conditions {
-				if cond.Type == string(gatewayv1.GatewayConditionAccepted) &&
+				if cond.Type == string(gatewayv1.ListenerConditionAccepted) &&
 					cond.Status == metav1.ConditionTrue {
 					accepted = true
 					break

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -1170,7 +1170,8 @@ func (r *gatewayReconciler) setAddressStatus(ctx context.Context, gw *gatewayv1.
 	if len(addresses) > 0 {
 		r.logger.InfoContext(ctx, "At least one valid address, marking gateway programmed", logfields.Resource, client.ObjectKeyFromObject(gw).String())
 		setGatewayProgrammed(gw, metav1.ConditionTrue, "Gateway Programmed", gatewayv1.GatewayReasonProgrammed)
-		for _, l := range gw.Status.Listeners {
+		for i := range gw.Status.Listeners {
+			l := &gw.Status.Listeners[i]
 			// Is Listener Accepted?
 			accepted := false
 

--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -1120,14 +1120,14 @@ func (r *gatewayReconciler) setAddressStatus(ctx context.Context, gw *gatewayv1.
 			if len(node.Status.Addresses) == 0 {
 				continue
 			}
-			nodeAddress := node.Status.Addresses[0]
-			ip, err := netip.ParseAddr(nodeAddress.Address)
-			if err != nil {
-				// the first address is not an IP address (e.g. a hostname),
-				// skip the node instead of reporting an invalid address.
-				continue
+			for _, nodeAddress := range node.Status.Addresses {
+				ip, err := netip.ParseAddr(nodeAddress.Address)
+				if err != nil {
+					continue
+				}
+				ips = append(ips, ip.Unmap())
+				break
 			}
-			ips = append(ips, ip.Unmap())
 		}
 
 		// sort the addresses for consistent ip addresses assigned

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -1080,6 +1080,77 @@ func Test_gatewayReconciler_setListenerStatus(t *testing.T) {
 	}
 }
 
+func Test_gatewayReconciler_setAddressStatus_updatesAcceptedListenerProgrammedCondition(t *testing.T) {
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "gateway",
+			Namespace:  "gateway-conformance-infra",
+			Generation: 7,
+		},
+		Status: gatewayv1.GatewayStatus{
+			Listeners: []gatewayv1.ListenerStatus{
+				{
+					Name: "http",
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(gatewayv1.ListenerConditionAccepted),
+							Status:             metav1.ConditionTrue,
+							Reason:             string(gatewayv1.ListenerReasonAccepted),
+							ObservedGeneration: 7,
+						},
+						{
+							Type:               string(gatewayv1.ListenerConditionProgrammed),
+							Status:             metav1.ConditionFalse,
+							Reason:             string(gatewayv1.ListenerReasonPending),
+							ObservedGeneration: 7,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gateway-service",
+			Namespace: gw.Namespace,
+			Labels: map[string]string{
+				owningGatewayLabel: shortener.ShortenK8sResourceName(gw.Name),
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeLoadBalancer,
+		},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{
+					{IP: "192.0.2.10"},
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+		WithObjects(svc).
+		Build()
+
+	r := &gatewayReconciler{
+		Client: c,
+		logger: hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug)),
+	}
+
+	require.NoError(t, r.setAddressStatus(t.Context(), gw))
+
+	require.Len(t, gw.Status.Addresses, 1)
+	require.Equal(t, "192.0.2.10", gw.Status.Addresses[0].Value)
+
+	programmed := listenerStatusCondition(t, gw.Status.Listeners, "http", string(gatewayv1.ListenerConditionProgrammed))
+	require.Equal(t, metav1.ConditionTrue, programmed.Status)
+	require.Equal(t, string(gatewayv1.ListenerReasonProgrammed), programmed.Reason)
+	require.Equal(t, int64(7), programmed.ObservedGeneration)
+}
+
 func listenerStatusCondition(t *testing.T, listeners []gatewayv1.ListenerStatus, name gatewayv1.SectionName, conditionType string) metav1.Condition {
 	t.Helper()
 

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -1151,6 +1151,65 @@ func Test_gatewayReconciler_setAddressStatus_updatesAcceptedListenerProgrammedCo
 	require.Equal(t, int64(7), programmed.ObservedGeneration)
 }
 
+func Test_gatewayReconciler_setAddressStatus_nodePortUsesFirstValidNodeIP(t *testing.T) {
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gateway",
+			Namespace: "gateway-conformance-infra",
+		},
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gateway-service",
+			Namespace: gw.Namespace,
+			Labels: map[string]string{
+				owningGatewayLabel: shortener.ShortenK8sResourceName(gw.Name),
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeNodePort,
+		},
+	}
+
+	nodes := []client.Object{
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "node-b"},
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
+					{Type: corev1.NodeHostName, Address: "node-b.example.test"},
+					{Type: corev1.NodeInternalIP, Address: "192.0.2.20"},
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "node-a"},
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
+					{Type: corev1.NodeInternalIP, Address: "192.0.2.10"},
+				},
+			},
+		},
+	}
+
+	objects := append([]client.Object{svc}, nodes...)
+	c := fake.NewClientBuilder().
+		WithScheme(helpers.TestScheme(helpers.AllOptionalKinds)).
+		WithObjects(objects...).
+		Build()
+
+	r := &gatewayReconciler{
+		Client: c,
+		logger: hivetest.Logger(t, hivetest.LogLevel(slog.LevelDebug)),
+	}
+
+	require.NoError(t, r.setAddressStatus(t.Context(), gw))
+
+	require.Len(t, gw.Status.Addresses, 2)
+	require.Equal(t, "192.0.2.10", gw.Status.Addresses[0].Value)
+	require.Equal(t, "192.0.2.20", gw.Status.Addresses[1].Value)
+}
+
 func listenerStatusCondition(t *testing.T, listeners []gatewayv1.ListenerStatus, name gatewayv1.SectionName, conditionType string) metav1.Condition {
 	t.Helper()
 


### PR DESCRIPTION
This PR fixes three issues in `setAddressStatus` in the Gateway API reconciler.

Please review the individual commits.