### PR TITLE
ci: monitor additional composite actions with Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -38,6 +38,8 @@
     ".github/actions/e2e/**",
     ".github/actions/kvstore/**",
     ".github/actions/gather-metrics/**",
+    ".github/actions/get-runner-ip/**",
+    ".github/actions/wait-for-images/**",
     ".github/actions/merge-artifacts/**",
     ".github/actions/post-logic/**",
     ".github/actions/ginkgo/**",


### PR DESCRIPTION
## Summary

- include `.github/actions/get-runner-ip/**` in Renovate dependency scanning
- include `.github/actions/wait-for-images/**` in Renovate dependency scanning

## Why

The existing explicit allowlist omitted these two composite actions. Adding both directories allows Renovate to track `actions/github-script` in `get-runner-ip` and `docker/login-action` in `wait-for-images` while preserving the current allowlist approach.

This change applies to dependency management on `main` only and does not require stable-branch backports.

## Validation

- Cilium's pinned `renovate-config-validator` reports the configuration as valid
- `renovate --platform=local --dry-run=lookup` discovers `actions/github-script` in `get-runner-ip/action.yml` and `docker/login-action` in `wait-for-images/action.yaml`
- `git diff --check`
