### PR TITLE
ci: use GitHub App client ID in v1.17 image workflow

### DIFF
--- a/.github/workflows/build-images-ci-v1.17.yaml
+++ b/.github/workflows/build-images-ci-v1.17.yaml
@@ -450,7 +450,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
-          app-id: ${{ secrets.AUTO_COMMENT_BOT_APP_ID }}
+          client-id: ${{ secrets.AUTO_COMMENT_CLIENT_APP_ID }}
           private-key: ${{ secrets.AUTO_COMMENT_BOT_PEM }}
       - name: Post /test comment
         env:

--- a/.github/workflows/build-images-ci-v1.17.yaml
+++ b/.github/workflows/build-images-ci-v1.17.yaml
@@ -450,7 +450,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
-          app-id: ${{ secrets.AUTO_COMMENT_BOT_APP_ID }}
+          client-id: ${{ secrets.AUTO_COMMENT_BOT_CLIENT_ID }}
           private-key: ${{ secrets.AUTO_COMMENT_BOT_PEM }}
       - name: Post /test comment
         env:


### PR DESCRIPTION
## Summary

- replace the deprecated `app-id` input with `client-id` in the v1.17 image workflow
- use `AUTO_COMMENT_CLIENT_APP_ID` for the corresponding GitHub App credential

## Why

The v1.17 workflow on `main` handles pull requests targeting the v1.17 branch. Keeping this change isolated allows the same one-file patch to be backported only to v1.17, where the corresponding workflow handles branch pushes.

Requested backport target: `v1.17` only.

## Validation

- changed workflow parses as valid YAML
- `git diff --check`
