### PR TITLE
chore: set cron for arian-scheduled for 30 mins past hour

### DIFF
--- a/.github/workflows/ariane-scheduled.yaml
+++ b/.github/workflows/ariane-scheduled.yaml
@@ -5,7 +5,7 @@ on:
   # Tests are only run when current hour % 6 corresponds
   # to the branch hourModulo value in the matrix
   schedule:
-    - cron: '0 */1 * * *'
+    - cron: '30 */1 * * *'
 
 
 permissions:


### PR DESCRIPTION
When ariane-scheduled.yaml is run at the top of the hour, we see irregular schedules owing to GitHub scheduling.

Setting to 30 mins past the hour would get more reliable scheduling of workflows.