### PR TITLE
Revert "gha: don't install LLVM and Clang in integration tests workflow"

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -103,6 +103,11 @@ jobs:
         with:
           comment_on_pr: false
 
+      - name: Install Dependencies
+        shell: bash
+        run: |
+          sudo apt update && sudo apt install -y --no-install-recommends build-essential make libtinfo6
+
       - name: Checkout context ref (trusted)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -152,6 +157,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-integration-test-cache-${{ runner.arch }}-
 
+      - name: Set clang directory
+        id: set_clang_dir
+        run: echo "clang_dir=$HOME/.clang" >> $GITHUB_OUTPUT
+
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@ebc0426251bc40c7cd31162802432c68818ab8f0 # v2.0.9
+        with:
+          version: "19.1.7"
+          directory: ${{ steps.set_clang_dir.outputs.clang_dir }}
+
       - name: Create cache directories if they don't exist
         if: ${{ steps.go-cache.outputs.cache-hit != 'true' }}
         env:
@@ -183,6 +198,7 @@ jobs:
         run: |
           export V=0
           export DOCKER_BUILD_FLAGS=--quiet
+          export CFLAGS="-Werror"
           make integration-tests LOG_CODEOWNERS=1 JUNIT_PATH="test/${{ env.job_name }}.xml"
 
       - name: Fetch JUnits


### PR DESCRIPTION
This reverts commit c215742d866ef342303dcf224db69b29565c8885.

The reverted commit removed the installation of LLVM and Clang from the integration tests workflow, under the assumption that they are not needed to run the Go based integration tests. However, it turns out that the TestObjectCache{,Parallel} tests actually invoke the compilation of a BPF program. Yet, I had not noticed it while testing the PR previously, as likely the GHA image includes Clang installed, and the version happens to be close enough to not cause failures.

Let's restore the explicit LLVM and Clang installation step, to prevent the risk of breakages due to version changes, or if the GHA image doesn't include them. The "Setup additional repositories" steps is not restored though, as it was only needed for libtinfo5, and it is also fragile as it depends on runner names.

AIL: 0