### PR TITLE
wireguard: track peer AllowedIPs as netip.Prefix

### DIFF
--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cilium/cilium/pkg/counter"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
-	iputil "github.com/cilium/cilium/pkg/ip"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/labels"
@@ -955,15 +954,15 @@ func (ipc *IPCache) LookupByIdentity(id identity.NumericIdentity) (ips []string)
 // LookupByHostRLocked returns the list of IPs returns the set of IPs
 // (endpoint or CIDR prefix) that have hostIPv4 or hostIPv6 associated as the
 // host of the entry. Requires the caller to hold the RLock.
-func (ipc *IPCache) LookupByHostRLocked(hostIPv4, hostIPv6 net.IP) (cidrs []net.IPNet) {
+func (ipc *IPCache) LookupByHostRLocked(hostIPv4, hostIPv6 net.IP) (cidrs []netip.Prefix) {
 	for ip, host := range ipc.ipToHostIPCache {
 		if hostIPv4 != nil && host.IP.Equal(hostIPv4) || hostIPv6 != nil && host.IP.Equal(hostIPv6) {
-			_, cidr, err := net.ParseCIDR(ip)
-			if err != nil {
-				endpointIP := net.ParseIP(ip)
-				cidr = iputil.IPToPrefix(endpointIP)
+			if pc, err := cmtypes.ParsePrefixCluster(ip); err == nil {
+				cidrs = append(cidrs, pc.AsPrefix().Masked())
+			} else if ac, err := cmtypes.ParseAddrCluster(ip); err == nil {
+				addr := ac.Addr()
+				cidrs = append(cidrs, netip.PrefixFrom(addr, addr.BitLen()))
 			}
-			cidrs = append(cidrs, *cidr)
 		}
 	}
 	return cidrs

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -34,11 +34,13 @@ import (
 	"github.com/cilium/cilium/pkg/backoff"
 	"github.com/cilium/cilium/pkg/clustermesh"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/container/set"
 	"github.com/cilium/cilium/pkg/datapath/link"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/safenetlink"
 	"github.com/cilium/cilium/pkg/datapath/linux/sysctl"
 	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	iputil "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
 	k8sSynced "github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/lock"
@@ -457,8 +459,12 @@ func (a *Agent) restoreFinished() error {
 	for _, p := range dev.Peers {
 		if pc, ok := pubKeyToPeerConfig[p.PublicKey]; ok {
 			for _, ip := range p.AllowedIPs {
-				if !pc.hasAllowedIP(ip) {
-					pc.queueAllowedIPsRemove(ip)
+				pfx, ok := netipx.FromStdIPNet(&ip)
+				if !ok {
+					continue
+				}
+				if !pc.hasAllowedIP(pfx) {
+					pc.queueAllowedIPsRemove(pfx)
 				}
 			}
 			a.logger.Info(
@@ -540,35 +546,29 @@ func (a *Agent) updatePeer(nodeName, pubKeyHex string, nodeIPv4, nodeIPv6 net.IP
 	// Handle Node IP change
 	if peer.nodeIPv4 != nil && !peer.nodeIPv4.Equal(nodeIPv4) {
 		delete(a.nodeNameByNodeIP, peer.nodeIPv4.String())
-		peer.queueAllowedIPsRemove(net.IPNet{
-			IP:   peer.nodeIPv4,
-			Mask: net.CIDRMask(net.IPv4len*8, net.IPv4len*8),
-		})
+		if ip := iputil.IPToNetPrefix(peer.nodeIPv4); ip.IsValid() {
+			peer.queueAllowedIPsRemove(ip)
+		}
 	}
 	if peer.nodeIPv6 != nil && !peer.nodeIPv6.Equal(nodeIPv6) {
 		delete(a.nodeNameByNodeIP, peer.nodeIPv6.String())
-		peer.queueAllowedIPsRemove(net.IPNet{
-			IP:   peer.nodeIPv6,
-			Mask: net.CIDRMask(net.IPv6len*8, net.IPv6len*8),
-		})
+		if ip := iputil.IPToNetPrefix(peer.nodeIPv6); ip.IsValid() {
+			peer.queueAllowedIPsRemove(ip)
+		}
 	}
 
 	if a.config.EnableIPv4 && nodeIPv4 != nil {
-		ipn := net.IPNet{
-			IP:   nodeIPv4,
-			Mask: net.CIDRMask(net.IPv4len*8, net.IPv4len*8),
-		}
-		if !peer.hasAllowedIP(ipn) {
-			peer.queueAllowedIPsInsert(ipn)
+		if ipn := iputil.IPToNetPrefix(nodeIPv4); ipn.IsValid() {
+			if !peer.hasAllowedIP(ipn) {
+				peer.queueAllowedIPsInsert(ipn)
+			}
 		}
 	}
 	if a.config.EnableIPv6 && nodeIPv6 != nil {
-		ipn := net.IPNet{
-			IP:   nodeIPv6,
-			Mask: net.CIDRMask(net.IPv6len*8, net.IPv6len*8),
-		}
-		if !peer.hasAllowedIP(ipn) {
-			peer.queueAllowedIPsInsert(ipn)
+		if ipn := iputil.IPToNetPrefix(nodeIPv6); ipn.IsValid() {
+			if !peer.hasAllowedIP(ipn) {
+				peer.queueAllowedIPsInsert(ipn)
+			}
 		}
 	}
 
@@ -674,7 +674,7 @@ func (a *Agent) updatePeerByConfig(p *peerConfig) error {
 	peer := wgtypes.PeerConfig{
 		PublicKey:  p.pubKey,
 		Endpoint:   p.endpoint,
-		AllowedIPs: addedIPs,
+		AllowedIPs: prefixesToIPNets(addedIPs),
 	}
 	if a.config.WireguardPersistentKeepalive != 0 {
 		peer.PersistentKeepaliveInterval = &a.config.WireguardPersistentKeepalive
@@ -722,7 +722,7 @@ func (a *Agent) updatePeerByConfig(p *peerConfig) error {
 		cfg.Peers = []wgtypes.PeerConfig{
 			{
 				PublicKey:  wgDummyPeerKey,
-				AllowedIPs: removedIPs,
+				AllowedIPs: prefixesToIPNets(removedIPs),
 			},
 		}
 
@@ -778,7 +778,7 @@ func loadOrGeneratePrivKey(filePath string) (key wgtypes.Key, err error) {
 // OnIPIdentityCacheChange implements ipcache.IPIdentityMappingListener
 func (a *Agent) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidrCluster cmtypes.PrefixCluster, oldHostIP, newHostIP net.IP,
 	_ *ipcache.Identity, _ ipcache.Identity, _ uint8, _ *ipcache.K8sMetadata, _ uint8) {
-	ipnet := cidrCluster.AsIPNet()
+	prefix := cidrCluster.AsPrefix()
 
 	// This function is invoked from the IPCache with the
 	// ipcache.IPIdentityCache lock held. We therefore need to be careful when
@@ -811,8 +811,8 @@ func (a *Agent) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidrC
 	case modType == ipcache.Delete && oldHostIP != nil:
 		if nodeName, ok := a.nodeNameByNodeIP[oldHostIP.String()]; ok {
 			if peer := a.peerByNodeName[nodeName]; peer != nil {
-				if peer.hasAllowedIP(ipnet) {
-					peer.queueAllowedIPsRemove(ipnet)
+				if peer.hasAllowedIP(prefix) {
+					peer.queueAllowedIPsRemove(prefix)
 					updatedPeer = peer
 				}
 			}
@@ -820,8 +820,8 @@ func (a *Agent) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidrC
 	case modType == ipcache.Upsert && newHostIP != nil:
 		if nodeName, ok := a.nodeNameByNodeIP[newHostIP.String()]; ok {
 			if peer := a.peerByNodeName[nodeName]; peer != nil {
-				if !peer.hasAllowedIP(ipnet) {
-					peer.queueAllowedIPsInsert(ipnet)
+				if !peer.hasAllowedIP(prefix) {
+					peer.queueAllowedIPsInsert(prefix)
 					updatedPeer = peer
 				}
 			}
@@ -834,7 +834,7 @@ func (a *Agent) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidrC
 				"Failed to update WireGuard peer after ipcache update",
 				logfields.Error, err,
 				logfields.Modification, modType,
-				logfields.IPAddr, ipnet,
+				logfields.IPAddr, prefix.Addr(),
 				logfields.OldNode, oldHostIP,
 				logfields.NewNode, newHostIP,
 				logfields.PubKey, updatedPeer.pubKey,
@@ -934,36 +934,19 @@ type peerConfig struct {
 	pubKey             wgtypes.Key
 	endpoint           *net.UDPAddr
 	nodeIPv4, nodeIPv6 net.IP
-	allowedIPs         map[netip.Prefix]net.IPNet
-	needsInsert        map[netip.Prefix]net.IPNet
-	needsRemove        map[netip.Prefix]net.IPNet
-}
-
-func (p *peerConfig) lazyInitMaps() {
-	if p.allowedIPs == nil {
-		p.allowedIPs = map[netip.Prefix]net.IPNet{}
-	}
-
-	if p.needsInsert == nil {
-		p.needsInsert = map[netip.Prefix]net.IPNet{}
-	}
-
-	if p.needsRemove == nil {
-		p.needsRemove = map[netip.Prefix]net.IPNet{}
-	}
+	allowedIPs         set.Set[netip.Prefix]
+	needsInsert        set.Set[netip.Prefix]
+	needsRemove        set.Set[netip.Prefix]
 }
 
 // queueAllowedIPsInsert adds ip to the list of IPs that need to be inserted
 // during the next update to this peer. The update is queued regardless of the
 // current state of p.allowedIPs, so callers should use hasAllowedIP to
 // avoid unnecessary updates.
-func (p *peerConfig) queueAllowedIPsInsert(ips ...net.IPNet) {
-	p.lazyInitMaps()
-
+func (p *peerConfig) queueAllowedIPsInsert(ips ...netip.Prefix) {
 	for _, ip := range ips {
-		pfx := ipnetToPrefix(ip)
-		p.needsInsert[pfx] = ip
-		delete(p.needsRemove, pfx)
+		p.needsInsert.Insert(ip)
+		p.needsRemove.Remove(ip)
 	}
 }
 
@@ -971,65 +954,49 @@ func (p *peerConfig) queueAllowedIPsInsert(ips ...net.IPNet) {
 // during the next update to this peer. The update is queued regardless of the
 // current state of p.allowedIPs, so callers should use hasAllowedIP to
 // avoid unnecessary updates.
-func (p *peerConfig) queueAllowedIPsRemove(ips ...net.IPNet) {
-	p.lazyInitMaps()
-
+func (p *peerConfig) queueAllowedIPsRemove(ips ...netip.Prefix) {
 	for _, ip := range ips {
-		pfx := ipnetToPrefix(ip)
-		p.needsRemove[pfx] = ip
-		delete(p.needsInsert, pfx)
+		p.needsRemove.Insert(ip)
+		p.needsInsert.Remove(ip)
 	}
 }
 
 // queuedAllowedIPUpdates returns the set of allowed IP insertions and removals
 // that are currently pending. If enableAllowedIPRemovals has not yet been
 // called, this method will not return any removals.
-func (p *peerConfig) queuedAllowedIPUpdates() (insert []net.IPNet, remove []net.IPNet) {
-	for _, ip := range p.needsInsert {
-		insert = append(insert, ip)
-	}
-
-	for _, ip := range p.needsRemove {
-		remove = append(remove, ip)
-	}
-
-	return
+func (p *peerConfig) queuedAllowedIPUpdates() (insert []netip.Prefix, remove []netip.Prefix) {
+	return p.needsInsert.AsSlice(), p.needsRemove.AsSlice()
 }
 
 // hasAllowedIP returns true if ip has been synced to this peer on the device.
-func (p *peerConfig) hasAllowedIP(ip net.IPNet) bool {
-	_, exists := p.allowedIPs[ipnetToPrefix(ip)]
-
-	return exists
+func (p *peerConfig) hasAllowedIP(ip netip.Prefix) bool {
+	return p.allowedIPs.Has(ip)
 }
 
 // finishAllowedIPSync signals that any queued updates for the given ips have
 // been processed and synced to the device. This removes these ips from the
 // update queues.
-func (p *peerConfig) finishAllowedIPSync(ips []net.IPNet) {
+func (p *peerConfig) finishAllowedIPSync(ips []netip.Prefix) {
 	for _, ip := range ips {
-		pfx := ipnetToPrefix(ip)
-		if aip, exists := p.needsInsert[pfx]; exists {
-			p.allowedIPs[pfx] = aip
-			delete(p.needsInsert, pfx)
+		if p.needsInsert.Has(ip) {
+			p.allowedIPs.Insert(ip)
+			p.needsInsert.Remove(ip)
 		}
 
-		if _, exists := p.needsRemove[pfx]; exists {
-			delete(p.allowedIPs, pfx)
-			delete(p.needsRemove, pfx)
+		if p.needsRemove.Has(ip) {
+			p.allowedIPs.Remove(ip)
+			p.needsRemove.Remove(ip)
 		}
-	}
-
-	if len(p.needsInsert) == 0 {
-		p.needsInsert = nil
-	}
-
-	if len(p.needsRemove) == 0 {
-		p.needsRemove = nil
 	}
 }
 
-func ipnetToPrefix(ipn net.IPNet) netip.Prefix {
-	cidr, _ := ipn.Mask.Size()
-	return netip.PrefixFrom(netipx.MustFromStdIP(ipn.IP), cidr)
+func prefixesToIPNets(prefixes []netip.Prefix) []net.IPNet {
+	if len(prefixes) == 0 {
+		return nil
+	}
+	ipnets := make([]net.IPNet, 0, len(prefixes))
+	for _, pfx := range prefixes {
+		ipnets = append(ipnets, *netipx.PrefixIPNet(pfx))
+	}
+	return ipnets
 }

--- a/pkg/wireguard/agent/agent_test.go
+++ b/pkg/wireguard/agent/agent_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cilium/hive/hivetest"
 	"github.com/stretchr/testify/require"
+	"go4.org/netipx"
 	"golang.org/x/sys/unix"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 
@@ -302,9 +303,10 @@ func TestAgent_PeerConfig(t *testing.T) {
 
 			assertAllowedIPs := func(e expectation) {
 				node := wgAgent.peerByNodeName[e.Subject]
-				require.Len(t, node.allowedIPs, len(e.AllowedIPs))
+				wantLen := len(e.AllowedIPs)
+				require.Equal(t, wantLen, node.allowedIPs.Len())
 				for _, ipn := range e.AllowedIPs {
-					require.True(t, containsIP(maps.Values(node.allowedIPs), ipn))
+					require.True(t, node.allowedIPs.Has(ipnetToPrefix(*ipn)))
 				}
 			}
 
@@ -741,4 +743,9 @@ func TestAgent_PeerEndpointSelection(t *testing.T) {
 			require.Equal(t, tt.expectedPort, peer.endpoint.Port)
 		})
 	}
+}
+
+func ipnetToPrefix(ipn net.IPNet) netip.Prefix {
+	cidr, _ := ipn.Mask.Size()
+	return netip.PrefixFrom(netipx.MustFromStdIP(ipn.IP), cidr)
 }

--- a/pkg/wireguard/agent/cell_test.go
+++ b/pkg/wireguard/agent/cell_test.go
@@ -318,8 +318,9 @@ func TestPrivileged_TestWireGuardCell(t *testing.T) {
 			require.EventuallyWithT(t, func(c *assert.CollectT) {
 				assert.Contains(c, wgAgent.peerByNodeName, k8s2NodeName)
 				assert.Truef(c, func() bool {
-					for _, n := range wgAgent.peerByNodeName[k8s2NodeName].allowedIPs {
-						if n.Contains(pod2IPv4.IP) {
+					pfx := ipnetToPrefix(*pod2IPv4)
+					for _, n := range wgAgent.peerByNodeName[k8s2NodeName].allowedIPs.AsSlice() {
+						if n.Contains(pfx.Addr()) {
 							return true
 						}
 					}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request]
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin]
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Disclose use of machine learning models (including LLMs and other generative AI)
      in accordance with the [Cilium AI Policy], and indicate the rating using
      [AI Influence Level].
      Example: "This PR was prepared with AIL:3. I personally checked X."
- [x] Thanks for contributing!

<!-- Description of change -->

`peerConfig` in the WireGuard agent was keeping each allowed IP in two places at once:

```go
allowedIPs  map[netip.Prefix]net.IPNet
needsInsert map[netip.Prefix]net.IPNet
needsRemove map[netip.Prefix]net.IPNet
```

The key and the value are the same prefix, just encoded differently. The `net.IPNet` half is there because `wgtypes.PeerConfig.AllowedIPs` is a `[]net.IPNet`, so the package was carrying the wgctrl representation through
its own state rather than converting at the edge.

This turns the three maps into sets keyed by `netip.Prefix` and moves the `net.IPNet` conversion out to the two spots that talk to wgctrl. A few other things follow from that:

- `ipnetToPrefix()` called `netipx.MustFromStdIP()`, which panics if the IP is not 4 or 16 bytes. The replacement uses `netipx.FromStdIP()` and callers skip the prefix if the conversion fails.
- Four blocks were building a `/32` or `/128` by hand with `net.CIDRMask()` plus an IPv4/IPv6 branch. `netip.Addr.BitLen()` already gives the right width, so those become one helper call each.

Left alone on purpose: `peerConfig.nodeIPv4`/`nodeIPv6` are still `net.IP`. Converting them touches ~100 more sites in the tests and would bury this change. The `fakeWgClient` helpers and the `wgtypes.PeerConfig` literals in `cell_test.go` also stay on `net.IPNet`, since that is the API they are standing in for.

Related: #24246

## Testing

`pkg/wireguard/agent` has no privileged tests, so the existing suite covers this locally end to end:

```
$ go build ./...
$ go vet ./pkg/wireguard/...
$ go test ./pkg/wireguard/...
ok      github.com/cilium/cilium/pkg/wireguard/agent    0.025s
$ golangci-lint run pkg/wireguard/...
0 issues.
$ gofmt -s -l pkg/wireguard/agent/
```

This PR was prepared with AIL:1. Used AI to re-phrase the PR body message

```release-note
Track peer AllowedIPs as netip.Prefix
```

[AI Influence Level]: https://danielmiessler.com/blog/ai-influence-level-ail
[Cilium AI Policy]: https://github.com/cilium/community/blob/main/AI-POLICY.md
[Developer’s Certificate of Origin]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo
[Submitting a pull request]: https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request
