### PR TITLE
fix(docs): make render-docs target work on macOS

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -19,7 +19,7 @@ define build_image
   $(ECHO_DOCKER) $(3)
   # Pre-pull FROM docker image due to Buildkit sometimes failing to pull them.
   grep --color=never -m 1 "^FROM " $(1) | tr -d '\r' | cut -d ' ' -f2 | xargs -n1 $(CONTAINER_ENGINE) pull
-  $(QUIET)tar c $(REQUIREMENTS) Dockerfile \
+  $(QUIET)tar --owner=0 --group=0 -c $(REQUIREMENTS) Dockerfile \
     | $(CONTAINER_ENGINE) build $(DOCKER_BUILD_FLAGS) \
                           --build-arg READTHEDOCS_VERSION \
                           --target $(2) --tag $(3) -


### PR DESCRIPTION
This is a small quality-of-life improvement for contributors working on the
documentation on macOS. The alternative is to document a workaround, but that
would require contributors to provide additional tar configuration manually.

When `make render-docs` runs on macOS, BSD tar records the host-specific UID and
GID in the Docker build context. These values can exceed the limits supported
by the tar headers consumed by Linux Docker tooling, causing the build context
to be parsed incorrectly and the image build to fail.

This change normalizes the archive ownership to UID and GID 0, making the Docker
build context portable across macOS and Linux.

`make render-docs` failed on macOS because BSD tar included macOS-specific metadata in the Docker build context which exceeds the header limits imposed by tar on Linux. macOS adds ownership data that makes Linux tooling interpret the tail of the ownership metadata as the start of the Dockerfile which cause the build to fail. This change normalize the ownership so it pass on both OSs.

Tests
- make -C Documentation builder-image
- make -C Documentation html SKIP_BUILDER_IMAGE=1
- make render-docs on macOS

Don't own a Linux machine so that test would be valuable to run.

This PR was prepared with AIL:3. I personally reviewed the change and verified the documentation build in a Linux Docker environment.

Fixes: N/A

```release-note
docs: Make `render-docs` work on macOS.
```