### PR TITLE
ipcache: migrate CIDR filter to netip

### DIFF
--- a/pkg/ipcache/api/ipcache_api_handler.go
+++ b/pkg/ipcache/api/ipcache_api_handler.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/netip"
 
 	"github.com/go-openapi/runtime/middleware"
 
@@ -37,7 +38,7 @@ func (r *IPCacheGetIPHandler) Handle(params policyapi.GetIPParams) middleware.Re
 		identityAllocator: r.identityAllocator,
 	}
 	if params.Cidr != nil {
-		_, cidrFilter, err := net.ParseCIDR(*params.Cidr)
+		cidrFilter, err := netip.ParsePrefix(*params.Cidr)
 		if err != nil {
 			return api.Error(policyapi.GetIPBadRequestCode, err)
 		}
@@ -55,7 +56,7 @@ func (r *IPCacheGetIPHandler) Handle(params policyapi.GetIPParams) middleware.Re
 }
 
 type ipCacheDumpListener struct {
-	cidrFilter        *net.IPNet
+	cidrFilter        netip.Prefix
 	labelsFilter      labels.Labels
 	identityAllocator identitycell.CachingIdentityAllocator
 	entries           []*models.IPListEntry
@@ -76,10 +77,10 @@ func (ipc *ipCacheDumpListener) OnIPIdentityCacheChange(modType ipcache.CacheMod
 	cidrCluster cmtypes.PrefixCluster, oldHostIP, newHostIP net.IP, oldID *ipcache.Identity,
 	newID ipcache.Identity, encryptKey uint8, k8sMeta *ipcache.K8sMetadata, endpointFlags uint8,
 ) {
-	cidr := cidrCluster.AsIPNet()
+	cidr := cidrCluster.AsPrefix()
 
 	// only capture entries which are a subnet of cidrFilter
-	if ipc.cidrFilter != nil && !containsSubnet(*ipc.cidrFilter, cidr) {
+	if ipc.cidrFilter.IsValid() && !containsSubnet(ipc.cidrFilter, cidr) {
 		return
 	}
 	// Only capture identities with requested labels
@@ -123,9 +124,6 @@ func (ipc *ipCacheDumpListener) OnIPIdentityCacheChange(modType ipcache.CacheMod
 }
 
 // containsSubnet returns true if 'outer' contains 'inner'
-func containsSubnet(outer, inner net.IPNet) bool {
-	outerOnes, outerBits := outer.Mask.Size()
-	innerOnes, innerBits := inner.Mask.Size()
-
-	return outerBits == innerBits && outerOnes <= innerOnes && outer.Contains(inner.IP)
+func containsSubnet(outer, inner netip.Prefix) bool {
+	return outer.Addr().BitLen() == inner.Addr().BitLen() && outer.Bits() <= inner.Bits() && outer.Contains(inner.Addr())
 }

--- a/pkg/ipcache/api/ipcache_api_handler_test.go
+++ b/pkg/ipcache/api/ipcache_api_handler_test.go
@@ -4,7 +4,7 @@
 package api
 
 import (
-	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -59,13 +59,21 @@ func TestContainsSubnet(t *testing.T) {
 			args: args{"::/0", "f00d::a10:0:0:1234/64"},
 			want: true,
 		},
+		{
+			args: args{"10.10.0.0/16", "f00d::a10:0:0:1234/64"},
+			want: false,
+		},
+		{
+			args: args{"f00d::a10:0:0:0/64", "10.10.0.0/16"},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
-		_, outer, err := net.ParseCIDR(tt.args.outer)
+		outer, err := netip.ParsePrefix(tt.args.outer)
 		require.NoError(t, err)
-		_, inner, err := net.ParseCIDR(tt.args.inner)
+		inner, err := netip.ParsePrefix(tt.args.inner)
 		require.NoError(t, err)
-		got := containsSubnet(*outer, *inner)
+		got := containsSubnet(outer, inner)
 		require.Equalf(t, tt.want, got, "expected containsSubnet(%q, %q) = %t, got %t", tt.args.outer, tt.args.inner, tt.want, got)
 	}
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models in accordance with the [Cilium AI Policy].
- [x] Thanks for contributing!

## Description

Migrate the private IPCache CIDR filter and subnet-containment helper from
`net.IPNet` to `netip.Prefix`.

This change:

- parses the optional CIDR filter with `netip.ParsePrefix`
- uses `PrefixCluster.AsPrefix()` when filtering IPCache entries
- replaces the private `net.IPNet` containment helper with `netip.Prefix`
- preserves IPv4, IPv6, equal-prefix, nested-prefix, and non-canonical-prefix behavior
- adds explicit IPv4-to-IPv6 and IPv6-to-IPv4 mismatch coverage

The existing IPCache listener interface remains unchanged.

Related: #24246

## Testing

```text
go test ./pkg/ipcache/api -run '^TestContainsSubnet$' -count=1
go test ./pkg/ipcache/api -count=1
go vet ./pkg/ipcache/api/...
git diff --check upstream/main...HEAD
```

This PR was prepared with AIL:4. Claude Code assisted with identifying and
implementing this narrow migration and its regression tests. I reviewed the
complete diff, verified the containment behavior, and ran all tests and checks
listed above.

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
