### PR TITLE
operator/ipam: Restore fatal exit when the IPAM node watcher fails

### DIFF
--- a/operator/pkg/ipam/nodewatcher.go
+++ b/operator/pkg/ipam/nodewatcher.go
@@ -52,6 +52,12 @@ func newNodeWatcherJobFactory(
 
 				return nil
 			},
+			// An IPAM allocator that cannot be brought up (e.g. the initial
+			// cloud API synchronization failed) leaves the operator unable to
+			// allocate any IP. Shut down the hive so the failure surfaces as a
+			// single fatal log and the operator is restarted instead of running
+			// silently without an allocator.
+			job.WithShutdown(),
 		)
 	}
 }


### PR DESCRIPTION
The cilium-nodes-watcher one-shot job bootstraps the cloud IPAM allocator, including the blocking initial synchronization with the cloud API. Before the switch to modular IPAM allocators, a failure there was fatal: `operator/cmd/root.go` called `logging.Fatal("Unable to start %s allocator")` and the operator exited, letting Kubernetes restart it.

Moving that bootstrap into a `job.OneShot` dropped the fatality, as the job is registered without `job.WithShutdown()`. An unrecoverable failure is now only logged at error level by the job runner and marks the job degraded, leaving the operator running with no allocator and no node watcher: it can no longer hand out any IP, yet stays alive with no signal beyond a degraded health report.

Add `job.WithShutdown()` to restore the previous behavior. The hive is shut down with the error, which `operator/cmd/root.go` turns into a single fatal log. Combined with the error chain repaired in f54b0828cb14 ("ipam: Return error from instance (re)sync instead of sentinel time.Time"), that log now also carries the underlying cloud API error, which the pre-regression fatal used to swallow.

The `job.OneShot` runner returns early when the job succeeds or when the context is canceled, so a normal shutdown does not trigger this path. The node watcher is shared with the clusterpool and multipool allocators, which are equally unable to operate if their watcher fails to start, so they get the same treatment.

Fixes: 9664b9b654c5 ("operator/ipam: Switch to modular IPAM allocators")

Before (1.19):

<img width="1282" height="168" alt="image" src="https://github.com/user-attachments/assets/0e1a2805-2d11-48f9-870b-12dd5b930d4a" />


Currently (without this PR's fix, 1.20):

<img width="2027" height="140" alt="image" src="https://github.com/user-attachments/assets/6309e66f-b9af-4f84-ad01-ae9f5a6bc408" />

(and after those logs, the operator pod sits idle forever, not logging anything else, instead of loudly crashing as we want it to)

After this PR:
<img width="2027" height="135" alt="image" src="https://github.com/user-attachments/assets/5d7efd7f-b95d-4cb8-a975-db275100b7e2" />

And the operator ends up in CLBO as previously under 1.19