### PR TITLE
ci: replace needs-attention action and use app client ID

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -492,7 +492,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
-          app-id: ${{ secrets.AUTO_COMMENT_BOT_APP_ID }}
+          client-id: ${{ secrets.AUTO_COMMENT_CLIENT_APP_ID }}
           private-key: ${{ secrets.AUTO_COMMENT_BOT_PEM }}
       - name: Post /test comment
         env:

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -492,7 +492,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
-          app-id: ${{ secrets.AUTO_COMMENT_BOT_APP_ID }}
+          client-id: ${{ secrets.AUTO_COMMENT_BOT_CLIENT_ID }}
           private-key: ${{ secrets.AUTO_COMMENT_BOT_PEM }}
       - name: Post /test comment
         env:

--- a/.github/workflows/needs-more-info.yaml
+++ b/.github/workflows/needs-more-info.yaml
@@ -13,8 +13,36 @@ jobs:
       issues: write
     steps:
       - name: Apply Needs Attention Label
-        uses: hramos/needs-attention@d0eaa7f961c04d4da86466b1176b56e0d4089022 # v2.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-            repo-token: ${{ secrets.GITHUB_TOKEN }}
-            response-required-label: 'need-more-info'
-            needs-attention-label: 'info-completed'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue = context.payload.issue;
+            const comment = context.payload.comment;
+            if (!issue || !comment) {
+              core.setOutput('result', 'Event does not contain an issue and comment');
+              return;
+            }
+
+            const responseRequiredLabel = 'need-more-info';
+            const needsAttentionLabel = 'info-completed';
+            const labels = issue.labels.map((label) =>
+              typeof label === 'string' ? label : label.name
+            );
+
+            if (!labels.includes(responseRequiredLabel) || issue.user.login !== comment.user.login) {
+              core.setOutput('result', `${context.repo.owner}/${context.repo.repo}#${issue.number} does not need attention`);
+              return;
+            }
+
+            await github.rest.issues.removeLabel({
+              ...context.repo,
+              issue_number: issue.number,
+              name: responseRequiredLabel,
+            });
+            await github.rest.issues.addLabels({
+              ...context.repo,
+              issue_number: issue.number,
+              labels: [needsAttentionLabel],
+            });
+            core.setOutput('result', `${context.repo.owner}/${context.repo.repo}#${issue.number} marked as needing attention`);


### PR DESCRIPTION
## Summary

- replace `hramos/needs-attention` with pinned `actions/github-script@v9` logic
- preserve the existing issue-label transition: when the issue author replies to an issue labeled `need-more-info`, remove that label and add `info-completed`
- configure `actions/create-github-app-token` in the image workflow with its `client-id` input and the `AUTO_COMMENT_BOT_CLIENT_ID` secret

## Why

Using `actions/github-script` makes the issue-author and label-transition behavior explicit in the workflow while moving the step to the current GitHub Actions runtime. The image workflow also needs to use the GitHub App client ID with the corresponding token-action input.

These workflows apply only to `main` and no backport is needed.

No stable-branch backport is required for this PR.

## Validation

- both changed workflows parse as valid YAML
- `git diff --check`
