### PR TITLE
feat(hubble/metrics): add path template matcher for the HTTP path label

### DIFF
--- a/pkg/hubble/metrics/pathtemplate/fuzz_test.go
+++ b/pkg/hubble/metrics/pathtemplate/fuzz_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package pathtemplate
+
+import (
+	"slices"
+	"testing"
+)
+
+// FuzzCompileAndMatch checks the two rules that keep the "path" label bounded.
+// A match only ever returns a configured template, and a compiled list holds
+// every template that was configured. Two templates are fuzzed instead of one,
+// so ordering, duplicate rejection and shadowing are covered as well.
+func FuzzCompileAndMatch(f *testing.F) {
+	seeds := []struct{ first, second, path string }{
+		{"/", "/api", "/"},
+		{"/api/v1/users/{id}", "/api/v1/users/me", "/api/v1/users/abc"},
+		{"/api/v1/users/{id}/orders", "/api/{rest...}", "/api/v1/users/abc/orders"},
+		{"/static/{rest...}", "/static/css/{file}", "/static/css/site.css"},
+		{"/{rest...}", "/healthz", "/anything"},
+		{"/reports/my%20report", "/api/%7Blegacy%7D", "/reports/my%20report"},
+		{"/b_{bucket}", "/", "/b_1"},
+		{"/{rest...}/more", "/", "/a/more"},
+		{"/{1id}", "/", "/1"},
+		{"/users/{id:[0-9]+}", "/", "/users/1"},
+		{"/a/{x}", "/a/{y}", "/a/b"},
+		{"", "", ""},
+		{"api/v1", "/", "api/v1"},
+	}
+	for _, seed := range seeds {
+		f.Add(seed.first, seed.second, seed.path)
+	}
+
+	f.Fuzz(func(t *testing.T, first, second, path string) {
+		templates := []string{first, second}
+		m, err := Compile(templates)
+		if err != nil {
+			return
+		}
+		if m.Len() != len(templates) {
+			t.Fatalf("Compile(%q) kept %d templates, want %d", templates, m.Len(), len(templates))
+		}
+
+		shadowed := make(map[int]bool)
+		for _, s := range m.Shadowed() {
+			if s.Index <= s.ByIndex {
+				t.Fatalf("Shadowed reported templates[%d] shadowed by the later templates[%d]", s.Index, s.ByIndex)
+			}
+			if s.Template != templates[s.Index] || s.ByTemplate != templates[s.ByIndex] {
+				t.Fatalf("Shadowed reported %q/%q, want %q/%q",
+					s.Template, s.ByTemplate, templates[s.Index], templates[s.ByIndex])
+			}
+			shadowed[s.Index] = true
+		}
+
+		got, ok := m.Match(path)
+		if !ok {
+			if got != "" {
+				t.Fatalf("Match(%q) returned %q on a miss, want an empty value", path, got)
+			}
+			return
+		}
+		i := slices.Index(templates, got)
+		if i < 0 {
+			t.Fatalf("Match(%q) returned %q, want one of %q", path, got, templates)
+		}
+		// If a shadowed template could win, the report would send someone off
+		// to reorder a list that already does what they want.
+		if shadowed[i] {
+			t.Fatalf("Match(%q) returned templates[%d] (%q), reported as shadowed", path, i, got)
+		}
+	})
+}

