### PR TITLE
bpf/lib/nat: rename icmpoff

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -820,7 +820,7 @@ snat_v4_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 	struct ipv4_ct_tuple tuple = {};
 	struct iphdr iphdr;
 	__u16 port_off;
-	__u32 icmpoff;
+	__u32 inner_l4_off;
 	__u8 type;
 	int ret;
 	bool icmp_has_inner_l4_csum = true;
@@ -841,7 +841,7 @@ snat_v4_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 	tuple.daddr = iphdr.saddr;
 	tuple.flags = NAT_DIR_EGRESS;
 
-	icmpoff = inner_l3_off + ipv4_hdrlen(&iphdr);
+	inner_l4_off = inner_l3_off + ipv4_hdrlen(&iphdr);
 	switch (tuple.nexthdr) {
 	case IPPROTO_TCP:
 	case IPPROTO_UDP:
@@ -851,13 +851,13 @@ snat_v4_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 		/* No reasons to handle IP fragmentation for this case as it is
 		 * expected that DF isn't set for this particular context.
 		 */
-		if (l4_load_ports(ctx, icmpoff, &tuple.dport) < 0)
+		if (l4_load_ports(ctx, inner_l4_off, &tuple.dport) < 0)
 			return DROP_INVALID;
 
 		port_off = TCP_DPORT_OFF;
 		break;
 	case IPPROTO_ICMP:
-		if (ctx_load_bytes(ctx, icmpoff, &type, sizeof(type)) < 0)
+		if (ctx_load_bytes(ctx, inner_l4_off, &type, sizeof(type)) < 0)
 			return DROP_INVALID;
 
 		switch (type) {
@@ -870,7 +870,7 @@ snat_v4_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 			return DROP_UNKNOWN_ICMP4_CODE;
 		}
 
-		if (ctx_load_bytes(ctx, icmpoff + port_off,
+		if (ctx_load_bytes(ctx, inner_l4_off + port_off,
 				   &tuple.sport, sizeof(tuple.sport)) < 0)
 			return DROP_INVALID;
 		break;
@@ -890,7 +890,7 @@ snat_v4_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 	/* We found SNAT entry to NAT embedded packet. The destination addr
 	 * should be NATed according to the entry.
 	 */
-	ret = snat_v4_rewrite_headers(ctx, tuple.nexthdr, inner_l3_off, true, icmpoff,
+	ret = snat_v4_rewrite_headers(ctx, tuple.nexthdr, inner_l3_off, true, inner_l4_off,
 				      tuple.saddr, (*state)->to_saddr, IPV4_DADDR_OFF,
 				      tuple.sport, (*state)->to_sport, port_off, 0);
 	/* Failing to update the inner L4 checksum is not fatal if the header
@@ -1047,7 +1047,7 @@ snat_v4_rev_nat_handle_icmp_error(struct __ctx_buff *ctx,
 	struct ipv4_ct_tuple tuple = {};
 	struct iphdr iphdr;
 	__u16 port_off;
-	__u32 icmpoff;
+	__u32 inner_l4_off;
 	__u8 type;
 	bool icmp_has_inner_l4_csum = true;
 	bool is_inner_l4_csum_enabled = true;
@@ -1072,7 +1072,7 @@ snat_v4_rev_nat_handle_icmp_error(struct __ctx_buff *ctx,
 	tuple.daddr = iphdr.saddr;
 	tuple.flags = NAT_DIR_INGRESS;
 
-	icmpoff = (__u32)(inner_l3_off + ipv4_hdrlen(&iphdr));
+	inner_l4_off = (__u32)(inner_l3_off + ipv4_hdrlen(&iphdr));
 	switch (tuple.nexthdr) {
 	case IPPROTO_TCP:
 	case IPPROTO_UDP:
@@ -1082,13 +1082,13 @@ snat_v4_rev_nat_handle_icmp_error(struct __ctx_buff *ctx,
 		/* No reasons to handle IP fragmentation for this case as it is
 		 * expected that DF isn't set for this particular context.
 		 */
-		if (l4_load_ports(ctx, icmpoff, &tuple.dport) < 0)
+		if (l4_load_ports(ctx, inner_l4_off, &tuple.dport) < 0)
 			return DROP_INVALID;
 
 		port_off = TCP_SPORT_OFF;
 		break;
 	case IPPROTO_ICMP:
-		if (ctx_load_bytes(ctx, icmpoff, &type, sizeof(type)) < 0)
+		if (ctx_load_bytes(ctx, inner_l4_off, &type, sizeof(type)) < 0)
 			return DROP_INVALID;
 
 		switch (type) {
@@ -1101,7 +1101,7 @@ snat_v4_rev_nat_handle_icmp_error(struct __ctx_buff *ctx,
 			return DROP_UNKNOWN_ICMP4_CODE;
 		}
 
-		if (ctx_load_bytes(ctx, icmpoff + port_off,
+		if (ctx_load_bytes(ctx, inner_l4_off + port_off,
 				   &tuple.dport, sizeof(tuple.dport)) < 0)
 			return DROP_INVALID;
 		break;
@@ -1122,7 +1122,7 @@ snat_v4_rev_nat_handle_icmp_error(struct __ctx_buff *ctx,
 	if (tuple.nexthdr == IPPROTO_UDP) {
 		__be16 l4_csum_be = 0;
 
-		if (ctx_load_bytes(ctx, icmpoff + offsetof(struct udphdr, check),
+		if (ctx_load_bytes(ctx, inner_l4_off + offsetof(struct udphdr, check),
 				   &l4_csum_be, sizeof(l4_csum_be)) < 0)
 			return DROP_INVALID;
 		if (l4_csum_be == 0)
@@ -1138,7 +1138,7 @@ snat_v4_rev_nat_handle_icmp_error(struct __ctx_buff *ctx,
 
 	/* The embedded packet was SNATed on egress. Reverse it again: */
 	ret = snat_v4_rewrite_headers(ctx, tuple.nexthdr, (int)inner_l3_off,
-				      true, icmpoff,
+				      true, inner_l4_off,
 				      tuple.daddr, (*state)->to_daddr, IPV4_SADDR_OFF,
 				      tuple.dport, (*state)->to_dport, port_off, 0);
 	/* Failing to update the inner L4 checksum is not fatal if the header
@@ -1843,7 +1843,7 @@ snat_v6_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 	struct ipv6_ct_tuple tuple = {};
 	struct ipv6hdr ip6;
 	__u16 port_off;
-	__u32 icmpoff;
+	__u32 inner_l4_off;
 	int hdrlen;
 	__u8 type;
 
@@ -1867,7 +1867,7 @@ snat_v6_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 	if (hdrlen < 0)
 		return hdrlen;
 
-	icmpoff = inner_l3_off + hdrlen;
+	inner_l4_off = inner_l3_off + hdrlen;
 
 	switch (tuple.nexthdr) {
 	case IPPROTO_TCP:
@@ -1878,13 +1878,13 @@ snat_v6_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 		/* No reasons to handle IP fragmentation for this case as it is
 		 * expected that DF isn't set for this particular context.
 		 */
-		if (l4_load_ports(ctx, icmpoff, &tuple.dport) < 0)
+		if (l4_load_ports(ctx, inner_l4_off, &tuple.dport) < 0)
 			return DROP_INVALID;
 
 		port_off = TCP_DPORT_OFF;
 		break;
 	case IPPROTO_ICMPV6:
-		if (icmp6_load_type(ctx, icmpoff, &type) < 0)
+		if (icmp6_load_type(ctx, inner_l4_off, &type) < 0)
 			return DROP_INVALID;
 
 		switch (type) {
@@ -1897,7 +1897,7 @@ snat_v6_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 			return DROP_UNKNOWN_ICMP6_CODE;
 		}
 
-		if (ctx_load_bytes(ctx, icmpoff + port_off,
+		if (ctx_load_bytes(ctx, inner_l4_off + port_off,
 				   &tuple.sport, sizeof(tuple.sport)) < 0)
 			return DROP_INVALID;
 		break;
@@ -1910,7 +1910,7 @@ snat_v6_nat_handle_icmp_error(struct __ctx_buff *ctx, __u64 off,
 		return NAT_PUNT_TO_STACK;
 
 	/* The embedded packet was RevSNATed on ingress. Reverse it again: */
-	return snat_v6_rewrite_headers(ctx, tuple.nexthdr, inner_l3_off, true, icmpoff,
+	return snat_v6_rewrite_headers(ctx, tuple.nexthdr, inner_l3_off, true, inner_l4_off,
 				       &tuple.saddr, &(*state)->to_saddr, IPV6_DADDR_OFF,
 				       tuple.sport, (*state)->to_sport, port_off);
 }
@@ -2061,7 +2061,7 @@ snat_v6_rev_nat_handle_icmp_pkt_toobig(struct __ctx_buff *ctx,
 	struct ipv6_ct_tuple tuple = {};
 	struct ipv6hdr iphdr;
 	__u16 port_off;
-	__u32 icmpoff;
+	__u32 inner_l4_off;
 	__u8 type;
 	int hdrlen;
 
@@ -2094,7 +2094,7 @@ snat_v6_rev_nat_handle_icmp_pkt_toobig(struct __ctx_buff *ctx,
 	if (hdrlen < 0)
 		return hdrlen;
 
-	icmpoff = inner_l3_off + hdrlen;
+	inner_l4_off = inner_l3_off + hdrlen;
 
 	switch (tuple.nexthdr) {
 	case IPPROTO_TCP:
@@ -2106,7 +2106,7 @@ snat_v6_rev_nat_handle_icmp_pkt_toobig(struct __ctx_buff *ctx,
 		 * as it is expected that DF isn't set for this particular
 		 * context.
 		 */
-		if (l4_load_ports(ctx, icmpoff, &tuple.dport) < 0)
+		if (l4_load_ports(ctx, inner_l4_off, &tuple.dport) < 0)
 			return DROP_INVALID;
 
 		port_off = TCP_SPORT_OFF;
@@ -2115,14 +2115,14 @@ snat_v6_rev_nat_handle_icmp_pkt_toobig(struct __ctx_buff *ctx,
 		/* No reasons to see a packet different than
 		 * ICMPV6_ECHO_REQUEST.
 		 */
-		if (icmp6_load_type(ctx, icmpoff, &type) < 0 ||
+		if (icmp6_load_type(ctx, inner_l4_off, &type) < 0 ||
 		    type != ICMPV6_ECHO_REQUEST)
 			return DROP_INVALID;
 
 		port_off = offsetof(struct icmp6hdr,
 				    icmp6_dataun.u_echo.identifier);
 
-		if (ctx_load_bytes(ctx, icmpoff + port_off,
+		if (ctx_load_bytes(ctx, inner_l4_off + port_off,
 				   &tuple.dport, sizeof(tuple.dport)) < 0)
 			return DROP_INVALID;
 		break;
@@ -2135,7 +2135,7 @@ snat_v6_rev_nat_handle_icmp_pkt_toobig(struct __ctx_buff *ctx,
 		return NAT_PUNT_TO_STACK;
 
 	/* The embedded packet was SNATed on egress. Reverse it again: */
-	return snat_v6_rewrite_headers(ctx, tuple.nexthdr, inner_l3_off, true, icmpoff,
+	return snat_v6_rewrite_headers(ctx, tuple.nexthdr, inner_l3_off, true, inner_l4_off,
 				       &tuple.daddr, &(*state)->to_daddr, IPV6_SADDR_OFF,
 				       tuple.dport, (*state)->to_dport, port_off);
 }


### PR DESCRIPTION
Minor code cleanup: although this value is sometimes used as the inner icmp offset the most likely case is that it is actually the inner l4 header offset.
So to make the code more readable just change this to the standard convention of inner_l4_off.

Originally part of https://github.com/cilium/cilium/pull/47222/changes/e76962d0dee068111bec23174dd3504f0ab8d0ca but I broke it off to avoid having to run all the tests on that branch.

