### PR TITLE
ci: replace unsupported LLVM installation action

### DIFF
--- a/.github/actions/install-llvm/action.yml
+++ b/.github/actions/install-llvm/action.yml
@@ -1,0 +1,48 @@
+name: Install LLVM and Clang
+description: Download and configure an official LLVM release without a JavaScript action runtime.
+
+inputs:
+  version:
+    description: LLVM release version to install.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Download and install LLVM and Clang
+      shell: bash
+      env:
+        LLVM_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+
+        LLVM_INSTALL_PATH="${HOME}/.clang"
+
+        case "${RUNNER_ARCH}" in
+          X64)
+            asset="LLVM-${LLVM_VERSION}-Linux-X64.tar.xz"
+            ;;
+          ARM64)
+            asset="clang%2Bllvm-${LLVM_VERSION}-aarch64-linux-gnu.tar.xz"
+            ;;
+          *)
+            echo "Unsupported runner architecture: ${RUNNER_ARCH}" >&2
+            exit 1
+            ;;
+        esac
+
+        download_dir="$(mktemp -d "${RUNNER_TEMP}/llvm.XXXXXX")"
+        trap 'rm -rf -- "${download_dir}"' EXIT
+        archive="${download_dir}/llvm-${LLVM_VERSION}.tar.xz"
+        curl --fail --location --retry 3 --retry-all-errors \
+          --output "${archive}" \
+          "https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/${asset}"
+        mkdir -p "${LLVM_INSTALL_PATH}"
+        tar --extract --xz --file "${archive}" --strip-components=1 --directory "${LLVM_INSTALL_PATH}"
+
+        echo "${LLVM_INSTALL_PATH}/bin" >> "${GITHUB_PATH}"
+        {
+          echo "LLVM_PATH=${LLVM_INSTALL_PATH}"
+          echo "LD_LIBRARY_PATH=${LLVM_INSTALL_PATH}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+        } >> "${GITHUB_ENV}"
+        "${LLVM_INSTALL_PATH}/bin/clang" --version

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -130,6 +130,11 @@ jobs:
           fi
           echo sha=${SHA} >> $GITHUB_OUTPUT
 
+      - name: Install LLVM and Clang
+        uses: ./.github/actions/install-llvm
+        with:
+          version: "19.1.7"
+
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.
       - name: Checkout pull request branch (NOT TRUSTED)
@@ -156,16 +161,6 @@ jobs:
           key: ${{ runner.os }}-go-integration-test-cache-${{ runner.arch }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-integration-test-cache-${{ runner.arch }}-
-
-      - name: Set clang directory
-        id: set_clang_dir
-        run: echo "clang_dir=$HOME/.clang" >> $GITHUB_OUTPUT
-
-      - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@ebc0426251bc40c7cd31162802432c68818ab8f0 # v2.0.9
-        with:
-          version: "19.1.7"
-          directory: ${{ steps.set_clang_dir.outputs.clang_dir }}
 
       - name: Create cache directories if they don't exist
         if: ${{ steps.go-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -391,20 +391,15 @@ jobs:
           # renovate: datasource=golang-version depName=go
           go-version: 1.26.5
 
-      - name: Set clang directory
-        id: set_clang_dir
-        run: echo "clang_dir=$HOME/.clang" >> $GITHUB_OUTPUT
-
       - name: Install LLVM and Clang prerequisites
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libtinfo6
 
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@ebc0426251bc40c7cd31162802432c68818ab8f0 # v2.0.9
+        uses: ./.github/actions/install-llvm
         with:
           version: "19.1.7"
-          directory: ${{ steps.set_clang_dir.outputs.clang_dir }}
 
       - name: Install ginkgo
         run: |


### PR DESCRIPTION
Replace the unsupported LLVM installer action in the lint and integration test workflows with a local Bash composite action.

The local action preserves:

- LLVM 19.1.7 installation
- X64 and ARM64 archive selection
- LLVM path and library environment exports
- installed Clang version verification

After #47780 restored LLVM and Clang installation in `integration-test.yaml`, this PR also migrates that restored occurrence to the local composite action.

This PR intentionally contains only changes shared by the maintained stable branches so the patch can be backported cleanly to v1.17, v1.18, v1.19, and v1.20.

Validation:

- the composite action and both changed workflows parse successfully as YAML
- `git diff --check` passes

This is the backportable portion of the workflow migration originally submitted in #47738.
