### PR TITLE
standalone-dns-proxy: return an error when no endpoint is found

### DIFF
--- a/standalone-dns-proxy/pkg/lookup/lookup.go
+++ b/standalone-dns-proxy/pkg/lookup/lookup.go
@@ -5,6 +5,7 @@ package lookup
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/netip"
@@ -41,7 +42,7 @@ func (r *rulesClient) LookupByIdentity(nid identity.NumericIdentity) []string {
 func (r *rulesClient) LookupRegisteredEndpoint(endpointAddr netip.Addr) (endpt *endpoint.Endpoint, isHost bool, err error) {
 	info, _, found := r.ipToIdentityTable.Get(r.db.ReadTxn(), client.IdIPToEndpointIndex.Query(endpointAddr))
 	if !found {
-		return nil, false, nil
+		return nil, false, fmt.Errorf("cannot find endpoint with IP %s", endpointAddr)
 	}
 	return &endpoint.Endpoint{
 		ID: uint16(info.ID),

--- a/standalone-dns-proxy/pkg/lookup/lookup_test.go
+++ b/standalone-dns-proxy/pkg/lookup/lookup_test.go
@@ -98,7 +98,7 @@ func TestLookupRegisteredEndpoint(t *testing.T) {
 	require.False(t, isHost)
 
 	ep, isHost, err = rc.LookupRegisteredEndpoint(netip.MustParseAddr("10.0.0.2"))
-	require.NoError(t, err)
+	require.Error(t, err)
 	require.Nil(t, ep)
 	require.False(t, isHost)
 


### PR DESCRIPTION
`LookupRegisteredEndpoint` reported a lookup miss as (nil, false, nil). The shared `ServeDNS` caller only inspects the returned error before using the endpoint, so it dereferenced the nil endpoint and panicked the whole proxy:

```
  panic: runtime error: invalid memory address or nil pointer dereference
  github.com/cilium/cilium/pkg/endpoint.(*Endpoint).StringID(...)
        pkg/endpoint/endpoint.go:848
  github.com/cilium/cilium/pkg/fqdn/dnsproxy.(*DNSProxy).ServeDNS(...)
        pkg/fqdn/dnsproxy/proxy.go:983
```
The IP to endpoint table is a snapshot replicated from the agent, so an endpoint can in principle send a DNS request before its IP has been received. This has not been observed in steady state, but it becomes likely during a burst of endpoint creation: starting a batch of pods selected by a `toFQDNs` policy on a single node reproduced it consistently, with the new pods' source IPs still absent from the table while they were already resolving. Because the panic takes down the proxy process, a single such
request breaks DNS for every endpoint on the node.
The agent's own implementation of this interface always returns a non-nil error when it cannot resolve an endpoint, which is why only the standalone DNS proxy was affected. Match that contract so a miss is reported as an error, and the request is answered with SERVFAIL instead of crashing.

AIL: 2

```release-note
standalone-dns-proxy: return an error when no endpoint is found
```