--- a/pkg/hubble/metrics/pathtemplate/pathtemplate.go
+++ b/pkg/hubble/metrics/pathtemplate/pathtemplate.go
@@ -13,10 +13,11 @@ import (
 // label values and the cost of a single match.
 const MaxTemplates = 100
 
-// maxStackSegments sizes the split buffer so it stays on the stack and a match
-// does not allocate. A template deeper than this still matches, at one
-// allocation per call.
-const maxStackSegments = 24
+// MaxTemplateSegments caps a single template's depth. It is what keeps Match's
+// split buffer on the stack, so a match never allocates whatever the config
+// holds. Raising it later is backwards compatible but costs time on every
+// match, since the buffer is zeroed per call.
+const MaxTemplateSegments = 32
 
 type segmentKind uint8
 
@@ -61,8 +62,8 @@ type Shadow struct {
 }
 
 // Compile turns templates into a Matcher, keeping the order given. The list
-// needs at least one entry and at most MaxTemplates, and every bad template is
-// reported in one error.
+// needs at least one entry and at most MaxTemplates, no template may be deeper
+// than MaxTemplateSegments, and every bad template is reported in one error.
 //
 // Two templates that match the same set of paths are rejected as duplicates,
 // even when they differ in placeholder names, because the second could never
@@ -132,15 +133,11 @@ func (m *Matcher) Match(path string) (string, bool) {
 	// Split at most maxSegments+1 times. No template looks past segment
 	// maxSegments-1, so splitting further cannot change the answer, and a path
 	// with thousands of segments costs the same as a short one. Splitting all of
-	// it would let the client set how much work a match takes.
+	// it would let the client set how much work a match takes. MaxTemplateSegments
+	// bounds maxSegments, so the buffer always fits on the stack.
 	limit := m.maxSegments + 1
-	var buf [maxStackSegments]string
-	var segments []string
-	if limit <= maxStackSegments {
-		segments = buf[:0]
-	} else {
-		segments = make([]string, 0, limit)
-	}
+	var buf [MaxTemplateSegments + 1]string
+	segments := buf[:0]
 
 	rest := path
 	for len(segments) < limit-1 {
@@ -304,6 +301,9 @@ func compileTemplate(raw string) (template, error) {
 	}
 
 	parts := strings.Split(raw, "/")
+	if len(parts) > MaxTemplateSegments {
+		return template{}, fmt.Errorf("template has %d segments, at most %d are supported", len(parts), MaxTemplateSegments)
+	}
 	segments := make([]segment, len(parts))
 	for i, part := range parts {
 		seg, err := compileSegment(part)

--- a/pkg/hubble/metrics/pathtemplate/pathtemplate.go
+++ b/pkg/hubble/metrics/pathtemplate/pathtemplate.go
@@ -1,0 +1,377 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package pathtemplate
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// MaxTemplates caps the list, which bounds both the number of distinct "path"
+// label values and the cost of a single match.
+const MaxTemplates = 100
+
+// maxStackSegments sizes the split buffer so it stays on the stack and a match
+// does not allocate. A template deeper than this still matches, at one
+// allocation per call.
+const maxStackSegments = 24
+
+type segmentKind uint8
+
+const (
+	// segmentLiteral matches one path segment byte for byte.
+	segmentLiteral segmentKind = iota
+	// segmentSingle is "{name}" and matches one non-empty path segment.
+	segmentSingle
+	// segmentTail is "{name...}" and matches every remaining path segment.
+	segmentTail
+)
+
+type segment struct {
+	kind segmentKind
+	// literal is only set for segmentLiteral.
+	literal string
+}
+
+type template struct {
+	raw      string
+	segments []segment
+	hasTail  bool
+}
+
+// Matcher is an ordered list of compiled path templates. It never changes after
+// Compile returns, so it is safe to use from several goroutines and safe to
+// replace as a whole on a config reload.
+type Matcher struct {
+	templates []template
+	// maxSegments is the longest template. Match never splits a path further,
+	// since no template can tell paths apart beyond that point.
+	maxSegments int
+}
+
+// Shadow describes a template that can never match, because a template before
+// it already matches every path it would.
+type Shadow struct {
+	Index      int
+	Template   string
+	ByIndex    int
+	ByTemplate string
+}
+
+// Compile turns templates into a Matcher, keeping the order given. The list
+// needs at least one entry and at most MaxTemplates, and every bad template is
+// reported in one error.
+//
+// Two templates that match the same set of paths are rejected as duplicates,
+// even when they differ in placeholder names, because the second could never
+// match. A broad template hiding a narrower one is not a duplicate. See
+// Matcher.Shadowed for that.
+//
+// Compile either fails or keeps every entry at the index it was given, so a
+// successful Matcher holds exactly the configured list. Callers rely on that to
+// check an "onMiss" value against the templates, and to work out which
+// templates a reload removed.
+func Compile(templates []string) (*Matcher, error) {
+	if len(templates) == 0 {
+		return nil, errors.New("no templates configured")
+	}
+	if len(templates) > MaxTemplates {
+		return nil, fmt.Errorf("%d templates configured, at most %d are supported", len(templates), MaxTemplates)
+	}
+
+	m := &Matcher{templates: make([]template, 0, len(templates))}
+	firstSeen := make(map[string]int, len(templates))
+	var errs []error
+
+	for i, raw := range templates {
+		t, err := compileTemplate(raw)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("templates[%d] (%q): %w", i, raw, err))
+			continue
+		}
+		key := t.matchSet()
+		if j, dup := firstSeen[key]; dup {
+			errs = append(errs, fmt.Errorf("templates[%d] (%q): matches the same paths as templates[%d] (%q)", i, raw, j, templates[j]))
+			continue
+		}
+		firstSeen[key] = i
+		m.templates = append(m.templates, t)
+		if len(t.segments) > m.maxSegments {
+			m.maxSegments = len(t.segments)
+		}
+	}
+
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+	return m, nil
+}
+
+// Match returns the first template that matches path, in configured order, and
+// whether one matched. The string returned is the template, placeholders and
+// all.
+//
+// Pass url.URL.EscapedPath, not url.URL.Path. url.Parse percent-decodes Path,
+// so an encoded "/" becomes a real separator and a request can split a path
+// where the operator never meant it to. EscapedPath is not the raw bytes off
+// the wire either, it re-encodes anything not already valid in a path, so a
+// segment holding a "{" arrives as "%7B" and the template has to spell it the
+// same way.
+//
+// Match does no other clean-up. Envoy normalizes the path before Hubble records
+// it, unless http-normalize-path is turned off.
+//
+// A nil Matcher matches nothing.
+func (m *Matcher) Match(path string) (string, bool) {
+	if m == nil {
+		return "", false
+	}
+
+	// Split at most maxSegments+1 times. No template looks past segment
+	// maxSegments-1, so splitting further cannot change the answer, and a path
+	// with thousands of segments costs the same as a short one. Splitting all of
+	// it would let the client set how much work a match takes.
+	limit := m.maxSegments + 1
+	var buf [maxStackSegments]string
+	var segments []string
+	if limit <= maxStackSegments {
+		segments = buf[:0]
+	} else {
+		segments = make([]string, 0, limit)
+	}
+
+	rest := path
+	for len(segments) < limit-1 {
+		i := strings.IndexByte(rest, '/')
+		if i < 0 {
+			break
+		}
+		segments = append(segments, rest[:i])
+		rest = rest[i+1:]
+	}
+	segments = append(segments, rest)
+
+	// complete says whether segments holds the whole path. If not, the last
+	// element is the unsplit remainder and the path has more segments than any
+	// template can tell apart.
+	complete := len(segments) < limit
+
+	for i := range m.templates {
+		if m.templates[i].match(segments, complete) {
+			return m.templates[i].raw, true
+		}
+	}
+	return "", false
+}
+
+func (m *Matcher) Len() int {
+	if m == nil {
+		return 0
+	}
+	return len(m.templates)
+}
+
+// Shadowed returns the templates that can never match, because an earlier
+// template already matches every path they would. Compile accepts these, since
+// the order is the operator's to choose, but it nearly always means the list is
+// in the wrong order, and a hit-or-miss counter will not show it because the
+// earlier template keeps matching.
+//
+// The list is not exhaustive. A template hidden only by several earlier
+// templates put together is not reported.
+func (m *Matcher) Shadowed() []Shadow {
+	if m == nil {
+		return nil
+	}
+	var shadows []Shadow
+	for i := range m.templates {
+		for j := range i {
+			if m.templates[j].covers(&m.templates[i]) {
+				shadows = append(shadows, Shadow{
+					Index:      i,
+					Template:   m.templates[i].raw,
+					ByIndex:    j,
+					ByTemplate: m.templates[j].raw,
+				})
+				break
+			}
+		}
+	}
+	return shadows
+}
+
+// match reports whether the template matches a path already split on "/".
+// complete says whether path holds every segment. If not, path holds
+// maxSegments+1 elements and the last one is the unsplit remainder.
+func (t *template) match(path []string, complete bool) bool {
+	if t.hasTail {
+		// The tail takes whatever is left and may be empty, so
+		// "/static/{rest...}" matches "/static/" but not "/static". A path that
+		// was not fully split always has more segments than any template.
+		if complete && len(path) < len(t.segments) {
+			return false
+		}
+	} else if !complete || len(path) != len(t.segments) {
+		return false
+	}
+
+	for i, seg := range t.segments {
+		switch seg.kind {
+		case segmentTail:
+			return true
+		case segmentSingle:
+			if path[i] == "" {
+				return false
+			}
+		case segmentLiteral:
+			if path[i] != seg.literal {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// covers reports whether every path u matches is also matched by t.
+func (t *template) covers(u *template) bool {
+	if t.hasTail {
+		// t matches any path of at least len(t.segments) segments, and the
+		// shortest path u matches has len(u.segments).
+		if len(u.segments) < len(t.segments) {
+			return false
+		}
+	} else if u.hasTail || len(u.segments) != len(t.segments) {
+		// Without a tail t matches one path length only, so it cannot cover a
+		// tail, which matches many.
+		return false
+	}
+
+	for i, seg := range t.segments {
+		if seg.kind == segmentTail {
+			return true
+		}
+		if !seg.covers(u.segments[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// covers reports whether every value s matches is also matched by seg.
+func (seg segment) covers(s segment) bool {
+	switch seg.kind {
+	case segmentLiteral:
+		return s.kind == segmentLiteral && s.literal == seg.literal
+	case segmentSingle:
+		// A placeholder needs a non-empty segment, so it covers any literal but
+		// the empty one.
+		return s.kind == segmentSingle || (s.kind == segmentLiteral && s.literal != "")
+	}
+	return false
+}
+
+// matchSet returns the template with placeholder names stripped, so two
+// templates matching the same paths share a key. A literal segment can never
+// hold a brace, so it cannot collide with a stripped placeholder.
+func (t *template) matchSet() string {
+	var b strings.Builder
+	b.Grow(len(t.raw))
+	for i, seg := range t.segments {
+		if i > 0 {
+			b.WriteByte('/')
+		}
+		switch seg.kind {
+		case segmentLiteral:
+			b.WriteString(seg.literal)
+		case segmentSingle:
+			b.WriteString("{}")
+		case segmentTail:
+			b.WriteString("{...}")
+		}
+	}
+	return b.String()
+}
+
+func compileTemplate(raw string) (template, error) {
+	if raw == "" {
+		return template{}, errors.New("template is empty")
+	}
+	// Paths come from a parsed URL and always start with "/".
+	if raw[0] != '/' {
+		return template{}, errors.New("template must start with '/'")
+	}
+
+	parts := strings.Split(raw, "/")
+	segments := make([]segment, len(parts))
+	for i, part := range parts {
+		seg, err := compileSegment(part)
+		if err != nil {
+			return template{}, fmt.Errorf("segment %d (%q): %w", i, part, err)
+		}
+		if seg.kind == segmentTail && i != len(parts)-1 {
+			return template{}, fmt.Errorf("segment %d (%q): a %q placeholder must be last", i, part, "{name...}")
+		}
+		segments[i] = seg
+	}
+
+	return template{
+		raw:      raw,
+		segments: segments,
+		hasTail:  segments[len(segments)-1].kind == segmentTail,
+	}, nil
+}
+
+func compileSegment(s string) (segment, error) {
+	if !strings.ContainsAny(s, "{}") {
+		return segment{kind: segmentLiteral, literal: s}, nil
+	}
+
+	name, ok := strings.CutPrefix(s, "{")
+	if !ok {
+		return segment{}, errors.New("a placeholder must span a whole segment")
+	}
+	name, ok = strings.CutSuffix(name, "}")
+	if !ok {
+		return segment{}, errors.New("a placeholder must span a whole segment")
+	}
+
+	// ":" is kept free for a future "{name:pattern}". Checked before the braces
+	// below so that a pattern holding braces reports the reserved syntax rather
+	// than a malformed segment.
+	if strings.Contains(name, ":") {
+		return segment{}, errors.New("patterns in placeholders are not supported")
+	}
+	if strings.ContainsAny(name, "{}") {
+		return segment{}, errors.New("a placeholder must span a whole segment")
+	}
+
+	kind := segmentSingle
+	if rest, isTail := strings.CutSuffix(name, "..."); isTail {
+		name = rest
+		kind = segmentTail
+	}
+
+	if !validPlaceholderName(name) {
+		return segment{}, fmt.Errorf("invalid placeholder name %q, expected [A-Za-z_][A-Za-z0-9_]*", name)
+	}
+
+	return segment{kind: kind}, nil
+}
+
+func validPlaceholderName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i := range len(name) {
+		c := name[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c == '_':
+		case i > 0 && c >= '0' && c <= '9':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/hubble/metrics/pathtemplate/pathtemplate_norace_test.go
+++ b/pkg/hubble/metrics/pathtemplate/pathtemplate_norace_test.go
@@ -7,6 +7,7 @@ package pathtemplate
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 
@@ -17,14 +18,28 @@ import (
 // TestMatchDoesNotAllocate checks that the split buffer stays on the stack.
 // Match runs once per HTTP flow, so one allocation here is one per request in
 // the agent. Skipped under -race, which allocates on its own.
+//
+// The deepest template sizes the buffer, so the config is varied along with the
+// path. Testing shallow configs alone missed a deep template pushing every
+// match onto the heap, short paths included.
 func TestMatchDoesNotAllocate(t *testing.T) {
-	templates := make([]string, 0, MaxTemplates)
+	full := make([]string, 0, MaxTemplates)
 	for i := range MaxTemplates {
-		templates = append(templates, fmt.Sprintf("/route/%d/items/{id}", i))
+		full = append(full, fmt.Sprintf("/route/%d/items/{id}", i))
 	}
-	templates[MaxTemplates-1] = "/static/{rest...}"
-	m, err := Compile(templates)
-	require.NoError(t, err)
+	full[MaxTemplates-1] = "/static/{rest...}"
+
+	atCap := "/" + strings.Repeat("seg/", MaxTemplateSegments-2) + "{id}"
+
+	configs := []struct {
+		name      string
+		templates []string
+	}{
+		{"shallow templates", full},
+		{"full list holding a template at the segment cap",
+			append(slices.Clone(full[:MaxTemplates-1]), atCap)},
+		{"one template at the segment cap", []string{atCap}},
+	}
 
 	paths := []string{
 		"/route/0/items/abc",
@@ -32,13 +47,21 @@ func TestMatchDoesNotAllocate(t *testing.T) {
 		"/healthz",
 		"/static/css/site.css",
 		"/static/" + strings.Repeat("a/", 64) + "site.css",
+		"/" + strings.Repeat("seg/", MaxTemplateSegments-2) + "abc",
 		strings.Repeat("/", 4000),
 	}
 
-	for _, path := range paths {
-		got := testing.AllocsPerRun(100, func() {
-			m.Match(path)
+	for _, cfg := range configs {
+		t.Run(cfg.name, func(t *testing.T) {
+			m, err := Compile(cfg.templates)
+			require.NoError(t, err)
+
+			for _, path := range paths {
+				got := testing.AllocsPerRun(100, func() {
+					m.Match(path)
+				})
+				assert.Zerof(t, got, "Match(%.32q) allocated", path)
+			}
 		})
-		assert.Zerof(t, got, "Match(%.32q) allocated", path)
 	}
 }

--- a/pkg/hubble/metrics/pathtemplate/pathtemplate_norace_test.go
+++ b/pkg/hubble/metrics/pathtemplate/pathtemplate_norace_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+//go:build !race
+
+package pathtemplate
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMatchDoesNotAllocate checks that the split buffer stays on the stack.
+// Match runs once per HTTP flow, so one allocation here is one per request in
+// the agent. Skipped under -race, which allocates on its own.
+func TestMatchDoesNotAllocate(t *testing.T) {
+	templates := make([]string, 0, MaxTemplates)
+	for i := range MaxTemplates {
+		templates = append(templates, fmt.Sprintf("/route/%d/items/{id}", i))
+	}
+	templates[MaxTemplates-1] = "/static/{rest...}"
+	m, err := Compile(templates)
+	require.NoError(t, err)
+
+	paths := []string{
+		"/route/0/items/abc",
+		"/route/50/items/abc",
+		"/healthz",
+		"/static/css/site.css",
+		"/static/" + strings.Repeat("a/", 64) + "site.css",
+		strings.Repeat("/", 4000),
+	}
+
+	for _, path := range paths {
+		got := testing.AllocsPerRun(100, func() {
+			m.Match(path)
+		})
+		assert.Zerof(t, got, "Match(%.32q) allocated", path)
+	}
+}

--- a/pkg/hubble/metrics/pathtemplate/pathtemplate_test.go
+++ b/pkg/hubble/metrics/pathtemplate/pathtemplate_test.go
@@ -77,6 +77,10 @@ func TestCompileErrors(t *testing.T) {
 		// ":" is checked before the braces the pattern holds, so the error
 		// names the real problem.
 		{"pattern holding braces", []string{"/users/{id:[0-9]{2}}"}, "patterns in placeholders are not supported"},
+		// One segment past the cap. The cap is what keeps Match's split buffer
+		// on the stack, and TestMatch covers a template sitting exactly on it.
+		{"template past the segment cap", []string{"/" + strings.Repeat("seg/", MaxTemplateSegments-1) + "{id}"},
+			fmt.Sprintf("template has %d segments, at most %d are supported", MaxTemplateSegments+1, MaxTemplateSegments)},
 		{"duplicate", []string{"/users/{id}", "/users/{id}"}, "matches the same paths as templates[0]"},
 		{"duplicate but for the name", []string{"/users/{id}", "/users/{user}"}, "matches the same paths as templates[0]"},
 		{"duplicate tail but for the name", []string{"/s/{rest...}", "/s/{other...}"}, "matches the same paths as templates[0]"},
@@ -380,29 +384,30 @@ func TestMatch(t *testing.T) {
 			want:      "/{rest...}",
 		},
 		{
-			// maxStackSegments-1 segments is the longest template that still
-			// splits into the stack buffer, and it fills it exactly.
-			name:      "template filling the stack buffer",
-			templates: []string{"/" + strings.Repeat("seg/", maxStackSegments-3) + "{id}"},
-			path:      "/" + strings.Repeat("seg/", maxStackSegments-3) + "abc",
-			want:      "/" + strings.Repeat("seg/", maxStackSegments-3) + "{id}",
+			// MaxTemplateSegments-2 repeats plus the leading empty segment and
+			// the placeholder is a template right at the cap, which fills the
+			// split buffer exactly.
+			name:      "template at the segment cap",
+			templates: []string{"/" + strings.Repeat("seg/", MaxTemplateSegments-2) + "{id}"},
+			path:      "/" + strings.Repeat("seg/", MaxTemplateSegments-2) + "abc",
+			want:      "/" + strings.Repeat("seg/", MaxTemplateSegments-2) + "{id}",
 		},
 		{
-			name:      "template one segment past the stack buffer",
-			templates: []string{"/" + strings.Repeat("seg/", maxStackSegments-2) + "{id}"},
-			path:      "/" + strings.Repeat("seg/", maxStackSegments-2) + "abc",
-			want:      "/" + strings.Repeat("seg/", maxStackSegments-2) + "{id}",
+			name:      "template one segment under the cap",
+			templates: []string{"/" + strings.Repeat("seg/", MaxTemplateSegments-3) + "{id}"},
+			path:      "/" + strings.Repeat("seg/", MaxTemplateSegments-3) + "abc",
+			want:      "/" + strings.Repeat("seg/", MaxTemplateSegments-3) + "{id}",
 		},
 		{
-			name:      "template deeper than the stack buffer",
-			templates: []string{"/" + strings.Repeat("seg/", maxStackSegments+4) + "{id}"},
-			path:      "/" + strings.Repeat("seg/", maxStackSegments+4) + "abc",
-			want:      "/" + strings.Repeat("seg/", maxStackSegments+4) + "{id}",
+			name:      "template at the cap against a path one segment short",
+			templates: []string{"/" + strings.Repeat("seg/", MaxTemplateSegments-2) + "{id}"},
+			path:      "/" + strings.Repeat("seg/", MaxTemplateSegments-2),
+			want:      "",
 		},
 		{
-			name:      "deep template against a path one segment short",
-			templates: []string{"/" + strings.Repeat("seg/", maxStackSegments+4) + "{id}"},
-			path:      "/" + strings.Repeat("seg/", maxStackSegments+4),
+			name:      "template at the cap against a deeper path",
+			templates: []string{"/" + strings.Repeat("seg/", MaxTemplateSegments-2) + "{id}"},
+			path:      "/" + strings.Repeat("seg/", MaxTemplateSegments+8) + "abc",
 			want:      "",
 		},
 	}

--- a/pkg/hubble/metrics/pathtemplate/pathtemplate_test.go
+++ b/pkg/hubble/metrics/pathtemplate/pathtemplate_test.go
@@ -1,0 +1,640 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package pathtemplate
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompileValid(t *testing.T) {
+	tests := []struct {
+		name      string
+		templates []string
+	}{
+		{"root", []string{"/"}},
+		{"literal", []string{"/api/v1/users"}},
+		{"placeholder", []string{"/api/v1/users/{id}"}},
+		{"several placeholders", []string{"/api/v1/users/{userID}/orders/{orderID}"}},
+		{"tail", []string{"/static/{rest...}"}},
+		{"tail only", []string{"/{rest...}"}},
+		{"trailing slash", []string{"/api/v1/users/"}},
+		{"name with underscore", []string{"/api/{_id}"}},
+		{"name with digits", []string{"/api/{id2}"}},
+		{"percent encoded literal", []string{"/reports/my%20report"}},
+		{"escaped braces are a literal", []string{"/api/%7Blegacy%7D"}},
+		{"dot segments", []string{"/a/../b"}},
+		{"several templates", []string{"/a", "/a/{id}", "/a/{id}/b", "/{rest...}"}},
+		// Nothing is captured, so unlike net/http.ServeMux a name may repeat.
+		{"repeated placeholder name", []string{"/users/{id}/orders/{id}"}},
+		// Only templates matching the same set of paths are duplicates.
+		{"placeholder and tail", []string{"/a/{x}", "/a/{x...}"}},
+		{"placeholder and empty segment", []string{"/a/{x}", "/a/"}},
+		{"same shape, different literals", []string{"/a/{x}", "/b/{x}"}},
+		{"same shape, different depths", []string{"/a/{x}", "/a/{x}/{y}"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := Compile(tt.templates)
+			require.NoError(t, err)
+			require.Equal(t, len(tt.templates), m.Len())
+		})
+	}
+}
+
+func TestCompileErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		templates []string
+		wantErr   string
+	}{
+		{"empty list", nil, "no templates configured"},
+		{"empty template", []string{""}, "template is empty"},
+		{"no leading slash", []string{"api/v1"}, "template must start with '/'"},
+		{"placeholder after a literal", []string{"/b_{bucket}"}, "must span a whole segment"},
+		{"placeholder before a literal", []string{"/{bucket}_b"}, "must span a whole segment"},
+		{"two placeholders in a segment", []string{"/{a}{b}"}, "must span a whole segment"},
+		{"unclosed placeholder", []string{"/{id"}, "must span a whole segment"},
+		{"unopened placeholder", []string{"/id}"}, "must span a whole segment"},
+		{"nested braces", []string{"/{{id}}"}, "must span a whole segment"},
+		{"tail not last", []string{"/static/{rest...}/more"}, "must be last"},
+		{"tail before an empty segment", []string{"/static/{rest...}/"}, "must be last"},
+		{"empty name", []string{"/{}"}, "invalid placeholder name"},
+		{"empty tail name", []string{"/{...}"}, "invalid placeholder name"},
+		{"name starting with a digit", []string{"/{1id}"}, "invalid placeholder name"},
+		{"name with a hyphen", []string{"/{user-id}"}, "invalid placeholder name"},
+		{"name with a dot", []string{"/{user.id}"}, "invalid placeholder name"},
+		{"non-ascii name", []string{"/{идентификатор}"}, "invalid placeholder name"},
+		{"pattern in a placeholder", []string{"/users/{id:[0-9]+}"}, "patterns in placeholders are not supported"},
+		{"pattern in a tail", []string{"/users/{id:.*...}"}, "patterns in placeholders are not supported"},
+		// ":" is checked before the braces the pattern holds, so the error
+		// names the real problem.
+		{"pattern holding braces", []string{"/users/{id:[0-9]{2}}"}, "patterns in placeholders are not supported"},
+		{"duplicate", []string{"/users/{id}", "/users/{id}"}, "matches the same paths as templates[0]"},
+		{"duplicate but for the name", []string{"/users/{id}", "/users/{user}"}, "matches the same paths as templates[0]"},
+		{"duplicate tail but for the name", []string{"/s/{rest...}", "/s/{other...}"}, "matches the same paths as templates[0]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := Compile(tt.templates)
+			require.ErrorContains(t, err, tt.wantErr)
+			require.Nil(t, m)
+		})
+	}
+}
+
+func TestCompileReportsEveryError(t *testing.T) {
+	_, err := Compile([]string{"/ok", "/b_{bucket}", "/{1id}", "/ok"})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, `templates[1] ("/b_{bucket}")`)
+	assert.ErrorContains(t, err, `templates[2] ("/{1id}")`)
+	assert.ErrorContains(t, err, `templates[3] ("/ok")`)
+}
+
+func TestCompileTemplateLimit(t *testing.T) {
+	templates := make([]string, 0, MaxTemplates+1)
+	for i := range MaxTemplates + 1 {
+		templates = append(templates, fmt.Sprintf("/route/%d", i))
+	}
+
+	m, err := Compile(templates[:MaxTemplates])
+	require.NoError(t, err)
+	require.Equal(t, MaxTemplates, m.Len())
+
+	_, err = Compile(templates)
+	require.ErrorContains(t, err, "101 templates configured, at most 100 are supported")
+}
+
+func TestMatch(t *testing.T) {
+	tests := []struct {
+		name      string
+		templates []string
+		path      string
+		want      string
+	}{
+		{
+			name:      "declaration order beats specificity",
+			templates: []string{"/api/{rest...}", "/api/v1/users"},
+			path:      "/api/v1/users",
+			want:      "/api/{rest...}",
+		},
+		{
+			name:      "reordered, the specific template wins",
+			templates: []string{"/api/v1/users", "/api/{rest...}"},
+			path:      "/api/v1/users",
+			want:      "/api/v1/users",
+		},
+		{
+			name:      "a shadowing template still matches other paths",
+			templates: []string{"/api/v1/users", "/api/{rest...}"},
+			path:      "/api/v2/users",
+			want:      "/api/{rest...}",
+		},
+		{
+			name:      "path longer than the template",
+			templates: []string{"/api/v1"},
+			path:      "/api/v1/users",
+			want:      "",
+		},
+		{
+			name:      "path shorter than the template",
+			templates: []string{"/api/v1/users"},
+			path:      "/api/v1",
+			want:      "",
+		},
+		{
+			name:      "trailing slash on the path",
+			templates: []string{"/api/v1/users"},
+			path:      "/api/v1/users/",
+			want:      "",
+		},
+		{
+			name:      "trailing slash on the template",
+			templates: []string{"/api/v1/users/"},
+			path:      "/api/v1/users",
+			want:      "",
+		},
+		{
+			name:      "trailing slash on both",
+			templates: []string{"/api/v1/users/"},
+			path:      "/api/v1/users/",
+			want:      "/api/v1/users/",
+		},
+		{
+			name:      "root",
+			templates: []string{"/"},
+			path:      "/",
+			want:      "/",
+		},
+		{
+			name:      "root against a deeper path",
+			templates: []string{"/"},
+			path:      "/api",
+			want:      "",
+		},
+		{
+			name:      "placeholder takes one segment",
+			templates: []string{"/api/v1/users/{id}"},
+			path:      "/api/v1/users/abc",
+			want:      "/api/v1/users/{id}",
+		},
+		{
+			name:      "another value collapses onto the same template",
+			templates: []string{"/api/v1/users/{id}"},
+			path:      "/api/v1/users/xyz",
+			want:      "/api/v1/users/{id}",
+		},
+		{
+			name:      "placeholder against an empty segment",
+			templates: []string{"/api/v1/users/{id}"},
+			path:      "/api/v1/users/",
+			want:      "",
+		},
+		{
+			name:      "placeholder against a missing segment",
+			templates: []string{"/api/v1/users/{id}"},
+			path:      "/api/v1/users",
+			want:      "",
+		},
+		{
+			name:      "placeholder against two segments",
+			templates: []string{"/api/v1/users/{id}"},
+			path:      "/api/v1/users/abc/orders",
+			want:      "",
+		},
+		{
+			name:      "placeholder mid-template",
+			templates: []string{"/api/v1/users/{id}/orders"},
+			path:      "/api/v1/users/abc/orders",
+			want:      "/api/v1/users/{id}/orders",
+		},
+		{
+			name:      "tail takes several segments",
+			templates: []string{"/static/{rest...}"},
+			path:      "/static/css/site.css",
+			want:      "/static/{rest...}",
+		},
+		{
+			name:      "tail takes one segment",
+			templates: []string{"/static/{rest...}"},
+			path:      "/static/site.css",
+			want:      "/static/{rest...}",
+		},
+		{
+			name:      "tail takes an empty segment",
+			templates: []string{"/static/{rest...}"},
+			path:      "/static/",
+			want:      "/static/{rest...}",
+		},
+		{
+			name:      "tail has nothing to take",
+			templates: []string{"/static/{rest...}"},
+			path:      "/static",
+			want:      "",
+		},
+		{
+			name:      "catch-all tail",
+			templates: []string{"/{rest...}"},
+			path:      "/anything/at/all",
+			want:      "/{rest...}",
+		},
+		{
+			name:      "catch-all tail on the root",
+			templates: []string{"/{rest...}"},
+			path:      "/",
+			want:      "/{rest...}",
+		},
+
+		// These describe the matcher on its own. Envoy normalizes the path
+		// before Hubble records it, unless http-normalize-path is turned off,
+		// so they are not promises about what happens end to end.
+		{
+			name:      "escaped space against an escaped space",
+			templates: []string{"/reports/my%20report"},
+			path:      "/reports/my%20report",
+			want:      "/reports/my%20report",
+		},
+		{
+			name:      "escaped space against a decoded space",
+			templates: []string{"/reports/my report"},
+			path:      "/reports/my%20report",
+			want:      "",
+		},
+		{
+			name:      "decoded space against an escaped space",
+			templates: []string{"/reports/my%20report"},
+			path:      "/reports/my report",
+			want:      "",
+		},
+		{
+			name:      "escaped slash stays inside a segment",
+			templates: []string{"/api/v1/{user}/orders"},
+			path:      "/api/v1/users%2Fadmin/orders",
+			want:      "/api/v1/{user}/orders",
+		},
+		{
+			name:      "escaped slash does not add a segment",
+			templates: []string{"/api/v1/users/{id}/orders"},
+			path:      "/api/v1/users%2Fadmin/orders",
+			want:      "",
+		},
+		{
+			name:      "escaped dot segments are not dot segments",
+			templates: []string{"/a/b"},
+			path:      "/a/%2e%2e/a/b",
+			want:      "",
+		},
+		{
+			name:      "dot segments are literals",
+			templates: []string{"/a/../b"},
+			path:      "/a/../b",
+			want:      "/a/../b",
+		},
+		{
+			name:      "dot segments are not resolved",
+			templates: []string{"/b"},
+			path:      "/a/../b",
+			want:      "",
+		},
+		{
+			name:      "duplicate slashes are not merged",
+			templates: []string{"/a/b"},
+			path:      "//a//b",
+			want:      "",
+		},
+		{
+			name:      "escaped non-ascii segment",
+			templates: []string{"/caf%C3%A9/detail"},
+			path:      "/caf%C3%A9/detail",
+			want:      "/caf%C3%A9/detail",
+		},
+		{
+			name:      "matching is case sensitive",
+			templates: []string{"/api/v1/Users"},
+			path:      "/api/v1/users",
+			want:      "",
+		},
+		{
+			name:      "empty path",
+			templates: []string{"/api/v1/users/{id}"},
+			path:      "",
+			want:      "",
+		},
+		{
+			name:      "relative path",
+			templates: []string{"/api/v1/users/{id}"},
+			path:      "api/v1/users/abc",
+			want:      "",
+		},
+		{
+			name:      "no template matches",
+			templates: []string{"/api/v1/users/{id}", "/api/v1/orders/{id}"},
+			path:      "/healthz",
+			want:      "",
+		},
+
+		// Match only splits as far as the longest template can tell paths
+		// apart. These run past that point.
+		{
+			name:      "path deeper than every template",
+			templates: []string{"/api/v1/users/{id}", "/healthz"},
+			path:      "/api/v1/users/abc/orders/1/items/2/detail",
+			want:      "",
+		},
+		{
+			name:      "tail takes a path deeper than every template",
+			templates: []string{"/api/v1/users/{id}", "/api/{rest...}"},
+			path:      "/api/v1/users/abc/orders/1/items/2/detail",
+			want:      "/api/{rest...}",
+		},
+		{
+			name:      "path one segment past the deepest template",
+			templates: []string{"/a/{x}"},
+			path:      "/a/b/c",
+			want:      "",
+		},
+		{
+			name:      "deep path against a shallow tail",
+			templates: []string{"/static/{rest...}"},
+			path:      "/static/" + strings.Repeat("a/", 64) + "site.css",
+			want:      "/static/{rest...}",
+		},
+		{
+			name:      "slash flood",
+			templates: []string{"/api/v1/users/{id}", "/healthz"},
+			path:      strings.Repeat("/", 4000),
+			want:      "",
+		},
+		{
+			name:      "slash flood against a tail",
+			templates: []string{"/{rest...}"},
+			path:      strings.Repeat("/", 4000),
+			want:      "/{rest...}",
+		},
+		{
+			// maxStackSegments-1 segments is the longest template that still
+			// splits into the stack buffer, and it fills it exactly.
+			name:      "template filling the stack buffer",
+			templates: []string{"/" + strings.Repeat("seg/", maxStackSegments-3) + "{id}"},
+			path:      "/" + strings.Repeat("seg/", maxStackSegments-3) + "abc",
+			want:      "/" + strings.Repeat("seg/", maxStackSegments-3) + "{id}",
+		},
+		{
+			name:      "template one segment past the stack buffer",
+			templates: []string{"/" + strings.Repeat("seg/", maxStackSegments-2) + "{id}"},
+			path:      "/" + strings.Repeat("seg/", maxStackSegments-2) + "abc",
+			want:      "/" + strings.Repeat("seg/", maxStackSegments-2) + "{id}",
+		},
+		{
+			name:      "template deeper than the stack buffer",
+			templates: []string{"/" + strings.Repeat("seg/", maxStackSegments+4) + "{id}"},
+			path:      "/" + strings.Repeat("seg/", maxStackSegments+4) + "abc",
+			want:      "/" + strings.Repeat("seg/", maxStackSegments+4) + "{id}",
+		},
+		{
+			name:      "deep template against a path one segment short",
+			templates: []string{"/" + strings.Repeat("seg/", maxStackSegments+4) + "{id}"},
+			path:      "/" + strings.Repeat("seg/", maxStackSegments+4),
+			want:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := Compile(tt.templates)
+			require.NoError(t, err)
+
+			got, ok := m.Match(tt.path)
+			assert.Equal(t, tt.want != "", ok)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestMatchReturnsConfiguredValues is the cardinality limit written as a test.
+func TestMatchReturnsConfiguredValues(t *testing.T) {
+	templates := []string{"/api/v1/users/{id}", "/api/v1/users/{id}/orders/{orderID}", "/static/{rest...}"}
+	m, err := Compile(templates)
+	require.NoError(t, err)
+
+	paths := []string{
+		"/api/v1/users/abc",
+		"/api/v1/users/xyz",
+		"/api/v1/users/abc/orders/1",
+		"/static/css/site.css",
+		"/static/",
+	}
+	for _, path := range paths {
+		got, ok := m.Match(path)
+		require.Truef(t, ok, "expected %q to match", path)
+		assert.Containsf(t, templates, got, "%q produced an unconfigured label value", path)
+	}
+}
+
+func TestNilMatcher(t *testing.T) {
+	var m *Matcher
+	got, ok := m.Match("/api/v1/users/abc")
+	assert.False(t, ok)
+	assert.Empty(t, got)
+	assert.Equal(t, 0, m.Len())
+	assert.Empty(t, m.Shadowed())
+}
+
+func TestShadowed(t *testing.T) {
+	tests := []struct {
+		name      string
+		templates []string
+		want      []Shadow
+	}{
+		{
+			name:      "a tail shadows everything below it",
+			templates: []string{"/api/{rest...}", "/api/v1/users", "/api/v1/users/{id}"},
+			want: []Shadow{
+				{Index: 1, Template: "/api/v1/users", ByIndex: 0, ByTemplate: "/api/{rest...}"},
+				{Index: 2, Template: "/api/v1/users/{id}", ByIndex: 0, ByTemplate: "/api/{rest...}"},
+			},
+		},
+		{
+			name:      "a catch-all shadows the whole list",
+			templates: []string{"/{rest...}", "/healthz"},
+			want:      []Shadow{{Index: 1, Template: "/healthz", ByIndex: 0, ByTemplate: "/{rest...}"}},
+		},
+		{
+			name:      "a placeholder shadows a literal at the same depth",
+			templates: []string{"/users/{id}", "/users/me"},
+			want:      []Shadow{{Index: 1, Template: "/users/me", ByIndex: 0, ByTemplate: "/users/{id}"}},
+		},
+		{
+			name:      "the shadowing template is reported, not the first template",
+			templates: []string{"/healthz", "/users/{id}", "/users/me"},
+			want:      []Shadow{{Index: 2, Template: "/users/me", ByIndex: 1, ByTemplate: "/users/{id}"}},
+		},
+		{
+			name:      "ordered narrowest first, nothing is shadowed",
+			templates: []string{"/api/v1/users", "/api/v1/users/{id}", "/api/{rest...}"},
+		},
+		{
+			name:      "a literal does not shadow a placeholder",
+			templates: []string{"/users/me", "/users/{id}"},
+		},
+		{
+			name:      "a placeholder does not shadow an empty segment",
+			templates: []string{"/users/{id}", "/users/"},
+		},
+		{
+			name:      "a placeholder does not shadow a tail",
+			templates: []string{"/static/{one}", "/static/{rest...}"},
+		},
+		{
+			name:      "a shallower tail does not shadow a deeper one",
+			templates: []string{"/a/{rest...}", "/a/b/{rest...}"},
+			want:      []Shadow{{Index: 1, Template: "/a/b/{rest...}", ByIndex: 0, ByTemplate: "/a/{rest...}"}},
+		},
+		{
+			name:      "a deeper tail does not shadow a shallower one",
+			templates: []string{"/a/b/{rest...}", "/a/{rest...}"},
+		},
+		{
+			name:      "different literals never shadow",
+			templates: []string{"/a/{x}", "/b/{x}"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := Compile(tt.templates)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, m.Shadowed())
+		})
+	}
+}
+
+// TestShadowedAgreesWithMatch checks that a template reported as shadowed never
+// wins a match, whatever the path.
+func TestShadowedAgreesWithMatch(t *testing.T) {
+	templates := []string{
+		"/healthz", "/api/{rest...}", "/api/v1/users", "/api/v1/users/{id}",
+		"/users/{id}", "/users/me", "/static/{one}", "/static/{rest...}",
+	}
+	m, err := Compile(templates)
+	require.NoError(t, err)
+
+	shadowed := make(map[string]bool)
+	for _, s := range m.Shadowed() {
+		shadowed[s.Template] = true
+	}
+	require.NotEmpty(t, shadowed)
+
+	paths := []string{
+		"/", "/healthz", "/api", "/api/", "/api/v1", "/api/v1/users",
+		"/api/v1/users/", "/api/v1/users/abc", "/api/v1/users/abc/orders",
+		"/users", "/users/", "/users/me", "/users/abc", "/static",
+		"/static/", "/static/one", "/static/a/b/c",
+	}
+	for _, path := range paths {
+		if got, ok := m.Match(path); ok {
+			assert.Falsef(t, shadowed[got], "%q matched shadowed template %q", path, got)
+		}
+	}
+}
+
+// TestMatchConcurrent checks that a compiled Matcher is safe to use from
+// several goroutines. Run it under -race.
+func TestMatchConcurrent(t *testing.T) {
+	m, err := Compile([]string{"/api/v1/users/{id}", "/api/v1/users/{id}/orders", "/static/{rest...}"})
+	require.NoError(t, err)
+
+	paths := []string{"/api/v1/users/abc", "/api/v1/users/abc/orders", "/static/css/site.css", "/healthz"}
+	want := make([]string, len(paths))
+	for i, path := range paths {
+		want[i], _ = m.Match(path)
+	}
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Go(func() {
+			for range 1000 {
+				for i, path := range paths {
+					if got, _ := m.Match(path); got != want[i] {
+						assert.Equalf(t, want[i], got, "Match(%q) raced", path)
+						return
+					}
+				}
+			}
+		})
+	}
+	wg.Wait()
+}
+
+// BenchmarkMatch uses a full template list, since the matcher sits on the HTTP
+// metrics hot path.
+func BenchmarkMatch(b *testing.B) {
+	benchmarks := []struct {
+		name string
+		path string
+	}{
+		{"first template", "/route/0/items/abc"},
+		{"last template", fmt.Sprintf("/route/%d/items/abc", MaxTemplates-1)},
+		{"miss", "/healthz"},
+	}
+
+	templates := make([]string, 0, MaxTemplates)
+	for i := range MaxTemplates {
+		templates = append(templates, fmt.Sprintf("/route/%d/items/{id}", i))
+	}
+	m, err := Compile(templates)
+	require.NoError(b, err)
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				m.Match(bm.path)
+			}
+		})
+	}
+}
+
+func BenchmarkMatchDeepTail(b *testing.B) {
+	m, err := Compile([]string{"/static/{rest...}"})
+	require.NoError(b, err)
+
+	path := "/static/" + strings.Repeat("a/", 32) + "site.css"
+	b.ReportAllocs()
+	for b.Loop() {
+		m.Match(path)
+	}
+}
+
+// BenchmarkMatchLongPath keeps the cost of a match tied to the templates, not
+// to the request. The client picks the path, and Envoy allows request headers
+// up to 60 KiB by default.
+func BenchmarkMatchLongPath(b *testing.B) {
+	benchmarks := []struct {
+		name string
+		path string
+	}{
+		{"deep", "/" + strings.Repeat("a/", 2000)},
+		{"slash flood", strings.Repeat("/", 4000)},
+	}
+
+	m, err := Compile([]string{"/api/v1/users/{id}", "/api/v1/users/{id}/orders", "/healthz"})
+	require.NoError(b, err)
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				m.Match(bm.path)
+			}
+		})
+	}
+}

--- a/test/fuzzing/oss-fuzz-build.sh
+++ b/test/fuzzing/oss-fuzz-build.sh
@@ -32,6 +32,7 @@ compile_native_go_fuzzer github.com/cilium/cilium/pkg/container/bitlpm FuzzUint8
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/fqdn/matchpattern FuzzMatchpatternValidate FuzzMatchpatternValidate
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/fqdn/matchpattern FuzzMatchpatternValidateWithoutCache FuzzMatchpatternValidateWithoutCache
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/fqdn/namemanager FuzzMapSelectorsToNamesLocked FuzzMapSelectorsToNamesLocked
+compile_native_go_fuzzer github.com/cilium/cilium/pkg/hubble/metrics/pathtemplate FuzzCompileAndMatch FuzzCompileAndMatch
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/hubble/parser FuzzParserDecode FuzzParserDecode
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2 FuzzCiliumClusterwideNetworkPolicyParse FuzzCiliumClusterwideNetworkPolicyParse
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2 FuzzCiliumNetworkPolicyParse FuzzCiliumNetworkPolicyParse


### PR DESCRIPTION
First PR of the CFP-26521 stack. Adds `pkg/hubble/metrics/pathtemplate`, which matches an HTTP request path against templates from the config and returns the template that matched. Returning the template rather than the path is what bounds the cardinality of the `path` label that later PRs add to the Hubble HTTP metrics, and is what resolves the objection this issue was originally closed on.

Nothing is wired up yet, so there is no metric or behaviour change. Config plumbing, the handler, and Helm plus docs follow.

Per the CFP: `{name}` and `{name...}` placeholders as `net/http.ServeMux` accepts them, templates tried in configured order with the first match winning, and a cap of 100 templates.

Two notes for review:

- `Match` splits a path only as far as the longest template can distinguish.
  The path is client controlled and Cilium does not set
  `max_request_headers_kb`, so Envoy's 60 KiB default applies. A 4000 slash path
  costs 26ns and no allocations instead of 32us and 65KB.
- `Matcher.Shadowed()` has no caller yet. The watcher PR uses it to warn when an
  earlier template makes a later one unreachable, which a hit/miss counter
  cannot detect on its own.

AIL: 2

Related: #26521

```release-note
Add the internal path template matcher that later PRs use to emit a bounded `path` label on the Hubble HTTP metrics. No user-facing change on its own.
```

