### PR TITLE
.github: Run envoy image check against PR content

### DIFF
--- a/.github/workflows/lint-images-base.yaml
+++ b/.github/workflows/lint-images-base.yaml
@@ -93,8 +93,11 @@ jobs:
           entrypoint: make
           args: -C untrusted/images check-runtime-image RUNTIME_IMAGE=${{ env.CILIUM_RUNTIME_IMAGE }}
 
-      - name: Check Cilium Envoy image
-        run: make -C trusted/images check-envoy-image
+      - uses: docker://quay.io/cilium/image-maker:7de7f1c855ce063bdbe57fdfb28599a3ad5ec8f1@sha256:dde8500cbfbb6c41433d376fdfcb3831e2df9cec50cf4f49e8553dc6eba74e72
+        name: Check Cilium Envoy image
+        with:
+          entrypoint: make
+          args: -C untrusted/images check-envoy-image
 
   merge-upload-and-status:
     name: Merge Upload and Status


### PR DESCRIPTION
Move this execution into a container and run the check against the PR
branch of the tree rather than the base branch. This matches how the
other steps in this workflow execute.
