### PR TITLE
docs: note on eBPF ClusterIP translation vs Docker raw-table protection

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -145,6 +145,27 @@ underlying Linux kernel support is missing.
 By default, Helm sets ``kubeProxyReplacement=false``, which only enables
 per-packet in-cluster load-balancing of ClusterIP services.
 
+.. note::
+
+   On hosts running both Kubernetes and Docker, a Service may use a backend that
+   is an unpublished Docker container. In this setup, ClusterIP translation is
+   performed by Cilium in the eBPF datapath before the packet reaches netfilter.
+   As a result, the packet can arrive at Docker's ``raw/PREROUTING`` rules
+   already addressed to the backend container.
+
+   In this case, Docker's per-container ``raw`` protection may drop the packet
+   before it reaches ``DOCKER-USER``. Any allow rule placed in
+   ``DOCKER-USER`` therefore has no effect for this traffic.
+
+   A simple way to verify this behaviour is to compare packet counters while
+   attempting a connection from a pod. If Docker's ``raw`` DROP rule increases
+   while the kube-proxy service chains (``KUBE-SVC`` / ``KUBE-SEP``) remain
+   unchanged, the packet is being dropped before it reaches the expected
+   netfilter path.
+
+   If this communication is intentional, allow only the specific traffic
+   required by adding a narrowly scoped rule in the ``raw`` table.
+
 Cilium's eBPF kube-proxy replacement is supported in direct routing as well as in
 tunneling mode.
 


### PR DESCRIPTION
Document an interaction between Cilium's eBPF ClusterIP translation and Docker's
raw-table protection that can affect hybrid Docker/Kubernetes hosts using
unpublished Docker container backends.

On such hosts, a `Service` backed by an unpublished Docker container can become
unreachable from pods: Cilium translates the ClusterIP in the eBPF datapath, so
the packet reaches Docker's `raw/PREROUTING` protection already addressed to the
backend and is dropped before `DOCKER-USER`. This adds a short note to the
kube-proxy-free documentation, next to the paragraph on per-packet ClusterIP
load-balancing, together with a counter-based way to confirm the behaviour.

Discussed and requested by a maintainer in #47601.

Fixes: #47601

AI disclosure: AIL:2. Generative AI tools were used for research and technical
analysis, and provided an initial draft which the author rewrote in their own
words. The author independently reproduced and verified the described behaviour
and takes full responsibility for the final content.


```release-note
NONE
```
