### PR TITLE
ariane-scheduled: Use gh-run-nr to ensure even distribution

### DIFF
--- a/.github/workflows/ariane-scheduled.yaml
+++ b/.github/workflows/ariane-scheduled.yaml
@@ -2,8 +2,10 @@ name: Ariane scheduled workflows
 
 on:
   # Run every 1 hours
-  # Tests are only run when current hour % 6 corresponds
-  # to the branch hourModulo value in the matrix
+  # Tests are only run when current GITHUB_RUN_NUMBER % 6 corresponds to the branch runModulo value in the matrix,
+  # meaning we run every branch roughly every six hours.
+  # We run this at :30, to avoid running at the same time as the default branch scheduled workflows (that mostly run
+  # at the top of the hour).
   schedule:
     - cron: '30 */1 * * *'
 
@@ -21,14 +23,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        # DON'T USE hourModulo=0 to avoid running ariane scheduled-workflows
-        # at the same time as regular main scheduled workflows
+          # runModulo (range [0, 5]) should be different for every branch
           - branch: 'v1.18'
-            hourModulo: 1
+            runModulo: 1
           - branch: 'v1.19'
-            hourModulo: 2
+            runModulo: 2
           - branch: 'v1.20'
-            hourModulo: 3
+            runModulo: 3
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout branch
@@ -42,9 +43,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Current date time: $(date --utc --rfc-3339=seconds)"
+          echo "Current run number: $GITHUB_RUN_NUMBER"
 
-          HOUR=$(date --utc +"%-H")
-          if (( HOUR % 6 == ${{ matrix.hourModulo }} )); then
+          if (( GITHUB_RUN_NUMBER % 6 == ${{ matrix.runModulo }} )); then
             echo "Running scheduled workflows for branch ${{ matrix.branch }}"
           else
             echo "Skipping scheduled workflows for branch ${{ matrix.branch }}"


### PR DESCRIPTION
Currently, our scheduled runs on the non-default branches are triggered by a GitHub workflow called "Ariane scheduled workflows". That workflow is ran every hour, and based on the outcome `$hour % 6`, dispatched a different branch every time. The goal is to run each configured branch every six hours.

This however does unfortunately not worked as expected. The GitHub cron job schedule is incredibly jittery, meaning the current `$hour` sometimes skips an hour. Even worse, some hours seem to be skipped more often than others, meaning some branches are executed less often than others very consistently.

To work around this problem, this PR instead relies on the `GITHUB_RUN_NUMBER` to determine what branch to run. From the documentation: "A unique number for each run of a particular workflow in a repository. This number begins at 1 for the workflow's first run, and increments with each new run. This number does not change if you re-run the workflow run.". Since we only run scheduled workflows from the default branch, this number is guaranteed to strictly be incremented by one each run, so even if an hour is skipped, the next branch is still triggered once the workflow runs again.

I've manually tested the `GITHUB_RUN_NUMBER` logic manually on a throw-away repo (but using workflow_dispatch rather than cron, since GitHub cron jobs at most run every 5 minutes).

AIL: 0

Suggested-by: Marco Iorio <marco.iorio@isovalent.com>